### PR TITLE
Add light/dark theme toggle and path-based URL routing

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15,6 +15,7 @@
         "lucide-react": "^0.312.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^7.12.0",
         "shiki": "^3.21.0",
         "tailwind-merge": "^2.2.0"
       },
@@ -1745,6 +1746,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2838,6 +2852,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.12.0.tgz",
+      "integrity": "sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.12.0.tgz",
+      "integrity": "sha512-pfO9fiBcpEfX4Tx+iTYKDtPbrSLLCbwJ5EqP+SPYQu1VYCXdy79GSj0wttR0U4cikVdlImZuEZ/9ZNCgoaxwBA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.12.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -3004,6 +3056,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shiki": {
       "version": "3.21.0",

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,7 @@
     "lucide-react": "^0.312.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^7.12.0",
     "shiki": "^3.21.0",
     "tailwind-merge": "^2.2.0"
   },

--- a/web/src/components/events/DiffViewer.tsx
+++ b/web/src/components/events/DiffViewer.tsx
@@ -15,7 +15,7 @@ export const DiffViewer = memo(function DiffViewer({ diff, compact = false }: Di
 
   if (compact) {
     return (
-      <div className="text-xs text-slate-400 flex items-center gap-1">
+      <div className="text-xs text-theme-text-secondary flex items-center gap-1">
         <RefreshCw className="w-3 h-3" />
         <span>{diff.summary || `${diff.fields.length} field(s) changed`}</span>
       </div>
@@ -26,7 +26,7 @@ export const DiffViewer = memo(function DiffViewer({ diff, compact = false }: Di
     <div className="space-y-2">
       {/* Summary */}
       {diff.summary && (
-        <div className="text-sm font-medium text-slate-300 flex items-center gap-2">
+        <div className="text-sm font-medium text-theme-text-secondary flex items-center gap-2">
           <RefreshCw className="w-4 h-4 text-blue-400" />
           {diff.summary}
         </div>
@@ -52,9 +52,9 @@ function FieldChangeRow({ field }: FieldChangeRowProps) {
   const isModified = !isAdded && !isRemoved
 
   return (
-    <div className="rounded bg-slate-800/50 border border-slate-700 px-3 py-2">
+    <div className="rounded bg-theme-surface/50 border border-theme-border px-3 py-2">
       {/* Field path */}
-      <div className="text-xs font-mono text-slate-500 mb-1">{field.path}</div>
+      <div className="text-xs font-mono text-theme-text-tertiary mb-1">{field.path}</div>
 
       {/* Values */}
       <div className="flex items-center gap-2 text-sm">
@@ -77,7 +77,7 @@ function FieldChangeRow({ field }: FieldChangeRowProps) {
             <span className="text-red-400 line-through">
               {formatValue(field.oldValue)}
             </span>
-            <ArrowRight className="w-3.5 h-3.5 text-slate-500 flex-shrink-0" />
+            <ArrowRight className="w-3.5 h-3.5 text-theme-text-tertiary flex-shrink-0" />
             <span className="text-green-400">
               {formatValue(field.newValue)}
             </span>

--- a/web/src/components/events/EventsTimeline.tsx
+++ b/web/src/components/events/EventsTimeline.tsx
@@ -174,22 +174,22 @@ export function EventsTimeline({ namespace, onViewChange, currentView = 'list', 
   return (
     <div className="flex flex-col h-full w-full">
       {/* Toolbar */}
-      <div className="flex items-center gap-4 px-4 py-3 border-b border-slate-700 bg-slate-800/50 flex-wrap">
+      <div className="flex items-center gap-4 px-4 py-3 border-b border-theme-border bg-theme-surface/50 flex-wrap">
         {/* Search */}
         <div className="flex-1 relative min-w-[200px]">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-theme-text-tertiary" />
           <input
             ref={searchInputRef}
             type="text"
             placeholder="Search... (/ or ⌘K)"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full max-w-md pl-10 pr-4 py-2 bg-slate-700 border border-slate-600 rounded-lg text-sm text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full max-w-md pl-10 pr-4 py-2 bg-theme-elevated border border-theme-border-light rounded-lg text-sm text-theme-text-primary placeholder-theme-text-disabled focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
         </div>
 
         {/* Event type filter */}
-        <div className="flex items-center gap-1 bg-slate-700 rounded-lg p-1">
+        <div className="flex items-center gap-1 bg-theme-elevated rounded-lg p-1">
           <FilterButton
             active={eventTypeFilter === 'all'}
             onClick={() => setEventTypeFilter('all')}
@@ -224,7 +224,7 @@ export function EventsTimeline({ namespace, onViewChange, currentView = 'list', 
         <select
           value={kindFilter}
           onChange={(e) => setKindFilter(e.target.value)}
-          className="appearance-none bg-slate-700 text-white text-sm rounded-lg px-3 py-2 border border-slate-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="appearance-none bg-theme-elevated text-theme-text-primary text-sm rounded-lg px-3 py-2 border border-theme-border-light focus:outline-none focus:ring-2 focus:ring-blue-500"
         >
           <option value="">All Kinds</option>
           {RESOURCE_KINDS.map((kind) => (
@@ -238,7 +238,7 @@ export function EventsTimeline({ namespace, onViewChange, currentView = 'list', 
         <select
           value={timeRange}
           onChange={(e) => setTimeRange(e.target.value as TimeRange)}
-          className="appearance-none bg-slate-700 text-white text-sm rounded-lg px-3 py-2 border border-slate-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="appearance-none bg-theme-elevated text-theme-text-primary text-sm rounded-lg px-3 py-2 border border-theme-border-light focus:outline-none focus:ring-2 focus:ring-blue-500"
         >
           {TIME_RANGES.map((range) => (
             <option key={range.value} value={range.value}>
@@ -249,12 +249,12 @@ export function EventsTimeline({ namespace, onViewChange, currentView = 'list', 
 
         {/* View toggle */}
         {onViewChange && (
-          <div className="flex items-center gap-1 bg-slate-700 rounded-lg p-1">
+          <div className="flex items-center gap-1 bg-theme-elevated rounded-lg p-1">
             <button
               onClick={() => onViewChange('list')}
               className={clsx(
                 'p-2 rounded-md transition-colors',
-                currentView === 'list' ? 'bg-slate-600 text-white' : 'text-slate-400 hover:text-white'
+                currentView === 'list' ? 'bg-theme-hover text-theme-text-primary' : 'text-theme-text-secondary hover:text-theme-text-primary'
               )}
               title="List view"
             >
@@ -264,7 +264,7 @@ export function EventsTimeline({ namespace, onViewChange, currentView = 'list', 
               onClick={() => onViewChange('swimlane')}
               className={clsx(
                 'p-2 rounded-md transition-colors',
-                currentView === 'swimlane' ? 'bg-slate-600 text-white' : 'text-slate-400 hover:text-white'
+                currentView === 'swimlane' ? 'bg-theme-hover text-theme-text-primary' : 'text-theme-text-secondary hover:text-theme-text-primary'
               )}
               title="Timeline view"
             >
@@ -276,7 +276,7 @@ export function EventsTimeline({ namespace, onViewChange, currentView = 'list', 
         {/* Refresh */}
         <button
           onClick={() => refetch()}
-          className="p-2 text-slate-400 hover:text-white hover:bg-slate-700 rounded-lg"
+          className="p-2 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded-lg"
           title="Refresh"
         >
           <RefreshCw className="w-4 h-4" />
@@ -286,12 +286,12 @@ export function EventsTimeline({ namespace, onViewChange, currentView = 'list', 
       {/* Timeline content */}
       <div className="flex-1 overflow-auto">
         {isLoading ? (
-          <div className="flex items-center justify-center h-full text-slate-500">
+          <div className="flex items-center justify-center h-full text-theme-text-tertiary">
             <RefreshCw className="w-5 h-5 animate-spin mr-2" />
             Loading timeline...
           </div>
         ) : filteredEvents.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-full text-slate-500">
+          <div className="flex flex-col items-center justify-center h-full text-theme-text-tertiary">
             <Clock className="w-12 h-12 mb-4 opacity-50" />
             <p className="text-lg">No events found</p>
             <p className="text-sm mt-2">
@@ -306,15 +306,15 @@ export function EventsTimeline({ namespace, onViewChange, currentView = 'list', 
               <div key={group.label}>
                 {/* Time period header */}
                 <div className="flex items-center gap-2 mb-3">
-                  <Clock className="w-4 h-4 text-slate-500" />
-                  <span className="text-sm font-medium text-slate-400">{group.label}</span>
-                  <span className="text-xs text-slate-600">
+                  <Clock className="w-4 h-4 text-theme-text-tertiary" />
+                  <span className="text-sm font-medium text-theme-text-secondary">{group.label}</span>
+                  <span className="text-xs text-theme-text-disabled">
                     ({group.events.length} event{group.events.length !== 1 ? 's' : ''})
                   </span>
                 </div>
 
                 {/* Events list */}
-                <div className="space-y-2 ml-6 border-l-2 border-slate-700 pl-4">
+                <div className="space-y-2 ml-6 border-l-2 border-theme-border pl-4">
                   {group.events.map((event) => (
                     <EventCard
                       key={event.id}
@@ -355,7 +355,7 @@ function FilterButton({ active, onClick, icon, label, count, color }: FilterButt
       onClick={onClick}
       className={clsx(
         'px-3 py-1.5 text-sm rounded-md transition-colors flex items-center gap-2',
-        active ? (color ? colorClasses[color] : 'bg-slate-600 text-white') : 'text-slate-400 hover:text-white'
+        active ? (color ? colorClasses[color] : 'bg-theme-hover text-theme-text-primary') : 'text-theme-text-secondary hover:text-theme-text-primary'
       )}
     >
       {icon}
@@ -364,7 +364,7 @@ function FilterButton({ active, onClick, icon, label, count, color }: FilterButt
         <span
           className={clsx(
             'text-xs px-1.5 rounded',
-            color ? `bg-${color}-500/30` : 'bg-slate-500/30'
+            color ? `bg-${color}-500/30` : 'bg-theme-hover/50'
           )}
         >
           {count}
@@ -397,13 +397,13 @@ function EventCard({ event, expanded, onToggle, onResourceClick }: EventCardProp
         case 'update':
           return 'bg-blue-500/5 border-blue-500/30 hover:border-blue-500/50'
         default:
-          return 'bg-slate-800/50 border-slate-700 hover:border-slate-600'
+          return 'bg-theme-surface/50 border-theme-border hover:border-theme-border-light'
       }
     }
     if (isWarning) {
       return 'bg-amber-500/5 border-amber-500/30 hover:border-amber-500/50'
     }
-    return 'bg-slate-800/50 border-slate-700 hover:border-slate-600'
+    return 'bg-theme-surface/50 border-theme-border hover:border-theme-border-light'
   }
 
   const getIcon = () => {
@@ -416,7 +416,7 @@ function EventCard({ event, expanded, onToggle, onResourceClick }: EventCardProp
         case 'update':
           return <RefreshCw className="w-4 h-4 text-blue-400" />
         default:
-          return <CheckCircle className="w-4 h-4 text-slate-400" />
+          return <CheckCircle className="w-4 h-4 text-theme-text-secondary" />
       }
     }
     if (isWarning) {
@@ -445,14 +445,14 @@ function EventCard({ event, expanded, onToggle, onResourceClick }: EventCardProp
                   e.stopPropagation()
                   onResourceClick?.(event.kind, event.namespace, event.name)
                 }}
-                className="flex items-center gap-2 hover:bg-slate-700/50 rounded px-1 -ml-1 transition-colors group"
+                className="flex items-center gap-2 hover:bg-theme-elevated/50 rounded px-1 -ml-1 transition-colors group"
               >
-                <span className="text-xs px-1.5 py-0.5 bg-slate-700 rounded text-slate-300 group-hover:bg-slate-600">
+                <span className="text-xs px-1.5 py-0.5 bg-theme-elevated rounded text-theme-text-secondary group-hover:bg-theme-hover">
                   {event.kind}
                 </span>
-                <span className="text-sm font-medium text-white truncate group-hover:text-blue-300">{event.name}</span>
+                <span className="text-sm font-medium text-theme-text-primary truncate group-hover:text-blue-300">{event.name}</span>
               </button>
-              {event.namespace && <span className="text-xs text-slate-500">in {event.namespace}</span>}
+              {event.namespace && <span className="text-xs text-theme-text-tertiary">in {event.namespace}</span>}
             </div>
 
             {/* Event details */}
@@ -485,10 +485,10 @@ function EventCard({ event, expanded, onToggle, onResourceClick }: EventCardProp
                 </>
               ) : (
                 <>
-                  <span className={clsx('text-sm font-medium', isWarning ? 'text-amber-300' : 'text-slate-300')}>
+                  <span className={clsx('text-sm font-medium', isWarning ? 'text-amber-300' : 'text-theme-text-secondary')}>
                     {event.reason}
                   </span>
-                  <span className="text-sm text-slate-400">
+                  <span className="text-sm text-theme-text-secondary">
                     {event.message && event.message.length > 80 && !expanded
                       ? `${event.message.slice(0, 80)}...`
                       : event.message}
@@ -500,25 +500,25 @@ function EventCard({ event, expanded, onToggle, onResourceClick }: EventCardProp
 
           {/* Time and count */}
           <div className="flex-shrink-0 text-right">
-            <div className="text-xs text-slate-500">{time}</div>
+            <div className="text-xs text-theme-text-tertiary">{time}</div>
             {event.count && event.count > 1 && (
-              <div className="text-xs text-slate-600 mt-1">x{event.count}</div>
+              <div className="text-xs text-theme-text-disabled mt-1">x{event.count}</div>
             )}
           </div>
 
           {/* Expand indicator */}
           <ChevronRight
-            className={clsx('w-4 h-4 text-slate-600 transition-transform flex-shrink-0', expanded && 'rotate-90')}
+            className={clsx('w-4 h-4 text-theme-text-disabled transition-transform flex-shrink-0', expanded && 'rotate-90')}
           />
         </div>
 
         {/* Expanded details */}
         {expanded && (
-          <div className="mt-3 pt-3 border-t border-slate-700/50 space-y-3">
+          <div className="mt-3 pt-3 border-t-subtle space-y-3">
             {/* Diff viewer for changes */}
             {isChange && event.diff && (
               <div>
-                <div className="text-xs text-slate-500 mb-2">Changes:</div>
+                <div className="text-xs text-theme-text-tertiary mb-2">Changes:</div>
                 <DiffViewer diff={event.diff} />
               </div>
             )}
@@ -526,20 +526,20 @@ function EventCard({ event, expanded, onToggle, onResourceClick }: EventCardProp
             {/* Full message for K8s events */}
             {!isChange && event.message && event.message.length > 80 && (
               <div>
-                <div className="text-xs text-slate-500 mb-1">Full message:</div>
-                <p className="text-sm text-slate-400 whitespace-pre-wrap">{event.message}</p>
+                <div className="text-xs text-theme-text-tertiary mb-1">Full message:</div>
+                <p className="text-sm text-theme-text-secondary whitespace-pre-wrap">{event.message}</p>
               </div>
             )}
 
             {/* Metadata */}
             <div className="grid grid-cols-2 gap-4 text-xs">
               <div>
-                <span className="text-slate-500">Timestamp:</span>
-                <span className="ml-2 text-slate-400">{new Date(event.timestamp).toLocaleString()}</span>
+                <span className="text-theme-text-tertiary">Timestamp:</span>
+                <span className="ml-2 text-theme-text-secondary">{new Date(event.timestamp).toLocaleString()}</span>
               </div>
               <div>
-                <span className="text-slate-500">Type:</span>
-                <span className="ml-2 text-slate-400">{isChange ? `Change (${event.operation})` : event.eventType}</span>
+                <span className="text-theme-text-tertiary">Type:</span>
+                <span className="ml-2 text-theme-text-secondary">{isChange ? `Change (${event.operation})` : event.eventType}</span>
               </div>
             </div>
           </div>

--- a/web/src/components/events/EventsTray.tsx
+++ b/web/src/components/events/EventsTray.tsx
@@ -41,7 +41,7 @@ function getOperationColor(operation: string): string {
     case 'delete':
       return 'text-red-400 bg-red-500/10'
     default:
-      return 'text-slate-400 bg-slate-500/10'
+      return 'text-theme-text-secondary bg-theme-hover/30'
   }
 }
 
@@ -60,7 +60,7 @@ function getKindColor(kind: string): string {
     case 'Event':
       return 'text-yellow-400'
     default:
-      return 'text-slate-400'
+      return 'text-theme-text-secondary'
   }
 }
 
@@ -70,19 +70,19 @@ export const EventsTray = memo(function EventsTray({
   onEventClick,
 }: EventsTrayProps) {
   return (
-    <div className="w-80 bg-slate-800 border-l border-slate-700 flex flex-col">
+    <div className="w-80 bg-theme-surface border-l border-theme-border flex flex-col">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-slate-700">
-        <h2 className="font-semibold text-white flex items-center gap-2">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-theme-border">
+        <h2 className="font-semibold text-theme-text-primary flex items-center gap-2">
           <AlertCircle className="w-4 h-4 text-blue-400" />
           Events
-          <span className="text-xs text-slate-400 font-normal">
+          <span className="text-xs text-theme-text-secondary font-normal">
             ({events.length})
           </span>
         </h2>
         <button
           onClick={onClose}
-          className="p-1 text-slate-400 hover:text-white hover:bg-slate-700 rounded"
+          className="p-1 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
         >
           <X className="w-4 h-4" />
         </button>
@@ -91,19 +91,19 @@ export const EventsTray = memo(function EventsTray({
       {/* Events list */}
       <div className="flex-1 overflow-y-auto">
         {events.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-full text-slate-400">
+          <div className="flex flex-col items-center justify-center h-full text-theme-text-secondary">
             <AlertCircle className="w-8 h-8 mb-2 opacity-50" />
             <p className="text-sm">No recent events</p>
           </div>
         ) : (
-          <div className="divide-y divide-slate-700">
+          <div className="table-divide-subtle">
             {events.map((event, index) => {
               const Icon = getOperationIcon(event.operation)
               return (
                 <button
                   key={`${event.kind}-${event.namespace}-${event.name}-${event.timestamp}-${index}`}
                   onClick={() => onEventClick(event)}
-                  className="w-full px-4 py-3 text-left hover:bg-slate-700/50 transition-colors"
+                  className="w-full px-4 py-3 text-left hover:bg-theme-elevated/50 transition-colors"
                 >
                   <div className="flex items-start gap-3">
                     <div
@@ -124,21 +124,21 @@ export const EventsTray = memo(function EventsTray({
                         >
                           {event.kind}
                         </span>
-                        <span className="text-xs text-slate-500">
+                        <span className="text-xs text-theme-text-tertiary">
                           {event.operation}
                         </span>
                       </div>
-                      <p className="text-sm text-white truncate mt-0.5">
+                      <p className="text-sm text-theme-text-primary truncate mt-0.5">
                         {event.name}
                       </p>
                       <div className="flex items-center gap-2 mt-1">
                         {event.namespace && (
-                          <span className="text-xs text-slate-500">
+                          <span className="text-xs text-theme-text-tertiary">
                             {event.namespace}
                           </span>
                         )}
                         {event.timestamp && (
-                          <span className="text-xs text-slate-500">
+                          <span className="text-xs text-theme-text-tertiary">
                             {formatTimeAgo(event.timestamp)}
                           </span>
                         )}

--- a/web/src/components/events/TimelineSwimlanes.tsx
+++ b/web/src/components/events/TimelineSwimlanes.tsx
@@ -634,7 +634,7 @@ export function TimelineSwimlanes({ events, isLoading, filterTimeRange: _filterT
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-full text-slate-500">
+      <div className="flex items-center justify-center h-full text-theme-text-tertiary">
         <RefreshCw className="w-5 h-5 animate-spin mr-2" />
         Loading timeline...
       </div>
@@ -646,7 +646,7 @@ export function TimelineSwimlanes({ events, isLoading, filterTimeRange: _filterT
     const hasRoutineOnly = routineEventCount > 0 && routineEventCount === events.length
 
     return (
-      <div className="flex flex-col items-center justify-center h-full text-slate-500">
+      <div className="flex flex-col items-center justify-center h-full text-theme-text-tertiary">
         <AlertCircle className="w-12 h-12 mb-4 opacity-50" />
         {hasFilteredEvents ? (
           <>
@@ -681,23 +681,23 @@ export function TimelineSwimlanes({ events, isLoading, filterTimeRange: _filterT
   return (
     <div className="flex flex-col h-full w-full">
       {/* Toolbar with search and zoom */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-slate-700 bg-slate-800/30">
+      <div className="flex items-center justify-between px-4 py-2 border-b border-theme-border bg-theme-surface/30">
         <div className="flex items-center gap-4">
           {/* Search */}
           <div className="relative">
-            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" />
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-theme-text-tertiary" />
             <input
               ref={searchInputRef}
               type="text"
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
               placeholder="Search... (/ or ⌘K)"
-              className="w-80 pl-9 pr-8 py-1.5 text-sm bg-slate-700 border border-slate-600 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-80 pl-9 pr-8 py-1.5 text-sm bg-theme-elevated border border-theme-border-light rounded-lg text-theme-text-primary placeholder-theme-text-disabled focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             />
             {searchTerm && (
               <button
                 onClick={() => setSearchTerm('')}
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-slate-500 hover:text-white"
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-theme-text-tertiary hover:text-theme-text-primary"
               >
                 <X className="w-4 h-4" />
               </button>
@@ -707,25 +707,25 @@ export function TimelineSwimlanes({ events, isLoading, filterTimeRange: _filterT
           <div className="flex items-center gap-2">
             <button
               onClick={handleZoomIn}
-              className="p-1.5 text-slate-400 hover:text-white hover:bg-slate-700 rounded"
+              className="p-1.5 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
               title="Zoom in (Ctrl+scroll)"
             >
               <ZoomIn className="w-4 h-4" />
             </button>
             <button
               onClick={handleZoomOut}
-              className="p-1.5 text-slate-400 hover:text-white hover:bg-slate-700 rounded"
+              className="p-1.5 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
               title="Zoom out (Ctrl+scroll)"
             >
               <ZoomOut className="w-4 h-4" />
             </button>
-            <span className="text-xs text-slate-500">
+            <span className="text-xs text-theme-text-tertiary">
               {zoom < 1 ? `${Math.round(zoom * 60)}m` : `${zoom}h`} window
             </span>
             {panOffset > 0 && (
               <button
                 onClick={() => setPanOffset(0)}
-                className="px-2 py-1 text-xs text-blue-400 hover:text-blue-300 hover:bg-slate-700 rounded"
+                className="px-2 py-1 text-xs text-blue-400 hover:text-blue-300 hover:bg-theme-elevated rounded"
                 title="Jump to current time"
               >
                 → Now
@@ -735,7 +735,7 @@ export function TimelineSwimlanes({ events, isLoading, filterTimeRange: _filterT
           {/* Sort by latest */}
           <button
             onClick={handleRefreshSort}
-            className="flex items-center gap-1.5 px-2 py-1.5 text-xs text-slate-400 hover:text-white hover:bg-slate-700 rounded"
+            className="flex items-center gap-1.5 px-2 py-1.5 text-xs text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
             title="Re-sort by importance"
           >
             <ArrowUpDown className="w-3.5 h-3.5" />
@@ -744,36 +744,36 @@ export function TimelineSwimlanes({ events, isLoading, filterTimeRange: _filterT
         </div>
         <div className="flex items-center gap-4">
           {/* Legend */}
-          <div className="flex items-center gap-3 text-xs text-slate-400">
+          <div className="flex items-center gap-3 text-xs text-theme-text-secondary">
             <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-full bg-green-500" />add</span>
             <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-full bg-blue-500" />update</span>
             <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-full bg-red-500" />delete</span>
             <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-full bg-amber-500" />warning</span>
           </div>
-          <span className="text-xs text-slate-500">
+          <span className="text-xs text-theme-text-tertiary">
             {lanes.length} resource{lanes.length !== 1 ? 's' : ''} · {filteredEvents.length} event
             {filteredEvents.length !== 1 ? 's' : ''}
             {searchTerm && ` (filtered)`}
           </span>
           {/* Routine updates toggle */}
           {routineEventCount > 0 && (
-            <label className="flex items-center gap-1.5 text-xs text-slate-400 cursor-pointer hover:text-slate-300">
+            <label className="flex items-center gap-1.5 text-xs text-theme-text-secondary cursor-pointer hover:text-theme-text-secondary">
               <input
                 type="checkbox"
                 checked={showRoutineUpdates}
                 onChange={(e) => setShowRoutineUpdates(e.target.checked)}
-                className="w-3.5 h-3.5 rounded border-slate-600 bg-slate-700 text-blue-500 focus:ring-blue-500 focus:ring-offset-0"
+                className="w-3.5 h-3.5 rounded border-theme-border-light bg-theme-elevated text-blue-500 focus:ring-blue-500 focus:ring-offset-0"
               />
               <span>Show routine events ({routineEventCount})</span>
             </label>
           )}
           {/* View toggle */}
           {onViewModeChange && (
-            <div className="flex items-center gap-1 bg-slate-700 rounded-lg p-1">
+            <div className="flex items-center gap-1 bg-theme-elevated rounded-lg p-1">
               <button
                 onClick={() => onViewModeChange('list')}
                 className={`flex items-center gap-1.5 px-2 py-1 text-xs rounded-md transition-colors ${
-                  viewMode === 'list' ? 'bg-slate-600 text-white' : 'text-slate-400 hover:text-white'
+                  viewMode === 'list' ? 'bg-theme-hover text-theme-text-primary' : 'text-theme-text-secondary hover:text-theme-text-primary'
                 }`}
               >
                 <List className="w-3.5 h-3.5" />
@@ -782,7 +782,7 @@ export function TimelineSwimlanes({ events, isLoading, filterTimeRange: _filterT
               <button
                 onClick={() => onViewModeChange('swimlane')}
                 className={`flex items-center gap-1.5 px-2 py-1 text-xs rounded-md transition-colors ${
-                  viewMode === 'swimlane' ? 'bg-slate-600 text-white' : 'text-slate-400 hover:text-white'
+                  viewMode === 'swimlane' ? 'bg-theme-hover text-theme-text-primary' : 'text-theme-text-secondary hover:text-theme-text-primary'
                 }`}
               >
                 <GanttChart className="w-3.5 h-3.5" />
@@ -803,10 +803,10 @@ export function TimelineSwimlanes({ events, isLoading, filterTimeRange: _filterT
           style={{ cursor: isDragging ? 'grabbing' : 'grab' }}
         >
           {/* Time axis header */}
-          <div className="sticky top-0 z-10 bg-slate-800 border-b border-slate-700">
+          <div className="sticky top-0 z-10 bg-theme-surface border-b border-theme-border">
             <div className="flex">
-              <div className="w-80 flex-shrink-0 border-r border-slate-700 px-3 py-2">
-                <span className="text-xs font-medium text-slate-400">Resource</span>
+              <div className="w-80 flex-shrink-0 border-r border-theme-border px-3 py-2">
+                <span className="text-xs font-medium text-theme-text-secondary">Resource</span>
               </div>
               <div className="flex-1 relative h-8 mr-8">
                 {axisTicks.map((tick) => {
@@ -818,8 +818,8 @@ export function TimelineSwimlanes({ events, isLoading, filterTimeRange: _filterT
                       className="absolute top-0 bottom-0 flex flex-col items-center"
                       style={{ left: `${x}%` }}
                     >
-                      <div className="h-2 w-px bg-slate-600" />
-                      <span className="text-xs text-slate-500 mt-0.5">{tick.label}</span>
+                      <div className="h-2 w-px bg-theme-hover" />
+                      <span className="text-xs text-theme-text-tertiary mt-0.5">{tick.label}</span>
                     </div>
                   )
                 })}
@@ -836,15 +836,15 @@ export function TimelineSwimlanes({ events, isLoading, filterTimeRange: _filterT
               return (
                 <div key={lane.id}>
                   {/* Parent lane */}
-                  <div className="border-b border-slate-700/50">
+                  <div className="border-b-subtle">
                     <div className="flex">
                       {/* Lane label */}
-                      <div className="w-80 flex-shrink-0 border-r border-slate-700 px-3 py-2 flex items-center gap-1">
+                      <div className="w-80 flex-shrink-0 border-r border-theme-border px-3 py-2 flex items-center gap-1">
                         {/* Expand/collapse button */}
                         {hasChildren ? (
                           <button
                             onClick={() => toggleLane(lane.id)}
-                            className="p-0.5 text-slate-500 hover:text-white hover:bg-slate-700 rounded"
+                            className="p-0.5 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
                           >
                             <ChevronRight className={clsx(
                               'w-3 h-3 transition-transform',
@@ -855,26 +855,26 @@ export function TimelineSwimlanes({ events, isLoading, filterTimeRange: _filterT
                           <div className="w-4" />
                         )}
                         <div
-                          className="flex-1 min-w-0 cursor-pointer hover:bg-slate-800/30 rounded px-1 -mx-1 group"
+                          className="flex-1 min-w-0 cursor-pointer hover:bg-theme-surface/30 rounded px-1 -mx-1 group"
                           onClick={() => onResourceClick?.(lane.kind, lane.namespace, lane.name)}
                         >
                           <div className="flex items-center gap-1">
                             <span className={clsx(
                               'text-xs px-1 py-0.5 rounded',
-                              lane.isWorkload ? 'bg-blue-900/50 text-blue-400' : 'bg-slate-700 text-slate-400'
+                              lane.isWorkload ? 'bg-blue-900/50 text-blue-400' : 'bg-theme-elevated text-theme-text-secondary'
                             )}>
                               {lane.kind}
                             </span>
                             {hasChildren && (
-                              <span className="text-xs text-slate-500">
+                              <span className="text-xs text-theme-text-tertiary">
                                 +{lane.children!.length}
                               </span>
                             )}
                           </div>
-                          <div className="text-sm text-white break-words group-hover:text-blue-300">
+                          <div className="text-sm text-theme-text-primary break-words group-hover:text-blue-300">
                             {lane.name}
                           </div>
-                          <div className="text-xs text-slate-500">{lane.namespace}</div>
+                          <div className="text-xs text-theme-text-tertiary">{lane.namespace}</div>
                         </div>
                       </div>
 
@@ -912,13 +912,13 @@ export function TimelineSwimlanes({ events, isLoading, filterTimeRange: _filterT
 
                   {/* Child lanes (when expanded) - includes parent as first row */}
                   {isExpanded && hasChildren && (
-                    <div className="border-l-2 border-blue-500/40 ml-3 bg-slate-800/30">
+                    <div className="border-l-2 border-blue-500/40 ml-3 bg-theme-surface/30">
                       {/* Parent's own events as first row (only if it has events) */}
                       {lane.events.length > 0 && (
-                        <div className="border-b border-slate-700/30">
+                        <div className="border-b-subtle">
                           <div className="flex">
                             <div
-                              className="w-[19.25rem] flex-shrink-0 border-r border-slate-700/50 pl-4 pr-3 py-1.5 flex items-center gap-2 cursor-pointer hover:bg-slate-700/30 group"
+                              className="w-[19.25rem] flex-shrink-0 border-r border-theme-border/50 pl-4 pr-3 py-1.5 flex items-center gap-2 cursor-pointer hover:bg-theme-elevated/30 group"
                               onClick={() => onResourceClick?.(lane.kind, lane.namespace, lane.name)}
                             >
                               <div className="flex-1 min-w-0">
@@ -927,7 +927,7 @@ export function TimelineSwimlanes({ events, isLoading, filterTimeRange: _filterT
                                     {lane.kind}
                                   </span>
                                 </div>
-                                <div className="text-sm text-slate-300 break-words group-hover:text-blue-300">
+                                <div className="text-sm text-theme-text-secondary break-words group-hover:text-blue-300">
                                   {lane.name}
                                 </div>
                               </div>
@@ -954,22 +954,22 @@ export function TimelineSwimlanes({ events, isLoading, filterTimeRange: _filterT
                       {/* Children */}
                       {lane.children!.map((child, idx) => (
                         <div key={child.id} className={clsx(
-                          'border-b border-slate-700/30',
+                          'border-b-subtle',
                           idx === lane.children!.length - 1 && 'border-b-0'
                         )}>
                           <div className="flex">
                             {/* Child lane label - indented */}
                             <div
-                              className="w-[19.25rem] flex-shrink-0 border-r border-slate-700/50 pl-4 pr-3 py-1.5 flex items-center gap-2 cursor-pointer hover:bg-slate-700/30 group"
+                              className="w-[19.25rem] flex-shrink-0 border-r border-theme-border/50 pl-4 pr-3 py-1.5 flex items-center gap-2 cursor-pointer hover:bg-theme-elevated/30 group"
                               onClick={() => onResourceClick?.(child.kind, child.namespace, child.name)}
                             >
                               <div className="flex-1 min-w-0">
                                 <div className="flex items-center gap-1">
-                                  <span className="text-xs px-1 py-0.5 rounded bg-slate-700/50 text-slate-400">
+                                  <span className="text-xs px-1 py-0.5 rounded bg-theme-elevated/50 text-theme-text-secondary">
                                     {child.kind}
                                   </span>
                                 </div>
-                                <div className="text-sm text-slate-300 break-words group-hover:text-blue-300">
+                                <div className="text-sm text-theme-text-secondary break-words group-hover:text-blue-300">
                                   {child.name}
                                 </div>
                               </div>
@@ -1044,7 +1044,7 @@ function EventMarker({ event, x, selected, onClick, dimmed, small }: EventMarker
             return 'bg-blue-500/20 border-2 border-dashed border-blue-500/60'
         }
       }
-      return 'bg-slate-500/20 border-2 border-dashed border-slate-400/60'
+      return 'bg-theme-hover/30 border-2 border-dashed border-theme-border-light'
     }
 
     // Solid fill for real-time events
@@ -1063,7 +1063,7 @@ function EventMarker({ event, x, selected, onClick, dimmed, small }: EventMarker
           return `bg-blue-500${opacity}`
       }
     }
-    return `bg-slate-400${opacity}`
+    return `bg-theme-text-tertiary${opacity}`
   }
 
   // No icons inside markers - at this size they just create visual noise
@@ -1104,7 +1104,7 @@ function EventMarker({ event, x, selected, onClick, dimmed, small }: EventMarker
         'absolute top-1/2 -translate-y-1/2 -translate-x-1/2 rounded-full transition-all group',
         small ? 'w-2.5 h-2.5' : 'w-3 h-3',
         markerClasses,
-        selected ? 'ring-2 ring-white ring-offset-2 ring-offset-slate-900 scale-150' : 'hover:scale-125',
+        selected ? 'ring-2 ring-white ring-offset-2 ring-offset-theme-base scale-150' : 'hover:scale-125',
         dimmed ? 'z-5' : isHistorical ? 'z-5' : 'z-10'
       )}
       style={{ left: `${x}%` }}
@@ -1113,7 +1113,7 @@ function EventMarker({ event, x, selected, onClick, dimmed, small }: EventMarker
         onClick()
       }}
     >
-      <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 text-xs bg-slate-900 text-white rounded whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none z-50 transition-opacity duration-75">
+      <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 text-xs bg-theme-base text-theme-text-primary rounded whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none z-50 transition-opacity duration-75">
         {tooltipText}
       </span>
     </button>
@@ -1132,35 +1132,35 @@ function EventDetailPanel({ event, onClose }: EventDetailPanelProps) {
   return (
     <div className={clsx(
       "fixed bottom-0 left-0 right-0 z-50 border-t p-4 max-h-72 overflow-auto shadow-2xl",
-      isProblematic ? "border-amber-600 bg-amber-950" : "border-slate-700 bg-slate-800"
+      isProblematic ? "border-amber-600 bg-amber-950" : "border-theme-border bg-theme-surface"
     )}>
       <div className="flex items-start justify-between mb-3">
         <div>
           <div className="flex items-center gap-2">
-            <span className="text-xs px-1.5 py-0.5 bg-slate-700 rounded text-slate-300">
+            <span className="text-xs px-1.5 py-0.5 bg-theme-elevated rounded text-theme-text-secondary">
               {event.kind}
             </span>
-            <span className="text-white font-medium">{event.name}</span>
+            <span className="text-theme-text-primary font-medium">{event.name}</span>
             {event.namespace && (
-              <span className="text-xs text-slate-500">in {event.namespace}</span>
+              <span className="text-xs text-theme-text-tertiary">in {event.namespace}</span>
             )}
             {event.isHistorical && (
-              <span className="text-xs px-1.5 py-0.5 bg-slate-600 rounded text-slate-400 flex items-center gap-1">
+              <span className="text-xs px-1.5 py-0.5 bg-theme-hover rounded text-theme-text-secondary flex items-center gap-1">
                 <Clock className="w-3 h-3" />
                 historical
               </span>
             )}
           </div>
-          <div className="text-xs text-slate-500 mt-1">
+          <div className="text-xs text-theme-text-tertiary mt-1">
             {formatFullTime(new Date(event.timestamp))}
             {event.isHistorical && event.reason && (
-              <span className="ml-2 text-slate-400">({event.reason})</span>
+              <span className="ml-2 text-theme-text-secondary">({event.reason})</span>
             )}
           </div>
         </div>
         <button
           onClick={onClose}
-          className="p-1.5 text-slate-400 hover:text-white hover:bg-slate-700 rounded"
+          className="p-1.5 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
           title="Close (Esc)"
         >
           <X className="w-4 h-4" />
@@ -1210,10 +1210,10 @@ function EventDetailPanel({ event, onClose }: EventDetailPanelProps) {
               {event.eventType}
             </span>
             {event.count && event.count > 1 && (
-              <span className="text-xs text-slate-500">x{event.count}</span>
+              <span className="text-xs text-theme-text-tertiary">x{event.count}</span>
             )}
           </div>
-          {event.message && <p className={clsx("text-sm", isProblematic ? "text-amber-200" : "text-slate-400")}>{event.message}</p>}
+          {event.message && <p className={clsx("text-sm", isProblematic ? "text-amber-200" : "text-theme-text-secondary")}>{event.message}</p>}
         </div>
       )}
     </div>

--- a/web/src/components/helm/HelmReleaseDrawer.tsx
+++ b/web/src/components/helm/HelmReleaseDrawer.tsx
@@ -200,7 +200,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource }: He
 
   return (
     <div
-      className="fixed right-0 bg-slate-800 border-l border-slate-700 flex flex-col shadow-2xl z-40"
+      className="fixed right-0 bg-theme-surface border-l border-theme-border flex flex-col shadow-2xl z-40"
       style={{ width: drawerWidth, top: headerHeight, height: `calc(100vh - ${headerHeight}px)` }}
     >
       {/* Resize handle */}
@@ -214,7 +214,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource }: He
       />
 
       {/* Header */}
-      <div className="border-b border-slate-700 shrink-0">
+      <div className="border-b border-theme-border shrink-0">
         <div className="flex items-center justify-between px-4 pt-3 pb-2">
           <div className="flex items-center gap-2 flex-wrap">
             <span className="px-2 py-0.5 text-xs font-medium rounded border border-purple-500/50 bg-purple-500/20 text-purple-300">
@@ -227,7 +227,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource }: He
             )}
             {/* Upgrade indicator */}
             {upgradeLoading ? (
-              <span className="px-2 py-0.5 text-xs font-medium rounded bg-slate-600/50 text-slate-400 animate-pulse">
+              <span className="px-2 py-0.5 text-xs font-medium rounded bg-theme-hover/50 text-theme-text-secondary animate-pulse">
                 checking...
               </span>
             ) : upgradeInfo?.updateAvailable ? (
@@ -249,19 +249,19 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource }: He
             <button
               onClick={() => refetch()}
               disabled={isRefetching}
-              className="p-1.5 text-slate-400 hover:text-white hover:bg-slate-700 rounded disabled:opacity-50"
+              className="p-1.5 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded disabled:opacity-50"
               title="Refresh"
             >
               <RefreshCw className={clsx('w-4 h-4', isRefetching && 'animate-spin')} />
             </button>
             <button
               onClick={() => setShowUninstallConfirm(true)}
-              className="p-1.5 text-slate-400 hover:text-red-400 hover:bg-red-500/10 rounded"
+              className="p-1.5 text-theme-text-secondary hover:text-red-400 hover:bg-red-500/10 rounded"
               title="Uninstall release"
             >
               <Trash2 className="w-4 h-4" />
             </button>
-            <button onClick={onClose} className="p-1.5 text-slate-400 hover:text-white hover:bg-slate-700 rounded" title="Close (Esc)">
+            <button onClick={onClose} className="p-1.5 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded" title="Close (Esc)">
               <X className="w-4 h-4" />
             </button>
           </div>
@@ -271,16 +271,16 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource }: He
         <div className="px-4 pb-3">
           <div className="flex items-center gap-2">
             <Package className="w-5 h-5 text-purple-400" />
-            <h2 className="text-lg font-semibold text-white truncate">{release.name}</h2>
+            <h2 className="text-lg font-semibold text-theme-text-primary truncate">{release.name}</h2>
             <button
               onClick={() => copyToClipboard(release.name, 'name')}
-              className="p-1 text-slate-400 hover:text-white hover:bg-slate-700 rounded shrink-0"
+              className="p-1 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded shrink-0"
               title="Copy name"
             >
               {copied === 'name' ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
             </button>
           </div>
-          <p className="text-sm text-slate-500">{release.namespace}</p>
+          <p className="text-sm text-theme-text-tertiary">{release.namespace}</p>
         </div>
 
         {/* Tabs */}
@@ -292,8 +292,8 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource }: He
               className={clsx(
                 'flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md transition-colors whitespace-nowrap',
                 activeTab === tab.id
-                  ? 'bg-slate-700 text-white'
-                  : 'text-slate-400 hover:text-white hover:bg-slate-700/50'
+                  ? 'bg-theme-elevated text-theme-text-primary'
+                  : 'text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated/50'
               )}
             >
               <tab.icon className="w-3.5 h-3.5" />
@@ -306,9 +306,9 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource }: He
       {/* Content */}
       <div className="flex-1 overflow-y-auto">
         {isLoading ? (
-          <div className="flex items-center justify-center h-32 text-slate-500">Loading...</div>
+          <div className="flex items-center justify-center h-32 text-theme-text-tertiary">Loading...</div>
         ) : !releaseDetail ? (
-          <div className="flex items-center justify-center h-32 text-slate-500">Release not found</div>
+          <div className="flex items-center justify-center h-32 text-theme-text-tertiary">Release not found</div>
         ) : (
           <>
             {activeTab === 'overview' && (
@@ -430,54 +430,54 @@ function OverviewTab({ release, onCopy, copied }: OverviewTabProps) {
   return (
     <div className="p-4 space-y-4">
       {/* Chart info */}
-      <div className="bg-slate-700/30 rounded-lg p-4">
-        <h3 className="text-sm font-medium text-slate-300 mb-3">Chart Information</h3>
+      <div className="bg-theme-elevated/30 rounded-lg p-4">
+        <h3 className="text-sm font-medium text-theme-text-secondary mb-3">Chart Information</h3>
         <dl className="grid grid-cols-2 gap-3 text-sm">
           <div>
-            <dt className="text-slate-500">Chart</dt>
-            <dd className="text-white font-medium">{release.chart}</dd>
+            <dt className="text-theme-text-tertiary">Chart</dt>
+            <dd className="text-theme-text-primary font-medium">{release.chart}</dd>
           </div>
           <div>
-            <dt className="text-slate-500">Chart Version</dt>
-            <dd className="text-white">{release.chartVersion}</dd>
+            <dt className="text-theme-text-tertiary">Chart Version</dt>
+            <dd className="text-theme-text-primary">{release.chartVersion}</dd>
           </div>
           <div>
-            <dt className="text-slate-500">App Version</dt>
-            <dd className="text-white">{release.appVersion || '-'}</dd>
+            <dt className="text-theme-text-tertiary">App Version</dt>
+            <dd className="text-theme-text-primary">{release.appVersion || '-'}</dd>
           </div>
           <div>
-            <dt className="text-slate-500">Revision</dt>
-            <dd className="text-white">{release.revision}</dd>
+            <dt className="text-theme-text-tertiary">Revision</dt>
+            <dd className="text-theme-text-primary">{release.revision}</dd>
           </div>
           <div className="col-span-2">
-            <dt className="text-slate-500">Updated</dt>
-            <dd className="text-white">{formatDate(release.updated)}</dd>
+            <dt className="text-theme-text-tertiary">Updated</dt>
+            <dd className="text-theme-text-primary">{formatDate(release.updated)}</dd>
           </div>
         </dl>
       </div>
 
       {/* Description */}
       {release.description && (
-        <div className="bg-slate-700/30 rounded-lg p-4">
-          <h3 className="text-sm font-medium text-slate-300 mb-2">Description</h3>
-          <p className="text-sm text-slate-400">{release.description}</p>
+        <div className="bg-theme-elevated/30 rounded-lg p-4">
+          <h3 className="text-sm font-medium text-theme-text-secondary mb-2">Description</h3>
+          <p className="text-sm text-theme-text-secondary">{release.description}</p>
         </div>
       )}
 
       {/* Notes */}
       {release.notes && (
-        <div className="bg-slate-700/30 rounded-lg p-4">
+        <div className="bg-theme-elevated/30 rounded-lg p-4">
           <div className="flex items-center justify-between mb-2">
-            <h3 className="text-sm font-medium text-slate-300">Release Notes</h3>
+            <h3 className="text-sm font-medium text-theme-text-secondary">Release Notes</h3>
             <button
               onClick={() => onCopy(release.notes, 'notes')}
-              className="flex items-center gap-1 px-2 py-1 text-xs text-slate-400 hover:text-white hover:bg-slate-700 rounded"
+              className="flex items-center gap-1 px-2 py-1 text-xs text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
             >
               {copied === 'notes' ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
               Copy
             </button>
           </div>
-          <pre className="text-xs text-slate-400 whitespace-pre-wrap font-mono bg-slate-900/50 rounded p-3 max-h-64 overflow-auto">
+          <pre className="text-xs text-theme-text-secondary whitespace-pre-wrap font-mono bg-theme-base/50 rounded p-3 max-h-64 overflow-auto">
             {release.notes}
           </pre>
         </div>
@@ -485,27 +485,27 @@ function OverviewTab({ release, onCopy, copied }: OverviewTabProps) {
 
       {/* Dependencies */}
       {release.dependencies && release.dependencies.length > 0 && (
-        <div className="bg-slate-700/30 rounded-lg p-4">
+        <div className="bg-theme-elevated/30 rounded-lg p-4">
           <div className="flex items-center gap-2 mb-3">
-            <GitFork className="w-4 h-4 text-slate-400" />
-            <h3 className="text-sm font-medium text-slate-300">Chart Dependencies</h3>
+            <GitFork className="w-4 h-4 text-theme-text-secondary" />
+            <h3 className="text-sm font-medium text-theme-text-secondary">Chart Dependencies</h3>
           </div>
           <div className="space-y-2">
             {release.dependencies.map((dep, i) => (
-              <div key={i} className="flex items-center justify-between bg-slate-900/50 rounded p-2 text-sm">
+              <div key={i} className="flex items-center justify-between bg-theme-base/50 rounded p-2 text-sm">
                 <div className="flex items-center gap-2">
-                  <span className="text-white font-medium">{dep.name}</span>
-                  <span className="text-slate-500">{dep.version}</span>
+                  <span className="text-theme-text-primary font-medium">{dep.name}</span>
+                  <span className="text-theme-text-tertiary">{dep.version}</span>
                 </div>
                 <div className="flex items-center gap-2">
                   {dep.condition && (
-                    <span className="text-xs text-slate-500">{dep.condition}</span>
+                    <span className="text-xs text-theme-text-tertiary">{dep.condition}</span>
                   )}
                   <span className={clsx(
                     'px-1.5 py-0.5 text-xs rounded',
                     dep.enabled
                       ? 'bg-green-500/20 text-green-400'
-                      : 'bg-slate-600/50 text-slate-400'
+                      : 'bg-theme-hover/50 text-theme-text-secondary'
                   )}>
                     {dep.enabled ? 'enabled' : 'disabled'}
                   </span>
@@ -518,21 +518,21 @@ function OverviewTab({ release, onCopy, copied }: OverviewTabProps) {
 
       {/* README */}
       {release.readme && (
-        <div className="bg-slate-700/30 rounded-lg p-4">
+        <div className="bg-theme-elevated/30 rounded-lg p-4">
           <div className="flex items-center justify-between mb-2">
             <div className="flex items-center gap-2">
-              <BookOpen className="w-4 h-4 text-slate-400" />
-              <h3 className="text-sm font-medium text-slate-300">Chart README</h3>
+              <BookOpen className="w-4 h-4 text-theme-text-secondary" />
+              <h3 className="text-sm font-medium text-theme-text-secondary">Chart README</h3>
             </div>
             <button
               onClick={() => onCopy(release.readme!, 'readme')}
-              className="flex items-center gap-1 px-2 py-1 text-xs text-slate-400 hover:text-white hover:bg-slate-700 rounded"
+              className="flex items-center gap-1 px-2 py-1 text-xs text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
             >
               {copied === 'readme' ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
               Copy
             </button>
           </div>
-          <pre className="text-xs text-slate-400 whitespace-pre-wrap font-mono bg-slate-900/50 rounded p-3 max-h-96 overflow-auto">
+          <pre className="text-xs text-theme-text-secondary whitespace-pre-wrap font-mono bg-theme-base/50 rounded p-3 max-h-96 overflow-auto">
             {release.readme}
           </pre>
         </div>
@@ -549,7 +549,7 @@ interface HooksTabProps {
 function HooksTab({ hooks }: HooksTabProps) {
   if (hooks.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-48 text-slate-500">
+      <div className="flex flex-col items-center justify-center h-48 text-theme-text-tertiary">
         <Anchor className="w-8 h-8 mb-2 opacity-50" />
         <p>No hooks defined for this release</p>
       </div>
@@ -557,7 +557,7 @@ function HooksTab({ hooks }: HooksTabProps) {
   }
 
   const getHookStatusColor = (status?: string) => {
-    if (!status) return 'bg-slate-600/50 text-slate-400'
+    if (!status) return 'bg-theme-hover/50 text-theme-text-secondary'
     switch (status.toLowerCase()) {
       case 'succeeded':
         return 'bg-green-500/20 text-green-400'
@@ -566,7 +566,7 @@ function HooksTab({ hooks }: HooksTabProps) {
       case 'running':
         return 'bg-blue-500/20 text-blue-400'
       default:
-        return 'bg-slate-600/50 text-slate-400'
+        return 'bg-theme-hover/50 text-theme-text-secondary'
     }
   }
 
@@ -575,25 +575,25 @@ function HooksTab({ hooks }: HooksTabProps) {
     if (event.includes('install')) return 'bg-green-500/20 text-green-400 border-green-500/30'
     if (event.includes('upgrade')) return 'bg-blue-500/20 text-blue-400 border-blue-500/30'
     if (event.includes('rollback')) return 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30'
-    return 'bg-slate-600/50 text-slate-400 border-slate-500/30'
+    return 'bg-theme-hover/50 text-theme-text-secondary border-theme-border'
   }
 
   return (
     <div className="p-4 space-y-3">
-      <p className="text-sm text-slate-400 mb-4">
+      <p className="text-sm text-theme-text-secondary mb-4">
         Helm hooks are executed at specific points during the release lifecycle.
       </p>
       {hooks.map((hook, i) => (
-        <div key={i} className="bg-slate-700/30 rounded-lg p-4">
+        <div key={i} className="bg-theme-elevated/30 rounded-lg p-4">
           <div className="flex items-start justify-between mb-2">
             <div>
               <div className="flex items-center gap-2">
-                <span className="text-white font-medium">{hook.name}</span>
-                <span className="px-1.5 py-0.5 text-xs rounded bg-slate-600/50 text-slate-300">
+                <span className="text-theme-text-primary font-medium">{hook.name}</span>
+                <span className="px-1.5 py-0.5 text-xs rounded bg-theme-hover/50 text-theme-text-secondary">
                   {hook.kind}
                 </span>
               </div>
-              <div className="flex items-center gap-2 mt-1 text-xs text-slate-500">
+              <div className="flex items-center gap-2 mt-1 text-xs text-theme-text-tertiary">
                 <span>Weight: {hook.weight}</span>
               </div>
             </div>

--- a/web/src/components/helm/HelmView.tsx
+++ b/web/src/components/helm/HelmView.tsx
@@ -43,32 +43,32 @@ export function HelmView({ namespace, selectedRelease, onReleaseClick }: HelmVie
       {/* Main Content */}
       <div className="flex-1 flex flex-col overflow-hidden min-w-0">
         {/* Toolbar */}
-        <div className="flex items-center gap-4 px-4 py-3 border-b border-slate-700 bg-slate-800/50 shrink-0">
-          <div className="flex items-center gap-2 text-slate-400">
+        <div className="flex items-center gap-4 px-4 py-3 border-b border-theme-border bg-theme-surface/50 shrink-0">
+          <div className="flex items-center gap-2 text-theme-text-secondary">
             <Package className="w-5 h-5" />
             <span className="font-medium">Helm Releases</span>
             {releases && (
-              <span className="text-xs bg-slate-700 px-2 py-0.5 rounded">
+              <span className="text-xs bg-theme-elevated px-2 py-0.5 rounded">
                 {releases.length}
               </span>
             )}
             {!isFullyLoaded && (
-              <RefreshCw className="w-3.5 h-3.5 animate-spin text-slate-500" />
+              <RefreshCw className="w-3.5 h-3.5 animate-spin text-theme-text-tertiary" />
             )}
           </div>
           <div className="flex-1 relative">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" />
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-theme-text-tertiary" />
             <input
               type="text"
               placeholder="Search releases..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full max-w-md pl-10 pr-4 py-2 bg-slate-700 border border-slate-600 rounded-lg text-sm text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full max-w-md pl-10 pr-4 py-2 bg-theme-elevated border border-theme-border-light rounded-lg text-sm text-theme-text-primary placeholder-theme-text-disabled focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
           </div>
           <button
             onClick={() => refetch()}
-            className="p-2 text-slate-400 hover:text-white hover:bg-slate-700 rounded-lg"
+            className="p-2 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded-lg"
             title="Refresh"
           >
             <RefreshCw className="w-4 h-4" />
@@ -78,12 +78,12 @@ export function HelmView({ namespace, selectedRelease, onReleaseClick }: HelmVie
         {/* Table */}
         <div className="flex-1 overflow-auto">
           {isLoading ? (
-            <div className="flex items-center justify-center h-full text-slate-500">
+            <div className="flex items-center justify-center h-full text-theme-text-tertiary">
               Loading...
             </div>
           ) : filteredReleases.length === 0 ? (
-            <div className="flex flex-col items-center justify-center h-full text-slate-500 gap-2">
-              <Package className="w-12 h-12 text-slate-600" />
+            <div className="flex flex-col items-center justify-center h-full text-theme-text-tertiary gap-2">
+              <Package className="w-12 h-12 text-theme-text-disabled" />
               <span>No Helm releases found</span>
               {searchTerm && (
                 <button
@@ -96,32 +96,32 @@ export function HelmView({ namespace, selectedRelease, onReleaseClick }: HelmVie
             </div>
           ) : (
             <table className="w-full table-fixed">
-              <thead className="bg-slate-800 sticky top-0 z-10">
+              <thead className="bg-theme-surface sticky top-0 z-10">
                 <tr>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-slate-400 uppercase tracking-wide">
+                  <th className="text-left px-4 py-3 text-xs font-medium text-theme-text-secondary uppercase tracking-wide">
                     Name
                   </th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-slate-400 uppercase tracking-wide w-32">
+                  <th className="text-left px-4 py-3 text-xs font-medium text-theme-text-secondary uppercase tracking-wide w-32">
                     Namespace
                   </th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-slate-400 uppercase tracking-wide w-48">
+                  <th className="text-left px-4 py-3 text-xs font-medium text-theme-text-secondary uppercase tracking-wide w-48">
                     Chart
                   </th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-slate-400 uppercase tracking-wide w-24 hidden xl:table-cell">
+                  <th className="text-left px-4 py-3 text-xs font-medium text-theme-text-secondary uppercase tracking-wide w-24 hidden xl:table-cell">
                     App Version
                   </th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-slate-400 uppercase tracking-wide w-28">
+                  <th className="text-left px-4 py-3 text-xs font-medium text-theme-text-secondary uppercase tracking-wide w-28">
                     Status
                   </th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-slate-400 uppercase tracking-wide w-20">
+                  <th className="text-left px-4 py-3 text-xs font-medium text-theme-text-secondary uppercase tracking-wide w-20">
                     Rev
                   </th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-slate-400 uppercase tracking-wide w-24">
+                  <th className="text-left px-4 py-3 text-xs font-medium text-theme-text-secondary uppercase tracking-wide w-24">
                     Updated
                   </th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-slate-700/50">
+              <tbody className="table-divide-subtle">
                 {filteredReleases.map((release) => (
                   <ReleaseRow
                     key={`${release.namespace}-${release.name}`}
@@ -158,13 +158,13 @@ function ReleaseRow({ release, upgradeInfo, isSelected, onClick }: ReleaseRowPro
         'cursor-pointer transition-colors',
         isSelected
           ? 'bg-blue-500/20 hover:bg-blue-500/30'
-          : 'hover:bg-slate-800/50'
+          : 'hover:bg-theme-surface/50'
       )}
     >
       <td className="px-4 py-3">
         <div className="flex items-center gap-2">
-          <Package className="w-4 h-4 text-slate-500 flex-shrink-0" />
-          <span className="text-sm text-white font-medium truncate">{release.name}</span>
+          <Package className="w-4 h-4 text-theme-text-tertiary flex-shrink-0" />
+          <span className="text-sm text-theme-text-primary font-medium truncate">{release.name}</span>
           {upgradeInfo?.updateAvailable && (
             <Tooltip content={`Upgrade available: ${release.chartVersion} → ${upgradeInfo.latestVersion}`}>
               <span className="flex items-center gap-0.5 px-1.5 py-0.5 text-xs font-medium rounded bg-amber-500/20 text-amber-400 border border-amber-500/30 shrink-0">
@@ -175,17 +175,17 @@ function ReleaseRow({ release, upgradeInfo, isSelected, onClick }: ReleaseRowPro
         </div>
       </td>
       <td className="px-4 py-3 w-32">
-        <span className="text-sm text-slate-400">{release.namespace}</span>
+        <span className="text-sm text-theme-text-secondary">{release.namespace}</span>
       </td>
       <td className="px-4 py-3 w-48">
         <Tooltip content={`${release.chart}-${release.chartVersion}`}>
-          <span className="text-sm text-slate-400 truncate block">
+          <span className="text-sm text-theme-text-secondary truncate block">
             {truncate(`${release.chart}-${release.chartVersion}`, 35)}
           </span>
         </Tooltip>
       </td>
       <td className="px-4 py-3 w-24 hidden xl:table-cell">
-        <span className="text-sm text-slate-400">{release.appVersion || '-'}</span>
+        <span className="text-sm text-theme-text-secondary">{release.appVersion || '-'}</span>
       </td>
       <td className="px-4 py-3 w-28">
         <span
@@ -198,11 +198,11 @@ function ReleaseRow({ release, upgradeInfo, isSelected, onClick }: ReleaseRowPro
         </span>
       </td>
       <td className="px-4 py-3 w-20">
-        <span className="text-sm text-slate-400">{release.revision}</span>
+        <span className="text-sm text-theme-text-secondary">{release.revision}</span>
       </td>
       <td className="px-4 py-3 w-24">
         <Tooltip content={release.updated}>
-          <span className="text-sm text-slate-400">
+          <span className="text-sm text-theme-text-secondary">
             {formatAge(release.updated)}
           </span>
         </Tooltip>

--- a/web/src/components/helm/ManifestDiffViewer.tsx
+++ b/web/src/components/helm/ManifestDiffViewer.tsx
@@ -12,7 +12,7 @@ interface ManifestDiffViewerProps {
 export function ManifestDiffViewer({ diff, isLoading, revision1, revision2, onClose }: ManifestDiffViewerProps) {
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-32 text-slate-500">
+      <div className="flex items-center justify-center h-32 text-theme-text-tertiary">
         Computing diff...
       </div>
     )
@@ -21,8 +21,8 @@ export function ManifestDiffViewer({ diff, isLoading, revision1, revision2, onCl
   if (!diff) {
     return (
       <div className="p-4">
-        <div className="flex flex-col items-center justify-center h-32 text-slate-500 gap-2">
-          <GitCompare className="w-8 h-8 text-slate-600" />
+        <div className="flex flex-col items-center justify-center h-32 text-theme-text-tertiary gap-2">
+          <GitCompare className="w-8 h-8 text-theme-text-disabled" />
           <span>No differences found</span>
         </div>
       </div>
@@ -33,21 +33,21 @@ export function ManifestDiffViewer({ diff, isLoading, revision1, revision2, onCl
     <div className="p-4">
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
-          <GitCompare className="w-4 h-4 text-slate-400" />
-          <span className="text-sm font-medium text-slate-300">
+          <GitCompare className="w-4 h-4 text-theme-text-secondary" />
+          <span className="text-sm font-medium text-theme-text-secondary">
             Comparing Revision {revision1} → {revision2}
           </span>
         </div>
         <button
           onClick={onClose}
-          className="flex items-center gap-1 px-2 py-1 text-xs text-slate-400 hover:text-white hover:bg-slate-700 rounded"
+          className="flex items-center gap-1 px-2 py-1 text-xs text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
         >
           <X className="w-3.5 h-3.5" />
           Close
         </button>
       </div>
 
-      <div className="rounded-lg overflow-hidden max-h-[calc(100vh-300px)] overflow-auto bg-slate-900/50 font-mono text-xs">
+      <div className="rounded-lg overflow-hidden max-h-[calc(100vh-300px)] overflow-auto bg-theme-base/50 font-mono text-xs">
         <div className="p-3">
           {diff.split('\n').map((line, index) => (
             <DiffLine key={index} line={line} />
@@ -56,7 +56,7 @@ export function ManifestDiffViewer({ diff, isLoading, revision1, revision2, onCl
       </div>
 
       {/* Legend */}
-      <div className="flex items-center gap-4 mt-3 text-xs text-slate-500">
+      <div className="flex items-center gap-4 mt-3 text-xs text-theme-text-tertiary">
         <div className="flex items-center gap-1">
           <span className="w-3 h-3 bg-red-500/20 border border-red-500/50 rounded" />
           <span>Removed</span>
@@ -81,8 +81,8 @@ function DiffLine({ line }: { line: string }) {
         'whitespace-pre',
         isAddition && 'bg-green-500/10 text-green-400',
         isRemoval && 'bg-red-500/10 text-red-400',
-        isHeader && 'text-slate-500 font-bold',
-        !isAddition && !isRemoval && !isHeader && 'text-slate-400'
+        isHeader && 'text-theme-text-tertiary font-bold',
+        !isAddition && !isRemoval && !isHeader && 'text-theme-text-secondary'
       )}
     >
       {line || ' '}

--- a/web/src/components/helm/ManifestViewer.tsx
+++ b/web/src/components/helm/ManifestViewer.tsx
@@ -12,7 +12,7 @@ interface ManifestViewerProps {
 export function ManifestViewer({ manifest, isLoading, revision, onCopy, copied }: ManifestViewerProps) {
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-32 text-slate-500">
+      <div className="flex items-center justify-center h-32 text-theme-text-tertiary">
         Loading manifest...
       </div>
     )
@@ -20,8 +20,8 @@ export function ManifestViewer({ manifest, isLoading, revision, onCopy, copied }
 
   if (!manifest) {
     return (
-      <div className="flex flex-col items-center justify-center h-32 text-slate-500 gap-2">
-        <Code className="w-8 h-8 text-slate-600" />
+      <div className="flex flex-col items-center justify-center h-32 text-theme-text-tertiary gap-2">
+        <Code className="w-8 h-8 text-theme-text-disabled" />
         <span>No manifest available</span>
       </div>
     )
@@ -33,17 +33,17 @@ export function ManifestViewer({ manifest, isLoading, revision, onCopy, copied }
     <div className="p-4">
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-slate-300">Rendered Manifest</span>
+          <span className="text-sm font-medium text-theme-text-secondary">Rendered Manifest</span>
           {revision && (
-            <span className="px-2 py-0.5 text-xs bg-slate-700 text-slate-400 rounded">
+            <span className="px-2 py-0.5 text-xs bg-theme-elevated text-theme-text-secondary rounded">
               Revision {revision}
             </span>
           )}
-          <span className="text-xs text-slate-500">{lineCount} lines</span>
+          <span className="text-xs text-theme-text-tertiary">{lineCount} lines</span>
         </div>
         <button
           onClick={() => onCopy(manifest)}
-          className="flex items-center gap-1 px-2 py-1 text-xs text-slate-400 hover:text-white hover:bg-slate-700 rounded"
+          className="flex items-center gap-1 px-2 py-1 text-xs text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
         >
           {copied ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
           Copy

--- a/web/src/components/helm/OwnedResources.tsx
+++ b/web/src/components/helm/OwnedResources.tsx
@@ -5,7 +5,7 @@ import { kindToPlural } from './helm-utils'
 
 // Status color mapping
 function getStatusColor(status?: string): string {
-  if (!status) return 'bg-slate-600/50 text-slate-400'
+  if (!status) return 'bg-theme-hover/50 text-theme-text-secondary'
 
   const statusLower = status.toLowerCase()
 
@@ -29,7 +29,7 @@ function getStatusColor(status?: string): string {
     return 'bg-blue-500/20 text-blue-400'
   }
 
-  return 'bg-slate-600/50 text-slate-400'
+  return 'bg-theme-hover/50 text-theme-text-secondary'
 }
 
 interface OwnedResourcesProps {
@@ -94,8 +94,8 @@ function computeHealthSummary(resources: HelmOwnedResource[]) {
 export function OwnedResources({ resources, onNavigate }: OwnedResourcesProps) {
   if (!resources || resources.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-32 text-slate-500 gap-2">
-        <Link2 className="w-8 h-8 text-slate-600" />
+      <div className="flex flex-col items-center justify-center h-32 text-theme-text-tertiary gap-2">
+        <Link2 className="w-8 h-8 text-theme-text-disabled" />
         <span>No owned resources</span>
       </div>
     )
@@ -108,7 +108,7 @@ export function OwnedResources({ resources, onNavigate }: OwnedResourcesProps) {
     <div className="p-4 space-y-4">
       {/* Health summary */}
       <div className="flex items-center justify-between">
-        <div className="text-sm text-slate-400">
+        <div className="text-sm text-theme-text-secondary">
           {resources.length} resource{resources.length !== 1 ? 's' : ''} created by this release
         </div>
         <div className="flex items-center gap-2">
@@ -134,11 +134,11 @@ export function OwnedResources({ resources, onNavigate }: OwnedResourcesProps) {
         const Icon = getIconForKind(kind)
 
         return (
-          <div key={kind} className="bg-slate-700/30 rounded-lg p-3">
+          <div key={kind} className="bg-theme-elevated/30 rounded-lg p-3">
             <div className="flex items-center gap-2 mb-2">
-              <Icon className="w-4 h-4 text-slate-400" />
-              <span className="text-sm font-medium text-slate-300">{kind}</span>
-              <span className="text-xs text-slate-500">({items.length})</span>
+              <Icon className="w-4 h-4 text-theme-text-secondary" />
+              <span className="text-sm font-medium text-theme-text-secondary">{kind}</span>
+              <span className="text-xs text-theme-text-tertiary">({items.length})</span>
             </div>
             <div className="space-y-1">
               {items.map((resource) => (
@@ -178,21 +178,21 @@ function ResourceItem({ resource, onNavigate }: ResourceItemProps) {
       className={clsx(
         'flex items-center justify-between p-2 rounded text-sm',
         canNavigate
-          ? 'cursor-pointer hover:bg-slate-700/50 group'
-          : 'bg-slate-800/50'
+          ? 'cursor-pointer hover:bg-theme-elevated/50 group'
+          : 'bg-theme-surface/50'
       )}
     >
       <div className="flex items-center gap-2 min-w-0 flex-1">
-        <span className="text-white truncate">{resource.name}</span>
+        <span className="text-theme-text-primary truncate">{resource.name}</span>
         {resource.namespace && (
-          <span className="text-xs text-slate-500 shrink-0">{resource.namespace}</span>
+          <span className="text-xs text-theme-text-tertiary shrink-0">{resource.namespace}</span>
         )}
       </div>
 
       <div className="flex items-center gap-2 shrink-0">
         {/* Ready count (e.g., 3/3) */}
         {resource.ready && (
-          <span className="text-xs text-slate-400 font-mono">{resource.ready}</span>
+          <span className="text-xs text-theme-text-secondary font-mono">{resource.ready}</span>
         )}
 
         {/* Status badge */}
@@ -213,7 +213,7 @@ function ResourceItem({ resource, onNavigate }: ResourceItemProps) {
         )}
 
         {canNavigate && (
-          <ExternalLink className="w-3.5 h-3.5 text-slate-500 opacity-0 group-hover:opacity-100 transition-opacity" />
+          <ExternalLink className="w-3.5 h-3.5 text-theme-text-tertiary opacity-0 group-hover:opacity-100 transition-opacity" />
         )}
       </div>
     </div>

--- a/web/src/components/helm/RevisionHistory.tsx
+++ b/web/src/components/helm/RevisionHistory.tsx
@@ -31,8 +31,8 @@ export function RevisionHistory({ history, currentRevision, onViewRevision, onCo
 
   if (!history || history.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-32 text-slate-500 gap-2">
-        <History className="w-8 h-8 text-slate-600" />
+      <div className="flex flex-col items-center justify-center h-32 text-theme-text-tertiary gap-2">
+        <History className="w-8 h-8 text-theme-text-disabled" />
         <span>No revision history</span>
       </div>
     )
@@ -49,7 +49,7 @@ export function RevisionHistory({ history, currentRevision, onViewRevision, onCo
           </div>
           <button
             onClick={() => setSelectedForCompare(null)}
-            className="text-xs text-slate-400 hover:text-white"
+            className="text-xs text-theme-text-secondary hover:text-theme-text-primary"
           >
             Cancel
           </button>
@@ -66,17 +66,17 @@ export function RevisionHistory({ history, currentRevision, onViewRevision, onCo
             <div
               key={revision.revision}
               className={clsx(
-                'relative bg-slate-700/30 rounded-lg p-4 border transition-colors',
+                'relative bg-theme-elevated/30 rounded-lg p-4 border transition-colors',
                 isCurrent
                   ? 'border-green-500/50'
                   : isSelectedForCompare
                   ? 'border-blue-500/50 bg-blue-500/10'
-                  : 'border-transparent hover:border-slate-600'
+                  : 'border-transparent hover:border-theme-border-light'
               )}
             >
               {/* Timeline connector */}
               {index < history.length - 1 && (
-                <div className="absolute left-7 top-14 bottom-0 w-0.5 bg-slate-600 -mb-2" />
+                <div className="absolute left-7 top-14 bottom-0 w-0.5 bg-theme-hover -mb-2" />
               )}
 
               <div className="flex items-start gap-3">
@@ -85,8 +85,8 @@ export function RevisionHistory({ history, currentRevision, onViewRevision, onCo
                   className={clsx(
                     'w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold shrink-0 z-10',
                     isCurrent
-                      ? 'bg-green-500 text-white'
-                      : 'bg-slate-600 text-slate-300'
+                      ? 'bg-green-500 text-theme-text-primary'
+                      : 'bg-theme-hover text-theme-text-secondary'
                   )}
                 >
                   {revision.revision}
@@ -95,7 +95,7 @@ export function RevisionHistory({ history, currentRevision, onViewRevision, onCo
                 {/* Revision details */}
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 flex-wrap">
-                    <span className="text-sm font-medium text-white">{revision.chart}</span>
+                    <span className="text-sm font-medium text-theme-text-primary">{revision.chart}</span>
                     <span className={clsx('px-1.5 py-0.5 text-xs font-medium rounded', getStatusColor(revision.status))}>
                       {revision.status}
                     </span>
@@ -106,20 +106,20 @@ export function RevisionHistory({ history, currentRevision, onViewRevision, onCo
                     )}
                   </div>
 
-                  <div className="flex items-center gap-4 mt-1 text-xs text-slate-500">
+                  <div className="flex items-center gap-4 mt-1 text-xs text-theme-text-tertiary">
                     <span title={revision.updated}>{formatDate(revision.updated)}</span>
                     <span>{formatAge(revision.updated)} ago</span>
                   </div>
 
                   {revision.description && (
-                    <p className="mt-2 text-sm text-slate-400 truncate">{revision.description}</p>
+                    <p className="mt-2 text-sm text-theme-text-secondary truncate">{revision.description}</p>
                   )}
 
                   {/* Actions */}
                   <div className="flex items-center gap-2 mt-3">
                     <button
                       onClick={() => onViewRevision(revision.revision)}
-                      className="flex items-center gap-1 px-2 py-1 text-xs text-slate-400 hover:text-white hover:bg-slate-700 rounded"
+                      className="flex items-center gap-1 px-2 py-1 text-xs text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
                     >
                       <Eye className="w-3.5 h-3.5" />
                       View Manifest
@@ -129,8 +129,8 @@ export function RevisionHistory({ history, currentRevision, onViewRevision, onCo
                       className={clsx(
                         'flex items-center gap-1 px-2 py-1 text-xs rounded',
                         isSelectedForCompare
-                          ? 'bg-blue-500 text-white'
-                          : 'text-slate-400 hover:text-white hover:bg-slate-700'
+                          ? 'bg-blue-500 text-theme-text-primary'
+                          : 'text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated'
                       )}
                     >
                       {isSelectedForCompare ? (

--- a/web/src/components/helm/ValuesViewer.tsx
+++ b/web/src/components/helm/ValuesViewer.tsx
@@ -22,7 +22,7 @@ export function ValuesViewer({
 }: ValuesViewerProps) {
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-32 text-slate-500">
+      <div className="flex items-center justify-center h-32 text-theme-text-tertiary">
         Loading values...
       </div>
     )
@@ -35,11 +35,11 @@ export function ValuesViewer({
     return (
       <div className="p-4">
         <div className="flex items-center justify-between mb-3">
-          <span className="text-sm font-medium text-slate-300">Values</span>
+          <span className="text-sm font-medium text-theme-text-secondary">Values</span>
           <ToggleButton showAll={showAllValues} onToggle={onToggleAllValues} />
         </div>
-        <div className="flex flex-col items-center justify-center h-32 text-slate-500 gap-2">
-          <Settings className="w-8 h-8 text-slate-600" />
+        <div className="flex flex-col items-center justify-center h-32 text-theme-text-tertiary gap-2">
+          <Settings className="w-8 h-8 text-theme-text-disabled" />
           <span>{showAllValues ? 'No computed values' : 'No user-supplied values'}</span>
         </div>
       </div>
@@ -52,7 +52,7 @@ export function ValuesViewer({
     <div className="p-4">
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-slate-300">
+          <span className="text-sm font-medium text-theme-text-secondary">
             {showAllValues ? 'All Values (Computed)' : 'User-Supplied Values'}
           </span>
         </div>
@@ -60,7 +60,7 @@ export function ValuesViewer({
           <ToggleButton showAll={showAllValues} onToggle={onToggleAllValues} />
           <button
             onClick={() => onCopy(yaml)}
-            className="flex items-center gap-1 px-2 py-1 text-xs text-slate-400 hover:text-white hover:bg-slate-700 rounded"
+            className="flex items-center gap-1 px-2 py-1 text-xs text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
           >
             {copied ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
             Copy
@@ -80,12 +80,12 @@ export function ValuesViewer({
 
 function ToggleButton({ showAll, onToggle }: { showAll: boolean; onToggle: (show: boolean) => void }) {
   return (
-    <div className="flex items-center bg-slate-700/50 rounded-md p-0.5 text-xs">
+    <div className="flex items-center bg-theme-elevated/50 rounded-md p-0.5 text-xs">
       <button
         onClick={() => onToggle(false)}
         className={clsx(
           'px-2 py-1 rounded transition-colors',
-          !showAll ? 'bg-slate-600 text-white' : 'text-slate-400 hover:text-white'
+          !showAll ? 'bg-theme-hover text-theme-text-primary' : 'text-theme-text-secondary hover:text-theme-text-primary'
         )}
       >
         User
@@ -94,7 +94,7 @@ function ToggleButton({ showAll, onToggle }: { showAll: boolean; onToggle: (show
         onClick={() => onToggle(true)}
         className={clsx(
           'px-2 py-1 rounded transition-colors',
-          showAll ? 'bg-slate-600 text-white' : 'text-slate-400 hover:text-white'
+          showAll ? 'bg-theme-hover text-theme-text-primary' : 'text-theme-text-secondary hover:text-theme-text-primary'
         )}
       >
         All

--- a/web/src/components/helm/helm-utils.ts
+++ b/web/src/components/helm/helm-utils.ts
@@ -7,7 +7,7 @@ export function getStatusColor(status: string): string {
     return 'bg-green-500/20 text-green-400'
   }
   if (statusLower === 'superseded') {
-    return 'bg-slate-500/20 text-slate-400'
+    return 'bg-theme-hover/50 text-theme-text-secondary'
   }
   if (statusLower === 'failed') {
     return 'bg-red-500/20 text-red-400'
@@ -19,9 +19,9 @@ export function getStatusColor(status: string): string {
     return 'bg-orange-500/20 text-orange-400'
   }
   if (statusLower === 'uninstalled') {
-    return 'bg-slate-500/20 text-slate-400'
+    return 'bg-theme-hover/50 text-theme-text-secondary'
   }
-  return 'bg-slate-500/20 text-slate-400'
+  return 'bg-theme-hover/50 text-theme-text-secondary'
 }
 
 // Format age from ISO date string

--- a/web/src/components/logs/LogsViewer.tsx
+++ b/web/src/components/logs/LogsViewer.tsx
@@ -144,22 +144,22 @@ export function LogsViewer({ namespace, podName, containers, initialContainer }:
     : logLines
 
   return (
-    <div className="flex flex-col h-full bg-slate-900">
+    <div className="flex flex-col h-full bg-theme-base">
       {/* Toolbar */}
-      <div className="flex items-center gap-2 px-3 py-2 border-b border-slate-700 bg-slate-800">
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-theme-border bg-theme-surface">
         {/* Container selector */}
         {containers.length > 1 && (
           <div className="relative">
             <select
               value={selectedContainer}
               onChange={(e) => setSelectedContainer(e.target.value)}
-              className="appearance-none bg-slate-700 text-white text-xs rounded px-2 py-1.5 pr-6 border border-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              className="appearance-none bg-theme-elevated text-theme-text-primary text-xs rounded px-2 py-1.5 pr-6 border border-theme-border-light focus:outline-none focus:ring-1 focus:ring-blue-500"
             >
               {containers.map(c => (
                 <option key={c} value={c}>{c}</option>
               ))}
             </select>
-            <ChevronDown className="absolute right-1.5 top-1/2 -translate-y-1/2 w-3 h-3 text-slate-400 pointer-events-none" />
+            <ChevronDown className="absolute right-1.5 top-1/2 -translate-y-1/2 w-3 h-3 text-theme-text-secondary pointer-events-none" />
           </div>
         )}
 
@@ -168,8 +168,8 @@ export function LogsViewer({ namespace, podName, containers, initialContainer }:
           onClick={isStreaming ? stopStreaming : startStreaming}
           className={`flex items-center gap-1.5 px-2 py-1.5 text-xs rounded transition-colors ${
             isStreaming
-              ? 'bg-green-600 text-white hover:bg-green-700'
-              : 'bg-slate-700 text-slate-300 hover:bg-slate-600'
+              ? 'bg-green-600 text-theme-text-primary hover:bg-green-700'
+              : 'bg-theme-elevated text-theme-text-secondary hover:bg-theme-hover'
           }`}
           title={isStreaming ? 'Stop streaming' : 'Start streaming'}
         >
@@ -181,19 +181,19 @@ export function LogsViewer({ namespace, podName, containers, initialContainer }:
         <button
           onClick={() => refetch()}
           disabled={isLoading || isStreaming}
-          className="flex items-center gap-1.5 px-2 py-1.5 text-xs rounded bg-slate-700 text-slate-300 hover:bg-slate-600 disabled:opacity-50 disabled:cursor-not-allowed"
+          className="flex items-center gap-1.5 px-2 py-1.5 text-xs rounded bg-theme-elevated text-theme-text-secondary hover:bg-theme-hover disabled:opacity-50 disabled:cursor-not-allowed"
           title="Refresh logs"
         >
           <RotateCcw className={`w-3 h-3 ${isLoading ? 'animate-spin' : ''}`} />
         </button>
 
         {/* Previous logs toggle */}
-        <label className="flex items-center gap-1.5 text-xs text-slate-400 cursor-pointer">
+        <label className="flex items-center gap-1.5 text-xs text-theme-text-secondary cursor-pointer">
           <input
             type="checkbox"
             checked={showPrevious}
             onChange={(e) => setShowPrevious(e.target.checked)}
-            className="w-3 h-3 rounded border-slate-600 bg-slate-700 text-blue-500 focus:ring-blue-500 focus:ring-offset-0"
+            className="w-3 h-3 rounded border-theme-border-light bg-theme-elevated text-blue-500 focus:ring-blue-500 focus:ring-offset-0"
           />
           <span>Previous</span>
         </label>
@@ -202,7 +202,7 @@ export function LogsViewer({ namespace, podName, containers, initialContainer }:
         <select
           value={tailLines}
           onChange={(e) => setTailLines(Number(e.target.value))}
-          className="appearance-none bg-slate-700 text-white text-xs rounded px-2 py-1.5 pr-5 border border-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          className="appearance-none bg-theme-elevated text-theme-text-primary text-xs rounded px-2 py-1.5 pr-5 border border-theme-border-light focus:outline-none focus:ring-1 focus:ring-blue-500"
         >
           <option value={100}>100 lines</option>
           <option value={500}>500 lines</option>
@@ -216,7 +216,7 @@ export function LogsViewer({ namespace, podName, containers, initialContainer }:
         <button
           onClick={() => setShowSearch(!showSearch)}
           className={`p-1.5 rounded transition-colors ${
-            showSearch ? 'bg-blue-600 text-white' : 'text-slate-400 hover:text-white hover:bg-slate-700'
+            showSearch ? 'bg-blue-600 text-theme-text-primary' : 'text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated'
           }`}
           title="Search logs"
         >
@@ -226,7 +226,7 @@ export function LogsViewer({ namespace, podName, containers, initialContainer }:
         {/* Download */}
         <button
           onClick={downloadLogs}
-          className="p-1.5 rounded text-slate-400 hover:text-white hover:bg-slate-700"
+          className="p-1.5 rounded text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated"
           title="Download logs"
         >
           <Download className="w-4 h-4" />
@@ -235,24 +235,24 @@ export function LogsViewer({ namespace, podName, containers, initialContainer }:
 
       {/* Search bar */}
       {showSearch && (
-        <div className="flex items-center gap-2 px-3 py-2 border-b border-slate-700 bg-slate-800/50">
-          <Search className="w-4 h-4 text-slate-400" />
+        <div className="flex items-center gap-2 px-3 py-2 border-b border-theme-border bg-theme-surface/50">
+          <Search className="w-4 h-4 text-theme-text-secondary" />
           <input
             type="text"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="Search logs..."
-            className="flex-1 bg-transparent text-white text-sm placeholder-slate-500 focus:outline-none"
+            className="flex-1 bg-transparent text-theme-text-primary text-sm placeholder-theme-text-disabled focus:outline-none"
             autoFocus
           />
           {searchQuery && (
             <>
-              <span className="text-xs text-slate-500">
+              <span className="text-xs text-theme-text-tertiary">
                 {filteredLines.length} / {logLines.length}
               </span>
               <button
                 onClick={() => setSearchQuery('')}
-                className="p-1 rounded text-slate-400 hover:text-white"
+                className="p-1 rounded text-theme-text-secondary hover:text-theme-text-primary"
               >
                 <X className="w-3 h-3" />
               </button>
@@ -268,14 +268,14 @@ export function LogsViewer({ namespace, podName, containers, initialContainer }:
         className="flex-1 overflow-auto font-mono text-xs"
       >
         {isLoading && logLines.length === 0 ? (
-          <div className="flex items-center justify-center h-full text-slate-500">
+          <div className="flex items-center justify-center h-full text-theme-text-tertiary">
             <div className="flex items-center gap-2">
               <RotateCcw className="w-4 h-4 animate-spin" />
               <span>Loading logs...</span>
             </div>
           </div>
         ) : filteredLines.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-full text-slate-500 gap-2">
+          <div className="flex flex-col items-center justify-center h-full text-theme-text-tertiary gap-2">
             <Terminal className="w-8 h-8" />
             <span>No logs available</span>
           </div>
@@ -297,7 +297,7 @@ export function LogsViewer({ namespace, podName, containers, initialContainer }:
               logContainerRef.current.scrollTop = logContainerRef.current.scrollHeight
             }
           }}
-          className="absolute bottom-4 right-4 px-3 py-1.5 bg-blue-600 text-white text-xs rounded-full shadow-lg hover:bg-blue-700"
+          className="absolute bottom-4 right-4 px-3 py-1.5 bg-blue-600 text-theme-text-primary text-xs rounded-full shadow-lg hover:bg-blue-700"
         >
           Scroll to bottom
         </button>
@@ -317,10 +317,10 @@ function LogLineItem({ line, searchQuery }: { line: LogLine; searchQuery: string
     : line.content
 
   return (
-    <div className="flex hover:bg-slate-800/50 group leading-5">
+    <div className="flex hover:bg-theme-surface/50 group leading-5">
       {/* Timestamp */}
       {line.timestamp && (
-        <span className="text-slate-500 select-none pr-2 whitespace-nowrap">
+        <span className="text-theme-text-tertiary select-none pr-2 whitespace-nowrap">
           {formatTimestamp(line.timestamp)}
         </span>
       )}
@@ -369,9 +369,9 @@ function getLogLevelColor(content: string): string {
     return 'text-yellow-400'
   }
   if (lower.includes('debug') || lower.includes('trace')) {
-    return 'text-slate-400'
+    return 'text-theme-text-secondary'
   }
-  return 'text-slate-200'
+  return 'text-theme-text-primary'
 }
 
 // Highlight search matches in text

--- a/web/src/components/resource-drawer/ResourceDrawer.tsx
+++ b/web/src/components/resource-drawer/ResourceDrawer.tsx
@@ -19,7 +19,7 @@ function getStatusBadge(status: HealthStatus) {
     case 'unhealthy':
       return 'bg-red-500/20 text-red-400 border-red-500/30'
     default:
-      return 'bg-slate-500/20 text-slate-400 border-slate-500/30'
+      return 'bg-theme-hover/50 text-theme-text-secondary border-theme-border'
   }
 }
 
@@ -50,7 +50,7 @@ function getKindBadge(kind: NodeKind): string {
     case 'HPA':
       return 'bg-pink-500/20 text-pink-400 border-pink-500/30'
     default:
-      return 'bg-slate-500/20 text-slate-400 border-slate-500/30'
+      return 'bg-theme-hover/50 text-theme-text-secondary border-theme-border'
   }
 }
 
@@ -143,9 +143,9 @@ export const ResourceDrawer = memo(function ResourceDrawer({
       />
 
       {/* Drawer */}
-      <div className="fixed right-0 top-0 bottom-0 w-96 bg-slate-800 border-l border-slate-700 z-50 flex flex-col shadow-2xl">
+      <div className="fixed right-0 top-0 bottom-0 w-96 bg-theme-surface border-l border-theme-border z-50 flex flex-col shadow-2xl">
         {/* Header */}
-        <div className="flex items-start justify-between p-4 border-b border-slate-700">
+        <div className="flex items-start justify-between p-4 border-b border-theme-border">
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-2">
               <span
@@ -166,12 +166,12 @@ export const ResourceDrawer = memo(function ResourceDrawer({
               </span>
             </div>
             <div className="flex items-center gap-2">
-              <h2 className="text-lg font-semibold text-white truncate">
+              <h2 className="text-lg font-semibold text-theme-text-primary truncate">
                 {node.name}
               </h2>
               <button
                 onClick={copyName}
-                className="p-1 text-slate-400 hover:text-white hover:bg-slate-700 rounded"
+                className="p-1 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
                 title="Copy name"
               >
                 {copied ? (
@@ -184,7 +184,7 @@ export const ResourceDrawer = memo(function ResourceDrawer({
           </div>
           <button
             onClick={onClose}
-            className="p-2 text-slate-400 hover:text-white hover:bg-slate-700 rounded"
+            className="p-2 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
           >
             <X className="w-5 h-5" />
           </button>
@@ -194,14 +194,14 @@ export const ResourceDrawer = memo(function ResourceDrawer({
         <div className="flex-1 overflow-y-auto p-4">
           {/* Details */}
           <section className="mb-6">
-            <h3 className="text-sm font-medium text-slate-400 uppercase tracking-wide mb-3">
+            <h3 className="text-sm font-medium text-theme-text-secondary uppercase tracking-wide mb-3">
               Details
             </h3>
             <div className="space-y-3">
               {fields.map(([label, value]) => (
                 <div key={label as string}>
-                  <dt className="text-xs text-slate-500 mb-0.5">{label as string}</dt>
-                  <dd className="text-sm text-white">{formatValue(value)}</dd>
+                  <dt className="text-xs text-theme-text-tertiary mb-0.5">{label as string}</dt>
+                  <dd className="text-sm text-theme-text-primary">{formatValue(value)}</dd>
                 </div>
               ))}
             </div>
@@ -209,23 +209,23 @@ export const ResourceDrawer = memo(function ResourceDrawer({
 
           {/* Raw data */}
           <section>
-            <h3 className="text-sm font-medium text-slate-400 uppercase tracking-wide mb-3">
+            <h3 className="text-sm font-medium text-theme-text-secondary uppercase tracking-wide mb-3">
               Raw Data
             </h3>
-            <pre className="bg-slate-900 rounded-lg p-3 text-xs text-slate-300 overflow-x-auto">
+            <pre className="bg-theme-base rounded-lg p-3 text-xs text-theme-text-secondary overflow-x-auto">
               {JSON.stringify(node.data, null, 2)}
             </pre>
           </section>
         </div>
 
         {/* Footer */}
-        <div className="p-4 border-t border-slate-700">
+        <div className="p-4 border-t border-theme-border">
           <button
             onClick={() => {
               // TODO: Open kubectl command or link to dashboard
               console.log('View in dashboard:', node)
             }}
-            className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded-lg transition-colors"
+            className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-blue-500 hover:bg-blue-600 text-theme-text-primary rounded-lg transition-colors"
           >
             <ExternalLink className="w-4 h-4" />
             View Full Resource

--- a/web/src/components/resource/ResourceDetailPage.tsx
+++ b/web/src/components/resource/ResourceDetailPage.tsx
@@ -139,14 +139,14 @@ export function ResourceDetailPage({
   const warningCount = resourceEvents.filter(isProblematicEvent).length
 
   return (
-    <div className="flex flex-col h-full w-full bg-slate-900">
+    <div className="flex flex-col h-full w-full bg-theme-base">
       {/* Header */}
-      <div className="flex-shrink-0 border-b border-slate-700 bg-slate-800">
+      <div className="flex-shrink-0 border-b border-theme-border bg-theme-surface">
         {/* Top bar with back button, title, actions */}
         <div className="px-4 py-3 flex items-center gap-4">
           <button
             onClick={onBack}
-            className="p-1.5 text-slate-400 hover:text-white hover:bg-slate-700 rounded-lg transition-colors"
+            className="p-1.5 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded-lg transition-colors"
           >
             <ArrowLeft className="w-5 h-5" />
           </button>
@@ -162,8 +162,8 @@ export function ResourceDetailPage({
                 </span>
               )}
             </div>
-            <h1 className="text-lg font-semibold text-white truncate">{name}</h1>
-            <p className="text-sm text-slate-400">{namespace}</p>
+            <h1 className="text-lg font-semibold text-theme-text-primary truncate">{name}</h1>
+            <p className="text-sm text-theme-text-secondary">{namespace}</p>
           </div>
 
           <div className="flex items-center gap-2">
@@ -174,11 +174,11 @@ export function ResourceDetailPage({
 
         {/* Metadata bar */}
         {metadata.length > 0 && (
-          <div className="px-4 py-2 bg-slate-800/50 border-t border-slate-700/50 flex flex-wrap gap-x-6 gap-y-1">
+          <div className="px-4 py-2 bg-theme-surface/50 border-t border-theme-border/50 flex flex-wrap gap-x-6 gap-y-1">
             {metadata.map((item, i) => (
               <div key={i} className="flex items-center gap-2 text-sm">
-                <span className="text-slate-500">{item.label}:</span>
-                <span className="text-slate-300 font-mono text-xs">{item.value}</span>
+                <span className="text-theme-text-tertiary">{item.label}:</span>
+                <span className="text-theme-text-secondary font-mono text-xs">{item.value}</span>
               </div>
             ))}
           </div>
@@ -197,14 +197,14 @@ export function ResourceDetailPage({
             <TabButton active={activeTab === 'pods'} onClick={() => setActiveTab('pods')}>
               <Container className="w-4 h-4" />
               Logs
-              <span className="ml-1 px-1.5 py-0.5 text-xs bg-slate-700 rounded">{pods.length}</span>
+              <span className="ml-1 px-1.5 py-0.5 text-xs bg-theme-elevated rounded">{pods.length}</span>
             </TabButton>
           )}
           <TabButton active={activeTab === 'events'} onClick={() => setActiveTab('events')}>
             <Clock className="w-4 h-4" />
             Events
             {resourceEvents.length > 0 && (
-              <span className="ml-1 px-1.5 py-0.5 text-xs bg-slate-700 rounded">{resourceEvents.length}</span>
+              <span className="ml-1 px-1.5 py-0.5 text-xs bg-theme-elevated rounded">{resourceEvents.length}</span>
             )}
           </TabButton>
           <TabButton active={activeTab === 'yaml'} onClick={() => setActiveTab('yaml')}>
@@ -393,7 +393,7 @@ function KindBadge({ kind }: { kind: string }) {
     CronJob: 'bg-teal-900/50 text-teal-400',
   }
   return (
-    <span className={clsx('text-xs px-2 py-0.5 rounded font-medium', colors[kind] || 'bg-slate-700 text-slate-300')}>
+    <span className={clsx('text-xs px-2 py-0.5 rounded font-medium', colors[kind] || 'bg-theme-elevated text-theme-text-secondary')}>
       {kind}
     </span>
   )
@@ -404,7 +404,7 @@ function HealthBadge({ state }: { state: string }) {
     healthy: { bg: 'bg-green-500/20', text: 'text-green-400', icon: CheckCircle },
     degraded: { bg: 'bg-yellow-500/20', text: 'text-yellow-400', icon: AlertCircle },
     unhealthy: { bg: 'bg-red-500/20', text: 'text-red-400', icon: AlertCircle },
-    unknown: { bg: 'bg-slate-500/20', text: 'text-slate-400', icon: Clock },
+    unknown: { bg: 'bg-theme-hover/50', text: 'text-theme-text-secondary', icon: Clock },
   }
   const { bg, text, icon: Icon } = config[state] || config.unknown
   return (
@@ -422,8 +422,8 @@ function TabButton({ active, onClick, children }: { active: boolean; onClick: ()
       className={clsx(
         'flex items-center gap-1.5 px-3 py-2 text-sm font-medium border-b-2 transition-colors',
         active
-          ? 'text-white border-blue-500'
-          : 'text-slate-400 border-transparent hover:text-white hover:border-slate-600'
+          ? 'text-theme-text-primary border-blue-500'
+          : 'text-theme-text-secondary border-transparent hover:text-theme-text-primary hover:border-theme-border-light'
       )}
     >
       {children}
@@ -440,14 +440,14 @@ function TimeRangeSelector({ value, onChange }: { value: TimeRange; onChange: (v
     { value: '24h', label: '24h' },
   ]
   return (
-    <div className="flex items-center gap-0.5 p-0.5 bg-slate-700 rounded-lg">
+    <div className="flex items-center gap-0.5 p-0.5 bg-theme-elevated rounded-lg">
       {options.map(opt => (
         <button
           key={opt.value}
           onClick={() => onChange(opt.value)}
           className={clsx(
             'px-2 py-1 text-xs rounded-md transition-colors',
-            value === opt.value ? 'bg-slate-600 text-white' : 'text-slate-400 hover:text-white'
+            value === opt.value ? 'bg-theme-hover text-theme-text-primary' : 'text-theme-text-secondary hover:text-theme-text-primary'
           )}
         >
           {opt.label}
@@ -472,14 +472,14 @@ function ActionsDropdown({ kind }: { kind: string; namespace: string; name: stri
     <div className="relative">
       <button
         onClick={() => setOpen(!open)}
-        className="p-2 text-slate-400 hover:text-white hover:bg-slate-700 rounded-lg"
+        className="p-2 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded-lg"
       >
         <MoreVertical className="w-5 h-5" />
       </button>
       {open && (
         <>
           <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
-          <div className="absolute right-0 top-full mt-1 z-50 w-48 bg-slate-800 border border-slate-700 rounded-lg shadow-xl py-1">
+          <div className="absolute right-0 top-full mt-1 z-50 w-48 bg-theme-surface border border-theme-border rounded-lg shadow-xl py-1">
             {actions.map((action, i) => (
               <button
                 key={i}
@@ -488,10 +488,10 @@ function ActionsDropdown({ kind }: { kind: string; namespace: string; name: stri
                 className={clsx(
                   'w-full px-3 py-2 text-sm text-left flex items-center gap-2 transition-colors',
                   action.disabled
-                    ? 'text-slate-600 cursor-not-allowed'
+                    ? 'text-theme-text-disabled cursor-not-allowed'
                     : action.danger
                     ? 'text-red-400 hover:bg-red-900/30'
-                    : 'text-slate-300 hover:bg-slate-700'
+                    : 'text-theme-text-secondary hover:bg-theme-elevated'
                 )}
               >
                 <action.icon className="w-4 h-4" />
@@ -527,10 +527,10 @@ function MiniTimeline({ events, timeRange }: { events: TimelineEvent[]; timeRang
   }).filter(e => e.x >= 0 && e.x <= 100)
 
   return (
-    <div className="px-4 py-2 border-t border-slate-700/50">
-      <div className="relative h-6 bg-slate-700/30 rounded overflow-hidden">
+    <div className="px-4 py-2 border-t border-theme-border/50">
+      <div className="relative h-6 bg-theme-elevated/30 rounded overflow-hidden">
         {/* Health bar background - gradient from past to now */}
-        <div className="absolute inset-0 bg-gradient-to-r from-slate-700/50 to-slate-600/30" />
+        <div className="absolute inset-0 bg-gradient-to-r from-theme-hover/50 to-theme-hover/30" />
 
         {/* Event markers */}
         {eventPositions.map((ep, i) => {
@@ -554,10 +554,10 @@ function MiniTimeline({ events, timeRange }: { events: TimelineEvent[]; timeRang
         })}
 
         {/* Time labels */}
-        <div className="absolute left-2 top-1/2 -translate-y-1/2 text-xs text-slate-500">
+        <div className="absolute left-2 top-1/2 -translate-y-1/2 text-xs text-theme-text-tertiary">
           -{timeRange}
         </div>
-        <div className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-slate-500">
+        <div className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-theme-text-tertiary">
           Now
         </div>
       </div>
@@ -584,7 +584,7 @@ function OverviewTab({
 }) {
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-full text-slate-500">
+      <div className="flex items-center justify-center h-full text-theme-text-tertiary">
         <RefreshCw className="w-5 h-5 animate-spin mr-2" />
         Loading...
       </div>
@@ -620,13 +620,13 @@ function OverviewTab({
         )}
 
         {/* Recent Activity */}
-        <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
-          <h3 className="text-sm font-medium text-slate-300 mb-3 flex items-center gap-2">
+        <div className="bg-theme-surface/50 border border-theme-border rounded-lg p-4">
+          <h3 className="text-sm font-medium text-theme-text-secondary mb-3 flex items-center gap-2">
             <Activity className="w-4 h-4" />
             Recent Activity
           </h3>
           {recentEvents.length === 0 ? (
-            <p className="text-sm text-slate-500">No recent events</p>
+            <p className="text-sm text-theme-text-tertiary">No recent events</p>
           ) : (
             <div className="space-y-2">
               {recentEvents.map(event => (
@@ -640,13 +640,13 @@ function OverviewTab({
                   )} />
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-2">
-                      <span className="text-slate-300">{event.reason || event.operation}</span>
+                      <span className="text-theme-text-secondary">{event.reason || event.operation}</span>
                       {event.kind !== kind && (
-                        <span className="text-xs px-1 py-0.5 bg-slate-700 rounded text-slate-400">{event.kind}</span>
+                        <span className="text-xs px-1 py-0.5 bg-theme-elevated rounded text-theme-text-secondary">{event.kind}</span>
                       )}
                     </div>
-                    {event.diff?.summary && <p className="text-slate-500 text-xs truncate">{event.diff.summary}</p>}
-                    <p className="text-slate-600 text-xs">{new Date(event.timestamp).toLocaleTimeString()}</p>
+                    {event.diff?.summary && <p className="text-theme-text-tertiary text-xs truncate">{event.diff.summary}</p>}
+                    <p className="text-theme-text-disabled text-xs">{new Date(event.timestamp).toLocaleTimeString()}</p>
                   </div>
                 </div>
               ))}
@@ -655,8 +655,8 @@ function OverviewTab({
         </div>
 
         {/* Related Resources */}
-        <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
-          <h3 className="text-sm font-medium text-slate-300 mb-3 flex items-center gap-2">
+        <div className="bg-theme-surface/50 border border-theme-border rounded-lg p-4">
+          <h3 className="text-sm font-medium text-theme-text-secondary mb-3 flex items-center gap-2">
             <Layers className="w-4 h-4" />
             Related Resources
           </h3>
@@ -665,8 +665,8 @@ function OverviewTab({
 
         {/* Resource Status (for workloads) */}
         {resource?.status && (
-          <div className="lg:col-span-2 bg-slate-800/50 border border-slate-700 rounded-lg p-4">
-            <h3 className="text-sm font-medium text-slate-300 mb-3 flex items-center gap-2">
+          <div className="lg:col-span-2 bg-theme-surface/50 border border-theme-border rounded-lg p-4">
+            <h3 className="text-sm font-medium text-theme-text-secondary mb-3 flex items-center gap-2">
               <Server className="w-4 h-4" />
               Status
             </h3>
@@ -682,7 +682,7 @@ function StatusGrid({ status, kind }: { status: any; kind: string }) {
   const items: { label: string; value: string | number; color?: string }[] = []
 
   if (['Deployment', 'StatefulSet', 'DaemonSet'].includes(kind)) {
-    items.push({ label: 'Ready', value: status.readyReplicas || 0, color: status.readyReplicas > 0 ? 'text-green-400' : 'text-slate-400' })
+    items.push({ label: 'Ready', value: status.readyReplicas || 0, color: status.readyReplicas > 0 ? 'text-green-400' : 'text-theme-text-secondary' })
     items.push({ label: 'Available', value: status.availableReplicas || 0 })
     items.push({ label: 'Updated', value: status.updatedReplicas || 0 })
     if (status.unavailableReplicas) {
@@ -717,15 +717,15 @@ function StatusGrid({ status, kind }: { status: any; kind: string }) {
   }
 
   if (items.length === 0) {
-    return <p className="text-sm text-slate-500">No status information available</p>
+    return <p className="text-sm text-theme-text-tertiary">No status information available</p>
   }
 
   return (
     <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
       {items.map((item, i) => (
         <div key={i}>
-          <p className="text-xs text-slate-500">{item.label}</p>
-          <p className={clsx('text-lg font-semibold', item.color || 'text-white')}>{item.value}</p>
+          <p className="text-xs text-theme-text-tertiary">{item.label}</p>
+          <p className={clsx('text-lg font-semibold', item.color || 'text-theme-text-primary')}>{item.value}</p>
         </div>
       ))}
     </div>
@@ -742,11 +742,11 @@ function RelatedResources({
   onNavigate?: (kind: string, namespace: string, name: string) => void
 }) {
   if (isLoading) {
-    return <p className="text-sm text-slate-500">Loading relationships...</p>
+    return <p className="text-sm text-theme-text-tertiary">Loading relationships...</p>
   }
 
   if (!relationships) {
-    return <p className="text-sm text-slate-500">No related resources</p>
+    return <p className="text-sm text-theme-text-tertiary">No related resources</p>
   }
 
   const sections: { title: string; items: ResourceRef[] }[] = []
@@ -759,24 +759,24 @@ function RelatedResources({
   if (relationships.pods?.length) sections.push({ title: 'Pods', items: relationships.pods.slice(0, 5) })
 
   if (sections.length === 0) {
-    return <p className="text-sm text-slate-500">No related resources</p>
+    return <p className="text-sm text-theme-text-tertiary">No related resources</p>
   }
 
   return (
     <div className="space-y-3">
       {sections.map(section => (
         <div key={section.title}>
-          <p className="text-xs text-slate-500 mb-1">{section.title}</p>
+          <p className="text-xs text-theme-text-tertiary mb-1">{section.title}</p>
           <div className="space-y-1">
             {section.items.map(item => (
               <button
                 key={`${item.kind}/${item.namespace}/${item.name}`}
                 onClick={() => onNavigate?.(item.kind, item.namespace, item.name)}
-                className="w-full text-left px-2 py-1.5 rounded hover:bg-slate-700/50 flex items-center gap-2 group"
+                className="w-full text-left px-2 py-1.5 rounded hover:bg-theme-elevated/50 flex items-center gap-2 group"
               >
                 <KindBadge kind={item.kind} />
-                <span className="text-sm text-slate-300 truncate flex-1 group-hover:text-white">{item.name}</span>
-                <ChevronRight className="w-3 h-3 text-slate-600 group-hover:text-slate-400" />
+                <span className="text-sm text-theme-text-secondary truncate flex-1 group-hover:text-theme-text-primary">{item.name}</span>
+                <ChevronRight className="w-3 h-3 text-theme-text-disabled group-hover:text-theme-text-secondary" />
               </button>
             ))}
           </div>
@@ -806,7 +806,7 @@ function LogsTab({
 
   if (pods.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-full text-slate-500">
+      <div className="flex flex-col items-center justify-center h-full text-theme-text-tertiary">
         <Terminal className="w-12 h-12 mb-4 opacity-50" />
         <p>No pods available</p>
       </div>
@@ -817,7 +817,7 @@ function LogsTab({
     <div className="h-full flex flex-col">
       {/* Pod selector - horizontal tabs */}
       {pods.length > 1 && (
-        <div className="flex-shrink-0 border-b border-slate-700 bg-slate-800/50 px-4 py-2 flex gap-2 overflow-x-auto">
+        <div className="flex-shrink-0 border-b border-theme-border bg-theme-surface/50 px-4 py-2 flex gap-2 overflow-x-auto">
           {pods.map(pod => (
             <button
               key={pod.name}
@@ -825,8 +825,8 @@ function LogsTab({
               className={clsx(
                 'px-3 py-1.5 text-sm rounded-lg whitespace-nowrap transition-colors',
                 selectedPod === pod.name
-                  ? 'bg-blue-500 text-white'
-                  : 'bg-slate-700 text-slate-300 hover:bg-slate-600'
+                  ? 'bg-blue-500 text-theme-text-primary'
+                  : 'bg-theme-elevated text-theme-text-secondary hover:bg-theme-hover'
               )}
             >
               {pod.name.length > 40 ? '...' + pod.name.slice(-37) : pod.name}
@@ -891,19 +891,19 @@ function PodLogsPanel({
   return (
     <div className="flex flex-col h-full">
       {/* Controls bar - always shown for container selector, follow, refresh */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-slate-700 bg-slate-800/50">
+      <div className="flex items-center justify-between px-4 py-2 border-b border-theme-border bg-theme-surface/50">
         <div className="flex items-center gap-3">
           {showHeader && (
             <>
-              <Terminal className="w-4 h-4 text-slate-400" />
-              <span className="text-sm font-medium text-white">{podName}</span>
+              <Terminal className="w-4 h-4 text-theme-text-secondary" />
+              <span className="text-sm font-medium text-theme-text-primary">{podName}</span>
             </>
           )}
           {containers.length > 1 && (
             <select
               value={container}
               onChange={(e) => setContainer(e.target.value)}
-              className="text-xs bg-slate-700 border border-slate-600 rounded px-2 py-1 text-white"
+              className="text-xs bg-theme-elevated border border-theme-border-light rounded px-2 py-1 text-theme-text-primary"
             >
               {containers.map(c => (
                 <option key={c} value={c}>{c}</option>
@@ -916,14 +916,14 @@ function PodLogsPanel({
             onClick={() => setFollow(!follow)}
             className={clsx(
               'px-2 py-1 text-xs rounded transition-colors',
-              follow ? 'bg-blue-500 text-white' : 'bg-slate-700 text-slate-400 hover:text-white'
+              follow ? 'bg-blue-500 text-theme-text-primary' : 'bg-theme-elevated text-theme-text-secondary hover:text-theme-text-primary'
             )}
           >
             {follow ? 'Following' : 'Follow'}
           </button>
           <button
             onClick={() => refetch()}
-            className="p-1 text-slate-400 hover:text-white"
+            className="p-1 text-theme-text-secondary hover:text-theme-text-primary"
             title="Refresh"
           >
             <RefreshCw className="w-4 h-4" />
@@ -931,7 +931,7 @@ function PodLogsPanel({
           {showHeader && (
             <button
               onClick={onClose}
-              className="p-1 text-slate-400 hover:text-white"
+              className="p-1 text-theme-text-secondary hover:text-theme-text-primary"
             >
               ×
             </button>
@@ -940,14 +940,14 @@ function PodLogsPanel({
       </div>
       <pre
         ref={logsRef}
-        className="flex-1 overflow-auto p-4 text-xs font-mono text-slate-300 bg-slate-950"
+        className="flex-1 overflow-auto p-4 text-xs font-mono text-theme-text-secondary bg-theme-base"
       >
         {isLoading ? (
-          <span className="text-slate-500">Loading logs...</span>
+          <span className="text-theme-text-tertiary">Loading logs...</span>
         ) : logs ? (
           logs
         ) : (
-          <span className="text-slate-500">No logs available</span>
+          <span className="text-theme-text-tertiary">No logs available</span>
         )}
       </pre>
     </div>
@@ -987,7 +987,7 @@ function EventsTab({
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-full text-slate-500">
+      <div className="flex items-center justify-center h-full text-theme-text-tertiary">
         <RefreshCw className="w-5 h-5 animate-spin mr-2" />
         Loading events...
       </div>
@@ -1014,13 +1014,13 @@ function EventsTab({
     <div className="h-full flex flex-col">
       {/* Filter bar */}
       {routineCount > 0 && (
-        <div className="px-4 py-2 border-b border-slate-700 flex items-center justify-end">
-          <label className="flex items-center gap-2 text-xs text-slate-400 cursor-pointer hover:text-slate-300">
+        <div className="px-4 py-2 border-b border-theme-border flex items-center justify-end">
+          <label className="flex items-center gap-2 text-xs text-theme-text-secondary cursor-pointer hover:text-theme-text-secondary">
             <input
               type="checkbox"
               checked={showRoutine}
               onChange={(e) => onToggleRoutine(e.target.checked)}
-              className="w-3.5 h-3.5 rounded border-slate-600 bg-slate-700 text-blue-500"
+              className="w-3.5 h-3.5 rounded border-theme-border-light bg-theme-elevated text-blue-500"
             />
             {showRoutine ? <Eye className="w-3.5 h-3.5" /> : <EyeOff className="w-3.5 h-3.5" />}
             Show routine events ({routineCount})
@@ -1031,16 +1031,16 @@ function EventsTab({
       {/* Events list */}
       <div className="flex-1 overflow-auto">
         {events.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-full text-slate-500">
+          <div className="flex flex-col items-center justify-center h-full text-theme-text-tertiary">
             <Clock className="w-12 h-12 mb-4 opacity-50" />
             <p className="text-lg">No events</p>
             <p className="text-sm">Events will appear here as things change</p>
           </div>
         ) : (
-          <div className="divide-y divide-slate-700/30">
+          <div className="table-divide-subtle">
             {groupedEvents.map(group => (
               <div key={group.date}>
-                <div className="sticky top-0 bg-slate-900/95 backdrop-blur px-4 py-2 text-xs font-medium text-slate-500 border-b border-slate-700/30">
+                <div className="sticky top-0 bg-theme-base/95 backdrop-blur px-4 py-2 text-xs font-medium text-theme-text-tertiary border-b border-theme-border/30">
                   {group.date}
                 </div>
                 <div>
@@ -1055,7 +1055,7 @@ function EventsTab({
                           onClick={() => hasDiff && toggleEvent(event.id)}
                           className={clsx(
                             'w-full px-4 py-3 flex items-start gap-4 text-left transition-colors',
-                            isExpanded ? 'bg-slate-800/50' : 'hover:bg-slate-800/30',
+                            isExpanded ? 'bg-theme-surface/50' : 'hover:bg-theme-surface/30',
                             !isOwn && 'pl-8',
                             !hasDiff && 'cursor-default'
                           )}
@@ -1068,12 +1068,12 @@ function EventsTab({
                                   'text-xs px-1.5 py-0.5 rounded',
                                   event.kind === 'ReplicaSet' ? 'bg-violet-900/50 text-violet-400' :
                                   event.kind === 'Pod' ? 'bg-green-900/50 text-green-400' :
-                                  'bg-slate-700 text-slate-400'
+                                  'bg-theme-elevated text-theme-text-secondary'
                                 )}>
                                   {event.kind}
                                 </span>
                               )}
-                              <span className="text-sm font-medium text-white">
+                              <span className="text-sm font-medium text-theme-text-primary">
                                 {event.type === 'change' ? event.operation : event.reason}
                               </span>
                               {event.healthState && event.healthState !== 'unknown' && (
@@ -1088,19 +1088,19 @@ function EventsTab({
                                 </span>
                               )}
                             </div>
-                            {!isOwn && <p className="text-xs text-slate-500 mb-1">{event.name}</p>}
-                            {event.diff?.summary && <p className="text-sm text-slate-400">{event.diff.summary}</p>}
-                            {event.message && <p className="text-sm text-slate-400 line-clamp-2">{event.message}</p>}
-                            <p className="text-xs text-slate-500 mt-1">{new Date(event.timestamp).toLocaleTimeString()}</p>
+                            {!isOwn && <p className="text-xs text-theme-text-tertiary mb-1">{event.name}</p>}
+                            {event.diff?.summary && <p className="text-sm text-theme-text-secondary">{event.diff.summary}</p>}
+                            {event.message && <p className="text-sm text-theme-text-secondary line-clamp-2">{event.message}</p>}
+                            <p className="text-xs text-theme-text-tertiary mt-1">{new Date(event.timestamp).toLocaleTimeString()}</p>
                           </div>
                           {hasDiff && (
-                            <ChevronRight className={clsx('w-4 h-4 text-slate-500 transition-transform flex-shrink-0', isExpanded && 'rotate-90')} />
+                            <ChevronRight className={clsx('w-4 h-4 text-theme-text-tertiary transition-transform flex-shrink-0', isExpanded && 'rotate-90')} />
                           )}
                         </button>
 
                         {/* Inline diff - shown when expanded */}
                         {isExpanded && event.diff && (
-                          <div className="px-4 pb-4 pl-16 bg-slate-800/30">
+                          <div className="px-4 pb-4 pl-16 bg-theme-surface/30">
                             <DiffViewer diff={event.diff} />
                           </div>
                         )}
@@ -1128,13 +1128,13 @@ function EventIcon({ event }: { event: TimelineEvent }) {
   }[event.operation || 'update'] : isProblematic ? {
     bg: 'bg-amber-500', icon: AlertCircle
   } : {
-    bg: 'bg-slate-500', icon: CheckCircle
+    bg: 'bg-theme-hover', icon: CheckCircle
   }
 
   const Icon = config?.icon || Clock
 
   return (
-    <div className={clsx('w-8 h-8 rounded-full flex items-center justify-center text-white flex-shrink-0', config?.bg || 'bg-slate-500')}>
+    <div className={clsx('w-8 h-8 rounded-full flex items-center justify-center text-theme-text-primary flex-shrink-0', config?.bg || 'bg-theme-hover')}>
       <Icon className="w-4 h-4" />
     </div>
   )
@@ -1145,7 +1145,7 @@ function YamlTab({ resource, isLoading }: { resource: any; isLoading: boolean })
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-full text-slate-500">
+      <div className="flex items-center justify-center h-full text-theme-text-tertiary">
         <RefreshCw className="w-5 h-5 animate-spin mr-2" />
         Loading...
       </div>
@@ -1162,16 +1162,16 @@ function YamlTab({ resource, isLoading }: { resource: any; isLoading: boolean })
 
   return (
     <div className="h-full flex flex-col">
-      <div className="px-4 py-2 border-b border-slate-700 flex items-center justify-end">
+      <div className="px-4 py-2 border-b border-theme-border flex items-center justify-end">
         <button
           onClick={handleCopy}
-          className="flex items-center gap-1.5 px-2 py-1 text-xs text-slate-400 hover:text-white hover:bg-slate-700 rounded"
+          className="flex items-center gap-1.5 px-2 py-1 text-xs text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
         >
           {copied ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
           {copied ? 'Copied!' : 'Copy'}
         </button>
       </div>
-      <pre className="flex-1 overflow-auto p-4 text-xs font-mono text-slate-300 bg-slate-950">
+      <pre className="flex-1 overflow-auto p-4 text-xs font-mono text-theme-text-secondary bg-theme-base">
         {yaml || 'No data available'}
       </pre>
     </div>

--- a/web/src/components/resources/ResourceDetailDrawer.tsx
+++ b/web/src/components/resources/ResourceDetailDrawer.tsx
@@ -136,7 +136,7 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate }: Resource
 
   return (
     <div
-      className="fixed right-0 bg-slate-800 border-l border-slate-700 flex flex-col shadow-2xl z-40"
+      className="fixed right-0 bg-theme-surface border-l border-theme-border flex flex-col shadow-2xl z-40"
       style={{ width: drawerWidth, top: headerHeight, height: `calc(100vh - ${headerHeight}px)` }}
     >
       {/* Resize handle - wider for easier grab, hidden on mobile */}
@@ -165,9 +165,9 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate }: Resource
       {/* Content */}
       <div className="flex-1 overflow-y-auto">
         {isLoading ? (
-          <div className="flex items-center justify-center h-32 text-slate-500">Loading...</div>
+          <div className="flex items-center justify-center h-32 text-theme-text-tertiary">Loading...</div>
         ) : !resourceData ? (
-          <div className="flex items-center justify-center h-32 text-slate-500">Resource not found</div>
+          <div className="flex items-center justify-center h-32 text-theme-text-tertiary">Resource not found</div>
         ) : showYaml ? (
           <YamlView data={resourceData} onCopy={(text) => copyToClipboard(text, 'yaml')} copied={copied === 'yaml'} />
         ) : (
@@ -205,7 +205,7 @@ function DrawerHeader({ resource, resourceData, showYaml, setShowYaml, isRefetch
   const status = getResourceStatus(resource.kind, resourceData)
 
   return (
-    <div className="border-b border-slate-700 shrink-0">
+    <div className="border-b border-theme-border shrink-0">
       {/* Top row: badges and controls */}
       <div className="flex items-center justify-between px-4 pt-3 pb-2">
         <div className="flex items-center gap-2 flex-wrap">
@@ -223,7 +223,7 @@ function DrawerHeader({ resource, resourceData, showYaml, setShowYaml, isRefetch
             onClick={() => setShowYaml(!showYaml)}
             className={clsx(
               'px-2 py-1 text-xs rounded transition-colors',
-              showYaml ? 'bg-blue-500 text-white' : 'text-slate-400 hover:text-white hover:bg-slate-700'
+              showYaml ? 'bg-blue-500 text-theme-text-primary' : 'text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated'
             )}
             title="Toggle YAML view"
           >
@@ -232,12 +232,12 @@ function DrawerHeader({ resource, resourceData, showYaml, setShowYaml, isRefetch
           <button
             onClick={() => onRefetch()}
             disabled={isRefetching}
-            className="p-1.5 text-slate-400 hover:text-white hover:bg-slate-700 rounded disabled:opacity-50"
+            className="p-1.5 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded disabled:opacity-50"
             title="Refresh"
           >
             <RefreshCw className={clsx('w-4 h-4', isRefetching && 'animate-spin')} />
           </button>
-          <button onClick={onClose} className="p-1.5 text-slate-400 hover:text-white hover:bg-slate-700 rounded" title="Close (Esc)">
+          <button onClick={onClose} className="p-1.5 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded" title="Close (Esc)">
             <X className="w-4 h-4" />
           </button>
         </div>
@@ -246,16 +246,16 @@ function DrawerHeader({ resource, resourceData, showYaml, setShowYaml, isRefetch
       {/* Name and namespace */}
       <div className="px-4 pb-3">
         <div className="flex items-center gap-2">
-          <h2 className="text-lg font-semibold text-white truncate">{resource.name}</h2>
+          <h2 className="text-lg font-semibold text-theme-text-primary truncate">{resource.name}</h2>
           <button
             onClick={() => onCopy(resource.name)}
-            className="p-1 text-slate-400 hover:text-white hover:bg-slate-700 rounded shrink-0"
+            className="p-1 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded shrink-0"
             title="Copy name"
           >
             {copied ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
           </button>
         </div>
-        <p className="text-sm text-slate-500">{resource.namespace}</p>
+        <p className="text-sm text-theme-text-tertiary">{resource.namespace}</p>
       </div>
 
       {/* Actions bar */}
@@ -359,7 +359,7 @@ function ActionsBar({ resource, data }: { resource: SelectedResource; data: any 
           key={i}
           onClick={(e) => showCopied(action.command, action.commandLabel, e)}
           disabled={action.disabled}
-          className="flex items-center gap-1.5 px-2 py-1 text-xs text-slate-400 hover:text-white hover:bg-slate-700 rounded transition-colors disabled:opacity-50"
+          className="flex items-center gap-1.5 px-2 py-1 text-xs text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded transition-colors disabled:opacity-50"
         >
           <action.icon className="w-3.5 h-3.5" />
           {action.label}
@@ -380,10 +380,10 @@ function YamlView({ data, onCopy, copied }: { data: any; onCopy: (text: string) 
   return (
     <div className="p-4">
       <div className="flex items-center justify-between mb-2">
-        <span className="text-sm font-medium text-slate-400">Raw JSON</span>
+        <span className="text-sm font-medium text-theme-text-secondary">Raw JSON</span>
         <button
           onClick={() => onCopy(json)}
-          className="flex items-center gap-1 px-2 py-1 text-xs text-slate-400 hover:text-white hover:bg-slate-700 rounded"
+          className="flex items-center gap-1 px-2 py-1 text-xs text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
         >
           {copied ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
           Copy

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -384,13 +384,37 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick }: 
     resourceNs?: string,
     resourceName?: string
   ) => {
-    const params = new URLSearchParams()
+    // Preserve existing params (like namespace from App)
+    const params = new URLSearchParams(window.location.search)
+
+    // Set/update resources-specific params
     params.set('kind', kindInfo.kind)
-    if (kindInfo.group) params.set('group', kindInfo.group)
-    if (search) params.set('search', search)
-    if (status) params.set('status', status)
-    if (problems.length > 0) params.set('problems', problems.join(','))
-    if (resourceNs && resourceName) params.set('resource', `${resourceNs}/${resourceName}`)
+    if (kindInfo.group) {
+      params.set('group', kindInfo.group)
+    } else {
+      params.delete('group')
+    }
+    if (search) {
+      params.set('search', search)
+    } else {
+      params.delete('search')
+    }
+    if (status) {
+      params.set('status', status)
+    } else {
+      params.delete('status')
+    }
+    if (problems.length > 0) {
+      params.set('problems', problems.join(','))
+    } else {
+      params.delete('problems')
+    }
+    if (resourceNs && resourceName) {
+      params.set('resource', `${resourceNs}/${resourceName}`)
+    } else {
+      params.delete('resource')
+    }
+
     const newURL = `${window.location.pathname}?${params.toString()}`
     window.history.replaceState({}, '', newURL)
   }, [])
@@ -846,9 +870,9 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick }: 
   return (
     <div className="flex h-full">
       {/* Sidebar - Resource Types */}
-      <div className="w-72 bg-slate-800 border-r border-slate-700 overflow-y-auto shrink-0">
-        <div className="p-3 border-b border-slate-700">
-          <h2 className="text-sm font-medium text-slate-400 uppercase tracking-wide">
+      <div className="w-72 bg-theme-surface border-r border-theme-border overflow-y-auto shrink-0">
+        <div className="p-3 border-b border-theme-border">
+          <h2 className="text-sm font-medium text-theme-text-secondary uppercase tracking-wide">
             Resources
           </h2>
         </div>
@@ -861,7 +885,7 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick }: 
                 <div key={category.name} className="mb-2">
                   <button
                     onClick={() => toggleCategory(category.name)}
-                    className="w-full flex items-center gap-2 px-2 py-1.5 text-xs font-medium text-slate-500 hover:text-slate-300 uppercase tracking-wide"
+                    className="w-full flex items-center gap-2 px-2 py-1.5 text-xs font-medium text-theme-text-tertiary hover:text-theme-text-secondary uppercase tracking-wide"
                   >
                     {isExpanded ? (
                       <ChevronDown className="w-3 h-3" />
@@ -870,7 +894,7 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick }: 
                     )}
                     <span className="flex-1 text-left">{category.name}</span>
                     {!isExpanded && (
-                      <span className="text-xs px-1.5 py-0.5 rounded bg-slate-700 text-slate-400 font-normal normal-case">
+                      <span className="text-xs px-1.5 py-0.5 rounded bg-theme-elevated text-theme-text-secondary font-normal normal-case">
                         {category.total}
                       </span>
                     )}
@@ -910,14 +934,14 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick }: 
                     'w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors',
                     isSelected
                       ? 'bg-blue-500/20 text-blue-300'
-                      : 'text-slate-400 hover:bg-slate-700 hover:text-white'
+                      : 'text-theme-text-secondary hover:bg-theme-elevated hover:text-theme-text-primary'
                   )}
                 >
                   <Icon className="w-4 h-4 flex-shrink-0" />
                   <span className="flex-1 text-left">{type.label}</span>
                   <span className={clsx(
                     'text-xs px-2 py-0.5 rounded',
-                    isSelected ? 'bg-blue-500/30' : 'bg-slate-700'
+                    isSelected ? 'bg-blue-500/30' : 'bg-theme-elevated'
                   )}>
                     {count}
                   </span>
@@ -930,7 +954,7 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick }: 
           {hiddenKindsCount > 0 || hiddenGroupsCount > 0 || showEmptyKinds ? (
             <button
               onClick={() => setShowEmptyKinds(!showEmptyKinds)}
-              className="w-full flex items-center gap-2 px-3 py-2 mt-2 text-xs text-slate-500 hover:text-slate-300 border-t border-slate-700"
+              className="w-full flex items-center gap-2 px-3 py-2 mt-2 text-xs text-theme-text-tertiary hover:text-theme-text-secondary border-t border-theme-border"
             >
               {showEmptyKinds ? (
                 <>
@@ -954,15 +978,15 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick }: 
       {/* Main Content - Resource Table */}
       <div className="flex-1 flex flex-col overflow-hidden min-w-0">
         {/* Toolbar */}
-        <div className="flex items-center gap-3 px-4 py-3 border-b border-slate-700 bg-slate-800/50 shrink-0">
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-theme-border bg-theme-surface/50 shrink-0">
           <div className="flex-1 relative">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" />
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-theme-text-tertiary" />
             <input
               type="text"
               placeholder="Search resources..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full max-w-md pl-10 pr-4 py-2 bg-slate-700 border border-slate-600 rounded-lg text-sm text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full max-w-md pl-10 pr-4 py-2 bg-theme-elevated border border-theme-border-light rounded-lg text-sm text-theme-text-primary placeholder-theme-text-disabled focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
           </div>
 
@@ -975,7 +999,7 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick }: 
                   'flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors',
                   hasActiveFilters
                     ? 'bg-blue-500/20 text-blue-300 hover:bg-blue-500/30'
-                    : 'text-slate-400 hover:text-white hover:bg-slate-700'
+                    : 'text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated'
                 )}
               >
                 <Filter className="w-4 h-4" />
@@ -988,13 +1012,13 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick }: 
               </button>
 
               {showFilterDropdown && (
-                <div className="absolute right-0 top-full mt-2 w-64 bg-slate-800 border border-slate-700 rounded-lg shadow-xl z-50">
-                  <div className="p-3 border-b border-slate-700 flex items-center justify-between">
-                    <span className="text-sm font-medium text-white">Filters</span>
+                <div className="absolute right-0 top-full mt-2 w-64 bg-theme-surface border border-theme-border rounded-lg shadow-xl z-50">
+                  <div className="p-3 border-b border-theme-border flex items-center justify-between">
+                    <span className="text-sm font-medium text-theme-text-primary">Filters</span>
                     {hasActiveFilters && (
                       <button
                         onClick={clearFilters}
-                        className="text-xs text-slate-400 hover:text-white"
+                        className="text-xs text-theme-text-secondary hover:text-theme-text-primary"
                       >
                         Clear all
                       </button>
@@ -1005,7 +1029,7 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick }: 
                     {/* Status/Phase filter */}
                     {filterOptions.type === 'pods' && filterOptions.phases.length > 0 && (
                       <div>
-                        <label className="text-xs font-medium text-slate-400 uppercase tracking-wide mb-2 block">
+                        <label className="text-xs font-medium text-theme-text-secondary uppercase tracking-wide mb-2 block">
                           Phase
                         </label>
                         <div className="flex flex-wrap gap-1.5">
@@ -1017,7 +1041,7 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick }: 
                                 'px-2 py-1 text-xs rounded transition-colors',
                                 statusFilter === value
                                   ? 'bg-blue-500/30 text-blue-300'
-                                  : 'bg-slate-700 text-slate-400 hover:text-white'
+                                  : 'bg-theme-elevated text-theme-text-secondary hover:text-theme-text-primary'
                               )}
                             >
                               {value} ({count})
@@ -1030,7 +1054,7 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick }: 
                     {/* Problem filter (pods only) */}
                     {filterOptions.type === 'pods' && filterOptions.problems.length > 0 && (
                       <div>
-                        <label className="text-xs font-medium text-slate-400 uppercase tracking-wide mb-2 block">
+                        <label className="text-xs font-medium text-theme-text-secondary uppercase tracking-wide mb-2 block">
                           Problems
                         </label>
                         <div className="flex flex-wrap gap-1.5">
@@ -1042,7 +1066,7 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick }: 
                                 'px-2 py-1 text-xs rounded transition-colors',
                                 problemFilters.includes(value)
                                   ? 'bg-red-500/30 text-red-300'
-                                  : 'bg-slate-700 text-slate-400 hover:text-white'
+                                  : 'bg-theme-elevated text-theme-text-secondary hover:text-theme-text-primary'
                               )}
                             >
                               {value} ({count})
@@ -1055,7 +1079,7 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick }: 
                     {/* Workload health filter */}
                     {filterOptions.type === 'workload' && filterOptions.health.length > 0 && (
                       <div>
-                        <label className="text-xs font-medium text-slate-400 uppercase tracking-wide mb-2 block">
+                        <label className="text-xs font-medium text-theme-text-secondary uppercase tracking-wide mb-2 block">
                           Health
                         </label>
                         <div className="flex flex-wrap gap-1.5">
@@ -1070,7 +1094,7 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick }: 
                                     : value === 'Degraded' ? 'bg-yellow-500/30 text-yellow-300'
                                     : value === 'Unhealthy' ? 'bg-red-500/30 text-red-300'
                                     : 'bg-blue-500/30 text-blue-300'
-                                  : 'bg-slate-700 text-slate-400 hover:text-white'
+                                  : 'bg-theme-elevated text-theme-text-secondary hover:text-theme-text-primary'
                               )}
                             >
                               {value} ({count})
@@ -1083,7 +1107,7 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick }: 
                     {/* Node conditions filter */}
                     {filterOptions.type === 'nodes' && filterOptions.conditions.length > 0 && (
                       <div>
-                        <label className="text-xs font-medium text-slate-400 uppercase tracking-wide mb-2 block">
+                        <label className="text-xs font-medium text-theme-text-secondary uppercase tracking-wide mb-2 block">
                           Conditions
                         </label>
                         <div className="flex flex-wrap gap-1.5">
@@ -1095,7 +1119,7 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick }: 
                                 'px-2 py-1 text-xs rounded transition-colors',
                                 statusFilter === value
                                   ? 'bg-red-500/30 text-red-300'
-                                  : 'bg-slate-700 text-slate-400 hover:text-white'
+                                  : 'bg-theme-elevated text-theme-text-secondary hover:text-theme-text-primary'
                               )}
                             >
                               {value.replace(/([A-Z])/g, ' $1').trim()} ({count})
@@ -1116,7 +1140,7 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick }: 
               {statusFilter && (
                 <span className="flex items-center gap-1 px-2 py-1 text-xs bg-blue-500/20 text-blue-300 rounded">
                   {statusFilter}
-                  <button onClick={() => setStatusFilter('')} className="hover:text-white">
+                  <button onClick={() => setStatusFilter('')} className="hover:text-theme-text-primary">
                     <X className="w-3 h-3" />
                   </button>
                 </span>
@@ -1124,7 +1148,7 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick }: 
               {problemFilters.map(p => (
                 <span key={p} className="flex items-center gap-1 px-2 py-1 text-xs bg-red-500/20 text-red-300 rounded">
                   {p}
-                  <button onClick={() => toggleProblemFilter(p)} className="hover:text-white">
+                  <button onClick={() => toggleProblemFilter(p)} className="hover:text-theme-text-primary">
                     <X className="w-3 h-3" />
                   </button>
                 </span>
@@ -1133,14 +1157,14 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick }: 
           )}
 
           {lastUpdated && (
-            <div className="flex items-center gap-1.5 text-xs text-slate-500">
+            <div className="flex items-center gap-1.5 text-xs text-theme-text-tertiary">
               <Clock className="w-3.5 h-3.5" />
               <span>Updated {formatAge(lastUpdated.toISOString())}</span>
             </div>
           )}
           <button
             onClick={() => refetch()}
-            className="p-2 text-slate-400 hover:text-white hover:bg-slate-700 rounded-lg"
+            className="p-2 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded-lg"
             title="Refresh"
           >
             <RefreshCw className="w-4 h-4" />
@@ -1150,16 +1174,16 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick }: 
         {/* Table */}
         <div className="flex-1 overflow-auto">
           {isLoading ? (
-            <div className="flex items-center justify-center h-full text-slate-500">
+            <div className="flex items-center justify-center h-full text-theme-text-tertiary">
               Loading...
             </div>
           ) : filteredResources.length === 0 ? (
-            <div className="flex items-center justify-center h-full text-slate-500">
+            <div className="flex items-center justify-center h-full text-theme-text-tertiary">
               No {selectedKind.kind} found
             </div>
           ) : (
             <table className="w-full table-fixed">
-              <thead className="bg-slate-800 sticky top-0 z-10">
+              <thead className="bg-theme-surface sticky top-0 z-10">
                 <tr>
                   {columns.map((col) => {
                     const isSortable = ['name', 'namespace', 'age', 'status', 'ready', 'restarts', 'type', 'version'].includes(col.key)
@@ -1171,14 +1195,14 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick }: 
                           'text-left px-4 py-3 text-xs font-medium uppercase tracking-wide',
                           col.key !== 'name' && col.width,
                           col.hideOnMobile && 'hidden xl:table-cell',
-                          isSortable ? 'text-slate-400 hover:text-slate-200 cursor-pointer select-none' : 'text-slate-400'
+                          isSortable ? 'text-theme-text-secondary hover:text-theme-text-primary cursor-pointer select-none' : 'text-theme-text-secondary'
                         )}
                         onClick={isSortable ? () => handleSort(col.key) : undefined}
                       >
                         <div className="flex items-center gap-1">
                           <span>{col.label}</span>
                           {isSortable && (
-                            <span className="text-slate-500">
+                            <span className="text-theme-text-tertiary">
                               {isSorted ? (
                                 sortDirection === 'asc' ? (
                                   <ChevronUp className="w-3.5 h-3.5" />
@@ -1196,7 +1220,7 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick }: 
                   })}
                 </tr>
               </thead>
-              <tbody className="divide-y divide-slate-700/50">
+              <tbody className="table-divide-subtle">
                 {filteredResources.map((resource: any) => {
                   const isSelected = selectedResource?.kind === selectedKind.name &&
                     selectedResource?.namespace === resource.metadata?.namespace &&
@@ -1238,7 +1262,7 @@ function ResourceTypeButton({ resource, count, isSelected, onClick }: ResourceTy
         'w-full flex items-center gap-3 px-3 py-1.5 rounded-lg text-sm transition-colors',
         isSelected
           ? 'bg-blue-500/20 text-blue-300'
-          : 'text-slate-400 hover:bg-slate-700 hover:text-white'
+          : 'text-theme-text-secondary hover:bg-theme-elevated hover:text-theme-text-primary'
       )}
     >
       <Icon className="w-4 h-4 flex-shrink-0" />
@@ -1249,7 +1273,7 @@ function ResourceTypeButton({ resource, count, isSelected, onClick }: ResourceTy
       </Tooltip>
       <span className={clsx(
         'text-xs px-1.5 py-0.5 rounded min-w-[1.5rem] text-center',
-        isSelected ? 'bg-blue-500/30' : 'bg-slate-700'
+        isSelected ? 'bg-blue-500/30' : 'bg-theme-elevated'
       )}>
         {count}
       </span>
@@ -1273,7 +1297,7 @@ function ResourceRow({ resource, kind, columns, isSelected, onClick }: ResourceR
         'cursor-pointer transition-colors',
         isSelected
           ? 'bg-blue-500/20 hover:bg-blue-500/30'
-          : 'hover:bg-slate-800/50'
+          : 'hover:bg-theme-surface/50'
       )}
     >
       {columns.map((col) => (
@@ -1305,7 +1329,7 @@ function CellContent({ resource, kind, column }: CellContentProps) {
   if (column === 'name') {
     return (
       <Tooltip content={meta.name}>
-        <span className="text-sm text-white font-medium truncate block">
+        <span className="text-sm text-theme-text-primary font-medium truncate block">
           {meta.name}
         </span>
       </Tooltip>
@@ -1314,12 +1338,12 @@ function CellContent({ resource, kind, column }: CellContentProps) {
   if (column === 'namespace') {
     return (
       <Tooltip content={meta.namespace}>
-        <span className="text-sm text-slate-400 truncate block">{meta.namespace || '-'}</span>
+        <span className="text-sm text-theme-text-secondary truncate block">{meta.namespace || '-'}</span>
       </Tooltip>
     )
   }
   if (column === 'age') {
-    return <span className="text-sm text-slate-400">{formatAge(meta.creationTimestamp)}</span>
+    return <span className="text-sm text-theme-text-secondary">{formatAge(meta.creationTimestamp)}</span>
   }
 
   // Kind-specific columns
@@ -1363,7 +1387,7 @@ function GenericCell({ resource, column }: { resource: any; column: string }) {
     case 'status': {
       // Try to extract status from common patterns
       const status = resource.status
-      if (!status) return <span className="text-sm text-slate-500">-</span>
+      if (!status) return <span className="text-sm text-theme-text-tertiary">-</span>
 
       // Check for phase (common in many CRDs)
       if (status.phase) {
@@ -1373,9 +1397,9 @@ function GenericCell({ resource, column }: { resource: any; column: string }) {
         return (
           <span className={clsx(
             'inline-flex items-center px-2 py-0.5 rounded text-xs font-medium',
-            isHealthy ? 'bg-green-500/20 text-green-400' :
-            isWarning ? 'bg-yellow-500/20 text-yellow-400' :
-            'bg-red-500/20 text-red-400'
+            isHealthy ? 'status-healthy' :
+            isWarning ? 'status-degraded' :
+            'status-unhealthy'
           )}>
             {phase}
           </span>
@@ -1390,7 +1414,7 @@ function GenericCell({ resource, column }: { resource: any; column: string }) {
           return (
             <span className={clsx(
               'inline-flex items-center px-2 py-0.5 rounded text-xs font-medium',
-              isReady ? 'bg-green-500/20 text-green-400' : 'bg-yellow-500/20 text-yellow-400'
+              isReady ? 'status-healthy' : 'status-degraded'
             )}>
               {isReady ? 'Ready' : 'Not Ready'}
             </span>
@@ -1401,16 +1425,16 @@ function GenericCell({ resource, column }: { resource: any; column: string }) {
       // Check for state field
       if (status.state) {
         return (
-          <span className="text-sm text-slate-400 truncate">
+          <span className="text-sm text-theme-text-secondary truncate">
             {String(status.state)}
           </span>
         )
       }
 
-      return <span className="text-sm text-slate-500">-</span>
+      return <span className="text-sm text-theme-text-tertiary">-</span>
     }
     default:
-      return <span className="text-sm text-slate-500">-</span>
+      return <span className="text-sm text-theme-text-tertiary">-</span>
   }
 }
 
@@ -1428,7 +1452,7 @@ function PodCell({ resource, column }: { resource: any; column: string }) {
       const allReady = ready === total && total > 0
       // Completed pods (Succeeded) show neutral color, not red
       const color = isCompleted
-        ? 'text-slate-400'
+        ? 'text-theme-text-secondary'
         : allReady
           ? 'text-green-400'
           : ready > 0
@@ -1463,7 +1487,7 @@ function PodCell({ resource, column }: { resource: any; column: string }) {
       return (
         <span className={clsx(
           'text-sm',
-          restarts > 5 ? 'text-red-400 font-medium' : restarts > 0 ? 'text-yellow-400' : 'text-slate-400'
+          restarts > 5 ? 'text-red-400 font-medium' : restarts > 0 ? 'text-yellow-400' : 'text-theme-text-secondary'
         )}>
           {restarts}
         </span>
@@ -1473,12 +1497,12 @@ function PodCell({ resource, column }: { resource: any; column: string }) {
       const nodeName = resource.spec?.nodeName || '-'
       return (
         <Tooltip content={nodeName}>
-          <span className="text-sm text-slate-400 truncate block">{nodeName}</span>
+          <span className="text-sm text-theme-text-secondary truncate block">{nodeName}</span>
         </Tooltip>
       )
     }
     default:
-      return <span className="text-sm text-slate-500">-</span>
+      return <span className="text-sm text-theme-text-tertiary">-</span>
   }
 }
 
@@ -1494,23 +1518,23 @@ function WorkloadCell({ resource, column }: { resource: any; kind: string; colum
       return (
         <span className={clsx(
           'text-sm font-medium',
-          desired === 0 ? 'text-slate-400' : allReady ? 'text-green-400' : ready > 0 ? 'text-yellow-400' : 'text-red-400'
+          desired === 0 ? 'text-theme-text-secondary' : allReady ? 'text-green-400' : ready > 0 ? 'text-yellow-400' : 'text-red-400'
         )}>
           {ready}/{desired}
         </span>
       )
     }
     case 'upToDate':
-      return <span className="text-sm text-slate-400">{status.updatedReplicas || 0}</span>
+      return <span className="text-sm text-theme-text-secondary">{status.updatedReplicas || 0}</span>
     case 'available':
-      return <span className="text-sm text-slate-400">{status.availableReplicas || 0}</span>
+      return <span className="text-sm text-theme-text-secondary">{status.availableReplicas || 0}</span>
     case 'images': {
       const images = getWorkloadImages(resource)
-      if (images.length === 0) return <span className="text-sm text-slate-500">-</span>
+      if (images.length === 0) return <span className="text-sm text-theme-text-tertiary">-</span>
       const display = images.length === 1 ? truncate(images[0], 40) : `${truncate(images[0], 30)} +${images.length - 1}`
       return (
         <Tooltip content={images.join('\n')}>
-          <span className="text-sm text-slate-400 truncate">
+          <span className="text-sm text-theme-text-secondary truncate">
             {display}
           </span>
         </Tooltip>
@@ -1518,7 +1542,7 @@ function WorkloadCell({ resource, column }: { resource: any; kind: string; colum
     }
     case 'conditions': {
       const { conditions, hasIssues } = getWorkloadConditions(resource)
-      if (conditions.length === 0) return <span className="text-sm text-slate-500">-</span>
+      if (conditions.length === 0) return <span className="text-sm text-theme-text-tertiary">-</span>
       const display = conditions.join(', ')
       return (
         <Tooltip content={display}>
@@ -1534,7 +1558,7 @@ function WorkloadCell({ resource, column }: { resource: any; kind: string; colum
       )
     }
     default:
-      return <span className="text-sm text-slate-500">-</span>
+      return <span className="text-sm text-theme-text-tertiary">-</span>
   }
 }
 
@@ -1543,7 +1567,7 @@ function DaemonSetCell({ resource, column }: { resource: any; column: string }) 
 
   switch (column) {
     case 'desired':
-      return <span className="text-sm text-slate-400">{status.desiredNumberScheduled || 0}</span>
+      return <span className="text-sm text-theme-text-secondary">{status.desiredNumberScheduled || 0}</span>
     case 'ready': {
       const desired = status.desiredNumberScheduled || 0
       const ready = status.numberReady || 0
@@ -1558,11 +1582,11 @@ function DaemonSetCell({ resource, column }: { resource: any; column: string }) 
       )
     }
     case 'upToDate':
-      return <span className="text-sm text-slate-400">{status.updatedNumberScheduled || 0}</span>
+      return <span className="text-sm text-theme-text-secondary">{status.updatedNumberScheduled || 0}</span>
     case 'available':
-      return <span className="text-sm text-slate-400">{status.numberAvailable || 0}</span>
+      return <span className="text-sm text-theme-text-secondary">{status.numberAvailable || 0}</span>
     default:
-      return <span className="text-sm text-slate-500">-</span>
+      return <span className="text-sm text-theme-text-tertiary">-</span>
   }
 }
 
@@ -1578,7 +1602,7 @@ function ReplicaSetCell({ resource, column }: { resource: any; column: string })
       return (
         <span className={clsx(
           'text-sm font-medium',
-          desired === 0 ? 'text-slate-400' : allReady ? 'text-green-400' : ready > 0 ? 'text-yellow-400' : 'text-red-400'
+          desired === 0 ? 'text-theme-text-secondary' : allReady ? 'text-green-400' : ready > 0 ? 'text-yellow-400' : 'text-red-400'
         )}>
           {ready}/{desired}
         </span>
@@ -1586,21 +1610,21 @@ function ReplicaSetCell({ resource, column }: { resource: any; column: string })
     }
     case 'owner': {
       const owner = getReplicaSetOwner(resource)
-      return <span className="text-sm text-slate-400 truncate">{owner || '-'}</span>
+      return <span className="text-sm text-theme-text-secondary truncate">{owner || '-'}</span>
     }
     case 'status': {
       const isActive = isReplicaSetActive(resource)
       return (
         <span className={clsx(
           'inline-flex items-center px-2 py-0.5 rounded text-xs font-medium',
-          isActive ? 'bg-blue-500/20 text-blue-400' : 'bg-slate-500/20 text-slate-400'
+          isActive ? 'status-neutral' : 'status-unknown'
         )}>
           {isActive ? 'Active' : 'Old'}
         </span>
       )
     }
     default:
-      return <span className="text-sm text-slate-500">-</span>
+      return <span className="text-sm text-theme-text-tertiary">-</span>
   }
 }
 
@@ -1618,7 +1642,7 @@ function ServiceCell({ resource, column }: { resource: any; column: string }) {
       const selector = getServiceSelector(resource)
       return (
         <Tooltip content={selector}>
-          <span className="text-sm text-slate-400 truncate">
+          <span className="text-sm text-theme-text-secondary truncate">
             {selector}
           </span>
         </Tooltip>
@@ -1633,10 +1657,10 @@ function ServiceCell({ resource, column }: { resource: any; column: string }) {
       )
     }
     case 'clusterIP':
-      return <span className="text-sm text-slate-400 font-mono">{resource.spec?.clusterIP || '-'}</span>
+      return <span className="text-sm text-theme-text-secondary font-mono">{resource.spec?.clusterIP || '-'}</span>
     case 'externalIP': {
       const external = getServiceExternalIP(resource)
-      if (!external) return <span className="text-sm text-slate-500">-</span>
+      if (!external) return <span className="text-sm text-theme-text-tertiary">-</span>
       return (
         <Tooltip content={external}>
           <div className="flex items-center gap-1">
@@ -1648,10 +1672,10 @@ function ServiceCell({ resource, column }: { resource: any; column: string }) {
     }
     case 'ports': {
       const ports = getServicePorts(resource)
-      return <span className="text-sm text-slate-400">{ports}</span>
+      return <span className="text-sm text-theme-text-secondary">{ports}</span>
     }
     default:
-      return <span className="text-sm text-slate-500">-</span>
+      return <span className="text-sm text-theme-text-tertiary">-</span>
   }
 }
 
@@ -1659,13 +1683,13 @@ function IngressCell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
     case 'class': {
       const ingressClass = getIngressClass(resource)
-      return <span className="text-sm text-slate-400">{ingressClass || '-'}</span>
+      return <span className="text-sm text-theme-text-secondary">{ingressClass || '-'}</span>
     }
     case 'hosts': {
       const hosts = getIngressHosts(resource)
       return (
         <Tooltip content={hosts}>
-          <span className="text-sm text-slate-400 truncate">{hosts}</span>
+          <span className="text-sm text-theme-text-secondary truncate">{hosts}</span>
         </Tooltip>
       )
     }
@@ -1673,7 +1697,7 @@ function IngressCell({ resource, column }: { resource: any; column: string }) {
       const rules = getIngressRules(resource)
       return (
         <Tooltip content={rules}>
-          <span className="text-sm text-slate-400 truncate">{rules}</span>
+          <span className="text-sm text-theme-text-secondary truncate">{rules}</span>
         </Tooltip>
       )
     }
@@ -1686,15 +1710,15 @@ function IngressCell({ resource, column }: { resource: any; column: string }) {
           </span>
         </Tooltip>
       ) : (
-        <span className="text-sm text-slate-500">-</span>
+        <span className="text-sm text-theme-text-tertiary">-</span>
       )
     }
     case 'address': {
       const address = getIngressAddress(resource)
-      return <span className="text-sm text-slate-400 truncate">{address || 'Pending'}</span>
+      return <span className="text-sm text-theme-text-secondary truncate">{address || 'Pending'}</span>
     }
     default:
-      return <span className="text-sm text-slate-500">-</span>
+      return <span className="text-sm text-theme-text-tertiary">-</span>
   }
 }
 
@@ -1704,10 +1728,10 @@ function ConfigMapCell({ resource, column }: { resource: any; column: string }) 
       const { count, preview } = getConfigMapKeys(resource)
       return (
         <div className="flex items-center gap-2">
-          <span className="text-sm text-slate-400">{count}</span>
+          <span className="text-sm text-theme-text-secondary">{count}</span>
           {count > 0 && (
             <Tooltip content={preview}>
-              <span className="text-xs text-slate-500 truncate">
+              <span className="text-xs text-theme-text-tertiary truncate">
                 ({preview})
               </span>
             </Tooltip>
@@ -1717,10 +1741,10 @@ function ConfigMapCell({ resource, column }: { resource: any; column: string }) 
     }
     case 'size': {
       const size = getConfigMapSize(resource)
-      return <span className="text-sm text-slate-400">{size}</span>
+      return <span className="text-sm text-theme-text-secondary">{size}</span>
     }
     default:
-      return <span className="text-sm text-slate-500">-</span>
+      return <span className="text-sm text-theme-text-tertiary">-</span>
   }
 }
 
@@ -1736,10 +1760,10 @@ function SecretCell({ resource, column }: { resource: any; column: string }) {
     }
     case 'keys': {
       const count = getSecretKeyCount(resource)
-      return <span className="text-sm text-slate-400">{count}</span>
+      return <span className="text-sm text-theme-text-secondary">{count}</span>
     }
     default:
-      return <span className="text-sm text-slate-500">-</span>
+      return <span className="text-sm text-theme-text-tertiary">-</span>
   }
 }
 
@@ -1759,7 +1783,7 @@ function JobCell({ resource, column }: { resource: any; column: string }) {
       return (
         <span className={clsx(
           'text-sm font-medium',
-          allDone ? 'text-green-400' : succeeded > 0 ? 'text-yellow-400' : 'text-slate-400'
+          allDone ? 'text-green-400' : succeeded > 0 ? 'text-yellow-400' : 'text-theme-text-secondary'
         )}>
           {succeeded}/{total}
         </span>
@@ -1767,10 +1791,10 @@ function JobCell({ resource, column }: { resource: any; column: string }) {
     }
     case 'duration': {
       const duration = getJobDuration(resource)
-      return <span className="text-sm text-slate-400">{duration || '-'}</span>
+      return <span className="text-sm text-theme-text-secondary">{duration || '-'}</span>
     }
     default:
-      return <span className="text-sm text-slate-500">-</span>
+      return <span className="text-sm text-theme-text-tertiary">-</span>
   }
 }
 
@@ -1780,8 +1804,8 @@ function CronJobCell({ resource, column }: { resource: any; column: string }) {
       const { cron, readable } = getCronJobSchedule(resource)
       return (
         <div className="flex flex-col">
-          <span className="text-sm text-slate-400 font-mono">{cron}</span>
-          <span className="text-xs text-slate-500">{readable}</span>
+          <span className="text-sm text-theme-text-secondary font-mono">{cron}</span>
+          <span className="text-xs text-theme-text-tertiary">{readable}</span>
         </div>
       )
     }
@@ -1795,10 +1819,10 @@ function CronJobCell({ resource, column }: { resource: any; column: string }) {
     }
     case 'lastRun': {
       const lastRun = getCronJobLastRun(resource)
-      return <span className="text-sm text-slate-400">{lastRun || 'Never'}</span>
+      return <span className="text-sm text-theme-text-secondary">{lastRun || 'Never'}</span>
     }
     default:
-      return <span className="text-sm text-slate-500">-</span>
+      return <span className="text-sm text-theme-text-tertiary">-</span>
   }
 }
 
@@ -1806,14 +1830,14 @@ function HPACell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
     case 'target': {
       const target = getHPATarget(resource)
-      return <span className="text-sm text-slate-400 truncate">{target}</span>
+      return <span className="text-sm text-theme-text-secondary truncate">{target}</span>
     }
     case 'replicas': {
       const { current, min, max } = getHPAReplicas(resource)
       return (
-        <span className="text-sm text-slate-400">
-          <span className="text-white font-medium">{current}</span>
-          <span className="text-slate-500"> ({min}-{max})</span>
+        <span className="text-sm text-theme-text-secondary">
+          <span className="text-theme-text-primary font-medium">{current}</span>
+          <span className="text-theme-text-tertiary"> ({min}-{max})</span>
         </span>
       )
     }
@@ -1823,7 +1847,7 @@ function HPACell({ resource, column }: { resource: any; column: string }) {
       if (cpu !== undefined) parts.push(`CPU: ${cpu}%`)
       if (memory !== undefined) parts.push(`Mem: ${memory}%`)
       if (custom > 0) parts.push(`+${custom} custom`)
-      return <span className="text-sm text-slate-400">{parts.join(', ') || '-'}</span>
+      return <span className="text-sm text-theme-text-secondary">{parts.join(', ') || '-'}</span>
     }
     case 'status': {
       const status = getHPAStatus(resource)
@@ -1834,7 +1858,7 @@ function HPACell({ resource, column }: { resource: any; column: string }) {
       )
     }
     default:
-      return <span className="text-sm text-slate-500">-</span>
+      return <span className="text-sm text-theme-text-tertiary">-</span>
   }
 }
 
@@ -1860,7 +1884,7 @@ function NodeCell({ resource, column }: { resource: any; column: string }) {
     }
     case 'roles': {
       const roles = getNodeRoles(resource)
-      return <span className="text-sm text-slate-400">{roles}</span>
+      return <span className="text-sm text-theme-text-secondary">{roles}</span>
     }
     case 'conditions': {
       const { problems, healthy } = getNodeConditions(resource)
@@ -1878,16 +1902,16 @@ function NodeCell({ resource, column }: { resource: any; column: string }) {
     case 'taints': {
       const { text, count } = getNodeTaints(resource)
       return (
-        <span className={clsx('text-sm', count > 0 ? 'text-yellow-400' : 'text-slate-400')}>
+        <span className={clsx('text-sm', count > 0 ? 'text-yellow-400' : 'text-theme-text-secondary')}>
           {text}
         </span>
       )
     }
     case 'version': {
       const version = getNodeVersion(resource)
-      return <span className="text-sm text-slate-400">{version}</span>
+      return <span className="text-sm text-theme-text-secondary">{version}</span>
     }
     default:
-      return <span className="text-sm text-slate-500">-</span>
+      return <span className="text-sm text-theme-text-tertiary">-</span>
   }
 }

--- a/web/src/components/resources/drawer-components.tsx
+++ b/web/src/components/resources/drawer-components.tsx
@@ -9,7 +9,7 @@ import { formatAge } from './resource-utils'
 
 export function KeyValueBadge({ k, v }: { k: string; v: string }) {
   return (
-    <span className="px-2 py-0.5 bg-slate-700 rounded text-xs text-slate-300">
+    <span className="px-2 py-0.5 bg-theme-elevated rounded text-xs text-theme-text-secondary">
       {k}={v}
     </span>
   )
@@ -37,14 +37,14 @@ export function Section({ title, icon: Icon, children, defaultExpanded = true }:
   const [expanded, setExpanded] = useState(defaultExpanded)
 
   return (
-    <div className="border-b border-slate-700/50 pb-4 last:border-0">
+    <div className="border-b-subtle pb-4 last:border-0">
       <button
         onClick={() => setExpanded(!expanded)}
-        className="flex items-center gap-2 w-full text-left mb-2 hover:text-white transition-colors"
+        className="flex items-center gap-2 w-full text-left mb-2 hover:text-theme-text-primary transition-colors"
       >
-        {expanded ? <ChevronDown className="w-4 h-4 text-slate-500" /> : <ChevronRight className="w-4 h-4 text-slate-500" />}
-        {Icon && <Icon className="w-4 h-4 text-slate-400" />}
-        <span className="text-sm font-medium text-slate-300">{title}</span>
+        {expanded ? <ChevronDown className="w-4 h-4 text-theme-text-tertiary" /> : <ChevronRight className="w-4 h-4 text-theme-text-tertiary" />}
+        {Icon && <Icon className="w-4 h-4 text-theme-text-secondary" />}
+        <span className="text-sm font-medium text-theme-text-secondary">{title}</span>
       </button>
       {expanded && <div className="pl-6">{children}</div>}
     </div>
@@ -64,7 +64,7 @@ export function ExpandableSection({ title, children, defaultExpanded = true }: E
     <div>
       <button
         onClick={() => setExpanded(!expanded)}
-        className="flex items-center gap-2 text-sm text-slate-400 hover:text-white transition-colors mb-1"
+        className="flex items-center gap-2 text-sm text-theme-text-secondary hover:text-theme-text-primary transition-colors mb-1"
       >
         {expanded ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
         {title}
@@ -92,12 +92,12 @@ export function Property({ label, value, copyable, onCopy, copied }: PropertyPro
 
   return (
     <div className="flex items-start gap-2 text-sm">
-      <span className="text-slate-500 w-28 shrink-0">{label}</span>
-      <span className="text-white break-all flex-1">{strValue}</span>
+      <span className="text-theme-text-tertiary w-28 shrink-0">{label}</span>
+      <span className="text-theme-text-primary break-all flex-1">{strValue}</span>
       {copyable && onCopy && (
         <button
           onClick={() => onCopy(strValue, label)}
-          className="p-0.5 text-slate-500 hover:text-white shrink-0"
+          className="p-0.5 text-theme-text-tertiary hover:text-theme-text-primary shrink-0"
         >
           {copied === label ? <Check className="w-3 h-3 text-green-400" /> : <Copy className="w-3 h-3" />}
         </button>
@@ -125,8 +125,8 @@ export function ConditionsSection({ conditions }: { conditions?: any[] }) {
               {cond.status === 'True' ? '✓' : '✗'}
             </span>
             <div>
-              <div className="text-white">{cond.type}</div>
-              {cond.message && <div className="text-xs text-slate-500">{cond.message}</div>}
+              <div className="text-theme-text-primary">{cond.type}</div>
+              {cond.message && <div className="text-xs text-theme-text-tertiary">{cond.message}</div>}
             </div>
           </div>
         ))}
@@ -157,8 +157,8 @@ export function AnnotationsSection({ data }: { data: any }) {
       <div className="space-y-1 max-h-48 overflow-y-auto">
         {Object.entries(annotations).map(([k, v]) => (
           <div key={k} className="text-xs">
-            <span className="text-slate-500">{k}:</span>
-            <span className="text-slate-300 ml-1 break-all">{v as string}</span>
+            <span className="text-theme-text-tertiary">{k}:</span>
+            <span className="text-theme-text-secondary ml-1 break-all">{v as string}</span>
           </div>
         ))}
       </div>
@@ -189,11 +189,11 @@ export function PodTemplateSection({ template }: { template: any }) {
   return (
     <div className="space-y-2">
       {containers.map((c: any, i: number) => (
-        <div key={i} className="bg-slate-700/30 rounded p-2 text-sm">
-          <div className="font-medium text-white">{c.name}</div>
-          <div className="text-xs text-slate-400 truncate" title={c.image}>{c.image}</div>
+        <div key={i} className="bg-theme-elevated/30 rounded p-2 text-sm">
+          <div className="font-medium text-theme-text-primary">{c.name}</div>
+          <div className="text-xs text-theme-text-secondary truncate" title={c.image}>{c.image}</div>
           {c.ports && (
-            <div className="text-xs text-slate-500 mt-1">
+            <div className="text-xs text-theme-text-tertiary mt-1">
               Ports: {c.ports.map((p: any) => `${p.containerPort}/${p.protocol || 'TCP'}`).join(', ')}
             </div>
           )}
@@ -338,7 +338,7 @@ function RelationshipGroup({ label, refs, onNavigate }: RelationshipGroupProps) 
 
   return (
     <div>
-      <div className="text-xs text-slate-500 mb-1">{label}</div>
+      <div className="text-xs text-theme-text-tertiary mb-1">{label}</div>
       <div className="flex flex-wrap gap-1">
         {refs.map((resourceRef, i) => (
           <ResourceRefBadge key={`${resourceRef.kind}-${resourceRef.namespace}-${resourceRef.name}-${i}`} resourceRef={resourceRef} onClick={onNavigate} />
@@ -416,7 +416,7 @@ export function EventsSection({ events, isLoading }: EventsSectionProps) {
   if (isLoading) {
     return (
       <Section title="Recent Events" defaultExpanded>
-        <div className="text-sm text-slate-500">Loading events...</div>
+        <div className="text-sm text-theme-text-tertiary">Loading events...</div>
       </Section>
     )
   }
@@ -424,7 +424,7 @@ export function EventsSection({ events, isLoading }: EventsSectionProps) {
   if (!events || events.length === 0) {
     return (
       <Section title="Recent Events" defaultExpanded={false}>
-        <div className="text-sm text-slate-500">No recent events</div>
+        <div className="text-sm text-theme-text-tertiary">No recent events</div>
       </Section>
     )
   }
@@ -441,24 +441,24 @@ export function EventsSection({ events, isLoading }: EventsSectionProps) {
                 ? 'bg-red-500/10 border-red-500'
                 : event.type === 'k8s_event'
                 ? 'bg-blue-500/10 border-blue-500'
-                : 'bg-slate-700/30 border-slate-500'
+                : 'bg-theme-elevated/30 border-theme-border'
             )}
           >
             <div className="flex items-center justify-between gap-2">
-              <span className="font-medium text-white">
+              <span className="font-medium text-theme-text-primary">
                 {event.type === 'k8s_event' ? event.reason : event.operation}
               </span>
-              <span className="text-xs text-slate-500">
+              <span className="text-xs text-theme-text-tertiary">
                 {formatEventTime(event.timestamp)}
               </span>
             </div>
             {event.message && (
-              <div className="text-xs text-slate-400 mt-1 line-clamp-2">
+              <div className="text-xs text-theme-text-secondary mt-1 line-clamp-2">
                 {event.message}
               </div>
             )}
             {event.type === 'change' && event.diff?.summary && (
-              <div className="text-xs text-slate-400 mt-1">
+              <div className="text-xs text-theme-text-secondary mt-1">
                 {event.diff.summary}
               </div>
             )}

--- a/web/src/components/resources/renderers/ConfigMapRenderer.tsx
+++ b/web/src/components/resources/renderers/ConfigMapRenderer.tsx
@@ -19,19 +19,19 @@ export function ConfigMapRenderer({ data }: ConfigMapRendererProps) {
             const isLarge = value.length > 500
             return (
               <ExpandableSection key={key} title={`${key} (${formatBytes(value.length)})`} defaultExpanded={!isLarge}>
-                <pre className="bg-slate-900 rounded p-2 text-xs text-slate-300 overflow-x-auto max-h-60 whitespace-pre-wrap">
+                <pre className="bg-theme-base rounded p-2 text-xs text-theme-text-secondary overflow-x-auto max-h-60 whitespace-pre-wrap">
                   {value}
                 </pre>
               </ExpandableSection>
             )
           })}
           {binaryDataKeys.map((key) => (
-            <div key={key} className="text-sm text-slate-400">
+            <div key={key} className="text-sm text-theme-text-secondary">
               {key} <span className="text-xs">(binary)</span>
             </div>
           ))}
           {dataKeys.length === 0 && binaryDataKeys.length === 0 && (
-            <div className="text-sm text-slate-500">No data</div>
+            <div className="text-sm text-theme-text-tertiary">No data</div>
           )}
         </div>
       </Section>

--- a/web/src/components/resources/renderers/GenericRenderer.tsx
+++ b/web/src/components/resources/renderers/GenericRenderer.tsx
@@ -47,7 +47,7 @@ export function GenericRenderer({ data }: GenericRendererProps) {
       {/* Raw Spec (for complex nested structures) */}
       {hasNestedObjects(spec) && (
         <ExpandableSection title="Full Specification" defaultExpanded={false}>
-          <pre className="text-xs text-slate-400 bg-slate-900/50 p-3 rounded overflow-x-auto max-h-64 overflow-y-auto">
+          <pre className="text-xs text-theme-text-secondary bg-theme-base/50 p-3 rounded overflow-x-auto max-h-64 overflow-y-auto">
             {JSON.stringify(spec, null, 2)}
           </pre>
         </ExpandableSection>
@@ -56,7 +56,7 @@ export function GenericRenderer({ data }: GenericRendererProps) {
       {/* Raw Status (for complex nested structures) */}
       {hasNestedObjects(status) && Object.keys(status).length > 0 && (
         <ExpandableSection title="Full Status" defaultExpanded={false}>
-          <pre className="text-xs text-slate-400 bg-slate-900/50 p-3 rounded overflow-x-auto max-h-64 overflow-y-auto">
+          <pre className="text-xs text-theme-text-secondary bg-theme-base/50 p-3 rounded overflow-x-auto max-h-64 overflow-y-auto">
             {JSON.stringify(status, null, 2)}
           </pre>
         </ExpandableSection>
@@ -153,18 +153,18 @@ function GenericConditionsSection({ conditions }: { conditions: any[] }) {
               </span>
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2">
-                  <span className="text-white font-medium">{cond.type}</span>
+                  <span className="text-theme-text-primary font-medium">{cond.type}</span>
                   {cond.reason && (
-                    <span className="text-xs text-slate-500">({cond.reason})</span>
+                    <span className="text-xs text-theme-text-tertiary">({cond.reason})</span>
                   )}
                 </div>
                 {cond.message && (
-                  <div className="text-xs text-slate-400 mt-0.5 break-words">
+                  <div className="text-xs text-theme-text-secondary mt-0.5 break-words">
                     {cond.message}
                   </div>
                 )}
                 {cond.lastTransitionTime && (
-                  <div className="text-xs text-slate-500 mt-0.5">
+                  <div className="text-xs text-theme-text-tertiary mt-0.5">
                     Last transition: {formatTimestamp(cond.lastTransitionTime)}
                   </div>
                 )}

--- a/web/src/components/resources/renderers/HPARenderer.tsx
+++ b/web/src/components/resources/renderers/HPARenderer.tsx
@@ -32,13 +32,13 @@ export function HPARenderer({ data }: HPARendererProps) {
               const current = metric.resource?.current?.averageUtilization || metric.resource?.current?.averageValue
               const target = spec.metrics?.[i]?.resource?.target?.averageUtilization || spec.metrics?.[i]?.resource?.target?.averageValue
               return (
-                <div key={i} className="bg-slate-700/30 rounded p-2">
+                <div key={i} className="bg-theme-elevated/30 rounded p-2">
                   <div className="flex items-center justify-between text-sm">
-                    <span className="text-white">{metric.resource?.name || metric.type}</span>
-                    <span className="text-slate-400">{current}{typeof current === 'number' ? '%' : ''} / {target}{typeof target === 'number' ? '%' : ''}</span>
+                    <span className="text-theme-text-primary">{metric.resource?.name || metric.type}</span>
+                    <span className="text-theme-text-secondary">{current}{typeof current === 'number' ? '%' : ''} / {target}{typeof target === 'number' ? '%' : ''}</span>
                   </div>
                   {typeof current === 'number' && typeof target === 'number' && (
-                    <div className="mt-2 h-2 bg-slate-600 rounded overflow-hidden">
+                    <div className="mt-2 h-2 bg-theme-hover rounded overflow-hidden">
                       <div
                         className={clsx(
                           'h-full transition-all',

--- a/web/src/components/resources/renderers/IngressRenderer.tsx
+++ b/web/src/components/resources/renderers/IngressRenderer.tsx
@@ -26,19 +26,19 @@ export function IngressRenderer({ data }: IngressRendererProps) {
       <Section title="Rules" defaultExpanded>
         <div className="space-y-3">
           {rules.map((rule: any, i: number) => (
-            <div key={i} className="bg-slate-700/30 rounded p-3">
+            <div key={i} className="bg-theme-elevated/30 rounded p-3">
               <div className="flex items-center gap-2 mb-2">
                 {tls.some((t: any) => t.hosts?.includes(rule.host)) && (
                   <Shield className="w-3.5 h-3.5 text-green-400" />
                 )}
-                <span className="text-sm font-medium text-white">{rule.host || '*'}</span>
+                <span className="text-sm font-medium text-theme-text-primary">{rule.host || '*'}</span>
               </div>
               <div className="space-y-1">
                 {rule.http?.paths?.map((path: any, j: number) => (
-                  <div key={j} className="text-xs text-slate-400 flex items-center gap-2">
-                    <span className="text-slate-500">{path.pathType || 'Prefix'}:</span>
+                  <div key={j} className="text-xs text-theme-text-secondary flex items-center gap-2">
+                    <span className="text-theme-text-tertiary">{path.pathType || 'Prefix'}:</span>
                     <span>{path.path || '/'}</span>
-                    <span className="text-slate-500">→</span>
+                    <span className="text-theme-text-tertiary">→</span>
                     <span className="text-blue-400">
                       {path.backend?.service?.name}:{path.backend?.service?.port?.number || path.backend?.service?.port?.name}
                     </span>
@@ -55,8 +55,8 @@ export function IngressRenderer({ data }: IngressRendererProps) {
           <div className="space-y-2">
             {tls.map((t: any, i: number) => (
               <div key={i} className="text-sm">
-                <div className="text-slate-400">Secret: <span className="text-white">{t.secretName}</span></div>
-                <div className="text-xs text-slate-500">Hosts: {t.hosts?.join(', ') || '*'}</div>
+                <div className="text-theme-text-secondary">Secret: <span className="text-theme-text-primary">{t.secretName}</span></div>
+                <div className="text-xs text-theme-text-tertiary">Hosts: {t.hosts?.join(', ') || '*'}</div>
               </div>
             ))}
           </div>

--- a/web/src/components/resources/renderers/PodRenderer.tsx
+++ b/web/src/components/resources/renderers/PodRenderer.tsx
@@ -40,9 +40,9 @@ export function PodRenderer({ data, onCopy, copied }: PodRendererProps) {
             const restarts = status?.restartCount || 0
 
             return (
-              <div key={i} className="bg-slate-700/30 rounded-lg p-3">
+              <div key={i} className="bg-theme-elevated/30 rounded-lg p-3">
                 <div className="flex items-center justify-between mb-2">
-                  <span className="text-sm font-medium text-white">{container.name}</span>
+                  <span className="text-sm font-medium text-theme-text-primary">{container.name}</span>
                   <div className="flex items-center gap-2">
                     <span className={clsx(
                       'px-2 py-0.5 text-xs rounded',
@@ -60,7 +60,7 @@ export function PodRenderer({ data, onCopy, copied }: PodRendererProps) {
                     </span>
                   </div>
                 </div>
-                <div className="text-xs text-slate-400 space-y-1">
+                <div className="text-xs text-theme-text-secondary space-y-1">
                   <div className="truncate" title={container.image}>Image: {container.image}</div>
                   {restarts > 0 && (
                     <div className={restarts > 5 ? 'text-red-400' : 'text-yellow-400'}>
@@ -107,22 +107,22 @@ function LogsSection({ namespace, podName, containers }: { namespace: string; po
   if (!namespace || !podName || containers.length === 0) return null
 
   return (
-    <div className="border border-slate-700/50 rounded-lg overflow-hidden">
+    <div className="border border-theme-border/50 rounded-lg overflow-hidden">
       <button
         onClick={() => setExpanded(!expanded)}
-        className="flex items-center gap-2 w-full px-3 py-2 text-left hover:bg-slate-700/30 transition-colors"
+        className="flex items-center gap-2 w-full px-3 py-2 text-left hover:bg-theme-elevated/30 transition-colors"
       >
         {expanded ? (
-          <ChevronDown className="w-4 h-4 text-slate-400" />
+          <ChevronDown className="w-4 h-4 text-theme-text-secondary" />
         ) : (
-          <ChevronRight className="w-4 h-4 text-slate-400" />
+          <ChevronRight className="w-4 h-4 text-theme-text-secondary" />
         )}
-        <FileText className="w-4 h-4 text-slate-400" />
-        <span className="text-sm font-medium text-white">Logs</span>
+        <FileText className="w-4 h-4 text-theme-text-secondary" />
+        <span className="text-sm font-medium text-theme-text-primary">Logs</span>
       </button>
 
       {expanded && (
-        <div className="h-80 border-t border-slate-700/50">
+        <div className="h-80 border-t border-theme-border/50">
           <LogsViewer
             namespace={namespace}
             podName={podName}

--- a/web/src/components/resources/renderers/SecretRenderer.tsx
+++ b/web/src/components/resources/renderers/SecretRenderer.tsx
@@ -40,25 +40,25 @@ export function SecretRenderer({ data }: SecretRendererProps) {
       <Section title="Data" defaultExpanded>
         <div className="space-y-2">
           {dataKeys.map((key) => (
-            <div key={key} className="bg-slate-700/30 rounded p-2">
+            <div key={key} className="bg-theme-elevated/30 rounded p-2">
               <div className="flex items-center justify-between">
-                <span className="text-sm text-white">{key}</span>
+                <span className="text-sm text-theme-text-primary">{key}</span>
                 <button
                   onClick={() => toggleReveal(key)}
-                  className="text-xs text-slate-400 hover:text-white"
+                  className="text-xs text-theme-text-secondary hover:text-theme-text-primary"
                 >
                   {revealed.has(key) ? 'Hide' : 'Reveal'}
                 </button>
               </div>
               {revealed.has(key) && (
-                <pre className="mt-2 bg-slate-900 rounded p-2 text-xs text-slate-300 overflow-x-auto max-h-40 whitespace-pre-wrap">
+                <pre className="mt-2 bg-theme-base rounded p-2 text-xs text-theme-text-secondary overflow-x-auto max-h-40 whitespace-pre-wrap">
                   {decodeBase64(data.data[key])}
                 </pre>
               )}
             </div>
           ))}
           {dataKeys.length === 0 && (
-            <div className="text-sm text-slate-500">No data</div>
+            <div className="text-sm text-theme-text-tertiary">No data</div>
           )}
         </div>
       </Section>

--- a/web/src/components/resources/renderers/ServiceRenderer.tsx
+++ b/web/src/components/resources/renderers/ServiceRenderer.tsx
@@ -38,12 +38,12 @@ export function ServiceRenderer({ data, onCopy, copied }: ServiceRendererProps) 
       <Section title="Ports" defaultExpanded>
         <div className="space-y-2">
           {ports.map((port: any, i: number) => (
-            <div key={i} className="bg-slate-700/30 rounded p-2 text-sm">
+            <div key={i} className="bg-theme-elevated/30 rounded p-2 text-sm">
               <div className="flex items-center justify-between">
-                <span className="text-white font-medium">{port.name || `port-${i}`}</span>
-                <span className="text-slate-400">{port.protocol || 'TCP'}</span>
+                <span className="text-theme-text-primary font-medium">{port.name || `port-${i}`}</span>
+                <span className="text-theme-text-secondary">{port.protocol || 'TCP'}</span>
               </div>
-              <div className="text-xs text-slate-400 mt-1">
+              <div className="text-xs text-theme-text-secondary mt-1">
                 {port.port} {port.targetPort !== port.port && `→ ${port.targetPort}`}
                 {port.nodePort && ` (NodePort: ${port.nodePort})`}
               </div>

--- a/web/src/components/resources/resource-utils.ts
+++ b/web/src/components/resources/resource-utils.ts
@@ -12,13 +12,13 @@ export interface StatusBadge {
   level: HealthLevel
 }
 
-// Color classes for different health levels
+// Color classes for different health levels (theme-aware)
 export const healthColors: Record<HealthLevel, string> = {
-  healthy: 'bg-green-500/20 text-green-400',
-  degraded: 'bg-yellow-500/20 text-yellow-400',
-  unhealthy: 'bg-red-500/20 text-red-400',
-  unknown: 'bg-slate-500/20 text-slate-400',
-  neutral: 'bg-blue-500/20 text-blue-400',
+  healthy: 'status-healthy',
+  degraded: 'status-degraded',
+  unhealthy: 'status-unhealthy',
+  unknown: 'status-unknown',
+  neutral: 'status-neutral',
 }
 
 // ============================================================================
@@ -286,7 +286,7 @@ export function isReplicaSetActive(rs: any): boolean {
 export function getServiceStatus(service: any): StatusBadge {
   const type = service.spec?.type || 'ClusterIP'
   const color = type === 'LoadBalancer' || type === 'NodePort'
-    ? 'bg-violet-500/20 text-violet-400'
+    ? 'status-violet'
     : healthColors.neutral
   return { text: type, color, level: 'neutral' }
 }
@@ -348,15 +348,15 @@ export function getServiceSelector(service: any): string {
 export function getServiceEndpointsStatus(service: any): { status: string; color: string } {
   const type = service.spec?.type
   if (type === 'ExternalName') {
-    return { status: 'External', color: 'bg-violet-500/20 text-violet-400' }
+    return { status: 'External', color: 'status-violet' }
   }
   const selector = service.spec?.selector || {}
   const hasSelector = Object.keys(selector).length > 0
   if (!hasSelector) {
-    return { status: 'None', color: 'bg-slate-500/20 text-slate-400' }
+    return { status: 'None', color: 'status-unknown' }
   }
   // If it has a selector, it should have endpoints (we assume active since we can't check endpoints from service alone)
-  return { status: 'Active', color: 'bg-green-500/20 text-green-400' }
+  return { status: 'Active', color: 'status-healthy' }
 }
 
 // ============================================================================
@@ -458,16 +458,16 @@ export function getConfigMapSize(cm: any): string {
 export function getSecretType(secret: any): { type: string; color: string } {
   const type = secret.type || 'Opaque'
   const typeMap: Record<string, { type: string; color: string }> = {
-    'Opaque': { type: 'Opaque', color: 'bg-slate-500/20 text-slate-400' },
-    'kubernetes.io/tls': { type: 'TLS', color: 'bg-blue-500/20 text-blue-400' },
-    'kubernetes.io/dockercfg': { type: 'Docker', color: 'bg-purple-500/20 text-purple-400' },
-    'kubernetes.io/dockerconfigjson': { type: 'Docker', color: 'bg-purple-500/20 text-purple-400' },
-    'kubernetes.io/basic-auth': { type: 'Basic Auth', color: 'bg-orange-500/20 text-orange-400' },
-    'kubernetes.io/ssh-auth': { type: 'SSH', color: 'bg-cyan-500/20 text-cyan-400' },
-    'kubernetes.io/service-account-token': { type: 'SA Token', color: 'bg-green-500/20 text-green-400' },
-    'bootstrap.kubernetes.io/token': { type: 'Bootstrap', color: 'bg-green-500/20 text-green-400' },
+    'Opaque': { type: 'Opaque', color: 'status-unknown' },
+    'kubernetes.io/tls': { type: 'TLS', color: 'status-neutral' },
+    'kubernetes.io/dockercfg': { type: 'Docker', color: 'status-purple' },
+    'kubernetes.io/dockerconfigjson': { type: 'Docker', color: 'status-purple' },
+    'kubernetes.io/basic-auth': { type: 'Basic Auth', color: 'status-orange' },
+    'kubernetes.io/ssh-auth': { type: 'SSH', color: 'status-cyan' },
+    'kubernetes.io/service-account-token': { type: 'SA Token', color: 'status-healthy' },
+    'bootstrap.kubernetes.io/token': { type: 'Bootstrap', color: 'status-healthy' },
   }
-  return typeMap[type] || { type: type.split('/').pop() || type, color: 'bg-slate-500/20 text-slate-400' }
+  return typeMap[type] || { type: type.split('/').pop() || type, color: 'status-unknown' }
 }
 
 export function getSecretKeyCount(secret: any): number {

--- a/web/src/components/topology/GroupNode.tsx
+++ b/web/src/components/topology/GroupNode.tsx
@@ -41,7 +41,7 @@ export const GroupNode = memo(function GroupNode({
       case 'label':
         return 'border-amber-500/40'
       default:
-        return 'border-slate-500/40'
+        return 'border-theme-border'
     }
   }
 
@@ -54,7 +54,7 @@ export const GroupNode = memo(function GroupNode({
       case 'label':
         return 'bg-amber-500/20'
       default:
-        return 'bg-slate-500/20'
+        return 'bg-theme-hover/50'
     }
   }
 
@@ -67,7 +67,7 @@ export const GroupNode = memo(function GroupNode({
       case 'label':
         return 'text-amber-300'
       default:
-        return 'text-slate-300'
+        return 'text-theme-text-secondary'
     }
   }
 
@@ -80,7 +80,7 @@ export const GroupNode = memo(function GroupNode({
       case 'label':
         return 'text-amber-400'
       default:
-        return 'text-slate-400'
+        return 'text-theme-text-secondary'
     }
   }
 
@@ -109,10 +109,10 @@ export const GroupNode = memo(function GroupNode({
             <Icon className={clsx('w-9 h-9', getIconColor())} />
             <span className={clsx('text-4xl font-bold', getLabelColor())}>{name}</span>
             {label && (
-              <span className="text-sm text-slate-400">({label})</span>
+              <span className="text-sm text-theme-text-secondary">({label})</span>
             )}
           </div>
-          <div className="mt-3 text-xl text-slate-400">
+          <div className="mt-3 text-xl text-theme-text-secondary">
             {nodeCount} {nodeCount === 1 ? 'resource' : 'resources'}
           </div>
         </div>
@@ -141,7 +141,7 @@ export const GroupNode = memo(function GroupNode({
         className={clsx(
           'absolute top-0 left-0 rounded-xl border-2 box-border isolate overflow-hidden',
           getBorderColor(),
-          'bg-slate-800/40'
+          'bg-theme-surface/40'
         )}
         style={{ width: width || '100%', height: height || '100%' }}
       >
@@ -157,9 +157,9 @@ export const GroupNode = memo(function GroupNode({
           <Icon className={clsx('w-9 h-9 flex-shrink-0', getIconColor())} />
           <span className={clsx('text-4xl font-bold truncate', getLabelColor())}>{name}</span>
           {label && (
-            <span className="text-sm text-slate-400 truncate">({label})</span>
+            <span className="text-sm text-theme-text-secondary truncate">({label})</span>
           )}
-          <span className="ml-auto flex-shrink-0 text-xl font-semibold text-slate-300 bg-slate-800/60 px-4 py-2 rounded-xl">
+          <span className="ml-auto flex-shrink-0 text-xl font-semibold text-theme-text-secondary bg-theme-surface/60 px-4 py-2 rounded-xl">
             {nodeCount}
           </span>
         </div>

--- a/web/src/components/topology/K8sResourceNode.tsx
+++ b/web/src/components/topology/K8sResourceNode.tsx
@@ -89,7 +89,7 @@ function getStatusBarColor(status: HealthStatus): string {
     case 'unhealthy':
       return 'bg-red-500'
     default:
-      return 'bg-slate-500'
+      return 'bg-theme-hover'
   }
 }
 
@@ -122,7 +122,7 @@ function getIconColor(kind: NodeKind): string {
     case 'PVC':
       return 'text-cyan-400'
     default:
-      return 'text-slate-400'
+      return 'text-theme-text-secondary'
   }
 }
 
@@ -245,7 +245,7 @@ export const K8sResourceNode = memo(function K8sResourceNode({
       <div
         className={clsx(
           'relative rounded-lg overflow-hidden',
-          'bg-slate-800 border border-slate-600',
+          'bg-theme-surface border border-theme-border-light',
           'shadow-md shadow-black/20',
           'transition-all duration-150',
           selected && 'ring-2 ring-blue-400 border-blue-400',
@@ -271,7 +271,7 @@ export const K8sResourceNode = memo(function K8sResourceNode({
           {/* Header row: icon + kind label + expand/collapse + status dot */}
           <div className="flex items-center gap-1.5 mb-0.5">
             <Icon className={clsx('w-3.5 h-3.5', getIconColor(kind))} />
-            <span className="text-[10px] uppercase tracking-wide text-slate-500 font-medium">
+            <span className="text-[10px] uppercase tracking-wide text-theme-text-tertiary font-medium">
               {isPodGroup ? 'Pod Group' : kind}
             </span>
             {/* Expand/Collapse button for PodGroup */}
@@ -281,10 +281,10 @@ export const K8sResourceNode = memo(function K8sResourceNode({
                   e.stopPropagation()
                   onExpand(id)
                 }}
-                className="ml-auto p-0.5 hover:bg-slate-700 rounded transition-colors"
+                className="ml-auto p-0.5 hover:bg-theme-elevated rounded transition-colors"
                 title="Expand to show individual pods"
               >
-                <ChevronDown className="w-3.5 h-3.5 text-slate-400" />
+                <ChevronDown className="w-3.5 h-3.5 text-theme-text-secondary" />
               </button>
             )}
             {canCollapse && (
@@ -293,10 +293,10 @@ export const K8sResourceNode = memo(function K8sResourceNode({
                   e.stopPropagation()
                   onCollapse(id)
                 }}
-                className="ml-auto p-0.5 hover:bg-slate-700 rounded transition-colors"
+                className="ml-auto p-0.5 hover:bg-theme-elevated rounded transition-colors"
                 title="Collapse back to group"
               >
-                <ChevronUp className="w-3.5 h-3.5 text-slate-400" />
+                <ChevronUp className="w-3.5 h-3.5 text-theme-text-secondary" />
               </button>
             )}
             <span
@@ -309,13 +309,13 @@ export const K8sResourceNode = memo(function K8sResourceNode({
           </div>
 
           {/* Name */}
-          <div className="text-sm font-medium text-white truncate pr-1">
+          <div className="text-sm font-medium text-theme-text-primary truncate pr-1">
             {name}
           </div>
 
           {/* Subtitle */}
           {subtitle && (
-            <div className="text-xs text-slate-400 truncate mt-0.5">
+            <div className="text-xs text-theme-text-secondary truncate mt-0.5">
               {subtitle}
             </div>
           )}

--- a/web/src/components/topology/TopologyFilterSidebar.tsx
+++ b/web/src/components/topology/TopologyFilterSidebar.tsx
@@ -104,10 +104,10 @@ export const TopologyFilterSidebar = memo(function TopologyFilterSidebar({
 
   if (collapsed) {
     return (
-      <div className="flex flex-col items-center py-3 px-1 bg-slate-800/90 backdrop-blur border-r border-slate-700">
+      <div className="flex flex-col items-center py-3 px-1 bg-theme-surface/90 backdrop-blur border-r border-theme-border">
         <button
           onClick={onToggleCollapse}
-          className="p-2 text-slate-400 hover:text-white hover:bg-slate-700 rounded-lg transition-colors"
+          className="p-2 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded-lg transition-colors"
           title="Expand filters"
         >
           <ChevronRight className="w-4 h-4" />
@@ -122,8 +122,8 @@ export const TopologyFilterSidebar = memo(function TopologyFilterSidebar({
                 className={clsx(
                   'p-1.5 rounded transition-colors',
                   isVisible
-                    ? 'bg-slate-700 text-white'
-                    : 'text-slate-500 hover:text-slate-300'
+                    ? 'bg-theme-elevated text-theme-text-primary'
+                    : 'text-theme-text-tertiary hover:text-theme-text-secondary'
                 )}
                 title={kind}
               >
@@ -132,7 +132,7 @@ export const TopologyFilterSidebar = memo(function TopologyFilterSidebar({
             )
           })}
           {availableKinds.length > 6 && (
-            <span className="text-xs text-slate-500 text-center">
+            <span className="text-xs text-theme-text-tertiary text-center">
               +{availableKinds.length - 6}
             </span>
           )}
@@ -142,13 +142,13 @@ export const TopologyFilterSidebar = memo(function TopologyFilterSidebar({
   }
 
   return (
-    <div className="w-56 flex flex-col bg-slate-800/90 backdrop-blur border-r border-slate-700 overflow-hidden">
+    <div className="w-56 flex flex-col bg-theme-surface/90 backdrop-blur border-r border-theme-border overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between px-3 py-2 border-b border-slate-700">
-        <span className="text-sm font-medium text-slate-300">Filters</span>
+      <div className="flex items-center justify-between px-3 py-2 border-b border-theme-border">
+        <span className="text-sm font-medium text-theme-text-secondary">Filters</span>
         <button
           onClick={onToggleCollapse}
-          className="p-1 text-slate-400 hover:text-white hover:bg-slate-700 rounded transition-colors"
+          className="p-1 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded transition-colors"
           title="Collapse sidebar"
         >
           <ChevronLeft className="w-4 h-4" />
@@ -156,15 +156,15 @@ export const TopologyFilterSidebar = memo(function TopologyFilterSidebar({
       </div>
 
       {/* Quick actions */}
-      <div className="flex gap-1 px-3 py-2 border-b border-slate-700">
+      <div className="flex gap-1 px-3 py-2 border-b border-theme-border">
         <button
           onClick={onShowAll}
           disabled={allVisible}
           className={clsx(
             'flex-1 flex items-center justify-center gap-1 px-2 py-1.5 text-xs rounded transition-colors',
             allVisible
-              ? 'bg-slate-700/50 text-slate-500 cursor-not-allowed'
-              : 'bg-slate-700 text-slate-300 hover:bg-slate-600 hover:text-white'
+              ? 'bg-theme-elevated/50 text-theme-text-tertiary cursor-not-allowed'
+              : 'bg-theme-elevated text-theme-text-secondary hover:bg-theme-hover hover:text-theme-text-primary'
           )}
         >
           <Eye className="w-3 h-3" />
@@ -176,8 +176,8 @@ export const TopologyFilterSidebar = memo(function TopologyFilterSidebar({
           className={clsx(
             'flex-1 flex items-center justify-center gap-1 px-2 py-1.5 text-xs rounded transition-colors',
             noneVisible
-              ? 'bg-slate-700/50 text-slate-500 cursor-not-allowed'
-              : 'bg-slate-700 text-slate-300 hover:bg-slate-600 hover:text-white'
+              ? 'bg-theme-elevated/50 text-theme-text-tertiary cursor-not-allowed'
+              : 'bg-theme-elevated text-theme-text-secondary hover:bg-theme-hover hover:text-theme-text-primary'
           )}
         >
           <EyeOff className="w-3 h-3" />
@@ -193,7 +193,7 @@ export const TopologyFilterSidebar = memo(function TopologyFilterSidebar({
 
           return (
             <div key={category.id} className="px-2 py-2">
-              <div className="text-xs font-medium text-slate-500 uppercase tracking-wider px-1 mb-1">
+              <div className="text-xs font-medium text-theme-text-tertiary uppercase tracking-wider px-1 mb-1">
                 {category.label}
               </div>
               <div className="space-y-0.5">
@@ -208,15 +208,15 @@ export const TopologyFilterSidebar = memo(function TopologyFilterSidebar({
                       className={clsx(
                         'w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-left transition-colors',
                         isVisible
-                          ? 'bg-slate-700/70 text-white'
-                          : 'text-slate-400 hover:bg-slate-700/40 hover:text-slate-300'
+                          ? 'bg-theme-elevated/70 text-theme-text-primary'
+                          : 'text-theme-text-secondary hover:bg-theme-elevated/40 hover:text-theme-text-secondary'
                       )}
                     >
-                      <Icon className={clsx('w-4 h-4 flex-shrink-0', isVisible ? color : 'text-slate-500')} />
+                      <Icon className={clsx('w-4 h-4 flex-shrink-0', isVisible ? color : 'text-theme-text-tertiary')} />
                       <span className="flex-1 text-sm truncate">{label}</span>
                       <span className={clsx(
                         'text-xs px-1.5 py-0.5 rounded',
-                        isVisible ? 'bg-slate-600 text-slate-300' : 'bg-slate-700/50 text-slate-500'
+                        isVisible ? 'bg-theme-hover text-theme-text-secondary' : 'bg-theme-elevated/50 text-theme-text-tertiary'
                       )}>
                         {count}
                       </span>
@@ -230,8 +230,8 @@ export const TopologyFilterSidebar = memo(function TopologyFilterSidebar({
       </div>
 
       {/* Footer stats */}
-      <div className="px-3 py-2 border-t border-slate-700 bg-slate-800/50">
-        <div className="text-xs text-slate-500">
+      <div className="px-3 py-2 border-t border-theme-border bg-theme-surface/50">
+        <div className="text-xs text-theme-text-tertiary">
           Showing {availableKinds.filter(k => visibleKinds.has(k.kind)).reduce((sum, k) => sum + (kindCounts.get(k.kind) || 0), 0)} of {nodes.length} resources
         </div>
       </div>

--- a/web/src/components/topology/TopologyGraph.tsx
+++ b/web/src/components/topology/TopologyGraph.tsx
@@ -376,7 +376,7 @@ export function TopologyGraph({
 
   if (!topology || topology.nodes.length === 0) {
     return (
-      <div className="flex-1 flex items-center justify-center text-slate-400">
+      <div className="flex-1 flex items-center justify-center text-theme-text-secondary">
         <div className="text-center">
           <p className="text-lg">No resources found</p>
           <p className="text-sm mt-2">
@@ -404,11 +404,11 @@ export function TopologyGraph({
       >
         <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="#334155" />
         <Controls
-          className="bg-slate-800 border border-slate-700 rounded-lg"
+          className="bg-theme-surface border border-theme-border rounded-lg"
           showInteractive={false}
         />
         <MiniMap
-          className="bg-slate-800 border border-slate-700 rounded-lg"
+          className="bg-theme-surface border border-theme-border rounded-lg"
           nodeColor={(node) => getNodeColor(node.data?.kind as string || node.data?.type as string || '')}
           maskColor="rgba(15, 23, 42, 0.8)"
         />

--- a/web/src/components/topology/TopologySearch.tsx
+++ b/web/src/components/topology/TopologySearch.tsx
@@ -55,7 +55,7 @@ function getKindColor(kind: string): string {
     case 'Secret':
       return 'text-red-400'
     default:
-      return 'text-slate-400'
+      return 'text-theme-text-secondary'
   }
 }
 
@@ -173,11 +173,11 @@ export function TopologySearch({ nodes, onNodeSelect, onZoomToNode }: TopologySe
       {/* Search trigger button */}
       <button
         onClick={handleOpen}
-        className="absolute top-4 left-4 z-10 flex items-center gap-2 px-3 py-2 bg-slate-800/90 backdrop-blur border border-slate-700 rounded-lg text-slate-400 hover:text-white hover:border-slate-600 transition-colors"
+        className="absolute top-4 left-4 z-10 flex items-center gap-2 px-3 py-2 bg-theme-surface/90 backdrop-blur border border-theme-border rounded-lg text-theme-text-secondary hover:text-theme-text-primary hover:border-theme-border-light transition-colors"
       >
         <Search className="w-4 h-4" />
         <span className="text-sm">Search</span>
-        <kbd className="hidden sm:inline-flex items-center gap-0.5 px-1.5 py-0.5 text-xs bg-slate-700 rounded border border-slate-600">
+        <kbd className="hidden sm:inline-flex items-center gap-0.5 px-1.5 py-0.5 text-xs bg-theme-elevated rounded border border-theme-border-light">
           <span className="text-[10px]">⌘</span>K
         </kbd>
       </button>
@@ -187,15 +187,15 @@ export function TopologySearch({ nodes, onNodeSelect, onZoomToNode }: TopologySe
         <div className="absolute inset-0 z-50 flex items-start justify-center pt-[10vh]">
           {/* Backdrop */}
           <div
-            className="absolute inset-0 bg-slate-900/60 backdrop-blur-sm"
+            className="absolute inset-0 bg-theme-base/60 backdrop-blur-sm"
             onClick={handleClose}
           />
 
           {/* Search panel */}
-          <div className="relative w-full max-w-lg mx-4 bg-slate-800 border border-slate-700 rounded-xl shadow-2xl overflow-hidden">
+          <div className="relative w-full max-w-lg mx-4 bg-theme-surface border border-theme-border rounded-xl shadow-2xl overflow-hidden">
             {/* Search input */}
-            <div className="flex items-center gap-3 px-4 py-3 border-b border-slate-700">
-              <Search className="w-5 h-5 text-slate-400" />
+            <div className="flex items-center gap-3 px-4 py-3 border-b border-theme-border">
+              <Search className="w-5 h-5 text-theme-text-secondary" />
               <input
                 ref={inputRef}
                 type="text"
@@ -203,18 +203,18 @@ export function TopologySearch({ nodes, onNodeSelect, onZoomToNode }: TopologySe
                 onChange={(e) => setQuery(e.target.value)}
                 onKeyDown={handleInputKeyDown}
                 placeholder="Search resources by name, kind, or namespace..."
-                className="flex-1 bg-transparent text-white placeholder-slate-500 outline-none text-sm"
+                className="flex-1 bg-transparent text-theme-text-primary placeholder-theme-text-disabled outline-none text-sm"
                 autoFocus
               />
               {query && (
                 <button
                   onClick={() => setQuery('')}
-                  className="p-1 text-slate-400 hover:text-white"
+                  className="p-1 text-theme-text-secondary hover:text-theme-text-primary"
                 >
                   <X className="w-4 h-4" />
                 </button>
               )}
-              <kbd className="px-1.5 py-0.5 text-xs text-slate-500 bg-slate-700 rounded border border-slate-600">
+              <kbd className="px-1.5 py-0.5 text-xs text-theme-text-tertiary bg-theme-elevated rounded border border-theme-border-light">
                 ESC
               </kbd>
             </div>
@@ -222,7 +222,7 @@ export function TopologySearch({ nodes, onNodeSelect, onZoomToNode }: TopologySe
             {/* Results */}
             <div ref={resultsRef} className="max-h-[60vh] overflow-y-auto">
               {query && filteredNodes.length === 0 && (
-                <div className="px-4 py-8 text-center text-slate-500">
+                <div className="px-4 py-8 text-center text-theme-text-tertiary">
                   <Search className="w-8 h-8 mx-auto mb-2 opacity-50" />
                   <p>No resources found for "{query}"</p>
                 </div>
@@ -240,28 +240,28 @@ export function TopologySearch({ nodes, onNodeSelect, onZoomToNode }: TopologySe
                     onMouseEnter={() => setSelectedIndex(index)}
                     className={clsx(
                       'w-full flex items-center gap-3 px-4 py-3 text-left transition-colors',
-                      isSelected ? 'bg-slate-700/50' : 'hover:bg-slate-700/30'
+                      isSelected ? 'bg-theme-elevated/50' : 'hover:bg-theme-elevated/30'
                     )}
                   >
                     <div className={clsx(
                       'flex items-center justify-center w-8 h-8 rounded-lg',
-                      isSelected ? 'bg-blue-500/20' : 'bg-slate-700/50'
+                      isSelected ? 'bg-blue-500/20' : 'bg-theme-elevated/50'
                     )}>
                       <Icon className={clsx('w-4 h-4', getKindColor(node.kind))} />
                     </div>
 
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2">
-                        <span className="font-medium text-white truncate">{node.name}</span>
+                        <span className="font-medium text-theme-text-primary truncate">{node.name}</span>
                         <span className={clsx(
                           'px-1.5 py-0.5 text-xs rounded',
-                          'bg-slate-700 text-slate-400'
+                          'bg-theme-elevated text-theme-text-secondary'
                         )}>
                           {node.kind}
                         </span>
                       </div>
                       {namespace && (
-                        <div className="text-xs text-slate-500 truncate">
+                        <div className="text-xs text-theme-text-tertiary truncate">
                           {namespace}
                         </div>
                       )}
@@ -269,7 +269,7 @@ export function TopologySearch({ nodes, onNodeSelect, onZoomToNode }: TopologySe
 
                     <ChevronRight className={clsx(
                       'w-4 h-4 transition-opacity',
-                      isSelected ? 'text-slate-400 opacity-100' : 'opacity-0'
+                      isSelected ? 'text-theme-text-secondary opacity-100' : 'opacity-0'
                     )} />
                   </button>
                 )
@@ -278,15 +278,15 @@ export function TopologySearch({ nodes, onNodeSelect, onZoomToNode }: TopologySe
 
             {/* Footer hint */}
             {filteredNodes.length > 0 && (
-              <div className="px-4 py-2 border-t border-slate-700 bg-slate-800/50">
-                <div className="flex items-center gap-4 text-xs text-slate-500">
+              <div className="px-4 py-2 border-t border-theme-border bg-theme-surface/50">
+                <div className="flex items-center gap-4 text-xs text-theme-text-tertiary">
                   <span className="flex items-center gap-1">
-                    <kbd className="px-1 py-0.5 bg-slate-700 rounded">↑</kbd>
-                    <kbd className="px-1 py-0.5 bg-slate-700 rounded">↓</kbd>
+                    <kbd className="px-1 py-0.5 bg-theme-elevated rounded">↑</kbd>
+                    <kbd className="px-1 py-0.5 bg-theme-elevated rounded">↓</kbd>
                     <span>Navigate</span>
                   </span>
                   <span className="flex items-center gap-1">
-                    <kbd className="px-1.5 py-0.5 bg-slate-700 rounded">Enter</kbd>
+                    <kbd className="px-1.5 py-0.5 bg-theme-elevated rounded">Enter</kbd>
                     <span>Zoom to resource</span>
                   </span>
                 </div>
@@ -295,12 +295,12 @@ export function TopologySearch({ nodes, onNodeSelect, onZoomToNode }: TopologySe
 
             {/* Empty state with hints */}
             {!query && (
-              <div className="px-4 py-6 text-center text-slate-500">
+              <div className="px-4 py-6 text-center text-theme-text-tertiary">
                 <p className="text-sm mb-3">Search for resources in the topology</p>
                 <div className="flex flex-wrap justify-center gap-2 text-xs">
-                  <span className="px-2 py-1 bg-slate-700/50 rounded">nginx</span>
-                  <span className="px-2 py-1 bg-slate-700/50 rounded">service/api</span>
-                  <span className="px-2 py-1 bg-slate-700/50 rounded">production</span>
+                  <span className="px-2 py-1 bg-theme-elevated/50 rounded">nginx</span>
+                  <span className="px-2 py-1 bg-theme-elevated/50 rounded">service/api</span>
+                  <span className="px-2 py-1 bg-theme-elevated/50 rounded">production</span>
                 </div>
               </div>
             )}

--- a/web/src/components/ui/CodeViewer.tsx
+++ b/web/src/components/ui/CodeViewer.tsx
@@ -66,7 +66,7 @@ export function CodeViewer({
       {showCopyButton && (
         <button
           onClick={handleCopy}
-          className="absolute top-2 right-2 z-10 flex items-center gap-1 px-2 py-1 text-xs text-slate-400 hover:text-white bg-slate-800/80 hover:bg-slate-700 rounded backdrop-blur-sm"
+          className="absolute top-2 right-2 z-10 flex items-center gap-1 px-2 py-1 text-xs text-theme-text-secondary hover:text-theme-text-primary bg-theme-surface/80 hover:bg-theme-elevated rounded backdrop-blur-sm"
         >
           {copied ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
           Copy
@@ -78,7 +78,7 @@ export function CodeViewer({
         style={{ maxHeight }}
       >
         {highlighting ? (
-          <div className="p-4 text-slate-500 text-sm font-mono">Loading...</div>
+          <div className="p-4 text-theme-text-tertiary text-sm font-mono">Loading...</div>
         ) : (
           <div
             className={`shiki-viewer text-xs ${showLineNumbers ? 'with-line-numbers' : ''}`}

--- a/web/src/components/ui/ConfirmDialog.tsx
+++ b/web/src/components/ui/ConfirmDialog.tsx
@@ -65,10 +65,10 @@ export function ConfirmDialog({
       <div
         ref={dialogRef}
         tabIndex={-1}
-        className="relative bg-slate-800 border border-slate-700 rounded-lg shadow-2xl max-w-md w-full mx-4 outline-none"
+        className="relative bg-theme-surface border border-theme-border rounded-lg shadow-2xl max-w-md w-full mx-4 outline-none"
       >
         {/* Header */}
-        <div className="flex items-start gap-3 p-4 border-b border-slate-700">
+        <div className="flex items-start gap-3 p-4 border-b border-theme-border">
           <div
             className={clsx(
               'flex items-center justify-center w-10 h-10 rounded-full shrink-0',
@@ -80,13 +80,13 @@ export function ConfirmDialog({
             />
           </div>
           <div className="flex-1 min-w-0">
-            <h3 className="text-lg font-semibold text-white">{title}</h3>
-            <p className="text-sm text-slate-400 mt-1">{message}</p>
+            <h3 className="text-lg font-semibold text-theme-text-primary">{title}</h3>
+            <p className="text-sm text-theme-text-secondary mt-1">{message}</p>
           </div>
           <button
             onClick={onClose}
             disabled={isLoading}
-            className="p-1 text-slate-400 hover:text-white hover:bg-slate-700 rounded disabled:opacity-50"
+            className="p-1 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded disabled:opacity-50"
           >
             <X className="w-5 h-5" />
           </button>
@@ -94,8 +94,8 @@ export function ConfirmDialog({
 
         {/* Details */}
         {details && (
-          <div className="p-4 border-b border-slate-700">
-            <pre className="text-xs text-slate-300 bg-slate-900/50 rounded p-3 overflow-auto max-h-32 whitespace-pre-wrap font-mono">
+          <div className="p-4 border-b border-theme-border">
+            <pre className="text-xs text-theme-text-secondary bg-theme-base/50 rounded p-3 overflow-auto max-h-32 whitespace-pre-wrap font-mono">
               {details}
             </pre>
           </div>
@@ -121,11 +121,11 @@ export function ConfirmDialog({
         </div>
 
         {/* Actions */}
-        <div className="flex items-center justify-end gap-3 p-4 border-t border-slate-700">
+        <div className="flex items-center justify-end gap-3 p-4 border-t border-theme-border">
           <button
             onClick={onClose}
             disabled={isLoading}
-            className="px-4 py-2 text-sm font-medium text-slate-300 hover:text-white hover:bg-slate-700 rounded-lg transition-colors disabled:opacity-50"
+            className="px-4 py-2 text-sm font-medium text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded-lg transition-colors disabled:opacity-50"
           >
             {cancelLabel}
           </button>
@@ -135,8 +135,8 @@ export function ConfirmDialog({
             className={clsx(
               'px-4 py-2 text-sm font-medium rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2',
               isDanger
-                ? 'bg-red-600 hover:bg-red-700 text-white'
-                : 'bg-amber-600 hover:bg-amber-700 text-white'
+                ? 'bg-red-600 hover:bg-red-700 text-theme-text-primary'
+                : 'bg-amber-600 hover:bg-amber-700 text-theme-text-primary'
             )}
           >
             {isLoading && (

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -89,7 +89,7 @@ function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: () => void }
     <div
       className={clsx(
         'flex items-start gap-3 p-3 rounded-lg shadow-xl border animate-in',
-        'bg-slate-800 border-slate-700',
+        'bg-theme-surface border-theme-border',
         'w-[400px] max-w-[calc(100vw-32px)]'
       )}
       style={style}
@@ -109,11 +109,11 @@ function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: () => void }
       {/* Content */}
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-white">{toast.message}</span>
+          <span className="text-sm font-medium text-theme-text-primary">{toast.message}</span>
           <Check className="w-3.5 h-3.5 text-green-400 shrink-0" />
         </div>
         {toast.command && (
-          <code className="block mt-1.5 text-xs text-slate-300 font-mono bg-slate-900 rounded px-2 py-1.5 whitespace-pre-wrap break-all">
+          <code className="block mt-1.5 text-xs text-theme-text-secondary font-mono bg-theme-base rounded px-2 py-1.5 whitespace-pre-wrap break-all">
             {toast.command}
           </code>
         )}
@@ -122,7 +122,7 @@ function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: () => void }
       {/* Dismiss button */}
       <button
         onClick={onDismiss}
-        className="p-1 text-slate-500 hover:text-white rounded hover:bg-slate-700 shrink-0"
+        className="p-1 text-theme-text-tertiary hover:text-theme-text-primary rounded hover:bg-theme-elevated shrink-0"
       >
         <X className="w-4 h-4" />
       </button>

--- a/web/src/components/ui/Tooltip.tsx
+++ b/web/src/components/ui/Tooltip.tsx
@@ -124,7 +124,7 @@ export function Tooltip({
           <span
             ref={tooltipRef}
             className={clsx(
-              'fixed z-[9999] px-2 py-1 text-xs text-white bg-slate-900 rounded shadow-lg',
+              'fixed z-[9999] px-2 py-1 text-xs text-theme-text-primary bg-theme-base rounded shadow-lg',
               'whitespace-nowrap pointer-events-none',
               className
             )}

--- a/web/src/context/ThemeContext.tsx
+++ b/web/src/context/ThemeContext.tsx
@@ -1,0 +1,74 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+
+type Theme = 'dark' | 'light'
+
+interface ThemeContextType {
+  theme: Theme
+  setTheme: (theme: Theme) => void
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
+
+const THEME_STORAGE_KEY = 'skyhook-explorer-theme'
+
+function getInitialTheme(): Theme {
+  // Check localStorage first
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY)
+    if (stored === 'light' || stored === 'dark') {
+      return stored
+    }
+    // Check system preference
+    if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+      return 'light'
+    }
+  }
+  return 'dark' // Default to dark
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(getInitialTheme)
+
+  const setTheme = (newTheme: Theme) => {
+    setThemeState(newTheme)
+    localStorage.setItem(THEME_STORAGE_KEY, newTheme)
+  }
+
+  const toggleTheme = () => {
+    setTheme(theme === 'dark' ? 'light' : 'dark')
+  }
+
+  // Apply theme to document
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme)
+  }, [theme])
+
+  // Listen for system theme changes
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: light)')
+    const handleChange = (e: MediaQueryListEvent) => {
+      // Only auto-switch if user hasn't explicitly set a preference
+      const stored = localStorage.getItem(THEME_STORAGE_KEY)
+      if (!stored) {
+        setThemeState(e.matches ? 'light' : 'dark')
+      }
+    }
+    mediaQuery.addEventListener('change', handleChange)
+    return () => mediaQuery.removeEventListener('change', handleChange)
+  }, [])
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext)
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider')
+  }
+  return context
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -2,18 +2,124 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ============================================
+   THEME SYSTEM - Central Color Definitions
+   ============================================ */
+
 :root {
+  /* Font settings */
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-  color-scheme: dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #0f172a;
+
+  /* Skyhook Brand */
+  --color-brand: #2D7AFF;
+  --color-brand-light: #5A9AFF;
+  --color-brand-dark: #1A5FCC;
+
+  /* Semantic Status Colors (same for both themes) */
+  --color-success: #22C55E;
+  --color-success-light: #4ADE80;
+  --color-success-dark: #16A34A;
+  --color-warning: #F59E0B;
+  --color-warning-light: #FBBF24;
+  --color-warning-dark: #D97706;
+  --color-error: #EF4444;
+  --color-error-light: #F87171;
+  --color-error-dark: #DC2626;
+  --color-info: #3B82F6;
 }
+
+/* Dark Theme (default) */
+:root,
+[data-theme="dark"] {
+  color-scheme: dark;
+
+  /* Backgrounds */
+  --bg-base: #0f172a;        /* slate-900 - main background */
+  --bg-surface: #1e293b;     /* slate-800 - cards, panels */
+  --bg-elevated: #334155;    /* slate-700 - elevated elements */
+  --bg-hover: #475569;       /* slate-600 - hover states */
+  --bg-active: #1e3a5f;      /* blue tinted - active/selected */
+
+  /* Text */
+  --text-primary: #f8fafc;   /* slate-50 - headings, primary text */
+  --text-secondary: #cbd5e1; /* slate-300 - body text */
+  --text-tertiary: #94a3b8;  /* slate-400 - muted text */
+  --text-disabled: #64748b;  /* slate-500 - disabled text */
+
+  /* Borders */
+  --border-default: #334155; /* slate-700 */
+  --border-light: #475569;   /* slate-600 */
+  --border-subtle: rgba(255, 255, 255, 0.02);  /* very subtle white for table dividers */
+  --border-focus: var(--color-brand);
+
+  /* Accent (uses brand) */
+  --accent: var(--color-brand);
+  --accent-light: var(--color-brand-light);
+  --accent-muted: rgba(45, 122, 255, 0.2);
+  --accent-text: #93c5fd;    /* blue-300 */
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.3);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.4);
+
+  /* Scrollbar */
+  --scrollbar-track: #1e293b;
+  --scrollbar-thumb: #475569;
+  --scrollbar-thumb-hover: #64748b;
+}
+
+/* Light Theme */
+[data-theme="light"] {
+  color-scheme: light;
+
+  /* Backgrounds */
+  --bg-base: #f8fafc;        /* slate-50 - main background */
+  --bg-surface: #ffffff;     /* white - cards, panels */
+  --bg-elevated: #f1f5f9;    /* slate-100 - elevated elements */
+  --bg-hover: #e2e8f0;       /* slate-200 - hover states */
+  --bg-active: #dbeafe;      /* blue-100 - active/selected */
+
+  /* Text */
+  --text-primary: #0f172a;   /* slate-900 - headings, primary text */
+  --text-secondary: #475569; /* slate-600 - body text */
+  --text-tertiary: #64748b;  /* slate-500 - muted text */
+  --text-disabled: #94a3b8;  /* slate-400 - disabled text */
+
+  /* Borders */
+  --border-default: #e2e8f0; /* slate-200 */
+  --border-light: #cbd5e1;   /* slate-300 */
+  --border-subtle: rgba(0, 0, 0, 0.06);  /* very subtle black for table dividers */
+  --border-focus: var(--color-brand);
+
+  /* Accent (uses brand) */
+  --accent: var(--color-brand);
+  --accent-light: var(--color-brand-dark);
+  --accent-muted: rgba(45, 122, 255, 0.1);
+  --accent-text: #1d4ed8;    /* blue-700 */
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+
+  /* Scrollbar */
+  --scrollbar-track: #f1f5f9;
+  --scrollbar-thumb: #cbd5e1;
+  --scrollbar-thumb-hover: #94a3b8;
+}
+
+/* ============================================
+   BASE STYLES
+   ============================================ */
 
 body {
   margin: 0;
   min-height: 100vh;
+  background-color: var(--bg-base);
+  color: var(--text-primary);
 }
 
 #root {
@@ -22,7 +128,49 @@ body {
   flex-direction: column;
 }
 
-/* React Flow customizations */
+/* ============================================
+   SUBTLE BORDERS (theme-aware)
+   ============================================ */
+
+/* Table row dividers */
+[data-theme="dark"] .table-divide-subtle > * + * {
+  border-top-color: rgba(255, 255, 255, 0.07);
+}
+
+[data-theme="light"] .table-divide-subtle > * + *,
+:root:not([data-theme]) .table-divide-subtle > * + * {
+  border-top-color: rgba(0, 0, 0, 0.08);
+}
+
+.table-divide-subtle > * + * {
+  border-top-width: 1px;
+  border-top-style: solid;
+}
+
+/* Subtle bottom border for rows */
+[data-theme="dark"] .border-b-subtle {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+[data-theme="light"] .border-b-subtle,
+:root:not([data-theme]) .border-b-subtle {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+/* Subtle top border */
+[data-theme="dark"] .border-t-subtle {
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+[data-theme="light"] .border-t-subtle,
+:root:not([data-theme]) .border-t-subtle {
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+/* ============================================
+   REACT FLOW CUSTOMIZATIONS
+   ============================================ */
+
 .react-flow__node {
   cursor: pointer;
 }
@@ -40,27 +188,27 @@ body {
   display: none;
 }
 
-/* React Flow Controls - Dark Theme */
+/* React Flow Controls */
 .react-flow__controls {
-  background: #1e293b;
-  border: 1px solid #334155;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
   border-radius: 8px;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-md);
 }
 
 .react-flow__controls-button {
-  background: #1e293b;
+  background: var(--bg-surface);
   border: none;
-  border-bottom: 1px solid #334155;
-  color: #94a3b8;
+  border-bottom: 1px solid var(--border-default);
+  color: var(--text-tertiary);
   width: 28px;
   height: 28px;
   padding: 5px;
 }
 
 .react-flow__controls-button:hover {
-  background: #334155;
-  color: #f1f5f9;
+  background: var(--bg-elevated);
+  color: var(--text-primary);
 }
 
 .react-flow__controls-button:last-child {
@@ -71,37 +219,47 @@ body {
   fill: currentColor;
 }
 
-/* React Flow MiniMap - Dark Theme */
+/* React Flow MiniMap */
 .react-flow__minimap {
-  background: #1e293b;
-  border: 1px solid #334155;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
   border-radius: 8px;
 }
 
-.react-flow__minimap-mask {
+[data-theme="dark"] .react-flow__minimap-mask {
   fill: rgba(15, 23, 42, 0.8);
 }
 
-/* Custom scrollbar */
+[data-theme="light"] .react-flow__minimap-mask {
+  fill: rgba(248, 250, 252, 0.8);
+}
+
+/* ============================================
+   CUSTOM SCROLLBAR
+   ============================================ */
+
 ::-webkit-scrollbar {
   width: 8px;
   height: 8px;
 }
 
 ::-webkit-scrollbar-track {
-  background: #1e293b;
+  background: var(--scrollbar-track);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #475569;
+  background: var(--scrollbar-thumb);
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #64748b;
+  background: var(--scrollbar-thumb-hover);
 }
 
-/* Toast animations */
+/* ============================================
+   ANIMATIONS
+   ============================================ */
+
 @keyframes slide-in-from-right {
   from {
     transform: translateX(100%);
@@ -132,4 +290,124 @@ body {
 
 .fade-in {
   animation: slide-in-from-right 0.2s ease-out;
+}
+
+/* ============================================
+   UTILITY CLASSES (theme-aware)
+   ============================================ */
+
+/* Backgrounds */
+.bg-theme-base { background-color: var(--bg-base); }
+.bg-theme-surface { background-color: var(--bg-surface); }
+.bg-theme-elevated { background-color: var(--bg-elevated); }
+.bg-theme-hover { background-color: var(--bg-hover); }
+.bg-theme-active { background-color: var(--bg-active); }
+
+/* Text */
+.text-theme-primary { color: var(--text-primary); }
+.text-theme-secondary { color: var(--text-secondary); }
+.text-theme-tertiary { color: var(--text-tertiary); }
+.text-theme-disabled { color: var(--text-disabled); }
+
+/* Borders */
+.border-theme { border-color: var(--border-default); }
+.border-theme-light { border-color: var(--border-light); }
+
+/* Accent */
+.bg-accent { background-color: var(--accent); }
+.bg-accent-muted { background-color: var(--accent-muted); }
+.text-accent { color: var(--accent); }
+.text-accent-text { color: var(--accent-text); }
+.border-accent { border-color: var(--accent); }
+
+/* Interactive states */
+.hover\:bg-theme-hover:hover { background-color: var(--bg-hover); }
+.hover\:bg-theme-elevated:hover { background-color: var(--bg-elevated); }
+.focus\:ring-accent:focus { --tw-ring-color: var(--accent); }
+
+/* ============================================
+   STATUS BADGE COLORS (theme-aware)
+   ============================================ */
+
+/* Healthy/Success - green */
+.status-healthy {
+  background-color: rgba(34, 197, 94, 0.15);
+  color: #16a34a; /* green-600 */
+}
+[data-theme="dark"] .status-healthy {
+  background-color: rgba(34, 197, 94, 0.2);
+  color: #4ade80; /* green-400 */
+}
+
+/* Degraded/Warning - yellow/amber */
+.status-degraded {
+  background-color: rgba(245, 158, 11, 0.15);
+  color: #d97706; /* amber-600 */
+}
+[data-theme="dark"] .status-degraded {
+  background-color: rgba(245, 158, 11, 0.2);
+  color: #fbbf24; /* amber-400 */
+}
+
+/* Unhealthy/Error - red */
+.status-unhealthy {
+  background-color: rgba(239, 68, 68, 0.15);
+  color: #dc2626; /* red-600 */
+}
+[data-theme="dark"] .status-unhealthy {
+  background-color: rgba(239, 68, 68, 0.2);
+  color: #f87171; /* red-400 */
+}
+
+/* Neutral/Info - blue */
+.status-neutral {
+  background-color: rgba(59, 130, 246, 0.15);
+  color: #2563eb; /* blue-600 */
+}
+[data-theme="dark"] .status-neutral {
+  background-color: rgba(59, 130, 246, 0.2);
+  color: #60a5fa; /* blue-400 */
+}
+
+/* Unknown/Muted - gray */
+.status-unknown {
+  background-color: var(--bg-elevated);
+  color: var(--text-secondary);
+}
+
+/* Special status colors */
+.status-violet {
+  background-color: rgba(139, 92, 246, 0.15);
+  color: #7c3aed; /* violet-600 */
+}
+[data-theme="dark"] .status-violet {
+  background-color: rgba(139, 92, 246, 0.2);
+  color: #a78bfa; /* violet-400 */
+}
+
+.status-purple {
+  background-color: rgba(168, 85, 247, 0.15);
+  color: #9333ea; /* purple-600 */
+}
+[data-theme="dark"] .status-purple {
+  background-color: rgba(168, 85, 247, 0.2);
+  color: #c084fc; /* purple-400 */
+}
+
+.status-orange {
+  background-color: rgba(249, 115, 22, 0.15);
+  color: #ea580c; /* orange-600 */
+}
+[data-theme="dark"] .status-orange {
+  background-color: rgba(249, 115, 22, 0.2);
+  color: #fb923c; /* orange-400 */
+}
+
+.status-cyan {
+  background-color: rgba(6, 182, 212, 0.15);
+  color: #0891b2; /* cyan-600 */
+}
+[data-theme="dark"] .status-cyan {
+  background-color: rgba(6, 182, 212, 0.2);
+  color: #22d3ee; /* cyan-400 */
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { BrowserRouter } from 'react-router-dom'
 import App from './App'
 import { ToastProvider } from './components/ui/Toast'
+import { ThemeProvider } from './context/ThemeContext'
 import './index.css'
 
 const queryClient = new QueryClient({
@@ -16,10 +18,14 @@ const queryClient = new QueryClient({
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <ToastProvider>
-        <App />
-      </ToastProvider>
-    </QueryClientProvider>
+    <BrowserRouter>
+      <ThemeProvider>
+        <QueryClientProvider client={queryClient}>
+          <ToastProvider>
+            <App />
+          </ToastProvider>
+        </QueryClientProvider>
+      </ThemeProvider>
+    </BrowserRouter>
   </React.StrictMode>
 )

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -7,6 +7,31 @@ export default {
   theme: {
     extend: {
       colors: {
+        // Theme-aware colors (use CSS variables)
+        'theme': {
+          'base': 'var(--bg-base)',
+          'surface': 'var(--bg-surface)',
+          'elevated': 'var(--bg-elevated)',
+          'hover': 'var(--bg-hover)',
+          'active': 'var(--bg-active)',
+        },
+        'theme-text': {
+          'primary': 'var(--text-primary)',
+          'secondary': 'var(--text-secondary)',
+          'tertiary': 'var(--text-tertiary)',
+          'disabled': 'var(--text-disabled)',
+        },
+        'theme-border': {
+          DEFAULT: 'var(--border-default)',
+          'light': 'var(--border-light)',
+          'subtle': 'var(--border-subtle)',
+        },
+        'accent': {
+          DEFAULT: 'var(--accent)',
+          'light': 'var(--accent-light)',
+          'muted': 'var(--accent-muted)',
+          'text': 'var(--accent-text)',
+        },
         // Skyhook brand colors
         'skyhook': {
           DEFAULT: '#2D7AFF',
@@ -35,6 +60,17 @@ export default {
         'k8s-hpa': '#ec4899',
         'k8s-job': '#a855f7',
         'k8s-cronjob': '#d946ef',
+      },
+      boxShadow: {
+        'theme-sm': 'var(--shadow-sm)',
+        'theme-md': 'var(--shadow-md)',
+        'theme-lg': 'var(--shadow-lg)',
+      },
+      ringColor: {
+        'accent': 'var(--accent)',
+      },
+      ringOffsetColor: {
+        'theme-base': 'var(--bg-base)',
       },
     },
   },

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -23,4 +23,6 @@ export default defineConfig({
     outDir: 'dist',
     emptyOutDir: true,
   },
+  // Handle client-side routing - serve index.html for all routes
+  appType: 'spa',
 })


### PR DESCRIPTION
## Summary
- Add comprehensive light/dark theme system with CSS variables and React context
- Replace query param routing (`?view=events`) with clean path-based URLs (`/events`)
- Migrate all components from hardcoded colors to theme-aware variables

## Changes

### Theme System
- Central CSS variables defined in `index.css` for both dark (default) and light themes
- `ThemeContext` provides state management with localStorage persistence
- Theme toggle button in header with sun/moon icons
- Theme-aware Tailwind classes via custom color configuration

### URL Routing
- Path-based routing: `/topology`, `/resources`, `/events`, `/helm`
- Automatic cleanup of view-specific params when switching views
- Namespace param preserved across navigation
- SPA config in vite.config.ts for client-side routing

### Component Updates
- All components migrated from `slate-*` to `theme-*` color classes
- Custom subtle border classes for theme-aware table dividers
- Fixed drawer dividers to use theme-aware borders

## Test plan
- [ ] Verify theme toggle switches between light and dark modes
- [ ] Verify theme persists across page reloads (localStorage)
- [ ] Test URL routing: navigating to `/events`, `/resources`, `/helm`, `/topology`
- [ ] Verify namespace param preserved when switching views
- [ ] Check table dividers visible but subtle in both themes
- [ ] Test responsive behavior on different screen widths