### PR TITLE
Update documentation with comprehensive feature coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 ## Project Overview
 
-Skyhook Explorer is an open-source Kubernetes cluster visualization tool that provides real-time topology views and event monitoring. It runs as a kubectl plugin or standalone binary and opens a web UI in the browser.
+Skyhook Explorer is an open-source Kubernetes cluster visualization tool that provides real-time topology views, event monitoring, pod terminal access, log streaming, port forwarding, and Helm release management. It runs as a kubectl plugin (`kubectl-explorer`) or standalone binary and opens a web UI in the browser.
 
 ## Architecture
 
@@ -13,7 +13,7 @@ Skyhook Explorer is an open-source Kubernetes cluster visualization tool that pr
 │                         User's Machine                          │
 │                                                                 │
 │   ┌─────────────────┐                   ┌───────────────────┐  │
-│   │    Browser      │◄─── HTTP/SSE ────►│  Explorer Binary  │  │
+│   │    Browser      │◄── HTTP/SSE/WS ──►│  Explorer Binary  │  │
 │   │  (React + UI)   │                   │  (Go + Embedded)  │  │
 │   └─────────────────┘                   └───────────────────┘  │
 │                                                  │              │
@@ -34,35 +34,65 @@ Skyhook Explorer is an open-source Kubernetes cluster visualization tool that pr
 
 ```
 skyhook-explorer/
-├── cmd/explorer/           # CLI entry point
+├── cmd/explorer/              # CLI entry point (main.go)
 ├── internal/
-│   ├── k8s/               # K8s client, caching (SharedInformers)
-│   ├── server/            # chi HTTP server, REST API, SSE
-│   └── topology/          # Graph construction logic
-├── web/                   # React frontend (embedded at build)
+│   ├── helm/                  # Helm client integration
+│   │   ├── client.go          # Helm SDK wrapper
+│   │   ├── handlers.go        # HTTP handlers for Helm operations
+│   │   └── types.go           # Helm release types
+│   ├── k8s/
+│   │   ├── cache.go           # Typed informer caching
+│   │   ├── client.go          # K8s client initialization
+│   │   ├── cluster_detection.go # GKE/EKS/AKS platform detection
+│   │   ├── discovery.go       # API resource discovery for CRDs
+│   │   ├── dynamic_cache.go   # CRD/dynamic resource support
+│   │   ├── history.go         # Change history tracking
+│   │   └── update.go          # Resource update/delete operations
+│   ├── server/
+│   │   ├── server.go          # chi router, main REST endpoints
+│   │   ├── sse.go             # Server-Sent Events broadcaster
+│   │   ├── exec.go            # WebSocket pod terminal exec
+│   │   ├── logs.go            # Pod logs streaming
+│   │   └── portforward.go     # Port forwarding sessions
+│   ├── static/                # Embedded frontend files
+│   └── topology/
+│       ├── builder.go         # Topology graph construction
+│       ├── relationships.go   # Resource relationship detection
+│       └── types.go           # Node, edge, topology definitions
+├── web/                       # React frontend (embedded at build)
 │   ├── src/
-│   │   ├── api/           # API client + SSE hooks
-│   │   ├── components/    # React components
-│   │   └── utils/         # Topology utilities
+│   │   ├── api/               # API client + SSE hooks
+│   │   ├── components/
+│   │   │   ├── dock/          # Bottom dock with terminal/logs tabs
+│   │   │   ├── events/        # Events timeline view
+│   │   │   ├── helm/          # Helm release management UI
+│   │   │   ├── logs/          # Logs viewer component
+│   │   │   ├── portforward/   # Port forward manager
+│   │   │   ├── resources/     # Resource list/detail panels
+│   │   │   ├── topology/      # Graph visualization
+│   │   │   └── ui/            # Base shadcn/ui components
+│   │   ├── types.ts           # TypeScript type definitions
+│   │   └── utils/             # Topology and utility functions
 │   └── package.json
-└── deploy/                # Docker, Helm, Krew configs
+├── deploy/                    # Docker, Helm, Krew configs
+└── Makefile
 ```
 
 ## Development Commands
 
 ### Backend (Go)
 ```bash
-# Build
+# Build binary
 go build -o explorer ./cmd/explorer
 
-# Run locally (without embedding frontend)
+# Run in dev mode (serves frontend from filesystem, not embedded)
 go run ./cmd/explorer --dev
 
 # Run tests
 go test ./...
 
-# Build with embedded frontend
-make build
+# Hot reload with Air (port 9280)
+make watch-backend
 ```
 
 ### Frontend (React)
@@ -72,10 +102,10 @@ cd web
 # Install dependencies
 npm install
 
-# Development server (with hot reload)
+# Development server with hot reload (port 9273)
 npm run dev
 
-# Build for production
+# Build for production (outputs to web/dist)
 npm run build
 
 # Type check
@@ -89,60 +119,177 @@ make build
 
 # Run the complete application
 ./explorer
+
+# Other Makefile targets
+make frontend       # Build frontend only
+make backend        # Build backend only
+make watch-frontend # Vite dev server (port 9273)
+make watch-backend  # Air hot reload (port 9280)
+make test           # Run all tests
+make docker         # Build Docker image
+```
+
+### Development Ports
+- **9280**: Backend API server (Go)
+- **9273**: Vite dev server (proxies /api to 9280)
+
+## CLI Flags
+
+```
+--kubeconfig        Path to kubeconfig file (default: ~/.kube/config)
+--namespace         Initial namespace filter (empty = all namespaces)
+--port              Server port (default: 9280)
+--no-browser        Don't auto-open browser
+--dev               Development mode (serve frontend from web/dist instead of embedded)
+--version           Show version and exit
+--persist-history   Persist change history to file
+--history-limit     Maximum number of changes to retain in history (default: 1000)
+```
+
+## API Endpoints
+
+### Core
+```
+GET  /api/health                              # Health check with resource count
+GET  /api/cluster-info                        # Platform detection (GKE, EKS, AKS, etc.)
+GET  /api/namespaces                          # List all namespaces
+GET  /api/api-resources                       # API resource discovery for CRDs
+```
+
+### Topology
+```
+GET  /api/topology                            # Full topology graph
+GET  /api/topology?namespace=X                # Namespace-filtered
+GET  /api/topology?view=traffic|resources     # View mode selection
+```
+
+### Resources
+```
+GET    /api/resources/{kind}                  # List resources by kind
+GET    /api/resources/{kind}?namespace=X      # Namespace-filtered list
+GET    /api/resources/{kind}/{ns}/{name}      # Single resource with relationships
+PUT    /api/resources/{kind}/{ns}/{name}      # Update resource from YAML
+DELETE /api/resources/{kind}/{ns}/{name}      # Delete resource
+```
+
+### Events & Changes
+```
+GET  /api/events                              # Recent K8s events
+GET  /api/events?namespace=X                  # Namespace-filtered events
+GET  /api/events/stream                       # SSE stream for real-time events
+GET  /api/changes                             # Timeline of resource changes
+GET  /api/changes?namespace=X&kind=Y&limit=N  # Filtered change history
+GET  /api/changes/{kind}/{ns}/{name}/children # Child resource changes
+```
+
+### Pod Operations
+```
+GET  /api/pods/{ns}/{name}/logs               # Fetch pod logs (non-streaming)
+GET  /api/pods/{ns}/{name}/logs/stream        # Stream pod logs via SSE
+GET  /api/pods/{ns}/{name}/exec               # WebSocket for pod terminal exec
+```
+
+### Port Forwarding
+```
+GET    /api/portforwards                           # List active port forward sessions
+POST   /api/portforwards                           # Start a new port forward
+DELETE /api/portforwards/{id}                      # Stop a port forward
+GET    /api/portforwards/available/{type}/{ns}/{name} # Get available ports for pod/service
+```
+
+### Helm Management
+```
+GET    /api/helm/releases                          # List all Helm releases
+GET    /api/helm/releases/{ns}/{name}              # Get release details
+GET    /api/helm/releases/{ns}/{name}/manifest     # Get rendered manifest
+GET    /api/helm/releases/{ns}/{name}/values       # Get release values
+GET    /api/helm/releases/{ns}/{name}/diff         # Diff between revisions
+GET    /api/helm/releases/{ns}/{name}/upgrade-info # Check upgrade availability
+GET    /api/helm/upgrade-check                     # Batch check for upgrades
+POST   /api/helm/releases/{ns}/{name}/rollback     # Rollback to previous revision
+POST   /api/helm/releases/{ns}/{name}/upgrade      # Upgrade to new version
+DELETE /api/helm/releases/{ns}/{name}              # Uninstall release
 ```
 
 ## Key Patterns
 
 ### K8s Caching
-- Uses SharedInformers for watch-based caching
-- Provides 50-100x latency improvement over direct API calls
-- Memory-efficient with field stripping (managed fields, annotations)
-- Change notifications via channel for real-time updates
+- Uses SharedInformers for watch-based caching of typed resources
+- Dynamic caching for CRDs and custom resource types via API discovery
+- Memory-efficient with field stripping (removes managed fields, last-applied annotations)
+- Change notifications via channel for real-time SSE updates
+- Supports: Pods, Services, Deployments, DaemonSets, StatefulSets, ReplicaSets, Ingresses, ConfigMaps, Secrets, Events, Jobs, CronJobs, HPAs, PVCs, Nodes, Namespaces
 
 ### Server-Sent Events (SSE)
-- Real-time updates pushed to browser via `/api/events/stream`
-- Topology changes, K8s events, heartbeats
-- Auto-reconnects on connection drop
+- Central `SSEBroadcaster` manages connected clients
+- Per-client namespace filters and view mode tracking
+- Cached topology for relationship lookups
+- Heartbeat mechanism for connection health
+- Event types: topology changes, K8s events, resource updates
+
+### WebSocket Pod Exec
+- Full terminal emulation via xterm.js in browser
+- Container and shell selection support
+- Terminal resize handling with size queue
+- TTY, stdin, stdout, stderr support
 
 ### Topology Builder
-- Constructs graph from K8s resources
-- Supports two view modes: 'traffic' (network flow) and 'resources' (full hierarchy)
-- Node types: Ingress, Service, Deployment, ReplicaSet, Pod, ConfigMap, Secret, HPA
+- Constructs directed graph from K8s resources
+- Owner reference traversal for parent-child relationships
+- Selector-based matching for Service→Pod, Deployment→ReplicaSet
+- Two view modes:
+  - `traffic`: Network flow (Ingress → Service → Pod)
+  - `resources`: Full hierarchy (Deployment → ReplicaSet → Pod)
+- Node types: Ingress, Service, Deployment, DaemonSet, StatefulSet, ReplicaSet, Pod, Job, CronJob, ConfigMap, Secret, HPA, PVC
 
-## API Endpoints
+### Change History
+- Ring buffer for in-memory change tracking
+- Optional file persistence in JSONL format (`--persist-history`)
+- Records: resource kind, name, namespace, change type, timestamp, owner info, health state
+- Configurable limit (default: 1000 changes)
 
-```
-GET  /api/health                    # Health check
-GET  /api/topology                  # Full topology graph
-GET  /api/topology?namespace=X      # Namespace-filtered
-GET  /api/resources/:kind           # List resources by kind
-GET  /api/resources/:kind/:ns/:name # Single resource detail
-GET  /api/events                    # Recent K8s events
-GET  /api/events/stream             # SSE stream for real-time
-GET  /api/cluster-info              # Platform detection (GKE, EKS, etc.)
-```
-
-## CLI Flags
-
-```
---kubeconfig    Path to kubeconfig (default: ~/.kube/config)
---namespace     Initial namespace filter (default: all)
---port          Server port (default: 8080)
---no-browser    Don't auto-open browser
---dev           Development mode (serve frontend from web/dist)
-```
+### Resource Relationships
+- Computed at query time for resource detail views
+- Tracks: parent (owner), children (owned), config (ConfigMaps/Secrets), network (Services/Ingresses)
+- Used for topology edges and change propagation
 
 ## Tech Stack
 
 ### Backend
 - Go 1.22+
-- client-go (K8s client)
-- chi (HTTP router)
+- client-go (K8s client library)
+- chi (HTTP router with middleware)
+- gorilla/websocket (WebSocket support for exec)
+- helm.sh/helm/v3 (Helm SDK)
 - go:embed (frontend embedding)
 
 ### Frontend
 - React 18 + TypeScript
-- Vite (build tool)
-- Xyflow/ReactFlow + ELK.js (graph visualization)
+- Vite (build tool, dev server)
+- @xyflow/react + elkjs (graph visualization and layout)
+- @xterm/xterm + @xterm/addon-fit (terminal emulation)
+- @monaco-editor/react (YAML editing)
+- shiki (syntax highlighting)
+- @tanstack/react-query v5 (server state management)
+- react-router-dom (client-side routing)
 - Tailwind CSS + shadcn/ui (styling)
-- TanStack Query v5 (server state)
+- Lucide React (icons)
+- yaml (YAML parsing)
+
+## Server Configuration
+
+### Middleware Stack
+- Logger, Recoverer (panic recovery)
+- 60-second request timeout
+- CORS enabled for `http://localhost:*` and `http://127.0.0.1:*`
+
+### Vite Dev Proxy
+In development, Vite proxies `/api` requests to the backend:
+```javascript
+proxy: {
+  '/api': {
+    target: 'http://localhost:9280',
+    ws: true  // WebSocket support for exec
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![CI](https://github.com/skyhook-io/explorer/actions/workflows/ci.yml/badge.svg)](https://github.com/skyhook-io/explorer/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![Go](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go&logoColor=white)](https://go.dev/)
+[![Go](https://img.shields.io/badge/Go-1.22+-00ADD8?logo=go&logoColor=white)](https://go.dev/)
 
-Real-time Kubernetes cluster topology visualization in your browser.
+Real-time Kubernetes cluster visualization and management in your browser.
 
 <p align="center">
   <img src="docs/screenshot.png" alt="Skyhook Explorer Screenshot" width="800">
@@ -12,13 +12,34 @@ Real-time Kubernetes cluster topology visualization in your browser.
 
 ## Features
 
-- **Real-time topology graph** - See your pods, deployments, services, and ingresses connected
+### Cluster Visualization
+- **Real-time topology graph** - See pods, deployments, services, and ingresses connected
 - **Live event stream** - Watch resource changes as they happen
-- **Resource details** - Click any node to see full resource information
-- **Namespace filtering** - Focus on specific namespaces
+- **Resource details** - Click any node to see full resource information with YAML editor
 - **Multiple view modes** - Traffic view (network path) or Resources view (hierarchy)
+- **Change history** - Track resource changes over time with optional persistence
+
+### Pod Operations
+- **Terminal access** - Open interactive shell sessions into pods via WebSocket
+- **Log streaming** - View and stream pod logs in real-time
+- **Container selection** - Choose specific containers in multi-container pods
+
+### Port Forwarding
+- **Session management** - Start and stop port forwards from the UI
+- **Auto-discovery** - Automatically detect available ports on pods and services
+- **Multiple sessions** - Run concurrent port forwards to different targets
+
+### Helm Integration
+- **Release management** - View all Helm releases across namespaces
+- **Revision history** - Compare manifests between revisions
+- **Upgrade & rollback** - Upgrade releases or rollback to previous versions
+- **Values inspection** - View computed values for any release
+
+### Additional Features
+- **Namespace filtering** - Focus on specific namespaces
 - **Platform detection** - Automatic detection of GKE, EKS, AKS, minikube, kind
-- **Zero cluster modification** - Read-only access, no agents to install
+- **CRD support** - Dynamic discovery and display of Custom Resource Definitions
+- **Zero cluster modification** - Read-only by default, no agents to install
 
 ## Installation
 
@@ -36,17 +57,17 @@ brew install skyhook-io/tap/explorer
 skyhook-explorer
 ```
 
-### Direct download
+### Direct Download
 
-Download the latest release from [GitHub Releases](https://github.com/skyhook-io/skyhook-explorer/releases).
+Download the latest release from [GitHub Releases](https://github.com/skyhook-io/explorer/releases).
 
 ### Docker
 
 ```bash
-docker run -v ~/.kube:/root/.kube -p 8080:8080 ghcr.io/skyhook-io/explorer
+docker run -v ~/.kube:/root/.kube -p 9280:9280 ghcr.io/skyhook-io/explorer
 ```
 
-## Usage
+## Quick Start
 
 ```bash
 # Basic usage - opens browser automatically
@@ -56,27 +77,114 @@ skyhook-explorer
 skyhook-explorer --namespace production
 
 # Custom port
-skyhook-explorer --port 9090
+skyhook-explorer --port 8080
 
 # Use specific kubeconfig
 skyhook-explorer --kubeconfig /path/to/kubeconfig
 
 # Don't auto-open browser
 skyhook-explorer --no-browser
+
+# Enable persistent change history
+skyhook-explorer --persist-history --history-limit 5000
 ```
 
-## API Endpoints
+## CLI Options
 
-When running, the following API endpoints are available:
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--kubeconfig` | `~/.kube/config` | Path to kubeconfig file |
+| `--namespace` | _(all)_ | Initial namespace filter |
+| `--port` | `9280` | Server port |
+| `--no-browser` | `false` | Don't auto-open browser |
+| `--dev` | `false` | Development mode |
+| `--persist-history` | `false` | Persist change history to file |
+| `--history-limit` | `1000` | Maximum changes to retain |
+| `--version` | | Show version and exit |
+
+## API Reference
+
+The Explorer exposes a REST API for programmatic access:
+
+### Core Endpoints
 
 | Endpoint | Description |
 |----------|-------------|
-| `GET /api/health` | Health check |
+| `GET /api/health` | Health check with resource counts |
 | `GET /api/cluster-info` | Cluster platform and version info |
 | `GET /api/topology` | Current topology graph |
 | `GET /api/namespaces` | List of namespaces |
-| `GET /api/resources/:kind` | List resources by kind |
-| `GET /api/events/stream` | SSE stream for real-time updates |
+| `GET /api/api-resources` | Available API resources (for CRDs) |
+
+### Resource Operations
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /api/resources/{kind}` | List resources by kind |
+| `GET /api/resources/{kind}/{ns}/{name}` | Get single resource with relationships |
+| `PUT /api/resources/{kind}/{ns}/{name}` | Update resource from YAML |
+| `DELETE /api/resources/{kind}/{ns}/{name}` | Delete resource |
+
+### Events & History
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /api/events` | Recent Kubernetes events |
+| `GET /api/events/stream` | SSE stream for real-time events |
+| `GET /api/changes` | Resource change history |
+
+### Pod Operations
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /api/pods/{ns}/{name}/logs` | Fetch pod logs |
+| `GET /api/pods/{ns}/{name}/logs/stream` | Stream logs via SSE |
+| `GET /api/pods/{ns}/{name}/exec` | WebSocket terminal session |
+
+### Port Forwarding
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /api/portforwards` | List active sessions |
+| `POST /api/portforwards` | Start port forward |
+| `DELETE /api/portforwards/{id}` | Stop port forward |
+
+### Helm Management
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /api/helm/releases` | List all releases |
+| `GET /api/helm/releases/{ns}/{name}` | Release details |
+| `POST /api/helm/releases/{ns}/{name}/rollback` | Rollback release |
+| `DELETE /api/helm/releases/{ns}/{name}` | Uninstall release |
+
+See the [Wiki](../../wiki) for complete API documentation.
+
+## Architecture
+
+```
+┌─────────────────┐              ┌───────────────────┐
+│    Browser      │◄──HTTP/SSE──►│  Explorer Binary  │
+│  (React + UI)   │◄──WebSocket─►│  (Go + Embedded)  │
+└─────────────────┘              └───────────────────┘
+                                         │
+                                ┌────────┴────────┐
+                                │   Kubernetes    │
+                                │   API Server    │
+                                └─────────────────┘
+```
+
+The Explorer uses Kubernetes SharedInformers for efficient, watch-based caching. Changes are pushed to the browser via Server-Sent Events (SSE) for real-time updates. Pod terminal access uses WebSocket connections for bidirectional communication.
+
+## Supported Resources
+
+- **Workloads**: Deployments, DaemonSets, StatefulSets, ReplicaSets, Pods, Jobs, CronJobs
+- **Networking**: Services, Ingresses
+- **Configuration**: ConfigMaps, Secrets (names only)
+- **Storage**: PersistentVolumeClaims
+- **Autoscaling**: HorizontalPodAutoscalers
+- **Cluster**: Nodes, Namespaces
+- **Custom**: Any CRD via dynamic discovery
 
 ## Development
 
@@ -84,57 +192,55 @@ When running, the following API endpoints are available:
 
 - Go 1.22+
 - Node.js 20+
-- npm or pnpm
+- npm
 
-### Build from source
+### Build from Source
 
 ```bash
 # Clone the repository
-git clone https://github.com/skyhook-io/skyhook-explorer.git
-cd skyhook-explorer
+git clone https://github.com/skyhook-io/explorer.git
+cd explorer
 
-# Build everything
+# Build everything (frontend + backend)
 make build
 
 # Run
 ./explorer
 ```
 
-### Development mode
+### Development Mode
+
+Run backend and frontend separately for hot reload:
 
 ```bash
-# Start backend
-go run ./cmd/explorer --dev --no-browser
+# Terminal 1: Backend with hot reload (port 9280)
+make watch-backend
 
-# In another terminal, start frontend with hot reload
-cd web
-npm install
-npm run dev
+# Terminal 2: Frontend with hot reload (port 9273)
+make watch-frontend
 ```
 
-## Architecture
+The Vite dev server proxies `/api` requests to the backend automatically.
 
-```
-┌─────────────────┐         ┌───────────────────┐
-│    Browser      │◄──SSE──►│  Explorer Binary  │
-│  (React + UI)   │         │  (Go + Embedded)  │
-└─────────────────┘         └───────────────────┘
-                                    │
-                           ┌────────┴────────┐
-                           │   Kubernetes    │
-                           │   API Server    │
-                           └─────────────────┘
-```
+### Makefile Targets
 
-The Explorer uses Kubernetes SharedInformers for efficient, watch-based caching of resources. Changes are pushed to the browser via Server-Sent Events (SSE) for real-time updates.
+| Target | Description |
+|--------|-------------|
+| `make build` | Build frontend + embedded binary |
+| `make frontend` | Build frontend only |
+| `make backend` | Build backend only |
+| `make watch-frontend` | Vite dev server (port 9273) |
+| `make watch-backend` | Go with Air hot reload (port 9280) |
+| `make test` | Run all tests |
+| `make docker` | Build Docker image |
 
-## Supported Resources
+## Documentation
 
-- **Workloads**: Deployments, DaemonSets, StatefulSets, ReplicaSets, Pods
-- **Networking**: Services, Ingresses
-- **Configuration**: ConfigMaps, Secrets (names only)
-- **Autoscaling**: HorizontalPodAutoscalers
-- **Batch**: Jobs, CronJobs
+- [Wiki Home](../../wiki) - Full documentation
+- [Getting Started](../../wiki/Getting-Started) - Installation and first steps
+- [User Guide](../../wiki/User-Guide) - Using the web interface
+- [API Reference](../../wiki/API-Reference) - Complete API documentation
+- [Development Guide](../../wiki/Development) - Contributing and local setup
 
 ## License
 
@@ -147,4 +253,3 @@ Contributions are welcome! Please read our [Contributing Guide](CONTRIBUTING.md)
 ## Related Projects
 
 - [Skyhook](https://skyhook.io) - The platform for Kubernetes made simple
-- [skyhook-connector](https://github.com/skyhook-dev/skyhook-connector) - In-cluster agent

--- a/docs/wiki/API-Reference.md
+++ b/docs/wiki/API-Reference.md
@@ -1,0 +1,797 @@
+# API Reference
+
+Skyhook Explorer exposes a REST API for programmatic access. All endpoints are available at `http://localhost:9280/api` (or your configured port).
+
+## Authentication
+
+The API uses your local kubeconfig for Kubernetes authentication. No additional authentication is required for the Explorer API itself.
+
+## Response Format
+
+All responses are JSON unless otherwise noted. Errors return:
+
+```json
+{
+  "error": "Error message description"
+}
+```
+
+---
+
+## Core Endpoints
+
+### Health Check
+
+```
+GET /api/health
+```
+
+Returns server health and resource counts.
+
+**Response:**
+```json
+{
+  "status": "ok",
+  "resources": {
+    "pods": 42,
+    "deployments": 12,
+    "services": 15,
+    "ingresses": 3
+  }
+}
+```
+
+### Cluster Info
+
+```
+GET /api/cluster-info
+```
+
+Returns cluster platform and version information.
+
+**Response:**
+```json
+{
+  "platform": "gke",
+  "version": "v1.28.3-gke.1234",
+  "context": "gke_project_zone_cluster",
+  "server": "https://10.0.0.1"
+}
+```
+
+**Platform Values:** `gke`, `eks`, `aks`, `minikube`, `kind`, `k3s`, `rancher`, `openshift`, `unknown`
+
+### List Namespaces
+
+```
+GET /api/namespaces
+```
+
+Returns all namespaces in the cluster.
+
+**Response:**
+```json
+{
+  "namespaces": [
+    {"name": "default", "status": "Active"},
+    {"name": "kube-system", "status": "Active"},
+    {"name": "production", "status": "Active"}
+  ]
+}
+```
+
+### API Resources
+
+```
+GET /api/api-resources
+```
+
+Returns available API resources for CRD discovery.
+
+**Response:**
+```json
+{
+  "resources": [
+    {
+      "name": "pods",
+      "kind": "Pod",
+      "namespaced": true,
+      "group": "",
+      "version": "v1"
+    },
+    {
+      "name": "certificates",
+      "kind": "Certificate",
+      "namespaced": true,
+      "group": "cert-manager.io",
+      "version": "v1"
+    }
+  ]
+}
+```
+
+---
+
+## Topology
+
+### Get Topology
+
+```
+GET /api/topology
+```
+
+Returns the cluster topology graph.
+
+**Query Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `namespace` | string | Filter by namespace |
+| `view` | string | View mode: `traffic` or `resources` |
+
+**Response:**
+```json
+{
+  "nodes": [
+    {
+      "id": "pod/default/nginx-abc123",
+      "kind": "Pod",
+      "name": "nginx-abc123",
+      "namespace": "default",
+      "status": "Running",
+      "health": "healthy",
+      "labels": {"app": "nginx"},
+      "metadata": {
+        "creationTimestamp": "2024-01-15T10:30:00Z",
+        "ownerReferences": [...]
+      }
+    }
+  ],
+  "edges": [
+    {
+      "source": "service/default/nginx",
+      "target": "pod/default/nginx-abc123",
+      "type": "selects"
+    }
+  ]
+}
+```
+
+---
+
+## Resources
+
+### List Resources
+
+```
+GET /api/resources/{kind}
+```
+
+List all resources of a specific kind.
+
+**Path Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `kind` | string | Resource kind (e.g., `pods`, `deployments`, `services`) |
+
+**Query Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `namespace` | string | Filter by namespace |
+
+**Response:**
+```json
+{
+  "items": [
+    {
+      "kind": "Pod",
+      "metadata": {
+        "name": "nginx-abc123",
+        "namespace": "default"
+      },
+      "spec": {...},
+      "status": {...}
+    }
+  ]
+}
+```
+
+### Get Resource
+
+```
+GET /api/resources/{kind}/{namespace}/{name}
+```
+
+Get a single resource with its relationships.
+
+**Response:**
+```json
+{
+  "resource": {
+    "kind": "Pod",
+    "metadata": {...},
+    "spec": {...},
+    "status": {...}
+  },
+  "relationships": {
+    "parent": {
+      "kind": "ReplicaSet",
+      "name": "nginx-5d4f6b7c8",
+      "namespace": "default"
+    },
+    "children": [],
+    "services": [
+      {"kind": "Service", "name": "nginx", "namespace": "default"}
+    ],
+    "configMaps": [],
+    "secrets": []
+  }
+}
+```
+
+### Update Resource
+
+```
+PUT /api/resources/{kind}/{namespace}/{name}
+```
+
+Update a resource from YAML.
+
+**Request Body:** YAML string of the resource
+
+**Response:**
+```json
+{
+  "message": "Resource updated successfully"
+}
+```
+
+### Delete Resource
+
+```
+DELETE /api/resources/{kind}/{namespace}/{name}
+```
+
+Delete a resource.
+
+**Response:**
+```json
+{
+  "message": "Resource deleted successfully"
+}
+```
+
+---
+
+## Events
+
+### List Events
+
+```
+GET /api/events
+```
+
+Get recent Kubernetes events.
+
+**Query Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `namespace` | string | Filter by namespace |
+| `limit` | integer | Maximum events to return (default: 100) |
+
+**Response:**
+```json
+{
+  "events": [
+    {
+      "type": "Warning",
+      "reason": "BackOff",
+      "message": "Back-off restarting failed container",
+      "involvedObject": {
+        "kind": "Pod",
+        "name": "nginx-abc123",
+        "namespace": "default"
+      },
+      "count": 5,
+      "firstTimestamp": "2024-01-15T10:00:00Z",
+      "lastTimestamp": "2024-01-15T10:30:00Z"
+    }
+  ]
+}
+```
+
+### Event Stream (SSE)
+
+```
+GET /api/events/stream
+```
+
+Server-Sent Events stream for real-time updates.
+
+**Query Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `namespace` | string | Filter by namespace |
+| `view` | string | View mode for topology updates |
+
+**Event Types:**
+- `topology` - Topology graph update
+- `event` - Kubernetes event
+- `heartbeat` - Connection keep-alive
+
+**Example:**
+```
+event: topology
+data: {"nodes":[...],"edges":[...]}
+
+event: event
+data: {"type":"Normal","reason":"Scheduled",...}
+
+event: heartbeat
+data: {"timestamp":"2024-01-15T10:30:00Z"}
+```
+
+---
+
+## Changes (History)
+
+### List Changes
+
+```
+GET /api/changes
+```
+
+Get resource change history.
+
+**Query Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `namespace` | string | Filter by namespace |
+| `kind` | string | Filter by resource kind |
+| `since` | string | RFC3339 timestamp |
+| `limit` | integer | Maximum changes (default: 100) |
+| `include_k8s_events` | boolean | Include K8s events |
+| `include_managed` | boolean | Include managed resources |
+
+**Response:**
+```json
+{
+  "changes": [
+    {
+      "type": "updated",
+      "kind": "Pod",
+      "name": "nginx-abc123",
+      "namespace": "default",
+      "timestamp": "2024-01-15T10:30:00Z",
+      "health": "healthy",
+      "owner": {
+        "kind": "ReplicaSet",
+        "name": "nginx-5d4f6b7c8"
+      }
+    }
+  ]
+}
+```
+
+### Get Child Changes
+
+```
+GET /api/changes/{kind}/{namespace}/{name}/children
+```
+
+Get changes for child resources of a workload.
+
+---
+
+## Pod Operations
+
+### Get Pod Logs
+
+```
+GET /api/pods/{namespace}/{name}/logs
+```
+
+Fetch pod logs (non-streaming).
+
+**Query Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `container` | string | Container name |
+| `tail` | integer | Lines from end (default: 100) |
+| `previous` | boolean | Previous container logs |
+| `timestamps` | boolean | Include timestamps |
+
+**Response:**
+```json
+{
+  "logs": "2024-01-15T10:30:00Z Starting server...\n2024-01-15T10:30:01Z Listening on port 8080\n"
+}
+```
+
+### Stream Pod Logs (SSE)
+
+```
+GET /api/pods/{namespace}/{name}/logs/stream
+```
+
+Stream pod logs in real-time via Server-Sent Events.
+
+**Query Parameters:** Same as above
+
+**Event Format:**
+```
+data: 2024-01-15T10:30:00Z Log line here
+
+data: 2024-01-15T10:30:01Z Another log line
+```
+
+### Pod Exec (WebSocket)
+
+```
+GET /api/pods/{namespace}/{name}/exec
+```
+
+WebSocket endpoint for interactive terminal sessions.
+
+**Query Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `container` | string | Container name |
+| `shell` | string | Shell path (default: `/bin/sh`) |
+
+**WebSocket Messages:**
+
+Client → Server:
+```json
+{"type": "input", "data": "ls -la\n"}
+{"type": "resize", "cols": 80, "rows": 24}
+```
+
+Server → Client:
+```json
+{"type": "output", "data": "total 48\ndrwxr-xr-x..."}
+{"type": "error", "data": "command not found"}
+```
+
+---
+
+## Port Forwarding
+
+### List Port Forwards
+
+```
+GET /api/portforwards
+```
+
+List active port forward sessions.
+
+**Response:**
+```json
+{
+  "portforwards": [
+    {
+      "id": "pf-abc123",
+      "type": "pod",
+      "namespace": "default",
+      "name": "nginx-abc123",
+      "targetPort": 80,
+      "localPort": 8080,
+      "status": "active",
+      "createdAt": "2024-01-15T10:30:00Z"
+    }
+  ]
+}
+```
+
+### Start Port Forward
+
+```
+POST /api/portforwards
+```
+
+Start a new port forward session.
+
+**Request Body:**
+```json
+{
+  "type": "pod",
+  "namespace": "default",
+  "name": "nginx-abc123",
+  "targetPort": 80,
+  "localPort": 8080
+}
+```
+
+If `localPort` is 0 or omitted, a random available port is assigned.
+
+**Response:**
+```json
+{
+  "id": "pf-abc123",
+  "localPort": 8080,
+  "url": "http://localhost:8080"
+}
+```
+
+### Stop Port Forward
+
+```
+DELETE /api/portforwards/{id}
+```
+
+Stop a port forward session.
+
+**Response:**
+```json
+{
+  "message": "Port forward stopped"
+}
+```
+
+### Get Available Ports
+
+```
+GET /api/portforwards/available/{type}/{namespace}/{name}
+```
+
+Get available ports for a pod or service.
+
+**Path Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | string | `pod` or `service` |
+| `namespace` | string | Resource namespace |
+| `name` | string | Resource name |
+
+**Response:**
+```json
+{
+  "ports": [
+    {"port": 80, "name": "http", "protocol": "TCP"},
+    {"port": 443, "name": "https", "protocol": "TCP"}
+  ]
+}
+```
+
+---
+
+## Helm Management
+
+### List Releases
+
+```
+GET /api/helm/releases
+```
+
+List all Helm releases.
+
+**Query Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `namespace` | string | Filter by namespace |
+
+**Response:**
+```json
+{
+  "releases": [
+    {
+      "name": "nginx",
+      "namespace": "default",
+      "chart": "nginx",
+      "chartVersion": "15.0.0",
+      "appVersion": "1.25.0",
+      "status": "deployed",
+      "revision": 3,
+      "updated": "2024-01-15T10:30:00Z"
+    }
+  ]
+}
+```
+
+### Get Release Details
+
+```
+GET /api/helm/releases/{namespace}/{name}
+```
+
+Get detailed information about a release.
+
+**Response:**
+```json
+{
+  "release": {
+    "name": "nginx",
+    "namespace": "default",
+    "info": {
+      "status": "deployed",
+      "description": "Upgrade complete",
+      "firstDeployed": "2024-01-01T00:00:00Z",
+      "lastDeployed": "2024-01-15T10:30:00Z"
+    },
+    "chart": {
+      "name": "nginx",
+      "version": "15.0.0",
+      "appVersion": "1.25.0"
+    },
+    "config": {...},
+    "version": 3
+  }
+}
+```
+
+### Get Release Manifest
+
+```
+GET /api/helm/releases/{namespace}/{name}/manifest
+```
+
+Get rendered Kubernetes manifests for a release.
+
+**Query Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `revision` | integer | Specific revision (default: latest) |
+
+**Response:**
+```json
+{
+  "manifest": "---\napiVersion: v1\nkind: Service\n..."
+}
+```
+
+### Get Release Values
+
+```
+GET /api/helm/releases/{namespace}/{name}/values
+```
+
+Get computed values for a release.
+
+**Response:**
+```json
+{
+  "values": {
+    "replicaCount": 3,
+    "image": {
+      "repository": "nginx",
+      "tag": "1.25.0"
+    }
+  }
+}
+```
+
+### Get Release Diff
+
+```
+GET /api/helm/releases/{namespace}/{name}/diff
+```
+
+Get diff between two revisions.
+
+**Query Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `revision1` | integer | First revision |
+| `revision2` | integer | Second revision |
+
+**Response:**
+```json
+{
+  "diff": "--- revision 2\n+++ revision 3\n@@ -10,7 +10,7 @@\n   replicas: 2\n+  replicas: 3\n"
+}
+```
+
+### Check Upgrade Availability
+
+```
+GET /api/helm/releases/{namespace}/{name}/upgrade-info
+```
+
+Check if chart upgrades are available.
+
+**Response:**
+```json
+{
+  "currentVersion": "15.0.0",
+  "latestVersion": "15.1.0",
+  "upgradeAvailable": true
+}
+```
+
+### Batch Upgrade Check
+
+```
+GET /api/helm/upgrade-check
+```
+
+Check upgrade availability for all releases.
+
+**Response:**
+```json
+{
+  "releases": [
+    {
+      "name": "nginx",
+      "namespace": "default",
+      "currentVersion": "15.0.0",
+      "latestVersion": "15.1.0",
+      "upgradeAvailable": true
+    }
+  ]
+}
+```
+
+### Rollback Release
+
+```
+POST /api/helm/releases/{namespace}/{name}/rollback
+```
+
+Rollback to a previous revision.
+
+**Request Body:**
+```json
+{
+  "revision": 2
+}
+```
+
+**Response:**
+```json
+{
+  "message": "Rollback to revision 2 successful"
+}
+```
+
+### Upgrade Release
+
+```
+POST /api/helm/releases/{namespace}/{name}/upgrade
+```
+
+Upgrade release to a new chart version.
+
+**Request Body:**
+```json
+{
+  "version": "15.1.0",
+  "values": {}
+}
+```
+
+**Response:**
+```json
+{
+  "message": "Upgrade successful",
+  "revision": 4
+}
+```
+
+### Uninstall Release
+
+```
+DELETE /api/helm/releases/{namespace}/{name}
+```
+
+Uninstall a Helm release.
+
+**Response:**
+```json
+{
+  "message": "Release uninstalled successfully"
+}
+```
+
+---
+
+## Error Codes
+
+| Status | Description |
+|--------|-------------|
+| 200 | Success |
+| 400 | Bad request (invalid parameters) |
+| 404 | Resource not found |
+| 500 | Internal server error |
+
+## Rate Limiting
+
+The API does not implement rate limiting. All requests go directly to the Kubernetes API server, which may have its own rate limits.

--- a/docs/wiki/Development.md
+++ b/docs/wiki/Development.md
@@ -1,0 +1,339 @@
+# Development Guide
+
+This guide covers setting up a development environment and contributing to Skyhook Explorer.
+
+## Prerequisites
+
+- **Go 1.22+** - [Download](https://go.dev/dl/)
+- **Node.js 20+** - [Download](https://nodejs.org/)
+- **npm** - Comes with Node.js
+- **Make** - Usually pre-installed on macOS/Linux
+- **Access to a Kubernetes cluster** - For testing
+
+Recommended tools:
+- [Air](https://github.com/cosmtrek/air) - Go hot reload (installed via `make watch-backend`)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) - Kubernetes CLI
+- [kind](https://kind.sigs.k8s.io/) or [minikube](https://minikube.sigs.k8s.io/) - Local clusters
+
+## Project Structure
+
+```
+explorer/
+├── cmd/explorer/              # CLI entry point
+│   └── main.go               # Main function, CLI flags
+├── internal/
+│   ├── helm/                 # Helm SDK integration
+│   │   ├── client.go         # Helm operations wrapper
+│   │   ├── handlers.go       # HTTP handlers
+│   │   └── types.go          # Type definitions
+│   ├── k8s/                  # Kubernetes client
+│   │   ├── cache.go          # SharedInformer caching
+│   │   ├── client.go         # Client initialization
+│   │   ├── cluster_detection.go # Platform detection
+│   │   ├── discovery.go      # API resource discovery
+│   │   ├── dynamic_cache.go  # CRD support
+│   │   ├── history.go        # Change history
+│   │   └── update.go         # Resource mutations
+│   ├── server/               # HTTP server
+│   │   ├── server.go         # Chi router, REST handlers
+│   │   ├── sse.go            # SSE broadcaster
+│   │   ├── exec.go           # Pod exec WebSocket
+│   │   ├── logs.go           # Pod logs handlers
+│   │   └── portforward.go    # Port forward sessions
+│   ├── static/               # Embedded frontend
+│   │   └── embed.go
+│   └── topology/             # Graph construction
+│       ├── builder.go        # Node/edge creation
+│       ├── relationships.go  # Resource relationships
+│       └── types.go          # Type definitions
+├── web/                      # React frontend
+│   ├── src/
+│   │   ├── api/              # API client, hooks
+│   │   ├── components/       # React components
+│   │   │   ├── dock/         # Bottom dock
+│   │   │   ├── events/       # Events timeline
+│   │   │   ├── helm/         # Helm UI
+│   │   │   ├── logs/         # Logs viewer
+│   │   │   ├── portforward/  # Port forward UI
+│   │   │   ├── resources/    # Resource panels
+│   │   │   ├── topology/     # Graph visualization
+│   │   │   └── ui/           # Base components
+│   │   ├── types.ts          # TypeScript types
+│   │   └── utils/            # Utility functions
+│   ├── package.json
+│   ├── vite.config.ts
+│   └── tailwind.config.js
+├── deploy/                   # Deployment configs
+├── Makefile
+└── go.mod
+```
+
+## Development Setup
+
+### Clone and Install
+
+```bash
+git clone https://github.com/skyhook-io/explorer.git
+cd explorer
+
+# Install frontend dependencies
+cd web && npm install && cd ..
+
+# Verify Go modules
+go mod download
+```
+
+### Running in Development Mode
+
+Development mode runs the backend and frontend separately with hot reload:
+
+**Terminal 1 - Backend (port 9280):**
+```bash
+make watch-backend
+```
+
+**Terminal 2 - Frontend (port 9273):**
+```bash
+make watch-frontend
+```
+
+Open http://localhost:9273 in your browser. The Vite dev server proxies `/api` requests to the backend.
+
+### Alternative: Direct Go Run
+
+```bash
+# Build frontend first
+cd web && npm run build && cd ..
+
+# Run backend in dev mode (serves from web/dist)
+go run ./cmd/explorer --dev --no-browser
+```
+
+## Makefile Targets
+
+| Target | Description |
+|--------|-------------|
+| `make build` | Build frontend + embedded binary |
+| `make frontend` | Build frontend only |
+| `make backend` | Build backend only |
+| `make watch-frontend` | Vite dev server with HMR |
+| `make watch-backend` | Go with Air hot reload |
+| `make test` | Run all tests |
+| `make lint` | Run linters |
+| `make docker` | Build Docker image |
+| `make clean` | Remove build artifacts |
+
+## Architecture Overview
+
+### Backend Flow
+
+1. **Startup** (`cmd/explorer/main.go`)
+   - Parse CLI flags
+   - Initialize Kubernetes client
+   - Start informer caches
+   - Initialize HTTP server
+   - Open browser (optional)
+
+2. **Kubernetes Caching** (`internal/k8s/cache.go`)
+   - SharedInformers for typed resources
+   - Dynamic informers for CRDs
+   - Change notifications via channels
+   - Field stripping for memory efficiency
+
+3. **HTTP Server** (`internal/server/server.go`)
+   - Chi router with middleware
+   - REST handlers for resources
+   - SSE broadcaster for real-time updates
+   - WebSocket handler for pod exec
+
+4. **Topology Building** (`internal/topology/builder.go`)
+   - Constructs graph from cached resources
+   - Determines edges via owner refs and selectors
+   - Supports traffic and resources view modes
+
+### Frontend Flow
+
+1. **Entry** (`web/src/main.tsx`)
+   - React app initialization
+   - TanStack Query provider
+   - React Router setup
+
+2. **API Layer** (`web/src/api/`)
+   - Typed API client
+   - SSE connection management
+   - React Query hooks
+
+3. **Topology View** (`web/src/components/topology/`)
+   - ReactFlow canvas
+   - ELK.js layout
+   - Custom node renderers
+
+4. **Bottom Dock** (`web/src/components/dock/`)
+   - Terminal sessions (xterm.js)
+   - Logs viewer
+   - Port forward management
+
+## Adding New Features
+
+### Adding a New API Endpoint
+
+1. Add handler in `internal/server/server.go`:
+```go
+r.Get("/api/example", s.handleExample)
+```
+
+2. Implement handler:
+```go
+func (s *Server) handleExample(w http.ResponseWriter, r *http.Request) {
+    // Implementation
+    json.NewEncoder(w).Encode(response)
+}
+```
+
+3. Add TypeScript types in `web/src/types.ts`
+
+4. Add API client function in `web/src/api/client.ts`
+
+5. Create React Query hook if needed
+
+### Adding a New Resource Type
+
+1. Add informer in `internal/k8s/cache.go`:
+```go
+case "newresources":
+    informer = informerFactory.Apps().V1().NewResources().Informer()
+```
+
+2. Add to topology builder in `internal/topology/builder.go`
+
+3. Add node type in `web/src/components/topology/`
+
+4. Update TypeScript types
+
+### Adding a New Frontend Component
+
+1. Create component in `web/src/components/`
+2. Use existing UI components from `components/ui/`
+3. Follow existing patterns for API calls
+4. Add to routing if it's a page
+
+## Testing
+
+### Backend Tests
+
+```bash
+# Run all tests
+go test ./...
+
+# Run with verbose output
+go test -v ./...
+
+# Run specific package
+go test ./internal/k8s/...
+
+# Run with coverage
+go test -cover ./...
+```
+
+### Frontend Tests
+
+```bash
+cd web
+
+# Type checking
+npm run tsc
+
+# Lint
+npm run lint
+```
+
+## Code Style
+
+### Go
+
+- Follow [Effective Go](https://go.dev/doc/effective_go)
+- Use `gofmt` for formatting
+- Keep functions focused and small
+- Handle errors explicitly
+
+### TypeScript/React
+
+- Use TypeScript strict mode
+- Prefer functional components with hooks
+- Use TanStack Query for server state
+- Follow existing component patterns
+
+## Pull Request Guidelines
+
+1. **Fork and branch** from `main`
+2. **Write tests** for new functionality
+3. **Update documentation** if needed
+4. **Run tests and linting** before submitting
+5. **Keep PRs focused** - one feature/fix per PR
+6. **Write clear commit messages**
+
+### Commit Message Format
+
+```
+type: short description
+
+Longer description if needed.
+
+Fixes #123
+```
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+
+## Debugging
+
+### Backend
+
+```bash
+# Verbose logging
+go run ./cmd/explorer --dev 2>&1 | tee debug.log
+
+# With delve debugger
+dlv debug ./cmd/explorer -- --dev --no-browser
+```
+
+### Frontend
+
+- Use browser DevTools
+- React Developer Tools extension
+- TanStack Query Devtools (included in dev mode)
+
+### Kubernetes
+
+```bash
+# Check what Explorer sees
+curl http://localhost:9280/api/health
+curl http://localhost:9280/api/topology | jq .
+
+# Compare with kubectl
+kubectl get pods -A
+kubectl get events -A
+```
+
+## Building Releases
+
+Releases are built via GitHub Actions using GoReleaser:
+
+```bash
+# Local build (for testing)
+goreleaser build --snapshot --clean
+
+# Full release (tags only)
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+The CI pipeline builds binaries for:
+- darwin/amd64, darwin/arm64
+- linux/amd64, linux/arm64
+- windows/amd64
+
+## Getting Help
+
+- [GitHub Issues](https://github.com/skyhook-io/explorer/issues) - Bug reports
+- [GitHub Discussions](https://github.com/skyhook-io/explorer/discussions) - Questions
+- [Contributing Guide](../CONTRIBUTING.md) - Contribution process

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,0 +1,133 @@
+# Getting Started
+
+This guide will help you install and run Skyhook Explorer for the first time.
+
+## Installation
+
+### Option 1: kubectl Plugin (Krew)
+
+If you have [Krew](https://krew.sigs.k8s.io/) installed:
+
+```bash
+kubectl krew install explorer
+kubectl explorer
+```
+
+### Option 2: Homebrew (macOS)
+
+```bash
+brew install skyhook-io/tap/explorer
+skyhook-explorer
+```
+
+### Option 3: Direct Download
+
+Download the appropriate binary from [GitHub Releases](https://github.com/skyhook-io/explorer/releases):
+
+- `explorer-darwin-amd64` - macOS Intel
+- `explorer-darwin-arm64` - macOS Apple Silicon
+- `explorer-linux-amd64` - Linux x86_64
+- `explorer-linux-arm64` - Linux ARM64
+- `explorer-windows-amd64.exe` - Windows
+
+Make it executable and run:
+
+```bash
+chmod +x explorer-*
+./explorer-darwin-arm64  # or your platform
+```
+
+### Option 4: Docker
+
+```bash
+docker run -v ~/.kube:/root/.kube -p 9280:9280 ghcr.io/skyhook-io/explorer
+```
+
+Then open http://localhost:9280 in your browser.
+
+### Option 5: Build from Source
+
+```bash
+git clone https://github.com/skyhook-io/explorer.git
+cd explorer
+make build
+./explorer
+```
+
+## First Run
+
+1. Ensure you have a valid kubeconfig (usually at `~/.kube/config`)
+2. Run the explorer:
+   ```bash
+   skyhook-explorer
+   ```
+3. Your browser will open automatically to http://localhost:9280
+4. You'll see the topology view of your current Kubernetes context
+
+## Basic Usage
+
+### View Different Namespaces
+
+Use the namespace dropdown in the header to filter by namespace, or select "All Namespaces" to see everything.
+
+### Switch View Modes
+
+Toggle between:
+- **Traffic View** - Shows network flow: Ingress → Service → Pod
+- **Resources View** - Shows ownership hierarchy: Deployment → ReplicaSet → Pod
+
+### Inspect Resources
+
+Click any node in the topology to open the resource detail panel showing:
+- Resource metadata
+- Status and conditions
+- Related resources
+- Full YAML (editable)
+
+### Open Pod Terminal
+
+1. Click on a Pod node
+2. Click the "Terminal" button in the detail panel
+3. Select a container (if multiple)
+4. An interactive terminal opens in the bottom dock
+
+### Stream Pod Logs
+
+1. Click on a Pod node
+2. Click the "Logs" button
+3. Select a container and configure options
+4. Logs stream in real-time in the bottom dock
+
+## CLI Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--kubeconfig` | `~/.kube/config` | Path to kubeconfig file |
+| `--namespace` | _(all)_ | Initial namespace filter |
+| `--port` | `9280` | Server port |
+| `--no-browser` | `false` | Don't auto-open browser |
+| `--persist-history` | `false` | Persist change history to file |
+| `--history-limit` | `1000` | Maximum changes to retain |
+| `--version` | | Show version and exit |
+
+## Examples
+
+```bash
+# Start with a specific namespace
+skyhook-explorer --namespace production
+
+# Use a different kubeconfig
+skyhook-explorer --kubeconfig ~/.kube/staging-config
+
+# Run on a different port without opening browser
+skyhook-explorer --port 8080 --no-browser
+
+# Enable persistent change history
+skyhook-explorer --persist-history --history-limit 5000
+```
+
+## Next Steps
+
+- Read the [User Guide](User-Guide) for detailed feature documentation
+- Check the [API Reference](API-Reference) for programmatic access
+- See [Development](Development) to contribute

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,44 @@
+# Skyhook Explorer Wiki
+
+Welcome to the Skyhook Explorer documentation. Explorer is a real-time Kubernetes cluster visualization and management tool.
+
+## Quick Links
+
+- [Getting Started](Getting-Started) - Installation and your first run
+- [User Guide](User-Guide) - Complete guide to the web interface
+- [API Reference](API-Reference) - REST API documentation
+- [Development](Development) - Contributing and local development
+
+## What is Skyhook Explorer?
+
+Skyhook Explorer is an open-source tool that provides:
+
+- **Visual topology** of your Kubernetes cluster resources
+- **Real-time updates** via Server-Sent Events
+- **Pod terminal access** directly in your browser
+- **Log streaming** with container selection
+- **Port forwarding** management
+- **Helm release** inspection and management
+- **Resource editing** with YAML support
+
+## How It Works
+
+Explorer runs as a single binary on your local machine. It:
+
+1. Connects to your Kubernetes cluster using your kubeconfig
+2. Uses SharedInformers to efficiently watch cluster resources
+3. Serves a React web UI embedded in the binary
+4. Pushes real-time updates to the browser via SSE
+5. Provides WebSocket connections for terminal sessions
+
+No agents or modifications to your cluster are required.
+
+## Requirements
+
+- Access to a Kubernetes cluster (kubeconfig)
+- A modern web browser
+
+## Support
+
+- [GitHub Issues](https://github.com/skyhook-io/explorer/issues) - Bug reports and feature requests
+- [GitHub Discussions](https://github.com/skyhook-io/explorer/discussions) - Questions and community

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -1,0 +1,48 @@
+# Wiki Content
+
+This folder contains the documentation content for the GitHub Wiki.
+
+## How to Publish
+
+GitHub Wikis are separate git repositories. To publish this content:
+
+### Option 1: Manual Copy
+
+1. Go to your repository on GitHub
+2. Click the "Wiki" tab
+3. Create pages manually and copy/paste content from each `.md` file
+
+### Option 2: Clone Wiki Repository
+
+```bash
+# Clone the wiki repo (it's a separate git repo)
+git clone https://github.com/skyhook-io/explorer.wiki.git
+
+# Copy all markdown files
+cp docs/wiki/*.md explorer.wiki/
+
+# Commit and push
+cd explorer.wiki
+git add .
+git commit -m "Update wiki documentation"
+git push
+```
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `Home.md` | Wiki home page |
+| `Getting-Started.md` | Installation and first run |
+| `User-Guide.md` | Complete UI documentation |
+| `API-Reference.md` | REST API documentation |
+| `Development.md` | Contributing guide |
+| `_Sidebar.md` | Wiki navigation sidebar |
+
+## Keeping in Sync
+
+When making documentation updates, update both:
+1. `README.md` - For GitHub repository landing page
+2. `docs/wiki/` - For detailed wiki documentation
+
+Consider adding a CI step to automatically sync wiki content.

--- a/docs/wiki/User-Guide.md
+++ b/docs/wiki/User-Guide.md
@@ -1,0 +1,263 @@
+# User Guide
+
+This guide covers all features of the Skyhook Explorer web interface.
+
+## Interface Overview
+
+The Explorer interface consists of:
+
+1. **Header** - Cluster info, namespace selector, view mode toggle
+2. **Main Canvas** - Interactive topology graph
+3. **Side Panel** - Resource details (opens on selection)
+4. **Bottom Dock** - Terminal sessions, logs, port forwards
+
+## Topology View
+
+### Navigation
+
+- **Pan**: Click and drag on empty space
+- **Zoom**: Mouse wheel or pinch gesture
+- **Select**: Click on a node
+- **Multi-select**: Shift+click or drag a selection box
+- **Fit view**: Double-click on empty space
+
+### View Modes
+
+**Traffic View**
+Shows network flow through your cluster:
+```
+Ingress → Service → Pod
+```
+Best for understanding how external traffic reaches your workloads.
+
+**Resources View**
+Shows ownership hierarchy:
+```
+Deployment → ReplicaSet → Pod
+DaemonSet → Pod
+StatefulSet → Pod
+Job → Pod
+CronJob → Job → Pod
+```
+Best for understanding resource relationships and debugging.
+
+### Node Types
+
+| Icon | Resource | Description |
+|------|----------|-------------|
+| Cube | Pod | Running container(s) |
+| Boxes | Deployment | Manages ReplicaSets |
+| Boxes (dashed) | ReplicaSet | Manages Pod replicas |
+| Server | DaemonSet | Pod on each node |
+| Database | StatefulSet | Stateful workloads |
+| Play | Job | One-time task |
+| Clock | CronJob | Scheduled jobs |
+| Globe | Service | Network endpoint |
+| Arrow | Ingress | External access |
+| File | ConfigMap | Configuration data |
+| Lock | Secret | Sensitive data |
+| Chart | HPA | Auto-scaling |
+| Disk | PVC | Storage claim |
+
+### Health Indicators
+
+Node colors indicate health status:
+- **Green**: Healthy/Running
+- **Yellow**: Warning/Pending
+- **Red**: Error/Failed
+- **Gray**: Unknown/Terminating
+
+## Resource Details Panel
+
+Click any node to open the details panel showing:
+
+### Overview Tab
+- Resource name and namespace
+- Labels and annotations
+- Creation timestamp
+- Owner references
+
+### Status Tab
+- Current status and phase
+- Conditions with timestamps
+- Container statuses (for Pods)
+- Replica counts (for Deployments)
+
+### Related Tab
+- Parent resources (owner)
+- Child resources (owned)
+- Network resources (Services, Ingresses)
+- Config resources (ConfigMaps, Secrets)
+
+### YAML Tab
+- Full resource YAML
+- Syntax highlighted
+- Editable with save button
+
+## Pod Operations
+
+### Terminal Access
+
+1. Select a Pod in the topology
+2. Click **Terminal** in the detail panel
+3. Choose a container (if multiple)
+4. Select shell (`/bin/sh`, `/bin/bash`, or custom)
+5. Terminal opens in the bottom dock
+
+Terminal features:
+- Full TTY support with colors
+- Copy/paste (Ctrl+Shift+C/V or Cmd+C/V)
+- Resize with dock handle
+- Multiple concurrent sessions
+
+### Log Streaming
+
+1. Select a Pod in the topology
+2. Click **Logs** in the detail panel
+3. Configure options:
+   - Container selection
+   - Tail lines (default: 100)
+   - Previous container logs
+   - Timestamps
+4. Logs stream in real-time
+
+Log features:
+- Auto-scroll to bottom
+- Pause/resume streaming
+- Search/filter (Ctrl+F)
+- Download logs
+- Clear display
+
+## Port Forwarding
+
+### Starting a Port Forward
+
+1. Select a Pod or Service
+2. Click **Port Forward** in the detail panel
+3. Select the target port from available ports
+4. Optionally specify local port (auto-assigned if empty)
+5. Click **Start**
+
+### Managing Port Forwards
+
+The Port Forward panel shows all active sessions:
+- Target resource and port
+- Local port and URL
+- Status indicator
+- Stop button
+
+Click the local URL to open in a new tab.
+
+### Auto-Discovery
+
+Explorer automatically discovers available ports from:
+- Pod container port definitions
+- Service port configurations
+
+## Helm Management
+
+Access via the **Helm** tab in the navigation.
+
+### Release List
+
+Shows all Helm releases across namespaces:
+- Release name and namespace
+- Chart name and version
+- App version
+- Status (deployed, failed, etc.)
+- Revision number
+- Last updated timestamp
+
+### Release Details
+
+Click a release to see:
+
+**Overview**
+- Chart information
+- Release notes
+- Resource count
+
+**Values**
+- Computed values YAML
+- User-supplied vs default values
+
+**Manifest**
+- Rendered Kubernetes manifests
+- All resources created by the release
+
+**History**
+- All revisions with timestamps
+- Diff between revisions
+- Rollback to any revision
+
+### Release Actions
+
+**Rollback**
+1. Open release details
+2. Go to History tab
+3. Select a revision
+4. Click **Rollback**
+5. Confirm the operation
+
+**Uninstall**
+1. Open release details
+2. Click **Uninstall**
+3. Confirm deletion
+
+## Events Timeline
+
+Access via the **Events** tab in the navigation.
+
+Shows recent Kubernetes events:
+- Resource involved
+- Event type (Normal/Warning)
+- Reason and message
+- Timestamp
+- Count (if repeated)
+
+Filter events by:
+- Namespace
+- Resource type
+- Event type
+- Time range
+
+## Change History
+
+The **Changes** view shows resource modifications:
+
+- Created/Updated/Deleted events
+- Resource kind and name
+- Timestamp
+- Health state changes
+- Owner information
+
+Enable persistent history with `--persist-history` to retain changes across restarts.
+
+## Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `Escape` | Close panel/modal |
+| `?` | Show keyboard shortcuts |
+| `/` | Focus search |
+| `r` | Refresh topology |
+| `f` | Fit view to screen |
+| `1` | Traffic view |
+| `2` | Resources view |
+
+## Tips & Tricks
+
+### Finding Resources
+Use the search box to filter the topology by resource name. Matching nodes are highlighted.
+
+### Debugging Pods
+1. Check Pod status and conditions
+2. View container statuses for restart counts
+3. Check logs for errors
+4. Use terminal to inspect container state
+
+### Understanding Relationships
+Switch to Resources view to see the full ownership chain. Click "Related" tab to see all connected resources.
+
+### Monitoring Deployments
+Watch the topology during a rollout to see new ReplicaSets and Pods being created while old ones terminate.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,0 +1,13 @@
+## Documentation
+
+* [Home](Home)
+* [Getting Started](Getting-Started)
+* [User Guide](User-Guide)
+* [API Reference](API-Reference)
+* [Development](Development)
+
+## Links
+
+* [GitHub Repository](https://github.com/skyhook-io/explorer)
+* [Issues](https://github.com/skyhook-io/explorer/issues)
+* [Releases](https://github.com/skyhook-io/explorer/releases)


### PR DESCRIPTION
## Summary

- Update README.md and CLAUDE.md with all current features including Helm integration, pod terminal access, logs streaming, port forwarding, and change history tracking
- Add complete GitHub Wiki documentation in `docs/wiki/` with Getting Started, User Guide, API Reference, and Development guides
- Fix incorrect default port (was 8080, now correctly 9280)
- Document all 30+ API endpoints with request/response examples

## Wiki Content

The `docs/wiki/` folder contains ready-to-publish documentation:
- **Home.md** - Wiki landing page
- **Getting-Started.md** - Installation and first run
- **User-Guide.md** - Complete UI documentation
- **API-Reference.md** - Full REST API docs
- **Development.md** - Contributing guide

To publish: clone the wiki repo and copy these files over.

🤖 Generated with [Claude Code](https://claude.ai/code)