### PR TITLE
Improve cluster card UX and show apiVersion/kind in YAML view

### DIFF
--- a/web/src/components/home/ClusterHealthCard.tsx
+++ b/web/src/components/home/ClusterHealthCard.tsx
@@ -68,8 +68,6 @@ export function ClusterHealthCard({
 }: ClusterHealthCardProps) {
   void _topCRDs // Reserved for future CRD display
 
-  const allHealthy = health.warning === 0 && health.error === 0
-
   // Pods ring segments
   const podsTotal = health.healthy + health.warning + health.error
   const podsRingSegments = [
@@ -104,14 +102,7 @@ export function ClusterHealthCard({
   return (
     <div className="rounded-lg border border-theme-border-light bg-theme-surface/50 overflow-hidden">
       {/* Main health section - three columns */}
-      <div className={clsx(
-        'px-6 py-5 border-b',
-        allHealthy
-          ? 'border-green-500/20 bg-green-500/5'
-          : health.error > 0
-            ? 'border-red-500/20 bg-red-500/5'
-            : 'border-yellow-500/20 bg-yellow-500/5'
-      )}>
+      <div className="px-6 py-5 border-b border-theme-border-light">
         <div className="flex items-stretch gap-8">
           {/* Left: Cluster info */}
           <div className="flex flex-col justify-center min-w-[180px] pr-8 border-r border-theme-border/50">


### PR DESCRIPTION
- Change cluster health card to neutral background color instead of conditional red/yellow/green which felt ominous
- Add apiVersion and kind fields to YAML view for all resources:
  - Typed resources (Pod, Deployment, etc.) via setTypeMeta() helper
  - CRDs/unstructured resources via GVR lookup in GetDynamicWithGroup()
- Kubernetes informers don't populate TypeMeta, so we set it explicitly
