### PR TITLE
Fix nil slice JSON serialization causing frontend errors

### DIFF
--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -634,7 +634,7 @@ func computeLCS(a, b []string) []string {
 // extractHooks extracts hook information from a release
 func extractHooks(rel *release.Release) []HelmHook {
 	if rel.Hooks == nil {
-		return nil
+		return []HelmHook{}
 	}
 
 	hooks := make([]HelmHook, 0, len(rel.Hooks))
@@ -682,7 +682,7 @@ func extractReadme(rel *release.Release) string {
 // extractDependencies extracts chart dependencies
 func extractDependencies(rel *release.Release) []ChartDependency {
 	if rel.Chart == nil || rel.Chart.Metadata == nil || rel.Chart.Metadata.Dependencies == nil {
-		return nil
+		return []ChartDependency{}
 	}
 
 	deps := make([]ChartDependency, 0, len(rel.Chart.Metadata.Dependencies))


### PR DESCRIPTION
## Summary

- Fix "can't access property 'length', x is null" error when viewing Home panel on clusters with zero Helm releases (#37)
- Ensure all slice fields in API responses serialize to empty arrays `[]` instead of `null` in JSON

## Changes

In Go, nil slices serialize to JSON `null` while empty slices serialize to `[]`. The frontend expects arrays for slice fields, so accessing `.length` on `null` throws an error.

This PR changes all backend functions that return slice types to return empty slices instead of nil:

**dashboard.go:**
- `getDashboardHelmSummary` - Initialize `Releases` field
- `getDashboardHealth` - Initialize `problems` slice  
- `getDashboardRecentEvents` - Return empty slice on error/empty
- `getDashboardRecentChanges` - Return empty slice on error/empty
- `getDashboardCRDCounts` - Return empty slice at all exit points
- `getDashboardTrafficSummary` - Initialize `TopFlows` field

**helm/client.go:**
- `extractHooks` - Return empty slice when no hooks
- `extractDependencies` - Return empty slice when no dependencies

Fixes #37