### PR TITLE
Add configurable RBAC for CRDs with expanded coverage

### DIFF
--- a/deploy/helm/radar/Chart.yaml
+++ b/deploy/helm/radar/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: radar
 description: Modern Kubernetes visibility — topology, traffic, and Helm management
 type: application
-version: 0.6.6
-appVersion: "0.6.6"
+version: 0.6.9
+appVersion: "0.6.9"
 keywords:
   - kubernetes
   - visualization

--- a/deploy/helm/radar/README.md
+++ b/deploy/helm/radar/README.md
@@ -75,24 +75,105 @@ See `values.yaml` for all configuration options.
 
 The chart creates a ClusterRole with read-only access to common Kubernetes resources.
 
-**Default permissions (always enabled):**
-- Core: pods, services, configmaps, events, namespaces, nodes, pvcs, serviceaccounts, endpoints
-- Apps: deployments, daemonsets, statefulsets, replicasets
-- Networking: ingresses, networkpolicies
-- Batch: jobs, cronjobs
-- Autoscaling: horizontalpodautoscalers
-- CRDs: Argo, Knative, cert-manager, Gateway API
+### Default Permissions (Core K8s Resources)
 
-**Opt-in permissions (disabled by default for security):**
+Always granted (required for basic functionality):
+
+| API Group | Resources |
+|-----------|-----------|
+| Core (`""`) | pods, services, configmaps, events, namespaces, nodes, pvcs, serviceaccounts, endpoints |
+| `apps` | deployments, daemonsets, statefulsets, replicasets |
+| `networking.k8s.io` | ingresses, networkpolicies |
+| `batch` | jobs, cronjobs |
+| `autoscaling` | horizontalpodautoscalers |
+| `apiextensions.k8s.io` | customresourcedefinitions (for CRD discovery) |
+
+### Privileged Permissions (Opt-in)
+
+Disabled by default for security:
 
 | Feature | Value | Description |
 |---------|-------|-------------|
 | Secrets | `rbac.secrets: true` | View secrets in resource list |
 | Terminal | `rbac.podExec: true` | Shell access to pods |
 | Port Forward | `rbac.portForward: true` | Port forwarding to pods |
-| Logs | `rbac.podLogs: true` | View pod logs (enabled by default) |
+| Logs | `rbac.podLogs: true` | View pod logs (**enabled by default**) |
 
-Radar uses its ServiceAccount permissions to access the Kubernetes API. The UI automatically detects which features are available based on RBAC and hides unavailable features.
+### CRD Access
+
+Radar discovers CRDs in your cluster. All common CRD groups are enabled by default. Granting RBAC for CRDs that don't exist has no effect.
+
+**Wildcard option:** Grant read access to ALL CRDs with one setting:
+```bash
+--set rbac.crdGroups.all=true
+```
+This overrides individual settings below. Simpler but broader — some orgs may not allow this.
+
+| Option | API Groups |
+|--------|------------|
+| `argo` | `argoproj.io` |
+| `awx` | `awx.ansible.com` |
+| `certManager` | `cert-manager.io` |
+| `cloudnativePg` | `cloudnative-pg.io` |
+| `crossplane` | `crossplane.io`, `pkg.crossplane.io` |
+| `descheduler` | `descheduler.alpha.kubernetes.io` |
+| `envoyGateway` | `gateway.envoyproxy.io` |
+| `externalDns` | `externaldns.k8s.io` |
+| `externalSecrets` | `external-secrets.io` |
+| `flux` | `*.toolkit.fluxcd.io` |
+| `gatewayApi` | `gateway.networking.k8s.io` |
+| `gcpMonitoring` | `monitoring.googleapis.com` |
+| `grafana` | `monitoring.grafana.com`, `tempo.grafana.com`, `loki.grafana.com` |
+| `istio` | `networking.istio.io`, `security.istio.io` |
+| `karpenter` | `karpenter.sh`, `karpenter.k8s.aws` |
+| `keda` | `keda.sh` |
+| `knative` | `serving.knative.dev`, `eventing.knative.dev` |
+| `kubeshark` | `kubeshark.io` |
+| `kured` | `kured.io` |
+| `kyverno` | `kyverno.io`, `wgpolicyk8s.io`, `reports.kyverno.io` |
+| `mariadb` | `mariadb.mmontes.io` |
+| `nginx` | `nginx.org` |
+| `openshift` | `observability.openshift.io` |
+| `opentelemetry` | `opentelemetry.io` |
+| `prometheus` | `monitoring.coreos.com` |
+| `reflector` | `reflector.v1.k8s.emberstack.com` |
+| `reloader` | `reloader.stakater.com` |
+| `sealedSecrets` | `sealed-secrets.bitnami.com` |
+| `strimzi` | `strimzi.io`, `kafka.strimzi.io` |
+| `tekton` | `tekton.dev` |
+| `traefik` | `traefik.io`, `traefik.containo.us` |
+| `velero` | `velero.io` |
+
+**Disable groups:** `--set rbac.crdGroups.istio=false`
+
+**Add unlisted CRDs:**
+```yaml
+rbac:
+  additionalCrdGroups:
+    - mycompany.io
+```
+
+### Troubleshooting: "Failed to list resource" Warnings
+
+If you see these warnings, Radar discovered a CRD but doesn't have RBAC access. This is **not an error** — add the API group to `additionalCrdGroups` if you need it.
+
+### Advanced: Custom Rules
+
+For fine-grained control, use `additionalRules` to add arbitrary RBAC rules:
+```yaml
+rbac:
+  additionalRules:
+    - apiGroups: ["custom.example.com"]
+      resources: ["myresources"]
+      verbs: ["get", "list", "watch"]
+    - apiGroups: [""]
+      resources: ["pods"]
+      verbs: ["delete"]  # Dangerous - use with caution
+```
+
+### Capability Detection
+
+Radar uses its ServiceAccount permissions to access the Kubernetes API. The UI automatically detects which features are available based on RBAC and hides unavailable features (e.g., the terminal button won't appear if `podExec` is disabled).
 
 ## Upgrading
 

--- a/deploy/helm/radar/templates/clusterrole.yaml
+++ b/deploy/helm/radar/templates/clusterrole.yaml
@@ -93,15 +93,183 @@ rules:
       - customresourcedefinitions
     verbs: ["get", "list", "watch"]
 
-  # Common CRDs (Argo, Knative, etc.) - read-only
-  - apiGroups:
-      - argoproj.io
-      - serving.knative.dev
-      - eventing.knative.dev
-      - cert-manager.io
-      - gateway.networking.k8s.io
+  # CRD access
+  {{- if .Values.rbac.crdGroups.all }}
+  # Wildcard access to all CRDs (rbac.crdGroups.all=true)
+  - apiGroups: ["*"]
     resources: ["*"]
     verbs: ["get", "list", "watch"]
+  {{- else }}
+  # Per-group CRD access
+  {{- if .Values.rbac.crdGroups.argo }}
+  - apiGroups: ["argoproj.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.awx }}
+  - apiGroups: ["awx.ansible.com"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.certManager }}
+  - apiGroups: ["cert-manager.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.cloudnativePg }}
+  - apiGroups: ["cloudnative-pg.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.crossplane }}
+  - apiGroups: ["crossplane.io", "pkg.crossplane.io", "apiextensions.crossplane.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.descheduler }}
+  - apiGroups: ["descheduler.alpha.kubernetes.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.envoyGateway }}
+  - apiGroups: ["gateway.envoyproxy.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.externalDns }}
+  - apiGroups: ["externaldns.k8s.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.externalSecrets }}
+  - apiGroups: ["external-secrets.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.flux }}
+  - apiGroups: ["source.toolkit.fluxcd.io", "kustomize.toolkit.fluxcd.io", "helm.toolkit.fluxcd.io", "notification.toolkit.fluxcd.io", "image.toolkit.fluxcd.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.gatewayApi }}
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.gcpMonitoring }}
+  - apiGroups: ["monitoring.googleapis.com"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.grafana }}
+  - apiGroups: ["monitoring.grafana.com", "tempo.grafana.com", "loki.grafana.com", "grafana.integreatly.org"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.istio }}
+  - apiGroups: ["networking.istio.io", "security.istio.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.karpenter }}
+  - apiGroups: ["karpenter.sh", "karpenter.k8s.aws"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.keda }}
+  - apiGroups: ["keda.sh"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.knative }}
+  - apiGroups: ["serving.knative.dev", "eventing.knative.dev"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.kubeshark }}
+  - apiGroups: ["kubeshark.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.kured }}
+  - apiGroups: ["kured.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.kyverno }}
+  - apiGroups: ["kyverno.io", "wgpolicyk8s.io", "reports.kyverno.io", "openreports.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.mariadb }}
+  - apiGroups: ["mariadb.mmontes.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.nginx }}
+  - apiGroups: ["nginx.org"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.openshift }}
+  - apiGroups: ["observability.openshift.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.opentelemetry }}
+  - apiGroups: ["opentelemetry.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.prometheus }}
+  - apiGroups: ["monitoring.coreos.com"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.reflector }}
+  - apiGroups: ["reflector.v1.k8s.emberstack.com"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.reloader }}
+  - apiGroups: ["reloader.stakater.com"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.sealedSecrets }}
+  - apiGroups: ["sealed-secrets.bitnami.com"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.strimzi }}
+  - apiGroups: ["strimzi.io", "kafka.strimzi.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.tekton }}
+  - apiGroups: ["tekton.dev"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.traefik }}
+  - apiGroups: ["traefik.io", "traefik.containo.us"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.velero }}
+  - apiGroups: ["velero.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- end }}
+
+  {{- with .Values.rbac.additionalCrdGroups }}
+  # Additional CRD groups from additionalCrdGroups
+  - apiGroups:
+    {{- toYaml . | nindent 6 }}
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
 
   {{- with .Values.rbac.additionalRules }}
   {{- toYaml . | nindent 2 }}

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -44,6 +44,50 @@ rbac:
   # Allow port forwarding (enables port forward feature)
   portForward: false
 
+  # CRD access - all common groups enabled by default
+  # Granting RBAC for CRDs that don't exist has no effect.
+  crdGroups:
+    # Set to true to grant read access to ALL CRDs (overrides individual settings below)
+    # Simpler but broader permissions - some orgs may not allow this
+    all: false
+
+    argo: true              # argoproj.io
+    awx: true               # awx.ansible.com
+    certManager: true       # cert-manager.io
+    cloudnativePg: true     # cloudnative-pg.io
+    crossplane: true        # crossplane.io, pkg.crossplane.io
+    descheduler: true       # descheduler.alpha.kubernetes.io
+    envoyGateway: true      # gateway.envoyproxy.io
+    externalDns: true       # externaldns.k8s.io
+    externalSecrets: true   # external-secrets.io
+    flux: true              # *.toolkit.fluxcd.io
+    gatewayApi: true        # gateway.networking.k8s.io
+    gcpMonitoring: true     # monitoring.googleapis.com
+    grafana: true           # monitoring.grafana.com, tempo/loki/grafana.integreatly.org
+    istio: true             # networking.istio.io, security.istio.io
+    karpenter: true         # karpenter.sh, karpenter.k8s.aws
+    keda: true              # keda.sh
+    knative: true           # serving.knative.dev, eventing.knative.dev
+    kubeshark: true         # kubeshark.io
+    kured: true             # kured.io
+    kyverno: true           # kyverno.io, wgpolicyk8s.io, reports.kyverno.io
+    mariadb: true           # mariadb.mmontes.io
+    nginx: true             # nginx.org
+    openshift: true         # observability.openshift.io
+    opentelemetry: true     # opentelemetry.io
+    prometheus: true        # monitoring.coreos.com
+    reflector: true         # reflector.v1.k8s.emberstack.com
+    reloader: true          # reloader.stakater.com
+    sealedSecrets: true     # sealed-secrets.bitnami.com
+    strimzi: true           # strimzi.io, kafka.strimzi.io
+    tekton: true            # tekton.dev
+    traefik: true           # traefik.io, traefik.containo.us
+    velero: true            # velero.io
+
+  # Additional CRD API groups for custom/unlisted CRDs
+  # Example: ["mycompany.io", "custom.example.com"]
+  additionalCrdGroups: []
+
 podAnnotations: {}
 
 podSecurityContext:


### PR DESCRIPTION
## Summary

- Expands CRD RBAC coverage from 4 groups to 33 common CRD API groups
- All CRD groups enabled by default (granting RBAC for non-existent CRDs has no effect)
- Adds `rbac.crdGroups.all` option for wildcard access to all CRDs
- Adds `rbac.additionalCrdGroups` for custom/unlisted API groups
- Improves RBAC documentation with troubleshooting guidance

Addresses "Failed to list resource" warnings by providing comprehensive CRD coverage and clear documentation on how to add access for unlisted CRDs.

## Usage

```bash
# Use expanded defaults (33 CRD groups)
helm install radar ./deploy/helm/radar

# Or enable wildcard access to all CRDs
helm install radar ./deploy/helm/radar --set rbac.crdGroups.all=true

# Disable specific groups
helm install radar ./deploy/helm/radar --set rbac.crdGroups.istio=false

# Add custom CRDs
helm install radar ./deploy/helm/radar --set rbac.additionalCrdGroups='{mycompany.io}'
```