### PR TITLE
fix: Remove Google Fonts CDN for airgapped environment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ curl -fsSL https://raw.githubusercontent.com/skyhook-io/radar/main/install.sh | 
 
 - **Zero install on your cluster** — runs on your laptop, talks to the K8s API directly
 - **Single binary** — no dependencies, no agents, no CRDs
+- **Airgapped-ready** — no external network calls, works in isolated environments
 - **Real-time** — watches your cluster via informers, pushes updates to the browser via SSE
 - **Works everywhere** — GKE, EKS, AKS, minikube, kind, k3s, or any conformant cluster
 - **In-cluster option** — deploy with Helm for shared team access with RBAC-scoped permissions

--- a/web/index.html
+++ b/web/index.html
@@ -5,9 +5,6 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600&display=swap" rel="stylesheet">
     <title>Radar</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary

- Remove external Google Fonts CDN references that would fail in airgapped deployments
- The CSS already uses a system font stack (Inter, system-ui, etc.) so this is a no-op for users with Inter installed and graceful fallback for others
- Add "Airgapped-ready" to the README feature list

Radar is now fully usable in isolated networks with no external network dependencies.