### PR TITLE
feat: Add workload-level log viewing

### DIFF
--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -1117,7 +1117,7 @@ func (c *ResourceCache) GetResourceStatus(kind, namespace, name string) *Resourc
 
 		// Check pod-level issues for unhealthy deployments
 		if dep.Status.ReadyReplicas < dep.Status.Replicas && dep.Status.Replicas > 0 {
-			pods := c.getPodsForWorkload(namespace, dep.Spec.Selector)
+			pods := c.GetPodsForWorkload(namespace, dep.Spec.Selector)
 			if len(pods) > 0 {
 				issueSummary := getPodsIssueSummary(pods)
 				if issueSummary.TopIssue != "" {
@@ -1155,7 +1155,7 @@ func (c *ResourceCache) GetResourceStatus(kind, namespace, name string) *Resourc
 
 		// Check pod-level issues for unhealthy statefulsets
 		if sts.Status.ReadyReplicas < replicas && replicas > 0 {
-			pods := c.getPodsForWorkload(namespace, sts.Spec.Selector)
+			pods := c.GetPodsForWorkload(namespace, sts.Spec.Selector)
 			if len(pods) > 0 {
 				issueSummary := getPodsIssueSummary(pods)
 				if issueSummary.TopIssue != "" {
@@ -1188,7 +1188,7 @@ func (c *ResourceCache) GetResourceStatus(kind, namespace, name string) *Resourc
 
 		// Get pods owned by this DaemonSet
 		if ds.Status.NumberReady < ds.Status.DesiredNumberScheduled {
-			pods := c.getPodsForWorkload(namespace, ds.Spec.Selector)
+			pods := c.GetPodsForWorkload(namespace, ds.Spec.Selector)
 			if len(pods) > 0 {
 				issueSummary := getPodsIssueSummary(pods)
 				if issueSummary.TopIssue != "" {
@@ -1460,8 +1460,8 @@ func (s *PodIssueSummary) FormatStatusSummary() string {
 	return fmt.Sprintf("%d/%d ready", s.Ready, s.Total)
 }
 
-// getPodsForWorkload returns pods matching the given label selector in a namespace
-func (c *ResourceCache) getPodsForWorkload(namespace string, selector *metav1.LabelSelector) []*corev1.Pod {
+// GetPodsForWorkload returns pods matching the given label selector in a namespace
+func (c *ResourceCache) GetPodsForWorkload(namespace string, selector *metav1.LabelSelector) []*corev1.Pod {
 	if c == nil || selector == nil {
 		return nil
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -150,6 +150,11 @@ func (s *Server) setupRoutes() {
 		// Workload restart
 		r.Post("/workloads/{kind}/{namespace}/{name}/restart", s.handleRestartWorkload)
 
+		// Workload logs (aggregated from all pods)
+		r.Get("/workloads/{kind}/{namespace}/{name}/logs", s.handleWorkloadLogs)
+		r.Get("/workloads/{kind}/{namespace}/{name}/logs/stream", s.handleWorkloadLogsStream)
+		r.Get("/workloads/{kind}/{namespace}/{name}/pods", s.handleWorkloadPods)
+
 		// Helm routes
 		helmHandlers := helm.NewHandlers()
 		helmHandlers.RegisterRoutes(r)

--- a/internal/server/workload_logs.go
+++ b/internal/server/workload_logs.go
@@ -1,0 +1,534 @@
+package server
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+)
+
+// WorkloadPodInfo contains basic info about a pod for the UI
+type WorkloadPodInfo struct {
+	Name       string   `json:"name"`
+	Containers []string `json:"containers"`
+	Ready      bool     `json:"ready"`
+}
+
+// workloadLogEntry is an internal structure for log lines from pods
+type workloadLogEntry struct {
+	Pod       string `json:"pod"`
+	Container string `json:"container"`
+	Timestamp string `json:"timestamp"`
+	Content   string `json:"content"`
+}
+
+// validWorkloadKinds defines which resource types support workload logs
+var validWorkloadKinds = map[string]bool{
+	"deployments":  true,
+	"statefulsets": true,
+	"daemonsets":   true,
+}
+
+// handleWorkloadPods returns the list of pods for a workload
+func (s *Server) handleWorkloadPods(w http.ResponseWriter, r *http.Request) {
+	kind := strings.ToLower(chi.URLParam(r, "kind"))
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	pods, err := s.getWorkloadPods(kind, namespace, name)
+	if err != nil {
+		s.writeWorkloadError(w, err)
+		return
+	}
+
+	s.writeJSON(w, map[string]any{
+		"pods": buildPodInfos(pods),
+	})
+}
+
+// handleWorkloadLogs fetches and merges logs from all pods (non-streaming)
+func (s *Server) handleWorkloadLogs(w http.ResponseWriter, r *http.Request) {
+	kind := strings.ToLower(chi.URLParam(r, "kind"))
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+	container := r.URL.Query().Get("container")
+	tailLines := parseTailLines(r.URL.Query().Get("tailLines"), 100)
+
+	pods, err := s.getWorkloadPods(kind, namespace, name)
+	if err != nil {
+		s.writeWorkloadError(w, err)
+		return
+	}
+
+	if len(pods) == 0 {
+		s.writeJSON(w, map[string]any{
+			"pods": []WorkloadPodInfo{},
+			"logs": []workloadLogEntry{},
+		})
+		return
+	}
+
+	client := k8s.GetClient()
+	if client == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "kubernetes client not available")
+		return
+	}
+
+	// Collect logs from all pods concurrently
+	allLogs := collectLogsFromPods(r.Context(), client, namespace, pods, container, tailLines)
+
+	// Sort by timestamp (string comparison works for RFC3339 format)
+	sortLogsByTimestamp(allLogs)
+
+	s.writeJSON(w, map[string]any{
+		"pods": buildPodInfos(pods),
+		"logs": allLogs,
+	})
+}
+
+// handleWorkloadLogsStream streams logs from all pods using SSE
+func (s *Server) handleWorkloadLogsStream(w http.ResponseWriter, r *http.Request) {
+	kind := strings.ToLower(chi.URLParam(r, "kind"))
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+	container := r.URL.Query().Get("container")
+	tailLines := parseTailLines(r.URL.Query().Get("tailLines"), 50)
+
+	if !validWorkloadKinds[kind] {
+		s.writeError(w, http.StatusBadRequest, "only deployments, statefulsets, and daemonsets are supported")
+		return
+	}
+
+	// Set SSE headers
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	cache := k8s.GetResourceCache()
+	if cache == nil {
+		sendSSEEvent(w, flusher, "error", map[string]string{"message": "resource cache not available"})
+		return
+	}
+
+	client := k8s.GetClient()
+	if client == nil {
+		sendSSEEvent(w, flusher, "error", map[string]string{"message": "kubernetes client not available"})
+		return
+	}
+
+	selector, err := getWorkloadSelector(cache, kind, namespace, name)
+	if err != nil {
+		sendSSEEvent(w, flusher, "error", map[string]string{"message": err.Error()})
+		return
+	}
+
+	// Get initial pods
+	pods := cache.GetPodsForWorkload(namespace, selector)
+	podInfos := buildPodInfos(pods)
+
+	// Send connected event with pod list
+	sendSSEEvent(w, flusher, "connected", map[string]any{
+		"workload":  name,
+		"namespace": namespace,
+		"kind":      kind,
+		"pods":      podInfos,
+	})
+
+	if len(pods) == 0 {
+		sendSSEEvent(w, flusher, "end", map[string]string{"reason": "no pods found"})
+		return
+	}
+
+	// Context for managing goroutines
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	// Channel for aggregated log lines
+	logCh := make(chan workloadLogEntry, 1000)
+
+	// Track active streams
+	var activeStreams sync.Map // podName+containerName -> cancel func
+	var streamWg sync.WaitGroup
+
+	// Start streaming from each pod/container
+	startPodStreams := func(pods []*corev1.Pod) {
+		for _, pod := range pods {
+			containers := getContainersToLog(pod, container)
+			for _, c := range containers {
+				key := pod.Name + "/" + c
+				if _, exists := activeStreams.Load(key); exists {
+					continue // Already streaming
+				}
+
+				streamCtx, streamCancel := context.WithCancel(ctx)
+				activeStreams.Store(key, streamCancel)
+
+				streamWg.Add(1)
+				go func(podName, containerName string, streamCtx context.Context) {
+					defer streamWg.Done()
+					defer activeStreams.Delete(podName + "/" + containerName)
+
+					streamPodLogs(streamCtx, client, namespace, podName, containerName, tailLines, logCh)
+				}(pod.Name, c, streamCtx)
+			}
+		}
+	}
+
+	// Start initial streams
+	startPodStreams(pods)
+
+	// Pod discovery ticker (every 5 seconds)
+	discoveryTicker := time.NewTicker(5 * time.Second)
+	defer discoveryTicker.Stop()
+
+	// Track known pods for detecting changes
+	knownPods := make(map[string]bool)
+	for _, p := range pods {
+		knownPods[p.Name] = true
+	}
+
+	// Main loop: forward logs and handle pod discovery
+	for {
+		select {
+		case <-ctx.Done():
+			sendSSEEvent(w, flusher, "end", map[string]string{"reason": "client disconnected"})
+			return
+
+		case entry := <-logCh:
+			sendSSEEvent(w, flusher, "log", entry)
+
+		case <-discoveryTicker.C:
+			// Re-discover pods
+			currentPods := cache.GetPodsForWorkload(namespace, selector)
+			currentPodNames := make(map[string]bool)
+			for _, p := range currentPods {
+				currentPodNames[p.Name] = true
+			}
+
+			// Check for new pods
+			var newPods []*corev1.Pod
+			for _, p := range currentPods {
+				if !knownPods[p.Name] {
+					newPods = append(newPods, p)
+					knownPods[p.Name] = true
+					// Notify frontend about new pod
+					sendSSEEvent(w, flusher, "pod_added", map[string]any{
+						"pods": []WorkloadPodInfo{buildPodInfo(p)},
+					})
+				}
+			}
+
+			// Check for removed pods
+			for podName := range knownPods {
+				if !currentPodNames[podName] {
+					delete(knownPods, podName)
+					// Cancel streams for this pod
+					activeStreams.Range(func(key, value any) bool {
+						if strings.HasPrefix(key.(string), podName+"/") {
+							if cancelFn, ok := value.(context.CancelFunc); ok {
+								cancelFn()
+							}
+							activeStreams.Delete(key)
+						}
+						return true
+					})
+					// Notify frontend
+					sendSSEEvent(w, flusher, "pod_removed", map[string]string{
+						"pod":    podName,
+						"reason": "terminated",
+					})
+				}
+			}
+
+			// Start streams for new pods
+			if len(newPods) > 0 {
+				startPodStreams(newPods)
+			}
+		}
+	}
+}
+
+// streamPodLogs streams logs from a single pod/container to the log channel
+func streamPodLogs(ctx context.Context, client *kubernetes.Clientset, namespace, podName, containerName string, tailLines int64, logCh chan<- workloadLogEntry) {
+	opts := &corev1.PodLogOptions{
+		Container:  containerName,
+		Follow:     true,
+		TailLines:  &tailLines,
+		Timestamps: true,
+	}
+
+	req := client.CoreV1().Pods(namespace).GetLogs(podName, opts)
+	stream, err := req.Stream(ctx)
+	if err != nil {
+		log.Printf("[workload-logs] Failed to stream logs for %s/%s: %v", podName, containerName, err)
+		return
+	}
+	defer stream.Close()
+
+	reader := bufio.NewReader(stream)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				if err == io.EOF || ctx.Err() != nil {
+					return
+				}
+				log.Printf("[workload-logs] Read error for %s/%s: %v", podName, containerName, err)
+				return
+			}
+
+			line = strings.TrimSuffix(line, "\n")
+			if line == "" {
+				continue
+			}
+
+			ts, content := parseLogLine(line)
+			select {
+			case logCh <- workloadLogEntry{
+				Pod:       podName,
+				Container: containerName,
+				Timestamp: ts,
+				Content:   content,
+			}:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+// getWorkloadSelector returns the label selector for a workload
+func getWorkloadSelector(cache *k8s.ResourceCache, kind, namespace, name string) (*metav1.LabelSelector, error) {
+	switch kind {
+	case "deployments":
+		dep, err := cache.Deployments().Deployments(namespace).Get(name)
+		if err != nil {
+			return nil, fmt.Errorf("deployment %s/%s not found: %w", namespace, name, err)
+		}
+		return dep.Spec.Selector, nil
+
+	case "statefulsets":
+		sts, err := cache.StatefulSets().StatefulSets(namespace).Get(name)
+		if err != nil {
+			return nil, fmt.Errorf("statefulset %s/%s not found: %w", namespace, name, err)
+		}
+		return sts.Spec.Selector, nil
+
+	case "daemonsets":
+		ds, err := cache.DaemonSets().DaemonSets(namespace).Get(name)
+		if err != nil {
+			return nil, fmt.Errorf("daemonset %s/%s not found: %w", namespace, name, err)
+		}
+		return ds.Spec.Selector, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported workload kind: %s", kind)
+	}
+}
+
+// getContainersToLog returns containers to stream logs from
+func getContainersToLog(pod *corev1.Pod, selectedContainer string) []string {
+	if selectedContainer != "" {
+		// Check if this container exists in the pod
+		for _, c := range pod.Spec.Containers {
+			if c.Name == selectedContainer {
+				return []string{selectedContainer}
+			}
+		}
+		for _, c := range pod.Spec.InitContainers {
+			if c.Name == selectedContainer {
+				return []string{selectedContainer}
+			}
+		}
+		// Container not found, return empty
+		return nil
+	}
+
+	// Return all containers
+	containers := make([]string, 0, len(pod.Spec.Containers))
+	for _, c := range pod.Spec.Containers {
+		containers = append(containers, c.Name)
+	}
+	return containers
+}
+
+// isPodReady checks if all containers in a pod are ready
+func isPodReady(pod *corev1.Pod) bool {
+	if pod.Status.Phase != corev1.PodRunning {
+		return false
+	}
+	for _, cs := range pod.Status.ContainerStatuses {
+		if !cs.Ready {
+			return false
+		}
+	}
+	return true
+}
+
+// buildPodInfos converts pods to WorkloadPodInfo slice
+func buildPodInfos(pods []*corev1.Pod) []WorkloadPodInfo {
+	infos := make([]WorkloadPodInfo, 0, len(pods))
+	for _, pod := range pods {
+		infos = append(infos, buildPodInfo(pod))
+	}
+	return infos
+}
+
+// buildPodInfo converts a single pod to WorkloadPodInfo
+func buildPodInfo(pod *corev1.Pod) WorkloadPodInfo {
+	containers := make([]string, 0, len(pod.Spec.Containers)+len(pod.Spec.InitContainers))
+	for _, c := range pod.Spec.InitContainers {
+		containers = append(containers, c.Name)
+	}
+	for _, c := range pod.Spec.Containers {
+		containers = append(containers, c.Name)
+	}
+	return WorkloadPodInfo{
+		Name:       pod.Name,
+		Containers: containers,
+		Ready:      isPodReady(pod),
+	}
+}
+
+// sortLogsByTimestamp sorts log entries by timestamp using efficient sort
+func sortLogsByTimestamp(logs []workloadLogEntry) {
+	sort.Slice(logs, func(i, j int) bool {
+		return logs[i].Timestamp < logs[j].Timestamp
+	})
+}
+
+// workloadError represents a typed error for workload operations
+type workloadError struct {
+	statusCode int
+	message    string
+}
+
+func (e *workloadError) Error() string { return e.message }
+
+// getWorkloadPods validates the kind, retrieves cache, and returns pods for a workload
+func (s *Server) getWorkloadPods(kind, namespace, name string) ([]*corev1.Pod, *workloadError) {
+	if !validWorkloadKinds[kind] {
+		return nil, &workloadError{http.StatusBadRequest, "only deployments, statefulsets, and daemonsets are supported"}
+	}
+
+	cache := k8s.GetResourceCache()
+	if cache == nil {
+		return nil, &workloadError{http.StatusServiceUnavailable, "resource cache not available"}
+	}
+
+	selector, err := getWorkloadSelector(cache, kind, namespace, name)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return nil, &workloadError{http.StatusNotFound, err.Error()}
+		}
+		return nil, &workloadError{http.StatusInternalServerError, err.Error()}
+	}
+
+	return cache.GetPodsForWorkload(namespace, selector), nil
+}
+
+// writeWorkloadError writes an error response based on workloadError
+func (s *Server) writeWorkloadError(w http.ResponseWriter, err *workloadError) {
+	s.writeError(w, err.statusCode, err.message)
+}
+
+// parseTailLines parses tailLines query parameter with a default value
+func parseTailLines(str string, defaultVal int64) int64 {
+	if str == "" {
+		return defaultVal
+	}
+	if t, err := strconv.ParseInt(str, 10, 64); err == nil && t > 0 {
+		return t
+	}
+	return defaultVal
+}
+
+// collectLogsFromPods fetches logs from all pods concurrently
+func collectLogsFromPods(ctx context.Context, client *kubernetes.Clientset, namespace string, pods []*corev1.Pod, container string, tailLines int64) []workloadLogEntry {
+	var allLogs []workloadLogEntry
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for _, pod := range pods {
+		containers := getContainersToLog(pod, container)
+		for _, c := range containers {
+			wg.Add(1)
+			go func(podName, containerName string) {
+				defer wg.Done()
+
+				entries := fetchPodContainerLogs(ctx, client, namespace, podName, containerName, tailLines)
+				if len(entries) > 0 {
+					mu.Lock()
+					allLogs = append(allLogs, entries...)
+					mu.Unlock()
+				}
+			}(pod.Name, c)
+		}
+	}
+
+	wg.Wait()
+	return allLogs
+}
+
+// fetchPodContainerLogs fetches logs for a single pod/container
+func fetchPodContainerLogs(ctx context.Context, client *kubernetes.Clientset, namespace, podName, containerName string, tailLines int64) []workloadLogEntry {
+	opts := &corev1.PodLogOptions{
+		Container:  containerName,
+		TailLines:  &tailLines,
+		Timestamps: true,
+	}
+
+	req := client.CoreV1().Pods(namespace).GetLogs(podName, opts)
+	stream, err := req.Stream(ctx)
+	if err != nil {
+		log.Printf("[workload-logs] Failed to get logs for %s/%s: %v", podName, containerName, err)
+		return nil
+	}
+	defer stream.Close()
+
+	content, err := io.ReadAll(stream)
+	if err != nil {
+		log.Printf("[workload-logs] Failed to read logs for %s/%s: %v", podName, containerName, err)
+		return nil
+	}
+
+	lines := strings.Split(string(content), "\n")
+	entries := make([]workloadLogEntry, 0, len(lines))
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		ts, text := parseLogLine(line)
+		entries = append(entries, workloadLogEntry{
+			Pod:       podName,
+			Container: containerName,
+			Timestamp: ts,
+			Content:   text,
+		})
+	}
+	return entries
+}

--- a/web/src/components/dock/BottomDock.tsx
+++ b/web/src/components/dock/BottomDock.tsx
@@ -1,9 +1,10 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
-import { X, ChevronDown, ChevronUp, Terminal, FileText, Trash2 } from 'lucide-react'
+import { X, ChevronDown, ChevronUp, Terminal, FileText, Trash2, Layers } from 'lucide-react'
 import { clsx } from 'clsx'
 import { useDock, DockTab } from './DockContext'
 import { TerminalTab } from './TerminalTab'
 import { LogsTab } from './LogsTab'
+import { WorkloadLogsTab } from './WorkloadLogsTab'
 
 const MIN_HEIGHT = 200
 const DEFAULT_HEIGHT = 300
@@ -135,7 +136,7 @@ function TabButton({
   onSelect: () => void
   onClose: () => void
 }) {
-  const Icon = tab.type === 'terminal' ? Terminal : FileText
+  const Icon = tab.type === 'terminal' ? Terminal : tab.type === 'workload-logs' ? Layers : FileText
 
   return (
     <div
@@ -182,6 +183,16 @@ function TabContent({ tab, isActive }: { tab: DockTab; isActive: boolean }) {
         podName={tab.podName!}
         containers={tab.containers!}
         initialContainer={tab.containerName}
+      />
+    )
+  }
+
+  if (tab.type === 'workload-logs') {
+    return (
+      <WorkloadLogsTab
+        namespace={tab.namespace!}
+        workloadKind={tab.workloadKind!}
+        workloadName={tab.workloadName!}
       />
     )
   }

--- a/web/src/components/dock/WorkloadLogsTab.tsx
+++ b/web/src/components/dock/WorkloadLogsTab.tsx
@@ -1,0 +1,23 @@
+import { WorkloadLogsViewer } from '../logs/WorkloadLogsViewer'
+
+interface WorkloadLogsTabProps {
+  namespace: string
+  workloadKind: string
+  workloadName: string
+}
+
+export function WorkloadLogsTab({
+  namespace,
+  workloadKind,
+  workloadName,
+}: WorkloadLogsTabProps) {
+  return (
+    <div className="h-full">
+      <WorkloadLogsViewer
+        kind={workloadKind}
+        namespace={namespace}
+        name={workloadName}
+      />
+    </div>
+  )
+}

--- a/web/src/components/dock/index.ts
+++ b/web/src/components/dock/index.ts
@@ -1,2 +1,2 @@
-export { DockProvider, useDock, useOpenTerminal, useOpenLogs } from './DockContext'
+export { DockProvider, useDock, useOpenTerminal, useOpenLogs, useOpenWorkloadLogs } from './DockContext'
 export { BottomDock } from './BottomDock'

--- a/web/src/components/logs/WorkloadLogsViewer.tsx
+++ b/web/src/components/logs/WorkloadLogsViewer.tsx
@@ -1,0 +1,527 @@
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
+import { useWorkloadLogs, createWorkloadLogStream } from '../../api/client'
+import type { WorkloadPodInfo, WorkloadLogStreamEvent } from '../../types'
+import { Play, Pause, Download, Search, X, ChevronDown, Terminal, RotateCcw, Filter } from 'lucide-react'
+import { Tooltip } from '../ui/Tooltip'
+import {
+  formatLogTimestamp,
+  getLogLevelColor,
+  highlightSearchMatches,
+  escapeHtml,
+} from '../../utils/log-format'
+
+interface LogLine {
+  timestamp: string
+  content: string
+  container: string
+  pod: string
+}
+
+interface WorkloadLogsViewerProps {
+  kind: string
+  namespace: string
+  name: string
+}
+
+// Pod colors for visual distinction
+const POD_COLORS = [
+  'text-blue-400',
+  'text-green-400',
+  'text-yellow-400',
+  'text-purple-400',
+  'text-pink-400',
+  'text-cyan-400',
+  'text-orange-400',
+  'text-lime-400',
+]
+
+export function WorkloadLogsViewer({ kind, namespace, name }: WorkloadLogsViewerProps) {
+  const [selectedContainer, setSelectedContainer] = useState<string>('')
+  const [selectedPods, setSelectedPods] = useState<Set<string>>(new Set())
+  const [isStreaming, setIsStreaming] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [showSearch, setShowSearch] = useState(false)
+  const [showPodFilter, setShowPodFilter] = useState(false)
+  const [tailLines, setTailLines] = useState(100)
+  const [logLines, setLogLines] = useState<LogLine[]>([])
+  const [autoScroll, setAutoScroll] = useState(true)
+  const [pods, setPods] = useState<WorkloadPodInfo[]>([])
+  const [podColors, setPodColors] = useState<Map<string, string>>(new Map())
+
+  const logContainerRef = useRef<HTMLDivElement>(null)
+  const eventSourceRef = useRef<EventSource | null>(null)
+
+  // Fetch initial logs (non-streaming)
+  const { data: logsData, refetch, isLoading } = useWorkloadLogs(kind, namespace, name, {
+    container: selectedContainer || undefined,
+    tailLines,
+  })
+
+  // Get all unique containers across all pods
+  const allContainers = useMemo(() => {
+    const containers = new Set<string>()
+    pods.forEach(pod => {
+      pod.containers.forEach(c => containers.add(c))
+    })
+    return Array.from(containers)
+  }, [pods])
+
+  // Parse logs data into lines
+  useEffect(() => {
+    if (logsData) {
+      const podsList = logsData.pods || []
+      const logsList = logsData.logs || []
+
+      setPods(podsList)
+
+      // Assign colors to pods
+      const colors = new Map<string, string>()
+      podsList.forEach((pod, i) => {
+        colors.set(pod.name, POD_COLORS[i % POD_COLORS.length])
+      })
+      setPodColors(colors)
+
+      // Initialize selected pods to all pods
+      if (selectedPods.size === 0 && podsList.length > 0) {
+        setSelectedPods(new Set(podsList.map(p => p.name)))
+      }
+
+      // Convert logs to lines
+      const lines = logsList.map(log => ({
+        timestamp: log.timestamp,
+        content: log.content,
+        container: log.container,
+        pod: log.pod,
+      }))
+      setLogLines(lines)
+    }
+  }, [logsData, selectedPods.size])
+
+  // Auto-scroll to bottom
+  useEffect(() => {
+    if (autoScroll && logContainerRef.current) {
+      logContainerRef.current.scrollTop = logContainerRef.current.scrollHeight
+    }
+  }, [logLines, autoScroll])
+
+  // Handle scroll to detect if user scrolled up
+  const handleScroll = useCallback(() => {
+    if (!logContainerRef.current) return
+    const { scrollTop, scrollHeight, clientHeight } = logContainerRef.current
+    const isAtBottom = scrollHeight - scrollTop - clientHeight < 50
+    setAutoScroll(isAtBottom)
+  }, [])
+
+  // Start streaming
+  const startStreaming = useCallback(() => {
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close()
+    }
+
+    const es = createWorkloadLogStream(kind, namespace, name, {
+      container: selectedContainer || undefined,
+      tailLines: 50,
+    })
+
+    es.addEventListener('connected', (event) => {
+      try {
+        const data: WorkloadLogStreamEvent = JSON.parse(event.data)
+        setIsStreaming(true)
+        if (data.pods) {
+          setPods(data.pods)
+          // Assign colors to pods
+          const colors = new Map<string, string>()
+          data.pods.forEach((pod, i) => {
+            colors.set(pod.name, POD_COLORS[i % POD_COLORS.length])
+          })
+          setPodColors(colors)
+          // Initialize selected pods
+          if (selectedPods.size === 0) {
+            setSelectedPods(new Set(data.pods.map(p => p.name)))
+          }
+        }
+      } catch (e) {
+        console.error('Failed to parse connected event:', e)
+      }
+    })
+
+    es.addEventListener('log', (event) => {
+      try {
+        const data: WorkloadLogStreamEvent = JSON.parse(event.data)
+        if (data.pod && data.content !== undefined) {
+          setLogLines(prev => [...prev, {
+            timestamp: data.timestamp || '',
+            content: data.content || '',
+            container: data.container || '',
+            pod: data.pod || '',
+          }])
+        }
+      } catch (e) {
+        console.error('Failed to parse log event:', e)
+      }
+    })
+
+    es.addEventListener('pod_added', (event) => {
+      try {
+        const data: WorkloadLogStreamEvent = JSON.parse(event.data)
+        if (data.pods && data.pods.length > 0) {
+          const newPod = data.pods[0]
+          setPods(prev => [...prev, newPod])
+          setSelectedPods(prev => new Set([...prev, newPod.name]))
+          setPodColors(prev => {
+            const newColors = new Map(prev)
+            newColors.set(newPod.name, POD_COLORS[prev.size % POD_COLORS.length])
+            return newColors
+          })
+        }
+      } catch (e) {
+        console.error('Failed to parse pod_added event:', e)
+      }
+    })
+
+    es.addEventListener('pod_removed', (event) => {
+      try {
+        const data: WorkloadLogStreamEvent = JSON.parse(event.data)
+        if (data.pod) {
+          setPods(prev => prev.filter(p => p.name !== data.pod))
+          setSelectedPods(prev => {
+            const newSet = new Set(prev)
+            newSet.delete(data.pod!)
+            return newSet
+          })
+        }
+      } catch (e) {
+        console.error('Failed to parse pod_removed event:', e)
+      }
+    })
+
+    es.addEventListener('end', () => {
+      setIsStreaming(false)
+    })
+
+    es.addEventListener('error', (event) => {
+      console.error('Workload log stream error:', event)
+      setIsStreaming(false)
+      es.close()
+    })
+
+    eventSourceRef.current = es
+  }, [kind, namespace, name, selectedContainer, selectedPods.size])
+
+  // Stop streaming
+  const stopStreaming = useCallback(() => {
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close()
+      eventSourceRef.current = null
+    }
+    setIsStreaming(false)
+  }, [])
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close()
+      }
+    }
+  }, [])
+
+  // Stop streaming when container changes
+  useEffect(() => {
+    stopStreaming()
+  }, [selectedContainer, stopStreaming])
+
+  // Toggle pod selection
+  const togglePod = useCallback((podName: string) => {
+    setSelectedPods(prev => {
+      const newSet = new Set(prev)
+      if (newSet.has(podName)) {
+        newSet.delete(podName)
+      } else {
+        newSet.add(podName)
+      }
+      return newSet
+    })
+  }, [])
+
+  // Select/deselect all pods
+  const toggleAllPods = useCallback(() => {
+    if (selectedPods.size === pods.length) {
+      setSelectedPods(new Set())
+    } else {
+      setSelectedPods(new Set(pods.map(p => p.name)))
+    }
+  }, [selectedPods.size, pods])
+
+  // Download logs
+  const downloadLogs = useCallback(() => {
+    const content = logLines
+      .filter(l => selectedPods.has(l.pod))
+      .map(l => `${l.timestamp} [${l.pod}/${l.container}] ${l.content}`)
+      .join('\n')
+    const blob = new Blob([content], { type: 'text/plain' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `${name}-logs.txt`
+    a.click()
+    URL.revokeObjectURL(url)
+  }, [logLines, name, selectedPods])
+
+  // Filter logs by search and selected pods
+  const filteredLines = useMemo(() => {
+    let lines = logLines.filter(l => selectedPods.has(l.pod))
+    if (searchQuery) {
+      lines = lines.filter(l => l.content.toLowerCase().includes(searchQuery.toLowerCase()))
+    }
+    return lines
+  }, [logLines, selectedPods, searchQuery])
+
+  return (
+    <div className="flex flex-col h-full bg-theme-base">
+      {/* Toolbar */}
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-theme-border bg-theme-surface">
+        {/* Pod filter */}
+        <div className="relative">
+          <button
+            onClick={() => setShowPodFilter(!showPodFilter)}
+            className={`flex items-center gap-1.5 px-2 py-1.5 text-xs rounded transition-colors ${
+              showPodFilter
+                ? 'bg-blue-600 text-theme-text-primary'
+                : 'bg-theme-elevated text-theme-text-secondary hover:bg-theme-hover'
+            }`}
+          >
+            <Filter className="w-3 h-3" />
+            <span>{selectedPods.size}/{pods.length} pods</span>
+            <ChevronDown className="w-3 h-3" />
+          </button>
+
+          {showPodFilter && (
+            <div className="absolute top-full left-0 mt-1 w-64 bg-theme-elevated border border-theme-border rounded-lg shadow-lg z-50 max-h-64 overflow-y-auto">
+              <div className="p-2 border-b border-theme-border">
+                <button
+                  onClick={toggleAllPods}
+                  className="text-xs text-blue-400 hover:text-blue-300"
+                >
+                  {selectedPods.size === pods.length ? 'Deselect all' : 'Select all'}
+                </button>
+              </div>
+              {pods.map(pod => (
+                <label
+                  key={pod.name}
+                  className="flex items-center gap-2 px-3 py-2 hover:bg-theme-hover cursor-pointer"
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedPods.has(pod.name)}
+                    onChange={() => togglePod(pod.name)}
+                    className="w-3 h-3 rounded border-theme-border-light bg-theme-elevated text-blue-500 focus:ring-blue-500 focus:ring-offset-0"
+                  />
+                  <span className={`w-2 h-2 rounded-full ${podColors.get(pod.name)?.replace('text-', 'bg-')}`} />
+                  <span className="text-xs text-theme-text-primary truncate flex-1">{pod.name}</span>
+                  <span className={`text-xs ${pod.ready ? 'text-green-400' : 'text-yellow-400'}`}>
+                    {pod.ready ? 'Ready' : 'Not Ready'}
+                  </span>
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Container selector */}
+        {allContainers.length > 1 && (
+          <div className="relative">
+            <select
+              value={selectedContainer}
+              onChange={(e) => setSelectedContainer(e.target.value)}
+              className="appearance-none bg-theme-elevated text-theme-text-primary text-xs rounded px-2 py-1.5 pr-6 border border-theme-border-light focus:outline-none focus:ring-1 focus:ring-blue-500"
+            >
+              <option value="">All containers</option>
+              {allContainers.map(c => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+            <ChevronDown className="absolute right-1.5 top-1/2 -translate-y-1/2 w-3 h-3 text-theme-text-secondary pointer-events-none" />
+          </div>
+        )}
+
+        {/* Stream toggle */}
+        <button
+          onClick={isStreaming ? stopStreaming : startStreaming}
+          className={`flex items-center gap-1.5 px-2 py-1.5 text-xs rounded transition-colors ${
+            isStreaming
+              ? 'bg-green-600 text-theme-text-primary hover:bg-green-700'
+              : 'bg-theme-elevated text-theme-text-secondary hover:bg-theme-hover'
+          }`}
+          title={isStreaming ? 'Stop streaming' : 'Start streaming'}
+        >
+          {isStreaming ? <Pause className="w-3 h-3" /> : <Play className="w-3 h-3" />}
+          <span className="hidden sm:inline">{isStreaming ? 'Streaming' : 'Stream'}</span>
+        </button>
+
+        {/* Refresh button */}
+        <button
+          onClick={() => refetch()}
+          disabled={isLoading || isStreaming}
+          className="flex items-center gap-1.5 px-2 py-1.5 text-xs rounded bg-theme-elevated text-theme-text-secondary hover:bg-theme-hover disabled:opacity-50 disabled:cursor-not-allowed"
+          title="Refresh logs"
+        >
+          <RotateCcw className={`w-3 h-3 ${isLoading ? 'animate-spin' : ''}`} />
+        </button>
+
+        {/* Tail lines selector */}
+        <Tooltip content="Number of historical log lines to load per pod." position="bottom">
+          <select
+            value={tailLines}
+            onChange={(e) => setTailLines(Number(e.target.value))}
+            className="appearance-none bg-theme-elevated text-theme-text-primary text-xs rounded px-2 py-1.5 pr-5 border border-theme-border-light focus:outline-none focus:ring-1 focus:ring-blue-500"
+          >
+            <option value={50}>50 lines</option>
+            <option value={100}>100 lines</option>
+            <option value={500}>500 lines</option>
+            <option value={1000}>1000 lines</option>
+          </select>
+        </Tooltip>
+
+        <div className="flex-1" />
+
+        {/* Search toggle */}
+        <button
+          onClick={() => setShowSearch(!showSearch)}
+          className={`p-1.5 rounded transition-colors ${
+            showSearch ? 'bg-blue-600 text-theme-text-primary' : 'text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated'
+          }`}
+          title="Search logs"
+        >
+          <Search className="w-4 h-4" />
+        </button>
+
+        {/* Download */}
+        <button
+          onClick={downloadLogs}
+          className="p-1.5 rounded text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated"
+          title="Download logs"
+        >
+          <Download className="w-4 h-4" />
+        </button>
+      </div>
+
+      {/* Search bar */}
+      {showSearch && (
+        <div className="flex items-center gap-2 px-3 py-2 border-b border-theme-border bg-theme-surface/50">
+          <Search className="w-4 h-4 text-theme-text-secondary" />
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search logs..."
+            className="flex-1 bg-transparent text-theme-text-primary text-sm placeholder-theme-text-disabled focus:outline-none"
+            autoFocus
+          />
+          {searchQuery && (
+            <>
+              <span className="text-xs text-theme-text-tertiary">
+                {filteredLines.length} / {logLines.filter(l => selectedPods.has(l.pod)).length}
+              </span>
+              <button
+                onClick={() => setSearchQuery('')}
+                className="p-1 rounded text-theme-text-secondary hover:text-theme-text-primary"
+              >
+                <X className="w-3 h-3" />
+              </button>
+            </>
+          )}
+        </div>
+      )}
+
+      {/* Log content */}
+      <div
+        ref={logContainerRef}
+        onScroll={handleScroll}
+        className="flex-1 overflow-auto font-mono text-xs"
+        onClick={() => setShowPodFilter(false)}
+      >
+        {isLoading && logLines.length === 0 ? (
+          <div className="flex items-center justify-center h-full text-theme-text-tertiary">
+            <div className="flex items-center gap-2">
+              <RotateCcw className="w-4 h-4 animate-spin" />
+              <span>Loading logs...</span>
+            </div>
+          </div>
+        ) : pods.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full text-theme-text-tertiary gap-2">
+            <Terminal className="w-8 h-8" />
+            <span>No pods found</span>
+          </div>
+        ) : filteredLines.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full text-theme-text-tertiary gap-2">
+            <Terminal className="w-8 h-8" />
+            <span>No logs available</span>
+          </div>
+        ) : (
+          <div className="p-2">
+            {filteredLines.map((line, i) => (
+              <WorkloadLogLineItem
+                key={i}
+                line={line}
+                searchQuery={searchQuery}
+                podColor={podColors.get(line.pod) || 'text-theme-text-primary'}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Auto-scroll indicator */}
+      {!autoScroll && (
+        <button
+          onClick={() => {
+            setAutoScroll(true)
+            if (logContainerRef.current) {
+              logContainerRef.current.scrollTop = logContainerRef.current.scrollHeight
+            }
+          }}
+          className="absolute bottom-4 right-4 px-3 py-1.5 bg-blue-600 text-theme-text-primary text-xs rounded-full shadow-lg hover:bg-blue-700"
+        >
+          Scroll to bottom
+        </button>
+      )}
+    </div>
+  )
+}
+
+// Individual log line component
+function WorkloadLogLineItem({
+  line,
+  searchQuery,
+  podColor,
+}: {
+  line: LogLine
+  searchQuery: string
+  podColor: string
+}) {
+  const levelColor = getLogLevelColor(line.content)
+  const content = searchQuery
+    ? highlightSearchMatches(line.content, searchQuery)
+    : escapeHtml(line.content)
+
+  // Extract short pod name (last two segments after -)
+  const shortPodName = line.pod.split('-').slice(-2).join('-')
+
+  return (
+    <div className="flex hover:bg-theme-surface/50 group leading-5">
+      {line.timestamp && (
+        <span className="text-theme-text-tertiary select-none pr-2 whitespace-nowrap">
+          {formatLogTimestamp(line.timestamp)}
+        </span>
+      )}
+      <span className={`${podColor} select-none pr-2 whitespace-nowrap min-w-[80px] max-w-[120px] truncate`} title={line.pod}>
+        [{shortPodName}]
+      </span>
+      <span
+        className={`whitespace-pre-wrap break-all ${levelColor}`}
+        dangerouslySetInnerHTML={{ __html: content }}
+      />
+    </div>
+  )
+}

--- a/web/src/components/resources/ResourceDetailDrawer.tsx
+++ b/web/src/components/resources/ResourceDetailDrawer.tsx
@@ -96,7 +96,7 @@ import {
   AlertRenderer,
   ArgoApplicationRenderer,
 } from './renderers'
-import { useOpenTerminal, useOpenLogs } from '../dock'
+import { useOpenTerminal, useOpenLogs, useOpenWorkloadLogs } from '../dock'
 import { PortForwardButton } from '../portforward/PortForwardButton'
 import { useCanExec, useCanViewLogs, useCanPortForward } from '../../contexts/CapabilitiesContext'
 import { useToast } from '../ui/Toast'
@@ -421,6 +421,7 @@ function ActionsBar({ resource, data, onClose }: ActionsBarProps) {
   const { showCopied } = useToast()
   const openTerminal = useOpenTerminal()
   const openLogs = useOpenLogs()
+  const openWorkloadLogs = useOpenWorkloadLogs()
   const kind = resource.kind.toLowerCase()
 
   // Check capabilities
@@ -520,20 +521,35 @@ function ActionsBar({ resource, data, onClose }: ActionsBarProps) {
         />
       )}
 
-      {/* Workload actions - restart */}
+      {/* Workload actions - restart and logs */}
       {['deployments', 'statefulsets', 'daemonsets', 'rollouts'].includes(kind) && (
-        <button
-          onClick={() => restartWorkloadMutation.mutate({
-            kind: resource.kind,
-            namespace: resource.namespace,
-            name: resource.name,
-          })}
-          disabled={restartWorkloadMutation.isPending}
-          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-slate-600 hover:bg-slate-500 rounded-lg transition-colors disabled:opacity-50"
-        >
-          <RefreshCw className={`w-3.5 h-3.5 ${restartWorkloadMutation.isPending ? 'animate-spin' : ''}`} />
-          {restartWorkloadMutation.isPending ? 'Restarting...' : 'Restart'}
-        </button>
+        <>
+          <button
+            onClick={() => restartWorkloadMutation.mutate({
+              kind: resource.kind,
+              namespace: resource.namespace,
+              name: resource.name,
+            })}
+            disabled={restartWorkloadMutation.isPending}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-slate-600 hover:bg-slate-500 rounded-lg transition-colors disabled:opacity-50"
+          >
+            <RefreshCw className={`w-3.5 h-3.5 ${restartWorkloadMutation.isPending ? 'animate-spin' : ''}`} />
+            {restartWorkloadMutation.isPending ? 'Restarting...' : 'Restart'}
+          </button>
+          {canViewLogs && ['deployments', 'statefulsets', 'daemonsets'].includes(kind) && (
+            <button
+              onClick={() => openWorkloadLogs({
+                namespace: resource.namespace,
+                workloadKind: kind,
+                workloadName: resource.name,
+              })}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-slate-600 hover:bg-slate-500 rounded-lg transition-colors"
+            >
+              <FileText className="w-3.5 h-3.5" />
+              Logs
+            </button>
+          )}
+        </>
       )}
 
       {/* CronJob actions */}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -692,3 +692,42 @@ export interface ImageMetadata {
   filesystem?: ImageFilesystem  // Included if cached
   authMethod: string   // "anonymous", "google", "credentials", etc.
 }
+
+// ============================================================================
+// Workload Logs Types
+// ============================================================================
+
+// Pod info returned from workload pods endpoint
+export interface WorkloadPodInfo {
+  name: string
+  containers: string[]
+  ready: boolean
+}
+
+// SSE event types for workload log streaming
+export type WorkloadLogEventType =
+  | 'connected'
+  | 'log'
+  | 'pod_added'
+  | 'pod_removed'
+  | 'end'
+  | 'error'
+
+// Workload log stream event data
+export interface WorkloadLogStreamEvent {
+  event: WorkloadLogEventType
+  // connected event
+  workload?: string
+  namespace?: string
+  kind?: string
+  pods?: WorkloadPodInfo[]
+  // log event
+  pod?: string
+  container?: string
+  timestamp?: string
+  content?: string
+  // pod_added/pod_removed events
+  reason?: string
+  // error event
+  message?: string
+}

--- a/web/src/utils/log-format.ts
+++ b/web/src/utils/log-format.ts
@@ -1,0 +1,84 @@
+/**
+ * Log formatting and display utilities.
+ * Shared between LogsViewer and WorkloadLogsViewer components.
+ */
+
+/**
+ * Format a K8s log timestamp for display.
+ * Extracts and formats the time portion (HH:MM:SS).
+ */
+export function formatLogTimestamp(ts: string): string {
+  try {
+    const date = new Date(ts)
+    return date.toLocaleTimeString('en-US', {
+      hour12: false,
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+  } catch {
+    // Fallback: extract HH:MM:SS from ISO timestamp
+    return ts.slice(11, 19)
+  }
+}
+
+/**
+ * Determine the color class for a log line based on its content.
+ * Detects common log level keywords.
+ */
+export function getLogLevelColor(content: string): string {
+  const lower = content.toLowerCase()
+  if (lower.includes('error') || lower.includes('fatal') || lower.includes('panic')) {
+    return 'text-red-400'
+  }
+  if (lower.includes('warn')) {
+    return 'text-yellow-400'
+  }
+  if (lower.includes('debug') || lower.includes('trace')) {
+    return 'text-theme-text-secondary'
+  }
+  return 'text-theme-text-primary'
+}
+
+/**
+ * Highlight search query matches in text with a mark tag.
+ * Returns HTML string safe for dangerouslySetInnerHTML.
+ */
+export function highlightSearchMatches(text: string, query: string): string {
+  if (!query) return escapeHtml(text)
+  const escaped = escapeHtml(text)
+  const escapedQuery = escapeHtml(query)
+  const regex = new RegExp(`(${escapeRegExp(escapedQuery)})`, 'gi')
+  return escaped.replace(regex, '<mark class="bg-yellow-500/30 text-yellow-200">$1</mark>')
+}
+
+/**
+ * Escape HTML special characters to prevent XSS.
+ */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+/**
+ * Escape special regex characters in a string.
+ */
+export function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Parse a K8s log line to extract timestamp and content.
+ * K8s timestamps are in RFC3339Nano format: 2024-01-20T10:30:00.123456789Z content
+ */
+export function parseLogLine(line: string): { timestamp: string; content: string } {
+  if (line.length > 30 && line[4] === '-' && line[7] === '-' && line[10] === 'T') {
+    const spaceIdx = line.indexOf(' ')
+    if (spaceIdx > 20 && spaceIdx < 40) {
+      return { timestamp: line.slice(0, spaceIdx), content: line.slice(spaceIdx + 1) }
+    }
+  }
+  return { timestamp: '', content: line }
+}


### PR DESCRIPTION
## Summary

Adds the ability to view aggregated logs from all pods belonging to a workload (Deployment, StatefulSet, DaemonSet). Users can now click a "Logs" button on any workload to see logs from all its pods in a unified stream.

- Real-time SSE streaming aggregates logs from all pods
- Pod filter panel with color-coded identification
- Container selector, search with highlighting, auto-scroll, download
- Handles pod churn gracefully (scaling, restarts)

## Changes

**Backend**: New `/api/workloads/{kind}/{ns}/{name}/logs[/stream]` endpoints that aggregate pod logs with 5-second pod discovery polling.

**Frontend**: New `WorkloadLogsViewer` component in the dock, with shared log formatting utilities extracted for XSS protection.