### PR TITLE
fix: Respect KUBECONFIG when KUBERNETES_SERVICE_HOST is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ radar
 | `--history-limit` | `10000` | Maximum events to retain in timeline |
 | `--version` | | Show version and exit |
 
+See [Configuration Guide](docs/configuration.md) for details on cluster connection precedence, multiple kubeconfig files, and context switching.
+
 ---
 
 ## Views

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,60 @@
+# Configuration
+
+This document covers Radar's cluster connection behavior. For CLI flags and basic usage, see the [README](../README.md#usage).
+
+## Cluster Connection Precedence
+
+Radar connects to Kubernetes clusters using the same configuration sources as `kubectl`, resolved in this order:
+
+| Priority | Source | Description |
+|----------|--------|-------------|
+| 1 | `--kubeconfig` flag | Explicit path to kubeconfig file |
+| 2 | `KUBECONFIG` env var | Environment variable pointing to kubeconfig file(s) |
+| 3 | `--kubeconfig-dir` flag | Directory containing multiple kubeconfig files |
+| 4 | In-cluster config | Automatic when running inside a Kubernetes pod |
+| 5 | `~/.kube/config` | Default kubeconfig location |
+
+## KUBECONFIG vs In-Cluster Detection
+
+When Radar runs inside a Kubernetes pod, Kubernetes automatically sets the `KUBERNETES_SERVICE_HOST` environment variable. This normally triggers in-cluster configuration using the pod's service account credentials.
+
+However, **explicit kubeconfig takes precedence**. If you set `KUBECONFIG` or pass `--kubeconfig`, Radar uses that instead of in-cluster config. This allows you to:
+
+- Run Radar inside a pod but connect to a different cluster
+- Use specific credentials instead of the pod's service account
+- Test with a custom kubeconfig while developing inside a cluster
+
+**Example: Override in-cluster config**
+```bash
+# Inside a pod, connect to a different cluster
+export KUBECONFIG=/path/to/other-cluster.yaml
+kubectl radar
+```
+
+This behavior matches `kubectl` and follows the [Kubernetes client-go precedence rules](https://github.com/kubernetes/kubernetes/issues/43662).
+
+## Multiple Kubeconfig Files
+
+`KUBECONFIG` can contain multiple file paths (colon-separated on Linux/macOS, semicolon-separated on Windows). Radar merges these files following Kubernetes conventions:
+
+```bash
+export KUBECONFIG=~/.kube/config:~/.kube/staging-config:~/.kube/prod-config
+kubectl radar
+```
+
+Alternatively, use `--kubeconfig-dir` to load all kubeconfig files from a directory:
+
+```bash
+kubectl radar --kubeconfig-dir ~/.kube/configs/
+```
+
+## Context Switching
+
+Radar supports switching between Kubernetes contexts at runtime through the UI. Click the context selector in the header to switch between available contexts.
+
+When running in-cluster (using the pod's service account), context switching is disabled.
+
+## Related Documentation
+
+- [README](../README.md#usage) — CLI flags and basic usage
+- [In-Cluster Deployment](in-cluster.md) — Deploy Radar inside your cluster with Helm

--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -2,6 +2,8 @@
 
 Deploy Radar to your Kubernetes cluster for shared team access.
 
+> **Note:** This guide covers deploying Radar as a pod in your cluster. If you're running Radar locally but need to understand cluster connection behavior (e.g., using `KUBECONFIG` to override in-cluster detection), see the [Configuration Guide](configuration.md).
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary

When both `KUBECONFIG` and `KUBERNETES_SERVICE_HOST` environment variables are set, radar now respects the explicit kubeconfig instead of attempting (and failing) in-cluster authentication.

This handles the edge case where a user is running inside a pod but wants to connect to a different cluster via an explicit kubeconfig file.

Fixes #52