### PR TITLE
feat: Add generic CRD topology support via owner references

### DIFF
--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -140,6 +140,11 @@ func main() {
 	// Warm up dynamic cache for common CRDs so they appear in initial timeline
 	k8s.WarmupCommonCRDs()
 
+	// Start full CRD discovery in background (for generic CRD topology support)
+	if dynamicCache := k8s.GetDynamicResourceCache(); dynamicCache != nil {
+		dynamicCache.DiscoverAllCRDs()
+	}
+
 	// Initialize metrics history collection (polls metrics-server every 30s)
 	k8s.InitMetricsHistory()
 

--- a/internal/k8s/cluster_detection.go
+++ b/internal/k8s/cluster_detection.go
@@ -11,13 +11,14 @@ import (
 
 // ClusterInfo contains detected cluster information
 type ClusterInfo struct {
-	Context           string `json:"context"`  // kubeconfig context name
-	Cluster           string `json:"cluster"`  // cluster name from kubeconfig
-	Platform          string `json:"platform"` // gke, gke-autopilot, eks, aks, minikube, kind, docker-desktop, generic
-	KubernetesVersion string `json:"kubernetesVersion"`
-	NodeCount         int    `json:"nodeCount"`
-	PodCount          int    `json:"podCount"`
-	NamespaceCount    int    `json:"namespaceCount"`
+	Context            string `json:"context"`                      // kubeconfig context name
+	Cluster            string `json:"cluster"`                      // cluster name from kubeconfig
+	Platform           string `json:"platform"`                     // gke, gke-autopilot, eks, aks, minikube, kind, docker-desktop, generic
+	KubernetesVersion  string `json:"kubernetesVersion"`
+	NodeCount          int    `json:"nodeCount"`
+	PodCount           int    `json:"podCount"`
+	NamespaceCount     int    `json:"namespaceCount"`
+	CRDDiscoveryStatus string `json:"crdDiscoveryStatus,omitempty"` // idle, discovering, ready
 }
 
 // GetClusterInfo returns detected cluster information
@@ -49,6 +50,12 @@ func GetClusterInfo(ctx context.Context) (*ClusterInfo, error) {
 		if namespaces, err := cache.Namespaces().List(labels.Everything()); err == nil {
 			info.NamespaceCount = len(namespaces)
 		}
+	}
+
+	// Get CRD discovery status
+	dynamicCache := GetDynamicResourceCache()
+	if dynamicCache != nil {
+		info.CRDDiscoveryStatus = string(dynamicCache.GetDiscoveryStatus())
 	}
 
 	return info, nil

--- a/internal/topology/types.go
+++ b/internal/topology/types.go
@@ -69,13 +69,14 @@ type Edge struct {
 
 // Topology represents the complete graph
 type Topology struct {
-	Nodes        []Node   `json:"nodes"`
-	Edges        []Edge   `json:"edges"`
-	Warnings     []string `json:"warnings,omitempty"`     // Warnings about resources that failed to load
-	Truncated    bool     `json:"truncated,omitempty"`    // True if topology was truncated due to size limit
-	TotalNodes   int      `json:"totalNodes,omitempty"`   // Total nodes before truncation (only set if truncated)
-	LargeCluster bool     `json:"largeCluster,omitempty"` // True if cluster exceeds large cluster threshold
-	HiddenKinds  []string `json:"hiddenKinds,omitempty"`  // Resource kinds auto-hidden for performance
+	Nodes              []Node   `json:"nodes"`
+	Edges              []Edge   `json:"edges"`
+	Warnings           []string `json:"warnings,omitempty"`           // Warnings about resources that failed to load
+	Truncated          bool     `json:"truncated,omitempty"`          // True if topology was truncated due to size limit
+	TotalNodes         int      `json:"totalNodes,omitempty"`         // Total nodes before truncation (only set if truncated)
+	LargeCluster       bool     `json:"largeCluster,omitempty"`       // True if cluster exceeds large cluster threshold
+	HiddenKinds        []string `json:"hiddenKinds,omitempty"`        // Resource kinds auto-hidden for performance
+	CRDDiscoveryStatus string   `json:"crdDiscoveryStatus,omitempty"` // CRD discovery status: idle, discovering, ready
 }
 
 // ViewMode determines how the topology is built
@@ -99,6 +100,7 @@ type BuildOptions struct {
 	IncludeConfigMaps  bool     // Include ConfigMap nodes
 	IncludePVCs        bool     // Include PersistentVolumeClaim nodes
 	IncludeReplicaSets bool     // Include ReplicaSet nodes (noisy intermediate objects)
+	IncludeGenericCRDs bool     // Include CRDs with owner refs to topology nodes (default: true)
 }
 
 // DefaultBuildOptions returns sensible defaults
@@ -112,6 +114,7 @@ func DefaultBuildOptions() BuildOptions {
 		IncludeConfigMaps:  true,
 		IncludePVCs:        true,
 		IncludeReplicaSets: false, // Hidden by default - noisy intermediate between Deployment and Pod
+		IncludeGenericCRDs: true,  // Show CRDs with owner refs to topology nodes
 	}
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -183,11 +183,17 @@ export function useDashboard(namespace?: string) {
 
 // Cluster info
 export function useClusterInfo() {
-  return useQuery<ClusterInfo>({
+  const query = useQuery<ClusterInfo>({
     queryKey: ['cluster-info'],
     queryFn: () => fetchJSON('/cluster-info'),
     staleTime: 60000, // 1 minute
+    // Poll faster when CRD discovery is in progress
+    refetchInterval: (query) => {
+      const status = query.state.data?.crdDiscoveryStatus
+      return status === 'discovering' ? 2000 : false
+    },
   })
+  return query
 }
 
 // Runtime stats for debug overlay

--- a/web/src/components/topology/GroupNode.tsx
+++ b/web/src/components/topology/GroupNode.tsx
@@ -144,38 +144,44 @@ export const GroupNode = memo(function GroupNode({
           ...getBorderStyle()
         }}
       >
-        {/* Header bar - uses CSS transform for zoom scaling (avoids React re-renders) */}
+        {/* Header bar - background extends full width, content scales, count fixed right */}
         {/* Hidden when hideHeader is true (single namespace view) */}
         {!hideHeader && (
           <div
-            className="flex items-center cursor-pointer group-header-scaled"
+            className="w-full cursor-pointer relative flex items-center"
             onClick={() => onToggleCollapse(id)}
-            style={{
-              padding: '20px 24px',
-              gap: '16px',
-              ...getHeaderBgStyle()
-            }}
+            style={getHeaderBgStyle()}
           >
-            <ChevronDown
-              className="shrink-0 w-8 h-8"
-              style={getIconStyle()}
-            />
-            <Icon
-              className="shrink-0 w-9 h-9"
-              style={getIconStyle()}
-            />
-            <span
-              className="font-bold truncate text-4xl"
-              style={getLabelStyle()}
+            {/* Scaled content */}
+            <div
+              className="flex items-center group-header-scaled"
+              style={{
+                padding: '20px 24px',
+                gap: '16px',
+              }}
             >
-              {name}
-            </span>
-            {label && (
-              <span className="text-sm text-theme-text-secondary truncate">
-                ({label})
+              <ChevronDown
+                className="shrink-0 w-8 h-8"
+                style={getIconStyle()}
+              />
+              <Icon
+                className="shrink-0 w-9 h-9"
+                style={getIconStyle()}
+              />
+              <span
+                className="font-bold truncate text-4xl"
+                style={getLabelStyle()}
+              >
+                {name}
               </span>
-            )}
-            <span className="ml-auto shrink-0 font-semibold text-xl text-theme-text-secondary bg-theme-surface/60 rounded-xl px-4 py-2">
+              {label && (
+                <span className="text-sm text-theme-text-secondary truncate">
+                  ({label})
+                </span>
+              )}
+            </div>
+            {/* Count badge - fixed size, anchored top-right */}
+            <span className="absolute right-4 top-4 shrink-0 font-medium text-sm text-theme-text-secondary bg-theme-surface/70 rounded-lg px-3 py-1">
               {nodeCount}
             </span>
           </div>

--- a/web/src/components/topology/K8sResourceNode.tsx
+++ b/web/src/components/topology/K8sResourceNode.tsx
@@ -77,6 +77,9 @@ function getIssueTooltip(issue: string | undefined): React.ReactNode {
   )
 }
 
+// Default dimensions for unknown CRD kinds
+export const DEFAULT_NODE_DIMENSIONS = { width: 260, height: 56 }
+
 // Node dimensions for ELK layout - sized for typical K8s resource names
 export const NODE_DIMENSIONS: Record<NodeKind, { width: number; height: number }> = {
   Internet: { width: 120, height: 52 },
@@ -289,7 +292,7 @@ export const K8sResourceNode = memo(function K8sResourceNode({
           status === 'unknown' && 'topology-node-status-unknown'
         )}
         style={{
-          width: NODE_DIMENSIONS[kind]?.width || 180,
+          width: NODE_DIMENSIONS[kind]?.width ?? DEFAULT_NODE_DIMENSIONS.width,
           ...getStatusStyle(status),
         }}
       >

--- a/web/src/components/topology/TopologyGraph.tsx
+++ b/web/src/components/topology/TopologyGraph.tsx
@@ -630,8 +630,9 @@ function ViewportController({ structureKey }: { structureKey: string }) {
   const updateZoomOffset = useCallback((viewport: Viewport) => {
     const { zoom } = viewport
     // Match the headerScale formula from GroupNode
-    const headerScale = Math.max(0.35, Math.min(1, 0.5 / zoom))
-    // At scale 1.0, offset is 0. At scale 0.35, offset is ~45px (header shrinks by ~45px)
+    // Min 0.5 = header never shrinks below 50%, formula 0.7/zoom = less aggressive scaling
+    const headerScale = Math.max(0.5, Math.min(1, 0.7 / zoom))
+    // At scale 1.0, offset is 0. At scale 0.5, offset is ~35px (header shrinks by ~35px)
     const headerOffset = (1 - headerScale) * 70
     document.documentElement.style.setProperty('--group-header-offset', `${-headerOffset}px`)
     document.documentElement.style.setProperty('--group-header-scale', String(headerScale))

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -65,8 +65,10 @@
   --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.4);
 
   /* Topology node styling */
-  --topology-node-border: var(--border-light);
-  --topology-node-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -2px rgba(0, 0, 0, 0.2);
+  --topology-node-border: rgba(255, 255, 255, 0.08);
+  --topology-node-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.3),
+    0 4px 12px rgba(0, 0, 0, 0.2);
 
   /* Scrollbar */
   --scrollbar-track: #1e293b;
@@ -130,8 +132,10 @@
   --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
 
   /* Topology node styling */
-  --topology-node-border: rgba(0, 0, 0, 0.05);
-  --topology-node-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  --topology-node-border: rgba(0, 0, 0, 0.10);
+  --topology-node-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.08),
+    0 4px 12px rgba(0, 0, 0, 0.05);
 
   /* Scrollbar */
   --scrollbar-track: #f1f5f9;
@@ -220,13 +224,25 @@ body {
    REACT FLOW CUSTOMIZATIONS
    ============================================ */
 
+.react-flow__pane {
+  cursor: grab;
+}
+
+.react-flow__pane:active {
+  cursor: grabbing;
+}
+
 .react-flow__node {
-  cursor: pointer;
+  cursor: pointer !important;
+}
+
+.react-flow__node:active {
+  cursor: pointer !important;
 }
 
 /* Topology node card styling - uses theme CSS variables */
 .topology-node-card {
-  border: none;
+  border: 1px solid var(--topology-node-border);
   box-shadow: var(--topology-node-shadow);
 }
 
@@ -259,6 +275,7 @@ body {
   font-weight: 700;
   color: white;
   flex-shrink: 0;
+  background: #6b7280; /* gray-500 - default for unknown CRD kinds */
 }
 .topology-icon-internet { background: #3b82f6; border-radius: 50%; }
 .topology-icon-ingress { background: #8b5cf6; }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -8,7 +8,8 @@ export interface Capabilities {
   secrets: boolean     // List secrets
 }
 
-export type NodeKind =
+// Core node kinds that have specific UI handling
+export type CoreNodeKind =
   | 'Internet'
   | 'Ingress'
   | 'Service'
@@ -30,6 +31,9 @@ export type NodeKind =
   | 'CronJob'
   | 'PVC'
   | 'Namespace'
+
+// NodeKind can be a core kind or any arbitrary CRD kind string
+export type NodeKind = CoreNodeKind | (string & {})
 
 export type HealthStatus = 'healthy' | 'degraded' | 'unhealthy' | 'unknown'
 
@@ -60,6 +64,7 @@ export interface Topology {
   totalNodes?: number // Total nodes before truncation (only set if truncated)
   largeCluster?: boolean // True if cluster exceeds large cluster threshold
   hiddenKinds?: string[] // Resource kinds auto-hidden for performance
+  crdDiscoveryStatus?: 'idle' | 'discovering' | 'ready' // CRD discovery status
 }
 
 // K8s Event (from SSE stream)
@@ -189,6 +194,7 @@ export interface ClusterInfo {
   nodeCount: number
   podCount: number
   namespaceCount: number
+  crdDiscoveryStatus?: 'idle' | 'discovering' | 'ready'
 }
 
 // Context info for context switching


### PR DESCRIPTION
## Summary

Adds support for displaying ANY Kubernetes CRD type in the topology based on owner references, not just hardcoded types. Resources with owner refs pointing to existing topology nodes will automatically appear.

<img width="1742" height="513" alt="image" src="https://github.com/user-attachments/assets/c6bc8187-8573-4dac-9bdd-d63709b7ff39" />

- CRDs with owner references to existing topology nodes automatically appear
- Health status extraction from common CRD patterns (conditions, phase fields)
- Loading indicator shows "Discovering CRDs..." during API discovery
- Dynamic filter sidebar includes discovered CRD kinds under "Custom Resources" category
- Per-kind limit (50 nodes) prevents overwhelming the topology

## Key Changes

**Backend:**
- `internal/topology/builder.go`: Added `addGenericCRDNodes()` and `extractGenericStatus()` for generic CRD support
- `internal/k8s/dynamic_cache.go`: CRD discovery with status tracking (idle → discovering → ready)
- `internal/topology/types.go`: Added `IncludeGenericCRDs` build option and `CRDDiscoveryStatus` to topology

**Frontend:**
- `web/src/App.tsx`: Loading indicator during CRD discovery, faster polling while discovering
- `web/src/components/topology/TopologyFilterSidebar.tsx`: Dynamic "Custom Resources" category
- `web/src/components/topology/K8sResourceNode.tsx`: Default dimensions for unknown kinds
- `web/src/index.css`: Default styling for unknown CRD icons

Closes #54