### PR TITLE
feat: Add multi-select namespace filtering

### DIFF
--- a/internal/server/traffic_handlers.go
+++ b/internal/server/traffic_handlers.go
@@ -43,11 +43,14 @@ func (s *Server) handleGetTrafficFlows(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Parse query parameters
-	namespace := r.URL.Query().Get("namespace")
+	namespaces := parseNamespaces(r.URL.Query())
 	sinceStr := r.URL.Query().Get("since")
 
 	opts := traffic.DefaultFlowOptions()
-	opts.Namespace = namespace
+	// Traffic only supports single namespace filter
+	if len(namespaces) == 1 {
+		opts.Namespace = namespaces[0]
+	}
 
 	if sinceStr != "" {
 		duration, err := time.ParseDuration(sinceStr)

--- a/internal/topology/pod_grouping.go
+++ b/internal/topology/pod_grouping.go
@@ -29,10 +29,15 @@ type PodGroupingResult struct {
 
 // PodGroupingOptions configures pod grouping behavior
 type PodGroupingOptions struct {
-	Namespace       string                                // Filter to specific namespace
+	Namespaces      []string                              // Filter to specific namespaces (empty = all)
 	ServiceMatching bool                                  // Whether to match pods to services (for traffic view)
 	ServicesByNS    map[string]map[string]*corev1.Service // Namespace -> svcKey -> service
 	ServiceIDs      map[string]string                     // svcKey -> serviceID
+}
+
+// matchesNamespaceFilter returns true if the given namespace matches the filter.
+func (opts PodGroupingOptions) matchesNamespaceFilter(ns string) bool {
+	return MatchesNamespace(opts.Namespaces, ns)
 }
 
 // GroupPods groups pods by app label or owner reference
@@ -42,7 +47,7 @@ func GroupPods(pods []*corev1.Pod, opts PodGroupingOptions) *PodGroupingResult {
 	}
 
 	for _, pod := range pods {
-		if opts.Namespace != "" && pod.Namespace != opts.Namespace {
+		if !opts.matchesNamespaceFilter(pod.Namespace) {
 			continue
 		}
 

--- a/web/src/api/traffic.ts
+++ b/web/src/api/traffic.ts
@@ -35,21 +35,22 @@ export function useTrafficSources() {
 
 // Get traffic flows
 export interface UseTrafficFlowsOptions {
-  namespace?: string
+  namespaces?: string[]
   since?: string // Duration like "5m", "1h"
   enabled?: boolean
 }
 
 export function useTrafficFlows(options: UseTrafficFlowsOptions = {}) {
-  const { namespace, since, enabled = true } = options
+  const { namespaces = [], since, enabled = true } = options
 
   const params = new URLSearchParams()
-  if (namespace) params.set('namespace', namespace)
+  // Traffic backend only supports single namespace, use first if provided
+  if (namespaces.length === 1) params.set('namespace', namespaces[0])
   if (since) params.set('since', since)
   const queryString = params.toString()
 
   return useQuery<TrafficFlowsResponse>({
-    queryKey: ['traffic-flows', namespace, since],
+    queryKey: ['traffic-flows', namespaces, since],
     queryFn: () => fetchJSON(`/traffic/flows${queryString ? `?${queryString}` : ''}`),
     staleTime: 5000, // 5 seconds
     enabled,

--- a/web/src/components/home/ActivitySummary.tsx
+++ b/web/src/components/home/ActivitySummary.tsx
@@ -9,7 +9,7 @@ import { buildResourceHierarchy, isProblematicEvent, type ResourceLane } from '.
 import { buildHealthSpans, timeToX } from '../timeline/shared'
 
 interface ActivitySummaryProps {
-  namespace?: string
+  namespaces: string[]
   topology?: Topology | null
   onNavigate: () => void
 }
@@ -65,9 +65,9 @@ const KIND_SHORT: Record<string, string> = {
   Ingress: 'Ing',
 }
 
-export function ActivitySummary({ namespace, topology, onNavigate }: ActivitySummaryProps) {
+export function ActivitySummary({ namespaces, topology, onNavigate }: ActivitySummaryProps) {
   const { data: events, isLoading, error } = useChanges({
-    namespace,
+    namespaces,
     timeRange: '1h',
     includeK8sEvents: true,
     includeManaged: true,

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -10,17 +10,17 @@ import { AlertTriangle, Loader2 } from 'lucide-react'
 import { clsx } from 'clsx'
 
 interface HomeViewProps {
-  namespace: string
+  namespaces: string[]
   topology: Topology | null
   onNavigateToView: (view: ExtendedMainView, params?: Record<string, string>) => void
   onNavigateToResourceKind: (kind: string, group?: string) => void
   onNavigateToResource: (resource: SelectedResource) => void
 }
 
-export function HomeView({ namespace, topology, onNavigateToView, onNavigateToResourceKind, onNavigateToResource }: HomeViewProps) {
-  const { data, isLoading, error } = useDashboard(namespace || undefined)
+export function HomeView({ namespaces, topology, onNavigateToView, onNavigateToResourceKind, onNavigateToResource }: HomeViewProps) {
+  const { data, isLoading, error } = useDashboard(namespaces)
   // CRDs load lazily after main dashboard to keep initial load fast
-  const { data: crdsData } = useDashboardCRDs(namespace || undefined)
+  const { data: crdsData } = useDashboardCRDs(namespaces)
 
   if (isLoading) {
     return (
@@ -77,7 +77,7 @@ export function HomeView({ namespace, topology, onNavigateToView, onNavigateToRe
               onNavigate={() => onNavigateToView('helm')}
             />
             <ActivitySummary
-              namespace={namespace || undefined}
+              namespaces={namespaces}
               topology={topology}
               onNavigate={() => onNavigateToView('timeline')}
             />

--- a/web/src/components/resource/ResourceDetailPage.tsx
+++ b/web/src/components/resource/ResourceDetailPage.tsx
@@ -66,14 +66,14 @@ export function ResourceDetailPage({
   const relationships = resourceResponse?.relationships
 
   // Fetch topology for hierarchy building
-  const { data: topology } = useTopology(namespace, 'resources')
+  const { data: topology } = useTopology([namespace], 'resources')
 
   // Convert zoom level to TimeRange for API
   const timeRange: TimeRange = zoom <= 0.5 ? '30m' : zoom <= 1 ? '1h' : zoom <= 6 ? '6h' : zoom <= 24 ? '24h' : 'all'
 
   // Fetch events - fetch from all namespaces to capture related resources in other namespaces
   const { data: allEvents, isLoading: eventsLoading } = useChanges({
-    namespace,
+    namespaces: [namespace],
     timeRange,
     includeK8sEvents: true,
     includeManaged: true,

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -597,7 +597,7 @@ function getColumnsForKind(kind: string): Column[] {
 }
 
 interface ResourcesViewProps {
-  namespace: string
+  namespaces: string[]
   selectedResource?: SelectedResource | null
   onResourceClick?: (kind: string, namespace: string, name: string, group?: string) => void
   onKindChange?: () => void // Called when user changes resource type in sidebar
@@ -639,7 +639,7 @@ function getInitialFiltersFromURL() {
 // Sort state type
 type SortDirection = 'asc' | 'desc' | null
 
-export function ResourcesView({ namespace, selectedResource, onResourceClick, onKindChange }: ResourcesViewProps) {
+export function ResourcesView({ namespaces, selectedResource, onResourceClick, onKindChange }: ResourcesViewProps) {
   const location = useLocation()
   const initialFilters = getInitialFiltersFromURL()
   const [selectedKind, setSelectedKind] = useState<SelectedKindInfo>(getInitialKindFromURL)
@@ -873,10 +873,10 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick, on
   // Fetch ALL resources using useQueries - single source of truth for both counts and display
   const resourceQueries = useQueries({
     queries: resourcesToCount.map((resource) => ({
-      queryKey: ['resources', resource.name, resource.group, namespace],
+      queryKey: ['resources', resource.name, resource.group, namespaces],
       queryFn: async () => {
         const params = new URLSearchParams()
-        if (namespace) params.set('namespace', namespace)
+        if (namespaces.length > 0) params.set('namespaces', namespaces.join(','))
         if (resource.group) params.set('group', resource.group)
         const res = await fetch(`/api/resources/${resource.name}?${params}`)
         if (!res.ok) return []
@@ -1806,7 +1806,7 @@ export function ResourcesView({ namespace, selectedResource, onResourceClick, on
             <div className="absolute inset-0 flex flex-col items-center justify-center text-theme-text-tertiary">
               <p>No {selectedKind.kind} found</p>
               {searchTerm && <p className="text-sm mt-1">No results for "{searchTerm}"</p>}
-              {namespace && <p className="text-sm mt-1 text-theme-text-disabled">Searching in namespace: {namespace}</p>}
+              {namespaces.length > 0 && <p className="text-sm mt-1 text-theme-text-disabled">Searching in {namespaces.length === 1 ? `namespace: ${namespaces[0]}` : `${namespaces.length} namespaces`}</p>}
             </div>
           ) : (
             <table className={clsx(

--- a/web/src/components/timeline/TimelineList.tsx
+++ b/web/src/components/timeline/TimelineList.tsx
@@ -38,7 +38,7 @@ function formatResourceAge(createdAt: string): string {
 export type ActivityTypeFilter = 'all' | 'changes' | 'k8s_events' | 'warnings' | 'unhealthy'
 
 interface TimelineListProps {
-  namespace: string
+  namespaces: string[]
   onViewChange?: (view: 'list' | 'swimlane') => void
   currentView?: 'list' | 'swimlane'
   onResourceClick?: (kind: string, namespace: string, name: string) => void
@@ -66,7 +66,7 @@ const RESOURCE_KINDS = [
   'StatefulSet',
 ]
 
-export function TimelineList({ namespace, onViewChange, currentView = 'list', onResourceClick, initialFilter, initialTimeRange }: TimelineListProps) {
+export function TimelineList({ namespaces, onViewChange, currentView = 'list', onResourceClick, initialFilter, initialTimeRange }: TimelineListProps) {
   const [searchTerm, setSearchTerm] = useState('')
   const [activityTypeFilter, setActivityTypeFilter] = useState<ActivityTypeFilter>(initialFilter ?? 'all')
   const [timeRange, setTimeRange] = useState<TimeRange>(initialTimeRange ?? '1h')
@@ -98,7 +98,7 @@ export function TimelineList({ namespace, onViewChange, currentView = 'list', on
 
   // Fetch unified timeline - always include all events, filter client-side
   const { data: activity, isLoading, refetch: refetchChanges } = useChanges({
-    namespace: namespace || undefined,
+    namespaces,
     kind: kindFilter || undefined,
     timeRange,
     includeK8sEvents: true, // Always fetch all, filter client-side for stable counts
@@ -408,7 +408,7 @@ export function TimelineList({ namespace, onViewChange, currentView = 'list', on
                 ? 'Try adjusting your filters'
                 : 'Activity will appear here when cluster changes occur'}
             </p>
-            {namespace && <p className="text-sm mt-1 text-theme-text-disabled">Searching in namespace: {namespace}</p>}
+            {namespaces && namespaces.length > 0 && <p className="text-sm mt-1 text-theme-text-disabled">Searching in: {namespaces.length === 1 ? namespaces[0] : `${namespaces.length} namespaces`}</p>}
           </div>
         ) : (
           <div className="p-4 space-y-6">

--- a/web/src/components/timeline/TimelineSwimlanes.tsx
+++ b/web/src/components/timeline/TimelineSwimlanes.tsx
@@ -43,7 +43,7 @@ interface TimelineSwimlanesProps {
   viewMode?: 'list' | 'swimlane'
   onViewModeChange?: (mode: 'list' | 'swimlane') => void
   topology?: Topology
-  namespace?: string
+  namespaces?: string[]
 }
 
 interface ResourceLane extends BaseResourceLane {
@@ -166,7 +166,7 @@ function calculateInterestingnessWithBreakdown(lane: ResourceLane): ScoreBreakdo
   return breakdown
 }
 
-export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode, onViewModeChange, topology, namespace }: TimelineSwimlanesProps) {
+export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode, onViewModeChange, topology, namespaces }: TimelineSwimlanesProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const searchInputRef = useRef<HTMLInputElement>(null)
   const [zoom, setZoom] = useState(1)
@@ -627,7 +627,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
                   <p className="text-sm mt-1">
                     {searchTerm ? `No results for "${searchTerm}"` : 'Try adjusting your filters'}
                   </p>
-                  {namespace && <p className="text-sm mt-1 text-theme-text-disabled">Searching in namespace: {namespace}</p>}
+                  {namespaces && namespaces.length > 0 && <p className="text-sm mt-1 text-theme-text-disabled">Searching in: {namespaces.length === 1 ? namespaces[0] : `${namespaces.length} namespaces`}</p>}
                 </>
               ) : (
                 <>

--- a/web/src/components/timeline/TimelineView.tsx
+++ b/web/src/components/timeline/TimelineView.tsx
@@ -25,19 +25,19 @@ export type TimelineViewMode = 'list' | 'swimlane'
 export type { ActivityTypeFilter } from './TimelineList'
 
 interface TimelineViewProps {
-  namespace: string
+  namespaces: string[]
   onResourceClick?: (kind: string, namespace: string, name: string) => void
   initialViewMode?: TimelineViewMode
   initialFilter?: 'all' | 'changes' | 'k8s_events' | 'warnings' | 'unhealthy'
   initialTimeRange?: TimeRange
 }
 
-export function TimelineView({ namespace, onResourceClick, initialViewMode, initialFilter, initialTimeRange }: TimelineViewProps) {
+export function TimelineView({ namespaces, onResourceClick, initialViewMode, initialFilter, initialTimeRange }: TimelineViewProps) {
   const [viewMode, setViewMode] = useState<TimelineViewMode>(initialViewMode ?? 'swimlane')
 
   // Fetch all activity - zoom controls what's visible in the UI
   const { data: activity, isLoading } = useChanges({
-    namespace: namespace || undefined,
+    namespaces,
     timeRange: 'all', // Fetch all available data, zoom controls the view
     includeK8sEvents: true,
     includeManaged: true, // Include Pods, ReplicaSets, etc. for hierarchical view
@@ -45,7 +45,7 @@ export function TimelineView({ namespace, onResourceClick, initialViewMode, init
   })
 
   // Fetch topology for service stack grouping
-  const { data: rawTopology } = useTopology(namespace, 'resources')
+  const { data: rawTopology } = useTopology(namespaces, 'resources')
 
   // Stabilize topology reference to prevent unnecessary lane recomputation
   // Only update the stable topology when the content meaningfully changes
@@ -70,14 +70,14 @@ export function TimelineView({ namespace, onResourceClick, initialViewMode, init
         viewMode={viewMode}
         onViewModeChange={setViewMode}
         topology={stableTopology}
-        namespace={namespace}
+        namespaces={namespaces}
       />
     )
   }
 
   return (
     <TimelineList
-      namespace={namespace}
+      namespaces={namespaces}
       currentView={viewMode}
       onViewChange={setViewMode}
       onResourceClick={onResourceClick}

--- a/web/src/components/traffic/TrafficView.tsx
+++ b/web/src/components/traffic/TrafficView.tsx
@@ -331,10 +331,10 @@ function isExternal(kind: string): boolean {
 }
 
 interface TrafficViewProps {
-  namespace: string
+  namespaces: string[]
 }
 
-export function TrafficView({ namespace }: TrafficViewProps) {
+export function TrafficView({ namespaces }: TrafficViewProps) {
   const [wizardState, setWizardState] = useState<TrafficWizardState>('detecting')
   const [timeRange, setTimeRange] = useState<string>('5m')
   const [hideSystem, setHideSystem] = useState(true)
@@ -383,7 +383,7 @@ export function TrafficView({ namespace }: TrafficViewProps) {
     isLoading: flowsLoading,
     refetch: refetchFlowsRaw,
   } = useTrafficFlows({
-    namespace,
+    namespaces,
     since: timeRange,
     // Only fetch flows when connected (not connecting and no connection error)
     enabled: wizardState === 'ready' && !isConnecting && !connectionError,


### PR DESCRIPTION
## Summary
- Convert namespace selector from single-select to multi-select with checkboxes
- Users can now select multiple namespaces to include, or "Select All" then uncheck specific namespaces to exclude (e.g. `kube-system`)
- URL format: `?namespaces=ns1,ns2,ns3` (backward compatible with `?namespace=`)

## Changes

### Backend (Go)
- Change `BuildOptions.Namespace string` to `Namespaces []string`
- Add shared `MatchesNamespace()` helper function to avoid duplication
- Update all handlers to parse comma-separated `namespaces` query param
- Sort namespaces at SSE subscription time for consistent client grouping

### Frontend (React/TypeScript)
- Convert `NamespaceSelector` to multi-select with checkboxes, "Select All" / "Clear All" buttons
- Update `App.tsx` state from `namespace: string` to `namespaces: string[]`
- Update URL sync to use `?namespaces=ns1,ns2,ns3` format
- Update all view components to accept `namespaces: string[]`

## Test plan
- [ ] Start with `go run ./cmd/explorer --dev`
- [ ] Verify "All Namespaces" still works (empty selection)
- [ ] Select multiple namespaces, verify topology filters correctly
- [ ] Use "Select All" → uncheck kube-system → verify it's excluded
- [ ] Test URL sharing: copy URL with namespaces, open in new tab
- [ ] Test backward compat: `?namespace=default` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)