### PR TITLE
fix: Add OIDC and other auth provider support

### DIFF
--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/skyhook-io/radar/internal/timeline"
 	"github.com/skyhook-io/radar/internal/traffic"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	_ "k8s.io/client-go/plugin/pkg/client/auth" // Register all auth provider plugins (OIDC, GCP, Azure, etc.)
 	"k8s.io/klog/v2"
 )
 


### PR DESCRIPTION
## Summary
- Register client-go auth provider plugins via blank import
- Enables kubeconfigs with OIDC, GCP, Azure, and exec auth providers

## Problem
Users with OIDC-based kubeconfig couldn't use Radar:
```
Failed to initialize K8s client: failed to create k8s clientset: no Auth Provider found for name "oidc"
```

## Solution
Single-line fix: import `k8s.io/client-go/plugin/pkg/client/auth` to register all auth provider plugins.

## Test plan
- [ ] Build succeeds
- [ ] User with OIDC kubeconfig can connect to cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)