### PR TITLE
chore: update npm dependencies (minor/patch)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15,8 +15,8 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
-        "@xyflow/react": "^12.0.0",
-        "clsx": "^2.1.0",
+        "@xyflow/react": "^12.10.0",
+        "clsx": "^2.1.1",
         "diff": "^8.0.3",
         "elkjs": "^0.11.0",
         "lucide-react": "^0.563.0",
@@ -34,10 +34,10 @@
         "@types/react": "^19.2.10",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.3",
-        "postcss": "^8.4.33",
+        "postcss": "^8.5.6",
         "prettier": "^3.8.1",
         "tailwindcss": "^4.1.18",
-        "typescript": "^5.3.3",
+        "typescript": "^5.9.3",
         "vite": "^7.3.1"
       }
     },

--- a/web/package.json
+++ b/web/package.json
@@ -19,8 +19,8 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
-    "@xyflow/react": "^12.0.0",
-    "clsx": "^2.1.0",
+    "@xyflow/react": "^12.10.0",
+    "clsx": "^2.1.1",
     "diff": "^8.0.3",
     "elkjs": "^0.11.0",
     "lucide-react": "^0.563.0",
@@ -38,10 +38,10 @@
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.3",
-    "postcss": "^8.4.33",
+    "postcss": "^8.5.6",
     "prettier": "^3.8.1",
     "tailwindcss": "^4.1.18",
-    "typescript": "^5.3.3",
+    "typescript": "^5.9.3",
     "vite": "^7.3.1"
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #75 - additional safe npm updates.

- `@xyflow/react` 12.0.0 → 12.10.0 (minor)
- `clsx` 2.1.0 → 2.1.1 (patch)
- `postcss` 8.4.33 → 8.5.6 (minor)
- `typescript` 5.3.3 → 5.9.3 (minor)