### PR TITLE
fix: improve CRD discovery loading indicator

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -128,6 +128,12 @@ func doInit(opts InitOptions) error {
 		}
 	}
 
+	// Increase QPS/Burst to speed up CRD discovery and reduce throttling
+	// Default client-go is 5 QPS / 10 Burst, kubectl uses 50/100
+	// This is safe for a read-only visibility tool
+	config.QPS = 50
+	config.Burst = 100
+
 	k8sConfig = config
 
 	k8sClient, err = kubernetes.NewForConfig(config)

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -83,9 +83,21 @@ func (b *SSEBroadcaster) Start() {
 	// Register for connection state changes (for graceful startup)
 	b.registerConnectionStateCallback()
 
+	// Register for CRD discovery completion
+	b.registerCRDDiscoveryCallback()
+
 	go b.run()
 	go b.watchResourceChanges()
 	go b.heartbeat()
+}
+
+// registerCRDDiscoveryCallback registers for CRD discovery completion
+// When discovery completes, broadcast topology to update the discovery status in UI
+func (b *SSEBroadcaster) registerCRDDiscoveryCallback() {
+	k8s.OnCRDDiscoveryComplete(func() {
+		log.Printf("SSE broadcaster: CRD discovery complete, broadcasting topology update")
+		b.broadcastTopologyUpdate()
+	})
 }
 
 // registerConnectionStateCallback registers for connection state changes

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -457,13 +457,6 @@ function AppInner() {
                 </button>
               )}
             </div>
-            {/* CRD Discovery indicator */}
-            {crdDiscoveryStatus === 'discovering' && (
-              <div className="flex items-center gap-1.5 ml-2 text-xs text-amber-400">
-                <Loader2 className="w-3 h-3 animate-spin" />
-                <span className="hidden sm:inline">Discovering CRDs...</span>
-              </div>
-            )}
           </div>
         </div>
 
@@ -539,6 +532,13 @@ function AppInner() {
 
         {/* Right: Controls */}
         <div className="flex items-center gap-3">
+          {/* CRD Discovery indicator */}
+          {crdDiscoveryStatus === 'discovering' && (
+            <div className="flex items-center gap-1.5 text-xs text-amber-400">
+              <Loader2 className="w-3 h-3 animate-spin" />
+              <span className="hidden md:inline">Discovering CRDs...</span>
+            </div>
+          )}
           {/* Namespace selector with search */}
           <NamespaceSelector
             value={namespaces}


### PR DESCRIPTION
## Summary

- Move the "Discovering CRDs..." loading indicator from the left header section to the right (before namespace selector), preventing overlap with centered view tabs on small screens
- Fix stuck loading indicator by adding a callback when CRD discovery completes to trigger topology update
- Increase K8s client QPS/Burst from 5/10 to 50/100 (matching kubectl defaults) to reduce API throttling delays during CRD discovery from ~30s to a few seconds

## Changes

**Frontend (App.tsx)**
- Repositioned CRD discovery indicator to the right controls section

**Backend**
- Added `OnCRDDiscoveryComplete` callback mechanism in `dynamic_cache.go`
- Registered callback in SSE broadcaster to trigger topology update when discovery completes
- Increased client QPS/Burst limits in `client.go` for faster CRD discovery