### PR TITLE
feat: add scale replicas button for Deployments and StatefulSets

### DIFF
--- a/web/src/components/resources/renderers/WorkloadRenderer.tsx
+++ b/web/src/components/resources/renderers/WorkloadRenderer.tsx
@@ -1,55 +1,86 @@
-import { Server, AlertTriangle, ExternalLink } from 'lucide-react'
+import { useState, useEffect } from 'react'
+import { Server, AlertTriangle, ExternalLink, Scale, Minus, Plus, Loader2 } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { Section, PropertyList, Property, ConditionsSection, PodTemplateSection } from '../drawer-components'
+import { useScaleWorkload } from '../../../api/client'
+import { useQueryClient } from '@tanstack/react-query'
 
 interface WorkloadRendererProps {
   kind: string
   data: any
 }
 
-// Extract problems from workload status and conditions
+// Check if the workload is actively progressing (scaling, rolling update)
+function isWorkloadProgressing(status: any): boolean {
+  const conditions = status.conditions || []
+  const progressing = conditions.find((c: any) => c.type === 'Progressing')
+  return progressing?.status === 'True' && progressing?.reason !== 'ProgressDeadlineExceeded'
+}
+
+// Extract real problems from workload status (excludes normal rollout progress)
 function getWorkloadProblems(status: any, spec: any, kind: string): string[] {
   const problems: string[] = []
-
+  const progressing = isWorkloadProgressing(status)
   const isDaemonSet = kind === 'daemonsets'
 
-  // Check replica/pod counts
+  // Check replica/pod counts — only flag as problem if NOT actively progressing
+  if (!progressing) {
+    if (isDaemonSet) {
+      const ready = status.numberReady || 0
+      const desired = status.desiredNumberScheduled || 0
+      if (desired > 0 && ready < desired) {
+        problems.push(`${desired - ready} of ${desired} pods are not ready`)
+      }
+      if (status.numberUnavailable > 0) {
+        problems.push(`${status.numberUnavailable} pods are unavailable`)
+      }
+    } else {
+      const ready = status.readyReplicas || 0
+      const desired = spec.replicas || 0
+      if (desired > 0 && ready < desired) {
+        problems.push(`${desired - ready} of ${desired} replicas are not ready`)
+      }
+      if (status.unavailableReplicas > 0) {
+        problems.push(`${status.unavailableReplicas} replicas are unavailable`)
+      }
+    }
+  }
+
+  // Check conditions — real failures always shown
+  const conditions = status.conditions || []
+  for (const cond of conditions) {
+    if (cond.status === 'True' && cond.type === 'ReplicaFailure' && cond.message) {
+      problems.push(cond.message)
+    }
+    // Show condition failures, but skip Available=False during active rollout (that's expected)
+    if (cond.status === 'False' && cond.message) {
+      if (progressing && cond.type === 'Available') continue
+      problems.push(`${cond.type}: ${cond.message}`)
+    }
+  }
+
+  return problems
+}
+
+// Get progress info for active rollouts
+function getWorkloadProgress(status: any, spec: any, kind: string): string | null {
+  if (!isWorkloadProgressing(status)) return null
+
+  const isDaemonSet = kind === 'daemonsets'
   if (isDaemonSet) {
     const ready = status.numberReady || 0
     const desired = status.desiredNumberScheduled || 0
     if (desired > 0 && ready < desired) {
-      const notReady = desired - ready
-      problems.push(`${notReady} of ${desired} pods are not ready`)
-    }
-    if (status.numberUnavailable > 0) {
-      problems.push(`${status.numberUnavailable} pods are unavailable`)
+      return `${ready} of ${desired} pods ready`
     }
   } else {
     const ready = status.readyReplicas || 0
     const desired = spec.replicas || 0
     if (desired > 0 && ready < desired) {
-      const notReady = desired - ready
-      problems.push(`${notReady} of ${desired} replicas are not ready`)
-    }
-    if (status.unavailableReplicas > 0) {
-      problems.push(`${status.unavailableReplicas} replicas are unavailable`)
+      return `${ready} of ${desired} replicas ready`
     }
   }
-
-  // Check conditions for more details
-  const conditions = status.conditions || []
-  for (const cond of conditions) {
-    if (cond.status === 'False' && cond.message) {
-      // Add the condition message as a problem
-      problems.push(`${cond.type}: ${cond.message}`)
-    }
-    // Also check for conditions that are True but indicate problems (e.g., ReplicaFailure)
-    if (cond.status === 'True' && cond.type === 'ReplicaFailure' && cond.message) {
-      problems.push(cond.message)
-    }
-  }
-
-  return problems
+  return null
 }
 
 // Map plural lowercase kind to singular PascalCase for ownerReferences matching
@@ -66,23 +97,80 @@ function getOwnerKind(kind: string): string {
 
 export function WorkloadRenderer({ kind, data }: WorkloadRendererProps) {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const status = data.status || {}
   const spec = data.spec || {}
   const metadata = data.metadata || {}
 
   const isDaemonSet = kind === 'daemonsets'
   const isStatefulSet = kind === 'statefulsets'
+  const isScalable = kind === 'deployments' || kind === 'statefulsets'
 
-  // Check for problems
+  // Scale dialog state
+  const [showScaleDialog, setShowScaleDialog] = useState(false)
+  const [targetReplicas, setTargetReplicas] = useState(spec.replicas || 0)
+  const [scaledTo, setScaledTo] = useState<number | null>(null)
+  const scaleMutation = useScaleWorkload()
+
+  // Clear scaledTo once the backend data catches up
+  useEffect(() => {
+    if (scaledTo !== null && spec.replicas === scaledTo) {
+      setScaledTo(null)
+    }
+  }, [spec.replicas, scaledTo])
+
+  // Check for problems and progress
   const problems = getWorkloadProblems(status, spec, kind)
   const hasProblems = problems.length > 0
+  const progressMessage = getWorkloadProgress(status, spec, kind)
+
+  // Poll for resource updates while scaling is in progress
+  const isScaling = scaledTo !== null || progressMessage !== null
+  useEffect(() => {
+    if (!isScaling) return
+    const interval = setInterval(() => {
+      queryClient.invalidateQueries({ queryKey: ['resource', kind, metadata.namespace, metadata.name] })
+    }, 2000)
+    return () => clearInterval(interval)
+  }, [isScaling, kind, metadata.namespace, metadata.name, queryClient])
 
   // Build URL for viewing pods owned by this workload
   const viewPodsUrl = `/resources?kind=pods&ownerKind=${encodeURIComponent(getOwnerKind(kind))}&ownerName=${encodeURIComponent(metadata.name || '')}&namespace=${encodeURIComponent(metadata.namespace || '')}`
 
+  const handleScale = () => {
+    scaleMutation.mutate({
+      kind,
+      namespace: metadata.namespace,
+      name: metadata.name,
+      replicas: targetReplicas,
+    }, {
+      onSuccess: () => {
+        setScaledTo(targetReplicas)
+        setShowScaleDialog(false)
+      },
+    })
+  }
+
+  const openScaleDialog = () => {
+    setTargetReplicas(spec.replicas || 0)
+    setShowScaleDialog(true)
+  }
+
   return (
     <>
-      {/* Problems alert - shown at top when there are issues */}
+      {/* Scaling in progress banner */}
+      {(scaledTo !== null || progressMessage) && !hasProblems && (
+        <div className="mb-4 p-3 bg-blue-500/10 border border-blue-500/30 rounded-lg">
+          <div className="flex items-center gap-2">
+            <Loader2 className="w-4 h-4 text-blue-400 animate-spin shrink-0" />
+            <div className="text-sm text-blue-300">
+              {progressMessage || `Scaling to ${scaledTo} replicas...`}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Problems alert - shown at top when there are real issues */}
       {hasProblems && (
         <div className="mb-4 p-3 bg-red-500/10 border border-red-500/30 rounded-lg">
           <div className="flex items-start gap-2">
@@ -133,7 +221,7 @@ export function WorkloadRenderer({ kind, data }: WorkloadRendererProps) {
             </>
           )}
         </PropertyList>
-        <div className="mt-3 pt-3 border-t border-theme-border">
+        <div className="mt-3 pt-3 border-t border-theme-border flex items-center gap-2">
           <button
             onClick={() => navigate(viewPodsUrl)}
             className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-blue-400 hover:text-blue-300 bg-blue-500/10 hover:bg-blue-500/20 border border-blue-500/30 rounded transition-colors"
@@ -141,8 +229,80 @@ export function WorkloadRenderer({ kind, data }: WorkloadRendererProps) {
             <ExternalLink className="w-3 h-3" />
             View Managed Pods
           </button>
+          {isScalable && (
+            <button
+              onClick={openScaleDialog}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-emerald-400 hover:text-emerald-300 bg-emerald-500/10 hover:bg-emerald-500/20 border border-emerald-500/30 rounded transition-colors"
+            >
+              <Scale className="w-3 h-3" />
+              Scale
+            </button>
+          )}
         </div>
       </Section>
+
+      {/* Scale Dialog */}
+      {showScaleDialog && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-theme-surface border border-theme-border rounded-lg shadow-xl w-80 p-4">
+            <h3 className="text-sm font-medium text-theme-text-primary mb-4">
+              Scale {metadata.name}
+            </h3>
+
+            <div className="flex items-center justify-center gap-4 mb-4">
+              <button
+                onClick={() => setTargetReplicas(Math.max(0, targetReplicas - 1))}
+                className="p-2 rounded-lg bg-theme-elevated hover:bg-theme-hover text-theme-text-secondary hover:text-theme-text-primary transition-colors"
+                disabled={targetReplicas <= 0}
+              >
+                <Minus className="w-5 h-5" />
+              </button>
+
+              <input
+                type="number"
+                min="0"
+                max="10000"
+                value={targetReplicas}
+                onChange={(e) => setTargetReplicas(Math.min(10000, Math.max(0, parseInt(e.target.value) || 0)))}
+                className="w-20 text-center text-2xl font-semibold bg-theme-elevated border border-theme-border rounded-lg py-2 text-theme-text-primary focus:outline-none focus:border-blue-500"
+              />
+
+              <button
+                onClick={() => setTargetReplicas(Math.min(10000, targetReplicas + 1))}
+                disabled={targetReplicas >= 10000}
+                className="p-2 rounded-lg bg-theme-elevated hover:bg-theme-hover text-theme-text-secondary hover:text-theme-text-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <Plus className="w-5 h-5" />
+              </button>
+            </div>
+
+            <div className="text-xs text-theme-text-tertiary text-center mb-4">
+              Current: {spec.replicas || 0} replicas
+              {targetReplicas !== (spec.replicas || 0) && (
+                <span className="text-theme-text-secondary">
+                  {' '}→ {targetReplicas}
+                </span>
+              )}
+            </div>
+
+            <div className="flex gap-2">
+              <button
+                onClick={() => setShowScaleDialog(false)}
+                className="flex-1 px-3 py-2 text-sm text-theme-text-secondary hover:text-theme-text-primary bg-theme-elevated hover:bg-theme-hover border border-theme-border rounded-lg transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleScale}
+                disabled={scaleMutation.isPending || targetReplicas === (spec.replicas || 0)}
+                className="flex-1 px-3 py-2 text-sm text-white bg-blue-600 hover:bg-blue-500 disabled:bg-blue-600/50 disabled:cursor-not-allowed rounded-lg transition-colors"
+              >
+                {scaleMutation.isPending ? 'Scaling...' : 'Apply'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       <Section title="Strategy">
         <PropertyList>


### PR DESCRIPTION
## Summary
- Adds the ability to scale Deployments and StatefulSets directly from the resource drawer
- Includes a modal dialog with +/- buttons and direct input for setting the desired replica count
- Uses PATCH operation for efficient scaling without full resource replacement

## Changes
- `internal/k8s/update.go`: Add `ScaleWorkload` function using dynamic client PATCH
- `internal/server/server.go`: Add `POST /api/workloads/{kind}/{ns}/{name}/scale` endpoint
- `web/src/api/client.ts`: Add `useScaleWorkload` React Query mutation hook
- `web/src/components/resources/renderers/WorkloadRenderer.tsx`: Add Scale button and modal dialog

## Test plan
- [x] Open a Deployment in the resource drawer
- [x] Click the "Scale" button next to "View Managed Pods"
- [x] Use +/- buttons or direct input to change replica count
- [x] Click "Apply" and verify the workload scales
- [x] Verify button is disabled when replica count hasn't changed
- [x] Verify StatefulSets also have the Scale button
- [x] Verify DaemonSets do NOT have the Scale button (not scalable)
