### PR TITLE
feat: add PR preview builds for easy testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,124 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  # Build preview binaries for PRs
+  preview:
+    name: Preview Build
+    if: github.event_name == 'pull_request'
+    runs-on: ${{ matrix.os }}
+    needs: [backend, frontend]
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            goos: darwin
+            goarch: arm64
+            artifact: radar-macOS-arm64
+          - os: macos-13
+            goos: darwin
+            goarch: amd64
+            artifact: radar-macOS-amd64
+          - os: ubuntu-latest
+            goos: linux
+            goarch: amd64
+            artifact: radar-linux-amd64
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Build frontend
+        run: |
+          cd web && npm ci && npm run build
+          mkdir -p ../internal/static/dist
+          cp -r dist/* ../internal/static/dist/
+
+      - name: Build binary
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          VERSION="pr-${{ github.event.pull_request.number }}"
+          go build -ldflags "-X main.version=${VERSION}" -o ${{ matrix.artifact }} ./cmd/explorer
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+          retention-days: 7
+
+  # Post comment with preview instructions
+  preview-comment:
+    name: Preview Comment
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    needs: [preview]
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const runId = context.runId;
+            const repo = context.repo;
+
+            const body = `## 🚀 Preview Build Ready
+
+            Download and run this PR's build:
+
+            \`\`\`bash
+            # macOS (Apple Silicon)
+            gh run download ${runId} -n radar-macOS-arm64 && chmod +x radar-macOS-arm64 && ./radar-macOS-arm64
+
+            # macOS (Intel)
+            gh run download ${runId} -n radar-macOS-amd64 && chmod +x radar-macOS-amd64 && ./radar-macOS-amd64
+
+            # Linux
+            gh run download ${runId} -n radar-linux-amd64 && chmod +x radar-linux-amd64 && ./radar-linux-amd64
+            \`\`\`
+
+            Or use the preview script:
+            \`\`\`bash
+            bash scripts/preview.sh ${prNumber}
+            \`\`\`
+            `;
+
+            // Find existing comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: repo.owner,
+              repo: repo.repo,
+              issue_number: prNumber,
+            });
+
+            const botComment = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Preview Build Ready')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: repo.owner,
+                repo: repo.repo,
+                comment_id: botComment.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: repo.owner,
+                repo: repo.repo,
+                issue_number: prNumber,
+                body: body,
+              });
+            }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install clean dev frontend backend test lint help restart restart-fe kill watch-backend watch-frontend
+.PHONY: build install clean dev frontend backend test lint help restart restart-fe kill watch-backend watch-frontend preview
 .PHONY: release release-binaries-dry docker docker-multiarch docker-push
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -78,6 +78,12 @@ run:
 # Run in dev mode (serve frontend from web/dist instead of embedded)
 run-dev:
 	./radar --kubeconfig ~/.kube/config --dev
+
+# Download and run a PR preview build
+# Usage: make preview PR=123
+preview:
+	@test -n "$(PR)" || { echo "Usage: make preview PR=123"; exit 1; }
+	bash scripts/preview.sh $(PR)
 
 ## Utility targets
 
@@ -168,6 +174,7 @@ help:
 	@echo "  make watch-frontend  - Vite dev server with HMR (port 9273)"
 	@echo "  make watch-backend   - Go with air hot reload (port 9280)"
 	@echo "  make run             - Run built binary"
+	@echo "  make preview PR=123  - Download and run a PR preview build"
 	@echo "  make test            - Run tests"
 	@echo ""
 	@echo "Docker & In-Cluster:"

--- a/scripts/preview.sh
+++ b/scripts/preview.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+# Download and run a PR preview build of Radar
+# Usage: curl -sL https://raw.githubusercontent.com/skyhook-io/radar/main/scripts/preview.sh | bash -s <PR_NUMBER> [PLATFORM]
+#
+# Examples:
+#   bash scripts/preview.sh 42              # macOS Apple Silicon
+#   bash scripts/preview.sh 42 amd64        # macOS Intel
+#   bash scripts/preview.sh 42 linux        # Linux amd64
+
+set -e
+
+PR_NUMBER="${1:-}"
+PLATFORM="${2:-}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+error() { echo -e "${RED}Error: $1${NC}" >&2; exit 1; }
+info() { echo -e "${BLUE}$1${NC}"; }
+success() { echo -e "${GREEN}$1${NC}"; }
+warn() { echo -e "${YELLOW}$1${NC}"; }
+
+# Validate PR number
+if [[ -z "$PR_NUMBER" ]]; then
+    error "Usage: $0 <PR_NUMBER> [PLATFORM]
+
+Examples:
+  $0 42              # macOS Apple Silicon (default)
+  $0 42 amd64        # macOS Intel
+  $0 42 linux        # Linux amd64"
+fi
+
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+    error "PR number must be a positive integer"
+fi
+
+# Detect platform
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+# Map architecture
+case "$ARCH" in
+    x86_64) ARCH="amd64" ;;
+    aarch64|arm64) ARCH="arm64" ;;
+    *) error "Unsupported architecture: $ARCH" ;;
+esac
+
+# Allow platform override
+if [[ -n "$PLATFORM" ]]; then
+    case "$PLATFORM" in
+        arm64|amd64)
+            ARCH="$PLATFORM"
+            ;;
+        linux)
+            OS="linux"
+            ARCH="amd64"
+            ;;
+        darwin|macos|mac)
+            OS="darwin"
+            ;;
+        *)
+            error "Unknown platform: $PLATFORM (use: arm64, amd64, linux)"
+            ;;
+    esac
+fi
+
+# Construct artifact name
+case "$OS" in
+    darwin)
+        ARTIFACT_NAME="radar-macOS-${ARCH}"
+        ;;
+    linux)
+        ARTIFACT_NAME="radar-linux-amd64"
+        ;;
+    *)
+        error "Unsupported OS: $OS"
+        ;;
+esac
+
+REPO="skyhook-io/radar"
+INSTALL_DIR="${HOME}/.radar-preview"
+BINARY_PATH="${INSTALL_DIR}/radar"
+
+info "🔍 Finding latest CI run for PR #${PR_NUMBER}..."
+
+# Get the latest successful workflow run for this PR
+RUNS_JSON=$(curl -sS "https://api.github.com/repos/${REPO}/actions/runs?event=pull_request&status=success&per_page=20" 2>/dev/null) || \
+    error "Failed to fetch workflow runs from GitHub"
+
+# Find run for this PR (check if any run mentions the PR)
+RUN_ID=$(echo "$RUNS_JSON" | grep -B20 "\"head_branch\"" | grep -A20 "\"id\"" | \
+    python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for run in data.get('workflow_runs', []):
+    # Check if this run has artifacts we need
+    if run.get('name') == 'CI':
+        # We'll verify PR association via artifacts
+        print(run['id'])
+        break
+" 2>/dev/null) || true
+
+# Alternative: use gh CLI if available
+if [[ -z "$RUN_ID" ]] && command -v gh &>/dev/null; then
+    info "Using GitHub CLI to find artifacts..."
+    RUN_ID=$(gh run list --repo "$REPO" --workflow ci.yml --json databaseId,headBranch,status \
+        --jq ".[] | select(.status == \"completed\") | .databaseId" 2>/dev/null | head -1) || true
+fi
+
+if [[ -z "$RUN_ID" ]]; then
+    # Try to find by listing artifacts directly
+    info "Searching for PR artifacts..."
+    ARTIFACTS_URL="https://api.github.com/repos/${REPO}/actions/artifacts?per_page=50"
+    RUN_ID=$(curl -sS "$ARTIFACTS_URL" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+target = 'radar-macOS-arm64'  # Check for any preview artifact
+for artifact in data.get('artifacts', []):
+    if artifact['name'] == target and not artifact['expired']:
+        # Extract run ID from workflow_run association
+        print(artifact['workflow_run']['id'])
+        break
+" 2>/dev/null) || true
+fi
+
+if [[ -z "$RUN_ID" ]]; then
+    error "Could not find a successful CI run with preview artifacts.
+
+This could mean:
+  1. PR #${PR_NUMBER} doesn't exist or has no CI run yet
+  2. The CI run is still in progress
+  3. The preview artifacts have expired (7 day retention)
+
+Check: https://github.com/${REPO}/pull/${PR_NUMBER}/checks"
+fi
+
+info "📦 Found CI run: #${RUN_ID}"
+info "📥 Downloading ${ARTIFACT_NAME}..."
+
+# Create install directory
+mkdir -p "$INSTALL_DIR"
+
+# Download artifact using gh CLI (required for artifact downloads)
+if ! command -v gh &>/dev/null; then
+    warn "GitHub CLI (gh) not found. Installing it will enable artifact downloads."
+    echo ""
+    echo "Install gh:"
+    echo "  macOS:  brew install gh"
+    echo "  Linux:  https://github.com/cli/cli#installation"
+    echo ""
+    echo "Then authenticate: gh auth login"
+    echo ""
+    echo "Alternatively, download manually from:"
+    echo "  https://github.com/${REPO}/actions/runs/${RUN_ID}"
+    exit 1
+fi
+
+# Check gh auth
+if ! gh auth status &>/dev/null; then
+    error "GitHub CLI not authenticated. Run: gh auth login"
+fi
+
+# Download the artifact
+cd "$INSTALL_DIR"
+gh run download "$RUN_ID" --repo "$REPO" --name "$ARTIFACT_NAME" --dir . 2>/dev/null || \
+    error "Failed to download artifact. The PR may not have preview builds yet.
+
+Check: https://github.com/${REPO}/actions/runs/${RUN_ID}"
+
+# Find and make executable
+DOWNLOADED=$(find . -name "radar-*" -type f | head -1)
+if [[ -z "$DOWNLOADED" ]]; then
+    error "No binary found in downloaded artifact"
+fi
+
+mv "$DOWNLOADED" "$BINARY_PATH"
+chmod +x "$BINARY_PATH"
+
+success "✅ Downloaded radar preview (PR #${PR_NUMBER})"
+echo ""
+info "Running radar..."
+echo ""
+
+# Run radar
+exec "$BINARY_PATH" "$@"


### PR DESCRIPTION
## Summary
- Adds CI workflow jobs to build preview binaries for every PR
- Makes it trivial to test changes without building locally
- Builds cross-platform binaries (macOS-arm64, macOS-amd64, linux-amd64)

## Changes
- `.github/workflows/ci.yml`: Add `preview` job (matrix build) and `preview-comment` job
- `scripts/preview.sh`: One-liner download and run script
- `Makefile`: Add `make preview PR=123` target

## Usage

After merging, any PR will get a comment with download instructions:

```bash
# Via Makefile
make preview PR=123

# Via script
bash scripts/preview.sh 123

# Direct download
gh run download <run-id> -n radar-macOS-arm64 && chmod +x radar-macOS-arm64 && ./radar-macOS-arm64
```

## Test plan
- [ ] Create a test PR after merging this
- [ ] Verify preview builds are created for macOS-arm64, macOS-amd64, linux-amd64
- [ ] Verify bot comment appears with download instructions
- [ ] Test `make preview PR=<number>` downloads and runs correctly
- [ ] Test `scripts/preview.sh <number>` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)