### PR TITLE
fix: add writable /tmp for image cache in Helm deployment

### DIFF
--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -69,17 +69,21 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if and .Values.persistence.enabled (eq .Values.timeline.storage "sqlite") }}
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            {{- if and .Values.persistence.enabled (eq .Values.timeline.storage "sqlite") }}
             - name: data
               mountPath: /data
-          {{- end }}
-      {{- if and .Values.persistence.enabled (eq .Values.timeline.storage "sqlite") }}
+            {{- end }}
       volumes:
+        - name: tmp
+          emptyDir: {}
+        {{- if and .Values.persistence.enabled (eq .Values.timeline.storage "sqlite") }}
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "radar.fullname" . }}
-      {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Summary

Fixes #86 — image filesystem inspection fails with "read-only file system" when Radar is deployed via Helm.

The Helm chart sets `readOnlyRootFilesystem: true` in the container security context, but the image inspection feature needs to write cached layers to `/tmp/radar-image-cache`. This adds an `emptyDir` volume mounted at `/tmp`, providing writable temp storage while maintaining the read-only root filesystem security posture.

- Always mounts a `tmp` emptyDir volume (not conditional)
- Existing sqlite PVC volume mount continues to work alongside it