### PR TITLE
Fix namespace filter not working across views

### DIFF
--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -226,7 +226,7 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	resp.Health.WarningEvents = s.countWarningEvents(cache, namespace)
 
 	// Recent changes from timeline
-	resp.RecentChanges = s.getDashboardRecentChanges(r.Context(), namespace)
+	resp.RecentChanges = s.getDashboardRecentChanges(r.Context(), namespaces)
 
 	// Topology summary
 	resp.TopologySummary = s.getDashboardTopologySummary(namespaces)
@@ -871,14 +871,14 @@ func (s *Server) getDashboardRecentEvents(cache *k8s.ResourceCache, namespace st
 	return result
 }
 
-func (s *Server) getDashboardRecentChanges(ctx context.Context, namespace string) []DashboardChange {
+func (s *Server) getDashboardRecentChanges(ctx context.Context, namespaces []string) []DashboardChange {
 	store := timeline.GetStore()
 	if store == nil {
 		return []DashboardChange{}
 	}
 
 	opts := timeline.QueryOptions{
-		Namespace:    namespace,
+		Namespaces:   namespaces,
 		Since:        time.Now().Add(-1 * time.Hour),
 		Limit:        5,
 		FilterPreset: "workloads",

--- a/internal/timeline/memory_store.go
+++ b/internal/timeline/memory_store.go
@@ -120,7 +120,7 @@ func (m *MemoryStore) QueryGrouped(ctx context.Context, opts QueryOptions) (*Tim
 
 	// First get all matching events
 	events, err := m.Query(ctx, QueryOptions{
-		Namespace:        opts.Namespace,
+		Namespaces:       opts.Namespaces,
 		Kinds:            opts.Kinds,
 		Since:            opts.Since,
 		Until:            opts.Until,
@@ -296,8 +296,17 @@ func (m *MemoryStore) matchesFilters(event *TimelineEvent, opts QueryOptions, cf
 		return false
 	}
 
-	if opts.Namespace != "" && event.Namespace != opts.Namespace {
-		return false
+	if len(opts.Namespaces) > 0 {
+		found := false
+		for _, ns := range opts.Namespaces {
+			if event.Namespace == ns {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
 	}
 
 	if len(opts.Kinds) > 0 {

--- a/internal/timeline/memory_store_test.go
+++ b/internal/timeline/memory_store_test.go
@@ -75,7 +75,7 @@ func TestMemoryStore_Query_Namespace(t *testing.T) {
 	_ = store.AppendBatch(ctx, events)
 
 	// Query for prod namespace only
-	result, err := store.Query(ctx, QueryOptions{Namespace: "prod", Limit: 10, IncludeManaged: true})
+	result, err := store.Query(ctx, QueryOptions{Namespaces: []string{"prod"}, Limit: 10, IncludeManaged: true})
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}

--- a/internal/timeline/metrics.go
+++ b/internal/timeline/metrics.go
@@ -277,7 +277,7 @@ func GetDiagnosis(kind, namespace, name string) DiagnoseResponse {
 	if store != nil {
 		// Query for events matching this resource
 		events, err := store.Query(nil, QueryOptions{
-			Namespace:        namespace,
+			Namespaces:       []string{namespace},
 			Kinds:            []string{kind},
 			Limit:            50,
 			IncludeManaged:   true,

--- a/internal/timeline/sqlite_store.go
+++ b/internal/timeline/sqlite_store.go
@@ -237,9 +237,16 @@ func (s *SQLiteStore) Query(ctx context.Context, opts QueryOptions) ([]TimelineE
 	var args []any
 
 	// Apply filters
-	if opts.Namespace != "" {
-		query.WriteString(" AND namespace = ?")
-		args = append(args, opts.Namespace)
+	if len(opts.Namespaces) > 0 {
+		query.WriteString(" AND namespace IN (")
+		for i, ns := range opts.Namespaces {
+			if i > 0 {
+				query.WriteString(",")
+			}
+			query.WriteString("?")
+			args = append(args, ns)
+		}
+		query.WriteString(")")
 	}
 
 	if len(opts.Kinds) > 0 {

--- a/internal/timeline/store.go
+++ b/internal/timeline/store.go
@@ -46,7 +46,7 @@ type EventStore interface {
 // QueryOptions configures event queries
 type QueryOptions struct {
 	// Filters
-	Namespace string        // Filter by namespace (empty = all)
+	Namespaces []string     // Filter by namespaces (empty = all)
 	Kinds     []string      // Filter by resource kinds (empty = all)
 	Since     time.Time     // Filter events after this time
 	Until     time.Time     // Filter events before this time

--- a/internal/topology/builder.go
+++ b/internal/topology/builder.go
@@ -280,6 +280,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		}
 		for _, rollout := range rollouts {
 			ns := rollout.GetNamespace()
+			if !opts.MatchesNamespaceFilter(ns) {
+				continue
+			}
 			name := rollout.GetName()
 
 			rolloutID := fmt.Sprintf("rollout/%s/%s", ns, name)
@@ -360,6 +363,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		}
 		for _, app := range applications {
 			ns := app.GetNamespace()
+			if !opts.MatchesNamespaceFilter(ns) {
+				continue
+			}
 			name := app.GetName()
 
 			appID := fmt.Sprintf("application/%s/%s", ns, name)
@@ -452,6 +458,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		}
 		for _, ks := range kustomizations {
 			ns := ks.GetNamespace()
+			if !opts.MatchesNamespaceFilter(ns) {
+				continue
+			}
 			name := ks.GetName()
 
 			ksID := fmt.Sprintf("kustomization/%s/%s", ns, name)
@@ -518,6 +527,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		}
 		for _, repo := range gitRepos {
 			ns := repo.GetNamespace()
+			if !opts.MatchesNamespaceFilter(ns) {
+				continue
+			}
 			name := repo.GetName()
 
 			repoID := fmt.Sprintf("gitrepository/%s/%s", ns, name)
@@ -579,6 +591,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		}
 		for _, hr := range helmReleases {
 			ns := hr.GetNamespace()
+			if !opts.MatchesNamespaceFilter(ns) {
+				continue
+			}
 			name := hr.GetName()
 
 			hrID := fmt.Sprintf("helmrelease/%s/%s", ns, name)
@@ -2377,12 +2392,16 @@ func (b *Builder) addGenericCRDNodes(nodes []Node, edges []Edge, opts BuildOptio
 				break
 			}
 
+			ns := resource.GetNamespace()
+			if !opts.MatchesNamespaceFilter(ns) {
+				continue
+			}
+
 			ownerRefs := resource.GetOwnerReferences()
 			if len(ownerRefs) == 0 {
 				continue
 			}
 
-			ns := resource.GetNamespace()
 			name := resource.GetName()
 			nodeID := fmt.Sprintf("%s/%s/%s", kindLower, ns, name)
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -225,8 +225,9 @@ function AppInner() {
     return groupingMode
   }, [hasNamespaceFilter, groupingMode])
 
-  // Hide group header when viewing specific namespaces with "no grouping" selected
-  const hideGroupHeader = hasNamespaceFilter && groupingMode === 'none'
+  // Hide group header when viewing a single namespace with "no grouping" selected
+  // (grouping header is meaningless with only one namespace, but needed for multi-namespace)
+  const hideGroupHeader = namespaces.length === 1 && groupingMode === 'none'
 
   // Fetch available namespaces
   const { data: availableNamespaces } = useNamespaces()
@@ -544,6 +545,8 @@ function AppInner() {
             value={namespaces}
             onChange={setNamespaces}
             namespaces={availableNamespaces}
+            disabled={mainView === 'helm'}
+            disabledTooltip="Helm view always shows all namespaces"
           />
 
           {/* Theme toggle */}

--- a/web/src/components/ui/NamespaceSelector.tsx
+++ b/web/src/components/ui/NamespaceSelector.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import { createPortal } from 'react-dom'
 import { clsx } from 'clsx'
 import { ChevronDown, Search, X, Check } from 'lucide-react'
+import { Tooltip } from './Tooltip'
 
 interface Namespace {
   name: string
@@ -12,6 +13,8 @@ interface NamespaceSelectorProps {
   onChange: (value: string[]) => void
   namespaces: Namespace[] | undefined
   className?: string
+  disabled?: boolean
+  disabledTooltip?: string
 }
 
 export function NamespaceSelector({
@@ -19,6 +22,8 @@ export function NamespaceSelector({
   onChange,
   namespaces,
   className,
+  disabled,
+  disabledTooltip,
 }: NamespaceSelectorProps) {
   const [isOpen, setIsOpen] = useState(false)
   const [search, setSearch] = useState('')
@@ -185,28 +190,38 @@ export function NamespaceSelector({
 
   return (
     <>
-      <button
-        ref={triggerRef}
-        type="button"
-        onClick={() => (isOpen ? closeDropdown() : openDropdown())}
-        className={clsx(
-          'appearance-none bg-theme-elevated text-theme-text-primary text-xs rounded px-2 py-1 pr-6 border border-theme-border-light',
-          'focus:outline-none focus:ring-1 focus:ring-blue-500 min-w-[100px] text-left relative',
-          'hover:bg-theme-hover transition-colors',
-          className
-        )}
-      >
-        <span className="block truncate">{displayValue}</span>
-        <ChevronDown
+      <Tooltip content={disabledTooltip} disabled={!disabled} position="bottom">
+        <button
+          ref={triggerRef}
+          type="button"
+          disabled={disabled}
+          onClick={() => (isOpen ? closeDropdown() : openDropdown())}
           className={clsx(
-            'absolute right-1.5 top-1/2 -translate-y-1/2 w-3 h-3 text-theme-text-secondary transition-transform',
-            isOpen && 'rotate-180'
+            'appearance-none bg-theme-elevated text-theme-text-primary text-xs rounded px-2 py-1 pr-6 border border-theme-border-light',
+            'focus:outline-none focus:ring-1 focus:ring-blue-500 min-w-[100px] text-left relative',
+            'transition-colors',
+            disabled ? 'opacity-50 cursor-not-allowed' : 'hover:bg-theme-hover',
+            className
           )}
-        />
-      </button>
+        >
+          <span className="block truncate">{displayValue}</span>
+          <ChevronDown
+            className={clsx(
+              'absolute right-1.5 top-1/2 -translate-y-1/2 w-3 h-3 text-theme-text-secondary transition-transform',
+              isOpen && 'rotate-180'
+            )}
+          />
+        </button>
+      </Tooltip>
 
       {isOpen &&
         createPortal(
+          <>
+          {/* Backdrop to capture clicks outside the dropdown */}
+          <div
+            className="fixed inset-0 z-[9998]"
+            onClick={closeDropdown}
+          />
           <div
             ref={dropdownRef}
             className="fixed z-[9999] bg-theme-elevated border border-theme-border rounded-md shadow-lg overflow-hidden"
@@ -323,7 +338,8 @@ export function NamespaceSelector({
                 )}
               </div>
             )}
-          </div>,
+          </div>
+          </>,
           document.body
         )}
     </>


### PR DESCRIPTION
## Summary

The namespace filter (top-right selector) worked for Topology/Traffic views but was ignored by Resources, Events, Timeline, and partially by Topology for CRD resources.

**Root cause:** Multiple backend handlers read the `namespace` (singular) query param while the frontend sends `namespaces` (plural, comma-separated). The existing `parseNamespaces()` helper handled both formats but wasn't used everywhere.

### What changed

- **Resources/Events/Changes handlers** — switched to `parseNamespaces()` with multi-namespace merge logic for all resource types and CRDs
- **Timeline query layer** — changed `QueryOptions.Namespace string` to `Namespaces []string` across memory store, SQLite store, and metrics
- **Topology builder** — added `MatchesNamespaceFilter()` checks to all 6 dynamic resource loops (Rollouts, ArgoCD Apps, Kustomizations, GitRepositories, HelmReleases, generic CRDs) that were fetching unfiltered when multiple namespaces were selected
- **Topology grouping** — namespace group headers now show when multiple namespaces are selected (previously hidden, making it impossible to tell which resources belong where)
- **Namespace selector UX** — click-outside-to-close via backdrop overlay (react-flow canvas was swallowing mouse events); disabled with tooltip on Helm view which always shows all namespaces