### PR TITLE
feat: dynamic Prometheus/VictoriaMetrics service discovery

### DIFF
--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -43,6 +44,8 @@ func main() {
 	// Timeline storage options
 	timelineStorage := flag.String("timeline-storage", "memory", "Timeline storage backend: memory or sqlite")
 	timelineDBPath := flag.String("timeline-db", "", "Path to timeline database file (default: ~/.radar/timeline.db)")
+	// Traffic/metrics options
+	prometheusURL := flag.String("prometheus-url", "", "Manual Prometheus/VictoriaMetrics URL (skips auto-discovery)")
 	flag.Parse()
 
 	// Set debug mode for event tracking
@@ -124,6 +127,15 @@ func main() {
 	k8s.RegisterTimelineFuncs(timeline.ResetStore, func() error {
 		return timeline.ReinitStore(timelineStoreCfg)
 	})
+
+	// Set manual Prometheus URL if provided (persists across context switches)
+	if *prometheusURL != "" {
+		u, err := url.Parse(*prometheusURL)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+			log.Fatalf("Invalid --prometheus-url %q: must be a valid HTTP(S) URL (e.g., http://prometheus-server.monitoring:9090)", *prometheusURL)
+		}
+		traffic.SetMetricsURL(*prometheusURL)
+	}
 
 	// Register traffic reset/reinit functions for context switching
 	k8s.RegisterTrafficFuncs(traffic.Reset, func() error {

--- a/deploy/helm/radar/README.md
+++ b/deploy/helm/radar/README.md
@@ -64,6 +64,7 @@ helm upgrade --install radar skyhook/radar \
 | `ingress.className` | Ingress class name | `""` |
 | `timeline.storage` | Timeline storage (memory/sqlite) | `memory` |
 | `persistence.enabled` | Enable PVC for SQLite | `false` |
+| `traffic.prometheusUrl` | Manual Prometheus/VictoriaMetrics URL (skips auto-discovery) | `""` |
 | `resources.limits.memory` | Memory limit | `512Mi` |
 | `resources.requests.memory` | Memory request | `128Mi` |
 

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
             - --timeline-db={{ .Values.timeline.dbPath }}
             {{- end }}
             - --history-limit={{ .Values.timeline.historyLimit }}
+            {{- if .Values.traffic.prometheusUrl }}
+            - --prometheus-url={{ .Values.traffic.prometheusUrl }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -147,6 +147,16 @@ timeline:
   # Maximum number of events to retain
   historyLimit: 10000
 
+# Traffic source configuration
+traffic:
+  # Manual Prometheus/VictoriaMetrics URL (bypasses auto-discovery)
+  # Use this when auto-discovery doesn't find your metrics service.
+  # Examples:
+  #   http://prometheus-server.monitoring:80
+  #   http://vmsingle.victoria-metrics:8428
+  #   http://vmselect.victoria-metrics:8481/select/0/prometheus
+  prometheusUrl: ""
+
 # Persistence for SQLite timeline storage
 # Required when timeline.storage is "sqlite" (readOnlyRootFilesystem prevents local writes)
 persistence:

--- a/internal/traffic/caretta.go
+++ b/internal/traffic/caretta.go
@@ -7,10 +7,13 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -20,21 +23,36 @@ const (
 	carettaAppLabel  = "app.kubernetes.io/name=caretta"
 )
 
-// Known Prometheus/VictoriaMetrics service locations to check
+// Known Prometheus/VictoriaMetrics service locations to check.
+// Each entry triggers a direct GET for fast O(n) lookup (Layer 2).
 var metricsServiceLocations = []struct {
 	namespace string
 	name      string
-	port      int // 0 means use service's first port
+	port      int    // 0 means use service's first port
+	basePath  string // sub-path for Prometheus API (empty = root)
 }{
 	// VictoriaMetrics (Caretta's default)
-	{"caretta", "caretta-vm", 8428},
+	{"caretta", "caretta-vm", 8428, ""},
+	// VictoriaMetrics common patterns
+	{"victoria-metrics", "victoria-metrics-single-server", 8428, ""},
+	{"victoria-metrics", "vmsingle", 8428, ""},
+	{"monitoring", "victoria-metrics-single-server", 8428, ""},
+	{"monitoring", "vmsingle", 8428, ""},
+	// VictoriaMetrics vmselect (cluster mode) - uses sub-path
+	{"victoria-metrics", "vmselect", 8481, "/select/0/prometheus"},
+	{"monitoring", "vmselect", 8481, "/select/0/prometheus"},
+	// kube-prometheus-stack (any release name uses this service name pattern)
+	{"monitoring", "prometheus-kube-prometheus-prometheus", 9090, ""},
+	{"monitoring", "prometheus-operated", 9090, ""},
 	// Standard Prometheus locations
-	{"opencost", "prometheus-server", 0},
-	{"monitoring", "prometheus-server", 0},
-	{"prometheus", "prometheus-server", 0},
-	{"kube-system", "prometheus", 0},
-	{"default", "prometheus", 0},
-	{"caretta", "prometheus", 0},
+	{"opencost", "prometheus-server", 0, ""},
+	{"monitoring", "prometheus-server", 0, ""},
+	{"prometheus", "prometheus-server", 0, ""},
+	{"observability", "prometheus-server", 0, ""},
+	{"metrics", "prometheus-server", 0, ""},
+	{"kube-system", "prometheus", 0, ""},
+	{"default", "prometheus", 0, ""},
+	{"caretta", "prometheus", 0, ""},
 }
 
 // CarettaSource implements TrafficSource for Caretta
@@ -42,9 +60,11 @@ type CarettaSource struct {
 	k8sClient        kubernetes.Interface
 	httpClient       *http.Client
 	prometheusAddr   string
+	metricsBasePath  string // sub-path for Prometheus API (e.g. "/select/0/prometheus" for vmselect)
 	metricsNamespace string // namespace where metrics service was found
 	metricsService   string // service name for port-forward
 	metricsPort      int    // port for port-forward
+	metricsURL       string // manual override URL from --prometheus-url flag
 	isConnected      bool
 	currentContext   string // current K8s context name
 	mu               sync.RWMutex
@@ -149,6 +169,7 @@ func (c *CarettaSource) GetFlows(ctx context.Context, opts FlowOptions) (*FlowsR
 	c.mu.RLock()
 	connected := c.isConnected
 	promAddr := c.prometheusAddr
+	basePath := c.metricsBasePath
 	c.mu.RUnlock()
 
 	if !connected {
@@ -158,6 +179,7 @@ func (c *CarettaSource) GetFlows(ctx context.Context, opts FlowOptions) (*FlowsR
 		}
 		c.mu.RLock()
 		promAddr = c.prometheusAddr
+		basePath = c.metricsBasePath
 		c.mu.RUnlock()
 	}
 
@@ -165,9 +187,9 @@ func (c *CarettaSource) GetFlows(ctx context.Context, opts FlowOptions) (*FlowsR
 	if promAddr == "" {
 		promAddr = c.discoverPrometheus(ctx)
 		if promAddr != "" {
-			c.mu.Lock()
-			c.prometheusAddr = promAddr
-			c.mu.Unlock()
+			c.mu.RLock()
+			basePath = c.metricsBasePath
+			c.mu.RUnlock()
 		}
 	}
 
@@ -182,7 +204,7 @@ func (c *CarettaSource) GetFlows(ctx context.Context, opts FlowOptions) (*FlowsR
 	}
 
 	// Query Prometheus for Caretta metrics
-	flows, err := c.queryPrometheusForFlows(ctx, promAddr, opts)
+	flows, err := c.queryPrometheusForFlows(ctx, promAddr, basePath, opts)
 	if err != nil {
 		log.Printf("[caretta] Error querying Prometheus: %v", err)
 		return &FlowsResponse{
@@ -200,19 +222,37 @@ func (c *CarettaSource) GetFlows(ctx context.Context, opts FlowOptions) (*FlowsR
 	}, nil
 }
 
-// discoverPrometheus finds and connects to the metrics service
-// Uses the managed port-forward if running locally
+// discoverPrometheus finds and connects to the metrics service.
+// Uses a 3-layer approach:
+//  1. Manual URL override (--prometheus-url flag) — does NOT fall through on failure
+//  2. Well-known service locations (fast direct lookups)
+//  3. Dynamic cluster-wide discovery with scoring
 func (c *CarettaSource) discoverPrometheus(ctx context.Context) string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	// If we have a cached address, verify it's still valid
 	if c.prometheusAddr != "" {
-		if c.tryMetricsEndpointLocked(ctx, c.prometheusAddr) {
+		testAddr := c.prometheusAddr + c.metricsBasePath
+		if c.tryMetricsEndpointLocked(ctx, testAddr) {
 			return c.prometheusAddr
 		}
 		// Clear stale address
 		c.prometheusAddr = ""
+		c.metricsBasePath = ""
+	}
+
+	// Layer 1: Manual URL override — if set, use it exclusively (don't fall through)
+	if c.metricsURL != "" {
+		addr := strings.TrimRight(c.metricsURL, "/")
+		if c.tryMetricsEndpointLocked(ctx, addr) {
+			log.Printf("[caretta] Using manual metrics URL: %s", addr)
+			c.prometheusAddr = addr
+			c.metricsBasePath = ""
+			return addr
+		}
+		log.Printf("[caretta] Manual metrics URL %s not reachable", addr)
+		return ""
 	}
 
 	// Check for active managed port-forward first
@@ -224,32 +264,54 @@ func (c *CarettaSource) discoverPrometheus(ctx context.Context) string {
 		}
 	}
 
-	// Find and try cluster-internal address
-	info := c.findMetricsServiceLocked(ctx)
+	// Layer 2+3: Well-known locations, then dynamic discovery
+	info := c.discoverServiceLocked(ctx)
 	if info == nil {
-		log.Printf("[caretta] No Prometheus/VictoriaMetrics service found")
+		log.Printf("[caretta] No Prometheus/VictoriaMetrics service found via any discovery method")
 		return ""
 	}
 
-	c.metricsNamespace = info.namespace
-	c.metricsService = info.name
-	c.metricsPort = info.port
-
 	// Try cluster address (works when running in-cluster)
-	if c.tryMetricsEndpointLocked(ctx, info.clusterAddr) {
-		log.Printf("[caretta] Found metrics service at %s", info.clusterAddr)
-		c.prometheusAddr = info.clusterAddr
+	if c.tryClusterAddrLocked(ctx, info) {
+		log.Printf("[caretta] Found metrics service at %s (basePath=%q)", info.clusterAddr, info.basePath)
 		return info.clusterAddr
 	}
 
-	// Not reachable - need to call Connect() to establish port-forward
-	log.Printf("[caretta] Metrics service %s/%s found but not reachable. Call Connect() to establish port-forward.",
+	// Service exists but not reachable in-cluster - will need port-forward
+	log.Printf("[caretta] Metrics service %s/%s found but not reachable in-cluster. Call Connect() for port-forward.",
 		info.namespace, info.name)
 	return ""
 }
 
+// discoverServiceLocked finds a metrics service via Layer 2 (well-known) then Layer 3 (dynamic).
+// Sets metricsNamespace, metricsService, metricsPort on success. Caller must hold lock.
+func (c *CarettaSource) discoverServiceLocked(ctx context.Context) *metricsServiceInfo {
+	info := c.findMetricsServiceLocked(ctx)
+	if info == nil {
+		info = c.discoverMetricsServiceDynamic(ctx)
+	}
+	if info != nil {
+		c.metricsNamespace = info.namespace
+		c.metricsService = info.name
+		c.metricsPort = info.port
+	}
+	return info
+}
+
+// tryClusterAddrLocked tries the cluster address with basePath and stores the result on success.
+// Caller must hold lock.
+func (c *CarettaSource) tryClusterAddrLocked(ctx context.Context, info *metricsServiceInfo) bool {
+	testAddr := info.clusterAddr + info.basePath
+	if c.tryMetricsEndpointLocked(ctx, testAddr) {
+		c.prometheusAddr = info.clusterAddr
+		c.metricsBasePath = info.basePath
+		return true
+	}
+	return false
+}
+
 // queryPrometheusForFlows queries Prometheus for caretta_links_observed metrics
-func (c *CarettaSource) queryPrometheusForFlows(ctx context.Context, promAddr string, opts FlowOptions) ([]Flow, error) {
+func (c *CarettaSource) queryPrometheusForFlows(ctx context.Context, promAddr string, basePath string, opts FlowOptions) ([]Flow, error) {
 	// Build PromQL query for Caretta's link metric
 	// caretta_links_observed{client_name, client_namespace, server_name, server_namespace, server_port, ...}
 	query := "caretta_links_observed"
@@ -259,8 +321,7 @@ func (c *CarettaSource) queryPrometheusForFlows(ctx context.Context, promAddr st
 			opts.Namespace, opts.Namespace)
 	}
 
-	// Query Prometheus API
-	queryURL := fmt.Sprintf("%s/api/v1/query?query=%s", promAddr, url.QueryEscape(query))
+	queryURL := fmt.Sprintf("%s%s/api/v1/query?query=%s", promAddr, basePath, url.QueryEscape(query))
 
 	req, err := http.NewRequestWithContext(ctx, "GET", queryURL, nil)
 	if err != nil {
@@ -405,6 +466,7 @@ func (c *CarettaSource) Close() error {
 	defer c.mu.Unlock()
 	c.isConnected = false
 	c.prometheusAddr = ""
+	c.metricsBasePath = ""
 	c.currentContext = ""
 	return nil
 }
@@ -417,7 +479,8 @@ func (c *CarettaSource) Connect(ctx context.Context, contextName string) (*Metri
 
 	// If already connected to the same context, check if still valid
 	if c.prometheusAddr != "" && c.currentContext == contextName {
-		if c.tryMetricsEndpointLocked(ctx, c.prometheusAddr) {
+		testAddr := c.prometheusAddr + c.metricsBasePath
+		if c.tryMetricsEndpointLocked(ctx, testAddr) {
 			return &MetricsConnectionInfo{
 				Connected:   true,
 				Address:     c.prometheusAddr,
@@ -428,35 +491,50 @@ func (c *CarettaSource) Connect(ctx context.Context, contextName string) (*Metri
 		}
 		// Connection lost, clear it
 		c.prometheusAddr = ""
+		c.metricsBasePath = ""
 	}
 
 	// Clear stale state if context changed
 	if c.currentContext != contextName {
 		c.prometheusAddr = ""
+		c.metricsBasePath = ""
 		c.currentContext = contextName
 	}
 
-	// Find the metrics service
-	metricsInfo := c.findMetricsServiceLocked(ctx)
-	if metricsInfo == nil {
+	// Layer 1: Manual URL override — if set, use it exclusively (don't fall through)
+	if c.metricsURL != "" {
+		addr := strings.TrimRight(c.metricsURL, "/")
+		if c.tryMetricsEndpointLocked(ctx, addr) {
+			log.Printf("[caretta] Connected using manual metrics URL: %s", addr)
+			c.prometheusAddr = addr
+			c.metricsBasePath = ""
+			return &MetricsConnectionInfo{
+				Connected:   true,
+				Address:     addr,
+				ContextName: contextName,
+			}, nil
+		}
 		return &MetricsConnectionInfo{
 			Connected: false,
-			Error:     "No Prometheus/VictoriaMetrics service found for Caretta",
+			Error:     fmt.Sprintf("Manual metrics URL %s is not reachable. Check the URL and ensure the service is running.", addr),
 		}, nil
 	}
 
-	c.metricsNamespace = metricsInfo.namespace
-	c.metricsService = metricsInfo.name
-	c.metricsPort = metricsInfo.port
+	// Layer 2+3: Well-known locations, then dynamic discovery
+	metricsInfo := c.discoverServiceLocked(ctx)
+	if metricsInfo == nil {
+		return &MetricsConnectionInfo{
+			Connected: false,
+			Error:     "No Prometheus/VictoriaMetrics service found. Use --prometheus-url to specify manually.",
+		}, nil
+	}
 
 	// Try cluster-internal address first (works when running in-cluster)
-	clusterAddr := metricsInfo.clusterAddr
-	if c.tryMetricsEndpointLocked(ctx, clusterAddr) {
-		log.Printf("[caretta] Connected to metrics service at %s", clusterAddr)
-		c.prometheusAddr = clusterAddr
+	if c.tryClusterAddrLocked(ctx, metricsInfo) {
+		log.Printf("[caretta] Connected to metrics service at %s (basePath=%q)", metricsInfo.clusterAddr, metricsInfo.basePath)
 		return &MetricsConnectionInfo{
 			Connected:   true,
-			Address:     clusterAddr,
+			Address:     metricsInfo.clusterAddr,
 			Namespace:   metricsInfo.namespace,
 			ServiceName: metricsInfo.name,
 			ContextName: contextName,
@@ -465,9 +543,11 @@ func (c *CarettaSource) Connect(ctx context.Context, contextName string) (*Metri
 
 	// Check if there's already a valid managed port-forward for this context
 	if pfAddr := GetMetricsAddress(contextName); pfAddr != "" {
-		if c.tryMetricsEndpointLocked(ctx, pfAddr) {
+		pfTestAddr := pfAddr + metricsInfo.basePath
+		if c.tryMetricsEndpointLocked(ctx, pfTestAddr) {
 			log.Printf("[caretta] Using existing port-forward at %s", pfAddr)
 			c.prometheusAddr = pfAddr
+			c.metricsBasePath = metricsInfo.basePath
 			return &MetricsConnectionInfo{
 				Connected:   true,
 				Address:     pfAddr,
@@ -491,7 +571,8 @@ func (c *CarettaSource) Connect(ctx context.Context, contextName string) (*Metri
 	}
 
 	c.prometheusAddr = connInfo.Address
-	log.Printf("[caretta] Connected via port-forward at %s", connInfo.Address)
+	c.metricsBasePath = metricsInfo.basePath
+	log.Printf("[caretta] Connected via port-forward at %s (basePath=%q)", connInfo.Address, metricsInfo.basePath)
 
 	return connInfo, nil
 }
@@ -502,9 +583,21 @@ type metricsServiceInfo struct {
 	name        string
 	port        int
 	clusterAddr string
+	basePath    string // sub-path for Prometheus API (e.g. "/select/0/prometheus" for vmselect)
 }
 
-// findMetricsServiceLocked finds a metrics service (caller must hold lock)
+// resolveServicePort determines the port to use for a service
+func resolveServicePort(svc corev1.Service, defaultPort int) int {
+	if defaultPort != 0 {
+		return defaultPort
+	}
+	if len(svc.Spec.Ports) > 0 {
+		return int(svc.Spec.Ports[0].Port)
+	}
+	return 80
+}
+
+// findMetricsServiceLocked finds a metrics service from well-known locations (caller must hold lock)
 func (c *CarettaSource) findMetricsServiceLocked(ctx context.Context) *metricsServiceInfo {
 	for _, loc := range metricsServiceLocations {
 		svc, err := c.k8sClient.CoreV1().Services(loc.namespace).Get(ctx, loc.name, metav1.GetOptions{})
@@ -512,23 +605,8 @@ func (c *CarettaSource) findMetricsServiceLocked(ctx context.Context) *metricsSe
 			continue
 		}
 
-		// Determine port
-		port := loc.port
-		if port == 0 && len(svc.Spec.Ports) > 0 {
-			port = int(svc.Spec.Ports[0].Port)
-		}
-		if port == 0 {
-			port = 80
-		}
-
-		// Build cluster-internal address
-		var clusterAddr string
-		if svc.Spec.ClusterIP == "None" {
-			// For headless services, use pod-0 directly
-			clusterAddr = fmt.Sprintf("http://%s-0.%s.%s.svc.cluster.local:%d", svc.Name, svc.Name, svc.Namespace, port)
-		} else {
-			clusterAddr = fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", svc.Name, svc.Namespace, port)
-		}
+		port := resolveServicePort(*svc, loc.port)
+		clusterAddr := buildClusterAddr(svc.Name, svc.Namespace, svc.Spec.ClusterIP, port)
 
 		log.Printf("[caretta] Found metrics service: %s/%s:%d", svc.Namespace, svc.Name, port)
 		return &metricsServiceInfo{
@@ -536,10 +614,215 @@ func (c *CarettaSource) findMetricsServiceLocked(ctx context.Context) *metricsSe
 			name:        svc.Name,
 			port:        port,
 			clusterAddr: clusterAddr,
+			basePath:    loc.basePath,
 		}
 	}
 
 	return nil
+}
+
+// Namespaces to skip during dynamic discovery - never contain metrics services
+var skipNamespaces = map[string]bool{
+	"kube-public":     true,
+	"kube-node-lease": true,
+}
+
+// metricsNamespaces commonly used for metrics services
+var metricsNamespaces = map[string]bool{
+	"monitoring":       true,
+	"prometheus":       true,
+	"observability":    true,
+	"metrics":          true,
+	"victoria-metrics": true,
+	"caretta":          true,
+	"opencost":         true,
+}
+
+// scoredService is a candidate from dynamic discovery
+type scoredService struct {
+	info  metricsServiceInfo
+	score int
+}
+
+// scoreMetricsService computes a heuristic score for a service being a Prometheus-compatible endpoint.
+// Only services with score > 0 are considered candidates.
+func scoreMetricsService(svc corev1.Service) (score int, basePath string) {
+	labels := svc.Labels
+	name := svc.Name
+	ns := svc.Namespace
+
+	// Skip ExternalName services
+	if svc.Spec.Type == corev1.ServiceTypeExternalName {
+		return 0, ""
+	}
+
+	// Skip filtered namespaces
+	if skipNamespaces[ns] {
+		return 0, ""
+	}
+
+	// --- Label signals ---
+	appName := labels["app.kubernetes.io/name"]
+	appLabel := labels["app"]
+	component := labels["app.kubernetes.io/component"]
+
+	switch appName {
+	case "prometheus":
+		score += 100
+	case "victoria-metrics-single", "vmsingle":
+		score += 100
+	case "vmselect":
+		score += 90
+		basePath = "/select/0/prometheus"
+	case "thanos-query", "thanos-querier":
+		score += 80
+	}
+
+	switch appLabel {
+	case "prometheus", "prometheus-server":
+		score += 80
+	case "vmsingle":
+		score += 80
+	case "vmselect":
+		score += 80
+		basePath = "/select/0/prometheus"
+	}
+
+	// Component disambiguator (only useful when already scored)
+	if score > 0 && component == "server" {
+		score += 20
+	}
+
+	// --- Port signals ---
+	for _, p := range svc.Spec.Ports {
+		switch p.Port {
+		case 9090:
+			score += 30
+		case 8428:
+			score += 30
+		case 8481:
+			score += 25
+		case 9009:
+			score += 25
+		}
+		if strings.Contains(strings.ToLower(p.Name), "prometheus") {
+			score += 10
+		}
+	}
+
+	// --- Name signals ---
+	nameLower := strings.ToLower(name)
+	if strings.Contains(nameLower, "prometheus") {
+		score += 20
+	}
+	if strings.Contains(nameLower, "victoria") || strings.Contains(nameLower, "vmsingle") || strings.Contains(nameLower, "vmselect") {
+		score += 20
+		if strings.Contains(nameLower, "vmselect") && basePath == "" {
+			basePath = "/select/0/prometheus"
+		}
+	}
+	if strings.Contains(nameLower, "thanos") {
+		score += 15
+	}
+
+	// --- Namespace signal ---
+	if metricsNamespaces[ns] {
+		score += 10
+	}
+
+	return score, basePath
+}
+
+// discoverMetricsServiceDynamic lists all services cluster-wide, scores them, and validates top candidates (Layer 3).
+// Caller must hold the mutex lock.
+func (c *CarettaSource) discoverMetricsServiceDynamic(ctx context.Context) *metricsServiceInfo {
+	log.Printf("[caretta] Starting dynamic metrics service discovery...")
+
+	svcs, err := c.k8sClient.CoreV1().Services("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		log.Printf("[caretta] Failed to list services for dynamic discovery: %v", err)
+		return nil
+	}
+
+	// Score all services
+	var candidates []scoredService
+	for _, svc := range svcs.Items {
+		score, bp := scoreMetricsService(svc)
+		if score <= 0 {
+			continue
+		}
+
+		port := resolveServicePort(svc, 0)
+		candidates = append(candidates, scoredService{
+			info: metricsServiceInfo{
+				namespace:   svc.Namespace,
+				name:        svc.Name,
+				port:        port,
+				clusterAddr: buildClusterAddr(svc.Name, svc.Namespace, svc.Spec.ClusterIP, port),
+				basePath:    bp,
+			},
+			score: score,
+		})
+	}
+
+	if len(candidates) == 0 {
+		log.Printf("[caretta] Dynamic discovery found no candidates")
+		return nil
+	}
+
+	// Sort by score descending
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].score > candidates[j].score
+	})
+
+	log.Printf("[caretta] Dynamic discovery found %d candidates, top scores:", len(candidates))
+	limit := 5
+	if len(candidates) < limit {
+		limit = len(candidates)
+	}
+	for i := 0; i < limit; i++ {
+		log.Printf("[caretta]   %s/%s (score=%d, basePath=%q)",
+			candidates[i].info.namespace, candidates[i].info.name,
+			candidates[i].score, candidates[i].info.basePath)
+	}
+
+	// Validate top candidates via API probe (works when running in-cluster)
+	for i := 0; i < limit; i++ {
+		cand := &candidates[i]
+		addr := cand.info.clusterAddr
+
+		// Try root path first
+		if c.tryMetricsEndpointLocked(ctx, addr) {
+			log.Printf("[caretta] Dynamic discovery validated: %s/%s at %s", cand.info.namespace, cand.info.name, addr)
+			cand.info.basePath = ""
+			return &cand.info
+		}
+
+		// If candidate has a sub-path (e.g. vmselect), try that too
+		if cand.info.basePath != "" {
+			subAddr := addr + cand.info.basePath
+			if c.tryMetricsEndpointLocked(ctx, subAddr) {
+				log.Printf("[caretta] Dynamic discovery validated: %s/%s at %s (sub-path: %s)",
+					cand.info.namespace, cand.info.name, addr, cand.info.basePath)
+				return &cand.info
+			}
+		}
+	}
+
+	// No candidate was reachable in-cluster (common when running locally).
+	// Return the highest-scored candidate — the caller can establish a port-forward.
+	best := &candidates[0]
+	log.Printf("[caretta] Dynamic discovery: no candidates reachable in-cluster, returning best candidate: %s/%s (score=%d)",
+		best.info.namespace, best.info.name, best.score)
+	return &best.info
+}
+
+// buildClusterAddr builds a cluster-internal address for a service
+func buildClusterAddr(name, namespace, clusterIP string, port int) string {
+	if clusterIP == "None" {
+		return fmt.Sprintf("http://%s-0.%s.%s.svc.cluster.local:%d", name, name, namespace, port)
+	}
+	return fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", name, namespace, port)
 }
 
 // tryMetricsEndpointLocked checks if endpoint is reachable (caller must hold lock)


### PR DESCRIPTION
## Summary

- Replaces the hardcoded 7-entry metrics service lookup with a **3-layer discovery system** that automatically finds Prometheus/VictoriaMetrics in most real-world deployments
- Adds `--prometheus-url` CLI flag (and Helm `traffic.prometheusUrl` value) as a manual escape hatch when auto-discovery can't find the metrics endpoint
- Adds VictoriaMetrics vmselect sub-path support (`/select/0/prometheus`) for cluster-mode deployments

## How it works

**Layer 1 — Manual override:** `--prometheus-url` flag skips all discovery and uses the URL directly. Does NOT fall through to auto-discovery on failure — returns a clear error instead.

**Layer 2 — Well-known locations:** Expanded from 7 to 18 direct service lookups covering VictoriaMetrics (single + cluster), kube-prometheus-stack, and additional namespaces (`victoria-metrics`, `observability`, `metrics`).

**Layer 3 — Dynamic discovery:** Lists all services cluster-wide, scores them by labels, ports, names, and namespace signals, then validates the top 5 candidates via Prometheus API probe (`/api/v1/query?query=up`). Returns the highest-scored candidate even if validation fails (common when running locally — port-forward handles connectivity). Only runs if Layer 2 finds nothing.

Closes #88

## Validated on live EKS cluster

| # | Test | Layer | Result |
|---|------|-------|--------|
| 1 | `caretta-vm` found via well-known locations | Layer 2 | PASS |
| 2 | `test-prom-prometheus-server` in non-standard `test-metrics` ns scored 140, found dynamically | Layer 3 scoring | PASS |
| 3 | Layer 3 candidate + automatic port-forward connection | Layer 3 + port-forward | PASS |
| 4 | `--prometheus-url=http://localhost:19090` used directly (local) | Layer 1 | PASS |
| 5 | Unreachable manual URL returns error, no silent fallthrough | Layer 1 error handling | PASS |
| 6 | Missing URL scheme (`prometheus-server:9090`) rejected at startup | URL validation | PASS |
| 7 | VM cluster vmselect scored 135, discovered dynamically with `basePath="/select/0/prometheus"` | Layer 3 + vmselect sub-path | PASS |
| 8 | vmselect port-forward + sub-path query responds correctly; root path confirmed rejected | vmselect end-to-end | PASS |
| 9 | Helm template renders `--prometheus-url` arg when set; omits it when empty | Helm chart | PASS |
| 10 | In-cluster deployment via Helm with `traffic.prometheusUrl` set — connected successfully | Helm in-cluster | PASS |
| 11 | `go build`, `go vet`, `helm template` | Build | PASS |