### PR TITLE
fix: actionable auth error UX for image inspection

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -29,10 +29,12 @@ const API_BASE = '/api'
 // ApiError preserves HTTP status code for callers to distinguish 403/404/500 etc.
 export class ApiError extends Error {
   status: number
-  constructor(message: string, status: number) {
+  data?: Record<string, unknown>
+  constructor(message: string, status: number, data?: Record<string, unknown>) {
     super(message)
     this.name = 'ApiError'
     this.status = status
+    this.data = data
   }
 }
 
@@ -43,8 +45,8 @@ export function isForbiddenError(error: unknown): boolean {
 async function fetchJSON<T>(path: string): Promise<T> {
   const response = await fetch(`${API_BASE}${path}`)
   if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Unknown error' }))
-    throw new ApiError(error.error || `HTTP ${response.status}`, response.status)
+    const errorData = await response.json().catch(() => ({ error: 'Unknown error' }))
+    throw new ApiError(errorData.error || `HTTP ${response.status}`, response.status, errorData)
   }
   return response.json()
 }


### PR DESCRIPTION
## Summary

- **Backend**: 401 responses from image inspection endpoints now include `registryType` (e.g. `"google"`, `"aws"`, `"generic"`) so the frontend can show registry-specific guidance. Also added auth error detection to `handleGetFile` which previously lacked it.
- **Frontend**: `ApiError` now carries the full error response `data`. The `ImageFilesystemModal` detects 401 errors and replaces the dead-end red error box with an `AuthenticationHelp` component showing the registry hostname, the specific CLI command to authenticate (e.g. `gcloud auth configure-docker`, `aws ecr get-login-password`), a copy button, and a retry button.
- Extracted `getRegistryHost()` as a standalone utility so both `AuthenticationHelp` and `DownloadConfirmation` can use it.

Addresses #103