### PR TITLE
fix: ensure Helm SDK uses writable paths on read-only filesystems

### DIFF
--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -81,12 +81,16 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            - name: home
+              mountPath: /home/nonroot
             {{- if and .Values.persistence.enabled (eq .Values.timeline.storage "sqlite") }}
             - name: data
               mountPath: /data
             {{- end }}
       volumes:
         - name: tmp
+          emptyDir: {}
+        - name: home
           emptyDir: {}
         {{- if and .Values.persistence.enabled (eq .Values.timeline.storage "sqlite") }}
         - name: data


### PR DESCRIPTION
## Summary

When running in containers with `readOnlyRootFilesystem`, the Helm SDK falls back to `$HOME/.cache` for chart downloads, which fails with `mkdir /home/nonroot/.cache: read-only file system`. The env vars set in the deployment template aren't always taking effect.

Two fixes, layered for robustness:

1. **Volume mount**: Mount `/home/nonroot` as a writable emptyDir in the deployment template. This makes all default fallback paths writable (`$HOME/.cache/helm/`, `$HOME/.config/helm/`, `$HOME/.kube/cache/`, etc.) even if the env vars don't take effect. The distroless nonroot image has nothing at this path so shadowing it is safe.

2. **Go-level safety net**: Before initializing the Helm SDK, check if the home directory is writable. If not, default `HELM_CACHE_HOME`/`HELM_CONFIG_HOME`/`HELM_DATA_HOME` to `/tmp/helm/*` and override client-go's discovery cache dir. No-op on local machines since the home dir is writable there.

Between the existing env vars, the volume mount, and the Go fallback — at least one will always work.

Addresses #94