### PR TITLE
fix: eliminate CRD loading waterfall and speed up context switch

### DIFF
--- a/cmd/desktop/main.go
+++ b/cmd/desktop/main.go
@@ -105,7 +105,7 @@ func main() {
 	<-ready
 
 	// Initialize cluster in background (browser will see progress via SSE)
-	go app.InitializeCluster(timelineStoreCfg)
+	go app.InitializeCluster()
 
 	// Build window title
 	windowTitle := "Radar"

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -119,7 +119,7 @@ func main() {
 	}
 
 	// Now initialize cluster connection and caches (browser will see progress via SSE)
-	app.InitializeCluster(timelineStoreCfg)
+	app.InitializeCluster()
 
 	// Block forever (server is running in background)
 	select {}

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -257,8 +257,8 @@ func GetResourceCache() *ResourceCache {
 	return resourceCache
 }
 
-// ResetResourceCache stops and clears the resource cache
-// This must be called before ReinitResourceCache when switching contexts
+// ResetResourceCache stops and clears the resource cache so it can be
+// reinitialized for a new cluster after context switch.
 func ResetResourceCache() {
 	cacheMu.Lock()
 	defer cacheMu.Unlock()
@@ -269,12 +269,6 @@ func ResetResourceCache() {
 	}
 	cacheOnce = sync.Once{}
 	initialSyncComplete = false
-}
-
-// ReinitResourceCache reinitializes the resource cache after a context switch
-// Must call ResetResourceCache first
-func ReinitResourceCache() error {
-	return InitResourceCache()
 }
 
 // addChangeHandlers registers event handlers for change notifications

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -392,6 +392,12 @@ func SwitchContext(name string) error {
 		return fmt.Errorf("failed to build config for context %q: %w", name, err)
 	}
 
+	// Apply the same QPS/Burst settings as initial client creation.
+	// Without this, new clients use the default 5 QPS / 10 Burst, causing
+	// severe client-side throttling during CRD discovery after context switch.
+	config.QPS = 50
+	config.Burst = 100
+
 	// Create new clients
 	newK8sClient, err := kubernetes.NewForConfig(config)
 	if err != nil {

--- a/internal/k8s/discovery.go
+++ b/internal/k8s/discovery.go
@@ -125,20 +125,14 @@ func GetResourceDiscovery() *ResourceDiscovery {
 	return resourceDiscovery
 }
 
-// ResetResourceDiscovery clears the resource discovery instance
-// This must be called before ReinitResourceDiscovery when switching contexts
+// ResetResourceDiscovery clears the resource discovery instance so it can be
+// reinitialized for a new cluster after context switch.
 func ResetResourceDiscovery() {
 	discoveryMu.Lock()
 	defer discoveryMu.Unlock()
 
 	resourceDiscovery = nil
 	discoveryOnce = sync.Once{}
-}
-
-// ReinitResourceDiscovery reinitializes resource discovery after a context switch
-// Must call ResetResourceDiscovery first
-func ReinitResourceDiscovery() error {
-	return InitResourceDiscovery()
 }
 
 // refresh fetches all API resources from the cluster

--- a/internal/k8s/dynamic_cache.go
+++ b/internal/k8s/dynamic_cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -112,8 +113,8 @@ func GetDynamicResourceCache() *DynamicResourceCache {
 	return dynamicResourceCache
 }
 
-// ResetDynamicResourceCache stops and clears the dynamic resource cache
-// This must be called before ReinitDynamicResourceCache when switching contexts
+// ResetDynamicResourceCache stops and clears the dynamic resource cache so it
+// can be reinitialized for a new cluster after context switch.
 func ResetDynamicResourceCache() {
 	dynamicCacheMu.Lock()
 	defer dynamicCacheMu.Unlock()
@@ -123,12 +124,6 @@ func ResetDynamicResourceCache() {
 		dynamicResourceCache = nil
 	}
 	dynamicCacheOnce = sync.Once{}
-}
-
-// ReinitDynamicResourceCache reinitializes the dynamic cache after a context switch
-// Must call ResetDynamicResourceCache first
-func ReinitDynamicResourceCache(changeCh chan ResourceChange) error {
-	return InitDynamicResourceCache(changeCh)
 }
 
 // EnsureWatching starts watching a resource type if not already watching
@@ -153,16 +148,16 @@ func (d *DynamicResourceCache) EnsureWatching(gvr schema.GroupVersionResource) e
 		return nil
 	}
 
-	// If CRD discovery is in progress, wait for warmup to finish instead of
-	// probing independently. WarmupParallel() probes all CRDs efficiently
+	// If CRD discovery is in progress, wait for it to finish instead of
+	// probing independently. DiscoverAllCRDs() probes all CRDs efficiently
 	// in parallel — individual probes here would compete for the same QPS
-	// budget and create a convoy effect on clusters with many CRDs.
-	// The discoveryDone channel is closed when DiscoverAllCRDs() completes
-	// or when Stop() is called.
+	// budget and cause throttling contention on clusters with many CRDs.
+	// The discoveryDone channel is closed when DiscoverAllCRDs() completes,
+	// when Stop() is called, or if the discovery goroutine panics.
 	if d.GetDiscoveryStatus() == CRDDiscoveryInProgress {
 		select {
 		case <-d.discoveryDone:
-		case <-time.After(35 * time.Second):
+		case <-time.After(45 * time.Second): // covers API resource fetch + parallel probes + 30s sync timeout
 			log.Printf("[dynamic cache] Timeout waiting for CRD discovery, probing %s independently", gvr.Resource)
 		}
 
@@ -645,13 +640,24 @@ func (d *DynamicResourceCache) DiscoverAllCRDs() {
 	// Run discovery in background
 	go func() {
 		defer func() {
+			panicked := false
+			if r := recover(); r != nil {
+				panicked = true
+				buf := make([]byte, 4096)
+				n := runtime.Stack(buf, false)
+				log.Printf("PANIC in CRD discovery goroutine: %v\n%s", r, buf[:n])
+			}
 			d.discoveryMu.Lock()
 			if d.discoveryStatus != CRDDiscoveryComplete {
 				d.discoveryStatus = CRDDiscoveryComplete
 				close(d.discoveryDone)
 			}
 			d.discoveryMu.Unlock()
-			log.Println("[CRD Discovery] CRD discovery complete")
+			if panicked {
+				log.Println("[CRD Discovery] CRD discovery terminated due to panic (marked complete to unblock waiters)")
+			} else {
+				log.Println("[CRD Discovery] CRD discovery complete")
+			}
 
 			// Notify callbacks to trigger topology update
 			notifyCRDDiscoveryComplete()

--- a/internal/k8s/subsystems.go
+++ b/internal/k8s/subsystems.go
@@ -1,0 +1,159 @@
+package k8s
+
+import (
+	"fmt"
+	"log"
+	"runtime"
+)
+
+// InitAllSubsystems initializes all subsystems in the correct order.
+// Used for both initial boot and after context switch.
+//
+// Returns an error if a critical subsystem (resource cache) fails to
+// initialize. All other subsystems log warnings and continue in degraded mode.
+//
+// External subsystem callbacks (timeline, helm, traffic) must be registered
+// via the Register*Funcs methods before calling this function.
+//
+// The progress callback receives human-readable status messages suitable for
+// display in the UI (e.g. via SSE connection status updates).
+func InitAllSubsystems(progress func(string)) error {
+	// 1. Timeline — before caches so events during warmup are captured
+	contextSwitchMu.RLock()
+	tlReinitFn := timelineReinitFunc
+	contextSwitchMu.RUnlock()
+	if tlReinitFn != nil {
+		progress("Initializing timeline...")
+		if err := tlReinitFn(); err != nil {
+			log.Printf("Warning: timeline init failed: %v", err)
+		}
+	}
+
+	// 2. Resource cache (typed informers) — critical, everything depends on this
+	progress("Loading workloads...")
+	if err := InitResourceCache(); err != nil {
+		return fmt.Errorf("resource cache init failed: %w", err)
+	}
+	if cache := GetResourceCache(); cache != nil {
+		log.Printf("Resource cache initialized with %d resources", cache.GetResourceCount())
+	}
+
+	// 3. API resource discovery
+	progress("Discovering API resources...")
+	if err := InitResourceDiscovery(); err != nil {
+		log.Printf("Warning: resource discovery init failed: %v", err)
+	}
+
+	// 4. Dynamic cache (factory init is synchronous; CRD warmup and discovery kick off async)
+	progress("Loading custom resources...")
+	if cache := GetResourceCache(); cache != nil {
+		changeCh := cache.ChangesRaw()
+		if err := InitDynamicResourceCache(changeCh); err != nil {
+			log.Printf("Warning: dynamic resource cache init failed: %v", err)
+		}
+
+		// CRD warmup and full discovery run in background.
+		// Common CRDs appear in topology quickly as they sync;
+		// remaining CRDs appear as DiscoverAllCRDs completes.
+		if dc := GetDynamicResourceCache(); dc != nil {
+			go func() {
+				// Warmup runs in its own recover so a panic there
+				// doesn't prevent full CRD discovery from running.
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							buf := make([]byte, 4096)
+							n := runtime.Stack(buf, false)
+							log.Printf("PANIC in CRD warmup: %v\n%s", r, buf[:n])
+						}
+					}()
+					WarmupCommonCRDs()
+				}()
+				dc.DiscoverAllCRDs()
+			}()
+		}
+	}
+
+	// 5. Metrics history
+	InitMetricsHistory()
+
+	// 6. Helm
+	contextSwitchMu.RLock()
+	hReinitFn := helmReinitFunc
+	contextSwitchMu.RUnlock()
+	if hReinitFn != nil {
+		progress("Loading Helm releases...")
+		if err := hReinitFn(GetKubeconfigPath()); err != nil {
+			log.Printf("Warning: Helm init failed: %v", err)
+		}
+	}
+
+	// 7. Traffic
+	contextSwitchMu.RLock()
+	trReinitFn := trafficReinitFunc
+	contextSwitchMu.RUnlock()
+	if trReinitFn != nil {
+		progress("Initializing traffic analysis...")
+		if err := trReinitFn(); err != nil {
+			log.Printf("Warning: traffic init failed: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// ResetAllSubsystems tears down all subsystems in reverse order of init.
+// Safe to call on first boot when singletons are nil.
+// Each reset is wrapped in a panic recover so a failure in one subsystem
+// does not prevent remaining subsystems from being torn down.
+func ResetAllSubsystems() {
+	// 7. Traffic
+	contextSwitchMu.RLock()
+	trResetFn := trafficResetFunc
+	contextSwitchMu.RUnlock()
+	if trResetFn != nil {
+		safeReset("traffic", trResetFn)
+	}
+
+	// 6. Helm
+	contextSwitchMu.RLock()
+	hResetFn := helmResetFunc
+	contextSwitchMu.RUnlock()
+	if hResetFn != nil {
+		safeReset("Helm", hResetFn)
+	}
+
+	// 5. Metrics history
+	safeReset("metrics history", ResetMetricsHistory)
+
+	// 4. Dynamic cache
+	safeReset("dynamic resource cache", ResetDynamicResourceCache)
+
+	// 3. Resource discovery
+	safeReset("resource discovery", ResetResourceDiscovery)
+
+	// 2. Resource cache
+	safeReset("resource cache", ResetResourceCache)
+
+	// 1. Timeline
+	contextSwitchMu.RLock()
+	tlResetFn := timelineResetFunc
+	contextSwitchMu.RUnlock()
+	if tlResetFn != nil {
+		safeReset("timeline", tlResetFn)
+	}
+}
+
+// safeReset calls fn inside a deferred recover so a panic in one subsystem's
+// teardown does not prevent the remaining subsystems from being reset.
+func safeReset(name string, fn func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			buf := make([]byte, 4096)
+			n := runtime.Stack(buf, false)
+			log.Printf("PANIC in %s reset: %v\n%s", name, r, buf[:n])
+		}
+	}()
+	log.Printf("Stopping %s...", name)
+	fn()
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -253,6 +253,10 @@ function AppInner() {
       // removeQueries clears cached data, invalidateQueries triggers refetch
       queryClient.removeQueries()
       queryClient.invalidateQueries()
+
+      // Reset URL to current view with no resource-specific params.
+      // Old cluster's selected pod/resource/kind don't exist on the new cluster.
+      navigate({ pathname: location.pathname, search: '' }, { replace: true })
     },
     onConnectionStateChange: updateConnectionFromSSE,
   })


### PR DESCRIPTION
## Summary

- **Unify cluster initialization**: `InitializeCluster` (boot) and `PerformContextSwitch` had duplicated init sequences that silently diverged — context switch was missing `DiscoverAllCRDs()`, `InitMetricsHistory()`, and had timeline init in the wrong order. Extracted `InitAllSubsystems()` / `ResetAllSubsystems()` so both paths use the same sequence.

- **Fix QPS/Burst after context switch**: `SwitchContext` created new K8s clients without applying the 50 QPS / 100 Burst settings. Post-switch clients used the default 5/10, causing severe client-side throttling during CRD discovery (~19s of background churn reduced to ~5s).

- **Move CRD warmup to background**: `WarmupCommonCRDs()` was blocking the switch critical path for ~1s. Now runs async — common CRDs appear within ~1s as they sync, but don't delay the switch completion.

- **Clear URL on context switch**: Stale resource selections (e.g. `?kind=Pod&resource=demo/some-pod`) from the old cluster no longer persist after switching.

## Key changes

| File | Change |
|------|--------|
| `internal/k8s/subsystems.go` | New — `InitAllSubsystems()` and `ResetAllSubsystems()` |
| `internal/k8s/context_manager.go` | `PerformContextSwitch` uses unified functions (~110 lines removed) |
| `internal/app/bootstrap.go` | `InitializeCluster` uses unified functions (~60 lines removed) |
| `internal/k8s/client.go` | Apply QPS/Burst to switched client configs |
| `web/src/App.tsx` | Clear URL params on `onContextChanged` |