### PR TITLE
fix: resolve ArgoCD Application CRD collision with app.k8s.io

### DIFF
--- a/internal/k8s/discovery_test.go
+++ b/internal/k8s/discovery_test.go
@@ -1,0 +1,76 @@
+package k8s
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestIsMoreStableVersion(t *testing.T) {
+	tests := []struct {
+		newVer string
+		oldVer string
+		want   bool
+	}{
+		{"v1", "v1alpha1", true},
+		{"v1", "v1beta1", true},
+		{"v1beta1", "v1alpha1", true},
+		{"v1alpha1", "v1beta1", false},
+		{"v1beta1", "v1", false},
+		{"v2", "v1", true},
+		{"v1", "v2", false},
+		{"v1beta2", "v1beta1", true},
+		{"v1beta1", "v1beta2", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.newVer+"_vs_"+tt.oldVer, func(t *testing.T) {
+			got := isMoreStableVersion(tt.newVer, tt.oldVer)
+			if got != tt.want {
+				t.Errorf("isMoreStableVersion(%q, %q) = %v, want %v", tt.newVer, tt.oldVer, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetGVRWithGroup_DisambiguatesSameKind(t *testing.T) {
+	// Simulate two CRDs with the same Kind but different groups:
+	// - argoproj.io/v1alpha1 Application
+	// - app.k8s.io/v1beta1 Application
+	d := &ResourceDiscovery{
+		resourceMap: make(map[string]APIResource),
+		gvrMap:      make(map[string]schema.GroupVersionResource),
+		resources: []APIResource{
+			{Group: "argoproj.io", Version: "v1alpha1", Kind: "Application", Name: "applications", Namespaced: true, IsCRD: true},
+			{Group: "app.k8s.io", Version: "v1beta1", Kind: "Application", Name: "applications", Namespaced: true, IsCRD: true},
+		},
+	}
+
+	// GetGVRWithGroup should return the correct group regardless of map contents
+	gvr, ok := d.GetGVRWithGroup("Application", "argoproj.io")
+	if !ok {
+		t.Fatal("expected to find Application in argoproj.io")
+	}
+	if gvr.Group != "argoproj.io" {
+		t.Errorf("expected group argoproj.io, got %s", gvr.Group)
+	}
+	if gvr.Version != "v1alpha1" {
+		t.Errorf("expected version v1alpha1, got %s", gvr.Version)
+	}
+
+	gvr, ok = d.GetGVRWithGroup("Application", "app.k8s.io")
+	if !ok {
+		t.Fatal("expected to find Application in app.k8s.io")
+	}
+	if gvr.Group != "app.k8s.io" {
+		t.Errorf("expected group app.k8s.io, got %s", gvr.Group)
+	}
+	if gvr.Version != "v1beta1" {
+		t.Errorf("expected version v1beta1, got %s", gvr.Version)
+	}
+
+	// Non-existent group should return false
+	_, ok = d.GetGVRWithGroup("Application", "nonexistent.io")
+	if ok {
+		t.Error("expected not to find Application in nonexistent.io")
+	}
+}

--- a/internal/k8s/dynamic_cache.go
+++ b/internal/k8s/dynamic_cache.go
@@ -846,7 +846,6 @@ func WarmupCommonCRDs() {
 		"Kustomization",  // FluxCD kustomize
 		"HelmRelease",    // FluxCD helm
 		"Alert",          // FluxCD notification
-		"Application",    // ArgoCD
 		"ApplicationSet", // ArgoCD
 		"AppProject",     // ArgoCD
 		"Gateway",        // Gateway API
@@ -862,6 +861,13 @@ func WarmupCommonCRDs() {
 			gvrs = append(gvrs, gvr)
 			log.Printf("Warming up CRD: %s", kind)
 		}
+	}
+
+	// ArgoCD Application needs group-qualified lookup to avoid collision with
+	// the Kubernetes SIG Application CRD (app.k8s.io), which shares the same Kind name.
+	if gvr, ok := discovery.GetGVRWithGroup("Application", "argoproj.io"); ok {
+		gvrs = append(gvrs, gvr)
+		log.Printf("Warming up CRD: Application (argoproj.io)")
 	}
 
 	if len(gvrs) > 0 {

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -1389,7 +1389,7 @@ func (s *Server) getDashboardCRDCounts(_ context.Context, namespace string) []Da
 		go func(idx int, r k8s.APIResource) {
 			defer wg.Done()
 
-			gvr, ok := discovery.GetGVR(r.Kind)
+			gvr, ok := discovery.GetGVRWithGroup(r.Kind, r.Group)
 			if !ok {
 				return
 			}

--- a/internal/topology/builder.go
+++ b/internal/topology/builder.go
@@ -377,7 +377,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	var applicationGVR schema.GroupVersionResource
 	hasApplications := false
 	if resourceDiscovery != nil {
-		applicationGVR, hasApplications = resourceDiscovery.GetGVR("Application")
+		applicationGVR, hasApplications = resourceDiscovery.GetGVRWithGroup("Application", "argoproj.io")
 	}
 	applicationIDs := make(map[string]string)                          // ns/name -> applicationID
 	var applicationResources []*unstructured.Unstructured              // Store for second pass


### PR DESCRIPTION
## Summary

Fixes #122 — ArgoCD Application resources not showing in the UI while ApplicationSet works fine.

**Root cause:** Both ArgoCD (`argoproj.io/v1alpha1`) and Kubernetes SIG (`app.k8s.io/v1beta1`) define a CRD with Kind `Application`. The resource discovery map is keyed by lowercase kind, so only one can be stored. Whichever is discovered first wins, making the other invisible across topology, resource listing, warmup, and dashboard counts.

**Fix:** Use group-qualified lookups (`GetGVRWithGroup`) in all code paths that need ArgoCD Applications:
- Topology builder — resolves correct GVR for ArgoCD Application nodes
- CRD warmup — ensures the ArgoCD Application informer starts at boot
- Resource listing API — reads the `group` query parameter the frontend already sends
- Dashboard CRD counts — uses group from the iterated resource instead of ambiguous kind lookup

Also adds `ListDynamicWithGroup` to mirror the existing `GetDynamicWithGroup` pattern, and a test validating the disambiguation logic.