### PR TITLE
fix: prefer source repo when checking for Helm chart upgrades

### DIFF
--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -786,9 +786,8 @@ func (c *Client) CheckForUpgrade(namespace, name string) (*UpgradeInfo, error) {
 		return info, nil
 	}
 
-	// Search through all repo indexes
-	var latestVersion string
-	var repoName string
+	// Search through all repo indexes, tracking which repos contain the current version
+	var candidates []repoVersionInfo
 	cacheDir := c.settings.RepositoryCache
 
 	for _, r := range f.Repositories {
@@ -802,15 +801,27 @@ func (c *Client) CheckForUpgrade(namespace, name string) (*UpgradeInfo, error) {
 
 		// Look for the chart
 		if versions, ok := indexFile.Entries[chartName]; ok {
+			var latestInRepo string
+			hasCurrentVersion := false
 			for _, v := range versions {
-				if latestVersion == "" || compareVersions(v.Version, latestVersion) > 0 {
-					latestVersion = v.Version
-					repoName = r.Name
+				if latestInRepo == "" || compareVersions(v.Version, latestInRepo) > 0 {
+					latestInRepo = v.Version
 				}
+				if v.Version == currentVersion {
+					hasCurrentVersion = true
+				}
+			}
+			if latestInRepo != "" {
+				candidates = append(candidates, repoVersionInfo{
+					repoName:          r.Name,
+					latestVersion:     latestInRepo,
+					hasCurrentVersion: hasCurrentVersion,
+				})
 			}
 		}
 	}
 
+	latestVersion, repoName := findBestUpgradeVersion(candidates)
 	if latestVersion == "" {
 		info.Error = "chart not found in configured repositories"
 		return info, nil
@@ -821,6 +832,39 @@ func (c *Client) CheckForUpgrade(namespace, name string) (*UpgradeInfo, error) {
 	info.UpdateAvailable = compareVersions(latestVersion, currentVersion) > 0
 
 	return info, nil
+}
+
+// repoVersionInfo holds version information from a single repository for upgrade comparison.
+type repoVersionInfo struct {
+	repoName          string
+	latestVersion     string
+	hasCurrentVersion bool
+}
+
+// findBestUpgradeVersion picks the best upgrade version for a chart.
+// It prefers repos that contain the currently installed version (source repo heuristic),
+// which avoids suggesting upgrades from unrelated charts that share the same name.
+func findBestUpgradeVersion(candidates []repoVersionInfo) (latestVersion, repoName string) {
+	// First: try repos that have the current version (likely the source repo)
+	for _, c := range candidates {
+		if c.hasCurrentVersion {
+			if latestVersion == "" || compareVersions(c.latestVersion, latestVersion) > 0 {
+				latestVersion = c.latestVersion
+				repoName = c.repoName
+			}
+		}
+	}
+	if latestVersion != "" {
+		return
+	}
+	// Fallback: pick highest across all repos (stale index case)
+	for _, c := range candidates {
+		if latestVersion == "" || compareVersions(c.latestVersion, latestVersion) > 0 {
+			latestVersion = c.latestVersion
+			repoName = c.repoName
+		}
+	}
+	return
 }
 
 // compareVersions compares two semver strings
@@ -1023,11 +1067,10 @@ func (c *Client) BatchCheckUpgrades(namespace string) (*BatchUpgradeInfo, error)
 		return result, nil
 	}
 
-	// Build a map of chart name -> latest version info from all repos
-	chartLatestVersions := make(map[string]struct {
-		version  string
-		repoName string
-	})
+	// Build a map of chart name -> per-repo version info (including all versions for source detection)
+	chartRepoVersions := make(map[string][]repoVersionInfo)
+	// Also track all available versions per chart per repo, for current-version matching
+	chartAllVersions := make(map[string]map[string][]string) // chartName -> repoName -> []versions
 
 	cacheDir := c.settings.RepositoryCache
 	for _, r := range f.Repositories {
@@ -1041,21 +1084,23 @@ func (c *Client) BatchCheckUpgrades(namespace string) (*BatchUpgradeInfo, error)
 			if len(versions) == 0 {
 				continue
 			}
-			// versions[0] is typically the latest
 			latestInRepo := versions[0].Version
+			var allVersions []string
 			for _, v := range versions {
+				allVersions = append(allVersions, v.Version)
 				if compareVersions(v.Version, latestInRepo) > 0 {
 					latestInRepo = v.Version
 				}
 			}
 
-			existing, exists := chartLatestVersions[chartName]
-			if !exists || compareVersions(latestInRepo, existing.version) > 0 {
-				chartLatestVersions[chartName] = struct {
-					version  string
-					repoName string
-				}{latestInRepo, r.Name}
+			chartRepoVersions[chartName] = append(chartRepoVersions[chartName], repoVersionInfo{
+				repoName:      r.Name,
+				latestVersion: latestInRepo,
+			})
+			if chartAllVersions[chartName] == nil {
+				chartAllVersions[chartName] = make(map[string][]string)
 			}
+			chartAllVersions[chartName][r.Name] = allVersions
 		}
 	}
 
@@ -1066,10 +1111,22 @@ func (c *Client) BatchCheckUpgrades(namespace string) (*BatchUpgradeInfo, error)
 			CurrentVersion: rel.ChartVersion,
 		}
 
-		if latest, ok := chartLatestVersions[rel.Chart]; ok {
-			info.LatestVersion = latest.version
-			info.RepositoryName = latest.repoName
-			info.UpdateAvailable = compareVersions(latest.version, rel.ChartVersion) > 0
+		if candidates, ok := chartRepoVersions[rel.Chart]; ok {
+			// Mark which repos contain the current version
+			for i := range candidates {
+				if repoVersions, ok := chartAllVersions[rel.Chart][candidates[i].repoName]; ok {
+					for _, v := range repoVersions {
+						if v == rel.ChartVersion {
+							candidates[i].hasCurrentVersion = true
+							break
+						}
+					}
+				}
+			}
+			latestVersion, repoName := findBestUpgradeVersion(candidates)
+			info.LatestVersion = latestVersion
+			info.RepositoryName = repoName
+			info.UpdateAvailable = compareVersions(latestVersion, rel.ChartVersion) > 0
 		} else {
 			info.Error = "chart not found in configured repositories"
 		}

--- a/internal/helm/client_test.go
+++ b/internal/helm/client_test.go
@@ -1,0 +1,98 @@
+package helm
+
+import "testing"
+
+func TestFindBestUpgradeVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		candidates      []repoVersionInfo
+		wantVersion     string
+		wantRepo        string
+	}{
+		{
+			name:        "no candidates returns empty",
+			candidates:  nil,
+			wantVersion: "",
+			wantRepo:    "",
+		},
+		{
+			name: "single repo with current version",
+			candidates: []repoVersionInfo{
+				{repoName: "metallb", latestVersion: "0.15.3", hasCurrentVersion: true},
+			},
+			wantVersion: "0.15.3",
+			wantRepo:    "metallb",
+		},
+		{
+			name: "multiple repos only one has current version - picks source repo",
+			candidates: []repoVersionInfo{
+				{repoName: "bitnami", latestVersion: "6.4.22", hasCurrentVersion: false},
+				{repoName: "metallb", latestVersion: "0.15.3", hasCurrentVersion: true},
+			},
+			wantVersion: "0.15.3",
+			wantRepo:    "metallb",
+		},
+		{
+			name: "multiple repos none has current version - falls back to highest",
+			candidates: []repoVersionInfo{
+				{repoName: "bitnami", latestVersion: "6.4.22", hasCurrentVersion: false},
+				{repoName: "metallb", latestVersion: "0.15.3", hasCurrentVersion: false},
+			},
+			wantVersion: "6.4.22",
+			wantRepo:    "bitnami",
+		},
+		{
+			name: "multiple repos both have current version - picks highest among them",
+			candidates: []repoVersionInfo{
+				{repoName: "repo-a", latestVersion: "2.0.0", hasCurrentVersion: true},
+				{repoName: "repo-b", latestVersion: "3.0.0", hasCurrentVersion: true},
+			},
+			wantVersion: "3.0.0",
+			wantRepo:    "repo-b",
+		},
+		{
+			name: "source repo has lower latest than non-source - still picks source",
+			candidates: []repoVersionInfo{
+				{repoName: "community", latestVersion: "10.0.0", hasCurrentVersion: false},
+				{repoName: "official", latestVersion: "1.2.0", hasCurrentVersion: true},
+			},
+			wantVersion: "1.2.0",
+			wantRepo:    "official",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotVersion, gotRepo := findBestUpgradeVersion(tt.candidates)
+			if gotVersion != tt.wantVersion {
+				t.Errorf("findBestUpgradeVersion() version = %q, want %q", gotVersion, tt.wantVersion)
+			}
+			if gotRepo != tt.wantRepo {
+				t.Errorf("findBestUpgradeVersion() repo = %q, want %q", gotRepo, tt.wantRepo)
+			}
+		})
+	}
+}
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		v1, v2 string
+		want   int
+	}{
+		{"1.0.0", "1.0.0", 0},
+		{"2.0.0", "1.0.0", 1},
+		{"1.0.0", "2.0.0", -1},
+		{"0.15.3", "6.4.22", -1},
+		{"6.4.22", "0.15.3", 1},
+		{"v1.0.0", "1.0.0", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.v1+"_vs_"+tt.v2, func(t *testing.T) {
+			got := compareVersions(tt.v1, tt.v2)
+			if got != tt.want {
+				t.Errorf("compareVersions(%q, %q) = %d, want %d", tt.v1, tt.v2, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- When multiple repos have a chart with the same name (e.g. `metallb` in both the official metallb repo and bitnami), the upgrade check picked the highest version globally — suggesting upgrading metallb 0.14.8 to bitnami's 6.4.22 instead of the correct 0.15.3
- Now identifies the source repo by checking which repos contain the currently installed version, and only suggests upgrades from that repo
- Falls back to the previous behavior (highest across all repos) if no repo contains the current version (stale index)

## Test plan

- [x] Unit tests for `findBestUpgradeVersion` covering: single source repo, multiple repos with only one source, no source repo fallback, tie-breaking
- [x] Unit tests for `compareVersions`
- [x] Verified bug reproduces with old code (picks bitnami 6.4.22)
- [x] Verified fix works with real metallb + bitnami repo indexes (picks metallb 0.15.3)
- [x] `go build ./...` and `go test ./internal/helm/...` pass

Fixes #128