### PR TITLE
fix: use theme-aware colors in port forward and dock components

### DIFF
--- a/web/src/components/dock/BottomDock.tsx
+++ b/web/src/components/dock/BottomDock.tsx
@@ -56,7 +56,7 @@ export function BottomDock() {
 
   return (
     <div
-      className="fixed bottom-0 left-0 right-0 bg-slate-900 border-t border-slate-700 flex flex-col z-40"
+      className="fixed bottom-0 left-0 right-0 bg-theme-base border-t border-theme-border flex flex-col z-40"
       style={{ height: isExpanded ? height : 36 }}
     >
       {/* Resize handle */}
@@ -68,7 +68,7 @@ export function BottomDock() {
       )}
 
       {/* Tab bar */}
-      <div className="flex items-center h-9 px-2 bg-slate-800 border-b border-slate-700">
+      <div className="flex items-center h-9 px-2 bg-theme-surface border-b border-theme-border">
         <div className="flex items-center gap-1 flex-1 overflow-x-auto">
           {tabs.map(tab => (
             <TabButton
@@ -88,7 +88,7 @@ export function BottomDock() {
           {tabs.length > 1 && (
             <button
               onClick={closeAll}
-              className="p-1 text-slate-400 hover:text-white hover:bg-slate-700 rounded"
+              className="p-1 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
               title="Close all"
             >
               <Trash2 className="w-3.5 h-3.5" />
@@ -96,7 +96,7 @@ export function BottomDock() {
           )}
           <button
             onClick={toggleExpanded}
-            className="p-1 text-slate-400 hover:text-white hover:bg-slate-700 rounded"
+            className="p-1 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
             title={isExpanded ? 'Collapse' : 'Expand'}
           >
             {isExpanded ? (
@@ -143,8 +143,8 @@ function TabButton({
       className={clsx(
         'flex items-center gap-1.5 px-2 py-1 rounded text-xs cursor-pointer group',
         isActive
-          ? 'bg-slate-700 text-white'
-          : 'text-slate-400 hover:text-white hover:bg-slate-700/50'
+          ? 'bg-theme-elevated text-theme-text-primary'
+          : 'text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-elevated/50'
       )}
       onClick={onSelect}
     >
@@ -155,7 +155,7 @@ function TabButton({
           e.stopPropagation()
           onClose()
         }}
-        className="p-0.5 rounded opacity-0 group-hover:opacity-100 hover:bg-slate-600"
+        className="p-0.5 rounded opacity-0 group-hover:opacity-100 hover:bg-theme-hover"
       >
         <X className="w-3 h-3" />
       </button>

--- a/web/src/components/dock/TerminalTab.tsx
+++ b/web/src/components/dock/TerminalTab.tsx
@@ -267,9 +267,9 @@ export function TerminalTab({
   }, [isActive])
 
   return (
-    <div className="relative h-full w-full bg-slate-900 overflow-hidden">
+    <div className="relative h-full w-full bg-theme-base overflow-hidden">
       {/* Mini toolbar */}
-      <div className="h-8 flex items-center gap-2 px-2 bg-slate-800/50 border-b border-slate-700/50">
+      <div className="h-8 flex items-center gap-2 px-2 bg-theme-surface/50 border-b border-theme-border/50">
         <Tooltip
           content={isConnected ? 'Connected to pod' : isConnecting ? 'Connecting...' : 'Disconnected - click Reconnect'}
           position="bottom"
@@ -281,7 +281,7 @@ export function TerminalTab({
             )}
           />
         </Tooltip>
-        <span className="text-xs text-slate-400">
+        <span className="text-xs text-theme-text-tertiary">
           {podName}
         </span>
 
@@ -290,7 +290,7 @@ export function TerminalTab({
             <select
               value={selectedContainer}
               onChange={(e) => handleContainerChange(e.target.value)}
-              className="appearance-none bg-slate-700 text-xs text-white px-2 py-0.5 pr-5 rounded border border-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              className="appearance-none bg-theme-elevated text-xs text-theme-text-primary px-2 py-0.5 pr-5 rounded border border-theme-border-light focus:outline-none focus:ring-1 focus:ring-blue-500"
             >
               {containers.map((c) => (
                 <option key={c} value={c}>
@@ -298,14 +298,14 @@ export function TerminalTab({
                 </option>
               ))}
             </select>
-            <ChevronDown className="absolute right-1 top-1/2 -translate-y-1/2 w-3 h-3 text-slate-400 pointer-events-none" />
+            <ChevronDown className="absolute right-1 top-1/2 -translate-y-1/2 w-3 h-3 text-theme-text-tertiary pointer-events-none" />
           </div>
         )}
 
         {!isConnected && !isConnecting && (
           <button
             onClick={connect}
-            className="flex items-center gap-1 px-2 py-0.5 text-xs text-slate-400 hover:text-white hover:bg-slate-700 rounded"
+            className="flex items-center gap-1 px-2 py-0.5 text-xs text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
           >
             <RefreshCw className="w-3 h-3" />
             Reconnect
@@ -319,7 +319,7 @@ export function TerminalTab({
           {errorType === 'shell_not_found' ? (
             <>
               <div className="text-amber-400 mb-2 text-sm">Shell not available</div>
-              <div className="text-xs text-slate-400 mb-4 max-w-md">
+              <div className="text-xs text-theme-text-tertiary mb-4 max-w-md">
                 This container doesn't have a shell (/bin/sh). This is common with distroless
                 or minimal container images. You can create a debug container to troubleshoot.
               </div>
@@ -343,7 +343,7 @@ export function TerminalTab({
                 </button>
                 <button
                   onClick={connect}
-                  className="flex items-center gap-2 px-3 py-1.5 bg-slate-700 text-white text-xs rounded hover:bg-slate-600"
+                  className="flex items-center gap-2 px-3 py-1.5 bg-theme-elevated text-theme-text-primary text-xs rounded hover:bg-theme-hover"
                 >
                   <RefreshCw className="w-3 h-3" />
                   Retry
@@ -353,7 +353,7 @@ export function TerminalTab({
           ) : (
             <>
               <div className="text-red-400 mb-2 text-sm">Failed to connect</div>
-              <div className="text-xs text-slate-500 mb-3">{error}</div>
+              <div className="text-xs text-theme-text-disabled mb-3">{error}</div>
               <button
                 onClick={connect}
                 className="flex items-center gap-2 px-3 py-1.5 bg-blue-600 text-white text-xs rounded hover:bg-blue-700"

--- a/web/src/components/portforward/PortForwardButton.tsx
+++ b/web/src/components/portforward/PortForwardButton.tsx
@@ -188,7 +188,7 @@ export function PortForwardButton({
         <button
           disabled
           className={clsx(
-            'flex items-center gap-2 px-3 py-2 bg-slate-700 text-white text-sm rounded-lg opacity-50 cursor-not-allowed',
+            'flex items-center gap-2 px-3 py-2 bg-theme-elevated text-theme-text-primary text-sm rounded-lg opacity-50 cursor-not-allowed',
             className
           )}
           title="No ports available"
@@ -206,7 +206,7 @@ export function PortForwardButton({
           onClick={() => handlePortSelect(ports[0])}
           disabled={isPending}
           className={clsx(
-            'flex items-center gap-2 px-3 py-2 bg-slate-700 text-white text-sm rounded-lg hover:bg-slate-600 transition-colors disabled:opacity-50',
+            'flex items-center gap-2 px-3 py-2 bg-theme-elevated text-theme-text-primary text-sm rounded-lg hover:bg-theme-hover transition-colors disabled:opacity-50',
             className
           )}
           title={`Port forward to ${ports[0].port}`}
@@ -228,7 +228,7 @@ export function PortForwardButton({
           onClick={() => setIsOpen(!isOpen)}
           disabled={isLoading || isPending}
           className={clsx(
-            'flex items-center gap-2 px-3 py-2 bg-slate-700 text-white text-sm rounded-lg hover:bg-slate-600 transition-colors disabled:opacity-50',
+            'flex items-center gap-2 px-3 py-2 bg-theme-elevated text-theme-text-primary text-sm rounded-lg hover:bg-theme-hover transition-colors disabled:opacity-50',
             className
           )}
         >
@@ -242,11 +242,11 @@ export function PortForwardButton({
         </button>
 
         {isOpen && (
-          <div className="absolute top-full left-0 mt-1 w-64 bg-slate-800 border border-slate-700 rounded-lg shadow-xl z-50 py-1">
+          <div className="absolute top-full left-0 mt-1 w-64 bg-theme-surface border border-theme-border rounded-lg shadow-xl z-50 py-1">
             {/* Listen address toggle - only for local mode */}
             {!inCluster && (
-              <div className="px-3 py-2 border-b border-slate-700">
-                <div className="text-xs text-slate-500 mb-2">Listen on</div>
+              <div className="px-3 py-2 border-b border-theme-border">
+                <div className="text-xs text-theme-text-disabled mb-2">Listen on</div>
                 <div className="flex gap-1">
                   <button
                     onClick={(e) => { e.stopPropagation(); setListenAddress('127.0.0.1') }}
@@ -254,7 +254,7 @@ export function PortForwardButton({
                       'flex-1 flex items-center justify-center gap-1.5 px-2 py-1.5 text-xs rounded transition-colors',
                       listenAddress === '127.0.0.1'
                         ? 'bg-blue-600 text-white'
-                        : 'bg-slate-700 text-slate-400 hover:text-slate-200'
+                        : 'bg-theme-elevated text-theme-text-tertiary hover:text-theme-text-primary'
                     )}
                     title="Only accessible from this machine"
                   >
@@ -267,7 +267,7 @@ export function PortForwardButton({
                       'flex-1 flex items-center justify-center gap-1.5 px-2 py-1.5 text-xs rounded transition-colors',
                       listenAddress === '0.0.0.0'
                         ? 'bg-amber-600 text-white'
-                        : 'bg-slate-700 text-slate-400 hover:text-slate-200'
+                        : 'bg-theme-elevated text-theme-text-tertiary hover:text-theme-text-primary'
                     )}
                     title="Accessible from other machines on the network"
                   >
@@ -277,22 +277,22 @@ export function PortForwardButton({
                 </div>
               </div>
             )}
-            <div className="px-2 py-1.5 text-xs text-slate-500 border-b border-slate-700">
+            <div className="px-2 py-1.5 text-xs text-theme-text-disabled border-b border-theme-border">
               Select port to forward
             </div>
             {ports.map((port, i) => (
               <button
                 key={i}
                 onClick={() => handlePortSelect(port)}
-                className="w-full px-3 py-2 text-left text-sm text-slate-200 hover:bg-slate-700 flex items-center justify-between"
+                className="w-full px-3 py-2 text-left text-sm text-theme-text-primary hover:bg-theme-elevated flex items-center justify-between"
               >
                 <span className="flex items-center gap-2">
-                  <code className="text-blue-400">{port.port}</code>
-                  <span className="text-slate-500">/{port.protocol || 'TCP'}</span>
+                  <code className="text-accent-text">{port.port}</code>
+                  <span className="text-theme-text-disabled">/{port.protocol || 'TCP'}</span>
                 </span>
-                <span className="text-xs text-slate-500">
+                <span className="text-xs text-theme-text-disabled">
                   {port.name && <span className="mr-2">{port.name}</span>}
-                  {port.containerName && <span className="text-slate-600">{port.containerName}</span>}
+                  {port.containerName && <span className="text-theme-text-tertiary">{port.containerName}</span>}
                 </span>
               </button>
             ))}
@@ -358,7 +358,7 @@ export function PortForwardInlineButton({
       <button
         onClick={handleClick}
         disabled={disabled || isPending}
-        className="inline-flex items-center gap-1 px-1.5 py-0.5 bg-slate-600/50 hover:bg-blue-600/50 rounded text-xs transition-colors disabled:opacity-50 disabled:hover:bg-slate-600/50"
+        className="inline-flex items-center gap-1 px-1.5 py-0.5 bg-theme-elevated hover:bg-accent-muted rounded text-xs transition-colors disabled:opacity-50 disabled:hover:bg-theme-elevated"
         title={`Port forward ${port}`}
       >
         {port}/{protocol}

--- a/web/src/components/portforward/PortForwardManager.tsx
+++ b/web/src/components/portforward/PortForwardManager.tsx
@@ -176,26 +176,26 @@ export function PortForwardManager({
     return (
       <button
         onClick={onToggleMinimize}
-        className="fixed bottom-4 left-4 z-40 flex items-center gap-2 px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg shadow-lg hover:bg-slate-700 transition-colors"
+        className="fixed bottom-4 left-4 z-40 flex items-center gap-2 px-3 py-2 bg-theme-surface border border-theme-border rounded-lg shadow-lg hover:bg-theme-elevated transition-colors"
       >
         <Radio className={clsx('w-4 h-4', errorSessions.length > 0 ? 'text-red-400' : 'text-green-400 animate-pulse')} />
-        <span className="text-sm text-slate-300">
+        <span className="text-sm text-theme-text-secondary">
           {activeSessions.length} port forward{activeSessions.length !== 1 ? 's' : ''}
           {errorSessions.length > 0 && <span className="text-red-400 ml-1">({errorSessions.length} failed)</span>}
         </span>
-        <ChevronUp className="w-4 h-4 text-slate-400" />
+        <ChevronUp className="w-4 h-4 text-theme-text-tertiary" />
       </button>
     )
   }
 
   return (
-    <div className="fixed bottom-4 left-4 z-40 w-80 bg-slate-800 border border-slate-700 rounded-lg shadow-2xl overflow-hidden">
+    <div className="fixed bottom-4 left-4 z-40 w-80 bg-theme-surface border border-theme-border rounded-lg shadow-2xl overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between px-3 py-2 bg-slate-700/50 border-b border-slate-700">
+      <div className="flex items-center justify-between px-3 py-2 bg-theme-elevated border-b border-theme-border">
         <div className="flex items-center gap-2">
-          <Plug className="w-4 h-4 text-blue-400" />
-          <span className="text-sm font-medium text-slate-200">Port Forwards</span>
-          <span className="text-xs px-1.5 py-0.5 bg-slate-600 rounded text-slate-300">
+          <Plug className="w-4 h-4 text-accent-text" />
+          <span className="text-sm font-medium text-theme-text-primary">Port Forwards</span>
+          <span className="text-xs px-1.5 py-0.5 bg-theme-hover rounded text-theme-text-secondary">
             {activeSessions.length}
           </span>
           {errorSessions.length > 0 && (
@@ -208,7 +208,7 @@ export function PortForwardManager({
           {onToggleMinimize && (
             <button
               onClick={onToggleMinimize}
-              className="p-1 text-slate-400 hover:text-white hover:bg-slate-600 rounded"
+              className="p-1 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-hover rounded"
             >
               <ChevronDown className="w-4 h-4" />
             </button>
@@ -216,7 +216,7 @@ export function PortForwardManager({
           {onClose && (
             <button
               onClick={onClose}
-              className="p-1 text-slate-400 hover:text-white hover:bg-slate-600 rounded"
+              className="p-1 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-hover rounded"
             >
               <X className="w-4 h-4" />
             </button>
@@ -228,18 +228,18 @@ export function PortForwardManager({
       <div className="max-h-64 overflow-y-auto">
         {isLoading ? (
           <div className="flex items-center justify-center p-4">
-            <Loader2 className="w-5 h-5 text-slate-400 animate-spin" />
+            <Loader2 className="w-5 h-5 text-theme-text-tertiary animate-spin" />
           </div>
         ) : activeSessions.length === 0 ? (
-          <div className="p-4 text-center text-sm text-slate-500">
+          <div className="p-4 text-center text-sm text-theme-text-disabled">
             No active port forwards
           </div>
         ) : (
-          <div className="divide-y divide-slate-700/50">
+          <div className="divide-y divide-theme-border">
             {activeSessions.map((session) => (
               <div key={session.id} className={clsx(
                 'p-3',
-                session.status === 'error' ? 'bg-red-500/10' : 'hover:bg-slate-700/30'
+                session.status === 'error' ? 'bg-red-500/10' : 'hover:bg-theme-elevated'
               )}>
                 <div className="flex items-start justify-between gap-2">
                   <div className="flex-1 min-w-0">
@@ -250,7 +250,7 @@ export function PortForwardManager({
                           session.status === 'running' ? 'bg-green-500' : 'bg-red-500'
                         )}
                       />
-                      <span className="text-sm text-slate-200 font-medium truncate">
+                      <span className="text-sm text-theme-text-primary font-medium truncate">
                         {session.serviceName || session.podName}
                       </span>
                       {session.status === 'error' && (
@@ -259,7 +259,7 @@ export function PortForwardManager({
                         </span>
                       )}
                     </div>
-                    <div className="mt-1 text-xs text-slate-500">
+                    <div className="mt-1 text-xs text-theme-text-disabled">
                       {session.namespace} · Port {session.podPort}
                     </div>
                     {session.status === 'error' && session.error && (
@@ -270,8 +270,8 @@ export function PortForwardManager({
                     {session.status === 'running' && (
                       <div className="mt-1.5 flex items-center gap-2">
                         {editingPortId === session.id ? (
-                          <div className="flex items-center text-xs bg-slate-900 rounded text-blue-400 font-mono">
-                            <span className="pl-2 py-1 text-slate-500 select-none">
+                          <div className="flex items-center text-xs bg-theme-base rounded text-accent-text font-mono">
+                            <span className="pl-2 py-1 text-theme-text-disabled select-none">
                               {session.listenAddress === '0.0.0.0' ? '0.0.0.0' : 'localhost'}:
                             </span>
                             <input
@@ -294,13 +294,13 @@ export function PortForwardManager({
                                 }
                               }}
                               onBlur={() => setEditingPortId(null)}
-                              className="w-16 bg-transparent border-none pr-2 py-1 text-blue-400 font-mono text-xs outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                              className="w-16 bg-transparent border-none pr-2 py-1 text-accent-text font-mono text-xs outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                             />
                           </div>
                         ) : (
                           <code
                             className={clsx(
-                              'group/port text-xs bg-slate-900 px-2 py-1 rounded text-blue-400 transition-all inline-flex items-center gap-1',
+                              'group/port text-xs bg-theme-base px-2 py-1 rounded text-accent-text transition-all inline-flex items-center gap-1',
                               changingPortId === session.id
                                 ? 'opacity-50'
                                 : 'cursor-pointer hover:ring-1 hover:ring-blue-500/50'
@@ -316,7 +316,7 @@ export function PortForwardManager({
                               <Loader2 className="w-3 h-3 animate-spin inline mr-1" />
                             )}
                             {session.listenAddress === '0.0.0.0' ? '0.0.0.0' : 'localhost'}:{session.localPort}
-                            <PenLine className="w-3 h-3 text-slate-500 opacity-0 group-hover/port:opacity-100 transition-opacity" />
+                            <PenLine className="w-3 h-3 text-theme-text-disabled opacity-0 group-hover/port:opacity-100 transition-opacity" />
                           </code>
                         )}
                         <button
@@ -326,7 +326,7 @@ export function PortForwardManager({
                             'flex items-center gap-1 px-1.5 py-0.5 text-xs rounded transition-colors',
                             session.listenAddress === '0.0.0.0'
                               ? 'bg-amber-500/20 text-amber-400 hover:bg-amber-500/30'
-                              : 'bg-slate-700 text-slate-400 hover:bg-slate-600 hover:text-slate-200'
+                              : 'bg-theme-elevated text-theme-text-tertiary hover:bg-theme-hover hover:text-theme-text-primary'
                           )}
                           title={session.listenAddress === '0.0.0.0'
                             ? 'Click to switch to localhost only'
@@ -351,7 +351,7 @@ export function PortForwardManager({
                       <>
                         <button
                           onClick={() => handleCopyUrl(session)}
-                          className="p-1.5 text-slate-400 hover:text-white hover:bg-slate-600 rounded"
+                          className="p-1.5 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-hover rounded"
                           title="Copy URL"
                         >
                           {copiedId === session.id ? (
@@ -362,7 +362,7 @@ export function PortForwardManager({
                         </button>
                         <button
                           onClick={() => handleOpenUrl(session)}
-                          className="p-1.5 text-slate-400 hover:text-white hover:bg-slate-600 rounded"
+                          className="p-1.5 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-hover rounded"
                           title="Open in browser"
                         >
                           <ExternalLink className="w-3.5 h-3.5" />
@@ -372,7 +372,7 @@ export function PortForwardManager({
                     <button
                       onClick={() => stopMutation.mutate(session.id)}
                       disabled={stopMutation.isPending}
-                      className="p-1.5 text-slate-400 hover:text-red-400 hover:bg-slate-600 rounded disabled:opacity-50"
+                      className="p-1.5 text-theme-text-tertiary hover:text-red-400 hover:bg-theme-hover rounded disabled:opacity-50"
                       title={session.status === 'error' ? 'Dismiss' : 'Stop'}
                     >
                       <Trash2 className="w-3.5 h-3.5" />


### PR DESCRIPTION
Replace hardcoded dark-theme slate colors with theme CSS variables so these components respect the active theme (light/dark):

- PortForwardButton: button, dropdown menu, listen address toggle
- PortForwardManager: minimized bar, session list, action buttons
- BottomDock: tab bar, tab buttons, close/collapse buttons
- TerminalTab: toolbar, container selector, reconnect button

## Description

Port forward components and bottom dock used hardcoded `bg-slate-700/800/900`, `text-slate-200/400`, `border-slate-700` classes instead of theme-aware CSS variables. This caused these elements to always render with dark colors even when light theme is active.

Replaced all hardcoded slate classes with theme system equivalents (`bg-theme-surface`, `text-theme-text-primary`, `border-theme-border`, etc.) consistent with the rest of the codebase.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How has this been tested?

- [x] Tested locally with `make build` — build passes with no errors
- [x] Verified light theme renders correctly
- [x] Verified dark theme is unchanged

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

<img width="530" height="332" alt="image" src="https://github.com/user-attachments/assets/47e4dbad-b181-4547-8731-43405fa0dfeb" />
