### PR TITLE
feat: add Ctrl+F search to read-only CodeViewer

### DIFF
--- a/web/src/components/ui/CodeViewer.tsx
+++ b/web/src/components/ui/CodeViewer.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react'
-import { Copy, Check } from 'lucide-react'
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { Copy, Check, ChevronUp, ChevronDown, X, Search } from 'lucide-react'
 import { codeToHtml } from 'shiki'
 
 interface CodeViewerProps {
@@ -24,6 +24,21 @@ export function CodeViewer({
   const [html, setHtml] = useState<string>('')
   const [highlighting, setHighlighting] = useState(true)
 
+  // Search state
+  const [searchOpen, setSearchOpen] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchDisplay, setSearchDisplay] = useState({ matchCount: 0, currentIndex: 0 })
+
+  // Use refs for match tracking to avoid re-renders that destroy DOM highlights
+  const matchCountRef = useRef(0)
+  const currentIndexRef = useRef(0)
+
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null)
+  const isMouseInsideRef = useRef(false)
+  const htmlRef = useRef<string>('')
+
   useEffect(() => {
     if (!code) {
       setHtml('')
@@ -33,7 +48,6 @@ export function CodeViewer({
 
     setHighlighting(true)
 
-    // Use 'text' language as fallback for unknown languages
     const shikiLang = language === 'text' ? 'text' : language
 
     codeToHtml(code, {
@@ -42,16 +56,257 @@ export function CodeViewer({
     })
       .then((highlighted) => {
         setHtml(highlighted)
+        htmlRef.current = highlighted
         setHighlighting(false)
       })
       .catch((error) => {
         console.error('Shiki highlighting failed:', error)
-        // Fallback to plain text
         const escaped = code.replace(/</g, '&lt;').replace(/>/g, '&gt;')
-        setHtml(`<pre><code>${escaped}</code></pre>`)
+        const fallback = `<pre><code>${escaped}</code></pre>`
+        setHtml(fallback)
+        htmlRef.current = fallback
         setHighlighting(false)
       })
   }, [code, language])
+
+  // Set innerHTML via ref so React doesn't manage it (preserves our <mark> elements across re-renders)
+  useEffect(() => {
+    if (contentRef.current && !highlighting && html) {
+      contentRef.current.innerHTML = html
+    }
+  }, [html, highlighting])
+
+  // Update the search display state (triggers re-render only for the search bar UI)
+  const updateSearchDisplay = useCallback((count: number, index: number) => {
+    setSearchDisplay({ matchCount: count, currentIndex: index })
+  }, [])
+
+  // Clear all <mark> highlights from the content, restore original HTML
+  const clearHighlights = useCallback(() => {
+    if (contentRef.current && htmlRef.current) {
+      contentRef.current.innerHTML = htmlRef.current
+    }
+    matchCountRef.current = 0
+    currentIndexRef.current = 0
+    updateSearchDisplay(0, 0)
+  }, [updateSearchDisplay])
+
+  // Walk text nodes and wrap matches in <mark> elements
+  const applyHighlights = useCallback((query: string, activeIndex: number) => {
+    const container = contentRef.current
+    if (!container || !query) {
+      clearHighlights()
+      return
+    }
+
+    // Restore original HTML first (clean slate)
+    if (htmlRef.current) {
+      container.innerHTML = htmlRef.current
+    }
+
+    const lowerQuery = query.toLowerCase()
+    let totalMatches = 0
+
+    // Collect all text nodes
+    const textNodes: Text[] = []
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT)
+    let node: Text | null
+    while ((node = walker.nextNode() as Text | null)) {
+      if (node.textContent && node.textContent.length > 0) {
+        textNodes.push(node)
+      }
+    }
+
+    // Process each text node — find matches and wrap them
+    for (const textNode of textNodes) {
+      const text = textNode.textContent || ''
+      const lowerText = text.toLowerCase()
+
+      // Find all match positions in this text node
+      const positions: number[] = []
+      let searchFrom = 0
+      while (searchFrom < lowerText.length) {
+        const idx = lowerText.indexOf(lowerQuery, searchFrom)
+        if (idx === -1) break
+        positions.push(idx)
+        searchFrom = idx + 1
+      }
+
+      if (positions.length === 0) continue
+
+      const parent = textNode.parentNode
+      if (!parent) continue
+
+      const frag = document.createDocumentFragment()
+      let lastEnd = 0
+
+      for (const pos of positions) {
+        // Text before match
+        if (pos > lastEnd) {
+          frag.appendChild(document.createTextNode(text.slice(lastEnd, pos)))
+        }
+
+        // The match
+        const mark = document.createElement('mark')
+        mark.className = totalMatches === activeIndex
+          ? 'search-highlight active'
+          : 'search-highlight'
+        mark.textContent = text.slice(pos, pos + query.length)
+        mark.dataset.matchIndex = String(totalMatches)
+        frag.appendChild(mark)
+
+        totalMatches++
+        lastEnd = pos + query.length
+      }
+
+      // Remaining text
+      if (lastEnd < text.length) {
+        frag.appendChild(document.createTextNode(text.slice(lastEnd)))
+      }
+
+      parent.replaceChild(frag, textNode)
+    }
+
+    matchCountRef.current = totalMatches
+    const clampedIndex = totalMatches > 0 ? Math.min(activeIndex, totalMatches - 1) : 0
+    currentIndexRef.current = clampedIndex
+    updateSearchDisplay(totalMatches, clampedIndex)
+
+    // Scroll to active match
+    if (totalMatches > 0) {
+      requestAnimationFrame(() => {
+        const activeMark = container.querySelector(`mark.search-highlight[data-match-index="${clampedIndex}"]`)
+        if (activeMark) {
+          activeMark.scrollIntoView({ block: 'center', behavior: 'smooth' })
+        }
+      })
+    }
+  }, [clearHighlights, updateSearchDisplay])
+
+  // Update active match by swapping CSS classes (no DOM rebuild)
+  const setActiveMatch = useCallback((newIndex: number) => {
+    const container = contentRef.current
+    if (!container || matchCountRef.current === 0) return
+
+    // Remove active from current
+    const current = container.querySelector('mark.search-highlight.active')
+    if (current) {
+      current.className = 'search-highlight'
+    }
+
+    // Add active to new
+    const next = container.querySelector(`mark.search-highlight[data-match-index="${newIndex}"]`)
+    if (next) {
+      next.className = 'search-highlight active'
+      next.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    }
+
+    currentIndexRef.current = newIndex
+    updateSearchDisplay(matchCountRef.current, newIndex)
+  }, [updateSearchDisplay])
+
+  // Apply highlights when query changes
+  useEffect(() => {
+    if (!searchOpen) return
+    if (!searchQuery) {
+      clearHighlights()
+      return
+    }
+
+    const timer = setTimeout(() => {
+      applyHighlights(searchQuery, 0)
+    }, 150)
+
+    return () => clearTimeout(timer)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchQuery, searchOpen])
+
+  // Re-apply highlights when Shiki finishes while search is open
+  useEffect(() => {
+    if (searchOpen && searchQuery && !highlighting) {
+      const timer = setTimeout(() => {
+        applyHighlights(searchQuery, currentIndexRef.current)
+      }, 50)
+      return () => clearTimeout(timer)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [html, highlighting])
+
+  // Close search when code changes
+  useEffect(() => {
+    if (searchOpen) {
+      clearHighlights()
+      setSearchOpen(false)
+      setSearchQuery('')
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [code])
+
+  // Navigation
+  const goToNextMatch = useCallback(() => {
+    if (matchCountRef.current === 0) return
+    const newIndex = (currentIndexRef.current + 1) % matchCountRef.current
+    setActiveMatch(newIndex)
+  }, [setActiveMatch])
+
+  const goToPrevMatch = useCallback(() => {
+    if (matchCountRef.current === 0) return
+    const newIndex = (currentIndexRef.current - 1 + matchCountRef.current) % matchCountRef.current
+    setActiveMatch(newIndex)
+  }, [setActiveMatch])
+
+  // Open search
+  const openSearch = useCallback(() => {
+    setSearchOpen(true)
+    requestAnimationFrame(() => {
+      searchInputRef.current?.focus()
+      searchInputRef.current?.select()
+    })
+  }, [])
+
+  // Close search
+  const closeSearch = useCallback(() => {
+    setSearchOpen(false)
+    setSearchQuery('')
+    clearHighlights()
+  }, [clearHighlights])
+
+  // Keyboard: Ctrl+F on wrapper
+  const handleWrapperKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+      e.preventDefault()
+      e.stopPropagation()
+      openSearch()
+    }
+  }, [openSearch])
+
+  // Global Ctrl+F when mouse is inside
+  useEffect(() => {
+    const handleGlobalKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'f' && isMouseInsideRef.current) {
+        e.preventDefault()
+        e.stopPropagation()
+        openSearch()
+      }
+    }
+    document.addEventListener('keydown', handleGlobalKeyDown, true)
+    return () => document.removeEventListener('keydown', handleGlobalKeyDown, true)
+  }, [openSearch])
+
+  // Search input keyboard
+  const handleSearchKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      closeSearch()
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      if (e.shiftKey) {
+        goToPrevMatch()
+      } else {
+        goToNextMatch()
+      }
+    }
+  }, [closeSearch, goToNextMatch, goToPrevMatch])
 
   const handleCopy = () => {
     if (onCopy) {
@@ -62,8 +317,16 @@ export function CodeViewer({
   }
 
   return (
-    <div className="relative rounded-lg overflow-hidden bg-[#0d1117]">
-      {showCopyButton && (
+    <div
+      ref={wrapperRef}
+      className="relative rounded-lg overflow-hidden bg-[#0d1117]"
+      tabIndex={0}
+      onKeyDown={handleWrapperKeyDown}
+      onMouseEnter={() => { isMouseInsideRef.current = true }}
+      onMouseLeave={() => { isMouseInsideRef.current = false }}
+      style={{ outline: 'none' }}
+    >
+      {showCopyButton && !searchOpen && (
         <button
           onClick={handleCopy}
           className="absolute top-2 right-2 z-10 flex items-center gap-1 px-2 py-1 text-xs text-theme-text-secondary hover:text-theme-text-primary bg-theme-surface/80 hover:bg-theme-elevated rounded backdrop-blur-sm"
@@ -71,6 +334,53 @@ export function CodeViewer({
           {copied ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
           Copy
         </button>
+      )}
+
+      {/* Search bar */}
+      {searchOpen && (
+        <div className="absolute top-2 right-2 z-20 flex items-center gap-1 px-2 py-1.5 bg-theme-surface border border-theme-border rounded-lg shadow-lg backdrop-blur-sm">
+          <Search className="w-3.5 h-3.5 text-theme-text-tertiary shrink-0" />
+          <input
+            ref={searchInputRef}
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            onKeyDown={handleSearchKeyDown}
+            placeholder="Search..."
+            className="w-40 bg-transparent text-xs text-theme-text-primary placeholder:text-theme-text-disabled outline-none"
+            autoFocus
+          />
+          {searchQuery && (
+            <span className="text-xs text-theme-text-tertiary whitespace-nowrap shrink-0">
+              {searchDisplay.matchCount > 0
+                ? `${searchDisplay.currentIndex + 1} of ${searchDisplay.matchCount}`
+                : 'No results'}
+            </span>
+          )}
+          <button
+            onClick={goToPrevMatch}
+            disabled={searchDisplay.matchCount === 0}
+            className="p-0.5 text-theme-text-tertiary hover:text-theme-text-primary disabled:opacity-30 rounded"
+            title="Previous (Shift+Enter)"
+          >
+            <ChevronUp className="w-3.5 h-3.5" />
+          </button>
+          <button
+            onClick={goToNextMatch}
+            disabled={searchDisplay.matchCount === 0}
+            className="p-0.5 text-theme-text-tertiary hover:text-theme-text-primary disabled:opacity-30 rounded"
+            title="Next (Enter)"
+          >
+            <ChevronDown className="w-3.5 h-3.5" />
+          </button>
+          <button
+            onClick={closeSearch}
+            className="p-0.5 text-theme-text-tertiary hover:text-theme-text-primary rounded"
+            title="Close (Escape)"
+          >
+            <X className="w-3.5 h-3.5" />
+          </button>
+        </div>
       )}
 
       <div
@@ -81,8 +391,8 @@ export function CodeViewer({
           <div className="p-4 text-theme-text-tertiary text-sm font-mono">Loading...</div>
         ) : (
           <div
+            ref={contentRef}
             className={`shiki-viewer text-xs ${showLineNumbers ? 'with-line-numbers' : ''}`}
-            dangerouslySetInnerHTML={{ __html: html }}
           />
         )}
       </div>
@@ -118,6 +428,17 @@ export function CodeViewer({
         }
         .shiki-viewer .line:hover {
           background: rgba(99, 110, 123, 0.1);
+        }
+        mark.search-highlight {
+          background-color: rgba(250, 204, 21, 0.35);
+          color: inherit;
+          border-radius: 2px;
+          padding: 0;
+        }
+        mark.search-highlight.active {
+          background-color: rgba(250, 204, 21, 0.8);
+          outline: 2px solid rgba(250, 204, 21, 0.9);
+          border-radius: 2px;
         }
       `}</style>
     </div>


### PR DESCRIPTION
Add in-component search overlay to the Shiki-based CodeViewer used for YAML manifests and Helm values. Ctrl+F / Cmd+F opens a search bar with match highlighting, navigation (Enter/Shift+Enter), and match counter. DOM is managed via refs to preserve highlights across React re-renders.

## Description

The read-only CodeViewer (Shiki-based) used for Helm manifests, Helm values, and resource YAML had no search capability. Ctrl+F would trigger the browser's native find which doesn't work well inside scrollable containers with syntax-highlighted content.

This adds an in-component search overlay:
- **Activation**: Ctrl+F / Cmd+F when mouse is over the viewer
- **Highlighting**: All matches highlighted in yellow, active match in bright yellow with outline
- **Navigation**: Enter (next), Shift+Enter (previous), up/down arrow buttons, wrap-around
- **Match counter**: "3 of 12" display
- **Close**: Escape key or X button

Technical: innerHTML is managed via refs instead of `dangerouslySetInnerHTML` to prevent React re-renders from destroying the `<mark>` highlight elements.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

- [x] Tested locally with `make build` — TypeScript and Vite build pass with no errors
- [x] Verified search works in Helm manifest viewer
- [x] Verified search works in Helm values viewer (read-only mode)
- [x] Verified navigation between matches works correctly
- [x] Verified Escape closes search and clears highlights

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
<img width="980" height="346" alt="image" src="https://github.com/user-attachments/assets/ba48812f-24bc-4fd4-8aad-2f2c2e5b076c" />
