### PR TITLE
fix: clean up port forward dropdown layout

### DIFF
--- a/web/src/components/portforward/PortForwardButton.tsx
+++ b/web/src/components/portforward/PortForwardButton.tsx
@@ -286,14 +286,13 @@ export function PortForwardButton({
                 onClick={() => handlePortSelect(port)}
                 className="w-full px-3 py-2 text-left text-sm text-theme-text-primary hover:bg-theme-elevated flex items-center justify-between"
               >
-                <span className="flex items-center gap-2">
+                <span className="flex items-center gap-2 shrink-0">
                   <code className="text-accent-text">{port.port}</code>
                   <span className="text-theme-text-disabled">/{port.protocol || 'TCP'}</span>
                 </span>
-                <span className="text-xs text-theme-text-disabled">
-                  {port.name && <span className="mr-2">{port.name}</span>}
-                  {port.containerName && <span className="text-theme-text-tertiary">{port.containerName}</span>}
-                </span>
+                {port.name && (
+                  <span className="text-xs text-theme-text-disabled truncate max-w-[120px]">{port.name}</span>
+                )}
               </button>
             ))}
           </div>


### PR DESCRIPTION
Remove container name from port list dropdown to prevent text overlap when names are long. Keep only port number, protocol, and port name (truncated if needed). Add `shrink-0` to port column to prevent squishing.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How has this been tested?

- [x] Tested locally with minikube/kind

Verified with deployments that have long names — the dropdown no longer overlaps text.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

<img width="533" height="367" alt="image" src="https://github.com/user-attachments/assets/1a09bad0-de26-472d-a00d-2684d36d249c" />

<img width="535" height="370" alt="image" src="https://github.com/user-attachments/assets/1dc85d96-3448-4342-80ad-d362139cf3fd" />

