### PR TITLE
feat: TLS certificate info for Secrets

### DIFF
--- a/internal/server/certificate.go
+++ b/internal/server/certificate.go
@@ -1,0 +1,277 @@
+package server
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"math"
+	"net/http"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+)
+
+const (
+	certExpiryWarningDays  = 30
+	certExpiryCriticalDays = 7
+)
+
+// CertificateInfo holds parsed X.509 certificate metadata for a single certificate.
+type CertificateInfo struct {
+	Subject      string   `json:"subject"`
+	SANs         []string `json:"sans,omitempty"`
+	Issuer       string   `json:"issuer"`
+	SelfSigned   bool     `json:"selfSigned,omitempty"`
+	KeyType      string   `json:"keyType"`
+	SerialNumber string   `json:"serialNumber"`
+	NotBefore    string   `json:"notBefore"`
+	NotAfter     string   `json:"notAfter"`
+	DaysLeft     int      `json:"daysLeft"`
+	Expired      bool     `json:"expired,omitempty"`
+}
+
+// SecretCertificateInfo holds parsed certificate data for a TLS secret.
+// Attached to secret responses so the frontend doesn't need to parse certs.
+// Certificates are ordered leaf-first: index 0 is the server certificate,
+// subsequent entries are intermediates/root.
+type SecretCertificateInfo struct {
+	Certificates []CertificateInfo `json:"certificates"`
+}
+
+// CertExpiry is a lightweight certificate expiry entry for list views.
+type CertExpiry struct {
+	DaysLeft int  `json:"daysLeft"`
+	Expired  bool `json:"expired,omitempty"`
+}
+
+// handleSecretCertExpiry returns certificate expiry for all TLS secrets.
+// Used by the frontend secrets list to show an "Expires" column without
+// parsing certificates client-side.
+func (s *Server) handleSecretCertExpiry(w http.ResponseWriter, r *http.Request) {
+	if !s.requireConnected(w) {
+		return
+	}
+
+	cache := k8s.GetResourceCache()
+	if cache == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "Resource cache not available")
+		return
+	}
+
+	lister := cache.Secrets()
+	if lister == nil {
+		s.writeJSON(w, map[string]CertExpiry{})
+		return
+	}
+
+	namespaces := parseNamespaces(r.URL.Query())
+	var secrets []*corev1.Secret
+	if len(namespaces) == 1 {
+		secrets, _ = lister.Secrets(namespaces[0]).List(labels.Everything())
+	} else if len(namespaces) > 1 {
+		for _, ns := range namespaces {
+			nsSecrets, _ := lister.Secrets(ns).List(labels.Everything())
+			secrets = append(secrets, nsSecrets...)
+		}
+	} else {
+		secrets, _ = lister.List(labels.Everything())
+	}
+
+	result := make(map[string]CertExpiry)
+	for _, secret := range secrets {
+		if secret.Type != corev1.SecretTypeTLS {
+			continue
+		}
+		certPEM, exists := secret.Data["tls.crt"]
+		if !exists || len(certPEM) == 0 {
+			continue
+		}
+		certs := parsePEMCertificates(certPEM)
+		if len(certs) == 0 {
+			continue
+		}
+		// Use the leaf certificate (first in chain) for expiry
+		key := secret.Namespace + "/" + secret.Name
+		result[key] = CertExpiry{
+			DaysLeft: certs[0].DaysLeft,
+			Expired:  certs[0].Expired,
+		}
+	}
+
+	s.writeJSON(w, result)
+}
+
+// DashboardCertificateHealth holds aggregate certificate health for the dashboard.
+type DashboardCertificateHealth struct {
+	Total    int `json:"total"`
+	Healthy  int `json:"healthy"`
+	Warning  int `json:"warning"`
+	Critical int `json:"critical"`
+	Expired  int `json:"expired"`
+}
+
+// getDashboardCertificateHealth scans all TLS secrets and counts by expiry bucket.
+func (s *Server) getDashboardCertificateHealth(namespace string) *DashboardCertificateHealth {
+	cache := k8s.GetResourceCache()
+	if cache == nil {
+		return nil
+	}
+
+	lister := cache.Secrets()
+	if lister == nil {
+		return nil
+	}
+
+	var secrets []*corev1.Secret
+	if namespace != "" {
+		secrets, _ = lister.Secrets(namespace).List(labels.Everything())
+	} else {
+		secrets, _ = lister.List(labels.Everything())
+	}
+
+	health := &DashboardCertificateHealth{}
+	for _, secret := range secrets {
+		if secret.Type != corev1.SecretTypeTLS {
+			continue
+		}
+		certPEM, exists := secret.Data["tls.crt"]
+		if !exists || len(certPEM) == 0 {
+			continue
+		}
+		certs := parsePEMCertificates(certPEM)
+		if len(certs) == 0 {
+			continue
+		}
+
+		health.Total++
+		leaf := certs[0]
+		switch {
+		case leaf.Expired:
+			health.Expired++
+		case leaf.DaysLeft < certExpiryCriticalDays:
+			health.Critical++
+		case leaf.DaysLeft < certExpiryWarningDays:
+			health.Warning++
+		default:
+			health.Healthy++
+		}
+	}
+
+	if health.Total == 0 {
+		return nil
+	}
+	return health
+}
+
+// parsePEMCertificates decodes PEM-encoded certificate data and returns parsed info
+// for each certificate in the chain.
+func parsePEMCertificates(certData []byte) []CertificateInfo {
+	var result []CertificateInfo
+
+	rest := certData
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			log.Printf("[certificate] Failed to parse certificate block %d in PEM chain: %v", len(result)+1, err)
+			continue
+		}
+
+		now := time.Now()
+		daysLeft := int(math.Floor(cert.NotAfter.Sub(now).Hours() / 24))
+
+		info := CertificateInfo{
+			Subject:      certSubjectCN(cert),
+			Issuer:       certIssuerCN(cert),
+			SelfSigned:   cert.Issuer.String() == cert.Subject.String(),
+			KeyType:      certKeyType(cert),
+			SerialNumber: fmt.Sprintf("%X", cert.SerialNumber),
+			NotBefore:    cert.NotBefore.Format(time.RFC3339),
+			NotAfter:     cert.NotAfter.Format(time.RFC3339),
+			DaysLeft:     daysLeft,
+			Expired:      now.After(cert.NotAfter),
+		}
+
+		// Collect SANs (DNS names + IP addresses)
+		for _, dns := range cert.DNSNames {
+			info.SANs = append(info.SANs, dns)
+		}
+		for _, ip := range cert.IPAddresses {
+			info.SANs = append(info.SANs, ip.String())
+		}
+
+		result = append(result, info)
+	}
+
+	return result
+}
+
+func certSubjectCN(cert *x509.Certificate) string {
+	if cert.Subject.CommonName != "" {
+		return cert.Subject.CommonName
+	}
+	s := cert.Subject.String()
+	if s != "" {
+		return s
+	}
+	return "-"
+}
+
+func certIssuerCN(cert *x509.Certificate) string {
+	if cert.Issuer.CommonName != "" {
+		return cert.Issuer.CommonName
+	}
+	s := cert.Issuer.String()
+	if s != "" {
+		return s
+	}
+	return "-"
+}
+
+func certKeyType(cert *x509.Certificate) string {
+	switch pub := cert.PublicKey.(type) {
+	case *rsa.PublicKey:
+		return fmt.Sprintf("RSA %d", pub.N.BitLen())
+	case *ecdsa.PublicKey:
+		return fmt.Sprintf("EC %s", ecCurveName(pub.Curve))
+	case ed25519.PublicKey:
+		return "Ed25519"
+	default:
+		return strings.TrimPrefix(fmt.Sprintf("%T", pub), "*")
+	}
+}
+
+func ecCurveName(curve elliptic.Curve) string {
+	switch curve {
+	case elliptic.P224():
+		return "P-224"
+	case elliptic.P256():
+		return "P-256"
+	case elliptic.P384():
+		return "P-384"
+	case elliptic.P521():
+		return "P-521"
+	default:
+		if params := curve.Params(); params != nil {
+			return params.Name
+		}
+		return "unknown"
+	}
+}

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -31,8 +31,9 @@ type DashboardResponse struct {
 	RecentChanges   []DashboardChange        `json:"recentChanges"`
 	TopologySummary DashboardTopologySummary `json:"topologySummary"`
 	TrafficSummary  *DashboardTrafficSummary `json:"trafficSummary"`
-	HelmReleases    DashboardHelmSummary     `json:"helmReleases"`
-	Metrics         *DashboardMetrics        `json:"metrics"`
+	HelmReleases      DashboardHelmSummary        `json:"helmReleases"`
+	Metrics           *DashboardMetrics           `json:"metrics"`
+	CertificateHealth *DashboardCertificateHealth `json:"certificateHealth,omitempty"`
 }
 
 // DashboardCRDsResponse is the response for CRD counts (loaded lazily)
@@ -243,6 +244,9 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 
 	// Cluster metrics (best-effort, nil if metrics-server unavailable)
 	resp.Metrics = s.getDashboardMetrics(r.Context())
+
+	// Certificate health (nil if no TLS secrets)
+	resp.CertificateHealth = s.getDashboardCertificateHealth(namespace)
 
 	s.writeJSON(w, resp)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -134,6 +134,7 @@ func (s *Server) setupRoutes() {
 			r.Get("/resources/{kind}/{namespace}/{name}", s.handleGetResource)
 			r.Put("/resources/{kind}/{namespace}/{name}", s.handleUpdateResource)
 			r.Delete("/resources/{kind}/{namespace}/{name}", s.handleDeleteResource)
+			r.Get("/secrets/certificate-expiry", s.handleSecretCertExpiry)
 			r.Get("/events", s.handleEvents)
 			r.Get("/changes", s.handleChanges)
 			r.Get("/changes/{kind}/{namespace}/{name}/children", s.handleChangeChildren)
@@ -960,6 +961,16 @@ func (s *Server) handleGetResource(w http.ResponseWriter, r *http.Request) {
 	response := topology.ResourceWithRelationships{
 		Resource:      resource,
 		Relationships: relationships,
+	}
+
+	// Enrich TLS secrets with parsed certificate info
+	if secret, ok := resource.(*corev1.Secret); ok && secret.Type == corev1.SecretTypeTLS {
+		if certPEM, exists := secret.Data["tls.crt"]; exists && len(certPEM) > 0 {
+			certs := parsePEMCertificates(certPEM)
+			if len(certs) > 0 {
+				response.CertificateInfo = &SecretCertificateInfo{Certificates: certs}
+			}
+		}
 	}
 
 	s.writeJSON(w, response)

--- a/internal/topology/types.go
+++ b/internal/topology/types.go
@@ -188,4 +188,8 @@ type Relationships struct {
 type ResourceWithRelationships struct {
 	Resource      any            `json:"resource"`
 	Relationships *Relationships `json:"relationships,omitempty"`
+	// CertificateInfo holds parsed TLS certificate metadata for Secret resources.
+	// Typed as any to avoid an import cycle (actual type: *server.SecretCertificateInfo).
+	// Only populated for kubernetes.io/tls secrets with valid PEM certificate data.
+	CertificateInfo any `json:"certificateInfo,omitempty"`
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -177,6 +177,14 @@ export interface DashboardCRDCount {
   count: number
 }
 
+export interface DashboardCertificateHealth {
+  total: number
+  healthy: number
+  warning: number
+  critical: number
+  expired: number
+}
+
 export interface DashboardResponse {
   cluster: DashboardCluster
   health: DashboardHealth
@@ -188,6 +196,7 @@ export interface DashboardResponse {
   trafficSummary: DashboardTrafficSummary | null
   helmReleases: DashboardHelmSummary
   metrics: DashboardMetrics | null
+  certificateHealth: DashboardCertificateHealth | null
 }
 
 export interface DashboardCRDsResponse {
@@ -201,6 +210,23 @@ export function useDashboard(namespaces: string[] = []) {
     queryFn: () => fetchJSON(`/dashboard${params}`),
     staleTime: 15000, // 15 seconds
     refetchInterval: 30000, // Refresh every 30 seconds
+  })
+}
+
+// Certificate expiry for TLS secrets (used in secrets list view)
+export interface CertExpiry {
+  daysLeft: number
+  expired?: boolean
+}
+
+export function useSecretCertExpiry(namespaces: string[] = [], enabled = true) {
+  const params = namespaces.length > 0 ? `?namespaces=${namespaces.join(',')}` : ''
+  return useQuery<Record<string, CertExpiry>>({
+    queryKey: ['secret-cert-expiry', namespaces],
+    queryFn: () => fetchJSON(`/secrets/certificate-expiry${params}`),
+    enabled,
+    staleTime: 30000,
+    refetchInterval: 60000,
   })
 }
 
@@ -391,6 +417,7 @@ export function useResource<T>(kind: string, namespace: string, name: string, gr
     ...query,
     data: query.data?.resource,
     relationships: query.data?.relationships,
+    certificateInfo: query.data?.certificateInfo,
   }
 }
 

--- a/web/src/components/home/CertificateHealthCard.tsx
+++ b/web/src/components/home/CertificateHealthCard.tsx
@@ -1,0 +1,111 @@
+import type { DashboardCertificateHealth } from '../../api/client'
+import { Shield, ArrowRight } from 'lucide-react'
+import { clsx } from 'clsx'
+
+interface CertificateHealthCardProps {
+  data: DashboardCertificateHealth
+  onNavigate: () => void
+}
+
+export function CertificateHealthCard({ data, onNavigate }: CertificateHealthCardProps) {
+  const hasIssues = data.expired > 0 || data.critical > 0
+  const hasWarnings = data.warning > 0
+  const borderColor = hasIssues
+    ? 'border-red-500/30 hover:border-red-500/60'
+    : hasWarnings
+      ? 'border-yellow-500/30 hover:border-yellow-500/60'
+      : 'border-green-500/30 hover:border-green-500/60'
+  const accentColor = hasIssues ? 'text-red-500' : hasWarnings ? 'text-yellow-500' : 'text-green-500'
+  const accentBg = hasIssues ? 'bg-red-500/10' : hasWarnings ? 'bg-yellow-500/10' : 'bg-green-500/10'
+
+  return (
+    <button
+      onClick={onNavigate}
+      className={clsx(
+        'group flex flex-col h-[260px] rounded-lg border-[3px] bg-theme-surface/50 hover:-translate-y-1 hover:shadow-[0_12px_24px_rgba(0,0,0,0.12)] transition-all duration-200 text-left cursor-pointer',
+        borderColor
+      )}
+    >
+      <div className="flex items-center justify-between px-4 py-2 border-b border-theme-border">
+        <div className="flex items-center gap-2">
+          <Shield className={clsx('w-4 h-4', accentColor)} />
+          <span className={clsx('text-sm font-semibold', accentColor)}>TLS Certificates</span>
+          <span className={clsx('text-[11px] px-1.5 py-0.5 rounded', accentBg, accentColor)}>
+            {data.total}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex-1 min-h-0 flex flex-col items-center justify-center px-4 py-4">
+        {/* Summary ring / bar */}
+        <div className="flex items-center gap-3 w-full">
+          {/* Color bar showing distribution */}
+          <div className="flex-1 h-3 rounded-full overflow-hidden bg-theme-hover flex">
+            {data.healthy > 0 && (
+              <div
+                className="h-full bg-green-500"
+                style={{ width: `${(data.healthy / data.total) * 100}%` }}
+              />
+            )}
+            {data.warning > 0 && (
+              <div
+                className="h-full bg-yellow-500"
+                style={{ width: `${(data.warning / data.total) * 100}%` }}
+              />
+            )}
+            {data.critical > 0 && (
+              <div
+                className="h-full bg-orange-500"
+                style={{ width: `${(data.critical / data.total) * 100}%` }}
+              />
+            )}
+            {data.expired > 0 && (
+              <div
+                className="h-full bg-red-500"
+                style={{ width: `${(data.expired / data.total) * 100}%` }}
+              />
+            )}
+          </div>
+        </div>
+
+        {/* Breakdown */}
+        <div className="grid grid-cols-2 gap-x-6 gap-y-2 mt-4 w-full">
+          <BucketRow label="Healthy" count={data.healthy} color="text-green-400" dotColor="bg-green-500" />
+          <BucketRow label="Warning" subtitle="< 30d" count={data.warning} color="text-yellow-400" dotColor="bg-yellow-500" />
+          <BucketRow label="Critical" subtitle="< 7d" count={data.critical} color="text-orange-400" dotColor="bg-orange-500" />
+          <BucketRow label="Expired" count={data.expired} color="text-red-400" dotColor="bg-red-500" />
+        </div>
+      </div>
+
+      <div className="px-4 py-1.5 border-t border-theme-border flex items-center justify-end">
+        <span className={clsx(
+          'flex items-center gap-1.5 text-xs font-medium transition-colors',
+          accentColor,
+          hasIssues ? 'group-hover:text-red-400' : hasWarnings ? 'group-hover:text-yellow-400' : 'group-hover:text-green-400'
+        )}>
+          View Secrets
+          <ArrowRight className="w-3.5 h-3.5 transition-transform group-hover:translate-x-0.5" />
+        </span>
+      </div>
+    </button>
+  )
+}
+
+function BucketRow({ label, subtitle, count, color, dotColor }: {
+  label: string
+  subtitle?: string
+  count: number
+  color: string
+  dotColor: string
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className={clsx('w-2 h-2 rounded-full shrink-0', dotColor)} />
+      <span className="text-xs text-theme-text-secondary flex-1">
+        {label}
+        {subtitle && <span className="text-theme-text-tertiary ml-1">{subtitle}</span>}
+      </span>
+      <span className={clsx('text-sm font-semibold tabular-nums', count > 0 ? color : 'text-theme-text-tertiary')}>{count}</span>
+    </div>
+  )
+}

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -6,6 +6,7 @@ import { TopologyPreview } from './TopologyPreview'
 import { HelmSummary } from './HelmSummary'
 import { ActivitySummary } from './ActivitySummary'
 import { TrafficSummary } from './TrafficSummary'
+import { CertificateHealthCard } from './CertificateHealthCard'
 import { ClusterHealthCard } from './ClusterHealthCard'
 import { AlertTriangle, Loader2 } from 'lucide-react'
 import { clsx } from 'clsx'
@@ -86,6 +87,12 @@ export function HomeView({ namespaces, topology, onNavigateToView, onNavigateToR
               data={data.trafficSummary}
               onNavigate={() => onNavigateToView('traffic')}
             />
+            {data.certificateHealth && (
+              <CertificateHealthCard
+                data={data.certificateHealth}
+                onNavigate={() => onNavigateToResourceKind('Secret')}
+              />
+            )}
           </div>
 
           {/* Right column: problems panel */}

--- a/web/src/components/resources/ResourceDetailDrawer.tsx
+++ b/web/src/components/resources/ResourceDetailDrawer.tsx
@@ -130,7 +130,7 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate }: Resource
 
   const updateResource = useUpdateResource()
 
-  const { data: resourceData, relationships, isLoading, refetch: refetchResource } = useResource<any>(
+  const { data: resourceData, relationships, certificateInfo, isLoading, refetch: refetchResource } = useResource<any>(
     resource.kind,
     resource.namespace,
     resource.name,
@@ -313,6 +313,7 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate }: Resource
             resource={resource}
             data={resourceData}
             relationships={relationships}
+            certificateInfo={certificateInfo}
             onCopy={copyToClipboard}
             copied={copied}
             onNavigate={handleNavigateToRelated}
@@ -1075,12 +1076,13 @@ interface ResourceContentProps {
   resource: SelectedResource
   data: any
   relationships?: Relationships
+  certificateInfo?: import('../../types').SecretCertificateInfo
   onCopy: (text: string, key: string) => void
   copied: string | null
   onNavigate?: (ref: ResourceRef) => void
 }
 
-function ResourceContent({ resource, data, relationships, onCopy, copied, onNavigate }: ResourceContentProps) {
+function ResourceContent({ resource, data, relationships, certificateInfo, onCopy, copied, onNavigate }: ResourceContentProps) {
   const kind = resource.kind.toLowerCase()
 
   // Fetch events for this resource
@@ -1114,7 +1116,7 @@ function ResourceContent({ resource, data, relationships, onCopy, copied, onNavi
       {kind === 'services' && <ServiceRenderer data={data} onCopy={onCopy} copied={copied} />}
       {kind === 'ingresses' && <IngressRenderer data={data} />}
       {kind === 'configmaps' && <ConfigMapRenderer data={data} />}
-      {kind === 'secrets' && <SecretRenderer data={data} />}
+      {kind === 'secrets' && <SecretRenderer data={data} certificateInfo={certificateInfo} />}
       {kind === 'jobs' && <JobRenderer data={data} />}
       {kind === 'cronjobs' && <CronJobRenderer data={data} />}
       {(kind === 'hpas' || kind === 'horizontalpodautoscalers') && <HPARenderer data={data} />}

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo, useEffect, useCallback, useRef, forwardRef } from 'r
 import { useRefreshAnimation } from '../../hooks/useRefreshAnimation'
 import { useLocation } from 'react-router-dom'
 import { useQueries } from '@tanstack/react-query'
-import { ApiError, isForbiddenError } from '../../api/client'
+import { ApiError, isForbiddenError, useSecretCertExpiry } from '../../api/client'
 import {
   Search,
   RefreshCw,
@@ -313,6 +313,7 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
     { key: 'namespace', label: 'Namespace', width: 'w-48' },
     { key: 'type', label: 'Type', width: 'w-28' },
     { key: 'keys', label: 'Keys', width: 'w-20' },
+    { key: 'expires', label: 'Expires', width: 'w-24', tooltip: 'Certificate expiry for TLS secrets' },
     { key: 'age', label: 'Age', width: 'w-20' },
   ],
   jobs: [
@@ -2601,6 +2602,7 @@ function ConfigMapCell({ resource, column }: { resource: any; column: string }) 
 }
 
 function SecretCell({ resource, column }: { resource: any; column: string }) {
+  const { data: certExpiry, isError: certExpiryError } = useSecretCertExpiry([], column === 'expires')
   switch (column) {
     case 'type': {
       const { type, color } = getSecretType(resource)
@@ -2613,6 +2615,26 @@ function SecretCell({ resource, column }: { resource: any; column: string }) {
     case 'keys': {
       const count = getSecretKeyCount(resource)
       return <span className="text-sm text-theme-text-secondary">{count}</span>
+    }
+    case 'expires': {
+      if (certExpiryError) {
+        return <span className="text-sm text-theme-text-tertiary" title="Failed to load certificate expiry">!</span>
+      }
+      const meta = resource.metadata || {}
+      const key = `${meta.namespace}/${meta.name}`
+      const expiry = certExpiry?.[key]
+      if (!expiry) {
+        return <span className="text-sm text-theme-text-tertiary">-</span>
+      }
+      const color = expiry.expired || expiry.daysLeft < 7
+        ? 'text-red-400'
+        : expiry.daysLeft < 30
+          ? 'text-yellow-400'
+          : 'text-green-400'
+      const text = expiry.expired
+        ? `Expired ${Math.abs(expiry.daysLeft)}d ago`
+        : `${expiry.daysLeft}d`
+      return <span className={clsx('text-sm font-medium', color)}>{text}</span>
     }
     default:
       return <span className="text-sm text-theme-text-tertiary">-</span>
@@ -2899,10 +2921,11 @@ function CertificateCell({ resource, column }: { resource: any; column: string }
       const expiry = getCertificateExpiry(resource)
       return (
         <span className={clsx(
-          'text-sm',
+          'text-sm font-medium',
           expiry.level === 'unhealthy' ? 'text-red-400' :
           expiry.level === 'degraded' ? 'text-yellow-400' :
-          'text-theme-text-secondary'
+          expiry.level === 'healthy' ? 'text-green-400' :
+          'text-theme-text-tertiary'
         )}>
           {expiry.text}
         </span>

--- a/web/src/components/resources/renderers/SecretRenderer.tsx
+++ b/web/src/components/resources/renderers/SecretRenderer.tsx
@@ -1,12 +1,21 @@
 import { useState } from 'react'
-import { AlertTriangle, Copy, Check } from 'lucide-react'
+import { AlertTriangle, Copy, Check, Shield } from 'lucide-react'
+import { clsx } from 'clsx'
 import { Section, PropertyList, Property } from '../drawer-components'
+import type { SecretCertificateInfo, CertificateInfo } from '../../../types'
 
 interface SecretRendererProps {
   data: any
+  certificateInfo?: SecretCertificateInfo
 }
 
-export function SecretRenderer({ data }: SecretRendererProps) {
+function formatDate(dateStr: string): string {
+  if (!dateStr) return '-'
+  const d = new Date(dateStr)
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+export function SecretRenderer({ data, certificateInfo }: SecretRendererProps) {
   const [revealed, setRevealed] = useState<Set<string>>(new Set())
   const [copied, setCopied] = useState<string | null>(null)
   const dataKeys = Object.keys(data.data || {})
@@ -37,6 +46,9 @@ export function SecretRenderer({ data }: SecretRendererProps) {
     }
   }
 
+  const certs = certificateInfo?.certificates
+  const leafCert = certs?.[0]
+
   return (
     <>
       <Section title="Secret">
@@ -46,6 +58,67 @@ export function SecretRenderer({ data }: SecretRendererProps) {
           {data.immutable && <Property label="Immutable" value="Yes" />}
         </PropertyList>
       </Section>
+
+      {/* Certificate expiry alerts */}
+      {leafCert && leafCert.expired && (
+        <div className="mb-4 p-3 bg-red-500/10 border border-red-500/30 rounded-lg">
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="w-4 h-4 text-red-400 mt-0.5 shrink-0" />
+            <div className="flex-1 min-w-0">
+              <div className="text-sm font-medium text-red-400">Certificate has expired</div>
+              <div className="text-xs text-red-300/80 mt-1">
+                Expired {formatDate(leafCert.notAfter)}. {leafCert.daysLeft !== 0 && `${Math.abs(leafCert.daysLeft)}d ago.`}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {leafCert && !leafCert.expired && leafCert.daysLeft <= 7 && (
+        <div className="mb-4 p-3 bg-red-500/10 border border-red-500/30 rounded-lg">
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="w-4 h-4 text-red-400 mt-0.5 shrink-0" />
+            <div className="flex-1 min-w-0">
+              <div className="text-sm font-medium text-red-400">
+                Certificate expires in {leafCert.daysLeft} day{leafCert.daysLeft !== 1 ? 's' : ''}
+              </div>
+              <div className="text-xs text-red-300/80 mt-1">
+                Check that cert-manager or your CA is renewing this certificate.
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {leafCert && !leafCert.expired && leafCert.daysLeft > 7 && leafCert.daysLeft <= 30 && (
+        <div className="mb-4 p-3 bg-yellow-500/10 border border-yellow-500/30 rounded-lg">
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="w-4 h-4 text-yellow-400 mt-0.5 shrink-0" />
+            <div className="flex-1 min-w-0">
+              <div className="text-sm font-medium text-yellow-400">
+                Certificate expires in {leafCert.daysLeft} day{leafCert.daysLeft !== 1 ? 's' : ''}
+              </div>
+              <div className="text-xs text-yellow-300/80 mt-1">
+                Renewal should happen automatically before expiry.
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Certificate info section */}
+      {certs && certs.length > 0 && (
+        <>
+          {certs.map((cert, i) => (
+            <CertificateInfoSection
+              key={cert.serialNumber}
+              cert={cert}
+              index={i}
+              total={certs.length}
+            />
+          ))}
+        </>
+      )}
 
       <Section title="Data" defaultExpanded>
         <div className="space-y-2">
@@ -98,5 +171,59 @@ export function SecretRenderer({ data }: SecretRendererProps) {
         Secret values are sensitive. Be careful when revealing.
       </div>
     </>
+  )
+}
+
+function CertificateInfoSection({ cert, index, total }: { cert: CertificateInfo; index: number; total: number }) {
+  const expiryTextColor = cert.expired || cert.daysLeft <= 7
+    ? 'text-red-400'
+    : cert.daysLeft <= 30
+      ? 'text-yellow-400'
+      : 'text-green-400'
+
+  const title = total > 1
+    ? `Certificate ${index + 1} of ${total}`
+    : 'Certificate Info'
+
+  return (
+    <Section title={title} icon={Shield} defaultExpanded={index === 0}>
+      <PropertyList>
+        <Property label="Subject (CN)" value={cert.subject} />
+        {cert.sans && cert.sans.length > 0 && (
+          <Property label="SANs" value={
+            <div className="flex flex-wrap gap-1">
+              {cert.sans.map(san => (
+                <span key={san} className="px-2 py-0.5 bg-theme-elevated rounded text-xs text-theme-text-secondary">
+                  {san}
+                </span>
+              ))}
+            </div>
+          } />
+        )}
+        <Property label="Issuer" value={
+          <span>
+            {cert.issuer}
+            {cert.selfSigned && (
+              <span className="ml-2 text-[10px] px-1 py-0.5 bg-yellow-500/10 text-yellow-400 rounded">self-signed</span>
+            )}
+          </span>
+        } />
+        <Property label="Key Type" value={cert.keyType} />
+        <Property label="Serial" value={
+          <span className="font-mono text-xs">{cert.serialNumber}</span>
+        } />
+        <Property label="Not Before" value={formatDate(cert.notBefore)} />
+        <Property label="Expires" value={
+          <span>
+            {formatDate(cert.notAfter)}
+            <span className={clsx('ml-2 text-xs', expiryTextColor)}>
+              {cert.expired
+                ? `(expired ${Math.abs(cert.daysLeft)}d ago)`
+                : `(${cert.daysLeft}d remaining)`}
+            </span>
+          </span>
+        } />
+      </PropertyList>
+    </Section>
   )
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -313,10 +313,28 @@ export interface Relationships {
   pods?: ResourceRef[]
 }
 
-// Resource with computed relationships (API response wrapper)
+// Parsed X.509 certificate metadata (from backend cert parsing)
+export interface CertificateInfo {
+  subject: string
+  sans?: string[]
+  issuer: string
+  selfSigned?: boolean
+  keyType: string
+  serialNumber: string
+  notBefore: string
+  notAfter: string
+  daysLeft: number
+  expired?: boolean
+}
+
+export interface SecretCertificateInfo {
+  certificates: CertificateInfo[]
+}
+
 export interface ResourceWithRelationships<T = unknown> {
   resource: T
   relationships?: Relationships
+  certificateInfo?: SecretCertificateInfo
 }
 
 // API Resource (from discovery endpoint)


### PR DESCRIPTION
## Summary

Parses X.509 certificates from Kubernetes TLS secrets server-side using Go's `crypto/x509` stdlib — zero new dependencies. Inspired by [lens-extension-certificate-info](https://github.com/jkroepke/lens-extension-certificate-info).

- **Secret detail view**: Shows certificate metadata (subject, SANs, issuer, key type, serial, validity) with color-coded expiry alerts. Supports full certificate chains ("Certificate 1 of 3").
- **Secrets list view**: New "Expires" column showing days remaining for TLS secrets, color-coded red/yellow/green. Powered by a lightweight `/api/secrets/certificate-expiry` endpoint.
- **Dashboard card**: Certificate health summary with healthy/warning/critical/expired buckets, rendered as a color bar. Only appears when TLS secrets exist in the cluster.

## Key decisions

- All cert parsing happens on the Go backend (`internal/server/certificate.go`) — no new npm dependencies, no client-side parsing
- List view uses a dedicated bulk endpoint rather than per-row API calls; React Query deduplicates across cells
- Dashboard health uses the same single-namespace pattern as other dashboard functions for consistency