### PR TITLE
fix: terminal resize race condition and desktop port-forward open

### DIFF
--- a/internal/server/exec.go
+++ b/internal/server/exec.go
@@ -278,13 +278,16 @@ func (s *Server) handlePodExec(w http.ResponseWriter, r *http.Request) {
 			case "input":
 				stdinWriter.Write([]byte(msg.Data))
 			case "resize":
+				// Drain any stale pending size so the new one isn't dropped.
+				// The initial 80x24 may still be buffered if StreamWithContext
+				// hasn't consumed it yet (K8s API connect is slower than local WS).
 				select {
-				case sizeQueue.resizeChan <- remotecommand.TerminalSize{
+				case <-sizeQueue.resizeChan:
+				default:
+				}
+				sizeQueue.resizeChan <- remotecommand.TerminalSize{
 					Width:  msg.Cols,
 					Height: msg.Rows,
-				}:
-				default:
-					// Drop resize if channel full
 				}
 			}
 		case <-r.Context().Done():

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -31,7 +31,7 @@ import { RefreshCw, FolderTree, Network, List, Clock, Package, Sun, Moon, Activi
 import { useTheme } from './context/ThemeContext'
 import { Tooltip } from './components/ui/Tooltip'
 import type { TopologyNode, GroupingMode, MainView, SelectedResource, SelectedHelmRelease, NodeKind, Topology } from './types'
-import { kindToPlural } from './utils/navigation'
+import { kindToPlural, openExternal } from './utils/navigation'
 
 // All possible node kinds (core + GitOps)
 const ALL_NODE_KINDS: NodeKind[] = [
@@ -900,7 +900,7 @@ function GitHubStarButton() {
         })
         .catch(() => {
           // Fallback: open GitHub in browser
-          window.open('https://github.com/skyhook-io/radar', '_blank')
+          openExternal('https://github.com/skyhook-io/radar')
         })
     } else {
       // No gh CLI — link opens GitHub; dismiss the callout

--- a/web/src/components/dock/TerminalTab.tsx
+++ b/web/src/components/dock/TerminalTab.tsx
@@ -94,21 +94,6 @@ export function TerminalTab({
     xterm.loadAddon(webLinksAddon)
     xterm.open(terminalRef.current)
 
-    // Delay fit to ensure container is sized
-    // Use proposeDimensions + 1 workaround for better space utilization
-    const doFit = () => {
-      const dims = fitAddon.proposeDimensions()
-      if (dims) {
-        xterm.resize(dims.cols, dims.rows)
-      }
-    }
-
-    requestAnimationFrame(() => {
-      doFit()
-      // Second fit after layout settles
-      setTimeout(doFit, 100)
-    })
-
     xtermRef.current = xterm
     fitAddonRef.current = fitAddon
 
@@ -119,18 +104,36 @@ export function TerminalTab({
     const ws = new WebSocket(wsUrl)
     wsRef.current = ws
 
+    // Fit terminal to container and notify backend of new dimensions
+    const doFit = () => {
+      const dims = fitAddon.proposeDimensions()
+      if (dims) {
+        xterm.resize(dims.cols, dims.rows)
+      }
+      if (ws.readyState === WebSocket.OPEN) {
+        const msg: TerminalMessage = {
+          type: 'resize',
+          rows: xterm.rows,
+          cols: xterm.cols,
+        }
+        ws.send(JSON.stringify(msg))
+      }
+    }
+
+    // Delay initial fit to ensure container is sized
+    requestAnimationFrame(() => {
+      doFit()
+      // Second fit after layout settles
+      setTimeout(doFit, 100)
+    })
+
     ws.onopen = () => {
       setIsConnected(true)
       setIsConnecting(false)
-      xterm.focus()
 
-      // Send initial size
-      const msg: TerminalMessage = {
-        type: 'resize',
-        rows: xterm.rows,
-        cols: xterm.cols,
-      }
-      ws.send(JSON.stringify(msg))
+      // Fit to container and send actual dimensions (not xterm defaults)
+      doFit()
+      xterm.focus()
     }
 
     ws.onmessage = (event) => {

--- a/web/src/components/portforward/PortForwardManager.tsx
+++ b/web/src/components/portforward/PortForwardManager.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react'
 import { clsx } from 'clsx'
 import { useToast } from '../ui/Toast'
+import { openExternal } from '../../utils/navigation'
 
 interface PortForwardSession {
   id: string
@@ -161,7 +162,7 @@ export function PortForwardManager({
   }, [])
 
   const handleOpenUrl = useCallback((session: PortForwardSession) => {
-    window.open(`http://localhost:${session.localPort}`, '_blank')
+    openExternal(`http://localhost:${session.localPort}`)
   }, [])
 
   // Show both running and error sessions (not stopped)

--- a/web/src/utils/navigation.ts
+++ b/web/src/utils/navigation.ts
@@ -1,6 +1,22 @@
 import type { SelectedResource, ResourceRef } from '../types'
 
 /**
+ * Open a URL in the system browser.
+ * In the Wails desktop app, window.open() is swallowed by the webview,
+ * so we use the injected runtime.BrowserOpenURL instead.
+ */
+export function openExternal(url: string): void {
+  const wailsRuntime = (window as unknown as Record<string, unknown>).runtime as
+    | { BrowserOpenURL?: (url: string) => void }
+    | undefined
+  if (wailsRuntime?.BrowserOpenURL) {
+    wailsRuntime.BrowserOpenURL(url)
+  } else {
+    window.open(url, '_blank')
+  }
+}
+
+/**
  * Canonical callback type for navigating to a resource.
  * All components that trigger resource navigation should use this type.
  */


### PR DESCRIPTION
## Summary
- Fix terminal exec stuck at 80 columns — backend race condition where the resize channel silently dropped the frontend's actual dimensions because the initial 80x24 was still buffered (K8s API connect is slower than local WebSocket)
- Fix `window.open()` not working in desktop app (Wails webview) for port-forward "Open" button and GitHub star fallback link

## Details

**Terminal resize (closes #153):**
- Backend (`exec.go`): drain stale pending size from the channel before pushing new resize, so it's never silently dropped
- Frontend (`TerminalTab.tsx`): `doFit()` now sends resize to WebSocket when connected; `ws.onopen` calls `doFit()` so the backend always gets correct dimensions

**Desktop port-forward open:**
- Added `openExternal()` utility that uses Wails `runtime.BrowserOpenURL` when in desktop app, falls back to `window.open()` in browser
- Applied to port-forward manager and GitHub star fallback