### PR TITLE
Add goroutine leak profiler support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,9 +47,10 @@ COPY --from=frontend-builder /app/web/dist internal/static/dist/
 ARG VERSION=dev
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
+ARG GOEXPERIMENT=""
 
 # Build the binary
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOEXPERIMENT=${GOEXPERIMENT} \
     go build -ldflags "-s -w -X main.version=${VERSION}" \
     -o /radar ./cmd/explorer
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -106,6 +106,7 @@ func (s *Server) setupRoutes() {
 		r.Get("/heap", pprof.Handler("heap").ServeHTTP)
 		r.Get("/mutex", pprof.Handler("mutex").ServeHTTP)
 		r.Get("/threadcreate", pprof.Handler("threadcreate").ServeHTTP)
+		r.Get("/goroutineleak", pprof.Handler("goroutineleak").ServeHTTP) // requires GOEXPERIMENT=goroutineleakprofile at build time
 	})
 
 	// API routes


### PR DESCRIPTION
## Summary
- Add pprof handler for `/debug/pprof/goroutineleak` endpoint (Go 1.26 goroutine leak profiler)
- Add `GOEXPERIMENT` build arg to Dockerfile for opt-in at build time
- Requires `GOEXPERIMENT=goroutineleakprofile` at build time to activate