### PR TITLE
fix: prevent crash from concurrent cache init and context switch

### DIFF
--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -110,6 +110,13 @@ func dropManagedFields(obj any) (any, error) {
 func InitResourceCache() error {
 	var initErr error
 	cacheOnce.Do(func() {
+		// Hold cacheMu for the entire init so that ResetResourceCache (which also
+		// acquires cacheMu) blocks until we finish. Without this, a concurrent
+		// context switch can zero cacheOnce while doSlow still holds its internal
+		// mutex, causing "sync: unlock of unlocked mutex".
+		cacheMu.Lock()
+		defer cacheMu.Unlock()
+
 		if k8sClient == nil {
 			initErr = fmt.Errorf("cannot create resource cache: k8s client not initialized")
 			return


### PR DESCRIPTION
## Description

Fix a race condition that causes the desktop app to crash with `fatal error: sync: unlock of unlocked mutex` during startup.

**Root cause:** `InitResourceCache()` runs inside `sync.Once.Do()` and takes ~17s to sync caches. If a context switch is triggered during this window (e.g. by the frontend), `ResetResourceCache()` executes `cacheOnce = sync.Once{}`, zeroing the internal mutex while `doSlow` still holds it. When `doSlow` finishes and runs `defer o.m.Unlock()`, the mutex is already zeroed — causing a fatal panic.

**Fix:** Hold `cacheMu` for the entire `cacheOnce.Do()` body in `InitResourceCache()`. Since `ResetResourceCache()` also acquires `cacheMu`, it will block until initialization completes, preventing the race.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How has this been tested?

- [x] Tested locally against a remote EKS cluster (~14k resources, ~25s cache sync)
- Verified the app starts without crash
- Verified context switching works after initialization completes

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

**Crash Logs**
 ~~~
2026/02/18 10:34:53 Resource caches synced successfully in 17.300140875s
fatal error: sync: unlock of unlocked mutex
goroutine 21 [running]:
internal/sync.fatal({0x104159f89?, 0x106cae380?})
/Users/runner/hostedtoolcache/go/1.26.0/arm64/src/runtime/panic.go:1191 +0x20
internal/sync.(Mutex).unlockSlow(0x10754ddfc, 0xffffffff)
/Users/runner/hostedtoolcache/go/1.26.0/arm64/src/internal/sync/mutex.go:204 +0x38
internal/sync.(Mutex).Unlock(...)
/Users/runner/hostedtoolcache/go/1.26.0/arm64/src/internal/sync/mutex.go:198
sync.(Mutex).Unlock(...)
/Users/runner/hostedtoolcache/go/1.26.0/arm64/src/sync/mutex.go:65
sync.(Once).doSlow(0x0?, 0x0?)
/Users/runner/hostedtoolcache/go/1.26.0/arm64/src/sync/once.go:80 +0x118
sync.(Once).Do(...)
/Users/runner/hostedtoolcache/go/1.26.0/arm64/src/sync/once.go:69
github.com/skyhook-io/radar/internal/k8s.InitResourceCache()
/Users/runner/work/radar/radar/internal/k8s/cache.go:112 +0x4c
github.com/skyhook-io/radar/internal/k8s.InitAllSubsystems(0x1072e4168)
/Users/runner/work/radar/radar/internal/k8s/subsystems.go:34 +0x188
github.com/skyhook-io/radar/internal/app.InitializeCluster()
/Users/runner/work/radar/radar/internal/app/bootstrap.go:160 +0xa4
created by main.main in goroutine 1
/Users/runner/work/radar/radar/cmd/desktop/main.go:108 +0x7ac
~~~