### PR TITLE
feat(helm): add mcp.enabled value to disable MCP server

### DIFF
--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
             {{- if .Values.traffic.prometheusUrl }}
             - --prometheus-url={{ .Values.traffic.prometheusUrl }}
             {{- end }}
+            {{- if not .Values.mcp.enabled }}
+            - --no-mcp
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -153,6 +153,11 @@ timeline:
   # Maximum number of events to retain
   historyLimit: 10000
 
+# MCP (Model Context Protocol) server for AI tools
+mcp:
+  # Set to false to disable the MCP server (useful when deployed behind authentication)
+  enabled: true
+
 # Traffic source configuration
 traffic:
   # Manual Prometheus/VictoriaMetrics URL (bypasses auto-discovery)


### PR DESCRIPTION
Adds a new `mcp.enabled` Helm value (default: true) that passes
`--no-mcp` to the radar binary when set to false. This allows
disabling the MCP server in Helm deployments, particularly useful
when radar is behind authentication that makes MCP inaccessible.

Closes #170

https://claude.ai/code/session_011NiR6dxpribxUKYSkqaPLy