### PR TITLE
Add type field to radar MCP server configuration

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -115,7 +115,8 @@ Add via the Cline MCP settings UI:
 {
   "mcpServers": {
     "radar": {
-      "url": "http://localhost:9280/mcp"
+      "url": "http://localhost:9280/mcp",
+      "type": "streamableHttp"
     }
   }
 }


### PR DESCRIPTION
## Description

Cline needs to be set to type streamableHttp  to work with the mcp server otherwise we get 405 error.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## How has this been tested?

Describe the tests you ran to verify your changes.

- [ ] Tested locally with minikube/kind
- [ ] Tested against a remote cluster
- [ ] Added/updated unit tests

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged


