### PR TITLE
feat: label filtering, workload rollback, pending deletion indicator, deployment shortcuts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,12 +132,33 @@ radar/
 
 ## Development Commands
 
+### CRITICAL: Frontend Embedding Pipeline
+
+The Go binary serves the frontend via `go:embed` from `internal/static/dist/`, NOT from `web/dist/`. The build pipeline is:
+
+```
+web/src → (npm run build) → web/dist → (make embed) → internal/static/dist → (go build) → binary
+```
+
+**ALWAYS use `make build` to build the full application.** Running `cd web && npm run build` followed by `go build` will NOT update the served frontend — the embed step (`make embed`) that copies `web/dist/*` to `internal/static/dist/` will be skipped, and the binary will serve stale frontend assets.
+
+```bash
+# CORRECT: Full build (frontend + embed + backend)
+make build
+
+# CORRECT: Quick rebuild after frontend-only changes
+make restart-fe    # frontend + embed + restart server
+
+# CORRECT: Full rebuild + restart
+make restart       # frontend + embed + backend + restart server
+
+# WRONG: This skips the embed step!
+cd web && npm run build && cd .. && go build -o radar ./cmd/explorer
+```
+
 ### Backend (Go)
 ```bash
-# Build binary
-go build -o radar ./cmd/explorer
-
-# Run in dev mode (serves frontend from filesystem, not embedded)
+# Run in dev mode (serves frontend from web/dist instead of embedded — no embed step needed)
 go run ./cmd/explorer --dev
 
 # Run tests
@@ -166,19 +187,18 @@ npm run tsc
 
 ### Full Build
 ```bash
-# Build everything (frontend + embedded binary)
-make build
-
-# Run the complete application
-./radar
-
-# Other Makefile targets
-make frontend       # Build frontend only
-make backend        # Build backend only
+make build          # Build everything (frontend + embed + binary)
+make restart        # Build + restart server
+make restart-fe     # Frontend-only rebuild + restart (no Go recompile)
+make frontend       # Build frontend only (to web/dist)
+make embed          # Copy web/dist → internal/static/dist
+make backend        # Build Go binary only (uses embedded assets)
 make watch-frontend # Vite dev server (port 9273)
 make watch-backend  # Air hot reload (port 9280)
 make test           # Run all tests
-make docker         # Build Docker image
+make tsc            # Type check frontend
+make kill           # Kill running radar on port 9280
+make clean          # Remove build artifacts
 ```
 
 ### Development Ports
@@ -273,6 +293,8 @@ GET  /api/workloads/{kind}/{ns}/{name}/logs/stream # Stream aggregated workload 
 GET  /api/workloads/{kind}/{ns}/{name}/pods        # List pods for a workload
 POST /api/workloads/{kind}/{ns}/{name}/restart     # Rolling restart workload
 POST /api/workloads/{kind}/{ns}/{name}/scale       # Scale workload replicas
+GET  /api/workloads/{kind}/{ns}/{name}/revisions   # List revision history (Deployments, StatefulSets, DaemonSets)
+POST /api/workloads/{kind}/{ns}/{name}/rollback    # Rollback to a specific revision
 ```
 
 ### CronJob Operations
@@ -431,7 +453,7 @@ GET  /api/ai/resources/{kind}/{ns}/{name}     # Minified single resource (verbos
 
 ### Resource Relationships
 - Computed at query time for resource detail views
-- Tracks: parent (owner), children (owned), config (ConfigMaps/Secrets), network (Services/Ingresses/Gateways/Routes)
+- Tracks: parent (owner), children (owned), deployment (grandparent shortcut for Pods owned by ReplicaSets), config (ConfigMaps/Secrets), network (Services/Ingresses/Gateways/Routes)
 - Used for topology edges and change propagation
 
 ### AI Context Minification

--- a/internal/k8s/update.go
+++ b/internal/k8s/update.go
@@ -2,8 +2,11 @@ package k8s
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
+	"sort"
+	"strconv"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -12,6 +15,16 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/yaml"
 )
+
+// WorkloadRevision represents a single revision in a workload's rollout history
+type WorkloadRevision struct {
+	Number    int64     `json:"number"`
+	CreatedAt time.Time `json:"createdAt"`
+	Image     string    `json:"image"`    // primary container image
+	IsCurrent bool      `json:"isCurrent"`
+	Replicas  int64     `json:"replicas"`
+	Template  string    `json:"template,omitempty"` // Pod template spec as YAML (for revision diff)
+}
 
 // UpdateResourceOptions contains options for updating a resource
 type UpdateResourceOptions struct {
@@ -358,7 +371,434 @@ func normalizeKind(kind string) string {
 		return "deployments"
 	case "StatefulSet", "statefulset", "statefulsets":
 		return "statefulsets"
+	case "DaemonSet", "daemonset", "daemonsets":
+		return "daemonsets"
 	default:
 		return kind
 	}
+}
+
+// ListWorkloadRevisions returns the revision history for a Deployment, StatefulSet, or DaemonSet.
+func ListWorkloadRevisions(ctx context.Context, kind, namespace, name string) ([]WorkloadRevision, error) {
+	dynamicClient := GetDynamicClient()
+	if dynamicClient == nil {
+		return nil, fmt.Errorf("dynamic client not initialized")
+	}
+
+	discovery := GetResourceDiscovery()
+	if discovery == nil {
+		return nil, fmt.Errorf("resource discovery not initialized")
+	}
+
+	normalizedKind := normalizeKind(kind)
+
+	// First fetch the workload itself so we can match ownerReferences by UID
+	workloadGVR, ok := discovery.GetGVR(normalizedKind)
+	if !ok {
+		return nil, fmt.Errorf("unknown resource kind: %s", kind)
+	}
+
+	workload, err := dynamicClient.Resource(workloadGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get workload: %w", err)
+	}
+	workloadUID := string(workload.GetUID())
+
+	switch normalizedKind {
+	case "deployments":
+		return listDeploymentRevisions(ctx, discovery, namespace, name, workloadUID)
+	case "statefulsets", "daemonsets":
+		return listControllerRevisions(ctx, discovery, namespace, name, workloadUID)
+	default:
+		return nil, fmt.Errorf("revision history not supported for %s", kind)
+	}
+}
+
+// listDeploymentRevisions lists revisions for a Deployment by finding its ReplicaSets.
+func listDeploymentRevisions(ctx context.Context, discovery *ResourceDiscovery, namespace, name, workloadUID string) ([]WorkloadRevision, error) {
+	dynamicClient := GetDynamicClient()
+
+	rsGVR, ok := discovery.GetGVR("replicasets")
+	if !ok {
+		return nil, fmt.Errorf("replicasets resource not found")
+	}
+
+	rsList, err := dynamicClient.Resource(rsGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list replicasets: %w", err)
+	}
+
+	var revisions []WorkloadRevision
+	var maxRevision int64
+
+	for _, rs := range rsList.Items {
+		// Filter by ownerReference matching the Deployment UID
+		owners := rs.GetOwnerReferences()
+		owned := false
+		for _, ref := range owners {
+			if string(ref.UID) == workloadUID {
+				owned = true
+				break
+			}
+		}
+		if !owned {
+			continue
+		}
+
+		// Extract revision number from annotation
+		annotations := rs.GetAnnotations()
+		revStr, ok := annotations["deployment.kubernetes.io/revision"]
+		if !ok {
+			continue
+		}
+		revNum, err := strconv.ParseInt(revStr, 10, 64)
+		if err != nil {
+			continue
+		}
+
+		// Extract primary container image
+		image := extractContainerImage(rs.Object)
+
+		// Extract replicas
+		replicas, _, _ := unstructured.NestedInt64(rs.Object, "spec", "replicas")
+
+		// Extract pod template as YAML for diff
+		var templateStr string
+		if template, found, _ := unstructured.NestedMap(rs.Object, "spec", "template"); found && template != nil {
+			if templateYAML, err := yaml.Marshal(template); err == nil {
+				templateStr = string(templateYAML)
+			}
+		}
+
+		// Track the highest revision number
+		if revNum > maxRevision {
+			maxRevision = revNum
+		}
+
+		revisions = append(revisions, WorkloadRevision{
+			Number:    revNum,
+			CreatedAt: rs.GetCreationTimestamp().Time,
+			Image:     image,
+			Replicas:  replicas,
+			Template:  templateStr,
+		})
+	}
+
+	// Mark the current revision
+	for i := range revisions {
+		if revisions[i].Number == maxRevision {
+			revisions[i].IsCurrent = true
+		}
+	}
+
+	// Sort descending by revision number
+	sort.Slice(revisions, func(i, j int) bool {
+		return revisions[i].Number > revisions[j].Number
+	})
+
+	return revisions, nil
+}
+
+// listControllerRevisions lists revisions for a StatefulSet or DaemonSet by finding ControllerRevisions.
+func listControllerRevisions(ctx context.Context, discovery *ResourceDiscovery, namespace, name, workloadUID string) ([]WorkloadRevision, error) {
+	dynamicClient := GetDynamicClient()
+
+	crGVR, ok := discovery.GetGVR("controllerrevisions")
+	if !ok {
+		return nil, fmt.Errorf("controllerrevisions resource not found")
+	}
+
+	crList, err := dynamicClient.Resource(crGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list controllerrevisions: %w", err)
+	}
+
+	var revisions []WorkloadRevision
+	var maxRevision int64
+
+	for _, cr := range crList.Items {
+		// Filter by ownerReference matching the workload UID
+		owners := cr.GetOwnerReferences()
+		owned := false
+		for _, ref := range owners {
+			if string(ref.UID) == workloadUID {
+				owned = true
+				break
+			}
+		}
+		if !owned {
+			continue
+		}
+
+		// Extract revision number from .revision field
+		revNum, found, err := unstructured.NestedInt64(cr.Object, "revision")
+		if err != nil || !found {
+			continue
+		}
+
+		// Extract primary container image from .data.spec.template.spec.containers[0].image
+		image := extractContainerImageFromData(cr.Object)
+
+		// Extract template as YAML for diff
+		// ControllerRevision .data contains the workload spec (includes template)
+		var templateStr string
+		if data, found, _ := unstructured.NestedMap(cr.Object, "data"); found && data != nil {
+			// Try to extract just the pod template from the spec
+			if template, tFound, _ := unstructured.NestedMap(data, "spec", "template"); tFound && template != nil {
+				if templateYAML, err := yaml.Marshal(template); err == nil {
+					templateStr = string(templateYAML)
+				}
+			} else {
+				// Fallback: use the full data (some CRDs structure differently)
+				if dataYAML, err := yaml.Marshal(data); err == nil {
+					templateStr = string(dataYAML)
+				}
+			}
+		}
+
+		if revNum > maxRevision {
+			maxRevision = revNum
+		}
+
+		revisions = append(revisions, WorkloadRevision{
+			Number:    revNum,
+			CreatedAt: cr.GetCreationTimestamp().Time,
+			Image:     image,
+			Template:  templateStr,
+		})
+	}
+
+	// Mark the current revision
+	for i := range revisions {
+		if revisions[i].Number == maxRevision {
+			revisions[i].IsCurrent = true
+		}
+	}
+
+	// Sort descending by revision number
+	sort.Slice(revisions, func(i, j int) bool {
+		return revisions[i].Number > revisions[j].Number
+	})
+
+	return revisions, nil
+}
+
+// extractContainerImage extracts the first container image from spec.template.spec.containers[0].image
+func extractContainerImage(obj map[string]any) string {
+	containers, found, _ := unstructured.NestedSlice(obj, "spec", "template", "spec", "containers")
+	if !found || len(containers) == 0 {
+		return ""
+	}
+	if container, ok := containers[0].(map[string]any); ok {
+		if image, ok := container["image"].(string); ok {
+			return image
+		}
+	}
+	return ""
+}
+
+// extractContainerImageFromData extracts the first container image from .data.spec.template.spec.containers[0].image
+// for ControllerRevision objects.
+func extractContainerImageFromData(obj map[string]any) string {
+	data, found, _ := unstructured.NestedMap(obj, "data")
+	if !found {
+		return ""
+	}
+	return extractContainerImage(data)
+}
+
+// RollbackWorkload rolls back a Deployment, StatefulSet, or DaemonSet to a specific revision.
+func RollbackWorkload(ctx context.Context, kind, namespace, name string, revision int64) error {
+	dynamicClient := GetDynamicClient()
+	if dynamicClient == nil {
+		return fmt.Errorf("dynamic client not initialized")
+	}
+
+	discovery := GetResourceDiscovery()
+	if discovery == nil {
+		return fmt.Errorf("resource discovery not initialized")
+	}
+
+	normalizedKind := normalizeKind(kind)
+
+	// First fetch the workload to get its UID
+	workloadGVR, ok := discovery.GetGVR(normalizedKind)
+	if !ok {
+		return fmt.Errorf("unknown resource kind: %s", kind)
+	}
+
+	workload, err := dynamicClient.Resource(workloadGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get workload: %w", err)
+	}
+	workloadUID := string(workload.GetUID())
+
+	switch normalizedKind {
+	case "deployments":
+		return rollbackDeployment(ctx, discovery, namespace, name, workloadUID, revision)
+	case "statefulsets", "daemonsets":
+		return rollbackControllerRevision(ctx, discovery, normalizedKind, namespace, name, workloadUID, revision)
+	default:
+		return fmt.Errorf("rollback not supported for %s", kind)
+	}
+}
+
+// rollbackDeployment rolls back a Deployment by copying the target ReplicaSet's pod template.
+func rollbackDeployment(ctx context.Context, discovery *ResourceDiscovery, namespace, name, workloadUID string, revision int64) error {
+	dynamicClient := GetDynamicClient()
+
+	rsGVR, ok := discovery.GetGVR("replicasets")
+	if !ok {
+		return fmt.Errorf("replicasets resource not found")
+	}
+
+	// List ReplicaSets to find the one with the target revision
+	rsList, err := dynamicClient.Resource(rsGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list replicasets: %w", err)
+	}
+
+	var targetRS *unstructured.Unstructured
+	for i := range rsList.Items {
+		rs := &rsList.Items[i]
+		owners := rs.GetOwnerReferences()
+		owned := false
+		for _, ref := range owners {
+			if string(ref.UID) == workloadUID {
+				owned = true
+				break
+			}
+		}
+		if !owned {
+			continue
+		}
+
+		annotations := rs.GetAnnotations()
+		revStr, ok := annotations["deployment.kubernetes.io/revision"]
+		if !ok {
+			continue
+		}
+		revNum, err := strconv.ParseInt(revStr, 10, 64)
+		if err != nil {
+			continue
+		}
+		if revNum == revision {
+			targetRS = rs
+			break
+		}
+	}
+
+	if targetRS == nil {
+		return fmt.Errorf("revision %d not found", revision)
+	}
+
+	// Extract the pod template from the target RS
+	podTemplate, found, err := unstructured.NestedMap(targetRS.Object, "spec", "template")
+	if err != nil || !found {
+		return fmt.Errorf("failed to extract pod template from revision %d", revision)
+	}
+
+	// Build the patch: replace the Deployment's spec.template with the target RS's template
+	patchData := map[string]any{
+		"spec": map[string]any{
+			"template": podTemplate,
+		},
+	}
+	patchBytes, err := json.Marshal(patchData)
+	if err != nil {
+		return fmt.Errorf("failed to build rollback patch: %w", err)
+	}
+
+	deployGVR, ok := discovery.GetGVR("deployments")
+	if !ok {
+		return fmt.Errorf("deployments resource not found")
+	}
+
+	_, err = dynamicClient.Resource(deployGVR).Namespace(namespace).Patch(
+		ctx,
+		name,
+		types.MergePatchType,
+		patchBytes,
+		metav1.PatchOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to rollback deployment: %w", err)
+	}
+
+	return nil
+}
+
+// rollbackControllerRevision rolls back a StatefulSet or DaemonSet using a ControllerRevision's data.
+func rollbackControllerRevision(ctx context.Context, discovery *ResourceDiscovery, normalizedKind, namespace, name, workloadUID string, revision int64) error {
+	dynamicClient := GetDynamicClient()
+
+	crGVR, ok := discovery.GetGVR("controllerrevisions")
+	if !ok {
+		return fmt.Errorf("controllerrevisions resource not found")
+	}
+
+	// List ControllerRevisions to find the one with the target revision
+	crList, err := dynamicClient.Resource(crGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list controllerrevisions: %w", err)
+	}
+
+	var targetCR *unstructured.Unstructured
+	for i := range crList.Items {
+		cr := &crList.Items[i]
+		owners := cr.GetOwnerReferences()
+		owned := false
+		for _, ref := range owners {
+			if string(ref.UID) == workloadUID {
+				owned = true
+				break
+			}
+		}
+		if !owned {
+			continue
+		}
+
+		revNum, found, err := unstructured.NestedInt64(cr.Object, "revision")
+		if err != nil || !found {
+			continue
+		}
+		if revNum == revision {
+			targetCR = cr
+			break
+		}
+	}
+
+	if targetCR == nil {
+		return fmt.Errorf("revision %d not found", revision)
+	}
+
+	// Extract the .data field from the ControllerRevision
+	data, found, err := unstructured.NestedMap(targetCR.Object, "data")
+	if err != nil || !found {
+		return fmt.Errorf("failed to extract data from revision %d", revision)
+	}
+
+	// Build a strategic merge patch from the ControllerRevision's data
+	patchBytes, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to build rollback patch: %w", err)
+	}
+
+	gvr, ok := discovery.GetGVR(normalizedKind)
+	if !ok {
+		return fmt.Errorf("unknown resource kind: %s", normalizedKind)
+	}
+
+	_, err = dynamicClient.Resource(gvr).Namespace(namespace).Patch(
+		ctx,
+		name,
+		types.StrategicMergePatchType,
+		patchBytes,
+		metav1.PatchOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to rollback workload: %w", err)
+	}
+
+	return nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -168,9 +168,11 @@ func (s *Server) setupRoutes() {
 			r.Post("/cronjobs/{namespace}/{name}/suspend", s.handleSuspendCronJob)
 			r.Post("/cronjobs/{namespace}/{name}/resume", s.handleResumeCronJob)
 
-			// Workload restart
+			// Workload restart, scale, rollback
 			r.Post("/workloads/{kind}/{namespace}/{name}/restart", s.handleRestartWorkload)
 			r.Post("/workloads/{kind}/{namespace}/{name}/scale", s.handleScaleWorkload)
+			r.Get("/workloads/{kind}/{namespace}/{name}/revisions", s.handleWorkloadRevisions)
+			r.Post("/workloads/{kind}/{namespace}/{name}/rollback", s.handleRollbackWorkload)
 
 			// Workload logs (non-streaming)
 			r.Get("/workloads/{kind}/{namespace}/{name}/logs", s.handleWorkloadLogs)
@@ -1420,6 +1422,109 @@ func (s *Server) handleScaleWorkload(w http.ResponseWriter, r *http.Request) {
 	s.writeJSON(w, map[string]any{
 		"message":  "Workload scaled",
 		"replicas": req.Replicas,
+	})
+}
+
+// handleWorkloadRevisions returns the revision history for a Deployment, StatefulSet, or DaemonSet
+func (s *Server) handleWorkloadRevisions(w http.ResponseWriter, r *http.Request) {
+	if !s.requireConnected(w) {
+		return
+	}
+
+	kind := chi.URLParam(r, "kind")
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	// Validate that this is a rollbackable workload type
+	validKinds := map[string]bool{
+		"deployments":  true,
+		"statefulsets": true,
+		"daemonsets":   true,
+	}
+	if !validKinds[strings.ToLower(kind)] {
+		s.writeError(w, http.StatusBadRequest, "revision history only available for Deployments, StatefulSets, and DaemonSets")
+		return
+	}
+
+	revisions, err := k8s.ListWorkloadRevisions(r.Context(), kind, namespace, name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			s.writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		if apierrors.IsForbidden(err) {
+			s.writeError(w, http.StatusForbidden, err.Error())
+			return
+		}
+		log.Printf("[revisions] Failed to list revisions for %s %s/%s: %v", kind, namespace, name, err)
+		s.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	s.writeJSON(w, revisions)
+}
+
+// handleRollbackWorkload rolls back a Deployment, StatefulSet, or DaemonSet to a previous revision
+func (s *Server) handleRollbackWorkload(w http.ResponseWriter, r *http.Request) {
+	if !s.requireConnected(w) {
+		return
+	}
+
+	kind := chi.URLParam(r, "kind")
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	// Parse request body
+	var req struct {
+		Revision int64 `json:"revision"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	// Validate revision
+	if req.Revision <= 0 {
+		s.writeError(w, http.StatusBadRequest, "revision must be a positive integer")
+		return
+	}
+
+	// Validate that this is a rollbackable workload type
+	validKinds := map[string]bool{
+		"deployments":  true,
+		"statefulsets": true,
+		"daemonsets":   true,
+	}
+	if !validKinds[strings.ToLower(kind)] {
+		s.writeError(w, http.StatusBadRequest, "rollback only available for Deployments, StatefulSets, and DaemonSets")
+		return
+	}
+
+	err := k8s.RollbackWorkload(r.Context(), kind, namespace, name, req.Revision)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			s.writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		if apierrors.IsForbidden(err) {
+			s.writeError(w, http.StatusForbidden, err.Error())
+			return
+		}
+		if strings.Contains(err.Error(), "not found") {
+			s.writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		if strings.Contains(err.Error(), "not supported") {
+			s.writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		log.Printf("[rollback] Failed to rollback %s %s/%s to revision %d: %v", kind, namespace, name, req.Revision, err)
+		s.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	s.writeJSON(w, map[string]string{
+		"message": fmt.Sprintf("Rollback to revision %d initiated", req.Revision),
 	})
 }
 

--- a/internal/topology/relationships.go
+++ b/internal/topology/relationships.go
@@ -131,8 +131,47 @@ func GetRelationships(kind, namespace, name string, topo *Topology) *Relationshi
 		}
 	}
 
+	// Convenience shortcuts: bridge the Deployment↔ReplicaSet↔Pod gap
+	// so users see Pods directly under Deployments and vice versa.
+	kindLower := strings.ToLower(kind)
+
+	// Deployment → show grandchild Pods (Deployment→ReplicaSet→Pod)
+	if kindLower == "deployments" || kindLower == "deployment" {
+		for _, child := range rel.Children {
+			if strings.EqualFold(child.Kind, "ReplicaSet") {
+				childID := buildNodeID(child.Kind, child.Namespace, child.Name)
+				for _, edge := range topo.Edges {
+					if edge.Source == childID && edge.Type == EdgeManages {
+						podRef := parseNodeID(edge.Target)
+						if podRef != nil && strings.EqualFold(podRef.Kind, "Pod") {
+							enrichRef(podRef)
+							rel.Pods = append(rel.Pods, *podRef)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Pod → if owner is a ReplicaSet, also show the grandparent Deployment
+	if kindLower == "pods" || kindLower == "pod" {
+		if rel.Owner != nil && strings.EqualFold(rel.Owner.Kind, "ReplicaSet") {
+			ownerID := buildNodeID(rel.Owner.Kind, rel.Owner.Namespace, rel.Owner.Name)
+			for _, edge := range topo.Edges {
+				if edge.Target == ownerID && edge.Type == EdgeManages {
+					deployRef := parseNodeID(edge.Source)
+					if deployRef != nil && strings.EqualFold(deployRef.Kind, "Deployment") {
+						enrichRef(deployRef)
+						rel.Deployment = deployRef
+						break
+					}
+				}
+			}
+		}
+	}
+
 	// Return nil if no relationships found
-	if rel.Owner == nil && len(rel.Children) == 0 && len(rel.Services) == 0 &&
+	if rel.Owner == nil && rel.Deployment == nil && len(rel.Children) == 0 && len(rel.Services) == 0 &&
 		len(rel.Ingresses) == 0 && len(rel.Gateways) == 0 && len(rel.Routes) == 0 &&
 		len(rel.ConfigRefs) == 0 && len(rel.Consumers) == 0 && len(rel.Scalers) == 0 &&
 		rel.ScaleTarget == nil && len(rel.Pods) == 0 {

--- a/internal/topology/types.go
+++ b/internal/topology/types.go
@@ -178,6 +178,7 @@ type ResourceRef struct {
 // Relationships holds computed relationships for a resource
 type Relationships struct {
 	Owner       *ResourceRef  `json:"owner,omitempty"`       // Parent via ownerReference (manages edge)
+	Deployment  *ResourceRef  `json:"deployment,omitempty"`  // Grandparent Deployment (for Pods owned by ReplicaSets)
 	Children    []ResourceRef `json:"children,omitempty"`    // Resources this owns (manages edge)
 	Services    []ResourceRef `json:"services,omitempty"`    // Services selecting/exposing this
 	Ingresses   []ResourceRef `json:"ingresses,omitempty"`   // Ingresses routing to this

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -977,6 +977,56 @@ export function useScaleWorkload() {
 }
 
 // ============================================================================
+// Workload rollback
+// ============================================================================
+
+// Workload revision history
+export interface WorkloadRevision {
+  number: number
+  createdAt: string
+  image: string
+  isCurrent: boolean
+  replicas: number
+  template?: string // Pod template spec as YAML (for revision diff)
+}
+
+export function useWorkloadRevisions(kind: string, namespace: string, name: string, enabled = true) {
+  return useQuery<WorkloadRevision[]>({
+    queryKey: ['workload-revisions', kind, namespace, name],
+    queryFn: () => fetchJSON(`/workloads/${kind}/${namespace}/${name}/revisions`),
+    enabled: Boolean(kind && namespace && name && enabled),
+  })
+}
+
+export function useRollbackWorkload() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async ({ kind, namespace, name, revision }: { kind: string; namespace: string; name: string; revision: number }) => {
+      const response = await fetch(`${API_BASE}/workloads/${kind}/${namespace}/${name}/rollback`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ revision }),
+      })
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({ error: 'Unknown error' }))
+        throw new Error(error.error || `HTTP ${response.status}`)
+      }
+      return response.json()
+    },
+    meta: {
+      errorMessage: 'Failed to rollback workload',
+      successMessage: 'Rollback initiated',
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['resources', variables.kind] })
+      queryClient.invalidateQueries({ queryKey: ['resource', variables.kind, variables.namespace, variables.name] })
+      queryClient.invalidateQueries({ queryKey: ['workload-revisions', variables.kind, variables.namespace, variables.name] })
+      queryClient.invalidateQueries({ queryKey: ['topology'] })
+    },
+  })
+}
+
+// ============================================================================
 // Helm API hooks
 // ============================================================================
 

--- a/web/src/components/resources/ResourceDetailDrawer.tsx
+++ b/web/src/components/resources/ResourceDetailDrawer.tsx
@@ -17,10 +17,14 @@ import {
   AlertTriangle,
   Box,
   ChevronDown,
+  History,
+  GitCompare,
 } from 'lucide-react'
+import { createTwoFilesPatch } from 'diff'
 import { clsx } from 'clsx'
 import { stringify as yamlStringify } from 'yaml'
-import { useResource, useResourceEvents, useUpdateResource, useDeleteResource, useTriggerCronJob, useSuspendCronJob, useResumeCronJob, useRestartWorkload, useFluxReconcile, useFluxSyncWithSource, useFluxSuspend, useFluxResume, useArgoSync, useArgoRefresh, useArgoSuspend, useArgoResume } from '../../api/client'
+import { useResource, useResourceEvents, useUpdateResource, useDeleteResource, useTriggerCronJob, useSuspendCronJob, useResumeCronJob, useRestartWorkload, useWorkloadRevisions, useRollbackWorkload, useFluxReconcile, useFluxSyncWithSource, useFluxSuspend, useFluxResume, useArgoSync, useArgoRefresh, useArgoSuspend, useArgoResume } from '../../api/client'
+import type { WorkloadRevision } from '../../api/client'
 import { ForceDeleteConfirmDialog } from '../ui/ForceDeleteConfirmDialog'
 import type { SelectedResource, Relationships, ResourceRef } from '../../types'
 import { refToSelectedResource } from '../../utils/navigation'
@@ -486,8 +490,13 @@ function ActionsBar({ resource, data, onClose }: ActionsBarProps) {
   const suspendCronJobMutation = useSuspendCronJob()
   const resumeCronJobMutation = useResumeCronJob()
 
-  // Workload restart mutation
+  // Workload restart and rollback mutations
   const restartWorkloadMutation = useRestartWorkload()
+  const rollbackMutation = useRollbackWorkload()
+  const [showRevisions, setShowRevisions] = useState(false)
+  const isRollbackKind = ['deployments', 'statefulsets', 'daemonsets'].includes(kind)
+  const { data: revisionsList } = useWorkloadRevisions(kind, resource.namespace, resource.name, isRollbackKind)
+  const hasMultipleRevisions = (revisionsList?.length ?? 0) > 1
 
   function handleDeleteConfirm(force: boolean) {
     deleteMutation.mutate(
@@ -605,7 +614,7 @@ function ActionsBar({ resource, data, onClose }: ActionsBarProps) {
         />
       )}
 
-      {/* Workload actions - restart and logs */}
+      {/* Workload actions - restart, rollback, and logs */}
       {['deployments', 'statefulsets', 'daemonsets', 'rollouts'].includes(kind) && (
         <>
           <button
@@ -620,6 +629,22 @@ function ActionsBar({ resource, data, onClose }: ActionsBarProps) {
             <RefreshCw className={`w-3.5 h-3.5 ${restartWorkloadMutation.isPending ? 'animate-spin' : ''}`} />
             {restartWorkloadMutation.isPending ? 'Restarting...' : 'Restart'}
           </button>
+          {isRollbackKind && (
+            <button
+              onClick={() => setShowRevisions(true)}
+              disabled={!hasMultipleRevisions}
+              title={hasMultipleRevisions ? 'View revision history and rollback' : 'Only one revision exists'}
+              className={clsx(
+                "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-colors",
+                hasMultipleRevisions
+                  ? "text-white bg-amber-600 hover:bg-amber-700"
+                  : "text-theme-text-disabled bg-theme-elevated"
+              )}
+            >
+              <History className="w-3.5 h-3.5" />
+              Rollback
+            </button>
+          )}
           {canViewLogs && ['deployments', 'statefulsets', 'daemonsets'].includes(kind) && (
             <button
               onClick={() => openWorkloadLogs({
@@ -721,6 +746,17 @@ function ActionsBar({ resource, data, onClose }: ActionsBarProps) {
         namespaceName={resource.namespace}
         isLoading={deleteMutation.isPending}
       />
+
+      {showRevisions && ['deployments', 'statefulsets', 'daemonsets'].includes(kind) && (
+        <RevisionHistoryDialog
+          kind={resource.kind}
+          namespace={resource.namespace}
+          name={resource.name}
+          open={showRevisions}
+          onClose={() => setShowRevisions(false)}
+          rollbackMutation={rollbackMutation}
+        />
+      )}
     </div>
   )
 }
@@ -887,6 +923,339 @@ function ArgoActions({ resource, data }: ArgoActionsProps) {
         </button>
       )}
     </>
+  )
+}
+
+// ============================================================================
+// REVISION HISTORY DIALOG
+// ============================================================================
+
+interface RevisionHistoryDialogProps {
+  kind: string
+  namespace: string
+  name: string
+  open: boolean
+  onClose: () => void
+  rollbackMutation: ReturnType<typeof useRollbackWorkload>
+}
+
+function RevisionHistoryDialog({ kind, namespace, name, open, onClose, rollbackMutation }: RevisionHistoryDialogProps) {
+  const { data: revisions, isLoading, error } = useWorkloadRevisions(kind, namespace, name, open)
+  const [confirmRevision, setConfirmRevision] = useState<number | null>(null)
+  const [diffRevision, setDiffRevision] = useState<number | null>(null)
+
+  if (!open) return null
+
+  const currentRevision = revisions?.find(r => r.isCurrent)
+  const selectedRevision = revisions?.find(r => r.number === diffRevision)
+  const hasDiffData = currentRevision?.template && selectedRevision?.template
+
+  function handleRollback(revision: number) {
+    rollbackMutation.mutate(
+      { kind, namespace, name, revision },
+      {
+        onSuccess: () => {
+          setConfirmRevision(null)
+          setDiffRevision(null)
+          onClose()
+        },
+      }
+    )
+  }
+
+  function formatTimeAgo(dateStr: string): string {
+    const date = new Date(dateStr)
+    const now = new Date()
+    const seconds = Math.floor((now.getTime() - date.getTime()) / 1000)
+    if (seconds < 60) return `${seconds}s ago`
+    const minutes = Math.floor(seconds / 60)
+    if (minutes < 60) return `${minutes}m ago`
+    const hours = Math.floor(minutes / 60)
+    if (hours < 24) return `${hours}h ago`
+    const days = Math.floor(hours / 24)
+    return `${days}d ago`
+  }
+
+  function getImageTag(image: string): string {
+    if (!image) return '-'
+    const parts = image.split(':')
+    if (parts.length > 1) return parts[parts.length - 1]
+    const slashParts = image.split('/')
+    return slashParts[slashParts.length - 1]
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={rollbackMutation.isPending ? undefined : () => { setDiffRevision(null); onClose() }}
+      />
+
+      {/* Dialog - wider when diff is shown */}
+      <div className={clsx(
+        "relative bg-theme-surface border border-theme-border rounded-lg shadow-2xl mx-4 outline-none flex flex-col",
+        diffRevision ? "max-w-5xl w-full max-h-[85vh]" : "max-w-lg w-full"
+      )}>
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-theme-border shrink-0">
+          <div className="flex items-center gap-2">
+            <History className="w-5 h-5 text-amber-500" />
+            <h3 className="text-lg font-semibold text-theme-text-primary">Revision History</h3>
+            {diffRevision && currentRevision && (
+              <span className="flex items-center gap-1 ml-2 px-2 py-0.5 text-xs bg-blue-500/15 text-blue-400 rounded">
+                <GitCompare className="w-3 h-3" />
+                #{currentRevision.number} vs #{diffRevision}
+              </span>
+            )}
+          </div>
+          <button
+            onClick={() => { setDiffRevision(null); onClose() }}
+            disabled={rollbackMutation.isPending}
+            className="p-1 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded disabled:opacity-50"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+          {/* Revision table */}
+          <div className={clsx("p-4 overflow-y-auto", diffRevision ? "max-h-48 shrink-0" : "max-h-80")}>
+            {isLoading && (
+              <div className="flex items-center justify-center py-8 text-theme-text-secondary text-sm">
+                Loading revisions...
+              </div>
+            )}
+
+            {error && (
+              <div className="flex items-center justify-center py-8 text-red-400 text-sm">
+                Failed to load revisions: {error instanceof Error ? error.message : 'Unknown error'}
+              </div>
+            )}
+
+            {revisions && revisions.length === 0 && (
+              <div className="flex items-center justify-center py-8 text-theme-text-secondary text-sm">
+                No revisions found
+              </div>
+            )}
+
+            {revisions && revisions.length > 0 && (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-theme-text-secondary text-left text-xs uppercase tracking-wider">
+                    <th className="pb-2 pr-3 font-medium">Rev</th>
+                    <th className="pb-2 pr-3 font-medium">Image</th>
+                    <th className="pb-2 pr-3 font-medium">Age</th>
+                    <th className="pb-2 font-medium text-right">Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {revisions.map((rev: WorkloadRevision) => (
+                    <tr
+                      key={rev.number}
+                      className={clsx(
+                        "border-t border-theme-border/50",
+                        diffRevision === rev.number && "bg-blue-500/10"
+                      )}
+                    >
+                      <td className="py-2 pr-3 text-theme-text-primary font-mono">
+                        #{rev.number}
+                      </td>
+                      <td className="py-2 pr-3 text-theme-text-secondary font-mono truncate max-w-[180px]" title={rev.image}>
+                        {getImageTag(rev.image)}
+                      </td>
+                      <td className="py-2 pr-3 text-theme-text-secondary whitespace-nowrap">
+                        {formatTimeAgo(rev.createdAt)}
+                      </td>
+                      <td className="py-2 text-right">
+                        <div className="flex items-center gap-1 justify-end">
+                          {/* Diff button (for non-current revisions with template data) */}
+                          {!rev.isCurrent && rev.template && currentRevision?.template && (
+                            <button
+                              onClick={() => setDiffRevision(diffRevision === rev.number ? null : rev.number)}
+                              className={clsx(
+                                "px-2 py-0.5 text-xs font-medium rounded transition-colors flex items-center gap-1",
+                                diffRevision === rev.number
+                                  ? "bg-blue-500/20 text-blue-400 border border-blue-400/50"
+                                  : "text-blue-400 hover:text-blue-300 hover:bg-blue-500/10 border border-transparent"
+                              )}
+                              title={`Compare with current revision`}
+                            >
+                              <GitCompare className="w-3 h-3" />
+                              Diff
+                            </button>
+                          )}
+                          {rev.isCurrent ? (
+                            <span className="inline-flex items-center px-2 py-0.5 text-xs font-medium bg-green-500/20 text-green-400 rounded">
+                              Current
+                            </span>
+                          ) : confirmRevision === rev.number ? (
+                            <>
+                              <button
+                                onClick={() => handleRollback(rev.number)}
+                                disabled={rollbackMutation.isPending}
+                                className="px-2 py-0.5 text-xs font-medium text-white bg-amber-600 hover:bg-amber-700 rounded transition-colors disabled:opacity-50"
+                              >
+                                {rollbackMutation.isPending ? 'Rolling back...' : 'Confirm'}
+                              </button>
+                              <button
+                                onClick={() => setConfirmRevision(null)}
+                                disabled={rollbackMutation.isPending}
+                                className="px-2 py-0.5 text-xs font-medium text-theme-text-secondary hover:text-theme-text-primary rounded transition-colors disabled:opacity-50"
+                              >
+                                Cancel
+                              </button>
+                            </>
+                          ) : (
+                            <button
+                              onClick={() => setConfirmRevision(rev.number)}
+                              className="px-2 py-0.5 text-xs font-medium text-amber-400 hover:text-white hover:bg-amber-600 border border-amber-400/50 hover:border-amber-600 rounded transition-colors"
+                            >
+                              Rollback
+                            </button>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+
+          {/* Diff viewer */}
+          {diffRevision && hasDiffData && (
+            <RevisionDiffView
+              currentTemplate={currentRevision!.template!}
+              selectedTemplate={selectedRevision!.template!}
+              currentRevision={currentRevision!.number}
+              selectedRevision={diffRevision}
+            />
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end p-4 border-t border-theme-border shrink-0">
+          <button
+            onClick={() => { setDiffRevision(null); onClose() }}
+            disabled={rollbackMutation.isPending}
+            className="px-4 py-2 text-sm font-medium text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded-lg transition-colors disabled:opacity-50"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// REVISION DIFF VIEW
+// ============================================================================
+
+// Strip auto-generated labels that create noise in revision diffs
+function stripAutoLabels(templateYaml: string): string {
+  return templateYaml
+    .split('\n')
+    .filter(line => !line.match(/^\s+pod-template-hash:/))
+    .join('\n')
+}
+
+function RevisionDiffView({ currentTemplate, selectedTemplate, currentRevision, selectedRevision }: {
+  currentTemplate: string
+  selectedTemplate: string
+  currentRevision: number
+  selectedRevision: number
+}) {
+  const [expanded, setExpanded] = useState(false)
+
+  const cleanCurrent = stripAutoLabels(currentTemplate)
+  const cleanSelected = stripAutoLabels(selectedTemplate)
+
+  // Compact: unified diff with 3 lines of context. Expanded: full spec with all context.
+  const patch = createTwoFilesPatch(
+    `Revision #${currentRevision} (current)`,
+    `Revision #${selectedRevision}`,
+    cleanCurrent,
+    cleanSelected,
+    '', '',
+    expanded ? { context: 999999 } : { context: 3 }
+  )
+
+  // Parse patch lines, skip the file header lines
+  const lines = patch.split('\n')
+  const diffLines = lines.filter(line =>
+    !line.startsWith('===') && !line.startsWith('Index:')
+  )
+
+  const hasChanges = diffLines.some(l => (l.startsWith('+') && !l.startsWith('+++')) || (l.startsWith('-') && !l.startsWith('---')))
+
+  return (
+    <div className="border-t border-theme-border flex flex-col shrink-0">
+      <div className="flex items-center justify-between px-4 py-2 bg-theme-elevated/50 text-xs text-theme-text-secondary shrink-0">
+        <div className="flex items-center gap-4">
+          <span className="flex items-center gap-1">
+            <span className="w-3 h-3 bg-red-500/20 border border-red-500/50 rounded" /> Revision #{currentRevision} (current)
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-3 h-3 bg-green-500/20 border border-green-500/50 rounded" /> Revision #{selectedRevision}
+          </span>
+        </div>
+        {hasChanges && (
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="flex items-center gap-1 px-2 py-0.5 text-xs text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded transition-colors"
+          >
+            <Code className="w-3 h-3" />
+            {expanded ? 'Show changes only' : 'Show full spec'}
+          </button>
+        )}
+      </div>
+      <div className="overflow-auto max-h-[400px]">
+        {hasChanges ? (
+          <pre className="text-xs font-mono p-0 m-0">
+            {diffLines.map((line, index) => {
+              const isAddition = line.startsWith('+') && !line.startsWith('+++')
+              const isDeletion = line.startsWith('-') && !line.startsWith('---')
+              const isHeader = line.startsWith('@@') || line.startsWith('---') || line.startsWith('+++')
+
+              return (
+                <div
+                  key={index}
+                  className={clsx(
+                    'flex',
+                    isAddition && 'bg-green-500/10',
+                    isDeletion && 'bg-red-500/10',
+                    isHeader && 'bg-blue-500/10'
+                  )}
+                >
+                  <span className="w-10 shrink-0 text-right pr-2 py-0.5 text-theme-text-disabled select-none border-r border-theme-border/50">
+                    {index + 1}
+                  </span>
+                  <span
+                    className={clsx(
+                      'flex-1 px-3 py-0.5 whitespace-pre',
+                      isAddition && 'text-green-400',
+                      isDeletion && 'text-red-400',
+                      isHeader && 'text-blue-400 font-medium',
+                      !isAddition && !isDeletion && !isHeader && 'text-theme-text-secondary'
+                    )}
+                  >
+                    {line || ' '}
+                  </span>
+                </div>
+              )
+            })}
+          </pre>
+        ) : (
+          <div className="flex flex-col items-center justify-center py-12 text-theme-text-tertiary">
+            <GitCompare className="w-8 h-8 mb-2 text-theme-text-disabled" />
+            <span className="text-sm">Templates are identical</span>
+          </div>
+        )}
+      </div>
+    </div>
   )
 }
 

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -22,6 +22,8 @@ import {
   Columns3,
   RotateCcw,
   Pin,
+  Trash2,
+  Tag,
 } from 'lucide-react'
 import { clsx } from 'clsx'
 import type { SelectedResource, APIResource } from '../../types'
@@ -1668,7 +1670,7 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
       result = result.filter((r: any) => isReplicaSetActive(r))
     }
 
-    // Apply label selector filter (e.g., "app=caretta,version=v1")
+    // Apply label selector filter (e.g., "app=caretta,version=v1") — OR logic: matches ANY selected label
     if (labelSelector) {
       const labelPairs = labelSelector.split(',').map(pair => {
         const [key, value] = pair.split('=')
@@ -1677,7 +1679,7 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
 
       result = result.filter((r: any) => {
         const labels = r.metadata?.labels || {}
-        return labelPairs.every(({ key, value }) => labels[key] === value)
+        return labelPairs.some(({ key, value }) => labels[key] === value)
       })
     }
 
@@ -1999,13 +2001,25 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
       }
     }
 
-    if (filterableColumns.length === 0 && !problems) {
-      console.debug('[filters] filterOptions: no filterable columns detected for', kindLower)
-      return null
+    // Compute available labels for label filtering
+    const labelCounts: Record<string, number> = {}
+    for (const r of resources) {
+      const labels = r.metadata?.labels || {}
+      for (const [key, value] of Object.entries(labels)) {
+        // Skip internal/noisy labels
+        if (key.includes('pod-template-hash') || key.includes('controller-revision-hash')) continue
+        const pair = `${key}=${value}`
+        labelCounts[pair] = (labelCounts[pair] || 0) + 1
+      }
     }
+    const labelValues = Object.entries(labelCounts)
+      .map(([pair, count]) => ({ value: pair, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 30) // cap at 30 most common labels
 
-    console.debug('[filters] filterOptions:', { kind: kindLower, columns: filterableColumns.map(c => `${c.label}(${c.values.length} vals)`), hasProblems: !!problems })
-    return { columns: filterableColumns, problems }
+    console.debug('[filters] filterOptions:', { kind: kindLower, columns: filterableColumns.map(c => `${c.label}(${c.values.length} vals)`), hasProblems: !!problems, labels: labelValues.length })
+    if (filterableColumns.length === 0 && !problems && labelValues.length === 0) return null
+    return { columns: filterableColumns, problems, labels: labelValues }
   }, [resources, selectedKind.name])
 
   // Compute inactive ReplicaSet count for toggle display
@@ -2044,6 +2058,32 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
         : [...prev, problem]
     )
   }, [])
+
+  // Toggle a label pair in the label selector (e.g., "app=nginx")
+  const toggleLabelFilter = useCallback((pair: string) => {
+    setLabelSelector(prev => {
+      const existing = prev ? prev.split(',').filter(Boolean) : []
+      const newLabels = existing.includes(pair)
+        ? existing.filter(p => p !== pair)
+        : [...existing, pair]
+      const newSelector = newLabels.join(',')
+      // Sync to URL
+      const params = new URLSearchParams(window.location.search)
+      if (newSelector) {
+        params.set('labels', newSelector)
+      } else {
+        params.delete('labels')
+      }
+      window.history.replaceState({}, '', `${window.location.pathname}?${params.toString()}`)
+      return newSelector
+    })
+  }, [])
+
+  // Parse active label pairs for display
+  const activeLabelPairs = useMemo(() => {
+    if (!labelSelector) return []
+    return labelSelector.split(',').filter(Boolean)
+  }, [labelSelector])
 
   return (
     <div className="flex h-full w-full">
@@ -2268,7 +2308,7 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
                 <span>Filter</span>
                 {hasActiveFilters && (
                   <span className="px-1.5 py-0.5 text-xs bg-blue-500/30 text-blue-700 dark:text-blue-300 rounded">
-                    {Object.values(columnFilters).filter(v => v).length + problemFilters.length}
+                    {Object.values(columnFilters).filter(v => v).length + problemFilters.length + activeLabelPairs.length}
                   </span>
                 )}
               </button>
@@ -2287,7 +2327,7 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
                     )}
                   </div>
 
-                  <div className="p-3 space-y-4 max-h-80 overflow-y-auto">
+                  <div className="p-3 space-y-4 max-h-[28rem] overflow-y-auto">
                     {/* Generic column filters */}
                     {filterOptions.columns.map(({ key, label, values }) => (
                       <div key={key}>
@@ -2345,6 +2385,34 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
                         </div>
                       </div>
                     )}
+
+                    {/* Label filter (multi-select) */}
+                    {filterOptions.labels && filterOptions.labels.length > 0 && (
+                      <div>
+                        <label className="text-xs font-medium text-theme-text-secondary uppercase tracking-wide mb-2 block">
+                          <span className="flex items-center gap-1">
+                            <Tag className="w-3 h-3" />
+                            Labels
+                          </span>
+                        </label>
+                        <div className="flex flex-wrap gap-1.5">
+                          {filterOptions.labels.map(({ value, count }) => (
+                            <button
+                              key={value}
+                              onClick={() => toggleLabelFilter(value)}
+                              className={clsx(
+                                'px-2 py-1 text-xs rounded transition-colors',
+                                activeLabelPairs.includes(value)
+                                  ? 'bg-green-500/30 text-green-700 dark:text-green-300'
+                                  : 'bg-theme-elevated text-theme-text-secondary hover:text-theme-text-primary'
+                              )}
+                            >
+                              {value} ({count})
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    )}
                   </div>
                 </div>
               )}
@@ -2383,6 +2451,15 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
                 <span key={p} className="flex items-center gap-1 px-2 py-1 text-xs bg-red-500/20 text-red-700 dark:text-red-300 rounded">
                   {p}
                   <button onClick={() => toggleProblemFilter(p)} className="hover:text-theme-text-primary">
+                    <X className="w-3 h-3" />
+                  </button>
+                </span>
+              ))}
+              {activeLabelPairs.map(pair => (
+                <span key={pair} className="flex items-center gap-1 px-2 py-1 text-xs bg-green-500/20 text-green-700 dark:text-green-300 rounded">
+                  <Tag className="w-3 h-3" />
+                  {pair}
+                  <button onClick={() => toggleLabelFilter(pair)} className="hover:text-theme-text-primary">
                     <X className="w-3 h-3" />
                   </button>
                 </span>
@@ -2699,12 +2776,23 @@ function CellContent({ resource, kind, column }: CellContentProps) {
 
   // Common columns
   if (column === 'name') {
+    const isTerminating = !!meta.deletionTimestamp
     return (
-      <Tooltip content={meta.name}>
-        <span className="text-sm text-theme-text-primary font-medium truncate block">
-          {meta.name}
-        </span>
-      </Tooltip>
+      <div className="flex items-center gap-1.5 min-w-0">
+        <Tooltip content={meta.name}>
+          <span className={clsx('text-sm font-medium truncate block', isTerminating ? 'text-theme-text-tertiary line-through' : 'text-theme-text-primary')}>
+            {meta.name}
+          </span>
+        </Tooltip>
+        {isTerminating && (
+          <Tooltip content="Resource is being deleted (has deletionTimestamp set). May be stuck due to finalizers.">
+            <span className="shrink-0 flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium bg-red-500/15 text-red-600 dark:text-red-400 rounded">
+              <Trash2 className="w-3 h-3" />
+              Terminating
+            </span>
+          </Tooltip>
+        )}
+      </div>
     )
   }
   if (column === 'namespace') {

--- a/web/src/components/resources/drawer-components.tsx
+++ b/web/src/components/resources/drawer-components.tsx
@@ -380,6 +380,7 @@ export function RelatedResourcesSection({ relationships, onNavigate }: RelatedRe
 
   const hasRelationships =
     relationships.owner ||
+    relationships.deployment ||
     (relationships.children && relationships.children.length > 0) ||
     (relationships.services && relationships.services.length > 0) ||
     (relationships.ingresses && relationships.ingresses.length > 0) ||
@@ -398,6 +399,9 @@ export function RelatedResourcesSection({ relationships, onNavigate }: RelatedRe
       <div className="space-y-3">
         {relationships.owner && (
           <RelationshipGroup label="Owner" refs={[relationships.owner]} onNavigate={onNavigate} />
+        )}
+        {relationships.deployment && (
+          <RelationshipGroup label="Deployment" refs={[relationships.deployment]} onNavigate={onNavigate} />
         )}
         {relationships.children && relationships.children.length > 0 && (
           <RelationshipGroup label="Children" refs={dedupeRefs(relationships.children)} onNavigate={onNavigate} />

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -305,6 +305,7 @@ export interface ResourceRef {
 // Computed relationships for a resource
 export interface Relationships {
   owner?: ResourceRef
+  deployment?: ResourceRef   // Grandparent Deployment (for Pods owned by ReplicaSets)
   children?: ResourceRef[]
   services?: ResourceRef[]
   ingresses?: ResourceRef[]


### PR DESCRIPTION
## Summary

Four usability improvements for resource browsing and workload management:

- **Label-based filtering UI** — Exposes the existing label filter infrastructure as a visible UI component in the resource list toolbar. Auto-suggests labels from visible resources, supports multi-select with OR logic, syncs to URL params, and filters out noisy internal labels (pod-template-hash, controller-revision-hash).

- **Workload rollback (kubectl rollout undo)** — Full revision history and rollback for Deployments, StatefulSets, and DaemonSets. Backend lists revisions via ReplicaSet owner references (Deployments) or ControllerRevisions (StatefulSets/DaemonSets). Frontend shows a revision history dialog with unified diff view between any revision and current, expand/collapse toggle, and confirmation before rollback. Rollback button is disabled when only one revision exists.

- **Pending deletion indicator** — Shows a trash icon and "Deleting" badge on resources that have `deletionTimestamp` set, making stuck deletions (finalizer issues) immediately visible in resource lists.

- **Deployment↔Pod relationship shortcuts** — Adds direct navigation between Pods and their grandparent Deployment, skipping the intermediate ReplicaSet. Topology edges use `SkipIfKindVisible` so shortcuts only render when ReplicaSets are hidden.

## Changes

**Backend (Go):**
- `internal/k8s/update.go` — `ListWorkloadRevisions()`, `RollbackWorkload()`, revision parsing for both ReplicaSet-based and ControllerRevision-based workloads
- `internal/server/server.go` — Two new routes (`GET .../revisions`, `POST .../rollback`) with handlers
- `internal/topology/relationships.go` — Deployment↔Pod grandparent/grandchild traversal
- `internal/topology/types.go` — `Deployment` field on `Relationships` struct

**Frontend (React/TypeScript):**
- `web/src/components/resources/ResourcesView.tsx` — Label filter UI, pending deletion indicator
- `web/src/components/resources/ResourceDetailDrawer.tsx` — Revision history dialog, diff viewer, rollback button
- `web/src/api/client.ts` — `useWorkloadRevisions` query hook, `rollbackWorkload` mutation
- `web/src/components/resources/drawer-components.tsx` — Deployment relationship rendering
- `web/src/types.ts` — `deployment` field on `Relationships` interface