### PR TITLE
feat: inline secret data editing

### DIFF
--- a/internal/k8s/capabilities.go
+++ b/internal/k8s/capabilities.go
@@ -49,13 +49,14 @@ type PermissionCheckResult struct {
 
 // Capabilities represents the features available based on RBAC permissions
 type Capabilities struct {
-	Exec        bool                 `json:"exec"`                // Can create pods/exec (terminal feature)
-	Logs        bool                 `json:"logs"`                // Can get pods/log (log viewer)
-	PortForward bool                 `json:"portForward"`         // Can create pods/portforward
-	Secrets     bool                 `json:"secrets"`             // Can list secrets
-	HelmWrite   bool                 `json:"helmWrite"`           // Helm write ops (detected via secrets/create as sentinel RBAC check)
-	MCPEnabled  bool                 `json:"mcpEnabled"`          // MCP server is running
-	Resources   *ResourcePermissions `json:"resources,omitempty"` // Per-resource-type permissions
+	Exec          bool                 `json:"exec"`                // Can create pods/exec (terminal feature)
+	Logs          bool                 `json:"logs"`                // Can get pods/log (log viewer)
+	PortForward   bool                 `json:"portForward"`         // Can create pods/portforward
+	Secrets       bool                 `json:"secrets"`             // Can list secrets
+	SecretsUpdate bool                 `json:"secretsUpdate"`       // Can update secrets (inline editing)
+	HelmWrite     bool                 `json:"helmWrite"`           // Helm write ops (detected via secrets/create as sentinel RBAC check)
+	MCPEnabled    bool                 `json:"mcpEnabled"`          // MCP server is running
+	Resources     *ResourcePermissions `json:"resources,omitempty"` // Per-resource-type permissions
 }
 
 var (
@@ -94,7 +95,7 @@ func CheckCapabilities(ctx context.Context) (*Capabilities, error) {
 	if GetClient() == nil {
 		// Return all false if client not initialized (fail closed)
 		log.Printf("Warning: K8s client not initialized, returning restricted capabilities")
-		return &Capabilities{Exec: false, Logs: false, PortForward: false, Secrets: false, HelmWrite: false}, nil
+		return &Capabilities{Exec: false, Logs: false, PortForward: false, Secrets: false, SecretsUpdate: false, HelmWrite: false}, nil
 	}
 
 	// Use a background context so that HTTP request cancellation doesn't cause
@@ -120,6 +121,7 @@ func CheckCapabilities(ctx context.Context) (*Capabilities, error) {
 		{"pods/log", "get", &caps.Logs},
 		{"pods/portforward", "create", &caps.PortForward},
 		{"secrets", "list", &caps.Secrets},
+		{"secrets", "update", &caps.SecretsUpdate},
 		{"secrets", "create", &caps.HelmWrite},
 	}
 

--- a/web/src/components/resources/ResourceDetailDrawer.tsx
+++ b/web/src/components/resources/ResourceDetailDrawer.tsx
@@ -134,7 +134,7 @@ import {
 } from './renderers'
 import { useOpenTerminal, useOpenLogs, useOpenWorkloadLogs } from '../dock'
 import { PortForwardButton } from '../portforward/PortForwardButton'
-import { useCanExec, useCanViewLogs, useCanPortForward } from '../../contexts/CapabilitiesContext'
+import { useCanExec, useCanViewLogs, useCanPortForward, useCanUpdateSecrets } from '../../contexts/CapabilitiesContext'
 import { useToast } from '../ui/Toast'
 import { CodeViewer } from '../ui/CodeViewer'
 import { YamlEditor } from '../ui/YamlEditor'
@@ -308,6 +308,24 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate }: Resource
     setYamlErrors(errors)
   }, [])
 
+  // RBAC: check if user can update secrets (hides inline edit buttons when denied)
+  const canUpdateSecrets = useCanUpdateSecrets()
+
+  // Save a single secret value inline (used by SecretRenderer)
+  const handleSaveSecretValue = useCallback(async (yaml: string) => {
+    try {
+      await updateResource.mutateAsync({
+        kind: resource.kind,
+        namespace: resource.namespace,
+        name: resource.name,
+        yaml,
+      })
+      setTimeout(() => refetch(), 1000)
+    } catch {
+      // Error is handled by the mutation (toast)
+    }
+  }, [updateResource, resource, refetch])
+
   const headerHeight = 49
 
   return (
@@ -373,6 +391,8 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate }: Resource
             onCopy={copyToClipboard}
             copied={copied}
             onNavigate={handleNavigateToRelated}
+            onSaveSecretValue={canUpdateSecrets ? handleSaveSecretValue : undefined}
+            isSavingSecret={updateResource.isPending}
           />
         )}
       </div>
@@ -1534,9 +1554,11 @@ interface ResourceContentProps {
   onCopy: (text: string, key: string) => void
   copied: string | null
   onNavigate?: (ref: ResourceRef) => void
+  onSaveSecretValue?: (yaml: string) => Promise<void>
+  isSavingSecret?: boolean
 }
 
-function ResourceContent({ resource, data, relationships, certificateInfo, onCopy, copied, onNavigate }: ResourceContentProps) {
+function ResourceContent({ resource, data, relationships, certificateInfo, onCopy, copied, onNavigate, onSaveSecretValue, isSavingSecret }: ResourceContentProps) {
   const kind = resource.kind.toLowerCase()
 
   // Fetch events for this resource
@@ -1577,7 +1599,7 @@ function ResourceContent({ resource, data, relationships, certificateInfo, onCop
       {kind === 'services' && <ServiceRenderer data={data} onCopy={onCopy} copied={copied} />}
       {kind === 'ingresses' && <IngressRenderer data={data} onNavigate={onNavigate} />}
       {kind === 'configmaps' && <ConfigMapRenderer data={data} />}
-      {kind === 'secrets' && <SecretRenderer data={data} certificateInfo={certificateInfo} />}
+      {kind === 'secrets' && <SecretRenderer data={data} certificateInfo={certificateInfo} resourceData={data} onSaveSecretValue={onSaveSecretValue} isSaving={isSavingSecret} />}
       {kind === 'jobs' && <JobRenderer data={data} />}
       {kind === 'cronjobs' && <CronJobRenderer data={data} onNavigate={onNavigate} />}
       {(kind === 'hpas' || kind === 'horizontalpodautoscalers') && <HPARenderer data={data} onNavigate={onNavigate} />}

--- a/web/src/components/resources/renderers/SecretRenderer.tsx
+++ b/web/src/components/resources/renderers/SecretRenderer.tsx
@@ -1,12 +1,17 @@
-import { useState } from 'react'
-import { AlertTriangle, Copy, Check, Shield } from 'lucide-react'
+import { useState, useCallback, useRef, useEffect } from 'react'
+import { AlertTriangle, Copy, Check, Shield, Pencil, Save, XCircle, RefreshCw } from 'lucide-react'
 import { clsx } from 'clsx'
+import { stringify as yamlStringify } from 'yaml'
 import { Section, PropertyList, Property, AlertBanner } from '../drawer-components'
+import { ConfirmDialog } from '../../ui/ConfirmDialog'
 import type { SecretCertificateInfo, CertificateInfo } from '../../../types'
 
 interface SecretRendererProps {
   data: any
   certificateInfo?: SecretCertificateInfo
+  resourceData?: any
+  onSaveSecretValue?: (yaml: string) => Promise<void>
+  isSaving?: boolean
 }
 
 function formatDate(dateStr: string): string {
@@ -15,10 +20,15 @@ function formatDate(dateStr: string): string {
   return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
 }
 
-export function SecretRenderer({ data, certificateInfo }: SecretRendererProps) {
+export function SecretRenderer({ data, certificateInfo, resourceData, onSaveSecretValue, isSaving }: SecretRendererProps) {
   const [revealed, setRevealed] = useState<Set<string>>(new Set())
   const [copied, setCopied] = useState<string | null>(null)
+  const [editingKey, setEditingKey] = useState<string | null>(null)
+  const [editValue, setEditValue] = useState('')
+  const [showSaveConfirm, setShowSaveConfirm] = useState(false)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
   const dataKeys = Object.keys(data.data || {})
+  const isImmutable = data.immutable === true
 
   function toggleReveal(key: string) {
     setRevealed(prev => {
@@ -30,7 +40,7 @@ export function SecretRenderer({ data, certificateInfo }: SecretRendererProps) {
 
   function decodeBase64(value: string): string {
     try {
-      return atob(value)
+      return decodeURIComponent(escape(atob(value)))
     } catch {
       return '[binary data]'
     }
@@ -45,6 +55,50 @@ export function SecretRenderer({ data, certificateInfo }: SecretRendererProps) {
       console.error('Failed to copy:', err)
     }
   }
+
+  function startEdit(key: string, decoded: string) {
+    setEditingKey(key)
+    setEditValue(decoded)
+  }
+
+  function cancelEdit() {
+    setEditingKey(null)
+    setEditValue('')
+    setShowSaveConfirm(false)
+  }
+
+  const handleSave = useCallback(async (key: string, newValue: string) => {
+    if (!onSaveSecretValue || !resourceData) return
+    const cleaned = structuredClone(resourceData)
+    delete cleaned.status
+    if (cleaned.metadata) {
+      delete cleaned.metadata.managedFields
+      delete cleaned.metadata.resourceVersion
+      delete cleaned.metadata.uid
+      delete cleaned.metadata.creationTimestamp
+      delete cleaned.metadata.generation
+    }
+    // Encode with UTF-8 support
+    cleaned.data[key] = btoa(unescape(encodeURIComponent(newValue)))
+    const yaml = yamlStringify(cleaned, { lineWidth: 0, indent: 2 })
+    try {
+      await onSaveSecretValue(yaml)
+      setEditingKey(null)
+      setEditValue('')
+      setShowSaveConfirm(false)
+    } catch {
+      // Error is handled by the mutation (toast)
+      setShowSaveConfirm(false)
+    }
+  }, [onSaveSecretValue, resourceData])
+
+  // Auto-resize textarea
+  useEffect(() => {
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto'
+      textareaRef.current.style.height = textareaRef.current.scrollHeight + 'px'
+    }
+  }, [editValue])
 
   const certs = certificateInfo?.certificates
   const leafCert = certs?.[0]
@@ -103,13 +157,24 @@ export function SecretRenderer({ data, certificateInfo }: SecretRendererProps) {
           {dataKeys.map((key) => {
             const decoded = decodeBase64(data.data[key])
             const isBinary = decoded === '[binary data]'
+            const isEditing = editingKey === key
+            const canEdit = onSaveSecretValue && !isImmutable && !isBinary
 
             return (
               <div key={key} className="bg-theme-elevated/30 rounded p-2">
                 <div className="flex items-center justify-between gap-2">
                   <span className="text-sm text-theme-text-primary truncate">{key}</span>
                   <div className="flex items-center gap-1 shrink-0">
-                    {revealed.has(key) && !isBinary && (
+                    {revealed.has(key) && !isBinary && !isEditing && canEdit && (
+                      <button
+                        onClick={() => startEdit(key, decoded)}
+                        className="p-1 text-theme-text-tertiary hover:text-blue-400 transition-colors"
+                        title="Edit value"
+                      >
+                        <Pencil className="w-3.5 h-3.5" />
+                      </button>
+                    )}
+                    {revealed.has(key) && !isBinary && !isEditing && (
                       <button
                         onClick={() => copyValue(key, decoded)}
                         className="p-1 text-theme-text-tertiary hover:text-theme-text-primary transition-colors"
@@ -122,19 +187,54 @@ export function SecretRenderer({ data, certificateInfo }: SecretRendererProps) {
                         )}
                       </button>
                     )}
-                    <button
-                      onClick={() => toggleReveal(key)}
-                      className="text-xs text-theme-text-secondary hover:text-theme-text-primary px-1.5 py-0.5 rounded hover:bg-theme-elevated transition-colors"
-                    >
-                      {revealed.has(key) ? 'Hide' : 'Reveal'}
-                    </button>
+                    {!isEditing && (
+                      <button
+                        onClick={() => toggleReveal(key)}
+                        className="text-xs text-theme-text-secondary hover:text-theme-text-primary px-1.5 py-0.5 rounded hover:bg-theme-elevated transition-colors"
+                      >
+                        {revealed.has(key) ? 'Hide' : 'Reveal'}
+                      </button>
+                    )}
                   </div>
                 </div>
-                {revealed.has(key) && (
+                {isEditing ? (
+                  <div className="mt-2">
+                    <textarea
+                      ref={textareaRef}
+                      value={editValue}
+                      onChange={(e) => setEditValue(e.target.value)}
+                      className="w-full bg-theme-base rounded p-2 text-xs text-theme-text-secondary font-mono border border-blue-500/50 focus:border-blue-500 focus:outline-none resize-none overflow-hidden whitespace-pre-wrap"
+                      style={{ minHeight: '60px' }}
+                      disabled={isSaving}
+                    />
+                    <div className="flex items-center gap-2 mt-2">
+                      <button
+                        onClick={() => setShowSaveConfirm(true)}
+                        disabled={isSaving}
+                        className="flex items-center gap-1 px-2.5 py-1 text-xs text-white bg-blue-600 hover:bg-blue-700 rounded transition-colors disabled:opacity-50"
+                      >
+                        {isSaving ? (
+                          <RefreshCw className="w-3 h-3 animate-spin" />
+                        ) : (
+                          <Save className="w-3 h-3" />
+                        )}
+                        {isSaving ? 'Saving...' : 'Save'}
+                      </button>
+                      <button
+                        onClick={cancelEdit}
+                        disabled={isSaving}
+                        className="flex items-center gap-1 px-2.5 py-1 text-xs text-theme-text-secondary hover:text-theme-text-primary rounded hover:bg-theme-elevated transition-colors disabled:opacity-50"
+                      >
+                        <XCircle className="w-3 h-3" />
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : revealed.has(key) ? (
                   <pre className="mt-2 bg-theme-base rounded p-2 text-xs text-theme-text-secondary overflow-x-auto max-h-40 whitespace-pre-wrap">
                     {decoded}
                   </pre>
-                )}
+                ) : null}
               </div>
             )
           })}
@@ -148,6 +248,20 @@ export function SecretRenderer({ data, certificateInfo }: SecretRendererProps) {
         <AlertTriangle className="w-4 h-4" />
         Secret values are sensitive. Be careful when revealing.
       </div>
+
+      {editingKey && (
+        <ConfirmDialog
+          open={showSaveConfirm}
+          onClose={() => setShowSaveConfirm(false)}
+          onConfirm={() => handleSave(editingKey, editValue)}
+          title="Update Secret"
+          message={`Update key "${editingKey}" in secret "${data.metadata?.name || 'unknown'}"?`}
+          details="This will modify the secret value in the cluster immediately."
+          confirmLabel="Update"
+          variant="warning"
+          isLoading={isSaving}
+        />
+      )}
     </>
   )
 }

--- a/web/src/contexts/CapabilitiesContext.tsx
+++ b/web/src/contexts/CapabilitiesContext.tsx
@@ -8,6 +8,7 @@ const defaultCapabilities: Capabilities = {
   logs: true,
   portForward: true,
   secrets: true,
+  secretsUpdate: true,
   helmWrite: true,
   mcpEnabled: true,
 }
@@ -18,6 +19,7 @@ const restrictedCapabilities: Capabilities = {
   logs: false,
   portForward: false,
   secrets: false,
+  secretsUpdate: false,
   helmWrite: false,
   mcpEnabled: false,
 }
@@ -69,6 +71,10 @@ export function useCanPortForward(): boolean {
 
 export function useCanViewSecrets(): boolean {
   return useContext(CapabilitiesContext).secrets
+}
+
+export function useCanUpdateSecrets(): boolean {
+  return useContext(CapabilitiesContext).secretsUpdate
 }
 
 export function useCanHelmWrite(): boolean {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -24,12 +24,13 @@ export interface ResourcePermissions {
 
 // Feature capabilities based on RBAC permissions
 export interface Capabilities {
-  exec: boolean        // Terminal feature (pods/exec)
-  logs: boolean        // Log viewer (pods/log)
-  portForward: boolean // Port forwarding (pods/portforward)
-  secrets: boolean     // List secrets
-  helmWrite: boolean   // Helm write operations (install, upgrade, rollback, uninstall, apply values)
-  mcpEnabled: boolean  // MCP server is running
+  exec: boolean           // Terminal feature (pods/exec)
+  logs: boolean           // Log viewer (pods/log)
+  portForward: boolean    // Port forwarding (pods/portforward)
+  secrets: boolean        // List secrets
+  secretsUpdate: boolean  // Update secrets (inline editing)
+  helmWrite: boolean      // Helm write operations (install, upgrade, rollback, uninstall, apply values)
+  mcpEnabled: boolean     // MCP server is running
   resources?: ResourcePermissions // Per-resource-type permissions
 }
 


### PR DESCRIPTION
## Summary

Adds inline editing of individual secret data keys directly in the Secret detail drawer, so users don't have to switch to full YAML mode and manually base64-encode values.

- Per-key Edit button (pencil icon) appears when a value is revealed
- Edits decoded plaintext in a textarea, auto-encodes to base64 on save
- Confirmation dialog before applying changes (consistent with Helm rollback/upgrade UX)
- RBAC-aware: checks `secrets/update` permission via `secretsUpdate` capability — edit buttons are hidden when the user lacks permission
- Graceful degradation: no edit buttons for immutable secrets or binary data

Closes #179

<img width="670" height="271" alt="image" src="https://github.com/user-attachments/assets/86a0ec43-cd6a-49bd-8142-b832df1dd2c9" />
<img width="642" height="198" alt="image" src="https://github.com/user-attachments/assets/adf2077c-8d7c-4723-9dcb-8a7c9e0ae476" />
<img width="572" height="436" alt="image" src="https://github.com/user-attachments/assets/a6d90dbe-9a13-4e62-81a9-718b1d1a565c" />
