### PR TITLE
feat: node health detection + MCP/REST dashboard convergence

### DIFF
--- a/internal/ai/context/summary.go
+++ b/internal/ai/context/summary.go
@@ -37,7 +37,8 @@ type ResourceSummary struct {
 	Strategy    string   `json:"strategy,omitempty"`
 	Completions string   `json:"completions,omitempty"`
 	Duration    string   `json:"duration,omitempty"`
-	Suspended   *bool    `json:"suspended,omitempty"`
+	Suspended     *bool    `json:"suspended,omitempty"`
+	Unschedulable *bool    `json:"unschedulable,omitempty"`
 	Active      int      `json:"active,omitempty"`
 	Target      string   `json:"target,omitempty"`
 	MinReplicas *int32   `json:"minReplicas,omitempty"`
@@ -370,6 +371,17 @@ func summarizeNode(node *corev1.Node) *ResourceSummary {
 			case corev1.NodePIDPressure:
 				s.Pressures = append(s.Pressures, "PIDPressure")
 			}
+		}
+	}
+
+	// Cordoned/unschedulable status
+	if node.Spec.Unschedulable {
+		unschedulable := true
+		s.Unschedulable = &unschedulable
+		if s.Status != "" {
+			s.Status += ",SchedulingDisabled"
+		} else {
+			s.Status = "SchedulingDisabled"
 		}
 	}
 

--- a/internal/k8s/health.go
+++ b/internal/k8s/health.go
@@ -1,0 +1,243 @@
+package k8s
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ClassifyPodHealth determines if a pod is "healthy", "warning", or "error".
+// This is the canonical implementation used by both MCP and REST dashboards.
+func ClassifyPodHealth(pod *corev1.Pod, now time.Time) string {
+	if pod.Status.Phase == corev1.PodSucceeded {
+		return "healthy"
+	}
+	if pod.Status.Phase == corev1.PodFailed {
+		return "error"
+	}
+
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.State.Waiting != nil {
+			reason := cs.State.Waiting.Reason
+			if reason == "CrashLoopBackOff" || reason == "ImagePullBackOff" || reason == "ErrImagePull" || reason == "CreateContainerConfigError" {
+				return "error"
+			}
+		}
+		if cs.State.Terminated != nil && cs.State.Terminated.Reason == "OOMKilled" {
+			return "error"
+		}
+		if cs.LastTerminationState.Terminated != nil && cs.LastTerminationState.Terminated.Reason == "OOMKilled" {
+			return "error"
+		}
+	}
+
+	// Init container errors
+	for _, cs := range pod.Status.InitContainerStatuses {
+		if cs.State.Waiting != nil {
+			reason := cs.State.Waiting.Reason
+			if reason == "CrashLoopBackOff" || reason == "ImagePullBackOff" || reason == "ErrImagePull" {
+				return "error"
+			}
+		}
+	}
+
+	// Warning: pods pending for more than 5 minutes
+	if pod.Status.Phase == corev1.PodPending {
+		if now.Sub(pod.CreationTimestamp.Time) > 5*time.Minute {
+			return "warning"
+		}
+		return "healthy"
+	}
+
+	// Warning: pods with high restart counts
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.RestartCount > 3 {
+			return "warning"
+		}
+	}
+
+	return "healthy"
+}
+
+// PodProblemReason returns a short reason string for a problematic pod.
+func PodProblemReason(pod *corev1.Pod) string {
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.State.Waiting != nil && cs.State.Waiting.Reason != "" {
+			return cs.State.Waiting.Reason
+		}
+		if cs.State.Terminated != nil && cs.State.Terminated.Reason != "" {
+			return cs.State.Terminated.Reason
+		}
+	}
+	return string(pod.Status.Phase)
+}
+
+// NodeHealth describes the health of a single node.
+type NodeHealth struct {
+	Ready         bool
+	Unschedulable bool
+	Pressures     []string // "MemoryPressure", "DiskPressure", "PIDPressure"
+	Version       string   // kubelet version
+	Reason        string   // condition message if NotReady
+}
+
+// ClassifyNodeHealth evaluates a node's conditions and spec.
+func ClassifyNodeHealth(node *corev1.Node) NodeHealth {
+	h := NodeHealth{
+		Unschedulable: node.Spec.Unschedulable,
+		Version:       node.Status.NodeInfo.KubeletVersion,
+	}
+
+	for _, cond := range node.Status.Conditions {
+		switch cond.Type {
+		case corev1.NodeReady:
+			h.Ready = cond.Status == corev1.ConditionTrue
+			if !h.Ready && cond.Message != "" {
+				h.Reason = cond.Message
+			}
+		case corev1.NodeMemoryPressure:
+			if cond.Status == corev1.ConditionTrue {
+				h.Pressures = append(h.Pressures, "MemoryPressure")
+			}
+		case corev1.NodeDiskPressure:
+			if cond.Status == corev1.ConditionTrue {
+				h.Pressures = append(h.Pressures, "DiskPressure")
+			}
+		case corev1.NodePIDPressure:
+			if cond.Status == corev1.ConditionTrue {
+				h.Pressures = append(h.Pressures, "PIDPressure")
+			}
+		}
+	}
+
+	return h
+}
+
+// NodeProblem describes a detected problem on a node.
+type NodeProblem struct {
+	NodeName string `json:"nodeName"`
+	Problem  string `json:"problem"`
+	Reason   string `json:"reason,omitempty"`
+	Severity string `json:"severity"` // "error" or "warning"
+}
+
+// DetectNodeProblems scans nodes for NotReady, Cordoned, and pressure conditions.
+func DetectNodeProblems(nodes []*corev1.Node) []NodeProblem {
+	var problems []NodeProblem
+
+	for _, node := range nodes {
+		h := ClassifyNodeHealth(node)
+
+		if !h.Ready {
+			reason := "NotReady"
+			if h.Reason != "" {
+				reason = h.Reason
+			}
+			problems = append(problems, NodeProblem{
+				NodeName: node.Name,
+				Problem:  "NotReady",
+				Reason:   reason,
+				Severity: "error",
+			})
+		} else if h.Unschedulable {
+			problems = append(problems, NodeProblem{
+				NodeName: node.Name,
+				Problem:  "Cordoned",
+				Reason:   "SchedulingDisabled",
+				Severity: "warning",
+			})
+		}
+
+		for _, pressure := range h.Pressures {
+			problems = append(problems, NodeProblem{
+				NodeName: node.Name,
+				Problem:  pressure,
+				Reason:   pressure,
+				Severity: "warning",
+			})
+		}
+	}
+
+	return problems
+}
+
+// VersionSkew describes a detected minor version skew across cluster nodes.
+type VersionSkew struct {
+	Versions   map[string][]string `json:"versions"`   // minor version -> node names
+	MinVersion string              `json:"minVersion"`
+	MaxVersion string              `json:"maxVersion"`
+}
+
+// DetectVersionSkew checks for minor version differences across nodes.
+// Returns nil if all nodes are on the same minor version (patch-only differences are normal).
+func DetectVersionSkew(nodes []*corev1.Node) *VersionSkew {
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	versions := make(map[string][]string) // minor version -> node names
+	for _, node := range nodes {
+		ver := node.Status.NodeInfo.KubeletVersion
+		minor := extractMinorVersion(ver)
+		if minor == "" {
+			continue
+		}
+		versions[minor] = append(versions[minor], node.Name)
+	}
+
+	if len(versions) <= 1 {
+		return nil
+	}
+
+	// Find min and max versions
+	var minV, maxV string
+	for v := range versions {
+		if minV == "" || v < minV {
+			minV = v
+		}
+		if maxV == "" || v > maxV {
+			maxV = v
+		}
+	}
+
+	return &VersionSkew{
+		Versions:   versions,
+		MinVersion: minV,
+		MaxVersion: maxV,
+	}
+}
+
+// extractMinorVersion extracts "v1.28" from "v1.28.3" or "1.28" from "1.28.3".
+func extractMinorVersion(version string) string {
+	version = strings.TrimPrefix(version, "v")
+	parts := strings.SplitN(version, ".", 3)
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[0] + "." + parts[1]
+}
+
+// FormatAge formats a duration into a human-readable age string (e.g., "5d", "3h").
+func FormatAge(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	if d < 24*time.Hour {
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	}
+	return fmt.Sprintf("%dd", int(d.Hours()/24))
+}
+
+// Truncate trims a string to maxLen characters, appending "..." if truncated.
+func Truncate(s string, maxLen int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/internal/k8s/health_test.go
+++ b/internal/k8s/health_test.go
@@ -1,0 +1,496 @@
+package k8s
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestClassifyPodHealth(t *testing.T) {
+	now := time.Now()
+	oldTime := metav1.NewTime(now.Add(-10 * time.Minute))
+	recentTime := metav1.NewTime(now.Add(-1 * time.Minute))
+
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want string
+	}{
+		{
+			name: "healthy running pod",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Ready: true, RestartCount: 0},
+					},
+				},
+			},
+			want: "healthy",
+		},
+		{
+			name: "succeeded pod",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{Phase: corev1.PodSucceeded},
+			},
+			want: "healthy",
+		},
+		{
+			name: "failed pod",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{Phase: corev1.PodFailed},
+			},
+			want: "error",
+		},
+		{
+			name: "CrashLoopBackOff",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}},
+					},
+				},
+			},
+			want: "error",
+		},
+		{
+			name: "OOMKilled",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "OOMKilled"}}},
+					},
+				},
+			},
+			want: "error",
+		},
+		{
+			name: "LastTerminationState OOMKilled",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Ready:                true,
+							LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "OOMKilled"}},
+						},
+					},
+				},
+			},
+			want: "error",
+		},
+		{
+			name: "init container error",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"}}},
+					},
+				},
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: oldTime},
+			},
+			want: "error",
+		},
+		{
+			name: "pending over 5 minutes",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: oldTime},
+				Status:     corev1.PodStatus{Phase: corev1.PodPending},
+			},
+			want: "warning",
+		},
+		{
+			name: "recently pending is healthy",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: recentTime},
+				Status:     corev1.PodStatus{Phase: corev1.PodPending},
+			},
+			want: "healthy",
+		},
+		{
+			name: "high restart count",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Ready: true, RestartCount: 10},
+					},
+				},
+			},
+			want: "warning",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyPodHealth(tt.pod, now)
+			if got != tt.want {
+				t.Errorf("ClassifyPodHealth() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyNodeHealth(t *testing.T) {
+	tests := []struct {
+		name            string
+		node            *corev1.Node
+		wantReady       bool
+		wantUnschedulable bool
+		wantPressures   int
+	}{
+		{
+			name: "ready node",
+			node: &corev1.Node{
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+					},
+					NodeInfo: corev1.NodeSystemInfo{KubeletVersion: "v1.28.3"},
+				},
+			},
+			wantReady:       true,
+			wantUnschedulable: false,
+			wantPressures:   0,
+		},
+		{
+			name: "not ready node",
+			node: &corev1.Node{
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeReady, Status: corev1.ConditionFalse, Message: "kubelet stopped"},
+					},
+				},
+			},
+			wantReady:       false,
+			wantUnschedulable: false,
+			wantPressures:   0,
+		},
+		{
+			name: "cordoned and ready",
+			node: &corev1.Node{
+				Spec: corev1.NodeSpec{Unschedulable: true},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+					},
+				},
+			},
+			wantReady:       true,
+			wantUnschedulable: true,
+			wantPressures:   0,
+		},
+		{
+			name: "cordoned and not ready",
+			node: &corev1.Node{
+				Spec: corev1.NodeSpec{Unschedulable: true},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+					},
+				},
+			},
+			wantReady:       false,
+			wantUnschedulable: true,
+			wantPressures:   0,
+		},
+		{
+			name: "memory pressure",
+			node: &corev1.Node{
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+						{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionTrue},
+					},
+				},
+			},
+			wantReady:       true,
+			wantUnschedulable: false,
+			wantPressures:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyNodeHealth(tt.node)
+			if got.Ready != tt.wantReady {
+				t.Errorf("Ready = %v, want %v", got.Ready, tt.wantReady)
+			}
+			if got.Unschedulable != tt.wantUnschedulable {
+				t.Errorf("Unschedulable = %v, want %v", got.Unschedulable, tt.wantUnschedulable)
+			}
+			if len(got.Pressures) != tt.wantPressures {
+				t.Errorf("Pressures = %v, want %d pressures", got.Pressures, tt.wantPressures)
+			}
+		})
+	}
+}
+
+func TestDetectNodeProblems(t *testing.T) {
+	tests := []struct {
+		name         string
+		nodes        []*corev1.Node
+		wantCount    int
+		wantSeverity string // first problem severity if any
+		wantProblem  string // first problem type if any
+	}{
+		{
+			name: "no problems",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "mixed problems",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "not-ready"},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "cordoned"},
+					Spec:       corev1.NodeSpec{Unschedulable: true},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			},
+			wantCount:    2,
+			wantSeverity: "error",
+			wantProblem:  "NotReady",
+		},
+		{
+			name: "cordoned only",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "cordoned"},
+					Spec:       corev1.NodeSpec{Unschedulable: true},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			},
+			wantCount:    1,
+			wantSeverity: "warning",
+			wantProblem:  "Cordoned",
+		},
+		{
+			name: "pressure conditions",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pressured"},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+							{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionTrue},
+							{Type: corev1.NodeDiskPressure, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			},
+			wantCount:    2,
+			wantSeverity: "warning",
+			wantProblem:  "MemoryPressure",
+		},
+		{
+			name: "not ready with pressure produces both",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "failing"},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{Type: corev1.NodeReady, Status: corev1.ConditionFalse, Message: "kubelet stopped"},
+							{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			},
+			wantCount:    2,
+			wantSeverity: "error",
+			wantProblem:  "NotReady",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			problems := DetectNodeProblems(tt.nodes)
+			if len(problems) != tt.wantCount {
+				t.Errorf("DetectNodeProblems() returned %d problems, want %d", len(problems), tt.wantCount)
+			}
+			if tt.wantCount > 0 && len(problems) > 0 {
+				if problems[0].Severity != tt.wantSeverity {
+					t.Errorf("first problem severity = %q, want %q", problems[0].Severity, tt.wantSeverity)
+				}
+				if problems[0].Problem != tt.wantProblem {
+					t.Errorf("first problem type = %q, want %q", problems[0].Problem, tt.wantProblem)
+				}
+			}
+		})
+	}
+}
+
+func TestDetectVersionSkew(t *testing.T) {
+	tests := []struct {
+		name     string
+		nodes    []*corev1.Node
+		wantNil  bool
+		wantMin  string
+		wantMax  string
+	}{
+		{
+			name:    "empty nodes",
+			nodes:   nil,
+			wantNil: true,
+		},
+		{
+			name: "same version",
+			nodes: []*corev1.Node{
+				{Status: corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{KubeletVersion: "v1.28.3"}}},
+				{Status: corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{KubeletVersion: "v1.28.5"}}},
+			},
+			wantNil: true, // same minor, different patch
+		},
+		{
+			name: "different minor versions",
+			nodes: []*corev1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "node1"}, Status: corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{KubeletVersion: "v1.27.8"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node2"}, Status: corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{KubeletVersion: "v1.28.3"}}},
+			},
+			wantNil: false,
+			wantMin: "1.27",
+			wantMax: "1.28",
+		},
+		{
+			name: "same minor different patch is nil",
+			nodes: []*corev1.Node{
+				{Status: corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{KubeletVersion: "v1.29.0"}}},
+				{Status: corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{KubeletVersion: "v1.29.4"}}},
+			},
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DetectVersionSkew(tt.nodes)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("DetectVersionSkew() = %+v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("DetectVersionSkew() = nil, want non-nil")
+			}
+			if got.MinVersion != tt.wantMin {
+				t.Errorf("MinVersion = %q, want %q", got.MinVersion, tt.wantMin)
+			}
+			if got.MaxVersion != tt.wantMax {
+				t.Errorf("MaxVersion = %q, want %q", got.MaxVersion, tt.wantMax)
+			}
+		})
+	}
+}
+
+func TestFormatAge(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{30 * time.Second, "30s"},
+		{5 * time.Minute, "5m"},
+		{3 * time.Hour, "3h"},
+		{48 * time.Hour, "2d"},
+	}
+	for _, tt := range tests {
+		got := FormatAge(tt.d)
+		if got != tt.want {
+			t.Errorf("FormatAge(%v) = %q, want %q", tt.d, got, tt.want)
+		}
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		s      string
+		maxLen int
+		want   string
+	}{
+		{"short", 10, "short"},
+		{"this is a longer string", 10, "this is..."},
+		{"  trimmed  ", 20, "trimmed"},
+	}
+	for _, tt := range tests {
+		got := Truncate(tt.s, tt.maxLen)
+		if got != tt.want {
+			t.Errorf("Truncate(%q, %d) = %q, want %q", tt.s, tt.maxLen, got, tt.want)
+		}
+	}
+}
+
+func TestPodProblemReason(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want string
+	}{
+		{
+			name: "waiting reason",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}},
+					},
+				},
+			},
+			want: "CrashLoopBackOff",
+		},
+		{
+			name: "terminated reason",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "OOMKilled"}}},
+					},
+				},
+			},
+			want: "OOMKilled",
+		},
+		{
+			name: "falls back to phase",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{Phase: corev1.PodPending},
+			},
+			want: "Pending",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PodProblemReason(tt.pod)
+			if got != tt.want {
+				t.Errorf("PodProblemReason() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -270,8 +270,8 @@ func handleGetEvents(ctx context.Context, req *mcp.CallToolRequest, input events
 	deduplicated := aicontext.DeduplicateEvents(eventValues)
 
 	limit := 20
-	if input.Limit > 0 && input.Limit < limit {
-		limit = input.Limit
+	if input.Limit > 0 {
+		limit = min(input.Limit, 100)
 	}
 	if len(deduplicated) > limit {
 		deduplicated = deduplicated[:limit]
@@ -344,6 +344,8 @@ func handleListNamespaces(ctx context.Context, req *mcp.CallToolRequest, input s
 
 type mcpDashboard struct {
 	Cluster        mcpClusterInfo   `json:"cluster"`
+	Nodes          mcpNodeSummary   `json:"nodes"`
+	VersionSkew    []string         `json:"versionSkew,omitempty"`
 	Health         mcpHealthSummary `json:"health"`
 	Problems       []mcpProblem     `json:"problems"`
 	WarningEvents  int              `json:"warningEvents"`
@@ -360,6 +362,13 @@ type mcpClusterInfo struct {
 	Version  string `json:"version"`
 }
 
+type mcpNodeSummary struct {
+	Total    int `json:"total"`
+	Ready    int `json:"ready"`
+	NotReady int `json:"notReady"`
+	Cordoned int `json:"cordoned"`
+}
+
 type mcpHealthSummary struct {
 	HealthyPods int `json:"healthyPods"`
 	WarningPods int `json:"warningPods"`
@@ -371,6 +380,7 @@ type mcpProblem struct {
 	Namespace string `json:"namespace,omitempty"`
 	Name      string `json:"name"`
 	Reason    string `json:"reason"`
+	Message   string `json:"message,omitempty"`
 	Age       string `json:"age"`
 }
 
@@ -418,7 +428,7 @@ func buildDashboard(ctx context.Context, cache *k8s.ResourceCache, namespace str
 		}
 		d.ResourceCounts["pods"] = len(pods)
 		for _, pod := range pods {
-			switch classifyPodHealth(pod, now) {
+			switch k8s.ClassifyPodHealth(pod, now) {
 			case "healthy":
 				d.Health.HealthyPods++
 			case "warning":
@@ -430,8 +440,8 @@ func buildDashboard(ctx context.Context, cache *k8s.ResourceCache, namespace str
 						Kind:      "Pod",
 						Namespace: pod.Namespace,
 						Name:      pod.Name,
-						Reason:    podProblemReason(pod),
-						Age:       formatAge(now.Sub(pod.CreationTimestamp.Time)),
+						Reason:    k8s.PodProblemReason(pod),
+						Age:       k8s.FormatAge(now.Sub(pod.CreationTimestamp.Time)),
 					})
 				}
 			}
@@ -440,46 +450,150 @@ func buildDashboard(ctx context.Context, cache *k8s.ResourceCache, namespace str
 
 	// Deployment problems
 	if depLister := cache.Deployments(); depLister != nil {
-		var deps []*corev1.Pod // placeholder type - will use actual
-		_ = deps
-		listDeps := func() {
-			if namespace != "" {
-				items, _ := cache.Deployments().Deployments(namespace).List(labels.Everything())
-				d.ResourceCounts["deployments"] = len(items)
-				for _, dep := range items {
-					if dep.Status.UnavailableReplicas > 0 && len(d.Problems) < 10 {
-						d.Problems = append(d.Problems, mcpProblem{
-							Kind:      "Deployment",
-							Namespace: dep.Namespace,
-							Name:      dep.Name,
-							Reason:    fmt.Sprintf("%d/%d available", dep.Status.AvailableReplicas, dep.Status.Replicas),
-							Age:       formatAge(now.Sub(dep.CreationTimestamp.Time)),
-						})
-					}
+		if namespace != "" {
+			items, _ := depLister.Deployments(namespace).List(labels.Everything())
+			d.ResourceCounts["deployments"] = len(items)
+			for _, dep := range items {
+				if dep.Status.UnavailableReplicas > 0 && len(d.Problems) < 10 {
+					d.Problems = append(d.Problems, mcpProblem{
+						Kind:      "Deployment",
+						Namespace: dep.Namespace,
+						Name:      dep.Name,
+						Reason:    fmt.Sprintf("%d/%d available", dep.Status.AvailableReplicas, dep.Status.Replicas),
+						Age:       k8s.FormatAge(now.Sub(dep.CreationTimestamp.Time)),
+					})
 				}
-			} else {
-				items, _ := cache.Deployments().List(labels.Everything())
-				d.ResourceCounts["deployments"] = len(items)
-				for _, dep := range items {
-					if dep.Status.UnavailableReplicas > 0 && len(d.Problems) < 10 {
-						d.Problems = append(d.Problems, mcpProblem{
-							Kind:      "Deployment",
-							Namespace: dep.Namespace,
-							Name:      dep.Name,
-							Reason:    fmt.Sprintf("%d/%d available", dep.Status.AvailableReplicas, dep.Status.Replicas),
-							Age:       formatAge(now.Sub(dep.CreationTimestamp.Time)),
-						})
-					}
+			}
+		} else {
+			items, _ := depLister.List(labels.Everything())
+			d.ResourceCounts["deployments"] = len(items)
+			for _, dep := range items {
+				if dep.Status.UnavailableReplicas > 0 && len(d.Problems) < 10 {
+					d.Problems = append(d.Problems, mcpProblem{
+						Kind:      "Deployment",
+						Namespace: dep.Namespace,
+						Name:      dep.Name,
+						Reason:    fmt.Sprintf("%d/%d available", dep.Status.AvailableReplicas, dep.Status.Replicas),
+						Age:       k8s.FormatAge(now.Sub(dep.CreationTimestamp.Time)),
+					})
 				}
 			}
 		}
-		listDeps()
+	}
+
+	// StatefulSet problems: readyReplicas < replicas
+	if ssLister := cache.StatefulSets(); ssLister != nil {
+		if namespace != "" {
+			ssets, _ := ssLister.StatefulSets(namespace).List(labels.Everything())
+			for _, ss := range ssets {
+				if ss.Status.ReadyReplicas < ss.Status.Replicas && len(d.Problems) < 10 {
+					d.Problems = append(d.Problems, mcpProblem{
+						Kind:      "StatefulSet",
+						Namespace: ss.Namespace,
+						Name:      ss.Name,
+						Reason:    fmt.Sprintf("%d/%d ready", ss.Status.ReadyReplicas, ss.Status.Replicas),
+						Age:       k8s.FormatAge(now.Sub(ss.CreationTimestamp.Time)),
+					})
+				}
+			}
+		} else {
+			ssets, _ := ssLister.List(labels.Everything())
+			for _, ss := range ssets {
+				if ss.Status.ReadyReplicas < ss.Status.Replicas && len(d.Problems) < 10 {
+					d.Problems = append(d.Problems, mcpProblem{
+						Kind:      "StatefulSet",
+						Namespace: ss.Namespace,
+						Name:      ss.Name,
+						Reason:    fmt.Sprintf("%d/%d ready", ss.Status.ReadyReplicas, ss.Status.Replicas),
+						Age:       k8s.FormatAge(now.Sub(ss.CreationTimestamp.Time)),
+					})
+				}
+			}
+		}
+	}
+
+	// DaemonSet problems: numberUnavailable > 0
+	if dsLister := cache.DaemonSets(); dsLister != nil {
+		if namespace != "" {
+			dsets, _ := dsLister.DaemonSets(namespace).List(labels.Everything())
+			for _, ds := range dsets {
+				if ds.Status.NumberUnavailable > 0 && len(d.Problems) < 10 {
+					d.Problems = append(d.Problems, mcpProblem{
+						Kind:      "DaemonSet",
+						Namespace: ds.Namespace,
+						Name:      ds.Name,
+						Reason:    fmt.Sprintf("%d unavailable", ds.Status.NumberUnavailable),
+						Age:       k8s.FormatAge(now.Sub(ds.CreationTimestamp.Time)),
+					})
+				}
+			}
+		} else {
+			dsets, _ := dsLister.List(labels.Everything())
+			for _, ds := range dsets {
+				if ds.Status.NumberUnavailable > 0 && len(d.Problems) < 10 {
+					d.Problems = append(d.Problems, mcpProblem{
+						Kind:      "DaemonSet",
+						Namespace: ds.Namespace,
+						Name:      ds.Name,
+						Reason:    fmt.Sprintf("%d unavailable", ds.Status.NumberUnavailable),
+						Age:       k8s.FormatAge(now.Sub(ds.CreationTimestamp.Time)),
+					})
+				}
+			}
+		}
+	}
+
+	// Node problems (cluster-scoped, not filtered by namespace)
+	if nodeLister := cache.Nodes(); nodeLister != nil {
+		nodes, _ := nodeLister.List(labels.Everything())
+		d.ResourceCounts["nodes"] = len(nodes)
+		d.Nodes.Total = len(nodes)
+
+		for _, node := range nodes {
+			h := k8s.ClassifyNodeHealth(node)
+			if h.Ready {
+				if h.Unschedulable {
+					d.Nodes.Cordoned++
+				} else {
+					d.Nodes.Ready++
+				}
+			} else {
+				d.Nodes.NotReady++
+			}
+		}
+
+		nodeProblems := k8s.DetectNodeProblems(nodes)
+		for _, np := range nodeProblems {
+			if len(d.Problems) < 10 {
+				age := ""
+				for _, n := range nodes {
+					if n.Name == np.NodeName {
+						age = k8s.FormatAge(now.Sub(n.CreationTimestamp.Time))
+						break
+					}
+				}
+				d.Problems = append(d.Problems, mcpProblem{
+					Kind:   "Node",
+					Name:   np.NodeName,
+					Reason: np.Problem,
+					Age:    age,
+				})
+			}
+		}
+
+		// Version skew
+		if skew := k8s.DetectVersionSkew(nodes); skew != nil {
+			for v := range skew.Versions {
+				d.VersionSkew = append(d.VersionSkew, v)
+			}
+			sort.Strings(d.VersionSkew)
+		}
 	}
 
 	// Simple resource counts for other types
 	countResources(cache, namespace, &d)
 
-	// Warning events
+	// Warning events — deduplicate first, then sort by count
 	if eventLister := cache.Events(); eventLister != nil {
 		var events []*corev1.Event
 		if namespace != "" {
@@ -488,42 +602,41 @@ func buildDashboard(ctx context.Context, cache *k8s.ResourceCache, namespace str
 			events, _ = eventLister.List(labels.Everything())
 		}
 
-		var warnings []*corev1.Event
+		var warningValues []corev1.Event
 		for _, e := range events {
 			if e.Type == "Warning" {
-				warnings = append(warnings, e)
+				warningValues = append(warningValues, *e)
 			}
 		}
-		d.WarningEvents = len(warnings)
+		d.WarningEvents = len(warningValues)
 
-		// Top 5 warnings sorted by recency
-		sort.Slice(warnings, func(i, j int) bool {
-			ti := warnings[i].LastTimestamp.Time
-			tj := warnings[j].LastTimestamp.Time
-			if ti.IsZero() {
-				ti = warnings[i].CreationTimestamp.Time
-			}
-			if tj.IsZero() {
-				tj = warnings[j].CreationTimestamp.Time
-			}
-			return ti.After(tj)
+		// Deduplicate and sort by count descending to surface systemic issues
+		deduplicated := aicontext.DeduplicateEvents(warningValues)
+		sort.Slice(deduplicated, func(i, j int) bool {
+			return deduplicated[i].Count > deduplicated[j].Count
 		})
-		limit := min(len(warnings), 5)
-		for _, e := range warnings[:limit] {
-			count := max(int(e.Count), 1)
+
+		limit := min(len(deduplicated), 5)
+		for _, e := range deduplicated[:limit] {
 			d.TopWarnings = append(d.TopWarnings, mcpWarning{
 				Reason:  e.Reason,
-				Message: truncate(e.Message, 200),
-				Count:   count,
+				Message: k8s.Truncate(e.Message, 200),
+				Count:   e.Count,
 			})
 		}
 	}
 
-	// Helm releases
+	// Helm releases — sort failed-first before slicing
 	if helmClient := helm.GetClient(); helmClient != nil {
 		releases, err := helmClient.ListReleases(namespace)
 		if err == nil {
 			d.HelmReleases.Total = len(releases)
+
+			// Sort: failed/pending-install first, then unhealthy/degraded
+			sort.SliceStable(releases, func(i, j int) bool {
+				return helmStatusPriority(releases[i].Status, releases[i].ResourceHealth) < helmStatusPriority(releases[j].Status, releases[j].ResourceHealth)
+			})
+
 			limit := min(len(releases), 5)
 			for _, r := range releases[:limit] {
 				d.HelmReleases.Releases = append(d.HelmReleases.Releases, mcpHelmRelease{
@@ -609,73 +722,24 @@ func countResources(cache *k8s.ResourceCache, namespace string, d *mcpDashboard)
 		items, _ := nsLister.List(labels.Everything())
 		d.ResourceCounts["namespaces"] = len(items)
 	}
-	if nodeLister := cache.Nodes(); nodeLister != nil {
-		items, _ := nodeLister.List(labels.Everything())
-		d.ResourceCounts["nodes"] = len(items)
-	}
 }
 
-// classifyPodHealth determines if a pod is healthy, warning, or error.
-func classifyPodHealth(pod *corev1.Pod, now time.Time) string {
-	if pod.Status.Phase == corev1.PodSucceeded {
-		return "healthy"
+// helmStatusPriority returns a sort priority for Helm release statuses.
+// Lower values sort first — failed and unhealthy releases are surfaced first.
+func helmStatusPriority(status, resourceHealth string) int {
+	if status == "failed" {
+		return 0
 	}
-	if pod.Status.Phase == corev1.PodFailed {
-		return "error"
+	if status == "pending-install" || status == "pending-upgrade" || status == "pending-rollback" {
+		return 1
 	}
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.State.Waiting != nil {
-			reason := cs.State.Waiting.Reason
-			if reason == "CrashLoopBackOff" || reason == "ImagePullBackOff" || reason == "ErrImagePull" || reason == "CreateContainerConfigError" {
-				return "error"
-			}
-		}
-		if cs.State.Terminated != nil && cs.State.Terminated.Reason == "OOMKilled" {
-			return "error"
-		}
+	switch resourceHealth {
+	case "unhealthy":
+		return 2
+	case "degraded":
+		return 3
 	}
-	if pod.Status.Phase == corev1.PodPending && now.Sub(pod.CreationTimestamp.Time) > 5*time.Minute {
-		return "warning"
-	}
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.RestartCount > 3 {
-			return "warning"
-		}
-	}
-	return "healthy"
-}
-
-func podProblemReason(pod *corev1.Pod) string {
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.State.Waiting != nil && cs.State.Waiting.Reason != "" {
-			return cs.State.Waiting.Reason
-		}
-		if cs.State.Terminated != nil && cs.State.Terminated.Reason != "" {
-			return cs.State.Terminated.Reason
-		}
-	}
-	return string(pod.Status.Phase)
-}
-
-func formatAge(d time.Duration) string {
-	if d < time.Minute {
-		return fmt.Sprintf("%ds", int(d.Seconds()))
-	}
-	if d < time.Hour {
-		return fmt.Sprintf("%dm", int(d.Minutes()))
-	}
-	if d < 24*time.Hour {
-		return fmt.Sprintf("%dh", int(d.Hours()))
-	}
-	return fmt.Sprintf("%dd", int(d.Hours()/24))
-}
-
-func truncate(s string, maxLen int) string {
-	s = strings.TrimSpace(s)
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen-3] + "..."
+	return 4
 }
 
 // toJSONResult marshals data into a text content MCP result.

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -35,6 +35,7 @@ type DashboardResponse struct {
 	Metrics                *DashboardMetrics           `json:"metrics"`
 	MetricsServerAvailable bool                        `json:"metricsServerAvailable"`
 	CertificateHealth      *DashboardCertificateHealth `json:"certificateHealth,omitempty"`
+	NodeVersionSkew        *k8s.VersionSkew            `json:"nodeVersionSkew,omitempty"`
 }
 
 // DashboardCRDsResponse is the response for CRD counts (loaded lazily)
@@ -120,6 +121,7 @@ type NodeCount struct {
 	Total    int `json:"total"`
 	Ready    int `json:"ready"`
 	NotReady int `json:"notReady"`
+	Cordoned int `json:"cordoned"`
 }
 
 type JobCount struct {
@@ -156,6 +158,7 @@ type DashboardEvent struct {
 	InvolvedObject string `json:"involvedObject"`
 	Namespace      string `json:"namespace"`
 	Timestamp      string `json:"timestamp"`
+	Count          int32  `json:"count,omitempty"`
 }
 
 type DashboardChange struct {
@@ -250,6 +253,12 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	// Certificate health (nil if no TLS secrets)
 	resp.CertificateHealth = s.getDashboardCertificateHealth(namespace)
 
+	// Node version skew
+	if nodeLister := cache.Nodes(); nodeLister != nil {
+		nodes, _ := nodeLister.List(labels.Everything())
+		resp.NodeVersionSkew = k8s.DetectVersionSkew(nodes)
+	}
+
 	s.writeJSON(w, resp)
 }
 
@@ -326,7 +335,7 @@ func (s *Server) getDashboardHealth(cache *k8s.ResourceCache, namespace string) 
 						Name:       d.Name,
 						Status:     "error",
 						Reason:     fmt.Sprintf("%d/%d available", d.Status.AvailableReplicas, d.Status.Replicas),
-						Age:        formatAge(ageDur),
+						Age:        k8s.FormatAge(ageDur),
 						AgeSeconds: int64(ageDur.Seconds()),
 					})
 				}
@@ -342,7 +351,7 @@ func (s *Server) getDashboardHealth(cache *k8s.ResourceCache, namespace string) 
 						Name:       d.Name,
 						Status:     "error",
 						Reason:     fmt.Sprintf("%d/%d available", d.Status.AvailableReplicas, d.Status.Replicas),
-						Age:        formatAge(ageDur),
+						Age:        k8s.FormatAge(ageDur),
 						AgeSeconds: int64(ageDur.Seconds()),
 					})
 				}
@@ -363,7 +372,7 @@ func (s *Server) getDashboardHealth(cache *k8s.ResourceCache, namespace string) 
 						Name:       ss.Name,
 						Status:     "error",
 						Reason:     fmt.Sprintf("%d/%d ready", ss.Status.ReadyReplicas, ss.Status.Replicas),
-						Age:        formatAge(ageDur),
+						Age:        k8s.FormatAge(ageDur),
 						AgeSeconds: int64(ageDur.Seconds()),
 					})
 				}
@@ -379,7 +388,7 @@ func (s *Server) getDashboardHealth(cache *k8s.ResourceCache, namespace string) 
 						Name:       ss.Name,
 						Status:     "error",
 						Reason:     fmt.Sprintf("%d/%d ready", ss.Status.ReadyReplicas, ss.Status.Replicas),
-						Age:        formatAge(ageDur),
+						Age:        k8s.FormatAge(ageDur),
 						AgeSeconds: int64(ageDur.Seconds()),
 					})
 				}
@@ -400,7 +409,7 @@ func (s *Server) getDashboardHealth(cache *k8s.ResourceCache, namespace string) 
 						Name:       ds.Name,
 						Status:     "error",
 						Reason:     fmt.Sprintf("%d unavailable", ds.Status.NumberUnavailable),
-						Age:        formatAge(ageDur),
+						Age:        k8s.FormatAge(ageDur),
 						AgeSeconds: int64(ageDur.Seconds()),
 					})
 				}
@@ -416,7 +425,7 @@ func (s *Server) getDashboardHealth(cache *k8s.ResourceCache, namespace string) 
 						Name:       ds.Name,
 						Status:     "error",
 						Reason:     fmt.Sprintf("%d unavailable", ds.Status.NumberUnavailable),
-						Age:        formatAge(ageDur),
+						Age:        k8s.FormatAge(ageDur),
 						AgeSeconds: int64(ageDur.Seconds()),
 					})
 				}
@@ -424,37 +433,28 @@ func (s *Server) getDashboardHealth(cache *k8s.ResourceCache, namespace string) 
 		}
 	}
 
-	// Node problems: Ready=False
+	// Node problems: NotReady, Cordoned, pressure conditions
 	var nodes []*corev1.Node
 	if nodeLister := cache.Nodes(); nodeLister != nil {
 		nodes, _ = nodeLister.List(labels.Everything())
 	}
-	for _, n := range nodes {
-		ready := false
-		for _, cond := range n.Status.Conditions {
-			if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
-				ready = true
+	for _, np := range k8s.DetectNodeProblems(nodes) {
+		ageDur := time.Duration(0)
+		for _, n := range nodes {
+			if n.Name == np.NodeName {
+				ageDur = now.Sub(n.CreationTimestamp.Time)
 				break
 			}
 		}
-		if !ready {
-			reason := "NotReady"
-			for _, cond := range n.Status.Conditions {
-				if cond.Type == corev1.NodeReady && cond.Message != "" {
-					reason = cond.Message
-					break
-				}
-			}
-			ageDur := now.Sub(n.CreationTimestamp.Time)
-			problems = append(problems, DashboardProblem{
-				Kind:       "Node",
-				Name:       n.Name,
-				Status:     "error",
-				Reason:     reason,
-				Age:        formatAge(ageDur),
-				AgeSeconds: int64(ageDur.Seconds()),
-			})
-		}
+		problems = append(problems, DashboardProblem{
+			Kind:       "Node",
+			Name:       np.NodeName,
+			Status:     np.Severity,
+			Reason:     np.Problem,
+			Message:    np.Reason,
+			Age:        k8s.FormatAge(ageDur),
+			AgeSeconds: int64(ageDur.Seconds()),
+		})
 	}
 
 	// Sort: errors first, then warnings; within each group sort by age (most recent first)
@@ -469,65 +469,9 @@ func (s *Server) getDashboardHealth(cache *k8s.ResourceCache, namespace string) 
 	return health, problems
 }
 
-// classifyPodHealth determines if a pod is healthy, warning, or error
+// classifyPodHealth delegates to the shared implementation in k8s.ClassifyPodHealth.
 func classifyPodHealth(pod *corev1.Pod, now time.Time) string {
-	// Succeeded pods are healthy
-	if pod.Status.Phase == corev1.PodSucceeded {
-		return "healthy"
-	}
-
-	// Failed pods are errors
-	if pod.Status.Phase == corev1.PodFailed {
-		return "error"
-	}
-
-	// Check container statuses for error conditions
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.State.Waiting != nil {
-			reason := cs.State.Waiting.Reason
-			if reason == "CrashLoopBackOff" || reason == "ImagePullBackOff" || reason == "ErrImagePull" || reason == "CreateContainerConfigError" {
-				return "error"
-			}
-		}
-		if cs.State.Terminated != nil && cs.State.Terminated.Reason == "OOMKilled" {
-			return "error"
-		}
-		if cs.LastTerminationState.Terminated != nil && cs.LastTerminationState.Terminated.Reason == "OOMKilled" {
-			return "error"
-		}
-	}
-
-	// Init container errors
-	for _, cs := range pod.Status.InitContainerStatuses {
-		if cs.State.Waiting != nil {
-			reason := cs.State.Waiting.Reason
-			if reason == "CrashLoopBackOff" || reason == "ImagePullBackOff" || reason == "ErrImagePull" {
-				return "error"
-			}
-		}
-	}
-
-	// Warning: pods pending for more than 5 minutes
-	if pod.Status.Phase == corev1.PodPending {
-		if now.Sub(pod.CreationTimestamp.Time) > 5*time.Minute {
-			return "warning"
-		}
-		return "healthy" // recently pending is fine
-	}
-
-	// Warning: pods with high restart counts
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.RestartCount > 3 {
-			return "warning"
-		}
-	}
-
-	// Running with all containers ready = healthy
-	if pod.Status.Phase == corev1.PodRunning {
-		return "healthy"
-	}
-
-	return "healthy"
+	return k8s.ClassifyPodHealth(pod, now)
 }
 
 func podToProblem(pod *corev1.Pod, severity string, now time.Time) DashboardProblem {
@@ -577,8 +521,8 @@ func podToProblem(pod *corev1.Pod, severity string, now time.Time) DashboardProb
 		Name:       pod.Name,
 		Status:     severity,
 		Reason:     reason,
-		Message:    truncate(message, 200),
-		Age:        formatAge(ageDur),
+		Message:    k8s.Truncate(message, 200),
+		Age:        k8s.FormatAge(ageDur),
 		AgeSeconds: int64(ageDur.Seconds()),
 	}
 }
@@ -760,15 +704,13 @@ func (s *Server) getDashboardResourceCounts(cache *k8s.ResourceCache, namespace 
 		nodeList, _ := nodeLister.List(labels.Everything())
 		counts.Nodes.Total = len(nodeList)
 		for _, n := range nodeList {
-			ready := false
-			for _, cond := range n.Status.Conditions {
-				if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
-					ready = true
-					break
+			h := k8s.ClassifyNodeHealth(n)
+			if h.Ready {
+				if h.Unschedulable {
+					counts.Nodes.Cordoned++
+				} else {
+					counts.Nodes.Ready++
 				}
-			}
-			if ready {
-				counts.Nodes.Ready++
 			} else {
 				counts.Nodes.NotReady++
 			}
@@ -951,10 +893,11 @@ func (s *Server) getDashboardRecentEvents(cache *k8s.ResourceCache, namespace st
 		result = append(result, DashboardEvent{
 			Type:           e.Type,
 			Reason:         e.Reason,
-			Message:        truncate(e.Message, 200),
+			Message:        k8s.Truncate(e.Message, 200),
 			InvolvedObject: fmt.Sprintf("%s/%s", e.InvolvedObject.Kind, e.InvolvedObject.Name),
 			Namespace:      e.Namespace,
 			Timestamp:      ts.Format(time.RFC3339),
+			Count:          max(e.Count, 1),
 		})
 	}
 
@@ -985,7 +928,7 @@ func (s *Server) getDashboardRecentChanges(ctx context.Context, namespaces []str
 		if e.Diff != nil && e.Diff.Summary != "" {
 			summary = e.Diff.Summary
 		} else if e.Message != "" {
-			summary = truncate(e.Message, 100)
+			summary = k8s.Truncate(e.Message, 100)
 		}
 
 		result = append(result, DashboardChange{
@@ -1104,6 +1047,13 @@ func (s *Server) getDashboardHelmSummary(namespace string) DashboardHelmSummary 
 	result := DashboardHelmSummary{
 		Total: len(releases),
 	}
+
+	// Sort: failed/unhealthy releases first to surface problems
+	sort.SliceStable(releases, func(i, j int) bool {
+		pi := helmStatusPriority(releases[i].Status, releases[i].ResourceHealth)
+		pj := helmStatusPriority(releases[j].Status, releases[j].ResourceHealth)
+		return pi < pj
+	})
 
 	// Take top 6 releases
 	limit := min(len(releases), 6)
@@ -1317,26 +1267,6 @@ func parseMemoryToBytes(s string) int64 {
 
 // Helper functions
 
-func formatAge(d time.Duration) string {
-	if d < time.Minute {
-		return fmt.Sprintf("%ds", int(d.Seconds()))
-	}
-	if d < time.Hour {
-		return fmt.Sprintf("%dm", int(d.Minutes()))
-	}
-	if d < 24*time.Hour {
-		return fmt.Sprintf("%dh", int(d.Hours()))
-	}
-	return fmt.Sprintf("%dd", int(d.Hours()/24))
-}
-
-func truncate(s string, maxLen int) string {
-	s = strings.TrimSpace(s)
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen-3] + "..."
-}
 
 // getDashboardCRDCounts returns counts of CRD instances in the cluster.
 func (s *Server) getDashboardCRDCounts(_ context.Context, namespace string) []DashboardCRDCount {
@@ -1430,4 +1360,22 @@ func (s *Server) getDashboardCRDCounts(_ context.Context, namespace string) []Da
 	}
 
 	return counts
+}
+
+// helmStatusPriority returns a sort priority for Helm release statuses.
+// Lower values sort first — failed and unhealthy releases are surfaced first.
+func helmStatusPriority(status, resourceHealth string) int {
+	if status == "failed" {
+		return 0
+	}
+	if status == "pending-install" || status == "pending-upgrade" || status == "pending-rollback" {
+		return 1
+	}
+	switch resourceHealth {
+	case "unhealthy":
+		return 2
+	case "degraded":
+		return 3
+	}
+	return 4
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -108,7 +108,7 @@ export interface DashboardResourceCounts {
   ingresses: number
   gateways?: number
   routes?: number
-  nodes: { total: number; ready: number; notReady: number }
+  nodes: { total: number; ready: number; notReady: number; cordoned: number }
   namespaces: number
   jobs: { total: number; active: number; succeeded: number; failed: number }
   cronJobs: { total: number; active: number; suspended: number }
@@ -198,6 +198,7 @@ export interface DashboardResponse {
   metrics: DashboardMetrics | null
   metricsServerAvailable: boolean
   certificateHealth: DashboardCertificateHealth | null
+  nodeVersionSkew: { versions: Record<string, string[]>; minVersion: string; maxVersion: string } | null
 }
 
 export interface DashboardCRDsResponse {

--- a/web/src/components/home/ClusterHealthCard.tsx
+++ b/web/src/components/home/ClusterHealthCard.tsx
@@ -20,6 +20,7 @@ interface ClusterHealthCardProps {
   metricsServerAvailable: boolean
   topCRDs?: DashboardCRDCount[] // Loaded lazily, may be undefined
   problems: DashboardProblem[]
+  nodeVersionSkew: DashboardResponse['nodeVersionSkew']
   onNavigateToKind: (kind: string, group?: string) => void
   onNavigateToView: () => void
   onWarningEventsClick?: () => void
@@ -102,6 +103,7 @@ export function ClusterHealthCard({
   metricsServerAvailable,
   topCRDs: _topCRDs,
   problems,
+  nodeVersionSkew,
   onNavigateToKind,
   onNavigateToView,
   onWarningEventsClick,
@@ -131,8 +133,10 @@ export function ClusterHealthCard({
   ]
 
   // Nodes ring segments
+  const cordonedCount = counts.nodes.cordoned ?? 0
   const nodesRingSegments = [
     { value: counts.nodes.ready, color: '#22c55e' },
+    { value: cordonedCount, color: '#eab308' }, // amber for cordoned
     { value: counts.nodes.notReady, color: '#ef4444' },
   ]
 
@@ -178,6 +182,29 @@ export function ClusterHealthCard({
               )}
               <span>{counts.namespaces} namespaces</span>
             </div>
+            {nodeVersionSkew && (
+              <Tooltip
+                content={
+                  <div className="space-y-1.5">
+                    <div className="font-medium">Node version skew detected</div>
+                    {Object.entries(nodeVersionSkew.versions).map(([version, nodes]) => (
+                      <div key={version}>
+                        <span className="font-mono font-medium">v{version}</span>
+                        <span className="text-theme-text-tertiary"> — {nodes.length} node{nodes.length > 1 ? 's' : ''}</span>
+                        <div className="text-[10px] text-theme-text-tertiary pl-2">{nodes.join(', ')}</div>
+                      </div>
+                    ))}
+                  </div>
+                }
+                position="bottom"
+                className="!whitespace-normal !max-w-sm"
+              >
+                <span className="flex items-center gap-1.5 mt-1 text-xs text-yellow-500">
+                  <AlertTriangle className="w-3 h-3 shrink-0" />
+                  Version skew: v{nodeVersionSkew.minVersion} — v{nodeVersionSkew.maxVersion}
+                </span>
+              </Tooltip>
+            )}
             {/* MCP Server indicator */}
             {mcpEnabled && (
               <button
@@ -263,6 +290,9 @@ export function ClusterHealthCard({
                 <span className="text-xs font-medium text-theme-text-secondary">Nodes</span>
                 <div className="flex items-center gap-2 text-[11px]">
                   <span className="text-green-500">{counts.nodes.ready} ready</span>
+                  {cordonedCount > 0 && (
+                    <span className="text-yellow-500">{cordonedCount} cordoned</span>
+                  )}
                   {counts.nodes.notReady > 0 && (
                     <span className="text-red-500">{counts.nodes.notReady} not ready</span>
                   )}

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -57,6 +57,7 @@ export function HomeView({ namespaces, topology, onNavigateToView, onNavigateToR
           metricsServerAvailable={data.metricsServerAvailable}
           topCRDs={crdsData?.topCRDs}
           problems={data.problems ?? []}
+          nodeVersionSkew={data.nodeVersionSkew}
           onNavigateToKind={onNavigateToResourceKind}
           onNavigateToView={() => onNavigateToView('resources')}
           onWarningEventsClick={() => onNavigateToView('timeline', { view: 'list', filter: 'warnings', time: 'all' })}

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -2051,6 +2051,23 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
     return result
   }, [resources, searchTerm, columnFilters, problemFilters, showInactiveReplicaSets, labelSelector, ownerKind, ownerName, selectedKind.name, sortColumn, sortDirection, getSortValue, podMatchesProblemFilter])
 
+  // For nodes table: compute the majority minor version so outliers can be highlighted
+  const majorityNodeMinorVersion = useMemo(() => {
+    if (selectedKind.name.toLowerCase() !== 'nodes') return ''
+    const counts = new Map<string, number>()
+    for (const r of filteredResources) {
+      const full = r.status?.nodeInfo?.kubeletVersion || ''
+      const match = full.match(/^v?(\d+\.\d+)/)
+      if (match) counts.set(match[1], (counts.get(match[1]) || 0) + 1)
+    }
+    let best = ''
+    let bestCount = 0
+    for (const [v, c] of counts) {
+      if (c > bestCount) { best = v; bestCount = c }
+    }
+    return counts.size > 1 ? best : '' // empty string means no skew
+  }, [filteredResources, selectedKind.name])
+
   // Keep refs in sync for keyboard shortcuts (shortcuts can't capture filteredResources directly)
   filteredResourceCountRef.current = filteredResources.length
   highlightedResourceRef.current = highlightedIndex >= 0 ? filteredResources[highlightedIndex] ?? null : null
@@ -2936,6 +2953,7 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
                       hasSpacerColumn={hasResizedColumns}
                       isSelected={isSelected}
                       isHighlighted={isHighlighted}
+                      majorityNodeMinorVersion={majorityNodeMinorVersion}
                       onClick={() => onResourceClick?.({ kind: selectedKind.name, namespace: resource.metadata?.namespace || '', name: resource.metadata?.name, group: selectedKind.group })}
                       onMouseEnter={() => setHighlightedIndex(-1)}
                     />
@@ -3033,12 +3051,13 @@ interface ResourceRowProps {
   hasSpacerColumn: boolean
   isSelected?: boolean
   isHighlighted?: boolean
+  majorityNodeMinorVersion?: string
   onClick?: () => void
   onMouseEnter?: () => void
 }
 
 const ResourceRow = forwardRef<HTMLTableCellElement, ResourceRowProps>(
-  function ResourceRow({ resource, kind, columns, hasSpacerColumn, isSelected, isHighlighted, onClick, onMouseEnter }, ref) {
+  function ResourceRow({ resource, kind, columns, hasSpacerColumn, isSelected, isHighlighted, majorityNodeMinorVersion, onClick, onMouseEnter }, ref) {
     return (
       <tr
         onClick={onClick}
@@ -3059,7 +3078,7 @@ const ResourceRow = forwardRef<HTMLTableCellElement, ResourceRowProps>(
                 : 'group-hover/row:bg-theme-surface/50'
           )}
         >
-          <CellContent resource={resource} kind={kind} column={col.key} />
+          <CellContent resource={resource} kind={kind} column={col.key} majorityNodeMinorVersion={majorityNodeMinorVersion} />
         </td>
       ))}
       {hasSpacerColumn && <td className="border-b-subtle p-0" />}
@@ -3072,9 +3091,10 @@ interface CellContentProps {
   resource: any
   kind: string
   column: string
+  majorityNodeMinorVersion?: string
 }
 
-function CellContent({ resource, kind, column }: CellContentProps) {
+function CellContent({ resource, kind, column, majorityNodeMinorVersion }: CellContentProps) {
   const meta = resource.metadata || {}
 
   // Common columns
@@ -3137,7 +3157,7 @@ function CellContent({ resource, kind, column }: CellContentProps) {
     case 'horizontalpodautoscalers':
       return <HPACell resource={resource} column={column} />
     case 'nodes':
-      return <NodeCell resource={resource} column={column} />
+      return <NodeCell resource={resource} column={column} majorityNodeMinorVersion={majorityNodeMinorVersion} />
     case 'persistentvolumeclaims':
       return <PVCCell resource={resource} column={column} />
     case 'rollouts':
@@ -3869,7 +3889,7 @@ function buildResourceTooltip(
   )
 }
 
-function NodeCell({ resource, column }: { resource: any; column: string }) {
+function NodeCell({ resource, column, majorityNodeMinorVersion }: { resource: any; column: string; majorityNodeMinorVersion?: string }) {
   const metrics = useContext(MetricsContext)
 
   switch (column) {
@@ -3918,7 +3938,12 @@ function NodeCell({ resource, column }: { resource: any; column: string }) {
     }
     case 'version': {
       const version = getNodeVersion(resource)
-      return <span className="text-sm text-theme-text-secondary">{version}</span>
+      const isSkewed = majorityNodeMinorVersion && version && !version.startsWith(`v${majorityNodeMinorVersion}`)
+      return (
+        <span className={clsx('text-sm', isSkewed ? 'text-yellow-400 font-medium' : 'text-theme-text-secondary')}>
+          {version}
+        </span>
+      )
     }
     case 'cpu': {
       const m = metrics.nodes.get(resource.metadata?.name)


### PR DESCRIPTION
## Summary

During a cluster debugging exercise, two LLMs using radar's MCP dashboard both missed critical node-level problems (cordoned node, version skew) because the dashboard didn't surface them. Investigation revealed the MCP and REST dashboards had drifted apart with duplicated, incomplete code.

This PR:
- **Extracts shared health detection** into `internal/k8s/health.go` — eliminates code duplication between MCP and REST dashboards
- **Adds node problem detection** — cordoned nodes, version skew (minor version differences), and pressure conditions now appear in both dashboards
- **Converges MCP dashboard** with REST — adds missing StatefulSet/DaemonSet problems, uses the complete pod health classifier
- **Fixes secondary bugs** — events limit was stuck at max 20 (now up to 100), top warnings sorted by count instead of recency, helm releases sorted failed-first
- **Updates frontend** — cordoned segment in nodes health ring, version skew indicator with tooltip on dashboard, version skew highlighting in nodes table

## Key files

| File | What changed |
|------|-------------|
| `internal/k8s/health.go` | New shared health detection (node health, version skew, pod health, utilities) |
| `internal/k8s/health_test.go` | 29 test cases covering all detection functions |
| `internal/mcp/tools.go` | Deleted duplicates, added node/SS/DS problems, fixed bugs |
| `internal/server/dashboard.go` | Uses shared functions, added cordoned/skew/count fields |
| `internal/ai/context/summary.go` | Added Unschedulable to node summaries |
| `web/src/components/home/ClusterHealthCard.tsx` | Cordoned ring segment + version skew tooltip |
| `web/src/components/resources/ResourcesView.tsx` | Version skew highlighting in nodes table |