### PR TITLE
feat: expand radar dashboard with HPA/CronJob detection, metrics, and parity fixes

### DIFF
--- a/internal/ai/context/summary.go
+++ b/internal/ai/context/summary.go
@@ -312,6 +312,12 @@ func summarizeCronJob(cj *batchv1.CronJob) *ResourceSummary {
 
 	if cj.Spec.Suspend != nil && *cj.Spec.Suspend {
 		s.Suspended = cj.Spec.Suspend
+	} else {
+		if cj.Status.LastScheduleTime != nil && time.Since(cj.Status.LastScheduleTime.Time) > 24*time.Hour {
+			s.Issue = "no recent runs"
+		} else if cj.Status.LastScheduleTime == nil && time.Since(cj.CreationTimestamp.Time) > 24*time.Hour {
+			s.Issue = "never scheduled"
+		}
 	}
 
 	return s
@@ -331,6 +337,10 @@ func summarizeHPA(hpa *autoscalingv2.HorizontalPodAutoscaler) *ResourceSummary {
 
 	if hpa.Spec.MinReplicas != nil {
 		s.MinReplicas = hpa.Spec.MinReplicas
+	}
+
+	if hpa.Spec.MaxReplicas > 0 && hpa.Status.CurrentReplicas >= hpa.Spec.MaxReplicas && hpa.Status.DesiredReplicas >= hpa.Spec.MaxReplicas {
+		s.Issue = "maxed"
 	}
 
 	return s

--- a/internal/ai/context/summary_test.go
+++ b/internal/ai/context/summary_test.go
@@ -2,8 +2,10 @@ package context
 
 import (
 	"testing"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -557,6 +559,107 @@ func TestSummary_CronJob(t *testing.T) {
 	}
 	if s.Active != 2 {
 		t.Errorf("Active = %d, want 2", s.Active)
+	}
+}
+
+func TestSummary_HPAIssue(t *testing.T) {
+	tests := []struct {
+		name      string
+		hpa       *autoscalingv2.HorizontalPodAutoscaler
+		wantIssue string
+	}{
+		{
+			name: "maxed",
+			hpa: &autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					MaxReplicas:    10,
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{Kind: "Deployment", Name: "web"},
+				},
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{CurrentReplicas: 10, DesiredReplicas: 10},
+			},
+			wantIssue: "maxed",
+		},
+		{
+			name: "normal",
+			hpa: &autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					MaxReplicas:    10,
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{Kind: "Deployment", Name: "web"},
+				},
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{CurrentReplicas: 5, DesiredReplicas: 5},
+			},
+			wantIssue: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := Minify(tt.hpa, LevelSummary)
+			if err != nil {
+				t.Fatalf("Minify failed: %v", err)
+			}
+			s := raw.(*ResourceSummary)
+			if s.Issue != tt.wantIssue {
+				t.Errorf("Issue = %q, want %q", s.Issue, tt.wantIssue)
+			}
+		})
+	}
+}
+
+func TestSummary_CronJobIssue(t *testing.T) {
+	now := time.Now()
+	suspended := true
+	notSuspended := false
+	oldTime := metav1.NewTime(now.Add(-48 * time.Hour))
+	freshTime := metav1.NewTime(now.Add(-1 * time.Hour))
+
+	tests := []struct {
+		name      string
+		cj        *batchv1.CronJob
+		wantIssue string
+	}{
+		{
+			name: "stale",
+			cj: &batchv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "backup", Namespace: "default", CreationTimestamp: metav1.NewTime(now.Add(-72 * time.Hour))},
+				Spec:       batchv1.CronJobSpec{Schedule: "0 2 * * *", Suspend: &notSuspended},
+				Status:     batchv1.CronJobStatus{LastScheduleTime: &oldTime},
+			},
+			wantIssue: "no recent runs",
+		},
+		{
+			name: "suspended is ok",
+			cj: &batchv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "backup", Namespace: "default", CreationTimestamp: metav1.NewTime(now.Add(-72 * time.Hour))},
+				Spec:       batchv1.CronJobSpec{Schedule: "0 2 * * *", Suspend: &suspended},
+				Status:     batchv1.CronJobStatus{LastScheduleTime: &oldTime},
+			},
+			wantIssue: "",
+		},
+		{
+			name: "fresh is ok",
+			cj: &batchv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "backup", Namespace: "default", CreationTimestamp: metav1.NewTime(now.Add(-72 * time.Hour))},
+				Spec:       batchv1.CronJobSpec{Schedule: "0 2 * * *", Suspend: &notSuspended},
+				Status:     batchv1.CronJobStatus{LastScheduleTime: &freshTime},
+			},
+			wantIssue: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := Minify(tt.cj, LevelSummary)
+			if err != nil {
+				t.Fatalf("Minify failed: %v", err)
+			}
+			s := raw.(*ResourceSummary)
+			if s.Issue != tt.wantIssue {
+				t.Errorf("Issue = %q, want %q", s.Issue, tt.wantIssue)
+			}
+		})
 	}
 }
 

--- a/internal/k8s/health.go
+++ b/internal/k8s/health.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -240,4 +242,113 @@ func Truncate(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen-3] + "..."
+}
+
+// HPAProblem describes a detected issue with an HPA.
+type HPAProblem struct {
+	Name      string
+	Namespace string
+	Problem   string // "maxed"
+	Reason    string
+}
+
+// DetectHPAProblems finds HPAs that have hit their replica ceiling.
+func DetectHPAProblems(hpas []*autoscalingv2.HorizontalPodAutoscaler) []HPAProblem {
+	var problems []HPAProblem
+	for _, hpa := range hpas {
+		if hpa.Spec.MaxReplicas > 0 && hpa.Status.CurrentReplicas >= hpa.Spec.MaxReplicas && hpa.Status.DesiredReplicas >= hpa.Spec.MaxReplicas {
+			problems = append(problems, HPAProblem{
+				Name:      hpa.Name,
+				Namespace: hpa.Namespace,
+				Problem:   "maxed",
+				Reason:    fmt.Sprintf("%d/%d replicas (wants %d)", hpa.Status.CurrentReplicas, hpa.Spec.MaxReplicas, hpa.Status.DesiredReplicas),
+			})
+		}
+	}
+	return problems
+}
+
+// CronJobProblem describes a detected issue with a CronJob.
+type CronJobProblem struct {
+	Name      string
+	Namespace string
+	Problem   string // "stale" or "never-scheduled"
+	Reason    string
+}
+
+// DetectCronJobProblems finds non-suspended CronJobs that haven't run recently.
+func DetectCronJobProblems(cronjobs []*batchv1.CronJob) []CronJobProblem {
+	var problems []CronJobProblem
+	now := time.Now()
+	for _, cj := range cronjobs {
+		if cj.Spec.Suspend != nil && *cj.Spec.Suspend {
+			continue
+		}
+		if cj.Status.LastScheduleTime != nil {
+			sinceLast := now.Sub(cj.Status.LastScheduleTime.Time)
+			if sinceLast > 24*time.Hour {
+				problems = append(problems, CronJobProblem{
+					Name:      cj.Name,
+					Namespace: cj.Namespace,
+					Problem:   "stale",
+					Reason:    fmt.Sprintf("last run %dh ago", int(sinceLast.Hours())),
+				})
+			}
+		} else if now.Sub(cj.CreationTimestamp.Time) > 24*time.Hour {
+			problems = append(problems, CronJobProblem{
+				Name:      cj.Name,
+				Namespace: cj.Namespace,
+				Problem:   "never-scheduled",
+				Reason:    "created but never ran",
+			})
+		}
+	}
+	return problems
+}
+
+// ParseCPUToMillis parses CPU quantity strings like "250m", "1", "500n".
+func ParseCPUToMillis(s string) int64 {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	if before, ok := strings.CutSuffix(s, "n"); ok {
+		var val int64
+		fmt.Sscanf(before, "%d", &val)
+		return val / 1000000
+	}
+	if before, ok := strings.CutSuffix(s, "m"); ok {
+		var val int64
+		fmt.Sscanf(before, "%d", &val)
+		return val
+	}
+	var val int64
+	fmt.Sscanf(s, "%d", &val)
+	return val * 1000
+}
+
+// ParseMemoryToBytes parses memory quantity strings like "1024Ki", "256Mi", "1Gi".
+func ParseMemoryToBytes(s string) int64 {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	if before, ok := strings.CutSuffix(s, "Ki"); ok {
+		var val int64
+		fmt.Sscanf(before, "%d", &val)
+		return val * 1024
+	}
+	if before, ok := strings.CutSuffix(s, "Mi"); ok {
+		var val int64
+		fmt.Sscanf(before, "%d", &val)
+		return val * 1024 * 1024
+	}
+	if before, ok := strings.CutSuffix(s, "Gi"); ok {
+		var val int64
+		fmt.Sscanf(before, "%d", &val)
+		return val * 1024 * 1024 * 1024
+	}
+	var val int64
+	fmt.Sscanf(s, "%d", &val)
+	return val
 }

--- a/internal/k8s/health_test.go
+++ b/internal/k8s/health_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -445,6 +447,194 @@ func TestTruncate(t *testing.T) {
 		got := Truncate(tt.s, tt.maxLen)
 		if got != tt.want {
 			t.Errorf("Truncate(%q, %d) = %q, want %q", tt.s, tt.maxLen, got, tt.want)
+		}
+	}
+}
+
+func TestDetectHPAProblems(t *testing.T) {
+	tests := []struct {
+		name      string
+		hpas      []*autoscalingv2.HorizontalPodAutoscaler
+		wantCount int
+		wantProblem string
+	}{
+		{
+			name: "maxed HPA",
+			hpas: []*autoscalingv2.HorizontalPodAutoscaler{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+					Spec:       autoscalingv2.HorizontalPodAutoscalerSpec{MaxReplicas: 10},
+					Status:     autoscalingv2.HorizontalPodAutoscalerStatus{CurrentReplicas: 10, DesiredReplicas: 10},
+				},
+			},
+			wantCount:   1,
+			wantProblem: "maxed",
+		},
+		{
+			name: "not maxed",
+			hpas: []*autoscalingv2.HorizontalPodAutoscaler{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+					Spec:       autoscalingv2.HorizontalPodAutoscalerSpec{MaxReplicas: 10},
+					Status:     autoscalingv2.HorizontalPodAutoscalerStatus{CurrentReplicas: 5, DesiredReplicas: 5},
+				},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "zero replicas",
+			hpas: []*autoscalingv2.HorizontalPodAutoscaler{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "idle", Namespace: "default"},
+					Spec:       autoscalingv2.HorizontalPodAutoscalerSpec{MaxReplicas: 10},
+					Status:     autoscalingv2.HorizontalPodAutoscalerStatus{CurrentReplicas: 0, DesiredReplicas: 0},
+				},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "maxReplicas zero is not a problem",
+			hpas: []*autoscalingv2.HorizontalPodAutoscaler{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "broken", Namespace: "default"},
+					Spec:       autoscalingv2.HorizontalPodAutoscalerSpec{MaxReplicas: 0},
+					Status:     autoscalingv2.HorizontalPodAutoscalerStatus{CurrentReplicas: 0, DesiredReplicas: 0},
+				},
+			},
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			problems := DetectHPAProblems(tt.hpas)
+			if len(problems) != tt.wantCount {
+				t.Errorf("DetectHPAProblems() returned %d problems, want %d", len(problems), tt.wantCount)
+			}
+			if tt.wantCount > 0 && len(problems) > 0 {
+				if problems[0].Problem != tt.wantProblem {
+					t.Errorf("problem = %q, want %q", problems[0].Problem, tt.wantProblem)
+				}
+			}
+		})
+	}
+}
+
+func TestDetectCronJobProblems(t *testing.T) {
+	now := time.Now()
+	suspended := true
+	notSuspended := false
+	oldTime := metav1.NewTime(now.Add(-48 * time.Hour))
+	freshTime := metav1.NewTime(now.Add(-1 * time.Hour))
+
+	tests := []struct {
+		name        string
+		cronjobs    []*batchv1.CronJob
+		wantCount   int
+		wantProblem string
+	}{
+		{
+			name: "stale cronjob",
+			cronjobs: []*batchv1.CronJob{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "backup", Namespace: "default", CreationTimestamp: metav1.NewTime(now.Add(-72 * time.Hour))},
+					Spec:       batchv1.CronJobSpec{Schedule: "0 2 * * *", Suspend: &notSuspended},
+					Status:     batchv1.CronJobStatus{LastScheduleTime: &oldTime},
+				},
+			},
+			wantCount:   1,
+			wantProblem: "stale",
+		},
+		{
+			name: "suspended old cronjob is ok",
+			cronjobs: []*batchv1.CronJob{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "backup", Namespace: "default", CreationTimestamp: metav1.NewTime(now.Add(-72 * time.Hour))},
+					Spec:       batchv1.CronJobSpec{Schedule: "0 2 * * *", Suspend: &suspended},
+					Status:     batchv1.CronJobStatus{LastScheduleTime: &oldTime},
+				},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "fresh cronjob is ok",
+			cronjobs: []*batchv1.CronJob{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "backup", Namespace: "default", CreationTimestamp: metav1.NewTime(now.Add(-72 * time.Hour))},
+					Spec:       batchv1.CronJobSpec{Schedule: "0 2 * * *", Suspend: &notSuspended},
+					Status:     batchv1.CronJobStatus{LastScheduleTime: &freshTime},
+				},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "never-scheduled cronjob",
+			cronjobs: []*batchv1.CronJob{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "new-cron", Namespace: "default", CreationTimestamp: metav1.NewTime(now.Add(-48 * time.Hour))},
+					Spec:       batchv1.CronJobSpec{Schedule: "0 * * * *", Suspend: &notSuspended},
+					Status:     batchv1.CronJobStatus{},
+				},
+			},
+			wantCount:   1,
+			wantProblem: "never-scheduled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			problems := DetectCronJobProblems(tt.cronjobs)
+			if len(problems) != tt.wantCount {
+				t.Errorf("DetectCronJobProblems() returned %d problems, want %d", len(problems), tt.wantCount)
+			}
+			if tt.wantCount > 0 && len(problems) > 0 {
+				if problems[0].Problem != tt.wantProblem {
+					t.Errorf("problem = %q, want %q", problems[0].Problem, tt.wantProblem)
+				}
+			}
+		})
+	}
+}
+
+func TestParseCPUToMillis(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int64
+	}{
+		{"", 0},
+		{"0", 0},
+		{"1", 1000},
+		{"2", 2000},
+		{"250m", 250},
+		{"1000m", 1000},
+		{"500000000n", 500},
+		{"100000000n", 100},
+	}
+	for _, tt := range tests {
+		got := ParseCPUToMillis(tt.input)
+		if got != tt.want {
+			t.Errorf("ParseCPUToMillis(%q) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestParseMemoryToBytes(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int64
+	}{
+		{"", 0},
+		{"0", 0},
+		{"1024", 1024},
+		{"1024Ki", 1024 * 1024},
+		{"256Mi", 256 * 1024 * 1024},
+		{"1Gi", 1024 * 1024 * 1024},
+		{"2Gi", 2 * 1024 * 1024 * 1024},
+	}
+	for _, tt := range tests {
+		got := ParseMemoryToBytes(tt.input)
+		if got != tt.want {
+			t.Errorf("ParseMemoryToBytes(%q) = %d, want %d", tt.input, got, tt.want)
 		}
 	}
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -111,7 +113,7 @@ type topologyInput struct {
 
 type eventsInput struct {
 	Namespace string `json:"namespace,omitempty" jsonschema:"filter to a specific namespace"`
-	Limit     int    `json:"limit,omitempty" jsonschema:"maximum number of events to return (default 20)"`
+	Limit     int    `json:"limit,omitempty" jsonschema:"max 100, default 20"`
 }
 
 type podLogsInput struct {
@@ -329,12 +331,16 @@ func handleListNamespaces(ctx context.Context, req *mcp.CallToolRequest, input s
 		return nil, nil, fmt.Errorf("failed to list namespaces: %w", err)
 	}
 
-	result := make([]map[string]string, 0, len(namespaces))
+	result := make([]map[string]any, 0, len(namespaces))
 	for _, ns := range namespaces {
-		result = append(result, map[string]string{
+		entry := map[string]any{
 			"name":   ns.Name,
 			"status": string(ns.Status.Phase),
-		})
+		}
+		if len(ns.Labels) > 0 {
+			entry["labels"] = ns.Labels
+		}
+		result = append(result, entry)
 	}
 
 	return toJSONResult(result)
@@ -351,9 +357,17 @@ type mcpDashboard struct {
 	WarningEvents  int              `json:"warningEvents"`
 	TopWarnings    []mcpWarning     `json:"topWarnings"`
 	HelmReleases   mcpHelmSummary   `json:"helmReleases"`
+	Metrics        *mcpMetrics      `json:"metrics,omitempty"`
 	TopologyNodes  int              `json:"topologyNodes"`
 	TopologyEdges  int              `json:"topologyEdges"`
 	ResourceCounts map[string]int   `json:"resourceCounts"`
+}
+
+type mcpMetrics struct {
+	CPUUsagePercent   int `json:"cpuUsagePercent,omitempty"`
+	CPURequestPercent int `json:"cpuRequestPercent,omitempty"`
+	MemUsagePercent   int `json:"memUsagePercent,omitempty"`
+	MemRequestPercent int `json:"memRequestPercent,omitempty"`
 }
 
 type mcpClusterInfo struct {
@@ -396,10 +410,12 @@ type mcpHelmSummary struct {
 }
 
 type mcpHelmRelease struct {
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
-	Chart     string `json:"chart"`
-	Status    string `json:"status"`
+	Name           string `json:"name"`
+	Namespace      string `json:"namespace"`
+	Chart          string `json:"chart"`
+	ChartVersion   string `json:"chartVersion"`
+	Status         string `json:"status"`
+	ResourceHealth string `json:"resourceHealth,omitempty"`
 }
 
 func buildDashboard(ctx context.Context, cache *k8s.ResourceCache, namespace string) mcpDashboard {
@@ -543,6 +559,46 @@ func buildDashboard(ctx context.Context, cache *k8s.ResourceCache, namespace str
 		}
 	}
 
+	// HPA problems
+	if hpaLister := cache.HorizontalPodAutoscalers(); hpaLister != nil {
+		var hpas []*autoscalingv2.HorizontalPodAutoscaler
+		if namespace != "" {
+			hpas, _ = hpaLister.HorizontalPodAutoscalers(namespace).List(labels.Everything())
+		} else {
+			hpas, _ = hpaLister.List(labels.Everything())
+		}
+		for _, hp := range k8s.DetectHPAProblems(hpas) {
+			if len(d.Problems) < 10 {
+				d.Problems = append(d.Problems, mcpProblem{
+					Kind:      "HorizontalPodAutoscaler",
+					Namespace: hp.Namespace,
+					Name:      hp.Name,
+					Reason:    hp.Reason,
+				})
+			}
+		}
+	}
+
+	// CronJob problems
+	if cjLister := cache.CronJobs(); cjLister != nil {
+		var cronjobs []*batchv1.CronJob
+		if namespace != "" {
+			cronjobs, _ = cjLister.CronJobs(namespace).List(labels.Everything())
+		} else {
+			cronjobs, _ = cjLister.List(labels.Everything())
+		}
+		for _, cp := range k8s.DetectCronJobProblems(cronjobs) {
+			if len(d.Problems) < 10 {
+				d.Problems = append(d.Problems, mcpProblem{
+					Kind:      "CronJob",
+					Namespace: cp.Namespace,
+					Name:      cp.Name,
+					Reason:    cp.Reason,
+				})
+			}
+		}
+	}
+
 	// Node problems (cluster-scoped, not filtered by namespace)
 	if nodeLister := cache.Nodes(); nodeLister != nil {
 		nodes, _ := nodeLister.List(labels.Everything())
@@ -640,11 +696,77 @@ func buildDashboard(ctx context.Context, cache *k8s.ResourceCache, namespace str
 			limit := min(len(releases), 5)
 			for _, r := range releases[:limit] {
 				d.HelmReleases.Releases = append(d.HelmReleases.Releases, mcpHelmRelease{
-					Name:      r.Name,
-					Namespace: r.Namespace,
-					Chart:     r.Chart,
-					Status:    r.Status,
+					Name:           r.Name,
+					Namespace:      r.Namespace,
+					Chart:          r.Chart,
+					ChartVersion:   r.ChartVersion,
+					Status:         r.Status,
+					ResourceHealth: r.ResourceHealth,
 				})
+			}
+		}
+	}
+
+	// Metrics (best-effort — silently skip if metrics-server unavailable)
+	if client := k8s.GetClient(); client != nil {
+		data, err := client.RESTClient().Get().
+			AbsPath("/apis/metrics.k8s.io/v1beta1/nodes").
+			DoRaw(ctx)
+		if err == nil {
+			var nodeMetricsList struct {
+				Items []struct {
+					Usage struct {
+						CPU    string `json:"cpu"`
+						Memory string `json:"memory"`
+					} `json:"usage"`
+				} `json:"items"`
+			}
+			if err := json.Unmarshal(data, &nodeMetricsList); err != nil {
+				log.Printf("[mcp] Failed to parse node metrics: %v", err)
+			} else if len(nodeMetricsList.Items) > 0 {
+				if nodeLister := cache.Nodes(); nodeLister != nil {
+					allNodes, _ := nodeLister.List(labels.Everything())
+					var cpuCapMillis, memCapBytes int64
+					for _, n := range allNodes {
+						cpuCapMillis += n.Status.Capacity.Cpu().MilliValue()
+						memCapBytes += n.Status.Capacity.Memory().Value()
+					}
+
+					var cpuUsageMillis, memUsageBytes int64
+					for _, item := range nodeMetricsList.Items {
+						cpuUsageMillis += k8s.ParseCPUToMillis(item.Usage.CPU)
+						memUsageBytes += k8s.ParseMemoryToBytes(item.Usage.Memory)
+					}
+
+					var cpuReqMillis, memReqBytes int64
+					if podLister := cache.Pods(); podLister != nil {
+						allPods, _ := podLister.List(labels.Everything())
+						for _, pod := range allPods {
+							if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+								continue
+							}
+							for _, c := range pod.Spec.Containers {
+								if c.Resources.Requests != nil {
+									if cpu, ok := c.Resources.Requests[corev1.ResourceCPU]; ok {
+										cpuReqMillis += cpu.MilliValue()
+									}
+									if mem, ok := c.Resources.Requests[corev1.ResourceMemory]; ok {
+										memReqBytes += mem.Value()
+									}
+								}
+							}
+						}
+					}
+
+					if cpuCapMillis > 0 && memCapBytes > 0 {
+						d.Metrics = &mcpMetrics{
+							CPUUsagePercent:   int(cpuUsageMillis * 100 / cpuCapMillis),
+							CPURequestPercent: int(cpuReqMillis * 100 / cpuCapMillis),
+							MemUsagePercent:   int(memUsageBytes * 100 / memCapBytes),
+							MemRequestPercent: int(memReqBytes * 100 / memCapBytes),
+						}
+					}
+				}
 			}
 		}
 	}

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -7,10 +7,11 @@ import (
 	"log"
 	"net/http"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -430,6 +431,46 @@ func (s *Server) getDashboardHealth(cache *k8s.ResourceCache, namespace string) 
 					})
 				}
 			}
+		}
+	}
+
+	// HPA problems: maxed out
+	if hpaLister := cache.HorizontalPodAutoscalers(); hpaLister != nil {
+		var hpas []*autoscalingv2.HorizontalPodAutoscaler
+		if namespace != "" {
+			hpas, _ = hpaLister.HorizontalPodAutoscalers(namespace).List(labels.Everything())
+		} else {
+			hpas, _ = hpaLister.List(labels.Everything())
+		}
+		for _, hp := range k8s.DetectHPAProblems(hpas) {
+			problems = append(problems, DashboardProblem{
+				Kind:      "HorizontalPodAutoscaler",
+				Namespace: hp.Namespace,
+				Name:      hp.Name,
+				Status:    "warning",
+				Reason:    hp.Problem,
+				Message:   hp.Reason,
+			})
+		}
+	}
+
+	// CronJob problems: stale or never-scheduled
+	if cjLister := cache.CronJobs(); cjLister != nil {
+		var cronjobs []*batchv1.CronJob
+		if namespace != "" {
+			cronjobs, _ = cjLister.CronJobs(namespace).List(labels.Everything())
+		} else {
+			cronjobs, _ = cjLister.List(labels.Everything())
+		}
+		for _, cp := range k8s.DetectCronJobProblems(cronjobs) {
+			problems = append(problems, DashboardProblem{
+				Kind:      "CronJob",
+				Namespace: cp.Namespace,
+				Name:      cp.Name,
+				Status:    "warning",
+				Reason:    cp.Problem,
+				Message:   cp.Reason,
+			})
 		}
 	}
 
@@ -870,6 +911,11 @@ func (s *Server) getDashboardRecentEvents(cache *k8s.ResourceCache, namespace st
 	}
 
 	sort.Slice(warnings, func(i, j int) bool {
+		ci := max(warnings[i].Count, 1)
+		cj := max(warnings[j].Count, 1)
+		if ci != cj {
+			return ci > cj
+		}
 		ti := warnings[i].LastTimestamp.Time
 		tj := warnings[j].LastTimestamp.Time
 		if ti.IsZero() {
@@ -1210,60 +1256,11 @@ func (s *Server) getDashboardMetrics(ctx context.Context) *DashboardMetrics {
 	return metrics
 }
 
-// parseCPUToMillis parses CPU quantity strings like "250m", "1", "500n"
-func parseCPUToMillis(s string) int64 {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return 0
-	}
-	if before, ok := strings.CutSuffix(s, "n"); ok {
-		// nanocores
-		s = before
-		var val int64
-		fmt.Sscanf(s, "%d", &val)
-		return val / 1000000
-	}
-	if before, ok := strings.CutSuffix(s, "m"); ok {
-		s = before
-		var val int64
-		fmt.Sscanf(s, "%d", &val)
-		return val
-	}
-	// Plain number = cores
-	var val int64
-	fmt.Sscanf(s, "%d", &val)
-	return val * 1000
-}
+// parseCPUToMillis delegates to k8s.ParseCPUToMillis.
+func parseCPUToMillis(s string) int64 { return k8s.ParseCPUToMillis(s) }
 
-// parseMemoryToBytes parses memory quantity strings like "1024Ki", "256Mi", "1Gi"
-func parseMemoryToBytes(s string) int64 {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return 0
-	}
-	if before, ok := strings.CutSuffix(s, "Ki"); ok {
-		s = before
-		var val int64
-		fmt.Sscanf(s, "%d", &val)
-		return val * 1024
-	}
-	if before, ok := strings.CutSuffix(s, "Mi"); ok {
-		s = before
-		var val int64
-		fmt.Sscanf(s, "%d", &val)
-		return val * 1024 * 1024
-	}
-	if before, ok := strings.CutSuffix(s, "Gi"); ok {
-		s = before
-		var val int64
-		fmt.Sscanf(s, "%d", &val)
-		return val * 1024 * 1024 * 1024
-	}
-	// Plain bytes
-	var val int64
-	fmt.Sscanf(s, "%d", &val)
-	return val
-}
+// parseMemoryToBytes delegates to k8s.ParseMemoryToBytes.
+func parseMemoryToBytes(s string) int64 { return k8s.ParseMemoryToBytes(s) }
 
 // Helper functions
 


### PR DESCRIPTION
## Summary

- Add shared `DetectHPAProblems` and `DetectCronJobProblems` to `k8s/health.go`, surfaced in both MCP and REST dashboards
- Add cluster metrics summary (CPU/memory usage & request percentages) to the MCP dashboard, reusing shared `ParseCPUToMillis`/`ParseMemoryToBytes` helpers moved from `server/dashboard.go`
- Fix REST events sort to count-primary, recency-secondary (matching MCP behavior)
- Add `ChartVersion` and `ResourceHealth` fields to MCP Helm releases
- Include namespace labels in `list_namespaces` output
- Add inline HPA maxed / CronJob stale issue detection in AI summaries
- Update events limit schema description to `"max 100, default 20"`

## Test plan

- [x] `go test ./internal/k8s/...` — HPA/CronJob detection, parse helper, and edge case tests pass
- [x] `go test ./internal/ai/context/...` — AI summary issue tests pass
- [x] `go test ./...` — no regressions
- [x] `make backend` — clean build