### PR TITLE
Consolidate MCP/REST shared logic into dedicated packages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -469,8 +469,8 @@ GET  /api/ai/resources/{kind}/{ns}/{name}     # Minified single resource (verbos
 
 ### MCP Server
 - Stateless HTTP handler mounted at `/mcp` (JSON-RPC over HTTP)
-- 13 tools organized into read and write categories:
-  - **Read tools** (7): `get_dashboard`, `list_resources`, `get_resource`, `get_topology`, `get_events`, `get_pod_logs`, `list_namespaces`
+- 14 tools organized into read and write categories:
+  - **Read tools** (8): `get_dashboard` (with problem-correlated changes), `list_resources`, `get_resource` (with optional `include`: events, relationships, metrics, logs), `get_topology` (with `format`: graph or summary), `get_events` (with optional `kind`/`name` resource filter), `get_pod_logs`, `list_namespaces`, `get_changes` (timeline of resource mutations)
   - **Read tools — Helm** (2): `list_helm_releases`, `get_helm_release` (with optional values/history/diff)
   - **Read tools — Logs** (1): `get_workload_logs` (aggregated, AI-filtered logs across all pods)
   - **Write tools** (3): `manage_workload` (restart/scale/rollback), `manage_cronjob` (trigger/suspend/resume), `manage_gitops` (ArgoCD sync/suspend/resume, FluxCD reconcile/suspend/resume)

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -165,13 +165,14 @@ Add to `~/.gemini/settings.json`:
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `get_dashboard` | Cluster health overview — resource counts, problems, warning events, Helm status | `namespace` (optional) |
+| `get_dashboard` | Cluster health overview — resource counts, problems, warning events, Helm status. Includes recent changes correlated with detected problems. | `namespace` (optional) |
 | `list_resources` | List resources of a kind with minified summaries (pods, deployments, services, CRDs, etc.) | `kind` (required), `namespace` (optional) |
-| `get_resource` | Detailed view of a single resource — minified spec, status, metadata | `kind` (required), `namespace` (required), `name` (required) |
-| `get_topology` | Topology graph showing resource relationships (nodes and edges) | `namespace` (optional), `view` (optional: `traffic` or `resources`) |
-| `get_events` | Recent warning events, deduplicated and sorted by recency | `namespace` (optional), `limit` (optional, default 20) |
+| `get_resource` | Detailed view of a single resource — minified spec, status, metadata. Optionally include related context to avoid extra tool calls. | `kind` (required), `namespace` (required), `name` (required), `include` (optional: `events,relationships,metrics,logs`) |
+| `get_topology` | Topology graph showing resource relationships (nodes and edges). Use `summary` format for LLM-friendly text descriptions of resource chains. | `namespace` (optional), `view` (optional: `traffic` or `resources`), `format` (optional: `graph` or `summary`) |
+| `get_events` | Recent warning events, deduplicated and sorted by recency. Filter by resource kind/name to scope to a specific resource. | `namespace` (optional), `limit` (optional, default 20), `kind` (optional), `name` (optional) |
 | `get_pod_logs` | Filtered pod logs prioritizing errors/warnings, with secret redaction | `namespace` (required), `name` (required), `container` (optional), `tail_lines` (optional) |
 | `list_namespaces` | List all namespaces with status | (none) |
+| `get_changes` | Recent resource changes (creates, updates, deletes) from the cluster timeline. Use to investigate what changed before an incident. | `namespace` (optional), `kind` (optional), `name` (optional), `since` (optional, e.g. `1h`, `30m`; default `1h`), `limit` (optional, default 20, max 50) |
 | `list_helm_releases` | List all Helm releases with status and health | `namespace` (optional) |
 | `get_helm_release` | Detailed Helm release info with optional values, history, and manifest diff | `namespace` (required), `name` (required), `include` (optional: `values,history,diff`), `diff_revision_1` / `diff_revision_2` (optional) |
 | `get_workload_logs` | Aggregated, AI-filtered logs from all pods of a workload (Deployment, StatefulSet, DaemonSet) | `kind` (required), `namespace` (required), `name` (required), `container` (optional), `tail_lines` (optional) |

--- a/internal/gitops/operations.go
+++ b/internal/gitops/operations.go
@@ -1,0 +1,456 @@
+package gitops
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+)
+
+// ArgoAppGVR is the GVR for ArgoCD Application resources.
+var ArgoAppGVR = schema.GroupVersionResource{
+	Group:    "argoproj.io",
+	Version:  "v1alpha1",
+	Resource: "applications",
+}
+
+// FluxKindEntry maps a lowercase kind to its GVR and canonical Kind name.
+type FluxKindEntry struct {
+	GVR  schema.GroupVersionResource
+	Kind string // e.g. "GitRepository"
+}
+
+// FluxKinds is the authoritative map of supported FluxCD resource kinds.
+var FluxKinds = map[string]FluxKindEntry{
+	"gitrepository":  {GVR: schema.GroupVersionResource{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "gitrepositories"}, Kind: "GitRepository"},
+	"ocirepository":  {GVR: schema.GroupVersionResource{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "ocirepositories"}, Kind: "OCIRepository"},
+	"helmrepository": {GVR: schema.GroupVersionResource{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "helmrepositories"}, Kind: "HelmRepository"},
+	"kustomization":  {GVR: schema.GroupVersionResource{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Resource: "kustomizations"}, Kind: "Kustomization"},
+	"helmrelease":    {GVR: schema.GroupVersionResource{Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"}, Kind: "HelmRelease"},
+	"alert":          {GVR: schema.GroupVersionResource{Group: "notification.toolkit.fluxcd.io", Version: "v1beta3", Resource: "alerts"}, Kind: "Alert"},
+}
+
+// ResolveFluxKind resolves any form (singular, plural, any case) to FluxKindEntry.
+func ResolveFluxKind(kind string) (FluxKindEntry, error) {
+	k := strings.ToLower(kind)
+
+	// Direct match on singular key
+	if entry, ok := FluxKinds[k]; ok {
+		return entry, nil
+	}
+
+	// Match on plural resource name or canonical Kind (case-insensitive)
+	for _, entry := range FluxKinds {
+		if strings.ToLower(entry.GVR.Resource) == k || strings.ToLower(entry.Kind) == k {
+			return entry, nil
+		}
+	}
+
+	supported := make([]string, 0, len(FluxKinds))
+	for k := range FluxKinds {
+		supported = append(supported, k)
+	}
+	return FluxKindEntry{}, fmt.Errorf("unknown FluxCD kind %q: supported kinds are %s", kind, strings.Join(supported, ", "))
+}
+
+// OperationResult is a transport-neutral result from a GitOps operation.
+type OperationResult struct {
+	Message     string
+	Operation   string // sync, reconcile, suspend, resume, refresh, terminate
+	Tool        string // argocd, fluxcd
+	Kind        string // Application, Kustomization, etc.
+	Namespace   string
+	Name        string
+	RequestedAt string     // RFC3339Nano, empty if not timed
+	Source      *SourceRef // only for sync-with-source
+}
+
+// SourceRef identifies the source resource in sync-with-source operations.
+type SourceRef struct {
+	Kind      string
+	Namespace string
+	Name      string
+}
+
+// --- ArgoCD operations ---
+
+// SyncArgoApp triggers a sync operation on an ArgoCD Application.
+func SyncArgoApp(ctx context.Context, dynClient dynamic.Interface, namespace, name string) (OperationResult, error) {
+	app, err := dynClient.Resource(ArgoAppGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return OperationResult{}, fmt.Errorf("ArgoCD Application %s/%s not found", namespace, name)
+		}
+		return OperationResult{}, fmt.Errorf("failed to get Application: %w", err)
+	}
+
+	phase, found, _ := unstructured.NestedString(app.Object, "status", "operationState", "phase")
+	if found && phase == "Running" {
+		return OperationResult{}, fmt.Errorf("sync operation already in progress for %s/%s", namespace, name)
+	}
+
+	timestamp := time.Now().Format(time.RFC3339Nano)
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]string{
+				"argocd.argoproj.io/refresh": "hard",
+			},
+		},
+		"operation": map[string]any{
+			"initiatedBy": map[string]any{
+				"username": "radar",
+			},
+			"sync": map[string]any{
+				"revision": "",
+				"prune":    true,
+			},
+		},
+	}
+
+	if err := mergePatch(ctx, dynClient, ArgoAppGVR, namespace, name, patch); err != nil {
+		return OperationResult{}, fmt.Errorf("failed to sync Application %s/%s: %w", namespace, name, err)
+	}
+
+	return OperationResult{
+		Message:     fmt.Sprintf("Sync initiated for ArgoCD Application %s/%s", namespace, name),
+		Operation:   "sync",
+		Tool:        "argocd",
+		Kind:        "Application",
+		Namespace:   namespace,
+		Name:        name,
+		RequestedAt: timestamp,
+	}, nil
+}
+
+// SetArgoAutoSync enables or disables automated sync on an ArgoCD Application.
+func SetArgoAutoSync(ctx context.Context, dynClient dynamic.Interface, namespace, name string, enable bool) (OperationResult, error) {
+	app, err := dynClient.Resource(ArgoAppGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return OperationResult{}, fmt.Errorf("ArgoCD Application %s/%s not found", namespace, name)
+		}
+		return OperationResult{}, fmt.Errorf("failed to get Application: %w", err)
+	}
+
+	var patch map[string]any
+	operation := "suspend"
+	pastAction := "suspended"
+
+	if enable {
+		operation = "resume"
+		pastAction = "resumed"
+		prune := true
+		selfHeal := true
+
+		annotations, _, _ := unstructured.NestedStringMap(app.Object, "metadata", "annotations")
+		if annotations != nil {
+			if v, ok := annotations["radar.skyhook.io/suspended-prune"]; ok {
+				prune = v == "true"
+			}
+			if v, ok := annotations["radar.skyhook.io/suspended-selfheal"]; ok {
+				selfHeal = v == "true"
+			}
+		}
+
+		patch = map[string]any{
+			"metadata": map[string]any{
+				"annotations": map[string]any{
+					"radar.skyhook.io/suspended-prune":    nil,
+					"radar.skyhook.io/suspended-selfheal": nil,
+				},
+			},
+			"spec": map[string]any{
+				"syncPolicy": map[string]any{
+					"automated": map[string]any{
+						"prune":    prune,
+						"selfHeal": selfHeal,
+					},
+				},
+			},
+		}
+	} else {
+		prune := false
+		selfHeal := false
+
+		automated, found, _ := unstructured.NestedMap(app.Object, "spec", "syncPolicy", "automated")
+		if found && automated != nil {
+			if v, ok := automated["prune"].(bool); ok {
+				prune = v
+			}
+			if v, ok := automated["selfHeal"].(bool); ok {
+				selfHeal = v
+			}
+		}
+
+		patch = map[string]any{
+			"metadata": map[string]any{
+				"annotations": map[string]string{
+					"radar.skyhook.io/suspended-prune":    fmt.Sprintf("%v", prune),
+					"radar.skyhook.io/suspended-selfheal": fmt.Sprintf("%v", selfHeal),
+				},
+			},
+			"spec": map[string]any{
+				"syncPolicy": map[string]any{
+					"automated": nil,
+				},
+			},
+		}
+	}
+
+	if err := mergePatch(ctx, dynClient, ArgoAppGVR, namespace, name, patch); err != nil {
+		return OperationResult{}, fmt.Errorf("failed to %s Application %s/%s: %w", operation, namespace, name, err)
+	}
+
+	return OperationResult{
+		Message:   fmt.Sprintf("ArgoCD Application %s/%s auto-sync %s", namespace, name, pastAction),
+		Operation: operation,
+		Tool:      "argocd",
+		Kind:      "Application",
+		Namespace: namespace,
+		Name:      name,
+	}, nil
+}
+
+// RefreshArgoApp triggers a refresh on an ArgoCD Application.
+func RefreshArgoApp(ctx context.Context, dynClient dynamic.Interface, namespace, name, refreshType string) (OperationResult, error) {
+	timestamp := time.Now().Format(time.RFC3339Nano)
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]string{
+				"argocd.argoproj.io/refresh": refreshType,
+			},
+		},
+	}
+
+	if err := mergePatch(ctx, dynClient, ArgoAppGVR, namespace, name, patch); err != nil {
+		if apierrors.IsNotFound(err) {
+			return OperationResult{}, fmt.Errorf("ArgoCD Application %s/%s not found", namespace, name)
+		}
+		return OperationResult{}, fmt.Errorf("failed to refresh Application %s/%s: %w", namespace, name, err)
+	}
+
+	return OperationResult{
+		Message:     fmt.Sprintf("Refresh (%s) triggered for ArgoCD Application %s/%s", refreshType, namespace, name),
+		Operation:   "refresh",
+		Tool:        "argocd",
+		Kind:        "Application",
+		Namespace:   namespace,
+		Name:        name,
+		RequestedAt: timestamp,
+	}, nil
+}
+
+// TerminateArgoSync terminates an ongoing sync operation on an ArgoCD Application.
+func TerminateArgoSync(ctx context.Context, dynClient dynamic.Interface, namespace, name string) (OperationResult, error) {
+	app, err := dynClient.Resource(ArgoAppGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return OperationResult{}, fmt.Errorf("ArgoCD Application %s/%s not found", namespace, name)
+		}
+		return OperationResult{}, fmt.Errorf("failed to get Application: %w", err)
+	}
+
+	phase, found, _ := unstructured.NestedString(app.Object, "status", "operationState", "phase")
+	if !found || phase != "Running" {
+		return OperationResult{}, fmt.Errorf("no sync operation in progress for %s/%s", namespace, name)
+	}
+
+	patchBytes := []byte(`[{"op": "remove", "path": "/operation"}]`)
+	_, err = dynClient.Resource(ArgoAppGVR).Namespace(namespace).Patch(
+		ctx, name, types.JSONPatchType, patchBytes, metav1.PatchOptions{},
+	)
+	if err != nil {
+		if strings.Contains(err.Error(), "nonexistent") {
+			return OperationResult{
+				Message:   fmt.Sprintf("No operation to terminate for ArgoCD Application %s/%s (may have already completed)", namespace, name),
+				Operation: "terminate",
+				Tool:      "argocd",
+				Kind:      "Application",
+				Namespace: namespace,
+				Name:      name,
+			}, nil
+		}
+		return OperationResult{}, fmt.Errorf("failed to terminate sync for Application %s/%s: %w", namespace, name, err)
+	}
+
+	return OperationResult{
+		Message:   fmt.Sprintf("Sync operation terminated for ArgoCD Application %s/%s", namespace, name),
+		Operation: "terminate",
+		Tool:      "argocd",
+		Kind:      "Application",
+		Namespace: namespace,
+		Name:      name,
+	}, nil
+}
+
+// --- FluxCD operations ---
+
+// ReconcileFlux triggers a reconciliation on a FluxCD resource.
+func ReconcileFlux(ctx context.Context, dynClient dynamic.Interface, entry FluxKindEntry, namespace, name string) (OperationResult, error) {
+	timestamp := time.Now().Format(time.RFC3339Nano)
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]string{
+				"reconcile.fluxcd.io/requestedAt": timestamp,
+			},
+		},
+	}
+
+	if err := mergePatch(ctx, dynClient, entry.GVR, namespace, name, patch); err != nil {
+		if apierrors.IsNotFound(err) {
+			return OperationResult{}, fmt.Errorf("FluxCD %s %s/%s not found", entry.Kind, namespace, name)
+		}
+		return OperationResult{}, fmt.Errorf("failed to reconcile %s %s/%s: %w", entry.Kind, namespace, name, err)
+	}
+
+	return OperationResult{
+		Message:     fmt.Sprintf("Reconciliation triggered for FluxCD %s %s/%s", entry.Kind, namespace, name),
+		Operation:   "reconcile",
+		Tool:        "fluxcd",
+		Kind:        entry.Kind,
+		Namespace:   namespace,
+		Name:        name,
+		RequestedAt: timestamp,
+	}, nil
+}
+
+// SetFluxSuspend sets the suspend field on a FluxCD resource.
+func SetFluxSuspend(ctx context.Context, dynClient dynamic.Interface, entry FluxKindEntry, namespace, name string, suspend bool) (OperationResult, error) {
+	patch := map[string]any{
+		"spec": map[string]any{
+			"suspend": suspend,
+		},
+	}
+
+	if err := mergePatch(ctx, dynClient, entry.GVR, namespace, name, patch); err != nil {
+		if apierrors.IsNotFound(err) {
+			return OperationResult{}, fmt.Errorf("FluxCD %s %s/%s not found", entry.Kind, namespace, name)
+		}
+		return OperationResult{}, fmt.Errorf("failed to update %s %s/%s: %w", entry.Kind, namespace, name, err)
+	}
+
+	operation := "suspend"
+	action := "suspended"
+	if !suspend {
+		operation = "resume"
+		action = "resumed"
+	}
+
+	return OperationResult{
+		Message:   fmt.Sprintf("FluxCD %s %s/%s %s", entry.Kind, namespace, name, action),
+		Operation: operation,
+		Tool:      "fluxcd",
+		Kind:      entry.Kind,
+		Namespace: namespace,
+		Name:      name,
+	}, nil
+}
+
+// SyncFluxWithSource reconciles the source first, then the resource itself.
+func SyncFluxWithSource(ctx context.Context, dynClient dynamic.Interface, kind, namespace, name string) (OperationResult, error) {
+	entry, err := ResolveFluxKind(kind)
+	if err != nil {
+		return OperationResult{}, err
+	}
+
+	// Get the resource to extract sourceRef
+	resource, err := dynClient.Resource(entry.GVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return OperationResult{}, fmt.Errorf("FluxCD %s %s/%s not found", entry.Kind, namespace, name)
+		}
+		return OperationResult{}, fmt.Errorf("failed to get %s %s/%s: %w", entry.Kind, namespace, name, err)
+	}
+
+	// Extract sourceRef based on kind
+	var sourceKind, sourceName, sourceNamespace string
+	spec, ok := resource.Object["spec"].(map[string]any)
+	if !ok {
+		return OperationResult{}, fmt.Errorf("invalid resource spec for %s %s/%s", entry.Kind, namespace, name)
+	}
+
+	switch entry.Kind {
+	case "Kustomization":
+		if sourceRef, ok := spec["sourceRef"].(map[string]any); ok {
+			sourceKind, _ = sourceRef["kind"].(string)
+			sourceName, _ = sourceRef["name"].(string)
+			sourceNamespace, _ = sourceRef["namespace"].(string)
+		}
+	case "HelmRelease":
+		if chart, ok := spec["chart"].(map[string]any); ok {
+			if chartSpec, ok := chart["spec"].(map[string]any); ok {
+				if sourceRef, ok := chartSpec["sourceRef"].(map[string]any); ok {
+					sourceKind, _ = sourceRef["kind"].(string)
+					sourceName, _ = sourceRef["name"].(string)
+					sourceNamespace, _ = sourceRef["namespace"].(string)
+				}
+			}
+		}
+	default:
+		return OperationResult{}, fmt.Errorf("sync-with-source only supported for Kustomization and HelmRelease")
+	}
+
+	if sourceName == "" {
+		return OperationResult{}, fmt.Errorf("no source reference found in %s %s/%s", entry.Kind, namespace, name)
+	}
+
+	if sourceNamespace == "" {
+		sourceNamespace = namespace
+	}
+
+	sourceEntry, err := ResolveFluxKind(sourceKind)
+	if err != nil {
+		return OperationResult{}, fmt.Errorf("unknown source kind: %s", sourceKind)
+	}
+
+	timestamp := time.Now().Format(time.RFC3339Nano)
+	reconcilePatch := map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]string{
+				"reconcile.fluxcd.io/requestedAt": timestamp,
+			},
+		},
+	}
+
+	// First, reconcile the source
+	if err := mergePatch(ctx, dynClient, sourceEntry.GVR, sourceNamespace, sourceName, reconcilePatch); err != nil {
+		return OperationResult{}, fmt.Errorf("failed to reconcile source %s %s/%s: %w", sourceEntry.Kind, sourceNamespace, sourceName, err)
+	}
+
+	// Then, reconcile the resource itself
+	if err := mergePatch(ctx, dynClient, entry.GVR, namespace, name, reconcilePatch); err != nil {
+		return OperationResult{}, fmt.Errorf("failed to reconcile %s %s/%s (note: source %s/%s was reconciled): %w",
+			entry.Kind, namespace, name, sourceName, sourceNamespace, err)
+	}
+
+	return OperationResult{
+		Message:     fmt.Sprintf("Sync with source triggered for FluxCD %s %s/%s", entry.Kind, namespace, name),
+		Operation:   "reconcile",
+		Tool:        "fluxcd",
+		Kind:        entry.Kind,
+		Namespace:   namespace,
+		Name:        name,
+		RequestedAt: timestamp,
+		Source:      &SourceRef{Kind: sourceEntry.Kind, Namespace: sourceNamespace, Name: sourceName},
+	}, nil
+}
+
+// mergePatch is a helper that applies a merge patch to a resource.
+func mergePatch(ctx context.Context, dynClient dynamic.Interface, gvr schema.GroupVersionResource, namespace, name string, patch map[string]any) error {
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("failed to marshal patch: %w", err)
+	}
+	_, err = dynClient.Resource(gvr).Namespace(namespace).Patch(
+		ctx, name, types.MergePatchType, patchBytes, metav1.PatchOptions{},
+	)
+	return err
+}

--- a/internal/helm/types.go
+++ b/internal/helm/types.go
@@ -273,3 +273,21 @@ type InstallProgress struct {
 	Message string `json:"message"`          // Human-readable status message
 	Detail  string `json:"detail,omitempty"` // Additional detail (e.g., command output)
 }
+
+// StatusPriority returns a sort priority for Helm release statuses.
+// Lower values sort first — failed and unhealthy releases are surfaced first.
+func StatusPriority(status, resourceHealth string) int {
+	if status == "failed" {
+		return 0
+	}
+	if status == "pending-install" || status == "pending-upgrade" || status == "pending-rollback" {
+		return 1
+	}
+	switch resourceHealth {
+	case "unhealthy":
+		return 2
+	case "degraded":
+		return 3
+	}
+	return 4
+}

--- a/internal/k8s/problems.go
+++ b/internal/k8s/problems.go
@@ -1,0 +1,169 @@
+package k8s
+
+import (
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// Problem is a transport-neutral cluster issue.
+type Problem struct {
+	Kind       string
+	Namespace  string
+	Name       string
+	Severity   string // "error" or "warning"
+	Reason     string
+	Message    string
+	Age        string // human-readable
+	AgeSeconds int64  // for sorting
+}
+
+// DetectProblems scans workloads in cache and returns detected problems.
+// Covers: Deployments, StatefulSets, DaemonSets, HPAs, CronJobs, Nodes.
+// Does NOT include pods (consumers handle pod problems differently).
+// namespace="" scans all namespaces.
+func DetectProblems(cache *ResourceCache, namespace string) []Problem {
+	var problems []Problem
+	now := time.Now()
+
+	// Deployment problems: unavailableReplicas > 0
+	if depLister := cache.Deployments(); depLister != nil {
+		var deps []*appsv1.Deployment
+		if namespace != "" {
+			deps, _ = depLister.Deployments(namespace).List(labels.Everything())
+		} else {
+			deps, _ = depLister.List(labels.Everything())
+		}
+		for _, d := range deps {
+			if d.Status.UnavailableReplicas > 0 {
+				ageDur := now.Sub(d.CreationTimestamp.Time)
+				problems = append(problems, Problem{
+					Kind:       "Deployment",
+					Namespace:  d.Namespace,
+					Name:       d.Name,
+					Severity:   "error",
+					Reason:     fmt.Sprintf("%d/%d available", d.Status.AvailableReplicas, d.Status.Replicas),
+					Age:        FormatAge(ageDur),
+					AgeSeconds: int64(ageDur.Seconds()),
+				})
+			}
+		}
+	}
+
+	// StatefulSet problems: readyReplicas < replicas
+	if ssLister := cache.StatefulSets(); ssLister != nil {
+		var ssets []*appsv1.StatefulSet
+		if namespace != "" {
+			ssets, _ = ssLister.StatefulSets(namespace).List(labels.Everything())
+		} else {
+			ssets, _ = ssLister.List(labels.Everything())
+		}
+		for _, ss := range ssets {
+			if ss.Status.ReadyReplicas < ss.Status.Replicas {
+				ageDur := now.Sub(ss.CreationTimestamp.Time)
+				problems = append(problems, Problem{
+					Kind:       "StatefulSet",
+					Namespace:  ss.Namespace,
+					Name:       ss.Name,
+					Severity:   "error",
+					Reason:     fmt.Sprintf("%d/%d ready", ss.Status.ReadyReplicas, ss.Status.Replicas),
+					Age:        FormatAge(ageDur),
+					AgeSeconds: int64(ageDur.Seconds()),
+				})
+			}
+		}
+	}
+
+	// DaemonSet problems: numberUnavailable > 0
+	if dsLister := cache.DaemonSets(); dsLister != nil {
+		var dsets []*appsv1.DaemonSet
+		if namespace != "" {
+			dsets, _ = dsLister.DaemonSets(namespace).List(labels.Everything())
+		} else {
+			dsets, _ = dsLister.List(labels.Everything())
+		}
+		for _, ds := range dsets {
+			if ds.Status.NumberUnavailable > 0 {
+				ageDur := now.Sub(ds.CreationTimestamp.Time)
+				problems = append(problems, Problem{
+					Kind:       "DaemonSet",
+					Namespace:  ds.Namespace,
+					Name:       ds.Name,
+					Severity:   "error",
+					Reason:     fmt.Sprintf("%d unavailable", ds.Status.NumberUnavailable),
+					Age:        FormatAge(ageDur),
+					AgeSeconds: int64(ageDur.Seconds()),
+				})
+			}
+		}
+	}
+
+	// HPA problems
+	if hpaLister := cache.HorizontalPodAutoscalers(); hpaLister != nil {
+		var hpas []*autoscalingv2.HorizontalPodAutoscaler
+		if namespace != "" {
+			hpas, _ = hpaLister.HorizontalPodAutoscalers(namespace).List(labels.Everything())
+		} else {
+			hpas, _ = hpaLister.List(labels.Everything())
+		}
+		for _, hp := range DetectHPAProblems(hpas) {
+			problems = append(problems, Problem{
+				Kind:      "HorizontalPodAutoscaler",
+				Namespace: hp.Namespace,
+				Name:      hp.Name,
+				Severity:  "warning",
+				Reason:    hp.Problem,
+				Message:   hp.Reason,
+			})
+		}
+	}
+
+	// CronJob problems
+	if cjLister := cache.CronJobs(); cjLister != nil {
+		var cronjobs []*batchv1.CronJob
+		if namespace != "" {
+			cronjobs, _ = cjLister.CronJobs(namespace).List(labels.Everything())
+		} else {
+			cronjobs, _ = cjLister.List(labels.Everything())
+		}
+		for _, cp := range DetectCronJobProblems(cronjobs) {
+			problems = append(problems, Problem{
+				Kind:      "CronJob",
+				Namespace: cp.Namespace,
+				Name:      cp.Name,
+				Severity:  "warning",
+				Reason:    cp.Problem,
+				Message:   cp.Reason,
+			})
+		}
+	}
+
+	// Node problems (cluster-scoped, not filtered by namespace)
+	if nodeLister := cache.Nodes(); nodeLister != nil {
+		nodes, _ := nodeLister.List(labels.Everything())
+		for _, np := range DetectNodeProblems(nodes) {
+			ageDur := time.Duration(0)
+			for _, n := range nodes {
+				if n.Name == np.NodeName {
+					ageDur = now.Sub(n.CreationTimestamp.Time)
+					break
+				}
+			}
+			problems = append(problems, Problem{
+				Kind:       "Node",
+				Name:       np.NodeName,
+				Severity:   np.Severity,
+				Reason:     np.Problem,
+				Message:    np.Reason,
+				Age:        FormatAge(ageDur),
+				AgeSeconds: int64(ageDur.Seconds()),
+			})
+		}
+	}
+
+	return problems
+}

--- a/internal/k8s/workload.go
+++ b/internal/k8s/workload.go
@@ -1,0 +1,77 @@
+package k8s
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetWorkloadSelector returns the label selector for a workload from cache.
+// kind must be "deployments", "statefulsets", or "daemonsets".
+func GetWorkloadSelector(cache *ResourceCache, kind, namespace, name string) (*metav1.LabelSelector, error) {
+	switch kind {
+	case "deployments":
+		lister := cache.Deployments()
+		if lister == nil {
+			return nil, fmt.Errorf("insufficient permissions to list deployments")
+		}
+		dep, err := lister.Deployments(namespace).Get(name)
+		if err != nil {
+			return nil, fmt.Errorf("deployment %s/%s not found: %w", namespace, name, err)
+		}
+		return dep.Spec.Selector, nil
+
+	case "statefulsets":
+		lister := cache.StatefulSets()
+		if lister == nil {
+			return nil, fmt.Errorf("insufficient permissions to list statefulsets")
+		}
+		sts, err := lister.StatefulSets(namespace).Get(name)
+		if err != nil {
+			return nil, fmt.Errorf("statefulset %s/%s not found: %w", namespace, name, err)
+		}
+		return sts.Spec.Selector, nil
+
+	case "daemonsets":
+		lister := cache.DaemonSets()
+		if lister == nil {
+			return nil, fmt.Errorf("insufficient permissions to list daemonsets")
+		}
+		ds, err := lister.DaemonSets(namespace).Get(name)
+		if err != nil {
+			return nil, fmt.Errorf("daemonset %s/%s not found: %w", namespace, name, err)
+		}
+		return ds.Spec.Selector, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported workload kind: %s", kind)
+	}
+}
+
+// GetContainersForPod returns container names to target for log collection.
+// If selectedContainer is non-empty, validates it against containers.
+// If includeInit is true, also checks init containers.
+// If selectedContainer is empty, returns all main container names.
+func GetContainersForPod(pod *corev1.Pod, selectedContainer string, includeInit bool) []string {
+	if selectedContainer != "" {
+		for _, c := range pod.Spec.Containers {
+			if c.Name == selectedContainer {
+				return []string{selectedContainer}
+			}
+		}
+		if includeInit {
+			for _, c := range pod.Spec.InitContainers {
+				if c.Name == selectedContainer {
+					return []string{selectedContainer}
+				}
+			}
+		}
+		return nil
+	}
+	containers := make([]string, 0, len(pod.Spec.Containers))
+	for _, c := range pod.Spec.Containers {
+		containers = append(containers, c.Name)
+	}
+	return containers
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -11,14 +11,13 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	autoscalingv2 "k8s.io/api/autoscaling/v2"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	aicontext "github.com/skyhook-io/radar/internal/ai/context"
 	"github.com/skyhook-io/radar/internal/helm"
 	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/internal/timeline"
 	"github.com/skyhook-io/radar/internal/topology"
 )
 
@@ -63,7 +62,9 @@ func registerTools(server *mcp.Server) {
 		Name: "get_resource",
 		Description: "Get detailed information about a single Kubernetes resource. " +
 			"Returns minified spec, status, and metadata. " +
-			"Use after list_resources to drill into a specific resource.",
+			"Use after list_resources to drill into a specific resource. " +
+			"Optionally include related context (events, relationships, metrics, logs) " +
+			"using the 'include' parameter (comma-separated) to avoid extra tool calls.",
 		Annotations: readOnly,
 	}, logToolCall("get_resource", handleGetResource))
 
@@ -96,6 +97,14 @@ func registerTools(server *mcp.Server) {
 			"Use to discover available namespaces before filtering other queries.",
 		Annotations: readOnly,
 	}, logToolCall("list_namespaces", handleListNamespaces))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "get_changes",
+		Description: "Get recent resource changes (creates, updates, deletes) from the cluster timeline. " +
+			"Use to investigate what changed before an incident. " +
+			"Filter by namespace, resource kind, or specific resource name.",
+		Annotations: readOnly,
+	}, logToolCall("get_changes", handleGetChanges))
 
 	// --- Helm tools (read-only) ---
 
@@ -181,16 +190,28 @@ type getResourceInput struct {
 	Kind      string `json:"kind" jsonschema:"resource kind, e.g. pod, deployment, service"`
 	Namespace string `json:"namespace" jsonschema:"resource namespace"`
 	Name      string `json:"name" jsonschema:"resource name"`
+	Include   string `json:"include,omitempty" jsonschema:"comma-separated extras to include: events, relationships, metrics, logs"`
 }
 
 type topologyInput struct {
 	Namespace string `json:"namespace,omitempty" jsonschema:"filter to a specific namespace"`
 	View      string `json:"view,omitempty" jsonschema:"view mode: traffic for network flow or resources for ownership hierarchy"`
+	Format    string `json:"format,omitempty" jsonschema:"output format: graph (default, full node/edge data) or summary (text description of resource chains)"`
 }
 
 type eventsInput struct {
 	Namespace string `json:"namespace,omitempty" jsonschema:"filter to a specific namespace"`
 	Limit     int    `json:"limit,omitempty" jsonschema:"max 100, default 20"`
+	Kind      string `json:"kind,omitempty" jsonschema:"filter to events involving this resource kind (e.g. Pod, Deployment)"`
+	Name      string `json:"name,omitempty" jsonschema:"filter to events involving this resource name"`
+}
+
+type getChangesInput struct {
+	Namespace string `json:"namespace,omitempty" jsonschema:"filter to a specific namespace"`
+	Kind      string `json:"kind,omitempty" jsonschema:"filter to a resource kind (e.g. Deployment, Pod)"`
+	Name      string `json:"name,omitempty" jsonschema:"filter to a specific resource name"`
+	Since     string `json:"since,omitempty" jsonschema:"duration to look back, e.g. 1h, 30m, 24h (default 1h)"`
+	Limit     int    `json:"limit,omitempty" jsonschema:"max changes to return (default 20, max 50)"`
 }
 
 type podLogsInput struct {
@@ -278,6 +299,7 @@ func handleGetResource(ctx context.Context, req *mcp.CallToolRequest, input getR
 	name := input.Name
 
 	// Try typed cache first
+	var resourceData any
 	obj, err := k8s.FetchResource(cache, kind, namespace, name)
 	if err == k8s.ErrUnknownKind {
 		// Fall through to dynamic cache for CRDs
@@ -285,19 +307,220 @@ func handleGetResource(ctx context.Context, req *mcp.CallToolRequest, input getR
 		if dynErr != nil {
 			return nil, nil, fmt.Errorf("resource not found: %w", dynErr)
 		}
-		return toJSONResult(aicontext.MinifyUnstructured(u, aicontext.LevelDetail))
-	}
-	if err != nil {
+		resourceData = aicontext.MinifyUnstructured(u, aicontext.LevelDetail)
+	} else if err != nil {
 		return nil, nil, fmt.Errorf("resource not found: %w", err)
+	} else {
+		k8s.SetTypeMeta(obj)
+		minified, minErr := aicontext.Minify(obj, aicontext.LevelDetail)
+		if minErr != nil {
+			return nil, nil, fmt.Errorf("failed to minify: %w", minErr)
+		}
+		resourceData = minified
 	}
 
-	k8s.SetTypeMeta(obj)
-	result, err := aicontext.Minify(obj, aicontext.LevelDetail)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to minify: %w", err)
+	includes := parseIncludes(input.Include)
+	if len(includes) == 0 {
+		return toJSONResult(resourceData)
 	}
 
+	// Build enriched response with requested extras
+	result := map[string]any{"resource": resourceData}
+	attachResourceExtras(ctx, cache, result, includes, kind, namespace, name)
 	return toJSONResult(result)
+}
+
+// attachResourceExtras populates optional extras (events, relationships, metrics, logs)
+// on the result map based on the includes set.
+func attachResourceExtras(ctx context.Context, cache *k8s.ResourceCache, result map[string]any, includes map[string]bool, kind, namespace, name string) {
+	if includes["events"] {
+		if eventLister := cache.Events(); eventLister != nil {
+			var events []*corev1.Event
+			var listErr error
+			if namespace != "" {
+				events, listErr = eventLister.Events(namespace).List(labels.Everything())
+			} else {
+				events, listErr = eventLister.List(labels.Everything())
+			}
+			if listErr != nil {
+				log.Printf("[mcp] Failed to list events for %s/%s/%s: %v", kind, namespace, name, listErr)
+			}
+			// Filter to events involving this resource
+			var matched []corev1.Event
+			displayKind := normalizeDisplayKind(kind)
+			for _, e := range events {
+				if strings.EqualFold(e.InvolvedObject.Kind, displayKind) && e.InvolvedObject.Name == name {
+					matched = append(matched, *e)
+				}
+			}
+			if len(matched) > 0 {
+				deduplicated := aicontext.DeduplicateEvents(matched)
+				if len(deduplicated) > 10 {
+					deduplicated = deduplicated[:10]
+				}
+				result["events"] = deduplicated
+			}
+		}
+	}
+
+	if includes["relationships"] {
+		opts := topology.DefaultBuildOptions()
+		if namespace != "" {
+			opts.Namespaces = []string{namespace}
+		}
+		builder := topology.NewBuilder()
+		topo, err := builder.Build(opts)
+		if err != nil {
+			log.Printf("[mcp] Failed to build topology for relationships %s/%s/%s: %v", kind, namespace, name, err)
+		} else {
+			displayKind := normalizeDisplayKind(kind)
+			if rels := topology.GetRelationships(displayKind, namespace, name, topo); rels != nil {
+				result["relationships"] = rels
+			}
+		}
+	}
+
+	if includes["metrics"] {
+		if isPodKind(kind) {
+			if metrics, err := k8s.GetPodMetrics(ctx, namespace, name); err == nil {
+				result["metrics"] = metrics
+			}
+		}
+	}
+
+	if includes["logs"] {
+		if isPodKind(kind) {
+			if client := k8s.GetClient(); client != nil {
+				tailLines := int64(100)
+				opts := &corev1.PodLogOptions{TailLines: &tailLines}
+				stream, err := client.CoreV1().Pods(namespace).GetLogs(name, opts).Stream(ctx)
+				if err != nil {
+					log.Printf("[mcp] Failed to get logs for %s/%s: %v", namespace, name, err)
+				} else {
+					defer stream.Close()
+					data, readErr := io.ReadAll(stream)
+					if readErr != nil {
+						log.Printf("[mcp] Failed to read logs for %s/%s: %v", namespace, name, readErr)
+					} else {
+						result["logs"] = aicontext.FilterLogs(string(data))
+					}
+				}
+			}
+		}
+	}
+}
+
+// normalizeDisplayKind converts a lowercase kind to its display form for matching
+// against InvolvedObject.Kind and topology node kinds (e.g. "pod" → "Pod").
+func normalizeDisplayKind(kind string) string {
+	displayKinds := map[string]string{
+		"pod": "Pod", "pods": "Pod",
+		"service": "Service", "services": "Service",
+		"deployment": "Deployment", "deployments": "Deployment",
+		"daemonset": "DaemonSet", "daemonsets": "DaemonSet",
+		"statefulset": "StatefulSet", "statefulsets": "StatefulSet",
+		"replicaset": "ReplicaSet", "replicasets": "ReplicaSet",
+		"ingress": "Ingress", "ingresses": "Ingress",
+		"configmap": "ConfigMap", "configmaps": "ConfigMap",
+		"secret": "Secret", "secrets": "Secret",
+		"job": "Job", "jobs": "Job",
+		"cronjob": "CronJob", "cronjobs": "CronJob",
+		"node": "Node", "nodes": "Node",
+		"namespace": "Namespace", "namespaces": "Namespace",
+		"persistentvolumeclaim": "PersistentVolumeClaim", "persistentvolumeclaims": "PersistentVolumeClaim",
+		"persistentvolume": "PersistentVolume", "persistentvolumes": "PersistentVolume",
+		"storageclass": "StorageClass", "storageclasses": "StorageClass",
+		"horizontalpodautoscaler": "HorizontalPodAutoscaler", "horizontalpodautoscalers": "HorizontalPodAutoscaler",
+		"poddisruptionbudget": "PodDisruptionBudget", "poddisruptionbudgets": "PodDisruptionBudget",
+	}
+	if display, ok := displayKinds[kind]; ok {
+		return display
+	}
+	return kind
+}
+
+func isPodKind(kind string) bool {
+	return kind == "pod" || kind == "pods"
+}
+
+func handleGetChanges(ctx context.Context, req *mcp.CallToolRequest, input getChangesInput) (*mcp.CallToolResult, any, error) {
+	store := timeline.GetStore()
+	if store == nil {
+		return nil, nil, fmt.Errorf("timeline store not initialized")
+	}
+
+	since := 1 * time.Hour
+	if input.Since != "" {
+		parsed, err := time.ParseDuration(input.Since)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid duration %q: %w", input.Since, err)
+		}
+		if parsed <= 0 {
+			return nil, nil, fmt.Errorf("duration must be positive, got %q", input.Since)
+		}
+		since = parsed
+	}
+
+	limit := 20
+	if input.Limit > 0 {
+		limit = min(input.Limit, 50)
+	}
+
+	queryOpts := timeline.QueryOptions{
+		Since:        time.Now().Add(-since),
+		FilterPreset: "default",
+	}
+	if input.Namespace != "" {
+		queryOpts.Namespaces = []string{input.Namespace}
+	}
+	if input.Kind != "" {
+		queryOpts.Kinds = []string{input.Kind}
+	}
+	// When name filtering is needed client-side, fetch more to compensate for post-filter reduction
+	if input.Name != "" {
+		queryOpts.Limit = limit * 10
+	} else {
+		queryOpts.Limit = limit
+	}
+
+	events, err := store.Query(ctx, queryOpts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to query timeline: %w", err)
+	}
+
+	// Client-side name filter (QueryOptions doesn't support name filtering)
+	if input.Name != "" {
+		filtered := events[:0]
+		for _, e := range events {
+			if e.Name == input.Name {
+				filtered = append(filtered, e)
+			}
+		}
+		events = filtered
+		if len(events) > limit {
+			events = events[:limit]
+		}
+	}
+
+	changes := make([]mcpChange, 0, len(events))
+	for _, e := range events {
+		summary := ""
+		if e.Diff != nil && e.Diff.Summary != "" {
+			summary = e.Diff.Summary
+		} else if e.Message != "" {
+			summary = k8s.Truncate(e.Message, 100)
+		}
+		changes = append(changes, mcpChange{
+			Kind:       e.Kind,
+			Namespace:  e.Namespace,
+			Name:       e.Name,
+			ChangeType: string(e.EventType),
+			Summary:    summary,
+			Timestamp:  e.Timestamp.Format(time.RFC3339),
+		})
+	}
+
+	return toJSONResult(changes)
 }
 
 func handleGetTopology(ctx context.Context, req *mcp.CallToolRequest, input topologyInput) (*mcp.CallToolResult, any, error) {
@@ -315,7 +538,185 @@ func handleGetTopology(ctx context.Context, req *mcp.CallToolRequest, input topo
 		return nil, nil, fmt.Errorf("failed to build topology: %w", err)
 	}
 
+	if strings.ToLower(input.Format) == "summary" {
+		return toJSONResult(buildTopologySummary(topo))
+	}
+
 	return toJSONResult(topo)
+}
+
+// topologySummary is an LLM-friendly text representation of the topology.
+type topologySummary struct {
+	Namespaces []nsSummary    `json:"namespaces"`
+	Problems   []string       `json:"problems,omitempty"`
+	Stats      topologyStats  `json:"stats"`
+}
+
+type nsSummary struct {
+	Namespace string   `json:"namespace"`
+	Chains    []string `json:"chains"`
+}
+
+type topologyStats struct {
+	Nodes int `json:"nodes"`
+	Edges int `json:"edges"`
+}
+
+func buildTopologySummary(topo *topology.Topology) topologySummary {
+	// Build lookup maps
+	nodeByID := make(map[string]*topology.Node, len(topo.Nodes))
+	for i := range topo.Nodes {
+		nodeByID[topo.Nodes[i].ID] = &topo.Nodes[i]
+	}
+
+	// Build adjacency: source → targets
+	children := make(map[string][]string)
+	parents := make(map[string][]string)
+	for _, e := range topo.Edges {
+		children[e.Source] = append(children[e.Source], e.Target)
+		parents[e.Target] = append(parents[e.Target], e.Source)
+	}
+
+	// Find root nodes (no incoming edges)
+	roots := make(map[string]bool)
+	for _, n := range topo.Nodes {
+		if len(parents[n.ID]) == 0 {
+			roots[n.ID] = true
+		}
+	}
+
+	// Walk chains from roots, group by namespace
+	visited := make(map[string]bool)
+	nsChains := make(map[string][]string)
+	var problems []string
+
+	for _, n := range topo.Nodes {
+		if !roots[n.ID] || visited[n.ID] {
+			continue
+		}
+		chain := walkChain(n.ID, nodeByID, children, visited, 0)
+		if chain == "" {
+			continue
+		}
+		ns := nodeNamespace(nodeByID[n.ID])
+		nsChains[ns] = append(nsChains[ns], chain)
+	}
+
+	// Also walk any unvisited nodes (cycles or isolated nodes)
+	for _, n := range topo.Nodes {
+		if visited[n.ID] {
+			continue
+		}
+		desc := describeNode(&n)
+		ns := nodeNamespace(&n)
+		nsChains[ns] = append(nsChains[ns], desc)
+		visited[n.ID] = true
+	}
+
+	// Detect problems
+	for _, n := range topo.Nodes {
+		if n.Status == topology.StatusUnhealthy || n.Status == topology.StatusDegraded {
+			problems = append(problems, fmt.Sprintf("%s %s: %s", n.Kind, n.Name, n.Status))
+		}
+	}
+
+	// Build sorted namespace list
+	var namespaces []nsSummary
+	sortedNs := make([]string, 0, len(nsChains))
+	for ns := range nsChains {
+		sortedNs = append(sortedNs, ns)
+	}
+	sort.Strings(sortedNs)
+	for _, ns := range sortedNs {
+		namespaces = append(namespaces, nsSummary{
+			Namespace: ns,
+			Chains:    nsChains[ns],
+		})
+	}
+
+	return topologySummary{
+		Namespaces: namespaces,
+		Problems:   problems,
+		Stats:      topologyStats{Nodes: len(topo.Nodes), Edges: len(topo.Edges)},
+	}
+}
+
+// walkChain recursively describes a resource chain from a root node.
+func walkChain(nodeID string, nodeByID map[string]*topology.Node, children map[string][]string, visited map[string]bool, depth int) string {
+	if depth > 10 || visited[nodeID] {
+		return ""
+	}
+	visited[nodeID] = true
+
+	node, ok := nodeByID[nodeID]
+	if !ok {
+		return ""
+	}
+
+	desc := describeNode(node)
+	kids := children[nodeID]
+	if len(kids) == 0 {
+		return desc
+	}
+
+	// For single-child chains, flatten into arrows
+	if len(kids) == 1 {
+		childDesc := walkChain(kids[0], nodeByID, children, visited, depth+1)
+		if childDesc != "" {
+			return desc + " → " + childDesc
+		}
+		return desc
+	}
+
+	// For multiple children, list them
+	var childDescs []string
+	for _, kid := range kids {
+		childDesc := walkChain(kid, nodeByID, children, visited, depth+1)
+		if childDesc != "" {
+			childDescs = append(childDescs, childDesc)
+		}
+	}
+	if len(childDescs) == 0 {
+		return desc
+	}
+	if len(childDescs) == 1 {
+		return desc + " → " + childDescs[0]
+	}
+	return desc + " → [" + strings.Join(childDescs, ", ") + "]"
+}
+
+func describeNode(n *topology.Node) string {
+	desc := fmt.Sprintf("%s/%s", n.Kind, n.Name)
+
+	// Add status annotation for unhealthy nodes
+	if n.Status == topology.StatusUnhealthy {
+		desc += " (unhealthy)"
+	} else if n.Status == topology.StatusDegraded {
+		desc += " (degraded)"
+	}
+
+	// Add useful data annotations
+	if n.Data != nil {
+		if ready, ok := n.Data["readyReplicas"]; ok {
+			if desired, ok2 := n.Data["replicas"]; ok2 {
+				desc += fmt.Sprintf(" (%v/%v ready)", ready, desired)
+			}
+		}
+		if host, ok := n.Data["host"]; ok && host != "" {
+			desc += fmt.Sprintf(" [%v]", host)
+		}
+	}
+
+	return desc
+}
+
+func nodeNamespace(n *topology.Node) string {
+	if n.Data != nil {
+		if ns, ok := n.Data["namespace"].(string); ok && ns != "" {
+			return ns
+		}
+	}
+	return "(cluster)"
 }
 
 func handleGetEvents(ctx context.Context, req *mcp.CallToolRequest, input eventsInput) (*mcp.CallToolResult, any, error) {
@@ -338,6 +739,21 @@ func handleGetEvents(ctx context.Context, req *mcp.CallToolRequest, input events
 	}
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to list events: %w", err)
+	}
+
+	// Filter by InvolvedObject kind/name if specified
+	if input.Kind != "" || input.Name != "" {
+		filtered := events[:0]
+		for _, e := range events {
+			if input.Kind != "" && !strings.EqualFold(e.InvolvedObject.Kind, input.Kind) {
+				continue
+			}
+			if input.Name != "" && e.InvolvedObject.Name != input.Name {
+				continue
+			}
+			filtered = append(filtered, e)
+		}
+		events = filtered
 	}
 
 	// Convert to non-pointer slice for DeduplicateEvents
@@ -431,6 +847,7 @@ type mcpDashboard struct {
 	VersionSkew    []string         `json:"versionSkew,omitempty"`
 	Health         mcpHealthSummary `json:"health"`
 	Problems       []mcpProblem     `json:"problems"`
+	RecentChanges  []mcpChange      `json:"recentChanges,omitempty"`
 	WarningEvents  int              `json:"warningEvents"`
 	TopWarnings    []mcpWarning     `json:"topWarnings"`
 	HelmReleases   mcpHelmSummary   `json:"helmReleases"`
@@ -438,6 +855,15 @@ type mcpDashboard struct {
 	TopologyNodes  int              `json:"topologyNodes"`
 	TopologyEdges  int              `json:"topologyEdges"`
 	ResourceCounts map[string]int   `json:"resourceCounts"`
+}
+
+type mcpChange struct {
+	Kind       string `json:"kind"`
+	Namespace  string `json:"namespace,omitempty"`
+	Name       string `json:"name"`
+	ChangeType string `json:"changeType"`
+	Summary    string `json:"summary,omitempty"`
+	Timestamp  string `json:"timestamp"`
 }
 
 type mcpMetrics struct {
@@ -541,142 +967,33 @@ func buildDashboard(ctx context.Context, cache *k8s.ResourceCache, namespace str
 		}
 	}
 
-	// Deployment problems
+	// Workload/HPA/CronJob/Node problems (excluding pods, handled above)
+	for _, p := range k8s.DetectProblems(cache, namespace) {
+		if len(d.Problems) >= 10 {
+			break
+		}
+		d.Problems = append(d.Problems, mcpProblem{
+			Kind:      p.Kind,
+			Namespace: p.Namespace,
+			Name:      p.Name,
+			Reason:    p.Reason,
+			Message:   p.Message,
+			Age:       p.Age,
+		})
+	}
+
+	// Deployment resource count
 	if depLister := cache.Deployments(); depLister != nil {
 		if namespace != "" {
 			items, _ := depLister.Deployments(namespace).List(labels.Everything())
 			d.ResourceCounts["deployments"] = len(items)
-			for _, dep := range items {
-				if dep.Status.UnavailableReplicas > 0 && len(d.Problems) < 10 {
-					d.Problems = append(d.Problems, mcpProblem{
-						Kind:      "Deployment",
-						Namespace: dep.Namespace,
-						Name:      dep.Name,
-						Reason:    fmt.Sprintf("%d/%d available", dep.Status.AvailableReplicas, dep.Status.Replicas),
-						Age:       k8s.FormatAge(now.Sub(dep.CreationTimestamp.Time)),
-					})
-				}
-			}
 		} else {
 			items, _ := depLister.List(labels.Everything())
 			d.ResourceCounts["deployments"] = len(items)
-			for _, dep := range items {
-				if dep.Status.UnavailableReplicas > 0 && len(d.Problems) < 10 {
-					d.Problems = append(d.Problems, mcpProblem{
-						Kind:      "Deployment",
-						Namespace: dep.Namespace,
-						Name:      dep.Name,
-						Reason:    fmt.Sprintf("%d/%d available", dep.Status.AvailableReplicas, dep.Status.Replicas),
-						Age:       k8s.FormatAge(now.Sub(dep.CreationTimestamp.Time)),
-					})
-				}
-			}
 		}
 	}
 
-	// StatefulSet problems: readyReplicas < replicas
-	if ssLister := cache.StatefulSets(); ssLister != nil {
-		if namespace != "" {
-			ssets, _ := ssLister.StatefulSets(namespace).List(labels.Everything())
-			for _, ss := range ssets {
-				if ss.Status.ReadyReplicas < ss.Status.Replicas && len(d.Problems) < 10 {
-					d.Problems = append(d.Problems, mcpProblem{
-						Kind:      "StatefulSet",
-						Namespace: ss.Namespace,
-						Name:      ss.Name,
-						Reason:    fmt.Sprintf("%d/%d ready", ss.Status.ReadyReplicas, ss.Status.Replicas),
-						Age:       k8s.FormatAge(now.Sub(ss.CreationTimestamp.Time)),
-					})
-				}
-			}
-		} else {
-			ssets, _ := ssLister.List(labels.Everything())
-			for _, ss := range ssets {
-				if ss.Status.ReadyReplicas < ss.Status.Replicas && len(d.Problems) < 10 {
-					d.Problems = append(d.Problems, mcpProblem{
-						Kind:      "StatefulSet",
-						Namespace: ss.Namespace,
-						Name:      ss.Name,
-						Reason:    fmt.Sprintf("%d/%d ready", ss.Status.ReadyReplicas, ss.Status.Replicas),
-						Age:       k8s.FormatAge(now.Sub(ss.CreationTimestamp.Time)),
-					})
-				}
-			}
-		}
-	}
-
-	// DaemonSet problems: numberUnavailable > 0
-	if dsLister := cache.DaemonSets(); dsLister != nil {
-		if namespace != "" {
-			dsets, _ := dsLister.DaemonSets(namespace).List(labels.Everything())
-			for _, ds := range dsets {
-				if ds.Status.NumberUnavailable > 0 && len(d.Problems) < 10 {
-					d.Problems = append(d.Problems, mcpProblem{
-						Kind:      "DaemonSet",
-						Namespace: ds.Namespace,
-						Name:      ds.Name,
-						Reason:    fmt.Sprintf("%d unavailable", ds.Status.NumberUnavailable),
-						Age:       k8s.FormatAge(now.Sub(ds.CreationTimestamp.Time)),
-					})
-				}
-			}
-		} else {
-			dsets, _ := dsLister.List(labels.Everything())
-			for _, ds := range dsets {
-				if ds.Status.NumberUnavailable > 0 && len(d.Problems) < 10 {
-					d.Problems = append(d.Problems, mcpProblem{
-						Kind:      "DaemonSet",
-						Namespace: ds.Namespace,
-						Name:      ds.Name,
-						Reason:    fmt.Sprintf("%d unavailable", ds.Status.NumberUnavailable),
-						Age:       k8s.FormatAge(now.Sub(ds.CreationTimestamp.Time)),
-					})
-				}
-			}
-		}
-	}
-
-	// HPA problems
-	if hpaLister := cache.HorizontalPodAutoscalers(); hpaLister != nil {
-		var hpas []*autoscalingv2.HorizontalPodAutoscaler
-		if namespace != "" {
-			hpas, _ = hpaLister.HorizontalPodAutoscalers(namespace).List(labels.Everything())
-		} else {
-			hpas, _ = hpaLister.List(labels.Everything())
-		}
-		for _, hp := range k8s.DetectHPAProblems(hpas) {
-			if len(d.Problems) < 10 {
-				d.Problems = append(d.Problems, mcpProblem{
-					Kind:      "HorizontalPodAutoscaler",
-					Namespace: hp.Namespace,
-					Name:      hp.Name,
-					Reason:    hp.Reason,
-				})
-			}
-		}
-	}
-
-	// CronJob problems
-	if cjLister := cache.CronJobs(); cjLister != nil {
-		var cronjobs []*batchv1.CronJob
-		if namespace != "" {
-			cronjobs, _ = cjLister.CronJobs(namespace).List(labels.Everything())
-		} else {
-			cronjobs, _ = cjLister.List(labels.Everything())
-		}
-		for _, cp := range k8s.DetectCronJobProblems(cronjobs) {
-			if len(d.Problems) < 10 {
-				d.Problems = append(d.Problems, mcpProblem{
-					Kind:      "CronJob",
-					Namespace: cp.Namespace,
-					Name:      cp.Name,
-					Reason:    cp.Reason,
-				})
-			}
-		}
-	}
-
-	// Node problems (cluster-scoped, not filtered by namespace)
+	// Node health summary (cluster-scoped, not filtered by namespace)
 	if nodeLister := cache.Nodes(); nodeLister != nil {
 		nodes, _ := nodeLister.List(labels.Everything())
 		d.ResourceCounts["nodes"] = len(nodes)
@@ -692,25 +1009,6 @@ func buildDashboard(ctx context.Context, cache *k8s.ResourceCache, namespace str
 				}
 			} else {
 				d.Nodes.NotReady++
-			}
-		}
-
-		nodeProblems := k8s.DetectNodeProblems(nodes)
-		for _, np := range nodeProblems {
-			if len(d.Problems) < 10 {
-				age := ""
-				for _, n := range nodes {
-					if n.Name == np.NodeName {
-						age = k8s.FormatAge(now.Sub(n.CreationTimestamp.Time))
-						break
-					}
-				}
-				d.Problems = append(d.Problems, mcpProblem{
-					Kind:   "Node",
-					Name:   np.NodeName,
-					Reason: np.Problem,
-					Age:    age,
-				})
 			}
 		}
 
@@ -767,7 +1065,7 @@ func buildDashboard(ctx context.Context, cache *k8s.ResourceCache, namespace str
 
 			// Sort: failed/pending-install first, then unhealthy/degraded
 			sort.SliceStable(releases, func(i, j int) bool {
-				return helmStatusPriority(releases[i].Status, releases[i].ResourceHealth) < helmStatusPriority(releases[j].Status, releases[j].ResourceHealth)
+				return helm.StatusPriority(releases[i].Status, releases[i].ResourceHealth) < helm.StatusPriority(releases[j].Status, releases[j].ResourceHealth)
 			})
 
 			limit := min(len(releases), 5)
@@ -859,6 +1157,56 @@ func buildDashboard(ctx context.Context, cache *k8s.ResourceCache, namespace str
 		d.TopologyEdges = len(topo.Edges)
 	}
 
+	// Correlate recent changes with problems — only show changes for broken resources
+	if store := timeline.GetStore(); store != nil && len(d.Problems) > 0 {
+		problemKeys := make(map[string]bool, len(d.Problems))
+		for _, p := range d.Problems {
+			problemKeys[fmt.Sprintf("%s/%s/%s", p.Kind, p.Namespace, p.Name)] = true
+		}
+
+		queryOpts := timeline.QueryOptions{
+			Since:        now.Add(-1 * time.Hour),
+			Limit:        20,
+			FilterPreset: "workloads",
+		}
+		if namespace != "" {
+			queryOpts.Namespaces = []string{namespace}
+		}
+		changes, err := store.Query(ctx, queryOpts)
+		if err != nil {
+			log.Printf("[mcp] Failed to query timeline for dashboard changes: %v", err)
+		}
+		if err == nil {
+			for _, c := range changes {
+				key := fmt.Sprintf("%s/%s/%s", c.Kind, c.Namespace, c.Name)
+				// Also check owner chain (e.g. Pod problem → Deployment change)
+				ownerKey := ""
+				if c.Owner != nil {
+					ownerKey = fmt.Sprintf("%s/%s/%s", c.Owner.Kind, c.Namespace, c.Owner.Name)
+				}
+				if problemKeys[key] || (ownerKey != "" && problemKeys[ownerKey]) {
+					summary := ""
+					if c.Diff != nil && c.Diff.Summary != "" {
+						summary = c.Diff.Summary
+					} else if c.Message != "" {
+						summary = k8s.Truncate(c.Message, 100)
+					}
+					d.RecentChanges = append(d.RecentChanges, mcpChange{
+						Kind:       c.Kind,
+						Namespace:  c.Namespace,
+						Name:       c.Name,
+						ChangeType: string(c.EventType),
+						Summary:    summary,
+						Timestamp:  c.Timestamp.Format(time.RFC3339),
+					})
+					if len(d.RecentChanges) >= 5 {
+						break
+					}
+				}
+			}
+		}
+	}
+
 	return d
 }
 
@@ -921,24 +1269,6 @@ func countResources(cache *k8s.ResourceCache, namespace string, d *mcpDashboard)
 		items, _ := nsLister.List(labels.Everything())
 		d.ResourceCounts["namespaces"] = len(items)
 	}
-}
-
-// helmStatusPriority returns a sort priority for Helm release statuses.
-// Lower values sort first — failed and unhealthy releases are surfaced first.
-func helmStatusPriority(status, resourceHealth string) int {
-	if status == "failed" {
-		return 0
-	}
-	if status == "pending-install" || status == "pending-upgrade" || status == "pending-rollback" {
-		return 1
-	}
-	switch resourceHealth {
-	case "unhealthy":
-		return 2
-	case "degraded":
-		return 3
-	}
-	return 4
 }
 
 // toJSONResult marshals data into a text content MCP result.

--- a/internal/mcp/tools_gitops.go
+++ b/internal/mcp/tools_gitops.go
@@ -2,19 +2,12 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/dynamic"
 
+	"github.com/skyhook-io/radar/internal/gitops"
 	"github.com/skyhook-io/radar/internal/k8s"
 )
 
@@ -28,22 +21,6 @@ type manageGitOpsInput struct {
 	Name      string `json:"name" jsonschema:"resource name"`
 }
 
-// ArgoCD GVR
-var argoAppGVR = schema.GroupVersionResource{
-	Group:    "argoproj.io",
-	Version:  "v1alpha1",
-	Resource: "applications",
-}
-
-// FluxCD GVRs
-var fluxGVRs = map[string]schema.GroupVersionResource{
-	"gitrepository":  {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "gitrepositories"},
-	"ocirepository":  {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "ocirepositories"},
-	"helmrepository": {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "helmrepositories"},
-	"kustomization":  {Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Resource: "kustomizations"},
-	"helmrelease":    {Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"},
-}
-
 // GitOps tool handler
 
 func handleManageGitOps(ctx context.Context, req *mcp.CallToolRequest, input manageGitOpsInput) (*mcp.CallToolResult, any, error) {
@@ -55,260 +32,56 @@ func handleManageGitOps(ctx context.Context, req *mcp.CallToolRequest, input man
 	tool := strings.ToLower(input.Tool)
 	action := strings.ToLower(input.Action)
 
+	var result gitops.OperationResult
+	var err error
+
 	switch tool {
 	case "argocd":
-		return handleArgoAction(ctx, dynClient, action, input.Namespace, input.Name)
+		switch action {
+		case "sync":
+			result, err = gitops.SyncArgoApp(ctx, dynClient, input.Namespace, input.Name)
+		case "suspend":
+			result, err = gitops.SetArgoAutoSync(ctx, dynClient, input.Namespace, input.Name, false)
+		case "resume":
+			result, err = gitops.SetArgoAutoSync(ctx, dynClient, input.Namespace, input.Name, true)
+		default:
+			return nil, nil, fmt.Errorf("unknown ArgoCD action %q: must be sync, suspend, or resume", action)
+		}
+
 	case "fluxcd":
-		return handleFluxAction(ctx, dynClient, action, input.Kind, input.Namespace, input.Name)
+		if input.Kind == "" {
+			return nil, nil, fmt.Errorf("kind is required for FluxCD operations (e.g. kustomization, helmrelease, gitrepository)")
+		}
+		entry, resolveErr := gitops.ResolveFluxKind(input.Kind)
+		if resolveErr != nil {
+			return nil, nil, resolveErr
+		}
+
+		switch action {
+		case "reconcile":
+			result, err = gitops.ReconcileFlux(ctx, dynClient, entry, input.Namespace, input.Name)
+		case "suspend":
+			result, err = gitops.SetFluxSuspend(ctx, dynClient, entry, input.Namespace, input.Name, true)
+		case "resume":
+			result, err = gitops.SetFluxSuspend(ctx, dynClient, entry, input.Namespace, input.Name, false)
+		default:
+			return nil, nil, fmt.Errorf("unknown FluxCD action %q: must be reconcile, suspend, or resume", action)
+		}
+
 	default:
 		return nil, nil, fmt.Errorf("unknown tool %q: must be argocd or fluxcd", input.Tool)
 	}
-}
 
-func handleArgoAction(ctx context.Context, dynClient dynamic.Interface, action, namespace, name string) (*mcp.CallToolResult, any, error) {
-	switch action {
-	case "sync":
-		return argoSync(ctx, dynClient, namespace, name)
-	case "suspend":
-		return argoSetAutoSync(ctx, dynClient, namespace, name, false)
-	case "resume":
-		return argoSetAutoSync(ctx, dynClient, namespace, name, true)
-	default:
-		return nil, nil, fmt.Errorf("unknown ArgoCD action %q: must be sync, suspend, or resume", action)
-	}
-}
-
-func handleFluxAction(ctx context.Context, dynClient dynamic.Interface, action, kind, namespace, name string) (*mcp.CallToolResult, any, error) {
-	if kind == "" {
-		return nil, nil, fmt.Errorf("kind is required for FluxCD operations (e.g. kustomization, helmrelease, gitrepository)")
-	}
-
-	gvr, ok := fluxGVRs[strings.ToLower(kind)]
-	if !ok {
-		return nil, nil, fmt.Errorf("unknown FluxCD kind %q: supported kinds are kustomization, helmrelease, gitrepository, ocirepository, helmrepository", kind)
-	}
-
-	switch action {
-	case "reconcile":
-		return fluxReconcile(ctx, dynClient, gvr, kind, namespace, name)
-	case "suspend":
-		return fluxSetSuspend(ctx, dynClient, gvr, kind, namespace, name, true)
-	case "resume":
-		return fluxSetSuspend(ctx, dynClient, gvr, kind, namespace, name, false)
-	default:
-		return nil, nil, fmt.Errorf("unknown FluxCD action %q: must be reconcile, suspend, or resume", action)
-	}
-}
-
-// argoSync triggers a sync operation on an ArgoCD Application.
-func argoSync(ctx context.Context, dynClient dynamic.Interface, namespace, name string) (*mcp.CallToolResult, any, error) {
-	// Check if there's already a sync in progress
-	app, err := dynClient.Resource(argoAppGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, nil, fmt.Errorf("ArgoCD Application %s/%s not found", namespace, name)
-		}
-		return nil, nil, fmt.Errorf("failed to get Application: %w", err)
+		return nil, nil, err
 	}
 
-	phase, found, _ := unstructured.NestedString(app.Object, "status", "operationState", "phase")
-	if found && phase == "Running" {
-		return nil, nil, fmt.Errorf("sync operation already in progress for %s/%s", namespace, name)
-	}
-
-	timestamp := time.Now().Format(time.RFC3339Nano)
-	patch := map[string]any{
-		"metadata": map[string]any{
-			"annotations": map[string]string{
-				"argocd.argoproj.io/refresh": "hard",
-			},
-		},
-		"operation": map[string]any{
-			"initiatedBy": map[string]any{
-				"username": "radar",
-			},
-			"sync": map[string]any{
-				"revision": "",
-				"prune":    true,
-			},
-		},
-	}
-
-	patchBytes, err := json.Marshal(patch)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create sync patch: %w", err)
-	}
-
-	_, err = dynClient.Resource(argoAppGVR).Namespace(namespace).Patch(
-		ctx, name, types.MergePatchType, patchBytes, metav1.PatchOptions{},
-	)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to sync Application %s/%s: %w", namespace, name, err)
-	}
-
-	return toJSONResult(map[string]string{
-		"status":      "ok",
-		"message":     fmt.Sprintf("Sync initiated for ArgoCD Application %s/%s", namespace, name),
-		"requestedAt": timestamp,
-	})
-}
-
-// argoSetAutoSync enables or disables automated sync on an ArgoCD Application.
-func argoSetAutoSync(ctx context.Context, dynClient dynamic.Interface, namespace, name string, enable bool) (*mcp.CallToolResult, any, error) {
-	app, err := dynClient.Resource(argoAppGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, nil, fmt.Errorf("ArgoCD Application %s/%s not found", namespace, name)
-		}
-		return nil, nil, fmt.Errorf("failed to get Application: %w", err)
-	}
-
-	var patch map[string]any
-	action := "suspend"
-	pastAction := "suspended"
-
-	if enable {
-		action = "resume"
-		pastAction = "resumed"
-		prune := true
-		selfHeal := true
-
-		annotations, _, _ := unstructured.NestedStringMap(app.Object, "metadata", "annotations")
-		if annotations != nil {
-			if v, ok := annotations["radar.skyhook.io/suspended-prune"]; ok {
-				prune = v == "true"
-			}
-			if v, ok := annotations["radar.skyhook.io/suspended-selfheal"]; ok {
-				selfHeal = v == "true"
-			}
-		}
-
-		patch = map[string]any{
-			"metadata": map[string]any{
-				"annotations": map[string]any{
-					"radar.skyhook.io/suspended-prune":    nil,
-					"radar.skyhook.io/suspended-selfheal": nil,
-				},
-			},
-			"spec": map[string]any{
-				"syncPolicy": map[string]any{
-					"automated": map[string]any{
-						"prune":    prune,
-						"selfHeal": selfHeal,
-					},
-				},
-			},
-		}
-	} else {
-		prune := false
-		selfHeal := false
-
-		automated, found, _ := unstructured.NestedMap(app.Object, "spec", "syncPolicy", "automated")
-		if found && automated != nil {
-			if v, ok := automated["prune"].(bool); ok {
-				prune = v
-			}
-			if v, ok := automated["selfHeal"].(bool); ok {
-				selfHeal = v
-			}
-		}
-
-		patch = map[string]any{
-			"metadata": map[string]any{
-				"annotations": map[string]string{
-					"radar.skyhook.io/suspended-prune":    fmt.Sprintf("%v", prune),
-					"radar.skyhook.io/suspended-selfheal": fmt.Sprintf("%v", selfHeal),
-				},
-			},
-			"spec": map[string]any{
-				"syncPolicy": map[string]any{
-					"automated": nil,
-				},
-			},
-		}
-	}
-
-	patchBytes, err := json.Marshal(patch)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create patch: %w", err)
-	}
-
-	_, err = dynClient.Resource(argoAppGVR).Namespace(namespace).Patch(
-		ctx, name, types.MergePatchType, patchBytes, metav1.PatchOptions{},
-	)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to %s Application %s/%s: %w", action, namespace, name, err)
-	}
-
-	return toJSONResult(map[string]string{
+	resp := map[string]string{
 		"status":  "ok",
-		"message": fmt.Sprintf("ArgoCD Application %s/%s auto-sync %s", namespace, name, pastAction),
-	})
-}
-
-// fluxReconcile triggers a reconciliation on a FluxCD resource.
-func fluxReconcile(ctx context.Context, dynClient dynamic.Interface, gvr schema.GroupVersionResource, kind, namespace, name string) (*mcp.CallToolResult, any, error) {
-	timestamp := time.Now().Format(time.RFC3339Nano)
-	patch := map[string]any{
-		"metadata": map[string]any{
-			"annotations": map[string]string{
-				"reconcile.fluxcd.io/requestedAt": timestamp,
-			},
-		},
+		"message": result.Message,
 	}
-
-	patchBytes, err := json.Marshal(patch)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create reconcile patch: %w", err)
+	if result.RequestedAt != "" {
+		resp["requestedAt"] = result.RequestedAt
 	}
-
-	_, err = dynClient.Resource(gvr).Namespace(namespace).Patch(
-		ctx, name, types.MergePatchType, patchBytes, metav1.PatchOptions{},
-	)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, nil, fmt.Errorf("FluxCD %s %s/%s not found", kind, namespace, name)
-		}
-		return nil, nil, fmt.Errorf("failed to reconcile %s %s/%s: %w", kind, namespace, name, err)
-	}
-
-	return toJSONResult(map[string]string{
-		"status":      "ok",
-		"message":     fmt.Sprintf("Reconciliation triggered for FluxCD %s %s/%s", kind, namespace, name),
-		"requestedAt": timestamp,
-	})
-}
-
-// fluxSetSuspend sets the suspend field on a FluxCD resource.
-func fluxSetSuspend(ctx context.Context, dynClient dynamic.Interface, gvr schema.GroupVersionResource, kind, namespace, name string, suspend bool) (*mcp.CallToolResult, any, error) {
-	patch := map[string]any{
-		"spec": map[string]any{
-			"suspend": suspend,
-		},
-	}
-
-	patchBytes, err := json.Marshal(patch)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create patch: %w", err)
-	}
-
-	_, err = dynClient.Resource(gvr).Namespace(namespace).Patch(
-		ctx, name, types.MergePatchType, patchBytes, metav1.PatchOptions{},
-	)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, nil, fmt.Errorf("FluxCD %s %s/%s not found", kind, namespace, name)
-		}
-		return nil, nil, fmt.Errorf("failed to update %s %s/%s: %w", kind, namespace, name, err)
-	}
-
-	action := "suspended"
-	if !suspend {
-		action = "resumed"
-	}
-
-	return toJSONResult(map[string]string{
-		"status":  "ok",
-		"message": fmt.Sprintf("FluxCD %s %s/%s %s", kind, namespace, name, action),
-	})
+	return toJSONResult(resp)
 }

--- a/internal/mcp/tools_workloads.go
+++ b/internal/mcp/tools_workloads.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	aicontext "github.com/skyhook-io/radar/internal/ai/context"
 	"github.com/skyhook-io/radar/internal/k8s"
@@ -147,7 +146,7 @@ func handleGetWorkloadLogs(ctx context.Context, req *mcp.CallToolRequest, input 
 	}
 
 	// Get the workload's label selector
-	selector, err := getWorkloadSelectorFromCache(cache, kind, input.Namespace, input.Name)
+	selector, err := k8s.GetWorkloadSelector(cache, kind, input.Namespace, input.Name)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -199,7 +198,7 @@ func handleGetWorkloadLogs(ctx context.Context, req *mcp.CallToolRequest, input 
 	var wg sync.WaitGroup
 
 	for _, pod := range pods {
-		containers := getContainersForPod(pod, input.Container)
+		containers := k8s.GetContainersForPod(pod, input.Container, true)
 		for _, c := range containers {
 			wg.Add(1)
 			go func(podName, containerName string) {
@@ -262,64 +261,6 @@ func handleGetWorkloadLogs(ctx context.Context, req *mcp.CallToolRequest, input 
 		"pods":     len(pods),
 		"logs":     allLogs,
 	})
-}
-
-// getWorkloadSelectorFromCache returns the label selector for a workload from cache.
-func getWorkloadSelectorFromCache(cache *k8s.ResourceCache, kind, namespace, name string) (*metav1.LabelSelector, error) {
-	switch kind {
-	case "deployments":
-		lister := cache.Deployments()
-		if lister == nil {
-			return nil, fmt.Errorf("insufficient permissions to list deployments")
-		}
-		dep, err := lister.Deployments(namespace).Get(name)
-		if err != nil {
-			return nil, fmt.Errorf("deployment %s/%s not found: %w", namespace, name, err)
-		}
-		return dep.Spec.Selector, nil
-
-	case "statefulsets":
-		lister := cache.StatefulSets()
-		if lister == nil {
-			return nil, fmt.Errorf("insufficient permissions to list statefulsets")
-		}
-		sts, err := lister.StatefulSets(namespace).Get(name)
-		if err != nil {
-			return nil, fmt.Errorf("statefulset %s/%s not found: %w", namespace, name, err)
-		}
-		return sts.Spec.Selector, nil
-
-	case "daemonsets":
-		lister := cache.DaemonSets()
-		if lister == nil {
-			return nil, fmt.Errorf("insufficient permissions to list daemonsets")
-		}
-		ds, err := lister.DaemonSets(namespace).Get(name)
-		if err != nil {
-			return nil, fmt.Errorf("daemonset %s/%s not found: %w", namespace, name, err)
-		}
-		return ds.Spec.Selector, nil
-
-	default:
-		return nil, fmt.Errorf("unsupported workload kind: %s", kind)
-	}
-}
-
-// getContainersForPod returns containers to fetch logs from.
-func getContainersForPod(pod *corev1.Pod, selectedContainer string) []string {
-	if selectedContainer != "" {
-		for _, c := range pod.Spec.Containers {
-			if c.Name == selectedContainer {
-				return []string{selectedContainer}
-			}
-		}
-		return nil
-	}
-	containers := make([]string, 0, len(pod.Spec.Containers))
-	for _, c := range pod.Spec.Containers {
-		containers = append(containers, c.Name)
-	}
-	return containers
 }
 
 // normalizeWorkloadKind converts various kind formats to the plural lowercase form.

--- a/internal/server/argo_handlers.go
+++ b/internal/server/argo_handlers.go
@@ -1,32 +1,19 @@
 package server
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/go-chi/chi/v5"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/skyhook-io/radar/internal/gitops"
 	"github.com/skyhook-io/radar/internal/k8s"
 )
 
-// ArgoCD Application GVR - all handlers operate on Applications
-var argoApplicationGVR = schema.GroupVersionResource{
-	Group:    "argoproj.io",
-	Version:  "v1alpha1",
-	Resource: "applications",
-}
-
 // handleArgoSync triggers a sync operation on an ArgoCD Application
-// This sets the operation field to initiate a sync
 func (s *Server) handleArgoSync(w http.ResponseWriter, r *http.Request) {
 	namespace := chi.URLParam(r, "namespace")
 	name := chi.URLParam(r, "name")
@@ -38,90 +25,20 @@ func (s *Server) handleArgoSync(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// First, get the current application to check its state
-	app, err := client.Resource(argoApplicationGVR).Namespace(namespace).Get(
-		r.Context(),
-		name,
-		metav1.GetOptions{},
-	)
+	result, err := gitops.SyncArgoApp(r.Context(), client, namespace, name)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			s.writeError(w, http.StatusNotFound, err.Error())
-			return
-		}
-		log.Printf("[argo] Failed to get application %s/%s: %v", namespace, name, err)
-		s.writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeGitOpsError(w, err, "argo", "sync", namespace, name)
 		return
 	}
 
-	// Check if there's already an operation in progress
-	phase, found, _ := unstructured.NestedString(app.Object, "status", "operationState", "phase")
-	if found {
-		if phase == "Running" {
-			s.writeError(w, http.StatusConflict, "sync operation already in progress")
-			return
-		}
-	}
-
-	// ArgoCD sync is triggered by setting the operation field
-	// The argocd-application-controller watches for this and performs the sync
-	timestamp := time.Now().Format(time.RFC3339Nano)
-
-	// We use a simpler approach: set the refresh annotation to trigger a sync
-	// This is similar to running `argocd app sync`
-	patch := map[string]any{
-		"metadata": map[string]any{
-			"annotations": map[string]string{
-				"argocd.argoproj.io/refresh": "hard",
-			},
-		},
-		"operation": map[string]any{
-			"initiatedBy": map[string]any{
-				"username": "radar",
-			},
-			"sync": map[string]any{
-				"revision": "", // Empty means use the target revision from spec
-				"prune":    true,
-			},
-		},
-	}
-
-	patchBytes, err := json.Marshal(patch)
-	if err != nil {
-		log.Printf("[argo] Failed to marshal sync patch for %s/%s: %v", namespace, name, err)
-		s.writeError(w, http.StatusInternalServerError, "failed to create patch")
-		return
-	}
-
-	_, err = client.Resource(argoApplicationGVR).Namespace(namespace).Patch(
-		r.Context(),
-		name,
-		types.MergePatchType,
-		patchBytes,
-		metav1.PatchOptions{},
-	)
-	if err != nil {
-		log.Printf("[argo] Failed to sync application %s/%s: %v", namespace, name, err)
-		s.writeError(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-
-	s.writeJSON(w, GitOpsOperationResponse{
-		Message:     "Sync operation initiated",
-		Operation:   "sync",
-		Tool:        "argocd",
-		Resource:    GitOpsResourceRef{Kind: "Application", Name: name, Namespace: namespace},
-		RequestedAt: timestamp,
-	})
+	s.writeJSON(w, toGitOpsResponse(result))
 }
 
 // handleArgoRefresh triggers a refresh (re-read from git) on an ArgoCD Application
-// This is a lighter operation than sync - it just refreshes the app status
 func (s *Server) handleArgoRefresh(w http.ResponseWriter, r *http.Request) {
 	namespace := chi.URLParam(r, "namespace")
 	name := chi.URLParam(r, "name")
 
-	// Get refresh type from query param (default: normal, can be "hard")
 	refreshType := r.URL.Query().Get("type")
 	if refreshType == "" {
 		refreshType = "normal"
@@ -137,48 +54,13 @@ func (s *Server) handleArgoRefresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	timestamp := time.Now().Format(time.RFC3339Nano)
-
-	// ArgoCD refresh is triggered by setting the refresh annotation
-	patch := map[string]any{
-		"metadata": map[string]any{
-			"annotations": map[string]string{
-				"argocd.argoproj.io/refresh": refreshType,
-			},
-		},
-	}
-
-	patchBytes, err := json.Marshal(patch)
+	result, err := gitops.RefreshArgoApp(r.Context(), client, namespace, name, refreshType)
 	if err != nil {
-		log.Printf("[argo] Failed to marshal refresh patch for %s/%s: %v", namespace, name, err)
-		s.writeError(w, http.StatusInternalServerError, "failed to create patch")
+		s.writeGitOpsError(w, err, "argo", "refresh", namespace, name)
 		return
 	}
 
-	_, err = client.Resource(argoApplicationGVR).Namespace(namespace).Patch(
-		r.Context(),
-		name,
-		types.MergePatchType,
-		patchBytes,
-		metav1.PatchOptions{},
-	)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			s.writeError(w, http.StatusNotFound, err.Error())
-			return
-		}
-		log.Printf("[argo] Failed to refresh application %s/%s: %v", namespace, name, err)
-		s.writeError(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-
-	s.writeJSON(w, GitOpsOperationResponse{
-		Message:     fmt.Sprintf("Refresh (%s) triggered", refreshType),
-		Operation:   "refresh",
-		Tool:        "argocd",
-		Resource:    GitOpsResourceRef{Kind: "Application", Name: name, Namespace: namespace},
-		RequestedAt: timestamp,
-	})
+	s.writeJSON(w, toGitOpsResponse(result))
 }
 
 // handleArgoTerminate terminates an ongoing sync operation
@@ -193,208 +75,96 @@ func (s *Server) handleArgoTerminate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// First, check if there's an operation in progress
-	app, err := client.Resource(argoApplicationGVR).Namespace(namespace).Get(
-		r.Context(),
-		name,
-		metav1.GetOptions{},
-	)
+	result, err := gitops.TerminateArgoSync(r.Context(), client, namespace, name)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			s.writeError(w, http.StatusNotFound, err.Error())
-			return
-		}
-		log.Printf("[argo] Failed to get application %s/%s for terminate: %v", namespace, name, err)
-		s.writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeGitOpsError(w, err, "argo", "terminate", namespace, name)
 		return
 	}
 
-	// Check the operation state
-	phase, found, _ := unstructured.NestedString(app.Object, "status", "operationState", "phase")
-	if !found || phase != "Running" {
-		s.writeError(w, http.StatusBadRequest, "no sync operation in progress")
-		return
-	}
-
-	// Terminate by removing the operation field - ArgoCD will cancel it
-	// Actually, ArgoCD termination is done by setting operation to nil
-	// We use a JSON patch to remove the operation field
-	patchBytes := []byte(`[{"op": "remove", "path": "/operation"}]`)
-
-	_, err = client.Resource(argoApplicationGVR).Namespace(namespace).Patch(
-		r.Context(),
-		name,
-		types.JSONPatchType,
-		patchBytes,
-		metav1.PatchOptions{},
-	)
-	if err != nil {
-		// If the operation field doesn't exist, the operation may have already completed
-		if strings.Contains(err.Error(), "nonexistent") {
-			log.Printf("[argo] Terminate: operation field already removed for %s/%s (may have completed)", namespace, name)
-			// Return informative response - the operation wasn't terminated by us
-			s.writeJSON(w, GitOpsOperationResponse{
-				Message:   "No operation to terminate (may have already completed)",
-				Operation: "terminate",
-				Tool:      "argocd",
-				Resource:  GitOpsResourceRef{Kind: "Application", Name: name, Namespace: namespace},
-			})
-			return
-		}
-		log.Printf("[argo] Failed to terminate operation for %s/%s: %v", namespace, name, err)
-		s.writeError(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-
-	s.writeJSON(w, GitOpsOperationResponse{
-		Message:   "Sync operation terminated",
-		Operation: "terminate",
-		Tool:      "argocd",
-		Resource:  GitOpsResourceRef{Kind: "Application", Name: name, Namespace: namespace},
-	})
+	s.writeJSON(w, toGitOpsResponse(result))
 }
 
 // handleArgoSuspend disables automated sync on an ArgoCD Application
-// ArgoCD doesn't have a direct suspend like Flux, but we can disable automated sync
 func (s *Server) handleArgoSuspend(w http.ResponseWriter, r *http.Request) {
-	s.setArgoAutomatedSync(w, r, false)
-}
-
-// handleArgoResume re-enables automated sync on an ArgoCD Application
-func (s *Server) handleArgoResume(w http.ResponseWriter, r *http.Request) {
-	s.setArgoAutomatedSync(w, r, true)
-}
-
-// setArgoAutomatedSync enables or disables automated sync policy
-func (s *Server) setArgoAutomatedSync(w http.ResponseWriter, r *http.Request, enable bool) {
 	namespace := chi.URLParam(r, "namespace")
 	name := chi.URLParam(r, "name")
 
-	action := "suspend"
-	if enable {
-		action = "resume"
-	}
-
 	client := k8s.GetDynamicClient()
 	if client == nil {
-		log.Printf("[argo] Dynamic client unavailable for %s Application %s/%s", action, namespace, name)
+		log.Printf("[argo] Dynamic client unavailable for suspend Application %s/%s", namespace, name)
 		s.writeError(w, http.StatusServiceUnavailable, "dynamic client not available")
 		return
 	}
 
-	// Get current application to check existing sync policy
-	app, err := client.Resource(argoApplicationGVR).Namespace(namespace).Get(
-		r.Context(),
-		name,
-		metav1.GetOptions{},
-	)
+	result, err := gitops.SetArgoAutoSync(r.Context(), client, namespace, name, false)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			s.writeError(w, http.StatusNotFound, err.Error())
-			return
-		}
-		log.Printf("[argo] Failed to get application %s/%s for %s: %v", namespace, name, action, err)
-		s.writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeGitOpsError(w, err, "argo", "suspend", namespace, name)
 		return
 	}
 
-	var patch map[string]any
+	s.writeJSON(w, toGitOpsResponse(result))
+}
 
-	if enable {
-		// Re-enable automated sync
-		// Get the existing prune and selfHeal settings if they exist
-		prune := true
-		selfHeal := true
+// handleArgoResume re-enables automated sync on an ArgoCD Application
+func (s *Server) handleArgoResume(w http.ResponseWriter, r *http.Request) {
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
 
-		// Try to get existing settings from annotations (we store them when suspending)
-		annotations, _, _ := unstructured.NestedStringMap(app.Object, "metadata", "annotations")
-		if annotations != nil {
-			if v, ok := annotations["radar.skyhook.io/suspended-prune"]; ok {
-				prune = v == "true"
-			}
-			if v, ok := annotations["radar.skyhook.io/suspended-selfheal"]; ok {
-				selfHeal = v == "true"
-			}
-		}
-
-		patch = map[string]any{
-			"metadata": map[string]any{
-				"annotations": map[string]any{
-					"radar.skyhook.io/suspended-prune":    nil, // Remove
-					"radar.skyhook.io/suspended-selfheal": nil, // Remove
-				},
-			},
-			"spec": map[string]any{
-				"syncPolicy": map[string]any{
-					"automated": map[string]any{
-						"prune":    prune,
-						"selfHeal": selfHeal,
-					},
-				},
-			},
-		}
-	} else {
-		// Disable automated sync (suspend)
-		// First, save current automated settings to annotations for later restore
-		prune := false
-		selfHeal := false
-
-		automated, found, _ := unstructured.NestedMap(app.Object, "spec", "syncPolicy", "automated")
-		if found && automated != nil {
-			if v, ok := automated["prune"].(bool); ok {
-				prune = v
-			}
-			if v, ok := automated["selfHeal"].(bool); ok {
-				selfHeal = v
-			}
-		}
-
-		patch = map[string]any{
-			"metadata": map[string]any{
-				"annotations": map[string]string{
-					"radar.skyhook.io/suspended-prune":    fmt.Sprintf("%v", prune),
-					"radar.skyhook.io/suspended-selfheal": fmt.Sprintf("%v", selfHeal),
-				},
-			},
-			"spec": map[string]any{
-				"syncPolicy": map[string]any{
-					"automated": nil, // Remove automated sync
-				},
-			},
-		}
-	}
-
-	patchBytes, err := json.Marshal(patch)
-	if err != nil {
-		log.Printf("[argo] Failed to marshal %s patch for %s/%s: %v", action, namespace, name, err)
-		s.writeError(w, http.StatusInternalServerError, "failed to create patch")
+	client := k8s.GetDynamicClient()
+	if client == nil {
+		log.Printf("[argo] Dynamic client unavailable for resume Application %s/%s", namespace, name)
+		s.writeError(w, http.StatusServiceUnavailable, "dynamic client not available")
 		return
 	}
 
-	_, err = client.Resource(argoApplicationGVR).Namespace(namespace).Patch(
-		r.Context(),
-		name,
-		types.MergePatchType,
-		patchBytes,
-		metav1.PatchOptions{},
-	)
+	result, err := gitops.SetArgoAutoSync(r.Context(), client, namespace, name, true)
 	if err != nil {
-		log.Printf("[argo] Failed to %s application %s/%s: %v", action, namespace, name, err)
-		s.writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeGitOpsError(w, err, "argo", "resume", namespace, name)
 		return
 	}
 
-	actionPast := "suspended"
-	operation := "suspend"
-	if enable {
-		actionPast = "resumed"
-		operation = "resume"
+	s.writeJSON(w, toGitOpsResponse(result))
+}
+
+// toGitOpsResponse converts a gitops.OperationResult to the REST response type.
+func toGitOpsResponse(r gitops.OperationResult) GitOpsOperationResponse {
+	resp := GitOpsOperationResponse{
+		Message:     r.Message,
+		Operation:   r.Operation,
+		Tool:        r.Tool,
+		Resource:    GitOpsResourceRef{Kind: r.Kind, Name: r.Name, Namespace: r.Namespace},
+		RequestedAt: r.RequestedAt,
+	}
+	if r.Source != nil {
+		resp.Source = &GitOpsResourceRef{Kind: r.Source.Kind, Name: r.Source.Name, Namespace: r.Source.Namespace}
+	}
+	return resp
+}
+
+// writeGitOpsError maps gitops operation errors to appropriate HTTP status codes.
+func (s *Server) writeGitOpsError(w http.ResponseWriter, err error, module, action, namespace, name string) {
+	msg := err.Error()
+
+	// Check typed K8s API errors first (preserved through %w wrapping)
+	if apierrors.IsNotFound(err) {
+		s.writeError(w, http.StatusNotFound, msg)
+		return
+	}
+	if apierrors.IsForbidden(err) {
+		s.writeError(w, http.StatusForbidden, msg)
+		return
 	}
 
-	s.writeJSON(w, GitOpsOperationResponse{
-		Message:   fmt.Sprintf("Application %s (automated sync %s)", actionPast, actionPast),
-		Operation: operation,
-		Tool:      "argocd",
-		Resource:  GitOpsResourceRef{Kind: "Application", Name: name, Namespace: namespace},
-	})
+	// Application-level errors from gitops operations
+	switch {
+	case strings.Contains(msg, "not found"):
+		s.writeError(w, http.StatusNotFound, msg)
+	case strings.Contains(msg, "already in progress"):
+		s.writeError(w, http.StatusConflict, msg)
+	case strings.Contains(msg, "no sync operation in progress"):
+		s.writeError(w, http.StatusBadRequest, msg)
+	default:
+		log.Printf("[%s] Failed to %s %s/%s: %v", module, action, namespace, name, err)
+		s.writeError(w, http.StatusInternalServerError, msg)
+	}
 }

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -10,8 +10,6 @@ import (
 	"sync"
 	"time"
 
-	autoscalingv2 "k8s.io/api/autoscaling/v2"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -323,178 +321,17 @@ func (s *Server) getDashboardHealth(cache *k8s.ResourceCache, namespace string) 
 		}
 	}
 
-	// Deployment problems: unavailableReplicas > 0
-	if depLister := cache.Deployments(); depLister != nil {
-		if namespace != "" {
-			deps, _ := depLister.Deployments(namespace).List(labels.Everything())
-			for _, d := range deps {
-				if d.Status.UnavailableReplicas > 0 {
-					ageDur := now.Sub(d.CreationTimestamp.Time)
-					problems = append(problems, DashboardProblem{
-						Kind:       "Deployment",
-						Namespace:  d.Namespace,
-						Name:       d.Name,
-						Status:     "error",
-						Reason:     fmt.Sprintf("%d/%d available", d.Status.AvailableReplicas, d.Status.Replicas),
-						Age:        k8s.FormatAge(ageDur),
-						AgeSeconds: int64(ageDur.Seconds()),
-					})
-				}
-			}
-		} else {
-			deps, _ := depLister.List(labels.Everything())
-			for _, d := range deps {
-				if d.Status.UnavailableReplicas > 0 {
-					ageDur := now.Sub(d.CreationTimestamp.Time)
-					problems = append(problems, DashboardProblem{
-						Kind:       "Deployment",
-						Namespace:  d.Namespace,
-						Name:       d.Name,
-						Status:     "error",
-						Reason:     fmt.Sprintf("%d/%d available", d.Status.AvailableReplicas, d.Status.Replicas),
-						Age:        k8s.FormatAge(ageDur),
-						AgeSeconds: int64(ageDur.Seconds()),
-					})
-				}
-			}
-		}
-	}
-
-	// StatefulSet problems: readyReplicas < replicas
-	if ssLister := cache.StatefulSets(); ssLister != nil {
-		if namespace != "" {
-			ssets, _ := ssLister.StatefulSets(namespace).List(labels.Everything())
-			for _, ss := range ssets {
-				if ss.Status.ReadyReplicas < ss.Status.Replicas {
-					ageDur := now.Sub(ss.CreationTimestamp.Time)
-					problems = append(problems, DashboardProblem{
-						Kind:       "StatefulSet",
-						Namespace:  ss.Namespace,
-						Name:       ss.Name,
-						Status:     "error",
-						Reason:     fmt.Sprintf("%d/%d ready", ss.Status.ReadyReplicas, ss.Status.Replicas),
-						Age:        k8s.FormatAge(ageDur),
-						AgeSeconds: int64(ageDur.Seconds()),
-					})
-				}
-			}
-		} else {
-			ssets, _ := ssLister.List(labels.Everything())
-			for _, ss := range ssets {
-				if ss.Status.ReadyReplicas < ss.Status.Replicas {
-					ageDur := now.Sub(ss.CreationTimestamp.Time)
-					problems = append(problems, DashboardProblem{
-						Kind:       "StatefulSet",
-						Namespace:  ss.Namespace,
-						Name:       ss.Name,
-						Status:     "error",
-						Reason:     fmt.Sprintf("%d/%d ready", ss.Status.ReadyReplicas, ss.Status.Replicas),
-						Age:        k8s.FormatAge(ageDur),
-						AgeSeconds: int64(ageDur.Seconds()),
-					})
-				}
-			}
-		}
-	}
-
-	// DaemonSet problems: numberUnavailable > 0
-	if dsLister := cache.DaemonSets(); dsLister != nil {
-		if namespace != "" {
-			dsets, _ := dsLister.DaemonSets(namespace).List(labels.Everything())
-			for _, ds := range dsets {
-				if ds.Status.NumberUnavailable > 0 {
-					ageDur := now.Sub(ds.CreationTimestamp.Time)
-					problems = append(problems, DashboardProblem{
-						Kind:       "DaemonSet",
-						Namespace:  ds.Namespace,
-						Name:       ds.Name,
-						Status:     "error",
-						Reason:     fmt.Sprintf("%d unavailable", ds.Status.NumberUnavailable),
-						Age:        k8s.FormatAge(ageDur),
-						AgeSeconds: int64(ageDur.Seconds()),
-					})
-				}
-			}
-		} else {
-			dsets, _ := dsLister.List(labels.Everything())
-			for _, ds := range dsets {
-				if ds.Status.NumberUnavailable > 0 {
-					ageDur := now.Sub(ds.CreationTimestamp.Time)
-					problems = append(problems, DashboardProblem{
-						Kind:       "DaemonSet",
-						Namespace:  ds.Namespace,
-						Name:       ds.Name,
-						Status:     "error",
-						Reason:     fmt.Sprintf("%d unavailable", ds.Status.NumberUnavailable),
-						Age:        k8s.FormatAge(ageDur),
-						AgeSeconds: int64(ageDur.Seconds()),
-					})
-				}
-			}
-		}
-	}
-
-	// HPA problems: maxed out
-	if hpaLister := cache.HorizontalPodAutoscalers(); hpaLister != nil {
-		var hpas []*autoscalingv2.HorizontalPodAutoscaler
-		if namespace != "" {
-			hpas, _ = hpaLister.HorizontalPodAutoscalers(namespace).List(labels.Everything())
-		} else {
-			hpas, _ = hpaLister.List(labels.Everything())
-		}
-		for _, hp := range k8s.DetectHPAProblems(hpas) {
-			problems = append(problems, DashboardProblem{
-				Kind:      "HorizontalPodAutoscaler",
-				Namespace: hp.Namespace,
-				Name:      hp.Name,
-				Status:    "warning",
-				Reason:    hp.Problem,
-				Message:   hp.Reason,
-			})
-		}
-	}
-
-	// CronJob problems: stale or never-scheduled
-	if cjLister := cache.CronJobs(); cjLister != nil {
-		var cronjobs []*batchv1.CronJob
-		if namespace != "" {
-			cronjobs, _ = cjLister.CronJobs(namespace).List(labels.Everything())
-		} else {
-			cronjobs, _ = cjLister.List(labels.Everything())
-		}
-		for _, cp := range k8s.DetectCronJobProblems(cronjobs) {
-			problems = append(problems, DashboardProblem{
-				Kind:      "CronJob",
-				Namespace: cp.Namespace,
-				Name:      cp.Name,
-				Status:    "warning",
-				Reason:    cp.Problem,
-				Message:   cp.Reason,
-			})
-		}
-	}
-
-	// Node problems: NotReady, Cordoned, pressure conditions
-	var nodes []*corev1.Node
-	if nodeLister := cache.Nodes(); nodeLister != nil {
-		nodes, _ = nodeLister.List(labels.Everything())
-	}
-	for _, np := range k8s.DetectNodeProblems(nodes) {
-		ageDur := time.Duration(0)
-		for _, n := range nodes {
-			if n.Name == np.NodeName {
-				ageDur = now.Sub(n.CreationTimestamp.Time)
-				break
-			}
-		}
+	// Workload/HPA/CronJob/Node problems (excluding pods, handled above)
+	for _, p := range k8s.DetectProblems(cache, namespace) {
 		problems = append(problems, DashboardProblem{
-			Kind:       "Node",
-			Name:       np.NodeName,
-			Status:     np.Severity,
-			Reason:     np.Problem,
-			Message:    np.Reason,
-			Age:        k8s.FormatAge(ageDur),
-			AgeSeconds: int64(ageDur.Seconds()),
+			Kind:       p.Kind,
+			Namespace:  p.Namespace,
+			Name:       p.Name,
+			Status:     p.Severity,
+			Reason:     p.Reason,
+			Message:    p.Message,
+			Age:        p.Age,
+			AgeSeconds: p.AgeSeconds,
 		})
 	}
 
@@ -1096,8 +933,8 @@ func (s *Server) getDashboardHelmSummary(namespace string) DashboardHelmSummary 
 
 	// Sort: failed/unhealthy releases first to surface problems
 	sort.SliceStable(releases, func(i, j int) bool {
-		pi := helmStatusPriority(releases[i].Status, releases[i].ResourceHealth)
-		pj := helmStatusPriority(releases[j].Status, releases[j].ResourceHealth)
+		pi := helm.StatusPriority(releases[i].Status, releases[i].ResourceHealth)
+		pj := helm.StatusPriority(releases[j].Status, releases[j].ResourceHealth)
 		return pi < pj
 	})
 
@@ -1359,20 +1196,3 @@ func (s *Server) getDashboardCRDCounts(_ context.Context, namespace string) []Da
 	return counts
 }
 
-// helmStatusPriority returns a sort priority for Helm release statuses.
-// Lower values sort first — failed and unhealthy releases are surfaced first.
-func helmStatusPriority(status, resourceHealth string) int {
-	if status == "failed" {
-		return 0
-	}
-	if status == "pending-install" || status == "pending-upgrade" || status == "pending-rollback" {
-		return 1
-	}
-	switch resourceHealth {
-	case "unhealthy":
-		return 2
-	case "degraded":
-		return 3
-	}
-	return 4
-}

--- a/internal/server/flux_handlers.go
+++ b/internal/server/flux_handlers.go
@@ -1,75 +1,14 @@
 package server
 
 import (
-	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
-	"strings"
-	"time"
 
 	"github.com/go-chi/chi/v5"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/skyhook-io/radar/internal/gitops"
 	"github.com/skyhook-io/radar/internal/k8s"
 )
-
-// FluxCD API groups and versions
-var (
-	fluxGitRepoGVR = schema.GroupVersionResource{
-		Group:    "source.toolkit.fluxcd.io",
-		Version:  "v1",
-		Resource: "gitrepositories",
-	}
-	fluxOCIRepoGVR = schema.GroupVersionResource{
-		Group:    "source.toolkit.fluxcd.io",
-		Version:  "v1",
-		Resource: "ocirepositories",
-	}
-	fluxHelmRepoGVR = schema.GroupVersionResource{
-		Group:    "source.toolkit.fluxcd.io",
-		Version:  "v1",
-		Resource: "helmrepositories",
-	}
-	fluxKustomizeGVR = schema.GroupVersionResource{
-		Group:    "kustomize.toolkit.fluxcd.io",
-		Version:  "v1",
-		Resource: "kustomizations",
-	}
-	fluxHelmReleaseGVR = schema.GroupVersionResource{
-		Group:    "helm.toolkit.fluxcd.io",
-		Version:  "v2",
-		Resource: "helmreleases",
-	}
-	fluxAlertGVR = schema.GroupVersionResource{
-		Group:    "notification.toolkit.fluxcd.io",
-		Version:  "v1beta3",
-		Resource: "alerts",
-	}
-)
-
-// getFluxGVR returns the appropriate GVR for a Flux resource kind
-func getFluxGVR(kind string) (schema.GroupVersionResource, error) {
-	switch strings.ToLower(kind) {
-	case "gitrepository", "gitrepositories":
-		return fluxGitRepoGVR, nil
-	case "ocirepository", "ocirepositories":
-		return fluxOCIRepoGVR, nil
-	case "helmrepository", "helmrepositories":
-		return fluxHelmRepoGVR, nil
-	case "kustomization", "kustomizations":
-		return fluxKustomizeGVR, nil
-	case "helmrelease", "helmreleases":
-		return fluxHelmReleaseGVR, nil
-	case "alert", "alerts":
-		return fluxAlertGVR, nil
-	default:
-		return schema.GroupVersionResource{}, fmt.Errorf("unknown Flux resource kind: %s", kind)
-	}
-}
 
 // handleFluxReconcile triggers a reconciliation by setting the reconcile annotation
 func (s *Server) handleFluxReconcile(w http.ResponseWriter, r *http.Request) {
@@ -77,27 +16,9 @@ func (s *Server) handleFluxReconcile(w http.ResponseWriter, r *http.Request) {
 	namespace := chi.URLParam(r, "namespace")
 	name := chi.URLParam(r, "name")
 
-	gvr, err := getFluxGVR(kind)
+	entry, err := gitops.ResolveFluxKind(kind)
 	if err != nil {
 		s.writeError(w, http.StatusBadRequest, err.Error())
-		return
-	}
-
-	// Patch the reconcile annotation to trigger reconciliation
-	// This is the standard FluxCD pattern for triggering a sync
-	timestamp := time.Now().Format(time.RFC3339Nano)
-	patch := map[string]any{
-		"metadata": map[string]any{
-			"annotations": map[string]string{
-				"reconcile.fluxcd.io/requestedAt": timestamp,
-			},
-		},
-	}
-
-	patchBytes, err := json.Marshal(patch)
-	if err != nil {
-		log.Printf("[flux] Failed to marshal reconcile patch for %s %s/%s: %v", kind, namespace, name, err)
-		s.writeError(w, http.StatusInternalServerError, "failed to create patch")
 		return
 	}
 
@@ -108,58 +29,35 @@ func (s *Server) handleFluxReconcile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, err = client.Resource(gvr).Namespace(namespace).Patch(
-		r.Context(),
-		name,
-		types.MergePatchType,
-		patchBytes,
-		metav1.PatchOptions{},
-	)
+	result, err := gitops.ReconcileFlux(r.Context(), client, entry, namespace, name)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			s.writeError(w, http.StatusNotFound, err.Error())
-			return
-		}
-		log.Printf("[flux] Failed to reconcile %s %s/%s: %v", kind, namespace, name, err)
-		s.writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeGitOpsError(w, err, "flux", "reconcile", namespace, name)
 		return
 	}
 
-	s.writeJSON(w, GitOpsOperationResponse{
-		Message:     "Reconciliation triggered",
-		Operation:   "reconcile",
-		Tool:        "fluxcd",
-		Resource:    GitOpsResourceRef{Kind: formatFluxKind(kind), Name: name, Namespace: namespace},
-		RequestedAt: timestamp,
-	})
+	s.writeJSON(w, toGitOpsResponse(result))
 }
 
 // handleFluxSuspend suspends a Flux resource by setting spec.suspend=true
 func (s *Server) handleFluxSuspend(w http.ResponseWriter, r *http.Request) {
-	s.setFluxSuspend(w, r, true)
+	s.fluxSetSuspend(w, r, true)
 }
 
 // handleFluxResume resumes a suspended Flux resource by setting spec.suspend=false
 func (s *Server) handleFluxResume(w http.ResponseWriter, r *http.Request) {
-	s.setFluxSuspend(w, r, false)
+	s.fluxSetSuspend(w, r, false)
 }
 
-// setFluxSuspend is a helper that sets the spec.suspend field
-func (s *Server) setFluxSuspend(w http.ResponseWriter, r *http.Request, suspend bool) {
+// fluxSetSuspend is a helper that sets the spec.suspend field
+func (s *Server) fluxSetSuspend(w http.ResponseWriter, r *http.Request, suspend bool) {
 	kind := chi.URLParam(r, "kind")
 	namespace := chi.URLParam(r, "namespace")
 	name := chi.URLParam(r, "name")
 
-	gvr, err := getFluxGVR(kind)
+	entry, err := gitops.ResolveFluxKind(kind)
 	if err != nil {
 		s.writeError(w, http.StatusBadRequest, err.Error())
 		return
-	}
-
-	patch := map[string]any{
-		"spec": map[string]any{
-			"suspend": suspend,
-		},
 	}
 
 	action := "suspend"
@@ -167,13 +65,6 @@ func (s *Server) setFluxSuspend(w http.ResponseWriter, r *http.Request, suspend 
 		action = "resume"
 	}
 
-	patchBytes, err := json.Marshal(patch)
-	if err != nil {
-		log.Printf("[flux] Failed to marshal %s patch for %s %s/%s: %v", action, kind, namespace, name, err)
-		s.writeError(w, http.StatusInternalServerError, "failed to create patch")
-		return
-	}
-
 	client := k8s.GetDynamicClient()
 	if client == nil {
 		log.Printf("[flux] Dynamic client unavailable for %s %s/%s", kind, namespace, name)
@@ -181,67 +72,23 @@ func (s *Server) setFluxSuspend(w http.ResponseWriter, r *http.Request, suspend 
 		return
 	}
 
-	_, err = client.Resource(gvr).Namespace(namespace).Patch(
-		r.Context(),
-		name,
-		types.MergePatchType,
-		patchBytes,
-		metav1.PatchOptions{},
-	)
+	result, err := gitops.SetFluxSuspend(r.Context(), client, entry, namespace, name, suspend)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			s.writeError(w, http.StatusNotFound, err.Error())
-			return
-		}
-		log.Printf("[flux] Failed to %s %s %s/%s: %v", action, kind, namespace, name, err)
-		s.writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeGitOpsError(w, err, "flux", action, namespace, name)
 		return
 	}
 
-	actionPast := "suspended"
-	operation := "suspend"
-	if !suspend {
-		actionPast = "resumed"
-		operation = "resume"
-	}
-
-	s.writeJSON(w, GitOpsOperationResponse{
-		Message:   fmt.Sprintf("%s %s", formatFluxKind(kind), actionPast),
-		Operation: operation,
-		Tool:      "fluxcd",
-		Resource:  GitOpsResourceRef{Kind: formatFluxKind(kind), Name: name, Namespace: namespace},
-	})
-}
-
-// formatFluxKind returns a human-readable name for a Flux kind
-func formatFluxKind(kind string) string {
-	switch strings.ToLower(kind) {
-	case "gitrepository", "gitrepositories":
-		return "GitRepository"
-	case "ocirepository", "ocirepositories":
-		return "OCIRepository"
-	case "helmrepository", "helmrepositories":
-		return "HelmRepository"
-	case "kustomization", "kustomizations":
-		return "Kustomization"
-	case "helmrelease", "helmreleases":
-		return "HelmRelease"
-	case "alert", "alerts":
-		return "Alert"
-	default:
-		return kind
-	}
+	s.writeJSON(w, toGitOpsResponse(result))
 }
 
 // handleFluxSyncWithSource reconciles the source first, then the resource
-// This is useful for Kustomizations and HelmReleases that depend on a source
 func (s *Server) handleFluxSyncWithSource(w http.ResponseWriter, r *http.Request) {
 	kind := chi.URLParam(r, "kind")
 	namespace := chi.URLParam(r, "namespace")
 	name := chi.URLParam(r, "name")
 
-	gvr, err := getFluxGVR(kind)
-	if err != nil {
+	// Validate kind early — bad input is a 400, not a 500
+	if _, err := gitops.ResolveFluxKind(kind); err != nil {
 		s.writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -253,120 +100,11 @@ func (s *Server) handleFluxSyncWithSource(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Get the resource to extract sourceRef
-	resource, err := client.Resource(gvr).Namespace(namespace).Get(r.Context(), name, metav1.GetOptions{})
+	result, err := gitops.SyncFluxWithSource(r.Context(), client, kind, namespace, name)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			s.writeError(w, http.StatusNotFound, err.Error())
-			return
-		}
-		log.Printf("[flux] Failed to get %s %s/%s for sync-with-source: %v", kind, namespace, name, err)
-		s.writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeGitOpsError(w, err, "flux", "sync-with-source", namespace, name)
 		return
 	}
 
-	// Extract sourceRef based on kind
-	var sourceKind, sourceName, sourceNamespace string
-	spec, ok := resource.Object["spec"].(map[string]any)
-	if !ok {
-		log.Printf("[flux] Invalid spec for %s %s/%s: expected map[string]any", kind, namespace, name)
-		s.writeError(w, http.StatusInternalServerError, "invalid resource spec")
-		return
-	}
-
-	switch strings.ToLower(kind) {
-	case "kustomization", "kustomizations":
-		// Kustomization: spec.sourceRef
-		if sourceRef, ok := spec["sourceRef"].(map[string]any); ok {
-			sourceKind, _ = sourceRef["kind"].(string)
-			sourceName, _ = sourceRef["name"].(string)
-			sourceNamespace, _ = sourceRef["namespace"].(string)
-		}
-	case "helmrelease", "helmreleases":
-		// HelmRelease: spec.chart.spec.sourceRef
-		if chart, ok := spec["chart"].(map[string]any); ok {
-			if chartSpec, ok := chart["spec"].(map[string]any); ok {
-				if sourceRef, ok := chartSpec["sourceRef"].(map[string]any); ok {
-					sourceKind, _ = sourceRef["kind"].(string)
-					sourceName, _ = sourceRef["name"].(string)
-					sourceNamespace, _ = sourceRef["namespace"].(string)
-				}
-			}
-		}
-	default:
-		s.writeError(w, http.StatusBadRequest, "sync-with-source only supported for Kustomization and HelmRelease")
-		return
-	}
-
-	if sourceName == "" {
-		s.writeError(w, http.StatusBadRequest, "no source reference found in resource")
-		return
-	}
-
-	// Default sourceNamespace to resource namespace
-	if sourceNamespace == "" {
-		sourceNamespace = namespace
-	}
-
-	// Get the GVR for the source
-	sourceGVR, err := getFluxGVR(sourceKind)
-	if err != nil {
-		s.writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown source kind: %s", sourceKind))
-		return
-	}
-
-	timestamp := time.Now().Format(time.RFC3339Nano)
-	patch := map[string]any{
-		"metadata": map[string]any{
-			"annotations": map[string]string{
-				"reconcile.fluxcd.io/requestedAt": timestamp,
-			},
-		},
-	}
-
-	patchBytes, err := json.Marshal(patch)
-	if err != nil {
-		log.Printf("[flux] Failed to marshal sync-with-source patch for %s %s/%s: %v", kind, namespace, name, err)
-		s.writeError(w, http.StatusInternalServerError, "failed to create patch")
-		return
-	}
-
-	// First, reconcile the source
-	_, err = client.Resource(sourceGVR).Namespace(sourceNamespace).Patch(
-		r.Context(),
-		sourceName,
-		types.MergePatchType,
-		patchBytes,
-		metav1.PatchOptions{},
-	)
-	if err != nil {
-		log.Printf("[flux] Failed to reconcile source %s %s/%s: %v", sourceKind, sourceNamespace, sourceName, err)
-		s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to reconcile source: %v", err))
-		return
-	}
-
-	// Then, reconcile the resource itself
-	_, err = client.Resource(gvr).Namespace(namespace).Patch(
-		r.Context(),
-		name,
-		types.MergePatchType,
-		patchBytes,
-		metav1.PatchOptions{},
-	)
-	if err != nil {
-		log.Printf("[flux] Partial sync-with-source: source %s/%s reconciled, but %s %s/%s failed: %v",
-			sourceNamespace, sourceName, kind, namespace, name, err)
-		s.writeError(w, http.StatusInternalServerError,
-			fmt.Sprintf("failed to reconcile resource (note: source %s/%s was reconciled): %v", sourceName, sourceNamespace, err))
-		return
-	}
-
-	s.writeJSON(w, GitOpsOperationResponse{
-		Message:     "Sync with source triggered",
-		Operation:   "reconcile",
-		Tool:        "fluxcd",
-		Resource:    GitOpsResourceRef{Kind: formatFluxKind(kind), Name: name, Namespace: namespace},
-		RequestedAt: timestamp,
-		Source:      &GitOpsResourceRef{Kind: formatFluxKind(sourceKind), Name: sourceName, Namespace: sourceNamespace},
-	})
+	s.writeJSON(w, toGitOpsResponse(result))
 }

--- a/internal/server/workload_logs.go
+++ b/internal/server/workload_logs.go
@@ -3,7 +3,6 @@ package server
 import (
 	"bufio"
 	"context"
-	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -15,7 +14,6 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/skyhook-io/radar/internal/k8s"
@@ -137,7 +135,7 @@ func (s *Server) handleWorkloadLogsStream(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	selector, err := getWorkloadSelector(cache, kind, namespace, name)
+	selector, err := k8s.GetWorkloadSelector(cache, kind, namespace, name)
 	if err != nil {
 		sendSSEEvent(w, flusher, "error", map[string]string{"message": err.Error()})
 		return
@@ -174,7 +172,7 @@ func (s *Server) handleWorkloadLogsStream(w http.ResponseWriter, r *http.Request
 	// Start streaming from each pod/container
 	startPodStreams := func(pods []*corev1.Pod) {
 		for _, pod := range pods {
-			containers := getContainersToLog(pod, container)
+			containers := k8s.GetContainersForPod(pod, container, true)
 			for _, c := range containers {
 				key := pod.Name + "/" + c
 				if _, exists := activeStreams.Load(key); exists {
@@ -321,61 +319,6 @@ func streamPodLogs(ctx context.Context, client *kubernetes.Clientset, namespace,
 	}
 }
 
-// getWorkloadSelector returns the label selector for a workload
-func getWorkloadSelector(cache *k8s.ResourceCache, kind, namespace, name string) (*metav1.LabelSelector, error) {
-	switch kind {
-	case "deployments":
-		dep, err := cache.Deployments().Deployments(namespace).Get(name)
-		if err != nil {
-			return nil, fmt.Errorf("deployment %s/%s not found: %w", namespace, name, err)
-		}
-		return dep.Spec.Selector, nil
-
-	case "statefulsets":
-		sts, err := cache.StatefulSets().StatefulSets(namespace).Get(name)
-		if err != nil {
-			return nil, fmt.Errorf("statefulset %s/%s not found: %w", namespace, name, err)
-		}
-		return sts.Spec.Selector, nil
-
-	case "daemonsets":
-		ds, err := cache.DaemonSets().DaemonSets(namespace).Get(name)
-		if err != nil {
-			return nil, fmt.Errorf("daemonset %s/%s not found: %w", namespace, name, err)
-		}
-		return ds.Spec.Selector, nil
-
-	default:
-		return nil, fmt.Errorf("unsupported workload kind: %s", kind)
-	}
-}
-
-// getContainersToLog returns containers to stream logs from
-func getContainersToLog(pod *corev1.Pod, selectedContainer string) []string {
-	if selectedContainer != "" {
-		// Check if this container exists in the pod
-		for _, c := range pod.Spec.Containers {
-			if c.Name == selectedContainer {
-				return []string{selectedContainer}
-			}
-		}
-		for _, c := range pod.Spec.InitContainers {
-			if c.Name == selectedContainer {
-				return []string{selectedContainer}
-			}
-		}
-		// Container not found, return empty
-		return nil
-	}
-
-	// Return all containers
-	containers := make([]string, 0, len(pod.Spec.Containers))
-	for _, c := range pod.Spec.Containers {
-		containers = append(containers, c.Name)
-	}
-	return containers
-}
-
 // isPodReady checks if all containers in a pod are ready
 func isPodReady(pod *corev1.Pod) bool {
 	if pod.Status.Phase != corev1.PodRunning {
@@ -440,10 +383,13 @@ func (s *Server) getWorkloadPods(kind, namespace, name string) ([]*corev1.Pod, *
 		return nil, &workloadError{http.StatusServiceUnavailable, "resource cache not available"}
 	}
 
-	selector, err := getWorkloadSelector(cache, kind, namespace, name)
+	selector, err := k8s.GetWorkloadSelector(cache, kind, namespace, name)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			return nil, &workloadError{http.StatusNotFound, err.Error()}
+		}
+		if strings.Contains(err.Error(), "insufficient permissions") {
+			return nil, &workloadError{http.StatusForbidden, err.Error()}
 		}
 		return nil, &workloadError{http.StatusInternalServerError, err.Error()}
 	}
@@ -474,7 +420,7 @@ func collectLogsFromPods(ctx context.Context, client *kubernetes.Clientset, name
 	var wg sync.WaitGroup
 
 	for _, pod := range pods {
-		containers := getContainersToLog(pod, container)
+		containers := k8s.GetContainersForPod(pod, container, true)
 		for _, c := range containers {
 			wg.Add(1)
 			go func(podName, containerName string) {

--- a/web/src/components/home/MCPSetupDialog.tsx
+++ b/web/src/components/home/MCPSetupDialog.tsx
@@ -212,18 +212,22 @@ export function MCPSetupDialog({ open, onClose, mcpUrl }: MCPSetupDialogProps) {
                   { name: 'kind', required: true, desc: 'resource kind, e.g. pods, deployments, services' },
                   { name: 'namespace', required: false, desc: 'filter to a specific namespace' },
                 ]},
-                { name: 'get_resource', desc: 'Get detailed information about a single Kubernetes resource. Returns minified spec, status, and metadata. Use after list_resources to drill into a specific resource.', params: [
+                { name: 'get_resource', desc: 'Get detailed information about a single Kubernetes resource. Returns minified spec, status, and metadata. Optionally include related context (events, relationships, metrics, logs) to avoid extra tool calls.', params: [
                   { name: 'kind', required: true, desc: 'resource kind, e.g. pod, deployment, service' },
                   { name: 'namespace', required: true, desc: 'resource namespace' },
                   { name: 'name', required: true, desc: 'resource name' },
+                  { name: 'include', required: false, desc: 'events, relationships, metrics, logs' },
                 ]},
-                { name: 'get_topology', desc: 'Get the topology graph showing relationships between Kubernetes resources. Returns nodes and edges representing Deployments, Services, Ingresses, Pods, etc. Use \'traffic\' view for network flow or \'resources\' view for ownership hierarchy.', params: [
+                { name: 'get_topology', desc: 'Get the topology graph showing relationships between Kubernetes resources. Returns nodes and edges representing Deployments, Services, Ingresses, Pods, etc. Use \'traffic\' view for network flow or \'resources\' view for ownership hierarchy. Use \'summary\' format for LLM-friendly text descriptions.', params: [
                   { name: 'namespace', required: false, desc: 'filter to a specific namespace' },
                   { name: 'view', required: false, desc: 'traffic or resources' },
+                  { name: 'format', required: false, desc: 'graph (default) or summary (text)' },
                 ]},
-                { name: 'get_events', desc: 'Get recent Kubernetes warning events, deduplicated and sorted by recency. Useful for diagnosing issues — shows event reason, message, and occurrence count.', params: [
+                { name: 'get_events', desc: 'Get recent Kubernetes warning events, deduplicated and sorted by recency. Useful for diagnosing issues — shows event reason, message, and occurrence count. Filter by resource kind/name to scope to a specific resource.', params: [
                   { name: 'namespace', required: false, desc: 'filter to a specific namespace' },
                   { name: 'limit', required: false, desc: 'max events to return (default 20)' },
+                  { name: 'kind', required: false, desc: 'filter to events for this resource kind' },
+                  { name: 'name', required: false, desc: 'filter to events for this resource name' },
                 ]},
                 { name: 'get_pod_logs', desc: 'Get filtered log lines from a pod, prioritizing errors and warnings. Returns diagnostically relevant lines (errors, panics, stack traces) or falls back to the last 20 lines if no error patterns match.', params: [
                   { name: 'namespace', required: true, desc: 'pod namespace' },
@@ -232,6 +236,13 @@ export function MCPSetupDialog({ open, onClose, mcpUrl }: MCPSetupDialogProps) {
                   { name: 'tail_lines', required: false, desc: 'lines from end (default 200)' },
                 ]},
                 { name: 'list_namespaces', desc: 'List all Kubernetes namespaces with their status. Use to discover available namespaces before filtering other queries.', params: [] },
+                { name: 'get_changes', desc: 'Get recent resource changes (creates, updates, deletes) from the cluster timeline. Use to investigate what changed before an incident. Filter by namespace, resource kind, or specific resource name.', params: [
+                  { name: 'namespace', required: false, desc: 'filter to a specific namespace' },
+                  { name: 'kind', required: false, desc: 'filter to a resource kind (e.g. Deployment)' },
+                  { name: 'name', required: false, desc: 'filter to a specific resource name' },
+                  { name: 'since', required: false, desc: 'lookback duration, e.g. 1h, 30m (default 1h)' },
+                  { name: 'limit', required: false, desc: 'max changes to return (default 20, max 50)' },
+                ]},
                 { name: 'list_helm_releases', desc: 'List all Helm releases in the cluster with their status and health. Returns release name, namespace, chart, version, status, and resource health.', params: [
                   { name: 'namespace', required: false, desc: 'filter to a specific namespace' },
                 ]},


### PR DESCRIPTION
## Summary

Extracts ~1300 lines of duplicated business logic from the MCP tool handlers (`internal/mcp/`) and REST API handlers (`internal/server/`) into shared packages, making both layers thin transport adapters.

**New shared packages:**
- `internal/gitops/operations.go` — All ArgoCD/FluxCD operations (sync, reconcile, suspend/resume, refresh, terminate) with a transport-neutral `OperationResult` type and unified `ResolveFluxKind` for fuzzy kind matching
- `internal/k8s/problems.go` — Unified `DetectProblems` scanning Deployments, StatefulSets, DaemonSets, HPAs, CronJobs, and Nodes (pods excluded — consumers handle those differently)
- `internal/k8s/workload.go` — Shared `GetWorkloadSelector` and `GetContainersForPod` helpers
- `internal/helm/types.go` — `StatusPriority` moved from duplicated private functions

**Error handling improvements:**
- `writeGitOpsError` now uses typed K8s API error checks (`apierrors.IsNotFound`, `apierrors.IsForbidden`) before falling back to string matching
- `handleFluxSyncWithSource` validates kind early (400) instead of letting invalid input fall through to 500
- RBAC "insufficient permissions" errors in workload endpoints now return 403 instead of 500

Net result: -1332 lines removed, +1436 lines added (including 756 lines in new shared packages that replace duplicated code in both consumers).