### PR TITLE
fix: make context switch non-blocking when credentials are expired

### DIFF
--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -1044,7 +1044,16 @@ func (c *ResourceCache) ChangesRaw() chan ResourceChange {
 	return c.changes
 }
 
-// Stop gracefully shuts down the cache
+// Stop gracefully shuts down the cache.
+// Closing stopCh signals all informers to stop. factory.Shutdown() is run in
+// a background goroutine so we don't block context switches when informers are
+// stuck in HTTP calls against a cluster with expired credentials.
+//
+// The changes channel is NOT closed here because informer handlers may still
+// be sending to it (the sends are non-blocking select/default, but sending to
+// a closed channel panics). The dynamic cache also shares this channel via
+// ChangesRaw(). The channel will be abandoned and GC'd once all informer
+// goroutines exit and no references remain.
 func (c *ResourceCache) Stop() {
 	if c == nil {
 		return
@@ -1053,8 +1062,20 @@ func (c *ResourceCache) Stop() {
 	c.stopOnce.Do(func() {
 		log.Println("Stopping resource cache")
 		close(c.stopCh)
-		c.factory.Shutdown()
-		close(c.changes)
+		// Let informers drain in background — don't block context switch
+		go func() {
+			done := make(chan struct{})
+			go func() {
+				c.factory.Shutdown()
+				close(done)
+			}()
+			select {
+			case <-done:
+				log.Println("Resource cache stopped cleanly")
+			case <-time.After(5 * time.Second):
+				log.Println("Resource cache: informers still draining in background")
+			}
+		}()
 	})
 }
 

--- a/internal/k8s/context_manager.go
+++ b/internal/k8s/context_manager.go
@@ -153,15 +153,20 @@ func TestClusterConnection(ctx context.Context) error {
 }
 
 // PerformContextSwitch orchestrates a full context switch:
-// 1. Tears down all subsystems
+// 1. Tears down all subsystems (non-blocking — old informers drain in background)
 // 2. Switches the K8s client to the new context
 // 3. Tests connectivity to ensure cluster is reachable
 // 4. Reinitializes all subsystems (same sequence as initial boot)
 // 5. Notifies all registered callbacks
+//
+// Individual steps have their own timeouts: teardown is non-blocking,
+// connection test has ConnectionTestTimeout (5s), and cache sync has its own
+// deadline. ContextSwitchTimeout is available for future use at the handler
+// level if needed.
 func PerformContextSwitch(newContext string) error {
 	log.Printf("Performing context switch to %q", newContext)
 
-	// Step 1: Tear down all subsystems
+	// Step 1: Tear down all subsystems (non-blocking — informers drain in background)
 	reportProgress("Stopping caches...")
 	ResetAllSubsystems()
 

--- a/internal/k8s/dynamic_cache.go
+++ b/internal/k8s/dynamic_cache.go
@@ -799,7 +799,10 @@ func (d *DynamicResourceCache) WarmupParallel(gvrs []schema.GroupVersionResource
 	}
 }
 
-// Stop gracefully shuts down the dynamic cache
+// Stop gracefully shuts down the dynamic cache.
+// Closing stopCh signals all informers to stop. factory.Shutdown() is run in
+// a background goroutine so we don't block context switches when informers are
+// stuck in HTTP calls against a cluster with expired credentials.
 func (d *DynamicResourceCache) Stop() {
 	if d == nil {
 		return
@@ -817,7 +820,20 @@ func (d *DynamicResourceCache) Stop() {
 		d.discoveryMu.Unlock()
 
 		close(d.stopCh)
-		d.factory.Shutdown()
+		// Let informers drain in background — don't block context switch
+		go func() {
+			done := make(chan struct{})
+			go func() {
+				d.factory.Shutdown()
+				close(done)
+			}()
+			select {
+			case <-done:
+				log.Println("Dynamic resource cache stopped cleanly")
+			case <-time.After(5 * time.Second):
+				log.Println("Dynamic resource cache: informers still draining in background")
+			}
+		}()
 	})
 }
 

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -26,6 +26,12 @@ type SSEBroadcaster struct {
 	mu         sync.RWMutex
 	stopCh     chan struct{}
 
+	// watchStopCh is closed to signal the current watchResourceChanges goroutine
+	// to exit. A new channel is created each time the watcher is restarted
+	// (e.g., after a context switch creates a new resource cache).
+	watchStopCh chan struct{}
+	watchMu     sync.Mutex // protects watchStopCh
+
 	// Cached topology for relationship lookups (updated on each topology rebuild)
 	cachedTopology   *topology.Topology
 	cachedTopologyMu sync.RWMutex
@@ -64,10 +70,11 @@ func safeSend(ch chan SSEEvent, event SSEEvent) {
 // NewSSEBroadcaster creates a new SSE broadcaster
 func NewSSEBroadcaster() *SSEBroadcaster {
 	return &SSEBroadcaster{
-		clients:    make(map[chan SSEEvent]ClientInfo),
-		register:   make(chan clientRegistration),
-		unregister: make(chan chan SSEEvent),
-		stopCh:     make(chan struct{}),
+		clients:     make(map[chan SSEEvent]ClientInfo),
+		register:    make(chan clientRegistration),
+		unregister:  make(chan chan SSEEvent),
+		stopCh:      make(chan struct{}),
+		watchStopCh: make(chan struct{}),
 	}
 }
 
@@ -150,6 +157,12 @@ func (b *SSEBroadcaster) registerContextSwitchCallback() {
 		b.cachedTopology = nil
 		b.cachedTopologyMu.Unlock()
 
+		// Restart the resource change watcher for the new cache.
+		// The old watcher is stuck on the previous cache's changes channel
+		// (which is never closed to avoid panics from in-flight informer sends).
+		// Signal it to exit, then start a new one bound to the new cache.
+		b.restartResourceWatcher()
+
 		// Broadcast context_changed event to all clients
 		b.mu.RLock()
 		clientCount := len(b.clients)
@@ -228,7 +241,20 @@ func (b *SSEBroadcaster) run() {
 	}
 }
 
-// watchResourceChanges listens for K8s resource changes and broadcasts topology updates
+// restartResourceWatcher stops the current watchResourceChanges goroutine and
+// starts a new one bound to the current resource cache's changes channel.
+func (b *SSEBroadcaster) restartResourceWatcher() {
+	b.watchMu.Lock()
+	close(b.watchStopCh)
+	b.watchStopCh = make(chan struct{})
+	b.watchMu.Unlock()
+
+	go b.watchResourceChanges()
+}
+
+// watchResourceChanges listens for K8s resource changes and broadcasts topology updates.
+// Exits when b.stopCh (server shutdown) or b.watchStopCh (context switch restart) is closed,
+// or when the changes channel is closed.
 func (b *SSEBroadcaster) watchResourceChanges() {
 	cache := k8s.GetResourceCache()
 	if cache == nil {
@@ -241,6 +267,12 @@ func (b *SSEBroadcaster) watchResourceChanges() {
 		return
 	}
 
+	// Capture the current watchStopCh — restartResourceWatcher will close this
+	// and create a new one, so we must read it under the lock once at startup.
+	b.watchMu.Lock()
+	watchStop := b.watchStopCh
+	b.watchMu.Unlock()
+
 	// Debounce changes - wait for 100ms of quiet before sending topology update
 	debounceTimer := time.NewTimer(0)
 	<-debounceTimer.C // drain initial timer
@@ -249,6 +281,9 @@ func (b *SSEBroadcaster) watchResourceChanges() {
 	for {
 		select {
 		case <-b.stopCh:
+			return
+
+		case <-watchStop:
 			return
 
 		case change, ok := <-changes:


### PR DESCRIPTION
## Summary

- When the active context has expired credentials (e.g., AWS SSO token), switching contexts hangs for minutes because `factory.Shutdown()` blocks on informer goroutines stuck in HTTP calls
- Fix: close `stopCh` to signal informers, run `factory.Shutdown()` in the background, and proceed with the switch immediately
- Stop closing the shared `changes` channel in `Stop()` — informers still draining in background would panic on send-to-closed-channel
- Restart the SSE resource watcher on context switch so it rebinds to the new cache's channel (also fixes a pre-existing bug where real-time SSE updates were lost after any context switch)

## Key design decision

Old informers don't need to be *stopped*, they need to be *abandoned*. Each cache generation (factory + informers + stopCh + changes channel) is self-contained. On switch: close `stopCh`, nil out the singleton, create a new generation. Old goroutines drain in the background and get GC'd.

Closes #198