### PR TITLE
fix: use explicit JS callbacks for Edit menu clipboard actions (fixes #216)

### DIFF
--- a/cmd/desktop/menu.go
+++ b/cmd/desktop/menu.go
@@ -19,15 +19,47 @@ func createMenu(desktopApp *DesktopApp) *menu.Menu {
 		runtime.Quit(desktopApp.ctx)
 	})
 
-	// Edit menu (standard accelerators)
+	// Edit menu — use explicit JS callbacks instead of nil.
+	// On macOS, nil callbacks rely on the WKWebView responder chain for clipboard
+	// actions, but this doesn't work for complex editors like Monaco (used for YAML
+	// editing). By using WindowExecJS we ensure clipboard operations reach the web
+	// content regardless of which element is focused.
+	// See: https://github.com/microsoft/monaco-editor/issues/2205
 	editMenu := appMenu.AddSubmenu("Edit")
-	editMenu.AddText("Undo", keys.CmdOrCtrl("z"), nil)
-	editMenu.AddText("Redo", keys.Combo("z", keys.ShiftKey, keys.CmdOrCtrlKey), nil)
+	editMenu.AddText("Undo", keys.CmdOrCtrl("z"), func(_ *menu.CallbackData) {
+		runtime.WindowExecJS(desktopApp.ctx, "document.execCommand('undo')")
+	})
+	editMenu.AddText("Redo", keys.Combo("z", keys.ShiftKey, keys.CmdOrCtrlKey), func(_ *menu.CallbackData) {
+		runtime.WindowExecJS(desktopApp.ctx, "document.execCommand('redo')")
+	})
 	editMenu.AddSeparator()
-	editMenu.AddText("Cut", keys.CmdOrCtrl("x"), nil)
-	editMenu.AddText("Copy", keys.CmdOrCtrl("c"), nil)
-	editMenu.AddText("Paste", keys.CmdOrCtrl("v"), nil)
-	editMenu.AddText("Select All", keys.CmdOrCtrl("a"), nil)
+	editMenu.AddText("Cut", keys.CmdOrCtrl("x"), func(_ *menu.CallbackData) {
+		runtime.WindowExecJS(desktopApp.ctx, "document.execCommand('cut')")
+	})
+	editMenu.AddText("Copy", keys.CmdOrCtrl("c"), func(_ *menu.CallbackData) {
+		runtime.WindowExecJS(desktopApp.ctx, "document.execCommand('copy')")
+	})
+	editMenu.AddText("Paste", keys.CmdOrCtrl("v"), func(_ *menu.CallbackData) {
+		// Paste requires special handling: read clipboard text, then dispatch a
+		// synthetic ClipboardEvent so Monaco's paste handler processes it correctly.
+		// Falls back to document.execCommand('insertText') for plain inputs.
+		runtime.WindowExecJS(desktopApp.ctx, `
+			navigator.clipboard.readText().then(function(text) {
+				if (!text) return;
+				var el = document.activeElement || document.body;
+				try {
+					var dt = new DataTransfer();
+					dt.setData('text/plain', text);
+					var ev = new ClipboardEvent('paste', {clipboardData: dt, bubbles: true, cancelable: true});
+					if (!el.dispatchEvent(ev)) return;
+				} catch(e) {}
+				document.execCommand('insertText', false, text);
+			}).catch(function(err) { console.warn('[Radar] Paste failed:', err); });
+		`)
+	})
+	editMenu.AddText("Select All", keys.CmdOrCtrl("a"), func(_ *menu.CallbackData) {
+		runtime.WindowExecJS(desktopApp.ctx, "document.execCommand('selectAll')")
+	})
 
 	// View menu
 	viewMenu := appMenu.AddSubmenu("View")


### PR DESCRIPTION
On macOS, the Wails desktop app's Edit menu items with nil callbacks rely
on WKWebView's responder chain for clipboard operations. This doesn't
work for Monaco editor (used for YAML editing) because the paste: selector
doesn't properly deliver content to Monaco's hidden textarea.

Replace all nil callbacks with explicit WindowExecJS calls. Paste uses
navigator.clipboard.readText() + synthetic ClipboardEvent dispatch so
Monaco's paste handler processes it correctly, with insertText fallback
for regular inputs.

Fixes #216