### PR TITLE
fix: resolve service targetPort for Prometheus/metrics port-forwarding

### DIFF
--- a/internal/prometheus/discovery.go
+++ b/internal/prometheus/discovery.go
@@ -146,7 +146,7 @@ func (c *Client) discover(ctx context.Context) (string, string, error) {
 
 	// Not reachable in-cluster — try port-forward
 	log.Printf("[prometheus] Service %s/%s not reachable in-cluster, starting port-forward...", info.namespace, info.name)
-	connInfo, err := portforward.Start(ctx, info.namespace, info.name, info.port, contextName)
+	connInfo, err := portforward.Start(ctx, info.namespace, info.name, info.targetPort, contextName)
 	if err != nil {
 		return "", "", fmt.Errorf("port-forward to %s/%s failed: %w", info.namespace, info.name, err)
 	}
@@ -177,7 +177,8 @@ func (c *Client) discover(ctx context.Context) (string, string, error) {
 type serviceInfo struct {
 	namespace   string
 	name        string
-	port        int
+	port        int // service port (for cluster-internal address)
+	targetPort  int // container port (for port-forwarding to pod)
 	clusterAddr string
 	basePath    string
 }
@@ -198,12 +199,14 @@ func (c *Client) findWellKnownService(ctx context.Context) *serviceInfo {
 
 		port := resolvePort(*svc, loc.port)
 		addr := buildClusterAddr(svc.Name, svc.Namespace, svc.Spec.ClusterIP, port)
+		tp := resolveTargetPort(*svc, port)
 
-		log.Printf("[prometheus] Found well-known service: %s/%s:%d", svc.Namespace, svc.Name, port)
+		log.Printf("[prometheus] Found well-known service: %s/%s:%d (targetPort=%d)", svc.Namespace, svc.Name, port, tp)
 		return &serviceInfo{
 			namespace:   svc.Namespace,
 			name:        svc.Name,
 			port:        port,
+			targetPort:  tp,
 			clusterAddr: addr,
 			basePath:    loc.basePath,
 		}
@@ -241,6 +244,7 @@ func (c *Client) discoverDynamic(ctx context.Context) *serviceInfo {
 				namespace:   svc.Namespace,
 				name:        svc.Name,
 				port:        port,
+				targetPort:  resolveTargetPort(svc, port),
 				clusterAddr: buildClusterAddr(svc.Name, svc.Namespace, svc.Spec.ClusterIP, port),
 				basePath:    bp,
 			},
@@ -373,6 +377,22 @@ func resolvePort(svc corev1.Service, defaultPort int) int {
 		return int(svc.Spec.Ports[0].Port)
 	}
 	return 80
+}
+
+// resolveTargetPort returns the container port for port-forwarding.
+// When the service port differs from the container's targetPort (e.g., service:80 → container:9090),
+// port-forwarding needs the container port since it bypasses the Service and connects directly to the pod.
+func resolveTargetPort(svc corev1.Service, servicePort int) int {
+	for _, p := range svc.Spec.Ports {
+		if int(p.Port) == servicePort {
+			if p.TargetPort.IntVal > 0 {
+				return int(p.TargetPort.IntVal)
+			}
+			// targetPort unset or zero defaults to the service port
+			return servicePort
+		}
+	}
+	return servicePort
 }
 
 func buildClusterAddr(name, namespace, clusterIP string, port int) string {

--- a/internal/traffic/caretta.go
+++ b/internal/traffic/caretta.go
@@ -565,8 +565,8 @@ func (c *CarettaSource) Connect(ctx context.Context, contextName string) (*portf
 	}
 
 	// Start a new managed port-forward
-	log.Printf("[caretta] Starting port-forward to %s/%s:%d", metricsInfo.namespace, metricsInfo.name, metricsInfo.port)
-	connInfo, err := portforward.Start(ctx, metricsInfo.namespace, metricsInfo.name, metricsInfo.port, contextName)
+	log.Printf("[caretta] Starting port-forward to %s/%s:%d (targetPort=%d)", metricsInfo.namespace, metricsInfo.name, metricsInfo.port, metricsInfo.targetPort)
+	connInfo, err := portforward.Start(ctx, metricsInfo.namespace, metricsInfo.name, metricsInfo.targetPort, contextName)
 	if err != nil {
 		return &portforward.ConnectionInfo{
 			Connected:   false,
@@ -587,7 +587,8 @@ func (c *CarettaSource) Connect(ctx context.Context, contextName string) (*portf
 type metricsServiceInfo struct {
 	namespace   string
 	name        string
-	port        int
+	port        int // service port (for cluster-internal address)
+	targetPort  int // container port (for port-forwarding to pod)
 	clusterAddr string
 	basePath    string // sub-path for Prometheus API (e.g. "/select/0/prometheus" for vmselect)
 }
@@ -603,6 +604,21 @@ func resolveServicePort(svc corev1.Service, defaultPort int) int {
 	return 80
 }
 
+// resolveTargetPort returns the container port for port-forwarding.
+// When the service port differs from the container's targetPort (e.g., service:80 → container:9090),
+// port-forwarding needs the container port since it bypasses the Service and connects directly to the pod.
+func resolveTargetPort(svc corev1.Service, servicePort int) int {
+	for _, p := range svc.Spec.Ports {
+		if int(p.Port) == servicePort {
+			if p.TargetPort.IntVal > 0 {
+				return int(p.TargetPort.IntVal)
+			}
+			return servicePort
+		}
+	}
+	return servicePort
+}
+
 // findMetricsServiceLocked finds a metrics service from well-known locations (caller must hold lock)
 func (c *CarettaSource) findMetricsServiceLocked(ctx context.Context) *metricsServiceInfo {
 	for _, loc := range metricsServiceLocations {
@@ -613,12 +629,14 @@ func (c *CarettaSource) findMetricsServiceLocked(ctx context.Context) *metricsSe
 
 		port := resolveServicePort(*svc, loc.port)
 		clusterAddr := buildClusterAddr(svc.Name, svc.Namespace, svc.Spec.ClusterIP, port)
+		tp := resolveTargetPort(*svc, port)
 
-		log.Printf("[caretta] Found metrics service: %s/%s:%d", svc.Namespace, svc.Name, port)
+		log.Printf("[caretta] Found metrics service: %s/%s:%d (targetPort=%d)", svc.Namespace, svc.Name, port, tp)
 		return &metricsServiceInfo{
 			namespace:   svc.Namespace,
 			name:        svc.Name,
 			port:        port,
+			targetPort:  tp,
 			clusterAddr: clusterAddr,
 			basePath:    loc.basePath,
 		}
@@ -764,6 +782,7 @@ func (c *CarettaSource) discoverMetricsServiceDynamic(ctx context.Context) *metr
 				namespace:   svc.Namespace,
 				name:        svc.Name,
 				port:        port,
+				targetPort:  resolveTargetPort(svc, port),
 				clusterAddr: buildClusterAddr(svc.Name, svc.Namespace, svc.Spec.ClusterIP, port),
 				basePath:    bp,
 			},


### PR DESCRIPTION
## Summary

Prometheus discovery fails to connect when the service port differs from the container's targetPort (e.g., `prometheus-server` with service port 80 mapping to container port 9090). The port-forward bypasses the Kubernetes Service and connects directly to the pod, so it needs the container port — but we were passing the service port.

This is the same class of bug we fixed in `internal/server/portforward.go` (592a44f) for user-initiated port-forwards, now fixed in the auto-discovery paths for both Prometheus metrics and Caretta traffic.

**Changes:**
- Add `resolveTargetPort()` to extract the container port from the service spec
- Track service port (for cluster-internal address) and target port (for port-forwarding) separately
- Applied to both `internal/prometheus/discovery.go` and `internal/traffic/caretta.go`

Fixes #222