### PR TITLE
fix: desktop Cmd+C/X copy and cut not working on macOS

### DIFF
--- a/cmd/desktop/menu.go
+++ b/cmd/desktop/menu.go
@@ -19,12 +19,19 @@ func createMenu(desktopApp *DesktopApp) *menu.Menu {
 		runtime.Quit(desktopApp.ctx)
 	})
 
-	// Edit menu — use explicit JS callbacks instead of nil.
-	// On macOS, nil callbacks rely on the WKWebView responder chain for clipboard
-	// actions, but this doesn't work for complex editors like Monaco (used for YAML
-	// editing). By using WindowExecJS we ensure clipboard operations reach the web
-	// content regardless of which element is focused.
-	// See: https://github.com/microsoft/monaco-editor/issues/2205
+	// Edit menu — clipboard handling strategy:
+	//
+	// Copy/Cut: Use nil callbacks to delegate to macOS's native responder chain.
+	// WKWebView does NOT dispatch DOM copy/cut events from the native selectors.
+	// Instead, the JS keydown handler in main.tsx intercepts Cmd+C/X before macOS
+	// consumes the event, reads the selection (including Monaco virtual selection),
+	// and writes to the clipboard via navigator.clipboard.writeText().
+	//
+	// Paste: Must use explicit WindowExecJS because WKWebView's native paste:
+	// doesn't work for complex editors like Monaco. We read from the clipboard
+	// API and dispatch a synthetic ClipboardEvent.
+	//
+	// Undo/Redo/SelectAll: Use WindowExecJS (these work fine via execCommand).
 	editMenu := appMenu.AddSubmenu("Edit")
 	editMenu.AddText("Undo", keys.CmdOrCtrl("z"), func(_ *menu.CallbackData) {
 		runtime.WindowExecJS(desktopApp.ctx, "document.execCommand('undo')")
@@ -33,16 +40,9 @@ func createMenu(desktopApp *DesktopApp) *menu.Menu {
 		runtime.WindowExecJS(desktopApp.ctx, "document.execCommand('redo')")
 	})
 	editMenu.AddSeparator()
-	editMenu.AddText("Cut", keys.CmdOrCtrl("x"), func(_ *menu.CallbackData) {
-		runtime.WindowExecJS(desktopApp.ctx, "document.execCommand('cut')")
-	})
-	editMenu.AddText("Copy", keys.CmdOrCtrl("c"), func(_ *menu.CallbackData) {
-		runtime.WindowExecJS(desktopApp.ctx, "document.execCommand('copy')")
-	})
+	editMenu.AddText("Cut", keys.CmdOrCtrl("x"), nil)
+	editMenu.AddText("Copy", keys.CmdOrCtrl("c"), nil)
 	editMenu.AddText("Paste", keys.CmdOrCtrl("v"), func(_ *menu.CallbackData) {
-		// Paste requires special handling: read clipboard text, then dispatch a
-		// synthetic ClipboardEvent so Monaco's paste handler processes it correctly.
-		// Falls back to document.execCommand('insertText') for plain inputs.
 		runtime.WindowExecJS(desktopApp.ctx, `
 			navigator.clipboard.readText().then(function(text) {
 				if (!text) return;
@@ -52,7 +52,7 @@ func createMenu(desktopApp *DesktopApp) *menu.Menu {
 					dt.setData('text/plain', text);
 					var ev = new ClipboardEvent('paste', {clipboardData: dt, bubbles: true, cancelable: true});
 					if (!el.dispatchEvent(ev)) return;
-				} catch(e) {}
+				} catch(e) { /* ClipboardEvent dispatch failed, fall back to insertText */ }
 				document.execCommand('insertText', false, text);
 			}).catch(function(err) { console.warn('[Radar] Paste failed:', err); });
 		`)

--- a/web/src/components/ui/YamlEditor.tsx
+++ b/web/src/components/ui/YamlEditor.tsx
@@ -135,9 +135,15 @@ export function YamlEditor({
     applyDecorations()
   }, [applyDecorations])
 
+  // Expose editor globally for desktop clipboard interception (see main.tsx).
+  useEffect(() => {
+    return () => { delete (window as any).__radarMonacoEditor }
+  }, [])
+
   const handleEditorMount: OnMount = useCallback((editor, monaco) => {
     editorRef.current = editor
     monacoRef.current = monaco
+    ;(window as any).__radarMonacoEditor = editor
 
     // Add CSS for editable line highlighting
     const styleId = 'yaml-editor-styles'

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -21,13 +21,104 @@ window.addEventListener('click', (e: MouseEvent) => {
   openExternal(href)
 })
 
-// Patch document.execCommand('paste') for Wails WebView compatibility.
-// WKWebView blocks execCommand('paste') from non-native UI elements (like Monaco's
-// right-click context menu). This intercept reads from the async clipboard API and
-// inserts text into the active element. The async nature means it won't return
-// synchronously, but the text will arrive in the editor shortly after the click.
+// === Wails Desktop Clipboard ===
+//
+// Background: The desktop app uses a RedirectHandler that navigates the Wails
+// webview from wails:// to http://localhost:<port>. After the redirect,
+// window.runtime (Wails JS API) is no longer available. Clipboard operations
+// must use navigator.clipboard and DOM events instead.
+//
+// What works and why:
+//   Cmd+C / Cmd+X: Handled in keydown listener below. The Edit menu registers
+//     these accelerators with nil callbacks (native responder chain), but WKWebView
+//     does NOT dispatch a DOM copy/cut event from the native copy: selector.
+//     The keydown event DOES reach JS, so we intercept it here.
+//   Cmd+V: Handled by menu.go's explicit WindowExecJS callback which reads
+//     navigator.clipboard.readText() and dispatches a synthetic paste event.
+//   Right-click Copy/Cut (Monaco): Monaco calls document.execCommand('copy'/'cut'),
+//     intercepted by the monkey-patch below.
+//   Right-click Paste (Monaco): Not supported — Monaco calls navigator.clipboard
+//     .readText() directly (not execCommand), and WKWebView blocks readText() from
+//     page JS context. Use Cmd+V instead.
+
+// Read selected text from Monaco if it has focus. Monaco uses virtual selection
+// (not DOM selection), so window.getSelection() doesn't work — we access the
+// editor instance exposed by YamlEditor.tsx.
+function getMonacoSelection(): { text: string; editor: any } | null {
+  const editor = (window as any).__radarMonacoEditor
+  if (!editor?.hasTextFocus?.()) return null
+  const sel = editor.getSelection()
+  const model = editor.getModel()
+  if (!sel || !model) return null
+  const text = model.getValueInRange(sel)
+  if (!text) return null
+  return { text, editor }
+}
+
+function getSelectedText(): { text: string; monaco: { text: string; editor: any } | null } {
+  const monaco = getMonacoSelection()
+  if (monaco) return { text: monaco.text, monaco }
+  const sel = window.getSelection()
+  const text = sel ? sel.toString() : ''
+  return { text, monaco: null }
+}
+
+function deleteMonacoSelection(editor: any): void {
+  editor.pushUndoStop()
+  editor.executeEdits('cut', [{ range: editor.getSelection(), text: '' }])
+  editor.pushUndoStop()
+}
+
+function handleCopyOrCut(isCut: boolean): void {
+  const { text, monaco } = getSelectedText()
+  if (!text) return
+  navigator.clipboard.writeText(text).catch((err) => { console.warn('[Radar] Clipboard write failed:', err) })
+  if (isCut) {
+    if (monaco) {
+      deleteMonacoSelection(monaco.editor)
+    } else {
+      _origExecCommand('delete')
+    }
+  }
+}
+
+// Cmd+C/X: the menu's nil callback does NOT dispatch a DOM copy event.
+document.addEventListener('keydown', (e) => {
+  if (!(e.metaKey || e.ctrlKey)) return
+  if (e.key !== 'c' && e.key !== 'x') return
+  handleCopyOrCut(e.key === 'x')
+}, true)
+
+// Intercept copy/cut DOM events to handle Monaco's virtual selection.
+// These fire from right-click -> Copy in some contexts. When a real
+// ClipboardEvent is available, we write directly to e.clipboardData
+// (synchronous, more reliable than the async clipboard API).
+document.addEventListener('copy', (e: ClipboardEvent) => {
+  const result = getMonacoSelection()
+  if (result && e.clipboardData) {
+    e.preventDefault()
+    e.clipboardData.setData('text/plain', result.text)
+  }
+}, true)
+
+document.addEventListener('cut', (e: ClipboardEvent) => {
+  const result = getMonacoSelection()
+  if (result && e.clipboardData) {
+    e.preventDefault()
+    e.clipboardData.setData('text/plain', result.text)
+    deleteMonacoSelection(result.editor)
+  }
+}, true)
+
+// Monkey-patch document.execCommand for Wails WebView compatibility.
+// Handles copy/cut from Monaco's right-click context menu, and paste from
+// any context that calls execCommand('paste').
 const _origExecCommand = document.execCommand.bind(document)
 document.execCommand = function (command: string, showUI?: boolean, value?: string) {
+  if (command === 'copy' || command === 'cut') {
+    handleCopyOrCut(command === 'cut')
+    return true
+  }
   if (command === 'paste') {
     navigator.clipboard.readText().then((text) => {
       if (!text) return
@@ -37,7 +128,7 @@ document.execCommand = function (command: string, showUI?: boolean, value?: stri
         dt.setData('text/plain', text)
         const ev = new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true })
         if (!el.dispatchEvent(ev)) return
-      } catch (_e) { /* fallback below */ }
+      } catch (_e) { /* ClipboardEvent dispatch failed, fall back to insertText */ }
       _origExecCommand('insertText', false, text)
     }).catch((err) => { console.warn('[Radar] Paste failed:', err) })
     return true


### PR DESCRIPTION
## Summary

- PR #220 broke Copy/Cut in the macOS desktop app by replacing `nil` Edit menu callbacks with `WindowExecJS` calls — `document.execCommand('copy')` silently fails in WKWebView because it's not a trusted user gesture
- Reverts Copy/Cut to `nil` callbacks (native responder chain) and handles clipboard via JS keydown listener + execCommand monkey-patch
- Exposes Monaco editor globally so clipboard handlers can read its virtual selection (not captured by `window.getSelection()`)

**Works:** Cmd+C, Cmd+X, Cmd+V, right-click Copy/Cut in Monaco
**Known limitation:** Right-click Paste in Monaco — WKWebView blocks `navigator.clipboard.readText()` from page JS context. Use Cmd+V instead.

Closes #227