### PR TITLE
refactor: deduplicate Knative renderers and fix review findings

### DIFF
--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -21,7 +21,7 @@ Common collisions:
 | Gateway | `gateway.networking.k8s.io` | Istio `networking.istio.io` |
 | Certificate | cert-manager `cert-manager.io` | Knative `networking.internal.knative.dev` |
 | Configuration | — | Knative `serving.knative.dev` |
-| Route | `gateway.networking.k8s.io` (HTTPRoute) | Knative `serving.knative.dev`, OpenShift |
+| Route | — | Knative `serving.knative.dev`, OpenShift |
 | Broker | — | Knative `eventing.knative.dev` |
 | Channel | — | Knative `messaging.knative.dev` |
 | Backup | Velero `velero.io` | CloudNativePG `cnpg.io` |
@@ -72,7 +72,7 @@ Edge type semantics (choose carefully):
 | Edge Type | Meaning | Example |
 |-----------|---------|---------|
 | `EdgeManages` | Owner relationship | Deployment → ReplicaSet |
-| `EdgeExposes` | Network exposure | Service → Pod, Route → Revision |
+| `EdgeExposes` | Network exposure (UI: "Services" group) | Service → Pod, Route → Revision |
 | `EdgeConfigures` | Configuration | ConfigMap → Deployment, DestinationRule → Service |
 | `EdgeUses` | Scaling relationship | HPA → Deployment |
 | `EdgeProtects` | Policy protection | PDB → Deployment |
@@ -237,6 +237,6 @@ After implementation, verify:
 
 5. **Two-phase topology pattern:** Store resources in slices during node creation (phase 1), reuse during edge creation (phase 2). Don't call `dynamicCache.List()` twice for the same kind.
 
-6. **Edge type choice matters:** Edge types drive the "Related Resources" grouping in the detail drawer. `EdgeExposes` creates a "Network" group, `EdgeManages` creates "Children", `EdgeConfigures` creates "Configuration", etc. Choose semantically, not by code convenience.
+6. **Edge type choice matters:** Edge types drive the "Related Resources" grouping in the detail drawer. `EdgeExposes` creates a "Services" group, `EdgeManages` creates "Children", `EdgeConfigures` creates "Configuration", etc. Choose semantically, not by code convenience.
 
 7. **CSS topology icon classes** must use the lowercase kind name: `.topology-icon-knativeservice`, not `.topology-icon-KnativeService`.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -623,6 +623,7 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 						s.writeError(w, http.StatusBadRequest, listErr.Error())
 						return
 					}
+					log.Printf("[resources] Failed to list %s in namespace %s (group=%s): %v", kind, ns, group, listErr)
 					s.writeError(w, http.StatusInternalServerError, listErr.Error())
 					return
 				}
@@ -827,6 +828,7 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 						s.writeError(w, http.StatusBadRequest, listErr.Error())
 						return
 					}
+					log.Printf("[resources] Failed to list %s in namespace %s: %v", kind, ns, listErr)
 					s.writeError(w, http.StatusInternalServerError, listErr.Error())
 					return
 				}

--- a/web/src/components/resources/ResourceDetailDrawer.tsx
+++ b/web/src/components/resources/ResourceDetailDrawer.tsx
@@ -95,21 +95,8 @@ import {
 } from './resource-utils-istio'
 import { getCNPGClusterStatus, getCNPGBackupStatus, getCNPGScheduledBackupStatus, getCNPGPoolerStatus } from './resource-utils-cnpg'
 import {
-  getKnativeServiceStatus,
-  getRevisionStatus as getKnativeRevisionStatus,
-  getRouteStatus as getKnativeRouteStatus,
-  getConfigurationStatus as getKnativeConfigurationStatus,
-  getKnativeIngressStatus,
-  getKnativeCertificateStatus,
-  getServerlessServiceStatus,
-  getBrokerStatus,
-  getTriggerStatus,
-  getSourceStatus as getKnativeSourceStatus,
-  getChannelStatus,
-  getSubscriptionStatus,
-  getSequenceStatus,
-  getParallelStatus,
-  getDomainMappingStatus,
+  getKnativeConditionStatus,
+  getRevisionStatus,
 } from './resource-utils-knative'
 import { getExternalSecretStatus, getClusterExternalSecretStatus, getSecretStoreStatus, getClusterSecretStoreStatus } from './resource-utils-eso'
 import {
@@ -1896,7 +1883,7 @@ function getResourceStatus(kind: string, data: any): { text: string; color: stri
   if (k === 'services') {
     // KNative Service uses its own status function
     if (data.apiVersion?.includes('serving.knative.dev')) {
-      const status = getKnativeServiceStatus(data)
+      const status = getKnativeConditionStatus(data)
       return { text: status.text, color: status.color }
     }
     const status = getServiceStatus(data)
@@ -1941,7 +1928,7 @@ function getResourceStatus(kind: string, data: any): { text: string; color: stri
   if (k === 'certificates') {
     // KNative Certificate uses its own status function
     if (data.apiVersion?.includes('networking.internal.knative.dev')) {
-      const status = getKnativeCertificateStatus(data)
+      const status = getKnativeConditionStatus(data)
       return { text: status.text, color: status.color }
     }
     const status = getCertificateStatus(data)
@@ -2207,90 +2194,23 @@ function getResourceStatus(kind: string, data: any): { text: string; color: stri
     return { text: status.text, color: status.color }
   }
 
-  // Knative Serving
-  if (k === 'knativeservices' || (k === 'services' && data.apiVersion?.includes('serving.knative.dev'))) {
-    const status = getKnativeServiceStatus(data)
-    return { text: status.text, color: status.color }
-  }
-
-  if (k === 'knativeconfigurations') {
-    const status = getKnativeConfigurationStatus(data)
-    return { text: status.text, color: status.color }
-  }
-
+  // Knative Revisions have custom status logic (scaled-to-zero, activating)
   if (k === 'knativerevisions') {
-    const status = getKnativeRevisionStatus(data)
+    const status = getRevisionStatus(data)
     return { text: status.text, color: status.color }
   }
 
-  if (k === 'knativeroutes') {
-    const status = getKnativeRouteStatus(data)
-    return { text: status.text, color: status.color }
-  }
-
-  // Knative Eventing
-  if (k === 'brokers') {
-    const status = getBrokerStatus(data)
-    return { text: status.text, color: status.color }
-  }
-
-  if (k === 'triggers') {
-    const status = getTriggerStatus(data)
-    return { text: status.text, color: status.color }
-  }
-
-  // Knative Sources
-  if (k === 'pingsources' || k === 'apiserversources' || k === 'containersources' || k === 'sinkbindings') {
-    const status = getKnativeSourceStatus(data)
-    return { text: status.text, color: status.color }
-  }
-
-  // Knative Eventing/Messaging
-  if (k === 'channels' || k === 'inmemorychannels') {
-    const status = getChannelStatus(data)
-    return { text: status.text, color: status.color }
-  }
-
-  if (k === 'subscriptions') {
-    const status = getSubscriptionStatus(data)
-    return { text: status.text, color: status.color }
-  }
-
-  // Knative Flows
-  if (k === 'sequences') {
-    const status = getSequenceStatus(data)
-    return { text: status.text, color: status.color }
-  }
-
-  if (k === 'parallels') {
-    const status = getParallelStatus(data)
-    return { text: status.text, color: status.color }
-  }
-
-  // Knative Serving
-  if (k === 'domainmappings') {
-    const status = getDomainMappingStatus(data)
-    return { text: status.text, color: status.color }
-  }
-
-  // Knative Networking
-  if (k === 'ingresses' && data.apiVersion?.includes('networking.internal.knative.dev')) {
-    const status = getKnativeIngressStatus(data)
-    return { text: status.text, color: status.color }
-  }
-
-  if (k === 'knativeingresses') {
-    const status = getKnativeIngressStatus(data)
-    return { text: status.text, color: status.color }
-  }
-
-  if ((k === 'certificates' && data.apiVersion?.includes('networking.internal.knative.dev')) || k === 'knativecertificates') {
-    const status = getKnativeCertificateStatus(data)
-    return { text: status.text, color: status.color }
-  }
-
-  if (k === 'serverlessservices') {
-    const status = getServerlessServiceStatus(data)
+  // All other KNative resources use the standard Ready condition pattern
+  const knativeConditionKinds = [
+    'knativeservices', 'knativeconfigurations', 'knativeroutes',
+    'brokers', 'triggers',
+    'pingsources', 'apiserversources', 'containersources', 'sinkbindings',
+    'channels', 'inmemorychannels', 'subscriptions',
+    'sequences', 'parallels',
+    'domainmappings', 'knativeingresses', 'knativecertificates', 'serverlessservices',
+  ]
+  if (knativeConditionKinds.includes(k) || (k === 'ingresses' && data.apiVersion?.includes('networking.internal.knative.dev'))) {
+    const status = getKnativeConditionStatus(data)
     return { text: status.text, color: status.color }
   }
 

--- a/web/src/components/resources/drawer-components.tsx
+++ b/web/src/components/resources/drawer-components.tsx
@@ -219,6 +219,14 @@ export function AlertBanner({ variant, icon, title, message, items, children }: 
   )
 }
 
+/** KNative "Not Ready" alert banner — shared across all KNative renderers */
+export function KnativeNotReadyBanner({ status, data, resourceType }: { status: { level: string }; data: any; resourceType: string }) {
+  if (status.level !== 'unhealthy') return null
+  const message = (data.status?.conditions || []).find((c: any) => c.type === 'Ready')?.message
+    || `This ${resourceType} is not in a ready state.`
+  return <AlertBanner variant="error" title={`${resourceType} Not Ready`} message={message} />
+}
+
 /** Problem type for ProblemAlerts component */
 export interface Problem {
   color: 'red' | 'yellow'

--- a/web/src/components/resources/renderers/KnativeConfigurationRenderer.tsx
+++ b/web/src/components/resources/renderers/KnativeConfigurationRenderer.tsx
@@ -1,7 +1,7 @@
 import { Settings, Container } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../drawer-components'
-import { getConfigurationStatus } from '../resource-utils-knative'
+import { Section, PropertyList, Property, ConditionsSection, KnativeNotReadyBanner, ResourceLink } from '../drawer-components'
+import { getKnativeConditionStatus } from '../resource-utils-knative'
 
 interface KnativeConfigurationRendererProps {
   data: any
@@ -9,7 +9,7 @@ interface KnativeConfigurationRendererProps {
 }
 
 export function KnativeConfigurationRenderer({ data, onNavigate }: KnativeConfigurationRendererProps) {
-  const status = getConfigurationStatus(data)
+  const status = getKnativeConditionStatus(data)
   const ns = data.metadata?.namespace || ''
 
   const latestCreated = data.status?.latestCreatedRevisionName
@@ -18,13 +18,7 @@ export function KnativeConfigurationRenderer({ data, onNavigate }: KnativeConfig
 
   return (
     <>
-      {status.level === 'unhealthy' && (
-        <AlertBanner
-          variant="error"
-          title="Configuration Not Ready"
-          message={(data.status?.conditions || []).find((c: any) => c.type === 'Ready')?.message || 'This configuration is not in a ready state.'}
-        />
-      )}
+      <KnativeNotReadyBanner status={status} data={data} resourceType="Configuration" />
 
       <Section title="Overview" icon={Settings} defaultExpanded>
         <PropertyList>

--- a/web/src/components/resources/renderers/KnativeEventingRenderer.tsx
+++ b/web/src/components/resources/renderers/KnativeEventingRenderer.tsx
@@ -1,12 +1,7 @@
 import { Radio, Filter, FileType, Inbox, ArrowRightLeft } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../drawer-components'
-import {
-  getBrokerStatus,
-  getTriggerStatus,
-  getChannelStatus,
-  getSubscriptionStatus,
-} from '../resource-utils-knative'
+import { Section, PropertyList, Property, ConditionsSection, KnativeNotReadyBanner, ResourceLink } from '../drawer-components'
+import { getKnativeConditionStatus } from '../resource-utils-knative'
 
 interface RendererProps {
   data: any
@@ -18,7 +13,7 @@ interface RendererProps {
 // ============================================================================
 
 export function BrokerRenderer({ data, onNavigate }: RendererProps) {
-  const status = getBrokerStatus(data)
+  const status = getKnativeConditionStatus(data)
   const ns = data.metadata?.namespace || ''
   const address = data.status?.address?.url
   const delivery = data.spec?.delivery
@@ -27,13 +22,7 @@ export function BrokerRenderer({ data, onNavigate }: RendererProps) {
 
   return (
     <>
-      {status.level === 'unhealthy' && (
-        <AlertBanner
-          variant="error"
-          title="Broker Not Ready"
-          message={(data.status?.conditions || []).find((c: any) => c.type === 'Ready')?.message || 'This broker is not in a ready state.'}
-        />
-      )}
+      <KnativeNotReadyBanner status={status} data={data} resourceType="Broker" />
 
       <Section title="Overview" icon={Radio} defaultExpanded>
         <PropertyList>
@@ -85,7 +74,7 @@ export function BrokerRenderer({ data, onNavigate }: RendererProps) {
 // ============================================================================
 
 export function TriggerRenderer({ data, onNavigate }: RendererProps) {
-  const status = getTriggerStatus(data)
+  const status = getKnativeConditionStatus(data)
   const ns = data.metadata?.namespace || ''
   const spec = data.spec || {}
   const brokerName = spec.broker || 'default'
@@ -96,13 +85,7 @@ export function TriggerRenderer({ data, onNavigate }: RendererProps) {
 
   return (
     <>
-      {status.level === 'unhealthy' && (
-        <AlertBanner
-          variant="error"
-          title="Trigger Not Ready"
-          message={(data.status?.conditions || []).find((c: any) => c.type === 'Ready')?.message || 'This trigger is not in a ready state.'}
-        />
-      )}
+      <KnativeNotReadyBanner status={status} data={data} resourceType="Trigger" />
 
       <Section title="Overview" icon={Filter} defaultExpanded>
         <PropertyList>
@@ -181,19 +164,13 @@ export function EventTypeRenderer({ data }: RendererProps) {
 // ============================================================================
 
 export function ChannelRenderer({ data }: RendererProps) {
-  const status = getChannelStatus(data)
+  const status = getKnativeConditionStatus(data)
   const address = data.status?.address?.url
   const subscribers = data.status?.subscribers || []
 
   return (
     <>
-      {status.level === 'unhealthy' && (
-        <AlertBanner
-          variant="error"
-          title="Channel Not Ready"
-          message={(data.status?.conditions || []).find((c: any) => c.type === 'Ready')?.message || 'This channel is not in a ready state.'}
-        />
-      )}
+      <KnativeNotReadyBanner status={status} data={data} resourceType="Channel" />
 
       <Section title="Overview" icon={Inbox} defaultExpanded>
         <PropertyList>
@@ -245,7 +222,7 @@ export function InMemoryChannelRenderer({ data, onNavigate }: RendererProps) {
 // ============================================================================
 
 export function SubscriptionRenderer({ data, onNavigate }: RendererProps) {
-  const status = getSubscriptionStatus(data)
+  const status = getKnativeConditionStatus(data)
   const ns = data.metadata?.namespace || ''
   const spec = data.spec || {}
 
@@ -258,13 +235,7 @@ export function SubscriptionRenderer({ data, onNavigate }: RendererProps) {
 
   return (
     <>
-      {status.level === 'unhealthy' && (
-        <AlertBanner
-          variant="error"
-          title="Subscription Not Ready"
-          message={(data.status?.conditions || []).find((c: any) => c.type === 'Ready')?.message || 'This subscription is not in a ready state.'}
-        />
-      )}
+      <KnativeNotReadyBanner status={status} data={data} resourceType="Subscription" />
 
       <Section title="Overview" icon={ArrowRightLeft} defaultExpanded>
         <PropertyList>

--- a/web/src/components/resources/renderers/KnativeFlowRenderer.tsx
+++ b/web/src/components/resources/renderers/KnativeFlowRenderer.tsx
@@ -1,7 +1,7 @@
 import { ListOrdered, GitFork } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../drawer-components'
-import { getSequenceStatus, getParallelStatus } from '../resource-utils-knative'
+import { Section, PropertyList, Property, ConditionsSection, KnativeNotReadyBanner, ResourceLink } from '../drawer-components'
+import { getKnativeConditionStatus } from '../resource-utils-knative'
 
 interface RendererProps {
   data: any
@@ -34,7 +34,7 @@ function RefDisplay({ ref: destRef, ns, onNavigate }: { ref: any; ns: string; on
 // ============================================================================
 
 export function SequenceRenderer({ data, onNavigate }: RendererProps) {
-  const status = getSequenceStatus(data)
+  const status = getKnativeConditionStatus(data)
   const ns = data.metadata?.namespace || ''
   const spec = data.spec || {}
   const steps = spec.steps || []
@@ -42,13 +42,7 @@ export function SequenceRenderer({ data, onNavigate }: RendererProps) {
 
   return (
     <>
-      {status.level === 'unhealthy' && (
-        <AlertBanner
-          variant="error"
-          title="Sequence Not Ready"
-          message={(data.status?.conditions || []).find((c: any) => c.type === 'Ready')?.message || 'This Sequence is not in a ready state.'}
-        />
-      )}
+      <KnativeNotReadyBanner status={status} data={data} resourceType="Sequence" />
 
       <Section title="Overview" icon={ListOrdered} defaultExpanded>
         <PropertyList>
@@ -89,7 +83,7 @@ export function SequenceRenderer({ data, onNavigate }: RendererProps) {
 // ============================================================================
 
 export function ParallelRenderer({ data, onNavigate }: RendererProps) {
-  const status = getParallelStatus(data)
+  const status = getKnativeConditionStatus(data)
   const ns = data.metadata?.namespace || ''
   const spec = data.spec || {}
   const branches = spec.branches || []
@@ -97,13 +91,7 @@ export function ParallelRenderer({ data, onNavigate }: RendererProps) {
 
   return (
     <>
-      {status.level === 'unhealthy' && (
-        <AlertBanner
-          variant="error"
-          title="Parallel Not Ready"
-          message={(data.status?.conditions || []).find((c: any) => c.type === 'Ready')?.message || 'This Parallel is not in a ready state.'}
-        />
-      )}
+      <KnativeNotReadyBanner status={status} data={data} resourceType="Parallel" />
 
       <Section title="Overview" icon={GitFork} defaultExpanded>
         <PropertyList>

--- a/web/src/components/resources/renderers/KnativeNetworkingRenderer.tsx
+++ b/web/src/components/resources/renderers/KnativeNetworkingRenderer.tsx
@@ -1,12 +1,7 @@
 import { Network, ShieldCheck, Server, Globe } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../drawer-components'
-import {
-  getKnativeIngressStatus,
-  getKnativeCertificateStatus,
-  getServerlessServiceStatus,
-  getDomainMappingStatus,
-} from '../resource-utils-knative'
+import { Section, PropertyList, Property, ConditionsSection, KnativeNotReadyBanner, ResourceLink } from '../drawer-components'
+import { getKnativeConditionStatus } from '../resource-utils-knative'
 
 interface RendererProps {
   data: any
@@ -18,7 +13,7 @@ interface RendererProps {
 // ============================================================================
 
 export function KnativeIngressRenderer({ data }: RendererProps) {
-  const status = getKnativeIngressStatus(data)
+  const status = getKnativeConditionStatus(data)
   const spec = data.spec || {}
   const rules = spec.rules || []
   const ingressClass = data.metadata?.annotations?.['networking.knative.dev/ingress.class']
@@ -26,13 +21,7 @@ export function KnativeIngressRenderer({ data }: RendererProps) {
 
   return (
     <>
-      {status.level === 'unhealthy' && (
-        <AlertBanner
-          variant="error"
-          title="Ingress Not Ready"
-          message={(data.status?.conditions || []).find((c: any) => c.type === 'Ready')?.message || 'This KNative Ingress is not in a ready state.'}
-        />
-      )}
+      <KnativeNotReadyBanner status={status} data={data} resourceType="Ingress" />
 
       <Section title="Overview" icon={Network} defaultExpanded>
         <PropertyList>
@@ -102,20 +91,14 @@ export function KnativeIngressRenderer({ data }: RendererProps) {
 // ============================================================================
 
 export function KnativeCertificateRenderer({ data }: RendererProps) {
-  const status = getKnativeCertificateStatus(data)
+  const status = getKnativeConditionStatus(data)
   const spec = data.spec || {}
   const dnsNames = spec.dnsNames || []
   const secretName = spec.secretName || data.status?.http01Challenges?.[0]?.secretName
 
   return (
     <>
-      {status.level === 'unhealthy' && (
-        <AlertBanner
-          variant="error"
-          title="Certificate Not Ready"
-          message={(data.status?.conditions || []).find((c: any) => c.type === 'Ready')?.message || 'This certificate is not in a ready state.'}
-        />
-      )}
+      <KnativeNotReadyBanner status={status} data={data} resourceType="Certificate" />
 
       <Section title="Overview" icon={ShieldCheck} defaultExpanded>
         <PropertyList>
@@ -151,7 +134,7 @@ export function KnativeCertificateRenderer({ data }: RendererProps) {
 // ============================================================================
 
 export function ServerlessServiceRenderer({ data, onNavigate }: RendererProps) {
-  const status = getServerlessServiceStatus(data)
+  const status = getKnativeConditionStatus(data)
   const ns = data.metadata?.namespace || ''
   const spec = data.spec || {}
   const mode = spec.mode
@@ -163,13 +146,7 @@ export function ServerlessServiceRenderer({ data, onNavigate }: RendererProps) {
 
   return (
     <>
-      {status.level === 'unhealthy' && (
-        <AlertBanner
-          variant="error"
-          title="ServerlessService Not Ready"
-          message={(data.status?.conditions || []).find((c: any) => c.type === 'Ready')?.message || 'This ServerlessService is not in a ready state.'}
-        />
-      )}
+      <KnativeNotReadyBanner status={status} data={data} resourceType="ServerlessService" />
 
       <Section title="Overview" icon={Server} defaultExpanded>
         <PropertyList>
@@ -213,7 +190,7 @@ export function ServerlessServiceRenderer({ data, onNavigate }: RendererProps) {
 // ============================================================================
 
 export function DomainMappingRenderer({ data, onNavigate }: RendererProps) {
-  const status = getDomainMappingStatus(data)
+  const status = getKnativeConditionStatus(data)
   const ns = data.metadata?.namespace || ''
   const url = data.status?.url
   const ref = data.spec?.ref
@@ -221,13 +198,7 @@ export function DomainMappingRenderer({ data, onNavigate }: RendererProps) {
 
   return (
     <>
-      {status.level === 'unhealthy' && (
-        <AlertBanner
-          variant="error"
-          title="DomainMapping Not Ready"
-          message={(data.status?.conditions || []).find((c: any) => c.type === 'Ready')?.message || 'This DomainMapping is not in a ready state.'}
-        />
-      )}
+      <KnativeNotReadyBanner status={status} data={data} resourceType="DomainMapping" />
 
       <Section title="Overview" icon={Globe} defaultExpanded>
         <PropertyList>

--- a/web/src/components/resources/renderers/KnativeRevisionRenderer.tsx
+++ b/web/src/components/resources/renderers/KnativeRevisionRenderer.tsx
@@ -1,6 +1,6 @@
 import { Container, Settings } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, KnativeNotReadyBanner } from '../drawer-components'
 import { getRevisionStatus } from '../resource-utils-knative'
 
 interface KnativeRevisionRendererProps {
@@ -27,13 +27,7 @@ export function KnativeRevisionRenderer({ data }: KnativeRevisionRendererProps) 
 
   return (
     <>
-      {status.level === 'unhealthy' && (
-        <AlertBanner
-          variant="error"
-          title="Revision Not Ready"
-          message={(data.status?.conditions || []).find((c: any) => c.type === 'Ready')?.message || 'This revision is not in a ready state.'}
-        />
-      )}
+      <KnativeNotReadyBanner status={status} data={data} resourceType="Revision" />
 
       <Section title="Overview" icon={Settings} defaultExpanded>
         <PropertyList>

--- a/web/src/components/resources/renderers/KnativeRouteRenderer.tsx
+++ b/web/src/components/resources/renderers/KnativeRouteRenderer.tsx
@@ -1,7 +1,7 @@
 import { Route } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../drawer-components'
-import { getRouteStatus } from '../resource-utils-knative'
+import { Section, PropertyList, Property, ConditionsSection, KnativeNotReadyBanner, ResourceLink } from '../drawer-components'
+import { getKnativeConditionStatus } from '../resource-utils-knative'
 
 interface KnativeRouteRendererProps {
   data: any
@@ -9,20 +9,14 @@ interface KnativeRouteRendererProps {
 }
 
 export function KnativeRouteRenderer({ data, onNavigate }: KnativeRouteRendererProps) {
-  const status = getRouteStatus(data)
+  const status = getKnativeConditionStatus(data)
   const traffic = data.status?.traffic || data.spec?.traffic || []
   const ns = data.metadata?.namespace || ''
   const url = data.status?.url || data.status?.address?.url
 
   return (
     <>
-      {status.level === 'unhealthy' && (
-        <AlertBanner
-          variant="error"
-          title="Route Not Ready"
-          message={(data.status?.conditions || []).find((c: any) => c.type === 'Ready')?.message || 'This route is not in a ready state.'}
-        />
-      )}
+      <KnativeNotReadyBanner status={status} data={data} resourceType="Route" />
 
       <Section title="Overview" icon={Route} defaultExpanded>
         <PropertyList>

--- a/web/src/components/resources/renderers/KnativeServiceRenderer.tsx
+++ b/web/src/components/resources/renderers/KnativeServiceRenderer.tsx
@@ -1,7 +1,7 @@
 import { Globe, Layers, Container } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../drawer-components'
-import { getKnativeServiceStatus } from '../resource-utils-knative'
+import { Section, PropertyList, Property, ConditionsSection, KnativeNotReadyBanner, ResourceLink } from '../drawer-components'
+import { getKnativeConditionStatus } from '../resource-utils-knative'
 
 interface KnativeServiceRendererProps {
   data: any
@@ -9,7 +9,7 @@ interface KnativeServiceRendererProps {
 }
 
 export function KnativeServiceRenderer({ data, onNavigate }: KnativeServiceRendererProps) {
-  const status = getKnativeServiceStatus(data)
+  const status = getKnativeConditionStatus(data)
   const ns = data.metadata?.namespace || ''
   const url = data.status?.url
   const traffic = data.status?.traffic || []
@@ -27,18 +27,9 @@ export function KnativeServiceRenderer({ data, onNavigate }: KnativeServiceRende
   const concurrency = templateSpec.containerConcurrency
   const timeoutSeconds = templateSpec.timeoutSeconds
 
-  const readyCond = (data.status?.conditions || []).find((c: any) => c.type === 'Ready')
-  const notReadyMessage = readyCond?.status === 'False' ? readyCond.message : undefined
-
   return (
     <>
-      {status.level === 'unhealthy' && (
-        <AlertBanner
-          variant="error"
-          title="Service Not Ready"
-          message={notReadyMessage || 'The KNative Service is not in a ready state.'}
-        />
-      )}
+      <KnativeNotReadyBanner status={status} data={data} resourceType="Service" />
 
       <Section title="Overview" icon={Globe} defaultExpanded>
         <PropertyList>

--- a/web/src/components/resources/renderers/KnativeSourceRenderer.tsx
+++ b/web/src/components/resources/renderers/KnativeSourceRenderer.tsx
@@ -1,7 +1,7 @@
 import { Clock, Server, Container, Link2 } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../drawer-components'
-import { getSourceStatus } from '../resource-utils-knative'
+import { Section, PropertyList, Property, ConditionsSection, KnativeNotReadyBanner, ResourceLink } from '../drawer-components'
+import { getKnativeConditionStatus } from '../resource-utils-knative'
 
 interface RendererProps {
   data: any
@@ -38,19 +38,13 @@ function SinkProperty({ sink, ns, onNavigate }: { sink: any; ns: string; onNavig
 // ============================================================================
 
 export function PingSourceRenderer({ data, onNavigate }: RendererProps) {
-  const status = getSourceStatus(data)
+  const status = getKnativeConditionStatus(data)
   const ns = data.metadata?.namespace || ''
   const spec = data.spec || {}
 
   return (
     <>
-      {status.level === 'unhealthy' && (
-        <AlertBanner
-          variant="error"
-          title="PingSource Not Ready"
-          message={(data.status?.conditions || []).find((c: any) => c.type === 'Ready')?.message || 'This PingSource is not in a ready state.'}
-        />
-      )}
+      <KnativeNotReadyBanner status={status} data={data} resourceType="PingSource" />
 
       <Section title="Overview" icon={Clock} defaultExpanded>
         <PropertyList>
@@ -79,20 +73,14 @@ export function PingSourceRenderer({ data, onNavigate }: RendererProps) {
 // ============================================================================
 
 export function ApiServerSourceRenderer({ data, onNavigate }: RendererProps) {
-  const status = getSourceStatus(data)
+  const status = getKnativeConditionStatus(data)
   const ns = data.metadata?.namespace || ''
   const spec = data.spec || {}
   const resources = spec.resources || []
 
   return (
     <>
-      {status.level === 'unhealthy' && (
-        <AlertBanner
-          variant="error"
-          title="ApiServerSource Not Ready"
-          message={(data.status?.conditions || []).find((c: any) => c.type === 'Ready')?.message || 'This ApiServerSource is not in a ready state.'}
-        />
-      )}
+      <KnativeNotReadyBanner status={status} data={data} resourceType="ApiServerSource" />
 
       <Section title="Overview" icon={Server} defaultExpanded>
         <PropertyList>
@@ -134,7 +122,7 @@ export function ApiServerSourceRenderer({ data, onNavigate }: RendererProps) {
 // ============================================================================
 
 export function ContainerSourceRenderer({ data, onNavigate }: RendererProps) {
-  const status = getSourceStatus(data)
+  const status = getKnativeConditionStatus(data)
   const ns = data.metadata?.namespace || ''
   const spec = data.spec || {}
   const template = spec.template?.spec || {}
@@ -142,13 +130,7 @@ export function ContainerSourceRenderer({ data, onNavigate }: RendererProps) {
 
   return (
     <>
-      {status.level === 'unhealthy' && (
-        <AlertBanner
-          variant="error"
-          title="ContainerSource Not Ready"
-          message={(data.status?.conditions || []).find((c: any) => c.type === 'Ready')?.message || 'This ContainerSource is not in a ready state.'}
-        />
-      )}
+      <KnativeNotReadyBanner status={status} data={data} resourceType="ContainerSource" />
 
       <Section title="Overview" icon={Container} defaultExpanded>
         <PropertyList>
@@ -189,20 +171,14 @@ export function ContainerSourceRenderer({ data, onNavigate }: RendererProps) {
 // ============================================================================
 
 export function SinkBindingRenderer({ data, onNavigate }: RendererProps) {
-  const status = getSourceStatus(data)
+  const status = getKnativeConditionStatus(data)
   const ns = data.metadata?.namespace || ''
   const spec = data.spec || {}
   const subjectRef = spec.subject
 
   return (
     <>
-      {status.level === 'unhealthy' && (
-        <AlertBanner
-          variant="error"
-          title="SinkBinding Not Ready"
-          message={(data.status?.conditions || []).find((c: any) => c.type === 'Ready')?.message || 'This SinkBinding is not in a ready state.'}
-        />
-      )}
+      <KnativeNotReadyBanner status={status} data={data} resourceType="SinkBinding" />
 
       <Section title="Overview" icon={Link2} defaultExpanded>
         <PropertyList>

--- a/web/src/components/resources/renderers/knative-cells.tsx
+++ b/web/src/components/resources/renderers/knative-cells.tsx
@@ -2,43 +2,30 @@
 
 import { clsx } from 'clsx'
 import {
-  getKnativeServiceStatus,
+  getKnativeConditionStatus,
   getKnativeServiceUrl,
   getKnativeServiceLatestRevision,
   getKnativeServiceTraffic,
   getRevisionStatus,
   getRevisionImage,
   getRevisionConcurrency,
-  getRouteStatus,
   getRouteUrl,
   getRouteTraffic,
-  getConfigurationStatus,
   getConfigurationLatestCreated,
   getConfigurationLatestReady,
-  getBrokerStatus,
   getBrokerAddress,
-  getTriggerStatus,
   getTriggerBroker,
   getTriggerSubscriber,
   getTriggerFilter,
-  getSourceStatus,
   getSourceSink,
   getPingSourceSchedule,
   getPingSourceData,
-  getChannelStatus,
   getChannelAddress,
-  getSubscriptionStatus,
   getSubscriptionChannel,
   getSubscriptionSubscriber,
-  getSequenceStatus,
   getSequenceStepCount,
-  getParallelStatus,
   getParallelBranchCount,
-  getDomainMappingStatus,
   getDomainMappingUrl,
-  getKnativeIngressStatus,
-  getKnativeCertificateStatus,
-  getServerlessServiceStatus,
   getServerlessServiceMode,
 } from '../resource-utils-knative'
 
@@ -70,7 +57,7 @@ function DefaultCell() {
 export function KnativeServiceCell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
     case 'status':
-      return <StatusCell resource={resource} getStatus={getKnativeServiceStatus} />
+      return <StatusCell resource={resource} getStatus={getKnativeConditionStatus} />
     case 'url':
       return <TextCell value={getKnativeServiceUrl(resource)} />
     case 'latestRevision':
@@ -112,7 +99,7 @@ export function RevisionCell({ resource, column }: { resource: any; column: stri
 export function RouteCell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
     case 'status':
-      return <StatusCell resource={resource} getStatus={getRouteStatus} />
+      return <StatusCell resource={resource} getStatus={getKnativeConditionStatus} />
     case 'url':
       return <TextCell value={getRouteUrl(resource)} />
     case 'traffic':
@@ -129,7 +116,7 @@ export function RouteCell({ resource, column }: { resource: any; column: string 
 export function ConfigurationCell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
     case 'status':
-      return <StatusCell resource={resource} getStatus={getConfigurationStatus} />
+      return <StatusCell resource={resource} getStatus={getKnativeConditionStatus} />
     case 'latestCreated':
       return <TextCell value={getConfigurationLatestCreated(resource)} />
     case 'latestReady':
@@ -146,7 +133,7 @@ export function ConfigurationCell({ resource, column }: { resource: any; column:
 export function BrokerCell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
     case 'status':
-      return <StatusCell resource={resource} getStatus={getBrokerStatus} />
+      return <StatusCell resource={resource} getStatus={getKnativeConditionStatus} />
     case 'address':
       return <TextCell value={getBrokerAddress(resource)} />
     default:
@@ -161,7 +148,7 @@ export function BrokerCell({ resource, column }: { resource: any; column: string
 export function TriggerCell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
     case 'status':
-      return <StatusCell resource={resource} getStatus={getTriggerStatus} />
+      return <StatusCell resource={resource} getStatus={getKnativeConditionStatus} />
     case 'broker':
       return <TextCell value={getTriggerBroker(resource)} />
     case 'subscriber':
@@ -202,7 +189,7 @@ export function EventTypeCell({ resource, column }: { resource: any; column: str
 export function PingSourceCell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
     case 'status':
-      return <StatusCell resource={resource} getStatus={getSourceStatus} />
+      return <StatusCell resource={resource} getStatus={getKnativeConditionStatus} />
     case 'schedule':
       return <TextCell value={getPingSourceSchedule(resource)} />
     case 'sink':
@@ -215,13 +202,13 @@ export function PingSourceCell({ resource, column }: { resource: any; column: st
 }
 
 // ============================================================================
-// APISERVERSOURCE
+// APISERVERSOURCE / CONTAINERSOURCE (identical columns: status + sink)
 // ============================================================================
 
-export function ApiServerSourceCell({ resource, column }: { resource: any; column: string }) {
+function SourceCell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
     case 'status':
-      return <StatusCell resource={resource} getStatus={getSourceStatus} />
+      return <StatusCell resource={resource} getStatus={getKnativeConditionStatus} />
     case 'sink':
       return <TextCell value={getSourceSink(resource)} />
     default:
@@ -229,20 +216,7 @@ export function ApiServerSourceCell({ resource, column }: { resource: any; colum
   }
 }
 
-// ============================================================================
-// CONTAINERSOURCE
-// ============================================================================
-
-export function ContainerSourceCell({ resource, column }: { resource: any; column: string }) {
-  switch (column) {
-    case 'status':
-      return <StatusCell resource={resource} getStatus={getSourceStatus} />
-    case 'sink':
-      return <TextCell value={getSourceSink(resource)} />
-    default:
-      return <DefaultCell />
-  }
-}
+export { SourceCell as ApiServerSourceCell, SourceCell as ContainerSourceCell }
 
 // ============================================================================
 // SINKBINDING
@@ -251,7 +225,7 @@ export function ContainerSourceCell({ resource, column }: { resource: any; colum
 export function SinkBindingCell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
     case 'status':
-      return <StatusCell resource={resource} getStatus={getSourceStatus} />
+      return <StatusCell resource={resource} getStatus={getKnativeConditionStatus} />
     case 'sink':
       return <TextCell value={getSourceSink(resource)} />
     case 'subject': {
@@ -270,13 +244,13 @@ export function SinkBindingCell({ resource, column }: { resource: any; column: s
 }
 
 // ============================================================================
-// CHANNEL
+// CHANNEL / INMEMORYCHANNEL (identical columns: status + address)
 // ============================================================================
 
-export function ChannelCell({ resource, column }: { resource: any; column: string }) {
+function ChannelCellBase({ resource, column }: { resource: any; column: string }) {
   switch (column) {
     case 'status':
-      return <StatusCell resource={resource} getStatus={getChannelStatus} />
+      return <StatusCell resource={resource} getStatus={getKnativeConditionStatus} />
     case 'address':
       return <TextCell value={getChannelAddress(resource)} />
     default:
@@ -284,20 +258,7 @@ export function ChannelCell({ resource, column }: { resource: any; column: strin
   }
 }
 
-// ============================================================================
-// INMEMORYCHANNEL
-// ============================================================================
-
-export function InMemoryChannelCell({ resource, column }: { resource: any; column: string }) {
-  switch (column) {
-    case 'status':
-      return <StatusCell resource={resource} getStatus={getChannelStatus} />
-    case 'address':
-      return <TextCell value={getChannelAddress(resource)} />
-    default:
-      return <DefaultCell />
-  }
-}
+export { ChannelCellBase as ChannelCell, ChannelCellBase as InMemoryChannelCell }
 
 // ============================================================================
 // SUBSCRIPTION
@@ -306,7 +267,7 @@ export function InMemoryChannelCell({ resource, column }: { resource: any; colum
 export function SubscriptionCell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
     case 'status':
-      return <StatusCell resource={resource} getStatus={getSubscriptionStatus} />
+      return <StatusCell resource={resource} getStatus={getKnativeConditionStatus} />
     case 'channel':
       return <TextCell value={getSubscriptionChannel(resource)} />
     case 'subscriber':
@@ -323,7 +284,7 @@ export function SubscriptionCell({ resource, column }: { resource: any; column: 
 export function SequenceCell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
     case 'status':
-      return <StatusCell resource={resource} getStatus={getSequenceStatus} />
+      return <StatusCell resource={resource} getStatus={getKnativeConditionStatus} />
     case 'steps':
       return <NumberCell value={getSequenceStepCount(resource)} />
     default:
@@ -338,7 +299,7 @@ export function SequenceCell({ resource, column }: { resource: any; column: stri
 export function ParallelCell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
     case 'status':
-      return <StatusCell resource={resource} getStatus={getParallelStatus} />
+      return <StatusCell resource={resource} getStatus={getKnativeConditionStatus} />
     case 'branches':
       return <NumberCell value={getParallelBranchCount(resource)} />
     default:
@@ -353,7 +314,7 @@ export function ParallelCell({ resource, column }: { resource: any; column: stri
 export function DomainMappingCell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
     case 'status':
-      return <StatusCell resource={resource} getStatus={getDomainMappingStatus} />
+      return <StatusCell resource={resource} getStatus={getKnativeConditionStatus} />
     case 'url':
       return <TextCell value={getDomainMappingUrl(resource)} />
     default:
@@ -368,7 +329,7 @@ export function DomainMappingCell({ resource, column }: { resource: any; column:
 export function KnativeIngressCell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
     case 'status':
-      return <StatusCell resource={resource} getStatus={getKnativeIngressStatus} />
+      return <StatusCell resource={resource} getStatus={getKnativeConditionStatus} />
     case 'ingressClass': {
       const cls = resource?.metadata?.annotations?.['networking.knative.dev/ingress.class'] || '-'
       // Show just the short name (e.g., "kourier" from "kourier.ingress.networking.knative.dev")
@@ -398,7 +359,7 @@ export function KnativeIngressCell({ resource, column }: { resource: any; column
 export function KnativeCertificateCell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
     case 'status':
-      return <StatusCell resource={resource} getStatus={getKnativeCertificateStatus} />
+      return <StatusCell resource={resource} getStatus={getKnativeConditionStatus} />
     case 'dnsNames': {
       const names = resource?.spec?.dnsNames || []
       return <TextCell value={names.length > 0 ? names.join(', ') : '-'} />
@@ -417,7 +378,7 @@ export function KnativeCertificateCell({ resource, column }: { resource: any; co
 export function ServerlessServiceCell({ resource, column }: { resource: any; column: string }) {
   switch (column) {
     case 'status':
-      return <StatusCell resource={resource} getStatus={getServerlessServiceStatus} />
+      return <StatusCell resource={resource} getStatus={getKnativeConditionStatus} />
     case 'mode': {
       const mode = getServerlessServiceMode(resource)
       return (

--- a/web/src/components/resources/resource-utils-knative.ts
+++ b/web/src/components/resources/resource-utils-knative.ts
@@ -7,7 +7,7 @@ import { healthColors } from './resource-utils'
 // SHARED HELPERS
 // ============================================================================
 
-function getKnativeConditionStatus(resource: any): StatusBadge {
+export function getKnativeConditionStatus(resource: any): StatusBadge {
   const conditions = resource?.status?.conditions || []
   const ready = conditions.find((c: any) => c.type === 'Ready')
   if (!ready) return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
@@ -36,10 +36,6 @@ function formatRef(ref: any): string {
 // ============================================================================
 // KNATIVE SERVICE (serving.knative.dev/v1)
 // ============================================================================
-
-export function getKnativeServiceStatus(resource: any): StatusBadge {
-  return getKnativeConditionStatus(resource)
-}
 
 export function getKnativeServiceUrl(resource: any): string {
   return resource?.status?.url || '-'
@@ -94,10 +90,6 @@ export function getRevisionConcurrency(resource: any): string {
 // ROUTE (serving.knative.dev/v1)
 // ============================================================================
 
-export function getRouteStatus(resource: any): StatusBadge {
-  return getKnativeConditionStatus(resource)
-}
-
 export function getRouteUrl(resource: any): string {
   return resource?.status?.url || '-'
 }
@@ -109,10 +101,6 @@ export function getRouteTraffic(resource: any): string {
 // ============================================================================
 // CONFIGURATION (serving.knative.dev/v1)
 // ============================================================================
-
-export function getConfigurationStatus(resource: any): StatusBadge {
-  return getKnativeConditionStatus(resource)
-}
 
 export function getConfigurationLatestCreated(resource: any): string {
   return resource?.status?.latestCreatedRevisionName || '-'
@@ -126,10 +114,6 @@ export function getConfigurationLatestReady(resource: any): string {
 // BROKER (eventing.knative.dev/v1)
 // ============================================================================
 
-export function getBrokerStatus(resource: any): StatusBadge {
-  return getKnativeConditionStatus(resource)
-}
-
 export function getBrokerAddress(resource: any): string {
   return resource?.status?.address?.url || '-'
 }
@@ -137,10 +121,6 @@ export function getBrokerAddress(resource: any): string {
 // ============================================================================
 // TRIGGER (eventing.knative.dev/v1)
 // ============================================================================
-
-export function getTriggerStatus(resource: any): StatusBadge {
-  return getKnativeConditionStatus(resource)
-}
 
 export function getTriggerBroker(resource: any): string {
   return resource?.spec?.broker || '-'
@@ -164,10 +144,6 @@ export function getTriggerFilter(resource: any): string {
 // SOURCES (sources.knative.dev/v1)
 // ============================================================================
 
-export function getSourceStatus(resource: any): StatusBadge {
-  return getKnativeConditionStatus(resource)
-}
-
 export function getSourceSink(resource: any): string {
   const ref = resource?.spec?.sink?.ref
   if (ref) return formatRef(ref)
@@ -189,10 +165,6 @@ export function getPingSourceData(resource: any): string {
 // CHANNEL (messaging.knative.dev/v1)
 // ============================================================================
 
-export function getChannelStatus(resource: any): StatusBadge {
-  return getKnativeConditionStatus(resource)
-}
-
 export function getChannelAddress(resource: any): string {
   return resource?.status?.address?.url || '-'
 }
@@ -200,10 +172,6 @@ export function getChannelAddress(resource: any): string {
 // ============================================================================
 // SUBSCRIPTION (messaging.knative.dev/v1)
 // ============================================================================
-
-export function getSubscriptionStatus(resource: any): StatusBadge {
-  return getKnativeConditionStatus(resource)
-}
 
 export function getSubscriptionChannel(resource: any): string {
   const channel = resource?.spec?.channel
@@ -221,10 +189,6 @@ export function getSubscriptionSubscriber(resource: any): string {
 // SEQUENCE (flows.knative.dev/v1)
 // ============================================================================
 
-export function getSequenceStatus(resource: any): StatusBadge {
-  return getKnativeConditionStatus(resource)
-}
-
 export function getSequenceStepCount(resource: any): number {
   return (resource?.spec?.steps || []).length
 }
@@ -232,10 +196,6 @@ export function getSequenceStepCount(resource: any): number {
 // ============================================================================
 // PARALLEL (flows.knative.dev/v1)
 // ============================================================================
-
-export function getParallelStatus(resource: any): StatusBadge {
-  return getKnativeConditionStatus(resource)
-}
 
 export function getParallelBranchCount(resource: any): number {
   return (resource?.spec?.branches || []).length
@@ -245,37 +205,13 @@ export function getParallelBranchCount(resource: any): number {
 // DOMAINMAPPING (serving.knative.dev/v1beta1)
 // ============================================================================
 
-export function getDomainMappingStatus(resource: any): StatusBadge {
-  return getKnativeConditionStatus(resource)
-}
-
 export function getDomainMappingUrl(resource: any): string {
   return resource?.status?.url || '-'
 }
 
 // ============================================================================
-// KNATIVE INGRESS (networking.internal.knative.dev/v1alpha1)
-// ============================================================================
-
-export function getKnativeIngressStatus(resource: any): StatusBadge {
-  return getKnativeConditionStatus(resource)
-}
-
-// ============================================================================
-// KNATIVE CERTIFICATE (networking.internal.knative.dev/v1alpha1)
-// ============================================================================
-
-export function getKnativeCertificateStatus(resource: any): StatusBadge {
-  return getKnativeConditionStatus(resource)
-}
-
-// ============================================================================
 // SERVERLESSSERVICE (networking.internal.knative.dev/v1alpha1)
 // ============================================================================
-
-export function getServerlessServiceStatus(resource: any): StatusBadge {
-  return getKnativeConditionStatus(resource)
-}
 
 export function getServerlessServiceMode(resource: any): string {
   return resource?.spec?.mode || '-'


### PR DESCRIPTION
## Summary
- Export shared `getKnativeConditionStatus`, remove 13 pass-through wrapper functions
- Extract `KnativeNotReadyBanner` helper to replace 17 inline alert banner patterns
- Deduplicate identical cell components (`SourceCell`, `ChannelCellBase`)
- Collapse 16 separate `getResourceStatus()` if-blocks into single array lookup
- Remove dead code branches for colliding kinds (services, certificates)
- Add missing `log.Printf` before 500 errors in server.go
- Fix factual errors in INTEGRATION_GUIDE.md (edge type grouping, Route collision)

Follow-up to #239 — review fixes and deduplication that missed the merge window.

## Test plan
- [x] Verified with Playwright: Broker table/drawer, KNative Service table/drawer, core K8s Service drawer (collision guard), topology view with all edges