### PR TITLE
Improve performance on large clusters (resource counts, SSE debounce, noisy filtering)

### DIFF
--- a/internal/server/resource_counts.go
+++ b/internal/server/resource_counts.go
@@ -1,0 +1,110 @@
+package server
+
+import (
+	"log"
+	"net/http"
+	"sync"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/pkg/k8score"
+)
+
+type ResourceCountsResponse struct {
+	Counts    map[string]int `json:"counts"`
+	Forbidden []string       `json:"forbidden,omitempty"`
+}
+
+func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
+	if !s.requireConnected(w) {
+		return
+	}
+
+	namespaces := parseNamespaces(r.URL.Query())
+
+	cache := k8s.GetResourceCache()
+	if cache == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "Resource cache not available")
+		return
+	}
+
+	counts := make(map[string]int)
+	var forbidden []string
+
+	// 1. Typed resources from allKindListers
+	for _, kl := range k8score.AllKindListers() {
+		l := kl.Lister()(cache.ResourceCache)
+		if l == nil {
+			forbidden = append(forbidden, kl.CountKey())
+			continue
+		}
+		n := k8score.ListCountNamespaced(l, namespaces)
+		if n > 0 {
+			counts[kl.CountKey()] = n
+		}
+	}
+
+	// 2. Dynamic resources (CRDs) — counted concurrently since each Count() hits a separate informer indexer
+	discovery := k8s.GetResourceDiscovery()
+	dynamicCache := k8s.GetDynamicResourceCache()
+	if discovery != nil && dynamicCache != nil {
+		resources, err := discovery.GetAPIResources()
+		if err != nil {
+			log.Printf("[resource-counts] Failed to discover API resources for CRD counts: %v", err)
+		} else {
+			// Deduplicate CRDs by group+kind
+			type crdInfo struct {
+				kind       string
+				group      string
+				namespaced bool
+			}
+			seen := make(map[string]bool)
+			var crds []crdInfo
+			for _, res := range resources {
+				if !res.IsCRD {
+					continue
+				}
+				key := res.Group + "/" + res.Kind
+				if !seen[key] {
+					seen[key] = true
+					crds = append(crds, crdInfo{kind: res.Kind, group: res.Group, namespaced: res.Namespaced})
+				}
+			}
+
+			var mu sync.Mutex
+			var wg sync.WaitGroup
+			for _, crd := range crds {
+				wg.Add(1)
+				go func(c crdInfo) {
+					defer wg.Done()
+					gvr, ok := discovery.GetGVRWithGroup(c.kind, c.group)
+					if !ok {
+						return
+					}
+					// For cluster-scoped CRDs, skip namespace filtering (same as typed resources)
+					ns := namespaces
+					if !c.namespaced {
+						ns = nil
+					}
+					n, err := dynamicCache.Count(gvr, ns)
+					if err != nil {
+						log.Printf("[resource-counts] Failed to count CRD %s/%s: %v", c.group, c.kind, err)
+						return
+					}
+					if n == 0 {
+						return
+					}
+					countKey := c.group + "/" + c.kind
+					mu.Lock()
+					counts[countKey] = n
+					mu.Unlock()
+				}(crd)
+			}
+			wg.Wait()
+		}
+	}
+
+	s.writeJSON(w, ResourceCountsResponse{
+		Counts:    counts,
+		Forbidden: forbidden,
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -139,6 +139,7 @@ func (s *Server) setupRoutes() {
 			r.Get("/topology", s.handleTopology)
 			r.Get("/namespaces", s.handleNamespaces)
 			r.Get("/api-resources", s.handleAPIResources)
+			r.Get("/resource-counts", s.handleResourceCounts)
 			r.Get("/resources/{kind}", s.handleListResources)
 			r.Get("/resources/{kind}/{namespace}/{name}", s.handleGetResource)
 			r.Put("/resources/{kind}/{namespace}/{name}", s.handleUpdateResource)

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -31,9 +31,10 @@ type SSEBroadcaster struct {
 	watchStopCh chan struct{}
 	watchMu     sync.Mutex
 
-	// Cached topology for relationship lookups (updated on each topology rebuild)
-	cachedTopology   *topology.Topology
-	cachedTopologyMu sync.RWMutex
+	// Cached topology for relationship lookups (rebuilt on broadcast or lazily on access)
+	cachedTopology      *topology.Topology
+	cachedTopologyMu    sync.RWMutex
+	cachedTopologyDirty bool // true when changes occurred but topology not yet rebuilt
 }
 
 // ClientInfo stores information about a connected client
@@ -200,9 +201,10 @@ func (b *SSEBroadcaster) registerContextSwitchCallback() {
 	k8s.OnContextSwitch(func(newContext string) {
 		log.Printf("SSE broadcaster: context switched to %q, clearing cached topology", newContext)
 
-		// Clear cached topology
+		// Clear cached topology and dirty flag for the old context
 		b.cachedTopologyMu.Lock()
 		b.cachedTopology = nil
+		b.cachedTopologyDirty = false
 		b.cachedTopologyMu.Unlock()
 
 		// Restart the resource change watcher for the new cache
@@ -362,7 +364,16 @@ func (b *SSEBroadcaster) watchResourceChanges() {
 		return
 	}
 
-	// Debounce changes - wait for 100ms of quiet before sending topology update
+	// Use longer debounce for large clusters to avoid constant topology rebuilds.
+	// On a cluster with 18k+ resources, changes arrive continuously; 500ms means
+	// rebuilding topology ~2x/sec with no quiet period ever.
+	debounceDuration := 500 * time.Millisecond
+	resourceCount := cache.GetResourceCount()
+	if resourceCount > 5000 {
+		debounceDuration = 5 * time.Second
+		log.Printf("SSE watcher: large cluster (%d resources), using %v topology debounce", resourceCount, debounceDuration)
+	}
+
 	debounceTimer := time.NewTimer(0)
 	<-debounceTimer.C // drain initial timer
 	pendingUpdate := false
@@ -403,9 +414,9 @@ func (b *SSEBroadcaster) watchResourceChanges() {
 				})
 			}
 
-			// Schedule debounced topology update (500ms to reduce UI thrashing)
+			// Schedule debounced topology update
 			if !pendingUpdate {
-				debounceTimer.Reset(500 * time.Millisecond)
+				debounceTimer.Reset(debounceDuration)
 				pendingUpdate = true
 			}
 
@@ -431,26 +442,24 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() {
 	maps.Copy(clients, b.clients)
 	b.mu.RUnlock()
 
+	if len(clients) == 0 {
+		// No clients — mark the relationship cache as dirty so it gets
+		// rebuilt on next GetCachedTopology() call. Skip the expensive build.
+		b.cachedTopologyMu.Lock()
+		b.cachedTopologyDirty = true
+		b.cachedTopologyMu.Unlock()
+		return
+	}
+
 	log.Printf("Broadcasting topology update to %d clients", len(clients))
 
-	builder := topology.NewBuilder(k8s.NewTopologyResourceProvider(k8s.GetResourceCache())).WithDynamic(k8s.NewTopologyDynamicProvider(k8s.GetDynamicResourceCache(), k8s.GetResourceDiscovery()))
-
-	// Always build and cache a full topology (all namespaces, resources view)
-	// for relationship lookups, even if no clients are connected
-	fullOpts := topology.DefaultBuildOptions()
-	fullOpts.ViewMode = topology.ViewModeResources
-	fullOpts.MaxNodes = 0 // No limit — this topology is only used for relationship lookups, not sent to the browser
-	fullOpts.IncludeReplicaSets = true // Include for relationship lookups
-	if fullTopo, err := builder.Build(fullOpts); err == nil {
+	if fullTopo, err := buildFullTopology(); err == nil {
 		b.updateCachedTopology(fullTopo)
 	} else {
 		log.Printf("Error building full topology for cache: %v", err)
 	}
 
-	if len(clients) == 0 {
-		log.Printf("No SSE clients to broadcast topology to")
-		return
-	}
+	builder := topology.NewBuilder(k8s.NewTopologyResourceProvider(k8s.GetResourceCache())).WithDynamic(k8s.NewTopologyDynamicProvider(k8s.GetDynamicResourceCache(), k8s.GetResourceDiscovery()))
 
 	// Group clients by namespace filter + viewMode
 	// Use comma-separated namespaces string as map key since slices aren't comparable
@@ -566,10 +575,44 @@ func (b *SSEBroadcaster) ClientCount() int {
 
 // GetCachedTopology returns the most recently built full topology.
 // This is used for relationship lookups without rebuilding the topology.
+// If the cache is dirty (changes occurred with no SSE clients), it rebuilds on demand.
 func (b *SSEBroadcaster) GetCachedTopology() *topology.Topology {
 	b.cachedTopologyMu.RLock()
-	defer b.cachedTopologyMu.RUnlock()
-	return b.cachedTopology
+	dirty := b.cachedTopologyDirty
+	topo := b.cachedTopology
+	b.cachedTopologyMu.RUnlock()
+
+	if dirty && k8s.GetResourceCache() != nil {
+		// Gate: only one goroutine proceeds to rebuild
+		b.cachedTopologyMu.Lock()
+		if !b.cachedTopologyDirty {
+			topo = b.cachedTopology
+			b.cachedTopologyMu.Unlock()
+			return topo
+		}
+		b.cachedTopologyDirty = false
+		b.cachedTopologyMu.Unlock()
+
+		b.rebuildCachedTopology()
+		b.cachedTopologyMu.RLock()
+		topo = b.cachedTopology
+		b.cachedTopologyMu.RUnlock()
+	}
+
+	return topo
+}
+
+// rebuildCachedTopology rebuilds the full topology for relationship lookups.
+func (b *SSEBroadcaster) rebuildCachedTopology() {
+	cache := k8s.GetResourceCache()
+	if cache == nil {
+		return
+	}
+	if fullTopo, err := buildFullTopology(); err == nil {
+		b.updateCachedTopology(fullTopo)
+	} else {
+		log.Printf("Error rebuilding topology cache on demand: %v", err)
+	}
 }
 
 // updateCachedTopology stores a full topology for relationship lookups
@@ -577,6 +620,18 @@ func (b *SSEBroadcaster) updateCachedTopology(topo *topology.Topology) {
 	b.cachedTopologyMu.Lock()
 	defer b.cachedTopologyMu.Unlock()
 	b.cachedTopology = topo
+	b.cachedTopologyDirty = false
+}
+
+// buildFullTopology constructs a full topology (all namespaces, resources view)
+// for relationship lookups. Used by both broadcast and lazy rebuild paths.
+func buildFullTopology() (*topology.Topology, error) {
+	builder := topology.NewBuilder(k8s.NewTopologyResourceProvider(k8s.GetResourceCache())).WithDynamic(k8s.NewTopologyDynamicProvider(k8s.GetDynamicResourceCache(), k8s.GetResourceDiscovery()))
+	opts := topology.DefaultBuildOptions()
+	opts.ViewMode = topology.ViewModeResources
+	opts.MaxNodes = 0
+	opts.IncludeReplicaSets = true
+	return builder.Build(opts)
 }
 
 // HandleSSE is the HTTP handler for the SSE endpoint

--- a/pkg/k8score/cache.go
+++ b/pkg/k8score/cache.go
@@ -332,10 +332,14 @@ func (rc *ResourceCache) enqueueChange(ch chan<- ResourceChange, kind string, ob
 		rc.safeCallback("OnReceived", func() { rc.config.OnReceived(kind) })
 	}
 
-	// Check if noisy (skip OnChange but still send to channel)
+	// Check if noisy — skip OnChange callback and don't send to changes channel.
+	// Noisy resources (Lease, Endpoints, EndpointSlice updates, etc.) fire constantly
+	// and don't affect topology or produce meaningful k8s_event broadcasts.
 	skipCallback := false
+	isNoisy := false
 	if rc.config.IsNoisyResource != nil && rc.config.IsNoisyResource(kind, name, op) {
 		skipCallback = true
+		isNoisy = true
 		if rc.config.OnDrop != nil {
 			rc.config.OnDrop(kind, ns, name, "noisy_filter", op)
 		}
@@ -366,14 +370,17 @@ func (rc *ResourceCache) enqueueChange(ch chan<- ResourceChange, kind string, ob
 		rc.safeCallback("OnChange", func() { rc.config.OnChange(change, obj, oldObj) })
 	}
 
-	// Non-blocking send to changes channel
-	select {
-	case ch <- change:
-	default:
-		if rc.config.OnDrop != nil {
-			rc.config.OnDrop(kind, ns, name, "channel_full", op)
-		} else {
-			rc.stdlog.Printf("Warning: change channel full, dropped %s %s/%s op=%s", kind, ns, name, op)
+	// Non-blocking send to changes channel (skip noisy resources entirely —
+	// they don't affect topology and would just trigger unnecessary rebuilds)
+	if !isNoisy {
+		select {
+		case ch <- change:
+		default:
+			if rc.config.OnDrop != nil {
+				rc.config.OnDrop(kind, ns, name, "channel_full", op)
+			} else {
+				rc.stdlog.Printf("Warning: change channel full, dropped %s %s/%s op=%s", kind, ns, name, op)
+			}
 		}
 	}
 }
@@ -531,32 +538,56 @@ func (rc *ResourceCache) GetResourceCount() int {
 // kindLister maps a Kind name to a lister accessor for table-driven counting.
 type kindLister struct {
 	kind   string
+	group  string // API group (empty for core, e.g. "apps", "batch", "networking.k8s.io")
 	lister func(rc *ResourceCache) any
 }
 
 // allKindListers is the table of all resource kinds and their lister accessors.
 var allKindListers = []kindLister{
-	{"Pod", func(rc *ResourceCache) any { return rc.Pods() }},
-	{"Service", func(rc *ResourceCache) any { return rc.Services() }},
-	{"Node", func(rc *ResourceCache) any { return rc.Nodes() }},
-	{"Namespace", func(rc *ResourceCache) any { return rc.Namespaces() }},
-	{"ConfigMap", func(rc *ResourceCache) any { return rc.ConfigMaps() }},
-	{"Secret", func(rc *ResourceCache) any { return rc.Secrets() }},
-	{"Event", func(rc *ResourceCache) any { return rc.Events() }},
-	{"PersistentVolumeClaim", func(rc *ResourceCache) any { return rc.PersistentVolumeClaims() }},
-	{"PersistentVolume", func(rc *ResourceCache) any { return rc.PersistentVolumes() }},
-	{"Deployment", func(rc *ResourceCache) any { return rc.Deployments() }},
-	{"DaemonSet", func(rc *ResourceCache) any { return rc.DaemonSets() }},
-	{"StatefulSet", func(rc *ResourceCache) any { return rc.StatefulSets() }},
-	{"ReplicaSet", func(rc *ResourceCache) any { return rc.ReplicaSets() }},
-	{"Ingress", func(rc *ResourceCache) any { return rc.Ingresses() }},
-	{"IngressClass", func(rc *ResourceCache) any { return rc.IngressClasses() }},
-	{"Job", func(rc *ResourceCache) any { return rc.Jobs() }},
-	{"CronJob", func(rc *ResourceCache) any { return rc.CronJobs() }},
-	{"HorizontalPodAutoscaler", func(rc *ResourceCache) any { return rc.HorizontalPodAutoscalers() }},
-	{"StorageClass", func(rc *ResourceCache) any { return rc.StorageClasses() }},
-	{"PodDisruptionBudget", func(rc *ResourceCache) any { return rc.PodDisruptionBudgets() }},
-	{"ServiceAccount", func(rc *ResourceCache) any { return rc.ServiceAccounts() }},
+	{"Pod", "", func(rc *ResourceCache) any { return rc.Pods() }},
+	{"Service", "", func(rc *ResourceCache) any { return rc.Services() }},
+	{"Node", "", func(rc *ResourceCache) any { return rc.Nodes() }},
+	{"Namespace", "", func(rc *ResourceCache) any { return rc.Namespaces() }},
+	{"ConfigMap", "", func(rc *ResourceCache) any { return rc.ConfigMaps() }},
+	{"Secret", "", func(rc *ResourceCache) any { return rc.Secrets() }},
+	{"Event", "", func(rc *ResourceCache) any { return rc.Events() }},
+	{"PersistentVolumeClaim", "", func(rc *ResourceCache) any { return rc.PersistentVolumeClaims() }},
+	{"PersistentVolume", "", func(rc *ResourceCache) any { return rc.PersistentVolumes() }},
+	{"Deployment", "apps", func(rc *ResourceCache) any { return rc.Deployments() }},
+	{"DaemonSet", "apps", func(rc *ResourceCache) any { return rc.DaemonSets() }},
+	{"StatefulSet", "apps", func(rc *ResourceCache) any { return rc.StatefulSets() }},
+	{"ReplicaSet", "apps", func(rc *ResourceCache) any { return rc.ReplicaSets() }},
+	{"Ingress", "networking.k8s.io", func(rc *ResourceCache) any { return rc.Ingresses() }},
+	{"IngressClass", "networking.k8s.io", func(rc *ResourceCache) any { return rc.IngressClasses() }},
+	{"Job", "batch", func(rc *ResourceCache) any { return rc.Jobs() }},
+	{"CronJob", "batch", func(rc *ResourceCache) any { return rc.CronJobs() }},
+	{"HorizontalPodAutoscaler", "autoscaling", func(rc *ResourceCache) any { return rc.HorizontalPodAutoscalers() }},
+	{"StorageClass", "storage.k8s.io", func(rc *ResourceCache) any { return rc.StorageClasses() }},
+	{"PodDisruptionBudget", "policy", func(rc *ResourceCache) any { return rc.PodDisruptionBudgets() }},
+	{"ServiceAccount", "", func(rc *ResourceCache) any { return rc.ServiceAccounts() }},
+}
+
+// AllKindListers returns the table of all resource kinds with their group and lister.
+// Used by the resource-counts endpoint to enumerate typed resources.
+func AllKindListers() []kindLister {
+	return allKindListers
+}
+
+// Kind returns the resource kind name.
+func (kl kindLister) Kind() string { return kl.kind }
+
+// Group returns the API group (empty for core resources).
+func (kl kindLister) Group() string { return kl.group }
+
+// Lister returns the lister accessor function.
+func (kl kindLister) Lister() func(rc *ResourceCache) any { return kl.lister }
+
+// CountKey returns the key used in resource-counts responses: "group/Kind" or just "Kind" for core.
+func (kl kindLister) CountKey() string {
+	if kl.group != "" {
+		return kl.group + "/" + kl.kind
+	}
+	return kl.kind
 }
 
 // GetKindObjectCounts returns the number of cached objects per resource kind.

--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -323,6 +323,37 @@ func (d *DynamicResourceCache) enqueueDynamicChange(kind string, gvr schema.Grou
 // Read methods
 // ---------------------------------------------------------------------------
 
+// Count returns the number of resources for a given GVR, optionally filtered by namespaces.
+// Unlike List(), this avoids allocating a result slice and skips StripUnstructuredFields.
+func (d *DynamicResourceCache) Count(gvr schema.GroupVersionResource, namespaces []string) (int, error) {
+	if d == nil {
+		return 0, fmt.Errorf("dynamic resource cache not initialized")
+	}
+
+	d.mu.RLock()
+	informer, exists := d.informers[gvr]
+	synced := d.syncComplete[gvr]
+	d.mu.RUnlock()
+
+	if !exists || !synced {
+		return 0, fmt.Errorf("informer not found or not synced for %v", gvr)
+	}
+
+	if len(namespaces) == 0 {
+		return len(informer.GetIndexer().List()), nil
+	}
+
+	total := 0
+	for _, ns := range namespaces {
+		items, err := informer.GetIndexer().ByIndex(cache.NamespaceIndex, ns)
+		if err != nil {
+			return 0, fmt.Errorf("failed to count resources in namespace %s: %w", ns, err)
+		}
+		total += len(items)
+	}
+	return total, nil
+}
+
 // List returns all resources of a given GVR, optionally filtered by namespace.
 // This is non-blocking — returns whatever data is available immediately.
 func (d *DynamicResourceCache) List(gvr schema.GroupVersionResource, namespace string) ([]*unstructured.Unstructured, error) {

--- a/pkg/k8score/listers.go
+++ b/pkg/k8score/listers.go
@@ -158,6 +158,95 @@ func (rc *ResourceCache) ServiceAccounts() listerscorev1.ServiceAccountLister {
 	return rc.factory.Core().V1().ServiceAccounts().Lister()
 }
 
+// listCountNamespaced counts items from a lister filtered to specific namespaces.
+// If namespaces is empty, it returns the total count (same as listCount).
+func listCountNamespaced(lister any, namespaces []string) int {
+	if lister == nil {
+		return 0
+	}
+	if len(namespaces) == 0 {
+		return listCount(lister)
+	}
+	// Cluster-scoped resources ignore namespace filter
+	if isClusterScoped(lister) {
+		return listCount(lister)
+	}
+	total := 0
+	for _, ns := range namespaces {
+		total += listCountInNamespace(lister, ns)
+	}
+	return total
+}
+
+func isClusterScoped(lister any) bool {
+	switch lister.(type) {
+	case listerscorev1.NodeLister, listerscorev1.NamespaceLister,
+		listerscorev1.PersistentVolumeLister, listersstoragev1.StorageClassLister,
+		listersnetworkingv1.IngressClassLister:
+		return true
+	}
+	return false
+}
+
+func listCountInNamespace(lister any, ns string) int {
+	switch l := lister.(type) {
+	case listerscorev1.PodLister:
+		items, _ := l.Pods(ns).List(labels.Everything())
+		return len(items)
+	case listerscorev1.ServiceLister:
+		items, _ := l.Services(ns).List(labels.Everything())
+		return len(items)
+	case listerscorev1.ConfigMapLister:
+		items, _ := l.ConfigMaps(ns).List(labels.Everything())
+		return len(items)
+	case listerscorev1.SecretLister:
+		items, _ := l.Secrets(ns).List(labels.Everything())
+		return len(items)
+	case listerscorev1.EventLister:
+		items, _ := l.Events(ns).List(labels.Everything())
+		return len(items)
+	case listerscorev1.PersistentVolumeClaimLister:
+		items, _ := l.PersistentVolumeClaims(ns).List(labels.Everything())
+		return len(items)
+	case listerscorev1.ServiceAccountLister:
+		items, _ := l.ServiceAccounts(ns).List(labels.Everything())
+		return len(items)
+	case listersappsv1.DeploymentLister:
+		items, _ := l.Deployments(ns).List(labels.Everything())
+		return len(items)
+	case listersappsv1.DaemonSetLister:
+		items, _ := l.DaemonSets(ns).List(labels.Everything())
+		return len(items)
+	case listersappsv1.StatefulSetLister:
+		items, _ := l.StatefulSets(ns).List(labels.Everything())
+		return len(items)
+	case listersappsv1.ReplicaSetLister:
+		items, _ := l.ReplicaSets(ns).List(labels.Everything())
+		return len(items)
+	case listersnetworkingv1.IngressLister:
+		items, _ := l.Ingresses(ns).List(labels.Everything())
+		return len(items)
+	case listersbatchv1.JobLister:
+		items, _ := l.Jobs(ns).List(labels.Everything())
+		return len(items)
+	case listersbatchv1.CronJobLister:
+		items, _ := l.CronJobs(ns).List(labels.Everything())
+		return len(items)
+	case listersautoscalingv2.HorizontalPodAutoscalerLister:
+		items, _ := l.HorizontalPodAutoscalers(ns).List(labels.Everything())
+		return len(items)
+	case listerspolicyv1.PodDisruptionBudgetLister:
+		items, _ := l.PodDisruptionBudgets(ns).List(labels.Everything())
+		return len(items)
+	}
+	return 0
+}
+
+// ListCountNamespaced is the exported version of listCountNamespaced for use by server handlers.
+func ListCountNamespaced(lister any, namespaces []string) int {
+	return listCountNamespaced(lister, namespaces)
+}
+
 // listCount is a helper that counts items from any known lister type.
 func listCount(lister any) int {
 	if lister == nil {


### PR DESCRIPTION
## Summary

Three performance improvements for large clusters (18k+ resources):

- **`GET /api/resource-counts`** — New lightweight endpoint returning `{kind: count}` for all resource kinds (~2KB vs ~608MB from 233 parallel `/api/resources/{kind}` calls). Backend only — frontend will consume this after `feature/k8s-ui-shared-package` lands.
- **SSE topology debounce** — Increases debounce from 500ms to 5s on clusters with >5000 resources to avoid constant topology rebuilds. Skips rebuild entirely when no SSE clients are connected (marks cache dirty instead).
- **Noisy resource channel skip** — Noisy resources (Lease, Endpoints, EndpointSlice updates) no longer get sent to the changes channel at all, preventing unnecessary topology rebuild triggers.

## Files changed

| File | Change |
|------|--------|
| `internal/server/resource_counts.go` | New handler with concurrent CRD counting |
| `internal/server/server.go` | Route registration |
| `internal/server/sse.go` | Adaptive debounce + skip rebuild when no clients |
| `pkg/k8score/cache.go` | `group` field on `kindLister`, noisy channel skip |
| `pkg/k8score/dynamic_cache.go` | `Count()` method (zero-alloc indexer count) |
| `pkg/k8score/listers.go` | `listCountNamespaced()` with cluster-scope handling |

## Tested

- Verified against AWS nonprod cluster (22 nodes, 432 namespaces, 67 resource kinds)
- All-namespaces: correct counts, 2.3KB response
- Namespace filtering: correct scoping, cluster-scoped resources not double-counted
- `forbidden` field correctly reports RBAC-denied kinds
- All tests pass (`go test ./pkg/k8score/...`, `go test ./internal/server/...`)