### PR TITLE
Improve resource list performance: virtual scrolling + lightweight counts

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1530,14 +1530,7 @@ export function ResourcesView({
 }: ResourcesViewProps) {
   const location = useMemo(() => ({ search: locationSearch, pathname: locationPathname }), [locationSearch, locationPathname])
   const initialFilters = getInitialFiltersFromURL()
-  const [selectedKind, setSelectedKindInternal] = useState<SelectedKindInfo>(() => getInitialKindFromURL(basePath))
-  // Wrap setSelectedKind to notify parent
-  const setSelectedKind = useCallback((kindOrFn: SelectedKindInfo | ((prev: SelectedKindInfo) => SelectedKindInfo)) => {
-    setSelectedKindInternal(prev => {
-      const next = typeof kindOrFn === 'function' ? kindOrFn(prev) : kindOrFn
-      return next
-    })
-  }, [])
+  const [selectedKind, setSelectedKind] = useState<SelectedKindInfo>(() => getInitialKindFromURL(basePath))
   // Notify parent of selected kind changes (including initial mount)
   useEffect(() => {
     onSelectedKindChange?.(selectedKind)
@@ -2379,8 +2372,8 @@ export function ResourcesView({
 
   // Track which resource kinds returned 403 Forbidden
   const forbiddenKinds = useMemo(() => {
-    if (useNewCountsMode && resourceForbiddenProp) {
-      return new Set(resourceForbiddenProp)
+    if (useNewCountsMode) {
+      return new Set(resourceForbiddenProp ?? [])
     }
     // Legacy: derive from full query errors
     const result = new Set<string>()

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react'
+import { useState, useMemo } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { ApiError, fetchJSON, isForbiddenError, useSecretCertExpiry, useTopPodMetrics, useTopNodeMetrics } from '../../api/client'
@@ -36,10 +36,6 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
   // Track the selected kind from the k8s-ui component
   const [selectedKind, setSelectedKind] = useState<{ name: string; kind: string; group: string } | null>(null)
 
-  const handleSelectedKindChange = useCallback((kind: { name: string; kind: string; group: string }) => {
-    setSelectedKind(kind)
-  }, [])
-
   // Lightweight resource counts for sidebar badges (~2KB instead of ~608MB)
   const namespacesParam = namespaces.join(',')
   const { data: countsData } = useQuery({
@@ -72,10 +68,8 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
       if (isSelectedCrd && selectedKind.group) params.set('group', selectedKind.group)
       const res = await fetch(`/api/resources/${selectedKind.name}?${params}`)
       if (!res.ok) {
-        if (res.status === 403) {
-          throw new ApiError('Insufficient permissions', 403)
-        }
-        return []
+        const errorData = await res.json().catch(() => ({ error: `HTTP ${res.status}` }))
+        throw new ApiError(errorData.error || `Failed to fetch ${selectedKind.name}`, res.status, errorData)
       }
       return res.json()
     },
@@ -134,7 +128,7 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
       resourceCounts={countsData?.counts}
       resourceForbidden={countsData?.forbidden}
       selectedKindQuery={selectedKindQueryResult}
-      onSelectedKindChange={handleSelectedKindChange}
+      onSelectedKindChange={setSelectedKind}
       topPodMetrics={topPodMetrics}
       topNodeMetrics={topNodeMetrics}
       certExpiry={certExpiry}


### PR DESCRIPTION
## Summary

Phase 1 of the large-cluster performance plan (follow-up to #273).

- **Sidebar counts**: The Resources page was firing ~233 parallel `GET /api/resources/{kind}` calls (608MB total) just to populate sidebar count badges. Now uses a single `GET /api/resource-counts` call (~2KB). Full resource data is only fetched for the currently selected kind.

- **Table virtualization**: Resource lists with thousands of items (e.g., 3,500 ReplicaSets → 35,000 DOM nodes) caused multi-second renders and scroll jank. Replaced `.map()` rendering with `TableVirtuoso` from react-virtuoso (already in deps). Only visible rows + buffer are rendered (~500 DOM nodes). Layout switches from CSS grid to `table-layout: fixed` with `<colgroup>`. Keyboard navigation and deep-link scrolling use `scrollToIndex()`.

New props on `ResourcesView` (`resourceCounts`, `resourceForbidden`, `selectedKindQuery`, `onSelectedKindChange`) are additive — the legacy `resourceQueries` array still works for backward compatibility.

## Test plan

- [ ] Open Resources page — sidebar counts load quickly, no waterfall of 233 requests in DevTools Network tab
- [ ] Click different resource kinds — table data loads for selected kind only
- [ ] With 1,000+ resources of one kind: smooth 60fps scrolling, no jank
- [ ] Column resize, sort, filter, search all work
- [ ] Keyboard navigation (j/k/Enter) scrolls to highlighted row
- [ ] Deep-linking (`/resources/pods?resource=...`) scrolls to correct row
- [ ] Small clusters (< 50 resources per kind) — no UX degradation