### PR TITLE
feat(topology): add PNG export button to topology controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2247,6 +2247,12 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
+    },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
@@ -3436,6 +3442,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
+        "html-to-image": "^1.11.0",
         "react-virtuoso": "^4.18.1",
         "shiki": "^4.0.0"
       },

--- a/packages/k8s-ui/package.json
+++ b/packages/k8s-ui/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
+    "html-to-image": "^1.11.0",
     "react-virtuoso": "^4.18.1",
     "shiki": "^4.0.0"
   },

--- a/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
+++ b/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
@@ -9,6 +9,7 @@ import {
   useReactFlow,
   useOnViewportChange,
   useNodes,
+  getViewportForBounds,
   type Node,
   type Edge,
   type NodeTypes,
@@ -17,8 +18,9 @@ import {
   MarkerType,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
+import { toCanvas } from 'html-to-image'
 
-import { AlertTriangle, RotateCw, Scissors, Shield } from 'lucide-react'
+import { AlertTriangle, Download, Loader2, RotateCw, Scissors, Shield } from 'lucide-react'
 import { useRegisterShortcuts } from '../../hooks/useKeyboardShortcuts'
 
 import { K8sResourceNode } from './K8sResourceNode'
@@ -629,10 +631,77 @@ export function TopologyGraph({
         <Controls
           className="bg-theme-surface border border-theme-border rounded-lg"
           showInteractive={false}
-        />
+        >
+          <ExportPngButton />
+        </Controls>
         <ViewportController structureKey={structureKey} />
       </ReactFlow>
     </ReactFlowProvider>
+  )
+}
+
+// Export topology as PNG button (must be inside ReactFlowProvider)
+function ExportPngButton() {
+  const [exporting, setExporting] = useState(false)
+  const { getNodes, getNodesBounds } = useReactFlow()
+
+  const handleExport = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation()
+    e.preventDefault()
+
+    const flowEl = document.querySelector('.react-flow__viewport') as HTMLElement
+    if (!flowEl) return
+
+    const nodes = getNodes()
+    if (nodes.length === 0) return
+
+    setExporting(true)
+    try {
+      const bounds = getNodesBounds(nodes)
+      const padding = 100
+      const w = Math.ceil(bounds.width + padding * 2)
+      const h = Math.ceil(bounds.height + padding * 2)
+      const vp = getViewportForBounds(bounds, w, h, 0.5, 2, padding)
+
+      const canvas = await toCanvas(flowEl, {
+        backgroundColor: '#0f172a',
+        width: w,
+        height: h,
+        pixelRatio: 2,
+        skipFonts: true,
+        style: {
+          width: `${w}px`,
+          height: `${h}px`,
+          transform: `translate(${vp.x}px, ${vp.y}px) scale(${vp.zoom})`,
+        },
+      })
+
+      canvas.toBlob((blob) => {
+        if (!blob) return
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        a.href = url
+        a.download = `topology-${new Date().toISOString().slice(0, 19).replace(/:/g, '-')}.png`
+        a.click()
+        setTimeout(() => URL.revokeObjectURL(url), 1000)
+      }, 'image/png')
+    } catch (err) {
+      console.error('Failed to export topology:', err)
+      alert('Failed to export: ' + (err instanceof Error ? err.message : String(err)))
+    } finally {
+      setExporting(false)
+    }
+  }, [getNodes, getNodesBounds])
+
+  return (
+    <button
+      className="react-flow__controls-button"
+      onClick={handleExport}
+      disabled={exporting}
+      title="Export as PNG"
+    >
+      {exporting ? <Loader2 className="w-3 h-3 animate-spin" /> : <Download className="w-3 h-3" />}
+    </button>
   )
 }
 


### PR DESCRIPTION
## Description

Add a download button to the topology view controls panel (bottom-left, alongside zoom buttons) that exports the full topology graph as a high-resolution PNG image (2x pixel ratio).
Uses `html-to-image` library (recommended by @xyflow/react docs) to capture the ReactFlow viewport, computing bounds aross all nodes to ensure the entire graph is included - not just the visible partion.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

Describe the tests you ran to verify your changes.

- [x] Tested locally with minikube/kind
- [x] Tested against a remote cluster
- [ ] Added/updated unit tests

Manually verified:
- Export button appears in topology controls (bottom-left0
- Clicking exports a timestamped PNG file (`topology-YYYY-MM-DDTTHH-MM-SS.png`)
- Exported image includes all nodes with 2x resolution (Retina quality)
- Button shows spinner during export and disables to prevent double-clicks
- Empty topology gracefully skips export (no crash)
- TypeScript type check passes (`npm run tsc`)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

## Related issues
none