### PR TITLE
fix: log download not working and missing user feedback

### DIFF
--- a/packages/k8s-ui/src/components/logs/LogCore.tsx
+++ b/packages/k8s-ui/src/components/logs/LogCore.tsx
@@ -262,7 +262,7 @@ export function LogCore({
         </Tooltip>
 
         {/* Download */}
-        <div className="relative" ref={downloadMenuRef}>
+        <div className="relative flex items-center" ref={downloadMenuRef}>
           <Tooltip content="Download logs" delay={TIP_DELAY} position="bottom">
             <button
               onClick={() => setShowDownloadMenu(prev => !prev)}

--- a/packages/k8s-ui/src/components/logs/LogsViewer.tsx
+++ b/packages/k8s-ui/src/components/logs/LogsViewer.tsx
@@ -7,6 +7,7 @@ import { ContainerSelect, LogRangeSelect } from './LogToolbarSelects'
 import { LogCore } from './LogCore'
 import type { DownloadFormat } from './LogCore'
 import { Tooltip } from '../ui/Tooltip'
+import { useToast } from '../ui/Toast'
 
 export interface LogsFetchParams {
   container: string
@@ -39,6 +40,7 @@ export function LogsViewer({
   const [fetchError, setFetchError] = useState<string | null>(null)
   const [logRange, setLogRange] = useState('500')
   const [showPrevious, setShowPrevious] = useState(false)
+  const { showError, showSuccess } = useToast()
 
   const { tailLines, sinceSeconds } = parseLogRange(logRange)
   const { entries, append, set, clear } = useLogBuffer()
@@ -83,6 +85,7 @@ export function LogsViewer({
   const downloadLogs = useCallback((format: DownloadFormat) => {
     let content: string
     let mime: string
+    const filename = `${podName}-${selectedContainer}-logs.${format}`
     switch (format) {
       case 'json':
         content = JSON.stringify(entries.map(l => ({ timestamp: l.timestamp, content: l.content, container: l.container })), null, 2)
@@ -98,8 +101,13 @@ export function LogsViewer({
         content = entries.map(l => `${l.timestamp} ${l.content}`).join('\n')
         mime = 'text/plain'
     }
-    triggerDownload(content, mime, `${podName}-${selectedContainer}-logs.${format}`)
-  }, [entries, podName, selectedContainer])
+    try {
+      triggerDownload(content, mime, filename)
+      showSuccess('Log download started', `Saving ${filename}. Check your browser or desktop Downloads location.`)
+    } catch (err) {
+      showError('Failed to download logs', err instanceof Error ? err.message : 'Unknown download error')
+    }
+  }, [entries, podName, selectedContainer, showError, showSuccess])
 
   const toolbarExtra = (
     <>

--- a/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
+++ b/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
@@ -8,6 +8,7 @@ import { ContainerSelect, LogRangeSelect } from './LogToolbarSelects'
 import { LogCore } from './LogCore'
 import type { DownloadFormat } from './LogCore'
 import type { WorkloadPodInfo } from '../../types'
+import { useToast } from '../ui/Toast'
 
 export interface WorkloadRawLog {
   pod: string
@@ -56,6 +57,7 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream }: WorkloadLog
   const [fetchError, setFetchError] = useState<string | null>(null)
   const [showPodFilter, setShowPodFilter] = useState(false)
   const [logRange, setLogRange] = useState('100')
+  const { showError, showSuccess } = useToast()
 
   const { tailLines, sinceSeconds } = parseLogRange(logRange)
   const { entries, append, set, clear } = useLogBuffer()
@@ -159,6 +161,7 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream }: WorkloadLog
   const downloadLogs = useCallback((format: DownloadFormat) => {
     let content: string
     let mime: string
+    const filename = `${name}-logs.${format}`
     switch (format) {
       case 'json':
         content = JSON.stringify(filteredEntries.map(l => ({
@@ -176,8 +179,13 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream }: WorkloadLog
         content = filteredEntries.map(l => `${l.timestamp} [${l.pod}/${l.container}] ${l.content}`).join('\n')
         mime = 'text/plain'
     }
-    triggerDownload(content, mime, `${name}-logs.${format}`)
-  }, [filteredEntries, name])
+    try {
+      triggerDownload(content, mime, filename)
+      showSuccess('Log download started', `Saving ${filename}. Check your browser or desktop Downloads location.`)
+    } catch (err) {
+      showError('Failed to download logs', err instanceof Error ? err.message : 'Unknown download error')
+    }
+  }, [filteredEntries, name, showError, showSuccess])
 
   const toolbarExtra = (
     <>

--- a/packages/k8s-ui/src/utils/download.ts
+++ b/packages/k8s-ui/src/utils/download.ts
@@ -1,10 +1,19 @@
-/** Triggers a file download in the browser. */
+/** Triggers a file download in the browser or desktop webview. */
 export function triggerDownload(content: string, mime: string, filename: string): void {
   const blob = new Blob([content], { type: mime })
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
+
   a.href = url
   a.download = filename
+  a.style.display = 'none'
+
+  document.body.appendChild(a)
   a.click()
-  URL.revokeObjectURL(url)
+
+  // Delay cleanup so embedded webviews still have time to consume the blob URL.
+  window.setTimeout(() => {
+    URL.revokeObjectURL(url)
+    a.remove()
+  }, 1000)
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -15,7 +15,7 @@ window.addEventListener('click', (e: MouseEvent) => {
   const anchor = (e.target as HTMLElement).closest?.('a[href]') as HTMLAnchorElement | null
   if (!anchor) return
   const href = anchor.href
-  if (!href || href.startsWith(window.location.origin) || href.startsWith('/') || href.startsWith('#')) return
+  if (!href || href.startsWith(window.location.origin) || href.startsWith('/') || href.startsWith('#') || href.startsWith('blob:')) return
   // External URL — open via system browser
   e.preventDefault()
   openExternal(href)


### PR DESCRIPTION
- Fix triggerDownload to append <a> to DOM and delay cleanup so downloads work reliably in browsers and desktop webviews
- Skip blob: URLs in the global click handler to prevent downloads from opening in a new tab
- Add toast notifications on download success/failure
- Align download button icon with other toolbar controls

Made-with: Cursor

## Description

Log downloads (TXT, JSON, CSV) were silently failing — clicking the download button produced no visible result. Root causes: the `<a>` element was not attached to the DOM before `.click()`, the blob URL was revoked immediately, and a global click handler in `main.tsx` was intercepting `blob:` URLs as external links (opening them in a new tab instead of downloading). Additionally, no user feedback was provided on success or failure, and the download icon was visually misaligned in the toolbar.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

- [x] Tested locally against a remote cluster
- Verified TXT, JSON, CSV downloads work in browser
- Verified toast notification appears on successful download
- Verified download icon alignment matches other toolbar buttons

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Related issues

Fixes #275