### PR TITLE
Fix deep link scroll with virtual scrolling

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -2707,21 +2707,20 @@ export function ResourcesView({
   filteredResourceCountRef.current = filteredResources.length
   highlightedResourceRef.current = highlightedIndex >= 0 ? filteredResources[highlightedIndex] ?? null : null
 
-  // Scroll to selected row when selection changes (but not on group expand/filteredResources change)
+  // Scroll to selected row when selection changes or data loads
   const lastScrolledResource = useRef<string | null>(null)
   useEffect(() => {
-    if (!selectedResource) return
+    if (!selectedResource || filteredResources.length === 0) return
     const resourceKey = `${selectedResource.kind}/${selectedResource.namespace}/${selectedResource.name}`
     if (lastScrolledResource.current === resourceKey) return
-    lastScrolledResource.current = resourceKey
 
     const timer = setTimeout(() => {
-      // Find the index of the selected resource in filtered list
       const idx = filteredResources.findIndex((r: any) =>
         r.metadata?.name === selectedResource.name &&
         r.metadata?.namespace === (selectedResource.namespace || '')
       )
       if (idx >= 0) {
+        lastScrolledResource.current = resourceKey
         virtuosoRef.current?.scrollToIndex({ index: idx, align: 'center', behavior: 'smooth' })
       }
     }, 100)


### PR DESCRIPTION
## Summary

Fixes deep link scroll-to-row broken by the virtual scrolling change in #277.

The scroll-to-selected effect was marking `lastScrolledResource` before data loaded, so when `filteredResources` populated the effect wouldn't re-fire. Now skips when `filteredResources` is empty and only marks as scrolled after a successful `scrollToIndex`.