### PR TITLE
feat(topology): improve export with dialog, WebP, and viewport capture

### DIFF
--- a/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
+++ b/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
@@ -681,6 +681,14 @@ const FORMAT_LABELS: Record<ImageFormat, string> = { 'image/png': 'PNG', 'image/
 const FORMAT_EXT: Record<ImageFormat, string> = { 'image/png': 'png', 'image/webp': 'webp' }
 
 const EXPORT_PADDING = 16
+const EXPORT_TIMEOUT_MS = 30_000
+
+function withTimeout<T>(promise: Promise<T>, ms: number, msg: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error(msg)), ms)),
+  ])
+}
 
 // Export topology as image button + dialog (must be inside ReactFlowProvider)
 function ExportImageButton({ onExportingChange }: { onExportingChange: (v: boolean) => void }) {
@@ -735,7 +743,7 @@ function ExportImageButton({ onExportingChange }: { onExportingChange: (v: boole
         const h = Math.ceil(bounds.height + EXPORT_PADDING * 2)
         const tx = -bounds.x + EXPORT_PADDING
         const ty = -bounds.y + EXPORT_PADDING
-        canvas = await toCanvas(flowEl, {
+        canvas = await withTimeout(toCanvas(flowEl, {
           backgroundColor: bgColor,
           width: w,
           height: h,
@@ -746,19 +754,19 @@ function ExportImageButton({ onExportingChange }: { onExportingChange: (v: boole
             height: `${h}px`,
             transform: `translate(${tx}px, ${ty}px) scale(1)`,
           },
-        })
+        }), EXPORT_TIMEOUT_MS, 'Export timed out — topology may be too large')
       } else {
         const flowContainer = document.querySelector('.react-flow') as HTMLElement
         if (!flowContainer) throw new Error('Topology container not found')
         const { width: vw, height: vh } = flowContainer.getBoundingClientRect()
 
-        canvas = await toCanvas(flowEl, {
+        canvas = await withTimeout(toCanvas(flowEl, {
           backgroundColor: bgColor,
           width: Math.ceil(vw),
           height: Math.ceil(vh),
           pixelRatio: scale,
           skipFonts: true,
-        })
+        }), EXPORT_TIMEOUT_MS, 'Export timed out — topology may be too large')
       }
 
       const ext = FORMAT_EXT[format]


### PR DESCRIPTION
## Summary

Follow-up to #278 — replaces the single-click PNG export with a full export dialog:

- **Export dialog** with filename (includes timestamp), format toggle (WebP/PNG), capture mode (entire graph vs visible area), quality selector, and transparent background option
- **Tight cropping** around nodes with minimal padding instead of excess whitespace
- **WebP support** for ~40% smaller files with lossless transparency when needed
- **Theme-aware background** via `getComputedStyle` instead of hardcoded dark color
- **Toast notifications** instead of `alert()` for success/error feedback with actionable messages
- **Loading overlay** with pulsing text during export
- **30s timeout** prevents stuck overlay if export hangs on very large topologies
- **`showExportButton` prop** so Skyhook can opt out of the export button
- **Fix `onlyRenderVisibleElements`** — temporarily disabled during full graph export so off-screen nodes are captured
- **Promise-based `toBlob`** — errors are properly caught instead of silently swallowed

## Test plan
- [ ] Click export button → dialog opens with timestamp filename
- [ ] Export full graph → tight crop, reasonable file size
- [ ] Export visible area at 1x/2x/3x → correct dimensions
- [ ] Toggle WebP/PNG → correct format and extension
- [ ] Enable transparent background → no background in exported image
- [ ] Toast shows file size on success, actionable message on error
- [ ] Escape/Enter keyboard shortcuts work in dialog
- [ ] Export overlay auto-clears after 30s if stuck