### PR TITLE
fix(files): wrap pod file browser commands in shell for PATH resolution

### DIFF
--- a/internal/server/copy.go
+++ b/internal/server/copy.go
@@ -57,7 +57,10 @@ func (s *Server) handlePodFileList(w http.ResponseWriter, r *http.Request) {
 	// Use find to list files — provides type, size, timestamp, permissions
 	// -maxdepth 1 lists only immediate children (like ls)
 	// Output format: type\tsize\ttimestamp\tpermissions\tpath
-	cmd := []string{"find", dirPath, "-maxdepth", "1", "-printf", `%y\t%s\t%T@\t%m\t%p\n`}
+	// Wrap in sh -c so the shell resolves PATH — direct exec via the container
+	// runtime can fail to find binaries that are available through the shell's PATH.
+	findCmd := fmt.Sprintf("find %s -maxdepth 1 -printf '%%y\\t%%s\\t%%T@\\t%%m\\t%%p\\n'", shellQuote(dirPath))
+	cmd := []string{"/bin/sh", "-c", findCmd}
 
 	req := client.CoreV1().RESTClient().Post().
 		Resource("pods").
@@ -110,7 +113,7 @@ func (s *Server) listFilesWithLS(r *http.Request, namespace, podName, container,
 	client := k8s.GetClient()
 	config := k8s.GetConfig()
 
-	cmd := []string{"ls", "-la", dirPath}
+	cmd := []string{"/bin/sh", "-c", fmt.Sprintf("ls -la %s", shellQuote(dirPath))}
 
 	req := client.CoreV1().RESTClient().Post().
 		Resource("pods").
@@ -503,6 +506,13 @@ func classifyExecError(findErr, lsErr string) string {
 
 	// Default: include the actual ls error so users can diagnose
 	return fmt.Sprintf("Failed to list files: %s", lsErr)
+}
+
+// shellQuote wraps a string in single quotes for safe use in sh -c commands.
+// Single quotes inside the string are escaped by ending the quote, adding an
+// escaped single quote, and re-opening the quote: ' → '\''
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
 // isCommandNotFound detects errors indicating a command is not available in the container


### PR DESCRIPTION
## Summary

Fixes the pod file browser failing with "Container lacks 'find' and 'ls' commands" even when those commands exist in the container and work fine from the terminal.

The root cause is that K8s exec API runs commands via `execve()` directly, which relies on the container runtime's PATH resolution. The terminal feature works because it launches `/bin/sh`, which resolves PATH from the container's environment. Some containers (e.g., Java apps with custom PATH in Dockerfile) have `find`/`ls` available through the shell but not discoverable by the runtime's direct exec.

The fix wraps `find` and `ls` commands in `/bin/sh -c "..."`, matching how the terminal resolves commands. Truly distroless containers (no shell) are already handled by the existing error classifier with a clear message.

Fixes #241