### PR TITLE
fix(ci): resolve Snyk failure for workspace dependency

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -50,9 +50,6 @@ jobs:
   snyk-node:
     name: Snyk Node
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: web
     steps:
       - uses: actions/checkout@v6
 
@@ -61,7 +58,6 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: web/package-lock.json
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- Snyk `monitor` was failing because `npm ci` ran inside `web/`, which can't resolve `@skyhook-io/k8s-ui` — a local workspace package defined in `packages/k8s-ui/`
- Fixed by running `npm ci` from the repo root where `"workspaces": ["web", "packages/*"]` is configured, so npm properly links workspace dependencies
- Snyk test/monitor steps still target `web/` via `working-directory`