### PR TITLE
fix: resources sidebar polish and density improvements

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -2196,6 +2196,14 @@ export function ResourcesView({
     }
     // Signal that initial resource param has been processed — URL update effect can now run
     hasProcessedInitialResource.current = true
+
+    // If the URL has no kind segment (e.g., /resources), update to include the default kind
+    const base = basePath.replace(/\/$/, '')
+    const path = window.location.pathname
+    if (path === base || path === base + '/') {
+      const search = window.location.search
+      window.history.replaceState({}, '', `${base}/${selectedKind.name}${search}`)
+    }
   }, []) // Only on mount
 
   // API resources for dynamic sidebar — provided via props
@@ -3039,18 +3047,16 @@ export function ResourcesView({
     <ResourcesViewDataContext.Provider value={resourcesViewDataContextValue}>
     <div className="flex h-full w-full">
       {/* Sidebar - Resource Types */}
-      <div className="w-72 bg-theme-surface border-r border-theme-border overflow-y-auto overflow-x-hidden shrink-0">
-        <div className="flex items-center gap-2 px-3 py-3 border-b border-theme-border">
-          <h2 className="text-sm font-medium text-theme-text-secondary uppercase tracking-wide shrink-0">
-            Resources
-          </h2>
-          <div className="flex-1 relative">
+      <div className="w-56 2xl:w-72 bg-theme-surface border-r border-theme-border overflow-y-auto overflow-x-hidden shrink-0">
+        <div className="px-2 py-2 border-b border-theme-border">
+          <div className="relative">
             <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-theme-text-tertiary" />
             <input
               type="text"
-              placeholder="Filter kinds..."
+              placeholder="Filter resources..."
               value={kindFilter}
               onChange={(e) => setKindFilter(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Escape') { setKindFilter(''); (e.target as HTMLInputElement).blur() } }}
               className="w-full pl-7 pr-7 py-2 bg-theme-elevated border border-theme-border-light rounded-lg text-sm text-theme-text-primary placeholder-theme-text-disabled focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
             {kindFilter && (
@@ -3077,7 +3083,7 @@ export function ResourcesView({
               )}
               <span className="flex-1 text-left">Favorites</span>
               {!favoritesExpanded && pinned.length > 0 && (
-                <span className="text-xs px-1.5 py-0.5 rounded bg-theme-elevated text-theme-text-secondary font-normal normal-case">
+                <span className={clsx('text-xs py-0.5 rounded bg-theme-elevated text-theme-text-secondary font-normal normal-case text-center', pinned.length < 1000 ? 'w-8' : 'w-9')}>
                   {pinned.length}
                 </span>
               )}
@@ -3123,7 +3129,7 @@ export function ResourcesView({
                 <div key={category.name} className="mb-2">
                   <button
                     onClick={() => toggleCategory(category.name)}
-                    className="w-full flex items-center gap-2 px-2 py-1.5 text-xs font-medium text-theme-text-tertiary hover:text-theme-text-secondary uppercase tracking-wide"
+                    className="w-full flex items-center gap-2 px-2 py-1.5 text-xs font-semibold text-theme-text-tertiary hover:text-theme-text-secondary uppercase tracking-wide"
                   >
                     {isExpanded ? (
                       <ChevronDown className="w-3 h-3" />
@@ -3132,7 +3138,7 @@ export function ResourcesView({
                     )}
                     <span className="flex-1 text-left">{category.name}</span>
                     {!isExpanded && (
-                      <span className="text-xs px-1.5 py-0.5 rounded bg-theme-elevated text-theme-text-secondary font-normal normal-case">
+                      <span className={clsx('text-xs py-0.5 rounded bg-theme-elevated text-theme-text-secondary font-normal normal-case text-center', category.total < 1000 ? 'w-8' : 'w-9')}>
                         {category.total}
                       </span>
                     )}
@@ -3779,7 +3785,7 @@ const ResourceTypeButton = forwardRef<HTMLButtonElement, ResourceTypeButtonProps
         ref={ref}
         onClick={onClick}
         className={clsx(
-          'w-full flex items-center gap-3 px-3 py-1.5 rounded-lg text-sm transition-colors group/kind min-w-0',
+          'w-full flex items-center gap-2 px-2 xl:px-3 py-1.5 rounded-lg text-sm transition-colors group/kind min-w-0',
           isSelected
             ? 'bg-blue-500/20 text-blue-700 dark:text-blue-300'
             : forbidden
@@ -3793,36 +3799,39 @@ const ResourceTypeButton = forwardRef<HTMLButtonElement, ResourceTypeButtonProps
             {resource.kind}
           </span>
         </Tooltip>
-        {forbidden ? (
-          <Tooltip content="Insufficient permissions" position="left">
-            <Shield className="w-3.5 h-3.5 text-amber-400/60" />
-          </Tooltip>
-        ) : (
-          <span className={clsx(
-            'text-xs px-1.5 py-0.5 rounded min-w-[1.5rem] text-center',
-            isSelected ? 'bg-blue-500/30 text-blue-700 dark:text-blue-300' : 'bg-theme-elevated'
-          )}>
-            {count}
-          </span>
-        )}
-        {onTogglePin && (
-          <span
-            role="button"
-            onClick={(e) => {
-              e.stopPropagation()
-              onTogglePin()
-            }}
-            className={clsx(
-              'ml-auto p-0.5 rounded transition-all shrink-0 hover:bg-theme-hover',
-              isPinned
-                ? 'text-theme-text-secondary'
-                : 'opacity-0 group-hover/kind:opacity-100 text-theme-text-disabled'
-            )}
-            title={isPinned ? 'Unpin from favorites' : 'Pin to favorites'}
-          >
-            <Pin className={clsx('w-3.5 h-3.5', isPinned && 'fill-current')} />
-          </span>
-        )}
+        <div className="ml-auto flex items-center gap-1 shrink-0">
+          {onTogglePin && (
+            <span
+              role="button"
+              onClick={(e) => {
+                e.stopPropagation()
+                onTogglePin()
+              }}
+              className={clsx(
+                'p-0.5 rounded transition-all hover:bg-theme-hover',
+                isPinned
+                  ? 'text-theme-text-secondary'
+                  : 'opacity-0 group-hover/kind:opacity-100 text-theme-text-disabled'
+              )}
+              title={isPinned ? 'Unpin from favorites' : 'Pin to favorites'}
+            >
+              <Pin className={clsx('w-3 h-3', isPinned && 'fill-current')} />
+            </span>
+          )}
+          {forbidden ? (
+            <Tooltip content="Insufficient permissions" position="left">
+              <Shield className="w-3.5 h-3.5 text-amber-400/60" />
+            </Tooltip>
+          ) : (
+            <span className={clsx(
+              'text-xs py-0.5 rounded text-center',
+              isSelected ? 'bg-blue-500/30 text-blue-700 dark:text-blue-300' : 'bg-theme-elevated',
+              count < 1000 ? 'w-8' : 'w-9'
+            )}>
+              {count}
+            </span>
+          )}
+        </div>
       </button>
     )
   }


### PR DESCRIPTION
## Summary

- Narrower sidebar on smaller screens (`w-56`, expands to `w-72` on 2xl) — gives more room to the main resource table
- Remove redundant "Resources" heading; search input takes full sidebar width
- Escape key clears filter input and blurs it
- Fixed-width count badges (`w-8`/`w-9`) prevent layout shift when counts change
- Bolder category headers (`font-semibold`) for better visual hierarchy
- Tighter spacing on smaller viewports with responsive padding
- Reorder pin icon before count badge in resource rows
- Fix bare `/resources` URL not updating to `/resources/pods` on mount (the `replaceState` was skipped because the URL update effect never re-fired after initial kind was set)