### PR TITLE
feat(pods): replace numeric Ready column with visual container squares

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -32,9 +32,9 @@ import type { NavigateToResource } from '../../utils/navigation'
 import { categorizeResources, CORE_RESOURCES } from '../../utils/api-resources'
 import {
   getPodStatus,
-  getPodReadiness,
   getPodRestarts,
   getPodProblems,
+  getContainerSquareStates,
   getWorkloadImages,
   getWorkloadConditions,
   getReplicaSetOwner,
@@ -242,7 +242,7 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
   pods: [
     { key: 'name', label: 'Name' },
     { key: 'namespace', label: 'Namespace', width: 'w-48' },
-    { key: 'ready', label: 'Ready', width: 'w-16' },
+    { key: 'containers', label: 'Containers', width: 'w-28' },
     { key: 'status', label: 'Status', width: 'w-40' },
     { key: 'cpu', label: 'CPU', width: 'w-40', tooltip: 'CPU usage / limit (marker = request)' },
     { key: 'memory', label: 'Memory', width: 'w-40', tooltip: 'Memory usage / limit (marker = request)' },
@@ -2441,13 +2441,15 @@ export function ResourcesView({
         return meta.creationTimestamp ? new Date(meta.creationTimestamp).getTime() : 0
       case 'status':
         return status.phase || ''
-      case 'ready':
-        // For pods, use ready/total ratio
+      case 'containers':
+        // Pod containers column — sort by readiness ratio
         if (status.containerStatuses) {
           const ready = status.containerStatuses.filter((c: any) => c.ready).length
           const total = status.containerStatuses.length
           return total > 0 ? ready / total : 0
         }
+        return 0
+      case 'ready':
         // For DaemonSets, use numberReady/desiredNumberScheduled
         if (kindLower === 'daemonsets') {
           const desired = status.desiredNumberScheduled ?? 0
@@ -4277,27 +4279,36 @@ function GenericCell({ resource, column }: { resource: any; column: string }) {
 // ============================================================================
 
 function PodCell({ resource, column }: { resource: any; column: string }) {
-  const phase = resource.status?.phase
-  const isCompleted = phase === 'Succeeded'
   const metrics = useContext(MetricsContext)
   const { onNavigate: navigate } = useContext(ResourcesViewDataContext)
 
   switch (column) {
-    case 'ready': {
-      const { ready, total } = getPodReadiness(resource)
-      const allReady = ready === total && total > 0
-      // Completed pods (Succeeded) show neutral color, not red
-      const color = isCompleted
-        ? 'text-theme-text-secondary'
-        : allReady
-          ? 'text-green-400'
-          : ready > 0
-            ? 'text-yellow-400'
-            : 'text-red-400'
+    case 'containers': {
+      const squares = getContainerSquareStates(resource)
+      const hasInit = squares.some(s => s.isInit)
       return (
-        <span className={clsx('text-sm font-medium', color)}>
-          {ready}/{total}
-        </span>
+        <div className="flex items-center gap-1">
+          {squares.map((sq, i) => {
+            const showSeparator = hasInit && i > 0 && sq.isInit !== squares[i - 1].isInit
+            const bgClass =
+              sq.status === 'ready' ? 'bg-green-500' :
+              sq.status === 'completed' ? 'bg-theme-text-tertiary/30 border border-theme-text-tertiary' :
+              sq.status === 'running' ? 'bg-yellow-500' :
+              sq.status === 'waiting' ? 'bg-red-500' :
+              sq.status === 'terminated' ? 'bg-red-500' :
+              'bg-theme-text-tertiary/30 border border-dashed border-theme-text-tertiary'
+            const ringClass = sq.restarts > 0 ? 'ring-2 ring-orange-400' : ''
+            const label = `${sq.isInit ? '(init) ' : ''}${sq.name}: ${sq.reason || sq.status}${sq.restarts > 0 ? ` (${sq.restarts} restarts)` : ''}`
+            return (
+              <React.Fragment key={i}>
+                {showSeparator && <div className="w-px h-3 bg-theme-text-tertiary/40 mx-0.5" />}
+                <Tooltip content={label}>
+                  <div className={clsx('w-2.5 h-2.5 rounded-sm', bgClass, ringClass)} />
+                </Tooltip>
+              </React.Fragment>
+            )
+          })}
+        </div>
       )
     }
     case 'status': {

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -197,6 +197,72 @@ export function getPodRestarts(pod: any): number {
   return containerStatuses.reduce((sum: number, c: any) => sum + (c.restartCount || 0), 0)
 }
 
+export interface ContainerSquareState {
+  name: string
+  status: 'ready' | 'running' | 'waiting' | 'completed' | 'terminated' | 'unknown'
+  restarts: number
+  reason?: string
+  isInit?: boolean
+}
+
+export function getContainerSquareStates(pod: any): ContainerSquareState[] {
+  const result: ContainerSquareState[] = []
+  const initStatuses = pod.status?.initContainerStatuses || []
+  const containerStatuses = pod.status?.containerStatuses || []
+  const specContainers = pod.spec?.containers || []
+
+  for (const cs of initStatuses) {
+    const stateKey = cs.state ? Object.keys(cs.state)[0] : 'unknown'
+    let status: ContainerSquareState['status'] = 'unknown'
+    if (stateKey === 'terminated' && cs.state?.terminated?.exitCode === 0) {
+      status = 'completed'
+    } else if (stateKey === 'running') {
+      status = cs.ready ? 'ready' : 'running'
+    } else if (stateKey === 'waiting') {
+      status = 'waiting'
+    } else if (stateKey === 'terminated') {
+      status = 'terminated'
+    }
+    result.push({
+      name: cs.name,
+      status,
+      restarts: cs.restartCount || 0,
+      reason: cs.state?.[stateKey]?.reason,
+      isInit: true,
+    })
+  }
+
+  if (containerStatuses.length > 0) {
+    for (const cs of containerStatuses) {
+      const stateKey = cs.state ? Object.keys(cs.state)[0] : 'unknown'
+      let status: ContainerSquareState['status'] = 'unknown'
+      if (stateKey === 'running' && cs.ready) {
+        status = 'ready'
+      } else if (stateKey === 'running') {
+        status = 'running'
+      } else if (stateKey === 'terminated' && cs.state?.terminated?.exitCode === 0) {
+        status = 'completed'
+      } else if (stateKey === 'terminated') {
+        status = 'terminated'
+      } else if (stateKey === 'waiting') {
+        status = 'waiting'
+      }
+      result.push({
+        name: cs.name,
+        status,
+        restarts: cs.restartCount || 0,
+        reason: cs.state?.[stateKey]?.reason,
+      })
+    }
+  } else {
+    for (const c of specContainers) {
+      result.push({ name: c.name, status: 'unknown', restarts: 0 })
+    }
+  }
+
+  return result
+}
+
 // ============================================================================
 // WORKLOAD UTILITIES (Deployment, StatefulSet, DaemonSet, ReplicaSet)
 // ============================================================================


### PR DESCRIPTION
Hey @nadaverell ! I'd like to propose a rethinking of how container status is displayed in the pods table. Currently the numeric format (e.g. 1/2) isn't always clear — for example, it shows orange even when one container has simply completed successfully, which can be misleading. This visual approach with per-container squares gives a much quicker and more intuitive understanding of what's actually going on with each container.

## Description

Replace the numeric `Ready` column (e.g. `1/2`) in the pods table with a visual `Containers` column showing per-container colored squares. The numeric format was confusing — a pod with one running container and one completed container shows `1/2` in orange, implying something is wrong when it's actually fine. The square-based approach (inspired by Lens/OpenLens) gives immediate per-container visibility at a glance.

**Container square states:**
- 🟢 **Green** — running & ready
- ⬜ **White/outlined** — completed (terminated with exit code 0)
- 🟡 **Yellow** — running but not yet ready
- 🔴 **Red** — error (CrashLoopBackOff, OOMKilled, terminated with error)
- 🟠 **Orange ring** — container has restarts
- ⬜ **Dashed outline** — unknown state

Init containers are displayed before regular containers, separated by a vertical divider. Each square has a tooltip showing container name, state, and restart count.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## How has this been tested?

- [x] Tested locally with minikube/kind
- Verified pods with all containers ready show green squares
- Verified completed pods (Jobs) show white/outlined squares
- Verified pods with restarts show orange ring on affected containers
- Verified pods with init containers show separator between init and regular containers
- Verified column sorting still works (sorts by readiness ratio)
- Verified TypeScript compiles with no errors

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

<img width="140" height="259" alt="image" src="https://github.com/user-attachments/assets/00efc1ea-9546-4867-92b5-d8e39981f044" />
