### PR TITLE
fix: merge CRD discovery indicator into connection status dot

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -545,7 +545,7 @@ function AppInner() {
                   !connected
                     ? 'Disconnected'
                     : crdDiscoveryStatus === 'discovering'
-                      ? 'Connected — discovering CRDs...'
+                      ? 'Connected — discovering Custom Resources...'
                       : 'Connected'
                 }
                 delay={100}
@@ -562,7 +562,11 @@ function AppInner() {
                 />
               </Tooltip>
               <span className="text-xs text-theme-text-tertiary hidden xl:inline">
-                {connected ? 'Connected' : 'Disconnected'}
+                {!connected
+                  ? 'Disconnected'
+                  : crdDiscoveryStatus === 'discovering'
+                    ? 'Discovering Custom Resources...'
+                    : 'Connected'}
               </span>
               {!connected && (
                 <button


### PR DESCRIPTION
## Summary
- The "Discovering CRDs..." text + spinner in the header right section overlapped with the center nav tabs on laptop-size screens (~1024-1280px)
- Removed the standalone indicator and merged CRD discovery state into the existing connection status dot
- Dot is now amber with pulse animation during CRD discovery, green when ready, red when disconnected
- Tooltip on hover shows the detailed state ("Connected — discovering CRDs...", etc.)