### PR TITLE
docs: comprehensive documentation sync with codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,9 +43,9 @@ radar/
 │   ├── explorer/              # CLI entry point (main.go)
 │   └── desktop/               # Desktop app entry point (Wails v2)
 ├── internal/
-│   ├── ai/
-│   │   └── context/           # AI context minification for LLM-friendly output
 │   ├── app/                   # Application lifecycle management
+│   ├── config/                # Configuration management
+│   ├── errorlog/              # Error logging utilities
 │   ├── helm/                  # Helm client integration
 │   │   ├── client.go          # Helm SDK wrapper
 │   │   ├── handlers.go        # HTTP handlers for Helm operations
@@ -69,41 +69,65 @@ radar/
 │   │   ├── fetch.go           # Resource fetching for AI/MCP consumers
 │   │   ├── metrics.go         # Pod/node metrics collection
 │   │   ├── metrics_history.go # Metrics history tracking
+│   │   ├── problems.go        # Problem detection
 │   │   ├── subsystems.go      # Cache subsystem management
-│   │   └── update.go          # Resource update/delete operations
+│   │   ├── topology_adapter.go # Topology adaptation layer
+│   │   ├── update.go          # Resource update/delete operations
+│   │   └── workload.go        # Workload operations (restart, scale, rollback)
 │   ├── mcp/                   # MCP (Model Context Protocol) server
 │   │   ├── server.go          # MCP HTTP handler setup
-│   │   ├── tools.go           # MCP tool definitions (7 tools)
+│   │   ├── tools.go           # MCP tool definitions (14 tools)
+│   │   ├── tools_helm.go      # Helm-specific MCP tools
+│   │   ├── tools_gitops.go    # GitOps-specific MCP tools
+│   │   ├── tools_workloads.go # Workload-specific MCP tools
 │   │   └── resources.go       # MCP resource definitions (3 resources)
+│   ├── opencost/              # OpenCost integration (cost analysis)
+│   │   ├── handlers.go        # HTTP handlers for cost endpoints
+│   │   └── types.go           # Cost data types
+│   ├── prometheus/            # Prometheus client integration
+│   │   ├── client.go          # Prometheus API client
+│   │   ├── discovery.go       # Auto-discovery of Prometheus/VictoriaMetrics
+│   │   ├── handlers.go        # HTTP handlers for Prometheus endpoints
+│   │   └── queries.go         # PromQL query helpers
 │   ├── server/
 │   │   ├── server.go          # chi router, main REST endpoints
 │   │   ├── sse.go             # Server-Sent Events broadcaster
 │   │   ├── certificate.go     # TLS certificate parsing and expiry
+│   │   ├── copy.go            # Copy operations
+│   │   ├── desktop_open_url.go # Desktop URL handling
+│   │   ├── desktop_update.go  # Desktop app auto-update handlers
+│   │   ├── diagnostics.go     # Diagnostics endpoints
 │   │   ├── exec.go            # WebSocket pod terminal exec
 │   │   ├── logs.go            # Pod logs streaming
 │   │   ├── workload_logs.go   # Workload-level log aggregation
 │   │   ├── portforward.go     # Port forwarding sessions
+│   │   ├── resource_counts.go # Resource counting
 │   │   ├── dashboard.go       # Dashboard summary endpoint
 │   │   ├── argo_handlers.go   # ArgoCD sync/refresh/suspend handlers
 │   │   ├── flux_handlers.go   # FluxCD reconcile/suspend handlers
 │   │   ├── gitops_types.go    # Shared GitOps request/response types
 │   │   ├── ai_handlers.go     # AI resource preview endpoints
-│   │   ├── traffic_handlers.go # Service mesh traffic flow handlers
-│   │   └── desktop_update.go  # Desktop app auto-update handlers
+│   │   └── traffic_handlers.go # Service mesh traffic flow handlers
+│   ├── settings/              # Application settings management
 │   ├── static/                # Embedded frontend files
-│   ├── timeline/              # Timeline event storage (memory/SQLite)
-│   ├── topology/
-│   │   ├── builder.go         # Topology graph construction
-│   │   ├── pod_grouping.go    # Pod grouping/collapsing logic
-│   │   ├── relationships.go   # Resource relationship detection
-│   │   └── types.go           # Node, edge, topology definitions
 │   ├── traffic/               # Service mesh traffic analysis
 │   ├── updater/               # Binary self-update logic
 │   └── version/               # Version information
 ├── pkg/
-│   └── k8score/               # Shared K8s caching layer (informers, listers, transforms)
+│   ├── ai/
+│   │   └── context/           # AI context minification for LLM-friendly output
+│   ├── gitops/                # GitOps operations abstraction
+│   ├── k8score/               # Shared K8s caching layer (informers, listers, transforms)
+│   ├── portforward/           # Port forwarding logic
+│   ├── timeline/              # Timeline event storage (memory/SQLite)
+│   └── topology/
+│       ├── builder.go         # Topology graph construction
+│       ├── certificates.go    # Certificate relationship detection
+│       ├── pod_grouping.go    # Pod grouping/collapsing logic
+│       ├── relationships.go   # Resource relationship detection
+│       └── types.go           # Node, edge, topology definitions
 ├── packages/
-│   └── k8s-ui/                # Shared UI package (@skyhook/k8s-ui)
+│   └── k8s-ui/                # Shared UI package (@skyhook-io/k8s-ui)
 │       └── src/
 │           ├── components/
 │           │   ├── resources/  # ResourcesView, resource-utils, renderers
@@ -128,10 +152,14 @@ radar/
 │   │   │   ├── portforward/   # Port forward manager
 │   │   │   ├── resource/      # Single resource detail page
 │   │   │   ├── resource-drawer/ # Resource drawer overlay
-│   │   │   ├── resources/     # Resource list panels (thin wrappers over @skyhook/k8s-ui)
+│   │   │   ├── resources/     # Resource list panels (thin wrappers over @skyhook-io/k8s-ui)
+│   │   │   ├── cost/           # Cost tracking and visualization
+│   │   │   ├── settings/      # Settings dialog
+│   │   │   ├── shared/        # Shared components (namespace picker, YAML editor)
 │   │   │   ├── timeline/      # Timeline view (activity & changes)
 │   │   │   ├── topology/      # Graph visualization
 │   │   │   ├── traffic/       # Traffic flow visualization
+│   │   │   ├── workload/      # Workload detail view
 │   │   │   └── ui/            # Base shadcn/ui components
 │   │   ├── context/           # React contexts (connection, theme, context-switch)
 │   │   ├── contexts/          # React contexts (capabilities)
@@ -238,6 +266,7 @@ make clean          # Remove build artifacts
 --debug-events      Enable verbose event debugging (logs all event drops)
 --fake-in-cluster   Simulate in-cluster mode for testing (shows kubectl copy buttons instead of port-forward)
 --disable-helm-write Simulate restricted Helm permissions (disables install/upgrade/rollback/uninstall)
+--disable-exec      Simulate restricted exec permissions (disables terminal, debug shell)
 --no-mcp            Disable MCP (Model Context Protocol) server for AI tools
 ```
 
@@ -249,6 +278,7 @@ GET  /api/health                              # Health check with resource count
 GET  /api/version-check                       # Check for newer radar versions
 GET  /api/dashboard                           # Dashboard summary (counts, health)
 GET  /api/dashboard/crds                      # CRD summary for dashboard
+GET  /api/dashboard/helm                      # Helm release status for dashboard
 GET  /api/cluster-info                        # Platform detection (GKE, EKS, AKS, etc.)
 GET  /api/capabilities                        # Cluster capability flags
 GET  /api/namespaces                          # List all namespaces
@@ -258,6 +288,15 @@ POST /api/connection/retry                    # Retry failed connection
 GET  /api/contexts                            # List kubeconfig contexts
 POST /api/contexts/{name}                     # Switch kubeconfig context
 GET  /api/sessions                            # List active sessions
+GET  /api/diagnostics                         # Diagnostic information
+GET  /api/resource-counts                     # Resource count summary by kind
+GET  /api/settings                            # Get application settings
+PUT  /api/settings                            # Update application settings
+GET  /api/config                              # Get running configuration
+PUT  /api/config                              # Update configuration
+GET  /api/github/starred                      # Get GitHub star status
+POST /api/github/star                         # Star on GitHub
+POST /api/github/dismiss                      # Dismiss GitHub star prompt
 ```
 
 ### Topology
@@ -300,6 +339,17 @@ GET  /api/pods/{ns}/{name}/logs               # Fetch pod logs (non-streaming)
 GET  /api/pods/{ns}/{name}/logs/stream        # Stream pod logs via SSE
 GET  /api/pods/{ns}/{name}/exec               # WebSocket for pod terminal exec
 POST /api/pods/{ns}/{name}/debug              # Create ephemeral debug container
+GET  /api/pods/{ns}/{name}/files              # List files in pod container
+GET  /api/pods/{ns}/{name}/files/download     # Download file from pod container
+```
+
+### Node Operations
+```
+POST /api/nodes/{name}/debug                  # Create ephemeral debug pod on node
+DELETE /api/nodes/{name}/debug                # Cleanup node debug pod
+POST /api/nodes/{name}/cordon                 # Mark node as unschedulable
+POST /api/nodes/{name}/uncordon               # Mark node as schedulable
+POST /api/nodes/{name}/drain                  # Cordon + evict all non-DaemonSet pods
 ```
 
 ### Workload Operations
@@ -326,6 +376,8 @@ GET  /api/metrics/pods/{ns}/{name}            # Current pod metrics
 GET  /api/metrics/pods/{ns}/{name}/history    # Pod metrics history
 GET  /api/metrics/nodes/{name}                # Current node metrics
 GET  /api/metrics/nodes/{name}/history        # Node metrics history
+GET  /api/metrics/top/pods                    # Top pods by resource usage
+GET  /api/metrics/top/nodes                   # Top nodes by resource usage
 ```
 
 ### Port Forwarding
@@ -356,6 +408,8 @@ GET    /api/helm/releases/{ns}/{name}/upgrade-info # Check upgrade availability
 GET    /api/helm/upgrade-check                     # Batch check for upgrades
 POST   /api/helm/releases/{ns}/{name}/rollback     # Rollback to previous revision
 POST   /api/helm/releases/{ns}/{name}/upgrade      # Upgrade to new version
+POST   /api/helm/releases/{ns}/{name}/upgrade-stream # Upgrade with streaming progress
+POST   /api/helm/releases/{ns}/{name}/rollback-stream # Rollback with streaming progress
 POST   /api/helm/releases/{ns}/{name}/values/preview # Preview values change
 PUT    /api/helm/releases/{ns}/{name}/values       # Apply values change
 DELETE /api/helm/releases/{ns}/{name}              # Uninstall release
@@ -393,6 +447,9 @@ POST /api/flux/{kind}/{ns}/{name}/resume          # Resume reconciliation
 ### Cost (OpenCost)
 ```
 GET  /api/opencost/summary                    # Namespace-level cost summary (requires OpenCost + Prometheus)
+GET  /api/opencost/workloads                  # Workload-level cost breakdown for a namespace
+GET  /api/opencost/trend                      # Cost trend data over time
+GET  /api/opencost/nodes                      # Per-node cost breakdown
 ```
 
 ### Traffic (Service Mesh)
@@ -412,6 +469,7 @@ GET  /api/traffic/connection                  # Traffic connection status
 POST /api/desktop/update                      # Start desktop app update download
 GET  /api/desktop/update/status               # Check update download progress
 POST /api/desktop/update/apply                # Apply downloaded update
+POST /api/desktop/open-url                    # Open URL in system browser (desktop only)
 ```
 
 ### Debug
@@ -443,7 +501,7 @@ GET  /api/ai/resources/{kind}/{ns}/{name}     # Minified single resource (verbos
 - Memory-efficient with field stripping (removes managed fields, last-applied annotations)
 - Change notifications via channel for real-time SSE updates
 - Application-specific behavior injected via `CacheConfig` callbacks: `OnChange`, `OnEventChange`, `OnReceived`, `OnDrop`, `ComputeDiff`, `IsNoisyResource`
-- Supports: Pods, Services, Deployments, DaemonSets, StatefulSets, ReplicaSets, Ingresses, ConfigMaps, Secrets, Events, Jobs, CronJobs, HorizontalPodAutoscalers, PersistentVolumeClaims, PersistentVolumes, StorageClasses, PodDisruptionBudgets, Nodes, Namespaces
+- Supports: Pods, Services, Deployments, DaemonSets, StatefulSets, ReplicaSets, Ingresses, IngressClasses, ConfigMaps, Secrets, Events, Jobs, CronJobs, HorizontalPodAutoscalers, PersistentVolumeClaims, PersistentVolumes, StorageClasses, PodDisruptionBudgets, ServiceAccounts, Nodes, Namespaces
 
 ### Server-Sent Events (SSE)
 - Central `SSEBroadcaster` manages connected clients
@@ -465,9 +523,9 @@ GET  /api/ai/resources/{kind}/{ns}/{name}     # Minified single resource (verbos
 - Two view modes:
   - `traffic`: Network flow (Ingress/Gateway → HTTPRoute → Service → Pod, also IstioGateway → VirtualService → Service, also IngressRoute → TraefikService → Service)
   - `resources`: Full hierarchy (Deployment → ReplicaSet → Pod)
-- Node types: Ingress, Gateway, HTTPRoute, GRPCRoute, TCPRoute, TLSRoute, Service, Deployment, DaemonSet, StatefulSet, ReplicaSet, Pod, Job, CronJob, ConfigMap, Secret, HorizontalPodAutoscaler, PersistentVolumeClaim, PersistentVolume, StorageClass, PodDisruptionBudget, VerticalPodAutoscaler
+- Node types: Internet, Ingress, Gateway, GatewayClass, HTTPRoute, GRPCRoute, TCPRoute, TLSRoute, Service, Deployment, DaemonSet, StatefulSet, ReplicaSet, Pod, Job, CronJob, ConfigMap, Secret, HorizontalPodAutoscaler, PersistentVolumeClaim, PersistentVolume, StorageClass, PodDisruptionBudget, VerticalPodAutoscaler, Rollout (Argo), Node, Namespace, NodePool, NodeClaim, NodeClass (Karpenter), ScaledObject, ScaledJob (KEDA)
 - Edge type semantics (these drive UI grouping in Related Resources): `EdgeManages` (owner), `EdgeUses` (autoscalers like HPA/VPA/KEDA → Scalers group), `EdgeProtects` (PDB → Policies group), `EdgeConfigures` (ConfigMap/Secret/DestinationRule), `EdgeExposes` (Service/Ingress/Gateway/VirtualService). Choose the right edge type — don't reuse one just because the code pattern is similar.
-- Istio service mesh nodes: VirtualService, DestinationRule, IstioGateway (note: uses "istiogateway" node ID prefix to disambiguate from Gateway API's "gateway"), ServiceEntry, PeerAuthentication, AuthorizationPolicy
+- Istio service mesh nodes: VirtualService, DestinationRule, IstioGateway (note: uses "istiogateway" node ID prefix to disambiguate from Gateway API's "gateway")
   - VirtualService → Service edges (EdgeExposes, via spec.http/tcp/tls route destinations, parses short/FQDN Istio host format)
   - Istio Gateway → VirtualService edges (EdgeExposes, via spec.gateways[] references)
   - DestinationRule → Service edges (EdgeConfigures, via spec.host)
@@ -522,11 +580,11 @@ GET  /api/ai/resources/{kind}/{ns}/{name}     # Minified single resource (verbos
 
 ### MCP Server
 - Stateless HTTP handler mounted at `/mcp` (JSON-RPC over HTTP)
-- 14 tools organized into read and write categories:
+- 15 tools organized into read and write categories:
   - **Read tools** (8): `get_dashboard` (with problem-correlated changes), `list_resources`, `get_resource` (with optional `include`: events, relationships, metrics, logs), `get_topology` (with `format`: graph or summary), `get_events` (with optional `kind`/`name` resource filter), `get_pod_logs`, `list_namespaces`, `get_changes` (timeline of resource mutations)
   - **Read tools — Helm** (2): `list_helm_releases`, `get_helm_release` (with optional values/history/diff)
   - **Read tools — Logs** (1): `get_workload_logs` (aggregated, AI-filtered logs across all pods)
-  - **Write tools** (3): `manage_workload` (restart/scale/rollback), `manage_cronjob` (trigger/suspend/resume), `manage_gitops` (ArgoCD sync/suspend/resume, FluxCD reconcile/suspend/resume)
+  - **Write tools** (4): `manage_workload` (restart/scale/rollback), `manage_cronjob` (trigger/suspend/resume), `manage_gitops` (ArgoCD sync/suspend/resume, FluxCD reconcile/suspend/resume), `manage_node` (cordon/uncordon/drain)
 - 3 resources: `cluster://health`, `cluster://topology`, `cluster://events`
 - Tool annotations: read-only tools use `readOnlyHint`, write tools use `destructiveHint: false`
 - Respects cluster RBAC
@@ -583,23 +641,46 @@ useMutation({
 
 Error responses are parsed as `{"error": "message"}` and displayed in toasts.
 
-### Shared UI Package (@skyhook/k8s-ui)
+### Shared UI Package (@skyhook-io/k8s-ui)
 - Located at `packages/k8s-ui/` — shared presentation components decoupled from data fetching
 - Components in the package are pure: data fetching hooks live in `web/`, injected via props/callbacks
 - `web/src/components/resources/ResourcesView.tsx` is a thin wrapper that instantiates hooks and passes data to the package's `ResourcesView`
-- Linked via npm workspaces; Vite aliases `@skyhook/k8s-ui` to `../packages/k8s-ui/src` (source-level, no build step)
+- Linked via npm workspaces; Vite aliases `@skyhook-io/k8s-ui` to `../packages/k8s-ui/src` (source-level, no build step)
 - Key exports: `ResourcesView`, `ResourceRendererDispatch`, `ResourceActionsBar`, `EditableYamlView`, all renderers, resource-utils, `categorizeResources`, `getKindLabel`, `getKindPlural`
 
 ### Resource Renderers
 - **Adding a new CRD integration? See [docs/INTEGRATION_GUIDE.md](docs/INTEGRATION_GUIDE.md)** for the full step-by-step checklist with all files, patterns, and collision gotchas.
 - Renderers, resource-utils, and table column config live in `packages/k8s-ui/src/components/resources/`
 - Sections with data should use `defaultExpanded` (true) — only collapse empty or low-priority sections
-- Register in: `packages/k8s-ui/src/components/resources/renderers/index.ts` (export), `web/src/components/resources/ResourceDetailDrawer.tsx` (import + knownKinds + render line + `getResourceStatus()`)
+- Register in: `packages/k8s-ui/src/components/resources/renderers/index.ts` (export), `packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx` (KNOWN_KINDS + render line + `getResourceStatus()`)
 - Use `AlertBanner` for problem detection, `ConditionsSection` for K8s conditions
 - Long text in alerts/banners needs `break-all` class for CSS word breaking
-- **Kind collision rule:** When a CRD kind collides with a core K8s kind (e.g., Knative Service vs core Service), you must guard THREE places in `ResourceDetailDrawer.tsx`: (1) the core renderer line, (2) `getResourceStatus()`, (3) action buttons (Port Forward, etc.). Use `data?.apiVersion?.includes('group.name')` checks. Missing any one causes dual rendering bugs.
-- Core K8s renderers: Role, ClusterRole, RoleBinding, ClusterRoleBinding, ServiceAccount, IngressClass, PriorityClass, RuntimeClass, Lease, MutatingWebhookConfiguration, ValidatingWebhookConfiguration
-- CRD integrations: Argo Rollouts, Argo Workflows, cert-manager, Gateway API, Sealed Secrets, FluxCD, ArgoCD, Trivy, Karpenter, KEDA, VPA, Prometheus Operator, Kyverno, Velero, External Secrets, CloudNativePG, Knative, Istio, Traefik
+- **Kind collision rule:** When a CRD kind collides with a core K8s kind (e.g., Knative Service vs core Service), you must guard THREE places in `ResourceRendererDispatch.tsx`: (1) the core renderer line, (2) `getResourceStatus()`, (3) action buttons (Port Forward, etc.). Use `data?.apiVersion?.includes('group.name')` checks. Missing any one causes dual rendering bugs.
+- Core K8s renderers: Pod, Service, ConfigMap, Secret, Ingress, PersistentVolume, ReplicaSet, StorageClass, NetworkPolicy, Event, Workload (Deployment/StatefulSet/DaemonSet), Role, ClusterRole, RoleBinding, ClusterRoleBinding, ServiceAccount, IngressClass, PriorityClass, RuntimeClass, Lease, MutatingWebhookConfiguration, ValidatingWebhookConfiguration
+- CRD integrations (88 renderer components total):
+
+  | Integration | Rendered Kinds |
+  |-------------|---------------|
+  | **Argo Rollouts** | Rollout |
+  | **Argo Workflows** | Workflow, WorkflowTemplate |
+  | **ArgoCD** | Application |
+  | **cert-manager** | Certificate, CertificateRequest, Issuer, ClusterIssuer, Order, Challenge |
+  | **CloudNativePG** | Cluster, Backup, ScheduledBackup, Pooler |
+  | **External Secrets** | ExternalSecret, ClusterExternalSecret, SecretStore |
+  | **FluxCD** | HelmRelease, Kustomization, GitRepository, HelmRepository, OCIRepository, Alert |
+  | **Gateway API** | Gateway, HTTPRoute, GRPCRoute |
+  | **Istio** | VirtualService, DestinationRule, Gateway, ServiceEntry, PeerAuthentication, AuthorizationPolicy |
+  | **Karpenter** | NodePool, NodeClaim, EC2NodeClass |
+  | **KEDA** | ScaledObject, ScaledJob, TriggerAuthentication |
+  | **Knative Serving** | Service, Configuration, Revision, Route, DomainMapping, Ingress, Certificate, ServerlessService |
+  | **Knative Eventing** | Broker, Trigger, Subscription, Channel, InMemoryChannel, Sequence, Parallel, PingSource, ContainerSource, SinkBinding, EventType |
+  | **Kyverno** | PolicyReport |
+  | **Prometheus Operator** | ServiceMonitor, PodMonitor, PrometheusRule |
+  | **Sealed Secrets** | SealedSecret |
+  | **Traefik** | IngressRoute |
+  | **Trivy** | VulnerabilityReport, ConfigAuditReport, ExposedSecretReport, SbomReport, ClusterComplianceReport |
+  | **Velero** | Backup, Schedule, Restore, BackupStorageLocation, VolumeSnapshotLocation |
+  | **VPA** | VerticalPodAutoscaler |
 
 ## Tech Stack
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,25 +82,35 @@ npm run tsc
 ### Building
 
 ```bash
-# Full build (frontend + embedded binary)
+# Full build (frontend + embed + binary)
 make build
 
-# Backend only
-go build -o radar ./cmd/explorer
+# Frontend only (builds to web/dist)
+cd web && npm run build
 
-# Frontend only
-cd web
-npm run build
+# IMPORTANT: Never run `go build` directly after `npm run build` —
+# it skips the embed step that copies web/dist → internal/static/dist.
+# Always use `make build` for a complete build.
 ```
 
 ## Project Structure
 
 ```
-├── cmd/explorer/       # CLI entry point
+├── cmd/
+│   ├── explorer/       # CLI entry point
+│   └── desktop/        # Desktop app entry point (Wails v2)
 ├── internal/
 │   ├── k8s/           # Kubernetes client and caching
 │   ├── server/        # HTTP server, REST API, SSE
-│   └── topology/      # Graph construction logic
+│   ├── helm/          # Helm SDK client and handlers
+│   ├── mcp/           # MCP (Model Context Protocol) server
+│   └── ...            # opencost, prometheus, config, settings, traffic
+├── pkg/
+│   ├── k8score/       # Shared K8s caching layer (informers, listers)
+│   ├── topology/      # Graph construction and relationships
+│   ├── ai/context/    # AI context minification
+│   └── timeline/      # Timeline event storage
+├── packages/k8s-ui/   # Shared UI package (@skyhook-io/k8s-ui)
 ├── web/               # React frontend
 │   ├── src/
 │   │   ├── api/       # API client and hooks

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -50,14 +50,30 @@ make desktop-package-darwin  # Package macOS .app bundle
 
 ```
 radar/
-├── cmd/explorer/           # CLI entry point (main.go)
+├── cmd/
+│   ├── explorer/           # CLI entry point (main.go)
+│   └── desktop/            # Desktop app entry point (Wails v2)
 ├── internal/
-│   ├── k8s/               # Kubernetes client, informers, caching
-│   ├── server/            # HTTP server, REST API, SSE, WebSocket
-│   ├── topology/          # Graph construction and relationships
+│   ├── app/               # Application lifecycle management
+│   ├── config/            # Persistent configuration (~/.radar/config.json)
 │   ├── helm/              # Helm SDK client and handlers
-│   ├── traffic/           # Traffic visualization (Caretta, Hubble)
-│   └── static/            # Embedded frontend (built from web/)
+│   ├── images/            # Container image inspection
+│   ├── k8s/               # Kubernetes client, informers, caching
+│   ├── mcp/               # MCP (Model Context Protocol) server
+│   ├── opencost/          # OpenCost integration (cost analysis)
+│   ├── prometheus/        # Prometheus client and discovery
+│   ├── server/            # HTTP server, REST API, SSE, WebSocket
+│   ├── settings/          # User preferences (~/.radar/settings.json)
+│   ├── static/            # Embedded frontend (built from web/)
+│   ├── traffic/           # Traffic visualization (Hubble, Caretta, Istio)
+│   └── ...                # errorlog, updater, version
+├── pkg/
+│   ├── ai/context/        # AI context minification for LLM-friendly output
+│   ├── k8score/           # Shared K8s caching layer (informers, listers)
+│   ├── timeline/          # Timeline event storage (memory/SQLite)
+│   └── topology/          # Graph construction and relationships
+├── packages/
+│   └── k8s-ui/            # Shared UI package (@skyhook-io/k8s-ui)
 ├── web/                    # React frontend
 │   ├── src/
 │   │   ├── api/           # API client, React Query hooks, SSE
@@ -146,8 +162,8 @@ For the full API reference, see [CLAUDE.md](CLAUDE.md#api-endpoints).
 ### New Resource Type
 
 1. Add informer in `internal/k8s/cache.go`
-2. Add to topology builder in `internal/topology/builder.go`
-3. Add TypeScript type in `web/src/types.ts`
+2. Add to topology builder in `pkg/topology/builder.go`
+3. Add TypeScript type in `packages/k8s-ui/src/types/core.ts`
 
 ### New UI Component
 
@@ -175,16 +191,15 @@ make watch-frontend  # Terminal 2
 # Interactive release (prompts for version and targets)
 make release
 
-# Or release specific components
-make release-binaries     # CLI via goreleaser → GitHub Releases + Homebrew
-make release-docker       # Docker image → GHCR
+# Dry-run goreleaser (local test, no publish)
+make release-binaries-dry
 ```
 
 | Target | Command | Output |
 |--------|---------|--------|
-| CLI binaries | `make release-binaries` | GitHub Releases + Homebrew tap |
-| Docker | `make release-docker` | `ghcr.io/skyhook-io/radar:VERSION` |
-| All | `make release` | Interactive, choose targets |
+| All | `make release` | Interactive — runs `scripts/release.sh` |
+| Dry run | `make release-binaries-dry` | Local goreleaser snapshot (no publish) |
+| Docker | `make docker-multiarch` | Multi-arch Docker image build |
 
 ### Prerequisites for Releasing
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ radar
 | `--timeline-storage` | `memory` | Timeline storage backend: `memory` or `sqlite` |
 | `--timeline-db` | `~/.radar/timeline.db` | Path to SQLite database (when using sqlite storage) |
 | `--history-limit` | `10000` | Maximum events to retain in timeline |
+| `--disable-exec` | `false` | Disable terminal and debug shell |
+| `--disable-helm-write` | `false` | Disable Helm write operations |
 | `--no-mcp` | `false` | Disable MCP server for AI tool integration |
 | `--version` | | Show version and exit |
 
@@ -247,7 +249,7 @@ Visualize live network traffic between services using Hubble or Caretta.
   <br><em>Traffic View — See how services communicate in real-time</em>
 </p>
 
-- Auto-detects Hubble (Cilium) or Caretta as traffic data sources
+- Auto-detects Hubble (Cilium), Caretta, or Istio as traffic data sources
 - Animated flow graph showing requests per second between services
 - Filter by namespace, protocol, or status code
 - Setup wizard to install a traffic source if none is detected
@@ -256,7 +258,7 @@ Visualize live network traffic between services using Hubble or Caretta.
 
 Radar includes a built-in [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that lets AI assistants — Claude, Cursor, Copilot, and others — query your cluster through Radar.
 
-Instead of raw `kubectl` output (verbose YAML that burns through LLM context windows), your AI gets pre-processed, token-optimized data: topology graphs, health assessments, deduplicated events, and filtered logs. All read-only by design.
+Instead of raw `kubectl` output (verbose YAML that burns through LLM context windows), your AI gets pre-processed, token-optimized data: topology graphs, health assessments, deduplicated events, and filtered logs. Read tools are strictly read-only; write tools (restart, scale, sync) are clearly annotated and non-destructive.
 
 Enabled by default. Disable with `--no-mcp`. See the **[MCP Guide](docs/mcp.md)** for setup instructions.
 
@@ -272,7 +274,7 @@ Radar auto-discovers any CRD in your cluster. Popular tools get [dedicated integ
 | **Networking** | Services, Ingresses, NetworkPolicies, Endpoints, PodDisruptionBudgets |
 | **Configuration** | ConfigMaps, Secrets (names only, values hidden) |
 | **Storage** | PersistentVolumeClaims, PersistentVolumes, StorageClasses |
-| **Autoscaling** | HorizontalPodAutoscalers |
+| **Autoscaling** | HorizontalPodAutoscalers, VerticalPodAutoscalers |
 | **Cluster** | Nodes, Namespaces, ServiceAccounts, Events |
 | **GitOps (FluxCD)** | GitRepository, OCIRepository, HelmRepository, Kustomization, HelmRelease, Alert |
 | **GitOps (ArgoCD)** | Application, ApplicationSet, AppProject |
@@ -289,7 +291,8 @@ Radar auto-discovers any CRD in your cluster. Popular tools get [dedicated integ
 | **Karpenter** | NodePool, NodeClaim (+ provider-specific NodeClasses via auto-discovery) |
 | **KEDA** | ScaledObject, ScaledJob, TriggerAuthentication, ClusterTriggerAuthentication |
 | **Prometheus Operator** | ServiceMonitor, PodMonitor, PrometheusRule, Alertmanager |
-| **Security (Trivy)** | VulnerabilityReport, ConfigAuditReport, ExposedSecretReport, ClusterComplianceReport, SbomReport |
+| **Security (Trivy)** | VulnerabilityReport, ConfigAuditReport, ExposedSecretReport, ClusterComplianceReport, SbomReport, RbacAssessmentReport, InfraAssessmentReport |
+| **Cost (OpenCost)** | Namespace/workload/node cost breakdown via Prometheus (no CRDs) |
 | **CRDs** | Any Custom Resource Definition in your cluster (auto-discovered) |
 
 ---
@@ -298,16 +301,22 @@ Radar auto-discovers any CRD in your cluster. Popular tools get [dedicated integ
 
 | Shortcut | Action |
 |----------|--------|
-| `Escape` | Close panel/modal |
+| `1`–`6` | Switch view (Home, Topology, Resources, Timeline, Helm, Traffic) |
+| `t` | Toggle dark/light theme |
 | `?` | Show keyboard shortcuts |
-| `/` | Focus search |
-| `Ctrl+F` | Search within current view |
-| `r` | Refresh topology |
-| `f` | Fit view to screen |
-| `1` | Traffic view |
-| `2` | Resources view |
+| `⌘K` | Open command palette |
+| `/` | Focus search (context-aware) |
+| `f` | Fit topology to screen |
+| `+` / `-` / `0` | Zoom in / out / reset (topology) |
+| `j` / `k` | Navigate rows (resources, helm) |
+| `g g` / `G` | Jump to first / last row |
+| `Enter` / `d` | Open selected resource detail |
+| `y` | Open YAML view |
+| `l` | Open logs (pods/workloads) |
+| `[` / `]` | Previous / next resource kind |
+| `Escape` | Close panel/modal/search |
 
-**Navigation:** Pan (drag), Zoom (scroll), Select (click), Multi-select (Shift+click)
+**Topology:** Pan (drag), Zoom (scroll), Select (click), Multi-select (Shift+click)
 
 ---
 

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -49,7 +49,7 @@ Add your CRD kinds to the warmup list so they're cached immediately on startup.
 
 ### 2. Backend: Topology Types
 
-**File:** `internal/topology/types.go`
+**File:** `pkg/topology/types.go`
 
 Add `NodeKind` constants for each resource that will appear in topology:
 ```go
@@ -60,7 +60,7 @@ KindKnativeService NodeKind = "KnativeService"
 
 ### 3. Backend: Topology Builder
 
-**File:** `internal/topology/builder.go` — `buildResourcesTopology()`
+**File:** `pkg/topology/builder.go` — `buildResourcesTopology()`
 
 Add a new section that:
 1. **Lists resources** from the dynamic cache (handle errors, don't discard with `_`)
@@ -79,7 +79,7 @@ Edge type semantics (choose carefully):
 
 **Performance tip:** If you need the same resource list for both node creation and edge creation, store it in a slice during phase 1 and reuse in phase 2. Don't re-fetch.
 
-**File:** `internal/topology/relationships.go`
+**File:** `pkg/topology/relationships.go`
 
 Add your kinds to `buildNodeID` and `normalizeKind` maps.
 - ** Collision:** Use a unique ID prefix (e.g., `knativeservice/`, `istiogateway/`)
@@ -129,7 +129,7 @@ Also verify `normalizeKindToPlural()` handles your kind correctly (watch out for
 
 Cell components that render rich table cells (status badges, links, etc.).
 
-**File:** `packages/k8s-ui/src/components/resources/ResourcesView.tsx` — `renderCellContent()`
+**File:** `packages/k8s-ui/src/components/resources/ResourcesView.tsx` — `CellContent` component
 
 Add cases for your kinds.
 - ** Collision:** Use `apiVersion` checks:
@@ -188,15 +188,15 @@ Update these files to support new topology node kinds:
 
 | File | What to Add |
 |------|-------------|
-| `web/src/types.ts` | Kind to `CoreNodeKind` type union + `displayKind` map |
+| `packages/k8s-ui/src/types/core.ts` | Kind to `CoreNodeKind` type union + `displayKind` map |
 | `web/src/App.tsx` | Kind to `ALL_NODE_KINDS` array |
 | `packages/k8s-ui/src/utils/resource-icons.ts` | Icon mapping |
 | `packages/k8s-ui/src/utils/badge-colors.ts` | Badge CSS class |
-| `web/src/components/topology/TopologyFilterSidebar.tsx` | Filter sidebar entry |
-| `web/src/components/topology/K8sResourceNode.tsx` | Node dimensions |
-| `web/src/components/topology/layout.ts` | `kindPriority` entry |
+| `packages/k8s-ui/src/components/topology/TopologyFilterSidebar.tsx` | Filter sidebar entry |
+| `packages/k8s-ui/src/components/topology/K8sResourceNode.tsx` | Node dimensions |
+| `packages/k8s-ui/src/components/topology/layout.ts` | `kindPriority` entry |
 | `packages/k8s-ui/src/utils/resource-hierarchy.ts` | `appLabelEligibleKinds` (if groupable by app label) |
-| `web/src/index.css` | `.topology-icon-{kind}` CSS class with color |
+| `packages/k8s-ui/src/components/topology/topology.css` | `.topology-icon-{kind}` CSS class with color |
 
 ### 10. Documentation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,17 +2,59 @@
 
 This document covers Radar's cluster connection behavior. For CLI flags and basic usage, see the [README](../README.md#usage).
 
+## Persistent Configuration
+
+Radar stores configuration in two files under `~/.radar/`:
+
+### Config File (`~/.radar/config.json`)
+
+Persistent defaults for CLI flags. CLI flags always override these values. Managed via the Settings dialog in the UI or `PUT /api/config`.
+
+```json
+{
+  "kubeconfig": "",
+  "kubeconfigDirs": [],
+  "namespace": "",
+  "port": 9280,
+  "noBrowser": false,
+  "timelineStorage": "memory",
+  "timelineDbPath": "~/.radar/timeline.db",
+  "historyLimit": 10000,
+  "prometheusUrl": "",
+  "mcp": true
+}
+```
+
+All fields are optional — omitted fields use built-in defaults.
+
+### Settings File (`~/.radar/settings.json`)
+
+User preferences for the UI. Managed via the Settings dialog or `PUT /api/settings`.
+
+```json
+{
+  "theme": "system",
+  "pinnedKinds": [
+    { "name": "Deployments", "kind": "Deployment", "group": "" }
+  ]
+}
+```
+
+| Field | Values | Description |
+|-------|--------|-------------|
+| `theme` | `light`, `dark`, `system` | UI theme preference |
+| `pinnedKinds` | Array of `{name, kind, group}` | Resource kinds pinned to the sidebar |
+
 ## Cluster Connection Precedence
 
-Radar connects to Kubernetes clusters using the same configuration sources as `kubectl`, resolved in this order:
+Radar connects to Kubernetes clusters using the same configuration sources as `kubectl`:
 
 | Priority | Source | Description |
 |----------|--------|-------------|
 | 1 | `--kubeconfig` flag | Explicit path to kubeconfig file |
-| 2 | `KUBECONFIG` env var | Environment variable pointing to kubeconfig file(s) |
-| 3 | `--kubeconfig-dir` flag | Directory containing multiple kubeconfig files |
-| 4 | In-cluster config | Automatic when running inside a Kubernetes pod |
-| 5 | `~/.kube/config` | Default kubeconfig location |
+| 2 | `KUBECONFIG` env var / `--kubeconfig-dir` flag | Either can provide kubeconfig(s); mutually exclusive alternatives |
+| 3 | In-cluster config | Automatic when running inside a Kubernetes pod (`KUBERNETES_SERVICE_HOST` is set) |
+| 4 | `~/.kube/config` | Default kubeconfig location |
 
 ## KUBECONFIG vs In-Cluster Detection
 

--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -8,7 +8,8 @@ Deploy Radar to your Kubernetes cluster for shared team access.
 
 ```bash
 helm repo add skyhook https://skyhook-io.github.io/helm-charts
-helm install radar skyhook/radar -n radar --create-namespace
+helm repo update skyhook
+helm upgrade --install radar skyhook/radar -n radar --create-namespace
 ```
 
 Access via port-forward:
@@ -126,14 +127,16 @@ Radar uses its ServiceAccount to access the Kubernetes API. The Helm chart creat
 
 ### Opt-in Permissions
 
-Some features require additional permissions that are **disabled by default** for security:
+Some features require additional permissions. Most are disabled by default for security:
 
-| Feature | Value | Description |
-|---------|-------|-------------|
-| Secrets | `rbac.secrets: true` | Show secrets in resource list |
-| Terminal | `rbac.podExec: true` | Shell access to pods |
-| Port Forward | `rbac.portForward: true` | Port forwarding to pods/services |
-| Logs | `rbac.podLogs: true` | View pod logs (enabled by default) |
+| Feature | Value | Default | Description |
+|---------|-------|---------|-------------|
+| Secrets | `rbac.secrets: true` | `false` | Show secrets in resource list |
+| Terminal | `rbac.podExec: true` | `false` | Shell access to pods |
+| Port Forward | `rbac.portForward: true` | `false` | Port forwarding to pods/services |
+| Logs | `rbac.podLogs: true` | `true` | View pod logs |
+| Helm Write | `rbac.helm: true` | `false` | Install/upgrade/rollback/uninstall Helm releases (grants broad write access; auto-enables secrets) |
+| Traffic TLS | `rbac.traffic: true` | `true` | Read Hubble relay TLS certs for Cilium traffic observation |
 
 Enable features as needed:
 
@@ -144,6 +147,31 @@ rbac:
   podExec: true       # Enable terminal feature
   podLogs: true       # Enable log viewer (default)
   portForward: true   # Enable port forwarding
+  helm: false         # Enable Helm write operations (broad permissions)
+```
+
+### CRD Permissions
+
+Radar reads CRDs from many popular tools. Each CRD group can be toggled individually:
+
+```yaml
+rbac:
+  crdGroups:
+    all: false          # Wildcard — grant read access to ALL API groups
+    # Individual groups (all default to true):
+    argo: true          # argoproj.io
+    certManager: true   # cert-manager.io
+    flux: true          # *.toolkit.fluxcd.io
+    istio: true         # networking.istio.io, security.istio.io
+    karpenter: true     # karpenter.sh, karpenter.k8s.aws, karpenter.azure.com
+    keda: true          # keda.sh
+    knative: true       # *.knative.dev
+    prometheus: true    # monitoring.coreos.com
+    traefik: true       # traefik.io
+    velero: true        # velero.io
+    # ... and 25+ more (see values.yaml for full list)
+  additionalCrdGroups: []   # Add custom API groups
+  additionalRules: []       # Arbitrary extra ClusterRole rules
 ```
 
 ### Graceful RBAC Degradation
@@ -216,11 +244,20 @@ See [Helm Chart README](../deploy/helm/radar/README.md) for all available values
 | `ingress.enabled` | Enable ingress | `false` |
 | `ingress.className` | Ingress class | `""` |
 | `service.port` | Service port | `9280` |
+| `mcp.enabled` | Enable MCP server for AI tools | `true` |
 | `timeline.storage` | Event storage (memory/sqlite) | `memory` |
+| `timeline.dbPath` | SQLite database path | `/data/timeline.db` |
+| `timeline.historyLimit` | Max events to retain | `10000` |
+| `traffic.prometheusUrl` | Manual Prometheus/VictoriaMetrics URL | `""` (auto-discover) |
+| `persistence.enabled` | Enable PVC for SQLite storage | `false` |
+| `persistence.size` | PVC size | `1Gi` |
 | `rbac.podLogs` | Enable log viewer | `true` |
 | `rbac.podExec` | Enable terminal feature | `false` |
 | `rbac.portForward` | Enable port forwarding | `false` |
 | `rbac.secrets` | Show secrets in resource list | `false` |
+| `rbac.helm` | Enable Helm write operations | `false` |
+| `rbac.traffic` | Read Hubble TLS certs | `true` |
+| `rbac.crdGroups.all` | Wildcard CRD read access | `false` |
 
 ## Troubleshooting
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -58,7 +58,8 @@ Radar automatically discovers and displays **any** Custom Resource Definition (C
 | NodePool | `karpenter.sh/v1` | Yes | Yes | Yes |
 | NodeClaim | `karpenter.sh/v1` | Yes | Yes | Yes |
 | EC2NodeClass | `karpenter.k8s.aws/v1` | Yes | Yes | Yes |
-| AKSNodeClass | `karpenter.azure.com/v1alpha2` | Yes | Yes | Yes |
+| AKSNodeClass | `karpenter.azure.com/v1alpha2` | Yes | Generic | Yes |
+| GCPNodeClass | `karpenter.gcp.compute.com/v1alpha1` | Yes | Generic | Yes |
 
 All provider-specific NodeClass variants are automatically detected and supported.
 
@@ -119,6 +120,26 @@ All provider-specific NodeClass variants are automatically detected and supporte
 | ScaledJob | `keda.sh/v1alpha1` | Yes | Yes | Yes |
 | TriggerAuthentication | `keda.sh/v1alpha1` | — | Yes | Yes |
 | ClusterTriggerAuthentication | `keda.sh/v1alpha1` | — | Yes | Yes |
+
+---
+
+## Vertical Pod Autoscaler (VPA)
+
+[VPA](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) automatically adjusts CPU and memory requests/limits for pods based on observed usage.
+
+### What Radar Shows
+
+**Topology:** VPA nodes appear in the Resources view with `EdgeUses` edges to target workloads, grouped in the Scalers section alongside HPA and KEDA.
+
+**Detail View:** Target workload, update mode, per-container resource recommendations (target, lower bound, upper bound, uncapped), resource policy, and conditions.
+
+**Problem Detection:** Alerts for unsupported configurations, missing recommendations, and low confidence scores.
+
+### Supported CRDs
+
+| CRD | Group | Topology | Detail View | AI Summary |
+|-----|-------|----------|-------------|------------|
+| VerticalPodAutoscaler | `autoscaling.k8s.io/v1` | Yes | Yes | — |
 
 ---
 
@@ -265,10 +286,10 @@ All provider-specific NodeClass variants are automatically detected and supporte
 
 | CRD | Group | Topology | Detail View | AI Summary |
 |-----|-------|----------|-------------|------------|
-| ServiceMonitor | `monitoring.coreos.com/v1` | — | Yes | Yes |
-| PodMonitor | `monitoring.coreos.com/v1` | — | Yes | Yes |
-| PrometheusRule | `monitoring.coreos.com/v1` | — | Yes | Yes |
-| Alertmanager | `monitoring.coreos.com/v1` | — | Generic | Yes |
+| ServiceMonitor | `monitoring.coreos.com/v1` | — | Yes | — |
+| PodMonitor | `monitoring.coreos.com/v1` | — | Yes | — |
+| PrometheusRule | `monitoring.coreos.com/v1` | — | Yes | — |
+| Alertmanager | `monitoring.coreos.com/v1` | — | Generic | — |
 
 ---
 
@@ -293,6 +314,11 @@ All provider-specific NodeClass variants are automatically detected and supporte
 | ExposedSecretReport | `aquasecurity.github.io/v1alpha1` | — | Yes | — |
 | ClusterComplianceReport | `aquasecurity.github.io/v1alpha1` | — | Yes | — |
 | SbomReport | `aquasecurity.github.io/v1alpha1` | — | Yes | — |
+| RbacAssessmentReport | `aquasecurity.github.io/v1alpha1` | — | Yes | — |
+| ClusterRbacAssessmentReport | `aquasecurity.github.io/v1alpha1` | — | Yes | — |
+| InfraAssessmentReport | `aquasecurity.github.io/v1alpha1` | — | Yes | — |
+| ClusterInfraAssessmentReport | `aquasecurity.github.io/v1alpha1` | — | Yes | — |
+| ClusterSbomReport | `aquasecurity.github.io/v1alpha1` | — | Yes | — |
 
 ---
 
@@ -320,7 +346,7 @@ See the main [README](../README.md#gitops) for GitOps integration details.
 
 | CRD | Group | Topology | Detail View | AI Summary |
 |-----|-------|----------|-------------|------------|
-| GitRepository | `source.toolkit.fluxcd.io/v1` | Yes | Yes | Yes |
+| GitRepository | `source.toolkit.fluxcd.io/v1` | Yes | Yes | — |
 | OCIRepository | `source.toolkit.fluxcd.io/v1beta2` | Yes | Yes | — |
 | HelmRepository | `source.toolkit.fluxcd.io/v1` | Yes | Yes | — |
 | Kustomization | `kustomize.toolkit.fluxcd.io/v1` | Yes | Yes | Yes |
@@ -355,6 +381,7 @@ See the main [README](../README.md#gitops) for GitOps integration details.
 |-----|-------|----------|-------------|------------|
 | Workflow | `argoproj.io/v1alpha1` | — | Yes | — |
 | WorkflowTemplate | `argoproj.io/v1alpha1` | — | Yes | — |
+| CronWorkflow | `argoproj.io/v1alpha1` | — | Generic | — |
 
 ---
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -169,19 +169,19 @@ Add to `~/.gemini/settings.json`:
 | `list_resources` | List resources of a kind with minified summaries (pods, deployments, services, CRDs, etc.) | `kind` (required), `namespace` (optional) |
 | `get_resource` | Detailed view of a single resource — minified spec, status, metadata. Optionally include related context to avoid extra tool calls. | `kind` (required), `namespace` (required), `name` (required), `include` (optional: `events,relationships,metrics,logs`) |
 | `get_topology` | Topology graph showing resource relationships (nodes and edges). Use `summary` format for LLM-friendly text descriptions of resource chains. | `namespace` (optional), `view` (optional: `traffic` or `resources`), `format` (optional: `graph` or `summary`) |
-| `get_events` | Recent warning events, deduplicated and sorted by recency. Filter by resource kind/name to scope to a specific resource. | `namespace` (optional), `limit` (optional, default 20), `kind` (optional), `name` (optional) |
-| `get_pod_logs` | Filtered pod logs prioritizing errors/warnings, with secret redaction | `namespace` (required), `name` (required), `container` (optional), `tail_lines` (optional) |
+| `get_events` | Recent Kubernetes events, deduplicated and sorted by recency. Filter by resource kind/name to scope to a specific resource. | `namespace` (optional), `limit` (optional, default 20, max 100), `kind` (optional), `name` (optional) |
+| `get_pod_logs` | Filtered pod logs prioritizing errors/warnings, with secret redaction | `namespace` (required), `name` (required), `container` (optional), `tail_lines` (optional, default 200) |
 | `list_namespaces` | List all namespaces with status | (none) |
 | `get_changes` | Recent resource changes (creates, updates, deletes) from the cluster timeline. Use to investigate what changed before an incident. | `namespace` (optional), `kind` (optional), `name` (optional), `since` (optional, e.g. `1h`, `30m`; default `1h`), `limit` (optional, default 20, max 50) |
 | `list_helm_releases` | List all Helm releases with status and health | `namespace` (optional) |
-| `get_helm_release` | Detailed Helm release info with optional values, history, and manifest diff | `namespace` (required), `name` (required), `include` (optional: `values,history,diff`), `diff_revision_1` / `diff_revision_2` (optional) |
-| `get_workload_logs` | Aggregated, AI-filtered logs from all pods of a workload (Deployment, StatefulSet, DaemonSet) | `kind` (required), `namespace` (required), `name` (required), `container` (optional), `tail_lines` (optional) |
+| `get_helm_release` | Detailed Helm release info with optional values, history, and manifest diff | `namespace` (required), `name` (required), `include` (optional: `values,history,diff`), `diff_revision_1` (required when `include=diff`) / `diff_revision_2` (optional) |
+| `get_workload_logs` | Aggregated, AI-filtered logs from all pods of a workload (Deployment, StatefulSet, DaemonSet) | `kind` (required), `namespace` (required), `name` (required), `container` (optional), `tail_lines` (optional, default 100 per pod) |
 
 ### Write Tools
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `manage_workload` | Restart, scale, or rollback a Deployment, StatefulSet, or DaemonSet | `action` (required: `restart`, `scale`, `rollback`), `kind` (required), `namespace` (required), `name` (required), `replicas` (for scale), `revision` (for rollback) |
+| `manage_workload` | Restart, scale, or rollback a Deployment, StatefulSet, or DaemonSet. Note: `scale` is not supported for DaemonSets. | `action` (required: `restart`, `scale`, `rollback`), `kind` (required), `namespace` (required), `name` (required), `replicas` (for scale), `revision` (for rollback) |
 | `manage_cronjob` | Trigger, suspend, or resume a CronJob | `action` (required: `trigger`, `suspend`, `resume`), `namespace` (required), `name` (required) |
 | `manage_gitops` | Manage ArgoCD and FluxCD resources — sync, reconcile, suspend, resume | `action` (required), `tool` (required: `argocd` or `fluxcd`), `namespace` (required), `name` (required), `kind` (FluxCD only) |
 


### PR DESCRIPTION
## Summary

Thorough audit of all documentation against the codebase found significant drift. This PR syncs 9 doc files:

- **README.md** — keyboard shortcuts were wrong (`1`=Home not Traffic, `r` and `Ctrl+F` don't exist), added Istio traffic source, VPA, OpenCost, missing CLI flags
- **CONTRIBUTING.md** — build instructions produced broken binary (missing embed step)
- **DEVELOPMENT.md** — referenced non-existent `make release-binaries` target, outdated project structure
- **docs/configuration.md** — `~/.radar/config.json` and `~/.radar/settings.json` were completely undocumented
- **docs/in-cluster.md** — missing `rbac.helm`, `rbac.traffic`, entire CRD groups subsystem, incomplete config reference table
- **docs/mcp.md** — `get_events` falsely described as "warning events" (returns all), missing parameter defaults, DaemonSet scale caveat
- **docs/integrations.md** — added VPA section, 5 missing Trivy CRDs, GCPNodeClass, fixed wrong AI Summary columns for Prometheus Operator and FluxCD
- **docs/INTEGRATION_GUIDE.md** — 9 file paths wrong after `internal/` → `pkg/` and `web/` → `packages/k8s-ui/` moves
- **CLAUDE.md** — package name, project structure, API endpoints, topology nodes, renderer dispatch path