### PR TITLE
fix: add Windows ConPTY support for local terminal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.4.0
 	github.com/skyhook-io/radar/pkg v0.0.0
 	github.com/wailsapp/wails/v2 v2.11.0
+	golang.org/x/sys v0.41.0
 	golang.org/x/term v0.40.0
 	google.golang.org/grpc v1.79.2
 	google.golang.org/protobuf v1.36.11
@@ -152,7 +153,6 @@ require (
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
-	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect

--- a/internal/server/localterm.go
+++ b/internal/server/localterm.go
@@ -3,29 +3,37 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
-	"os/exec"
-	"runtime"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
-	"github.com/creack/pty"
 	"github.com/gorilla/websocket"
 
 	"github.com/skyhook-io/radar/internal/k8s"
 )
+
+// ptyHandle abstracts platform-specific PTY implementations
+type ptyHandle interface {
+	io.ReadWriteCloser
+	Resize(cols, rows uint16) error
+}
+
+// shellProcess holds the started shell process and its PTY
+type shellProcess struct {
+	pty     ptyHandle
+	process *os.Process
+}
 
 // LocalTermSession tracks an active local terminal session
 type LocalTermSession struct {
 	ID    string `json:"id"`
 	Shell string `json:"shell"`
 	conn  *websocket.Conn
-	cmd   *exec.Cmd
-	ptmx  *os.File
+	proc  *shellProcess
 }
 
 type localTermSessionManager struct {
@@ -52,28 +60,17 @@ func StopAllLocalTermSessions() {
 
 	for id, session := range localTermMgr.sessions {
 		log.Printf("[localterm] Closing session %s", id)
-		if session.cmd != nil && session.cmd.Process != nil {
-			session.cmd.Process.Signal(syscall.SIGHUP)
-		}
-		if session.ptmx != nil {
-			session.ptmx.Close()
+		if session.proc != nil {
+			if session.proc.process != nil {
+				signalProcess(session.proc.process)
+			}
+			session.proc.pty.Close()
 		}
 		if session.conn != nil {
 			session.conn.Close()
 		}
 		delete(localTermMgr.sessions, id)
 	}
-}
-
-// getDefaultShell returns the user's default shell
-func getDefaultShell() string {
-	if shell := os.Getenv("SHELL"); shell != "" {
-		return shell
-	}
-	if runtime.GOOS == "darwin" {
-		return "/bin/zsh"
-	}
-	return "/bin/bash"
 }
 
 // setEnv replaces or appends an environment variable in the env slice
@@ -116,12 +113,11 @@ func (s *Server) handleLocalTerminal(w http.ResponseWriter, r *http.Request) {
 		env = setEnv(env, "KUBECONFIG", kubeconfigPath)
 	}
 
-	// Start shell with PTY
-	cmd := exec.Command(shell, "-l")
-	cmd.Env = env
-	cmd.Dir = os.Getenv("HOME")
+	// Get home directory (cross-platform)
+	homeDir, _ := os.UserHomeDir()
 
-	ptmx, err := pty.Start(cmd)
+	// Start shell with PTY
+	proc, err := startShell(shell, env, homeDir)
 	if err != nil {
 		log.Printf("[localterm] Failed to start PTY: %v", err)
 		sendWSError(conn, fmt.Sprintf("Failed to start shell: %v", err))
@@ -130,14 +126,13 @@ func (s *Server) handleLocalTerminal(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Set initial terminal size
-	pty.Setsize(ptmx, &pty.Winsize{Rows: 24, Cols: 80})
+	proc.pty.Resize(80, 24)
 
 	session := &LocalTermSession{
 		ID:    sessionID,
 		Shell: shell,
 		conn:  conn,
-		cmd:   cmd,
-		ptmx:  ptmx,
+		proc:  proc,
 	}
 	localTermMgr.mu.Lock()
 	localTermMgr.sessions[sessionID] = session
@@ -150,11 +145,11 @@ func (s *Server) handleLocalTerminal(w http.ResponseWriter, r *http.Request) {
 		delete(localTermMgr.sessions, sessionID)
 		localTermMgr.mu.Unlock()
 
-		if cmd.Process != nil {
-			cmd.Process.Signal(syscall.SIGHUP)
+		if proc.process != nil {
+			signalProcess(proc.process)
 		}
-		ptmx.Close()
-		cmd.Wait()
+		proc.pty.Close()
+		waitProcess(proc)
 		conn.Close()
 		log.Printf("[localterm] Session %s ended", sessionID)
 	}()
@@ -163,12 +158,10 @@ func (s *Server) handleLocalTerminal(w http.ResponseWriter, r *http.Request) {
 	var wsMu sync.Mutex
 
 	// Read from PTY → write to WebSocket
-	readDone := make(chan struct{})
 	go func() {
-		defer close(readDone)
 		buf := make([]byte, 4096)
 		for {
-			n, err := ptmx.Read(buf)
+			n, err := proc.pty.Read(buf)
 			if n > 0 {
 				msg := TerminalMessage{Type: "output", Data: string(buf[:n])}
 				data, _ := json.Marshal(msg)
@@ -210,12 +203,9 @@ func (s *Server) handleLocalTerminal(w http.ResponseWriter, r *http.Request) {
 
 		switch msg.Type {
 		case "input":
-			ptmx.Write([]byte(msg.Data))
+			proc.pty.Write([]byte(msg.Data))
 		case "resize":
-			pty.Setsize(ptmx, &pty.Winsize{
-				Rows: msg.Rows,
-				Cols: msg.Cols,
-			})
+			proc.pty.Resize(msg.Cols, msg.Rows)
 		}
 	}
 }

--- a/internal/server/localterm_unix.go
+++ b/internal/server/localterm_unix.go
@@ -1,0 +1,60 @@
+//go:build !windows
+
+package server
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"syscall"
+
+	"github.com/creack/pty"
+)
+
+// unixPty wraps the master end of a Unix pseudo-terminal
+type unixPty struct {
+	f *os.File
+}
+
+func (p *unixPty) Read(b []byte) (int, error)  { return p.f.Read(b) }
+func (p *unixPty) Write(b []byte) (int, error) { return p.f.Write(b) }
+func (p *unixPty) Close() error                { return p.f.Close() }
+
+func (p *unixPty) Resize(cols, rows uint16) error {
+	return pty.Setsize(p.f, &pty.Winsize{Rows: rows, Cols: cols})
+}
+
+func getDefaultShell() string {
+	if shell := os.Getenv("SHELL"); shell != "" {
+		return shell
+	}
+	if runtime.GOOS == "darwin" {
+		return "/bin/zsh"
+	}
+	return "/bin/bash"
+}
+
+func startShell(shell string, env []string, dir string) (*shellProcess, error) {
+	cmd := exec.Command(shell, "-l")
+	cmd.Env = env
+	cmd.Dir = dir
+
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		return nil, err
+	}
+	return &shellProcess{
+		pty:     &unixPty{f: ptmx},
+		process: cmd.Process,
+	}, nil
+}
+
+func signalProcess(p *os.Process) {
+	p.Signal(syscall.SIGHUP)
+}
+
+func waitProcess(proc *shellProcess) {
+	// On Unix, we need to wait for the child process to avoid zombies.
+	// The process was started via exec.Cmd, but we only hold *os.Process here.
+	proc.process.Wait()
+}

--- a/internal/server/localterm_windows.go
+++ b/internal/server/localterm_windows.go
@@ -1,0 +1,214 @@
+//go:build windows
+
+package server
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// conPty wraps a Windows ConPTY pseudo-console
+type conPty struct {
+	console windows.Handle
+	inWrite *os.File // our write end → ConPTY input
+	outRead *os.File // our read end ← ConPTY output
+}
+
+func (p *conPty) Read(b []byte) (int, error)  { return p.outRead.Read(b) }
+func (p *conPty) Write(b []byte) (int, error) { return p.inWrite.Write(b) }
+
+func (p *conPty) Close() error {
+	windows.ClosePseudoConsole(p.console)
+	err1 := p.inWrite.Close()
+	err2 := p.outRead.Close()
+	if err1 != nil {
+		return err1
+	}
+	return err2
+}
+
+func (p *conPty) Resize(cols, rows uint16) error {
+	return windows.ResizePseudoConsole(p.console, windows.Coord{X: int16(cols), Y: int16(rows)})
+}
+
+func getDefaultShell() string {
+	if ps, err := exec.LookPath("powershell.exe"); err == nil {
+		return ps
+	}
+	if comspec := os.Getenv("COMSPEC"); comspec != "" {
+		return comspec
+	}
+	return "cmd.exe"
+}
+
+func startShell(shell string, env []string, dir string) (*shellProcess, error) {
+	// Create pipes: ConPTY reads from inRead, writes to outWrite.
+	// We write to inWrite, read from outRead.
+	inRead, inWrite, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("create input pipe: %w", err)
+	}
+	outRead, outWrite, err := os.Pipe()
+	if err != nil {
+		inRead.Close()
+		inWrite.Close()
+		return nil, fmt.Errorf("create output pipe: %w", err)
+	}
+
+	// Create the pseudo console
+	var hPC windows.Handle
+	size := windows.Coord{X: 80, Y: 24}
+	err = windows.CreatePseudoConsole(
+		size,
+		windows.Handle(inRead.Fd()),
+		windows.Handle(outWrite.Fd()),
+		0,
+		&hPC,
+	)
+	if err != nil {
+		inRead.Close()
+		inWrite.Close()
+		outRead.Close()
+		outWrite.Close()
+		return nil, fmt.Errorf("CreatePseudoConsole: %w", err)
+	}
+
+	// Close the pipe ends we gave to the console — they're now owned by ConPTY
+	inRead.Close()
+	outWrite.Close()
+
+	// Set up process creation with the pseudo console attribute
+	attrs, err := windows.NewProcThreadAttributeList(1)
+	if err != nil {
+		windows.ClosePseudoConsole(hPC)
+		inWrite.Close()
+		outRead.Close()
+		return nil, fmt.Errorf("NewProcThreadAttributeList: %w", err)
+	}
+	defer attrs.Delete()
+
+	err = attrs.Update(
+		windows.PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
+		unsafe.Pointer(&hPC),
+		unsafe.Sizeof(hPC),
+	)
+	if err != nil {
+		windows.ClosePseudoConsole(hPC)
+		inWrite.Close()
+		outRead.Close()
+		return nil, fmt.Errorf("UpdateProcThreadAttribute: %w", err)
+	}
+
+	// Build the command line
+	cmdLine, err := windows.UTF16PtrFromString(shell)
+	if err != nil {
+		windows.ClosePseudoConsole(hPC)
+		inWrite.Close()
+		outRead.Close()
+		return nil, err
+	}
+
+	// Build environment block
+	var envBlock *uint16
+	if len(env) > 0 {
+		envBlock = createEnvBlock(env)
+	}
+
+	// Build working directory
+	var dirPtr *uint16
+	if dir != "" {
+		dirPtr, _ = windows.UTF16PtrFromString(dir)
+	}
+
+	// Create the process
+	si := &windows.StartupInfoEx{
+		StartupInfo: windows.StartupInfo{
+			Cb: uint32(unsafe.Sizeof(windows.StartupInfoEx{})),
+		},
+		ProcThreadAttributeList: attrs.List(),
+	}
+
+	pi := &windows.ProcessInformation{}
+
+	err = windows.CreateProcess(
+		nil,
+		cmdLine,
+		nil,
+		nil,
+		false,
+		windows.CREATE_UNICODE_ENVIRONMENT|windows.EXTENDED_STARTUPINFO_PRESENT,
+		envBlock,
+		dirPtr,
+		&si.StartupInfo,
+		pi,
+	)
+	if err != nil {
+		windows.ClosePseudoConsole(hPC)
+		inWrite.Close()
+		outRead.Close()
+		return nil, fmt.Errorf("CreateProcess: %w", err)
+	}
+
+	// Close handles we don't need
+	windows.CloseHandle(pi.Thread)
+
+	proc, err := os.FindProcess(int(pi.ProcessId))
+	if err != nil {
+		windows.ClosePseudoConsole(hPC)
+		inWrite.Close()
+		outRead.Close()
+		windows.CloseHandle(pi.Process)
+		return nil, fmt.Errorf("FindProcess: %w", err)
+	}
+
+	// FindProcess opened its own handle; close the one from CreateProcess
+	windows.CloseHandle(pi.Process)
+
+	return &shellProcess{
+		pty: &conPty{
+			console: hPC,
+			inWrite: inWrite,
+			outRead: outRead,
+		},
+		process: proc,
+	}, nil
+}
+
+func signalProcess(p *os.Process) {
+	// Windows doesn't have SIGHUP; just kill the process
+	p.Kill()
+}
+
+func waitProcess(proc *shellProcess) {
+	proc.process.Wait()
+}
+
+// createEnvBlock builds a Windows environment block (null-terminated UTF-16 strings, double-null terminated)
+func createEnvBlock(env []string) *uint16 {
+	// Calculate total length
+	total := 0
+	for _, s := range env {
+		total += len(s) + 1 // each string + null terminator
+	}
+	total++ // final double-null
+
+	block := make([]uint16, 0, total*2) // rough estimate, UTF-16 may expand
+	for _, s := range env {
+		u, _ := windows.UTF16FromString(s)
+		block = append(block, u...)
+	}
+	block = append(block, 0) // final double-null
+
+	return &block[0]
+}
+
+// Ensure conPty satisfies ptyHandle at compile time
+var _ ptyHandle = (*conPty)(nil)
+
+// Ensure io interfaces are satisfied
+var _ io.ReadWriteCloser = (*conPty)(nil)


### PR DESCRIPTION
## Summary

Fixes #335 — the local terminal feature crashed on Windows with "Failed to start shell: unsupported" because `creack/pty` is Unix-only.

- Split `localterm.go` into platform-specific implementations using build tags
- **Unix** (`localterm_unix.go`): keeps `creack/pty` — no behavior change
- **Windows** (`localterm_windows.go`): native ConPTY via `golang.org/x/sys/windows` — no new dependencies (already in go.mod)
- Also fixed `os.Getenv("HOME")` → `os.UserHomeDir()` for cross-platform home directory detection
- Default shell on Windows: `powershell.exe` (fallback `cmd.exe`)

Verified: compiles on darwin/arm64, linux/amd64, and windows/amd64.