### PR TITLE
fix: show cri-docker hint when Prometheus metrics return empty results

### DIFF
--- a/internal/prometheus/handlers.go
+++ b/internal/prometheus/handlers.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/skyhook-io/radar/internal/errorlog"
+	"github.com/skyhook-io/radar/internal/k8s"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 // RegisterRoutes registers Prometheus metric routes on the given router.
@@ -134,6 +137,7 @@ type ResourceMetricsResponse struct {
 	Range     string         `json:"range"`
 	Result    *QueryResult   `json:"result"`
 	Query     string         `json:"query,omitempty"` // PromQL query used (included when result is empty for diagnostics)
+	Hint      string         `json:"hint,omitempty"`  // Contextual hint when results are empty (e.g. cri-docker label issues)
 }
 
 // handleResourceMetrics returns Prometheus metrics for a specific resource.
@@ -212,6 +216,7 @@ func handleResourceMetrics(w http.ResponseWriter, r *http.Request) {
 	// label mismatches or missing metrics in their Prometheus instance.
 	if len(result.Series) == 0 {
 		resp.Query = query
+		resp.Hint = detectCRIDockerHint(kind, namespace, name)
 		log.Printf("[prometheus] Empty result for %s/%s/%s (%s), query: %s", kind, namespace, name, category, query)
 		errorlog.Record("prometheus", "warning", "empty result for %s/%s/%s (%s), query: %s", kind, namespace, name, category, query)
 	}
@@ -422,4 +427,81 @@ func handleRawQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, result)
+}
+
+const criDockerHint = "This pod's node uses the Docker container runtime (cri-docker), which is known to cause missing pod and namespace labels in cAdvisor metrics. " +
+	"Verify that your Prometheus scrape config produces the standard 'pod' and 'namespace' labels on container_cpu_usage_seconds_total."
+
+// detectCRIDockerHint returns a diagnostic hint when the resource runs on a
+// node using cri-docker, which is known to cause missing cAdvisor labels.
+// For Pods it checks the specific node; for workloads it checks all nodes
+// running pods that match the workload name prefix.
+func detectCRIDockerHint(kind, namespace, name string) string {
+	// Node metrics use node-exporter, not cAdvisor — cri-docker is irrelevant.
+	if strings.EqualFold(kind, "Node") {
+		return ""
+	}
+
+	cache := k8s.GetResourceCache()
+	if cache == nil || cache.Nodes() == nil {
+		return ""
+	}
+
+	// Collect the node names to check.
+	var nodeNames []string
+	if strings.EqualFold(kind, "Pod") {
+		// For a specific pod, check only its assigned node.
+		if cache.Pods() != nil {
+			pod, err := cache.Pods().Pods(namespace).Get(name)
+			if err == nil && pod.Spec.NodeName != "" {
+				nodeNames = append(nodeNames, pod.Spec.NodeName)
+			}
+		}
+	} else {
+		// For workloads, find pods matching the name prefix (e.g. "myapp-" for Deployment "myapp").
+		if cache.Pods() != nil {
+			pods, err := cache.Pods().Pods(namespace).List(labels.Everything())
+			if err == nil {
+				prefix := name + "-"
+				for _, pod := range pods {
+					if strings.HasPrefix(pod.Name, prefix) && pod.Spec.NodeName != "" {
+						nodeNames = append(nodeNames, pod.Spec.NodeName)
+					}
+				}
+			}
+		}
+	}
+
+	// If we couldn't resolve any nodes (pod not scheduled yet, etc.), fall back
+	// to checking all cluster nodes.
+	if len(nodeNames) == 0 {
+		allNodes, err := cache.Nodes().List(labels.Everything())
+		if err != nil {
+			return ""
+		}
+		return anyNodeUsesDocker(allNodes)
+	}
+
+	// Check specific nodes.
+	for _, nodeName := range nodeNames {
+		node, err := cache.Nodes().Get(nodeName)
+		if err != nil {
+			continue
+		}
+		if strings.HasPrefix(node.Status.NodeInfo.ContainerRuntimeVersion, "docker://") {
+			return criDockerHint
+		}
+	}
+	return ""
+}
+
+// anyNodeUsesDocker returns the cri-docker hint if any node in the list uses
+// the Docker container runtime, empty string otherwise.
+func anyNodeUsesDocker(nodes []*corev1.Node) string {
+	for _, node := range nodes {
+		if strings.HasPrefix(node.Status.NodeInfo.ContainerRuntimeVersion, "docker://") {
+			return criDockerHint
+		}
+	}
+	return ""
 }

--- a/internal/prometheus/handlers_test.go
+++ b/internal/prometheus/handlers_test.go
@@ -1,0 +1,86 @@
+package prometheus
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAnyNodeUsesDocker(t *testing.T) {
+	tests := []struct {
+		name    string
+		nodes   []*corev1.Node
+		wantHit bool
+	}{
+		{
+			name:    "no nodes",
+			nodes:   nil,
+			wantHit: false,
+		},
+		{
+			name: "containerd only",
+			nodes: []*corev1.Node{
+				nodeWithRuntime("node-1", "containerd://1.6.21"),
+				nodeWithRuntime("node-2", "containerd://1.7.0"),
+			},
+			wantHit: false,
+		},
+		{
+			name: "cri-o only",
+			nodes: []*corev1.Node{
+				nodeWithRuntime("node-1", "cri-o://1.27.1"),
+			},
+			wantHit: false,
+		},
+		{
+			name: "docker only",
+			nodes: []*corev1.Node{
+				nodeWithRuntime("node-1", "docker://24.0.2"),
+			},
+			wantHit: true,
+		},
+		{
+			name: "mixed — one docker node among containerd",
+			nodes: []*corev1.Node{
+				nodeWithRuntime("node-1", "containerd://1.6.21"),
+				nodeWithRuntime("node-2", "docker://20.10.23"),
+				nodeWithRuntime("node-3", "containerd://1.7.0"),
+			},
+			wantHit: true,
+		},
+		{
+			name: "empty runtime string",
+			nodes: []*corev1.Node{
+				nodeWithRuntime("node-1", ""),
+			},
+			wantHit: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := anyNodeUsesDocker(tt.nodes)
+			if tt.wantHit && got == "" {
+				t.Error("expected cri-docker hint, got empty string")
+			}
+			if !tt.wantHit && got != "" {
+				t.Errorf("expected no hint, got: %s", got)
+			}
+			if tt.wantHit && got != criDockerHint {
+				t.Errorf("hint text mismatch:\n  got:  %s\n  want: %s", got, criDockerHint)
+			}
+		})
+	}
+}
+
+func nodeWithRuntime(name, runtimeVersion string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: corev1.NodeStatus{
+			NodeInfo: corev1.NodeSystemInfo{
+				ContainerRuntimeVersion: runtimeVersion,
+			},
+		},
+	}
+}

--- a/packages/k8s-ui/src/components/workload/WorkloadView.tsx
+++ b/packages/k8s-ui/src/components/workload/WorkloadView.tsx
@@ -444,6 +444,7 @@ export function WorkloadView({
               isSavingSecret={isUpdatingResource}
               rendererOverrides={rendererOverrides}
               resolvedEnvFrom={resolvedEnvFrom}
+              renderMetrics={renderMetricsTab}
             />
           )}
         </div>

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -892,6 +892,7 @@ export interface PrometheusResourceMetrics {
   range: string
   result: PrometheusQueryResult
   query?: string // PromQL query (included when result is empty, for diagnostics)
+  hint?: string  // Contextual hint when results are empty (e.g. cri-docker label issues)
 }
 
 export type PrometheusMetricCategory = 'cpu' | 'memory' | 'network_rx' | 'network_tx' | 'filesystem'

--- a/web/src/components/resource/PrometheusCharts.tsx
+++ b/web/src/components/resource/PrometheusCharts.tsx
@@ -221,6 +221,11 @@ export function PrometheusCharts({ kind, namespace, name, showEmptyState = false
             <p className="text-xs text-theme-text-quaternary mt-1">
               Try a different time range or check that metrics are being collected
             </p>
+            {metrics?.hint && (
+              <p className="mt-3 px-3 py-2 w-full max-w-lg text-xs text-yellow-700 dark:text-yellow-400 bg-yellow-500/10 border border-yellow-500/30 rounded">
+                {metrics.hint}
+              </p>
+            )}
             {metrics?.query && (
               <details className="mt-3 w-full max-w-lg text-left">
                 <summary className="text-xs text-theme-text-quaternary cursor-pointer hover:text-theme-text-tertiary">


### PR DESCRIPTION
## Summary

Addresses #240 — when Prometheus is connected but queries return no data, users on cri-docker clusters now see a targeted diagnostic hint explaining that the Docker container runtime is known to cause missing pod/namespace labels in cAdvisor metrics.

### cri-docker hint

The hint is kind-aware:
- **Pod** — checks the specific node the pod is scheduled on
- **Workload** (Deployment, StatefulSet, etc.) — checks nodes running pods that match the workload
- **Node** — skipped (node-exporter metrics don't use cAdvisor labels)
- **Fallback** — if no pods are resolved, checks all cluster nodes

No change for users on containerd/cri-o.

**Backend:** `detectCRIDockerHint()` resolves relevant nodes from the cache and checks `ContainerRuntimeVersion` for `docker://`. Returns a hint string in the empty-result response via a new `hint` JSON field.
**Frontend:** Renders the hint as a warning banner (using standard theme-aware warning colors) above the existing PromQL diagnostics section.

### Drawer metrics fix

Also fixes Prometheus charts not appearing in the collapsed drawer view — `renderMetrics` was not being passed to `ResourceRendererDispatch` in the drawer mode of `WorkloadView`, so charts only showed in the expanded full-page view.

### Tests

Unit tests for the `anyNodeUsesDocker` helper covering containerd, cri-o, docker, mixed, and empty runtime scenarios.