### PR TITLE
feat: cascade delete preview in delete dialog

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -151,6 +151,7 @@ func (s *Server) setupRoutes() {
 			r.Get("/resources/{kind}", s.handleListResources)
 			r.Get("/resources/{kind}/{namespace}/{name}", s.handleGetResource)
 			r.Put("/resources/{kind}/{namespace}/{name}", s.handleUpdateResource)
+			r.Get("/resources/{kind}/{namespace}/{name}/cascade-preview", s.handleCascadeDeletePreview)
 			r.Delete("/resources/{kind}/{namespace}/{name}", s.handleDeleteResource)
 			r.Get("/secrets/certificate-expiry", s.handleSecretCertExpiry)
 			r.Get("/events", s.handleEvents)
@@ -1592,6 +1593,27 @@ func (s *Server) handleDeleteResource(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleCascadeDeletePreview returns a preview of resources that would be garbage-collected
+// if the specified resource is deleted (via Kubernetes owner reference cascade).
+func (s *Server) handleCascadeDeletePreview(w http.ResponseWriter, r *http.Request) {
+	if !s.requireConnected(w) {
+		return
+	}
+
+	kind := chi.URLParam(r, "kind")
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+	if namespace == "_" {
+		namespace = ""
+	}
+
+	cachedTopo := s.broadcaster.GetCachedTopology()
+	dp := k8s.NewTopologyDynamicProvider(k8s.GetDynamicResourceCache(), k8s.GetResourceDiscovery())
+	preview := topology.GetCascadeDeletePreview(kind, namespace, name, cachedTopo, dp)
+
+	s.writeJSON(w, preview)
 }
 
 // handleTriggerCronJob creates a Job from a CronJob

--- a/packages/k8s-ui/src/components/shared/ResourceActionsBar.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceActionsBar.tsx
@@ -18,7 +18,7 @@ import {
 } from 'lucide-react'
 import { createTwoFilesPatch } from 'diff'
 import { clsx } from 'clsx'
-import { ForceDeleteConfirmDialog } from '../ui/ForceDeleteConfirmDialog'
+import { ForceDeleteConfirmDialog, type CascadeDependent } from '../ui/ForceDeleteConfirmDialog'
 import { ConfirmDialog } from '../ui/ConfirmDialog'
 import { DialogPortal } from '../ui/DialogPortal'
 import type { SelectedResource, WorkloadRevision } from '../../types'
@@ -53,6 +53,8 @@ interface ResourceActionsBarProps {
   // Delete
   onDelete?: (params: { kind: string; namespace: string; name: string; force: boolean }, callbacks?: { onSuccess?: () => void; onError?: (err: unknown) => void }) => void
   isDeleting?: boolean
+  cascadeDependents?: CascadeDependent[]
+  cascadeLoading?: boolean
 
   // Workload restart
   onRestart?: (params: { kind: string; namespace: string; name: string }, callbacks?: { onSuccess?: () => void; onError?: (err: unknown) => void }) => void
@@ -111,7 +113,7 @@ export function ResourceActionsBar({
   canExec, canViewLogs, canPortForward,
   onOpenTerminal, onOpenLogs: openLogs, onOpenWorkloadLogs: openWorkloadLogs, onCopyCommand,
   renderPortForward,
-  onDelete, isDeleting,
+  onDelete, isDeleting, cascadeDependents, cascadeLoading,
   onRestart, isRestarting,
   revisions: revisionsList, revisionsLoading, revisionsError, onRollback, isRollingBack,
   onTriggerCronJob, isTriggeringCronJob,
@@ -498,6 +500,8 @@ export function ResourceActionsBar({
         resourceKind={formatKindName(resource.kind)}
         namespaceName={resource.namespace}
         isLoading={isDeleting ?? false}
+        cascadeDependents={cascadeDependents}
+        cascadeLoading={cascadeLoading}
       />
 
       {/* Node cordon confirmation */}

--- a/packages/k8s-ui/src/components/ui/ForceDeleteConfirmDialog.tsx
+++ b/packages/k8s-ui/src/components/ui/ForceDeleteConfirmDialog.tsx
@@ -1,5 +1,14 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
+import { ChevronDown, ChevronRight, Loader2 } from 'lucide-react'
 import { ConfirmDialog } from './ConfirmDialog'
+import { formatKindName } from './drawer-components'
+
+export interface CascadeDependent {
+  kind: string
+  namespace: string
+  name: string
+  group?: string
+}
 
 interface ForceDeleteConfirmDialogProps {
   open: boolean
@@ -9,6 +18,8 @@ interface ForceDeleteConfirmDialogProps {
   resourceKind: string
   namespaceName: string
   isLoading: boolean
+  cascadeDependents?: CascadeDependent[]
+  cascadeLoading?: boolean
 }
 
 export function ForceDeleteConfirmDialog({
@@ -19,6 +30,8 @@ export function ForceDeleteConfirmDialog({
   resourceKind,
   namespaceName,
   isLoading,
+  cascadeDependents,
+  cascadeLoading,
 }: ForceDeleteConfirmDialogProps) {
   const [forceDelete, setForceDelete] = useState(false)
 
@@ -43,15 +56,76 @@ export function ForceDeleteConfirmDialog({
       variant="danger"
       isLoading={isLoading}
     >
-      <label className="flex items-center gap-2 text-sm text-theme-text-secondary">
-        <input
-          type="checkbox"
-          checked={forceDelete}
-          onChange={(e) => setForceDelete(e.target.checked)}
-          className="w-4 h-4 rounded border-theme-border bg-theme-base text-red-600 focus:ring-red-500 focus:ring-offset-0"
-        />
-        <span>Force delete (strips finalizers and bypasses grace period)</span>
-      </label>
+      <div className="flex flex-col gap-3 pb-1">
+        {cascadeLoading && (
+          <div className="flex items-center gap-2 text-xs text-theme-text-tertiary">
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            Checking for dependent resources...
+          </div>
+        )}
+
+        {!cascadeLoading && cascadeDependents && cascadeDependents.length > 0 && (
+          <CascadeDependentsList dependents={cascadeDependents} />
+        )}
+
+        <label className="flex items-center gap-2 text-sm text-theme-text-secondary">
+          <input
+            type="checkbox"
+            checked={forceDelete}
+            onChange={(e) => setForceDelete(e.target.checked)}
+            className="w-4 h-4 rounded border-theme-border bg-theme-base text-red-600 focus:ring-red-500 focus:ring-offset-0"
+          />
+          <span>Force delete (strips finalizers and bypasses grace period)</span>
+        </label>
+      </div>
     </ConfirmDialog>
+  )
+}
+
+const MAX_NAMES_PER_KIND = 8
+
+function CascadeDependentsList({ dependents }: { dependents: CascadeDependent[] }) {
+  const [expanded, setExpanded] = useState(false)
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, string[]>()
+    for (const dep of dependents) {
+      const kind = dep.kind
+      if (!map.has(kind)) map.set(kind, [])
+      map.get(kind)!.push(dep.name)
+    }
+    return Array.from(map.entries()).sort((a, b) => a[0].localeCompare(b[0]))
+  }, [dependents])
+
+  return (
+    <div className="rounded border border-amber-500/30 bg-amber-500/5">
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="flex items-center gap-2 w-full px-3 py-2 text-left text-xs font-medium text-amber-400 hover:bg-amber-500/10 transition-colors"
+      >
+        {expanded ? <ChevronDown className="w-3.5 h-3.5 shrink-0" /> : <ChevronRight className="w-3.5 h-3.5 shrink-0" />}
+        <span>
+          Will also delete {dependents.length} dependent {dependents.length === 1 ? 'resource' : 'resources'}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="px-3 pb-2.5 space-y-1.5">
+          {grouped.map(([kind, names]) => (
+            <div key={kind} className="text-xs">
+              <span className="font-medium text-theme-text-primary">{formatKindName(kind)}</span>
+              <span className="text-theme-text-tertiary ml-1">({names.length})</span>
+              <div className="ml-3 mt-0.5 text-theme-text-secondary font-mono break-all">
+                {names.slice(0, MAX_NAMES_PER_KIND).join(', ')}
+                {names.length > MAX_NAMES_PER_KIND && (
+                  <span className="text-theme-text-tertiary"> +{names.length - MAX_NAMES_PER_KIND} more</span>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
   )
 }

--- a/pkg/topology/relationships.go
+++ b/pkg/topology/relationships.go
@@ -6,6 +6,64 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// GetCascadeDeletePreview returns a preview of all resources that will be garbage-collected
+// when the specified resource is deleted. It walks EdgeManages edges recursively
+// to find all transitive dependents — mirroring Kubernetes owner-reference cascade behavior.
+func GetCascadeDeletePreview(kind, namespace, name string, topo *Topology, dp DynamicProvider) *CascadeDeletePreview {
+	if topo == nil {
+		return &CascadeDeletePreview{
+			Root:       ResourceRef{Kind: kind, Namespace: namespace, Name: name},
+			Dependents: []ResourceRef{},
+		}
+	}
+
+	root := ResourceRef{Kind: kind, Namespace: namespace, Name: name}
+	enrichRef(&root, dp)
+
+	// Build adjacency list for EdgeManages edges (source → targets)
+	manages := make(map[string][]string)
+	for _, edge := range topo.Edges {
+		if edge.Type == EdgeManages {
+			manages[edge.Source] = append(manages[edge.Source], edge.Target)
+		}
+	}
+
+	// BFS from root node
+	rootID := buildNodeID(kind, namespace, name, dp)
+	visited := map[string]bool{rootID: true}
+	queue := []string{rootID}
+	var dependents []ResourceRef
+
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		for _, targetID := range manages[current] {
+			if visited[targetID] {
+				continue
+			}
+			visited[targetID] = true
+
+			ref := parseNodeID(targetID, dp)
+			if ref == nil {
+				continue
+			}
+			enrichRef(ref, dp)
+			dependents = append(dependents, *ref)
+			queue = append(queue, targetID)
+		}
+	}
+
+	if dependents == nil {
+		dependents = []ResourceRef{}
+	}
+
+	return &CascadeDeletePreview{
+		Root:       root,
+		Dependents: dependents,
+	}
+}
+
 // resolveAPIGroup returns the API group for a resource kind using resource discovery.
 // Returns empty string for core K8s types (pods, services, etc.).
 func resolveAPIGroup(kind string, dp DynamicProvider) string {

--- a/pkg/topology/types.go
+++ b/pkg/topology/types.go
@@ -256,6 +256,13 @@ type SecretCertificateInfo struct {
 	Certificates []CertificateInfo `json:"certificates"`
 }
 
+// CascadeDeletePreview represents all resources that will be garbage-collected
+// when a parent resource is deleted via Kubernetes owner reference cascade.
+type CascadeDeletePreview struct {
+	Root       ResourceRef   `json:"root"`
+	Dependents []ResourceRef `json:"dependents"`
+}
+
 // ResourceWithRelationships wraps a K8s resource with computed relationships
 type ResourceWithRelationships struct {
 	Resource        any                    `json:"resource"`

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1106,6 +1106,21 @@ export function useUpdateResource() {
   })
 }
 
+// Cascade delete preview — shows resources that will be garbage-collected
+export interface CascadeDeletePreview {
+  root: { kind: string; namespace: string; name: string; group?: string }
+  dependents: { kind: string; namespace: string; name: string; group?: string }[]
+}
+
+export function useCascadeDeletePreview(kind: string, namespace: string, name: string, enabled: boolean) {
+  return useQuery<CascadeDeletePreview>({
+    queryKey: ['cascade-preview', kind, namespace, name],
+    queryFn: () => fetchJSON<CascadeDeletePreview>(`/resources/${kind}/${namespace}/${name}/cascade-preview`),
+    enabled,
+    staleTime: 30_000,
+  })
+}
+
 // Delete a resource
 export function useDeleteResource() {
   const queryClient = useQueryClient()

--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -16,6 +16,7 @@ import {
   useFluxReconcile, useFluxSyncWithSource, useFluxSuspend, useFluxResume,
   useArgoSync, useArgoRefresh, useArgoSuspend, useArgoResume,
   useCordonNode, useUncordonNode, useDrainNode,
+  useCascadeDeletePreview,
   fetchJSON,
 } from '../../api/client'
 import { PrometheusCharts, isPrometheusSupported } from '../resource/PrometheusCharts'
@@ -134,6 +135,8 @@ function useActionsBarProps(kind: string, namespace: string, name: string) {
   const argoSuspendMutation = useArgoSuspend()
   const argoResumeMutation = useArgoResume()
 
+  const { data: cascadePreview, isLoading: cascadeLoading } = useCascadeDeletePreview(kind, namespace, name, true)
+
   const canNodeWrite = useCanNodeWrite()
   const cordonMutation = useCordonNode()
   const uncordonMutation = useUncordonNode()
@@ -153,6 +156,8 @@ function useActionsBarProps(kind: string, namespace: string, name: string) {
     ),
     onDelete: (params: any, callbacks?: any) => deleteMutation.mutate(params, { onSuccess: callbacks?.onSuccess }),
     isDeleting: deleteMutation.isPending,
+    cascadeDependents: cascadePreview?.dependents,
+    cascadeLoading,
     onRestart: (params: any) => restartWorkloadMutation.mutate(params),
     isRestarting: restartWorkloadMutation.isPending,
     revisions: revisionsList,


### PR DESCRIPTION
## Summary
- Adds a cascade delete preview to the resource delete confirmation dialog
- When deleting a resource (e.g. a Deployment), the dialog now shows an expandable warning listing all dependent resources that will be garbage-collected (ReplicaSets, Pods, etc.)
- Backend: new `GET /api/resources/{kind}/{ns}/{name}/cascade-preview` endpoint that walks `EdgeManages` topology edges via BFS to find all transitive dependents
- Frontend: expandable amber-highlighted section in the delete dialog grouped by resource kind

## Changes
- **`pkg/topology/`**: `GetCascadeDeletePreview()` BFS function + `CascadeDeletePreview` type
- **`internal/server/server.go`**: New cascade-preview HTTP handler
- **`packages/k8s-ui/`**: `ForceDeleteConfirmDialog` now renders cascade dependents list; `ResourceActionsBar` accepts cascade props
- **`web/src/`**: `useCascadeDeletePreview` React Query hook, wired through `useActionsBarProps` in `WorkloadView`

<img width="896" height="822" alt="localhost_50433_resources_deployments_apiGroup=apps resource=staging%2Fbilling" src="https://github.com/user-attachments/assets/a97fed45-88b9-445c-acf7-57f9d034c5a4" />
