### PR TITLE
Open local terminal support for Windows machine

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,7 +10,9 @@ import (
 func TestLoadMissing(t *testing.T) {
 	// Override path to a non-existent file
 	orig := os.Getenv("HOME")
-	t.Setenv("HOME", t.TempDir())
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
 	defer os.Setenv("HOME", orig)
 
 	c := Load()
@@ -22,6 +24,7 @@ func TestLoadMissing(t *testing.T) {
 func TestSaveAndLoad(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
 
 	mcp := true
 	want := Config{
@@ -74,7 +77,9 @@ func TestSaveAndLoad(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
 
 	result, err := Update(func(c *Config) {
 		c.Port = 8080
@@ -146,6 +151,7 @@ func TestHelpers(t *testing.T) {
 func TestLoadInvalidJSON(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
 
 	path := filepath.Join(dir, ".radar")
 	os.MkdirAll(path, 0o755)

--- a/internal/server/localterm_windows.go
+++ b/internal/server/localterm_windows.go
@@ -105,9 +105,11 @@ func startShell(shell string, env []string, dir string) (*shellProcess, error) {
 	}
 	defer attrs.Delete()
 
+	// Pass the pseudo console handle value directly (not a pointer to it).
+	// HPCON is a void* in C — lpValue expects the handle value itself.
 	err = attrs.Update(
 		windows.PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
-		unsafe.Pointer(&hPC),
+		unsafe.Pointer(hPC),
 		unsafe.Sizeof(hPC),
 	)
 	if err != nil {

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 func TestLoadMissing(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
 
 	s := Load()
 	if s.Theme != "" || s.PinnedKinds != nil {
@@ -17,7 +19,9 @@ func TestLoadMissing(t *testing.T) {
 }
 
 func TestSaveAndLoad(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
 
 	want := Settings{
 		Theme:       "dark",
@@ -38,7 +42,9 @@ func TestSaveAndLoad(t *testing.T) {
 }
 
 func TestUpdateMergesFields(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
 
 	// Set initial state
 	Save(Settings{Theme: "light"})
@@ -79,6 +85,7 @@ func TestEmptySettingsProducesMinimalJSON(t *testing.T) {
 func TestLoadInvalidJSON(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
 
 	os.MkdirAll(filepath.Join(dir, ".radar"), 0o755)
 	os.WriteFile(filepath.Join(dir, ".radar", "settings.json"), []byte("{bad"), 0o644)
@@ -92,6 +99,7 @@ func TestLoadInvalidJSON(t *testing.T) {
 func TestSaveCreatesDirectory(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
 
 	// .radar/ doesn't exist yet
 	if err := Save(Settings{Theme: "light"}); err != nil {


### PR DESCRIPTION
## Description

Windows machine.
The terminal area is blank. No prompt, no output, no response to keyboard input. The session starts on the backend (log shows [localterm] Session local-term-N started (shell=C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe)) but no data flows back to the browser.

In internal/server/localterm_windows.go, the ConPTY pipes were created using os.Pipe() which returns *os.File. Go's os.File wrapper on Windows adds internal runtime management that is incompatible with ConPTY's synchronous anonymous pipes. This causes outRead.Read() (PTY → WebSocket goroutine) to block indefinitely — no shell output ever reaches the browser.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

Describe the tests you ran to verify your changes.

- [ ] Tested locally with minikube/kind
- [x] Tested against a remote cluster
- [ ] Added/updated unit tests

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

## Related issues

Fixes #335
