### PR TITLE
fix: ad-hoc codesign macOS desktop app (#343)

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -56,6 +56,14 @@ jobs:
       - name: Build macOS .app (universal)
         run: cd cmd/desktop && wails build -platform darwin/universal -ldflags "-X main.version=${GITHUB_REF_NAME#v}"
 
+      - name: Ad-hoc codesign
+        run: |
+          APP="build/bin/radar-desktop.app"
+          # Sign all nested binaries and frameworks first, then the bundle
+          codesign --force --deep --sign - "$APP"
+          # Verify the signature
+          codesign --verify --verbose "$APP"
+
       - name: Create archive
         run: |
           VERSION="${GITHUB_REF_NAME}"
@@ -386,9 +394,8 @@ jobs:
             app "Radar.app"
 
             caveats <<~EOS
-              Radar Desktop is not yet code-signed. On first launch:
+              Radar Desktop is not yet notarized with Apple. On first launch:
                 Right-click Radar.app → Open → click "Open"
-              Or install with: brew install --cask --no-quarantine radar-desktop
             EOS
           end
           CASK


### PR DESCRIPTION
## Summary

Fixes #343 — Radar Desktop silently fails to launch on macOS 26.3.1 (and Apple Silicon in general).

- **Root cause**: The release workflow produces a completely unsigned `.app` bundle. Apple's AMFI terminates unsigned ARM64 binaries (`Killed: 9`), and newer macOS versions silently ignore "Run Anyway" for unsigned apps.
- **Fix**: Adds an ad-hoc codesign step (`codesign --force --deep --sign -`) after the Wails build in the macOS release job. This satisfies the minimum signature requirement so the app can actually launch.
- **Homebrew cask**: Removed the stale `--no-quarantine` caveat (Homebrew no longer supports that flag) and updated the message to reflect the current state.

Users will still see a Gatekeeper warning on first launch (right-click → Open), but the app will run. Full Developer ID notarization is a follow-up.

## Test plan

- [ ] Trigger a desktop release build and verify the codesign step passes
- [ ] Download the resulting `.zip` on an Apple Silicon Mac running macOS 26.x
- [ ] Confirm the app launches after right-click → Open