### PR TITLE
feat(ui): close resource and Helm drawers by clicking outside

### DIFF
--- a/packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx
+++ b/packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx
@@ -113,6 +113,19 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
   const headerHeight = headerHeightProp ?? 49
 
   return (
+    <>
+      {/* Backdrop — only shown in drawer mode (not expanded), closes on click */}
+      {!expanded && (
+        <div
+          className={clsx(
+            'fixed inset-0 z-30 transition-opacity duration-300',
+            isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none',
+          )}
+          style={{ top: headerHeight }}
+          onClick={onClose}
+        />
+      )}
+
     <div
       className={clsx(
         'fixed right-0 bg-theme-surface border-l border-theme-border flex flex-col shadow-2xl z-40',
@@ -154,5 +167,6 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
         onCollapseToDrawer: onCollapse ? () => onCollapse() : undefined,
       })}
     </div>
+    </>
   )
 }

--- a/web/src/components/helm/HelmReleaseDrawer.tsx
+++ b/web/src/components/helm/HelmReleaseDrawer.tsx
@@ -282,6 +282,17 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
   }
 
   return (
+    <>
+      {/* Backdrop — closes drawer on click */}
+      <div
+        className={clsx(
+          'fixed inset-0 z-30 transition-opacity duration-300',
+          isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none',
+        )}
+        style={{ top: headerHeight }}
+        onClick={onClose}
+      />
+
     <div
       className={clsx(
         'fixed right-0 bg-theme-surface border-l border-theme-border flex flex-col shadow-2xl z-40',
@@ -533,6 +544,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
         {upgradeProgress.length > 0 && <ProgressLog entries={upgradeProgress} />}
       </ConfirmDialog>
     </div>
+    </>
   )
 }
 


### PR DESCRIPTION
Add a transparent backdrop overlay behind the resource detail drawer and Helm release drawer so users can dismiss them by clicking any empty area, instead of having to click the same row again.

Made-with: Cursor

## Description

Currently, to close the resource detail drawer or Helm release drawer, users had to click the same row that opened it (or the X button). This PR adds a transparent backdrop overlay behind both drawers so clicking anywhere on the empty area to the left dismisses them — a more intuitive UX pattern.

Changes:
- `packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx` — backdrop is hidden when the drawer is expanded to full-screen WorkloadView to prevent accidental dismissal
- `web/src/components/helm/HelmReleaseDrawer.tsx` — same backdrop added

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

- [x] Tested locally with a remote cluster (EKS)
- Opened a resource in the Resources view → clicked empty area to the left of the drawer → it closed
- Opened a Helm release → clicked empty area to the left → it closed
- Expanded resource drawer to full WorkloadView → confirmed backdrop is not shown (no accidental close)
- Confirmed X button and row click still work as before

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged

## Related issues

N/A