### PR TITLE
fix: workload log streaming follows pod rollouts

### DIFF
--- a/internal/server/workload_logs.go
+++ b/internal/server/workload_logs.go
@@ -169,7 +169,7 @@ func (s *Server) handleWorkloadLogsStream(w http.ResponseWriter, r *http.Request
 	logCh := make(chan workloadLogEntry, 1000)
 
 	// Track active streams
-	var activeStreams sync.Map // podName+containerName -> cancel func
+	var activeStreams sync.Map // podName/containerName -> cancel func
 	var streamWg sync.WaitGroup
 
 	// Start streaming from each pod/container
@@ -186,12 +186,12 @@ func (s *Server) handleWorkloadLogsStream(w http.ResponseWriter, r *http.Request
 				activeStreams.Store(key, streamCancel)
 
 				streamWg.Add(1)
-				go func(podName, containerName string, streamCtx context.Context) {
+				go func(podName, containerName, key string, streamCtx context.Context) {
 					defer streamWg.Done()
-					defer activeStreams.Delete(podName + "/" + containerName)
+					defer activeStreams.Delete(key)
 
 					streamPodLogs(streamCtx, client, namespace, podName, containerName, tailLines, sinceSeconds, logCh)
-				}(pod.Name, c, streamCtx)
+				}(pod.Name, c, key, streamCtx)
 			}
 		}
 	}
@@ -228,10 +228,8 @@ func (s *Server) handleWorkloadLogsStream(w http.ResponseWriter, r *http.Request
 			}
 
 			// Check for new pods
-			var newPods []*corev1.Pod
 			for _, p := range currentPods {
 				if !knownPods[p.Name] {
-					newPods = append(newPods, p)
 					knownPods[p.Name] = true
 					// Notify frontend about new pod
 					sendSSEEvent(w, flusher, "pod_added", map[string]any{
@@ -262,10 +260,10 @@ func (s *Server) handleWorkloadLogsStream(w http.ResponseWriter, r *http.Request
 				}
 			}
 
-			// Start streams for new pods
-			if len(newPods) > 0 {
-				startPodStreams(newPods)
-			}
+			// Start streams for all current pods — startPodStreams skips pods
+			// that already have active streams, so this safely retries pods
+			// whose initial stream failed (e.g., container wasn't ready yet)
+			startPodStreams(currentPods)
 		}
 	}
 }

--- a/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
+++ b/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
@@ -131,6 +131,29 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, forceDark }: 
             })
           }
         },
+        onPodAdded: (data: any) => {
+          if (data?.pods) {
+            const newPods = data.pods as WorkloadPodInfo[]
+            setPods(prev => {
+              const existing = new Set(prev.map(p => p.name))
+              const toAdd = newPods.filter(p => !existing.has(p.name))
+              return toAdd.length > 0 ? [...prev, ...toAdd] : prev
+            })
+            setSelectedPods(prev => {
+              const next = new Set(prev)
+              newPods.forEach(p => next.add(p.name))
+              return next
+            })
+          }
+        },
+        onPodRemoved: (data: any) => {
+          if (data?.pod) {
+            const removedName = data.pod as string
+            setPods(prev => prev.filter(p => p.name !== removedName))
+            // Don't remove from selectedPods — keep old log entries visible
+            // while new pod logs start flowing in
+          }
+        },
       },
       'Workload log stream error',
     )
@@ -152,8 +175,9 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, forceDark }: 
   }, [])
 
   const toggleAllPods = useCallback(() => {
-    setSelectedPods(selectedPods.size === pods.length ? new Set() : new Set(pods.map(p => p.name)))
-  }, [selectedPods.size, pods])
+    const allSelected = pods.every(p => selectedPods.has(p.name))
+    setSelectedPods(allSelected ? new Set() : new Set(pods.map(p => p.name)))
+  }, [selectedPods, pods])
 
   const filteredEntries = useMemo(
     () => entries.filter(e => !e.pod || selectedPods.has(e.pod)),
@@ -200,7 +224,7 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, forceDark }: 
           }`}
         >
           <Filter className="w-3 h-3" />
-          <span>{selectedPods.size}/{pods.length} pods</span>
+          <span>{pods.filter(p => selectedPods.has(p.name)).length}/{pods.length} pods</span>
           <ChevronDown className="w-3 h-3" />
         </button>
 
@@ -208,7 +232,7 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, forceDark }: 
           <div className="absolute top-full left-0 mt-1 w-64 bg-theme-elevated border border-theme-border rounded-lg shadow-lg z-50 max-h-64 overflow-y-auto">
             <div className="p-2 border-b border-theme-border">
               <button onClick={toggleAllPods} className="text-xs text-blue-400 hover:text-blue-300">
-                {selectedPods.size === pods.length ? 'Deselect all' : 'Select all'}
+                {pods.every(p => selectedPods.has(p.name)) ? 'Deselect all' : 'Select all'}
               </button>
             </div>
             {pods.map(pod => (

--- a/packages/k8s-ui/src/components/logs/useLogStream.ts
+++ b/packages/k8s-ui/src/components/logs/useLogStream.ts
@@ -6,6 +6,10 @@ export interface LogStreamHandlers {
   onConnected?: (data: unknown) => void
   /** Called for each log event with parsed event data */
   onLog: (data: unknown) => void
+  /** Called when new pods are discovered during streaming (workload logs only) */
+  onPodAdded?: (data: unknown) => void
+  /** Called when pods are terminated during streaming (workload logs only) */
+  onPodRemoved?: (data: unknown) => void
 }
 
 /**
@@ -42,6 +46,22 @@ export function useLogStream() {
     es.addEventListener('log', (event) => {
       try { handlers.onLog(JSON.parse((event as MessageEvent).data)) } catch (e) {
         console.error('Failed to parse log event:', e)
+      }
+    })
+
+    es.addEventListener('pod_added', (event) => {
+      if (handlers.onPodAdded) {
+        try { handlers.onPodAdded(JSON.parse((event as MessageEvent).data)) } catch (e) {
+          console.error('Failed to parse pod_added event:', e)
+        }
+      }
+    })
+
+    es.addEventListener('pod_removed', (event) => {
+      if (handlers.onPodRemoved) {
+        try { handlers.onPodRemoved(JSON.parse((event as MessageEvent).data)) } catch (e) {
+          console.error('Failed to parse pod_removed event:', e)
+        }
       }
     })
 


### PR DESCRIPTION
## Summary

During a deployment rollout, the workload log viewer would sometimes show "No logs available" after pods rolled over. Two independent bugs:

- **Frontend**: The `pod_added` and `pod_removed` SSE events (already sent by the backend) were never listened to. When the old pod terminated, its log entries were filtered out before new pod logs arrived — leaving the viewer empty.
- **Backend**: If a new pod wasn't ready when the 5-second discovery tick fired, `streamPodLogs` failed and was never retried — the pod was already in `knownPods` so future ticks skipped it.

### Changes

- `useLogStream.ts`: Added `pod_added`/`pod_removed` event listeners with optional callbacks
- `WorkloadLogsViewer.tsx`: Handles pod lifecycle events — adds new pods to the filter and auto-selects them; keeps old log entries visible during transitions
- `workload_logs.go`: Discovery tick now calls `startPodStreams` for all current pods (not just new ones), safely retrying failed streams since the function already skips active ones

Closes #355