### PR TITLE
feat: 3-level namespace topology with workload cards

### DIFF
--- a/packages/k8s-ui/src/components/topology/GroupNode.tsx
+++ b/packages/k8s-ui/src/components/topology/GroupNode.tsx
@@ -1,6 +1,10 @@
 import { memo } from 'react'
 import { NodeProps, Handle, Position } from '@xyflow/react'
-import { ChevronDown, ChevronRight, Box, Tag } from 'lucide-react'
+import { Box, LayoutGrid, Maximize2, Minus, Tag, Workflow } from 'lucide-react'
+import { healthToSeverity, SEVERITY_DOT } from '../../utils/badge-colors'
+import type { HealthStatus } from '../../types'
+import { Tooltip } from '../ui/Tooltip'
+import type { WorkloadCard, GroupDisplayLevel } from './layout'
 
 interface GroupNodeData {
   type: 'namespace' | 'app' | 'label'
@@ -8,8 +12,16 @@ interface GroupNodeData {
   label?: string
   nodeCount: number
   collapsed: boolean
-  onToggleCollapse: (groupId: string) => void
+  displayLevel: GroupDisplayLevel
+  onSetLevel: (groupId: string, level: GroupDisplayLevel) => void
+  onCardClick?: (nodeId: string) => void
+  onMaximizeNamespace?: (namespace: string) => void
   hideHeader?: boolean
+  worstStatus?: HealthStatus
+  unhealthyCount?: number
+  kindCounts?: Record<string, number>
+  workloadCards?: WorkloadCard[]
+  gridColumns?: number
 }
 
 export const GroupNode = memo(function GroupNode({
@@ -18,7 +30,14 @@ export const GroupNode = memo(function GroupNode({
   width,
   height,
 }: NodeProps & { data: GroupNodeData }) {
-  const { type, name, label, nodeCount, collapsed, onToggleCollapse, hideHeader } = data
+  const {
+    type, name, label, nodeCount, displayLevel,
+    onSetLevel, onCardClick, onMaximizeNamespace, hideHeader,
+    worstStatus, unhealthyCount, kindCounts,
+    workloadCards, gridColumns,
+  } = data
+  const hasProblems = (unhealthyCount ?? 0) > 0
+  const statusDotColor = hasProblems && worstStatus ? SEVERITY_DOT[healthToSeverity(worstStatus)] : null
 
   const getIcon = () => {
     switch (type) {
@@ -33,7 +52,6 @@ export const GroupNode = memo(function GroupNode({
   }
 
   const getBorderStyle = (): React.CSSProperties => {
-    // Must set full 'border' property to override ReactFlow's --xy-node-border
     switch (type) {
       case 'namespace':
         return { border: '2px solid var(--group-border-namespace)' }
@@ -87,112 +105,204 @@ export const GroupNode = memo(function GroupNode({
 
   const Icon = getIcon()
 
-  // When collapsed, render as a compact card
-  if (collapsed) {
+  // Invisible handles (shared across all levels)
+  const handles = (
+    <>
+      <Handle type="target" position={Position.Left} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Handle type="source" position={Position.Right} className="!bg-transparent !border-0 !w-0 !h-0" />
+    </>
+  )
+
+  // Level control buttons — shared across all headers
+  const TIP_DELAY = 100
+  const levelControls = (
+    <div className="flex items-center gap-0.5 shrink-0" onClick={(e) => e.stopPropagation()}>
+      <Tooltip content="Collapse" delay={TIP_DELAY} position="bottom">
+        <button
+          className={`p-1 rounded transition-colors ${displayLevel === 'chip' ? 'opacity-40' : 'hover:bg-white/10'}`}
+          onClick={() => displayLevel !== 'chip' && onSetLevel(id, 'chip')}
+          disabled={displayLevel === 'chip'}
+        >
+          <Minus className="w-4 h-4" style={getIconStyle()} />
+        </button>
+      </Tooltip>
+      <Tooltip content="Workload cards" delay={TIP_DELAY} position="bottom">
+        <button
+          className={`p-1 rounded transition-colors ${displayLevel === 'cardGrid' ? 'opacity-40' : 'hover:bg-white/10'}`}
+          onClick={() => displayLevel !== 'cardGrid' && onSetLevel(id, 'cardGrid')}
+          disabled={displayLevel === 'cardGrid'}
+        >
+          <LayoutGrid className="w-4 h-4" style={getIconStyle()} />
+        </button>
+      </Tooltip>
+      <Tooltip content="Full topology" delay={TIP_DELAY} position="bottom">
+        <button
+          className={`p-1 rounded transition-colors ${displayLevel === 'topology' ? 'opacity-40' : 'hover:bg-white/10'}`}
+          onClick={() => displayLevel !== 'topology' && onSetLevel(id, 'topology')}
+          disabled={displayLevel === 'topology'}
+        >
+          <Workflow className="w-4 h-4" style={getIconStyle()} />
+        </button>
+      </Tooltip>
+      {onMaximizeNamespace && type === 'namespace' && (
+        <Tooltip content="Focus namespace" delay={TIP_DELAY} position="bottom">
+          <button
+            className="p-1 rounded hover:bg-white/10 transition-colors"
+            onClick={() => onMaximizeNamespace(name)}
+          >
+            <Maximize2 className="w-4 h-4" style={getIconStyle()} />
+          </button>
+        </Tooltip>
+      )}
+    </div>
+  )
+
+  // ── Level 1: Chip (compact collapsed card) ──
+  if (displayLevel === 'chip') {
+    // Size tier: 0-9 → 0, 10-99 → 1, 100-999 → 2, 1000+ → 3
+    const tier = nodeCount === 0 ? 0 : Math.min(3, Math.floor(Math.log10(nodeCount)))
+    const nameSize = ['text-sm', 'text-xl', 'text-4xl', 'text-6xl'][tier]
+    const iconSize = ['w-3.5 h-3.5', 'w-5 h-5', 'w-9 h-9', 'w-12 h-12'][tier]
+    const maxPills = [2, 5, 8, 12][tier]
+    const chipPadding = ['8px 10px', '10px 12px', '14px 16px', '16px 20px'][tier]
+
+    const kindPills = kindCounts
+      ? Object.entries(kindCounts)
+          .sort(([, a], [, b]) => b - a)
+          .slice(0, maxPills)
+      : []
+
     return (
       <>
-        <Handle
-          type="target"
-          position={Position.Left}
-          className="!bg-transparent !border-0 !w-0 !h-0"
-        />
-
+        {handles}
         <div
-          className="rounded-xl p-4 cursor-pointer group-header-scaled"
-          onClick={() => onToggleCollapse(id)}
-          style={{ ...getBorderStyle(), ...getHeaderBgStyle() }}
+          className="rounded-xl group-header-scaled overflow-hidden"
+          style={{ ...getBorderStyle(), ...getHeaderBgStyle(), padding: chipPadding, width: width || '100%', height: height || '100%' }}
         >
-          <div className="flex items-center gap-4">
-            <ChevronRight className="w-8 h-8" style={getIconStyle()} />
-            <Icon className="w-9 h-9" style={getIconStyle()} />
-            <span className="text-4xl font-bold" style={getLabelStyle()}>{name}</span>
-            {label && (
-              <span className="text-sm text-theme-text-secondary">({label})</span>
+          {/* Header row: icon + name + count + status + controls */}
+          <div className="flex items-center gap-2 min-w-0">
+            <Icon className={`${iconSize} shrink-0`} style={getIconStyle()} />
+            <span className={`${nameSize} font-bold truncate`} style={getLabelStyle()}>{name}</span>
+            <span className="text-[10px] text-theme-text-secondary shrink-0 bg-theme-surface/50 rounded px-1.5 py-0.5">{nodeCount}</span>
+            {statusDotColor && (
+              <span className={`w-2 h-2 rounded-full shrink-0 ${statusDotColor}`} />
             )}
+            <div className="ml-auto shrink-0">{levelControls}</div>
           </div>
-          <div className="mt-3 text-xl text-theme-text-secondary">
-            {nodeCount} {nodeCount === 1 ? 'resource' : 'resources'}
-          </div>
+          {/* Kind pills row: colored icons with counts */}
+          {kindPills.length > 0 && (
+            <div className="flex flex-wrap gap-1 mt-1.5">
+              {kindPills.map(([kind, count]) => (
+                <div key={kind} className="flex items-center gap-1 bg-theme-surface/50 rounded px-1.5 py-0.5">
+                  <span className={`topology-icon topology-icon-${kind.toLowerCase()}`} style={{ width: 10, height: 10, fontSize: 6, borderRadius: 2 }} />
+                  <span className="text-[10px] text-theme-text-secondary">{count} {kind}{count > 1 ? 's' : ''}</span>
+                </div>
+              ))}
+              {kindCounts && Object.keys(kindCounts).length > maxPills && (
+                <span className="text-[10px] text-theme-text-tertiary self-center">+{Object.keys(kindCounts).length - maxPills}</span>
+              )}
+            </div>
+          )}
         </div>
-
-        <Handle
-          type="source"
-          position={Position.Right}
-          className="!bg-transparent !border-0 !w-0 !h-0"
-        />
       </>
     )
   }
 
-  // When expanded, render as a container with header
-  // Children are rendered automatically by ReactFlow via parentId
+  // ── Level 2: Card Grid (workload cards inside namespace) ──
+  if (displayLevel === 'cardGrid' && workloadCards) {
+    const cols = gridColumns || Math.min(4, workloadCards.length || 1)
+    return (
+      <>
+        {handles}
+        <div
+          className="rounded-xl overflow-hidden group-header-scaled"
+          style={{ ...getBorderStyle(), width: width || '100%', height: height || '100%' }}
+        >
+          {/* Header bar with level controls */}
+          <div
+            className="w-full relative flex items-center"
+            style={{ ...getHeaderBgStyle(), padding: '8px 12px' }}
+          >
+            <div className="flex items-center gap-2 min-w-0 flex-1">
+              <Icon className="shrink-0 w-5 h-5" style={getIconStyle()} />
+              <span className="font-bold truncate text-base" style={getLabelStyle()}>{name}</span>
+              <span className="shrink-0 text-xs text-theme-text-secondary bg-theme-surface/50 rounded px-1.5 py-0.5">
+                {workloadCards.length}
+              </span>
+            </div>
+            <div className="shrink-0 ml-2">{levelControls}</div>
+          </div>
+
+          {/* Workload card grid */}
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: `repeat(${cols}, 200px)`,
+              gap: '6px',
+              padding: '8px 14px 14px',
+            }}
+          >
+            {workloadCards.map(card => {
+              const statusClass = card.status === 'unhealthy' ? 'grid-card-unhealthy'
+                : card.status === 'degraded' ? 'grid-card-degraded'
+                : card.status === 'unknown' ? 'grid-card-unknown' : ''
+              return (
+                <div
+                  key={card.id}
+                  className={`grid-card ${statusClass}`}
+                  onClick={(e) => { e.stopPropagation(); onCardClick?.(card.id) }}
+                >
+                  <div className="grid-card-header">
+                    <span className={`topology-icon topology-icon-${card.kind.toLowerCase()}`} />
+                    <span className="grid-card-kind">{card.kind}</span>
+                    <span className="grid-card-count">{card.resourceCount}</span>
+                  </div>
+                  <div className="grid-card-name">{card.name}</div>
+                  {card.subtitle && (
+                    <div className="grid-card-subtitle">{card.subtitle}</div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      </>
+    )
+  }
+
+  // ── Level 3: Topology (full expanded container) ──
   return (
     <>
-      <Handle
-        type="target"
-        position={Position.Left}
-        className="!bg-transparent !border-0 !w-0 !h-0"
-      />
-
-      {/* Container with border - use explicit dimensions from props */}
-      {/* Top position adjusts based on CSS variable set by ViewportController */}
+      {handles}
       <div
-        className="absolute left-0 rounded-xl box-border isolate overflow-hidden bg-theme-surface/40 group-container-adjusted"
+        className={`absolute left-0 box-border isolate overflow-hidden group-container-adjusted ${hideHeader ? '' : 'rounded-xl bg-theme-surface/40'}`}
         style={{
           width: width || '100%',
           height: height || '100%',
-          ...getBorderStyle()
+          ...(hideHeader ? {} : getBorderStyle())
         }}
       >
-        {/* Header bar - background extends full width, content scales, count fixed right */}
-        {/* Hidden when hideHeader is true (single namespace view) */}
         {!hideHeader && (
           <div
-            className="w-full cursor-pointer relative flex items-center"
-            onClick={() => onToggleCollapse(id)}
-            style={getHeaderBgStyle()}
+            className="w-full relative flex items-center"
+            style={{ ...getHeaderBgStyle(), padding: '12px 16px' }}
           >
-            {/* Scaled content */}
             <div
-              className="flex items-center group-header-scaled"
-              style={{
-                padding: '20px 24px',
-                gap: '16px',
-              }}
+              className="flex items-center gap-3 min-w-0 flex-1 group-header-scaled"
             >
-              <ChevronDown
-                className="shrink-0 w-8 h-8"
-                style={getIconStyle()}
-              />
-              <Icon
-                className="shrink-0 w-9 h-9"
-                style={getIconStyle()}
-              />
-              <span
-                className="font-bold truncate text-4xl"
-                style={getLabelStyle()}
-              >
-                {name}
-              </span>
+              <Icon className="shrink-0 w-7 h-7" style={getIconStyle()} />
+              <span className="font-bold truncate text-2xl" style={getLabelStyle()}>{name}</span>
               {label && (
-                <span className="text-sm text-theme-text-secondary truncate">
-                  ({label})
-                </span>
+                <span className="text-sm text-theme-text-secondary truncate">({label})</span>
               )}
+              <span className="shrink-0 text-xs text-theme-text-secondary bg-theme-surface/50 rounded px-1.5 py-0.5">
+                {nodeCount}
+              </span>
             </div>
-            {/* Count badge - fixed size, anchored top-right */}
-            <span className="absolute right-4 top-4 shrink-0 font-medium text-sm text-theme-text-secondary bg-theme-surface/70 rounded-lg px-3 py-1">
-              {nodeCount}
-            </span>
+            <div className="shrink-0 ml-2">{levelControls}</div>
           </div>
         )}
       </div>
-
-      <Handle
-        type="source"
-        position={Position.Right}
-        className="!bg-transparent !border-0 !w-0 !h-0"
-      />
     </>
   )
 })

--- a/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
+++ b/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
@@ -20,13 +20,14 @@ import {
 import '@xyflow/react/dist/style.css'
 import { toCanvas } from 'html-to-image'
 
-import { AlertTriangle, Download, Loader2, Pause, Play, RotateCw, Shield } from 'lucide-react'
+import { AlertTriangle, Download, LayoutGrid, Loader2, Maximize, Minus, Pause, Play, Plus, RotateCw, Shield, Workflow } from 'lucide-react'
+import { Tooltip } from '../ui/Tooltip'
 import { useToast } from '../ui/Toast'
 import { useRegisterShortcuts } from '../../hooks/useKeyboardShortcuts'
 
 import { K8sResourceNode } from './K8sResourceNode'
 import { GroupNode } from './GroupNode'
-import { buildHierarchicalElkGraph, applyHierarchicalLayout, getGroupKey } from './layout'
+import { buildHierarchicalElkGraph, applyHierarchicalLayout, getGroupKey, type GroupDisplayLevel } from './layout'
 import type { Topology, TopologyNode, TopologyEdge, ViewMode, GroupingMode } from '../../types'
 
 // Edge colors by type
@@ -66,6 +67,9 @@ function getEdgeStyle(type: string, isTrafficView: boolean, isTrafficEdge: boole
 
 // Threshold for disabling edge animations (performance optimization)
 const EDGE_ANIMATION_THRESHOLD = 200
+
+// Auto-collapse all namespace groups when cluster has more than this many namespaces
+const LARGE_CLUSTER_NS_THRESHOLD = 5
 
 // Build edges, handling collapsed groups
 function buildEdges(
@@ -159,6 +163,14 @@ interface TopologyGraphProps {
   showExportButton?: boolean
   paused?: boolean
   onTogglePause?: () => void
+  /** Called when user clicks "maximize" on a namespace group — sets namespace filter to just that namespace */
+  onMaximizeNamespace?: (namespace: string) => void
+  /** Shown as a breadcrumb label when viewing a single namespace */
+  namespaceBreadcrumb?: string
+  /** Called when breadcrumb "back" is clicked to return to all-namespace view */
+  onClearNamespace?: () => void
+  /** Serialized namespace filter — when this changes, reset groupLevels for fresh smart default */
+  namespacesKey?: string
 }
 
 export function TopologyGraph({
@@ -171,6 +183,10 @@ export function TopologyGraph({
   showExportButton = true,
   paused = false,
   onTogglePause,
+  onMaximizeNamespace,
+  namespaceBreadcrumb,
+  onClearNamespace,
+  namespacesKey = '',
 }: TopologyGraphProps) {
   const isTrafficView = viewMode === 'traffic'
   const [nodes, setNodes, onNodesChangeBase] = useNodesState([] as Node[])
@@ -185,10 +201,21 @@ export function TopologyGraph({
       }
     }
   }, [onNodesChangeBase])
-  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set())
+  // 3-level display: chip (compact) → cardGrid (workload cards) → topology (full graph)
+  const [groupLevels, setGroupLevels] = useState<Map<string, GroupDisplayLevel>>(new Map())
   const [expandedPodGroups, setExpandedPodGroups] = useState<Set<string>>(new Set())
+
+  // Derive collapsedGroups for ELK/edges: both 'chip' and 'cardGrid' are collapsed
+  const collapsedGroups = useMemo(() => {
+    const set = new Set<string>()
+    for (const [id, level] of groupLevels) {
+      if (level !== 'topology') set.add(id)
+    }
+    return set
+  }, [groupLevels])
   const [layoutError, setLayoutError] = useState<string | null>(null)
   const [layoutRetryCount, setLayoutRetryCount] = useState(0)
+  const [fitViewCounter, setFitViewCounter] = useState(0)
   const [isExporting, setIsExporting] = useState(false)
   const prevStructureRef = useRef<string>('')
   const layoutVersionRef = useRef(0) // Used to invalidate stale layout results
@@ -196,19 +223,48 @@ export function TopologyGraph({
   // Prevents every cluster change from re-running a full ELK layout (which shifts all nodes).
   const savedPositionsRef = useRef<Map<string, { x: number; y: number }>>(new Map())
   const prevRetryCountRef = useRef(0)
+  // Stores the current groupMap so collapse-all can reference group IDs without a stale closure
+  const groupMapRef = useRef<Map<string, string[]>>(new Map())
+  // Tracks whether the one-time smart default (collapse all for large clusters) has fired
+  const hasAppliedSmartDefaultRef = useRef(false)
+  // After layout completes for a single-group change, stores the group ID so
+  // ViewportController can fitView to it (with correct timing — after setNodes)
+  const fitToGroupAfterLayoutRef = useRef<string | null>(null)
 
-  // Toggle group collapse
-  const handleToggleCollapse = useCallback((groupId: string) => {
-    setCollapsedGroups(prev => {
-      const next = new Set(prev)
-      if (next.has(groupId)) {
-        next.delete(groupId)
-      } else {
-        next.add(groupId)
-      }
+  // Reset group display levels when namespace filter changes (instant switching)
+  const prevNamespacesKeyRef = useRef(namespacesKey)
+  useEffect(() => {
+    if (namespacesKey !== prevNamespacesKeyRef.current) {
+      prevNamespacesKeyRef.current = namespacesKey
+      setGroupLevels(new Map())
+      hasAppliedSmartDefaultRef.current = false
+      savedPositionsRef.current.clear()
+      setFitViewCounter(c => c + 1)
+    }
+  }, [namespacesKey])
+
+  // Set display level for a single group
+  const handleSetLevel = useCallback((groupId: string, level: GroupDisplayLevel) => {
+    setGroupLevels(prev => {
+      const next = new Map(prev)
+      next.set(groupId, level)
       return next
     })
+    savedPositionsRef.current.clear()
+    // After layout completes, ViewportController will fitView to this group
+    fitToGroupAfterLayoutRef.current = groupId
   }, [])
+
+  // Set all groups to a given level
+  const setAllLevels = useCallback((level: GroupDisplayLevel) => {
+    const next = new Map<string, GroupDisplayLevel>()
+    for (const groupKey of groupMapRef.current.keys()) {
+      next.set(`group-${groupingMode}-${groupKey}`, level)
+    }
+    setGroupLevels(next)
+    savedPositionsRef.current.clear()
+    setFitViewCounter(c => c + 1)
+  }, [groupingMode])
 
   // Expand pod group to show individual pods
   const handleExpandPodGroup = useCallback((podGroupId: string) => {
@@ -378,13 +434,19 @@ export function TopologyGraph({
     return { workingNodes: nodes, workingEdges: edges }
   }, [topology, expandedPodGroups, expandPodGroup, isTrafficView, groupingMode, createPerGroupInternetNodes])
 
-  // Structure key for change detection
+  // Handle card click in card-grid view — find the topology node and open drawer
+  const handleCardClick = useCallback((nodeId: string) => {
+    const topoNode = topology?.nodes.find(n => n.id === nodeId) || workingNodes.find(n => n.id === nodeId)
+    if (topoNode) onNodeClick(topoNode)
+  }, [topology, workingNodes, onNodeClick])
+
+  // Structure key for change detection — includes groupLevels so chip↔cardGrid triggers relayout
   const structureKey = useMemo(() => {
     const nodeIds = workingNodes.map(n => n.id).sort().join(',')
-    const collapsed = Array.from(collapsedGroups).sort().join(',')
+    const levels = Array.from(groupLevels.entries()).sort().map(([k, v]) => `${k}:${v}`).join(',')
     const expanded = Array.from(expandedPodGroups).sort().join(',')
-    return `${viewMode}|${nodeIds}|${collapsed}|${expanded}|${groupingMode}|${layoutRetryCount}`
-  }, [viewMode, workingNodes, collapsedGroups, expandedPodGroups, groupingMode, layoutRetryCount])
+    return `${viewMode}|${nodeIds}|${levels}|${expanded}|${groupingMode}|${layoutRetryCount}`
+  }, [viewMode, workingNodes, groupLevels, expandedPodGroups, groupingMode, layoutRetryCount])
 
   // Layout when structure changes - use hierarchical ELK layout
   useEffect(() => {
@@ -393,6 +455,7 @@ export function TopologyGraph({
       setEdges([])
       prevStructureRef.current = ''
       savedPositionsRef.current.clear() // Clear on context switch / topology reset
+      hasAppliedSmartDefaultRef.current = false
       return
     }
 
@@ -418,6 +481,24 @@ export function TopologyGraph({
 
     prevStructureRef.current = structureKey
 
+    // Smart default: start all namespace groups as chips for large clusters.
+    // Fires once per topology lifecycle (reset on context switch). Returns early
+    // so the re-render with groupLevels set computes the actual layout.
+    if (!hasAppliedSmartDefaultRef.current && groupLevels.size === 0 && groupingMode === 'namespace' && !hideGroupHeader) {
+      const uniqueNamespaces = new Set(workingNodes.map(n => n.data.namespace as string).filter(Boolean))
+      if (uniqueNamespaces.size > LARGE_CLUSTER_NS_THRESHOLD) {
+        hasAppliedSmartDefaultRef.current = true
+        savedPositionsRef.current.clear()
+        const levels = new Map<string, GroupDisplayLevel>()
+        for (const ns of uniqueNamespaces) levels.set(`group-namespace-${ns}`, 'chip')
+        setGroupLevels(levels)
+        return
+      }
+      // Don't mark as applied when skipping — topology data may be stale (e.g., still
+      // showing single-namespace data during a transition to all-namespaces). The real
+      // all-namespace data will arrive and re-trigger this check.
+    }
+
     // Increment version to invalidate any previous in-flight layout
     const thisLayoutVersion = ++layoutVersionRef.current
 
@@ -426,18 +507,22 @@ export function TopologyGraph({
       workingNodes,
       workingEdges,
       groupingMode,
-      collapsedGroups
+      collapsedGroups,
+      groupLevels
     )
+    groupMapRef.current = groupMap
 
     // Apply layout and get positioned nodes
     applyHierarchicalLayout(
       elkGraph,
       workingNodes,
+      workingEdges,
       groupMap,
       groupingMode,
       collapsedGroups,
-      handleToggleCollapse,
-      hideGroupHeader
+      { onSetLevel: handleSetLevel, onCardClick: handleCardClick, onMaximizeNamespace },
+      hideGroupHeader,
+      groupLevels
     ).then(({ nodes: layoutedNodes, error }) => {
       // Check if a newer layout has started - if so, discard this stale result
       if (layoutVersionRef.current !== thisLayoutVersion) {
@@ -492,23 +577,34 @@ export function TopologyGraph({
 
       setNodes(nodesWithHandlers)
 
-      // Build edges with styling (pass node count for animation threshold)
-      const builtEdges = buildEdges(
-        workingEdges,
-        collapsedGroups,
-        groupMap,
-        groupingMode,
-        isTrafficView,
-        nodeToGroup,
-        nodesWithHandlers.length
+      // Hide edges when all groups are collapsed — inter-namespace edges are noise in the overview.
+      // Always show edges in single-namespace view (hideGroupHeader) since there's no group container.
+      const hasAnyExpandedGroup = hideGroupHeader || nodesWithHandlers.some(n =>
+        n.type === 'group' && (n.data as Record<string, unknown>)?.displayLevel === 'topology'
       )
-      setEdges(builtEdges)
+      if (!hasAnyExpandedGroup && groupingMode !== 'none') {
+        setEdges([])
+      } else {
+        const builtEdges = buildEdges(
+          workingEdges,
+          collapsedGroups,
+          groupMap,
+          groupingMode,
+          isTrafficView,
+          nodeToGroup,
+          nodesWithHandlers.length
+        )
+        setEdges(builtEdges)
+      }
+    }).catch((err) => {
+      console.error('[TopologyGraph] Layout post-processing error:', err)
+      setLayoutError(err instanceof Error ? err.message : String(err))
     })
 
     // No cleanup function - we use version-based invalidation instead
     // This prevents React's effect re-runs from canceling in-flight layouts
     // when the actual structure hasn't changed
-  }, [workingNodes, workingEdges, structureKey, groupingMode, hideGroupHeader, collapsedGroups, handleToggleCollapse, isTrafficView, expandedPodGroups, handleExpandPodGroup, handleCollapsePodGroup, setNodes, setEdges, layoutRetryCount])
+  }, [workingNodes, workingEdges, structureKey, groupingMode, hideGroupHeader, collapsedGroups, groupLevels, handleSetLevel, handleCardClick, onMaximizeNamespace, isTrafficView, expandedPodGroups, handleExpandPodGroup, handleCollapsePodGroup, setNodes, setEdges, layoutRetryCount])
 
   // Handle node click
   const handleNodeClick = useCallback(
@@ -554,7 +650,18 @@ export function TopologyGraph({
     })
   }, [selectedNodeId, setNodes])
 
-  if (!topology || topology.nodes.length === 0) {
+  if (!topology) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-theme-text-secondary">
+        <div className="text-center">
+          <Loader2 className="w-6 h-6 animate-spin mx-auto mb-2 opacity-50" />
+          <p className="text-sm">Loading topology...</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (topology.nodes.length === 0) {
     return (
       <div className="flex-1 flex items-center justify-center text-theme-text-secondary">
         <div className="text-center">
@@ -596,6 +703,25 @@ export function TopologyGraph({
 
   return (
     <ReactFlowProvider>
+      {/* Namespace breadcrumb — shown when viewing a single namespace */}
+      {namespaceBreadcrumb && (
+        <div className="absolute top-3 left-3 z-10 flex items-center gap-1.5">
+          {onClearNamespace && (
+            <button
+              onClick={onClearNamespace}
+              className="text-xs text-theme-text-tertiary hover:text-theme-text-secondary transition-colors"
+            >
+              All Namespaces
+            </button>
+          )}
+          {onClearNamespace && (
+            <span className="text-xs text-theme-text-tertiary">/</span>
+          )}
+          <span className="text-xs font-medium text-theme-text-secondary bg-theme-surface/80 backdrop-blur-sm border border-theme-border/50 rounded-md px-2 py-0.5">
+            {namespaceBreadcrumb}
+          </span>
+        </div>
+      )}
       {/* Warning banner for partial topology data */}
       {topology?.warnings && topology.warnings.length > 0 && (() => {
         const rbacWarnings = topology.warnings.filter(w => w.includes('RBAC not granted'))
@@ -675,19 +801,53 @@ export function TopologyGraph({
         <Controls
           className="bg-theme-surface border border-theme-border rounded-lg"
           showInteractive={false}
+          showZoom={false}
+          showFitView={false}
         >
-          {showExportButton && <ExportImageButton onExportingChange={setIsExporting} />}
-          {onTogglePause && (
-            <button
-              className={`react-flow__controls-button ${paused ? 'text-amber-400' : ''}`}
-              onClick={onTogglePause}
-              title={paused ? 'Resume live updates' : 'Pause live updates'}
-            >
-              {paused ? <Play className="w-3 h-3" /> : <Pause className="w-3 h-3" />}
-            </button>
-          )}
+          <CustomControlButtons
+            showExportButton={showExportButton}
+            paused={paused}
+            onTogglePause={onTogglePause}
+            onExportingChange={setIsExporting}
+          />
         </Controls>
-        <ViewportController viewMode={viewMode} layoutRetryCount={layoutRetryCount} />
+        {/* Level controls — separate group matching per-node icons */}
+        {groupingMode !== 'none' && (
+          <div className="react-flow__panel react-flow__controls bottom-left bg-theme-surface border border-theme-border rounded-lg" style={{ marginBottom: 0, left: 10, bottom: 'auto', top: namespaceBreadcrumb ? 40 : 10 }}>
+            {!hideGroupHeader && (
+              <Tooltip content="Collapse all" delay={100} position="right">
+                <button
+                  className="react-flow__controls-button"
+                  onClick={() => setAllLevels('chip')}
+                >
+                  <Minus className="w-3.5 h-3.5" />
+                </button>
+              </Tooltip>
+            )}
+            <Tooltip content="All workload cards" delay={100} position="right">
+              <button
+                className="react-flow__controls-button"
+                onClick={() => setAllLevels('cardGrid')}
+              >
+                <LayoutGrid className="w-3.5 h-3.5" />
+              </button>
+            </Tooltip>
+            <Tooltip content="Expand all" delay={100} position="right">
+              <button
+                className="react-flow__controls-button"
+                onClick={() => setAllLevels('topology')}
+              >
+                <Workflow className="w-3.5 h-3.5" />
+              </button>
+            </Tooltip>
+          </div>
+        )}
+        <ViewportController
+          viewMode={viewMode}
+          layoutRetryCount={layoutRetryCount}
+          fitViewCounter={fitViewCounter}
+          fitToGroupAfterLayoutRef={fitToGroupAfterLayoutRef}
+        />
       </ReactFlow>
     </ReactFlowProvider>
   )
@@ -854,14 +1014,15 @@ function ExportImageButton({ onExportingChange }: { onExportingChange: (v: boole
 
   return (
     <>
-      <button
-        className="react-flow__controls-button"
-        onClick={openDialog}
-        disabled={exporting}
-        title="Export as image"
-      >
-        {exporting ? <Loader2 className="w-3 h-3 animate-spin" /> : <Download className="w-3 h-3" />}
-      </button>
+      <Tooltip content="Export as image" delay={100} position="right">
+        <button
+          className="react-flow__controls-button"
+          onClick={openDialog}
+          disabled={exporting}
+        >
+          {exporting ? <Loader2 className="w-3 h-3 animate-spin" /> : <Download className="w-3 h-3" />}
+        </button>
+      </Tooltip>
       {showDialog && (
         <div
           className="absolute bottom-12 left-0 z-50 bg-theme-surface border border-theme-border rounded-lg shadow-2xl p-3 w-72"
@@ -963,6 +1124,52 @@ function ExportImageButton({ onExportingChange }: { onExportingChange: (v: boole
   )
 }
 
+// Custom control buttons — replaces ReactFlow defaults so we can use our Tooltip component
+function CustomControlButtons({
+  showExportButton,
+  paused,
+  onTogglePause,
+  onExportingChange,
+}: {
+  showExportButton: boolean
+  paused: boolean
+  onTogglePause?: () => void
+  onExportingChange: (v: boolean) => void
+}) {
+  const { zoomIn, zoomOut, fitView } = useReactFlow()
+  const TIP = 100
+  return (
+    <>
+      <Tooltip content="Zoom in" delay={TIP} position="right">
+        <button className="react-flow__controls-button" onClick={() => zoomIn({ duration: 200 })}>
+          <Plus className="w-3 h-3" />
+        </button>
+      </Tooltip>
+      <Tooltip content="Zoom out" delay={TIP} position="right">
+        <button className="react-flow__controls-button" onClick={() => zoomOut({ duration: 200 })}>
+          <Minus className="w-3 h-3" />
+        </button>
+      </Tooltip>
+      <Tooltip content="Fit view" delay={TIP} position="right">
+        <button className="react-flow__controls-button" onClick={() => fitView({ padding: 0.15, duration: 400 })}>
+          <Maximize className="w-3 h-3" />
+        </button>
+      </Tooltip>
+      {showExportButton && <ExportImageButton onExportingChange={onExportingChange} />}
+      {onTogglePause && (
+        <Tooltip content={paused ? 'Resume live updates' : 'Pause live updates'} delay={TIP} position="right">
+          <button
+            className={`react-flow__controls-button ${paused ? 'text-amber-400' : ''}`}
+            onClick={onTogglePause}
+          >
+            {paused ? <Play className="w-3 h-3" /> : <Pause className="w-3 h-3" />}
+          </button>
+        </Tooltip>
+      )}
+    </>
+  )
+}
+
 // Animation duration for viewport transitions
 const VIEWPORT_ANIMATION_DURATION = 400
 
@@ -971,14 +1178,19 @@ const VIEWPORT_ANIMATION_DURATION = 400
 function ViewportController({
   viewMode,
   layoutRetryCount,
+  fitViewCounter = 0,
+  fitToGroupAfterLayoutRef,
 }: {
   viewMode: string
   layoutRetryCount: number
+  fitViewCounter?: number
+  fitToGroupAfterLayoutRef?: React.MutableRefObject<string | null>
 }) {
   const { fitView, zoomIn, zoomOut, setViewport, getViewport } = useReactFlow()
   const nodes = useNodes() // Reactive hook to watch node changes
   const prevViewModeRef = useRef<string>(viewMode)
   const prevRetryCountRef = useRef(layoutRetryCount)
+  const prevFitViewCounterRef = useRef(fitViewCounter)
   const prevNodesLengthRef = useRef(0)
 
   // Topology keyboard shortcuts
@@ -1056,12 +1268,14 @@ function ViewportController({
     const nodesJustPopulated = prevNodesLengthRef.current === 0 && nodes.length > 0
     const viewModeChanged = viewMode !== prevViewModeRef.current
     const retryRequested = layoutRetryCount !== prevRetryCountRef.current
+    const fitViewRequested = fitViewCounter !== prevFitViewCounterRef.current
 
     prevNodesLengthRef.current = nodes.length
     prevViewModeRef.current = viewMode
     prevRetryCountRef.current = layoutRetryCount
+    prevFitViewCounterRef.current = fitViewCounter
 
-    if (nodesJustPopulated || viewModeChanged || retryRequested) {
+    if (nodesJustPopulated || viewModeChanged || retryRequested || fitViewRequested) {
       const timeoutId = setTimeout(() => {
         fitView({
           padding: 0.15,
@@ -1071,7 +1285,27 @@ function ViewportController({
 
       return () => clearTimeout(timeoutId)
     }
-  }, [viewMode, layoutRetryCount, nodes.length, fitView])
+  }, [viewMode, layoutRetryCount, fitViewCounter, nodes.length, fitView])
+
+  // After a single-group expand/collapse, fit the viewport to that group.
+  // This effect fires when nodes update (triggered by setNodes after async layout).
+  useEffect(() => {
+    if (!fitToGroupAfterLayoutRef?.current) return
+    const targetGroupId = fitToGroupAfterLayoutRef.current
+    fitToGroupAfterLayoutRef.current = null
+    // Find the group and its children to fit to
+    const targetNodes = nodes.filter(n => n.id === targetGroupId || n.parentId === targetGroupId)
+    if (targetNodes.length > 0) {
+      setTimeout(() => {
+        fitView({
+          nodes: targetNodes.map(n => ({ id: n.id })),
+          padding: 0.2,
+          duration: VIEWPORT_ANIMATION_DURATION,
+          maxZoom: 1.5,
+        })
+      }, 10)
+    }
+  }, [nodes, fitView, fitToGroupAfterLayoutRef])
 
   return null
 }

--- a/packages/k8s-ui/src/components/topology/layout.ts
+++ b/packages/k8s-ui/src/components/topology/layout.ts
@@ -1,6 +1,24 @@
 import type { Node } from '@xyflow/react'
-import type { TopologyNode, GroupingMode, NodeKind } from '../../types'
+import type { TopologyNode, GroupingMode, NodeKind, HealthStatus } from '../../types'
 import { NODE_DIMENSIONS } from './K8sResourceNode'
+
+// --- 3-level display system types ---
+export type GroupDisplayLevel = 'chip' | 'cardGrid' | 'topology'
+
+export interface WorkloadCard {
+  id: string             // Node ID of primary resource (for click handling)
+  kind: NodeKind         // Kind of primary resource (Deployment, StatefulSet, etc.)
+  name: string           // Name of primary resource
+  status: HealthStatus   // Worst health status in the connected subgraph
+  subtitle: string       // Status info (e.g., "3/3 ready", "ClusterIP", "*/5 * * * *")
+  resourceCount: number  // Total connected resources in this workload
+}
+
+// Card grid layout constants — must match CSS in GroupNode.tsx cardGrid rendering
+const GRID_CARD_W = 200
+const GRID_CARD_H = 68
+const GRID_GAP = 6
+const GRID_PAD = { top: 48, left: 14, bottom: 14, right: 14 }
 
 // Group padding - space for header + internal spacing (must account for border)
 // Top padding accommodates the header at its largest (when zoomed out)
@@ -190,7 +208,7 @@ async function runLayoutOnMainThread(
       groupLayouts.push({
         groupId: child.id, groupKey,
         width: Math.max(child.width || 280, minWidth),
-        height: child.height || 90,
+        height: child.height || 82,
         children: [], isCollapsed: true,
       })
     } else {
@@ -399,61 +417,11 @@ function propagateAppLabels(
   return nodeGroupLabels
 }
 
-// Pick a representative name for a connected component group
+// Pick a representative name for a connected component group (uses shared KIND_PRIORITY)
 function pickGroupName(nodes: TopologyNode[]): string {
-  // Priority order for picking the group name
-  const kindPriority: Record<string, number> = {
-    'Deployment': 1,
-    'Rollout': 1,
-    'StatefulSet': 2,
-    'DaemonSet': 3,
-    'CronJob': 4,
-    'Job': 5,
-    'Service': 6,
-    'Gateway': 7,
-    'HTTPRoute': 6,
-    'GRPCRoute': 6,
-    'TCPRoute': 6,
-    'TLSRoute': 6,
-    'Ingress': 7,
-    'ReplicaSet': 8,
-    'Pod': 9,
-    'PodGroup': 9,
-    'ConfigMap': 10,
-    'Secret': 10,
-    'PersistentVolumeClaim': 10,
-    'HorizontalPodAutoscaler': 10,
-    'KnativeService': 1,
-    'KnativeConfiguration': 3,
-    'KnativeRevision': 4,
-    'KnativeRoute': 2,
-    'Broker': 2,
-    'Channel': 2,
-    'Trigger': 3,
-    'PingSource': 3,
-    'ApiServerSource': 3,
-    'ContainerSource': 3,
-    'SinkBinding': 3,
-    'IngressRoute': 1,
-    'IngressRouteTCP': 1,
-    'IngressRouteUDP': 1,
-    'TraefikService': 2,
-    'Middleware': 3,
-    'MiddlewareTCP': 3,
-    'ServersTransport': 4,
-    'ServersTransportTCP': 4,
-    'TLSOption': 4,
-    'TLSStore': 4,
-    'HTTPProxy': 1, // Contour
-  }
-
-  // Sort by priority and pick the first
   const sorted = [...nodes].sort((a, b) => {
-    const priorityA = kindPriority[a.kind] || 99
-    const priorityB = kindPriority[b.kind] || 99
-    return priorityA - priorityB
+    return (KIND_PRIORITY[a.kind] || 99) - (KIND_PRIORITY[b.kind] || 99)
   })
-
   return sorted[0].name
 }
 
@@ -462,7 +430,8 @@ export function buildHierarchicalElkGraph(
   topologyNodes: TopologyNode[],
   edges: Array<{ id: string; source: string; target: string; type: string }>,
   groupingMode: GroupingMode,
-  collapsedGroups: Set<string>
+  collapsedGroups: Set<string>,
+  groupLevels?: Map<string, GroupDisplayLevel>
 ): { elkGraph: ElkGraph; groupMap: Map<string, string[]>; nodeToGroup: Map<string, string> } {
   const groupMap = new Map<string, string[]>()
   const nodeToGroup = new Map<string, string>()
@@ -508,25 +477,67 @@ export function buildHierarchicalElkGraph(
       })
     }
   } else {
+    // Build node lookup once for O(1) access in dimension/card computation
+    const nodeMapForGroups = new Map(topologyNodes.map(n => [n.id, n]))
     // Create group nodes with children
     for (const [groupKey, memberIds] of groupMap) {
       const groupId = `group-${groupingMode}-${groupKey}`
-      const isCollapsed = collapsedGroups.has(groupId)
+      // When groupLevels has entries for the CURRENT grouping mode, any group without
+      // an explicit 'topology' level is collapsed. This prevents late-arriving namespaces
+      // from defaulting to expanded and overlapping with collapsed chips.
+      // Only apply when levels exist for the same grouping prefix — don't let namespace
+      // levels leak into app/label grouping contexts.
+      const groupPrefix = `group-${groupingMode}-`
+      const hasLevelsForCurrentMode = groupLevels && groupLevels.size > 0 &&
+        [...groupLevels.keys()].some(k => k.startsWith(groupPrefix))
+      const isCollapsed = collapsedGroups.has(groupId) ||
+        (hasLevelsForCurrentMode && groupLevels!.get(groupId) !== 'topology')
 
       if (isCollapsed) {
-        // Collapsed group is a single node - width based on label length
-        const collapsedWidth = Math.max(400, groupKey.length * 16 + 180)
-        children.push({
-          id: groupId,
-          width: collapsedWidth,
-          height: 90,
-          labels: [{ text: groupKey }],
-        })
+        const displayLevel = groupLevels?.get(groupId) || 'chip'
+
+        if (displayLevel === 'cardGrid') {
+          // Card grid: compute dimensions from workload card count
+          const cards = computeWorkloadCards(memberIds, edges, nodeMapForGroups)
+          const { width, height } = computeGridDimensions(cards.length, groupKey)
+          children.push({
+            id: groupId,
+            width,
+            height,
+            labels: [{ text: groupKey }],
+          })
+        } else {
+          // Chip size scales with resource count (log10 tiers)
+          const count = memberIds.length
+          const tier = count === 0 ? 0 : Math.min(3, Math.floor(Math.log10(count)))
+          const tierWidthBonus = [0, 120, 300, 500][tier]
+          const collapsedWidth = Math.max(240 + tierWidthBonus, groupKey.length * 16 + 160)
+
+          // Count unique kinds for pill row height calculation
+          const uniqueKinds = new Set<string>()
+          for (const nId of memberIds) {
+            const n = nodeMapForGroups.get(nId)
+            if (n && n.kind !== 'PodGroup') uniqueKinds.add(n.kind)
+          }
+          const maxPills = [2, 5, 8, 12][tier]
+          const pillCount = Math.min(maxPills, uniqueKinds.size)
+          const pillWidth = 90
+          const pillCols = Math.max(1, Math.floor((collapsedWidth - 24) / (pillWidth + 6)))
+          const pillRows = pillCount > 0 ? Math.ceil(pillCount / pillCols) : 0
+          const headerHeight = [20, 28, 40, 56][tier]
+          const tierHeight = 20 + headerHeight + (pillRows > 0 ? 8 + pillRows * 24 : 0)
+          children.push({
+            id: groupId,
+            width: collapsedWidth,
+            height: tierHeight,
+            labels: [{ text: groupKey }],
+          })
+        }
       } else {
         // Expanded group contains its children
         const groupChildren: ElkNode[] = []
         for (const nodeId of memberIds) {
-          const node = topologyNodes.find(n => n.id === nodeId)
+          const node = nodeMapForGroups.get(nodeId)
           if (node) {
             const kind = node.kind as NodeKind
             const dims = NODE_DIMENSIONS[kind] || { width: 200, height: 56 }
@@ -624,16 +635,164 @@ export function buildHierarchicalElkGraph(
   }
 }
 
+// Lower number = higher severity
+const HEALTH_PRIORITY: Record<HealthStatus, number> = { unhealthy: 0, degraded: 1, unknown: 2, healthy: 3 }
+
+function computeGroupHealth(memberIds: string[], nodeMap: Map<string, TopologyNode>): { worstStatus: HealthStatus; unhealthyCount: number } {
+  let worstPriority = 3
+  let worstStatus: HealthStatus = 'healthy'
+  let unhealthyCount = 0
+  for (const id of memberIds) {
+    const node = nodeMap.get(id)
+    if (!node) continue
+    const priority = HEALTH_PRIORITY[node.status] ?? 2
+    if (priority < worstPriority) {
+      worstPriority = priority
+      worstStatus = node.status
+    }
+    if (node.status === 'unhealthy' || node.status === 'degraded') {
+      unhealthyCount++
+    }
+  }
+  return { worstStatus, unhealthyCount }
+}
+
+// Compute workload cards for a card-grid group by finding connected subgraphs.
+// Each connected component becomes one card, named after its highest-priority resource.
+function computeWorkloadCards(
+  memberIds: string[],
+  edges: Array<{ id: string; source: string; target: string; type: string }>,
+  nodeMap: Map<string, TopologyNode>
+): WorkloadCard[] {
+  const memberSet = new Set(memberIds)
+
+  // Build adjacency list restricted to this group's members
+  const adj = new Map<string, Set<string>>()
+  for (const id of memberIds) adj.set(id, new Set())
+  for (const edge of edges) {
+    if (memberSet.has(edge.source) && memberSet.has(edge.target)) {
+      adj.get(edge.source)?.add(edge.target)
+      adj.get(edge.target)?.add(edge.source)
+    }
+  }
+
+  // BFS to find connected components
+  const visited = new Set<string>()
+  const components: TopologyNode[][] = []
+  for (const id of memberIds) {
+    if (visited.has(id)) continue
+    const component: TopologyNode[] = []
+    const queue = [id]
+    visited.add(id)
+    while (queue.length > 0) {
+      const nodeId = queue.shift()!
+      const node = nodeMap.get(nodeId)
+      if (node) component.push(node)
+      for (const neighbor of adj.get(nodeId) || []) {
+        if (!visited.has(neighbor)) {
+          visited.add(neighbor)
+          queue.push(neighbor)
+        }
+      }
+    }
+    if (component.length > 0) components.push(component)
+  }
+
+  // Convert each component to a workload card
+  const cards: WorkloadCard[] = components.map(comp => {
+    // Pick primary resource using kindPriority (reuse the same map from pickGroupName)
+    const sorted = [...comp].sort((a, b) => {
+      const pa = KIND_PRIORITY[a.kind] || 99
+      const pb = KIND_PRIORITY[b.kind] || 99
+      return pa - pb
+    })
+    const primary = sorted[0]
+
+    // Compute worst health
+    let worstPriority = 3
+    let worstStatus: HealthStatus = 'healthy'
+    for (const node of comp) {
+      const p = HEALTH_PRIORITY[node.status] ?? 2
+      if (p < worstPriority) { worstPriority = p; worstStatus = node.status }
+    }
+
+    // Extract subtitle from primary resource's data
+    const d = primary.data as Record<string, unknown>
+    let subtitle = ''
+    if (['Deployment', 'StatefulSet', 'DaemonSet', 'Rollout', 'ReplicaSet'].includes(primary.kind)) {
+      subtitle = (d.statusSummary as string) || `${d.readyReplicas ?? '?'}/${d.totalReplicas ?? '?'} ready`
+    } else if (primary.kind === 'Service') {
+      subtitle = (d.type as string) || 'ClusterIP'
+    } else if (primary.kind === 'CronJob') {
+      subtitle = (d.schedule as string) || ''
+    } else if (primary.kind === 'Job') {
+      subtitle = (d.phase as string) || ''
+    } else if (primary.kind === 'Application') {
+      const sync = d.syncStatus as string
+      const health = d.healthStatus as string
+      subtitle = [sync, health].filter(Boolean).join(' · ')
+    } else if (primary.kind === 'KnativeService' || primary.kind === 'Kustomization' || primary.kind === 'HelmRelease') {
+      subtitle = d.ready ? 'Ready' : 'Not Ready'
+    }
+
+    return {
+      id: primary.id,
+      kind: primary.kind,
+      name: primary.name,
+      status: worstStatus,
+      subtitle,
+      resourceCount: comp.length,
+    }
+  })
+
+  // Sort by resource count descending (biggest workloads first)
+  cards.sort((a, b) => b.resourceCount - a.resourceCount)
+  return cards
+}
+
+// Shared kind priority map — used by both pickGroupName and computeWorkloadCards
+const KIND_PRIORITY: Record<string, number> = {
+  'Deployment': 1, 'Rollout': 1, 'StatefulSet': 2, 'DaemonSet': 3,
+  'CronJob': 4, 'Job': 5, 'Service': 6, 'Gateway': 7,
+  'HTTPRoute': 6, 'GRPCRoute': 6, 'TCPRoute': 6, 'TLSRoute': 6, 'Ingress': 7,
+  'ReplicaSet': 8, 'Pod': 9, 'PodGroup': 9,
+  'ConfigMap': 10, 'Secret': 10, 'PersistentVolumeClaim': 10, 'HorizontalPodAutoscaler': 10,
+  'KnativeService': 1, 'KnativeConfiguration': 3, 'KnativeRevision': 4, 'KnativeRoute': 2,
+  'Broker': 2, 'Channel': 2, 'Trigger': 3, 'PingSource': 3, 'ApiServerSource': 3,
+  'ContainerSource': 3, 'SinkBinding': 3,
+  'IngressRoute': 1, 'IngressRouteTCP': 1, 'IngressRouteUDP': 1, 'TraefikService': 2,
+  'Middleware': 3, 'MiddlewareTCP': 3, 'ServersTransport': 4, 'ServersTransportTCP': 4,
+  'TLSOption': 4, 'TLSStore': 4, 'HTTPProxy': 1,
+  'Application': 1, 'Kustomization': 1, 'HelmRelease': 1, 'GitRepository': 2,
+}
+
+// Compute grid dimensions from workload card count
+function computeGridDimensions(cardCount: number, groupKey: string): { width: number; height: number; columns: number } {
+  if (cardCount === 0) return { width: 400, height: 130, columns: 1 }
+  const columns = Math.min(4, cardCount)
+  const rows = Math.ceil(cardCount / columns)
+  const minWidth = Math.max(400, groupKey.length * 16 + 180)
+  const width = Math.max(minWidth, columns * (GRID_CARD_W + GRID_GAP) - GRID_GAP + GRID_PAD.left + GRID_PAD.right)
+  const height = GRID_PAD.top + rows * (GRID_CARD_H + GRID_GAP) - GRID_GAP + GRID_PAD.bottom
+  return { width, height, columns }
+}
+
 // Two-phase layout: first layout groups internally, then position groups based on connections
 // Layout is performed in a Web Worker to avoid blocking the main thread
 export async function applyHierarchicalLayout(
   elkGraph: ElkGraph,
   topologyNodes: TopologyNode[],
+  topologyEdges: Array<{ id: string; source: string; target: string; type: string }>,
   groupMap: Map<string, string[]>,
   groupingMode: GroupingMode,
   _collapsedGroups: Set<string>,
-  onToggleCollapse: (groupId: string) => void,
-  hideGroupHeader: boolean = false
+  callbacks: {
+    onSetLevel: (groupId: string, level: GroupDisplayLevel) => void
+    onCardClick: (nodeId: string) => void
+    onMaximizeNamespace?: (namespace: string) => void
+  },
+  hideGroupHeader: boolean = false,
+  groupLevels?: Map<string, GroupDisplayLevel>
 ): Promise<{ nodes: Node[]; positions: Map<string, { x: number; y: number }>; error?: string }> {
   try {
     const padding = hideGroupHeader ? GROUP_PADDING_NO_HEADER : GROUP_PADDING
@@ -651,6 +810,8 @@ export async function applyHierarchicalLayout(
     // Build ReactFlow nodes using positions from worker
     const nodes: Node[] = []
     const positions = new Map<string, { x: number; y: number }>()
+    // Build node lookup once for O(1) health aggregation across all groups
+    const nodeMap = new Map(topologyNodes.map(n => [n.id, n]))
 
     for (const group of workerResult.groupLayouts) {
       const pos = groupPositions.get(group.groupId) || { x: 0, y: 0 }
@@ -658,29 +819,65 @@ export async function applyHierarchicalLayout(
 
       positions.set(group.groupId, pos)
 
-      // Add group node
-      nodes.push({
-        id: group.groupId,
-        type: 'group',
-        position: pos,
-        data: {
-          type: groupingMode,
-          name: group.groupKey,
-          nodeCount: memberIds.length,
-          collapsed: group.isCollapsed,
-          onToggleCollapse,
-          hideHeader: hideGroupHeader,
-        },
-        style: {
-          width: group.width,
-          height: group.height,
-        },
-        zIndex: -1,
-      })
+      const { worstStatus, unhealthyCount } = computeGroupHealth(memberIds, nodeMap)
+      // Default to 'chip' when groupLevels has entries for the current grouping mode,
+      // so late-arriving namespaces don't render as expanded topology and overlap with chips.
+      const hasLevelsForMode = groupLevels && groupLevels.size > 0 &&
+        [...groupLevels.keys()].some(k => k.startsWith(`group-${groupingMode}-`))
+      const defaultLevel: GroupDisplayLevel = hasLevelsForMode ? 'chip' : 'topology'
+      const displayLevel: GroupDisplayLevel = groupLevels?.get(group.groupId) || (group.isCollapsed ? 'chip' : defaultLevel)
 
-      // Add child nodes with positions relative to group
+      // Compute kind breakdown for collapsed chips
+      const kindCounts: Record<string, number> = {}
+      for (const id of memberIds) {
+        const node = nodeMap.get(id)
+        if (!node || node.kind === 'PodGroup') continue
+        kindCounts[node.kind] = (kindCounts[node.kind] || 0) + 1
+      }
+
+      // Compute workload cards for card-grid groups
+      const workloadCards = displayLevel === 'cardGrid'
+        ? computeWorkloadCards(memberIds, topologyEdges, nodeMap)
+        : undefined
+      const gridColumns = workloadCards ? Math.min(4, workloadCards.length || 1) : undefined
+
+      // Skip the group container node entirely in single-namespace topology view —
+      // it creates an invisible bounding box that constrains child node movement
+      const skipGroupNode = hideGroupHeader && displayLevel === 'topology'
+
+      if (!skipGroupNode) {
+        nodes.push({
+          id: group.groupId,
+          type: 'group',
+          position: pos,
+          data: {
+            type: groupingMode,
+            name: group.groupKey,
+            nodeCount: memberIds.length,
+            collapsed: group.isCollapsed,
+            displayLevel,
+            onSetLevel: callbacks.onSetLevel,
+            onCardClick: callbacks.onCardClick,
+            onMaximizeNamespace: callbacks.onMaximizeNamespace,
+            hideHeader: hideGroupHeader,
+            worstStatus,
+            unhealthyCount,
+            kindCounts,
+            workloadCards,
+            gridColumns,
+          },
+          style: {
+            width: group.width,
+            height: group.height,
+          },
+          zIndex: -1,
+        })
+      }
+
+      // Add child nodes — use absolute positions (no parent) when header is hidden
+      // (single namespace view), otherwise relative positions inside the group container
       for (const child of group.children) {
-        const topoNode = topologyNodes.find(n => n.id === child.id)
+        const topoNode = nodeMap.get(child.id)
         if (topoNode) {
           const absX = pos.x + child.x
           const absY = pos.y + child.y
@@ -689,9 +886,8 @@ export async function applyHierarchicalLayout(
           nodes.push({
             id: child.id,
             type: 'k8sResource',
-            position: { x: child.x, y: child.y },
-            parentId: group.groupId,
-            extent: 'parent',
+            position: hideGroupHeader ? { x: absX, y: absY } : { x: child.x, y: child.y },
+            ...(hideGroupHeader ? {} : { parentId: group.groupId, extent: 'parent' as const }),
             data: {
               kind: topoNode.kind,
               name: topoNode.name,
@@ -707,7 +903,7 @@ export async function applyHierarchicalLayout(
     // Add ungrouped nodes
     for (const node of workerResult.ungroupedNodes) {
       const pos = groupPositions.get(node.id) || { x: 0, y: 0 }
-      const topoNode = topologyNodes.find(n => n.id === node.id)
+      const topoNode = nodeMap.get(node.id)
       if (topoNode) {
         positions.set(node.id, pos)
 

--- a/packages/k8s-ui/src/components/topology/topology.css
+++ b/packages/k8s-ui/src/components/topology/topology.css
@@ -121,6 +121,117 @@
   top: var(--group-header-offset, 0px);
 }
 
+/* ── Workload card grid ── */
+
+/* Individual workload card in the card-grid namespace view.
+   Mirrors K8sResourceNode's left-bar status pattern. */
+.grid-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 8px 10px 8px 14px;
+  border-radius: 8px;
+  background: var(--bg-surface);
+  border: 0.5px solid var(--topology-node-border, var(--border-default));
+  box-shadow: var(--topology-node-shadow, none);
+  cursor: pointer;
+  min-width: 0;
+  overflow: hidden;
+  transition: filter 0.15s, box-shadow 0.15s;
+}
+.grid-card:hover {
+  filter: brightness(1.08);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+
+/* Left status bar (matches topology-node-status-bar pattern) */
+.grid-card::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  border-radius: 3px 0 0 3px;
+  background-color: rgb(34 197 94); /* green-500 — healthy default */
+}
+.grid-card-degraded {
+  border-color: rgb(234 179 8 / 0.5);
+  background: light-dark(rgb(254 252 232 / 0.5), rgb(251 146 60 / 0.08));
+}
+.grid-card-degraded::before {
+  background-color: rgb(245 158 11); /* amber-500 */
+}
+.grid-card-unhealthy {
+  border-color: rgb(239 68 68 / 0.5);
+  background: light-dark(rgb(254 242 242 / 0.6), rgb(248 113 113 / 0.1));
+}
+.grid-card-unhealthy::before {
+  background-color: rgb(239 68 68); /* red-500 */
+}
+.grid-card-unknown::before {
+  background-color: rgb(100 116 139); /* slate-500 */
+}
+
+/* Card header row: icon + kind + resource count */
+.grid-card-header {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-bottom: 2px;
+}
+.grid-card-kind {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 500;
+  opacity: 0.55;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.grid-card-count {
+  font-size: 10px;
+  opacity: 0.4;
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+
+/* Card name — primary visual element */
+.grid-card-name {
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Card subtitle — status info, prominent when unhealthy */
+.grid-card-subtitle {
+  font-size: 10px;
+  line-height: 1.3;
+  margin-top: 1px;
+  opacity: 0.5;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.grid-card-degraded .grid-card-subtitle,
+.grid-card-unhealthy .grid-card-subtitle {
+  opacity: 0.85;
+  font-weight: 500;
+}
+
+/* Dividers between custom control buttons in our separate panel */
+.react-flow__panel.react-flow__controls .react-flow__controls-button + .react-flow__controls-button,
+.react-flow__panel.react-flow__controls span + span {
+  border-top: 1px solid var(--border-default, rgba(0,0,0,0.08));
+}
+
 .react-flow__edge-path {
   stroke-width: 2;
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -59,6 +59,10 @@ const ALL_NODE_KINDS: NodeKind[] = [
 // Default visible kinds (ReplicaSet hidden by default - noisy intermediate object)
 const DEFAULT_VISIBLE_KINDS = ALL_NODE_KINDS.filter(k => k !== 'ReplicaSet')
 
+// CRD kinds hidden by default in the topology (infrastructure plumbing).
+// Users can re-enable via the filter sidebar.
+const CRD_HIDDEN_BY_DEFAULT = new Set(['GatewayClass', 'IngressClass', 'NodePool', 'NodeClaim', 'NodeClass'])
+
 // Convert API resource name back to topology node ID prefix
 function apiResourceToNodeIdPrefix(apiResource: string): string {
   const prefixMap: Record<string, string> = {
@@ -204,6 +208,8 @@ function AppInner() {
   }, [navigate, searchParams])
 
   const [namespaces, setNamespaces] = useState<string[]>(getInitialState().namespaces)
+  // For large clusters: force SSE to reconnect with namespace filter
+  const [forceNamespaceFilter, setForceNamespaceFilter] = useState<string[] | undefined>(undefined)
   const [selectedResource, setSelectedResource] = useState<SelectedResource | null>(null)
   const [drawerInitialTab, setDrawerInitialTab] = useState<'detail' | 'yaml'>('detail')
   const [selectedHelmRelease, setSelectedHelmRelease] = useState<SelectedHelmRelease | null>(null)
@@ -369,9 +375,10 @@ function AppInner() {
     return groupingMode
   }, [hasNamespaceFilter, groupingMode])
 
-  // Hide group header when viewing a single namespace with "no grouping" selected
-  // (grouping header is meaningless with only one namespace, but needed for multi-namespace)
-  const hideGroupHeader = namespaces.length === 1 && groupingMode === 'none'
+  // Hide group header when viewing a single namespace with namespace grouping —
+  // the namespace name is already shown in the breadcrumb/picker. Preserve headers
+  // for app/label grouping so those group boundaries remain visible.
+  const hideGroupHeader = namespaces.length === 1 && effectiveGroupingMode === 'namespace'
 
   // Fetch available namespaces
   const { data: availableNamespaces, error: namespacesError } = useNamespaces()
@@ -427,7 +434,8 @@ function AppInner() {
     }, 3000)
   }, [queryClient])
 
-  // SSE connection for real-time updates
+  // SSE connection for real-time updates — no namespace filter for small/medium clusters (frontend filters).
+  // forceNamespaceFilter is only set for large clusters that require server-side filtering.
   const { topology, connected, reconnect: reconnectSSE } = useEventSource(namespaces, topologyMode, {
     onContextSwitchComplete: endSwitch,
     onContextSwitchProgress: updateProgress,
@@ -464,7 +472,7 @@ function AppInner() {
       queryClient.invalidateQueries({ queryKey: ['dashboard'] })
     },
     onK8sEvent: handleK8sEvent,
-  })
+  }, forceNamespaceFilter)
   const [reconnect, isReconnecting] = useRefreshAnimation(reconnectSSE)
 
   // Apply live topology updates only when not paused. While paused, buffer the
@@ -509,7 +517,9 @@ function AppInner() {
       const k = node.kind as string
       if (!allNodeKindsSet.has(k) && !seededCRDKindsRef.current.has(k)) {
         seededCRDKindsRef.current.add(k)
-        newKinds.push(node.kind)
+        if (!CRD_HIDDEN_BY_DEFAULT.has(k)) {
+          newKinds.push(node.kind)
+        }
       }
     }
     if (newKinds.length > 0) {
@@ -646,7 +656,12 @@ function AppInner() {
   const filteredTopology = useMemo((): Topology | null => {
     if (!displayedTopology) return null
 
-    const filteredNodes = displayedTopology.nodes.filter(node => visibleKinds.has(node.kind))
+    // Filter by namespace (frontend-side) and by visible kinds
+    const nsSet = namespaces.length > 0 ? new Set(namespaces) : null
+    const filteredNodes = displayedTopology.nodes.filter(node =>
+      visibleKinds.has(node.kind) &&
+      (!nsSet || nsSet.has(node.data.namespace as string) || !(node.data.namespace as string))
+    )
     const filteredNodeIds = new Set(filteredNodes.map(n => n.id))
 
     // Keep edges where both source and target are visible
@@ -667,7 +682,7 @@ function AppInner() {
       nodes: filteredNodes,
       edges: filteredEdges,
     }
-  }, [displayedTopology, visibleKinds])
+  }, [displayedTopology, visibleKinds, namespaces])
 
   // Filter handlers
   const handleToggleKind = useCallback((kind: NodeKind) => {
@@ -971,7 +986,7 @@ function AppInner() {
         {/* Topology view */}
         {mainView === 'topology' && (
           <>
-            {topology?.requiresNamespaceFilter ? (
+            {topology?.requiresNamespaceFilter && namespaces.length === 0 ? (
               /* Large cluster: prompt user to select a namespace */
               <div className="flex-1 flex items-center justify-center">
                 <div className="max-w-md w-full mx-4 text-center">
@@ -989,7 +1004,11 @@ function AppInner() {
                     <div className="relative">
                       <LargeClusterNamespacePicker
                         namespaces={availableNamespaces}
-                        onSelect={(ns) => setNamespaces([ns])}
+                        onSelect={(ns) => {
+                          setNamespaces([ns])
+                          // Large clusters need server-side filtering — reconnect SSE with namespace
+                          setForceNamespaceFilter([ns])
+                        }}
                       />
                     </div>
                   </div>
@@ -1023,6 +1042,10 @@ function AppInner() {
                     selectedNodeId={selectedResource ? `${apiResourceToNodeIdPrefix(selectedResource.kind)}-${selectedResource.namespace}-${selectedResource.name}` : undefined}
                     paused={topologyPaused}
                     onTogglePause={handleTogglePause}
+                    onMaximizeNamespace={(ns) => setNamespaces([ns])}
+                    namespaceBreadcrumb={namespaces.length === 1 ? namespaces[0] : undefined}
+                    onClearNamespace={namespaces.length === 1 ? () => setNamespaces([]) : undefined}
+                    namespacesKey={namespaces.join(',')}
                   />
 
                   {/* Topology controls overlay - top right */}

--- a/web/src/hooks/useEventSource.ts
+++ b/web/src/hooks/useEventSource.ts
@@ -33,7 +33,9 @@ const MAX_RECONNECT_DELAY_MS = 30000 // Cap at 30 seconds
 export function useEventSource(
   namespaces: string[],
   viewMode: ViewMode = 'resources',
-  options?: UseEventSourceOptions
+  options?: UseEventSourceOptions,
+  /** When set, SSE reconnects with this namespace filter (for large clusters that require server-side filtering) */
+  forceNamespaceFilter?: string[]
 ): UseEventSourceReturn {
   const [topology, setTopology] = useState<Topology | null>(null)
   const [events, setEvents] = useState<K8sEvent[]>([])
@@ -49,8 +51,12 @@ export function useEventSource(
   const throttleTimeoutRef = useRef<number | null>(null)
   const currentNodeCountRef = useRef<number>(0) // Track node count for dynamic throttle
 
-  // Serialize namespaces for stable dependency
+  // Serialize namespaces for stable dependency (used for events clearing)
   const namespacesKey = namespaces.join(',')
+
+  // SSE namespace filter: only used for large clusters that require server-side filtering.
+  // Small/medium clusters get all-namespace data and filter on the frontend.
+  const sseNamespaceFilter = forceNamespaceFilter?.join(',') || ''
 
   // Use ref to avoid stale closures while not triggering reconnection on callback changes
   const optionsRef = useRef(options)
@@ -60,15 +66,17 @@ export function useEventSource(
     // Clean up existing connection
     if (eventSourceRef.current) {
       eventSourceRef.current.close()
+      // Clear stale topology so consumers show loading state instead of old data
+      setTopology(null)
     }
     if (reconnectTimeoutRef.current) {
       clearTimeout(reconnectTimeoutRef.current)
     }
 
-    // Build URL
+    // Build URL — only pass namespace filter for large clusters (forceNamespaceFilter)
     const params = new URLSearchParams()
-    if (namespaces.length > 0) {
-      params.set('namespaces', namespaces.join(','))
+    if (sseNamespaceFilter) {
+      params.set('namespaces', sseNamespaceFilter)
     }
     if (viewMode && viewMode !== 'resources') {
       params.set('view', viewMode)
@@ -207,7 +215,7 @@ export function useEventSource(
         console.error('Failed to parse connection_state event:', e)
       }
     })
-  }, [namespacesKey, viewMode])
+  }, [sseNamespaceFilter, viewMode])
 
   // Reconnect function for manual reconnection
   const reconnect = useCallback(() => {


### PR DESCRIPTION
## Summary

Large clusters render an unreadable topology by default — fitView zooms out to fit everything, making nodes tiny. This adds a 3-level display system for namespace groups:

- **Chip** — compact card with name, resource count, colored kind pills, health dot. Size scales with resource count (log10 tiers)
- **Workload Cards** — each connected subgraph becomes one card (Deployment + RS + Pods + Service = one card). CSS grid inside namespace container
- **Full Topology** — existing behavior with all nodes, edges, ELK layout

Each namespace header has inline level controls (collapse / cards / topology / maximize). Global controls in a separate toolbar. Clusters with >5 namespaces start all-collapsed. Single namespace view starts expanded with breadcrumb navigation.

Also: hidden infrastructure CRDs by default, no inter-namespace edges in collapsed view, fast tooltips, custom ReactFlow control buttons.

Closes #377