### PR TITLE
fix: add macOS entitlements for hardened runtime codesigning

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -69,8 +69,9 @@ jobs:
         run: |
           APP="build/bin/radar-desktop.app"
           codesign --timestamp --options=runtime \
+            --entitlements build/darwin/entitlements.plist \
             --sign "Developer ID Application: KoalaOps, Inc. (${{ secrets.APPLE_TEAM_ID }})" \
-            --force "$APP"
+            --force --deep "$APP"
           codesign --verify --verbose "$APP"
 
       - name: Create archive

--- a/build/darwin/entitlements.plist
+++ b/build/darwin/entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- Adds `build/darwin/entitlements.plist` with JIT, unsigned executable memory, and library validation entitlements required by Wails/WebKit
- Updates the codesign step in the release workflow to pass `--entitlements` and `--deep`

## Context

#383 reports that the desktop app silently fails to launch on macOS 26.4, while the inner executable works fine when run directly from Terminal. This pattern is consistent with hardened runtime blocking WebKit's JIT without the proper entitlements — newer macOS versions may enforce this more strictly.

We were signing with `--options=runtime` but providing no entitlements file, which is incorrect for any app using WebKit/WKWebView. This fix adds the standard entitlements that Wails documents for codesigned builds. It may not be the full story for #383 but it's a gap that should be closed regardless — we'll need to cut a release and have the reporter test to confirm.