### PR TITLE
fix: desktop app no longer silently exits on missing kubeconfig

### DIFF
--- a/cmd/desktop/env.go
+++ b/cmd/desktop/env.go
@@ -12,37 +12,61 @@ import (
 	"time"
 )
 
-// enrichPath ensures the desktop app can find CLI tools like
-// gke-gcloud-auth-plugin, aws, gcloud, helm, etc. that are
-// installed in the user's shell environment but not available
-// to macOS .app bundles or Linux desktop applications.
-func enrichPath() {
-	shellPath := getShellPath()
-	if shellPath != "" {
-		os.Setenv("PATH", shellPath)
-		log.Printf("PATH enriched from login shell (%d entries)", len(strings.Split(shellPath, ":")))
-		return
+// shellEnvVars lists environment variables to capture from the user's
+// login shell. GUI apps (macOS .app, Linux .desktop) inherit a minimal
+// environment that lacks these, causing silent failures when tools or
+// configs set in .zshrc/.bashrc are not available.
+var shellEnvVars = []string{
+	"PATH",
+	"KUBECONFIG",
+	"AWS_PROFILE",
+	"AWS_DEFAULT_REGION",
+	"GOOGLE_APPLICATION_CREDENTIALS",
+	"CLOUDSDK_CONFIG",
+	"AZURE_CONFIG_DIR",
+}
+
+// enrichEnv captures key environment variables from the user's login
+// shell so the desktop app can find CLI tools and config files that are
+// set in .zshrc/.bashrc but not available to macOS .app bundles or
+// Linux desktop applications.
+func enrichEnv() {
+	captured := getShellEnv(shellEnvVars)
+
+	if path, ok := captured["PATH"]; ok && path != "" {
+		os.Setenv("PATH", path)
+		log.Printf("PATH enriched from login shell (%d entries)", len(strings.Split(path, ":")))
+	} else {
+		// Fallback: append common tool locations
+		current := os.Getenv("PATH")
+		extras := commonPaths()
+		if len(extras) > 0 {
+			os.Setenv("PATH", current+":"+strings.Join(extras, ":"))
+			log.Printf("PATH enriched with %d common paths (shell detection failed)", len(extras))
+		} else {
+			log.Printf("PATH enrichment: no additional paths found; auth plugins like gke-gcloud-auth-plugin may not be found")
+		}
 	}
 
-	// Fallback: append common tool locations
-	current := os.Getenv("PATH")
-	extras := commonPaths()
-	if len(extras) > 0 {
-		os.Setenv("PATH", current+":"+strings.Join(extras, ":"))
-		log.Printf("PATH enriched with %d common paths (shell detection failed)", len(extras))
-	} else {
-		log.Printf("PATH enrichment: no additional paths found; auth plugins like gke-gcloud-auth-plugin may not be found")
+	// Apply non-PATH vars that were found in the shell but not in our env
+	for _, key := range shellEnvVars {
+		if key == "PATH" {
+			continue
+		}
+		if val, ok := captured[key]; ok && val != "" && os.Getenv(key) == "" {
+			os.Setenv(key, val)
+			log.Printf("Env enriched: %s from login shell", key)
+		}
 	}
 }
 
-// getShellPath runs the user's login shell to capture their full PATH.
+// getShellEnv runs the user's login shell to capture environment variables.
 // It uses -i (interactive) so that zsh reads ~/.zshrc, where tools like
-// Homebrew's google-cloud-sdk add their PATH entries. Without -i, a
-// non-interactive login shell skips ~/.zshrc, so PATH entries added
-// there (like gke-gcloud-auth-plugin) are missing.
-// Output markers safely extract PATH even if the interactive shell
+// Homebrew's google-cloud-sdk add their PATH/KUBECONFIG entries. Without -i,
+// a non-interactive login shell skips ~/.zshrc.
+// Output markers safely extract values even if the interactive shell
 // prints extra text (e.g. Oh My Zsh banners, motd).
-func getShellPath() string {
+func getShellEnv(keys []string) map[string]string {
 	shell := os.Getenv("SHELL")
 	if shell == "" {
 		if runtime.GOOS == "darwin" {
@@ -52,9 +76,16 @@ func getShellPath() string {
 		}
 	}
 
-	const startMarker = "__RADAR_PATH_START__"
-	const endMarker = "__RADAR_PATH_END__"
-	echoCmd := "echo " + startMarker + "$PATH" + endMarker
+	// Print each var on its own line between markers so values containing
+	// special strings don't break parsing. Using printf '%s\n' per var.
+	const startMarker = "__RADAR_ENV_START__"
+	const endMarker = "__RADAR_ENV_END__"
+
+	var printCmds []string
+	for _, key := range keys {
+		printCmds = append(printCmds, "printf '%s\\n' \"$"+key+"\"")
+	}
+	echoCmd := "echo " + startMarker + "; " + strings.Join(printCmds, "; ") + "; echo " + endMarker
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -68,24 +99,34 @@ func getShellPath() string {
 	cmd.Stdin = nil
 	out, err := cmd.Output()
 	if err != nil {
-		log.Printf("Shell PATH detection failed (%s -l -i -c): %v", shell, err)
-		return ""
+		log.Printf("Shell env detection failed (%s -l -i -c): %v", shell, err)
+		return nil
 	}
 
 	output := string(out)
 	startIdx := strings.Index(output, startMarker)
 	endIdx := strings.Index(output, endMarker)
 	if startIdx == -1 || endIdx == -1 || endIdx <= startIdx {
-		log.Printf("Shell PATH detection: markers not found in output")
-		return ""
+		log.Printf("Shell env detection: markers not found in output")
+		return nil
 	}
-	path := output[startIdx+len(startMarker) : endIdx]
-	path = strings.TrimSpace(path)
+	// Payload is: \nVAL1\nVAL2\n...\nVALn\n (empty vars produce empty lines).
+	// Split on \n gives ["", val1, val2, ..., valn, ""] — trim first and last.
+	payload := output[startIdx+len(startMarker) : endIdx]
+	lines := strings.Split(payload, "\n")
+	if len(lines) >= 2 {
+		lines = lines[1 : len(lines)-1] // drop leading "" from echo newline and trailing ""
+	}
+	if len(lines) != len(keys) {
+		log.Printf("Shell env detection: expected %d values, got %d", len(keys), len(lines))
+		return nil
+	}
 
-	if path == "" || path == os.Getenv("PATH") {
-		return ""
+	result := make(map[string]string, len(keys))
+	for i, key := range keys {
+		result[key] = lines[i]
 	}
-	return path
+	return result
 }
 
 // commonPaths returns well-known directories where CLI tools are typically installed.

--- a/cmd/desktop/main.go
+++ b/cmd/desktop/main.go
@@ -61,14 +61,15 @@ func main() {
 	// GUI apps (macOS .app, Linux .desktop) get a minimal PATH that
 	// doesn't include user-installed tools like gke-gcloud-auth-plugin,
 	// gcloud, aws CLI, etc. Enrich PATH from the user's login shell.
-	enrichPath()
+	enrichEnv()
 
 	// On Linux, detect system dark mode via xdg-desktop-portal D-Bus and
 	// set GTK_THEME so WebKitGTK's prefers-color-scheme media query works.
 	applySystemTheme()
 
 	if *kubeconfig != "" && *kubeconfigDir != "" {
-		log.Fatalf("--kubeconfig and --kubeconfig-dir are mutually exclusive")
+		log.Printf("ERROR: --kubeconfig and --kubeconfig-dir are mutually exclusive")
+		os.Exit(1)
 	}
 
 	cfg := app.AppConfig{
@@ -95,8 +96,16 @@ func main() {
 	// Clean up leftover files from previous update
 	updater.CleanupOldUpdate()
 
-	if err := app.InitializeK8s(cfg); err != nil {
-		log.Fatalf("%v", err)
+	// Initialize K8s client — if this fails (e.g., no kubeconfig found),
+	// still start the UI so the user sees the error instead of a silent exit.
+	k8sInitErr := app.InitializeK8s(cfg)
+	if k8sInitErr != nil {
+		log.Printf("K8s init failed (will show in UI): %v", k8sInitErr)
+		k8s.SetConnectionStatus(k8s.ConnectionStatus{
+			State:     k8s.StateDisconnected,
+			Error:     k8sInitErr.Error(),
+			ErrorType: "config",
+		})
 	}
 
 	timelineStoreCfg := app.BuildTimelineStoreConfig(cfg)
@@ -111,7 +120,8 @@ func main() {
 	ready := make(chan struct{})
 	go func() {
 		if err := srv.StartWithReady(ready); err != nil {
-			log.Fatalf("Server error: %v", err)
+			log.Printf("Server error: %v", err)
+			os.Exit(1)
 		}
 	}()
 	<-ready
@@ -120,7 +130,9 @@ func main() {
 	app.WriteMCPPortFile(srv.ActualPort())
 
 	// Initialize cluster in background (browser will see progress via SSE)
-	go app.InitializeCluster()
+	if k8sInitErr == nil {
+		go app.InitializeCluster()
+	}
 
 	// Track opens and maybe prompt to star (non-blocking)
 	app.MaybePromptGitHubStar()

--- a/web/src/components/ConnectionErrorView.tsx
+++ b/web/src/components/ConnectionErrorView.tsx
@@ -75,6 +75,14 @@ function getAuthHints(context: string): AuthHints {
 }
 
 const errorHints: Record<string, { title: string; hints: string[] }> = {
+  config: {
+    title: 'No Kubeconfig Found',
+    hints: [
+      'Radar could not find a kubeconfig file at ~/.kube/config',
+      'If your kubeconfig is at a custom path, set the KUBECONFIG environment variable in your shell profile (~/.zshrc or ~/.bashrc)',
+      'You can also pass --kubeconfig <path> when launching from the terminal',
+    ],
+  },
   rbac: {
     title: 'Insufficient Permissions',
     hints: [
@@ -161,7 +169,7 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
           </div>
 
           <h2 className="text-xl font-semibold text-theme-text-primary mb-2">
-            Cannot Connect to Cluster
+            {connection.errorType === 'config' ? 'No Cluster Configuration' : 'Cannot Connect to Cluster'}
           </h2>
 
           <p className="text-sm text-theme-text-secondary mb-1">
@@ -221,7 +229,7 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
               )}
             </button>
 
-            <ContextSwitcher />
+            {connection.errorType !== 'config' && <ContextSwitcher />}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Fixes #383. The desktop app silently exited when launched from Finder/Launchpad if the user's kubeconfig wasn't at `~/.kube/config`. GUI apps don't inherit shell environment variables like `KUBECONFIG`, so users who set it in `.zshrc`/`.bashrc` saw the app vanish without any error.

Three changes:
- **`enrichEnv()`** replaces `enrichPath()` — now captures `KUBECONFIG`, `AWS_PROFILE`, `GOOGLE_APPLICATION_CREDENTIALS`, and other cloud provider env vars from the user's login shell, not just `PATH`
- **Graceful K8s init failure** — `InitializeK8s` errors are shown in the UI as a "No Cluster Configuration" screen with actionable hints, instead of calling `log.Fatalf` which silently kills the process
- **`config` error type in frontend** — dedicated error view explaining how to set `KUBECONFIG` or pass `--kubeconfig`

The app now always starts the UI regardless of kubeconfig state, matching user expectations for a desktop application.

![Uploading image.png…]()
