### PR TITLE
deps(npm): upgrade @xyflow/react, @playwright/test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -571,13 +571,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.0.tgz",
-      "integrity": "sha512-TOA5sTLd49rTDaZpYpvCQ9hGefHQq/OYOyCVnGqS2mjMfX+lGZv2iddIJd0I48cfxqSPttS9S3OuLKyylHcO1w==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.0"
+        "playwright": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3798,13 +3798,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.0.tgz",
-      "integrity": "sha512-wihGScriusvATUxmhfENxg0tj1vHEFeIwxlnPFKQTOQVd7aG08mUfvvniRP/PtQOC+2Bs52kBOC/Up1jTXeIbw==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.0"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3817,9 +3817,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.0.tgz",
-      "integrity": "sha512-PW/X/IoZ6BMUUy8rpwHEZ8Kc0IiLIkgKYGNFaMs5KmQhcfLILNx9yCQD0rnWeWfz1PNeqcFP1BsihQhDOBCwZw==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4837,7 +4837,7 @@
         "yaml": "^2.8.3"
       },
       "devDependencies": {
-        "@playwright/test": "^1.59.0",
+        "@playwright/test": "^1.59.1",
         "@types/diff": "^8.0.0",
         "@types/node": "^25.5.0",
         "@types/react": "^19.2.14",

--- a/web/package.json
+++ b/web/package.json
@@ -38,7 +38,7 @@
     "yaml": "^2.8.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.59.0",
+    "@playwright/test": "^1.59.1",
     "@types/diff": "^8.0.0",
     "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",


### PR DESCRIPTION
## Summary
- `@xyflow/react` 12.10.1 → 12.10.2 (patch: remount fix, selection state cleanup, viewport helper fix)
- `@playwright/test` 1.58.2 → 1.59.1 (minor: screencast API, dev-only)

Supersedes #392 and #395.