### PR TITLE
fix: dark mode broken in published builds (CI Node 20 → 22)

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
@@ -146,7 +146,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
@@ -232,7 +232,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 

--- a/packages/k8s-ui/src/theme/variables.css
+++ b/packages/k8s-ui/src/theme/variables.css
@@ -11,7 +11,7 @@
  */
 
 :root {
-  color-scheme: light dark;
+  color-scheme: light;
 
   /* ── Brand (refined blue — more life than slate, less generic than tech blue) ── */
   --color-brand: light-dark(#4A7CC9, #6A9FE0);
@@ -128,8 +128,13 @@
   --scrollbar-thumb-hover: light-dark(#AABACF, #484C55);
 }
 
-/* Dark overrides for comma-separated values that can't use light-dark() */
+/* Dark overrides — color-scheme drives light-dark() resolution.
+   We declare it in CSS (not just via JS inline style) because Lightning CSS
+   may compile light-dark() into a @media (prefers-color-scheme) polyfill
+   (e.g. on Node <22), which only responds to CSS color-scheme declarations.
+   Also guards against WKWebView quirks in the desktop app. */
 .dark {
+  color-scheme: dark;
   --shadow-sm: 0 1px 3px rgba(0,0,0,0.3), 0 1px 2px rgba(0,0,0,0.2), 0 0 0 1px rgba(255,255,255,0.06);
   --shadow-md: 0 4px 12px -2px rgba(0,0,0,0.35), 0 2px 4px rgba(0,0,0,0.15), 0 0 0 1px rgba(255,255,255,0.06);
   --shadow-lg: 0 12px 32px -6px rgba(0,0,0,0.3), 0 4px 8px rgba(0,0,0,0.1);


### PR DESCRIPTION
## Summary

- Dark mode toggle had no effect on background colors in Brew-installed desktop app and CLI — clicking the button changed some Tailwind `dark:` utilities but `light-dark()` CSS variables stayed on light values
- **Root cause**: CI used Node 20, which caused Lightning CSS (bundled in Tailwind CSS v4's Vite plugin) to compile `light-dark()` into a `@media (prefers-color-scheme)` polyfill. That polyfill only responds to OS-level dark mode, not JavaScript `style.colorScheme` toggles. On Node 22+, Lightning CSS emits native `light-dark()` which works correctly
- Locally-built binaries were unaffected because local Node (v25) never triggered the polyfill path
- Bump all release workflows (desktop + CLI) from Node 20 → 22
- Add `color-scheme: dark` to the `.dark` CSS rule as a defensive fallback

## Test plan

- [x] `npm run tsc` — clean
- [x] `npm run build` — succeeds, built CSS has `color-scheme:light` and `color-scheme:dark` (no `--lightningcss-light` polyfill)
- [x] `make desktop` + launch from dock — dark mode toggles correctly
- [x] Local build with hardened runtime + `io.skyhook.radar` bundle ID — dark mode works