### PR TITLE
feat: authenticate in terminal on auth failures

### DIFF
--- a/internal/k8s/connection_state.go
+++ b/internal/k8s/connection_state.go
@@ -125,10 +125,12 @@ func ClassifyError(err error) string {
 	// Timeout errors — but when an exec credential plugin is configured,
 	// timeouts almost always mean expired credentials (the plugin hangs
 	// trying to refresh), not actual network timeouts.
+	// Exception: "cluster unreachable" means the connectivity test ran
+	// (exec plugin didn't block), so the cluster itself is down/offline.
 	if strings.Contains(errLower, "i/o timeout") ||
 		strings.Contains(errLower, "context deadline exceeded") ||
 		strings.Contains(errLower, "timeout") {
-		if UsesExecAuth() {
+		if UsesExecAuth() && !strings.Contains(errLower, "cluster unreachable") {
 			return "auth"
 		}
 		return "timeout"

--- a/packages/k8s-ui/src/components/dock/DockContext.tsx
+++ b/packages/k8s-ui/src/components/dock/DockContext.tsx
@@ -20,6 +20,8 @@ export interface DockTab {
   workloadName?: string
   // Node terminal props
   nodeName?: string
+  // Local terminal props
+  initialCommand?: string
 }
 
 export interface DockContextValue {
@@ -250,10 +252,11 @@ export function useOpenNodeTerminal() {
 export function useOpenLocalTerminal() {
   const { addTab } = useDock()
 
-  return () => {
+  return (opts?: { initialCommand?: string; title?: string }) => {
     addTab({
       type: 'local-terminal',
-      title: 'Terminal',
+      title: opts?.title || 'Terminal',
+      initialCommand: opts?.initialCommand,
     })
   }
 }

--- a/packages/k8s-ui/src/components/dock/LocalTerminalTab.tsx
+++ b/packages/k8s-ui/src/components/dock/LocalTerminalTab.tsx
@@ -10,11 +10,14 @@ export interface LocalTerminalTabProps {
   isActive?: boolean
   /** Returns the WebSocket URL for the local terminal session */
   createSession: () => Promise<{ wsUrl: string }>
+  /** Command to auto-execute after the terminal connects */
+  initialCommand?: string
 }
 
 export function LocalTerminalTab({
   isActive = true,
   createSession,
+  initialCommand,
 }: LocalTerminalTabProps) {
   const terminalRef = useRef<HTMLDivElement>(null)
   const xtermRef = useRef<XTerm | null>(null)
@@ -104,6 +107,14 @@ export function LocalTerminalTab({
           setIsConnecting(false)
           doFit(ws)
           xterm.focus()
+          if (initialCommand) {
+            // Small delay to let the shell prompt initialize
+            setTimeout(() => {
+              if (ws.readyState === WebSocket.OPEN) {
+                ws.send(JSON.stringify({ type: 'input', data: initialCommand + '\n' }))
+              }
+            }, 300)
+          }
         }
 
         ws.onmessage = (event) => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -826,7 +826,7 @@ function AppInner() {
           {/* Local terminal */}
           {capabilities.localTerminal && (
             <button
-              onClick={openLocalTerminal}
+              onClick={() => openLocalTerminal()}
               className="p-1.5 rounded-md bg-theme-elevated hover:bg-theme-hover text-theme-text-secondary hover:text-theme-text-primary transition-colors"
               title="Open local terminal"
             >

--- a/web/src/components/ConnectionErrorView.tsx
+++ b/web/src/components/ConnectionErrorView.tsx
@@ -1,8 +1,9 @@
-import { XCircle, RefreshCw, Loader2, Copy, Check } from 'lucide-react'
+import { XCircle, RefreshCw, Loader2, Copy, Check, TerminalSquare } from 'lucide-react'
 import { useState } from 'react'
 import type { ConnectionState } from '../context/ConnectionContext'
 import { ContextSwitcher } from './ContextSwitcher'
 import { parseContextName } from '../utils/context-name'
+import { useOpenLocalTerminal } from '@skyhook-io/k8s-ui'
 
 interface ConnectionErrorViewProps {
   connection: ConnectionState
@@ -13,7 +14,10 @@ interface ConnectionErrorViewProps {
 interface AuthHints {
   title: string
   hints: string[]
-  commands?: { label: string; command: string }[]
+  /** Primary auth command — usually sufficient on its own */
+  authCommand?: { label: string; command: string }
+  /** Secondary command shown as fallback if primary doesn't resolve the issue */
+  fallbackCommand?: { label: string; command: string }
 }
 
 function getAuthHints(context: string): AuthHints {
@@ -21,47 +25,41 @@ function getAuthHints(context: string): AuthHints {
 
   switch (parsed.provider) {
     case 'GKE': {
-      const commands: { label: string; command: string }[] = [
-        { label: 'Re-authenticate with Google Cloud:', command: 'gcloud auth login' },
-      ]
+      const result: AuthHints = {
+        title: 'GKE Authentication Failed',
+        hints: ['Your Google Cloud credentials have expired.'],
+        authCommand: { label: 'Re-authenticate with Google Cloud:', command: 'gcloud auth login' },
+      }
       if (parsed.region && parsed.account) {
         const isZone = /^[a-z]+-[a-z]+\d+-[a-z]$/.test(parsed.region)
         const flag = isZone ? '--zone' : '--region'
-        commands.push({
-          label: 'Then refresh cluster credentials:',
+        result.fallbackCommand = {
+          label: 'If that doesn\'t work, refresh cluster credentials:',
           command: `gcloud container clusters get-credentials ${parsed.clusterName} ${flag} ${parsed.region} --project ${parsed.account}`,
-        })
+        }
       }
-      return {
-        title: 'GKE Authentication Failed',
-        hints: ['Your Google Cloud credentials have expired.'],
-        commands,
-      }
+      return result
     }
     case 'EKS': {
-      const commands: { label: string; command: string }[] = [
-        { label: 'Re-authenticate with AWS:', command: 'aws sso login' },
-      ]
-      if (parsed.region) {
-        commands.push({
-          label: 'Then refresh cluster credentials:',
-          command: `aws eks update-kubeconfig --name ${parsed.clusterName} --region ${parsed.region}`,
-        })
-      }
-      return {
+      const result: AuthHints = {
         title: 'EKS Authentication Failed',
         hints: ['Your AWS credentials have expired.'],
-        commands,
+        authCommand: { label: 'Re-authenticate with AWS:', command: 'aws sso login' },
       }
+      if (parsed.region) {
+        result.fallbackCommand = {
+          label: 'If that doesn\'t work, refresh cluster credentials:',
+          command: `aws eks update-kubeconfig --name ${parsed.clusterName} --region ${parsed.region}`,
+        }
+      }
+      return result
     }
     case 'AKS':
       return {
         title: 'AKS Authentication Failed',
         hints: ['Your Azure credentials have expired.'],
-        commands: [
-          { label: 'Re-authenticate with Azure:', command: 'az login' },
-          { label: 'Then refresh cluster credentials:', command: 'az aks get-credentials --name <cluster> --resource-group <rg>' },
-        ],
+        authCommand: { label: 'Re-authenticate with Azure:', command: 'az login' },
+        fallbackCommand: { label: 'If that doesn\'t work, refresh cluster credentials:', command: 'az aks get-credentials --name <cluster> --resource-group <rg>' },
       }
     default:
       return {
@@ -120,7 +118,7 @@ const errorHints: Record<string, { title: string; hints: string[] }> = {
   },
 }
 
-function CopyableCommand({ command }: { command: string }) {
+function CopyableCommand({ command, onRunInTerminal }: { command: string; onRunInTerminal?: (command: string) => void }) {
   const [copied, setCopied] = useState(false)
 
   const handleCopy = () => {
@@ -133,14 +131,21 @@ function CopyableCommand({ command }: { command: string }) {
   }
 
   return (
-    <div
-      className="mt-2 flex items-center gap-2 bg-theme-elevated border border-theme-border rounded-md px-3 py-2 cursor-pointer hover:border-theme-border-hover transition-colors group"
-      onClick={handleCopy}
-    >
+    <div className="mt-2 flex items-center gap-2 bg-theme-elevated border border-theme-border rounded-md px-3 py-2 group">
       <code className="text-xs font-mono text-theme-text-primary flex-1 select-all break-all">
         {command}
       </code>
+      {onRunInTerminal && (
+        <button
+          onClick={() => onRunInTerminal(command)}
+          className="shrink-0 text-theme-text-tertiary hover:text-theme-text-secondary transition-colors"
+          title="Run in terminal"
+        >
+          <TerminalSquare className="w-3.5 h-3.5" />
+        </button>
+      )}
       <button
+        onClick={handleCopy}
         className="shrink-0 text-theme-text-tertiary hover:text-theme-text-secondary transition-colors"
         title="Copy to clipboard"
       >
@@ -159,6 +164,22 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
   const isAuth = connection.errorType === 'auth'
   const authInfo = isAuth ? getAuthHints(connection.context || '') : null
   const errorInfo = authInfo || errorHints[connection.errorType || 'unknown'] || errorHints.unknown
+  const openLocalTerminal = useOpenLocalTerminal()
+
+  // Build a command that auto-retries connection after successful auth
+  const retryCmd = `curl -s -X POST http://${window.location.host}/api/connection/retry > /dev/null`
+
+  const handleAuthInTerminal = () => {
+    if (!authInfo?.authCommand) return
+    openLocalTerminal({
+      initialCommand: `${authInfo.authCommand.command} && ${retryCmd}`,
+      title: 'Auth',
+    })
+  }
+
+  const handleRunInTerminal = (command: string) => {
+    openLocalTerminal({ initialCommand: command, title: 'Auth' })
+  }
 
   return (
     <div className="flex-1 flex items-start justify-center pt-16 px-8">
@@ -194,12 +215,25 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
                 </li>
               ))}
             </ul>
-            {authInfo?.commands?.map((cmd, i) => (
-              <div key={i} className="mt-3">
-                <p className="text-xs text-theme-text-tertiary">{cmd.label}</p>
-                <CopyableCommand command={cmd.command} />
+            {authInfo?.authCommand && (
+              <div className="mt-3">
+                <p className="text-xs text-theme-text-tertiary">{authInfo.authCommand.label}</p>
+                <CopyableCommand command={authInfo.authCommand.command} onRunInTerminal={handleRunInTerminal} />
+                <button
+                  onClick={handleAuthInTerminal}
+                  className="mt-3 w-full inline-flex items-center justify-center gap-2 px-3 py-2 text-xs font-medium btn-brand rounded-md"
+                >
+                  <TerminalSquare className="w-3.5 h-3.5" />
+                  Authenticate in terminal
+                </button>
               </div>
-            ))}
+            )}
+            {authInfo?.fallbackCommand && (
+              <div className="mt-4 pt-3 border-t border-theme-border/50">
+                <p className="text-xs text-theme-text-tertiary">{authInfo.fallbackCommand.label}</p>
+                <CopyableCommand command={authInfo.fallbackCommand.command} onRunInTerminal={handleRunInTerminal} />
+              </div>
+            )}
           </div>
 
           {connection.error && (

--- a/web/src/components/dock/BottomDock.tsx
+++ b/web/src/components/dock/BottomDock.tsx
@@ -53,7 +53,7 @@ function renderTabContent(tab: DockTab, isActive: boolean) {
 
   if (tab.type === 'local-terminal') {
     return (
-      <LocalTerminalTab isActive={isActive} />
+      <LocalTerminalTab isActive={isActive} initialCommand={tab.initialCommand} />
     )
   }
 

--- a/web/src/components/dock/LocalTerminalTab.tsx
+++ b/web/src/components/dock/LocalTerminalTab.tsx
@@ -2,9 +2,10 @@ import { LocalTerminalTab as SharedLocalTerminalTab } from '@skyhook-io/k8s-ui'
 
 interface LocalTerminalTabProps {
   isActive?: boolean
+  initialCommand?: string
 }
 
-export function LocalTerminalTab({ isActive }: LocalTerminalTabProps) {
+export function LocalTerminalTab({ isActive, initialCommand }: LocalTerminalTabProps) {
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
 
   const createSession = () =>
@@ -16,6 +17,7 @@ export function LocalTerminalTab({ isActive }: LocalTerminalTabProps) {
     <SharedLocalTerminalTab
       isActive={isActive}
       createSession={createSession}
+      initialCommand={initialCommand}
     />
   )
 }


### PR DESCRIPTION
## Summary

- Adds an **"Authenticate in terminal"** button to the connection error view when credentials expire. Opens a local terminal tab, auto-runs the provider-specific auth command (`gcloud auth login`, `aws sso login`, `az login`), and auto-retries the cluster connection on success via `&&` chaining.
- Restructures auth error hints: the login command is the primary action with a prominent button; the `get-credentials` command is shown as a fallback ("if that doesn't work") since re-login alone is usually sufficient when credentials expire.
- Fixes misclassification of offline/unreachable clusters as auth errors. When exec credential plugins (GKE/EKS/AKS) are configured, timeouts were always classified as `auth` — but if the error contains "cluster unreachable", the plugin didn't hang (auth is fine), the cluster itself is down. Now correctly classified as `timeout`.

## Changes

- `DockTab` gains `initialCommand?: string`; `useOpenLocalTerminal()` accepts optional `{ initialCommand, title }`
- `LocalTerminalTab` sends the initial command via WebSocket 300ms after connect
- `ConnectionErrorView` adds run-in-terminal buttons and restructured auth/fallback layout
- `ClassifyError()` excludes "cluster unreachable" errors from exec-auth timeout → auth reclassification