### PR TITLE
feat(auth): OIDC TLS skip-verify and custom CA cert

### DIFF
--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -63,6 +63,8 @@ func main() {
 	authOIDCRedirectURL := flag.String("auth-oidc-redirect-url", "", "OIDC redirect URL")
 	authOIDCGroupsClaim := flag.String("auth-oidc-groups-claim", "groups", "JWT claim for groups")
 	authOIDCPostLogoutRedirectURL := flag.String("auth-oidc-post-logout-redirect-url", "", "URL to redirect after OIDC provider logout (must be registered with IdP)")
+	authOIDCInsecureSkipVerify := flag.Bool("auth-oidc-insecure-skip-verify", false, "Skip TLS certificate verification for OIDC provider (insecure, dev/test only)")
+	authOIDCCACert := flag.String("auth-oidc-ca-cert", "", "Path to CA certificate file for OIDC provider TLS verification")
 	flag.Parse()
 
 	if *showVersion {
@@ -119,7 +121,9 @@ func main() {
 			OIDCClientSecret: *authOIDCClientSecret,
 			OIDCRedirectURL:           *authOIDCRedirectURL,
 			OIDCGroupsClaim:           *authOIDCGroupsClaim,
-			OIDCPostLogoutRedirectURL: *authOIDCPostLogoutRedirectURL,
+			OIDCPostLogoutRedirectURL:  *authOIDCPostLogoutRedirectURL,
+			OIDCInsecureSkipVerify:     *authOIDCInsecureSkipVerify,
+			OIDCCACert:                 *authOIDCCACert,
 		},
 	}
 

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -72,6 +72,12 @@ spec:
             {{- if .Values.auth.oidc.postLogoutRedirectURL }}
             - --auth-oidc-post-logout-redirect-url={{ .Values.auth.oidc.postLogoutRedirectURL }}
             {{- end }}
+            {{- if .Values.auth.oidc.caCert }}
+            - --auth-oidc-ca-cert={{ .Values.auth.oidc.caCert }}
+            {{- end }}
+            {{- if .Values.auth.oidc.insecureSkipVerify }}
+            - --auth-oidc-insecure-skip-verify
+            {{- end }}
             {{- end }}
           ports:
             - name: http

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -177,6 +177,10 @@ auth:
     groupsClaim: "groups"
     # URL to redirect after OIDC provider logout (must be registered with IdP)
     postLogoutRedirectURL: ""
+    # Path to CA certificate file for OIDC provider TLS (e.g., /etc/radar/oidc-ca.crt)
+    caCert: ""
+    # Skip TLS verification for OIDC provider (insecure, dev/test only)
+    insecureSkipVerify: false
 
 # MCP (Model Context Protocol) server for AI tools
 mcp:

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -3,11 +3,15 @@ package auth
 import (
 	"context"
 	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -23,12 +27,42 @@ type OIDCHandler struct {
 	provider           *oidc.Provider
 	oauth              oauth2.Config
 	verifier           *oidc.IDTokenVerifier
-	endSessionEndpoint string // from OIDC discovery; empty if IdP doesn't support RP-Initiated Logout
+	endSessionEndpoint string       // from OIDC discovery; empty if IdP doesn't support RP-Initiated Logout
+	httpClient         *http.Client // custom TLS client for OIDC provider calls; nil = default
 }
 
 // NewOIDCHandler creates a new OIDC handler. Returns an error if the provider
 // cannot be discovered (network error, invalid issuer URL, etc.).
 func NewOIDCHandler(ctx context.Context, cfg Config) (*OIDCHandler, error) {
+	// Build a custom HTTP client for OIDC provider TLS when configured
+	var httpClient *http.Client
+	if cfg.OIDCCACert != "" {
+		caCert, err := os.ReadFile(cfg.OIDCCACert)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read OIDC CA cert %s: %w", cfg.OIDCCACert, err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caCert) {
+			return nil, fmt.Errorf("failed to parse OIDC CA cert %s: no valid certificates found", cfg.OIDCCACert)
+		}
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{RootCAs: pool}
+		httpClient = &http.Client{Transport: transport}
+		log.Printf("[oidc] Using custom CA certificate: %s", cfg.OIDCCACert)
+		if cfg.OIDCInsecureSkipVerify {
+			log.Printf("[oidc] WARNING: --auth-oidc-insecure-skip-verify is ignored because --auth-oidc-ca-cert is set")
+		}
+	} else if cfg.OIDCInsecureSkipVerify {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // user-requested via CLI flag
+		httpClient = &http.Client{Transport: transport}
+		log.Printf("[oidc] WARNING: TLS verification disabled for OIDC provider — do NOT use in production")
+	}
+
+	if httpClient != nil {
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
+	}
+
 	provider, err := oidc.NewProvider(ctx, cfg.OIDCIssuer)
 	if err != nil {
 		return nil, err
@@ -62,6 +96,7 @@ func NewOIDCHandler(ctx context.Context, cfg Config) (*OIDCHandler, error) {
 		oauth:              oauthCfg,
 		verifier:           verifier,
 		endSessionEndpoint: providerClaims.EndSessionEndpoint,
+		httpClient:         httpClient,
 	}, nil
 }
 
@@ -106,6 +141,11 @@ func (h *OIDCHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
+
+	// Inject custom TLS client for OIDC provider calls (token exchange, JWKS fetch)
+	if h.httpClient != nil {
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, h.httpClient)
+	}
 
 	// Verify state against cookie to prevent CSRF
 	stateCookie, err := r.Cookie(oidcStateCookieName)

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -1,9 +1,12 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
+	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -276,5 +279,204 @@ func TestHandleLogin_NoForceLoginWithoutCookie(t *testing.T) {
 	location := w.Header().Get("Location")
 	if strings.Contains(location, "prompt=login") {
 		t.Errorf("redirect URL should NOT contain prompt=login on normal login, got %q", location)
+	}
+}
+
+// newTLSOIDCServer starts an httptest.NewTLSServer that serves a minimal OIDC
+// discovery document. The caller must call Close() when done.
+func newTLSOIDCServer() *httptest.Server {
+	var srv *httptest.Server
+	srv = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                 srv.URL,
+			"authorization_endpoint": srv.URL + "/auth",
+			"token_endpoint":         srv.URL + "/token",
+			"jwks_uri":               srv.URL + "/jwks",
+			"response_types_supported": []string{"code"},
+			"subject_types_supported":  []string{"public"},
+			"id_token_signing_alg_values_supported": []string{"RS256"},
+		})
+	}))
+	return srv
+}
+
+func TestNewOIDCHandler_FailsWithSelfSignedCert(t *testing.T) {
+	srv := newTLSOIDCServer()
+	defer srv.Close()
+
+	_, err := NewOIDCHandler(context.Background(), Config{
+		Mode:         "oidc",
+		OIDCIssuer:   srv.URL,
+		OIDCClientID: "test",
+		OIDCClientSecret: "secret",
+		OIDCRedirectURL:  "http://localhost/callback",
+	})
+	if err == nil {
+		t.Fatal("expected TLS error, got nil")
+	}
+	if !strings.Contains(err.Error(), "certificate") {
+		t.Errorf("expected certificate error, got: %v", err)
+	}
+}
+
+func TestNewOIDCHandler_InsecureSkipVerify(t *testing.T) {
+	srv := newTLSOIDCServer()
+	defer srv.Close()
+
+	h, err := NewOIDCHandler(context.Background(), Config{
+		Mode:                   "oidc",
+		OIDCIssuer:             srv.URL,
+		OIDCClientID:           "test",
+		OIDCClientSecret:       "secret",
+		OIDCRedirectURL:        "http://localhost/callback",
+		OIDCInsecureSkipVerify: true,
+	})
+	if err != nil {
+		t.Fatalf("expected success with InsecureSkipVerify, got: %v", err)
+	}
+	if h.httpClient == nil {
+		t.Error("httpClient should be set when InsecureSkipVerify is true")
+	}
+}
+
+func TestNewOIDCHandler_CACert(t *testing.T) {
+	srv := newTLSOIDCServer()
+	defer srv.Close()
+
+	// Write the test server's CA cert to a temp file
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: srv.TLS.Certificates[0].Certificate[0],
+	})
+	f, err := os.CreateTemp("", "oidc-ca-*.pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.Write(certPEM); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	h, err := NewOIDCHandler(context.Background(), Config{
+		Mode:             "oidc",
+		OIDCIssuer:       srv.URL,
+		OIDCClientID:     "test",
+		OIDCClientSecret: "secret",
+		OIDCRedirectURL:  "http://localhost/callback",
+		OIDCCACert:       f.Name(),
+	})
+	if err != nil {
+		t.Fatalf("expected success with CA cert, got: %v", err)
+	}
+	if h.httpClient == nil {
+		t.Error("httpClient should be set when CACert is provided")
+	}
+}
+
+func TestNewOIDCHandler_CACertTakesPrecedence(t *testing.T) {
+	srv := newTLSOIDCServer()
+	defer srv.Close()
+
+	// Write CA cert
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: srv.TLS.Certificates[0].Certificate[0],
+	})
+	f, err := os.CreateTemp("", "oidc-ca-*.pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.Write(certPEM); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	// Both flags set — CA cert should win (InsecureSkipVerify should be false on transport)
+	h, err := NewOIDCHandler(context.Background(), Config{
+		Mode:                   "oidc",
+		OIDCIssuer:             srv.URL,
+		OIDCClientID:           "test",
+		OIDCClientSecret:       "secret",
+		OIDCRedirectURL:        "http://localhost/callback",
+		OIDCCACert:             f.Name(),
+		OIDCInsecureSkipVerify: true,
+	})
+	if err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+	if h.httpClient == nil {
+		t.Fatal("httpClient should be set")
+	}
+	// Verify InsecureSkipVerify is NOT set (CA cert takes precedence)
+	transport := h.httpClient.Transport.(*http.Transport)
+	if transport.TLSClientConfig.InsecureSkipVerify {
+		t.Error("InsecureSkipVerify should be false when CA cert is provided")
+	}
+	if transport.TLSClientConfig.RootCAs == nil {
+		t.Error("RootCAs should be set when CA cert is provided")
+	}
+}
+
+func TestNewOIDCHandler_InvalidCACertPath(t *testing.T) {
+	_, err := NewOIDCHandler(context.Background(), Config{
+		Mode:             "oidc",
+		OIDCIssuer:       "https://example.com",
+		OIDCClientID:     "test",
+		OIDCClientSecret: "secret",
+		OIDCRedirectURL:  "http://localhost/callback",
+		OIDCCACert:       "/nonexistent/ca.pem",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid CA cert path")
+	}
+	if !strings.Contains(err.Error(), "failed to read") {
+		t.Errorf("expected 'failed to read' error, got: %v", err)
+	}
+}
+
+func TestNewOIDCHandler_InvalidCACertContent(t *testing.T) {
+	f, err := os.CreateTemp("", "oidc-bad-ca-*.pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	f.WriteString("not a certificate")
+	f.Close()
+
+	_, err = NewOIDCHandler(context.Background(), Config{
+		Mode:             "oidc",
+		OIDCIssuer:       "https://example.com",
+		OIDCClientID:     "test",
+		OIDCClientSecret: "secret",
+		OIDCRedirectURL:  "http://localhost/callback",
+		OIDCCACert:       f.Name(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid CA cert content")
+	}
+	if !strings.Contains(err.Error(), "no valid certificates") {
+		t.Errorf("expected 'no valid certificates' error, got: %v", err)
+	}
+}
+
+func TestOIDCHandler_CallbackUsesCustomClient(t *testing.T) {
+	h := newTestOIDCHandler()
+	h.httpClient = &http.Client{} // non-nil signals custom client is set
+
+	// The callback should inject the client into the context.
+	// We test this indirectly: a valid state + code but nil oauth config
+	// will fail at Exchange, not at client injection.
+	r := httptest.NewRequest("GET", "/auth/callback?state=abc&code=xyz", nil)
+	r.AddCookie(&http.Cookie{Name: oidcStateCookieName, Value: "abc"})
+	w := httptest.NewRecorder()
+
+	h.HandleCallback(w, r)
+
+	// Should fail at token exchange (oauth config is nil), not panic
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500 (exchange failure, not panic)", w.Code)
 	}
 }

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -27,7 +27,9 @@ type Config struct {
 	OIDCClientSecret string
 	OIDCRedirectURL           string
 	OIDCGroupsClaim           string // default "groups"
-	OIDCPostLogoutRedirectURL string // optional, URL to redirect after IdP logout
+	OIDCPostLogoutRedirectURL  string // optional, URL to redirect after IdP logout
+	OIDCInsecureSkipVerify     bool   // skip TLS verification for OIDC provider (dev/test only)
+	OIDCCACert                 string // path to CA certificate file for OIDC provider TLS
 }
 
 // User represents an authenticated user


### PR DESCRIPTION
## Summary

Adds two new flags for OIDC authentication with providers that use self-signed or internal CA certificates (e.g., on-prem Keycloak):

- `--auth-oidc-insecure-skip-verify` — disables TLS verification for the OIDC provider (dev/test escape hatch)
- `--auth-oidc-ca-cert <path>` — loads a custom CA certificate bundle for the OIDC provider (secure option)

When both are set, `--auth-oidc-ca-cert` takes precedence and a warning is logged.

The custom HTTP client is injected via `oauth2.HTTPClient` context key, which covers all three TLS touchpoints in the OIDC flow: provider discovery, token exchange, and JWKS fetch.

Both flags are also exposed in the Helm chart under `auth.oidc.insecureSkipVerify` and `auth.oidc.caCert`.

Closes #410

## Changes

- **`pkg/auth/types.go`** — added `OIDCInsecureSkipVerify` and `OIDCCACert` config fields
- **`internal/auth/oidc.go`** — builds custom HTTP client, injects into context at init and callback
- **`cmd/explorer/main.go`** — new CLI flags wired to config
- **`deploy/helm/`** — Helm values + deployment template for both flags
- **`internal/auth/oidc_test.go`** — 7 new tests: TLS failure baseline, skip-verify, CA cert, precedence, invalid cert path/content, callback injection