### PR TITLE
feat(auth): load OIDC client secret from existing K8s Secret

### DIFF
--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -60,9 +60,7 @@ spec:
             {{- if .Values.auth.oidc.clientID }}
             - --auth-oidc-client-id={{ .Values.auth.oidc.clientID }}
             {{- end }}
-            {{- if .Values.auth.oidc.clientSecret }}
-            - --auth-oidc-client-secret={{ .Values.auth.oidc.clientSecret }}
-            {{- end }}
+            {{- /* clientSecret is injected via RADAR_OIDC_CLIENT_SECRET env var below */}}
             {{- if .Values.auth.oidc.redirectURL }}
             - --auth-oidc-redirect-url={{ .Values.auth.oidc.redirectURL }}
             {{- end }}
@@ -93,6 +91,17 @@ spec:
                   key: {{ .Values.auth.existingSecretKey }}
               {{- else }}
               value: {{ .Values.auth.secret | quote }}
+              {{- end }}
+            {{- end }}
+            {{- if and (eq .Values.auth.mode "oidc") (or .Values.auth.oidc.clientSecret .Values.auth.oidc.existingSecret) }}
+            - name: RADAR_OIDC_CLIENT_SECRET
+              {{- if .Values.auth.oidc.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.oidc.existingSecret }}
+                  key: {{ .Values.auth.oidc.clientSecretKey }}
+              {{- else }}
+              value: {{ .Values.auth.oidc.clientSecret | quote }}
               {{- end }}
             {{- end }}
             - name: HELM_CACHE_HOME

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -173,6 +173,11 @@ auth:
     issuerURL: ""
     clientID: ""
     clientSecret: ""
+    # Use an existing K8s Secret for the OIDC client secret (avoids storing in Helm values).
+    # The Secret must contain a key matching clientSecretKey below.
+    existingSecret: ""
+    # Key within the existingSecret that holds the client secret value
+    clientSecretKey: "client-secret"
     redirectURL: ""
     groupsClaim: "groups"
     # URL to redirect after OIDC provider logout (must be registered with IdP)

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -93,21 +93,39 @@ Radar discovers the provider's `end_session_endpoint` automatically from the OID
 
 To redirect users back to Radar after IdP logout, set `--auth-oidc-post-logout-redirect-url` (or `auth.oidc.postLogoutRedirectURL` in Helm). This URL **must be registered** with your identity provider as a valid post-logout redirect URI.
 
-**Using a K8s Secret for the session signing key:**
+**Using K8s Secrets for sensitive values:**
 
-> `existingSecret` stores only the HMAC key used to sign session cookies — not OIDC client credentials. The OIDC client ID and secret are still passed as Helm values (visible in Helm release history). For production, consider injecting them via environment variables or a secrets manager.
+For production, use K8s Secrets instead of storing credentials in Helm values (which are visible in Helm release history):
 
 ```yaml
 auth:
   mode: oidc
+  # Session signing key from a K8s Secret
   existingSecret: radar-auth-secret        # K8s Secret containing the HMAC key
   existingSecretKey: auth-secret            # Key within the Secret (default)
   oidc:
     issuerURL: https://accounts.google.com
     clientID: your-client-id
-    clientSecret: your-client-secret
+    # OIDC client secret from a K8s Secret
+    existingSecret: radar-oidc-credentials  # K8s Secret containing the client secret
+    clientSecretKey: client-secret           # Key within the Secret (default)
     redirectURL: https://radar.example.com/auth/callback
 ```
+
+You can also mix approaches — use `existingSecret` for the client secret but pass `clientID` as a plain value (it's not sensitive).
+
+**TLS configuration for self-signed certificates:**
+
+If your OIDC provider uses a self-signed or internal CA certificate (e.g., on-prem Keycloak), use one of:
+
+```yaml
+auth:
+  oidc:
+    caCert: /etc/radar/oidc-ca.crt          # Path to CA certificate file (secure)
+    # insecureSkipVerify: true              # Skip TLS verification (dev/test only)
+```
+
+When using `caCert` in Kubernetes, mount the CA certificate into the pod via a ConfigMap or Secret volume.
 
 ## Setting Up User Permissions
 
@@ -316,9 +334,13 @@ Radar uses stateless HMAC-SHA256 signed cookies for sessions. The cookie contain
 | OIDC issuer | `--auth-oidc-issuer` | `auth.oidc.issuerURL` | — |
 | OIDC client ID | `--auth-oidc-client-id` | `auth.oidc.clientID` | — |
 | OIDC client secret | `--auth-oidc-client-secret` | `auth.oidc.clientSecret` | — |
+| OIDC client secret (K8s Secret) | — | `auth.oidc.existingSecret` | — |
+| OIDC client secret key | — | `auth.oidc.clientSecretKey` | `client-secret` |
 | OIDC redirect URL | `--auth-oidc-redirect-url` | `auth.oidc.redirectURL` | — |
 | OIDC groups claim | `--auth-oidc-groups-claim` | `auth.oidc.groupsClaim` | `groups` |
 | OIDC post-logout redirect | `--auth-oidc-post-logout-redirect-url` | `auth.oidc.postLogoutRedirectURL` | — |
+| OIDC CA certificate | `--auth-oidc-ca-cert` | `auth.oidc.caCert` | — |
+| OIDC skip TLS verify | `--auth-oidc-insecure-skip-verify` | `auth.oidc.insecureSkipVerify` | `false` |
 
 ## Troubleshooting
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -101,7 +101,7 @@ func New(cfg Config) *Server {
 				log.Fatalf("[auth] --auth-oidc-client-id is required when auth-mode=oidc")
 			}
 			if s.authConfig.OIDCClientSecret == "" {
-				log.Fatalf("[auth] --auth-oidc-client-secret is required when auth-mode=oidc")
+				log.Fatalf("[auth] OIDC client secret is required when auth-mode=oidc (set --auth-oidc-client-secret flag or RADAR_OIDC_CLIENT_SECRET env var)")
 			}
 			if s.authConfig.OIDCRedirectURL == "" {
 				log.Fatalf("[auth] --auth-oidc-redirect-url is required when auth-mode=oidc")

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -52,9 +52,12 @@ func (c *Config) Defaults() {
 	if c.OIDCGroupsClaim == "" {
 		c.OIDCGroupsClaim = "groups"
 	}
-	// Fall back to env var for secret (used by Helm chart)
+	// Fall back to env vars for secrets (used by Helm chart)
 	if c.Secret == "" {
 		c.Secret = os.Getenv("RADAR_AUTH_SECRET")
+	}
+	if c.OIDCClientSecret == "" {
+		c.OIDCClientSecret = os.Getenv("RADAR_OIDC_CLIENT_SECRET")
 	}
 	// Auto-generate secret if still empty and auth is enabled
 	if c.Secret == "" && c.Enabled() {


### PR DESCRIPTION
## Summary

Adds support for loading the OIDC client secret from an existing K8s Secret, avoiding exposure in Helm release history. Also updates auth documentation to cover this and the new TLS flags from #416.

New Helm values under `auth.oidc`:
- `existingSecret` — name of the K8s Secret containing the OIDC client secret
- `clientSecretKey` — key within the Secret (default: `client-secret`)

When `existingSecret` is set, the secret is injected as `RADAR_OIDC_CLIENT_SECRET` env var via `secretKeyRef`. When not set, falls back to the plain `clientSecret` value. This matches the existing pattern used for the session signing key (`auth.existingSecret` → `RADAR_AUTH_SECRET`).

## Changes

- **Helm chart** — new `existingSecret`/`clientSecretKey` values, env var injection via `secretKeyRef`
- **`pkg/auth/types.go`** — `RADAR_OIDC_CLIENT_SECRET` env var fallback in `Defaults()`
- **`internal/server/server.go`** — improved error message when client secret is missing (mentions env var path)
- **`docs/authentication.md`** — updated K8s Secrets section (was stale after this change), added TLS config docs, added new flags (#416) to config reference table

Closes #380