### PR TITLE
fix(prometheus): improve reliability for non-standard metrics setups

### DIFF
--- a/internal/prometheus/discovery.go
+++ b/internal/prometheus/discovery.go
@@ -84,11 +84,7 @@ func (c *Client) discover(ctx context.Context) (string, string, error) {
 		addr := strings.TrimRight(manualURL, "/")
 		if c.probe(ctx, addr) {
 			log.Printf("[prometheus] Using manual URL: %s", addr)
-			c.mu.Lock()
-			c.baseURL = addr
-			c.basePath = ""
-			c.discovered = true
-			c.mu.Unlock()
+			c.markConnected(addr, "")
 			return addr, "", nil
 		}
 		errorlog.Record("prometheus", "error", "manual Prometheus URL %s not reachable", addr)
@@ -99,11 +95,7 @@ func (c *Client) discover(ctx context.Context) (string, string, error) {
 	if pfAddr := portforward.GetAddress(contextName); pfAddr != "" {
 		if c.probe(ctx, pfAddr) {
 			log.Printf("[prometheus] Using traffic system port-forward: %s", pfAddr)
-			c.mu.Lock()
-			c.baseURL = pfAddr
-			c.basePath = ""
-			c.discovered = true
-			c.mu.Unlock()
+			c.markConnected(pfAddr, "")
 			return pfAddr, "", nil
 		}
 	}
@@ -121,17 +113,8 @@ func (c *Client) discover(ctx context.Context) (string, string, error) {
 	for _, info := range candidates {
 		if c.probe(ctx, info.clusterAddr+info.basePath) {
 			log.Printf("[prometheus] Connected to %s/%s at %s", info.namespace, info.name, info.clusterAddr)
-			c.mu.Lock()
-			c.discoveryService = &ServiceInfo{
-				Namespace: info.namespace,
-				Name:      info.name,
-				Port:      info.port,
-				BasePath:  info.basePath,
-			}
-			c.baseURL = info.clusterAddr
-			c.basePath = info.basePath
-			c.discovered = true
-			c.mu.Unlock()
+			c.setDiscoveryService(info)
+			c.markConnected(info.clusterAddr, info.basePath)
 			return info.clusterAddr, info.basePath, nil
 		}
 		log.Printf("[prometheus] Well-known service %s/%s not reachable in-cluster, trying next...", info.namespace, info.name)
@@ -141,26 +124,16 @@ func (c *Client) discover(ctx context.Context) (string, string, error) {
 	if len(candidates) > 0 {
 		info := candidates[0]
 		log.Printf("[prometheus] No well-known service reachable in-cluster, trying port-forward to %s/%s...", info.namespace, info.name)
-		c.mu.Lock()
-		c.discoveryService = &ServiceInfo{
-			Namespace: info.namespace,
-			Name:      info.name,
-			Port:      info.port,
-			BasePath:  info.basePath,
-		}
-		c.mu.Unlock()
+		c.setDiscoveryService(info)
 
 		connInfo, pfErr := portforward.Start(ctx, info.namespace, info.name, info.targetPort, contextName)
 		if pfErr == nil {
 			addr := connInfo.Address
 			if c.probe(ctx, addr+info.basePath) {
-				c.mu.Lock()
-				c.baseURL = addr
-				c.basePath = info.basePath
-				c.discovered = true
-				c.mu.Unlock()
+				c.markConnected(addr, info.basePath)
 				return addr, info.basePath, nil
 			}
+			log.Printf("[prometheus] Well-known service %s/%s not responding after port-forward, falling back to dynamic discovery", info.namespace, info.name)
 			portforward.Stop()
 		} else {
 			errorlog.Record("prometheus", "error", "port-forward to %s/%s failed: %v", info.namespace, info.name, pfErr)
@@ -177,22 +150,11 @@ func (c *Client) discover(ctx context.Context) (string, string, error) {
 		return "", "", fmt.Errorf("no Prometheus service found in cluster")
 	}
 
-	c.mu.Lock()
-	c.discoveryService = &ServiceInfo{
-		Namespace: info.namespace,
-		Name:      info.name,
-		Port:      info.port,
-		BasePath:  info.basePath,
-	}
-	c.mu.Unlock()
+	c.setDiscoveryService(info)
 
 	if c.probe(ctx, info.clusterAddr+info.basePath) {
 		log.Printf("[prometheus] Connected to %s/%s at %s (dynamic)", info.namespace, info.name, info.clusterAddr)
-		c.mu.Lock()
-		c.baseURL = info.clusterAddr
-		c.basePath = info.basePath
-		c.discovered = true
-		c.mu.Unlock()
+		c.markConnected(info.clusterAddr, info.basePath)
 		return info.clusterAddr, info.basePath, nil
 	}
 
@@ -205,17 +167,34 @@ func (c *Client) discover(ctx context.Context) (string, string, error) {
 
 	addr := connInfo.Address
 	if c.probe(ctx, addr+info.basePath) {
-		c.mu.Lock()
-		c.baseURL = addr
-		c.basePath = info.basePath
-		c.discovered = true
-		c.mu.Unlock()
+		c.markConnected(addr, info.basePath)
 		return addr, info.basePath, nil
 	}
 
 	portforward.Stop()
 	errorlog.Record("prometheus", "error", "Prometheus at %s/%s not responding after port-forward", info.namespace, info.name)
 	return "", "", fmt.Errorf("Prometheus at %s/%s not responding after port-forward", info.namespace, info.name)
+}
+
+// setDiscoveryService records the discovered service metadata under write lock.
+func (c *Client) setDiscoveryService(info *serviceInfo) {
+	c.mu.Lock()
+	c.discoveryService = &ServiceInfo{
+		Namespace: info.namespace,
+		Name:      info.name,
+		Port:      info.port,
+		BasePath:  info.basePath,
+	}
+	c.mu.Unlock()
+}
+
+// markConnected records the active connection and marks discovery as complete.
+func (c *Client) markConnected(addr, basePath string) {
+	c.mu.Lock()
+	c.baseURL = addr
+	c.basePath = basePath
+	c.discovered = true
+	c.mu.Unlock()
 }
 
 type serviceInfo struct {

--- a/internal/prometheus/handlers.go
+++ b/internal/prometheus/handlers.go
@@ -1,7 +1,9 @@
 package prometheus
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"net/url"
@@ -203,20 +205,9 @@ func handleResourceMetrics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Fallback: if the primary query returned no data and this category uses
-	// container!='' filtering, retry without it. This handles cri-docker and
-	// other setups where cAdvisor metrics lack the container label entirely.
-	if len(result.Series) == 0 && categoryUsesContainerFilter(category) {
-		fallbackQuery := BuildQueryNoContainerFilter(kind, namespace, name, category)
-		if fallbackQuery != "" && fallbackQuery != query {
-			fallbackResult, fallbackErr := client.QueryRange(r.Context(), fallbackQuery, start, end, step)
-			if fallbackErr == nil && len(fallbackResult.Series) > 0 {
-				log.Printf("[prometheus] Primary query empty for %s/%s/%s (%s), fallback without container filter succeeded", kind, namespace, name, category)
-				result = fallbackResult
-				query = fallbackQuery
-			}
-		}
-	}
+	result, query = retryWithoutContainerFilter(r.Context(), client, result, query, category, start, end, step,
+		func() string { return BuildQueryNoContainerFilter(kind, namespace, name, category) },
+		fmt.Sprintf("Primary query empty for %s/%s/%s (%s)", kind, namespace, name, category))
 
 	resp := ResourceMetricsResponse{
 		Kind:      kind,
@@ -347,16 +338,9 @@ func handleNamespaceMetrics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(result.Series) == 0 && categoryUsesContainerFilter(category) {
-		fallbackQuery := BuildNamespaceQueryNoContainerFilter(namespace, category)
-		if fallbackQuery != "" && fallbackQuery != query {
-			fallbackResult, fallbackErr := client.QueryRange(r.Context(), fallbackQuery, start, end, step)
-			if fallbackErr == nil && len(fallbackResult.Series) > 0 {
-				log.Printf("[prometheus] Namespace query empty for %s (%s), fallback without container filter succeeded", namespace, category)
-				result = fallbackResult
-			}
-		}
-	}
+	result, _ = retryWithoutContainerFilter(r.Context(), client, result, query, category, start, end, step,
+		func() string { return BuildNamespaceQueryNoContainerFilter(namespace, category) },
+		fmt.Sprintf("Namespace query empty for %s (%s)", namespace, category))
 
 	writeJSON(w, http.StatusOK, NamespaceMetricsResponse{
 		Namespace: namespace,
@@ -405,16 +389,9 @@ func handleClusterMetrics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(result.Series) == 0 && categoryUsesContainerFilter(category) {
-		fallbackQuery := BuildClusterQueryNoContainerFilter(category)
-		if fallbackQuery != "" && fallbackQuery != query {
-			fallbackResult, fallbackErr := client.QueryRange(r.Context(), fallbackQuery, start, end, step)
-			if fallbackErr == nil && len(fallbackResult.Series) > 0 {
-				log.Printf("[prometheus] Cluster query empty (%s), fallback without container filter succeeded", category)
-				result = fallbackResult
-			}
-		}
-	}
+	result, _ = retryWithoutContainerFilter(r.Context(), client, result, query, category, start, end, step,
+		func() string { return BuildClusterQueryNoContainerFilter(category) },
+		fmt.Sprintf("Cluster query empty (%s)", category))
 
 	writeJSON(w, http.StatusOK, ClusterMetricsResponse{
 		Category: category,
@@ -464,6 +441,30 @@ func handleRawQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, result)
+}
+
+// retryWithoutContainerFilter re-runs the query without the container!='' filter
+// when the primary result is empty and the category uses that filter. This handles
+// cri-docker and other setups where cAdvisor metrics lack the container label.
+// Returns the updated result (original or fallback) and the query that produced it.
+func retryWithoutContainerFilter(ctx context.Context, client *Client, result *QueryResult, query string, category MetricCategory, start, end time.Time, step time.Duration, buildFallback func() string, logPrefix string) (*QueryResult, string) {
+	if len(result.Series) > 0 || !categoryUsesContainerFilter(category) {
+		return result, query
+	}
+	fallbackQuery := buildFallback()
+	if fallbackQuery == "" || fallbackQuery == query {
+		return result, query
+	}
+	fallbackResult, err := client.QueryRange(ctx, fallbackQuery, start, end, step)
+	if err != nil {
+		log.Printf("[prometheus] %s, fallback query also failed: %v", logPrefix, err)
+		return result, query
+	}
+	if len(fallbackResult.Series) == 0 {
+		return result, query
+	}
+	log.Printf("[prometheus] %s, fallback without container filter succeeded", logPrefix)
+	return fallbackResult, fallbackQuery
 }
 
 const criDockerHint = "This pod's node uses the Docker container runtime (cri-docker), which is known to cause missing pod and namespace labels in cAdvisor metrics. " +

--- a/internal/prometheus/queries.go
+++ b/internal/prometheus/queries.go
@@ -178,15 +178,9 @@ func buildClusterQueryInner(category MetricCategory, filterContainer bool) strin
 	}
 	switch category {
 	case CategoryCPU:
-		if cf != "" {
-			return fmt.Sprintf(`sum(rate(container_cpu_usage_seconds_total{%s}[5m]))`, cf)
-		}
-		return `sum(rate(container_cpu_usage_seconds_total[5m]))`
+		return fmt.Sprintf(`sum(rate(container_cpu_usage_seconds_total{%s}[5m]))`, cf)
 	case CategoryMemory:
-		if cf != "" {
-			return fmt.Sprintf(`sum(container_memory_working_set_bytes{%s})`, cf)
-		}
-		return `sum(container_memory_working_set_bytes)`
+		return fmt.Sprintf(`sum(container_memory_working_set_bytes{%s})`, cf)
 	case CategoryNetworkRX:
 		return `sum(rate(container_network_receive_bytes_total[5m]))`
 	case CategoryNetworkTX:


### PR DESCRIPTION
## Summary

Two fixes for Prometheus metrics reliability:

**1. Fallback queries for clusters without `container` label**
On cri-docker clusters, cAdvisor metrics lack the `container` label entirely. Our PromQL queries filter with `container!=''` to exclude aggregate rows, but in PromQL missing labels are treated as empty strings — dropping all data. Now when a CPU/memory query returns empty, the handler retries without the container filter. Standard clusters are unaffected (fallback only fires when the primary query returns nothing).

**2. Discovery failover across well-known services**
Previously `findWellKnownService` returned the first service that *existed* in the K8s API without checking reachability. If that service had no backing pods (e.g., Prometheus operator stuck in ContainerCreating), discovery failed without trying other candidates like VictoriaMetrics. Now all existing well-known services are probed in priority order until one responds.

Fixes #240