### PR TITLE
feat: Cluster Audit — best practices scanner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 ## Project Overview
 
-Radar is a modern Kubernetes visibility tool — local-first, no account required, no cloud dependency, fast. It provides topology visualization, event timeline, service traffic maps, resource browsing, and Helm management. Runs as a kubectl plugin (`kubectl-radar`) or standalone binary and opens a web UI in the browser. Open source, free forever. Built by Skyhook.
+Radar is a modern Kubernetes visibility tool — local-first, no account required, no cloud dependency, fast. It provides topology visualization, event timeline, service traffic maps, resource browsing, Helm management, and cluster audit (best-practices scanning). Runs as a kubectl plugin (`kubectl-radar`) or standalone binary and opens a web UI in the browser. Open source, free forever. Built by Skyhook.
 
 ## Reference Docs — MUST READ before making changes
 
@@ -57,6 +57,7 @@ radar/
 │   └── desktop/               # Desktop app entry point (Wails v2)
 ├── internal/
 │   ├── app/                   # Application lifecycle management
+│   ├── audit/                 # Radar-specific audit runner (cache → pkg/audit bridge)
 │   ├── config/                # Configuration management
 │   ├── errorlog/              # Error logging utilities
 │   ├── helm/                  # Helm client integration
@@ -129,6 +130,7 @@ radar/
 ├── pkg/
 │   ├── ai/
 │   │   └── context/           # AI context minification for LLM-friendly output
+│   ├── audit/                 # Shared cluster audit check engine (reusable by skyhook-connector)
 │   ├── gitops/                # GitOps operations abstraction
 │   ├── k8score/               # Shared K8s caching layer (informers, listers, transforms)
 │   ├── portforward/           # Port forwarding logic
@@ -143,6 +145,7 @@ radar/
 │   └── k8s-ui/                # Shared UI package (@skyhook-io/k8s-ui)
 │       └── src/
 │           ├── components/
+│           │   ├── audit/      # AuditCard, AuditAlerts, AuditFindingsTable (shared)
 │           │   ├── resources/  # ResourcesView, resource-utils, renderers
 │           │   ├── shared/     # ResourceRendererDispatch, ResourceActionsBar, EditableYamlView
 │           │   ├── gitops/     # ArgoCD/FluxCD panels
@@ -166,6 +169,7 @@ radar/
 │   │   │   ├── resource/      # Single resource detail page
 │   │   │   ├── resource-drawer/ # Resource drawer overlay
 │   │   │   ├── resources/     # Resource list panels (thin wrappers over @skyhook-io/k8s-ui)
+│   │   │   ├── audit/          # Cluster audit detail view
 │   │   │   ├── cost/           # Cost tracking and visualization
 │   │   │   ├── settings/      # Settings dialog
 │   │   │   ├── shared/        # Shared components (namespace picker, YAML editor)
@@ -273,6 +277,7 @@ make clean          # Remove build artifacts
 - Workloads: `/api/workloads/{kind}/{ns}/{name}/...` (logs, restart, scale, rollback)
 - GitOps: `/api/argo/applications/...`, `/api/flux/{kind}/...`
 - Nodes: `/api/nodes/{name}/...` (cordon, uncordon, drain, debug)
+- Audit: `/api/audit`, `/api/audit/resource/{kind}/{ns}/{name}`, `/api/settings/audit` (GET/PUT)
 
 ## Key Patterns
 
@@ -364,8 +369,9 @@ make clean          # Remove build artifacts
 
 ### MCP Server
 - Stateless HTTP handler mounted at `/mcp` (JSON-RPC over HTTP)
-- 16 tools organized into read and write categories:
+- 17 tools organized into read and write categories:
   - **Read tools** (8): `get_dashboard` (with problem-correlated changes), `list_resources`, `get_resource` (with optional `include`: events, relationships, metrics, logs), `get_topology` (with `format`: graph or summary), `get_events` (with optional `kind`/`name` resource filter), `get_pod_logs`, `list_namespaces`, `get_changes` (timeline of resource mutations)
+  - **Read tools — Audit** (1): `get_cluster_audit` (best-practice findings with remediation, filter by namespace/category/severity)
   - **Read tools — Helm** (2): `list_helm_releases`, `get_helm_release` (with optional values/history/diff)
   - **Read tools — Logs** (1): `get_workload_logs` (aggregated, AI-filtered logs across all pods)
   - **Write tools** (5): `apply_resource` (create or update from YAML, supports multi-doc and dry-run), `manage_workload` (restart/scale/rollback), `manage_cronjob` (trigger/suspend/resume), `manage_gitops` (ArgoCD sync/suspend/resume, FluxCD reconcile/suspend/resume), `manage_node` (cordon/uncordon/drain)

--- a/README.md
+++ b/README.md
@@ -265,6 +265,19 @@ Track Kubernetes spending with OpenCost integration — no additional configurat
 - Node costs with instance type and region pricing
 - Appears automatically when OpenCost metrics are detected in Prometheus
 
+### Cluster Audit
+
+Proactive best-practices scanner with 31 checks across security, reliability, and efficiency — inspired by Polaris, Kubescape, Trivy, and NSA/CISA guidelines. Runs instantly against cached data with zero cluster-side installation.
+
+- Security: privileged containers, privilege escalation, dangerous/insecure capabilities, host namespaces, container runtime socket mounts, sensitive host paths, secrets in ConfigMaps, auto-mounted service account tokens
+- Reliability: missing probes, image tag `latest`, single-replica deployments, missing PDB/topology spread, pod HA risk (all replicas on same node), orphan services/ingresses, deprecated API versions
+- Efficiency: missing CPU/memory requests and limits, orphan ConfigMaps/Secrets, resource utilization vs requests
+- Grouped-by-resource and by-namespace views with search, category/severity/framework filters
+- Each finding includes description and remediation guidance, with inline hide actions (per-check, per-category, per-namespace)
+- Configurable: ignored namespaces (with wildcard patterns), disabled checks, persisted across sessions
+- Framework labels: NSA/CISA, CIS benchmarks
+- MCP tool (`get_cluster_audit`) for AI-assisted cluster analysis
+
 ### AI Integration (MCP) <sup>beta</sup>
 
 Radar includes a built-in [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that lets AI assistants — Claude, Cursor, Copilot, and others — query your cluster through Radar.

--- a/cmd/desktop/mouse_darwin.go
+++ b/cmd/desktop/mouse_darwin.go
@@ -4,9 +4,10 @@ package main
 
 /*
 #cgo CFLAGS: -x objective-c
-#cgo LDFLAGS: -framework Cocoa
+#cgo LDFLAGS: -framework Cocoa -framework WebKit
 
 #import <Cocoa/Cocoa.h>
+#import <WebKit/WebKit.h>
 
 // Callback from Go
 extern void onMouseButton(int button);
@@ -24,6 +25,7 @@ static void startMouseMonitor() {
 			int btn = (int)[event buttonNumber];
 			if (btn == 3 || btn == 4) {
 				onMouseButton(btn);
+				return nil; // consume the event — don't pass to WebView
 			}
 			return event;
 		}];
@@ -35,29 +37,77 @@ static void stopMouseMonitor() {
 		mouseMonitor = nil;
 	}
 }
+
+// Navigate using WKWebView's native goBack/goForward on the main thread.
+// This avoids crashes from evaluateJavaScript racing with WebView internal state.
+static void navigateBack() {
+	dispatch_async(dispatch_get_main_queue(), ^{
+		NSWindow *window = [[NSApplication sharedApplication] mainWindow];
+		if (!window) return;
+		// Find the WKWebView in the window's view hierarchy
+		NSView *contentView = [window contentView];
+		for (NSView *subview in [contentView subviews]) {
+			if ([subview isKindOfClass:[WKWebView class]]) {
+				WKWebView *webView = (WKWebView *)subview;
+				if ([webView canGoBack]) {
+					[webView goBack];
+				}
+				return;
+			}
+			// Check one level deeper (Wails wraps in a container)
+			for (NSView *nested in [subview subviews]) {
+				if ([nested isKindOfClass:[WKWebView class]]) {
+					WKWebView *webView = (WKWebView *)nested;
+					if ([webView canGoBack]) {
+						[webView goBack];
+					}
+					return;
+				}
+			}
+		}
+	});
+}
+
+static void navigateForward() {
+	dispatch_async(dispatch_get_main_queue(), ^{
+		NSWindow *window = [[NSApplication sharedApplication] mainWindow];
+		if (!window) return;
+		NSView *contentView = [window contentView];
+		for (NSView *subview in [contentView subviews]) {
+			if ([subview isKindOfClass:[WKWebView class]]) {
+				WKWebView *webView = (WKWebView *)subview;
+				if ([webView canGoForward]) {
+					[webView goForward];
+				}
+				return;
+			}
+			for (NSView *nested in [subview subviews]) {
+				if ([nested isKindOfClass:[WKWebView class]]) {
+					WKWebView *webView = (WKWebView *)nested;
+					if ([webView canGoForward]) {
+						[webView goForward];
+					}
+					return;
+				}
+			}
+		}
+	});
+}
 */
 import "C"
 
-import (
-	"context"
+import "context"
 
-	"github.com/wailsapp/wails/v2/pkg/runtime"
-)
-
-// appCtx is set once in startNativeMouseMonitor (before the monitor starts)
-// and only read thereafter — no concurrent writes.
+// appCtx kept for potential future use but no longer needed for navigation.
 var appCtx context.Context
 
 //export onMouseButton
 func onMouseButton(button C.int) {
-	if appCtx == nil {
-		return
-	}
 	switch int(button) {
 	case 3: // back
-		runtime.WindowExecJS(appCtx, "window.history.back()")
+		C.navigateBack()
 	case 4: // forward
-		runtime.WindowExecJS(appCtx, "window.history.forward()")
+		C.navigateForward()
 	}
 }
 

--- a/internal/audit/runner.go
+++ b/internal/audit/runner.go
@@ -1,0 +1,107 @@
+package audit
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+	bp "github.com/skyhook-io/radar/pkg/audit"
+)
+
+// RunOptions provides optional data sources for checks that need them.
+type RunOptions struct {
+	ClusterVersion string   // e.g. "1.30"
+	ServedAPIs     []string // e.g. ["apps/v1", "batch/v1beta1"]
+}
+
+// RunFromCache fetches resources from Radar's cache and runs all best-practice
+// checks. namespaces filters to specific namespaces; empty = all.
+func RunFromCache(cache *k8s.ResourceCache, namespaces []string, opts *RunOptions) *bp.ScanResults {
+	if cache == nil {
+		return &bp.ScanResults{Summary: bp.ScanSummary{Categories: map[string]bp.CategorySummary{}}}
+	}
+
+	input := &bp.CheckInput{
+		Pods:                     listNamespaced(cache.Pods(), namespaces),
+		Deployments:              listNamespaced(cache.Deployments(), namespaces),
+		StatefulSets:             listNamespaced(cache.StatefulSets(), namespaces),
+		DaemonSets:               listNamespaced(cache.DaemonSets(), namespaces),
+		Services:                 listNamespaced(cache.Services(), namespaces),
+		Ingresses:                listNamespaced(cache.Ingresses(), namespaces),
+		HorizontalPodAutoscalers: listNamespaced(cache.HorizontalPodAutoscalers(), namespaces),
+		PodDisruptionBudgets:     listNamespaced(cache.PodDisruptionBudgets(), namespaces),
+		ConfigMaps:               listNamespaced(cache.ConfigMaps(), namespaces),
+		Secrets:                  listNamespaced(cache.Secrets(), namespaces),
+	}
+
+	if opts != nil {
+		input.ClusterVersion = opts.ClusterVersion
+		input.ServedAPIs = opts.ServedAPIs
+	}
+
+	return bp.RunChecks(input)
+}
+
+// lister is a generic interface that all typed K8s listers satisfy.
+type lister[T any] interface {
+	List(selector labels.Selector) ([]*T, error)
+}
+
+// listNamespaced fetches all objects from a lister, optionally filtered by namespaces.
+func listNamespaced[T any, L lister[T]](l L, namespaces []string) []*T {
+	var zero L
+	if any(l) == any(zero) {
+		return nil
+	}
+	if len(namespaces) == 0 {
+		items, _ := l.List(labels.Everything())
+		return items
+	}
+	// For namespace-filtered queries we rely on the global list + filter approach
+	// since typed listers use different namespace lister types that don't share
+	// a common interface. This is simple and fast for cached data.
+	all, _ := l.List(labels.Everything())
+	nsSet := make(map[string]bool, len(namespaces))
+	for _, ns := range namespaces {
+		nsSet[ns] = true
+	}
+	var filtered []*T
+	for _, item := range all {
+		if ns := extractNamespace(item); ns == "" || nsSet[ns] {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
+}
+
+// extractNamespace uses type assertions for known types to get namespace.
+func extractNamespace(obj any) string {
+	switch v := obj.(type) {
+	case *corev1.Pod:
+		return v.Namespace
+	case *appsv1.Deployment:
+		return v.Namespace
+	case *appsv1.StatefulSet:
+		return v.Namespace
+	case *appsv1.DaemonSet:
+		return v.Namespace
+	case *corev1.Service:
+		return v.Namespace
+	case *networkingv1.Ingress:
+		return v.Namespace
+	case *autoscalingv2.HorizontalPodAutoscaler:
+		return v.Namespace
+	case *policyv1.PodDisruptionBudget:
+		return v.Namespace
+	case *corev1.ConfigMap:
+		return v.Namespace
+	case *corev1.Secret:
+		return v.Namespace
+	}
+	return ""
+}
+

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -106,6 +106,20 @@ func registerTools(server *mcp.Server) {
 		Annotations: readOnly,
 	}, logToolCall("get_changes", handleGetChanges))
 
+	// --- Audit tool (read-only) ---
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "get_cluster_audit",
+		Description: "Run best-practice checks against cluster resources and return findings " +
+			"with remediation guidance. Checks cover security (running as root, privileged " +
+			"containers, dangerous capabilities), reliability (missing probes, single replicas, " +
+			"no PDB), and efficiency (missing resource requests/limits). " +
+			"Each finding includes what's wrong and how to fix it. " +
+			"Respects user's audit settings (ignored namespaces, disabled checks). " +
+			"Filter by namespace, category, or severity.",
+		Annotations: readOnly,
+	}, logToolCall("get_cluster_audit", handleGetAudit))
+
 	// --- Helm tools (read-only) ---
 
 	mcp.AddTool(server, &mcp.Tool{

--- a/internal/mcp/tools_audit.go
+++ b/internal/mcp/tools_audit.go
@@ -1,0 +1,132 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/skyhook-io/radar/internal/audit"
+	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/internal/settings"
+	bp "github.com/skyhook-io/radar/pkg/audit"
+)
+
+type auditInput struct {
+	Namespace string `json:"namespace,omitempty" jsonschema:"filter to a specific namespace"`
+	Category  string `json:"category,omitempty" jsonschema:"filter by category: Security, Reliability, or Efficiency"`
+	Severity  string `json:"severity,omitempty" jsonschema:"filter by severity: danger or warning"`
+	Limit     int    `json:"limit,omitempty" jsonschema:"max findings to return (default 30, max 100)"`
+}
+
+type auditToolResult struct {
+	Summary    auditSummary      `json:"summary"`
+	Findings   []auditFinding    `json:"findings"`
+	TotalCount int               `json:"totalCount"`
+	Truncated  bool              `json:"truncated,omitempty"`
+}
+
+type auditSummary struct {
+	Critical   int            `json:"critical"`
+	Warning    int            `json:"warning"`
+	Resources  int            `json:"resources"`
+	Categories map[string]int `json:"categories"`
+}
+
+type auditFinding struct {
+	Resource    string `json:"resource"`    // "Deployment/default/web"
+	Check       string `json:"check"`       // "runAsRoot"
+	Severity    string `json:"severity"`    // "danger" or "warning"
+	Category    string `json:"category"`    // "Security"
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+func handleGetAudit(ctx context.Context, req *mcp.CallToolRequest, input auditInput) (*mcp.CallToolResult, any, error) {
+	cache := k8s.GetResourceCache()
+	if cache == nil {
+		return nil, nil, fmt.Errorf("not connected to cluster")
+	}
+
+	var namespaces []string
+	if input.Namespace != "" {
+		namespaces = []string{input.Namespace}
+	}
+
+	results := audit.RunFromCache(cache, namespaces, nil)
+	if results == nil {
+		return toJSONResult(auditToolResult{})
+	}
+
+	// Apply user settings (namespace ignore + disabled checks)
+	cfg := loadAuditConfig()
+	results = bp.ApplySettings(results, cfg.IgnoredNamespaces, cfg.DisabledChecks)
+
+	// Build the check registry lookup for remediation
+	registry := bp.CheckRegistry
+
+	// Filter and transform findings
+	limit := input.Limit
+	if limit <= 0 {
+		limit = 30
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	// Category counts
+	catCounts := map[string]int{}
+	for _, f := range results.Findings {
+		catCounts[f.Category]++
+	}
+
+	var filtered []auditFinding
+	for _, f := range results.Findings {
+		if input.Category != "" && f.Category != input.Category {
+			continue
+		}
+		if input.Severity != "" && f.Severity != input.Severity {
+			continue
+		}
+		remediation := ""
+		if meta, ok := registry[f.CheckID]; ok {
+			remediation = meta.Remediation
+		}
+		filtered = append(filtered, auditFinding{
+			Resource:    fmt.Sprintf("%s/%s/%s", f.Kind, f.Namespace, f.Name),
+			Check:       f.CheckID,
+			Severity:    f.Severity,
+			Category:    f.Category,
+			Message:     f.Message,
+			Remediation: remediation,
+		})
+	}
+
+	totalCount := len(filtered)
+	truncated := false
+	if len(filtered) > limit {
+		filtered = filtered[:limit]
+		truncated = true
+	}
+
+	return toJSONResult(auditToolResult{
+		Summary: auditSummary{
+			Critical:   results.Summary.Danger,
+			Warning:    results.Summary.Warning,
+			Resources:  len(results.Groups),
+			Categories: catCounts,
+		},
+		Findings:   filtered,
+		TotalCount: totalCount,
+		Truncated:  truncated,
+	})
+}
+
+func loadAuditConfig() settings.AuditConfig {
+	s := settings.Load()
+	if s.Audit != nil {
+		return *s.Audit
+	}
+	return settings.DefaultAuditConfig()
+}
+

--- a/internal/server/audit_handlers.go
+++ b/internal/server/audit_handlers.go
@@ -1,0 +1,174 @@
+package server
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/skyhook-io/radar/internal/audit"
+	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/internal/settings"
+	bp "github.com/skyhook-io/radar/pkg/audit"
+)
+
+// apiResourceKindMap maps lowercase plural API resource names to Go Kind names
+// for the resource types that the audit scanner checks.
+var apiResourceKindMap = map[string]string{
+	"pods":         "Pod",
+	"deployments":  "Deployment",
+	"statefulsets": "StatefulSet",
+	"daemonsets":   "DaemonSet",
+	"services":     "Service",
+	"ingresses":    "Ingress",
+	"configmaps":   "ConfigMap",
+	"secrets":      "Secret",
+}
+
+func apiResourceToKind(resource string) string {
+	if kind, ok := apiResourceKindMap[resource]; ok {
+		return kind
+	}
+	return resource
+}
+
+// auditCache caches scan results for a short TTL so that
+// dashboard polls and per-resource lookups share the same scan.
+var auditCache struct {
+	mu        sync.RWMutex
+	results   *bp.ScanResults
+	nsKey     string // comma-joined namespace filter used for this result
+	expiresAt time.Time
+}
+
+const auditCacheTTL = 5 * time.Second
+
+// getCachedResults returns cached scan results if fresh, or runs a new scan.
+func getCachedResults(cache *k8s.ResourceCache, namespaces []string) *bp.ScanResults {
+	nsKey := strings.Join(namespaces, ",")
+
+	auditCache.mu.RLock()
+	if auditCache.results != nil && auditCache.nsKey == nsKey && time.Now().Before(auditCache.expiresAt) {
+		r := auditCache.results
+		auditCache.mu.RUnlock()
+		return r
+	}
+	auditCache.mu.RUnlock()
+
+	results := audit.RunFromCache(cache, namespaces, nil)
+
+	auditCache.mu.Lock()
+	auditCache.results = results
+	auditCache.nsKey = nsKey
+	auditCache.expiresAt = time.Now().Add(auditCacheTTL)
+	auditCache.mu.Unlock()
+
+	return results
+}
+
+// applyAuditSettings filters results based on user settings.
+func applyAuditSettings(results *bp.ScanResults, cfg settings.AuditConfig) *bp.ScanResults {
+	return bp.ApplySettings(results, cfg.IgnoredNamespaces, cfg.DisabledChecks)
+}
+
+// getAuditConfig returns the current audit config with defaults applied.
+func getAuditConfig() settings.AuditConfig {
+	s := settings.Load()
+	if s.Audit != nil {
+		return *s.Audit
+	}
+	return settings.DefaultAuditConfig()
+}
+
+// handleAudit returns full audit scan results.
+// GET /api/audit?namespace=X&namespaces=X,Y
+func (s *Server) handleAudit(w http.ResponseWriter, r *http.Request) {
+	if !s.requireConnected(w) {
+		return
+	}
+	cache := k8s.GetResourceCache()
+	if cache == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "Cache not initialized")
+		return
+	}
+	namespaces := s.parseNamespacesForUser(r)
+	if noNamespaceAccess(namespaces) {
+		s.writeJSON(w, &bp.ScanResults{Summary: bp.ScanSummary{Categories: map[string]bp.CategorySummary{}}})
+		return
+	}
+	results := getCachedResults(cache, namespaces)
+	results = applyAuditSettings(results, getAuditConfig())
+	s.writeJSON(w, results)
+}
+
+// handleAuditResource returns findings for a specific resource.
+// GET /api/audit/resource/{kind}/{namespace}/{name}
+func (s *Server) handleAuditResource(w http.ResponseWriter, r *http.Request) {
+	if !s.requireConnected(w) {
+		return
+	}
+	cache := k8s.GetResourceCache()
+	if cache == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "Cache not initialized")
+		return
+	}
+
+	kind := chi.URLParam(r, "kind")
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	namespaces := s.parseNamespacesForUser(r)
+	if noNamespaceAccess(namespaces) {
+		s.writeJSON(w, []bp.Finding{})
+		return
+	}
+	results := getCachedResults(cache, namespaces)
+	results = applyAuditSettings(results, getAuditConfig())
+	index := bp.IndexByResource(results.Findings)
+
+	// Try exact kind first, then map API resource name (e.g. "deployments") to Go kind (e.g. "Deployment")
+	findings := index[bp.ResourceKey(kind, namespace, name)]
+	if findings == nil {
+		goKind := apiResourceToKind(kind)
+		if goKind != kind {
+			findings = index[bp.ResourceKey(goKind, namespace, name)]
+		}
+	}
+	if findings == nil {
+		findings = []bp.Finding{}
+	}
+	s.writeJSON(w, findings)
+}
+
+// handleGetAuditSettings returns the current audit configuration.
+// GET /api/settings/audit
+func (s *Server) handleGetAuditSettings(w http.ResponseWriter, r *http.Request) {
+	s.writeJSON(w, getAuditConfig())
+}
+
+// handlePutAuditSettings updates the audit configuration.
+// PUT /api/settings/audit
+func (s *Server) handlePutAuditSettings(w http.ResponseWriter, r *http.Request) {
+	var cfg settings.AuditConfig
+	if err := json.NewDecoder(r.Body).Decode(&cfg); err != nil {
+		s.writeError(w, http.StatusBadRequest, "Invalid JSON: "+err.Error())
+		return
+	}
+	updated, err := settings.Update(func(s *settings.Settings) {
+		s.Audit = &cfg
+	})
+	if err != nil {
+		log.Printf("[audit] Failed to save audit settings: %v", err)
+		s.writeError(w, http.StatusInternalServerError, "Failed to save settings: "+err.Error())
+		return
+	}
+	if updated.Audit != nil {
+		s.writeJSON(w, *updated.Audit)
+	} else {
+		s.writeJSON(w, settings.DefaultAuditConfig())
+	}
+}

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -38,6 +38,7 @@ type DashboardResponse struct {
 	CertificateHealth      *DashboardCertificateHealth     `json:"certificateHealth,omitempty"`
 	NetworkPolicyCoverage  *DashboardNetworkPolicyCoverage `json:"networkPolicyCoverage,omitempty"`
 	NodeVersionSkew        *k8s.VersionSkew            `json:"nodeVersionSkew,omitempty"`
+	Audit          *DashboardAudit      `json:"audit,omitempty"`
 	DeferredLoading        bool                        `json:"deferredLoading,omitempty"`  // True while deferred informers (secrets, events, etc.) are still syncing
 	PartialData            []string                    `json:"partialData,omitempty"`      // Resource kinds that timed out during critical sync (e.g. ["Pod", "Deployment"])
 	AccessRestricted       bool                        `json:"accessRestricted,omitempty"` // True when user has no namespace access (RBAC)
@@ -290,6 +291,7 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 
 	resp.CertificateHealth = s.getDashboardCertificateHealth(namespace)
 	resp.NetworkPolicyCoverage = s.getDashboardNetworkPolicyCoverage(cache, namespaces)
+	resp.Audit = getDashboardAudit(cache, namespaces)
 
 	if nodeLister := cache.Nodes(); nodeLister != nil {
 		nodes, _ := nodeLister.List(labels.Everything())
@@ -1271,7 +1273,6 @@ func (s *Server) getDashboardNetworkPolicyCoverage(cache *k8s.ResourceCache, nam
 		return nil
 	}
 
-	// Collect all NetworkPolicy selectors
 	var allNPs []npSelector
 	if len(namespaces) == 0 {
 		nps, err := npLister.List(labels.Everything())
@@ -1303,7 +1304,6 @@ func (s *Server) getDashboardNetworkPolicyCoverage(cache *k8s.ResourceCache, nam
 		}
 	}
 
-	// Also count CiliumNetworkPolicy selectors (from dynamic cache)
 	if dynamicCache := k8s.GetDynamicResourceCache(); dynamicCache != nil {
 		if discovery := k8s.GetResourceDiscovery(); discovery != nil {
 			if cnpGVR, ok := discovery.GetGVR("CiliumNetworkPolicy"); ok {
@@ -1320,7 +1320,6 @@ func (s *Server) getDashboardNetworkPolicyCoverage(cache *k8s.ResourceCache, nam
 						}
 						selectorMap, _, _ := unstructured.NestedMap(cnp.Object, "spec", "endpointSelector", "matchLabels")
 						if len(selectorMap) == 0 {
-							// Empty selector matches all pods in namespace
 							allNPs = append(allNPs, npSelector{ns, labels.Everything()})
 						} else {
 							selectorLabels := make(map[string]string)
@@ -1339,7 +1338,6 @@ func (s *Server) getDashboardNetworkPolicyCoverage(cache *k8s.ResourceCache, nam
 		}
 	}
 
-	// Count workloads and which are covered by at least one policy
 	covered := make(map[string]bool)
 	totalWorkloads := 0
 
@@ -1409,6 +1407,42 @@ func (s *Server) getDashboardNetworkPolicyCoverage(cache *k8s.ResourceCache, nam
 		TotalPolicies:    len(allNPs),
 		CoveredWorkloads: len(covered),
 		TotalWorkloads:   totalWorkloads,
+	}
+}
+
+// DashboardAudit is the audit summary in the dashboard response.
+type DashboardAudit struct {
+	Passing    int                                `json:"passing"`
+	Warning    int                                `json:"warning"`
+	Danger     int                                `json:"danger"`
+	Categories map[string]DashboardCategorySummary `json:"categories"`
+}
+
+// DashboardCategorySummary provides per-category counts for the dashboard.
+type DashboardCategorySummary struct {
+	Passing int `json:"passing"`
+	Warning int `json:"warning"`
+	Danger  int `json:"danger"`
+}
+
+func getDashboardAudit(cache *k8s.ResourceCache, namespaces []string) *DashboardAudit {
+	results := applyAuditSettings(getCachedResults(cache, namespaces), getAuditConfig())
+	if results == nil {
+		return nil
+	}
+	cats := make(map[string]DashboardCategorySummary, len(results.Summary.Categories))
+	for k, v := range results.Summary.Categories {
+		cats[k] = DashboardCategorySummary{
+			Passing: v.Passing,
+			Warning: v.Warning,
+			Danger:  v.Danger,
+		}
+	}
+	return &DashboardAudit{
+		Passing:    results.Summary.Passing,
+		Warning:    results.Summary.Warning,
+		Danger:     results.Summary.Danger,
+		Categories: cats,
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -215,6 +215,12 @@ func (s *Server) setupRoutes() {
 			r.Get("/resources/{kind}/{namespace}/{name}/cascade-preview", s.handleCascadeDeletePreview)
 			r.Delete("/resources/{kind}/{namespace}/{name}", s.handleDeleteResource)
 			r.Get("/secrets/certificate-expiry", s.handleSecretCertExpiry)
+
+			// Cluster audit
+			r.Get("/audit", s.handleAudit)
+			r.Get("/audit/resource/{kind}/{namespace}/{name}", s.handleAuditResource)
+			r.Get("/settings/audit", s.handleGetAuditSettings)
+			r.Put("/settings/audit", s.handlePutAuditSettings)
 			r.Get("/events", s.handleEvents)
 			r.Get("/changes", s.handleChanges)
 			r.Get("/changes/{kind}/{namespace}/{name}/children", s.handleChangeChildren)

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -15,10 +15,24 @@ type PinnedKind struct {
 	Group string `json:"group"`
 }
 
+// AuditConfig holds cluster audit preferences.
+type AuditConfig struct {
+	IgnoredNamespaces []string `json:"ignoredNamespaces"`
+	DisabledChecks    []string `json:"disabledChecks"`
+}
+
+// DefaultAuditConfig returns the default audit settings.
+func DefaultAuditConfig() AuditConfig {
+	return AuditConfig{
+		IgnoredNamespaces: []string{"kube-system", "kube-node-lease", "kube-public", "*-system"},
+	}
+}
+
 // Settings holds user preferences persisted across restarts.
 type Settings struct {
 	Theme       string       `json:"theme,omitempty"`
 	PinnedKinds []PinnedKind `json:"pinnedKinds,omitempty"`
+	Audit       *AuditConfig `json:"audit,omitempty"`
 }
 
 // mu serializes Load-mutate-Save cycles to prevent concurrent PUTs from

--- a/packages/k8s-ui/src/components/audit/AuditAlerts.tsx
+++ b/packages/k8s-ui/src/components/audit/AuditAlerts.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react'
+import { ClipboardCheck, ChevronRight, ShieldAlert, AlertTriangle, ArrowRight } from 'lucide-react'
+import { clsx } from 'clsx'
+import { SEVERITY_TEXT, BP_CATEGORY_BADGE, DEFAULT_BADGE_COLOR } from '../../utils/badge-colors'
+
+export interface AuditFinding {
+  kind: string
+  namespace: string
+  name: string
+  checkID: string
+  category: string
+  severity: string
+  message: string
+}
+
+interface AuditAlertsProps {
+  findings: AuditFinding[]
+  onViewAll?: () => void
+}
+
+/**
+ * Subtle collapsible section showing audit findings for a resource.
+ * Renders as a collapsed summary by default — not intrusive.
+ */
+export function AuditAlerts({ findings, onViewAll }: AuditAlertsProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  if (findings.length === 0) return null
+
+  const dangers = findings.filter(f => f.severity === 'danger').length
+  const warnings = findings.filter(f => f.severity === 'warning').length
+
+  return (
+    <div className="border-b-subtle pb-4 last:border-0">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex items-center gap-2 w-full text-left mb-2 hover:text-theme-text-primary transition-colors"
+      >
+        <ChevronRight className={clsx('w-4 h-4 text-theme-text-tertiary transition-transform duration-200', expanded && 'rotate-90')} />
+        <ClipboardCheck className="w-4 h-4 text-theme-text-secondary" />
+        <span className="text-sm font-medium text-theme-text-secondary">Audit Findings</span>
+        <div className="flex items-center gap-2 ml-1">
+          {dangers > 0 && (
+            <span className={clsx('text-xs font-medium tabular-nums', SEVERITY_TEXT.error)}>{dangers} critical</span>
+          )}
+          {warnings > 0 && (
+            <span className={clsx('text-xs font-medium tabular-nums', SEVERITY_TEXT.warning)}>{warnings} warning</span>
+          )}
+        </div>
+      </button>
+
+      <div
+        className="grid transition-[grid-template-rows] duration-200 ease-out"
+        style={{ gridTemplateRows: expanded ? '1fr' : '0fr' }}
+      >
+        <div className="overflow-hidden">
+          <div className="pl-6 pt-1 flex flex-col gap-0.5">
+            {findings.map((f, i) => {
+              const isDanger = f.severity === 'danger'
+              return (
+                <div key={`${f.checkID}-${i}`} className="flex items-start gap-2 py-1">
+                  {isDanger ? (
+                    <ShieldAlert className={clsx('w-3.5 h-3.5 shrink-0 mt-0.5', SEVERITY_TEXT.error)} />
+                  ) : (
+                    <AlertTriangle className={clsx('w-3.5 h-3.5 shrink-0 mt-0.5', SEVERITY_TEXT.warning)} />
+                  )}
+                  <span className="text-xs text-theme-text-secondary flex-1">{f.message}</span>
+                  <span className={clsx('badge-sm text-[10px] shrink-0', BP_CATEGORY_BADGE[f.category] || DEFAULT_BADGE_COLOR)}>
+                    {f.category}
+                  </span>
+                </div>
+              )
+            })}
+            {onViewAll && (
+              <button
+                onClick={(e) => { e.stopPropagation(); onViewAll() }}
+                className="flex items-center gap-1 text-xs text-skyhook-500 hover:text-skyhook-400 mt-1 py-1 transition-colors"
+              >
+                View all findings
+                <ArrowRight className="w-3 h-3" />
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/k8s-ui/src/components/audit/AuditCard.tsx
+++ b/packages/k8s-ui/src/components/audit/AuditCard.tsx
@@ -1,0 +1,130 @@
+import { ClipboardCheck, ArrowRight, Check } from 'lucide-react'
+import { clsx } from 'clsx'
+import { SEVERITY_TEXT, SEVERITY_DOT } from '../../utils/badge-colors'
+
+export interface AuditCardData {
+  passing: number
+  warning: number
+  danger: number
+  categories: Record<string, { passing: number; warning: number; danger: number }>
+}
+
+interface AuditCardProps {
+  data: AuditCardData
+  onNavigate: () => void
+}
+
+type SeverityLevel = 'success' | 'warning' | 'error'
+
+function getSeverityLevel(data: AuditCardData): SeverityLevel {
+  if (data.warning + data.danger === 0) return 'success'
+  const dangerRatio = data.danger / (data.warning + data.danger)
+  if (dangerRatio > 0.2) return 'error'
+  return 'warning'
+}
+
+// Card-specific accent backgrounds (light opacity variants, work in both themes)
+const ACCENT_BG: Record<SeverityLevel, string> = {
+  success: 'bg-green-500/10',
+  warning: 'bg-yellow-500/10',
+  error: 'bg-red-500/10',
+}
+
+export function AuditCard({ data, onNavigate }: AuditCardProps) {
+  const total = data.passing + data.warning + data.danger
+  const issueCount = data.warning + data.danger
+  const allPassing = issueCount === 0
+  const level = getSeverityLevel(data)
+  const accentColor = SEVERITY_TEXT[level]
+  const accentBg = ACCENT_BG[level]
+
+  return (
+    <button
+      onClick={onNavigate}
+      className="group h-[260px] rounded-xl bg-theme-surface shadow-theme-sm hover:-translate-y-1 hover:shadow-theme-md transition-all duration-200 text-left animate-fade-in-up"
+    >
+      <div className="flex flex-col h-full w-full">
+        <div className="flex items-center justify-between px-5 py-3 border-b border-theme-border/50">
+          <div className="flex items-center gap-2">
+            <ClipboardCheck className={clsx('w-4 h-4', accentColor)} />
+            <span className={clsx('text-xs font-semibold uppercase tracking-wider', accentColor)}>Cluster Audit</span>
+            {issueCount > 0 ? (
+              <span className={clsx('badge-sm', accentBg, accentColor)}>
+                {issueCount}
+              </span>
+            ) : (
+              <span className={clsx('badge-sm', accentBg, accentColor)}>
+                <Check className="w-3 h-3" />
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className="flex-1 min-h-0 flex flex-col items-center justify-center px-4 py-4">
+          {allPassing ? (
+            <div className="flex flex-col items-center gap-2">
+              <Check className={clsx('w-8 h-8', SEVERITY_TEXT.success)} />
+              <span className={clsx('text-sm font-medium', SEVERITY_TEXT.success)}>All checks passing</span>
+              {total > 0 && (
+                <span className="text-xs text-theme-text-tertiary">{total} checks across {Object.keys(data.categories).length} categories</span>
+              )}
+            </div>
+          ) : (
+            <>
+              {/* Distribution bar — only show when we have passing data for context */}
+              {data.passing > 0 && total > 0 && (
+                <div className="flex items-center gap-3 w-full">
+                  <div className="flex-1 h-3 rounded-full overflow-hidden bg-theme-hover flex">
+                    <div className={clsx('h-full', SEVERITY_DOT.success)} style={{ width: `${(data.passing / total) * 100}%` }} />
+                    {data.warning > 0 && (
+                      <div className={clsx('h-full', SEVERITY_DOT.warning)} style={{ width: `${(data.warning / total) * 100}%` }} />
+                    )}
+                    {data.danger > 0 && (
+                      <div className={clsx('h-full', SEVERITY_DOT.error)} style={{ width: `${(data.danger / total) * 100}%` }} />
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {/* Category breakdown */}
+              <div className="grid grid-cols-1 gap-y-2 mt-4 w-full">
+                {Object.entries(data.categories).map(([category, counts]) => {
+                  const catIssues = counts.warning + counts.danger
+                  const dotColor = counts.danger > 0 ? SEVERITY_DOT.error : counts.warning > 0 ? SEVERITY_DOT.warning : SEVERITY_DOT.success
+                  return (
+                    <div key={category} className="flex items-center gap-2">
+                      <span className={clsx('w-2 h-2 rounded-full shrink-0', dotColor)} />
+                      <span className="text-xs text-theme-text-secondary flex-1">{category}</span>
+                      {catIssues > 0 ? (
+                        <div className="flex items-center gap-2">
+                          {counts.danger > 0 && (
+                            <span className={clsx('text-xs font-semibold tabular-nums', SEVERITY_TEXT.error)}>{counts.danger} critical</span>
+                          )}
+                          {counts.warning > 0 && (
+                            <span className={clsx('text-xs font-semibold tabular-nums', SEVERITY_TEXT.warning)}>{counts.warning} warning</span>
+                          )}
+                        </div>
+                      ) : (
+                        <span className={clsx('text-xs font-semibold', SEVERITY_TEXT.success)}>All passing</span>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            </>
+          )}
+        </div>
+
+        <div className="px-4 py-1.5 border-t border-theme-border/50 flex items-center justify-end">
+          <span className={clsx(
+            'flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider transition-colors',
+            accentColor,
+          )}>
+            View Details
+            <ArrowRight className="w-3.5 h-3.5 transition-transform group-hover:translate-x-0.5" />
+          </span>
+        </div>
+      </div>
+    </button>
+  )
+}

--- a/packages/k8s-ui/src/components/audit/AuditFindingsTable.tsx
+++ b/packages/k8s-ui/src/components/audit/AuditFindingsTable.tsx
@@ -1,0 +1,526 @@
+import { useState, useMemo, useRef, useEffect } from 'react'
+import { ShieldAlert, AlertTriangle, ChevronRight, Search, ExternalLink, MoreHorizontal, EyeOff, Layers } from 'lucide-react'
+import { clsx } from 'clsx'
+import type { AuditFinding } from './AuditAlerts'
+import { SEVERITY_TEXT, BP_CATEGORY_BADGE, DEFAULT_BADGE_COLOR } from '../../utils/badge-colors'
+
+const CATEGORIES = ['Security', 'Reliability', 'Efficiency'] as const
+const SEVERITIES = ['danger', 'warning'] as const
+
+export interface ResourceGroup {
+  kind: string
+  namespace: string
+  name: string
+  warning: number
+  danger: number
+  findings: AuditFinding[]
+}
+
+export interface CheckMeta {
+  id: string
+  title: string
+  description: string
+  remediation: string
+  frameworks?: string[]
+}
+
+export interface AuditFindingsTableProps {
+  groups?: ResourceGroup[]
+  findings?: AuditFinding[]
+  checks?: Record<string, CheckMeta>
+  onResourceClick?: (kind: string, namespace: string, name: string) => void
+  onHideCheck?: (checkID: string, title: string) => void
+  onHideCategory?: (category: string) => void
+  onHideNamespace?: (namespace: string) => void
+}
+
+export function AuditFindingsTable({ groups, findings, checks, onResourceClick, onHideCheck, onHideCategory, onHideNamespace }: AuditFindingsTableProps) {
+  const [categoryFilter, setCategoryFilter] = useState<string | null>(null)
+  const [severityFilter, setSeverityFilter] = useState<string | null>(null)
+  const [frameworkFilter, setFrameworkFilter] = useState<string | null>(null)
+  const [searchTerm, setSearchTerm] = useState('')
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const [expandedNS, setExpandedNS] = useState<Set<string>>(new Set())
+  const [groupByNS, setGroupByNS] = useState(false)
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  // "/" keyboard shortcut to focus search
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === '/' && !e.ctrlKey && !e.metaKey && document.activeElement?.tagName !== 'INPUT') {
+        e.preventDefault()
+        searchInputRef.current?.focus()
+      }
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [])
+
+  // Compute totals from whichever data source we have
+  const allFindings = useMemo(() => {
+    if (groups) return groups.flatMap(g => g.findings)
+    return findings ?? []
+  }, [groups, findings])
+
+  const totalDangerCount = allFindings.filter(f => f.severity === 'danger').length
+  const totalWarningCount = allFindings.filter(f => f.severity === 'warning').length
+
+  // Derive available frameworks from checks metadata
+  const frameworks = useMemo(() => {
+    if (!checks) return []
+    const set = new Set<string>()
+    Object.values(checks).forEach(c => c.frameworks?.forEach(f => set.add(f)))
+    return Array.from(set).sort()
+  }, [checks])
+
+  const searchLower = searchTerm.toLowerCase()
+
+  // Match a finding against category/severity/framework filters
+  const matchesFinding = (f: AuditFinding) => {
+    if (categoryFilter && f.category !== categoryFilter) return false
+    if (severityFilter && f.severity !== severityFilter) return false
+    if (frameworkFilter && checks) {
+      const meta = checks[f.checkID]
+      if (!meta?.frameworks?.includes(frameworkFilter)) return false
+    }
+    return true
+  }
+
+  // Match a resource group against search term
+  const matchesSearch = (g: ResourceGroup) => {
+    if (!searchLower) return true
+    if (g.name.toLowerCase().includes(searchLower)) return true
+    if (g.namespace.toLowerCase().includes(searchLower)) return true
+    if (g.kind.toLowerCase().includes(searchLower)) return true
+    return g.findings.some(f => f.message.toLowerCase().includes(searchLower))
+  }
+
+  // Filter groups: a group is visible if it matches search AND has findings matching filters
+  const filteredGroups = useMemo(() => {
+    if (!groups) return undefined
+    return groups
+      .filter(g => matchesSearch(g))
+      .map(g => {
+        const filtered = g.findings.filter(matchesFinding)
+        if (filtered.length === 0) return null
+        return { ...g, findings: filtered, danger: filtered.filter(f => f.severity === 'danger').length, warning: filtered.filter(f => f.severity === 'warning').length }
+      })
+      .filter((g): g is ResourceGroup => g !== null)
+  }, [groups, categoryFilter, severityFilter, frameworkFilter, searchLower]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Filter flat findings (fallback mode)
+  const filteredFindings = useMemo(() => {
+    if (groups) return undefined
+    return (findings ?? []).filter(f => {
+      if (!matchesFinding(f)) return false
+      if (searchLower && !f.message.toLowerCase().includes(searchLower) && !f.name.toLowerCase().includes(searchLower)) return false
+      return true
+    })
+  }, [groups, findings, categoryFilter, severityFilter, frameworkFilter, checks, searchLower]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const toggle = (key: string) => {
+    setExpanded(prev => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
+
+  // Compute counts from filtered results (so summary reflects active filters)
+  const hasActiveFilters = !!(categoryFilter || severityFilter || frameworkFilter || searchTerm)
+  const filteredAllFindings = filteredGroups
+    ? filteredGroups.flatMap(g => g.findings)
+    : filteredFindings ?? []
+  const dangerCount = hasActiveFilters ? filteredAllFindings.filter(f => f.severity === 'danger').length : totalDangerCount
+  const warningCount = hasActiveFilters ? filteredAllFindings.filter(f => f.severity === 'warning').length : totalWarningCount
+
+  // Group resources by namespace when enabled
+  const namespacedGroups = useMemo(() => {
+    if (!groupByNS || !filteredGroups) return undefined
+    const nsMap = new Map<string, ResourceGroup[]>()
+    for (const g of filteredGroups) {
+      const ns = g.namespace || '(cluster-scoped)'
+      const list = nsMap.get(ns) || []
+      list.push(g)
+      nsMap.set(ns, list)
+    }
+    // Sort namespaces: most severe first
+    return Array.from(nsMap.entries()).sort((a, b) => {
+      const aDanger = a[1].reduce((n, g) => n + g.danger, 0)
+      const bDanger = b[1].reduce((n, g) => n + g.danger, 0)
+      if (aDanger !== bDanger) return bDanger - aDanger
+      return a[0].localeCompare(b[0])
+    })
+  }, [groupByNS, filteredGroups])
+
+  const toggleNS = (ns: string) => {
+    const isOpening = !expandedNS.has(ns)
+    setExpandedNS(prev => {
+      const next = new Set(prev)
+      if (next.has(ns)) next.delete(ns)
+      else next.add(ns)
+      return next
+    })
+    // When opening a namespace, auto-expand all its resource groups
+    if (isOpening && namespacedGroups) {
+      const nsEntry = namespacedGroups.find(([n]) => n === ns)
+      if (nsEntry) {
+        setExpanded(prev => {
+          const next = new Set(prev)
+          for (const g of nsEntry[1]) {
+            next.add(`${g.kind}/${g.namespace}/${g.name}`)
+          }
+          return next
+        })
+      }
+    }
+  }
+
+  // Auto-enable grouping for large result sets; auto-expand all in flat view
+  const resourceCount = filteredGroups?.length ?? 0
+  useEffect(() => {
+    if (resourceCount > 20) {
+      setGroupByNS(true)
+    } else if (filteredGroups) {
+      // Small result set — start with all resource groups expanded
+      setExpanded(new Set(filteredGroups.map(g => `${g.kind}/${g.namespace}/${g.name}`)))
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const isEmpty = filteredGroups ? filteredGroups.length === 0 : (filteredFindings?.length ?? 0) === 0
+  const totalEmpty = allFindings.length === 0
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Toolbar */}
+      <div className="flex flex-col gap-2 px-4 py-3 border-b border-theme-border bg-theme-base rounded-xl shrink-0">
+        {/* Row 1: Counts + Search + View toggle */}
+        <div className="flex items-center gap-4">
+          <SummaryBadge label="Critical" count={dangerCount} color={SEVERITY_TEXT.error} />
+          <SummaryBadge label="Warning" count={warningCount} color={SEVERITY_TEXT.warning} />
+
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-theme-text-tertiary" />
+            <input
+              ref={searchInputRef}
+              type="text"
+              placeholder="Search... (press /)"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="w-56 pl-10 pr-4 py-1.5 bg-theme-elevated border border-theme-border-light rounded-lg text-sm text-theme-text-primary placeholder-theme-text-disabled focus:outline-none focus:ring-2 focus:ring-skyhook-500"
+            />
+          </div>
+
+          <div className="flex-1" />
+
+          {groups && (
+            <div className="flex items-center gap-1.5">
+              <button
+                onClick={() => setGroupByNS(!groupByNS)}
+                className={clsx(
+                  'flex items-center gap-1 px-2.5 py-1 text-xs rounded-md border transition-colors',
+                  groupByNS ? 'bg-theme-text-primary/10 text-theme-text-primary font-medium border-theme-border' : 'text-theme-text-tertiary hover:text-theme-text-secondary border-transparent'
+                )}
+              >
+                <Layers className="w-3.5 h-3.5" />
+                Group by namespace
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* Row 2: Filter chips */}
+        <div className="flex flex-wrap items-center gap-1">
+          <FilterChip label="All" active={!categoryFilter && !severityFilter && !frameworkFilter} onClick={() => { setCategoryFilter(null); setSeverityFilter(null); setFrameworkFilter(null) }} />
+          <span className="w-px h-4 bg-theme-text-tertiary/30 mx-3" />
+          {CATEGORIES.map(cat => (
+            <FilterChip key={cat} label={cat} active={categoryFilter === cat} onClick={() => setCategoryFilter(categoryFilter === cat ? null : cat)} />
+          ))}
+          <span className="w-px h-4 bg-theme-text-tertiary/30 mx-3" />
+          {SEVERITIES.map(sev => (
+            <FilterChip key={sev} label={sev === 'danger' ? 'Critical' : 'Warning'} active={severityFilter === sev} onClick={() => setSeverityFilter(severityFilter === sev ? null : sev)} />
+          ))}
+          {frameworks.length > 0 && (
+            <>
+              <span className="w-px h-4 bg-theme-text-tertiary/30 mx-3" />
+              {frameworks.map(fw => (
+                <FilterChip key={fw} label={fw} active={frameworkFilter === fw} onClick={() => setFrameworkFilter(frameworkFilter === fw ? null : fw)} />
+              ))}
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Content */}
+      {isEmpty ? (
+        <div className="flex items-center justify-center py-12 text-theme-text-tertiary text-sm">
+          {totalEmpty ? 'All checks passing — no issues found' : 'No findings match the current filters'}
+        </div>
+      ) : namespacedGroups ? (
+        /* Namespace-grouped view */
+        <div className="flex flex-col gap-1">
+          {namespacedGroups.map(([ns, nsGroups]) => {
+            const nsExpanded = expandedNS.has(ns)
+            const nsDanger = nsGroups.reduce((n, g) => n + g.danger, 0)
+            const nsWarning = nsGroups.reduce((n, g) => n + g.warning, 0)
+            return (
+              <div key={ns}>
+                <button
+                  onClick={() => toggleNS(ns)}
+                  className="group flex items-center gap-3 w-full px-4 py-2 rounded-lg hover:bg-theme-hover/30 transition-colors text-left"
+                >
+                  <ChevronRight className={clsx('w-4 h-4 text-theme-text-tertiary shrink-0 transition-transform duration-200', nsExpanded && 'rotate-90')} />
+                  <span className="text-sm font-semibold text-theme-text-primary">{ns}</span>
+                  <span className="text-xs text-theme-text-tertiary">{nsGroups.length} resource{nsGroups.length !== 1 ? 's' : ''}</span>
+                  <span className="flex-1" />
+                  <div className="flex items-center gap-3 shrink-0">
+                    {nsDanger > 0 && <span className={clsx('text-xs font-semibold tabular-nums', SEVERITY_TEXT.error)}>{nsDanger} critical</span>}
+                    {nsWarning > 0 && <span className={clsx('text-xs font-semibold tabular-nums', SEVERITY_TEXT.warning)}>{nsWarning} warning</span>}
+                  </div>
+                  {onHideNamespace && ns !== '(cluster-scoped)' && (
+                    <ContextMenu items={[{ label: `Hide ${ns} namespace`, onClick: () => onHideNamespace(ns) }]} />
+                  )}
+                </button>
+                <div
+                  className="grid transition-[grid-template-rows] duration-200 ease-out"
+                  style={{ gridTemplateRows: nsExpanded ? '1fr' : '0fr' }}
+                >
+                  <div className="overflow-hidden">
+                    <div className="pl-4">
+                      {nsGroups.map(g => (
+                        <ResourceGroupRow key={`${g.kind}/${g.namespace}/${g.name}`} group={g} checks={checks} expanded={expanded} onToggle={toggle} onResourceClick={onResourceClick} onHideCheck={onHideCheck} onHideCategory={onHideCategory} />
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      ) : filteredGroups ? (
+        /* Flat grouped view */
+        <div className="flex flex-col gap-0.5">
+          {filteredGroups.map(g => (
+            <ResourceGroupRow key={`${g.kind}/${g.namespace}/${g.name}`} group={g} checks={checks} expanded={expanded} onToggle={toggle} onResourceClick={onResourceClick} onHideCheck={onHideCheck} onHideCategory={onHideCategory} onHideNamespace={onHideNamespace} showNamespace />
+          ))}
+        </div>
+      ) : (
+        /* Flat fallback (per-resource view) */
+        <div className="flex flex-col gap-1">
+          {filteredFindings?.map((f, i) => (
+            <FlatFindingRow key={`${f.checkID}-${i}`} finding={f} onResourceClick={onResourceClick} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function FindingDetail({ finding, meta, onHideCheck, onHideCategory }: {
+  finding: AuditFinding
+  meta?: CheckMeta
+  onHideCheck?: (checkID: string, title: string) => void
+  onHideCategory?: (category: string) => void
+}) {
+  const isDanger = finding.severity === 'danger'
+  const menuItems: ContextMenuItem[] = []
+  if (onHideCheck) {
+    menuItems.push({ label: `Hide "${meta?.title || finding.checkID}" check`, onClick: () => onHideCheck(finding.checkID, meta?.title || finding.checkID) })
+  }
+  if (onHideCategory) {
+    menuItems.push({ label: `Hide all ${finding.category} checks`, onClick: () => onHideCategory(finding.category) })
+  }
+
+  return (
+    <div className="flex flex-col gap-0.5 px-3 py-2 rounded group/finding">
+      <div className="flex items-center gap-3">
+        {isDanger ? (
+          <ShieldAlert className={clsx('w-4 h-4 shrink-0', SEVERITY_TEXT.error)} />
+        ) : (
+          <AlertTriangle className={clsx('w-4 h-4 shrink-0', SEVERITY_TEXT.warning)} />
+        )}
+        <span className="text-sm text-theme-text-primary flex-1 min-w-0">{finding.message}</span>
+        <span className={clsx('badge-sm text-[10px]', BP_CATEGORY_BADGE[finding.category] || DEFAULT_BADGE_COLOR)}>
+          {finding.category}
+        </span>
+        {menuItems.length > 0 && <ContextMenu items={menuItems} />}
+      </div>
+      {meta && (
+        <div className="pl-7 flex flex-col gap-0.5">
+          <span className="text-xs text-theme-text-tertiary">{meta.description}</span>
+          <span className="text-xs text-theme-text-secondary">Fix: {meta.remediation}</span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ResourceGroupRow({ group: g, checks, expanded, onToggle, onResourceClick, onHideCheck, onHideCategory, onHideNamespace, showNamespace = false }: {
+  group: ResourceGroup
+  checks?: Record<string, CheckMeta>
+  expanded: Set<string>
+  onToggle: (key: string) => void
+  onResourceClick?: (kind: string, namespace: string, name: string) => void
+  onHideCheck?: (checkID: string, title: string) => void
+  onHideCategory?: (category: string) => void
+  onHideNamespace?: (namespace: string) => void
+  showNamespace?: boolean
+}) {
+  const key = `${g.kind}/${g.namespace}/${g.name}`
+  const isExpanded = expanded.has(key)
+  const hasDanger = g.danger > 0
+
+  return (
+    <div>
+      <button
+        onClick={() => onToggle(key)}
+        className="group flex items-center gap-3 w-full px-4 py-2.5 rounded-lg hover:bg-theme-hover/50 transition-colors text-left focus-visible:ring-2 focus-visible:ring-theme-text-primary/20 focus-visible:outline-none"
+      >
+        <ChevronRight className={clsx('w-3.5 h-3.5 text-theme-text-tertiary shrink-0 transition-transform duration-200', isExpanded && 'rotate-90')} />
+        {hasDanger ? (
+          <ShieldAlert className={clsx('w-4 h-4 shrink-0', SEVERITY_TEXT.error)} />
+        ) : (
+          <AlertTriangle className={clsx('w-4 h-4 shrink-0', SEVERITY_TEXT.warning)} />
+        )}
+        <span className="text-xs text-theme-text-tertiary shrink-0">{g.kind}</span>
+        {onResourceClick ? (
+          <span
+            role="link"
+            tabIndex={0}
+            onClick={(e) => { e.stopPropagation(); onResourceClick(g.kind, g.namespace, g.name) }}
+            onKeyDown={(e) => { if (e.key === 'Enter') { e.stopPropagation(); onResourceClick(g.kind, g.namespace, g.name) } }}
+            className="text-sm font-medium text-skyhook-500 hover:text-skyhook-400 hover:underline cursor-pointer truncate max-w-[300px] inline-flex items-center gap-1"
+          >
+            {showNamespace && g.namespace ? `${g.namespace} / ` : ''}{g.name}
+            <ExternalLink className="w-3 h-3 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
+          </span>
+        ) : (
+          <span className="text-sm font-medium text-theme-text-primary truncate max-w-[300px]">
+            {showNamespace && g.namespace ? `${g.namespace} / ` : ''}{g.name}
+          </span>
+        )}
+        <span className="flex-1" />
+        <div className="flex items-center gap-3 shrink-0">
+          {g.danger > 0 && <span className={clsx('text-xs font-semibold tabular-nums', SEVERITY_TEXT.error)}>{g.danger} critical</span>}
+          {g.warning > 0 && <span className={clsx('text-xs font-semibold tabular-nums', SEVERITY_TEXT.warning)}>{g.warning} warning</span>}
+        </div>
+        {showNamespace && onHideNamespace && g.namespace && (
+          <ContextMenu items={[{ label: `Hide ${g.namespace} namespace`, onClick: () => onHideNamespace(g.namespace) }]} />
+        )}
+      </button>
+      <div
+        className="grid transition-[grid-template-rows] duration-200 ease-out"
+        style={{ gridTemplateRows: isExpanded ? '1fr' : '0fr' }}
+      >
+        <div className="overflow-hidden">
+          <div className="pl-11 pb-1">
+            {g.findings.map((f, i) => (
+              <FindingDetail key={`${f.checkID}-${i}`} finding={f} meta={checks?.[f.checkID]} onHideCheck={onHideCheck} onHideCategory={onHideCategory} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function FlatFindingRow({ finding, onResourceClick }: { finding: AuditFinding; onResourceClick?: (kind: string, namespace: string, name: string) => void }) {
+  const isDanger = finding.severity === 'danger'
+  const severityColor = isDanger ? SEVERITY_TEXT.error : SEVERITY_TEXT.warning
+
+  return (
+    <div className="flex items-center gap-3 px-4 py-2.5 rounded-lg hover:bg-theme-hover/50 transition-colors">
+      {isDanger ? (
+        <ShieldAlert className={clsx('w-4 h-4 shrink-0', severityColor)} />
+      ) : (
+        <AlertTriangle className={clsx('w-4 h-4 shrink-0', severityColor)} />
+      )}
+      {onResourceClick ? (
+        <button
+          onClick={() => onResourceClick(finding.kind, finding.namespace, finding.name)}
+          className="text-xs font-medium text-theme-text-secondary hover:text-theme-text-primary transition-colors shrink-0 max-w-[200px] truncate text-left focus-visible:ring-1 focus-visible:ring-theme-text-primary/30 focus-visible:outline-none rounded"
+        >
+          {finding.kind}/{finding.namespace ? `${finding.namespace}/` : ''}{finding.name}
+        </button>
+      ) : (
+        <span className="text-xs font-medium text-theme-text-secondary shrink-0 max-w-[200px] truncate">
+          {finding.kind}/{finding.namespace ? `${finding.namespace}/` : ''}{finding.name}
+        </span>
+      )}
+      <span className="text-xs text-theme-text-primary flex-1 min-w-0">{finding.message}</span>
+      <span className={clsx('badge-sm text-[10px]', BP_CATEGORY_BADGE[finding.category] || DEFAULT_BADGE_COLOR)}>
+        {finding.category}
+      </span>
+    </div>
+  )
+}
+
+function SummaryBadge({ label, count, color }: { label: string; count: number; color: string }) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className={clsx('text-2xl font-bold tabular-nums', count > 0 ? color : 'text-theme-text-tertiary')}>{count}</span>
+      <span className="text-xs text-theme-text-secondary">{label}</span>
+    </div>
+  )
+}
+
+function FilterChip({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className={clsx(
+        'px-2 py-0.5 text-xs rounded-md transition-colors focus-visible:ring-2 focus-visible:ring-theme-text-primary/20 focus-visible:outline-none',
+        active
+          ? 'bg-theme-text-primary/10 text-theme-text-primary font-medium'
+          : 'text-theme-text-tertiary hover:text-theme-text-secondary hover:bg-theme-hover'
+      )}
+    >
+      {label}
+    </button>
+  )
+}
+
+interface ContextMenuItem {
+  label: string
+  onClick: () => void
+}
+
+function ContextMenu({ items }: { items: ContextMenuItem[] }) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open])
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={(e) => { e.stopPropagation(); setOpen(!open) }}
+        className="p-1 rounded hover:bg-theme-hover text-theme-text-tertiary hover:text-theme-text-secondary opacity-0 group-hover:opacity-100 group-hover/finding:opacity-100 transition-opacity"
+      >
+        <MoreHorizontal className="w-4 h-4" />
+      </button>
+      {open && (
+        <div className="absolute right-0 top-full mt-1 min-w-48 bg-theme-surface border border-theme-border rounded-lg shadow-xl z-50 py-1">
+          {items.map((item, i) => (
+            <button
+              key={i}
+              onClick={(e) => { e.stopPropagation(); item.onClick(); setOpen(false) }}
+              className="w-full text-left px-3 py-1.5 text-xs text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-hover transition-colors flex items-center gap-2"
+            >
+              <EyeOff className="w-3.5 h-3.5 shrink-0" />
+              {item.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/k8s-ui/src/components/audit/index.ts
+++ b/packages/k8s-ui/src/components/audit/index.ts
@@ -1,0 +1,3 @@
+export { AuditCard, type AuditCardData } from './AuditCard'
+export { AuditAlerts, type AuditFinding } from './AuditAlerts'
+export { AuditFindingsTable, type AuditFindingsTableProps, type ResourceGroup, type CheckMeta } from './AuditFindingsTable'

--- a/packages/k8s-ui/src/components/resources/renderers/GenericRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/GenericRenderer.tsx
@@ -358,7 +358,7 @@ function NestedObjectViewer({ name, value, depth = 0 }: NestedObjectViewerProps)
           <div className="ml-5 mt-1 space-y-1">
             {simpleEntries.map(([k, v]) => (
               <div key={k} className="flex items-start gap-2 text-xs">
-                <span className="text-theme-text-tertiary w-28 shrink-0">{formatFieldName(k)}</span>
+                <span className="text-theme-text-tertiary w-40 shrink-0">{formatFieldName(k)}</span>
                 <span className="text-theme-text-secondary break-all">{formatValue(v)}</span>
               </div>
             ))}

--- a/packages/k8s-ui/src/components/resources/renderers/ServiceRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ServiceRenderer.tsx
@@ -16,11 +16,10 @@ export function ServiceRenderer({ data, onCopy, copied, renderPortAction }: Serv
   const namespace = data.metadata?.namespace
   const serviceName = data.metadata?.name
 
-  // Check for issues
   const isLoadBalancer = spec.type === 'LoadBalancer'
+  const isExternalName = spec.type === 'ExternalName'
   const lbPending = isLoadBalancer && lbIngress.length === 0
   const hasNoSelector = !spec.selector || Object.keys(spec.selector).length === 0
-  const isExternalName = spec.type === 'ExternalName'
 
   return (
     <>
@@ -46,47 +45,60 @@ export function ServiceRenderer({ data, onCopy, copied, renderPortAction }: Serv
       <Section title="Service" icon={Globe}>
         <PropertyList>
           <Property label="Type" value={spec.type || 'ClusterIP'} />
-          <Property label="Cluster IP" value={spec.clusterIP} copyable onCopy={onCopy} copied={copied} />
+          {isExternalName ? (
+            <Property label="External Name" value={spec.externalName} copyable onCopy={onCopy} copied={copied} />
+          ) : (
+            <Property label="Cluster IP" value={spec.clusterIP} copyable onCopy={onCopy} copied={copied} />
+          )}
           {spec.externalIPs?.length > 0 && (
             <Property label="External IPs" value={spec.externalIPs.join(', ')} copyable onCopy={onCopy} copied={copied} />
           )}
-          {lbIngress.length > 0 && (
+          {lbIngress.map((ing: any, i: number) => (
             <Property
-              label="Load Balancer"
-              value={lbIngress[0].ip || lbIngress[0].hostname}
+              key={i}
+              label={lbIngress.length > 1 ? `Load Balancer ${i + 1}` : 'Load Balancer'}
+              value={ing.ip || ing.hostname}
               copyable
               onCopy={onCopy}
               copied={copied}
             />
-          )}
+          ))}
           <Property label="Session Affinity" value={spec.sessionAffinity} />
           <Property label="External Traffic" value={spec.externalTrafficPolicy} />
+          <Property label="Internal Traffic" value={spec.internalTrafficPolicy} />
+          {spec.ipFamilyPolicy && <Property label="IP Family Policy" value={spec.ipFamilyPolicy} />}
+          {spec.ipFamilies?.length > 0 && <Property label="IP Families" value={spec.ipFamilies.join(', ')} />}
         </PropertyList>
       </Section>
 
-      <Section title="Ports" defaultExpanded>
-        <div className="space-y-2">
-          {ports.map((port: any, i: number) => (
-            <div key={`${port.port}-${port.protocol || 'TCP'}`} className="card-inner text-sm">
-              <div className="flex items-center justify-between">
-                <span className="text-theme-text-primary font-medium">{port.name || `port-${i + 1}`}</span>
-                <div className="flex items-center gap-2">
-                  {renderPortAction?.({
-                    namespace,
-                    serviceName,
-                    port: port.port,
-                    protocol: port.protocol || 'TCP',
-                  })}
+      {ports.length > 0 && (
+        <Section title="Ports" defaultExpanded>
+          <div className="space-y-2">
+            {ports.map((port: any, i: number) => (
+              <div key={`${port.port}-${port.protocol || 'TCP'}`} className="card-inner text-sm">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className="text-theme-text-primary font-medium">{port.name || `port-${i + 1}`}</span>
+                    <span className="text-xs text-theme-text-tertiary">{port.protocol || 'TCP'}</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {renderPortAction?.({
+                      namespace,
+                      serviceName,
+                      port: port.port,
+                      protocol: port.protocol || 'TCP',
+                    })}
+                  </div>
+                </div>
+                <div className="text-xs text-theme-text-secondary mt-1">
+                  {port.port}{port.targetPort != null && port.targetPort !== port.port ? ` → ${port.targetPort}` : ''}
+                  {port.nodePort ? ` (NodePort: ${port.nodePort})` : ''}
                 </div>
               </div>
-              <div className="text-xs text-theme-text-secondary mt-1">
-                {port.port} {port.targetPort !== port.port && `→ ${port.targetPort}`}
-                {port.nodePort && ` (NodePort: ${port.nodePort})`}
-              </div>
-            </div>
-          ))}
-        </div>
-      </Section>
+            ))}
+          </div>
+        </Section>
+      )}
 
       {spec.selector && (
         <Section title="Selector">

--- a/packages/k8s-ui/src/components/ui/drawer-components.tsx
+++ b/packages/k8s-ui/src/components/ui/drawer-components.tsx
@@ -117,7 +117,7 @@ export function Property({ label, value, copyable, onCopy, copied }: PropertyPro
 
   return (
     <div className="flex items-start gap-2 text-sm">
-      <span className="text-theme-text-tertiary w-28 shrink-0">{label}</span>
+      <span className="text-theme-text-tertiary w-40 shrink-0">{label}</span>
       <span className="text-theme-text-primary break-all flex-1">{displayValue}</span>
       {copyable && onCopy && !isReactElement(value) && (
         <button

--- a/packages/k8s-ui/src/components/workload/WorkloadView.tsx
+++ b/packages/k8s-ui/src/components/workload/WorkloadView.tsx
@@ -121,6 +121,8 @@ interface WorkloadViewProps {
   renderMetricsTab?: (props: { kind: string; namespace: string; name: string }) => ReactNode
   /** Whether metrics are available for this resource kind */
   isMetricsAvailable?: (kind: string, resource: any) => boolean
+  /** Render extra content at the bottom of the overview tab (e.g. audit findings) */
+  renderOverviewExtra?: (props: { kind: string; namespace: string; name: string }) => ReactNode
 
   // ── Duplicate ────────────────────────────────────────────────────────────
   /** Duplicate handler — opens create dialog with this resource's YAML */
@@ -172,6 +174,7 @@ export function WorkloadView({
   isMetricsAvailable,
   // Duplicate
   onDuplicate,
+  renderOverviewExtra,
   // Actions bar
   actionsBarProps,
   // Renderer overrides
@@ -439,20 +442,27 @@ export function WorkloadView({
               onDuplicate={onDuplicate}
             />
           ) : (
-            <ResourceRendererDispatch
-              resource={selectedResource}
-              data={resource}
-              relationships={relationships}
-              certificateInfo={certificateInfo}
-              onCopy={copyToClipboard}
-              copied={copied}
-              onNavigate={onNavigateToResource ? (ref) => onNavigateToResource(refToSelectedResource(ref)) : undefined}
-              onSaveSecretValue={canUpdateSecrets ? handleSaveSecretValue : undefined}
-              isSavingSecret={isUpdatingResource}
-              rendererOverrides={rendererOverrides}
-              resolvedEnvFrom={resolvedEnvFrom}
-              renderMetrics={renderMetricsTab}
-            />
+            <>
+              <ResourceRendererDispatch
+                resource={selectedResource}
+                data={resource}
+                relationships={relationships}
+                certificateInfo={certificateInfo}
+                onCopy={copyToClipboard}
+                copied={copied}
+                onNavigate={onNavigateToResource ? (ref) => onNavigateToResource(refToSelectedResource(ref)) : undefined}
+                onSaveSecretValue={canUpdateSecrets ? handleSaveSecretValue : undefined}
+                isSavingSecret={isUpdatingResource}
+                rendererOverrides={rendererOverrides}
+                resolvedEnvFrom={resolvedEnvFrom}
+                renderMetrics={renderMetricsTab}
+              />
+              {renderOverviewExtra && (
+                <div className="px-4 pb-4">
+                  {renderOverviewExtra({ kind, namespace, name })}
+                </div>
+              )}
+            </>
           )}
         </div>
       </div>
@@ -578,21 +588,22 @@ export function WorkloadView({
       {/* Tab Content */}
       <div className="flex-1 overflow-hidden relative">
         {activeTab === 'overview' && (
-          <InfoTab
-            resource={resource}
-            selectedResource={selectedResource}
-            relationships={relationships}
-            isLoading={resourceLoading}
-            onNavigate={onNavigateToResource}
-            onCopy={copyToClipboard}
-            copied={copied}
-            onSaveSecretValue={canUpdateSecrets ? handleSaveSecretValue : undefined}
-            isSavingSecret={isUpdatingResource}
-            onOpenLogs={handleOpenLogs}
-            onSwitchToTimeline={() => handleSetTab('timeline')}
-            rendererOverrides={rendererOverrides}
-            resolvedEnvFrom={resolvedEnvFrom}
-          />
+            <InfoTab
+              resource={resource}
+              selectedResource={selectedResource}
+              relationships={relationships}
+              isLoading={resourceLoading}
+              onNavigate={onNavigateToResource}
+              onCopy={copyToClipboard}
+              copied={copied}
+              onSaveSecretValue={canUpdateSecrets ? handleSaveSecretValue : undefined}
+              isSavingSecret={isUpdatingResource}
+              onOpenLogs={handleOpenLogs}
+              onSwitchToTimeline={() => handleSetTab('timeline')}
+              rendererOverrides={rendererOverrides}
+              resolvedEnvFrom={resolvedEnvFrom}
+              extraContent={renderOverviewExtra && renderOverviewExtra({ kind, namespace, name })}
+            />
         )}
         {activeTab === 'timeline' && (
           <EventsTab
@@ -1076,6 +1087,7 @@ function InfoTab({
   onSwitchToTimeline,
   rendererOverrides,
   resolvedEnvFrom,
+  extraContent,
 }: {
   resource: any
   selectedResource: SelectedResource
@@ -1090,6 +1102,7 @@ function InfoTab({
   onSwitchToTimeline?: () => void
   rendererOverrides?: RendererOverrides
   resolvedEnvFrom?: ResolvedEnvFrom
+  extraContent?: ReactNode
 }) {
   if (isLoading) {
     return (
@@ -1140,6 +1153,11 @@ function InfoTab({
           </div>
         )}
       />
+      {extraContent && (
+        <div className="px-4 pb-4">
+          {extraContent}
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/k8s-ui/src/index.ts
+++ b/packages/k8s-ui/src/index.ts
@@ -33,3 +33,6 @@ export * from './components/dock'
 
 // Topology (TopologyGraph, TopologySearch, TopologyFilterSidebar, layout utilities)
 export * from './components/topology'
+
+// Cluster audit (AuditCard, AuditAlerts, AuditFindingsTable)
+export * from './components/audit'

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -847,7 +847,7 @@ export interface TrafficFilters {
 }
 
 // Main view type now includes 'traffic' and 'cost'
-export type ExtendedMainView = MainView | 'traffic' | 'cost'
+export type ExtendedMainView = MainView | 'traffic' | 'cost' | 'audit'
 
 // ============================================================================
 // Image Filesystem Types

--- a/packages/k8s-ui/src/utils/badge-colors.ts
+++ b/packages/k8s-ui/src/utils/badge-colors.ts
@@ -52,6 +52,13 @@ export const HELM_STATUS_COLORS: Record<string, string> = {
   uninstalled: BADGE_SEVERITY_COLORS.neutral,
 }
 
+// Best practices category colors
+export const BP_CATEGORY_BADGE: Record<string, string> = {
+  Security: 'bg-purple-50 text-purple-700 border-purple-200 dark:bg-purple-950/40 dark:text-purple-400 dark:border-purple-800/40',
+  Reliability: 'bg-sky-50 text-sky-700 border-sky-200 dark:bg-sky-950/40 dark:text-sky-400 dark:border-sky-800/40',
+  Efficiency: 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-400 dark:border-emerald-800/40',
+}
+
 // Default fallback color
 export const DEFAULT_BADGE_COLOR = 'bg-theme-elevated text-theme-text-secondary'
 

--- a/pkg/audit/checks.go
+++ b/pkg/audit/checks.go
@@ -1,0 +1,874 @@
+package audit
+
+import (
+	"fmt"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// RunChecks runs all best-practice checks against the provided resources
+// and returns aggregated results.
+func RunChecks(input *CheckInput) *ScanResults {
+	if input == nil {
+		return &ScanResults{Summary: ScanSummary{Categories: map[string]CategorySummary{}}}
+	}
+
+	var findings []Finding
+
+	// Build indexes needed by cross-resource checks
+	podsBySelector := indexPodsByLabels(input.Pods)
+	hpaTargets := indexHPATargets(input)
+	pdbSelectors := collectPDBSelectors(input.PodDisruptionBudgets)
+	servicesByName := indexServicesByName(input.Services)
+
+	// --- Security checks (container-level, attributed to owning workload) ---
+	findings = append(findings, checkWorkloadPodSpecs(input)...)
+
+	// --- Reliability checks ---
+	findings = append(findings, checkSingleReplica(input.Deployments, hpaTargets)...)
+	// Only check PDB coverage if we can actually list PDBs (nil = RBAC denied, not "none exist")
+	if input.PodDisruptionBudgets != nil {
+		findings = append(findings, checkMissingPDB(input.Deployments, input.StatefulSets, pdbSelectors)...)
+	}
+	findings = append(findings, checkMissingTopologySpread(input.Deployments, input.StatefulSets)...)
+	findings = append(findings, checkPodHARisk(input.Pods, input.Deployments)...)
+
+	// --- Efficiency checks are included in checkWorkloadPodSpecs ---
+	findings = append(findings, checkOrphanConfigMapsSecrets(input)...)
+	findings = append(findings, checkSecretInConfigMap(input.ConfigMaps)...)
+
+	// --- Cross-resource checks ---
+	findings = append(findings, checkServiceNoMatchingPods(input.Services, podsBySelector)...)
+	findings = append(findings, checkIngressNoMatchingService(input.Ingresses, servicesByName)...)
+
+	// --- Utilization checks (optional, only when metrics provided) ---
+	findings = append(findings, checkResourceUtilization(input.PodMetrics)...)
+
+	// --- Deprecated API checks ---
+	findings = append(findings, checkDeprecatedAPIs(input.ServedAPIs, input.ClusterVersion)...)
+
+	return buildResults(findings)
+}
+
+// ============================================================================
+// Pod spec checks (security, reliability, efficiency)
+// Applied to workload pod templates; falls back to bare pods.
+// ============================================================================
+
+func checkWorkloadPodSpecs(input *CheckInput) []Finding {
+	var findings []Finding
+
+	// Collect pod specs from workloads (attributed to the workload, not individual pods)
+	type workloadPodSpec struct {
+		kind, namespace, name string
+		spec                  corev1.PodSpec
+	}
+	var specs []workloadPodSpec
+
+	for _, d := range input.Deployments {
+		specs = append(specs, workloadPodSpec{"Deployment", d.Namespace, d.Name, d.Spec.Template.Spec})
+	}
+	for _, ss := range input.StatefulSets {
+		specs = append(specs, workloadPodSpec{"StatefulSet", ss.Namespace, ss.Name, ss.Spec.Template.Spec})
+	}
+	for _, ds := range input.DaemonSets {
+		specs = append(specs, workloadPodSpec{"DaemonSet", ds.Namespace, ds.Name, ds.Spec.Template.Spec})
+	}
+
+	// Bare pods (no ownerReferences) get checked directly
+	for _, p := range input.Pods {
+		if len(p.OwnerReferences) == 0 {
+			specs = append(specs, workloadPodSpec{"Pod", p.Namespace, p.Name, p.Spec})
+		}
+	}
+
+	for _, w := range specs {
+		findings = append(findings, checkPodSpecSecurity(w.kind, w.namespace, w.name, w.spec)...)
+		findings = append(findings, checkPodSpecReliability(w.kind, w.namespace, w.name, w.spec)...)
+		findings = append(findings, checkPodSpecEfficiency(w.kind, w.namespace, w.name, w.spec)...)
+		findings = append(findings, checkPodSpecVolumes(w.kind, w.namespace, w.name, w.spec)...)
+	}
+	return findings
+}
+
+// ============================================================================
+// Security checks
+// ============================================================================
+
+func checkPodSpecSecurity(kind, namespace, name string, spec corev1.PodSpec) []Finding {
+	var findings []Finding
+	f := func(checkID, severity, msg string) {
+		findings = append(findings, Finding{
+			Kind: kind, Namespace: namespace, Name: name,
+			CheckID: checkID, Category: CategorySecurity, Severity: severity, Message: msg,
+		})
+	}
+
+	// Pod-level checks
+	if spec.HostNetwork {
+		f("hostNetwork", SeverityWarning, "Pod uses host network")
+	}
+	if spec.HostPID {
+		f("hostPID", SeverityDanger, "Pod uses host PID namespace")
+	}
+	if spec.HostIPC {
+		f("hostIPC", SeverityDanger, "Pod uses host IPC namespace")
+	}
+
+	// automountServiceAccountToken: only flag if not explicitly set to false
+	if spec.AutomountServiceAccountToken == nil || *spec.AutomountServiceAccountToken {
+		f("automountServiceAccountToken", SeverityWarning, "Service account token is auto-mounted")
+	}
+
+	// Container-level checks (iterate init and regular separately to avoid
+	// mutating the InitContainers backing array via append)
+	for i := range spec.InitContainers {
+		checkContainerSecurity(f, &spec.InitContainers[i])
+	}
+	for i := range spec.Containers {
+		checkContainerSecurity(f, &spec.Containers[i])
+	}
+
+	return findings
+}
+
+func checkContainerSecurity(f func(string, string, string), c *corev1.Container) {
+	sc := c.SecurityContext
+
+	if sc == nil || sc.RunAsNonRoot == nil || !*sc.RunAsNonRoot {
+		f("runAsRoot", SeverityWarning, fmt.Sprintf("Container %q may run as root (runAsNonRoot not set)", c.Name))
+	}
+
+	if sc != nil && sc.Privileged != nil && *sc.Privileged {
+		f("privileged", SeverityDanger, fmt.Sprintf("Container %q runs in privileged mode", c.Name))
+	}
+
+	if sc == nil || sc.AllowPrivilegeEscalation == nil || *sc.AllowPrivilegeEscalation {
+		f("privilegeEscalation", SeverityDanger, fmt.Sprintf("Container %q allows privilege escalation", c.Name))
+	}
+
+	if sc == nil || sc.ReadOnlyRootFilesystem == nil || !*sc.ReadOnlyRootFilesystem {
+		f("readOnlyRootFs", SeverityWarning, fmt.Sprintf("Container %q does not use a read-only root filesystem", c.Name))
+	}
+
+	if sc != nil && sc.Capabilities != nil {
+		for _, cap := range sc.Capabilities.Add {
+			capStr := strings.ToUpper(string(cap))
+			switch capStr {
+			case "SYS_ADMIN", "NET_ADMIN", "ALL":
+				f("dangerousCapabilities", SeverityDanger, fmt.Sprintf("Container %q adds dangerous capability %s", c.Name, cap))
+			case "NET_RAW", "SYS_PTRACE", "MKNOD", "DAC_OVERRIDE":
+				f("insecureCapabilities", SeverityWarning, fmt.Sprintf("Container %q adds insecure capability %s", c.Name, cap))
+			}
+		}
+	}
+}
+
+// ============================================================================
+// Volume security checks
+// ============================================================================
+
+// sensitiveHostPaths lists host paths that should not be mounted into containers.
+var sensitiveHostPaths = []string{"/etc", "/proc", "/sys", "/var/run", "/var/log", "/root"}
+
+func checkPodSpecVolumes(kind, namespace, name string, spec corev1.PodSpec) []Finding {
+	var findings []Finding
+	f := func(checkID, severity, msg string) {
+		findings = append(findings, Finding{
+			Kind: kind, Namespace: namespace, Name: name,
+			CheckID: checkID, Category: CategorySecurity, Severity: severity, Message: msg,
+		})
+	}
+
+	for _, v := range spec.Volumes {
+		if v.HostPath == nil {
+			continue
+		}
+		p := v.HostPath.Path
+
+		// Container runtime socket — critical attack vector
+		if strings.Contains(p, "docker.sock") || strings.Contains(p, "containerd.sock") || strings.Contains(p, "crio.sock") {
+			f("dockerSocketMount", SeverityDanger, fmt.Sprintf("Volume %q mounts container runtime socket %s", v.Name, p))
+			continue
+		}
+
+		// Root filesystem mount
+		if p == "/" {
+			f("sensitiveHostPath", SeverityDanger, fmt.Sprintf("Volume %q mounts the entire host root filesystem", v.Name))
+			continue
+		}
+
+		// Sensitive host paths
+		for _, prefix := range sensitiveHostPaths {
+			if p == prefix || strings.HasPrefix(p, prefix+"/") {
+				f("sensitiveHostPath", SeverityWarning, fmt.Sprintf("Volume %q mounts sensitive host path %s", v.Name, p))
+				break
+			}
+		}
+	}
+
+	return findings
+}
+
+// ============================================================================
+// Secret detection in ConfigMaps
+// ============================================================================
+
+// sensitiveKeyPatterns matches ConfigMap keys that likely contain secrets.
+var sensitiveKeyPatterns = []string{
+	"password", "passwd", "secret", "api_key", "apikey", "api-key",
+	"token", "private_key", "privatekey", "private-key",
+	"credential", "credentials", "auth", "authorization",
+	"access_key", "accesskey", "access-key",
+	"secret_key", "secretkey", "secret-key",
+}
+
+func checkSecretInConfigMap(configMaps []*corev1.ConfigMap) []Finding {
+	if len(configMaps) == 0 {
+		return nil
+	}
+
+	var findings []Finding
+	for _, cm := range configMaps {
+		for key := range cm.Data {
+			keyLower := strings.ToLower(key)
+			for _, pattern := range sensitiveKeyPatterns {
+				if strings.Contains(keyLower, pattern) {
+					findings = append(findings, Finding{
+						Kind: "ConfigMap", Namespace: cm.Namespace, Name: cm.Name,
+						CheckID:  "secretInConfigMap",
+						Category: CategorySecurity, Severity: SeverityWarning,
+						Message:  fmt.Sprintf("ConfigMap key %q may contain sensitive data — use a Secret instead", key),
+					})
+					break // one finding per key is enough
+				}
+			}
+		}
+	}
+	return findings
+}
+
+// ============================================================================
+// Reliability checks
+// ============================================================================
+
+func checkPodSpecReliability(kind, namespace, name string, spec corev1.PodSpec) []Finding {
+	var findings []Finding
+	f := func(checkID, severity, msg string) {
+		findings = append(findings, Finding{
+			Kind: kind, Namespace: namespace, Name: name,
+			CheckID: checkID, Category: CategoryReliability, Severity: severity, Message: msg,
+		})
+	}
+
+	for _, c := range spec.Containers {
+		if c.ReadinessProbe == nil {
+			f("readinessProbeMissing", SeverityWarning, fmt.Sprintf("Container %q has no readiness probe", c.Name))
+		}
+		if c.LivenessProbe == nil {
+			f("livenessProbeMissing", SeverityWarning, fmt.Sprintf("Container %q has no liveness probe", c.Name))
+		}
+
+		tag := imageTag(c.Image)
+		if tag == "latest" || tag == "" {
+			f("imageTagLatest", SeverityDanger, fmt.Sprintf("Container %q uses image tag %q", c.Name, tagDisplay(tag)))
+		}
+
+		if (tag == "latest" || tag == "") && c.ImagePullPolicy != corev1.PullAlways {
+			f("pullPolicyNotAlways", SeverityWarning, fmt.Sprintf("Container %q with mutable tag should use imagePullPolicy=Always", c.Name))
+		}
+	}
+
+	return findings
+}
+
+func checkSingleReplica(deployments []*appsv1.Deployment, hpaTargets map[string]bool) []Finding {
+	var findings []Finding
+	for _, d := range deployments {
+		replicas := int32(1)
+		if d.Spec.Replicas != nil {
+			replicas = *d.Spec.Replicas
+		}
+		if replicas <= 1 && !hpaTargets[hpaKey("Deployment", d.Namespace, d.Name)] {
+			findings = append(findings, Finding{
+				Kind: "Deployment", Namespace: d.Namespace, Name: d.Name,
+				CheckID: "singleReplica", Category: CategoryReliability, Severity: SeverityWarning,
+				Message: "Deployment has only 1 replica",
+			})
+		}
+	}
+	return findings
+}
+
+func checkMissingPDB(deployments []*appsv1.Deployment, statefulSets []*appsv1.StatefulSet, pdbSelectors []namespacedSelector) []Finding {
+	var findings []Finding
+
+	check := func(kind, namespace, name string, replicas *int32, matchLabels map[string]string) {
+		r := int32(1)
+		if replicas != nil {
+			r = *replicas
+		}
+		if r <= 1 {
+			return // PDB only matters for multi-replica workloads
+		}
+		podLabels := labels.Set(matchLabels)
+		for _, ns := range pdbSelectors {
+			if ns.namespace == namespace && ns.selector.Matches(podLabels) {
+				return // covered by a PDB in the same namespace
+			}
+		}
+		findings = append(findings, Finding{
+			Kind: kind, Namespace: namespace, Name: name,
+			CheckID: "missingPDB", Category: CategoryReliability, Severity: SeverityWarning,
+			Message: fmt.Sprintf("%s has %d replicas but no PodDisruptionBudget", kind, r),
+		})
+	}
+
+	for _, d := range deployments {
+		check("Deployment", d.Namespace, d.Name, d.Spec.Replicas, d.Spec.Selector.MatchLabels)
+	}
+	for _, ss := range statefulSets {
+		check("StatefulSet", ss.Namespace, ss.Name, ss.Spec.Replicas, ss.Spec.Selector.MatchLabels)
+	}
+	return findings
+}
+
+// ============================================================================
+// Efficiency checks
+// ============================================================================
+
+func checkPodSpecEfficiency(kind, namespace, name string, spec corev1.PodSpec) []Finding {
+	var findings []Finding
+	f := func(checkID, severity, msg string) {
+		findings = append(findings, Finding{
+			Kind: kind, Namespace: namespace, Name: name,
+			CheckID: checkID, Category: CategoryEfficiency, Severity: severity, Message: msg,
+		})
+	}
+
+	for _, c := range spec.Containers {
+		res := c.Resources
+		if res.Requests.Cpu() == nil || res.Requests.Cpu().IsZero() {
+			f("cpuRequestMissing", SeverityWarning, fmt.Sprintf("Container %q has no CPU request", c.Name))
+		}
+		if res.Requests.Memory() == nil || res.Requests.Memory().IsZero() {
+			f("memoryRequestMissing", SeverityWarning, fmt.Sprintf("Container %q has no memory request", c.Name))
+		}
+		if res.Limits.Cpu() == nil || res.Limits.Cpu().IsZero() {
+			f("cpuLimitMissing", SeverityWarning, fmt.Sprintf("Container %q has no CPU limit", c.Name))
+		}
+		if res.Limits.Memory() == nil || res.Limits.Memory().IsZero() {
+			f("memoryLimitMissing", SeverityWarning, fmt.Sprintf("Container %q has no memory limit", c.Name))
+		}
+	}
+
+	return findings
+}
+
+// ============================================================================
+// Cross-resource checks (Radar-native)
+// ============================================================================
+
+func checkServiceNoMatchingPods(services []*corev1.Service, podsBySelector map[string][]*corev1.Pod) []Finding {
+	var findings []Finding
+	for _, svc := range services {
+		if len(svc.Spec.Selector) == 0 {
+			continue // headless or external-name services
+		}
+		if svc.Spec.Type == corev1.ServiceTypeExternalName {
+			continue
+		}
+		sel := labels.SelectorFromSet(labels.Set(svc.Spec.Selector))
+		found := false
+		for _, pod := range podsBySelector[svc.Namespace] {
+			if sel.Matches(labels.Set(pod.Labels)) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			findings = append(findings, Finding{
+				Kind: "Service", Namespace: svc.Namespace, Name: svc.Name,
+				CheckID: "serviceNoMatchingPods", Category: CategoryReliability, Severity: SeverityWarning,
+				Message: "Service selector matches no pods",
+			})
+		}
+	}
+	return findings
+}
+
+func checkIngressNoMatchingService(ingresses []*networkingv1.Ingress, servicesByName map[string]bool) []Finding {
+	var findings []Finding
+	for _, ing := range ingresses {
+		for _, rule := range ing.Spec.Rules {
+			if rule.HTTP == nil {
+				continue
+			}
+			for _, path := range rule.HTTP.Paths {
+				if path.Backend.Service == nil {
+					continue
+				}
+				svcKey := ing.Namespace + "/" + path.Backend.Service.Name
+				if !servicesByName[svcKey] {
+					findings = append(findings, Finding{
+						Kind: "Ingress", Namespace: ing.Namespace, Name: ing.Name,
+						CheckID:  "ingressNoMatchingService", Category: CategoryReliability, Severity: SeverityWarning,
+						Message:  fmt.Sprintf("Ingress references non-existent Service %q", path.Backend.Service.Name),
+					})
+				}
+			}
+		}
+	}
+	return findings
+}
+
+// ============================================================================
+// Topology spread + HA checks
+// ============================================================================
+
+func checkMissingTopologySpread(deployments []*appsv1.Deployment, statefulSets []*appsv1.StatefulSet) []Finding {
+	var findings []Finding
+
+	check := func(kind, namespace, name string, replicas *int32, spec corev1.PodSpec) {
+		r := int32(1)
+		if replicas != nil {
+			r = *replicas
+		}
+		if r <= 1 {
+			return
+		}
+		if len(spec.TopologySpreadConstraints) > 0 {
+			return
+		}
+		findings = append(findings, Finding{
+			Kind: kind, Namespace: namespace, Name: name,
+			CheckID: "missingTopologySpread", Category: CategoryReliability, Severity: SeverityWarning,
+			Message: fmt.Sprintf("%s has %d replicas but no topology spread constraints", kind, r),
+		})
+	}
+
+	for _, d := range deployments {
+		check("Deployment", d.Namespace, d.Name, d.Spec.Replicas, d.Spec.Template.Spec)
+	}
+	for _, ss := range statefulSets {
+		check("StatefulSet", ss.Namespace, ss.Name, ss.Spec.Replicas, ss.Spec.Template.Spec)
+	}
+	return findings
+}
+
+func checkPodHARisk(pods []*corev1.Pod, deployments []*appsv1.Deployment) []Finding {
+	var findings []Finding
+	for _, d := range deployments {
+		replicas := int32(1)
+		if d.Spec.Replicas != nil {
+			replicas = *d.Spec.Replicas
+		}
+		if replicas <= 1 || d.Spec.Selector == nil {
+			continue
+		}
+		sel, err := metav1.LabelSelectorAsSelector(d.Spec.Selector)
+		if err != nil {
+			continue
+		}
+		nodeSet := make(map[string]bool)
+		matchCount := 0
+		for _, pod := range pods {
+			if pod.Namespace != d.Namespace {
+				continue
+			}
+			if !sel.Matches(labels.Set(pod.Labels)) {
+				continue
+			}
+			// Skip pods not running (pending pods don't have a node yet)
+			if pod.Spec.NodeName == "" {
+				continue
+			}
+			nodeSet[pod.Spec.NodeName] = true
+			matchCount++
+		}
+		if matchCount > 1 && len(nodeSet) == 1 {
+			var nodeName string
+			for n := range nodeSet {
+				nodeName = n
+			}
+			findings = append(findings, Finding{
+				Kind: "Deployment", Namespace: d.Namespace, Name: d.Name,
+				CheckID: "podHARisk", Category: CategoryReliability, Severity: SeverityWarning,
+				Message: fmt.Sprintf("All %d running pods are on node %s", matchCount, nodeName),
+			})
+		}
+	}
+	return findings
+}
+
+// ============================================================================
+// Orphan resource checks
+// ============================================================================
+
+func checkOrphanConfigMapsSecrets(input *CheckInput) []Finding {
+	if len(input.ConfigMaps) == 0 && len(input.Secrets) == 0 {
+		return nil
+	}
+
+	// Build set of referenced ConfigMap and Secret names (namespace/name)
+	referencedCMs := make(map[string]bool)
+	referencedSecrets := make(map[string]bool)
+
+	for _, pod := range input.Pods {
+		ns := pod.Namespace
+		spec := pod.Spec
+		// Check all containers (init + regular)
+		for _, c := range spec.InitContainers {
+			collectContainerRefs(ns, c, referencedCMs, referencedSecrets)
+		}
+		for _, c := range spec.Containers {
+			collectContainerRefs(ns, c, referencedCMs, referencedSecrets)
+		}
+		// Volume references
+		for _, v := range spec.Volumes {
+			if v.ConfigMap != nil {
+				referencedCMs[ns+"/"+v.ConfigMap.Name] = true
+			}
+			if v.Secret != nil {
+				referencedSecrets[ns+"/"+v.Secret.SecretName] = true
+			}
+			if v.Projected != nil {
+				for _, src := range v.Projected.Sources {
+					if src.ConfigMap != nil {
+						referencedCMs[ns+"/"+src.ConfigMap.Name] = true
+					}
+					if src.Secret != nil {
+						referencedSecrets[ns+"/"+src.Secret.Name] = true
+					}
+				}
+			}
+		}
+		// ImagePullSecrets
+		for _, ips := range spec.ImagePullSecrets {
+			referencedSecrets[ns+"/"+ips.Name] = true
+		}
+		// ServiceAccount token secrets (referenced implicitly)
+		if spec.ServiceAccountName != "" {
+			// SA token secrets are named like "<sa-name>-token-xxxxx" — we can't match exactly,
+			// but we skip SA-related secrets via the type filter below
+		}
+	}
+
+	// Ingress TLS secrets
+	for _, ing := range input.Ingresses {
+		for _, tls := range ing.Spec.TLS {
+			if tls.SecretName != "" {
+				referencedSecrets[ing.Namespace+"/"+tls.SecretName] = true
+			}
+		}
+	}
+
+	var findings []Finding
+
+	// Check ConfigMaps
+	for _, cm := range input.ConfigMaps {
+		key := cm.Namespace + "/" + cm.Name
+		if referencedCMs[key] {
+			continue
+		}
+		// Skip well-known system ConfigMaps
+		if cm.Name == "kube-root-ca.crt" {
+			continue
+		}
+		findings = append(findings, Finding{
+			Kind: "ConfigMap", Namespace: cm.Namespace, Name: cm.Name,
+			CheckID: "orphanConfigMapSecret", Category: CategoryEfficiency, Severity: SeverityWarning,
+			Message: fmt.Sprintf("ConfigMap %q is not referenced by any pod", cm.Name),
+		})
+	}
+
+	// Check Secrets
+	for _, sec := range input.Secrets {
+		key := sec.Namespace + "/" + sec.Name
+		if referencedSecrets[key] {
+			continue
+		}
+		// Skip service account tokens and Helm release secrets
+		if sec.Type == corev1.SecretTypeServiceAccountToken {
+			continue
+		}
+		if sec.Type == "helm.sh/release.v1" {
+			continue
+		}
+		// Skip TLS secrets used by cert-manager (they may be referenced by Ingress annotations, not spec)
+		if sec.Labels != nil && sec.Labels["cert-manager.io/certificate-name"] != "" {
+			continue
+		}
+		findings = append(findings, Finding{
+			Kind: "Secret", Namespace: sec.Namespace, Name: sec.Name,
+			CheckID: "orphanConfigMapSecret", Category: CategoryEfficiency, Severity: SeverityWarning,
+			Message: fmt.Sprintf("Secret %q is not referenced by any pod", sec.Name),
+		})
+	}
+
+	return findings
+}
+
+func collectContainerRefs(ns string, c corev1.Container, cms, secrets map[string]bool) {
+	for _, env := range c.Env {
+		if env.ValueFrom != nil {
+			if env.ValueFrom.ConfigMapKeyRef != nil {
+				cms[ns+"/"+env.ValueFrom.ConfigMapKeyRef.Name] = true
+			}
+			if env.ValueFrom.SecretKeyRef != nil {
+				secrets[ns+"/"+env.ValueFrom.SecretKeyRef.Name] = true
+			}
+		}
+	}
+	for _, envFrom := range c.EnvFrom {
+		if envFrom.ConfigMapRef != nil {
+			cms[ns+"/"+envFrom.ConfigMapRef.Name] = true
+		}
+		if envFrom.SecretRef != nil {
+			secrets[ns+"/"+envFrom.SecretRef.Name] = true
+		}
+	}
+}
+
+// ============================================================================
+// Resource utilization checks
+// ============================================================================
+
+func checkResourceUtilization(metrics []PodMetricsInput) []Finding {
+	if len(metrics) == 0 {
+		return nil
+	}
+
+	var findings []Finding
+	for _, m := range metrics {
+		// CPU utilization
+		if m.CPURequest > 0 {
+			cpuPct := float64(m.CPUUsage) / float64(m.CPURequest) * 100
+			if cpuPct < 10 && m.CPUUsage > 0 {
+				findings = append(findings, Finding{
+					Kind: "Pod", Namespace: m.Namespace, Name: m.Name,
+					CheckID: "resourceUtilization", Category: CategoryEfficiency, Severity: SeverityWarning,
+					Message: fmt.Sprintf("CPU usage is %.0f%% of request (%dm used, %dm requested) — consider reducing request", cpuPct, m.CPUUsage, m.CPURequest),
+				})
+			} else if cpuPct > 90 {
+				findings = append(findings, Finding{
+					Kind: "Pod", Namespace: m.Namespace, Name: m.Name,
+					CheckID: "resourceUtilization", Category: CategoryEfficiency, Severity: SeverityWarning,
+					Message: fmt.Sprintf("CPU usage is %.0f%% of request (%dm used, %dm requested) — at risk of throttling", cpuPct, m.CPUUsage, m.CPURequest),
+				})
+			}
+		}
+
+		// Memory utilization
+		if m.MemoryRequest > 0 {
+			memPct := float64(m.MemoryUsage) / float64(m.MemoryRequest) * 100
+			memUsageMi := m.MemoryUsage / (1024 * 1024)
+			memReqMi := m.MemoryRequest / (1024 * 1024)
+			if memPct < 10 && m.MemoryUsage > 0 {
+				findings = append(findings, Finding{
+					Kind: "Pod", Namespace: m.Namespace, Name: m.Name,
+					CheckID: "resourceUtilization", Category: CategoryEfficiency, Severity: SeverityWarning,
+					Message: fmt.Sprintf("Memory usage is %.0f%% of request (%dMi used, %dMi requested) — consider reducing request", memPct, memUsageMi, memReqMi),
+				})
+			} else if memPct > 90 {
+				findings = append(findings, Finding{
+					Kind: "Pod", Namespace: m.Namespace, Name: m.Name,
+					CheckID: "resourceUtilization", Category: CategoryEfficiency, Severity: SeverityWarning,
+					Message: fmt.Sprintf("Memory usage is %.0f%% of request (%dMi used, %dMi requested) — at risk of OOM kill", memPct, memUsageMi, memReqMi),
+				})
+			}
+		}
+	}
+	return findings
+}
+
+// ============================================================================
+// Deprecated API checks
+// ============================================================================
+
+func checkDeprecatedAPIs(servedAPIs []string, clusterVersion string) []Finding {
+	if len(servedAPIs) == 0 || clusterVersion == "" {
+		return nil
+	}
+
+	deprecations := DeprecationsByGroupVersion()
+	var findings []Finding
+
+	for _, gv := range servedAPIs {
+		entries, ok := deprecations[gv]
+		if !ok {
+			continue
+		}
+		for _, entry := range entries {
+			kindLabel := gv
+			msg := fmt.Sprintf("API %s is deprecated (since %s, removed in %s) — use %s",
+				gv, entry.DeprecatedIn, entry.RemovedIn, entry.Replacement)
+			if entry.Kind != "" {
+				kindLabel = entry.Kind
+				msg = fmt.Sprintf("API %s %s is deprecated (since %s, removed in %s) — use %s",
+					gv, entry.Kind, entry.DeprecatedIn, entry.RemovedIn, entry.Replacement)
+			}
+			findings = append(findings, Finding{
+				Kind:     kindLabel,
+				Name:     gv,
+				CheckID:  "deprecatedAPIVersion",
+				Category: CategoryReliability,
+				Severity: SeverityDanger,
+				Message:  msg,
+			})
+		}
+	}
+
+	return findings
+}
+
+// ============================================================================
+// Index builders
+// ============================================================================
+
+// indexPodsByLabels groups pods by namespace for selector matching.
+func indexPodsByLabels(pods []*corev1.Pod) map[string][]*corev1.Pod {
+	m := make(map[string][]*corev1.Pod)
+	for _, p := range pods {
+		m[p.Namespace] = append(m[p.Namespace], p)
+	}
+	return m
+}
+
+// indexHPATargets returns a set of "Kind/namespace/name" for HPA targets.
+func indexHPATargets(input *CheckInput) map[string]bool {
+	m := make(map[string]bool)
+	for _, hpa := range input.HorizontalPodAutoscalers {
+		ref := hpa.Spec.ScaleTargetRef
+		m[hpaKey(ref.Kind, hpa.Namespace, ref.Name)] = true
+	}
+	return m
+}
+
+func hpaKey(kind, namespace, name string) string {
+	return kind + "/" + namespace + "/" + name
+}
+
+// namespacedSelector pairs a label selector with its namespace.
+type namespacedSelector struct {
+	namespace string
+	selector  labels.Selector
+}
+
+// collectPDBSelectors returns label selectors from all PodDisruptionBudgets,
+// keyed by namespace so we only match PDBs in the same namespace as the workload.
+func collectPDBSelectors(pdbs []*policyv1.PodDisruptionBudget) []namespacedSelector {
+	var sels []namespacedSelector
+	for _, pdb := range pdbs {
+		if pdb.Spec.Selector == nil {
+			continue
+		}
+		sel, err := metav1.LabelSelectorAsSelector(pdb.Spec.Selector)
+		if err != nil {
+			continue
+		}
+		sels = append(sels, namespacedSelector{namespace: pdb.Namespace, selector: sel})
+	}
+	return sels
+}
+
+// indexServicesByName returns a set of "namespace/name" for all services.
+func indexServicesByName(services []*corev1.Service) map[string]bool {
+	m := make(map[string]bool)
+	for _, svc := range services {
+		m[svc.Namespace+"/"+svc.Name] = true
+	}
+	return m
+}
+
+// ============================================================================
+// Result aggregation
+// ============================================================================
+
+func buildResults(findings []Finding) *ScanResults {
+	categories := map[string]CategorySummary{}
+	// Initialize all categories
+	for _, cat := range []string{CategorySecurity, CategoryReliability, CategoryEfficiency} {
+		categories[cat] = CategorySummary{}
+	}
+
+	// Merge findings: same (resource, checkID) get combined into one finding
+	// with messages joined, so multi-container workloads show all affected containers.
+	type checkKey struct{ resource, checkID string }
+	mergeIndex := make(map[checkKey]int) // key → index in dedupFindings
+	var dedupFindings []Finding
+
+	for _, f := range findings {
+		key := checkKey{ResourceKey(f.Kind, f.Namespace, f.Name), f.CheckID}
+		if idx, exists := mergeIndex[key]; exists {
+			dedupFindings[idx].Message += "; " + f.Message
+			continue
+		}
+		mergeIndex[key] = len(dedupFindings)
+		dedupFindings = append(dedupFindings, f)
+
+		cs := categories[f.Category]
+		switch f.Severity {
+		case SeverityWarning:
+			cs.Warning++
+		case SeverityDanger:
+			cs.Danger++
+		}
+		categories[f.Category] = cs
+	}
+
+	totalWarning, totalDanger := 0, 0
+	for _, cs := range categories {
+		totalWarning += cs.Warning
+		totalDanger += cs.Danger
+	}
+
+	// Include full registry so settings dialog can show all checks (including disabled ones)
+	checks := make(map[string]CheckMeta, len(CheckRegistry))
+	for id, meta := range CheckRegistry {
+		checks[id] = meta
+	}
+
+	return &ScanResults{
+		Summary: ScanSummary{
+			Warning:    totalWarning,
+			Danger:     totalDanger,
+			Categories: categories,
+		},
+		Findings: dedupFindings,
+		Groups:   GroupByResource(dedupFindings),
+		Checks:   checks,
+	}
+}
+
+// ============================================================================
+// Utilities
+// ============================================================================
+
+// imageTag extracts the tag from an image reference.
+// Returns "" if no tag or digest is present.
+func imageTag(image string) string {
+	// Handle digest references (image@sha256:...)
+	if strings.Contains(image, "@") {
+		return strings.SplitN(image, "@", 2)[1]
+	}
+	// Handle tag references (image:tag)
+	parts := strings.SplitN(image, ":", 2)
+	if len(parts) == 2 && !strings.Contains(parts[1], "/") {
+		return parts[1]
+	}
+	return ""
+}
+
+func tagDisplay(tag string) string {
+	if tag == "" {
+		return "<none>"
+	}
+	return tag
+}

--- a/pkg/audit/checks_test.go
+++ b/pkg/audit/checks_test.go
@@ -1,0 +1,1089 @@
+package audit
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func TestRunChecks_Empty(t *testing.T) {
+	results := RunChecks(&CheckInput{})
+	if len(results.Findings) != 0 {
+		t.Errorf("expected no findings for empty input, got %d", len(results.Findings))
+	}
+}
+
+func TestRunChecks_Nil(t *testing.T) {
+	results := RunChecks(nil)
+	if results == nil {
+		t.Fatal("expected non-nil results for nil input")
+	}
+}
+
+func TestSecurityChecks(t *testing.T) {
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "insecure-app", Namespace: "default"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(3)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "insecure"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						HostNetwork: true,
+						Containers: []corev1.Container{{
+							Name:  "app",
+							Image: "nginx:1.25",
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: ptr(true),
+							},
+						}},
+					},
+				},
+			},
+		}},
+	}
+
+	results := RunChecks(input)
+	findingsByCheck := map[string]Finding{}
+	for _, f := range results.Findings {
+		findingsByCheck[f.CheckID] = f
+	}
+
+	// Should flag: hostNetwork, privileged, runAsRoot, privilegeEscalation, readOnlyRootFs, automountServiceAccountToken
+	for _, expected := range []string{"hostNetwork", "privileged", "runAsRoot", "privilegeEscalation", "readOnlyRootFs", "automountServiceAccountToken"} {
+		if _, ok := findingsByCheck[expected]; !ok {
+			t.Errorf("expected finding for check %q, not found", expected)
+		}
+	}
+
+	// Verify they're attributed to the Deployment, not a Pod
+	for _, f := range results.Findings {
+		if f.Kind != "Deployment" {
+			t.Errorf("expected findings attributed to Deployment, got %q", f.Kind)
+		}
+	}
+}
+
+func TestSecurityChecks_Secure(t *testing.T) {
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "secure-app", Namespace: "default"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(2)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "secure"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						AutomountServiceAccountToken: ptr(false),
+						TopologySpreadConstraints: []corev1.TopologySpreadConstraint{{
+							MaxSkew: 1, TopologyKey: "kubernetes.io/hostname",
+							WhenUnsatisfiable: corev1.DoNotSchedule,
+							LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "secure"}},
+						}},
+						Containers: []corev1.Container{{
+							Name:  "app",
+							Image: "nginx:1.25",
+							SecurityContext: &corev1.SecurityContext{
+								RunAsNonRoot:             ptr(true),
+								ReadOnlyRootFilesystem:   ptr(true),
+								AllowPrivilegeEscalation: ptr(false),
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("128Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("200m"),
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
+								},
+							},
+							ReadinessProbe: &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/ready", Port: intstr.FromInt(8080)}}},
+							LivenessProbe:  &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/health", Port: intstr.FromInt(8080)}}},
+						}},
+					},
+				},
+			},
+		}},
+		PodDisruptionBudgets: []*policyv1.PodDisruptionBudget{{
+			ObjectMeta: metav1.ObjectMeta{Name: "secure-pdb", Namespace: "default"},
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "secure"}},
+			},
+		}},
+	}
+
+	results := RunChecks(input)
+
+	// A well-configured deployment should have zero security/reliability/efficiency findings
+	securityFindings := 0
+	for _, f := range results.Findings {
+		if f.Category == CategorySecurity || f.Category == CategoryReliability || f.Category == CategoryEfficiency {
+			securityFindings++
+			t.Errorf("unexpected finding: [%s] %s - %s", f.CheckID, f.Category, f.Message)
+		}
+	}
+}
+
+func TestReliabilityChecks(t *testing.T) {
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "single-replica", Namespace: "default"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(1)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "single"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						AutomountServiceAccountToken: ptr(false),
+						Containers: []corev1.Container{{
+							Name:  "app",
+							Image: "myapp:latest",
+							SecurityContext: &corev1.SecurityContext{
+								RunAsNonRoot:             ptr(true),
+								ReadOnlyRootFilesystem:   ptr(true),
+								AllowPrivilegeEscalation: ptr(false),
+							},
+						}},
+					},
+				},
+			},
+		}},
+	}
+
+	results := RunChecks(input)
+	checks := map[string]bool{}
+	for _, f := range results.Findings {
+		checks[f.CheckID] = true
+	}
+
+	if !checks["singleReplica"] {
+		t.Error("expected singleReplica finding")
+	}
+	if !checks["imageTagLatest"] {
+		t.Error("expected imageTagLatest finding")
+	}
+	if !checks["pullPolicyNotAlways"] {
+		t.Error("expected pullPolicyNotAlways finding")
+	}
+}
+
+func TestSingleReplica_SkippedWithHPA(t *testing.T) {
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "autoscaled", Namespace: "default"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(1)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "auto"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: "app:v1"}}},
+				},
+			},
+		}},
+		HorizontalPodAutoscalers: []*autoscalingv2.HorizontalPodAutoscaler{{
+			ObjectMeta: metav1.ObjectMeta{Name: "autoscaled-hpa", Namespace: "default"},
+			Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+				ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+					Kind: "Deployment", Name: "autoscaled",
+				},
+			},
+		}},
+	}
+
+	results := RunChecks(input)
+	for _, f := range results.Findings {
+		if f.CheckID == "singleReplica" {
+			t.Error("singleReplica should not fire when HPA targets the deployment")
+		}
+	}
+}
+
+func TestEfficiencyChecks(t *testing.T) {
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "no-resources", Namespace: "default"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(1)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "nores"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						AutomountServiceAccountToken: ptr(false),
+						Containers: []corev1.Container{{
+							Name:  "app",
+							Image: "app:v1",
+							SecurityContext: &corev1.SecurityContext{
+								RunAsNonRoot:             ptr(true),
+								ReadOnlyRootFilesystem:   ptr(true),
+								AllowPrivilegeEscalation: ptr(false),
+							},
+							// No resources set
+						}},
+					},
+				},
+			},
+		}},
+	}
+
+	results := RunChecks(input)
+	checks := map[string]bool{}
+	for _, f := range results.Findings {
+		checks[f.CheckID] = true
+	}
+
+	for _, expected := range []string{"cpuRequestMissing", "memoryRequestMissing", "cpuLimitMissing", "memoryLimitMissing"} {
+		if !checks[expected] {
+			t.Errorf("expected finding for check %q", expected)
+		}
+	}
+}
+
+func TestServiceNoMatchingPods(t *testing.T) {
+	input := &CheckInput{
+		Services: []*corev1.Service{{
+			ObjectMeta: metav1.ObjectMeta{Name: "orphan-svc", Namespace: "default"},
+			Spec: corev1.ServiceSpec{
+				Selector: map[string]string{"app": "nonexistent"},
+			},
+		}},
+		Pods: []*corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{Name: "other-pod", Namespace: "default", Labels: map[string]string{"app": "other"}},
+		}},
+	}
+
+	results := RunChecks(input)
+	found := false
+	for _, f := range results.Findings {
+		if f.CheckID == "serviceNoMatchingPods" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected serviceNoMatchingPods finding")
+	}
+}
+
+func TestIngressNoMatchingService(t *testing.T) {
+	input := &CheckInput{
+		Ingresses: []*networkingv1.Ingress{{
+			ObjectMeta: metav1.ObjectMeta{Name: "bad-ingress", Namespace: "default"},
+			Spec: networkingv1.IngressSpec{
+				Rules: []networkingv1.IngressRule{{
+					Host: "example.com",
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{{
+								Path: "/",
+								Backend: networkingv1.IngressBackend{
+									Service: &networkingv1.IngressServiceBackend{
+										Name: "missing-service",
+									},
+								},
+							}},
+						},
+					},
+				}},
+			},
+		}},
+		Services: []*corev1.Service{}, // no services
+	}
+
+	results := RunChecks(input)
+	found := false
+	for _, f := range results.Findings {
+		if f.CheckID == "ingressNoMatchingService" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected ingressNoMatchingService finding")
+	}
+}
+
+func TestBarePodChecked(t *testing.T) {
+	input := &CheckInput{
+		Pods: []*corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{Name: "bare-pod", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:  "app",
+					Image: "nginx",
+				}},
+			},
+			// No OwnerReferences — bare pod
+		}},
+	}
+
+	results := RunChecks(input)
+	if len(results.Findings) == 0 {
+		t.Error("expected findings for bare pod with no security context or probes")
+	}
+	for _, f := range results.Findings {
+		if f.Kind != "Pod" {
+			t.Errorf("bare pod findings should have Kind=Pod, got %q", f.Kind)
+		}
+	}
+}
+
+func TestOwnedPodNotChecked(t *testing.T) {
+	input := &CheckInput{
+		Pods: []*corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "owned-pod", Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{{Kind: "ReplicaSet", Name: "my-rs"}},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app", Image: "nginx"}},
+			},
+		}},
+	}
+
+	results := RunChecks(input)
+	for _, f := range results.Findings {
+		if f.Kind == "Pod" {
+			t.Error("owned pods should not produce findings (workload checks cover them)")
+		}
+	}
+}
+
+func TestImageTag(t *testing.T) {
+	tests := []struct {
+		image string
+		want  string
+	}{
+		{"nginx:1.25", "1.25"},
+		{"nginx:latest", "latest"},
+		{"nginx", ""},
+		{"gcr.io/project/image:v2", "v2"},
+		{"image@sha256:abc123", "sha256:abc123"},
+	}
+	for _, tt := range tests {
+		got := imageTag(tt.image)
+		if got != tt.want {
+			t.Errorf("imageTag(%q) = %q, want %q", tt.image, got, tt.want)
+		}
+	}
+}
+
+func TestDangerousCapabilities(t *testing.T) {
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "cap-app", Namespace: "default"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(1)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "cap"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  "app",
+							Image: "app:v1",
+							SecurityContext: &corev1.SecurityContext{
+								Capabilities: &corev1.Capabilities{
+									Add: []corev1.Capability{"SYS_ADMIN", "NET_BIND_SERVICE"},
+								},
+							},
+						}},
+					},
+				},
+			},
+		}},
+	}
+
+	results := RunChecks(input)
+	found := false
+	for _, f := range results.Findings {
+		if f.CheckID == "dangerousCapabilities" {
+			found = true
+			if f.Severity != SeverityDanger {
+				t.Errorf("dangerousCapabilities should be danger severity, got %q", f.Severity)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected dangerousCapabilities finding for SYS_ADMIN")
+	}
+}
+
+func TestMissingPDB(t *testing.T) {
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "multi-replica", Namespace: "default"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(3)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "multi"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: "app:v1"}}},
+				},
+			},
+		}},
+		PodDisruptionBudgets: []*policyv1.PodDisruptionBudget{}, // empty = listed but none exist
+	}
+
+	results := RunChecks(input)
+	found := false
+	for _, f := range results.Findings {
+		if f.CheckID == "missingPDB" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected missingPDB finding for multi-replica deployment without PDB")
+	}
+}
+
+func TestMissingPDB_CoveredByPDB(t *testing.T) {
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "covered", Namespace: "default"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(3)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "covered"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: "app:v1"}}},
+				},
+			},
+		}},
+		PodDisruptionBudgets: []*policyv1.PodDisruptionBudget{{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-pdb", Namespace: "default"},
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				MinAvailable: &intstr.IntOrString{IntVal: 2},
+				Selector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "covered"}},
+			},
+		}},
+	}
+
+	results := RunChecks(input)
+	for _, f := range results.Findings {
+		if f.CheckID == "missingPDB" {
+			t.Error("missingPDB should not fire when PDB covers the deployment")
+		}
+	}
+}
+
+func TestMissingPDB_CrossNamespaceNotCovered(t *testing.T) {
+	// PDB in namespace "monitoring" should NOT suppress findings for
+	// a Deployment in namespace "production" even if labels match.
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "prod-app", Namespace: "production"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(3)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: "app:v1"}}},
+				},
+			},
+		}},
+		PodDisruptionBudgets: []*policyv1.PodDisruptionBudget{{
+			ObjectMeta: metav1.ObjectMeta{Name: "wrong-ns-pdb", Namespace: "monitoring"},
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				MinAvailable: &intstr.IntOrString{IntVal: 2},
+				Selector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+			},
+		}},
+	}
+
+	results := RunChecks(input)
+	found := false
+	for _, f := range results.Findings {
+		if f.CheckID == "missingPDB" && f.Namespace == "production" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected missingPDB finding — PDB in different namespace should not cover the deployment")
+	}
+}
+
+func TestGroupByResource_SortingAndCounts(t *testing.T) {
+	findings := []Finding{
+		{Kind: "Deployment", Namespace: "default", Name: "app-a", CheckID: "cpuLimitMissing", Category: CategoryEfficiency, Severity: SeverityWarning, Message: "no cpu limit"},
+		{Kind: "Deployment", Namespace: "default", Name: "app-b", CheckID: "runAsRoot", Category: CategorySecurity, Severity: SeverityDanger, Message: "runs as root"},
+		{Kind: "Deployment", Namespace: "default", Name: "app-b", CheckID: "cpuLimitMissing", Category: CategoryEfficiency, Severity: SeverityWarning, Message: "no cpu limit"},
+		{Kind: "Deployment", Namespace: "default", Name: "app-c", CheckID: "cpuLimitMissing", Category: CategoryEfficiency, Severity: SeverityWarning, Message: "no cpu limit"},
+		{Kind: "Deployment", Namespace: "default", Name: "app-c", CheckID: "memoryLimitMissing", Category: CategoryEfficiency, Severity: SeverityWarning, Message: "no mem limit"},
+	}
+
+	groups := GroupByResource(findings)
+
+	if len(groups) != 3 {
+		t.Fatalf("expected 3 groups, got %d", len(groups))
+	}
+
+	// app-b has 1 danger → should be first
+	if groups[0].Name != "app-b" {
+		t.Errorf("expected first group to be app-b (has danger), got %s", groups[0].Name)
+	}
+	if groups[0].Danger != 1 || groups[0].Warning != 1 {
+		t.Errorf("app-b: expected 1 danger + 1 warning, got %d danger + %d warning", groups[0].Danger, groups[0].Warning)
+	}
+
+	// app-c has 2 warnings → should be before app-a (1 warning)
+	if groups[1].Name != "app-c" {
+		t.Errorf("expected second group to be app-c (2 warnings), got %s", groups[1].Name)
+	}
+	if groups[1].Warning != 2 {
+		t.Errorf("app-c: expected 2 warnings, got %d", groups[1].Warning)
+	}
+
+	// app-a has 1 warning → last
+	if groups[2].Name != "app-a" {
+		t.Errorf("expected third group to be app-a (1 warning), got %s", groups[2].Name)
+	}
+}
+
+func TestGroupByResource_Empty(t *testing.T) {
+	groups := GroupByResource(nil)
+	if len(groups) != 0 {
+		t.Errorf("expected 0 groups for nil input, got %d", len(groups))
+	}
+}
+
+func TestBuildResults_MergesMultiContainerFindings(t *testing.T) {
+	// Two containers in the same deployment both lack probes
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "multi", Namespace: "default"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(1)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "multi"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						AutomountServiceAccountToken: ptr(false),
+						Containers: []corev1.Container{
+							{
+								Name: "app", Image: "app:v1",
+								SecurityContext: &corev1.SecurityContext{
+									RunAsNonRoot: ptr(true), ReadOnlyRootFilesystem: ptr(true), AllowPrivilegeEscalation: ptr(false),
+								},
+							},
+							{
+								Name: "sidecar", Image: "sidecar:v1",
+								SecurityContext: &corev1.SecurityContext{
+									RunAsNonRoot: ptr(true), ReadOnlyRootFilesystem: ptr(true), AllowPrivilegeEscalation: ptr(false),
+								},
+							},
+						},
+					},
+				},
+			},
+		}},
+	}
+
+	results := RunChecks(input)
+
+	// Both containers lack probes — should be merged into one finding per checkID
+	probeFindings := 0
+	for _, f := range results.Findings {
+		if f.CheckID == "readinessProbeMissing" {
+			probeFindings++
+			// Merged message should mention both containers
+			if !contains(f.Message, "app") || !contains(f.Message, "sidecar") {
+				t.Errorf("merged readinessProbeMissing should mention both containers, got: %s", f.Message)
+			}
+		}
+	}
+	if probeFindings != 1 {
+		t.Errorf("expected 1 merged readinessProbeMissing finding, got %d", probeFindings)
+	}
+}
+
+func TestRegistryCompleteness(t *testing.T) {
+	// Create a maximally-insecure input that triggers every check
+	input := &CheckInput{
+		Pods: []*corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{Name: "bare", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				HostNetwork: true, HostPID: true, HostIPC: true,
+				Containers: []corev1.Container{{
+					Name: "c", Image: "nginx",
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: ptr(true),
+						Capabilities: &corev1.Capabilities{
+							Add: []corev1.Capability{"SYS_ADMIN"},
+						},
+					},
+				}},
+			},
+		}},
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "deploy", Namespace: "default"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(3)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "d"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "c", Image: "nginx:latest"}},
+					},
+				},
+			},
+		}},
+		Services: []*corev1.Service{{
+			ObjectMeta: metav1.ObjectMeta{Name: "orphan", Namespace: "default"},
+			Spec:       corev1.ServiceSpec{Selector: map[string]string{"app": "nope"}},
+		}},
+		Ingresses: []*networkingv1.Ingress{{
+			ObjectMeta: metav1.ObjectMeta{Name: "bad-ing", Namespace: "default"},
+			Spec: networkingv1.IngressSpec{
+				Rules: []networkingv1.IngressRule{{
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{{
+								Backend: networkingv1.IngressBackend{
+									Service: &networkingv1.IngressServiceBackend{Name: "missing"},
+								},
+							}},
+						},
+					},
+				}},
+			},
+		}},
+	}
+
+	results := RunChecks(input)
+
+	// Every checkID that fired must have a registry entry
+	seen := make(map[string]bool)
+	for _, f := range results.Findings {
+		seen[f.CheckID] = true
+	}
+	for checkID := range seen {
+		if _, ok := CheckRegistry[checkID]; !ok {
+			t.Errorf("checkID %q has no entry in CheckRegistry", checkID)
+		}
+	}
+
+	// Verify the Checks map in results is populated
+	for checkID := range seen {
+		if _, ok := results.Checks[checkID]; !ok {
+			t.Errorf("checkID %q missing from results.Checks map", checkID)
+		}
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
+}
+
+func containsStr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+// ============================================================================
+// New check tests
+// ============================================================================
+
+func TestInsecureCapabilities(t *testing.T) {
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "cap-test", Namespace: "default"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(1)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "cap"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						AutomountServiceAccountToken: ptr(false),
+						Containers: []corev1.Container{{
+							Name: "app", Image: "app:v1",
+							SecurityContext: &corev1.SecurityContext{
+								RunAsNonRoot: ptr(true), ReadOnlyRootFilesystem: ptr(true), AllowPrivilegeEscalation: ptr(false),
+								Capabilities: &corev1.Capabilities{
+									Add: []corev1.Capability{"NET_RAW", "SYS_PTRACE", "NET_BIND_SERVICE"},
+								},
+							},
+						}},
+					},
+				},
+			},
+		}},
+	}
+
+	results := RunChecks(input)
+	checks := map[string]bool{}
+	for _, f := range results.Findings {
+		checks[f.CheckID] = true
+	}
+
+	if !checks["insecureCapabilities"] {
+		t.Error("expected insecureCapabilities finding for NET_RAW/SYS_PTRACE")
+	}
+	// NET_BIND_SERVICE should NOT be flagged
+	for _, f := range results.Findings {
+		if f.CheckID == "insecureCapabilities" && containsStr(f.Message, "NET_BIND_SERVICE") {
+			t.Error("NET_BIND_SERVICE should not be flagged as insecure")
+		}
+	}
+	// dangerousCapabilities should NOT fire (no SYS_ADMIN/NET_ADMIN/ALL)
+	if checks["dangerousCapabilities"] {
+		t.Error("dangerousCapabilities should not fire for NET_RAW/SYS_PTRACE")
+	}
+}
+
+func TestMissingTopologySpread(t *testing.T) {
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "no-spread", Namespace: "default"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(3)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "ns"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: "app:v1"}}},
+				},
+			},
+		}},
+	}
+
+	results := RunChecks(input)
+	found := false
+	for _, f := range results.Findings {
+		if f.CheckID == "missingTopologySpread" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected missingTopologySpread for 3-replica deployment without constraints")
+	}
+}
+
+func TestMissingTopologySpread_SingleReplica(t *testing.T) {
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "single", Namespace: "default"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(1)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "s"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: "app:v1"}}},
+				},
+			},
+		}},
+	}
+
+	results := RunChecks(input)
+	for _, f := range results.Findings {
+		if f.CheckID == "missingTopologySpread" {
+			t.Error("missingTopologySpread should not fire for single-replica deployment")
+		}
+	}
+}
+
+func TestPodHARisk(t *testing.T) {
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(3)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: "app:v1"}}},
+				},
+			},
+		}},
+		Pods: []*corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "web-1", Namespace: "default", Labels: map[string]string{"app": "web"}}, Spec: corev1.PodSpec{NodeName: "node-1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "web-2", Namespace: "default", Labels: map[string]string{"app": "web"}}, Spec: corev1.PodSpec{NodeName: "node-1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "web-3", Namespace: "default", Labels: map[string]string{"app": "web"}}, Spec: corev1.PodSpec{NodeName: "node-1"}},
+		},
+	}
+
+	results := RunChecks(input)
+	found := false
+	for _, f := range results.Findings {
+		if f.CheckID == "podHARisk" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected podHARisk when all 3 pods are on the same node")
+	}
+}
+
+func TestPodHARisk_Distributed(t *testing.T) {
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(2)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: "app:v1"}}},
+				},
+			},
+		}},
+		Pods: []*corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "web-1", Namespace: "default", Labels: map[string]string{"app": "web"}}, Spec: corev1.PodSpec{NodeName: "node-1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "web-2", Namespace: "default", Labels: map[string]string{"app": "web"}}, Spec: corev1.PodSpec{NodeName: "node-2"}},
+		},
+	}
+
+	results := RunChecks(input)
+	for _, f := range results.Findings {
+		if f.CheckID == "podHARisk" {
+			t.Error("podHARisk should not fire when pods are on different nodes")
+		}
+	}
+}
+
+func TestOrphanConfigMapSecret(t *testing.T) {
+	input := &CheckInput{
+		Pods: []*corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "app", Image: "app:v1",
+					Env: []corev1.EnvVar{{
+						Name: "DB_URL",
+						ValueFrom: &corev1.EnvVarSource{
+							ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "app-config"},
+							},
+						},
+					}},
+				}},
+			},
+		}},
+		ConfigMaps: []*corev1.ConfigMap{
+			{ObjectMeta: metav1.ObjectMeta{Name: "app-config", Namespace: "default"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "orphan-config", Namespace: "default"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "kube-root-ca.crt", Namespace: "default"}}, // system — should be skipped
+		},
+		Secrets: []*corev1.Secret{
+			{ObjectMeta: metav1.ObjectMeta{Name: "orphan-secret", Namespace: "default"}, Type: corev1.SecretTypeOpaque},
+			{ObjectMeta: metav1.ObjectMeta{Name: "sa-token", Namespace: "default"}, Type: corev1.SecretTypeServiceAccountToken}, // should be skipped
+		},
+	}
+
+	results := RunChecks(input)
+	orphans := map[string]bool{}
+	for _, f := range results.Findings {
+		if f.CheckID == "orphanConfigMapSecret" {
+			orphans[f.Name] = true
+		}
+	}
+
+	if !orphans["orphan-config"] {
+		t.Error("expected orphan finding for orphan-config")
+	}
+	if !orphans["orphan-secret"] {
+		t.Error("expected orphan finding for orphan-secret")
+	}
+	if orphans["app-config"] {
+		t.Error("app-config is referenced, should not be flagged as orphan")
+	}
+	if orphans["kube-root-ca.crt"] {
+		t.Error("kube-root-ca.crt should be skipped")
+	}
+	if orphans["sa-token"] {
+		t.Error("service account token secrets should be skipped")
+	}
+}
+
+func TestDeprecatedAPIVersion(t *testing.T) {
+	input := &CheckInput{
+		ClusterVersion: "1.30",
+		ServedAPIs: []string{
+			"apps/v1",                    // stable — should not flag
+			"batch/v1beta1",              // deprecated, removed in 1.25 — should flag
+			"policy/v1beta1",             // deprecated, removed in 1.25 — should flag
+			"networking.k8s.io/v1",       // stable — should not flag
+		},
+	}
+
+	results := RunChecks(input)
+	deprecated := 0
+	for _, f := range results.Findings {
+		if f.CheckID == "deprecatedAPIVersion" {
+			deprecated++
+		}
+	}
+	// batch/v1beta1 has CronJob, policy/v1beta1 has PDB + PSP = at least 3 entries
+	if deprecated < 3 {
+		t.Errorf("expected at least 3 deprecatedAPIVersion findings, got %d", deprecated)
+	}
+}
+
+func TestDeprecatedAPIVersion_NoServedAPIs(t *testing.T) {
+	input := &CheckInput{
+		ClusterVersion: "1.30",
+		// No ServedAPIs — check should be skipped
+	}
+	results := RunChecks(input)
+	for _, f := range results.Findings {
+		if f.CheckID == "deprecatedAPIVersion" {
+			t.Error("deprecatedAPIVersion should not fire when ServedAPIs is empty")
+		}
+	}
+}
+
+func TestResourceUtilization(t *testing.T) {
+	input := &CheckInput{
+		PodMetrics: []PodMetricsInput{
+			{Namespace: "default", Name: "waste-pod", CPUUsage: 5, CPURequest: 1000, MemoryUsage: 10 * 1024 * 1024, MemoryRequest: 512 * 1024 * 1024},       // 0.5% CPU, 2% memory — waste
+			{Namespace: "default", Name: "hot-pod", CPUUsage: 950, CPURequest: 1000, MemoryUsage: 480 * 1024 * 1024, MemoryRequest: 512 * 1024 * 1024},        // 95% CPU, 94% memory — risk
+			{Namespace: "default", Name: "normal-pod", CPUUsage: 500, CPURequest: 1000, MemoryUsage: 256 * 1024 * 1024, MemoryRequest: 512 * 1024 * 1024},     // 50% — fine
+			{Namespace: "default", Name: "no-request-pod", CPUUsage: 100, CPURequest: 0, MemoryUsage: 128 * 1024 * 1024, MemoryRequest: 0},                     // no requests — skip
+		},
+	}
+
+	results := RunChecks(input)
+	pods := map[string]int{} // pod name → finding count
+	for _, f := range results.Findings {
+		if f.CheckID == "resourceUtilization" {
+			pods[f.Name]++
+		}
+	}
+
+	if pods["waste-pod"] < 1 {
+		t.Error("expected utilization finding for waste-pod (under-utilized)")
+	}
+	if pods["hot-pod"] < 1 {
+		t.Error("expected utilization finding for hot-pod (over-utilized)")
+	}
+	if pods["normal-pod"] > 0 {
+		t.Error("normal-pod at 50% utilization should not be flagged")
+	}
+	if pods["no-request-pod"] > 0 {
+		t.Error("pod with no requests should not be flagged")
+	}
+}
+
+func TestResourceUtilization_Empty(t *testing.T) {
+	input := &CheckInput{}
+	results := RunChecks(input)
+	for _, f := range results.Findings {
+		if f.CheckID == "resourceUtilization" {
+			t.Error("resourceUtilization should not fire when no metrics provided")
+		}
+	}
+}
+
+func TestDockerSocketMount(t *testing.T) {
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "ci-runner", Namespace: "default"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(1)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "ci"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						AutomountServiceAccountToken: ptr(false),
+						Containers: []corev1.Container{{
+							Name: "runner", Image: "runner:v1",
+							SecurityContext: &corev1.SecurityContext{RunAsNonRoot: ptr(true), ReadOnlyRootFilesystem: ptr(true), AllowPrivilegeEscalation: ptr(false)},
+						}},
+						Volumes: []corev1.Volume{{
+							Name:         "docker-sock",
+							VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/run/docker.sock"}},
+						}},
+					},
+				},
+			},
+		}},
+	}
+
+	results := RunChecks(input)
+	found := false
+	for _, f := range results.Findings {
+		if f.CheckID == "dockerSocketMount" {
+			found = true
+			if f.Severity != SeverityDanger {
+				t.Errorf("dockerSocketMount should be danger, got %s", f.Severity)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected dockerSocketMount finding for /var/run/docker.sock volume")
+	}
+}
+
+func TestSensitiveHostPath(t *testing.T) {
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "logger", Namespace: "default"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(1)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "log"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						AutomountServiceAccountToken: ptr(false),
+						Containers: []corev1.Container{{
+							Name: "log", Image: "log:v1",
+							SecurityContext: &corev1.SecurityContext{RunAsNonRoot: ptr(true), ReadOnlyRootFilesystem: ptr(true), AllowPrivilegeEscalation: ptr(false)},
+						}},
+						Volumes: []corev1.Volume{
+							{Name: "host-etc", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/etc"}}},
+							{Name: "app-data", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/data/app"}}},
+						},
+					},
+				},
+			},
+		}},
+	}
+
+	results := RunChecks(input)
+	checks := map[string]bool{}
+	for _, f := range results.Findings {
+		if f.CheckID == "sensitiveHostPath" {
+			checks[f.Message] = true
+		}
+	}
+
+	// /etc should be flagged
+	foundEtc := false
+	for msg := range checks {
+		if containsStr(msg, "/etc") {
+			foundEtc = true
+		}
+	}
+	if !foundEtc {
+		t.Error("expected sensitiveHostPath finding for /etc")
+	}
+
+	// /data/app should NOT be flagged
+	for msg := range checks {
+		if containsStr(msg, "/data") {
+			t.Error("/data/app should not be flagged as sensitive host path")
+		}
+	}
+}
+
+func TestSecretInConfigMap(t *testing.T) {
+	input := &CheckInput{
+		ConfigMaps: []*corev1.ConfigMap{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "app-config", Namespace: "default"},
+				Data:       map[string]string{"app_name": "myapp", "log_level": "info"},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "db-config", Namespace: "default"},
+				Data:       map[string]string{"db_host": "postgres", "db_password": "hunter2"},
+			},
+		},
+	}
+
+	results := RunChecks(input)
+	found := map[string]bool{}
+	for _, f := range results.Findings {
+		if f.CheckID == "secretInConfigMap" {
+			found[f.Name] = true
+		}
+	}
+
+	if !found["db-config"] {
+		t.Error("expected secretInConfigMap finding for db-config (has db_password key)")
+	}
+	if found["app-config"] {
+		t.Error("app-config should not be flagged (no sensitive keys)")
+	}
+}

--- a/pkg/audit/deprecations.go
+++ b/pkg/audit/deprecations.go
@@ -1,0 +1,59 @@
+package audit
+
+// DeprecationEntry describes a deprecated Kubernetes API version.
+type DeprecationEntry struct {
+	// GroupVersion is the deprecated API group/version (e.g. "extensions/v1beta1").
+	GroupVersion string
+	// Kind is the resource kind affected (empty = all kinds in this GV).
+	Kind string
+	// DeprecatedIn is the K8s version where this was deprecated (e.g. "1.14").
+	DeprecatedIn string
+	// RemovedIn is the K8s version where this was removed (e.g. "1.22").
+	RemovedIn string
+	// Replacement is the stable API to use instead (e.g. "networking.k8s.io/v1").
+	Replacement string
+}
+
+// DeprecationTable contains known deprecated K8s APIs from 1.16 through 1.32.
+// Sources: https://kubernetes.io/docs/reference/using-api/deprecation-guide/
+var DeprecationTable = []DeprecationEntry{
+	// ── Removed in 1.22 ───────────────────────────────────────────────
+	{GroupVersion: "extensions/v1beta1", Kind: "Ingress", DeprecatedIn: "1.14", RemovedIn: "1.22", Replacement: "networking.k8s.io/v1"},
+	{GroupVersion: "networking.k8s.io/v1beta1", Kind: "Ingress", DeprecatedIn: "1.19", RemovedIn: "1.22", Replacement: "networking.k8s.io/v1"},
+	{GroupVersion: "networking.k8s.io/v1beta1", Kind: "IngressClass", DeprecatedIn: "1.19", RemovedIn: "1.22", Replacement: "networking.k8s.io/v1"},
+	{GroupVersion: "rbac.authorization.k8s.io/v1beta1", Kind: "", DeprecatedIn: "1.17", RemovedIn: "1.22", Replacement: "rbac.authorization.k8s.io/v1"},
+	{GroupVersion: "coordination.k8s.io/v1beta1", Kind: "Lease", DeprecatedIn: "1.19", RemovedIn: "1.22", Replacement: "coordination.k8s.io/v1"},
+	{GroupVersion: "extensions/v1beta1", Kind: "DaemonSet", DeprecatedIn: "1.14", RemovedIn: "1.22", Replacement: "apps/v1"},
+	{GroupVersion: "extensions/v1beta1", Kind: "Deployment", DeprecatedIn: "1.14", RemovedIn: "1.22", Replacement: "apps/v1"},
+	{GroupVersion: "extensions/v1beta1", Kind: "ReplicaSet", DeprecatedIn: "1.14", RemovedIn: "1.22", Replacement: "apps/v1"},
+
+	// ── Removed in 1.25 ───────────────────────────────────────────────
+	{GroupVersion: "batch/v1beta1", Kind: "CronJob", DeprecatedIn: "1.21", RemovedIn: "1.25", Replacement: "batch/v1"},
+	{GroupVersion: "discovery.k8s.io/v1beta1", Kind: "EndpointSlice", DeprecatedIn: "1.21", RemovedIn: "1.25", Replacement: "discovery.k8s.io/v1"},
+	{GroupVersion: "events.k8s.io/v1beta1", Kind: "Event", DeprecatedIn: "1.21", RemovedIn: "1.25", Replacement: "events.k8s.io/v1"},
+	{GroupVersion: "policy/v1beta1", Kind: "PodDisruptionBudget", DeprecatedIn: "1.21", RemovedIn: "1.25", Replacement: "policy/v1"},
+	{GroupVersion: "policy/v1beta1", Kind: "PodSecurityPolicy", DeprecatedIn: "1.21", RemovedIn: "1.25", Replacement: "(removed, use Pod Security Admission)"},
+	{GroupVersion: "node.k8s.io/v1beta1", Kind: "RuntimeClass", DeprecatedIn: "1.22", RemovedIn: "1.25", Replacement: "node.k8s.io/v1"},
+
+	// ── Removed in 1.26 ───────────────────────────────────────────────
+	{GroupVersion: "autoscaling/v2beta2", Kind: "HorizontalPodAutoscaler", DeprecatedIn: "1.23", RemovedIn: "1.26", Replacement: "autoscaling/v2"},
+	{GroupVersion: "flowcontrol.apiserver.k8s.io/v1beta1", Kind: "", DeprecatedIn: "1.23", RemovedIn: "1.26", Replacement: "flowcontrol.apiserver.k8s.io/v1beta3"},
+
+	// ── Removed in 1.27 ───────────────────────────────────────────────
+	{GroupVersion: "storage.k8s.io/v1beta1", Kind: "CSIStorageCapacity", DeprecatedIn: "1.24", RemovedIn: "1.27", Replacement: "storage.k8s.io/v1"},
+
+	// ── Removed in 1.29 ───────────────────────────────────────────────
+	{GroupVersion: "flowcontrol.apiserver.k8s.io/v1beta2", Kind: "", DeprecatedIn: "1.26", RemovedIn: "1.29", Replacement: "flowcontrol.apiserver.k8s.io/v1"},
+
+	// ── Removed in 1.32 ───────────────────────────────────────────────
+	{GroupVersion: "flowcontrol.apiserver.k8s.io/v1beta3", Kind: "", DeprecatedIn: "1.29", RemovedIn: "1.32", Replacement: "flowcontrol.apiserver.k8s.io/v1"},
+}
+
+// DeprecationsByGroupVersion indexes the deprecation table by group/version for fast lookup.
+func DeprecationsByGroupVersion() map[string][]DeprecationEntry {
+	m := make(map[string][]DeprecationEntry)
+	for _, d := range DeprecationTable {
+		m[d.GroupVersion] = append(m[d.GroupVersion], d)
+	}
+	return m
+}

--- a/pkg/audit/helpers.go
+++ b/pkg/audit/helpers.go
@@ -1,0 +1,142 @@
+package audit
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ResourceKey returns the index key for a resource: "Kind/namespace/name".
+func ResourceKey(kind, namespace, name string) string {
+	if namespace == "" {
+		return fmt.Sprintf("%s//%s", kind, name)
+	}
+	return fmt.Sprintf("%s/%s/%s", kind, namespace, name)
+}
+
+// IndexByResource builds a lookup map from ResourceKey → []Finding.
+func IndexByResource(findings []Finding) map[string][]Finding {
+	m := make(map[string][]Finding)
+	for _, f := range findings {
+		key := ResourceKey(f.Kind, f.Namespace, f.Name)
+		m[key] = append(m[key], f)
+	}
+	return m
+}
+
+// GroupByResource aggregates findings into per-resource groups,
+// sorted by severity (most danger first), then by name.
+func GroupByResource(findings []Finding) []ResourceGroup {
+	index := IndexByResource(findings)
+
+	groups := make([]ResourceGroup, 0, len(index))
+	for _, fs := range index {
+		g := ResourceGroup{
+			Kind:      fs[0].Kind,
+			Namespace: fs[0].Namespace,
+			Name:      fs[0].Name,
+			Findings:  fs,
+		}
+		for _, f := range fs {
+			switch f.Severity {
+			case SeverityDanger:
+				g.Danger++
+			case SeverityWarning:
+				g.Warning++
+			}
+		}
+		groups = append(groups, g)
+	}
+
+	sort.Slice(groups, func(i, j int) bool {
+		if groups[i].Danger != groups[j].Danger {
+			return groups[i].Danger > groups[j].Danger
+		}
+		if groups[i].Warning != groups[j].Warning {
+			return groups[i].Warning > groups[j].Warning
+		}
+		return ResourceKey(groups[i].Kind, groups[i].Namespace, groups[i].Name) <
+			ResourceKey(groups[j].Kind, groups[j].Namespace, groups[j].Name)
+	})
+
+	return groups
+}
+
+// ApplySettings filters audit results based on ignored namespaces (with wildcard
+// patterns like *-system) and disabled checks. This is the shared implementation
+// used by all consumers (HTTP handlers, MCP, skyhook-connector).
+func ApplySettings(results *ScanResults, ignoredNamespaces, disabledChecks []string) *ScanResults {
+	if results == nil || (len(ignoredNamespaces) == 0 && len(disabledChecks) == 0) {
+		return results
+	}
+
+	ignoreNS := make(map[string]bool, len(ignoredNamespaces))
+	var ignorePatterns []string
+	for _, ns := range ignoredNamespaces {
+		if strings.HasPrefix(ns, "*") || strings.HasSuffix(ns, "*") {
+			ignorePatterns = append(ignorePatterns, ns)
+		} else {
+			ignoreNS[ns] = true
+		}
+	}
+	disabled := make(map[string]bool, len(disabledChecks))
+	for _, c := range disabledChecks {
+		disabled[c] = true
+	}
+
+	matchesIgnoredNS := func(ns string) bool {
+		if ignoreNS[ns] {
+			return true
+		}
+		for _, p := range ignorePatterns {
+			if strings.HasSuffix(p, "*") && strings.HasPrefix(ns, p[:len(p)-1]) {
+				return true
+			}
+			if strings.HasPrefix(p, "*") && strings.HasSuffix(ns, p[1:]) {
+				return true
+			}
+		}
+		return false
+	}
+
+	var filtered []Finding
+	for _, f := range results.Findings {
+		if matchesIgnoredNS(f.Namespace) || disabled[f.CheckID] {
+			continue
+		}
+		filtered = append(filtered, f)
+	}
+
+	// Rebuild groups and summary
+	groups := GroupByResource(filtered)
+	categories := map[string]CategorySummary{}
+	for _, cat := range []string{CategorySecurity, CategoryReliability, CategoryEfficiency} {
+		categories[cat] = CategorySummary{}
+	}
+	for _, f := range filtered {
+		cs := categories[f.Category]
+		switch f.Severity {
+		case SeverityWarning:
+			cs.Warning++
+		case SeverityDanger:
+			cs.Danger++
+		}
+		categories[f.Category] = cs
+	}
+	totalWarning, totalDanger := 0, 0
+	for _, cs := range categories {
+		totalWarning += cs.Warning
+		totalDanger += cs.Danger
+	}
+
+	return &ScanResults{
+		Summary: ScanSummary{
+			Warning:    totalWarning,
+			Danger:     totalDanger,
+			Categories: categories,
+		},
+		Findings: filtered,
+		Groups:   groups,
+		Checks:   results.Checks,
+	}
+}

--- a/pkg/audit/registry.go
+++ b/pkg/audit/registry.go
@@ -1,0 +1,225 @@
+package audit
+
+// CheckMeta provides human-readable context for a best-practice check.
+type CheckMeta struct {
+	ID          string   `json:"id"`
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Remediation string   `json:"remediation"`
+	Frameworks  []string `json:"frameworks,omitempty"`
+}
+
+// Framework constants
+const (
+	FrameworkNSACISA = "NSA/CISA"
+	FrameworkCIS     = "CIS"
+)
+
+// CheckRegistry maps checkID → metadata for all built-in checks.
+var CheckRegistry = map[string]CheckMeta{
+	// ── Security ──────────────────────────────────────────────────────
+	"runAsRoot": {
+		ID:          "runAsRoot",
+		Title:       "Run as non-root",
+		Description: "Containers running as root have full access to the host filesystem. If compromised, an attacker gains root-level access.",
+		Remediation: "Set securityContext.runAsNonRoot: true and runAsUser: 1000 (or higher) on the container or pod spec.",
+		Frameworks:  []string{FrameworkNSACISA, FrameworkCIS},
+	},
+	"privileged": {
+		ID:          "privileged",
+		Title:       "Privileged container",
+		Description: "Privileged containers have all host capabilities, bypassing container isolation. An attacker in a privileged container can compromise the entire node.",
+		Remediation: "Set securityContext.privileged: false on the container.",
+		Frameworks:  []string{FrameworkNSACISA, FrameworkCIS},
+	},
+	"privilegeEscalation": {
+		ID:          "privilegeEscalation",
+		Title:       "Privilege escalation",
+		Description: "Allows a process to gain more privileges than its parent. Attackers can exploit this to escalate from container to host.",
+		Remediation: "Set securityContext.allowPrivilegeEscalation: false on the container.",
+		Frameworks:  []string{FrameworkNSACISA, FrameworkCIS},
+	},
+	"readOnlyRootFs": {
+		ID:          "readOnlyRootFs",
+		Title:       "Read-only root filesystem",
+		Description: "A writable root filesystem allows attackers to modify binaries, install tools, or tamper with the application.",
+		Remediation: "Set securityContext.readOnlyRootFilesystem: true. Use emptyDir volumes for writable paths.",
+		Frameworks:  []string{FrameworkNSACISA},
+	},
+	"dangerousCapabilities": {
+		ID:          "dangerousCapabilities",
+		Title:       "Dangerous capabilities",
+		Description: "Capabilities like SYS_ADMIN, NET_ADMIN, and ALL grant near-root powers and can be used to escape the container.",
+		Remediation: "Remove dangerous capabilities from securityContext.capabilities.add. Drop all and add only what is needed.",
+		Frameworks:  []string{FrameworkNSACISA, FrameworkCIS},
+	},
+	"dockerSocketMount": {
+		ID:          "dockerSocketMount",
+		Title:       "Container runtime socket mounted",
+		Description: "Mounting the Docker/containerd socket gives the container full control over the host's container runtime — equivalent to root access. This is a documented attack vector used in cryptojacking campaigns.",
+		Remediation: "Remove the hostPath volume mounting the container runtime socket. If CI/CD needs Docker access, use Docker-in-Docker (DinD) or Kaniko instead.",
+		Frameworks:  []string{FrameworkNSACISA, FrameworkCIS},
+	},
+	"sensitiveHostPath": {
+		ID:          "sensitiveHostPath",
+		Title:       "Sensitive host path mounted",
+		Description: "Mounting sensitive host directories (/etc, /proc, /sys, /var/run) exposes host configuration, credentials, and runtime state to the container. Attackers can use this to escalate privileges or access other containers.",
+		Remediation: "Remove the hostPath volume or restrict it to a specific, non-sensitive directory. Use emptyDir or PVC for writable storage.",
+		Frameworks:  []string{FrameworkNSACISA, FrameworkCIS},
+	},
+	"secretInConfigMap": {
+		ID:          "secretInConfigMap",
+		Title:       "Potential secret in ConfigMap",
+		Description: "ConfigMap keys with names suggesting sensitive data (passwords, tokens, keys) should use Kubernetes Secrets instead. ConfigMaps are not encrypted at rest and may appear in logs and kubectl output.",
+		Remediation: "Move sensitive data to a Secret resource. ConfigMaps should only contain non-sensitive configuration.",
+		Frameworks:  []string{FrameworkNSACISA},
+	},
+	"insecureCapabilities": {
+		ID:          "insecureCapabilities",
+		Title:       "Insecure capabilities",
+		Description: "Capabilities like NET_RAW, SYS_PTRACE, and MKNOD can be exploited for packet spoofing, process injection, or device manipulation.",
+		Remediation: "Remove insecure capabilities from securityContext.capabilities.add. Use capabilities.drop: [ALL] and add back only what is strictly needed.",
+		Frameworks:  []string{FrameworkNSACISA, FrameworkCIS},
+	},
+	"hostNetwork": {
+		ID:          "hostNetwork",
+		Title:       "Host network",
+		Description: "Sharing the host network namespace lets the container see all network traffic and access host network services.",
+		Remediation: "Remove hostNetwork: true unless the workload genuinely needs host network access.",
+		Frameworks:  []string{FrameworkNSACISA, FrameworkCIS},
+	},
+	"hostPID": {
+		ID:          "hostPID",
+		Title:       "Host PID namespace",
+		Description: "Sharing the host PID namespace lets the container see and signal all host processes, enabling process injection attacks.",
+		Remediation: "Remove hostPID: true from the pod spec.",
+		Frameworks:  []string{FrameworkNSACISA, FrameworkCIS},
+	},
+	"hostIPC": {
+		ID:          "hostIPC",
+		Title:       "Host IPC namespace",
+		Description: "Sharing the host IPC namespace allows access to shared memory and inter-process communication with host processes.",
+		Remediation: "Remove hostIPC: true from the pod spec.",
+		Frameworks:  []string{FrameworkNSACISA, FrameworkCIS},
+	},
+	"automountServiceAccountToken": {
+		ID:          "automountServiceAccountToken",
+		Title:       "Service account token auto-mount",
+		Description: "Auto-mounted tokens can be used by attackers to authenticate to the Kubernetes API server and escalate privileges.",
+		Remediation: "Set automountServiceAccountToken: false on the pod spec. Only enable for pods that need API access.",
+		Frameworks:  []string{FrameworkNSACISA},
+	},
+
+	// ── Reliability ───────────────────────────────────────────────────
+	"readinessProbeMissing": {
+		ID:          "readinessProbeMissing",
+		Title:       "Missing readiness probe",
+		Description: "Without a readiness probe, Kubernetes sends traffic to pods before they are ready, causing errors for users.",
+		Remediation: "Add a readinessProbe (HTTP GET, TCP, or exec) to each container.",
+	},
+	"livenessProbeMissing": {
+		ID:          "livenessProbeMissing",
+		Title:       "Missing liveness probe",
+		Description: "Without a liveness probe, Kubernetes cannot detect and restart containers that are stuck or deadlocked.",
+		Remediation: "Add a livenessProbe (HTTP GET, TCP, or exec) to each container.",
+	},
+	"imageTagLatest": {
+		ID:          "imageTagLatest",
+		Title:       "Image tag latest or missing",
+		Description: "Using 'latest' or no tag means deployments are not reproducible — you cannot tell which version is running, and rollbacks may not work.",
+		Remediation: "Pin images to a specific version tag (e.g., nginx:1.25.3).",
+	},
+	"pullPolicyNotAlways": {
+		ID:          "pullPolicyNotAlways",
+		Title:       "Pull policy not Always",
+		Description: "With a mutable tag and non-Always pull policy, nodes may run stale cached images, causing inconsistency across replicas.",
+		Remediation: "Set imagePullPolicy: Always when using mutable tags, or pin to immutable digests.",
+	},
+	"singleReplica": {
+		ID:          "singleReplica",
+		Title:       "Single replica",
+		Description: "A single-replica deployment has no redundancy — any pod disruption (node drain, OOM, crash) causes downtime.",
+		Remediation: "Set replicas: 2 or higher, or configure an HPA for autoscaling.",
+	},
+	"missingPDB": {
+		ID:          "missingPDB",
+		Title:       "Missing PodDisruptionBudget",
+		Description: "Without a PDB, cluster operations (node drains, upgrades) can take down all replicas simultaneously.",
+		Remediation: "Create a PodDisruptionBudget with minAvailable or maxUnavailable matching your availability requirements.",
+	},
+	"missingTopologySpread": {
+		ID:          "missingTopologySpread",
+		Title:       "Missing topology spread constraints",
+		Description: "Without topology spread constraints, all replicas can land on the same node or availability zone, giving an illusion of HA without real fault tolerance.",
+		Remediation: "Add topologySpreadConstraints to the pod template with topologyKey: kubernetes.io/hostname or topology.kubernetes.io/zone.",
+	},
+	"podHARisk": {
+		ID:          "podHARisk",
+		Title:       "All replicas on same node",
+		Description: "All pod replicas are scheduled on the same node. If that node fails, all replicas go down simultaneously — no actual high availability.",
+		Remediation: "Add pod anti-affinity or topology spread constraints to distribute replicas across nodes.",
+	},
+
+	// ── Efficiency ────────────────────────────────────────────────────
+	"cpuRequestMissing": {
+		ID:          "cpuRequestMissing",
+		Title:       "Missing CPU request",
+		Description: "Without CPU requests, the scheduler cannot make informed placement decisions, leading to overcommitted nodes and throttling.",
+		Remediation: "Set resources.requests.cpu (e.g., 100m) on each container.",
+		Frameworks:  []string{FrameworkCIS},
+	},
+	"memoryRequestMissing": {
+		ID:          "memoryRequestMissing",
+		Title:       "Missing memory request",
+		Description: "Without memory requests, pods may be scheduled on nodes without enough memory, causing OOM kills.",
+		Remediation: "Set resources.requests.memory (e.g., 128Mi) on each container.",
+		Frameworks:  []string{FrameworkCIS},
+	},
+	"cpuLimitMissing": {
+		ID:          "cpuLimitMissing",
+		Title:       "Missing CPU limit",
+		Description: "Without CPU limits, a single container can consume all CPU on a node, starving other workloads.",
+		Remediation: "Set resources.limits.cpu (e.g., 500m) on each container.",
+		Frameworks:  []string{FrameworkCIS},
+	},
+	"memoryLimitMissing": {
+		ID:          "memoryLimitMissing",
+		Title:       "Missing memory limit",
+		Description: "Without memory limits, a container can consume unbounded memory, eventually triggering kernel OOM kills on the node.",
+		Remediation: "Set resources.limits.memory (e.g., 512Mi) on each container.",
+		Frameworks:  []string{FrameworkCIS},
+	},
+	"resourceUtilization": {
+		ID:          "resourceUtilization",
+		Title:       "Resource utilization mismatch",
+		Description: "Pod resource usage is significantly different from its requests — either wasting resources (<10% used) or at risk of throttling/OOM (>90% used).",
+		Remediation: "Adjust resources.requests to match actual usage. Use metrics or VPA recommendations to right-size.",
+	},
+	"orphanConfigMapSecret": {
+		ID:          "orphanConfigMapSecret",
+		Title:       "Unused ConfigMap or Secret",
+		Description: "This ConfigMap or Secret is not referenced by any pod (env vars, volumes, or imagePullSecrets). It may be orphaned and safe to remove.",
+		Remediation: "Verify this resource is no longer needed and delete it, or add a reference from a pod spec if it should be in use.",
+	},
+
+	"deprecatedAPIVersion": {
+		ID:          "deprecatedAPIVersion",
+		Title:       "Deprecated API version",
+		Description: "This cluster still serves a deprecated API version. Resources using this API will break after a Kubernetes upgrade that removes it.",
+		Remediation: "Migrate resources to the replacement API version before upgrading the cluster.",
+	},
+
+	// ── Cross-resource ────────────────────────────────────────────────
+	"serviceNoMatchingPods": {
+		ID:          "serviceNoMatchingPods",
+		Title:       "Service has no matching pods",
+		Description: "The service selector does not match any running pods — traffic sent to this service will fail.",
+		Remediation: "Verify the service selector labels match the pod template labels on the target workload.",
+	},
+	"ingressNoMatchingService": {
+		ID:          "ingressNoMatchingService",
+		Title:       "Ingress references missing service",
+		Description: "The ingress backend references a service that does not exist, so incoming traffic will get 503 errors.",
+		Remediation: "Check the ingress spec and correct the service name, or create the missing service.",
+	},
+}

--- a/pkg/audit/types.go
+++ b/pkg/audit/types.go
@@ -1,0 +1,101 @@
+package audit
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
+)
+
+// CheckInput contains the typed K8s resources to check.
+// Each field is optional — checks are skipped for nil/empty slices.
+// Callers populate this from their own cache or API client.
+type CheckInput struct {
+	Pods                     []*corev1.Pod
+	Deployments              []*appsv1.Deployment
+	StatefulSets             []*appsv1.StatefulSet
+	DaemonSets               []*appsv1.DaemonSet
+	Services                 []*corev1.Service
+	Ingresses                []*networkingv1.Ingress
+	HorizontalPodAutoscalers []*autoscalingv2.HorizontalPodAutoscaler
+	PodDisruptionBudgets     []*policyv1.PodDisruptionBudget
+	ConfigMaps               []*corev1.ConfigMap
+	Secrets                  []*corev1.Secret
+	// ClusterVersion is the K8s server version (e.g. "1.30"). Used for deprecated API checks.
+	ClusterVersion string
+	// ServedAPIs lists API group/versions the cluster still serves (e.g. ["apps/v1", "batch/v1beta1"]).
+	// Used to detect deprecated APIs. Callers populate from discovery client.
+	ServedAPIs []string
+	// PodMetrics provides live CPU/memory usage for utilization checks.
+	// Optional — check is skipped when nil/empty. Callers populate from metrics-server or equivalent.
+	PodMetrics []PodMetricsInput
+}
+
+// PodMetricsInput provides metrics data for resource utilization checks.
+type PodMetricsInput struct {
+	Namespace     string
+	Name          string
+	CPUUsage      int64 // millicores
+	MemoryUsage   int64 // bytes
+	CPURequest    int64 // millicores
+	MemoryRequest int64 // bytes
+}
+
+// ScanResults is the output of RunChecks.
+type ScanResults struct {
+	Summary  ScanSummary          `json:"summary"`
+	Findings []Finding            `json:"findings"`
+	Groups   []ResourceGroup      `json:"groups"`
+	Checks   map[string]CheckMeta `json:"checks"`
+}
+
+// ResourceGroup aggregates findings for a single resource.
+// Groups are sorted by severity (danger first), then by name.
+type ResourceGroup struct {
+	Kind      string    `json:"kind"`
+	Namespace string    `json:"namespace"`
+	Name      string    `json:"name"`
+	Warning   int       `json:"warning"`
+	Danger    int       `json:"danger"`
+	Findings  []Finding `json:"findings"`
+}
+
+// ScanSummary provides aggregate counts.
+type ScanSummary struct {
+	Passing    int                        `json:"passing"`
+	Warning    int                        `json:"warning"`
+	Danger     int                        `json:"danger"`
+	Categories map[string]CategorySummary `json:"categories"`
+}
+
+// CategorySummary provides per-category counts.
+type CategorySummary struct {
+	Passing int `json:"passing"`
+	Warning int `json:"warning"`
+	Danger  int `json:"danger"`
+}
+
+// Finding represents a single best-practice violation.
+type Finding struct {
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	CheckID   string `json:"checkID"`
+	Category  string `json:"category"` // "Security", "Reliability", "Efficiency"
+	Severity  string `json:"severity"` // "warning" or "danger"
+	Message   string `json:"message"`
+}
+
+// Categories
+const (
+	CategorySecurity    = "Security"
+	CategoryReliability = "Reliability"
+	CategoryEfficiency  = "Efficiency"
+)
+
+// Severities
+const (
+	SeverityWarning = "warning"
+	SeverityDanger  = "danger"
+)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,6 +14,7 @@ import { WorkloadViewRoute } from './components/workload/WorkloadView'
 import { HelmView } from './components/helm/HelmView'
 import { TrafficView } from './components/traffic/TrafficView'
 import { CostView } from './components/cost/CostView'
+import { AuditView } from './components/audit/AuditView'
 import { HelmReleaseDrawer } from './components/helm/HelmReleaseDrawer'
 import { PortForwardManager, usePortForwardCount } from './components/portforward/PortForwardManager'
 import { DockProvider, BottomDock, useDock, useOpenLocalTerminal } from './components/dock'
@@ -91,7 +92,7 @@ function apiResourceToNodeIdPrefix(apiResource: string): string {
 }
 
 // Extended MainView type that includes traffic and cost
-type ExtendedMainView = MainView | 'traffic' | 'cost' | 'workload'
+type ExtendedMainView = MainView | 'traffic' | 'cost' | 'workload' | 'audit'
 
 // Extract view from URL path
 function getViewFromPath(pathname: string): ExtendedMainView {
@@ -104,6 +105,7 @@ function getViewFromPath(pathname: string): ExtendedMainView {
   if (path === 'traffic') return 'traffic'
   if (path === 'cost') return 'cost'
   if (path === 'workload') return 'workload'
+  if (path === 'audit') return 'audit'
   return 'home'
 }
 
@@ -1114,6 +1116,29 @@ function AppInner() {
         {/* Cost detail view */}
         {mainView === 'cost' && (
           <CostView onBack={() => setMainView('home')} />
+        )}
+
+        {/* Best practices detail view */}
+        {mainView === 'audit' && (
+          <AuditView
+            namespaces={namespaces}
+            onBack={() => setMainView('home')}
+            onNavigateToResource={(resource) => {
+              const pluralKind = kindToPlural(resource.kind)
+              setSelectedResource({ ...resource, kind: pluralKind })
+              const newParams = new URLSearchParams(searchParams)
+              newParams.delete('kind')
+              newParams.delete('mode')
+              newParams.delete('group')
+              newParams.delete('resource')
+              if (resource.group) {
+                newParams.set('apiGroup', resource.group)
+              } else {
+                newParams.delete('apiGroup')
+              }
+              navigate({ pathname: `/resources/${pluralKind}`, search: newParams.toString() })
+            }}
+          />
         )}
 
         {/* Workload full view (direct URL only — expand from drawer uses drawer's expanded state) */}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -210,6 +210,18 @@ export interface DashboardCRDCount {
   count: number
 }
 
+// Re-export shared types from k8s-ui — single source of truth
+import type { AuditCardData, AuditFinding, ResourceGroup, CheckMeta } from '@skyhook-io/k8s-ui'
+export type DashboardAudit = AuditCardData
+export type { AuditFinding, ResourceGroup, CheckMeta }
+
+export interface AuditResponse {
+  summary: DashboardAudit
+  findings: AuditFinding[]
+  groups: ResourceGroup[]
+  checks: Record<string, CheckMeta>
+}
+
 export interface DashboardCertificateHealth {
   total: number
   healthy: number
@@ -237,6 +249,7 @@ export interface DashboardResponse {
   metricsServerAvailable: boolean
   certificateHealth: DashboardCertificateHealth | null
   networkPolicyCoverage: DashboardNetworkPolicyCoverage | null
+  audit: DashboardAudit | null
   nodeVersionSkew: { versions: Record<string, string[]>; minVersion: string; maxVersion: string } | null
   deferredLoading?: boolean // True while deferred informers (secrets, events, etc.) are still syncing
   accessRestricted?: boolean // True when user has no namespace access (RBAC)
@@ -253,6 +266,66 @@ export function useDashboard(namespaces: string[] = []) {
     queryFn: () => fetchJSON(`/dashboard${params}`),
     staleTime: 15000, // 15 seconds
     refetchInterval: 30000, // Refresh every 30 seconds
+  })
+}
+
+// Best practices
+export function useAudit(namespaces: string[] = []) {
+  const params = namespaces.length > 0 ? `?namespaces=${namespaces.join(',')}` : ''
+  return useQuery<AuditResponse>({
+    queryKey: ['audit', namespaces],
+    queryFn: () => fetchJSON(`/audit${params}`),
+    staleTime: 30000,
+    refetchInterval: 60000,
+  })
+}
+
+export function useResourceAudit(kind: string, namespace: string, name: string) {
+  return useQuery<AuditFinding[]>({
+    queryKey: ['audit', 'resource', kind, namespace, name],
+    queryFn: () => fetchJSON(`/audit/resource/${kind}/${namespace}/${name}`),
+    staleTime: 30000,
+  })
+}
+
+// Audit settings
+export interface AuditSettings {
+  ignoredNamespaces: string[]
+  disabledChecks: string[]
+}
+
+export function useAuditSettings() {
+  return useQuery<AuditSettings>({
+    queryKey: ['audit-settings'],
+    queryFn: () => fetchJSON('/settings/audit'),
+    staleTime: 60000,
+  })
+}
+
+export function useUpdateAuditSettings() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (settings: AuditSettings) => {
+      const resp = await apiFetch(`${API_BASE}/settings/audit`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(settings),
+      })
+      if (!resp.ok) {
+        const body = await resp.json().catch(() => ({ error: 'Unknown error' }))
+        throw new Error(body.error || `HTTP ${resp.status}`)
+      }
+      return resp.json()
+    },
+    meta: {
+      errorMessage: 'Failed to save audit settings',
+      successMessage: 'Audit settings saved',
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['audit-settings'] })
+      queryClient.invalidateQueries({ queryKey: ['audit'] })
+      queryClient.invalidateQueries({ queryKey: ['dashboard'] })
+    },
   })
 }
 

--- a/web/src/components/audit/AuditSettingsDialog.tsx
+++ b/web/src/components/audit/AuditSettingsDialog.tsx
@@ -1,0 +1,162 @@
+import { useState, useEffect } from 'react'
+import { X, Plus, Trash2 } from 'lucide-react'
+import { useAuditSettings, useUpdateAuditSettings, useAudit } from '../../api/client'
+import type { CheckMeta } from '@skyhook-io/k8s-ui'
+
+interface AuditSettingsDialogProps {
+  namespaces: string[]
+  onClose: () => void
+}
+
+export function AuditSettingsDialog({ namespaces, onClose }: AuditSettingsDialogProps) {
+  const { data: settings } = useAuditSettings()
+  const { data: auditData } = useAudit(namespaces)
+  const updateSettings = useUpdateAuditSettings()
+  const [ignoredNs, setIgnoredNs] = useState<string[]>([])
+  const [disabledChecks, setDisabledChecks] = useState<string[]>([])
+  const [newNs, setNewNs] = useState('')
+
+  useEffect(() => {
+    if (settings) {
+      setIgnoredNs(settings.ignoredNamespaces || [])
+      setDisabledChecks(settings.disabledChecks || [])
+    }
+  }, [settings])
+
+  // Get all available checks from the audit response
+  const allChecks: CheckMeta[] = auditData?.checks
+    ? Object.values(auditData.checks).sort((a, b) => a.title.localeCompare(b.title))
+    : []
+
+  const addNamespace = () => {
+    const ns = newNs.trim()
+    if (ns && !ignoredNs.includes(ns)) {
+      setIgnoredNs([...ignoredNs, ns])
+      setNewNs('')
+    }
+  }
+
+  const toggleCheck = (checkID: string) => {
+    if (disabledChecks.includes(checkID)) {
+      setDisabledChecks(disabledChecks.filter(c => c !== checkID))
+    } else {
+      setDisabledChecks([...disabledChecks, checkID])
+    }
+  }
+
+  const handleSave = () => {
+    updateSettings.mutate(
+      { ignoredNamespaces: ignoredNs, disabledChecks },
+      { onSuccess: () => onClose() },
+    )
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+      <div className="bg-theme-surface rounded-xl shadow-xl w-full max-w-lg mx-4 max-h-[80vh] flex flex-col" onClick={e => e.stopPropagation()}>
+        <div className="flex items-center justify-between px-5 py-4 border-b border-theme-border shrink-0">
+          <h2 className="text-sm font-semibold text-theme-text-primary">Audit Settings</h2>
+          <button onClick={onClose} className="p-1 rounded-lg hover:bg-theme-hover transition-colors">
+            <X className="w-4 h-4 text-theme-text-tertiary" />
+          </button>
+        </div>
+
+        <div className="px-5 py-4 overflow-y-auto flex-1">
+          {/* Ignored Namespaces */}
+          <div className="mb-6">
+            <label className="text-xs font-medium text-theme-text-secondary uppercase tracking-wider">
+              Ignored Namespaces
+            </label>
+            <p className="text-xs text-theme-text-tertiary mt-1 mb-3">
+              Findings in these namespaces are hidden from all views.
+            </p>
+
+            <div className="flex flex-col gap-1.5 mb-3">
+              {ignoredNs.map(ns => (
+                <div key={ns} className="flex items-center justify-between px-3 py-1.5 bg-theme-elevated rounded-lg">
+                  <span className="text-sm text-theme-text-primary">{ns}</span>
+                  <button
+                    onClick={() => setIgnoredNs(ignoredNs.filter(n => n !== ns))}
+                    className="p-1 rounded hover:bg-theme-hover text-theme-text-tertiary hover:text-red-400 transition-colors"
+                  >
+                    <Trash2 className="w-3.5 h-3.5" />
+                  </button>
+                </div>
+              ))}
+              {ignoredNs.length === 0 && (
+                <div className="text-xs text-theme-text-tertiary py-2">No namespaces ignored.</div>
+              )}
+            </div>
+
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={newNs}
+                onChange={e => setNewNs(e.target.value)}
+                onKeyDown={e => { if (e.key === 'Enter') addNamespace() }}
+                placeholder="Add namespace..."
+                className="flex-1 px-3 py-1.5 bg-theme-elevated border border-theme-border-light rounded-lg text-sm text-theme-text-primary placeholder-theme-text-disabled focus:outline-none focus:ring-2 focus:ring-skyhook-500"
+              />
+              <button
+                onClick={addNamespace}
+                disabled={!newNs.trim()}
+                className="px-3 py-1.5 text-sm btn-brand rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <Plus className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+
+          {/* Disabled Checks */}
+          <div>
+            <label className="text-xs font-medium text-theme-text-secondary uppercase tracking-wider">
+              Enabled Checks
+            </label>
+            <p className="text-xs text-theme-text-tertiary mt-1 mb-3">
+              Uncheck to disable specific checks globally across all views.
+            </p>
+
+            <div className="flex flex-col gap-0.5">
+              {allChecks.map(check => {
+                const disabled = disabledChecks.includes(check.id)
+                return (
+                  <label
+                    key={check.id}
+                    className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-theme-hover/50 cursor-pointer transition-colors"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={!disabled}
+                      onChange={() => toggleCheck(check.id)}
+                      className="w-4 h-4 rounded border-theme-border text-skyhook-500 focus:ring-skyhook-500"
+                    />
+                    <div className="flex-1 min-w-0">
+                      <span className="text-sm text-theme-text-primary">{check.title}</span>
+                      <p className="text-xs text-theme-text-tertiary truncate">{check.description}</p>
+                    </div>
+                  </label>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-2 px-5 py-3 border-t border-theme-border shrink-0">
+          <button
+            onClick={onClose}
+            className="px-4 py-1.5 text-sm text-theme-text-secondary hover:text-theme-text-primary bg-theme-elevated hover:bg-theme-hover border border-theme-border rounded-lg transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={updateSettings.isPending}
+            className="px-4 py-1.5 text-sm btn-brand rounded-lg disabled:opacity-50"
+          >
+            {updateSettings.isPending ? 'Saving...' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/audit/AuditView.tsx
+++ b/web/src/components/audit/AuditView.tsx
@@ -1,0 +1,123 @@
+import { useState, useCallback } from 'react'
+import { useAudit, useAuditSettings, useUpdateAuditSettings } from '../../api/client'
+import type { SelectedResource } from '../../types'
+import { AuditFindingsTable } from '@skyhook-io/k8s-ui'
+import { ArrowLeft, ClipboardCheck, Loader2, Settings } from 'lucide-react'
+import { AuditSettingsDialog } from './AuditSettingsDialog'
+
+interface AuditViewProps {
+  namespaces: string[]
+  onBack: () => void
+  onNavigateToResource: (resource: SelectedResource) => void
+}
+
+export function AuditView({ namespaces, onBack, onNavigateToResource }: AuditViewProps) {
+  const { data, isLoading, error } = useAudit(namespaces)
+  const { data: auditSettings } = useAuditSettings()
+  const updateSettings = useUpdateAuditSettings()
+  const [showSettings, setShowSettings] = useState(false)
+
+  const ignoredCount = auditSettings?.ignoredNamespaces?.length ?? 0
+
+  // Inline hide actions — persist to settings immediately
+  const hideCheck = useCallback((checkID: string) => {
+    if (!auditSettings) return
+    const current = auditSettings.disabledChecks || []
+    if (current.includes(checkID)) return
+    updateSettings.mutate({ ...auditSettings, disabledChecks: [...current, checkID] })
+  }, [auditSettings, updateSettings])
+
+  const hideCategory = useCallback((category: string) => {
+    if (!auditSettings || !data?.checks) return
+    const checksInCategory = Object.values(data.checks).filter(c => {
+      // Match checks whose findings are in this category
+      return data.findings.some(f => f.checkID === c.id && f.category === category)
+    }).map(c => c.id)
+    const current = auditSettings.disabledChecks || []
+    const toAdd = checksInCategory.filter(id => !current.includes(id))
+    if (toAdd.length === 0) return
+    updateSettings.mutate({ ...auditSettings, disabledChecks: [...current, ...toAdd] })
+  }, [auditSettings, data, updateSettings])
+
+  const hideNamespace = useCallback((ns: string) => {
+    if (!auditSettings) return
+    const current = auditSettings.ignoredNamespaces || []
+    if (current.includes(ns)) return
+    updateSettings.mutate({ ...auditSettings, ignoredNamespaces: [...current, ns] })
+  }, [auditSettings, updateSettings])
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <div className="flex flex-col items-center gap-3">
+          <Loader2 className="w-6 h-6 animate-spin text-theme-text-tertiary" />
+          <span className="text-sm text-theme-text-tertiary">Loading audit data...</span>
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-theme-text-secondary">
+        <p>Failed to load audit data</p>
+      </div>
+    )
+  }
+
+  if (!data) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-theme-text-secondary">
+        <p>No audit data available</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0 p-6 gap-6 overflow-auto">
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <button
+          onClick={onBack}
+          className="p-1.5 rounded-lg hover:bg-theme-hover transition-colors"
+        >
+          <ArrowLeft className="w-5 h-5 text-theme-text-secondary" />
+        </button>
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <ClipboardCheck className="w-5 h-5 text-theme-text-secondary" />
+            <h1 className="text-lg font-semibold text-theme-text-primary">Cluster Audit</h1>
+          </div>
+          <p className="text-sm text-theme-text-tertiary mt-1 ml-7">
+            Security, reliability, and efficiency checks based on Kubernetes best practices from NSA/CISA guidelines, CIS benchmarks, and industry tools like Polaris and Kubescape.
+          </p>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          {ignoredCount > 0 && (
+            <button onClick={() => setShowSettings(true)} className="text-xs text-theme-text-tertiary hover:text-theme-text-secondary transition-colors">{ignoredCount} {ignoredCount === 1 ? 'namespace' : 'namespaces'} hidden</button>
+          )}
+          <button
+            onClick={() => setShowSettings(true)}
+            className="p-2 rounded-lg hover:bg-theme-hover text-theme-text-tertiary hover:text-theme-text-secondary transition-colors"
+            title="Audit settings"
+          >
+            <Settings className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      <AuditFindingsTable
+        groups={data.groups}
+        checks={data.checks}
+        onResourceClick={(kind, namespace, name) =>
+          onNavigateToResource({ kind, namespace, name })
+        }
+        onHideCheck={hideCheck}
+        onHideCategory={hideCategory}
+        onHideNamespace={hideNamespace}
+      />
+
+      {showSettings && <AuditSettingsDialog namespaces={namespaces} onClose={() => setShowSettings(false)} />}
+    </div>
+  )
+}

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -9,6 +9,7 @@ import { TrafficSummary } from './TrafficSummary'
 import { CertificateHealthCard } from './CertificateHealthCard'
 import { NetworkPolicyCoverageCard } from './NetworkPolicyCoverageCard'
 import { CostCard } from './CostCard'
+import { AuditCard } from '@skyhook-io/k8s-ui'
 import { ClusterHealthCard } from './ClusterHealthCard'
 import { AlertTriangle, Loader2, Shield } from 'lucide-react'
 import { clsx } from 'clsx'
@@ -88,39 +89,66 @@ export function HomeView({ namespaces, topology, onNavigateToView, onNavigateToR
           'grid gap-6',
           hasProblems ? 'grid-cols-1 lg:grid-cols-[1fr_420px]' : 'grid-cols-1'
         )}>
-          {/* Left column: teaser cards in 2-col grid */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 auto-rows-min">
-            <TopologyPreview
-              topology={topology}
-              summary={data.topologySummary}
-              onNavigate={() => onNavigateToView('topology')}
-            />
-            <HelmSummary
-              data={helmData}
-              onNavigate={() => onNavigateToView('helm')}
-            />
-            <ActivitySummary
-              namespaces={namespaces}
-              topology={topology}
-              onNavigate={() => onNavigateToView('timeline')}
-            />
-            <TrafficSummary
-              data={data.trafficSummary}
-              onNavigate={() => onNavigateToView('traffic')}
-            />
-            {data.certificateHealth && (
-              <CertificateHealthCard
-                data={data.certificateHealth}
-                onNavigate={() => onNavigateToResourceKind('secrets', undefined, { type: ['TLS'] })}
+          {/* Left column: teaser cards */}
+          <div className="flex flex-col gap-6 auto-rows-min">
+            {/* Primary cards — 2-col grid */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+              <TopologyPreview
+                topology={topology}
+                summary={data.topologySummary}
+                onNavigate={() => onNavigateToView('topology')}
               />
-            )}
-            {data.networkPolicyCoverage && (
-              <NetworkPolicyCoverageCard
-                data={data.networkPolicyCoverage}
-                onNavigate={() => onNavigateToResourceKind('networkpolicies', 'networking.k8s.io')}
+              <HelmSummary
+                data={helmData}
+                onNavigate={() => onNavigateToView('helm')}
               />
-            )}
-            <CostCard onNavigate={() => onNavigateToView('cost')} />
+              <ActivitySummary
+                namespaces={namespaces}
+                topology={topology}
+                onNavigate={() => onNavigateToView('timeline')}
+              />
+              <TrafficSummary
+                data={data.trafficSummary}
+                onNavigate={() => onNavigateToView('traffic')}
+              />
+              <CostCard onNavigate={() => onNavigateToView('cost')} />
+            </div>
+
+            {/* Health & compliance cards — 3-col when enough cards, 2-col fallback */}
+            {(data.certificateHealth || data.networkPolicyCoverage || data.audit) && (() => {
+              const healthCards = [
+                data.certificateHealth && (
+                  <CertificateHealthCard
+                    key="certs"
+                    data={data.certificateHealth}
+                    onNavigate={() => onNavigateToResourceKind('secrets', undefined, { type: ['TLS'] })}
+                  />
+                ),
+                data.networkPolicyCoverage && (
+                  <NetworkPolicyCoverageCard
+                    key="netpol"
+                    data={data.networkPolicyCoverage}
+                    onNavigate={() => onNavigateToResourceKind('networkpolicies', 'networking.k8s.io')}
+                  />
+                ),
+                data.audit && (
+                  <AuditCard
+                    key="audit"
+                    data={data.audit}
+                    onNavigate={() => onNavigateToView('audit')}
+                  />
+                ),
+              ].filter(Boolean)
+
+              return (
+                <div className={clsx(
+                  'grid gap-6',
+                  healthCards.length >= 3 ? 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3' : 'grid-cols-1 sm:grid-cols-2'
+                )}>
+                  {healthCards}
+                </div>
+              )
+            })()}
           </div>
 
           {/* Right column: problems panel */}

--- a/web/src/components/home/NetworkPolicyCoverageCard.tsx
+++ b/web/src/components/home/NetworkPolicyCoverageCard.tsx
@@ -12,12 +12,13 @@ export function NetworkPolicyCoverageCard({ data, onNavigate }: NetworkPolicyCov
     ? Math.round((data.coveredWorkloads / data.totalWorkloads) * 100)
     : 0
   const hasPolicies = data.totalPolicies > 0
-  const fullCoverage = hasPolicies && percentage === 100
   const accentColor = !hasPolicies
     ? 'text-theme-text-tertiary'
-    : fullCoverage
+    : percentage >= 75
       ? 'text-green-500'
-      : 'text-yellow-500'
+      : percentage >= 40
+        ? 'text-yellow-500'
+        : 'text-red-500'
 
   return (
     <button
@@ -60,7 +61,7 @@ export function NetworkPolicyCoverageCard({ data, onNavigate }: NetworkPolicyCov
                     />
                   )}
                 </div>
-                <span className={clsx('text-sm font-semibold tabular-nums', fullCoverage ? 'text-green-400' : 'text-yellow-400')}>
+                <span className={clsx('text-sm font-semibold tabular-nums', accentColor)}>
                   {percentage}%
                 </span>
               </div>

--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -20,6 +20,8 @@ import {
   fetchJSON,
 } from '../../api/client'
 import { PrometheusCharts, isPrometheusSupported } from '../resource/PrometheusCharts'
+import { useResourceAudit } from '../../api/client'
+import { AuditAlerts } from '@skyhook-io/k8s-ui'
 import { WorkloadLogsViewer } from '../logs/WorkloadLogsViewer'
 import { LogsViewer } from '../logs/LogsViewer'
 import { useCanUpdateSecrets, useCanNodeWrite, useNamespacedCapabilities } from '../../contexts/CapabilitiesContext'
@@ -355,6 +357,9 @@ export function WorkloadView({
       actionsBarProps={actionsBarProps}
       rendererOverrides={rendererOverrides}
       resolvedEnvFrom={resolvedEnvFrom}
+      renderOverviewExtra={({ kind: k, namespace: ns, name: n }) => (
+        <AuditSection kind={k} namespace={ns} name={n} />
+      )}
     />
     <CreateResourceDialog
       open={duplicateDialogOpen}
@@ -517,4 +522,11 @@ function MultiPodLogsTab({ pods, namespace, selectedPod, onSelectPod, initialCon
       )}
     </div>
   )
+}
+
+function AuditSection({ kind, namespace, name }: { kind: string; namespace: string; name: string }) {
+  const navigate = useNavigate()
+  const { data: findings } = useResourceAudit(kind, namespace, name)
+  if (!findings || findings.length === 0) return null
+  return <AuditAlerts findings={findings} onViewAll={() => navigate('/audit')} />
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -136,11 +136,13 @@ document.execCommand = function (command: string, showUI?: boolean, value?: stri
   return _origExecCommand(command, showUI, value)
 } as typeof document.execCommand
 
-// Mouse back/forward button navigation for desktop webview.
-// On Windows (WebView2/Chromium), these events fire natively — this handles them.
-// On macOS (WKWebView), these events never reach JS — handled by native NSEvent monitor in mouse_darwin.go.
-// On Linux (webkit2gtk), behavior varies by version — this catches it when supported.
-window.addEventListener('auxclick', (e: MouseEvent) => {
+// Mouse back/forward button navigation (button 3 = back, button 4 = forward).
+// Uses 'mouseup' in capture phase to intercept before the browser's native handler.
+// This prevents double-navigation in browsers (where auxclick + native both fire)
+// and handles desktop WebView (Windows/Linux) where native handling varies.
+// On macOS WKWebView, mouse events don't reach JS — native NSEvent monitor in
+// mouse_darwin.go handles them via WKWebView.goBack()/goForward() directly.
+window.addEventListener('mouseup', (e: MouseEvent) => {
   if (e.button === 3) {
     e.preventDefault()
     window.history.back()
@@ -148,7 +150,7 @@ window.addEventListener('auxclick', (e: MouseEvent) => {
     e.preventDefault()
     window.history.forward()
   }
-})
+}, true)
 
 // Type the meta property for mutations
 declare module '@tanstack/react-query' {


### PR DESCRIPTION
## Summary

Adds a native best-practices scanner that checks cluster resources against 21 security, reliability, and efficiency rules. Runs against Radar's in-memory cache (<10ms), zero new Go dependencies.

**Checks include:** running as root, privileged containers, privilege escalation, dangerous capabilities, host network/PID/IPC, missing probes, image tag latest, single replica, missing PDB, missing resource requests/limits, service selector mismatches, ingress referencing missing services.

Each check includes a description (why it matters) and remediation guidance (how to fix), sourced from Polaris and Kubescape (both Apache-2.0).

**UI:**
- Dashboard card with severity distribution bar and category breakdown
- Detail view (`/audit`) with resources grouped by severity, expandable findings with descriptions and fix instructions, search, and category/severity filters
- Per-resource audit section in resource detail drawer (collapsed by default)

**Architecture:**
- `pkg/audit/` — shared check engine, reusable by skyhook-connector
- `packages/k8s-ui/` — shared UI components (AuditCard, AuditAlerts, AuditFindingsTable)
- 5s TTL cache so dashboard polls and per-resource lookups share results
- 16 unit tests

Also includes: Property label column widened for better readability, Service renderer improvements (ExternalName, multiple LB entries, IP family fields).