### PR TITLE
Overhaul problem categorization: unified severity, workload rollup, duration, expanded detection

### DIFF
--- a/internal/k8s/health.go
+++ b/internal/k8s/health.go
@@ -122,7 +122,7 @@ type NodeProblem struct {
 	NodeName string `json:"nodeName"`
 	Problem  string `json:"problem"`
 	Reason   string `json:"reason,omitempty"`
-	Severity string `json:"severity"` // "error" or "warning"
+	Severity string `json:"severity"` // "critical", "high", or "medium"
 }
 
 // DetectNodeProblems scans nodes for NotReady, Cordoned, and pressure conditions.
@@ -141,14 +141,14 @@ func DetectNodeProblems(nodes []*corev1.Node) []NodeProblem {
 				NodeName: node.Name,
 				Problem:  "NotReady",
 				Reason:   reason,
-				Severity: "error",
+				Severity: "critical",
 			})
 		} else if h.Unschedulable {
 			problems = append(problems, NodeProblem{
 				NodeName: node.Name,
 				Problem:  "Cordoned",
 				Reason:   "SchedulingDisabled",
-				Severity: "warning",
+				Severity: "medium",
 			})
 		}
 
@@ -157,7 +157,7 @@ func DetectNodeProblems(nodes []*corev1.Node) []NodeProblem {
 				NodeName: node.Name,
 				Problem:  pressure,
 				Reason:   pressure,
-				Severity: "warning",
+				Severity: "critical",
 			})
 		}
 	}

--- a/internal/k8s/health_test.go
+++ b/internal/k8s/health_test.go
@@ -277,7 +277,7 @@ func TestDetectNodeProblems(t *testing.T) {
 				},
 			},
 			wantCount:    2,
-			wantSeverity: "error",
+			wantSeverity: "critical",
 			wantProblem:  "NotReady",
 		},
 		{
@@ -294,7 +294,7 @@ func TestDetectNodeProblems(t *testing.T) {
 				},
 			},
 			wantCount:    1,
-			wantSeverity: "warning",
+			wantSeverity: "medium",
 			wantProblem:  "Cordoned",
 		},
 		{
@@ -312,7 +312,7 @@ func TestDetectNodeProblems(t *testing.T) {
 				},
 			},
 			wantCount:    2,
-			wantSeverity: "warning",
+			wantSeverity: "critical",
 			wantProblem:  "MemoryPressure",
 		},
 		{
@@ -329,7 +329,7 @@ func TestDetectNodeProblems(t *testing.T) {
 				},
 			},
 			wantCount:    2,
-			wantSeverity: "error",
+			wantSeverity: "critical",
 			wantProblem:  "NotReady",
 		},
 	}

--- a/internal/k8s/problems.go
+++ b/internal/k8s/problems.go
@@ -7,19 +7,22 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
 // Problem is a transport-neutral cluster issue.
 type Problem struct {
-	Kind       string
-	Namespace  string
-	Name       string
-	Severity   string // "error" or "warning"
-	Reason     string
-	Message    string
-	Age        string // human-readable
-	AgeSeconds int64  // for sorting
+	Kind            string
+	Namespace       string
+	Name            string
+	Severity        string // "critical", "high", or "medium"
+	Reason          string
+	Message         string
+	Age             string // human-readable
+	AgeSeconds      int64  // for sorting
+	Duration        string // how long the problem has persisted
+	DurationSeconds int64
 }
 
 // DetectProblems scans workloads in cache and returns detected problems.
@@ -41,15 +44,46 @@ func DetectProblems(cache *ResourceCache, namespace string) []Problem {
 		for _, d := range deps {
 			if d.Status.UnavailableReplicas > 0 {
 				ageDur := now.Sub(d.CreationTimestamp.Time)
+				durDur := ageDur // fallback to creation time
+				for _, cond := range d.Status.Conditions {
+					if cond.Type == appsv1.DeploymentAvailable && cond.Status == "False" && !cond.LastTransitionTime.IsZero() {
+						durDur = now.Sub(cond.LastTransitionTime.Time)
+						break
+					}
+				}
 				problems = append(problems, Problem{
-					Kind:       "Deployment",
-					Namespace:  d.Namespace,
-					Name:       d.Name,
-					Severity:   "error",
-					Reason:     fmt.Sprintf("%d/%d available", d.Status.AvailableReplicas, d.Status.Replicas),
-					Age:        FormatAge(ageDur),
-					AgeSeconds: int64(ageDur.Seconds()),
+					Kind:            "Deployment",
+					Namespace:       d.Namespace,
+					Name:            d.Name,
+					Severity:        "critical",
+					Reason:          fmt.Sprintf("%d/%d available", d.Status.AvailableReplicas, d.Status.Replicas),
+					Age:             FormatAge(ageDur),
+					AgeSeconds:      int64(ageDur.Seconds()),
+					Duration:        FormatAge(durDur),
+					DurationSeconds: int64(durDur.Seconds()),
 				})
+			}
+			// Stuck rollout: ProgressDeadlineExceeded
+			for _, cond := range d.Status.Conditions {
+				if cond.Type == appsv1.DeploymentProgressing && cond.Status == "False" && cond.Reason == "ProgressDeadlineExceeded" {
+					durDur := now.Sub(d.CreationTimestamp.Time)
+					if !cond.LastTransitionTime.IsZero() {
+						durDur = now.Sub(cond.LastTransitionTime.Time)
+					}
+					problems = append(problems, Problem{
+						Kind:            "Deployment",
+						Namespace:       d.Namespace,
+						Name:            d.Name,
+						Severity:        "critical",
+						Reason:          "Rollout stuck",
+						Message:         cond.Message,
+						Age:             FormatAge(now.Sub(d.CreationTimestamp.Time)),
+						AgeSeconds:      int64(now.Sub(d.CreationTimestamp.Time).Seconds()),
+						Duration:        FormatAge(durDur),
+						DurationSeconds: int64(durDur.Seconds()),
+					})
+					break
+				}
 			}
 		}
 	}
@@ -66,13 +100,15 @@ func DetectProblems(cache *ResourceCache, namespace string) []Problem {
 			if ss.Status.ReadyReplicas < ss.Status.Replicas {
 				ageDur := now.Sub(ss.CreationTimestamp.Time)
 				problems = append(problems, Problem{
-					Kind:       "StatefulSet",
-					Namespace:  ss.Namespace,
-					Name:       ss.Name,
-					Severity:   "error",
-					Reason:     fmt.Sprintf("%d/%d ready", ss.Status.ReadyReplicas, ss.Status.Replicas),
-					Age:        FormatAge(ageDur),
-					AgeSeconds: int64(ageDur.Seconds()),
+					Kind:            "StatefulSet",
+					Namespace:       ss.Namespace,
+					Name:            ss.Name,
+					Severity:        "critical",
+					Reason:          fmt.Sprintf("%d/%d ready", ss.Status.ReadyReplicas, ss.Status.Replicas),
+					Age:             FormatAge(ageDur),
+					AgeSeconds:      int64(ageDur.Seconds()),
+					Duration:        FormatAge(ageDur),
+					DurationSeconds: int64(ageDur.Seconds()),
 				})
 			}
 		}
@@ -90,13 +126,15 @@ func DetectProblems(cache *ResourceCache, namespace string) []Problem {
 			if ds.Status.NumberUnavailable > 0 {
 				ageDur := now.Sub(ds.CreationTimestamp.Time)
 				problems = append(problems, Problem{
-					Kind:       "DaemonSet",
-					Namespace:  ds.Namespace,
-					Name:       ds.Name,
-					Severity:   "error",
-					Reason:     fmt.Sprintf("%d unavailable", ds.Status.NumberUnavailable),
-					Age:        FormatAge(ageDur),
-					AgeSeconds: int64(ageDur.Seconds()),
+					Kind:            "DaemonSet",
+					Namespace:       ds.Namespace,
+					Name:            ds.Name,
+					Severity:        "critical",
+					Reason:          fmt.Sprintf("%d unavailable", ds.Status.NumberUnavailable),
+					Age:             FormatAge(ageDur),
+					AgeSeconds:      int64(ageDur.Seconds()),
+					Duration:        FormatAge(ageDur),
+					DurationSeconds: int64(ageDur.Seconds()),
 				})
 			}
 		}
@@ -115,7 +153,7 @@ func DetectProblems(cache *ResourceCache, namespace string) []Problem {
 				Kind:      "HorizontalPodAutoscaler",
 				Namespace: hp.Namespace,
 				Name:      hp.Name,
-				Severity:  "warning",
+				Severity:  "medium",
 				Reason:    hp.Problem,
 				Message:   hp.Reason,
 			})
@@ -135,7 +173,7 @@ func DetectProblems(cache *ResourceCache, namespace string) []Problem {
 				Kind:      "CronJob",
 				Namespace: cp.Namespace,
 				Name:      cp.Name,
-				Severity:  "warning",
+				Severity:  "medium",
 				Reason:    cp.Problem,
 				Message:   cp.Reason,
 			})
@@ -162,6 +200,62 @@ func DetectProblems(cache *ResourceCache, namespace string) []Problem {
 				Age:        FormatAge(ageDur),
 				AgeSeconds: int64(ageDur.Seconds()),
 			})
+		}
+	}
+
+	// PVC problems: stuck in Pending phase
+	if pvcLister := cache.PersistentVolumeClaims(); pvcLister != nil {
+		var pvcs []*corev1.PersistentVolumeClaim
+		if namespace != "" {
+			pvcs, _ = pvcLister.PersistentVolumeClaims(namespace).List(labels.Everything())
+		} else {
+			pvcs, _ = pvcLister.List(labels.Everything())
+		}
+		for _, pvc := range pvcs {
+			if pvc.Status.Phase == corev1.ClaimPending {
+				ageDur := now.Sub(pvc.CreationTimestamp.Time)
+				if ageDur > 5*time.Minute {
+					problems = append(problems, Problem{
+						Kind:            "PersistentVolumeClaim",
+						Namespace:       pvc.Namespace,
+						Name:            pvc.Name,
+						Severity:        "high",
+						Reason:          "Pending",
+						Age:             FormatAge(ageDur),
+						AgeSeconds:      int64(ageDur.Seconds()),
+						Duration:        FormatAge(ageDur),
+						DurationSeconds: int64(ageDur.Seconds()),
+					})
+				}
+			}
+		}
+	}
+
+	// Job problems: stuck active (running > 1h with no completions)
+	if jobLister := cache.Jobs(); jobLister != nil {
+		var jobs []*batchv1.Job
+		if namespace != "" {
+			jobs, _ = jobLister.Jobs(namespace).List(labels.Everything())
+		} else {
+			jobs, _ = jobLister.List(labels.Everything())
+		}
+		for _, job := range jobs {
+			if job.Status.Active > 0 && job.Status.Succeeded == 0 && job.Status.Failed == 0 {
+				ageDur := now.Sub(job.CreationTimestamp.Time)
+				if ageDur > time.Hour {
+					problems = append(problems, Problem{
+						Kind:            "Job",
+						Namespace:       job.Namespace,
+						Name:            job.Name,
+						Severity:        "high",
+						Reason:          fmt.Sprintf("Running for %s with no completions", FormatAge(ageDur)),
+						Age:             FormatAge(ageDur),
+						AgeSeconds:      int64(ageDur.Seconds()),
+						Duration:        FormatAge(ageDur),
+						DurationSeconds: int64(ageDur.Seconds()),
+					})
+				}
+			}
 		}
 	}
 

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -67,7 +67,7 @@ type DashboardProblem struct {
 	Kind       string `json:"kind"`
 	Namespace  string `json:"namespace"`
 	Name       string `json:"name"`
-	Status     string `json:"status"`
+	Severity   string `json:"severity"`
 	Reason     string `json:"reason"`
 	Message    string `json:"message"`
 	Age        string `json:"age"`
@@ -393,7 +393,7 @@ func (s *Server) getDashboardHealth(cache *k8s.ResourceCache, namespace string) 
 			Kind:       p.Kind,
 			Namespace:  p.Namespace,
 			Name:       p.Name,
-			Status:     p.Severity,
+			Severity:   p.Severity,
 			Reason:     p.Reason,
 			Message:    p.Message,
 			Age:        p.Age,
@@ -403,10 +403,10 @@ func (s *Server) getDashboardHealth(cache *k8s.ResourceCache, namespace string) 
 
 	// Sort: errors first, then warnings; within each group sort by age (most recent first)
 	sort.SliceStable(problems, func(i, j int) bool {
-		if problems[i].Status != problems[j].Status {
-			return problems[i].Status == "error"
+		if problems[i].Severity != problems[j].Severity {
+			return problems[i].Severity == "error"
 		}
-		// Within same status, sort by age (lower AgeSeconds = more recent = first)
+		// Within same severity, sort by age (lower AgeSeconds = more recent = first)
 		return problems[i].AgeSeconds < problems[j].AgeSeconds
 	})
 
@@ -463,7 +463,7 @@ func podToProblem(pod *corev1.Pod, severity string, now time.Time) DashboardProb
 		Kind:       "Pod",
 		Namespace:  pod.Namespace,
 		Name:       pod.Name,
-		Status:     severity,
+		Severity:   severity,
 		Reason:     reason,
 		Message:    k8s.Truncate(message, 200),
 		Age:        k8s.FormatAge(ageDur),

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -64,14 +66,17 @@ type DashboardHealth struct {
 }
 
 type DashboardProblem struct {
-	Kind       string `json:"kind"`
-	Namespace  string `json:"namespace"`
-	Name       string `json:"name"`
-	Severity   string `json:"severity"`
-	Reason     string `json:"reason"`
-	Message    string `json:"message"`
-	Age        string `json:"age"`
-	AgeSeconds int64  `json:"ageSeconds"` // For sorting: lower = more recent
+	Kind            string `json:"kind"`
+	Namespace       string `json:"namespace"`
+	Name            string `json:"name"`
+	Severity        string `json:"severity"`        // "critical", "high", or "medium"
+	Reason          string `json:"reason"`
+	Message         string `json:"message"`
+	Age             string `json:"age"`
+	AgeSeconds      int64  `json:"ageSeconds"`      // For sorting: lower = more recent
+	Duration        string `json:"duration"`         // How long the problem has persisted
+	DurationSeconds int64  `json:"durationSeconds"`  // For sorting by problem age
+	PodCount        int    `json:"podCount,omitempty"` // For workload rollups: number of affected pods
 }
 
 type DashboardResourceCounts struct {
@@ -367,6 +372,10 @@ func (s *Server) getDashboardHealth(cache *k8s.ResourceCache, namespace string) 
 			pods, err = podLister.List(labels.Everything())
 		}
 	}
+	// Group unhealthy pods by owner workload for rollup
+	ownerGroups := make(map[ownerKey]*ownerGroup)
+	var orphanProblems []DashboardProblem
+
 	if err == nil {
 		for _, pod := range pods {
 			status := classifyPodHealth(pod, now)
@@ -375,38 +384,67 @@ func (s *Server) getDashboardHealth(cache *k8s.ResourceCache, namespace string) 
 				health.Healthy++
 			case "warning":
 				health.Warning++
-				if len(problems) < 20 {
-					problems = append(problems, podToProblem(pod, "warning", now))
-				}
+				collectPodForRollup(pod, "medium", now, ownerGroups, &orphanProblems)
 			case "error":
 				health.Error++
-				if len(problems) < 20 {
-					problems = append([]DashboardProblem{podToProblem(pod, "error", now)}, problems...)
-				}
+				collectPodForRollup(pod, "critical", now, ownerGroups, &orphanProblems)
 			}
 		}
 	}
 
+	// Convert owner groups to rolled-up problems
+	for key, g := range ownerGroups {
+		// Build reason summary: "CrashLoopBackOff (3), Pending (1)"
+		var reasonParts []string
+		for reason, count := range g.reasons {
+			if count > 1 {
+				reasonParts = append(reasonParts, fmt.Sprintf("%s (%d)", reason, count))
+			} else {
+				reasonParts = append(reasonParts, reason)
+			}
+		}
+		sort.Strings(reasonParts)
+
+		problems = append(problems, DashboardProblem{
+			Kind:            key.kind,
+			Namespace:       key.namespace,
+			Name:            key.name,
+			Severity:        g.severity,
+			Reason:          fmt.Sprintf("%d %s unhealthy", g.podCount, func() string { if g.podCount == 1 { return "pod" }; return "pods" }()),
+			Message:         k8s.Truncate(strings.Join(reasonParts, ", "), 200),
+			Age:             k8s.FormatAge(g.newestAge),
+			AgeSeconds:      int64(g.newestAge.Seconds()),
+			Duration:        k8s.FormatAge(g.newestDur),
+			DurationSeconds: int64(g.newestDur.Seconds()),
+			PodCount:        g.podCount,
+		})
+	}
+	// Add orphan pod problems (no owner workload)
+	problems = append(problems, orphanProblems...)
+
 	// Workload/HPA/CronJob/Node problems (excluding pods, handled above)
 	for _, p := range k8s.DetectProblems(cache, namespace) {
 		problems = append(problems, DashboardProblem{
-			Kind:       p.Kind,
-			Namespace:  p.Namespace,
-			Name:       p.Name,
-			Severity:   p.Severity,
-			Reason:     p.Reason,
-			Message:    p.Message,
-			Age:        p.Age,
-			AgeSeconds: p.AgeSeconds,
+			Kind:            p.Kind,
+			Namespace:       p.Namespace,
+			Name:            p.Name,
+			Severity:        p.Severity,
+			Reason:          p.Reason,
+			Message:         p.Message,
+			Age:             p.Age,
+			AgeSeconds:      p.AgeSeconds,
+			Duration:        p.Duration,
+			DurationSeconds: p.DurationSeconds,
 		})
 	}
 
-	// Sort: errors first, then warnings; within each group sort by age (most recent first)
+	// Sort: critical first, then high, then medium; within each group sort by age (most recent first)
+	severityOrder := map[string]int{"critical": 0, "high": 1, "medium": 2}
 	sort.SliceStable(problems, func(i, j int) bool {
-		if problems[i].Severity != problems[j].Severity {
-			return problems[i].Severity == "error"
+		si, sj := severityOrder[problems[i].Severity], severityOrder[problems[j].Severity]
+		if si != sj {
+			return si < sj
 		}
-		// Within same severity, sort by age (lower AgeSeconds = more recent = first)
 		return problems[i].AgeSeconds < problems[j].AgeSeconds
 	})
 
@@ -458,16 +496,114 @@ func podToProblem(pod *corev1.Pod, severity string, now time.Time) DashboardProb
 	}
 
 	ageDur := now.Sub(pod.CreationTimestamp.Time)
+	durDur := podProblemDuration(pod, now)
 
 	return DashboardProblem{
-		Kind:       "Pod",
-		Namespace:  pod.Namespace,
-		Name:       pod.Name,
-		Severity:   severity,
-		Reason:     reason,
-		Message:    k8s.Truncate(message, 200),
-		Age:        k8s.FormatAge(ageDur),
-		AgeSeconds: int64(ageDur.Seconds()),
+		Kind:            "Pod",
+		Namespace:       pod.Namespace,
+		Name:            pod.Name,
+		Severity:        severity,
+		Reason:          reason,
+		Message:         k8s.Truncate(message, 200),
+		Age:             k8s.FormatAge(ageDur),
+		AgeSeconds:      int64(ageDur.Seconds()),
+		Duration:        k8s.FormatAge(durDur),
+		DurationSeconds: int64(durDur.Seconds()),
+	}
+}
+
+// podProblemDuration estimates how long a pod has been in a problematic state.
+// Uses condition lastTransitionTime when available, falls back to creation time.
+func podProblemDuration(pod *corev1.Pod, now time.Time) time.Duration {
+	// For pending pods: use the PodScheduled or Ready condition transition
+	// For running-but-unhealthy: use ContainersReady condition transition
+	// For failed: use the Ready condition transition
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.ContainersReady && cond.Status == corev1.ConditionFalse {
+			if !cond.LastTransitionTime.IsZero() {
+				return now.Sub(cond.LastTransitionTime.Time)
+			}
+		}
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionFalse {
+			if !cond.LastTransitionTime.IsZero() {
+				return now.Sub(cond.LastTransitionTime.Time)
+			}
+		}
+		if cond.Type == corev1.PodScheduled && cond.Status == corev1.ConditionFalse {
+			if !cond.LastTransitionTime.IsZero() {
+				return now.Sub(cond.LastTransitionTime.Time)
+			}
+		}
+	}
+	// Fallback: use pod creation time
+	return now.Sub(pod.CreationTimestamp.Time)
+}
+
+type ownerKey struct{ kind, namespace, name string }
+type ownerGroup struct {
+	podCount   int
+	severity   string
+	reasons    map[string]int
+	newestDur  time.Duration
+	newestAge  time.Duration
+}
+
+// collectPodForRollup groups a problematic pod under its owner workload, or adds it as an orphan.
+func collectPodForRollup(pod *corev1.Pod, severity string, now time.Time, groups map[ownerKey]*ownerGroup, orphans *[]DashboardProblem) {
+	// Find the workload owner (Deployment owns ReplicaSet owns Pod, so look for grandparent)
+	var ownerKind, ownerName string
+	for _, ref := range pod.OwnerReferences {
+		if ref.Kind == "ReplicaSet" || ref.Kind == "StatefulSet" || ref.Kind == "DaemonSet" || ref.Kind == "Job" {
+			ownerKind = ref.Kind
+			ownerName = ref.Name
+			break
+		}
+	}
+
+	// For ReplicaSets, strip the hash suffix to get the Deployment name
+	if ownerKind == "ReplicaSet" {
+		ownerKind = "Deployment"
+		if idx := strings.LastIndex(ownerName, "-"); idx > 0 {
+			ownerName = ownerName[:idx]
+		}
+	}
+
+	// No workload owner — orphan pod
+	if ownerKind == "" {
+		*orphans = append(*orphans, podToProblem(pod, severity, now))
+		return
+	}
+
+	key := ownerKey{ownerKind, pod.Namespace, ownerName}
+	g, ok := groups[key]
+	if !ok {
+		g = &ownerGroup{
+			reasons:   make(map[string]int),
+			newestDur: 1<<62 - 1,
+			newestAge: 1<<62 - 1,
+		}
+		groups[key] = g
+	}
+
+	g.podCount++
+	// Keep worst severity: critical > high > medium
+	order := map[string]int{"critical": 0, "high": 1, "medium": 2}
+	if g.severity == "" || order[severity] < order[g.severity] {
+		g.severity = severity
+	}
+
+	reason := k8s.PodProblemReason(pod)
+	if reason != "" {
+		g.reasons[reason]++
+	}
+
+	ageDur := now.Sub(pod.CreationTimestamp.Time)
+	durDur := podProblemDuration(pod, now)
+	if durDur < g.newestDur {
+		g.newestDur = durDur
+	}
+	if ageDur < g.newestAge {
+		g.newestAge = ageDur
 	}
 }
 

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -116,6 +116,8 @@ import {
   getCellFilterValue,
   parseColumnFilters,
   serializeColumnFilters,
+  podMatchesProblemCategory,
+  SEVERITY_DOT_COLOR,
 } from './resource-utils'
 import { SEVERITY_BADGE, EVENT_TYPE_COLORS } from '../../utils/badge-colors'
 import { Tooltip } from '../ui/Tooltip'
@@ -2478,33 +2480,8 @@ export function ResourcesView({
   const podMatchesProblemFilter = useCallback((pod: any, filters: string[]): boolean => {
     if (filters.length === 0) return true
     const problems = getPodProblems(pod)
-    const problemMessages = problems.map(p => p.message)
     const restarts = getPodRestarts(pod)
-
-    return filters.some(filter => {
-      switch (filter) {
-        case 'CrashLoopBackOff':
-          return problemMessages.includes('CrashLoopBackOff')
-        case 'ImagePullBackOff':
-          return problemMessages.some(m => m.includes('ImagePull') && !m.startsWith('Init:'))
-        case 'OOMKilled':
-          return problemMessages.includes('OOMKilled')
-        case 'Unschedulable':
-          return problemMessages.includes('Unschedulable')
-        case 'Not Ready':
-          return problemMessages.includes('Not Ready') || problemMessages.some(m => m.includes('Probe'))
-        case 'High Restarts':
-          return restarts > 5
-        case 'Init Failed':
-          return problemMessages.some(m => m.startsWith('Init:'))
-        case 'Exit Code Error':
-          return problemMessages.some(m => m.startsWith('Exit Code'))
-        case 'Failed':
-          return problemMessages.includes('Failed') || problemMessages.includes('Unknown')
-        default:
-          return false
-      }
-    })
+    return filters.some(filter => podMatchesProblemCategory(problems, restarts, filter))
   }, [])
 
 
@@ -2810,18 +2787,12 @@ export function ResourcesView({
 
       for (const pod of resources) {
         const podProblems = getPodProblems(pod)
-        const msgs = podProblems.map(p => p.message)
         const restarts = getPodRestarts(pod)
-
-        if (msgs.includes('CrashLoopBackOff')) problemCounts['CrashLoopBackOff']++
-        if (msgs.some(m => m.includes('ImagePull') && !m.startsWith('Init:'))) problemCounts['ImagePullBackOff']++
-        if (msgs.includes('OOMKilled')) problemCounts['OOMKilled']++
-        if (msgs.includes('Unschedulable')) problemCounts['Unschedulable']++
-        if (msgs.includes('Not Ready') || msgs.some(m => m.includes('Probe'))) problemCounts['Not Ready']++
-        if (restarts > 5) problemCounts['High Restarts']++
-        if (msgs.some(m => m.startsWith('Init:'))) problemCounts['Init Failed']++
-        if (msgs.some(m => m.startsWith('Exit Code'))) problemCounts['Exit Code Error']++
-        if (msgs.includes('Failed') || msgs.includes('Unknown')) problemCounts['Failed']++
+        for (const category of POD_PROBLEMS) {
+          if (podMatchesProblemCategory(podProblems, restarts, category)) {
+            problemCounts[category]++
+          }
+        }
       }
 
       const activeProblems = POD_PROBLEMS
@@ -4041,11 +4012,7 @@ function PodCell({ resource, column }: { resource: any; column: string }) {
               <div className="space-y-0.5">
                 {problems.map((p, i) => (
                   <div key={i} className="flex items-center gap-1.5">
-                    <span className={clsx('w-1.5 h-1.5 rounded-full shrink-0', {
-                      'bg-red-400': p.severity === 'critical',
-                      'bg-orange-400': p.severity === 'high',
-                      'bg-yellow-400': p.severity === 'medium',
-                    })} />
+                    <span className={clsx('w-1.5 h-1.5 rounded-full shrink-0', SEVERITY_DOT_COLOR[p.severity])} />
                     <span>{p.message}</span>
                   </div>
                 ))}

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -31,6 +31,8 @@ import {
   getPodStatus,
   getPodRestarts,
   getPodProblems,
+  getWorkloadProblems,
+  workloadMatchesProblemCategory,
   getContainerSquareStates,
   getWorkloadImages,
   getWorkloadConditions,
@@ -142,7 +144,9 @@ import { ResourcesSidebar } from './ResourcesSidebar'
 import type { SelectedKindInfo } from './ResourcesSidebar'
 
 // Pod problem filter options (special multi-select, not a single column value)
-const POD_PROBLEMS = ['CrashLoopBackOff', 'ImagePullBackOff', 'OOMKilled', 'Unschedulable', 'Not Ready', 'High Restarts', 'Init Failed', 'Exit Code Error', 'Failed'] as const
+const POD_PROBLEMS = ['CrashLoopBackOff', 'ImagePullBackOff', 'OOMKilled', 'Unschedulable', 'Not Ready', 'High Restarts', 'Init Failed', 'Exit Code Error', 'Failed', 'Other'] as const
+const WORKLOAD_PROBLEMS = ['Unavailable', 'Rollout Stuck', 'Rollout In Progress'] as const
+const WORKLOAD_KINDS = new Set(['deployments', 'statefulsets', 'daemonsets'])
 
 // Columns to skip for auto-detected filters (high cardinality, text-like, or non-filterable)
 const SKIP_FILTER_COLUMNS = new Set([
@@ -2511,9 +2515,17 @@ export function ResourcesView({
       )
     }
 
-    // Apply problem filters (pods only)
-    if (problemFilters.length > 0 && selectedKind.name.toLowerCase() === 'pods') {
-      result = result.filter((r: any) => podMatchesProblemFilter(r, problemFilters))
+    // Apply problem filters
+    if (problemFilters.length > 0) {
+      const kindLower = normalizeKindToPlural(selectedKind.name, selectedKind.group)
+      if (kindLower === 'pods') {
+        result = result.filter((r: any) => podMatchesProblemFilter(r, problemFilters))
+      } else if (WORKLOAD_KINDS.has(kindLower)) {
+        result = result.filter((r: any) => {
+          const problems = getWorkloadProblems(r, kindLower)
+          return problemFilters.some(f => workloadMatchesProblemCategory(problems, f))
+        })
+      }
     }
 
     // Apply inactive ReplicaSet filter (default: hide inactive)
@@ -2796,6 +2808,28 @@ export function ResourcesView({
       }
 
       const activeProblems = POD_PROBLEMS
+        .map(p => ({ value: p, count: problemCounts[p] }))
+        .filter(p => p.count > 0)
+      if (activeProblems.length > 0) {
+        problems = activeProblems
+      }
+    }
+
+    // Workload-specific: compute problem counts
+    if (WORKLOAD_KINDS.has(kindLower)) {
+      const problemCounts: Record<string, number> = {}
+      WORKLOAD_PROBLEMS.forEach(p => problemCounts[p] = 0)
+
+      for (const resource of resources) {
+        const workloadProblems = getWorkloadProblems(resource, kindLower)
+        for (const category of WORKLOAD_PROBLEMS) {
+          if (workloadMatchesProblemCategory(workloadProblems, category)) {
+            problemCounts[category]++
+          }
+        }
+      }
+
+      const activeProblems = WORKLOAD_PROBLEMS
         .map(p => ({ value: p, count: problemCounts[p] }))
         .filter(p => p.count > 0)
       if (activeProblems.length > 0) {
@@ -4003,11 +4037,11 @@ function PodCell({ resource, column }: { resource: any; column: string }) {
       const status = getPodStatus(resource)
       const problems = getPodProblems(resource)
       return (
-        <div className="flex items-center gap-2">
-          <span className={clsx('badge', status.color)}>
+        <div className="flex items-center gap-2 min-w-0">
+          <span className={clsx('badge truncate', status.color)} title={status.text}>
             {status.text}
           </span>
-          {problems.length > 0 && (
+          {problems.length > 1 && (
             <Tooltip content={
               <div className="space-y-0.5">
                 {problems.map((p, i) => (
@@ -4092,7 +4126,7 @@ function PodCell({ resource, column }: { resource: any; column: string }) {
   }
 }
 
-function WorkloadCell({ resource, column }: { resource: any; kind: string; column: string }) {
+function WorkloadCell({ resource, column, kind }: { resource: any; kind: string; column: string }) {
   const status = resource.status || {}
   const spec = resource.spec || {}
 
@@ -4101,13 +4135,32 @@ function WorkloadCell({ resource, column }: { resource: any; kind: string; colum
       const desired = spec.replicas ?? 0
       const ready = status.readyReplicas || 0
       const allReady = ready === desired && desired > 0
+      const problems = getWorkloadProblems(resource, kind)
       return (
-        <span className={clsx(
-          'text-sm font-medium',
-          desired === 0 ? 'text-theme-text-secondary' : allReady ? 'text-green-400' : ready > 0 ? 'text-yellow-400' : 'text-red-400'
-        )}>
-          {ready}/{desired}
-        </span>
+        <div className="flex items-center gap-1.5">
+          <span className={clsx(
+            'text-sm font-medium',
+            desired === 0 ? 'text-theme-text-secondary' : allReady ? 'text-green-400' : ready > 0 ? 'text-yellow-400' : 'text-red-400'
+          )}>
+            {ready}/{desired}
+          </span>
+          {problems.length > 0 && (
+            <Tooltip content={
+              <div className="space-y-0.5">
+                {problems.map((p, i) => (
+                  <div key={i} className="flex items-center gap-1.5">
+                    <span className={clsx('w-1.5 h-1.5 rounded-full shrink-0', SEVERITY_DOT_COLOR[p.severity])} />
+                    <span>{p.message}</span>
+                  </div>
+                ))}
+              </div>
+            }>
+              <span className="text-red-400">
+                <AlertTriangle className="w-3.5 h-3.5" />
+              </span>
+            </Tooltip>
+          )}
+        </div>
       )
     }
     case 'upToDate':
@@ -4158,13 +4211,32 @@ function DaemonSetCell({ resource, column }: { resource: any; column: string }) 
       const desired = status.desiredNumberScheduled || 0
       const ready = status.numberReady || 0
       const allReady = ready === desired && desired > 0
+      const problems = getWorkloadProblems(resource, 'daemonsets')
       return (
-        <span className={clsx(
-          'text-sm font-medium',
-          allReady ? 'text-green-400' : ready > 0 ? 'text-yellow-400' : 'text-red-400'
-        )}>
-          {ready}
-        </span>
+        <div className="flex items-center gap-1.5">
+          <span className={clsx(
+            'text-sm font-medium',
+            allReady ? 'text-green-400' : ready > 0 ? 'text-yellow-400' : 'text-red-400'
+          )}>
+            {ready}
+          </span>
+          {problems.length > 0 && (
+            <Tooltip content={
+              <div className="space-y-0.5">
+                {problems.map((p, i) => (
+                  <div key={i} className="flex items-center gap-1.5">
+                    <span className={clsx('w-1.5 h-1.5 rounded-full shrink-0', SEVERITY_DOT_COLOR[p.severity])} />
+                    <span>{p.message}</span>
+                  </div>
+                ))}
+              </div>
+            }>
+              <span className="text-red-400">
+                <AlertTriangle className="w-3.5 h-3.5" />
+              </span>
+            </Tooltip>
+          )}
+        </div>
       )
     }
     case 'upToDate':

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -140,7 +140,7 @@ import { ResourcesSidebar } from './ResourcesSidebar'
 import type { SelectedKindInfo } from './ResourcesSidebar'
 
 // Pod problem filter options (special multi-select, not a single column value)
-const POD_PROBLEMS = ['CrashLoopBackOff', 'ImagePullBackOff', 'OOMKilled', 'Unschedulable', 'Not Ready', 'High Restarts'] as const
+const POD_PROBLEMS = ['CrashLoopBackOff', 'ImagePullBackOff', 'OOMKilled', 'Unschedulable', 'Not Ready', 'High Restarts', 'Init Failed', 'Exit Code Error', 'Failed'] as const
 
 // Columns to skip for auto-detected filters (high cardinality, text-like, or non-filterable)
 const SKIP_FILTER_COLUMNS = new Set([
@@ -2486,7 +2486,7 @@ export function ResourcesView({
         case 'CrashLoopBackOff':
           return problemMessages.includes('CrashLoopBackOff')
         case 'ImagePullBackOff':
-          return problemMessages.some(m => m.includes('ImagePull'))
+          return problemMessages.some(m => m.includes('ImagePull') && !m.startsWith('Init:'))
         case 'OOMKilled':
           return problemMessages.includes('OOMKilled')
         case 'Unschedulable':
@@ -2495,6 +2495,12 @@ export function ResourcesView({
           return problemMessages.includes('Not Ready') || problemMessages.some(m => m.includes('Probe'))
         case 'High Restarts':
           return restarts > 5
+        case 'Init Failed':
+          return problemMessages.some(m => m.startsWith('Init:'))
+        case 'Exit Code Error':
+          return problemMessages.some(m => m.startsWith('Exit Code'))
+        case 'Failed':
+          return problemMessages.includes('Failed') || problemMessages.includes('Unknown')
         default:
           return false
       }
@@ -2808,11 +2814,14 @@ export function ResourcesView({
         const restarts = getPodRestarts(pod)
 
         if (msgs.includes('CrashLoopBackOff')) problemCounts['CrashLoopBackOff']++
-        if (msgs.some(m => m.includes('ImagePull'))) problemCounts['ImagePullBackOff']++
+        if (msgs.some(m => m.includes('ImagePull') && !m.startsWith('Init:'))) problemCounts['ImagePullBackOff']++
         if (msgs.includes('OOMKilled')) problemCounts['OOMKilled']++
         if (msgs.includes('Unschedulable')) problemCounts['Unschedulable']++
         if (msgs.includes('Not Ready') || msgs.some(m => m.includes('Probe'))) problemCounts['Not Ready']++
         if (restarts > 5) problemCounts['High Restarts']++
+        if (msgs.some(m => m.startsWith('Init:'))) problemCounts['Init Failed']++
+        if (msgs.some(m => m.startsWith('Exit Code'))) problemCounts['Exit Code Error']++
+        if (msgs.includes('Failed') || msgs.includes('Unknown')) problemCounts['Failed']++
       }
 
       const activeProblems = POD_PROBLEMS
@@ -4028,7 +4037,20 @@ function PodCell({ resource, column }: { resource: any; column: string }) {
             {status.text}
           </span>
           {problems.length > 0 && (
-            <Tooltip content={problems.map(p => p.message).join(', ')}>
+            <Tooltip content={
+              <div className="space-y-0.5">
+                {problems.map((p, i) => (
+                  <div key={i} className="flex items-center gap-1.5">
+                    <span className={clsx('w-1.5 h-1.5 rounded-full shrink-0', {
+                      'bg-red-400': p.severity === 'critical',
+                      'bg-orange-400': p.severity === 'high',
+                      'bg-yellow-400': p.severity === 'medium',
+                    })} />
+                    <span>{p.message}</span>
+                  </div>
+                ))}
+              </div>
+            }>
               <span className="text-red-400">
                 <AlertTriangle className="w-3.5 h-3.5" />
               </span>

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
@@ -2,7 +2,7 @@ import { useState, type ReactNode, type JSX } from 'react'
 import { Server, HardDrive, Terminal as TerminalIcon, FileText, Activity, CirclePlay, FolderOpen, List, Eye, EyeOff } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, CopyHandler, AlertBanner, ResourceLink } from '../../ui/drawer-components'
-import { formatResources, formatDuration, getPodProblems } from '../resource-utils'
+import { formatResources, formatDuration, getPodProblems, SEVERITY_DOT_COLOR } from '../resource-utils'
 import { getResourceStatusColor, SEVERITY_BADGE_BORDERED } from '../../../utils/badge-colors'
 import type { ResolvedEnvFrom } from '../../../types'
 import { Tooltip } from '../../ui/Tooltip'
@@ -323,11 +323,7 @@ export function PodRenderer({
           <ul className="text-xs space-y-1">
             {podProblems.map((p, i) => (
               <li key={i} className="flex items-center gap-1.5">
-                <span className={clsx('w-1.5 h-1.5 rounded-full shrink-0', {
-                  'bg-red-500': p.severity === 'critical',
-                  'bg-orange-400': p.severity === 'high',
-                  'bg-yellow-400': p.severity === 'medium',
-                })} />
+                <span className={clsx('w-1.5 h-1.5 rounded-full shrink-0', SEVERITY_DOT_COLOR[p.severity])} />
                 <span className="text-red-600 dark:text-red-400">{p.message}</span>
               </li>
             ))}

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
@@ -2,7 +2,7 @@ import { useState, type ReactNode, type JSX } from 'react'
 import { Server, HardDrive, Terminal as TerminalIcon, FileText, Activity, CirclePlay, FolderOpen, List, Eye, EyeOff } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, CopyHandler, AlertBanner, ResourceLink } from '../../ui/drawer-components'
-import { formatResources, formatDuration } from '../resource-utils'
+import { formatResources, formatDuration, getPodProblems } from '../resource-utils'
 import { getResourceStatusColor, SEVERITY_BADGE_BORDERED } from '../../../utils/badge-colors'
 import type { ResolvedEnvFrom } from '../../../types'
 import { Tooltip } from '../../ui/Tooltip'
@@ -77,69 +77,6 @@ interface PodRendererProps {
   resolvedEnvFrom?: ResolvedEnvFrom
 }
 
-// Extract problems from pod status and conditions
-function getPodProblems(data: any): string[] {
-  const problems: string[] = []
-  const phase = data.status?.phase
-  const conditions = data.status?.conditions || []
-  const containerStatuses = data.status?.containerStatuses || []
-  const initContainerStatuses = data.status?.initContainerStatuses || []
-
-  // Check phase
-  if (phase === 'Failed' || phase === 'Unknown') {
-    problems.push(`Pod is in ${phase} state`)
-  }
-
-  // Check conditions for scheduling/init issues
-  for (const cond of conditions) {
-    if (cond.status === 'False') {
-      if (cond.type === 'PodScheduled' && cond.reason) {
-        problems.push(`Scheduling: ${cond.reason}${cond.message ? ' - ' + cond.message : ''}`)
-      } else if (cond.type === 'Initialized' && cond.message) {
-        problems.push(`Init failed: ${cond.message}`)
-      } else if (cond.type === 'ContainersReady' && cond.reason === 'ContainersNotReady') {
-        // Will be covered by container status details
-      } else if (cond.message) {
-        problems.push(`${cond.type}: ${cond.message}`)
-      }
-    }
-  }
-
-  // Check init container failures
-  for (const initStatus of initContainerStatuses) {
-    if (initStatus.state?.waiting?.reason && initStatus.state.waiting.reason !== 'PodInitializing') {
-      problems.push(`Init container "${initStatus.name}": ${initStatus.state.waiting.reason}`)
-    }
-    if (initStatus.state?.terminated?.exitCode && initStatus.state.terminated.exitCode !== 0) {
-      problems.push(`Init container "${initStatus.name}" failed with exit code ${initStatus.state.terminated.exitCode}`)
-    }
-  }
-
-  // Check container issues (most important)
-  for (const status of containerStatuses) {
-    const waiting = status.state?.waiting
-    const terminated = status.state?.terminated
-
-    if (waiting?.reason && waiting.reason !== 'ContainerCreating') {
-      const msg = `Container "${status.name}": ${waiting.reason}`
-      if (waiting.reason === 'ImagePullBackOff' || waiting.reason === 'ErrImagePull') {
-        problems.push(msg + (waiting.message ? ` - ${waiting.message.slice(0, 100)}` : ''))
-      } else if (waiting.reason === 'CrashLoopBackOff') {
-        problems.push(msg + ' (container keeps crashing)')
-      } else {
-        problems.push(msg)
-      }
-    }
-
-    if (terminated?.reason === 'OOMKilled') {
-      problems.push(`Container "${status.name}" was OOMKilled - increase memory limit`)
-    } else if (terminated?.exitCode && terminated.exitCode !== 0) {
-      problems.push(`Container "${status.name}" exited with code ${terminated.exitCode}`)
-    }
-  }
-
-  return problems
-}
 
 // ── Env vars section — extracted to use hooks (useState for reveal) ──────────
 
@@ -315,8 +252,8 @@ export function PodRenderer({
   const isRunning = data.status?.phase === 'Running'
 
   // Check for problems
-  const problems = getPodProblems(data)
-  const hasProblems = problems.length > 0
+  const podProblems = getPodProblems(data)
+  const hasProblems = podProblems.length > 0
 
   // Image filesystem modal state
   const [selectedImage, setSelectedImage] = useState<string | null>(null)
@@ -382,7 +319,20 @@ export function PodRenderer({
     <>
       {/* Problems alert - shown at top when there are issues */}
       {hasProblems && (
-        <AlertBanner variant="error" title="Issues Detected" items={problems} />
+        <AlertBanner variant="error" title="Issues Detected">
+          <ul className="text-xs space-y-1">
+            {podProblems.map((p, i) => (
+              <li key={i} className="flex items-center gap-1.5">
+                <span className={clsx('w-1.5 h-1.5 rounded-full shrink-0', {
+                  'bg-red-500': p.severity === 'critical',
+                  'bg-orange-400': p.severity === 'high',
+                  'bg-yellow-400': p.severity === 'medium',
+                })} />
+                <span className="text-red-600 dark:text-red-400">{p.message}</span>
+              </li>
+            ))}
+          </ul>
+        </AlertBanner>
       )}
 
       {/* Status section */}

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
@@ -77,7 +77,6 @@ interface PodRendererProps {
   resolvedEnvFrom?: ResolvedEnvFrom
 }
 
-
 // ── Env vars section — extracted to use hooks (useState for reveal) ──────────
 
 function SecretValueCell({ value }: { value: string }) {

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -87,7 +87,31 @@ export function getPodStatus(pod: any): StatusBadge {
 export function getPodProblems(pod: any): PodProblem[] {
   const problems: PodProblem[] = []
   const containerStatuses = pod.status?.containerStatuses || []
+  const initContainerStatuses = pod.status?.initContainerStatuses || []
   const conditions = pod.status?.conditions || []
+  const phase = pod.status?.phase
+
+  // Failed or Unknown phase
+  if (phase === 'Failed' && pod.status?.reason !== 'Evicted') {
+    problems.push({ severity: 'critical', message: 'Failed' })
+  } else if (phase === 'Unknown') {
+    problems.push({ severity: 'high', message: 'Unknown' })
+  }
+
+  // Init container failures
+  for (const cs of initContainerStatuses) {
+    if (cs.state?.waiting?.reason && cs.state.waiting.reason !== 'PodInitializing') {
+      const reason = cs.state.waiting.reason
+      if (['CrashLoopBackOff', 'ImagePullBackOff', 'ErrImagePull'].includes(reason)) {
+        problems.push({ severity: 'critical', message: `Init: ${reason}` })
+      } else {
+        problems.push({ severity: 'high', message: `Init: ${reason}` })
+      }
+    }
+    if (cs.state?.terminated?.exitCode && cs.state.terminated.exitCode !== 0) {
+      problems.push({ severity: 'high', message: `Init: Exit Code ${cs.state.terminated.exitCode}` })
+    }
+  }
 
   for (const cs of containerStatuses) {
     // Check waiting state
@@ -104,6 +128,8 @@ export function getPodProblems(pod: any): PodProblem[] {
     // Check terminated state
     if (cs.state?.terminated?.reason === 'OOMKilled') {
       problems.push({ severity: 'critical', message: 'OOMKilled' })
+    } else if (cs.state?.terminated?.exitCode && cs.state.terminated.exitCode !== 0) {
+      problems.push({ severity: 'high', message: `Exit Code ${cs.state.terminated.exitCode}` })
     }
     // High restart count
     if (cs.restartCount > 5) {
@@ -142,7 +168,7 @@ export function getPodProblems(pod: any): PodProblem[] {
   }
 
   // Evicted pods
-  if (pod.status?.phase === 'Failed' && pod.status?.reason === 'Evicted') {
+  if (phase === 'Failed' && pod.status?.reason === 'Evicted') {
     problems.push({ severity: 'high', message: 'Evicted' })
   }
 
@@ -156,7 +182,6 @@ export function getPodProblems(pod: any): PodProblem[] {
   }
 
   // Not ready (Running but containers not ready)
-  const phase = pod.status?.phase
   if (phase === 'Running') {
     const readyContainers = containerStatuses.filter((c: any) => c.ready).length
     const totalContainers = containerStatuses.length

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -42,6 +42,40 @@ export interface PodProblem {
   message: string
 }
 
+/** Tailwind classes for severity dot indicators (used in tooltips and alert banners) */
+export const SEVERITY_DOT_COLOR: Record<PodProblem['severity'], string> = {
+  critical: 'bg-red-400',
+  high: 'bg-orange-400',
+  medium: 'bg-yellow-400',
+}
+
+/** Check whether a pod's problems match a given problem category (filter chip label) */
+export function podMatchesProblemCategory(problems: PodProblem[], restarts: number, category: string): boolean {
+  const msgs = problems.map(p => p.message)
+  switch (category) {
+    case 'CrashLoopBackOff':
+      return msgs.includes('CrashLoopBackOff')
+    case 'ImagePullBackOff':
+      return msgs.some(m => m.includes('ImagePull') && !m.startsWith('Init:'))
+    case 'OOMKilled':
+      return msgs.includes('OOMKilled')
+    case 'Unschedulable':
+      return msgs.includes('Unschedulable')
+    case 'Not Ready':
+      return msgs.includes('Not Ready') || msgs.some(m => m.includes('Probe'))
+    case 'High Restarts':
+      return restarts > 5
+    case 'Init Failed':
+      return msgs.some(m => m.startsWith('Init:'))
+    case 'Exit Code Error':
+      return msgs.some(m => m.startsWith('Exit Code'))
+    case 'Failed':
+      return msgs.includes('Failed') || msgs.includes('Unknown')
+    default:
+      return false
+  }
+}
+
 export function getPodStatus(pod: any): StatusBadge {
   const phase = pod.status?.phase || 'Unknown'
   const containerStatuses = pod.status?.containerStatuses || []
@@ -123,6 +157,8 @@ export function getPodProblems(pod: any): PodProblem[] {
         problems.push({ severity: 'critical', message: 'Config Error' })
       } else if (reason === 'ContainerCannotRun') {
         problems.push({ severity: 'critical', message: 'Cannot Run' })
+      } else if (reason !== 'ContainerCreating' && reason !== 'PodInitializing') {
+        problems.push({ severity: 'high', message: reason })
       }
     }
     // Check terminated state

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -71,6 +71,10 @@ export function podMatchesProblemCategory(problems: PodProblem[], restarts: numb
       return msgs.some(m => m.startsWith('Exit Code'))
     case 'Failed':
       return msgs.includes('Failed') || msgs.includes('Unknown')
+    case 'Other': {
+      const knownPatterns = ['CrashLoopBackOff', 'ImagePull', 'ErrImagePull', 'OOMKilled', 'Unschedulable', 'Not Ready', 'Probe', 'Init:', 'Exit Code', 'Failed', 'Unknown']
+      return problems.some(p => !knownPatterns.some(pat => p.message.includes(pat)) && p.message !== `${restarts} restarts`)
+    }
     default:
       return false
   }
@@ -394,6 +398,70 @@ export function getWorkloadStatus(resource: any, kind: string): StatusBadge {
     return { text: `${ready}/${desired}`, color: healthColors.degraded, level: 'degraded' }
   }
   return { text: `${ready}/${desired}`, color: healthColors.unhealthy, level: 'unhealthy' }
+}
+
+/** Detect problems for Deployments, StatefulSets, DaemonSets. Parallel to getPodProblems. */
+export function getWorkloadProblems(resource: any, kind: string): PodProblem[] {
+  const problems: PodProblem[] = []
+  const status = resource.status || {}
+  const spec = resource.spec || {}
+  const k = kind.toLowerCase()
+
+  if (k === 'daemonsets') {
+    const desired = status.desiredNumberScheduled || 0
+    const ready = status.numberReady || 0
+    if (desired > 0 && ready === 0) {
+      problems.push({ severity: 'critical', message: 'No pods ready' })
+    } else if (desired > 0 && ready < desired) {
+      problems.push({ severity: 'high', message: `${desired - ready} pods unavailable` })
+    }
+    return problems
+  }
+
+  // Deployment, StatefulSet
+  const desired = spec.replicas ?? status.replicas ?? 0
+  const ready = status.readyReplicas || 0
+  const available = status.availableReplicas ?? ready
+  const updated = status.updatedReplicas || 0
+
+  if (desired === 0) return problems
+
+  if (ready === 0 && desired > 0) {
+    problems.push({ severity: 'critical', message: 'No pods ready' })
+  } else if (available < desired) {
+    problems.push({ severity: 'high', message: `${desired - available} pods unavailable` })
+  }
+
+  if (updated > 0 && updated < desired) {
+    problems.push({ severity: 'medium', message: 'Rollout in progress' })
+  }
+
+  // Check conditions for stuck rollouts (Deployment only)
+  if (k === 'deployments') {
+    const conditions = status.conditions || []
+    for (const cond of conditions) {
+      if (cond.type === 'Progressing' && cond.status === 'False' && cond.reason === 'ProgressDeadlineExceeded') {
+        problems.push({ severity: 'critical', message: 'Rollout stuck' })
+      }
+    }
+  }
+
+  return problems
+}
+
+/** Check whether a workload's problems match a given problem category */
+export function workloadMatchesProblemCategory(problems: PodProblem[], category: string): boolean {
+  const msgs = problems.map(p => p.message)
+  switch (category) {
+    case 'Unavailable':
+      return msgs.some(m => m.includes('unavailable') || m.includes('No pods ready'))
+    case 'Rollout Stuck':
+      return msgs.includes('Rollout stuck')
+    case 'Rollout In Progress':
+      return msgs.includes('Rollout in progress')
+    default:
+      return false
+  }
 }
 
 export function getWorkloadImages(resource: any): string[] {
@@ -1386,37 +1454,6 @@ export function getRoleBindingSubjectCount(rb: any): number {
 // WORKLOAD PROBLEM DETECTION (for table row indicators)
 // ============================================================================
 
-export function getWorkloadProblems(resource: any, kind: string): string[] {
-  const problems: string[] = []
-  const status = resource.status || {}
-  const spec = resource.spec || {}
-
-  if (kind === 'daemonsets') {
-    const ready = status.numberReady || 0
-    const desired = status.desiredNumberScheduled || 0
-    if (desired > 0 && ready < desired) {
-      problems.push(`${desired - ready} pods not ready`)
-    }
-  } else {
-    const ready = status.readyReplicas || 0
-    const desired = spec.replicas ?? 0
-    if (desired > 0 && ready < desired) {
-      problems.push(`${desired - ready} replicas not ready`)
-    }
-  }
-
-  const conditions = status.conditions || []
-  for (const cond of conditions) {
-    if (cond.status === 'True' && cond.type === 'ReplicaFailure') {
-      problems.push('ReplicaFailure')
-    }
-    if (cond.status === 'False' && cond.type === 'Available') {
-      problems.push('Unavailable')
-    }
-  }
-
-  return problems
-}
 
 // ============================================================================
 // FORMATTING UTILITIES

--- a/packages/k8s-ui/src/components/timeline/TimelineList.tsx
+++ b/packages/k8s-ui/src/components/timeline/TimelineList.tsx
@@ -603,10 +603,17 @@ function ActivityCard({ item, expanded, onToggle, onResourceClick }: ActivityCar
               {item.owner && (
                 <span className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
                   <span className="text-xs text-theme-text-quaternary">←</span>
-                  <ResourceRefBadge
-                    resourceRef={{ kind: item.owner.kind, namespace: item.namespace, name: item.owner.name }}
-                    onClick={(ref) => onResourceClick?.(refToSelectedResource(ref))}
-                  />
+                  {item.owner.kind === 'ReplicaSet' ? (
+                    <ResourceRefBadge
+                      resourceRef={{ kind: 'Deployment', namespace: item.namespace, name: item.owner.name.replace(/-[a-z0-9]+$/, '') }}
+                      onClick={(ref) => onResourceClick?.(refToSelectedResource(ref))}
+                    />
+                  ) : (
+                    <ResourceRefBadge
+                      resourceRef={{ kind: item.owner.kind, namespace: item.namespace, name: item.owner.name }}
+                      onClick={(ref) => onResourceClick?.(refToSelectedResource(ref))}
+                    />
+                  )}
                 </span>
               )}
               {item.createdAt && (

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -107,7 +107,7 @@ export interface DashboardProblem {
   kind: string
   namespace: string
   name: string
-  status: string
+  severity: string
   reason: string
   message: string
   age: string

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -107,11 +107,14 @@ export interface DashboardProblem {
   kind: string
   namespace: string
   name: string
-  severity: string
+  severity: 'critical' | 'high' | 'medium'
   reason: string
   message: string
   age: string
   ageSeconds: number
+  duration: string
+  durationSeconds: number
+  podCount?: number
 }
 
 export interface WorkloadCount {

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -198,7 +198,7 @@ function ProblemsPanel({ problems, onResourceClick }: ProblemsPanelProps) {
             >
               <span className={clsx(
                 'w-1.5 h-1.5 rounded-full shrink-0',
-                p.status === 'error' ? 'bg-red-500' : 'bg-yellow-500'
+                p.severity === 'error' ? 'bg-red-500' : 'bg-yellow-500'
               )} />
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-1.5">

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -198,18 +198,21 @@ function ProblemsPanel({ problems, onResourceClick }: ProblemsPanelProps) {
             >
               <span className={clsx(
                 'w-1.5 h-1.5 rounded-full shrink-0',
-                p.severity === 'error' ? 'bg-red-500' : 'bg-yellow-500'
+                p.severity === 'critical' ? 'bg-red-400' : p.severity === 'high' ? 'bg-orange-400' : 'bg-yellow-400'
               )} />
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-1.5">
                   <span className="text-[10px] text-theme-text-tertiary bg-theme-elevated px-1 py-0.5 rounded">{p.kind}</span>
                   <span className="text-xs text-theme-text-primary truncate font-medium">{p.name}</span>
-                  <span className="text-[10px] text-theme-text-tertiary ml-auto shrink-0">{p.age}</span>
+                  <span className="text-[10px] text-theme-text-tertiary ml-auto shrink-0">{p.duration || p.age}</span>
                 </div>
                 <div className="flex items-center gap-1.5 mt-0.5">
                   <span className="text-[11px] text-theme-text-secondary truncate">{p.reason}</span>
                   <span className="text-[10px] text-theme-text-tertiary shrink-0">{p.namespace}</span>
                 </div>
+                {p.message && (
+                  <div className="text-[10px] text-theme-text-tertiary truncate mt-0.5">{p.message}</div>
+                )}
               </div>
             </button>
           ))}


### PR DESCRIPTION
## Summary

Comprehensive overhaul of Radar's problem detection and display system, informed by competitor analysis.

### Unified severity vocabulary
Aligned backend and frontend to a single `critical` / `high` / `medium` severity model. Previously split between backend `error/warning` and frontend `critical/high/medium`. Consistent color-coded severity dots (red/orange/yellow) across all views — dashboard, tables, drawers. Node pressure upgraded from `high` to `critical` (actively evicts pods).

### Problem duration
Dashboard problems now show how long the problem has persisted using K8s condition `lastTransitionTime`, instead of resource creation age. "Broken for 15m" is more actionable than "created 30d ago".

### Workload-level dashboard rollup
Pod problems grouped by owner workload. Instead of 6 individual pod entries, shows "Deployment X — 2 pods unhealthy (CrashLoopBackOff, ImagePullBackOff)". Orphan pods remain individual. Click navigates to the workload.

### Workload problem detection in tables
Deployment/StatefulSet/DaemonSet tables now have warning triangles on the Ready column with severity tooltips, plus filter chips (Unavailable, Rollout Stuck, Rollout In Progress).

### Consolidated pod problem detection
- Merged duplicate `getPodProblems` into single shared implementation
- Added: init container failures, non-zero exit codes, Failed/Unknown phase, catch-all for unknown waiting reasons
- "Other" catch-all filter for unfilterable problem types (Config Error, Evicted, Volume Mount Failed, etc.)
- Renamed `DashboardProblem.Status` → `Severity`

### New runtime checks
- PVC Pending (>5 min) — stuck volume claims blocking workloads
- Job stuck active (>1h with no completions)
- Deployment stuck rollout (ProgressDeadlineExceeded) in backend

### Other improvements
- Timeline: Pod events show parent Deployment link instead of ReplicaSet hash
- Pod table: badge truncation fix, tooltip only shown for multi-problem pods
- Extracted shared `SEVERITY_DOT_COLOR` and `podMatchesProblemCategory` utilities