### PR TITLE
Add shared LabelSelectorDisplay, Trivy search, and consolidate alert patterns

### DIFF
--- a/packages/k8s-ui/src/components/resources/renderers/CiliumNetworkPolicyRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CiliumNetworkPolicyRenderer.tsx
@@ -254,7 +254,7 @@ function CiliumRuleCard({ rule }: { rule: any }) {
           <div className="flex flex-wrap gap-1">
             {toServices.map((svc: any, j: number) => {
               const k8s = svc.k8sService
-              const sel = svc.k8sServiceNamespace
+              const sel = svc.k8sServiceSelector
               if (k8s) {
                 const ns = k8s.namespace ? `${k8s.namespace}/` : ''
                 return (
@@ -264,7 +264,7 @@ function CiliumRuleCard({ rule }: { rule: any }) {
                 )
               }
               if (sel) {
-                return <LabelSelectorDisplay key={j} selector={sel} />
+                return <LabelSelectorDisplay key={j} selector={sel.selector || sel} />
               }
               return (
                 <span key={j} className="badge bg-theme-elevated text-theme-text-secondary">

--- a/packages/k8s-ui/src/components/resources/renderers/CiliumNetworkPolicyRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CiliumNetworkPolicyRenderer.tsx
@@ -1,5 +1,5 @@
 import { Shield, ArrowDownToLine, ArrowUpFromLine, Ban, Lock } from 'lucide-react'
-import { Section, PropertyList, Property } from '../../ui/drawer-components'
+import { Section, LabelSelectorDisplay } from '../../ui/drawer-components'
 
 interface CiliumNetworkPolicyRendererProps {
   data: any
@@ -8,8 +8,6 @@ interface CiliumNetworkPolicyRendererProps {
 export function CiliumNetworkPolicyRenderer({ data }: CiliumNetworkPolicyRendererProps) {
   const spec = data.spec || data.specs || {}
   const endpointSelector = spec.endpointSelector || {}
-  const matchLabels = endpointSelector.matchLabels || {}
-  const hasMatchLabels = Object.keys(matchLabels).length > 0
   const ingress: any[] | undefined = spec.ingress
   const ingressDeny: any[] | undefined = spec.ingressDeny
   const egress: any[] | undefined = spec.egress
@@ -23,34 +21,14 @@ export function CiliumNetworkPolicyRenderer({ data }: CiliumNetworkPolicyRendere
         {description && (
           <p className="text-xs text-theme-text-secondary mb-2">{description}</p>
         )}
-        <PropertyList>
-          <Property
-            label="Endpoint Selector"
-            value={hasMatchLabels ? undefined : 'All endpoints in namespace'}
-          />
-        </PropertyList>
-        {hasMatchLabels && (
-          <div className="mt-2">
-            <div className="text-xs text-theme-text-tertiary mb-1">Endpoint Selector</div>
-            <div className="flex flex-wrap gap-1">
-              {Object.entries(matchLabels).map(([k, v]) => (
-                <span key={k} className="badge bg-theme-elevated text-theme-text-secondary">
-                  {k}={String(v)}
-                </span>
-              ))}
-            </div>
-          </div>
-        )}
+        <div className="mt-2">
+          <div className="text-xs text-theme-text-tertiary mb-1">Endpoint Selector</div>
+          <LabelSelectorDisplay selector={endpointSelector} emptyText="All endpoints in namespace" />
+        </div>
         {spec.nodeSelector && (
           <div className="mt-2">
             <div className="text-xs text-theme-text-tertiary mb-1">Node Selector</div>
-            <div className="flex flex-wrap gap-1">
-              {Object.entries(spec.nodeSelector.matchLabels || {}).map(([k, v]) => (
-                <span key={k} className="badge bg-theme-elevated text-theme-text-secondary">
-                  {k}={String(v)}
-                </span>
-              ))}
-            </div>
+            <LabelSelectorDisplay selector={spec.nodeSelector} emptyText="All nodes" />
           </div>
         )}
         {enableDefaultDeny && (
@@ -155,7 +133,7 @@ function CiliumRuleCard({ rule }: { rule: any }) {
           <div className="text-xs text-theme-text-tertiary mb-1">From Endpoints</div>
           <div className="space-y-1">
             {fromEndpoints.map((ep: any, j: number) => (
-              <SelectorEntry key={j} selector={ep} />
+              <LabelSelectorDisplay key={j} selector={ep} emptyText="all endpoints" inline />
             ))}
           </div>
         </div>
@@ -204,7 +182,7 @@ function CiliumRuleCard({ rule }: { rule: any }) {
           <div className="text-xs text-theme-text-tertiary mb-1">From Nodes</div>
           <div className="space-y-1">
             {fromNodes.map((node: any, j: number) => (
-              <SelectorEntry key={j} selector={node} />
+              <LabelSelectorDisplay key={j} selector={node} />
             ))}
           </div>
         </div>
@@ -226,7 +204,7 @@ function CiliumRuleCard({ rule }: { rule: any }) {
           <div className="text-xs text-theme-text-tertiary mb-1">To Endpoints</div>
           <div className="space-y-1">
             {toEndpoints.map((ep: any, j: number) => (
-              <SelectorEntry key={j} selector={ep} />
+              <LabelSelectorDisplay key={j} selector={ep} emptyText="all endpoints" inline />
             ))}
           </div>
         </div>
@@ -286,7 +264,7 @@ function CiliumRuleCard({ rule }: { rule: any }) {
                 )
               }
               if (sel) {
-                return <SelectorEntry key={j} selector={sel} />
+                return <LabelSelectorDisplay key={j} selector={sel} />
               }
               return (
                 <span key={j} className="badge bg-theme-elevated text-theme-text-secondary">
@@ -303,7 +281,7 @@ function CiliumRuleCard({ rule }: { rule: any }) {
           <div className="text-xs text-theme-text-tertiary mb-1">To Nodes</div>
           <div className="space-y-1">
             {toNodes.map((node: any, j: number) => (
-              <SelectorEntry key={j} selector={node} />
+              <LabelSelectorDisplay key={j} selector={node} />
             ))}
           </div>
         </div>
@@ -463,25 +441,5 @@ function CloudGroupEntry({ group }: { group: any }) {
     <span className="badge bg-theme-elevated text-theme-text-secondary">
       {JSON.stringify(group)}
     </span>
-  )
-}
-
-function SelectorEntry({ selector }: { selector: any }) {
-  const matchLabels = selector.matchLabels || {}
-  const hasLabels = Object.keys(matchLabels).length > 0
-  return (
-    <div className="text-sm">
-      {hasLabels ? (
-        <span className="inline-flex flex-wrap gap-1 align-middle">
-          {Object.entries(matchLabels).map(([k, v]) => (
-            <span key={k} className="badge bg-theme-elevated text-theme-text-secondary">
-              {k}={String(v)}
-            </span>
-          ))}
-        </span>
-      ) : (
-        <span className="text-xs text-theme-text-tertiary">all endpoints</span>
-      )}
-    </div>
   )
 }

--- a/packages/k8s-ui/src/components/resources/renderers/ClusterComplianceReportRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ClusterComplianceReportRenderer.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { ShieldCheck, ChevronDown, ChevronRight, CheckCircle2, XCircle } from 'lucide-react'
+import { useState, useMemo } from 'react'
+import { ShieldCheck, ChevronDown, ChevronRight, CheckCircle2, XCircle, Search } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, AlertBanner } from '../../ui/drawer-components'
 import { formatAge } from '../resource-utils'
@@ -12,6 +12,8 @@ interface ClusterComplianceReportRendererProps {
 export function ClusterComplianceReportRenderer({ data }: ClusterComplianceReportRendererProps) {
   const [expandedSection, setExpandedSection] = useState(true)
   const [expandedControls, setExpandedControls] = useState<Set<string>>(new Set())
+  const [searchTerm, setSearchTerm] = useState('')
+  const [showFailedOnly, setShowFailedOnly] = useState(false)
 
   const compliance = data.spec?.compliance || {}
   const status = data.status || {}
@@ -24,18 +26,40 @@ export function ClusterComplianceReportRenderer({ data }: ClusterComplianceRepor
   const total = passCount + failCount
 
   // Build a map of control definitions for descriptions
-  const controlMap = new Map<string, any>()
-  for (const ctrl of controls) {
-    if (ctrl.id) controlMap.set(ctrl.id, ctrl)
-  }
+  const controlMap = useMemo(() => {
+    const map = new Map<string, any>()
+    for (const ctrl of controls) {
+      if (ctrl.id) map.set(ctrl.id, ctrl)
+    }
+    return map
+  }, [controls])
 
   // Sort: failed first by severity, then passed
-  const sortedChecks = [...controlChecks].sort((a: any, b: any) => {
+  const sortedChecks = useMemo(() => [...controlChecks].sort((a: any, b: any) => {
     const aFail = (a.totalFail || 0) > 0
     const bFail = (b.totalFail || 0) > 0
     if (aFail !== bFail) return aFail ? -1 : 1
     return (SEVERITY_ORDER[a.severity] ?? 99) - (SEVERITY_ORDER[b.severity] ?? 99)
-  })
+  }), [controlChecks])
+
+  const filteredChecks = useMemo(() => {
+    let result = sortedChecks
+    if (showFailedOnly) {
+      result = result.filter((c: any) => (c.totalFail || 0) > 0)
+    }
+    if (searchTerm) {
+      const term = searchTerm.toLowerCase()
+      result = result.filter((c: any) => {
+        const def = controlMap.get(c.id)
+        return (c.name || '').toLowerCase().includes(term) ||
+          (c.id || '').toLowerCase().includes(term) ||
+          (def?.description || '').toLowerCase().includes(term)
+      })
+    }
+    return result
+  }, [sortedChecks, searchTerm, showFailedOnly, controlMap])
+
+  const hasActiveFilter = searchTerm !== '' || showFailedOnly
 
   const toggleControl = (id: string) => {
     setExpandedControls(prev => {
@@ -82,6 +106,11 @@ export function ClusterComplianceReportRenderer({ data }: ClusterComplianceRepor
             <span className="text-sm font-medium text-red-400">{failCount}</span>
             <span className="text-xs text-theme-text-tertiary">failed</span>
           </div>
+          {total > 0 && (
+            <div className="ml-auto text-sm font-medium text-theme-text-secondary">
+              {Math.round((passCount / total) * 100)}% compliant
+            </div>
+          )}
         </div>
         {total > 0 && (
           <div className="h-3 rounded overflow-hidden flex">
@@ -102,8 +131,45 @@ export function ClusterComplianceReportRenderer({ data }: ClusterComplianceRepor
             {sortedChecks.length} controls
           </button>
           {expandedSection && (
+            <>
+            {/* Search and filter */}
+            <div className="flex items-center gap-2 mb-2">
+              <div className="relative flex-1">
+                <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-theme-text-tertiary" />
+                <input
+                  type="text"
+                  placeholder="Filter by control name or ID..."
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                  className="w-full pl-6 pr-2 py-1 text-xs bg-theme-bg border border-theme-border rounded text-theme-text-primary placeholder:text-theme-text-tertiary focus:outline-none focus:ring-1 focus:ring-blue-500/50"
+                />
+              </div>
+              <button
+                onClick={() => setShowFailedOnly(!showFailedOnly)}
+                className={clsx(
+                  'flex items-center gap-1 px-2 py-1 text-xs rounded border transition-colors whitespace-nowrap',
+                  showFailedOnly
+                    ? 'bg-red-500/15 border-red-500/30 text-red-400'
+                    : 'bg-theme-bg border-theme-border text-theme-text-tertiary hover:text-theme-text-secondary'
+                )}
+              >
+                <XCircle className="w-3 h-3" />
+                Failed
+              </button>
+            </div>
+            {hasActiveFilter && (
+              <div className="flex items-center gap-1 mb-2 text-xs text-theme-text-tertiary">
+                Showing {filteredChecks.length} of {sortedChecks.length}
+                <button
+                  onClick={() => { setSearchTerm(''); setShowFailedOnly(false) }}
+                  className="ml-1 text-blue-400 hover:text-blue-300 hover:underline"
+                >
+                  Clear
+                </button>
+              </div>
+            )}
             <div className="space-y-0.5">
-              {sortedChecks.map((check: any) => {
+              {filteredChecks.map((check: any) => {
                 const hasFail = (check.totalFail || 0) > 0
                 const controlDef = controlMap.get(check.id)
                 const isExpanded = expandedControls.has(check.id)
@@ -155,7 +221,13 @@ export function ClusterComplianceReportRenderer({ data }: ClusterComplianceRepor
                   </div>
                 )
               })}
+              {filteredChecks.length === 0 && (
+                <div className="py-4 text-center text-xs text-theme-text-tertiary">
+                  No controls match the current filter.
+                </div>
+              )}
             </div>
+            </>
           )}
         </Section>
       )}

--- a/packages/k8s-ui/src/components/resources/renderers/ClusterExternalSecretRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ClusterExternalSecretRenderer.tsx
@@ -28,10 +28,8 @@ export function ClusterExternalSecretRenderer({ data, onNavigate }: ClusterExter
   const refreshInterval = esSpec?.refreshInterval || '-'
   const storeRef = esSpec?.secretStoreRef
   const storeName = storeRef?.name
-  const storeKind = (storeRef?.kind || 'SecretStore') === 'ClusterSecretStore'
-    ? 'clustersecretstores'
-    : 'secretstores'
-  const storeNamespace = storeKind === 'clustersecretstores' ? '' : (data.metadata?.namespace || '')
+  const storeKindSingular = storeRef?.kind || 'SecretStore'
+  const storeNamespace = storeKindSingular === 'ClusterSecretStore' ? '' : (data.metadata?.namespace || '')
   const dataCount = (esSpec?.data || []).length
   const dataFromCount = (esSpec?.dataFrom || []).length
 
@@ -127,7 +125,7 @@ export function ClusterExternalSecretRenderer({ data, onNavigate }: ClusterExter
             <>
               <Property label="Store Name" value={
                 storeName
-                  ? <ResourceLink name={storeName} kind={storeKind} namespace={storeNamespace} onNavigate={onNavigate} />
+                  ? <ResourceLink name={storeName} kind={storeKindSingular} namespace={storeNamespace} onNavigate={onNavigate} />
                   : '-'
               } />
               <Property label="Store Kind" value={storeRef.kind || 'SecretStore'} />

--- a/packages/k8s-ui/src/components/resources/renderers/ClusterExternalSecretRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ClusterExternalSecretRenderer.tsx
@@ -27,6 +27,11 @@ export function ClusterExternalSecretRenderer({ data, onNavigate }: ClusterExter
   const esSpec = data.spec?.externalSecretSpec
   const refreshInterval = esSpec?.refreshInterval || '-'
   const storeRef = esSpec?.secretStoreRef
+  const storeName = storeRef?.name
+  const storeKind = (storeRef?.kind || 'SecretStore') === 'ClusterSecretStore'
+    ? 'clustersecretstores'
+    : 'secretstores'
+  const storeNamespace = storeKind === 'clustersecretstores' ? '' : (data.metadata?.namespace || '')
   const dataCount = (esSpec?.data || []).length
   const dataFromCount = (esSpec?.dataFrom || []).length
 
@@ -120,23 +125,11 @@ export function ClusterExternalSecretRenderer({ data, onNavigate }: ClusterExter
           <Property label="Refresh Interval" value={refreshInterval} />
           {storeRef && (
             <>
-              <Property label="Store Name" value={(() => {
-                const storeName = storeRef.name
-                if (storeName) {
-                  const storeKind = (storeRef.kind || 'SecretStore') === 'ClusterSecretStore'
-                    ? 'clustersecretstores'
-                    : 'secretstores'
-                  return (
-                    <ResourceLink
-                      name={storeName}
-                      kind={storeKind}
-                      namespace={storeKind === 'clustersecretstores' ? '' : (data.metadata?.namespace || '')}
-                      onNavigate={onNavigate}
-                    />
-                  )
-                }
-                return '-'
-              })()} />
+              <Property label="Store Name" value={
+                storeName
+                  ? <ResourceLink name={storeName} kind={storeKind} namespace={storeNamespace} onNavigate={onNavigate} />
+                  : '-'
+              } />
               <Property label="Store Kind" value={storeRef.kind || 'SecretStore'} />
             </>
           )}

--- a/packages/k8s-ui/src/components/resources/renderers/ClusterExternalSecretRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ClusterExternalSecretRenderer.tsx
@@ -1,5 +1,5 @@
 import { Globe, AlertTriangle } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
 import {
   getClusterExternalSecretStatus,
   getClusterExternalSecretProvisionedNamespaces,
@@ -10,9 +10,10 @@ import {
 
 interface ClusterExternalSecretRendererProps {
   data: any
+  onNavigate?: (ref: { kind: string; namespace: string; name: string }) => void
 }
 
-export function ClusterExternalSecretRenderer({ data }: ClusterExternalSecretRendererProps) {
+export function ClusterExternalSecretRenderer({ data, onNavigate }: ClusterExternalSecretRendererProps) {
   const status = data.status || {}
   const conditions = status.conditions || []
 
@@ -119,7 +120,23 @@ export function ClusterExternalSecretRenderer({ data }: ClusterExternalSecretRen
           <Property label="Refresh Interval" value={refreshInterval} />
           {storeRef && (
             <>
-              <Property label="Store Name" value={storeRef.name || '-'} />
+              <Property label="Store Name" value={(() => {
+                const storeName = storeRef.name
+                if (storeName) {
+                  const storeKind = (storeRef.kind || 'SecretStore') === 'ClusterSecretStore'
+                    ? 'clustersecretstores'
+                    : 'secretstores'
+                  return (
+                    <ResourceLink
+                      name={storeName}
+                      kind={storeKind}
+                      namespace={storeKind === 'clustersecretstores' ? '' : (data.metadata?.namespace || '')}
+                      onNavigate={onNavigate}
+                    />
+                  )
+                }
+                return '-'
+              })()} />
               <Property label="Store Kind" value={storeRef.kind || 'SecretStore'} />
             </>
           )}

--- a/packages/k8s-ui/src/components/resources/renderers/ClusterExternalSecretRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ClusterExternalSecretRenderer.tsx
@@ -29,7 +29,6 @@ export function ClusterExternalSecretRenderer({ data, onNavigate }: ClusterExter
   const storeRef = esSpec?.secretStoreRef
   const storeName = storeRef?.name
   const storeKindSingular = storeRef?.kind || 'SecretStore'
-  const storeNamespace = storeKindSingular === 'ClusterSecretStore' ? '' : (data.metadata?.namespace || '')
   const dataCount = (esSpec?.data || []).length
   const dataFromCount = (esSpec?.dataFrom || []).length
 
@@ -124,9 +123,9 @@ export function ClusterExternalSecretRenderer({ data, onNavigate }: ClusterExter
           {storeRef && (
             <>
               <Property label="Store Name" value={
-                storeName
-                  ? <ResourceLink name={storeName} kind={storeKindSingular} namespace={storeNamespace} onNavigate={onNavigate} />
-                  : '-'
+                storeName && storeKindSingular === 'ClusterSecretStore'
+                  ? <ResourceLink name={storeName} kind={storeKindSingular} namespace="" onNavigate={onNavigate} />
+                  : storeName || '-'
               } />
               <Property label="Store Kind" value={storeRef.kind || 'SecretStore'} />
             </>

--- a/packages/k8s-ui/src/components/resources/renderers/ClusterNetworkPolicyRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ClusterNetworkPolicyRenderer.tsx
@@ -1,6 +1,6 @@
 import { Shield, ArrowDownToLine, ArrowUpFromLine } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, LabelSelectorDisplay } from '../../ui/drawer-components'
 
 interface ClusterNetworkPolicyRendererProps {
   data: any
@@ -24,7 +24,7 @@ export function ClusterNetworkPolicyRenderer({ data }: ClusterNetworkPolicyRende
         {subject.namespaces && (
           <div className="mt-2">
             <div className="text-xs text-theme-text-tertiary mb-1">Namespace Selector</div>
-            <SelectorBadges selector={subject.namespaces} />
+            <LabelSelectorDisplay selector={subject.namespaces} />
           </div>
         )}
         {subject.pods && (
@@ -33,13 +33,13 @@ export function ClusterNetworkPolicyRenderer({ data }: ClusterNetworkPolicyRende
             {subject.pods.namespaceSelector && (
               <div className="mb-1">
                 <span className="text-xs text-theme-text-secondary">namespaces: </span>
-                <SelectorBadges selector={subject.pods.namespaceSelector} />
+                <LabelSelectorDisplay selector={subject.pods.namespaceSelector} inline />
               </div>
             )}
             {subject.pods.podSelector && (
               <div>
                 <span className="text-xs text-theme-text-secondary">pods: </span>
-                <SelectorBadges selector={subject.pods.podSelector} />
+                <LabelSelectorDisplay selector={subject.pods.podSelector} inline />
               </div>
             )}
           </div>
@@ -121,7 +121,7 @@ function AdminPeerEntry({ peer }: { peer: any }) {
     return (
       <div className="text-sm">
         <span className="text-theme-text-secondary text-xs">namespaces: </span>
-        <SelectorBadges selector={peer.namespaces} />
+        <LabelSelectorDisplay selector={peer.namespaces} inline />
       </div>
     )
   }
@@ -131,13 +131,13 @@ function AdminPeerEntry({ peer }: { peer: any }) {
         {peer.pods.namespaceSelector && (
           <div>
             <span className="text-theme-text-secondary text-xs">namespaces: </span>
-            <SelectorBadges selector={peer.pods.namespaceSelector} />
+            <LabelSelectorDisplay selector={peer.pods.namespaceSelector} inline />
           </div>
         )}
         {peer.pods.podSelector && (
           <div>
             <span className="text-theme-text-secondary text-xs">pods: </span>
-            <SelectorBadges selector={peer.pods.podSelector} />
+            <LabelSelectorDisplay selector={peer.pods.podSelector} inline />
           </div>
         )}
       </div>
@@ -158,17 +158,3 @@ function AdminPeerEntry({ peer }: { peer: any }) {
   return null
 }
 
-function SelectorBadges({ selector }: { selector: any }) {
-  const matchLabels = selector?.matchLabels || {}
-  const hasLabels = Object.keys(matchLabels).length > 0
-  if (!hasLabels) return <span className="text-xs text-theme-text-tertiary">all</span>
-  return (
-    <span className="inline-flex flex-wrap gap-1 align-middle">
-      {Object.entries(matchLabels).map(([k, v]) => (
-        <span key={k} className="badge bg-theme-elevated text-theme-text-secondary">
-          {k}={String(v)}
-        </span>
-      ))}
-    </span>
-  )
-}

--- a/packages/k8s-ui/src/components/resources/renderers/ExternalSecretRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ExternalSecretRenderer.tsx
@@ -76,14 +76,12 @@ export function ExternalSecretRenderer({ data, onNavigate }: ExternalSecretRende
         <PropertyList>
           <Property label="Store Name" value={(() => {
             if (store.name && store.name !== '-') {
-              const storeKind = store.kind === 'ClusterSecretStore'
-                ? 'clustersecretstores'
-                : 'secretstores'
+              const storeKindSingular = store.kind || 'SecretStore'
               return (
                 <ResourceLink
                   name={store.name}
-                  kind={storeKind}
-                  namespace={store.kind === 'ClusterSecretStore' ? '' : (data.metadata?.namespace || '')}
+                  kind={storeKindSingular}
+                  namespace={storeKindSingular === 'ClusterSecretStore' ? '' : (data.metadata?.namespace || '')}
                   onNavigate={onNavigate}
                 />
               )

--- a/packages/k8s-ui/src/components/resources/renderers/GitRepositoryRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/GitRepositoryRenderer.tsx
@@ -1,6 +1,5 @@
-import { GitBranch, AlertTriangle, FolderGit, CheckCircle2 } from 'lucide-react'
-import { clsx } from 'clsx'
-import { Section, PropertyList, Property, ConditionsSection } from '../../ui/drawer-components'
+import { GitBranch, FolderGit, CheckCircle2 } from 'lucide-react'
+import { Section, PropertyList, Property, ConditionsSection, ProblemAlerts } from '../../ui/drawer-components'
 import { formatAge } from '../resource-utils'
 import { formatBytes } from '../../../utils/format'
 import { GitOpsStatusBadge, SyncCountdown } from '../../gitops'
@@ -37,45 +36,7 @@ export function GitRepositoryRenderer({ data }: GitRepositoryRendererProps) {
 
   return (
     <>
-      {/* Problem alerts */}
-      {problems.map((problem, i) => (
-        <div
-          key={i}
-          className={clsx(
-            'mb-4 p-3 border rounded-lg',
-            problem.color === 'red'
-              ? 'bg-red-500/10 border-red-500/30'
-              : 'bg-yellow-500/10 border-yellow-500/30'
-          )}
-        >
-          <div className="flex items-start gap-2">
-            <AlertTriangle
-              className={clsx(
-                'w-4 h-4 mt-0.5 shrink-0',
-                problem.color === 'red' ? 'text-red-400' : 'text-yellow-400'
-              )}
-            />
-            <div className="flex-1 min-w-0">
-              <div
-                className={clsx(
-                  'text-sm font-medium',
-                  problem.color === 'red' ? 'text-red-400' : 'text-yellow-400'
-                )}
-              >
-                {problem.color === 'red' ? 'Issue Detected' : 'Warning'}
-              </div>
-              <div
-                className={clsx(
-                  'text-xs mt-1',
-                  problem.color === 'red' ? 'text-red-300/80' : 'text-yellow-300/80'
-                )}
-              >
-                {problem.message}
-              </div>
-            </div>
-          </div>
-        </div>
-      ))}
+      <ProblemAlerts problems={problems} />
 
       {/* Status section */}
       <Section title="Status">

--- a/packages/k8s-ui/src/components/resources/renderers/HelmRepositoryRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/HelmRepositoryRenderer.tsx
@@ -1,6 +1,6 @@
-import { Database, AlertTriangle, CheckCircle2, Shield } from 'lucide-react'
+import { Database, CheckCircle2, Shield } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property, ConditionsSection } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, ProblemAlerts } from '../../ui/drawer-components'
 import { formatAge } from '../resource-utils'
 import { formatBytes } from '../../../utils/format'
 import { GitOpsStatusBadge, SyncCountdown } from '../../gitops'
@@ -35,45 +35,7 @@ export function HelmRepositoryRenderer({ data }: HelmRepositoryRendererProps) {
 
   return (
     <>
-      {/* Problem alerts */}
-      {problems.map((problem, i) => (
-        <div
-          key={i}
-          className={clsx(
-            'mb-4 p-3 border rounded-lg',
-            problem.color === 'red'
-              ? 'bg-red-500/10 border-red-500/30'
-              : 'bg-yellow-500/10 border-yellow-500/30'
-          )}
-        >
-          <div className="flex items-start gap-2">
-            <AlertTriangle
-              className={clsx(
-                'w-4 h-4 mt-0.5 shrink-0',
-                problem.color === 'red' ? 'text-red-400' : 'text-yellow-400'
-              )}
-            />
-            <div className="flex-1 min-w-0">
-              <div
-                className={clsx(
-                  'text-sm font-medium',
-                  problem.color === 'red' ? 'text-red-400' : 'text-yellow-400'
-                )}
-              >
-                {problem.color === 'red' ? 'Issue Detected' : 'Warning'}
-              </div>
-              <div
-                className={clsx(
-                  'text-xs mt-1',
-                  problem.color === 'red' ? 'text-red-300/80' : 'text-yellow-300/80'
-                )}
-              >
-                {problem.message}
-              </div>
-            </div>
-          </div>
-        </div>
-      ))}
+      <ProblemAlerts problems={problems} />
 
       {/* Status section */}
       <Section title="Status">

--- a/packages/k8s-ui/src/components/resources/renderers/NetworkPolicyRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/NetworkPolicyRenderer.tsx
@@ -1,6 +1,6 @@
 import { Shield, ArrowDownToLine, ArrowUpFromLine, GitFork } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property } from '../../ui/drawer-components'
+import { Section, LabelSelectorDisplay } from '../../ui/drawer-components'
 import { NetworkPolicyDiagram } from './NetworkPolicyDiagram'
 
 interface NetworkPolicyRendererProps {
@@ -14,8 +14,6 @@ export function NetworkPolicyRenderer({ data }: NetworkPolicyRendererProps) {
   const ingress: any[] | undefined = spec.ingress
   const egress: any[] | undefined = spec.egress
 
-  const matchLabels = podSelector.matchLabels || {}
-  const hasMatchLabels = Object.keys(matchLabels).length > 0
   const hasIngress = policyTypes.includes('Ingress')
   const hasEgress = policyTypes.includes('Egress')
 
@@ -30,27 +28,10 @@ export function NetworkPolicyRenderer({ data }: NetworkPolicyRendererProps) {
       )}
 
       <Section title="Target" icon={Shield}>
-        <PropertyList>
-          <Property
-            label="Pod Selector"
-            value={hasMatchLabels ? undefined : 'All pods in namespace'}
-          />
-        </PropertyList>
-        {hasMatchLabels && (
-          <div className="mt-2">
-            <div className="text-xs text-theme-text-tertiary mb-1">Pod Selector</div>
-            <div className="flex flex-wrap gap-1">
-              {Object.entries(matchLabels).map(([k, v]) => (
-                <span
-                  key={k}
-                  className="badge bg-theme-elevated text-theme-text-secondary"
-                >
-                  {k}={String(v)}
-                </span>
-              ))}
-            </div>
-          </div>
-        )}
+        <div className="mt-2">
+          <div className="text-xs text-theme-text-tertiary mb-1">Pod Selector</div>
+          <LabelSelectorDisplay selector={podSelector} emptyText="All pods in namespace" />
+        </div>
         {policyTypes.length > 0 && (
           <div className="mt-2">
             <div className="text-xs text-theme-text-tertiary mb-1">Policy Types</div>
@@ -152,49 +133,19 @@ function IngressEgressRuleCard({
 
 function PeerEntry({ peer }: { peer: any }) {
   if (peer.podSelector) {
-    const labels = peer.podSelector.matchLabels || {}
-    const hasLabels = Object.keys(labels).length > 0
     return (
       <div className="text-sm">
         <span className="text-theme-text-secondary text-xs">podSelector: </span>
-        {hasLabels ? (
-          <span className="inline-flex flex-wrap gap-1 align-middle">
-            {Object.entries(labels).map(([k, v]) => (
-              <span
-                key={k}
-                className="badge bg-theme-elevated text-theme-text-secondary"
-              >
-                {k}={String(v)}
-              </span>
-            ))}
-          </span>
-        ) : (
-          <span className="text-xs text-theme-text-tertiary">all pods</span>
-        )}
+        <LabelSelectorDisplay selector={peer.podSelector} emptyText="all pods" inline />
       </div>
     )
   }
 
   if (peer.namespaceSelector) {
-    const labels = peer.namespaceSelector.matchLabels || {}
-    const hasLabels = Object.keys(labels).length > 0
     return (
       <div className="text-sm">
         <span className="text-theme-text-secondary text-xs">namespaceSelector: </span>
-        {hasLabels ? (
-          <span className="inline-flex flex-wrap gap-1 align-middle">
-            {Object.entries(labels).map(([k, v]) => (
-              <span
-                key={k}
-                className="badge bg-theme-elevated text-theme-text-secondary"
-              >
-                {k}={String(v)}
-              </span>
-            ))}
-          </span>
-        ) : (
-          <span className="text-xs text-theme-text-tertiary">all namespaces</span>
-        )}
+        <LabelSelectorDisplay selector={peer.namespaceSelector} emptyText="all namespaces" inline />
       </div>
     )
   }

--- a/packages/k8s-ui/src/components/resources/renderers/OCIRepositoryRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/OCIRepositoryRenderer.tsx
@@ -1,6 +1,5 @@
-import { Package, AlertTriangle, CheckCircle2 } from 'lucide-react'
-import { clsx } from 'clsx'
-import { Section, PropertyList, Property, ConditionsSection } from '../../ui/drawer-components'
+import { Package, CheckCircle2 } from 'lucide-react'
+import { Section, PropertyList, Property, ConditionsSection, ProblemAlerts } from '../../ui/drawer-components'
 import { formatAge } from '../resource-utils'
 import { formatBytes } from '../../../utils/format'
 import { GitOpsStatusBadge, SyncCountdown } from '../../gitops'
@@ -36,45 +35,7 @@ export function OCIRepositoryRenderer({ data }: OCIRepositoryRendererProps) {
 
   return (
     <>
-      {/* Problem alerts */}
-      {problems.map((problem, i) => (
-        <div
-          key={i}
-          className={clsx(
-            'mb-4 p-3 border rounded-lg',
-            problem.color === 'red'
-              ? 'bg-red-500/10 border-red-500/30'
-              : 'bg-yellow-500/10 border-yellow-500/30'
-          )}
-        >
-          <div className="flex items-start gap-2">
-            <AlertTriangle
-              className={clsx(
-                'w-4 h-4 mt-0.5 shrink-0',
-                problem.color === 'red' ? 'text-red-400' : 'text-yellow-400'
-              )}
-            />
-            <div className="flex-1 min-w-0">
-              <div
-                className={clsx(
-                  'text-sm font-medium',
-                  problem.color === 'red' ? 'text-red-400' : 'text-yellow-400'
-                )}
-              >
-                {problem.color === 'red' ? 'Issue Detected' : 'Warning'}
-              </div>
-              <div
-                className={clsx(
-                  'text-xs mt-1',
-                  problem.color === 'red' ? 'text-red-300/80' : 'text-yellow-300/80'
-                )}
-              >
-                {problem.message}
-              </div>
-            </div>
-          </div>
-        </div>
-      ))}
+      <ProblemAlerts problems={problems} />
 
       {/* Status section */}
       <Section title="Status">

--- a/packages/k8s-ui/src/components/resources/renderers/PodDisruptionBudgetRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodDisruptionBudgetRenderer.tsx
@@ -1,6 +1,6 @@
 import { Shield, Activity } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property, ConditionsSection, KeyValueBadgeList, AlertBanner } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, LabelSelectorDisplay, AlertBanner } from '../../ui/drawer-components'
 
 interface PodDisruptionBudgetRendererProps {
   data: any
@@ -9,8 +9,7 @@ interface PodDisruptionBudgetRendererProps {
 export function PodDisruptionBudgetRenderer({ data }: PodDisruptionBudgetRendererProps) {
   const spec = data.spec || {}
   const status = data.status || {}
-  const matchLabels = spec.selector?.matchLabels || {}
-  const hasSelector = Object.keys(matchLabels).length > 0
+  const selector = spec.selector
 
   // Determine budget type
   const hasMaxUnavailable = spec.maxUnavailable !== undefined && spec.maxUnavailable !== null
@@ -113,11 +112,7 @@ export function PodDisruptionBudgetRenderer({ data }: PodDisruptionBudgetRendere
       </Section>
 
       <Section title="Selector">
-        {hasSelector ? (
-          <KeyValueBadgeList items={matchLabels} />
-        ) : (
-          <div className="text-sm text-theme-text-tertiary">All pods in namespace</div>
-        )}
+        <LabelSelectorDisplay selector={selector} emptyText="All pods in namespace" />
       </Section>
 
       <ConditionsSection conditions={status.conditions} />

--- a/packages/k8s-ui/src/components/resources/renderers/PodMonitorRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodMonitorRenderer.tsx
@@ -1,5 +1,5 @@
 import { Radio } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, KeyValueBadgeList } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, LabelSelectorDisplay } from '../../ui/drawer-components'
 import {
   getPodMonitorEndpoints,
   getPodMonitorNamespaceSelector,
@@ -11,7 +11,7 @@ interface PodMonitorRendererProps {
 
 export function PodMonitorRenderer({ data }: PodMonitorRendererProps) {
   const endpoints = getPodMonitorEndpoints(data)
-  const selector = data.spec?.selector?.matchLabels
+  const selector = data.spec?.selector
   const conditions = data.status?.conditions
 
   return (
@@ -51,11 +51,9 @@ export function PodMonitorRenderer({ data }: PodMonitorRendererProps) {
         </Section>
       )}
 
-      {selector && Object.keys(selector).length > 0 && (
-        <Section title="Selector">
-          <KeyValueBadgeList items={selector} />
-        </Section>
-      )}
+      <Section title="Selector">
+        <LabelSelectorDisplay selector={selector} emptyText="No selector" />
+      </Section>
 
       <ConditionsSection conditions={conditions} />
     </>

--- a/packages/k8s-ui/src/components/resources/renderers/ReplicaSetRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ReplicaSetRenderer.tsx
@@ -1,5 +1,5 @@
 import { Server } from 'lucide-react'
-import { Section, PropertyList, Property, KeyValueBadgeList, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, LabelSelectorDisplay, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
 
 interface ReplicaSetRendererProps {
   data: any
@@ -62,7 +62,7 @@ export function ReplicaSetRenderer({ data }: ReplicaSetRendererProps) {
       </Section>
 
       <Section title="Selector">
-        <KeyValueBadgeList items={data.spec?.selector?.matchLabels} />
+        <LabelSelectorDisplay selector={data.spec?.selector} />
       </Section>
 
       <ConditionsSection conditions={data.status?.conditions} />

--- a/packages/k8s-ui/src/components/resources/renderers/SbomReportRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/SbomReportRenderer.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { Package, ChevronDown, ChevronRight } from 'lucide-react'
+import { useState, useMemo } from 'react'
+import { Package, ChevronDown, ChevronRight, Search } from 'lucide-react'
 import { Section, PropertyList, Property } from '../../ui/drawer-components'
 import { formatAge } from '../resource-utils'
 import { formatTrivyImage } from './trivy-shared'
@@ -13,6 +13,7 @@ const INITIAL_SHOW_COUNT = 100
 export function SbomReportRenderer({ data }: SbomReportRendererProps) {
   const [showAll, setShowAll] = useState(false)
   const [expanded, setExpanded] = useState(true)
+  const [searchTerm, setSearchTerm] = useState('')
 
   const report = data.report || {}
   const scanner = report.scanner || {}
@@ -29,7 +30,18 @@ export function SbomReportRenderer({ data }: SbomReportRendererProps) {
   const bomFormat = components.bomFormat || '-'
   const specVersion = components.specVersion || '-'
 
-  const displayedComponents = showAll ? bom : bom.slice(0, INITIAL_SHOW_COUNT)
+  const filteredBom = useMemo(() => {
+    if (!searchTerm) return bom
+    const term = searchTerm.toLowerCase()
+    return bom.filter((comp: any) =>
+      (comp.name || '').toLowerCase().includes(term) ||
+      (comp.purl || '').toLowerCase().includes(term) ||
+      (comp.type || '').toLowerCase().includes(term)
+    )
+  }, [bom, searchTerm])
+
+  const hasActiveFilter = searchTerm !== ''
+  const displayedComponents = showAll ? filteredBom : filteredBom.slice(0, INITIAL_SHOW_COUNT)
 
   return (
     <>
@@ -58,6 +70,30 @@ export function SbomReportRenderer({ data }: SbomReportRendererProps) {
           </button>
           {expanded && (
             <div className="overflow-x-auto -mx-1">
+              {/* Search */}
+              <div className="flex items-center gap-2 mb-2 px-1">
+                <div className="relative flex-1">
+                  <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-theme-text-tertiary" />
+                  <input
+                    type="text"
+                    placeholder="Filter by name, type, or purl..."
+                    value={searchTerm}
+                    onChange={(e) => { setSearchTerm(e.target.value); setShowAll(false) }}
+                    className="w-full pl-6 pr-2 py-1 text-xs bg-theme-bg border border-theme-border rounded text-theme-text-primary placeholder:text-theme-text-tertiary focus:outline-none focus:ring-1 focus:ring-blue-500/50"
+                  />
+                </div>
+              </div>
+              {hasActiveFilter && (
+                <div className="flex items-center gap-1 mb-2 px-1 text-xs text-theme-text-tertiary">
+                  Showing {filteredBom.length} of {bom.length}
+                  <button
+                    onClick={() => { setSearchTerm(''); setShowAll(false) }}
+                    className="ml-1 text-blue-400 hover:text-blue-300 hover:underline"
+                  >
+                    Clear
+                  </button>
+                </div>
+              )}
               <table className="w-full text-xs">
                 <thead>
                   <tr className="border-b border-theme-border text-theme-text-tertiary">
@@ -81,12 +117,17 @@ export function SbomReportRenderer({ data }: SbomReportRendererProps) {
                   })}
                 </tbody>
               </table>
-              {!showAll && bom.length > INITIAL_SHOW_COUNT && (
+              {displayedComponents.length === 0 && (
+                <div className="py-4 text-center text-xs text-theme-text-tertiary">
+                  No components match the current filter.
+                </div>
+              )}
+              {!showAll && filteredBom.length > INITIAL_SHOW_COUNT && (
                 <button
                   onClick={() => setShowAll(true)}
                   className="mt-2 text-xs text-blue-400 hover:text-blue-300 hover:underline"
                 >
-                  Show all {bom.length} components
+                  Show all {filteredBom.length} components
                 </button>
               )}
             </div>

--- a/packages/k8s-ui/src/components/resources/renderers/SealedSecretRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/SealedSecretRenderer.tsx
@@ -68,7 +68,7 @@ export function SealedSecretRenderer({ data, onNavigate }: SealedSecretRendererP
           />
           <Property label="Target Secret" value={
             <ResourceLink
-              name={data.metadata?.name || ''}
+              name={data.spec?.template?.metadata?.name || data.metadata?.name || ''}
               kind="secrets"
               namespace={data.metadata?.namespace || ''}
               onNavigate={onNavigate}

--- a/packages/k8s-ui/src/components/resources/renderers/SealedSecretRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/SealedSecretRenderer.tsx
@@ -1,9 +1,10 @@
 import { Lock, Key, FileText } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property, ConditionsSection, KeyValueBadgeList, AlertBanner } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, KeyValueBadgeList, AlertBanner, ResourceLink } from '../../ui/drawer-components'
 
 interface SealedSecretRendererProps {
   data: any
+  onNavigate?: (ref: { kind: string; namespace: string; name: string }) => void
 }
 
 function getScope(annotations: Record<string, string> | undefined): string {
@@ -13,7 +14,7 @@ function getScope(annotations: Record<string, string> | undefined): string {
   return 'strict'
 }
 
-export function SealedSecretRenderer({ data }: SealedSecretRendererProps) {
+export function SealedSecretRenderer({ data, onNavigate }: SealedSecretRendererProps) {
   const spec = data.spec || {}
   const status = data.status || {}
   const conditions = status.conditions || []
@@ -65,6 +66,14 @@ export function SealedSecretRenderer({ data }: SealedSecretRendererProps) {
               </span>
             }
           />
+          <Property label="Target Secret" value={
+            <ResourceLink
+              name={data.metadata?.name || ''}
+              kind="secrets"
+              namespace={data.metadata?.namespace || ''}
+              onNavigate={onNavigate}
+            />
+          } />
           <Property label="Secret Type" value={secretType} />
           <Property label="Scope" value={scope} />
           <Property label="Observed Gen" value={status.observedGeneration} />

--- a/packages/k8s-ui/src/components/resources/renderers/ServiceMonitorRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ServiceMonitorRenderer.tsx
@@ -1,5 +1,5 @@
 import { Radio } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, KeyValueBadgeList } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, LabelSelectorDisplay } from '../../ui/drawer-components'
 import {
   getServiceMonitorEndpoints,
   getServiceMonitorJobLabel,
@@ -12,7 +12,7 @@ interface ServiceMonitorRendererProps {
 
 export function ServiceMonitorRenderer({ data }: ServiceMonitorRendererProps) {
   const endpoints = getServiceMonitorEndpoints(data)
-  const selector = data.spec?.selector?.matchLabels
+  const selector = data.spec?.selector
   const conditions = data.status?.conditions
 
   return (
@@ -53,11 +53,9 @@ export function ServiceMonitorRenderer({ data }: ServiceMonitorRendererProps) {
         </Section>
       )}
 
-      {selector && Object.keys(selector).length > 0 && (
-        <Section title="Selector">
-          <KeyValueBadgeList items={selector} />
-        </Section>
-      )}
+      <Section title="Selector">
+        <LabelSelectorDisplay selector={selector} emptyText="No selector" />
+      </Section>
 
       <ConditionsSection conditions={conditions} />
     </>

--- a/packages/k8s-ui/src/components/resources/renderers/WebhookConfigRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/WebhookConfigRenderer.tsx
@@ -1,6 +1,6 @@
 import { Shield } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property, AlertBanner } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, AlertBanner, LabelSelectorDisplay } from '../../ui/drawer-components'
 
 interface WebhookConfigRendererProps {
   data: any
@@ -65,8 +65,8 @@ export function WebhookConfigRenderer({ data, isMutating }: WebhookConfigRendere
                 ? `URL: ${url}`
                 : 'No target'
 
-            const nsLabels = wh.namespaceSelector?.matchLabels
-            const objLabels = wh.objectSelector?.matchLabels
+            const nsSelector = wh.namespaceSelector
+            const objSelector = wh.objectSelector
 
             return (
               <div key={i} className="card-inner-lg">
@@ -119,26 +119,18 @@ export function WebhookConfigRenderer({ data, isMutating }: WebhookConfigRendere
                 )}
 
                 {/* Selectors */}
-                {(nsLabels || objLabels) && (
+                {(nsSelector || objSelector) && (
                   <div className="mt-2 space-y-1">
-                    {nsLabels && Object.keys(nsLabels).length > 0 && (
+                    {nsSelector && (
                       <div>
                         <div className="text-xs text-theme-text-tertiary mb-1">Namespace Selector</div>
-                        <div className="flex flex-wrap gap-1">
-                          {Object.entries(nsLabels).map(([k, v]) => (
-                            <span key={k} className="badge-sm bg-theme-elevated text-theme-text-secondary">{k}={String(v)}</span>
-                          ))}
-                        </div>
+                        <LabelSelectorDisplay selector={nsSelector} />
                       </div>
                     )}
-                    {objLabels && Object.keys(objLabels).length > 0 && (
+                    {objSelector && (
                       <div>
                         <div className="text-xs text-theme-text-tertiary mb-1">Object Selector</div>
-                        <div className="flex flex-wrap gap-1">
-                          {Object.entries(objLabels).map(([k, v]) => (
-                            <span key={k} className="badge-sm bg-theme-elevated text-theme-text-secondary">{k}={String(v)}</span>
-                          ))}
-                        </div>
+                        <LabelSelectorDisplay selector={objSelector} />
                       </div>
                     )}
                   </div>

--- a/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
@@ -353,7 +353,7 @@ export function ResourceRendererDispatch({
         {kind === 'grpcroutes' && <GRPCRouteRenderer data={data} onNavigate={onNavigate} />}
         {kind === 'tcproutes' && <SimpleRouteRenderer data={data} kind="TCPRoute" onNavigate={onNavigate} />}
         {kind === 'tlsroutes' && <SimpleRouteRenderer data={data} kind="TLSRoute" onNavigate={onNavigate} />}
-        {kind === 'sealedsecrets' && <SealedSecretRenderer data={data} />}
+        {kind === 'sealedsecrets' && <SealedSecretRenderer data={data} onNavigate={onNavigate} />}
         {kind === 'workflowtemplates' && <WorkflowTemplateRenderer data={data} />}
         {(kind === 'networkpolicies' || kind === 'networkpolicy') && <NetworkPolicyRenderer data={data} />}
         {(kind === 'ciliumnetworkpolicies' || kind === 'ciliumnetworkpolicy' || kind === 'ciliumclusterwidenetworkpolicies' || kind === 'ciliumclusterwidenetworkpolicy') && <CiliumNetworkPolicyRenderer data={data} />}
@@ -395,7 +395,7 @@ export function ResourceRendererDispatch({
         {kind === 'backupstoragelocations' && <VeleroBSLRenderer data={data} />}
         {kind === 'volumesnapshotlocations' && <VeleroVSLRenderer data={data} />}
         {kind === 'externalsecrets' && <ExternalSecretRenderer data={data} onNavigate={onNavigate} />}
-        {kind === 'clusterexternalsecrets' && <ClusterExternalSecretRenderer data={data} />}
+        {kind === 'clusterexternalsecrets' && <ClusterExternalSecretRenderer data={data} onNavigate={onNavigate} />}
         {(kind === 'secretstores' || kind === 'clustersecretstores') && <SecretStoreRenderer data={data} />}
         {kind === 'clusters' && <CNPGClusterRenderer data={data} onNavigate={onNavigate} />}
         {kind === 'scheduledbackups' && <CNPGScheduledBackupRenderer data={data} onNavigate={onNavigate} />}

--- a/packages/k8s-ui/src/components/ui/drawer-components.tsx
+++ b/packages/k8s-ui/src/components/ui/drawer-components.tsx
@@ -32,6 +32,7 @@ export function KeyValueBadgeList({ items }: { items: Record<string, unknown> | 
  * Renders a Kubernetes label selector (matchLabels + matchExpressions).
  * Accepts either a full selector object `{ matchLabels?, matchExpressions? }`
  * or a flat `Record<string, string>` (e.g. Service.spec.selector).
+ * Pass `inline` for flow-inline rendering (e.g. within a sentence).
  */
 export function LabelSelectorDisplay({
   selector,
@@ -47,7 +48,7 @@ export function LabelSelectorDisplay({
   }
 
   // Detect flat selector (e.g. Service.spec.selector has no matchLabels wrapper)
-  const isFlat = selector && typeof selector === 'object' && !selector.matchLabels && !selector.matchExpressions && !Array.isArray(selector)
+  const isFlat = typeof selector === 'object' && !Array.isArray(selector) && !selector.matchLabels && !selector.matchExpressions
   const matchLabels: Record<string, unknown> = isFlat ? selector : (selector.matchLabels || {})
   const matchExpressions: Array<{ key: string; operator: string; values?: string[] }> = selector.matchExpressions || []
 
@@ -280,7 +281,7 @@ export interface Problem {
   message: string
 }
 
-/** Displays a list of problem alerts (warnings and errors) for GitOps resources */
+/** Displays a list of problem alerts (warnings and errors) */
 export function ProblemAlerts({ problems }: { problems: Problem[] }) {
   if (problems.length === 0) return null
 

--- a/packages/k8s-ui/src/components/ui/drawer-components.tsx
+++ b/packages/k8s-ui/src/components/ui/drawer-components.tsx
@@ -28,6 +28,52 @@ export function KeyValueBadgeList({ items }: { items: Record<string, unknown> | 
   )
 }
 
+/**
+ * Renders a Kubernetes label selector (matchLabels + matchExpressions).
+ * Accepts either a full selector object `{ matchLabels?, matchExpressions? }`
+ * or a flat `Record<string, string>` (e.g. Service.spec.selector).
+ */
+export function LabelSelectorDisplay({
+  selector,
+  emptyText = 'All',
+  inline = false,
+}: {
+  selector: any
+  emptyText?: string
+  inline?: boolean
+}) {
+  if (!selector) {
+    return <span className="text-xs text-theme-text-tertiary">{emptyText}</span>
+  }
+
+  // Detect flat selector (e.g. Service.spec.selector has no matchLabels wrapper)
+  const isFlat = selector && typeof selector === 'object' && !selector.matchLabels && !selector.matchExpressions && !Array.isArray(selector)
+  const matchLabels: Record<string, unknown> = isFlat ? selector : (selector.matchLabels || {})
+  const matchExpressions: Array<{ key: string; operator: string; values?: string[] }> = selector.matchExpressions || []
+
+  const hasLabels = Object.keys(matchLabels).length > 0
+  const hasExpressions = matchExpressions.length > 0
+
+  if (!hasLabels && !hasExpressions) {
+    return <span className="text-xs text-theme-text-tertiary">{emptyText}</span>
+  }
+
+  const Wrapper = inline ? 'span' : 'div'
+
+  return (
+    <Wrapper className={inline ? 'inline-flex flex-wrap gap-1 align-middle' : 'flex flex-wrap gap-1'}>
+      {Object.entries(matchLabels).map(([k, v]) => (
+        <KeyValueBadge key={`l-${k}`} k={k} v={String(v)} />
+      ))}
+      {matchExpressions.map((expr, i) => (
+        <span key={`e-${i}`} className="badge bg-theme-elevated text-theme-text-secondary">
+          {expr.key} {expr.operator}{expr.values && expr.values.length > 0 ? ` ${expr.values.join(', ')}` : ''}
+        </span>
+      ))}
+    </Wrapper>
+  )
+}
+
 interface SectionProps {
   title: string
   icon?: React.ComponentType<{ className?: string }>

--- a/packages/k8s-ui/src/utils/navigation.test.ts
+++ b/packages/k8s-ui/src/utils/navigation.test.ts
@@ -1,5 +1,9 @@
-import { describe, test, expect } from 'vitest'
-import { kindToPlural, pluralToKind, refToSelectedResource, initNavigationMap } from './navigation'
+import { describe, test, expect, afterEach } from 'vitest'
+import { kindToPlural, pluralToKind, refToSelectedResource, initNavigationMap, resetNavigationMap } from './navigation'
+
+afterEach(() => {
+  resetNavigationMap()
+})
 
 describe('kindToPlural', () => {
   test('singular PascalCase to plural lowercase', () => {

--- a/packages/k8s-ui/src/utils/navigation.test.ts
+++ b/packages/k8s-ui/src/utils/navigation.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest'
-import { kindToPlural, pluralToKind, refToSelectedResource } from './navigation'
+import { kindToPlural, pluralToKind, refToSelectedResource, initNavigationMap } from './navigation'
 
 describe('kindToPlural', () => {
   test('singular PascalCase to plural lowercase', () => {
@@ -107,6 +107,29 @@ describe('pluralToKind', () => {
     // "databases" triggers the -ses rule (strips 2 chars) — a known limitation
     // of the heuristic fallback. Known kinds use the PLURAL_TO_KIND map instead.
     expect(pluralToKind('databases')).toBe('Databas')
+  })
+})
+
+describe('initNavigationMap', () => {
+  test('discovered API resources override heuristic pluralization', () => {
+    // Before init, an unknown CRD would hit the heuristic fallback
+    // After init, it uses the discovered plural name
+    initNavigationMap([
+      { group: 'external-secrets.io', version: 'v1', kind: 'SecretStore', name: 'secretstores', namespaced: true, isCrd: true, verbs: ['get'] },
+      { group: 'external-secrets.io', version: 'v1', kind: 'ClusterSecretStore', name: 'clustersecretstores', namespaced: false, isCrd: true, verbs: ['get'] },
+    ])
+    expect(kindToPlural('SecretStore')).toBe('secretstores')
+    expect(kindToPlural('ClusterSecretStore')).toBe('clustersecretstores')
+    expect(pluralToKind('secretstores')).toBe('SecretStore')
+    expect(pluralToKind('clustersecretstores')).toBe('ClusterSecretStore')
+  })
+
+  test('prevents double-pluralization of discovered plurals', () => {
+    initNavigationMap([
+      { group: 'external-secrets.io', version: 'v1', kind: 'SecretStore', name: 'secretstores', namespaced: true, isCrd: true, verbs: ['get'] },
+    ])
+    // Passing an already-plural kind should be idempotent
+    expect(kindToPlural('secretstores')).toBe('secretstores')
   })
 })
 

--- a/packages/k8s-ui/src/utils/navigation.ts
+++ b/packages/k8s-ui/src/utils/navigation.ts
@@ -57,6 +57,12 @@ export function initNavigationMap(resources: APIResource[]) {
   discoveredKindToPlural = k2p
 }
 
+/** Reset navigation maps to builtin-only state. For testing. */
+export function resetNavigationMap() {
+  discoveredPluralToKind = null
+  discoveredKindToPlural = null
+}
+
 function getPluralToKind(): Record<string, string> {
   return discoveredPluralToKind || BUILTIN_PLURAL_TO_KIND
 }

--- a/packages/k8s-ui/src/utils/navigation.ts
+++ b/packages/k8s-ui/src/utils/navigation.ts
@@ -1,4 +1,4 @@
-import type { SelectedResource, ResourceRef } from '../types/core'
+import type { SelectedResource, ResourceRef, APIResource } from '../types/core'
 
 /**
  * Canonical callback type for navigating to a resource.
@@ -6,9 +6,8 @@ import type { SelectedResource, ResourceRef } from '../types/core'
  */
 export type NavigateToResource = (resource: SelectedResource) => void
 
-// Known plural API resource names → singular PascalCase kind.
-// Shared between kindToPlural (idempotency guard) and pluralToKind (reverse lookup).
-const PLURAL_TO_KIND: Record<string, string> = {
+// Fallback map for core K8s resources — used before API discovery completes.
+const BUILTIN_PLURAL_TO_KIND: Record<string, string> = {
   pods: 'Pod',
   services: 'Service',
   deployments: 'Deployment',
@@ -16,11 +15,6 @@ const PLURAL_TO_KIND: Record<string, string> = {
   statefulsets: 'StatefulSet',
   replicasets: 'ReplicaSet',
   ingresses: 'Ingress',
-  gateways: 'Gateway',
-  httproutes: 'HTTPRoute',
-  grpcroutes: 'GRPCRoute',
-  tcproutes: 'TCPRoute',
-  tlsroutes: 'TLSRoute',
   configmaps: 'ConfigMap',
   secrets: 'Secret',
   namespaces: 'Namespace',
@@ -33,29 +27,38 @@ const PLURAL_TO_KIND: Record<string, string> = {
   persistentvolumes: 'PersistentVolume',
   storageclasses: 'StorageClass',
   poddisruptionbudgets: 'PodDisruptionBudget',
-  rollouts: 'Rollout',
-  applications: 'Application',
-  kustomizations: 'Kustomization',
-  helmreleases: 'HelmRelease',
-  gitrepositories: 'GitRepository',
-  certificates: 'Certificate',
   roles: 'Role',
   clusterroles: 'ClusterRole',
   rolebindings: 'RoleBinding',
   clusterrolebindings: 'ClusterRoleBinding',
   serviceaccounts: 'ServiceAccount',
   networkpolicies: 'NetworkPolicy',
-  verticalpodautoscalers: 'VerticalPodAutoscaler',
-  virtualservices: 'VirtualService',
-  destinationrules: 'DestinationRule',
-  serviceentries: 'ServiceEntry',
-  peerauthentications: 'PeerAuthentication',
-  authorizationpolicies: 'AuthorizationPolicy',
-  externalsecrets: 'ExternalSecret',
-  clusterexternalsecrets: 'ClusterExternalSecret',
-  secretstores: 'SecretStore',
-  clustersecretstores: 'ClusterSecretStore',
-  sealedsecrets: 'SealedSecret',
+}
+
+// Dynamic map built from API discovery — populated by initNavigationMap().
+// Once populated, this is the source of truth for all kind↔plural lookups.
+let discoveredPluralToKind: Record<string, string> | null = null
+let discoveredKindToPlural: Record<string, string> | null = null
+
+/**
+ * Initialize navigation maps from discovered API resources.
+ * Call once when API resources are fetched. After this, kindToPlural/pluralToKind
+ * use the real cluster data instead of heuristics.
+ */
+export function initNavigationMap(resources: APIResource[]) {
+  const p2k: Record<string, string> = { ...BUILTIN_PLURAL_TO_KIND }
+  const k2p: Record<string, string> = {}
+  for (const r of resources) {
+    const plural = r.name.toLowerCase()
+    p2k[plural] = r.kind
+    k2p[r.kind.toLowerCase()] = plural
+  }
+  discoveredPluralToKind = p2k
+  discoveredKindToPlural = k2p
+}
+
+function getPluralToKind(): Record<string, string> {
+  return discoveredPluralToKind || BUILTIN_PLURAL_TO_KIND
 }
 
 /**
@@ -66,9 +69,15 @@ const PLURAL_TO_KIND: Record<string, string> = {
  */
 export function kindToPlural(kind: string): string {
   const kindLower = kind.toLowerCase()
+  const pluralToKindMap = getPluralToKind()
 
   // Already a known plural — return as-is to prevent double-pluralization
-  if (kindLower in PLURAL_TO_KIND) return kindLower
+  if (kindLower in pluralToKindMap) return kindLower
+
+  // Lookup from discovered API resources (singular kind → plural name)
+  if (discoveredKindToPlural && kindLower in discoveredKindToPlural) {
+    return discoveredKindToPlural[kindLower]
+  }
 
   // Aliases: abbreviations or mappings to a different resource name
   const aliases: Record<string, string> = {
@@ -78,7 +87,7 @@ export function kindToPlural(kind: string): string {
   }
   if (aliases[kindLower]) return aliases[kindLower]
 
-  // English pluralization rules (covers *Class→*classes, *Policy→*policies, *Repository→*repositories, etc.)
+  // Fallback: English pluralization rules (covers *Class→*classes, *Policy→*policies, *Repository→*repositories, etc.)
   if (kindLower.endsWith('s') || kindLower.endsWith('x') || kindLower.endsWith('ch') || kindLower.endsWith('sh')) {
     return kindLower + 'es'
   }
@@ -95,8 +104,9 @@ export function kindToPlural(kind: string): string {
  */
 export function pluralToKind(plural: string): string {
   const lower = plural.toLowerCase()
+  const pluralToKindMap = getPluralToKind()
 
-  if (PLURAL_TO_KIND[lower]) return PLURAL_TO_KIND[lower]
+  if (pluralToKindMap[lower]) return pluralToKindMap[lower]
 
   // If it already looks like a singular PascalCase kind (starts with uppercase), return as-is
   if (plural[0] === plural[0].toUpperCase() && plural[0] !== plural[0].toLowerCase()) {

--- a/packages/k8s-ui/src/utils/navigation.ts
+++ b/packages/k8s-ui/src/utils/navigation.ts
@@ -51,6 +51,11 @@ const PLURAL_TO_KIND: Record<string, string> = {
   serviceentries: 'ServiceEntry',
   peerauthentications: 'PeerAuthentication',
   authorizationpolicies: 'AuthorizationPolicy',
+  externalsecrets: 'ExternalSecret',
+  clusterexternalsecrets: 'ClusterExternalSecret',
+  secretstores: 'SecretStore',
+  clustersecretstores: 'ClusterSecretStore',
+  sealedsecrets: 'SealedSecret',
 }
 
 /**

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -1,8 +1,9 @@
-import { useState, useMemo, useCallback } from 'react'
+import { useState, useMemo, useCallback, useEffect } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { ApiError, fetchJSON, isForbiddenError, useSecretCertExpiry, useTopPodMetrics, useTopNodeMetrics } from '../../api/client'
 import { useAPIResources } from '../../api/apiResources'
+import { initNavigationMap } from '@skyhook-io/k8s-ui'
 import { usePinnedKinds } from '../../hooks/useFavorites'
 import { useOpenLogs, useOpenWorkloadLogs } from '../dock'
 import {
@@ -34,6 +35,11 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
 
   // API resources discovery
   const { data: apiResources } = useAPIResources()
+
+  // Initialize navigation kind↔plural maps from discovered API resources
+  useEffect(() => {
+    if (apiResources) initNavigationMap(apiResources)
+  }, [apiResources])
 
   // Track the selected kind from the k8s-ui component
   const [selectedKind, setSelectedKind] = useState<{ name: string; kind: string; group: string } | null>(null)


### PR DESCRIPTION
## Summary

Cross-cutting improvements to CRD renderers, identified during a comprehensive gap analysis of all 100+ renderer files.

**LabelSelectorDisplay shared component** — `matchExpressions` was silently dropped in 16 of 17 renderers that display K8s label selectors. New shared component handles both `matchLabels` and `matchExpressions`, with support for flat selectors and inline rendering. Replaced 4 different inline patterns across 8 renderers, removing 3 local helper functions.

**Search/filter for Trivy reports** — SbomReport (100-500+ components per image) and ClusterComplianceReport (CIS has 100+ controls) had no search. Added text search to both, plus a "Failed only" toggle and compliance percentage to compliance reports.

**FluxCD alert consolidation** — GitRepository, HelmRepository, OCIRepository each had ~40 lines of duplicated inline alert markup. Replaced with the existing shared `<ProblemAlerts>` component.

**Navigation wiring** — SealedSecret gets clickable "Target Secret" link (respects `spec.template.metadata.name` override). ClusterExternalSecret gets clickable store reference. Both wired through dispatch.

**API discovery-based kind pluralization** — Replaced the hardcoded `PLURAL_TO_KIND` map (which required manual entries for every CRD) with a dynamic lookup built from the cluster's actual API resource discovery data. `kindToPlural`/`pluralToKind` now use real `{kind, name}` pairs from the K8s API server, falling back to a small builtin map for core resources before discovery completes. This fixes the "secretstoreses" double-pluralization bug and eliminates the need to manually register new CRD kinds.

21 files, +326/-344 (net -18).