### PR TITLE
Add P0 renderer gaps: Karpenter status, PrometheusRule details, FluxCD values/deps

### DIFF
--- a/.claude/commands/visual-test.md
+++ b/.claude/commands/visual-test.md
@@ -1,0 +1,162 @@
+# Visual Test
+
+Visually test Radar changes against a real cluster using Playwright MCP. Takes screenshots, organizes them, and reports what looks right or wrong.
+
+## Step 1: Verify Playwright MCP
+
+Check if Playwright MCP tools are available (e.g., `mcp__playwright__browser_navigate`). If NOT available, tell the user "Playwright MCP is not available -- please add it to your MCP config and restart" and **stop**.
+
+## Step 2: Understand What to Test
+
+Determine what changed and what needs visual verification:
+
+```bash
+git status
+git branch --show-current
+git log main..HEAD --oneline
+git diff main..HEAD --name-only
+```
+
+If on main with no branch commits, check unstaged changes instead. Summarize what changed and what UI areas are affected (which renderers, which views, which components).
+
+## Step 3: Verify Cluster Access
+
+**This is critical -- Radar is useless without a live cluster.** Check in order:
+
+```bash
+# 1. Check current kubeconfig context
+kubectl config current-context
+
+# 2. Verify actual connectivity (not just config)
+kubectl cluster-info --request-timeout=5s
+```
+
+**If cluster is not reachable**, try to diagnose:
+```bash
+# GKE:
+gcloud container clusters list 2>/dev/null | head -5
+# EKS:
+aws eks list-clusters 2>/dev/null | head -5
+```
+
+**If auth is expired or cluster is unreachable:**
+- Tell the user which context is configured and that it's not reachable
+- Suggest the auth command (e.g., `gcloud container clusters get-credentials ...` or `aws eks update-kubeconfig ...`)
+- Ask them to run `! <auth-command>` in the prompt to authenticate
+- **Stop and wait** -- don't proceed without a working cluster
+
+## Step 4: Check Required Resources Exist
+
+Based on what changed, verify the cluster has the CRD resources needed to test:
+
+```bash
+# Check if the CRD exists
+kubectl api-resources --verbs=list 2>/dev/null | grep -i <kind>
+
+# Check if instances exist
+kubectl get <kind> -A --no-headers 2>/dev/null | head -5
+```
+
+**If CRDs exist but no instances:**
+- Tell the user: "The cluster has the <Kind> CRD but no instances. Want me to create a test resource?"
+- **Wait for confirmation before creating anything**
+- If creating: use a clearly labeled test namespace/name (e.g., `radar-test/test-<kind>`)
+
+**If CRDs don't exist at all:**
+- Tell the user which CRDs are missing
+- Some CRDs can be installed easily (e.g., `kubectl apply -f` a CRD manifest), others require full operator installation
+- Ask the user how they want to proceed
+
+**IMPORTANT: Never modify cluster state (create/delete/update resources) without explicit user confirmation. Read-only operations (get, list, describe) are always safe.**
+
+## Step 5: Build and Launch Radar
+
+Use the helper script — it handles build, port selection, launch, health check, and state file creation in a single command:
+
+```bash
+./scripts/visual-test-start.sh
+```
+
+If the binary is already built and you just want to relaunch:
+```bash
+./scripts/visual-test-start.sh --skip-build
+```
+
+The script outputs the URL, PID, screenshot dir, and writes state to `.playwright-mcp/visual-test-state.env`. Source it to get the variables:
+```bash
+source .playwright-mcp/visual-test-state.env
+# Now $RADAR_URL, $SCREENSHOT_DIR, $RADAR_PID, $RADAR_LOG are set
+```
+
+**When to use `--dev` mode instead:** For rapid CSS/layout iteration, you can skip the helper and run the Vite dev server + Go backend separately (Vite on port+1 proxies /api to the backend). But for testing actual renderer changes, the full `make build` + binary is the right approach — it tests the real embedded frontend.
+
+## Step 6: Visual Testing with Playwright
+
+Navigate to `$RADAR_URL` and systematically test the changed areas.
+
+### Screenshot Strategy
+
+**Choose the right scope for each screenshot:**
+- **Full page**: For layout issues, overall view verification, or when context matters
+- **Element/region**: For specific component rendering (renderers, badges, sections). Often more useful -- the reader can see detail without noise. Use Playwright's element screenshot or crop to the relevant area.
+
+**Naming convention**: `<kind>-<what>.png` (e.g., `nodepool-resource-usage.png`, `prometheusrule-alert-details.png`, `helmrelease-values-section.png`)
+
+**Screenshots MUST be saved under `.playwright-mcp/`** — Playwright MCP blocks writes outside this dir and the repo root. The start script already creates the right directory.
+
+### Testing flow
+
+For each changed renderer/component:
+
+1. **Navigate to the resource list**: Navigate directly to `$RADAR_URL/resources/<plural-kind>`
+2. **Screenshot the list view** (if table columns changed)
+3. **Click into a resource** to open the detail drawer
+4. **Use `browser_snapshot`** to find elements in the drawer — don't rely on keyboard scrolling. Drawers have their own scroll container, so `End`/`PageDown` keys scroll the page, not the drawer.
+5. **Screenshot the specific section** that was added/changed (element screenshot preferred over full page)
+6. **Test interactions** if applicable: expand/collapse, search/filter, click links
+7. **Check the browser console** for errors: `mcp__playwright__browser_console_messages`
+8. **Check dark mode** if color/styling changes were made (toggle in settings)
+
+### What to look for
+
+- Sections render with data (not empty/undefined/null)
+- Badges have correct colors and text
+- Links are clickable and navigate to the right resource
+- Empty states show appropriate text (not blank space)
+- Layout doesn't break (no overflow, no clipping, proper spacing)
+- Responsive behavior in the drawer (text truncation, wrapping)
+- Long text doesn't overflow into adjacent table columns
+
+## Step 7: Report
+
+List screenshot paths as plain text in a code block — do NOT use markdown links (they break when clicked in the terminal). At the end, run `open $SCREENSHOT_DIR` to open the folder in Finder.
+
+```
+## Visual Test Results
+
+Screenshots saved to:
+  .playwright-mcp/visual-test/<timestamp>/
+
+### Passed
+- [kind]: what looks correct (screenshot: filename.png)
+
+### Issues Found
+- [kind]: what's wrong (screenshot: filename.png)
+
+### Could Not Test
+- [kind]: why (e.g., no instances in cluster, CRD not installed)
+
+### Console Errors
+- (list any JS errors, or "None")
+```
+
+## Step 8: Cleanup
+
+Use the stop script:
+```bash
+./scripts/visual-test-stop.sh
+```
+
+This kills the Radar process, opens the screenshot folder, and cleans up the state file.
+
+Don't delete the screenshots or logs -- the user may want to reference them or attach to a PR.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./scripts/visual-test-start.sh)",
+      "Bash(./scripts/visual-test-start.sh:*)",
+      "Bash(./scripts/visual-test-stop.sh)"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,15 @@ make kill           # Kill running radar on port 9280
 make clean          # Remove build artifacts
 ```
 
+### Visual Testing
+```bash
+./scripts/visual-test-start.sh          # Build + launch on random port (9300-9399)
+./scripts/visual-test-start.sh --skip-build  # Relaunch without rebuilding
+source .playwright-mcp/visual-test-state.env # Load $RADAR_URL, $SCREENSHOT_DIR, etc.
+./scripts/visual-test-stop.sh           # Kill process, open screenshot folder
+```
+Use `/visual-test` command for the full workflow (cluster check, Playwright MCP, screenshots, report). Screenshots go under `.playwright-mcp/visual-test/`.
+
 ### Development Ports
 - **9280**: Backend API server (Go)
 - **9273**: Vite dev server (proxies /api to 9280)
@@ -460,7 +469,8 @@ Error responses are parsed as `{"error": "message"}` and displayed in toasts.
 - Renderers, resource-utils, and table column config live in `packages/k8s-ui/src/components/resources/`
 - Sections with data should use `defaultExpanded` (true) — only collapse empty or low-priority sections
 - Register in: `packages/k8s-ui/src/components/resources/renderers/index.ts` (export), `packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx` (KNOWN_KINDS + render line + `getResourceStatus()`)
-- Use `AlertBanner` for problem detection, `ConditionsSection` for K8s conditions
+- Use `AlertBanner` for problem detection, `ProblemAlerts` for multiple warnings/errors, `ConditionsSection` for K8s conditions
+- Use `LabelSelectorDisplay` for rendering K8s label selectors — handles `matchLabels` + `matchExpressions` + flat selectors. Never hand-roll selector badge rendering.
 - Long text in alerts/banners needs `break-all` class for CSS word breaking
 - **Kind collision rule:** When a CRD kind collides with a core K8s kind (e.g., Knative Service vs core Service), you must guard THREE places in `ResourceRendererDispatch.tsx`: (1) the core renderer line, (2) `getResourceStatus()`, (3) action buttons (Port Forward, etc.). Use `data?.apiVersion?.includes('group.name')` checks. Missing any one causes dual rendering bugs.
 - Core K8s renderers: Pod, Service, ConfigMap, Secret, Ingress, PersistentVolume, ReplicaSet, StorageClass, NetworkPolicy, Event, Workload (Deployment/StatefulSet/DaemonSet), Role, ClusterRole, RoleBinding, ClusterRoleBinding, ServiceAccount, IngressClass, PriorityClass, RuntimeClass, Lease, MutatingWebhookConfiguration, ValidatingWebhookConfiguration

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -455,6 +455,8 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
     { key: 'namespace', label: 'Namespace', width: 'w-36' },
     { key: 'status', label: 'Status', width: 'w-24' },
     { key: 'instanceType', label: 'Instance Type', width: 'w-32' },
+    { key: 'capacityType', label: 'Capacity', width: 'w-24', tooltip: 'Spot or On-Demand' },
+    { key: 'zone', label: 'Zone', width: 'w-28', hideOnMobile: true },
     { key: 'nodePool', label: 'Node Pool', width: 'w-32' },
     { key: 'nodeName', label: 'Node', width: 'w-40', hideOnMobile: true },
     { key: 'age', label: 'Age', width: 'w-20' },

--- a/packages/k8s-ui/src/components/resources/renderers/FluxHelmReleaseRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/FluxHelmReleaseRenderer.tsx
@@ -41,8 +41,10 @@ export function FluxHelmReleaseRenderer({ data, onNavigate }: FluxHelmReleaseRen
     })
   }
 
-  // Revision mismatch detection
+  // Revision mismatch detection — only flag when Ready=False to avoid false positives during active reconciliation
+  const isReadyFalse = conditions.find((c: any) => c.type === 'Ready')?.status === 'False'
   if (
+    isReadyFalse &&
     status.lastAppliedRevision &&
     status.lastAttemptedRevision &&
     status.lastAppliedRevision !== status.lastAttemptedRevision

--- a/packages/k8s-ui/src/components/resources/renderers/FluxHelmReleaseRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/FluxHelmReleaseRenderer.tsx
@@ -1,15 +1,16 @@
-import { Package, Settings, CheckCircle2, History } from 'lucide-react'
+import { Package, Settings, CheckCircle2, History, FileCode2, GitBranch } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property, ConditionsSection, ProblemAlerts } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, ProblemAlerts, ResourceLink } from '../../ui/drawer-components'
 import { formatAge } from '../resource-utils'
 import { GitOpsStatusBadge, SyncCountdown } from '../../gitops'
 import { fluxConditionsToGitOpsStatus, type FluxCondition } from '../../../types/gitops'
 
 interface FluxHelmReleaseRendererProps {
   data: any
+  onNavigate?: (ref: { kind: string; namespace: string; name: string }) => void
 }
 
-export function FluxHelmReleaseRenderer({ data }: FluxHelmReleaseRendererProps) {
+export function FluxHelmReleaseRenderer({ data, onNavigate }: FluxHelmReleaseRendererProps) {
   const status = data.status || {}
   const spec = data.spec || {}
   const conditions = (status.conditions || []) as FluxCondition[]
@@ -39,6 +40,26 @@ export function FluxHelmReleaseRenderer({ data }: FluxHelmReleaseRendererProps) 
       message: testFailCondition.message || 'Helm tests failed',
     })
   }
+
+  // Revision mismatch detection
+  if (
+    status.lastAppliedRevision &&
+    status.lastAttemptedRevision &&
+    status.lastAppliedRevision !== status.lastAttemptedRevision
+  ) {
+    problems.push({
+      color: 'red',
+      message: `Revision mismatch: attempted ${status.lastAttemptedRevision} but applied ${status.lastAppliedRevision} — the latest reconciliation failed.`,
+    })
+  }
+
+  // Values info
+  const valuesFrom = spec.valuesFrom || []
+  const values = spec.values || {}
+  const valueKeys = Object.keys(values)
+
+  // Dependencies
+  const dependsOn: Array<{ name: string; namespace?: string }> = spec.dependsOn || []
 
   // Chart reference
   const chartRef = spec.chart?.spec || {}
@@ -96,6 +117,71 @@ export function FluxHelmReleaseRenderer({ data }: FluxHelmReleaseRendererProps) 
           )}
         </PropertyList>
       </Section>
+
+      {/* Dependencies */}
+      {dependsOn.length > 0 && (
+        <Section title={`Dependencies (${dependsOn.length})`} icon={GitBranch}>
+          <div className="flex flex-wrap gap-1">
+            {dependsOn.map((dep, idx) => (
+              <ResourceLink
+                key={idx}
+                name={dep.name}
+                kind="helmreleases"
+                namespace={dep.namespace || data.metadata?.namespace || ''}
+                onNavigate={onNavigate}
+              />
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {/* Values */}
+      {(valuesFrom.length > 0 || valueKeys.length > 0) && (
+        <Section title="Values" icon={FileCode2} defaultExpanded={valuesFrom.length > 0}>
+          {valuesFrom.length > 0 && (
+            <div className="mb-3">
+              <div className="text-xs font-medium text-theme-text-secondary uppercase tracking-wider mb-1.5">
+                Values From
+              </div>
+              <div className="space-y-1">
+                {valuesFrom.map((ref: any, idx: number) => (
+                  <div key={idx} className="card-inner text-sm flex items-center gap-2 flex-wrap">
+                    <span className="badge-sm status-neutral">{ref.kind || 'ConfigMap'}</span>
+                    <ResourceLink
+                      name={ref.name}
+                      kind={ref.kind === 'Secret' ? 'secrets' : 'configmaps'}
+                      namespace={data.metadata?.namespace || ''}
+                      onNavigate={onNavigate}
+                    />
+                    {ref.valuesKey && (
+                      <span className="text-theme-text-tertiary text-xs">
+                        key: {ref.valuesKey}
+                      </span>
+                    )}
+                    {ref.targetPath && (
+                      <span className="text-theme-text-tertiary text-xs">
+                        path: {ref.targetPath}
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+          {valueKeys.length > 0 && (
+            <div>
+              <div className="text-xs font-medium text-theme-text-secondary uppercase tracking-wider mb-1.5">
+                Inline Overrides ({valueKeys.length} {valueKeys.length === 1 ? 'key' : 'keys'})
+              </div>
+              <Section title={`${valueKeys.length} value ${valueKeys.length === 1 ? 'override' : 'overrides'}`} defaultExpanded={false}>
+                <pre className="text-xs text-theme-text-secondary font-mono bg-theme-elevated rounded-md p-2 overflow-x-auto max-h-48">
+                  {JSON.stringify(values, null, 2)}
+                </pre>
+              </Section>
+            </div>
+          )}
+        </Section>
+      )}
 
       {/* Install/Upgrade settings */}
       {(spec.install || spec.upgrade) && (

--- a/packages/k8s-ui/src/components/resources/renderers/KarpenterEC2NodeClassRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KarpenterEC2NodeClassRenderer.tsx
@@ -163,7 +163,7 @@ export function KarpenterEC2NodeClassRenderer({ data }: KarpenterEC2NodeClassRen
           <div className="space-y-2">
             {statusAMIs.map((ami: any, i: number) => (
               <div key={i} className="card-inner">
-                <div className="text-sm font-medium text-theme-text-primary mb-1">{ami.id}</div>
+                <div className="text-sm font-medium text-theme-text-primary mb-1">{ami.id || '(unknown AMI)'}</div>
                 {ami.name && (
                   <div className="text-xs text-theme-text-tertiary mb-1">{ami.name}</div>
                 )}

--- a/packages/k8s-ui/src/components/resources/renderers/KarpenterEC2NodeClassRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KarpenterEC2NodeClassRenderer.tsx
@@ -1,5 +1,5 @@
-import { Server, HardDrive, Shield, Network } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
+import { Server, HardDrive, Shield, Network, Tag, Image } from 'lucide-react'
+import { Section, PropertyList, Property, ConditionsSection, AlertBanner, KeyValueBadgeList } from '../../ui/drawer-components'
 import { getEC2NodeClassStatus } from '../resource-utils-karpenter'
 
 interface KarpenterEC2NodeClassRendererProps {
@@ -20,6 +20,11 @@ export function KarpenterEC2NodeClassRenderer({ data }: KarpenterEC2NodeClassRen
   const subnetTerms = spec.subnetSelectorTerms || []
   const sgTerms = spec.securityGroupSelectorTerms || []
   const metadataOptions = spec.metadataOptions
+  const statusAMIs = status.amis || []
+  const statusSubnets = status.subnets || []
+  const statusSecurityGroups = status.securityGroups || []
+  const specTags = spec.tags || {}
+  const instanceProfile = status.instanceProfile
 
   return (
     <>
@@ -42,6 +47,7 @@ export function KarpenterEC2NodeClassRenderer({ data }: KarpenterEC2NodeClassRen
             />
           )}
           {spec.amiFamily && <Property label="AMI Family" value={spec.amiFamily} />}
+          {instanceProfile && <Property label="Instance Profile" value={instanceProfile} />}
         </PropertyList>
       </Section>
 
@@ -148,6 +154,64 @@ export function KarpenterEC2NodeClassRenderer({ data }: KarpenterEC2NodeClassRen
               <Property label="HTTP Endpoint" value={metadataOptions.httpEndpoint} />
             )}
           </PropertyList>
+        </Section>
+      )}
+
+      {/* Resolved AMIs from status */}
+      {statusAMIs.length > 0 && (
+        <Section title={`Resolved AMIs (${statusAMIs.length})`} icon={Image} defaultExpanded>
+          <div className="space-y-2">
+            {statusAMIs.map((ami: any, i: number) => (
+              <div key={i} className="card-inner">
+                <div className="text-sm font-medium text-theme-text-primary mb-1">{ami.id}</div>
+                {ami.name && (
+                  <div className="text-xs text-theme-text-tertiary mb-1">{ami.name}</div>
+                )}
+                {ami.requirements && ami.requirements.length > 0 && (
+                  <div className="flex flex-wrap gap-1">
+                    {ami.requirements.map((req: any, ri: number) => (
+                      <span key={ri} className="badge-sm bg-theme-hover text-theme-text-secondary">
+                        {req.key}: {req.values?.join(', ') || req.operator}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {/* Resolved Subnets from status */}
+      {statusSubnets.length > 0 && (
+        <Section title={`Resolved Subnets (${statusSubnets.length})`} icon={Network} defaultExpanded>
+          <div className="flex flex-wrap gap-1">
+            {statusSubnets.map((subnet: any, i: number) => (
+              <span key={i} className="badge-sm bg-theme-hover text-theme-text-secondary">
+                {subnet.id}{subnet.zone ? ` (${subnet.zone})` : ''}
+              </span>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {/* Resolved Security Groups from status */}
+      {statusSecurityGroups.length > 0 && (
+        <Section title={`Resolved Security Groups (${statusSecurityGroups.length})`} icon={Shield} defaultExpanded>
+          <div className="flex flex-wrap gap-1">
+            {statusSecurityGroups.map((sg: any, i: number) => (
+              <span key={i} className="badge-sm bg-theme-hover text-theme-text-secondary">
+                {sg.id}{sg.name ? ` (${sg.name})` : ''}
+              </span>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {/* EC2 Tags */}
+      {Object.keys(specTags).length > 0 && (
+        <Section title={`EC2 Tags (${Object.keys(specTags).length})`} icon={Tag} defaultExpanded>
+          <KeyValueBadgeList items={specTags} />
         </Section>
       )}
 

--- a/packages/k8s-ui/src/components/resources/renderers/KarpenterNodeClaimRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KarpenterNodeClaimRenderer.tsx
@@ -35,6 +35,8 @@ export function KarpenterNodeClaimRenderer({ data, onNavigate }: KarpenterNodeCl
   const status = data.status || {}
   const conditions = status.conditions || []
 
+  const labels = data.metadata?.labels || {}
+
   const claimStatus = getNodeClaimStatus(data)
   const isNotReady = claimStatus.level === 'unhealthy'
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
@@ -42,6 +44,10 @@ export function KarpenterNodeClaimRenderer({ data, onNavigate }: KarpenterNodeCl
   const requirements = getNodeClaimRequirements(data)
   const nodeClassRef = getNodeClaimNodeClassRef(data)
   const expireAfter = getNodeClaimExpireAfter(data)
+  const capacityType = labels['karpenter.sh/capacity-type'] || ''
+  const zone = labels['topology.kubernetes.io/zone'] || ''
+  const arch = labels['kubernetes.io/arch'] || ''
+  const nodeName = getNodeClaimNodeName(data)
 
   // Provisioning steps for timeline
   const steps = [
@@ -66,7 +72,35 @@ export function KarpenterNodeClaimRenderer({ data, onNavigate }: KarpenterNodeCl
       <Section title="Instance" icon={Server}>
         <PropertyList>
           <Property label="Instance Type" value={getNodeClaimInstanceType(data)} />
-          <Property label="Node Name" value={getNodeClaimNodeName(data)} />
+          {capacityType && (
+            <Property
+              label="Capacity Type"
+              value={
+                <span className={clsx(
+                  'badge-sm',
+                  capacityType === 'spot'
+                    ? 'bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-950/50 dark:text-amber-400 dark:border-amber-700/40'
+                    : 'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40'
+                )}>
+                  {capacityType}
+                </span>
+              }
+            />
+          )}
+          <Property
+            label="Node Name"
+            value={nodeName !== '-' ? (
+              <ResourceLink
+                name={nodeName}
+                kind="Node"
+                namespace=""
+                label={nodeName}
+                onNavigate={onNavigate}
+              />
+            ) : '-'}
+          />
+          {zone && <Property label="Zone" value={zone} />}
+          {arch && <Property label="Architecture" value={arch} />}
           <Property label="NodePool" value={getNodeClaimNodePoolRef(data)} />
           {nodeClassRef && (
             <Property

--- a/packages/k8s-ui/src/components/resources/renderers/KarpenterNodeClaimRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KarpenterNodeClaimRenderer.tsx
@@ -3,6 +3,7 @@ import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
 import { kindToPlural } from '../../../utils/navigation'
 import {
+  CAPACITY_TYPE_BADGE,
   getNodeClaimStatus,
   getNodeClaimInstanceType,
   getNodeClaimNodeName,
@@ -76,12 +77,7 @@ export function KarpenterNodeClaimRenderer({ data, onNavigate }: KarpenterNodeCl
             <Property
               label="Capacity Type"
               value={
-                <span className={clsx(
-                  'badge-sm',
-                  capacityType === 'spot'
-                    ? 'bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-950/50 dark:text-amber-400 dark:border-amber-700/40'
-                    : 'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40'
-                )}>
+                <span className={clsx('badge-sm', CAPACITY_TYPE_BADGE[capacityType] || '')}>
                   {capacityType}
                 </span>
               }

--- a/packages/k8s-ui/src/components/resources/renderers/KarpenterNodePoolRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KarpenterNodePoolRenderer.tsx
@@ -18,10 +18,6 @@ function formatCpuCores(value: string): string {
   return value
 }
 
-function formatMemory(value: string): string {
-  // Already human-readable (e.g. "48Gi", "128Gi") — pass through
-  return value
-}
 
 interface KarpenterNodePoolRendererProps {
   data: any
@@ -107,7 +103,7 @@ export function KarpenterNodePoolRenderer({ data, onNavigate }: KarpenterNodePoo
             {statusResources.memory && (
               <Property
                 label="Memory"
-                value={`${formatMemory(statusResources.memory)}${spec.limits?.memory ? ` / ${formatMemory(spec.limits.memory)}` : ''}`}
+                value={`${statusResources.memory}${spec.limits?.memory ? ` / ${spec.limits.memory}` : ''}`}
               />
             )}
           </PropertyList>
@@ -164,7 +160,7 @@ export function KarpenterNodePoolRenderer({ data, onNavigate }: KarpenterNodePoo
                 key={i}
                 className="badge-sm bg-theme-hover text-theme-text-secondary"
               >
-                {taint.key}={taint.value || ''}:{taint.effect}
+                {taint.key}={taint.value || ''}:{taint.effect || ''}
               </span>
             ))}
           </div>
@@ -180,7 +176,7 @@ export function KarpenterNodePoolRenderer({ data, onNavigate }: KarpenterNodePoo
                 key={i}
                 className="badge-sm bg-theme-hover text-theme-text-secondary"
               >
-                {taint.key}={taint.value || ''}:{taint.effect}
+                {taint.key}={taint.value || ''}:{taint.effect || ''}
               </span>
             ))}
           </div>

--- a/packages/k8s-ui/src/components/resources/renderers/KarpenterNodePoolRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KarpenterNodePoolRenderer.tsx
@@ -1,4 +1,4 @@
-import { Server, Settings, Shield, Cpu, Tag } from 'lucide-react'
+import { Server, Settings, Shield, Cpu, Tag, BarChart3 } from 'lucide-react'
 import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
 import { kindToPlural } from '../../../utils/navigation'
 import {
@@ -8,6 +8,20 @@ import {
   getNodePoolRequirements,
   getNodePoolWeight,
 } from '../resource-utils-karpenter'
+
+function formatCpuCores(value: string): string {
+  // Karpenter status.resources CPU is typically in millicores (e.g. "12000m") or cores (e.g. "12")
+  if (value.endsWith('m')) {
+    const millis = parseInt(value, 10)
+    if (!isNaN(millis)) return String(millis / 1000)
+  }
+  return value
+}
+
+function formatMemory(value: string): string {
+  // Already human-readable (e.g. "48Gi", "128Gi") — pass through
+  return value
+}
 
 interface KarpenterNodePoolRendererProps {
   data: any
@@ -28,6 +42,9 @@ export function KarpenterNodePoolRenderer({ data, onNavigate }: KarpenterNodePoo
   const templateLabels = spec.template?.metadata?.labels || {}
   const templateExpireAfter = spec.template?.spec?.expireAfter
   const nodeClassRef = spec.template?.spec?.nodeClassRef
+  const templateTaints = spec.template?.spec?.taints || []
+  const templateStartupTaints = spec.template?.spec?.startupTaints || []
+  const statusResources = status.resources || {}
 
   return (
     <>
@@ -77,6 +94,26 @@ export function KarpenterNodePoolRenderer({ data, onNavigate }: KarpenterNodePoo
         </PropertyList>
       </Section>
 
+      {/* Resource Usage — from status.resources vs spec.limits */}
+      {(statusResources.cpu || statusResources.memory) && (
+        <Section title="Resource Usage" icon={BarChart3} defaultExpanded>
+          <PropertyList>
+            {statusResources.cpu && (
+              <Property
+                label="CPU"
+                value={`${formatCpuCores(statusResources.cpu)}${spec.limits?.cpu ? ` / ${formatCpuCores(spec.limits.cpu)}` : ''}`}
+              />
+            )}
+            {statusResources.memory && (
+              <Property
+                label="Memory"
+                value={`${formatMemory(statusResources.memory)}${spec.limits?.memory ? ` / ${formatMemory(spec.limits.memory)}` : ''}`}
+              />
+            )}
+          </PropertyList>
+        </Section>
+      )}
+
       {/* Disruption */}
       <Section title="Disruption" icon={Shield}>
         <PropertyList>
@@ -112,6 +149,38 @@ export function KarpenterNodePoolRenderer({ data, onNavigate }: KarpenterNodePoo
                 className="badge-sm bg-theme-hover text-theme-text-secondary"
               >
                 {key}: {String(val)}
+              </span>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {/* Template Taints */}
+      {templateTaints.length > 0 && (
+        <Section title={`Template Taints (${templateTaints.length})`} icon={Shield} defaultExpanded>
+          <div className="flex flex-wrap gap-1">
+            {templateTaints.map((taint: any, i: number) => (
+              <span
+                key={i}
+                className="badge-sm bg-theme-hover text-theme-text-secondary"
+              >
+                {taint.key}={taint.value || ''}:{taint.effect}
+              </span>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {/* Template Startup Taints */}
+      {templateStartupTaints.length > 0 && (
+        <Section title={`Startup Taints (${templateStartupTaints.length})`} icon={Shield} defaultExpanded>
+          <div className="flex flex-wrap gap-1">
+            {templateStartupTaints.map((taint: any, i: number) => (
+              <span
+                key={i}
+                className="badge-sm bg-theme-hover text-theme-text-secondary"
+              >
+                {taint.key}={taint.value || ''}:{taint.effect}
               </span>
             ))}
           </div>

--- a/packages/k8s-ui/src/components/resources/renderers/KustomizationRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KustomizationRenderer.tsx
@@ -40,8 +40,10 @@ export function KustomizationRenderer({ data, onNavigate }: KustomizationRendere
     })
   }
 
-  // Revision mismatch detection
+  // Revision mismatch detection — only flag when Ready=False to avoid false positives during active reconciliation
+  const isReadyFalse = conditions.find((c: any) => c.type === 'Ready')?.status === 'False'
   if (
+    isReadyFalse &&
     status.lastAppliedRevision &&
     status.lastAttemptedRevision &&
     status.lastAppliedRevision !== status.lastAttemptedRevision

--- a/packages/k8s-ui/src/components/resources/renderers/KustomizationRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KustomizationRenderer.tsx
@@ -1,14 +1,15 @@
-import { Layers, FolderTree } from 'lucide-react'
-import { Section, PropertyList, Property, ConditionsSection, ProblemAlerts } from '../../ui/drawer-components'
+import { Layers, FolderTree, GitBranch } from 'lucide-react'
+import { Section, PropertyList, Property, ConditionsSection, ProblemAlerts, ResourceLink } from '../../ui/drawer-components'
 import { formatAge } from '../resource-utils'
 import { GitOpsStatusBadge, ManagedResourcesList, SyncCountdown } from '../../gitops'
 import { fluxConditionsToGitOpsStatus, parseFluxInventory, type FluxCondition } from '../../../types/gitops'
 
 interface KustomizationRendererProps {
   data: any
+  onNavigate?: (ref: { kind: string; namespace: string; name: string }) => void
 }
 
-export function KustomizationRenderer({ data }: KustomizationRendererProps) {
+export function KustomizationRenderer({ data, onNavigate }: KustomizationRendererProps) {
   const status = data.status || {}
   const spec = data.spec || {}
   const conditions = (status.conditions || []) as FluxCondition[]
@@ -38,6 +39,21 @@ export function KustomizationRenderer({ data }: KustomizationRendererProps) {
       message: healthyCondition.message || 'Deployed resources are not healthy',
     })
   }
+
+  // Revision mismatch detection
+  if (
+    status.lastAppliedRevision &&
+    status.lastAttemptedRevision &&
+    status.lastAppliedRevision !== status.lastAttemptedRevision
+  ) {
+    problems.push({
+      color: 'red',
+      message: `Revision mismatch: attempted ${status.lastAttemptedRevision} but applied ${status.lastAppliedRevision} — the latest reconciliation failed.`,
+    })
+  }
+
+  // Dependencies
+  const dependsOn: Array<{ name: string; namespace?: string }> = spec.dependsOn || []
 
   // Source reference
   const sourceRef = spec.sourceRef || {}
@@ -93,6 +109,23 @@ export function KustomizationRenderer({ data }: KustomizationRendererProps) {
           )}
         </PropertyList>
       </Section>
+
+      {/* Dependencies */}
+      {dependsOn.length > 0 && (
+        <Section title={`Dependencies (${dependsOn.length})`} icon={GitBranch}>
+          <div className="flex flex-wrap gap-1">
+            {dependsOn.map((dep, idx) => (
+              <ResourceLink
+                key={idx}
+                name={dep.name}
+                kind="kustomizations"
+                namespace={dep.namespace || data.metadata?.namespace || ''}
+                onNavigate={onNavigate}
+              />
+            ))}
+          </div>
+        </Section>
+      )}
 
       {/* Health checks */}
       {spec.healthChecks && spec.healthChecks.length > 0 && (

--- a/packages/k8s-ui/src/components/resources/renderers/PrometheusRuleRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PrometheusRuleRenderer.tsx
@@ -1,13 +1,165 @@
-import { Bell } from 'lucide-react'
+import { useState, useMemo } from 'react'
+import { Bell, Search, ChevronRight } from 'lucide-react'
+import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection } from '../../ui/drawer-components'
 import {
   getPrometheusRuleGroups,
   getPrometheusRuleTotalRules,
   getPrometheusRuleGroupCount,
 } from '../resource-utils-prometheus'
+import type { PrometheusRuleGroup, PrometheusAlertRule, PrometheusRecordingRule } from '../resource-utils-prometheus'
 
 interface PrometheusRuleRendererProps {
   data: any
+}
+
+const SEVERITY_BADGE: Record<string, string> = {
+  critical: 'bg-red-100 text-red-700 border-red-300 dark:bg-red-950/50 dark:text-red-400 dark:border-red-700/40',
+  warning: 'bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-950/50 dark:text-amber-400 dark:border-amber-700/40',
+  info: 'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40',
+}
+
+const EXPR_TRUNCATE_LEN = 200
+const SUMMARY_TRUNCATE_LEN = 100
+
+function TruncatedExpr({ expr }: { expr: string }) {
+  const [expanded, setExpanded] = useState(false)
+  const needsTruncation = expr.length > EXPR_TRUNCATE_LEN
+
+  return (
+    <div className="mt-1">
+      <pre className="text-xs font-mono text-theme-text-secondary bg-theme-elevated rounded px-2 py-1.5 whitespace-pre-wrap break-all">
+        {expanded || !needsTruncation ? expr : expr.slice(0, EXPR_TRUNCATE_LEN) + '...'}
+      </pre>
+      {needsTruncation && (
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="text-[10px] text-accent-text hover:underline mt-0.5"
+        >
+          {expanded ? 'Show less' : 'Show more'}
+        </button>
+      )}
+    </div>
+  )
+}
+
+function AlertRuleCard({ rule }: { rule: PrometheusAlertRule }) {
+  const severityClass = rule.severity ? SEVERITY_BADGE[rule.severity] : undefined
+  const summaryText = rule.summary || rule.description || ''
+  const truncatedSummary = summaryText.length > SUMMARY_TRUNCATE_LEN
+    ? summaryText.slice(0, SUMMARY_TRUNCATE_LEN) + '...'
+    : summaryText
+
+  return (
+    <div className="card-inner text-sm">
+      <div className="flex items-center gap-2 flex-wrap">
+        <span className="text-theme-text-primary font-medium">{rule.alert}</span>
+        {rule.severity && (
+          <span className={clsx('badge-sm', severityClass || 'bg-theme-hover text-theme-text-secondary')}>
+            {rule.severity}
+          </span>
+        )}
+        {rule.for && (
+          <span className="badge-sm bg-theme-hover text-theme-text-secondary">
+            for: {rule.for}
+          </span>
+        )}
+      </div>
+      {truncatedSummary && (
+        <div className="text-xs text-theme-text-tertiary mt-1">{truncatedSummary}</div>
+      )}
+      <TruncatedExpr expr={rule.expr} />
+    </div>
+  )
+}
+
+function RecordingRuleCard({ rule }: { rule: PrometheusRecordingRule }) {
+  return (
+    <div className="card-inner text-sm">
+      <div className="flex items-center gap-2">
+        <span className="text-theme-text-primary font-medium">{rule.record}</span>
+        <span className="badge-sm bg-theme-hover text-theme-text-tertiary">recording</span>
+      </div>
+      <TruncatedExpr expr={rule.expr} />
+    </div>
+  )
+}
+
+function RuleGroupSection({ group, searchTerm }: { group: PrometheusRuleGroup; searchTerm: string }) {
+  const defaultExpanded = group.ruleCount <= 10
+  const [expanded, setExpanded] = useState(defaultExpanded)
+
+  const filteredRules = useMemo(() => {
+    if (!searchTerm) return group.rules
+    const term = searchTerm.toLowerCase()
+    return group.rules.filter((rule) => {
+      if (rule.type === 'alert') {
+        return (
+          rule.alert.toLowerCase().includes(term) ||
+          rule.expr.toLowerCase().includes(term) ||
+          (rule.severity || '').toLowerCase().includes(term) ||
+          (rule.summary || '').toLowerCase().includes(term) ||
+          (rule.description || '').toLowerCase().includes(term)
+        )
+      }
+      return (
+        rule.record.toLowerCase().includes(term) ||
+        rule.expr.toLowerCase().includes(term)
+      )
+    })
+  }, [group.rules, searchTerm])
+
+  // If searching and no matches, hide the group entirely
+  if (searchTerm && filteredRules.length === 0) return null
+
+  return (
+    <div className="card-inner">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex items-center justify-between w-full text-left"
+      >
+        <div className="flex items-center gap-2">
+          <ChevronRight className={clsx('w-3.5 h-3.5 text-theme-text-tertiary transition-transform duration-200', expanded && 'rotate-90')} />
+          <span className="text-sm text-theme-text-primary font-medium">{group.name}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          {group.interval && (
+            <span className="badge-sm bg-theme-hover text-theme-text-secondary">
+              {group.interval}
+            </span>
+          )}
+          <span className="text-xs text-theme-text-tertiary">
+            {searchTerm ? `${filteredRules.length}/${group.ruleCount}` : group.ruleCount} rule{group.ruleCount !== 1 ? 's' : ''}
+          </span>
+        </div>
+      </button>
+      {!expanded && (
+        <div className="text-xs text-theme-text-secondary mt-1 ml-5.5 flex gap-3">
+          {group.alertCount > 0 && <span>{group.alertCount} alert{group.alertCount !== 1 ? 's' : ''}</span>}
+          {group.recordCount > 0 && <span>{group.recordCount} recording</span>}
+        </div>
+      )}
+      <div
+        className="grid transition-[grid-template-rows] duration-200 ease-out"
+        style={{ gridTemplateRows: expanded ? '1fr' : '0fr' }}
+      >
+        <div className="overflow-hidden">
+          <div className="mt-2 space-y-2">
+            {filteredRules.map((rule, i) => (
+              rule.type === 'alert'
+                ? <AlertRuleCard key={`alert-${rule.alert}-${i}`} rule={rule} />
+                : <RecordingRuleCard key={`rec-${rule.record}-${i}`} rule={rule} />
+            ))}
+            {searchTerm && filteredRules.length === 0 && (
+              <div className="text-xs text-theme-text-tertiary py-2 text-center">
+                No rules match the current filter.
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
 }
 
 export function PrometheusRuleRenderer({ data }: PrometheusRuleRendererProps) {
@@ -16,6 +168,8 @@ export function PrometheusRuleRenderer({ data }: PrometheusRuleRendererProps) {
   const totalAlerts = groups.reduce((sum, g) => sum + g.alertCount, 0)
   const totalRecords = groups.reduce((sum, g) => sum + g.recordCount, 0)
   const conditions = data.status?.conditions
+
+  const [searchTerm, setSearchTerm] = useState('')
 
   return (
     <>
@@ -30,28 +184,45 @@ export function PrometheusRuleRenderer({ data }: PrometheusRuleRendererProps) {
 
       {groups.length > 0 && (
         <Section title={`Rule Groups (${groups.length})`} defaultExpanded>
+          {/* Search bar */}
+          {totalRules > 5 && (
+            <div className="relative mb-3">
+              <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-theme-text-tertiary" />
+              <input
+                type="text"
+                placeholder="Filter rules by name or expression..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="w-full pl-7 pr-2 py-1.5 text-xs bg-theme-elevated border border-theme-border rounded-md text-theme-text-primary placeholder:text-theme-text-tertiary focus:outline-none focus:ring-1 focus:ring-accent/50"
+              />
+            </div>
+          )}
           <div className="space-y-2">
             {groups.map((group, i) => (
-              <div key={i} className="card-inner text-sm">
-                <div className="flex items-center justify-between">
-                  <span className="text-theme-text-primary font-medium">{group.name}</span>
-                  <div className="flex items-center gap-2">
-                    {group.interval && (
-                      <span className="badge-sm bg-theme-hover text-theme-text-secondary">
-                        {group.interval}
-                      </span>
-                    )}
-                    <span className="text-xs text-theme-text-tertiary">
-                      {group.ruleCount} rule{group.ruleCount !== 1 ? 's' : ''}
-                    </span>
-                  </div>
-                </div>
-                <div className="text-xs text-theme-text-secondary mt-1 flex gap-3">
-                  {group.alertCount > 0 && <span>{group.alertCount} alert{group.alertCount !== 1 ? 's' : ''}</span>}
-                  {group.recordCount > 0 && <span>{group.recordCount} recording</span>}
-                </div>
-              </div>
+              <RuleGroupSection key={i} group={group} searchTerm={searchTerm} />
             ))}
+            {searchTerm && groups.every(g => {
+              const term = searchTerm.toLowerCase()
+              return g.rules.every(rule => {
+                if (rule.type === 'alert') {
+                  return !(
+                    rule.alert.toLowerCase().includes(term) ||
+                    rule.expr.toLowerCase().includes(term) ||
+                    (rule.severity || '').toLowerCase().includes(term) ||
+                    (rule.summary || '').toLowerCase().includes(term) ||
+                    (rule.description || '').toLowerCase().includes(term)
+                  )
+                }
+                return !(
+                  rule.record.toLowerCase().includes(term) ||
+                  rule.expr.toLowerCase().includes(term)
+                )
+              })
+            }) && (
+              <div className="text-xs text-theme-text-tertiary py-3 text-center">
+                No rules match "{searchTerm}".
+              </div>
+            )}
           </div>
         </Section>
       )}

--- a/packages/k8s-ui/src/components/resources/renderers/PrometheusRuleRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PrometheusRuleRenderer.tsx
@@ -2,21 +2,39 @@ import { useState, useMemo } from 'react'
 import { Bell, Search, ChevronRight } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection } from '../../ui/drawer-components'
+import { BADGE_SEVERITY_COLORS } from '../../ui/Badge'
 import {
   getPrometheusRuleGroups,
   getPrometheusRuleTotalRules,
   getPrometheusRuleGroupCount,
 } from '../resource-utils-prometheus'
-import type { PrometheusRuleGroup, PrometheusAlertRule, PrometheusRecordingRule } from '../resource-utils-prometheus'
+import type { PrometheusRuleGroup, PrometheusRule, PrometheusAlertRule, PrometheusRecordingRule } from '../resource-utils-prometheus'
 
 interface PrometheusRuleRendererProps {
   data: any
 }
 
+// Map Prometheus severity names to centralized badge colors
 const SEVERITY_BADGE: Record<string, string> = {
-  critical: 'bg-red-100 text-red-700 border-red-300 dark:bg-red-950/50 dark:text-red-400 dark:border-red-700/40',
-  warning: 'bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-950/50 dark:text-amber-400 dark:border-amber-700/40',
-  info: 'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40',
+  critical: BADGE_SEVERITY_COLORS.error,
+  warning: BADGE_SEVERITY_COLORS.warning,
+  info: BADGE_SEVERITY_COLORS.info,
+}
+
+function matchesSearch(rule: PrometheusRule, term: string): boolean {
+  if (rule.type === 'alert') {
+    return (
+      rule.alert.toLowerCase().includes(term) ||
+      rule.expr.toLowerCase().includes(term) ||
+      (rule.severity || '').toLowerCase().includes(term) ||
+      (rule.summary || '').toLowerCase().includes(term) ||
+      (rule.description || '').toLowerCase().includes(term)
+    )
+  }
+  return (
+    (rule.record || '').toLowerCase().includes(term) ||
+    rule.expr.toLowerCase().includes(term)
+  )
 }
 
 const EXPR_TRUNCATE_LEN = 200
@@ -86,28 +104,16 @@ function RecordingRuleCard({ rule }: { rule: PrometheusRecordingRule }) {
 }
 
 function RuleGroupSection({ group, searchTerm }: { group: PrometheusRuleGroup; searchTerm: string }) {
-  const defaultExpanded = group.ruleCount <= 10
-  const [expanded, setExpanded] = useState(defaultExpanded)
+  const [manualExpanded, setManualExpanded] = useState(group.ruleCount <= 10)
 
   const filteredRules = useMemo(() => {
     if (!searchTerm) return group.rules
     const term = searchTerm.toLowerCase()
-    return group.rules.filter((rule) => {
-      if (rule.type === 'alert') {
-        return (
-          rule.alert.toLowerCase().includes(term) ||
-          rule.expr.toLowerCase().includes(term) ||
-          (rule.severity || '').toLowerCase().includes(term) ||
-          (rule.summary || '').toLowerCase().includes(term) ||
-          (rule.description || '').toLowerCase().includes(term)
-        )
-      }
-      return (
-        rule.record.toLowerCase().includes(term) ||
-        rule.expr.toLowerCase().includes(term)
-      )
-    })
+    return group.rules.filter((rule) => matchesSearch(rule, term))
   }, [group.rules, searchTerm])
+
+  // Auto-expand when searching so matched rules are visible
+  const expanded = searchTerm ? filteredRules.length > 0 : manualExpanded
 
   // If searching and no matches, hide the group entirely
   if (searchTerm && filteredRules.length === 0) return null
@@ -115,7 +121,7 @@ function RuleGroupSection({ group, searchTerm }: { group: PrometheusRuleGroup; s
   return (
     <div className="card-inner">
       <button
-        onClick={() => setExpanded(!expanded)}
+        onClick={() => setManualExpanded(!manualExpanded)}
         className="flex items-center justify-between w-full text-left"
       >
         <div className="flex items-center gap-2">
@@ -150,11 +156,6 @@ function RuleGroupSection({ group, searchTerm }: { group: PrometheusRuleGroup; s
                 ? <AlertRuleCard key={`alert-${rule.alert}-${i}`} rule={rule} />
                 : <RecordingRuleCard key={`rec-${rule.record}-${i}`} rule={rule} />
             ))}
-            {searchTerm && filteredRules.length === 0 && (
-              <div className="text-xs text-theme-text-tertiary py-2 text-center">
-                No rules match the current filter.
-              </div>
-            )}
           </div>
         </div>
       </div>
@@ -203,21 +204,7 @@ export function PrometheusRuleRenderer({ data }: PrometheusRuleRendererProps) {
             ))}
             {searchTerm && groups.every(g => {
               const term = searchTerm.toLowerCase()
-              return g.rules.every(rule => {
-                if (rule.type === 'alert') {
-                  return !(
-                    rule.alert.toLowerCase().includes(term) ||
-                    rule.expr.toLowerCase().includes(term) ||
-                    (rule.severity || '').toLowerCase().includes(term) ||
-                    (rule.summary || '').toLowerCase().includes(term) ||
-                    (rule.description || '').toLowerCase().includes(term)
-                  )
-                }
-                return !(
-                  rule.record.toLowerCase().includes(term) ||
-                  rule.expr.toLowerCase().includes(term)
-                )
-              })
+              return g.rules.every(rule => !matchesSearch(rule, term))
             }) && (
               <div className="text-xs text-theme-text-tertiary py-3 text-center">
                 No rules match "{searchTerm}".

--- a/packages/k8s-ui/src/components/resources/renderers/VeleroBackupRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/VeleroBackupRenderer.tsx
@@ -56,7 +56,7 @@ export function VeleroBackupRenderer({ data }: VeleroBackupRendererProps) {
         <AlertBanner
           variant="error"
           title={isFailed ? 'Backup Failed' : 'Backup Partially Failed'}
-          message={`${errors} error(s) occurred during backup.`}
+          message={status.failureReason || `${errors} error(s) occurred during backup.`}
           items={validationErrors.length > 0 ? validationErrors : undefined}
         />
       )}
@@ -84,8 +84,16 @@ export function VeleroBackupRenderer({ data }: VeleroBackupRendererProps) {
           )}
           <Property label="Duration" value={getBackupDuration(data)} />
           <Property label="Expiration" value={getBackupExpiry(data)} />
-          {errors > 0 && <Property label="Errors" value={String(errors)} />}
-          {warnings > 0 && <Property label="Warnings" value={String(warnings)} />}
+          <Property label="Errors" value={
+            errors > 0
+              ? <span className="text-red-500 dark:text-red-400 font-medium">{errors}</span>
+              : '0'
+          } />
+          <Property label="Warnings" value={
+            warnings > 0
+              ? <span className="text-amber-500 dark:text-amber-400 font-medium">{warnings}</span>
+              : '0'
+          } />
         </PropertyList>
       </Section>
 

--- a/packages/k8s-ui/src/components/resources/renderers/VeleroRestoreRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/VeleroRestoreRenderer.tsx
@@ -49,7 +49,7 @@ export function VeleroRestoreRenderer({ data }: VeleroRestoreRendererProps) {
         <AlertBanner
           variant="error"
           title={isFailed ? 'Restore Failed' : 'Restore Partially Failed'}
-          message={`${errors} error(s) occurred during restore.`}
+          message={status.failureReason || `${errors} error(s) occurred during restore.`}
         />
       )}
       {warnings > 0 && !isFailed && (
@@ -76,8 +76,16 @@ export function VeleroRestoreRenderer({ data }: VeleroRestoreRendererProps) {
             <Property label="Completed" value={formatAge(status.completionTimestamp) + ' ago'} />
           )}
           <Property label="Duration" value={getRestoreDuration(data)} />
-          {errors > 0 && <Property label="Errors" value={String(errors)} />}
-          {warnings > 0 && <Property label="Warnings" value={String(warnings)} />}
+          <Property label="Errors" value={
+            errors > 0
+              ? <span className="text-red-500 dark:text-red-400 font-medium">{errors}</span>
+              : '0'
+          } />
+          <Property label="Warnings" value={
+            warnings > 0
+              ? <span className="text-amber-500 dark:text-amber-400 font-medium">{warnings}</span>
+              : '0'
+          } />
         </PropertyList>
       </Section>
 

--- a/packages/k8s-ui/src/components/resources/renderers/karpenter-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/karpenter-cells.tsx
@@ -22,9 +22,11 @@ export function NodePoolCell({ resource, column }: { resource: any; column: stri
     case 'status': {
       const status = getNodePoolStatus(resource)
       return (
-        <span className={clsx('badge', status.color)}>
-          {status.text}
-        </span>
+        <Tooltip content={status.text}>
+          <span className={clsx('badge truncate max-w-[140px]', status.color)}>
+            {status.text}
+          </span>
+        </Tooltip>
       )
     }
     case 'nodeClass': {

--- a/packages/k8s-ui/src/components/resources/renderers/karpenter-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/karpenter-cells.tsx
@@ -3,6 +3,7 @@
 import { clsx } from 'clsx'
 import { Tooltip } from '../../ui/Tooltip'
 import {
+  CAPACITY_TYPE_BADGE,
   getNodePoolStatus,
   getNodePoolNodeClassRef,
   getNodePoolLimits,
@@ -75,14 +76,7 @@ export function NodeClaimCell({ resource, column }: { resource: any; column: str
     case 'capacityType': {
       const ct = resource.metadata?.labels?.['karpenter.sh/capacity-type'] || '-'
       return (
-        <span className={clsx(
-          'badge-sm',
-          ct === 'spot'
-            ? 'bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-950/50 dark:text-amber-400 dark:border-amber-700/40'
-            : ct === 'on-demand'
-              ? 'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40'
-              : ''
-        )}>
+        <span className={clsx('badge-sm', CAPACITY_TYPE_BADGE[ct] || '')}>
           {ct}
         </span>
       )

--- a/packages/k8s-ui/src/components/resources/renderers/karpenter-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/karpenter-cells.tsx
@@ -70,6 +70,25 @@ export function NodeClaimCell({ resource, column }: { resource: any; column: str
       const pool = getNodeClaimNodePoolRef(resource)
       return <span className="text-sm text-theme-text-secondary">{pool}</span>
     }
+    case 'capacityType': {
+      const ct = resource.metadata?.labels?.['karpenter.sh/capacity-type'] || '-'
+      return (
+        <span className={clsx(
+          'badge-sm',
+          ct === 'spot'
+            ? 'bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-950/50 dark:text-amber-400 dark:border-amber-700/40'
+            : ct === 'on-demand'
+              ? 'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40'
+              : ''
+        )}>
+          {ct}
+        </span>
+      )
+    }
+    case 'zone': {
+      const zone = resource.metadata?.labels?.['topology.kubernetes.io/zone'] || '-'
+      return <span className="text-sm text-theme-text-secondary">{zone}</span>
+    }
     default:
       return <span className="text-sm text-theme-text-tertiary">-</span>
   }

--- a/packages/k8s-ui/src/components/resources/resource-utils-karpenter.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-karpenter.ts
@@ -3,6 +3,12 @@
 import type { StatusBadge } from './resource-utils'
 import { healthColors } from './resource-utils'
 
+// Shared capacity type badge colors for NodeClaim renderer and table cells
+export const CAPACITY_TYPE_BADGE: Record<string, string> = {
+  spot: 'bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-950/50 dark:text-amber-400 dark:border-amber-700/40',
+  'on-demand': 'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40',
+}
+
 // ============================================================================
 // KARPENTER NODEPOOL UTILITIES
 // ============================================================================

--- a/packages/k8s-ui/src/components/resources/resource-utils-prometheus.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-prometheus.ts
@@ -99,23 +99,67 @@ export function getPrometheusRuleTotalRules(resource: any): number {
   return groups.reduce((sum: number, g: any) => sum + (g.rules?.length || 0), 0)
 }
 
-export function getPrometheusRuleGroups(resource: any): Array<{
+export interface PrometheusAlertRule {
+  type: 'alert'
+  alert: string
+  expr: string
+  for?: string
+  severity?: string
+  summary?: string
+  description?: string
+  labels?: Record<string, string>
+}
+
+export interface PrometheusRecordingRule {
+  type: 'recording'
+  record: string
+  expr: string
+  labels?: Record<string, string>
+}
+
+export type PrometheusRule = PrometheusAlertRule | PrometheusRecordingRule
+
+export interface PrometheusRuleGroup {
   name: string
   interval?: string
   ruleCount: number
   alertCount: number
   recordCount: number
-}> {
+  rules: PrometheusRule[]
+}
+
+export function getPrometheusRuleGroups(resource: any): PrometheusRuleGroup[] {
   return (resource.spec?.groups || []).map((g: any) => {
-    const rules = g.rules || []
-    const alertCount = rules.filter((r: any) => r.alert).length
-    const recordCount = rules.filter((r: any) => r.record).length
+    const rawRules = g.rules || []
+    const alertCount = rawRules.filter((r: any) => r.alert).length
+    const recordCount = rawRules.filter((r: any) => r.record).length
+    const rules: PrometheusRule[] = rawRules.map((r: any) => {
+      if (r.alert) {
+        return {
+          type: 'alert' as const,
+          alert: r.alert,
+          expr: r.expr || '',
+          for: r.for,
+          severity: r.labels?.severity,
+          summary: r.annotations?.summary,
+          description: r.annotations?.description,
+          labels: r.labels,
+        }
+      }
+      return {
+        type: 'recording' as const,
+        record: r.record,
+        expr: r.expr || '',
+        labels: r.labels,
+      }
+    })
     return {
       name: g.name,
       interval: g.interval,
-      ruleCount: rules.length,
+      ruleCount: rawRules.length,
       alertCount,
       recordCount,
+      rules,
     }
   })
 }

--- a/packages/k8s-ui/src/components/resources/resource-utils-prometheus.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-prometheus.ts
@@ -148,7 +148,7 @@ export function getPrometheusRuleGroups(resource: any): PrometheusRuleGroup[] {
       }
       return {
         type: 'recording' as const,
-        record: r.record,
+        record: r.record || '',
         expr: r.expr || '',
         labels: r.labels,
       }

--- a/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
@@ -366,8 +366,8 @@ export function ResourceRendererDispatch({
         {kind === 'gitrepositories' && <GitRepositoryRenderer data={data} />}
         {kind === 'ocirepositories' && <OCIRepositoryRenderer data={data} />}
         {kind === 'helmrepositories' && <HelmRepositoryRenderer data={data} />}
-        {kind === 'kustomizations' && <KustomizationRenderer data={data} />}
-        {kind === 'helmreleases' && <FluxHelmReleaseRenderer data={data} />}
+        {kind === 'kustomizations' && <KustomizationRenderer data={data} onNavigate={onNavigate} />}
+        {kind === 'helmreleases' && <FluxHelmReleaseRenderer data={data} onNavigate={onNavigate} />}
         {kind === 'alerts' && <AlertRenderer data={data} />}
         {kind === 'applications' && <ArgoApplicationRenderer data={data} />}
         {kind === 'nodepools' && <KarpenterNodePoolRenderer data={data} onNavigate={onNavigate} />}

--- a/scripts/visual-test-start.sh
+++ b/scripts/visual-test-start.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Start a Radar instance for visual testing.
+# Usage: ./scripts/visual-test-start.sh [--skip-build]
+#
+# Outputs a state file at .playwright-mcp/visual-test-state.env that
+# the stop script and the /visual-test command can source.
+
+set -euo pipefail
+
+SKIP_BUILD=false
+if [[ "${1:-}" == "--skip-build" ]]; then
+  SKIP_BUILD=true
+fi
+
+PORT=$((9300 + RANDOM % 100))
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+SSDIR=".playwright-mcp/visual-test/$TIMESTAMP"
+LOGFILE="/tmp/radar-visual-test-$PORT.log"
+STATEFILE=".playwright-mcp/visual-test-state.env"
+
+mkdir -p "$SSDIR"
+
+# Build unless skipped
+if [[ "$SKIP_BUILD" == false ]]; then
+  echo "Building Radar..."
+  make build
+fi
+
+# Check binary exists
+if [[ ! -f ./radar ]]; then
+  echo "ERROR: ./radar binary not found. Run 'make build' first." >&2
+  exit 1
+fi
+
+# Launch
+echo "Starting Radar on port $PORT..."
+./radar -port "$PORT" -no-browser > "$LOGFILE" 2>&1 &
+PID=$!
+
+# Wait for ready
+echo -n "Waiting for Radar to be ready"
+for i in $(seq 1 30); do
+  if curl -s "http://localhost:$PORT/api/dashboard" > /dev/null 2>&1; then
+    echo " ready!"
+    break
+  fi
+  echo -n "."
+  sleep 1
+  if [[ $i -eq 30 ]]; then
+    echo " TIMEOUT"
+    echo "Radar failed to start. Check logs: $LOGFILE" >&2
+    kill "$PID" 2>/dev/null || true
+    exit 1
+  fi
+done
+
+# Write state file
+cat > "$STATEFILE" <<EOF
+RADAR_PID=$PID
+RADAR_PORT=$PORT
+SCREENSHOT_DIR=$SSDIR
+RADAR_LOG=$LOGFILE
+RADAR_URL=http://localhost:$PORT
+EOF
+
+echo ""
+echo "=== Visual Test Ready ==="
+echo "  URL:          http://localhost:$PORT"
+echo "  PID:          $PID"
+echo "  Screenshots:  $SSDIR"
+echo "  Logs:         $LOGFILE"
+echo "  State:        $STATEFILE"

--- a/scripts/visual-test-stop.sh
+++ b/scripts/visual-test-stop.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Stop a running visual test Radar instance and open the screenshot folder.
+# Reads state from .playwright-mcp/visual-test-state.env
+
+set -euo pipefail
+
+STATEFILE=".playwright-mcp/visual-test-state.env"
+
+if [[ ! -f "$STATEFILE" ]]; then
+  echo "No visual test running (state file not found: $STATEFILE)" >&2
+  exit 1
+fi
+
+source "$STATEFILE"
+
+# Kill Radar
+if kill "$RADAR_PID" 2>/dev/null; then
+  echo "Radar (PID $RADAR_PID) stopped."
+else
+  echo "Radar (PID $RADAR_PID) was already stopped."
+fi
+
+# Open screenshot folder
+if [[ -d "$SCREENSHOT_DIR" ]]; then
+  echo "Screenshots: $SCREENSHOT_DIR"
+  open "$SCREENSHOT_DIR" 2>/dev/null || true
+fi
+
+echo "Logs: $RADAR_LOG"
+
+# Clean up state file
+rm -f "$STATEFILE"


### PR DESCRIPTION
## Summary

Addresses the highest-priority (P0) gaps identified in the comprehensive CRD renderer gap analysis, plus visual testing tooling.

**Karpenter** — NodePool now shows `status.resources` (CPU/memory used vs configured limits — the #1 "why isn't Karpenter scaling?" field), template taints, and startup taints. EC2NodeClass shows resolved AMIs, subnets, and security groups from status (spec shows intent, status shows reality — top launch failure debug field). NodeClaim shows capacity type (spot/on-demand) as a colored badge, zone, architecture, and makes node name a clickable link. Capacity type and zone added as table columns. Fixed pre-existing NodePool status badge overflow in table view.

**PrometheusRule** — Previously showed only group-level summaries with zero individual rule details. Now expands each group to show alert rules (name, severity badge, `for` duration, expression in monospace, annotations) and recording rules (record name, expression). Includes search bar for filtering across all groups by name/expression/severity. Groups with >10 rules default collapsed.

**Velero Backup/Restore** — `status.failureReason` now shown in the error alert banner (previously only showed an error count with no actual error text). Error and warning counts always visible in the status section.

**FluxCD HelmRelease** — Added `spec.values` (inline overrides, collapsed) and `spec.valuesFrom` (ConfigMap/Secret references as navigable links) — the #1 thing users check when debugging a HelmRelease. Added `spec.dependsOn` as navigable dependency list. Added revision mismatch detection (applied vs attempted) as a problem alert.

**FluxCD Kustomization** — Added `spec.dependsOn` and revision mismatch alert (same pattern as HelmRelease).

**Visual test tooling** — Added helper scripts (`scripts/visual-test-start.sh`, `visual-test-stop.sh`) and updated `/visual-test` command. Scripts handle build, port selection, launch, health check, and cleanup in one invocation, reducing permission prompts from ~15 to 1.