### PR TITLE
Fix P0 renderer gaps: Argo, CNPG, cert-manager, KEDA

### DIFF
--- a/packages/k8s-ui/src/components/resources/renderers/ArgoApplicationRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ArgoApplicationRenderer.tsx
@@ -58,6 +58,10 @@ function SourceProperties({ source }: { source: any }) {
   )
 }
 
+function isSyncResourceFailed(res: any): boolean {
+  return res.status === 'SyncFailed' || res.hookPhase === 'Failed' || res.hookPhase === 'Error'
+}
+
 function getSyncResourceBadgeClass(status: string, hookPhase?: string): string {
   if (status === 'SyncFailed' || hookPhase === 'Failed' || hookPhase === 'Error') {
     return 'status-unhealthy'
@@ -111,12 +115,8 @@ export function ArgoApplicationRenderer({ data, onTerminate, isTerminating }: Ar
 
   // Extract sync result resources for per-resource failure details
   const syncResultResources: any[] = operationState?.syncResult?.resources || []
-  const failedSyncResources = syncResultResources.filter(
-    (r: any) => r.status === 'SyncFailed' || r.hookPhase === 'Failed' || r.hookPhase === 'Error'
-  )
-  const otherSyncResources = syncResultResources.filter(
-    (r: any) => r.status !== 'SyncFailed' && r.hookPhase !== 'Failed' && r.hookPhase !== 'Error'
-  )
+  const failedSyncResources = syncResultResources.filter(isSyncResourceFailed)
+  const otherSyncResources = syncResultResources.filter((r: any) => !isSyncResourceFailed(r))
   const sortedSyncResources = [...failedSyncResources, ...otherSyncResources]
 
   return (
@@ -283,7 +283,7 @@ export function ArgoApplicationRenderer({ data, onTerminate, isTerminating }: Ar
         >
           <div className="space-y-1.5">
             {sortedSyncResources.map((res: any, idx: number) => {
-              const isFailed = res.status === 'SyncFailed' || res.hookPhase === 'Failed' || res.hookPhase === 'Error'
+              const isFailed = isSyncResourceFailed(res)
               return (
                 <div
                   key={`${res.kind}-${res.namespace}-${res.name}-${idx}`}

--- a/packages/k8s-ui/src/components/resources/renderers/ArgoApplicationRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ArgoApplicationRenderer.tsx
@@ -42,9 +42,9 @@ function SourceProperties({ source }: { source: any }) {
           label="Helm Parameters"
           value={
             <div className="flex flex-wrap gap-1">
-              {source.helm.parameters.map((p: { name: string; value: string }, i: number) => (
+              {source.helm.parameters.filter(Boolean).map((p: { name: string; value: string }, i: number) => (
                 <span key={i} className="badge-sm bg-theme-elevated text-theme-text-secondary font-mono">
-                  {p.name}={p.value}
+                  {p.name ?? '?'}={p.value ?? ''}
                 </span>
               ))}
             </div>
@@ -100,7 +100,7 @@ export function ArgoApplicationRenderer({ data, onTerminate, isTerminating }: Ar
   }
 
   // Extract source info — support both spec.source (single) and spec.sources (multi, ArgoCD 2.6+)
-  const sources: any[] = spec.sources || (spec.source ? [spec.source] : [])
+  const sources: any[] = (spec.sources && spec.sources.length > 0) ? spec.sources : (spec.source ? [spec.source] : [])
   const isMultiSource = Array.isArray(spec.sources) && spec.sources.length > 0
   const destination = spec.destination || {}
   const syncPolicy = spec.syncPolicy || {}

--- a/packages/k8s-ui/src/components/resources/renderers/ArgoApplicationRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ArgoApplicationRenderer.tsx
@@ -1,4 +1,4 @@
-import { GitBranch, FolderTree, Settings, Target, XCircle, History } from 'lucide-react'
+import { GitBranch, FolderTree, Settings, Target, XCircle, History, ListChecks } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, ProblemAlerts } from '../../ui/drawer-components'
 import { formatAge } from '../resource-utils'
@@ -14,6 +14,58 @@ interface ArgoApplicationRendererProps {
   data: any
   onTerminate?: (params: { namespace: string; name: string }) => void
   isTerminating?: boolean
+}
+
+function SourceProperties({ source }: { source: any }) {
+  if (!source) return null
+  return (
+    <>
+      <Property label="Repository" value={source.repoURL} />
+      {source.path && <Property label="Path" value={source.path} />}
+      {source.targetRevision && (
+        <Property
+          label="Target Revision"
+          value={
+            <span className="flex items-center gap-1">
+              <GitBranch className="w-3.5 h-3.5" />
+              {source.targetRevision}
+            </span>
+          }
+        />
+      )}
+      {source.chart && <Property label="Helm Chart" value={source.chart} />}
+      {source.helm?.valueFiles && source.helm.valueFiles.length > 0 && (
+        <Property label="Value Files" value={source.helm.valueFiles.join(', ')} />
+      )}
+      {source.helm?.parameters && source.helm.parameters.length > 0 && (
+        <Property
+          label="Helm Parameters"
+          value={
+            <div className="flex flex-wrap gap-1">
+              {source.helm.parameters.map((p: { name: string; value: string }, i: number) => (
+                <span key={i} className="badge-sm bg-theme-elevated text-theme-text-secondary font-mono">
+                  {p.name}={p.value}
+                </span>
+              ))}
+            </div>
+          }
+        />
+      )}
+      {source.kustomize?.namePrefix && (
+        <Property label="Kustomize Prefix" value={source.kustomize.namePrefix} />
+      )}
+    </>
+  )
+}
+
+function getSyncResourceBadgeClass(status: string, hookPhase?: string): string {
+  if (status === 'SyncFailed' || hookPhase === 'Failed' || hookPhase === 'Error') {
+    return 'status-unhealthy'
+  }
+  if (status === 'Synced') return 'status-healthy'
+  if (status === 'Pruned') return 'status-neutral'
+  if (status === 'PruneSkipped') return 'status-degraded'
+  return 'status-unknown'
 }
 
 export function ArgoApplicationRenderer({ data, onTerminate, isTerminating }: ArgoApplicationRendererProps) {
@@ -47,14 +99,25 @@ export function ArgoApplicationRenderer({ data, onTerminate, isTerminating }: Ar
     problems.push({ color: 'yellow', message: 'Application is out of sync with git' })
   }
 
-  // Extract source info
-  const source = spec.source || {}
+  // Extract source info — support both spec.source (single) and spec.sources (multi, ArgoCD 2.6+)
+  const sources: any[] = spec.sources || (spec.source ? [spec.source] : [])
+  const isMultiSource = Array.isArray(spec.sources) && spec.sources.length > 0
   const destination = spec.destination || {}
   const syncPolicy = spec.syncPolicy || {}
   const operationState = status.operationState
 
   // Check if sync is in progress
   const isSyncing = operationState?.phase === 'Running'
+
+  // Extract sync result resources for per-resource failure details
+  const syncResultResources: any[] = operationState?.syncResult?.resources || []
+  const failedSyncResources = syncResultResources.filter(
+    (r: any) => r.status === 'SyncFailed' || r.hookPhase === 'Failed' || r.hookPhase === 'Error'
+  )
+  const otherSyncResources = syncResultResources.filter(
+    (r: any) => r.status !== 'SyncFailed' && r.hookPhase !== 'Failed' && r.hookPhase !== 'Error'
+  )
+  const sortedSyncResources = [...failedSyncResources, ...otherSyncResources]
 
   return (
     <>
@@ -90,57 +153,27 @@ export function ArgoApplicationRenderer({ data, onTerminate, isTerminating }: Ar
         </div>
       </Section>
 
-      {/* Source section */}
-      <Section title="Source" icon={FolderTree}>
-        <PropertyList>
-          <Property label="Repository" value={source.repoURL} />
-          {source.path && <Property label="Path" value={source.path} />}
-          {source.targetRevision && (
-            <Property
-              label="Target Revision"
-              value={
-                <span className="flex items-center gap-1">
-                  <GitBranch className="w-3.5 h-3.5" />
-                  {source.targetRevision}
-                </span>
-              }
-            />
-          )}
-          {source.chart && <Property label="Helm Chart" value={source.chart} />}
-          {source.helm?.valueFiles && source.helm.valueFiles.length > 0 && (
-            <Property label="Value Files" value={source.helm.valueFiles.join(', ')} />
-          )}
-          {source.helm?.parameters && source.helm.parameters.length > 0 && (
-            <Property
-              label="Helm Parameters"
-              value={
-                <div className="flex flex-wrap gap-1">
-                  {source.helm.parameters.map((p: { name: string; value: string }, i: number) => (
-                    <span key={i} className="badge-sm bg-theme-elevated text-theme-text-secondary font-mono">
-                      {p.name}={p.value}
-                    </span>
-                  ))}
-                </div>
-              }
-            />
-          )}
-          {source.kustomize?.namePrefix && (
-            <Property label="Kustomize Prefix" value={source.kustomize.namePrefix} />
-          )}
-        </PropertyList>
-        {source.helm?.values && (
-          <div className="mt-3">
-            <div className="text-xs font-medium text-theme-text-secondary uppercase tracking-wider mb-1.5">
-              Inline Values
-            </div>
-            <Section title={`${source.helm.values.split('\n').length} lines`} defaultExpanded={false}>
-              <pre className="text-xs text-theme-text-secondary font-mono bg-theme-elevated rounded-md p-2 overflow-x-auto max-h-48 whitespace-pre-wrap">
-                {source.helm.values}
-              </pre>
-            </Section>
+      {/* Source section — renders each source for multi-source apps */}
+      {isMultiSource ? (
+        <Section title={`Sources (${sources.length})`} icon={FolderTree}>
+          <div className="space-y-3">
+            {sources.map((src: any, idx: number) => (
+              <div key={idx} className="card-inner">
+                <div className="text-xs font-medium text-theme-text-tertiary mb-1.5">Source {idx + 1}</div>
+                <PropertyList>
+                  <SourceProperties source={src} />
+                </PropertyList>
+              </div>
+            ))}
           </div>
-        )}
-      </Section>
+        </Section>
+      ) : sources.length > 0 ? (
+        <Section title="Source" icon={FolderTree}>
+          <PropertyList>
+            <SourceProperties source={sources[0]} />
+          </PropertyList>
+        </Section>
+      ) : null}
 
       {/* Destination section */}
       <Section title="Destination" icon={Target}>
@@ -238,6 +271,55 @@ export function ArgoApplicationRenderer({ data, onTerminate, isTerminating }: Ar
               <Property label="Revision" value={operationState.syncResult.revision} />
             )}
           </PropertyList>
+        </Section>
+      )}
+
+      {/* Sync Result Resources — per-resource sync status with failure details */}
+      {sortedSyncResources.length > 0 && (
+        <Section
+          title={`Sync Result Resources (${sortedSyncResources.length})`}
+          icon={ListChecks}
+          defaultExpanded={failedSyncResources.length > 0}
+        >
+          <div className="space-y-1.5">
+            {sortedSyncResources.map((res: any, idx: number) => {
+              const isFailed = res.status === 'SyncFailed' || res.hookPhase === 'Failed' || res.hookPhase === 'Error'
+              return (
+                <div
+                  key={`${res.kind}-${res.namespace}-${res.name}-${idx}`}
+                  className={clsx(
+                    'card-inner px-3 py-2',
+                    isFailed && 'border-l-2 border-red-500'
+                  )}
+                >
+                  <div className="flex items-center gap-2 text-sm">
+                    <span className={clsx('badge badge-sm', getSyncResourceBadgeClass(res.status, res.hookPhase))}>
+                      {res.status || res.hookPhase || 'Unknown'}
+                    </span>
+                    <span className="text-theme-text-primary">
+                      {res.kind}/{res.name}
+                    </span>
+                    {res.namespace && (
+                      <span className="text-theme-text-tertiary text-xs">({res.namespace})</span>
+                    )}
+                  </div>
+                  {res.message && (
+                    <div className={clsx(
+                      'text-xs mt-1 break-all',
+                      isFailed ? 'text-red-400' : 'text-theme-text-secondary'
+                    )}>
+                      {res.message}
+                    </div>
+                  )}
+                  {res.hookPhase && res.hookPhase !== res.status && (
+                    <div className="text-xs text-theme-text-tertiary mt-0.5">
+                      Hook: {res.hookPhase}
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
         </Section>
       )}
 

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGBackupRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGBackupRenderer.tsx
@@ -25,6 +25,13 @@ export function CNPGBackupRenderer({ data, onNavigate }: CNPGBackupRendererProps
   const target = getCNPGBackupTarget(data)
   const clusterName = getCNPGBackupCluster(data)
 
+  // WAL range fields
+  const beginWal = data.status?.beginWal
+  const endWal = data.status?.endWal
+  const beginLSN = data.status?.beginLSN
+  const endLSN = data.status?.endLSN
+  const hasWalRange = beginWal || endWal || beginLSN || endLSN
+
   return (
     <>
       {/* Problem alerts */}
@@ -78,6 +85,18 @@ export function CNPGBackupRenderer({ data, onNavigate }: CNPGBackupRendererProps
           <Property label="Server Name" value={getCNPGBackupServerName(data)} />
         </PropertyList>
       </Section>
+
+      {/* WAL Range */}
+      {hasWalRange && (
+        <Section title="WAL Range" defaultExpanded>
+          <PropertyList>
+            {beginWal && <Property label="Begin WAL" value={beginWal} />}
+            {endWal && <Property label="End WAL" value={endWal} />}
+            {beginLSN && <Property label="Begin LSN" value={beginLSN} />}
+            {endLSN && <Property label="End LSN" value={endLSN} />}
+          </PropertyList>
+        </Section>
+      )}
 
       {/* Target - for PITR backups */}
       {target !== '-' && (

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
@@ -1,8 +1,7 @@
-import { Database, HardDrive, Activity, Clock, Shield } from 'lucide-react'
+import { Database, HardDrive, Activity, Clock, Shield, KeyRound } from 'lucide-react'
 import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
 import {
   getCNPGClusterInstances,
-  getCNPGClusterPrimary,
   getCNPGClusterPhase,
   getCNPGClusterImage,
   getCNPGClusterStorage,
@@ -16,6 +15,8 @@ import {
   getCNPGClusterReplicaSource,
   getCNPGClusterInstanceNames,
   getCNPGClusterPostgresParams,
+  getCNPGClusterInstancesReportedState,
+  getCNPGClusterCertificateExpirations,
 } from '../resource-utils-cnpg'
 
 interface CNPGClusterRendererProps {
@@ -35,6 +36,24 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
   const postgresParams = getCNPGClusterPostgresParams(data)
   const instanceNames = getCNPGClusterInstanceNames(data)
   const bootstrapMethod = getCNPGClusterBootstrapMethod(data)
+  const reportedState = getCNPGClusterInstancesReportedState(data)
+  const certExpirations = getCNPGClusterCertificateExpirations(data)
+
+  // Primary mismatch detection
+  const targetPrimary = data.status?.targetPrimary
+  const currentPrimary = data.status?.currentPrimary
+  const primaryMismatch = targetPrimary && currentPrimary && targetPrimary !== currentPrimary
+
+  // Split-brain detection: multiple instances report isPrimary
+  const primariesReported = reportedState.filter(i => i.isPrimary)
+  const hasSplitBrain = primariesReported.length > 1
+
+  // Certificate expiry warnings
+  const criticalCerts = certExpirations.filter(c => c.daysUntilExpiry <= 7)
+  const warningCerts = certExpirations.filter(c => c.daysUntilExpiry > 7 && c.daysUntilExpiry <= 30)
+
+  // Last failed backup
+  const lastFailedBackup = data.status?.lastFailedBackup
 
   // Problem detection
   const isDown = instances > 0 && readyInstances === 0
@@ -45,6 +64,13 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
   return (
     <>
       {/* Problem alerts */}
+      {hasSplitBrain && (
+        <AlertBanner
+          variant="error"
+          title="Potential Split-Brain Detected"
+          message={`Multiple instances report as primary: ${primariesReported.map(i => i.podName).join(', ')}. Immediate investigation required.`}
+        />
+      )}
       {isDown && (
         <AlertBanner
           variant="error"
@@ -73,13 +99,44 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
           message={`Cluster is performing a switchover. Current phase: ${phase}`}
         />
       )}
+      {primaryMismatch && (
+        <AlertBanner
+          variant="warning"
+          title="Switchover Pending"
+          message={`Target primary is ${targetPrimary} but current primary is ${currentPrimary}.`}
+        />
+      )}
+      {lastFailedBackup && (
+        <AlertBanner
+          variant="error"
+          title="Last Backup Failed"
+          message={`Last backup failed at ${lastFailedBackup}. WAL archiving may be impacted and RPO is growing.`}
+        />
+      )}
+      {criticalCerts.length > 0 && (
+        <AlertBanner
+          variant="error"
+          title="Certificate Expiring Soon"
+          items={criticalCerts.map(c => `${c.secretName} expires in ${c.daysUntilExpiry} day${c.daysUntilExpiry === 1 ? '' : 's'} (${c.expiryDate})`)}
+        />
+      )}
+      {warningCerts.length > 0 && (
+        <AlertBanner
+          variant="warning"
+          title="Certificate Expiry Warning"
+          items={warningCerts.map(c => `${c.secretName} expires in ${c.daysUntilExpiry} days (${c.expiryDate})`)}
+        />
+      )}
 
       {/* Cluster Overview */}
       <Section title="Cluster Overview" icon={Database} defaultExpanded>
         <PropertyList>
           <Property label="Phase" value={phase} />
           <Property label="Instances" value={getCNPGClusterInstances(data)} />
-          <Property label="Current Primary" value={getCNPGClusterPrimary(data)} />
+          <Property label="Current Primary" value={currentPrimary || '-'} />
+          {targetPrimary && targetPrimary !== currentPrimary && (
+            <Property label="Target Primary" value={targetPrimary} />
+          )}
           <Property label="Image" value={getCNPGClusterImage(data)} />
           <Property label="Update Strategy" value={getCNPGClusterUpdateStrategy(data)} />
           {data.status?.writeService && (
@@ -123,6 +180,29 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
         )}
       </Section>
 
+      {/* Replication State */}
+      {reportedState.length > 0 && (
+        <Section title="Replication" icon={Activity} defaultExpanded>
+          <div className="space-y-1.5">
+            {reportedState.map((instance) => (
+              <div key={instance.podName} className="flex items-center gap-2 text-sm">
+                <span className="text-theme-text-primary font-mono flex-1 break-all">{instance.podName}</span>
+                <span className={
+                  instance.isPrimary
+                    ? 'badge-sm bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300'
+                    : 'badge-sm bg-theme-elevated text-theme-text-secondary'
+                }>
+                  {instance.isPrimary ? 'Primary' : 'Replica'}
+                </span>
+                {instance.timelineID != null && (
+                  <span className="text-xs text-theme-text-tertiary">TL {instance.timelineID}</span>
+                )}
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+
       {/* Storage */}
       <Section title="Storage" icon={HardDrive} defaultExpanded>
         <PropertyList>
@@ -162,10 +242,42 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
             {backupConfig.lastSuccessfulBackup && (
               <Property label="Last Successful" value={backupConfig.lastSuccessfulBackup} />
             )}
+            {lastFailedBackup && (
+              <Property label="Last Failed" value={lastFailedBackup} />
+            )}
             {backupConfig.firstRecoverabilityPoint && (
               <Property label="First Recoverability" value={backupConfig.firstRecoverabilityPoint} />
             )}
           </PropertyList>
+        </Section>
+      )}
+
+      {/* Certificates */}
+      {certExpirations.length > 0 && (
+        <Section title="Certificates" icon={KeyRound} defaultExpanded>
+          <div className="space-y-1.5">
+            {certExpirations.map((cert) => (
+              <div key={cert.secretName} className="flex items-center gap-2 text-sm">
+                <span className="text-theme-text-primary font-mono flex-1 break-all">{cert.secretName}</span>
+                <span className="text-xs text-theme-text-tertiary">{cert.expiryDate}</span>
+                {cert.daysUntilExpiry <= 7 && (
+                  <span className="badge-sm bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300">
+                    {cert.daysUntilExpiry}d
+                  </span>
+                )}
+                {cert.daysUntilExpiry > 7 && cert.daysUntilExpiry <= 30 && (
+                  <span className="badge-sm bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+                    {cert.daysUntilExpiry}d
+                  </span>
+                )}
+                {cert.daysUntilExpiry > 30 && (
+                  <span className="badge-sm bg-theme-elevated text-theme-text-secondary">
+                    {cert.daysUntilExpiry}d
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
         </Section>
       )}
 
@@ -196,7 +308,7 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
 
       {/* Replication - only if this is a replica cluster */}
       {isReplica && (
-        <Section title="Replication" icon={Shield} defaultExpanded>
+        <Section title="Replica Cluster" icon={Shield} defaultExpanded>
           <PropertyList>
             <Property label="Role" value="Replica" />
             <Property label="Source" value={getCNPGClusterReplicaSource(data)} />

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
@@ -49,7 +49,8 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
   const hasSplitBrain = primariesReported.length > 1
 
   // Certificate expiry warnings
-  const criticalCerts = certExpirations.filter(c => c.daysUntilExpiry <= 7)
+  const expiredCerts = certExpirations.filter(c => c.daysUntilExpiry < 0)
+  const criticalCerts = certExpirations.filter(c => c.daysUntilExpiry >= 0 && c.daysUntilExpiry <= 7)
   const warningCerts = certExpirations.filter(c => c.daysUntilExpiry > 7 && c.daysUntilExpiry <= 30)
 
   // Last failed backup
@@ -111,6 +112,13 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
           variant="error"
           title="Last Backup Failed"
           message={`Last backup failed at ${lastFailedBackup}. WAL archiving may be impacted and RPO is growing.`}
+        />
+      )}
+      {expiredCerts.length > 0 && (
+        <AlertBanner
+          variant="error"
+          title="Certificate Expired"
+          items={expiredCerts.map(c => `${c.secretName} expired ${Math.abs(c.daysUntilExpiry)} day${Math.abs(c.daysUntilExpiry) === 1 ? '' : 's'} ago (${c.expiryDate})`)}
         />
       )}
       {criticalCerts.length > 0 && (

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGPoolerRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGPoolerRenderer.tsx
@@ -1,4 +1,4 @@
-import { Users, Database } from 'lucide-react'
+import { Users, Database, KeyRound } from 'lucide-react'
 import { Section, PropertyList, Property, AlertBanner, ResourceLink } from '../../ui/drawer-components'
 import {
   getCNPGPoolerCluster,
@@ -6,6 +6,8 @@ import {
   getCNPGPoolerMode,
   getCNPGPoolerInstances,
   getCNPGPoolerParameters,
+  getCNPGPoolerAuthQuery,
+  getCNPGPoolerAuthQuerySecret,
 } from '../resource-utils-cnpg'
 
 interface CNPGPoolerRendererProps {
@@ -19,6 +21,8 @@ export function CNPGPoolerRenderer({ data, onNavigate }: CNPGPoolerRendererProps
   const isDegraded = desired > 0 && ready < desired
   const clusterName = getCNPGPoolerCluster(data)
   const parameters = getCNPGPoolerParameters(data)
+  const authQuery = getCNPGPoolerAuthQuery(data)
+  const authQuerySecret = getCNPGPoolerAuthQuerySecret(data)
 
   return (
     <>
@@ -39,6 +43,29 @@ export function CNPGPoolerRenderer({ data, onNavigate }: CNPGPoolerRendererProps
           <Property label="Instances" value={getCNPGPoolerInstances(data)} />
         </PropertyList>
       </Section>
+
+      {/* Authentication */}
+      {(authQuery || authQuerySecret) && (
+        <Section title="Authentication" icon={KeyRound} defaultExpanded>
+          <PropertyList>
+            {authQuery && (
+              <Property label="Auth Query" value={
+                <code className="text-xs font-mono bg-theme-elevated px-1.5 py-0.5 rounded break-all">{authQuery}</code>
+              } />
+            )}
+            {authQuerySecret && (
+              <Property label="Auth Query Secret" value={
+                <ResourceLink
+                  name={authQuerySecret.name}
+                  kind="secrets"
+                  namespace={data.metadata?.namespace || ''}
+                  onNavigate={onNavigate}
+                />
+              } />
+            )}
+          </PropertyList>
+        </Section>
+      )}
 
       {/* Cluster Reference */}
       <Section title="Cluster" icon={Database} defaultExpanded>

--- a/packages/k8s-ui/src/components/resources/renderers/ChallengeRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ChallengeRenderer.tsx
@@ -68,7 +68,7 @@ export function ChallengeRenderer({ data }: { data: any }) {
               </span>
             }
           />
-          {status.reason && <Property label="Reason" value={status.reason} />}
+          {status.reason && !isError && <Property label="Reason" value={status.reason} />}
           <Property
             label="Type"
             value={

--- a/packages/k8s-ui/src/components/resources/renderers/ChallengeRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ChallengeRenderer.tsx
@@ -68,6 +68,7 @@ export function ChallengeRenderer({ data }: { data: any }) {
               </span>
             }
           />
+          {status.reason && <Property label="Reason" value={status.reason} />}
           <Property
             label="Type"
             value={

--- a/packages/k8s-ui/src/components/resources/renderers/KedaScaledJobRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KedaScaledJobRenderer.tsx
@@ -46,6 +46,9 @@ export function KedaScaledJobRenderer({ data }: KedaScaledJobRendererProps) {
           {spec.failedJobsHistoryLimit !== undefined && (
             <Property label="Failure History" value={String(spec.failedJobsHistoryLimit)} />
           )}
+          {spec.minReplicaCount !== undefined && (
+            <Property label="Min Replicas" value={String(spec.minReplicaCount)} />
+          )}
           {spec.maxReplicaCount !== undefined && (
             <Property label="Max Replicas" value={String(spec.maxReplicaCount)} />
           )}

--- a/packages/k8s-ui/src/components/resources/renderers/RolloutRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/RolloutRenderer.tsx
@@ -1,6 +1,7 @@
 import { Server, GitBranch, AlertTriangle, Network } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, PodTemplateSection } from '../../ui/drawer-components'
+import { formatAge } from '../resource-utils'
 
 interface RolloutRendererProps {
   data: any
@@ -35,6 +36,11 @@ export function RolloutRenderer({ data }: RolloutRendererProps) {
   // Problem detection
   const problems: Array<{ color: 'red' | 'yellow'; message: string }> = []
 
+  // Aborted rollout detection — must come before generic paused check
+  if (status.abort === true) {
+    problems.push({ color: 'red', message: status.message || 'Rollout was aborted' })
+  }
+
   if (phase === 'Degraded') {
     problems.push({ color: 'red', message: status.message || 'Rollout is degraded' })
   }
@@ -53,8 +59,19 @@ export function RolloutRenderer({ data }: RolloutRendererProps) {
     problems.push({ color: 'red', message: invalidSpecCond.message || 'Invalid rollout spec' })
   }
 
-  if (phase === 'Paused') {
-    problems.push({ color: 'yellow', message: 'Rollout is paused' })
+  // Pause conditions — show specific reasons instead of generic "Rollout is paused"
+  const pauseConditions: Array<{ reason: string; startTime?: string }> = status.pauseConditions || []
+  if (phase === 'Paused' && !status.abort) {
+    if (pauseConditions.length > 0) {
+      const reasons = pauseConditions.map((pc: any) => {
+        const reason = pc.reason || 'Unknown'
+        const since = pc.startTime ? ` (since ${formatAge(pc.startTime)})` : ''
+        return `${reason}${since}`
+      })
+      problems.push({ color: 'yellow', message: `Rollout is paused: ${reasons.join('; ')}` })
+    } else {
+      problems.push({ color: 'yellow', message: 'Rollout is paused' })
+    }
   }
 
   // Phase badge color

--- a/packages/k8s-ui/src/components/resources/renderers/WorkflowRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/WorkflowRenderer.tsx
@@ -1,4 +1,4 @@
-import { Play, Clock, CheckCircle, XCircle, Loader2 } from 'lucide-react'
+import { Play, Clock, CheckCircle, XCircle, Loader2, SkipForward, PauseCircle } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
 import { formatAge, formatDuration } from '../resource-utils'
@@ -13,6 +13,8 @@ interface WorkflowStep {
   phase: string
   startedAt: string | null
   finishedAt: string | null
+  message: string | null
+  nodeType: string
 }
 
 function getStepDuration(step: WorkflowStep): string | null {
@@ -22,7 +24,13 @@ function getStepDuration(step: WorkflowStep): string | null {
   return formatDuration(end.getTime() - start.getTime(), true)
 }
 
-function StepStatusIcon({ phase }: { phase: string }) {
+function StepStatusIcon({ phase, nodeType }: { phase: string; nodeType?: string }) {
+  if (nodeType === 'Skipped' || phase === 'Skipped') {
+    return <SkipForward className="w-4 h-4 text-theme-text-tertiary shrink-0" />
+  }
+  if (nodeType === 'Suspend') {
+    return <PauseCircle className="w-4 h-4 text-yellow-400 shrink-0" />
+  }
   switch (phase) {
     case 'Succeeded':
       return <CheckCircle className="w-4 h-4 text-green-400 shrink-0" />
@@ -46,6 +54,9 @@ function getPhaseBadgeClass(phase: string): string {
       return 'status-unhealthy'
     case 'Pending':
       return 'status-degraded'
+    case 'Skipped':
+    case 'Omitted':
+      return 'status-unknown'
     default:
       return 'status-unknown'
   }
@@ -74,29 +85,40 @@ function getWorkflowProblems(data: any): string[] {
     problems.push(status.message || 'Workflow error')
   }
 
-  // Check for failed nodes
+  // Check for failed nodes — include error messages when available
   const nodes = status.nodes || {}
-  const failedSteps = Object.values(nodes)
+  const failedNodes = Object.values(nodes)
     .filter((node: any) => node.type === 'Pod' && node.phase === 'Failed')
-    .map((node: any) => node.displayName)
 
-  if (failedSteps.length > 0) {
-    problems.push(`Failed steps: ${failedSteps.join(', ')}`)
+  if (failedNodes.length > 0) {
+    const withMessages = failedNodes.filter((node: any) => node.message)
+    if (withMessages.length > 0) {
+      for (const node of withMessages) {
+        const n = node as any
+        problems.push(`${n.displayName}: ${n.message}`)
+      }
+    } else {
+      problems.push(`Failed steps: ${failedNodes.map((n: any) => n.displayName).join(', ')}`)
+    }
   }
 
   return problems
 }
 
+const VISIBLE_NODE_TYPES = new Set(['Pod', 'Skipped', 'Suspend'])
+
 function extractSteps(data: any): WorkflowStep[] {
   const nodes = data.status?.nodes || {}
   const steps: WorkflowStep[] = Object.entries(nodes)
-    .filter(([, node]: [string, any]) => node.type === 'Pod')
+    .filter(([, node]: [string, any]) => VISIBLE_NODE_TYPES.has(node.type))
     .map(([id, node]: [string, any]) => ({
       id,
       displayName: node.displayName || id,
-      phase: node.phase || 'Pending',
+      phase: node.phase || (node.type === 'Skipped' ? 'Skipped' : 'Pending'),
       startedAt: node.startedAt || null,
       finishedAt: node.finishedAt || null,
+      message: node.message || null,
+      nodeType: node.type,
     }))
 
   steps.sort((a, b) => {
@@ -186,13 +208,33 @@ export function WorkflowRenderer({ data }: WorkflowRendererProps) {
       {steps.length > 0 && (
         <Section title={`Steps (${steps.length})`} defaultExpanded>
           <div className="space-y-1.5">
-            {steps.map(step => (
-              <div key={step.id} className="flex items-center gap-2 text-sm card-inner px-3 py-2">
-                <StepStatusIcon phase={step.phase} />
-                <span className="flex-1 text-theme-text-primary">{step.displayName}</span>
-                <span className="text-xs text-theme-text-secondary">{getStepDuration(step) || '-'}</span>
-              </div>
-            ))}
+            {steps.map(step => {
+              const isFailed = step.phase === 'Failed' || step.phase === 'Error'
+              const isSkipped = step.nodeType === 'Skipped' || step.phase === 'Skipped'
+              const isSuspend = step.nodeType === 'Suspend'
+              return (
+                <div key={step.id} className={clsx(
+                  'text-sm card-inner px-3 py-2',
+                  isFailed && 'border-l-2 border-red-500'
+                )}>
+                  <div className="flex items-center gap-2">
+                    <StepStatusIcon phase={step.phase} nodeType={step.nodeType} />
+                    <span className={clsx(
+                      'flex-1',
+                      isSkipped ? 'text-theme-text-tertiary' : isSuspend ? 'text-yellow-400' : 'text-theme-text-primary'
+                    )}>
+                      {step.displayName}
+                      {isSkipped && <span className="ml-1 text-xs text-theme-text-tertiary">(skipped)</span>}
+                      {isSuspend && <span className="ml-1 text-xs text-yellow-400/70">(suspend)</span>}
+                    </span>
+                    <span className="text-xs text-theme-text-secondary">{getStepDuration(step) || '-'}</span>
+                  </div>
+                  {isFailed && step.message && (
+                    <div className="text-xs text-red-400 mt-1 ml-6 break-all">{step.message}</div>
+                  )}
+                </div>
+              )
+            })}
           </div>
         </Section>
       )}

--- a/packages/k8s-ui/src/components/resources/renderers/WorkflowRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/WorkflowRenderer.tsx
@@ -88,7 +88,7 @@ function getWorkflowProblems(data: any): string[] {
   // Check for failed nodes — include error messages when available
   const nodes = status.nodes || {}
   const failedNodes = Object.values(nodes)
-    .filter((node: any) => node.type === 'Pod' && node.phase === 'Failed')
+    .filter((node: any) => (node.type === 'Pod' || node.type === 'Suspend' || node.type === 'Skipped') && (node.phase === 'Failed' || node.phase === 'Error'))
 
   if (failedNodes.length > 0) {
     const withMessages = failedNodes.filter((node: any) => node.message)

--- a/packages/k8s-ui/src/components/resources/renderers/WorkflowRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/WorkflowRenderer.tsx
@@ -28,7 +28,7 @@ function StepStatusIcon({ phase, nodeType }: { phase: string; nodeType?: string 
   if (nodeType === 'Skipped' || phase === 'Skipped') {
     return <SkipForward className="w-4 h-4 text-theme-text-tertiary shrink-0" />
   }
-  if (nodeType === 'Suspend') {
+  if (nodeType === 'Suspend' && phase !== 'Succeeded') {
     return <PauseCircle className="w-4 h-4 text-yellow-400 shrink-0" />
   }
   switch (phase) {
@@ -93,8 +93,7 @@ function getWorkflowProblems(data: any): string[] {
   if (failedNodes.length > 0) {
     const withMessages = failedNodes.filter((node: any) => node.message)
     if (withMessages.length > 0) {
-      for (const node of withMessages) {
-        const n = node as any
+      for (const n of withMessages as any[]) {
         problems.push(`${n.displayName}: ${n.message}`)
       }
     } else {

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
@@ -196,7 +196,9 @@ export function getCNPGClusterCertificateExpirations(resource: any): CNPGCertifi
   const now = new Date()
   return Object.entries(expirations).map(([secretName, expiryDate]: [string, any]) => {
     const expiry = new Date(expiryDate)
-    const daysUntilExpiry = Math.floor((expiry.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
+    const daysUntilExpiry = isNaN(expiry.getTime())
+      ? -1  // treat unparseable dates as expired/critical
+      : Math.floor((expiry.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
     return { secretName, expiryDate: String(expiryDate), daysUntilExpiry }
   })
 }

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
@@ -166,6 +166,41 @@ export function getCNPGClusterPostgresParams(resource: any): Record<string, stri
   return resource.spec?.postgresql?.parameters || {}
 }
 
+/** Per-instance replication state from status.instancesReportedState */
+export interface CNPGInstanceReportedState {
+  podName: string
+  isPrimary: boolean
+  timelineID?: number
+}
+
+export function getCNPGClusterInstancesReportedState(resource: any): CNPGInstanceReportedState[] {
+  const reported = resource.status?.instancesReportedState
+  if (!reported || typeof reported !== 'object') return []
+  return Object.entries(reported).map(([podName, state]: [string, any]) => ({
+    podName,
+    isPrimary: state?.isPrimary === true,
+    timelineID: state?.timelineID,
+  }))
+}
+
+/** Certificate expirations from status.certificates.expirations */
+export interface CNPGCertificateExpiry {
+  secretName: string
+  expiryDate: string
+  daysUntilExpiry: number
+}
+
+export function getCNPGClusterCertificateExpirations(resource: any): CNPGCertificateExpiry[] {
+  const expirations = resource.status?.certificates?.expirations
+  if (!expirations || typeof expirations !== 'object') return []
+  const now = new Date()
+  return Object.entries(expirations).map(([secretName, expiryDate]: [string, any]) => {
+    const expiry = new Date(expiryDate)
+    const daysUntilExpiry = Math.floor((expiry.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
+    return { secretName, expiryDate: String(expiryDate), daysUntilExpiry }
+  })
+}
+
 // ============================================================================
 // CNPG BACKUP UTILITIES
 // ============================================================================
@@ -341,4 +376,14 @@ export function getCNPGPoolerInstances(resource: any): string {
 
 export function getCNPGPoolerParameters(resource: any): Record<string, string> {
   return resource.spec?.pgbouncer?.parameters || {}
+}
+
+export function getCNPGPoolerAuthQuery(resource: any): string | undefined {
+  return resource.spec?.pgbouncer?.authQuery
+}
+
+export function getCNPGPoolerAuthQuerySecret(resource: any): { name: string } | undefined {
+  const secret = resource.spec?.pgbouncer?.authQuerySecret
+  if (!secret?.name) return undefined
+  return { name: secret.name }
 }


### PR DESCRIPTION
## Summary

Second batch of P0 renderer gaps from the comprehensive gap analysis. 9 files, +411/-51.

**Argo CD Application** — Multi-source apps (`spec.sources`) now render all sources instead of showing an empty section. Per-resource sync failure details from `syncResult.resources[]` shown in a new section with failed resources sorted to top and highlighted.

**Argo Rollouts** — Aborted rollouts (`status.abort`) now show a dedicated red alert instead of being lumped with "paused". Pause conditions (`status.pauseConditions[]`) show specific reasons (CanaryPauseStep, BlueGreenPause, etc.) with start times instead of a generic "paused" message.

**Argo Workflows** — Failed step error messages (`node.message`) now visible (were completely filtered out). Skipped and Suspend node types are shown with appropriate visual indicators instead of being filtered to Pod-only.

**CNPG Cluster** — Per-instance replication state with Primary/Replica badges and split-brain detection. Target vs current primary mismatch alert. Certificate expiry dates with 7/30 day warnings. Last failed backup alert for RPO gap detection.

**CNPG Backup** — WAL range (beginWal/endWal/beginLSN/endLSN) for PITR planning.

**CNPG Pooler** — Auth query and auth query secret (navigable link) — the #1 cause of pooler connection failures.

**cert-manager Challenge** — `status.reason` visible for all states (was hidden behind error-only guard).

**KEDA ScaledJob** — `spec.minReplicaCount` property added.