### PR TITLE
Add P1 renderer improvements: Argo, CNPG, cert-manager, KEDA

### DIFF
--- a/packages/k8s-ui/src/components/resources/renderers/ArgoApplicationRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ArgoApplicationRenderer.tsx
@@ -1,4 +1,4 @@
-import { GitBranch, FolderTree, Settings, Target, XCircle } from 'lucide-react'
+import { GitBranch, FolderTree, Settings, Target, XCircle, History } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, ProblemAlerts } from '../../ui/drawer-components'
 import { formatAge } from '../resource-utils'
@@ -110,10 +110,36 @@ export function ArgoApplicationRenderer({ data, onTerminate, isTerminating }: Ar
           {source.helm?.valueFiles && source.helm.valueFiles.length > 0 && (
             <Property label="Value Files" value={source.helm.valueFiles.join(', ')} />
           )}
+          {source.helm?.parameters && source.helm.parameters.length > 0 && (
+            <Property
+              label="Helm Parameters"
+              value={
+                <div className="flex flex-wrap gap-1">
+                  {source.helm.parameters.map((p: { name: string; value: string }, i: number) => (
+                    <span key={i} className="badge-sm bg-theme-elevated text-theme-text-secondary font-mono">
+                      {p.name}={p.value}
+                    </span>
+                  ))}
+                </div>
+              }
+            />
+          )}
           {source.kustomize?.namePrefix && (
             <Property label="Kustomize Prefix" value={source.kustomize.namePrefix} />
           )}
         </PropertyList>
+        {source.helm?.values && (
+          <div className="mt-3">
+            <div className="text-xs font-medium text-theme-text-secondary uppercase tracking-wider mb-1.5">
+              Inline Values
+            </div>
+            <Section title={`${source.helm.values.split('\n').length} lines`} defaultExpanded={false}>
+              <pre className="text-xs text-theme-text-secondary font-mono bg-theme-elevated rounded-md p-2 overflow-x-auto max-h-48 whitespace-pre-wrap">
+                {source.helm.values}
+              </pre>
+            </Section>
+          </div>
+        )}
       </Section>
 
       {/* Destination section */}
@@ -192,8 +218,21 @@ export function ArgoApplicationRenderer({ data, onTerminate, isTerminating }: Ar
             {operationState.message && (
               <Property label="Message" value={operationState.message} />
             )}
+            {operationState.startedAt && (
+              <Property label="Started" value={formatAge(operationState.startedAt)} />
+            )}
             {operationState.finishedAt && (
               <Property label="Finished" value={formatAge(operationState.finishedAt)} />
+            )}
+            {operationState.retryCount != null && (
+              <Property
+                label="Retries"
+                value={
+                  syncPolicy.retry?.limit
+                    ? `${operationState.retryCount}/${syncPolicy.retry.limit}`
+                    : String(operationState.retryCount)
+                }
+              />
             )}
             {operationState.syncResult?.revision && (
               <Property label="Revision" value={operationState.syncResult.revision} />
@@ -208,6 +247,47 @@ export function ArgoApplicationRenderer({ data, onTerminate, isTerminating }: Ar
           resources={managedResources}
           title={`Managed Resources (${managedResources.length})`}
         />
+      )}
+
+      {/* Revision History */}
+      {status.history && status.history.length > 0 && (
+        <Section title={`Revision History (${status.history.length})`} icon={History} defaultExpanded={false}>
+          <div className="space-y-2 max-h-48 overflow-y-auto">
+            {status.history
+              .slice(0, 10)
+              .map((entry, idx) => (
+                <div
+                  key={entry.id ?? idx}
+                  className={clsx(
+                    'p-2 rounded text-sm',
+                    idx === 0
+                      ? 'bg-green-500/10 border border-green-500/30'
+                      : 'bg-theme-elevated/30'
+                  )}
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium text-theme-text-primary font-mono text-xs">
+                      {entry.revision
+                        ? entry.revision.length > 12
+                          ? entry.revision.slice(0, 12)
+                          : entry.revision
+                        : '-'}
+                    </span>
+                    {entry.deployedAt && (
+                      <span className="text-xs text-theme-text-tertiary">
+                        {formatAge(entry.deployedAt)}
+                      </span>
+                    )}
+                  </div>
+                  {entry.source?.path && (
+                    <div className="text-xs text-theme-text-secondary mt-0.5 truncate" title={entry.source.path}>
+                      {entry.source.path}
+                    </div>
+                  )}
+                </div>
+              ))}
+          </div>
+        </Section>
       )}
 
       {/* Revision Info */}

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGBackupRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGBackupRenderer.tsx
@@ -43,6 +43,9 @@ export function CNPGBackupRenderer({ data, onNavigate }: CNPGBackupRendererProps
           <Property label="Method" value={getCNPGBackupMethod(data)} />
           <Property label="Duration" value={getCNPGBackupDuration(data)} />
           <Property label="Backup Name" value={getCNPGBackupName(data)} />
+          {data.status?.instanceID?.podName && (
+            <Property label="Instance" value={data.status.instanceID.podName} />
+          )}
         </PropertyList>
         {data.status?.startedAt && (
           <div className="mt-2 pt-2 border-t border-theme-border">

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
@@ -74,6 +74,29 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
           <Property label="Current Primary" value={getCNPGClusterPrimary(data)} />
           <Property label="Image" value={getCNPGClusterImage(data)} />
           <Property label="Update Strategy" value={getCNPGClusterUpdateStrategy(data)} />
+          {data.status?.writeService && (
+            <Property label="Write Service" value={
+              <ResourceLink name={data.status.writeService} kind="Service" namespace={data.metadata?.namespace || ''} onNavigate={onNavigate} />
+            } />
+          )}
+          {data.status?.readService && (
+            <Property label="Read Service" value={
+              <ResourceLink name={data.status.readService} kind="Service" namespace={data.metadata?.namespace || ''} onNavigate={onNavigate} />
+            } />
+          )}
+          {data.spec?.enableSuperuserAccess !== undefined && (
+            <Property label="Superuser Access" value={
+              <span className={`badge-sm ${data.spec.enableSuperuserAccess ? 'bg-green-500/20 text-green-400' : 'bg-theme-hover text-theme-text-secondary'}`}>
+                {data.spec.enableSuperuserAccess ? 'Enabled' : 'Disabled'}
+              </span>
+            } />
+          )}
+          {(data.spec?.minSyncReplicas !== undefined || data.spec?.maxSyncReplicas !== undefined) && (
+            <Property
+              label="Sync Replicas"
+              value={`Min: ${data.spec?.minSyncReplicas ?? '-'} / Max: ${data.spec?.maxSyncReplicas ?? '-'}`}
+            />
+          )}
         </PropertyList>
         {instanceNames.length > 0 && (
           <div className="mt-2 pt-2 border-t border-theme-border">

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGClusterRenderer.tsx
@@ -37,13 +37,21 @@ export function CNPGClusterRenderer({ data, onNavigate }: CNPGClusterRendererPro
   const bootstrapMethod = getCNPGClusterBootstrapMethod(data)
 
   // Problem detection
-  const isDegraded = instances > 0 && readyInstances < instances
+  const isDown = instances > 0 && readyInstances === 0
+  const isDegraded = instances > 0 && readyInstances < instances && readyInstances > 0
   const isFailover = phase.toLowerCase().includes('failing over')
   const isSwitchover = phase.toLowerCase().includes('switchover')
 
   return (
     <>
       {/* Problem alerts */}
+      {isDown && (
+        <AlertBanner
+          variant="error"
+          title="Cluster Down"
+          message={`All ${instances} instances are not ready.`}
+        />
+      )}
       {isDegraded && (
         <AlertBanner
           variant="warning"

--- a/packages/k8s-ui/src/components/resources/renderers/CertificateRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CertificateRenderer.tsx
@@ -1,4 +1,4 @@
-import { Shield, Clock, Globe } from 'lucide-react'
+import { Shield, Clock, Globe, Key } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
 
@@ -25,6 +25,10 @@ export function CertificateRenderer({ data }: CertificateRendererProps) {
   const dnsNames = spec.dnsNames || []
   const issuerRef = spec.issuerRef || {}
   const usages = spec.usages || []
+
+  const privateKey = spec.privateKey
+  const failedIssuanceAttempts = status.failedIssuanceAttempts
+  const lastFailureTime = status.lastFailureTime
 
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
   const isReady = readyCond?.status === 'True'
@@ -96,30 +100,53 @@ export function CertificateRenderer({ data }: CertificateRendererProps) {
         />
       )}
 
+      {failedIssuanceAttempts > 0 && (
+        <AlertBanner
+          variant="warning"
+          title={`${failedIssuanceAttempts} failed issuance attempt${failedIssuanceAttempts !== 1 ? 's' : ''}`}
+          message={lastFailureTime ? `Last failure: ${formatDate(lastFailureTime)}` : undefined}
+        />
+      )}
+
       {/* Certificate Info */}
       <Section title="Certificate Info" icon={Shield}>
         <PropertyList>
           <Property
             label="Status"
             value={
-              <span className={clsx(
-                'badge',
-                isReady
-                  ? 'bg-green-500/20 text-green-400'
-                  : 'bg-red-500/20 text-red-400'
-              )}>
-                {isReady ? 'Ready' : 'Not Ready'}
+              <span className="flex items-center gap-2">
+                <span className={clsx(
+                  'badge',
+                  isReady
+                    ? 'bg-green-500/20 text-green-400'
+                    : 'bg-red-500/20 text-red-400'
+                )}>
+                  {isReady ? 'Ready' : 'Not Ready'}
+                </span>
+                {spec.isCA && (
+                  <span className="badge bg-purple-500/20 text-purple-400">
+                    CA Certificate
+                  </span>
+                )}
               </span>
             }
           />
           <Property label="Secret Name" value={spec.secretName} />
           <Property label="Revision" value={status.revision} />
+          {failedIssuanceAttempts > 0 && (
+            <Property label="Failed Issuance Attempts" value={String(failedIssuanceAttempts)} />
+          )}
+          {lastFailureTime && (
+            <Property label="Last Failure Time" value={formatDate(lastFailureTime)} />
+          )}
         </PropertyList>
       </Section>
 
       {/* Validity */}
       <Section title="Validity" icon={Clock}>
         <PropertyList>
+          <Property label="Duration" value={spec.duration} />
+          <Property label="Renew Before" value={spec.renewBefore} />
           <Property label="Not Before" value={notBefore ? formatDate(notBefore) : '-'} />
           <Property
             label="Not After"
@@ -160,6 +187,18 @@ export function CertificateRenderer({ data }: CertificateRendererProps) {
           </div>
         )}
       </Section>
+
+      {/* Private Key */}
+      {privateKey && (
+        <Section title="Private Key" icon={Key}>
+          <PropertyList>
+            <Property label="Algorithm" value={privateKey.algorithm} />
+            <Property label="Size" value={privateKey.size != null ? String(privateKey.size) : undefined} />
+            <Property label="Encoding" value={privateKey.encoding} />
+            <Property label="Rotation Policy" value={privateKey.rotationPolicy} />
+          </PropertyList>
+        </Section>
+      )}
 
       {/* Domains */}
       {dnsNames.length > 0 && (

--- a/packages/k8s-ui/src/components/resources/renderers/ChallengeRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ChallengeRenderer.tsx
@@ -1,4 +1,4 @@
-import { Shield, AlertTriangle, Globe, Key } from 'lucide-react'
+import { Shield, AlertTriangle, Globe, Key, FileText } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection } from '../../ui/drawer-components'
 import { getSolverType } from './ClusterIssuerRenderer'
@@ -71,8 +71,15 @@ export function ChallengeRenderer({ data }: { data: any }) {
           <Property
             label="Type"
             value={
-              <span className="badge bg-theme-elevated text-theme-text-secondary">
-                {challengeType}
+              <span className="flex items-center gap-2">
+                <span className="badge bg-theme-elevated text-theme-text-secondary">
+                  {challengeType}
+                </span>
+                {spec.wildcard && (
+                  <span className="badge bg-purple-500/20 text-purple-400">
+                    Wildcard
+                  </span>
+                )}
               </span>
             }
           />
@@ -83,6 +90,17 @@ export function ChallengeRenderer({ data }: { data: any }) {
           {spec.dnsName && <Property label="Domain" value={spec.dnsName} />}
         </PropertyList>
       </Section>
+
+      {/* Issuer */}
+      {spec.issuerRef && (
+        <Section title="Issuer" icon={FileText}>
+          <PropertyList>
+            <Property label="Name" value={spec.issuerRef.name} />
+            <Property label="Kind" value={spec.issuerRef.kind} />
+            <Property label="Group" value={spec.issuerRef.group} />
+          </PropertyList>
+        </Section>
+      )}
 
       {/* ACME */}
       {(spec.url || spec.token) && (

--- a/packages/k8s-ui/src/components/resources/renderers/ClusterIssuerRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ClusterIssuerRenderer.tsx
@@ -1,4 +1,4 @@
-import { Shield, AlertTriangle, Globe, Lock, Key } from 'lucide-react'
+import { Shield, AlertTriangle, Globe, Lock, Key, Server } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection } from '../../ui/drawer-components'
 
@@ -7,6 +7,15 @@ function detectIssuerType(spec: any): string {
   if (spec.ca) return 'CA'
   if (spec.selfSigned !== undefined) return 'SelfSigned'
   if (spec.vault) return 'Vault'
+  if (spec.venafi) return 'Venafi'
+  return 'Unknown'
+}
+
+function getVaultAuthMethod(auth: any): string {
+  if (!auth) return 'Unknown'
+  if (auth.tokenSecretRef) return 'Token'
+  if (auth.appRole) return 'AppRole'
+  if (auth.kubernetes) return 'Kubernetes'
   return 'Unknown'
 }
 
@@ -134,6 +143,55 @@ function IssuerRendererBase({ data, kind }: { data: any; kind: string }) {
         <Section title="CA" icon={Lock}>
           <PropertyList>
             <Property label="Secret Name" value={spec.ca.secretName} />
+          </PropertyList>
+        </Section>
+      )}
+
+      {/* Vault section */}
+      {spec.vault && (
+        <Section title="Vault Configuration" icon={Server}>
+          <PropertyList>
+            <Property label="Server" value={spec.vault.server} />
+            <Property label="Path" value={spec.vault.path} />
+            <Property label="Auth Method" value={getVaultAuthMethod(spec.vault.auth)} />
+            {spec.vault.auth?.appRole?.roleId && (
+              <Property label="AppRole Role ID" value={spec.vault.auth.appRole.roleId} />
+            )}
+            {spec.vault.auth?.appRole?.secretRef?.name && (
+              <Property label="AppRole Secret Ref" value={spec.vault.auth.appRole.secretRef.name} />
+            )}
+            {spec.vault.auth?.tokenSecretRef?.name && (
+              <Property label="Token Secret Ref" value={spec.vault.auth.tokenSecretRef.name} />
+            )}
+            {spec.vault.auth?.kubernetes?.role && (
+              <Property label="K8s Auth Role" value={spec.vault.auth.kubernetes.role} />
+            )}
+            {spec.vault.auth?.kubernetes?.secretRef?.name && (
+              <Property label="K8s Secret Ref" value={spec.vault.auth.kubernetes.secretRef.name} />
+            )}
+            <Property label="Custom CA" value={spec.vault.caBundle ? 'Yes' : 'No'} />
+            {spec.vault.namespace && (
+              <Property label="Vault Namespace" value={spec.vault.namespace} />
+            )}
+          </PropertyList>
+        </Section>
+      )}
+
+      {/* Venafi section */}
+      {spec.venafi && (
+        <Section title="Venafi Configuration" icon={Shield}>
+          <PropertyList>
+            <Property label="Zone" value={spec.venafi.zone} />
+            <Property
+              label="Platform"
+              value={spec.venafi.cloud ? 'Cloud' : spec.venafi.tpp ? 'TPP' : '-'}
+            />
+            {spec.venafi.cloud?.url && (
+              <Property label="Cloud URL" value={spec.venafi.cloud.url} />
+            )}
+            {spec.venafi.tpp?.url && (
+              <Property label="TPP URL" value={spec.venafi.tpp.url} />
+            )}
           </PropertyList>
         </Section>
       )}

--- a/packages/k8s-ui/src/components/resources/renderers/KedaScaledObjectRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KedaScaledObjectRenderer.tsx
@@ -1,4 +1,4 @@
-import { Cpu } from 'lucide-react'
+import { Cpu, Settings } from 'lucide-react'
 import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
 import { kindToPlural } from '../../../utils/navigation'
 import {
@@ -11,6 +11,16 @@ import {
   getScaledObjectPollingInterval,
   getScaledObjectCooldownPeriod,
 } from '../resource-utils-keda'
+
+function summarizeScalingPolicies(policies: any[] | undefined, periodSeconds?: number): string {
+  if (!policies || policies.length === 0) return '-'
+  return policies.map((p: any) => {
+    const value = p.value ?? '?'
+    const type = p.type === 'Percent' ? '%' : ` pod${value !== 1 ? 's' : ''}`
+    const period = p.periodSeconds ?? periodSeconds ?? '?'
+    return `max ${value}${type}/${period}s`
+  }).join(', ')
+}
 
 interface KedaScaledObjectRendererProps {
   data: any
@@ -128,6 +138,50 @@ export function KedaScaledObjectRenderer({ data, onNavigate }: KedaScaledObjectR
               </div>
             ))}
           </div>
+        </Section>
+      )}
+
+      {/* Advanced section */}
+      {data.spec?.advanced && (
+        <Section title="Advanced" icon={Settings} defaultExpanded={false}>
+          <PropertyList>
+            {data.spec.advanced.restoreToOriginalReplicaCount != null && (
+              <Property
+                label="Restore Original Replicas"
+                value={data.spec.advanced.restoreToOriginalReplicaCount ? 'Yes' : 'No'}
+              />
+            )}
+            {data.spec.advanced.horizontalPodAutoscalerConfig?.behavior?.scaleUp && (
+              <Property
+                label="Scale Up"
+                value={summarizeScalingPolicies(
+                  data.spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp.policies,
+                  data.spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp.stabilizationWindowSeconds
+                )}
+              />
+            )}
+            {data.spec.advanced.horizontalPodAutoscalerConfig?.behavior?.scaleDown && (
+              <Property
+                label="Scale Down"
+                value={summarizeScalingPolicies(
+                  data.spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown.policies,
+                  data.spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown.stabilizationWindowSeconds
+                )}
+              />
+            )}
+            {data.spec.advanced.horizontalPodAutoscalerConfig?.behavior?.scaleUp?.stabilizationWindowSeconds != null && (
+              <Property
+                label="Scale Up Stabilization"
+                value={`${data.spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp.stabilizationWindowSeconds}s`}
+              />
+            )}
+            {data.spec.advanced.horizontalPodAutoscalerConfig?.behavior?.scaleDown?.stabilizationWindowSeconds != null && (
+              <Property
+                label="Scale Down Stabilization"
+                value={`${data.spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown.stabilizationWindowSeconds}s`}
+              />
+            )}
+          </PropertyList>
         </Section>
       )}
 

--- a/packages/k8s-ui/src/components/resources/renderers/KedaTriggerAuthRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KedaTriggerAuthRenderer.tsx
@@ -19,6 +19,7 @@ export function KedaTriggerAuthRenderer({ data, onNavigate }: KedaTriggerAuthRen
   const vault = spec.hashiCorpVault
   const azureKeyVault = spec.azureKeyVault
   const awsSecretManager = spec.awsSecretManager
+  const gcpSecretManager = spec.gcpSecretManager
   const podIdentity = spec.podIdentity
 
   return (
@@ -138,6 +139,28 @@ export function KedaTriggerAuthRenderer({ data, onNavigate }: KedaTriggerAuthRen
                 <div key={i} className="card-inner text-sm">
                   <span className="text-theme-text-primary font-medium">{s.parameter}</span>
                   <span className="text-theme-text-secondary ml-2">{s.name}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </Section>
+      )}
+
+      {/* GCP Secret Manager */}
+      {gcpSecretManager && (
+        <Section title="GCP Secret Manager" icon={Cloud}>
+          <PropertyList>
+            {gcpSecretManager.credentials?.clientSecret?.name && (
+              <Property label="Credentials Secret" value={gcpSecretManager.credentials.clientSecret.name} />
+            )}
+          </PropertyList>
+          {gcpSecretManager.secrets && gcpSecretManager.secrets.length > 0 && (
+            <div className="mt-2 space-y-1">
+              <div className="text-xs font-medium text-theme-text-secondary uppercase tracking-wider mb-1">Secrets</div>
+              {gcpSecretManager.secrets.map((s: any, i: number) => (
+                <div key={i} className="card-inner text-sm">
+                  <span className="text-theme-text-primary font-medium">{s.parameter}</span>
+                  <span className="text-theme-text-secondary ml-2">{s.id}{s.version ? ` (v${s.version})` : ''}</span>
                 </div>
               ))}
             </div>

--- a/packages/k8s-ui/src/components/resources/renderers/RolloutRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/RolloutRenderer.tsx
@@ -1,4 +1,4 @@
-import { Server, GitBranch, AlertTriangle } from 'lucide-react'
+import { Server, GitBranch, AlertTriangle, Network } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, PodTemplateSection } from '../../ui/drawer-components'
 
@@ -17,6 +17,20 @@ export function RolloutRenderer({ data }: RolloutRendererProps) {
   const isCanary = !!canaryStrategy
   const steps = canaryStrategy?.steps || []
   const currentStepIndex = status.currentStepIndex
+  const trafficRouting = canaryStrategy?.trafficRouting
+
+  // Detect traffic routing provider
+  const trafficProvider = trafficRouting
+    ? (() => {
+        if (trafficRouting.istio) return { name: 'Istio', details: trafficRouting.istio }
+        if (trafficRouting.nginx) return { name: 'Nginx', details: trafficRouting.nginx }
+        if (trafficRouting.alb) return { name: 'ALB', details: trafficRouting.alb }
+        if (trafficRouting.smi) return { name: 'SMI', details: trafficRouting.smi }
+        if (trafficRouting.traefik) return { name: 'Traefik', details: trafficRouting.traefik }
+        if (trafficRouting.ambassador) return { name: 'Ambassador', details: trafficRouting.ambassador }
+        return null
+      })()
+    : null
 
   // Problem detection
   const problems: Array<{ color: 'red' | 'yellow'; message: string }> = []
@@ -152,6 +166,77 @@ export function RolloutRenderer({ data }: RolloutRendererProps) {
           )}
         </PropertyList>
       </Section>
+
+      {/* Traffic Routing */}
+      {trafficProvider && (
+        <Section title="Traffic Routing" icon={Network}>
+          <PropertyList>
+            <Property
+              label="Provider"
+              value={
+                <span className="badge-sm status-neutral">{trafficProvider.name}</span>
+              }
+            />
+            {trafficProvider.name === 'Istio' && (
+              <>
+                {trafficProvider.details.virtualService?.name && (
+                  <Property label="VirtualService" value={trafficProvider.details.virtualService.name} />
+                )}
+                {trafficProvider.details.destinationRule?.name && (
+                  <Property label="DestinationRule" value={trafficProvider.details.destinationRule.name} />
+                )}
+              </>
+            )}
+            {trafficProvider.name === 'ALB' && (
+              <>
+                {trafficProvider.details.ingress && (
+                  <Property label="Ingress" value={trafficProvider.details.ingress} />
+                )}
+                {trafficProvider.details.servicePort != null && (
+                  <Property label="Service Port" value={trafficProvider.details.servicePort} />
+                )}
+              </>
+            )}
+            {trafficProvider.name === 'Nginx' && (
+              <>
+                {trafficProvider.details.stableIngress && (
+                  <Property label="Stable Ingress" value={trafficProvider.details.stableIngress} />
+                )}
+                {trafficProvider.details.additionalIngressAnnotations && (
+                  <Property
+                    label="Annotations"
+                    value={Object.keys(trafficProvider.details.additionalIngressAnnotations).length + ' annotations'}
+                  />
+                )}
+              </>
+            )}
+            {trafficProvider.name === 'SMI' && (
+              <>
+                {trafficProvider.details.rootService && (
+                  <Property label="Root Service" value={trafficProvider.details.rootService} />
+                )}
+                {trafficProvider.details.trafficSplitName && (
+                  <Property label="TrafficSplit" value={trafficProvider.details.trafficSplitName} />
+                )}
+              </>
+            )}
+            {trafficProvider.name === 'Traefik' && (
+              <>
+                {trafficProvider.details.weightedTraefikServiceName && (
+                  <Property label="Weighted Service" value={trafficProvider.details.weightedTraefikServiceName} />
+                )}
+              </>
+            )}
+            {trafficProvider.name === 'Ambassador' && (
+              <>
+                {trafficProvider.details.mappings && (
+                  <Property label="Mappings" value={trafficProvider.details.mappings.join(', ')} />
+                )}
+              </>
+            )}
+          </PropertyList>
+        </Section>
+      )}
 
       {/* Canary Steps visual */}
       {isCanary && steps.length > 0 && (

--- a/packages/k8s-ui/src/components/resources/renderers/WorkflowRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/WorkflowRenderer.tsx
@@ -163,8 +163,21 @@ export function WorkflowRenderer({ data }: WorkflowRendererProps) {
           {status.startedAt && <Property label="Started" value={formatAge(status.startedAt)} />}
           <Property label="Finished" value={status.finishedAt ? formatAge(status.finishedAt) : 'Running...'} />
           {templateName && <Property label="Template" value={templateName} />}
+          {status.progress && (
+            <Property label="Progress" value={status.progress} />
+          )}
           {estimatedDuration != null && (
             <Property label="Estimated Duration" value={formatEstimatedDuration(estimatedDuration)} />
+          )}
+          {status.resourcesDuration && (
+            <Property
+              label="Resource Usage"
+              value={
+                Object.entries(status.resourcesDuration as Record<string, number>)
+                  .map(([resource, seconds]) => `${resource}: ${seconds}s`)
+                  .join(', ')
+              }
+            />
           )}
         </PropertyList>
       </Section>

--- a/packages/k8s-ui/src/components/resources/renderers/WorkflowTemplateRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/WorkflowTemplateRenderer.tsx
@@ -1,4 +1,4 @@
-import { Play, FileText, Key, Lock } from 'lucide-react'
+import { Play, FileText, Key, Lock, File, ArrowDownToLine, ArrowUpFromLine } from 'lucide-react'
 import { Section, PropertyList, Property } from '../../ui/drawer-components'
 
 interface WorkflowTemplateRendererProps {
@@ -44,6 +44,11 @@ export function WorkflowTemplateRenderer({ data }: WorkflowTemplateRendererProps
             {templates.map((template: any) => {
               const type = getTemplateType(template)
               const image = getTemplateImage(template)
+              const inputParams: Array<{ name: string }> = template.inputs?.parameters || []
+              const outputParams: Array<{ name: string }> = template.outputs?.parameters || []
+              const outputArtifacts: Array<{ name: string }> = template.outputs?.artifacts || []
+              const inputArtifacts: Array<{ name: string }> = template.inputs?.artifacts || []
+              const hasIO = inputParams.length > 0 || outputParams.length > 0 || outputArtifacts.length > 0 || inputArtifacts.length > 0
               return (
                 <div key={template.name} className="card-inner px-3 py-2 text-sm">
                   <div className="font-medium text-theme-text-primary">{template.name}</div>
@@ -51,6 +56,46 @@ export function WorkflowTemplateRenderer({ data }: WorkflowTemplateRendererProps
                   {image && (
                     <div className="text-xs text-theme-text-tertiary mt-0.5 truncate" title={image}>
                       {image}
+                    </div>
+                  )}
+                  {hasIO && (
+                    <div className="mt-2 space-y-1.5">
+                      {(inputParams.length > 0 || inputArtifacts.length > 0) && (
+                        <div className="flex items-start gap-1.5">
+                          <ArrowDownToLine className="w-3 h-3 text-theme-text-tertiary mt-0.5 shrink-0" />
+                          <div className="flex flex-wrap gap-1">
+                            {inputParams.map((p) => (
+                              <span key={p.name} className="badge-sm bg-theme-elevated text-theme-text-secondary">
+                                {p.name}
+                              </span>
+                            ))}
+                            {inputArtifacts.map((a) => (
+                              <span key={a.name} className="badge-sm bg-theme-elevated text-theme-text-secondary flex items-center gap-0.5">
+                                <File className="w-2.5 h-2.5" />
+                                {a.name}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+                      {(outputParams.length > 0 || outputArtifacts.length > 0) && (
+                        <div className="flex items-start gap-1.5">
+                          <ArrowUpFromLine className="w-3 h-3 text-theme-text-tertiary mt-0.5 shrink-0" />
+                          <div className="flex flex-wrap gap-1">
+                            {outputParams.map((p) => (
+                              <span key={p.name} className="badge-sm bg-theme-elevated text-theme-text-secondary">
+                                {p.name}
+                              </span>
+                            ))}
+                            {outputArtifacts.map((a) => (
+                              <span key={a.name} className="badge-sm bg-theme-elevated text-theme-text-secondary flex items-center gap-0.5">
+                                <File className="w-2.5 h-2.5" />
+                                {a.name}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+                      )}
                     </div>
                   )}
                 </div>

--- a/packages/k8s-ui/src/types/gitops.ts
+++ b/packages/k8s-ui/src/types/gitops.ts
@@ -230,7 +230,9 @@ export interface ArgoAppStatus {
   operationState?: {
     phase?: ArgoOperationPhase | string // Known types + allow unknown
     message?: string
+    startedAt?: string
     finishedAt?: string
+    retryCount?: number
     syncResult?: {
       revision?: string
       source?: ArgoSyncResultSource
@@ -238,6 +240,12 @@ export interface ArgoAppStatus {
     }
   }
   reconciledAt?: string
+  history?: Array<{
+    revision?: string
+    deployedAt?: string
+    id?: number
+    source?: { repoURL?: string; path?: string }
+  }>
 }
 
 /**


### PR DESCRIPTION
## Summary

P1 renderer improvements for the same CRD integrations addressed in the P0 batches. 12 files, +465/-16.

**Argo CD Application** — Revision history section (last 10 syncs with deployed time). Operation startedAt and retryCount. Helm parameters and inline values display (were only showing valueFiles).

**Argo Rollouts** — Canary traffic routing section showing provider config (Istio virtualService, ALB ingress, Nginx stableIngress, etc.).

**Argo Workflows** — `status.progress` ("3/5") and `status.resourcesDuration` (CPU/memory seconds) in status section.

**Argo WorkflowTemplate** — Template inputs/outputs (parameters and artifacts) shown per template.

**CNPG Cluster** — Read/write service names as navigable links (users need these for connection strings). Sync replica config (min/max). Superuser access flag.

**CNPG Backup** — Instance ID (which pod ran the backup).

**cert-manager Certificate** — `renewBefore`, `duration`, private key config (algorithm/size/encoding/rotation), `isCA` badge, `failedIssuanceAttempts` with warning alert.

**cert-manager ClusterIssuer** — Vault configuration section (server, path, auth method, namespace) and Venafi configuration section (zone, cloud/TPP URL). Both were completely blank — users just saw "Type: Vault" with zero details.

**cert-manager Challenge** — Wildcard badge, issuerRef properties.

**KEDA TriggerAuth** — GCP Secret Manager section (was missing entirely as a cloud provider).

**KEDA ScaledObject** — `spec.advanced` section with `restoreToOriginalReplicaCount` and HPA scaling behavior policies.