### PR TITLE
Surface kubeconfig loading state in diagnostics

### DIFF
--- a/cmd/desktop/env.go
+++ b/cmd/desktop/env.go
@@ -10,6 +10,9 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/skyhook-io/radar/internal/errorlog"
+	"github.com/skyhook-io/radar/internal/k8s"
 )
 
 // shellEnvVars lists environment variables to capture from the user's
@@ -53,9 +56,38 @@ func enrichEnv() {
 		if key == "PATH" {
 			continue
 		}
-		if val, ok := captured[key]; ok && val != "" && os.Getenv(key) == "" {
+		val, found := captured[key]
+		if found && val != "" && os.Getenv(key) == "" {
 			os.Setenv(key, val)
 			log.Printf("Env enriched: %s from login shell", key)
+			if key == "KUBECONFIG" {
+				k8s.EnrichedKubeconfigFromShell = true
+			}
+			continue
+		}
+		// Explain KUBECONFIG skip reasons — the GUI app starts with a stripped
+		// env on macOS/Linux, and if enrichment doesn't fire the user may see
+		// fewer clusters than they expect in the switcher. We surface this via
+		// the errorlog so it shows up in bug report diagnostics.
+		if key != "KUBECONFIG" {
+			continue
+		}
+		switch {
+		case os.Getenv(key) != "":
+			// Pre-existing KUBECONFIG in the process env blocks enrichment.
+			// Most likely cause: launchctl setenv or a parent shell that
+			// already exported a (possibly shorter) value.
+			existing := os.Getenv(key)
+			pathCount := len(filepath.SplitList(existing))
+			log.Printf("KUBECONFIG enrichment skipped: already set in process env (%d path(s))", pathCount)
+			errorlog.Record("env-enrich", "warning",
+				"KUBECONFIG enrichment skipped: already set in process env with %d path(s); "+
+					"login shell value ignored", pathCount)
+		case !found || val == "":
+			log.Printf("KUBECONFIG enrichment skipped: not found in login shell")
+			errorlog.Record("env-enrich", "warning",
+				"KUBECONFIG not found in login shell (%s -l -i); "+
+					"multi-file configs from .zshrc/.bashrc will not be visible", os.Getenv("SHELL"))
 		}
 	}
 }

--- a/cmd/desktop/env.go
+++ b/cmd/desktop/env.go
@@ -61,7 +61,7 @@ func enrichEnv() {
 			os.Setenv(key, val)
 			log.Printf("Env enriched: %s from login shell", key)
 			if key == "KUBECONFIG" {
-				k8s.EnrichedKubeconfigFromShell = true
+				k8s.SetEnrichedKubeconfigFromShell(true)
 			}
 			continue
 		}
@@ -84,10 +84,14 @@ func enrichEnv() {
 				"KUBECONFIG enrichment skipped: already set in process env with %d path(s); "+
 					"login shell value ignored", pathCount)
 		case !found || val == "":
+			// Use Base() so a user with a custom shell binary under $HOME
+			// (e.g. nix-profile) doesn't leak their username into a public
+			// bug report.
+			shellName := filepath.Base(os.Getenv("SHELL"))
 			log.Printf("KUBECONFIG enrichment skipped: not found in login shell")
 			errorlog.Record("env-enrich", "warning",
 				"KUBECONFIG not found in login shell (%s -l -i); "+
-					"multi-file configs from .zshrc/.bashrc will not be visible", os.Getenv("SHELL"))
+					"multi-file configs from .zshrc/.bashrc will not be visible", shellName)
 		}
 	}
 }

--- a/cmd/desktop/env.go
+++ b/cmd/desktop/env.go
@@ -86,8 +86,13 @@ func enrichEnv() {
 		case !found || val == "":
 			// Use Base() so a user with a custom shell binary under $HOME
 			// (e.g. nix-profile) doesn't leak their username into a public
-			// bug report.
-			shellName := filepath.Base(os.Getenv("SHELL"))
+			// bug report. Fall back to a placeholder when $SHELL is unset
+			// — filepath.Base("") returns "." which would be a confusing
+			// diagnostic message.
+			shellName := "unknown"
+			if s := os.Getenv("SHELL"); s != "" {
+				shellName = filepath.Base(s)
+			}
 			log.Printf("KUBECONFIG enrichment skipped: not found in login shell")
 			errorlog.Record("env-enrich", "warning",
 				"KUBECONFIG not found in login shell (%s -l -i); "+

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -1,10 +1,13 @@
 package k8s
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 
@@ -13,34 +16,56 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/util/homedir"
+
+	"github.com/skyhook-io/radar/internal/errorlog"
 )
 
 var (
-	k8sClient         *kubernetes.Clientset
-	k8sConfig         *rest.Config
-	discoveryClient   *discovery.DiscoveryClient
-	dynamicClient     dynamic.Interface
-	initOnce          sync.Once
-	initErr           error
-	kubeconfigPath    string
-	kubeconfigPaths   []string // Multiple kubeconfig paths when using --kubeconfig-dir or KUBECONFIG env
-	kubeconfigMode    string   // One of: "in-cluster", "single", "multi-env", "multi-dir"
-	mergedContextCount int     // Number of contexts exposed after client-go merged all kubeconfig files
-	contextName       string
-	clusterName       string
-	contextNamespace  string // Default namespace from kubeconfig context
-	fallbackNamespace string // Explicit namespace from --namespace flag
-	contextUsesExec   bool   // True when the current context uses an exec credential plugin
-	// EnrichedKubeconfigFromShell is set by the desktop app's enrichEnv() when
+	k8sClient          *kubernetes.Clientset
+	k8sConfig          *rest.Config
+	discoveryClient    *discovery.DiscoveryClient
+	dynamicClient      dynamic.Interface
+	initOnce           sync.Once
+	initErr            error
+	kubeconfigPath     string
+	kubeconfigPaths    []string // Multiple kubeconfig paths when using --kubeconfig-dir or KUBECONFIG env
+	kubeconfigMode     string   // One of: "in-cluster", "single", "multi-env", "multi-dir"
+	mergedContextCount int      // Number of contexts exposed after client-go merged all kubeconfig files
+	contextName        string
+	clusterName        string
+	contextNamespace   string // Default namespace from kubeconfig context
+	fallbackNamespace  string // Explicit namespace from --namespace flag
+	contextUsesExec    bool   // True when the current context uses an exec credential plugin
+	// execPluginCommands is the set of unique exec-auth plugin command basenames
+	// referenced by any context in the merged kubeconfig. Populated from
+	// rawConfig.AuthInfos at load time and refreshed on SwitchContext. Stored
+	// as basenames only so diagnostics never leak full binary paths. Used by
+	// GetKubeconfigSummary() to produce present/missing lists against the
+	// current process PATH.
+	execPluginCommands []string
+	// enrichedKubeconfigFromShell is set by the desktop app's enrichEnv() when
 	// it successfully captured KUBECONFIG from the user's login shell. Surfaced
 	// in diagnostics so we can tell whether the GUI app's env was enriched or
-	// whether we fell back to whatever the parent process handed us.
-	EnrichedKubeconfigFromShell bool
+	// whether we fell back to whatever the parent process handed us. All access
+	// goes through clientMu like the rest of the globals in this file —
+	// callers use SetEnrichedKubeconfigFromShell to write.
+	enrichedKubeconfigFromShell bool
 	// clientMu protects access to client variables during context switches.
 	// Readers use RLock, context switch uses Lock.
 	clientMu sync.RWMutex
 )
+
+// SetEnrichedKubeconfigFromShell records that the desktop app's enrichEnv()
+// successfully captured KUBECONFIG from the user's login shell. Used only for
+// diagnostic reporting — does not affect K8s client behavior. Takes clientMu
+// like every other write to the package-level state.
+func SetEnrichedKubeconfigFromShell(v bool) {
+	clientMu.Lock()
+	defer clientMu.Unlock()
+	enrichedKubeconfigFromShell = v
+}
 
 // InitOptions configures the K8s client initialization
 type InitOptions struct {
@@ -134,11 +159,21 @@ func doInit(opts InitOptions) error {
 		configOverrides := &clientcmd.ConfigOverrides{}
 		kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 
-		// Get raw config to extract context/cluster names
-		rawConfig, err := kubeConfig.RawConfig()
-		if err == nil {
+		// Get raw config to extract context/cluster names. If this fails we
+		// still let ClientConfig() try below — it can occasionally succeed
+		// for the current context when a non-current stanza is malformed —
+		// but we must NOT silently skip the diagnostic bookkeeping, or we'd
+		// report contextCount=0 in the snapshot and mask the exact "some
+		// clusters don't show up" symptom this instrumentation is for.
+		rawConfig, rawErr := kubeConfig.RawConfig()
+		if rawErr != nil {
+			log.Printf("Kubeconfig metadata load failed (mode=%s): %v", kubeconfigMode, rawErr)
+			errorlog.Record("k8s-init", "warning",
+				"RawConfig() failed; context metadata and diagnostic counts unavailable: %v", rawErr)
+		} else {
 			contextName = rawConfig.CurrentContext
 			mergedContextCount = len(rawConfig.Contexts)
+			execPluginCommands = collectExecPluginCommands(&rawConfig)
 			fileCount := len(kubeconfigPaths)
 			if fileCount == 0 && kubeconfigPath != "" {
 				fileCount = 1
@@ -147,8 +182,8 @@ func doInit(opts InitOptions) error {
 			// client-go silently drops later duplicates when merging by name, so
 			// this count is the "ground truth" of what the user can actually pick
 			// from the dropdown — not the sum of per-file contexts.
-			log.Printf("Kubeconfig loaded: mode=%s, files=%d, contexts=%d",
-				kubeconfigMode, fileCount, mergedContextCount)
+			log.Printf("Kubeconfig loaded: mode=%s, files=%d, contexts=%d, exec-plugins=%d",
+				kubeconfigMode, fileCount, mergedContextCount, len(execPluginCommands))
 			if ctx, ok := rawConfig.Contexts[contextName]; ok {
 				clusterName = ctx.Cluster
 				contextNamespace = ctx.Namespace
@@ -160,6 +195,12 @@ func doInit(opts InitOptions) error {
 
 		config, err = kubeConfig.ClientConfig()
 		if err != nil {
+			// Record to errorlog so the failure lands in the diagnostics
+			// snapshot's recentErrors. Include only the file count and mode —
+			// never the kubeconfig paths — so the snapshot stays shareable.
+			errorlog.Record("k8s-init", "error",
+				"failed to build kubeconfig client config (mode=%s, files=%d): %v",
+				kubeconfigMode, len(kubeconfigPaths), err)
 			if len(kubeconfigPaths) > 0 {
 				return fmt.Errorf("failed to build kubeconfig from %d files: %w", len(kubeconfigPaths), err)
 			}
@@ -202,6 +243,14 @@ func discoverKubeconfigs(dirs []string) ([]string, error) {
 		entries, err := os.ReadDir(dir)
 		if err != nil {
 			log.Printf("Warning: cannot read kubeconfig directory %s: %v", dir, err)
+			// Surface scan failures in the diagnostics snapshot so "my
+			// dropdown is empty" reports can tell permission/missing-dir
+			// apart from "dir was there but held no valid configs".
+			// Strip full paths from the error text via *fs.PathError so
+			// the snapshot stays shareable — just Op + underlying cause.
+			errorlog.Record("k8s-init", "warning",
+				"kubeconfig dir %q scan failed: %s",
+				filepath.Base(dir), scrubPathError(err))
 			continue // Skip inaccessible dirs
 		}
 		for _, entry := range entries {
@@ -219,10 +268,30 @@ func discoverKubeconfigs(dirs []string) ([]string, error) {
 				log.Printf("Found kubeconfig: %s", path)
 			} else {
 				log.Printf("Skipping invalid kubeconfig: %s", path)
+				// Per-file parse/validation failures are invisible from
+				// the merged-config counts alone — a broken file lowers
+				// fileCount without explaining why. Record the basename
+				// (never the full path) so the triager knows which file
+				// to ask the user about.
+				errorlog.Record("k8s-init", "warning",
+					"skipping invalid kubeconfig file %q during directory scan",
+					filepath.Base(path))
 			}
 		}
 	}
 	return configs, nil
+}
+
+// scrubPathError returns the underlying error cause (e.g. "permission denied",
+// "no such file or directory") without the filesystem path that produced it,
+// so errorlog entries derived from os.ReadDir / os.Open can safely ship in a
+// bug report. Non-PathError values fall through unchanged.
+func scrubPathError(err error) string {
+	var pErr *os.PathError
+	if errors.As(err, &pErr) && pErr.Err != nil {
+		return pErr.Op + ": " + pErr.Err.Error()
+	}
+	return err.Error()
 }
 
 // isValidKubeconfig checks if a file is a valid kubeconfig
@@ -273,29 +342,89 @@ func GetKubeconfigPath() string {
 
 // KubeconfigSummary is a non-sensitive snapshot of kubeconfig loading state,
 // suitable for inclusion in diagnostic output. It never includes the resolved
-// paths themselves, only counts and mode flags.
+// paths themselves, only counts, mode flags, and exec plugin basenames.
 type KubeconfigSummary struct {
-	Mode              string // "in-cluster", "single", "multi-env", "multi-dir", or "" if not initialized
-	FileCount         int    // Number of kubeconfig files loaded (0 for in-cluster)
-	ContextCount      int    // Number of contexts exposed after client-go merged all files
-	EnrichedFromShell bool   // Desktop app captured KUBECONFIG from login shell
+	Mode                   string   // "in-cluster", "single", "multi-env", "multi-dir", or "" if not initialized
+	FileCount              int      // Number of kubeconfig files loaded (0 for in-cluster)
+	ContextCount           int      // Number of contexts exposed after client-go merged all files
+	EnrichedFromShell      bool     // Desktop app captured KUBECONFIG from login shell
+	CurrentContextUsesExec bool     // Current context's AuthInfo uses an exec credential plugin
+	ExecPluginsPresent     []string // Unique exec plugin command basenames (any context) resolvable on $PATH
+	ExecPluginsMissing     []string // Unique exec plugin command basenames (any context) NOT resolvable on $PATH
 }
 
 // GetKubeconfigSummary returns the current kubeconfig loading state for
 // diagnostics. All values are safe to include in a bug report.
+//
+// ExecPluginsPresent/Missing are computed lazily against the *current*
+// process PATH so the snapshot reflects what an in-flight context switch
+// would actually see — not the state at init time. This matters on the
+// desktop app where PATH may still be getting enriched.
 func GetKubeconfigSummary() KubeconfigSummary {
 	clientMu.RLock()
-	defer clientMu.RUnlock()
+	mode := kubeconfigMode
 	fileCount := len(kubeconfigPaths)
 	if fileCount == 0 && kubeconfigPath != "" {
 		fileCount = 1
 	}
-	return KubeconfigSummary{
-		Mode:              kubeconfigMode,
-		FileCount:         fileCount,
-		ContextCount:      mergedContextCount,
-		EnrichedFromShell: EnrichedKubeconfigFromShell,
+	contextCount := mergedContextCount
+	enriched := enrichedKubeconfigFromShell
+	currentExec := contextUsesExec
+	cmds := append([]string(nil), execPluginCommands...)
+	clientMu.RUnlock()
+
+	// LookPath outside the lock — it can stat the filesystem and we don't
+	// want to hold clientMu across I/O.
+	var present, missing []string
+	for _, cmd := range cmds {
+		if _, err := exec.LookPath(cmd); err == nil {
+			present = append(present, cmd)
+		} else {
+			missing = append(missing, cmd)
+		}
 	}
+
+	return KubeconfigSummary{
+		Mode:                   mode,
+		FileCount:              fileCount,
+		ContextCount:           contextCount,
+		EnrichedFromShell:      enriched,
+		CurrentContextUsesExec: currentExec,
+		ExecPluginsPresent:     present,
+		ExecPluginsMissing:     missing,
+	}
+}
+
+// collectExecPluginCommands walks every context in raw and collects the
+// unique command basenames of any referenced AuthInfo that uses an exec
+// credential plugin. Basenames only — never full paths — so the result is
+// safe to surface in diagnostics. Orphan AuthInfos (not referenced by any
+// context) are intentionally skipped: they can't cause a context switch
+// to fail, so there's no signal in them. Must be called under clientMu.Lock
+// (or before any other goroutine has a reference to the package state).
+func collectExecPluginCommands(raw *clientcmdapi.Config) []string {
+	if raw == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var out []string
+	for _, ctx := range raw.Contexts {
+		if ctx == nil {
+			continue
+		}
+		ai, ok := raw.AuthInfos[ctx.AuthInfo]
+		if !ok || ai == nil || ai.Exec == nil || ai.Exec.Command == "" {
+			continue
+		}
+		base := filepath.Base(ai.Exec.Command)
+		if _, dup := seen[base]; dup {
+			continue
+		}
+		seen[base] = struct{}{}
+		out = append(out, base)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // WriteKubeconfigForCurrentContext creates a temporary kubeconfig file with
@@ -537,6 +666,9 @@ func SwitchContext(name string) error {
 	if ai, ok := rawConfig.AuthInfos[ctx.AuthInfo]; ok && ai.Exec != nil {
 		usesExec = true
 	}
+	// Re-collect exec plugin commands — SwitchContext loads a fresh RawConfig
+	// so the user may have added/removed kubeconfig files since init.
+	execCmds := collectExecPluginCommands(&rawConfig)
 
 	clientMu.Lock()
 	k8sConfig = config
@@ -548,6 +680,7 @@ func SwitchContext(name string) error {
 	contextNamespace = ctx.Namespace
 	contextUsesExec = usesExec
 	mergedContextCount = len(rawConfig.Contexts)
+	execPluginCommands = execCmds
 	clientMu.Unlock()
 
 	return nil

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -159,21 +159,29 @@ func doInit(opts InitOptions) error {
 		configOverrides := &clientcmd.ConfigOverrides{}
 		kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 
-		// Get raw config to extract context/cluster names. If this fails we
-		// still let ClientConfig() try below — it can occasionally succeed
-		// for the current context when a non-current stanza is malformed —
-		// but we must NOT silently skip the diagnostic bookkeeping, or we'd
-		// report contextCount=0 in the snapshot and mask the exact "some
-		// clusters don't show up" symptom this instrumentation is for.
+		// Get raw config to extract context/cluster names. If this fails
+		// we still let ClientConfig() run below — it's likely to fail too,
+		// but we record the two failures separately so the snapshot shows
+		// the first error without bookkeeping getting silently skipped.
+		// Emitting at "error" severity (not "warning") because a RawConfig
+		// failure zeroes out every downstream diagnostic field this PR
+		// exists to surface — the entry must not be easy to overlook.
 		rawConfig, rawErr := kubeConfig.RawConfig()
 		if rawErr != nil {
 			log.Printf("Kubeconfig metadata load failed (mode=%s): %v", kubeconfigMode, rawErr)
-			errorlog.Record("k8s-init", "warning",
+			errorlog.Record("k8s-init", "error",
 				"RawConfig() failed; context metadata and diagnostic counts unavailable: %v", rawErr)
 		} else {
 			contextName = rawConfig.CurrentContext
 			mergedContextCount = len(rawConfig.Contexts)
-			execPluginCommands = collectExecPluginCommands(&rawConfig)
+			cmds, emptyAIs := collectExecPluginCommands(&rawConfig)
+			execPluginCommands = cmds
+			if len(emptyAIs) > 0 {
+				// Aggregate into a single errorlog entry — a pathological
+				// kubeconfig with hundreds of broken AuthInfos would otherwise
+				// flood the 200-entry ring buffer and evict other diagnostics.
+				recordEmptyCommandWarning("k8s-init", emptyAIs)
+			}
 			fileCount := len(kubeconfigPaths)
 			if fileCount == 0 && kubeconfigPath != "" {
 				fileCount = 1
@@ -246,7 +254,7 @@ func discoverKubeconfigs(dirs []string) ([]string, error) {
 			// Surface scan failures in the diagnostics snapshot so "my
 			// dropdown is empty" reports can tell permission/missing-dir
 			// apart from "dir was there but held no valid configs".
-			// Strip full paths from the error text via *fs.PathError so
+			// Strip full paths from the error text via *os.PathError so
 			// the snapshot stays shareable — just Op + underlying cause.
 			errorlog.Record("k8s-init", "warning",
 				"kubeconfig dir %q scan failed: %s",
@@ -285,13 +293,20 @@ func discoverKubeconfigs(dirs []string) ([]string, error) {
 // scrubPathError returns the underlying error cause (e.g. "permission denied",
 // "no such file or directory") without the filesystem path that produced it,
 // so errorlog entries derived from os.ReadDir / os.Open can safely ship in a
-// bug report. Non-PathError values fall through unchanged.
+// bug report. Errors that aren't an `*os.PathError` (or whose inner Err is
+// nil) are *not* passed through via err.Error() — their text may still
+// contain the originating path — so they collapse to a conservative
+// "unscrubbable" placeholder. The helper's entire point is the privacy
+// contract; a future caller adding a non-PathError must not silently leak.
 func scrubPathError(err error) string {
+	if err == nil {
+		return ""
+	}
 	var pErr *os.PathError
 	if errors.As(err, &pErr) && pErr.Err != nil {
 		return pErr.Op + ": " + pErr.Err.Error()
 	}
-	return err.Error()
+	return "(unscrubbable error — omitted to avoid leaking paths)"
 }
 
 // isValidKubeconfig checks if a file is a valid kubeconfig
@@ -357,9 +372,11 @@ type KubeconfigSummary struct {
 // diagnostics. All values are safe to include in a bug report.
 //
 // ExecPluginsPresent/Missing are computed lazily against the *current*
-// process PATH so the snapshot reflects what an in-flight context switch
-// would actually see — not the state at init time. This matters on the
-// desktop app where PATH may still be getting enriched.
+// process PATH at snapshot time (not init time) so a user who installs
+// `gke-gcloud-auth-plugin` (or similar) *after* launching Radar sees the
+// plugin move from "missing" to "present" in their next snapshot without
+// restarting — and a user whose PATH is smaller in a long-running session
+// still gets accurate data.
 func GetKubeconfigSummary() KubeconfigSummary {
 	clientMu.RLock()
 	mode := kubeconfigMode
@@ -395,36 +412,86 @@ func GetKubeconfigSummary() KubeconfigSummary {
 	}
 }
 
-// collectExecPluginCommands walks every context in raw and collects the
-// unique command basenames of any referenced AuthInfo that uses an exec
-// credential plugin. Basenames only — never full paths — so the result is
-// safe to surface in diagnostics. Orphan AuthInfos (not referenced by any
-// context) are intentionally skipped: they can't cause a context switch
-// to fail, so there's no signal in them. Must be called under clientMu.Lock
-// (or before any other goroutine has a reference to the package state).
-func collectExecPluginCommands(raw *clientcmdapi.Config) []string {
+// collectExecPluginCommands walks every context in raw and returns:
+//
+//   - cmds: the unique, sorted basenames of any exec plugin command
+//     referenced by a context's AuthInfo. Basenames only — never full
+//     paths — so the result is safe to surface in diagnostics.
+//   - emptyCommandAuthInfos: the unique, sorted names of AuthInfos that
+//     reference an exec block with an empty Command. This is a user
+//     misconfiguration that will fail at auth time — the caller should
+//     record each one via errorlog so it shows up in a bug report.
+//
+// Orphan AuthInfos (not referenced by any context) are intentionally
+// skipped: they can't cause a context switch to fail, so there's no
+// signal in them.
+//
+// The function is pure on its *clientcmdapi.Config argument and touches
+// no shared state, so it is safe to call without any lock held. Callers
+// are responsible for assigning the returned cmds slice to the package
+// global `execPluginCommands` under clientMu.Lock.
+func collectExecPluginCommands(raw *clientcmdapi.Config) (cmds []string, emptyCommandAuthInfos []string) {
 	if raw == nil {
-		return nil
+		return nil, nil
 	}
-	seen := make(map[string]struct{})
-	var out []string
+	seenCmds := make(map[string]struct{})
+	seenEmpty := make(map[string]struct{})
 	for _, ctx := range raw.Contexts {
 		if ctx == nil {
 			continue
 		}
 		ai, ok := raw.AuthInfos[ctx.AuthInfo]
-		if !ok || ai == nil || ai.Exec == nil || ai.Exec.Command == "" {
+		if !ok || ai == nil || ai.Exec == nil {
+			continue
+		}
+		if ai.Exec.Command == "" {
+			// Malformed exec block — surface via the second return
+			// so the caller can record a warning. Dedupe by AuthInfo
+			// name since the same AuthInfo may be referenced by
+			// multiple contexts.
+			if _, dup := seenEmpty[ctx.AuthInfo]; !dup {
+				seenEmpty[ctx.AuthInfo] = struct{}{}
+				emptyCommandAuthInfos = append(emptyCommandAuthInfos, ctx.AuthInfo)
+			}
 			continue
 		}
 		base := filepath.Base(ai.Exec.Command)
-		if _, dup := seen[base]; dup {
+		if _, dup := seenCmds[base]; dup {
 			continue
 		}
-		seen[base] = struct{}{}
-		out = append(out, base)
+		seenCmds[base] = struct{}{}
+		cmds = append(cmds, base)
 	}
-	sort.Strings(out)
-	return out
+	sort.Strings(cmds)
+	sort.Strings(emptyCommandAuthInfos)
+	return cmds, emptyCommandAuthInfos
+}
+
+// recordEmptyCommandWarning records a single aggregated errorlog entry for a
+// batch of AuthInfos that reference exec plugins with an empty Command. A
+// single errorlog call (rather than one-per-name) is deliberate — a
+// pathological or corrupted kubeconfig with hundreds of broken AuthInfos
+// would otherwise flood the 200-entry ring buffer and evict unrelated
+// diagnostics. Listing is capped at the first maxListed names so the
+// message text itself stays bounded; the count is always accurate.
+func recordEmptyCommandWarning(source string, authInfos []string) {
+	if len(authInfos) == 0 {
+		return
+	}
+	const maxListed = 10
+	listed := authInfos
+	truncated := false
+	if len(listed) > maxListed {
+		listed = listed[:maxListed]
+		truncated = true
+	}
+	suffix := ""
+	if truncated {
+		suffix = fmt.Sprintf(" (+%d more)", len(authInfos)-maxListed)
+	}
+	errorlog.Record(source, "warning",
+		"%d AuthInfo(s) reference exec plugins with empty command — context switches to these identities will fail at auth time: %v%s",
+		len(authInfos), listed, suffix)
 }
 
 // WriteKubeconfigForCurrentContext creates a temporary kubeconfig file with
@@ -668,7 +735,10 @@ func SwitchContext(name string) error {
 	}
 	// Re-collect exec plugin commands — SwitchContext loads a fresh RawConfig
 	// so the user may have added/removed kubeconfig files since init.
-	execCmds := collectExecPluginCommands(&rawConfig)
+	execCmds, emptyAIs := collectExecPluginCommands(&rawConfig)
+	if len(emptyAIs) > 0 {
+		recordEmptyCommandWarning("context-switch", emptyAIs)
+	}
 
 	clientMu.Lock()
 	k8sConfig = config

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -24,12 +24,19 @@ var (
 	initOnce          sync.Once
 	initErr           error
 	kubeconfigPath    string
-	kubeconfigPaths   []string // Multiple kubeconfig paths when using --kubeconfig-dir
+	kubeconfigPaths   []string // Multiple kubeconfig paths when using --kubeconfig-dir or KUBECONFIG env
+	kubeconfigMode    string   // One of: "in-cluster", "single", "multi-env", "multi-dir"
+	mergedContextCount int     // Number of contexts exposed after client-go merged all kubeconfig files
 	contextName       string
 	clusterName       string
 	contextNamespace  string // Default namespace from kubeconfig context
 	fallbackNamespace string // Explicit namespace from --namespace flag
 	contextUsesExec   bool   // True when the current context uses an exec credential plugin
+	// EnrichedKubeconfigFromShell is set by the desktop app's enrichEnv() when
+	// it successfully captured KUBECONFIG from the user's login shell. Surfaced
+	// in diagnostics so we can tell whether the GUI app's env was enriched or
+	// whether we fell back to whatever the parent process handed us.
+	EnrichedKubeconfigFromShell bool
 	// clientMu protects access to client variables during context switches.
 	// Readers use RLock, context switch uses Lock.
 	clientMu sync.RWMutex
@@ -76,6 +83,7 @@ func doInit(opts InitOptions) error {
 		if err == nil {
 			contextName = "in-cluster"
 			clusterName = "in-cluster"
+			kubeconfigMode = "in-cluster"
 		}
 	}
 
@@ -94,6 +102,7 @@ func doInit(opts InitOptions) error {
 			}
 			log.Printf("Discovered %d kubeconfig files from %d directories", len(configs), len(opts.KubeconfigDirs))
 			kubeconfigPaths = configs
+			kubeconfigMode = "multi-dir"
 			loadingRules = &clientcmd.ClientConfigLoadingRules{Precedence: configs}
 		} else {
 			// Single kubeconfig mode (existing behavior)
@@ -112,10 +121,12 @@ func doInit(opts InitOptions) error {
 			// Split and use Precedence when there are multiple entries.
 			if paths := filepath.SplitList(kubeconfig); len(paths) > 1 {
 				kubeconfigPaths = paths
+				kubeconfigMode = "multi-env"
 				loadingRules = &clientcmd.ClientConfigLoadingRules{Precedence: paths}
 				log.Printf("KUBECONFIG contains %d paths, using merged mode", len(paths))
 			} else {
 				kubeconfigPath = kubeconfig
+				kubeconfigMode = "single"
 				loadingRules = &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig}
 			}
 		}
@@ -127,6 +138,17 @@ func doInit(opts InitOptions) error {
 		rawConfig, err := kubeConfig.RawConfig()
 		if err == nil {
 			contextName = rawConfig.CurrentContext
+			mergedContextCount = len(rawConfig.Contexts)
+			fileCount := len(kubeconfigPaths)
+			if fileCount == 0 && kubeconfigPath != "" {
+				fileCount = 1
+			}
+			// Log the merged context count so multi-file collisions are visible.
+			// client-go silently drops later duplicates when merging by name, so
+			// this count is the "ground truth" of what the user can actually pick
+			// from the dropdown — not the sum of per-file contexts.
+			log.Printf("Kubeconfig loaded: mode=%s, files=%d, contexts=%d",
+				kubeconfigMode, fileCount, mergedContextCount)
 			if ctx, ok := rawConfig.Contexts[contextName]; ok {
 				clusterName = ctx.Cluster
 				contextNamespace = ctx.Namespace
@@ -247,6 +269,33 @@ func GetKubeconfigPath() string {
 	clientMu.RLock()
 	defer clientMu.RUnlock()
 	return kubeconfigPath
+}
+
+// KubeconfigSummary is a non-sensitive snapshot of kubeconfig loading state,
+// suitable for inclusion in diagnostic output. It never includes the resolved
+// paths themselves, only counts and mode flags.
+type KubeconfigSummary struct {
+	Mode              string // "in-cluster", "single", "multi-env", "multi-dir", or "" if not initialized
+	FileCount         int    // Number of kubeconfig files loaded (0 for in-cluster)
+	ContextCount      int    // Number of contexts exposed after client-go merged all files
+	EnrichedFromShell bool   // Desktop app captured KUBECONFIG from login shell
+}
+
+// GetKubeconfigSummary returns the current kubeconfig loading state for
+// diagnostics. All values are safe to include in a bug report.
+func GetKubeconfigSummary() KubeconfigSummary {
+	clientMu.RLock()
+	defer clientMu.RUnlock()
+	fileCount := len(kubeconfigPaths)
+	if fileCount == 0 && kubeconfigPath != "" {
+		fileCount = 1
+	}
+	return KubeconfigSummary{
+		Mode:              kubeconfigMode,
+		FileCount:         fileCount,
+		ContextCount:      mergedContextCount,
+		EnrichedFromShell: EnrichedKubeconfigFromShell,
+	}
 }
 
 // WriteKubeconfigForCurrentContext creates a temporary kubeconfig file with
@@ -498,6 +547,7 @@ func SwitchContext(name string) error {
 	clusterName = ctx.Cluster
 	contextNamespace = ctx.Namespace
 	contextUsesExec = usesExec
+	mergedContextCount = len(rawConfig.Contexts)
 	clientMu.Unlock()
 
 	return nil

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -1,0 +1,279 @@
+package k8s
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// newExecAuthInfo builds an AuthInfo that uses an exec credential plugin
+// with the given command. A helper because clientcmdapi.AuthInfo has a lot
+// of fields we don't care about and we want test tables to stay readable.
+func newExecAuthInfo(command string) *clientcmdapi.AuthInfo {
+	return &clientcmdapi.AuthInfo{
+		Exec: &clientcmdapi.ExecConfig{
+			Command: command,
+		},
+	}
+}
+
+func TestCollectExecPluginCommands(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         *clientcmdapi.Config
+		wantCmds       []string
+		wantEmptyAIs   []string
+	}{
+		{
+			name:   "nil config",
+			config: nil,
+		},
+		{
+			name:   "empty config",
+			config: clientcmdapi.NewConfig(),
+		},
+		{
+			name: "single context with simple exec plugin",
+			config: &clientcmdapi.Config{
+				Contexts: map[string]*clientcmdapi.Context{
+					"prod": {AuthInfo: "prod-user"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"prod-user": newExecAuthInfo("aws"),
+				},
+			},
+			wantCmds: []string{"aws"},
+		},
+		{
+			name: "full path is reduced to basename",
+			config: &clientcmdapi.Config{
+				Contexts: map[string]*clientcmdapi.Context{
+					"gke": {AuthInfo: "gke-user"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"gke-user": newExecAuthInfo("/usr/local/google-cloud-sdk/bin/gke-gcloud-auth-plugin"),
+				},
+			},
+			wantCmds: []string{"gke-gcloud-auth-plugin"},
+		},
+		{
+			name: "duplicate basenames across contexts are deduped",
+			config: &clientcmdapi.Config{
+				Contexts: map[string]*clientcmdapi.Context{
+					"gke-a": {AuthInfo: "gke-user-a"},
+					"gke-b": {AuthInfo: "gke-user-b"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"gke-user-a": newExecAuthInfo("/usr/local/google-cloud-sdk/bin/gke-gcloud-auth-plugin"),
+					"gke-user-b": newExecAuthInfo("gke-gcloud-auth-plugin"),
+				},
+			},
+			wantCmds: []string{"gke-gcloud-auth-plugin"},
+		},
+		{
+			name: "orphan AuthInfo (no context references it) is skipped",
+			config: &clientcmdapi.Config{
+				Contexts: map[string]*clientcmdapi.Context{
+					"prod": {AuthInfo: "prod-user"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"prod-user":   newExecAuthInfo("aws"),
+					"orphan-user": newExecAuthInfo("doctl"), // unused — must not appear in output
+				},
+			},
+			wantCmds: []string{"aws"},
+		},
+		{
+			name: "output is sorted lexicographically",
+			config: &clientcmdapi.Config{
+				Contexts: map[string]*clientcmdapi.Context{
+					"one":   {AuthInfo: "u1"},
+					"two":   {AuthInfo: "u2"},
+					"three": {AuthInfo: "u3"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"u1": newExecAuthInfo("kubelogin"),
+					"u2": newExecAuthInfo("aws"),
+					"u3": newExecAuthInfo("doctl"),
+				},
+			},
+			wantCmds: []string{"aws", "doctl", "kubelogin"},
+		},
+		{
+			name: "empty exec.Command is reported in emptyCommandAuthInfos",
+			config: &clientcmdapi.Config{
+				Contexts: map[string]*clientcmdapi.Context{
+					"broken": {AuthInfo: "broken-user"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"broken-user": newExecAuthInfo(""),
+				},
+			},
+			wantEmptyAIs: []string{"broken-user"},
+		},
+		{
+			name: "empty command deduped across multiple contexts",
+			config: &clientcmdapi.Config{
+				Contexts: map[string]*clientcmdapi.Context{
+					"broken-a": {AuthInfo: "broken-user"},
+					"broken-b": {AuthInfo: "broken-user"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"broken-user": newExecAuthInfo(""),
+				},
+			},
+			wantEmptyAIs: []string{"broken-user"},
+		},
+		{
+			name: "nil Exec block is skipped silently",
+			config: &clientcmdapi.Config{
+				Contexts: map[string]*clientcmdapi.Context{
+					"token-auth": {AuthInfo: "token-user"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"token-user": {Token: "abc"}, // no Exec block
+				},
+			},
+		},
+		{
+			name: "mixed: valid plugin + empty-command + orphan, all handled",
+			config: &clientcmdapi.Config{
+				Contexts: map[string]*clientcmdapi.Context{
+					"prod":   {AuthInfo: "prod-user"},
+					"broken": {AuthInfo: "broken-user"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"prod-user":   newExecAuthInfo("aws"),
+					"broken-user": newExecAuthInfo(""),
+					"orphan-user": newExecAuthInfo("doctl"),
+				},
+			},
+			wantCmds:     []string{"aws"},
+			wantEmptyAIs: []string{"broken-user"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmds, emptyAIs := collectExecPluginCommands(tt.config)
+			if !stringSlicesEqual(cmds, tt.wantCmds) {
+				t.Errorf("cmds = %v, want %v", cmds, tt.wantCmds)
+			}
+			if !stringSlicesEqual(emptyAIs, tt.wantEmptyAIs) {
+				t.Errorf("emptyCommandAuthInfos = %v, want %v", emptyAIs, tt.wantEmptyAIs)
+			}
+		})
+	}
+}
+
+func TestScrubPathError(t *testing.T) {
+	// Simulate the shape os.ReadDir returns: a *PathError with the path
+	// and an underlying syscall error. We want the path stripped and only
+	// the Op + underlying cause preserved.
+	directPathErr := &os.PathError{
+		Op:   "open",
+		Path: "/Users/alice/.kube/configs/prod.yaml",
+		Err:  os.ErrPermission,
+	}
+	wrappedPathErr := fmt.Errorf("load kubeconfig: %w", directPathErr)
+
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "nil error returns empty string",
+			err:  nil,
+			want: "",
+		},
+		{
+			name: "direct *os.PathError strips path and returns op + cause",
+			err:  directPathErr,
+			// The "permission denied" text comes from os.ErrPermission.Error().
+			// We assert via Contains below to avoid coupling to the exact
+			// stdlib phrasing, which varies by platform.
+			want: "open: ",
+		},
+		{
+			name: "wrapped via fmt.Errorf(%w, PathError) still unwraps",
+			err:  wrappedPathErr,
+			want: "open: ",
+		},
+		{
+			name: "non-PathError error collapses to conservative placeholder",
+			// errors.New text may itself contain what looks like a path —
+			// the helper must not pass it through.
+			err:  errors.New("open /Users/alice/secrets/token.key: denied"),
+			want: "(unscrubbable error — omitted to avoid leaking paths)",
+		},
+		{
+			name: "*os.PathError with nil inner Err collapses to placeholder",
+			err:  &os.PathError{Op: "stat", Path: "/home/bob", Err: nil},
+			want: "(unscrubbable error — omitted to avoid leaking paths)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := scrubPathError(tt.err)
+
+			// Case-specific checks:
+			// 1. The result must never contain an absolute-looking path from
+			//    any of our fixtures. This is the privacy contract.
+			for _, leak := range []string{
+				"/Users/alice/.kube/configs/prod.yaml",
+				"/Users/alice/secrets/token.key",
+				"/home/bob",
+			} {
+				if containsSubstring(got, leak) {
+					t.Errorf("scrubPathError leaked path %q in result %q", leak, got)
+				}
+			}
+
+			// 2. The returned string must contain the expected prefix/exact.
+			switch tt.name {
+			case "nil error returns empty string",
+				"non-PathError error collapses to conservative placeholder",
+				"*os.PathError with nil inner Err collapses to placeholder":
+				if got != tt.want {
+					t.Errorf("got %q, want %q", got, tt.want)
+				}
+			default:
+				if !containsSubstring(got, tt.want) {
+					t.Errorf("got %q, want it to contain %q", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+// stringSlicesEqual returns true if two slices contain the same elements in
+// the same order. Nil and empty slices are treated as equal so test cases
+// don't have to distinguish "no output" shapes.
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func containsSubstring(haystack, needle string) bool {
+	if needle == "" {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/k8s/context_manager.go
+++ b/internal/k8s/context_manager.go
@@ -237,8 +237,10 @@ func PerformContextSwitch(newContext string) error {
 	t = time.Now()
 	log.Printf("Switching K8s client to context %q...", newContext)
 	if err := SwitchContext(newContext); err != nil {
-		log.Printf("[ops] Context switch FAILED at SwitchContext: %v (%v)", err, time.Since(switchStart))
-		errorlog.Record("context-switch", "error", "SwitchContext failed (target=%q): %v", newContext, err)
+		elapsed := time.Since(switchStart).Truncate(time.Millisecond)
+		log.Printf("[ops] Context switch FAILED at SwitchContext: %v (%v)", err, elapsed)
+		errorlog.Record("context-switch", "error",
+			"stage=SwitchContext target=%q elapsed=%v: %v", newContext, elapsed, err)
 		return fmt.Errorf("failed to switch context: %w", err)
 	}
 	logTiming("   [ops] SwitchContext: %v", time.Since(t))
@@ -257,8 +259,10 @@ func PerformContextSwitch(newContext string) error {
 	connCtx, connCancel := NewOperationContext(ConnectionTestTimeout)
 	defer connCancel()
 	if err := TestClusterConnection(connCtx); err != nil {
-		log.Printf("[ops] Context switch FAILED at connectivity test: %v (%v since switch start)", err, time.Since(switchStart))
-		errorlog.Record("context-switch", "error", "connectivity test failed (target=%q): %v", newContext, err)
+		elapsed := time.Since(switchStart).Truncate(time.Millisecond)
+		log.Printf("[ops] Context switch FAILED at connectivity test: %v (%v since switch start)", err, elapsed)
+		errorlog.Record("context-switch", "error",
+			"stage=TestClusterConnection target=%q elapsed=%v: %v", newContext, elapsed, err)
 		return fmt.Errorf("cluster connection failed: %w", err)
 	}
 	log.Printf("[ops] Cluster connectivity verified (%v)", time.Since(t))
@@ -270,8 +274,10 @@ func PerformContextSwitch(newContext string) error {
 	initCtx, initCancel := NewOperationContext(ContextSwitchTimeout)
 	defer initCancel()
 	if err := InitAllSubsystems(initCtx, reportProgress); err != nil {
-		log.Printf("[ops] Context switch FAILED at subsystem init: %v (%v since switch start)", err, time.Since(switchStart))
-		errorlog.Record("context-switch", "error", "subsystem init failed (target=%q): %v", newContext, err)
+		elapsed := time.Since(switchStart).Truncate(time.Millisecond)
+		log.Printf("[ops] Context switch FAILED at subsystem init: %v (%v since switch start)", err, elapsed)
+		errorlog.Record("context-switch", "error",
+			"stage=InitAllSubsystems target=%q elapsed=%v: %v", newContext, elapsed, err)
 		return fmt.Errorf("subsystem init failed: %w", err)
 	}
 	logTiming("   [ops] InitAllSubsystems: %v", time.Since(t))

--- a/internal/k8s/context_manager.go
+++ b/internal/k8s/context_manager.go
@@ -9,6 +9,8 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	"github.com/skyhook-io/radar/internal/errorlog"
 )
 
 // ContextSwitchTimeout is the maximum time allowed for a context switch operation
@@ -236,6 +238,7 @@ func PerformContextSwitch(newContext string) error {
 	log.Printf("Switching K8s client to context %q...", newContext)
 	if err := SwitchContext(newContext); err != nil {
 		log.Printf("[ops] Context switch FAILED at SwitchContext: %v (%v)", err, time.Since(switchStart))
+		errorlog.Record("context-switch", "error", "SwitchContext failed (target=%q): %v", newContext, err)
 		return fmt.Errorf("failed to switch context: %w", err)
 	}
 	logTiming("   [ops] SwitchContext: %v", time.Since(t))
@@ -255,6 +258,7 @@ func PerformContextSwitch(newContext string) error {
 	defer connCancel()
 	if err := TestClusterConnection(connCtx); err != nil {
 		log.Printf("[ops] Context switch FAILED at connectivity test: %v (%v since switch start)", err, time.Since(switchStart))
+		errorlog.Record("context-switch", "error", "connectivity test failed (target=%q): %v", newContext, err)
 		return fmt.Errorf("cluster connection failed: %w", err)
 	}
 	log.Printf("[ops] Cluster connectivity verified (%v)", time.Since(t))
@@ -267,6 +271,7 @@ func PerformContextSwitch(newContext string) error {
 	defer initCancel()
 	if err := InitAllSubsystems(initCtx, reportProgress); err != nil {
 		log.Printf("[ops] Context switch FAILED at subsystem init: %v (%v since switch start)", err, time.Since(switchStart))
+		errorlog.Record("context-switch", "error", "subsystem init failed (target=%q): %v", newContext, err)
 		return fmt.Errorf("subsystem init failed: %w", err)
 	}
 	logTiming("   [ops] InitAllSubsystems: %v", time.Since(t))

--- a/internal/k8s/context_manager.go
+++ b/internal/k8s/context_manager.go
@@ -238,7 +238,7 @@ func PerformContextSwitch(newContext string) error {
 	log.Printf("Switching K8s client to context %q...", newContext)
 	if err := SwitchContext(newContext); err != nil {
 		elapsed := time.Since(switchStart).Truncate(time.Millisecond)
-		log.Printf("[ops] Context switch FAILED at SwitchContext: %v (%v)", err, elapsed)
+		log.Printf("[ops] Context switch FAILED at SwitchContext: %v (%v since switch start)", err, elapsed)
 		errorlog.Record("context-switch", "error",
 			"stage=SwitchContext target=%q elapsed=%v: %v", newContext, elapsed, err)
 		return fmt.Errorf("failed to switch context: %w", err)

--- a/internal/server/diagnostics.go
+++ b/internal/server/diagnostics.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/skyhook-io/radar/internal/errorlog"
 	"github.com/skyhook-io/radar/internal/k8s"
-	"github.com/skyhook-io/radar/pkg/k8score"
 	prometheuspkg "github.com/skyhook-io/radar/internal/prometheus"
 	"github.com/skyhook-io/radar/internal/timeline"
 	"github.com/skyhook-io/radar/internal/traffic"
 	"github.com/skyhook-io/radar/internal/version"
+	"github.com/skyhook-io/radar/pkg/k8score"
 )
 
 // DiagConfig holds sanitized configuration for the diagnostics endpoint.
@@ -40,24 +40,24 @@ type DiagnosticsSnapshot struct {
 	Uptime       string `json:"uptime"`
 	UptimeSec    int64  `json:"uptimeSec"`
 
-	Connection    *DiagConnection           `json:"connection,omitempty"`
-	Kubeconfig    *DiagKubeconfig           `json:"kubeconfig,omitempty"`
-	Cluster       *DiagCluster              `json:"cluster,omitempty"`
-	Cache         *DiagCache                `json:"cache,omitempty"`
-	Metrics       *k8s.MetricsCollectionHealth `json:"metrics,omitempty"`
-	Timeline      *DiagTimeline             `json:"timeline,omitempty"`
-	EventPipeline *DiagEventPipeline        `json:"eventPipeline,omitempty"`
-	Informers     *DiagInformers            `json:"informers,omitempty"`
-	Prometheus    *DiagPrometheus           `json:"prometheus,omitempty"`
-	Traffic       *DiagTraffic              `json:"traffic,omitempty"`
-	Permissions   *DiagPermissions          `json:"permissions,omitempty"`
-	APIDiscovery  *DiagAPIDiscovery         `json:"apiDiscovery,omitempty"`
-	SSE           *DiagSSE                  `json:"sse,omitempty"`
-	Runtime       *DiagRuntime              `json:"runtime,omitempty"`
-	Config        *DiagConfig               `json:"config,omitempty"`
-	RecentErrors       []errorlog.ErrorEntry `json:"recentErrors,omitempty"`
-	TotalErrorsRecorded int64                `json:"totalErrorsRecorded,omitempty"`
-	Errors        []string                  `json:"errors,omitempty"`
+	Connection          *DiagConnection              `json:"connection,omitempty"`
+	Kubeconfig          *DiagKubeconfig              `json:"kubeconfig,omitempty"`
+	Cluster             *DiagCluster                 `json:"cluster,omitempty"`
+	Cache               *DiagCache                   `json:"cache,omitempty"`
+	Metrics             *k8s.MetricsCollectionHealth `json:"metrics,omitempty"`
+	Timeline            *DiagTimeline                `json:"timeline,omitempty"`
+	EventPipeline       *DiagEventPipeline           `json:"eventPipeline,omitempty"`
+	Informers           *DiagInformers               `json:"informers,omitempty"`
+	Prometheus          *DiagPrometheus              `json:"prometheus,omitempty"`
+	Traffic             *DiagTraffic                 `json:"traffic,omitempty"`
+	Permissions         *DiagPermissions             `json:"permissions,omitempty"`
+	APIDiscovery        *DiagAPIDiscovery            `json:"apiDiscovery,omitempty"`
+	SSE                 *DiagSSE                     `json:"sse,omitempty"`
+	Runtime             *DiagRuntime                 `json:"runtime,omitempty"`
+	Config              *DiagConfig                  `json:"config,omitempty"`
+	RecentErrors        []errorlog.ErrorEntry        `json:"recentErrors,omitempty"`
+	TotalErrorsRecorded int64                        `json:"totalErrorsRecorded,omitempty"`
+	Errors              []string                     `json:"errors,omitempty"`
 }
 
 // DiagConnection holds connection state info.
@@ -70,15 +70,21 @@ type DiagConnection struct {
 }
 
 // DiagKubeconfig holds non-sensitive kubeconfig loading state. It never
-// includes resolved file paths — only counts and mode flags suitable for
-// inclusion in a public bug report. Helps triage issues like "some clusters
-// don't show up in the switcher" where the answer depends on whether we
-// loaded one file or many, and how many contexts survived the merge.
+// includes resolved file paths — only counts, mode flags, and exec plugin
+// command basenames suitable for inclusion in a public bug report. Helps
+// triage issues like "some clusters don't show up in the switcher" or
+// "can't switch clusters on the desktop app" (radar#411) — the answer
+// typically lives in one of: kubeconfig loading mode, context merge
+// collisions, shell env enrichment, or an exec auth plugin missing from
+// the desktop app's PATH.
 type DiagKubeconfig struct {
-	Mode              string `json:"mode"`              // in-cluster, single, multi-env, multi-dir
-	FileCount         int    `json:"fileCount"`         // Number of kubeconfig files loaded
-	ContextCount      int    `json:"contextCount"`      // Contexts exposed after client-go merge
-	EnrichedFromShell bool   `json:"enrichedFromShell"` // Desktop app captured KUBECONFIG from login shell
+	Mode                   string   `json:"mode"`                             // in-cluster, single, multi-env, multi-dir, or "" if not initialized
+	FileCount              int      `json:"fileCount"`                        // Number of kubeconfig files loaded
+	ContextCount           int      `json:"contextCount"`                     // Contexts exposed after client-go merge
+	EnrichedFromShell      bool     `json:"enrichedFromShell"`                // Desktop app captured KUBECONFIG from login shell
+	CurrentContextUsesExec bool     `json:"currentContextUsesExec"`           // Current context's AuthInfo uses an exec credential plugin
+	ExecPluginsPresent     []string `json:"execPluginsPresent,omitempty"`     // Exec plugin command basenames resolvable on $PATH
+	ExecPluginsMissing     []string `json:"execPluginsMissing,omitempty"`     // Exec plugin command basenames NOT resolvable on $PATH (smoking gun for desktop-app multi-cluster failures)
 }
 
 // DiagCluster holds cluster detection info.
@@ -108,11 +114,11 @@ type DiagTimeline struct {
 
 // DiagEventPipeline holds event pipeline metrics.
 type DiagEventPipeline struct {
-	Received    map[string]int64        `json:"received"`
-	Dropped     map[string]int64        `json:"dropped"`
-	Recorded    map[string]int64        `json:"recorded"`
-	RecentDrops []timeline.DropRecord   `json:"recentDrops"`
-	Uptime      string                  `json:"uptime"`
+	Received    map[string]int64      `json:"received"`
+	Dropped     map[string]int64      `json:"dropped"`
+	Recorded    map[string]int64      `json:"recorded"`
+	RecentDrops []timeline.DropRecord `json:"recentDrops"`
+	Uptime      string                `json:"uptime"`
 }
 
 // DiagInformers holds informer counts and sync status.
@@ -214,10 +220,13 @@ func (s *Server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
 	collectSafe("kubeconfig", &errs, func() {
 		summary := k8s.GetKubeconfigSummary()
 		snap.Kubeconfig = &DiagKubeconfig{
-			Mode:              summary.Mode,
-			FileCount:         summary.FileCount,
-			ContextCount:      summary.ContextCount,
-			EnrichedFromShell: summary.EnrichedFromShell,
+			Mode:                   summary.Mode,
+			FileCount:              summary.FileCount,
+			ContextCount:           summary.ContextCount,
+			EnrichedFromShell:      summary.EnrichedFromShell,
+			CurrentContextUsesExec: summary.CurrentContextUsesExec,
+			ExecPluginsPresent:     summary.ExecPluginsPresent,
+			ExecPluginsMissing:     summary.ExecPluginsMissing,
 		}
 	})
 

--- a/internal/server/diagnostics.go
+++ b/internal/server/diagnostics.go
@@ -41,6 +41,7 @@ type DiagnosticsSnapshot struct {
 	UptimeSec    int64  `json:"uptimeSec"`
 
 	Connection    *DiagConnection           `json:"connection,omitempty"`
+	Kubeconfig    *DiagKubeconfig           `json:"kubeconfig,omitempty"`
 	Cluster       *DiagCluster              `json:"cluster,omitempty"`
 	Cache         *DiagCache                `json:"cache,omitempty"`
 	Metrics       *k8s.MetricsCollectionHealth `json:"metrics,omitempty"`
@@ -66,6 +67,18 @@ type DiagConnection struct {
 	ClusterName string `json:"clusterName,omitempty"`
 	Error       string `json:"error,omitempty"`
 	ErrorType   string `json:"errorType,omitempty"`
+}
+
+// DiagKubeconfig holds non-sensitive kubeconfig loading state. It never
+// includes resolved file paths — only counts and mode flags suitable for
+// inclusion in a public bug report. Helps triage issues like "some clusters
+// don't show up in the switcher" where the answer depends on whether we
+// loaded one file or many, and how many contexts survived the merge.
+type DiagKubeconfig struct {
+	Mode              string `json:"mode"`              // in-cluster, single, multi-env, multi-dir
+	FileCount         int    `json:"fileCount"`         // Number of kubeconfig files loaded
+	ContextCount      int    `json:"contextCount"`      // Contexts exposed after client-go merge
+	EnrichedFromShell bool   `json:"enrichedFromShell"` // Desktop app captured KUBECONFIG from login shell
 }
 
 // DiagCluster holds cluster detection info.
@@ -194,6 +207,17 @@ func (s *Server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
 			ClusterName: status.ClusterName,
 			Error:       status.Error,
 			ErrorType:   status.ErrorType,
+		}
+	})
+
+	// Kubeconfig loading state — non-sensitive, always safe to include
+	collectSafe("kubeconfig", &errs, func() {
+		summary := k8s.GetKubeconfigSummary()
+		snap.Kubeconfig = &DiagKubeconfig{
+			Mode:              summary.Mode,
+			FileCount:         summary.FileCount,
+			ContextCount:      summary.ContextCount,
+			EnrichedFromShell: summary.EnrichedFromShell,
 		}
 	})
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2459,7 +2459,7 @@ export interface DiagnosticsSnapshot {
     errorType?: string
   }
   kubeconfig?: {
-    mode: string // in-cluster, single, multi-env, multi-dir
+    mode: '' | 'in-cluster' | 'single' | 'multi-env' | 'multi-dir'
     fileCount: number
     contextCount: number
     enrichedFromShell: boolean

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2458,6 +2458,12 @@ export interface DiagnosticsSnapshot {
     error?: string
     errorType?: string
   }
+  kubeconfig?: {
+    mode: string // in-cluster, single, multi-env, multi-dir
+    fileCount: number
+    contextCount: number
+    enrichedFromShell: boolean
+  }
   cluster?: {
     platform: string
     kubernetesVersion: string

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2463,6 +2463,9 @@ export interface DiagnosticsSnapshot {
     fileCount: number
     contextCount: number
     enrichedFromShell: boolean
+    currentContextUsesExec: boolean
+    execPluginsPresent?: string[]
+    execPluginsMissing?: string[]
   }
   cluster?: {
     platform: string

--- a/web/src/components/ui/DiagnosticsOverlay.tsx
+++ b/web/src/components/ui/DiagnosticsOverlay.tsx
@@ -207,12 +207,33 @@ function ConnectionSection({ data }: { data: DiagnosticsSnapshot }) {
 function KubeconfigSection({ data }: { data: DiagnosticsSnapshot }) {
   if (!data.kubeconfig) return null
   const k = data.kubeconfig
+  // Missing exec plugins are the single strongest signal for desktop-app
+  // multi-cluster failures (radar#411) — GUI apps often don't inherit the
+  // user's PATH, so aws/gcloud/doctl/kubelogin can be invisible even though
+  // the CLI works fine. Highlight the whole section when that's the case.
+  const missing = k.execPluginsMissing ?? []
+  const present = k.execPluginsPresent ?? []
+  const hasMissing = missing.length > 0
   return (
-    <Section title="Kubeconfig">
+    <Section title="Kubeconfig" warn={hasMissing}>
       <Row label="Mode" value={k.mode || '(not initialized)'} />
       <Row label="Files Loaded" value={k.fileCount} />
       <Row label="Contexts (post-merge)" value={k.contextCount} />
       <Row label="Enriched From Shell" value={k.enrichedFromShell ? 'Yes' : 'No'} />
+      <Row
+        label="Current Context Uses Exec"
+        value={k.currentContextUsesExec ? 'Yes' : 'No'}
+      />
+      {present.length > 0 && (
+        <Row label="Exec Plugins on PATH" value={present.join(', ')} />
+      )}
+      {hasMissing && (
+        <Row
+          label="Exec Plugins MISSING from PATH"
+          value={missing.join(', ')}
+          warn
+        />
+      )}
     </Section>
   )
 }
@@ -432,6 +453,13 @@ function formatForGitHub(data: DiagnosticsSnapshot, includeRawJson = true): stri
     const k = data.kubeconfig
     lines.push(`### Kubeconfig`)
     lines.push(`- Mode: \`${k.mode || '(not initialized)'}\` | Files: ${k.fileCount} | Contexts (post-merge): ${k.contextCount} | Enriched From Shell: ${k.enrichedFromShell ? 'Yes' : 'No'}`)
+    lines.push(`- Current Context Uses Exec: ${k.currentContextUsesExec ? 'Yes' : 'No'}`)
+    if (k.execPluginsPresent && k.execPluginsPresent.length > 0) {
+      lines.push(`- Exec Plugins on PATH: \`${k.execPluginsPresent.join('`, `')}\``)
+    }
+    if (k.execPluginsMissing && k.execPluginsMissing.length > 0) {
+      lines.push(`- **Exec Plugins MISSING from PATH:** \`${k.execPluginsMissing.join('`, `')}\``)
+    }
     lines.push(``)
   }
 

--- a/web/src/components/ui/DiagnosticsOverlay.tsx
+++ b/web/src/components/ui/DiagnosticsOverlay.tsx
@@ -106,6 +106,7 @@ export function DiagnosticsOverlay({ onClose, isOpen = true }: DiagnosticsOverla
             <>
               <ErrorLogSection data={data} />
               <ConnectionSection data={data} />
+              <KubeconfigSection data={data} />
               <ClusterSection data={data} />
               <CacheSection data={data} />
               <MetricsSection data={data} />
@@ -199,6 +200,19 @@ function ConnectionSection({ data }: { data: DiagnosticsSnapshot }) {
       {c.clusterName && <Row label="Cluster" value={c.clusterName} />}
       {c.error && <Row label="Error" value={c.error} warn />}
       {c.errorType && <Row label="Error Type" value={c.errorType} warn />}
+    </Section>
+  )
+}
+
+function KubeconfigSection({ data }: { data: DiagnosticsSnapshot }) {
+  if (!data.kubeconfig) return null
+  const k = data.kubeconfig
+  return (
+    <Section title="Kubeconfig">
+      <Row label="Mode" value={k.mode || '(not initialized)'} />
+      <Row label="Files Loaded" value={k.fileCount} />
+      <Row label="Contexts (post-merge)" value={k.contextCount} />
+      <Row label="Enriched From Shell" value={k.enrichedFromShell ? 'Yes' : 'No'} />
     </Section>
   )
 }
@@ -411,6 +425,13 @@ function formatForGitHub(data: DiagnosticsSnapshot, includeRawJson = true): stri
     if (c.clusterName) lines.push(`- Cluster: \`${c.clusterName}\``)
     if (c.error) lines.push(`- Error: ${c.error}`)
     if (c.errorType) lines.push(`- Error Type: \`${c.errorType}\``)
+    lines.push(``)
+  }
+
+  if (data.kubeconfig) {
+    const k = data.kubeconfig
+    lines.push(`### Kubeconfig`)
+    lines.push(`- Mode: \`${k.mode || '(not initialized)'}\` | Files: ${k.fileCount} | Contexts (post-merge): ${k.contextCount} | Enriched From Shell: ${k.enrichedFromShell ? 'Yes' : 'No'}`)
     lines.push(``)
   }
 


### PR DESCRIPTION
## Summary

Multi-kubeconfig bugs (specifically skyhook-io/radar#411) were hard to triage from pasted bug reports: the diagnostics snapshot deliberately strips kubeconfig paths, and none of the context-switch failure paths routed through `errorlog`, so `recentErrors` never captured them either. A user reporting "can't switch clusters" was giving us their K8s version and nothing about which of several possible failure modes was actually in play.

This PR adds the minimum non-sensitive signal needed to distinguish those failure modes from a copy-pasted diagnostics snapshot, without exposing any paths.

## Changes

### Mode + merge counts (initial commit)

- **`internal/k8s/client.go`** — track `kubeconfigMode` (`in-cluster` / `single` / `multi-env` / `multi-dir`), `mergedContextCount` (count *after* client-go merges multi-file configs — so silent context-name collisions become visible), and an `EnrichedKubeconfigFromShell` flag for the desktop app. Exposed via `GetKubeconfigSummary()`.
- **`internal/k8s/context_manager.go`** — the three `PerformContextSwitch` failure sites now call `errorlog.Record("context-switch", ...)` alongside the existing `log.Printf`, so they land in the diagnostics snapshot's `recentErrors` instead of only in stderr/unified log.
- **`cmd/desktop/env.go`** — `enrichEnv()` now sets `EnrichedKubeconfigFromShell = true` on success and logs + records an `errorlog` warning on skip, distinguishing "already set in process env" (probably `launchctl setenv`) from "not found in login shell".
- **`internal/server/diagnostics.go`** — new `DiagKubeconfig` section on the snapshot.
- **`web/`** — matching TS type, new `KubeconfigSection` in `DiagnosticsOverlay.tsx`, and a `### Kubeconfig` block in `formatForGitHub()`.

### Exec-plugin PATH signal + errorlog holes (second commit)

The biggest remaining gap after the first commit was that the #1 cause of desktop-app multi-cluster failures — an exec credential plugin (`aws`, `gke-gcloud-auth-plugin`, `doctl`, `kubelogin`) not on the GUI app's PATH — had no signal at all. This commit adds that and closes a few adjacent errorlog holes.

- **`internal/k8s/client.go`** — `collectExecPluginCommands` walks every context's AuthInfo at init time (and on `SwitchContext`), collecting unique command **basenames** from any exec plugin referenced. `GetKubeconfigSummary()` runs `exec.LookPath` against the **current** process PATH at snapshot time (not init time — desktop PATH may still be getting enriched) and returns `currentContextUsesExec` / `execPluginsPresent` / `execPluginsMissing`. Basenames only — never full paths.
- **`internal/k8s/client.go`** — four new `errorlog.Record("k8s-init", ...)` sites:
  - `discoverKubeconfigs` per-directory scan failure
  - `discoverKubeconfigs` per-file "skipping invalid kubeconfig"
  - `ClientConfig()` build failure
  - `RawConfig()` metadata-load failure
  A new `scrubPathError` helper unwraps `*os.PathError` so the recorded text never contains full filesystem paths — just the op + underlying cause.
- **`internal/k8s/context_manager.go`** — the three context-switch failure sites now prefix with `stage=X target=Q elapsed=Xms` so a triager can see which stage died and how far the switch got.
- **`internal/k8s/client.go`** — `SetEnrichedKubeconfigFromShell` helper that takes `clientMu`; the previous direct write was the only access to package-level state that skipped the lock.
- **`cmd/desktop/env.go`** — `filepath.Base(\$SHELL)` so users with a custom shell under `\$HOME/nix-profile/...` don't leak their username in bug reports.
- **`web/`** — KubeconfigSection renders `execPluginsMissing` with warn styling (whole section turns yellow) and the markdown exporter bolds missing plugins so they stand out in a pasted issue body.

## Triage value for skyhook-io/radar#411

A fresh diagnostics snapshot now distinguishes the leading theories for the "can't switch clusters with multiple kubeconfig files" report on its own:

| Snapshot signal | Root cause |
|---|---|
| `execPluginsMissing: ["gke-gcloud-auth-plugin"]` (or aws / doctl / kubelogin) | GUI app's PATH is missing the exec plugin binary — the most common cause |
| `mode: single`, `enrichedFromShell: false` on desktop | `enrichEnv()` skipped — KUBECONFIG pre-set by `launchctl`/parent shell (warning in `recentErrors` explains which) |
| `mode: multi-env` with `fileCount: N`, `contextCount` lower than expected | client-go dropped duplicate context names during merge |
| `[context-switch] stage=TestClusterConnection ... elapsed=30s: context deadline exceeded` | Reachability, not auth |
| `[k8s-init] skipping invalid kubeconfig file ...` | One of the user's files is broken |
| Healthy counts + a `[context-switch]` entry in `recentErrors` | Tells us which stage failed and the underlying error |