### PR TITLE
Move Port Forwards to top-bar indicator + persistent panel (#451)

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesSidebar.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useRef, forwardRef } from 'react'
+import { useState, useMemo, useEffect, useRef, useCallback, forwardRef } from 'react'
 import {
   Search,
   ChevronDown,
@@ -44,6 +44,9 @@ export interface ResourcesSidebarProps {
   onNavigate?: (path: string) => void
   /** Base path for generating navigation URLs (e.g., '/org/clusters/id/k8s-resources') */
   basePath?: string
+  /** Called when a kind is selected via keyboard (Enter in the filter). Parent uses this
+   *  to move focus to the next UI level (e.g., the table search input). */
+  onKindNavigated?: () => void
 }
 
 // Persisted across remounts so collapsed categories survive tab switches
@@ -93,6 +96,8 @@ interface ResourceTypeButtonProps {
   resource: APIResource
   count: number
   isSelected: boolean
+  /** Keyboard-highlight state (arrow nav in the filter input). */
+  isHighlighted?: boolean
   isForbidden?: boolean
   isPinned?: boolean
   onTogglePin?: () => void
@@ -100,7 +105,7 @@ interface ResourceTypeButtonProps {
 }
 
 const ResourceTypeButton = forwardRef<HTMLButtonElement, ResourceTypeButtonProps>(
-  function ResourceTypeButton({ resource, count, isSelected, isForbidden: forbidden, isPinned, onTogglePin, onClick }, ref) {
+  function ResourceTypeButton({ resource, count, isSelected, isHighlighted, isForbidden: forbidden, isPinned, onTogglePin, onClick }, ref) {
     const Icon = getResourceIcon(resource.kind)
     return (
       <button
@@ -110,9 +115,11 @@ const ResourceTypeButton = forwardRef<HTMLButtonElement, ResourceTypeButtonProps
           'w-full flex items-center gap-2 px-2 xl:px-3 py-1.5 rounded-lg text-sm transition-colors group/kind min-w-0',
           isSelected
             ? 'selection-strong selection-text'
-            : forbidden
-              ? 'text-theme-text-disabled hover:bg-theme-elevated hover:text-theme-text-secondary'
-              : 'text-theme-text-secondary hover:bg-theme-elevated hover:text-theme-text-primary'
+            : isHighlighted
+              ? 'bg-theme-hover text-theme-text-primary'
+              : forbidden
+                ? 'text-theme-text-disabled hover:bg-theme-elevated hover:text-theme-text-secondary'
+                : 'text-theme-text-secondary hover:bg-theme-elevated hover:text-theme-text-primary'
         )}
       >
         <Icon className="w-4 h-4 shrink-0" />
@@ -172,6 +179,7 @@ export function ResourcesSidebar({
   className,
   onNavigate,
   basePath,
+  onKindNavigated,
 }: ResourcesSidebarProps) {
   // Wraps kind selection to also navigate when basePath/onNavigate are provided
   const selectKind = (kind: SelectedKindInfo) => {
@@ -194,6 +202,15 @@ export function ResourcesSidebar({
 
   // Ref to selected sidebar item for scrolling into view on deeplink
   const selectedSidebarRef = useRef<HTMLButtonElement>(null)
+
+  // Ref to kind search input — auto-focused on mount so users can type a kind name immediately
+  const kindSearchRef = useRef<HTMLInputElement>(null)
+  useEffect(() => {
+    // Only focus on fine-pointer devices to avoid popping up the virtual keyboard on touch
+    if (typeof window !== 'undefined' && window.matchMedia('(pointer: fine)').matches) {
+      kindSearchRef.current?.focus()
+    }
+  }, [])
 
   // Effective selected kind — fall back to a safe default
   const effectiveSelectedKind = selectedKind ?? { name: 'pods', kind: 'Pod', group: '' }
@@ -335,6 +352,69 @@ export function ResourcesSidebar({
     })
   }
 
+  // --- Keyboard navigation ---
+  // Flat list of all navigable kinds in the order they appear in the sidebar.
+  const flatVisibleKinds = useMemo<SelectedKindInfo[]>(() => {
+    const kinds: SelectedKindInfo[] = []
+    if (favoritesExpanded) {
+      for (const p of pinned) {
+        kinds.push({ name: p.name, kind: p.kind, group: p.group })
+      }
+    }
+    if (filteredCategories) {
+      for (const cat of filteredCategories) {
+        if (effectiveExpandedCategories.has(cat.name)) {
+          for (const r of cat.visibleResources) {
+            kinds.push({ name: r.name, kind: r.kind, group: r.group })
+          }
+        }
+      }
+    }
+    return kinds
+  }, [favoritesExpanded, pinned, filteredCategories, effectiveExpandedCategories])
+
+  const [highlightedIndex, setHighlightedIndex] = useState(-1)
+  // Reset highlight when the filter or kind list changes
+  useEffect(() => {
+    setHighlightedIndex(kindFilter ? 0 : -1)
+  }, [kindFilter]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const highlightedKind = highlightedIndex >= 0 && highlightedIndex < flatVisibleKinds.length
+    ? flatVisibleKinds[highlightedIndex]
+    : null
+
+  // Scroll the highlighted kind button into view
+  const highlightedRef = useRef<HTMLButtonElement>(null)
+  useEffect(() => {
+    if (highlightedRef.current) {
+      highlightedRef.current.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+    }
+  }, [highlightedIndex])
+
+  const handleSearchKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Escape') {
+      setKindFilter('')
+      setHighlightedIndex(-1)
+      ;(e.target as HTMLInputElement).blur()
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setHighlightedIndex(prev => Math.min(prev + 1, flatVisibleKinds.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setHighlightedIndex(prev => Math.max(prev - 1, 0))
+    } else if (e.key === 'Enter' && highlightedKind) {
+      e.preventDefault()
+      selectKind(highlightedKind)
+      setHighlightedIndex(-1)
+      setKindFilter('')
+      onKindNavigated?.()
+    }
+  }, [flatVisibleKinds.length, highlightedKind, selectKind, onKindNavigated]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const isKindHighlighted = useCallback((name: string, group: string) => {
+    return highlightedKind?.name === name && highlightedKind?.group === group
+  }, [highlightedKind])
+
   // Scroll sidebar to show selected kind on mount (deep linking) and on kind changes (keyboard nav)
   const lastScrolledKind = useRef<string | null>(null)
   const isInitialScroll = useRef(true)
@@ -362,11 +442,12 @@ export function ResourcesSidebar({
         <div className="relative">
           <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-theme-text-tertiary" />
           <input
+            ref={kindSearchRef}
             type="text"
             placeholder="Filter resources..."
             value={kindFilter}
             onChange={(e) => setKindFilter(e.target.value)}
-            onKeyDown={(e) => { if (e.key === 'Escape') { setKindFilter(''); (e.target as HTMLInputElement).blur() } }}
+            onKeyDown={handleSearchKeyDown}
             className="w-full pl-7 pr-7 py-2 bg-theme-elevated border border-theme-border-light rounded-lg text-sm text-theme-text-primary placeholder-theme-text-disabled focus:outline-none focus:ring-2 focus:ring-skyhook-500"
           />
           {kindFilter && (
@@ -398,34 +479,41 @@ export function ResourcesSidebar({
               </span>
             )}
           </button>
-          {favoritesExpanded && (
-            <div className="space-y-0.5">
-              {pinned.length === 0 ? (
-                <div className="px-3 py-2 text-xs text-theme-text-disabled">
-                  No pinned resources. Click <Pin className="w-3 h-3 inline" /> on any resource type to pin it here.
-                </div>
-              ) : (
-                pinned.map((p) => {
-                  const isResourceSelected =
-                    (effectiveSelectedKind.name === p.name && effectiveSelectedKind.group === p.group) ||
-                    (effectiveSelectedKind.kind.toLowerCase() === p.kind.toLowerCase() && effectiveSelectedKind.group === p.group)
-                  return (
-                    <ResourceTypeButton
-                      key={`${p.name}-${p.group}`}
-                      ref={isResourceSelected ? selectedSidebarRef : null}
-                      resource={{ name: p.name, kind: p.kind, group: p.group, version: '', namespaced: true, isCrd: false, verbs: [] }}
-                      count={counts?.[(p.group ? `${p.group}/${p.kind}` : p.kind)] ?? 0}
-                      isSelected={isResourceSelected}
-                      isForbidden={forbiddenKinds.has(p.group ? `${p.group}/${p.kind}` : p.kind)}
-                      isPinned={true}
-                      onTogglePin={() => togglePin(p)}
-                      onClick={() => selectKind({ name: p.name, kind: p.kind, group: p.group })}
-                    />
-                  )
-                })
-              )}
+          <div className={clsx(
+            'grid transition-[grid-template-rows] duration-200',
+            favoritesExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+          )} style={{ transitionTimingFunction: 'cubic-bezier(0.16, 1, 0.3, 1)' }}>
+            <div className="overflow-hidden">
+              <div className="space-y-0.5">
+                {pinned.length === 0 ? (
+                  <div className="px-3 py-2 text-xs text-theme-text-disabled">
+                    No pinned resources. Click <Pin className="w-3 h-3 inline" /> on any resource type to pin it here.
+                  </div>
+                ) : (
+                  pinned.map((p) => {
+                    const isResourceSelected =
+                      (effectiveSelectedKind.name === p.name && effectiveSelectedKind.group === p.group) ||
+                      (effectiveSelectedKind.kind.toLowerCase() === p.kind.toLowerCase() && effectiveSelectedKind.group === p.group)
+                    const highlighted = isKindHighlighted(p.name, p.group)
+                    return (
+                      <ResourceTypeButton
+                        key={`${p.name}-${p.group}`}
+                        ref={highlighted ? highlightedRef : (isResourceSelected ? selectedSidebarRef : null)}
+                        resource={{ name: p.name, kind: p.kind, group: p.group, version: '', namespaced: true, isCrd: false, verbs: [] }}
+                        count={counts?.[(p.group ? `${p.group}/${p.kind}` : p.kind)] ?? 0}
+                        isSelected={isResourceSelected}
+                        isHighlighted={highlighted}
+                        isForbidden={forbiddenKinds.has(p.group ? `${p.group}/${p.kind}` : p.kind)}
+                        isPinned={true}
+                        onTogglePin={() => togglePin(p)}
+                        onClick={() => selectKind({ name: p.name, kind: p.kind, group: p.group })}
+                      />
+                    )
+                  })
+                )}
+              </div>
             </div>
-          )}
+          </div>
         </div>
         {filteredCategories ? (
           // Dynamic categories from API
@@ -449,31 +537,38 @@ export function ResourcesSidebar({
                     </span>
                   )}
                 </button>
-                {isExpanded && (
-                  <div className="space-y-0.5">
-                    {category.visibleResources.map((resource) => {
-                      const resourceIsPinned = isPinned(resource.name, resource.group)
-                      const isResourceSelected =
-                        (effectiveSelectedKind.name === resource.name && effectiveSelectedKind.group === resource.group) ||
-                        (effectiveSelectedKind.kind.toLowerCase() === resource.kind.toLowerCase() && effectiveSelectedKind.group === resource.group)
-                      // If the resource is pinned, let the Favorites section own the highlight
-                      const showSelected = isResourceSelected && !resourceIsPinned
-                      return (
-                      <ResourceTypeButton
-                        key={resource.name}
-                        ref={isResourceSelected ? selectedSidebarRef : null}
-                        resource={resource}
-                        count={counts?.[(resource.group ? `${resource.group}/${resource.kind}` : resource.kind)] ?? 0}
-                        isSelected={showSelected}
-                        isForbidden={forbiddenKinds.has(resource.group ? `${resource.group}/${resource.kind}` : resource.kind)}
-                        isPinned={resourceIsPinned}
-                        onTogglePin={() => togglePin({ name: resource.name, kind: resource.kind, group: resource.group })}
-                        onClick={() => selectKind({ name: resource.name, kind: resource.kind, group: resource.group })}
-                      />
-                      )
-                    })}
+                <div className={clsx(
+                  'grid transition-[grid-template-rows] duration-200',
+                  isExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+                )} style={{ transitionTimingFunction: 'cubic-bezier(0.16, 1, 0.3, 1)' }}>
+                  <div className="overflow-hidden">
+                    <div className="space-y-0.5">
+                      {category.visibleResources.map((resource) => {
+                        const resourceIsPinned = isPinned(resource.name, resource.group)
+                        const isResourceSelected =
+                          (effectiveSelectedKind.name === resource.name && effectiveSelectedKind.group === resource.group) ||
+                          (effectiveSelectedKind.kind.toLowerCase() === resource.kind.toLowerCase() && effectiveSelectedKind.group === resource.group)
+                        // If the resource is pinned, let the Favorites section own the highlight
+                        const showSelected = isResourceSelected && !resourceIsPinned
+                        const highlighted = isKindHighlighted(resource.name, resource.group)
+                        return (
+                        <ResourceTypeButton
+                          key={resource.name}
+                          ref={highlighted ? highlightedRef : (isResourceSelected ? selectedSidebarRef : null)}
+                          resource={resource}
+                          count={counts?.[(resource.group ? `${resource.group}/${resource.kind}` : resource.kind)] ?? 0}
+                          isSelected={showSelected}
+                          isHighlighted={highlighted}
+                          isForbidden={forbiddenKinds.has(resource.group ? `${resource.group}/${resource.kind}` : resource.kind)}
+                          isPinned={resourceIsPinned}
+                          onTogglePin={() => togglePin({ name: resource.name, kind: resource.kind, group: resource.group })}
+                          onClick={() => selectKind({ name: resource.name, kind: resource.kind, group: resource.group })}
+                        />
+                        )
+                      })}
+                    </div>
                   </div>
-                )}
+                </div>
               </div>
             )
           })

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -2938,6 +2938,11 @@ export function ResourcesView({
           pinned={pinned}
           togglePin={togglePin}
           isPinned={isPinned}
+          onKindNavigated={() => {
+            // After selecting a kind via keyboard, move focus to the table search
+            // so the user can immediately filter within the selected kind.
+            setTimeout(() => searchInputRef.current?.focus(), 50)
+          }}
         />
       )}
 
@@ -2953,6 +2958,30 @@ export function ResourcesView({
               placeholder="Search... (press /)"
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'ArrowDown') {
+                  // Hand off to the table's keyboard navigation — blur the input
+                  // so the registered ArrowDown/j/k shortcuts take over, and
+                  // highlight the first row.
+                  e.preventDefault()
+                  searchInputRef.current?.blur()
+                  setHighlightedIndex(0)
+                } else if (e.key === 'Enter' && filteredResourceCountRef.current > 0) {
+                  // Select the first (or currently highlighted) resource
+                  e.preventDefault()
+                  searchInputRef.current?.blur()
+                  if (highlightedIndex < 0) setHighlightedIndex(0)
+                  // Defer to next frame so the highlight renders before we open
+                  requestAnimationFrame(() => {
+                    const res = highlightedResourceRef.current ?? filteredResources[0]
+                    if (res?.metadata?.name) {
+                      onResourceClick?.({ kind: selectedKind.name, namespace: res.metadata.namespace || '', name: res.metadata.name, group: selectedKind.group })
+                    }
+                  })
+                } else if (e.key === 'Escape') {
+                  searchInputRef.current?.blur()
+                }
+              }}
               className="w-full max-w-md pl-10 pr-4 py-2 bg-theme-elevated border border-theme-border-light rounded-lg text-sm text-theme-text-primary placeholder-theme-text-disabled focus:outline-none focus:ring-2 focus:ring-skyhook-500"
             />
           </div>

--- a/packages/k8s-ui/src/components/ui/Tooltip.tsx
+++ b/packages/k8s-ui/src/components/ui/Tooltip.tsx
@@ -109,6 +109,22 @@ export function Tooltip({
     }
   }, [])
 
+  // When disabled flips true, proactively cancel any pending show timer and
+  // clear visible state. Without this, a tooltip that was visible (or armed)
+  // when disabled became true would pop back on as soon as disabled flips
+  // false — even though the cursor is elsewhere and no fresh mouseenter has
+  // fired. Also covers the case where the trigger becomes unreachable via
+  // pointer-events-none and never fires mouseleave.
+  useEffect(() => {
+    if (disabled) {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+        timeoutRef.current = null
+      }
+      setIsVisible(false)
+    }
+  }, [disabled])
+
   if (disabled || !content) {
     return <>{children}</>
   }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,7 +16,7 @@ import { TrafficView } from './components/traffic/TrafficView'
 import { CostView } from './components/cost/CostView'
 import { AuditView } from './components/audit/AuditView'
 import { HelmReleaseDrawer } from './components/helm/HelmReleaseDrawer'
-import { PortForwardManager, usePortForwardCount } from './components/portforward/PortForwardManager'
+import { PortForwardProvider, PortForwardIndicator, PortForwardPanel } from './components/portforward/PortForwardManager'
 import { DockProvider, BottomDock, useDock, useOpenLocalTerminal } from './components/dock'
 import { DURATION_DOCK } from '@skyhook-io/k8s-ui/utils/animation'
 import { ContextSwitcher } from './components/ContextSwitcher'
@@ -36,7 +36,7 @@ import { useNamespaces, useSwitchContext, useAuthMe, setAuthQueryClient } from '
 import { KeyboardShortcutProvider, useRegisterShortcut, useRegisterShortcuts } from './hooks/useKeyboardShortcuts'
 import { useAnimatedUnmount } from './hooks/useAnimatedUnmount'
 import { Loader2 } from 'lucide-react'
-import { RefreshCw, Network, List, Clock, Package, Sun, Moon, Activity, Home, Star, Search, Bug, Settings, SquareTerminal } from 'lucide-react'
+import { RefreshCw, Network, List, Clock, Package, Sun, Moon, Activity, Home, Star, Search, Bug, Settings, SquareTerminal, ShieldCheck } from 'lucide-react'
 import { useTheme } from './context/ThemeContext'
 import { Tooltip } from './components/ui/Tooltip'
 import { LargeClusterNamespacePicker } from './components/shared/LargeClusterNamespacePicker'
@@ -716,6 +716,7 @@ function AppInner() {
   }, [])
 
   return (
+    <PortForwardProvider>
     <div className="flex flex-col h-screen bg-theme-base min-w-[800px]">
       {/* Header */}
       <header className="relative z-50 flex items-center justify-between px-4 py-2 bg-theme-base/90 backdrop-blur-sm border-b border-theme-border/50">
@@ -769,6 +770,8 @@ function AppInner() {
                 </button>
               )}
             </div>
+            {/* Port forwards indicator — shown only when sessions exist */}
+            <PortForwardIndicator />
           </div>
         </div>
 
@@ -781,18 +784,22 @@ function AppInner() {
             { view: 'timeline' as const, icon: Clock, label: 'Timeline' },
             { view: 'helm' as const, icon: Package, label: 'Helm' },
             { view: 'traffic' as const, icon: Activity, label: 'Traffic' },
+            // Cost is intentionally hidden from the pill bar for now — the view still
+            // exists and is reachable via /cost, the Home dashboard card, and the
+            // command palette (⌘K). Remove this comment to restore it.
+            { view: 'audit' as const, icon: ShieldCheck, label: 'Audit' },
           ] as const).map(({ view, icon: Icon, label }) => (
             <Tooltip key={view} content={label} delay={100} position="bottom">
               <button
                 onClick={() => setMainView(view)}
-                className={`flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-full transition-colors ${
+                className={`flex items-center gap-1.5 px-2.5 py-1.5 text-sm rounded-full transition-colors ${
                   mainView === view
                     ? 'bg-skyhook-600 dark:bg-skyhook-500 text-white shadow-glow-brand-sm'
                     : 'text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-hover'
                 }`}
               >
                 <Icon className="w-4 h-4" />
-                <span className="hidden lg:inline">{label}</span>
+                <span className="hidden xl:inline">{label}</span>
               </button>
             </Tooltip>
           ))}
@@ -1198,8 +1205,8 @@ function AppInner() {
         />
       )}
 
-      {/* Port Forward Manager */}
-      <PortForwardManagerWrapper />
+      {/* Port Forward floating panel (indicator lives in header) */}
+      <PortForwardPanel />
 
       {/* Update notification */}
       <UpdateNotification />
@@ -1233,6 +1240,11 @@ function AppInner() {
               else params.delete('apiGroup')
               params.delete('resource')
               navigate({ pathname: `/resources/${kind}`, search: params.toString() })
+              // Focus the table search after navigation — the user came from ⌘K
+              // (keyboard flow) and expects to type a resource name immediately.
+              setTimeout(() => {
+                (document.querySelector('input[placeholder="Search... (press /)"]') as HTMLInputElement)?.focus()
+              }, 100)
             }
           }}
           onSwitchContext={(name) => switchContext.mutate({ name })}
@@ -1258,6 +1270,7 @@ function AppInner() {
             if (pendingKindNav.group) params.set('apiGroup', pendingKindNav.group)
             navigate({ pathname: `/resources/${pendingKindNav.kind}`, search: params.toString() })
             setPendingKindNav(null)
+            setTimeout(() => { (document.querySelector('input[placeholder="Search... (press /)"]') as HTMLInputElement)?.focus() }, 100)
           }}
           onKeep={() => {
             const params = new URLSearchParams(searchParams)
@@ -1267,6 +1280,7 @@ function AppInner() {
             params.delete('resource')
             navigate({ pathname: `/resources/${pendingKindNav.kind}`, search: params.toString() })
             setPendingKindNav(null)
+            setTimeout(() => { (document.querySelector('input[placeholder="Search... (press /)"]') as HTMLInputElement)?.focus() }, 100)
           }}
           onClose={() => setPendingKindNav(null)}
         />
@@ -1275,6 +1289,7 @@ function AppInner() {
       {/* Debug overlay - only in dev mode */}
       {import.meta.env.DEV && <DebugOverlay />}
     </div>
+    </PortForwardProvider>
   )
 }
 
@@ -1550,21 +1565,6 @@ function ThemeToggle() {
         <Moon className="w-4 h-4" />
       )}
     </button>
-  )
-}
-
-// Wrapper component that conditionally renders PortForwardManager
-function PortForwardManagerWrapper() {
-  const [minimized, setMinimized] = useState(false)
-  const count = usePortForwardCount()
-
-  if (count === 0) return null
-
-  return (
-    <PortForwardManager
-      minimized={minimized}
-      onToggleMinimize={() => setMinimized(!minimized)}
-    />
   )
 }
 

--- a/web/src/components/portforward/PortForwardManager.tsx
+++ b/web/src/components/portforward/PortForwardManager.tsx
@@ -1,14 +1,20 @@
-import { useState, useCallback } from 'react'
+import {
+  useState,
+  useCallback,
+  useRef,
+  useEffect,
+  useLayoutEffect,
+  createContext,
+  useContext,
+  type ReactNode,
+} from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
-  X,
   ExternalLink,
   Copy,
   Check,
   Trash2,
-  Radio,
   Loader2,
-  ChevronDown,
   ChevronUp,
   Plug,
   Globe,
@@ -16,9 +22,15 @@ import {
   PenLine,
 } from 'lucide-react'
 import { clsx } from 'clsx'
+// CSS_EASE (the shared spring curve) is intentionally NOT used for this panel —
+// its overshoot makes scale animations on small popovers look bouncy.
+// We use a custom ease-out inline instead.
 import { SEVERITY_BADGE } from '../../utils/badge-colors'
+import { Tooltip } from '../ui/Tooltip'
 import { useToast } from '../ui/Toast'
 import { openExternal } from '../../utils/navigation'
+
+// --- Types -------------------------------------------------------------------
 
 interface PortForwardSession {
   id: string
@@ -33,61 +45,371 @@ interface PortForwardSession {
   error?: string
 }
 
-interface PortForwardManagerProps {
-  onClose?: () => void
-  minimized?: boolean
-  onToggleMinimize?: () => void
-}
+// --- Shared query ------------------------------------------------------------
 
-export function PortForwardManager({
-  onClose,
-  minimized = false,
-  onToggleMinimize,
-}: PortForwardManagerProps) {
-  const [copiedId, setCopiedId] = useState<string | null>(null)
-  const [editingPortId, setEditingPortId] = useState<string | null>(null)
-  const [editPortValue, setEditPortValue] = useState('')
-  const [changingPortId, setChangingPortId] = useState<string | null>(null)
-  const queryClient = useQueryClient()
-  const { showSuccess, showError } = useToast()
-
-  // Fetch active port forwards
-  const { data: sessions = [], isLoading } = useQuery<PortForwardSession[]>({
+function usePortForwardQuery() {
+  return useQuery<PortForwardSession[]>({
     queryKey: ['portforwards'],
     queryFn: async () => {
       const res = await fetch('/api/portforwards')
       if (!res.ok) throw new Error('Failed to fetch port forwards')
       return res.json()
     },
-    refetchInterval: 30000, // Poll every 30 seconds - sessions are invalidated on user actions
+    // 30s fallback poll — user mutations invalidate immediately, but out-of-band
+    // session death (pod restart, OOM kill, server-side cleanup) only surfaces on
+    // the next tick.
+    refetchInterval: 30000,
   })
+}
 
-  // Stop port forward mutation
-  const stopMutation = useMutation({
-    mutationFn: async (id: string) => {
-      const res = await fetch(`/api/portforwards/${id}`, { method: 'DELETE' })
-      if (!res.ok) throw new Error('Failed to stop port forward')
-      return res.json()
-    },
-    meta: {
-      errorMessage: 'Failed to stop port forward',
-      successMessage: 'Port forward stopped',
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['portforwards'] })
-    },
-  })
+// --- Context & provider ------------------------------------------------------
 
-  // Toggle listen address (restart with different address)
+// Show the panel this long after a new forward starts before auto-minimizing.
+const AUTO_MINIMIZE_INITIAL_MS = 4000
+// Shorter grace period after the cursor leaves a hovered panel.
+const AUTO_MINIMIZE_HOVER_LEAVE_MS = 1500
+
+/** Measured position for anchoring the panel to the indicator button. */
+interface PanelAnchor {
+  top: number
+  right: number
+  /** Horizontal center of the indicator (relative to panel's right edge) — for caret positioning. */
+  caretRight: number
+}
+
+interface PortForwardContextValue {
+  sessions: PortForwardSession[]
+  activeSessions: PortForwardSession[]
+  errorSessions: PortForwardSession[]
+  isLoading: boolean
+  /** True when the session query itself failed (network/server error). */
+  isQueryError: boolean
+  queryError: Error | null
+  isPanelOpen: boolean
+  openPanel: () => void
+  minimizePanel: () => void
+  togglePanel: () => void
+  /**
+   * Permanently disarms the auto-minimize timer. Call from any user-initiated
+   * interaction inside the panel. Re-arming only happens when a new forward
+   * starts AND the panel is currently closed (minimized or never opened) —
+   * an already-open panel stays sticky regardless of count changes.
+   */
+  commitInteraction: () => void
+  onPanelHoverEnter: () => void
+  onPanelHoverLeave: () => void
+  /** Ref for the indicator button — used for dynamic panel positioning. */
+  indicatorRef: React.RefObject<HTMLButtonElement | null>
+  /** Measured anchor position from the indicator, or null if not yet measured. */
+  anchor: PanelAnchor | null
+}
+
+const PortForwardContext = createContext<PortForwardContextValue | null>(null)
+
+export function PortForwardProvider({ children }: { children: ReactNode }) {
+  const {
+    data: sessions = [],
+    isLoading,
+    isError: isQueryError,
+    error: queryError,
+  } = usePortForwardQuery()
+  const activeSessions = sessions.filter((s) => s.status !== 'stopped')
+  const errorSessions = sessions.filter((s) => s.status === 'error')
+  const count = activeSessions.length
+
+  const [isPanelOpen, setIsPanelOpen] = useState(false)
+  // Mirror isPanelOpen in a ref so the count-watch effect can read the *current* open state
+  // without needing isPanelOpen in its deps (which would re-run the effect on every open/close).
+  const isPanelOpenRef = useRef(false)
+  useEffect(() => { isPanelOpenRef.current = isPanelOpen }, [isPanelOpen])
+  // Armed = a new session opened the panel and we still intend to auto-minimize.
+  // Cleared by any user interaction (commitInteraction) or when the timer fires.
+  const autoMinimizeArmedRef = useRef(false)
+  const autoMinimizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const isHoveringRef = useRef(false)
+  const prevCountRef = useRef(0)
+
+  // --- Indicator ref + panel anchor measurement ---
+  // The panel is positioned dynamically below the indicator button.
+  const indicatorRef = useRef<HTMLButtonElement>(null)
+  const [anchor, setAnchor] = useState<PanelAnchor | null>(null)
+
+  const measureAnchor = useCallback(() => {
+    if (!indicatorRef.current) return
+    const rect = indicatorRef.current.getBoundingClientRect()
+    setAnchor({
+      top: rect.bottom + 10,
+      right: Math.max(16, window.innerWidth - rect.right),
+      caretRight: rect.width / 2 - 6,
+    })
+  }, [])
+
+  // Measure on mount / count change (indicator may appear/disappear) + window resize.
+  useLayoutEffect(() => { measureAnchor() }, [count, measureAnchor])
+  useEffect(() => {
+    window.addEventListener('resize', measureAnchor)
+    return () => window.removeEventListener('resize', measureAnchor)
+  }, [measureAnchor])
+
+  const clearAutoMinimizeTimer = useCallback(() => {
+    if (autoMinimizeTimerRef.current) {
+      clearTimeout(autoMinimizeTimerRef.current)
+      autoMinimizeTimerRef.current = null
+    }
+  }, [])
+
+  const scheduleAutoMinimize = useCallback(
+    (delay: number) => {
+      clearAutoMinimizeTimer()
+      autoMinimizeTimerRef.current = setTimeout(() => {
+        setIsPanelOpen(false)
+        autoMinimizeArmedRef.current = false
+        autoMinimizeTimerRef.current = null
+      }, delay)
+    },
+    [clearAutoMinimizeTimer]
+  )
+
+  // Auto-open the panel when a new forward starts; fully close when all forwards stop.
+  // Important: if the panel was already open (manually or from an earlier auto-open that the
+  // user already committed to via interaction), don't re-arm the auto-minimize timer —
+  // that would close a panel the user deliberately kept visible.
+  useEffect(() => {
+    const prev = prevCountRef.current
+    prevCountRef.current = count
+    if (count > prev && count > 0) {
+      const wasClosed = !isPanelOpenRef.current
+      setIsPanelOpen(true)
+      if (wasClosed) {
+        autoMinimizeArmedRef.current = true
+        if (!isHoveringRef.current) {
+          scheduleAutoMinimize(AUTO_MINIMIZE_INITIAL_MS)
+        }
+      }
+      // If the panel was already open, leave armed state alone: a user who opened it
+      // manually stays sticky; a user who's still within their initial grace window
+      // keeps the existing timer.
+    } else if (count === 0) {
+      // Provider stays mounted across sessions — explicitly reset state so a future
+      // forward starts with a fresh auto-open + auto-minimize cycle. (The indicator
+      // and panel early-return when count===0 but they don't own this state.)
+      setIsPanelOpen(false)
+      autoMinimizeArmedRef.current = false
+      clearAutoMinimizeTimer()
+    }
+  }, [count, scheduleAutoMinimize, clearAutoMinimizeTimer])
+
+  // Cleanup any in-flight timer on unmount.
+  useEffect(() => () => clearAutoMinimizeTimer(), [clearAutoMinimizeTimer])
+
+  const openPanel = useCallback(() => {
+    setIsPanelOpen(true)
+    autoMinimizeArmedRef.current = false
+    clearAutoMinimizeTimer()
+  }, [clearAutoMinimizeTimer])
+
+  const minimizePanel = useCallback(() => {
+    setIsPanelOpen(false)
+    autoMinimizeArmedRef.current = false
+    clearAutoMinimizeTimer()
+  }, [clearAutoMinimizeTimer])
+
+  const togglePanel = useCallback(() => {
+    if (isPanelOpen) minimizePanel()
+    else openPanel()
+  }, [isPanelOpen, openPanel, minimizePanel])
+
+  const commitInteraction = useCallback(() => {
+    autoMinimizeArmedRef.current = false
+    clearAutoMinimizeTimer()
+  }, [clearAutoMinimizeTimer])
+
+  const onPanelHoverEnter = useCallback(() => {
+    isHoveringRef.current = true
+    clearAutoMinimizeTimer()
+  }, [clearAutoMinimizeTimer])
+
+  const onPanelHoverLeave = useCallback(() => {
+    isHoveringRef.current = false
+    if (autoMinimizeArmedRef.current) {
+      scheduleAutoMinimize(AUTO_MINIMIZE_HOVER_LEAVE_MS)
+    }
+  }, [scheduleAutoMinimize])
+
+  return (
+    <PortForwardContext.Provider
+      value={{
+        sessions,
+        activeSessions,
+        errorSessions,
+        isLoading,
+        isQueryError,
+        queryError: queryError as Error | null,
+        isPanelOpen,
+        openPanel,
+        minimizePanel,
+        togglePanel,
+        commitInteraction,
+        onPanelHoverEnter,
+        onPanelHoverLeave,
+        indicatorRef,
+        anchor,
+      }}
+    >
+      {children}
+    </PortForwardContext.Provider>
+  )
+}
+
+function usePortForwardContext(): PortForwardContextValue {
+  const ctx = useContext(PortForwardContext)
+  if (!ctx) {
+    throw new Error('usePortForwardContext must be used inside <PortForwardProvider>')
+  }
+  return ctx
+}
+
+// --- Header indicator --------------------------------------------------------
+
+export function PortForwardIndicator() {
+  const { activeSessions, errorSessions, isPanelOpen, togglePanel, indicatorRef } = usePortForwardContext()
+  const count = activeSessions.length
+  if (count === 0) return null
+
+  const hasErrors = errorSessions.length > 0
+  const tooltipText = hasErrors
+    ? `${count} port forward${count !== 1 ? 's' : ''} — ${errorSessions.length} failed`
+    : `${count} active port forward${count !== 1 ? 's' : ''}`
+
+  return (
+    <Tooltip content={tooltipText} delay={150} position="bottom" disabled={isPanelOpen}>
+      <button
+        ref={indicatorRef}
+        type="button"
+        onClick={togglePanel}
+        aria-label={tooltipText}
+        aria-expanded={isPanelOpen}
+        className={clsx(
+          'relative flex items-center gap-1.5 h-7 px-2 ml-2 rounded-md text-xs transition-colors',
+          isPanelOpen
+            ? 'bg-theme-elevated text-theme-text-primary'
+            : 'text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated'
+        )}
+      >
+        {/* The icon itself pulses when running (replaces the separate dot overlay).
+            Slightly larger than standard pill icons for visual weight as a status indicator. */}
+        <Plug className={clsx(
+          'w-5 h-5',
+          hasErrors ? 'text-red-400' : 'text-green-400',
+          !isPanelOpen && !hasErrors && 'animate-pulse'
+        )} />
+        <span className="font-mono tabular-nums">{count}</span>
+        {!isPanelOpen && hasErrors && (
+          <span className={clsx('badge-sm', SEVERITY_BADGE.error)}>
+            {errorSessions.length}
+          </span>
+        )}
+      </button>
+    </Tooltip>
+  )
+}
+
+// --- Floating panel ----------------------------------------------------------
+
+export function PortForwardPanel() {
+  const {
+    activeSessions,
+    errorSessions,
+    isLoading,
+    isQueryError,
+    queryError,
+    isPanelOpen,
+    minimizePanel,
+    commitInteraction,
+    onPanelHoverEnter,
+    onPanelHoverLeave,
+    anchor,
+  } = usePortForwardContext()
+
+  const [copiedId, setCopiedId] = useState<string | null>(null)
+  const [editingPortId, setEditingPortId] = useState<string | null>(null)
+  const [editPortValue, setEditPortValue] = useState('')
+  const [changingPortId, setChangingPortId] = useState<string | null>(null)
   const [togglingId, setTogglingId] = useState<string | null>(null)
+  // Per-session stop tracking — allows stopping multiple forwards simultaneously
+  // without disabling all stop buttons (the old shared-mutation approach blocked
+  // every row when any single stop was in-flight).
+  const [stoppingIds, setStoppingIds] = useState<Set<string>>(() => new Set())
+  const queryClient = useQueryClient()
+  const { showSuccess, showError } = useToast()
+
+  // Track the "copied!" reset timeout so it can be cleared if the panel unmounts
+  // before the 2s window elapses (otherwise React warns about setState on unmount).
+  const copyResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => {
+    return () => {
+      if (copyResetTimerRef.current) {
+        clearTimeout(copyResetTimerRef.current)
+      }
+    }
+  }, [])
+
+  // Minimize on Escape when the panel is visible. Skip if focus is in an input —
+  // the inline port editor has its own Escape handler (exits edit mode), and
+  // upstream inputs (ResourcesSidebar search, etc.) should keep their own semantics.
+  useEffect(() => {
+    if (!isPanelOpen) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      const active = document.activeElement
+      if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) {
+        return
+      }
+      minimizePanel()
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [isPanelOpen, minimizePanel])
+
+  const stopPortForward = useCallback(async (id: string) => {
+    setStoppingIds(prev => new Set(prev).add(id))
+    try {
+      const res = await fetch(`/api/portforwards/${id}`, { method: 'DELETE' })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.error || `Failed to stop port forward (HTTP ${res.status})`)
+      }
+      queryClient.invalidateQueries({ queryKey: ['portforwards'] })
+    } catch (err) {
+      queryClient.invalidateQueries({ queryKey: ['portforwards'] })
+      const msg = err instanceof Error ? err.message : 'Failed to stop port forward'
+      showError('Failed to stop port forward', msg)
+      console.error('Failed to stop port forward:', err)
+    } finally {
+      setStoppingIds(prev => {
+        const next = new Set(prev)
+        next.delete(id)
+        return next
+      })
+    }
+  }, [queryClient, showError])
+
   const toggleListenAddress = async (session: PortForwardSession) => {
+    commitInteraction()
     const newAddress = session.listenAddress === '0.0.0.0' ? '127.0.0.1' : '0.0.0.0'
+    const prevLabel = session.listenAddress === '0.0.0.0' ? 'network' : 'localhost'
+    const nextLabel = newAddress === '0.0.0.0' ? 'network' : 'localhost'
     setTogglingId(session.id)
+    // Track whether the DELETE half succeeded so we can tell "original still running"
+    // apart from "original gone and recreate failed = data loss."
+    let deleted = false
     try {
       const delRes = await fetch(`/api/portforwards/${session.id}`, { method: 'DELETE' })
       if (!delRes.ok) {
-        throw new Error(`Failed to stop existing port forward (HTTP ${delRes.status})`)
+        const body = await delRes.json().catch(() => ({}))
+        throw new Error(body.error || `Failed to stop existing port forward (HTTP ${delRes.status})`)
       }
+      deleted = true
       const res = await fetch('/api/portforwards', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -102,13 +424,22 @@ export function PortForwardManager({
       })
       if (!res.ok) {
         const error = await res.json().catch(() => ({}))
-        throw new Error(error.error || 'Failed to restart port forward')
+        throw new Error(error.error || `Failed to restart port forward (HTTP ${res.status})`)
       }
       queryClient.invalidateQueries({ queryKey: ['portforwards'] })
     } catch (error) {
       queryClient.invalidateQueries({ queryKey: ['portforwards'] })
       const msg = error instanceof Error ? error.message : 'Failed to change network access'
-      showError('Failed to change network access', msg)
+      if (deleted) {
+        // DELETE succeeded but POST failed — the original forward is gone.
+        showError(
+          'Port forward lost',
+          `Forward on port ${session.localPort} (${prevLabel}) was stopped but recreating it as ${nextLabel} failed: ${msg}`
+        )
+      } else {
+        // DELETE failed — the original forward is still running.
+        showError('Failed to change network access', msg)
+      }
       console.error('Failed to toggle listen address:', error)
     } finally {
       setTogglingId(null)
@@ -116,17 +447,23 @@ export function PortForwardManager({
   }
 
   const changeLocalPort = async (session: PortForwardSession, newPort: number) => {
+    commitInteraction()
     if (newPort === session.localPort) {
       setEditingPortId(null)
       return
     }
     setChangingPortId(session.id)
     setEditingPortId(null)
+    // Track whether the DELETE half succeeded so we can tell "original still running"
+    // apart from "original gone and recreate failed = data loss."
+    let deleted = false
     try {
       const delRes = await fetch(`/api/portforwards/${session.id}`, { method: 'DELETE' })
       if (!delRes.ok) {
-        throw new Error(`Failed to stop existing port forward (HTTP ${delRes.status})`)
+        const body = await delRes.json().catch(() => ({}))
+        throw new Error(body.error || `Failed to stop existing port forward (HTTP ${delRes.status})`)
       }
+      deleted = true
       const res = await fetch('/api/portforwards', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -141,59 +478,114 @@ export function PortForwardManager({
       })
       if (!res.ok) {
         const error = await res.json().catch(() => ({}))
-        throw new Error(error.error || 'Failed to restart port forward')
+        throw new Error(error.error || `Failed to restart port forward (HTTP ${res.status})`)
       }
       queryClient.invalidateQueries({ queryKey: ['portforwards'] })
       showSuccess('Port forward updated', `Now listening on localhost:${newPort}`)
     } catch (error) {
       queryClient.invalidateQueries({ queryKey: ['portforwards'] })
       const msg = error instanceof Error ? error.message : 'Failed to change local port'
-      showError('Port forward lost', `Forward on port ${session.localPort} was stopped but port ${newPort} failed: ${msg}`)
+      if (deleted) {
+        showError(
+          'Port forward lost',
+          `Forward on port ${session.localPort} was stopped but port ${newPort} failed: ${msg}`
+        )
+      } else {
+        // DELETE failed — the original forward on session.localPort is still running.
+        showError('Failed to change local port', msg)
+      }
       console.error('Failed to change local port:', error)
     } finally {
       setChangingPortId(null)
     }
   }
 
-  const handleCopyUrl = useCallback((session: PortForwardSession) => {
-    // Always use localhost for copy (works on the machine running Radar)
-    navigator.clipboard.writeText(`http://localhost:${session.localPort}`)
-    setCopiedId(session.id)
-    setTimeout(() => setCopiedId(null), 2000)
-  }, [])
+  const handleCopyUrl = useCallback(
+    async (session: PortForwardSession) => {
+      commitInteraction()
+      try {
+        await navigator.clipboard.writeText(`http://localhost:${session.localPort}`)
+      } catch (err) {
+        // Clipboard API can reject in non-secure contexts, denied permissions, or
+        // when the document isn't focused. Surface the failure — the checkmark
+        // would otherwise lie to the user.
+        const msg = err instanceof Error ? err.message : 'Clipboard access denied'
+        showError('Failed to copy URL', msg)
+        console.error('Failed to copy URL:', err)
+        return
+      }
+      setCopiedId(session.id)
+      if (copyResetTimerRef.current) clearTimeout(copyResetTimerRef.current)
+      copyResetTimerRef.current = setTimeout(() => {
+        setCopiedId(null)
+        copyResetTimerRef.current = null
+      }, 2000)
+    },
+    [commitInteraction, showError]
+  )
 
-  const handleOpenUrl = useCallback((session: PortForwardSession) => {
-    openExternal(`http://localhost:${session.localPort}`)
-  }, [])
+  const handleOpenUrl = useCallback(
+    (session: PortForwardSession) => {
+      commitInteraction()
+      openExternal(`http://localhost:${session.localPort}`)
+    },
+    [commitInteraction]
+  )
 
-  // Show both running and error sessions (not stopped)
-  const activeSessions = sessions.filter((s) => s.status !== 'stopped')
-  const errorSessions = sessions.filter((s) => s.status === 'error')
-
-  if (activeSessions.length === 0 && !isLoading) {
-    return null // Don't show if no active sessions
+  // Unmount when there are no sessions AND the query isn't reporting a fault.
+  // Distinguishing a failed query from "no sessions" keeps us from silently
+  // telling the user their forwards vanished when really /api/portforwards errored.
+  if (activeSessions.length === 0 && !isLoading && !isQueryError) {
+    return null
   }
 
-  if (minimized) {
-    return (
-      <button
-        onClick={onToggleMinimize}
-        className="fixed bottom-4 left-4 z-40 flex items-center gap-2 px-3 py-2 bg-theme-surface border border-theme-border rounded-lg shadow-lg hover:bg-theme-elevated transition-colors"
-      >
-        <Radio className={clsx('w-4 h-4', errorSessions.length > 0 ? 'text-red-400' : 'text-green-400 animate-pulse')} />
-        <span className="text-sm text-theme-text-secondary">
-          {activeSessions.length} port forward{activeSessions.length !== 1 ? 's' : ''}
-          {errorSessions.length > 0 && <span className="text-red-400 ml-1">({errorSessions.length} failed)</span>}
-        </span>
-        <ChevronUp className="w-4 h-4 text-theme-text-tertiary" />
-      </button>
-    )
-  }
+  const hasErrors = errorSessions.length > 0
 
   return (
-    <div className="fixed bottom-4 left-4 z-40 w-80 dialog overflow-hidden">
-      {/* Header */}
-      <div className="flex items-center justify-between px-3 py-2 bg-theme-elevated border-b border-theme-border">
+    // Wrapper — positioning + opacity. Opacity fades fast (150ms), separately from the
+    // height reveal (300ms) so users perceive the panel as "there" before it finishes growing.
+    <div
+      onMouseEnter={onPanelHoverEnter}
+      onMouseLeave={onPanelHoverLeave}
+      className={clsx(
+        'fixed z-[51] w-80',
+        'transition-opacity duration-150 ease-out',
+        isPanelOpen
+          ? 'opacity-100 pointer-events-auto'
+          : 'opacity-0 pointer-events-none'
+      )}
+      style={{
+        top: anchor?.top ?? 56,
+        right: anchor?.right ?? 16,
+      }}
+      aria-hidden={!isPanelOpen}
+    >
+      {/* Panel shell — visual chrome (border, shadow, bg, corners). Height is driven
+          by the grid-sizer child. As the grid grows 0→auto, the shell grows with it,
+          keeping border and rounded corners correct at every intermediate height. */}
+      <div className="overflow-hidden rounded-xl bg-theme-surface dark:bg-theme-elevated border-2 border-skyhook-500/35 dark:border-skyhook-400/40 shadow-2xl dark:shadow-[0_24px_60px_-12px_rgba(0,0,0,0.75),0_10px_24px_-6px_rgba(0,0,0,0.45)]">
+
+        {/* Grid sizer — the height engine. grid-template-rows 0fr→1fr animates
+            height from 0 to auto. Content clips from the bottom up, creating a
+            natural top-to-bottom reveal (header appears first, sessions follow). */}
+        <div
+          className={clsx(
+            'grid transition-[grid-template-rows] duration-300',
+            isPanelOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+          )}
+          style={{ transitionTimingFunction: 'cubic-bezier(0.16, 1, 0.3, 1)' }}
+        >
+          <div className="overflow-hidden">
+
+      {/* Header — tinted green when all sessions running, red when any have failed. */}
+      <div
+        className={clsx(
+          'flex items-center justify-between px-3 py-2 border-b transition-colors duration-200',
+          hasErrors
+            ? 'bg-red-500/10 dark:bg-red-500/15 border-red-500/25 dark:border-red-500/20'
+            : 'bg-green-500/8 dark:bg-green-400/10 border-green-500/20 dark:border-green-400/15'
+        )}
+      >
         <div className="flex items-center gap-2">
           <Plug className="w-4 h-4 text-accent-text" />
           <span className="text-sm font-medium text-theme-text-primary">Port Forwards</span>
@@ -206,43 +598,46 @@ export function PortForwardManager({
             </span>
           )}
         </div>
-        <div className="flex items-center gap-1">
-          {onToggleMinimize && (
-            <button
-              onClick={onToggleMinimize}
-              className="p-1 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-hover rounded"
-            >
-              <ChevronDown className="w-4 h-4" />
-            </button>
-          )}
-          {onClose && (
-            <button
-              onClick={onClose}
-              className="p-1 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-hover rounded"
-            >
-              <X className="w-4 h-4" />
-            </button>
-          )}
-        </div>
+        <button
+          type="button"
+          onClick={minimizePanel}
+          aria-label="Minimize port forwards"
+          className="p-1 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-hover rounded"
+        >
+          <ChevronUp className="w-4 h-4" />
+        </button>
       </div>
 
       {/* Sessions list */}
       <div className="max-h-64 overflow-y-auto">
+        {isQueryError ? (
+          <div className="p-3 text-xs bg-red-500/10 border-b border-theme-border">
+            <div className={clsx('badge-sm mb-1 inline-block', SEVERITY_BADGE.error)}>
+              Connection error
+            </div>
+            <div className="text-red-400 break-all">
+              Failed to load port forwards: {queryError?.message ?? 'unknown error'}
+            </div>
+          </div>
+        ) : null}
         {isLoading ? (
           <div className="flex items-center justify-center p-4">
             <Loader2 className="w-5 h-5 text-theme-text-tertiary animate-spin" />
           </div>
         ) : activeSessions.length === 0 ? (
           <div className="p-4 text-center text-sm text-theme-text-disabled">
-            No active port forwards
+            {isQueryError ? 'Unable to load port forwards' : 'No active port forwards'}
           </div>
         ) : (
           <div className="divide-y divide-theme-border">
             {activeSessions.map((session) => (
-              <div key={session.id} className={clsx(
-                'p-3',
-                session.status === 'error' ? 'bg-red-500/10' : 'hover:bg-theme-elevated'
-              )}>
+              <div
+                key={session.id}
+                className={clsx(
+                  'p-3',
+                  session.status === 'error' ? 'bg-red-500/10' : 'hover:bg-theme-elevated'
+                )}
+              >
                 <div className="flex items-start justify-between gap-2">
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2">
@@ -256,9 +651,7 @@ export function PortForwardManager({
                         {session.serviceName || session.podName}
                       </span>
                       {session.status === 'error' && (
-                        <span className={clsx('badge-sm', SEVERITY_BADGE.error)}>
-                          Failed
-                        </span>
+                        <span className={clsx('badge-sm', SEVERITY_BADGE.error)}>Failed</span>
                       )}
                     </div>
                     <div className="mt-1 text-xs text-theme-text-disabled">
@@ -282,16 +675,30 @@ export function PortForwardManager({
                               min={1}
                               max={65535}
                               value={editPortValue}
-                              onChange={(e) => setEditPortValue(e.target.value)}
+                              onChange={(e) => {
+                                // Any keystroke is a deliberate user action — keep the panel open.
+                                commitInteraction()
+                                setEditPortValue(e.target.value)
+                              }}
                               onKeyDown={(e) => {
                                 if (e.key === 'Enter') {
                                   const val = Number(editPortValue)
-                                  if (isNaN(val) || val < 1 || val > 65535 || !Number.isInteger(val)) {
-                                    showError('Invalid port', 'Port must be a number between 1 and 65535')
+                                  if (
+                                    isNaN(val) ||
+                                    val < 1 ||
+                                    val > 65535 ||
+                                    !Number.isInteger(val)
+                                  ) {
+                                    commitInteraction()
+                                    showError(
+                                      'Invalid port',
+                                      'Port must be a number between 1 and 65535'
+                                    )
                                     return
                                   }
                                   changeLocalPort(session, val)
                                 } else if (e.key === 'Escape') {
+                                  commitInteraction()
                                   setEditingPortId(null)
                                 }
                               }}
@@ -300,6 +707,7 @@ export function PortForwardManager({
                             />
                           </div>
                         ) : (
+                          <Tooltip content="Click to change local port" delay={300} position="bottom" disabled={!isPanelOpen}>
                           <code
                             className={clsx(
                               'group/port text-xs bg-theme-base px-2 py-1 rounded text-accent-text transition-all inline-flex items-center gap-1',
@@ -307,9 +715,9 @@ export function PortForwardManager({
                                 ? 'opacity-50'
                                 : 'cursor-pointer hover:ring-1 hover:ring-blue-500/50'
                             )}
-                            title="Click to change local port"
                             onClick={() => {
                               if (changingPortId || togglingId) return
+                              commitInteraction()
                               setEditingPortId(session.id)
                               setEditPortValue(String(session.localPort))
                             }}
@@ -317,10 +725,16 @@ export function PortForwardManager({
                             {changingPortId === session.id && (
                               <Loader2 className="w-3 h-3 animate-spin inline mr-1" />
                             )}
-                            {session.listenAddress === '0.0.0.0' ? '0.0.0.0' : 'localhost'}:{session.localPort}
+                            {session.listenAddress === '0.0.0.0' ? '0.0.0.0' : 'localhost'}:
+                            {session.localPort}
                             <PenLine className="w-3 h-3 text-theme-text-disabled opacity-0 group-hover/port:opacity-100 transition-opacity" />
                           </code>
+                          </Tooltip>
                         )}
+                        <Tooltip
+                          content={session.listenAddress === '0.0.0.0' ? 'Switch to localhost only' : 'Allow access from other machines'}
+                          delay={300} position="bottom" disabled={!isPanelOpen}
+                        >
                         <button
                           onClick={() => toggleListenAddress(session)}
                           disabled={togglingId === session.id || changingPortId === session.id}
@@ -330,10 +744,6 @@ export function PortForwardManager({
                               ? `${SEVERITY_BADGE.warning} hover:bg-amber-500/30`
                               : 'bg-theme-elevated text-theme-text-tertiary hover:bg-theme-hover hover:text-theme-text-primary'
                           )}
-                          title={session.listenAddress === '0.0.0.0'
-                            ? 'Click to switch to localhost only'
-                            : 'Click to allow access from other machines'
-                          }
                         >
                           {togglingId === session.id ? (
                             <Loader2 className="w-3 h-3 animate-spin" />
@@ -344,6 +754,7 @@ export function PortForwardManager({
                           )}
                           {session.listenAddress === '0.0.0.0' ? 'network' : 'local'}
                         </button>
+                        </Tooltip>
                       </div>
                     )}
                   </div>
@@ -351,10 +762,10 @@ export function PortForwardManager({
                   <div className="flex items-center gap-1 shrink-0">
                     {session.status === 'running' && (
                       <>
+                        <Tooltip content={copiedId === session.id ? 'Copied!' : 'Copy URL'} delay={300} position="bottom" disabled={!isPanelOpen}>
                         <button
                           onClick={() => handleCopyUrl(session)}
                           className="p-1.5 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-hover rounded"
-                          title="Copy URL"
                         >
                           {copiedId === session.id ? (
                             <Check className="w-3.5 h-3.5 text-green-400" />
@@ -362,23 +773,29 @@ export function PortForwardManager({
                             <Copy className="w-3.5 h-3.5" />
                           )}
                         </button>
+                        </Tooltip>
+                        <Tooltip content="Open in browser" delay={300} position="bottom" disabled={!isPanelOpen}>
                         <button
                           onClick={() => handleOpenUrl(session)}
                           className="p-1.5 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-hover rounded"
-                          title="Open in browser"
                         >
                           <ExternalLink className="w-3.5 h-3.5" />
                         </button>
+                        </Tooltip>
                       </>
                     )}
+                    <Tooltip content={session.status === 'error' ? 'Dismiss' : 'Stop'} delay={300} position="bottom" disabled={!isPanelOpen}>
                     <button
-                      onClick={() => stopMutation.mutate(session.id)}
-                      disabled={stopMutation.isPending}
+                      onClick={() => {
+                        commitInteraction()
+                        stopPortForward(session.id)
+                      }}
+                      disabled={stoppingIds.has(session.id)}
                       className="p-1.5 text-theme-text-tertiary hover:text-red-400 hover:bg-theme-hover rounded disabled:opacity-50"
-                      title={session.status === 'error' ? 'Dismiss' : 'Stop'}
                     >
                       <Trash2 className="w-3.5 h-3.5" />
                     </button>
+                    </Tooltip>
                   </div>
                 </div>
               </div>
@@ -386,11 +803,30 @@ export function PortForwardManager({
           </div>
         )}
       </div>
+
+          </div>{/* /overflow-hidden */}
+        </div>{/* /grid-sizer */}
+      </div>{/* /panel-shell */}
+
+      {/* Caret — rendered after the shell so it paints on top (z-10). Opaque fill
+          covers the shell's border at the junction. The tint layer matches the header. */}
+      <div
+        className="absolute -top-[6px] w-3.5 h-3.5 rotate-45 z-10 bg-theme-surface dark:bg-theme-elevated border-t-2 border-l-2 border-skyhook-500/35 dark:border-skyhook-400/40"
+        style={{ right: anchor?.caretRight ?? 16 }}
+      >
+        <div className={clsx(
+          'absolute inset-0 transition-colors duration-200',
+          hasErrors ? 'bg-red-500/10 dark:bg-red-500/15' : 'bg-green-500/8 dark:bg-green-400/10'
+        )} />
+      </div>
     </div>
   )
 }
 
-// Hook for starting port forwards
+// --- Public mutation hook for starting a forward -----------------------------
+// Stable hook shape — callers don't need to know about the panel UI. The provider's
+// count-watch effect reacts to the new session and handles open/auto-minimize.
+
 export function useStartPortForward() {
   const queryClient = useQueryClient()
 
@@ -409,14 +845,17 @@ export function useStartPortForward() {
         body: JSON.stringify(req),
       })
       if (!res.ok) {
-        const error = await res.json()
+        const error = await res.json().catch(() => ({}))
         throw new Error(error.error || 'Failed to start port forward')
       }
       return res.json() as Promise<PortForwardSession>
     },
     meta: {
       errorMessage: 'Failed to start port forward',
-      successMessage: 'Port forward started',
+      // No successMessage — the panel auto-opens on new sessions and provides
+      // strictly more information than a toast ("started" → here are the details).
+      // Only the error toast remains as the signal-of-last-resort when the
+      // mutation fails and no panel update can happen.
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['portforwards'] })
@@ -424,18 +863,8 @@ export function useStartPortForward() {
   })
 }
 
-// Hook for getting active port forwards count (includes errors)
+// Backwards-compat: existing consumers that just want a count number.
 export function usePortForwardCount() {
-  const { data: sessions = [] } = useQuery<PortForwardSession[]>({
-    queryKey: ['portforwards'],
-    queryFn: async () => {
-      const res = await fetch('/api/portforwards')
-      if (!res.ok) return []
-      return res.json()
-    },
-    refetchInterval: 30000, // Poll every 30 seconds
-  })
-
-  // Count both running and error sessions (not stopped)
+  const { data: sessions = [] } = usePortForwardQuery()
   return sessions.filter((s) => s.status !== 'stopped').length
 }

--- a/web/src/components/timeline/TimelineSwimlanes.tsx
+++ b/web/src/components/timeline/TimelineSwimlanes.tsx
@@ -755,7 +755,10 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
 
                   {/* Child lanes (when expanded) - includes parent as first row */}
                   {isExpanded && hasChildren && (
-                    <div className="border-l-2 border-blue-500/40 ml-3 bg-theme-surface/30">
+                    <div
+                      className="border-l-2 border-blue-500/40 ml-3 bg-theme-surface/30"
+                      style={{ animation: 'swimlane-expand 250ms ease-out both' }}
+                    >
                       {/* Parent's own events as first row (only if it has events) */}
                       {lane.events.length > 0 && (
                         <div className="border-b-subtle">

--- a/web/src/components/ui/CommandPalette.tsx
+++ b/web/src/components/ui/CommandPalette.tsx
@@ -1,12 +1,12 @@
 import { useState, useMemo, useRef, useEffect, useCallback } from 'react'
 import { TRANSITION_BACKDROP, TRANSITION_PANEL } from '../../utils/animation'
 import { Search, X, ChevronRight } from 'lucide-react'
-import { Home, Network, List, Clock, Package, Activity, Sun, Stethoscope } from 'lucide-react'
+import { Home, Network, List, Clock, Package, Activity, Sun, Stethoscope, DollarSign, ShieldCheck } from 'lucide-react'
 import { clsx } from 'clsx'
 import { useNamespaces, useContexts } from '../../api/client'
 import { CORE_RESOURCES, useAPIResources } from '../../api/apiResources'
 import { getResourceIcon } from '../../utils/resource-icons'
-type MainView = 'home' | 'topology' | 'resources' | 'timeline' | 'helm' | 'traffic'
+type MainView = 'home' | 'topology' | 'resources' | 'timeline' | 'helm' | 'traffic' | 'cost' | 'audit'
 
 interface CommandPaletteProps {
   onClose: () => void
@@ -112,6 +112,8 @@ export function CommandPalette({
       { view: 'timeline', label: 'Timeline', icon: Clock, shortcut: '4' },
       { view: 'helm', label: 'Helm', icon: Package, shortcut: '5' },
       { view: 'traffic', label: 'Traffic', icon: Activity, shortcut: '6' },
+      { view: 'cost', label: 'Cost', icon: DollarSign, shortcut: '7' },
+      { view: 'audit', label: 'Audit', icon: ShieldCheck, shortcut: '8' },
     ]
     for (const v of viewEntries) {
       result.push({

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -137,6 +137,19 @@ body {
   }
 }
 
+/* Expand animation for timeline swimlane children — GPU-composited (transform + opacity only).
+   Slides down from the parent row with a fade. Collapse is instant (unmount). */
+@keyframes swimlane-expand {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 @keyframes fade-out {
   from {
     opacity: 1;


### PR DESCRIPTION
## Summary

Fixes skyhook-io/radar#451 — the floating Port Forwards panel was getting fully covered by the BottomDock whenever users opened logs or terminals.

**Port Forwards — anchored popover:**
The panel is now a popover anchored below the indicator button in the header, with a caret pointing up for spatial tethering. Uses a height-reveal animation (`grid-template-rows: 0fr→1fr`) — content is never distorted. Auto-opens on new session with a 4s auto-minimize timer (pauses on hover, permanently disarms on interaction). State-reactive header tint (green running / red error). Per-session stop tracking allows batch-stopping multiple forwards. Error handling hardened throughout (deleted flag, query error surfacing, clipboard rejection handling).

**Keyboard-first resource navigation:**
- Sidebar kind filter supports ArrowDown/Up to navigate the filtered kind list + Enter to select. On Enter, focus chains to the table search input (Option B).
- Table search supports ArrowDown to hand off to the existing `j`/`k`/arrow row navigation, and Enter to directly open the first matching resource.
- Command palette (⌘K) kind navigation auto-focuses the table search after navigating to a kind.
- Full keyboard flow: ⌘K → type kind → Enter → type resource → ArrowDown → Enter → drawer opens. No mouse needed.

**Also bundled:**
- Audit view in top-bar pill nav + command palette. Cost in command palette (hidden from pills for now).
- ResourcesSidebar auto-focuses kind search on mount.
- Sidebar category + timeline swimlane expand/collapse animations (grid-rows height-reveal / GPU-composited fade+slide).
- Tooltip stale-state fix (clears isVisible when disabled flips true).

## Files

| File | Change |
|---|---|
| `PortForwardManager.tsx` | Full refactor → Provider + Indicator + Panel. Anchored popover, height-reveal, state-reactive header, per-session stop, all error/tooltip/timer logic. |
| `App.tsx` | Wire Provider, Indicator, Panel, Audit pill, Cost hidden, ⌘K focus chain. |
| `CommandPalette.tsx` | Add Cost + Audit entries. |
| `ResourcesSidebar.tsx` | Keyboard nav (arrow+enter), auto-focus, grid-rows category animation, onKindNavigated prop. |
| `ResourcesView.tsx` | Table search ArrowDown/Enter handoff to row navigation, onKindNavigated wiring. |
| `Tooltip.tsx` | useEffect to clear stale visibility on disabled toggle. |
| `TimelineSwimlanes.tsx` | Swimlane expand: CSS fade+slide animation. |
| `index.css` | `@keyframes swimlane-expand` definition. |