### PR TITLE
Fix pod terminal default shell (fixes #452)

### DIFF
--- a/cmd/desktop/main.go
+++ b/cmd/desktop/main.go
@@ -39,6 +39,7 @@ func main() {
 	fakeInCluster := flag.Bool("fake-in-cluster", false, "Simulate in-cluster mode for testing")
 	disableHelmWrite := flag.Bool("disable-helm-write", false, "Simulate restricted Helm permissions")
 	disableExec := flag.Bool("disable-exec", false, "Simulate restricted exec permissions")
+	podShellDefault := flag.String("pod-shell-default", "", "Override the default pod exec shell command (runs as 'sh -c <value>'; empty = built-in bash -il → ash → sh cascade)")
 	timelineStorage := flag.String("timeline-storage", fileCfg.TimelineStorageOr("memory"), "Timeline storage backend: memory or sqlite")
 	timelineDBPath := flag.String("timeline-db", fileCfg.TimelineDBPath, "Path to timeline database file (default: ~/.radar/timeline.db)")
 	prometheusURL := flag.String("prometheus-url", fileCfg.PrometheusURL, "Manual Prometheus/VictoriaMetrics URL (skips auto-discovery)")
@@ -83,6 +84,7 @@ func main() {
 		FakeInCluster:    *fakeInCluster,
 		DisableHelmWrite: *disableHelmWrite,
 		DisableExec:      *disableExec,
+		PodShellDefault:  *podShellDefault,
 		TimelineStorage:  *timelineStorage,
 		TimelineDBPath:   *timelineDBPath,
 		PrometheusURL:    *prometheusURL,

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -44,6 +44,7 @@ func main() {
 	disableHelmWrite := flag.Bool("disable-helm-write", false, "Simulate restricted Helm permissions (disables install/upgrade/rollback/uninstall)")
 	disableExec := flag.Bool("disable-exec", false, "Simulate restricted exec permissions (disables terminal, debug shell)")
 	disableLocalTerminal := flag.Bool("disable-local-terminal", false, "Disable local terminal feature")
+	podShellDefault := flag.String("pod-shell-default", "", "Override the default pod exec shell command (runs as 'sh -c <value>'; empty = built-in bash -il → ash → sh cascade)")
 	// Timeline storage options
 	timelineStorage := flag.String("timeline-storage", fileCfg.TimelineStorageOr("memory"), "Timeline storage backend: memory or sqlite")
 	timelineDBPath := flag.String("timeline-db", fileCfg.TimelineDBPath, "Path to timeline database file (default: ~/.radar/timeline.db)")
@@ -105,6 +106,7 @@ func main() {
 		DisableHelmWrite: *disableHelmWrite,
 		DisableExec:          *disableExec,
 		DisableLocalTerminal: *disableLocalTerminal,
+		PodShellDefault:      *podShellDefault,
 		TimelineStorage:  *timelineStorage,
 		TimelineDBPath:   *timelineDBPath,
 		PrometheusURL:    *prometheusURL,

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -38,6 +38,7 @@ type AppConfig struct {
 	DisableHelmWrite bool
 	DisableExec          bool
 	DisableLocalTerminal bool
+	PodShellDefault      string
 	TimelineStorage      string
 	TimelineDBPath   string
 	PrometheusURL    string
@@ -54,6 +55,7 @@ func SetGlobals(cfg AppConfig) {
 	k8s.ForceDisableHelmWrite = cfg.DisableHelmWrite
 	k8s.ForceDisableExec = cfg.DisableExec
 	k8s.ForceDisableLocalTerminal = cfg.DisableLocalTerminal
+	server.DefaultPodShellCommand = cfg.PodShellDefault
 	versionpkg.SetCurrent(cfg.Version)
 }
 

--- a/internal/server/exec.go
+++ b/internal/server/exec.go
@@ -26,6 +26,50 @@ var upgrader = websocket.Upgrader{
 	},
 }
 
+// defaultShellScript is the built-in fallback command used when no shell is
+// requested explicitly via ?shell= and no override is set via --pod-shell-default.
+// It exports TERM so colours and cursor movement work in container shells that
+// don't set it, then detects the best available shell with `command -v` and
+// execs into it.
+//
+// We detect with `command -v` *before* execing, rather than relying on
+// `exec bash || exec ash || exec sh`, because POSIX requires a non-interactive
+// shell to exit immediately when `exec` fails to find the requested command.
+// That behaviour breaks the naive `||` cascade: once `exec bash` fails in an
+// image without bash, the outer `sh -c` exits 127 and the `|| exec ash`
+// branch never runs. The `command -v` check confirms existence first, so
+// `exec` can only fail for exotic reasons (e.g. permission denied), which
+// POSIX does treat as fatal — and in that case the session surfaces the
+// error to the frontend, which is the correct behaviour.
+//
+// bash is run as `bash -il` (interactive login) so it sources /etc/profile,
+// /etc/bash.bashrc, and the user's rc files. That picks up the image's PS1
+// (typically containing \w for the working directory), which is the third
+// symptom from skyhook-io/radar#452.
+const defaultShellScript = "export TERM=xterm-256color; if command -v bash >/dev/null 2>&1; then exec bash -il; elif command -v ash >/dev/null 2>&1; then exec ash; else exec sh; fi"
+
+// DefaultPodShellCommand, when non-empty, overrides defaultShellScript as the
+// script passed to `sh -c`. Set by the bootstrap layer from the
+// --pod-shell-default CLI flag. Empty means "use the built-in default".
+var DefaultPodShellCommand string
+
+// defaultExecCommand builds the command argv for a pod exec session.
+//
+// Precedence:
+//  1. If override is non-empty (from ?shell=), use it verbatim as a single argv
+//     element — the caller is explicitly asking for that shell.
+//  2. If fallback is non-empty (from --pod-shell-default), run it as `sh -c fallback`.
+//  3. Otherwise run `sh -c defaultShellScript`.
+func defaultExecCommand(override, fallback string) []string {
+	if override != "" {
+		return []string{override}
+	}
+	if fallback != "" {
+		return []string{"sh", "-c", fallback}
+	}
+	return []string{"sh", "-c", defaultShellScript}
+}
+
 // ExecSession tracks an active exec WebSocket connection
 type ExecSession struct {
 	ID        string `json:"id"`
@@ -113,11 +157,10 @@ func (s *Server) handlePodExec(w http.ResponseWriter, r *http.Request) {
 	podName := chi.URLParam(r, "name")
 	container := r.URL.Query().Get("container")
 
-	// Get shell - prefer bash, fall back to sh
-	shell := r.URL.Query().Get("shell")
-	if shell == "" {
-		shell = "/bin/sh"
-	}
+	// Build the argv for the exec. If the caller explicitly requested a shell
+	// via ?shell=, honour it; otherwise use defaultExecCommand, which runs the
+	// configured fallback (or the built-in bash → ash → sh cascade) under sh -c.
+	command := defaultExecCommand(r.URL.Query().Get("shell"), DefaultPodShellCommand)
 
 	// Upgrade to WebSocket
 	conn, err := upgrader.Upgrade(w, r, nil)
@@ -160,7 +203,7 @@ func (s *Server) handlePodExec(w http.ResponseWriter, r *http.Request) {
 	auth.AuditLog(r, namespace, podName)
 
 	// Create SPDY executor
-	exec, err := k8score.NewPodExecExecutor(client, config, namespace, podName, container, []string{shell}, true)
+	exec, err := k8score.NewPodExecExecutor(client, config, namespace, podName, container, command, true)
 	if err != nil {
 		sendWSError(conn, fmt.Sprintf("Failed to create executor: %v", err))
 		return

--- a/internal/server/exec.go
+++ b/internal/server/exec.go
@@ -278,6 +278,14 @@ func (s *Server) handlePodExec(w http.ResponseWriter, r *http.Request) {
 				errorType := "exec_error"
 				if isShellNotFoundError(errMsg) {
 					errorType = "shell_not_found"
+				} else if looksLikeShellNotFound(errMsg) {
+					// Drift canary: the error has shell-not-found hallmarks but
+					// isShellNotFoundError's substring matcher didn't recognize
+					// it. Most likely kubelet/runc/containerd reworded the
+					// upstream error text. Log a breadcrumb so we notice before
+					// users start filing "Failed to connect" bugs. See the
+					// looksLikeShellNotFound doc comment for rationale.
+					log.Printf("[exec] WARNING: error looks shell-related but isShellNotFoundError did not match — kubelet error text may have drifted; update isShellNotFoundError patterns if this recurs. errMsg=%q", errMsg)
 				}
 				log.Printf("Exec failed (%s): %v", errorType, err)
 				sendWSErrorWithType(conn, errorType, errMsg)
@@ -374,6 +382,32 @@ func isShellNotFoundError(errMsg string) bool {
 		if strings.Contains(errLower, pattern) {
 			return true
 		}
+	}
+	return false
+}
+
+// looksLikeShellNotFound is a drift canary for isShellNotFoundError. It
+// returns true when an error message has shell-not-found hallmarks using
+// broader heuristics than the substring patterns above: (a) the message
+// contains both "exec" and "not found", which catches most variants of
+// missing-executable errors across container runtimes, or (b) the message
+// contains "exit code 127", which is POSIX's reserved exit status for
+// "command not found" and is what kubelet surfaces when our `sh -c` script
+// can't exec the detected shell.
+//
+// The caller uses this only for logging, never for classification — if
+// this matches but isShellNotFoundError doesn't, we log a WARNING so a
+// maintainer can update the patterns. False positives here are harmless
+// (noisier logs on unrelated errors) but silent false negatives there
+// would demote shell-missing errors to the generic "exec_error" branch,
+// losing the frontend's "Start debug container" CTA.
+func looksLikeShellNotFound(errMsg string) bool {
+	errLower := strings.ToLower(errMsg)
+	if strings.Contains(errLower, "exec") && strings.Contains(errLower, "not found") {
+		return true
+	}
+	if strings.Contains(errLower, "exit code 127") {
+		return true
 	}
 	return false
 }

--- a/internal/server/exec.go
+++ b/internal/server/exec.go
@@ -42,10 +42,14 @@ var upgrader = websocket.Upgrader{
 // POSIX does treat as fatal — and in that case the session surfaces the
 // error to the frontend, which is the correct behaviour.
 //
-// bash is run as `bash -il` (interactive login) so it sources /etc/profile,
-// /etc/bash.bashrc, and the user's rc files. That picks up the image's PS1
-// (typically containing \w for the working directory), which is the third
-// symptom from skyhook-io/radar#452.
+// bash is run as `bash -il` (interactive login) so it picks up the image's
+// startup files. Per the bash manual, a login shell reads /etc/profile and
+// then the first existing of ~/.bash_profile, ~/.bash_login, or ~/.profile.
+// Debian-family images typically also chain in /etc/bash.bashrc (via a
+// distro hook in /etc/profile) and then ~/.bashrc (via the canonical
+// `[ -f ~/.bashrc ] && . ~/.bashrc` line in ~/.bash_profile). One of those
+// files sets PS1 — almost always containing \w — which fixes the missing
+// working-directory-in-prompt symptom from skyhook-io/radar#452.
 const defaultShellScript = "export TERM=xterm-256color; if command -v bash >/dev/null 2>&1; then exec bash -il; elif command -v ash >/dev/null 2>&1; then exec ash; else exec sh; fi"
 
 // DefaultPodShellCommand, when non-empty, overrides defaultShellScript as the
@@ -159,7 +163,7 @@ func (s *Server) handlePodExec(w http.ResponseWriter, r *http.Request) {
 
 	// Build the argv for the exec. If the caller explicitly requested a shell
 	// via ?shell=, honour it; otherwise use defaultExecCommand, which runs the
-	// configured fallback (or the built-in bash → ash → sh cascade) under sh -c.
+	// configured fallback (or the built-in bash/ash/sh detection script) under sh -c.
 	command := defaultExecCommand(r.URL.Query().Get("shell"), DefaultPodShellCommand)
 
 	// Upgrade to WebSocket

--- a/internal/server/exec_test.go
+++ b/internal/server/exec_test.go
@@ -83,3 +83,63 @@ func TestDefaultShellScript(t *testing.T) {
 		t.Error("defaultShellScript must run bash as `-il` (interactive login) so it sources the image's startup files and picks up a PS1 with \\w — that's the PWD-in-prompt fix from skyhook-io/radar#452")
 	}
 }
+
+// TestLooksLikeShellNotFound covers the drift canary. The function is a
+// broader heuristic than isShellNotFoundError and intentionally tolerates
+// some false positives — the goal is to log a breadcrumb when an error
+// LOOKS shell-related but the precise substring matcher didn't recognise
+// it, so maintainers notice kubelet error-text drift before users do.
+func TestLooksLikeShellNotFound(t *testing.T) {
+	tests := []struct {
+		name    string
+		errMsg  string
+		want    bool
+		comment string
+	}{
+		{
+			name:    "current kubelet: executable file not found",
+			errMsg:  `rpc error: code = Unknown desc = failed to exec in container: failed to start exec: cannot exec in a stopped container: executable file not found in $PATH: unknown`,
+			want:    true,
+			comment: "contains 'exec' and 'not found' — catches the error our isShellNotFoundError already handles, ensuring the canary overlap is intact",
+		},
+		{
+			name:    "hypothetical kubelet reword: exec missing",
+			errMsg:  `unable to start container process: exec: "bash": not found`,
+			want:    true,
+			comment: "new phrasing with 'exec' + 'not found' — the exact drift scenario the canary is designed to catch",
+		},
+		{
+			name:    "exit code 127 from sh -c script",
+			errMsg:  `command terminated with exit code 127`,
+			want:    true,
+			comment: "POSIX's reserved 'command not found' exit code — what kubelet surfaces when sh -c can't run",
+		},
+		{
+			name:    "unrelated websocket error",
+			errMsg:  `unable to upgrade connection: timeout`,
+			want:    false,
+			comment: "no exec/not-found/127 signals — must not fire",
+		},
+		{
+			name:    "permission denied",
+			errMsg:  `forbidden: pods "foo" is forbidden: User cannot exec`,
+			want:    false,
+			comment: "contains 'exec' but no 'not found' or exit 127 — must not fire",
+		},
+		{
+			name:    "k8s not found (pod, not shell)",
+			errMsg:  `pods "nonexistent-pod" not found`,
+			want:    false,
+			comment: "contains 'not found' but no 'exec' signal — must not fire",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := looksLikeShellNotFound(tc.errMsg)
+			if got != tc.want {
+				t.Errorf("looksLikeShellNotFound(%q) = %v, want %v (%s)", tc.errMsg, got, tc.want, tc.comment)
+			}
+		})
+	}
+}

--- a/internal/server/exec_test.go
+++ b/internal/server/exec_test.go
@@ -1,0 +1,71 @@
+package server
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestDefaultExecCommand covers the precedence rules for building the argv
+// passed to the pod exec subresource:
+//   - ?shell= override always wins and is passed verbatim as a single argv element
+//   - --pod-shell-default fallback is used when no override is present
+//   - the built-in defaultShellScript is used when neither is set
+func TestDefaultExecCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		override string
+		fallback string
+		want     []string
+	}{
+		{
+			name:     "no override and no fallback uses built-in script",
+			override: "",
+			fallback: "",
+			want:     []string{"sh", "-c", defaultShellScript},
+		},
+		{
+			name:     "fallback configured, no override, wraps in sh -c",
+			override: "",
+			fallback: "exec zsh",
+			want:     []string{"sh", "-c", "exec zsh"},
+		},
+		{
+			name:     "explicit override without fallback is passed verbatim",
+			override: "/bin/bash",
+			fallback: "",
+			want:     []string{"/bin/bash"},
+		},
+		{
+			name:     "explicit override wins over configured fallback",
+			override: "/bin/dash",
+			fallback: "exec zsh",
+			want:     []string{"/bin/dash"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := defaultExecCommand(tc.override, tc.fallback)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("defaultExecCommand(%q, %q) = %v, want %v", tc.override, tc.fallback, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDefaultShellScript documents the exact script content. Its role is to
+// fail loudly if someone edits defaultShellScript without updating the
+// verification checklist in the plan — the script is load-bearing for
+// skyhook-io/radar#452.
+//
+// Note: earlier drafts used `exec bash || exec ash || exec sh`, but POSIX
+// requires non-interactive shells to exit immediately when `exec` fails to
+// find the target. That broke the fallback chain on images without bash.
+// The current form detects each shell with `command -v` before execing,
+// so exec only runs for commands that are known to exist.
+func TestDefaultShellScript(t *testing.T) {
+	const expected = "export TERM=xterm-256color; if command -v bash >/dev/null 2>&1; then exec bash -il; elif command -v ash >/dev/null 2>&1; then exec ash; else exec sh; fi"
+	if defaultShellScript != expected {
+		t.Errorf("defaultShellScript changed:\n  got:  %q\n  want: %q", defaultShellScript, expected)
+	}
+}

--- a/internal/server/exec_test.go
+++ b/internal/server/exec_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -53,19 +54,32 @@ func TestDefaultExecCommand(t *testing.T) {
 	}
 }
 
-// TestDefaultShellScript documents the exact script content. Its role is to
-// fail loudly if someone edits defaultShellScript without updating the
-// verification checklist in the plan — the script is load-bearing for
-// skyhook-io/radar#452.
+// TestDefaultShellScript is a tripwire that pins the exact script content.
+// The script is load-bearing for skyhook-io/radar#452 — any edit should be
+// manually re-verified against the scenarios documented in the PR that
+// introduced it (bash present, ash-only, sh-only, --pod-shell-default
+// override, multi-container pod). If you're here because this test failed,
+// update `expected` AND re-run those scenarios before merging.
 //
-// Note: earlier drafts used `exec bash || exec ash || exec sh`, but POSIX
-// requires non-interactive shells to exit immediately when `exec` fails to
-// find the target. That broke the fallback chain on images without bash.
-// The current form detects each shell with `command -v` before execing,
-// so exec only runs for commands that are known to exist.
+// Earlier drafts used `exec bash || exec ash || exec sh`, but POSIX requires
+// non-interactive shells to exit immediately when `exec` fails to find the
+// target — so that cascade died with exit 127 on the first missing shell.
+// The current form detects each shell with `command -v` before execing, so
+// exec only runs for commands that are known to exist.
 func TestDefaultShellScript(t *testing.T) {
 	const expected = "export TERM=xterm-256color; if command -v bash >/dev/null 2>&1; then exec bash -il; elif command -v ash >/dev/null 2>&1; then exec ash; else exec sh; fi"
 	if defaultShellScript != expected {
 		t.Errorf("defaultShellScript changed:\n  got:  %q\n  want: %q", defaultShellScript, expected)
+	}
+
+	// Behavioral asserts — pin the load-bearing properties so a future edit
+	// that drops one of them fails with a specific message, not just a
+	// string-diff. These would have caught the `exec bash || exec ash` draft
+	// that broke live in alpine during this PR's development.
+	if !strings.Contains(defaultShellScript, "command -v bash") {
+		t.Error("defaultShellScript must detect bash with `command -v` before exec'ing — naive `exec bash || ...` fails under POSIX because non-interactive shells exit on exec-not-found")
+	}
+	if !strings.Contains(defaultShellScript, "bash -il") {
+		t.Error("defaultShellScript must run bash as `-il` (interactive login) so it sources the image's startup files and picks up a PS1 with \\w — that's the PWD-in-prompt fix from skyhook-io/radar#452")
 	}
 }


### PR DESCRIPTION
## Summary

Pod exec was hardcoded to `/bin/sh`, which on most minimal images is BusyBox `ash` or `dash` — neither ships readline, so users saw no up-arrow history, no tab completion, and no working-directory in the prompt. Bash was typically present on the same images but never tried. Closes #452.

The default is now a nested `sh -c` script that detects the best available shell via `command -v` and then `exec`s into it:

```sh
export TERM=xterm-256color
if command -v bash >/dev/null 2>&1; then exec bash -il
elif command -v ash >/dev/null 2>&1; then exec ash
else exec sh
fi
```

- **`bash -il`** — interactive login so `/etc/bash.bashrc` and `/etc/profile` get sourced, which is how images pick up a `\w`-containing `PS1` (the third symptom from the issue).
- **Detection before exec** — a naive `exec bash || exec ash` cascade doesn't work: POSIX requires non-interactive shells to exit immediately when `exec` fails to find the target, so the first missing shell kills the session before the fallback runs. `command -v` confirms existence first.
- **`TERM=xterm-256color`** — exported up front so colours and cursor movement work in images that don't set `TERM` themselves.

Also adds a `--pod-shell-default` CLI flag as a power-user escape hatch for cases where someone wants a different default (e.g. `zsh`). Wired through `internal/app/bootstrap` alongside the existing `--disable-exec` pattern. Normal users never need to touch it.

The existing `?shell=<path>` query-param override is preserved for the explicit case. Pods with no shell at all still surface the existing `shell_not_found` error path unchanged.

## What's not in scope

- **Windows pod support** (PowerShell fallback) — Radar doesn't detect pod OS today; separate follow-up.
- **UI shell picker** — neither Lens nor Headlamp expose one; the CLI flag leaves a clean seam if demand materialises.

## Verification

Unit tests: table-driven `TestDefaultExecCommand` covers the override × fallback matrix, plus a tripwire `TestDefaultShellScript` documenting the exact script content so future edits can't silently drift.

Live-tested against a real EKS cluster across five distinct scenarios:

| Scenario | Image | Expected | `$0` | `TERM` | Prompt rendered |
|---|---|---|---|---|---|
| Bash golden path | `debian:bookworm-slim` | `bash -il` | `bash` | `xterm-256color` | `root@test-bash-452:/#` |
| Ash fallback | `nginx:alpine` | `ash` | `ash` | `xterm-256color` | `/ #` |
| sh-only `else` branch | debian+bash removed | `sh` (dash) | `sh` | `xterm-256color` | `#` |
| `--pod-shell-default` override | `nginx:alpine` | user banner + shell | — | `xterm-256color` | `RADAR_OVERRIDE_HIT_72` + `/ #` |
| Multi-container switch | podinfo (alpine) + istio-proxy (ubuntu) | per-container | `ash` → `bash` | `xterm-256color` | `~ $` → `istio-proxy@…:/$` |

An earlier draft of this fix used `exec bash \|\| exec ash \|\| exec sh`; the live alpine test immediately caught that this dies with exit 127 on the first missing shell (POSIX exec-failure-exits-non-interactive-shell). The `command -v`-first form above is what the tests and live runs now validate.