### PR TITLE
Session lifecycle: sliding TTL, 4h default, editor draft persistence (prep for #382)

### DIFF
--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -55,7 +55,7 @@ func main() {
 	// Auth flags
 	authMode := flag.String("auth-mode", "none", "Authentication mode: none, proxy, or oidc")
 	authSecret := flag.String("auth-secret", "", "HMAC secret key for session cookies (auto-generated if empty)")
-	authCookieTTL := flag.Duration("auth-cookie-ttl", 24*time.Hour, "Session cookie TTL")
+	authCookieTTL := flag.Duration("auth-cookie-ttl", 4*time.Hour, "Session cookie TTL (sliding — extends on activity)")
 	authUserHeader := flag.String("auth-user-header", "X-Forwarded-User", "Header for username (proxy mode)")
 	authGroupsHeader := flag.String("auth-groups-header", "X-Forwarded-Groups", "Header for groups (proxy mode)")
 	authOIDCIssuer := flag.String("auth-oidc-issuer", "", "OIDC issuer URL")

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -162,8 +162,8 @@ auth:
   # Use an existing secret for the auth HMAC key
   existingSecret: ""
   existingSecretKey: "auth-secret"
-  # Session cookie TTL
-  cookieTTL: "24h"
+  # Session cookie TTL (sliding — extends on activity, idle sessions expire after this duration)
+  cookieTTL: "4h"
   # Proxy mode settings
   proxy:
     userHeader: "X-Forwarded-User"

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -318,7 +318,8 @@ The ServiceAccount's existing read permissions (list pods, watch deployments, et
 
 Radar uses stateless HMAC-SHA256 signed cookies for sessions. The cookie contains the username and groups — no server-side session storage.
 
-- **Cookie TTL**: 24 hours by default, configurable with `--auth-cookie-ttl` or `auth.cookieTTL` in Helm values
+- **Cookie TTL**: 4 hours by default (sliding), configurable with `--auth-cookie-ttl` or `auth.cookieTTL` in Helm values. Sessions auto-extend while you're active; idle sessions expire after the configured TTL. Active users won't notice — Radar's frontend polling keeps the session alive automatically.
+- **Proxy mode**: When the cookie expires, the middleware transparently re-creates the session from proxy headers on the next request, so the shorter default TTL has no UX impact.
 - **Session secret**: Set `auth.secret` or `RADAR_AUTH_SECRET` env var. If empty, a random key is generated at startup (sessions won't survive pod restarts)
 - **For production**: Use `auth.existingSecret` to reference a K8s Secret, so sessions survive restarts
 
@@ -328,7 +329,7 @@ Radar uses stateless HMAC-SHA256 signed cookies for sessions. The cookie contain
 |-----------|----------|------------|---------|
 | Auth mode | `--auth-mode` | `auth.mode` | `none` |
 | Session secret | `--auth-secret` | `auth.secret` | auto-generated |
-| Cookie TTL | `--auth-cookie-ttl` | `auth.cookieTTL` | `24h` |
+| Cookie TTL | `--auth-cookie-ttl` | `auth.cookieTTL` | `4h` (sliding) |
 | User header (proxy) | `--auth-user-header` | `auth.proxy.userHeader` | `X-Forwarded-User` |
 | Groups header (proxy) | `--auth-groups-header` | `auth.proxy.groupsHeader` | `X-Forwarded-Groups` |
 | OIDC issuer | `--auth-oidc-issuer` | `auth.oidc.issuerURL` | — |

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -9,6 +9,7 @@ import pkgauth "github.com/skyhook-io/radar/pkg/auth"
 // All callers can continue to import "internal/auth" without changes.
 type Config = pkgauth.Config
 type User = pkgauth.User
+type Session = pkgauth.Session
 type UserPermissions = pkgauth.UserPermissions
 type PermissionCache = pkgauth.PermissionCache
 
@@ -17,15 +18,14 @@ const DefaultCookieName = pkgauth.DefaultCookieName
 
 // Re-export functions from pkg/auth
 var (
-	UserFromContext      = pkgauth.UserFromContext
-	ContextWithUser      = pkgauth.ContextWithUser
-	NewPermissionCache   = pkgauth.NewPermissionCache
-	DiscoverNamespaces   = pkgauth.DiscoverNamespaces
-	SubjectCanI          = pkgauth.SubjectCanI
-	FilterNamespacesForUser = pkgauth.FilterNamespacesForUser
-	CreateSessionCookie          = pkgauth.CreateSessionCookie
-	CreateSessionCookieWithIDToken = pkgauth.CreateSessionCookieWithIDToken
-	ParseSessionCookie           = pkgauth.ParseSessionCookie
-	ClearSessionCookie           = pkgauth.ClearSessionCookie
-	IDTokenFromCookie            = pkgauth.IDTokenFromCookie
+	UserFromContext          = pkgauth.UserFromContext
+	ContextWithUser          = pkgauth.ContextWithUser
+	NewPermissionCache       = pkgauth.NewPermissionCache
+	DiscoverNamespaces       = pkgauth.DiscoverNamespaces
+	SubjectCanI              = pkgauth.SubjectCanI
+	FilterNamespacesForUser  = pkgauth.FilterNamespacesForUser
+	CreateSessionCookie      = pkgauth.CreateSessionCookie
+	NewSessionID             = pkgauth.NewSessionID
+	ParseSessionCookie       = pkgauth.ParseSessionCookie
+	ClearSessionCookie       = pkgauth.ClearSessionCookie
 )

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // Authenticate returns a chi middleware that extracts user identity from
@@ -27,8 +28,25 @@ func Authenticate(cfg Config) func(http.Handler) http.Handler {
 			// (set by the upstream reverse proxy) or a direct TLS connection.
 			secure := cfg.Mode == "oidc" || r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
 
-			// Try to get user from session cookie first
+			// Try to get user from session cookie first.
+			// Cookie-valid path slides the TTL; header-auth path below is a full re-auth.
 			if session := ParseSessionCookie(r, cfg.Secret); session != nil {
+				// Sliding TTL: re-issue cookie if past half-life or if remaining exceeds
+				// the configured TTL (handles TTL downgrade, e.g. 24h → 4h).
+				// SetCookie runs before next.ServeHTTP so the handler can't commit headers first.
+				remaining := time.Until(session.ExpiresAt)
+				if remaining < cfg.CookieTTL/2 || remaining > cfg.CookieTTL {
+					sid := session.SID
+					if sid == "" {
+						// Pre-upgrade cookie without sid — mint one on first sliding re-issue
+						sid = NewSessionID()
+					}
+					http.SetCookie(w, CreateSessionCookie(session.User, sid, session.IDToken, cfg.Secret, cfg.CookieTTL, secure))
+					if remaining > cfg.CookieTTL {
+						log.Printf("[auth] TTL downgrade detected for user %q: cookie remaining %s exceeds configured TTL %s, snapping",
+							session.User.Username, remaining.Round(time.Second), cfg.CookieTTL)
+					}
+				}
 				ctx := ContextWithUser(r.Context(), session.User)
 				next.ServeHTTP(w, r.WithContext(ctx))
 				return

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -28,8 +28,8 @@ func Authenticate(cfg Config) func(http.Handler) http.Handler {
 			secure := cfg.Mode == "oidc" || r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
 
 			// Try to get user from session cookie first
-			if user := ParseSessionCookie(r, cfg.Secret); user != nil {
-				ctx := ContextWithUser(r.Context(), user)
+			if session := ParseSessionCookie(r, cfg.Secret); session != nil {
+				ctx := ContextWithUser(r.Context(), session.User)
 				next.ServeHTTP(w, r.WithContext(ctx))
 				return
 			}
@@ -50,7 +50,8 @@ func Authenticate(cfg Config) func(http.Handler) http.Handler {
 					user := &User{Username: username, Groups: groups}
 
 					// Set session cookie so subsequent requests don't need headers
-					http.SetCookie(w, CreateSessionCookie(user, cfg.Secret, cfg.CookieTTL, secure))
+					// Header-auth creates a fresh session (new sid each time)
+					http.SetCookie(w, CreateSessionCookie(user, NewSessionID(), "", cfg.Secret, cfg.CookieTTL, secure))
 
 					ctx := ContextWithUser(r.Context(), user)
 					next.ServeHTTP(w, r.WithContext(ctx))

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -2,7 +2,11 @@ package auth
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -319,5 +323,229 @@ func TestIsSoftAuthPath(t *testing.T) {
 				t.Errorf("isSoftAuthPath(%q) = %v, want %v", tt.path, got, tt.want)
 			}
 		})
+	}
+}
+
+// --- Sliding TTL tests ---
+
+// makeCookieWithExpiry creates a signed session cookie with a specific ExpiresAt.
+func makeCookieWithExpiry(user *User, sid, secret string, expiresAt time.Time) *http.Cookie {
+	// Use the public constructor, but we need to craft a specific expiry.
+	// We compute the TTL that would produce the desired ExpiresAt from now.
+	ttl := time.Until(expiresAt)
+	return CreateSessionCookie(user, sid, "", secret, ttl, false)
+}
+
+func TestMiddleware_SlidingTTL_ReissuesPastHalfLife(t *testing.T) {
+	cfg := proxyConfig() // CookieTTL = 1h
+	mw := Authenticate(cfg)
+	handler := mw(http.HandlerFunc(echoUser))
+
+	// Cookie that expires in 15 minutes (past half-life of 1h)
+	sid := NewSessionID()
+	cookie := makeCookieWithExpiry(&User{Username: "alice"}, sid, cfg.Secret, time.Now().Add(15*time.Minute))
+
+	req := httptest.NewRequest("GET", "/api/topology", nil)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	// Should have re-issued a session cookie
+	found := false
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == DefaultCookieName {
+			found = true
+			// New cookie should have ~1h MaxAge (the configured TTL)
+			if c.MaxAge < 3500 || c.MaxAge > 3700 {
+				t.Errorf("re-issued cookie MaxAge = %d, want ~3600", c.MaxAge)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected Set-Cookie for sliding TTL re-issue past half-life")
+	}
+}
+
+func TestMiddleware_SlidingTTL_NoReissueWhenFresh(t *testing.T) {
+	cfg := proxyConfig() // CookieTTL = 1h
+	mw := Authenticate(cfg)
+	handler := mw(http.HandlerFunc(echoUser))
+
+	// Cookie that expires in 50 minutes (within first half of 1h TTL — fresh)
+	sid := NewSessionID()
+	cookie := makeCookieWithExpiry(&User{Username: "alice"}, sid, cfg.Secret, time.Now().Add(50*time.Minute))
+
+	req := httptest.NewRequest("GET", "/api/topology", nil)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	// Should NOT have set a cookie (still fresh)
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == DefaultCookieName {
+			t.Error("should not re-issue cookie when still in fresh half of TTL")
+		}
+	}
+}
+
+func TestMiddleware_SlidingTTL_ReissuesOnTTLDowngrade(t *testing.T) {
+	cfg := proxyConfig()
+	cfg.CookieTTL = 4 * time.Hour // simulate downgrade to 4h
+	mw := Authenticate(cfg)
+	handler := mw(http.HandlerFunc(echoUser))
+
+	// Old cookie with 20h remaining (issued under 24h TTL)
+	sid := NewSessionID()
+	cookie := makeCookieWithExpiry(&User{Username: "alice"}, sid, cfg.Secret, time.Now().Add(20*time.Hour))
+
+	req := httptest.NewRequest("GET", "/api/topology", nil)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	// Should snap to new TTL
+	found := false
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == DefaultCookieName {
+			found = true
+			// New cookie should have ~4h MaxAge
+			expected := int(4 * time.Hour / time.Second)
+			if c.MaxAge < expected-100 || c.MaxAge > expected+100 {
+				t.Errorf("re-issued cookie MaxAge = %d, want ~%d", c.MaxAge, expected)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected Set-Cookie for TTL downgrade snap")
+	}
+}
+
+func TestMiddleware_SlidingTTL_PreservesSID(t *testing.T) {
+	cfg := proxyConfig()
+	mw := Authenticate(cfg)
+	handler := mw(http.HandlerFunc(echoUser))
+
+	// Cookie past half-life so it gets re-issued
+	sid := "deadbeef01234567deadbeef01234567"
+	cookie := makeCookieWithExpiry(&User{Username: "alice"}, sid, cfg.Secret, time.Now().Add(10*time.Minute))
+
+	req := httptest.NewRequest("GET", "/api/topology", nil)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	// Parse the re-issued cookie to verify sid
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == DefaultCookieName {
+			parseReq := httptest.NewRequest("GET", "/", nil)
+			parseReq.AddCookie(c)
+			session := ParseSessionCookie(parseReq, cfg.Secret)
+			if session == nil {
+				t.Fatal("failed to parse re-issued cookie")
+			}
+			if session.SID != sid {
+				t.Errorf("re-issued SID = %q, want %q (should be preserved)", session.SID, sid)
+			}
+			return
+		}
+	}
+	t.Error("expected Set-Cookie for sliding re-issue")
+}
+
+func TestMiddleware_SlidingTTL_LegacyCookieMintsSID(t *testing.T) {
+	cfg := proxyConfig()
+	mw := Authenticate(cfg)
+	handler := mw(http.HandlerFunc(echoUser))
+
+	// Simulate a legacy cookie without SID by crafting a cookie whose parsed SID is ""
+	// We do this by using the old schema format (no "s" field)
+	legacyCookie := makeLegacyCookie("alice", cfg.Secret, time.Now().Add(10*time.Minute))
+
+	req := httptest.NewRequest("GET", "/api/topology", nil)
+	req.AddCookie(legacyCookie)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	// Re-issued cookie should have a minted SID
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == DefaultCookieName {
+			parseReq := httptest.NewRequest("GET", "/", nil)
+			parseReq.AddCookie(c)
+			session := ParseSessionCookie(parseReq, cfg.Secret)
+			if session == nil {
+				t.Fatal("failed to parse re-issued cookie")
+			}
+			if session.SID == "" {
+				t.Error("re-issued cookie should have a minted SID for legacy cookie")
+			}
+			if len(session.SID) != 32 {
+				t.Errorf("minted SID length = %d, want 32", len(session.SID))
+			}
+			return
+		}
+	}
+	t.Error("expected Set-Cookie for legacy cookie re-issue")
+}
+
+// makeLegacyCookie creates a signed cookie using the old schema (no SID field).
+func makeLegacyCookie(username, secret string, expiresAt time.Time) *http.Cookie {
+	type legacyPayload struct {
+		Username  string   `json:"u"`
+		Groups    []string `json:"g,omitempty"`
+		ExpiresAt int64    `json:"e"`
+	}
+
+	payload := legacyPayload{
+		Username:  username,
+		ExpiresAt: expiresAt.Unix(),
+	}
+
+	data, _ := json.Marshal(payload)
+	encoded := base64.RawURLEncoding.EncodeToString(data)
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	fmt.Fprint(mac, encoded)
+	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+
+	return &http.Cookie{
+		Name:  DefaultCookieName,
+		Value: encoded + "." + sig,
+	}
+}
+
+func TestMiddleware_NoReissueOnExpiredCookie(t *testing.T) {
+	cfg := proxyConfig()
+	mw := Authenticate(cfg)
+	handler := mw(http.HandlerFunc(echoUser))
+
+	// Expired cookie
+	cookie := makeCookieWithExpiry(&User{Username: "alice"}, NewSessionID(), cfg.Secret, time.Now().Add(-1*time.Minute))
+
+	req := httptest.NewRequest("GET", "/api/topology", nil)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	// Should get 401, not 200 with re-issue
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 for expired cookie", rec.Code)
 	}
 }

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -129,7 +129,7 @@ func TestMiddleware_SessionCookie(t *testing.T) {
 
 	// Create a valid session cookie
 	user := &User{Username: "bob", Groups: []string{"ops"}}
-	cookie := CreateSessionCookie(user, cfg.Secret, cfg.CookieTTL, false)
+	cookie := CreateSessionCookie(user, NewSessionID(), "", cfg.Secret, cfg.CookieTTL, false)
 
 	req := httptest.NewRequest("GET", "/api/topology", nil)
 	req.AddCookie(cookie)
@@ -154,7 +154,7 @@ func TestMiddleware_SessionCookie_TakesPrecedence(t *testing.T) {
 	handler := mw(http.HandlerFunc(echoUser))
 
 	// Cookie says "bob", proxy header says "alice"
-	cookie := CreateSessionCookie(&User{Username: "bob"}, cfg.Secret, cfg.CookieTTL, false)
+	cookie := CreateSessionCookie(&User{Username: "bob"}, NewSessionID(), "", cfg.Secret, cfg.CookieTTL, false)
 
 	req := httptest.NewRequest("GET", "/api/topology", nil)
 	req.AddCookie(cookie)
@@ -191,7 +191,7 @@ func TestMiddleware_SoftAuthPath_WithUser(t *testing.T) {
 	handler := mw(http.HandlerFunc(echoUser))
 
 	// /api/auth/me with valid cookie should include user
-	cookie := CreateSessionCookie(&User{Username: "carol"}, cfg.Secret, cfg.CookieTTL, false)
+	cookie := CreateSessionCookie(&User{Username: "carol"}, NewSessionID(), "", cfg.Secret, cfg.CookieTTL, false)
 	req := httptest.NewRequest("GET", "/api/auth/me", nil)
 	req.AddCookie(cookie)
 	rec := httptest.NewRecorder()

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -468,6 +468,41 @@ func TestMiddleware_SlidingTTL_PreservesSID(t *testing.T) {
 	t.Error("expected Set-Cookie for sliding re-issue")
 }
 
+func TestMiddleware_SlidingTTL_PreservesIDToken(t *testing.T) {
+	cfg := proxyConfig()
+	mw := Authenticate(cfg)
+	handler := mw(http.HandlerFunc(echoUser))
+
+	// Cookie past half-life with an ID token (needed for RP-Initiated Logout)
+	sid := NewSessionID()
+	idToken := "eyJhbGciOiJSUzI1NiJ9.test-payload.test-sig"
+	ttl := time.Until(time.Now().Add(10 * time.Minute))
+	cookie := CreateSessionCookie(&User{Username: "alice"}, sid, idToken, cfg.Secret, ttl, false)
+
+	req := httptest.NewRequest("GET", "/api/topology", nil)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	// Parse the re-issued cookie to verify IDToken survived
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == DefaultCookieName {
+			parseReq := httptest.NewRequest("GET", "/", nil)
+			parseReq.AddCookie(c)
+			session := ParseSessionCookie(parseReq, cfg.Secret)
+			if session == nil {
+				t.Fatal("failed to parse re-issued cookie")
+			}
+			if session.IDToken != idToken {
+				t.Errorf("re-issued IDToken = %q, want %q (must survive for RP-Initiated Logout)", session.IDToken, idToken)
+			}
+			return
+		}
+	}
+	t.Error("expected Set-Cookie for sliding re-issue")
+}
+
 func TestMiddleware_SlidingTTL_LegacyCookieMintsSID(t *testing.T) {
 	cfg := proxyConfig()
 	mw := Authenticate(cfg)

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -232,9 +232,20 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 
 	user := &User{Username: username, Groups: groups}
 
+	// Extract session ID from ID token if present (needed for backchannel logout matching),
+	// otherwise generate a random one.
+	var sid string
+	if s, ok := claims["sid"].(string); ok && s != "" {
+		sid = s
+		log.Printf("[oidc] Using IdP-provided session ID (sid claim present)")
+	} else {
+		sid = NewSessionID()
+		log.Printf("[oidc] Generated local session ID (IdP did not provide sid claim)")
+	}
+
 	// Create session cookie (include raw ID token for RP-Initiated Logout)
 	secure := true // OIDC typically behind TLS
-	http.SetCookie(w, CreateSessionCookieWithIDToken(user, rawIDToken, h.cfg.Secret, h.cfg.CookieTTL, secure))
+	http.SetCookie(w, CreateSessionCookie(user, sid, rawIDToken, h.cfg.Secret, h.cfg.CookieTTL, secure))
 
 	log.Printf("[oidc] User %s authenticated (groups: %v)", username, groups)
 
@@ -248,7 +259,10 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 // the SSO session.
 func (h *OIDCHandler) HandleLogout(w http.ResponseWriter, r *http.Request) {
 	// Extract ID token before clearing the cookie (needed as id_token_hint)
-	idToken := IDTokenFromCookie(r, h.cfg.Secret)
+	var idToken string
+	if session := ParseSessionCookie(r, h.cfg.Secret); session != nil {
+		idToken = session.IDToken
+	}
 
 	http.SetCookie(w, ClearSessionCookie())
 

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -99,7 +99,7 @@ func TestHandleLogout_WithEndSessionEndpoint(t *testing.T) {
 
 	// Create a session cookie with an ID token
 	user := &User{Username: "alice"}
-	cookie := CreateSessionCookieWithIDToken(user, "my-id-token", h.cfg.Secret, 1*time.Hour, false)
+	cookie := CreateSessionCookie(user, NewSessionID(), "my-id-token", h.cfg.Secret, 1*time.Hour, false)
 
 	r := httptest.NewRequest("GET", "/auth/logout", nil)
 	r.AddCookie(cookie)
@@ -167,7 +167,7 @@ func TestHandleLogout_NoIDTokenInCookie(t *testing.T) {
 
 	// Session cookie without ID token (old session from before upgrade)
 	user := &User{Username: "alice"}
-	cookie := CreateSessionCookie(user, h.cfg.Secret, 1*time.Hour, false)
+	cookie := CreateSessionCookie(user, NewSessionID(), "", h.cfg.Secret, 1*time.Hour, false)
 
 	r := httptest.NewRequest("GET", "/auth/logout", nil)
 	r.AddCookie(cookie)

--- a/packages/k8s-ui/src/components/shared/EditableYamlView.tsx
+++ b/packages/k8s-ui/src/components/shared/EditableYamlView.tsx
@@ -91,6 +91,18 @@ function formatSaveError(error: string): { summary: string; details?: string } {
   return { summary: error }
 }
 
+// Safe sessionStorage wrappers — storage can throw QuotaExceededError or be
+// blocked by browser security policies. Draft persistence is best-effort.
+function safeSessionGet(key: string): string | null {
+  try { return sessionStorage.getItem(key) } catch { return null }
+}
+function safeSessionSet(key: string, value: string): void {
+  try { sessionStorage.setItem(key, value) } catch { /* best-effort */ }
+}
+function safeSessionRemove(key: string): void {
+  try { sessionStorage.removeItem(key) } catch { /* best-effort */ }
+}
+
 interface EditableYamlViewProps {
   resource: SelectedResource
   data: any
@@ -111,8 +123,10 @@ interface EditableYamlViewProps {
 export function EditableYamlView({ resource, data, onCopy, copied, onSaved, onSave, isSaving, saveError, onDuplicate }: EditableYamlViewProps) {
   const draftKey = `radar_yaml_draft:${resource.kind}/${resource.namespace}/${resource.name}`
 
-  // Restore draft from sessionStorage (e.g., after session-expiry redirect)
-  const savedDraft = useRef(sessionStorage.getItem(draftKey))
+  // Restore draft from sessionStorage (e.g., after session-expiry redirect).
+  // All sessionStorage calls are wrapped in try-catch — storage can throw
+  // QuotaExceededError or be blocked by browser security policies.
+  const savedDraft = useRef(safeSessionGet(draftKey))
   const [isEditing, setIsEditing] = useState(savedDraft.current !== null)
   const [editedYaml, setEditedYaml] = useState(savedDraft.current ?? '')
   const [yamlErrors, setYamlErrors] = useState<string[]>([])
@@ -120,18 +134,18 @@ export function EditableYamlView({ resource, data, onCopy, copied, onSaved, onSa
 
   // Clean up restored draft flag
   useEffect(() => {
-    if (savedDraft.current) {
-      sessionStorage.removeItem(draftKey)
+    if (typeof savedDraft.current === 'string') {
+      safeSessionRemove(draftKey)
       savedDraft.current = null
     }
   }, [draftKey])
 
-  // Autosave draft to sessionStorage while editing
+  // Autosave draft to sessionStorage while editing (best-effort)
   useEffect(() => {
     if (isEditing && editedYaml) {
-      sessionStorage.setItem(draftKey, editedYaml)
+      safeSessionSet(draftKey, editedYaml)
     } else {
-      sessionStorage.removeItem(draftKey)
+      safeSessionRemove(draftKey)
     }
   }, [isEditing, editedYaml, draftKey])
 

--- a/packages/k8s-ui/src/components/shared/EditableYamlView.tsx
+++ b/packages/k8s-ui/src/components/shared/EditableYamlView.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import {
   Copy,
   CopyPlus,
@@ -109,10 +109,31 @@ interface EditableYamlViewProps {
 }
 
 export function EditableYamlView({ resource, data, onCopy, copied, onSaved, onSave, isSaving, saveError, onDuplicate }: EditableYamlViewProps) {
-  const [isEditing, setIsEditing] = useState(false)
-  const [editedYaml, setEditedYaml] = useState('')
+  const draftKey = `radar_yaml_draft:${resource.kind}/${resource.namespace}/${resource.name}`
+
+  // Restore draft from sessionStorage (e.g., after session-expiry redirect)
+  const savedDraft = useRef(sessionStorage.getItem(draftKey))
+  const [isEditing, setIsEditing] = useState(savedDraft.current !== null)
+  const [editedYaml, setEditedYaml] = useState(savedDraft.current ?? '')
   const [yamlErrors, setYamlErrors] = useState<string[]>([])
   const [showErrorDetails, setShowErrorDetails] = useState(false)
+
+  // Clean up restored draft flag
+  useEffect(() => {
+    if (savedDraft.current) {
+      sessionStorage.removeItem(draftKey)
+      savedDraft.current = null
+    }
+  }, [draftKey])
+
+  // Autosave draft to sessionStorage while editing
+  useEffect(() => {
+    if (isEditing && editedYaml) {
+      sessionStorage.setItem(draftKey, editedYaml)
+    } else {
+      sessionStorage.removeItem(draftKey)
+    }
+  }, [isEditing, editedYaml, draftKey])
 
   // Convert resource to YAML for editing
   const convertToYaml = useCallback((d: any) => {

--- a/pkg/auth/config_test.go
+++ b/pkg/auth/config_test.go
@@ -32,8 +32,8 @@ func TestConfig_Defaults(t *testing.T) {
 	cfg := Config{Mode: "proxy"}
 	cfg.Defaults()
 
-	if cfg.CookieTTL != 24*time.Hour {
-		t.Errorf("CookieTTL = %v, want 24h", cfg.CookieTTL)
+	if cfg.CookieTTL != 4*time.Hour {
+		t.Errorf("CookieTTL = %v, want 4h", cfg.CookieTTL)
 	}
 	if cfg.UserHeader != "X-Forwarded-User" {
 		t.Errorf("UserHeader = %q, want %q", cfg.UserHeader, "X-Forwarded-User")

--- a/pkg/auth/cookie.go
+++ b/pkg/auth/cookie.go
@@ -2,8 +2,10 @@ package auth
 
 import (
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -15,23 +17,71 @@ import (
 // DefaultCookieName is the default session cookie name
 const DefaultCookieName = "radar_session"
 
+// Session represents a parsed session cookie.
+type Session struct {
+	User      *User
+	SID       string    // stable session identifier (empty for pre-upgrade cookies)
+	IDToken   string    // raw OIDC id_token for RP-Initiated Logout
+	ExpiresAt time.Time // when the cookie expires
+}
+
 // cookiePayload is the data stored in the session cookie
 type cookiePayload struct {
 	Username  string   `json:"u"`
 	Groups    []string `json:"g,omitempty"`
 	ExpiresAt int64    `json:"e"`
 	IDToken   string   `json:"t,omitempty"` // raw OIDC id_token for RP-Initiated Logout
+	SID       string   `json:"s,omitempty"` // session ID for backchannel logout revocation
+}
+
+// NewSessionID generates a random 16-byte hex session ID.
+func NewSessionID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		log.Fatalf("[auth] Failed to generate session ID: %v", err)
+	}
+	return hex.EncodeToString(b)
 }
 
 // CreateSessionCookie creates a signed session cookie for the given user.
-// Format: base64(json) + "." + base64(hmac-sha256)
-func CreateSessionCookie(user *User, secret string, ttl time.Duration, secure bool) *http.Cookie {
-	return CreateSessionCookieWithIDToken(user, "", secret, ttl, secure)
+// Format: base64(json) + "." + base64(hmac-sha256).
+// The sid must be non-empty — use NewSessionID() to generate one.
+func CreateSessionCookie(user *User, sid, idToken, secret string, ttl time.Duration, secure bool) *http.Cookie {
+	if sid == "" {
+		log.Fatalf("[auth] CreateSessionCookie called with empty sid for user %s", user.Username)
+	}
+
+	payload := cookiePayload{
+		Username:  user.Username,
+		Groups:    user.Groups,
+		ExpiresAt: time.Now().Add(ttl).Unix(),
+		IDToken:   idToken,
+		SID:       sid,
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		log.Fatalf("[auth] Failed to marshal session cookie payload for user %s: %v", user.Username, err)
+	}
+	encoded := base64.RawURLEncoding.EncodeToString(data)
+
+	sig := signData(encoded, secret)
+
+	return &http.Cookie{
+		Name:     DefaultCookieName,
+		Value:    encoded + "." + sig,
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   int(ttl.Seconds()),
+	}
 }
 
 // ParseSessionCookie validates and parses a session cookie.
 // Returns nil if the cookie is missing, invalid, or expired.
-func ParseSessionCookie(r *http.Request, secret string) *User {
+// Pre-upgrade cookies without a SID parse successfully with Session.SID == "".
+func ParseSessionCookie(r *http.Request, secret string) *Session {
 	cookie, err := r.Cookie(DefaultCookieName)
 	if err != nil {
 		return nil
@@ -68,76 +118,15 @@ func ParseSessionCookie(r *http.Request, secret string) *User {
 		return nil
 	}
 
-	return &User{
-		Username: p.Username,
-		Groups:   p.Groups,
+	return &Session{
+		User: &User{
+			Username: p.Username,
+			Groups:   p.Groups,
+		},
+		SID:       p.SID,
+		IDToken:   p.IDToken,
+		ExpiresAt: time.Unix(p.ExpiresAt, 0),
 	}
-}
-
-// CreateSessionCookieWithIDToken creates a signed session cookie that also stores
-// the raw OIDC ID token for use as id_token_hint during RP-Initiated Logout.
-func CreateSessionCookieWithIDToken(user *User, idToken string, secret string, ttl time.Duration, secure bool) *http.Cookie {
-	payload := cookiePayload{
-		Username:  user.Username,
-		Groups:    user.Groups,
-		ExpiresAt: time.Now().Add(ttl).Unix(),
-		IDToken:   idToken,
-	}
-
-	data, err := json.Marshal(payload)
-	if err != nil {
-		log.Fatalf("[auth] Failed to marshal session cookie payload for user %s: %v", user.Username, err)
-	}
-	encoded := base64.RawURLEncoding.EncodeToString(data)
-
-	sig := signData(encoded, secret)
-
-	return &http.Cookie{
-		Name:     DefaultCookieName,
-		Value:    encoded + "." + sig,
-		Path:     "/",
-		HttpOnly: true,
-		Secure:   secure,
-		SameSite: http.SameSiteLaxMode,
-		MaxAge:   int(ttl.Seconds()),
-	}
-}
-
-// IDTokenFromCookie extracts the raw OIDC ID token from the session cookie.
-// Returns "" if the cookie is missing, invalid, expired, or has no ID token.
-func IDTokenFromCookie(r *http.Request, secret string) string {
-	cookie, err := r.Cookie(DefaultCookieName)
-	if err != nil {
-		return ""
-	}
-
-	parts := strings.SplitN(cookie.Value, ".", 2)
-	if len(parts) != 2 {
-		return ""
-	}
-
-	encoded, sig := parts[0], parts[1]
-
-	expected := signData(encoded, secret)
-	if !hmac.Equal([]byte(sig), []byte(expected)) {
-		return ""
-	}
-
-	data, err := base64.RawURLEncoding.DecodeString(encoded)
-	if err != nil {
-		return ""
-	}
-
-	var p cookiePayload
-	if err := json.Unmarshal(data, &p); err != nil {
-		return ""
-	}
-
-	if time.Now().Unix() > p.ExpiresAt {
-		return ""
-	}
-
-	return p.IDToken
 }
 
 // ClearSessionCookie returns a cookie that clears the session

--- a/pkg/auth/cookie.go
+++ b/pkg/auth/cookie.go
@@ -38,7 +38,7 @@ type cookiePayload struct {
 func NewSessionID() string {
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
-		log.Fatalf("[auth] Failed to generate session ID: %v", err)
+		panic(fmt.Sprintf("[auth] Failed to generate session ID: %v", err))
 	}
 	return hex.EncodeToString(b)
 }
@@ -48,7 +48,7 @@ func NewSessionID() string {
 // The sid must be non-empty — use NewSessionID() to generate one.
 func CreateSessionCookie(user *User, sid, idToken, secret string, ttl time.Duration, secure bool) *http.Cookie {
 	if sid == "" {
-		log.Fatalf("[auth] CreateSessionCookie called with empty sid for user %s", user.Username)
+		panic(fmt.Sprintf("[auth] CreateSessionCookie called with empty sid for user %s", user.Username))
 	}
 
 	payload := cookiePayload{

--- a/pkg/auth/cookie_test.go
+++ b/pkg/auth/cookie_test.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,9 +12,10 @@ import (
 func TestCreateAndParseSessionCookie(t *testing.T) {
 	secret := "test-secret-key"
 	user := &User{Username: "alice", Groups: []string{"devs", "admins"}}
+	sid := NewSessionID()
 	ttl := 1 * time.Hour
 
-	cookie := CreateSessionCookie(user, secret, ttl, false)
+	cookie := CreateSessionCookie(user, sid, "", secret, ttl, false)
 
 	// Verify cookie properties
 	if cookie.Name != DefaultCookieName {
@@ -39,17 +42,20 @@ func TestCreateAndParseSessionCookie(t *testing.T) {
 	if parsed == nil {
 		t.Fatal("ParseSessionCookie returned nil for valid cookie")
 	}
-	if parsed.Username != "alice" {
-		t.Errorf("username = %q, want %q", parsed.Username, "alice")
+	if parsed.User.Username != "alice" {
+		t.Errorf("username = %q, want %q", parsed.User.Username, "alice")
 	}
-	if len(parsed.Groups) != 2 || parsed.Groups[0] != "devs" || parsed.Groups[1] != "admins" {
-		t.Errorf("groups = %v, want [devs admins]", parsed.Groups)
+	if len(parsed.User.Groups) != 2 || parsed.User.Groups[0] != "devs" || parsed.User.Groups[1] != "admins" {
+		t.Errorf("groups = %v, want [devs admins]", parsed.User.Groups)
+	}
+	if parsed.SID != sid {
+		t.Errorf("SID = %q, want %q", parsed.SID, sid)
 	}
 }
 
 func TestParseSessionCookie_WrongSecret(t *testing.T) {
 	user := &User{Username: "alice"}
-	cookie := CreateSessionCookie(user, "secret-1", 1*time.Hour, false)
+	cookie := CreateSessionCookie(user, NewSessionID(), "", "secret-1", 1*time.Hour, false)
 
 	req := httptest.NewRequest("GET", "/", nil)
 	req.AddCookie(cookie)
@@ -63,7 +69,7 @@ func TestParseSessionCookie_WrongSecret(t *testing.T) {
 func TestParseSessionCookie_Expired(t *testing.T) {
 	user := &User{Username: "alice"}
 	// TTL of -1 second = already expired
-	cookie := CreateSessionCookie(user, "secret", -1*time.Second, false)
+	cookie := CreateSessionCookie(user, NewSessionID(), "", "secret", -1*time.Second, false)
 
 	req := httptest.NewRequest("GET", "/", nil)
 	req.AddCookie(cookie)
@@ -84,7 +90,7 @@ func TestParseSessionCookie_NoCookie(t *testing.T) {
 
 func TestParseSessionCookie_TamperedPayload(t *testing.T) {
 	user := &User{Username: "alice"}
-	cookie := CreateSessionCookie(user, "secret", 1*time.Hour, false)
+	cookie := CreateSessionCookie(user, NewSessionID(), "", "secret", 1*time.Hour, false)
 
 	// Tamper with the payload (change first char)
 	val := cookie.Value
@@ -115,7 +121,7 @@ func TestParseSessionCookie_MalformedValue(t *testing.T) {
 
 func TestCreateSessionCookie_Secure(t *testing.T) {
 	user := &User{Username: "alice"}
-	cookie := CreateSessionCookie(user, "secret", 1*time.Hour, true)
+	cookie := CreateSessionCookie(user, NewSessionID(), "", "secret", 1*time.Hour, true)
 	if !cookie.Secure {
 		t.Error("cookie should be Secure when secure=true")
 	}
@@ -123,7 +129,7 @@ func TestCreateSessionCookie_Secure(t *testing.T) {
 
 func TestCreateSessionCookie_NoGroups(t *testing.T) {
 	user := &User{Username: "bob"}
-	cookie := CreateSessionCookie(user, "secret", 1*time.Hour, false)
+	cookie := CreateSessionCookie(user, NewSessionID(), "", "secret", 1*time.Hour, false)
 
 	req := httptest.NewRequest("GET", "/", nil)
 	req.AddCookie(cookie)
@@ -132,11 +138,11 @@ func TestCreateSessionCookie_NoGroups(t *testing.T) {
 	if parsed == nil {
 		t.Fatal("ParseSessionCookie returned nil")
 	}
-	if parsed.Username != "bob" {
-		t.Errorf("username = %q, want %q", parsed.Username, "bob")
+	if parsed.User.Username != "bob" {
+		t.Errorf("username = %q, want %q", parsed.User.Username, "bob")
 	}
-	if len(parsed.Groups) != 0 {
-		t.Errorf("groups = %v, want empty", parsed.Groups)
+	if len(parsed.User.Groups) != 0 {
+		t.Errorf("groups = %v, want empty", parsed.User.Groups)
 	}
 }
 
@@ -174,14 +180,14 @@ func TestSignData_DifferentSecrets(t *testing.T) {
 	}
 }
 
-func TestCreateSessionCookieWithIDToken(t *testing.T) {
+func TestCreateSessionCookie_WithIDToken(t *testing.T) {
 	secret := "test-secret"
 	user := &User{Username: "alice", Groups: []string{"devs"}}
+	sid := NewSessionID()
 	idToken := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test-payload.test-sig"
 
-	cookie := CreateSessionCookieWithIDToken(user, idToken, secret, 1*time.Hour, false)
+	cookie := CreateSessionCookie(user, sid, idToken, secret, 1*time.Hour, false)
 
-	// Should still parse as a valid session cookie
 	req := httptest.NewRequest("GET", "/", nil)
 	req.AddCookie(cookie)
 
@@ -189,60 +195,126 @@ func TestCreateSessionCookieWithIDToken(t *testing.T) {
 	if parsed == nil {
 		t.Fatal("ParseSessionCookie returned nil for cookie with ID token")
 	}
-	if parsed.Username != "alice" {
-		t.Errorf("username = %q, want %q", parsed.Username, "alice")
+	if parsed.User.Username != "alice" {
+		t.Errorf("username = %q, want %q", parsed.User.Username, "alice")
 	}
-
-	// Should be able to extract ID token
-	got := IDTokenFromCookie(req, secret)
-	if got != idToken {
-		t.Errorf("IDTokenFromCookie = %q, want %q", got, idToken)
+	if parsed.IDToken != idToken {
+		t.Errorf("IDToken = %q, want %q", parsed.IDToken, idToken)
+	}
+	if parsed.SID != sid {
+		t.Errorf("SID = %q, want %q", parsed.SID, sid)
 	}
 }
 
-func TestIDTokenFromCookie_NoIDToken(t *testing.T) {
+func TestSessionIDToken_NoIDToken(t *testing.T) {
 	secret := "test-secret"
 	user := &User{Username: "alice"}
 
-	// Cookie created without ID token (e.g., proxy mode or pre-upgrade session)
-	cookie := CreateSessionCookie(user, secret, 1*time.Hour, false)
+	cookie := CreateSessionCookie(user, NewSessionID(), "", secret, 1*time.Hour, false)
 	req := httptest.NewRequest("GET", "/", nil)
 	req.AddCookie(cookie)
 
-	got := IDTokenFromCookie(req, secret)
-	if got != "" {
-		t.Errorf("IDTokenFromCookie = %q, want empty string", got)
+	parsed := ParseSessionCookie(req, secret)
+	if parsed == nil {
+		t.Fatal("ParseSessionCookie returned nil")
+	}
+	if parsed.IDToken != "" {
+		t.Errorf("IDToken = %q, want empty string", parsed.IDToken)
 	}
 }
 
-func TestIDTokenFromCookie_NoCookie(t *testing.T) {
-	req := httptest.NewRequest("GET", "/", nil)
-	got := IDTokenFromCookie(req, "secret")
-	if got != "" {
-		t.Errorf("IDTokenFromCookie = %q, want empty string", got)
-	}
-}
-
-func TestIDTokenFromCookie_WrongSecret(t *testing.T) {
+func TestCreateSessionCookie_WithSID(t *testing.T) {
+	secret := "test-secret"
 	user := &User{Username: "alice"}
-	cookie := CreateSessionCookieWithIDToken(user, "some-token", "secret-1", 1*time.Hour, false)
+	sid := "abcdef0123456789abcdef0123456789"
+
+	cookie := CreateSessionCookie(user, sid, "", secret, 1*time.Hour, false)
+
 	req := httptest.NewRequest("GET", "/", nil)
 	req.AddCookie(cookie)
 
-	got := IDTokenFromCookie(req, "secret-2")
-	if got != "" {
-		t.Errorf("IDTokenFromCookie should return empty string for wrong secret")
+	parsed := ParseSessionCookie(req, secret)
+	if parsed == nil {
+		t.Fatal("ParseSessionCookie returned nil")
+	}
+	if parsed.SID != sid {
+		t.Errorf("SID = %q, want %q", parsed.SID, sid)
 	}
 }
 
-func TestIDTokenFromCookie_Expired(t *testing.T) {
+func TestParseSessionCookie_LegacyCookieWithoutSID(t *testing.T) {
+	// Simulate a pre-upgrade cookie that doesn't have the "s" field
+	secret := "test-secret"
+	payload := struct {
+		Username  string   `json:"u"`
+		Groups    []string `json:"g,omitempty"`
+		ExpiresAt int64    `json:"e"`
+		IDToken   string   `json:"t,omitempty"`
+	}{
+		Username:  "alice",
+		Groups:    []string{"devs"},
+		ExpiresAt: time.Now().Add(1 * time.Hour).Unix(),
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded := base64.RawURLEncoding.EncodeToString(data)
+	sig := signData(encoded, secret)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  DefaultCookieName,
+		Value: encoded + "." + sig,
+	})
+
+	parsed := ParseSessionCookie(req, secret)
+	if parsed == nil {
+		t.Fatal("ParseSessionCookie should handle legacy cookies without sid")
+	}
+	if parsed.User.Username != "alice" {
+		t.Errorf("username = %q, want %q", parsed.User.Username, "alice")
+	}
+	if parsed.SID != "" {
+		t.Errorf("SID = %q, want empty string for legacy cookie", parsed.SID)
+	}
+}
+
+func TestNewSessionID_Unique(t *testing.T) {
+	id1 := NewSessionID()
+	id2 := NewSessionID()
+
+	if id1 == id2 {
+		t.Error("NewSessionID should produce unique values")
+	}
+	if len(id1) != 32 {
+		t.Errorf("NewSessionID length = %d, want 32 (16 bytes hex)", len(id1))
+	}
+	if len(id2) != 32 {
+		t.Errorf("NewSessionID length = %d, want 32 (16 bytes hex)", len(id2))
+	}
+}
+
+func TestParseSessionCookie_ExpiresAt(t *testing.T) {
+	secret := "test-secret"
 	user := &User{Username: "alice"}
-	cookie := CreateSessionCookieWithIDToken(user, "some-token", "secret", -1*time.Second, false)
+	ttl := 2 * time.Hour
+
+	cookie := CreateSessionCookie(user, NewSessionID(), "", secret, ttl, false)
+
 	req := httptest.NewRequest("GET", "/", nil)
 	req.AddCookie(cookie)
 
-	got := IDTokenFromCookie(req, "secret")
-	if got != "" {
-		t.Errorf("IDTokenFromCookie should return empty string for expired cookie")
+	parsed := ParseSessionCookie(req, secret)
+	if parsed == nil {
+		t.Fatal("ParseSessionCookie returned nil")
+	}
+
+	// ExpiresAt should be approximately now + ttl (within a few seconds)
+	expected := time.Now().Add(ttl)
+	diff := parsed.ExpiresAt.Sub(expected)
+	if diff < -5*time.Second || diff > 5*time.Second {
+		t.Errorf("ExpiresAt off by %v, want within 5s of now+2h", diff)
 	}
 }

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -41,7 +41,7 @@ type User struct {
 // Defaults applies default values to config fields that are empty
 func (c *Config) Defaults() {
 	if c.CookieTTL == 0 {
-		c.CookieTTL = 24 * time.Hour
+		c.CookieTTL = 4 * time.Hour // default 4h, sliding — extends on activity
 	}
 	if c.UserHeader == "" {
 		c.UserHeader = "X-Forwarded-User"

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -15,7 +15,7 @@ import (
 type Config struct {
 	Mode      string        // "none" (default), "proxy", "oidc"
 	Secret    string        // HMAC signing key for session cookies
-	CookieTTL time.Duration // default 24h
+	CookieTTL time.Duration // default 4h, sliding
 
 	// Proxy mode
 	UserHeader   string // default "X-Forwarded-User"

--- a/scripts/test-proxy-auth.sh
+++ b/scripts/test-proxy-auth.sh
@@ -165,9 +165,63 @@ else
     FAIL=$((FAIL + 1))
 fi
 
-# --- Test 6: Restricted user (no K8s RBAC) ---
+# --- Test 6: Session ID (sid) in cookie ---
 echo ""
-echo -e "${YELLOW}Test 6: User with no K8s RBAC → limited/no access${NC}"
+echo -e "${YELLOW}Test 6: Cookie contains session ID${NC}"
+
+if [[ -n "$cookie_val" ]]; then
+    # Decode the base64 payload (before the dot)
+    payload=$(echo "$cookie_val" | cut -d. -f1)
+    # Add padding and decode
+    sid=$(echo "$payload" | python3 -c "import sys,base64,json; d=sys.stdin.read().strip(); d+='='*(-len(d)%4); print(json.loads(base64.urlsafe_b64decode(d)).get('s',''))" 2>/dev/null)
+
+    if [[ ${#sid} -eq 32 ]]; then
+        echo -e "  ${GREEN}PASS${NC} SID present (${sid:0:8}..., 32 chars)"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}FAIL${NC} SID missing or wrong length (got '${sid}', len=${#sid})"
+        FAIL=$((FAIL + 1))
+    fi
+else
+    echo -e "  ${YELLOW}SKIP${NC} no cookie from test 5"
+fi
+
+# --- Test 7: Sliding TTL re-issues cookie past half-life ---
+echo ""
+echo -e "${YELLOW}Test 7: Sliding TTL re-issues cookie${NC}"
+
+if [[ -n "$cookie_val" ]]; then
+    # The default --auth-cookie-ttl is used (whatever the caller set).
+    # We can't rely on timing with the default 4h TTL, so we craft a
+    # near-expiry cookie by re-creating a session with a very short TTL.
+    # Instead, we just verify that a fresh cookie does NOT get re-issued
+    # (proves the sliding logic exists and doesn't fire on every request).
+    reissue_header=$(curl -s -D - -o /dev/null \
+        -b "radar_session=$cookie_val" \
+        "$BASE/api/auth/me" | grep -i 'set-cookie.*radar_session' || true)
+
+    if [[ -z "$reissue_header" ]]; then
+        echo -e "  ${GREEN}PASS${NC} fresh cookie not re-issued (sliding logic active, not firing on every request)"
+        PASS=$((PASS + 1))
+    else
+        # Re-issue on a fresh cookie means sliding is broken (firing too eagerly)
+        echo -e "  ${RED}FAIL${NC} fresh cookie was re-issued (sliding TTL fired too early)"
+        FAIL=$((FAIL + 1))
+    fi
+
+    # Verify SID is stable if a re-issue did happen (non-failure path)
+    if [[ -n "$reissue_header" ]]; then
+        new_val=$(echo "$reissue_header" | sed 's/.*radar_session=\([^;]*\).*/\1/')
+        new_sid=$(echo "$new_val" | cut -d. -f1 | python3 -c "import sys,base64,json; d=sys.stdin.read().strip(); d+='='*(-len(d)%4); print(json.loads(base64.urlsafe_b64decode(d)).get('s',''))" 2>/dev/null)
+        check "SID preserved across re-issue" "$sid" "$new_sid"
+    fi
+else
+    echo -e "  ${YELLOW}SKIP${NC} no cookie from test 5"
+fi
+
+# --- Test 8: Restricted user (no K8s RBAC) ---
+echo ""
+echo -e "${YELLOW}Test 8: User with no K8s RBAC → limited/no access${NC}"
 
 # A user with no RBAC bindings should see 0 or very few namespaces.
 # (Exact behavior depends on cluster config — some clusters give default access.)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -32,7 +32,7 @@ import { ShortcutHelpOverlay } from './components/ui/ShortcutHelpOverlay'
 import { CommandPalette } from './components/ui/CommandPalette'
 import { DiagnosticsOverlay } from './components/ui/DiagnosticsOverlay'
 import { useEventSource } from './hooks/useEventSource'
-import { useNamespaces, useSwitchContext, useAuthMe, setAuthQueryClient } from './api/client'
+import { useNamespaces, useSwitchContext, useAuthMe } from './api/client'
 import { KeyboardShortcutProvider, useRegisterShortcut, useRegisterShortcuts } from './hooks/useKeyboardShortcuts'
 import { useAnimatedUnmount } from './hooks/useAnimatedUnmount'
 import { Loader2 } from 'lucide-react'
@@ -156,8 +156,15 @@ function AppInner() {
 
   // Auth check — detect if auth is enabled but user is not authenticated
   const { data: authMe, isPending: authMePending } = useAuthMe()
-  const authQC = useQueryClient()
-  useEffect(() => { setAuthQueryClient(authQC) }, [authQC])
+
+  // Restore navigation path after session-expiry re-auth redirect
+  useEffect(() => {
+    const returnPath = sessionStorage.getItem('radar_return_path')
+    if (returnPath) {
+      sessionStorage.removeItem('radar_return_path')
+      navigate(returnPath, { replace: true })
+    }
+  }, [navigate])
 
   // Parse namespaces from URL (supports both 'namespaces' and legacy 'namespace')
   const parseNamespacesFromURL = (params: URLSearchParams): string[] => {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -27,33 +27,27 @@ import type { GitOpsOperationResponse } from '../types/gitops'
 
 const API_BASE = '/api'
 
-// Module-level query client reference for invalidating auth state from apiFetch.
-// Set by setAuthQueryClient() from the app root.
-let _authQueryClient: import('@tanstack/react-query').QueryClient | null = null
-export function setAuthQueryClient(qc: import('@tanstack/react-query').QueryClient) {
-  _authQueryClient = qc
-}
-
 // Wrapper around fetch that always includes credentials (for session cookies)
 // and handles 401 responses globally.
 function apiFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
   return fetch(input, { credentials: 'same-origin', ...init }).then(async response => {
     if (response.status === 401 && !window.location.pathname.startsWith('/auth')) {
-      // Invalidate auth state so AuthBarrier activates
-      _authQueryClient?.setQueryData(['auth-me'], { authEnabled: true, authMode: 'unknown' })
+      // Save current location so user returns to where they were after re-auth.
+      // Editor draft is auto-saved by EditableYamlView via sessionStorage.
+      sessionStorage.setItem('radar_return_path', window.location.pathname + window.location.search)
 
-      // Check authMode from 401 body to handle proxy vs OIDC differently
+      let isProxy = false
       try {
         const body = await response.clone().json()
-        if (body.authMode) {
-          _authQueryClient?.setQueryData(['auth-me'], { authEnabled: true, authMode: body.authMode })
-        }
-        if (body.authMode !== 'proxy') {
-          window.location.href = '/auth/login'
-        }
+        if (body.authMode === 'proxy') isProxy = true
       } catch {
-        // Can't parse 401 body — don't redirect blindly (proxy mode has no /auth/login)
         console.warn('Authentication required (unable to determine auth mode)')
+      }
+
+      if (isProxy) {
+        window.location.reload()
+      } else {
+        window.location.href = '/auth/login'
       }
     }
     return response

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -34,20 +34,28 @@ function apiFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Respons
     if (response.status === 401 && !window.location.pathname.startsWith('/auth')) {
       // Save current location so user returns to where they were after re-auth.
       // Editor draft is auto-saved by EditableYamlView via sessionStorage.
-      sessionStorage.setItem('radar_return_path', window.location.pathname + window.location.search)
+      try { sessionStorage.setItem('radar_return_path', window.location.pathname + window.location.search) } catch { /* best-effort */ }
 
-      let isProxy = false
+      let authMode: string | undefined
       try {
         const body = await response.clone().json()
-        if (body.authMode === 'proxy') isProxy = true
+        authMode = body.authMode
       } catch {
         console.warn('Authentication required (unable to determine auth mode)')
       }
 
-      if (isProxy) {
-        window.location.reload()
-      } else {
+      if (authMode === 'oidc') {
         window.location.href = '/auth/login'
+      } else {
+        // Proxy mode or unknown — reload is safe for both (proxy re-injects headers,
+        // unknown avoids redirecting to /auth/login which doesn't exist in proxy mode).
+        // Guard against infinite reload if proxy is misconfigured and keeps returning 401.
+        const lastReload = sessionStorage.getItem('radar_proxy_reload')
+        const now = Date.now()
+        if (!lastReload || now - parseInt(lastReload) > 5000) {
+          try { sessionStorage.setItem('radar_proxy_reload', String(now)) } catch { /* best-effort */ }
+          window.location.reload()
+        }
       }
     }
     return response


### PR DESCRIPTION
## Summary

Groundwork for OIDC backchannel logout (#382). Adds session primitives that the backchannel endpoint (PR 2) will use, and is independently valuable as a security/UX improvement.

- **Session ID in cookie** — each session carries a stable `sid` field (32-char hex). Pre-upgrade cookies without sid parse fine and get one minted on their next sliding re-issue. OIDC callback extracts `sid` from the ID token claims when the IdP provides one.
- **Sliding TTL** — cookies re-issue when past half-life, so shorter TTLs don't cause friction. Also handles TTL downgrade (e.g. admin changes 24h → 4h — old cookies snap to new TTL on next request, logged).
- **Default TTL 24h → 4h** — shrinks the IdP-revocation exposure window. Active users unaffected (frontend polling at 15-60s keeps the cookie alive). Proxy mode re-authenticates transparently from headers.
- **Editor draft persistence** — `EditableYamlView` autosaves drafts to `sessionStorage`. On session-expiry, the current URL is saved before redirect. After re-auth, user lands back on the same page with unsaved YAML edits restored and editor re-opened.
- **Review fixes** — `log.Fatalf` → `panic` in per-request paths (chi Recoverer contains blast radius), proxy-mode reload guard (prevents infinite loop on misconfigured proxy), unknown authMode defaults to reload instead of blind `/auth/login` redirect, sessionStorage wrapped in try-catch.

## What's NOT in this PR (deferred to PR 2)

Backchannel logout endpoint, revocation list, `logout_token` verifier, `--auth-oidc-backchannel-logout` CLI flag.

## Test plan

- [x] `go test` — 10 new tests (cookie sid round-trip, legacy cookie compat, NewSessionID uniqueness, sliding TTL half-life/fresh/downgrade/sid-preservation/idtoken-preservation/legacy-mint/expired)
- [x] `npm run tsc` — clean
- [x] `scripts/test-proxy-auth.sh` — 15/16 pass (1 pre-existing topology race), new SID + sliding TTL assertions
- [x] OIDC e2e with local Dex — full login flow, cookie contains username + sid + id_token, sliding re-issue preserves both, expiry returns 401
- [x] TTL downgrade verified (1h cookie → 10s config snaps with log message)
- [ ] Manual: browser QA for sessionStorage draft restore across re-auth (needs real browser)