### PR TITLE
Fix navbar text labels hidden on 14-inch MacBook Pro

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -806,7 +806,7 @@ function AppInner() {
                 }`}
               >
                 <Icon className="w-4 h-4" />
-                <span className="hidden xl:inline">{label}</span>
+                <span className="hidden lg:inline">{label}</span>
               </button>
             </Tooltip>
           ))}
@@ -1512,11 +1512,11 @@ function GitHubStarButton() {
         className="flex items-center gap-1.5 h-7 px-2 rounded-md transition-colors bg-theme-elevated hover:bg-theme-hover text-theme-text-secondary hover:text-theme-text-primary"
       >
         <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-        <Star className={`w-3 h-3 ${starred ? 'text-yellow-500 fill-current' : ''}`} />
+        <Star className={`w-3 h-3 hidden xl:block ${starred ? 'text-yellow-500 fill-current' : ''}`} />
         {starCount !== null && (
           <>
-            <span className="w-px h-3 bg-theme-border" />
-            <span className="text-xs tabular-nums">{starCount.toLocaleString()}</span>
+            <span className="w-px h-3 bg-theme-border hidden xl:block" />
+            <span className="text-xs tabular-nums hidden xl:inline">{starCount.toLocaleString()}</span>
           </>
         )}
       </a>


### PR DESCRIPTION
## Summary

- Nav item labels (Home, Topology, Resources, etc.) used the `xl` breakpoint (1536px) — exactly the CSS viewport of a 14" MacBook Pro at default scaling. Any browser chrome or non-maximized window caused all labels to disappear, leaving icon-only navigation.
- Lowered the nav label breakpoint from `xl` (1536px) to `lg` (1280px) so text is visible on all standard laptop screens.
- Collapsed the GitHub star count (star icon + divider + number) behind `xl` so it only shows on wide screens, freeing horizontal space for the nav labels.

## Test plan

- [ ] Open on 14" MacBook Pro (non-maximized window) — nav labels should be visible
- [ ] Resize browser to < 1280px — nav labels collapse to icons only
- [ ] Resize browser to > 1536px — full GitHub star widget (icon + count) appears
- [ ] GitHub star button still works at all widths (click opens repo)