### PR TITLE
Return 503 instead of 403 for deferred resources still syncing

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -786,6 +786,17 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusForbidden, fmt.Sprintf("insufficient permissions to list %s", resourceKind))
 	}
 
+	// notReadyOrForbidden returns 503 when a deferred resource is still syncing,
+	// or 403 when RBAC denied access. Callers use this for deferred resource types
+	// (configmaps, secrets, events, etc.) where a nil lister can mean either case.
+	notReadyOrForbidden := func(resourceKind string) {
+		if cache.IsDeferredPending(resourceKind) {
+			s.writeError(w, http.StatusServiceUnavailable, fmt.Sprintf("%s are still loading, please retry shortly", resourceKind))
+			return
+		}
+		forbiddenMsg(resourceKind)
+	}
+
 	// When a group is specified, skip the typed cache and use the dynamic cache
 	// directly. This handles CRDs whose plural name collides with core resources
 	// (e.g., KNative "services" vs core "services").
@@ -874,6 +885,8 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 		)
 	case "replicasets":
 		if cache.ReplicaSets() == nil {
+			// ReplicaSets lister uses isEnabled (not isReady) — available before deferred sync completes.
+			// Nil here means RBAC denied, not deferred-pending.
 			forbiddenMsg("replicasets")
 			return
 		}
@@ -892,7 +905,7 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 		)
 	case "configmaps":
 		if cache.ConfigMaps() == nil {
-			forbiddenMsg("configmaps")
+			notReadyOrForbidden("configmaps")
 			return
 		}
 		result, err = listPerNs(
@@ -902,7 +915,7 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 	case "secrets":
 		lister := cache.Secrets()
 		if lister == nil {
-			forbiddenMsg("secrets")
+			notReadyOrForbidden("secrets")
 			return
 		}
 		result, err = listPerNs(
@@ -911,7 +924,7 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 		)
 	case "events":
 		if cache.Events() == nil {
-			forbiddenMsg("events")
+			notReadyOrForbidden("events")
 			return
 		}
 		result, err = listPerNs(
@@ -920,7 +933,7 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 		)
 	case "persistentvolumeclaims", "pvcs":
 		if cache.PersistentVolumeClaims() == nil {
-			forbiddenMsg("persistentvolumeclaims")
+			notReadyOrForbidden("persistentvolumeclaims")
 			return
 		}
 		result, err = listPerNs(
@@ -949,6 +962,7 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 		)
 	case "hpas", "horizontalpodautoscalers":
 		if cache.HorizontalPodAutoscalers() == nil {
+			// HPA lister uses isEnabled (not isReady) — available before deferred sync completes.
 			forbiddenMsg("horizontalpodautoscalers")
 			return
 		}
@@ -972,19 +986,19 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 		result, err = cache.Namespaces().List(labels.Everything())
 	case "persistentvolumes", "pvs":
 		if cache.PersistentVolumes() == nil {
-			forbiddenMsg("persistentvolumes")
+			notReadyOrForbidden("persistentvolumes")
 			return
 		}
 		result, err = cache.PersistentVolumes().List(labels.Everything())
 	case "storageclasses", "sc":
 		if cache.StorageClasses() == nil {
-			forbiddenMsg("storageclasses")
+			notReadyOrForbidden("storageclasses")
 			return
 		}
 		result, err = cache.StorageClasses().List(labels.Everything())
 	case "poddisruptionbudgets", "pdbs":
 		if cache.PodDisruptionBudgets() == nil {
-			forbiddenMsg("poddisruptionbudgets")
+			notReadyOrForbidden("poddisruptionbudgets")
 			return
 		}
 		result, err = listPerNs(
@@ -995,7 +1009,7 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 		)
 	case "networkpolicies", "netpol":
 		if cache.NetworkPolicies() == nil {
-			forbiddenMsg("networkpolicies")
+			notReadyOrForbidden("networkpolicies")
 			return
 		}
 		result, err = listPerNs(
@@ -1094,6 +1108,15 @@ func (s *Server) handleGetResource(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusForbidden, fmt.Sprintf("insufficient permissions to access %s", resourceKind))
 	}
 
+	// notReadyOrForbiddenGet is the single-resource counterpart of notReadyOrForbidden (see handleListResources).
+	notReadyOrForbiddenGet := func(resourceKind string) {
+		if cache.IsDeferredPending(resourceKind) {
+			s.writeError(w, http.StatusServiceUnavailable, fmt.Sprintf("%s are still loading, please retry shortly", resourceKind))
+			return
+		}
+		forbiddenGet(resourceKind)
+	}
+
 	// When a group is specified, skip the typed cache and use the dynamic cache
 	// directly. This handles CRDs whose plural name collides with core resources
 	// (e.g., KNative "services" vs core "services").
@@ -1175,26 +1198,26 @@ func (s *Server) handleGetResource(w http.ResponseWriter, r *http.Request) {
 		resource, err = cache.Ingresses().Ingresses(namespace).Get(name)
 	case "configmaps", "configmap":
 		if cache.ConfigMaps() == nil {
-			forbiddenGet("configmaps")
+			notReadyOrForbiddenGet("configmaps")
 			return
 		}
 		resource, err = cache.ConfigMaps().ConfigMaps(namespace).Get(name)
 	case "secrets", "secret":
 		lister := cache.Secrets()
 		if lister == nil {
-			forbiddenGet("secrets")
+			notReadyOrForbiddenGet("secrets")
 			return
 		}
 		resource, err = lister.Secrets(namespace).Get(name)
 	case "events", "event":
 		if cache.Events() == nil {
-			forbiddenGet("events")
+			notReadyOrForbiddenGet("events")
 			return
 		}
 		resource, err = cache.Events().Events(namespace).Get(name)
 	case "persistentvolumeclaims", "persistentvolumeclaim", "pvcs", "pvc":
 		if cache.PersistentVolumeClaims() == nil {
-			forbiddenGet("persistentvolumeclaims")
+			notReadyOrForbiddenGet("persistentvolumeclaims")
 			return
 		}
 		resource, err = cache.PersistentVolumeClaims().PersistentVolumeClaims(namespace).Get(name)
@@ -1230,25 +1253,25 @@ func (s *Server) handleGetResource(w http.ResponseWriter, r *http.Request) {
 		resource, err = cache.Namespaces().Get(name)
 	case "persistentvolumes", "persistentvolume", "pvs", "pv":
 		if cache.PersistentVolumes() == nil {
-			forbiddenGet("persistentvolumes")
+			notReadyOrForbiddenGet("persistentvolumes")
 			return
 		}
 		resource, err = cache.PersistentVolumes().Get(name)
 	case "storageclasses", "storageclass", "sc":
 		if cache.StorageClasses() == nil {
-			forbiddenGet("storageclasses")
+			notReadyOrForbiddenGet("storageclasses")
 			return
 		}
 		resource, err = cache.StorageClasses().Get(name)
 	case "poddisruptionbudgets", "poddisruptionbudget", "pdbs", "pdb":
 		if cache.PodDisruptionBudgets() == nil {
-			forbiddenGet("poddisruptionbudgets")
+			notReadyOrForbiddenGet("poddisruptionbudgets")
 			return
 		}
 		resource, err = cache.PodDisruptionBudgets().PodDisruptionBudgets(namespace).Get(name)
 	case "networkpolicies", "networkpolicy", "netpol":
 		if cache.NetworkPolicies() == nil {
-			forbiddenGet("networkpolicies")
+			notReadyOrForbiddenGet("networkpolicies")
 			return
 		}
 		resource, err = cache.NetworkPolicies().NetworkPolicies(namespace).Get(name)

--- a/pkg/k8score/cache.go
+++ b/pkg/k8score/cache.go
@@ -473,6 +473,7 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 				rc.deferredMu.Unlock()
 				stdlog.Printf("Background Events sync complete in %v", time.Since(bgStart))
 			} else {
+				rc.deferredFailed.Store(true)
 				stdlog.Printf("WARNING: Background Events sync failed after %v", time.Since(bgStart))
 			}
 		}()
@@ -950,4 +951,27 @@ func (rc *ResourceCache) isReady(key string) bool {
 	rc.deferredMu.RLock()
 	defer rc.deferredMu.RUnlock()
 	return rc.deferredSynced[key]
+}
+
+// IsDeferredPending returns true when the resource type passed RBAC checks
+// (informer is enabled) but deferred sync has not completed yet. Callers
+// can use this to distinguish "no permission" (return 403) from "not ready
+// yet" (return 503) when a lister returns nil.
+// Returns false once deferred sync has permanently failed (avoids infinite spinner).
+func (rc *ResourceCache) IsDeferredPending(key string) bool {
+	if rc == nil {
+		return false
+	}
+	if !rc.isEnabled(key) {
+		return false
+	}
+	if rc.config.DeferredTypes == nil || !rc.config.DeferredTypes[key] {
+		return false
+	}
+	if rc.deferredFailed.Load() {
+		return false
+	}
+	rc.deferredMu.RLock()
+	defer rc.deferredMu.RUnlock()
+	return !rc.deferredSynced[key]
 }


### PR DESCRIPTION
## Summary

Deferred resources (ConfigMaps, Secrets, Events, PVCs, PVs, StorageClasses, PDBs, NetworkPolicies) sync after critical resources at startup. Previously, requests during this window returned **403 "insufficient permissions"** — misleading since RBAC actually passed, the informer just hadn't finished syncing.

The frontend already has retry logic that skips 403 but retries 503 up to 3 times. By returning the correct status code, deferred resources auto-recover without any frontend changes.

### What changed

- **`pkg/k8score/cache.go`**: Added `IsDeferredPending()` — returns true when RBAC passed but deferred sync hasn't completed. Guards against infinite loading via `deferredFailed` flag. Also sets `deferredFailed` in the background sync (Events) failure path, which was previously missing.
- **`internal/server/server.go`**: Added `notReadyOrForbidden` helpers used by all deferred resource handlers (both list and get). Returns 503 "still loading" for deferred-pending, 403 for RBAC-denied. ReplicaSets and HPAs stay on `forbiddenMsg` since their listers use `isEnabled` (available before deferred sync).

Ref #460