### PR TITLE
fix(prometheus): skip empty/non-Prometheus endpoints during probe

### DIFF
--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -280,7 +280,8 @@ func (c *Client) probe(ctx context.Context, addr string) bool {
 
 	// Verify the instance actually has scrape targets. An empty VictoriaMetrics
 	// or Prometheus instance returns 200 with zero results — skip it.
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	// 10 MB matches doQuery's limit so a large cluster's `up` response fits.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
 	if err != nil {
 		return false
 	}
@@ -295,7 +296,11 @@ func (c *Client) probe(ctx context.Context, addr string) bool {
 		// Prometheus (captive portal, ingress login page, misconfigured proxy).
 		return false
 	}
-	if promResp.Status == "success" && len(promResp.Data.Result) == 0 {
+	if promResp.Status != "success" {
+		// Some proxies return 200 with a Prometheus-shaped error body.
+		return false
+	}
+	if len(promResp.Data.Result) == 0 {
 		errorlog.Record("prometheus", "warning", "endpoint %s has no active scrape targets (empty instance), skipping", addr)
 		return false
 	}

--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -255,7 +255,10 @@ func (c *Client) doQuery(ctx context.Context, reqURL string) (*QueryResult, erro
 	return parseQueryResult(promResp.Data)
 }
 
-// probe checks if a Prometheus endpoint is reachable.
+// probe checks if a Prometheus endpoint is reachable and has data.
+// An instance that responds HTTP 200 but returns zero results for "up"
+// (no active scrape targets) is treated as unreachable so discovery
+// continues to the next candidate.
 func (c *Client) probe(ctx context.Context, addr string) bool {
 	testCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
@@ -271,7 +274,32 @@ func (c *Client) probe(ctx context.Context, addr string) bool {
 	}
 	defer resp.Body.Close()
 
-	return resp.StatusCode == http.StatusOK
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+
+	// Verify the instance actually has scrape targets. An empty VictoriaMetrics
+	// or Prometheus instance returns 200 with zero results — skip it.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return false
+	}
+	var promResp struct {
+		Status string `json:"status"`
+		Data   struct {
+			Result []json.RawMessage `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &promResp); err != nil {
+		// A 200 response that isn't Prometheus JSON is almost certainly not
+		// Prometheus (captive portal, ingress login page, misconfigured proxy).
+		return false
+	}
+	if promResp.Status == "success" && len(promResp.Data.Result) == 0 {
+		errorlog.Record("prometheus", "warning", "endpoint %s has no active scrape targets (empty instance), skipping", addr)
+		return false
+	}
+	return true
 }
 
 // Prometheus API response types

--- a/internal/prometheus/client_test.go
+++ b/internal/prometheus/client_test.go
@@ -1,0 +1,71 @@
+package prometheus
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestProbe(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		want       bool
+	}{
+		{
+			name:       "healthy prometheus with targets",
+			statusCode: http.StatusOK,
+			body:       `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"job":"prometheus"},"value":[1700000000,"1"]}]}}`,
+			want:       true,
+		},
+		{
+			name:       "empty instance returns success with zero results",
+			statusCode: http.StatusOK,
+			body:       `{"status":"success","data":{"resultType":"vector","result":[]}}`,
+			want:       false,
+		},
+		{
+			name:       "non-prometheus 200 response (html)",
+			statusCode: http.StatusOK,
+			body:       `<html><body>Login</body></html>`,
+			want:       false,
+		},
+		{
+			name:       "prometheus error body with 200",
+			statusCode: http.StatusOK,
+			body:       `{"status":"error","errorType":"bad_data","error":"invalid query"}`,
+			want:       false,
+		},
+		{
+			name:       "non-200 status",
+			statusCode: http.StatusInternalServerError,
+			body:       `oops`,
+			want:       false,
+		},
+		{
+			name:       "401 unauthorized",
+			statusCode: http.StatusUnauthorized,
+			body:       ``,
+			want:       false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.statusCode)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			c := &Client{httpClient: &http.Client{Timeout: 5 * time.Second}}
+			got := c.probe(context.Background(), srv.URL)
+			if got != tc.want {
+				t.Fatalf("probe() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/prometheus/client_test.go
+++ b/internal/prometheus/client_test.go
@@ -6,14 +6,17 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/skyhook-io/radar/internal/errorlog"
 )
 
 func TestProbe(t *testing.T) {
 	tests := []struct {
-		name       string
-		statusCode int
-		body       string
-		want       bool
+		name           string
+		statusCode     int
+		body           string
+		want           bool
+		wantEmptyEntry bool // expect the empty-instance warning to be recorded
 	}{
 		{
 			name:       "healthy prometheus with targets",
@@ -22,10 +25,11 @@ func TestProbe(t *testing.T) {
 			want:       true,
 		},
 		{
-			name:       "empty instance returns success with zero results",
-			statusCode: http.StatusOK,
-			body:       `{"status":"success","data":{"resultType":"vector","result":[]}}`,
-			want:       false,
+			name:           "empty instance returns success with zero results",
+			statusCode:     http.StatusOK,
+			body:           `{"status":"success","data":{"resultType":"vector","result":[]}}`,
+			want:           false,
+			wantEmptyEntry: true,
 		},
 		{
 			name:       "non-prometheus 200 response (html)",
@@ -55,6 +59,8 @@ func TestProbe(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			errorlog.Reset()
+
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(tc.statusCode)
 				_, _ = w.Write([]byte(tc.body))
@@ -65,6 +71,16 @@ func TestProbe(t *testing.T) {
 			got := c.probe(context.Background(), srv.URL)
 			if got != tc.want {
 				t.Fatalf("probe() = %v, want %v", got, tc.want)
+			}
+
+			gotEmptyEntry := false
+			for _, e := range errorlog.GetEntries() {
+				if e.Source == "prometheus" && e.Level == "warning" {
+					gotEmptyEntry = true
+				}
+			}
+			if gotEmptyEntry != tc.wantEmptyEntry {
+				t.Fatalf("empty-instance warning recorded = %v, want %v", gotEmptyEntry, tc.wantEmptyEntry)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Tightens Prometheus endpoint discovery so `probe()` doesn't lock onto useless endpoints.

Previously, any HTTP 200 response passed the probe. Three failure modes slipped through:

1. **Empty instances.** A freshly-installed VictoriaMetrics/Prometheus with no active scrape targets returns 200 with zero results for `up`. Discovery would pick it and shadow a working candidate lower in the priority list.
2. **Non-Prometheus 200s.** Captive portals, ingress login pages, or misconfigured proxies returning 200 with non-Prometheus JSON would pass, then cause confusing parse errors on the first real query.
3. **Prometheus-shaped error bodies with 200.** Some proxies return `{"status":"error",...}` with HTTP 200 — the probe now explicitly rejects these instead of marking the endpoint connected.

Probe now parses the response body and rejects all three. The empty-instance skip is recorded via `errorlog.Record` (severity `warning`) so it surfaces in the Diagnostics UI instead of being buried in stdout — previously the user would see the misleading "no Prometheus service found in cluster" error even when instances were found but empty.

The body read limit is 10 MB, matching `doQuery`, so large clusters' `up` response doesn't get truncated mid-JSON and cause a healthy Prometheus to be rejected.

Completes the discovery hardening arc started in #bad0a8b (try all candidates) and #c3b2526 (fallback queries for cri-docker).

## Test plan

- [x] Unit tests (`go test ./internal/prometheus/...`) — table-driven `TestProbe` covers healthy, empty, non-JSON 200, error-body 200, 500, and 401 cases.
- [x] Manual (GCP koalabackend nonprod us-east1, has `opencost/prometheus-server`): discovery finds it, probe accepts it, workload Metrics tab populates with real CPU data. No false empty-instance warnings.
- [x] Manual (AWS koalabackend nonprod us-east-1, no real Prometheus): dynamic discovery scores coredns-scrape shims, port-forward + probe fail cleanly as before, UI shows "Prometheus not connected" empty state. No regression.
- [ ] Not manually exercised end-to-end: the empty-instance-200 and error-body-200 paths (no real cluster returns those shapes). Covered by unit tests.