### PR TITLE
Improve command palette UX: remove blocking dialog, better ranking, input-friendly ⌘K

### DIFF
--- a/packages/k8s-ui/src/hooks/useKeyboardShortcuts.tsx
+++ b/packages/k8s-ui/src/hooks/useKeyboardShortcuts.tsx
@@ -30,6 +30,8 @@ export interface KeyboardShortcut {
   handler: (e: KeyboardEvent) => void
   /** Whether this shortcut is currently active */
   enabled?: boolean
+  /** Fire even when focus is inside an input/textarea. For global modifier combos (⌘K, Ctrl+Shift+D) that can't collide with typing. */
+  allowInInputs?: boolean
 }
 
 // Internal registration with stable ID
@@ -215,7 +217,7 @@ export function KeyboardShortcutProvider({ children }: { children: ReactNode }) 
           return
         }
 
-        if (suppressed) continue
+        if (suppressed && !shortcut.allowInInputs) continue
 
         if (matchesKey(e, matcher, '')) {
           e.preventDefault()

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -322,9 +322,6 @@ function AppInner() {
     navigate(-1)
   }, [navigate])
 
-  // Pending navigation that needs namespace filter confirmation
-  const [pendingKindNav, setPendingKindNav] = useState<{ kind: string; group: string } | null>(null)
-
   // Theme toggle for keyboard shortcut
   const { toggleTheme } = useTheme()
 
@@ -1266,24 +1263,24 @@ function AppInner() {
           onClose={() => setShowCommandPalette(false)}
           onNavigateView={(view) => setMainView(view)}
           onNavigateKind={(kind, group) => {
-            if (namespaces.length > 0) {
-              // Namespace filter is active — confirm before navigating
-              setPendingKindNav({ kind, group })
-            } else {
-              const params = new URLSearchParams(searchParams)
-              params.delete('kind')
-              if (group) params.set('apiGroup', group)
-              else params.delete('apiGroup')
-              params.delete('resource')
-              navigate({ pathname: `/resources/${kind}`, search: params.toString() })
-              // Focus the table search after navigation — the user came from ⌘K
-              // (keyboard flow) and expects to type a resource name immediately.
-              setTimeout(() => {
-                (document.querySelector('input[placeholder="Search... (press /)"]') as HTMLInputElement)?.focus()
-              }, 100)
-            }
+            const params = new URLSearchParams(searchParams)
+            params.delete('kind')
+            if (group) params.set('apiGroup', group)
+            else params.delete('apiGroup')
+            params.delete('resource')
+            navigate({ pathname: `/resources/${kind}`, search: params.toString() })
+            // Focus the table search after navigation — the user came from ⌘K
+            // (keyboard flow) and expects to type a resource name immediately.
+            setTimeout(() => {
+              (document.querySelector('input[placeholder="Search... (press /)"]') as HTMLInputElement)?.focus()
+            }, 100)
           }}
-          onSwitchContext={(name) => switchContext.mutate({ name })}
+          onSwitchContext={(name) => switchContext.mutate(
+            { name },
+            // Namespace filter from the previous context may not exist in the
+            // new one — clear it so resource lists don't silently go empty.
+            { onSettled: () => setNamespaces([]) },
+          )}
           onSetNamespaces={setNamespaces}
           onToggleTheme={toggleTheme}
           onShowDiagnostics={() => setShowDiagnostics(true)}
@@ -1296,92 +1293,12 @@ function AppInner() {
       {/* Settings dialog */}
       <SettingsDialog open={showSettings} onClose={() => setShowSettings(false)} />
 
-      {/* Namespace filter confirmation for command palette navigation */}
-      {pendingKindNav && (
-        <NamespaceFilterDialog
-          namespaces={namespaces}
-          onConfirm={() => {
-            setNamespaces([])
-            const params = new URLSearchParams()
-            if (pendingKindNav.group) params.set('apiGroup', pendingKindNav.group)
-            navigate({ pathname: `/resources/${pendingKindNav.kind}`, search: params.toString() })
-            setPendingKindNav(null)
-            setTimeout(() => { (document.querySelector('input[placeholder="Search... (press /)"]') as HTMLInputElement)?.focus() }, 100)
-          }}
-          onKeep={() => {
-            const params = new URLSearchParams(searchParams)
-            params.delete('kind')
-            if (pendingKindNav.group) params.set('apiGroup', pendingKindNav.group)
-            else params.delete('apiGroup')
-            params.delete('resource')
-            navigate({ pathname: `/resources/${pendingKindNav.kind}`, search: params.toString() })
-            setPendingKindNav(null)
-            setTimeout(() => { (document.querySelector('input[placeholder="Search... (press /)"]') as HTMLInputElement)?.focus() }, 100)
-          }}
-          onClose={() => setPendingKindNav(null)}
-        />
-      )}
-
       {/* Debug overlay - only in dev mode */}
       {import.meta.env.DEV && <DebugOverlay />}
     </div>
     </PortForwardProvider>
   )
 }
-
-// Lightweight dialog to confirm clearing namespace filter when navigating from command palette
-function NamespaceFilterDialog({ namespaces, onConfirm, onKeep, onClose }: {
-  namespaces: string[]
-  onConfirm: () => void
-  onKeep: () => void
-  onClose: () => void
-}) {
-  const confirmRef = useRef<HTMLButtonElement>(null)
-
-  useEffect(() => {
-    confirmRef.current?.focus()
-  }, [])
-
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') { e.preventDefault(); e.stopPropagation(); onClose() }
-    }
-    document.addEventListener('keydown', handler, true)
-    return () => document.removeEventListener('keydown', handler, true)
-  }, [onClose])
-
-  const label = namespaces.length === 1 ? namespaces[0] : `${namespaces.length} namespaces`
-
-  return (
-    <div className="fixed inset-0 z-[100] flex items-start justify-center pt-[20vh]">
-      <div className="absolute inset-0 bg-theme-base/60 backdrop-blur-sm" onClick={onClose} />
-      <div className="relative dialog max-w-sm w-full mx-4 p-4">
-        <p className="text-sm text-theme-text-primary mb-1">
-          Namespace filter is active
-        </p>
-        <p className="text-xs text-theme-text-secondary mb-4">
-          Currently filtered to <span className="font-medium text-theme-text-primary">{label}</span>. Clear filter to show all namespaces?
-        </p>
-        <div className="flex items-center justify-end gap-2">
-          <button
-            onClick={onKeep}
-            className="px-3 py-1.5 text-xs font-medium text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded-lg transition-colors"
-          >
-            Keep filter
-          </button>
-          <button
-            ref={confirmRef}
-            onClick={onConfirm}
-            className="px-3 py-1.5 text-xs font-medium btn-brand rounded-lg focus:outline-none focus:ring-2 focus:ring-skyhook-500 focus:ring-offset-1 focus:ring-offset-theme-surface"
-          >
-            Clear filter
-          </button>
-        </div>
-      </div>
-    </div>
-  )
-}
-
 
 // Spacer component that adds padding when dock is open
 function DockSpacer() {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -361,6 +361,7 @@ function AppInner() {
       description: 'Open command palette',
       category: 'General' as const,
       scope: 'global' as const,
+      allowInInputs: true,
       handler: () => setShowCommandPalette(true),
     },
     {
@@ -369,6 +370,7 @@ function AppInner() {
       description: 'Open diagnostics',
       category: 'General' as const,
       scope: 'global' as const,
+      allowInInputs: true,
       handler: () => setShowDiagnostics(prev => !prev),
     },
   ])

--- a/web/src/components/ui/CommandPalette.tsx
+++ b/web/src/components/ui/CommandPalette.tsx
@@ -30,18 +30,59 @@ interface CommandItem {
   action: () => void
   /** Extra terms to match against during search (not displayed) */
   searchTerms?: string[]
+  /** Small priority bonus added to the final score (only if the item matched). Used to nudge built-in k8s kinds above CRDs on tied queries like "policy" or "event". */
+  priorityBonus?: number
 }
 
-// Fuzzy match scoring: exact prefix > word boundary > substring
+// Built-in k8s API groups. Used to nudge these above CRDs on tied matches.
+const CORE_GROUP_BONUS = 10
+const WELL_KNOWN_GROUP_BONUS = 5
+const WELL_KNOWN_GROUPS = new Set([
+  'apps',
+  'batch',
+  'autoscaling',
+  'policy',
+  'networking.k8s.io',
+  'rbac.authorization.k8s.io',
+  'storage.k8s.io',
+  'scheduling.k8s.io',
+  'coordination.k8s.io',
+  'apiextensions.k8s.io',
+  'admissionregistration.k8s.io',
+  'apiregistration.k8s.io',
+  'certificates.k8s.io',
+  'events.k8s.io',
+  'discovery.k8s.io',
+  'flowcontrol.apiserver.k8s.io',
+  'node.k8s.io',
+  'authentication.k8s.io',
+  'authorization.k8s.io',
+])
+
+function groupPriorityBonus(group: string): number {
+  if (!group) return CORE_GROUP_BONUS
+  if (WELL_KNOWN_GROUPS.has(group)) return WELL_KNOWN_GROUP_BONUS
+  return 0
+}
+
+// Fuzzy match scoring: exact > prefix > word boundary > substring.
+// Within a tier, a coverage bonus (up to +20) breaks ties in favor of
+// shorter labels — so "serv" picks Service over ServiceAccount, and
+// "service" picks Service (exact) decisively. Bonus is capped below the
+// 25-point tier gap, so tier ordering is preserved.
 function scoreMatch(text: string, query: string): number {
   const lower = text.toLowerCase()
   const q = query.toLowerCase()
   if (!lower.includes(q)) return 0
-  if (lower.startsWith(q)) return 100
-  // Word boundary match
-  const wordStart = lower.indexOf(q)
-  if (wordStart > 0 && (lower[wordStart - 1] === ' ' || lower[wordStart - 1] === '/' || lower[wordStart - 1] === '-' || lower[wordStart - 1] === '.')) return 75
-  return 50
+  let base: number
+  if (lower === q) base = 150
+  else if (lower.startsWith(q)) base = 100
+  else {
+    const wordStart = lower.indexOf(q)
+    const prev = lower[wordStart - 1]
+    base = wordStart > 0 && (prev === ' ' || prev === '/' || prev === '-' || prev === '.') ? 75 : 50
+  }
+  return base + (q.length / lower.length) * 20
 }
 
 function bestScore(item: CommandItem, query: string): number {
@@ -59,7 +100,9 @@ function bestScore(item: CommandItem, query: string): number {
       best = Math.max(best, scoreMatch(term, query))
     }
   }
-  return best
+  // Only apply the priority bonus to items that actually matched, so we don't
+  // surface unrelated built-ins ahead of a relevant CRD.
+  return best > 0 ? best + (item.priorityBonus || 0) : 0
 }
 
 export function CommandPalette({
@@ -142,6 +185,7 @@ export function CommandPalette({
         icon: getResourceIcon(r.kind),
         action: () => { onNavigateKind(r.name, r.group) },
         searchTerms: [r.name, r.kind],
+        priorityBonus: groupPriorityBonus(r.group),
       })
     }
 


### PR DESCRIPTION
A few command palette / ⌘K improvements, all in service of making the keyboard flow actually frictionless.

## 1. Remove the namespace-filter confirmation dialog

When a namespace filter was active, navigating between resource kinds via ⌘K popped a dialog asking whether to clear the filter. The default action was **Clear filter** (destructive), so every ⌘K → kind → Enter wiped the active filter. Users who stay in one namespace and jump between kinds (the intended ⌘K workflow) had to Shift+Tab to keep their filter — and desktop keyboard nav in the dialog was broken on top of that.

Dialog removed. Filter is preserved silently. The existing header namespace selector already surfaces the filter state, so discoverability is unchanged. This matches what Headlamp, Lens, and Freelens all do.

**Related fix**: context switching now clears the namespace filter, since the filter from the previous cluster may reference a namespace that doesn't exist in the new one (silently empty resource lists).

## 2. Better ranking

Typing `serv` used to rank ServiceAccount above Service because both hit the prefix tier with equal score. Three stacked tiebreakers:

- **Exact-match tier** above prefix — `service` → Service decisively.
- **Coverage bonus** (`query.length / text.length × 20`) — shorter labels win within the same tier, so `serv` → Service beats ServiceAccount / ServiceCIDR / ServiceEntry.
- **Group-priority bonus** — `+10` for core group, `+5` for well-known k8s groups (apps, batch, networking.k8s.io, rbac.*, etc). Tied matches favor built-in kinds over CRDs, so `net` clusters NetworkPolicy / Ingress / IngressClass above Istio/AWS/Cilium networking CRDs. Bonus is capped below the 25-point tier gap, so match quality always beats group priority.

## 3. ⌘K works even when focused inside an input

Previously ⌘K was suppressed any time focus was in a text input (including the table search on `/resources/...`), forcing users to blur first. Modifier-only combos can't collide with typing, so there's no reason to swallow them. Opt-in via a new `allowInInputs` flag on shortcut definitions (also applied to Ctrl+Shift+D).

## Test plan

- [ ] Filter to a namespace, ⌘K, pick a kind → navigates without dialog, filter preserved.
- [ ] Filter to a namespace, switch context via ⌘K → filter cleared.
- [ ] ⌘K while focused in the resource table search input → palette opens.
- [ ] Type `serv` → Service ranks first.
- [ ] Type `net` → NetworkPolicy / Ingress / IngressClass (networking.k8s.io) cluster at the top.