### PR TITLE
Narrow ⌘K/Ctrl+Shift+D input-bypass to plain inputs only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,9 +106,10 @@ run-dev:
 
 ## Utility targets
 
-# Kill any running radar process
+# Kill any running radar process (on configured port and by process name)
 kill:
 	@lsof -ti:$(PORT) | xargs kill -9 2>/dev/null || true
+	@pkill -9 -f './radar' 2>/dev/null || true
 
 # Install all dependencies
 deps:

--- a/packages/k8s-ui/src/hooks/useKeyboardShortcuts.tsx
+++ b/packages/k8s-ui/src/hooks/useKeyboardShortcuts.tsx
@@ -48,28 +48,22 @@ const KeyboardShortcutContext = createContext<KeyboardShortcutContextType | null
 
 let nextRegistrationId = 0
 
-// Check if focus is in an element that should suppress shortcuts
-function shouldSuppressShortcut(e: KeyboardEvent): boolean {
+// Classify suppression level for the currently-focused element.
+//   none — no suppression, all shortcuts fire
+//   soft — plain text inputs; bypassed by shortcuts with allowInInputs
+//   hard — rich editors (Monaco, xterm) that own their own keyboard UX;
+//          never bypassed, since Cmd+K / Ctrl+Shift+D have meaning there
+type SuppressionLevel = 'none' | 'soft' | 'hard'
+
+function getSuppressionLevel(e: KeyboardEvent): SuppressionLevel {
   const target = e.target as HTMLElement
-  if (!target) return false
-
-  // Always allow Escape
-  if (e.key === 'Escape') return false
-
-  // Suppress in text inputs
+  if (!target) return 'none'
+  if (e.key === 'Escape') return 'none'
+  if (target.closest('.monaco-editor') || target.closest('.xterm')) return 'hard'
   const tagName = target.tagName
-  if (tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT') return true
-
-  // Suppress in contenteditable
-  if (target.isContentEditable) return true
-
-  // Suppress in Monaco editor
-  if (target.closest('.monaco-editor')) return true
-
-  // Suppress in xterm terminal
-  if (target.closest('.xterm')) return true
-
-  return false
+  if (tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT') return 'soft'
+  if (target.isContentEditable) return 'soft'
+  return 'none'
 }
 
 // Parse a key string like "Shift+N", "Cmd+K", "g g" into match criteria
@@ -160,7 +154,8 @@ export function KeyboardShortcutProvider({ children }: { children: ReactNode }) 
   // Global keydown listener
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      const suppressed = shouldSuppressShortcut(e)
+      const suppression = getSuppressionLevel(e)
+      const suppressed = suppression !== 'none'
 
       // Get all enabled shortcuts, sorted by scope priority (highest first)
       const shortcuts = Array.from(shortcutsRef.current.values())
@@ -217,7 +212,7 @@ export function KeyboardShortcutProvider({ children }: { children: ReactNode }) 
           return
         }
 
-        if (suppressed && !shortcut.allowInInputs) continue
+        if (suppressed && !(shortcut.allowInInputs && suppression === 'soft')) continue
 
         if (matchesKey(e, matcher, '')) {
           e.preventDefault()


### PR DESCRIPTION
Follow-up to #474.

The \`allowInInputs\` flag introduced there bypassed every level of suppression in \`getSuppressionLevel\`, including Monaco editor and xterm terminal. Those editors own their own keyboard UX — Cmd+K in xterm is the iTerm2/Terminal-app convention for "clear screen"; Monaco has its own keyboard-shortcuts palette on Cmd+K. Both got hijacked.

Classify suppression into three levels:
- \`none\` — all shortcuts fire (the default)
- \`soft\` — plain text inputs (INPUT / TEXTAREA / SELECT / contenteditable). Bypassed by \`allowInInputs\`, so ⌘K still opens the palette from the resource-table search or any other input.
- \`hard\` — rich editors (Monaco, xterm). Never bypassed.

Also a drive-by: \`make kill\` now also runs \`pkill -f './radar'\` so orphaned visual-test processes bound to random ports get cleaned up alongside the port-bound one.

## Test plan
- [ ] ⌘K from the resource-table search input opens the palette (the fix from #474 still works).
- [ ] ⌘K while focused in a Monaco YAML editor does NOT open the palette (Monaco's own Cmd+K stays).
- [ ] ⌘K while focused in the bottom-dock xterm does NOT open the palette (terminal clear behavior stays).