### PR TITLE
fix: one failing deferred informer blocks siblings (#460)

### DIFF
--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -128,14 +128,15 @@ func InitResourceCache(ctx context.Context) error {
 		}
 
 		cfg := k8score.CacheConfig{
-			Client:          k8sClient,
-			ResourceTypes:   enabled,
-			DeferredTypes:   deferredResources,
-			NamespaceScoped: permResult.NamespaceScoped,
-			Namespace:       permResult.Namespace,
-			DebugEvents:     DebugEvents,
-			TimingLogger:    logTiming,
-			SyncTimeout:     60 * time.Second,
+			Client:              k8sClient,
+			ResourceTypes:       enabled,
+			DeferredTypes:       deferredResources,
+			NamespaceScoped:     permResult.NamespaceScoped,
+			Namespace:           permResult.Namespace,
+			DebugEvents:         DebugEvents,
+			TimingLogger:        logTiming,
+			SyncTimeout:         60 * time.Second,
+			DeferredSyncTimeout: 3 * time.Minute,
 
 			OnReceived: func(kind string) {
 				timeline.IncrementReceived(kind)

--- a/internal/k8s/topology_adapter.go
+++ b/internal/k8s/topology_adapter.go
@@ -106,6 +106,9 @@ func (a *topologyResourceProvider) Ingresses() ([]*networkingv1.Ingress, error) 
 func (a *topologyResourceProvider) ConfigMaps() ([]*corev1.ConfigMap, error) {
 	lister := a.cache.ConfigMaps()
 	if lister == nil {
+		if a.cache.IsDeferredPending(k8score.ConfigMaps) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("configmaps not available (RBAC not granted)")
 	}
 	return lister.List(labels.Everything())
@@ -114,6 +117,9 @@ func (a *topologyResourceProvider) ConfigMaps() ([]*corev1.ConfigMap, error) {
 func (a *topologyResourceProvider) Secrets() ([]*corev1.Secret, error) {
 	lister := a.cache.Secrets()
 	if lister == nil {
+		if a.cache.IsDeferredPending(k8score.Secrets) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("secrets not available (RBAC not granted)")
 	}
 	return lister.List(labels.Everything())
@@ -122,6 +128,9 @@ func (a *topologyResourceProvider) Secrets() ([]*corev1.Secret, error) {
 func (a *topologyResourceProvider) PersistentVolumeClaims() ([]*corev1.PersistentVolumeClaim, error) {
 	lister := a.cache.PersistentVolumeClaims()
 	if lister == nil {
+		if a.cache.IsDeferredPending(k8score.PersistentVolumeClaims) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("persistentvolumeclaims not available (RBAC not granted)")
 	}
 	return lister.List(labels.Everything())
@@ -130,6 +139,9 @@ func (a *topologyResourceProvider) PersistentVolumeClaims() ([]*corev1.Persisten
 func (a *topologyResourceProvider) PersistentVolumes() ([]*corev1.PersistentVolume, error) {
 	lister := a.cache.PersistentVolumes()
 	if lister == nil {
+		if a.cache.IsDeferredPending(k8score.PersistentVolumes) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("persistentvolumes not available (RBAC not granted)")
 	}
 	return lister.List(labels.Everything())
@@ -146,6 +158,9 @@ func (a *topologyResourceProvider) HorizontalPodAutoscalers() ([]*autoscalingv2.
 func (a *topologyResourceProvider) PodDisruptionBudgets() ([]*policyv1.PodDisruptionBudget, error) {
 	lister := a.cache.PodDisruptionBudgets()
 	if lister == nil {
+		if a.cache.IsDeferredPending(k8score.PodDisruptionBudgets) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("poddisruptionbudgets not available (RBAC not granted)")
 	}
 	return lister.List(labels.Everything())
@@ -154,6 +169,9 @@ func (a *topologyResourceProvider) PodDisruptionBudgets() ([]*policyv1.PodDisrup
 func (a *topologyResourceProvider) NetworkPolicies() ([]*networkingv1.NetworkPolicy, error) {
 	lister := a.cache.NetworkPolicies()
 	if lister == nil {
+		if a.cache.IsDeferredPending(k8score.NetworkPolicies) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("networkpolicies not available (RBAC not granted)")
 	}
 	return lister.List(labels.Everything())

--- a/internal/k8s/topology_adapter_test.go
+++ b/internal/k8s/topology_adapter_test.go
@@ -1,0 +1,173 @@
+package k8s
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/skyhook-io/radar/pkg/k8score"
+)
+
+// newAdapterCache builds a k8s.ResourceCache wrapping a k8score.ResourceCache
+// configured for the given ResourceTypes + DeferredTypes. A list reactor can
+// be attached via clientMod to simulate API failures.
+func newAdapterCache(t *testing.T, enabled, deferred map[string]bool, timeout time.Duration, clientMod func(*fake.Clientset)) *ResourceCache {
+	t.Helper()
+	client := fake.NewClientset()
+	if clientMod != nil {
+		clientMod(client)
+	}
+	core, err := k8score.NewResourceCache(k8score.CacheConfig{
+		Client:              client,
+		ResourceTypes:       enabled,
+		DeferredTypes:       deferred,
+		DeferredSyncTimeout: timeout,
+	})
+	if err != nil {
+		t.Fatalf("NewResourceCache: %v", err)
+	}
+	t.Cleanup(core.Stop)
+	return &ResourceCache{ResourceCache: core}
+}
+
+// TestTopologyAdapter_ConfigMaps_DeferredPending verifies that while the
+// ConfigMaps informer is still deferred-pending, the adapter returns
+// (nil, nil) instead of a misleading "RBAC not granted" error. This is the
+// core fix for issue #460 — one failing sibling must not produce misleading
+// topology warnings for healthy-but-not-yet-synced resources.
+func TestTopologyAdapter_ConfigMaps_DeferredPending(t *testing.T) {
+	// Make ConfigMaps LIST hang long enough to observe the pending state.
+	// A reactor that returns no items but takes >100ms keeps HasSynced=false
+	// during our observation window.
+	cache := newAdapterCache(t,
+		map[string]bool{k8score.Pods: true, k8score.ConfigMaps: true},
+		map[string]bool{k8score.ConfigMaps: true},
+		3*time.Second,
+		func(c *fake.Clientset) {
+			c.PrependReactor("list", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				time.Sleep(200 * time.Millisecond)
+				return true, &corev1.ConfigMapList{}, nil
+			})
+		},
+	)
+
+	// Observe while pending: IsDeferredPending must be true, lister must be nil.
+	if !cache.IsDeferredPending(k8score.ConfigMaps) {
+		t.Fatal("expected ConfigMaps to be deferred-pending immediately after start")
+	}
+	if cache.ConfigMaps() != nil {
+		t.Fatal("expected nil lister during deferred-pending")
+	}
+
+	adapter := NewTopologyResourceProvider(cache)
+	cms, err := adapter.ConfigMaps()
+	if err != nil {
+		t.Errorf("expected no error during deferred-pending, got: %v", err)
+	}
+	if cms != nil {
+		t.Errorf("expected nil slice during deferred-pending, got %d items", len(cms))
+	}
+}
+
+// TestTopologyAdapter_ConfigMaps_RBACDenied verifies that when the informer
+// was never enabled (simulating RBAC denial), the adapter returns the genuine
+// "RBAC not granted" error — not the silent nil,nil path used for pending.
+func TestTopologyAdapter_ConfigMaps_RBACDenied(t *testing.T) {
+	cache := newAdapterCache(t,
+		map[string]bool{k8score.Pods: true}, // ConfigMaps deliberately NOT enabled
+		map[string]bool{},
+		3*time.Second,
+		nil,
+	)
+
+	if cache.IsDeferredPending(k8score.ConfigMaps) {
+		t.Fatal("ConfigMaps was never enabled; IsDeferredPending must be false")
+	}
+	if cache.ConfigMaps() != nil {
+		t.Fatal("expected nil lister for unenabled resource")
+	}
+
+	adapter := NewTopologyResourceProvider(cache)
+	cms, err := adapter.ConfigMaps()
+	if err == nil {
+		t.Error("expected RBAC error for unenabled resource, got nil")
+	}
+	if cms != nil {
+		t.Errorf("expected nil slice on RBAC denial, got %d items", len(cms))
+	}
+}
+
+// TestTopologyAdapter_ConfigMaps_Synced verifies the happy path: when the
+// informer is synced, the adapter returns the list with no error.
+func TestTopologyAdapter_ConfigMaps_Synced(t *testing.T) {
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm-1", Namespace: "default"}}
+	client := fake.NewClientset(cm)
+	core, err := k8score.NewResourceCache(k8score.CacheConfig{
+		Client:        client,
+		ResourceTypes: map[string]bool{k8score.Pods: true, k8score.ConfigMaps: true},
+		DeferredTypes: map[string]bool{k8score.ConfigMaps: true},
+	})
+	if err != nil {
+		t.Fatalf("NewResourceCache: %v", err)
+	}
+	t.Cleanup(core.Stop)
+	cache := &ResourceCache{ResourceCache: core}
+
+	// Wait for ConfigMaps to become ready (fake client syncs fast).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cache.ConfigMaps() != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if cache.ConfigMaps() == nil {
+		t.Fatal("ConfigMaps never became ready")
+	}
+
+	adapter := NewTopologyResourceProvider(cache)
+	cms, err := adapter.ConfigMaps()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(cms) != 1 {
+		t.Errorf("expected 1 ConfigMap, got %d", len(cms))
+	}
+}
+
+// TestTopologyAdapter_NetworkPolicies_DeferredPending verifies that the same
+// (nil, nil) behavior applies to NetworkPolicies — the guard was added to
+// six methods, and at least one other should be exercised so a regression
+// that only fixes ConfigMaps doesn't pass.
+func TestTopologyAdapter_NetworkPolicies_DeferredPending(t *testing.T) {
+	cache := newAdapterCache(t,
+		map[string]bool{k8score.Pods: true, k8score.NetworkPolicies: true},
+		map[string]bool{k8score.NetworkPolicies: true},
+		3*time.Second,
+		func(c *fake.Clientset) {
+			c.PrependReactor("list", "networkpolicies", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				time.Sleep(200 * time.Millisecond)
+				return true, nil, fmt.Errorf("slow api")
+			})
+		},
+	)
+
+	if !cache.IsDeferredPending(k8score.NetworkPolicies) {
+		t.Fatal("expected NetworkPolicies to be deferred-pending immediately after start")
+	}
+
+	adapter := NewTopologyResourceProvider(cache)
+	nps, err := adapter.NetworkPolicies()
+	if err != nil {
+		t.Errorf("expected no error during deferred-pending, got: %v", err)
+	}
+	if nps != nil {
+		t.Errorf("expected nil slice during deferred-pending, got %d items", len(nps))
+	}
+}

--- a/pkg/k8score/cache.go
+++ b/pkg/k8score/cache.go
@@ -472,10 +472,10 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 			}
 
 			if timedOut {
-				// Some informers never synced within the deadline. Flip
-				// deferredFailed so IsDeferredPending returns false for the
-				// stragglers (HTTP handlers return 403 instead of perpetual
-				// 503). Informers that already synced keep their own
+				// Stop waiting on stragglers. deferredFailed is the "give up"
+				// signal read by IsDeferredPending — stragglers start reporting
+				// not-pending, so HTTP handlers return 403 instead of perpetual
+				// 503. Informers that already synced keep their own
 				// deferredSynced[k]=true and continue serving normally.
 				rc.deferredMu.RLock()
 				var pending []string
@@ -486,7 +486,9 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 				}
 				rc.deferredMu.RUnlock()
 				rc.deferredFailed.Store(true)
-				stdlog.Printf("WARNING: Deferred sync timed out after %v; %d informer(s) never synced: %s",
+				stdlog.Printf("WARNING: Deferred sync timed out after %v; %d informer(s) never synced: %s. "+
+					"These resources will return 403 to API consumers. Common cause: the corresponding API "+
+					"version isn't served on this cluster (check `kubectl api-resources | grep <resource>`).",
 					cfg.DeferredSyncTimeout, len(pending), strings.Join(pending, ", "))
 			} else {
 				logf("    Phase 2 sync (%d deferred informers): %v", len(deferredSyncFuncs), time.Since(deferredStart))

--- a/pkg/k8score/cache.go
+++ b/pkg/k8score/cache.go
@@ -402,14 +402,32 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 			progressTicker := time.NewTicker(5 * time.Second)
 			defer progressTicker.Stop()
 
+			var deadlineCh <-chan time.Time
+			if cfg.DeferredSyncTimeout > 0 {
+				t := time.NewTimer(cfg.DeferredSyncTimeout)
+				defer t.Stop()
+				deadlineCh = t.C
+			}
+
+			timedOut := false
 			for {
+				// Mark each informer synced the moment its own HasSynced() is
+				// true. A permanently-failing informer (e.g. HPA autoscaling/v2
+				// on K8s <1.23) must not block siblings from becoming ready.
+				rc.deferredMu.Lock()
 				allSynced := true
-				for _, fn := range deferredSyncFuncs {
-					if !fn() {
+				for i, fn := range deferredSyncFuncs {
+					k := deferredKeys[i]
+					if rc.deferredSynced[k] {
+						continue
+					}
+					if fn() {
+						rc.deferredSynced[k] = true
+					} else {
 						allSynced = false
-						break
 					}
 				}
+				rc.deferredMu.Unlock()
 				if allSynced {
 					break
 				}
@@ -417,9 +435,11 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 				select {
 				case <-stopCh:
 					rc.deferredFailed.Store(true)
-					stdlog.Printf("ERROR: Deferred resource cache sync failed after %v", time.Since(deferredStart))
+					stdlog.Printf("ERROR: Deferred resource cache sync aborted after %v", time.Since(deferredStart))
 					close(deferredDone)
 					return
+				case <-deadlineCh:
+					timedOut = true
 				case <-progressTicker.C:
 					counts := rc.GetKindObjectCounts()
 					rc.informerMu.RLock()
@@ -445,16 +465,34 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 				default:
 					time.Sleep(100 * time.Millisecond)
 				}
+
+				if timedOut {
+					break
+				}
 			}
 
-			rc.deferredMu.Lock()
-			for _, k := range deferredKeys {
-				rc.deferredSynced[k] = true
+			if timedOut {
+				// Some informers never synced within the deadline. Flip
+				// deferredFailed so IsDeferredPending returns false for the
+				// stragglers (HTTP handlers return 403 instead of perpetual
+				// 503). Informers that already synced keep their own
+				// deferredSynced[k]=true and continue serving normally.
+				rc.deferredMu.RLock()
+				var pending []string
+				for _, k := range deferredKeys {
+					if !rc.deferredSynced[k] {
+						pending = append(pending, k)
+					}
+				}
+				rc.deferredMu.RUnlock()
+				rc.deferredFailed.Store(true)
+				stdlog.Printf("WARNING: Deferred sync timed out after %v; %d informer(s) never synced: %s",
+					cfg.DeferredSyncTimeout, len(pending), strings.Join(pending, ", "))
+			} else {
+				logf("    Phase 2 sync (%d deferred informers): %v", len(deferredSyncFuncs), time.Since(deferredStart))
+				stdlog.Printf("Deferred resource caches synced in %v (total: %v)", time.Since(deferredStart), time.Since(syncStart))
 			}
-			rc.deferredMu.Unlock()
 			close(deferredDone)
-			logf("    Phase 2 sync (%d deferred informers): %v", len(deferredSyncFuncs), time.Since(deferredStart))
-			stdlog.Printf("Deferred resource caches synced in %v (total: %v)", time.Since(deferredStart), time.Since(syncStart))
 		}()
 	} else {
 		close(deferredDone)

--- a/pkg/k8score/cache_test.go
+++ b/pkg/k8score/cache_test.go
@@ -140,13 +140,21 @@ func TestNewResourceCache_DeferredSync_PartialFailure(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	if rc.ConfigMaps() == nil {
-		t.Error("expected ConfigMaps() to become ready despite sibling HPA failing")
+		t.Fatal("expected ConfigMaps() to become ready despite sibling HPA failing")
 	}
 	if rc.Secrets() == nil {
-		t.Error("expected Secrets() to become ready despite sibling HPA failing")
+		t.Fatal("expected Secrets() to become ready despite sibling HPA failing")
 	}
-	if rc.HorizontalPodAutoscalers() == nil {
-		t.Error("HPA lister uses isEnabled(), not isReady() — expected non-nil")
+
+	// Pre-timeout contract check: while HPA is still stuck and the deadline
+	// hasn't fired, IsDeferredPending must report HPA pending (HTTP handlers
+	// return 503) and ConfigMaps not-pending (handlers serve data). This is
+	// the 503-vs-403 distinction the fix is built around.
+	if !rc.IsDeferredPending(HorizontalPodAutoscalers) {
+		t.Error("pre-timeout: expected IsDeferredPending(HPA)=true while informer still stuck")
+	}
+	if rc.IsDeferredPending(ConfigMaps) {
+		t.Error("pre-timeout: ConfigMaps synced, expected IsDeferredPending=false")
 	}
 
 	// deferredDone must close even though HPA never syncs — otherwise the
@@ -157,14 +165,14 @@ func TestNewResourceCache_DeferredSync_PartialFailure(t *testing.T) {
 		t.Fatal("deferredDone never closed after DeferredSyncTimeout")
 	}
 
-	// Post-timeout: ConfigMaps synced fine → IsDeferredPending returns false.
-	// HPA never synced → IsDeferredPending also returns false (because
-	// deferredFailed is set) so HTTP handlers return 403, not perpetual 503.
-	if rc.IsDeferredPending(ConfigMaps) {
-		t.Error("ConfigMaps synced, expected IsDeferredPending=false")
-	}
+	// Post-timeout: HPA flips from pending to not-pending because
+	// deferredFailed is now set — stops the perpetual-503 spinner.
+	// ConfigMaps stays not-pending (it was already synced).
 	if rc.IsDeferredPending(HorizontalPodAutoscalers) {
-		t.Error("HPA never synced but timeout fired, expected IsDeferredPending=false")
+		t.Error("post-timeout: expected IsDeferredPending(HPA)=false (deferredFailed signals give-up)")
+	}
+	if rc.IsDeferredPending(ConfigMaps) {
+		t.Error("post-timeout: ConfigMaps synced, expected IsDeferredPending=false")
 	}
 }
 

--- a/pkg/k8score/cache_test.go
+++ b/pkg/k8score/cache_test.go
@@ -1,13 +1,16 @@
 package k8score
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestNewResourceCache_Basic(t *testing.T) {
@@ -91,6 +94,77 @@ func TestNewResourceCache_DeferredSync(t *testing.T) {
 	}
 	if rc.Secrets() == nil {
 		t.Error("expected Secrets() lister to be available after deferred sync")
+	}
+}
+
+// TestNewResourceCache_DeferredSync_PartialFailure verifies that a permanently
+// failing deferred informer (e.g. HPA autoscaling/v2 on a K8s <1.23 cluster,
+// which responds with "the server could not find the requested resource")
+// does not block sibling deferred informers from becoming ready. It also
+// verifies the DeferredSyncTimeout path flips deferredFailed so stragglers
+// return false from IsDeferredPending.
+func TestNewResourceCache_DeferredSync_PartialFailure(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	// Make HPA LIST fail forever, as happens when the v2 API isn't served.
+	client.PrependReactor("list", "horizontalpodautoscalers", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("the server could not find the requested resource")
+	})
+
+	rc, err := NewResourceCache(CacheConfig{
+		Client: client,
+		ResourceTypes: map[string]bool{
+			Pods:                     true,
+			ConfigMaps:               true,
+			Secrets:                  true,
+			HorizontalPodAutoscalers: true,
+		},
+		DeferredTypes: map[string]bool{
+			ConfigMaps:               true,
+			Secrets:                  true,
+			HorizontalPodAutoscalers: true,
+		},
+		DeferredSyncTimeout: 500 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewResourceCache failed: %v", err)
+	}
+	defer rc.Stop()
+
+	// Poll for ConfigMaps and Secrets to become ready. A failing sibling
+	// (HPA) must not block them.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if rc.ConfigMaps() != nil && rc.Secrets() != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if rc.ConfigMaps() == nil {
+		t.Error("expected ConfigMaps() to become ready despite sibling HPA failing")
+	}
+	if rc.Secrets() == nil {
+		t.Error("expected Secrets() to become ready despite sibling HPA failing")
+	}
+	if rc.HorizontalPodAutoscalers() == nil {
+		t.Error("HPA lister uses isEnabled(), not isReady() — expected non-nil")
+	}
+
+	// deferredDone must close even though HPA never syncs — otherwise the
+	// SSE warmup completion never fires.
+	select {
+	case <-rc.DeferredDone():
+	case <-time.After(3 * time.Second):
+		t.Fatal("deferredDone never closed after DeferredSyncTimeout")
+	}
+
+	// Post-timeout: ConfigMaps synced fine → IsDeferredPending returns false.
+	// HPA never synced → IsDeferredPending also returns false (because
+	// deferredFailed is set) so HTTP handlers return 403, not perpetual 503.
+	if rc.IsDeferredPending(ConfigMaps) {
+		t.Error("ConfigMaps synced, expected IsDeferredPending=false")
+	}
+	if rc.IsDeferredPending(HorizontalPodAutoscalers) {
+		t.Error("HPA never synced but timeout fired, expected IsDeferredPending=false")
 	}
 }
 

--- a/pkg/k8score/types.go
+++ b/pkg/k8score/types.go
@@ -146,6 +146,13 @@ type CacheConfig struct {
 	// Zero means wait indefinitely (original behavior).
 	SyncTimeout time.Duration
 
+	// DeferredSyncTimeout caps how long we wait for deferred informers to
+	// finish syncing before giving up. When the deadline fires, deferredDone
+	// is closed and deferredFailed is set so any still-unsynced types return
+	// 403 from HTTP handlers instead of perpetual 503s. Synced types are
+	// unaffected. Zero means wait indefinitely.
+	DeferredSyncTimeout time.Duration
+
 	// DebugEvents enables verbose event debug logging.
 	DebugEvents bool
 


### PR DESCRIPTION
## Summary

Fixes #460 — ConfigMaps, Secrets, PVCs, PDBs, NetworkPolicies become inaccessible whenever any *one* deferred informer permanently fails to sync. The reporter hit this on K8s 1.21 because `autoscaling/v2` HPA doesn't exist there; the RBAC probe passes (SAR doesn't check versions) but the informer's LIST fails forever, which blocked the entire all-or-nothing deferred sync batch.

## What changed

**`pkg/k8score/cache.go`** — The deferred sync goroutine now marks each key `deferredSynced[k]=true` the moment its own `HasSynced()` returns true, instead of waiting for the whole batch. A new `CacheConfig.DeferredSyncTimeout` (default 3m, wired in `internal/k8s/cache.go`) caps the overall wait: on deadline, `deferredFailed` is set so any still-stuck types return 403 instead of perpetual 503, and `deferredDone` closes so SSE warmup can complete.

**`internal/k8s/topology_adapter.go`** — Distinguishes "still syncing" from "RBAC denied" for the six deferred-backed listers (ConfigMaps, Secrets, PVCs, PVs, PDBs, NetworkPolicies). Pending returns `(nil, nil)` silently — the next topology rebuild after sync picks them up. The genuine "RBAC not granted" error stays for informers that never enabled.

**`pkg/k8score/cache_test.go`** — New `TestNewResourceCache_DeferredSync_PartialFailure` reproduces the exact scenario via a reactor that makes HPA LIST fail forever; asserts ConfigMaps/Secrets become ready independently, deadline fires, `IsDeferredPending` flips false for stragglers.

## Follow-ups (not in this PR)

- API-discovery pre-flight to avoid registering HPA v2 on clusters that don't serve it — would eliminate residual client-go reflector log spam on K8s <1.23.
- HPA version fallback (v2 → v2beta2 → v1) for true old-cluster support.

## Test plan

- [x] `go test ./pkg/... ./internal/k8s/...` passes
- [x] `go build ./...` clean
- [ ] Manual verification against K8s ≤1.22 cluster (kind with `kindest/node:v1.21.1`): ConfigMap drawer opens, `/api/resources/configmaps` returns 200, no `WARNING [topology] Failed to list ConfigMaps` log loops, SSE `deferred_ready` event fires.
- [x] Regression sanity check on modern K8s (1.29+): deferred informers sync as before.