### PR TITLE
fix: set TERM in local terminal so backspace/delete work

### DIFF
--- a/internal/server/localterm.go
+++ b/internal/server/localterm.go
@@ -120,6 +120,12 @@ func (s *Server) handleLocalTerminal(w http.ResponseWriter, r *http.Request) {
 		env = setEnv(env, "KUBECONFIG", tmpKubeconfig)
 	}
 
+	// Ensure TERM is set so the shell's terminfo binds the escape sequences
+	// xterm.js emits (e.g. Backspace → 0x7f, Delete → CSI 3~). When Radar is
+	// launched from a GUI (desktop app, browser), the inherited env often has
+	// no TERM, leaving backspace/delete keys broken.
+	env = setEnv(env, "TERM", "xterm-256color")
+
 	// Get home directory (cross-platform)
 	homeDir, _ := os.UserHomeDir()
 


### PR DESCRIPTION
## Summary

Backspace was printing a space and Delete was printing `~` in the local (OS) terminal tab. Fix by setting `TERM=xterm-256color` on the shell process.

## Why

xterm.js sends `0x7f` for Backspace and `CSI 3~` for Delete. Without `TERM` set, the shell's terminfo doesn't bind these escape sequences, so they fall through as raw bytes.

When Radar is launched from a GUI (desktop app, or browser opening the binary), the inherited environment typically has no `TERM`. Pod exec already handles this (`internal/server/exec.go:53`); local terminal was missing the same.

Fixes #372