### PR TITLE
desktop: log Linux session + render env at startup

### DIFF
--- a/cmd/desktop/boot_env_linux.go
+++ b/cmd/desktop/boot_env_linux.go
@@ -1,0 +1,41 @@
+//go:build linux
+
+package main
+
+import (
+	"log"
+	"os"
+	"strings"
+)
+
+// logBootEnv prints Linux desktop environment context at startup so bug
+// reports include the info needed to diagnose Wayland/X11, compositor, and
+// WebKit rendering issues without the reporter having to run extra commands.
+func logBootEnv() {
+	session := []string{"XDG_SESSION_TYPE", "XDG_CURRENT_DESKTOP", "WAYLAND_DISPLAY", "DISPLAY"}
+	overrides := []string{"GDK_BACKEND", "GSK_RENDERER", "WEBKIT_DISABLE_DMABUF_RENDERER", "WEBKIT_DISABLE_COMPOSITING_MODE", "GTK_THEME"}
+	sandbox := []string{"SNAP", "FLATPAK_ID", "container"}
+
+	log.Printf("[desktop] session: %s", joinEnv(session, true))
+	if s := joinEnv(overrides, false); s != "" {
+		log.Printf("[desktop] render overrides: %s", s)
+	}
+	if s := joinEnv(sandbox, false); s != "" {
+		log.Printf("[desktop] sandbox: %s", s)
+	}
+}
+
+// joinEnv formats env vars as "KEY=value" pairs. When includeUnset is true,
+// unset vars are rendered as "KEY=" so the reader can tell they were checked.
+// When false, unset vars are omitted (noise reduction for overrides).
+func joinEnv(keys []string, includeUnset bool) string {
+	var parts []string
+	for _, k := range keys {
+		v := os.Getenv(k)
+		if v == "" && !includeUnset {
+			continue
+		}
+		parts = append(parts, k+"="+v)
+	}
+	return strings.Join(parts, " ")
+}

--- a/cmd/desktop/boot_env_other.go
+++ b/cmd/desktop/boot_env_other.go
@@ -1,0 +1,5 @@
+//go:build !linux
+
+package main
+
+func logBootEnv() {}

--- a/cmd/desktop/main.go
+++ b/cmd/desktop/main.go
@@ -59,6 +59,11 @@ func main() {
 
 	log.Printf("Radar Desktop %s starting...", version)
 
+	// Log Linux desktop environment (session type, render overrides) so bug
+	// reports for startup failures include the diagnostic context by default.
+	// No-op on macOS/Windows.
+	logBootEnv()
+
 	// GUI apps (macOS .app, Linux .desktop) get a minimal PATH that
 	// doesn't include user-installed tools like gke-gcloud-auth-plugin,
 	// gcloud, aws CLI, etc. Enrich PATH from the user's login shell.


### PR DESCRIPTION
## Summary

When a desktop bug report comes in for a startup failure (e.g. #465), the reporter's console log is often all we have to work with — the Ctrl+Shift+D in-app diagnostics snapshot can't help if the UI never loads. Today we have to follow up and ask the reporter to run extra commands to tell us whether they're on Wayland or X11, which desktop environment, and whether any render-override env vars are set.

This patch logs that context at startup so it's in every console paste by default — no flag, no doc to find, no action required from the user.

## What's logged

On Linux only, two or three lines right after the "starting..." log:

```
[desktop] session: XDG_SESSION_TYPE=wayland XDG_CURRENT_DESKTOP=KDE WAYLAND_DISPLAY=wayland-0 DISPLAY=
[desktop] render overrides: GDK_BACKEND=X11 WEBKIT_DISABLE_DMABUF_RENDERER=1
[desktop] sandbox: FLATPAK_ID=io.skyhook.Radar
```

Session vars are always shown (unset rendered as `KEY=`) so the reader can tell they were checked. Override and sandbox lines only appear when at least one of their vars is set, to keep the boot log tidy for the common case.

## Scope

- `cmd/desktop/boot_env_linux.go` — new, ~35 lines.
- `cmd/desktop/boot_env_other.go` — 5-line no-op stub for macOS/Windows.
- `cmd/desktop/main.go` — one call site, placed before `enrichEnv`/`applySystemTheme` so the log captures the user's original env, not our mutations.

No behavior changes, no new dependencies, no new flags.