### PR TITLE
fix(k8s): add NodeWrite check to CheckCapabilitiesForUser

### DIFF
--- a/internal/k8s/capabilities.go
+++ b/internal/k8s/capabilities.go
@@ -406,6 +406,7 @@ func CheckCapabilitiesForUser(ctx context.Context, username string, groups []str
 		{"secrets", "list", &caps.Secrets},
 		{"secrets", "update", &caps.SecretsUpdate},
 		{"secrets", "create", &caps.HelmWrite},
+		{"nodes", "patch", &caps.NodeWrite},
 	}
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
## Description

`CheckCapabilitiesForUser` (used when OIDC/proxy auth is enabled) was missing the `nodes/patch` capability check that already exists in `CheckCapabilities` (the no-auth path). This caused `nodeWrite` to always be `false` for authenticated users, hiding the cordon/drain/uncordon buttons in the Nodes view regardless of the user's actual RBAC permissions.

One line added to mirror the existing check in the OIDC code path.


 >>> cordon and drain missing in first screenshot when auth is enabled

<img width="538" height="353" alt="radar-oidc" src="https://github.com/user-attachments/assets/d7fee5aa-8b7e-448c-a535-1f757a0a892d" />


<img width="371" height="303" alt="radar-local" src="https://github.com/user-attachments/assets/b2c2e80d-4c9c-4fff-888e-cdf26edba59d" />


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

Tested against a live AWS EKS cluster with Radar deployed via Helm (`skyhook/radar:1.4.8`) in OIDC auth mode (authentik IDP):

- User is member of `admin` group, bound to `cluster-admin` ClusterRole
- Before fix: `/api/capabilities` returned `nodeWrite: false`, cordon/drain/uncordon buttons absent
- After fix: `/api/capabilities` returns `nodeWrite: true`, buttons appear and operations succeed
- No-auth path (`CheckCapabilities`) behaviour unchanged

- [ ] Tested locally with minikube/kind
- [x] Tested against a remote cluster
- [x] Added/updated unit tests

Go tests: all packages pass (internal/k8s included — 6.1s)
Frontend type check: no errors after installing deps

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [ ] I have added comments where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

## Related issues

Fixes #(issue number)
