### PR TITLE
radar-app + k8s-ui: finish Tailwind v4 migration; fix npm-consumer build

### DIFF
--- a/packages/k8s-ui/src/topology.css
+++ b/packages/k8s-ui/src/topology.css
@@ -1,0 +1,6 @@
+/* Top-level re-export of topology.css so both npm-exports resolution and
+ * source-alias resolution (in the radar monorepo's Vite config) land on
+ * the same stylesheet. Keeps external consumers' @import paths simple
+ * (@skyhook-io/k8s-ui/topology.css) without forcing them to know the
+ * components/ subdirectory layout. */
+@import "./components/topology/topology.css";

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -4,7 +4,7 @@
 @import "@skyhook-io/k8s-ui/theme/variables.css";
 @import "@skyhook-io/k8s-ui/theme/tailwind-theme.css";
 @import "@skyhook-io/k8s-ui/theme/components.css";
-@import "@skyhook-io/k8s-ui/components/topology/topology.css";
+@import "@skyhook-io/k8s-ui/topology.css";
 @import "@fontsource-variable/dm-sans";
 @import "@fontsource/dm-mono";
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,5 +1,4 @@
 @import "tailwindcss";
-@config "../tailwind.config.js";
 @variant dark (&:where(.dark, .dark *));
 @import "@skyhook-io/k8s-ui/theme/variables.css";
 @import "@skyhook-io/k8s-ui/theme/tailwind-theme.css";
@@ -7,6 +6,49 @@
 @import "@skyhook-io/k8s-ui/topology.css";
 @import "@fontsource-variable/dm-sans";
 @import "@fontsource/dm-mono";
+
+/*
+ * Tailwind v4 theme tokens. Migrated from the legacy v3 tailwind.config.js
+ * to CSS-first @theme so library consumers (e.g. radar-hub-web) don't need
+ * to pick up radar's Node config or its `@tailwindcss/typography` plugin
+ * when they consume this package from npm.
+ */
+@theme {
+  /* Fonts — DM Sans for UI, DM Mono for code/metric panes. */
+  --font-sans: "DM Sans Variable", "DM Sans", system-ui, sans-serif;
+  --font-mono: "DM Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  /* Breakpoints — desktop-first K8s UI; tighter than Tailwind defaults. */
+  --breakpoint-sm: 900px;
+  --breakpoint-md: 1100px;
+  --breakpoint-lg: 1280px;
+  --breakpoint-xl: 1536px;
+
+  /* Shadows (mapped to the --shadow-* CSS vars from k8s-ui/theme). */
+  --shadow-theme-sm: var(--shadow-sm);
+  --shadow-theme-md: var(--shadow-md);
+  --shadow-theme-lg: var(--shadow-lg);
+  --shadow-glow-brand-sm: var(--glow-brand-sm);
+  --shadow-glow-brand-md: var(--glow-brand-md);
+  --shadow-drawer: var(--shadow-drawer);
+
+  /* Ring (focus outline) color — follow the accent CSS var. */
+  --color-accent: var(--accent);
+
+  /* Border radius — rounder than Tailwind defaults to match the brand. */
+  --radius: 0.375rem;    /* default (was 0.25rem) */
+  --radius-md: 0.5rem;   /* was 0.375rem */
+  --radius-lg: 0.625rem; /* was 0.5rem */
+  --radius-xl: 0.875rem; /* was 0.75rem */
+
+  /* Custom transient toast animation used in a few spots. */
+  --animate-fade-in-out: fadeInOut 2s ease-in-out forwards;
+}
+
+@keyframes fadeInOut {
+  0%, 100% { opacity: 0; transform: translateY(-8px); }
+  15%, 85% { opacity: 1; transform: translateY(0); }
+}
 
 /* Global: pointer cursor for all interactive elements */
 button, [role="button"], a, label, select, summary, [tabindex]:not([tabindex="-1"]) {


### PR DESCRIPTION
## Summary

Unblocks external-consumer builds (radar-hub-web on Vercel) by finishing the Tailwind v4 migration in `web/` and aligning the topology.css import path with k8s-ui's npm-exports field.

### 1. Port remaining v3 config to CSS-first `@theme`

`web/src/index.css` had `@config "../tailwind.config.js"` — a v4 compat shim that worked in the monorepo but broke npm consumers two ways:
- `tailwind.config.js` lives outside `web/src/` (not in published `files`)
- The config imports `@tailwindcss/typography` which isn't a peer dep

Move the handful of radar-specific theme extensions (fonts, custom breakpoints, shadow aliases, border-radius scale, transient toast animation) into CSS-first `@theme` blocks in `index.css`. No v3 config coupling left.

Radar's own build still works — typography plugin wasn't actually referenced anywhere (no `prose` classes in `src/`). The @theme block reproduces the same utility classes radar's code was using via the old JS config.

### 2. Fix topology.css import path

Change `@import "@skyhook-io/k8s-ui/components/topology/topology.css"` → `@import "@skyhook-io/k8s-ui/topology.css"`. The latter matches k8s-ui's published `exports` field.

Add a thin `packages/k8s-ui/src/topology.css` that re-imports from the `components/` subdir — radar's own monorepo build uses a source alias (bypassing npm-exports resolution), so it needs a file at that path too.

## Verified

- `cd web && npm run build` succeeds (radar's own binary)
- External consumer (`radar-hub-web`) builds cleanly against a patched `node_modules` copy of these changes

## Follow-ups after merge

1. Tag `radar-app-v0.1.2` → auto-publishes the fixed CSS
2. `radar-hub-web` bumps `@skyhook-io/radar-app` to `^0.1.2` → Vercel deploys can build
3. (Optional cleanup) delete `web/tailwind.config.js` entirely — no longer referenced