### PR TITLE
fix(audit): honor K8s inheritance for security + efficiency checks

### DIFF
--- a/deploy/helm/radar/templates/clusterrole.yaml
+++ b/deploy/helm/radar/templates/clusterrole.yaml
@@ -18,6 +18,7 @@ rules:
       - persistentvolumeclaims
       - serviceaccounts
       - endpoints
+      - limitranges
     verbs: ["get", "list", "watch"]
 
   {{- if .Values.rbac.helm }}

--- a/internal/audit/runner.go
+++ b/internal/audit/runner.go
@@ -36,6 +36,8 @@ func RunFromCache(cache *k8s.ResourceCache, namespaces []string, opts *RunOption
 		PodDisruptionBudgets:     listNamespaced(cache.PodDisruptionBudgets(), namespaces),
 		ConfigMaps:               listNamespaced(cache.ConfigMaps(), namespaces),
 		Secrets:                  listNamespaced(cache.Secrets(), namespaces),
+		ServiceAccounts:          listNamespaced(cache.ServiceAccounts(), namespaces),
+		LimitRanges:              listNamespaced(cache.LimitRanges(), namespaces),
 	}
 
 	if opts != nil {
@@ -100,6 +102,10 @@ func extractNamespace(obj any) string {
 	case *corev1.ConfigMap:
 		return v.Namespace
 	case *corev1.Secret:
+		return v.Namespace
+	case *corev1.ServiceAccount:
+		return v.Namespace
+	case *corev1.LimitRange:
 		return v.Namespace
 	}
 	return ""

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -61,6 +61,8 @@ var deferredResources = map[string]bool{
 	"networkpolicies":          true,
 	"replicasets":              true, // topology-only (Deployment→RS→Pod); can be very large
 	"horizontalpodautoscalers": true, // problems detection, not critical for first render
+	"serviceaccounts":          true, // audit inheritance lookups, not first-render
+	"limitranges":              true, // audit inheritance lookups, not first-render
 }
 
 // ResourceChange is a type alias for the canonical definition in pkg/k8score.
@@ -125,6 +127,8 @@ func InitResourceCache(ctx context.Context) error {
 			"storageclasses":           perms.StorageClasses,
 			"poddisruptionbudgets":     perms.PodDisruptionBudgets,
 			"networkpolicies":          perms.NetworkPolicies,
+			"serviceaccounts":          perms.ServiceAccounts,
+			"limitranges":              perms.LimitRanges,
 		}
 
 		cfg := k8score.CacheConfig{

--- a/internal/k8s/capabilities.go
+++ b/internal/k8s/capabilities.go
@@ -45,6 +45,8 @@ type ResourcePermissions struct {
 	StorageClasses           bool `json:"storageClasses"`
 	PodDisruptionBudgets     bool `json:"podDisruptionBudgets"`
 	NetworkPolicies          bool `json:"networkPolicies"`
+	ServiceAccounts          bool `json:"serviceAccounts"`
+	LimitRanges              bool `json:"limitRanges"`
 	Gateways                 bool `json:"gateways"`
 	HTTPRoutes               bool `json:"httpRoutes"`
 }
@@ -567,6 +569,9 @@ func CheckResourcePermissions(ctx context.Context) *PermissionCheckResult {
 		{"policy", "poddisruptionbudgets", &perms.PodDisruptionBudgets},
 		// networking.k8s.io group
 		{"networking.k8s.io", "networkpolicies", &perms.NetworkPolicies},
+		// core (namespaced) — inheritance lookups for audit checks
+		{"", "serviceaccounts", &perms.ServiceAccounts},
+		{"", "limitranges", &perms.LimitRanges},
 	}
 
 	// Phase 1: Check all resources cluster-wide

--- a/pkg/audit/checks.go
+++ b/pkg/audit/checks.go
@@ -226,9 +226,10 @@ func tokenAutoMounted(namespace string, spec corev1.PodSpec, saByKey map[string]
 
 // effectivelyNonRoot reports whether a container is guaranteed not to run as
 // root, merging the pod-level PodSecurityContext with the container-level
-// override. A container is non-root if runAsNonRoot is true OR runAsUser is
-// set to a non-zero UID, at either scope. Container-level settings override
-// pod-level for each field independently.
+// override. Each field (runAsNonRoot, runAsUser) independently inherits from
+// the pod and is overridden by any non-nil container-level value. After the
+// merge, the container is non-root if runAsNonRoot is true OR runAsUser is
+// set to a non-zero UID.
 func effectivelyNonRoot(sc *corev1.SecurityContext, podSC *corev1.PodSecurityContext) bool {
 	var runAsNonRoot *bool
 	var runAsUser *int64

--- a/pkg/audit/checks.go
+++ b/pkg/audit/checks.go
@@ -88,20 +88,82 @@ func checkWorkloadPodSpecs(input *CheckInput) []Finding {
 		}
 	}
 
+	// Index ServiceAccounts and LimitRanges by namespace for inheritance lookups.
+	saByKey := indexServiceAccounts(input.ServiceAccounts)
+	limitsByNs := indexLimitRangesByNamespace(input.LimitRanges)
+
 	for _, w := range specs {
-		findings = append(findings, checkPodSpecSecurity(w.kind, w.namespace, w.name, w.spec)...)
+		findings = append(findings, checkPodSpecSecurity(w.kind, w.namespace, w.name, w.spec, saByKey)...)
 		findings = append(findings, checkPodSpecReliability(w.kind, w.namespace, w.name, w.spec)...)
-		findings = append(findings, checkPodSpecEfficiency(w.kind, w.namespace, w.name, w.spec)...)
+		findings = append(findings, checkPodSpecEfficiency(w.kind, w.namespace, w.name, w.spec, limitsByNs[w.namespace])...)
 		findings = append(findings, checkPodSpecVolumes(w.kind, w.namespace, w.name, w.spec)...)
 	}
 	return findings
+}
+
+// indexServiceAccounts returns a map keyed by "namespace/name".
+func indexServiceAccounts(sas []*corev1.ServiceAccount) map[string]*corev1.ServiceAccount {
+	if len(sas) == 0 {
+		return nil
+	}
+	m := make(map[string]*corev1.ServiceAccount, len(sas))
+	for _, sa := range sas {
+		m[sa.Namespace+"/"+sa.Name] = sa
+	}
+	return m
+}
+
+// indexLimitRangesByNamespace groups LimitRanges by namespace.
+func indexLimitRangesByNamespace(lrs []*corev1.LimitRange) map[string][]*corev1.LimitRange {
+	if len(lrs) == 0 {
+		return nil
+	}
+	m := make(map[string][]*corev1.LimitRange)
+	for _, lr := range lrs {
+		m[lr.Namespace] = append(m[lr.Namespace], lr)
+	}
+	return m
+}
+
+// containerDefaultsFromLimitRanges reports which container resource types
+// (cpu/memory requests/limits) would be filled in by admission based on the
+// namespace's LimitRange defaults. Only LimitRange items with Type=Container
+// contribute to container defaults.
+type containerDefaults struct {
+	cpuRequest, memoryRequest bool
+	cpuLimit, memoryLimit     bool
+}
+
+func containerDefaultsFromLimitRanges(lrs []*corev1.LimitRange) containerDefaults {
+	var d containerDefaults
+	for _, lr := range lrs {
+		for _, item := range lr.Spec.Limits {
+			if item.Type != corev1.LimitTypeContainer {
+				continue
+			}
+			// DefaultRequest covers requests; Default covers limits.
+			if _, ok := item.DefaultRequest[corev1.ResourceCPU]; ok {
+				d.cpuRequest = true
+			}
+			if _, ok := item.DefaultRequest[corev1.ResourceMemory]; ok {
+				d.memoryRequest = true
+			}
+			if _, ok := item.Default[corev1.ResourceCPU]; ok {
+				d.cpuLimit = true
+			}
+			if _, ok := item.Default[corev1.ResourceMemory]; ok {
+				d.memoryLimit = true
+			}
+		}
+	}
+	return d
 }
 
 // ============================================================================
 // Security checks
 // ============================================================================
 
-func checkPodSpecSecurity(kind, namespace, name string, spec corev1.PodSpec) []Finding {
+func checkPodSpecSecurity(kind, namespace, name string, spec corev1.PodSpec, saByKey map[string]*corev1.ServiceAccount) []Finding {
 	var findings []Finding
 	f := func(checkID, severity, msg string) {
 		findings = append(findings, Finding{
@@ -121,8 +183,11 @@ func checkPodSpecSecurity(kind, namespace, name string, spec corev1.PodSpec) []F
 		f("hostIPC", SeverityDanger, "Pod uses host IPC namespace")
 	}
 
-	// automountServiceAccountToken: only flag if not explicitly set to false
-	if spec.AutomountServiceAccountToken == nil || *spec.AutomountServiceAccountToken {
+	// automountServiceAccountToken: honors both pod-level and SA-level settings.
+	// Pod-level takes precedence. If neither is explicitly false, the token is
+	// auto-mounted. Only flag when the effective value is true (or unset, which
+	// defaults to true per K8s).
+	if tokenAutoMounted(namespace, spec, saByKey) {
 		f("automountServiceAccountToken", SeverityWarning, "Service account token is auto-mounted")
 	}
 
@@ -138,6 +203,25 @@ func checkPodSpecSecurity(kind, namespace, name string, spec corev1.PodSpec) []F
 	}
 
 	return findings
+}
+
+// tokenAutoMounted reports whether a service account token would be mounted
+// into the pod per K8s effective-value rules. Pod-level
+// automountServiceAccountToken overrides the ServiceAccount-level setting;
+// when neither is set, the default is true (token is mounted).
+func tokenAutoMounted(namespace string, spec corev1.PodSpec, saByKey map[string]*corev1.ServiceAccount) bool {
+	if spec.AutomountServiceAccountToken != nil {
+		return *spec.AutomountServiceAccountToken
+	}
+	saName := spec.ServiceAccountName
+	if saName == "" {
+		saName = "default"
+	}
+	if sa, ok := saByKey[namespace+"/"+saName]; ok &&
+		sa.AutomountServiceAccountToken != nil && !*sa.AutomountServiceAccountToken {
+		return false
+	}
+	return true
 }
 
 // effectivelyNonRoot reports whether a container is guaranteed not to run as
@@ -374,7 +458,7 @@ func checkMissingPDB(deployments []*appsv1.Deployment, statefulSets []*appsv1.St
 // Efficiency checks
 // ============================================================================
 
-func checkPodSpecEfficiency(kind, namespace, name string, spec corev1.PodSpec) []Finding {
+func checkPodSpecEfficiency(kind, namespace, name string, spec corev1.PodSpec, lrs []*corev1.LimitRange) []Finding {
 	var findings []Finding
 	f := func(checkID, severity, msg string) {
 		findings = append(findings, Finding{
@@ -383,18 +467,22 @@ func checkPodSpecEfficiency(kind, namespace, name string, spec corev1.PodSpec) [
 		})
 	}
 
+	// LimitRange defaults in the namespace are applied by admission — skip
+	// flagging missing values that would be filled in automatically.
+	defaults := containerDefaultsFromLimitRanges(lrs)
+
 	for _, c := range spec.Containers {
 		res := c.Resources
-		if res.Requests.Cpu() == nil || res.Requests.Cpu().IsZero() {
+		if (res.Requests.Cpu() == nil || res.Requests.Cpu().IsZero()) && !defaults.cpuRequest {
 			f("cpuRequestMissing", SeverityWarning, fmt.Sprintf("Container %q has no CPU request", c.Name))
 		}
-		if res.Requests.Memory() == nil || res.Requests.Memory().IsZero() {
+		if (res.Requests.Memory() == nil || res.Requests.Memory().IsZero()) && !defaults.memoryRequest {
 			f("memoryRequestMissing", SeverityWarning, fmt.Sprintf("Container %q has no memory request", c.Name))
 		}
-		if res.Limits.Cpu() == nil || res.Limits.Cpu().IsZero() {
+		if (res.Limits.Cpu() == nil || res.Limits.Cpu().IsZero()) && !defaults.cpuLimit {
 			f("cpuLimitMissing", SeverityWarning, fmt.Sprintf("Container %q has no CPU limit", c.Name))
 		}
-		if res.Limits.Memory() == nil || res.Limits.Memory().IsZero() {
+		if (res.Limits.Memory() == nil || res.Limits.Memory().IsZero()) && !defaults.memoryLimit {
 			f("memoryLimitMissing", SeverityWarning, fmt.Sprintf("Container %q has no memory limit", c.Name))
 		}
 	}

--- a/pkg/audit/checks.go
+++ b/pkg/audit/checks.go
@@ -127,21 +127,52 @@ func checkPodSpecSecurity(kind, namespace, name string, spec corev1.PodSpec) []F
 	}
 
 	// Container-level checks (iterate init and regular separately to avoid
-	// mutating the InitContainers backing array via append)
+	// mutating the InitContainers backing array via append).
+	// Pod-level SecurityContext is passed so container checks can honor
+	// fields like runAsNonRoot/runAsUser that inherit from the pod.
 	for i := range spec.InitContainers {
-		checkContainerSecurity(f, &spec.InitContainers[i])
+		checkContainerSecurity(f, &spec.InitContainers[i], spec.SecurityContext)
 	}
 	for i := range spec.Containers {
-		checkContainerSecurity(f, &spec.Containers[i])
+		checkContainerSecurity(f, &spec.Containers[i], spec.SecurityContext)
 	}
 
 	return findings
 }
 
-func checkContainerSecurity(f func(string, string, string), c *corev1.Container) {
+// effectivelyNonRoot reports whether a container is guaranteed not to run as
+// root, merging the pod-level PodSecurityContext with the container-level
+// override. A container is non-root if runAsNonRoot is true OR runAsUser is
+// set to a non-zero UID, at either scope. Container-level settings override
+// pod-level for each field independently.
+func effectivelyNonRoot(sc *corev1.SecurityContext, podSC *corev1.PodSecurityContext) bool {
+	var runAsNonRoot *bool
+	var runAsUser *int64
+	if podSC != nil {
+		runAsNonRoot = podSC.RunAsNonRoot
+		runAsUser = podSC.RunAsUser
+	}
+	if sc != nil {
+		if sc.RunAsNonRoot != nil {
+			runAsNonRoot = sc.RunAsNonRoot
+		}
+		if sc.RunAsUser != nil {
+			runAsUser = sc.RunAsUser
+		}
+	}
+	if runAsNonRoot != nil && *runAsNonRoot {
+		return true
+	}
+	if runAsUser != nil && *runAsUser != 0 {
+		return true
+	}
+	return false
+}
+
+func checkContainerSecurity(f func(string, string, string), c *corev1.Container, podSC *corev1.PodSecurityContext) {
 	sc := c.SecurityContext
 
-	if sc == nil || sc.RunAsNonRoot == nil || !*sc.RunAsNonRoot {
+	if !effectivelyNonRoot(sc, podSC) {
 		f("runAsRoot", SeverityWarning, fmt.Sprintf("Container %q may run as root (runAsNonRoot not set)", c.Name))
 	}
 

--- a/pkg/audit/checks_test.go
+++ b/pkg/audit/checks_test.go
@@ -133,6 +133,100 @@ func TestSecurityChecks_Secure(t *testing.T) {
 	}
 }
 
+func TestSecurityChecks_RunAsNonRootInheritedFromPod(t *testing.T) {
+	// Pod-level PodSecurityContext.RunAsNonRoot=true should satisfy the
+	// runAsRoot check for containers that don't set it themselves.
+	// Regression for https://github.com/skyhook-io/radar/issues/484
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-nonroot", Namespace: "default"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(2)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: ptr(true)},
+						Containers: []corev1.Container{{
+							Name: "app", Image: "nginx:1.25",
+							SecurityContext: &corev1.SecurityContext{
+								ReadOnlyRootFilesystem:   ptr(true),
+								AllowPrivilegeEscalation: ptr(false),
+							},
+						}},
+					},
+				},
+			},
+		}},
+	}
+	for _, f := range RunChecks(input).Findings {
+		if f.CheckID == "runAsRoot" {
+			t.Errorf("runAsRoot flagged despite pod-level RunAsNonRoot=true: %s", f.Message)
+		}
+	}
+}
+
+func TestSecurityChecks_RunAsUserNonZeroSatisfiesNonRoot(t *testing.T) {
+	// A non-zero runAsUser at the pod level also means the container
+	// doesn't run as root, even without RunAsNonRoot being set.
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-uid", Namespace: "default"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(2)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{RunAsUser: ptr(int64(1000))},
+						Containers: []corev1.Container{{
+							Name: "app", Image: "nginx:1.25",
+							SecurityContext: &corev1.SecurityContext{
+								ReadOnlyRootFilesystem:   ptr(true),
+								AllowPrivilegeEscalation: ptr(false),
+							},
+						}},
+					},
+				},
+			},
+		}},
+	}
+	for _, f := range RunChecks(input).Findings {
+		if f.CheckID == "runAsRoot" {
+			t.Errorf("runAsRoot flagged despite pod-level RunAsUser=1000: %s", f.Message)
+		}
+	}
+}
+
+func TestSecurityChecks_ContainerOverridesPod(t *testing.T) {
+	// Container-level RunAsNonRoot=false must override pod-level true.
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "override", Namespace: "default"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(2)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: ptr(true)},
+						Containers: []corev1.Container{{
+							Name: "app", Image: "nginx:1.25",
+							SecurityContext: &corev1.SecurityContext{RunAsNonRoot: ptr(false)},
+						}},
+					},
+				},
+			},
+		}},
+	}
+	found := false
+	for _, f := range RunChecks(input).Findings {
+		if f.CheckID == "runAsRoot" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected runAsRoot finding when container overrides pod with RunAsNonRoot=false")
+	}
+}
+
 func TestReliabilityChecks(t *testing.T) {
 	input := &CheckInput{
 		Deployments: []*appsv1.Deployment{{

--- a/pkg/audit/checks_test.go
+++ b/pkg/audit/checks_test.go
@@ -227,6 +227,124 @@ func TestSecurityChecks_ContainerOverridesPod(t *testing.T) {
 	}
 }
 
+func TestSecurityChecks_AutomountFromServiceAccount(t *testing.T) {
+	// Pod doesn't set AutomountServiceAccountToken; its ServiceAccount sets
+	// it to false. No finding should be emitted.
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "sa-noauto", Namespace: "team"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(2)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						ServiceAccountName: "restricted",
+						SecurityContext:    &corev1.PodSecurityContext{RunAsNonRoot: ptr(true)},
+						Containers: []corev1.Container{{
+							Name: "app", Image: "nginx:1.25",
+							SecurityContext: &corev1.SecurityContext{
+								ReadOnlyRootFilesystem:   ptr(true),
+								AllowPrivilegeEscalation: ptr(false),
+							},
+						}},
+					},
+				},
+			},
+		}},
+		ServiceAccounts: []*corev1.ServiceAccount{{
+			ObjectMeta:                   metav1.ObjectMeta{Name: "restricted", Namespace: "team"},
+			AutomountServiceAccountToken: ptr(false),
+		}},
+	}
+	for _, f := range RunChecks(input).Findings {
+		if f.CheckID == "automountServiceAccountToken" {
+			t.Errorf("automount flagged despite SA setting false: %s", f.Message)
+		}
+	}
+}
+
+func TestSecurityChecks_PodOverridesServiceAccountAutomount(t *testing.T) {
+	// SA says false, pod explicitly says true — pod wins, finding emitted.
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "override-auto", Namespace: "team"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(2)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						ServiceAccountName:           "restricted",
+						AutomountServiceAccountToken: ptr(true),
+						SecurityContext:              &corev1.PodSecurityContext{RunAsNonRoot: ptr(true)},
+						Containers: []corev1.Container{{
+							Name: "app", Image: "nginx:1.25",
+							SecurityContext: &corev1.SecurityContext{
+								ReadOnlyRootFilesystem:   ptr(true),
+								AllowPrivilegeEscalation: ptr(false),
+							},
+						}},
+					},
+				},
+			},
+		}},
+		ServiceAccounts: []*corev1.ServiceAccount{{
+			ObjectMeta:                   metav1.ObjectMeta{Name: "restricted", Namespace: "team"},
+			AutomountServiceAccountToken: ptr(false),
+		}},
+	}
+	found := false
+	for _, f := range RunChecks(input).Findings {
+		if f.CheckID == "automountServiceAccountToken" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected automount finding when pod explicitly sets it to true")
+	}
+}
+
+func TestEfficiencyChecks_LimitRangeDefaults(t *testing.T) {
+	// Namespace has a LimitRange with container defaults — the containers
+	// below don't set requests/limits, but admission would fill them in, so
+	// no efficiency findings should be emitted.
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "no-explicit", Namespace: "team"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(2)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "app", Image: "nginx:1.25"}},
+					},
+				},
+			},
+		}},
+		LimitRanges: []*corev1.LimitRange{{
+			ObjectMeta: metav1.ObjectMeta{Name: "defaults", Namespace: "team"},
+			Spec: corev1.LimitRangeSpec{
+				Limits: []corev1.LimitRangeItem{{
+					Type: corev1.LimitTypeContainer,
+					Default: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
+					},
+					DefaultRequest: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+					},
+				}},
+			},
+		}},
+	}
+	for _, f := range RunChecks(input).Findings {
+		switch f.CheckID {
+		case "cpuRequestMissing", "memoryRequestMissing", "cpuLimitMissing", "memoryLimitMissing":
+			t.Errorf("efficiency check flagged despite LimitRange defaults: %s", f.Message)
+		}
+	}
+}
+
 func TestReliabilityChecks(t *testing.T) {
 	input := &CheckInput{
 		Deployments: []*appsv1.Deployment{{

--- a/pkg/audit/checks_test.go
+++ b/pkg/audit/checks_test.go
@@ -345,6 +345,160 @@ func TestEfficiencyChecks_LimitRangeDefaults(t *testing.T) {
 	}
 }
 
+func TestEfficiencyChecks_LimitRangePodTypeDoesNotSuppress(t *testing.T) {
+	// LimitRanges with Type=Pod apply to aggregate pod limits, not to
+	// container defaults — container-level findings must still fire.
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-limits", Namespace: "team"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(2)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "app", Image: "nginx:1.25"}},
+					},
+				},
+			},
+		}},
+		LimitRanges: []*corev1.LimitRange{{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-scope", Namespace: "team"},
+			Spec: corev1.LimitRangeSpec{
+				Limits: []corev1.LimitRangeItem{{
+					Type: corev1.LimitTypePod,
+					Default: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				}},
+			},
+		}},
+	}
+	need := map[string]bool{"cpuRequestMissing": true, "memoryRequestMissing": true, "cpuLimitMissing": true, "memoryLimitMissing": true}
+	for _, f := range RunChecks(input).Findings {
+		delete(need, f.CheckID)
+	}
+	if len(need) > 0 {
+		t.Errorf("LimitType=Pod should not suppress container findings; missing: %v", need)
+	}
+}
+
+func TestEfficiencyChecks_LimitRangeMaxDoesNotSuppress(t *testing.T) {
+	// LimitRange items with Max/Min but no Default/DefaultRequest enforce
+	// constraints — they do not inject values, so missing-request/limit
+	// findings must still fire.
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "max-only", Namespace: "team"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(2)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "app", Image: "nginx:1.25"}},
+					},
+				},
+			},
+		}},
+		LimitRanges: []*corev1.LimitRange{{
+			ObjectMeta: metav1.ObjectMeta{Name: "max-only", Namespace: "team"},
+			Spec: corev1.LimitRangeSpec{
+				Limits: []corev1.LimitRangeItem{{
+					Type: corev1.LimitTypeContainer,
+					Max: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				}},
+			},
+		}},
+	}
+	need := map[string]bool{"cpuRequestMissing": true, "memoryRequestMissing": true, "cpuLimitMissing": true, "memoryLimitMissing": true}
+	for _, f := range RunChecks(input).Findings {
+		delete(need, f.CheckID)
+	}
+	if len(need) > 0 {
+		t.Errorf("LimitRange.Max-only should not suppress missing-resource findings; missing: %v", need)
+	}
+}
+
+func TestEfficiencyChecks_LimitRangePartialDefaults(t *testing.T) {
+	// LimitRange sets only DefaultRequest.cpu — only cpuRequestMissing should
+	// be suppressed; the other three findings must still fire.
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "partial", Namespace: "team"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(2)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "app", Image: "nginx:1.25"}},
+					},
+				},
+			},
+		}},
+		LimitRanges: []*corev1.LimitRange{{
+			ObjectMeta: metav1.ObjectMeta{Name: "cpu-req-only", Namespace: "team"},
+			Spec: corev1.LimitRangeSpec{
+				Limits: []corev1.LimitRangeItem{{
+					Type: corev1.LimitTypeContainer,
+					DefaultRequest: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("100m"),
+					},
+				}},
+			},
+		}},
+	}
+	flagged := map[string]bool{}
+	for _, f := range RunChecks(input).Findings {
+		flagged[f.CheckID] = true
+	}
+	if flagged["cpuRequestMissing"] {
+		t.Error("cpuRequestMissing should be suppressed by LimitRange DefaultRequest.cpu")
+	}
+	for _, id := range []string{"memoryRequestMissing", "cpuLimitMissing", "memoryLimitMissing"} {
+		if !flagged[id] {
+			t.Errorf("%s should still fire — LimitRange covered only cpu request", id)
+		}
+	}
+}
+
+func TestSecurityChecks_AutomountDefaultServiceAccount(t *testing.T) {
+	// Pod doesn't set ServiceAccountName — implicit "default" SA applies.
+	// If the default SA has automount=false, no finding should fire.
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{Name: "implicit-default", Namespace: "team"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr(int32(2)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: ptr(true)},
+						Containers: []corev1.Container{{
+							Name: "app", Image: "nginx:1.25",
+							SecurityContext: &corev1.SecurityContext{
+								ReadOnlyRootFilesystem:   ptr(true),
+								AllowPrivilegeEscalation: ptr(false),
+							},
+						}},
+					},
+				},
+			},
+		}},
+		ServiceAccounts: []*corev1.ServiceAccount{{
+			ObjectMeta:                   metav1.ObjectMeta{Name: "default", Namespace: "team"},
+			AutomountServiceAccountToken: ptr(false),
+		}},
+	}
+	for _, f := range RunChecks(input).Findings {
+		if f.CheckID == "automountServiceAccountToken" {
+			t.Errorf("automount flagged despite implicit default SA with automount=false: %s", f.Message)
+		}
+	}
+}
+
 func TestReliabilityChecks(t *testing.T) {
 	input := &CheckInput{
 		Deployments: []*appsv1.Deployment{{

--- a/pkg/audit/types.go
+++ b/pkg/audit/types.go
@@ -22,6 +22,8 @@ type CheckInput struct {
 	PodDisruptionBudgets     []*policyv1.PodDisruptionBudget
 	ConfigMaps               []*corev1.ConfigMap
 	Secrets                  []*corev1.Secret
+	ServiceAccounts          []*corev1.ServiceAccount
+	LimitRanges              []*corev1.LimitRange
 	// ClusterVersion is the K8s server version (e.g. "1.30"). Used for deprecated API checks.
 	ClusterVersion string
 	// ServedAPIs lists API group/versions the cluster still serves (e.g. ["apps/v1", "batch/v1beta1"]).

--- a/pkg/k8score/cache.go
+++ b/pkg/k8score/cache.go
@@ -549,6 +549,7 @@ func buildInformerSetups(factory informers.SharedInformerFactory) []informerSetu
 		{PodDisruptionBudgets, "PodDisruptionBudget", func() cache.SharedIndexInformer { return factory.Policy().V1().PodDisruptionBudgets().Informer() }, false},
 		{NetworkPolicies, "NetworkPolicy", func() cache.SharedIndexInformer { return factory.Networking().V1().NetworkPolicies().Informer() }, false},
 		{ServiceAccounts, "ServiceAccount", func() cache.SharedIndexInformer { return factory.Core().V1().ServiceAccounts().Informer() }, false},
+		{LimitRanges, "LimitRange", func() cache.SharedIndexInformer { return factory.Core().V1().LimitRanges().Informer() }, false},
 	}
 }
 
@@ -927,6 +928,7 @@ var allKindListers = []kindLister{
 	{"PodDisruptionBudget", "policy", func(rc *ResourceCache) any { return rc.PodDisruptionBudgets() }},
 	{"NetworkPolicy", "networking.k8s.io", func(rc *ResourceCache) any { return rc.NetworkPolicies() }},
 	{"ServiceAccount", "", func(rc *ResourceCache) any { return rc.ServiceAccounts() }},
+	{"LimitRange", "", func(rc *ResourceCache) any { return rc.LimitRanges() }},
 }
 
 // AllKindListers returns the table of all resource kinds with their group and lister.

--- a/pkg/k8score/listers.go
+++ b/pkg/k8score/listers.go
@@ -165,6 +165,13 @@ func (rc *ResourceCache) ServiceAccounts() listerscorev1.ServiceAccountLister {
 	return rc.factory.Core().V1().ServiceAccounts().Lister()
 }
 
+func (rc *ResourceCache) LimitRanges() listerscorev1.LimitRangeLister {
+	if rc == nil || !rc.isEnabled(LimitRanges) {
+		return nil
+	}
+	return rc.factory.Core().V1().LimitRanges().Lister()
+}
+
 // listCountNamespaced counts items from a lister filtered to specific namespaces.
 // If namespaces is empty, it returns the total count (same as listCount).
 func listCountNamespaced(lister any, namespaces []string) int {
@@ -217,6 +224,9 @@ func listCountInNamespace(lister any, ns string) int {
 		return len(items)
 	case listerscorev1.ServiceAccountLister:
 		items, _ := l.ServiceAccounts(ns).List(labels.Everything())
+		return len(items)
+	case listerscorev1.LimitRangeLister:
+		items, _ := l.LimitRanges(ns).List(labels.Everything())
 		return len(items)
 	case listersappsv1.DeploymentLister:
 		items, _ := l.Deployments(ns).List(labels.Everything())
@@ -291,6 +301,9 @@ func listCount(lister any) int {
 		items, _ := l.List(labels.Everything())
 		return len(items)
 	case listerscorev1.ServiceAccountLister:
+		items, _ := l.List(labels.Everything())
+		return len(items)
+	case listerscorev1.LimitRangeLister:
 		items, _ := l.List(labels.Everything())
 		return len(items)
 	case listersappsv1.DeploymentLister:

--- a/pkg/k8score/types.go
+++ b/pkg/k8score/types.go
@@ -42,6 +42,7 @@ const (
 	PodDisruptionBudgets     ResourceType = "poddisruptionbudgets"
 	NetworkPolicies          ResourceType = "networkpolicies"
 	ServiceAccounts          ResourceType = "serviceaccounts"
+	LimitRanges              ResourceType = "limitranges"
 )
 
 // Operation constants for resource change events.


### PR DESCRIPTION
## Summary

Fixes three K8s inheritance blind spots in the audit runner that produced false-positive findings. Closes #484.

### Bug 1: runAsRoot ignored pod-level SecurityContext
The `runAsRoot` check only inspected container-level `SecurityContext`, missing pods that set `runAsNonRoot` or `runAsUser` at the pod scope via `PodSecurityContext`.

### Bug 2: automountServiceAccountToken ignored ServiceAccount-level setting
The check only looked at the pod spec. If the pod's ServiceAccount has `automountServiceAccountToken=false`, no token mounts at all — the pod shouldn't be flagged. Now honors SA-level with pod override.

### Bug 3: Resource requests/limits ignored namespace LimitRange defaults
A `LimitRange` with `Default`/`DefaultRequest` on container items causes admission to inject the values — containers without explicit requests/limits still end up with them. We were flagging them anyway.

## Wiring changes

Adding SA + LimitRange data to the audit required:

- `pkg/audit/types.go` — new `ServiceAccounts`, `LimitRanges` fields on `CheckInput`
- `pkg/audit/checks.go` — new `tokenAutoMounted()`, `effectivelyNonRoot()`, `containerDefaultsFromLimitRanges()` helpers; updated security + efficiency checks to use them
- `pkg/k8score/` — adds `LimitRanges` as a new cached resource type (ServiceAccounts was already wired)
- `internal/k8s/capabilities.go` — adds RBAC checks for `serviceaccounts` and `limitranges`
- `internal/k8s/cache.go` — enables both informers (marked as deferred — not first-render critical)
- `internal/audit/runner.go` — populates both from cache
- `deploy/helm/radar/templates/clusterrole.yaml` — adds `limitranges` read permission

## Test plan

- [x] `go test ./pkg/audit/...` — passes including 6 new regression tests
- [x] `go test ./...` across both modules — passes
- [x] `go build ./...` — clean
- [ ] Reviewer to eyeball the merge-precedence logic for each field
- [ ] Sanity check on live cluster after merge that audit findings don't regress