### PR TITLE
fix(ui): restore HealthRing center-label color in dark mode

### DIFF
--- a/packages/k8s-ui/src/components/ui/HealthRing.tsx
+++ b/packages/k8s-ui/src/components/ui/HealthRing.tsx
@@ -35,7 +35,7 @@ export function HealthRing({ segments, size = 48, strokeWidth = 5, label }: Heal
           className="text-theme-border"
         />
         {label && (
-          <text x="50" y="48" textAnchor="middle" dominantBaseline="central" className="fill-theme-text-tertiary text-[22px] font-semibold font-mono">
+          <text x="50" y="48" textAnchor="middle" dominantBaseline="central" fill="currentColor" className="text-theme-text-tertiary text-[22px] font-semibold font-mono">
             0
           </text>
         )}
@@ -98,7 +98,7 @@ export function HealthRing({ segments, size = 48, strokeWidth = 5, label }: Heal
       </g>
       {/* Center label — nudged up slightly for visual centering in 270° arc */}
       {label && (
-        <text x="50" y="48" textAnchor="middle" dominantBaseline="central" className="fill-theme-text-primary text-[22px] font-semibold font-mono">
+        <text x="50" y="48" textAnchor="middle" dominantBaseline="central" fill="currentColor" className="text-theme-text-primary text-[22px] font-semibold font-mono">
           {label}
         </text>
       )}


### PR DESCRIPTION
## Summary

The dashboard ring numbers (pods / deployments / nodes) went unreadable in dark mode after #376 — showing as near-black text on the dark surface.

**Root cause:** the ring's center `<text>` used `fill-theme-text-primary` / `fill-theme-text-tertiary`, but those classes are only referenced inside `packages/k8s-ui/src/`. Radar's Tailwind v4 setup only scans `web/src/`, so the `fill-*` utilities were never emitted to CSS and the SVG text fell back to the browser's default black fill.

**Fix:** switch to `fill="currentColor"` + `text-theme-text-{primary,tertiary}`. The `text-*` utilities *are* generated (they're used extensively in `web/src/`), and SVG `fill=currentColor` resolves through the CSS `color` property, so the label now picks up the correct light/dark token.

Verified: rebuilt CSS now contains `.text-theme-text-primary` / `.text-theme-text-tertiary`; `tsc` clean; no source-scanning config changes required.