### PR TITLE
radar-app: export ShortcutHelpOverlay for library consumers

### DIFF
--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -15,3 +15,4 @@ export {
   getCredentialsMode,
 } from './api/config';
 export type { NavCustomization } from './context/NavCustomization';
+export { ShortcutHelpOverlay } from './components/ui/ShortcutHelpOverlay';


### PR DESCRIPTION
## Summary
- One-line addition to `web/src/index.ts` exposing `ShortcutHelpOverlay` through radar-app's public surface.
- Radar Hub (skyhook-dev/radar-hub-web) wants the same keyboard-shortcut modal Radar already renders on `?` — instead of copying the component or re-rolling the chrome, it can now import it directly.
- No behavior change for Radar's own binary or web app — pure re-export of an existing internal component.

## Context
- The overlay has no Radar-specific deps (it reads from `@skyhook-io/k8s-ui`'s `useActiveShortcuts`), so no follow-on exports are needed.
- Once this merges, tag `radar-app-v0.1.3` to publish — the existing `publish-radar-app.yml` workflow picks it up on tag push.

## Test plan
- [x] `npm run tsc` passes in `web/`
- [ ] After publish, `@skyhook-io/radar-app` installs and hub-web builds against the new version