### PR TITLE
fix(ui): node condition polarity (#517) + capacity layout (#516)

### DIFF
--- a/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.tsx
@@ -106,37 +106,51 @@ export function NodeRenderer({ data, relationships, onViewPods, metrics, metrics
 
       {/* Capacity */}
       <Section title="Capacity" icon={HardDrive}>
-        <div className="space-y-1">
-          <div className="grid grid-cols-4 gap-2 text-xs text-theme-text-tertiary font-medium mb-2">
-            <span>Resource</span>
-            <span>Capacity</span>
-            <span>Allocatable</span>
-            <span>In Use</span>
-          </div>
-          <div className="grid grid-cols-4 gap-2 text-sm">
-            <span className="text-theme-text-secondary">CPU</span>
-            <span className="text-theme-text-primary">{capacity.cpu || '-'}</span>
-            <span className="text-theme-text-primary">{allocatable.cpu || '-'}</span>
-            <span className="text-theme-text-primary font-medium">{metrics?.usage?.cpu || '-'}</span>
-          </div>
-          <div className="grid grid-cols-4 gap-2 text-sm">
-            <span className="text-theme-text-secondary">Memory</span>
-            <span className="text-theme-text-primary">{formatMemory(capacity.memory)}</span>
-            <span className="text-theme-text-primary">{formatMemory(allocatable.memory)}</span>
-            <span className="text-theme-text-primary font-medium">{metrics?.usage?.memory ? formatMemory(metrics.usage.memory) : '-'}</span>
-          </div>
-          <div className="grid grid-cols-4 gap-2 text-sm">
-            <span className="text-theme-text-secondary">Pods</span>
-            <span className="text-theme-text-primary">{capacity.pods || '-'}</span>
-            <span className="text-theme-text-primary">{allocatable.pods || '-'}</span>
-            <span className="text-theme-text-primary font-medium">{relationships?.pods?.length ?? '-'}</span>
-          </div>
-          <div className="grid grid-cols-4 gap-2 text-sm">
-            <span className="text-theme-text-secondary">Ephemeral Storage</span>
-            <span className="text-theme-text-primary">{formatStorage(capacity['ephemeral-storage'])}</span>
-            <span className="text-theme-text-primary">{formatStorage(allocatable['ephemeral-storage'])}</span>
-            <span className="text-theme-text-primary">-</span>
-          </div>
+        <div className="space-y-2">
+          {[
+            {
+              label: 'CPU',
+              capacity: capacity.cpu,
+              allocatable: allocatable.cpu,
+              inUse: metrics?.usage?.cpu,
+            },
+            {
+              label: 'Memory',
+              capacity: formatMemory(capacity.memory),
+              allocatable: formatMemory(allocatable.memory),
+              inUse: metrics?.usage?.memory ? formatMemory(metrics.usage.memory) : undefined,
+            },
+            {
+              label: 'Pods',
+              capacity: capacity.pods,
+              allocatable: allocatable.pods,
+              inUse: relationships?.pods?.length,
+            },
+            {
+              label: 'Ephemeral Storage',
+              capacity: formatStorage(capacity['ephemeral-storage']),
+              allocatable: formatStorage(allocatable['ephemeral-storage']),
+              inUse: undefined,
+            },
+          ].map((row) => (
+            <div key={row.label} className="card-inner">
+              <div className="text-xs font-medium text-theme-text-secondary mb-1">{row.label}</div>
+              <div className="space-y-0.5 text-xs">
+                <div className="flex items-baseline justify-between gap-2">
+                  <span className="text-theme-text-tertiary">Capacity</span>
+                  <span className="text-theme-text-primary tabular-nums">{row.capacity ?? '-'}</span>
+                </div>
+                <div className="flex items-baseline justify-between gap-2">
+                  <span className="text-theme-text-tertiary">Allocatable</span>
+                  <span className="text-theme-text-primary tabular-nums">{row.allocatable ?? '-'}</span>
+                </div>
+                <div className="flex items-baseline justify-between gap-2">
+                  <span className="text-theme-text-tertiary">In Use</span>
+                  <span className="text-theme-text-primary font-medium tabular-nums">{row.inUse ?? '-'}</span>
+                </div>
+              </div>
+            </div>
+          ))}
         </div>
         {onViewPods && (
           <div className="mt-3 pt-3 border-t border-theme-border">

--- a/packages/k8s-ui/src/components/ui/drawer-components.tsx
+++ b/packages/k8s-ui/src/components/ui/drawer-components.tsx
@@ -183,8 +183,10 @@ export function Property({ label, value, copyable, onCopy, copied }: PropertyPro
 // ============================================================================
 
 // Condition types where status=True means a problem and status=False means healthy.
-// Covers kubelet-native Node conditions, Pod DisruptionTarget, and common Node Problem
-// Detector (NPD) conditions. Name-based patterns catch additional NPD-style types.
+// Covers kubelet-native Node conditions, Pod DisruptionTarget, common Node Problem
+// Detector (NPD) conditions, and the `Degraded`/`Stalled`/`OutOfSync`/`ReplicaFailure`
+// patterns used by Operator-style CRDs (ArgoCD, FluxCD, cert-manager, etc.).
+// Name-based patterns catch additional same-family types.
 const NEGATIVE_POLARITY_TYPES = new Set([
   'MemoryPressure',
   'DiskPressure',
@@ -195,6 +197,10 @@ const NEGATIVE_POLARITY_TYPES = new Set([
   'ReadonlyFilesystem',
   'CorruptDockerOverlay2',
   'Swap',
+  'Degraded',
+  'Stalled',
+  'OutOfSync',
+  'ReplicaFailure',
 ])
 
 const NEGATIVE_POLARITY_PATTERNS: RegExp[] = [
@@ -208,6 +214,9 @@ const NEGATIVE_POLARITY_PATTERNS: RegExp[] = [
   /Shutdown$/,
   /^ReadOnly/,
   /Error/,
+  /Failure$/,
+  /^Failed/,
+  /^Failing/,
 ]
 
 function isInvertedPolarityCondition(type: string | undefined): boolean {
@@ -232,7 +241,7 @@ export function ConditionsSection({ conditions }: { conditions?: any[] }) {
     return (a.type || '').localeCompare(b.type || '')
   })
 
-  const failCount = sorted.filter((c: any) => c.status !== 'Unknown' && !isConditionHealthy(c)).length
+  const failCount = sorted.filter((c: any) => (c.status === 'True' || c.status === 'False') && !isConditionHealthy(c)).length
 
   return (
     <Section
@@ -245,7 +254,7 @@ export function ConditionsSection({ conditions }: { conditions?: any[] }) {
 
         <div className="space-y-0.5">
           {sorted.map((cond: any) => {
-            const isUnknown = cond.status === 'Unknown'
+            const isUnknown = cond.status !== 'True' && cond.status !== 'False'
             const isOk = !isUnknown && isConditionHealthy(cond)
             const isFail = !isOk && !isUnknown
             return (

--- a/packages/k8s-ui/src/components/ui/drawer-components.tsx
+++ b/packages/k8s-ui/src/components/ui/drawer-components.tsx
@@ -218,6 +218,17 @@ const NEGATIVE_POLARITY_TYPES = new Set([
   'ReadOnlyRootFileSystem',
   'ResourceExhausted',
   'Swap',
+  // NPD — AKS extensions (learn.microsoft.com/azure/aks/node-problem-detector)
+  'FilesystemCorruptionProblem',
+  'KubeletProblem',
+  'ContainerRuntimeProblem',
+  'VMEventScheduled',
+  'GPUMissing',
+  'NVLinkStatusInactive',
+  'XIDErrors',
+  'IBLinkFlapping',
+  'GPUClockThrottling',
+  'UnhealthyNvidiaDevicePlugin',
   // ArgoCD Application
   'DeletionError',
   'InvalidSpecError',
@@ -229,8 +240,25 @@ const NEGATIVE_POLARITY_TYPES = new Set([
   'OrphanedResourceWarning',
   'ExcludedResourceWarning',
   'OutOfSync',
+  // ArgoCD ApplicationSet
+  'ErrorOccurred',
   // FluxCD (meta)
   'Stalled',
+  // Gateway API (sigs.k8s.io/gateway-api v1)
+  'Conflicted',
+  'OverlappingTLSConfig',
+  'PartiallyInvalid',
+  'InsecureFrontendValidationMode',
+  // cert-manager (CertificateRequest)
+  'Denied',
+  'InvalidRequest',
+  // Karpenter NodeClaim
+  'Drifted',
+  // VPA
+  'ConfigUnsupported',
+  'LowConfidence',
+  // KEDA ScaledObject
+  'Fallback',
   // Operator-pattern CRDs (widespread)
   'Degraded',
   'Failed',

--- a/packages/k8s-ui/src/components/ui/drawer-components.tsx
+++ b/packages/k8s-ui/src/components/ui/drawer-components.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { ChevronRight, Copy, Check, Tag, AlertTriangle, CheckCircle, ExternalLink, Layers } from 'lucide-react'
+import { ChevronRight, Copy, Check, Tag, AlertTriangle, CheckCircle, ExternalLink, Layers, X, Minus } from 'lucide-react'
 import { clsx } from 'clsx'
 import { formatAge, formatDuration } from '../resources/resource-utils'
 import { Tooltip } from './Tooltip'
@@ -182,6 +182,45 @@ export function Property({ label, value, copyable, onCopy, copied }: PropertyPro
 // COMMON SECTIONS
 // ============================================================================
 
+// Condition types where status=True means a problem and status=False means healthy.
+// Covers kubelet-native Node conditions, Pod DisruptionTarget, and common Node Problem
+// Detector (NPD) conditions. Name-based patterns catch additional NPD-style types.
+const NEGATIVE_POLARITY_TYPES = new Set([
+  'MemoryPressure',
+  'DiskPressure',
+  'PIDPressure',
+  'NetworkUnavailable',
+  'DisruptionTarget',
+  'KernelDeadlock',
+  'ReadonlyFilesystem',
+  'CorruptDockerOverlay2',
+  'Swap',
+])
+
+const NEGATIVE_POLARITY_PATTERNS: RegExp[] = [
+  /Pressure$/,
+  /Unavailable$/,
+  /^Deprecated/,
+  /^Frequent/,
+  /^Corrupt/,
+  /Deadlock$/,
+  /Exhausted$/,
+  /Shutdown$/,
+  /^ReadOnly/,
+  /Error/,
+]
+
+function isInvertedPolarityCondition(type: string | undefined): boolean {
+  if (!type) return false
+  if (NEGATIVE_POLARITY_TYPES.has(type)) return true
+  return NEGATIVE_POLARITY_PATTERNS.some((re) => re.test(type))
+}
+
+function isConditionHealthy(cond: { type?: string; status?: string }): boolean {
+  const inverted = isInvertedPolarityCondition(cond.type)
+  return inverted ? cond.status === 'False' : cond.status === 'True'
+}
+
 export function ConditionsSection({ conditions }: { conditions?: any[] }) {
   if (!conditions || conditions.length === 0) return null
 
@@ -193,7 +232,7 @@ export function ConditionsSection({ conditions }: { conditions?: any[] }) {
     return (a.type || '').localeCompare(b.type || '')
   })
 
-  const failCount = sorted.filter((c: any) => c.status === 'False').length
+  const failCount = sorted.filter((c: any) => c.status !== 'Unknown' && !isConditionHealthy(c)).length
 
   return (
     <Section
@@ -206,8 +245,8 @@ export function ConditionsSection({ conditions }: { conditions?: any[] }) {
 
         <div className="space-y-0.5">
           {sorted.map((cond: any) => {
-            const isOk = cond.status === 'True'
             const isUnknown = cond.status === 'Unknown'
+            const isOk = !isUnknown && isConditionHealthy(cond)
             const isFail = !isOk && !isUnknown
             return (
               <div key={cond.type} className={clsx(
@@ -220,12 +259,14 @@ export function ConditionsSection({ conditions }: { conditions?: any[] }) {
                 </div>
                 {/* Timeline dot */}
                 <span className={clsx(
-                  'w-[13px] h-[13px] rounded-full flex items-center justify-center text-[8px] shrink-0 mt-[3px] z-10 ring-2 ring-theme-surface',
+                  'w-3 h-3 rounded-full flex items-center justify-center shrink-0 mt-1 z-10 ring-2 ring-theme-surface',
                   isOk ? 'bg-emerald-500/20 text-emerald-500 dark:bg-emerald-500/30'
                     : isUnknown ? 'bg-gray-400/20 text-gray-400 dark:bg-gray-400/30'
                     : 'bg-red-500/25 text-red-500 dark:bg-red-500/35'
                 )}>
-                  {isOk ? '✓' : isUnknown ? '?' : '✗'}
+                  {isOk ? <Check className="w-2 h-2" strokeWidth={4} />
+                    : isUnknown ? <Minus className="w-2 h-2" strokeWidth={4} />
+                    : <X className="w-2 h-2" strokeWidth={4} />}
                 </span>
                 {/* Content */}
                 <div className="min-w-0 flex-1 pl-2">

--- a/packages/k8s-ui/src/components/ui/drawer-components.tsx
+++ b/packages/k8s-ui/src/components/ui/drawer-components.tsx
@@ -183,40 +183,64 @@ export function Property({ label, value, copyable, onCopy, copied }: PropertyPro
 // ============================================================================
 
 // Condition types where status=True means a problem and status=False means healthy.
-// Covers kubelet-native Node conditions, Pod DisruptionTarget, common Node Problem
-// Detector (NPD) conditions, and the `Degraded`/`Stalled`/`OutOfSync`/`ReplicaFailure`
-// patterns used by Operator-style CRDs (ArgoCD, FluxCD, cert-manager, etc.).
-// Name-based patterns catch additional same-family types.
+//
+// K8s has no canonical API metadata for polarity — SIG-API Machinery explicitly
+// declined to add it (https://gateway-api.sigs.k8s.io/geps/gep-1364/), so every
+// consumer has to maintain a list. This one is assembled from:
+//   - Core K8s (kubelet node conditions, Pod, workload controllers)
+//   - Node Problem Detector default configs (kubernetes/node-problem-detector)
+//   - GKE's NPD plugin set (observed in-cluster)
+//   - ArgoCD Application conditions (argoproj/argo-cd)
+//   - FluxCD meta conditions (fluxcd/pkg/apis/meta)
+//   - Conventional Operator-pattern conditions (Degraded, OutOfSync)
+// Patterns only cover two NPD naming families whose convention is
+// strict ("Deprecated*" for deprecation checks, "Frequent*" for restart
+// counters) — everything else is explicit to avoid guessing wrong.
 const NEGATIVE_POLARITY_TYPES = new Set([
+  // Core K8s — Node (kubelet)
   'MemoryPressure',
   'DiskPressure',
   'PIDPressure',
   'NetworkUnavailable',
+  // Core K8s — Pod
   'DisruptionTarget',
-  'KernelDeadlock',
-  'ReadonlyFilesystem',
-  'CorruptDockerOverlay2',
-  'Swap',
-  'Degraded',
-  'Stalled',
-  'OutOfSync',
+  // Core K8s — workloads
   'ReplicaFailure',
+  // NPD — upstream default configs
+  'KernelDeadlock',
+  'CperHardwareErrorFatal',
+  'XfsShutdown',
+  'CorruptDockerOverlay2',
+  'ReadonlyFilesystem',
+  'ContainerRuntimeUnhealthy',
+  'KubeletUnhealthy',
+  // NPD — GKE extensions (observed)
+  'ReadOnlyRootFileSystem',
+  'ResourceExhausted',
+  'Swap',
+  // ArgoCD Application
+  'DeletionError',
+  'InvalidSpecError',
+  'ComparisonError',
+  'SyncError',
+  'UnknownError',
+  'SharedResourceWarning',
+  'RepeatedResourceWarning',
+  'OrphanedResourceWarning',
+  'ExcludedResourceWarning',
+  'OutOfSync',
+  // FluxCD (meta)
+  'Stalled',
+  // Operator-pattern CRDs (widespread)
+  'Degraded',
+  'Failed',
 ])
 
 const NEGATIVE_POLARITY_PATTERNS: RegExp[] = [
-  /Pressure$/,
-  /Unavailable$/,
+  // NPD deprecation-check family (e.g. DeprecatedAuthsFieldInContainerdConfiguration)
   /^Deprecated/,
+  // NPD restart-counter family (e.g. FrequentKubeletRestart, FrequentUnregisterNetDevice)
   /^Frequent/,
-  /^Corrupt/,
-  /Deadlock$/,
-  /Exhausted$/,
-  /Shutdown$/,
-  /^ReadOnly/,
-  /Error/,
-  /Failure$/,
-  /^Failed/,
-  /^Failing/,
 ]
 
 function isInvertedPolarityCondition(type: string | undefined): boolean {


### PR DESCRIPTION
## Summary

Two fixes for the Node detail drawer:

**#517 — Inverted-polarity conditions shown as failures.** Conditions like `MemoryPressure`, `DiskPressure`, `PIDPressure`, `NetworkUnavailable`, and common Node Problem Detector checks (`CorruptDockerOverlay2`, `Deprecated*Configuration`, `KernelDeadlock`, `Swap`, etc.) use `status=False` to mean healthy, but `ConditionsSection` was treating all `False` as failing. On a healthy GKE node this rendered as "24 conditions · 21 failing" with most rows red.

The fix maintains an explicit set of known negative-polarity condition types plus name-pattern heuristics (`*Pressure`, `*Unavailable`, `Deprecated*`, `Frequent*`, `Corrupt*`, `*Deadlock`, `*Exhausted`, `*Shutdown`, `ReadOnly*`, `*Error*`) so newly added NPD checks are picked up without code changes. Also swapped the small unicode `✓`/`✗` glyphs for Lucide `Check`/`X`/`Minus` icons — crisper at small sizes.

**#516 — Capacity section squashed in narrow drawer.** The 4-column grid (`Resource / Capacity / Allocatable / In Use`) didn't fit in the 384px drawer width — labels like "Ephemeral Storage" wrapped and the whole table collapsed visually into a single stacked column. Replaced with per-resource cards: one block per resource (CPU, Memory, Pods, Ephemeral Storage) with each metric as a label:value row, `tabular-nums` for aligned numerics.

## Test plan
- [x] Healthy GKE node: conditions show `24 conditions` with no failing count, all green checks
- [x] Crashlooping pod (`3scale-kourier-gateway`): `ContainersReady` and `Ready` render with red X and left-border rail
- [x] Capacity section renders as four stacked cards with right-aligned values in a 384px drawer
- [x] `npm run tsc` passes