### PR TITLE
fix(kubeconfig): isolate each file to stop shared-name collisions

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -32,7 +32,18 @@ var (
 	kubeconfigPath     string
 	kubeconfigPaths    []string // Multiple kubeconfig paths when using --kubeconfig-dir or KUBECONFIG env
 	kubeconfigMode     string   // One of: "in-cluster", "single", "multi-env", "multi-dir"
-	mergedContextCount int      // Number of contexts exposed after client-go merged all kubeconfig files
+	mergedContextCount int      // Total number of contexts exposed across all kubeconfig files (pre-#519 this was the post-merge count; kept the variable name to avoid diff churn)
+	// contextRegistry maps each user-facing context name to its source file and
+	// the name it has inside that file. Populated when Radar loads more than one
+	// kubeconfig file (multi-dir, multi-env with >1 paths, or CAPI-added files).
+	// Each file is loaded in isolation via ExplicitPath rather than merged via
+	// Precedence — a shared user/cluster/context name across files no longer
+	// clobbers anything, which is the whole point of the registry. See issue
+	// #519 (and #411, #514) for the bug this replaces.
+	contextRegistry map[string]contextEntry
+	// perFileConfigs caches each file's parsed api.Config so GetAvailableContexts
+	// doesn't re-read N files on every call. Keyed by absolute file path.
+	perFileConfigs map[string]*clientcmdapi.Config
 	contextName        string
 	clusterName        string
 	contextNamespace   string // Default namespace from kubeconfig context
@@ -115,9 +126,11 @@ func doInit(opts InitOptions) error {
 	if config == nil {
 		// Use kubeconfig (for local development / CLI usage)
 		var loadingRules *clientcmd.ClientConfigLoadingRules
+		configOverrides := &clientcmd.ConfigOverrides{}
 
 		if len(opts.KubeconfigDirs) > 0 {
-			// Multi-kubeconfig mode: discover and merge configs from directories
+			// Multi-kubeconfig mode: discover files and, if more than one,
+			// load them in isolation via the context registry (see issue #519).
 			configs, err := discoverKubeconfigs(opts.KubeconfigDirs)
 			if err != nil {
 				return fmt.Errorf("failed to discover kubeconfigs: %w", err)
@@ -128,7 +141,15 @@ func doInit(opts InitOptions) error {
 			log.Printf("Discovered %d kubeconfig files from %d directories", len(configs), len(opts.KubeconfigDirs))
 			kubeconfigPaths = configs
 			kubeconfigMode = "multi-dir"
-			loadingRules = &clientcmd.ClientConfigLoadingRules{Precedence: configs}
+			if len(configs) == 1 {
+				loadingRules = &clientcmd.ClientConfigLoadingRules{ExplicitPath: configs[0]}
+			} else {
+				lr, ovr, err := setupIsolatedLoad(configs)
+				if err != nil {
+					return err
+				}
+				loadingRules, configOverrides = lr, ovr
+			}
 		} else {
 			// Single kubeconfig mode (existing behavior)
 			kubeconfig := opts.KubeconfigPath
@@ -142,13 +163,18 @@ func doInit(opts InitOptions) error {
 			}
 
 			// KUBECONFIG can contain multiple paths separated by the OS path
-			// list separator (colon on Unix, semicolon on Windows).
-			// Split and use Precedence when there are multiple entries.
+			// list separator (colon on Unix, semicolon on Windows). With more
+			// than one path we go through the isolated-load path rather than
+			// client-go's Precedence merge — same reason as multi-dir.
 			if paths := filepath.SplitList(kubeconfig); len(paths) > 1 {
 				kubeconfigPaths = paths
 				kubeconfigMode = "multi-env"
-				loadingRules = &clientcmd.ClientConfigLoadingRules{Precedence: paths}
-				log.Printf("KUBECONFIG contains %d paths, using merged mode", len(paths))
+				lr, ovr, err := setupIsolatedLoad(paths)
+				if err != nil {
+					return err
+				}
+				loadingRules, configOverrides = lr, ovr
+				log.Printf("KUBECONFIG contains %d paths, using isolated per-file loading", len(paths))
 			} else {
 				kubeconfigPath = kubeconfig
 				kubeconfigMode = "single"
@@ -156,7 +182,6 @@ func doInit(opts InitOptions) error {
 			}
 		}
 
-		configOverrides := &clientcmd.ConfigOverrides{}
 		kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 
 		// Get raw config to extract context/cluster names. If this fails
@@ -172,33 +197,61 @@ func doInit(opts InitOptions) error {
 			errorlog.Record("k8s-init", "error",
 				"RawConfig() failed; context metadata and diagnostic counts unavailable: %v", rawErr)
 		} else {
-			contextName = rawConfig.CurrentContext
-			mergedContextCount = len(rawConfig.Contexts)
-			cmds, emptyAIs := collectExecPluginCommands(&rawConfig)
-			execPluginCommands = cmds
-			if len(emptyAIs) > 0 {
-				// Aggregate into a single errorlog entry — a pathological
-				// kubeconfig with hundreds of broken AuthInfos would otherwise
-				// flood the 200-entry ring buffer and evict other diagnostics.
-				recordEmptyCommandWarning("k8s-init", emptyAIs)
+			// In isolated-load mode, rawConfig reflects the single chosen
+			// file — which is all the current context needs, but the
+			// "how many contexts can the user pick from?" number must come
+			// from the registry (sum across all files), and exec plugin
+			// discovery must cover every file.
+			if contextRegistry != nil {
+				// contextName was already set to the qualified name by
+				// setupIsolatedLoad; don't overwrite with the original name
+				// inside the single chosen file.
+				mergedContextCount = len(contextRegistry)
+				cmds, emptyAIs := aggregateExecPluginCommands(kubeconfigPaths, perFileConfigs)
+				execPluginCommands = cmds
+				if len(emptyAIs) > 0 {
+					recordEmptyCommandWarning("k8s-init", emptyAIs)
+				}
+				// Look up the current context's cluster/namespace/exec via
+				// the registry-resolved file. rawConfig.Contexts is keyed by
+				// the *original* name inside the chosen file.
+				if entry, ok := contextRegistry[contextName]; ok {
+					if ctx, ok := rawConfig.Contexts[entry.OriginalName]; ok {
+						clusterName = ctx.Cluster
+						contextNamespace = ctx.Namespace
+						if ai, ok := rawConfig.AuthInfos[ctx.AuthInfo]; ok && ai.Exec != nil {
+							contextUsesExec = true
+						}
+					}
+				}
+			} else {
+				contextName = rawConfig.CurrentContext
+				mergedContextCount = len(rawConfig.Contexts)
+				cmds, emptyAIs := collectExecPluginCommands(&rawConfig)
+				execPluginCommands = cmds
+				if len(emptyAIs) > 0 {
+					// Aggregate into a single errorlog entry — a pathological
+					// kubeconfig with hundreds of broken AuthInfos would otherwise
+					// flood the 200-entry ring buffer and evict other diagnostics.
+					recordEmptyCommandWarning("k8s-init", emptyAIs)
+				}
+				if ctx, ok := rawConfig.Contexts[contextName]; ok {
+					clusterName = ctx.Cluster
+					contextNamespace = ctx.Namespace
+					if ai, ok := rawConfig.AuthInfos[ctx.AuthInfo]; ok && ai.Exec != nil {
+						contextUsesExec = true
+					}
+				}
 			}
 			fileCount := len(kubeconfigPaths)
 			if fileCount == 0 && kubeconfigPath != "" {
 				fileCount = 1
 			}
-			// Log the merged context count so multi-file collisions are visible.
-			// client-go silently drops later duplicates when merging by name, so
-			// this count is the "ground truth" of what the user can actually pick
-			// from the dropdown — not the sum of per-file contexts.
+			// Total contexts across all files (pre-#519 this was the post-merge
+			// count, which silently hid colliding user/cluster definitions;
+			// now every file's contexts are individually reachable).
 			log.Printf("Kubeconfig loaded: mode=%s, files=%d, contexts=%d, exec-plugins=%d",
 				kubeconfigMode, fileCount, mergedContextCount, len(execPluginCommands))
-			if ctx, ok := rawConfig.Contexts[contextName]; ok {
-				clusterName = ctx.Cluster
-				contextNamespace = ctx.Namespace
-				if ai, ok := rawConfig.AuthInfos[ctx.AuthInfo]; ok && ai.Exec != nil {
-					contextUsesExec = true
-				}
-			}
 		}
 
 		config, err = kubeConfig.ClientConfig()
@@ -500,29 +553,46 @@ func recordEmptyCommandWarning(source string, authInfos []string) {
 func WriteKubeconfigForCurrentContext() (string, error) {
 	clientMu.RLock()
 	ctx := contextName
-	paths := kubeconfigPaths
+	registry := contextRegistry
+	fileConfigs := perFileConfigs
 	singlePath := kubeconfigPath
 	clientMu.RUnlock()
 
-	var loadingRules *clientcmd.ClientConfigLoadingRules
-	if len(paths) > 0 {
-		loadingRules = &clientcmd.ClientConfigLoadingRules{Precedence: paths}
+	var rawConfig clientcmdapi.Config
+	var currentContextForFile string
+
+	if registry != nil {
+		// Isolated-load mode: write only the current context's source file,
+		// with CurrentContext set to the name it has inside that file. This
+		// avoids leaking other files' (possibly colliding) definitions into
+		// the temp kubeconfig we hand out.
+		entry, ok := registry[ctx]
+		if !ok {
+			return "", fmt.Errorf("current context %q not found in registry", ctx)
+		}
+		cfg, ok := fileConfigs[entry.SourceFile]
+		if !ok {
+			return "", fmt.Errorf("no cached config for file %q", entry.SourceFile)
+		}
+		rawConfig = *cfg.DeepCopy()
+		currentContextForFile = entry.OriginalName
 	} else {
 		if singlePath == "" {
 			return "", fmt.Errorf("kubeconfig path not set")
 		}
-		loadingRules = &clientcmd.ClientConfigLoadingRules{ExplicitPath: singlePath}
+		loadingRules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: singlePath}
+		loaded, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			loadingRules, &clientcmd.ConfigOverrides{},
+		).RawConfig()
+		if err != nil {
+			return "", fmt.Errorf("failed to load kubeconfig: %w", err)
+		}
+		rawConfig = loaded
+		currentContextForFile = ctx
 	}
 
-	rawConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		loadingRules, &clientcmd.ConfigOverrides{},
-	).RawConfig()
-	if err != nil {
-		return "", fmt.Errorf("failed to load kubeconfig: %w", err)
-	}
-
-	if ctx != "" {
-		rawConfig.CurrentContext = ctx
+	if currentContextForFile != "" {
+		rawConfig.CurrentContext = currentContextForFile
 	}
 
 	tmpFile, err := os.CreateTemp("", "radar-kubeconfig-*.yaml")
@@ -622,35 +692,52 @@ func GetAvailableContexts() ([]ContextInfo, error) {
 		}, nil
 	}
 
-	var loadingRules *clientcmd.ClientConfigLoadingRules
-	if len(kubeconfigPaths) > 0 {
-		// Multi-kubeconfig mode
-		loadingRules = &clientcmd.ClientConfigLoadingRules{Precedence: kubeconfigPaths}
-	} else {
-		// Single kubeconfig mode
-		kubeconfig := kubeconfigPath
-		if kubeconfig == "" {
-			return nil, fmt.Errorf("kubeconfig path not set")
+	clientMu.RLock()
+	registry := contextRegistry
+	fileConfigs := perFileConfigs
+	currentCtx := contextName
+	clientMu.RUnlock()
+
+	if registry != nil {
+		// Isolated-load mode: enumerate every registered context, pulling
+		// cluster/user/namespace from the file it originally lives in.
+		// No merge happens — shared names across files stay distinct.
+		contexts := make([]ContextInfo, 0, len(registry))
+		for qName, entry := range registry {
+			cfg, ok := fileConfigs[entry.SourceFile]
+			if !ok {
+				continue
+			}
+			ctx, ok := cfg.Contexts[entry.OriginalName]
+			if !ok || ctx == nil {
+				continue
+			}
+			contexts = append(contexts, ContextInfo{
+				Name:      qName,
+				Cluster:   ctx.Cluster,
+				User:      ctx.AuthInfo,
+				Namespace: ctx.Namespace,
+				IsCurrent: qName == currentCtx,
+			})
 		}
-		loadingRules = &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig}
+		return contexts, nil
 	}
 
-	configOverrides := &clientcmd.ConfigOverrides{}
-	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
-
+	// Single-file fallback: load the one file and enumerate its contexts.
+	kubeconfig := kubeconfigPath
+	if kubeconfig == "" {
+		return nil, fmt.Errorf("kubeconfig path not set")
+	}
+	loadingRules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig}
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
 	rawConfig, err := kubeConfig.RawConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
 	}
-
-	// Use Explorer's in-memory contextName to determine current context
-	// This allows Explorer to switch contexts without modifying the kubeconfig file
-	currentCtx := contextName
 	if currentCtx == "" {
 		// Fall back to kubeconfig's current-context if we haven't switched yet
 		currentCtx = rawConfig.CurrentContext
 	}
-
 	contexts := make([]ContextInfo, 0, len(rawConfig.Contexts))
 	for name, ctx := range rawConfig.Contexts {
 		contexts = append(contexts, ContextInfo{
@@ -661,7 +748,6 @@ func GetAvailableContexts() ([]ContextInfo, error) {
 			IsCurrent: name == currentCtx,
 		})
 	}
-
 	return contexts, nil
 }
 
@@ -672,21 +758,35 @@ func SwitchContext(name string) error {
 		return fmt.Errorf("cannot switch context when running in-cluster")
 	}
 
+	clientMu.RLock()
+	registry := contextRegistry
+	clientMu.RUnlock()
+
 	var loadingRules *clientcmd.ClientConfigLoadingRules
-	if len(kubeconfigPaths) > 0 {
-		// Multi-kubeconfig mode
-		loadingRules = &clientcmd.ClientConfigLoadingRules{Precedence: kubeconfigPaths}
+	var overrideContextName string
+
+	if registry != nil {
+		// Isolated-load mode: resolve the qualified name to the source file
+		// and load only that file. Every other file is ignored here, so
+		// colliding user/cluster names in sibling files can't pollute this
+		// context's credentials (issue #519).
+		entry, ok := registry[name]
+		if !ok {
+			return fmt.Errorf("context %q not found in kubeconfig", name)
+		}
+		loadingRules = &clientcmd.ClientConfigLoadingRules{ExplicitPath: entry.SourceFile}
+		overrideContextName = entry.OriginalName
 	} else {
-		// Single kubeconfig mode
 		kubeconfig := kubeconfigPath
 		if kubeconfig == "" {
 			return fmt.Errorf("kubeconfig path not set")
 		}
 		loadingRules = &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig}
+		overrideContextName = name
 	}
 
 	// Build config with the new context
-	configOverrides := &clientcmd.ConfigOverrides{CurrentContext: name}
+	configOverrides := &clientcmd.ConfigOverrides{CurrentContext: overrideContextName}
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 
 	// Verify the context exists
@@ -695,7 +795,7 @@ func SwitchContext(name string) error {
 		return fmt.Errorf("failed to load kubeconfig: %w", err)
 	}
 
-	ctx, ok := rawConfig.Contexts[name]
+	ctx, ok := rawConfig.Contexts[overrideContextName]
 	if !ok {
 		return fmt.Errorf("context %q not found in kubeconfig", name)
 	}
@@ -733,9 +833,18 @@ func SwitchContext(name string) error {
 	if ai, ok := rawConfig.AuthInfos[ctx.AuthInfo]; ok && ai.Exec != nil {
 		usesExec = true
 	}
-	// Re-collect exec plugin commands — SwitchContext loads a fresh RawConfig
-	// so the user may have added/removed kubeconfig files since init.
-	execCmds, emptyAIs := collectExecPluginCommands(&rawConfig)
+	// Re-collect exec plugin commands. In isolated-load mode rawConfig only
+	// reflects the one chosen file, so we walk the full registry to keep
+	// the diagnostic honest about which plugins span the whole configuration.
+	var execCmds, emptyAIs []string
+	var totalContexts int
+	if registry != nil {
+		execCmds, emptyAIs = aggregateExecPluginCommands(kubeconfigPaths, perFileConfigs)
+		totalContexts = len(registry)
+	} else {
+		execCmds, emptyAIs = collectExecPluginCommands(&rawConfig)
+		totalContexts = len(rawConfig.Contexts)
+	}
 	if len(emptyAIs) > 0 {
 		recordEmptyCommandWarning("context-switch", emptyAIs)
 	}
@@ -749,7 +858,7 @@ func SwitchContext(name string) error {
 	clusterName = ctx.Cluster
 	contextNamespace = ctx.Namespace
 	contextUsesExec = usesExec
-	mergedContextCount = len(rawConfig.Contexts)
+	mergedContextCount = totalContexts
 	execPluginCommands = execCmds
 	clientMu.Unlock()
 
@@ -759,22 +868,31 @@ func SwitchContext(name string) error {
 // capiKubeconfigs tracks temp kubeconfig files by context name to avoid accumulation.
 var capiKubeconfigs = make(map[string]string) // contextName -> tmpPath
 
-// MergeAndSwitchContext writes the provided kubeconfig data to a temporary file
-// and adds it to Radar's kubeconfig search path so that the context becomes
-// available for switching. Returns the temp file path.
-func MergeAndSwitchContext(kubeconfigData []byte, contextName string) (string, error) {
+// MergeAndSwitchContext writes the provided kubeconfig data to a temporary
+// file and registers its context so that Radar can switch to it. The returned
+// qualifiedName is the identifier the caller should pass to PerformContextSwitch
+// — it may differ from the input contextName if another file already owns that
+// name, in which case the registry disambiguates via qualifyContextName.
+//
+// If Radar started in single-file mode, the first CAPI merge promotes it into
+// isolated-load mode by seeding the registry with the original kubeconfig plus
+// the new CAPI file.
+func MergeAndSwitchContext(kubeconfigData []byte, contextName string) (string, string, error) {
 	// Parse the incoming kubeconfig
 	newConfig, err := clientcmd.Load(kubeconfigData)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse kubeconfig: %w", err)
+		return "", "", fmt.Errorf("failed to parse kubeconfig: %w", err)
 	}
 
 	// Verify the context exists
 	if _, ok := newConfig.Contexts[contextName]; !ok {
-		return "", fmt.Errorf("context %q not found in provided kubeconfig", contextName)
+		return "", "", fmt.Errorf("context %q not found in provided kubeconfig", contextName)
 	}
 
-	// Reuse existing temp file for same context (avoids accumulation)
+	// Reuse existing temp file for same qualified context name (avoids accumulation).
+	// Keyed on the qualified name, which we resolve below — but for the "update
+	// same CAPI context" path we look up by both the qualified and original name
+	// since callers always pass the original.
 	clientMu.Lock()
 	existingPath := capiKubeconfigs[contextName]
 	clientMu.Unlock()
@@ -783,7 +901,15 @@ func MergeAndSwitchContext(kubeconfigData []byte, contextName string) (string, e
 		// Overwrite existing file with fresh kubeconfig data
 		if err := clientcmd.WriteToFile(*newConfig, existingPath); err == nil {
 			log.Printf("[capi] Updated existing kubeconfig for context %s: %s", contextName, existingPath)
-			return existingPath, nil
+			// Existing path already registered under its qualified name during
+			// the initial merge — look up and return that.
+			clientMu.RLock()
+			qName := findQualifiedNameForPath(contextRegistry, existingPath, contextName)
+			clientMu.RUnlock()
+			if qName == "" {
+				qName = contextName
+			}
+			return qName, existingPath, nil
 		}
 		// If overwrite fails, fall through to create a new file
 	}
@@ -791,37 +917,77 @@ func MergeAndSwitchContext(kubeconfigData []byte, contextName string) (string, e
 	// Write to a new temp file
 	tmpFile, err := os.CreateTemp("", "radar-capi-kubeconfig-*.yaml")
 	if err != nil {
-		return "", fmt.Errorf("failed to create temp kubeconfig: %w", err)
+		return "", "", fmt.Errorf("failed to create temp kubeconfig: %w", err)
 	}
 	tmpPath := tmpFile.Name()
 	tmpFile.Close()
 
 	if err := clientcmd.WriteToFile(*newConfig, tmpPath); err != nil {
 		os.Remove(tmpPath)
-		return "", fmt.Errorf("failed to write kubeconfig: %w", err)
+		return "", "", fmt.Errorf("failed to write kubeconfig: %w", err)
 	}
 
-	// Add the temp file to Radar's kubeconfig search path.
-	// In single-kubeconfig mode, kubeconfigPaths is empty — seed it with the
-	// original path so SwitchContext still sees the user's other contexts.
 	clientMu.Lock()
-	if len(kubeconfigPaths) == 0 && kubeconfigPath != "" {
-		kubeconfigPaths = []string{kubeconfigPath}
-	}
-	// Remove stale path for this context if overwrite failed above
-	if existingPath != "" {
-		updated := kubeconfigPaths[:0]
-		for _, p := range kubeconfigPaths {
-			if p != existingPath {
-				updated = append(updated, p)
+	defer clientMu.Unlock()
+
+	// If we're still in single-file mode, promote to isolated-load mode by
+	// seeding the registry with the original kubeconfig. Otherwise every
+	// future CAPI merge would silently revert to client-go's Precedence
+	// behavior — exactly the bug #519 fixes.
+	if contextRegistry == nil {
+		seedPaths := []string{}
+		if kubeconfigPath != "" {
+			seedPaths = append(seedPaths, kubeconfigPath)
+		}
+		seedPaths = append(seedPaths, tmpPath)
+		registry, fileConfigs := buildContextRegistry(seedPaths)
+		contextRegistry = registry
+		perFileConfigs = fileConfigs
+		kubeconfigPaths = seedPaths
+		// Leave kubeconfigMode as-is — this stays "single" or whatever the
+		// initial mode was for diagnostics, even though we're now running
+		// through the isolated loader.
+	} else {
+		// Registry already populated — just add this file to it.
+		cfg, err := clientcmd.LoadFromFile(tmpPath)
+		if err != nil {
+			os.Remove(tmpPath)
+			return "", "", fmt.Errorf("failed to re-load temp kubeconfig: %w", err)
+		}
+		perFileConfigs[tmpPath] = cfg
+		kubeconfigPaths = append(kubeconfigPaths, tmpPath)
+		// Qualify the incoming context name against the existing registry
+		// and add every context in the new file (including the target one).
+		for name := range cfg.Contexts {
+			qName := qualifyContextName(contextRegistry, name, tmpPath)
+			contextRegistry[qName] = contextEntry{
+				SourceFile:   tmpPath,
+				OriginalName: name,
 			}
 		}
-		kubeconfigPaths = updated
 	}
-	kubeconfigPaths = append(kubeconfigPaths, tmpPath)
-	capiKubeconfigs[contextName] = tmpPath
-	clientMu.Unlock()
 
-	log.Printf("[capi] Added workload cluster kubeconfig: %s (context: %s)", tmpPath, contextName)
-	return tmpPath, nil
+	// Resolve the qualified name for the context the caller asked about.
+	qualifiedName := findQualifiedNameForPath(contextRegistry, tmpPath, contextName)
+	if qualifiedName == "" {
+		os.Remove(tmpPath)
+		return "", "", fmt.Errorf("internal: failed to register context %q from %s", contextName, tmpPath)
+	}
+
+	capiKubeconfigs[qualifiedName] = tmpPath
+
+	log.Printf("[capi] Added workload cluster kubeconfig: %s (context: %s)", tmpPath, qualifiedName)
+	return qualifiedName, tmpPath, nil
+}
+
+// findQualifiedNameForPath returns the qualified registry name of the given
+// (file, originalContextName) pair, or "" if none is registered. Used by the
+// CAPI merge path to learn the post-disambiguation identifier.
+func findQualifiedNameForPath(registry map[string]contextEntry, file, originalName string) string {
+	for qName, entry := range registry {
+		if entry.SourceFile == file && entry.OriginalName == originalName {
+			return qName
+		}
+	}
+	return ""
 }

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -32,7 +32,7 @@ var (
 	kubeconfigPath     string
 	kubeconfigPaths    []string // Multiple kubeconfig paths when using --kubeconfig-dir or KUBECONFIG env
 	kubeconfigMode     string   // One of: "in-cluster", "single", "multi-env", "multi-dir"
-	mergedContextCount int      // Total number of contexts exposed across all kubeconfig files (pre-#519 this was the post-merge count; kept the variable name to avoid diff churn)
+	totalContextCount int      // Total number of contexts exposed across all kubeconfig files
 	// contextRegistry maps each user-facing context name to its source file and
 	// the name it has inside that file. Populated when Radar loads more than one
 	// kubeconfig file (multi-dir, multi-env with >1 paths, or CAPI-added files).
@@ -43,12 +43,12 @@ var (
 	contextRegistry map[string]contextEntry
 	// perFileConfigs caches each file's parsed api.Config so GetAvailableContexts
 	// doesn't re-read N files on every call. Keyed by absolute file path.
-	perFileConfigs map[string]*clientcmdapi.Config
-	contextName        string
-	clusterName        string
-	contextNamespace   string // Default namespace from kubeconfig context
-	fallbackNamespace  string // Explicit namespace from --namespace flag
-	contextUsesExec    bool   // True when the current context uses an exec credential plugin
+	perFileConfigs    map[string]*clientcmdapi.Config
+	contextName       string
+	clusterName       string
+	contextNamespace  string // Default namespace from kubeconfig context
+	fallbackNamespace string // Explicit namespace from --namespace flag
+	contextUsesExec   bool   // True when the current context uses an exec credential plugin
 	// execPluginCommands is the set of unique exec-auth plugin command basenames
 	// referenced by any context in the merged kubeconfig. Populated from
 	// rawConfig.AuthInfos at load time and refreshed on SwitchContext. Stored
@@ -206,7 +206,7 @@ func doInit(opts InitOptions) error {
 				// contextName was already set to the qualified name by
 				// setupIsolatedLoad; don't overwrite with the original name
 				// inside the single chosen file.
-				mergedContextCount = len(contextRegistry)
+				totalContextCount = len(contextRegistry)
 				cmds, emptyAIs := aggregateExecPluginCommands(kubeconfigPaths, perFileConfigs)
 				execPluginCommands = cmds
 				if len(emptyAIs) > 0 {
@@ -216,7 +216,7 @@ func doInit(opts InitOptions) error {
 				// the registry-resolved file. rawConfig.Contexts is keyed by
 				// the *original* name inside the chosen file.
 				if entry, ok := contextRegistry[contextName]; ok {
-					if ctx, ok := rawConfig.Contexts[entry.OriginalName]; ok {
+					if ctx, ok := rawConfig.Contexts[entry.InFileName]; ok {
 						clusterName = ctx.Cluster
 						contextNamespace = ctx.Namespace
 						if ai, ok := rawConfig.AuthInfos[ctx.AuthInfo]; ok && ai.Exec != nil {
@@ -226,7 +226,7 @@ func doInit(opts InitOptions) error {
 				}
 			} else {
 				contextName = rawConfig.CurrentContext
-				mergedContextCount = len(rawConfig.Contexts)
+				totalContextCount = len(rawConfig.Contexts)
 				cmds, emptyAIs := collectExecPluginCommands(&rawConfig)
 				execPluginCommands = cmds
 				if len(emptyAIs) > 0 {
@@ -251,7 +251,7 @@ func doInit(opts InitOptions) error {
 			// count, which silently hid colliding user/cluster definitions;
 			// now every file's contexts are individually reachable).
 			log.Printf("Kubeconfig loaded: mode=%s, files=%d, contexts=%d, exec-plugins=%d",
-				kubeconfigMode, fileCount, mergedContextCount, len(execPluginCommands))
+				kubeconfigMode, fileCount, totalContextCount, len(execPluginCommands))
 		}
 
 		config, err = kubeConfig.ClientConfig()
@@ -437,7 +437,7 @@ func GetKubeconfigSummary() KubeconfigSummary {
 	if fileCount == 0 && kubeconfigPath != "" {
 		fileCount = 1
 	}
-	contextCount := mergedContextCount
+	contextCount := totalContextCount
 	enriched := enrichedKubeconfigFromShell
 	currentExec := contextUsesExec
 	cmds := append([]string(nil), execPluginCommands...)
@@ -575,7 +575,7 @@ func WriteKubeconfigForCurrentContext() (string, error) {
 			return "", fmt.Errorf("no cached config for file %q", entry.SourceFile)
 		}
 		rawConfig = *cfg.DeepCopy()
-		currentContextForFile = entry.OriginalName
+		currentContextForFile = entry.InFileName
 	} else {
 		if singlePath == "" {
 			return "", fmt.Errorf("kubeconfig path not set")
@@ -708,7 +708,7 @@ func GetAvailableContexts() ([]ContextInfo, error) {
 			if !ok {
 				continue
 			}
-			ctx, ok := cfg.Contexts[entry.OriginalName]
+			ctx, ok := cfg.Contexts[entry.InFileName]
 			if !ok || ctx == nil {
 				continue
 			}
@@ -758,8 +758,15 @@ func SwitchContext(name string) error {
 		return fmt.Errorf("cannot switch context when running in-cluster")
 	}
 
+	// Snapshot registry-related globals under the lock. MergeAndSwitchContext
+	// can mutate all three concurrently, so reads have to be atomic as a set.
 	clientMu.RLock()
 	registry := contextRegistry
+	pathsSnapshot := append([]string(nil), kubeconfigPaths...)
+	configsSnapshot := make(map[string]*clientcmdapi.Config, len(perFileConfigs))
+	for k, v := range perFileConfigs {
+		configsSnapshot[k] = v
+	}
 	clientMu.RUnlock()
 
 	var loadingRules *clientcmd.ClientConfigLoadingRules
@@ -775,7 +782,7 @@ func SwitchContext(name string) error {
 			return fmt.Errorf("context %q not found in kubeconfig", name)
 		}
 		loadingRules = &clientcmd.ClientConfigLoadingRules{ExplicitPath: entry.SourceFile}
-		overrideContextName = entry.OriginalName
+		overrideContextName = entry.InFileName
 	} else {
 		kubeconfig := kubeconfigPath
 		if kubeconfig == "" {
@@ -839,7 +846,7 @@ func SwitchContext(name string) error {
 	var execCmds, emptyAIs []string
 	var totalContexts int
 	if registry != nil {
-		execCmds, emptyAIs = aggregateExecPluginCommands(kubeconfigPaths, perFileConfigs)
+		execCmds, emptyAIs = aggregateExecPluginCommands(pathsSnapshot, configsSnapshot)
 		totalContexts = len(registry)
 	} else {
 		execCmds, emptyAIs = collectExecPluginCommands(&rawConfig)
@@ -858,7 +865,7 @@ func SwitchContext(name string) error {
 	clusterName = ctx.Cluster
 	contextNamespace = ctx.Namespace
 	contextUsesExec = usesExec
-	mergedContextCount = totalContexts
+	totalContextCount = totalContexts
 	execPluginCommands = execCmds
 	clientMu.Unlock()
 
@@ -869,112 +876,133 @@ func SwitchContext(name string) error {
 var capiKubeconfigs = make(map[string]string) // contextName -> tmpPath
 
 // MergeAndSwitchContext writes the provided kubeconfig data to a temporary
-// file and registers its context so that Radar can switch to it. The returned
-// qualifiedName is the identifier the caller should pass to PerformContextSwitch
-// — it may differ from the input contextName if another file already owns that
-// name, in which case the registry disambiguates via qualifyContextName.
+// file and registers its context so that Radar can switch to it. Returns
+// (qualifiedName, tmpPath, error): qualifiedName is the identifier the caller
+// must pass to PerformContextSwitch, and may differ from the input contextName
+// if another file already owns that name (the registry disambiguates via
+// qualifyContextName). tmpPath is the on-disk location of the kubeconfig,
+// exposed for diagnostics / logging only.
 //
-// If Radar started in single-file mode, the first CAPI merge promotes it into
-// isolated-load mode by seeding the registry with the original kubeconfig plus
-// the new CAPI file.
+// If Radar started in single-file mode, the first CAPI merge promotes it
+// into isolated-load mode by seeding the registry with the original
+// kubeconfig plus the new CAPI file — otherwise subsequent CAPI merges
+// would silently revert to client-go's Precedence behavior (issue #519).
+//
+// Concurrency: the entire decision is serialized under clientMu.Lock. The
+// input contextName is the stable key for reuse across reconnects (CAPI
+// re-emits the same context name each time for the same workload cluster),
+// so we can dedupe without having to reverse-lookup the qualified form.
 func MergeAndSwitchContext(kubeconfigData []byte, contextName string) (string, string, error) {
-	// Parse the incoming kubeconfig
 	newConfig, err := clientcmd.Load(kubeconfigData)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to parse kubeconfig: %w", err)
 	}
-
-	// Verify the context exists
 	if _, ok := newConfig.Contexts[contextName]; !ok {
 		return "", "", fmt.Errorf("context %q not found in provided kubeconfig", contextName)
 	}
 
-	// Reuse existing temp file for same qualified context name (avoids accumulation).
-	// Keyed on the qualified name, which we resolve below — but for the "update
-	// same CAPI context" path we look up by both the qualified and original name
-	// since callers always pass the original.
+	// Hold clientMu for the entire reuse-check + registration path so two
+	// concurrent CAPI merges for the same workload cluster can't both see
+	// "no existing path" and both create orphan temp files.
 	clientMu.Lock()
-	existingPath := capiKubeconfigs[contextName]
-	clientMu.Unlock()
+	defer clientMu.Unlock()
 
-	if existingPath != "" {
-		// Overwrite existing file with fresh kubeconfig data
+	// Fast path: same CAPI context was registered before. Overwrite the
+	// existing temp file so the user gets a fresh exec plugin config, and
+	// return the qualified name we assigned on the original merge.
+	if existingPath, ok := capiKubeconfigs[contextName]; ok {
 		if err := clientcmd.WriteToFile(*newConfig, existingPath); err == nil {
-			log.Printf("[capi] Updated existing kubeconfig for context %s: %s", contextName, existingPath)
-			// Existing path already registered under its qualified name during
-			// the initial merge — look up and return that.
-			clientMu.RLock()
-			qName := findQualifiedNameForPath(contextRegistry, existingPath, contextName)
-			clientMu.RUnlock()
-			if qName == "" {
-				qName = contextName
+			// Refresh the cached parsed config so subsequent GetAvailableContexts
+			// calls reflect any changes in the incoming YAML.
+			if parsed, perr := clientcmd.LoadFromFile(existingPath); perr == nil {
+				perFileConfigs[existingPath] = parsed
 			}
-			return qName, existingPath, nil
+			qName := findQualifiedNameForPath(contextRegistry, existingPath, contextName)
+			if qName == "" {
+				// Registry is missing the entry somehow — rebuild it below by
+				// falling through to the new-file path. Scrub the stale map
+				// entry so we don't keep returning it.
+				delete(capiKubeconfigs, contextName)
+			} else {
+				log.Printf("[capi] Updated existing kubeconfig for context %s: %s", contextName, existingPath)
+				return qName, existingPath, nil
+			}
 		}
-		// If overwrite fails, fall through to create a new file
+		// Overwrite failed — fall through to create a new temp file.
 	}
 
-	// Write to a new temp file
+	// Write to a new temp file.
 	tmpFile, err := os.CreateTemp("", "radar-capi-kubeconfig-*.yaml")
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create temp kubeconfig: %w", err)
 	}
 	tmpPath := tmpFile.Name()
 	tmpFile.Close()
-
 	if err := clientcmd.WriteToFile(*newConfig, tmpPath); err != nil {
 		os.Remove(tmpPath)
 		return "", "", fmt.Errorf("failed to write kubeconfig: %w", err)
 	}
 
-	clientMu.Lock()
-	defer clientMu.Unlock()
+	// Build a local snapshot of the registry additions we're about to make,
+	// then validate before committing to globals. If validation fails we
+	// remove the temp file and leave the globals untouched — no half-state.
+	var newRegistry map[string]contextEntry
+	var newFileConfigs map[string]*clientcmdapi.Config
+	var newPaths []string
 
-	// If we're still in single-file mode, promote to isolated-load mode by
-	// seeding the registry with the original kubeconfig. Otherwise every
-	// future CAPI merge would silently revert to client-go's Precedence
-	// behavior — exactly the bug #519 fixes.
 	if contextRegistry == nil {
+		// Promote single-file mode to isolated-load mode.
 		seedPaths := []string{}
 		if kubeconfigPath != "" {
 			seedPaths = append(seedPaths, kubeconfigPath)
 		}
 		seedPaths = append(seedPaths, tmpPath)
 		registry, fileConfigs := buildContextRegistry(seedPaths)
-		contextRegistry = registry
-		perFileConfigs = fileConfigs
-		kubeconfigPaths = seedPaths
-		// Leave kubeconfigMode as-is — this stays "single" or whatever the
-		// initial mode was for diagnostics, even though we're now running
-		// through the isolated loader.
+		if _, hasTmp := fileConfigs[tmpPath]; !hasTmp {
+			os.Remove(tmpPath)
+			return "", "", fmt.Errorf("internal: failed to register CAPI kubeconfig %s", tmpPath)
+		}
+		newRegistry = registry
+		newFileConfigs = fileConfigs
+		newPaths = seedPaths
 	} else {
-		// Registry already populated — just add this file to it.
 		cfg, err := clientcmd.LoadFromFile(tmpPath)
 		if err != nil {
 			os.Remove(tmpPath)
 			return "", "", fmt.Errorf("failed to re-load temp kubeconfig: %w", err)
 		}
-		perFileConfigs[tmpPath] = cfg
-		kubeconfigPaths = append(kubeconfigPaths, tmpPath)
-		// Qualify the incoming context name against the existing registry
-		// and add every context in the new file (including the target one).
+		// Copy-on-write: stage new maps / slice so we don't publish a
+		// partially-updated registry on any error path below.
+		newRegistry = make(map[string]contextEntry, len(contextRegistry)+len(cfg.Contexts))
+		for k, v := range contextRegistry {
+			newRegistry[k] = v
+		}
+		newFileConfigs = make(map[string]*clientcmdapi.Config, len(perFileConfigs)+1)
+		for k, v := range perFileConfigs {
+			newFileConfigs[k] = v
+		}
+		newFileConfigs[tmpPath] = cfg
+		newPaths = append(append([]string(nil), kubeconfigPaths...), tmpPath)
 		for name := range cfg.Contexts {
-			qName := qualifyContextName(contextRegistry, name, tmpPath)
-			contextRegistry[qName] = contextEntry{
-				SourceFile:   tmpPath,
-				OriginalName: name,
+			qName := qualifyContextName(newRegistry, name, tmpPath)
+			newRegistry[qName] = contextEntry{
+				SourceFile: tmpPath,
+				InFileName: name,
 			}
 		}
 	}
 
-	// Resolve the qualified name for the context the caller asked about.
-	qualifiedName := findQualifiedNameForPath(contextRegistry, tmpPath, contextName)
+	qualifiedName := findQualifiedNameForPath(newRegistry, tmpPath, contextName)
 	if qualifiedName == "" {
 		os.Remove(tmpPath)
 		return "", "", fmt.Errorf("internal: failed to register context %q from %s", contextName, tmpPath)
 	}
 
-	capiKubeconfigs[qualifiedName] = tmpPath
+	// Commit. All globals updated atomically under the single Lock held above.
+	contextRegistry = newRegistry
+	perFileConfigs = newFileConfigs
+	kubeconfigPaths = newPaths
+	capiKubeconfigs[contextName] = tmpPath
 
 	log.Printf("[capi] Added workload cluster kubeconfig: %s (context: %s)", tmpPath, qualifiedName)
 	return qualifiedName, tmpPath, nil
@@ -983,9 +1011,9 @@ func MergeAndSwitchContext(kubeconfigData []byte, contextName string) (string, s
 // findQualifiedNameForPath returns the qualified registry name of the given
 // (file, originalContextName) pair, or "" if none is registered. Used by the
 // CAPI merge path to learn the post-disambiguation identifier.
-func findQualifiedNameForPath(registry map[string]contextEntry, file, originalName string) string {
+func findQualifiedNameForPath(registry map[string]contextEntry, file, inFileName string) string {
 	for qName, entry := range registry {
-		if entry.SourceFile == file && entry.OriginalName == originalName {
+		if entry.SourceFile == file && entry.InFileName == inFileName {
 			return qName
 		}
 	}

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -924,7 +924,7 @@ func MergeAndSwitchContext(kubeconfigData []byte, contextName string) (string, s
 				// entry so we don't keep returning it.
 				delete(capiKubeconfigs, contextName)
 			} else {
-				log.Printf("[capi] Updated existing kubeconfig for context %s: %s", contextName, existingPath)
+				log.Printf("[capi] Updated existing kubeconfig for context %q: %q", contextName, existingPath)
 				return qName, existingPath, nil
 			}
 		}
@@ -1004,7 +1004,7 @@ func MergeAndSwitchContext(kubeconfigData []byte, contextName string) (string, s
 	kubeconfigPaths = newPaths
 	capiKubeconfigs[contextName] = tmpPath
 
-	log.Printf("[capi] Added workload cluster kubeconfig: %s (context: %s)", tmpPath, qualifiedName)
+	log.Printf("[capi] Added workload cluster kubeconfig: %q (context: %q)", tmpPath, qualifiedName)
 	return qualifiedName, tmpPath, nil
 }
 

--- a/internal/k8s/context_registry.go
+++ b/internal/k8s/context_registry.go
@@ -1,0 +1,202 @@
+package k8s
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// setupIsolatedLoad populates contextRegistry, perFileConfigs, and contextName
+// from the given kubeconfig files, then returns LoadingRules + Overrides that
+// load *only* the initial file via ExplicitPath. Caller must already hold
+// initOnce (we're inside doInit) and has exclusive access to the globals.
+//
+// This is how Radar avoids client-go's Precedence merge when there's more
+// than one kubeconfig file: each file stays an island. A SwitchContext later
+// looks up the target entry in the registry and loads that one file, so
+// shared user/cluster names across files never collide — see issue #519.
+func setupIsolatedLoad(paths []string) (
+	*clientcmd.ClientConfigLoadingRules,
+	*clientcmd.ConfigOverrides,
+	error,
+) {
+	registry, fileConfigs := buildContextRegistry(paths)
+	if len(registry) == 0 {
+		return nil, nil, fmt.Errorf("no contexts found across %d kubeconfig files", len(paths))
+	}
+	qName, entry, ok := pickInitialContext(paths, registry, fileConfigs)
+	if !ok {
+		return nil, nil, fmt.Errorf("no usable context found across %d kubeconfig files", len(paths))
+	}
+	contextRegistry = registry
+	perFileConfigs = fileConfigs
+	contextName = qName
+	return &clientcmd.ClientConfigLoadingRules{ExplicitPath: entry.SourceFile},
+		&clientcmd.ConfigOverrides{CurrentContext: entry.OriginalName},
+		nil
+}
+
+// contextEntry locates a kubeconfig context by its source file and the name
+// it has inside that file. The registry uses this to route SwitchContext to
+// a specific file (loaded in isolation via ExplicitPath) so that clusters,
+// users, and contexts with shared names across files don't clobber each
+// other via client-go's Precedence merge.
+type contextEntry struct {
+	SourceFile   string // absolute path to the kubeconfig on disk
+	OriginalName string // context name as it appears inside SourceFile
+}
+
+// buildContextRegistry loads each kubeconfig file in isolation and produces:
+//   - registry: user-facing context name → (file, original name in that file)
+//   - fileConfigs: per-file parsed Configs so GetAvailableContexts can
+//     enumerate contexts without re-reading disk
+//
+// When two files contain a context with the same name, the second one is
+// qualified with its source filename (e.g. "kas-107 (file2)"). Users and
+// clusters are never renamed — they stay scoped to their own file and are
+// only referenced via ExplicitPath loads, so cross-file name collisions
+// on AuthInfo/Cluster maps are structurally impossible.
+//
+// Files that fail to parse are skipped with a log line; the caller already
+// ran isValidKubeconfig() during directory discovery, so this is defense
+// against files that became unreadable between scan and load.
+func buildContextRegistry(paths []string) (map[string]contextEntry, map[string]*clientcmdapi.Config) {
+	registry := make(map[string]contextEntry)
+	fileConfigs := make(map[string]*clientcmdapi.Config)
+	for _, path := range paths {
+		cfg, err := clientcmd.LoadFromFile(path)
+		if err != nil {
+			// Non-fatal: skip and continue. discoverKubeconfigs has
+			// already validated these, so a failure here is surprising
+			// enough to log but shouldn't block the whole init.
+			continue
+		}
+		fileConfigs[path] = cfg
+		for name := range cfg.Contexts {
+			qName := qualifyContextName(registry, name, path)
+			registry[qName] = contextEntry{
+				SourceFile:   path,
+				OriginalName: name,
+			}
+		}
+	}
+	return registry, fileConfigs
+}
+
+// qualifyContextName returns a globally-unique context name for a context
+// called `name` coming from file `path`. When `name` isn't taken yet, it
+// returns `name` unchanged — most contexts across most files don't collide
+// (it's the users/clusters that typically share names, not the context
+// names themselves), and the user-visible dropdown should show the
+// original names wherever possible. On collision it falls back to
+// "<name> (<file-basename-without-ext>)", and then "<name> (<base> #N)"
+// for further collisions from a third+ file with the same basename.
+func qualifyContextName(registry map[string]contextEntry, name, path string) string {
+	if _, taken := registry[name]; !taken {
+		return name
+	}
+	base := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	qualified := fmt.Sprintf("%s (%s)", name, base)
+	if _, taken := registry[qualified]; !taken {
+		return qualified
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s (%s #%d)", name, base, i)
+		if _, taken := registry[candidate]; !taken {
+			return candidate
+		}
+	}
+}
+
+// pickInitialContext chooses which context Radar should start in when
+// using per-file isolated loading. It walks `paths` in order and returns
+// the first non-empty CurrentContext from any file — matching client-go's
+// Precedence merge, which picks the first file's CurrentContext. If no
+// file declares a CurrentContext, it returns the first context from the
+// first file with any contexts at all, so Radar can still come up.
+//
+// Returns (qualifiedName, entry, found). `found == false` means there
+// isn't a single usable context anywhere — the caller should surface this
+// as an init error.
+func pickInitialContext(
+	paths []string,
+	registry map[string]contextEntry,
+	fileConfigs map[string]*clientcmdapi.Config,
+) (string, contextEntry, bool) {
+	// First pass: honor CurrentContext in file order.
+	for _, path := range paths {
+		cfg, ok := fileConfigs[path]
+		if !ok || cfg.CurrentContext == "" {
+			continue
+		}
+		// Find the registry entry whose (SourceFile, OriginalName) matches.
+		for qName, entry := range registry {
+			if entry.SourceFile == path && entry.OriginalName == cfg.CurrentContext {
+				return qName, entry, true
+			}
+		}
+	}
+	// Fallback: any context from the first file that has one.
+	for _, path := range paths {
+		cfg, ok := fileConfigs[path]
+		if !ok {
+			continue
+		}
+		for name := range cfg.Contexts {
+			for qName, entry := range registry {
+				if entry.SourceFile == path && entry.OriginalName == name {
+					return qName, entry, true
+				}
+			}
+		}
+	}
+	return "", contextEntry{}, false
+}
+
+// aggregateExecPluginCommands walks every context across every per-file
+// config and returns the unique sorted set of exec-plugin basenames plus
+// the list of AuthInfos that reference exec blocks with empty Commands.
+// Mirrors collectExecPluginCommands for single-Config usage but handles
+// the multi-file case — deduplicating across files and scoping AuthInfo
+// names by file so a "me" with empty Command in file-a doesn't get
+// confused with a valid "me" in file-b.
+func aggregateExecPluginCommands(
+	paths []string,
+	fileConfigs map[string]*clientcmdapi.Config,
+) (cmds []string, emptyCommandAuthInfos []string) {
+	seenCmds := make(map[string]struct{})
+	seenEmpty := make(map[string]struct{})
+	for _, path := range paths {
+		cfg, ok := fileConfigs[path]
+		if !ok {
+			continue
+		}
+		fileCmds, fileEmpty := collectExecPluginCommands(cfg)
+		for _, c := range fileCmds {
+			if _, dup := seenCmds[c]; dup {
+				continue
+			}
+			seenCmds[c] = struct{}{}
+			cmds = append(cmds, c)
+		}
+		base := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+		for _, ai := range fileEmpty {
+			// Scope by file so diagnostics aren't ambiguous when the same
+			// AuthInfo name appears in multiple files.
+			scoped := fmt.Sprintf("%s (%s)", ai, base)
+			if _, dup := seenEmpty[scoped]; dup {
+				continue
+			}
+			seenEmpty[scoped] = struct{}{}
+			emptyCommandAuthInfos = append(emptyCommandAuthInfos, scoped)
+		}
+	}
+	// Sort for stable output (matches collectExecPluginCommands' contract).
+	sort.Strings(cmds)
+	sort.Strings(emptyCommandAuthInfos)
+	return cmds, emptyCommandAuthInfos
+}

--- a/internal/k8s/context_registry.go
+++ b/internal/k8s/context_registry.go
@@ -2,18 +2,22 @@ package k8s
 
 import (
 	"fmt"
+	"log"
 	"path/filepath"
 	"sort"
 	"strings"
 
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/skyhook-io/radar/internal/errorlog"
 )
 
 // setupIsolatedLoad populates contextRegistry, perFileConfigs, and contextName
 // from the given kubeconfig files, then returns LoadingRules + Overrides that
-// load *only* the initial file via ExplicitPath. Caller must already hold
-// initOnce (we're inside doInit) and has exclusive access to the globals.
+// load *only* the initial file via ExplicitPath. Only called from doInit,
+// inside initOnce, so no concurrent readers exist yet — writes to the globals
+// are safe without clientMu.
 //
 // This is how Radar avoids client-go's Precedence merge when there's more
 // than one kubeconfig file: each file stays an island. A SwitchContext later
@@ -36,7 +40,7 @@ func setupIsolatedLoad(paths []string) (
 	perFileConfigs = fileConfigs
 	contextName = qName
 	return &clientcmd.ClientConfigLoadingRules{ExplicitPath: entry.SourceFile},
-		&clientcmd.ConfigOverrides{CurrentContext: entry.OriginalName},
+		&clientcmd.ConfigOverrides{CurrentContext: entry.InFileName},
 		nil
 }
 
@@ -46,8 +50,8 @@ func setupIsolatedLoad(paths []string) (
 // users, and contexts with shared names across files don't clobber each
 // other via client-go's Precedence merge.
 type contextEntry struct {
-	SourceFile   string // absolute path to the kubeconfig on disk
-	OriginalName string // context name as it appears inside SourceFile
+	SourceFile string // absolute path to the kubeconfig on disk
+	InFileName string // context name as it appears inside SourceFile
 }
 
 // buildContextRegistry loads each kubeconfig file in isolation and produces:
@@ -72,15 +76,20 @@ func buildContextRegistry(paths []string) (map[string]contextEntry, map[string]*
 		if err != nil {
 			// Non-fatal: skip and continue. discoverKubeconfigs has
 			// already validated these, so a failure here is surprising
-			// enough to log but shouldn't block the whole init.
+			// enough to log. The file's basename is safe to surface
+			// via errorlog (see scrubPathError's privacy contract).
+			log.Printf("[k8s-init] skipping kubeconfig %q during registry build: %v", filepath.Base(path), err)
+			errorlog.Record("k8s-init", "warning",
+				"kubeconfig %q failed to load during registry build: %s",
+				filepath.Base(path), scrubPathError(err))
 			continue
 		}
 		fileConfigs[path] = cfg
 		for name := range cfg.Contexts {
 			qName := qualifyContextName(registry, name, path)
 			registry[qName] = contextEntry{
-				SourceFile:   path,
-				OriginalName: name,
+				SourceFile: path,
+				InFileName: name,
 			}
 		}
 	}
@@ -133,9 +142,9 @@ func pickInitialContext(
 		if !ok || cfg.CurrentContext == "" {
 			continue
 		}
-		// Find the registry entry whose (SourceFile, OriginalName) matches.
+		// Find the registry entry whose (SourceFile, InFileName) matches.
 		for qName, entry := range registry {
-			if entry.SourceFile == path && entry.OriginalName == cfg.CurrentContext {
+			if entry.SourceFile == path && entry.InFileName == cfg.CurrentContext {
 				return qName, entry, true
 			}
 		}
@@ -148,7 +157,7 @@ func pickInitialContext(
 		}
 		for name := range cfg.Contexts {
 			for qName, entry := range registry {
-				if entry.SourceFile == path && entry.OriginalName == name {
+				if entry.SourceFile == path && entry.InFileName == name {
 					return qName, entry, true
 				}
 			}

--- a/internal/k8s/context_registry_test.go
+++ b/internal/k8s/context_registry_test.go
@@ -157,7 +157,7 @@ func TestBuildContextRegistry_ContextNameCollision(t *testing.T) {
 	if registry["my-ctx (staging)"].SourceFile != f2 {
 		t.Errorf("qualified context should resolve to f2")
 	}
-	if registry["my-ctx (staging)"].OriginalName != "my-ctx" {
+	if registry["my-ctx (staging)"].InFileName != "my-ctx" {
 		t.Errorf("original name must remain 'my-ctx' inside f2")
 	}
 }
@@ -262,6 +262,130 @@ func TestPickInitialContext_NoCurrentContextAnywhere(t *testing.T) {
 	}
 	if qName != "only-ctx" {
 		t.Errorf("expected 'only-ctx', got %q", qName)
+	}
+}
+
+// Regression guard for the #519 class of bug. Simulates what SwitchContext does:
+// resolve the qualified name through the registry, then load the target with
+// ExplicitPath. Two files share user and cluster names but carry distinct
+// tokens / server URLs. Each context must resolve to *its own* file's
+// definitions — which is exactly what client-go's Precedence merge would
+// have broken.
+func TestSwitchContextRouting_SharedNames_RoutesToCorrectFile(t *testing.T) {
+	dir := t.TempDir()
+	f1 := writeKubeconfig(t, dir, "file-a.yaml", "kas-107", []kubeEntry{
+		{ctxName: "kas-107", userName: "me", clusterName: "shared"},
+	})
+	f2 := writeKubeconfig(t, dir, "file-b.yaml", "kas-108", []kubeEntry{
+		{ctxName: "kas-108", userName: "me", clusterName: "shared"},
+	})
+	// Replace the shared user/cluster definitions with per-file unique
+	// tokens and server URLs so the test can observe which file a later
+	// ExplicitPath load actually reads from.
+	setUserTokenAndServer(t, f1, "me", "token-from-a", "shared", "https://server-a.test")
+	setUserTokenAndServer(t, f2, "me", "token-from-b", "shared", "https://server-b.test")
+
+	registry, _ := buildContextRegistry([]string{f1, f2})
+
+	entryA, ok := registry["kas-107"]
+	if !ok {
+		t.Fatal("kas-107 missing from registry")
+	}
+	loadedA, err := clientcmd.LoadFromFile(entryA.SourceFile)
+	if err != nil {
+		t.Fatalf("load %s: %v", entryA.SourceFile, err)
+	}
+	if got := loadedA.AuthInfos["me"].Token; got != "token-from-a" {
+		t.Errorf("kas-107 token: got %q, want token-from-a", got)
+	}
+	if got := loadedA.Clusters["shared"].Server; got != "https://server-a.test" {
+		t.Errorf("kas-107 server: got %q, want https://server-a.test", got)
+	}
+
+	entryB, ok := registry["kas-108"]
+	if !ok {
+		t.Fatal("kas-108 missing from registry")
+	}
+	loadedB, err := clientcmd.LoadFromFile(entryB.SourceFile)
+	if err != nil {
+		t.Fatalf("load %s: %v", entryB.SourceFile, err)
+	}
+	if got := loadedB.AuthInfos["me"].Token; got != "token-from-b" {
+		t.Errorf("kas-108 token: got %q, want token-from-b (Precedence-merge regression would show token-from-a)", got)
+	}
+	if got := loadedB.Clusters["shared"].Server; got != "https://server-b.test" {
+		t.Errorf("kas-108 server: got %q, want https://server-b.test", got)
+	}
+}
+
+func setUserTokenAndServer(t *testing.T, path, userName, token, clusterName, server string) {
+	t.Helper()
+	cfg, err := clientcmd.LoadFromFile(path)
+	if err != nil {
+		t.Fatalf("load %s: %v", path, err)
+	}
+	cfg.AuthInfos[userName] = &clientcmdapi.AuthInfo{Token: token}
+	cfg.Clusters[clusterName] = &clientcmdapi.Cluster{
+		Server:                server,
+		InsecureSkipTLSVerify: true,
+	}
+	data, err := clientcmd.Write(*cfg)
+	if err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("writeback %s: %v", path, err)
+	}
+}
+
+func TestAggregateExecPluginCommands_EmptyCommandScopedByFile(t *testing.T) {
+	dir := t.TempDir()
+	// Each file has a user with an exec block but an EMPTY command — a
+	// classic user misconfiguration. The aggregator must report both
+	// separately so diagnostics can point at the right file.
+	f1 := writeKubeconfig(t, dir, "alpha.yaml", "ctx-a", []kubeEntry{
+		{ctxName: "ctx-a", userName: "oidc", clusterName: "c1", execCommand: ""},
+	})
+	f2 := writeKubeconfig(t, dir, "beta.yaml", "ctx-b", []kubeEntry{
+		{ctxName: "ctx-b", userName: "oidc", clusterName: "c2", execCommand: ""},
+	})
+	// Manually inject an empty-command exec block (writeKubeconfig's
+	// execCommand="" falls through to a token — we want an actual exec with
+	// empty Command to hit the aggregator's emptyCommandAuthInfos path).
+	injectEmptyExec(t, f1, "oidc")
+	injectEmptyExec(t, f2, "oidc")
+
+	paths := []string{f1, f2}
+	_, fileConfigs := buildContextRegistry(paths)
+	_, empty := aggregateExecPluginCommands(paths, fileConfigs)
+
+	if len(empty) != 2 {
+		t.Fatalf("expected 2 scoped empty-command entries, got %d: %v", len(empty), empty)
+	}
+	// Should be sorted; "oidc (alpha)" < "oidc (beta)".
+	if empty[0] != "oidc (alpha)" || empty[1] != "oidc (beta)" {
+		t.Errorf("empty-command AuthInfos not scoped by file basename: got %v, want [oidc (alpha) oidc (beta)]", empty)
+	}
+}
+
+func injectEmptyExec(t *testing.T, path, userName string) {
+	t.Helper()
+	cfg, err := clientcmd.LoadFromFile(path)
+	if err != nil {
+		t.Fatalf("load %s: %v", path, err)
+	}
+	cfg.AuthInfos[userName] = &clientcmdapi.AuthInfo{
+		Exec: &clientcmdapi.ExecConfig{
+			APIVersion: "client.authentication.k8s.io/v1beta1",
+			Command:    "", // the bit we care about
+		},
+	}
+	data, err := clientcmd.Write(*cfg)
+	if err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("writeback %s: %v", path, err)
 	}
 }
 

--- a/internal/k8s/context_registry_test.go
+++ b/internal/k8s/context_registry_test.go
@@ -1,0 +1,298 @@
+package k8s
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// writeKubeconfig writes a minimal but valid kubeconfig to a temp file in
+// dir and returns its path. Each (ctxName, userName, clusterName) entry
+// becomes a context with matching Cluster/AuthInfo references. currentCtx
+// sets the CurrentContext field; pass "" to omit it.
+func writeKubeconfig(t *testing.T, dir, filename, currentCtx string, entries []kubeEntry) string {
+	t.Helper()
+	cfg := clientcmdapi.NewConfig()
+	for _, e := range entries {
+		cfg.Contexts[e.ctxName] = &clientcmdapi.Context{
+			Cluster:   e.clusterName,
+			AuthInfo:  e.userName,
+			Namespace: e.namespace,
+		}
+		if _, ok := cfg.Clusters[e.clusterName]; !ok {
+			cfg.Clusters[e.clusterName] = &clientcmdapi.Cluster{
+				Server: "https://" + e.clusterName,
+				// Base64 of "ca" — client-go validates presence on load.
+				InsecureSkipTLSVerify: true,
+			}
+		}
+		if _, ok := cfg.AuthInfos[e.userName]; !ok {
+			ai := &clientcmdapi.AuthInfo{}
+			if e.execCommand != "" {
+				ai.Exec = &clientcmdapi.ExecConfig{
+					APIVersion: "client.authentication.k8s.io/v1beta1",
+					Command:    e.execCommand,
+				}
+			} else {
+				ai.Token = "fake-token-for-" + e.userName
+			}
+			cfg.AuthInfos[e.userName] = ai
+		}
+	}
+	cfg.CurrentContext = currentCtx
+
+	path := filepath.Join(dir, filename)
+	data, err := clientcmd.Write(*cfg)
+	if err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+type kubeEntry struct {
+	ctxName     string
+	userName    string
+	clusterName string
+	namespace   string
+	execCommand string // empty = token auth
+}
+
+func TestBuildContextRegistry_NoCollisions(t *testing.T) {
+	dir := t.TempDir()
+	f1 := writeKubeconfig(t, dir, "a.yaml", "ctx-a", []kubeEntry{
+		{ctxName: "ctx-a", userName: "user-a", clusterName: "cluster-a"},
+	})
+	f2 := writeKubeconfig(t, dir, "b.yaml", "ctx-b", []kubeEntry{
+		{ctxName: "ctx-b", userName: "user-b", clusterName: "cluster-b"},
+	})
+
+	registry, fileConfigs := buildContextRegistry([]string{f1, f2})
+
+	if len(registry) != 2 {
+		t.Fatalf("registry size: got %d, want 2", len(registry))
+	}
+	if _, ok := registry["ctx-a"]; !ok {
+		t.Errorf("missing ctx-a in registry")
+	}
+	if _, ok := registry["ctx-b"]; !ok {
+		t.Errorf("missing ctx-b in registry")
+	}
+	if registry["ctx-a"].SourceFile != f1 {
+		t.Errorf("ctx-a sourceFile: got %s, want %s", registry["ctx-a"].SourceFile, f1)
+	}
+	if _, ok := fileConfigs[f1]; !ok {
+		t.Errorf("fileConfigs missing %s", f1)
+	}
+}
+
+// Core issue #519 scenario: two files share user AND cluster names but have
+// distinct context names. Both contexts should be registered under their
+// original names, and each entry should resolve to its own source file so
+// ExplicitPath loading gives the correct credentials.
+func TestBuildContextRegistry_SharedUserAndCluster_DistinctContexts(t *testing.T) {
+	dir := t.TempDir()
+	f1 := writeKubeconfig(t, dir, "kas-107.yaml", "kas-107", []kubeEntry{
+		{ctxName: "kas-107", userName: "me", clusterName: "gitlab_kas"},
+	})
+	f2 := writeKubeconfig(t, dir, "kas-108.yaml", "kas-108", []kubeEntry{
+		{ctxName: "kas-108", userName: "me", clusterName: "gitlab_kas"},
+	})
+
+	registry, _ := buildContextRegistry([]string{f1, f2})
+
+	if len(registry) != 2 {
+		t.Fatalf("registry size: got %d, want 2 — shared users/clusters must not collapse distinct contexts", len(registry))
+	}
+	if registry["kas-107"].SourceFile != f1 {
+		t.Errorf("kas-107 must resolve to file 1, got %s", registry["kas-107"].SourceFile)
+	}
+	if registry["kas-108"].SourceFile != f2 {
+		t.Errorf("kas-108 must resolve to file 2, got %s", registry["kas-108"].SourceFile)
+	}
+	// Neither should be renamed — the original names don't collide.
+	for qName := range registry {
+		if qName != "kas-107" && qName != "kas-108" {
+			t.Errorf("unexpected renamed context %q; distinct names must not be qualified", qName)
+		}
+	}
+}
+
+// When context names themselves collide across files, later files get their
+// context name qualified with the source file's basename.
+func TestBuildContextRegistry_ContextNameCollision(t *testing.T) {
+	dir := t.TempDir()
+	f1 := writeKubeconfig(t, dir, "prod.yaml", "my-ctx", []kubeEntry{
+		{ctxName: "my-ctx", userName: "user-a", clusterName: "cluster-a"},
+	})
+	f2 := writeKubeconfig(t, dir, "staging.yaml", "my-ctx", []kubeEntry{
+		{ctxName: "my-ctx", userName: "user-b", clusterName: "cluster-b"},
+	})
+
+	registry, _ := buildContextRegistry([]string{f1, f2})
+
+	if len(registry) != 2 {
+		t.Fatalf("registry size: got %d, want 2", len(registry))
+	}
+	if _, ok := registry["my-ctx"]; !ok {
+		t.Errorf("first file's context should keep its original name")
+	}
+	if registry["my-ctx"].SourceFile != f1 {
+		t.Errorf("my-ctx should resolve to f1")
+	}
+	if _, ok := registry["my-ctx (staging)"]; !ok {
+		names := []string{}
+		for n := range registry {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		t.Errorf("expected qualified name 'my-ctx (staging)' in registry; got: %v", names)
+	}
+	if registry["my-ctx (staging)"].SourceFile != f2 {
+		t.Errorf("qualified context should resolve to f2")
+	}
+	if registry["my-ctx (staging)"].OriginalName != "my-ctx" {
+		t.Errorf("original name must remain 'my-ctx' inside f2")
+	}
+}
+
+// Three-way collision: same context name across three files, all sharing the
+// same basename (two with different extensions). Third should fall back to
+// the numeric-suffix form.
+func TestBuildContextRegistry_ThreeWayCollision(t *testing.T) {
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	dirC := t.TempDir()
+	f1 := writeKubeconfig(t, dirA, "env.yaml", "ctx", []kubeEntry{
+		{ctxName: "ctx", userName: "u1", clusterName: "c1"},
+	})
+	// Same basename after trimming extension — forces numeric suffix path.
+	f2 := writeKubeconfig(t, dirB, "env.yml", "ctx", []kubeEntry{
+		{ctxName: "ctx", userName: "u2", clusterName: "c2"},
+	})
+	f3 := writeKubeconfig(t, dirC, "env.yaml", "ctx", []kubeEntry{
+		{ctxName: "ctx", userName: "u3", clusterName: "c3"},
+	})
+
+	registry, _ := buildContextRegistry([]string{f1, f2, f3})
+
+	if len(registry) != 3 {
+		t.Fatalf("registry size: got %d, want 3", len(registry))
+	}
+	// f1: plain "ctx"
+	if e, ok := registry["ctx"]; !ok || e.SourceFile != f1 {
+		t.Errorf("'ctx' should resolve to f1")
+	}
+	// f2: "ctx (env)"
+	if e, ok := registry["ctx (env)"]; !ok || e.SourceFile != f2 {
+		t.Errorf("'ctx (env)' should resolve to f2")
+	}
+	// f3: "ctx (env #2)" — same basename as f2 after ext trim.
+	if e, ok := registry["ctx (env #2)"]; !ok || e.SourceFile != f3 {
+		names := []string{}
+		for n := range registry {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		t.Errorf("'ctx (env #2)' should resolve to f3; registry has: %v", names)
+	}
+}
+
+func TestPickInitialContext_PrefersFirstFileCurrentContext(t *testing.T) {
+	dir := t.TempDir()
+	f1 := writeKubeconfig(t, dir, "first.yaml", "from-first", []kubeEntry{
+		{ctxName: "from-first", userName: "u1", clusterName: "c1"},
+	})
+	f2 := writeKubeconfig(t, dir, "second.yaml", "from-second", []kubeEntry{
+		{ctxName: "from-second", userName: "u2", clusterName: "c2"},
+	})
+
+	paths := []string{f1, f2}
+	registry, fileConfigs := buildContextRegistry(paths)
+	qName, entry, ok := pickInitialContext(paths, registry, fileConfigs)
+	if !ok {
+		t.Fatal("expected initial context")
+	}
+	if qName != "from-first" {
+		t.Errorf("expected 'from-first', got %q", qName)
+	}
+	if entry.SourceFile != f1 {
+		t.Errorf("expected entry from f1, got %s", entry.SourceFile)
+	}
+}
+
+func TestPickInitialContext_FallsBackWhenCurrentContextEmpty(t *testing.T) {
+	dir := t.TempDir()
+	// First file has no CurrentContext; second does.
+	f1 := writeKubeconfig(t, dir, "first.yaml", "", []kubeEntry{
+		{ctxName: "from-first", userName: "u1", clusterName: "c1"},
+	})
+	f2 := writeKubeconfig(t, dir, "second.yaml", "from-second", []kubeEntry{
+		{ctxName: "from-second", userName: "u2", clusterName: "c2"},
+	})
+
+	paths := []string{f1, f2}
+	registry, fileConfigs := buildContextRegistry(paths)
+	qName, _, ok := pickInitialContext(paths, registry, fileConfigs)
+	if !ok {
+		t.Fatal("expected initial context")
+	}
+	if qName != "from-second" {
+		t.Errorf("expected 'from-second', got %q", qName)
+	}
+}
+
+func TestPickInitialContext_NoCurrentContextAnywhere(t *testing.T) {
+	dir := t.TempDir()
+	f1 := writeKubeconfig(t, dir, "first.yaml", "", []kubeEntry{
+		{ctxName: "only-ctx", userName: "u1", clusterName: "c1"},
+	})
+
+	paths := []string{f1}
+	registry, fileConfigs := buildContextRegistry(paths)
+	qName, _, ok := pickInitialContext(paths, registry, fileConfigs)
+	if !ok {
+		t.Fatal("expected initial context from any-ctx fallback")
+	}
+	if qName != "only-ctx" {
+		t.Errorf("expected 'only-ctx', got %q", qName)
+	}
+}
+
+func TestAggregateExecPluginCommands_UniqueAcrossFiles(t *testing.T) {
+	dir := t.TempDir()
+	// File 1: user 'oidc' with kubectl exec plugin.
+	f1 := writeKubeconfig(t, dir, "a.yaml", "ctx-a", []kubeEntry{
+		{ctxName: "ctx-a", userName: "oidc", clusterName: "c1", execCommand: "kubectl"},
+	})
+	// File 2: same user name, different exec plugin — under Precedence merge
+	// this second one would be silently dropped. Aggregation must see both.
+	f2 := writeKubeconfig(t, dir, "b.yaml", "ctx-b", []kubeEntry{
+		{ctxName: "ctx-b", userName: "oidc", clusterName: "c2", execCommand: "gke-gcloud-auth-plugin"},
+	})
+
+	paths := []string{f1, f2}
+	_, fileConfigs := buildContextRegistry(paths)
+	cmds, empty := aggregateExecPluginCommands(paths, fileConfigs)
+
+	if len(empty) != 0 {
+		t.Errorf("expected no empty-command AuthInfos, got %v", empty)
+	}
+	wantCmds := map[string]bool{"kubectl": false, "gke-gcloud-auth-plugin": false}
+	for _, c := range cmds {
+		if _, ok := wantCmds[c]; ok {
+			wantCmds[c] = true
+		}
+	}
+	for c, seen := range wantCmds {
+		if !seen {
+			t.Errorf("expected exec plugin %q in aggregated list, got %v", c, cmds)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2489,8 +2489,10 @@ func (s *Server) handleCAPIClusterConnect(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Merge into the user's kubeconfig
-	mergedPath, err := k8s.MergeAndSwitchContext(kubeconfigData, contextName)
+	// Merge into the user's kubeconfig. The returned qualifiedName reflects
+	// any disambiguation the registry had to do (e.g. if another file already
+	// owned this context name). Always switch using the qualified name.
+	qualifiedName, mergedPath, err := k8s.MergeAndSwitchContext(kubeconfigData, contextName)
 	if err != nil {
 		log.Printf("[capi] Failed to merge kubeconfig for cluster %s/%s: %v", ns, name, err)
 		s.writeError(w, http.StatusInternalServerError, "failed to connect: "+err.Error())
@@ -2504,10 +2506,10 @@ func (s *Server) handleCAPIClusterConnect(w http.ResponseWriter, r *http.Request
 	}
 
 	// Switch to the new context
-	if err := k8s.PerformContextSwitch(contextName); err != nil {
+	if err := k8s.PerformContextSwitch(qualifiedName); err != nil {
 		k8s.SetConnectionStatus(k8s.ConnectionStatus{
 			State:     k8s.StateDisconnected,
-			Context:   contextName,
+			Context:   qualifiedName,
 			Error:     err.Error(),
 			ErrorType: k8s.ClassifyError(err),
 		})
@@ -2521,11 +2523,11 @@ func (s *Server) handleCAPIClusterConnect(w http.ResponseWriter, r *http.Request
 		ClusterName: k8s.GetClusterName(),
 	})
 
-	log.Printf("[capi] Connected to workload cluster %s/%s (context: %s, kubeconfig: %s)", ns, name, contextName, mergedPath)
+	log.Printf("[capi] Connected to workload cluster %s/%s (context: %s, kubeconfig: %s)", ns, name, qualifiedName, mergedPath)
 
 	s.writeJSON(w, map[string]string{
 		"status":  "connected",
-		"context": contextName,
+		"context": qualifiedName,
 	})
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2523,7 +2523,12 @@ func (s *Server) handleCAPIClusterConnect(w http.ResponseWriter, r *http.Request
 		ClusterName: k8s.GetClusterName(),
 	})
 
-	log.Printf("[capi] Connected to workload cluster %s/%s (context: %s, kubeconfig: %s)", ns, name, qualifiedName, mergedPath)
+	// Use %q on user-influenced values (context name derived from an uploaded
+	// kubeconfig YAML, temp path partly includes the system TMPDIR) so a
+	// crafted context name can't inject forged log lines when Radar's stderr
+	// is scraped by a log aggregator. CodeQL alert "Log entries created from
+	// user input".
+	log.Printf("[capi] Connected to workload cluster %s/%s (context: %q, kubeconfig: %q)", ns, name, qualifiedName, mergedPath)
 
 	s.writeJSON(w, map[string]string{
 		"status":  "connected",


### PR DESCRIPTION
Fixes #519. Also fixes #411 and fixes #514 — the three are the same root-cause bug viewed from different angles.

## The bug

Radar handed every discovered kubeconfig file to client-go's `ClientConfigLoadingRules.Precedence` merger. That merge resolves `clusters`, `users`, and `contexts` on a **first-wins-by-name** basis and silently drops later duplicates. So when two files share a user name (e.g. both define `user: oidc` or `user: me`) or a cluster name, the second file's definition is thrown away at load time. Switching to the "second" context then ends up sending the first file's token to the first file's server — which is why:

- **#411**: switching clusters with multiple kubeconfigs produces "server has asked for credentials" — the later file's creds were discarded.
- **#514**: OIDC only works for the first cluster because every file's `user: oidc` collapsed into one plugin invocation.
- **#519**: two files with `user: me` and `cluster: gitlab_kas` lose one entry completely — the reporter explicitly links it to #514.

The existing `"Kubeconfig loaded: files=34, contexts=18"` log line was the only hint: 16 contexts silently vanished during merge.

## The fix

Replace the merge with a **per-file context registry**. Each kubeconfig is loaded via `ExplicitPath` as its own island. `GetAvailableContexts` enumerates the registry across all files; `SwitchContext` looks up the qualified context name, resolves to the source file + original-name inside it, and loads only that file. Shared user/cluster names across files can't collide because they're never asked to — each ExplicitPath load sees only one file's maps.

When two files happen to share a context *name* (not just a user or cluster name), the registry qualifies the second one with its source filename, e.g. `my-ctx (staging)`. The common case — distinct context names with shared user/cluster names — sees no rename and no visible UI change. That matches the #519 repro: both files have `user: me` but contexts `kas-107` and `kas-108`, which now both work under their original names.

KUBECONFIG env vars with multiple colon-separated paths go through the same isolated loader. Single-file mode is unchanged. The CAPI flow (`MergeAndSwitchContext`) promotes to isolated-load mode on first use and returns the qualified context name so the caller switches correctly even if the incoming CAPI context name collides with an existing one.

## Verification

- Four new table-driven tests in `context_registry_test.go` cover no-collision, the exact #519 shared-user-and-cluster case, context-name collision (gets qualified), and a three-way collision (numeric-suffix fallback).
- Ran the full #519 repro end-to-end against a live binary: two files with identical `cluster: shared-cluster` / `user: shared-user` but different server URLs. Both contexts are visible in the dropdown under their original names; switching to each one correctly routes to *that file's* server URL. Under the old code, both would have hit the first file's server.
- Full test suite (`go test ./...`) green.

Diagnostic logging is now honest: the `contexts=N` number is the sum across all files rather than the post-merge count, so "files discovered vs contexts reachable" is always `N == M` unless a file fails to parse.