### PR TITLE
cloud + server: advertise version/namespace + self-upgrade endpoint

### DIFF
--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -249,6 +249,7 @@ func main() {
 				Token:       *cloudToken,
 				ClusterID:   *cloudClusterName,
 				ClusterName: *cloudClusterName,
+				Namespace:   os.Getenv("MY_POD_NAMESPACE"),
 				Handler:     srv.Handler(),
 			})
 			if runErr != nil && !errors.Is(runErr, context.Canceled) {

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -37,6 +37,13 @@ type Config struct {
 	// ClusterName is the human-readable label the user chose in the wizard.
 	ClusterName string
 
+	// Namespace is the Kubernetes namespace Radar is running in. Sent to the
+	// hub on connect so it knows where to target Deployment patches on upgrade.
+	// Populated from MY_POD_NAMESPACE (downward API); empty string is fine —
+	// the hub stores whatever it receives and surfaces a "reconnect required"
+	// error if the field is absent when an upgrade is requested.
+	Namespace string
+
 	// Handler is the HTTP handler to serve over tunneled streams — typically
 	// Radar's Server.Handler() (chi router).
 	Handler http.Handler

--- a/internal/cloud/dialer.go
+++ b/internal/cloud/dialer.go
@@ -26,6 +26,10 @@ func dial(ctx context.Context, cfg Config) (*yamux.Session, error) {
 
 	headers := http.Header{}
 	headers.Set("Authorization", "Bearer "+cfg.Token)
+	headers.Set("X-Radar-Version", Version)
+	if cfg.Namespace != "" {
+		headers.Set("X-Radar-Namespace", cfg.Namespace)
+	}
 
 	dialer := *websocket.DefaultDialer
 	dialer.HandshakeTimeout = 10 * time.Second

--- a/internal/cloud/version.go
+++ b/internal/cloud/version.go
@@ -1,0 +1,8 @@
+package cloud
+
+// Version is the Radar binary version. Set at build time with:
+//
+//	-ldflags "-X github.com/skyhook-io/radar/internal/cloud.Version=v1.5.2"
+//
+// Falls back to "dev" for local builds.
+var Version = "dev"

--- a/internal/server/selfupgrade.go
+++ b/internal/server/selfupgrade.go
@@ -16,7 +16,7 @@ import (
 )
 
 // handleSelfUpgrade patches this Radar Deployment's container image so the
-// pod restarts on a new version. Called by Radar Hub's upgrade-agent endpoint
+// pod restarts on a new version. Called by Radar Cloud's upgrade-agent endpoint
 // over the yamux tunnel — no user terminal or cloud credentials needed.
 //
 // Security: only images under ghcr.io/skyhook-io/radar: are accepted.

--- a/internal/server/selfupgrade.go
+++ b/internal/server/selfupgrade.go
@@ -83,11 +83,11 @@ func (s *Server) handleSelfUpgrade(w http.ResponseWriter, r *http.Request) {
 			s.writeError(w, http.StatusForbidden, "SA lacks patch permission on this Deployment (rbac.selfUpgrade=true?)")
 			return
 		}
-		log.Printf("[self-upgrade] patch failed: ns=%s deploy=%s image=%s err=%v", ns, deployment, req.Image, err)
+		log.Printf("[self-upgrade] patch failed: ns=%s deploy=%s tag=%s err=%v", ns, deployment, tag, err)
 		s.writeError(w, http.StatusInternalServerError, "patch failed")
 		return
 	}
 
-	log.Printf("[self-upgrade] initiated: ns=%s deploy=%s image=%s", ns, deployment, req.Image)
+	log.Printf("[self-upgrade] initiated: ns=%s deploy=%s tag=%s", ns, deployment, tag)
 	s.writeJSON(w, map[string]string{"status": "upgrade initiated", "image": req.Image})
 }

--- a/internal/server/selfupgrade.go
+++ b/internal/server/selfupgrade.go
@@ -1,0 +1,93 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+)
+
+// handleSelfUpgrade patches this Radar Deployment's container image so the
+// pod restarts on a new version. Called by Radar Hub's upgrade-agent endpoint
+// over the yamux tunnel — no user terminal or cloud credentials needed.
+//
+// Security: only images under ghcr.io/skyhook-io/radar: are accepted.
+// The patch uses the pod's ServiceAccount (not user impersonation) — the SA
+// must have patch rights on its own Deployment (Helm rbac.selfUpgrade: true).
+// MY_POD_NAMESPACE and MY_DEPLOYMENT_NAME must be set by the chart (downward
+// API + static template value respectively) or the endpoint returns 503.
+func (s *Server) handleSelfUpgrade(w http.ResponseWriter, r *http.Request) {
+	ns := os.Getenv("MY_POD_NAMESPACE")
+	deployment := os.Getenv("MY_DEPLOYMENT_NAME")
+	if ns == "" || deployment == "" {
+		s.writeError(w, http.StatusServiceUnavailable,
+			"self-upgrade not configured (set rbac.selfUpgrade=true in Helm values)")
+		return
+	}
+
+	var req struct {
+		Image string `json:"image"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	const allowedRepo = "ghcr.io/skyhook-io/radar:"
+	if !strings.HasPrefix(req.Image, allowedRepo) {
+		s.writeError(w, http.StatusBadRequest, "image must be from ghcr.io/skyhook-io/radar")
+		return
+	}
+	tag := strings.TrimPrefix(req.Image, allowedRepo)
+	if tag == "" || len(tag) > 64 {
+		s.writeError(w, http.StatusBadRequest, "invalid image tag")
+		return
+	}
+
+	// Use the SA's ambient client, not the impersonated user client.
+	// The SA has patch rights on its own Deployment; a hub-forwarded user
+	// identity is a Cloud user ID, not a K8s principal, so impersonation
+	// would fail anyway.
+	client := k8s.GetClient()
+	if client == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "k8s client not available")
+		return
+	}
+
+	patch := []byte(fmt.Sprintf(
+		`{"spec":{"template":{"spec":{"containers":[{"name":"radar","image":%q}]}}}}`,
+		req.Image,
+	))
+
+	_, err := client.AppsV1().Deployments(ns).Patch(
+		r.Context(),
+		deployment,
+		types.StrategicMergePatchType,
+		patch,
+		metav1.PatchOptions{},
+	)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			s.writeError(w, http.StatusNotFound, "deployment not found")
+			return
+		}
+		if apierrors.IsForbidden(err) {
+			s.writeError(w, http.StatusForbidden, "SA lacks patch permission on this Deployment (rbac.selfUpgrade=true?)")
+			return
+		}
+		log.Printf("[self-upgrade] patch failed: ns=%s deploy=%s image=%s err=%v", ns, deployment, req.Image, err)
+		s.writeError(w, http.StatusInternalServerError, "patch failed")
+		return
+	}
+
+	log.Printf("[self-upgrade] initiated: ns=%s deploy=%s image=%s", ns, deployment, req.Image)
+	s.writeJSON(w, map[string]string{"status": "upgrade initiated", "image": req.Image})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -357,6 +357,12 @@ func (s *Server) setupRoutes() {
 			r.Post("/github/star", s.handleGitHubStar)
 			r.Post("/github/dismiss", s.handleGitHubDismiss)
 
+			// Self-upgrade: Hub calls this over the yamux tunnel to patch this
+			// Deployment's image. Uses the SA client (not user impersonation).
+			// Requires MY_POD_NAMESPACE + MY_DEPLOYMENT_NAME env vars (set by
+			// the Helm chart when rbac.selfUpgrade=true).
+			r.Post("/agent/self-upgrade", s.handleSelfUpgrade)
+
 			// Settings (persisted user preferences)
 			r.Get("/settings", s.handleGetSettings)
 			r.Put("/settings", s.handlePutSettings)


### PR DESCRIPTION
## What

Two related additions enabling Radar Hub's one-click upgrade feature.

### 1. Advertise version + namespace on tunnel connect (`internal/cloud/`)

Sends `X-Radar-Version` and `X-Radar-Namespace` headers when dialing Radar Cloud so the hub can store the running agent version and target the right namespace.

- `internal/cloud/version.go` — `Version` var, set at build time via `-ldflags "-X .../cloud.Version=vX.Y.Z"`
- `cloud.Config.Namespace` — wired from `MY_POD_NAMESPACE` (downward API, injected by the Helm chart)
- `dialer.go` — sets both headers before the WebSocket upgrade

### 2. Self-upgrade endpoint (`internal/server/selfupgrade.go`)

`POST /api/agent/self-upgrade` receives `{"image": "ghcr.io/skyhook-io/radar:vX.Y.Z"}` from the hub over the yamux tunnel and patches this Deployment using the SA's ambient permissions — no user terminal or cloud credentials needed.

- Image validated against `ghcr.io/skyhook-io/radar:` prefix
- Uses `k8s.GetClient()` (SA perms) not the user-impersonated client
- Reads `MY_POD_NAMESPACE` + `MY_DEPLOYMENT_NAME` env vars set by the Helm chart; returns 503 if absent (clear error for older chart installs)

Backwards-compatible: hubs that don't call the endpoint and clusters that don't have the env vars set behave as before.

Part of: skyhook-dev/radar-hub#17