### PR TITLE
logs: explicit palette — fix dark log viewer unreadable on light page

### DIFF
--- a/packages/k8s-ui/src/components/logs/JsonLogLine.tsx
+++ b/packages/k8s-ui/src/components/logs/JsonLogLine.tsx
@@ -1,17 +1,20 @@
 import { useState, useMemo } from 'react'
 import { ChevronRight, ChevronDown } from 'lucide-react'
-import { getLevelColor } from '../../utils/log-format'
 import type { LogLevel } from './useLogBuffer'
+import { getLogPalette, getLogLevelColor } from './log-palette'
 
 interface JsonLogLineProps {
   content: string
   level: LogLevel
   wordWrap: boolean
+  /** Dark/light palette selector. Defaults to `true` for the dark-by-default viewer. */
+  isDark?: boolean
 }
 
-export function JsonLogLine({ content, level, wordWrap }: JsonLogLineProps) {
+export function JsonLogLine({ content, level, wordWrap, isDark = true }: JsonLogLineProps) {
   const [expanded, setExpanded] = useState(false)
-  const levelColor = getLevelColor(level)
+  const palette = useMemo(() => getLogPalette(isDark), [isDark])
+  const levelColor = getLogLevelColor(level, isDark)
 
   const parsed = useMemo(() => {
     try {
@@ -36,17 +39,17 @@ export function JsonLogLine({ content, level, wordWrap }: JsonLogLineProps) {
     <span className={levelColor}>
       <button
         onClick={() => setExpanded(!expanded)}
-        className="inline-flex items-center gap-0.5 hover:bg-theme-surface/50 rounded px-0.5 -ml-0.5 align-middle"
+        className={`inline-flex items-center gap-0.5 ${palette.hoverSurface} rounded px-0.5 -ml-0.5 align-middle`}
       >
         {expanded
-          ? <ChevronDown className="w-3 h-3 shrink-0 text-theme-text-tertiary" />
-          : <ChevronRight className="w-3 h-3 shrink-0 text-theme-text-tertiary" />
+          ? <ChevronDown className={`w-3 h-3 shrink-0 ${palette.textTertiary}`} />
+          : <ChevronRight className={`w-3 h-3 shrink-0 ${palette.textTertiary}`} />
         }
       </button>
       {!expanded ? (
         <span className={wordWrap ? 'whitespace-pre-wrap break-all' : 'whitespace-pre'}>
           {summary}
-          <span className="text-theme-text-tertiary ml-1">{`{${fieldCount} fields}`}</span>
+          <span className={`${palette.textTertiary} ml-1`}>{`{${fieldCount} fields}`}</span>
         </span>
       ) : (
         <span className={`block ml-4 ${wordWrap ? 'whitespace-pre-wrap break-all' : 'whitespace-pre'}`}>

--- a/packages/k8s-ui/src/components/logs/LogCore.tsx
+++ b/packages/k8s-ui/src/components/logs/LogCore.tsx
@@ -1,21 +1,29 @@
 import { useRef, useCallback, useState, useMemo, useEffect, type ReactNode } from 'react'
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso'
-import { Play, Square, Download, Search, X, Terminal, RotateCcw, ChevronUp, ChevronDown, ChevronRight, CaseSensitive, Regex, WrapText, Clock, Copy, Trash2, Filter, Braces, Palette, ListCollapse } from 'lucide-react'
+import { Play, Square, Download, Search, X, Terminal, RotateCcw, ChevronUp, ChevronDown, ChevronRight, CaseSensitive, Regex, WrapText, Clock, Copy, Trash2, Filter, Braces, Palette, ListCollapse, Sun, Moon } from 'lucide-react'
 import type { LogEntry, LogLevel } from './useLogBuffer'
 import { useLogSearch } from './useLogSearch'
 import { StructuredLogLine } from './StructuredLogLine'
 import { Tooltip } from '../ui/Tooltip'
 import {
   formatLogTimestamp,
-  getLevelColor,
   highlightSearchMatches,
   stripAnsi,
   ansiToHtml,
   type TimestampFormat,
   TIMESTAMP_FORMAT_LABELS,
 } from '../../utils/log-format'
+import { getLogPalette, getLogLevelColor, type LogPalette } from './log-palette'
 
 export type DownloadFormat = 'txt' | 'json' | 'csv'
+
+/**
+ * `toolbarExtra` may be a plain ReactNode, or a function that receives the
+ * current dark/light context so wrappers can produce palette-matched controls.
+ */
+export type ToolbarExtraRenderer =
+  | ReactNode
+  | ((ctx: { isDark: boolean; palette: LogPalette }) => ReactNode)
 
 interface LogCoreProps {
   entries: LogEntry[]
@@ -26,20 +34,40 @@ interface LogCoreProps {
   onRefresh: () => void
   onDownload: (format: DownloadFormat) => void
   onClear?: () => void
-  toolbarExtra?: ReactNode
+  toolbarExtra?: ToolbarExtraRenderer
   showPodName?: boolean
   emptyMessage?: string
   errorMessage?: string | null
-  /** Optionally force dark styling for embedded consumers. */
+  /**
+   * Optional initial dark/light override. When provided, pins the starting
+   * value regardless of `localStorage['radar-logs-dark']`. Users can still
+   * flip the mode via the viewer's built-in Sun/Moon toggle.
+   * @default true
+   */
   forceDark?: boolean
 }
 
-const LEVEL_OPTIONS: { level: LogLevel; label: string; color: string; activeColor: string }[] = [
-  { level: 'error', label: 'ERR', color: 'text-red-400', activeColor: 'bg-red-500/30 dark:bg-red-500/20 text-red-600 dark:text-red-400 border-red-500/60 dark:border-red-500/40' },
-  { level: 'warn', label: 'WARN', color: 'text-yellow-400', activeColor: 'bg-yellow-400/30 dark:bg-yellow-500/20 text-yellow-700 dark:text-yellow-400 border-yellow-500/60 dark:border-yellow-500/40' },
-  { level: 'info', label: 'INFO', color: 'text-blue-400', activeColor: 'bg-blue-500/25 dark:bg-blue-500/20 text-blue-700 dark:text-blue-400 border-blue-500/60 dark:border-blue-500/40' },
-  { level: 'debug', label: 'DBG', color: 'text-theme-text-secondary', activeColor: 'bg-theme-surface text-theme-text-secondary border-theme-border-light' },
+interface LevelOption {
+  level: LogLevel
+  label: string
+}
+
+const LEVEL_OPTIONS: LevelOption[] = [
+  { level: 'error', label: 'ERR' },
+  { level: 'warn', label: 'WARN' },
+  { level: 'info', label: 'INFO' },
+  { level: 'debug', label: 'DBG' },
 ]
+
+function getLevelActiveColor(level: LogLevel, palette: LogPalette): string {
+  switch (level) {
+    case 'error': return palette.levelActiveError
+    case 'warn': return palette.levelActiveWarn
+    case 'info': return palette.levelActiveInfo
+    case 'debug': return palette.levelActiveDebug
+    default: return palette.levelActiveDebug
+  }
+}
 
 const TIMESTAMP_FORMAT_ORDER: TimestampFormat[] = [
   'time-local', 'time-utc', 'iso-local', 'iso-utc', 'relative', 'epoch',
@@ -82,10 +110,30 @@ export function LogCore({
   showPodName = false,
   emptyMessage = 'No logs available',
   errorMessage,
-  forceDark = false,
+  forceDark,
 }: LogCoreProps) {
   const virtuosoRef = useRef<VirtuosoHandle>(null)
   const [atBottom, setAtBottom] = useState(true)
+  // Dark/light for the log viewer is self-contained — the viewer's own Sun/Moon
+  // toggle flips this, persisted to localStorage. `forceDark` prop pins the
+  // initial value when explicitly provided.
+  const [isDark, setIsDark] = useState<boolean>(() => {
+    if (typeof forceDark === 'boolean') return forceDark
+    try {
+      const v = localStorage.getItem('radar-logs-dark')
+      if (v === 'false') return false
+      if (v === 'true') return true
+    } catch {}
+    return true
+  })
+  const palette = useMemo(() => getLogPalette(isDark), [isDark])
+  const toggleDark = useCallback(() => {
+    setIsDark(prev => {
+      const next = !prev
+      try { localStorage.setItem('radar-logs-dark', String(next)) } catch {}
+      return next
+    })
+  }, [])
   const [wordWrap, setWordWrap] = useState(() => {
     try { return localStorage.getItem('radar-logs-wrap') !== 'false' } catch { return true }
   })
@@ -296,14 +344,32 @@ export function LogCore({
     })
   }, [groupedEntries.length])
 
+  const toolbarExtraNode = typeof toolbarExtra === 'function'
+    ? toolbarExtra({ isDark, palette })
+    : toolbarExtra
+
+  // Shared "inactive toolbar button" classes. All strings are literals so
+  // Tailwind's class scanner picks them up. Two variants differ only in the
+  // default text color (secondary vs tertiary).
+  const iconBtnInactive = isDark
+    ? 'p-1.5 rounded transition-colors text-slate-400 hover:text-slate-100 hover:bg-slate-800'
+    : 'p-1.5 rounded transition-colors text-slate-600 hover:text-slate-900 hover:bg-slate-200'
+  const iconBtnInactiveTertiary = isDark
+    ? 'p-1.5 rounded transition-colors text-slate-500 hover:text-slate-100 hover:bg-slate-800'
+    : 'p-1.5 rounded transition-colors text-slate-400 hover:text-slate-900 hover:bg-slate-200'
+  // "disabled → tertiary on hover" for inactive level filter chips.
+  const levelChipInactive = isDark
+    ? 'border-transparent text-slate-600 hover:text-slate-500'
+    : 'border-transparent text-slate-300 hover:text-slate-400'
+
   return (
     <div
-      className={`flex flex-col h-full bg-theme-base${forceDark ? ' dark' : ''}`}
-      style={{ colorScheme: forceDark ? 'dark' : undefined, fontFamily: "'SF Mono', 'Cascadia Code', 'Fira Code', Menlo, Consolas, 'DejaVu Sans Mono', monospace" }}
+      className={`flex flex-col h-full ${palette.containerBg}`}
+      style={{ colorScheme: isDark ? 'dark' : 'light', fontFamily: "'SF Mono', 'Cascadia Code', 'Fira Code', Menlo, Consolas, 'DejaVu Sans Mono', monospace" }}
     >
       {/* Toolbar */}
-      <div className="flex items-center gap-2 px-3 py-2 border-b border-theme-border bg-theme-surface">
-        {toolbarExtra}
+      <div className={`flex items-center gap-2 px-3 py-2 border-b ${palette.border} ${palette.toolbarBg}`}>
+        {toolbarExtraNode}
 
         {/* Stream / Stop toggle — only shown when streaming is supported */}
         {onStartStream && (
@@ -313,7 +379,7 @@ export function LogCore({
               className={`flex items-center gap-1.5 px-2 py-1.5 text-xs rounded transition-colors ${
                 isStreaming
                   ? 'bg-green-600 text-white hover:bg-green-700'
-                  : 'bg-theme-elevated text-theme-text-secondary hover:bg-theme-hover'
+                  : `${palette.elevatedBg} ${palette.textSecondary} ${palette.hoverBg}`
               }`}
             >
               {isStreaming ? <Square className="w-3 h-3" /> : <Play className="w-3 h-3" />}
@@ -327,7 +393,7 @@ export function LogCore({
           <button
             onClick={onRefresh}
             disabled={isLoading || isStreaming}
-            className="flex items-center gap-1.5 px-2 py-1.5 text-xs rounded bg-theme-elevated text-theme-text-secondary hover:bg-theme-hover disabled:opacity-50 disabled:cursor-not-allowed"
+            className={`flex items-center gap-1.5 px-2 py-1.5 text-xs rounded ${palette.elevatedBg} ${palette.textSecondary} ${palette.hoverBg} disabled:opacity-50 disabled:cursor-not-allowed`}
           >
             <RotateCcw className={`w-3 h-3 ${isLoading ? 'animate-spin' : ''}`} />
           </button>
@@ -344,8 +410,8 @@ export function LogCore({
                   onClick={() => toggleLevel(opt.level)}
                   className={`px-1.5 py-0.5 text-[10px] font-medium rounded border transition-colors ${
                     active
-                      ? opt.activeColor
-                      : 'border-transparent text-theme-text-disabled hover:text-theme-text-tertiary'
+                      ? getLevelActiveColor(opt.level, palette)
+                      : levelChipInactive
                   }`}
                 >
                   {opt.label}{count > 0 ? ` ${count}` : ''}
@@ -363,7 +429,7 @@ export function LogCore({
             <button
               onClick={() => setExpandAllStructured(prev => !prev)}
               className={`p-1.5 rounded transition-colors ${
-                expandAllStructured ? 'btn-brand-toggle' : 'text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated'
+                expandAllStructured ? 'btn-brand-toggle' : iconBtnInactive
               }`}
             >
               <Braces className="w-4 h-4" />
@@ -377,7 +443,7 @@ export function LogCore({
             <button
               onClick={toggleTimestamps}
               className={`p-1.5 rounded-l transition-colors ${
-                showTimestamps ? 'btn-brand-toggle' : 'text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated'
+                showTimestamps ? 'btn-brand-toggle' : iconBtnInactive
               }`}
             >
               <Clock className="w-4 h-4" />
@@ -388,7 +454,7 @@ export function LogCore({
               <button
                 onClick={() => setShowTsMenu(prev => !prev)}
                 className={`px-2 py-1.5 rounded-r text-[10px] font-medium transition-colors whitespace-nowrap ${
-                  showTimestamps ? 'btn-brand-toggle' : 'text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-elevated'
+                  showTimestamps ? 'btn-brand-toggle' : iconBtnInactiveTertiary
                 }`}
                 aria-label="Pick timestamp format"
               >
@@ -399,20 +465,20 @@ export function LogCore({
               </button>
             </Tooltip>
             {showTsMenu && (
-              <div className="absolute top-full right-0 mt-1 w-44 bg-theme-elevated border border-theme-border rounded-lg shadow-lg z-50">
-                <div className="px-3 py-1.5 text-[10px] uppercase tracking-wide text-theme-text-tertiary border-b border-theme-border">
+              <div className={`absolute top-full right-0 mt-1 w-44 ${palette.menuBg} border ${palette.border} rounded-lg shadow-lg z-50`}>
+                <div className={`px-3 py-1.5 text-[10px] uppercase tracking-wide ${palette.textTertiary} border-b ${palette.border}`}>
                   Timestamp format
                 </div>
                 {TIMESTAMP_FORMAT_ORDER.map(fmt => (
                   <button
                     key={fmt}
                     onClick={() => pickTsFormat(fmt)}
-                    className={`w-full text-left px-3 py-1.5 text-xs hover:bg-theme-hover flex items-center justify-between ${
-                      tsFormat === fmt ? 'text-theme-text-primary' : 'text-theme-text-secondary'
+                    className={`w-full text-left px-3 py-1.5 text-xs ${palette.hoverBg} flex items-center justify-between ${
+                      tsFormat === fmt ? palette.textPrimary : palette.textSecondary
                     }`}
                   >
                     <span>{TIMESTAMP_FORMAT_LABELS[fmt]}</span>
-                    {tsFormat === fmt && <span className="text-[10px] text-blue-400">✓</span>}
+                    {tsFormat === fmt && <span className={`text-[10px] ${isDark ? 'text-blue-400' : 'text-blue-700'}`}>✓</span>}
                   </button>
                 ))}
               </div>
@@ -425,7 +491,7 @@ export function LogCore({
           <button
             onClick={toggleCollapseStacks}
             className={`p-1.5 rounded transition-colors ${
-              collapseStacks ? 'btn-brand-toggle' : 'text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated'
+              collapseStacks ? 'btn-brand-toggle' : iconBtnInactive
             }`}
           >
             <ListCollapse className="w-4 h-4" />
@@ -437,7 +503,7 @@ export function LogCore({
           <button
             onClick={toggleAnsi}
             className={`p-1.5 rounded transition-colors ${
-              ansiEnabled ? 'btn-brand-toggle' : 'text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated'
+              ansiEnabled ? 'btn-brand-toggle' : iconBtnInactive
             }`}
           >
             <Palette className="w-4 h-4" />
@@ -449,7 +515,7 @@ export function LogCore({
           <button
             onClick={toggleWrap}
             className={`p-1.5 rounded transition-colors ${
-              wordWrap ? 'btn-brand-toggle' : 'text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated'
+              wordWrap ? 'btn-brand-toggle' : iconBtnInactive
             }`}
           >
             <WrapText className="w-4 h-4" />
@@ -461,10 +527,21 @@ export function LogCore({
           <button
             onClick={() => search.isOpen ? search.close() : search.open()}
             className={`p-1.5 rounded transition-colors ${
-              search.isOpen ? 'btn-brand-toggle' : 'text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated'
+              search.isOpen ? 'btn-brand-toggle' : iconBtnInactive
             }`}
           >
             <Search className="w-4 h-4" />
+          </button>
+        </Tooltip>
+
+        {/* Dark/light mode toggle — self-contained, doesn't depend on page theme */}
+        <Tooltip content={isDark ? 'Switch to light mode' : 'Switch to dark mode'} delay={TIP_DELAY} position="bottom">
+          <button
+            onClick={toggleDark}
+            className={iconBtnInactive}
+            aria-label={isDark ? 'Switch log viewer to light mode' : 'Switch log viewer to dark mode'}
+          >
+            {isDark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
           </button>
         </Tooltip>
 
@@ -473,18 +550,18 @@ export function LogCore({
           <Tooltip content="Download logs" delay={TIP_DELAY} position="bottom">
             <button
               onClick={() => setShowDownloadMenu(prev => !prev)}
-              className="p-1.5 rounded text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated"
+              className={iconBtnInactive}
             >
               <Download className="w-4 h-4" />
             </button>
           </Tooltip>
           {showDownloadMenu && (
-            <div className="absolute top-full right-0 mt-1 w-32 bg-theme-elevated border border-theme-border rounded-lg shadow-lg z-50">
+            <div className={`absolute top-full right-0 mt-1 w-32 ${palette.menuBg} border ${palette.border} rounded-lg shadow-lg z-50`}>
               {(['txt', 'json', 'csv'] as DownloadFormat[]).map(fmt => (
                 <button
                   key={fmt}
                   onClick={() => { onDownload(fmt); setShowDownloadMenu(false) }}
-                  className="w-full text-left px-3 py-2 text-xs text-theme-text-primary hover:bg-theme-hover first:rounded-t-lg last:rounded-b-lg"
+                  className={`w-full text-left px-3 py-2 text-xs ${palette.textPrimary} ${palette.hoverBg} first:rounded-t-lg last:rounded-b-lg`}
                 >
                   {fmt.toUpperCase()}
                 </button>
@@ -498,7 +575,7 @@ export function LogCore({
           <Tooltip content="Clear logs" delay={TIP_DELAY} position="bottom">
             <button
               onClick={onClear}
-              className="p-1.5 rounded text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated"
+              className={iconBtnInactive}
             >
               <Trash2 className="w-4 h-4" />
             </button>
@@ -508,8 +585,8 @@ export function LogCore({
 
       {/* Search bar */}
       {search.isOpen && (
-        <div className="flex items-center gap-2 px-3 py-2 border-b border-theme-border bg-theme-surface/50">
-          <Search className="w-4 h-4 text-theme-text-secondary shrink-0" />
+        <div className={`flex items-center gap-2 px-3 py-2 border-b ${palette.border} ${palette.toolbarBgMuted}`}>
+          <Search className={`w-4 h-4 ${palette.textSecondary} shrink-0`} />
           <input
             type="text"
             value={search.query}
@@ -526,7 +603,7 @@ export function LogCore({
               }
             }}
             placeholder="Search logs..."
-            className="flex-1 bg-transparent text-theme-text-primary text-sm placeholder-theme-text-disabled focus:outline-none min-w-0"
+            className={`flex-1 bg-transparent ${palette.textPrimary} text-sm ${palette.placeholder} focus:outline-none min-w-0`}
             autoFocus
           />
 
@@ -535,7 +612,7 @@ export function LogCore({
             <button
               onClick={search.toggleRegex}
               className={`p-1 rounded transition-colors ${
-                search.isRegex ? 'btn-brand-toggle' : 'text-theme-text-tertiary hover:text-theme-text-secondary'
+                search.isRegex ? 'btn-brand-toggle' : `${palette.textTertiary} ${palette.hoverText}`
               }`}
             >
               <Regex className="w-3.5 h-3.5" />
@@ -547,7 +624,7 @@ export function LogCore({
             <button
               onClick={search.toggleCaseSensitive}
               className={`p-1 rounded transition-colors ${
-                search.isCaseSensitive ? 'btn-brand-toggle' : 'text-theme-text-tertiary hover:text-theme-text-secondary'
+                search.isCaseSensitive ? 'btn-brand-toggle' : `${palette.textTertiary} ${palette.hoverText}`
               }`}
             >
               <CaseSensitive className="w-3.5 h-3.5" />
@@ -559,7 +636,7 @@ export function LogCore({
             <button
               onClick={search.toggleFilterMode}
               className={`p-1 rounded transition-colors ${
-                search.isFilterMode ? 'btn-brand-toggle' : 'text-theme-text-tertiary hover:text-theme-text-secondary'
+                search.isFilterMode ? 'btn-brand-toggle' : `${palette.textTertiary} ${palette.hoverText}`
               }`}
             >
               <Filter className="w-3.5 h-3.5" />
@@ -568,7 +645,7 @@ export function LogCore({
 
           {search.query && (
             <>
-              <span className={`text-xs whitespace-nowrap ${search.regexError ? 'text-red-400' : 'text-theme-text-tertiary'}`}>
+              <span className={`text-xs whitespace-nowrap ${search.regexError ? (isDark ? 'text-red-400' : 'text-red-700') : palette.textTertiary}`}>
                 {search.regexError
                   ? 'Invalid regex'
                   : search.matchCount > 0
@@ -581,7 +658,7 @@ export function LogCore({
                 <button
                   onClick={search.goToPrev}
                   disabled={search.matchCount === 0}
-                  className="p-1 rounded text-theme-text-secondary hover:text-theme-text-primary disabled:opacity-30"
+                  className={`p-1 rounded ${palette.textSecondary} ${palette.hoverText} disabled:opacity-30`}
                 >
                   <ChevronUp className="w-3.5 h-3.5" />
                 </button>
@@ -590,7 +667,7 @@ export function LogCore({
                 <button
                   onClick={search.goToNext}
                   disabled={search.matchCount === 0}
-                  className="p-1 rounded text-theme-text-secondary hover:text-theme-text-primary disabled:opacity-30"
+                  className={`p-1 rounded ${palette.textSecondary} ${palette.hoverText} disabled:opacity-30`}
                 >
                   <ChevronDown className="w-3.5 h-3.5" />
                 </button>
@@ -598,7 +675,7 @@ export function LogCore({
 
               <button
                 onClick={() => search.setQuery('')}
-                className="p-1 rounded text-theme-text-secondary hover:text-theme-text-primary"
+                className={`p-1 rounded ${palette.textSecondary} ${palette.hoverText}`}
               >
                 <X className="w-3 h-3" />
               </button>
@@ -609,19 +686,19 @@ export function LogCore({
 
       {/* Log content */}
       {isLoading && entries.length === 0 ? (
-        <div className="flex-1 flex items-center justify-center text-theme-text-tertiary">
+        <div className={`flex-1 flex items-center justify-center ${palette.textTertiary}`}>
           <div className="flex items-center gap-2">
             <RotateCcw className="w-4 h-4 animate-spin" />
             <span>Loading logs...</span>
           </div>
         </div>
       ) : errorMessage ? (
-        <div className="flex-1 flex flex-col items-center justify-center text-red-400 gap-2">
+        <div className={`flex-1 flex flex-col items-center justify-center gap-2 ${isDark ? 'text-red-400' : 'text-red-700'}`}>
           <Terminal className="w-8 h-8" />
           <span>{errorMessage}</span>
         </div>
       ) : groupedEntries.length === 0 ? (
-        <div className="flex-1 flex flex-col items-center justify-center text-theme-text-tertiary gap-2">
+        <div className={`flex-1 flex flex-col items-center justify-center gap-2 ${palette.textTertiary}`}>
           <Terminal className="w-8 h-8" />
           <span>{emptyMessage}</span>
         </div>
@@ -651,6 +728,8 @@ export function LogCore({
                 onFilterValue={handleFilterValue}
                 isStackExpanded={expandedStacks.has(group.head.id)}
                 onToggleStack={toggleStackExpanded}
+                isDark={isDark}
+                palette={palette}
               />
             )}
             className="h-full font-mono text-xs"
@@ -668,20 +747,20 @@ export function LogCore({
       )}
 
       {/* Keyboard shortcut hints */}
-      <div className="flex items-center gap-4 px-3 py-1 border-t border-theme-border bg-theme-surface text-[10px] text-theme-text-disabled">
-        <Shortcut keys="Ctrl+F" label="Search" />
-        <Shortcut keys="Enter" label="Next match" />
-        <Shortcut keys="Shift+Enter" label="Prev match" />
-        <Shortcut keys="Esc" label="Close search" />
+      <div className={`flex items-center gap-4 px-3 py-1 border-t ${palette.border} ${palette.toolbarBg} text-[10px] ${palette.textDisabled}`}>
+        <Shortcut keys="Ctrl+F" label="Search" palette={palette} />
+        <Shortcut keys="Enter" label="Next match" palette={palette} />
+        <Shortcut keys="Shift+Enter" label="Prev match" palette={palette} />
+        <Shortcut keys="Esc" label="Close search" palette={palette} />
       </div>
     </div>
   )
 }
 
-function Shortcut({ keys, label }: { keys: string; label: string }) {
+function Shortcut({ keys, label, palette }: { keys: string; label: string; palette: LogPalette }) {
   return (
     <span className="flex items-center gap-1">
-      <kbd className="px-1 py-px rounded bg-theme-elevated border border-theme-border-light font-mono">{keys}</kbd>
+      <kbd className={`px-1 py-px rounded ${palette.elevatedBg} border ${palette.borderLight} font-mono`}>{keys}</kbd>
       <span>{label}</span>
     </span>
   )
@@ -702,6 +781,8 @@ interface LogLineProps {
   onFilterValue?: (value: string) => void
   /** Optional lead element rendered at the start of the row (e.g. stack-trace toggle). */
   leadSlot?: ReactNode
+  isDark: boolean
+  palette: LogPalette
 }
 
 function LogLine({
@@ -718,8 +799,10 @@ function LogLine({
   defaultExpanded,
   onFilterValue,
   leadSlot,
+  isDark,
+  palette,
 }: LogLineProps) {
-  const levelColor = getLevelColor(entry.level)
+  const levelColor = getLogLevelColor(entry.level, isDark)
 
   // Determine content rendering. Priority: search highlight > structured > ANSI/plain.
   let contentElement: React.ReactNode
@@ -741,6 +824,7 @@ function LogLine({
         isLogfmt={entry.isLogfmt}
         defaultExpanded={defaultExpanded}
         onFilterValue={onFilterValue}
+        isDark={isDark}
       />
     )
   } else if (ansiEnabled) {
@@ -765,11 +849,11 @@ function LogLine({
   }
 
   return (
-    <div className={`flex hover:bg-theme-surface/50 group leading-5 px-2 ${isCurrentMatch ? 'bg-yellow-500/10' : ''}`}>
+    <div className={`flex ${palette.hoverSurface} group leading-5 px-2 ${isCurrentMatch ? palette.currentMatchBg : ''}`}>
       {leadSlot}
       {showTimestamp && entry.timestamp && (
         <span
-          className="text-theme-text-tertiary select-none pr-2 whitespace-nowrap"
+          className={`${palette.textTertiary} select-none pr-2 whitespace-nowrap`}
           title={entry.timestamp}
         >
           {formatLogTimestamp(entry.timestamp, tsFormat)}
@@ -777,7 +861,7 @@ function LogLine({
       )}
       {showPodName && entry.pod && (
         <span
-          className={`${entry.podColor || 'text-theme-text-primary'} select-none pr-2 whitespace-nowrap min-w-[80px] max-w-[120px] truncate`}
+          className={`${entry.podColor || palette.textPrimary} select-none pr-2 whitespace-nowrap min-w-[80px] max-w-[120px] truncate`}
           title={entry.pod}
         >
           [{entry.pod.split('-').slice(-2).join('-')}]
@@ -786,7 +870,7 @@ function LogLine({
       <span className="flex-1 min-w-0">{contentElement}</span>
       <button
         onClick={handleCopy}
-        className="opacity-0 group-hover:opacity-100 ml-1 p-0.5 rounded text-theme-text-tertiary hover:text-theme-text-secondary shrink-0 transition-opacity"
+        className={`opacity-0 group-hover:opacity-100 ml-1 p-0.5 rounded ${palette.textTertiary} ${palette.hoverText} shrink-0 transition-opacity`}
         title="Copy line"
       >
         <Copy className="w-3 h-3" />
@@ -810,16 +894,18 @@ interface LogGroupItemProps {
   onFilterValue: (value: string) => void
   isStackExpanded: boolean
   onToggleStack: (id: number) => void
+  isDark: boolean
+  palette: LogPalette
 }
 
 function LogGroupItem(props: LogGroupItemProps) {
-  const { group, isStackExpanded, onToggleStack, ...rest } = props
+  const { group, isStackExpanded, onToggleStack, palette, ...rest } = props
   const hasStack = group.continuations.length > 0
 
   const stackToggle = hasStack ? (
     <button
       onClick={() => onToggleStack(group.head.id)}
-      className="mr-1 self-start p-0.5 rounded text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-surface/50 shrink-0"
+      className={`mr-1 self-start p-0.5 rounded ${palette.textTertiary} ${palette.hoverText} ${palette.hoverSurface} shrink-0`}
       title={isStackExpanded ? 'Collapse stack trace' : `Expand ${group.continuations.length} stack frames`}
     >
       {isStackExpanded
@@ -833,19 +919,20 @@ function LogGroupItem(props: LogGroupItemProps) {
       <LogLine
         entry={group.head}
         {...rest}
+        palette={palette}
         leadSlot={stackToggle}
       />
       {hasStack && !isStackExpanded && (
         <button
           onClick={() => onToggleStack(group.head.id)}
-          className="block w-full text-left pl-6 pr-2 py-0 text-[10px] text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-surface/40"
+          className={`block w-full text-left pl-6 pr-2 py-0 text-[10px] ${palette.textTertiary} ${palette.hoverText} ${palette.hoverSurface}`}
         >
           [+{group.continuations.length} stack {group.continuations.length === 1 ? 'line' : 'lines'}]
         </button>
       )}
       {hasStack && isStackExpanded && group.continuations.map(cont => (
         <div key={cont.id} className="pl-4">
-          <LogLine entry={cont} {...rest} isCurrentMatch={false} />
+          <LogLine entry={cont} {...rest} palette={palette} isCurrentMatch={false} />
         </div>
       ))}
     </div>

--- a/packages/k8s-ui/src/components/logs/LogCore.tsx
+++ b/packages/k8s-ui/src/components/logs/LogCore.tsx
@@ -39,10 +39,15 @@ interface LogCoreProps {
   emptyMessage?: string
   errorMessage?: string | null
   /**
-   * Optional initial dark/light override. When provided, pins the starting
-   * value regardless of `localStorage['radar-logs-dark']`. Users can still
-   * flip the mode via the viewer's built-in Sun/Moon toggle.
-   * @default true
+   * Initial dark/light override for the viewer's self-contained isDark state.
+   * When set, seeds the starting value (and skips the localStorage fallback).
+   * Despite the name this does not *lock* the mode — users can still flip via
+   * the in-toolbar Sun/Moon toggle; the new value is persisted to
+   * `localStorage['radar-logs-dark']` and takes precedence on next mount
+   * unless `forceDark` is passed again.
+   *
+   * When undefined (default): falls through to localStorage, then defaults
+   * to `true` (dark) if nothing is stored.
    */
   forceDark?: boolean
 }
@@ -114,9 +119,9 @@ export function LogCore({
 }: LogCoreProps) {
   const virtuosoRef = useRef<VirtuosoHandle>(null)
   const [atBottom, setAtBottom] = useState(true)
-  // Dark/light for the log viewer is self-contained — the viewer's own Sun/Moon
-  // toggle flips this, persisted to localStorage. `forceDark` prop pins the
-  // initial value when explicitly provided.
+  // Seed isDark: forceDark prop wins; else localStorage['radar-logs-dark'];
+  // else default dark. See log-palette.ts for why the viewer is palette-driven
+  // instead of theme-token-driven.
   const [isDark, setIsDark] = useState<boolean>(() => {
     if (typeof forceDark === 'boolean') return forceDark
     try {
@@ -348,9 +353,9 @@ export function LogCore({
     ? toolbarExtra({ isDark, palette })
     : toolbarExtra
 
-  // Shared "inactive toolbar button" classes. All strings are literals so
-  // Tailwind's class scanner picks them up. Two variants differ only in the
-  // default text color (secondary vs tertiary).
+  // Composite "inactive toolbar button" classes — static literals so
+  // Tailwind's class scanner picks them up. Two variants for secondary
+  // vs tertiary default text color.
   const iconBtnInactive = isDark
     ? 'p-1.5 rounded transition-colors text-slate-400 hover:text-slate-100 hover:bg-slate-800'
     : 'p-1.5 rounded transition-colors text-slate-600 hover:text-slate-900 hover:bg-slate-200'
@@ -478,7 +483,7 @@ export function LogCore({
                     }`}
                   >
                     <span>{TIMESTAMP_FORMAT_LABELS[fmt]}</span>
-                    {tsFormat === fmt && <span className={`text-[10px] ${isDark ? 'text-blue-400' : 'text-blue-700'}`}>✓</span>}
+                    {tsFormat === fmt && <span className={`text-[10px] ${palette.textAccent}`}>✓</span>}
                   </button>
                 ))}
               </div>
@@ -645,7 +650,7 @@ export function LogCore({
 
           {search.query && (
             <>
-              <span className={`text-xs whitespace-nowrap ${search.regexError ? (isDark ? 'text-red-400' : 'text-red-700') : palette.textTertiary}`}>
+              <span className={`text-xs whitespace-nowrap ${search.regexError ? palette.textError : palette.textTertiary}`}>
                 {search.regexError
                   ? 'Invalid regex'
                   : search.matchCount > 0
@@ -693,7 +698,7 @@ export function LogCore({
           </div>
         </div>
       ) : errorMessage ? (
-        <div className={`flex-1 flex flex-col items-center justify-center gap-2 ${isDark ? 'text-red-400' : 'text-red-700'}`}>
+        <div className={`flex-1 flex flex-col items-center justify-center gap-2 ${palette.textError}`}>
           <Terminal className="w-8 h-8" />
           <span>{errorMessage}</span>
         </div>
@@ -861,7 +866,7 @@ function LogLine({
       )}
       {showPodName && entry.pod && (
         <span
-          className={`${entry.podColor || palette.textPrimary} select-none pr-2 whitespace-nowrap min-w-[80px] max-w-[120px] truncate`}
+          className={`${entry.podColorIndex !== undefined ? palette.podColors[entry.podColorIndex % palette.podColors.length].text : palette.textPrimary} select-none pr-2 whitespace-nowrap min-w-[80px] max-w-[120px] truncate`}
           title={entry.pod}
         >
           [{entry.pod.split('-').slice(-2).join('-')}]

--- a/packages/k8s-ui/src/components/logs/LogCore.tsx
+++ b/packages/k8s-ui/src/components/logs/LogCore.tsx
@@ -808,6 +808,9 @@ function LogLine({
   palette,
 }: LogLineProps) {
   const levelColor = getLogLevelColor(entry.level, isDark)
+  const podTextColor = entry.podColorIndex !== undefined
+    ? palette.podColors[entry.podColorIndex % palette.podColors.length].text
+    : palette.textPrimary
 
   // Determine content rendering. Priority: search highlight > structured > ANSI/plain.
   let contentElement: React.ReactNode
@@ -866,7 +869,7 @@ function LogLine({
       )}
       {showPodName && entry.pod && (
         <span
-          className={`${entry.podColorIndex !== undefined ? palette.podColors[entry.podColorIndex % palette.podColors.length].text : palette.textPrimary} select-none pr-2 whitespace-nowrap min-w-[80px] max-w-[120px] truncate`}
+          className={`${podTextColor} select-none pr-2 whitespace-nowrap min-w-[80px] max-w-[120px] truncate`}
           title={entry.pod}
         >
           [{entry.pod.split('-').slice(-2).join('-')}]

--- a/packages/k8s-ui/src/components/logs/LogCore.tsx
+++ b/packages/k8s-ui/src/components/logs/LogCore.tsx
@@ -39,15 +39,9 @@ interface LogCoreProps {
   emptyMessage?: string
   errorMessage?: string | null
   /**
-   * Initial dark/light override for the viewer's self-contained isDark state.
-   * When set, seeds the starting value (and skips the localStorage fallback).
-   * Despite the name this does not *lock* the mode — users can still flip via
-   * the in-toolbar Sun/Moon toggle; the new value is persisted to
-   * `localStorage['radar-logs-dark']` and takes precedence on next mount
-   * unless `forceDark` is passed again.
-   *
-   * When undefined (default): falls through to localStorage, then defaults
-   * to `true` (dark) if nothing is stored.
+   * Hard override for the viewer palette. When set, the viewer stays pinned to
+   * that mode and hides the in-viewer dark/light toggle. When undefined,
+   * the viewer manages its own palette via localStorage and the Sun/Moon button.
    */
   forceDark?: boolean
 }
@@ -119,6 +113,7 @@ export function LogCore({
 }: LogCoreProps) {
   const virtuosoRef = useRef<VirtuosoHandle>(null)
   const [atBottom, setAtBottom] = useState(true)
+  const themeLocked = typeof forceDark === 'boolean'
   // Seed isDark: forceDark prop wins; else localStorage['radar-logs-dark'];
   // else default dark. See log-palette.ts for why the viewer is palette-driven
   // instead of theme-token-driven.
@@ -131,14 +126,20 @@ export function LogCore({
     } catch {}
     return true
   })
+  useEffect(() => {
+    if (typeof forceDark === 'boolean') {
+      setIsDark(forceDark)
+    }
+  }, [forceDark])
   const palette = useMemo(() => getLogPalette(isDark), [isDark])
   const toggleDark = useCallback(() => {
+    if (themeLocked) return
     setIsDark(prev => {
       const next = !prev
       try { localStorage.setItem('radar-logs-dark', String(next)) } catch {}
       return next
     })
-  }, [])
+  }, [themeLocked])
   const [wordWrap, setWordWrap] = useState(() => {
     try { return localStorage.getItem('radar-logs-wrap') !== 'false' } catch { return true }
   })
@@ -434,7 +435,7 @@ export function LogCore({
             <button
               onClick={() => setExpandAllStructured(prev => !prev)}
               className={`p-1.5 rounded transition-colors ${
-                expandAllStructured ? 'btn-brand-toggle' : iconBtnInactive
+                expandAllStructured ? palette.toolbarActive : iconBtnInactive
               }`}
             >
               <Braces className="w-4 h-4" />
@@ -448,7 +449,7 @@ export function LogCore({
             <button
               onClick={toggleTimestamps}
               className={`p-1.5 rounded-l transition-colors ${
-                showTimestamps ? 'btn-brand-toggle' : iconBtnInactive
+                showTimestamps ? palette.toolbarActive : iconBtnInactive
               }`}
             >
               <Clock className="w-4 h-4" />
@@ -459,7 +460,7 @@ export function LogCore({
               <button
                 onClick={() => setShowTsMenu(prev => !prev)}
                 className={`px-2 py-1.5 rounded-r text-[10px] font-medium transition-colors whitespace-nowrap ${
-                  showTimestamps ? 'btn-brand-toggle' : iconBtnInactiveTertiary
+                  showTimestamps ? palette.toolbarActive : iconBtnInactiveTertiary
                 }`}
                 aria-label="Pick timestamp format"
               >
@@ -496,7 +497,7 @@ export function LogCore({
           <button
             onClick={toggleCollapseStacks}
             className={`p-1.5 rounded transition-colors ${
-              collapseStacks ? 'btn-brand-toggle' : iconBtnInactive
+              collapseStacks ? palette.toolbarActive : iconBtnInactive
             }`}
           >
             <ListCollapse className="w-4 h-4" />
@@ -508,7 +509,7 @@ export function LogCore({
           <button
             onClick={toggleAnsi}
             className={`p-1.5 rounded transition-colors ${
-              ansiEnabled ? 'btn-brand-toggle' : iconBtnInactive
+              ansiEnabled ? palette.toolbarActive : iconBtnInactive
             }`}
           >
             <Palette className="w-4 h-4" />
@@ -520,7 +521,7 @@ export function LogCore({
           <button
             onClick={toggleWrap}
             className={`p-1.5 rounded transition-colors ${
-              wordWrap ? 'btn-brand-toggle' : iconBtnInactive
+              wordWrap ? palette.toolbarActive : iconBtnInactive
             }`}
           >
             <WrapText className="w-4 h-4" />
@@ -532,23 +533,24 @@ export function LogCore({
           <button
             onClick={() => search.isOpen ? search.close() : search.open()}
             className={`p-1.5 rounded transition-colors ${
-              search.isOpen ? 'btn-brand-toggle' : iconBtnInactive
+              search.isOpen ? palette.toolbarActive : iconBtnInactive
             }`}
           >
             <Search className="w-4 h-4" />
           </button>
         </Tooltip>
 
-        {/* Dark/light mode toggle — self-contained, doesn't depend on page theme */}
-        <Tooltip content={isDark ? 'Switch to light mode' : 'Switch to dark mode'} delay={TIP_DELAY} position="bottom">
-          <button
-            onClick={toggleDark}
-            className={iconBtnInactive}
-            aria-label={isDark ? 'Switch log viewer to light mode' : 'Switch log viewer to dark mode'}
-          >
-            {isDark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
-          </button>
-        </Tooltip>
+        {!themeLocked && (
+          <Tooltip content={isDark ? 'Switch to light mode' : 'Switch to dark mode'} delay={TIP_DELAY} position="bottom">
+            <button
+              onClick={toggleDark}
+              className={iconBtnInactive}
+              aria-label={isDark ? 'Switch log viewer to light mode' : 'Switch log viewer to dark mode'}
+            >
+              {isDark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+            </button>
+          </Tooltip>
+        )}
 
         {/* Download */}
         <div className="relative flex items-center" ref={downloadMenuRef}>
@@ -617,7 +619,7 @@ export function LogCore({
             <button
               onClick={search.toggleRegex}
               className={`p-1 rounded transition-colors ${
-                search.isRegex ? 'btn-brand-toggle' : `${palette.textTertiary} ${palette.hoverText}`
+                search.isRegex ? palette.toolbarActive : `${palette.textTertiary} ${palette.hoverText}`
               }`}
             >
               <Regex className="w-3.5 h-3.5" />
@@ -629,7 +631,7 @@ export function LogCore({
             <button
               onClick={search.toggleCaseSensitive}
               className={`p-1 rounded transition-colors ${
-                search.isCaseSensitive ? 'btn-brand-toggle' : `${palette.textTertiary} ${palette.hoverText}`
+                search.isCaseSensitive ? palette.toolbarActive : `${palette.textTertiary} ${palette.hoverText}`
               }`}
             >
               <CaseSensitive className="w-3.5 h-3.5" />
@@ -641,7 +643,7 @@ export function LogCore({
             <button
               onClick={search.toggleFilterMode}
               className={`p-1 rounded transition-colors ${
-                search.isFilterMode ? 'btn-brand-toggle' : `${palette.textTertiary} ${palette.hoverText}`
+                search.isFilterMode ? palette.toolbarActive : `${palette.textTertiary} ${palette.hoverText}`
               }`}
             >
               <Filter className="w-3.5 h-3.5" />

--- a/packages/k8s-ui/src/components/logs/LogToolbarSelects.tsx
+++ b/packages/k8s-ui/src/components/logs/LogToolbarSelects.tsx
@@ -1,8 +1,14 @@
 import { ChevronDown } from 'lucide-react'
 import { Tooltip } from '../ui/Tooltip'
+import { getLogPalette } from './log-palette'
 
-const SELECT_CLASS =
-  'appearance-none bg-theme-elevated text-theme-text-primary text-xs rounded px-2 py-1.5 border border-theme-border-light focus:outline-none focus:ring-1 focus:ring-blue-500'
+// Explicit dark/light classes — do NOT use theme-* tokens here because the
+// log viewer forces its own color-scheme and `light-dark()` resolution
+// doesn't propagate reliably after the Tailwind v4 migration.
+function selectClass(isDark: boolean): string {
+  const p = getLogPalette(isDark)
+  return `appearance-none ${p.elevatedBg} ${p.textPrimary} text-xs rounded px-2 py-1.5 border ${p.borderLight} focus:outline-none focus:ring-1 focus:ring-blue-500`
+}
 
 // ── ContainerSelect ───────────────────────────────────────────────────────────
 
@@ -12,21 +18,24 @@ interface ContainerSelectProps {
   onChange: (value: string) => void
   /** If true, prepend an "All containers" option with value="" */
   includeAll?: boolean
+  /** Dark/light palette selector. Defaults to `true` (dark viewer). */
+  isDark?: boolean
 }
 
-export function ContainerSelect({ containers, value, onChange, includeAll = false }: ContainerSelectProps) {
+export function ContainerSelect({ containers, value, onChange, includeAll = false, isDark = true }: ContainerSelectProps) {
   if (containers.length <= 1 && !includeAll) return null
+  const p = getLogPalette(isDark)
   return (
     <div className="relative">
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className={`${SELECT_CLASS} pr-6`}
+        className={`${selectClass(isDark)} pr-6`}
       >
         {includeAll && <option value="">All containers</option>}
         {containers.map(c => <option key={c} value={c}>{c}</option>)}
       </select>
-      <ChevronDown className="absolute right-1.5 top-1/2 -translate-y-1/2 w-3 h-3 text-theme-text-secondary pointer-events-none" />
+      <ChevronDown className={`absolute right-1.5 top-1/2 -translate-y-1/2 w-3 h-3 ${p.textSecondary} pointer-events-none`} />
     </div>
   )
 }
@@ -39,6 +48,8 @@ interface LogRangeSelectProps {
   /** Line count options to show. Defaults to [100, 500, 1000, 5000]. */
   lineOptions?: number[]
   tooltip?: string
+  /** Dark/light palette selector. Defaults to `true` (dark viewer). */
+  isDark?: boolean
 }
 
 export function LogRangeSelect({
@@ -46,13 +57,14 @@ export function LogRangeSelect({
   onChange,
   lineOptions = [100, 500, 1000, 5000],
   tooltip = 'How many logs to load — by line count or time range',
+  isDark = true,
 }: LogRangeSelectProps) {
   return (
     <Tooltip content={tooltip} position="bottom">
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className={`${SELECT_CLASS} pr-5`}
+        className={`${selectClass(isDark)} pr-5`}
       >
         <optgroup label="Lines">
           {lineOptions.map(n => (

--- a/packages/k8s-ui/src/components/logs/LogToolbarSelects.tsx
+++ b/packages/k8s-ui/src/components/logs/LogToolbarSelects.tsx
@@ -1,12 +1,11 @@
 import { ChevronDown } from 'lucide-react'
 import { Tooltip } from '../ui/Tooltip'
-import { getLogPalette } from './log-palette'
+import { getLogPalette, type LogPalette } from './log-palette'
 
 // See log-palette.ts for why the viewer uses explicit palette classes
 // instead of theme-* tokens.
-function selectClass(isDark: boolean): string {
-  const p = getLogPalette(isDark)
-  return `appearance-none ${p.elevatedBg} ${p.textPrimary} text-xs rounded px-2 py-1.5 border ${p.borderLight} focus:outline-none focus:ring-1 focus:ring-blue-500`
+function selectClass(palette: LogPalette): string {
+  return `appearance-none ${palette.elevatedBg} ${palette.textPrimary} text-xs rounded px-2 py-1.5 border ${palette.borderLight} focus:outline-none focus:ring-1 focus:ring-blue-500`
 }
 
 // ── ContainerSelect ───────────────────────────────────────────────────────────
@@ -23,18 +22,18 @@ interface ContainerSelectProps {
 
 export function ContainerSelect({ containers, value, onChange, includeAll = false, isDark = true }: ContainerSelectProps) {
   if (containers.length <= 1 && !includeAll) return null
-  const p = getLogPalette(isDark)
+  const palette = getLogPalette(isDark)
   return (
     <div className="relative">
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className={`${selectClass(isDark)} pr-6`}
+        className={`${selectClass(palette)} pr-6`}
       >
         {includeAll && <option value="">All containers</option>}
         {containers.map(c => <option key={c} value={c}>{c}</option>)}
       </select>
-      <ChevronDown className={`absolute right-1.5 top-1/2 -translate-y-1/2 w-3 h-3 ${p.textSecondary} pointer-events-none`} />
+      <ChevronDown className={`absolute right-1.5 top-1/2 -translate-y-1/2 w-3 h-3 ${palette.textSecondary} pointer-events-none`} />
     </div>
   )
 }
@@ -58,12 +57,13 @@ export function LogRangeSelect({
   tooltip = 'How many logs to load — by line count or time range',
   isDark = true,
 }: LogRangeSelectProps) {
+  const palette = getLogPalette(isDark)
   return (
     <Tooltip content={tooltip} position="bottom">
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className={`${selectClass(isDark)} pr-5`}
+        className={`${selectClass(palette)} pr-5`}
       >
         <optgroup label="Lines">
           {lineOptions.map(n => (

--- a/packages/k8s-ui/src/components/logs/LogToolbarSelects.tsx
+++ b/packages/k8s-ui/src/components/logs/LogToolbarSelects.tsx
@@ -2,9 +2,8 @@ import { ChevronDown } from 'lucide-react'
 import { Tooltip } from '../ui/Tooltip'
 import { getLogPalette } from './log-palette'
 
-// Explicit dark/light classes — do NOT use theme-* tokens here because the
-// log viewer forces its own color-scheme and `light-dark()` resolution
-// doesn't propagate reliably after the Tailwind v4 migration.
+// See log-palette.ts for why the viewer uses explicit palette classes
+// instead of theme-* tokens.
 function selectClass(isDark: boolean): string {
   const p = getLogPalette(isDark)
   return `appearance-none ${p.elevatedBg} ${p.textPrimary} text-xs rounded px-2 py-1.5 border ${p.borderLight} focus:outline-none focus:ring-1 focus:ring-blue-500`

--- a/packages/k8s-ui/src/components/logs/LogsViewer.tsx
+++ b/packages/k8s-ui/src/components/logs/LogsViewer.tsx
@@ -117,23 +117,27 @@ export function LogsViewer({
     }
   }, [entries, podName, selectedContainer, overrideDownload, showError, showSuccess])
 
-  const toolbarExtra = (
+  // toolbarExtra is a render function so the inline controls can use the
+  // LogCore palette (dark/light driven by the viewer's own isDark state)
+  // instead of theme-* tokens, which don't resolve inside the forced
+  // color-scheme container.
+  const renderToolbarExtra = ({ isDark, palette }: { isDark: boolean; palette: import('./log-palette').LogPalette }) => (
     <>
-      <ContainerSelect containers={containers} value={selectedContainer} onChange={setSelectedContainer} />
+      <ContainerSelect containers={containers} value={selectedContainer} onChange={setSelectedContainer} isDark={isDark} />
 
       <Tooltip content="Show logs from the pod's previous instance (if it was restarted). Useful for troubleshooting crashed containers." position="bottom">
-        <label className="flex items-center gap-1.5 text-xs text-theme-text-secondary">
+        <label className={`flex items-center gap-1.5 text-xs ${palette.textSecondary}`}>
           <input
             type="checkbox"
             checked={showPrevious}
             onChange={(e) => setShowPrevious(e.target.checked)}
-            className="w-3 h-3 rounded border-theme-border-light bg-theme-elevated text-blue-500 focus:ring-blue-500 focus:ring-offset-0"
+            className={`w-3 h-3 rounded ${palette.borderLight} ${palette.elevatedBg} text-blue-500 focus:ring-blue-500 focus:ring-offset-0`}
           />
-          <span className="border-b border-dotted border-theme-text-tertiary">Previous</span>
+          <span className={`border-b border-dotted ${isDark ? 'border-slate-500' : 'border-slate-400'}`}>Previous</span>
         </label>
       </Tooltip>
 
-      <LogRangeSelect value={logRange} onChange={setLogRange} />
+      <LogRangeSelect value={logRange} onChange={setLogRange} isDark={isDark} />
     </>
   )
 
@@ -148,7 +152,7 @@ export function LogsViewer({
       onRefresh={loadLogs}
       onDownload={downloadLogs}
       onClear={clear}
-      toolbarExtra={toolbarExtra}
+      toolbarExtra={renderToolbarExtra}
       forceDark={forceDark}
     />
   )

--- a/packages/k8s-ui/src/components/logs/LogsViewer.tsx
+++ b/packages/k8s-ui/src/components/logs/LogsViewer.tsx
@@ -117,10 +117,8 @@ export function LogsViewer({
     }
   }, [entries, podName, selectedContainer, overrideDownload, showError, showSuccess])
 
-  // toolbarExtra is a render function so the inline controls can use the
-  // LogCore palette (dark/light driven by the viewer's own isDark state)
-  // instead of theme-* tokens, which don't resolve inside the forced
-  // color-scheme container.
+  // Render-function form so inline controls receive the viewer's current
+  // palette — see log-palette.ts.
   const renderToolbarExtra = ({ isDark, palette }: { isDark: boolean; palette: import('./log-palette').LogPalette }) => (
     <>
       <ContainerSelect containers={containers} value={selectedContainer} onChange={setSelectedContainer} isDark={isDark} />

--- a/packages/k8s-ui/src/components/logs/LogsViewer.tsx
+++ b/packages/k8s-ui/src/components/logs/LogsViewer.tsx
@@ -6,6 +6,7 @@ import { useLogStream } from './useLogStream'
 import { ContainerSelect, LogRangeSelect } from './LogToolbarSelects'
 import { LogCore } from './LogCore'
 import type { DownloadFormat } from './LogCore'
+import type { LogPalette } from './log-palette'
 import { Tooltip } from '../ui/Tooltip'
 import { useToast } from '../ui/Toast'
 
@@ -117,9 +118,7 @@ export function LogsViewer({
     }
   }, [entries, podName, selectedContainer, overrideDownload, showError, showSuccess])
 
-  // Render-function form so inline controls receive the viewer's current
-  // palette — see log-palette.ts.
-  const renderToolbarExtra = ({ isDark, palette }: { isDark: boolean; palette: import('./log-palette').LogPalette }) => (
+  const renderToolbarExtra = ({ isDark, palette }: { isDark: boolean; palette: LogPalette }) => (
     <>
       <ContainerSelect containers={containers} value={selectedContainer} onChange={setSelectedContainer} isDark={isDark} />
 

--- a/packages/k8s-ui/src/components/logs/StructuredLogLine.tsx
+++ b/packages/k8s-ui/src/components/logs/StructuredLogLine.tsx
@@ -1,10 +1,7 @@
 import { useState, useMemo } from 'react'
 import { ChevronRight, ChevronDown, Filter } from 'lucide-react'
 import type { LogLevel } from './useLogBuffer'
-import {
-  unescapeJsonStrings,
-  parseLogfmt,
-} from '../../utils/log-format'
+import { unescapeJsonStrings, parseLogfmt } from '../../utils/log-format'
 import { getLogPalette, getLogLevelColor, type LogPalette } from './log-palette'
 
 interface StructuredLogLineProps {

--- a/packages/k8s-ui/src/components/logs/StructuredLogLine.tsx
+++ b/packages/k8s-ui/src/components/logs/StructuredLogLine.tsx
@@ -4,11 +4,6 @@ import type { LogLevel } from './useLogBuffer'
 import {
   unescapeJsonStrings,
   parseLogfmt,
-  SYNTAX_COLOR_KEY,
-  SYNTAX_COLOR_STRING,
-  SYNTAX_COLOR_NUMBER,
-  SYNTAX_COLOR_BOOLEAN,
-  SYNTAX_COLOR_NULL,
 } from '../../utils/log-format'
 import { getLogPalette, getLogLevelColor, type LogPalette } from './log-palette'
 
@@ -73,7 +68,7 @@ export function StructuredLogLine({ content, level, wordWrap, isLogfmt, defaultE
           className={`cursor-pointer ${palette.hoverSurface} rounded px-0.5 -ml-0.5 ${wordWrap ? 'whitespace-pre-wrap break-all' : 'whitespace-pre'}`}
         >
           <span className="inline-flex items-center align-middle mr-0.5">{chevron}</span>
-          <SummaryLine obj={parsed} palette={palette} isDark={isDark} />
+          <SummaryLine obj={parsed} palette={palette} />
           <span className={`${palette.textTertiary} ml-1`}>{`{${fieldCount} fields}`}</span>
         </span>
       ) : (
@@ -84,7 +79,7 @@ export function StructuredLogLine({ content, level, wordWrap, isLogfmt, defaultE
           className={`cursor-pointer ${palette.hoverSurface} rounded px-0.5 -ml-0.5`}
         >
           <span className="inline-flex items-center align-middle mr-0.5">{chevron}</span>
-          <SummaryLine obj={parsed} palette={palette} isDark={isDark} />
+          <SummaryLine obj={parsed} palette={palette} />
           <span className={`${palette.textTertiary} ml-1`}>{`{${fieldCount} fields}`}</span>
         </span>
         <span className={`block ml-4 ${wordWrap ? 'whitespace-pre-wrap break-all' : 'whitespace-pre'}`}>
@@ -147,25 +142,25 @@ function JsonExpanded({ text, onFilterValue, palette }: { text: string; onFilter
     }
     const [, key, str, num, bool, nil] = match
     if (key !== undefined) {
-      nodes.push(<span key={`k${idx++}`} style={{ color: SYNTAX_COLOR_KEY }}>{key}</span>)
+      nodes.push(<span key={`k${idx++}`} style={{ color: palette.syntaxKey }}>{key}</span>)
       nodes.push(<span key={`c${idx++}`}>:</span>)
     } else if (str !== undefined) {
       // Unescape the quoted string for the filter value (users expect to filter on
       // the displayed string, not JSON-escaped bytes).
       const inner = str.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\')
       nodes.push(
-        <FilterableValue key={`s${idx++}`} value={inner} onFilter={onFilterValue} color={SYNTAX_COLOR_STRING} palette={palette} />
+        <FilterableValue key={`s${idx++}`} value={inner} onFilter={onFilterValue} color={palette.syntaxString} palette={palette} />
       )
     } else if (num !== undefined) {
       nodes.push(
-        <FilterableValue key={`n${idx++}`} value={num} onFilter={onFilterValue} color={SYNTAX_COLOR_NUMBER} palette={palette} />
+        <FilterableValue key={`n${idx++}`} value={num} onFilter={onFilterValue} color={palette.syntaxNumber} palette={palette} />
       )
     } else if (bool !== undefined) {
       nodes.push(
-        <FilterableValue key={`b${idx++}`} value={bool} onFilter={onFilterValue} color={SYNTAX_COLOR_BOOLEAN} palette={palette} />
+        <FilterableValue key={`b${idx++}`} value={bool} onFilter={onFilterValue} color={palette.syntaxBoolean} palette={palette} />
       )
     } else if (nil !== undefined) {
-      nodes.push(<span key={`z${idx++}`} style={{ color: SYNTAX_COLOR_NULL }}>{nil}</span>)
+      nodes.push(<span key={`z${idx++}`} style={{ color: palette.syntaxNull }}>{nil}</span>)
     }
     lastIndex = tokenRe.lastIndex
   }
@@ -175,7 +170,7 @@ function JsonExpanded({ text, onFilterValue, palette }: { text: string; onFilter
   return <>{nodes}</>
 }
 
-function SummaryLine({ obj, palette, isDark }: { obj: Record<string, unknown>; palette: LogPalette; isDark: boolean }) {
+function SummaryLine({ obj, palette }: { obj: Record<string, unknown>; palette: LogPalette }) {
   const lvl = obj.level ?? obj.severity ?? obj.lvl ?? nestedField(obj, 'log', 'level')
   const msg = obj.msg ?? obj.message
   const rawErr = obj.error ?? obj.err
@@ -195,7 +190,7 @@ function SummaryLine({ obj, palette, isDark }: { obj: Record<string, unknown>; p
         <span className={palette.textPrimary}>{msg}</span>
       )}
       {typeof err === 'string' && (
-        <span className={`${isDark ? 'text-red-400' : 'text-red-700'} ml-2`}>error={err}</span>
+        <span className={`${palette.textError} ml-2`}>error={err}</span>
       )}
       {typeof caller === 'string' && (
         <span className={`${palette.textDisabled} ml-2`}>{caller}</span>
@@ -211,9 +206,9 @@ function ExpandedLogfmt({ obj, onFilterValue, palette }: { obj: Record<string, u
         const str = String(val)
         return (
           <div key={key}>
-            <span style={{ color: SYNTAX_COLOR_KEY }}>{key}</span>
+            <span style={{ color: palette.syntaxKey }}>{key}</span>
             <span className={palette.textTertiary}>=</span>
-            <FilterableValue value={str} onFilter={onFilterValue} color={SYNTAX_COLOR_STRING} palette={palette} />
+            <FilterableValue value={str} onFilter={onFilterValue} color={palette.syntaxString} palette={palette} />
           </div>
         )
       })}

--- a/packages/k8s-ui/src/components/logs/StructuredLogLine.tsx
+++ b/packages/k8s-ui/src/components/logs/StructuredLogLine.tsx
@@ -2,7 +2,6 @@ import { useState, useMemo } from 'react'
 import { ChevronRight, ChevronDown, Filter } from 'lucide-react'
 import type { LogLevel } from './useLogBuffer'
 import {
-  getLevelColor,
   unescapeJsonStrings,
   parseLogfmt,
   SYNTAX_COLOR_KEY,
@@ -11,7 +10,7 @@ import {
   SYNTAX_COLOR_BOOLEAN,
   SYNTAX_COLOR_NULL,
 } from '../../utils/log-format'
-import { SEVERITY_BADGE_BORDERED } from '../../utils/badge-colors'
+import { getLogPalette, getLogLevelColor, type LogPalette } from './log-palette'
 
 interface StructuredLogLineProps {
   content: string
@@ -25,9 +24,16 @@ interface StructuredLogLineProps {
    * add the value to the log search/filter.
    */
   onFilterValue?: (value: string) => void
+  /**
+   * Whether the log viewer is in dark mode. Determines the color palette used
+   * for text, hover states, and level badges. Defaults to `true` since the
+   * viewer defaults to dark mode.
+   */
+  isDark?: boolean
 }
 
-export function StructuredLogLine({ content, level, wordWrap, isLogfmt, defaultExpanded, onFilterValue }: StructuredLogLineProps) {
+export function StructuredLogLine({ content, level, wordWrap, isLogfmt, defaultExpanded, onFilterValue, isDark = true }: StructuredLogLineProps) {
+  const palette = useMemo(() => getLogPalette(isDark), [isDark])
   // null = user hasn't toggled this line; defers to defaultExpanded (global toggle)
   const [localExpanded, setLocalExpanded] = useState<boolean | null>(null)
   const expanded = localExpanded ?? defaultExpanded ?? false
@@ -45,7 +51,7 @@ export function StructuredLogLine({ content, level, wordWrap, isLogfmt, defaultE
 
   if (!parsed) {
     return (
-      <span className={`${wordWrap ? 'whitespace-pre-wrap break-all' : 'whitespace-pre'} ${getLevelColor(level)}`}>
+      <span className={`${wordWrap ? 'whitespace-pre-wrap break-all' : 'whitespace-pre'} ${getLogLevelColor(level, isDark)}`}>
         {content}
       </span>
     )
@@ -55,8 +61,8 @@ export function StructuredLogLine({ content, level, wordWrap, isLogfmt, defaultE
 
   const toggle = () => setLocalExpanded(!expanded)
   const chevron = expanded
-    ? <ChevronDown className="w-3 h-3 shrink-0 text-theme-text-tertiary" />
-    : <ChevronRight className="w-3 h-3 shrink-0 text-theme-text-tertiary" />
+    ? <ChevronDown className={`w-3 h-3 shrink-0 ${palette.textTertiary}`} />
+    : <ChevronRight className={`w-3 h-3 shrink-0 ${palette.textTertiary}`} />
 
   return (
     <span>
@@ -64,30 +70,31 @@ export function StructuredLogLine({ content, level, wordWrap, isLogfmt, defaultE
         // Collapsed: entire summary line is clickable
         <span
           onClick={toggle}
-          className={`cursor-pointer hover:bg-theme-surface/50 rounded px-0.5 -ml-0.5 ${wordWrap ? 'whitespace-pre-wrap break-all' : 'whitespace-pre'}`}
+          className={`cursor-pointer ${palette.hoverSurface} rounded px-0.5 -ml-0.5 ${wordWrap ? 'whitespace-pre-wrap break-all' : 'whitespace-pre'}`}
         >
           <span className="inline-flex items-center align-middle mr-0.5">{chevron}</span>
-          <SummaryLine obj={parsed} />
-          <span className="text-theme-text-tertiary ml-1">{`{${fieldCount} fields}`}</span>
+          <SummaryLine obj={parsed} palette={palette} isDark={isDark} />
+          <span className={`${palette.textTertiary} ml-1`}>{`{${fieldCount} fields}`}</span>
         </span>
       ) : (
         // Expanded: summary header is clickable to collapse, JSON content is selectable
         <>
         <span
           onClick={toggle}
-          className="cursor-pointer hover:bg-theme-surface/50 rounded px-0.5 -ml-0.5"
+          className={`cursor-pointer ${palette.hoverSurface} rounded px-0.5 -ml-0.5`}
         >
           <span className="inline-flex items-center align-middle mr-0.5">{chevron}</span>
-          <SummaryLine obj={parsed} />
-          <span className="text-theme-text-tertiary ml-1">{`{${fieldCount} fields}`}</span>
+          <SummaryLine obj={parsed} palette={palette} isDark={isDark} />
+          <span className={`${palette.textTertiary} ml-1`}>{`{${fieldCount} fields}`}</span>
         </span>
         <span className={`block ml-4 ${wordWrap ? 'whitespace-pre-wrap break-all' : 'whitespace-pre'}`}>
           {isLogfmt ? (
-            <ExpandedLogfmt obj={parsed} onFilterValue={onFilterValue} />
+            <ExpandedLogfmt obj={parsed} onFilterValue={onFilterValue} palette={palette} />
           ) : (
             <JsonExpanded
               text={unescapeJsonStrings(JSON.stringify(parsed, null, 2))}
               onFilterValue={onFilterValue}
+              palette={palette}
             />
           )}
         </span>
@@ -102,18 +109,18 @@ export function StructuredLogLine({ content, level, wordWrap, isLogfmt, defaultE
  * Clicking the chip calls onFilter(value) so the caller can push it into log search.
  */
 function FilterableValue({
-  value, onFilter, color,
-}: { value: string; onFilter?: (v: string) => void; color?: string }) {
+  value, onFilter, color, palette,
+}: { value: string; onFilter?: (v: string) => void; color?: string; palette: LogPalette }) {
   if (!onFilter) {
     return <span style={color ? { color } : undefined}>{value}</span>
   }
   return (
-    <span className="group/flt inline-flex items-baseline align-baseline gap-0.5 rounded hover:bg-theme-surface/60">
+    <span className={`group/flt inline-flex items-baseline align-baseline gap-0.5 rounded ${palette.hoverSurface}`}>
       <span style={color ? { color } : undefined}>{value}</span>
       <button
         type="button"
         onClick={(e) => { e.stopPropagation(); onFilter(value) }}
-        className="opacity-0 group-hover/flt:opacity-100 transition-opacity text-theme-text-tertiary hover:text-theme-text-primary px-0.5"
+        className={`opacity-0 group-hover/flt:opacity-100 transition-opacity ${palette.textTertiary} ${palette.hoverText} px-0.5`}
         title={`Filter to lines containing "${value}"`}
         aria-label={`Filter to lines containing ${value}`}
       >
@@ -128,7 +135,7 @@ function FilterableValue({
  * the layout that JSON.stringify(..., null, 2) produces. Tokenizes the string
  * and emits React nodes so the hover chip can be wired per value.
  */
-function JsonExpanded({ text, onFilterValue }: { text: string; onFilterValue?: (v: string) => void }) {
+function JsonExpanded({ text, onFilterValue, palette }: { text: string; onFilterValue?: (v: string) => void; palette: LogPalette }) {
   const tokenRe = /("(?:\\.|[^"\\])*")\s*:|("(?:\\.|[^"\\])*")|(-?\b\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\b)|\b(true|false)\b|\b(null)\b/g
   const nodes: React.ReactNode[] = []
   let lastIndex = 0
@@ -147,15 +154,15 @@ function JsonExpanded({ text, onFilterValue }: { text: string; onFilterValue?: (
       // the displayed string, not JSON-escaped bytes).
       const inner = str.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\')
       nodes.push(
-        <FilterableValue key={`s${idx++}`} value={inner} onFilter={onFilterValue} color={SYNTAX_COLOR_STRING} />
+        <FilterableValue key={`s${idx++}`} value={inner} onFilter={onFilterValue} color={SYNTAX_COLOR_STRING} palette={palette} />
       )
     } else if (num !== undefined) {
       nodes.push(
-        <FilterableValue key={`n${idx++}`} value={num} onFilter={onFilterValue} color={SYNTAX_COLOR_NUMBER} />
+        <FilterableValue key={`n${idx++}`} value={num} onFilter={onFilterValue} color={SYNTAX_COLOR_NUMBER} palette={palette} />
       )
     } else if (bool !== undefined) {
       nodes.push(
-        <FilterableValue key={`b${idx++}`} value={bool} onFilter={onFilterValue} color={SYNTAX_COLOR_BOOLEAN} />
+        <FilterableValue key={`b${idx++}`} value={bool} onFilter={onFilterValue} color={SYNTAX_COLOR_BOOLEAN} palette={palette} />
       )
     } else if (nil !== undefined) {
       nodes.push(<span key={`z${idx++}`} style={{ color: SYNTAX_COLOR_NULL }}>{nil}</span>)
@@ -168,7 +175,7 @@ function JsonExpanded({ text, onFilterValue }: { text: string; onFilterValue?: (
   return <>{nodes}</>
 }
 
-function SummaryLine({ obj }: { obj: Record<string, unknown> }) {
+function SummaryLine({ obj, palette, isDark }: { obj: Record<string, unknown>; palette: LogPalette; isDark: boolean }) {
   const lvl = obj.level ?? obj.severity ?? obj.lvl ?? nestedField(obj, 'log', 'level')
   const msg = obj.msg ?? obj.message
   const rawErr = obj.error ?? obj.err
@@ -180,24 +187,24 @@ function SummaryLine({ obj }: { obj: Record<string, unknown> }) {
   return (
     <>
       {lvl != null && (
-        <span className={`${getLevelBadgeColor(lvl)} text-[10px] font-semibold px-1 py-px rounded mr-1.5 inline-block`}>
+        <span className={`${getLevelBadgeColor(lvl, palette)} text-[10px] font-semibold px-1 py-px rounded mr-1.5 inline-block`}>
           {formatLevel(lvl)}
         </span>
       )}
       {typeof msg === 'string' && (
-        <span className="text-theme-text-primary">{msg}</span>
+        <span className={palette.textPrimary}>{msg}</span>
       )}
       {typeof err === 'string' && (
-        <span className="text-red-400 ml-2">error={err}</span>
+        <span className={`${isDark ? 'text-red-400' : 'text-red-700'} ml-2`}>error={err}</span>
       )}
       {typeof caller === 'string' && (
-        <span className="text-theme-text-disabled ml-2">{caller}</span>
+        <span className={`${palette.textDisabled} ml-2`}>{caller}</span>
       )}
     </>
   )
 }
 
-function ExpandedLogfmt({ obj, onFilterValue }: { obj: Record<string, unknown>; onFilterValue?: (v: string) => void }) {
+function ExpandedLogfmt({ obj, onFilterValue, palette }: { obj: Record<string, unknown>; onFilterValue?: (v: string) => void; palette: LogPalette }) {
   return (
     <>
       {Object.entries(obj).map(([key, val]) => {
@@ -205,8 +212,8 @@ function ExpandedLogfmt({ obj, onFilterValue }: { obj: Record<string, unknown>; 
         return (
           <div key={key}>
             <span style={{ color: SYNTAX_COLOR_KEY }}>{key}</span>
-            <span className="text-theme-text-tertiary">=</span>
-            <FilterableValue value={str} onFilter={onFilterValue} color={SYNTAX_COLOR_STRING} />
+            <span className={palette.textTertiary}>=</span>
+            <FilterableValue value={str} onFilter={onFilterValue} color={SYNTAX_COLOR_STRING} palette={palette} />
           </div>
         )
       })}
@@ -232,7 +239,7 @@ function formatLevel(lvl: unknown): string {
   return String(lvl).toUpperCase()
 }
 
-function getLevelBadgeColor(lvl: unknown): string {
+function getLevelBadgeColor(lvl: unknown, palette: LogPalette): string {
   let normalized: string
   if (typeof lvl === 'number') {
     // Pino/bunyan numeric levels: 10=trace, 20=debug, 30=info, 40=warn, 50=error, 60=fatal
@@ -243,9 +250,9 @@ function getLevelBadgeColor(lvl: unknown): string {
   } else {
     normalized = String(lvl).toLowerCase()
   }
-  if (/^(error|err|fatal|panic|critical|crit)$/.test(normalized)) return SEVERITY_BADGE_BORDERED.error
-  if (/^(warn|warning)$/.test(normalized)) return SEVERITY_BADGE_BORDERED.warning
-  if (/^(info|information|notice)$/.test(normalized)) return SEVERITY_BADGE_BORDERED.info
-  if (/^(debug|dbg|trace|verbose)$/.test(normalized)) return SEVERITY_BADGE_BORDERED.debug
-  return SEVERITY_BADGE_BORDERED.neutral
+  if (/^(error|err|fatal|panic|critical|crit)$/.test(normalized)) return palette.levelBadgeError
+  if (/^(warn|warning)$/.test(normalized)) return palette.levelBadgeWarn
+  if (/^(info|information|notice)$/.test(normalized)) return palette.levelBadgeInfo
+  if (/^(debug|dbg|trace|verbose)$/.test(normalized)) return palette.levelBadgeDebug
+  return palette.levelBadgeNeutral
 }

--- a/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
+++ b/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
@@ -217,14 +217,16 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
     }
   }, [filteredEntries, name, overrideDownload, showError, showSuccess])
 
-  const toolbarExtra = (
+  // toolbarExtra as a render function so inline controls get the viewer's
+  // current palette (explicit dark/light classes, not theme-* tokens).
+  const renderToolbarExtra = ({ isDark, palette }: { isDark: boolean; palette: import('./log-palette').LogPalette }) => (
     <>
       {/* Pod filter */}
       <div className="relative">
         <button
           onClick={() => setShowPodFilter(v => !v)}
           className={`flex items-center gap-1.5 px-2 py-1.5 text-xs rounded transition-colors ${
-            showPodFilter ? 'btn-brand-toggle' : 'bg-theme-elevated text-theme-text-secondary hover:bg-theme-hover'
+            showPodFilter ? 'btn-brand-toggle' : `${palette.elevatedBg} ${palette.textSecondary} ${palette.hoverBg}`
           }`}
         >
           <Filter className="w-3 h-3" />
@@ -233,23 +235,23 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
         </button>
 
         {showPodFilter && (
-          <div className="absolute top-full left-0 mt-1 w-64 bg-theme-elevated border border-theme-border rounded-lg shadow-lg z-50 max-h-64 overflow-y-auto">
-            <div className="p-2 border-b border-theme-border">
-              <button onClick={toggleAllPods} className="text-xs text-blue-400 hover:text-blue-300">
+          <div className={`absolute top-full left-0 mt-1 w-64 ${palette.menuBg} border ${palette.border} rounded-lg shadow-lg z-50 max-h-64 overflow-y-auto`}>
+            <div className={`p-2 border-b ${palette.border}`}>
+              <button onClick={toggleAllPods} className={`text-xs ${isDark ? 'text-blue-400 hover:text-blue-300' : 'text-blue-700 hover:text-blue-800'}`}>
                 {pods.every(p => selectedPods.has(p.name)) ? 'Deselect all' : 'Select all'}
               </button>
             </div>
             {pods.map(pod => (
-              <label key={pod.name} className="flex items-center gap-2 px-3 py-2 hover:bg-theme-hover">
+              <label key={pod.name} className={`flex items-center gap-2 px-3 py-2 ${palette.hoverBg}`}>
                 <input
                   type="checkbox"
                   checked={selectedPods.has(pod.name)}
                   onChange={() => togglePod(pod.name)}
-                  className="w-3 h-3 rounded border-theme-border-light bg-theme-elevated text-blue-500 focus:ring-blue-500 focus:ring-offset-0"
+                  className={`w-3 h-3 rounded ${palette.borderLight} ${palette.elevatedBg} text-blue-500 focus:ring-blue-500 focus:ring-offset-0`}
                 />
                 <span className={`w-2 h-2 rounded-full ${podColors.get(pod.name)?.replace('text-', 'bg-')}`} />
-                <span className="text-xs text-theme-text-primary truncate flex-1">{pod.name}</span>
-                <span className={`text-xs ${pod.ready ? 'text-green-400' : 'text-yellow-400'}`}>
+                <span className={`text-xs ${palette.textPrimary} truncate flex-1`}>{pod.name}</span>
+                <span className={`text-xs ${pod.ready ? (isDark ? 'text-green-400' : 'text-green-700') : (isDark ? 'text-yellow-400' : 'text-yellow-700')}`}>
                   {pod.ready ? 'Ready' : 'Not Ready'}
                 </span>
               </label>
@@ -263,6 +265,7 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
         value={selectedContainer}
         onChange={setSelectedContainer}
         includeAll
+        isDark={isDark}
       />
 
       <LogRangeSelect
@@ -270,6 +273,7 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
         onChange={setLogRange}
         lineOptions={[50, 100, 500, 1000]}
         tooltip="How many logs to load per pod — by line count or time range"
+        isDark={isDark}
       />
     </>
   )
@@ -284,7 +288,7 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
       onRefresh={loadLogs}
       onDownload={downloadLogs}
       onClear={clear}
-      toolbarExtra={toolbarExtra}
+      toolbarExtra={renderToolbarExtra}
       showPodName
       emptyMessage={pods.length === 0 ? 'No pods found' : 'No logs available'}
       errorMessage={fetchError}

--- a/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
+++ b/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
@@ -223,7 +223,7 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
         <button
           onClick={() => setShowPodFilter(v => !v)}
           className={`flex items-center gap-1.5 px-2 py-1.5 text-xs rounded transition-colors ${
-            showPodFilter ? 'btn-brand-toggle' : `${palette.elevatedBg} ${palette.textSecondary} ${palette.hoverBg}`
+            showPodFilter ? palette.toolbarActive : `${palette.elevatedBg} ${palette.textSecondary} ${palette.hoverBg}`
           }`}
         >
           <Filter className="w-3 h-3" />

--- a/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
+++ b/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
@@ -48,11 +48,6 @@ export interface WorkloadLogsViewerProps {
   forceDark?: boolean
 }
 
-const POD_COLORS = [
-  'text-blue-400', 'text-green-400', 'text-yellow-400', 'text-purple-400',
-  'text-pink-400', 'text-cyan-400', 'text-orange-400', 'text-lime-400',
-]
-
 export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownload, forceDark }: WorkloadLogsViewerProps) {
   const [selectedContainer, setSelectedContainer] = useState<string>('')
   const [pods, setPods] = useState<WorkloadPodInfo[]>([])
@@ -67,9 +62,12 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
   const { entries, append, set, clear } = useLogBuffer()
   const { isStreaming, startStreaming, stopStreaming } = useLogStream()
 
-  const podColors = useMemo(() => {
-    const m = new Map<string, string>()
-    pods.forEach((pod, i) => m.set(pod.name, POD_COLORS[i % POD_COLORS.length]))
+  // Map pod.name → index. Color classes are resolved at render time from the
+  // current palette (see LogCore / pod-filter dropdown below) so toggling
+  // isDark re-themes pod labels without re-fetching.
+  const podColorIndex = useMemo(() => {
+    const m = new Map<string, number>()
+    pods.forEach((pod, i) => m.set(pod.name, i))
     return m
   }, [pods])
 
@@ -88,15 +86,15 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
         setSelectedPods(new Set(result.pods.map(p => p.name)))
       }
 
-      const colors = new Map<string, string>()
-      result.pods.forEach((pod, i) => colors.set(pod.name, POD_COLORS[i % POD_COLORS.length]))
+      const indexByPod = new Map<string, number>()
+      result.pods.forEach((pod, i) => indexByPod.set(pod.name, i))
 
       set(result.logs.map(log => ({
         timestamp: log.timestamp,
         content: log.content,
         container: log.container,
         pod: log.pod,
-        podColor: colors.get(log.pod),
+        podColorIndex: indexByPod.get(log.pod),
       })))
     } catch (err) {
       console.error('Failed to fetch workload logs:', err)
@@ -129,7 +127,7 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
               content: data.content || '',
               container: data.container || '',
               pod: data.pod || '',
-              podColor: podColors.get(data.pod || ''),
+              podColorIndex: podColorIndex.get(data.pod || ''),
             })
           }
         },
@@ -159,7 +157,7 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
       },
       'Workload log stream error',
     )
-  }, [createStream, startStreaming, selectedContainer, sinceSeconds, append, podColors, selectedPods.size])
+  }, [createStream, startStreaming, selectedContainer, sinceSeconds, append, podColorIndex, selectedPods.size])
 
   const allContainers = useMemo(() => {
     const s = new Set<string>()
@@ -217,8 +215,8 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
     }
   }, [filteredEntries, name, overrideDownload, showError, showSuccess])
 
-  // toolbarExtra as a render function so inline controls get the viewer's
-  // current palette (explicit dark/light classes, not theme-* tokens).
+  // Render-function form so inline controls receive the viewer's current
+  // palette — see log-palette.ts.
   const renderToolbarExtra = ({ isDark, palette }: { isDark: boolean; palette: import('./log-palette').LogPalette }) => (
     <>
       {/* Pod filter */}
@@ -237,7 +235,7 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
         {showPodFilter && (
           <div className={`absolute top-full left-0 mt-1 w-64 ${palette.menuBg} border ${palette.border} rounded-lg shadow-lg z-50 max-h-64 overflow-y-auto`}>
             <div className={`p-2 border-b ${palette.border}`}>
-              <button onClick={toggleAllPods} className={`text-xs ${isDark ? 'text-blue-400 hover:text-blue-300' : 'text-blue-700 hover:text-blue-800'}`}>
+              <button onClick={toggleAllPods} className={`text-xs ${palette.textAccent} hover:underline`}>
                 {pods.every(p => selectedPods.has(p.name)) ? 'Deselect all' : 'Select all'}
               </button>
             </div>
@@ -249,9 +247,9 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
                   onChange={() => togglePod(pod.name)}
                   className={`w-3 h-3 rounded ${palette.borderLight} ${palette.elevatedBg} text-blue-500 focus:ring-blue-500 focus:ring-offset-0`}
                 />
-                <span className={`w-2 h-2 rounded-full ${podColors.get(pod.name)?.replace('text-', 'bg-')}`} />
+                <span className={`w-2 h-2 rounded-full ${palette.podColors[(podColorIndex.get(pod.name) ?? 0) % palette.podColors.length].bg}`} />
                 <span className={`text-xs ${palette.textPrimary} truncate flex-1`}>{pod.name}</span>
-                <span className={`text-xs ${pod.ready ? (isDark ? 'text-green-400' : 'text-green-700') : (isDark ? 'text-yellow-400' : 'text-yellow-700')}`}>
+                <span className={`text-xs ${pod.ready ? (isDark ? 'text-emerald-400' : 'text-emerald-700') : (isDark ? 'text-amber-400' : 'text-amber-700')}`}>
                   {pod.ready ? 'Ready' : 'Not Ready'}
                 </span>
               </label>

--- a/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
+++ b/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
@@ -7,6 +7,7 @@ import { useLogStream } from './useLogStream'
 import { ContainerSelect, LogRangeSelect } from './LogToolbarSelects'
 import { LogCore } from './LogCore'
 import type { DownloadFormat } from './LogCore'
+import type { LogPalette } from './log-palette'
 import type { WorkloadPodInfo } from '../../types'
 import { useToast } from '../ui/Toast'
 
@@ -215,9 +216,7 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
     }
   }, [filteredEntries, name, overrideDownload, showError, showSuccess])
 
-  // Render-function form so inline controls receive the viewer's current
-  // palette — see log-palette.ts.
-  const renderToolbarExtra = ({ isDark, palette }: { isDark: boolean; palette: import('./log-palette').LogPalette }) => (
+  const renderToolbarExtra = ({ isDark, palette }: { isDark: boolean; palette: LogPalette }) => (
     <>
       {/* Pod filter */}
       <div className="relative">
@@ -239,21 +238,30 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
                 {pods.every(p => selectedPods.has(p.name)) ? 'Deselect all' : 'Select all'}
               </button>
             </div>
-            {pods.map(pod => (
-              <label key={pod.name} className={`flex items-center gap-2 px-3 py-2 ${palette.hoverBg}`}>
-                <input
-                  type="checkbox"
-                  checked={selectedPods.has(pod.name)}
-                  onChange={() => togglePod(pod.name)}
-                  className={`w-3 h-3 rounded ${palette.borderLight} ${palette.elevatedBg} text-blue-500 focus:ring-blue-500 focus:ring-offset-0`}
-                />
-                <span className={`w-2 h-2 rounded-full ${palette.podColors[(podColorIndex.get(pod.name) ?? 0) % palette.podColors.length].bg}`} />
-                <span className={`text-xs ${palette.textPrimary} truncate flex-1`}>{pod.name}</span>
-                <span className={`text-xs ${pod.ready ? (isDark ? 'text-emerald-400' : 'text-emerald-700') : (isDark ? 'text-amber-400' : 'text-amber-700')}`}>
-                  {pod.ready ? 'Ready' : 'Not Ready'}
-                </span>
-              </label>
-            ))}
+            {pods.map(pod => {
+              const dotBg = palette.podColors[(podColorIndex.get(pod.name) ?? 0) % palette.podColors.length].bg
+              let readyColor: string
+              if (pod.ready) {
+                readyColor = isDark ? 'text-emerald-400' : 'text-emerald-700'
+              } else {
+                readyColor = isDark ? 'text-amber-400' : 'text-amber-700'
+              }
+              return (
+                <label key={pod.name} className={`flex items-center gap-2 px-3 py-2 ${palette.hoverBg}`}>
+                  <input
+                    type="checkbox"
+                    checked={selectedPods.has(pod.name)}
+                    onChange={() => togglePod(pod.name)}
+                    className={`w-3 h-3 rounded ${palette.borderLight} ${palette.elevatedBg} text-blue-500 focus:ring-blue-500 focus:ring-offset-0`}
+                  />
+                  <span className={`w-2 h-2 rounded-full ${dotBg}`} />
+                  <span className={`text-xs ${palette.textPrimary} truncate flex-1`}>{pod.name}</span>
+                  <span className={`text-xs ${readyColor}`}>
+                    {pod.ready ? 'Ready' : 'Not Ready'}
+                  </span>
+                </label>
+              )
+            })}
           </div>
         )}
       </div>

--- a/packages/k8s-ui/src/components/logs/log-palette.ts
+++ b/packages/k8s-ui/src/components/logs/log-palette.ts
@@ -1,0 +1,155 @@
+/**
+ * Explicit color palettes for the log viewer.
+ *
+ * The log viewer is intentionally self-contained: it does NOT use theme tokens
+ * (`text-theme-*`, `bg-theme-*`, etc.) because those are driven by CSS
+ * `light-dark()` and don't resolve correctly through the log viewer's forced
+ * `color-scheme` container. Instead it flips between two explicit palettes
+ * based on its own `isDark` state (toggled by a Sun/Moon button in the
+ * toolbar, persisted to `localStorage['radar-logs-dark']`).
+ *
+ * All class strings are static literals so Tailwind's class scanner picks them
+ * up — do not construct them dynamically.
+ */
+
+/** All color-related class strings used inside the log viewer. */
+export interface LogPalette {
+  // Container / surfaces
+  containerBg: string
+  toolbarBg: string
+  toolbarBgMuted: string
+  menuBg: string
+  elevatedBg: string
+
+  // Borders
+  border: string
+  borderLight: string
+
+  // Text
+  textPrimary: string
+  textSecondary: string
+  textTertiary: string
+  textDisabled: string
+
+  // Placeholder (plain class, applied via `placeholder-*` below)
+  placeholder: string
+
+  // Hover states
+  hoverBg: string
+  hoverSurface: string
+  hoverText: string
+
+  // Row highlight (current search match)
+  currentMatchBg: string
+
+  // Level-filter button active colors (per-level, full className)
+  levelActiveError: string
+  levelActiveWarn: string
+  levelActiveInfo: string
+  levelActiveDebug: string
+
+  // Level-badge colors used inside StructuredLogLine
+  levelBadgeError: string
+  levelBadgeWarn: string
+  levelBadgeInfo: string
+  levelBadgeDebug: string
+  levelBadgeNeutral: string
+}
+
+const DARK_PALETTE: LogPalette = {
+  containerBg: 'bg-slate-950',
+  toolbarBg: 'bg-slate-900',
+  toolbarBgMuted: 'bg-slate-900/60',
+  menuBg: 'bg-slate-900',
+  elevatedBg: 'bg-slate-800',
+
+  border: 'border-slate-800',
+  borderLight: 'border-slate-700',
+
+  textPrimary: 'text-slate-100',
+  textSecondary: 'text-slate-400',
+  textTertiary: 'text-slate-500',
+  textDisabled: 'text-slate-600',
+
+  placeholder: 'placeholder-slate-600',
+
+  hoverBg: 'hover:bg-slate-800',
+  hoverSurface: 'hover:bg-slate-800/50',
+  hoverText: 'hover:text-slate-100',
+
+  currentMatchBg: 'bg-yellow-500/10',
+
+  levelActiveError: 'bg-red-500/20 text-red-400 border-red-500/40',
+  levelActiveWarn: 'bg-amber-500/20 text-amber-400 border-amber-500/40',
+  levelActiveInfo: 'bg-blue-500/20 text-blue-400 border-blue-500/40',
+  levelActiveDebug: 'bg-slate-700 text-slate-300 border-slate-600',
+
+  levelBadgeError: 'bg-red-500/20 text-red-400 border border-red-500/40',
+  levelBadgeWarn: 'bg-amber-500/20 text-amber-400 border border-amber-500/40',
+  levelBadgeInfo: 'bg-blue-500/20 text-blue-400 border border-blue-500/40',
+  levelBadgeDebug: 'bg-slate-700 text-slate-300 border border-slate-600',
+  levelBadgeNeutral: 'bg-slate-800 text-slate-400 border border-slate-700',
+}
+
+const LIGHT_PALETTE: LogPalette = {
+  containerBg: 'bg-slate-50',
+  toolbarBg: 'bg-slate-100',
+  toolbarBgMuted: 'bg-slate-100/60',
+  menuBg: 'bg-white',
+  elevatedBg: 'bg-white',
+
+  border: 'border-slate-200',
+  borderLight: 'border-slate-300',
+
+  textPrimary: 'text-slate-900',
+  textSecondary: 'text-slate-600',
+  textTertiary: 'text-slate-400',
+  textDisabled: 'text-slate-300',
+
+  placeholder: 'placeholder-slate-400',
+
+  hoverBg: 'hover:bg-slate-200',
+  hoverSurface: 'hover:bg-slate-200/60',
+  hoverText: 'hover:text-slate-900',
+
+  currentMatchBg: 'bg-yellow-200/60',
+
+  levelActiveError: 'bg-red-100 text-red-700 border-red-400',
+  levelActiveWarn: 'bg-amber-100 text-amber-700 border-amber-400',
+  levelActiveInfo: 'bg-blue-100 text-blue-700 border-blue-400',
+  levelActiveDebug: 'bg-slate-200 text-slate-700 border-slate-400',
+
+  levelBadgeError: 'bg-red-100 text-red-700 border border-red-400',
+  levelBadgeWarn: 'bg-amber-100 text-amber-700 border border-amber-400',
+  levelBadgeInfo: 'bg-blue-100 text-blue-700 border border-blue-400',
+  levelBadgeDebug: 'bg-slate-200 text-slate-700 border border-slate-400',
+  levelBadgeNeutral: 'bg-slate-100 text-slate-600 border border-slate-300',
+}
+
+/** Get the palette for the current dark/light mode. */
+export function getLogPalette(isDark: boolean): LogPalette {
+  return isDark ? DARK_PALETTE : LIGHT_PALETTE
+}
+
+/** Per-level content color (log text body). */
+export function getLogLevelColor(
+  level: 'error' | 'warn' | 'info' | 'debug' | 'unknown',
+  isDark: boolean,
+): string {
+  if (isDark) {
+    switch (level) {
+      case 'error': return 'text-red-400'
+      case 'warn': return 'text-amber-400'
+      case 'info': return 'text-blue-400'
+      case 'debug': return 'text-slate-400'
+      default: return 'text-slate-100'
+    }
+  }
+  switch (level) {
+    case 'error': return 'text-red-700'
+    case 'warn': return 'text-amber-600'
+    case 'info': return 'text-blue-700'
+    case 'debug': return 'text-slate-500'
+    default: return 'text-slate-900'
+  }
+}

--- a/packages/k8s-ui/src/components/logs/log-palette.ts
+++ b/packages/k8s-ui/src/components/logs/log-palette.ts
@@ -42,6 +42,8 @@ export interface LogPalette {
   hoverBg: string
   hoverSurface: string
   hoverText: string
+  /** Active/selected toolbar controls inside the viewer. */
+  toolbarActive: string
 
   // Row highlight (current search match)
   currentMatchBg: string
@@ -100,6 +102,7 @@ const DARK_PALETTE: LogPalette = {
   hoverBg: 'hover:bg-slate-800',
   hoverSurface: 'hover:bg-slate-800/50',
   hoverText: 'hover:text-slate-100',
+  toolbarActive: 'bg-slate-700 text-slate-100 hover:bg-slate-600',
 
   currentMatchBg: 'bg-yellow-500/10',
 
@@ -155,6 +158,7 @@ const LIGHT_PALETTE: LogPalette = {
   hoverBg: 'hover:bg-slate-200',
   hoverSurface: 'hover:bg-slate-200/60',
   hoverText: 'hover:text-slate-900',
+  toolbarActive: 'bg-slate-200 text-slate-900 hover:bg-slate-300',
 
   currentMatchBg: 'bg-yellow-200/60',
 

--- a/packages/k8s-ui/src/components/logs/log-palette.ts
+++ b/packages/k8s-ui/src/components/logs/log-palette.ts
@@ -30,6 +30,12 @@ export interface LogPalette {
   textSecondary: string
   textTertiary: string
   textDisabled: string
+  /** Standalone error text (inline "error=..." in structured lines, inline validation errors). */
+  textError: string
+  /** Accent/link text — blue-family. Used for toolbar toggles, "select all" etc. */
+  textAccent: string
+  /** Checkmark green on option-menu items. */
+  textCheckmark: string
 
   // Placeholder (plain class, applied via `placeholder-*` below)
   placeholder: string
@@ -54,6 +60,24 @@ export interface LogPalette {
   levelBadgeInfo: string
   levelBadgeDebug: string
   levelBadgeNeutral: string
+
+  /**
+   * Pod label colors for WorkloadLogsViewer (aggregated logs across pods).
+   * Pairs: one class for the name text, one for the filter-list dot.
+   * Pods are round-robined through this array.
+   */
+  podColors: Array<{ text: string; bg: string }>
+
+  /**
+   * Syntax-highlight colors for structured JSON/logfmt renderings.
+   * Applied as inline `style={{ color }}` (not classes) because the values
+   * come from log-format.ts and feed React's style prop.
+   */
+  syntaxKey: string
+  syntaxString: string
+  syntaxNumber: string
+  syntaxBoolean: string
+  syntaxNull: string
 }
 
 const DARK_PALETTE: LogPalette = {
@@ -70,6 +94,9 @@ const DARK_PALETTE: LogPalette = {
   textSecondary: 'text-slate-400',
   textTertiary: 'text-slate-500',
   textDisabled: 'text-slate-600',
+  textError: 'text-red-400',
+  textAccent: 'text-blue-400',
+  textCheckmark: 'text-emerald-400',
 
   placeholder: 'placeholder-slate-600',
 
@@ -89,6 +116,24 @@ const DARK_PALETTE: LogPalette = {
   levelBadgeInfo: 'bg-blue-500/20 text-blue-400 border border-blue-500/40',
   levelBadgeDebug: 'bg-slate-700 text-slate-300 border border-slate-600',
   levelBadgeNeutral: 'bg-slate-800 text-slate-400 border border-slate-700',
+
+  podColors: [
+    { text: 'text-blue-400', bg: 'bg-blue-400' },
+    { text: 'text-emerald-400', bg: 'bg-emerald-400' },
+    { text: 'text-amber-400', bg: 'bg-amber-400' },
+    { text: 'text-purple-400', bg: 'bg-purple-400' },
+    { text: 'text-pink-400', bg: 'bg-pink-400' },
+    { text: 'text-cyan-400', bg: 'bg-cyan-400' },
+    { text: 'text-orange-400', bg: 'bg-orange-400' },
+    { text: 'text-lime-400', bg: 'bg-lime-400' },
+  ],
+
+  // Hex values tuned for the `bg-slate-950` container.
+  syntaxKey: '#7cacf8',
+  syntaxString: '#73c991',
+  syntaxNumber: '#e5c07b',
+  syntaxBoolean: '#c678dd',
+  syntaxNull: '#808080',
 }
 
 const LIGHT_PALETTE: LogPalette = {
@@ -105,6 +150,9 @@ const LIGHT_PALETTE: LogPalette = {
   textSecondary: 'text-slate-600',
   textTertiary: 'text-slate-400',
   textDisabled: 'text-slate-300',
+  textError: 'text-red-700',
+  textAccent: 'text-blue-700',
+  textCheckmark: 'text-emerald-700',
 
   placeholder: 'placeholder-slate-400',
 
@@ -124,6 +172,25 @@ const LIGHT_PALETTE: LogPalette = {
   levelBadgeInfo: 'bg-blue-100 text-blue-700 border border-blue-400',
   levelBadgeDebug: 'bg-slate-200 text-slate-700 border border-slate-400',
   levelBadgeNeutral: 'bg-slate-100 text-slate-600 border border-slate-300',
+
+  podColors: [
+    { text: 'text-blue-700', bg: 'bg-blue-700' },
+    { text: 'text-emerald-700', bg: 'bg-emerald-700' },
+    { text: 'text-amber-700', bg: 'bg-amber-700' },
+    { text: 'text-purple-700', bg: 'bg-purple-700' },
+    { text: 'text-pink-700', bg: 'bg-pink-700' },
+    { text: 'text-cyan-700', bg: 'bg-cyan-700' },
+    { text: 'text-orange-700', bg: 'bg-orange-700' },
+    { text: 'text-lime-700', bg: 'bg-lime-700' },
+  ],
+
+  // Hex values tuned for the `bg-slate-50` container — darker so they read
+  // on a near-white background.
+  syntaxKey: '#0b63c0',
+  syntaxString: '#2b8a3e',
+  syntaxNumber: '#b95f00',
+  syntaxBoolean: '#7c3aed',
+  syntaxNull: '#6b7280',
 }
 
 /** Get the palette for the current dark/light mode. */

--- a/packages/k8s-ui/src/components/logs/log-palette.ts
+++ b/packages/k8s-ui/src/components/logs/log-palette.ts
@@ -34,8 +34,6 @@ export interface LogPalette {
   textError: string
   /** Accent/link text — blue-family. Used for toolbar toggles, "select all" etc. */
   textAccent: string
-  /** Checkmark green on option-menu items. */
-  textCheckmark: string
 
   // Placeholder (plain class, applied via `placeholder-*` below)
   placeholder: string
@@ -96,7 +94,6 @@ const DARK_PALETTE: LogPalette = {
   textDisabled: 'text-slate-600',
   textError: 'text-red-400',
   textAccent: 'text-blue-400',
-  textCheckmark: 'text-emerald-400',
 
   placeholder: 'placeholder-slate-600',
 
@@ -152,7 +149,6 @@ const LIGHT_PALETTE: LogPalette = {
   textDisabled: 'text-slate-300',
   textError: 'text-red-700',
   textAccent: 'text-blue-700',
-  textCheckmark: 'text-emerald-700',
 
   placeholder: 'placeholder-slate-400',
 

--- a/packages/k8s-ui/src/components/logs/useLogBuffer.ts
+++ b/packages/k8s-ui/src/components/logs/useLogBuffer.ts
@@ -9,7 +9,12 @@ export interface LogEntry {
   content: string
   container: string
   pod?: string
-  podColor?: string
+  /**
+   * Index into the current palette's `podColors` array. Stored as an index
+   * (not a resolved class) so the pod-label color can re-theme when the
+   * viewer's isDark state toggles at runtime.
+   */
+  podColorIndex?: number
   level: LogLevel
   isJson: boolean
   isLogfmt: boolean

--- a/web/src/components/logs/LogsViewer.tsx
+++ b/web/src/components/logs/LogsViewer.tsx
@@ -3,6 +3,7 @@ import { fetchJSON, createLogStream } from '../../api/client'
 import { LogsViewer as SharedLogsViewer } from '@skyhook-io/k8s-ui'
 import type { LogsFetchParams } from '@skyhook-io/k8s-ui'
 import { useDesktopDownload } from '../../hooks/useDesktopDownload'
+import { useTheme } from '../../context/ThemeContext'
 
 interface LogsViewerProps {
   namespace: string
@@ -13,6 +14,7 @@ interface LogsViewerProps {
 
 export function LogsViewer({ namespace, podName, containers, initialContainer }: LogsViewerProps) {
   const desktopDownload = useDesktopDownload()
+  const { theme } = useTheme()
 
   const fetchLogs = useCallback(async (params: LogsFetchParams) => {
     const query = new URLSearchParams()
@@ -39,6 +41,7 @@ export function LogsViewer({ namespace, podName, containers, initialContainer }:
       fetchLogs={fetchLogs}
       createStream={makeStream}
       overrideDownload={desktopDownload}
+      forceDark={theme === 'dark' ? true : undefined}
     />
   )
 }

--- a/web/src/components/logs/WorkloadLogsViewer.tsx
+++ b/web/src/components/logs/WorkloadLogsViewer.tsx
@@ -3,6 +3,7 @@ import { fetchJSON, createWorkloadLogStream } from '../../api/client'
 import { WorkloadLogsViewer as SharedWorkloadLogsViewer } from '@skyhook-io/k8s-ui'
 import type { WorkloadLogsFetchParams, WorkloadLogsResult } from '@skyhook-io/k8s-ui'
 import { useDesktopDownload } from '../../hooks/useDesktopDownload'
+import { useTheme } from '../../context/ThemeContext'
 
 interface WorkloadLogsViewerProps {
   kind: string
@@ -12,6 +13,7 @@ interface WorkloadLogsViewerProps {
 
 export function WorkloadLogsViewer({ kind, namespace, name }: WorkloadLogsViewerProps) {
   const desktopDownload = useDesktopDownload()
+  const { theme } = useTheme()
 
   const fetchAll = useCallback(async (params: WorkloadLogsFetchParams): Promise<WorkloadLogsResult> => {
     const query = new URLSearchParams()
@@ -35,6 +37,7 @@ export function WorkloadLogsViewer({ kind, namespace, name }: WorkloadLogsViewer
       fetchAll={fetchAll}
       createStream={makeStream}
       overrideDownload={desktopDownload}
+      forceDark={theme === 'dark' ? true : undefined}
     />
   )
 }


### PR DESCRIPTION
## Summary

The log viewer forces `color-scheme: dark` on its own container so it can render as a terminal-style dark surface regardless of page theme. Theme tokens (`text-theme-*`, `bg-theme-*`) are supposed to follow that via CSS `light-dark()` — but after the Tailwind v4 migration in #487 that propagation broke. Result: dark-grey text on dark-grey bg = unreadable logs in light-page mode (reproducible in Radar Cloud, where `@skyhook-io/radar-app` embeds into a light-themed host).

## Fix

Pragmatic bypass: explicit slate-* palettes in a new `log-palette.ts`, selected by the viewer's own `isDark` state. No dependency on `light-dark()` resolution; no page-theme token inheritance inside the log viewer. Result: the log viewer's visuals depend only on its own Sun/Moon toggle state. Light page + dark log viewer now renders slate-100 on slate-950 = readable. Light viewer on dark page also works.

## Commits

1. **`c2d60de` — initial palette bypass.** Add `log-palette.ts` (DARK_PALETTE / LIGHT_PALETTE + `getLogPalette(isDark)` / `getLogLevelColor(level, isDark)`). Strip all `text-theme-*` / `bg-theme-*` / `border-theme-*` / `hover:bg-theme-*` tokens from LogCore/StructuredLogLine/JsonLogLine/LogsViewer/WorkloadLogsViewer/LogToolbarSelects. Widen `toolbarExtra` prop from `ReactNode` to `ReactNode | ((ctx: { isDark, palette }) => ReactNode)` so wrapper viewers can palette-match their inline controls.

2. **`1760332` — review follow-up.** Close the gaps the first pass left:
   - `POD_COLORS` (hardcoded `text-*-400`) moved onto palette as `podColors: { text, bg }[]`; `LogEntry.podColor` → `LogEntry.podColorIndex` (int index) so toggling isDark re-themes pod labels without refetching.
   - `SYNTAX_COLOR_*` hex constants moved onto palette; light variants added (`#0b63c0` etc.) for dark-on-light readability.
   - Added `textError` + `textAccent` palette fields; collapsed 4 inline `isDark ? 'text-red-400' : 'text-red-700'` escape hatches.
   - Fixed `@default true` on `forceDark` JSDoc (prop has no default; `undefined` falls through to localStorage).
   - Deduplicated the "why theme tokens are bypassed" rationale — canonical in `log-palette.ts`, one-liner pointers elsewhere.

3. **`ad05c60` — simplifier pass.** `import type { LogPalette }` at top of LogsViewer/WorkloadLogsViewer (drops inline `import('./log-palette').LogPalette`); lift nested ternary in WorkloadLogsViewer pod row to local consts; `selectClass` in LogToolbarSelects takes a palette directly (one `getLogPalette` call per render instead of two); drop unused `textCheckmark` field.

## Follow-up needed

For this to reach Radar Cloud users, `@skyhook-io/radar-app` needs a new release that includes this commit, then `radar-hub-web`'s `^0.1.3` dep bumps. The version in `web/package.json` is already at `0.1.4` but that tag was never pushed. Proposal: tag `radar-app-v0.1.5` from merged state (clean jump past the unpublished 0.1.4).

## Out of scope

- `JsonLogLine.tsx` is dead code (not exported from `components/logs/index.ts`; `web/` shim re-exports `StructuredLogLine` under that name). Pre-existing, not a regression. Flagged for a separate cleanup.
- Full root-cause fix for why `light-dark()` doesn't propagate through `color-scheme: dark` containers after Tailwind v4. The bypass here is the pragmatic shipping fix; root cause is deferred.