### PR TITLE
chart: port self-upgrade RBAC + env vars from helm-charts #9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install clean dev frontend backend test test-e2e lint help restart restart-fe kill watch-backend watch-frontend
+.PHONY: build install clean dev frontend backend test test-e2e test-chart lint help restart restart-fe kill watch-backend watch-frontend
 .PHONY: release release-binaries-dry docker docker-test docker-multiarch docker-push
 .PHONY: desktop desktop-binary desktop-dev desktop-package-darwin desktop-package-windows desktop-package-linux
 
@@ -136,6 +136,10 @@ test:
 # Run e2e tests against the current kubeconfig cluster (on-demand, not in CI)
 test-e2e:
 	go test -tags e2e -v -timeout 5m ./internal/k8s/
+
+# Smoke-test the Helm chart's template rendering (requires `helm` on PATH)
+test-chart:
+	./scripts/test-chart.sh
 
 # Run linter
 lint:

--- a/deploy/helm/radar/README.md
+++ b/deploy/helm/radar/README.md
@@ -98,6 +98,16 @@ Disabled by default for security:
 | Port Forward | `rbac.portForward: true` | Port forwarding to pods |
 | Logs | `rbac.podLogs: true` | View pod logs (**enabled by default**) |
 
+### In-app Agent Upgrades (opt-in, for Radar Cloud users)
+
+`rbac.selfUpgrade: true` lets Radar Cloud trigger one-click upgrades from the web UI — no terminal or cloud credentials needed. Disabled by default; only needed when connecting to Radar Cloud (the install wizard sets this automatically).
+
+It creates a namespace-scoped Role (not a ClusterRole) with `get` + `patch` on this Deployment only, enforced via `resourceNames`. The endpoint validates that the requested image comes from `ghcr.io/skyhook-io/radar` before issuing any patch.
+
+```bash
+--set rbac.selfUpgrade=true
+```
+
 ### CRD Access
 
 Radar discovers CRDs in your cluster. All common CRD groups are enabled by default. Granting RBAC for CRDs that don't exist has no effect.

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -145,6 +145,14 @@ spec:
               {{- end }}
             {{- end }}
             {{- end }}
+            {{- if .Values.rbac.selfUpgrade }}
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_DEPLOYMENT_NAME
+              value: {{ include "radar.fullname" . }}
+            {{- end }}
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deploy/helm/radar/templates/selfupgrade-role.yaml
+++ b/deploy/helm/radar/templates/selfupgrade-role.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.rbac.create .Values.rbac.selfUpgrade -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "radar.fullname" . }}-self-upgrade
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "radar.labels" . | nindent 4 }}
+rules:
+  # Allows Radar Cloud to patch this Deployment's image via the yamux tunnel,
+  # enabling one-click upgrades from the Radar Cloud UI. Scoped to this
+  # Deployment only — no other resources or namespaces are affected.
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames: ["{{ include "radar.fullname" . }}"]
+    verbs: ["get", "patch"]
+{{- end }}

--- a/deploy/helm/radar/templates/selfupgrade-rolebinding.yaml
+++ b/deploy/helm/radar/templates/selfupgrade-rolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.rbac.create .Values.rbac.selfUpgrade -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "radar.fullname" . }}-self-upgrade
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "radar.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "radar.fullname" . }}-self-upgrade
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "radar.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -50,6 +50,15 @@ rbac:
   # Allow port forwarding (enables port forward feature)
   portForward: false
 
+  # Allow Radar Cloud to trigger one-click in-app upgrades without customers
+  # needing a terminal or cloud credentials. Not needed for standalone/local
+  # installs — those have direct kubectl/Helm access anyway.
+  # Security scope: namespace-scoped Role (not ClusterRole), restricted to this
+  # Deployment only via resourceNames, get+patch verbs only (no delete/create).
+  # The endpoint validates that the requested image comes from
+  # ghcr.io/skyhook-io/radar before issuing any patch.
+  selfUpgrade: false
+
   # Traffic visibility (Hubble/Cilium integration)
   # Grants read access ONLY to hubble-relay-client-certs secret for TLS auth
   traffic: true

--- a/scripts/test-chart.sh
+++ b/scripts/test-chart.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Smoke tests for the radar Helm chart's template rendering.
+#
+# Exercises the self-upgrade toggle paths: the chart was silently clobbered
+# by release.yml's wholesale-replace sync once (helm-charts@c68795c wiped
+# helm-charts#9). Golden-string assertions here pin the rendered output so
+# the next regression fails the build instead of shipping silently.
+#
+# Usage:
+#   ./scripts/test-chart.sh
+
+set -euo pipefail
+
+CHART_DIR="$(cd "$(dirname "$0")/.." && pwd)/deploy/helm/radar"
+FAIL=0
+CASE=""
+
+fail() {
+  echo "    ✗ $1"
+  FAIL=1
+}
+pass() {
+  echo "    ✓ $1"
+}
+
+assert_contains() {
+  local pattern="$1" label="$2"
+  if echo "$OUT" | grep -Eq "$pattern"; then pass "$label"
+  else fail "$label — no match for: $pattern"; fi
+}
+
+assert_not_contains() {
+  local pattern="$1" label="$2"
+  if echo "$OUT" | grep -Eq "$pattern"; then fail "$label — unexpected match for: $pattern"
+  else pass "$label"; fi
+}
+
+render() {
+  CASE="$1"; shift
+  echo "  Case: $CASE"
+  OUT=$(helm template radar "$CHART_DIR" "$@" 2>&1) || {
+    fail "helm template failed"
+    echo "$OUT" | sed 's/^/      /'
+    return
+  }
+}
+
+echo "Running chart template tests against $CHART_DIR"
+echo
+
+render "defaults — no self-upgrade footprint"
+assert_not_contains '^kind: Role$'                  "no namespaced Role"
+assert_not_contains '^kind: RoleBinding$'           "no namespaced RoleBinding"
+assert_not_contains 'MY_POD_NAMESPACE'              "no downward-API env var"
+assert_not_contains 'MY_DEPLOYMENT_NAME'            "no deployment-name env var"
+assert_not_contains 'self-upgrade'                  "no self-upgrade references anywhere"
+echo
+
+render "rbac.selfUpgrade=true — full feature wiring" --set rbac.selfUpgrade=true
+assert_contains '^kind: Role$'                      "namespaced Role emitted"
+assert_contains '^kind: RoleBinding$'               "namespaced RoleBinding emitted"
+assert_contains 'name: radar-self-upgrade$'         "names match fullname-self-upgrade convention"
+assert_contains 'resourceNames: \["radar"\]'        "Role restricted via resourceNames to the Deployment"
+assert_contains 'verbs: \["get", "patch"\]'         "verbs scoped to get+patch"
+assert_contains 'apiGroups: \["apps"\]'             "apiGroup scoped to apps"
+assert_contains 'resources: \["deployments"\]'      "resource scoped to deployments"
+assert_contains 'name: radar$'                      "RoleBinding subject is radar SA"
+assert_contains 'MY_POD_NAMESPACE'                  "downward-API namespace env var injected"
+assert_contains 'fieldPath: metadata.namespace'     "namespace sourced from downward API"
+assert_contains 'MY_DEPLOYMENT_NAME'                "deployment-name env var injected"
+echo
+
+render "cloud.enabled=true alone — does NOT auto-enable self-upgrade" \
+  --set cloud.enabled=true --set cloud.url=wss://x --set cloud.token=t --set cloud.clusterName=c
+assert_not_contains 'MY_POD_NAMESPACE'              "env vars absent without explicit rbac.selfUpgrade"
+assert_not_contains 'self-upgrade'                  "no Role/RoleBinding without explicit opt-in"
+echo
+
+render "rbac.create=false + rbac.selfUpgrade=true — pins current PR #9 gating" \
+  --set rbac.create=false --set rbac.selfUpgrade=true
+# NOTE: this combo is a footgun (env vars render, Role does not → runtime 403).
+# We deliberately lock in the current helm-charts#9 behavior here. If gating
+# is ever redesigned, update this case rather than silently flipping behavior.
+assert_not_contains '^kind: Role$'                  "no Role when rbac.create=false (matches cloud-rbac convention)"
+assert_not_contains '^kind: RoleBinding$'           "no RoleBinding when rbac.create=false"
+assert_contains 'MY_POD_NAMESPACE'                  "env vars still injected — known footgun, tracked separately"
+echo
+
+if [[ $FAIL -eq 0 ]]; then
+  echo "All chart template tests passed."
+  exit 0
+else
+  echo "One or more assertions failed."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- helm-charts#9 added self-upgrade Role/RoleBinding + `MY_POD_NAMESPACE`/`MY_DEPLOYMENT_NAME` env vars for backend PR #526's `/api/agent/self-upgrade` endpoint — but it was merged directly to the mirror, not to this source-of-truth.
- `release.yml`'s sync step (`rm -rf /tmp/helm-charts/charts/radar; cp -r deploy/helm/radar …`) ran next and wiped it. Published chart v1.5.3 is v1.5.2 contents with a version-label bump.
- This PR re-applies #9 verbatim to the source of truth + adds smoke tests so the next time this gets clobbered, CI fails loudly.
- Byte-identical to helm-charts commit `d0c81e8` for the new/edited blocks.

## Evidence the feature is broken today

```
$ helm install radar skyhook/radar --set cloud.enabled=true --set rbac.selfUpgrade=true …
$ kubectl exec … -- curl -XPOST localhost:9280/api/agent/self-upgrade -d '{"image":"ghcr.io/skyhook-io/radar:1.5.3"}'
{"error":"self-upgrade not configured (set rbac.selfUpgrade=true in Helm values)"}
```

503 fires because `MY_POD_NAMESPACE` is unset — the chart never injected it. Every Cloud-install upgrade-button click returns this.

## After this merges

1. Next radar release → `release.yml` syncs these files into helm-charts. Published chart actually has self-upgrade.
2. Cloud customers on the new chart version get the one-click upgrade button working.
3. `make test-chart` catches the next sync-clobber immediately.

## Tests (included, not follow-up)

`scripts/test-chart.sh` + `make test-chart` target. 4 cases, 21 assertions:

| Case | Assertion |
|------|-----------|
| defaults | no Role/RoleBinding/env-vars/self-upgrade references anywhere |
| `rbac.selfUpgrade=true` | Role+RoleBinding with `get`+`patch` on `apps/deployments` restricted by `resourceNames`; env vars present with downward-API namespace source |
| `cloud.enabled=true` alone | does NOT auto-enable self-upgrade (wizard sets it explicitly) |
| `rbac.create=false + selfUpgrade=true` | pins current PR #9 gating: env vars render, Role does not — see footgun below |

All 21 pass locally. Not wired into `make test` — helm isn't guaranteed on every dev's PATH and isn't in CI today. Follow-up would add a helm install step to CI and invoke `make test-chart` from the test job.

## Known footgun, pinned in test

`rbac.create=false` + `rbac.selfUpgrade=true` renders deployment env vars but suppresses the Role → runtime 403. This is verbatim from helm-charts#9, not introduced here. Test #4 locks the current behavior so any future redesign has to update the test deliberately. Gating cleanup belongs in a separate PR (also takes the opportunity to revisit whether `rbac.create=false` should imply all feature flags are no-ops chart-wide).

## Test plan

- [x] `make test-chart` — all 21 assertions pass
- [x] Byte-diff against `d0c81e8`: `selfupgrade-role.yaml`, `selfupgrade-rolebinding.yaml`, `README.md` identical; `selfUpgrade` blocks in `deployment.yaml`/`values.yaml` identical
- [ ] After merge + next release, rerun the `/api/agent/self-upgrade` curl above on a fresh cluster — should 200/403, not 503

## Follow-ups (separate PRs)

- Branch-protect `helm-charts/charts/**` to block direct human pushes; enforces "the mirror is a mirror" instead of trusting it socially.
- Gating cleanup for the `rbac.create=false + selfUpgrade=true` combo — either align env-var gate with Role gate, add `{{ fail }}`, or redesign the chart-wide `rbac.create` convention.
- Wire `make test-chart` into CI (requires helm install step).
- Comment rot cleanup (separate PR to keep this one as a clean verbatim port): drop "via the yamux tunnel" from the Role comment; loosen the registry string in values.yaml/README to reference the Go allowlist as source of truth.