### PR TITLE
chart: fix self-upgrade gating — decouple from rbac.create

### DIFF
--- a/deploy/helm/radar/templates/selfupgrade-role.yaml
+++ b/deploy/helm/radar/templates/selfupgrade-role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create .Values.rbac.selfUpgrade -}}
+{{- if .Values.rbac.selfUpgrade -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/deploy/helm/radar/templates/selfupgrade-rolebinding.yaml
+++ b/deploy/helm/radar/templates/selfupgrade-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create .Values.rbac.selfUpgrade -}}
+{{- if .Values.rbac.selfUpgrade -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/scripts/test-chart.sh
+++ b/scripts/test-chart.sh
@@ -76,14 +76,18 @@ assert_not_contains 'MY_POD_NAMESPACE'              "env vars absent without exp
 assert_not_contains 'self-upgrade'                  "no Role/RoleBinding without explicit opt-in"
 echo
 
-render "rbac.create=false + rbac.selfUpgrade=true — pins current PR #9 gating" \
+render "rbac.create=false + rbac.selfUpgrade=true — feature still works" \
   --set rbac.create=false --set rbac.selfUpgrade=true
-# NOTE: this combo is a footgun (env vars render, Role does not → runtime 403).
-# We deliberately lock in the current helm-charts#9 behavior here. If gating
-# is ever redesigned, update this case rather than silently flipping behavior.
-assert_not_contains '^kind: Role$'                  "no Role when rbac.create=false (matches cloud-rbac convention)"
-assert_not_contains '^kind: RoleBinding$'           "no RoleBinding when rbac.create=false"
-assert_contains 'MY_POD_NAMESPACE'                  "env vars still injected — known footgun, tracked separately"
+# `rbac.create` is the master switch for the big cluster-wide ClusterRole —
+# a BYO-RBAC user needs that to live outside the chart. The self-upgrade
+# Role is narrow (get+patch on THIS Deployment by resourceNames), so it
+# doesn't belong under that switch; cloud-rbac.yaml already follows the
+# same "feature gates itself, independent of rbac.create" pattern. Either
+# the feature is on end-to-end or it's off end-to-end — no silent 403.
+assert_contains '^kind: Role$'                      "Role still emitted — narrow scope, independent of rbac.create"
+assert_contains '^kind: RoleBinding$'               "RoleBinding still emitted"
+assert_not_contains '^kind: ClusterRole$'           "no ClusterRole when rbac.create=false (big ClusterRole still suppressed)"
+assert_contains 'MY_POD_NAMESPACE'                  "env vars injected — feature is fully wired"
 echo
 
 if [[ $FAIL -eq 0 ]]; then


### PR DESCRIPTION
## Summary

Two-line fix + test update. The self-upgrade Role and RoleBinding were gated on `rbac.create AND rbac.selfUpgrade`, but deployment env vars on `rbac.selfUpgrade` alone. The combo `rbac.create=false + rbac.selfUpgrade=true` rendered a pod that thought the feature was wired (env vars present → backend guard at `selfupgrade.go:28-29` passes) but had no RBAC behind it. Silent 403 at upgrade-click time, no loud error at helm install.

## Root cause

`rbac.create` and `rbac.selfUpgrade` answer different questions. Conflating them caused the drift.

| Value | Question it answers | Blast radius |
|-------|---------------------|--------------|
| `rbac.create` | Who emits the chart's big ClusterRole? | Cluster-wide reads on all resources. Legitimately externalizable. |
| `rbac.selfUpgrade` | Is the self-upgrade feature on? | One `patch` verb on one named Deployment via `resourceNames`. This pod's own Deployment only. |

The self-upgrade Role is too narrow to belong under `rbac.create`'s master switch. `cloud-rbac.yaml` already sets this precedent — it gates on `cloud.enabled && cloud.defaultRbac.create` (its own toggle), independent of `rbac.create`. Aligning selfupgrade with that pattern removes the conflation.

## Change

```diff
-{{- if and .Values.rbac.create .Values.rbac.selfUpgrade -}}
+{{- if .Values.rbac.selfUpgrade -}}
```

In both `selfupgrade-role.yaml` and `selfupgrade-rolebinding.yaml`.

## Mental model after

| Input | Outcome |
|-------|---------|
| `selfUpgrade=false`, any `rbac.create` | Feature off. No env vars, no Role, no RoleBinding. |
| `selfUpgrade=true`, any `rbac.create` | Feature on end-to-end. Env vars + Role + RoleBinding rendered. |

No silent 403 combo.

## Tests

`make test-chart` — case 4 (`rbac.create=false + selfUpgrade=true`) flipped to lock in the new correct behavior:

```
✓ Role still emitted — narrow scope, independent of rbac.create
✓ RoleBinding still emitted
✓ no ClusterRole when rbac.create=false (big ClusterRole still suppressed)
✓ env vars injected — feature is fully wired
```

22/22 assertions pass.

## Note on "what about strict BYO-RBAC shops?"

The hypothetical user who wants to externalize even a 1-verb/1-named-resource Role could be served by a future `rbac.selfUpgrade.externalRole: true` escape hatch (two lines). Not building it speculatively — YAGNI. Anyone who actually hits this can request it with a concrete use case.

## Test plan

- [x] `make test-chart` — all cases pass
- [x] Verified `helm template` output on all four value combos
- [ ] After merge + next release, rerun the Cloud upgrade-button flow on a fresh cluster — should 200, not 503 or 403