### PR TITLE
feat: /api/packages REST + MCP list_packages with 4-source GitOps detection

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -154,16 +154,21 @@ func registerTools(server *mcp.Server) {
 			"Argo Applications, Flux HelmReleases + Kustomizations) with their sources, " +
 			"versions, and health. Each row carries a `sources` array (H=Helm API, " +
 			"L=workload labels, C=CRD registrations, A=Argo declaration, F=Flux declaration) " +
-			"so the caller can see WHY this package is detected. Use to answer 'what's " +
-			"installed?' / 'what version of cert-manager is running?' / 'are there orphaned " +
-			"operators?' in a single call instead of combining list_helm_releases + " +
-			"list_resources + manual merge. Filter by namespace, source, or chart substring. " +
-			"Response includes `sourcesErrored` listing any sources that failed (e.g. RBAC " +
-			"denied for Helm release secrets, Helm client not initialized, GitOps informer " +
-			"errors other than the controller's CRDs being absent). When this is non-empty, " +
-			"results are still returned but are partial — fewer rows than expected may " +
-			"indicate a dropped source rather than nothing installed. ArgoCD/FluxCD CRDs " +
-			"that are simply not installed in the cluster do NOT appear in sourcesErrored.",
+			"so the caller can see WHY this package is detected, plus a `contributors` " +
+			"array with per-source detail (each source's view of health/version, plus the " +
+			"GitOps controller resource identity in declarationName/declarationNamespace " +
+			"for sources A and F). Aggregated row-level health is worst-of contributors; " +
+			"row-level version is first-source-priority — read `contributors` to detect " +
+			"same-cluster disagreement. Use to answer 'what's installed?' / 'what version " +
+			"of cert-manager is running?' / 'are there orphaned operators?' in a single " +
+			"call instead of combining list_helm_releases + list_resources + manual merge. " +
+			"Filter by namespace, source, or chart substring. Response includes " +
+			"`sourcesErrored` listing any sources that failed (e.g. RBAC denied for Helm " +
+			"release secrets, Helm client not initialized, GitOps informer errors other " +
+			"than the controller's CRDs being absent). When this is non-empty, results " +
+			"are still returned but are partial — fewer rows than expected may indicate a " +
+			"dropped source rather than nothing installed. ArgoCD/FluxCD CRDs that are " +
+			"simply not installed in the cluster do NOT appear in sourcesErrored.",
 		Annotations: readOnly,
 	}, logToolCall("list_packages", handleListPackages))
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -159,9 +159,11 @@ func registerTools(server *mcp.Server) {
 			"operators?' in a single call instead of combining list_helm_releases + " +
 			"list_resources + manual merge. Filter by namespace, source, or chart substring. " +
 			"Response includes `sourcesErrored` listing any sources that failed (e.g. RBAC " +
-			"denied for Helm release secrets, missing GitOps controller informer). When this " +
-			"is non-empty, results are still returned but are partial — fewer rows than " +
-			"expected may indicate a dropped source rather than nothing installed.",
+			"denied for Helm release secrets, Helm client not initialized, GitOps informer " +
+			"errors other than the controller's CRDs being absent). When this is non-empty, " +
+			"results are still returned but are partial — fewer rows than expected may " +
+			"indicate a dropped source rather than nothing installed. ArgoCD/FluxCD CRDs " +
+			"that are simply not installed in the cluster do NOT appear in sourcesErrored.",
 		Annotations: readOnly,
 	}, logToolCall("list_packages", handleListPackages))
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -140,6 +140,27 @@ func registerTools(server *mcp.Server) {
 		Annotations: readOnly,
 	}, logToolCall("get_helm_release", handleGetHelmRelease))
 
+	// --- Packages tool (read-only) ---
+	//
+	// Higher-level than list_helm_releases: collapses Helm releases,
+	// workload labels, CRD registrations, and GitOps declarations
+	// (Argo Applications + Flux HelmReleases/Kustomizations) into a
+	// unified "what's installed in this cluster" view with source
+	// provenance. Each row's `sources` field shows which detection
+	// channels voted "this is installed" — H, L, C, A, F.
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "list_packages",
+		Description: "List installed packages (Helm releases, label-managed workloads, CRDs, " +
+			"Argo Applications, Flux HelmReleases + Kustomizations) with their sources, " +
+			"versions, and health. Each row carries a `sources` array (H=Helm API, " +
+			"L=workload labels, C=CRD registrations, A=Argo declaration, F=Flux declaration) " +
+			"so the caller can see WHY this package is detected. Use to answer 'what's " +
+			"installed?' / 'what version of cert-manager is running?' / 'are there orphaned " +
+			"operators?' in a single call instead of combining list_helm_releases + " +
+			"list_resources + manual merge. Filter by namespace, source, or chart substring.",
+		Annotations: readOnly,
+	}, logToolCall("list_packages", handleListPackages))
+
 	// --- Workload logs tool (read-only) ---
 
 	mcp.AddTool(server, &mcp.Tool{

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -157,7 +157,11 @@ func registerTools(server *mcp.Server) {
 			"so the caller can see WHY this package is detected. Use to answer 'what's " +
 			"installed?' / 'what version of cert-manager is running?' / 'are there orphaned " +
 			"operators?' in a single call instead of combining list_helm_releases + " +
-			"list_resources + manual merge. Filter by namespace, source, or chart substring.",
+			"list_resources + manual merge. Filter by namespace, source, or chart substring. " +
+			"Response includes `sourcesErrored` listing any sources that failed (e.g. RBAC " +
+			"denied for Helm release secrets, missing GitOps controller informer). When this " +
+			"is non-empty, results are still returned but are partial — fewer rows than " +
+			"expected may indicate a dropped source rather than nothing installed.",
 		Annotations: readOnly,
 	}, logToolCall("list_packages", handleListPackages))
 

--- a/internal/mcp/tools_packages.go
+++ b/internal/mcp/tools_packages.go
@@ -1,0 +1,39 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/skyhook-io/radar/internal/server"
+)
+
+// listPackagesInput mirrors the /api/packages query params. Same shape
+// is exposed both as a REST handler and an MCP tool — the tool's job
+// is just to surface the merged "what's installed" view in a way an
+// AI agent can consume directly.
+type listPackagesInput struct {
+	Namespace string `json:"namespace,omitempty" jsonschema:"limit to packages in this namespace (release-namespace match). Default: all namespaces."`
+	Source    string `json:"source,omitempty" jsonschema:"limit to rows where this source contributed. One of: H (Helm API), L (workload labels), C (CRDs), A (Argo Application), F (Flux HelmRelease/Kustomization)."`
+	Chart     string `json:"chart,omitempty" jsonschema:"case-insensitive substring filter on chart name."`
+}
+
+// handleListPackages calls the same `server.ListPackages` free function
+// the REST handler uses. Single source of truth for the merge logic +
+// the 60s namespace-keyed cache; the MCP path is just a different
+// transport with the same caching benefits.
+func handleListPackages(ctx context.Context, req *mcp.CallToolRequest, input listPackagesInput) (*mcp.CallToolResult, any, error) {
+	user, groups := userFromContext(ctx)
+	resp, err := server.ListPackages(ctx, server.ListPackagesParams{
+		Namespace: input.Namespace,
+		Source:    input.Source,
+		Chart:     input.Chart,
+		User:      user,
+		Groups:    groups,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("packages: %w", err)
+	}
+	return toJSONResult(resp)
+}

--- a/internal/mcp/tools_packages.go
+++ b/internal/mcp/tools_packages.go
@@ -9,28 +9,25 @@ import (
 	"github.com/skyhook-io/radar/internal/server"
 )
 
-// listPackagesInput mirrors the /api/packages query params. Same shape
-// is exposed both as a REST handler and an MCP tool — the tool's job
-// is just to surface the merged "what's installed" view in a way an
-// AI agent can consume directly.
+// listPackagesInput mirrors the /api/packages query params.
 type listPackagesInput struct {
 	Namespace string `json:"namespace,omitempty" jsonschema:"limit to packages in this namespace (release-namespace match). Default: all namespaces."`
-	Source    string `json:"source,omitempty" jsonschema:"limit to rows where this source contributed. One of: H (Helm API), L (workload labels), C (CRDs), A (Argo Application), F (Flux HelmRelease/Kustomization)."`
+	Source    string `json:"source,omitempty" jsonschema:"limit to rows where this source contributed. One of: H (Helm API), L (workload labels), C (CRDs), A (Argo Application), F (Flux HelmRelease/Kustomization). The response field 'sourcesErrored' lists sources that failed (e.g. RBAC denied for Helm release secrets) — fewer rows than expected may mean a source dropped out, not that nothing is installed."`
 	Chart     string `json:"chart,omitempty" jsonschema:"case-insensitive substring filter on chart name."`
 }
 
-// handleListPackages calls the same `server.ListPackages` free function
-// the REST handler uses. Single source of truth for the merge logic +
-// the 60s namespace-keyed cache; the MCP path is just a different
-// transport with the same caching benefits.
 func handleListPackages(ctx context.Context, req *mcp.CallToolRequest, input listPackagesInput) (*mcp.CallToolResult, any, error) {
 	user, groups := userFromContext(ctx)
+	var namespaces []string
+	if input.Namespace != "" {
+		namespaces = []string{input.Namespace}
+	}
 	resp, err := server.ListPackages(ctx, server.ListPackagesParams{
-		Namespace: input.Namespace,
-		Source:    input.Source,
-		Chart:     input.Chart,
-		User:      user,
-		Groups:    groups,
+		Namespaces: namespaces,
+		Source:     input.Source,
+		Chart:      input.Chart,
+		User:       user,
+		Groups:     groups,
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("packages: %w", err)

--- a/internal/server/packages.go
+++ b/internal/server/packages.go
@@ -1,0 +1,469 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/skyhook-io/radar/internal/auth"
+	"github.com/skyhook-io/radar/internal/helm"
+	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/pkg/packages"
+)
+
+// packagesCacheTTL bounds how often we recompute the merged package
+// list. Aggregate is cheap (~ms even on a 100-CRD cluster) but the
+// inputs cost: Helm secret reads, dynamic-cache walks, etc. The
+// dashboard endpoint uses the same 5s TTL pattern; align here.
+const packagesCacheTTL = 60 * time.Second
+
+// packagesCache holds the most recent /api/packages response, with a
+// per-namespace cache key. Single-value cache (not LRU) — only one
+// "all namespaces" + a few namespaced views in active use at once.
+var (
+	packagesCacheMu sync.Mutex
+	packagesCache   = map[string]packagesCacheEntry{}
+)
+
+type packagesCacheEntry struct {
+	at   time.Time
+	rows []packages.PackageRow
+}
+
+// PackagesResponse is the on-wire shape returned by /api/packages.
+type PackagesResponse struct {
+	Packages    []packages.PackageRow `json:"packages"`
+	GeneratedAt time.Time             `json:"generatedAt"`
+	// SourcesUsed is the set of source codes that contributed at least
+	// one row. Lets the SPA show "no Helm access — using labels + CRDs"
+	// callouts when the user's RBAC limits coverage.
+	SourcesUsed []string `json:"sourcesUsed"`
+	// SourcesErrored carries source-level failures (e.g. Helm 403). Each
+	// entry's `Source` matches the same single-character codes used in
+	// PackageRow.Sources. The fleet aggregator uses this to render
+	// per-cluster coverage callouts.
+	SourcesErrored []SourceError `json:"sourcesErrored,omitempty"`
+}
+
+// SourceError carries a per-source failure. Source is one of H/L/C/A/F.
+type SourceError struct {
+	Source     string `json:"source"`
+	StatusCode int    `json:"statusCode,omitempty"`
+	Error      string `json:"error"`
+}
+
+// ListPackagesParams carries the filters the REST + MCP handlers both
+// support.
+type ListPackagesParams struct {
+	Namespace string // empty = all namespaces
+	Source    string // H/L/C/A/F or empty
+	Chart     string // case-insensitive substring or empty
+	// User identity for Helm release secret reads. Empty username means
+	// "use the SA identity" (helm.ListReleasesAsUser convention).
+	User   string
+	Groups []string
+}
+
+// ListPackages is the public entry point shared by the REST handler
+// and the MCP tool. Free function (not a Server method) so MCP can
+// call without needing a Server reference — it relies on the same
+// k8s.GetResourceCache + helm.GetClient singletons the REST handler
+// reads through. Caches at the namespace level (60s TTL).
+func ListPackages(ctx context.Context, p ListPackagesParams) (PackagesResponse, error) {
+	cacheKey := p.Namespace
+	packagesCacheMu.Lock()
+	entry, hit := packagesCache[cacheKey]
+	packagesCacheMu.Unlock()
+
+	var rows []packages.PackageRow
+	var sourceErrs []SourceError
+	if hit && time.Since(entry.at) < packagesCacheTTL {
+		rows = entry.rows
+	} else {
+		var err error
+		rows, sourceErrs, err = computePackagesInternal(ctx, p.Namespace, p.User, p.Groups)
+		if err != nil {
+			return PackagesResponse{}, err
+		}
+		packagesCacheMu.Lock()
+		packagesCache[cacheKey] = packagesCacheEntry{at: time.Now(), rows: rows}
+		packagesCacheMu.Unlock()
+	}
+
+	if p.Source != "" {
+		rows = filterBySource(rows, strings.ToUpper(p.Source))
+	}
+	if p.Chart != "" {
+		rows = filterByChartSubstring(rows, strings.ToLower(p.Chart))
+	}
+
+	return PackagesResponse{
+		Packages:       rows,
+		GeneratedAt:    time.Now(),
+		SourcesUsed:    sourcesUsed(rows),
+		SourcesErrored: sourceErrs,
+	}, nil
+}
+
+// handleListPackages serves GET /api/packages.
+//
+// Query params:
+//
+//	?namespace=<name> — limit to packages whose release-namespace
+//	                     equals this. Default: all namespaces.
+//	?source=H|L|C|A|F — limit to rows that had this source contribute.
+//	?chart=<substr>   — limit to rows whose chart name contains this.
+//
+// Returns: PackagesResponse with the merged row list plus per-source
+// error attribution. 200 even when some sources failed (we'd rather
+// ship the partial view than 5xx the whole call).
+func (s *Server) handleListPackages(w http.ResponseWriter, r *http.Request) {
+	if !s.requireConnected(w) {
+		return
+	}
+	user, groups := userCredsForPackages(r)
+	resp, err := ListPackages(r.Context(), ListPackagesParams{
+		Namespace: r.URL.Query().Get("namespace"),
+		Source:    r.URL.Query().Get("source"),
+		Chart:     r.URL.Query().Get("chart"),
+		User:      user,
+		Groups:    groups,
+	})
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.writeJSON(w, resp)
+}
+
+// computePackagesInternal reads from all four (potentially five) data sources,
+// builds a packages.Sources, and runs Aggregate. Per-source errors are
+// captured but not fatal: a 403 on Helm (secret access denied) just
+// means the row set comes from L/C/A/F.
+func computePackagesInternal(ctx context.Context, namespace, user string, groups []string) ([]packages.PackageRow, []SourceError, error) {
+	cache := k8s.GetResourceCache()
+	if cache == nil {
+		return nil, nil, errResourceCacheUnavailable
+	}
+
+	src := packages.Sources{}
+	var errs []SourceError
+
+	// Helm releases (source H).
+	if hClient := helm.GetClient(); hClient != nil {
+		releases, err := hClient.ListReleasesAsUser(namespace, user, groups)
+		switch {
+		case err == nil:
+			src.Helm = make([]packages.HelmRelease, 0, len(releases))
+			for _, h := range releases {
+				src.Helm = append(src.Helm, packages.HelmRelease{
+					Name:           h.Name,
+					Namespace:      h.Namespace,
+					Chart:          h.Chart,
+					ChartVersion:   h.ChartVersion,
+					AppVersion:     h.AppVersion,
+					Status:         h.Status,
+					ResourceHealth: h.ResourceHealth,
+				})
+			}
+		case helm.IsForbiddenError(err):
+			errs = append(errs, SourceError{Source: packages.SourceHelm, StatusCode: http.StatusForbidden, Error: "RBAC denied (helm release secrets)"})
+		default:
+			errs = append(errs, SourceError{Source: packages.SourceHelm, Error: err.Error()})
+		}
+	}
+
+	// Workloads (source L) — Deployments + DaemonSets + StatefulSets.
+	src.Workloads = collectWorkloadInputs(cache, namespace)
+
+	// CRDs (source C). Always cluster-scoped, so namespace filter
+	// doesn't apply here — but we'll filter rows by namespace at the
+	// end so a namespaced query doesn't surface unrelated CRD-only
+	// rows.
+	if crds, err := cache.ListDynamicWithGroup(ctx, "CustomResourceDefinition", "", "apiextensions.k8s.io"); err == nil {
+		src.CRDs = make([]packages.CRD, 0, len(crds))
+		for _, c := range crds {
+			obj := c.Object
+			specMap, _ := obj["spec"].(map[string]any)
+			group, _ := specMap["group"].(string)
+			names, _ := specMap["names"].(map[string]any)
+			kind, _ := names["kind"].(string)
+			plural, _ := names["plural"].(string)
+			versions, _ := specMap["versions"].([]any)
+			var versionNames []string
+			for _, v := range versions {
+				if vm, ok := v.(map[string]any); ok {
+					if name, ok := vm["name"].(string); ok {
+						versionNames = append(versionNames, name)
+					}
+				}
+			}
+			src.CRDs = append(src.CRDs, packages.CRD{
+				Name:    c.GetName(),
+				Group:   group,
+				Kind:    kind,
+				Plural:  plural,
+				Versions: versionNames,
+			})
+		}
+	} else {
+		errs = append(errs, SourceError{Source: packages.SourceCRDs, Error: err.Error()})
+	}
+
+	// GitOps declarations (sources A + F). All optional — controllers
+	// may not be installed. Each parser tries the canonical CRD shape;
+	// missing CRDs surface as ListDynamic errors, captured per-source.
+	src.GitOpsDeclarations = collectGitOpsDeclarations(ctx, cache, namespace, &errs)
+
+	rows := packages.Aggregate(src)
+
+	// Apply namespace filter post-aggregate. CRD-only rows have empty
+	// Namespace; keep them if the caller asked for "all" (namespace == "").
+	if namespace != "" {
+		filtered := make([]packages.PackageRow, 0, len(rows))
+		for _, r := range rows {
+			// Always keep rows that match the requested namespace.
+			// Drop CRD-only rows in namespaced queries — the caller is
+			// asking "what's in this namespace?" and CRDs are
+			// cluster-scoped.
+			if r.Namespace == namespace {
+				filtered = append(filtered, r)
+			}
+		}
+		rows = filtered
+	}
+
+	return rows, errs, nil
+}
+
+// collectWorkloadInputs reads Deployments + DaemonSets + StatefulSets
+// from the cache and converts them to the packages.Workload shape used
+// by the merger. Only workloads with helm.sh/chart label OR
+// meta.helm.sh/release-name annotation contribute; the rest aren't
+// Helm-managed and the merger would skip them anyway, but filtering
+// here saves a million map allocs on big clusters.
+func collectWorkloadInputs(cache *k8s.ResourceCache, namespace string) []packages.Workload {
+	var out []packages.Workload
+	add := func(kind, ns, name string, lbls, anns map[string]string, health string) {
+		// Cheap pre-filter: only Helm-suggesting rows make it to the merger.
+		if lbls["helm.sh/chart"] == "" && anns["meta.helm.sh/release-name"] == "" {
+			return
+		}
+		out = append(out, packages.Workload{
+			Kind:      kind,
+			Namespace: ns,
+			Name:      name,
+			Labels:    lbls,
+			Annotations: anns,
+			Health:    health,
+		})
+	}
+	if depLister := cache.Deployments(); depLister != nil {
+		var deps []*appsListResult
+		if namespace != "" {
+			items, _ := depLister.Deployments(namespace).List(labels.Everything())
+			for _, d := range items {
+				deps = append(deps, &appsListResult{
+					ns: d.Namespace, name: d.Name, labels: d.Labels, anns: d.Annotations,
+					health: deploymentHealth(int(d.Status.Replicas), int(d.Status.AvailableReplicas)),
+				})
+			}
+		} else {
+			items, _ := depLister.List(labels.Everything())
+			for _, d := range items {
+				deps = append(deps, &appsListResult{
+					ns: d.Namespace, name: d.Name, labels: d.Labels, anns: d.Annotations,
+					health: deploymentHealth(int(d.Status.Replicas), int(d.Status.AvailableReplicas)),
+				})
+			}
+		}
+		for _, d := range deps {
+			add("Deployment", d.ns, d.name, d.labels, d.anns, d.health)
+		}
+	}
+	if dsLister := cache.DaemonSets(); dsLister != nil {
+		if namespace != "" {
+			items, _ := dsLister.DaemonSets(namespace).List(labels.Everything())
+			for _, d := range items {
+				add("DaemonSet", d.Namespace, d.Name, d.Labels, d.Annotations,
+					daemonsetHealth(int(d.Status.DesiredNumberScheduled), int(d.Status.NumberReady)))
+			}
+		} else {
+			items, _ := dsLister.List(labels.Everything())
+			for _, d := range items {
+				add("DaemonSet", d.Namespace, d.Name, d.Labels, d.Annotations,
+					daemonsetHealth(int(d.Status.DesiredNumberScheduled), int(d.Status.NumberReady)))
+			}
+		}
+	}
+	if ssLister := cache.StatefulSets(); ssLister != nil {
+		if namespace != "" {
+			items, _ := ssLister.StatefulSets(namespace).List(labels.Everything())
+			for _, ss := range items {
+				add("StatefulSet", ss.Namespace, ss.Name, ss.Labels, ss.Annotations,
+					statefulsetHealth(int(ss.Status.Replicas), int(ss.Status.ReadyReplicas)))
+			}
+		} else {
+			items, _ := ssLister.List(labels.Everything())
+			for _, ss := range items {
+				add("StatefulSet", ss.Namespace, ss.Name, ss.Labels, ss.Annotations,
+					statefulsetHealth(int(ss.Status.Replicas), int(ss.Status.ReadyReplicas)))
+			}
+		}
+	}
+	return out
+}
+
+type appsListResult struct {
+	ns, name string
+	labels   map[string]string
+	anns     map[string]string
+	health   string
+}
+
+func deploymentHealth(desired, available int) string {
+	if desired == 0 {
+		return "unknown"
+	}
+	if available >= desired {
+		return "healthy"
+	}
+	if available == 0 {
+		return "unhealthy"
+	}
+	return "degraded"
+}
+func daemonsetHealth(desired, ready int) string  { return deploymentHealth(desired, ready) }
+func statefulsetHealth(desired, ready int) string { return deploymentHealth(desired, ready) }
+
+// collectGitOpsDeclarations reads Argo Applications + Flux HelmReleases
+// + Flux Kustomizations from the dynamic cache and converts each to a
+// packages.Declaration. Missing CRDs (controller not installed) just
+// produce no declarations; not an error. Real errors (informer
+// failures) surface in the errs slice.
+func collectGitOpsDeclarations(ctx context.Context, cache *k8s.ResourceCache, namespace string, errs *[]SourceError) []packages.Declaration {
+	var out []packages.Declaration
+
+	// Argo Applications (argoproj.io/Application). Argo apps are
+	// always namespaced — typically in argocd or argocd-system.
+	if items, err := cache.ListDynamicWithGroup(ctx, "Application", namespace, "argoproj.io"); err == nil {
+		for _, item := range items {
+			if d, ok := packages.ParseArgoApplication(item.Object); ok {
+				out = append(out, d)
+			}
+		}
+	} else if !isMissingCRDErr(err) {
+		*errs = append(*errs, SourceError{Source: packages.SourceArgoCD, Error: err.Error()})
+	}
+
+	// Flux HelmReleases.
+	if items, err := cache.ListDynamicWithGroup(ctx, "HelmRelease", namespace, "helm.toolkit.fluxcd.io"); err == nil {
+		for _, item := range items {
+			if d, ok := packages.ParseFluxHelmRelease(item.Object); ok {
+				out = append(out, d)
+			}
+		}
+	} else if !isMissingCRDErr(err) {
+		*errs = append(*errs, SourceError{Source: packages.SourceFluxCD, Error: err.Error()})
+	}
+
+	// Flux Kustomizations.
+	if items, err := cache.ListDynamicWithGroup(ctx, "Kustomization", namespace, "kustomize.toolkit.fluxcd.io"); err == nil {
+		for _, item := range items {
+			if d, ok := packages.ParseFluxKustomization(item.Object); ok {
+				out = append(out, d)
+			}
+		}
+	} else if !isMissingCRDErr(err) {
+		// Only emit a F-source error once even if both HR + Kust failed.
+		// For now keep simple: emit twice if both fail; SourcesErrored
+		// is informational, dedup downstream.
+		*errs = append(*errs, SourceError{Source: packages.SourceFluxCD, Error: err.Error()})
+	}
+
+	return out
+}
+
+// isMissingCRDErr matches the "unknown resource kind" error
+// ListDynamicWithGroup returns when the requested CRD isn't installed.
+// Cleaner than wrapping the error type: the cache returns plain
+// errors.New strings.
+func isMissingCRDErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unknown resource kind")
+}
+
+// userCredsForPackages — same shape as helm.userCreds but kept local
+// since the helm package doesn't export it.
+func userCredsForPackages(r *http.Request) (string, []string) {
+	if user := auth.UserFromContext(r.Context()); user != nil {
+		return user.Username, user.Groups
+	}
+	return "", nil
+}
+
+func filterBySource(rows []packages.PackageRow, src string) []packages.PackageRow {
+	out := make([]packages.PackageRow, 0, len(rows))
+	for _, r := range rows {
+		for _, s := range r.Sources {
+			if s == src {
+				out = append(out, r)
+				break
+			}
+		}
+	}
+	return out
+}
+
+func filterByChartSubstring(rows []packages.PackageRow, sub string) []packages.PackageRow {
+	out := make([]packages.PackageRow, 0, len(rows))
+	for _, r := range rows {
+		if strings.Contains(strings.ToLower(r.Chart), sub) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func sourcesUsed(rows []packages.PackageRow) []string {
+	seen := map[string]bool{}
+	for _, r := range rows {
+		for _, s := range r.Sources {
+			seen[s] = true
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for _, s := range []string{packages.SourceHelm, packages.SourceLabels, packages.SourceCRDs, packages.SourceArgoCD, packages.SourceFluxCD} {
+		if seen[s] {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// errResourceCacheUnavailable mirrors the error other handlers return
+// when the cache singleton is nil. Defined here as a package var so a
+// future test can match on it.
+var errResourceCacheUnavailable = packagesError("resource cache unavailable")
+
+type packagesError string
+
+func (e packagesError) Error() string { return string(e) }
+
+// Prevent "imported and not used" if the encoding/json import is only
+// needed transitively via writeJSON.
+var _ = json.Marshal
+
+// Convenience: the top-level Server has a global k8s.GetCache() but
+// we'd rather a helper that's testable. Reserved for future use; for
+// now we go direct.
+var _ = log.Print

--- a/internal/server/packages.go
+++ b/internal/server/packages.go
@@ -28,8 +28,9 @@ const packagesCacheTTL = 60 * time.Second
 // packagesCacheMaxEntries caps cache map growth. Each (user, namespace
 // set) tuple gets an entry; under multi-user Hub-mode use the map would
 // otherwise grow unbounded. When the cap is exceeded we evict the
-// oldest entry.
-const packagesCacheMaxEntries = 256
+// oldest entry. Var (not const) so tests can lower the cap to drive
+// the eviction-at-insert path with a small fixture.
+var packagesCacheMaxEntries = 256
 
 var (
 	packagesCacheMu sync.Mutex
@@ -55,6 +56,12 @@ type SourceError struct {
 	Source     packages.SourceCode `json:"source"`
 	StatusCode int                 `json:"statusCode,omitempty"`
 	Error      string              `json:"error"`
+	// AffectedNamespaces, when set, lists the namespaces this error
+	// applies to. Populated when the error is scoped (e.g., a
+	// per-namespace Helm RBAC denial); empty when cluster-wide.
+	// Lets consumers reason about partial-result scope without
+	// reverse-parsing the Error string.
+	AffectedNamespaces []string `json:"affectedNamespaces,omitempty"`
 }
 
 // ListPackagesParams carries the filters the REST + MCP handlers both
@@ -72,9 +79,25 @@ type ListPackagesParams struct {
 	Groups []string
 }
 
+// ErrInvalidSourceCode is returned when ListPackagesParams.Source is set
+// but doesn't match one of the five known source codes (H/L/C/A/F).
+// REST handlers map this to 400; MCP returns it as a tool error so the
+// agent doesn't get a silent empty list and conclude "nothing installed."
+var ErrInvalidSourceCode = packagesError("invalid source code (want one of H, L, C, A, F)")
+
 // ListPackages is the public entry point shared by the REST handler
 // and the MCP tool.
 func ListPackages(ctx context.Context, p ListPackagesParams) (PackagesResponse, error) {
+	// Validate source filter at the boundary — without this, an invalid
+	// or typo'd `?source=helm` would silently return an empty list
+	// (HTTP 200) and a downstream consumer would conclude "nothing
+	// installed via Helm."
+	if p.Source != "" {
+		if !packages.SourceCode(strings.ToUpper(p.Source)).Valid() {
+			return PackagesResponse{}, ErrInvalidSourceCode
+		}
+	}
+
 	// Auth-restricted to no namespaces → empty response, skip cache.
 	if p.Namespaces != nil && len(p.Namespaces) == 0 {
 		return PackagesResponse{
@@ -203,6 +226,10 @@ func (s *Server) handleListPackages(w http.ResponseWriter, r *http.Request) {
 			s.writeError(w, http.StatusServiceUnavailable, err.Error())
 			return
 		}
+		if errors.Is(err, ErrInvalidSourceCode) {
+			s.writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
 		log.Printf("[packages] ListPackages failed: %v", err)
 		s.writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -308,6 +335,13 @@ func computePackagesInternal(ctx context.Context, namespaces []string, user stri
 // errors are coalesced into one SourceError so a user with access to
 // ns-a but not ns-b still sees ns-a's releases.
 func collectHelmReleases(namespaces []string, user string, groups []string) ([]packages.HelmRelease, []SourceError) {
+	// Defensive: empty (non-nil) slice means "no namespaces authorized";
+	// callers should short-circuit before reaching here, but guard
+	// against a future caller that forgets and would otherwise fall
+	// through to a cluster-wide read.
+	if namespaces != nil && len(namespaces) == 0 {
+		return nil, nil
+	}
 	hClient := helm.GetClient()
 	if hClient == nil {
 		return nil, []SourceError{{
@@ -323,7 +357,8 @@ func collectHelmReleases(namespaces []string, user string, groups []string) ([]p
 		scopes = namespaces
 	}
 	var out []packages.HelmRelease
-	var forbidden []string
+	var forbiddenNamespaces []string
+	var otherErrNamespaces []string
 	var otherErrs []error
 	for _, ns := range scopes {
 		releases, err := hClient.ListReleasesAsUser(ns, user, groups)
@@ -342,27 +377,59 @@ func collectHelmReleases(namespaces []string, user string, groups []string) ([]p
 			continue
 		}
 		if helm.IsForbiddenError(err) {
-			label := ns
-			if label == "" {
-				label = "cluster-wide"
-			}
-			forbidden = append(forbidden, label)
+			forbiddenNamespaces = append(forbiddenNamespaces, ns)
 			continue
 		}
+		otherErrNamespaces = append(otherErrNamespaces, ns)
 		otherErrs = append(otherErrs, fmt.Errorf("ns=%q: %w", ns, err))
 	}
 	var errs []SourceError
-	if len(forbidden) > 0 {
+	if len(forbiddenNamespaces) > 0 {
 		errs = append(errs, SourceError{
-			Source:     packages.SourceHelm,
-			StatusCode: http.StatusForbidden,
-			Error:      "RBAC denied (helm release secrets): " + strings.Join(forbidden, ", "),
+			Source:             packages.SourceHelm,
+			StatusCode:         http.StatusForbidden,
+			Error:              "RBAC denied (helm release secrets): " + describeNamespaces(forbiddenNamespaces),
+			AffectedNamespaces: namespaceList(forbiddenNamespaces),
 		})
 	}
 	if len(otherErrs) > 0 {
-		errs = append(errs, SourceError{Source: packages.SourceHelm, Error: errors.Join(otherErrs...).Error()})
+		errs = append(errs, SourceError{
+			Source:             packages.SourceHelm,
+			Error:              errors.Join(otherErrs...).Error(),
+			AffectedNamespaces: namespaceList(otherErrNamespaces),
+		})
 	}
 	return out, errs
+}
+
+// describeNamespaces produces a human-readable label for a slice of
+// namespace scopes. Empty string means "cluster-wide" — callers should
+// continue to read AffectedNamespaces for structured access.
+func describeNamespaces(scopes []string) string {
+	labels := make([]string, 0, len(scopes))
+	for _, ns := range scopes {
+		if ns == "" {
+			labels = append(labels, "cluster-wide")
+			continue
+		}
+		labels = append(labels, ns)
+	}
+	return strings.Join(labels, ", ")
+}
+
+// namespaceList drops the "" sentinel (cluster-wide) — empty slice means
+// the error applied cluster-wide; non-empty lists explicit namespaces.
+func namespaceList(scopes []string) []string {
+	out := make([]string, 0, len(scopes))
+	for _, ns := range scopes {
+		if ns != "" {
+			out = append(out, ns)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // collectWorkloadInputs reads Deployments + DaemonSets + StatefulSets

--- a/internal/server/packages.go
+++ b/internal/server/packages.go
@@ -46,15 +46,15 @@ type packagesCacheEntry struct {
 type PackagesResponse struct {
 	Packages       []packages.PackageRow `json:"packages"`
 	GeneratedAt    time.Time             `json:"generatedAt"`
-	SourcesUsed    []string              `json:"sourcesUsed"`
+	SourcesUsed    []packages.SourceCode `json:"sourcesUsed"`
 	SourcesErrored []SourceError         `json:"sourcesErrored,omitempty"`
 }
 
-// SourceError carries a per-source failure. Source is one of H/L/C/A/F.
+// SourceError carries a per-source failure.
 type SourceError struct {
-	Source     string `json:"source"`
-	StatusCode int    `json:"statusCode,omitempty"`
-	Error      string `json:"error"`
+	Source     packages.SourceCode `json:"source"`
+	StatusCode int                 `json:"statusCode,omitempty"`
+	Error      string              `json:"error"`
 }
 
 // ListPackagesParams carries the filters the REST + MCP handlers both
@@ -80,7 +80,7 @@ func ListPackages(ctx context.Context, p ListPackagesParams) (PackagesResponse, 
 		return PackagesResponse{
 			Packages:       []packages.PackageRow{},
 			GeneratedAt:    time.Now(),
-			SourcesUsed:    []string{},
+			SourcesUsed:    []packages.SourceCode{},
 			SourcesErrored: nil,
 		}, nil
 	}
@@ -116,7 +116,7 @@ func ListPackages(ctx context.Context, p ListPackagesParams) (PackagesResponse, 
 	}
 
 	if p.Source != "" {
-		rows = filterBySource(rows, strings.ToUpper(p.Source))
+		rows = filterBySource(rows, packages.SourceCode(strings.ToUpper(p.Source)))
 	}
 	if p.Chart != "" {
 		rows = filterByChartSubstring(rows, strings.ToLower(p.Chart))
@@ -127,7 +127,7 @@ func ListPackages(ctx context.Context, p ListPackagesParams) (PackagesResponse, 
 	}
 	used := sourcesUsed(rows)
 	if used == nil {
-		used = []string{}
+		used = []packages.SourceCode{}
 	}
 	return PackagesResponse{
 		Packages:       rows,
@@ -336,7 +336,7 @@ func collectHelmReleases(namespaces []string, user string, groups []string) ([]p
 					ChartVersion:   h.ChartVersion,
 					AppVersion:     h.AppVersion,
 					Status:         h.Status,
-					ResourceHealth: h.ResourceHealth,
+					ResourceHealth: packages.Health(h.ResourceHealth),
 				})
 			}
 			continue
@@ -384,7 +384,7 @@ func collectWorkloadInputs(cache *k8s.ResourceCache, namespaces []string) ([]pac
 		}
 		listerErrs = append(listerErrs, fmt.Errorf("%s ns=%s: %w", kind, nsLabel, err))
 	}
-	add := func(kind, ns, name string, lbls, anns map[string]string, health string) {
+	add := func(kind, ns, name string, lbls, anns map[string]string, health packages.Health) {
 		if lbls["helm.sh/chart"] == "" && anns["meta.helm.sh/release-name"] == "" {
 			return
 		}
@@ -470,20 +470,20 @@ func collectWorkloadInputs(cache *k8s.ResourceCache, namespaces []string) ([]pac
 	return out, errors.Join(listerErrs...)
 }
 
-func deploymentHealth(desired, available int) string {
+func deploymentHealth(desired, available int) packages.Health {
 	if desired == 0 {
-		return "unknown"
+		return packages.HealthUnknown
 	}
 	if available >= desired {
-		return "healthy"
+		return packages.HealthHealthy
 	}
 	if available == 0 {
-		return "unhealthy"
+		return packages.HealthUnhealthy
 	}
-	return "degraded"
+	return packages.HealthDegraded
 }
-func daemonsetHealth(desired, ready int) string   { return deploymentHealth(desired, ready) }
-func statefulsetHealth(desired, ready int) string { return deploymentHealth(desired, ready) }
+func daemonsetHealth(desired, ready int) packages.Health   { return deploymentHealth(desired, ready) }
+func statefulsetHealth(desired, ready int) packages.Health { return deploymentHealth(desired, ready) }
 
 // collectGitOpsDeclarations reads Argo Applications + Flux HelmReleases
 // + Flux Kustomizations cluster-wide. Missing CRDs (controller not
@@ -549,7 +549,7 @@ func userCredsForPackages(r *http.Request) (string, []string) {
 	return "", nil
 }
 
-func filterBySource(rows []packages.PackageRow, src string) []packages.PackageRow {
+func filterBySource(rows []packages.PackageRow, src packages.SourceCode) []packages.PackageRow {
 	out := make([]packages.PackageRow, 0, len(rows))
 	for _, r := range rows {
 		for _, s := range r.Sources {
@@ -572,15 +572,15 @@ func filterByChartSubstring(rows []packages.PackageRow, sub string) []packages.P
 	return out
 }
 
-func sourcesUsed(rows []packages.PackageRow) []string {
-	seen := map[string]bool{}
+func sourcesUsed(rows []packages.PackageRow) []packages.SourceCode {
+	seen := map[packages.SourceCode]bool{}
 	for _, r := range rows {
 		for _, s := range r.Sources {
 			seen[s] = true
 		}
 	}
-	out := make([]string, 0, len(seen))
-	for _, s := range []string{packages.SourceHelm, packages.SourceLabels, packages.SourceCRDs, packages.SourceArgoCD, packages.SourceFluxCD} {
+	out := make([]packages.SourceCode, 0, len(seen))
+	for _, s := range packages.AllSourceCodes {
 		if seen[s] {
 			out = append(out, s)
 		}

--- a/internal/server/packages.go
+++ b/internal/server/packages.go
@@ -2,9 +2,9 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"log"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -18,37 +18,27 @@ import (
 )
 
 // packagesCacheTTL bounds how often we recompute the merged package
-// list. Aggregate is cheap (~ms even on a 100-CRD cluster) but the
-// inputs cost: Helm secret reads, dynamic-cache walks, etc. The
-// dashboard endpoint uses the same 5s TTL pattern; align here.
+// list. Aggregate is cheap; the inputs (Helm secret reads, dynamic-cache
+// walks) are not.
 const packagesCacheTTL = 60 * time.Second
 
-// packagesCache holds the most recent /api/packages response, with a
-// per-namespace cache key. Single-value cache (not LRU) — only one
-// "all namespaces" + a few namespaced views in active use at once.
 var (
 	packagesCacheMu sync.Mutex
 	packagesCache   = map[string]packagesCacheEntry{}
 )
 
 type packagesCacheEntry struct {
-	at   time.Time
-	rows []packages.PackageRow
+	at     time.Time
+	rows   []packages.PackageRow
+	errors []SourceError
 }
 
 // PackagesResponse is the on-wire shape returned by /api/packages.
 type PackagesResponse struct {
-	Packages    []packages.PackageRow `json:"packages"`
-	GeneratedAt time.Time             `json:"generatedAt"`
-	// SourcesUsed is the set of source codes that contributed at least
-	// one row. Lets the SPA show "no Helm access — using labels + CRDs"
-	// callouts when the user's RBAC limits coverage.
-	SourcesUsed []string `json:"sourcesUsed"`
-	// SourcesErrored carries source-level failures (e.g. Helm 403). Each
-	// entry's `Source` matches the same single-character codes used in
-	// PackageRow.Sources. The fleet aggregator uses this to render
-	// per-cluster coverage callouts.
-	SourcesErrored []SourceError `json:"sourcesErrored,omitempty"`
+	Packages       []packages.PackageRow `json:"packages"`
+	GeneratedAt    time.Time             `json:"generatedAt"`
+	SourcesUsed    []string              `json:"sourcesUsed"`
+	SourcesErrored []SourceError         `json:"sourcesErrored,omitempty"`
 }
 
 // SourceError carries a per-source failure. Source is one of H/L/C/A/F.
@@ -61,9 +51,12 @@ type SourceError struct {
 // ListPackagesParams carries the filters the REST + MCP handlers both
 // support.
 type ListPackagesParams struct {
-	Namespace string // empty = all namespaces
-	Source    string // H/L/C/A/F or empty
-	Chart     string // case-insensitive substring or empty
+	// Namespaces filters returned rows by release-namespace.
+	// nil = all namespaces. Empty (non-nil) slice = "no access" → returns
+	// an empty response without consulting the cache.
+	Namespaces []string
+	Source     string // H/L/C/A/F or empty
+	Chart      string // case-insensitive substring or empty
 	// User identity for Helm release secret reads. Empty username means
 	// "use the SA identity" (helm.ListReleasesAsUser convention).
 	User   string
@@ -71,12 +64,19 @@ type ListPackagesParams struct {
 }
 
 // ListPackages is the public entry point shared by the REST handler
-// and the MCP tool. Free function (not a Server method) so MCP can
-// call without needing a Server reference — it relies on the same
-// k8s.GetResourceCache + helm.GetClient singletons the REST handler
-// reads through. Caches at the namespace level (60s TTL).
+// and the MCP tool.
 func ListPackages(ctx context.Context, p ListPackagesParams) (PackagesResponse, error) {
-	cacheKey := p.Namespace
+	// Auth-restricted to no namespaces → empty response, skip cache.
+	if p.Namespaces != nil && len(p.Namespaces) == 0 {
+		return PackagesResponse{
+			Packages:       []packages.PackageRow{},
+			GeneratedAt:    time.Now(),
+			SourcesUsed:    []string{},
+			SourcesErrored: nil,
+		}, nil
+	}
+
+	cacheKey := packagesCacheKeyFor(p.User, p.Namespaces)
 	packagesCacheMu.Lock()
 	entry, hit := packagesCache[cacheKey]
 	packagesCacheMu.Unlock()
@@ -85,14 +85,15 @@ func ListPackages(ctx context.Context, p ListPackagesParams) (PackagesResponse, 
 	var sourceErrs []SourceError
 	if hit && time.Since(entry.at) < packagesCacheTTL {
 		rows = entry.rows
+		sourceErrs = entry.errors
 	} else {
 		var err error
-		rows, sourceErrs, err = computePackagesInternal(ctx, p.Namespace, p.User, p.Groups)
+		rows, sourceErrs, err = computePackagesInternal(ctx, p.Namespaces, p.User, p.Groups)
 		if err != nil {
 			return PackagesResponse{}, err
 		}
 		packagesCacheMu.Lock()
-		packagesCache[cacheKey] = packagesCacheEntry{at: time.Now(), rows: rows}
+		packagesCache[cacheKey] = packagesCacheEntry{at: time.Now(), rows: rows, errors: sourceErrs}
 		packagesCacheMu.Unlock()
 	}
 
@@ -103,50 +104,80 @@ func ListPackages(ctx context.Context, p ListPackagesParams) (PackagesResponse, 
 		rows = filterByChartSubstring(rows, strings.ToLower(p.Chart))
 	}
 
+	if rows == nil {
+		rows = []packages.PackageRow{}
+	}
+	used := sourcesUsed(rows)
+	if used == nil {
+		used = []string{}
+	}
 	return PackagesResponse{
 		Packages:       rows,
 		GeneratedAt:    time.Now(),
-		SourcesUsed:    sourcesUsed(rows),
+		SourcesUsed:    used,
 		SourcesErrored: sourceErrs,
 	}, nil
+}
+
+// packagesCacheKeyFor produces a stable cache key. Both the user
+// identity and the requested namespace set must be part of the key:
+// Helm reads are user-scoped (RBAC-impersonated), so two users hitting
+// the same namespace must not share an entry.
+func packagesCacheKeyFor(user string, namespaces []string) string {
+	var b strings.Builder
+	b.WriteString(user)
+	b.WriteByte('|')
+	if namespaces == nil {
+		b.WriteByte('*')
+	} else {
+		// Sort defensively; the handler already sorts, but MCP / direct
+		// callers might not.
+		ns := append([]string(nil), namespaces...)
+		sort.Strings(ns)
+		b.WriteString(strings.Join(ns, ","))
+	}
+	return b.String()
 }
 
 // handleListPackages serves GET /api/packages.
 //
 // Query params:
 //
-//	?namespace=<name> — limit to packages whose release-namespace
-//	                     equals this. Default: all namespaces.
-//	?source=H|L|C|A|F — limit to rows that had this source contribute.
-//	?chart=<substr>   — limit to rows whose chart name contains this.
+//	?namespaces=a,b,c | ?namespace=a — limit to release-namespace ∈ set.
+//	?source=H|L|C|A|F                — limit to rows where this source contributed.
+//	?chart=<substr>                  — case-insensitive substring on chart name.
 //
-// Returns: PackagesResponse with the merged row list plus per-source
-// error attribution. 200 even when some sources failed (we'd rather
-// ship the partial view than 5xx the whole call).
+// Returns 200 even when some sources failed (per-source failures are
+// attributed in `sourcesErrored`).
 func (s *Server) handleListPackages(w http.ResponseWriter, r *http.Request) {
 	if !s.requireConnected(w) {
 		return
 	}
+	namespaces := s.parseNamespacesForUser(r)
 	user, groups := userCredsForPackages(r)
 	resp, err := ListPackages(r.Context(), ListPackagesParams{
-		Namespace: r.URL.Query().Get("namespace"),
-		Source:    r.URL.Query().Get("source"),
-		Chart:     r.URL.Query().Get("chart"),
-		User:      user,
-		Groups:    groups,
+		Namespaces: namespaces,
+		Source:     r.URL.Query().Get("source"),
+		Chart:      r.URL.Query().Get("chart"),
+		User:       user,
+		Groups:     groups,
 	})
 	if err != nil {
+		if err == errResourceCacheUnavailable {
+			s.writeError(w, http.StatusServiceUnavailable, err.Error())
+			return
+		}
+		log.Printf("[packages] ListPackages failed: %v", err)
 		s.writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	s.writeJSON(w, resp)
 }
 
-// computePackagesInternal reads from all four (potentially five) data sources,
-// builds a packages.Sources, and runs Aggregate. Per-source errors are
-// captured but not fatal: a 403 on Helm (secret access denied) just
-// means the row set comes from L/C/A/F.
-func computePackagesInternal(ctx context.Context, namespace, user string, groups []string) ([]packages.PackageRow, []SourceError, error) {
+// computePackagesInternal reads from all sources, merges via
+// packages.Aggregate, and post-filters by the requested namespace set.
+// Per-source errors are attributed but non-fatal.
+func computePackagesInternal(ctx context.Context, namespaces []string, user string, groups []string) ([]packages.PackageRow, []SourceError, error) {
 	cache := k8s.GetResourceCache()
 	if cache == nil {
 		return nil, nil, errResourceCacheUnavailable
@@ -155,9 +186,15 @@ func computePackagesInternal(ctx context.Context, namespace, user string, groups
 	src := packages.Sources{}
 	var errs []SourceError
 
-	// Helm releases (source H).
+	// Helm releases (source H). For multi-namespace queries we list
+	// cluster-wide and rely on the post-aggregate filter — Helm's RBAC
+	// impersonation already scopes results to what the user can see.
+	helmNamespace := ""
+	if len(namespaces) == 1 {
+		helmNamespace = namespaces[0]
+	}
 	if hClient := helm.GetClient(); hClient != nil {
-		releases, err := hClient.ListReleasesAsUser(namespace, user, groups)
+		releases, err := hClient.ListReleasesAsUser(helmNamespace, user, groups)
 		switch {
 		case err == nil:
 			src.Helm = make([]packages.HelmRelease, 0, len(releases))
@@ -173,19 +210,24 @@ func computePackagesInternal(ctx context.Context, namespace, user string, groups
 				})
 			}
 		case helm.IsForbiddenError(err):
-			errs = append(errs, SourceError{Source: packages.SourceHelm, StatusCode: http.StatusForbidden, Error: "RBAC denied (helm release secrets)"})
+			errs = append(errs, SourceError{
+				Source:     packages.SourceHelm,
+				StatusCode: http.StatusForbidden,
+				Error:      "RBAC denied (helm release secrets): " + err.Error(),
+			})
 		default:
 			errs = append(errs, SourceError{Source: packages.SourceHelm, Error: err.Error()})
 		}
 	}
 
 	// Workloads (source L) — Deployments + DaemonSets + StatefulSets.
-	src.Workloads = collectWorkloadInputs(cache, namespace)
+	workloads, listerErr := collectWorkloadInputs(cache, namespaces)
+	src.Workloads = workloads
+	if listerErr != nil {
+		errs = append(errs, SourceError{Source: packages.SourceLabels, Error: listerErr.Error()})
+	}
 
-	// CRDs (source C). Always cluster-scoped, so namespace filter
-	// doesn't apply here — but we'll filter rows by namespace at the
-	// end so a namespaced query doesn't surface unrelated CRD-only
-	// rows.
+	// CRDs (source C). Always cluster-scoped.
 	if crds, err := cache.ListDynamicWithGroup(ctx, "CustomResourceDefinition", "", "apiextensions.k8s.io"); err == nil {
 		src.CRDs = make([]packages.CRD, 0, len(crds))
 		for _, c := range crds {
@@ -205,10 +247,10 @@ func computePackagesInternal(ctx context.Context, namespace, user string, groups
 				}
 			}
 			src.CRDs = append(src.CRDs, packages.CRD{
-				Name:    c.GetName(),
-				Group:   group,
-				Kind:    kind,
-				Plural:  plural,
+				Name:     c.GetName(),
+				Group:    group,
+				Kind:     kind,
+				Plural:   plural,
 				Versions: versionNames,
 			})
 		}
@@ -216,23 +258,25 @@ func computePackagesInternal(ctx context.Context, namespace, user string, groups
 		errs = append(errs, SourceError{Source: packages.SourceCRDs, Error: err.Error()})
 	}
 
-	// GitOps declarations (sources A + F). All optional — controllers
-	// may not be installed. Each parser tries the canonical CRD shape;
-	// missing CRDs surface as ListDynamic errors, captured per-source.
-	src.GitOpsDeclarations = collectGitOpsDeclarations(ctx, cache, namespace, &errs)
+	// GitOps declarations (sources A + F). Listed cluster-wide regardless
+	// of the requested namespaces: Argo Apps live in `argocd` but target
+	// other namespaces (and Flux HRs use spec.targetNamespace), so the
+	// declaration's own namespace is the wrong filter — the post-aggregate
+	// step below scopes by target namespace via row.Namespace.
+	src.GitOpsDeclarations = collectGitOpsDeclarations(ctx, cache, &errs)
 
 	rows := packages.Aggregate(src)
 
-	// Apply namespace filter post-aggregate. CRD-only rows have empty
-	// Namespace; keep them if the caller asked for "all" (namespace == "").
-	if namespace != "" {
+	// Post-aggregate namespace filter. CRD-only rows (Namespace == "")
+	// are dropped from namespaced queries.
+	if namespaces != nil {
+		allowed := map[string]bool{}
+		for _, ns := range namespaces {
+			allowed[ns] = true
+		}
 		filtered := make([]packages.PackageRow, 0, len(rows))
 		for _, r := range rows {
-			// Always keep rows that match the requested namespace.
-			// Drop CRD-only rows in namespaced queries — the caller is
-			// asking "what's in this namespace?" and CRDs are
-			// cluster-scoped.
-			if r.Namespace == namespace {
+			if allowed[r.Namespace] {
 				filtered = append(filtered, r)
 			}
 		}
@@ -245,86 +289,102 @@ func computePackagesInternal(ctx context.Context, namespace, user string, groups
 // collectWorkloadInputs reads Deployments + DaemonSets + StatefulSets
 // from the cache and converts them to the packages.Workload shape used
 // by the merger. Only workloads with helm.sh/chart label OR
-// meta.helm.sh/release-name annotation contribute; the rest aren't
-// Helm-managed and the merger would skip them anyway, but filtering
-// here saves a million map allocs on big clusters.
-func collectWorkloadInputs(cache *k8s.ResourceCache, namespace string) []packages.Workload {
+// meta.helm.sh/release-name annotation contribute. Returns the first
+// lister error encountered (so the caller can attribute it to source L)
+// — informer listers fail rarely (indexer issues), but per the
+// CLAUDE.md backend convention we don't drop errors silently.
+func collectWorkloadInputs(cache *k8s.ResourceCache, namespaces []string) ([]packages.Workload, error) {
 	var out []packages.Workload
+	var firstErr error
+	noteErr := func(err error) {
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
 	add := func(kind, ns, name string, lbls, anns map[string]string, health string) {
-		// Cheap pre-filter: only Helm-suggesting rows make it to the merger.
 		if lbls["helm.sh/chart"] == "" && anns["meta.helm.sh/release-name"] == "" {
 			return
 		}
 		out = append(out, packages.Workload{
-			Kind:      kind,
-			Namespace: ns,
-			Name:      name,
-			Labels:    lbls,
+			Kind:        kind,
+			Namespace:   ns,
+			Name:        name,
+			Labels:      lbls,
 			Annotations: anns,
-			Health:    health,
+			Health:      health,
 		})
 	}
+
+	// listFor expands the namespace set into per-namespace calls (or one
+	// cluster-wide call when namespaces is nil).
+	forEachNamespace := func(fn func(ns string)) {
+		if namespaces == nil {
+			fn("")
+			return
+		}
+		for _, ns := range namespaces {
+			fn(ns)
+		}
+	}
+
 	if depLister := cache.Deployments(); depLister != nil {
-		var deps []*appsListResult
-		if namespace != "" {
-			items, _ := depLister.Deployments(namespace).List(labels.Everything())
-			for _, d := range items {
-				deps = append(deps, &appsListResult{
-					ns: d.Namespace, name: d.Name, labels: d.Labels, anns: d.Annotations,
-					health: deploymentHealth(int(d.Status.Replicas), int(d.Status.AvailableReplicas)),
-				})
+		forEachNamespace(func(ns string) {
+			if ns == "" {
+				items, err := depLister.List(labels.Everything())
+				noteErr(err)
+				for _, d := range items {
+					add("Deployment", d.Namespace, d.Name, d.Labels, d.Annotations,
+						deploymentHealth(int(d.Status.Replicas), int(d.Status.AvailableReplicas)))
+				}
+				return
 			}
-		} else {
-			items, _ := depLister.List(labels.Everything())
+			items, err := depLister.Deployments(ns).List(labels.Everything())
+			noteErr(err)
 			for _, d := range items {
-				deps = append(deps, &appsListResult{
-					ns: d.Namespace, name: d.Name, labels: d.Labels, anns: d.Annotations,
-					health: deploymentHealth(int(d.Status.Replicas), int(d.Status.AvailableReplicas)),
-				})
+				add("Deployment", d.Namespace, d.Name, d.Labels, d.Annotations,
+					deploymentHealth(int(d.Status.Replicas), int(d.Status.AvailableReplicas)))
 			}
-		}
-		for _, d := range deps {
-			add("Deployment", d.ns, d.name, d.labels, d.anns, d.health)
-		}
+		})
 	}
 	if dsLister := cache.DaemonSets(); dsLister != nil {
-		if namespace != "" {
-			items, _ := dsLister.DaemonSets(namespace).List(labels.Everything())
+		forEachNamespace(func(ns string) {
+			if ns == "" {
+				items, err := dsLister.List(labels.Everything())
+				noteErr(err)
+				for _, d := range items {
+					add("DaemonSet", d.Namespace, d.Name, d.Labels, d.Annotations,
+						daemonsetHealth(int(d.Status.DesiredNumberScheduled), int(d.Status.NumberReady)))
+				}
+				return
+			}
+			items, err := dsLister.DaemonSets(ns).List(labels.Everything())
+			noteErr(err)
 			for _, d := range items {
 				add("DaemonSet", d.Namespace, d.Name, d.Labels, d.Annotations,
 					daemonsetHealth(int(d.Status.DesiredNumberScheduled), int(d.Status.NumberReady)))
 			}
-		} else {
-			items, _ := dsLister.List(labels.Everything())
-			for _, d := range items {
-				add("DaemonSet", d.Namespace, d.Name, d.Labels, d.Annotations,
-					daemonsetHealth(int(d.Status.DesiredNumberScheduled), int(d.Status.NumberReady)))
-			}
-		}
+		})
 	}
 	if ssLister := cache.StatefulSets(); ssLister != nil {
-		if namespace != "" {
-			items, _ := ssLister.StatefulSets(namespace).List(labels.Everything())
+		forEachNamespace(func(ns string) {
+			if ns == "" {
+				items, err := ssLister.List(labels.Everything())
+				noteErr(err)
+				for _, ss := range items {
+					add("StatefulSet", ss.Namespace, ss.Name, ss.Labels, ss.Annotations,
+						statefulsetHealth(int(ss.Status.Replicas), int(ss.Status.ReadyReplicas)))
+				}
+				return
+			}
+			items, err := ssLister.StatefulSets(ns).List(labels.Everything())
+			noteErr(err)
 			for _, ss := range items {
 				add("StatefulSet", ss.Namespace, ss.Name, ss.Labels, ss.Annotations,
 					statefulsetHealth(int(ss.Status.Replicas), int(ss.Status.ReadyReplicas)))
 			}
-		} else {
-			items, _ := ssLister.List(labels.Everything())
-			for _, ss := range items {
-				add("StatefulSet", ss.Namespace, ss.Name, ss.Labels, ss.Annotations,
-					statefulsetHealth(int(ss.Status.Replicas), int(ss.Status.ReadyReplicas)))
-			}
-		}
+		})
 	}
-	return out
-}
-
-type appsListResult struct {
-	ns, name string
-	labels   map[string]string
-	anns     map[string]string
-	health   string
+	return out, firstErr
 }
 
 func deploymentHealth(desired, available int) string {
@@ -339,20 +399,17 @@ func deploymentHealth(desired, available int) string {
 	}
 	return "degraded"
 }
-func daemonsetHealth(desired, ready int) string  { return deploymentHealth(desired, ready) }
+func daemonsetHealth(desired, ready int) string   { return deploymentHealth(desired, ready) }
 func statefulsetHealth(desired, ready int) string { return deploymentHealth(desired, ready) }
 
 // collectGitOpsDeclarations reads Argo Applications + Flux HelmReleases
-// + Flux Kustomizations from the dynamic cache and converts each to a
-// packages.Declaration. Missing CRDs (controller not installed) just
-// produce no declarations; not an error. Real errors (informer
-// failures) surface in the errs slice.
-func collectGitOpsDeclarations(ctx context.Context, cache *k8s.ResourceCache, namespace string, errs *[]SourceError) []packages.Declaration {
+// + Flux Kustomizations cluster-wide. Missing CRDs (controller not
+// installed) are silently absent; real informer errors surface as
+// per-source errors with controller-distinguishing messages.
+func collectGitOpsDeclarations(ctx context.Context, cache *k8s.ResourceCache, errs *[]SourceError) []packages.Declaration {
 	var out []packages.Declaration
 
-	// Argo Applications (argoproj.io/Application). Argo apps are
-	// always namespaced — typically in argocd or argocd-system.
-	if items, err := cache.ListDynamicWithGroup(ctx, "Application", namespace, "argoproj.io"); err == nil {
+	if items, err := cache.ListDynamicWithGroup(ctx, "Application", "", "argoproj.io"); err == nil {
 		for _, item := range items {
 			if d, ok := packages.ParseArgoApplication(item.Object); ok {
 				out = append(out, d)
@@ -362,48 +419,40 @@ func collectGitOpsDeclarations(ctx context.Context, cache *k8s.ResourceCache, na
 		*errs = append(*errs, SourceError{Source: packages.SourceArgoCD, Error: err.Error()})
 	}
 
-	// Flux HelmReleases.
-	if items, err := cache.ListDynamicWithGroup(ctx, "HelmRelease", namespace, "helm.toolkit.fluxcd.io"); err == nil {
+	if items, err := cache.ListDynamicWithGroup(ctx, "HelmRelease", "", "helm.toolkit.fluxcd.io"); err == nil {
 		for _, item := range items {
 			if d, ok := packages.ParseFluxHelmRelease(item.Object); ok {
 				out = append(out, d)
 			}
 		}
 	} else if !isMissingCRDErr(err) {
-		*errs = append(*errs, SourceError{Source: packages.SourceFluxCD, Error: err.Error()})
+		*errs = append(*errs, SourceError{Source: packages.SourceFluxCD, Error: "HelmRelease: " + err.Error()})
 	}
 
-	// Flux Kustomizations.
-	if items, err := cache.ListDynamicWithGroup(ctx, "Kustomization", namespace, "kustomize.toolkit.fluxcd.io"); err == nil {
+	if items, err := cache.ListDynamicWithGroup(ctx, "Kustomization", "", "kustomize.toolkit.fluxcd.io"); err == nil {
 		for _, item := range items {
 			if d, ok := packages.ParseFluxKustomization(item.Object); ok {
 				out = append(out, d)
 			}
 		}
 	} else if !isMissingCRDErr(err) {
-		// Only emit a F-source error once even if both HR + Kust failed.
-		// For now keep simple: emit twice if both fail; SourcesErrored
-		// is informational, dedup downstream.
-		*errs = append(*errs, SourceError{Source: packages.SourceFluxCD, Error: err.Error()})
+		*errs = append(*errs, SourceError{Source: packages.SourceFluxCD, Error: "Kustomization: " + err.Error()})
 	}
 
 	return out
 }
 
 // isMissingCRDErr matches the "unknown resource kind" error
-// ListDynamicWithGroup returns when the requested CRD isn't installed.
-// Cleaner than wrapping the error type: the cache returns plain
-// errors.New strings.
+// k8score returns when the requested CRD isn't installed. Pinned by
+// `TestIsMissingCRDErr_PinsK8scoreErrorString` — change here breaks
+// graceful degradation for clusters without ArgoCD/FluxCD.
 func isMissingCRDErr(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "unknown resource kind")
+	return strings.Contains(strings.ToLower(err.Error()), "unknown resource kind")
 }
 
-// userCredsForPackages — same shape as helm.userCreds but kept local
-// since the helm package doesn't export it.
 func userCredsForPackages(r *http.Request) (string, []string) {
 	if user := auth.UserFromContext(r.Context()); user != nil {
 		return user.Username, user.Groups
@@ -450,20 +499,8 @@ func sourcesUsed(rows []packages.PackageRow) []string {
 	return out
 }
 
-// errResourceCacheUnavailable mirrors the error other handlers return
-// when the cache singleton is nil. Defined here as a package var so a
-// future test can match on it.
 var errResourceCacheUnavailable = packagesError("resource cache unavailable")
 
 type packagesError string
 
 func (e packagesError) Error() string { return string(e) }
-
-// Prevent "imported and not used" if the encoding/json import is only
-// needed transitively via writeJSON.
-var _ = json.Marshal
-
-// Convenience: the top-level Server has a global k8s.GetCache() but
-// we'd rather a helper that's testable. Reserved for future use; for
-// now we go direct.
-var _ = log.Print

--- a/internal/server/packages.go
+++ b/internal/server/packages.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"sort"
@@ -19,8 +21,15 @@ import (
 
 // packagesCacheTTL bounds how often we recompute the merged package
 // list. Aggregate is cheap; the inputs (Helm secret reads, dynamic-cache
-// walks) are not.
+// walks) are not. Cache is not event-invalidated; new installs become
+// visible within TTL.
 const packagesCacheTTL = 60 * time.Second
+
+// packagesCacheMaxEntries caps cache map growth. Each (user, namespace
+// set) tuple gets an entry; under multi-user Hub-mode use the map would
+// otherwise grow unbounded. When the cap is exceeded we evict the
+// oldest entry.
+const packagesCacheMaxEntries = 256
 
 var (
 	packagesCacheMu sync.Mutex
@@ -83,17 +92,26 @@ func ListPackages(ctx context.Context, p ListPackagesParams) (PackagesResponse, 
 
 	var rows []packages.PackageRow
 	var sourceErrs []SourceError
+	var generatedAt time.Time
 	if hit && time.Since(entry.at) < packagesCacheTTL {
 		rows = entry.rows
 		sourceErrs = entry.errors
+		generatedAt = entry.at
 	} else {
 		var err error
 		rows, sourceErrs, err = computePackagesInternal(ctx, p.Namespaces, p.User, p.Groups)
 		if err != nil {
 			return PackagesResponse{}, err
 		}
+		generatedAt = time.Now()
+		if len(sourceErrs) > 0 {
+			log.Printf("[packages] computed with %d source errors: %+v", len(sourceErrs), sourceErrs)
+		}
 		packagesCacheMu.Lock()
-		packagesCache[cacheKey] = packagesCacheEntry{at: time.Now(), rows: rows, errors: sourceErrs}
+		if len(packagesCache) >= packagesCacheMaxEntries {
+			evictOldestPackagesCacheEntry()
+		}
+		packagesCache[cacheKey] = packagesCacheEntry{at: generatedAt, rows: rows, errors: sourceErrs}
 		packagesCacheMu.Unlock()
 	}
 
@@ -113,10 +131,28 @@ func ListPackages(ctx context.Context, p ListPackagesParams) (PackagesResponse, 
 	}
 	return PackagesResponse{
 		Packages:       rows,
-		GeneratedAt:    time.Now(),
+		GeneratedAt:    generatedAt,
 		SourcesUsed:    used,
 		SourcesErrored: sourceErrs,
 	}, nil
+}
+
+// evictOldestPackagesCacheEntry drops the entry with the earliest `at`.
+// Caller must hold packagesCacheMu.
+func evictOldestPackagesCacheEntry() {
+	var oldestKey string
+	var oldestAt time.Time
+	first := true
+	for k, e := range packagesCache {
+		if first || e.at.Before(oldestAt) {
+			oldestKey = k
+			oldestAt = e.at
+			first = false
+		}
+	}
+	if !first {
+		delete(packagesCache, oldestKey)
+	}
 }
 
 // packagesCacheKeyFor produces a stable cache key. Both the user
@@ -163,7 +199,7 @@ func (s *Server) handleListPackages(w http.ResponseWriter, r *http.Request) {
 		Groups:     groups,
 	})
 	if err != nil {
-		if err == errResourceCacheUnavailable {
+		if errors.Is(err, errResourceCacheUnavailable) {
 			s.writeError(w, http.StatusServiceUnavailable, err.Error())
 			return
 		}
@@ -186,39 +222,14 @@ func computePackagesInternal(ctx context.Context, namespaces []string, user stri
 	src := packages.Sources{}
 	var errs []SourceError
 
-	// Helm releases (source H). For multi-namespace queries we list
-	// cluster-wide and rely on the post-aggregate filter — Helm's RBAC
-	// impersonation already scopes results to what the user can see.
-	helmNamespace := ""
-	if len(namespaces) == 1 {
-		helmNamespace = namespaces[0]
-	}
-	if hClient := helm.GetClient(); hClient != nil {
-		releases, err := hClient.ListReleasesAsUser(helmNamespace, user, groups)
-		switch {
-		case err == nil:
-			src.Helm = make([]packages.HelmRelease, 0, len(releases))
-			for _, h := range releases {
-				src.Helm = append(src.Helm, packages.HelmRelease{
-					Name:           h.Name,
-					Namespace:      h.Namespace,
-					Chart:          h.Chart,
-					ChartVersion:   h.ChartVersion,
-					AppVersion:     h.AppVersion,
-					Status:         h.Status,
-					ResourceHealth: h.ResourceHealth,
-				})
-			}
-		case helm.IsForbiddenError(err):
-			errs = append(errs, SourceError{
-				Source:     packages.SourceHelm,
-				StatusCode: http.StatusForbidden,
-				Error:      "RBAC denied (helm release secrets): " + err.Error(),
-			})
-		default:
-			errs = append(errs, SourceError{Source: packages.SourceHelm, Error: err.Error()})
-		}
-	}
+	// Helm releases (source H). For a single-namespace request we ask
+	// Helm directly; for nil (all namespaces) we ask cluster-wide. For a
+	// multi-namespace allow-list we iterate per-namespace — asking
+	// cluster-wide would require the user to have list-secrets across
+	// the cluster, which limited-RBAC users typically lack.
+	helmReleases, helmErrs := collectHelmReleases(namespaces, user, groups)
+	src.Helm = helmReleases
+	errs = append(errs, helmErrs...)
 
 	// Workloads (source L) — Deployments + DaemonSets + StatefulSets.
 	workloads, listerErr := collectWorkloadInputs(cache, namespaces)
@@ -286,20 +297,92 @@ func computePackagesInternal(ctx context.Context, namespaces []string, user stri
 	return rows, errs, nil
 }
 
+// collectHelmReleases reads Helm releases for the requested namespace
+// scope, attributing per-source errors. RBAC denials are non-fatal —
+// they surface as a SourceError with StatusCode 403 so the caller can
+// distinguish "cluster has no Helm" from "user can't read Helm secrets."
+//
+// nil namespaces → cluster-wide (one call)
+// single namespace → that namespace (one call)
+// multi-namespace → one call per namespace; per-namespace forbidden
+// errors are coalesced into one SourceError so a user with access to
+// ns-a but not ns-b still sees ns-a's releases.
+func collectHelmReleases(namespaces []string, user string, groups []string) ([]packages.HelmRelease, []SourceError) {
+	hClient := helm.GetClient()
+	if hClient == nil {
+		return nil, []SourceError{{
+			Source: packages.SourceHelm,
+			Error:  "helm client not initialized (cluster connect in progress or failed)",
+		}}
+	}
+	scopes := []string{""}
+	switch {
+	case len(namespaces) == 1:
+		scopes = []string{namespaces[0]}
+	case len(namespaces) > 1:
+		scopes = namespaces
+	}
+	var out []packages.HelmRelease
+	var forbidden []string
+	var otherErrs []error
+	for _, ns := range scopes {
+		releases, err := hClient.ListReleasesAsUser(ns, user, groups)
+		if err == nil {
+			for _, h := range releases {
+				out = append(out, packages.HelmRelease{
+					Name:           h.Name,
+					Namespace:      h.Namespace,
+					Chart:          h.Chart,
+					ChartVersion:   h.ChartVersion,
+					AppVersion:     h.AppVersion,
+					Status:         h.Status,
+					ResourceHealth: h.ResourceHealth,
+				})
+			}
+			continue
+		}
+		if helm.IsForbiddenError(err) {
+			label := ns
+			if label == "" {
+				label = "cluster-wide"
+			}
+			forbidden = append(forbidden, label)
+			continue
+		}
+		otherErrs = append(otherErrs, fmt.Errorf("ns=%q: %w", ns, err))
+	}
+	var errs []SourceError
+	if len(forbidden) > 0 {
+		errs = append(errs, SourceError{
+			Source:     packages.SourceHelm,
+			StatusCode: http.StatusForbidden,
+			Error:      "RBAC denied (helm release secrets): " + strings.Join(forbidden, ", "),
+		})
+	}
+	if len(otherErrs) > 0 {
+		errs = append(errs, SourceError{Source: packages.SourceHelm, Error: errors.Join(otherErrs...).Error()})
+	}
+	return out, errs
+}
+
 // collectWorkloadInputs reads Deployments + DaemonSets + StatefulSets
 // from the cache and converts them to the packages.Workload shape used
 // by the merger. Only workloads with helm.sh/chart label OR
-// meta.helm.sh/release-name annotation contribute. Returns the first
-// lister error encountered (so the caller can attribute it to source L)
-// — informer listers fail rarely (indexer issues), but per the
-// CLAUDE.md backend convention we don't drop errors silently.
+// meta.helm.sh/release-name annotation contribute. Errors from any
+// lister/namespace combination are joined (with kind+ns context) so
+// the caller can attribute them to source L without dropping any.
 func collectWorkloadInputs(cache *k8s.ResourceCache, namespaces []string) ([]packages.Workload, error) {
 	var out []packages.Workload
-	var firstErr error
-	noteErr := func(err error) {
-		if err != nil && firstErr == nil {
-			firstErr = err
+	var listerErrs []error
+	noteErr := func(kind, ns string, err error) {
+		if err == nil {
+			return
 		}
+		nsLabel := ns
+		if nsLabel == "" {
+			nsLabel = "*"
+		}
+		listerErrs = append(listerErrs, fmt.Errorf("%s ns=%s: %w", kind, nsLabel, err))
 	}
 	add := func(kind, ns, name string, lbls, anns map[string]string, health string) {
 		if lbls["helm.sh/chart"] == "" && anns["meta.helm.sh/release-name"] == "" {
@@ -331,7 +414,7 @@ func collectWorkloadInputs(cache *k8s.ResourceCache, namespaces []string) ([]pac
 		forEachNamespace(func(ns string) {
 			if ns == "" {
 				items, err := depLister.List(labels.Everything())
-				noteErr(err)
+				noteErr("Deployment", ns, err)
 				for _, d := range items {
 					add("Deployment", d.Namespace, d.Name, d.Labels, d.Annotations,
 						deploymentHealth(int(d.Status.Replicas), int(d.Status.AvailableReplicas)))
@@ -339,7 +422,7 @@ func collectWorkloadInputs(cache *k8s.ResourceCache, namespaces []string) ([]pac
 				return
 			}
 			items, err := depLister.Deployments(ns).List(labels.Everything())
-			noteErr(err)
+			noteErr("Deployment", ns, err)
 			for _, d := range items {
 				add("Deployment", d.Namespace, d.Name, d.Labels, d.Annotations,
 					deploymentHealth(int(d.Status.Replicas), int(d.Status.AvailableReplicas)))
@@ -350,7 +433,7 @@ func collectWorkloadInputs(cache *k8s.ResourceCache, namespaces []string) ([]pac
 		forEachNamespace(func(ns string) {
 			if ns == "" {
 				items, err := dsLister.List(labels.Everything())
-				noteErr(err)
+				noteErr("DaemonSet", ns, err)
 				for _, d := range items {
 					add("DaemonSet", d.Namespace, d.Name, d.Labels, d.Annotations,
 						daemonsetHealth(int(d.Status.DesiredNumberScheduled), int(d.Status.NumberReady)))
@@ -358,7 +441,7 @@ func collectWorkloadInputs(cache *k8s.ResourceCache, namespaces []string) ([]pac
 				return
 			}
 			items, err := dsLister.DaemonSets(ns).List(labels.Everything())
-			noteErr(err)
+			noteErr("DaemonSet", ns, err)
 			for _, d := range items {
 				add("DaemonSet", d.Namespace, d.Name, d.Labels, d.Annotations,
 					daemonsetHealth(int(d.Status.DesiredNumberScheduled), int(d.Status.NumberReady)))
@@ -369,7 +452,7 @@ func collectWorkloadInputs(cache *k8s.ResourceCache, namespaces []string) ([]pac
 		forEachNamespace(func(ns string) {
 			if ns == "" {
 				items, err := ssLister.List(labels.Everything())
-				noteErr(err)
+				noteErr("StatefulSet", ns, err)
 				for _, ss := range items {
 					add("StatefulSet", ss.Namespace, ss.Name, ss.Labels, ss.Annotations,
 						statefulsetHealth(int(ss.Status.Replicas), int(ss.Status.ReadyReplicas)))
@@ -377,14 +460,14 @@ func collectWorkloadInputs(cache *k8s.ResourceCache, namespaces []string) ([]pac
 				return
 			}
 			items, err := ssLister.StatefulSets(ns).List(labels.Everything())
-			noteErr(err)
+			noteErr("StatefulSet", ns, err)
 			for _, ss := range items {
 				add("StatefulSet", ss.Namespace, ss.Name, ss.Labels, ss.Annotations,
 					statefulsetHealth(int(ss.Status.Replicas), int(ss.Status.ReadyReplicas)))
 			}
 		})
 	}
-	return out, firstErr
+	return out, errors.Join(listerErrs...)
 }
 
 func deploymentHealth(desired, available int) string {
@@ -413,6 +496,8 @@ func collectGitOpsDeclarations(ctx context.Context, cache *k8s.ResourceCache, er
 		for _, item := range items {
 			if d, ok := packages.ParseArgoApplication(item.Object); ok {
 				out = append(out, d)
+			} else {
+				log.Printf("[packages] failed to parse Argo Application %s/%s — skipping", item.GetNamespace(), item.GetName())
 			}
 		}
 	} else if !isMissingCRDErr(err) {
@@ -423,6 +508,8 @@ func collectGitOpsDeclarations(ctx context.Context, cache *k8s.ResourceCache, er
 		for _, item := range items {
 			if d, ok := packages.ParseFluxHelmRelease(item.Object); ok {
 				out = append(out, d)
+			} else {
+				log.Printf("[packages] failed to parse Flux HelmRelease %s/%s — skipping", item.GetNamespace(), item.GetName())
 			}
 		}
 	} else if !isMissingCRDErr(err) {
@@ -433,6 +520,8 @@ func collectGitOpsDeclarations(ctx context.Context, cache *k8s.ResourceCache, er
 		for _, item := range items {
 			if d, ok := packages.ParseFluxKustomization(item.Object); ok {
 				out = append(out, d)
+			} else {
+				log.Printf("[packages] failed to parse Flux Kustomization %s/%s — skipping", item.GetNamespace(), item.GetName())
 			}
 		}
 	} else if !isMissingCRDErr(err) {

--- a/internal/server/packages_test.go
+++ b/internal/server/packages_test.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/skyhook-io/radar/pkg/packages"
+)
+
+// Pins the error wording produced by k8s.ResourceCache.ListDynamicWithGroup
+// when the requested CRD isn't installed. If that wording changes,
+// graceful degradation breaks for clusters without ArgoCD/FluxCD —
+// every Radar install would suddenly show error banners on /api/packages.
+// See internal/k8s/cache.go ListDynamicWithGroup.
+func TestIsMissingCRDErr_PinsK8scoreErrorString(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"with-group", fmt.Errorf("unknown resource kind: %s (group: %s)", "Application", "argoproj.io"), true},
+		{"without-group", fmt.Errorf("unknown resource kind: %s", "Application"), true},
+		{"case-insensitive", errors.New("UNKNOWN RESOURCE KIND: Application"), true},
+		{"unrelated", errors.New("connection refused"), false},
+		{"forbidden", errors.New("namespaces is forbidden"), false},
+		{"nil", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isMissingCRDErr(c.err); got != c.want {
+				t.Errorf("isMissingCRDErr(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}
+
+func TestPackagesCacheKey_DistinguishesUserAndNamespaces(t *testing.T) {
+	// Same user, different namespace sets → different keys.
+	a := packagesCacheKeyFor("alice", []string{"prod"})
+	b := packagesCacheKeyFor("alice", []string{"staging"})
+	if a == b {
+		t.Errorf("expected different keys for different namespaces, got %q", a)
+	}
+	// Different users, same namespaces → different keys.
+	c := packagesCacheKeyFor("bob", []string{"prod"})
+	if a == c {
+		t.Errorf("expected different keys for different users, got %q", a)
+	}
+	// nil namespaces vs empty slice should be different (empty = no access).
+	all := packagesCacheKeyFor("alice", nil)
+	none := packagesCacheKeyFor("alice", []string{})
+	if all == none {
+		t.Errorf("nil (all namespaces) and empty slice (no access) must differ; both = %q", all)
+	}
+	// Order independence: same set in different orders → same key.
+	x := packagesCacheKeyFor("alice", []string{"a", "b"})
+	y := packagesCacheKeyFor("alice", []string{"b", "a"})
+	if x != y {
+		t.Errorf("namespace order should not affect key: %q vs %q", x, y)
+	}
+}
+
+func TestSourcesUsed_StableCanonicalOrder(t *testing.T) {
+	// Build rows whose Sources collectively cover all five codes,
+	// added in non-canonical order. sourcesUsed should still emit
+	// H, L, C, A, F in canonical order.
+	rows := []packages.PackageRow{
+		{Sources: []string{packages.SourceFluxCD, packages.SourceArgoCD}},
+		{Sources: []string{packages.SourceCRDs}},
+		{Sources: []string{packages.SourceLabels, packages.SourceHelm}},
+	}
+	got := sourcesUsed(rows)
+	want := []string{packages.SourceHelm, packages.SourceLabels, packages.SourceCRDs, packages.SourceArgoCD, packages.SourceFluxCD}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("sourcesUsed = %v, want %v", got, want)
+	}
+}
+
+func TestFilterByChartSubstring_CaseInsensitive(t *testing.T) {
+	rows := []packages.PackageRow{
+		{Chart: "cert-manager"},
+		{Chart: "Karpenter"},
+		{Chart: "external-dns"},
+	}
+	out := filterByChartSubstring(rows, "karpen")
+	if len(out) != 1 || out[0].Chart != "Karpenter" {
+		t.Errorf("expected Karpenter row only, got %+v", out)
+	}
+}

--- a/internal/server/packages_test.go
+++ b/internal/server/packages_test.go
@@ -76,6 +76,62 @@ func TestSourcesUsed_StableCanonicalOrder(t *testing.T) {
 	}
 }
 
+// Invalid `?source=` values must NOT silently return an empty list
+// (HTTP 200 with no rows looks identical to "nothing installed" — a
+// confidently-wrong answer for any consumer that typo'd a source code).
+// Validate at the boundary; surface as ErrInvalidSourceCode.
+func TestListPackages_InvalidSourceRejected(t *testing.T) {
+	withCleanCache(t, func() {
+		cases := []string{"Z", "helm", "h,l", " H", ""}
+		for _, in := range cases {
+			if in == "" {
+				// Empty source means "no filter" — must NOT be rejected.
+				continue
+			}
+			t.Run(in, func(t *testing.T) {
+				_, err := ListPackages(context.Background(), ListPackagesParams{
+					Namespaces: []string{"prod"}, User: "alice", Source: in,
+				})
+				if !errors.Is(err, ErrInvalidSourceCode) {
+					t.Errorf("source=%q want ErrInvalidSourceCode, got %v", in, err)
+				}
+			})
+		}
+		// And empty source still works (filter is just skipped).
+		_, err := ListPackages(context.Background(), ListPackagesParams{
+			Namespaces: []string{}, User: "alice", Source: "",
+		})
+		if err != nil {
+			t.Errorf("empty source must not error, got %v", err)
+		}
+	})
+}
+
+// `?source=A` must match rows where Argo contributed (in addition to
+// any other sources), not only rows where Argo was the sole contributor.
+// This is the query semantic Hub locks in — "show me everything Argo
+// manages, including releases also reported by Helm or labels."
+func TestFilterBySource_MatchesAnyContributor(t *testing.T) {
+	rows := []packages.PackageRow{
+		{Chart: "helm-only", Sources: []packages.SourceCode{packages.SourceHelm}},
+		{Chart: "argo-managed-helm", Sources: []packages.SourceCode{packages.SourceHelm, packages.SourceArgoCD}},
+		{Chart: "argo-only", Sources: []packages.SourceCode{packages.SourceArgoCD}},
+		{Chart: "labels-only", Sources: []packages.SourceCode{packages.SourceLabels}},
+	}
+	got := filterBySource(rows, packages.SourceArgoCD)
+	if len(got) != 2 {
+		t.Fatalf("source=A want 2 rows (argo-managed-helm + argo-only), got %d: %+v", len(got), got)
+	}
+	gotCharts := map[string]bool{got[0].Chart: true, got[1].Chart: true}
+	if !gotCharts["argo-managed-helm"] || !gotCharts["argo-only"] {
+		t.Errorf("expected charts {argo-managed-helm, argo-only}, got %v", gotCharts)
+	}
+	// Sanity: source=H still matches multi-source row.
+	if got := filterBySource(rows, packages.SourceHelm); len(got) != 2 {
+		t.Errorf("source=H want 2 rows, got %d", len(got))
+	}
+}
+
 func TestFilterByChartSubstring_CaseInsensitive(t *testing.T) {
 	rows := []packages.PackageRow{
 		{Chart: "cert-manager"},
@@ -214,36 +270,72 @@ func TestListPackages_CachedResponseUsesEntryTimestamp(t *testing.T) {
 	})
 }
 
-// Behavioral guard for cache size cap: once packagesCacheMaxEntries is
-// reached, the next compute must evict the oldest entry rather than
-// growing the map indefinitely.
-func TestListPackages_CacheCapEvictsOldest(t *testing.T) {
+// Direct unit test on the eviction helper — picks the oldest by `at`.
+func TestEvictOldestPackagesCacheEntry(t *testing.T) {
 	withCleanCache(t, func() {
-		// Fill cache to cap with entries at staggered timestamps —
-		// "old" must be evicted first.
 		now := time.Now()
-		oldKey := packagesCacheKeyFor("zero", []string{"old"})
+		oldKey := "oldest"
 		packagesCacheMu.Lock()
 		packagesCache[oldKey] = packagesCacheEntry{at: now.Add(-time.Hour)}
-		for i := 1; i < packagesCacheMaxEntries; i++ {
-			k := packagesCacheKeyFor(fmt.Sprintf("u%d", i), []string{fmt.Sprintf("ns%d", i)})
-			packagesCache[k] = packagesCacheEntry{at: now}
-		}
-		// Sanity: at cap.
-		if len(packagesCache) != packagesCacheMaxEntries {
-			t.Fatalf("setup: want %d entries, got %d", packagesCacheMaxEntries, len(packagesCache))
-		}
-		// Trigger eviction by manually calling — the eviction path runs
-		// inside the locked block before insertion in ListPackages, but
-		// we don't have a backend wired up so we test the helper directly.
+		packagesCache["recent-1"] = packagesCacheEntry{at: now}
+		packagesCache["recent-2"] = packagesCacheEntry{at: now.Add(-time.Minute)}
 		evictOldestPackagesCacheEntry()
 		if _, hit := packagesCache[oldKey]; hit {
 			t.Errorf("oldest entry %q should have been evicted", oldKey)
 		}
-		if len(packagesCache) != packagesCacheMaxEntries-1 {
-			t.Errorf("after eviction want %d entries, got %d", packagesCacheMaxEntries-1, len(packagesCache))
+		if len(packagesCache) != 2 {
+			t.Errorf("after eviction want 2 entries, got %d", len(packagesCache))
 		}
 		packagesCacheMu.Unlock()
+	})
+}
+
+// Behavioral guard for cache size cap: the eviction-at-insert path in
+// ListPackages must keep the map from growing past packagesCacheMaxEntries.
+// Drives ListPackages with the empty-namespace fast-path so we never need
+// a real backend, yet still exercise the cache-write code path indirectly
+// — by pre-populating up to cap and then triggering one more compute.
+func TestListPackages_CacheCapEnforcedAtInsert(t *testing.T) {
+	withCleanCache(t, func() {
+		origCap := packagesCacheMaxEntries
+		packagesCacheMaxEntries = 4
+		defer func() { packagesCacheMaxEntries = origCap }()
+
+		// Pre-fill cache to cap with stale-but-valid entries.
+		base := time.Now().Add(-30 * time.Second) // still fresh for TTL
+		packagesCacheMu.Lock()
+		oldestKey := packagesCacheKeyFor("u0", []string{"ns0"})
+		packagesCache[oldestKey] = packagesCacheEntry{at: base.Add(-time.Minute)}
+		for i := 1; i < packagesCacheMaxEntries; i++ {
+			k := packagesCacheKeyFor(fmt.Sprintf("u%d", i), []string{fmt.Sprintf("ns%d", i)})
+			packagesCache[k] = packagesCacheEntry{at: base.Add(time.Duration(i) * time.Second)}
+		}
+		if len(packagesCache) != packagesCacheMaxEntries {
+			t.Fatalf("setup: want %d entries, got %d", packagesCacheMaxEntries, len(packagesCache))
+		}
+		packagesCacheMu.Unlock()
+
+		// Drive eviction directly — simulates what ListPackages does
+		// inside the locked block before inserting a new entry. (We
+		// can't drive computePackagesInternal in unit tests without a
+		// real K8s cache, so we exercise the same eviction call site
+		// the production path uses.)
+		packagesCacheMu.Lock()
+		if len(packagesCache) >= packagesCacheMaxEntries {
+			evictOldestPackagesCacheEntry()
+		}
+		packagesCache[packagesCacheKeyFor("new-user", []string{"new-ns"})] = packagesCacheEntry{at: time.Now()}
+		packagesCacheMu.Unlock()
+
+		// The oldest entry must have been evicted; cap respected.
+		packagesCacheMu.Lock()
+		defer packagesCacheMu.Unlock()
+		if _, hit := packagesCache[oldestKey]; hit {
+			t.Errorf("oldest entry should have been evicted under cap")
+		}
+		if len(packagesCache) > packagesCacheMaxEntries {
+			t.Errorf("cap %d exceeded: %d entries", packagesCacheMaxEntries, len(packagesCache))
+		}
 	})
 }
 

--- a/internal/server/packages_test.go
+++ b/internal/server/packages_test.go
@@ -1,10 +1,11 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
+	"time"
 
 	"github.com/skyhook-io/radar/pkg/packages"
 )
@@ -63,17 +64,14 @@ func TestPackagesCacheKey_DistinguishesUserAndNamespaces(t *testing.T) {
 }
 
 func TestSourcesUsed_StableCanonicalOrder(t *testing.T) {
-	// Build rows whose Sources collectively cover all five codes,
-	// added in non-canonical order. sourcesUsed should still emit
-	// H, L, C, A, F in canonical order.
 	rows := []packages.PackageRow{
-		{Sources: []string{packages.SourceFluxCD, packages.SourceArgoCD}},
-		{Sources: []string{packages.SourceCRDs}},
-		{Sources: []string{packages.SourceLabels, packages.SourceHelm}},
+		{Sources: []packages.SourceCode{packages.SourceFluxCD, packages.SourceArgoCD}},
+		{Sources: []packages.SourceCode{packages.SourceCRDs}},
+		{Sources: []packages.SourceCode{packages.SourceLabels, packages.SourceHelm}},
 	}
 	got := sourcesUsed(rows)
-	want := []string{packages.SourceHelm, packages.SourceLabels, packages.SourceCRDs, packages.SourceArgoCD, packages.SourceFluxCD}
-	if strings.Join(got, ",") != strings.Join(want, ",") {
+	want := []packages.SourceCode{packages.SourceHelm, packages.SourceLabels, packages.SourceCRDs, packages.SourceArgoCD, packages.SourceFluxCD}
+	if !sourceCodesEqual(got, want) {
 		t.Errorf("sourcesUsed = %v, want %v", got, want)
 	}
 }
@@ -89,3 +87,192 @@ func TestFilterByChartSubstring_CaseInsensitive(t *testing.T) {
 		t.Errorf("expected Karpenter row only, got %+v", out)
 	}
 }
+
+// Behavioral guard against the most security-sensitive regression in
+// this module: two users hitting the same namespace must NOT see each
+// other's Helm rows. We pre-populate the cache with two distinct
+// (user, ns) entries and verify ListPackages returns each user's data
+// from their respective entry.
+//
+// This catches: forgetting User in packagesCacheKeyFor; reordering the
+// cache lookup before the user is wired in; or any refactor that drops
+// user identity from the key path.
+func TestListPackages_UserScopedCacheReturnsDistinctData(t *testing.T) {
+	withCleanCache(t, func() {
+		now := time.Now()
+		aliceKey := packagesCacheKeyFor("alice", []string{"prod"})
+		bobKey := packagesCacheKeyFor("bob", []string{"prod"})
+
+		packagesCacheMu.Lock()
+		packagesCache[aliceKey] = packagesCacheEntry{
+			at: now,
+			rows: []packages.PackageRow{{
+				Chart: "alice-only-chart", Namespace: "prod", ReleaseName: "alice-app",
+				Sources: []packages.SourceCode{packages.SourceHelm}, Health: packages.HealthHealthy,
+			}},
+		}
+		packagesCache[bobKey] = packagesCacheEntry{
+			at: now,
+			rows: []packages.PackageRow{{
+				Chart: "bob-only-chart", Namespace: "prod", ReleaseName: "bob-app",
+				Sources: []packages.SourceCode{packages.SourceHelm}, Health: packages.HealthHealthy,
+			}},
+		}
+		packagesCacheMu.Unlock()
+
+		aliceResp, err := ListPackages(context.Background(), ListPackagesParams{
+			Namespaces: []string{"prod"}, User: "alice",
+		})
+		if err != nil {
+			t.Fatalf("alice ListPackages: %v", err)
+		}
+		if len(aliceResp.Packages) != 1 || aliceResp.Packages[0].Chart != "alice-only-chart" {
+			t.Fatalf("alice got %+v, want chart=alice-only-chart", aliceResp.Packages)
+		}
+
+		bobResp, err := ListPackages(context.Background(), ListPackagesParams{
+			Namespaces: []string{"prod"}, User: "bob",
+		})
+		if err != nil {
+			t.Fatalf("bob ListPackages: %v", err)
+		}
+		if len(bobResp.Packages) != 1 || bobResp.Packages[0].Chart != "bob-only-chart" {
+			t.Fatalf("bob got %+v, want chart=bob-only-chart", bobResp.Packages)
+		}
+	})
+}
+
+// Behavioral guard for the auth-restricted-to-zero-namespaces path:
+// callers passing an empty (non-nil) namespace slice must get an empty
+// response without consulting the cache OR the backend. A regression
+// where empty slice gets confused with nil ("all namespaces") would
+// leak every package in the cluster to a zero-access user.
+func TestListPackages_EmptyNamespacesShortCircuits(t *testing.T) {
+	withCleanCache(t, func() {
+		// Pre-populate "all namespaces" cache to make sure the
+		// short-circuit doesn't accidentally read it.
+		nilKey := packagesCacheKeyFor("alice", nil)
+		packagesCacheMu.Lock()
+		packagesCache[nilKey] = packagesCacheEntry{
+			at: time.Now(),
+			rows: []packages.PackageRow{{
+				Chart: "should-not-appear", Sources: []packages.SourceCode{packages.SourceHelm}, Health: packages.HealthHealthy,
+			}},
+		}
+		packagesCacheMu.Unlock()
+
+		resp, err := ListPackages(context.Background(), ListPackagesParams{
+			Namespaces: []string{}, User: "alice",
+		})
+		if err != nil {
+			t.Fatalf("ListPackages: %v", err)
+		}
+		if len(resp.Packages) != 0 {
+			t.Errorf("want 0 packages, got %d: %+v", len(resp.Packages), resp.Packages)
+		}
+		if len(resp.SourcesUsed) != 0 {
+			t.Errorf("want empty SourcesUsed, got %v", resp.SourcesUsed)
+		}
+		if len(resp.SourcesErrored) != 0 {
+			t.Errorf("want empty SourcesErrored, got %v", resp.SourcesErrored)
+		}
+		// Verify the empty-slice path didn't write a cache entry.
+		emptyKey := packagesCacheKeyFor("alice", []string{})
+		packagesCacheMu.Lock()
+		_, hit := packagesCache[emptyKey]
+		packagesCacheMu.Unlock()
+		if hit {
+			t.Error("empty-namespace path should not write a cache entry")
+		}
+	})
+}
+
+// Behavioral guard for the cached-response timestamp: after a cache
+// hit, GeneratedAt must reflect the cached entry's age, NOT time.Now().
+// Otherwise the wire format lies about freshness — agents trust the
+// timestamp and don't re-fetch even when data is up to TTL old.
+func TestListPackages_CachedResponseUsesEntryTimestamp(t *testing.T) {
+	withCleanCache(t, func() {
+		entryAt := time.Now().Add(-30 * time.Second)
+		key := packagesCacheKeyFor("alice", []string{"prod"})
+		packagesCacheMu.Lock()
+		packagesCache[key] = packagesCacheEntry{
+			at:   entryAt,
+			rows: []packages.PackageRow{},
+		}
+		packagesCacheMu.Unlock()
+
+		resp, err := ListPackages(context.Background(), ListPackagesParams{
+			Namespaces: []string{"prod"}, User: "alice",
+		})
+		if err != nil {
+			t.Fatalf("ListPackages: %v", err)
+		}
+		if !resp.GeneratedAt.Equal(entryAt) {
+			t.Errorf("GeneratedAt = %v, want cached entry time %v", resp.GeneratedAt, entryAt)
+		}
+	})
+}
+
+// Behavioral guard for cache size cap: once packagesCacheMaxEntries is
+// reached, the next compute must evict the oldest entry rather than
+// growing the map indefinitely.
+func TestListPackages_CacheCapEvictsOldest(t *testing.T) {
+	withCleanCache(t, func() {
+		// Fill cache to cap with entries at staggered timestamps —
+		// "old" must be evicted first.
+		now := time.Now()
+		oldKey := packagesCacheKeyFor("zero", []string{"old"})
+		packagesCacheMu.Lock()
+		packagesCache[oldKey] = packagesCacheEntry{at: now.Add(-time.Hour)}
+		for i := 1; i < packagesCacheMaxEntries; i++ {
+			k := packagesCacheKeyFor(fmt.Sprintf("u%d", i), []string{fmt.Sprintf("ns%d", i)})
+			packagesCache[k] = packagesCacheEntry{at: now}
+		}
+		// Sanity: at cap.
+		if len(packagesCache) != packagesCacheMaxEntries {
+			t.Fatalf("setup: want %d entries, got %d", packagesCacheMaxEntries, len(packagesCache))
+		}
+		// Trigger eviction by manually calling — the eviction path runs
+		// inside the locked block before insertion in ListPackages, but
+		// we don't have a backend wired up so we test the helper directly.
+		evictOldestPackagesCacheEntry()
+		if _, hit := packagesCache[oldKey]; hit {
+			t.Errorf("oldest entry %q should have been evicted", oldKey)
+		}
+		if len(packagesCache) != packagesCacheMaxEntries-1 {
+			t.Errorf("after eviction want %d entries, got %d", packagesCacheMaxEntries-1, len(packagesCache))
+		}
+		packagesCacheMu.Unlock()
+	})
+}
+
+// withCleanCache snapshots, clears, then restores the package-level
+// cache so tests don't leak state into each other (or into other tests
+// in the same package).
+func withCleanCache(t *testing.T, fn func()) {
+	t.Helper()
+	packagesCacheMu.Lock()
+	saved := packagesCache
+	packagesCache = map[string]packagesCacheEntry{}
+	packagesCacheMu.Unlock()
+	defer func() {
+		packagesCacheMu.Lock()
+		packagesCache = saved
+		packagesCacheMu.Unlock()
+	}()
+	fn()
+}
+
+func sourceCodesEqual(a, b []packages.SourceCode) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -238,6 +238,11 @@ func (s *Server) setupRoutes() {
 			// Cluster audit
 			r.Get("/audit", s.handleAudit)
 			r.Get("/audit/resource/{kind}/{namespace}/{name}", s.handleAuditResource)
+
+			// Packages — merged "what's installed" view across Helm
+			// releases, workload labels, CRD registrations, and GitOps
+			// declarations. See pkg/packages for merge semantics.
+			r.Get("/packages", s.handleListPackages)
 			r.Get("/settings/audit", s.handleGetAuditSettings)
 			r.Put("/settings/audit", s.handlePutAuditSettings)
 			r.Get("/events", s.handleEvents)

--- a/pkg/packages/aggregate.go
+++ b/pkg/packages/aggregate.go
@@ -67,7 +67,7 @@ func Aggregate(s Sources) []PackageRow {
 		}
 		k := key{chart: chartName, namespace: h.Namespace, releaseName: h.Name}
 		r := get(k)
-		addSource(r, SourceHelm)
+		r.AddSource(SourceHelm)
 		// Helm fields win over later sources for these (highest signal).
 		if r.Version == "" {
 			r.Version = chartVersion
@@ -75,7 +75,7 @@ func Aggregate(s Sources) []PackageRow {
 		if r.AppVersion == "" {
 			r.AppVersion = h.AppVersion
 		}
-		r.Health = worseHealth(r.Health, h.ResourceHealth)
+		r.MergeHealth(h.ResourceHealth)
 	}
 
 	// 2. Workloads with Helm labels (source L).
@@ -86,14 +86,11 @@ func Aggregate(s Sources) []PackageRow {
 		if releaseName == "" && chartLabel == "" {
 			continue
 		}
-		// Derive chart name + version from the label first; fall back to
-		// release name + no version when the label's missing.
 		var chartName, chartVersion string
 		if chartLabel != "" {
 			chartName, chartVersion = splitChart(chartLabel)
 		}
 		if chartName == "" && releaseName != "" {
-			// Best-guess: release names often equal chart names ("cert-manager")
 			chartName = releaseName
 		}
 		if chartName == "" {
@@ -110,42 +107,34 @@ func Aggregate(s Sources) []PackageRow {
 		}
 		k := key{chart: chartName, namespace: releaseNs, releaseName: releaseName}
 		r := get(k)
-		addSource(r, SourceLabels)
-		// Label version is a secondary signal — only fill when Helm didn't.
+		r.AddSource(SourceLabels)
 		if r.Version == "" {
 			r.Version = chartVersion
 		}
-		// Worst-of health across all workloads for this release.
-		r.Health = worseHealth(r.Health, w.Health)
+		r.MergeHealth(w.Health)
 	}
 
 	// 3. GitOps declarations (sources A / F) — declared installs, may
 	//    or may not be running yet.
 	for _, d := range s.GitOpsDeclarations {
-		var src string
+		var src SourceCode
 		switch strings.ToLower(d.Source) {
 		case "argocd", "argo-cd", "argo":
 			src = SourceArgoCD
 		case "flux", "fluxcd":
 			src = SourceFluxCD
 		default:
-			// Unknown declaration source — skip rather than misattribute.
 			continue
 		}
 		chartName := d.Chart
 		// When the declaration omits the chart (e.g. raw-YAML Flux
-		// Kustomization), fall back to the declaration name itself —
-		// produces a usable row, just less rich.
+		// Kustomization), fall back to the declaration name itself.
 		if chartName == "" {
 			chartName = d.Name
 		}
 		if chartName == "" {
 			continue
 		}
-		// Use the declaration's target identity to merge with Helm/L
-		// rows when the GitOps controller manages a Helm release the
-		// Helm API also reports. Argo Helm-source apps + Flux
-		// HelmReleases land here.
 		ns := d.TargetNamespace
 		release := d.TargetName
 		if release == "" {
@@ -153,13 +142,11 @@ func Aggregate(s Sources) []PackageRow {
 		}
 		k := key{chart: chartName, namespace: ns, releaseName: release}
 		r := get(k)
-		addSource(r, src)
+		r.AddSource(src)
 		if r.Version == "" {
 			r.Version = d.ChartVersion
 		}
-		// Declarations contribute health when no runtime source did
-		// (typical for declared-but-not-yet-running installs).
-		r.Health = worseHealth(r.Health, d.Status)
+		r.MergeHealth(d.Status)
 	}
 
 	// 4. CRD registrations (source C). Two cases:
@@ -176,11 +163,10 @@ func Aggregate(s Sources) []PackageRow {
 			version = c.Versions[0]
 		}
 		if known {
-			// Find any rows for this chart and add C to them.
 			matched := false
 			for k, r := range rows {
 				if k.chart == chartName {
-					addSource(r, SourceCRDs)
+					r.AddSource(SourceCRDs)
 					if r.Version == "" {
 						r.Version = version
 					}
@@ -194,12 +180,12 @@ func Aggregate(s Sources) []PackageRow {
 			// CRD-only row so the install is visible.
 			k := key{chart: chartName, namespace: "", releaseName: ""}
 			r := get(k)
-			addSource(r, SourceCRDs)
+			r.AddSource(SourceCRDs)
 			if r.Version == "" {
 				r.Version = version
 			}
 			if r.Health == "" {
-				r.Health = "unknown"
+				r.Health = HealthUnknown
 			}
 			continue
 		}
@@ -208,21 +194,20 @@ func Aggregate(s Sources) []PackageRow {
 		// single row.
 		k := key{chart: c.Group, namespace: "", releaseName: ""}
 		r := get(k)
-		addSource(r, SourceCRDs)
+		r.AddSource(SourceCRDs)
 		r.FromCRDGroup = c.Group
 		if r.Version == "" {
 			r.Version = version
 		}
 		if r.Health == "" {
-			r.Health = "unknown"
+			r.Health = HealthUnknown
 		}
 	}
 
-	// Default health to unknown for any row that ended up with none
-	// (CRD-only rows; declarations without a status; etc.).
+	// Default health to unknown for any row that ended up with none.
 	for _, r := range rows {
 		if r.Health == "" {
-			r.Health = "unknown"
+			r.Health = HealthUnknown
 		}
 	}
 
@@ -243,22 +228,14 @@ func Aggregate(s Sources) []PackageRow {
 	return out
 }
 
-// addSource appends src to r.Sources if not already present. Maintains
-// canonical order H, L, C, A, F.
-func addSource(r *PackageRow, src string) {
-	for _, s := range r.Sources {
-		if s == src {
-			return
-		}
-	}
-	r.Sources = append(r.Sources, src)
-	// Re-sort into canonical order.
-	sort.Slice(r.Sources, func(i, j int) bool {
-		return sourceRank(r.Sources[i]) < sourceRank(r.Sources[j])
+// sortSources sorts in place into canonical order H, L, C, A, F.
+func sortSources(s []SourceCode) {
+	sort.Slice(s, func(i, j int) bool {
+		return sourceRank(s[i]) < sourceRank(s[j])
 	})
 }
 
-func sourceRank(s string) int {
+func sourceRank(s SourceCode) int {
 	switch s {
 	case SourceHelm:
 		return 0
@@ -295,7 +272,6 @@ func splitChart(s string) (name, version string) {
 		if rest == "" {
 			continue
 		}
-		// Version: starts with digit, or v followed by digit.
 		c := rest[0]
 		if c >= '0' && c <= '9' {
 			return s[:i-1], rest
@@ -310,36 +286,37 @@ func splitChart(s string) (name, version string) {
 	return s, ""
 }
 
-// worseHealth returns the worse of two health strings using the order:
-// unhealthy > degraded > unknown > healthy. (Unknown beats healthy
+// worseHealth returns the worse of two Health values using the order:
+// Unhealthy > Degraded > Unknown > Healthy. (Unknown beats Healthy
 // because we don't want a CRD-only "unknown" row to be promoted to
-// "healthy" just because no other source contributed.) Unknown vocab
-// (typo, future GitOps reason we don't recognize yet) maps to the
-// "unknown" rank — quieter than degraded, still beats healthy.
+// "healthy" just because no other source contributed.) Unrecognized
+// vocab (typo, future GitOps reason) maps to the "unknown" rank —
+// quieter than Degraded, still beats Healthy.
 //
-// Empty strings are treated as "no opinion" — the other side wins.
-func worseHealth(a, b string) string {
+// Empty strings are "no opinion" — the other side wins.
+func worseHealth(a, b Health) Health {
 	if a == "" {
 		return b
 	}
 	if b == "" {
 		return a
 	}
-	rank := func(h string) int {
-		switch strings.ToLower(h) {
-		case "unhealthy", "danger", "critical", "failed", "stalled":
-			return 4
-		case "degraded", "warning", "warn", "progressing", "reconciling":
-			return 3
-		case "unknown":
-			return 2
-		case "healthy", "ok", "ready", "available":
-			return 1
-		}
-		return 2
-	}
-	if rank(a) >= rank(b) {
+	if healthRank(a) >= healthRank(b) {
 		return a
 	}
 	return b
+}
+
+func healthRank(h Health) int {
+	switch Health(strings.ToLower(string(h))) {
+	case HealthUnhealthy, "danger", "critical", "failed", "stalled":
+		return 4
+	case HealthDegraded, "warning", "warn", "progressing", "reconciling":
+		return 3
+	case HealthUnknown:
+		return 2
+	case HealthHealthy, "ok", "ready", "available":
+		return 1
+	}
+	return 2
 }

--- a/pkg/packages/aggregate.go
+++ b/pkg/packages/aggregate.go
@@ -1,0 +1,346 @@
+package packages
+
+import (
+	"sort"
+	"strings"
+	"time"
+)
+
+// Aggregate is the merge function. Given a Sources struct, returns a
+// deduplicated, source-attributed list of PackageRow.
+//
+// Merge keys:
+//   - Helm-shaped rows (sources H/L/A-with-chart/F-with-chart) merge on
+//     (release_namespace, release_name) — so "cert-manager Helm release
+//     in cert-manager namespace" + "cert-manager workload labels
+//     pointing to that same release" become one row.
+//   - CRD-only rows merge into Helm-shaped rows when crdGroupToChart
+//     resolves to the same chart name. So "cert-manager.io CRDs
+//     detected" + "cert-manager Helm release" → one row with sources
+//     [H,C].
+//   - Unknown CRD groups stay as their own rows (FromCRDGroup set).
+//
+// Determinism: rows are returned sorted by (chart, namespace,
+// release_name) so consumers (SPA tables, MCP tool output) get stable
+// ordering across calls.
+func Aggregate(s Sources) []PackageRow {
+	now := time.Now()
+	// We accumulate rows in a map keyed by (chart, namespace, releaseName).
+	// CRD-only rows that don't resolve to a chart get a synthetic key
+	// using FromCRDGroup.
+	type key struct {
+		chart       string
+		namespace   string
+		releaseName string
+	}
+	rows := map[key]*PackageRow{}
+
+	get := func(k key) *PackageRow {
+		if r, ok := rows[k]; ok {
+			return r
+		}
+		r := &PackageRow{
+			Chart:        k.chart,
+			Namespace:    k.namespace,
+			ReleaseName:  k.releaseName,
+			AggregatedAt: now,
+		}
+		rows[k] = r
+		return r
+	}
+
+	// 1. Helm releases (source H) — primary signal.
+	for _, h := range s.Helm {
+		chartName := h.ChartName
+		chartVersion := h.ChartVersion
+		if chartName == "" || chartVersion == "" {
+			parsedName, parsedVer := splitChart(h.Chart)
+			if chartName == "" {
+				chartName = parsedName
+			}
+			if chartVersion == "" {
+				chartVersion = parsedVer
+			}
+		}
+		if chartName == "" {
+			// Unparseable chart string and no name supplied — skip
+			// rather than create a row keyed on empty-string (which
+			// would absorb every other no-name row into one).
+			continue
+		}
+		k := key{chart: chartName, namespace: h.Namespace, releaseName: h.Name}
+		r := get(k)
+		addSource(r, SourceHelm)
+		// Helm fields win over later sources for these (highest signal).
+		if r.Version == "" {
+			r.Version = chartVersion
+		}
+		if r.AppVersion == "" {
+			r.AppVersion = h.AppVersion
+		}
+		r.Health = worseHealth(r.Health, h.ResourceHealth)
+	}
+
+	// 2. Workloads with Helm labels (source L).
+	for _, w := range s.Workloads {
+		releaseName := w.Annotations["meta.helm.sh/release-name"]
+		releaseNs := w.Annotations["meta.helm.sh/release-namespace"]
+		chartLabel := w.Labels["helm.sh/chart"]
+		if releaseName == "" && chartLabel == "" {
+			continue
+		}
+		// Derive chart name + version from the label first; fall back to
+		// release name + no version when the label's missing.
+		var chartName, chartVersion string
+		if chartLabel != "" {
+			chartName, chartVersion = splitChart(chartLabel)
+		}
+		if chartName == "" && releaseName != "" {
+			// Best-guess: release names often equal chart names ("cert-manager")
+			chartName = releaseName
+		}
+		if chartName == "" {
+			continue
+		}
+		// Without an explicit release-namespace annotation, fall back
+		// to the workload's namespace — covers Argo-applied Helm charts
+		// that don't always set the annotation.
+		if releaseNs == "" {
+			releaseNs = w.Namespace
+		}
+		if releaseName == "" {
+			releaseName = chartName
+		}
+		k := key{chart: chartName, namespace: releaseNs, releaseName: releaseName}
+		r := get(k)
+		addSource(r, SourceLabels)
+		// Label version is a secondary signal — only fill when Helm didn't.
+		if r.Version == "" {
+			r.Version = chartVersion
+		}
+		// Worst-of health across all workloads for this release.
+		r.Health = worseHealth(r.Health, w.Health)
+	}
+
+	// 3. GitOps declarations (sources A / F) — declared installs, may
+	//    or may not be running yet.
+	for _, d := range s.GitOpsDeclarations {
+		var src string
+		switch strings.ToLower(d.Source) {
+		case "argocd", "argo-cd", "argo":
+			src = SourceArgoCD
+		case "flux", "fluxcd":
+			src = SourceFluxCD
+		default:
+			// Unknown declaration source — skip rather than misattribute.
+			continue
+		}
+		chartName := d.Chart
+		// When the declaration omits the chart (e.g. raw-YAML Flux
+		// Kustomization), fall back to the declaration name itself —
+		// produces a usable row, just less rich.
+		if chartName == "" {
+			chartName = d.Name
+		}
+		if chartName == "" {
+			continue
+		}
+		// Use the declaration's target identity to merge with Helm/L
+		// rows when the GitOps controller manages a Helm release the
+		// Helm API also reports. Argo Helm-source apps + Flux
+		// HelmReleases land here.
+		ns := d.TargetNamespace
+		release := d.TargetName
+		if release == "" {
+			release = chartName
+		}
+		k := key{chart: chartName, namespace: ns, releaseName: release}
+		r := get(k)
+		addSource(r, src)
+		if r.Version == "" {
+			r.Version = d.ChartVersion
+		}
+		// Declarations contribute health when no runtime source did
+		// (typical for declared-but-not-yet-running installs).
+		r.Health = worseHealth(r.Health, d.Status)
+	}
+
+	// 4. CRD registrations (source C). Two cases:
+	//    a. Group resolves to a known chart → merge into existing Helm/L
+	//       row for that chart (any namespace). When multiple Helm rows
+	//       exist for the same chart in different namespaces, we
+	//       contribute C to ALL of them (defensible: the CRDs are the
+	//       cluster-scoped underpinning that all releases share).
+	//    b. Group doesn't resolve → standalone row, FromCRDGroup set.
+	for _, c := range s.CRDs {
+		chartName, known := chartFromCRDGroup(c.Group)
+		var version string
+		if len(c.Versions) > 0 {
+			version = c.Versions[0]
+		}
+		if known {
+			// Find any rows for this chart and add C to them.
+			matched := false
+			for k, r := range rows {
+				if k.chart == chartName {
+					addSource(r, SourceCRDs)
+					if r.Version == "" {
+						r.Version = version
+					}
+					matched = true
+				}
+			}
+			if matched {
+				continue
+			}
+			// Known chart but no Helm/L row for it — synthesize a
+			// CRD-only row so the install is visible.
+			k := key{chart: chartName, namespace: "", releaseName: ""}
+			r := get(k)
+			addSource(r, SourceCRDs)
+			if r.Version == "" {
+				r.Version = version
+			}
+			if r.Health == "" {
+				r.Health = "unknown"
+			}
+			continue
+		}
+		// Unknown group — standalone CRD-only row keyed on the group
+		// string itself. Multiple CRDs in the same group fold into a
+		// single row.
+		k := key{chart: c.Group, namespace: "", releaseName: ""}
+		r := get(k)
+		addSource(r, SourceCRDs)
+		r.FromCRDGroup = c.Group
+		if r.Version == "" {
+			r.Version = version
+		}
+		if r.Health == "" {
+			r.Health = "unknown"
+		}
+	}
+
+	// Default health to unknown for any row that ended up with none
+	// (CRD-only rows; declarations without a status; etc.).
+	for _, r := range rows {
+		if r.Health == "" {
+			r.Health = "unknown"
+		}
+	}
+
+	// Stable sort: chart, then namespace, then release name.
+	out := make([]PackageRow, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, *r)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Chart != out[j].Chart {
+			return out[i].Chart < out[j].Chart
+		}
+		if out[i].Namespace != out[j].Namespace {
+			return out[i].Namespace < out[j].Namespace
+		}
+		return out[i].ReleaseName < out[j].ReleaseName
+	})
+	return out
+}
+
+// addSource appends src to r.Sources if not already present. Maintains
+// canonical order H, L, C, A, F.
+func addSource(r *PackageRow, src string) {
+	for _, s := range r.Sources {
+		if s == src {
+			return
+		}
+	}
+	r.Sources = append(r.Sources, src)
+	// Re-sort into canonical order.
+	sort.Slice(r.Sources, func(i, j int) bool {
+		return sourceRank(r.Sources[i]) < sourceRank(r.Sources[j])
+	})
+}
+
+func sourceRank(s string) int {
+	switch s {
+	case SourceHelm:
+		return 0
+	case SourceLabels:
+		return 1
+	case SourceCRDs:
+		return 2
+	case SourceArgoCD:
+		return 3
+	case SourceFluxCD:
+		return 4
+	}
+	return 5
+}
+
+// splitChart splits a Helm chart string like "cert-manager-1.14.0" or
+// "cert-manager-v1.14.0" into (name, version). Returns ("", "") if the
+// string doesn't look like name-version. Handles charts whose own name
+// contains hyphens ("kube-prometheus-stack-45.27.2").
+//
+// Heuristic: find the last hyphen followed by a digit-or-v-digit; the
+// name is the prefix, the version is the suffix. Falls back to the
+// whole string as name with empty version when no version part is
+// found.
+func splitChart(s string) (name, version string) {
+	if s == "" {
+		return "", ""
+	}
+	for i := len(s) - 1; i >= 1; i-- {
+		if s[i-1] != '-' {
+			continue
+		}
+		rest := s[i:]
+		if rest == "" {
+			continue
+		}
+		// Version: starts with digit, or v followed by digit.
+		c := rest[0]
+		if c >= '0' && c <= '9' {
+			return s[:i-1], rest
+		}
+		if c == 'v' && len(rest) > 1 {
+			d := rest[1]
+			if d >= '0' && d <= '9' {
+				return s[:i-1], rest
+			}
+		}
+	}
+	return s, ""
+}
+
+// worseHealth returns the worse of two health strings using the order:
+// unhealthy > degraded > unknown > healthy. (Unknown beats healthy
+// because we don't want a CRD-only "unknown" row to be promoted to
+// "healthy" just because no other source contributed.)
+//
+// Empty strings are treated as "no opinion" — the other side wins.
+func worseHealth(a, b string) string {
+	if a == "" {
+		return b
+	}
+	if b == "" {
+		return a
+	}
+	rank := func(h string) int {
+		switch strings.ToLower(h) {
+		case "unhealthy", "danger", "critical", "failed", "stalled":
+			return 4
+		case "degraded", "warning", "warn", "progressing", "reconciling":
+			return 3
+		case "unknown", "":
+			return 2
+		case "healthy", "ok", "ready", "available":
+			return 1
+		}
+		return 2
+	}
+	if rank(a) >= rank(b) {
+		return a
+	}
+	return b
+}

--- a/pkg/packages/aggregate.go
+++ b/pkg/packages/aggregate.go
@@ -3,7 +3,6 @@ package packages
 import (
 	"sort"
 	"strings"
-	"time"
 )
 
 // Aggregate is the merge function. Given a Sources struct, returns a
@@ -24,10 +23,9 @@ import (
 // release_name) so consumers (SPA tables, MCP tool output) get stable
 // ordering across calls.
 func Aggregate(s Sources) []PackageRow {
-	now := time.Now()
-	// We accumulate rows in a map keyed by (chart, namespace, releaseName).
 	// CRD-only rows that don't resolve to a chart get a synthetic key
-	// using FromCRDGroup.
+	// using the group string; non-CRD rows key on (chart, namespace,
+	// releaseName) so multiple sources for the same release merge.
 	type key struct {
 		chart       string
 		namespace   string
@@ -40,10 +38,9 @@ func Aggregate(s Sources) []PackageRow {
 			return r
 		}
 		r := &PackageRow{
-			Chart:        k.chart,
-			Namespace:    k.namespace,
-			ReleaseName:  k.releaseName,
-			AggregatedAt: now,
+			Chart:       k.chart,
+			Namespace:   k.namespace,
+			ReleaseName: k.releaseName,
 		}
 		rows[k] = r
 		return r
@@ -316,7 +313,9 @@ func splitChart(s string) (name, version string) {
 // worseHealth returns the worse of two health strings using the order:
 // unhealthy > degraded > unknown > healthy. (Unknown beats healthy
 // because we don't want a CRD-only "unknown" row to be promoted to
-// "healthy" just because no other source contributed.)
+// "healthy" just because no other source contributed.) Unknown vocab
+// (typo, future GitOps reason we don't recognize yet) maps to the
+// "unknown" rank — quieter than degraded, still beats healthy.
 //
 // Empty strings are treated as "no opinion" — the other side wins.
 func worseHealth(a, b string) string {
@@ -332,7 +331,7 @@ func worseHealth(a, b string) string {
 			return 4
 		case "degraded", "warning", "warn", "progressing", "reconciling":
 			return 3
-		case "unknown", "":
+		case "unknown":
 			return 2
 		case "healthy", "ok", "ready", "available":
 			return 1

--- a/pkg/packages/aggregate.go
+++ b/pkg/packages/aggregate.go
@@ -167,15 +167,19 @@ func Aggregate(s Sources) []PackageRow {
 		if len(c.Versions) > 0 {
 			version = c.Versions[0]
 		}
-		crdContribution := SourceContribution{
-			Source:  SourceCRDs,
-			Version: version,
+		// Build a fresh contribution per row to avoid future fragility
+		// — SourceContribution is a value struct today (safe by Go
+		// semantics) but adding a slice or map field later would
+		// silently expose mutation across rows if the literal were
+		// shared.
+		newContribution := func() SourceContribution {
+			return SourceContribution{Source: SourceCRDs, Version: version}
 		}
 		if known {
 			matched := false
 			for k, r := range rows {
 				if k.chart == chartName {
-					r.AddContribution(crdContribution)
+					r.AddContribution(newContribution())
 					matched = true
 				}
 			}
@@ -186,7 +190,7 @@ func Aggregate(s Sources) []PackageRow {
 			// CRD-only row so the install is visible.
 			k := key{chart: chartName, namespace: "", releaseName: ""}
 			r := get(k)
-			r.AddContribution(crdContribution)
+			r.AddContribution(newContribution())
 			if r.Health == "" {
 				r.Health = HealthUnknown
 			}
@@ -197,7 +201,7 @@ func Aggregate(s Sources) []PackageRow {
 		// single row.
 		k := key{chart: c.Group, namespace: "", releaseName: ""}
 		r := get(k)
-		r.AddContribution(crdContribution)
+		r.AddContribution(newContribution())
 		r.FromCRDGroup = c.Group
 		if r.Health == "" {
 			r.Health = HealthUnknown

--- a/pkg/packages/aggregate.go
+++ b/pkg/packages/aggregate.go
@@ -67,15 +67,14 @@ func Aggregate(s Sources) []PackageRow {
 		}
 		k := key{chart: chartName, namespace: h.Namespace, releaseName: h.Name}
 		r := get(k)
-		r.AddSource(SourceHelm)
-		// Helm fields win over later sources for these (highest signal).
-		if r.Version == "" {
-			r.Version = chartVersion
-		}
-		if r.AppVersion == "" {
-			r.AppVersion = h.AppVersion
-		}
-		r.MergeHealth(h.ResourceHealth)
+		r.AddContribution(SourceContribution{
+			Source:           SourceHelm,
+			Health:           h.ResourceHealth,
+			Version:          chartVersion,
+			AppVersion:       h.AppVersion,
+			ReleaseName:      h.Name,
+			ReleaseNamespace: h.Namespace,
+		})
 	}
 
 	// 2. Workloads with Helm labels (source L).
@@ -107,11 +106,13 @@ func Aggregate(s Sources) []PackageRow {
 		}
 		k := key{chart: chartName, namespace: releaseNs, releaseName: releaseName}
 		r := get(k)
-		r.AddSource(SourceLabels)
-		if r.Version == "" {
-			r.Version = chartVersion
-		}
-		r.MergeHealth(w.Health)
+		r.AddContribution(SourceContribution{
+			Source:           SourceLabels,
+			Health:           w.Health,
+			Version:          chartVersion,
+			ReleaseName:      releaseName,
+			ReleaseNamespace: releaseNs,
+		})
 	}
 
 	// 3. GitOps declarations (sources A / F) — declared installs, may
@@ -142,11 +143,15 @@ func Aggregate(s Sources) []PackageRow {
 		}
 		k := key{chart: chartName, namespace: ns, releaseName: release}
 		r := get(k)
-		r.AddSource(src)
-		if r.Version == "" {
-			r.Version = d.ChartVersion
-		}
-		r.MergeHealth(d.Status)
+		r.AddContribution(SourceContribution{
+			Source:               src,
+			Health:               d.Status,
+			Version:              d.ChartVersion,
+			ReleaseName:          release,
+			ReleaseNamespace:     ns,
+			DeclarationName:      d.Name,
+			DeclarationNamespace: d.Namespace,
+		})
 	}
 
 	// 4. CRD registrations (source C). Two cases:
@@ -162,14 +167,15 @@ func Aggregate(s Sources) []PackageRow {
 		if len(c.Versions) > 0 {
 			version = c.Versions[0]
 		}
+		crdContribution := SourceContribution{
+			Source:  SourceCRDs,
+			Version: version,
+		}
 		if known {
 			matched := false
 			for k, r := range rows {
 				if k.chart == chartName {
-					r.AddSource(SourceCRDs)
-					if r.Version == "" {
-						r.Version = version
-					}
+					r.AddContribution(crdContribution)
 					matched = true
 				}
 			}
@@ -180,10 +186,7 @@ func Aggregate(s Sources) []PackageRow {
 			// CRD-only row so the install is visible.
 			k := key{chart: chartName, namespace: "", releaseName: ""}
 			r := get(k)
-			r.AddSource(SourceCRDs)
-			if r.Version == "" {
-				r.Version = version
-			}
+			r.AddContribution(crdContribution)
 			if r.Health == "" {
 				r.Health = HealthUnknown
 			}
@@ -194,11 +197,8 @@ func Aggregate(s Sources) []PackageRow {
 		// single row.
 		k := key{chart: c.Group, namespace: "", releaseName: ""}
 		r := get(k)
-		r.AddSource(SourceCRDs)
+		r.AddContribution(crdContribution)
 		r.FromCRDGroup = c.Group
-		if r.Version == "" {
-			r.Version = version
-		}
 		if r.Health == "" {
 			r.Health = HealthUnknown
 		}
@@ -232,6 +232,13 @@ func Aggregate(s Sources) []PackageRow {
 func sortSources(s []SourceCode) {
 	sort.Slice(s, func(i, j int) bool {
 		return sourceRank(s[i]) < sourceRank(s[j])
+	})
+}
+
+// sortContributors sorts contributions in place by canonical Source order.
+func sortContributors(cs []SourceContribution) {
+	sort.Slice(cs, func(i, j int) bool {
+		return sourceRank(cs[i].Source) < sourceRank(cs[j].Source)
 	})
 }
 

--- a/pkg/packages/aggregate_test.go
+++ b/pkg/packages/aggregate_test.go
@@ -261,39 +261,94 @@ func TestAggregate_HealthIsWorstOf(t *testing.T) {
 	}
 }
 
+// Worst-of ranking: unhealthy > degraded > unknown > healthy. Plus
+// alias collapse (stalled → unhealthy rank, progressing → degraded
+// rank). Empty string is "no opinion" (the other side wins).
+func TestWorseHealth_Ranking(t *testing.T) {
+	cases := []struct {
+		a, b, want string
+	}{
+		{"unhealthy", "degraded", "unhealthy"},
+		{"degraded", "unhealthy", "unhealthy"},
+		{"unknown", "healthy", "unknown"},
+		{"healthy", "unknown", "unknown"},
+		{"degraded", "unknown", "degraded"},
+		{"healthy", "degraded", "degraded"},
+		{"stalled", "degraded", "stalled"},          // stalled ranks with unhealthy
+		{"progressing", "healthy", "progressing"},   // progressing ranks with degraded
+		{"", "healthy", "healthy"},                  // empty = no opinion
+		{"degraded", "", "degraded"},                // empty = no opinion
+		{"weirdo", "healthy", "weirdo"},             // unknown vocab → "unknown" rank, beats healthy
+	}
+	for _, c := range cases {
+		if got := worseHealth(c.a, c.b); got != c.want {
+			t.Errorf("worseHealth(%q, %q) = %q, want %q", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+// Three-contributor merge: when Helm reports degraded, a workload
+// reports unhealthy, and an Argo declaration reports healthy, the row
+// must surface the worst (unhealthy).
+func TestAggregate_HealthWorstOf_ThreeContributors(t *testing.T) {
+	rows := Aggregate(Sources{
+		Helm: []HelmRelease{{
+			Name: "cert-manager", Namespace: "cm", Chart: "cert-manager-1.14.0",
+			ResourceHealth: "degraded",
+		}},
+		Workloads: []Workload{{
+			Kind: "Deployment", Namespace: "cm", Name: "cert-manager",
+			Labels:      map[string]string{"helm.sh/chart": "cert-manager-1.14.0"},
+			Annotations: map[string]string{"meta.helm.sh/release-name": "cert-manager", "meta.helm.sh/release-namespace": "cm"},
+			Health:      "unhealthy",
+		}},
+		GitOpsDeclarations: []Declaration{{
+			Source: "argocd", Namespace: "argocd", Name: "cert-manager",
+			TargetNamespace: "cm", TargetName: "cert-manager", Chart: "cert-manager", Status: "healthy",
+		}},
+	})
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d: %+v", len(rows), rows)
+	}
+	if rows[0].Health != "unhealthy" {
+		t.Errorf("want health=unhealthy, got %q", rows[0].Health)
+	}
+}
+
 // Sources order must be canonical H, L, C, A, F regardless of input
-// declaration order.
+// declaration order. Uses cert-manager so the CRD group resolves to
+// the same chart as Helm/L/A/F — exercises all five source codes on
+// one row.
 func TestAggregate_SourceOrderIsCanonical(t *testing.T) {
 	rows := Aggregate(Sources{
 		// Provide in reverse order to verify Aggregate normalizes.
 		GitOpsDeclarations: []Declaration{{
-			Source: "flux", Name: "x", TargetNamespace: "ns", TargetName: "x", Chart: "x", Status: "healthy",
+			Source: "flux", Name: "cert-manager", TargetNamespace: "cm", TargetName: "cert-manager", Chart: "cert-manager", Status: "healthy",
 		}, {
-			Source: "argocd", Name: "x", TargetNamespace: "ns", TargetName: "x", Chart: "x", Status: "healthy",
+			Source: "argocd", Name: "cert-manager", TargetNamespace: "cm", TargetName: "cert-manager", Chart: "cert-manager", Status: "healthy",
 		}},
-		CRDs: []CRD{{Group: "x.example.com", Versions: []string{"v1"}}},
+		CRDs: []CRD{{Name: "certificates.cert-manager.io", Group: "cert-manager.io", Kind: "Certificate", Plural: "certificates", Versions: []string{"v1"}}},
 		Workloads: []Workload{{
-			Kind: "Deployment", Namespace: "ns", Name: "x",
-			Labels:      map[string]string{"helm.sh/chart": "x-1.0"},
-			Annotations: map[string]string{"meta.helm.sh/release-name": "x", "meta.helm.sh/release-namespace": "ns"},
+			Kind: "Deployment", Namespace: "cm", Name: "cert-manager",
+			Labels:      map[string]string{"helm.sh/chart": "cert-manager-1.14.0"},
+			Annotations: map[string]string{"meta.helm.sh/release-name": "cert-manager", "meta.helm.sh/release-namespace": "cm"},
 			Health:      "healthy",
 		}},
-		Helm: []HelmRelease{{Name: "x", Namespace: "ns", Chart: "x-1.0", ResourceHealth: "healthy"}},
+		Helm: []HelmRelease{{Name: "cert-manager", Namespace: "cm", Chart: "cert-manager-1.14.0", ResourceHealth: "healthy"}},
 	})
 	if len(rows) == 0 {
 		t.Fatal("expected at least one row")
 	}
-	// Find the chart=x row and verify source order.
 	for _, r := range rows {
-		if r.Chart == "x" {
-			want := []string{SourceHelm, SourceLabels, SourceArgoCD, SourceFluxCD}
+		if r.Chart == "cert-manager" {
+			want := []string{SourceHelm, SourceLabels, SourceCRDs, SourceArgoCD, SourceFluxCD}
 			if !equalStrings(r.Sources, want) {
 				t.Errorf("want canonical sources %v, got %v", want, r.Sources)
 			}
 			return
 		}
 	}
-	t.Errorf("no x chart row found in %+v", rows)
+	t.Errorf("no cert-manager row found in %+v", rows)
 }
 
 func equalStrings(a, b []string) bool {

--- a/pkg/packages/aggregate_test.go
+++ b/pkg/packages/aggregate_test.go
@@ -351,6 +351,131 @@ func TestAggregate_SourceOrderIsCanonical(t *testing.T) {
 	t.Errorf("no cert-manager row found in %+v", rows)
 }
 
+// Contributors should carry per-source detail that survives the
+// worst-of-health and first-wins-version merges. This is what Hub uses
+// for the "Helm: healthy · Argo: degraded" tooltip and for deep-linking
+// to the controlling Argo Application.
+func TestAggregate_ContributorsCarryPerSourceDetail(t *testing.T) {
+	rows := Aggregate(Sources{
+		Helm: []HelmRelease{{
+			Name:           "cert-manager",
+			Namespace:      "cm",
+			Chart:          "cert-manager-1.14.0",
+			AppVersion:     "v1.14.0",
+			ResourceHealth: HealthHealthy,
+		}},
+		Workloads: []Workload{{
+			Kind:        "Deployment",
+			Namespace:   "cm",
+			Name:        "cert-manager",
+			Labels:      map[string]string{"helm.sh/chart": "cert-manager-1.14.0"},
+			Annotations: map[string]string{"meta.helm.sh/release-name": "cert-manager", "meta.helm.sh/release-namespace": "cm"},
+			Health:      HealthDegraded,
+		}},
+		GitOpsDeclarations: []Declaration{{
+			Source:          "argocd",
+			Namespace:       "argocd",
+			Name:            "cert-manager-app",
+			TargetNamespace: "cm",
+			TargetName:      "cert-manager",
+			Chart:           "cert-manager",
+			ChartVersion:    "1.14.1", // disagrees with Helm's 1.14.0
+			Status:          HealthHealthy,
+		}},
+	})
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d: %+v", len(rows), rows)
+	}
+	r := rows[0]
+
+	// Aggregated fields keep existing semantics: worst-of-health, first-
+	// wins-version (Helm wins because it runs first).
+	if r.Health != HealthDegraded {
+		t.Errorf("aggregated Health = %q, want degraded (worst-of)", r.Health)
+	}
+	if r.Version != "1.14.0" {
+		t.Errorf("aggregated Version = %q, want 1.14.0 (Helm first-wins)", r.Version)
+	}
+
+	// Contributors carry per-source detail and are in canonical order.
+	if len(r.Contributors) != 3 {
+		t.Fatalf("want 3 contributors (H, L, A), got %d: %+v", len(r.Contributors), r.Contributors)
+	}
+	wantOrder := []SourceCode{SourceHelm, SourceLabels, SourceArgoCD}
+	for i, c := range r.Contributors {
+		if c.Source != wantOrder[i] {
+			t.Errorf("contributor[%d].Source = %q, want %q (canonical order)", i, c.Source, wantOrder[i])
+		}
+	}
+
+	helm := findContrib(r, SourceHelm)
+	if helm.Health != HealthHealthy || helm.Version != "1.14.0" || helm.AppVersion != "v1.14.0" || helm.ReleaseName != "cert-manager" || helm.ReleaseNamespace != "cm" {
+		t.Errorf("Helm contribution wrong: %+v", helm)
+	}
+
+	labels := findContrib(r, SourceLabels)
+	if labels.Health != HealthDegraded {
+		t.Errorf("Labels contribution health = %q, want degraded (per-source preserved)", labels.Health)
+	}
+
+	argo := findContrib(r, SourceArgoCD)
+	// The Argo Application's identity is exposed for deep-linking.
+	if argo.DeclarationName != "cert-manager-app" || argo.DeclarationNamespace != "argocd" {
+		t.Errorf("Argo declaration identity wrong: name=%q ns=%q", argo.DeclarationName, argo.DeclarationNamespace)
+	}
+	// Argo's version disagreement is preserved per-source even though
+	// the aggregated row.Version takes Helm's value.
+	if argo.Version != "1.14.1" {
+		t.Errorf("Argo contribution Version = %q, want 1.14.1 (per-source disagreement preserved)", argo.Version)
+	}
+	if argo.Health != HealthHealthy {
+		t.Errorf("Argo contribution Health = %q, want healthy (per-source preserved)", argo.Health)
+	}
+}
+
+// Multiple workloads under the same release: their Health worst-ofs
+// within the single L contribution, not into separate entries.
+func TestAggregate_Contributors_LabelsCollapseAcrossWorkloads(t *testing.T) {
+	rows := Aggregate(Sources{
+		Workloads: []Workload{
+			{
+				Kind: "Deployment", Namespace: "cm", Name: "cert-manager",
+				Labels:      map[string]string{"helm.sh/chart": "cert-manager-1.14.0"},
+				Annotations: map[string]string{"meta.helm.sh/release-name": "cert-manager", "meta.helm.sh/release-namespace": "cm"},
+				Health:      HealthHealthy,
+			},
+			{
+				Kind: "Deployment", Namespace: "cm", Name: "cert-manager-cainjector",
+				Labels:      map[string]string{"helm.sh/chart": "cert-manager-1.14.0"},
+				Annotations: map[string]string{"meta.helm.sh/release-name": "cert-manager", "meta.helm.sh/release-namespace": "cm"},
+				Health:      HealthDegraded,
+			},
+		},
+	})
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d", len(rows))
+	}
+	r := rows[0]
+	if len(r.Contributors) != 1 {
+		t.Fatalf("want 1 contributor (collapsed L), got %d: %+v", len(r.Contributors), r.Contributors)
+	}
+	if r.Contributors[0].Source != SourceLabels {
+		t.Fatalf("contributor source = %q, want L", r.Contributors[0].Source)
+	}
+	if r.Contributors[0].Health != HealthDegraded {
+		t.Errorf("L contribution Health = %q, want degraded (worst-of across workloads)", r.Contributors[0].Health)
+	}
+}
+
+func findContrib(r PackageRow, src SourceCode) SourceContribution {
+	for _, c := range r.Contributors {
+		if c.Source == src {
+			return c
+		}
+	}
+	return SourceContribution{}
+}
+
 func equalSources(a, b []SourceCode) bool {
 	if len(a) != len(b) {
 		return false

--- a/pkg/packages/aggregate_test.go
+++ b/pkg/packages/aggregate_test.go
@@ -467,6 +467,103 @@ func TestAggregate_Contributors_LabelsCollapseAcrossWorkloads(t *testing.T) {
 	}
 }
 
+// CRD-only rows produce a C contribution with no release identity (CRDs
+// are cluster-scoped registrations). Hub's "managed by Argo →" deep-link
+// logic relies on `Contributors[i].DeclarationName != ""` as the GitOps
+// signal — if a C contribution accidentally got a release-name from
+// somewhere, the contract breaks for downstream consumers.
+func TestAggregate_CRDOnlyContributionShape(t *testing.T) {
+	rows := Aggregate(Sources{
+		CRDs: []CRD{{
+			Name: "certificates.cert-manager.io", Group: "cert-manager.io",
+			Kind: "Certificate", Plural: "certificates", Versions: []string{"v1"},
+		}},
+	})
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d", len(rows))
+	}
+	r := rows[0]
+	if len(r.Contributors) != 1 {
+		t.Fatalf("want 1 contributor, got %d: %+v", len(r.Contributors), r.Contributors)
+	}
+	c := r.Contributors[0]
+	if c.Source != SourceCRDs {
+		t.Errorf("Source = %q, want C", c.Source)
+	}
+	if c.Version != "v1" {
+		t.Errorf("Version = %q, want v1", c.Version)
+	}
+	if c.ReleaseName != "" || c.ReleaseNamespace != "" {
+		t.Errorf("CRD contribution should have no release identity, got name=%q ns=%q",
+			c.ReleaseName, c.ReleaseNamespace)
+	}
+	if c.DeclarationName != "" || c.DeclarationNamespace != "" {
+		t.Errorf("CRD contribution should have no GitOps declaration identity, got name=%q ns=%q",
+			c.DeclarationName, c.DeclarationNamespace)
+	}
+	if c.Cluster != "" {
+		t.Errorf("single-cluster mode should leave Cluster empty, got %q", c.Cluster)
+	}
+}
+
+// Hub fan-in: contributions from different clusters with the same
+// SourceCode must coexist (not collapse). This is what lets Hub deep-
+// link to per-cluster Argo App identity in the "same chart, two
+// clusters, two Apps" hub-and-spoke pattern.
+func TestPackageRow_AddContribution_ClusterDisambiguates(t *testing.T) {
+	r := &PackageRow{Chart: "cert-manager"}
+	r.AddContribution(SourceContribution{
+		Source: SourceArgoCD, Health: HealthHealthy, Version: "1.14.0",
+		DeclarationName: "cert-manager-app", DeclarationNamespace: "argocd",
+		Cluster: "cluster-a",
+	})
+	r.AddContribution(SourceContribution{
+		Source: SourceArgoCD, Health: HealthDegraded, Version: "1.13.5",
+		DeclarationName: "cert-manager-app", DeclarationNamespace: "argocd",
+		Cluster: "cluster-b",
+	})
+	if len(r.Contributors) != 2 {
+		t.Fatalf("want 2 A contributions (per cluster), got %d: %+v", len(r.Contributors), r.Contributors)
+	}
+	gotClusters := map[string]bool{r.Contributors[0].Cluster: true, r.Contributors[1].Cluster: true}
+	if !gotClusters["cluster-a"] || !gotClusters["cluster-b"] {
+		t.Errorf("expected both cluster contributions, got %v", gotClusters)
+	}
+	// Aggregated row health is worst-of across all clusters.
+	if r.Health != HealthDegraded {
+		t.Errorf("Health = %q, want degraded (worst-of across clusters)", r.Health)
+	}
+	// Helper picks the first contribution by canonical source order.
+	if c := r.Contributor(SourceArgoCD); c == nil {
+		t.Errorf("Contributor(A) returned nil")
+	}
+	if c := r.Contributor(SourceHelm); c != nil {
+		t.Errorf("Contributor(H) want nil, got %+v", c)
+	}
+}
+
+// Same-cluster repeated contribution from the same Source still merges
+// in place (the merge key (Source, Cluster) collapses to Source when
+// Cluster is empty in single-cluster mode).
+func TestPackageRow_AddContribution_SingleClusterMerges(t *testing.T) {
+	r := &PackageRow{Chart: "cert-manager"}
+	r.AddContribution(SourceContribution{Source: SourceArgoCD, Health: HealthHealthy, Version: "1.14.0", DeclarationName: "first-app"})
+	r.AddContribution(SourceContribution{Source: SourceArgoCD, Health: HealthDegraded, Version: "1.14.1", DeclarationName: "second-app"})
+	if len(r.Contributors) != 1 {
+		t.Fatalf("single-cluster: want 1 merged A contribution, got %d", len(r.Contributors))
+	}
+	c := r.Contributors[0]
+	if c.Health != HealthDegraded {
+		t.Errorf("merged Health = %q, want degraded (worst-of)", c.Health)
+	}
+	if c.Version != "1.14.0" {
+		t.Errorf("merged Version = %q, want 1.14.0 (first-wins)", c.Version)
+	}
+	if c.DeclarationName != "first-app" {
+		t.Errorf("merged DeclarationName = %q, want first-app (first-wins)", c.DeclarationName)
+	}
+}
+
 func findContrib(r PackageRow, src SourceCode) SourceContribution {
 	for _, c := range r.Contributors {
 		if c.Source == src {

--- a/pkg/packages/aggregate_test.go
+++ b/pkg/packages/aggregate_test.go
@@ -86,8 +86,8 @@ func TestAggregate_CertManager_AllThreeSources(t *testing.T) {
 	if r.Chart != "cert-manager" {
 		t.Errorf("want chart=cert-manager, got %q", r.Chart)
 	}
-	want := []string{SourceHelm, SourceLabels, SourceCRDs}
-	if !equalStrings(r.Sources, want) {
+	want := []SourceCode{SourceHelm, SourceLabels, SourceCRDs}
+	if !equalSources(r.Sources, want) {
 		t.Errorf("want sources=%v, got %v", want, r.Sources)
 	}
 }
@@ -122,8 +122,8 @@ func TestAggregate_Karpenter_NoHelmAccess(t *testing.T) {
 	if r.Chart != "karpenter" {
 		t.Errorf("want chart=karpenter, got %q", r.Chart)
 	}
-	want := []string{SourceLabels, SourceCRDs}
-	if !equalStrings(r.Sources, want) {
+	want := []SourceCode{SourceLabels, SourceCRDs}
+	if !equalSources(r.Sources, want) {
 		t.Errorf("want sources=%v, got %v", want, r.Sources)
 	}
 	// Both CRDs map to "karpenter" — should fold into the same row,
@@ -150,7 +150,7 @@ func TestAggregate_RawOperator_KnownGroup(t *testing.T) {
 	if r.Chart != "cert-manager" || r.Health != "unknown" || r.FromCRDGroup != "" {
 		t.Errorf("bad CRD-only row: %+v", r)
 	}
-	if !equalStrings(r.Sources, []string{SourceCRDs}) {
+	if !equalSources(r.Sources, []SourceCode{SourceCRDs}) {
 		t.Errorf("want sources=[C], got %v", r.Sources)
 	}
 }
@@ -200,7 +200,7 @@ func TestAggregate_ArgoHelmApp_MergesWithHelmRelease(t *testing.T) {
 	if len(rows) != 1 {
 		t.Fatalf("want 1 merged row, got %d: %+v", len(rows), rows)
 	}
-	if got := rows[0].Sources; !equalStrings(got, []string{SourceHelm, SourceArgoCD}) {
+	if got := rows[0].Sources; !equalSources(got, []SourceCode{SourceHelm, SourceArgoCD}) {
 		t.Errorf("want sources=[H,A], got %v", got)
 	}
 }
@@ -226,7 +226,7 @@ func TestAggregate_FluxKustomization_NoChart(t *testing.T) {
 	if r.Chart != "infra-controllers" {
 		t.Errorf("want chart=infra-controllers, got %q", r.Chart)
 	}
-	if !equalStrings(r.Sources, []string{SourceFluxCD}) {
+	if !equalSources(r.Sources, []SourceCode{SourceFluxCD}) {
 		t.Errorf("want sources=[F], got %v", r.Sources)
 	}
 }
@@ -266,19 +266,19 @@ func TestAggregate_HealthIsWorstOf(t *testing.T) {
 // rank). Empty string is "no opinion" (the other side wins).
 func TestWorseHealth_Ranking(t *testing.T) {
 	cases := []struct {
-		a, b, want string
+		a, b, want Health
 	}{
-		{"unhealthy", "degraded", "unhealthy"},
-		{"degraded", "unhealthy", "unhealthy"},
-		{"unknown", "healthy", "unknown"},
-		{"healthy", "unknown", "unknown"},
-		{"degraded", "unknown", "degraded"},
-		{"healthy", "degraded", "degraded"},
-		{"stalled", "degraded", "stalled"},          // stalled ranks with unhealthy
-		{"progressing", "healthy", "progressing"},   // progressing ranks with degraded
-		{"", "healthy", "healthy"},                  // empty = no opinion
-		{"degraded", "", "degraded"},                // empty = no opinion
-		{"weirdo", "healthy", "weirdo"},             // unknown vocab → "unknown" rank, beats healthy
+		{HealthUnhealthy, HealthDegraded, HealthUnhealthy},
+		{HealthDegraded, HealthUnhealthy, HealthUnhealthy},
+		{HealthUnknown, HealthHealthy, HealthUnknown},
+		{HealthHealthy, HealthUnknown, HealthUnknown},
+		{HealthDegraded, HealthUnknown, HealthDegraded},
+		{HealthHealthy, HealthDegraded, HealthDegraded},
+		{"stalled", HealthDegraded, "stalled"},          // stalled ranks with unhealthy
+		{"progressing", HealthHealthy, "progressing"},   // progressing ranks with degraded
+		{"", HealthHealthy, HealthHealthy},              // empty = no opinion
+		{HealthDegraded, "", HealthDegraded},            // empty = no opinion
+		{"weirdo", HealthHealthy, "weirdo"},             // unrecognized → "unknown" rank, beats healthy
 	}
 	for _, c := range cases {
 		if got := worseHealth(c.a, c.b); got != c.want {
@@ -341,8 +341,8 @@ func TestAggregate_SourceOrderIsCanonical(t *testing.T) {
 	}
 	for _, r := range rows {
 		if r.Chart == "cert-manager" {
-			want := []string{SourceHelm, SourceLabels, SourceCRDs, SourceArgoCD, SourceFluxCD}
-			if !equalStrings(r.Sources, want) {
+			want := []SourceCode{SourceHelm, SourceLabels, SourceCRDs, SourceArgoCD, SourceFluxCD}
+			if !equalSources(r.Sources, want) {
 				t.Errorf("want canonical sources %v, got %v", want, r.Sources)
 			}
 			return
@@ -351,7 +351,7 @@ func TestAggregate_SourceOrderIsCanonical(t *testing.T) {
 	t.Errorf("no cert-manager row found in %+v", rows)
 }
 
-func equalStrings(a, b []string) bool {
+func equalSources(a, b []SourceCode) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/pkg/packages/aggregate_test.go
+++ b/pkg/packages/aggregate_test.go
@@ -1,0 +1,309 @@
+package packages
+
+import (
+	"testing"
+)
+
+func TestSplitChart(t *testing.T) {
+	cases := []struct {
+		in              string
+		wantName, wantV string
+	}{
+		{"cert-manager-1.14.0", "cert-manager", "1.14.0"},
+		{"cert-manager-v1.14.0", "cert-manager", "v1.14.0"},
+		{"kube-prometheus-stack-45.27.2", "kube-prometheus-stack", "45.27.2"},
+		// scans backwards for first hyphen-followed-by-digit; finds 0.32.0-dev.
+		{"karpenter-0.32.0-dev", "karpenter", "0.32.0-dev"},
+		{"foo", "foo", ""},
+		{"", "", ""},
+		{"-1.0.0", "", "1.0.0"},
+	}
+	for _, c := range cases {
+		gotName, gotV := splitChart(c.in)
+		if gotName != c.wantName || gotV != c.wantV {
+			t.Errorf("splitChart(%q) = (%q, %q), want (%q, %q)", c.in, gotName, gotV, c.wantName, c.wantV)
+		}
+	}
+}
+
+func TestAggregate_HelmOnly(t *testing.T) {
+	rows := Aggregate(Sources{
+		Helm: []HelmRelease{{
+			Name:           "cert-manager",
+			Namespace:      "cert-manager",
+			Chart:          "cert-manager-1.14.0",
+			ResourceHealth: "healthy",
+		}},
+	})
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d: %+v", len(rows), rows)
+	}
+	r := rows[0]
+	if r.Chart != "cert-manager" || r.Version != "1.14.0" || r.Namespace != "cert-manager" {
+		t.Errorf("bad row %+v", r)
+	}
+	if got := r.Sources; len(got) != 1 || got[0] != SourceHelm {
+		t.Errorf("want sources=[H], got %v", got)
+	}
+	if r.Health != "healthy" {
+		t.Errorf("want health=healthy, got %q", r.Health)
+	}
+}
+
+// HelmAPI + workload labels + CRDs all describing the same cert-manager
+// install must collapse into a single row with sources [H,L,C].
+func TestAggregate_CertManager_AllThreeSources(t *testing.T) {
+	rows := Aggregate(Sources{
+		Helm: []HelmRelease{{
+			Name:           "cert-manager",
+			Namespace:      "cert-manager",
+			Chart:          "cert-manager-1.14.0",
+			ResourceHealth: "healthy",
+		}},
+		Workloads: []Workload{{
+			Kind:      "Deployment",
+			Namespace: "cert-manager",
+			Name:      "cert-manager",
+			Labels:    map[string]string{"helm.sh/chart": "cert-manager-1.14.0"},
+			Annotations: map[string]string{
+				"meta.helm.sh/release-name":      "cert-manager",
+				"meta.helm.sh/release-namespace": "cert-manager",
+			},
+			Health: "healthy",
+		}},
+		CRDs: []CRD{{
+			Name:    "certificates.cert-manager.io",
+			Group:   "cert-manager.io",
+			Kind:    "Certificate",
+			Plural:  "certificates",
+			Versions: []string{"v1"},
+		}},
+	})
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d: %+v", len(rows), rows)
+	}
+	r := rows[0]
+	if r.Chart != "cert-manager" {
+		t.Errorf("want chart=cert-manager, got %q", r.Chart)
+	}
+	want := []string{SourceHelm, SourceLabels, SourceCRDs}
+	if !equalStrings(r.Sources, want) {
+		t.Errorf("want sources=%v, got %v", want, r.Sources)
+	}
+}
+
+// Karpenter typical install: Helm secret access blocked → only labels +
+// CRDs contribute. Row should be [L,C] with the workload's namespace +
+// release-name annotation.
+func TestAggregate_Karpenter_NoHelmAccess(t *testing.T) {
+	rows := Aggregate(Sources{
+		Workloads: []Workload{{
+			Kind:      "Deployment",
+			Namespace: "karpenter",
+			Name:      "karpenter",
+			Labels: map[string]string{
+				"helm.sh/chart": "karpenter-0.32.0",
+			},
+			Annotations: map[string]string{
+				"meta.helm.sh/release-name":      "karpenter",
+				"meta.helm.sh/release-namespace": "karpenter",
+			},
+			Health: "healthy",
+		}},
+		CRDs: []CRD{
+			{Name: "nodepools.karpenter.sh", Group: "karpenter.sh", Kind: "NodePool", Plural: "nodepools", Versions: []string{"v1beta1"}},
+			{Name: "ec2nodeclasses.karpenter.k8s.aws", Group: "karpenter.k8s.aws", Kind: "EC2NodeClass", Plural: "ec2nodeclasses", Versions: []string{"v1beta1"}},
+		},
+	})
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d: %+v", len(rows), rows)
+	}
+	r := rows[0]
+	if r.Chart != "karpenter" {
+		t.Errorf("want chart=karpenter, got %q", r.Chart)
+	}
+	want := []string{SourceLabels, SourceCRDs}
+	if !equalStrings(r.Sources, want) {
+		t.Errorf("want sources=%v, got %v", want, r.Sources)
+	}
+	// Both CRDs map to "karpenter" — should fold into the same row,
+	// not produce duplicates.
+}
+
+// Raw-YAML operator: only CRDs registered, no Helm release, no
+// workload labels → standalone CRD-only row keyed on the chart we
+// know the group corresponds to.
+func TestAggregate_RawOperator_KnownGroup(t *testing.T) {
+	rows := Aggregate(Sources{
+		CRDs: []CRD{{
+			Name:    "certificates.cert-manager.io",
+			Group:   "cert-manager.io",
+			Kind:    "Certificate",
+			Plural:  "certificates",
+			Versions: []string{"v1"},
+		}},
+	})
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d", len(rows))
+	}
+	r := rows[0]
+	if r.Chart != "cert-manager" || r.Health != "unknown" || r.FromCRDGroup != "" {
+		t.Errorf("bad CRD-only row: %+v", r)
+	}
+	if !equalStrings(r.Sources, []string{SourceCRDs}) {
+		t.Errorf("want sources=[C], got %v", r.Sources)
+	}
+}
+
+// Unknown CRD group should produce a standalone row keyed on the group
+// itself (FromCRDGroup set).
+func TestAggregate_RawOperator_UnknownGroup(t *testing.T) {
+	rows := Aggregate(Sources{
+		CRDs: []CRD{{
+			Name:    "widgets.example.com",
+			Group:   "example.com",
+			Kind:    "Widget",
+			Plural:  "widgets",
+			Versions: []string{"v1alpha1"},
+		}},
+	})
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d", len(rows))
+	}
+	r := rows[0]
+	if r.Chart != "example.com" || r.FromCRDGroup != "example.com" {
+		t.Errorf("bad unknown-group row: %+v", r)
+	}
+}
+
+// Argo Application that declares a Helm chart should merge with the
+// Helm release the app actually creates → sources [H, A].
+func TestAggregate_ArgoHelmApp_MergesWithHelmRelease(t *testing.T) {
+	rows := Aggregate(Sources{
+		Helm: []HelmRelease{{
+			Name:           "my-app",
+			Namespace:      "production",
+			Chart:          "my-app-2.0.0",
+			ResourceHealth: "healthy",
+		}},
+		GitOpsDeclarations: []Declaration{{
+			Source:          "argocd",
+			Namespace:       "argocd",
+			Name:            "my-app",
+			TargetNamespace: "production",
+			TargetName:      "my-app",
+			Chart:           "my-app",
+			ChartVersion:    "2.0.0",
+			Status:          "healthy",
+		}},
+	})
+	if len(rows) != 1 {
+		t.Fatalf("want 1 merged row, got %d: %+v", len(rows), rows)
+	}
+	if got := rows[0].Sources; !equalStrings(got, []string{SourceHelm, SourceArgoCD}) {
+		t.Errorf("want sources=[H,A], got %v", got)
+	}
+}
+
+// Flux Kustomization with no chart info → standalone row keyed on the
+// declaration name. Source [F].
+func TestAggregate_FluxKustomization_NoChart(t *testing.T) {
+	rows := Aggregate(Sources{
+		GitOpsDeclarations: []Declaration{{
+			Source:          "flux",
+			Namespace:       "flux-system",
+			Name:            "infra-controllers",
+			TargetNamespace: "infra",
+			TargetName:      "",
+			// No chart field — Kustomization renders raw YAML.
+			Status: "healthy",
+		}},
+	})
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d", len(rows))
+	}
+	r := rows[0]
+	if r.Chart != "infra-controllers" {
+		t.Errorf("want chart=infra-controllers, got %q", r.Chart)
+	}
+	if !equalStrings(r.Sources, []string{SourceFluxCD}) {
+		t.Errorf("want sources=[F], got %v", r.Sources)
+	}
+}
+
+// Health is the worst across contributors. A degraded workload + a
+// healthy Helm release → degraded.
+func TestAggregate_HealthIsWorstOf(t *testing.T) {
+	rows := Aggregate(Sources{
+		Helm: []HelmRelease{{
+			Name:           "cert-manager",
+			Namespace:      "cert-manager",
+			Chart:          "cert-manager-1.14.0",
+			ResourceHealth: "healthy",
+		}},
+		Workloads: []Workload{{
+			Kind:      "Deployment",
+			Namespace: "cert-manager",
+			Name:      "cert-manager-cainjector",
+			Labels:    map[string]string{"helm.sh/chart": "cert-manager-1.14.0"},
+			Annotations: map[string]string{
+				"meta.helm.sh/release-name":      "cert-manager",
+				"meta.helm.sh/release-namespace": "cert-manager",
+			},
+			Health: "degraded",
+		}},
+	})
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d", len(rows))
+	}
+	if rows[0].Health != "degraded" {
+		t.Errorf("want health=degraded, got %q", rows[0].Health)
+	}
+}
+
+// Sources order must be canonical H, L, C, A, F regardless of input
+// declaration order.
+func TestAggregate_SourceOrderIsCanonical(t *testing.T) {
+	rows := Aggregate(Sources{
+		// Provide in reverse order to verify Aggregate normalizes.
+		GitOpsDeclarations: []Declaration{{
+			Source: "flux", Name: "x", TargetNamespace: "ns", TargetName: "x", Chart: "x", Status: "healthy",
+		}, {
+			Source: "argocd", Name: "x", TargetNamespace: "ns", TargetName: "x", Chart: "x", Status: "healthy",
+		}},
+		CRDs: []CRD{{Group: "x.example.com", Versions: []string{"v1"}}},
+		Workloads: []Workload{{
+			Kind: "Deployment", Namespace: "ns", Name: "x",
+			Labels:      map[string]string{"helm.sh/chart": "x-1.0"},
+			Annotations: map[string]string{"meta.helm.sh/release-name": "x", "meta.helm.sh/release-namespace": "ns"},
+			Health:      "healthy",
+		}},
+		Helm: []HelmRelease{{Name: "x", Namespace: "ns", Chart: "x-1.0", ResourceHealth: "healthy"}},
+	})
+	if len(rows) == 0 {
+		t.Fatal("expected at least one row")
+	}
+	// Find the chart=x row and verify source order.
+	for _, r := range rows {
+		if r.Chart == "x" {
+			want := []string{SourceHelm, SourceLabels, SourceArgoCD, SourceFluxCD}
+			if !equalStrings(r.Sources, want) {
+				t.Errorf("want canonical sources %v, got %v", want, r.Sources)
+			}
+			return
+		}
+	}
+	t.Errorf("no x chart row found in %+v", rows)
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/packages/crd_groups.go
+++ b/pkg/packages/crd_groups.go
@@ -17,11 +17,12 @@ var crdGroupToChart = map[string]string{
 	"cert-manager.io":   "cert-manager",
 	"acme.cert-manager.io": "cert-manager",
 
-	// Argo CD + Argo Workflows + Argo Rollouts
+	// Argo CD + Argo Workflows + Argo Rollouts.
+	// All three share the argoproj.io group; we map to "argo-cd" so
+	// argo-rollouts standalone installs get folded in. Acceptable
+	// because the chart-name match is an aggregation hint, not a strict
+	// install identity.
 	"argoproj.io": "argo-cd",
-	// Some Argo charts split groups; keep the single chart name for now.
-	// Customers running argo-rollouts standalone get rolled into argo-cd
-	// — acceptable v1; revisit when separation matters.
 
 	// Flux v2 (toolkit)
 	"source.toolkit.fluxcd.io":       "flux",

--- a/pkg/packages/crd_groups.go
+++ b/pkg/packages/crd_groups.go
@@ -1,0 +1,99 @@
+package packages
+
+// crdGroupToChart maps CRD spec.group → conventional chart name. Lets
+// the merge logic collapse "cert-manager Helm release + cert-manager.io
+// CRDs" into a single row instead of two parallel ones.
+//
+// Sourced from observed customer installs. Conservative: groups not in
+// this map become standalone rows keyed by the group string itself
+// (FromCRDGroup field set), so we don't lose visibility on operators
+// we haven't seen before.
+//
+// When adding a new group, also consider whether the chart name we use
+// matches the canonical Helm chart name (the one that would appear in
+// Helm release secrets) — that's how rows merge.
+var crdGroupToChart = map[string]string{
+	// Cert-manager
+	"cert-manager.io":   "cert-manager",
+	"acme.cert-manager.io": "cert-manager",
+
+	// Argo CD + Argo Workflows + Argo Rollouts
+	"argoproj.io": "argo-cd",
+	// Some Argo charts split groups; keep the single chart name for now.
+	// Customers running argo-rollouts standalone get rolled into argo-cd
+	// — acceptable v1; revisit when separation matters.
+
+	// Flux v2 (toolkit)
+	"source.toolkit.fluxcd.io":       "flux",
+	"helm.toolkit.fluxcd.io":         "flux",
+	"kustomize.toolkit.fluxcd.io":    "flux",
+	"notification.toolkit.fluxcd.io": "flux",
+	"image.toolkit.fluxcd.io":        "flux",
+
+	// Karpenter
+	"karpenter.sh":      "karpenter",
+	"karpenter.k8s.aws": "karpenter",
+
+	// External Secrets Operator
+	"external-secrets.io":          "external-secrets",
+
+	// Velero
+	"velero.io": "velero",
+
+	// Kyverno
+	"kyverno.io":                "kyverno",
+	"wgpolicyk8s.io":            "kyverno", // PolicyReport CRDs
+
+	// Prometheus stack (kube-prometheus-stack)
+	"monitoring.coreos.com": "kube-prometheus-stack",
+
+	// Istio
+	"networking.istio.io":  "istio",
+	"security.istio.io":    "istio",
+	"telemetry.istio.io":   "istio",
+	"install.istio.io":     "istio",
+	"extensions.istio.io":  "istio",
+
+	// Traefik
+	"traefik.io":          "traefik",
+	"traefik.containo.us": "traefik",
+
+	// CloudNativePG
+	"postgresql.cnpg.io": "cloudnative-pg",
+
+	// OpenTelemetry
+	"opentelemetry.io": "opentelemetry-operator",
+
+	// KEDA
+	"keda.sh": "keda",
+	"eventing.keda.sh": "keda",
+
+	// Knative
+	"operator.knative.dev": "knative-operator",
+	"serving.knative.dev":  "knative-serving",
+	"eventing.knative.dev": "knative-eventing",
+	"sources.knative.dev":  "knative-eventing",
+
+	// Cluster API
+	"cluster.x-k8s.io":           "cluster-api",
+	"controlplane.cluster.x-k8s.io": "cluster-api",
+	"bootstrap.cluster.x-k8s.io":  "cluster-api",
+	"infrastructure.cluster.x-k8s.io": "cluster-api",
+	"addons.cluster.x-k8s.io":     "cluster-api",
+
+	// Trivy operator
+	"aquasecurity.github.io": "trivy-operator",
+
+	// Cilium
+	"cilium.io":          "cilium",
+}
+
+// chartFromCRDGroup returns (chartName, true) if the group is in our
+// known mapping, else (group, false). Callers decide whether to render
+// the group as a standalone row or skip.
+func chartFromCRDGroup(group string) (string, bool) {
+	if c, ok := crdGroupToChart[group]; ok {
+		return c, true
+	}
+	return group, false
+}

--- a/pkg/packages/gitops.go
+++ b/pkg/packages/gitops.go
@@ -90,20 +90,20 @@ func argoSourceChart(spec map[string]any) (string, string) {
 	return "", ""
 }
 
-func mapArgoHealth(s string) string {
+func mapArgoHealth(s string) Health {
 	switch strings.ToLower(s) {
 	case "healthy":
-		return "healthy"
+		return HealthHealthy
 	case "progressing":
-		return "degraded" // not yet ready
+		return HealthDegraded // not yet ready
 	case "degraded":
-		return "unhealthy"
+		return HealthUnhealthy
 	case "suspended":
-		return "degraded"
+		return HealthDegraded
 	case "missing", "unknown":
-		return "unknown"
+		return HealthUnknown
 	}
-	return "unknown"
+	return HealthUnknown
 }
 
 // ParseFluxHelmRelease parses a helm.toolkit.fluxcd.io/HelmRelease into
@@ -190,14 +190,14 @@ func ParseFluxKustomization(obj map[string]any) (Declaration, bool) {
 // our health vocabulary. Flux conditions are status: True/False with
 // a reason like "ReconciliationSucceeded", "InstallFailed",
 // "DependencyNotReady".
-func fluxConditionStatus(obj map[string]any) string {
+func fluxConditionStatus(obj map[string]any) Health {
 	status := mapAt(obj, "status")
 	if status == nil {
-		return "unknown"
+		return HealthUnknown
 	}
 	conds, ok := status["conditions"].([]any)
 	if !ok {
-		return "unknown"
+		return HealthUnknown
 	}
 	// Look for Ready first; fall back to Stalled if present.
 	var ready, stalled map[string]any
@@ -214,14 +214,14 @@ func fluxConditionStatus(obj map[string]any) string {
 		}
 	}
 	if stalled != nil && stringAt(stalled, "status") == "True" {
-		return "unhealthy"
+		return HealthUnhealthy
 	}
 	if ready == nil {
-		return "unknown"
+		return HealthUnknown
 	}
 	switch stringAt(ready, "status") {
 	case "True":
-		return "healthy"
+		return HealthHealthy
 	case "False":
 		// Whitelist transient reasons; everything else (including any
 		// unrecognized future reason) classifies as unhealthy. Errs
@@ -229,11 +229,11 @@ func fluxConditionStatus(obj map[string]any) string {
 		// masking a hard failure we don't yet recognize.
 		reason := stringAt(ready, "reason")
 		if isTransientFluxReason(reason) {
-			return "degraded"
+			return HealthDegraded
 		}
-		return "unhealthy"
+		return HealthUnhealthy
 	}
-	return "unknown"
+	return HealthUnknown
 }
 
 func isTransientFluxReason(r string) bool {

--- a/pkg/packages/gitops.go
+++ b/pkg/packages/gitops.go
@@ -100,7 +100,12 @@ func mapArgoHealth(s string) Health {
 		return HealthUnhealthy
 	case "suspended":
 		return HealthDegraded
-	case "missing", "unknown":
+	case "missing":
+		// Argo "Missing" = "should exist but doesn't" — a real signal
+		// (controller hasn't been able to apply); not the same as
+		// Unknown ("haven't observed yet"). Surface as Degraded.
+		return HealthDegraded
+	case "unknown":
 		return HealthUnknown
 	}
 	return HealthUnknown

--- a/pkg/packages/gitops.go
+++ b/pkg/packages/gitops.go
@@ -1,0 +1,265 @@
+package packages
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Parsers for GitOps controller resources. Take generic JSON-decoded
+// maps (CRDs are dynamic; we don't import the controllers' typed Go
+// modules) and return Declaration. Returns (Declaration{}, false) when
+// the input doesn't look like the expected shape.
+
+// ParseArgoApplication parses an argoproj.io/Application into a
+// Declaration. Argo apps have multiple source shapes:
+//
+//   - Helm chart (spec.source.chart + spec.source.helm.parameters)
+//   - Git repo with kustomize (spec.source.path + spec.source.kustomize)
+//   - Git repo with raw manifests (spec.source.path)
+//   - Multi-source apps (spec.sources[]) — first Helm source wins for
+//     chart info; we don't model multiple charts per app.
+//
+// Status mapping: spec.health.status → our health vocab. Argo's:
+// Healthy, Progressing, Degraded, Suspended, Missing, Unknown.
+func ParseArgoApplication(obj map[string]any) (Declaration, bool) {
+	meta := mapAt(obj, "metadata")
+	if meta == nil {
+		return Declaration{}, false
+	}
+	d := Declaration{
+		Source:    "argocd",
+		Namespace: stringAt(meta, "namespace"),
+		Name:      stringAt(meta, "name"),
+	}
+	if d.Name == "" {
+		return Declaration{}, false
+	}
+	spec := mapAt(obj, "spec")
+	if spec == nil {
+		return d, true
+	}
+	// Destination → target.
+	if dest := mapAt(spec, "destination"); dest != nil {
+		d.TargetNamespace = stringAt(dest, "namespace")
+		// "name" field is the destination cluster (Argo cluster name),
+		// not the resource name. Use empty target name; the Helm chart
+		// or app name fills it later.
+	}
+	// Single-source vs multi-source.
+	chart, version := argoSourceChart(spec)
+	d.Chart = chart
+	d.ChartVersion = version
+	if d.TargetName == "" {
+		// Conventionally Argo apps name == release name when source is
+		// Helm. Fall back to app name.
+		d.TargetName = d.Name
+	}
+	// Status from status.health.status.
+	if status := mapAt(obj, "status"); status != nil {
+		if health := mapAt(status, "health"); health != nil {
+			d.Status = mapArgoHealth(stringAt(health, "status"))
+		}
+	}
+	return d, true
+}
+
+// argoSourceChart pulls (chart, version) from spec.source or the first
+// spec.sources[] entry that's a Helm chart.
+func argoSourceChart(spec map[string]any) (string, string) {
+	// Single source.
+	if src := mapAt(spec, "source"); src != nil {
+		chart := stringAt(src, "chart")
+		ver := stringAt(src, "targetRevision")
+		if chart != "" {
+			return chart, ver
+		}
+	}
+	// Multi source.
+	if sources, ok := spec["sources"].([]any); ok {
+		for _, s := range sources {
+			if src, ok := s.(map[string]any); ok {
+				chart := stringAt(src, "chart")
+				ver := stringAt(src, "targetRevision")
+				if chart != "" {
+					return chart, ver
+				}
+			}
+		}
+	}
+	return "", ""
+}
+
+func mapArgoHealth(s string) string {
+	switch strings.ToLower(s) {
+	case "healthy":
+		return "healthy"
+	case "progressing":
+		return "degraded" // not yet ready
+	case "degraded":
+		return "unhealthy"
+	case "suspended":
+		return "degraded"
+	case "missing", "unknown":
+		return "unknown"
+	}
+	return "unknown"
+}
+
+// ParseFluxHelmRelease parses a helm.toolkit.fluxcd.io/HelmRelease into
+// a Declaration. Flux HRs always declare a Helm chart, so Chart is
+// always populated.
+func ParseFluxHelmRelease(obj map[string]any) (Declaration, bool) {
+	meta := mapAt(obj, "metadata")
+	if meta == nil {
+		return Declaration{}, false
+	}
+	d := Declaration{
+		Source:    "flux",
+		Namespace: stringAt(meta, "namespace"),
+		Name:      stringAt(meta, "name"),
+	}
+	if d.Name == "" {
+		return Declaration{}, false
+	}
+	spec := mapAt(obj, "spec")
+	if spec == nil {
+		return d, true
+	}
+	// Chart info — spec.chart.spec.{chart,version} on v2; spec.chart.* on
+	// v2beta2; spec.chartRef on the newer OCI-source variant.
+	if chart := mapAt(spec, "chart"); chart != nil {
+		if cspec := mapAt(chart, "spec"); cspec != nil {
+			d.Chart = stringAt(cspec, "chart")
+			d.ChartVersion = stringAt(cspec, "version")
+		}
+	}
+	if d.Chart == "" {
+		// Some HelmRelease variants put chart at spec.chart.chart directly.
+		if chart := mapAt(spec, "chart"); chart != nil {
+			d.Chart = stringAt(chart, "chart")
+			d.ChartVersion = stringAt(chart, "version")
+		}
+	}
+	// Target.
+	d.TargetNamespace = stringAt(spec, "targetNamespace")
+	if d.TargetNamespace == "" {
+		d.TargetNamespace = d.Namespace
+	}
+	d.TargetName = stringAt(spec, "releaseName")
+	if d.TargetName == "" {
+		d.TargetName = d.Name
+	}
+	// Status: status.conditions[type=Ready].status / .reason.
+	d.Status = fluxConditionStatus(obj)
+	return d, true
+}
+
+// ParseFluxKustomization parses a kustomize.toolkit.fluxcd.io/Kustomization
+// into a Declaration. Kustomizations don't have Helm chart info — they
+// render raw YAML — so Chart stays empty (Aggregate will fall back to
+// the Kustomization name as the row identity).
+func ParseFluxKustomization(obj map[string]any) (Declaration, bool) {
+	meta := mapAt(obj, "metadata")
+	if meta == nil {
+		return Declaration{}, false
+	}
+	d := Declaration{
+		Source:    "flux",
+		Namespace: stringAt(meta, "namespace"),
+		Name:      stringAt(meta, "name"),
+	}
+	if d.Name == "" {
+		return Declaration{}, false
+	}
+	spec := mapAt(obj, "spec")
+	if spec != nil {
+		d.TargetNamespace = stringAt(spec, "targetNamespace")
+		if d.TargetNamespace == "" {
+			d.TargetNamespace = d.Namespace
+		}
+	}
+	d.TargetName = d.Name
+	d.Status = fluxConditionStatus(obj)
+	return d, true
+}
+
+// fluxConditionStatus reads status.conditions[type=Ready] and returns
+// our health vocabulary. Flux conditions are status: True/False with
+// a reason like "ReconciliationSucceeded", "InstallFailed",
+// "DependencyNotReady".
+func fluxConditionStatus(obj map[string]any) string {
+	status := mapAt(obj, "status")
+	if status == nil {
+		return "unknown"
+	}
+	conds, ok := status["conditions"].([]any)
+	if !ok {
+		return "unknown"
+	}
+	// Look for Ready first; fall back to Stalled if present.
+	var ready, stalled map[string]any
+	for _, c := range conds {
+		cm, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		switch stringAt(cm, "type") {
+		case "Ready":
+			ready = cm
+		case "Stalled":
+			stalled = cm
+		}
+	}
+	if stalled != nil && stringAt(stalled, "status") == "True" {
+		return "unhealthy"
+	}
+	if ready == nil {
+		return "unknown"
+	}
+	switch stringAt(ready, "status") {
+	case "True":
+		return "healthy"
+	case "False":
+		// Reconciling vs failed. Flux uses reasons like "Progressing",
+		// "DependencyNotReady" for transient; "InstallFailed",
+		// "UpgradeFailed" for hard failures.
+		reason := stringAt(ready, "reason")
+		if isTransientFluxReason(reason) {
+			return "degraded"
+		}
+		return "unhealthy"
+	}
+	return "unknown"
+}
+
+func isTransientFluxReason(r string) bool {
+	switch r {
+	case "Progressing", "DependencyNotReady", "ReconciliationInProgress",
+		"ChartNotReady", "ArtifactFailed":
+		return true
+	}
+	return false
+}
+
+// Tiny typed lookup helpers — Go stdlib doesn't expose nice JSON
+// path-walking and writing it inline gets noisy.
+func mapAt(m map[string]any, key string) map[string]any {
+	if m == nil {
+		return nil
+	}
+	v, _ := m[key].(map[string]any)
+	return v
+}
+
+func stringAt(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	switch v := m[key].(type) {
+	case string:
+		return v
+	case fmt.Stringer:
+		return v.String()
+	}
+	return ""
+}

--- a/pkg/packages/gitops.go
+++ b/pkg/packages/gitops.go
@@ -19,8 +19,9 @@ import (
 //   - Multi-source apps (spec.sources[]) — first Helm source wins for
 //     chart info; we don't model multiple charts per app.
 //
-// Status mapping: spec.health.status → our health vocab. Argo's:
-// Healthy, Progressing, Degraded, Suspended, Missing, Unknown.
+// Status mapping: status.health.status → our health vocab via
+// mapArgoHealth (which falls back to "unknown" for any unrecognized
+// state, including future additions to Argo's HealthStatus enum).
 func ParseArgoApplication(obj map[string]any) (Declaration, bool) {
 	meta := mapAt(obj, "metadata")
 	if meta == nil {
@@ -125,8 +126,11 @@ func ParseFluxHelmRelease(obj map[string]any) (Declaration, bool) {
 	if spec == nil {
 		return d, true
 	}
-	// Chart info — spec.chart.spec.{chart,version} on v2; spec.chart.* on
-	// v2beta2; spec.chartRef on the newer OCI-source variant.
+	// Chart info — primary path is spec.chart.spec.{chart,version} (the
+	// HelmChartTemplate shape used by stable Flux v2 APIs). Fallback
+	// handles defensive flat-shape variants seen in the wild.
+	// NOTE: spec.chartRef (OCI HelmChart reference) is NOT yet parsed —
+	// OCI-sourced HelmReleases will report empty Chart/ChartVersion.
 	if chart := mapAt(spec, "chart"); chart != nil {
 		if cspec := mapAt(chart, "spec"); cspec != nil {
 			d.Chart = stringAt(cspec, "chart")
@@ -134,7 +138,6 @@ func ParseFluxHelmRelease(obj map[string]any) (Declaration, bool) {
 		}
 	}
 	if d.Chart == "" {
-		// Some HelmRelease variants put chart at spec.chart.chart directly.
 		if chart := mapAt(spec, "chart"); chart != nil {
 			d.Chart = stringAt(chart, "chart")
 			d.ChartVersion = stringAt(chart, "version")
@@ -220,9 +223,10 @@ func fluxConditionStatus(obj map[string]any) string {
 	case "True":
 		return "healthy"
 	case "False":
-		// Reconciling vs failed. Flux uses reasons like "Progressing",
-		// "DependencyNotReady" for transient; "InstallFailed",
-		// "UpgradeFailed" for hard failures.
+		// Whitelist transient reasons; everything else (including any
+		// unrecognized future reason) classifies as unhealthy. Errs
+		// loud — false-positive unhealthy is preferable to silently
+		// masking a hard failure we don't yet recognize.
 		reason := stringAt(ready, "reason")
 		if isTransientFluxReason(reason) {
 			return "degraded"

--- a/pkg/packages/gitops_test.go
+++ b/pkg/packages/gitops_test.go
@@ -76,16 +76,16 @@ func TestParseArgoApplication_MissingNameRejected(t *testing.T) {
 }
 
 func TestMapArgoHealth(t *testing.T) {
-	cases := map[string]string{
-		"Healthy":     "healthy",
-		"healthy":     "healthy",
-		"Progressing": "degraded",
-		"Degraded":    "unhealthy",
-		"Suspended":   "degraded",
-		"Missing":     "unknown",
-		"Unknown":     "unknown",
-		"":            "unknown",
-		"Bogus":       "unknown",
+	cases := map[string]Health{
+		"Healthy":     HealthHealthy,
+		"healthy":     HealthHealthy,
+		"Progressing": HealthDegraded,
+		"Degraded":    HealthUnhealthy,
+		"Suspended":   HealthDegraded,
+		"Missing":     HealthUnknown,
+		"Unknown":     HealthUnknown,
+		"":            HealthUnknown,
+		"Bogus":       HealthUnknown,
 	}
 	for in, want := range cases {
 		if got := mapArgoHealth(in); got != want {

--- a/pkg/packages/gitops_test.go
+++ b/pkg/packages/gitops_test.go
@@ -1,0 +1,218 @@
+package packages
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseArgoApplication_SingleSourceHelm(t *testing.T) {
+	obj := map[string]any{
+		"metadata": map[string]any{
+			"namespace": "argocd",
+			"name":      "cert-manager",
+		},
+		"spec": map[string]any{
+			"destination": map[string]any{
+				"namespace": "cert-manager",
+				"name":      "in-cluster",
+			},
+			"source": map[string]any{
+				"chart":          "cert-manager",
+				"targetRevision": "1.14.0",
+			},
+		},
+		"status": map[string]any{
+			"health": map[string]any{"status": "Healthy"},
+		},
+	}
+	d, ok := ParseArgoApplication(obj)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	want := Declaration{
+		Source:          "argocd",
+		Namespace:       "argocd",
+		Name:            "cert-manager",
+		TargetNamespace: "cert-manager",
+		TargetName:      "cert-manager",
+		Chart:           "cert-manager",
+		ChartVersion:    "1.14.0",
+		Status:          "healthy",
+	}
+	if !reflect.DeepEqual(d, want) {
+		t.Errorf("got %+v\nwant %+v", d, want)
+	}
+}
+
+// First Helm source wins; we don't model multiple charts per app.
+func TestParseArgoApplication_MultiSourceFirstHelmWins(t *testing.T) {
+	obj := map[string]any{
+		"metadata": map[string]any{"name": "stack", "namespace": "argocd"},
+		"spec": map[string]any{
+			"destination": map[string]any{"namespace": "monitoring"},
+			"sources": []any{
+				map[string]any{"repoURL": "git@example.com/values.git", "path": "."},
+				map[string]any{"chart": "prometheus", "targetRevision": "25.0.0"},
+				map[string]any{"chart": "grafana", "targetRevision": "7.0.0"},
+			},
+		},
+	}
+	d, ok := ParseArgoApplication(obj)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if d.Chart != "prometheus" || d.ChartVersion != "25.0.0" {
+		t.Errorf("first Helm source should win, got chart=%q version=%q", d.Chart, d.ChartVersion)
+	}
+}
+
+func TestParseArgoApplication_MissingNameRejected(t *testing.T) {
+	if _, ok := ParseArgoApplication(map[string]any{"metadata": map[string]any{}}); ok {
+		t.Error("expected !ok for missing metadata.name")
+	}
+	if _, ok := ParseArgoApplication(map[string]any{}); ok {
+		t.Error("expected !ok for missing metadata")
+	}
+}
+
+func TestMapArgoHealth(t *testing.T) {
+	cases := map[string]string{
+		"Healthy":     "healthy",
+		"healthy":     "healthy",
+		"Progressing": "degraded",
+		"Degraded":    "unhealthy",
+		"Suspended":   "degraded",
+		"Missing":     "unknown",
+		"Unknown":     "unknown",
+		"":            "unknown",
+		"Bogus":       "unknown",
+	}
+	for in, want := range cases {
+		if got := mapArgoHealth(in); got != want {
+			t.Errorf("mapArgoHealth(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// v2 layout: spec.chart.spec.{chart,version}.
+func TestParseFluxHelmRelease_V2Layout(t *testing.T) {
+	obj := map[string]any{
+		"metadata": map[string]any{"name": "redis", "namespace": "data"},
+		"spec": map[string]any{
+			"chart": map[string]any{
+				"spec": map[string]any{"chart": "redis", "version": "18.0.0"},
+			},
+			"targetNamespace": "redis",
+			"releaseName":     "redis-prod",
+		},
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{"type": "Ready", "status": "True"},
+			},
+		},
+	}
+	d, ok := ParseFluxHelmRelease(obj)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if d.Chart != "redis" || d.ChartVersion != "18.0.0" {
+		t.Errorf("v2 chart shape, got chart=%q version=%q", d.Chart, d.ChartVersion)
+	}
+	if d.TargetNamespace != "redis" || d.TargetName != "redis-prod" {
+		t.Errorf("target wrong: ns=%q name=%q", d.TargetNamespace, d.TargetName)
+	}
+	if d.Status != "healthy" {
+		t.Errorf("Ready=True should map healthy, got %q", d.Status)
+	}
+}
+
+// v2beta2 layout: spec.chart.{chart,version}.
+func TestParseFluxHelmRelease_V2Beta2Layout(t *testing.T) {
+	obj := map[string]any{
+		"metadata": map[string]any{"name": "nginx", "namespace": "kube-system"},
+		"spec": map[string]any{
+			"chart": map[string]any{"chart": "nginx", "version": "1.5.0"},
+		},
+	}
+	d, ok := ParseFluxHelmRelease(obj)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if d.Chart != "nginx" || d.ChartVersion != "1.5.0" {
+		t.Errorf("v2beta2 chart shape, got chart=%q version=%q", d.Chart, d.ChartVersion)
+	}
+	// targetNamespace falls back to the HR's own namespace when not set.
+	if d.TargetNamespace != "kube-system" {
+		t.Errorf("targetNamespace fallback, got %q", d.TargetNamespace)
+	}
+	// releaseName falls back to the HR's name.
+	if d.TargetName != "nginx" {
+		t.Errorf("releaseName fallback, got %q", d.TargetName)
+	}
+}
+
+func TestParseFluxKustomization(t *testing.T) {
+	obj := map[string]any{
+		"metadata": map[string]any{"name": "platform", "namespace": "flux-system"},
+		"spec": map[string]any{
+			"targetNamespace": "platform",
+		},
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{"type": "Ready", "status": "False", "reason": "ReconciliationFailed"},
+			},
+		},
+	}
+	d, ok := ParseFluxKustomization(obj)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if d.Chart != "" {
+		t.Errorf("Kustomization should leave Chart empty, got %q", d.Chart)
+	}
+	if d.TargetNamespace != "platform" || d.TargetName != "platform" {
+		t.Errorf("target wrong: ns=%q name=%q", d.TargetNamespace, d.TargetName)
+	}
+	if d.Status != "unhealthy" {
+		t.Errorf("Ready=False with hard reason should map unhealthy, got %q", d.Status)
+	}
+}
+
+// Stalled=True overrides Ready=True — Flux uses Stalled to signal a
+// terminal failure that needs operator intervention even if the previous
+// reconciliation succeeded.
+func TestFluxConditionStatus_StalledOverridesReady(t *testing.T) {
+	obj := map[string]any{
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{"type": "Ready", "status": "True"},
+				map[string]any{"type": "Stalled", "status": "True", "reason": "InstallFailed"},
+			},
+		},
+	}
+	if got := fluxConditionStatus(obj); got != "unhealthy" {
+		t.Errorf("Stalled=True should override Ready=True, got %q", got)
+	}
+}
+
+func TestFluxConditionStatus_TransientReasonDegraded(t *testing.T) {
+	obj := map[string]any{
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{"type": "Ready", "status": "False", "reason": "Progressing"},
+			},
+		},
+	}
+	if got := fluxConditionStatus(obj); got != "degraded" {
+		t.Errorf("Ready=False with transient reason should map degraded, got %q", got)
+	}
+}
+
+func TestFluxConditionStatus_NoConditions(t *testing.T) {
+	if got := fluxConditionStatus(map[string]any{}); got != "unknown" {
+		t.Errorf("missing status → unknown, got %q", got)
+	}
+	if got := fluxConditionStatus(map[string]any{"status": map[string]any{}}); got != "unknown" {
+		t.Errorf("empty status → unknown, got %q", got)
+	}
+}

--- a/pkg/packages/gitops_test.go
+++ b/pkg/packages/gitops_test.go
@@ -82,10 +82,12 @@ func TestMapArgoHealth(t *testing.T) {
 		"Progressing": HealthDegraded,
 		"Degraded":    HealthUnhealthy,
 		"Suspended":   HealthDegraded,
-		"Missing":     HealthUnknown,
-		"Unknown":     HealthUnknown,
-		"":            HealthUnknown,
-		"Bogus":       HealthUnknown,
+		// Missing means "should exist but doesn't" — surface as a
+		// real signal (degraded), not as the same bucket as Unknown.
+		"Missing": HealthDegraded,
+		"Unknown": HealthUnknown,
+		"":       HealthUnknown,
+		"Bogus":  HealthUnknown,
 	}
 	for in, want := range cases {
 		if got := mapArgoHealth(in); got != want {

--- a/pkg/packages/types.go
+++ b/pkg/packages/types.go
@@ -134,6 +134,10 @@ type Sources struct {
 // "Helm: healthy · Argo: degraded" tooltip, "managed by Argo →" deep
 // link, same-cluster version-disagreement detection) read Contributors;
 // simple consumers read the aggregated fields on PackageRow directly.
+//
+// Contributor merge identity is `Source` alone — at most one
+// contribution per SourceCode per row. For cross-cluster fan-in (Hub),
+// see `Cluster` below.
 type SourceContribution struct {
 	Source           SourceCode `json:"source"`
 	Health           Health     `json:"health,omitempty"`
@@ -144,8 +148,16 @@ type SourceContribution struct {
 	// For GitOps sources (A/F): the controller resource's own identity
 	// (e.g. the Argo Application's namespace/name, the Flux HelmRelease's
 	// namespace/name). Lets consumers deep-link to the controller view.
+	// Always empty for non-GitOps sources (H/L/C).
 	DeclarationName      string `json:"declarationName,omitempty"`
 	DeclarationNamespace string `json:"declarationNamespace,omitempty"`
+	// Cluster identifies the cluster this contribution came from.
+	// Always empty in single-cluster output (Radar standalone). Hub
+	// populates this when fanning rows in across clusters so the
+	// merge key effectively becomes (Source, Cluster) — preserving
+	// per-cluster Argo identity in the "same chart, different Apps,
+	// different clusters" hub-and-spoke pattern.
+	Cluster string `json:"cluster,omitempty"`
 }
 
 // PackageRow is the output shape — one row per detected package.
@@ -153,9 +165,11 @@ type SourceContribution struct {
 // `Sources` field carries the deduplicated voters and `Contributors`
 // carries each source's pre-merge view.
 //
-// Hub fan-in note: when merging rows from multiple clusters, use
-// AddContribution on the destination row to preserve the canonical-
-// order + worst-of-health invariants and to keep per-source provenance.
+// Hub fan-in note: AddContribution dedupes on (Source, Cluster). When
+// Hub merges rows from N clusters, it stamps each contribution with the
+// originating cluster so Argo App identity from cluster A and from
+// cluster B both survive on the merged row. Single-cluster Radar
+// leaves Cluster empty, so dedupe collapses to Source alone.
 type PackageRow struct {
 	// Chart name. Always populated. Derived from (in priority order):
 	// Helm release ChartName, helm.sh/chart label parse, crdGroupToChart
@@ -214,9 +228,10 @@ func (r *PackageRow) MergeHealth(h Health) {
 
 // AddContribution merges a per-source contribution into r. Updates:
 //  1. r.Sources (idempotent, canonical order — via AddSource)
-//  2. r.Contributors (idempotent on Source: subsequent contributions
-//     from the same Source merge — Health worst-of, other fields
-//     keep first-seen non-empty values)
+//  2. r.Contributors (idempotent on (Source, Cluster): subsequent
+//     contributions with the same key merge — Health worst-of, other
+//     fields keep first-seen non-empty values; contributions with
+//     different Cluster keys land as separate entries)
 //  3. Aggregated fields (r.Health worst-of, r.Version/AppVersion
 //     first-seen wins) — preserves the existing on-wire semantics
 //     for simple consumers that ignore Contributors.
@@ -230,7 +245,7 @@ func (r *PackageRow) AddContribution(c SourceContribution) {
 		r.AppVersion = c.AppVersion
 	}
 	for i := range r.Contributors {
-		if r.Contributors[i].Source != c.Source {
+		if r.Contributors[i].Source != c.Source || r.Contributors[i].Cluster != c.Cluster {
 			continue
 		}
 		existing := &r.Contributors[i]
@@ -257,4 +272,18 @@ func (r *PackageRow) AddContribution(c SourceContribution) {
 	}
 	r.Contributors = append(r.Contributors, c)
 	sortContributors(r.Contributors)
+}
+
+// Contributor returns the first contribution from the given source
+// (canonical order). Returns nil if no contribution from that source
+// exists. Hub fan-in iterates Contributors directly (since it may have
+// per-cluster entries for the same Source); this helper is for
+// single-cluster consumers asking "what did Helm say?"
+func (r *PackageRow) Contributor(s SourceCode) *SourceContribution {
+	for i := range r.Contributors {
+		if r.Contributors[i].Source == s {
+			return &r.Contributors[i]
+		}
+	}
+	return nil
 }

--- a/pkg/packages/types.go
+++ b/pkg/packages/types.go
@@ -1,0 +1,150 @@
+// Package packages aggregates "what's installed" signals across multiple
+// detection sources into a unified package list. Designed for both:
+//
+//   - Radar OSS REST `/api/packages` — single-cluster view via the Helm
+//     API + workload labels + CRD registrations + GitOps declarations.
+//   - Radar Hub fleet `/api/fleet/packages` — multi-cluster aggregation
+//     by fanning out to per-cluster `/api/packages` and pivoting.
+//
+// Pure Go, no internal/ imports. The shape is `Aggregate(Sources) []PackageRow`
+// — feed in whatever you have, get back a deduplicated, source-attributed
+// merge.
+//
+// Source codes (single character so `[]string` cells in the SPA stay compact):
+//
+//	H — Helm API (release secret read; gives chart + version + health)
+//	L — Workload labels (helm.sh/chart label on Deployments/DaemonSets/
+//	    StatefulSets; works without secret access)
+//	C — CRD registration (CRD spec.group → chart name via crdGroupToChart)
+//	A — Argo Application declaration (declared, may not yet be running)
+//	F — Flux HelmRelease + Kustomization declarations (likewise)
+//
+// A row's `Sources` field carries the deduplicated set of contributors
+// that voted "this package is installed" — `[H,L,C]` is the typical case
+// for a fully-instrumented Helm chart whose CRDs land alongside.
+package packages
+
+import "time"
+
+// Source codes returned in PackageRow.Sources. Stable on-wire — agents,
+// SPAs, and other consumers rely on these single characters.
+const (
+	SourceHelm        = "H"
+	SourceLabels      = "L"
+	SourceCRDs        = "C"
+	SourceArgoCD      = "A"
+	SourceFluxCD      = "F"
+)
+
+// HelmRelease is the Helm-side input shape. Mirrors the on-wire shape
+// of `internal/helm.HelmRelease` but lives here so pkg/packages stays
+// dependency-free of internal/.
+type HelmRelease struct {
+	Name           string `json:"name"`
+	Namespace      string `json:"namespace"`
+	Chart          string `json:"chart"`         // raw chart string from Helm release ("cert-manager-1.14.0")
+	ChartName      string `json:"chartName"`     // optional pre-parsed name; empty → derived from Chart
+	ChartVersion   string `json:"chartVersion"`  // optional pre-parsed version; empty → derived from Chart
+	AppVersion     string `json:"appVersion"`
+	Status         string `json:"status"`
+	ResourceHealth string `json:"resourceHealth,omitempty"` // healthy|degraded|unhealthy|unknown
+}
+
+// Workload is the labels-side input shape. We need just enough to look up
+// helm.sh/chart + meta.helm.sh/release-{name,namespace} annotations and
+// derive aggregated health. Callers translate from their concrete types
+// (corev1.Deployment, etc.) using the helpers in workloads.go.
+type Workload struct {
+	Kind        string            `json:"kind"`        // Deployment | DaemonSet | StatefulSet | Job | CronJob
+	Namespace   string            `json:"namespace"`
+	Name        string            `json:"name"`
+	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations"`
+	// Health is the workload's aggregated runtime status. Caller decides
+	// the rule (e.g. ready/desired ratio for Deployments). One of:
+	// healthy|degraded|unhealthy|unknown.
+	Health string `json:"health"`
+}
+
+// CRD is the CRD-side input shape. We need just enough to map
+// spec.group → chart name and pick a version.
+type CRD struct {
+	Name    string   `json:"name"`              // metadata.name (e.g., "certificates.cert-manager.io")
+	Group   string   `json:"group"`             // spec.group (e.g., "cert-manager.io")
+	Kind    string   `json:"kind"`              // spec.names.kind
+	Plural  string   `json:"plural"`            // spec.names.plural
+	Versions []string `json:"versions,omitempty"` // spec.versions[*].name (first one used)
+}
+
+// Declaration is the GitOps-side input shape — what a GitOps controller
+// declares should be installed. Argo Applications, Flux HelmReleases,
+// and Flux Kustomizations all collapse to this shape.
+//
+// Note the cross-cluster gotcha: when Argo CD runs in cluster A but
+// deploys to cluster B, the Application resources live in A. A
+// per-cluster `/api/packages` from cluster B won't include those Argo
+// declarations. This is an accepted v1 limitation; documented in
+// SESSION-HANDOFF.md.
+type Declaration struct {
+	Source    string `json:"source"`    // "argocd" | "flux"
+	Namespace string `json:"namespace"` // declaration's own namespace
+	Name      string `json:"name"`      // declaration's own name (App name / Kustomization name)
+	// Target install identity (where the declaration says the package
+	// lives). Argo Application: spec.destination.{namespace,name}
+	// Flux HelmRelease: spec.releaseName (in spec.targetNamespace)
+	// Flux Kustomization: name itself (no Helm shape — chart will be empty)
+	TargetNamespace string `json:"targetNamespace"`
+	TargetName      string `json:"targetName"`
+	// Chart info (when known — Argo Helm-source apps + Flux HelmReleases
+	// know it; Flux Kustomizations may not).
+	Chart        string `json:"chart,omitempty"`
+	ChartVersion string `json:"chartVersion,omitempty"`
+	// Status as the GitOps controller sees it. One of:
+	// healthy|degraded|unhealthy|unknown — caller maps from their
+	// vocabulary (Argo: Healthy/Progressing/Degraded/Suspended/Missing/Unknown;
+	// Flux: Ready/Stalled/Reconciling/Suspended).
+	Status string `json:"status"`
+}
+
+// Sources is the input struct fed to Aggregate. Every field is optional;
+// missing data sources just don't contribute. Callers populate from
+// whatever they have access to — Hub-mode might pass all five, a
+// minimal RBAC-restricted Radar might pass only Workloads + CRDs.
+type Sources struct {
+	Helm                []HelmRelease `json:"helm,omitempty"`
+	Workloads           []Workload    `json:"workloads,omitempty"`
+	CRDs                []CRD         `json:"crds,omitempty"`
+	GitOpsDeclarations  []Declaration `json:"gitopsDeclarations,omitempty"`
+}
+
+// PackageRow is the output shape — one row per detected package.
+// Multiple sources contribute to a single row when they agree; the
+// `Sources` field carries the deduplicated voters.
+type PackageRow struct {
+	// Chart name. Always populated. Derived from (in priority order):
+	// Helm release ChartName, helm.sh/chart label parse, crdGroupToChart
+	// lookup, GitOps declaration Chart field.
+	Chart string `json:"chart"`
+	// Where the install lives. Empty for CRD-only rows (CRDs are
+	// cluster-scoped registrations with no namespaced release identity).
+	Namespace   string `json:"namespace,omitempty"`
+	ReleaseName string `json:"releaseName,omitempty"`
+	// Version (Helm chart version > label version > CRD spec.versions[0].name
+	// > GitOps declared version). Empty if no source supplied one.
+	Version string `json:"version,omitempty"`
+	// AppVersion if Helm provided one. Optional.
+	AppVersion string `json:"appVersion,omitempty"`
+	// Health: healthy|degraded|unhealthy|unknown. Worst of contributors.
+	Health string `json:"health"`
+	// Sources is the deduplicated set of source codes that contributed.
+	// At least one element. Order: H, L, C, A, F (declaration order).
+	Sources []string `json:"sources"`
+	// FromCRDGroup, when set, indicates this row originated from a CRD
+	// whose group wasn't in crdGroupToChart — Chart is the group string
+	// itself in that case. Lets the SPA render with appropriate framing
+	// ("cert-manager.io CRDs detected") vs a real chart row.
+	FromCRDGroup string `json:"fromCRDGroup,omitempty"`
+	// AggregatedAt is the time Aggregate ran. Useful for cache freshness
+	// debugging in distributed traces.
+	AggregatedAt time.Time `json:"aggregatedAt"`
+}

--- a/pkg/packages/types.go
+++ b/pkg/packages/types.go
@@ -11,14 +11,42 @@
 //	F — Flux HelmRelease / Kustomization declaration
 package packages
 
-// Source codes returned in PackageRow.Sources. Stable on-wire — agents,
-// SPAs, and other consumers rely on these single characters.
+// SourceCode is the single-character code identifying which signal
+// contributed to a PackageRow. Stable on-wire — agents, SPAs, Hub
+// fan-in, etc. depend on these exact strings. Defined as a named type
+// so call sites get compile-time checks against typos.
+type SourceCode string
+
 const (
-	SourceHelm        = "H"
-	SourceLabels      = "L"
-	SourceCRDs        = "C"
-	SourceArgoCD      = "A"
-	SourceFluxCD      = "F"
+	SourceHelm   SourceCode = "H"
+	SourceLabels SourceCode = "L"
+	SourceCRDs   SourceCode = "C"
+	SourceArgoCD SourceCode = "A"
+	SourceFluxCD SourceCode = "F"
+)
+
+// AllSourceCodes is the canonical-order enumeration. Used by sourcesUsed
+// to emit deterministic output and by Hub fan-in to iterate sources.
+var AllSourceCodes = []SourceCode{SourceHelm, SourceLabels, SourceCRDs, SourceArgoCD, SourceFluxCD}
+
+// Valid reports whether s is one of the five known source codes.
+func (s SourceCode) Valid() bool {
+	switch s {
+	case SourceHelm, SourceLabels, SourceCRDs, SourceArgoCD, SourceFluxCD:
+		return true
+	}
+	return false
+}
+
+// Health is the package-level health vocabulary. All four contributors
+// (Helm, Workloads, CRDs default, GitOps) normalize to one of these.
+type Health string
+
+const (
+	HealthHealthy   Health = "healthy"
+	HealthDegraded  Health = "degraded"
+	HealthUnhealthy Health = "unhealthy"
+	HealthUnknown   Health = "unknown"
 )
 
 // HelmRelease is the Helm-side input shape. Mirrors the on-wire shape
@@ -27,37 +55,36 @@ const (
 type HelmRelease struct {
 	Name           string `json:"name"`
 	Namespace      string `json:"namespace"`
-	Chart          string `json:"chart"`         // raw chart string from Helm release ("cert-manager-1.14.0")
-	ChartName      string `json:"chartName"`     // optional pre-parsed name; empty → derived from Chart
-	ChartVersion   string `json:"chartVersion"`  // optional pre-parsed version; empty → derived from Chart
+	Chart          string `json:"chart"`        // raw chart string from Helm release ("cert-manager-1.14.0")
+	ChartName      string `json:"chartName"`    // optional pre-parsed name; empty → derived from Chart
+	ChartVersion   string `json:"chartVersion"` // optional pre-parsed version; empty → derived from Chart
 	AppVersion     string `json:"appVersion"`
 	Status         string `json:"status"`
-	ResourceHealth string `json:"resourceHealth,omitempty"` // healthy|degraded|unhealthy|unknown
+	ResourceHealth Health `json:"resourceHealth,omitempty"`
 }
 
 // Workload is the labels-side input shape. We need just enough to look up
 // helm.sh/chart + meta.helm.sh/release-{name,namespace} annotations and
 // derive aggregated health. Callers translate from their concrete types
-// (corev1.Deployment, etc.) using the helpers in workloads.go.
+// (corev1.Deployment, etc.).
 type Workload struct {
-	Kind        string            `json:"kind"`        // Deployment | DaemonSet | StatefulSet | Job | CronJob
+	Kind        string            `json:"kind"` // Deployment | DaemonSet | StatefulSet | Job | CronJob
 	Namespace   string            `json:"namespace"`
 	Name        string            `json:"name"`
 	Labels      map[string]string `json:"labels"`
 	Annotations map[string]string `json:"annotations"`
 	// Health is the workload's aggregated runtime status. Caller decides
-	// the rule (e.g. ready/desired ratio for Deployments). One of:
-	// healthy|degraded|unhealthy|unknown.
-	Health string `json:"health"`
+	// the rule (e.g. ready/desired ratio for Deployments).
+	Health Health `json:"health"`
 }
 
 // CRD is the CRD-side input shape. We need just enough to map
 // spec.group → chart name and pick a version.
 type CRD struct {
-	Name    string   `json:"name"`              // metadata.name (e.g., "certificates.cert-manager.io")
-	Group   string   `json:"group"`             // spec.group (e.g., "cert-manager.io")
-	Kind    string   `json:"kind"`              // spec.names.kind
-	Plural  string   `json:"plural"`            // spec.names.plural
+	Name     string   `json:"name"`               // metadata.name (e.g., "certificates.cert-manager.io")
+	Group    string   `json:"group"`              // spec.group (e.g., "cert-manager.io")
+	Kind     string   `json:"kind"`               // spec.names.kind
+	Plural   string   `json:"plural"`             // spec.names.plural
 	Versions []string `json:"versions,omitempty"` // spec.versions[*].name (first one used)
 }
 
@@ -82,13 +109,12 @@ type Declaration struct {
 	// know it; Flux Kustomizations may not).
 	Chart        string `json:"chart,omitempty"`
 	ChartVersion string `json:"chartVersion,omitempty"`
-	// Status as the GitOps controller sees it. One of:
-	// healthy|degraded|unhealthy|unknown — caller maps from their
+	// Status as the GitOps controller sees it. Caller maps from their
 	// vocabulary. Argo: Healthy/Progressing/Degraded/Suspended/Missing/
 	// Unknown. Flux: derived from Ready and Stalled conditions; transient
 	// reasons collapse to degraded. Suspended (spec.suspend) is not yet
 	// surfaced separately.
-	Status string `json:"status"`
+	Status Health `json:"status"`
 }
 
 // Sources is the input struct fed to Aggregate. Every field is optional;
@@ -96,15 +122,20 @@ type Declaration struct {
 // whatever they have access to — Hub-mode might pass all five, a
 // minimal RBAC-restricted Radar might pass only Workloads + CRDs.
 type Sources struct {
-	Helm                []HelmRelease `json:"helm,omitempty"`
-	Workloads           []Workload    `json:"workloads,omitempty"`
-	CRDs                []CRD         `json:"crds,omitempty"`
-	GitOpsDeclarations  []Declaration `json:"gitopsDeclarations,omitempty"`
+	Helm               []HelmRelease `json:"helm,omitempty"`
+	Workloads          []Workload    `json:"workloads,omitempty"`
+	CRDs               []CRD         `json:"crds,omitempty"`
+	GitOpsDeclarations []Declaration `json:"gitopsDeclarations,omitempty"`
 }
 
 // PackageRow is the output shape — one row per detected package.
 // Multiple sources contribute to a single row when they agree; the
 // `Sources` field carries the deduplicated voters.
+//
+// Hub fan-in note: when merging rows from multiple clusters, use
+// AddSource and MergeHealth on the destination row to preserve the
+// canonical-order + worst-of-health invariants without re-implementing
+// them.
 type PackageRow struct {
 	// Chart name. Always populated. Derived from (in priority order):
 	// Helm release ChartName, helm.sh/chart label parse, crdGroupToChart
@@ -119,14 +150,34 @@ type PackageRow struct {
 	Version string `json:"version,omitempty"`
 	// AppVersion if Helm provided one. Optional.
 	AppVersion string `json:"appVersion,omitempty"`
-	// Health: healthy|degraded|unhealthy|unknown. Worst of contributors.
-	Health string `json:"health"`
+	// Health is the worst-of across contributors.
+	Health Health `json:"health"`
 	// Sources is the deduplicated set of source codes that contributed.
-	// At least one element. Order: H, L, C, A, F (declaration order).
-	Sources []string `json:"sources"`
+	// At least one element. Order: H, L, C, A, F (canonical). Treat as
+	// immutable after Aggregate returns; mutate via AddSource.
+	Sources []SourceCode `json:"sources"`
 	// FromCRDGroup, when set, indicates this row originated from a CRD
 	// whose group wasn't in crdGroupToChart — Chart is the group string
 	// itself in that case. Lets the SPA render with appropriate framing
 	// ("cert-manager.io CRDs detected") vs a real chart row.
 	FromCRDGroup string `json:"fromCRDGroup,omitempty"`
+}
+
+// AddSource appends src to r.Sources if not already present and
+// re-sorts into canonical order H, L, C, A, F. Idempotent.
+func (r *PackageRow) AddSource(src SourceCode) {
+	for _, s := range r.Sources {
+		if s == src {
+			return
+		}
+	}
+	r.Sources = append(r.Sources, src)
+	sortSources(r.Sources)
+}
+
+// MergeHealth replaces r.Health with the worse of (r.Health, h),
+// using the order Unhealthy > Degraded > Unknown > Healthy. Empty h
+// is "no opinion" — r.Health unchanged.
+func (r *PackageRow) MergeHealth(h Health) {
+	r.Health = worseHealth(r.Health, h)
 }

--- a/pkg/packages/types.go
+++ b/pkg/packages/types.go
@@ -1,27 +1,14 @@
-// Package packages aggregates "what's installed" signals across multiple
-// detection sources into a unified package list. Designed for both:
+// Package packages aggregates "what's installed" signals into a unified
+// package list. Pure Go, no internal/ imports. Entry point is
+// Aggregate(Sources) []PackageRow.
 //
-//   - Radar OSS REST `/api/packages` — single-cluster view via the Helm
-//     API + workload labels + CRD registrations + GitOps declarations.
-//   - Radar Hub fleet `/api/fleet/packages` — multi-cluster aggregation
-//     by fanning out to per-cluster `/api/packages` and pivoting.
+// Source codes (single character — stable on-wire):
 //
-// Pure Go, no internal/ imports. The shape is `Aggregate(Sources) []PackageRow`
-// — feed in whatever you have, get back a deduplicated, source-attributed
-// merge.
-//
-// Source codes (single character so `[]string` cells in the SPA stay compact):
-//
-//	H — Helm API (release secret read; gives chart + version + health)
-//	L — Workload labels (helm.sh/chart label on Deployments/DaemonSets/
-//	    StatefulSets; works without secret access)
-//	C — CRD registration (CRD spec.group → chart name via crdGroupToChart)
-//	A — Argo Application declaration (declared, may not yet be running)
-//	F — Flux HelmRelease + Kustomization declarations (likewise)
-//
-// A row's `Sources` field carries the deduplicated set of contributors
-// that voted "this package is installed" — `[H,L,C]` is the typical case
-// for a fully-instrumented Helm chart whose CRDs land alongside.
+//	H — Helm API (release secret read)
+//	L — Workload labels (helm.sh/chart, meta.helm.sh/release-name)
+//	C — CRD registration (spec.group → chart via crdGroupToChart)
+//	A — Argo Application declaration
+//	F — Flux HelmRelease / Kustomization declaration
 package packages
 
 import "time"
@@ -80,11 +67,9 @@ type CRD struct {
 // declares should be installed. Argo Applications, Flux HelmReleases,
 // and Flux Kustomizations all collapse to this shape.
 //
-// Note the cross-cluster gotcha: when Argo CD runs in cluster A but
-// deploys to cluster B, the Application resources live in A. A
-// per-cluster `/api/packages` from cluster B won't include those Argo
-// declarations. This is an accepted v1 limitation; documented in
-// SESSION-HANDOFF.md.
+// Cross-cluster caveat: when Argo CD runs in cluster A but deploys to
+// cluster B, the Application resources live in A — a `/api/packages`
+// call against cluster B won't see those declarations.
 type Declaration struct {
 	Source    string `json:"source"`    // "argocd" | "flux"
 	Namespace string `json:"namespace"` // declaration's own namespace

--- a/pkg/packages/types.go
+++ b/pkg/packages/types.go
@@ -128,14 +128,34 @@ type Sources struct {
 	GitOpsDeclarations []Declaration `json:"gitopsDeclarations,omitempty"`
 }
 
+// SourceContribution is what one signal saw for this package, before
+// the worst-of-health / first-wins-version merge collapsed contributors
+// into a single PackageRow. Consumers needing per-source detail (Hub's
+// "Helm: healthy · Argo: degraded" tooltip, "managed by Argo →" deep
+// link, same-cluster version-disagreement detection) read Contributors;
+// simple consumers read the aggregated fields on PackageRow directly.
+type SourceContribution struct {
+	Source           SourceCode `json:"source"`
+	Health           Health     `json:"health,omitempty"`
+	Version          string     `json:"version,omitempty"`
+	AppVersion       string     `json:"appVersion,omitempty"`
+	ReleaseName      string     `json:"releaseName,omitempty"`
+	ReleaseNamespace string     `json:"releaseNamespace,omitempty"`
+	// For GitOps sources (A/F): the controller resource's own identity
+	// (e.g. the Argo Application's namespace/name, the Flux HelmRelease's
+	// namespace/name). Lets consumers deep-link to the controller view.
+	DeclarationName      string `json:"declarationName,omitempty"`
+	DeclarationNamespace string `json:"declarationNamespace,omitempty"`
+}
+
 // PackageRow is the output shape — one row per detected package.
 // Multiple sources contribute to a single row when they agree; the
-// `Sources` field carries the deduplicated voters.
+// `Sources` field carries the deduplicated voters and `Contributors`
+// carries each source's pre-merge view.
 //
 // Hub fan-in note: when merging rows from multiple clusters, use
-// AddSource and MergeHealth on the destination row to preserve the
-// canonical-order + worst-of-health invariants without re-implementing
-// them.
+// AddContribution on the destination row to preserve the canonical-
+// order + worst-of-health invariants and to keep per-source provenance.
 type PackageRow struct {
 	// Chart name. Always populated. Derived from (in priority order):
 	// Helm release ChartName, helm.sh/chart label parse, crdGroupToChart
@@ -146,7 +166,9 @@ type PackageRow struct {
 	Namespace   string `json:"namespace,omitempty"`
 	ReleaseName string `json:"releaseName,omitempty"`
 	// Version (Helm chart version > label version > CRD spec.versions[0].name
-	// > GitOps declared version). Empty if no source supplied one.
+	// > GitOps declared version). Empty if no source supplied one. For
+	// per-source values (and to detect same-cluster version disagreement),
+	// read Contributors.
 	Version string `json:"version,omitempty"`
 	// AppVersion if Helm provided one. Optional.
 	AppVersion string `json:"appVersion,omitempty"`
@@ -154,8 +176,13 @@ type PackageRow struct {
 	Health Health `json:"health"`
 	// Sources is the deduplicated set of source codes that contributed.
 	// At least one element. Order: H, L, C, A, F (canonical). Treat as
-	// immutable after Aggregate returns; mutate via AddSource.
+	// immutable after Aggregate returns; mutate via AddContribution.
 	Sources []SourceCode `json:"sources"`
+	// Contributors carries each source's pre-merge view (one entry per
+	// SourceCode). Same canonical order as Sources. Hub uses this for
+	// the "Helm says healthy, Argo says degraded" tooltip and to deep-
+	// link to the GitOps controller resource that manages a row.
+	Contributors []SourceContribution `json:"contributors,omitempty"`
 	// FromCRDGroup, when set, indicates this row originated from a CRD
 	// whose group wasn't in crdGroupToChart — Chart is the group string
 	// itself in that case. Lets the SPA render with appropriate framing
@@ -165,6 +192,9 @@ type PackageRow struct {
 
 // AddSource appends src to r.Sources if not already present and
 // re-sorts into canonical order H, L, C, A, F. Idempotent.
+//
+// Most callers should use AddContribution instead — it captures the
+// per-source detail and calls AddSource as a side-effect.
 func (r *PackageRow) AddSource(src SourceCode) {
 	for _, s := range r.Sources {
 		if s == src {
@@ -180,4 +210,51 @@ func (r *PackageRow) AddSource(src SourceCode) {
 // is "no opinion" — r.Health unchanged.
 func (r *PackageRow) MergeHealth(h Health) {
 	r.Health = worseHealth(r.Health, h)
+}
+
+// AddContribution merges a per-source contribution into r. Updates:
+//  1. r.Sources (idempotent, canonical order — via AddSource)
+//  2. r.Contributors (idempotent on Source: subsequent contributions
+//     from the same Source merge — Health worst-of, other fields
+//     keep first-seen non-empty values)
+//  3. Aggregated fields (r.Health worst-of, r.Version/AppVersion
+//     first-seen wins) — preserves the existing on-wire semantics
+//     for simple consumers that ignore Contributors.
+func (r *PackageRow) AddContribution(c SourceContribution) {
+	r.AddSource(c.Source)
+	r.MergeHealth(c.Health)
+	if r.Version == "" {
+		r.Version = c.Version
+	}
+	if r.AppVersion == "" {
+		r.AppVersion = c.AppVersion
+	}
+	for i := range r.Contributors {
+		if r.Contributors[i].Source != c.Source {
+			continue
+		}
+		existing := &r.Contributors[i]
+		existing.Health = worseHealth(existing.Health, c.Health)
+		if existing.Version == "" {
+			existing.Version = c.Version
+		}
+		if existing.AppVersion == "" {
+			existing.AppVersion = c.AppVersion
+		}
+		if existing.ReleaseName == "" {
+			existing.ReleaseName = c.ReleaseName
+		}
+		if existing.ReleaseNamespace == "" {
+			existing.ReleaseNamespace = c.ReleaseNamespace
+		}
+		if existing.DeclarationName == "" {
+			existing.DeclarationName = c.DeclarationName
+		}
+		if existing.DeclarationNamespace == "" {
+			existing.DeclarationNamespace = c.DeclarationNamespace
+		}
+		return
+	}
+	r.Contributors = append(r.Contributors, c)
+	sortContributors(r.Contributors)
 }

--- a/pkg/packages/types.go
+++ b/pkg/packages/types.go
@@ -11,8 +11,6 @@
 //	F — Flux HelmRelease / Kustomization declaration
 package packages
 
-import "time"
-
 // Source codes returned in PackageRow.Sources. Stable on-wire — agents,
 // SPAs, and other consumers rely on these single characters.
 const (
@@ -86,8 +84,10 @@ type Declaration struct {
 	ChartVersion string `json:"chartVersion,omitempty"`
 	// Status as the GitOps controller sees it. One of:
 	// healthy|degraded|unhealthy|unknown — caller maps from their
-	// vocabulary (Argo: Healthy/Progressing/Degraded/Suspended/Missing/Unknown;
-	// Flux: Ready/Stalled/Reconciling/Suspended).
+	// vocabulary. Argo: Healthy/Progressing/Degraded/Suspended/Missing/
+	// Unknown. Flux: derived from Ready and Stalled conditions; transient
+	// reasons collapse to degraded. Suspended (spec.suspend) is not yet
+	// surfaced separately.
 	Status string `json:"status"`
 }
 
@@ -129,7 +129,4 @@ type PackageRow struct {
 	// itself in that case. Lets the SPA render with appropriate framing
 	// ("cert-manager.io CRDs detected") vs a real chart row.
 	FromCRDGroup string `json:"fromCRDGroup,omitempty"`
-	// AggregatedAt is the time Aggregate ran. Useful for cache freshness
-	// debugging in distributed traces.
-	AggregatedAt time.Time `json:"aggregatedAt"`
 }


### PR DESCRIPTION
## Summary

A unified `/api/packages` REST endpoint and `list_packages` MCP tool that aggregate "what's installed" signals across **5 sources** into one source-attributed view, ready for both Radar standalone (MCP agents) and Radar Hub fan-in.

## Sources merged

`H` Helm release · `L` workload labels (`helm.sh/chart`, `meta.helm.sh/release-name`) · `C` CRD groups (mapped via `crdGroupToChart`) · `A` Argo Application · `F` Flux HelmRelease/Kustomization. The same install showing in 3 sources collapses to one row with `sources: [H, L, C]`.

## Architecture

- New `pkg/packages/` — pure Go, zero `internal/` imports. Mirrors `pkg/audit` shape (embeddable, reusable). Hub fan-in imports this package directly.
- `server.ListPackages(ctx, params)` is the single entry point. REST handler and MCP tool both call through it for the 60s `(user, namespaces)`-keyed cache + per-source error attribution.

## API surface (typed for Hub)

- `SourceCode` and `Health` are defined string types with constants — typos no longer compile through, and invalid `?source=` values at the HTTP/MCP boundary return 400 instead of an empty list.
- `PackageRow.Contributors []SourceContribution` carries each source's pre-merge view: per-source `Health`, `Version`, `ReleaseName/Namespace`, plus `DeclarationName/Namespace` for Argo/Flux deep-links and a `Cluster` field for Hub multi-cluster fan-in. Aggregated row fields (worst-of `Health`, first-wins `Version`) are unchanged for simple consumers.
- `(*PackageRow).AddContribution(SourceContribution)` is the public merge primitive. Hub fan-in stamps `Cluster` per per-cluster contribution; the dedupe key is `(Source, Cluster)`, so the same chart from multiple clusters keeps per-cluster Argo App identity instead of collapsing.
- `(*PackageRow).Contributor(SourceCode)` lookup helper for single-cluster consumers.
- `SourceError.AffectedNamespaces []string` carries structured per-namespace scope on partial-RBAC failures — Hub no longer needs to reverse-parse the free-text `Error`.

## User-scoped cache + multi-namespace

- Cache key is `(user, sorted namespaces)` — Helm reads use RBAC impersonation, so two users hitting the same namespace must not share an entry. Behavioral test pre-populates two distinct user entries and verifies isolation.
- Multi-namespace requests iterate Helm per-namespace (a user with access to ns-a but not ns-b keeps ns-a visibility instead of falling back to cluster-wide RBAC).
- Empty (non-nil) namespaces — auth-restricted to nothing — short-circuits to an empty response, never touching the cache or backend.
- LRU cap at 256 entries (oldest-eviction) so the map can't grow unbounded under multi-user Hub mode. Test exercises the eviction-at-insert path with a small fixture.

## Graceful degradation

Per-source failures attribute to `sourcesErrored` without breaking the response: Helm RBAC denial → 403 with `affectedNamespaces`, nil Helm client, GitOps informer errors. Missing GitOps CRDs (Argo/Flux not installed) are filtered out of `sourcesErrored` — pinned by `TestIsMissingCRDErr_PinsK8scoreErrorString`. The MCP docstring tells the agent that `sourcesErrored` means partial results, so it doesn't confidently answer "your cluster has no Helm releases" when the user actually lacks RBAC.

Argo `Missing` health surfaces as `Degraded` (not `Unknown`) so "should exist but doesn't" gets a real signal rather than being indistinguishable from "haven't observed yet."

## Cross-cluster gotcha

Argo CD running in cluster A deploying to cluster B → B's `/api/packages` won't include those Argo Applications (CRDs not installed in B). Documented in `pkg/packages/types.go`. Accepted v1 limitation — Hub's fan-in addresses fleet-level visibility.

## Tests

- **`pkg/packages/`**: merge scenarios (Helm+labels+CRDs collapse, Karpenter labels+CRDs without Helm RBAC, raw-YAML CRDs, unknown CRD groups, Argo+Helm overlap, Flux Kustomization standalone), GitOps parsers (Argo single/multi-source, Flux v2 layouts, Stalled overrides Ready, transient-reason → degraded), worst-of-health ranking + alias collapse + 3-contributor merge, canonical source order across all 5 codes, Contributors per-source detail + collapse-across-workloads + CRD-only contribution shape, Hub fan-in cluster-disambiguation.
- **`internal/server/`**: pinned k8score "unknown resource kind" string, cache-key user/namespace differentiation, source canonical ordering, chart substring matching, **behavioral tests**: user-scoped cache isolation (security guard), empty-namespace short-circuit, cached-response timestamp fidelity, cache-cap eviction-at-insert, invalid `?source=` rejected with `ErrInvalidSourceCode`, `?source=A` matches any-contributor semantic.

## Live-tested across 5 clusters

| Cluster | Total | Sources | Notes |
|---------|-------|---------|-------|
| GKE nonprod us-east1 | 43 | H, L, A | Argo deep-link data populated |
| AWS nonprod us-east-1 | 8 | H, L, **F** | Flux Kustomization `declarationName` populated |
| AWS prod us-east-1 | 8 | H, L | cert-manager, ingress-nginx, prometheus all healthy |
| AWS mgmt us-east-1 | 2 | H, L | koala-agent + aws-vpc-cni |
| GKE management me-west1 | 85 | H, L, A | 64 Argo apps, real degraded/unhealthy signals |

Verified on live clusters: endpoint shape, Contributors with per-source Argo+Flux deep-link identity, multi-namespace filter, valid+invalid source filter, chart substring filter, real degraded/unhealthy signal flow.

## Hub follow-on (separate repos)

- `radar-hub` backend: collapses 5-fan-out per cluster into one call against `/api/packages`, then per-cluster cell rendering.
- Hub MCP `fleet_list_packages`: first fleet-native MCP tool, drives off the per-cluster Radar tool.
- Hub SPA: per-source breakdown tooltip, drift badge, "managed by Argo →" deep-links — all enabled by `Contributors` + `Cluster` field. No further OSS changes needed.