### PR TITLE
k8s-ui: visual-review follow-ups — FilterPill chip, ClusterName headline, audit EmptyState CTA

### DIFF
--- a/packages/k8s-ui/src/components/audit/AuditFindingsTable.tsx
+++ b/packages/k8s-ui/src/components/audit/AuditFindingsTable.tsx
@@ -243,20 +243,26 @@ export function AuditFindingsTable({ groups, findings, checks, onResourceClick, 
           )}
         </div>
 
-        {/* Row 2: Filter chips */}
-        <div className="flex flex-wrap items-center gap-1">
+        {/* Row 2: Filter chips — three groups separated by dividers (All | Categories | Severities | Frameworks). */}
+        <div className="flex flex-wrap items-center gap-1.5">
           <FilterPill label="All" active={!categoryFilter && !severityFilter && !frameworkFilter} onClick={() => { setCategoryFilter(null); setSeverityFilter(null); setFrameworkFilter(null) }} />
-          <span className="w-px h-4 bg-theme-text-tertiary/30 mx-3" />
+          <span className="w-px h-5 bg-theme-border mx-2" />
           {CATEGORIES.map(cat => (
             <FilterPill key={cat} label={cat} active={categoryFilter === cat} onClick={() => setCategoryFilter(categoryFilter === cat ? null : cat)} />
           ))}
-          <span className="w-px h-4 bg-theme-text-tertiary/30 mx-3" />
+          <span className="w-px h-5 bg-theme-border mx-2" />
           {SEVERITIES.map(sev => (
-            <FilterPill key={sev} label={sev === 'danger' ? 'Critical' : 'Warning'} active={severityFilter === sev} onClick={() => setSeverityFilter(severityFilter === sev ? null : sev)} />
+            <FilterPill
+              key={sev}
+              label={sev === 'danger' ? 'Critical' : 'Warning'}
+              active={severityFilter === sev}
+              tone={sev === 'danger' ? 'danger' : 'warn'}
+              onClick={() => setSeverityFilter(severityFilter === sev ? null : sev)}
+            />
           ))}
           {frameworks.length > 0 && (
             <>
-              <span className="w-px h-4 bg-theme-text-tertiary/30 mx-3" />
+              <span className="w-px h-5 bg-theme-border mx-2" />
               {frameworks.map(fw => (
                 <FilterPill key={fw} label={fw} active={frameworkFilter === fw} onClick={() => setFrameworkFilter(frameworkFilter === fw ? null : fw)} />
               ))}
@@ -283,6 +289,15 @@ export function AuditFindingsTable({ groups, findings, checks, onResourceClick, 
             variant="card"
             headline="No findings match the current filters"
             body="Try clearing one or more filters to see more results."
+            action={
+              <button
+                type="button"
+                onClick={() => { setCategoryFilter(null); setSeverityFilter(null); setFrameworkFilter(null); setSearchTerm('') }}
+                className="badge badge-sm border border-theme-border bg-theme-elevated text-theme-text-primary hover:bg-theme-hover transition-colors"
+              >
+                Clear all filters
+              </button>
+            }
           />
         )
       ) : namespacedGroups ? (

--- a/packages/k8s-ui/src/components/ui/FilterPill.tsx
+++ b/packages/k8s-ui/src/components/ui/FilterPill.tsx
@@ -41,17 +41,19 @@ interface Props {
   className?: string
 }
 
+// Always-bordered chip: same border-width in both states keeps geometry stable
+// when toggling, and a visible inactive border is what makes pills read as
+// pressable chips instead of plain links. Active states fill the chip and
+// promote the border to a tone-matched ring.
 const TONE_ACTIVE: Record<FilterPillTone, string> = {
-  // Neutral matches Radar's pre-existing style (preserves back-compat with
-  // AuditFindingsTable's previous local toggle).
-  neutral: 'bg-theme-text-primary/10 text-theme-text-primary font-medium',
-  danger:  'bg-red-500/15 text-red-700 dark:text-red-300 font-medium',
-  warn:    'bg-amber-500/15 text-amber-800 dark:text-amber-300 font-medium',
-  ok:      'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 font-medium',
-  brand:   'bg-[var(--color-brand-50)] text-theme-text-primary ring-1 ring-inset ring-[var(--color-radar-accent)] dark:bg-[var(--color-brand-950)] font-medium',
+  neutral: 'bg-theme-text-primary/10 border-theme-text-primary/25 text-theme-text-primary',
+  danger:  'bg-red-500/15 border-red-500/40 text-red-700 dark:text-red-300',
+  warn:    'bg-amber-500/15 border-amber-500/40 text-amber-800 dark:text-amber-300',
+  ok:      'bg-emerald-500/15 border-emerald-500/40 text-emerald-700 dark:text-emerald-300',
+  brand:   'bg-[var(--color-brand-50)] border-[var(--color-radar-accent)] text-theme-text-primary dark:bg-[var(--color-brand-950)]',
 }
 
-const INACTIVE = 'text-theme-text-tertiary hover:text-theme-text-secondary hover:bg-theme-hover'
+const INACTIVE = 'border-theme-border-light text-theme-text-secondary hover:border-theme-border hover:text-theme-text-primary hover:bg-theme-hover/50'
 
 export function FilterPill({
   label,
@@ -73,7 +75,7 @@ export function FilterPill({
       aria-pressed={active}
       aria-label={ariaLabel}
       className={clsx(
-        'inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs transition-colors',
+        'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors',
         'focus-visible:ring-2 focus-visible:ring-theme-text-primary/20 focus-visible:outline-none',
         active ? TONE_ACTIVE[tone] : INACTIVE,
         className,

--- a/web/src/components/home/ClusterHealthCard.tsx
+++ b/web/src/components/home/ClusterHealthCard.tsx
@@ -10,7 +10,7 @@ import { clsx } from 'clsx'
 import { formatCPUMillicores, formatMemoryMiB } from '../../utils/format'
 import { useCapabilitiesContext } from '../../contexts/CapabilitiesContext'
 import { MCPSetupDialog } from './MCPSetupDialog'
-import { pluralize } from '@skyhook-io/k8s-ui'
+import { pluralize, parseContextName } from '@skyhook-io/k8s-ui'
 import { Tooltip } from '../ui/Tooltip'
 
 interface ClusterHealthCardProps {
@@ -158,6 +158,13 @@ export function ClusterHealthCard({
     { kind: 'cronjobs', label: 'CronJobs', icon: Clock, total: counts.cronJobs.total, subtitle: `${counts.cronJobs.active} active` },
   ]
   const platformInfo = getPlatformInfo(cluster.platform)
+  // The raw cluster.name is the kubeconfig context (e.g.
+  // `gke_koalabackend_us-east1-b_nonprod-cluster-us-east1`). That string
+  // is the user's primary orientation cue, but the bit they actually
+  // recognize is the short clusterName. We promote that, push the raw
+  // path into a tooltip, and surface project/region as muted metadata.
+  const parsedContext = parseContextName(cluster.name || '')
+  const headlineName = parsedContext.clusterName || cluster.name || 'Cluster'
 
   return (
     <div className="rounded-xl bg-theme-surface shadow-theme-sm overflow-hidden">
@@ -166,22 +173,38 @@ export function ClusterHealthCard({
         <div className="flex items-stretch gap-8">
           {/* Left: Cluster info */}
           <div className="flex flex-col justify-center w-[300px] shrink-0 pr-8 border-r border-theme-border/50">
-            <div className="flex items-center gap-2 mb-2">
+            <div className="flex items-center gap-2 mb-1.5">
               {platformInfo.icon ? (
                 <img src={platformInfo.icon} alt={platformInfo.name} className="w-5 h-5 object-contain" />
               ) : (
                 <Server className="w-4 h-4 text-theme-text-tertiary" />
               )}
-              <span className="text-xs text-theme-text-secondary">{platformInfo.name}</span>
+              <span className="text-xs text-theme-text-secondary truncate">{platformInfo.name}</span>
             </div>
-            <h2 className="text-sm font-semibold text-theme-text-primary break-all mb-1" title={cluster.name}>
-              {cluster.name || 'Cluster'}
+            <h2
+              className="text-xl font-semibold text-theme-text-primary truncate mb-1.5 leading-tight"
+              title={cluster.name}
+            >
+              {headlineName}
             </h2>
-            <div className="flex flex-col gap-1 text-xs text-theme-text-tertiary">
+            <div className="flex flex-col gap-0.5 text-xs text-theme-text-tertiary">
+              {(parsedContext.account || parsedContext.region) && (
+                <span className="truncate font-mono" title={[parsedContext.account, parsedContext.region].filter(Boolean).join(' · ')}>
+                  {[parsedContext.account, parsedContext.region].filter(Boolean).join(' · ')}
+                </span>
+              )}
               {cluster.version && (
                 <span>Kubernetes {cluster.version}</span>
               )}
               <span><span className="font-mono">{counts.namespaces}</span> namespaces</span>
+              {cluster.name && cluster.name !== headlineName && (
+                <span
+                  className="font-mono text-[10px] text-theme-text-disabled break-all leading-snug pt-0.5"
+                  title={cluster.name}
+                >
+                  {cluster.name}
+                </span>
+              )}
             </div>
             {nodeVersionSkew && (
               <Tooltip


### PR DESCRIPTION
## Summary

Visual-review follow-ups on the primitives merged in #533. Three small, scoped polish passes:

### `FilterPill` — chip-shaped, with a real active state

Always-bordered, padding bumped from `px-2 py-0.5` → `px-2.5 py-1`, font-medium baseline. Inactive pills now read as pressable chips instead of link text; active states fill the chip and promote the border to a tone-matched ring (e.g. red border on `tone='danger'` active). Severity filters in `AuditFindingsTable` (Critical / Warning) wire up `tone='danger'` / `tone='warn'` so the active state encodes severity.

Before: in dark mode, "Security | Reliability | Efficiency" was nearly invisible flat text and the active "All" was a barely-perceptible bg shift. After: every chip has a visible frame in both themes.

### `AuditFindingsTable` filter row — group spacing + filtered EmptyState CTA

Dividers between the three filter groups (categories | severities | frameworks) bumped from `h-4 mx-3` → `h-5 mx-2`, gap between pills from `gap-1` → `gap-1.5`. Reads as three groups instead of one undifferentiated row.

The filtered `EmptyState` gets an `action` prop wired to a "Clear all filters" button so the no-results state isn't a dead end.

### `ClusterHealthCard` — promote the short cluster name

The raw `cluster.name` is the kubeconfig context (e.g. `gke_koalabackend_us-east1-b_nonprod-cluster-us-east1`) — long, the user's primary orientation cue, but the *actually recognizable* part is the short clusterName at the end. Now uses `parseContextName` to:

- Promote the parsed short name to an XL bold headline
- Surface project / region as a muted `account · region` line
- Keep the raw kubeconfig path visible as the smallest mono footer (plus title-attr tooltip on the headline) — visible, just demoted

## Verification

- `tsc --noEmit`: clean
- `vitest run` in `packages/k8s-ui`: 55/55 pass
- `go build ./...`: clean
- Visually verified light + dark mode on Audit page (FilterPill, EmptyState filtered + healthy) and Home page (ClusterHealthCard); see `.playwright-mcp/visual-test/20260426-101203/` for before/after screenshots if you want them.

## Out of scope (filed for follow-up)

- ResourcesView "No prometheusrules found" lowercase-plural empty-state copy — line dates to March (commit 18dd79fa), pre-existing; not introduced by the pluralize sweep in #533.
- ContextSwitcher dropdown row density.