### PR TITLE
fix(exec): classify "exit code 127" as shell-not-found

### DIFF
--- a/internal/server/exec.go
+++ b/internal/server/exec.go
@@ -376,6 +376,14 @@ func isShellNotFoundError(errMsg string) bool {
 		"oci runtime exec failed",
 		"executable not found",
 		"not found in $path",
+		// POSIX exit 127 = "command not found". Some runtime/kubelet
+		// combinations surface a missing shell as "command terminated with
+		// exit code 127" via the SPDY stream rather than as a structured
+		// runtime error. Our default exec wraps in `sh -c <script>`, so an
+		// exit-127 from that wrapper means `sh` itself couldn't run — i.e.
+		// shell missing. The drift canary picked this up against distroless
+		// coredns; see skyhook-io/radar#456 (comment thread).
+		"exit code 127",
 	}
 	errLower := strings.ToLower(errMsg)
 	for _, pattern := range patterns {

--- a/internal/server/exec_test.go
+++ b/internal/server/exec_test.go
@@ -84,6 +84,62 @@ func TestDefaultShellScript(t *testing.T) {
 	}
 }
 
+// TestIsShellNotFoundError pins the substring patterns used to classify
+// "shell missing" errors so the frontend renders the "Start debug container"
+// CTA instead of a generic "Failed to connect". Patterns must stay broad
+// enough to catch each container runtime's wording — see comments inline.
+func TestIsShellNotFoundError(t *testing.T) {
+	tests := []struct {
+		name   string
+		errMsg string
+		want   bool
+	}{
+		{
+			name:   "containerd: executable file not found",
+			errMsg: `OCI runtime exec failed: exec failed: unable to start container process: exec: "sh": executable file not found in $PATH: unknown`,
+			want:   true,
+		},
+		{
+			name:   "no such file or directory",
+			errMsg: `no such file or directory`,
+			want:   true,
+		},
+		{
+			name:   "exit code 127 from sh -c wrapper",
+			errMsg: `command terminated with exit code 127`,
+			want:   true,
+		},
+		{
+			name:   "case-insensitive OCI runtime",
+			errMsg: `oci runtime exec failed`,
+			want:   true,
+		},
+		{
+			name:   "non-127 exit codes are not classified as shell-missing",
+			errMsg: `command terminated with exit code 1`,
+			want:   false,
+		},
+		{
+			name:   "unrelated transport error",
+			errMsg: `unable to upgrade connection: timeout`,
+			want:   false,
+		},
+		{
+			name:   "permission denied is not shell-missing",
+			errMsg: `forbidden: pods "foo" is forbidden: User cannot exec`,
+			want:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isShellNotFoundError(tc.errMsg); got != tc.want {
+				t.Errorf("isShellNotFoundError(%q) = %v, want %v", tc.errMsg, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestLooksLikeShellNotFound covers the drift canary. The function is a
 // broader heuristic than isShellNotFoundError and intentionally tolerates
 // some false positives — the goal is to log a breadcrumb when an error


### PR DESCRIPTION
## Summary

Reported on #456 (comment): pod terminal exec into distroless pods (e.g. `kube-system/coredns`) regressed in 1.5.0 / 1.5.1 — the terminal opens but renders nothing, instead of the friendly "Shell not available — Start debug container" CTA users got in 1.4.8.

#456 changed the default exec command from `["/bin/sh"]` to `["sh", "-c", <detect-and-exec-bash/ash/sh script>]`. Wrapping in `sh -c` shifted how some runtime/kubelet combinations report a missing shell: instead of the structured `executable file not found in $PATH`, they surface `command terminated with exit code 127` via the SPDY stream. None of `isShellNotFoundError`'s substring patterns matched that wording, so the frontend fell through to the generic `exec_error` branch and showed "Failed to connect" with the raw error.

The drift canary added in 869c0e09 (`looksLikeShellNotFound`) flagged this correctly — POSIX 127 is the reserved exit code for "command not found", and from a `sh -c <script>` wrapper an exit-127 means `sh` itself couldn't run, i.e. shell missing. This PR promotes that signal into the classifier so the frontend gets `errorType: "shell_not_found"` and renders the "Start debug container" CTA. The canary stays in place to keep watching for future kubelet wording drift.

## Why this is safe

- **`?shell=<binary>` override**: kubelet returns `executable file not found` when the binary is missing, not `exit code 127` — no overlap.
- **Default `sh -c <built-in script>`**: exit 127 from the wrapper means `sh` itself couldn't be exec'd → genuinely shell-not-found.
- **`--pod-shell-default` fallback**: a power-user-supplied command could in theory exit 127 for unrelated reasons. Worst-case false positive is showing the "Start debug container" CTA — acceptable.

## Tests

Adds `TestIsShellNotFoundError` (table-driven) pinning the classifier contract: the new exit-127 pattern, the existing patterns (`executable file not found`, `no such file or directory`, OCI runtime), plus negative cases (non-127 exits, transport timeouts, permission denied). All exec-related tests pass locally.