### PR TITLE
ui: visual-review polish across drawer, traffic, secrets, certs, switcher

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -390,7 +390,7 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
     { key: 'name', label: 'Name' },
     { key: 'namespace', label: 'Namespace', width: 'w-48' },
     { key: 'status', label: 'Ready', width: 'w-24' },
-    { key: 'domains', label: 'Domains', width: 'w-48' },
+    { key: 'domains', label: 'Domains', width: 'w-56' },
     { key: 'issuer', label: 'Issuer', width: 'w-36', hideOnMobile: true },
     { key: 'expires', label: 'Expires', width: 'w-24', tooltip: 'Days until certificate expires' },
     { key: 'age', label: 'Age', width: 'w-24' },

--- a/packages/k8s-ui/src/components/resources/renderers/SecretRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/SecretRenderer.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
-import { AlertTriangle, Copy, Check, Shield, Pencil, Save, XCircle, RefreshCw } from 'lucide-react'
+import { AlertTriangle, Copy, Check, Shield, Pencil, Save, XCircle, RefreshCw, Eye, EyeOff } from 'lucide-react'
 import { clsx } from 'clsx'
 import { stringify as yamlStringify } from 'yaml'
 import { Section, PropertyList, Property, AlertBanner } from '../../ui/drawer-components'
@@ -191,8 +191,13 @@ export function SecretRenderer({ data, certificateInfo, resourceData, onSaveSecr
                     {!isEditing && (
                       <button
                         onClick={() => toggleReveal(key)}
-                        className="text-xs text-theme-text-secondary hover:text-theme-text-primary px-1.5 py-0.5 rounded hover:bg-theme-elevated transition-colors"
+                        className="inline-flex items-center gap-1 text-xs text-theme-text-secondary hover:text-theme-text-primary px-1.5 py-0.5 rounded hover:bg-theme-elevated transition-colors"
                       >
+                        {revealed.has(key) ? (
+                          <EyeOff className="w-3.5 h-3.5" />
+                        ) : (
+                          <Eye className="w-3.5 h-3.5" />
+                        )}
                         {revealed.has(key) ? 'Hide' : 'Reveal'}
                       </button>
                     )}

--- a/packages/k8s-ui/src/components/ui/drawer-components.tsx
+++ b/packages/k8s-ui/src/components/ui/drawer-components.tsx
@@ -642,6 +642,17 @@ export function getKindColor(kind: string): string {
   return getKindColorClass(kind)
 }
 
+// In drawer headers, kind sits next to a status pill ("Pod" / "Running"). Both
+// filled creates two pills competing for attention even though kind is just
+// metadata (the user already clicked the resource) and status is the signal.
+// Stripping the fills makes kind read as a label and status as a value.
+export function getKindColorOutline(kind: string): string {
+  return getKindColorClass(kind)
+    .replace(/\b(?:dark:)?bg-\S+/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
 export function formatKindName(kind: string): string {
   const k = kind.toLowerCase()
   const names: Record<string, string> = {

--- a/packages/k8s-ui/src/components/workload/WorkloadView.tsx
+++ b/packages/k8s-ui/src/components/workload/WorkloadView.tsx
@@ -39,7 +39,7 @@ import {
 import { ResourceActionsBar } from '../shared/ResourceActionsBar'
 import { EditableYamlView, SaveSuccessAnimation } from '../shared/EditableYamlView'
 import { ResourceRendererDispatch, getResourceStatus, type RendererOverrides } from '../shared/ResourceRendererDispatch'
-import { getKindColor, formatKindName } from '../ui/drawer-components'
+import { getKindColorOutline, formatKindName } from '../ui/drawer-components'
 
 type TabType = 'overview' | 'timeline' | 'logs' | 'metrics' | 'yaml'
 
@@ -360,7 +360,7 @@ export function WorkloadView({
           {/* Top row: badges and controls */}
           <div className="flex items-center justify-between px-4 pt-3 pb-2">
             <div className="flex items-center gap-2 flex-wrap">
-              <span className={clsx('badge', getKindColor(apiKind))}>
+              <span className={clsx('badge', getKindColorOutline(apiKind))}>
                 {formatKindName(apiKind)}
               </span>
               {status && (
@@ -497,7 +497,7 @@ export function WorkloadView({
               </button>
             </div>
             <div className="flex items-center gap-3 text-sm text-theme-text-secondary">
-              <span className={clsx('badge', getKindColor(apiKind))}>
+              <span className={clsx('badge', getKindColorOutline(apiKind))}>
                 {formatKindName(apiKind)}
               </span>
               {status && (

--- a/web/src/components/ContextSwitcher.tsx
+++ b/web/src/components/ContextSwitcher.tsx
@@ -344,8 +344,8 @@ export function ContextSwitcher({ className = '' }: ContextSwitcherProps) {
                       <div className="border-t border-theme-border-light my-1" />
                     )}
                     {showHeader && (
-                      <div className="px-3 py-1.5 bg-theme-elevated/30">
-                        <span className="text-[10px] text-theme-text-tertiary font-medium">
+                      <div className="px-3 py-1 bg-theme-elevated/60 border-b border-theme-border/60">
+                        <span className="text-[11px] text-theme-text-secondary font-semibold">
                           {headerLabel}
                         </span>
                       </div>
@@ -383,19 +383,19 @@ export function ContextSwitcher({ className = '' }: ContextSwitcherProps) {
                               <span className={`text-sm font-medium truncate ${item.context.isCurrent ? 'text-blue-600 dark:text-blue-400' : 'text-theme-text-primary'}`}>
                                 {item.clusterName}
                               </span>
-                              {item.region && (
-                                <span className="shrink-0 text-[10px] text-theme-text-tertiary bg-theme-elevated px-1 rounded">
-                                  {item.region}
-                                </span>
-                              )}
                               {item.context.isCurrent && (
                                 <span className="shrink-0 text-[9px] text-blue-600 dark:text-blue-400">
                                   ●
                                 </span>
                               )}
+                              {item.region && (
+                                <span className="shrink-0 ml-auto text-[10px] text-theme-text-tertiary bg-theme-elevated px-1 rounded">
+                                  {item.region}
+                                </span>
+                              )}
                             </div>
                             {item.provider && (
-                              <div className="text-[10px] text-theme-text-tertiary truncate mt-0.5" title={item.raw}>
+                              <div className="text-[10px] text-theme-text-tertiary opacity-70 truncate mt-0.5" title={item.raw}>
                                 {item.raw}
                               </div>
                             )}

--- a/web/src/components/traffic/TrafficView.tsx
+++ b/web/src/components/traffic/TrafficView.tsx
@@ -7,10 +7,11 @@ import { TrafficWizard } from './TrafficWizard'
 import { TrafficGraph, type TrafficGraphSelection } from './TrafficGraph'
 import { TrafficFilterSidebar } from './TrafficFilterSidebar'
 import { TrafficFlowListProvider } from './TrafficFlowListContext'
-import { Loader2, RefreshCw, Filter, Plug, ChevronDown, List } from 'lucide-react'
+import { Loader2, RefreshCw, Filter, Plug, ChevronDown, List, Activity, AlertTriangle } from 'lucide-react'
 import { clsx } from 'clsx'
 import { useQueryClient } from '@tanstack/react-query'
 import { useDock } from '../dock'
+import { EmptyState } from '@skyhook-io/k8s-ui'
 
 // Addon types for filtering
 export type AddonMode = 'show' | 'group' | 'hide'
@@ -1168,42 +1169,52 @@ export function TrafficView({ namespaces }: TrafficViewProps) {
               </div>
             </div>
           ) : (
-            <div className="absolute inset-0 flex items-center justify-center">
-              <div className="text-center space-y-2">
-                <Filter className="h-12 w-12 text-theme-text-tertiary mx-auto" />
-                {flowStats.total > 0 && flowStats.shown === 0 ? (
-                  <>
-                    <p className="text-theme-text-secondary">All traffic is filtered out</p>
-                    <p className="text-xs text-theme-text-tertiary">
-                      {flowStats.total} flows hidden by current filters.
-                      <button
-                        onClick={() => {
-                          setHideSystem(false)
-                          setHideExternal(false)
-                          setMinConnections(0)
-                        }}
-                        className="ml-1 text-blue-400 hover:underline"
-                      >
-                        Show all
-                      </button>
-                    </p>
-                  </>
-                ) : flowsData?.warning ? (
-                  <>
-                    <p className="text-theme-text-secondary">Unable to fetch traffic data</p>
-                    <p className="text-xs text-yellow-500 max-w-md">
-                      {flowsData.warning}
-                    </p>
-                  </>
-                ) : (
-                  <>
-                    <p className="text-theme-text-secondary">No traffic observed</p>
-                    <p className="text-xs text-theme-text-tertiary">
-                      Traffic will appear here once connections are made between services
-                    </p>
-                  </>
-                )}
-              </div>
+            <div className="absolute inset-0 flex items-center justify-center px-4">
+              {flowStats.total > 0 && flowStats.shown === 0 ? (
+                <EmptyState
+                  tone="filtered"
+                  variant="card"
+                  icon={Filter}
+                  headline="All traffic is filtered out"
+                  body={`${flowStats.total} ${flowStats.total === 1 ? 'flow' : 'flows'} hidden by current filters.`}
+                  action={
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setHideSystem(false)
+                        setHideExternal(false)
+                        setMinConnections(0)
+                      }}
+                      className="badge badge-sm border border-theme-border bg-theme-elevated text-theme-text-primary hover:bg-theme-hover transition-colors"
+                    >
+                      Show all
+                    </button>
+                  }
+                  className="max-w-md"
+                />
+              ) : flowsData?.warning ? (
+                <EmptyState
+                  tone="neutral"
+                  variant="card"
+                  icon={AlertTriangle}
+                  headline="Unable to fetch traffic data"
+                  body={flowsData.warning}
+                  className="max-w-md"
+                />
+              ) : (
+                <EmptyState
+                  tone="neutral"
+                  variant="card"
+                  icon={Activity}
+                  headline={
+                    sourcesData?.active
+                      ? `Observing via ${sourcesData.active} — no traffic yet`
+                      : 'No traffic observed yet'
+                  }
+                  body="Traffic will appear here once services start communicating."
+                  className="max-w-md"
+                />
+              )}
             </div>
           )}
       </div>


### PR DESCRIPTION
## Summary

Six small visual-review fixes, each addressing a real hierarchy or affordance gap surfaced in dark-mode review of the live nonprod cluster.

### Pod drawer pill hierarchy

In `WorkloadView` (the drawer header used everywhere), the kind pill (\"Pod\") and status pill (\"Running\") were both filled, both bordered, both `font-medium`. For healthy resources both render in green hues — collapsing into \"two green pills\" until you read the text. Kind is metadata (the user already clicked the resource); status is the signal.

New `getKindColorOutline` helper in `drawer-components.tsx` strips the fill classes, giving the kind pill an outline-only treatment that retains its color identity in border + text. Status keeps its filled treatment. Clear hierarchy: outline = label, filled = signal.

### Traffic empty states

The \"no traffic observed\" branch previously used a Filter icon — implies the user's filters caused the emptiness, even when nothing was being seen at all. Misleading.

Refactored to the new `EmptyState` primitive (#533) with three branches:
- **Filtered out**: `tone='filtered'` + Filter icon + \"Show all\" CTA
- **Warning** (`flowsData.warning`): `tone='neutral'` + AlertTriangle icon
- **No traffic yet**: `tone='neutral'` + Activity icon + dynamic headline `\"Observing via {sourceName} — no traffic yet\"`

Connection-failed stays custom (no error tone in EmptyState — that scoping was deliberate in #533).

The dynamic headline matters: it puts the connection status (\"yes, we're hooked up and waiting\") in the place the user is actually looking, not just the small corner pill.

### ContextSwitcher dropdown

Three small changes to the dropdown items and group header:

- Region pill moved to the right of each row (`ml-auto`), so the cluster name has uninterrupted left-aligned scan and the region floats as a tag
- Raw kubeconfig context line gets `opacity-70` on top of tertiary — quieter without inventing a new color tier; still copy/pasteable via tooltip
- Group header (\"GKE · blitz-prod-404612\") bumps to `text-[11px] font-semibold` on `bg-theme-elevated/60` with a thin bottom border. Reads as a deliberate section divider instead of a default-looking small grey label.

### Secret Reveal eye icon

Per #533's review: the muted \"Reveal\" buttons read as text. Keeping the deliberate-friction muted-color treatment (the AlertBanner's cautionary tone shouldn't compete with a loud CTA) but adding an Eye / EyeOff icon makes the action scannable as a button, not dead text.

### Certificates list — Domains column

Widened from `w-48` (192px) to `w-56` (224px) to fit typical production FQDNs without ellipsis truncation. Tooltip on hover still handles the long tail.

## Test plan

- [x] `make tsc` clean
- [x] `/visual-test` against live nonprod cluster: all five UI areas verified — context switcher dropdown, traffic \"no traffic yet\" empty state, pod drawer header pill hierarchy, certificates list domains column, secret drawer reveal/hide eye icon toggle
- [x] No console errors during walkthrough