### PR TITLE
fix(k8s-ui): ResourceBar empty track invisible — wrong theme token

### DIFF
--- a/packages/k8s-ui/src/components/ui/ResourceBar.tsx
+++ b/packages/k8s-ui/src/components/ui/ResourceBar.tsx
@@ -40,7 +40,7 @@ export function ResourceBar({ used, total, percent, colorScheme = 'utilization',
         </span>
       </div>
       <div className="relative">
-        <div className="h-1.5 rounded-full border border-theme-border bg-theme-bg-elevated overflow-hidden">
+        <div className="h-1.5 rounded-full border border-theme-border bg-theme-elevated overflow-hidden">
           <div
             className={clsx('h-full rounded-full transition-[width] duration-300 ease-out', getBarColor(percent, colorScheme))}
             style={{ width: `${Math.min(percent, 100)}%` }}


### PR DESCRIPTION
## Summary

`ResourceBar.tsx:43` referenced `bg-theme-bg-elevated`, which isn't a real Tailwind token in our theme — `tailwind-theme.css` defines `--color-theme-elevated`, not `--color-theme-bg-elevated`. The class produced no rule, so the bullet-graph bar's empty track was transparent and fell through to the row background. The bar then read as a colored fill sitting directly on the table row, instead of fill-on-track.

The token everyone else uses is `bg-theme-elevated` (30+ refs across the codebase). One-character fix.

## Context

Surfaced while investigating discussion #478 — a user reported that the vertical request markers had disappeared from Pods-list bars. That regression turned out to be the Tailwind v4 `@source` scan miss already fixed in #522. While verifying the marker fix, this separate latent bug — present since the bars were originally introduced in #191 — became visible.

## Verification

`/visual-test` against a live GKE cluster, light + dark mode, on the Pods list (autopush ns) and Nodes list. The bar's empty track now renders as the elevated surface in both modes, restoring the bullet-graph visual hierarchy. Markers continue to render at the correct position (e.g. req=100m / lim=1000m → marker at 10%). No console errors.