### PR TITLE
fix(helm): in-cluster Helm + Cloud role gates + role-aware UI

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -26,6 +26,10 @@ const (
 	RoleOwner  = pkgauth.RoleOwner
 )
 
+// ErrCodeCloudRoleInsufficient is re-exported from pkg/auth so handlers
+// don't have to import the package directly to write the wire value.
+const ErrCodeCloudRoleInsufficient = pkgauth.ErrCodeCloudRoleInsufficient
+
 // Re-export functions from pkg/auth
 var (
 	UserFromContext          = pkgauth.UserFromContext

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -13,9 +13,18 @@ type Session = pkgauth.Session
 type SessionRevoker = pkgauth.SessionRevoker
 type UserPermissions = pkgauth.UserPermissions
 type PermissionCache = pkgauth.PermissionCache
+type CloudRole = pkgauth.CloudRole
 
 // Re-export constants from pkg/auth
 const DefaultCookieName = pkgauth.DefaultCookieName
+
+// Cloud role constants — re-exported from pkg/auth.
+const (
+	RoleNone   = pkgauth.RoleNone
+	RoleViewer = pkgauth.RoleViewer
+	RoleMember = pkgauth.RoleMember
+	RoleOwner  = pkgauth.RoleOwner
+)
 
 // Re-export functions from pkg/auth
 var (
@@ -29,4 +38,6 @@ var (
 	NewSessionID             = pkgauth.NewSessionID
 	ParseSessionCookie       = pkgauth.ParseSessionCookie
 	ClearSessionCookie       = pkgauth.ClearSessionCookie
+	CloudRoleFromGroups      = pkgauth.CloudRoleFromGroups
+	CloudRoleFromContext     = pkgauth.CloudRoleFromContext
 )

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -25,6 +25,7 @@ import (
 	"helm.sh/helm/v3/pkg/releaseutil"
 	"helm.sh/helm/v3/pkg/repo"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
 )
 
 // HTTP client for ArtifactHub requests
@@ -149,7 +150,7 @@ func (c *Client) buildActionConfig(namespace, username string, groups []string) 
 
 	getter, err := c.restClientGetter(namespace, username, groups)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to build helm RESTClientGetter: %w", err)
 	}
 
 	if err := actionConfig.Init(getter, namespace, "secrets", log.Printf); err != nil {
@@ -162,22 +163,45 @@ func (c *Client) buildActionConfig(namespace, username string, groups []string) 
 	return actionConfig, nil
 }
 
-// restClientGetter picks between two RESTClientGetter strategies:
+// restClientGetter picks the RESTClientGetter strategy for this client.
+// Caller must hold c.mu (read or write). Reads global k8s package state
+// (rest.Config, current context); pure logic lives in
+// buildRESTClientGetter so it can be tested without those globals.
+func (c *Client) restClientGetter(namespace, username string, groups []string) (genericclioptions.RESTClientGetter, error) {
+	return buildRESTClientGetter(restClientGetterParams{
+		kubeconfig:     c.kubeconfig,
+		restConfig:     k8s.GetConfig(),
+		currentContext: k8s.GetContextName(),
+		namespace:      namespace,
+		username:       username,
+		groups:         groups,
+	})
+}
+
+type restClientGetterParams struct {
+	kubeconfig     string
+	restConfig     *rest.Config
+	currentContext string
+	namespace      string
+	username       string
+	groups         []string
+}
+
+// buildRESTClientGetter is the pure logic behind Client.restClientGetter.
+// Two strategies:
 //
 //   - kubeconfig path is set: hand Helm a ConfigFlags pointing at that
 //     single file. This is the dominant OSS path (kubectl plugin /
 //     standalone binary on a laptop with ~/.kube/config).
-//   - kubeconfig path is empty: hand Helm the rest.Config Radar
-//     already resolved at boot. Fires for in-cluster deploys (Hub
-//     mode, OSS Helm-chart deploy — no ~/.kube/config in the pod) and
-//     for multi-source kubeconfig modes (--kubeconfig-dir / multi-path
+//   - kubeconfig path is empty: hand Helm the rest.Config Radar already
+//     resolved at boot. Fires for in-cluster deploys (Hub mode, OSS
+//     Helm-chart deploy — no ~/.kube/config in the pod) and for
+//     multi-source kubeconfig modes (--kubeconfig-dir / multi-path
 //     KUBECONFIG, where there's no single file path to hand Helm).
-//
-// Caller must hold c.mu (read or write).
-func (c *Client) restClientGetter(namespace, username string, groups []string) (genericclioptions.RESTClientGetter, error) {
-	if c.kubeconfig == "" {
-		if cfg := k8s.GetConfig(); cfg != nil {
-			return newRESTConfigGetter(cfg, namespace, username, groups), nil
+func buildRESTClientGetter(p restClientGetterParams) (genericclioptions.RESTClientGetter, error) {
+	if p.kubeconfig == "" {
+		if p.restConfig != nil {
+			return newRESTConfigGetter(p.restConfig, p.namespace, p.username, p.groups), nil
 		}
 		// No kubeconfig path AND no resolved rest.Config — no point in
 		// handing Helm a getter that would fall through to localhost:8080.
@@ -185,8 +209,7 @@ func (c *Client) restClientGetter(namespace, username string, groups []string) (
 		return nil, fmt.Errorf("helm: no kubeconfig path and no resolved rest.Config available")
 	}
 
-	// Use RESTClientGetter for kubeconfig.
-	// NOTE: Use false for usePersistentConfig to avoid caching issues during context switches.
+	// usePersistentConfig=false avoids caching issues across context switches.
 	configFlags := genericclioptions.NewConfigFlags(false)
 	// Override the default discovery cache dir ($HOME/.kube/cache) to a writable path
 	// when running on a read-only filesystem (e.g. in-cluster with readOnlyRootFilesystem).
@@ -194,21 +217,20 @@ func (c *Client) restClientGetter(namespace, username string, groups []string) (
 		kubeCacheDir := "/tmp/helm/kube-cache"
 		configFlags.CacheDir = &kubeCacheDir
 	}
-	configFlags.KubeConfig = &c.kubeconfig
-	if namespace != "" {
-		configFlags.Namespace = &namespace
+	configFlags.KubeConfig = &p.kubeconfig
+	if p.namespace != "" {
+		configFlags.Namespace = &p.namespace
 	}
 
-	// Use Explorer's current context (in-memory) instead of kubeconfig's current-context.
-	// This ensures Helm uses the same context as the rest of Explorer after context switches.
-	currentContext := k8s.GetContextName()
-	if currentContext != "" && currentContext != "in-cluster" {
-		configFlags.Context = &currentContext
+	// Use Explorer's current context (in-memory) instead of kubeconfig's
+	// current-context, so Helm tracks Explorer through context switches.
+	if p.currentContext != "" && p.currentContext != "in-cluster" {
+		configFlags.Context = &p.currentContext
 	}
 
-	if username != "" {
-		configFlags.Impersonate = &username
-		configFlags.ImpersonateGroup = &groups
+	if p.username != "" {
+		configFlags.Impersonate = &p.username
+		configFlags.ImpersonateGroup = &p.groups
 	}
 
 	return configFlags, nil

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -126,13 +126,67 @@ func ReinitClient(kubeconfig string) error {
 
 // getActionConfig creates a new action configuration for the given namespace
 func (c *Client) getActionConfig(namespace string) (*action.Configuration, error) {
+	return c.buildActionConfig(namespace, "", nil)
+}
+
+// getActionConfigForUser creates an action configuration with K8s impersonation set.
+// Used for write operations when auth is enabled.
+func (c *Client) getActionConfigForUser(namespace, username string, groups []string) (*action.Configuration, error) {
+	return c.buildActionConfig(namespace, username, groups)
+}
+
+// buildActionConfig is the shared init path for both anonymous and
+// impersonated action configurations. When kubeconfig is empty (running
+// in-cluster) we hand Helm an in-cluster RESTClientGetter built from the
+// rest.Config the rest of Radar already uses — Helm's default
+// ConfigFlags only resolves kubeconfig and would otherwise fall through
+// to localhost:8080 inside a pod with no ~/.kube/config.
+func (c *Client) buildActionConfig(namespace, username string, groups []string) (*action.Configuration, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
 	actionConfig := new(action.Configuration)
 
-	// Use RESTClientGetter for kubeconfig
-	// NOTE: Use false for usePersistentConfig to avoid caching issues during context switches
+	getter, err := c.restClientGetter(namespace, username, groups)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := actionConfig.Init(getter, namespace, "secrets", log.Printf); err != nil {
+		if username != "" {
+			return nil, fmt.Errorf("failed to initialize helm action config for user %s: %w", username, err)
+		}
+		return nil, fmt.Errorf("failed to initialize helm action config: %w", err)
+	}
+
+	return actionConfig, nil
+}
+
+// restClientGetter picks between two RESTClientGetter strategies:
+//
+//   - kubeconfig path is set: hand Helm a ConfigFlags pointing at that
+//     single file. This is the dominant OSS path (kubectl plugin /
+//     standalone binary on a laptop with ~/.kube/config).
+//   - kubeconfig path is empty: hand Helm the rest.Config Radar
+//     already resolved at boot. Fires for in-cluster deploys (Hub
+//     mode, OSS Helm-chart deploy — no ~/.kube/config in the pod) and
+//     for multi-source kubeconfig modes (--kubeconfig-dir / multi-path
+//     KUBECONFIG, where there's no single file path to hand Helm).
+//
+// Caller must hold c.mu (read or write).
+func (c *Client) restClientGetter(namespace, username string, groups []string) (genericclioptions.RESTClientGetter, error) {
+	if c.kubeconfig == "" {
+		if cfg := k8s.GetConfig(); cfg != nil {
+			return newRESTConfigGetter(cfg, namespace, username, groups), nil
+		}
+		// No kubeconfig path AND no resolved rest.Config — no point in
+		// handing Helm a getter that would fall through to localhost:8080.
+		// Surface the misconfiguration instead.
+		return nil, fmt.Errorf("helm: no kubeconfig path and no resolved rest.Config available")
+	}
+
+	// Use RESTClientGetter for kubeconfig.
+	// NOTE: Use false for usePersistentConfig to avoid caching issues during context switches.
 	configFlags := genericclioptions.NewConfigFlags(false)
 	// Override the default discovery cache dir ($HOME/.kube/cache) to a writable path
 	// when running on a read-only filesystem (e.g. in-cluster with readOnlyRootFilesystem).
@@ -140,61 +194,24 @@ func (c *Client) getActionConfig(namespace string) (*action.Configuration, error
 		kubeCacheDir := "/tmp/helm/kube-cache"
 		configFlags.CacheDir = &kubeCacheDir
 	}
-	if c.kubeconfig != "" {
-		configFlags.KubeConfig = &c.kubeconfig
-	}
+	configFlags.KubeConfig = &c.kubeconfig
 	if namespace != "" {
 		configFlags.Namespace = &namespace
 	}
 
-	// Use Explorer's current context (in-memory) instead of kubeconfig's current-context
-	// This ensures Helm uses the same context as the rest of Explorer after context switches
+	// Use Explorer's current context (in-memory) instead of kubeconfig's current-context.
+	// This ensures Helm uses the same context as the rest of Explorer after context switches.
 	currentContext := k8s.GetContextName()
 	if currentContext != "" && currentContext != "in-cluster" {
 		configFlags.Context = &currentContext
 	}
 
-	if err := actionConfig.Init(configFlags, namespace, "secrets", log.Printf); err != nil {
-		return nil, fmt.Errorf("failed to initialize helm action config: %w", err)
+	if username != "" {
+		configFlags.Impersonate = &username
+		configFlags.ImpersonateGroup = &groups
 	}
 
-	return actionConfig, nil
-}
-
-// getActionConfigForUser creates an action configuration with K8s impersonation set.
-// Used for write operations when auth is enabled.
-func (c *Client) getActionConfigForUser(namespace, username string, groups []string) (*action.Configuration, error) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	actionConfig := new(action.Configuration)
-
-	configFlags := genericclioptions.NewConfigFlags(false)
-	if homeDir, err := os.UserHomeDir(); err != nil || !isDirWritable(homeDir) {
-		kubeCacheDir := "/tmp/helm/kube-cache"
-		configFlags.CacheDir = &kubeCacheDir
-	}
-	if c.kubeconfig != "" {
-		configFlags.KubeConfig = &c.kubeconfig
-	}
-	if namespace != "" {
-		configFlags.Namespace = &namespace
-	}
-
-	currentContext := k8s.GetContextName()
-	if currentContext != "" && currentContext != "in-cluster" {
-		configFlags.Context = &currentContext
-	}
-
-	// Set impersonation
-	configFlags.Impersonate = &username
-	configFlags.ImpersonateGroup = &groups
-
-	if err := actionConfig.Init(configFlags, namespace, "secrets", log.Printf); err != nil {
-		return nil, fmt.Errorf("failed to initialize helm action config for user %s: %w", username, err)
-	}
-
-	return actionConfig, nil
+	return configFlags, nil
 }
 
 // GetActionConfig returns an action configuration for the given namespace.

--- a/internal/helm/handlers.go
+++ b/internal/helm/handlers.go
@@ -678,7 +678,16 @@ func (h *Handlers) handleListRepositories(w http.ResponseWriter, r *http.Request
 	writeJSON(w, repos)
 }
 
-// handleUpdateRepository updates the index for a specific repository
+// handleUpdateRepository updates the index for a specific repository.
+//
+// Deliberately NOT gated by requireCloudRole: this fetches chart
+// metadata from external repos (artifacthub.io, oci://, etc.) and
+// caches it on the radar pod's local filesystem. It mutates pod-local
+// state, not cluster state — refresh-the-catalog rather than
+// modify-the-cluster. requireHelmWrite still gates it because a future
+// install/upgrade depends on a fresh repo cache, but a viewer
+// triggering a repo refresh has no security or product cost beyond a
+// few HTTP calls to public chart hosts.
 func (h *Handlers) handleUpdateRepository(w http.ResponseWriter, r *http.Request) {
 	if !requireHelmWrite(w, r) {
 		return
@@ -943,8 +952,6 @@ type installResult struct {
 	err     error
 }
 
-// Helper functions
-
 // requireHelmWrite checks if the service account has Helm write permissions.
 // Uses secrets/create as a sentinel check — if the service account can create
 // secrets, it likely has the broad RBAC granted by rbac.helm=true.
@@ -1013,7 +1020,7 @@ func requireCloudRole(w http.ResponseWriter, r *http.Request, min auth.CloudRole
 		return true
 	}
 	log.Printf("[helm] Cloud role %q denied %s (need at least %q): %s", role, opName, min, r.URL.Path)
-	writeErrorCode(w, http.StatusForbidden, "cloud_role_insufficient",
+	writeErrorCode(w, http.StatusForbidden, auth.ErrCodeCloudRoleInsufficient,
 		"Your Radar Cloud role ("+role.String()+") cannot "+opName+". Ask a "+string(min)+" or higher.")
 	return false
 }

--- a/internal/helm/handlers.go
+++ b/internal/helm/handlers.go
@@ -1023,7 +1023,9 @@ func requireCloudRole(w http.ResponseWriter, r *http.Request, min auth.CloudRole
 	if u := auth.UserFromContext(r.Context()); u != nil {
 		username = u.Username
 	}
-	log.Printf("[helm] Cloud role %q denied %s for user %q (need at least %q): %s", role, opName, username, min, r.URL.Path)
+	// All user-controlled values use %q so log-line injection via CR/LF
+	// in headers or path is escaped. opName is a compile-time literal.
+	log.Printf("[helm] Cloud role %q denied %s for user %q (need at least %q): %q", role, opName, username, min, r.URL.Path)
 	writeErrorCode(w, http.StatusForbidden, auth.ErrCodeCloudRoleInsufficient,
 		"Your Radar Cloud role ("+role.String()+") cannot "+opName+". Requires "+string(min)+" or higher.")
 	return false

--- a/internal/helm/handlers.go
+++ b/internal/helm/handlers.go
@@ -125,8 +125,14 @@ func (h *Handlers) handleGetRelease(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, release)
 }
 
-// handleGetManifest returns the rendered manifest for a release
+// handleGetManifest returns the rendered manifest for a release.
+// Member+ only — manifests can inline literal Secret resources with
+// base64-encoded data, which K8s 'view' (the default cloud:viewer
+// binding) excludes.
 func (h *Handlers) handleGetManifest(w http.ResponseWriter, r *http.Request) {
+	if !requireCloudRole(w, r, auth.RoleMember, "view Helm release manifests") {
+		return
+	}
 	client := GetClient()
 	if client == nil {
 		writeError(w, http.StatusServiceUnavailable, "Helm client not initialized")
@@ -156,8 +162,12 @@ func (h *Handlers) handleGetManifest(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(manifest))
 }
 
-// handleGetValues returns the values for a release
+// handleGetValues returns the values for a release. Member+ only —
+// values may contain credentials set via --set or values.yaml.
 func (h *Handlers) handleGetValues(w http.ResponseWriter, r *http.Request) {
+	if !requireCloudRole(w, r, auth.RoleMember, "view Helm release values") {
+		return
+	}
 	client := GetClient()
 	if client == nil {
 		writeError(w, http.StatusServiceUnavailable, "Helm client not initialized")
@@ -178,8 +188,12 @@ func (h *Handlers) handleGetValues(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, values)
 }
 
-// handleGetDiff returns the diff between two revisions
+// handleGetDiff returns the diff between two revisions. Member+ only
+// — same surface as GetManifest (renders both revisions).
 func (h *Handlers) handleGetDiff(w http.ResponseWriter, r *http.Request) {
+	if !requireCloudRole(w, r, auth.RoleMember, "diff Helm release manifests") {
+		return
+	}
 	client := GetClient()
 	if client == nil {
 		writeError(w, http.StatusServiceUnavailable, "Helm client not initialized")
@@ -262,6 +276,9 @@ func (h *Handlers) handleBatchUpgradeCheck(w http.ResponseWriter, r *http.Reques
 
 // handleRollback rolls back a release to a previous revision
 func (h *Handlers) handleRollback(w http.ResponseWriter, r *http.Request) {
+	if !requireCloudRole(w, r, auth.RoleMember, "rollback Helm releases") {
+		return
+	}
 	if !requireHelmWrite(w, r) {
 		return
 	}
@@ -308,6 +325,9 @@ func (h *Handlers) handleRollback(w http.ResponseWriter, r *http.Request) {
 
 // handleRollbackStream rolls back a release with SSE progress streaming
 func (h *Handlers) handleRollbackStream(w http.ResponseWriter, r *http.Request) {
+	if !requireCloudRole(w, r, auth.RoleMember, "rollback Helm releases") {
+		return
+	}
 	if !requireHelmWrite(w, r) {
 		return
 	}
@@ -398,6 +418,9 @@ func (h *Handlers) handleRollbackStream(w http.ResponseWriter, r *http.Request) 
 
 // handleUninstall removes a release
 func (h *Handlers) handleUninstall(w http.ResponseWriter, r *http.Request) {
+	if !requireCloudRole(w, r, auth.RoleMember, "uninstall Helm releases") {
+		return
+	}
 	if !requireHelmWrite(w, r) {
 		return
 	}
@@ -432,6 +455,9 @@ func (h *Handlers) handleUninstall(w http.ResponseWriter, r *http.Request) {
 
 // handleUpgrade upgrades a release to a new version
 func (h *Handlers) handleUpgrade(w http.ResponseWriter, r *http.Request) {
+	if !requireCloudRole(w, r, auth.RoleMember, "upgrade Helm releases") {
+		return
+	}
 	if !requireHelmWrite(w, r) {
 		return
 	}
@@ -472,6 +498,9 @@ func (h *Handlers) handleUpgrade(w http.ResponseWriter, r *http.Request) {
 
 // handleUpgradeStream upgrades a release with SSE progress streaming
 func (h *Handlers) handleUpgradeStream(w http.ResponseWriter, r *http.Request) {
+	if !requireCloudRole(w, r, auth.RoleMember, "upgrade Helm releases") {
+		return
+	}
 	if !requireHelmWrite(w, r) {
 		return
 	}
@@ -554,8 +583,13 @@ func (h *Handlers) handleUpgradeStream(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// handlePreviewValues previews the effect of new values on a release
+// handlePreviewValues previews the effect of new values on a release.
+// Member+ — renders the chart with proposed values, same surface as
+// GetManifest.
 func (h *Handlers) handlePreviewValues(w http.ResponseWriter, r *http.Request) {
+	if !requireCloudRole(w, r, auth.RoleMember, "preview Helm release values") {
+		return
+	}
 	client := GetClient()
 	if client == nil {
 		writeError(w, http.StatusServiceUnavailable, "Helm client not initialized")
@@ -582,6 +616,9 @@ func (h *Handlers) handlePreviewValues(w http.ResponseWriter, r *http.Request) {
 
 // handleApplyValues applies new values to a release
 func (h *Handlers) handleApplyValues(w http.ResponseWriter, r *http.Request) {
+	if !requireCloudRole(w, r, auth.RoleMember, "apply Helm release values") {
+		return
+	}
 	if !requireHelmWrite(w, r) {
 		return
 	}
@@ -730,6 +767,9 @@ func (h *Handlers) handleGetChartDetailVersion(w http.ResponseWriter, r *http.Re
 
 // handleInstall installs a new Helm release (non-streaming version)
 func (h *Handlers) handleInstall(w http.ResponseWriter, r *http.Request) {
+	if !requireCloudRole(w, r, auth.RoleMember, "install Helm releases") {
+		return
+	}
 	if !requireHelmWrite(w, r) {
 		return
 	}
@@ -786,6 +826,9 @@ func (h *Handlers) handleInstall(w http.ResponseWriter, r *http.Request) {
 
 // handleInstallStream installs a Helm release with SSE progress streaming
 func (h *Handlers) handleInstallStream(w http.ResponseWriter, r *http.Request) {
+	if !requireCloudRole(w, r, auth.RoleMember, "install Helm releases") {
+		return
+	}
 	if !requireHelmWrite(w, r) {
 		return
 	}
@@ -933,6 +976,46 @@ func writeError(w http.ResponseWriter, status int, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	json.NewEncoder(w).Encode(map[string]string{"error": message})
+}
+
+// writeErrorCode is writeError with a stable machine-readable error_code
+// in the response body so the SPA + MCP clients can branch on the error
+// type without parsing the human message. Used for role-gated 403s and
+// any other case where the consumer wants to react differently per code.
+func writeErrorCode(w http.ResponseWriter, status int, code, message string) {
+	if status >= 500 {
+		errorlog.Record("helm", "error", "%s", message)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(map[string]string{
+		"error":      message,
+		"error_code": code,
+	})
+}
+
+// requireCloudRole gates a handler on the caller's Cloud role tier.
+// Returns true if the request should proceed.
+//
+// When the caller has no Cloud role (OSS deploy, or running outside
+// Cloud's tunnel), CloudRole.AtLeast bypasses the gate — radar OSS
+// continues to use only K8s RBAC for authorization, no Cloud-specific
+// product gating. This is the same behavior as before; the gate is
+// strictly additive for Cloud-attributed callers.
+//
+// When the caller IS Cloud-attributed and their tier is below `min`,
+// returns 403 with error_code=cloud_role_insufficient so the SPA can
+// render a friendly "your role doesn't allow this" message instead of
+// a generic auth failure.
+func requireCloudRole(w http.ResponseWriter, r *http.Request, min auth.CloudRole, opName string) bool {
+	role := auth.CloudRoleFromContext(r.Context())
+	if role.AtLeast(min) {
+		return true
+	}
+	log.Printf("[helm] Cloud role %q denied %s (need at least %q): %s", role, opName, min, r.URL.Path)
+	writeErrorCode(w, http.StatusForbidden, "cloud_role_insufficient",
+		"Your Radar Cloud role ("+role.String()+") cannot "+opName+". Ask a "+string(min)+" or higher.")
+	return false
 }
 
 // ============================================================================

--- a/internal/helm/handlers.go
+++ b/internal/helm/handlers.go
@@ -1019,9 +1019,13 @@ func requireCloudRole(w http.ResponseWriter, r *http.Request, min auth.CloudRole
 	if role.AtLeast(min) {
 		return true
 	}
-	log.Printf("[helm] Cloud role %q denied %s (need at least %q): %s", role, opName, min, r.URL.Path)
+	username := "unknown"
+	if u := auth.UserFromContext(r.Context()); u != nil {
+		username = u.Username
+	}
+	log.Printf("[helm] Cloud role %q denied %s for user %q (need at least %q): %s", role, opName, username, min, r.URL.Path)
 	writeErrorCode(w, http.StatusForbidden, auth.ErrCodeCloudRoleInsufficient,
-		"Your Radar Cloud role ("+role.String()+") cannot "+opName+". Ask a "+string(min)+" or higher.")
+		"Your Radar Cloud role ("+role.String()+") cannot "+opName+". Requires "+string(min)+" or higher.")
 	return false
 }
 

--- a/internal/helm/handlers_test.go
+++ b/internal/helm/handlers_test.go
@@ -1,0 +1,84 @@
+package helm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/skyhook-io/radar/internal/auth"
+)
+
+// TestRequireCloudRole exercises the role gate without standing up a
+// Helm client — the gate runs first, so we never hit the client. This
+// guards the gate against regressions ("forgot to wire requireCloudRole
+// on a new write endpoint", "swapped the comparison the wrong way").
+func TestRequireCloudRole(t *testing.T) {
+	cases := []struct {
+		name     string
+		groups   []string
+		min      auth.CloudRole
+		wantOK   bool
+		wantCode string // expected error_code when wantOK == false
+	}{
+		// No user attached (OSS / non-Cloud): gate bypasses.
+		{name: "no user — bypass", groups: nil, min: auth.RoleMember, wantOK: true},
+
+		// Cloud user without role group (header stripped, misconfig):
+		// CloudRole is RoleNone, AtLeast bypasses. This is permissive
+		// by design — the assumption is that radar-hub guarantees the
+		// role group when forwarding.
+		{name: "user without cloud:* — bypass", groups: []string{"developers"}, min: auth.RoleOwner, wantOK: true},
+
+		// Cloud-attributed users — gate enforces.
+		{name: "viewer denied member-required op", groups: []string{"cloud:viewer"}, min: auth.RoleMember,
+			wantOK: false, wantCode: "cloud_role_insufficient"},
+		{name: "viewer denied owner-required op", groups: []string{"cloud:viewer"}, min: auth.RoleOwner,
+			wantOK: false, wantCode: "cloud_role_insufficient"},
+		{name: "viewer allowed viewer-required op", groups: []string{"cloud:viewer"}, min: auth.RoleViewer, wantOK: true},
+		{name: "member allowed member-required op", groups: []string{"cloud:member"}, min: auth.RoleMember, wantOK: true},
+		{name: "member denied owner-required op", groups: []string{"cloud:member"}, min: auth.RoleOwner,
+			wantOK: false, wantCode: "cloud_role_insufficient"},
+		{name: "owner allowed owner-required op", groups: []string{"cloud:owner"}, min: auth.RoleOwner, wantOK: true},
+
+		// Defensive: a stuffed lower tier alongside owner shouldn't
+		// downgrade the user. CloudRoleFromGroups picks the highest.
+		{name: "stuffed viewer + owner — allowed", groups: []string{"cloud:viewer", "cloud:owner"}, min: auth.RoleOwner, wantOK: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			ctx := req.Context()
+			if tc.groups != nil {
+				ctx = auth.ContextWithUser(ctx, &auth.User{Username: "test-user", Groups: tc.groups})
+			} else {
+				_ = context.Background()
+			}
+			req = req.WithContext(ctx)
+			rec := httptest.NewRecorder()
+
+			ok := requireCloudRole(rec, req, tc.min, "test-op")
+			if ok != tc.wantOK {
+				t.Errorf("requireCloudRole = %v, want %v (status=%d, body=%s)",
+					ok, tc.wantOK, rec.Code, rec.Body.String())
+			}
+			if !tc.wantOK {
+				if rec.Code != http.StatusForbidden {
+					t.Errorf("status = %d, want 403", rec.Code)
+				}
+				var resp map[string]string
+				if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+					t.Fatalf("decode body: %v (body=%s)", err, rec.Body.String())
+				}
+				if resp["error_code"] != tc.wantCode {
+					t.Errorf("error_code = %q, want %q", resp["error_code"], tc.wantCode)
+				}
+				if resp["error"] == "" {
+					t.Error("error message is empty")
+				}
+			}
+		})
+	}
+}

--- a/internal/helm/handlers_test.go
+++ b/internal/helm/handlers_test.go
@@ -33,13 +33,13 @@ func TestRequireCloudRole(t *testing.T) {
 
 		// Cloud-attributed users — gate enforces.
 		{name: "viewer denied member-required op", groups: []string{"cloud:viewer"}, min: auth.RoleMember,
-			wantOK: false, wantCode: "cloud_role_insufficient"},
+			wantOK: false, wantCode: auth.ErrCodeCloudRoleInsufficient},
 		{name: "viewer denied owner-required op", groups: []string{"cloud:viewer"}, min: auth.RoleOwner,
-			wantOK: false, wantCode: "cloud_role_insufficient"},
+			wantOK: false, wantCode: auth.ErrCodeCloudRoleInsufficient},
 		{name: "viewer allowed viewer-required op", groups: []string{"cloud:viewer"}, min: auth.RoleViewer, wantOK: true},
 		{name: "member allowed member-required op", groups: []string{"cloud:member"}, min: auth.RoleMember, wantOK: true},
 		{name: "member denied owner-required op", groups: []string{"cloud:member"}, min: auth.RoleOwner,
-			wantOK: false, wantCode: "cloud_role_insufficient"},
+			wantOK: false, wantCode: auth.ErrCodeCloudRoleInsufficient},
 		{name: "owner allowed owner-required op", groups: []string{"cloud:owner"}, min: auth.RoleOwner, wantOK: true},
 
 		// Defensive: a stuffed lower tier alongside owner shouldn't
@@ -78,6 +78,69 @@ func TestRequireCloudRole(t *testing.T) {
 				if resp["error"] == "" {
 					t.Error("error message is empty")
 				}
+			}
+		})
+	}
+}
+
+// TestSensitiveHelmHandlers_GateOnViewer asserts that every Helm
+// handler we believe is gated actually 403s a Cloud viewer with
+// error_code=cloud_role_insufficient. The unit test above
+// (TestRequireCloudRole) covers the gate function in isolation; this
+// test covers the *application* of the gate to each handler.
+//
+// Why both: the gate was retrofitted as a one-line `if !requireCloudRole(...)
+// { return }` at the top of each handler. A future refactor that drops
+// the line (or reorders it after a side-effecting call) would silently
+// regress without the unit test failing. This test fails the moment
+// the gate disappears from any covered handler.
+//
+// We don't need a real Helm client because the gate runs first; the
+// handler short-circuits before touching `helm.GetClient()`.
+func TestSensitiveHelmHandlers_GateOnViewer(t *testing.T) {
+	h := NewHandlers()
+
+	// (name, method, handler) for every endpoint we believe is gated.
+	// Sensitive reads → member; writes → member.
+	cases := []struct {
+		name    string
+		method  string
+		handler http.HandlerFunc
+	}{
+		{"GetManifest", http.MethodGet, h.handleGetManifest},
+		{"GetValues", http.MethodGet, h.handleGetValues},
+		{"GetDiff", http.MethodGet, h.handleGetDiff},
+		{"PreviewValues", http.MethodPost, h.handlePreviewValues},
+		{"ApplyValues", http.MethodPut, h.handleApplyValues},
+		{"Rollback", http.MethodPost, h.handleRollback},
+		{"RollbackStream", http.MethodPost, h.handleRollbackStream},
+		{"Uninstall", http.MethodDelete, h.handleUninstall},
+		{"Upgrade", http.MethodPost, h.handleUpgrade},
+		{"UpgradeStream", http.MethodPost, h.handleUpgradeStream},
+		{"Install", http.MethodPost, h.handleInstall},
+		{"InstallStream", http.MethodPost, h.handleInstallStream},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, "/test", nil)
+			req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{
+				Username: "viewer-test",
+				Groups:   []string{"cloud:viewer"},
+			}))
+			rec := httptest.NewRecorder()
+
+			tc.handler(rec, req)
+
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want 403 (gate should fire before any helm work)", rec.Code)
+			}
+			var resp map[string]string
+			if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("decode body: %v (body=%s)", err, rec.Body.String())
+			}
+			if resp["error_code"] != auth.ErrCodeCloudRoleInsufficient {
+				t.Errorf("error_code = %q, want %q", resp["error_code"], auth.ErrCodeCloudRoleInsufficient)
 			}
 		})
 	}

--- a/internal/helm/rest_config_getter.go
+++ b/internal/helm/rest_config_getter.go
@@ -57,9 +57,11 @@ func (g *restConfigGetter) ToRESTConfig() (*rest.Config, error) {
 	}
 	cfg := rest.CopyConfig(g.config)
 	if g.impersonate != "" {
+		// Copy groups so a future Helm/middleware mutation can't bleed
+		// into a different user's request via the captured slice.
 		cfg.Impersonate = rest.ImpersonationConfig{
 			UserName: g.impersonate,
-			Groups:   g.impersonateGrp,
+			Groups:   append([]string(nil), g.impersonateGrp...),
 		}
 	}
 	return cfg, nil
@@ -75,7 +77,8 @@ func (g *restConfigGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterfa
 	if err != nil {
 		return nil, err
 	}
-	// Helm fans out discovery calls during chart rendering / list ops.
+	// Match kubectl's QPS/Burst defaults (50/100). The client-go default
+	// (5/10) is too low for Helm operations that walk many resources.
 	cfg.Burst = 100
 	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
 	if err != nil {
@@ -86,14 +89,17 @@ func (g *restConfigGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterfa
 }
 
 func (g *restConfigGetter) ToRESTMapper() (meta.RESTMapper, error) {
+	// ToDiscoveryClient does its own locking; calling it under g.mu would
+	// deadlock since sync.Mutex is non-reentrant. Take the discovery
+	// client first (idempotent), then lock for the mapper cache.
+	dc, err := g.ToDiscoveryClient()
+	if err != nil {
+		return nil, err
+	}
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if g.mapper != nil {
 		return g.mapper, nil
-	}
-	dc, err := g.ToDiscoveryClient()
-	if err != nil {
-		return nil, err
 	}
 	deferred := restmapper.NewDeferredDiscoveryRESTMapper(dc)
 	g.mapper = restmapper.NewShortcutExpander(deferred, dc, func(string) {})
@@ -101,9 +107,10 @@ func (g *restConfigGetter) ToRESTMapper() (meta.RESTMapper, error) {
 }
 
 func (g *restConfigGetter) ToRawKubeConfigLoader() clientcmd.ClientConfig {
-	// Helm uses this primarily for namespace resolution. We have no real
-	// kubeconfig to surface; return an empty Config with the namespace
-	// override so action.Configuration.Init's fallback path picks it up.
+	// Helm calls Namespace() on this loader (in EnvSettings + the kube
+	// client) to resolve the default namespace. We have no real kubeconfig
+	// to surface, so return an empty Config with just the namespace
+	// override.
 	return clientcmd.NewDefaultClientConfig(
 		clientcmdapi.Config{},
 		&clientcmd.ConfigOverrides{

--- a/internal/helm/rest_config_getter.go
+++ b/internal/helm/rest_config_getter.go
@@ -1,0 +1,113 @@
+package helm
+
+import (
+	"fmt"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// restConfigGetter implements genericclioptions.RESTClientGetter by
+// reusing a *rest.Config Radar already resolved at boot, instead of
+// asking Helm to re-resolve from kubeconfig.
+//
+// Used whenever no single kubeconfig file path is available to hand
+// Helm. Two cases trigger this:
+//
+//  1. In-cluster (Hub mode, OSS Helm-chart deploy): no ~/.kube/config in
+//     the pod. Helm's default ConfigFlags would fall through to
+//     localhost:8080.
+//  2. Multi-source kubeconfig on a laptop (--kubeconfig-dir or a
+//     KUBECONFIG env var with multiple paths): Radar uses isolated
+//     per-file loading, so there isn't one path Helm can re-parse —
+//     it would silently pick a different file from its own precedence.
+//
+// In both cases we hand Helm the exact rest.Config Radar's K8s client
+// is already using, so Helm can't drift to a different cluster or
+// fabricate a localhost target.
+type restConfigGetter struct {
+	config         *rest.Config
+	namespace      string
+	impersonate    string
+	impersonateGrp []string
+
+	mu        sync.Mutex
+	discovery discovery.CachedDiscoveryInterface
+	mapper    meta.RESTMapper
+}
+
+func newRESTConfigGetter(cfg *rest.Config, namespace, user string, groups []string) *restConfigGetter {
+	return &restConfigGetter{
+		config:         cfg,
+		namespace:      namespace,
+		impersonate:    user,
+		impersonateGrp: groups,
+	}
+}
+
+func (g *restConfigGetter) ToRESTConfig() (*rest.Config, error) {
+	if g.config == nil {
+		return nil, fmt.Errorf("no in-cluster rest config available")
+	}
+	cfg := rest.CopyConfig(g.config)
+	if g.impersonate != "" {
+		cfg.Impersonate = rest.ImpersonationConfig{
+			UserName: g.impersonate,
+			Groups:   g.impersonateGrp,
+		}
+	}
+	return cfg, nil
+}
+
+func (g *restConfigGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.discovery != nil {
+		return g.discovery, nil
+	}
+	cfg, err := g.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+	// Helm fans out discovery calls during chart rendering / list ops.
+	cfg.Burst = 100
+	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	g.discovery = memory.NewMemCacheClient(dc)
+	return g.discovery, nil
+}
+
+func (g *restConfigGetter) ToRESTMapper() (meta.RESTMapper, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.mapper != nil {
+		return g.mapper, nil
+	}
+	dc, err := g.ToDiscoveryClient()
+	if err != nil {
+		return nil, err
+	}
+	deferred := restmapper.NewDeferredDiscoveryRESTMapper(dc)
+	g.mapper = restmapper.NewShortcutExpander(deferred, dc, func(string) {})
+	return g.mapper, nil
+}
+
+func (g *restConfigGetter) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	// Helm uses this primarily for namespace resolution. We have no real
+	// kubeconfig to surface; return an empty Config with the namespace
+	// override so action.Configuration.Init's fallback path picks it up.
+	return clientcmd.NewDefaultClientConfig(
+		clientcmdapi.Config{},
+		&clientcmd.ConfigOverrides{
+			Context: clientcmdapi.Context{Namespace: g.namespace},
+		},
+	)
+}

--- a/internal/helm/rest_config_getter.go
+++ b/internal/helm/rest_config_getter.go
@@ -79,6 +79,7 @@ func (g *restConfigGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterfa
 	}
 	// Match kubectl's QPS/Burst defaults (50/100). The client-go default
 	// (5/10) is too low for Helm operations that walk many resources.
+	cfg.QPS = 50
 	cfg.Burst = 100
 	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
 	if err != nil {

--- a/internal/helm/rest_config_getter_test.go
+++ b/internal/helm/rest_config_getter_test.go
@@ -1,8 +1,11 @@
 package helm
 
 import (
+	"strings"
 	"testing"
+	"time"
 
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
 )
 
@@ -29,7 +32,8 @@ func TestRESTConfigGetter_ToRESTConfig_NoImpersonation(t *testing.T) {
 
 func TestRESTConfigGetter_ToRESTConfig_WithImpersonation(t *testing.T) {
 	src := &rest.Config{Host: "https://kubernetes.default.svc"}
-	g := newRESTConfigGetter(src, "default", "alice@example.com", []string{"viewers"})
+	srcGroups := []string{"viewers"}
+	g := newRESTConfigGetter(src, "default", "alice@example.com", srcGroups)
 
 	cfg, err := g.ToRESTConfig()
 	if err != nil {
@@ -43,6 +47,12 @@ func TestRESTConfigGetter_ToRESTConfig_WithImpersonation(t *testing.T) {
 	}
 	if src.Impersonate.UserName != "" {
 		t.Error("source rest.Config was mutated; impersonation must apply only to the copy")
+	}
+	// Groups must not share storage with the caller's slice — mutating
+	// the returned config's groups must not bleed into the source.
+	cfg.Impersonate.Groups[0] = "mutated"
+	if srcGroups[0] != "viewers" {
+		t.Errorf("ToRESTConfig leaked Groups slice; src[0] = %q, want viewers", srcGroups[0])
 	}
 }
 
@@ -62,5 +72,110 @@ func TestRESTConfigGetter_ToRawKubeConfigLoader_NamespaceOverride(t *testing.T) 
 	}
 	if ns != "my-ns" {
 		t.Errorf("Namespace = %q, want my-ns", ns)
+	}
+}
+
+// TestRESTConfigGetter_DiscoveryAndMapper_NoDeadlock exercises the
+// ToDiscoveryClient → ToRESTMapper chain Helm uses on every install /
+// upgrade / resource-builder call. ToRESTMapper used to acquire the
+// getter's mutex and then call ToDiscoveryClient, which re-acquires the
+// same non-reentrant sync.Mutex — deadlocking the first call.
+//
+// The cfg.Host is bogus on purpose: discovery client construction is
+// lazy (no network until a request is made), so we get to test the
+// locking discipline without standing up a fake apiserver.
+func TestRESTConfigGetter_DiscoveryAndMapper_NoDeadlock(t *testing.T) {
+	g := newRESTConfigGetter(&rest.Config{Host: "https://nowhere.invalid"}, "default", "", nil)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if _, err := g.ToDiscoveryClient(); err != nil {
+			t.Errorf("ToDiscoveryClient: %v", err)
+		}
+		if _, err := g.ToRESTMapper(); err != nil {
+			t.Errorf("ToRESTMapper: %v", err)
+		}
+		// Second call must also return without blocking — both should
+		// hit their cached paths.
+		if _, err := g.ToRESTMapper(); err != nil {
+			t.Errorf("ToRESTMapper (cached): %v", err)
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ToDiscoveryClient/ToRESTMapper deadlocked")
+	}
+}
+
+// TestBuildRESTClientGetter exercises the strategy picker that decides
+// when to use the captured rest.Config vs a kubeconfig-backed
+// ConfigFlags. This is the actual decision the PR ships — the leaf
+// getter tests above are necessary but not sufficient.
+func TestBuildRESTClientGetter(t *testing.T) {
+	cases := []struct {
+		name       string
+		params     restClientGetterParams
+		wantType   string // "configFlags" | "restConfigGetter" | ""
+		wantErr    bool
+		wantErrSub string
+	}{
+		{
+			name: "kubeconfig set: use ConfigFlags (dominant OSS laptop case)",
+			params: restClientGetterParams{
+				kubeconfig: "/home/user/.kube/config",
+				restConfig: &rest.Config{Host: "https://example"},
+				namespace:  "default",
+			},
+			wantType: "configFlags",
+		},
+		{
+			name: "kubeconfig empty + rest.Config available: use restConfigGetter (in-cluster / multi-source)",
+			params: restClientGetterParams{
+				kubeconfig: "",
+				restConfig: &rest.Config{Host: "https://kubernetes.default.svc"},
+				namespace:  "kube-system",
+			},
+			wantType: "restConfigGetter",
+		},
+		{
+			name: "kubeconfig empty + no rest.Config: error",
+			params: restClientGetterParams{
+				kubeconfig: "",
+				restConfig: nil,
+			},
+			wantErr:    true,
+			wantErrSub: "no kubeconfig path and no resolved rest.Config",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildRESTClientGetter(tc.params)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got %T", got)
+				}
+				if tc.wantErrSub != "" && !strings.Contains(err.Error(), tc.wantErrSub) {
+					t.Errorf("error %q missing substring %q", err.Error(), tc.wantErrSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			switch tc.wantType {
+			case "configFlags":
+				if _, ok := got.(*genericclioptions.ConfigFlags); !ok {
+					t.Errorf("got %T, want *genericclioptions.ConfigFlags", got)
+				}
+			case "restConfigGetter":
+				if _, ok := got.(*restConfigGetter); !ok {
+					t.Errorf("got %T, want *restConfigGetter", got)
+				}
+			}
+		})
 	}
 }

--- a/internal/helm/rest_config_getter_test.go
+++ b/internal/helm/rest_config_getter_test.go
@@ -1,0 +1,66 @@
+package helm
+
+import (
+	"testing"
+
+	"k8s.io/client-go/rest"
+)
+
+func TestRESTConfigGetter_ToRESTConfig_NoImpersonation(t *testing.T) {
+	src := &rest.Config{Host: "https://kubernetes.default.svc"}
+	g := newRESTConfigGetter(src, "kube-system", "", nil)
+
+	cfg, err := g.ToRESTConfig()
+	if err != nil {
+		t.Fatalf("ToRESTConfig: %v", err)
+	}
+	if cfg.Host != src.Host {
+		t.Errorf("Host = %q, want %q", cfg.Host, src.Host)
+	}
+	if cfg.Impersonate.UserName != "" {
+		t.Errorf("Impersonate.UserName = %q, want empty", cfg.Impersonate.UserName)
+	}
+	// Must be a copy — mutating result must not bleed into the source.
+	cfg.Host = "mutated"
+	if src.Host == "mutated" {
+		t.Error("ToRESTConfig returned shared pointer; expected a copy")
+	}
+}
+
+func TestRESTConfigGetter_ToRESTConfig_WithImpersonation(t *testing.T) {
+	src := &rest.Config{Host: "https://kubernetes.default.svc"}
+	g := newRESTConfigGetter(src, "default", "alice@example.com", []string{"viewers"})
+
+	cfg, err := g.ToRESTConfig()
+	if err != nil {
+		t.Fatalf("ToRESTConfig: %v", err)
+	}
+	if cfg.Impersonate.UserName != "alice@example.com" {
+		t.Errorf("Impersonate.UserName = %q, want alice@example.com", cfg.Impersonate.UserName)
+	}
+	if len(cfg.Impersonate.Groups) != 1 || cfg.Impersonate.Groups[0] != "viewers" {
+		t.Errorf("Impersonate.Groups = %v, want [viewers]", cfg.Impersonate.Groups)
+	}
+	if src.Impersonate.UserName != "" {
+		t.Error("source rest.Config was mutated; impersonation must apply only to the copy")
+	}
+}
+
+func TestRESTConfigGetter_ToRESTConfig_NilConfig(t *testing.T) {
+	g := newRESTConfigGetter(nil, "default", "", nil)
+	if _, err := g.ToRESTConfig(); err == nil {
+		t.Fatal("ToRESTConfig with nil config: want error, got nil")
+	}
+}
+
+func TestRESTConfigGetter_ToRawKubeConfigLoader_NamespaceOverride(t *testing.T) {
+	g := newRESTConfigGetter(&rest.Config{Host: "https://example"}, "my-ns", "", nil)
+	loader := g.ToRawKubeConfigLoader()
+	ns, _, err := loader.Namespace()
+	if err != nil {
+		t.Fatalf("Namespace(): %v", err)
+	}
+	if ns != "my-ns" {
+		t.Errorf("Namespace = %q, want my-ns", ns)
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -995,6 +995,14 @@ type mcpWarning struct {
 type mcpHelmSummary struct {
 	Total    int              `json:"total"`
 	Releases []mcpHelmRelease `json:"releases,omitempty"`
+	// Unavailable + UnavailableReason are populated when the Helm read
+	// failed (Helm client not initialized, RBAC denied, network error,
+	// etc.) — distinguishes "this cluster has zero Helm releases" from
+	// "Helm is broken; results aren't an honest count." LLM consumers
+	// should surface UnavailableReason to the user instead of confidently
+	// reporting Total=0.
+	Unavailable       bool   `json:"unavailable,omitempty"`
+	UnavailableReason string `json:"unavailableReason,omitempty"`
 }
 
 type mcpHelmRelease struct {
@@ -1159,13 +1167,25 @@ func buildDashboard(ctx context.Context, cache *k8s.ResourceCache, namespace str
 	}
 
 	// Helm releases — sort failed-first before slicing
-	if helmClient := helm.GetClient(); helmClient != nil {
+	helmClient := helm.GetClient()
+	if helmClient == nil {
+		d.HelmReleases.Unavailable = true
+		d.HelmReleases.UnavailableReason = "Helm client not initialized."
+	} else {
 		username, groups := userFromContext(ctx)
 		releases, err := helmClient.ListReleasesAsUser(namespace, username, groups)
 		if err != nil {
 			// Not fatal for the dashboard — a viewer with no helm access
-			// still sees everything else. Log so the absence isn't silent.
+			// still sees everything else. Surface to LLM consumers via
+			// Unavailable so they don't confidently report "Total=0
+			// releases" when in fact the read failed.
 			log.Printf("[mcp] Dashboard helm list failed: %v", err)
+			d.HelmReleases.Unavailable = true
+			if helm.IsForbiddenError(err) {
+				d.HelmReleases.UnavailableReason = "RBAC denied: caller cannot list Helm release secrets in this scope."
+			} else {
+				d.HelmReleases.UnavailableReason = "Helm read failed: " + err.Error()
+			}
 		} else {
 			d.HelmReleases.Total = len(releases)
 

--- a/internal/mcp/tools_helm.go
+++ b/internal/mcp/tools_helm.go
@@ -92,13 +92,25 @@ func handleGetHelmRelease(ctx context.Context, req *mcp.CallToolRequest, input g
 
 	includes := parseIncludes(input.Include)
 
+	// Mirror the SPA gate on sensitive Helm reads: viewers cannot pull
+	// values/manifest/diff. Without this the user would still be blocked
+	// by K8s RBAC (view ClusterRole excludes secrets), but the error would
+	// be a confusing K8s "secrets is forbidden" rather than the structured
+	// cloud_role_insufficient code the SPA emits.
+	cloudRole := pkgauth.CloudRoleFromContext(ctx)
+	gatedSensitive := !cloudRole.AtLeast(pkgauth.RoleMember)
+
 	if includes["values"] {
-		values, err := helmClient.GetValuesAsUser(input.Namespace, input.Name, false, username, groups)
-		if err != nil {
-			log.Printf("[mcp] Failed to get values for %s/%s: %v", input.Namespace, input.Name, err)
-			result["valuesError"] = err.Error()
+		if gatedSensitive {
+			result["valuesError"] = fmt.Sprintf("Radar Cloud role %q cannot view Helm release values (requires member or higher)", cloudRole.String())
 		} else {
-			result["values"] = values.UserSupplied
+			values, err := helmClient.GetValuesAsUser(input.Namespace, input.Name, false, username, groups)
+			if err != nil {
+				log.Printf("[mcp] Failed to get values for %s/%s: %v", input.Namespace, input.Name, err)
+				result["valuesError"] = err.Error()
+			} else {
+				result["values"] = values.UserSupplied
+			}
 		}
 	}
 
@@ -107,16 +119,20 @@ func handleGetHelmRelease(ctx context.Context, req *mcp.CallToolRequest, input g
 	}
 
 	if includes["diff"] && input.DiffRev1 > 0 {
-		rev2 := input.DiffRev2
-		if rev2 == 0 {
-			rev2 = detail.Revision // default to current revision
-		}
-		diff, err := helmClient.GetManifestDiffAsUser(input.Namespace, input.Name, input.DiffRev1, rev2, username, groups)
-		if err != nil {
-			log.Printf("[mcp] Failed to get manifest diff for %s/%s: %v", input.Namespace, input.Name, err)
-			result["diffError"] = err.Error()
+		if gatedSensitive {
+			result["diffError"] = fmt.Sprintf("Radar Cloud role %q cannot view Helm release diffs (requires member or higher)", cloudRole.String())
 		} else {
-			result["diff"] = diff
+			rev2 := input.DiffRev2
+			if rev2 == 0 {
+				rev2 = detail.Revision // default to current revision
+			}
+			diff, err := helmClient.GetManifestDiffAsUser(input.Namespace, input.Name, input.DiffRev1, rev2, username, groups)
+			if err != nil {
+				log.Printf("[mcp] Failed to get manifest diff for %s/%s: %v", input.Namespace, input.Name, err)
+				result["diffError"] = err.Error()
+			} else {
+				result["diff"] = diff
+			}
 		}
 	}
 

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -203,7 +203,16 @@ type DashboardTopFlow struct {
 type DashboardHelmSummary struct {
 	Total      int                    `json:"total"`
 	Releases   []DashboardHelmRelease `json:"releases"`
-	Restricted bool                   `json:"restricted,omitempty"` // True when user lacks permissions to list Helm releases
+	Restricted bool                   `json:"restricted,omitempty"` // True when user lacks permissions to list Helm releases (RBAC-denied)
+	// Error + ErrorCode are populated when the Helm read failed for a
+	// reason other than RBAC (Helm client not initialized, no resolved
+	// rest.Config, network error). Lets the dashboard widget render
+	// "Helm unavailable: not configured" instead of an empty list that
+	// looks like "this cluster has zero releases." ErrorCode uses the
+	// same vocabulary as packages.go ErrCode* (rbac_denied,
+	// unreachable, timed_out, unconfigured, auth_required).
+	Error     string `json:"error,omitempty"`
+	ErrorCode string `json:"errorCode,omitempty"`
 }
 
 type DashboardHelmRelease struct {
@@ -1129,7 +1138,11 @@ func (s *Server) getDashboardTrafficSummary(ctx context.Context, namespaces []st
 func (s *Server) getDashboardHelmSummary(r *http.Request, namespace string) DashboardHelmSummary {
 	helmClient := helm.GetClient()
 	if helmClient == nil {
-		return DashboardHelmSummary{Releases: []DashboardHelmRelease{}}
+		return DashboardHelmSummary{
+			Releases:  []DashboardHelmRelease{},
+			Error:     "Helm client not initialized",
+			ErrorCode: ErrCodeUnconfigured,
+		}
 	}
 
 	var username string
@@ -1144,7 +1157,11 @@ func (s *Server) getDashboardHelmSummary(r *http.Request, namespace string) Dash
 			return DashboardHelmSummary{Releases: []DashboardHelmRelease{}, Restricted: true}
 		}
 		log.Printf("[dashboard] Failed to list Helm releases: %v", err)
-		return DashboardHelmSummary{Releases: []DashboardHelmRelease{}}
+		return DashboardHelmSummary{
+			Releases:  []DashboardHelmRelease{},
+			Error:     err.Error(),
+			ErrorCode: errorCodeForHelm(err.Error(), 0),
+		}
 	}
 
 	result := DashboardHelmSummary{

--- a/internal/server/packages.go
+++ b/internal/server/packages.go
@@ -117,9 +117,11 @@ func errorCodeForHelm(err string, statusCode int) string {
 		return ErrCodeTimedOut
 	case strings.Contains(e, "connection refused"),
 		strings.Contains(e, "no such host"),
-		strings.Contains(e, "i/o timeout"),
 		strings.Contains(e, "dial tcp"),
 		strings.Contains(e, "cluster unreachable"):
+		// Note: "i/o timeout" is dead here — the timed_out case above
+		// matches "timeout" which subsumes it. The TimedOut classification
+		// is the right one for that shape (see test "timeout + dial tcp").
 		return ErrCodeUnreachable
 	}
 	return ""
@@ -169,7 +171,7 @@ func ListPackages(ctx context.Context, p ListPackagesParams) (PackagesResponse, 
 		}, nil
 	}
 
-	cacheKey := packagesCacheKeyFor(p.User, p.Namespaces)
+	cacheKey := packagesCacheKeyFor(p.Namespaces)
 	packagesCacheMu.Lock()
 	entry, hit := packagesCache[cacheKey]
 	packagesCacheMu.Unlock()
@@ -239,14 +241,14 @@ func evictOldestPackagesCacheEntry() {
 	}
 }
 
-// packagesCacheKeyFor produces a stable cache key. Both the user
-// identity and the requested namespace set must be part of the key:
-// Helm reads are user-scoped (RBAC-impersonated), so two users hitting
-// the same namespace must not share an entry.
-func packagesCacheKeyFor(user string, namespaces []string) string {
+// packagesCacheKeyFor produces a stable cache key from the requested
+// namespace set. User identity is intentionally NOT part of the key:
+// inventory reads run via the ServiceAccount (see computePackagesInternal),
+// so the result is identical for any caller with the same namespace
+// scope. Sharing entries across users avoids N-way duplication and
+// premature LRU eviction in multi-user Cloud deployments.
+func packagesCacheKeyFor(namespaces []string) string {
 	var b strings.Builder
-	b.WriteString(user)
-	b.WriteByte('|')
 	if namespaces == nil {
 		b.WriteByte('*')
 	} else {

--- a/internal/server/packages.go
+++ b/internal/server/packages.go
@@ -56,12 +56,68 @@ type SourceError struct {
 	Source     packages.SourceCode `json:"source"`
 	StatusCode int                 `json:"statusCode,omitempty"`
 	Error      string              `json:"error"`
+	// Code is a machine-readable category for this failure. Stable
+	// across phrasing changes in Error so consumers (the SPA's
+	// categorize fn, MCP clients) can branch without string-matching
+	// log messages. Populated for known failure shapes; empty for
+	// generic errors (consumer falls back to category="failed"). See
+	// errorCodeForHelm / categorizeSourceError.
+	Code string `json:"code,omitempty"`
 	// AffectedNamespaces, when set, lists the namespaces this error
 	// applies to. Populated when the error is scoped (e.g., a
 	// per-namespace Helm RBAC denial); empty when cluster-wide.
 	// Lets consumers reason about partial-result scope without
 	// reverse-parsing the Error string.
 	AffectedNamespaces []string `json:"affectedNamespaces,omitempty"`
+}
+
+// Error code constants. Stable wire values — the SPA categorize and
+// MCP clients branch on these. Add new codes here, never rename.
+const (
+	ErrCodeRBACDenied   = "rbac_denied"
+	ErrCodeUnreachable  = "unreachable"
+	ErrCodeTimedOut     = "timed_out"
+	ErrCodeUnconfigured = "unconfigured"
+	ErrCodeAuthRequired = "auth_required"
+)
+
+// errorCodeForHelm classifies a Helm error string + status into a
+// stable Code value. The SPA used to do this with regex on the user-
+// visible string; doing it backend-side means a phrasing change in
+// the SDK doesn't silently move errors into "failed" until someone
+// updates the regex too.
+func errorCodeForHelm(err string, statusCode int) string {
+	e := strings.ToLower(err)
+	switch {
+	case statusCode == http.StatusUnauthorized,
+		strings.Contains(e, "unauthorized"),
+		strings.Contains(e, "credentials expired"),
+		strings.Contains(e, "token expired"):
+		return ErrCodeAuthRequired
+	case statusCode == http.StatusForbidden,
+		strings.Contains(e, "rbac"),
+		strings.Contains(e, "forbidden"),
+		strings.Contains(e, "not authorized"),
+		strings.Contains(e, "cannot list"):
+		return ErrCodeRBACDenied
+	case strings.Contains(e, "no kubeconfig path"),
+		strings.Contains(e, "no resolved rest.config"),
+		strings.Contains(e, "no in-cluster rest config"),
+		strings.Contains(e, "client not initialized"),
+		strings.Contains(e, "connect in progress"):
+		return ErrCodeUnconfigured
+	case strings.Contains(e, "context deadline exceeded"),
+		strings.Contains(e, "timed out"),
+		strings.Contains(e, "timeout"):
+		return ErrCodeTimedOut
+	case strings.Contains(e, "connection refused"),
+		strings.Contains(e, "no such host"),
+		strings.Contains(e, "i/o timeout"),
+		strings.Contains(e, "dial tcp"),
+		strings.Contains(e, "cluster unreachable"):
+		return ErrCodeUnreachable
+	}
+	return ""
 }
 
 // ListPackagesParams carries the filters the REST + MCP handlers both
@@ -364,6 +420,7 @@ func collectHelmReleases(namespaces []string, user string, groups []string) ([]p
 		return nil, []SourceError{{
 			Source: packages.SourceHelm,
 			Error:  "helm client not initialized (cluster connect in progress or failed)",
+			Code:   ErrCodeUnconfigured,
 		}}
 	}
 	scopes := []string{""}
@@ -406,13 +463,16 @@ func collectHelmReleases(namespaces []string, user string, groups []string) ([]p
 			Source:             packages.SourceHelm,
 			StatusCode:         http.StatusForbidden,
 			Error:              "RBAC denied (helm release secrets): " + describeNamespaces(forbiddenNamespaces),
+			Code:               ErrCodeRBACDenied,
 			AffectedNamespaces: namespaceList(forbiddenNamespaces),
 		})
 	}
 	if len(otherErrs) > 0 {
+		joined := errors.Join(otherErrs...).Error()
 		errs = append(errs, SourceError{
 			Source:             packages.SourceHelm,
-			Error:              errors.Join(otherErrs...).Error(),
+			Error:              joined,
+			Code:               errorCodeForHelm(joined, 0),
 			AffectedNamespaces: namespaceList(otherErrNamespaces),
 		})
 	}

--- a/internal/server/packages.go
+++ b/internal/server/packages.go
@@ -122,7 +122,7 @@ func ListPackages(ctx context.Context, p ListPackagesParams) (PackagesResponse, 
 		generatedAt = entry.at
 	} else {
 		var err error
-		rows, sourceErrs, err = computePackagesInternal(ctx, p.Namespaces, p.User, p.Groups)
+		rows, sourceErrs, err = computePackagesInternal(ctx, p.Namespaces)
 		if err != nil {
 			return PackagesResponse{}, err
 		}
@@ -240,7 +240,13 @@ func (s *Server) handleListPackages(w http.ResponseWriter, r *http.Request) {
 // computePackagesInternal reads from all sources, merges via
 // packages.Aggregate, and post-filters by the requested namespace set.
 // Per-source errors are attributed but non-fatal.
-func computePackagesInternal(ctx context.Context, namespaces []string, user string, groups []string) ([]packages.PackageRow, []SourceError, error) {
+//
+// User identity is intentionally NOT a parameter: every read source
+// here is inventory metadata that uses the ServiceAccount under
+// cloud-mode (see the helm comment below for the rationale). User
+// identity does still flow through ListPackagesParams for cache
+// scoping and for sensitive Helm endpoints invoked elsewhere.
+func computePackagesInternal(ctx context.Context, namespaces []string) ([]packages.PackageRow, []SourceError, error) {
 	cache := k8s.GetResourceCache()
 	if cache == nil {
 		return nil, nil, errResourceCacheUnavailable
@@ -251,10 +257,21 @@ func computePackagesInternal(ctx context.Context, namespaces []string, user stri
 
 	// Helm releases (source H). For a single-namespace request we ask
 	// Helm directly; for nil (all namespaces) we ask cluster-wide. For a
-	// multi-namespace allow-list we iterate per-namespace — asking
-	// cluster-wide would require the user to have list-secrets across
-	// the cluster, which limited-RBAC users typically lack.
-	helmReleases, helmErrs := collectHelmReleases(namespaces, user, groups)
+	// multi-namespace allow-list we iterate per-namespace.
+	//
+	// Inventory reads use the ServiceAccount (empty user/groups) rather
+	// than impersonating the calling user. Helm release secrets are
+	// stored as K8s Secrets, but the chart's default cloud:viewer →
+	// K8s `view` ClusterRoleBinding excludes secrets — so impersonating
+	// would 403 every viewer on a feature that's purely inventory
+	// metadata (chart, version, status), not credential data. SA
+	// inventory matches the chart's stated intent and gives every
+	// Cloud tier the same fleet visibility.
+	//
+	// Sensitive Helm reads (GetValues, GetManifest) and all Helm writes
+	// MUST keep impersonating — those carry data + state changes the
+	// view-role exclusion was actually designed to gate.
+	helmReleases, helmErrs := collectHelmReleases(namespaces, "", nil)
 	src.Helm = helmReleases
 	errs = append(errs, helmErrs...)
 

--- a/internal/server/packages.go
+++ b/internal/server/packages.go
@@ -51,7 +51,11 @@ type PackagesResponse struct {
 	SourcesErrored []SourceError         `json:"sourcesErrored,omitempty"`
 }
 
-// SourceError carries a per-source failure.
+// SourceError carries a per-source failure. Field names + JSON tags
+// are part of the /api/packages public response shape — wire-stable.
+// Code values are likewise stable (see ErrCode* below); add new codes,
+// never rename. Renaming any of these fields silently breaks the SPA
+// (radar-hub-web) and MCP fleet_list_packages clients.
 type SourceError struct {
 	Source     packages.SourceCode `json:"source"`
 	StatusCode int                 `json:"statusCode,omitempty"`
@@ -60,8 +64,9 @@ type SourceError struct {
 	// across phrasing changes in Error so consumers (the SPA's
 	// categorize fn, MCP clients) can branch without string-matching
 	// log messages. Populated for known failure shapes; empty for
-	// generic errors (consumer falls back to category="failed"). See
-	// errorCodeForHelm / categorizeSourceError.
+	// generic errors (consumer falls back to category="failed").
+	// Producer: errorCodeForHelm in this file. Consumer: the SPA's
+	// categorizeSourceError in radar-hub-web.
 	Code string `json:"code,omitempty"`
 	// AffectedNamespaces, when set, lists the namespaces this error
 	// applies to. Populated when the error is scoped (e.g., a
@@ -311,22 +316,12 @@ func computePackagesInternal(ctx context.Context, namespaces []string) ([]packag
 	src := packages.Sources{}
 	var errs []SourceError
 
-	// Helm releases (source H). For a single-namespace request we ask
-	// Helm directly; for nil (all namespaces) we ask cluster-wide. For a
-	// multi-namespace allow-list we iterate per-namespace.
-	//
-	// Inventory reads use the ServiceAccount (empty user/groups) rather
-	// than impersonating the calling user. Helm release secrets are
-	// stored as K8s Secrets, but the chart's default cloud:viewer →
-	// K8s `view` ClusterRoleBinding excludes secrets — so impersonating
-	// would 403 every viewer on a feature that's purely inventory
-	// metadata (chart, version, status), not credential data. SA
-	// inventory matches the chart's stated intent and gives every
-	// Cloud tier the same fleet visibility.
-	//
-	// Sensitive Helm reads (GetValues, GetManifest) and all Helm writes
-	// MUST keep impersonating — those carry data + state changes the
-	// view-role exclusion was actually designed to gate.
+	// Helm releases (source H). Inventory reads pass empty user/groups
+	// so the SA does the read — see deploy/helm/radar/templates/clusterrole.yaml
+	// for the secrets-rule rationale (cloud:viewer → K8s `view` excludes
+	// secrets, so impersonating would 403 viewers on inventory metadata
+	// that isn't credential data). Sensitive Helm reads (GetValues,
+	// GetManifest) and all writes still impersonate.
 	helmReleases, helmErrs := collectHelmReleases(namespaces, "", nil)
 	src.Helm = helmReleases
 	errs = append(errs, helmErrs...)

--- a/internal/server/packages_test.go
+++ b/internal/server/packages_test.go
@@ -10,6 +10,54 @@ import (
 	"github.com/skyhook-io/radar/pkg/packages"
 )
 
+func TestErrorCodeForHelm(t *testing.T) {
+	cases := []struct {
+		name       string
+		err        string
+		statusCode int
+		want       string
+	}{
+		{"empty", "", 0, ""},
+		{"unknown shape", "something weird happened", 0, ""},
+
+		// auth — 401 status OR auth-keyword in body.
+		{"401 status", "x", 401, ErrCodeAuthRequired},
+		{"unauthorized in body", "Unauthorized: token expired", 0, ErrCodeAuthRequired},
+
+		// rbac — 403 status OR rbac/forbidden-keyword.
+		{"403 status", "denied", 403, ErrCodeRBACDenied},
+		{"rbac in body", "rbac denied (helm release secrets)", 0, ErrCodeRBACDenied},
+		{"forbidden in body", "secrets is forbidden: User cannot list", 0, ErrCodeRBACDenied},
+		{"cannot list", "cannot list resource secrets", 0, ErrCodeRBACDenied},
+
+		// unconfigured — covers both legacy + new-from-restConfigGetter strings.
+		{"new restConfigGetter error", `helm: no kubeconfig path and no resolved rest.Config available`, 0, ErrCodeUnconfigured},
+		{"in-cluster fallback error", "no in-cluster rest config available", 0, ErrCodeUnconfigured},
+		{"client not initialized", "helm client not initialized (cluster connect in progress or failed)", 0, ErrCodeUnconfigured},
+
+		// timeout
+		{"context deadline", "context deadline exceeded", 0, ErrCodeTimedOut},
+		{"timeout in body", "operation timeout", 0, ErrCodeTimedOut},
+
+		// unreachable
+		{"connection refused", `dial tcp 127.0.0.1:8080: connect: connection refused`, 0, ErrCodeUnreachable},
+		{"no such host", "dial tcp: lookup foo: no such host", 0, ErrCodeUnreachable},
+
+		// Ordering: auth precedes rbac (a 403 with "unauthorized" in
+		// body is auth-required, not rbac-denied — though that combo
+		// shouldn't happen in practice).
+		{"401 with rbac word in body", "rbac unavailable", 401, ErrCodeAuthRequired},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := errorCodeForHelm(tc.err, tc.statusCode)
+			if got != tc.want {
+				t.Errorf("errorCodeForHelm(%q, %d) = %q, want %q", tc.err, tc.statusCode, got, tc.want)
+			}
+		})
+	}
+}
+
 // Pins the error wording produced by k8s.ResourceCache.ListDynamicWithGroup
 // when the requested CRD isn't installed. If that wording changes,
 // graceful degradation breaks for clusters without ArgoCD/FluxCD —

--- a/internal/server/packages_test.go
+++ b/internal/server/packages_test.go
@@ -43,10 +43,14 @@ func TestErrorCodeForHelm(t *testing.T) {
 		{"connection refused", `dial tcp 127.0.0.1:8080: connect: connection refused`, 0, ErrCodeUnreachable},
 		{"no such host", "dial tcp: lookup foo: no such host", 0, ErrCodeUnreachable},
 
-		// Ordering: auth precedes rbac (a 403 with "unauthorized" in
-		// body is auth-required, not rbac-denied — though that combo
-		// shouldn't happen in practice).
-		{"401 with rbac word in body", "rbac unavailable", 401, ErrCodeAuthRequired},
+		// Ordering pins. The classifier is a sequential switch; these
+		// cases lock down precedence so a future reorder doesn't
+		// silently re-bucket multi-keyword bodies.
+		{"401 status with rbac word in body", "rbac unavailable", 401, ErrCodeAuthRequired},
+		{"rbac word + context deadline", "context deadline exceeded querying rbac role", 0, ErrCodeRBACDenied},
+		{"forbidden + connection refused", "forbidden: dial tcp connection refused", 0, ErrCodeRBACDenied},
+		{"unconfigured + timeout phrase", "no resolved rest.Config available; timeout reached", 0, ErrCodeUnconfigured},
+		{"timeout + dial tcp (i/o timeout shape)", "i/o timeout dialing tcp 10.0.0.1:443", 0, ErrCodeTimedOut},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/server/packages_test.go
+++ b/internal/server/packages_test.go
@@ -89,27 +89,25 @@ func TestIsMissingCRDErr_PinsK8scoreErrorString(t *testing.T) {
 	}
 }
 
-func TestPackagesCacheKey_DistinguishesUserAndNamespaces(t *testing.T) {
-	// Same user, different namespace sets → different keys.
-	a := packagesCacheKeyFor("alice", []string{"prod"})
-	b := packagesCacheKeyFor("alice", []string{"staging"})
+func TestPackagesCacheKey_DistinguishesNamespaces(t *testing.T) {
+	// Different namespace sets → different keys.
+	a := packagesCacheKeyFor([]string{"prod"})
+	b := packagesCacheKeyFor([]string{"staging"})
 	if a == b {
 		t.Errorf("expected different keys for different namespaces, got %q", a)
 	}
-	// Different users, same namespaces → different keys.
-	c := packagesCacheKeyFor("bob", []string{"prod"})
-	if a == c {
-		t.Errorf("expected different keys for different users, got %q", a)
-	}
-	// nil namespaces vs empty slice should be different (empty = no access).
-	all := packagesCacheKeyFor("alice", nil)
-	none := packagesCacheKeyFor("alice", []string{})
+	// User identity is intentionally NOT part of the key — inventory
+	// reads run via the SA so two users with the same namespace scope
+	// share the entry. (See packagesCacheKeyFor godoc.)
+	// nil namespaces vs empty slice must differ (empty = no access).
+	all := packagesCacheKeyFor(nil)
+	none := packagesCacheKeyFor([]string{})
 	if all == none {
 		t.Errorf("nil (all namespaces) and empty slice (no access) must differ; both = %q", all)
 	}
 	// Order independence: same set in different orders → same key.
-	x := packagesCacheKeyFor("alice", []string{"a", "b"})
-	y := packagesCacheKeyFor("alice", []string{"b", "a"})
+	x := packagesCacheKeyFor([]string{"a", "b"})
+	y := packagesCacheKeyFor([]string{"b", "a"})
 	if x != y {
 		t.Errorf("namespace order should not affect key: %q vs %q", x, y)
 	}
@@ -196,56 +194,41 @@ func TestFilterByChartSubstring_CaseInsensitive(t *testing.T) {
 	}
 }
 
-// Behavioral guard against the most security-sensitive regression in
-// this module: two users hitting the same namespace must NOT see each
-// other's Helm rows. We pre-populate the cache with two distinct
-// (user, ns) entries and verify ListPackages returns each user's data
-// from their respective entry.
+// Inventory reads run via the SA (computePackagesInternal ignores user
+// identity), so two users with the same namespace scope must share a
+// cache entry — duplicating per-user wastes memory and triggers
+// premature LRU eviction in multi-user Cloud deployments. We populate
+// one entry, dispatch two requests under different user identities,
+// and verify both see the same rows.
 //
-// This catches: forgetting User in packagesCacheKeyFor; reordering the
-// cache lookup before the user is wired in; or any refactor that drops
-// user identity from the key path.
-func TestListPackages_UserScopedCacheReturnsDistinctData(t *testing.T) {
+// This catches: a regression that re-introduces user identity into
+// packagesCacheKeyFor (e.g. "let's scope per-user for safety" without
+// a corresponding return to per-user impersonation in
+// computePackagesInternal).
+func TestListPackages_SharedCacheAcrossUsers(t *testing.T) {
 	withCleanCache(t, func() {
-		now := time.Now()
-		aliceKey := packagesCacheKeyFor("alice", []string{"prod"})
-		bobKey := packagesCacheKeyFor("bob", []string{"prod"})
-
+		key := packagesCacheKeyFor([]string{"prod"})
+		shared := packagesCacheEntry{
+			at: time.Now(),
+			rows: []packages.PackageRow{{
+				Chart: "shared-chart", Namespace: "prod", ReleaseName: "shared-app",
+				Sources: []packages.SourceCode{packages.SourceHelm}, Health: packages.HealthHealthy,
+			}},
+		}
 		packagesCacheMu.Lock()
-		packagesCache[aliceKey] = packagesCacheEntry{
-			at: now,
-			rows: []packages.PackageRow{{
-				Chart: "alice-only-chart", Namespace: "prod", ReleaseName: "alice-app",
-				Sources: []packages.SourceCode{packages.SourceHelm}, Health: packages.HealthHealthy,
-			}},
-		}
-		packagesCache[bobKey] = packagesCacheEntry{
-			at: now,
-			rows: []packages.PackageRow{{
-				Chart: "bob-only-chart", Namespace: "prod", ReleaseName: "bob-app",
-				Sources: []packages.SourceCode{packages.SourceHelm}, Health: packages.HealthHealthy,
-			}},
-		}
+		packagesCache[key] = shared
 		packagesCacheMu.Unlock()
 
-		aliceResp, err := ListPackages(context.Background(), ListPackagesParams{
-			Namespaces: []string{"prod"}, User: "alice",
-		})
-		if err != nil {
-			t.Fatalf("alice ListPackages: %v", err)
-		}
-		if len(aliceResp.Packages) != 1 || aliceResp.Packages[0].Chart != "alice-only-chart" {
-			t.Fatalf("alice got %+v, want chart=alice-only-chart", aliceResp.Packages)
-		}
-
-		bobResp, err := ListPackages(context.Background(), ListPackagesParams{
-			Namespaces: []string{"prod"}, User: "bob",
-		})
-		if err != nil {
-			t.Fatalf("bob ListPackages: %v", err)
-		}
-		if len(bobResp.Packages) != 1 || bobResp.Packages[0].Chart != "bob-only-chart" {
-			t.Fatalf("bob got %+v, want chart=bob-only-chart", bobResp.Packages)
+		for _, user := range []string{"alice", "bob"} {
+			resp, err := ListPackages(context.Background(), ListPackagesParams{
+				Namespaces: []string{"prod"}, User: user,
+			})
+			if err != nil {
+				t.Fatalf("%s ListPackages: %v", user, err)
+			}
+			if len(resp.Packages) != 1 || resp.Packages[0].Chart != "shared-chart" {
+				t.Fatalf("%s got %+v, want chart=shared-chart from shared entry", user, resp.Packages)
+			}
 		}
 	})
 }
@@ -259,7 +242,7 @@ func TestListPackages_EmptyNamespacesShortCircuits(t *testing.T) {
 	withCleanCache(t, func() {
 		// Pre-populate "all namespaces" cache to make sure the
 		// short-circuit doesn't accidentally read it.
-		nilKey := packagesCacheKeyFor("alice", nil)
+		nilKey := packagesCacheKeyFor(nil)
 		packagesCacheMu.Lock()
 		packagesCache[nilKey] = packagesCacheEntry{
 			at: time.Now(),
@@ -285,7 +268,7 @@ func TestListPackages_EmptyNamespacesShortCircuits(t *testing.T) {
 			t.Errorf("want empty SourcesErrored, got %v", resp.SourcesErrored)
 		}
 		// Verify the empty-slice path didn't write a cache entry.
-		emptyKey := packagesCacheKeyFor("alice", []string{})
+		emptyKey := packagesCacheKeyFor([]string{})
 		packagesCacheMu.Lock()
 		_, hit := packagesCache[emptyKey]
 		packagesCacheMu.Unlock()
@@ -302,7 +285,7 @@ func TestListPackages_EmptyNamespacesShortCircuits(t *testing.T) {
 func TestListPackages_CachedResponseUsesEntryTimestamp(t *testing.T) {
 	withCleanCache(t, func() {
 		entryAt := time.Now().Add(-30 * time.Second)
-		key := packagesCacheKeyFor("alice", []string{"prod"})
+		key := packagesCacheKeyFor([]string{"prod"})
 		packagesCacheMu.Lock()
 		packagesCache[key] = packagesCacheEntry{
 			at:   entryAt,
@@ -356,10 +339,10 @@ func TestListPackages_CacheCapEnforcedAtInsert(t *testing.T) {
 		// Pre-fill cache to cap with stale-but-valid entries.
 		base := time.Now().Add(-30 * time.Second) // still fresh for TTL
 		packagesCacheMu.Lock()
-		oldestKey := packagesCacheKeyFor("u0", []string{"ns0"})
+		oldestKey := packagesCacheKeyFor([]string{"ns0"})
 		packagesCache[oldestKey] = packagesCacheEntry{at: base.Add(-time.Minute)}
 		for i := 1; i < packagesCacheMaxEntries; i++ {
-			k := packagesCacheKeyFor(fmt.Sprintf("u%d", i), []string{fmt.Sprintf("ns%d", i)})
+			k := packagesCacheKeyFor([]string{fmt.Sprintf("ns%d", i)})
 			packagesCache[k] = packagesCacheEntry{at: base.Add(time.Duration(i) * time.Second)}
 		}
 		if len(packagesCache) != packagesCacheMaxEntries {
@@ -376,7 +359,7 @@ func TestListPackages_CacheCapEnforcedAtInsert(t *testing.T) {
 		if len(packagesCache) >= packagesCacheMaxEntries {
 			evictOldestPackagesCacheEntry()
 		}
-		packagesCache[packagesCacheKeyFor("new-user", []string{"new-ns"})] = packagesCacheEntry{at: time.Now()}
+		packagesCache[packagesCacheKeyFor([]string{"new-ns"})] = packagesCacheEntry{at: time.Now()}
 		packagesCacheMu.Unlock()
 
 		// The oldest entry must have been evicted; cap respected.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2602,6 +2602,12 @@ func (s *Server) handleAuthMe(w http.ResponseWriter, r *http.Request) {
 	if user := auth.UserFromContext(r.Context()); user != nil {
 		resp["username"] = user.Username
 		resp["groups"] = user.Groups
+		// Pre-compute the Cloud role so the SPA doesn't have to
+		// re-parse `cloud:<tier>` group prefixes. Empty string means
+		// "not running under Cloud" (OSS deploy or no role group).
+		if role := auth.CloudRoleFromGroups(user.Groups); role != auth.RoleNone {
+			resp["cloudRole"] = string(role)
+		}
 	}
 	s.writeJSON(w, resp)
 }

--- a/internal/server/server_auth_test.go
+++ b/internal/server/server_auth_test.go
@@ -86,6 +86,28 @@ func TestHandleAuthMe_AuthEnabled_WithUser(t *testing.T) {
 	if len(groups) != 2 {
 		t.Errorf("groups = %v, want 2 groups", groups)
 	}
+	// Non-Cloud user — cloudRole must be absent so the SPA's
+	// useCloudRole hook treats them as "not under Cloud."
+	if _, has := body["cloudRole"]; has {
+		t.Errorf("cloudRole should not be present for non-Cloud user (groups=%v)", groups)
+	}
+}
+
+func TestHandleAuthMe_CloudUser_ExposesCloudRole(t *testing.T) {
+	s := newAuthServer(auth.Config{Mode: "proxy"})
+	w := httptest.NewRecorder()
+	r := requestWithUser("GET", "/api/auth/me", &auth.User{
+		Username: "bob",
+		Groups:   []string{"cloud:viewer", "cloud:org:abc"},
+	})
+	s.handleAuthMe(w, r)
+
+	var body map[string]any
+	json.NewDecoder(w.Body).Decode(&body)
+
+	if body["cloudRole"] != "viewer" {
+		t.Errorf("cloudRole = %v, want viewer", body["cloudRole"])
+	}
 }
 
 // --- parseNamespaces ---

--- a/pkg/auth/cloud_role.go
+++ b/pkg/auth/cloud_role.go
@@ -28,6 +28,13 @@ const (
 
 const cloudGroupPrefix = "cloud:"
 
+// ErrCodeCloudRoleInsufficient is the stable wire value emitted in 403
+// response bodies (`error_code` field) when a request is denied by a
+// Cloud role gate. SPA + MCP clients branch on this exact string —
+// never rename. Hoisted out of internal/helm/handlers.go so the
+// canonical value lives next to the role types it pertains to.
+const ErrCodeCloudRoleInsufficient = "cloud_role_insufficient"
+
 var tierRank = map[CloudRole]int{
 	RoleViewer: 1,
 	RoleMember: 2,

--- a/pkg/auth/cloud_role.go
+++ b/pkg/auth/cloud_role.go
@@ -1,0 +1,86 @@
+package auth
+
+import (
+	"context"
+	"strings"
+)
+
+// CloudRole captures the user's tier under Radar Cloud's RBAC model.
+// Cloud injects one of `cloud:owner` / `cloud:member` / `cloud:viewer`
+// into X-Forwarded-Groups; this type extracts that signal.
+//
+// CloudRole is the **product-side** boundary (decides whether the user
+// can attempt an operation in the UI / API). The K8s ClusterRoleBindings
+// the chart ships are the **structural** boundary (decides whether the
+// K8s API server allows the impersonated request). The two stack:
+// CloudRole gates "can I attempt it?", K8s RBAC gates "can it succeed?".
+type CloudRole string
+
+const (
+	// RoleNone means the request is not from a Cloud-attributed user
+	// (OSS deploy, or a Cloud bug stripped the role group). AtLeast
+	// returns true for RoleNone so non-Cloud deploys aren't gated.
+	RoleNone   CloudRole = ""
+	RoleViewer CloudRole = "viewer"
+	RoleMember CloudRole = "member"
+	RoleOwner  CloudRole = "owner"
+)
+
+const cloudGroupPrefix = "cloud:"
+
+var tierRank = map[CloudRole]int{
+	RoleViewer: 1,
+	RoleMember: 2,
+	RoleOwner:  3,
+}
+
+// CloudRoleFromGroups returns the highest-ranked Cloud tier present in
+// the group list. Returns RoleNone when no `cloud:<tier>` group is
+// found, which the call sites treat as "not running under Cloud."
+func CloudRoleFromGroups(groups []string) CloudRole {
+	var best CloudRole
+	bestRank := 0
+	for _, g := range groups {
+		if !strings.HasPrefix(g, cloudGroupPrefix) {
+			continue
+		}
+		role := CloudRole(strings.TrimPrefix(g, cloudGroupPrefix))
+		rank, ok := tierRank[role]
+		if !ok {
+			continue
+		}
+		if rank > bestRank {
+			best = role
+			bestRank = rank
+		}
+	}
+	return best
+}
+
+// CloudRoleFromContext is a convenience over UserFromContext +
+// CloudRoleFromGroups. Returns RoleNone when no user is in context.
+func CloudRoleFromContext(ctx context.Context) CloudRole {
+	user := UserFromContext(ctx)
+	if user == nil {
+		return RoleNone
+	}
+	return CloudRoleFromGroups(user.Groups)
+}
+
+// AtLeast reports whether r meets or exceeds min. RoleNone (no Cloud
+// role detected) bypasses the gate — non-Cloud deploys must not be
+// blocked by Cloud-tier checks.
+func (r CloudRole) AtLeast(min CloudRole) bool {
+	if r == RoleNone {
+		return true
+	}
+	return tierRank[r] >= tierRank[min]
+}
+
+// String returns the role name suitable for log/error messages.
+func (r CloudRole) String() string {
+	if r == RoleNone {
+		return "none"
+	}
+	return string(r)
+}

--- a/pkg/auth/cloud_role_test.go
+++ b/pkg/auth/cloud_role_test.go
@@ -1,0 +1,92 @@
+package auth
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCloudRoleFromGroups(t *testing.T) {
+	cases := []struct {
+		name   string
+		groups []string
+		want   CloudRole
+	}{
+		{"empty groups", nil, RoleNone},
+		{"no cloud prefix", []string{"developers", "sre"}, RoleNone},
+		{"viewer", []string{"cloud:viewer"}, RoleViewer},
+		{"member", []string{"cloud:member"}, RoleMember},
+		{"owner", []string{"cloud:owner"}, RoleOwner},
+		{"unknown cloud tier", []string{"cloud:superuser"}, RoleNone},
+		{"viewer + non-cloud", []string{"cloud:viewer", "team:platform"}, RoleViewer},
+		// Cloud injects multiple cloud:* groups (cloud:<tier>, cloud:org:<id>,
+		// cloud:user:<id>). Only the tier should drive the role.
+		{"multiple cloud groups", []string{"cloud:viewer", "cloud:org:abc", "cloud:user:xyz"}, RoleViewer},
+		// If two tiers are present (shouldn't happen in practice), prefer
+		// the highest. Defensive: a header-stuffing attempt to downgrade
+		// shouldn't succeed by adding a lower-tier alongside.
+		{"two tiers — pick highest", []string{"cloud:viewer", "cloud:owner"}, RoleOwner},
+		{"member + viewer", []string{"cloud:member", "cloud:viewer"}, RoleMember},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CloudRoleFromGroups(tc.groups)
+			if got != tc.want {
+				t.Errorf("CloudRoleFromGroups(%v) = %q, want %q", tc.groups, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCloudRole_AtLeast(t *testing.T) {
+	cases := []struct {
+		role CloudRole
+		min  CloudRole
+		want bool
+	}{
+		// RoleNone bypasses — non-Cloud deploys must not be gated.
+		{RoleNone, RoleViewer, true},
+		{RoleNone, RoleMember, true},
+		{RoleNone, RoleOwner, true},
+		{RoleViewer, RoleViewer, true},
+		{RoleViewer, RoleMember, false},
+		{RoleViewer, RoleOwner, false},
+		{RoleMember, RoleViewer, true},
+		{RoleMember, RoleMember, true},
+		{RoleMember, RoleOwner, false},
+		{RoleOwner, RoleViewer, true},
+		{RoleOwner, RoleMember, true},
+		{RoleOwner, RoleOwner, true},
+	}
+	for _, tc := range cases {
+		got := tc.role.AtLeast(tc.min)
+		if got != tc.want {
+			t.Errorf("CloudRole(%q).AtLeast(%q) = %v, want %v", tc.role, tc.min, got, tc.want)
+		}
+	}
+}
+
+func TestCloudRoleFromContext(t *testing.T) {
+	t.Run("no user in context", func(t *testing.T) {
+		if got := CloudRoleFromContext(context.Background()); got != RoleNone {
+			t.Errorf("CloudRoleFromContext(empty) = %q, want RoleNone", got)
+		}
+	})
+	t.Run("user with Cloud groups", func(t *testing.T) {
+		ctx := ContextWithUser(context.Background(), &User{
+			Username: "alice",
+			Groups:   []string{"cloud:member", "cloud:org:abc"},
+		})
+		if got := CloudRoleFromContext(ctx); got != RoleMember {
+			t.Errorf("CloudRoleFromContext = %q, want member", got)
+		}
+	})
+	t.Run("user without Cloud groups (OSS proxy/oidc)", func(t *testing.T) {
+		ctx := ContextWithUser(context.Background(), &User{
+			Username: "bob",
+			Groups:   []string{"sre", "platform-team"},
+		})
+		if got := CloudRoleFromContext(ctx); got != RoleNone {
+			t.Errorf("CloudRoleFromContext = %q, want RoleNone (no cloud: prefix)", got)
+		}
+	})
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -212,7 +212,13 @@ export interface DashboardHelmRelease {
 export interface DashboardHelmSummary {
   total: number
   releases: DashboardHelmRelease[]
-  restricted?: boolean // True when user lacks permissions to list Helm releases
+  restricted?: boolean // True when user lacks permissions to list Helm releases (RBAC-denied)
+  // error + errorCode populated when the Helm read failed for a non-RBAC
+  // reason (client not initialized, unconfigured, network). Surfaced
+  // via the dashboard widget so empty results aren't mistaken for
+  // "this cluster has zero releases."
+  error?: string
+  errorCode?: string
 }
 
 export interface DashboardCRDCount {
@@ -264,6 +270,7 @@ export interface DashboardResponse {
   audit: DashboardAudit | null
   nodeVersionSkew: { versions: Record<string, string[]>; minVersion: string; maxVersion: string } | null
   deferredLoading?: boolean // True while deferred informers (secrets, events, etc.) are still syncing
+  partialData?: string[] // Resource kinds still loading after first paint (slow-cluster fallback)
   accessRestricted?: boolean // True when user has no namespace access (RBAC)
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -690,22 +690,31 @@ const CLOUD_ROLE_RANK: Record<string, number> = { viewer: 1, member: 2, owner: 3
 
 /**
  * useCloudRole returns the caller's Cloud tier (`owner` / `member` /
- * `viewer`) and a `canAtLeast(min)` gate. When no Cloud role is
- * present (OSS, OIDC, no role group), `canAtLeast` returns true for
- * every tier — the gate is strictly additive for Cloud-attributed
+ * `viewer`) and a `canAtLeast(min)` gate. When auth/me has resolved
+ * AND no Cloud role is present (OSS, OIDC, no role group), the gate
+ * bypasses — the gate is strictly additive for Cloud-attributed
  * users, mirroring the backend's `requireCloudRole` semantics.
+ *
+ * While auth/me is still loading, `canAtLeast` returns false. The
+ * alternative (treat loading as "no role" → bypass) lets a viewer
+ * see action buttons momentarily enabled on first paint, which then
+ * flip to disabled when /api/auth/me resolves a few hundred ms
+ * later. Fail-closed during load matches what users expect — buttons
+ * start disabled and enable once we know who they are.
  *
  * Use to hide / disable UI affordances for ops the user can't
  * perform. The backend still enforces; this is purely UX.
  */
 export function useCloudRole() {
-  const { data } = useAuthMe()
+  const { data, isLoading } = useAuthMe()
   const role = data?.cloudRole
   return {
     role,
+    isLoading,
     isCloudUser: !!role,
     canAtLeast: (min: CloudRole) => {
-      if (!role) return true // not Cloud-attributed → no gate
+      if (isLoading) return false // fail-closed during /api/auth/me round-trip
+      if (!role) return true // resolved + no Cloud tier → OSS/OIDC, no gate
       return (CLOUD_ROLE_RANK[role] ?? 0) >= (CLOUD_ROLE_RANK[min] ?? 0)
     },
   }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1731,8 +1731,11 @@ export function useHelmRelease(namespace: string, name: string) {
   })
 }
 
-// Get manifest for a Helm release (optionally at a specific revision)
-export function useHelmManifest(namespace: string, name: string, revision?: number) {
+// Get manifest for a Helm release (optionally at a specific revision).
+// `enabled` lets callers skip the query when the user's Cloud role
+// would 403 the read — saves a round-trip and avoids a transient
+// "error" state that the role-gated empty panel doesn't need.
+export function useHelmManifest(namespace: string, name: string, revision?: number, enabled = true) {
   const params = revision ? `?revision=${revision}` : ''
   return useQuery<string>({
     queryKey: ['helm-manifest', namespace, name, revision],
@@ -1744,34 +1747,35 @@ export function useHelmManifest(namespace: string, name: string, revision?: numb
       }
       return response.text()
     },
-    enabled: Boolean(namespace && name),
+    enabled: Boolean(namespace && name && enabled),
     staleTime: 60000, // 1 minute
   })
 }
 
-// Get values for a Helm release
-export function useHelmValues(namespace: string, name: string, allValues?: boolean) {
+// Get values for a Helm release. `enabled` see useHelmManifest.
+export function useHelmValues(namespace: string, name: string, allValues?: boolean, enabled = true) {
   const params = allValues ? '?all=true' : ''
   return useQuery<HelmValues>({
     queryKey: ['helm-values', namespace, name, allValues],
     queryFn: () => fetchJSON(`/helm/releases/${namespace}/${name}/values${params}`),
-    enabled: Boolean(namespace && name),
+    enabled: Boolean(namespace && name && enabled),
     staleTime: 60000,
   })
 }
 
-// Get diff between two revisions
+// Get diff between two revisions. `enabled` see useHelmManifest.
 export function useHelmManifestDiff(
   namespace: string,
   name: string,
   revision1: number,
-  revision2: number
+  revision2: number,
+  enabled = true,
 ) {
   return useQuery<ManifestDiff>({
     queryKey: ['helm-diff', namespace, name, revision1, revision2],
     queryFn: () =>
       fetchJSON(`/helm/releases/${namespace}/${name}/diff?revision1=${revision1}&revision2=${revision2}`),
-    enabled: Boolean(namespace && name && revision1 > 0 && revision2 > 0 && revision1 !== revision2),
+    enabled: Boolean(namespace && name && revision1 > 0 && revision2 > 0 && revision1 !== revision2 && enabled),
     staleTime: 60000,
   })
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -690,20 +690,20 @@ const CLOUD_ROLE_RANK: Record<string, number> = { viewer: 1, member: 2, owner: 3
 
 /**
  * useCloudRole returns the caller's Cloud tier (`owner` / `member` /
- * `viewer`) and a `canAtLeast(min)` gate. When auth/me has resolved
- * AND no Cloud role is present (OSS, OIDC, no role group), the gate
- * bypasses — the gate is strictly additive for Cloud-attributed
- * users, mirroring the backend's `requireCloudRole` semantics.
+ * `viewer`) and a `canAtLeast(min)` gate. When no Cloud role is
+ * present (OSS, OIDC, no role group, OR auth/me is still loading),
+ * `canAtLeast` returns true — the gate is strictly additive for
+ * Cloud-attributed users, mirroring the backend's `requireCloudRole`
+ * semantics. Use for passive content gating (panels, sections); use
+ * `useCanHelmAct` (or similar) for *click-prone* surfaces where you
+ * need fail-closed behavior during the auth/me round-trip to prevent
+ * a viewer from clicking through during the loading window.
  *
- * While auth/me is still loading, `canAtLeast` returns false. The
- * alternative (treat loading as "no role" → bypass) lets a viewer
- * see action buttons momentarily enabled on first paint, which then
- * flip to disabled when /api/auth/me resolves a few hundred ms
- * later. Fail-closed during load matches what users expect — buttons
- * start disabled and enable once we know who they are.
- *
- * Use to hide / disable UI affordances for ops the user can't
- * perform. The backend still enforces; this is purely UX.
+ * Why optimistic during load: the gated empty state ("Your role can't
+ * view…") rendered briefly to OSS / kubectl-plugin users before
+ * auth/me resolves is a worse regression than a Cloud viewer seeing
+ * a content tab populate for a tick before being gated out. Click-
+ * prevention belongs in the action-button hook, not here.
  */
 export function useCloudRole() {
   const { data, isLoading } = useAuthMe()
@@ -713,8 +713,7 @@ export function useCloudRole() {
     isLoading,
     isCloudUser: !!role,
     canAtLeast: (min: CloudRole) => {
-      if (isLoading) return false // fail-closed during /api/auth/me round-trip
-      if (!role) return true // resolved + no Cloud tier → OSS/OIDC, no gate
+      if (!role) return true // not Cloud-attributed (incl. still-loading) → no gate
       return (CLOUD_ROLE_RANK[role] ?? 0) >= (CLOUD_ROLE_RANK[min] ?? 0)
     },
   }
@@ -732,7 +731,17 @@ export function useCloudRole() {
  */
 export function useCanHelmAct(): { allowed: boolean; reason?: string } {
   const helmWrite = useCanHelmWrite()
-  const { role, canAtLeast } = useCloudRole()
+  const { role, canAtLeast, isLoading } = useCloudRole()
+  // Fail-closed for action buttons during the auth/me round-trip:
+  // a Cloud viewer who clicks during loading would otherwise fire a
+  // real request that gets 403'd. For OSS / kubectl-plugin the
+  // round-trip is sub-ms so this is imperceptible; for Cloud it
+  // prevents the click-through window. Distinct from useCloudRole's
+  // canAtLeast (which is optimistic during loading) because passive
+  // content gates don't have a click-handler to misfire.
+  if (isLoading) {
+    return { allowed: false, reason: 'Loading permissions…' }
+  }
   if (!canAtLeast('member')) {
     return {
       allowed: false,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient, skipToken } from '@tanstack/react-query'
 import { showApiError, showApiSuccess } from '../components/ui/Toast'
+import { useCanHelmWrite } from '../contexts/CapabilitiesContext'
 import type {
   Topology,
   ClusterInfo,
@@ -661,11 +662,16 @@ export function useNamespaceCapabilities(namespace: string | undefined, globalCa
 }
 
 // Auth
+export type CloudRole = 'owner' | 'member' | 'viewer'
+
 export interface AuthMe {
   authEnabled: boolean
   authMode?: string
   username?: string
   groups?: string[]
+  /** Pre-computed Cloud tier from `cloud:<tier>` group prefix.
+   *  Absent when not running under Cloud (OSS, OIDC, no role group). */
+  cloudRole?: CloudRole
 }
 
 export function useAuthMe() {
@@ -674,6 +680,63 @@ export function useAuthMe() {
     queryFn: () => fetchJSON('/auth/me'),
     staleTime: 300000, // 5 minutes
   })
+}
+
+// Tier ordering for Cloud-role gates. Mirrors radar OSS pkg/auth
+// CloudRole.AtLeast — the SPA must agree with the backend on what
+// "member-or-higher" means; otherwise we'd hide a button the
+// backend would happily honor (or vice versa).
+const CLOUD_ROLE_RANK: Record<string, number> = { viewer: 1, member: 2, owner: 3 }
+
+/**
+ * useCloudRole returns the caller's Cloud tier (`owner` / `member` /
+ * `viewer`) and a `canAtLeast(min)` gate. When no Cloud role is
+ * present (OSS, OIDC, no role group), `canAtLeast` returns true for
+ * every tier — the gate is strictly additive for Cloud-attributed
+ * users, mirroring the backend's `requireCloudRole` semantics.
+ *
+ * Use to hide / disable UI affordances for ops the user can't
+ * perform. The backend still enforces; this is purely UX.
+ */
+export function useCloudRole() {
+  const { data } = useAuthMe()
+  const role = data?.cloudRole
+  return {
+    role,
+    isCloudUser: !!role,
+    canAtLeast: (min: CloudRole) => {
+      if (!role) return true // not Cloud-attributed → no gate
+      return (CLOUD_ROLE_RANK[role] ?? 0) >= (CLOUD_ROLE_RANK[min] ?? 0)
+    },
+  }
+}
+
+/**
+ * useCanHelmAct combines the K8s capability gate (rbac.helm=true) and
+ * the Cloud role gate (member+) into a single answer for any Helm
+ * write or sensitive-read button. Returns { allowed, reason } so the
+ * tooltip can explain which gate failed.
+ *
+ * Cloud role check runs FIRST so the message is actionable for Cloud
+ * users — telling them "Helm write permissions required" is wrong if
+ * the chart is fine and the actual gate is their viewer role.
+ */
+export function useCanHelmAct(): { allowed: boolean; reason?: string } {
+  const helmWrite = useCanHelmWrite()
+  const { role, canAtLeast } = useCloudRole()
+  if (!canAtLeast('member')) {
+    return {
+      allowed: false,
+      reason: `Your Radar Cloud role (${role ?? 'unknown'}) cannot run Helm operations. Ask a member or owner.`,
+    }
+  }
+  if (!helmWrite) {
+    return {
+      allowed: false,
+      reason: 'Helm write permissions required. Set rbac.helm=true in the Radar Helm chart values.',
+    }
+  }
+  return { allowed: true }
 }
 
 // Namespaces

--- a/web/src/components/helm/ChartBrowser.tsx
+++ b/web/src/components/helm/ChartBrowser.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from 'react'
 import { Search, RefreshCw, Package, Database, AlertCircle, ExternalLink, ChevronDown, Star, Shield, BadgeCheck, Building2, Globe, ArrowUpDown, FileJson, PenTool } from 'lucide-react'
 import { clsx } from 'clsx'
 import { useHelmRepositories, useSearchCharts, useUpdateRepository, useArtifactHubSearch, type ArtifactHubSortOption } from '../../api/client'
-import { useCanHelmAct } from '../../api/client'
+import { useCanHelmWrite } from '../../contexts/CapabilitiesContext'
 import type { ChartInfo, HelmRepository, ArtifactHubChart, ChartSource } from '../../types'
 import { formatAge } from './helm-utils'
 import { SEVERITY_BADGE } from '../../utils/badge-colors'
@@ -23,7 +23,13 @@ export function ChartBrowser({ onChartSelect }: ChartBrowserProps) {
   const [showVerifiedOnly, setShowVerifiedOnly] = useState(false)
   const [artifactHubSort, setArtifactHubSort] = useState<ArtifactHubSortOption>('relevance')
 
-  const { allowed: canHelmWrite, reason: helmActReason } = useCanHelmAct()
+  // Repo refresh is gated only by `requireHelmWrite` on the backend
+  // (handleUpdateRepository deliberately skips requireCloudRole — it
+  // mutates pod-local chart cache, not cluster state). So the SPA gate
+  // here must NOT include the Cloud role check, or Cloud viewers with
+  // rbac.helm=true would be blocked from a refresh the backend allows.
+  const canHelmWrite = useCanHelmWrite()
+  const helmWriteReason = canHelmWrite ? '' : 'Helm write permissions required. Set rbac.helm=true in the Radar Helm chart values.'
 
   // Local repo hooks
   const { data: repositories, isLoading: reposLoading } = useHelmRepositories()
@@ -162,7 +168,7 @@ export function ChartBrowser({ onChartSelect }: ChartBrowserProps) {
                       onUpdate={() => handleUpdateRepo(repo.name)}
                       isUpdating={updateRepoMutation.isPending}
                       canUpdate={canHelmWrite}
-                      cantUpdateReason={helmActReason}
+                      cantUpdateReason={helmWriteReason}
                     />
                   ))
                 )}
@@ -236,7 +242,7 @@ export function ChartBrowser({ onChartSelect }: ChartBrowserProps) {
             </label>
 
             {/* Refresh button */}
-            <Tooltip content={canHelmWrite ? "Update all repositories" : (helmActReason ?? '')}>
+            <Tooltip content={canHelmWrite ? "Update all repositories" : helmWriteReason}>
               <button
                 onClick={handleUpdateAllRepos}
                 disabled={updateRepoMutation.isPending || !canHelmWrite}
@@ -357,9 +363,9 @@ interface RepoDropdownItemProps {
   onUpdate: () => void
   isUpdating: boolean
   canUpdate: boolean
-  /** Reason rendered in the disabled button's tooltip — comes from
-   *  useCanHelmAct so a viewer sees the role gate, not the rbac.helm
-   *  message that's only relevant for K8s-capability denials. */
+  /** Reason rendered in the disabled button's tooltip when canUpdate
+   *  is false — only the rbac.helm capability is relevant here, since
+   *  repo refresh is not Cloud-role-gated on the backend. */
   cantUpdateReason?: string
 }
 

--- a/web/src/components/helm/ChartBrowser.tsx
+++ b/web/src/components/helm/ChartBrowser.tsx
@@ -162,6 +162,7 @@ export function ChartBrowser({ onChartSelect }: ChartBrowserProps) {
                       onUpdate={() => handleUpdateRepo(repo.name)}
                       isUpdating={updateRepoMutation.isPending}
                       canUpdate={canHelmWrite}
+                      cantUpdateReason={helmActReason}
                     />
                   ))
                 )}
@@ -356,9 +357,13 @@ interface RepoDropdownItemProps {
   onUpdate: () => void
   isUpdating: boolean
   canUpdate: boolean
+  /** Reason rendered in the disabled button's tooltip — comes from
+   *  useCanHelmAct so a viewer sees the role gate, not the rbac.helm
+   *  message that's only relevant for K8s-capability denials. */
+  cantUpdateReason?: string
 }
 
-function RepoDropdownItem({ repo, isSelected, onSelect, onUpdate, isUpdating, canUpdate }: RepoDropdownItemProps) {
+function RepoDropdownItem({ repo, isSelected, onSelect, onUpdate, isUpdating, canUpdate, cantUpdateReason }: RepoDropdownItemProps) {
   return (
     <div className="flex items-center justify-between px-3 py-2 hover:bg-theme-hover group">
       <button
@@ -379,7 +384,7 @@ function RepoDropdownItem({ repo, isSelected, onSelect, onUpdate, isUpdating, ca
         onClick={(e) => { e.stopPropagation(); onUpdate() }}
         disabled={isUpdating || !canUpdate}
         className="p-1 text-theme-text-tertiary hover:text-theme-text-primary opacity-0 group-hover:opacity-100 transition-opacity disabled:opacity-50"
-        title={canUpdate ? "Update repository" : "Helm write permissions required (rbac.helm=true)"}
+        title={canUpdate ? "Update repository" : (cantUpdateReason ?? "Helm write permissions required")}
       >
         <RefreshCw className={clsx('w-3.5 h-3.5', isUpdating && 'animate-spin')} />
       </button>

--- a/web/src/components/helm/ChartBrowser.tsx
+++ b/web/src/components/helm/ChartBrowser.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from 'react'
 import { Search, RefreshCw, Package, Database, AlertCircle, ExternalLink, ChevronDown, Star, Shield, BadgeCheck, Building2, Globe, ArrowUpDown, FileJson, PenTool } from 'lucide-react'
 import { clsx } from 'clsx'
 import { useHelmRepositories, useSearchCharts, useUpdateRepository, useArtifactHubSearch, type ArtifactHubSortOption } from '../../api/client'
-import { useCanHelmWrite } from '../../contexts/CapabilitiesContext'
+import { useCanHelmAct } from '../../api/client'
 import type { ChartInfo, HelmRepository, ArtifactHubChart, ChartSource } from '../../types'
 import { formatAge } from './helm-utils'
 import { SEVERITY_BADGE } from '../../utils/badge-colors'
@@ -23,7 +23,7 @@ export function ChartBrowser({ onChartSelect }: ChartBrowserProps) {
   const [showVerifiedOnly, setShowVerifiedOnly] = useState(false)
   const [artifactHubSort, setArtifactHubSort] = useState<ArtifactHubSortOption>('relevance')
 
-  const canHelmWrite = useCanHelmWrite()
+  const { allowed: canHelmWrite, reason: helmActReason } = useCanHelmAct()
 
   // Local repo hooks
   const { data: repositories, isLoading: reposLoading } = useHelmRepositories()
@@ -235,7 +235,7 @@ export function ChartBrowser({ onChartSelect }: ChartBrowserProps) {
             </label>
 
             {/* Refresh button */}
-            <Tooltip content={canHelmWrite ? "Update all repositories" : "Helm write permissions required (rbac.helm=true)"}>
+            <Tooltip content={canHelmWrite ? "Update all repositories" : (helmActReason ?? '')}>
               <button
                 onClick={handleUpdateAllRepos}
                 disabled={updateRepoMutation.isPending || !canHelmWrite}

--- a/web/src/components/helm/HelmReleaseDrawer.tsx
+++ b/web/src/components/helm/HelmReleaseDrawer.tsx
@@ -12,7 +12,8 @@ import type { SelectedHelmRelease, HelmHook, ChartDependency } from '../../types
 import type { NavigateToResource } from '../../utils/navigation'
 import { formatDate } from './helm-utils'
 import { getHelmStatusColor, SEVERITY_BADGE, SEVERITY_TEXT } from '../../utils/badge-colors'
-import { useCanHelmAct } from '../../api/client'
+import { useCanHelmAct, useCloudRole } from '../../api/client'
+import { RoleGatedPanel } from './RoleGatedPanel'
 import { RevisionHistory } from './RevisionHistory'
 import { ManifestViewer } from './ManifestViewer'
 import { ValuesViewer } from './ValuesViewer'
@@ -47,6 +48,12 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
   const resizeStartX = useRef(0)
   const resizeStartWidth = useRef(DEFAULT_WIDTH)
   const { allowed: canHelmWrite, reason: helmActReason } = useCanHelmAct()
+  // Cloud viewers can't view release manifests / values / diffs
+  // (backend gate at requireCloudRole('member')). Skip the queries
+  // when the role would 403 — saves a round-trip and avoids a
+  // transient error state under the role-gated panel.
+  const { canAtLeast } = useCloudRole()
+  const canViewSensitive = canAtLeast('member')
 
   const { data: releaseDetail, isLoading, refetch: refetchRelease } = useHelmRelease(
     release.namespace,
@@ -58,14 +65,16 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
   const { data: manifest, isLoading: manifestLoading } = useHelmManifest(
     release.namespace,
     release.name,
-    selectedRevision
+    selectedRevision,
+    canViewSensitive,
   )
 
   // Fetch values
   const { data: values, isLoading: valuesLoading } = useHelmValues(
     release.namespace,
     release.name,
-    showAllValues
+    showAllValues,
+    canViewSensitive,
   )
 
   // Fetch diff if comparing revisions
@@ -73,7 +82,8 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
     release.namespace,
     release.name,
     diffRevisions?.rev1 || 0,
-    diffRevisions?.rev2 || 0
+    diffRevisions?.rev2 || 0,
+    canViewSensitive,
   )
 
   // Lazy check for upgrade availability
@@ -421,26 +431,30 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
               />
             )}
             {activeTab === 'manifest' && (
-              <ManifestViewer
-                manifest={manifest || ''}
-                isLoading={manifestLoading}
-                revision={selectedRevision}
-                onCopy={(text) => copyToClipboard(text, 'manifest')}
-                copied={copied === 'manifest'}
-              />
+              <RoleGatedPanel min="member" feature="release manifests">
+                <ManifestViewer
+                  manifest={manifest || ''}
+                  isLoading={manifestLoading}
+                  revision={selectedRevision}
+                  onCopy={(text) => copyToClipboard(text, 'manifest')}
+                  copied={copied === 'manifest'}
+                />
+              </RoleGatedPanel>
             )}
             {activeTab === 'values' && (
-              <ValuesViewer
-                values={values}
-                isLoading={valuesLoading}
-                showAllValues={showAllValues}
-                onToggleAllValues={setShowAllValues}
-                onCopy={(text) => copyToClipboard(text, 'values')}
-                copied={copied === 'values'}
-                namespace={release.namespace}
-                name={release.name}
-                onApplySuccess={() => refetch()}
-              />
+              <RoleGatedPanel min="member" feature="release values">
+                <ValuesViewer
+                  values={values}
+                  isLoading={valuesLoading}
+                  showAllValues={showAllValues}
+                  onToggleAllValues={setShowAllValues}
+                  onCopy={(text) => copyToClipboard(text, 'values')}
+                  copied={copied === 'values'}
+                  namespace={release.namespace}
+                  name={release.name}
+                  onApplySuccess={() => refetch()}
+                />
+              </RoleGatedPanel>
             )}
             {activeTab === 'resources' && (
               <OwnedResources
@@ -452,16 +466,18 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
               <HooksTab hooks={releaseDetail.hooks || []} />
             )}
             {activeTab === 'diff' && diffRevisions && (
-              <ManifestDiffViewer
-                diff={diffData?.diff || ''}
-                isLoading={diffLoading}
-                revision1={diffRevisions.rev1}
-                revision2={diffRevisions.rev2}
-                onClose={() => {
-                  setDiffRevisions(null)
-                  setActiveTab('history')
-                }}
-              />
+              <RoleGatedPanel min="member" feature="release manifest diffs">
+                <ManifestDiffViewer
+                  diff={diffData?.diff || ''}
+                  isLoading={diffLoading}
+                  revision1={diffRevisions.rev1}
+                  revision2={diffRevisions.rev2}
+                  onClose={() => {
+                    setDiffRevisions(null)
+                    setActiveTab('history')
+                  }}
+                />
+              </RoleGatedPanel>
             )}
           </>
         )}

--- a/web/src/components/helm/HelmReleaseDrawer.tsx
+++ b/web/src/components/helm/HelmReleaseDrawer.tsx
@@ -12,7 +12,7 @@ import type { SelectedHelmRelease, HelmHook, ChartDependency } from '../../types
 import type { NavigateToResource } from '../../utils/navigation'
 import { formatDate } from './helm-utils'
 import { getHelmStatusColor, SEVERITY_BADGE, SEVERITY_TEXT } from '../../utils/badge-colors'
-import { useCanHelmWrite } from '../../contexts/CapabilitiesContext'
+import { useCanHelmAct } from '../../api/client'
 import { RevisionHistory } from './RevisionHistory'
 import { ManifestViewer } from './ManifestViewer'
 import { ValuesViewer } from './ValuesViewer'
@@ -46,7 +46,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
   const [showUpgradeConfirm, setShowUpgradeConfirm] = useState(false)
   const resizeStartX = useRef(0)
   const resizeStartWidth = useRef(DEFAULT_WIDTH)
-  const canHelmWrite = useCanHelmWrite()
+  const { allowed: canHelmWrite, reason: helmActReason } = useCanHelmAct()
 
   const { data: releaseDetail, isLoading, refetch: refetchRelease } = useHelmRelease(
     release.namespace,
@@ -325,7 +325,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
                   'badge transition-colors', SEVERITY_BADGE.warning,
                   canHelmWrite ? 'hover:bg-amber-500/30 cursor-pointer' : 'opacity-50 cursor-not-allowed'
                 )}
-                title={canHelmWrite ? `Click to upgrade: ${upgradeInfo.currentVersion} → ${upgradeInfo.latestVersion}${upgradeInfo.repositoryName ? ` (${upgradeInfo.repositoryName})` : ''}` : 'Helm write permissions required (rbac.helm=true)'}
+                title={canHelmWrite ? `Click to upgrade: ${upgradeInfo.currentVersion} → ${upgradeInfo.latestVersion}${upgradeInfo.repositoryName ? ` (${upgradeInfo.repositoryName})` : ''}` : helmActReason}
               >
                 <ArrowUpCircle className="w-3 h-3" />
                 {upgradeInfo.latestVersion}
@@ -354,7 +354,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
                   ? 'text-theme-text-secondary hover:text-red-400 hover:bg-red-500/10'
                   : 'text-theme-text-disabled cursor-not-allowed'
               )}
-              title={canHelmWrite ? 'Uninstall release' : 'Helm write permissions required (rbac.helm=true)'}
+              title={canHelmWrite ? 'Uninstall release' : helmActReason}
             >
               <Trash2 className="w-4 h-4" />
             </button>

--- a/web/src/components/helm/InstallWizard.tsx
+++ b/web/src/components/helm/InstallWizard.tsx
@@ -5,7 +5,7 @@ import yaml from 'yaml'
 import { createPatch } from 'diff'
 import { useQueryClient } from '@tanstack/react-query'
 import { useChartDetail, useNamespaces, useArtifactHubChart, installChartWithProgress, type InstallProgressEvent } from '../../api/client'
-import { useCanHelmWrite } from '../../contexts/CapabilitiesContext'
+import { useCanHelmAct } from '../../api/client'
 import type { ChartSource, ChartDetail, ArtifactHubChartDetail } from '../../types'
 import { YamlEditor } from '../ui/YamlEditor'
 import { Tooltip } from '../ui/Tooltip'
@@ -64,7 +64,7 @@ export function InstallWizard({ repo, chartName, version, source, repoUrl, defau
   const progressEndRef = useRef<HTMLDivElement>(null)
 
   const queryClient = useQueryClient()
-  const canHelmWrite = useCanHelmWrite()
+  const { allowed: canHelmWrite, reason: helmActReason } = useCanHelmAct()
 
   // Choose the right data based on source
   const isLocal = source === 'local'
@@ -389,7 +389,7 @@ export function InstallWizard({ repo, chartName, version, source, repoUrl, defau
                     onClick={handleInstall}
                     disabled={!canInstall || isInstalling || !canHelmWrite}
                     className="flex items-center gap-2 px-4 py-2 text-sm font-medium btn-brand rounded-lg disabled:cursor-not-allowed"
-                    title={!canHelmWrite ? 'Helm write permissions required (rbac.helm=true)' : undefined}
+                    title={!canHelmWrite ? helmActReason : undefined}
                   >
                     {isInstalling ? (
                       <Loader2 className="w-4 h-4 animate-spin" />

--- a/web/src/components/helm/RoleGatedPanel.tsx
+++ b/web/src/components/helm/RoleGatedPanel.tsx
@@ -1,0 +1,47 @@
+import { Lock } from 'lucide-react'
+import { useCloudRole, type CloudRole } from '../../api/client'
+
+interface RoleGatedPanelProps {
+  /** Minimum Cloud tier required to view the children. */
+  min: CloudRole
+  /** Human-readable name of the gated content, e.g. "release manifests". */
+  feature: string
+  children: React.ReactNode
+}
+
+/**
+ * RoleGatedPanel wraps tab-content surfaces that require a Cloud role
+ * (member+) to view. Renders the children when the gate passes; renders
+ * an explanatory empty state when the caller's role is insufficient.
+ *
+ * Why a per-tab gate rather than hiding tabs from the list: viewers
+ * should learn what the platform offers and what their tier can't do,
+ * not have features silently vanish. This mirrors how the action
+ * buttons (Uninstall, Upgrade, etc.) are rendered visible-but-disabled
+ * with a role-aware tooltip.
+ *
+ * Bypasses for non-Cloud users (OSS, OIDC, etc.) — `canAtLeast` returns
+ * true when no Cloud role is present. The backend gate has the same
+ * shape, so the SPA stays in lockstep.
+ */
+export function RoleGatedPanel({ min, feature, children }: RoleGatedPanelProps) {
+  const { role, canAtLeast } = useCloudRole()
+  if (canAtLeast(min)) {
+    return <>{children}</>
+  }
+  return (
+    <div className="flex flex-col items-center justify-center h-full py-12 px-6 text-center">
+      <div className="rounded-full bg-theme-surface p-3 mb-3">
+        <Lock className="w-5 h-5 text-theme-text-tertiary" aria-hidden />
+      </div>
+      <div className="text-sm font-medium text-theme-text-primary">
+        Your role can't view {feature}
+      </div>
+      <div className="mt-1 max-w-md text-xs text-theme-text-secondary">
+        You're signed in as <span className="font-mono text-theme-text-primary">{role ?? 'viewer'}</span>.
+        This view requires <span className="font-mono text-theme-text-primary">{min}</span> or higher.
+        Ask a {min} or owner if you need access.
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/helm/ValuesViewer.tsx
+++ b/web/src/components/helm/ValuesViewer.tsx
@@ -6,7 +6,7 @@ import type { HelmValues, ValuesPreviewResponse } from '../../types'
 import { CodeViewer } from '../ui/CodeViewer'
 import { YamlEditor } from '../ui/YamlEditor'
 import { useHelmPreviewValues, useHelmApplyValues } from '../../api/client'
-import { useCanHelmWrite } from '../../contexts/CapabilitiesContext'
+import { useCanHelmAct } from '../../api/client'
 import { ValuesDiffPreview } from './ValuesDiffPreview'
 
 interface ValuesViewerProps {
@@ -41,7 +41,7 @@ export function ValuesViewer({
 
   const previewMutation = useHelmPreviewValues()
   const applyMutation = useHelmApplyValues()
-  const canHelmWrite = useCanHelmWrite()
+  const { allowed: canHelmWrite, reason: helmActReason } = useCanHelmAct()
 
   const canEdit = Boolean(namespace && name) && canHelmWrite
 
@@ -234,7 +234,7 @@ export function ValuesViewer({
                 onClick={handleApply}
                 disabled={!!yamlError || applyMutation.isPending || !canHelmWrite}
                 className="flex items-center gap-1 px-2.5 py-1 text-xs btn-brand rounded disabled:cursor-not-allowed"
-                title={!canHelmWrite ? 'Helm write permissions required (rbac.helm=true)' : undefined}
+                title={!canHelmWrite ? helmActReason : undefined}
               >
                 {applyMutation.isPending ? (
                   <Loader2 className="w-3.5 h-3.5 animate-spin" />

--- a/web/src/components/home/HelmSummary.tsx
+++ b/web/src/components/home/HelmSummary.tsx
@@ -82,6 +82,18 @@ export function HelmSummary({ data, onNavigate }: HelmSummaryProps) {
             <span className="text-xs font-medium text-theme-text-secondary">Access Restricted</span>
             <span className="text-[11px] mt-1">Insufficient permissions to list Helm releases</span>
           </div>
+        ) : data.error ? (
+          <div className="flex flex-col items-center justify-center h-full py-4 text-theme-text-tertiary">
+            <Shield className="w-8 h-8 text-amber-400 mb-2" />
+            <span className="text-xs font-medium text-theme-text-secondary">
+              {data.errorCode === 'unconfigured' ? 'Helm not configured' : 'Helm unavailable'}
+            </span>
+            <span className="text-[11px] mt-1 text-center px-2 truncate max-w-full" title={data.error}>
+              {data.errorCode === 'unconfigured'
+                ? 'Set rbac.helm=true in the Radar Helm chart values.'
+                : data.error}
+            </span>
+          </div>
         ) : !data.releases || data.releases.length === 0 ? (
           <div className="flex items-center justify-center h-full py-4 text-xs text-theme-text-tertiary">
             No Helm releases found


### PR DESCRIPTION
End-to-end fix for in-cluster Helm + a full Cloud role gating pass on top.

## What was broken

In-cluster Radar deploys (Hub mode, OSS Helm-chart deploy) returned `Kubernetes cluster unreachable: dial tcp 127.0.0.1:8080: connect: connection refused` on every Helm operation. Helm's default `ConfigFlags` only resolves kubeconfig paths and falls through to `localhost:8080` when none exist — even inside a pod with a working ServiceAccount. The labels-based detection path worked because the K8s client uses `rest.InClusterConfig()`; Helm did not.

## What this ships

**1. Helm SDK uses Radar's resolved rest.Config when no kubeconfig path is available.**
New `restConfigGetter` (`internal/helm/rest_config_getter.go`) implements `RESTClientGetter` over the captured `*rest.Config`. Fires for in-cluster + multi-source kubeconfig modes. The dominant OSS laptop case (`~/.kube/config` exists) is unchanged. `buildRESTClientGetter` is a pure helper covered by a 3-case test.

**2. Inventory reads use the SA, sensitive reads + writes impersonate.**
The chart maps `cloud:viewer` → K8s `view`, which excludes Secrets — so impersonating viewers on the fleet packages page would 403 every viewer on pure metadata. `computePackagesInternal` now passes empty user/groups for the inventory read; sensitive Helm reads (GetValues, GetManifest, Diff) and all writes still impersonate.

**3. Cloud role gates on sensitive endpoints with structured 403s.**
New `pkg/auth/cloud_role.go` exposes `CloudRole` + `CloudRoleFromGroups` + `AtLeast` (bypasses for non-Cloud users). New `requireCloudRole` helper gates 12 Helm endpoints (manifest/values/diff/preview, install/upgrade/rollback/uninstall + streaming variants, applyValues). Denials carry `error_code: cloud_role_insufficient` so the SPA renders friendly copy. Hoisted to `auth.ErrCodeCloudRoleInsufficient` constant alongside the rest of the `ErrCode*` family.

**4. Dashboard surfaces Helm misconfiguration instead of empty list.**
Both the REST dashboard handler and the MCP `get_dashboard` tool used to swallow Helm errors into an empty release list — indistinguishable from \"this cluster has zero releases.\" Now ship `Error/ErrorCode` (REST) and `Unavailable/UnavailableReason` (MCP). The Home dashboard widget renders \"Helm not configured\" / \"Helm unavailable\" distinct from RBAC-restricted and genuine empty.

**5. Role-aware UI in radar OSS web.**
`/api/auth/me` now ships pre-computed `cloudRole`. New `useCloudRole()` + `useCanHelmAct()` hooks; four Helm UI surfaces (HelmReleaseDrawer, ChartBrowser, InstallWizard, ValuesViewer) gate action buttons with role-aware tooltips (member-required vs rbac.helm-required vs both). New `<RoleGatedPanel>` wraps Manifest/Values/Diff tab content with an explanatory empty state for viewers; queries skip when the role would 403, saving the round-trip.

**6. Stable error-code wire vocabulary.**
`SourceError.Code` now carries `rbac_denied / unreachable / timed_out / unconfigured / auth_required` from `errorCodeForHelm`. The SPA stops regex-ing log messages — phrasing changes upstream don't silently re-categorize.

## Tests

33+ new tests across `pkg/auth`, `internal/helm`, `internal/server`. Notably:
- `TestSensitiveHelmHandlers_GateOnViewer` — every gated handler 403s a viewer with the structured code (catches the retrofit-regression class).
- `TestRESTConfigGetter_DiscoveryAndMapper_NoDeadlock` — pins the lock-ordering fix from the first review pass.
- `TestErrorCodeForHelm` — table covering 5 categories + ordering pins for multi-keyword bodies.

## Pairs with

- [skyhook-dev/radar-hub-web#23](https://github.com/skyhook-dev/radar-hub-web/pull/23) — SPA consumes the structured `error_code` + ships role-aware error labels.
- [skyhook-dev/radar-hub#23](https://github.com/skyhook-dev/radar-hub/pull/23) — Hub-side audit log records `cluster.action_denied` for the 403s this PR emits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Helm client initialization/REST client selection and adds Cloud role-based authorization gates around Helm endpoints, which can impact cluster operations and access control. Also changes `/api/packages` caching scope and error-code wire shapes, affecting multiple consumers (SPA/MCP).
> 
> **Overview**
> Fixes Helm operations in in-cluster and multi-kubeconfig setups by teaching the Helm client to reuse Radar’s resolved `*rest.Config` (via a new `RESTClientGetter`) when no kubeconfig path is available, instead of falling back to `localhost:8080`.
> 
> Adds Radar Cloud *role-tier* gating (`viewer`/`member`/`owner`) on sensitive Helm reads and all Helm write endpoints, returning structured 403s with `error_code=cloud_role_insufficient`, and exposes `cloudRole` in `/api/auth/me` for the UI.
> 
> Improves “Helm unavailable” reporting by surfacing explicit error state in the dashboard and MCP responses, introduces stable per-source error `code`s for `/api/packages`, and changes the packages cache key to be namespace-scoped (shared across users) while ensuring Helm inventory reads use the ServiceAccount rather than user impersonation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a272892d357f2c7e82791612b788639a97a2fcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->