### PR TITLE
fix(cloud): propagate build-time version to tunnel handshake

### DIFF
--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -28,6 +28,13 @@ var (
 func main() {
 	startupStart := time.Now()
 
+	// Propagate the build-time version to the cloud dialer so the agent
+	// advertises the real version (e.g. "1.5.5") on the tunnel handshake
+	// instead of the "dev" default. Dockerfile + Makefile inject
+	// `-X main.version=...`; mirror it here rather than adding a second
+	// ldflags target so there's a single source of truth.
+	cloud.Version = version
+
 	// Load persistent config (~/.radar/config.json) for flag defaults.
 	// CLI flags override config file values.
 	fileCfg := config.Load()


### PR DESCRIPTION
## Summary
- Dockerfile + Makefile inject `-X main.version=$VERSION` into `cmd/explorer`, but the cloud dialer reads `internal/cloud.Version` when sending the `X-Radar-Version` header on the tunnel handshake.
- Mismatch meant prod images built as 1.5.5 advertised themselves to radar-hub as `"dev"` — the Cloud UI Clusters table shows VERSION=dev across the fleet and the upgrade-available banner never fires.
- One-line fix: mirror `version` into `cloud.Version` at the top of `main()` so the existing ldflags target stays the single source of truth (rather than adding a second `-X` symbol that future build paths could forget).

## Test plan
- [ ] Local `go build ./cmd/explorer` succeeds.
- [ ] After release + rolling the prod cluster's Radar pod, `clusters.radar_version` (captured at tunnel-accept) flips from NULL/`dev` to `1.5.x` and the Cloud UI Clusters table shows the real version.
- [ ] Upgrade-available banner fires once a newer release is published and a stale agent is still connected.