### PR TITLE
fix(resources): strip basename in ResourcesView nav adapter

### DIFF
--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -120,10 +120,24 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
   const openLogs = useOpenLogs()
   const openWorkloadLogs = useOpenWorkloadLogs()
 
-  // Navigation adapter
+  // Navigation adapter. k8s-ui constructs paths from `basePath` (which
+  // includes the router basename so they line up with window.location.pathname
+  // for path-equality checks) and from `window.location.pathname` directly.
+  // React Router's navigate() applies the basename itself, so handing it a
+  // path that already contains the basename double-prefixes it
+  // (e.g. /c/abc/c/abc/resources/pods). Under that URL, getViewFromPath()
+  // sees 'c' as the first segment and falls through to 'home' — which
+  // manifests as "click a resource → bounced to the home dashboard" in
+  // any host that mounts RadarApp under a non-empty basename (Radar Cloud).
+  // Strip the basename here so react-router can re-apply it cleanly.
   const handleNavigate = useMemo(() => {
+    const base = getBasename()
     return (path: string, options?: { replace?: boolean }) => {
-      navigate(path, { replace: options?.replace })
+      let p = path
+      if (base && (p === base || p.startsWith(base + '/') || p.startsWith(base + '?'))) {
+        p = p.slice(base.length) || '/'
+      }
+      navigate(p, { replace: options?.replace })
     }
   }, [navigate])
 


### PR DESCRIPTION
## Summary

When `RadarApp` is mounted under a non-empty router basename (Radar Cloud embeds it under `/c/{cluster_id}`), clicking a resource row bounced the user to the home dashboard instead of opening the drawer. Standalone OSS Radar (basename `''`) was unaffected.

## Root cause

k8s-ui's `BaseResourcesView` constructs URL paths from `basePath` (`getBasename() + '/resources'`) and from `window.location.pathname` — both include the basename so they line up with location-equality checks inside the component. The radar-side `onNavigate` adapter forwarded those paths verbatim to react-router's `navigate()`, which re-applied the basename, producing `/c/abc/c/abc/resources/pods`. `getViewFromPath()` then sees `'c'` as the first segment and falls through to `'home'`.

## Fix

`web/src/components/resources/ResourcesView.tsx` — strip the basename in the adapter before handing off to react-router. No-op when basename is empty (OSS).

## Verification

- Standalone OSS against a real GKE cluster: regression check, drawer opens, URL stays clean (`/resources/pods?resource=...`).
- Radar Cloud (radar-hub-web with this radar source linked locally + radar-hub backend + radar binary, all against the same cluster): clicking a pod row now opens the drawer with the URL `/c/{id}/resources/pods?resource=ns/name` — single basename, no bounce. 0 console errors.

## Follow-up

Bump `radar/web/package.json` version and publish via the `radar-app-v<semver>` workflow so `radar-hub-web` can pick this up.