### PR TITLE
ui: shared ClusterSwitcher + Radar loading icon

### DIFF
--- a/packages/k8s-ui/package.json
+++ b/packages/k8s-ui/package.json
@@ -47,7 +47,8 @@
     "./theme/tailwind-theme.css": "./src/theme/tailwind-theme.css",
     "./theme/components.css": "./src/theme/components.css",
     "./theme": "./src/theme/index.ts",
-    "./topology.css": "./src/components/topology/topology.css"
+    "./topology.css": "./src/components/topology/topology.css",
+    "./assets/radar/radar-icon-loading.svg": "./src/assets/radar/radar-icon-loading.svg"
   },
   "scripts": {
     "tsc": "tsc --noEmit",

--- a/packages/k8s-ui/src/assets/radar/radar-icon-loading.svg
+++ b/packages/k8s-ui/src/assets/radar/radar-icon-loading.svg
@@ -1,0 +1,147 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <defs>
+    <!-- Dark emerald background gradient -->
+    <radialGradient id="bgHub" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#072920"/>
+      <stop offset="70%" stop-color="#03180f"/>
+      <stop offset="100%" stop-color="#010a06"/>
+    </radialGradient>
+
+    <!-- Sweep trail gradient, emerald -->
+    <linearGradient id="sweepGlowHub" x1="0" y1="0" x2="1" y2="0" gradientTransform="rotate(-45, 0.5, 0.5)">
+      <stop offset="0%" stop-color="#10b981" stop-opacity="0"/>
+      <stop offset="60%" stop-color="#10b981" stop-opacity="0.22"/>
+      <stop offset="100%" stop-color="#a7f3d0" stop-opacity="0.55"/>
+    </linearGradient>
+
+    <!-- Ring glow -->
+    <filter id="ringGlowHub" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="1.5" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+
+    <!-- Dot glow -->
+    <filter id="dotGlowHub" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="2.5" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+
+    <!-- Sweep line glow -->
+    <filter id="lineGlowHub" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="3" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+
+    <!-- Outer ring glow -->
+    <filter id="outerGlowHub" x="-10%" y="-10%" width="120%" height="120%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+
+    <clipPath id="radarClipHub">
+      <circle cx="128" cy="128" r="118"/>
+    </clipPath>
+
+    <!--
+      Self-contained CSS animation. This SVG is consumed via <img>, so
+      neither external CSS nor JS reaches it — keyframes have to live
+      inside the file. Sweep arm rotates around (128,128); each blip
+      pings via animation-delay timed to when the arm passes its angle
+      (cycle = 2400ms, baseline = 45° NE). Honors prefers-reduced-motion.
+    -->
+    <style>
+      .sweep-arm {
+        transform-origin: 128px 128px;
+        animation: radar-sweep 2.4s linear infinite;
+      }
+      @keyframes radar-sweep {
+        to { transform: rotate(360deg); }
+      }
+
+      .blip {
+        transform-origin: center;
+        transform-box: fill-box;
+        animation: blip-ping 2.4s linear infinite;
+      }
+      @keyframes blip-ping {
+        0%   { opacity: 1;    transform: scale(1.45); }
+        6%   { opacity: 0.95; transform: scale(1.15); }
+        25%  { opacity: 0.6;  transform: scale(1);    }
+        100% { opacity: 0.55; transform: scale(1);    }
+      }
+
+      .center-dot {
+        transform-origin: 128px 128px;
+        animation: center-pulse 2.4s ease-in-out infinite;
+      }
+      @keyframes center-pulse {
+        0%, 100% { opacity: 0.75; }
+        50%      { opacity: 1;    }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .sweep-arm,
+        .blip,
+        .center-dot { animation: none; }
+      }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <circle cx="128" cy="128" r="128" fill="#010a06"/>
+  <circle cx="128" cy="128" r="118" fill="url(#bgHub)"/>
+
+  <!-- Outer ring -->
+  <circle cx="128" cy="128" r="118" fill="none" stroke="#34d399" stroke-width="3.5" filter="url(#outerGlowHub)" opacity="0.9"/>
+
+  <!-- Concentric rings -->
+  <g filter="url(#ringGlowHub)" opacity="0.6">
+    <circle cx="128" cy="128" r="90" fill="none" stroke="#059669" stroke-width="1.2"/>
+    <circle cx="128" cy="128" r="62" fill="none" stroke="#059669" stroke-width="1.2"/>
+    <circle cx="128" cy="128" r="34" fill="none" stroke="#059669" stroke-width="1.2"/>
+  </g>
+
+  <!-- Crosshairs -->
+  <g opacity="0.15" stroke="#34d399" stroke-width="0.5">
+    <line x1="128" y1="10" x2="128" y2="246"/>
+    <line x1="10" y1="128" x2="246" y2="128"/>
+  </g>
+
+  <!-- Radar blips. animation-delay = -((360 - (angle - 45)) mod 360) / 360 * 2400ms,
+       so the 0% peak fires when the rotating sweep arm is at the blip's angle.
+       Negative delays put the animation mid-cycle at t=0 so the first paint isn't
+       a sea of bright pings. -->
+  <g filter="url(#dotGlowHub)">
+    <circle class="blip" cx="155" cy="68"  r="4"   fill="#ffffff" style="animation-delay: -140ms"/>
+    <circle class="blip" cx="178" cy="108" r="3.5" fill="#ffffff" style="animation-delay: -2247ms"/>
+    <circle class="blip" cx="98"  cy="85"  r="3"   fill="#ecfdf5" style="animation-delay: -533ms"/>
+    <circle class="blip" cx="85"  cy="155" r="3.5" fill="#ecfdf5" style="animation-delay: -1113ms"/>
+    <circle class="blip" cx="160" cy="175" r="3"   fill="#ecfdf5" style="animation-delay: -1727ms"/>
+    <circle class="blip" cx="108" cy="195" r="3.5" fill="#ecfdf5" style="animation-delay: -1387ms"/>
+  </g>
+
+  <!-- Sweep arm: trail + leading line, rotated as one group -->
+  <g class="sweep-arm">
+    <g clip-path="url(#radarClipHub)">
+      <path d="M128,128 L128,10 A118,118 0 0,1 211.5,44.5 Z" fill="url(#sweepGlowHub)" opacity="0.75"/>
+      <path d="M128,128 L211.5,44.5 A118,118 0 0,1 240,95 Z" fill="#10b981" opacity="0.06"/>
+    </g>
+    <line x1="128" y1="128" x2="211" y2="45" stroke="#a7f3d0" stroke-width="2" filter="url(#lineGlowHub)" stroke-linecap="round"/>
+    <line x1="128" y1="128" x2="211" y2="45" stroke="#ffffff" stroke-width="1" opacity="0.9" stroke-linecap="round"/>
+  </g>
+
+  <!-- Center dot -->
+  <circle class="center-dot" cx="128" cy="128" r="3" fill="#6ee7b7" filter="url(#dotGlowHub)"/>
+</svg>

--- a/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
+++ b/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
@@ -1,0 +1,330 @@
+import {
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { ChevronDown, Check, Loader2, Search, X } from 'lucide-react'
+import { StatusDot, type StatusTone } from '../ui/status-tone'
+
+export interface ClusterSwitcherItem {
+  id: string
+  name: string
+  secondary?: string
+  badge?: string
+  group?: { key: string; label?: string }
+  disabled?: boolean
+  status?: StatusTone
+  /** Hard navigation target. Takes precedence over the parent's `onSelect`. */
+  href?: string
+  /** Tooltip — useful on disabled rows to explain why the row is inert. */
+  title?: string
+}
+
+export interface ClusterSwitcherProps {
+  currentId?: string
+  currentName: string
+  currentTooltip?: string
+  triggerIcon?: ReactNode
+  triggerPrefix?: ReactNode
+  triggerMaxWidthClass?: string
+  items: ClusterSwitcherItem[]
+  onSelect?: (item: ClusterSwitcherItem) => void
+  searchable?: boolean
+  showGroupHeaders?: boolean
+  showCurrentBullet?: boolean
+  loading?: boolean
+  disabled?: boolean
+  emptyText?: string
+  footerSlot?: ReactNode
+  errorSlot?: ReactNode
+  className?: string
+  align?: 'left' | 'right'
+}
+
+const DEFAULT_TRIGGER_MAX_WIDTH = 'max-w-[120px] sm:max-w-[220px]'
+
+export function ClusterSwitcher({
+  currentId,
+  currentName,
+  currentTooltip,
+  triggerIcon,
+  triggerPrefix,
+  triggerMaxWidthClass = DEFAULT_TRIGGER_MAX_WIDTH,
+  items,
+  onSelect,
+  searchable = true,
+  showGroupHeaders = true,
+  showCurrentBullet = true,
+  loading = false,
+  disabled = false,
+  emptyText = 'No clusters',
+  footerSlot,
+  errorSlot,
+  className = '',
+  align = 'left',
+}: ClusterSwitcherProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [search, setSearch] = useState('')
+  const [highlightedIndex, setHighlightedIndex] = useState(-1)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  const groups = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    const matches = (item: ClusterSwitcherItem) => {
+      if (!q) return true
+      return (
+        item.name.toLowerCase().includes(q) ||
+        item.secondary?.toLowerCase().includes(q) ||
+        item.badge?.toLowerCase().includes(q) ||
+        item.group?.label?.toLowerCase().includes(q)
+      )
+    }
+    const map = new Map<string, { key: string; label?: string; items: ClusterSwitcherItem[] }>()
+    for (const item of items) {
+      if (!matches(item)) continue
+      const key = item.group?.key ?? ''
+      if (!map.has(key)) map.set(key, { key, label: item.group?.label, items: [] })
+      map.get(key)!.items.push(item)
+    }
+    return Array.from(map.values())
+  }, [items, search])
+
+  const flat = useMemo(() => groups.flatMap(g => g.items), [groups])
+  const indexById = useMemo(() => {
+    const m = new Map<string, number>()
+    flat.forEach((it, i) => m.set(it.id, i))
+    return m
+  }, [flat])
+
+  useEffect(() => {
+    if (!isOpen) return
+    setSearch('')
+    setHighlightedIndex(-1)
+    requestAnimationFrame(() => searchInputRef.current?.focus())
+  }, [isOpen])
+
+  useEffect(() => {
+    setHighlightedIndex(-1)
+  }, [search])
+
+  useEffect(() => {
+    if (!isOpen || highlightedIndex < 0 || !rootRef.current) return
+    const el = rootRef.current.querySelector('[data-highlighted="true"]')
+    if (el) (el as HTMLElement).scrollIntoView({ block: 'nearest' })
+  }, [highlightedIndex, isOpen])
+
+  // Listeners attach only while open so a closed switcher doesn't intercept
+  // ESC or click-outside meant for parent modals/overlays.
+  useEffect(() => {
+    if (!isOpen) return
+    function onClick(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setIsOpen(false)
+    }
+    function onEsc(e: KeyboardEvent) {
+      if (e.key === 'Escape') setIsOpen(false)
+    }
+    document.addEventListener('mousedown', onClick)
+    document.addEventListener('keydown', onEsc)
+    return () => {
+      document.removeEventListener('mousedown', onClick)
+      document.removeEventListener('keydown', onEsc)
+    }
+  }, [isOpen])
+
+  const select = (item: ClusterSwitcherItem) => {
+    if (item.disabled || item.id === currentId) return
+    setIsOpen(false)
+    if (item.href) {
+      window.location.href = item.href
+      return
+    }
+    onSelect?.(item)
+  }
+
+  const onSearchKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setHighlightedIndex(p => (p < flat.length - 1 ? p + 1 : p))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setHighlightedIndex(p => (p > 0 ? p - 1 : 0))
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      if (highlightedIndex >= 0 && flat[highlightedIndex]) select(flat[highlightedIndex])
+      else if (flat.length > 0) setHighlightedIndex(0)
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      setIsOpen(false)
+    }
+  }
+
+  const positionClass = align === 'right' ? 'right-0 origin-top-right' : 'left-0 origin-top-left'
+
+  return (
+    <div className={`relative ${className}`} ref={rootRef}>
+      <button
+        type="button"
+        onClick={() => setIsOpen(v => !v)}
+        disabled={disabled || loading}
+        title={currentTooltip ?? currentName}
+        className={`
+          flex items-center gap-1.5 px-2.5 py-1.5
+          bg-theme-elevated border border-theme-border rounded text-sm font-medium
+          text-theme-text-primary hover:bg-theme-hover hover:border-theme-border-light
+          transition-colors cursor-pointer
+          disabled:opacity-50 disabled:cursor-not-allowed
+        `}
+      >
+        {loading ? (
+          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+        ) : (
+          triggerIcon
+        )}
+        {triggerPrefix && (
+          <span className="text-theme-text-tertiary">{triggerPrefix}</span>
+        )}
+        <span className={`${triggerMaxWidthClass} truncate`}>
+          {loading ? 'Switching...' : currentName}
+        </span>
+        <ChevronDown className={`w-3 h-3 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+      </button>
+
+      {isOpen && (
+        <div
+          className={`absolute top-full ${positionClass} mt-1 z-50 min-w-[280px] max-w-[420px] bg-theme-surface border border-theme-border-light rounded-lg shadow-xl overflow-hidden`}
+        >
+          {searchable && (
+            <div className="p-2 border-b border-theme-border">
+              <div className="relative">
+                <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-theme-text-tertiary" />
+                <input
+                  ref={searchInputRef}
+                  type="text"
+                  value={search}
+                  onChange={e => setSearch(e.target.value)}
+                  onKeyDown={onSearchKeyDown}
+                  placeholder="Search clusters..."
+                  className="w-full bg-theme-base text-theme-text-primary text-xs rounded px-2 py-1.5 pl-7 pr-7 border border-theme-border-light focus:outline-none focus:ring-1 focus:ring-[var(--color-brand)] placeholder:text-theme-text-tertiary"
+                />
+                {search && (
+                  <button
+                    type="button"
+                    onClick={() => setSearch('')}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-theme-text-tertiary hover:text-theme-text-secondary"
+                  >
+                    <X className="w-3.5 h-3.5" />
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
+
+          <div className="max-h-[400px] overflow-y-auto">
+            {flat.length === 0 ? (
+              <div className="px-3 py-6 text-center text-xs text-theme-text-tertiary">
+                {search ? `No clusters match "${search}"` : emptyText}
+              </div>
+            ) : (
+              groups.map((group, gi) => (
+                <div key={group.key || `g${gi}`}>
+                  {gi > 0 && <div className="border-t border-theme-border-light my-1" />}
+                  {showGroupHeaders && group.label && (
+                    <div className="px-3 py-1 bg-theme-elevated/60 border-b border-theme-border/60">
+                      <span className="text-[11px] text-theme-text-secondary font-semibold">
+                        {group.label}
+                      </span>
+                    </div>
+                  )}
+                  {group.items.map(item => {
+                    const idx = indexById.get(item.id) ?? -1
+                    const isCurrent = item.id === currentId
+                    return (
+                      <button
+                        type="button"
+                        key={item.id}
+                        data-highlighted={idx === highlightedIndex}
+                        onClick={() => select(item)}
+                        onMouseEnter={() => setHighlightedIndex(idx)}
+                        disabled={isCurrent || item.disabled}
+                        title={item.title}
+                        className={`
+                          w-full flex items-center gap-2 px-3 py-2 text-left transition-colors
+                          ${isCurrent
+                            ? 'selection'
+                            : idx === highlightedIndex
+                              ? 'bg-theme-hover cursor-pointer'
+                              : 'hover:bg-theme-hover cursor-pointer'}
+                          disabled:opacity-50
+                        `}
+                      >
+                        <div className="shrink-0 w-4 h-4 flex items-center justify-center">
+                          {isCurrent ? (
+                            <Check className="w-3.5 h-3.5 selection-text" />
+                          ) : showCurrentBullet ? (
+                            <div className="w-1.5 h-1.5 rounded-full bg-theme-text-tertiary/30" />
+                          ) : null}
+                        </div>
+                        {item.status && (
+                          <span className="shrink-0">
+                            <StatusDot tone={item.status} />
+                          </span>
+                        )}
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-1.5">
+                            <span
+                              className={`text-sm font-medium truncate ${
+                                isCurrent
+                                  ? 'selection-text'
+                                  : item.disabled
+                                    ? 'text-theme-text-tertiary'
+                                    : 'text-theme-text-primary'
+                              }`}
+                            >
+                              {item.name}
+                            </span>
+                            {item.badge && (
+                              <span className="shrink-0 ml-auto text-[10px] text-theme-text-tertiary bg-theme-elevated px-1 rounded">
+                                {item.badge}
+                              </span>
+                            )}
+                          </div>
+                          {item.secondary && (
+                            <div
+                              className="text-[10px] text-theme-text-tertiary opacity-70 truncate mt-0.5"
+                              title={item.secondary}
+                            >
+                              {item.secondary}
+                            </div>
+                          )}
+                        </div>
+                      </button>
+                    )
+                  })}
+                </div>
+              ))
+            )}
+          </div>
+
+          {search && flat.length > 0 && flat.length < items.length && (
+            <div className="px-3 py-1.5 text-[10px] text-theme-text-tertiary border-t border-theme-border bg-theme-base">
+              {flat.length} of {items.length} clusters
+            </div>
+          )}
+
+          {footerSlot && (
+            <div className="border-t border-theme-border bg-theme-base">{footerSlot}</div>
+          )}
+
+          {errorSlot && (
+            <div className="px-3 py-2 bg-red-500/10 border-t border-red-500/20">
+              {errorSlot}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/k8s-ui/src/components/cluster-switcher/index.ts
+++ b/packages/k8s-ui/src/components/cluster-switcher/index.ts
@@ -1,0 +1,2 @@
+export { ClusterSwitcher } from './ClusterSwitcher'
+export type { ClusterSwitcherProps, ClusterSwitcherItem } from './ClusterSwitcher'

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo, useEffect, useCallback, useRef, useContext } from 'react'
 import { TableVirtuoso, type TableVirtuosoHandle } from 'react-virtuoso'
 import { useRefreshAnimation } from '../../hooks/useRefreshAnimation'
+import radarLoadingIcon from '../../assets/radar/radar-icon-loading.svg'
 import type { TopPodMetrics, TopNodeMetrics } from '../../types'
 import {
   Search,
@@ -3547,8 +3548,9 @@ export function ResourcesView({
           }}
         >
           {isLoading ? (
-            <div className="absolute inset-0 flex items-center justify-center text-theme-text-tertiary">
-              Loading...
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 text-theme-text-tertiary">
+              <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
+              <span className="text-sm">Loading…</span>
             </div>
           ) : isSelectedForbidden ? (
             <div className="absolute inset-0 flex flex-col items-center justify-center text-theme-text-tertiary">

--- a/packages/k8s-ui/src/index.ts
+++ b/packages/k8s-ui/src/index.ts
@@ -36,3 +36,6 @@ export * from './components/topology'
 
 // Cluster audit (AuditCard, AuditAlerts, AuditFindingsTable)
 export * from './components/audit'
+
+// Cluster switcher (shared trigger+dropdown for OSS Radar and Radar Hub)
+export * from './components/cluster-switcher'

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyhook-io/radar-app",
-  "version": "0.1.4",
+  "version": "0.1.7",
   "description": "Radar's full web UI as a reusable React component. Used by Radar's own binary and by external consumers like Radar Cloud.",
   "repository": {
     "type": "git",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -37,7 +37,7 @@ import { useNamespaces, useSwitchContext, useAuthMe } from './api/client'
 import { routePath, apiUrl, getAuthHeaders, getCredentialsMode } from './api/config'
 import { KeyboardShortcutProvider, useRegisterShortcut, useRegisterShortcuts } from './hooks/useKeyboardShortcuts'
 import { useAnimatedUnmount } from './hooks/useAnimatedUnmount'
-import { Loader2 } from 'lucide-react'
+import radarLoadingIcon from '@skyhook-io/k8s-ui/assets/radar/radar-icon-loading.svg'
 import { RefreshCw, Network, List, Clock, Package, Sun, Moon, Activity, Home, Star, Search, Bug, Settings, SquareTerminal, ShieldCheck } from 'lucide-react'
 import { useTheme } from './context/ThemeContext'
 import { Tooltip } from './components/ui/Tooltip'
@@ -141,7 +141,7 @@ function AuthBarrier({ authMode }: { authMode: string }) {
     return (
       <div className="flex-1 flex items-center justify-center bg-theme-base">
         <div className="flex flex-col items-center gap-4">
-          <Loader2 className="w-8 h-8 animate-spin text-blue-400" />
+          <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
           <p className="text-sm text-theme-text-secondary">Redirecting to login...</p>
         </div>
       </div>
@@ -942,7 +942,7 @@ function AppInner() {
       {!isSwitching && !(authMe?.authEnabled && !authMe?.username) && connection.state === 'connecting' && (
         <div className="flex-1 flex items-center justify-center bg-theme-base">
           <div className="flex flex-col items-center gap-4 text-theme-text-secondary">
-            <Loader2 className="w-8 h-8 animate-spin text-blue-400" />
+            <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
             <div className="text-center">
               <p className="font-medium text-theme-text-primary">Connecting to cluster</p>
               <p className="text-sm text-theme-text-secondary mt-1">{connection.context || 'Loading...'}</p>
@@ -960,7 +960,7 @@ function AppInner() {
       {isSwitching && (
         <div className="flex-1 flex items-center justify-center bg-theme-base">
           <div className="flex flex-col items-center gap-4 text-theme-text-secondary">
-            <Loader2 className="w-8 h-8 animate-spin text-blue-400" />
+            <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
             <div className="text-center">
               <div className="text-sm font-medium text-theme-text-primary">Switching context</div>
               {targetContext && (

--- a/web/src/components/ContextSwitcher.tsx
+++ b/web/src/components/ContextSwitcher.tsx
@@ -1,12 +1,16 @@
-import { useState, useRef, useEffect, useMemo } from 'react'
-import { ChevronDown, Check, Loader2, Server, AlertTriangle, Search, X } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { Server, AlertTriangle } from 'lucide-react'
+import {
+  ClusterSwitcher,
+  type ClusterSwitcherItem,
+  pluralize,
+} from '@skyhook-io/k8s-ui'
 import { useContexts, useSwitchContext, useClusterInfo, fetchSessionCounts, type SessionCounts } from '../api/client'
 import { useContextSwitch } from '../context/ContextSwitchContext'
 import { useToast } from '../components/ui/Toast'
 import { useDock } from '../components/dock'
 import type { ContextInfo } from '../types'
 import { parseContextName, type ParsedContextName } from '../utils/context-name'
-import { pluralize } from '@skyhook-io/k8s-ui'
 
 interface ContextSwitcherProps {
   className?: string
@@ -16,22 +20,10 @@ interface ParsedContext extends ParsedContextName {
   context: ContextInfo
 }
 
-// Group contexts by provider, then by account
-interface ContextGroup {
-  provider: string | null
-  account: string | null
-  items: ParsedContext[]
-}
-
 export function ContextSwitcher({ className = '' }: ContextSwitcherProps) {
-  const [isOpen, setIsOpen] = useState(false)
-  const [search, setSearch] = useState('')
-  const [highlightedIndex, setHighlightedIndex] = useState(-1)
   const [showConfirm, setShowConfirm] = useState(false)
   const [pendingSwitch, setPendingSwitch] = useState<ParsedContext | null>(null)
   const [sessionCounts, setSessionCounts] = useState<SessionCounts | null>(null)
-  const dropdownRef = useRef<HTMLDivElement>(null)
-  const searchInputRef = useRef<HTMLInputElement>(null)
 
   const { data: contexts, isLoading: contextsLoading } = useContexts()
   const { data: clusterInfo } = useClusterInfo()
@@ -40,178 +32,45 @@ export function ContextSwitcher({ className = '' }: ContextSwitcherProps) {
   const { showError } = useToast()
   const { tabs } = useDock()
 
-  // Parse, group, and sort contexts
-  const { groups, hasMultipleAccounts } = useMemo(() => {
-    if (!contexts) return { groups: [], hasMultipleProviders: false, hasMultipleAccounts: false }
-
-    // Parse all contexts
-    const parsed: ParsedContext[] = contexts.map(ctx => ({
-      context: ctx,
-      ...parseContextName(ctx.name),
-    }))
-
-    // Check if we have multiple accounts (to decide whether to show group headers)
+  // Parse contexts and decide whether to render group headers (multi-account only).
+  const { parsedById, hasMultipleAccounts } = useMemo(() => {
+    if (!contexts) return { parsedById: new Map<string, ParsedContext>(), hasMultipleAccounts: false }
+    const parsed: ParsedContext[] = contexts.map(ctx => ({ context: ctx, ...parseContextName(ctx.name) }))
     const accounts = new Set(parsed.map(p => `${p.provider}:${p.account}`))
-    const hasMultipleAccounts = accounts.size > 1
-
-    // Group by provider + account
-    const groupMap = new Map<string, ContextGroup>()
-    for (const p of parsed) {
-      const key = `${p.provider || 'other'}:${p.account || 'default'}`
-      if (!groupMap.has(key)) {
-        groupMap.set(key, { provider: p.provider, account: p.account, items: [] })
-      }
-      groupMap.get(key)!.items.push(p)
-    }
-
-    // Sort groups: GKE first, then EKS, then AKS, then Other
-    // Within provider, sort by account name
-    const providerOrder: Record<string, number> = { 'GKE': 0, 'EKS': 1, 'AKS': 2 }
-    const groups = Array.from(groupMap.values()).sort((a, b) => {
-      const orderA = providerOrder[a.provider || ''] ?? 3
-      const orderB = providerOrder[b.provider || ''] ?? 3
-      if (orderA !== orderB) return orderA - orderB
-      return (a.account || '').localeCompare(b.account || '')
-    })
-
-    // Sort items within each group by cluster name
-    for (const group of groups) {
-      group.items.sort((a, b) => a.clusterName.localeCompare(b.clusterName))
-    }
-
-    return { groups, hasMultipleAccounts }
+    const byId = new Map<string, ParsedContext>()
+    for (const p of parsed) byId.set(p.context.name, p)
+    return { parsedById: byId, hasMultipleAccounts: accounts.size > 1 }
   }, [contexts])
 
-  // Filter groups by search query
-  const { filteredGroups, flatItems, itemIndexMap } = useMemo(() => {
-    const filteredGroups = search.trim()
-      ? groups
-          .map(group => ({
-            ...group,
-            items: group.items.filter(item => {
-              const searchLower = search.toLowerCase()
-              return (
-                item.clusterName.toLowerCase().includes(searchLower) ||
-                item.raw.toLowerCase().includes(searchLower) ||
-                (item.region && item.region.toLowerCase().includes(searchLower)) ||
-                (item.account && item.account.toLowerCase().includes(searchLower))
-              )
-            }),
-          }))
-          .filter(group => group.items.length > 0)
-      : groups
-
-    const flatItems = filteredGroups.flatMap(g => g.items)
-    const itemIndexMap = new Map<string, number>()
-    flatItems.forEach((item, i) => itemIndexMap.set(item.context.name, i))
-
-    return { filteredGroups, flatItems, itemIndexMap }
-  }, [groups, search])
-
-  // Reset search and highlight when dropdown opens/closes
-  useEffect(() => {
-    if (isOpen) {
-      setSearch('')
-      setHighlightedIndex(-1)
-      requestAnimationFrame(() => {
-        searchInputRef.current?.focus()
-      })
-    }
-  }, [isOpen])
-
-  // Reset highlighted index when filtered results change
-  useEffect(() => {
-    setHighlightedIndex(-1)
-  }, [search])
-
-  // Keyboard navigation for search
-  const handleSearchKeyDown = (e: React.KeyboardEvent) => {
-    switch (e.key) {
-      case 'ArrowDown':
-        e.preventDefault()
-        setHighlightedIndex(prev => (prev < flatItems.length - 1 ? prev + 1 : prev))
-        break
-      case 'ArrowUp':
-        e.preventDefault()
-        setHighlightedIndex(prev => (prev > 0 ? prev - 1 : 0))
-        break
-      case 'Enter':
-        e.preventDefault()
-        if (highlightedIndex >= 0 && flatItems[highlightedIndex]) {
-          handleContextSwitch(flatItems[highlightedIndex])
-        } else if (flatItems.length > 0) {
-          setHighlightedIndex(0)
-        }
-        break
-      case 'Escape':
-        e.preventDefault()
-        setIsOpen(false)
-        break
-    }
-  }
-
-  // Scroll highlighted item into view
-  useEffect(() => {
-    if (!isOpen || highlightedIndex < 0 || !dropdownRef.current) return
-    const highlighted = dropdownRef.current.querySelector('[data-highlighted="true"]')
-    if (highlighted) {
-      highlighted.scrollIntoView({ block: 'nearest' })
-    }
-  }, [highlightedIndex, isOpen])
-
-  // Close dropdown when clicking outside
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setIsOpen(false)
+  // Map parsed contexts → generic ClusterSwitcher items, sorted GKE/EKS/AKS/Other → account → name.
+  const items = useMemo<ClusterSwitcherItem[]>(() => {
+    const order: Record<string, number> = { GKE: 0, EKS: 1, AKS: 2 }
+    const arr = Array.from(parsedById.values())
+    arr.sort((a, b) => {
+      const oa = order[a.provider || ''] ?? 3
+      const ob = order[b.provider || ''] ?? 3
+      if (oa !== ob) return oa - ob
+      const acc = (a.account || '').localeCompare(b.account || '')
+      if (acc !== 0) return acc
+      return a.clusterName.localeCompare(b.clusterName)
+    })
+    return arr.map(p => {
+      const groupKey = `${p.provider || 'other'}:${p.account || 'default'}`
+      const groupLabel = hasMultipleAccounts && p.provider
+        ? `${p.provider}${p.account ? ` · ${p.account}` : ''}`
+        : hasMultipleAccounts
+          ? 'Other'
+          : undefined
+      return {
+        id: p.context.name,
+        name: p.clusterName,
+        secondary: p.provider ? p.raw : undefined,
+        badge: p.region || undefined,
+        group: { key: groupKey, label: groupLabel },
       }
-    }
+    })
+  }, [parsedById, hasMultipleAccounts])
 
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [])
-
-  // Close dropdown on escape
-  useEffect(() => {
-    function handleEscape(event: KeyboardEvent) {
-      if (event.key === 'Escape') {
-        setIsOpen(false)
-      }
-    }
-
-    document.addEventListener('keydown', handleEscape)
-    return () => document.removeEventListener('keydown', handleEscape)
-  }, [])
-
-  // Check for active sessions and show confirmation if needed
-  const handleContextSwitch = async (parsed: ParsedContext) => {
-    if (parsed.context.isCurrent || switchContext.isPending) return
-
-    setIsOpen(false)
-
-    // Check for active sessions (port forwards from API + terminal tabs from dock)
-    try {
-      const counts = await fetchSessionCounts()
-      const terminalTabs = tabs.filter(t => t.type === 'terminal').length
-      const totalSessions = counts.portForwards + terminalTabs
-
-      if (totalSessions > 0) {
-        // Show confirmation dialog
-        setSessionCounts({ ...counts, execSessions: terminalTabs, total: totalSessions })
-        setPendingSwitch(parsed)
-        setShowConfirm(true)
-        return
-      }
-    } catch (error) {
-      console.error('Failed to check sessions:', error)
-      // Continue with switch even if check fails
-    }
-
-    // No active sessions, proceed with switch
-    performSwitch(parsed)
-  }
-
-  // Actually perform the context switch
   const performSwitch = async (parsed: ParsedContext) => {
     startSwitch({
       raw: parsed.raw,
@@ -222,21 +81,45 @@ export function ContextSwitcher({ className = '' }: ContextSwitcherProps) {
     })
     try {
       await switchContext.mutateAsync({ name: parsed.context.name })
-      // Success - endSwitch is called by the overlay when it detects success
     } catch (error) {
       console.error('Failed to switch context:', error)
       endSwitch()
-      // Show toast as fallback — if the backend set StateDisconnected,
-      // ConnectionErrorView will render with provider-specific hints.
-      // But if the request never reached the backend (network error,
-      // client timeout), connection.state stays 'connected' and the
-      // toast is the only error feedback the user gets.
+      // Backend may not transition to StateDisconnected on client-side errors
+      // (network, timeout) — without this toast the user gets no feedback.
       const message = error instanceof Error ? error.message : 'Unknown error'
       showError('Failed to switch context', message)
     }
   }
 
-  // Handle confirmation dialog actions
+  const handleSelect = async (item: ClusterSwitcherItem) => {
+    const parsed = parsedById.get(item.id)
+    if (!parsed || parsed.context.isCurrent || switchContext.isPending) return
+
+    // Active sessions (port forwards from API + terminal tabs from dock) get
+    // a confirmation prompt — switching contexts kills both.
+    try {
+      const counts = await fetchSessionCounts()
+      const terminalTabs = tabs.filter(t => t.type === 'terminal').length
+      const total = counts.portForwards + terminalTabs
+      if (total > 0) {
+        setSessionCounts({ ...counts, execSessions: terminalTabs, total })
+        setPendingSwitch(parsed)
+        setShowConfirm(true)
+        return
+      }
+    } catch (error) {
+      // Session-counts is best-effort; failing it shouldn't block the user.
+      // But warn — if there ARE active sessions we couldn't see, the switch
+      // will silently kill them.
+      console.error('Failed to check sessions:', error)
+      showError(
+        'Could not check active sessions',
+        'Switching anyway. Any open port-forwards or terminals will be terminated.',
+      )
+    }
+    performSwitch(parsed)
+  }
+
   const handleConfirmSwitch = () => {
     setShowConfirm(false)
     if (pendingSwitch) {
@@ -251,15 +134,9 @@ export function ContextSwitcher({ className = '' }: ContextSwitcherProps) {
     setSessionCounts(null)
   }
 
-  // Get current context info - parse it to extract cluster name
-  const currentContextRaw = clusterInfo?.context || contexts?.find(c => c.isCurrent)?.name || 'Unknown'
-  const currentParsed = useMemo(() => parseContextName(currentContextRaw), [currentContextRaw])
-  const currentDisplayName = currentParsed.clusterName
-
-  // Check if in-cluster mode (only one context named "in-cluster")
+  // In-cluster mode renders a static badge instead of a switcher (only one
+  // synthetic context, no kubeconfig to choose from).
   const isInClusterMode = contexts?.length === 1 && contexts[0].name === 'in-cluster'
-
-  // If in-cluster mode, just show a static badge
   if (isInClusterMode) {
     return (
       <div className={`flex items-center gap-2 ${className}`}>
@@ -270,166 +147,31 @@ export function ContextSwitcher({ className = '' }: ContextSwitcherProps) {
     )
   }
 
+  const currentRaw = clusterInfo?.context || contexts?.find(c => c.isCurrent)?.name || 'Unknown'
+  const currentParsed = parseContextName(currentRaw)
+  const currentId = contexts?.find(c => c.isCurrent)?.name
+
   return (
-    <div className={`relative ${className}`} ref={dropdownRef}>
-      {/* Trigger button */}
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        disabled={switchContext.isPending || contextsLoading}
-        className={`
-          flex items-center gap-1.5 px-2.5 py-1.5
-          bg-theme-elevated border border-theme-border rounded text-sm font-medium
-          text-theme-text-primary hover:bg-theme-hover hover:border-theme-border-light
-          transition-colors cursor-pointer
-          disabled:opacity-50 disabled:cursor-not-allowed
-        `}
-        title={currentContextRaw}
-      >
-        {switchContext.isPending ? (
-          <Loader2 className="w-3.5 h-3.5 animate-spin" />
-        ) : (
-          <Server className="w-3.5 h-3.5 text-theme-text-secondary" />
-        )}
-        <span className="max-w-[120px] sm:max-w-[220px] truncate">
-          {switchContext.isPending ? 'Switching...' : currentDisplayName}
-        </span>
-        <ChevronDown className={`w-3 h-3 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
-      </button>
+    <>
+      <ClusterSwitcher
+        className={className}
+        currentId={currentId}
+        currentName={currentParsed.clusterName}
+        currentTooltip={currentRaw}
+        triggerIcon={<Server className="w-3.5 h-3.5 text-theme-text-secondary" />}
+        items={items}
+        onSelect={handleSelect}
+        loading={switchContext.isPending}
+        disabled={contextsLoading}
+        searchable={items.length > 1}
+        showGroupHeaders={hasMultipleAccounts}
+        errorSlot={
+          switchContext.isError ? (
+            <span className="text-xs text-red-400">{switchContext.error?.message}</span>
+          ) : undefined
+        }
+      />
 
-      {/* Dropdown menu */}
-      {isOpen && !contextsLoading && contexts && (
-        <div className="absolute top-full left-0 mt-1 z-50 min-w-[280px] max-w-[420px] bg-theme-surface border border-theme-border-light rounded-lg shadow-xl overflow-hidden">
-          {/* Search input */}
-          {contexts.length > 1 && (
-            <div className="p-2 border-b border-theme-border">
-              <div className="relative">
-                <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-theme-text-tertiary" />
-                <input
-                  ref={searchInputRef}
-                  type="text"
-                  value={search}
-                  onChange={(e) => setSearch(e.target.value)}
-                  onKeyDown={handleSearchKeyDown}
-                  placeholder="Search clusters..."
-                  className="w-full bg-theme-base text-theme-text-primary text-xs rounded px-2 py-1.5 pl-7 pr-7 border border-theme-border-light focus:outline-none focus:ring-1 focus:ring-blue-500 placeholder:text-theme-text-tertiary"
-                />
-                {search && (
-                  <button
-                    type="button"
-                    onClick={() => setSearch('')}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 text-theme-text-tertiary hover:text-theme-text-secondary"
-                  >
-                    <X className="w-3.5 h-3.5" />
-                  </button>
-                )}
-              </div>
-            </div>
-          )}
-
-          <div className="max-h-[400px] overflow-y-auto">
-            {flatItems.length === 0 ? (
-              <div className="px-3 py-6 text-center text-xs text-theme-text-tertiary">
-                No clusters match "{search}"
-              </div>
-            ) : (
-              filteredGroups.map((group, groupIndex) => {
-                const showHeader = hasMultipleAccounts
-                const headerLabel = group.provider
-                  ? `${group.provider}${group.account ? ` · ${group.account}` : ''}`
-                  : 'Other'
-
-                return (
-                  <div key={`${group.provider}:${group.account}`}>
-                    {groupIndex > 0 && (
-                      <div className="border-t border-theme-border-light my-1" />
-                    )}
-                    {showHeader && (
-                      <div className="px-3 py-1 bg-theme-elevated/60 border-b border-theme-border/60">
-                        <span className="text-[11px] text-theme-text-secondary font-semibold">
-                          {headerLabel}
-                        </span>
-                      </div>
-                    )}
-                    {group.items.map((item) => {
-                      const itemIndex = itemIndexMap.get(item.context.name) ?? -1
-                      return (
-                        <button
-                          key={item.context.name}
-                          data-highlighted={itemIndex === highlightedIndex}
-                          onClick={() => handleContextSwitch(item)}
-                          onMouseEnter={() => setHighlightedIndex(itemIndex)}
-                          disabled={item.context.isCurrent || switchContext.isPending}
-                          className={`
-                            w-full flex items-center gap-2 px-3 py-2 text-left
-                            transition-colors
-                            ${item.context.isCurrent
-                              ? 'bg-blue-500/10'
-                              : itemIndex === highlightedIndex
-                                ? 'bg-theme-hover cursor-pointer'
-                                : 'hover:bg-theme-hover cursor-pointer'
-                            }
-                            disabled:opacity-50
-                          `}
-                        >
-                          <div className="shrink-0 w-4 h-4 flex items-center justify-center">
-                            {item.context.isCurrent ? (
-                              <Check className="w-3.5 h-3.5 text-blue-600 dark:text-blue-400" />
-                            ) : (
-                              <div className="w-1.5 h-1.5 rounded-full bg-theme-text-tertiary/30" />
-                            )}
-                          </div>
-                          <div className="flex-1 min-w-0">
-                            <div className="flex items-center gap-1.5">
-                              <span className={`text-sm font-medium truncate ${item.context.isCurrent ? 'text-blue-600 dark:text-blue-400' : 'text-theme-text-primary'}`}>
-                                {item.clusterName}
-                              </span>
-                              {item.context.isCurrent && (
-                                <span className="shrink-0 text-[9px] text-blue-600 dark:text-blue-400">
-                                  ●
-                                </span>
-                              )}
-                              {item.region && (
-                                <span className="shrink-0 ml-auto text-[10px] text-theme-text-tertiary bg-theme-elevated px-1 rounded">
-                                  {item.region}
-                                </span>
-                              )}
-                            </div>
-                            {item.provider && (
-                              <div className="text-[10px] text-theme-text-tertiary opacity-70 truncate mt-0.5" title={item.raw}>
-                                {item.raw}
-                              </div>
-                            )}
-                          </div>
-                        </button>
-                      )
-                    })}
-                  </div>
-                )
-              })
-            )}
-          </div>
-
-          {/* Footer with count */}
-          {contexts.length > 1 && search && flatItems.length > 0 && (
-            <div className="px-3 py-1.5 text-[10px] text-theme-text-tertiary border-t border-theme-border bg-theme-base">
-              {flatItems.length === contexts.length
-                ? `${contexts.length} clusters`
-                : `${flatItems.length} of ${contexts.length} clusters`}
-            </div>
-          )}
-
-          {/* Error message if switch failed */}
-          {switchContext.isError && (
-            <div className="px-3 py-2 bg-red-500/10 border-t border-red-500/20">
-              <span className="text-xs text-red-400">
-                {switchContext.error?.message}
-              </span>
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Confirmation modal */}
       {showConfirm && sessionCounts && pendingSwitch && (
         <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50">
           <div className="bg-theme-surface border border-theme-border rounded-lg shadow-xl max-w-md mx-4 overflow-hidden">
@@ -476,7 +218,6 @@ export function ContextSwitcher({ className = '' }: ContextSwitcherProps) {
           </div>
         </div>
       )}
-
-    </div>
+    </>
   )
 }

--- a/web/src/components/audit/AuditView.tsx
+++ b/web/src/components/audit/AuditView.tsx
@@ -2,7 +2,8 @@ import { useState, useCallback } from 'react'
 import { useAudit, useAuditSettings, useUpdateAuditSettings } from '../../api/client'
 import type { SelectedResource } from '../../types'
 import { AuditFindingsTable } from '@skyhook-io/k8s-ui'
-import { ArrowLeft, ClipboardCheck, Loader2, Settings } from 'lucide-react'
+import { ArrowLeft, ClipboardCheck, Settings } from 'lucide-react'
+import radarLoadingIcon from '@skyhook-io/k8s-ui/assets/radar/radar-icon-loading.svg'
 import { AuditSettingsDialog } from './AuditSettingsDialog'
 
 interface AuditViewProps {
@@ -50,7 +51,7 @@ export function AuditView({ namespaces, onBack, onNavigateToResource }: AuditVie
     return (
       <div className="flex-1 flex items-center justify-center">
         <div className="flex flex-col items-center gap-3">
-          <Loader2 className="w-6 h-6 animate-spin text-theme-text-tertiary" />
+          <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
           <span className="text-sm text-theme-text-tertiary">Loading audit data...</span>
         </div>
       </div>

--- a/web/src/components/cost/CostView.tsx
+++ b/web/src/components/cost/CostView.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useOpenCostSummary, useOpenCostWorkloads, useOpenCostNodes } from '../../api/client'
 import type { OpenCostNamespaceCost, OpenCostWorkloadCost, OpenCostNodeCost } from '../../api/client'
 import { ArrowLeft, ChevronDown, ChevronRight, DollarSign, HelpCircle, Loader2, Server, X } from 'lucide-react'
+import radarLoadingIcon from '@skyhook-io/k8s-ui/assets/radar/radar-icon-loading.svg'
 import { CostTrendChart } from './CostTrendChart'
 
 interface CostViewProps {
@@ -17,7 +18,7 @@ export function CostView({ onBack }: CostViewProps) {
     return (
       <div className="flex-1 flex items-center justify-center">
         <div className="flex flex-col items-center gap-3">
-          <Loader2 className="w-6 h-6 animate-spin text-theme-text-tertiary" />
+          <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
           <span className="text-sm text-theme-text-tertiary">Loading cost data...</span>
         </div>
       </div>

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -11,7 +11,8 @@ import { NetworkPolicyCoverageCard } from './NetworkPolicyCoverageCard'
 import { CostCard } from './CostCard'
 import { AuditCard, StatusDot, mapHealthToTone } from '@skyhook-io/k8s-ui'
 import { ClusterHealthCard } from './ClusterHealthCard'
-import { AlertTriangle, Loader2, Shield } from 'lucide-react'
+import { AlertTriangle, Shield } from 'lucide-react'
+import radarLoadingIcon from '@skyhook-io/k8s-ui/assets/radar/radar-icon-loading.svg'
 import { clsx } from 'clsx'
 
 interface HomeViewProps {
@@ -32,7 +33,7 @@ export function HomeView({ namespaces, topology, onNavigateToView, onNavigateToR
     return (
       <div className="flex-1 flex items-center justify-center">
         <div className="flex flex-col items-center gap-3">
-          <Loader2 className="w-6 h-6 animate-spin text-theme-text-tertiary" />
+          <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
           <span className="text-sm text-theme-text-tertiary">Loading dashboard...</span>
         </div>
       </div>

--- a/web/src/components/resources/ImageFilesystemModal.tsx
+++ b/web/src/components/resources/ImageFilesystemModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useMemo, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { X, Folder, File, Link2, ChevronRight, ChevronDown, AlertTriangle, Loader2, Search, Download, HardDrive, Shield, ShieldCheck, Terminal, Copy, Check, RefreshCw } from 'lucide-react'
+import radarLoadingIcon from '@skyhook-io/k8s-ui/assets/radar/radar-icon-loading.svg'
 import { clsx } from 'clsx'
 import { useImageMetadata, ApiError } from '../../api/client'
 import type { FileNode, ImageFilesystem } from '../../types'
@@ -178,7 +179,7 @@ export function ImageFilesystemModal({
           {/* Loading state */}
           {isLoading && (
             <div className="flex flex-col items-center justify-center h-64">
-              <Loader2 className="w-8 h-8 text-blue-400 animate-spin" />
+              <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
               <span className="mt-3 text-theme-text-secondary">
                 {isLoadingMetadata ? 'Checking image...' : 'Downloading image layers...'}
               </span>

--- a/web/src/components/resources/PodFilesystemModal.tsx
+++ b/web/src/components/resources/PodFilesystemModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useMemo, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { X, File, Link2, ChevronRight, AlertTriangle, Loader2, Search, Download, FolderOpen } from 'lucide-react'
+import radarLoadingIcon from '@skyhook-io/k8s-ui/assets/radar/radar-icon-loading.svg'
 import { clsx } from 'clsx'
 import type { FileNode } from '../../types'
 import { formatBytes } from '../../utils/format'
@@ -206,7 +207,7 @@ export function PodFilesystemModal({
           {/* Loading */}
           {isLoading && (
             <div className="flex flex-col items-center justify-center h-64">
-              <Loader2 className="w-8 h-8 text-blue-400 animate-spin" />
+              <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
               <span className="mt-3 text-theme-text-secondary">Loading files...</span>
             </div>
           )}

--- a/web/src/components/traffic/TrafficWizard.tsx
+++ b/web/src/components/traffic/TrafficWizard.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import type { TrafficSourcesResponse, TrafficWizardState } from '../../types'
-import { Loader2, CheckCircle2, XCircle, AlertTriangle, Copy, ExternalLink, ArrowRight, ArrowLeft, Package } from 'lucide-react'
+import { CheckCircle2, XCircle, AlertTriangle, Copy, ExternalLink, ArrowRight, ArrowLeft, Package } from 'lucide-react'
+import radarLoadingIcon from '@skyhook-io/k8s-ui/assets/radar/radar-icon-loading.svg'
 import { InstallWizard } from '../helm/InstallWizard'
 
 interface TrafficWizardProps {
@@ -91,7 +92,7 @@ export function TrafficWizard({
     return (
       <div className="flex items-center justify-center h-full w-full">
         <div className="text-center space-y-4">
-          <Loader2 className="h-8 w-8 animate-spin text-blue-400 mx-auto" />
+          <img src={radarLoadingIcon} alt="" aria-hidden className="h-11 w-11 mx-auto" />
           <p className="text-theme-text-secondary">Detecting traffic sources...</p>
         </div>
       </div>
@@ -105,7 +106,7 @@ export function TrafficWizard({
         <div className="flex items-center justify-center h-full w-full">
           <div className="max-w-md w-full p-6 space-y-6">
             <div className="text-center space-y-2">
-              <Loader2 className="h-8 w-8 animate-spin text-blue-400 mx-auto" />
+              <img src={radarLoadingIcon} alt="" aria-hidden className="h-11 w-11 mx-auto" />
               <h2 className="text-lg font-medium text-theme-text-primary">Waiting for traffic source...</h2>
               <p className="text-sm text-theme-text-secondary">
                 Checking for availability

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -16,3 +16,9 @@ export {
 } from './api/config';
 export type { NavCustomization } from './context/NavCustomization';
 export { ShortcutHelpOverlay } from './components/ui/ShortcutHelpOverlay';
+
+// Shared cluster-switcher primitive — re-exported from @skyhook-io/k8s-ui so
+// embedders (Radar Hub) can render a switcher visually identical to OSS Radar's
+// kubeconfig ContextSwitcher without taking a direct dep on k8s-ui internals.
+export { ClusterSwitcher } from '@skyhook-io/k8s-ui';
+export type { ClusterSwitcherProps, ClusterSwitcherItem } from '@skyhook-io/k8s-ui';


### PR DESCRIPTION
## Summary

- **Shared `ClusterSwitcher`** (in `@skyhook-io/k8s-ui`, re-exported from `@skyhook-io/radar-app`) replaces two divergent cluster-picker UIs. OSS Radar's `ContextSwitcher` rewrites on top of it; Radar Hub's `HubClusterSwitcher` will too in a follow-up Hub PR. Hub's picker previously rendered the raw `gke_<account>_<region>_<cluster>` context with a `Cluster:` prefix and **no truncation** — overflowing into the connection indicator and the view tabs on narrower screens. The primitive enforces `max-w-[120px] sm:max-w-[220px] truncate`.
- **Loading icon swap**: replace the generic `lucide` `Loader2` spinner with the Radar-branded SVG (sweep arm + pinging blips) across the auth barrier, connecting/switching overlays, Audit, Cost, Home, Resources, the pod/image filesystem modals, and the traffic-test wizard. SVG lives in `@skyhook-io/k8s-ui` (`exports: ./assets/radar/radar-icon-loading.svg`) so Hub consumes the same asset.

## Why

The picker divergence wasn't just cosmetic — Hub had no overflow protection, dropped active-session confirmation, dropped search, and would render with a different brand color than OSS once `--color-brand-*` tokens diverged. Pulling the primitive into k8s-ui means both apps stay in sync, and the OSS rewrite drops ~290 lines.

While here: the OSS `ContextSwitcher` previously swallowed `fetchSessionCounts` failures with a `console.error` and silently switched, killing port-forwards/terminals without warning. It now surfaces a toast.

## Notable design decisions

- `href` on a `ClusterSwitcherItem` takes precedence over the parent's `onSelect` — documented in JSDoc rather than hidden behind a discriminated union (two consumers don't justify the type complexity).
- `ESC` and click-outside listeners attach only while the dropdown is open, so a stacked modal (the active-sessions confirm dialog) doesn't get its escape key intercepted.
- Selection styling uses `.selection` / `.selection-text` classes so the active row picks up Hub's brand color, not Radar-blue.
- Status (dot) and badge (right-anchored pill) are rendered in distinct slots so future callers passing both don't collide.

## Ship order

`@skyhook-io/k8s-ui` must publish first (radar-app peer-deps `>=1.5.0`); then radar-app. Hub's PR will pin the new versions.

## Test plan

- [x] `npm run tsc` clean in `web/`
- [x] `make frontend` builds without warnings (other than pre-existing elkjs dynamic-import warning)
- [ ] Verify Radar's switcher trigger truncates correctly on a long context (e.g., GKE)
- [ ] Verify Radar's connecting/switching overlays render the new icon at the same vertical position
- [ ] Verify the search-result count footer ("3 of 12 clusters") appears when filtering

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it refactors the cluster context-switching UI and interaction flow (selection, grouping, session-confirmation) and replaces loading indicators across multiple views, which could introduce UX regressions or switching edge cases.
> 
> **Overview**
> Introduces a reusable `ClusterSwitcher` component in `@skyhook-io/k8s-ui` (and re-exports it from both `k8s-ui` and `@skyhook-io/radar-app`) to standardize cluster/context picking with search, grouping, keyboard navigation, truncating trigger text, and optional error/footer slots.
> 
> Refactors OSS Radar’s `ContextSwitcher` to use the shared switcher, preserving the active-session confirmation prompt and improving failure handling by surfacing a toast when session-count checks fail (instead of silently switching).
> 
> Adds a branded animated Radar SVG loading icon to `k8s-ui` exports and swaps multiple `Loader2` spinners in both `k8s-ui` (resources loading state) and the web app (auth redirect, connecting/switching overlays, audit/cost/home, filesystem modals, traffic wizard) to use the shared asset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b3a537f2be4ff279957a8ca686b46ce99bbef1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->