### PR TITLE
ui: PaneLoader for center-of-page loading + finish radar-icon swap

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useEffect, useCallback, useRef, useContext } from 'react'
 import { TableVirtuoso, type TableVirtuosoHandle } from 'react-virtuoso'
 import { useRefreshAnimation } from '../../hooks/useRefreshAnimation'
-import radarLoadingIcon from '../../assets/radar/radar-icon-loading.svg'
+import { PaneLoader } from '../ui/PaneLoader'
 import type { TopPodMetrics, TopNodeMetrics } from '../../types'
 import {
   Search,
@@ -3548,10 +3548,7 @@ export function ResourcesView({
           }}
         >
           {isLoading ? (
-            <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 text-theme-text-tertiary">
-              <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
-              <span className="text-sm">Loading…</span>
-            </div>
+            <PaneLoader className="absolute inset-0" />
           ) : isSelectedForbidden ? (
             <div className="absolute inset-0 flex flex-col items-center justify-center text-theme-text-tertiary">
               <Shield className="w-8 h-8 text-amber-400 mb-2" />

--- a/packages/k8s-ui/src/components/timeline/TimelineList.tsx
+++ b/packages/k8s-ui/src/components/timeline/TimelineList.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useRef, useEffect } from 'react'
 import { useRefreshAnimation } from '../../hooks/useRefreshAnimation'
+import { PaneLoader } from '../ui/PaneLoader'
 import {
   AlertCircle,
   CheckCircle,
@@ -403,10 +404,7 @@ export function TimelineList({ events, isLoading, onRefresh, onQueryChange, hasL
       {/* Timeline content */}
       <div className="flex-1 overflow-auto">
         {isLoading ? (
-          <div className="flex items-center justify-center h-full text-theme-text-tertiary">
-            <RefreshCw className="w-5 h-5 animate-spin mr-2" />
-            Loading timeline...
-          </div>
+          <PaneLoader label="Loading timeline…" className="h-full" />
         ) : filteredActivity.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full text-theme-text-tertiary">
             <Clock className="w-12 h-12 mb-4 opacity-50" />

--- a/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
+++ b/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
@@ -21,6 +21,7 @@ import '@xyflow/react/dist/style.css'
 import { toCanvas } from 'html-to-image'
 
 import { AlertTriangle, Download, LayoutGrid, Loader2, Maximize, Minus, Pause, Play, Plus, RotateCw, Shield, Workflow } from 'lucide-react'
+import { PaneLoader } from '../ui/PaneLoader'
 import { Tooltip } from '../ui/Tooltip'
 import { useToast } from '../ui/Toast'
 import { useRegisterShortcuts } from '../../hooks/useKeyboardShortcuts'
@@ -653,14 +654,7 @@ export function TopologyGraph({
   }, [selectedNodeId, setNodes])
 
   if (!topology) {
-    return (
-      <div className="flex-1 flex items-center justify-center text-theme-text-secondary">
-        <div className="text-center">
-          <Loader2 className="w-6 h-6 animate-spin mx-auto mb-2 opacity-50" />
-          <p className="text-sm">Loading topology...</p>
-        </div>
-      </div>
-    )
+    return <PaneLoader label="Loading topology…" className="flex-1" />
   }
 
   if (topology.nodes.length === 0) {

--- a/packages/k8s-ui/src/components/ui/PaneLoader.tsx
+++ b/packages/k8s-ui/src/components/ui/PaneLoader.tsx
@@ -1,0 +1,21 @@
+import radarLoadingIcon from '../../assets/radar/radar-icon-loading.svg'
+
+// PaneLoader — center-of-pane loading state. Animated radar icon stacked
+// above a label so swapping the label across the loading chain doesn't
+// shift the icon horizontally. Pin to the parent's fill via `className`
+// (`flex-1`, `h-full`, `h-32`, `absolute inset-0`, etc.). The SVG self-
+// animates (sweep arm + blips, `prefers-reduced-motion` honored).
+export function PaneLoader({
+  label = 'Loading…',
+  className = '',
+}: {
+  label?: string
+  className?: string
+}) {
+  return (
+    <div className={`flex flex-col items-center justify-center gap-3 ${className}`}>
+      <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
+      <span className="text-sm text-theme-text-tertiary">{label}</span>
+    </div>
+  )
+}

--- a/packages/k8s-ui/src/components/ui/index.ts
+++ b/packages/k8s-ui/src/components/ui/index.ts
@@ -1,4 +1,5 @@
 export { Tooltip } from './Tooltip'
+export { PaneLoader } from './PaneLoader'
 export { ClusterName } from './ClusterName'
 export { EmptyState } from './EmptyState'
 export type { EmptyStateTone, EmptyStateVariant } from './EmptyState'

--- a/packages/k8s-ui/src/components/workload/WorkloadView.tsx
+++ b/packages/k8s-ui/src/components/workload/WorkloadView.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useEffect, useRef, useCallback, type ReactNode } from 'react'
 import { flushSync } from 'react-dom'
 import { useRefreshAnimation } from '../../hooks/useRefreshAnimation'
+import { PaneLoader } from '../ui/PaneLoader'
 import { useRegisterShortcuts } from '../../hooks/useKeyboardShortcuts'
 import { clsx } from 'clsx'
 import {
@@ -426,7 +427,7 @@ export function WorkloadView({
         {/* Content — viewTransitionName scopes View Transitions API cross-fade to this element */}
         <div className="flex-1 overflow-y-auto" style={{ viewTransitionName: 'drawer-content' }}>
           {resourceLoading ? (
-            <div className="flex items-center justify-center h-32 text-theme-text-tertiary">Loading...</div>
+            <PaneLoader className="h-32" />
           ) : !resource ? (
             <div className="flex items-center justify-center h-32 text-theme-text-tertiary">Resource not found</div>
           ) : showYaml ? (
@@ -640,7 +641,7 @@ export function WorkloadView({
         {activeTab === 'yaml' && (
           <div className="h-full overflow-auto">
             {resourceLoading ? (
-              <div className="flex items-center justify-center h-32 text-theme-text-tertiary">Loading...</div>
+              <PaneLoader className="h-32" />
             ) : !resource ? (
               <div className="flex items-center justify-center h-32 text-theme-text-tertiary">Resource not found</div>
             ) : (
@@ -1105,12 +1106,7 @@ function InfoTab({
   extraContent?: ReactNode
 }) {
   if (isLoading) {
-    return (
-      <div className="flex items-center justify-center h-full text-theme-text-tertiary">
-        <RefreshCw className="w-5 h-5 animate-spin mr-2" />
-        Loading...
-      </div>
-    )
+    return <PaneLoader className="h-full" />
   }
 
   if (!resource) {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyhook-io/radar-app",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Radar's full web UI as a reusable React component. Used by Radar's own binary and by external consumers like Radar Cloud.",
   "repository": {
     "type": "git",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -142,7 +142,7 @@ function AuthBarrier({ authMode }: { authMode: string }) {
       <div className="flex-1 flex items-center justify-center bg-theme-base">
         <div className="flex flex-col items-center gap-4">
           <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
-          <p className="text-sm text-theme-text-secondary">Redirecting to login...</p>
+          <p className="text-sm text-theme-text-secondary">Redirecting to login…</p>
         </div>
       </div>
     )
@@ -945,7 +945,7 @@ function AppInner() {
             <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
             <div className="text-center">
               <p className="font-medium text-theme-text-primary">Connecting to cluster</p>
-              <p className="text-sm text-theme-text-secondary mt-1">{connection.context || 'Loading...'}</p>
+              <p className="text-sm text-theme-text-secondary mt-1">{connection.context || 'Loading…'}</p>
               {connection.progressMessage && (
                 <p className="text-xs text-theme-text-tertiary animate-pulse mt-3">
                   {connection.progressMessage}

--- a/web/src/components/audit/AuditView.tsx
+++ b/web/src/components/audit/AuditView.tsx
@@ -1,9 +1,8 @@
 import { useState, useCallback } from 'react'
 import { useAudit, useAuditSettings, useUpdateAuditSettings } from '../../api/client'
 import type { SelectedResource } from '../../types'
-import { AuditFindingsTable } from '@skyhook-io/k8s-ui'
+import { AuditFindingsTable, PaneLoader } from '@skyhook-io/k8s-ui'
 import { ArrowLeft, ClipboardCheck, Settings } from 'lucide-react'
-import radarLoadingIcon from '@skyhook-io/k8s-ui/assets/radar/radar-icon-loading.svg'
 import { AuditSettingsDialog } from './AuditSettingsDialog'
 
 interface AuditViewProps {
@@ -48,14 +47,7 @@ export function AuditView({ namespaces, onBack, onNavigateToResource }: AuditVie
   }, [auditSettings, updateSettings])
 
   if (isLoading) {
-    return (
-      <div className="flex-1 flex items-center justify-center">
-        <div className="flex flex-col items-center gap-3">
-          <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
-          <span className="text-sm text-theme-text-tertiary">Loading audit data...</span>
-        </div>
-      </div>
-    )
+    return <PaneLoader label="Loading audit data…" className="flex-1" />
   }
 
   if (error) {

--- a/web/src/components/cost/CostView.tsx
+++ b/web/src/components/cost/CostView.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import { useOpenCostSummary, useOpenCostWorkloads, useOpenCostNodes } from '../../api/client'
 import type { OpenCostNamespaceCost, OpenCostWorkloadCost, OpenCostNodeCost } from '../../api/client'
 import { ArrowLeft, ChevronDown, ChevronRight, DollarSign, HelpCircle, Loader2, Server, X } from 'lucide-react'
-import radarLoadingIcon from '@skyhook-io/k8s-ui/assets/radar/radar-icon-loading.svg'
+import { PaneLoader } from '@skyhook-io/k8s-ui'
 import { CostTrendChart } from './CostTrendChart'
 
 interface CostViewProps {
@@ -15,14 +15,7 @@ export function CostView({ onBack }: CostViewProps) {
   const [showHelp, setShowHelp] = useState(false)
 
   if (isLoading) {
-    return (
-      <div className="flex-1 flex items-center justify-center">
-        <div className="flex flex-col items-center gap-3">
-          <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
-          <span className="text-sm text-theme-text-tertiary">Loading cost data...</span>
-        </div>
-      </div>
-    )
+    return <PaneLoader label="Loading cost data…" className="flex-1" />
   }
 
   if (!data || !data.available) {

--- a/web/src/components/helm/ChartBrowser.tsx
+++ b/web/src/components/helm/ChartBrowser.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react'
 import { Search, RefreshCw, Package, Database, AlertCircle, ExternalLink, ChevronDown, Star, Shield, BadgeCheck, Building2, Globe, ArrowUpDown, FileJson, PenTool } from 'lucide-react'
+import { PaneLoader } from '@skyhook-io/k8s-ui'
 import { clsx } from 'clsx'
 import { useHelmRepositories, useSearchCharts, useUpdateRepository, useArtifactHubSearch, type ArtifactHubSortOption } from '../../api/client'
 import { useCanHelmWrite } from '../../contexts/CapabilitiesContext'
@@ -258,9 +259,7 @@ export function ChartBrowser({ onChartSelect }: ChartBrowserProps) {
       {/* Chart grid */}
       <div className="flex-1 overflow-auto p-4">
         {isLoading ? (
-          <div className="flex items-center justify-center h-32 text-theme-text-tertiary">
-            Loading charts...
-          </div>
+          <PaneLoader label="Loading charts…" className="h-32" />
         ) : chartSource === 'local' ? (
           // Local charts view
           filteredLocalCharts.length === 0 ? (

--- a/web/src/components/helm/HelmReleaseDrawer.tsx
+++ b/web/src/components/helm/HelmReleaseDrawer.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { flushSync } from 'react-dom'
+import { PaneLoader } from '@skyhook-io/k8s-ui'
 import { TRANSITION_DRAWER } from '../../utils/animation'
 import { useRefreshAnimation } from '../../hooks/useRefreshAnimation'
 import { X, Copy, Check, RefreshCw, Package, Code, History, FileText, Settings, Link2, Anchor, GitFork, BookOpen, ArrowUpCircle, Trash2 } from 'lucide-react'
@@ -413,7 +414,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
       {/* Content */}
       <div className="flex-1 overflow-y-auto" style={{ viewTransitionName: 'helm-drawer-content' }}>
         {isLoading ? (
-          <div className="flex items-center justify-center h-32 text-theme-text-tertiary">Loading...</div>
+          <PaneLoader className="h-32" />
         ) : !releaseDetail ? (
           <div className="flex items-center justify-center h-32 text-theme-text-tertiary">Release not found</div>
         ) : (

--- a/web/src/components/helm/HelmView.tsx
+++ b/web/src/components/helm/HelmView.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useRef, useEffect, useCallback, forwardRef } from 'r
 import { useRefreshAnimation } from '../../hooks/useRefreshAnimation'
 import { useRegisterShortcuts } from '../../hooks/useKeyboardShortcuts'
 import { Package, Search, RefreshCw, ArrowUpCircle, LayoutGrid, List, Shield } from 'lucide-react'
+import { PaneLoader } from '@skyhook-io/k8s-ui'
 import { clsx } from 'clsx'
 import { useHelmReleases, useHelmBatchUpgradeInfo, isForbiddenError } from '../../api/client'
 import type { HelmRelease, SelectedHelmRelease, UpgradeInfo, ChartSource } from '../../types'
@@ -232,9 +233,7 @@ export function HelmView({ namespace, selectedRelease, onReleaseClick }: HelmVie
             {/* Releases Table */}
             <div className="flex-1 overflow-auto">
               {isLoading ? (
-                <div className="flex items-center justify-center h-full text-theme-text-tertiary">
-                  Loading...
-                </div>
+                <PaneLoader className="h-full" />
               ) : isForbidden ? (
                 <div className="flex flex-col items-center justify-center h-full text-theme-text-tertiary">
                   <Shield className="w-8 h-8 text-amber-400 mb-2" />

--- a/web/src/components/helm/InstallWizard.tsx
+++ b/web/src/components/helm/InstallWizard.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { X, Package, ChevronRight, ChevronLeft, Play, Loader2, AlertTriangle, CheckCircle, User, BookOpen, Link as LinkIcon, Star, BadgeCheck, Shield, Globe, Building2, Plus, Minus, Terminal } from 'lucide-react'
+import { PaneLoader } from '@skyhook-io/k8s-ui'
 import { clsx } from 'clsx'
 import yaml from 'yaml'
 import { createPatch } from 'diff'
@@ -277,10 +278,7 @@ export function InstallWizard({ repo, chartName, version, source, repoUrl, defau
         {/* Content */}
         <div className="flex-1 overflow-auto p-4">
           {chartLoading ? (
-            <div className="flex items-center justify-center h-32 text-theme-text-tertiary">
-              <Loader2 className="w-5 h-5 animate-spin mr-2" />
-              Loading chart details...
-            </div>
+            <PaneLoader label="Loading chart details…" className="h-32" />
           ) : (
             <>
               {step === 'info' && (

--- a/web/src/components/helm/ManifestDiffViewer.tsx
+++ b/web/src/components/helm/ManifestDiffViewer.tsx
@@ -1,4 +1,5 @@
 import { X, GitCompare } from 'lucide-react'
+import { PaneLoader } from '@skyhook-io/k8s-ui'
 import { clsx } from 'clsx'
 
 interface ManifestDiffViewerProps {
@@ -11,11 +12,7 @@ interface ManifestDiffViewerProps {
 
 export function ManifestDiffViewer({ diff, isLoading, revision1, revision2, onClose }: ManifestDiffViewerProps) {
   if (isLoading) {
-    return (
-      <div className="flex items-center justify-center h-32 text-theme-text-tertiary">
-        Computing diff...
-      </div>
-    )
+    return <PaneLoader label="Computing diff…" className="h-32" />
   }
 
   if (!diff) {

--- a/web/src/components/helm/ManifestViewer.tsx
+++ b/web/src/components/helm/ManifestViewer.tsx
@@ -1,4 +1,5 @@
 import { Copy, Check, Code } from 'lucide-react'
+import { PaneLoader } from '@skyhook-io/k8s-ui'
 import { CodeViewer } from '../ui/CodeViewer'
 
 interface ManifestViewerProps {
@@ -11,11 +12,7 @@ interface ManifestViewerProps {
 
 export function ManifestViewer({ manifest, isLoading, revision, onCopy, copied }: ManifestViewerProps) {
   if (isLoading) {
-    return (
-      <div className="flex items-center justify-center h-32 text-theme-text-tertiary">
-        Loading manifest...
-      </div>
-    )
+    return <PaneLoader label="Loading manifest…" className="h-32" />
   }
 
   if (!manifest) {

--- a/web/src/components/helm/ValuesViewer.tsx
+++ b/web/src/components/helm/ValuesViewer.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react'
 import { Copy, Check, Settings, Pencil, X, Eye, Play, Loader2 } from 'lucide-react'
+import { PaneLoader } from '@skyhook-io/k8s-ui'
 import { clsx } from 'clsx'
 import yaml from 'yaml'
 import type { HelmValues, ValuesPreviewResponse } from '../../types'
@@ -138,11 +139,7 @@ export function ValuesViewer({
   }, [previewData, namespace, name, applyMutation, handleCancelEdit, onApplySuccess])
 
   if (isLoading) {
-    return (
-      <div className="flex items-center justify-center h-32 text-theme-text-tertiary">
-        Loading values...
-      </div>
-    )
+    return <PaneLoader label="Loading values…" className="h-32" />
   }
 
   if (isEmpty && !isEditing) {

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -9,10 +9,9 @@ import { TrafficSummary } from './TrafficSummary'
 import { CertificateHealthCard } from './CertificateHealthCard'
 import { NetworkPolicyCoverageCard } from './NetworkPolicyCoverageCard'
 import { CostCard } from './CostCard'
-import { AuditCard, StatusDot, mapHealthToTone } from '@skyhook-io/k8s-ui'
+import { AuditCard, PaneLoader, StatusDot, mapHealthToTone } from '@skyhook-io/k8s-ui'
 import { ClusterHealthCard } from './ClusterHealthCard'
 import { AlertTriangle, Shield } from 'lucide-react'
-import radarLoadingIcon from '@skyhook-io/k8s-ui/assets/radar/radar-icon-loading.svg'
 import { clsx } from 'clsx'
 
 interface HomeViewProps {
@@ -30,14 +29,7 @@ export function HomeView({ namespaces, topology, onNavigateToView, onNavigateToR
   const { data: helmData } = useDashboardHelm(namespaces)
 
   if (isLoading) {
-    return (
-      <div className="flex-1 flex items-center justify-center">
-        <div className="flex flex-col items-center gap-3">
-          <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
-          <span className="text-sm text-theme-text-tertiary">Loading dashboard...</span>
-        </div>
-      </div>
-    )
+    return <PaneLoader label="Loading dashboard…" className="flex-1" />
   }
 
   if (error || !data) {

--- a/web/src/components/resources/ImageFilesystemModal.tsx
+++ b/web/src/components/resources/ImageFilesystemModal.tsx
@@ -178,13 +178,13 @@ export function ImageFilesystemModal({
         <div className="flex-1 overflow-y-auto p-4">
           {/* Loading state */}
           {isLoading && (
-            <div className="flex flex-col items-center justify-center h-64">
+            <div className="flex flex-col items-center justify-center gap-3 h-64">
               <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
-              <span className="mt-3 text-theme-text-secondary">
-                {isLoadingMetadata ? 'Checking image...' : 'Downloading image layers...'}
+              <span className="text-sm text-theme-text-secondary">
+                {isLoadingMetadata ? 'Checking image…' : 'Downloading image layers…'}
               </span>
               {isLoadingFilesystem && metadata && (
-                <span className="mt-1 text-xs text-theme-text-tertiary">
+                <span className="text-xs text-theme-text-tertiary">
                   This may take a moment for large images
                 </span>
               )}

--- a/web/src/components/resources/PodFilesystemModal.tsx
+++ b/web/src/components/resources/PodFilesystemModal.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useMemo, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { X, File, Link2, ChevronRight, AlertTriangle, Loader2, Search, Download, FolderOpen } from 'lucide-react'
-import radarLoadingIcon from '@skyhook-io/k8s-ui/assets/radar/radar-icon-loading.svg'
+import { PaneLoader } from '@skyhook-io/k8s-ui'
 import { clsx } from 'clsx'
 import type { FileNode } from '../../types'
 import { formatBytes } from '../../utils/format'
@@ -205,12 +205,7 @@ export function PodFilesystemModal({
         {/* Content */}
         <div className="flex-1 overflow-y-auto p-4">
           {/* Loading */}
-          {isLoading && (
-            <div className="flex flex-col items-center justify-center h-64">
-              <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
-              <span className="mt-3 text-theme-text-secondary">Loading files...</span>
-            </div>
-          )}
+          {isLoading && <PaneLoader label="Loading files…" className="h-64" />}
 
           {/* Error */}
           {error && !isLoading && (

--- a/web/src/components/timeline/TimelineSwimlanes.tsx
+++ b/web/src/components/timeline/TimelineSwimlanes.tsx
@@ -27,7 +27,7 @@ import { useHasLimitedAccess } from '../../contexts/CapabilitiesContext'
 import type { TimelineEvent, Topology } from '../../types'
 import type { NavigateToResource } from '../../utils/navigation'
 import { kindToPlural } from '../../utils/navigation'
-import { pluralize } from '@skyhook-io/k8s-ui'
+import { PaneLoader, pluralize } from '@skyhook-io/k8s-ui'
 import { isChangeEvent, isHistoricalEvent, isOperation, displayKind } from '../../types'
 import { DiffViewer } from './DiffViewer'
 import { getOperationColor, getHealthBadgeColor, getEventTypeColor } from '../../utils/badge-colors'
@@ -436,12 +436,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
   }, [])
 
   if (isLoading) {
-    return (
-      <div className="flex items-center justify-center h-full w-full text-theme-text-tertiary">
-        <RefreshCw className="w-5 h-5 animate-spin mr-2" />
-        Loading timeline...
-      </div>
-    )
+    return <PaneLoader label="Loading timeline…" className="h-full w-full" />
   }
 
   // Compute empty state info (but don't early return - we need the toolbar visible)

--- a/web/src/components/traffic/TrafficView.tsx
+++ b/web/src/components/traffic/TrafficView.tsx
@@ -11,7 +11,7 @@ import { Loader2, RefreshCw, Filter, Plug, ChevronDown, List, Activity, AlertTri
 import { clsx } from 'clsx'
 import { useQueryClient } from '@tanstack/react-query'
 import { useDock } from '../dock'
-import { EmptyState } from '@skyhook-io/k8s-ui'
+import { EmptyState, PaneLoader } from '@skyhook-io/k8s-ui'
 
 // Addon types for filtering
 export type AddonMode = 'show' | 'group' | 'hide'
@@ -1136,12 +1136,10 @@ export function TrafficView({ namespaces }: TrafficViewProps) {
           })()}
 
           {isConnecting || (flowsFetching && finalFlows.length === 0) ? (
-            <div className="absolute inset-0 flex items-center justify-center">
-              <div className="flex items-center gap-2 text-theme-text-secondary">
-                <Loader2 className="h-5 w-5 animate-spin" />
-                <span>{isConnecting ? 'Connecting to traffic source...' : 'Loading traffic data...'}</span>
-              </div>
-            </div>
+            <PaneLoader
+              label={isConnecting ? 'Connecting to traffic source…' : 'Loading traffic data…'}
+              className="absolute inset-0"
+            />
           ) : finalFlows.length > 0 ? (
             <TrafficGraph
               flows={finalFlows}

--- a/web/src/components/traffic/TrafficWizard.tsx
+++ b/web/src/components/traffic/TrafficWizard.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import type { TrafficSourcesResponse, TrafficWizardState } from '../../types'
 import { CheckCircle2, XCircle, AlertTriangle, Copy, ExternalLink, ArrowRight, ArrowLeft, Package } from 'lucide-react'
+import { PaneLoader } from '@skyhook-io/k8s-ui'
 import radarLoadingIcon from '@skyhook-io/k8s-ui/assets/radar/radar-icon-loading.svg'
 import { InstallWizard } from '../helm/InstallWizard'
 
@@ -89,14 +90,7 @@ export function TrafficWizard({
 
   // Detecting state
   if (state === 'detecting' || sourcesLoading) {
-    return (
-      <div className="flex items-center justify-center h-full w-full">
-        <div className="text-center space-y-4">
-          <img src={radarLoadingIcon} alt="" aria-hidden className="h-11 w-11 mx-auto" />
-          <p className="text-theme-text-secondary">Detecting traffic sources...</p>
-        </div>
-      </div>
-    )
+    return <PaneLoader label="Detecting traffic sources…" className="h-full w-full" />
   }
 
   // Checking state (polling for newly enabled source)
@@ -105,9 +99,9 @@ export function TrafficWizard({
       <>
         <div className="flex items-center justify-center h-full w-full">
           <div className="max-w-md w-full p-6 space-y-6">
-            <div className="text-center space-y-2">
-              <img src={radarLoadingIcon} alt="" aria-hidden className="h-11 w-11 mx-auto" />
-              <h2 className="text-lg font-medium text-theme-text-primary">Waiting for traffic source...</h2>
+            <div className="flex flex-col items-center gap-3">
+              <img src={radarLoadingIcon} alt="" aria-hidden className="h-11 w-11" />
+              <h2 className="text-lg font-medium text-theme-text-primary">Waiting for traffic source…</h2>
               <p className="text-sm text-theme-text-secondary">
                 Checking for availability
               </p>


### PR DESCRIPTION
## Summary

Builds on #548 (which introduced the animated radar SVG and swapped the first batch of full-screen Loader2 sites). This PR extracts a reusable `PaneLoader` component and finishes the sweep so every in-pane / modal-body / wizard-step loading state now uses the same icon + label shape.

`PaneLoader` lives at `packages/k8s-ui/components/ui/PaneLoader.tsx` and is exported from `@skyhook-io/k8s-ui`. Call sites collapse from a 5-line `<div>… <img/>… <span>…</span></div>` block to one line, e.g. `<PaneLoader label="Loading topology…" className="flex-1" />`.

## What's swapped (16 sites)

- **k8s-ui**: ResourcesView, TopologyGraph (`Loading topology…`), TimelineList, WorkloadView (3 sites).
- **radar/web**: HomeView, AuditView, CostView, HelmView, ChartBrowser, HelmReleaseDrawer, InstallWizard chart-loading, ManifestViewer, ManifestDiffViewer, ValuesViewer, TimelineSwimlanes, TrafficView (`Connecting to traffic source…` / `Loading traffic data…`), TrafficWizard detecting, PodFilesystemModal.

## What stays bespoke

Each kept the raw `radarLoadingIcon` import for a reason that doesn't fit `PaneLoader`'s simple icon+label shape:

- `App.tsx` (3 sites: AuthBarrier OIDC redirect, "Connecting to cluster", "Switching context") — primary heading + sub-context + optional progress message.
- `TrafficWizard` checking state — icon + h2 + sublabel + action buttons.
- `ImageFilesystemModal` — dynamic label that toggles between two strings plus a conditional sub-line.

## Side cleanups

- Ellipsis standardized to `…` (Unicode) across swapped labels.
- Dropped now-unused `Loader2` imports where no inline spinner remained.
- Bumped `@skyhook-io/radar-app` 0.1.7 → 0.1.8 since the visible loading states changed shape.

Future tweaks to the loader visual now touch one file. Net diff: -119 +73 (~70 lines of repeated structure removed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor that mostly consolidates loading spinners into a shared component; main risk is minor layout/styling regressions in affected screens and modals.
> 
> **Overview**
> Adds a shared `PaneLoader` component to `k8s-ui` (exported via `components/ui/index.ts`) to standardize center-of-pane loading states using the animated radar icon + label.
> 
> Replaces numerous bespoke loading placeholders in `k8s-ui` views (resources, timeline, topology, workload) and `web` screens/modals (home, audit, cost, helm flows, timeline, traffic, filesystem) with `PaneLoader`, and bumps `@skyhook-io/radar-app` version `0.1.7` → `0.1.8`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba3a2b2b949aac1f846694baf4e0553010e4d1ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->