### PR TITLE
fix(publish): unblock radar-app 0.1.8 + tolerate version-equal source

### DIFF
--- a/.github/workflows/publish-radar-app.yml
+++ b/.github/workflows/publish-radar-app.yml
@@ -30,7 +30,7 @@ jobs:
         run: echo "version=${GITHUB_REF_NAME#radar-app-v}" >> "$GITHUB_OUTPUT"
 
       - name: Set package version
-        run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version
+        run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyhook-io/radar-app",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Radar's full web UI as a reusable React component. Used by Radar's own binary and by external consumers like Radar Cloud.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The \`radar-app-v0.1.8\` publish workflow [failed](https://github.com/skyhook-io/radar/actions/runs/25020791102) because it runs \`npm version 0.1.8 --no-git-tag-version\` against a source package.json already at 0.1.8 (#549 bumped it before tagging), and npm errors with \"Version not changed\".

Two fixes:

- **Workflow**: add \`--allow-same-version\` so source-equal-to-tag isn't fatal. Future contributors can bump source in their PR (the natural place) without breaking publish.
- **Version**: bump source 0.1.8 → 0.1.9 to skip the snared 0.1.8 tag. After merge, tag \`radar-app-v0.1.9\` and the workflow will publish cleanly.

Same pattern applies to \`publish-k8s-ui.yml\` if anyone hits this there — out of scope for now since k8s-ui's last publish (1.5.7) succeeded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the npm publish GitHub Actions workflow and increments the package version, with no runtime logic changes.
> 
> **Overview**
> Unblocks `@skyhook-io/radar-app` releases by updating the publish workflow to run `npm version ... --allow-same-version`, preventing failures when the tagged version equals the repo’s `package.json` version.
> 
> Bumps `web/package.json` from `0.1.8` to `0.1.9` to move past the previously failed release tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e621d9559a5a373e20fb16c96e6e310d8e2eb066. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->