### PR TITLE
fix(connecting): drop redundant 'Loading…' under 'Connecting to cluster'

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -945,7 +945,9 @@ function AppInner() {
             <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
             <div className="text-center">
               <p className="font-medium text-theme-text-primary">Connecting to cluster</p>
-              <p className="text-sm text-theme-text-secondary mt-1">{connection.context || 'Loading…'}</p>
+              {connection.context && (
+                <p className="text-sm text-theme-text-secondary mt-1">{connection.context}</p>
+              )}
               {connection.progressMessage && (
                 <p className="text-xs text-theme-text-tertiary animate-pulse mt-3">
                   {connection.progressMessage}


### PR DESCRIPTION
When `connection.context` is empty (e.g. embedded in radar-hub-web, which doesn't pass a kubeconfig context name), the secondary line fell back to 'Loading…' — which paired with 'Connecting to cluster' above just repeated the same information.

Hide the secondary line when context is empty. In OSS Radar with a kubeconfig context, it still shows the context name as before.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that affects the connecting screen copy; no data flow or state management logic is modified.
> 
> **Overview**
> Removes the redundant `Loading…` fallback in the connecting screen.
> 
> `App.tsx` now only renders the secondary line under **Connecting to cluster** when `connection.context` is present, avoiding an extra placeholder line when no context name is provided (e.g., embedded mode).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2da5f4e6e73d0b73d9848b93ed4ae98125310b8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->