### PR TITLE
fix(resources): kind URL sync, drawer reset, canonical /resources redirect

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1763,8 +1763,8 @@ export function ResourcesView({
   pinned = [],
   togglePin = () => {},
   isPinned = () => false,
-  locationSearch = '',
-  locationPathname = '',
+  locationSearch,
+  locationPathname,
   onNavigate,
   basePath = '/resources',
   onOpenLogs,
@@ -1775,7 +1775,6 @@ export function ResourcesView({
   extraLeadingColumns,
   onRowSelect,
 }: ResourcesViewProps) {
-  const location = useMemo(() => ({ search: locationSearch, pathname: locationPathname }), [locationSearch, locationPathname])
   const initialFilters = getInitialFiltersFromURL()
   const [selectedKind, setSelectedKind] = useState<SelectedKindInfo>(() => getInitialKindFromURL(basePath, locationPathname, locationSearch))
   // Sync selectedKind from URL when locationPathname changes (e.g., browser back, external sidebar navigation)
@@ -2367,7 +2366,7 @@ export function ResourcesView({
     requestAnimationFrame(() => {
       isSyncingFromURL.current = false
     })
-  }, [location.search, location.pathname]) // Re-run when URL path or search params change
+  }, [locationPathname, locationSearch]) // Re-run when injected URL path or search params change
 
   const navigate = useMemo(() => {
     if (!onNavigate) return (_pathOrObj: any, _opts?: any) => {}

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1695,8 +1695,20 @@ function getInitialKindFromURL(
   locationPathname?: string,
   locationSearch?: string,
 ): SelectedKindInfo {
-  const pathname = locationPathname || window.location.pathname
-  const search = locationSearch || window.location.search
+  // Prefer injected pathname/search from the host router. Using `||` would incorrectly fall back to
+  // window when the host passes '' before hydration. SSR has no window.
+  const pathname =
+    locationPathname !== undefined
+      ? locationPathname
+      : typeof window !== 'undefined'
+        ? window.location.pathname
+        : ''
+  const search =
+    locationSearch !== undefined
+      ? locationSearch
+      : typeof window !== 'undefined'
+        ? window.location.search
+        : ''
   const base = basePath.replace(/\/$/, '') // strip trailing slash
   let kind: string | null = null
   if (pathname.startsWith(base + '/')) {
@@ -1772,7 +1784,7 @@ export function ResourcesView({
     if (kindFromURL.name !== selectedKind.name || kindFromURL.group !== selectedKind.group) {
       setSelectedKind(kindFromURL)
     }
-  }, [locationPathname]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [locationPathname, locationSearch]) // eslint-disable-line react-hooks/exhaustive-deps
   // Notify parent of selected kind changes (including initial mount)
   useEffect(() => {
     onSelectedKindChange?.(selectedKind)

--- a/web/e2e/url-routing.spec.ts
+++ b/web/e2e/url-routing.spec.ts
@@ -4,9 +4,17 @@ test.describe('URL routing: kind in path', () => {
 
   test('/resources defaults to /resources/pods', async ({ page }) => {
     await page.goto('/resources')
-    // The redirect uses history.replaceState (not navigate), so use polling assertion
+    // Replace navigation — poll until canonical path appears.
     await expect(page).toHaveURL(/\/resources\/pods/, { timeout: 10000 })
     expect(page.url()).not.toContain('kind=')
+  })
+
+  test('/resources redirect preserves query string', async ({ page }) => {
+    await page.goto('/resources?namespaces=default&search=foo')
+    await expect(page).toHaveURL(/\/resources\/pods/, { timeout: 10000 })
+    const url = new URL(page.url())
+    expect(url.searchParams.get('namespaces')).toBe('default')
+    expect(url.searchParams.get('search')).toBe('foo')
   })
 
   test('query params are preserved alongside path-based kind', async ({ page }) => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -217,6 +217,13 @@ function AppInner() {
   // Get mainView from URL path
   const mainView = getViewFromPath(location.pathname)
 
+  // `/resources` vs `/resources/pods` — both mean Pods; `/resources/deployments` etc. switches workload kind.
+  const normalizedResourcesKindSlug = useMemo(() => {
+    const m = location.pathname.match(/^\/resources(?:\/([^/]+))?/)
+    const slug = m?.[1] ?? ''
+    return slug || 'pods'
+  }, [location.pathname])
+
   // Set mainView by navigating to the path
   const setMainView = useCallback((view: ExtendedMainView, params?: Record<string, string>) => {
     const path = view === 'home' ? '/' : `/${view}`
@@ -291,6 +298,23 @@ function AppInner() {
 
   // Suppress the mainView-change clear effect during controlled expand/collapse transitions.
   const suppressViewClearRef = useRef(false)
+
+  // Close resource drawer when switching workload kind in URL (/resources/pods → /resources/deployments).
+  // Keeps stale Pod drawer from masking the table after sidebar navigation (Radar Hub / app.radarhq.io).
+  const prevResourcesKindSlugRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (mainView !== 'resources') {
+      prevResourcesKindSlugRef.current = null
+      return
+    }
+    const slug = normalizedResourcesKindSlug
+    const prev = prevResourcesKindSlugRef.current
+    prevResourcesKindSlugRef.current = slug
+    if (prev !== null && prev !== slug) {
+      setSelectedResource(null)
+      setDrawerExpanded(false)
+    }
+  }, [mainView, normalizedResourcesKindSlug])
 
   // Animation hooks for smooth mount/unmount transitions
   const resourceDrawer = useAnimatedUnmount(!!selectedResource, 300)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -217,12 +217,22 @@ function AppInner() {
   // Get mainView from URL path
   const mainView = getViewFromPath(location.pathname)
 
-  // `/resources` vs `/resources/pods` — both mean Pods; `/resources/deployments` etc. switches workload kind.
+  // Workload slug after `/resources/` (defaults to `pods`). Bare `/resources` redirects to `/resources/pods`.
   const normalizedResourcesKindSlug = useMemo(() => {
     const m = location.pathname.match(/^\/resources(?:\/([^/]+))?/)
     const slug = m?.[1] ?? ''
     return slug || 'pods'
   }, [location.pathname])
+
+  // Canonical URL — `/resources` is not stable for bookmarks/sharing; normalize to `/resources/pods`.
+  useEffect(() => {
+    const path = location.pathname.replace(/\/+$/, '') || '/'
+    if (path !== '/resources') return
+    navigate(
+      { pathname: '/resources/pods', search: location.search, hash: location.hash },
+      { replace: true },
+    )
+  }, [location.pathname, location.search, location.hash, navigate])
 
   // Set mainView by navigating to the path
   const setMainView = useCallback((view: ExtendedMainView, params?: Record<string, string>) => {

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -160,6 +160,7 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
   return (
     <>
     <BaseResourcesView
+      key={location.pathname}
       namespaces={namespaces}
       selectedResource={selectedResource}
       onResourceClick={onResourceClick}


### PR DESCRIPTION
## Summary
Targets **Radar web** (`app.radarhq.io` / path-based `/resources/:kind`) and **`@skyhook-io/k8s-ui`** consumers.

### k8s-ui
- `getInitialKindFromURL`: when the host passes `locationPathname` / `locationSearch`, use them as-is (including empty string) instead of `|| window` so we do not read stale `window` during router-driven updates.
- Re-run kind sync when `locationSearch` changes (e.g. `apiGroup`).

### web (Radar app)
- **`/resources` → `/resources/pods`**: canonical URL via `replace` navigation; query string and hash preserved (bookmarks/sharing).
- `key={location.pathname}` on embedded `ResourcesView` so list state resets when the path kind changes.
- Close resource drawer + collapse workload expansion when normalized `/resources/:kind` slug changes while staying on Resources view (avoids feeling stuck on Pod with drawer open).

### Tests
- `npm run tsc` in `web/` and `packages/k8s-ui/`.
- Playwright `e2e/url-routing.spec.ts` (redirect + query preservation).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches URL parsing/navigation and view state reset logic, so regressions could break routing, deep links, or drawer behavior in the Resources view; changes are localized and covered by e2e assertions.
> 
> **Overview**
> Improves `@skyhook-io/k8s-ui` `ResourcesView` URL handling by preferring injected `locationPathname`/`locationSearch` (even when empty) over `window` access for SSR/hydration safety, and re-syncing selected kind when either pathname or search (e.g. `apiGroup`) changes.
> 
> In the Radar web app, normalizes `/resources` to a canonical `/resources/pods` via `replace` navigation while preserving query/hash, forces the embedded resources view to remount on pathname changes (`key={location.pathname}`), and closes/collapses the resource drawer when the `/resources/:kind` slug changes to avoid stale selections. Playwright routing tests are updated to cover redirect behavior and query-string preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f169e518ffc94fa365b8d84d94c23eb324d7b1e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->