### PR TITLE
ui: width-aware ClusterName + converge ClusterSwitcher rendering

### DIFF
--- a/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
+++ b/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
@@ -5,11 +5,14 @@ import {
   useRef,
   useState,
 } from 'react'
-import { ChevronDown, Check, Loader2, Search, X } from 'lucide-react'
+import { ChevronDown, Check, Loader2, Search, Server, X } from 'lucide-react'
+import { ClusterName } from '../ui/ClusterName'
 import { StatusDot, type StatusTone } from '../ui/status-tone'
 
 export interface ClusterSwitcherItem {
   id: string
+  /** Raw context / display string. ClusterName collapses GKE/EKS/AKS
+   *  shapes; user-named clusters pass through unchanged. */
   name: string
   secondary?: string
   badge?: string
@@ -18,17 +21,17 @@ export interface ClusterSwitcherItem {
   status?: StatusTone
   /** Hard navigation target. Takes precedence over the parent's `onSelect`. */
   href?: string
-  /** Tooltip — useful on disabled rows to explain why the row is inert. */
+  /** Native tooltip — useful on disabled rows to explain why the row is inert.
+   *  ClusterName supplies its own tooltip for the cluster name itself; this
+   *  is for row-level affordances (e.g. "Cluster offline — reconnect…"). */
   title?: string
 }
 
 export interface ClusterSwitcherProps {
   currentId?: string
+  /** Raw context / display string. Pass it as-is — the trigger renders
+   *  through ClusterName, which handles parse + provider badge + tooltip. */
   currentName: string
-  currentTooltip?: string
-  triggerIcon?: ReactNode
-  triggerPrefix?: ReactNode
-  triggerMaxWidthClass?: string
   items: ClusterSwitcherItem[]
   onSelect?: (item: ClusterSwitcherItem) => void
   searchable?: boolean
@@ -43,15 +46,15 @@ export interface ClusterSwitcherProps {
   align?: 'left' | 'right'
 }
 
-const DEFAULT_TRIGGER_MAX_WIDTH = 'max-w-[120px] sm:max-w-[220px]'
+// Trigger width cap. With middle-truncation kicking in, this is mostly a
+// horizontal-real-estate guard rather than a readability one — names get
+// to use up to ~260px on desktop before they need to truncate, comfortably
+// fitting most parsed cluster names (`prod-cluster-us-east1` etc.) in full.
+const TRIGGER_NAME_MAX_WIDTH = 'max-w-[160px] sm:max-w-[260px]'
 
 export function ClusterSwitcher({
   currentId,
   currentName,
-  currentTooltip,
-  triggerIcon,
-  triggerPrefix,
-  triggerMaxWidthClass = DEFAULT_TRIGGER_MAX_WIDTH,
   items,
   onSelect,
   searchable = true,
@@ -169,7 +172,6 @@ export function ClusterSwitcher({
         type="button"
         onClick={() => setIsOpen(v => !v)}
         disabled={disabled || loading}
-        title={currentTooltip ?? currentName}
         className={`
           flex items-center gap-1.5 px-2.5 py-1.5
           bg-theme-elevated border border-theme-border rounded text-sm font-medium
@@ -179,16 +181,21 @@ export function ClusterSwitcher({
         `}
       >
         {loading ? (
-          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          <>
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            <span className={`${TRIGGER_NAME_MAX_WIDTH} block truncate`}>Switching…</span>
+          </>
         ) : (
-          triggerIcon
+          // ClusterName parses the context (provider badge for GKE/EKS/AKS,
+          // raw name for custom kubeconfig) and middle-truncates to the cap.
+          // Server icon is the fallback badge for the no-provider case so
+          // the trigger always has a leading visual.
+          <ClusterName
+            name={currentName}
+            fallbackBadge={<Server className="w-3.5 h-3.5 text-theme-text-secondary" />}
+            className={TRIGGER_NAME_MAX_WIDTH}
+          />
         )}
-        {triggerPrefix && (
-          <span className="text-theme-text-tertiary">{triggerPrefix}</span>
-        )}
-        <span className={`${triggerMaxWidthClass} truncate`}>
-          {loading ? 'Switching...' : currentName}
-        </span>
         <ChevronDown className={`w-3 h-3 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
       </button>
 
@@ -274,19 +281,18 @@ export function ClusterSwitcher({
                         )}
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center gap-1.5">
-                            <span
-                              className={`text-sm font-medium truncate ${
+                            <ClusterName
+                              name={item.name}
+                              className={`text-sm font-medium flex-1 ${
                                 isCurrent
                                   ? 'selection-text'
                                   : item.disabled
                                     ? 'text-theme-text-tertiary'
                                     : 'text-theme-text-primary'
                               }`}
-                            >
-                              {item.name}
-                            </span>
+                            />
                             {item.badge && (
-                              <span className="shrink-0 ml-auto text-[10px] text-theme-text-tertiary bg-theme-elevated px-1 rounded">
+                              <span className="shrink-0 text-[10px] text-theme-text-tertiary bg-theme-elevated px-1 rounded">
                                 {item.badge}
                               </span>
                             )}

--- a/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
+++ b/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
@@ -191,11 +191,15 @@ export function ClusterSwitcher({
           // ClusterName parses the context (provider badge for GKE/EKS/AKS,
           // raw name for custom kubeconfig) and middle-truncates to the cap.
           // Server icon is the fallback badge for the no-provider case so
-          // the trigger always has a leading visual.
+          // the trigger always has a leading visual. Tooltip is suppressed
+          // while the dropdown is open — the popover already shows the raw
+          // context inline (per-row secondary line), and an extra hover
+          // tooltip would just overlap the search input.
           <ClusterName
             name={currentName}
             fallbackBadge={<Server className="w-3.5 h-3.5 text-theme-text-secondary" />}
             className={TRIGGER_NAME_MAX_WIDTH}
+            noTooltip={isOpen}
           />
         )}
         <ChevronDown className={`w-3 h-3 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
@@ -283,8 +287,13 @@ export function ClusterSwitcher({
                         )}
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center gap-1.5">
+                            {/* No tooltip on row names — each row already
+                                renders the raw context inline below the
+                                name (item.secondary), so the hover tooltip
+                                would just repeat what's already visible. */}
                             <ClusterName
                               name={item.name}
+                              noTooltip
                               className={`text-sm font-medium flex-1 ${
                                 isCurrent
                                   ? 'selection-text'

--- a/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
+++ b/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
@@ -50,9 +50,8 @@ export interface ClusterSwitcherProps {
 // horizontal-real-estate guard rather than a readability one. The cap
 // grows with viewport so wide screens (where there's no real estate
 // pressure) show full cluster names rather than middle-truncating
-// pointlessly. `xl:max-w-[400px]` fits names up to ~30 chars in full,
-// which covers ~all real-world parsed names (`prod-cluster-us-east1`,
-// `nonprod-cluster-us-central1`, `koalabackend-us-east-1-mng`).
+// pointlessly. The xl tier (~400px) fits names up to ~30 chars in
+// full — comfortably covering parsed cluster names from any provider.
 const TRIGGER_NAME_MAX_WIDTH = 'max-w-[160px] sm:max-w-[260px] xl:max-w-[400px]'
 
 export function ClusterSwitcher({

--- a/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
+++ b/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
@@ -46,11 +46,14 @@ export interface ClusterSwitcherProps {
   align?: 'left' | 'right'
 }
 
-// Trigger width cap. With middle-truncation kicking in, this is mostly a
-// horizontal-real-estate guard rather than a readability one — names get
-// to use up to ~260px on desktop before they need to truncate, comfortably
-// fitting most parsed cluster names (`prod-cluster-us-east1` etc.) in full.
-const TRIGGER_NAME_MAX_WIDTH = 'max-w-[160px] sm:max-w-[260px]'
+// Trigger width cap. With middle-truncation kicking in, this is a
+// horizontal-real-estate guard rather than a readability one. The cap
+// grows with viewport so wide screens (where there's no real estate
+// pressure) show full cluster names rather than middle-truncating
+// pointlessly. `xl:max-w-[400px]` fits names up to ~30 chars in full,
+// which covers ~all real-world parsed names (`prod-cluster-us-east1`,
+// `nonprod-cluster-us-central1`, `koalabackend-us-east-1-mng`).
+const TRIGGER_NAME_MAX_WIDTH = 'max-w-[160px] sm:max-w-[260px] xl:max-w-[400px]'
 
 export function ClusterSwitcher({
   currentId,

--- a/packages/k8s-ui/src/components/ui/ClusterName.tsx
+++ b/packages/k8s-ui/src/components/ui/ClusterName.tsx
@@ -48,12 +48,13 @@ interface Props {
   name: string
   /** Visual shape. Default: inline. */
   variant?: 'inline' | 'stacked'
-  /** Suppress the provider badge — use when context already conveys provider. */
+  /** Suppress the provider badge — use when context already conveys provider.
+   *  Also suppresses `fallbackBadge`; `noBadge` wins when both are set. */
   noBadge?: boolean
   /** Rendered in the badge slot when no provider is detected and `noBadge`
    *  is not set. Lets the cluster switcher trigger keep a Server-icon
    *  fallback for custom kubeconfig names without forcing every consumer
-   *  to ship one. */
+   *  to ship one. Ignored when `noBadge` is set. */
   fallbackBadge?: ReactNode
   /** Optional className on the outer span. */
   className?: string

--- a/packages/k8s-ui/src/components/ui/ClusterName.tsx
+++ b/packages/k8s-ui/src/components/ui/ClusterName.tsx
@@ -1,3 +1,5 @@
+import { type ReactNode, useCallback, useState } from 'react'
+import { MiddleEllipsis } from './MiddleEllipsis'
 import { Tooltip } from './Tooltip'
 import { parseContextName } from '../../utils/context-name'
 import type { ParsedContextName } from '../../utils/context-name'
@@ -10,8 +12,14 @@ import azureLogo from './provider-logos/azure.svg'
 // cluster identity surfaced as primary text and provider/region pushed
 // into supporting metadata. Wraps parseContextName from utils/context-name
 // so all surfaces (cluster cards, table cells, column headers, switcher
-// dropdowns, breadcrumb, error views) share identical cluster-identity
-// rendering.
+// trigger + dropdowns, breadcrumb, error views) share identical
+// cluster-identity rendering.
+//
+// Width-aware: the name middle-truncates to fit its container so long
+// strings (`gke_proj_us-east1-b_prod-cluster-us-east1`, custom user names)
+// keep both ends readable. Tooltip surfaces the raw whenever EITHER the
+// parse collapsed something (`gke_…` → `prod-cluster-us-east1`) OR the
+// rendered name is being middle-truncated to fit.
 //
 // Variants:
 //   inline   — name + small provider logo, fits in a table cell or
@@ -20,7 +28,9 @@ import azureLogo from './provider-logos/azure.svg'
 //              for card-sized surfaces
 //
 // User-named clusters that don't match a known shape pass through
-// unchanged — no provider badge, no tooltip needed.
+// unchanged. A `fallbackBadge` prop lets surfaces that always want a
+// leading visual (e.g. the cluster-switcher trigger) supply one for the
+// no-provider case.
 
 type Provider = NonNullable<ParsedContextName['provider']>
 
@@ -40,6 +50,11 @@ interface Props {
   variant?: 'inline' | 'stacked'
   /** Suppress the provider badge — use when context already conveys provider. */
   noBadge?: boolean
+  /** Rendered in the badge slot when no provider is detected and `noBadge`
+   *  is not set. Lets the cluster switcher trigger keep a Server-icon
+   *  fallback for custom kubeconfig names without forcing every consumer
+   *  to ship one. */
+  fallbackBadge?: ReactNode
   /** Optional className on the outer span. */
   className?: string
 }
@@ -60,19 +75,27 @@ function ProviderBadge({ provider }: { provider: Provider }) {
   )
 }
 
-export function ClusterName({ name, variant = 'inline', noBadge, className }: Props) {
+export function ClusterName({ name, variant = 'inline', noBadge, fallbackBadge, className }: Props) {
   const parsed = parseContextName(name)
+  const [truncated, setTruncated] = useState(false)
+  const onTruncatedChange = useCallback((t: boolean) => setTruncated(t), [])
 
-  const showBadge = !noBadge && parsed.provider !== null
+  const hasProvider = parsed.provider !== null
+  const showProviderBadge = !noBadge && hasProvider
+  const showFallback = !noBadge && !hasProvider && fallbackBadge != null
   const showRegion = parsed.region !== null && variant === 'stacked'
-  const needsTooltip = parsed.raw !== parsed.clusterName
+  const collapsed = parsed.raw !== parsed.clusterName
+  // Tooltip when there's something to disclose — either we collapsed the
+  // raw, or the displayed name is being middle-truncated to fit.
+  const needsTooltip = collapsed || truncated
 
   const body = (
     <span className={['inline-flex items-center gap-1.5 min-w-0', className ?? ''].join(' ')}>
-      {showBadge && <ProviderBadge provider={parsed.provider!} />}
+      {showProviderBadge && <ProviderBadge provider={parsed.provider!} />}
+      {showFallback && fallbackBadge}
       {variant === 'stacked' ? (
-        <span className="flex flex-col min-w-0">
-          <span className="truncate">{parsed.clusterName}</span>
+        <span className="flex flex-col min-w-0 flex-1">
+          <MiddleEllipsis text={parsed.clusterName} onTruncatedChange={onTruncatedChange} />
           {showRegion && (
             <span className="text-[10px] text-theme-text-tertiary truncate">
               {parsed.provider} · {parsed.region}
@@ -80,7 +103,7 @@ export function ClusterName({ name, variant = 'inline', noBadge, className }: Pr
           )}
         </span>
       ) : (
-        <span className="truncate">{parsed.clusterName}</span>
+        <MiddleEllipsis text={parsed.clusterName} onTruncatedChange={onTruncatedChange} />
       )}
     </span>
   )

--- a/packages/k8s-ui/src/components/ui/ClusterName.tsx
+++ b/packages/k8s-ui/src/components/ui/ClusterName.tsx
@@ -58,6 +58,11 @@ interface Props {
   fallbackBadge?: ReactNode
   /** Optional className on the outer span. */
   className?: string
+  /** Suppress the hover tooltip even when the parsed name was collapsed
+   *  or middle-truncated. Use when the surrounding chrome already
+   *  discloses the raw context (e.g. inside an open switcher dropdown
+   *  where the tooltip would overlap the popover content). */
+  noTooltip?: boolean
 }
 
 function ProviderBadge({ provider }: { provider: Provider }) {
@@ -76,7 +81,7 @@ function ProviderBadge({ provider }: { provider: Provider }) {
   )
 }
 
-export function ClusterName({ name, variant = 'inline', noBadge, fallbackBadge, className }: Props) {
+export function ClusterName({ name, variant = 'inline', noBadge, fallbackBadge, className, noTooltip }: Props) {
   const parsed = parseContextName(name)
   const [truncated, setTruncated] = useState(false)
   const onTruncatedChange = useCallback((t: boolean) => setTruncated(t), [])
@@ -87,8 +92,9 @@ export function ClusterName({ name, variant = 'inline', noBadge, fallbackBadge, 
   const showRegion = parsed.region !== null && variant === 'stacked'
   const collapsed = parsed.raw !== parsed.clusterName
   // Tooltip when there's something to disclose — either we collapsed the
-  // raw, or the displayed name is being middle-truncated to fit.
-  const needsTooltip = collapsed || truncated
+  // raw, or the displayed name is being middle-truncated to fit. Callers
+  // can opt out via `noTooltip` when the raw is already visible elsewhere.
+  const needsTooltip = !noTooltip && (collapsed || truncated)
 
   const body = (
     <span className={['inline-flex items-center gap-1.5 min-w-0', className ?? ''].join(' ')}>

--- a/packages/k8s-ui/src/components/ui/MiddleEllipsis.tsx
+++ b/packages/k8s-ui/src/components/ui/MiddleEllipsis.tsx
@@ -15,6 +15,11 @@ import { useEffect, useRef, useState } from 'react'
 // flex parent shrink-wraps to the truncated content, MiddleEllipsis sees
 // the shrunken width, keeps truncating; widening doesn't recover.
 //
+// Concretely, removing the ghost makes the trigger render full-width on
+// first paint, then collapse to the truncated width on the first
+// ResizeObserver tick, and stay collapsed forever even when the viewport
+// widens. The ghost is load-bearing — don't simplify it away.
+//
 // Place inside a width-constrained container (e.g. a button child with
 // `max-w-[…]`). The wrapper itself takes `width: 100%` of that container.
 
@@ -26,9 +31,15 @@ export interface MiddleEllipsisProps {
   /** Native browser tooltip. Opt-in: defaulting to the full text would
    *  duplicate any tooltip wrapper (e.g. `<Tooltip>`) higher up the tree. */
   title?: string
-  /** Fires whenever the rendered text changes between full and truncated.
-   *  Lets a parent gate behavior on actual truncation — e.g. show a custom
-   *  tooltip only when the visible text isn't already the full string. */
+  /** Fires whenever the rendered text changes between full and truncated
+   *  (edge-triggered, not level — won't fire on every render). Lets a parent
+   *  gate behavior on actual truncation, e.g. show a custom tooltip only
+   *  when the visible text isn't already the full string.
+   *
+   *  Do NOT use the value to alter the width of the measured container — a
+   *  truncated→untruncated swap that resizes the parent would oscillate
+   *  through the ResizeObserver. Tooltips, badges, and other overlays/sibling
+   *  affordances are fine; layout-affecting changes are not. */
   onTruncatedChange?: (truncated: boolean) => void
 }
 
@@ -50,7 +61,19 @@ export function MiddleEllipsis({ text, className, title, onTruncatedChange }: Mi
       const width = node.clientWidth
       if (width <= 0) return
       const cs = window.getComputedStyle(node)
-      ctx.font = `${cs.fontWeight} ${cs.fontSize} ${cs.fontFamily}`
+      // Include fontStyle in the shorthand so italic faces measure correctly.
+      // If the assignment ever silently fails (malformed family quoting,
+      // exotic computed values), the browser leaves ctx.font at its previous
+      // value — on first call that's the default `10px sans-serif`, which
+      // under-measures and would cause over-truncation. Detect by reading
+      // back: if ctx.font normalised to the default but we didn't ask for
+      // it, bail to full-text render (clipped by overflow:hidden) rather
+      // than render a wrongly-truncated string.
+      ctx.font = `${cs.fontStyle} ${cs.fontWeight} ${cs.fontSize} ${cs.fontFamily}`
+      if (ctx.font === '10px sans-serif' && cs.fontSize !== '10px') {
+        setDisplay(text)
+        return
+      }
       const next = fitMiddleTruncate(text, width, ctx)
       setDisplay(next)
       const truncated = next !== text

--- a/packages/k8s-ui/src/components/ui/MiddleEllipsis.tsx
+++ b/packages/k8s-ui/src/components/ui/MiddleEllipsis.tsx
@@ -106,6 +106,13 @@ export function MiddleEllipsis({ text, className, title, onTruncatedChange }: Mi
         overflow: 'hidden',
         whiteSpace: 'nowrap',
         minWidth: 0,
+        // width:100% so the wrapper claims the parent's full available
+        // width before measurement. Without it, a parent with extra room
+        // would let the wrapper shrink to the ghost's natural width — and
+        // the absolute-positioned visible overlay (inset:0) would clip to
+        // that shrunken box, making text middle-truncate even when the
+        // surrounding container had room to render it in full.
+        width: '100%',
       }}
     >
       {/* Ghost: claims the full text's natural width in flow so flex parents

--- a/packages/k8s-ui/src/components/ui/MiddleEllipsis.tsx
+++ b/packages/k8s-ui/src/components/ui/MiddleEllipsis.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef, useState } from 'react'
+
+// Renders text on a single line, fitted to its parent's width. When the full
+// string overflows, it's truncated from the middle (`gke_koala…us-east1`)
+// rather than the end, so cluster context strings like
+// `gke_koalabackend_us-east1-b_prod-cluster-us-east1` keep both the
+// identifying prefix and the region/role suffix.
+//
+// The trick: a "ghost" copy of the full text sits in normal flow but is
+// visually hidden, while the visible truncated text overlays it absolutely.
+// The ghost lets flex layout know our PREFERRED width is the full text — so
+// when an ancestor's max-width grows (e.g. on a viewport breakpoint change),
+// the wrapper re-grows back instead of staying trapped at the truncated
+// render's width. Without it the layout settles into a fixed point: the
+// flex parent shrink-wraps to the truncated content, MiddleEllipsis sees
+// the shrunken width, keeps truncating; widening doesn't recover.
+//
+// Place inside a width-constrained container (e.g. a button child with
+// `max-w-[…]`). The wrapper itself takes `width: 100%` of that container.
+
+const ELLIPSIS = '…'
+
+export interface MiddleEllipsisProps {
+  text: string
+  className?: string
+  /** Native browser tooltip. Opt-in: defaulting to the full text would
+   *  duplicate any tooltip wrapper (e.g. `<Tooltip>`) higher up the tree. */
+  title?: string
+  /** Fires whenever the rendered text changes between full and truncated.
+   *  Lets a parent gate behavior on actual truncation — e.g. show a custom
+   *  tooltip only when the visible text isn't already the full string. */
+  onTruncatedChange?: (truncated: boolean) => void
+}
+
+export function MiddleEllipsis({ text, className, title, onTruncatedChange }: MiddleEllipsisProps) {
+  const wrapperRef = useRef<HTMLSpanElement>(null)
+  const [display, setDisplay] = useState(text)
+  const lastReportedTruncated = useRef<boolean | null>(null)
+
+  useEffect(() => {
+    const node = wrapperRef.current
+    if (!node || typeof window === 'undefined') return
+    const ctx = document.createElement('canvas').getContext('2d')
+    if (!ctx) {
+      setDisplay(text)
+      return
+    }
+
+    const recompute = () => {
+      const width = node.clientWidth
+      if (width <= 0) return
+      const cs = window.getComputedStyle(node)
+      ctx.font = `${cs.fontWeight} ${cs.fontSize} ${cs.fontFamily}`
+      const next = fitMiddleTruncate(text, width, ctx)
+      setDisplay(next)
+      const truncated = next !== text
+      if (truncated !== lastReportedTruncated.current) {
+        lastReportedTruncated.current = truncated
+        onTruncatedChange?.(truncated)
+      }
+    }
+
+    recompute()
+    const observer = new ResizeObserver(recompute)
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [text, onTruncatedChange])
+
+  return (
+    <span
+      ref={wrapperRef}
+      className={className}
+      title={title}
+      style={{
+        display: 'inline-block',
+        position: 'relative',
+        overflow: 'hidden',
+        whiteSpace: 'nowrap',
+        minWidth: 0,
+        verticalAlign: 'bottom',
+        width: '100%',
+      }}
+    >
+      {/* Ghost: claims the full text's natural width in flow so flex parents
+          shrink-wrap to the *full* preferred size, not the truncated render. */}
+      <span aria-hidden="true" style={{ visibility: 'hidden' }}>
+        {text}
+      </span>
+      {/* Visible: overlays the ghost with the current truncated rendering. */}
+      <span style={{ position: 'absolute', inset: 0, overflow: 'hidden', whiteSpace: 'nowrap' }}>
+        {display}
+      </span>
+    </span>
+  )
+}
+
+// Binary-search the largest `n` such that `prefix(n) + … + suffix(n)` fits
+// in `width`. Symmetric on purpose — keeping prefix and suffix balanced is
+// the cheapest way to preserve the most identifying chars on both ends of
+// names like `arn:aws:eks:…:cluster/prod` or `gke_…_prod-cluster-us-east1`.
+function fitMiddleTruncate(
+  text: string,
+  width: number,
+  ctx: CanvasRenderingContext2D,
+): string {
+  if (ctx.measureText(text).width <= width) return text
+  if (text.length <= 2) return text
+
+  let lo = 1
+  let hi = Math.floor((text.length - 1) / 2)
+  let best = 0
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1
+    const candidate = text.slice(0, mid) + ELLIPSIS + text.slice(-mid)
+    if (ctx.measureText(candidate).width <= width) {
+      best = mid
+      lo = mid + 1
+    } else {
+      hi = mid - 1
+    }
+  }
+  return best === 0 ? ELLIPSIS : text.slice(0, best) + ELLIPSIS + text.slice(-best)
+}

--- a/packages/k8s-ui/src/components/ui/MiddleEllipsis.tsx
+++ b/packages/k8s-ui/src/components/ui/MiddleEllipsis.tsx
@@ -58,7 +58,13 @@ export function MiddleEllipsis({ text, className, title, onTruncatedChange }: Mi
     }
 
     const recompute = () => {
-      const width = node.clientWidth
+      // Use subpixel width (`getBoundingClientRect`) rather than the
+      // pixel-rounded `clientWidth`. measureText returns subpixel widths,
+      // and when the full text is JUST under the available space — say
+      // ctx.measureText says 173.4px and clientWidth rounds to 173 — the
+      // integer comparison decides we don't fit and middle-truncates a
+      // name that visually would have rendered fine.
+      const width = node.getBoundingClientRect().width
       if (width <= 0) return
       const cs = window.getComputedStyle(node)
       // Include fontStyle in the shorthand so italic faces measure correctly.
@@ -95,13 +101,11 @@ export function MiddleEllipsis({ text, className, title, onTruncatedChange }: Mi
       className={className}
       title={title}
       style={{
-        display: 'inline-block',
+        display: 'block',
         position: 'relative',
         overflow: 'hidden',
         whiteSpace: 'nowrap',
         minWidth: 0,
-        verticalAlign: 'bottom',
-        width: '100%',
       }}
     >
       {/* Ghost: claims the full text's natural width in flow so flex parents

--- a/packages/k8s-ui/src/components/ui/index.ts
+++ b/packages/k8s-ui/src/components/ui/index.ts
@@ -1,6 +1,8 @@
 export { Tooltip } from './Tooltip'
 export { PaneLoader } from './PaneLoader'
 export { ClusterName } from './ClusterName'
+export { MiddleEllipsis } from './MiddleEllipsis'
+export type { MiddleEllipsisProps } from './MiddleEllipsis'
 export { EmptyState } from './EmptyState'
 export type { EmptyStateTone, EmptyStateVariant } from './EmptyState'
 export { FilterPill } from './FilterPill'

--- a/web/public/images/radar/radar-icon.svg
+++ b/web/public/images/radar/radar-icon.svg
@@ -1,0 +1,100 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <defs>
+    <!-- Dark emerald background gradient -->
+    <radialGradient id="bgHub" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#072920"/>
+      <stop offset="70%" stop-color="#03180f"/>
+      <stop offset="100%" stop-color="#010a06"/>
+    </radialGradient>
+
+    <!-- Sweep trail gradient, emerald -->
+    <linearGradient id="sweepGlowHub" x1="0" y1="0" x2="1" y2="0" gradientTransform="rotate(-45, 0.5, 0.5)">
+      <stop offset="0%" stop-color="#10b981" stop-opacity="0"/>
+      <stop offset="60%" stop-color="#10b981" stop-opacity="0.22"/>
+      <stop offset="100%" stop-color="#a7f3d0" stop-opacity="0.55"/>
+    </linearGradient>
+
+    <!-- Ring glow -->
+    <filter id="ringGlowHub" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="1.5" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+
+    <!-- Dot glow -->
+    <filter id="dotGlowHub" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="2.5" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+
+    <!-- Sweep line glow -->
+    <filter id="lineGlowHub" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="3" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+
+    <!-- Outer ring glow -->
+    <filter id="outerGlowHub" x="-10%" y="-10%" width="120%" height="120%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+
+    <clipPath id="radarClipHub">
+      <circle cx="128" cy="128" r="118"/>
+    </clipPath>
+  </defs>
+
+  <!-- Background -->
+  <circle cx="128" cy="128" r="128" fill="#010a06"/>
+  <circle cx="128" cy="128" r="118" fill="url(#bgHub)"/>
+
+  <!-- Outer ring -->
+  <circle cx="128" cy="128" r="118" fill="none" stroke="#34d399" stroke-width="3.5" filter="url(#outerGlowHub)" opacity="0.9"/>
+
+  <!-- Concentric rings -->
+  <g filter="url(#ringGlowHub)" opacity="0.6">
+    <circle cx="128" cy="128" r="90" fill="none" stroke="#059669" stroke-width="1.2"/>
+    <circle cx="128" cy="128" r="62" fill="none" stroke="#059669" stroke-width="1.2"/>
+    <circle cx="128" cy="128" r="34" fill="none" stroke="#059669" stroke-width="1.2"/>
+  </g>
+
+  <!-- Crosshairs -->
+  <g opacity="0.15" stroke="#34d399" stroke-width="0.5">
+    <line x1="128" y1="10" x2="128" y2="246"/>
+    <line x1="10" y1="128" x2="246" y2="128"/>
+  </g>
+
+  <!-- Sweep trail -->
+  <g clip-path="url(#radarClipHub)">
+    <path d="M128,128 L128,10 A118,118 0 0,1 211.5,44.5 Z" fill="url(#sweepGlowHub)" opacity="0.75"/>
+    <path d="M128,128 L211.5,44.5 A118,118 0 0,1 240,95 Z" fill="#10b981" opacity="0.06"/>
+  </g>
+
+  <!-- Sweep line -->
+  <line x1="128" y1="128" x2="211" y2="45" stroke="#a7f3d0" stroke-width="2" filter="url(#lineGlowHub)" stroke-linecap="round"/>
+  <line x1="128" y1="128" x2="211" y2="45" stroke="#ffffff" stroke-width="1" opacity="0.9" stroke-linecap="round"/>
+
+  <!-- Radar blips -->
+  <g filter="url(#dotGlowHub)">
+    <circle cx="155" cy="68" r="4" fill="#ffffff" opacity="0.95"/>
+    <circle cx="178" cy="108" r="3.5" fill="#ffffff" opacity="0.9"/>
+    <circle cx="98" cy="85" r="3" fill="#ecfdf5" opacity="0.7"/>
+    <circle cx="85" cy="155" r="3.5" fill="#ecfdf5" opacity="0.65"/>
+    <circle cx="160" cy="175" r="3" fill="#ecfdf5" opacity="0.6"/>
+    <circle cx="108" cy="195" r="3.5" fill="#ecfdf5" opacity="0.5"/>
+  </g>
+
+  <!-- Center dot -->
+  <circle cx="128" cy="128" r="3" fill="#6ee7b7" filter="url(#dotGlowHub)" opacity="0.9"/>
+</svg>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -834,7 +834,12 @@ function AppInner() {
                 }`}
               >
                 <Icon className="w-4 h-4" />
-                <span className="hidden lg:inline">{label}</span>
+                {/* Labels show at 1500+ — that's just under default 14" MBP
+                    (1512px logical) so most desktop users keep them, while
+                    narrower viewports collapse to icon-only and avoid Audit
+                    getting pushed off. Tooltip on each button discloses the
+                    label on hover when collapsed. */}
+                <span className="hidden min-[1500px]:inline">{label}</span>
               </button>
             </Tooltip>
           ))}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -782,13 +782,17 @@ function AppInner() {
                   }`}
                 />
               </Tooltip>
-              <span className="text-xs text-theme-text-tertiary hidden xl:inline">
-                {!connected
-                  ? 'Disconnected'
-                  : crdDiscoveryStatus === 'discovering'
-                    ? 'Discovering Custom Resources...'
-                    : 'Connected'}
-              </span>
+              {/* Inline label only for non-steady states where the user
+                  might need to act or wait. The healthy "Connected" case
+                  is the dot alone; the dot's tooltip discloses it. Keeping
+                  "Connected" text here would expand the left section and
+                  collide with the absolute-centered nav block at xl, which
+                  is the same breakpoint where nav labels appear. */}
+              {(!connected || crdDiscoveryStatus === 'discovering') && (
+                <span className="text-xs text-theme-text-tertiary hidden xl:inline">
+                  {!connected ? 'Disconnected' : 'Discovering Custom Resources...'}
+                </span>
+              )}
               {!connected && (
                 <button
                   onClick={reconnect}
@@ -829,12 +833,14 @@ function AppInner() {
                 }`}
               >
                 <Icon className="w-4 h-4" />
-                {/* Labels show at 1500+ — that's just under default 14" MBP
-                    (1512px logical) so most desktop users keep them, while
-                    narrower viewports collapse to icon-only and avoid Audit
-                    getting pushed off. Tooltip on each button discloses the
-                    label on hover when collapsed. */}
-                <span className="hidden min-[1500px]:inline">{label}</span>
+                {/* Off-system breakpoint: the absolute-centered nav block
+                    (~650px wide with labels) collides with the left section
+                    (logo + cluster switcher) below ~1415px. We add a small
+                    breathing-room buffer and land at 1440. xl (1536) — where
+                    Connected text + star count appear and add right-side
+                    pressure — sits a step above. Per-button Tooltip discloses
+                    labels on hover for the icon-only zone. */}
+                <span className="hidden min-[1440px]:inline">{label}</span>
               </button>
             </Tooltip>
           ))}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -833,13 +833,16 @@ function AppInner() {
                 }`}
               >
                 <Icon className="w-4 h-4" />
-                {/* Off-system breakpoint: the absolute-centered nav block
-                    (~650px wide with labels) collides with the left section
-                    (logo + cluster switcher) below ~1415px. We add a small
-                    breathing-room buffer and land at 1440. xl (1536) — where
-                    Connected text + star count appear and add right-side
-                    pressure — sits a step above. Per-button Tooltip discloses
-                    labels on hover for the icon-only zone. */}
+                {/* Labels appear only when the absolute-centered nav has
+                    enough horizontal room past the left section. Right-side
+                    chrome that adds further pressure (Connected text, star
+                    count) is intentionally pushed to the next tier (xl) so
+                    label rendering and right-side expansion stay decoupled.
+                    Per-button Tooltip discloses labels on hover when the
+                    icon-only viewport is in effect. The 1440 anchor is an
+                    off-system breakpoint chosen by measurement at the time
+                    of this PR — recompute if the cluster switcher cap or
+                    other left-section chrome changes appreciably. */}
                 <span className="hidden min-[1440px]:inline">{label}</span>
               </button>
             </Tooltip>
@@ -1387,19 +1390,28 @@ function App() {
   )
 }
 
-// Skyhook logo that switches based on theme
-// Header brand: emerald-square radar icon + "Radar" wordmark with a small
-// "by Skyhook" subtitle. Mirrors the RadarLogo component used in the
-// Skyhook Cloud (radar-hub-web) shell so the standalone OSS Radar and
-// the embedded Cloud experience read as the same product. More compact
-// horizontally than the prior Skyhook logotype + "radar" wordmark combo,
-// which buys a few dozen pixels of header real estate that other chrome
-// (cluster switcher, nav) gets to use.
+// Header brand: emerald-square radar icon + stacked "Radar" / "by Skyhook"
+// wordmark. Shares its visual shape with the radar-hub-web shell so the
+// standalone OSS app and the embedded Cloud experience read as the same
+// product, and is narrow enough to leave room for the cluster switcher
+// and nav block on standard laptop viewports.
 function Logo() {
   return (
     <div className="flex items-center gap-2.5">
       <div className="relative w-7 h-7 rounded-lg overflow-hidden flex-shrink-0 bg-emerald-500/10 border border-emerald-500/20">
-        <img src="/images/radar/radar-icon.svg" alt="" aria-hidden className="w-full h-full p-0.5" />
+        <img
+          src="/images/radar/radar-icon.svg"
+          alt=""
+          aria-hidden
+          className="w-full h-full p-0.5"
+          // Fail loud on a missing/blocked asset rather than rendering an
+          // empty emerald square next to the wordmark — the latter reads
+          // as broken chrome with no diagnostics. Most likely cause is a
+          // build/deploy path mismatch.
+          onError={(e) =>
+            console.error('Radar logo asset failed to load:', (e.currentTarget as HTMLImageElement).src)
+          }
+        />
       </div>
       <div className="flex flex-col leading-none">
         <span className="font-semibold text-[15px] tracking-tight text-theme-text-primary">Radar</span>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -755,12 +755,7 @@ function AppInner() {
       <header className="relative z-50 flex items-center justify-between px-4 py-2 bg-theme-base/90 backdrop-blur-sm border-b border-theme-border/50">
         {/* Left: Logo + Cluster info */}
         <div className="flex items-center gap-4 shrink-0">
-          {navCustomization.brandSlot ?? (
-            <div className="flex items-center gap-2.5">
-              <Logo />
-              <span className="text-xl text-theme-text-primary leading-none -translate-y-0.5" style={{ fontFamily: "'DM Sans', sans-serif", fontWeight: 520 }}>radar</span>
-            </div>
-          )}
+          {navCustomization.brandSlot ?? <Logo />}
 
           <div className="flex items-center gap-2">
             {navCustomization.contextSlot ?? <ContextSwitcher />}
@@ -1387,13 +1382,25 @@ function App() {
 }
 
 // Skyhook logo that switches based on theme
+// Header brand: emerald-square radar icon + "Radar" wordmark with a small
+// "by Skyhook" subtitle. Mirrors the RadarLogo component used in the
+// Skyhook Cloud (radar-hub-web) shell so the standalone OSS Radar and
+// the embedded Cloud experience read as the same product. More compact
+// horizontally than the prior Skyhook logotype + "radar" wordmark combo,
+// which buys a few dozen pixels of header real estate that other chrome
+// (cluster switcher, nav) gets to use.
 function Logo() {
-  const { theme } = useTheme()
-  const logoSrc = theme === 'dark'
-    ? '/assets/skyhook/logotype-white-color.svg'
-    : '/assets/skyhook/logotype-dark-color.svg'
-
-  return <img src={logoSrc} alt="Skyhook" className="h-5 w-auto" />
+  return (
+    <div className="flex items-center gap-2.5">
+      <div className="relative w-7 h-7 rounded-lg overflow-hidden flex-shrink-0 bg-emerald-500/10 border border-emerald-500/20">
+        <img src="/images/radar/radar-icon.svg" alt="" aria-hidden className="w-full h-full p-0.5" />
+      </div>
+      <div className="flex flex-col leading-none">
+        <span className="font-semibold text-[15px] tracking-tight text-theme-text-primary">Radar</span>
+        <span className="text-[9px] mt-0.5 tracking-wide uppercase text-theme-text-tertiary">by Skyhook</span>
+      </div>
+    </div>
+  )
 }
 
 // GitHub star button with live star count + programmatic starring via gh CLI

--- a/web/src/components/ContextSwitcher.tsx
+++ b/web/src/components/ContextSwitcher.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { Server, AlertTriangle } from 'lucide-react'
+import { AlertTriangle } from 'lucide-react'
 import {
   ClusterSwitcher,
   type ClusterSwitcherItem,
@@ -61,10 +61,12 @@ export function ContextSwitcher({ className = '' }: ContextSwitcherProps) {
         : hasMultipleAccounts
           ? 'Other'
           : undefined
+      // Pass the raw context as `name`; ClusterSwitcher renders through
+      // ClusterName which parses + collapses + tooltips on hover. We keep
+      // the parse locally only for grouping/sorting and the region badge.
       return {
         id: p.context.name,
-        name: p.clusterName,
-        secondary: p.provider ? p.raw : undefined,
+        name: p.context.name,
         badge: p.region || undefined,
         group: { key: groupKey, label: groupLabel },
       }
@@ -148,7 +150,6 @@ export function ContextSwitcher({ className = '' }: ContextSwitcherProps) {
   }
 
   const currentRaw = clusterInfo?.context || contexts?.find(c => c.isCurrent)?.name || 'Unknown'
-  const currentParsed = parseContextName(currentRaw)
   const currentId = contexts?.find(c => c.isCurrent)?.name
 
   return (
@@ -156,9 +157,7 @@ export function ContextSwitcher({ className = '' }: ContextSwitcherProps) {
       <ClusterSwitcher
         className={className}
         currentId={currentId}
-        currentName={currentParsed.clusterName}
-        currentTooltip={currentRaw}
-        triggerIcon={<Server className="w-3.5 h-3.5 text-theme-text-secondary" />}
+        currentName={currentRaw}
         items={items}
         onSelect={handleSelect}
         loading={switchContext.isPending}

--- a/web/src/components/ContextSwitcher.tsx
+++ b/web/src/components/ContextSwitcher.tsx
@@ -61,12 +61,15 @@ export function ContextSwitcher({ className = '' }: ContextSwitcherProps) {
         : hasMultipleAccounts
           ? 'Other'
           : undefined
-      // Pass the raw context as `name`; ClusterSwitcher renders through
-      // ClusterName which parses + collapses + tooltips on hover. We keep
-      // the parse locally only for grouping/sorting and the region badge.
+      // `name` is the raw context — ClusterSwitcher renders it through
+      // ClusterName, which collapses GKE/EKS/AKS shapes to the meaningful
+      // tail. `secondary` shows the original raw when we collapsed it,
+      // so users always see the full context at a glance (rather than
+      // having to hover to reveal it).
       return {
         id: p.context.name,
         name: p.context.name,
+        secondary: p.provider ? p.raw : undefined,
         badge: p.region || undefined,
         group: { key: groupKey, label: groupLabel },
       }


### PR DESCRIPTION
## What

Three independent threads ended up overlapping while testing this on a real cluster — keeping them in one PR since each fix unblocked the next.

### 1. ClusterSwitcher convergence

`<ClusterName>` is now width-aware. Replaces the inner CSS `truncate` with a new `<MiddleEllipsis>` primitive (canvas `measureText` + binary-search + `ResizeObserver`, plus a ghost-copy in flow so flex parents shrink-wrap to the full preferred width). Tooltip surfaces the raw context whenever EITHER `parseContextName` collapsed something OR the rendered name is being truncated.

`<ClusterSwitcher>` converges on `<ClusterName>` for both the trigger and dropdown rows. Drops `currentTooltip`, `triggerIcon`, `triggerPrefix`, and `triggerMaxWidthClass` props. Trigger uses a `Server` icon as `fallbackBadge` for custom kubeconfig names; for GKE/EKS/AKS the cloud-provider logo leads. Dropdown rows show the parsed name + region pill + raw context inline as a tertiary-color subline (so users see the full context at a glance, not on hover).

OSS `ContextSwitcher` stops calling `parseContextName` on the way into the switcher; raw context goes in, the switcher handles the rest. Local parse stays for grouping/sorting/region badge.

**Why:** Three different cluster-identity renderings had drifted (`<ClusterName>` everywhere else / OSS inline parse / Hub raw passthrough). Now there's one. Side benefit: long custom cluster names that were silently end-truncating in the sidebar / fleet tables / breadcrumbs now disclose on hover — strict upgrade for every existing `<ClusterName>` consumer.

### 2. Header refresh

Swap the standalone OSS Radar brand from the Skyhook-logotype + "radar" wordmark combo to the emerald-icon + stacked "Radar / by Skyhook" logo used by Skyhook Cloud. Visually consistent across products, and ~50px narrower in the header — which created room to recover the next item:

Nav labels (Home/Topology/etc.) now show at `min-[1440px]:inline` instead of being permanently visible at `lg`. Below that, icons-only with per-button tooltips. The previous setup pushed Audit off-screen on narrower laptops because the centered nav block collided with the cluster switcher.

Inline "Connected" text only renders in non-steady states (Disconnected, Discovering). The dot + Tooltip already discloses the healthy case; keeping the text in steady state was expanding the left section into the centered nav at xl.

### 3. MiddleEllipsis polish

Visual-test against OSS Radar caught a subpixel-rounding bug — `MiddleEllipsis` was comparing `ctx.measureText().width` (subpixel float) against `node.clientWidth` (pixel-rounded int), and a 0.4px difference was flipping the fits-in-cap check to false. Switching to `getBoundingClientRect().width` puts both in the same subpixel space. Trigger and dropdown rows both stopped over-truncating after this. Also bumped the trigger cap to `xl:max-w-[400px]` so wide screens don't middle-truncate when there's plenty of room.

## Visual-tested

Built radar with the local k8s-ui workspace and drove it through Playwright at 800/1100/1305/1440/1512/1900/2200px in light + dark mode, with a 31-context kubeconfig (mixed GKE + EKS, multiple accounts). Verified provider-logo rendering (incl. AWS dark variant), multi-account grouping, search against raw context, secondary line in dropdown rows, and re-expansion when widening from a truncated state.

## Follow-up

`skyhook-dev/radar-hub-web`'s `HubClusterSwitcher` (in `src/pages/ClusterView.tsx`) currently passes `currentTooltip` and `triggerIcon` — both will be no-ops after the next `@skyhook-io/k8s-ui` publish. Small cleanup PR there once this lands and a new `radar-app` version ships.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI risk: changes shared `k8s-ui` component APIs/behavior (`ClusterSwitcher` props removed, new tooltip/truncation logic) and adds a custom ResizeObserver/canvas-based truncation primitive that could affect rendering/perf across many surfaces.
> 
> **Overview**
> **Unifies cluster identity rendering across the app.** `ClusterSwitcher` now renders both the trigger and dropdown rows via `ClusterName` (including provider badges) and removes trigger customization props (`currentTooltip`, `triggerIcon`, `triggerPrefix`, `triggerMaxWidthClass`), switching to a fixed responsive name-width cap and a `Server` fallback badge.
> 
> **Adds width-aware middle truncation + smarter tooltips.** `ClusterName` now uses a new `MiddleEllipsis` component to middle-truncate based on measured width, and shows the raw context in a tooltip when parsing collapses the name or when truncation actually occurs (with a `noTooltip` escape hatch and `fallbackBadge` support).
> 
> **Updates consuming UI to match the new contract and layout.** OSS `ContextSwitcher` now passes raw context names (and uses `secondary` to show the raw inline when collapsed), and the main header is tightened: new Radar/Skyhook brand mark + SVG asset, nav labels gated to wider screens, and connection status text only shown for non-steady states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 997a6f6c5a3f2eb2082092075bec813707e7aa7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->