### PR TITLE
fix(resources): pass basename-relative basePath so kind URL syncs in Cloud

### DIFF
--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -181,15 +181,14 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
       pinned={pinned}
       togglePin={togglePin}
       isPinned={(kind: string, group?: string) => isPinned(kind, group ?? '')}
-      // Navigation. basePath is the full URL prefix where the Resources view
-      // lives — '/resources' for standalone Radar, '/c/{cluster}/resources'
-      // when embedded in a host app that mounts RadarApp under a basename.
-      // k8s-ui's ResourcesView uses this to read the current kind out of
-      // window.location.pathname and to write URL updates (drawer open/close,
-      // filter changes) back via history.replaceState. Without the basename
-      // prefix, those writes would drop the host-app route context and the
-      // URL would no longer be reloadable.
-      basePath={getBasename() + '/resources'}
+      // Navigation. basePath is basename-relative. React Router's useLocation
+      // strips the basename from `location.pathname`, so reading the current
+      // kind compares basename-relative paths on both sides. URL writes go
+      // through `handleNavigate`, which strips any leading basename before
+      // handing off to react-router (which re-applies it). Embedding hosts
+      // (e.g. Radar Cloud at /c/{cluster}/resources) work without ResourcesView
+      // needing to know the basename.
+      basePath="/resources"
       locationSearch={location.search}
       locationPathname={location.pathname}
       onNavigate={handleNavigate}


### PR DESCRIPTION
## Summary

Follow-up to #552. The canonical `/resources → /resources/pods` redirect
landed, but the **kind-from-URL** read still ignored the URL when
embedded in Radar Cloud — clicking any sidebar resource (Deployments,
Services, etc.) updated the address bar but the table kept rendering
Pods.

## Root cause

`web/src/components/resources/ResourcesView.tsx` passed
`basePath={getBasename() + '/resources'}` (e.g.
`/c/{cluster}/resources` in Cloud), but `locationPathname` comes from
react-router's `useLocation()`, which **strips** the basename
(`/resources/deployments`). `getInitialKindFromURL`'s
`pathname.startsWith(basePath + '/')` check could therefore never match
in Cloud — fell through to the default `Pod` kind on every URL change.

Standalone Radar (`getBasename()` returns `''`) was unaffected, which is
why the standalone Playwright suite under `web/e2e/url-routing.spec.ts`
went green.

## Fix

`basePath` is now `/resources` regardless of basename. Both sides of the
comparison (`basePath` and the basename-stripped `locationPathname`) are
basename-relative. URL writes still go through `handleNavigate`, which
strips any leading basename before react-router re-applies it — so
Cloud's `/c/{cluster}/resources/{kind}` bookmarks, history rewrites,
and drawer state preservation all keep working.

## Test plan

Verified live against Radar Cloud (`radar-hub-web` mounting `<RadarApp basename="/c/{id}" />`):
- [x] Sidebar **Deployments** → URL `/c/{id}/resources/deployments?apiGroup=apps`, table shows Deployment columns (Ready / Up-to-date / Available / Images)
- [x] Sidebar **Services** → URL `/c/{id}/resources/services`, Service columns (Type / Selector / Endpoints / Ports / External)
- [x] Direct deep-link `/c/{id}/resources/applications?apiGroup=argoproj.io` → ArgoCD Application columns (Project / Sync / Health / Repository)
- [x] **Home → Certificates card** → `/c/{id}/resources/secrets?filters=type%3ATLS`, 31 TLS rows with Expires column
- [x] Browser back from a CRD → previous kind re-syncs correctly
- [x] Canonical `/c/{id}/resources` → `/c/{id}/resources/pods` redirect still fires
- [x] `npm run tsc` in `web/`

Standalone Radar paths unchanged — `basePath` was already `/resources`
when `getBasename()` returns `''`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes resource navigation URL parsing in `ResourcesView`, which can affect routing/deep-link behavior for embedded deployments; scope is small but impacts a core navigation path.
> 
> **Overview**
> Fixes kind selection syncing from the URL when the app is mounted under a React Router `basename` (e.g. Cloud embeds).
> 
> `ResourcesView` now passes a constant basename-relative `basePath` (`/resources`) to `k8s-ui` so `location.pathname` comparisons match, while navigation continues to flow through the existing `handleNavigate` adapter to keep URL writes working under a basename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bc5b7f953ce91ab99bb42d8da51ad1d1ac2fc6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->