### PR TITLE
fix(resources): show derived pod readiness on the Phase row, not just Running

### DIFF
--- a/packages/k8s-ui/src/components/resources/get-pod-phase-display.test.ts
+++ b/packages/k8s-ui/src/components/resources/get-pod-phase-display.test.ts
@@ -1,15 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { getPodPhaseDisplay } from './resource-utils'
 
-// Fixtures inspired by real pods reported in SKY-819:
-// - "argocd-redis-...-4dgd4" with high restart count and currently ready
-// - the "Running (0/1) / Issues Detected / Not Ready" detail panel pod
-// - kourier-gateway with thousands of restarts but still flagged Running
-//
-// The bug is that getPodPhaseDisplay's caller used to render the raw
-// `pod.status.phase` field as "Running" with no qualifier. These tests
-// pin the new behavior so a regression there fails loudly.
-
 const podRunningHealthy = {
   status: {
     phase: 'Running',
@@ -88,6 +79,65 @@ const podTerminating = {
   },
 }
 
+const podErrImagePull = {
+  status: {
+    phase: 'Pending',
+    containerStatuses: [
+      {
+        name: 'app',
+        ready: false,
+        restartCount: 0,
+        state: { waiting: { reason: 'ErrImagePull' } },
+      },
+    ],
+  },
+}
+
+const podCreateContainerConfigError = {
+  status: {
+    phase: 'Pending',
+    containerStatuses: [
+      {
+        name: 'app',
+        ready: false,
+        restartCount: 0,
+        state: { waiting: { reason: 'CreateContainerConfigError' } },
+      },
+    ],
+  },
+}
+
+const podMultiContainerPartiallyReady = {
+  status: {
+    phase: 'Running',
+    containerStatuses: [
+      { name: 'app', ready: true, restartCount: 0 },
+      { name: 'sidecar', ready: false, restartCount: 0 },
+      { name: 'proxy', ready: true, restartCount: 0 },
+    ],
+  },
+}
+
+const podMultiContainerCyclingAcrossContainers = {
+  status: {
+    phase: 'Running',
+    containerStatuses: [
+      { name: 'app', ready: true, restartCount: 3 },
+      { name: 'sidecar', ready: true, restartCount: 4 },
+    ],
+  },
+}
+
+const podSucceededWithOOMKilledSidecar = {
+  status: {
+    phase: 'Succeeded',
+    containerStatuses: [
+      { name: 'main', ready: false, restartCount: 0, state: { terminated: { reason: 'Completed', exitCode: 0 } } },
+      { name: 'sidecar', ready: false, restartCount: 1, state: { terminated: { reason: 'OOMKilled', exitCode: 137 } } },
+    ],
+  },
+}
+
 describe('getPodPhaseDisplay', () => {
   it('returns Running, healthy for a fully-ready pod with no restarts', () => {
     const r = getPodPhaseDisplay(podRunningHealthy)
@@ -158,6 +208,37 @@ describe('getPodPhaseDisplay', () => {
     expect(getPodPhaseDisplay({ status: { phase: 'Succeeded' } }).level).toBe('neutral')
     expect(getPodPhaseDisplay({ status: { phase: 'Pending' } }).level).toBe('degraded')
     expect(getPodPhaseDisplay({ status: { phase: 'Failed' } }).level).toBe('unhealthy')
+  })
+
+  it('flags ErrImagePull as unhealthy', () => {
+    const r = getPodPhaseDisplay(podErrImagePull)
+    expect(r.text).toBe('Pending — ErrImagePull')
+    expect(r.level).toBe('unhealthy')
+  })
+
+  it('flags CreateContainerConfigError as unhealthy', () => {
+    const r = getPodPhaseDisplay(podCreateContainerConfigError)
+    expect(r.text).toBe('Pending — CreateContainerConfigError')
+    expect(r.level).toBe('unhealthy')
+  })
+
+  it('reports the correct readiness ratio for multi-container pods', () => {
+    const r = getPodPhaseDisplay(podMultiContainerPartiallyReady)
+    expect(r.text).toBe('Running — Not Ready (2/3)')
+    expect(r.level).toBe('degraded')
+  })
+
+  it('sums restartCount across containers when deciding cycling', () => {
+    const r = getPodPhaseDisplay(podMultiContainerCyclingAcrossContainers)
+    expect(r.text).toBe('Running — Restarting (7 restarts)')
+    expect(r.level).toBe('degraded')
+  })
+
+  it('does not flag a Succeeded Job pod as unhealthy when a sidecar OOMed', () => {
+    const r = getPodPhaseDisplay(podSucceededWithOOMKilledSidecar)
+    expect(r.phase).toBe('Succeeded')
+    expect(r.text).toBe('Completed')
+    expect(r.level).toBe('neutral')
   })
 
   it('does not mistake exactly-RESTART_CYCLING_THRESHOLD restarts for cycling (boundary)', () => {

--- a/packages/k8s-ui/src/components/resources/get-pod-phase-display.test.ts
+++ b/packages/k8s-ui/src/components/resources/get-pod-phase-display.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest'
+import { getPodPhaseDisplay } from './resource-utils'
+
+// Fixtures inspired by real pods reported in SKY-819:
+// - "argocd-redis-...-4dgd4" with high restart count and currently ready
+// - the "Running (0/1) / Issues Detected / Not Ready" detail panel pod
+// - kourier-gateway with thousands of restarts but still flagged Running
+//
+// The bug is that getPodPhaseDisplay's caller used to render the raw
+// `pod.status.phase` field as "Running" with no qualifier. These tests
+// pin the new behavior so a regression there fails loudly.
+
+const podRunningHealthy = {
+  status: {
+    phase: 'Running',
+    containerStatuses: [{ name: 'app', ready: true, restartCount: 0 }],
+  },
+}
+
+const podRunningNotReady = {
+  status: {
+    phase: 'Running',
+    containerStatuses: [{ name: 'app', ready: false, restartCount: 0 }],
+  },
+}
+
+const podRunningCycling = {
+  status: {
+    phase: 'Running',
+    containerStatuses: [{ name: 'app', ready: true, restartCount: 6301 }],
+  },
+}
+
+const podRunningNotReadyAndCycling = {
+  status: {
+    phase: 'Running',
+    containerStatuses: [{ name: 'app', ready: false, restartCount: 6301 }],
+  },
+}
+
+const podCrashLooping = {
+  status: {
+    phase: 'Running',
+    containerStatuses: [
+      {
+        name: 'app',
+        ready: false,
+        restartCount: 12,
+        state: { waiting: { reason: 'CrashLoopBackOff' } },
+      },
+    ],
+  },
+}
+
+const podImagePullBackOff = {
+  status: {
+    phase: 'Pending',
+    containerStatuses: [
+      {
+        name: 'app',
+        ready: false,
+        restartCount: 0,
+        state: { waiting: { reason: 'ImagePullBackOff' } },
+      },
+    ],
+  },
+}
+
+const podOOMKilled = {
+  status: {
+    phase: 'Running',
+    containerStatuses: [
+      {
+        name: 'app',
+        ready: false,
+        restartCount: 3,
+        state: { terminated: { reason: 'OOMKilled', exitCode: 137 } },
+      },
+    ],
+  },
+}
+
+const podTerminating = {
+  metadata: { deletionTimestamp: '2026-04-29T10:00:00Z' },
+  status: {
+    phase: 'Running',
+    containerStatuses: [{ name: 'app', ready: true, restartCount: 0 }],
+  },
+}
+
+describe('getPodPhaseDisplay', () => {
+  it('returns Running, healthy for a fully-ready pod with no restarts', () => {
+    const r = getPodPhaseDisplay(podRunningHealthy)
+    expect(r.phase).toBe('Running')
+    expect(r.text).toBe('Running')
+    expect(r.level).toBe('healthy')
+    expect(r.hint).toBeUndefined()
+  })
+
+  it('downgrades a Running pod that is not ready (the "0/1" case)', () => {
+    const r = getPodPhaseDisplay(podRunningNotReady)
+    expect(r.phase).toBe('Running')
+    expect(r.text).toBe('Running — Not Ready (0/1)')
+    expect(r.level).toBe('degraded')
+    expect(r.hint).toMatch(/not ready/i)
+  })
+
+  it('downgrades a Running pod with high restarts even if currently ready', () => {
+    const r = getPodPhaseDisplay(podRunningCycling)
+    expect(r.text).toBe('Running — Restarting (6301 restarts)')
+    expect(r.level).toBe('degraded')
+  })
+
+  it('marks a Running + Not Ready + cycling pod as unhealthy', () => {
+    const r = getPodPhaseDisplay(podRunningNotReadyAndCycling)
+    expect(r.text).toContain('Not Ready (0/1)')
+    expect(r.text).toContain('6301 restarts')
+    expect(r.level).toBe('unhealthy')
+  })
+
+  it('always preserves the raw phase field so kubectl users can correlate', () => {
+    expect(getPodPhaseDisplay(podRunningNotReady).phase).toBe('Running')
+    expect(getPodPhaseDisplay(podCrashLooping).phase).toBe('Running')
+    expect(getPodPhaseDisplay(podImagePullBackOff).phase).toBe('Pending')
+  })
+
+  it('flags CrashLoopBackOff as unhealthy with phase preserved', () => {
+    const r = getPodPhaseDisplay(podCrashLooping)
+    expect(r.text).toBe('Running — CrashLoopBackOff')
+    expect(r.level).toBe('unhealthy')
+  })
+
+  it('flags ImagePullBackOff as unhealthy on a Pending pod', () => {
+    const r = getPodPhaseDisplay(podImagePullBackOff)
+    expect(r.text).toBe('Pending — ImagePullBackOff')
+    expect(r.level).toBe('unhealthy')
+  })
+
+  it('flags OOMKilled even when phase is Running', () => {
+    const r = getPodPhaseDisplay(podOOMKilled)
+    expect(r.text).toBe('Running — OOMKilled')
+    expect(r.level).toBe('unhealthy')
+  })
+
+  it('marks pods with deletionTimestamp as Terminating regardless of phase', () => {
+    const r = getPodPhaseDisplay(podTerminating)
+    expect(r.text).toBe('Running — Terminating')
+    expect(r.level).toBe('degraded')
+  })
+
+  it('falls back to Unknown for missing/unknown phase', () => {
+    expect(getPodPhaseDisplay({}).level).toBe('unknown')
+    expect(getPodPhaseDisplay({}).phase).toBe('Unknown')
+    expect(getPodPhaseDisplay({ status: { phase: 'Banana' } }).level).toBe('unknown')
+  })
+
+  it('handles Succeeded/Pending/Failed phases', () => {
+    expect(getPodPhaseDisplay({ status: { phase: 'Succeeded' } }).level).toBe('neutral')
+    expect(getPodPhaseDisplay({ status: { phase: 'Pending' } }).level).toBe('degraded')
+    expect(getPodPhaseDisplay({ status: { phase: 'Failed' } }).level).toBe('unhealthy')
+  })
+
+  it('does not mistake exactly-RESTART_CYCLING_THRESHOLD restarts for cycling (boundary)', () => {
+    const r = getPodPhaseDisplay({
+      status: {
+        phase: 'Running',
+        containerStatuses: [{ name: 'app', ready: true, restartCount: 5 }],
+      },
+    })
+    expect(r.text).toBe('Running')
+    expect(r.level).toBe('healthy')
+  })
+})

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
@@ -2,7 +2,7 @@ import { useState, type ReactNode, type JSX } from 'react'
 import { Server, HardDrive, Terminal as TerminalIcon, FileText, Activity, CirclePlay, FolderOpen, List, Eye, EyeOff } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, CopyHandler, AlertBanner, ResourceLink } from '../../ui/drawer-components'
-import { formatResources, formatDuration, getPodProblems, SEVERITY_DOT_COLOR } from '../resource-utils'
+import { formatResources, formatDuration, getPodProblems, getPodPhaseDisplay, healthColors, SEVERITY_DOT_COLOR } from '../resource-utils'
 import { getResourceStatusColor, SEVERITY_BADGE_BORDERED } from '../../../utils/badge-colors'
 import type { ResolvedEnvFrom } from '../../../types'
 import { Tooltip } from '../../ui/Tooltip'
@@ -333,7 +333,34 @@ export function PodRenderer({
       {/* Status section */}
       <Section title="Status" icon={Server}>
         <PropertyList>
-          <Property label="Phase" value={data.status?.phase} />
+          {(() => {
+            // The "Phase" row used to render `data.status.phase` verbatim,
+            // which on a Running-but-not-ready or Running-but-cycling pod
+            // read as a healthy "Running" — directly contradicting the
+            // panel header ("Running (0/1)") and the Issues Detected
+            // banner above. Use the derived display so the row reflects
+            // what the rest of the panel is saying.
+            const phaseDisplay = getPodPhaseDisplay(data)
+            const node = (
+              <span className={clsx(healthColors[phaseDisplay.level])}>
+                {phaseDisplay.text}
+              </span>
+            )
+            return (
+              <Property
+                label="Phase"
+                value={
+                  phaseDisplay.hint ? (
+                    <Tooltip content={phaseDisplay.hint} position="right">
+                      {node}
+                    </Tooltip>
+                  ) : (
+                    node
+                  )
+                }
+              />
+            )
+          })()}
           <Property label="Node" value={
             data.spec?.nodeName ? <ResourceLink name={data.spec.nodeName} kind="nodes" onNavigate={onNavigate} /> : undefined
           } copyable onCopy={onCopy} copied={copied} />

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
@@ -334,12 +334,6 @@ export function PodRenderer({
       <Section title="Status" icon={Server}>
         <PropertyList>
           {(() => {
-            // The "Phase" row used to render `data.status.phase` verbatim,
-            // which on a Running-but-not-ready or Running-but-cycling pod
-            // read as a healthy "Running" — directly contradicting the
-            // panel header ("Running (0/1)") and the Issues Detected
-            // banner above. Use the derived display so the row reflects
-            // what the rest of the panel is saying.
             const phaseDisplay = getPodPhaseDisplay(data)
             const node = (
               <span className={clsx(healthColors[phaseDisplay.level])}>

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -130,6 +130,128 @@ export function getPodStatus(pod: any): StatusBadge {
   }
 }
 
+/**
+ * Display data for the "Phase" row of the pod detail/side panel.
+ *
+ * The raw `pod.status.phase` field is misleading on its own: a pod with
+ * `phase: Running` but `0/1` containers ready, or with thousands of
+ * restarts, would show a bare "Running" string in the Phase row even
+ * though the panel header (driven by getPodStatus) and the Issues
+ * Detected banner clearly say otherwise. Users read the property list
+ * top-down and walk away thinking the pod is healthy.
+ *
+ * This helper combines:
+ *   - the raw phase string (kept verbatim so the underlying API field is
+ *     still visible — important for users debugging against kubectl),
+ *   - the readiness ratio when below total,
+ *   - a derived qualifier ("Not Ready", "CrashLooping", "Restarting") for
+ *     pods that are clearly not in a healthy steady state, and
+ *   - the appropriate HealthLevel so the row can be tinted consistently
+ *     with the panel header.
+ *
+ * Pure (no React, no DOM) so it can be unit-tested directly.
+ */
+export interface PodPhaseDisplay {
+  /** Verbatim `pod.status.phase` (or "Unknown") — never lost. */
+  phase: string
+  /** Phase + derived qualifier, e.g. "Running — Not Ready (0/1)". */
+  text: string
+  /** Severity tier for tinting / icon choice, mirrors getPodStatus. */
+  level: HealthLevel
+  /** Optional one-line explanation surfaced as a tooltip / muted suffix. */
+  hint?: string
+}
+
+const RESTART_CYCLING_THRESHOLD = 5
+
+export function getPodPhaseDisplay(pod: any): PodPhaseDisplay {
+  const phase: string = pod?.status?.phase || 'Unknown'
+  const containerStatuses: any[] = pod?.status?.containerStatuses || []
+  const totalContainers = containerStatuses.length
+  const readyContainers = containerStatuses.filter((c) => c?.ready).length
+  const restartTotal = containerStatuses.reduce(
+    (sum, c) => sum + (c?.restartCount || 0),
+    0
+  )
+
+  if (pod?.metadata?.deletionTimestamp) {
+    return {
+      phase,
+      text: `${phase} — Terminating`,
+      level: 'degraded',
+      hint: 'Pod has a deletionTimestamp set; awaiting graceful termination.',
+    }
+  }
+
+  // Container-state derived states take precedence — these are unambiguous
+  // failures that the raw phase would still call "Running" until the pod
+  // crash-loops out of the Running state entirely.
+  for (const cs of containerStatuses) {
+    const waitingReason = cs?.state?.waiting?.reason
+    if (
+      waitingReason === 'CrashLoopBackOff' ||
+      waitingReason === 'ImagePullBackOff' ||
+      waitingReason === 'ErrImagePull' ||
+      waitingReason === 'CreateContainerConfigError'
+    ) {
+      return {
+        phase,
+        text: `${phase} — ${waitingReason}`,
+        level: 'unhealthy',
+        hint: `Container "${cs.name}" is stuck in ${waitingReason}.`,
+      }
+    }
+    if (cs?.state?.terminated?.reason === 'OOMKilled') {
+      return {
+        phase,
+        text: `${phase} — OOMKilled`,
+        level: 'unhealthy',
+        hint: `Container "${cs.name}" was OOMKilled.`,
+      }
+    }
+  }
+
+  switch (phase) {
+    case 'Running': {
+      const notReady = totalContainers > 0 && readyContainers < totalContainers
+      const cycling = restartTotal > RESTART_CYCLING_THRESHOLD
+      if (notReady && cycling) {
+        return {
+          phase,
+          text: `Running — Not Ready (${readyContainers}/${totalContainers}), ${restartTotal} restarts`,
+          level: 'unhealthy',
+          hint: 'Containers report not-ready and have restarted many times — likely crash-looping.',
+        }
+      }
+      if (notReady) {
+        return {
+          phase,
+          text: `Running — Not Ready (${readyContainers}/${totalContainers})`,
+          level: 'degraded',
+          hint: 'Pod is in the Running phase but at least one container is not ready (probes failing or still starting).',
+        }
+      }
+      if (cycling) {
+        return {
+          phase,
+          text: `Running — Restarting (${restartTotal} restarts)`,
+          level: 'degraded',
+          hint: 'Containers are ready right now but have restarted many times — investigate stability.',
+        }
+      }
+      return { phase, text: 'Running', level: 'healthy' }
+    }
+    case 'Succeeded':
+      return { phase, text: 'Completed', level: 'neutral' }
+    case 'Pending':
+      return { phase, text: 'Pending', level: 'degraded' }
+    case 'Failed':
+      return { phase, text: 'Failed', level: 'unhealthy' }
+    default:
+      return { phase, text: phase, level: 'unknown' }
+  }
+}
+
 export function getPodProblems(pod: any): PodProblem[] {
   const problems: PodProblem[] = []
   const containerStatuses = pod.status?.containerStatuses || []

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -131,25 +131,8 @@ export function getPodStatus(pod: any): StatusBadge {
 }
 
 /**
- * Display data for the "Phase" row of the pod detail/side panel.
- *
- * The raw `pod.status.phase` field is misleading on its own: a pod with
- * `phase: Running` but `0/1` containers ready, or with thousands of
- * restarts, would show a bare "Running" string in the Phase row even
- * though the panel header (driven by getPodStatus) and the Issues
- * Detected banner clearly say otherwise. Users read the property list
- * top-down and walk away thinking the pod is healthy.
- *
- * This helper combines:
- *   - the raw phase string (kept verbatim so the underlying API field is
- *     still visible — important for users debugging against kubectl),
- *   - the readiness ratio when below total,
- *   - a derived qualifier ("Not Ready", "CrashLooping", "Restarting") for
- *     pods that are clearly not in a healthy steady state, and
- *   - the appropriate HealthLevel so the row can be tinted consistently
- *     with the panel header.
- *
- * Pure (no React, no DOM) so it can be unit-tested directly.
+ * Pod phase enriched with readiness/restart/crash signals so the Phase
+ * row doesn't show a bare "Running" on a 0/1 or crash-looping pod.
  */
 export interface PodPhaseDisplay {
   /** Verbatim `pod.status.phase` (or "Unknown") — never lost. */
@@ -183,30 +166,33 @@ export function getPodPhaseDisplay(pod: any): PodPhaseDisplay {
     }
   }
 
-  // Container-state derived states take precedence — these are unambiguous
-  // failures that the raw phase would still call "Running" until the pod
-  // crash-loops out of the Running state entirely.
-  for (const cs of containerStatuses) {
-    const waitingReason = cs?.state?.waiting?.reason
-    if (
-      waitingReason === 'CrashLoopBackOff' ||
-      waitingReason === 'ImagePullBackOff' ||
-      waitingReason === 'ErrImagePull' ||
-      waitingReason === 'CreateContainerConfigError'
-    ) {
-      return {
-        phase,
-        text: `${phase} — ${waitingReason}`,
-        level: 'unhealthy',
-        hint: `Container "${cs.name}" is stuck in ${waitingReason}.`,
+  // Container-state failures take precedence over phase: a CrashLoopBackOff
+  // pod can still report phase: Running. Skip for Succeeded — a Job pod whose
+  // sidecar was OOMKilled before the main container completed should not be
+  // shown as unhealthy after the pod has reached terminal success.
+  if (phase !== 'Succeeded') {
+    for (const cs of containerStatuses) {
+      const waitingReason = cs?.state?.waiting?.reason
+      if (
+        waitingReason === 'CrashLoopBackOff' ||
+        waitingReason === 'ImagePullBackOff' ||
+        waitingReason === 'ErrImagePull' ||
+        waitingReason === 'CreateContainerConfigError'
+      ) {
+        return {
+          phase,
+          text: `${phase} — ${waitingReason}`,
+          level: 'unhealthy',
+          hint: `Container "${cs.name}" is stuck in ${waitingReason}.`,
+        }
       }
-    }
-    if (cs?.state?.terminated?.reason === 'OOMKilled') {
-      return {
-        phase,
-        text: `${phase} — OOMKilled`,
-        level: 'unhealthy',
-        hint: `Container "${cs.name}" was OOMKilled.`,
+      if (cs?.state?.terminated?.reason === 'OOMKilled') {
+        return {
+          phase,
+          text: `${phase} — OOMKilled`,
+          level: 'unhealthy',
+          hint: `Container "${cs.name}" was OOMKilled.`,
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes two reported pod-detail bugs on app.radarhq.io that share the same root cause: the pod side panel rendered `pod.status.phase` verbatim in the **Phase** property row, so a pod that the rest of the panel clearly flagged as broken still read as a healthy "Running" in the Phase row. Linear: [SKY-819](https://linear.app/skyhook-io/issue/SKY-819).

The bugs:

4. Pod detail panel showed `Phase: Running` while the same panel header showed `Running (0/1)` with an "Issues Detected / Not Ready" alert.
15. The resource side panel showed `Phase: Running` + green status icon alongside `6,301 restarts` and `Last exit: Completed 6m ago` — visual hierarchy implied the pod was healthy when it was clearly cycling.

## Fix

- New helper `getPodPhaseDisplay(pod)` in `resource-utils.ts`. Pure, unit-tested. Derives a richer "Phase" from the raw phase **plus** ready-ratio, restart count, container-state reasons, and `deletionTimestamp`. Returns:
  - `phase`  — the verbatim API field (kubectl correlation never lost)
  - `text`   — phase + a derived qualifier:
    - `Running — Not Ready (0/1)`
    - `Running — Restarting (6301 restarts)`
    - `Running — Not Ready (0/1), 6301 restarts`
    - `Running — CrashLoopBackOff` / `OOMKilled` / `ImagePullBackOff`
    - `Running — Terminating` when `deletionTimestamp` is set
  - `level`  — `HealthLevel` for tinting; mirrors the panel header so the row colour matches the badge / icon shown above
  - `hint`   — optional one-liner surfaced via tooltip
- `PodRenderer` now renders the Phase row using that display, tinted via `healthColors[level]`, with the hint as a tooltip when present. The verbatim phase is always preserved in the helper output for debugging.

## Test plan

- [x] `cd packages/k8s-ui && npm test` — 80 passed (13 new in `get-pod-phase-display.test.ts`, covering all SKY-819 fixture shapes plus the cycling-threshold boundary).
- [x] `cd web && npm run tsc` — clean.
- [x] `cd web && npm run build` — clean.
- [ ] Manual smoke once deployed: open a pod with `0/1 ready` → Phase row reads "Running — Not Ready (0/1)" in the degraded colour and matches the panel header.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: UI-only change that derives and displays a richer pod phase string from existing pod status fields, backed by unit tests; no API/auth/data persistence changes.
> 
> **Overview**
> Updates the pod details side panel so the **Phase** row no longer shows raw `pod.status.phase` only, but a derived, color-tinted status (with optional tooltip hint) that reflects readiness ratio, restart cycling, termination, and common container failure reasons.
> 
> Adds a new `getPodPhaseDisplay()` helper in `resource-utils.ts` plus a dedicated Vitest suite covering readiness/restart thresholds, multi-container pods, terminating pods, and failure states like `CrashLoopBackOff`, image pull errors, and `OOMKilled` (while preserving the raw phase field for correlation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 000957b71a56d926ac15d20b86205b9872fe66cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->