### PR TITLE
fix(resources): stop "Updated Xs" timer resetting on no-op refetches

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1752,6 +1752,51 @@ function getInitialFiltersFromURL() {
 // Sort state type
 type SortDirection = 'asc' | 'desc' | null
 
+// Coarse "just now / Xm / Xh / Xd" buckets — finer-grained updates
+// add motion in the periphery without aiding any user decision.
+function formatLastUpdatedBucket(elapsedMs: number): string {
+  const elapsedSec = Math.max(0, Math.floor(elapsedMs / 1000))
+  if (elapsedSec < 60) return 'just now'
+  const minutes = Math.floor(elapsedSec / 60)
+  if (minutes < 60) return `${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h`
+  return `${Math.floor(hours / 24)}d`
+}
+
+// ms until the displayed bucket would change.
+function msToNextBucket(elapsedMs: number): number {
+  const elapsed = Math.max(0, elapsedMs)
+  if (elapsed < 60_000) return 60_000 - elapsed
+  if (elapsed < 3_600_000) return 60_000 - (elapsed % 60_000)
+  if (elapsed < 86_400_000) return 3_600_000 - (elapsed % 3_600_000)
+  return 86_400_000 - (elapsed % 86_400_000)
+}
+
+// Isolated subtree so re-renders don't cascade into the parent's
+// virtualized table.
+function LastUpdatedLabel({ lastUpdated }: { lastUpdated: Date }) {
+  const [, force] = useState(0)
+  useEffect(() => {
+    let id: ReturnType<typeof setTimeout>
+    function schedule() {
+      const delay = Math.max(1000, msToNextBucket(Date.now() - lastUpdated.getTime()))
+      id = setTimeout(() => {
+        force(t => t + 1)
+        schedule()
+      }, delay)
+    }
+    schedule()
+    return () => clearTimeout(id)
+  }, [lastUpdated])
+  return (
+    <div className="flex items-center gap-1.5 text-xs text-theme-text-tertiary">
+      <Clock className="w-3.5 h-3.5" />
+      <span>Updated {formatLastUpdatedBucket(Date.now() - lastUpdated.getTime())}</span>
+    </div>
+  )
+}
+
 export function ResourcesView({
   namespaces, selectedResource, onResourceClick, onResourceClickYaml, onKindChange,
   apiResources: apiResourcesProp,
@@ -2680,12 +2725,18 @@ export function ResourcesView({
 
   const [refetch, isRefreshAnimating, refreshPhase] = useRefreshAnimation(() => refetchFn?.())
 
-  // Track last updated time
+  // React Query bumps dataUpdatedAt on no-op refetches (window focus,
+  // mount, sibling subscribers); structural sharing returns the same
+  // resources reference when data is byte-identical. Skip the timer
+  // reset in that case — otherwise opening a filter drawer looks like
+  // it triggered a real fetch.
+  const lastDataRef = useRef<unknown>(undefined)
   useEffect(() => {
-    if (dataUpdatedAt) {
-      setLastUpdated(new Date(dataUpdatedAt))
-    }
-  }, [dataUpdatedAt])
+    if (!dataUpdatedAt) return
+    if (resources === lastDataRef.current) return
+    lastDataRef.current = resources
+    setLastUpdated(new Date(dataUpdatedAt))
+  }, [dataUpdatedAt, resources])
 
   // Derive counts — prefer lightweight resourceCounts prop over full query data
   const counts = useMemo(() => {
@@ -3524,12 +3575,7 @@ export function ResourcesView({
             </span>
           )}
 
-          {lastUpdated && (
-            <div className="flex items-center gap-1.5 text-xs text-theme-text-tertiary">
-              <Clock className="w-3.5 h-3.5" />
-              <span>Updated <span className="inline-block min-w-[4ch] tabular-nums">{formatAge(lastUpdated.toISOString())}</span></span>
-            </div>
-          )}
+          {lastUpdated && <LastUpdatedLabel lastUpdated={lastUpdated} />}
           {/* Column picker */}
           <div className="relative" ref={columnPickerRef}>
             <button
@@ -4026,7 +4072,14 @@ function CellContent({ resource, kind, column, group, majorityNodeMinorVersion, 
     )
   }
   if (column === 'age') {
-    return <span className="text-sm text-theme-text-secondary">{formatAge(meta.creationTimestamp)}</span>
+    if (!meta.creationTimestamp) {
+      return <span className="text-sm text-theme-text-secondary">-</span>
+    }
+    return (
+      <Tooltip content={new Date(meta.creationTimestamp).toLocaleString()}>
+        <span className="text-sm text-theme-text-secondary">{formatAge(meta.creationTimestamp)}</span>
+      </Tooltip>
+    )
   }
 
   // Kind-specific columns (normalize CRD singular names like 'ScaledObject' → 'scaledobjects')


### PR DESCRIPTION
## Summary

Two related bugs in the Resources view header (SKY-820):

- **16**: The "Updated Xs" timer briefly reset to "<1s" when reopening filters, suggesting a real refetch was triggered for a UI-only action.
- **10**: Age values in the resource list felt like they shifted between refreshes, with no fixed reference to verify against.

## Root cause (bug 16)

The effect that drives `lastUpdated` was keyed on React Query's `dataUpdatedAt`, which bumps on every successful fetch — even when the response is byte-identical and structural sharing returns the same `resources` reference. Window focus, mount, and any sibling subscriber issuing the same queryKey can all trigger such no-op refetches, each one resetting the visible timer.

## Fix

Single file, +65/-12:

1. **Gate the `lastUpdated` effect on a real cache mutation**: `if (resources === lastDataRef.current) return`. React Query's structural sharing returns the same reference when responses are byte-identical, so reference equality is the cheapest correct way to detect "real change vs no-op".

2. **Switch the toolbar label to coarse buckets** (`just now` → `Xm` → `Xh` → `Xd`). The previous behavior was per-second `formatAge` — distracting in the periphery without aiding any user decision (a label going `5s` → `6s` → `7s` carries zero actionable info). Buckets cross at minute / hour / day boundaries, so the label updates roughly once per minute under an hour, once per hour up to a day, etc. — and a single `setTimeout` to the next boundary replaces the 1Hz `setInterval`.

3. **Isolate the label in its own `LastUpdatedLabel` component** so re-renders don't cascade into the parent's virtualized table.

4. **Bug 10 — Age column tooltip**: wrap the relative-age cell in a Tooltip showing the absolute `creationTimestamp.toLocaleString()`, so users have a stable reference when relative ages feel inconsistent. Also handles the falsy-`creationTimestamp` case explicitly.

## UX rationale for buckets

Continuous per-second updates are flagged as distracting / cognitively expensive across UX research (Smashing's [Real-Time Dashboards](https://www.smashingmagazine.com/2025/09/ux-strategies-real-time-dashboards/), accessibility guidance via WCAG / web.dev). Consumer products (Slack, Linear, GitHub notifications) all converged on coarse buckets. Grafana's own Clock Panel documents "if second ticking annoys you, change the time format" as the escape hatch — strong signal the per-second tick is a known irritation. For the toolbar staleness indicator, users care about "is this fresh / a few minutes old / stale" — bucket granularity, not seconds.

## Test plan

- [x] `npm test` (k8s-ui) — 211 passing
- [x] `npm run tsc` (k8s-ui + web) — clean
- [x] Visual: header shows "Updated just now" on fresh data, stable across 15s sampling; no flicker; no "<1s" reset on window-focus / refetch events
- [x] Visual: Age cell tooltip shows absolute creation timestamp on hover