### PR TITLE
fix(sidebar): stop counts flickering to 0 during initial load

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesSidebar.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesSidebar.tsx
@@ -94,7 +94,9 @@ const CORE_RESOURCE_TYPES = [
 // Resource type button in sidebar
 interface ResourceTypeButtonProps {
   resource: APIResource
-  count: number
+  /** `null` means "count not loaded yet" — rendered as a placeholder so
+   *  the badge doesn't flicker to "0" while the API call is in flight. */
+  count: number | null
   isSelected: boolean
   /** Keyboard-highlight state (arrow nav in the filter input). */
   isHighlighted?: boolean
@@ -155,9 +157,11 @@ const ResourceTypeButton = forwardRef<HTMLButtonElement, ResourceTypeButtonProps
             <span className={clsx(
               'text-xs py-0.5 rounded text-center font-mono',
               isSelected ? 'bg-skyhook-500/30 selection-text' : 'bg-theme-elevated',
-              count < 1000 ? 'w-8' : 'w-9'
+              count === null
+                ? 'w-8 text-theme-text-disabled'
+                : count < 1000 ? 'w-8' : 'w-9',
             )}>
-              {count}
+              {count === null ? '–' : count}
             </span>
           )}
         </div>
@@ -253,12 +257,28 @@ export function ResourcesSidebar({
     }))
   }, [categories])
 
+  // null for a key means "not loaded yet" (rendered as a placeholder
+  // dash in the badge). 0 means "the API replied and confirmed there
+  // are zero of this kind". Don't conflate them — otherwise the
+  // sidebar shows a confident "0" for every kind while the count
+  // payload is still in flight.
   const counts = useMemo(() => {
-    if (!resourceCounts) return {} as Record<string, number>
-    const results: Record<string, number> = {}
+    const results: Record<string, number | null> = {}
+    if (!resourceCounts) {
+      for (const resource of resourcesToCount) {
+        const key = resource.group ? `${resource.group}/${resource.kind}` : resource.kind
+        results[key] = null
+      }
+      return results
+    }
     for (const resource of resourcesToCount) {
       const key = resource.group ? `${resource.group}/${resource.kind}` : resource.kind
-      results[key] = resourceCounts[key] ?? 0
+      const v = resourceCounts[key]
+      // Treat missing keys in a present resourceCounts payload as
+      // "the API replied and didn't include this kind" → 0. Treat the
+      // entire payload being absent as "not loaded" → null (handled
+      // above).
+      results[key] = v ?? 0
     }
     return results
   }, [resourcesToCount, resourceCounts])
@@ -276,16 +296,22 @@ export function ResourcesSidebar({
     let totalHiddenGroups = 0
 
     const withTotals = categories.map(category => {
+      // Coerce nulls (loading) to 0 for the category total — we still
+      // want to show *some* number on collapsed categories during
+      // load, just not "0" badges on every individual kind.
       const total = category.resources.reduce(
-        (sum, resource) => sum + (counts?.[(resource.group ? `${resource.group}/${resource.kind}` : resource.kind)] ?? 0),
+        (sum, resource) => sum + (counts[resource.group ? `${resource.group}/${resource.kind}` : resource.kind] ?? 0),
         0
       )
 
-      // Filter resources: show if has instances, is core kind, or showEmptyKinds is true
+      // Filter resources: show if has instances, is core kind, has an
+      // unknown count (loading — don't pre-emptively hide), or
+      // showEmptyKinds is true.
       const visibleResources = category.resources.filter(resource => {
-        const count = counts?.[(resource.group ? `${resource.group}/${resource.kind}` : resource.kind)] ?? 0
+        const count = counts[resource.group ? `${resource.group}/${resource.kind}` : resource.kind]
         const isCore = ALWAYS_SHOWN_KINDS.has(resource.kind)
-        const shouldShow = count > 0 || isCore || showEmptyKinds
+        const isLoading = count === null
+        const shouldShow = (count ?? 0) > 0 || isCore || isLoading || showEmptyKinds
         if (!shouldShow) totalHiddenKinds++
         return shouldShow
       })
@@ -500,7 +526,7 @@ export function ResourcesSidebar({
                         key={`${p.name}-${p.group}`}
                         ref={highlighted ? highlightedRef : (isResourceSelected ? selectedSidebarRef : null)}
                         resource={{ name: p.name, kind: p.kind, group: p.group, version: '', namespaced: true, isCrd: false, verbs: [] }}
-                        count={counts?.[(p.group ? `${p.group}/${p.kind}` : p.kind)] ?? 0}
+                        count={counts[p.group ? `${p.group}/${p.kind}` : p.kind] ?? null}
                         isSelected={isResourceSelected}
                         isHighlighted={highlighted}
                         isForbidden={forbiddenKinds.has(p.group ? `${p.group}/${p.kind}` : p.kind)}
@@ -556,7 +582,7 @@ export function ResourcesSidebar({
                           key={resource.name}
                           ref={highlighted ? highlightedRef : (isResourceSelected ? selectedSidebarRef : null)}
                           resource={resource}
-                          count={counts?.[(resource.group ? `${resource.group}/${resource.kind}` : resource.kind)] ?? 0}
+                          count={counts[resource.group ? `${resource.group}/${resource.kind}` : resource.kind] ?? null}
                           isSelected={showSelected}
                           isHighlighted={highlighted}
                           isForbidden={forbiddenKinds.has(resource.group ? `${resource.group}/${resource.kind}` : resource.kind)}
@@ -581,7 +607,7 @@ export function ResourcesSidebar({
               ? type.label.slice(0, -1)
               : type.label
             const Icon = getResourceIcon(kindKey)
-            const count = counts?.[kindKey] ?? 0
+            const count = counts[kindKey] ?? null
             const isSelected = effectiveSelectedKind.name === type.kind && !effectiveSelectedKind.group
             return (
               <button
@@ -600,9 +626,10 @@ export function ResourcesSidebar({
                 <span className="flex-1 text-left">{type.label}</span>
                 <span className={clsx(
                   'badge font-mono',
-                  isSelected ? 'bg-skyhook-500/30 selection-text' : 'bg-theme-elevated'
+                  isSelected ? 'bg-skyhook-500/30 selection-text' : 'bg-theme-elevated',
+                  count === null && 'text-theme-text-disabled',
                 )}>
-                  {count}
+                  {count === null ? '–' : count}
                 </span>
               </button>
             )


### PR DESCRIPTION
## Summary

Sidebar resource counts went to "0" for every kind during the window between mount and the count payload arriving — visible as ~2s of "data loss" on the cloud product where the API has WAN latency. (SKY-824 bug 39.)

## Root cause

The counts memo coerced every missing key to 0:

```ts
results[key] = resourceCounts[key] ?? 0
```

This conflates "API hasn't replied yet" with "API confirmed zero of this kind", rendering a confident "0" badge for every resource during the loading window.

## Fix

Change the internal counts type from `Record<string, number>` to `Record<string, number | null>`:
- `null` = not loaded; rendered as an en-dash placeholder with `text-theme-text-disabled` so it's visually subordinate
- `0` = API confirmed empty; rendered as "0"
- Category "show this kind" filter treats null as "show, might have data" (don't pre-emptively hide kinds during load)
- Category totals coerce nulls to 0 for the collapsed-summary badge — honest because the total is over a known finite set of kinds

## Out of scope

The related one-frame flat-fallback flicker during nav transitions (bug 65 — sidebar briefly collapses to the flat layout when `apiResources` is `undefined` for one render on remount) is intentionally **not** addressed here. The clean fix would be to move state above the `BaseResourcesView` remount boundary, which is a larger structural change. The flat-fallback flicker is less alarming than the "0" flicker; this PR addresses the more visible symptom.

The `Checks` page mentioned in bug 40 lives in `radar-hub-web`, not radar OSS.

## Test plan

- [x] `npm test` (k8s-ui) — 216 passing, none affected
- [x] `npm run tsc` (k8s-ui + web) — clean
- [x] Manual: navigate to `/resources/pods` on a slow connection — counts show en-dash placeholders during load, not "0"