### PR TITLE
fix(ui): register number-key shortcuts for Cost and Audit views

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4100,7 +4100,7 @@
     },
     "web": {
       "name": "@skyhook-io/radar-app",
-      "version": "0.1.0",
+      "version": "0.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/dm-sans": "^5.2.8",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -366,7 +366,7 @@ function AppInner() {
   const switchContext = useSwitchContext()
 
   // View switching keyboard shortcuts
-  const views: ExtendedMainView[] = ['home', 'topology', 'resources', 'timeline', 'helm', 'traffic']
+  const views: ExtendedMainView[] = ['home', 'topology', 'resources', 'timeline', 'helm', 'traffic', 'cost', 'audit']
   useRegisterShortcuts([
     ...views.map((view, i) => ({
       id: `view-${view}`,


### PR DESCRIPTION
## Summary

The command palette lists digit shortcuts for all main views (including **7** for Cost and **8** for Audit), but the global `useRegisterShortcuts` hook only registered views through Traffic. Keys 7 and 8 did nothing until this change.

## Changes

- Extend the `views` array passed into view-switch shortcuts in `web/src/App.tsx` with `cost` and `audit` so digits 1–8 match the palette and navigate correctly.
- Align the root `package-lock.json` workspace entry for `web` with `web/package.json` (version `0.1.9`) after it had drifted.

## Testing

- `go test ./...`
- `cd web && npm run tsc`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only shortcut registration change plus a lockfile version sync; low likelihood of runtime impact beyond key bindings.
> 
> **Overview**
> Fixes global view-switch keyboard shortcuts so the numeric bindings cover **Cost** and **Audit** as well (updating the `views` list used by `useRegisterShortcuts` in `web/src/App.tsx`).
> 
> Also updates the root `package-lock.json` workspace entry for `web` to version `0.1.9` to match the app package version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 328b589c6f3ddf85b0ef17206dd37da7c5b26ec3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->