### PR TITLE
fix(topology): make the "Policies" toggle actually paint policy effects

### DIFF
--- a/packages/k8s-ui/src/components/topology/TopologyControls.tsx
+++ b/packages/k8s-ui/src/components/topology/TopologyControls.tsx
@@ -25,20 +25,46 @@ export function TopologyControls({
 }: TopologyControlsProps) {
   return (
     <div className="absolute top-4 right-4 z-10 flex items-center gap-2">
-      {/* Policy effect toggle */}
+      {/* Policy effect toggle + legend */}
       {onShowPolicyEffectChange && (
-        <button
-          onClick={() => onShowPolicyEffectChange(!showPolicyEffect)}
-          className={`flex items-center gap-1.5 px-2.5 py-1.5 text-xs rounded-lg border transition-colors ${
-            showPolicyEffect
-              ? 'bg-indigo-600 text-white border-indigo-600'
-              : 'bg-theme-surface/90 backdrop-blur text-theme-text-secondary border-theme-border hover:text-theme-text-primary'
-          }`}
-          title="Show NetworkPolicy effects on edges"
-        >
-          <ShieldCheck className="w-3.5 h-3.5" />
-          Policies
-        </button>
+        <>
+          {showPolicyEffect && (
+            <div
+              className="flex items-center gap-2 px-2.5 py-1.5 text-[10px] uppercase tracking-wide rounded-lg border bg-theme-surface/90 backdrop-blur text-theme-text-secondary border-theme-border"
+              role="legend"
+              aria-label="NetworkPolicy effect legend"
+            >
+              <span className="flex items-center gap-1">
+                <span className="inline-block w-3 h-[2px]" style={{ background: '#10b981' }} />
+                allowed
+              </span>
+              <span className="flex items-center gap-1">
+                <span
+                  className="inline-block w-3 h-[2.5px]"
+                  style={{ background: 'repeating-linear-gradient(90deg, #ef4444 0 4px, transparent 4px 6px)' }}
+                />
+                blocked
+              </span>
+              <span className="flex items-center gap-1">
+                <span className="inline-block w-3 h-[2px]" style={{ background: '#f59e0b' }} />
+                unprotected
+              </span>
+            </div>
+          )}
+          <button
+            onClick={() => onShowPolicyEffectChange(!showPolicyEffect)}
+            className={`flex items-center gap-1.5 px-2.5 py-1.5 text-xs rounded-lg border transition-colors ${
+              showPolicyEffect
+                ? 'bg-indigo-600 text-white border-indigo-600'
+                : 'bg-theme-surface/90 backdrop-blur text-theme-text-secondary border-theme-border hover:text-theme-text-primary'
+            }`}
+            title="Show NetworkPolicy effects on edges (allowed / blocked / unprotected)"
+            aria-pressed={showPolicyEffect}
+          >
+            <ShieldCheck className="w-3.5 h-3.5" />
+            Policies
+          </button>
+        </>
       )}
 
       {/* Grouping selector */}

--- a/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
+++ b/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
@@ -41,7 +41,31 @@ const EDGE_COLORS = {
   'uses': '#ec4899',       // Pink for HPA
 } as const
 
-function getEdgeColor(type: string, isTrafficView: boolean): string {
+// Policy-effect overlay colors (SKY-832 bug 62). When the user toggles
+// the "Policies" button, the backend annotates each edge with one of
+// these effects. The toggle previously had no visible result on the
+// canvas because the edge renderer didn't consult the field at all.
+//   - allowed:     a NetworkPolicy explicitly allows this edge
+//   - blocked:     a NetworkPolicy denies this edge (this is the
+//                  signal the user most wants to see)
+//   - unprotected: no NetworkPolicy applies (default-allow)
+const POLICY_EFFECT_COLORS = {
+  allowed: '#10b981',     // emerald — explicitly permitted
+  blocked: '#ef4444',     // red     — denied by policy
+  unprotected: '#f59e0b', // amber   — no policy in effect
+} as const
+
+export function getEdgeColor(
+  type: string,
+  isTrafficView: boolean,
+  policyEffect?: 'allowed' | 'blocked' | 'unprotected',
+): string {
+  // Policy effect, when present, takes priority over both view-mode
+  // and per-type colors so the user can actually see the policy
+  // overlay they asked for.
+  if (policyEffect && POLICY_EFFECT_COLORS[policyEffect]) {
+    return POLICY_EFFECT_COLORS[policyEffect]
+  }
   if (isTrafficView) {
     // In traffic view, use green for all edges
     return '#22c55e'
@@ -52,15 +76,29 @@ function getEdgeColor(type: string, isTrafficView: boolean): string {
 // Memoized edge style cache to avoid creating new objects on every render
 const edgeStyleCache = new Map<string, React.CSSProperties>()
 
-function getEdgeStyle(type: string, isTrafficView: boolean, isTrafficEdge: boolean, animated: boolean): React.CSSProperties {
-  const cacheKey = `${type}-${isTrafficView}-${isTrafficEdge}-${animated}`
+export function getEdgeStyle(
+  type: string,
+  isTrafficView: boolean,
+  isTrafficEdge: boolean,
+  animated: boolean,
+  policyEffect?: 'allowed' | 'blocked' | 'unprotected',
+): React.CSSProperties {
+  const cacheKey = `${type}-${isTrafficView}-${isTrafficEdge}-${animated}-${policyEffect ?? 'none'}`
   let style = edgeStyleCache.get(cacheKey)
   if (!style) {
-    const edgeColor = getEdgeColor(type, isTrafficView)
+    const edgeColor = getEdgeColor(type, isTrafficView, policyEffect)
+    // 'blocked' edges get a wider, dashed stroke so they read as
+    // "this connection is being denied" even on dense graphs.
+    const baseWidth = isTrafficView ? 2 : 1.5
     style = {
       stroke: edgeColor,
-      strokeWidth: isTrafficView ? 2 : 1.5,
-      strokeDasharray: isTrafficView && isTrafficEdge && animated ? '5 5' : undefined,
+      strokeWidth: policyEffect === 'blocked' ? baseWidth + 0.5 : baseWidth,
+      strokeDasharray:
+        policyEffect === 'blocked'
+          ? '6 4'
+          : isTrafficView && isTrafficEdge && animated
+            ? '5 5'
+            : undefined,
     }
     edgeStyleCache.set(cacheKey, style)
   }
@@ -124,9 +162,16 @@ function buildEdges(
     if (seenEdgeIds.has(edgeId)) continue
     seenEdgeIds.add(edgeId)
 
-    const edgeColor = getEdgeColor(edge.type, isTrafficView)
+    const edgeColor = getEdgeColor(edge.type, isTrafficView, edge.policyEffect)
     const isTrafficEdge = edge.type === 'routes-to' || edge.type === 'exposes'
-    const animated = enableAnimations && isTrafficView && isTrafficEdge
+    // `blocked` edges should never animate — animation reads as
+    // "traffic is flowing", which is the opposite of what `blocked`
+    // means.
+    const animated =
+      enableAnimations &&
+      isTrafficView &&
+      isTrafficEdge &&
+      edge.policyEffect !== 'blocked'
 
     edges.push({
       id: edgeId,
@@ -140,7 +185,7 @@ function buildEdges(
         width: 12,
         height: 12,
       },
-      style: getEdgeStyle(edge.type, isTrafficView, isTrafficEdge, animated),
+      style: getEdgeStyle(edge.type, isTrafficView, isTrafficEdge, animated, edge.policyEffect),
     })
   }
 

--- a/packages/k8s-ui/src/components/topology/edge-style.test.ts
+++ b/packages/k8s-ui/src/components/topology/edge-style.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getEdgeColor, getEdgeStyle } from './TopologyGraph'
+
+// SKY-832 bug 62: the "Policies" button toggled state and shipped a
+// `?policyEffect=true` to the backend, but the resulting per-edge
+// `policyEffect` field on the topology response was never consulted
+// when computing edge color / style. Toggling the button therefore
+// had zero visible effect on the canvas.
+//
+// These tests pin the priority rule (policy effect overrides view-mode
+// and per-type colors) and the "blocked" presentation (red + dashed +
+// thicker stroke).
+
+describe('getEdgeColor', () => {
+  it('uses the per-type palette in resource view when no policy effect', () => {
+    expect(getEdgeColor('routes-to', false)).toBe('#22c55e')
+    expect(getEdgeColor('exposes', false)).toBe('#3b82f6')
+    expect(getEdgeColor('manages', false)).toBe('#64748b')
+    expect(getEdgeColor('configures', false)).toBe('#f59e0b')
+    expect(getEdgeColor('uses', false)).toBe('#ec4899')
+  })
+
+  it('uses traffic-green for every edge in traffic view', () => {
+    expect(getEdgeColor('routes-to', true)).toBe('#22c55e')
+    expect(getEdgeColor('manages', true)).toBe('#22c55e')
+  })
+
+  it('falls back to gray for unknown edge types', () => {
+    expect(getEdgeColor('unknown-type', false)).toBe('#64748b')
+  })
+
+  it('policy-effect overrides per-type color in resource view', () => {
+    expect(getEdgeColor('routes-to', false, 'allowed')).toBe('#10b981')
+    expect(getEdgeColor('routes-to', false, 'blocked')).toBe('#ef4444')
+    expect(getEdgeColor('routes-to', false, 'unprotected')).toBe('#f59e0b')
+  })
+
+  it('policy-effect overrides traffic-view color too', () => {
+    expect(getEdgeColor('routes-to', true, 'blocked')).toBe('#ef4444')
+    expect(getEdgeColor('exposes', true, 'allowed')).toBe('#10b981')
+  })
+
+  it('falls through to base behaviour for an unrecognised effect string', () => {
+    // Defensive: an unexpected string from the backend should not
+    // poison the renderer.
+    expect(
+      getEdgeColor('routes-to', false, 'mystery' as 'allowed'),
+    ).toBe('#22c55e')
+  })
+})
+
+describe('getEdgeStyle', () => {
+  beforeEach(() => {
+    // The implementation memoizes by composite key; the cache lives
+    // for the lifetime of the module under test. That's fine for
+    // production but means tests for different inputs need distinct
+    // keys, which they naturally do.
+  })
+
+  it('blocked edges render red, dashed, and thicker than the base width', () => {
+    const style = getEdgeStyle('routes-to', false, true, true, 'blocked')
+    expect(style.stroke).toBe('#ef4444')
+    expect(style.strokeDasharray).toBe('6 4')
+    // Base width in resource view is 1.5; blocked adds 0.5.
+    expect(style.strokeWidth).toBe(2)
+  })
+
+  it('blocked in traffic view also gets the +0.5 width bump', () => {
+    const style = getEdgeStyle('routes-to', true, true, true, 'blocked')
+    expect(style.strokeWidth).toBe(2.5) // traffic base 2 + 0.5
+    expect(style.strokeDasharray).toBe('6 4')
+  })
+
+  it('allowed/unprotected use the policy color but keep the base presentation', () => {
+    const allowed = getEdgeStyle('routes-to', false, true, false, 'allowed')
+    expect(allowed.stroke).toBe('#10b981')
+    expect(allowed.strokeWidth).toBe(1.5)
+    // Not animated, not blocked → no dash.
+    expect(allowed.strokeDasharray).toBeUndefined()
+
+    const unprotected = getEdgeStyle('routes-to', false, true, false, 'unprotected')
+    expect(unprotected.stroke).toBe('#f59e0b')
+    expect(unprotected.strokeWidth).toBe(1.5)
+  })
+
+  it('without a policy effect, traffic-edge animations still produce the dotted dash', () => {
+    const animated = getEdgeStyle('routes-to', true, true, true)
+    expect(animated.strokeDasharray).toBe('5 5')
+    expect(animated.stroke).toBe('#22c55e')
+  })
+
+  it('static traffic edges (animated=false) have no dash', () => {
+    const style = getEdgeStyle('routes-to', true, true, false)
+    expect(style.strokeDasharray).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Closes part of [SKY-832](https://linear.app/skyhook/issue/SKY-832).

## Symptom

Clicking the "Policies" button in the topology toolbar highlighted it blue, opened a `?policyEffect=true` SSE stream, and… changed nothing visible on the canvas.

## Root cause

The backend correctly annotates each edge with a `policyEffect` of `allowed`, `blocked`, or `unprotected` when policy effect is enabled, and the field is plumbed through to `TopologyEdge` in the shared types. But `buildEdges` / `getEdgeColor` / `getEdgeStyle` in `TopologyGraph.tsx` never consulted that field, so the edge colour and stroke were chosen entirely from `edge.type` / `viewMode`. The user's "Policies" click effectively had no rendering side-effect.

## Fix

- `getEdgeColor` and `getEdgeStyle` now accept an optional `policyEffect` and prioritise it over view-mode and per-type colors:
  - `allowed`     → emerald (`#10b981`)
  - `blocked`     → red (`#ef4444`), thicker (+0.5), dashed (`6 4`), and never animated (animation reads as "traffic flowing", opposite of `blocked`).
  - `unprotected` → amber (`#f59e0b`)
- `buildEdges` passes `edge.policyEffect` through to both helpers, and to the React Flow `markerEnd.color` so arrowheads stay in sync.
- `TopologyControls` now renders a small inline legend next to the toggle whenever it's on, so the colour meanings are obvious without scrolling/docs. Also adds `aria-pressed` to the button for screen readers.

## Tests

New `packages/k8s-ui/src/components/topology/edge-style.test.ts` (10 cases) pins:

- Per-type palette unchanged when no policy effect.
- Traffic-view green unchanged when no policy effect.
- Policy effect overrides per-type and traffic-view colours.
- `blocked` ⇒ red + dashed + +0.5 stroke (in both view modes).
- Unknown policy strings fall through gracefully.
- Animation flag still produces the dotted dash for traffic edges when no policy effect.

## Out of scope

Bugs 30 and 31 were also tracked under SKY-832:

- **30**: "Show All" clips the top row of `GatewayClass` nodes — needs an `elk` padding / `fitViewOptions` audit.
- **31**: Traffic mode renders an empty canvas while the sidebar reports 241/242 resources visible — needs investigation of the traffic-view edge filter.

Both will be follow-up PRs against this issue.

## Test plan

- [x] `npm test` (k8s-ui) — 79 passed (10 new for edge styling).
- [x] `npm run tsc` (k8s-ui + web) — clean.
- [x] `npm run build` (web) — clean.
- [ ] Manual: in the topology view, click "Policies"; verify that allowed edges turn green, blocked edges turn red + dashed + thicker, and the legend strip appears next to the toggle.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core topology edge rendering and animation behavior, which could change visuals/perf across large graphs, but is isolated to UI styling with added unit coverage.
> 
> **Overview**
> Makes the **"Policies"** toggle actually affect the topology canvas by threading each edge’s `policyEffect` into edge rendering.
> 
> `getEdgeColor`/`getEdgeStyle` now prioritize `policyEffect` (allowed/blocked/unprotected) over view-mode/type colors, render `blocked` edges as red + dashed + thicker, and prevent `blocked` edges from animating; arrowhead colors are kept in sync. The toolbar also shows an inline legend when enabled and adds `aria-pressed` for accessibility, with new Vitest coverage pinning the styling/priority rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a7cbcd5d5a7ca66b36b37fb9b59311b4110c280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->