### PR TITLE
chart: grant read on Cluster API, Contour, Trivy CRDs by default

### DIFF
--- a/deploy/helm/radar/templates/clusterrole.yaml
+++ b/deploy/helm/radar/templates/clusterrole.yaml
@@ -154,6 +154,21 @@ rules:
     resources: ["*"]
     verbs: ["get", "list", "watch"]
   {{- end }}
+  {{- if .Values.rbac.crdGroups.clusterApi }}
+  - apiGroups:
+      - "cluster.x-k8s.io"
+      - "infrastructure.cluster.x-k8s.io"
+      - "controlplane.cluster.x-k8s.io"
+      - "bootstrap.cluster.x-k8s.io"
+      - "addons.cluster.x-k8s.io"
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.contour }}
+  - apiGroups: ["projectcontour.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
   {{- if .Values.rbac.crdGroups.crossplane }}
   - apiGroups: ["crossplane.io", "pkg.crossplane.io", "apiextensions.crossplane.io"]
     resources: ["*"]
@@ -286,6 +301,11 @@ rules:
   {{- end }}
   {{- if .Values.rbac.crdGroups.traefik }}
   - apiGroups: ["traefik.io", "traefik.containo.us"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.trivy }}
+  - apiGroups: ["aquasecurity.github.io"]
     resources: ["*"]
     verbs: ["get", "list", "watch"]
   {{- end }}

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -79,6 +79,8 @@ rbac:
     awx: true               # awx.ansible.com
     certManager: true       # cert-manager.io
     cloudnativePg: true     # cloudnative-pg.io
+    clusterApi: true        # *.cluster.x-k8s.io (CAPI core + infrastructure / controlplane / bootstrap / addons)
+    contour: true           # projectcontour.io
     crossplane: true        # crossplane.io, pkg.crossplane.io
     descheduler: true       # descheduler.alpha.kubernetes.io
     envoyGateway: true      # gateway.envoyproxy.io
@@ -106,6 +108,7 @@ rbac:
     strimzi: true           # strimzi.io, kafka.strimzi.io
     tekton: true            # tekton.dev
     traefik: true           # traefik.io, traefik.containo.us
+    trivy: true             # aquasecurity.github.io
     velero: true            # velero.io
 
   # Additional CRD API groups for custom/unlisted CRDs


### PR DESCRIPTION
## Why

Radar already ships dedicated renderers for **Cluster API** (provider chains, control-plane wiring), **Contour** (HTTPProxy + middlewares), and **Trivy** (VulnerabilityReport, ConfigAuditReport). The chart's `rbac.crdGroups` block forgot to include them, so users running the typed Helm install with default values land on a *"needs read on \`cluster.x-k8s.io\`"* hint in the UI rather than the actual integrated view.

Those three are advertised as out-of-the-box on `radarhq.io/docs/features/integrations` and in `docs/integrations.md` (this repo). Defaults should match the docs.

## What changed

`deploy/helm/radar/values.yaml` - three new flags under `rbac.crdGroups`, default `true`, alphabetical order:

\`\`\`yaml
clusterApi: true        # *.cluster.x-k8s.io (CAPI core + infrastructure / controlplane / bootstrap / addons)
contour: true           # projectcontour.io
trivy: true             # aquasecurity.github.io
\`\`\`

`deploy/helm/radar/templates/clusterrole.yaml` - three matching \`{{- if .Values.rbac.crdGroups.X }}\` blocks. CAPI gets all five sub-groups (CAPI groups split across infrastructure / controlplane / bootstrap / addons providers), the others are single-group.

## Opting out

Cluster admins who don't run any of these can disable per-group like any existing entry: \`--set rbac.crdGroups.contour=false\`, etc. The wildcard \`rbac.crdGroups.all=true\` continues to override individual flags.

## Verified

\`helm template ./deploy/helm/radar --name-template radar\` emits the three new \`apiGroups\` blocks in the ClusterRole. No other template output changes.

## Risk

Strictly additive: existing values.yaml without these flags falls through to the per-group default of \`true\`. Existing users who explicitly disable these groups would be unaffected. The new ClusterRole grants are read-only (\`get\`, \`list\`, \`watch\`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Helm RBAC change that only expands read-only permissions for specific CRD groups behind configurable flags.
> 
> **Overview**
> Updates the Helm chart to **grant default read-only access** (`get`, `list`, `watch`) to additional CRD API groups used by Radar integrations.
> 
> Adds new `rbac.crdGroups` flags in `values.yaml` (`clusterApi`, `contour`, `trivy`, default `true`) and wires them into `templates/clusterrole.yaml`, including the full set of Cluster API sub-groups (`cluster.x-k8s.io`, `infrastructure.*`, `controlplane.*`, `bootstrap.*`, `addons.*`) plus `projectcontour.io` and `aquasecurity.github.io`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36b03a01469f7c7564e463cec838fead6ff0332f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->