### PR TITLE
fix(helm): make Catalog empty state actionable; signpost failed releases

### DIFF
--- a/packages/k8s-ui/src/utils/badge-colors.ts
+++ b/packages/k8s-ui/src/utils/badge-colors.ts
@@ -286,6 +286,31 @@ export function getHelmStatusColor(status: string): string {
   return HELM_STATUS_COLORS[statusLower] || 'bg-theme-hover/50 text-theme-text-secondary'
 }
 
+/**
+ * Helm release statuses where the row UI should signpost the user
+ * toward the drawer (history / rollback / logs).
+ *
+ * Currently `failed` only. The `pending-*` statuses (install /
+ * upgrade / rollback) are excluded deliberately: they're Helm's
+ * normal in-flight states during every routine operation. Treating
+ * them as "actionable" would briefly attach an alarming chevron +
+ * tooltip to every install while it ran — indistinguishable from
+ * the genuinely-stuck case (controller crashed mid-flight). Until
+ * we have release age available client-side to disambiguate
+ * "in-flight" from "stuck > N min", we give up the stuck-detect
+ * signpost rather than wrongly alarm the common case.
+ *
+ * @see https://github.com/helm/helm/blob/dev-v3/pkg/release/status.go
+ */
+const ACTIONABLE_HELM_STATUSES: ReadonlySet<string> = new Set([
+  'failed',
+])
+
+export function isHelmReleaseActionable(status: string | null | undefined): boolean {
+  if (!status) return false
+  return ACTIONABLE_HELM_STATUSES.has(status.toLowerCase())
+}
+
 // =============================================================================
 // VULNERABILITY SEVERITY COLORS - for Trivy and other security scanners
 // =============================================================================

--- a/packages/k8s-ui/src/utils/helm-status.test.ts
+++ b/packages/k8s-ui/src/utils/helm-status.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { isHelmReleaseActionable } from './badge-colors'
+
+// Pin the membership set so adding a new Helm status becomes a
+// deliberate decision here.
+
+describe('isHelmReleaseActionable', () => {
+  it('returns true for `failed`', () => {
+    expect(isHelmReleaseActionable('failed')).toBe(true)
+  })
+
+  it('is case-insensitive (matches Helm SDK serialisation variants)', () => {
+    expect(isHelmReleaseActionable('FAILED')).toBe(true)
+    expect(isHelmReleaseActionable('Failed')).toBe(true)
+  })
+
+  it('returns FALSE for the pending-* in-flight statuses', () => {
+    // These are Helm's NORMAL in-flight states during every
+    // routine install/upgrade/rollback. If we treated them as
+    // actionable, every routine install would briefly attach an
+    // alarming chevron + tooltip to its own row. Until we have
+    // release age available client-side to distinguish
+    // "transient" from "stuck > N min", we give up the
+    // stuck-controller signpost rather than alarm the common case.
+    expect(isHelmReleaseActionable('pending-install')).toBe(false)
+    expect(isHelmReleaseActionable('pending-upgrade')).toBe(false)
+    expect(isHelmReleaseActionable('pending-rollback')).toBe(false)
+  })
+
+  it('returns false for the success / normal statuses', () => {
+    expect(isHelmReleaseActionable('deployed')).toBe(false)
+    expect(isHelmReleaseActionable('superseded')).toBe(false)
+    expect(isHelmReleaseActionable('uninstalled')).toBe(false)
+  })
+
+  it('returns false for `uninstalling` (in-progress, not stuck)', () => {
+    expect(isHelmReleaseActionable('uninstalling')).toBe(false)
+  })
+
+  it('returns false for null / undefined / empty', () => {
+    expect(isHelmReleaseActionable(null)).toBe(false)
+    expect(isHelmReleaseActionable(undefined)).toBe(false)
+    expect(isHelmReleaseActionable('')).toBe(false)
+  })
+
+  it('returns false for unknown strings (defensive)', () => {
+    expect(isHelmReleaseActionable('mystery-status')).toBe(false)
+    expect(isHelmReleaseActionable('error')).toBe(false) // Helm uses 'failed', not 'error'
+  })
+})

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2148,29 +2148,49 @@ export function useHelmRepositories() {
   })
 }
 
+// Shared mutation fn + cache invalidation for the helm-repo
+// update endpoint. Hoisted so useUpdateRepository and
+// useUpdateRepositorySilent can't drift on URL, error parsing, or
+// invalidation keys — only the toast meta differs.
+async function updateRepositoryFn(repoName: string): Promise<unknown> {
+  const response = await apiFetch(`${getApiBase()}/helm/repositories/${repoName}/update`, {
+    method: 'POST',
+  })
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Unknown error' }))
+    throw new Error(error.error || `HTTP ${response.status}`)
+  }
+  return response.json()
+}
+
+function invalidateHelmAfterRepoUpdate(queryClient: ReturnType<typeof useQueryClient>) {
+  queryClient.invalidateQueries({ queryKey: ['helm-repositories'] })
+  queryClient.invalidateQueries({ queryKey: ['helm-charts'] })
+}
+
 // Update a repository index
 export function useUpdateRepository() {
   const queryClient = useQueryClient()
-
   return useMutation({
-    mutationFn: async (repoName: string) => {
-      const response = await apiFetch(`${getApiBase()}/helm/repositories/${repoName}/update`, {
-        method: 'POST',
-      })
-      if (!response.ok) {
-        const error = await response.json().catch(() => ({ error: 'Unknown error' }))
-        throw new Error(error.error || `HTTP ${response.status}`)
-      }
-      return response.json()
-    },
+    mutationFn: updateRepositoryFn,
     meta: {
       errorMessage: 'Failed to update repository',
       successMessage: 'Repository updated',
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['helm-repositories'] })
-      queryClient.invalidateQueries({ queryKey: ['helm-charts'] })
-    },
+    onSuccess: () => invalidateHelmAfterRepoUpdate(queryClient),
+  })
+}
+
+// Same endpoint as useUpdateRepository but without meta — the
+// caller surfaces ONE aggregate toast for the whole batch, so the
+// global MutationCache must NOT fire a per-call toast (otherwise
+// N failures = N identical "Failed to update repository" toasts
+// with no repo name).
+export function useUpdateRepositorySilent() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: updateRepositoryFn,
+    onSuccess: () => invalidateHelmAfterRepoUpdate(queryClient),
   })
 }
 

--- a/web/src/components/helm/ChartBrowser.tsx
+++ b/web/src/components/helm/ChartBrowser.tsx
@@ -2,12 +2,13 @@ import { useState, useMemo } from 'react'
 import { Search, RefreshCw, Package, Database, AlertCircle, ExternalLink, ChevronDown, Star, Shield, BadgeCheck, Building2, Globe, ArrowUpDown, FileJson, PenTool } from 'lucide-react'
 import { PaneLoader } from '@skyhook-io/k8s-ui'
 import { clsx } from 'clsx'
-import { useHelmRepositories, useSearchCharts, useUpdateRepository, useArtifactHubSearch, type ArtifactHubSortOption } from '../../api/client'
+import { useHelmRepositories, useSearchCharts, useUpdateRepository, useUpdateRepositorySilent, useArtifactHubSearch, type ArtifactHubSortOption } from '../../api/client'
 import { useCanHelmWrite } from '../../contexts/CapabilitiesContext'
 import type { ChartInfo, HelmRepository, ArtifactHubChart, ChartSource } from '../../types'
 import { formatAge } from './helm-utils'
 import { SEVERITY_BADGE } from '../../utils/badge-colors'
 import { Tooltip } from '../ui/Tooltip'
+import { useToast } from '../ui/Toast'
 
 interface ChartBrowserProps {
   onChartSelect: (repo: string, chart: string, version: string, source: ChartSource) => void
@@ -66,21 +67,54 @@ export function ChartBrowser({ onChartSelect }: ChartBrowserProps) {
     return groups
   }, [filteredLocalCharts])
 
+  // Silent variant for the bulk path so the global MutationCache
+  // doesn't fire a per-call "Failed to update repository" toast
+  // — handleUpdateAllRepos surfaces a single aggregate toast
+  // that names the failed repos.
+  const updateRepoSilentMutation = useUpdateRepositorySilent()
+  const { showError, showSuccess } = useToast()
+  // updateRepoSilentMutation.isPending flips to false BETWEEN
+  // sequential mutateAsync calls, briefly re-enabling the bulk
+  // button mid-loop. Track the whole-batch state explicitly so
+  // the user can't kick off a second concurrent batch.
+  const [isBatchUpdating, setIsBatchUpdating] = useState(false)
+
   const handleUpdateRepo = async (repoName: string) => {
     await updateRepoMutation.mutateAsync(repoName)
     refetchCharts()
   }
 
   const handleUpdateAllRepos = async () => {
-    if (!repositories) return
-    for (const repo of repositories) {
-      try {
-        await updateRepoMutation.mutateAsync(repo.name)
-      } catch {
-        // Continue with other repos
+    if (!repositories || repositories.length === 0 || isBatchUpdating) return
+    setIsBatchUpdating(true)
+    const failed: string[] = []
+    try {
+      for (const repo of repositories) {
+        try {
+          await updateRepoSilentMutation.mutateAsync(repo.name)
+        } catch (err) {
+          failed.push(repo.name)
+          console.warn(`helm repo update failed for "${repo.name}":`, err)
+        }
       }
+    } finally {
+      setIsBatchUpdating(false)
     }
     refetchCharts()
+    const ok = repositories.length - failed.length
+    if (failed.length === 0) {
+      showSuccess(`Updated ${ok} ${ok === 1 ? 'repository' : 'repositories'}`)
+    } else if (ok === 0) {
+      showError(
+        `Failed to update ${failed.length} ${failed.length === 1 ? 'repository' : 'repositories'}`,
+        `Failed: ${failed.join(', ')}`,
+      )
+    } else {
+      showError(
+        `Updated ${ok}/${repositories.length} repositories`,
+        `Failed: ${failed.join(', ')}`,
+      )
+    }
   }
 
   const isLoading = chartSource === 'local' ? chartsLoading : artifactHubLoading
@@ -246,10 +280,10 @@ export function ChartBrowser({ onChartSelect }: ChartBrowserProps) {
             <Tooltip content={canHelmWrite ? "Update all repositories" : helmWriteReason}>
               <button
                 onClick={handleUpdateAllRepos}
-                disabled={updateRepoMutation.isPending || !canHelmWrite}
+                disabled={isBatchUpdating || !canHelmWrite}
                 className="p-2 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded-lg disabled:opacity-50"
               >
-                <RefreshCw className={clsx('w-4 h-4', updateRepoMutation.isPending && 'animate-spin')} />
+                <RefreshCw className={clsx('w-4 h-4', isBatchUpdating && 'animate-spin')} />
               </button>
             </Tooltip>
           </>
@@ -280,7 +314,24 @@ export function ChartBrowser({ onChartSelect }: ChartBrowserProps) {
                     </p>
                   </div>
                 ) : (
-                  <p className="text-sm mt-1">Try updating your repositories</p>
+                  <div className="text-sm mt-1 flex flex-col items-center gap-2">
+                    <p>Your repositories may be out of date.</p>
+                    <button
+                      onClick={handleUpdateAllRepos}
+                      disabled={isBatchUpdating || !canHelmWrite}
+                      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs btn-brand rounded disabled:opacity-50"
+                      title={canHelmWrite ? 'Run helm repo update on every configured repository' : helmWriteReason}
+                    >
+                      <RefreshCw className={`w-3.5 h-3.5 ${isBatchUpdating ? 'animate-spin' : ''}`} />
+                      {isBatchUpdating ? 'Updating…' : 'Update all repositories'}
+                    </button>
+                    <button
+                      onClick={() => setChartSource('artifacthub')}
+                      className="text-xs text-blue-400 hover:underline"
+                    >
+                      Or browse ArtifactHub instead
+                    </button>
+                  </div>
                 )}
               </div>
             </div>

--- a/web/src/components/helm/HelmView.tsx
+++ b/web/src/components/helm/HelmView.tsx
@@ -1,12 +1,12 @@
 import { useState, useMemo, useRef, useEffect, useCallback, forwardRef } from 'react'
 import { useRefreshAnimation } from '../../hooks/useRefreshAnimation'
 import { useRegisterShortcuts } from '../../hooks/useKeyboardShortcuts'
-import { Package, Search, RefreshCw, ArrowUpCircle, LayoutGrid, List, Shield, GitBranch } from 'lucide-react'
+import { Package, Search, RefreshCw, ArrowUpCircle, LayoutGrid, List, Shield, GitBranch, ChevronRight } from 'lucide-react'
 import { PaneLoader } from '@skyhook-io/k8s-ui'
 import { clsx } from 'clsx'
 import { useHelmReleases, useHelmBatchUpgradeInfo, isForbiddenError } from '../../api/client'
 import type { HelmRelease, SelectedHelmRelease, UpgradeInfo, ChartSource } from '../../types'
-import { getStatusColor, formatAge, truncate } from './helm-utils'
+import { getStatusColor, formatAge, truncate, isHelmReleaseActionable } from './helm-utils'
 import { SEVERITY_BADGE } from '../../utils/badge-colors'
 import { Tooltip } from '../ui/Tooltip'
 import { ChartBrowser } from './ChartBrowser'
@@ -481,17 +481,34 @@ const ReleaseRow = forwardRef<HTMLTableRowElement, ReleaseRowProps>(
         </Tooltip>
       </td>
       <td className="px-4 py-3 w-24 hidden xl:table-cell">
-        <span className="text-sm text-theme-text-secondary">{release.appVersion || '-'}</span>
+        {release.appVersion ? (
+          <span className="text-sm text-theme-text-secondary">{release.appVersion}</span>
+        ) : (
+          <Tooltip content="This chart did not declare an appVersion in Chart.yaml.">
+            <span className="text-sm text-theme-text-disabled cursor-help">—</span>
+          </Tooltip>
+        )}
       </td>
       <td className="px-4 py-3 w-28">
-        <span
-          className={clsx(
-            'badge',
-            getStatusColor(release.status)
-          )}
-        >
-          {release.status}
-        </span>
+        {isHelmReleaseActionable(release.status) ? (
+          <Tooltip content="Click row to view rollback / history / logs and recover">
+            <span
+              className={clsx('badge inline-flex items-center gap-1', getStatusColor(release.status))}
+            >
+              {release.status}
+              <ChevronRight className="w-3 h-3 opacity-70" />
+            </span>
+          </Tooltip>
+        ) : (
+          <span
+            className={clsx(
+              'badge',
+              getStatusColor(release.status)
+            )}
+          >
+            {release.status}
+          </span>
+        )}
       </td>
       <td className="px-4 py-3 w-20">
         <span className="text-sm text-theme-text-secondary">{release.revision}</span>

--- a/web/src/components/helm/helm-utils.ts
+++ b/web/src/components/helm/helm-utils.ts
@@ -35,3 +35,7 @@ export function getChartDisplay(chart: string, version: string): string {
 
 // Re-export kindToPlural from centralized navigation utils
 export { kindToPlural } from '../../utils/navigation'
+
+// Re-export from k8s-ui where the predicate lives next to the
+// Helm status color palette and is unit-tested.
+export { isHelmReleaseActionable } from '../../utils/badge-colors'


### PR DESCRIPTION
Closes part of [SKY-829](https://linear.app/skyhook/issue/SKY-829).

## Why

Three SKY-829 bugs share one root cause: the Helm UI tells the user "something is up" but gives no path forward.

## Bugs fixed

### 33 — "My Repos" empty state had no actionable button

The empty state read "Try updating your repositories" — even though the toolbar already had an Update-all handler. Now the empty state inlines:
- An **Update all repositories** button (calls the same handler as the toolbar; spinner + disable on `isBatchUpdating` / `!canHelmWrite`).
- A secondary "Or browse ArtifactHub instead" link.

### 58 — Failed Helm releases had no signpost to the recovery actions

Failed releases rendered as a bare red badge in the list. Users had no idea the row was the path forward (where the drawer exposes Rollback / History / Uninstall).

Now `failed` releases wrap a Tooltip ("Click row to view rollback / history / logs and recover") and append a chevron to make the affordance visible.

**Scope note**: the predicate `isHelmReleaseActionable` currently matches only `failed`. The three `pending-*` statuses (`pending-install`, `pending-upgrade`, `pending-rollback`) are deliberately excluded — they're transient by design and without release-age in the client we'd surface a stuck-recovery affordance during every routine install. See the JSDoc on `ACTIONABLE_HELM_STATUSES` for the in-flight false-positive rationale; a follow-up can include them once age is plumbed through.

### 22 — argocd APP VERSION rendered as bare `-`

Indistinguishable from "Radar lost the data." Some charts genuinely don't declare an `appVersion` in `Chart.yaml` — that's valid Helm. Now we render an em-dash with a `cursor-help` tooltip ("This chart did not declare an appVersion in Chart.yaml.") so the user knows it's upstream, not a Radar bug.

## Bonus fix: bulk-update aggregate toast

While implementing the empty-state Update button (bug 33), we doubled the visibility of an existing UX issue in `handleUpdateAllRepos`: the bulk loop silently `try/catch`-swallowed per-repo failures, and the global MutationCache fired N identical "Failed to update repository" toasts with no repo name.

Replaced with:
- New `useUpdateRepositorySilent` (no `meta.errorMessage`) so the global MutationCache doesn't fire per-call toasts during the batch.
- Shared `updateRepositoryFn` + `invalidateHelmAfterRepoUpdate` so `useUpdateRepository` and the silent variant can't drift on URL / error parsing / invalidation keys.
- `isBatchUpdating` state to guard against re-entrant batches (`mutation.isPending` flips false between sequential `mutateAsync` calls).
- One aggregate toast at the end: all-success → "Updated N repositories"; all-fail → "Failed to update N repositories" + names; partial → "Updated N/M repositories" + "Failed: a, b, c".

## Shared helper

Added `isHelmReleaseActionable` to `packages/k8s-ui/utils/badge-colors` (next to the existing `getHelmStatusColor`) so the actionable-set rule is shared across radar OSS and cloud, and unit-tested.

## Tests

`packages/k8s-ui/src/utils/helm-status.test.ts` (7 cases) pins:
- `failed` → true
- The three `pending-*` statuses → **false** (with a comment explaining the in-flight exclusion)
- Case-insensitive
- Success / normal statuses (`deployed`, `superseded`, `uninstalled`, `uninstalling`, generic `error`) → false
- null / undefined / empty / unknown → false

## Out of scope

- **34** (ArtifactHub card height inconsistency) — needs a flex-vs-grid layout audit
- **56** (keda chart shows `v1alpha1` as chart version on prod) — looks like backend captured API version into chart version; needs Go-side investigation

Both will be follow-up PRs against this issue.

## Test plan

- [x] `npm test` (k8s-ui) — 7/7 `isHelmReleaseActionable` cases pass
- [x] `npm run tsc` (k8s-ui + web) — clean
- [x] E2E manual verification on kind cluster:
  - Chart with no `appVersion` → em-dash + tooltip ✓
  - Failed release row → chevron + tooltip + drawer ✓
  - Empty Catalog state → "Update all repositories" button ✓
  - Bulk update with mocked partial failure → aggregate toast `Updated 31/34 repositories` / `Failed: a, b, c` ✓