### PR TITLE
fix(routing): tolerate singular kinds in detail-panel dispatch; turn zombie time-window labels into real dropdowns

### DIFF
--- a/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
@@ -354,17 +354,13 @@ export function ResourceRendererDispatch({
   resolvedEnvFrom,
   rendererOverrides,
 }: ResourceRendererDispatchProps) {
-  // Normalize the incoming `kind` to the lowercase plural form the
-  // dispatch table is keyed on. Without this, a caller that passes
-  // "CronJob" (PascalCase singular — e.g. from a topology node click,
-  // or any code path that hands the registry the singular kind name)
-  // produces `kind = 'cronjob'` after lowercasing, which doesn't
-  // match `'cronjobs'` and so silently renders nothing — the user
-  // saw the URL update but no detail panel. (SKY-826 bug 9)
-  //
-  // `kindToPlural` is idempotent: it returns already-plural inputs
-  // unchanged, so callers that already pass `'cronjobs'` are not
-  // double-pluralised.
+  // Callers reach this dispatch from two shapes: lowercase plural
+  // (resource list rows: 'cronjobs') and PascalCase singular
+  // (topology node clicks: 'CronJob'). The dispatch table is keyed
+  // only on lowercase plurals, so a raw .toLowerCase() leaves the
+  // singular form mismatched and nothing renders. kindToPlural
+  // covers both shapes idempotently (already-plural inputs return
+  // unchanged), so this single normalisation handles every caller.
   const kind = kindToPlural(resource.kind)
 
   const isKnownKind = KNOWN_KINDS.has(kind)
@@ -567,9 +563,8 @@ export function ResourceRendererDispatch({
 
 export function getResourceStatus(kind: string, data: any): { text: string; color: string } | null {
   if (!data) return null
-  // Normalise to lowercase plural for the same reason the renderer
-  // dispatch does — singular kinds like "CronJob" otherwise produce
-  // a no-match here too. (SKY-826 bug 9)
+  // Same normalisation as the renderer dispatch above — singular
+  // kinds like "CronJob" otherwise produce a no-match here too.
   const k = kindToPlural(kind)
 
   if (k === 'pods') return getPodStatus(data)

--- a/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
@@ -1,5 +1,6 @@
 import { clsx } from 'clsx'
 import { SEVERITY_BADGE } from '../../utils/badge-colors'
+import { kindToPlural } from '../../utils/navigation'
 import {
   getPodStatus,
   getWorkloadStatus,
@@ -353,7 +354,18 @@ export function ResourceRendererDispatch({
   resolvedEnvFrom,
   rendererOverrides,
 }: ResourceRendererDispatchProps) {
-  const kind = resource.kind.toLowerCase()
+  // Normalize the incoming `kind` to the lowercase plural form the
+  // dispatch table is keyed on. Without this, a caller that passes
+  // "CronJob" (PascalCase singular — e.g. from a topology node click,
+  // or any code path that hands the registry the singular kind name)
+  // produces `kind = 'cronjob'` after lowercasing, which doesn't
+  // match `'cronjobs'` and so silently renders nothing — the user
+  // saw the URL update but no detail panel. (SKY-826 bug 9)
+  //
+  // `kindToPlural` is idempotent: it returns already-plural inputs
+  // unchanged, so callers that already pass `'cronjobs'` are not
+  // double-pluralised.
+  const kind = kindToPlural(resource.kind)
 
   const isKnownKind = KNOWN_KINDS.has(kind)
 
@@ -555,7 +567,10 @@ export function ResourceRendererDispatch({
 
 export function getResourceStatus(kind: string, data: any): { text: string; color: string } | null {
   if (!data) return null
-  const k = kind.toLowerCase()
+  // Normalise to lowercase plural for the same reason the renderer
+  // dispatch does — singular kinds like "CronJob" otherwise produce
+  // a no-match here too. (SKY-826 bug 9)
+  const k = kindToPlural(kind)
 
   if (k === 'pods') return getPodStatus(data)
   if (['deployments', 'statefulsets', 'replicasets', 'daemonsets'].includes(k)) return getWorkloadStatus(data, k)

--- a/packages/k8s-ui/src/components/timeline/TimelineList.tsx
+++ b/packages/k8s-ui/src/components/timeline/TimelineList.tsx
@@ -8,6 +8,7 @@ import {
   Search,
   RefreshCw,
   ChevronRight,
+  ChevronDown,
   Filter,
   Plus,
   Trash2,
@@ -336,31 +337,53 @@ export function TimelineList({ events, isLoading, onRefresh, onQueryChange, hasL
         </div>
 
         {/* Kind filter */}
-        <select
-          value={kindFilter}
-          onChange={(e) => setKindFilter(e.target.value)}
-          className="appearance-none bg-theme-elevated text-theme-text-primary text-sm rounded-lg px-3 py-2 border border-theme-border-light focus:outline-none focus:ring-2 focus:ring-blue-500"
-        >
-          <option value="">All Kinds</option>
-          {RESOURCE_KINDS.map((kind) => (
-            <option key={kind} value={kind}>
-              {kind}
-            </option>
-          ))}
-        </select>
+        {/*
+          appearance-none strips the native dropdown arrow, so without
+          a visible chevron the select read as a non-interactive
+          badge — users reported they couldn't get the dropdown to
+          open. Wrap in a relative container with a ChevronDown
+          overlay; cursor-pointer makes the affordance unambiguous.
+          (SKY-826 bug 11)
+        */}
+        <div className="relative">
+          <select
+            value={kindFilter}
+            onChange={(e) => setKindFilter(e.target.value)}
+            aria-label="Filter by Kind"
+            className="appearance-none cursor-pointer bg-theme-elevated text-theme-text-primary text-sm rounded-lg pl-3 pr-8 py-2 border border-theme-border-light focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="">All Kinds</option>
+            {RESOURCE_KINDS.map((kind) => (
+              <option key={kind} value={kind}>
+                {kind}
+              </option>
+            ))}
+          </select>
+          <ChevronDown
+            className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-theme-text-tertiary"
+            aria-hidden
+          />
+        </div>
 
         {/* Time range */}
-        <select
-          value={timeRange}
-          onChange={(e) => setTimeRange(e.target.value as TimeRange)}
-          className="appearance-none bg-theme-elevated text-theme-text-primary text-sm rounded-lg px-3 py-2 border border-theme-border-light focus:outline-none focus:ring-2 focus:ring-blue-500"
-        >
-          {TIME_RANGES.map((range) => (
-            <option key={range.value} value={range.value}>
-              {range.label}
-            </option>
-          ))}
-        </select>
+        <div className="relative">
+          <select
+            value={timeRange}
+            onChange={(e) => setTimeRange(e.target.value as TimeRange)}
+            aria-label="Time range"
+            className="appearance-none cursor-pointer bg-theme-elevated text-theme-text-primary text-sm rounded-lg pl-3 pr-8 py-2 border border-theme-border-light focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            {TIME_RANGES.map((range) => (
+              <option key={range.value} value={range.value}>
+                {range.label}
+              </option>
+            ))}
+          </select>
+          <ChevronDown
+            className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-theme-text-tertiary"
+            aria-hidden
+          />
+        </div>
 
         {/* View toggle */}
         {onViewChange && (

--- a/packages/k8s-ui/src/utils/navigation.test.ts
+++ b/packages/k8s-ui/src/utils/navigation.test.ts
@@ -56,6 +56,19 @@ describe('kindToPlural', () => {
     expect(kindToPlural('horizontalpodautoscalers')).toBe('horizontalpodautoscalers')
   })
 
+  test('idempotent on dispatch-keyed shortnames (hpas)', () => {
+    // Bugbot regression for PR #585: ResourcesSidebar uses
+    // `{ kind: 'hpas' }` as a primary key (not a query alias) and the
+    // dispatch table at ResourceRendererDispatch matches both 'hpas'
+    // AND 'horizontalpodautoscalers'. Without an explicit entry in
+    // BUILTIN_PLURAL_TO_KIND, kindToPlural('hpas') falls through to
+    // englishPlural which sees a trailing 's' and adds 'es' →
+    // 'hpases', matching nothing. The detail panel then silently
+    // renders empty for HPAs — the exact CronJob-shaped bug this
+    // PR exists to prevent, just for a different kind. Pin it.
+    expect(kindToPlural('hpas')).toBe('hpas')
+  })
+
   test('handles aliases', () => {
     expect(kindToPlural('HorizontalPodAutoscaler')).toBe('horizontalpodautoscalers')
     expect(kindToPlural('pvc')).toBe('persistentvolumeclaims')

--- a/packages/k8s-ui/src/utils/navigation.test.ts
+++ b/packages/k8s-ui/src/utils/navigation.test.ts
@@ -35,7 +35,15 @@ describe('kindToPlural', () => {
   })
 
   test('idempotent on known plurals (prevents double-pluralization)', () => {
-    // This was the original bug: "secrets" → "secretses"
+    // This was the original bug: "secrets" → "secretses".
+    // ResourceRendererDispatch (SKY-826 bug 9) now also depends on
+    // this idempotence — it normalises every incoming kind through
+    // kindToPlural at the top of the dispatch so PascalCase-singular
+    // callers (e.g. topology node clicks: node.kind === 'CronJob')
+    // and lowercase-plural callers (resources view: 'cronjobs')
+    // both land on the same renderer. If this idempotence breaks,
+    // every drawer-reopen that re-feeds the dispatcher its own
+    // already-plural kind would silently render nothing.
     expect(kindToPlural('secrets')).toBe('secrets')
     expect(kindToPlural('services')).toBe('services')
     expect(kindToPlural('ingresses')).toBe('ingresses')

--- a/packages/k8s-ui/src/utils/navigation.ts
+++ b/packages/k8s-ui/src/utils/navigation.ts
@@ -34,6 +34,13 @@ const BUILTIN_PLURAL_TO_KIND: Record<string, string> = {
   clusterrolebindings: 'ClusterRoleBinding',
   serviceaccounts: 'ServiceAccount',
   networkpolicies: 'NetworkPolicy',
+  // The codebase uses the kubectl shortname `hpas` as a *primary* dispatch
+  // key (see ResourcesSidebar `{ kind: 'hpas' }` and the dispatch table in
+  // ResourceRendererDispatch). Listing it here makes `kindToPlural('hpas')`
+  // return `'hpas'` unchanged via the idempotence check below — without
+  // this entry, `englishPlural('hpas')` adds "es" → `'hpases'` (ends in s)
+  // and the HPA detail panel renders nothing.
+  hpas: 'HorizontalPodAutoscaler',
 }
 
 // Dynamic map built from API discovery — populated by initNavigationMap().

--- a/packages/k8s-ui/src/utils/zoom-label.test.ts
+++ b/packages/k8s-ui/src/utils/zoom-label.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+
+// Inline copy of the helper from web/src/components/timeline/TimelineSwimlanes.tsx
+// (same module — re-declared here to avoid pulling the swimlanes
+// React component into the unit-test boundary). If the rules drift,
+// update both. The shared rule it pins:
+//
+//   <  1h → "<m>m"
+//   <  24h → "<n>h"
+//   >= 24h → "<n>d"
+//
+// SKY-826 bug 12 turned a static "1h window" label into a real
+// dropdown of preset windows. The picker and the previous-render
+// label have to format identically or the user sees flicker between
+// "60m" (label) and "1h" (popover option) for the same zoom.
+function formatZoomLabel(zoom: number): string {
+  if (zoom < 1) return `${Math.round(zoom * 60)}m`
+  if (zoom >= 24) return `${Math.round(zoom / 24)}d`
+  return `${zoom}h`
+}
+
+describe('formatZoomLabel (timeline window picker)', () => {
+  it('formats sub-hour zooms as minutes', () => {
+    expect(formatZoomLabel(0.25)).toBe('15m')
+    expect(formatZoomLabel(0.5)).toBe('30m')
+  })
+
+  it('formats hour-scale zooms as hours', () => {
+    expect(formatZoomLabel(1)).toBe('1h')
+    expect(formatZoomLabel(2)).toBe('2h')
+    expect(formatZoomLabel(12)).toBe('12h')
+  })
+
+  it('formats day-scale zooms as days', () => {
+    expect(formatZoomLabel(24)).toBe('1d')
+    expect(formatZoomLabel(48)).toBe('2d')
+    expect(formatZoomLabel(72)).toBe('3d')
+    expect(formatZoomLabel(168)).toBe('7d')
+  })
+
+  it('rounds (does not truncate) values at the bucket boundaries', () => {
+    // 0.49 * 60 = 29.4 → rounds to 29
+    expect(formatZoomLabel(0.49)).toBe('29m')
+    // 35h / 24 = 1.458... → rounds to 1d (closer to 1 than 2)
+    expect(formatZoomLabel(35)).toBe('1d')
+  })
+})

--- a/packages/k8s-ui/src/utils/zoom-label.test.ts
+++ b/packages/k8s-ui/src/utils/zoom-label.test.ts
@@ -1,24 +1,10 @@
 import { describe, it, expect } from 'vitest'
+import { formatZoomLabel } from './zoom-label'
 
-// Inline copy of the helper from web/src/components/timeline/TimelineSwimlanes.tsx
-// (same module — re-declared here to avoid pulling the swimlanes
-// React component into the unit-test boundary). If the rules drift,
-// update both. The shared rule it pins:
-//
-//   <  1h → "<m>m"
-//   <  24h → "<n>h"
-//   >= 24h → "<n>d"
-//
-// SKY-826 bug 12 turned a static "1h window" label into a real
-// dropdown of preset windows. The picker and the previous-render
-// label have to format identically or the user sees flicker between
-// "60m" (label) and "1h" (popover option) for the same zoom.
-function formatZoomLabel(zoom: number): string {
-  if (zoom < 1) return `${Math.round(zoom * 60)}m`
-  if (zoom >= 24) return `${Math.round(zoom / 24)}d`
-  return `${zoom}h`
-}
-
+// Pin the timeline-window label format. The picker and the
+// previous-render label MUST format identically or the user sees
+// flicker between "60m" (label) and "1h" (popover option) for the
+// same zoom.
 describe('formatZoomLabel (timeline window picker)', () => {
   it('formats sub-hour zooms as minutes', () => {
     expect(formatZoomLabel(0.25)).toBe('15m')
@@ -39,9 +25,7 @@ describe('formatZoomLabel (timeline window picker)', () => {
   })
 
   it('rounds (does not truncate) values at the bucket boundaries', () => {
-    // 0.49 * 60 = 29.4 → rounds to 29
     expect(formatZoomLabel(0.49)).toBe('29m')
-    // 35h / 24 = 1.458... → rounds to 1d (closer to 1 than 2)
     expect(formatZoomLabel(35)).toBe('1d')
   })
 })

--- a/packages/k8s-ui/src/utils/zoom-label.ts
+++ b/packages/k8s-ui/src/utils/zoom-label.ts
@@ -1,0 +1,19 @@
+/**
+ * Format a zoom-window value (in hours) for display next to the
+ * timeline. Pure helper so the popover and the rest of the toolbar
+ * agree on the same string.
+ *
+ * Rules:
+ *   <  1h → "<m>m"
+ *   <  24h → "<n>h"
+ *   >= 24h → "<n>d"
+ *
+ * Lives in the shared utils package (not the web/ component file)
+ * so the unit test can import the production implementation
+ * directly instead of duplicating it.
+ */
+export function formatZoomLabel(zoom: number): string {
+  if (zoom < 1) return `${Math.round(zoom * 60)}m`
+  if (zoom >= 24) return `${Math.round(zoom / 24)}d`
+  return `${zoom}h`
+}

--- a/web/src/components/timeline/TimelineSwimlanes.tsx
+++ b/web/src/components/timeline/TimelineSwimlanes.tsx
@@ -173,21 +173,8 @@ function calculateInterestingnessWithBreakdown(lane: ResourceLane): ScoreBreakdo
   return breakdown
 }
 
-/**
- * Format a zoom-window value (in hours) for display next to the
- * timeline. Pure helper so the popover and the rest of the toolbar
- * agree on the same string. (SKY-826 bug 12)
- *
- * Rules:
- *   <  1h → "<m>m"
- *   <  24h → "<n>h"
- *   >= 24h → "<n>d"
- */
-export function formatZoomLabel(zoom: number): string {
-  if (zoom < 1) return `${Math.round(zoom * 60)}m`
-  if (zoom >= 24) return `${Math.round(zoom / 24)}d`
-  return `${zoom}h`
-}
+import { formatZoomLabel } from '@skyhook-io/k8s-ui/utils/zoom-label'
+export { formatZoomLabel }
 
 interface ZoomWindowPickerProps {
   zoom: number

--- a/web/src/components/timeline/TimelineSwimlanes.tsx
+++ b/web/src/components/timeline/TimelineSwimlanes.tsx
@@ -173,6 +173,98 @@ function calculateInterestingnessWithBreakdown(lane: ResourceLane): ScoreBreakdo
   return breakdown
 }
 
+/**
+ * Format a zoom-window value (in hours) for display next to the
+ * timeline. Pure helper so the popover and the rest of the toolbar
+ * agree on the same string. (SKY-826 bug 12)
+ *
+ * Rules:
+ *   <  1h → "<m>m"
+ *   <  24h → "<n>h"
+ *   >= 24h → "<n>d"
+ */
+export function formatZoomLabel(zoom: number): string {
+  if (zoom < 1) return `${Math.round(zoom * 60)}m`
+  if (zoom >= 24) return `${Math.round(zoom / 24)}d`
+  return `${zoom}h`
+}
+
+interface ZoomWindowPickerProps {
+  zoom: number
+  levels: ReadonlyArray<number>
+  onSelect: (next: number) => void
+  formatLabel: (zoom: number) => string
+}
+
+/**
+ * Button + popover for the timeline zoom window. Replaces a static
+ * `<span>` users tried to click and got nothing from. Click-outside
+ * and Escape both close. (SKY-826 bug 12)
+ */
+function ZoomWindowPicker({ zoom, levels, onSelect, formatLabel }: ZoomWindowPickerProps) {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (e: PointerEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        title="Choose time window"
+        className="text-xs text-theme-text-tertiary hover:text-theme-text-primary inline-flex items-center gap-1 px-1.5 py-0.5 rounded hover:bg-theme-elevated"
+      >
+        <span>{formatLabel(zoom)} window</span>
+        <svg className="w-3 h-3" viewBox="0 0 12 12" aria-hidden>
+          <path d="M3 5l3 3 3-3" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </button>
+      {open && (
+        <ul
+          role="listbox"
+          className="absolute left-0 top-full mt-1 z-30 min-w-[120px] bg-theme-surface border border-theme-border rounded shadow-lg py-1 max-h-64 overflow-y-auto"
+        >
+          {levels.map(level => (
+            <li key={level}>
+              <button
+                type="button"
+                role="option"
+                aria-selected={level === zoom}
+                onClick={() => { onSelect(level); setOpen(false) }}
+                className={clsx(
+                  'w-full text-left px-3 py-1 text-xs hover:bg-theme-elevated transition-colors',
+                  level === zoom ? 'text-theme-text-primary font-medium bg-theme-elevated/50' : 'text-theme-text-secondary',
+                )}
+              >
+                {formatLabel(level)}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
 export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode, onViewModeChange, topology, namespaces }: TimelineSwimlanesProps) {
   const hasLimitedAccess = useHasLimitedAccess()
   const containerRef = useRef<HTMLDivElement>(null)
@@ -484,9 +576,18 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
               >
                 <ZoomOut className="w-4 h-4" />
               </button>
-              <span className="text-xs text-theme-text-tertiary">
-                {zoom < 1 ? `${Math.round(zoom * 60)}m` : zoom >= 24 ? `${Math.round(zoom / 24)}d` : `${zoom}h`} window
-              </span>
+              {/*
+                Used to be a static <span>; users tried to click it
+                expecting a dropdown of preset windows and got
+                nothing. Now it's a real button + popover with the
+                full ZOOM_LEVELS palette. (SKY-826 bug 12)
+              */}
+              <ZoomWindowPicker
+                zoom={zoom}
+                levels={ZOOM_LEVELS}
+                onSelect={setZoom}
+                formatLabel={formatZoomLabel}
+              />
               {panOffset > 0 && (
                 <button
                   onClick={() => setPanOffset(0)}

--- a/web/src/components/timeline/TimelineSwimlanes.tsx
+++ b/web/src/components/timeline/TimelineSwimlanes.tsx
@@ -174,7 +174,6 @@ function calculateInterestingnessWithBreakdown(lane: ResourceLane): ScoreBreakdo
 }
 
 import { formatZoomLabel } from '@skyhook-io/k8s-ui/utils/zoom-label'
-export { formatZoomLabel }
 
 interface ZoomWindowPickerProps {
   zoom: number


### PR DESCRIPTION
Closes part of [SKY-826](https://linear.app/skyhook/issue/SKY-826).

## Why

Three SKY-826 bugs share the same shape: the user clicked something the UI made look interactive, the URL updated, and then nothing rendered or nothing opened.

## Bug 9 — CronJob row click updates URL but no detail panel renders

Root cause: \`ResourceRendererDispatch\` keys its dispatch table on lowercase plural kinds (\`'cronjobs'\`), but \`resource.kind\` reaches the dispatcher in **two** shapes depending on which path opened it:

- Resources view → lowercase plural (\`'cronjobs'\`)
- Topology node click → PascalCase singular (\`node.kind === 'CronJob'\` was forwarded verbatim)

The dispatcher did \`resource.kind.toLowerCase()\` and matched on equality — so the singular path produced \`'cronjob'\` and matched **no renderer**. Silent no-op; URL set, drawer empty.

Fix: route the dispatch's incoming \`kind\` through \`kindToPlural\`, which is idempotent on already-plural lowercase inputs and pluralises PascalCase singular. Same fix applied to the sibling \`getResourceStatus\` helper in the same file.

## Bug 11 — TimelineList \"1 hour\" / \"All Kinds\" dropdowns don't open on click

Root cause: \`appearance-none\` strips the native dropdown arrow. Without a chevron the selects rendered as flat badges with no pointer cursor — convincing users they were static labels. The native \`<select>\` *does* still open on click, but the unstyled chrome killed the affordance.

Fix: wrap each select in a relative container with a \`ChevronDown\` overlay (\`pointer-events-none\` so it doesn't steal the click), plus \`cursor-pointer\` and an \`aria-label\`.

## Bug 12 — TimelineSwimlanes \"1h window\" is a zombie span

The element displaying the current zoom level (\`{zoom}h window\`) was a static \`<span>\`. Users clicked it expecting a dropdown of preset windows; nothing happened — they had to hunt for the +/- zoom buttons.

Fix: replaced with a real button + popover (\`ZoomWindowPicker\`) listing all \`ZOOM_LEVELS\` (15m / 30m / 1h / 2h / 4h / 8h / 12h / 1d / 2d / 3d / 7d). Pointerdown-outside and Escape both close. Extracted the formatting rule into a pure \`formatZoomLabel\` helper so the picker and the previous render of the label can't drift apart.

## Tests

- \`navigation.test.ts\` — strengthened comment around the \`idempotent on known plurals\` test to call out that ResourceRendererDispatch now depends on this property too. Existing test \`expect(kindToPlural('CronJob')).toBe('cronjobs')\` already pinned the regression for bug 9.
- \`zoom-label.test.ts\` (new, 4 cases) pins the format rules (sub-hour → minutes, hour scale → hours, day scale → days, rounding behaviour at bucket boundaries).

## Test plan

- [x] \`npm test\` (k8s-ui) — 72 passed
- [x] \`npm run tsc\` (k8s-ui + web) — clean
- [x] \`npm run build\` (web) — clean
- [ ] Manual: open a CronJob from topology *and* from resources list — both render the detail panel; TimelineList kind/time selects show chevron and open on click; Swimlane \"1h window\" opens a popover of preset zooms

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI/UX and string-normalization changes with limited blast radius; risk is confined to potential mismatches in kind normalization affecting which renderer/status path is selected.
> 
> **Overview**
> Fixes detail-panel rendering and status lookup for resources opened from different navigation paths by normalizing incoming kinds via `kindToPlural` (handling singular PascalCase and dispatch-keyed shortnames like `hpas`).
> 
> Improves timeline filter UX by restoring dropdown affordance on the Kind/Time selects (chevron overlay + pointer cursor + aria labels), and replaces the swimlane zoom “window” label with an interactive popover picker backed by a new shared `formatZoomLabel` helper plus unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d053afac53bbec3862218a3fb4d98db91be55111. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->