### PR TITLE
fix(ui): NetworkPolicy pill truncation + topology loader centering

### DIFF
--- a/packages/k8s-ui/src/components/resources/renderers/NetworkPolicyDiagram.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/NetworkPolicyDiagram.tsx
@@ -190,7 +190,7 @@ function FlowRow({
   const isIngress = direction === 'ingress'
 
   const sourceNodes = (
-    <div className="flex-1 min-w-0 space-y-1">
+    <div className="min-w-0 max-w-full shrink space-y-1">
       {sources.map((peer, i) => (
         <div key={i}>
           {i > 0 && (
@@ -199,13 +199,13 @@ function FlowRow({
           <Tooltip content={peer.sublabel ? `${peer.label}\n${peer.sublabel}` : peer.label} position="top">
             <div
               className={clsx(
-                'rounded-md border px-2 py-1.5',
+                'rounded-md border px-2 py-1.5 min-w-0 overflow-hidden',
                 PEER_STYLES[peer.type],
               )}
             >
-              <div className="flex items-center gap-1.5">
+              <div className="flex items-center gap-1.5 min-w-0">
                 <span className={clsx('w-1.5 h-1.5 rounded-full shrink-0', PEER_DOT[peer.type])} />
-                <span className={clsx('text-[11px] font-medium truncate', denied && 'line-through text-red-400')}>
+                <span className={clsx('text-[11px] font-medium truncate min-w-0', denied && 'line-through text-red-400')}>
                   {peer.label}
                 </span>
               </div>
@@ -220,14 +220,16 @@ function FlowRow({
   )
 
   const targetNode = (
-    <Tooltip content={target} position="top">
-      <div className="rounded-md border border-indigo-500/30 bg-indigo-500/8 px-2 py-1.5 flex-1 min-w-0">
-        <div className="flex items-center gap-1.5">
-          <span className="w-1.5 h-1.5 rounded-full shrink-0 bg-indigo-500" />
-          <span className="text-[11px] font-medium truncate">{target}</span>
+    <div className="min-w-0 max-w-full shrink-[1000]">
+      <Tooltip content={target} position="top">
+        <div className="rounded-md border border-indigo-500/30 bg-indigo-500/8 px-2 py-1.5 min-w-0 max-w-full overflow-hidden">
+          <div className="flex items-center gap-1.5 min-w-0">
+            <span className="w-1.5 h-1.5 rounded-full shrink-0 bg-indigo-500" />
+            <span className="text-[11px] font-medium truncate min-w-0">{target}</span>
+          </div>
         </div>
-      </div>
-    </Tooltip>
+      </Tooltip>
+    </div>
   )
 
   const arrow = (

--- a/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
+++ b/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
@@ -654,12 +654,12 @@ export function TopologyGraph({
   }, [selectedNodeId, setNodes])
 
   if (!topology) {
-    return <PaneLoader label="Loading topology…" className="flex-1" />
+    return <PaneLoader label="Loading topology…" className="absolute inset-0" />
   }
 
   if (topology.nodes.length === 0) {
     return (
-      <div className="flex-1 flex items-center justify-center text-theme-text-secondary">
+      <div className="absolute inset-0 flex items-center justify-center text-theme-text-secondary">
         <div className="text-center">
           <p className="text-lg">No resources found</p>
           <p className="text-sm mt-2">
@@ -673,7 +673,7 @@ export function TopologyGraph({
   // Show layout error if we have topology data but layout failed
   if (layoutError && nodes.length === 0) {
     return (
-      <div className="flex-1 flex items-center justify-center text-theme-text-secondary">
+      <div className="absolute inset-0 flex items-center justify-center text-theme-text-secondary">
         <div className="text-center max-w-md">
           <p className="text-lg text-amber-400">Layout Error</p>
           <p className="text-sm mt-2">


### PR DESCRIPTION
Two unrelated drive-by layout fixes in shared pane components:

**NetworkPolicy Policy Flow** — when the policy's `podSelector` had multi-label `matchLabels` (e.g. the standard `app.kubernetes.io/component`/`instance`/`name` set), the long target pill either left a dead gap on one side of the row or overflowed past the drawer. Two underlying issues: (1) `flex-1` on both pills forced a 50/50 split that left a gap whenever one side was short like "Any source"; (2) source was wrapped in our own `min-w-0` div but target was the Tooltip's `inline-flex` span with `min-width: auto`, so target refused to shrink and pushed the source to 0 width. Now both pills sit at content size by default (left-aligned, no gap), share space symmetrically when the row is too narrow, and target carries `shrink-[1000]` so it absorbs the truncation instead of clipping a short label. Tooltip still surfaces the full text.

**Topology pane states** — the loading spinner ("Loading topology…"), "No resources found", and "Layout Error" branches in `TopologyGraph` all used `flex-1` to fill the canvas, but their parent `<div className="flex-1 relative">` in `App.tsx` is a block container, not a flex column. `flex-1` resolved to nothing, so all three states collapsed to content height and hugged the top of the pane instead of centering. Switched to `absolute inset-0`, which fills the existing `relative` parent regardless of its display mode.

Both verified visually with Playwright on a real cluster (`mcp-s/mcp-s-postgresql` NetworkPolicy with the long label set).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: styling-only tweaks to flexbox sizing/positioning for NetworkPolicy diagram pills and TopologyGraph placeholder states, with no logic or data-flow changes.
> 
> **Overview**
> Fixes NetworkPolicy flow row layout so long source/target “pill” labels truncate predictably without forcing a 50/50 split or overflowing the drawer (adds consistent `min-w-0`/`overflow-hidden` handling and makes the target pill aggressively shrinkable).
> 
> Updates TopologyGraph loading/empty/error placeholders to fill and center within the pane by switching from `flex-1` sizing to `absolute inset-0` positioning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bfd9cc96655c92e6aec04cad2e9ddd78fc08218. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->