### PR TITLE
fix(topology): inline NetworkPolicy badge in card header

### DIFF
--- a/packages/k8s-ui/src/components/topology/K8sResourceNode.tsx
+++ b/packages/k8s-ui/src/components/topology/K8sResourceNode.tsx
@@ -374,71 +374,58 @@ export const K8sResourceNode = memo(function K8sResourceNode({
           'pl-3 pr-3',
           isSmallNode ? 'py-2' : 'py-2.5'
         )}>
-          {/* Header row: icon + kind label + expand/collapse + status dot */}
+          {/* Header row: icon + kind label + (right-aligned) policy badge + expand/collapse + status dot */}
           <div className="flex items-center gap-1.5 mb-0.5">
             <span className={iconClass} />
             <span className="text-[10px] uppercase tracking-wide text-theme-text-tertiary font-medium">
               {isPodGroup ? 'Pod Group' : displayKind(kind)}
             </span>
-            {/* Expand/Collapse button for PodGroup */}
-            {canExpand && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onExpand(id)
-                }}
-                className="ml-auto p-0.5 hover:bg-theme-elevated rounded transition-colors"
-                title="Expand to show individual pods"
-              >
-                <ChevronDown className="w-3.5 h-3.5 text-theme-text-secondary" />
-              </button>
-            )}
-            {canCollapse && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onCollapse(id)
-                }}
-                className="ml-auto p-0.5 hover:bg-theme-elevated rounded transition-colors"
-                title="Collapse back to group"
-              >
-                <ChevronUp className="w-3.5 h-3.5 text-theme-text-secondary" />
-              </button>
-            )}
-            {issueTooltip ? (
-              <Tooltip content={issueTooltip} position="right">
-                <span
-                  className={clsx(
-                    canExpand || canCollapse ? '' : 'ml-auto',
-                    'w-1.5 h-1.5 rounded-full cursor-help',
-                    getStatusDotColor(status)
-                  )}
-                />
-              </Tooltip>
-            ) : (
-              <span
-                className={clsx(
-                  canExpand || canCollapse ? '' : 'ml-auto',
-                  'w-1.5 h-1.5 rounded-full',
-                  getStatusDotColor(status)
-                )}
-              />
-            )}
+            <div className="ml-auto flex items-center gap-1.5">
+              {policyStatus && (
+                <Tooltip content={policyStatus === 'protected' ? 'Protected by NetworkPolicy' : 'No NetworkPolicy coverage'} position="right">
+                  <span className={clsx(
+                    'inline-flex items-center justify-center w-3 h-3 rounded-sm text-[8px] font-bold cursor-help leading-none',
+                    policyStatus === 'protected'
+                      ? 'bg-green-500/20 text-green-500 border border-green-500/30'
+                      : 'bg-yellow-500/20 text-yellow-500 border border-yellow-500/30',
+                  )}>
+                    {policyStatus === 'protected' ? '✓' : '!'}
+                  </span>
+                </Tooltip>
+              )}
+              {canExpand && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onExpand(id)
+                  }}
+                  className="p-0.5 hover:bg-theme-elevated rounded transition-colors"
+                  title="Expand to show individual pods"
+                >
+                  <ChevronDown className="w-3.5 h-3.5 text-theme-text-secondary" />
+                </button>
+              )}
+              {canCollapse && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onCollapse(id)
+                  }}
+                  className="p-0.5 hover:bg-theme-elevated rounded transition-colors"
+                  title="Collapse back to group"
+                >
+                  <ChevronUp className="w-3.5 h-3.5 text-theme-text-secondary" />
+                </button>
+              )}
+              {issueTooltip ? (
+                <Tooltip content={issueTooltip} position="right">
+                  <span className={clsx('w-1.5 h-1.5 rounded-full cursor-help', getStatusDotColor(status))} />
+                </Tooltip>
+              ) : (
+                <span className={clsx('w-1.5 h-1.5 rounded-full', getStatusDotColor(status))} />
+              )}
+            </div>
           </div>
-
-          {/* Network Policy coverage indicator */}
-          {policyStatus && (
-            <Tooltip content={policyStatus === 'protected' ? 'Protected by NetworkPolicy' : 'No NetworkPolicy coverage'} position="right">
-              <span className={clsx(
-                'inline-flex items-center justify-center w-3.5 h-3.5 rounded-sm text-[8px] font-bold cursor-help',
-                policyStatus === 'protected'
-                  ? 'bg-green-500/20 text-green-500 border border-green-500/30'
-                  : 'bg-yellow-500/20 text-yellow-500 border border-yellow-500/30',
-              )}>
-                {policyStatus === 'protected' ? '✓' : '!'}
-              </span>
-            </Tooltip>
-          )}
 
           {/* Name */}
           <div className="text-sm font-medium text-theme-text-primary truncate pr-1">


### PR DESCRIPTION
## Summary

The `policyStatus` ✓/! badge on workload cards rendered as its own block-level row between the kind label and the workload name, adding ~14px of vertical space to every workload card whenever the Policies toggle was on. Cards looked noticeably taller than the surrounding Service/Pod cards.

Move the badge into the right-aligned cluster of the header row alongside the expand/collapse buttons and status dot. Cards now keep their compact height in policy mode and visually match Service/Pod cards.

## Notes

- Behavior is unchanged: same tooltip text, same colors, same `protected` vs uncovered logic.
- Collapsed the conditional `ml-auto` ternary on the status dot into a single `ml-auto` on a wrapper div — fewer branches, same right-alignment.
- Badge size went from `w-3.5 h-3.5` (14px) → `w-3 h-3` (12px) with `leading-none` to fit alongside the status dot inline.

## Test plan

- [x] `make tsc` clean
- [x] `npm test` in `packages/k8s-ui` — 68/68 pass
- [x] `go test ./...` — all pass
- [x] Eyeballed in topology view with the Policies toggle on: ✓/! badge appears top-right of card, cards shorter, no overflow into ReactFlow allocated height.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI layout refactor in `K8sResourceNode` that repositions existing indicators without changing policy/health logic; low risk aside from potential minor alignment/regression in card header rendering.
> 
> **Overview**
> Makes workload cards more compact in topology view by moving the `policyStatus` (✓/!) NetworkPolicy coverage badge into the **right-aligned header cluster** alongside the PodGroup expand/collapse controls and health status dot, instead of rendering it as a separate row.
> 
> Also simplifies header alignment by wrapping these controls in a single `ml-auto` container, and slightly reduces badge size (`w-3 h-3` + `leading-none`) to fit inline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9c4d1fc5ef7f4fa5a71f6943b81ca0835e20f4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->