### PR TITLE
fix(search): make zero-result topology + resource search self-explanatory

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -3578,6 +3578,24 @@ export function ResourcesView({
                   <X className="w-3.5 h-3.5" />
                 </button>
               )}
+              {/*
+                The sidebar's count badge shows the cluster-wide
+                total for the selected kind (from resourceCounts) and
+                deliberately stays unfiltered — making the filter
+                state survivable across kind switches. When a search
+                yields zero results the user can think the badge is
+                lying. Spell out that the badge is the cluster total,
+                not the filtered count. (SKY-828 bug 46)
+              */}
+              {searchTerm && (() => {
+                const totalForKind = counts[selectedKind.group ? `${selectedKind.group}/${selectedKind.kind}` : selectedKind.kind] ?? 0
+                if (totalForKind === 0) return null
+                return (
+                  <p className="text-xs mt-1 text-theme-text-disabled">
+                    The sidebar shows {totalForKind} {totalForKind === 1 ? selectedKind.kind : `${selectedKind.kind}s`} in the cluster — the count is unfiltered.
+                  </p>
+                )
+              })()}
               {namespaces.length > 0 && <p className="text-sm mt-1 text-theme-text-disabled">Searching in {namespaces.length === 1 ? `namespace: ${namespaces[0]}` : `${namespaces.length} namespaces`}</p>}
               {/* Show active filters as dismissible badges so user can clear them */}
               {(() => {

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -3581,18 +3581,17 @@ export function ResourcesView({
               {/*
                 The sidebar's count badge shows the cluster-wide
                 total for the selected kind (from resourceCounts) and
-                deliberately stays unfiltered — making the filter
-                state survivable across kind switches. When a search
-                yields zero results the user can think the badge is
-                lying. Spell out that the badge is the cluster total,
-                not the filtered count. (SKY-828 bug 46)
+                deliberately stays unfiltered. When a search yields
+                zero results the user can think the badge is lying.
+                Spell out that the badge is the cluster total, not
+                the filtered count.
               */}
               {searchTerm && (() => {
                 const totalForKind = counts[selectedKind.group ? `${selectedKind.group}/${selectedKind.kind}` : selectedKind.kind] ?? 0
                 if (totalForKind === 0) return null
                 return (
                   <p className="text-xs mt-1 text-theme-text-disabled">
-                    The sidebar shows {totalForKind} {totalForKind === 1 ? selectedKind.kind : `${selectedKind.kind}s`} in the cluster — the count is unfiltered.
+                    The sidebar shows {pluralize(totalForKind, selectedKind.kind)} in the cluster — the count is unfiltered.
                   </p>
                 )
               })()}

--- a/packages/k8s-ui/src/components/resources/resources-search-sidebar-hint.test.ts
+++ b/packages/k8s-ui/src/components/resources/resources-search-sidebar-hint.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { pluralize } from '../../utils/pluralize'
+import type { SelectedKindInfo } from './ResourcesSidebar'
+
+// Mirrors the empty-state hint rule inside ResourcesView (kept in
+// sync by reuse) — pure so we can pin the lookup + render contract
+// without rendering the React component. See
+// `packages/k8s-ui/src/components/resources/ResourcesView.tsx`
+// search for "the count is unfiltered".
+function sidebarHint(
+  counts: Record<string, number>,
+  selectedKind: SelectedKindInfo,
+  searchTerm: string,
+): string | null {
+  if (!searchTerm) return null
+  const key = selectedKind.group ? `${selectedKind.group}/${selectedKind.kind}` : selectedKind.kind
+  const totalForKind = counts[key] ?? 0
+  if (totalForKind === 0) return null
+  return `The sidebar shows ${pluralize(totalForKind, selectedKind.kind)} in the cluster — the count is unfiltered.`
+}
+
+describe('ResourcesView empty-search sidebar hint (SKY-828 bug 46)', () => {
+  // The bug: sidebar count badge stays unfiltered and shows the
+  // cluster-wide total per kind. When a search returns zero rows
+  // (e.g. "5 Pods" in sidebar, "No Pods found" in pane) the user
+  // reads the badge as a lie. The empty-state appends a sentence
+  // making the unfiltered nature explicit. The rule must:
+  //   1. Suppress entirely when there's no active search.
+  //   2. Suppress when the cluster total for the kind is 0
+  //      (no badge to explain → no hint).
+  //   3. Look up the count under `${group}/${kind}` for grouped
+  //      kinds, plain `kind` for core kinds (matches sidebar key).
+  //   4. Pluralize via pluralize() so "Ingress" → "Ingresses",
+  //      "NetworkPolicy" → "NetworkPolicies" (regression of the
+  //      naive `${kind}s` Cursor Bugbot caught in 80eb64b).
+  //   5. Singular for n===1: "1 Pod", not "1 Pods".
+
+  const pod: SelectedKindInfo = { name: 'pods', kind: 'Pod', group: '' }
+
+  it('returns null when there is no active search', () => {
+    expect(sidebarHint({ Pod: 232 }, pod, '')).toBeNull()
+  })
+
+  it('returns null when the cluster total for the kind is 0', () => {
+    expect(sidebarHint({ Pod: 0 }, pod, 'xyz')).toBeNull()
+  })
+
+  it('returns null when the kind is missing from counts', () => {
+    expect(sidebarHint({}, pod, 'xyz')).toBeNull()
+  })
+
+  it('formats the sentence with the cluster total and pluralized kind', () => {
+    expect(sidebarHint({ Pod: 232 }, pod, 'xyz')).toBe(
+      'The sidebar shows 232 Pods in the cluster — the count is unfiltered.',
+    )
+  })
+
+  it('uses singular noun when total is 1', () => {
+    expect(sidebarHint({ Pod: 1 }, pod, 'xyz')).toBe(
+      'The sidebar shows 1 Pod in the cluster — the count is unfiltered.',
+    )
+  })
+
+  it('looks up grouped kinds under `${group}/${kind}`', () => {
+    const ar: SelectedKindInfo = { name: 'rollouts', kind: 'Rollout', group: 'argoproj.io' }
+    const counts = { Rollout: 999, 'argoproj.io/Rollout': 4 }
+    expect(sidebarHint(counts, ar, 'xyz')).toBe(
+      'The sidebar shows 4 Rollouts in the cluster — the count is unfiltered.',
+    )
+  })
+
+  it('pluralizes Ingress correctly (regression: not "Ingresss")', () => {
+    const ing: SelectedKindInfo = { name: 'ingresses', kind: 'Ingress', group: '' }
+    expect(sidebarHint({ Ingress: 3 }, ing, 'xyz')).toBe(
+      'The sidebar shows 3 Ingresses in the cluster — the count is unfiltered.',
+    )
+  })
+
+  it('pluralizes NetworkPolicy correctly (regression: not "NetworkPolicys")', () => {
+    const np: SelectedKindInfo = { name: 'networkpolicies', kind: 'NetworkPolicy', group: 'networking.k8s.io' }
+    expect(sidebarHint({ 'networking.k8s.io/NetworkPolicy': 2 }, np, 'xyz')).toBe(
+      'The sidebar shows 2 NetworkPolicies in the cluster — the count is unfiltered.',
+    )
+  })
+})

--- a/packages/k8s-ui/src/components/topology/TopologySearch.tsx
+++ b/packages/k8s-ui/src/components/topology/TopologySearch.tsx
@@ -9,6 +9,20 @@ interface TopologySearchProps {
   nodes: TopologyNode[]
   onNodeSelect?: (node: TopologyNode) => void
   onZoomToNode?: (nodeId: string) => void
+  /**
+   * Optional unfiltered node set. When the parent has applied a
+   * view-mode filter (e.g. Fleet mode hides Pods/Deployments and
+   * only shows CAPI kinds), it should still pass the full topology
+   * here so the empty-state can tell users "your query matches X
+   * resources hidden by the current view" rather than the
+   * misleading "No resources found." (SKY-828 bug 45)
+   */
+  allNodes?: TopologyNode[]
+  /**
+   * Human-readable label for the current view mode. Used in the
+   * empty-state hint above. Defaults to "current view".
+   */
+  viewModeLabel?: string
 }
 
 // Icon mapping for different resource kinds
@@ -50,33 +64,47 @@ function getKindColor(kind: string): string {
   }
 }
 
-export function TopologySearch({ nodes, onNodeSelect, onZoomToNode }: TopologySearchProps) {
+export function TopologySearch({ nodes, onNodeSelect, onZoomToNode, allNodes, viewModeLabel }: TopologySearchProps) {
   const [isOpen, setIsOpen] = useState(false)
   const [query, setQuery] = useState('')
   const [selectedIndex, setSelectedIndex] = useState(0)
   const inputRef = useRef<HTMLInputElement>(null)
   const resultsRef = useRef<HTMLDivElement>(null)
 
+  const matchesQuery = useCallback((node: TopologyNode, lowerQuery: string) => {
+    const name = node.name.toLowerCase()
+    const kind = node.kind.toLowerCase()
+    const namespace = (node.data.namespace as string || '').toLowerCase()
+    return (
+      name.includes(lowerQuery) ||
+      kind.includes(lowerQuery) ||
+      namespace.includes(lowerQuery) ||
+      `${kind}/${name}`.includes(lowerQuery) ||
+      `${namespace}/${name}`.includes(lowerQuery)
+    )
+  }, [])
+
   // Filter nodes based on query
   const filteredNodes = useMemo(() => {
     if (!query.trim()) return []
-
     const lowerQuery = query.toLowerCase()
     return nodes
-      .filter(node => {
-        const name = node.name.toLowerCase()
-        const kind = node.kind.toLowerCase()
-        const namespace = (node.data.namespace as string || '').toLowerCase()
-        return (
-          name.includes(lowerQuery) ||
-          kind.includes(lowerQuery) ||
-          namespace.includes(lowerQuery) ||
-          `${kind}/${name}`.includes(lowerQuery) ||
-          `${namespace}/${name}`.includes(lowerQuery)
-        )
-      })
+      .filter(node => matchesQuery(node, lowerQuery))
       .slice(0, 10) // Limit results
-  }, [nodes, query])
+  }, [nodes, query, matchesQuery])
+
+  // Count of matches in the unfiltered topology that the current
+  // view-mode filter is hiding. We only compute this when there's
+  // a query AND the visible set returned zero results, so the cost
+  // is bounded to actual no-result interactions.
+  // (SKY-828 bug 45: Fleet view hides Pods, so searching pod names
+  // returned "No resources found" — misleading.)
+  const hiddenMatchCount = useMemo(() => {
+    if (!query.trim() || filteredNodes.length > 0 || !allNodes) return 0
+    const lowerQuery = query.toLowerCase()
+    const visibleIds = new Set(nodes.map(n => n.id))
+    return allNodes.filter(n => !visibleIds.has(n.id) && matchesQuery(n, lowerQuery)).length
+  }, [query, filteredNodes.length, allNodes, nodes, matchesQuery])
 
   // Reset selection when results change
   useEffect(() => {
@@ -216,7 +244,12 @@ export function TopologySearch({ nodes, onNodeSelect, onZoomToNode }: TopologySe
               {query && filteredNodes.length === 0 && (
                 <div className="px-4 py-8 text-center text-theme-text-tertiary">
                   <Search className="w-8 h-8 mx-auto mb-2 opacity-50" />
-                  <p>No resources found for "{query}"</p>
+                  <p>No resources found for "{query}"{viewModeLabel ? ` in ${viewModeLabel}` : ''}</p>
+                  {hiddenMatchCount > 0 && (
+                    <p className="mt-2 text-xs text-amber-400">
+                      {hiddenMatchCount} {hiddenMatchCount === 1 ? 'match is' : 'matches are'} hidden by the current view{viewModeLabel ? ` (${viewModeLabel})` : ''}. Switch view to see them.
+                    </p>
+                  )}
                 </div>
               )}
 

--- a/packages/k8s-ui/src/components/topology/topology-search-match.test.ts
+++ b/packages/k8s-ui/src/components/topology/topology-search-match.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import type { TopologyNode } from '../../types'
+
+// Mirrors the matching predicate inside TopologySearch (kept in sync
+// by reuse) — pure so we can pin the matching rule without rendering
+// the React component.
+function matchesQuery(node: TopologyNode, lowerQuery: string): boolean {
+  const name = node.name.toLowerCase()
+  const kind = node.kind.toLowerCase()
+  const namespace = (node.data.namespace as string || '').toLowerCase()
+  return (
+    name.includes(lowerQuery) ||
+    kind.includes(lowerQuery) ||
+    namespace.includes(lowerQuery) ||
+    `${kind}/${name}`.includes(lowerQuery) ||
+    `${namespace}/${name}`.includes(lowerQuery)
+  )
+}
+
+function countHidden(allNodes: TopologyNode[], visibleNodes: TopologyNode[], query: string): number {
+  if (!query.trim()) return 0
+  const lowerQuery = query.toLowerCase()
+  // First check whether the visible set already has matches — the
+  // hint should only appear when the visible search yielded zero.
+  const visibleMatches = visibleNodes.filter(n => matchesQuery(n, lowerQuery))
+  if (visibleMatches.length > 0) return 0
+  const visibleIds = new Set(visibleNodes.map(n => n.id))
+  return allNodes.filter(n => !visibleIds.has(n.id) && matchesQuery(n, lowerQuery)).length
+}
+
+function makeNode(id: string, kind: string, name: string, namespace = 'default'): TopologyNode {
+  // Tests only need the four fields the matcher reads — cast through
+  // unknown so the partial shape doesn't have to satisfy the full
+  // TopologyNode type.
+  return {
+    id,
+    kind,
+    name,
+    data: { namespace },
+  } as unknown as TopologyNode
+}
+
+describe('TopologySearch hidden-match counting (SKY-828 bug 45)', () => {
+  // The bug: in Fleet topology view (which only shows CAPI kinds),
+  // searching pod names returned "No resources found" — misleading
+  // when the cluster has 338 pods. We compute a hidden-match count
+  // so the empty-state can say "X matches are hidden by the current
+  // view; switch view to see them."
+  //
+  // The count should:
+  //  1. Be 0 when the visible set has any match (don't shame the
+  //     visible empty-state).
+  //  2. Otherwise count nodes that match in the unfiltered set but
+  //     are NOT in the visible set.
+  //  3. Match by name, kind, namespace, kind/name, or
+  //     namespace/name (case-insensitive).
+
+  it('returns 0 when visible nodes contain a match', () => {
+    const visible = [makeNode('a', 'Cluster', 'prod')]
+    const all = [
+      ...visible,
+      makeNode('b', 'Pod', 'prod-app'), // would also match "prod"
+    ]
+    expect(countHidden(all, visible, 'prod')).toBe(0)
+  })
+
+  it('returns count of hidden matches when visible has none (Fleet → pod search)', () => {
+    const visible = [
+      makeNode('cluster-1', 'Cluster', 'prod-cluster'),
+      makeNode('machine-1', 'Machine', 'prod-machine-1'),
+    ]
+    const all = [
+      ...visible,
+      makeNode('pod-1', 'Pod', '3scale-gateway-abc'),
+      makeNode('pod-2', 'Pod', '3scale-system-xyz'),
+      makeNode('pod-3', 'Pod', 'billing-api-789'),
+    ]
+    expect(countHidden(all, visible, '3scale')).toBe(2)
+    expect(countHidden(all, visible, 'billing')).toBe(1)
+  })
+
+  it('matches case-insensitively', () => {
+    const visible = [makeNode('a', 'Cluster', 'prod')]
+    const all = [...visible, makeNode('b', 'Pod', 'MyApp')]
+    expect(countHidden(all, visible, 'myapp')).toBe(1)
+    expect(countHidden(all, visible, 'MYAPP')).toBe(1)
+  })
+
+  it('matches by namespace as well as name', () => {
+    const visible = [makeNode('a', 'Cluster', 'prod')]
+    const all = [
+      ...visible,
+      makeNode('p1', 'Pod', 'frontend', 'billing'),
+      makeNode('p2', 'Pod', 'backend', 'billing'),
+    ]
+    expect(countHidden(all, visible, 'billing')).toBe(2)
+  })
+
+  it('returns 0 for an empty/whitespace query', () => {
+    const visible: TopologyNode[] = []
+    const all = [makeNode('a', 'Pod', 'foo')]
+    expect(countHidden(all, visible, '')).toBe(0)
+    expect(countHidden(all, visible, '   ')).toBe(0)
+  })
+
+  it('does not double-count: a node visible AND matching is excluded from hidden', () => {
+    const visible = [makeNode('a', 'Pod', 'foo-1')]
+    const all = [...visible, makeNode('b', 'Pod', 'foo-2')]
+    // visible has a match → hint suppressed entirely
+    expect(countHidden(all, visible, 'foo')).toBe(0)
+  })
+})


### PR DESCRIPTION
Closes part of [SKY-828](https://linear.app/skyhook/issue/SKY-828).

## Why

Two SKY-828 bugs share the same shape: the user searches and gets back \"No results found\", but the surrounding UI tells them something different exists. They conclude search is broken.

## Bug 45 — Fleet topology search returns 0 hits for known pod names

Fleet view of the topology only renders CAPI kinds (Cluster, Machine, MachineSet, ...). Pods, Deployments, etc. are filtered out of the \`nodes\` prop the search reads. Searching \"3scale\" or \"billing\" returned a flat \"No resources found\" with no clue that the matches existed in another view.

**Fix.** \`TopologySearch\` gains two optional props:

- \`allNodes\` — the unfiltered topology. When present we use it to count hidden matches.
- \`viewModeLabel\` — a human-readable label for the current view (e.g. \"Fleet\").

When the visible search yields zero AND \`allNodes\` contains hidden matches, the empty-state now reads:

> No resources found for \"3scale\" in Fleet
> 
> 2 matches are hidden by the current view (Fleet). Switch view to see them.

Backwards-compatible — call sites that don't pass \`allNodes\` see no change.

## Bug 46 — Sidebar count badge looks like it's lying when search returns 0

The sidebar's count badge shows the cluster-wide total (\`resourceCounts\`) and intentionally stays unfiltered so it survives kind switches and search-state. When a search yields zero results the user sees \"5 Pods\" in the sidebar and \"No Pods found\" in the pane and concludes the badge is wrong.

**Fix.** When the empty-state is shown with an active search, append:

> The sidebar shows N Pods in the cluster — the count is unfiltered.

No sidebar API change required.

## Tests

\`packages/k8s-ui/src/components/topology/topology-search-match.test.ts\` (6 cases) pins the hidden-match-count rule:
- 0 when the visible set has any match (don't shame the visible UI)
- count of hidden-but-matching nodes otherwise
- case-insensitive
- matches by name OR kind OR namespace OR \`kind/name\` OR \`namespace/name\`
- 0 for empty/whitespace queries
- never double-counts a node that's both visible and matches

## Out of scope

**Bug 47** (Global Search header \"338 pods across 2 connected clusters\" returning 0 hits for any pod name) is in the cloud product (radar-hub-web), not this OSS repo. Searched the repo for \`across.*clusters\` / \`connected clusters\` UI strings — no matches; only backend usages.

## Test plan

- [x] \`npm test\` (k8s-ui) — 74 passed (6 new for hidden-match counting)
- [x] \`npm run tsc\` (k8s-ui + web) — clean
- [x] \`npm run build\` (web) — clean
- [ ] Manual (cloud product, where TopologySearch is rendered): switch topology to Fleet view, search \"3scale\" → empty state shows \"X matches are hidden by the current view (Fleet)\"
- [ ] Manual (OSS): list any kind, type a search that yields nothing → empty state mentions the sidebar shows the unfiltered cluster total

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX-only changes that add explanatory hints for empty search results; logic is small and guarded, with new unit tests to prevent regressions.
> 
> **Overview**
> Makes zero-result search states self-explanatory in `ResourcesView` and `TopologySearch`.
> 
> When a resource list search returns nothing, the empty state now explains that the sidebar badge is the **cluster-wide, unfiltered** total (using `pluralize`). For topology search, adds optional `allNodes`/`viewModeLabel` props to detect matches hidden by the current view filter and surfaces a hint in the empty state; matching logic is factored into a shared predicate and pinned with new `vitest` unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37a699528cf779b73878a00bab1b2b8e6c343223. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->