### PR TITLE
fix(dashboard): respect full namespace selection for cert health (SKY-834)

### DIFF
--- a/internal/server/certificate.go
+++ b/internal/server/certificate.go
@@ -58,18 +58,31 @@ type DashboardCertificateHealth struct {
 	Expired  int `json:"expired"`
 }
 
-// getDashboardCertificateHealth scans all TLS secrets and counts by expiry bucket.
-func (s *Server) getDashboardCertificateHealth(namespace string) *DashboardCertificateHealth {
+// getDashboardCertificateHealth scans TLS secrets in the given
+// namespaces and counts by expiry bucket. Empty `namespaces` means
+// "every namespace the cache exposes" (matches the convention used
+// throughout this package).
+//
+// SKY-834 bug 54: previously this took a single `namespace string`,
+// and the caller only forwarded it when the user had selected
+// EXACTLY one namespace — for any other count (0 = all, 2+ = some
+// subset) the call collapsed to the empty-string "all namespaces"
+// path. Result: the Home Cert Health card and the Secrets list page
+// counted from different namespace scopes. With a 2-namespace
+// selection the Home card would show "0 Expired" while the Secrets
+// page (which always respects the full selection) showed multiple
+// expired TLS bundles.
+//
+// Now takes the full slice and forwards it untouched, matching the
+// shape of `getDashboardAudit`, `getDashboardNetworkPolicyCoverage`,
+// etc.
+func (s *Server) getDashboardCertificateHealth(namespaces []string) *DashboardCertificateHealth {
 	cache := k8s.GetResourceCache()
 	if cache == nil {
 		return nil
 	}
 
 	provider := k8s.NewTopologyResourceProvider(cache)
-	var namespaces []string
-	if namespace != "" {
-		namespaces = []string{namespace}
-	}
 
 	expiry, err := topology.GetCertificateExpiry(provider, namespaces)
 	if err != nil {

--- a/internal/server/certificate.go
+++ b/internal/server/certificate.go
@@ -59,23 +59,9 @@ type DashboardCertificateHealth struct {
 }
 
 // getDashboardCertificateHealth scans TLS secrets in the given
-// namespaces and counts by expiry bucket. Empty `namespaces` means
-// "every namespace the cache exposes" (matches the convention used
-// throughout this package).
-//
-// SKY-834 bug 54: previously this took a single `namespace string`,
-// and the caller only forwarded it when the user had selected
-// EXACTLY one namespace — for any other count (0 = all, 2+ = some
-// subset) the call collapsed to the empty-string "all namespaces"
-// path. Result: the Home Cert Health card and the Secrets list page
-// counted from different namespace scopes. With a 2-namespace
-// selection the Home card would show "0 Expired" while the Secrets
-// page (which always respects the full selection) showed multiple
-// expired TLS bundles.
-//
-// Now takes the full slice and forwards it untouched, matching the
-// shape of `getDashboardAudit`, `getDashboardNetworkPolicyCoverage`,
-// etc.
+// namespaces and counts by expiry bucket. nil namespaces means
+// "every namespace the cache exposes"; an empty slice means none
+// (matches the MatchesNamespace contract used throughout this package).
 func (s *Server) getDashboardCertificateHealth(namespaces []string) *DashboardCertificateHealth {
 	cache := k8s.GetResourceCache()
 	if cache == nil {

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -305,7 +305,7 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	resp.TopologySummary = s.getDashboardTopologySummary(namespaces)
 	k8s.LogTiming("  [dashboard] topology: %v", time.Since(t))
 
-	resp.CertificateHealth = s.getDashboardCertificateHealth(namespace)
+	resp.CertificateHealth = s.getDashboardCertificateHealth(namespaces)
 	resp.NetworkPolicyCoverage = s.getDashboardNetworkPolicyCoverage(cache, namespaces)
 	resp.Audit = getDashboardAudit(cache, namespaces)
 

--- a/pkg/topology/certificates_test.go
+++ b/pkg/topology/certificates_test.go
@@ -1,0 +1,167 @@
+package topology
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// SKY-834 bug 54: the Home Cert Health card disagreed with the
+// Secrets list page on how many TLS certs were expired. The two
+// endpoints both flow through GetCertificateExpiry, so they SHOULD
+// agree — but the dashboard wrapper used to take a single namespace
+// argument and was only forwarded by the caller when the user had
+// EXACTLY one namespace selected. With 2+ namespaces selected the
+// dashboard collapsed to the empty-string ("all namespaces") path
+// and counted certs from namespaces the Secrets page wasn't
+// listing — leaving the user with an inconsistent picture.
+//
+// These tests pin the namespace-filter contract that both call paths
+// now rely on:
+//
+//  1. nil/empty namespaces → all secrets visible to the provider
+//     are scanned.
+//  2. A specific list filters to only those namespaces and excludes
+//     everything else.
+//  3. Multi-namespace selection works (the original failure mode).
+
+// genTLSSecret produces a TLS Secret with a valid PEM-encoded cert
+// expiring in `daysFromNow` days. Negative values produce expired
+// certs. Used to build a deterministic fixture for the table-test
+// below without hitting the filesystem.
+func genTLSSecret(t *testing.T, namespace, name string, daysFromNow int) *corev1.Secret {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	tpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: name},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Duration(daysFromNow) * 24 * time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tpl, tpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("createcert: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Type:       corev1.SecretTypeTLS,
+		Data:       map[string][]byte{"tls.crt": pemBytes},
+	}
+}
+
+func TestGetCertificateExpiry_NamespaceFiltering(t *testing.T) {
+	// Three TLS secrets across three namespaces, each with a
+	// different expiry posture.
+	prov := &mockProvider{
+		secrets: []*corev1.Secret{
+			genTLSSecret(t, "ns-a", "cert-a-expired", -7),  // expired 7d ago
+			genTLSSecret(t, "ns-b", "cert-b-warning", 15),  // < 30d
+			genTLSSecret(t, "ns-c", "cert-c-healthy", 200), // healthy
+		},
+	}
+
+	cases := []struct {
+		name       string
+		namespaces []string
+		want       []string // keys (ns/name) we expect to appear
+	}{
+		{
+			// "all namespaces" path: dashboard.go signals this with
+			// a nil slice (see MatchesNamespace contract).
+			name:       "nil namespaces returns every TLS secret",
+			namespaces: nil,
+			want:       []string{"ns-a/cert-a-expired", "ns-b/cert-b-warning", "ns-c/cert-c-healthy"},
+		},
+		{
+			// Important contract distinction: an empty (non-nil)
+			// slice is a meaningful "no namespaces selected" state,
+			// NOT a synonym for "all". Pin it so a future refactor
+			// of MatchesNamespace doesn't silently flip the meaning
+			// and reintroduce SKY-834-style mismatches.
+			name:       "empty slice matches no namespaces",
+			namespaces: []string{},
+			want:       []string{},
+		},
+		{
+			name:       "single namespace filters to that namespace only",
+			namespaces: []string{"ns-a"},
+			want:       []string{"ns-a/cert-a-expired"},
+		},
+		{
+			// The exact failure mode of bug 54: 2-namespace
+			// selection. Pre-fix, the dashboard wrapper would
+			// collapse this to the all-namespaces path and the
+			// Secrets list page would honour both → mismatched
+			// counts in the UI.
+			name:       "multi-namespace selection returns ONLY those namespaces",
+			namespaces: []string{"ns-a", "ns-b"},
+			want:       []string{"ns-a/cert-a-expired", "ns-b/cert-b-warning"},
+		},
+		{
+			name:       "namespace with no TLS secrets returns empty",
+			namespaces: []string{"ns-d"},
+			want:       []string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := GetCertificateExpiry(prov, tc.namespaces)
+			if err != nil {
+				t.Fatalf("GetCertificateExpiry: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d entries, want %d (%v vs %v)", len(got), len(tc.want), keys(got), tc.want)
+			}
+			for _, k := range tc.want {
+				if _, ok := got[k]; !ok {
+					t.Errorf("missing key %q in result %v", k, keys(got))
+				}
+			}
+		})
+	}
+}
+
+func TestGetCertificateExpiry_ExpiredFlag(t *testing.T) {
+	// Defensive pin: the Expired flag on the entry should reflect
+	// whether NotAfter is in the past. Both the dashboard and the
+	// Secrets list page use this flag; a regression here would
+	// reintroduce SKY-834 by a different route.
+	prov := &mockProvider{
+		secrets: []*corev1.Secret{
+			genTLSSecret(t, "ns", "expired", -1),
+			genTLSSecret(t, "ns", "valid", 10),
+		},
+	}
+	got, err := GetCertificateExpiry(prov, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !got["ns/expired"].Expired {
+		t.Errorf("expected ns/expired.Expired=true, got %+v", got["ns/expired"])
+	}
+	if got["ns/valid"].Expired {
+		t.Errorf("expected ns/valid.Expired=false, got %+v", got["ns/valid"])
+	}
+}
+
+func keys(m map[string]CertExpiry) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/pkg/topology/certificates_test.go
+++ b/pkg/topology/certificates_test.go
@@ -15,29 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// SKY-834 bug 54: the Home Cert Health card disagreed with the
-// Secrets list page on how many TLS certs were expired. The two
-// endpoints both flow through GetCertificateExpiry, so they SHOULD
-// agree — but the dashboard wrapper used to take a single namespace
-// argument and was only forwarded by the caller when the user had
-// EXACTLY one namespace selected. With 2+ namespaces selected the
-// dashboard collapsed to the empty-string ("all namespaces") path
-// and counted certs from namespaces the Secrets page wasn't
-// listing — leaving the user with an inconsistent picture.
-//
-// These tests pin the namespace-filter contract that both call paths
-// now rely on:
-//
-//  1. nil/empty namespaces → all secrets visible to the provider
-//     are scanned.
-//  2. A specific list filters to only those namespaces and excludes
-//     everything else.
-//  3. Multi-namespace selection works (the original failure mode).
-
-// genTLSSecret produces a TLS Secret with a valid PEM-encoded cert
-// expiring in `daysFromNow` days. Negative values produce expired
-// certs. Used to build a deterministic fixture for the table-test
-// below without hitting the filesystem.
 func genTLSSecret(t *testing.T, namespace, name string, daysFromNow int) *corev1.Secret {
 	t.Helper()
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -63,34 +40,28 @@ func genTLSSecret(t *testing.T, namespace, name string, daysFromNow int) *corev1
 }
 
 func TestGetCertificateExpiry_NamespaceFiltering(t *testing.T) {
-	// Three TLS secrets across three namespaces, each with a
-	// different expiry posture.
 	prov := &mockProvider{
 		secrets: []*corev1.Secret{
-			genTLSSecret(t, "ns-a", "cert-a-expired", -7),  // expired 7d ago
-			genTLSSecret(t, "ns-b", "cert-b-warning", 15),  // < 30d
-			genTLSSecret(t, "ns-c", "cert-c-healthy", 200), // healthy
+			genTLSSecret(t, "ns-a", "cert-a-expired", -7),
+			genTLSSecret(t, "ns-b", "cert-b-warning", 15),
+			genTLSSecret(t, "ns-c", "cert-c-healthy", 200),
 		},
 	}
 
 	cases := []struct {
 		name       string
 		namespaces []string
-		want       []string // keys (ns/name) we expect to appear
+		want       []string
 	}{
 		{
-			// "all namespaces" path: dashboard.go signals this with
-			// a nil slice (see MatchesNamespace contract).
 			name:       "nil namespaces returns every TLS secret",
 			namespaces: nil,
 			want:       []string{"ns-a/cert-a-expired", "ns-b/cert-b-warning", "ns-c/cert-c-healthy"},
 		},
 		{
-			// Important contract distinction: an empty (non-nil)
-			// slice is a meaningful "no namespaces selected" state,
-			// NOT a synonym for "all". Pin it so a future refactor
-			// of MatchesNamespace doesn't silently flip the meaning
-			// and reintroduce SKY-834-style mismatches.
+			// Empty (non-nil) slice means "no namespaces selected", NOT
+			// "all". Pin so a refactor of MatchesNamespace doesn't
+			// silently flip the meaning.
 			name:       "empty slice matches no namespaces",
 			namespaces: []string{},
 			want:       []string{},
@@ -101,11 +72,6 @@ func TestGetCertificateExpiry_NamespaceFiltering(t *testing.T) {
 			want:       []string{"ns-a/cert-a-expired"},
 		},
 		{
-			// The exact failure mode of bug 54: 2-namespace
-			// selection. Pre-fix, the dashboard wrapper would
-			// collapse this to the all-namespaces path and the
-			// Secrets list page would honour both → mismatched
-			// counts in the UI.
 			name:       "multi-namespace selection returns ONLY those namespaces",
 			namespaces: []string{"ns-a", "ns-b"},
 			want:       []string{"ns-a/cert-a-expired", "ns-b/cert-b-warning"},
@@ -136,10 +102,6 @@ func TestGetCertificateExpiry_NamespaceFiltering(t *testing.T) {
 }
 
 func TestGetCertificateExpiry_ExpiredFlag(t *testing.T) {
-	// Defensive pin: the Expired flag on the entry should reflect
-	// whether NotAfter is in the past. Both the dashboard and the
-	// Secrets list page use this flag; a regression here would
-	// reintroduce SKY-834 by a different route.
 	prov := &mockProvider{
 		secrets: []*corev1.Secret{
 			genTLSSecret(t, "ns", "expired", -1),


### PR DESCRIPTION
Linear: [SKY-834](https://linear.app/skyhook/issue/SKY-834)

## Why
**Bug 54**: the Home → Cert Health card and the Secrets list page disagreed on how many TLS certs were expired whenever the user had **2+ namespaces** selected.

Both endpoints flow through `topology.GetCertificateExpiry`, but the dashboard wrapper used to take a single `namespace string` and the caller only forwarded it when EXACTLY one namespace was selected — for any other count (0 = all, 2+ = subset) the call collapsed to the empty-string "all namespaces" path.

Net effect: with a 2-namespace selection the Home card would show "0 Expired" while the Secrets page (which always honoured the full selection) showed multiple expired TLS bundles.

## What
- `internal/server/certificate.go` — `getDashboardCertificateHealth` now takes `[]string` and forwards the full slice, matching the shape of `getDashboardAudit` / `getDashboardNetworkPolicyCoverage`.
- `internal/server/dashboard.go` — caller passes the full `namespaces` slice instead of the truncated single-string compat var.
- `pkg/topology/certificates_test.go` (new) — pins the `GetCertificateExpiry` namespace contract:
  - `nil` → all namespaces
  - `[]` → no namespaces (meaningful "nothing selected" state)
  - single namespace → filters to that one
  - **multi-namespace selection → returns ONLY those namespaces** (the exact failure mode of bug 54)
  - namespace with no TLS secrets → empty
  - plus an `ExpiredFlag` test pinning the `Expired` boolean both call paths rely on.

## Out of scope
**Bug 52** (junk / orphan clusters in the cluster list after deletion) is investigative — separate PR once we agree on retention policy. No code change in this PR.

## Test plan
- [x] `go build ./...`
- [x] `cd pkg/topology && go test ./...` (all green; 6 new subtests for cert namespace filtering)
- [ ] Manual: Home card vs Secrets page agree on expired-cert count for 2-namespace selection
- [ ] Manual: single-namespace, all-namespaces selections still work

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small server-side wiring change to pass the full namespace filter into certificate health aggregation, plus new unit tests pinning namespace filtering semantics.
> 
> **Overview**
> Fixes the dashboard cert-health aggregation to **respect the full namespace selection** by changing `getDashboardCertificateHealth` to accept a `[]string` namespace filter (with `nil` meaning all and `[]` meaning none) and updating the dashboard handler to pass the full slice.
> 
> Adds `pkg/topology/certificates_test.go` to pin `GetCertificateExpiry` behavior for nil vs empty vs multi-namespace filters and to verify the `Expired` flag is set correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5911a83f0036d9c5cbf0c9d8352b5f1276efa6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->