### PR TITLE
chore: release-radar-app menu option + dependabot k8s/otel grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,14 @@ updates:
       interval: weekly
     commit-message:
       prefix: "deps(go):"
+    groups:
+      k8s:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      otel:
+        patterns:
+          - "go.opentelemetry.io/*"
 
   - package-ecosystem: npm
     directory: /

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -249,6 +249,77 @@ release_k8s_ui() {
   echo ""
 }
 
+release_radar_app() {
+  echo ""
+  echo -e "${BLUE}=========================================="
+  echo "  @skyhook-io/radar-app Release"
+  echo -e "==========================================${NC}"
+  echo ""
+  echo "This publishes @skyhook-io/radar-app to npm."
+  echo "Tags use the prefix 'radar-app-' (e.g. radar-app-v0.1.0)."
+  echo ""
+  warn "Reminder: radar-app's peerDependency on @skyhook-io/k8s-ui resolves"
+  warn "to '>=1.5.0'. If your changes rely on new k8s-ui exports, publish"
+  warn "the matching k8s-ui version FIRST (option 3)."
+  echo ""
+
+  git fetch --tags 2>/dev/null || true
+
+  LATEST_RADAR_APP_TAG=$(git tag -l 'radar-app-v*' --sort=-v:refname | head -n1)
+  LATEST_RADAR_APP_TAG=${LATEST_RADAR_APP_TAG:-radar-app-v0.0.0}
+  LATEST_RADAR_APP_VER=${LATEST_RADAR_APP_TAG#radar-app-}
+
+  info "Latest radar-app release: $LATEST_RADAR_APP_TAG"
+  echo ""
+  echo "Choose release version:"
+  echo "  1) Patch  radar-app-$(increment_version "$LATEST_RADAR_APP_VER" patch)"
+  echo "  2) Minor  radar-app-$(increment_version "$LATEST_RADAR_APP_VER" minor)"
+  echo "  3) Major  radar-app-$(increment_version "$LATEST_RADAR_APP_VER" major)"
+  echo "  4) Custom"
+  echo ""
+  read -p "Choice (1-4): " choice
+
+  case $choice in
+    1) RADAR_APP_VERSION="radar-app-$(increment_version "$LATEST_RADAR_APP_VER" patch)" ;;
+    2) RADAR_APP_VERSION="radar-app-$(increment_version "$LATEST_RADAR_APP_VER" minor)" ;;
+    3) RADAR_APP_VERSION="radar-app-$(increment_version "$LATEST_RADAR_APP_VER" major)" ;;
+    4) read -p "Enter version (e.g., radar-app-v0.2.0): " RADAR_APP_VERSION ;;
+    *) error "Invalid choice" ;;
+  esac
+
+  if [[ ! $RADAR_APP_VERSION =~ ^radar-app-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    error "Invalid version format: $RADAR_APP_VERSION (expected radar-app-vX.Y.Z)"
+  fi
+
+  if [ -n "$(git status --porcelain)" ]; then
+    warn "You have uncommitted changes"
+    git status --short
+    echo ""
+    read -p "Continue anyway? (y/n): " -n 1 -r
+    echo
+    [[ $REPLY =~ ^[Yy]$ ]] || exit 1
+  fi
+
+  echo ""
+  echo "  Tag: $RADAR_APP_VERSION"
+  echo ""
+  read -p "Proceed? (y/n): " -n 1 -r
+  echo
+  [[ $REPLY =~ ^[Yy]$ ]] || exit 1
+
+  git tag "$RADAR_APP_VERSION"
+  git push origin "$RADAR_APP_VERSION"
+
+  echo ""
+  info "Tag pushed! GitHub Actions will publish @skyhook-io/radar-app to npm."
+  echo ""
+  echo "  Consumers can now run:"
+  echo "    npm install @skyhook-io/radar-app@${RADAR_APP_VERSION#radar-app-v}"
+  echo ""
+  echo "  Watch progress: gh run watch"
+  echo ""
+}
+
 release_pkg() {
   echo ""
   echo -e "${BLUE}=========================================="
@@ -327,15 +398,17 @@ main() {
   echo -e "==========================================${NC}"
   echo ""
   echo "What would you like to release?"
-  echo "  1) Radar app      (v*.*.*)"
-  echo "  2) pkg module     (pkg/v*.*.*)"
+  echo "  1) Radar app          (v*.*.*)"
+  echo "  2) pkg module         (pkg/v*.*.*)"
   echo "  3) @skyhook-io/k8s-ui (k8s-ui-v*.*.*)"
+  echo "  4) @skyhook-io/radar-app (radar-app-v*.*.*)"
   echo ""
-  read -p "Choice (1-3): " release_choice
+  read -p "Choice (1-4): " release_choice
   case $release_choice in
     1) : ;; # continue to app release flow below
     2) release_pkg; exit 0 ;;
     3) release_k8s_ui; exit 0 ;;
+    4) release_radar_app; exit 0 ;;
     *) error "Invalid choice" ;;
   esac
 


### PR DESCRIPTION
## Summary
Two small chore commits bundled together:

1. **\`scripts/release.sh\`** — Adds a 4th menu option to the interactive release script for publishing \`@skyhook-io/radar-app\` (npm). Wires the existing \`publish-radar-app.yml\` workflow (triggered by \`radar-app-v<semver>\` tags) into the same patch/minor/major/custom flow used by the other release tracks.

2. **\`.github/dependabot.yml\`** — Adds groupings for \`k8s.io/*\`/\`sigs.k8s.io/*\` and \`go.opentelemetry.io/*\` go modules. The k8s.io modules must move in lockstep; receiving them as 4 separate PRs (as happened with the 0.36.0 bump that became #591) forces manual coordination. Future minor bumps will arrive as a single reviewable PR.

## Test plan
- [ ] dependabot recognizes the new groups on its next weekly run
- [ ] release.sh option 4 prompts for a \`radar-app-v*\` tag and pushes it (will validate on next radar-app release)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only affects release/dependency automation (tagging flow and Dependabot grouping) with no production runtime impact; main risk is accidental tagging/publishing if the new menu option is misused.
> 
> **Overview**
> Adds a new `release_radar_app` path to `scripts/release.sh` and wires it into the main menu so maintainers can tag and publish `@skyhook-io/radar-app` via `radar-app-vX.Y.Z` tags, using the same patch/minor/major/custom prompting and safety checks as other release targets.
> 
> Updates `.github/dependabot.yml` to **group Go module bumps** for Kubernetes (`k8s.io/*`, `sigs.k8s.io/*`) and OpenTelemetry (`go.opentelemetry.io/*`) dependencies into single PRs instead of many separate ones.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac0e1b6bad331455ea26328c9a98f996e45144fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->