### PR TITLE
cleanup(ui): centralize duplicate badge colors and align Helm wizard with brand

### DIFF
--- a/packages/k8s-ui/src/components/resources/renderers/AWSManagedMachinePoolRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/AWSManagedMachinePoolRenderer.tsx
@@ -3,6 +3,7 @@ import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
 import { getCAPIConditions } from '../resource-utils-capi'
 import { getAWSMMPStatus, getAWSMMPInstanceType, getAWSMMPCapacityType, getAWSMMPAMIType, getAWSMMPNodegroupName, getAWSMMPScaling } from '../resource-utils-aws-capi'
+import { CAPACITY_TYPE_BADGE } from '../../../utils/badge-colors'
 
 interface Props {
   data: any
@@ -39,10 +40,7 @@ export function AWSManagedMachinePoolRenderer({ data }: Props) {
           <Property label="Instance Type" value={getAWSMMPInstanceType(data)} />
           <Property label="AMI Type" value={getAWSMMPAMIType(data)} />
           <Property label="Capacity Type" value={
-            <span className={clsx('badge badge-sm', capacityType === 'spot'
-              ? 'bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-950/50 dark:text-amber-400 dark:border-amber-700/40'
-              : 'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40'
-            )}>{capacityType === 'onDemand' ? 'On-Demand' : capacityType}</span>
+            <span className={clsx('badge badge-sm', capacityType === 'spot' ? CAPACITY_TYPE_BADGE.spot : CAPACITY_TYPE_BADGE.onDemand)}>{capacityType === 'onDemand' ? 'On-Demand' : capacityType}</span>
           } />
           {spec.roleName && <Property label="IAM Role" value={spec.roleName} />}
         </PropertyList>

--- a/packages/k8s-ui/src/components/resources/renderers/ArgoApplicationRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ArgoApplicationRenderer.tsx
@@ -9,6 +9,7 @@ import {
   type ArgoAppStatus,
   type ArgoResource,
 } from '../../../types/gitops'
+import { BADGE_INACTIVE } from '../../../utils/badge-colors'
 
 interface ArgoApplicationRendererProps {
   data: any
@@ -192,7 +193,7 @@ export function ArgoApplicationRenderer({ data, onTerminate, isTerminating }: Ar
               <span
                 className={clsx(
                   'badge',
-                  syncPolicy.automated ? 'bg-green-500/20 text-green-400' : 'bg-gray-500/20 text-gray-400'
+                  syncPolicy.automated ? 'bg-green-500/20 text-green-400' : BADGE_INACTIVE
                 )}
               >
                 {syncPolicy.automated ? 'Enabled' : 'Disabled'}
@@ -241,7 +242,7 @@ export function ArgoApplicationRenderer({ data, onTerminate, isTerminating }: Ar
                       ? 'bg-blue-500/20 text-blue-400'
                       : operationState.phase === 'Failed' || operationState.phase === 'Error'
                       ? 'bg-red-500/20 text-red-400'
-                      : 'bg-gray-500/20 text-gray-400'
+                      : BADGE_INACTIVE
                   )}
                 >
                   {operationState.phase}

--- a/packages/k8s-ui/src/components/resources/renderers/AzureManagedMachinePoolRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/AzureManagedMachinePoolRenderer.tsx
@@ -3,6 +3,7 @@ import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
 import { getCAPIConditions } from '../resource-utils-capi'
 import { getAzureMMPStatus, getAzureMMPSKU, getAzureMMPMode, getAzureMMPOSDiskInfo, getAzureMMPScaling, getAzureMMPScaleSetPriority, getAzureMMPOSType } from '../resource-utils-azure-capi'
+import { CAPACITY_TYPE_BADGE, NODEPOOL_MODE_BADGE } from '../../../utils/badge-colors'
 
 interface Props {
   data: any
@@ -34,18 +35,12 @@ export function AzureManagedMachinePoolRenderer({ data }: Props) {
           {spec.name && <Property label="Pool Name" value={spec.name} />}
           <Property label="VM Size" value={getAzureMMPSKU(data)} />
           <Property label="Mode" value={
-            <span className={clsx('badge badge-sm', mode === 'System'
-              ? 'bg-purple-100 text-purple-800 border-purple-300 dark:bg-purple-950/50 dark:text-purple-400 dark:border-purple-700/40'
-              : 'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40'
-            )}>{mode}</span>
+            <span className={clsx('badge badge-sm', NODEPOOL_MODE_BADGE[mode] || NODEPOOL_MODE_BADGE.User)}>{mode}</span>
           } />
           <Property label="OS" value={getAzureMMPOSType(data)} />
           <Property label="OS Disk" value={getAzureMMPOSDiskInfo(data)} />
           <Property label="Priority" value={
-            <span className={clsx('badge badge-sm', priority === 'Spot'
-              ? 'bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-950/50 dark:text-amber-400 dark:border-amber-700/40'
-              : 'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40'
-            )}>{priority}</span>
+            <span className={clsx('badge badge-sm', priority === 'Spot' ? CAPACITY_TYPE_BADGE.spot : CAPACITY_TYPE_BADGE.regular)}>{priority}</span>
           } />
           {spec.maxPods != null && <Property label="Max Pods" value={String(spec.maxPods)} />}
         </PropertyList>

--- a/packages/k8s-ui/src/components/resources/renderers/ChallengeRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ChallengeRenderer.tsx
@@ -2,6 +2,7 @@ import { Shield, AlertTriangle, Globe, Key, FileText } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection } from '../../ui/drawer-components'
 import { getSolverType } from './ClusterIssuerRenderer'
+import { BADGE_INACTIVE } from '../../../utils/badge-colors'
 
 function getChallengeStateBadge(state: string): { color: string; text: string } {
   switch (state?.toLowerCase()) {
@@ -20,7 +21,7 @@ function getChallengeStateBadge(state: string): { color: string; text: string } 
     case 'errored':
       return { text: 'Errored', color: 'bg-red-500/20 text-red-400' }
     default:
-      return { text: state || 'Unknown', color: 'bg-gray-500/20 text-gray-400' }
+      return { text: state || 'Unknown', color: BADGE_INACTIVE }
   }
 }
 

--- a/packages/k8s-ui/src/components/resources/renderers/ClusterComplianceReportRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ClusterComplianceReportRenderer.tsx
@@ -5,6 +5,7 @@ import { Section, PropertyList, Property, AlertBanner } from '../../ui/drawer-co
 import { formatAge } from '../resource-utils'
 import { SEVERITY_BADGE_COLORS, SEVERITY_ORDER } from './trivy-shared'
 import { pluralize } from '../../../utils/pluralize'
+import { BADGE_INACTIVE } from '../../../utils/badge-colors'
 
 interface ClusterComplianceReportRendererProps {
   data: any
@@ -185,7 +186,7 @@ export function ClusterComplianceReportRenderer({ data }: ClusterComplianceRepor
                       ) : (
                         <CheckCircle2 className="w-3.5 h-3.5 text-green-400 shrink-0" />
                       )}
-                      <span className={clsx('px-1.5 py-0.5 rounded text-[10px] font-medium shrink-0', SEVERITY_BADGE_COLORS[check.severity] || 'bg-gray-500/20 text-gray-400')}>
+                      <span className={clsx('px-1.5 py-0.5 rounded text-[10px] font-medium shrink-0', SEVERITY_BADGE_COLORS[check.severity] || BADGE_INACTIVE)}>
                         {check.severity || '-'}
                       </span>
                       <span className="text-xs text-theme-text-secondary truncate flex-1">{check.name || check.id}</span>

--- a/packages/k8s-ui/src/components/resources/renderers/ConfigAuditReportRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ConfigAuditReportRenderer.tsx
@@ -4,6 +4,7 @@ import { clsx } from 'clsx'
 import { Section, PropertyList, Property } from '../../ui/drawer-components'
 import { formatAge } from '../resource-utils'
 import { SEVERITY_BADGE_COLORS, SEVERITY_ORDER, TrivyAlertBanner } from './trivy-shared'
+import { BADGE_INACTIVE } from '../../../utils/badge-colors'
 
 interface ConfigAuditReportRendererProps {
   data: any
@@ -169,7 +170,7 @@ export function ConfigAuditReportRenderer({ data }: ConfigAuditReportRendererPro
                       ) : (
                         <XCircle className="w-3.5 h-3.5 text-red-400 shrink-0" />
                       )}
-                      <span className={clsx('px-1.5 py-0.5 rounded text-[10px] font-medium shrink-0', SEVERITY_BADGE_COLORS[group.severity] || 'bg-gray-500/20 text-gray-400')}>
+                      <span className={clsx('px-1.5 py-0.5 rounded text-[10px] font-medium shrink-0', SEVERITY_BADGE_COLORS[group.severity] || BADGE_INACTIVE)}>
                         {group.severity}
                       </span>
                       <span className="text-xs text-theme-text-secondary truncate flex-1">{group.title}</span>

--- a/packages/k8s-ui/src/components/resources/renderers/ExposedSecretReportRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ExposedSecretReportRenderer.tsx
@@ -5,6 +5,7 @@ import { Section, PropertyList, Property } from '../../ui/drawer-components'
 import { formatAge } from '../resource-utils'
 import { SEVERITY_BADGE_COLORS, TrivyAlertBanner, formatTrivyImage } from './trivy-shared'
 import { pluralize } from '../../../utils/pluralize'
+import { BADGE_INACTIVE } from '../../../utils/badge-colors'
 
 interface ExposedSecretReportRendererProps {
   data: any
@@ -92,7 +93,7 @@ export function ExposedSecretReportRenderer({ data }: ExposedSecretReportRendere
                     <tr key={`${secret.ruleID || i}-${i}`} className="border-b border-theme-border/50 hover:bg-theme-hover/50">
                       <td className="py-1.5 px-1 text-theme-text-secondary font-mono">{secret.ruleID || '-'}</td>
                       <td className="py-1.5 px-1">
-                        <span className={clsx('px-1.5 py-0.5 rounded text-[10px] font-medium', SEVERITY_BADGE_COLORS[secret.severity] || 'bg-gray-500/20 text-gray-400')}>
+                        <span className={clsx('px-1.5 py-0.5 rounded text-[10px] font-medium', SEVERITY_BADGE_COLORS[secret.severity] || BADGE_INACTIVE)}>
                           {secret.severity || '-'}
                         </span>
                       </td>

--- a/packages/k8s-ui/src/components/resources/renderers/GatewayClassRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/GatewayClassRenderer.tsx
@@ -1,6 +1,7 @@
 import { Cpu } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
+import { BADGE_INACTIVE } from '../../../utils/badge-colors'
 
 interface GatewayClassRendererProps {
   data: any
@@ -40,7 +41,7 @@ export function GatewayClassRenderer({ data }: GatewayClassRendererProps) {
                   ? 'bg-green-500/20 text-green-400'
                   : isNotAccepted
                     ? 'bg-red-500/20 text-red-400'
-                    : 'bg-gray-500/20 text-gray-400'
+                    : BADGE_INACTIVE
               )}>
                 {isAccepted ? 'True' : isNotAccepted ? 'False' : 'Unknown'}
               </span>

--- a/packages/k8s-ui/src/components/resources/renderers/GatewayRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/GatewayRenderer.tsx
@@ -1,6 +1,7 @@
 import { Globe, Radio, Lock } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
+import { BADGE_INACTIVE } from '../../../utils/badge-colors'
 
 const protocolColors: Record<string, string> = {
   HTTP: 'bg-blue-500/20 text-blue-400',
@@ -73,7 +74,7 @@ export function GatewayRenderer({ data, onNavigate }: GatewayRendererProps) {
                   ? 'bg-green-500/20 text-green-400'
                   : isNotAccepted
                     ? 'bg-red-500/20 text-red-400'
-                    : 'bg-gray-500/20 text-gray-400'
+                    : BADGE_INACTIVE
               )}>
                 {isAccepted ? 'True' : isNotAccepted ? 'False' : 'Unknown'}
               </span>
@@ -88,7 +89,7 @@ export function GatewayRenderer({ data, onNavigate }: GatewayRendererProps) {
                   ? 'bg-green-500/20 text-green-400'
                   : isNotProgrammed
                     ? 'bg-red-500/20 text-red-400'
-                    : 'bg-gray-500/20 text-gray-400'
+                    : BADGE_INACTIVE
               )}>
                 {isProgrammed ? 'True' : isNotProgrammed ? 'False' : 'Unknown'}
               </span>
@@ -134,7 +135,7 @@ export function GatewayRenderer({ data, onNavigate }: GatewayRendererProps) {
                     <span className="text-sm font-medium text-theme-text-primary">{listener.name}</span>
                     <span className={clsx(
                       'px-1.5 py-0.5 rounded text-[10px] font-medium',
-                      protocolColors[listener.protocol] || 'bg-gray-500/20 text-gray-400'
+                      protocolColors[listener.protocol] || BADGE_INACTIVE
                     )}>
                       {listener.protocol}:{listener.port}
                     </span>
@@ -157,7 +158,7 @@ export function GatewayRenderer({ data, onNavigate }: GatewayRendererProps) {
                           ? 'bg-green-500/20 text-green-400'
                           : isListenerNotAccepted
                             ? 'bg-red-500/20 text-red-400'
-                            : 'bg-gray-500/20 text-gray-400'
+                            : BADGE_INACTIVE
                       )}>
                         {isListenerAccepted ? '\u2713' : isListenerNotAccepted ? '\u2717' : '?'}
                       </span>

--- a/packages/k8s-ui/src/components/resources/renderers/IngressClassRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/IngressClassRenderer.tsx
@@ -1,6 +1,7 @@
 import { Globe } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property } from '../../ui/drawer-components'
+import { BADGE_INACTIVE } from '../../../utils/badge-colors'
 
 interface IngressClassRendererProps {
   data: any
@@ -24,7 +25,7 @@ export function IngressClassRenderer({ data }: IngressClassRendererProps) {
                 'badge',
                 isDefault
                   ? 'bg-green-500/20 text-green-400'
-                  : 'bg-gray-500/20 text-gray-400'
+                  : BADGE_INACTIVE
               )}>
                 {isDefault ? 'Yes' : 'No'}
               </span>

--- a/packages/k8s-ui/src/components/resources/renderers/IstioAuthorizationPolicyRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/IstioAuthorizationPolicyRenderer.tsx
@@ -6,6 +6,7 @@ import {
   getAuthorizationPolicyRules,
   getAuthorizationPolicySelector,
 } from '../resource-utils-istio'
+import { BADGE_INACTIVE } from '../../../utils/badge-colors'
 
 const actionColors: Record<string, string> = {
   ALLOW: 'bg-green-500/20 text-green-400',
@@ -52,7 +53,7 @@ export function IstioAuthorizationPolicyRenderer({ data }: IstioAuthorizationPol
           <Property label="Action" value={
             <span className={clsx(
               'badge',
-              actionColors[action] || 'bg-gray-500/20 text-gray-400'
+              actionColors[action] || BADGE_INACTIVE
             )}>
               {action}
             </span>

--- a/packages/k8s-ui/src/components/resources/renderers/IstioGatewayRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/IstioGatewayRenderer.tsx
@@ -6,6 +6,7 @@ import {
   getIstioGatewayServers,
   getIstioGatewaySelector,
 } from '../resource-utils-istio'
+import { BADGE_INACTIVE } from '../../../utils/badge-colors'
 
 const protocolColors: Record<string, string> = {
   HTTP: 'bg-blue-500/20 text-blue-400',
@@ -73,7 +74,7 @@ export function IstioGatewayRenderer({ data }: IstioGatewayRendererProps) {
                       </span>
                       <span className={clsx(
                         'px-1.5 py-0.5 rounded text-[10px] font-medium',
-                        protocolColors[protocol] || 'bg-gray-500/20 text-gray-400'
+                        protocolColors[protocol] || BADGE_INACTIVE
                       )}>
                         {protocol}:{server.port.number}
                       </span>
@@ -98,7 +99,7 @@ export function IstioGatewayRenderer({ data }: IstioGatewayRendererProps) {
                               ? 'bg-green-500/20 text-green-400'
                               : server.tls.mode === 'PASSTHROUGH'
                                 ? 'bg-blue-500/20 text-blue-400'
-                                : 'bg-gray-500/20 text-gray-400'
+                                : BADGE_INACTIVE
                           )}>
                             {server.tls.mode || 'SIMPLE'}
                           </span>

--- a/packages/k8s-ui/src/components/resources/renderers/IstioPeerAuthenticationRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/IstioPeerAuthenticationRenderer.tsx
@@ -6,12 +6,13 @@ import {
   getPeerAuthenticationSelector,
   getPeerAuthenticationPortLevelMtls,
 } from '../resource-utils-istio'
+import { BADGE_INACTIVE } from '../../../utils/badge-colors'
 
 const modeColors: Record<string, string> = {
   STRICT: 'bg-green-500/20 text-green-400',
   PERMISSIVE: 'bg-yellow-500/20 text-yellow-400',
   DISABLE: 'bg-red-500/20 text-red-400',
-  UNSET: 'bg-gray-500/20 text-gray-400',
+  UNSET: BADGE_INACTIVE,
 }
 
 interface IstioPeerAuthenticationRendererProps {

--- a/packages/k8s-ui/src/components/resources/renderers/KarpenterNodeClaimRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KarpenterNodeClaimRenderer.tsx
@@ -2,7 +2,7 @@ import { Server, Cpu, Settings } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
 import { kindToPlural } from '../../../utils/navigation'
-import { CAPACITY_TYPE_BADGE } from '../../../utils/badge-colors'
+import { CAPACITY_TYPE_BADGE, BADGE_INACTIVE } from '../../../utils/badge-colors'
 import {
   getNodeClaimStatus,
   getNodeClaimInstanceType,
@@ -188,7 +188,7 @@ export function KarpenterNodeClaimRenderer({ data, onNavigate }: KarpenterNodeCl
                     isComplete && 'bg-green-500/20 text-green-400',
                     isCurrent && 'bg-blue-500/20 text-blue-400',
                     isFailed && 'bg-red-500/20 text-red-400',
-                    isPending && !isCurrent && 'bg-gray-500/20 text-gray-400'
+                    isPending && !isCurrent && BADGE_INACTIVE
                   )}
                 >
                   {isComplete ? '\u2713' : isFailed ? '\u2717' : isCurrent ? '\u25CF' : '\u25CB'}

--- a/packages/k8s-ui/src/components/resources/renderers/KarpenterNodeClaimRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KarpenterNodeClaimRenderer.tsx
@@ -2,8 +2,8 @@ import { Server, Cpu, Settings } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
 import { kindToPlural } from '../../../utils/navigation'
+import { CAPACITY_TYPE_BADGE } from '../../../utils/badge-colors'
 import {
-  CAPACITY_TYPE_BADGE,
   getNodeClaimStatus,
   getNodeClaimInstanceType,
   getNodeClaimNodeName,

--- a/packages/k8s-ui/src/components/resources/renderers/OrderRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/OrderRenderer.tsx
@@ -1,6 +1,7 @@
 import { ShoppingCart, AlertTriangle, Globe, Shield } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection } from '../../ui/drawer-components'
+import { BADGE_INACTIVE } from '../../../utils/badge-colors'
 
 function getOrderStateBadge(state: string): { color: string; text: string } {
   switch (state?.toLowerCase()) {
@@ -17,7 +18,7 @@ function getOrderStateBadge(state: string): { color: string; text: string } {
     case 'errored':
       return { text: 'Errored', color: 'bg-red-500/20 text-red-400' }
     default:
-      return { text: state || 'Unknown', color: 'bg-gray-500/20 text-gray-400' }
+      return { text: state || 'Unknown', color: BADGE_INACTIVE }
   }
 }
 

--- a/packages/k8s-ui/src/components/resources/renderers/RoleBindingRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/RoleBindingRenderer.tsx
@@ -1,6 +1,7 @@
 import { Shield, Users } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ResourceLink, AlertBanner } from '../../ui/drawer-components'
+import { BADGE_INACTIVE } from '../../../utils/badge-colors'
 
 interface RoleBindingRendererProps {
   data: any
@@ -16,7 +17,7 @@ function getSubjectKindBadgeClass(kind: string): string {
     case 'Group':
       return 'bg-purple-500/20 text-purple-400'
     default:
-      return 'bg-gray-500/20 text-gray-400'
+      return BADGE_INACTIVE
   }
 }
 
@@ -27,7 +28,7 @@ function getRoleRefKindBadgeClass(kind: string): string {
     case 'ClusterRole':
       return 'bg-purple-500/20 text-purple-400'
     default:
-      return 'bg-gray-500/20 text-gray-400'
+      return BADGE_INACTIVE
   }
 }
 

--- a/packages/k8s-ui/src/components/resources/renderers/RolloutRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/RolloutRenderer.tsx
@@ -2,6 +2,7 @@ import { Server, GitBranch, AlertTriangle, Network } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, PodTemplateSection } from '../../ui/drawer-components'
 import { formatAge } from '../resource-utils'
+import { BADGE_INACTIVE } from '../../../utils/badge-colors'
 
 interface RolloutRendererProps {
   data: any
@@ -292,7 +293,7 @@ export function RolloutRenderer({ data }: RolloutRendererProps) {
                       'w-5 h-5 rounded-full flex items-center justify-center text-xs shrink-0',
                       isCompleted && 'bg-green-500/20 text-green-400',
                       isCurrent && 'bg-blue-500/20 text-blue-400',
-                      isPending && 'bg-gray-500/20 text-gray-400'
+                      isPending && BADGE_INACTIVE
                     )}
                   >
                     {isCompleted ? '\u2713' : isCurrent ? '\u25CF' : '\u25CB'}

--- a/packages/k8s-ui/src/components/resources/renderers/aws-capi-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/aws-capi-cells.tsx
@@ -2,6 +2,7 @@
 
 import { clsx } from 'clsx'
 import { Tooltip } from '../../ui/Tooltip'
+import { CAPACITY_TYPE_BADGE } from '../../../utils/badge-colors'
 import {
   getAWSMCPStatus, getAWSMCPEKSClusterName, getAWSMCPRegion, getAWSMCPVersion,
   getAWSMMPStatus, getAWSMMPInstanceType, getAWSMMPReplicas, getAWSMMPCapacityType,
@@ -57,10 +58,7 @@ export function AWSManagedMachinePoolCell({ resource, column }: { resource: any;
     case 'capacityType': {
       const ct = getAWSMMPCapacityType(resource)
       return (
-        <span className={clsx('badge badge-sm', ct === 'spot'
-          ? 'bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-950/50 dark:text-amber-400 dark:border-amber-700/40'
-          : 'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40'
-        )}>{ct === 'onDemand' ? 'On-Demand' : ct}</span>
+        <span className={clsx('badge badge-sm', ct === 'spot' ? CAPACITY_TYPE_BADGE.spot : CAPACITY_TYPE_BADGE.onDemand)}>{ct === 'onDemand' ? 'On-Demand' : ct}</span>
       )
     }
     default:

--- a/packages/k8s-ui/src/components/resources/renderers/azure-capi-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/azure-capi-cells.tsx
@@ -2,6 +2,7 @@
 
 import { Tooltip } from '../../ui/Tooltip'
 import { clsx } from 'clsx'
+import { CAPACITY_TYPE_BADGE, NODEPOOL_MODE_BADGE } from '../../../utils/badge-colors'
 import {
   getAzureMCPStatus, getAzureMCPLocation, getAzureMCPVersion, getAzureMCPResourceGroup,
   getAzureMMPStatus, getAzureMMPSKU, getAzureMMPMode, getAzureMMPReplicas, getAzureMMPScaleSetPriority,
@@ -40,20 +41,14 @@ export function AzureManagedMachinePoolCell({ resource, column }: { resource: an
     case 'mode': {
       const mode = getAzureMMPMode(resource)
       return (
-        <span className={clsx('badge badge-sm', mode === 'System'
-          ? 'bg-purple-100 text-purple-800 border-purple-300 dark:bg-purple-950/50 dark:text-purple-400 dark:border-purple-700/40'
-          : 'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40'
-        )}>{mode}</span>
+        <span className={clsx('badge badge-sm', NODEPOOL_MODE_BADGE[mode] || NODEPOOL_MODE_BADGE.User)}>{mode}</span>
       )
     }
     case 'replicas': return <TextCell value={getAzureMMPReplicas(resource)} />
     case 'priority': {
       const p = getAzureMMPScaleSetPriority(resource)
       return (
-        <span className={clsx('badge badge-sm', p === 'Spot'
-          ? 'bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-950/50 dark:text-amber-400 dark:border-amber-700/40'
-          : 'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40'
-        )}>{p}</span>
+        <span className={clsx('badge badge-sm', p === 'Spot' ? CAPACITY_TYPE_BADGE.spot : CAPACITY_TYPE_BADGE.regular)}>{p}</span>
       )
     }
     default: return <span className="text-sm text-theme-text-tertiary">-</span>

--- a/packages/k8s-ui/src/components/resources/renderers/istio-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/istio-cells.tsx
@@ -1,6 +1,7 @@
 // Istio cell components for ResourcesView table
 
 import { clsx } from 'clsx'
+import { BADGE_INACTIVE } from '../../../utils/badge-colors'
 import {
   getVirtualServiceStatus,
   getVirtualServiceHosts,
@@ -164,7 +165,7 @@ export function PeerAuthenticationCell({ resource, column }: { resource: any; co
       return (
         <span className={clsx(
           'badge',
-          modeColors[mode] || 'bg-gray-500/20 text-gray-400'
+          modeColors[mode] || BADGE_INACTIVE
         )}>
           {mode}
         </span>
@@ -194,7 +195,7 @@ export function AuthorizationPolicyCell({ resource, column }: { resource: any; c
       return (
         <span className={clsx(
           'badge',
-          actionColors[action] || 'bg-gray-500/20 text-gray-400'
+          actionColors[action] || BADGE_INACTIVE
         )}>
           {action}
         </span>

--- a/packages/k8s-ui/src/components/resources/renderers/karpenter-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/karpenter-cells.tsx
@@ -2,8 +2,8 @@
 
 import { clsx } from 'clsx'
 import { Tooltip } from '../../ui/Tooltip'
+import { CAPACITY_TYPE_BADGE } from '../../../utils/badge-colors'
 import {
-  CAPACITY_TYPE_BADGE,
   getNodePoolStatus,
   getNodePoolNodeClassRef,
   getNodePoolLimits,

--- a/packages/k8s-ui/src/components/resources/resource-utils-karpenter.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-karpenter.ts
@@ -3,12 +3,6 @@
 import type { StatusBadge } from './resource-utils'
 import { healthColors } from './resource-utils'
 
-// Shared capacity type badge colors for NodeClaim renderer and table cells
-export const CAPACITY_TYPE_BADGE: Record<string, string> = {
-  spot: 'bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-950/50 dark:text-amber-400 dark:border-amber-700/40',
-  'on-demand': 'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40',
-}
-
 // ============================================================================
 // KARPENTER NODEPOOL UTILITIES
 // ============================================================================

--- a/packages/k8s-ui/src/components/timeline/shared.tsx
+++ b/packages/k8s-ui/src/components/timeline/shared.tsx
@@ -244,21 +244,20 @@ export function EventMarker({ event, x, selected, onClick, dimmed, small }: Even
       return 'bg-theme-hover/30 border-2 border-dashed border-theme-border-light'
     }
 
-    const opacity = dimmed ? '/50' : ''
     if (isProblematic) {
-      return `bg-amber-500${opacity}`
+      return dimmed ? 'bg-amber-500/50' : 'bg-amber-500'
     }
     if (isChange) {
       switch (event.eventType) {
         case 'add':
-          return `bg-green-500${opacity}`
+          return dimmed ? 'bg-green-500/50' : 'bg-green-500'
         case 'delete':
-          return `bg-red-500${opacity}`
+          return dimmed ? 'bg-red-500/50' : 'bg-red-500'
         case 'update':
-          return `bg-blue-500${opacity}`
+          return dimmed ? 'bg-blue-500/50' : 'bg-blue-500'
       }
     }
-    return `bg-theme-text-tertiary${opacity}`
+    return dimmed ? 'bg-theme-text-tertiary/50' : 'bg-theme-text-tertiary'
   }
 
   const getOperationLabel = () => {

--- a/packages/k8s-ui/src/utils/badge-colors.ts
+++ b/packages/k8s-ui/src/utils/badge-colors.ts
@@ -53,6 +53,21 @@ export const HELM_STATUS_COLORS: Record<string, string> = {
   uninstalled: BADGE_SEVERITY_COLORS.neutral,
 }
 
+// Cloud instance capacity/priority badges — used by Karpenter NodeClaim and CAPI cloud-provider renderers
+// Keyed by the value as it appears in the resource (spot, on-demand, regular, onDemand)
+export const CAPACITY_TYPE_BADGE: Record<string, string> = {
+  spot: 'bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-950/50 dark:text-amber-400 dark:border-amber-700/40',
+  'on-demand': 'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40',
+  onDemand: 'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40',
+  regular: 'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40',
+}
+
+// AKS-style nodepool mode badges — System (control plane) vs User (workload)
+export const NODEPOOL_MODE_BADGE: Record<string, string> = {
+  System: 'bg-purple-100 text-purple-800 border-purple-300 dark:bg-purple-950/50 dark:text-purple-400 dark:border-purple-700/40',
+  User: 'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40',
+}
+
 // Best practices category colors
 export const BP_CATEGORY_BADGE: Record<string, string> = {
   Security: 'bg-purple-50 text-purple-700 border-purple-200 dark:bg-purple-950/40 dark:text-purple-400 dark:border-purple-800/40',

--- a/packages/k8s-ui/src/utils/badge-colors.ts
+++ b/packages/k8s-ui/src/utils/badge-colors.ts
@@ -68,6 +68,10 @@ export const NODEPOOL_MODE_BADGE: Record<string, string> = {
   User: 'bg-sky-100 text-sky-700 border-sky-300 dark:bg-sky-950/50 dark:text-sky-400 dark:border-sky-700/40',
 }
 
+// Translucent gray badge for "inactive / unknown / pending / unset / disabled" states.
+// The de-facto fallback in renderers when no severity or category applies.
+export const BADGE_INACTIVE = 'bg-gray-500/20 text-gray-400'
+
 // Best practices category colors
 export const BP_CATEGORY_BADGE: Record<string, string> = {
   Security: 'bg-purple-50 text-purple-700 border-purple-200 dark:bg-purple-950/40 dark:text-purple-400 dark:border-purple-800/40',

--- a/web/src/components/helm/ChartBrowser.tsx
+++ b/web/src/components/helm/ChartBrowser.tsx
@@ -148,7 +148,7 @@ export function ChartBrowser({ onChartSelect }: ChartBrowserProps) {
                   onClick={() => { setSelectedRepo('all'); setRepoDropdownOpen(false) }}
                   className={clsx(
                     'w-full px-3 py-2 text-left text-sm hover:bg-theme-hover flex items-center justify-between',
-                    selectedRepo === 'all' ? 'text-blue-400' : 'text-theme-text-primary'
+                    selectedRepo === 'all' ? 'text-accent' : 'text-theme-text-primary'
                   )}
                 >
                   <span>All Repositories</span>
@@ -186,9 +186,9 @@ export function ChartBrowser({ onChartSelect }: ChartBrowserProps) {
                 type="checkbox"
                 checked={showOfficialOnly}
                 onChange={(e) => setShowOfficialOnly(e.target.checked)}
-                className="rounded border-theme-border text-blue-500 focus:ring-blue-500"
+                className="rounded border-theme-border text-accent focus:ring-accent"
               />
-              <BadgeCheck className="w-3.5 h-3.5 text-blue-400" />
+              <BadgeCheck className="w-3.5 h-3.5 text-accent" />
               Official
             </label>
             <label className="flex items-center gap-1.5 text-sm text-theme-text-secondary">
@@ -196,7 +196,7 @@ export function ChartBrowser({ onChartSelect }: ChartBrowserProps) {
                 type="checkbox"
                 checked={showVerifiedOnly}
                 onChange={(e) => setShowVerifiedOnly(e.target.checked)}
-                className="rounded border-theme-border text-blue-500 focus:ring-blue-500"
+                className="rounded border-theme-border text-accent focus:ring-accent"
               />
               <Shield className="w-3.5 h-3.5 text-green-400" />
               Verified
@@ -207,7 +207,7 @@ export function ChartBrowser({ onChartSelect }: ChartBrowserProps) {
               <select
                 value={artifactHubSort}
                 onChange={(e) => setArtifactHubSort(e.target.value as ArtifactHubSortOption)}
-                className="bg-theme-elevated border border-theme-border-light rounded px-2 py-1 text-sm text-theme-text-primary focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="bg-theme-elevated border border-theme-border-light rounded px-2 py-1 text-sm text-theme-text-primary focus:outline-none focus:ring-2 focus:ring-accent"
               >
                 <option value="relevance">Relevance</option>
                 <option value="stars">Stars</option>
@@ -225,7 +225,7 @@ export function ChartBrowser({ onChartSelect }: ChartBrowserProps) {
             placeholder={chartSource === 'local' ? "Search charts..." : "Search ArtifactHub..."}
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full max-w-md pl-10 pr-4 py-2 bg-theme-elevated border border-theme-border-light rounded-lg text-sm text-theme-text-primary placeholder-theme-text-disabled focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full max-w-md pl-10 pr-4 py-2 bg-theme-elevated border border-theme-border-light rounded-lg text-sm text-theme-text-primary placeholder-theme-text-disabled focus:outline-none focus:ring-2 focus:ring-accent"
           />
         </div>
 
@@ -237,7 +237,7 @@ export function ChartBrowser({ onChartSelect }: ChartBrowserProps) {
                 type="checkbox"
                 checked={showAllVersions}
                 onChange={(e) => setShowAllVersions(e.target.checked)}
-                className="rounded border-theme-border text-blue-500 focus:ring-blue-500"
+                className="rounded border-theme-border text-accent focus:ring-accent"
               />
               All versions
             </label>
@@ -276,7 +276,7 @@ export function ChartBrowser({ onChartSelect }: ChartBrowserProps) {
                       Add repositories using <code className="bg-theme-elevated px-1 rounded">helm repo add</code>
                     </p>
                     <p className="mt-2">
-                      Or try searching on <button onClick={() => setChartSource('artifacthub')} className="text-blue-400 hover:underline">ArtifactHub</button>
+                      Or try searching on <button onClick={() => setChartSource('artifacthub')} className="text-accent-text hover:underline">ArtifactHub</button>
                     </p>
                   </div>
                 ) : (
@@ -375,7 +375,7 @@ function RepoDropdownItem({ repo, isSelected, onSelect, onUpdate, isUpdating, ca
         onClick={onSelect}
         className={clsx(
           'flex-1 text-left text-sm truncate',
-          isSelected ? 'text-blue-400' : 'text-theme-text-primary'
+          isSelected ? 'text-accent' : 'text-theme-text-primary'
         )}
       >
         {repo.name}
@@ -413,7 +413,7 @@ function LocalChartCard({ chart, onSelect }: LocalChartCardProps) {
           <img
             src={chart.icon}
             alt=""
-            className="w-10 h-10 rounded object-contain bg-white/10 p-1"
+            className="w-10 h-10 rounded object-contain bg-theme-elevated p-1"
             onError={(e) => {
               (e.target as HTMLImageElement).style.display = 'none'
             }}
@@ -476,7 +476,7 @@ function ArtifactHubChartCard({ chart, onSelect }: ArtifactHubChartCardProps) {
           <img
             src={chart.logoUrl}
             alt=""
-            className="w-12 h-12 rounded object-contain bg-white/10 p-1 shrink-0"
+            className="w-12 h-12 rounded object-contain bg-theme-elevated p-1 shrink-0"
             onError={(e) => {
               (e.target as HTMLImageElement).style.display = 'none'
             }}

--- a/web/src/components/helm/InstallWizard.tsx
+++ b/web/src/components/helm/InstallWizard.tsx
@@ -206,7 +206,7 @@ export function InstallWizard({ repo, chartName, version, source, repoUrl, defau
               <img
                 src={isLocal ? (chartDetail as ChartDetail)?.icon : (chartDetail as ArtifactHubChartDetail)?.logoUrl}
                 alt=""
-                className="w-8 h-8 rounded object-contain bg-white/10 p-1"
+                className="w-8 h-8 rounded object-contain bg-theme-elevated p-1"
               />
             ) : (
               <Package className="w-8 h-8 text-purple-400" />
@@ -216,7 +216,7 @@ export function InstallWizard({ repo, chartName, version, source, repoUrl, defau
                 <h2 className="text-lg font-semibold text-theme-text-primary">Install {chartName}</h2>
                 {!isLocal && (
                   <Tooltip content="From ArtifactHub">
-                    <Globe className="w-4 h-4 text-blue-400" />
+                    <Globe className="w-4 h-4 text-accent" />
                   </Tooltip>
                 )}
               </div>
@@ -224,7 +224,7 @@ export function InstallWizard({ repo, chartName, version, source, repoUrl, defau
                 <span>{repo} / {version}</span>
                 {!isLocal && (chartDetail as ArtifactHubChartDetail)?.repository?.official && (
                   <Tooltip content="Official">
-                    <BadgeCheck className="w-3.5 h-3.5 text-blue-400" />
+                    <BadgeCheck className="w-3.5 h-3.5 text-accent" />
                   </Tooltip>
                 )}
                 {!isLocal && (chartDetail as ArtifactHubChartDetail)?.repository?.verifiedPublisher && (
@@ -264,7 +264,7 @@ export function InstallWizard({ repo, chartName, version, source, repoUrl, defau
                 >
                   <span className={clsx(
                     'w-5 h-5 rounded-full flex items-center justify-center text-xs font-medium',
-                    step === s.id ? 'bg-blue-500 text-white' : 'bg-theme-elevated text-theme-text-secondary'
+                    step === s.id ? 'bg-accent text-white' : 'bg-theme-elevated text-theme-text-secondary'
                   )}>
                     {i + 1}
                   </span>
@@ -506,7 +506,7 @@ function InfoStep({
                   href={home}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300"
+                  className="flex items-center gap-1 text-xs text-accent-text hover:underline"
                 >
                   <LinkIcon className="w-3.5 h-3.5" />
                   Homepage
@@ -533,7 +533,7 @@ function InfoStep({
           value={releaseName}
           onChange={(e) => setReleaseName(e.target.value)}
           placeholder="my-release"
-          className="w-full px-3 py-2 bg-theme-elevated border border-theme-border-light rounded-lg text-sm text-theme-text-primary placeholder-theme-text-disabled focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="w-full px-3 py-2 bg-theme-elevated border border-theme-border-light rounded-lg text-sm text-theme-text-primary placeholder-theme-text-disabled focus:outline-none focus:ring-2 focus:ring-accent"
         />
         <p className="mt-1 text-xs text-theme-text-tertiary">
           A unique name for this release in the namespace
@@ -551,7 +551,7 @@ function InfoStep({
           value={namespace}
           onChange={(e) => setNamespace(e.target.value)}
           placeholder="Enter namespace name"
-          className="w-full px-3 py-2 bg-theme-elevated border border-theme-border-light rounded-lg text-sm text-theme-text-primary placeholder-theme-text-disabled focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="w-full px-3 py-2 bg-theme-elevated border border-theme-border-light rounded-lg text-sm text-theme-text-primary placeholder-theme-text-disabled focus:outline-none focus:ring-2 focus:ring-accent"
         />
         <datalist id="namespace-suggestions">
           {namespaces.map(ns => (
@@ -563,7 +563,7 @@ function InfoStep({
             type="checkbox"
             checked={createNamespace}
             onChange={(e) => setCreateNamespace(e.target.checked)}
-            className="rounded border-theme-border text-blue-500 focus:ring-blue-500"
+            className="rounded border-theme-border text-accent focus:ring-accent"
           />
           Create namespace if it doesn't exist
         </label>
@@ -574,7 +574,7 @@ function InfoStep({
         <div>
           <button
             onClick={() => setShowReadme(!showReadme)}
-            className="flex items-center gap-2 text-sm text-blue-400 hover:text-blue-300"
+            className="flex items-center gap-2 text-sm text-accent-text hover:underline"
           >
             <BookOpen className="w-4 h-4" />
             {showReadme ? 'Hide' : 'Show'} Chart README
@@ -619,8 +619,8 @@ function ValuesStep({ valuesYaml, setValuesYaml, yamlError, setYamlError, chartD
   return (
     <div className="space-y-4">
       {/* Info banner */}
-      <div className="flex items-start gap-3 p-4 bg-blue-500/10 border border-blue-500/30 rounded-lg">
-        <CheckCircle className="w-5 h-5 text-blue-400 shrink-0 mt-0.5" />
+      <div className="flex items-start gap-3 p-4 bg-accent-muted border border-accent/30 rounded-lg">
+        <CheckCircle className="w-5 h-5 text-accent shrink-0 mt-0.5" />
         <div>
           <p className="text-sm font-medium text-theme-text-primary">Ready to install with defaults</p>
           <p className="text-xs text-theme-text-secondary mt-1">
@@ -633,7 +633,7 @@ function ValuesStep({ valuesYaml, setValuesYaml, yamlError, setYamlError, chartD
               href={homeUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300 mt-2"
+              className="inline-flex items-center gap-1 text-xs text-accent-text hover:underline mt-2"
             >
               <LinkIcon className="w-3 h-3" />
               View chart documentation
@@ -819,8 +819,8 @@ function ReviewStep({
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3 p-4 bg-blue-500/10 border border-blue-500/30 rounded-lg">
-        <CheckCircle className="w-6 h-6 text-blue-400 shrink-0" />
+      <div className="flex items-center gap-3 p-4 bg-accent-muted border border-accent/30 rounded-lg">
+        <CheckCircle className="w-6 h-6 text-accent shrink-0" />
         <div>
           <p className="text-sm font-medium text-theme-text-primary">Ready to install</p>
           <p className="text-xs text-theme-text-secondary mt-0.5">
@@ -873,7 +873,7 @@ function ReviewStep({
                 <>Local: {repo}</>
               ) : (
                 <>
-                  <Globe className="w-3.5 h-3.5 text-blue-400" />
+                  <Globe className="w-3.5 h-3.5 text-accent" />
                   ArtifactHub: {repo}
                 </>
               )}

--- a/web/src/components/timeline/TimelineSwimlanes.tsx
+++ b/web/src/components/timeline/TimelineSwimlanes.tsx
@@ -1093,23 +1093,22 @@ function EventMarker({ event, x, selected, onClick, dimmed, small }: EventMarker
       return 'bg-red-500'
     }
 
-    // Solid fill for real-time events
-    const opacity = dimmed ? '/50' : ''
-    // Problematic events (warnings, BackOff, etc.) are always amber/orange
+    // Solid fill for real-time events.
+    // Problematic events (warnings, BackOff, etc.) are always amber/orange.
     if (isProblematic) {
-      return `bg-amber-500${opacity}`
+      return dimmed ? 'bg-amber-500/50' : 'bg-amber-500'
     }
     if (isChange) {
       switch (event.eventType) {
         case 'add':
-          return `bg-green-500${opacity}`
+          return dimmed ? 'bg-green-500/50' : 'bg-green-500'
         case 'delete':
-          return `bg-red-500${opacity}`
+          return dimmed ? 'bg-red-500/50' : 'bg-red-500'
         case 'update':
-          return `bg-blue-500${opacity}`
+          return dimmed ? 'bg-blue-500/50' : 'bg-blue-500'
       }
     }
-    return `bg-theme-text-tertiary${opacity}`
+    return dimmed ? 'bg-theme-text-tertiary/50' : 'bg-theme-text-tertiary'
   }
 
   const markerClasses = getMarkerStyle()

--- a/web/src/components/timeline/TimelineSwimlanes.tsx
+++ b/web/src/components/timeline/TimelineSwimlanes.tsx
@@ -457,7 +457,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
                 placeholder="Search... (press /)"
-                className="w-80 pl-9 pr-8 py-1.5 text-sm bg-theme-elevated border border-theme-border-light rounded-lg text-theme-text-primary placeholder-theme-text-disabled focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="w-80 pl-9 pr-8 py-1.5 text-sm bg-theme-elevated border border-theme-border-light rounded-lg text-theme-text-primary placeholder-theme-text-disabled focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
               />
               {searchTerm && (
                 <button
@@ -490,7 +490,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
               {panOffset > 0 && (
                 <button
                   onClick={() => setPanOffset(0)}
-                  className="px-2 py-1 text-xs text-blue-600 dark:text-blue-300 hover:text-blue-700 dark:hover:text-blue-200 hover:bg-theme-elevated rounded"
+                  className="px-2 py-1 text-xs text-accent-text hover:underline hover:bg-theme-elevated rounded"
                   title="Jump to current time"
                 >
                   → Now
@@ -519,7 +519,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
                   type="checkbox"
                   checked={groupByApp}
                   onChange={(e) => setGroupByApp(e.target.checked)}
-                  className="w-3.5 h-3.5 rounded border-theme-border-light bg-theme-elevated text-blue-500 focus:ring-blue-500 focus:ring-offset-0"
+                  className="w-3.5 h-3.5 rounded border-theme-border-light bg-theme-elevated text-accent focus:ring-accent focus:ring-offset-0"
                 />
                 <span className="border-b border-dotted border-theme-text-tertiary">Group by app</span>
               </label>
@@ -687,7 +687,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
                           <div className="flex items-center gap-1">
                             <span className={clsx(
                               'text-xs px-1 py-0.5 rounded',
-                              lane.isWorkload ? 'bg-blue-500/15 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300' : 'bg-theme-elevated text-theme-text-secondary'
+                              lane.isWorkload ? 'bg-accent-muted text-accent-text' : 'bg-theme-elevated text-theme-text-secondary'
                             )}>
                               {displayKind(lane.kind)}
                             </span>
@@ -711,7 +711,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
                               )
                             })()}
                           </div>
-                          <div className="text-sm text-theme-text-primary break-words group-hover:text-blue-600 dark:group-hover:text-blue-300 group-hover:underline cursor-pointer">
+                          <div className="text-sm text-theme-text-primary break-words group-hover:text-accent-text group-hover:underline cursor-pointer">
                             {lane.name}
                           </div>
                           <div className="text-xs text-theme-text-tertiary">{lane.namespace}</div>
@@ -751,7 +751,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
                   {/* Child lanes (when expanded) - includes parent as first row */}
                   {isExpanded && hasChildren && (
                     <div
-                      className="border-l-2 border-blue-500/40 ml-3 bg-theme-surface/30"
+                      className="border-l-2 border-accent/40 ml-3 bg-theme-surface/30"
                       style={{ animation: 'swimlane-expand 250ms ease-out both' }}
                     >
                       {/* Parent's own events as first row (only if it has events) */}
@@ -764,11 +764,11 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
                             >
                               <div className="flex-1 min-w-0">
                                 <div className="flex items-center gap-1">
-                                  <span className="text-xs px-1 py-0.5 rounded bg-blue-500/15 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300">
+                                  <span className="text-xs px-1 py-0.5 rounded bg-accent-muted text-accent-text">
                                     {displayKind(lane.kind)}
                                   </span>
                                 </div>
-                                <div className="text-sm text-theme-text-secondary break-words group-hover:text-blue-600 dark:group-hover:text-blue-300 group-hover:underline cursor-pointer">
+                                <div className="text-sm text-theme-text-secondary break-words group-hover:text-accent-text group-hover:underline cursor-pointer">
                                   {lane.name}
                                 </div>
                               </div>
@@ -820,7 +820,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
                                     {displayKind(child.kind)}
                                   </span>
                                 </div>
-                                <div className="text-sm text-theme-text-secondary break-words group-hover:text-blue-600 dark:group-hover:text-blue-300 group-hover:underline cursor-pointer">
+                                <div className="text-sm text-theme-text-secondary break-words group-hover:text-accent-text group-hover:underline cursor-pointer">
                                   {child.name}
                                 </div>
                               </div>
@@ -1235,7 +1235,7 @@ function EventDetailPanel({ event, onClose, onResourceClick }: EventDetailPanelP
             </span>
             <button
               onClick={() => onResourceClick?.({ kind: kindToPlural(event.kind), namespace: event.namespace, name: event.name })}
-              className="text-theme-text-primary font-medium hover:text-blue-600 dark:hover:text-blue-300"
+              className="text-theme-text-primary font-medium hover:text-accent-text"
             >
               {event.name}
             </button>

--- a/web/src/components/ui/UpdateNotification.tsx
+++ b/web/src/components/ui/UpdateNotification.tsx
@@ -111,9 +111,9 @@ export function UpdateNotification() {
   const effectiveState: DesktopUpdateState = updateStatus?.state ?? 'idle'
 
   return (
-    <div className="fixed bottom-4 right-4 z-50 max-w-sm bg-theme-surface border border-blue-500/50 rounded-lg shadow-xl p-4 animate-in slide-in-from-right">
+    <div className="fixed bottom-4 right-4 z-50 max-w-sm bg-theme-surface border border-accent/50 rounded-lg shadow-xl p-4 animate-in slide-in-from-right">
       <div className="flex items-start gap-3">
-        <div className="flex items-center justify-center w-8 h-8 bg-blue-500/20 rounded-full shrink-0">
+        <div className="flex items-center justify-center w-8 h-8 bg-accent-muted rounded-full shrink-0">
           <UpdateIcon state={effectiveState} />
         </div>
         <div className="flex-1 min-w-0">
@@ -154,7 +154,7 @@ export function UpdateNotification() {
                 href={versionInfo.releaseUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 mt-2 text-xs font-medium text-blue-400 hover:text-blue-300"
+                className="inline-flex items-center gap-1 mt-2 text-xs font-medium text-accent-text hover:underline"
               >
                 Download from GitHub →
               </a>
@@ -186,11 +186,11 @@ function UpdateIcon({ state }: { state: DesktopUpdateState }) {
   switch (state) {
     case 'downloading':
     case 'applying':
-      return <Loader2 className="w-4 h-4 text-blue-400 animate-spin" />
+      return <Loader2 className="w-4 h-4 text-accent animate-spin" />
     case 'ready':
       return <ArrowDownToLine className="w-4 h-4 text-green-400" />
     default:
-      return <Download className="w-4 h-4 text-blue-400" />
+      return <Download className="w-4 h-4 text-accent" />
   }
 }
 
@@ -247,7 +247,7 @@ function DesktopUpdateControls({
         <div className="mt-2 space-y-1">
           <div className="w-full bg-theme-elevated rounded-full h-1.5 overflow-hidden">
             <div
-              className="bg-blue-500 h-full rounded-full transition-all duration-300"
+              className="bg-accent h-full rounded-full transition-all duration-300"
               style={{ width: `${Math.round((progress ?? 0) * 100)}%` }}
             />
           </div>
@@ -272,7 +272,7 @@ function DesktopUpdateControls({
     case 'applying':
       return (
         <div className="mt-2 flex items-center gap-2">
-          <Loader2 className="w-3.5 h-3.5 text-blue-400 animate-spin" />
+          <Loader2 className="w-3.5 h-3.5 text-accent animate-spin" />
           <p className="text-xs text-theme-text-secondary">Applying update...</p>
         </div>
       )


### PR DESCRIPTION
## Summary

Three buckets of design-system cleanup driven by an audit against `DESIGN.md`. All token / centralization changes; no behavior changes.

**Mechanical centralization (no visual change).**
- `CAPACITY_TYPE_BADGE` moved from `resource-utils-karpenter.ts` into `badge-colors.ts` alongside the other shared palettes (`EVENT_TYPE_COLORS`, `BP_CATEGORY_BADGE`, `VULN_SEVERITY_BADGE`, …). Added `NODEPOOL_MODE_BADGE` for the AKS System/User pattern that was hand-rolled in two places. Five inline-duplicated badge strings across `AzureManagedMachinePoolRenderer`, `AWSManagedMachinePoolRenderer`, `azure-capi-cells`, `aws-capi-cells`, `karpenter-cells`, and `KarpenterNodeClaimRenderer` now reference the shared constants.
- Replaced template-literal Tailwind class construction (`` `bg-amber-500${opacity}` ``) in `TimelineSwimlanes` and `timeline/shared` with explicit static strings so the Tailwind scanner can see them. Same runtime output.

**Helm wizard brand alignment (visual fix).** `InstallWizard.tsx` and `ChartBrowser.tsx` were the largest concentration of raw `bg-blue-*` / `text-blue-*` violations — generic Tailwind `#3B82F6`, noticeably different from the app's brand accent (`#4A7CC9` light / `#6A9FE0` dark, used in 28 other files via `.btn-brand` / `bg-accent` / `text-accent-text`). Converted active step pills, hyperlinks, focus rings, checkbox accents, decorative icons, and the standalone "Ready to install" info banners to the accent tokens. Replaced `bg-white/10` chart-logo backdrops with `bg-theme-elevated` (works in both modes; the original was effectively invisible in light mode).

**Deliberately preserved deviations.** Three blue usages in `InstallWizard.tsx` are intentionally kept raw: the values diff hunk header (paired with `bg-green-500/10` add and `bg-red-500/10` remove rows) and the install progress panel + spinner (paired with `bg-green-500/10` complete and `bg-red-500/10` error). In each case blue is part of a categorical/status triple — converting just the blue would break the semantic set.

## Test plan
- [ ] `make tsc` (passes locally)
- [ ] Open the Helm install wizard — active step, focus rings, checkboxes, info banners, links should now match the rest of the app's brand blue
- [ ] Verify Helm install in-progress panel still shows blue (paired with green/red on complete/error)
- [ ] Open a Karpenter NodeClaim, AKS Managed Machine Pool, EKS Managed Machine Pool — capacity-type and mode badges render unchanged
- [ ] Open the timeline — event marker dots render unchanged for both live (solid) and historical (dimmed) states

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily mechanical styling/token refactors with limited surface area outside UI appearance; main risk is minor visual regressions from class name changes.
> 
> **Overview**
> **Centralizes badge styling** by adding shared constants in `badge-colors.ts` (`CAPACITY_TYPE_BADGE`, `NODEPOOL_MODE_BADGE`, `BADGE_INACTIVE`) and updating many K8s resource renderers/table cells to consume them instead of inlined Tailwind class strings.
> 
> **Makes timeline marker coloring Tailwind-safe** by replacing template-literal class construction with explicit `bg-*/50` class strings in timeline components.
> 
> **Aligns Helm Chart Browser/Install Wizard with the app accent theme** by swapping `blue-*` focus/selection/link/icon styles (and logo backdrops) to `accent` tokens for consistent branding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2eca3777a16d282f30cb5b59c1d89470979efab4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->