### PR TITLE
docs: link to radarhq.io and add About section

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,14 @@ Contributions are welcome! Please read our [Contributing Guide](CONTRIBUTING.md)
 
 ---
 
+## About
+
+Radar is built and maintained by [Skyhook](https://skyhook.io) (YC W23) and is open source under Apache-2.0. The OSS version is fully featured and the recommended way to run Radar.
+
+For teams that want hosted multi-cluster Radar with SSO and shared dashboards, we also offer [Radar Cloud](https://radarhq.io).
+
+---
+
 ## License
 
 Apache 2.0 — see [LICENSE](LICENSE)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 **Modern Kubernetes visibility.**
 <br>Local-first. No account. No cloud dependency. Blazing Fast.
 
+🌐 **[radarhq.io](https://radarhq.io)** · [Docs](https://radarhq.io/docs) · [Releases](https://github.com/skyhook-io/radar/releases)
+
 Topology, event timeline, and service traffic — plus resource browsing, Helm management, and GitOps support for FluxCD and ArgoCD.
 
 [![CI](https://github.com/skyhook-io/radar/actions/workflows/ci.yml/badge.svg)](https://github.com/skyhook-io/radar/actions/workflows/ci.yml)


### PR DESCRIPTION
Two small README additions ahead of the Product Hunt push:

1. **Header link line** under the tagline pointing to radarhq.io, /docs, and Releases - so visitors landing on the repo have a clear path to the project site.
2. **About section** (between Contributing and License) disclosing that Radar is built by Skyhook (YC W23), reinforcing that the OSS version is fully featured, and mentioning Radar Cloud for teams that want a hosted option.

Also recommend setting the GitHub repo's "Website" field to https://radarhq.io (separate from this PR).