### PR TITLE
docs: launch banner + surface Discord in CONTRIBUTING & issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,11 @@
 blank_issues_enabled: false
 contact_links:
+  - name: 💬 Discord Community
+    url: https://radarhq.io/community/chat
+    about: Ask questions, share feedback, and chat with the team and other Radar users.
   - name: Questions & Discussions
     url: https://github.com/skyhook-io/radar/discussions
-    about: Ask questions, share ideas, or discuss features with the community
+    about: Ask questions, share ideas, or discuss features with the community.
   - name: Documentation
-    url: https://github.com/skyhook-io/radar#readme
-    about: Check the README for usage and installation instructions
+    url: https://radarhq.io/docs
+    about: Check the docs for usage and installation instructions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,12 @@ Thank you for your interest in contributing to Radar! This document provides gui
 
 By participating in this project, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
 
+## Get Help & Join the Community
+
+The fastest way to get help, ask questions, or share feedback is our [Discord community](https://radarhq.io/community/chat). Maintainers and other Radar users hang out there.
+
+For longer-form discussion, use [GitHub Discussions](https://github.com/skyhook-io/radar/discussions).
+
 ## How to Contribute
 
 ### Reporting Bugs

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Radar
 
+> [!IMPORTANT]
+> 📣 **Radar is launching on Product Hunt this Sunday, May 3.**
+> [**Notify me on PH** ↗](https://www.producthunt.com/products/radar-7?launch=radar-42edb7b0-e388-4fa8-9ba5-4876c2c0d638) · [Join the Discord ↗](https://radarhq.io/community/chat)
+
 **Modern Kubernetes visibility.**
 <br>Local-first. No account. No cloud dependency. Blazing Fast.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > [!IMPORTANT]
 > 📣 **Radar is launching on Product Hunt this Sunday, May 3.**
-> [**Notify me on PH** ↗](https://www.producthunt.com/products/radar-7?launch=radar-42edb7b0-e388-4fa8-9ba5-4876c2c0d638) · [Join the Discord ↗](https://radarhq.io/community/chat)
+> [**Follow on Product Hunt** ↗](https://www.producthunt.com/products/radar-7?launch=radar-42edb7b0-e388-4fa8-9ba5-4876c2c0d638) (get notified at launch) · [Join the Discord ↗](https://radarhq.io/community/chat)
 
 **Modern Kubernetes visibility.**
 <br>Local-first. No account. No cloud dependency. Blazing Fast.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Radar
 
 > [!IMPORTANT]
-> 📣 **Radar is launching on Product Hunt this Sunday, May 3.**
-> [**Follow** ↗](https://www.producthunt.com/products/radar-7?launch=radar-42edb7b0-e388-4fa8-9ba5-4876c2c0d638) (get notified at launch) · [We have a new Discord ↗](https://radarhq.io/community/chat)
+> 📣 **Radar is launching on Product Hunt this Sunday!**
+> [**Follow Radar on PH** ↗](https://www.producthunt.com/products/radar-7?launch=radar-42edb7b0-e388-4fa8-9ba5-4876c2c0d638) · [We have a new Discord ↗](https://radarhq.io/community/chat)
 
 **Modern Kubernetes visibility.**
 <br>Local-first. No account. No cloud dependency. Blazing Fast.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > [!IMPORTANT]
 > 📣 **Radar is launching on Product Hunt this Sunday, May 3.**
-> [**Follow on Product Hunt** ↗](https://www.producthunt.com/products/radar-7?launch=radar-42edb7b0-e388-4fa8-9ba5-4876c2c0d638) (get notified at launch) · [Join the Discord ↗](https://radarhq.io/community/chat)
+> [**Follow** ↗](https://www.producthunt.com/products/radar-7?launch=radar-42edb7b0-e388-4fa8-9ba5-4876c2c0d638) (get notified at launch) · [We have a new Discord ↗](https://radarhq.io/community/chat)
 
 **Modern Kubernetes visibility.**
 <br>Local-first. No account. No cloud dependency. Blazing Fast.


### PR DESCRIPTION
Adds a temporary launch banner at the top of the README using GitHub's `[!IMPORTANT]` callout, linking to the PH "Notify me" page and the Discord invite.

Visible to every visitor landing on the repo this week. Will remove (or rotate to a softer post-launch version) shortly after Sunday.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes that update community/support links and add a temporary README announcement banner; no runtime behavior is affected.
> 
> **Overview**
> Adds a prominent `[!IMPORTANT]` launch callout to the top of `README.md` linking to Product Hunt and the new Discord.
> 
> Updates contributor/support touchpoints by adding a Discord contact link to the GitHub issue template, polishing link copy, and pointing the Documentation contact link to `radarhq.io/docs`. Also adds a *Get Help & Join the Community* section in `CONTRIBUTING.md` with Discord and GitHub Discussions links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f655027fa908c57dc670592665e7d679801a4d03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->