### PR TITLE
install: switch to /bin/sh shebang and use get.radarhq.io vanity URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Visualize your cluster topology, browse resources, stream logs, exec into pods, 
 
 **Install and run in 30 seconds:**
 ```bash
-curl -fsSL get.radarhq.io | sh && kubectl radar
+curl -fsSL https://get.radarhq.io | sh && kubectl radar
 ```
 [More installation options ↓](#installation)
 
@@ -47,7 +47,7 @@ curl -fsSL get.radarhq.io | sh && kubectl radar
 
 **Quick Install:**
 ```bash
-curl -fsSL get.radarhq.io | sh
+curl -fsSL https://get.radarhq.io | sh
 ```
 
 **Homebrew:**
@@ -75,7 +75,7 @@ scoop install radar
 
 **PowerShell (Windows):**
 ```powershell
-irm get.radarhq.io/install.ps1 | iex
+irm https://get.radarhq.io/install.ps1 | iex
 ```
 
 **Direct download** — [GitHub Releases](https://github.com/skyhook-io/radar/releases) for macOS, Linux, or Windows.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Visualize your cluster topology, browse resources, stream logs, exec into pods, 
 
 **Install and run in 30 seconds:**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/skyhook-io/radar/main/install.sh | bash && kubectl radar
+curl -fsSL get.radarhq.io | sh && kubectl radar
 ```
 [More installation options ↓](#installation)
 
@@ -47,7 +47,7 @@ curl -fsSL https://raw.githubusercontent.com/skyhook-io/radar/main/install.sh | 
 
 **Quick Install:**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/skyhook-io/radar/main/install.sh | bash
+curl -fsSL get.radarhq.io | sh
 ```
 
 **Homebrew:**
@@ -75,7 +75,7 @@ scoop install radar
 
 **PowerShell (Windows):**
 ```powershell
-irm https://raw.githubusercontent.com/skyhook-io/radar/main/install.ps1 | iex
+irm get.radarhq.io/install.ps1 | iex
 ```
 
 **Direct download** — [GitHub Releases](https://github.com/skyhook-io/radar/releases) for macOS, Linux, or Windows.

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 # Radar installer
-# Usage: curl -fsSL get.radarhq.io | sh
+# Usage: curl -fsSL https://get.radarhq.io | sh
+#
+# Always use the explicit https:// scheme — without it curl defaults to
+# port 80 and accepts a 308 redirect to https, which lets a network
+# attacker substitute the script before the redirect.
 #
 # Keep POSIX-clean: no [[ ]], no $((  )), no arrays, no <<<. The script is
 # piped to `sh` everywhere we publish it, so bash-isms will silently break

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,11 @@
-#!/bin/bash
+#!/bin/sh
 # Radar installer
-# Usage: curl -fsSL https://raw.githubusercontent.com/skyhook-io/radar/main/install.sh | bash
+# Usage: curl -fsSL get.radarhq.io | sh
+#
+# Keep POSIX-clean: no [[ ]], no $((  )), no arrays, no <<<. The script is
+# piped to `sh` everywhere we publish it, so bash-isms will silently break
+# the install on systems whose /bin/sh is not bash (Alpine, Debian dash,
+# BusyBox).
 
 set -e
 


### PR DESCRIPTION
## Summary

Two related cleanups for the OSS install surface, paired with the marketing-side PR that provisioned the new vanity install URL.

**1. Switch \`install.sh\` shebang to \`#!/bin/sh\`.** The script is fully POSIX-clean today (single brackets, no \`[[ ]]\`, no \`\$((  ))\`, no arrays, no \`<<<\`). The bash shebang was overstating the requirement. Worse, when piped to \`sh\` (which is the dominant install-script convention - Docker, k3s, Ollama, mise, uv, deno, rustup, starship all use \`sh\`), bash-isms added by future contributors would silently break the install on systems whose \`/bin/sh\` is not bash (Alpine, Debian dash, BusyBox). Added a keep-POSIX-clean comment so the constraint is enforceable.

**2. Use the short \`get.radarhq.io\` vanity URL in the README.** The marketing site at skyhook-dev/marketing#109 set up \`get.radarhq.io\` as a vanity install host (the radar equivalent of \`get.docker.com\` / \`get.helm.sh\` / \`get.k3s.io\`). This PR updates the README's three install snippets to use it. Long \`raw.githubusercontent.com\` URLs continue to work indefinitely - this is polish, not a breaking change.

## Test plan
- [ ] Verify \`curl -fsSL get.radarhq.io | sh\` succeeds on macOS and Linux once the marketing PR is deployed
- [ ] Verify \`irm get.radarhq.io/install.ps1 | iex\` succeeds on Windows

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the install entrypoints (`install.sh` and README snippets), so any subtle shell-compatibility or URL/hosting issue could break first-time installs, though the functional installer logic is unchanged.
> 
> **Overview**
> Updates all README install commands to use the new vanity URL `https://get.radarhq.io` (including the PowerShell snippet) instead of `raw.githubusercontent.com`.
> 
> Switches `install.sh` to a POSIX `#!/bin/sh` shebang and adds explicit guidance/comments about staying POSIX-clean and always using `https://` to reduce redirect/script-substitution risk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2adc7fdab00f01402de91c039fa40d11249f5c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->