### PR TITLE
feat(dock): add Cmd+J / Ctrl+J as alternate dock toggle shortcut

### DIFF
--- a/packages/k8s-ui/src/components/dock/BottomDock.tsx
+++ b/packages/k8s-ui/src/components/dock/BottomDock.tsx
@@ -3,7 +3,7 @@ import { DURATION_DOCK } from '../../utils/animation'
 import { X, ChevronDown, ChevronUp, Terminal, FileText, Trash2, Layers, Maximize2, Minimize2, Activity } from 'lucide-react'
 import { clsx } from 'clsx'
 import { useDock, DockTab } from './DockContext'
-import { useRegisterShortcut } from '../../hooks/useKeyboardShortcuts'
+import { useRegisterShortcuts } from '../../hooks/useKeyboardShortcuts'
 
 const MIN_HEIGHT = 200
 const DEFAULT_HEIGHT = 400
@@ -80,15 +80,26 @@ export function BottomDock({ renderTabContent, renderTabHeaderExtra, leftOffset:
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [isMaximized])
 
-  useRegisterShortcut({
-    id: 'dock-toggle',
-    keys: 'Ctrl+`',
-    description: 'Toggle dock',
-    category: 'Dock',
-    scope: 'global',
-    handler: () => toggleExpanded(),
-    enabled: tabs.length > 0,
-  })
+  useRegisterShortcuts([
+    {
+      id: 'dock-toggle-backtick',
+      keys: 'Ctrl+`',
+      description: 'Toggle dock',
+      category: 'Dock',
+      scope: 'global',
+      handler: () => toggleExpanded(),
+      enabled: tabs.length > 0,
+    },
+    {
+      id: 'dock-toggle-j',
+      keys: 'Cmd+J',
+      description: 'Toggle dock',
+      category: 'Dock',
+      scope: 'global',
+      handler: () => toggleExpanded(),
+      enabled: tabs.length > 0,
+    },
+  ])
 
   if (tabs.length === 0) {
     return null


### PR DESCRIPTION
## Summary

Adds `Cmd+J` (Mac) / `Ctrl+J` (Win/Linux) as a second binding for toggling the bottom dock, alongside the existing `` Ctrl+` ``. Both match VS Code conventions:

- `` Ctrl+` `` — VS Code's "Toggle Terminal" (literal Ctrl on Mac too, intentional)
- `Cmd+J` / `Ctrl+J` — VS Code's "Toggle Panel"

The `?` shortcut help overlay merges both bindings into a single "Toggle dock" row via shared `description`, same pattern used for `+` / `=` zoom in the topology view.

Closes #557.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an additional keyboard shortcut binding for an existing UI toggle without changing dock behavior or data flow.
> 
> **Overview**
> Adds a second global shortcut (`Cmd+J` with platform-aware mapping) to toggle the bottom dock, alongside the existing `Ctrl+`` binding.
> 
> Refactors `BottomDock` to use `useRegisterShortcuts` to register both bindings with distinct IDs but the same description/category so shortcut help can present them consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecdbeca73aaa235894a707322b5b4e78d6e3296c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->