### PR TITLE
feat(diagnostics): surface per-informer sync status in overlay + markdown

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2603,6 +2603,31 @@ export interface DiagErrorEntry {
   level: string
 }
 
+export type DiagSyncPhase = 'not_started' | 'syncing_critical' | 'syncing_deferred' | 'complete'
+
+export interface DiagInformerSyncStatus {
+  kind: string
+  key: string
+  deferred: boolean
+  synced: boolean
+  syncedAt?: string
+  items: number
+}
+
+export interface DiagCacheSyncStatus {
+  phase: DiagSyncPhase
+  syncStarted?: string
+  elapsedSec: number
+  criticalTotal: number
+  criticalSynced: number
+  deferredTotal: number
+  deferredSynced: number
+  informers: DiagInformerSyncStatus[]
+  pendingCritical?: string[]
+  pendingDeferred?: string[]
+  promotedKinds?: string[]
+}
+
 export interface DiagnosticsSnapshot {
   timestamp: string
   radarVersion: string
@@ -2666,6 +2691,7 @@ export interface DiagnosticsSnapshot {
     typedCount: number
     dynamicCount: number
     watchedCRDs: string[]
+    syncStatus?: DiagCacheSyncStatus
   }
   prometheus?: {
     connected: boolean

--- a/web/src/components/ui/DiagnosticsOverlay.tsx
+++ b/web/src/components/ui/DiagnosticsOverlay.tsx
@@ -393,8 +393,9 @@ function formatElapsed(sec: number): string {
   const s = Math.max(0, sec)
   if (s < 1) return `${Math.round(s * 1000)}ms`
   if (s < 60) return `${s.toFixed(1)}s`
-  const m = Math.floor(s / 60)
-  const rem = Math.round(s - m * 60)
+  const total = Math.round(s)
+  const m = Math.floor(total / 60)
+  const rem = total - m * 60
   return `${m}m ${rem}s`
 }
 

--- a/web/src/components/ui/DiagnosticsOverlay.tsx
+++ b/web/src/components/ui/DiagnosticsOverlay.tsx
@@ -4,7 +4,7 @@ import { clsx } from 'clsx'
 import { TRANSITION_BACKDROP, TRANSITION_PANEL } from '../../utils/animation'
 import { openExternal } from '../../utils/navigation'
 import { useDiagnostics } from '../../api/client'
-import type { DiagnosticsSnapshot, DiagMetricsSourceHealth, DiagDropRecord, DiagErrorEntry } from '../../api/client'
+import type { DiagnosticsSnapshot, DiagMetricsSourceHealth, DiagDropRecord, DiagErrorEntry, DiagCacheSyncStatus, DiagInformerSyncStatus, DiagSyncPhase } from '../../api/client'
 
 interface DiagnosticsOverlayProps {
   onClose: () => void
@@ -315,15 +315,86 @@ function EventPipelineSection({ data }: { data: DiagnosticsSnapshot }) {
 function InformersSection({ data }: { data: DiagnosticsSnapshot }) {
   if (!data.informers) return null
   const inf = data.informers
+  const sync = inf.syncStatus
+  const phaseWarn = sync ? sync.phase !== 'complete' : false
+  const criticalWarn = sync ? sync.criticalSynced < sync.criticalTotal : false
+  const promoted = sync?.promotedKinds ?? []
+  const pendingCritical = sync?.pendingCritical ?? []
+  const pendingDeferred = sync?.pendingDeferred ?? []
+  const sectionWarn = phaseWarn || promoted.length > 0
   return (
-    <Section title="Informers">
+    <Section title="Informers" warn={sectionWarn}>
       <Row label="Typed" value={inf.typedCount} />
       <Row label="Dynamic (CRDs)" value={inf.dynamicCount} />
+      {sync && (
+        <>
+          <Row
+            label="Sync Phase"
+            value={`${formatSyncPhase(sync.phase)} (${formatElapsed(sync.elapsedSec)})`}
+            warn={phaseWarn}
+          />
+          <Row
+            label="Critical Synced"
+            value={`${sync.criticalSynced} / ${sync.criticalTotal}`}
+            warn={criticalWarn}
+          />
+          <Row
+            label="Deferred Synced"
+            value={`${sync.deferredSynced} / ${sync.deferredTotal}`}
+          />
+          {promoted.length > 0 && (
+            <Row label="Promoted to Deferred" value={promoted.join(', ')} warn />
+          )}
+          {(pendingCritical.length > 0 || pendingDeferred.length > 0) && (
+            <PendingInformers sync={sync} />
+          )}
+        </>
+      )}
       {inf.watchedCRDs && inf.watchedCRDs.length > 0 && (
         <Row label="Watched CRDs" value={inf.watchedCRDs.join(', ')} />
       )}
     </Section>
   )
+}
+
+function PendingInformers({ sync }: { sync: DiagCacheSyncStatus }) {
+  const pendingNames = new Set([
+    ...(sync.pendingCritical ?? []),
+    ...(sync.pendingDeferred ?? []),
+  ])
+  const pending = sync.informers.filter((i) => pendingNames.has(i.kind))
+  if (pending.length === 0) return null
+  pending.sort((a, b) => Number(a.deferred) - Number(b.deferred) || a.kind.localeCompare(b.kind))
+  return (
+    <div className="mt-1.5 pt-1.5 border-t border-theme-border-light">
+      <span className="text-[10px] text-theme-text-tertiary uppercase">Pending Informers ({pending.length})</span>
+      {pending.map((i: DiagInformerSyncStatus) => (
+        <Row
+          key={i.kind}
+          label={`${i.kind} (${i.deferred ? 'deferred' : 'critical'})`}
+          value={`${i.items.toLocaleString()} items so far`}
+          warn={!i.deferred}
+        />
+      ))}
+    </div>
+  )
+}
+
+function formatSyncPhase(phase: DiagSyncPhase): string {
+  switch (phase) {
+    case 'not_started': return 'not started'
+    case 'syncing_critical': return 'syncing critical'
+    case 'syncing_deferred': return 'syncing deferred'
+    case 'complete': return 'complete'
+  }
+}
+
+function formatElapsed(sec: number): string {
+  if (sec < 1) return `${Math.round(sec * 1000)}ms`
+  if (sec < 60) return `${sec.toFixed(1)}s`
+  const m = Math.floor(sec / 60)
+  const s = Math.round(sec - m * 60)
+  return `${m}m ${s}s`
 }
 
 function PrometheusSection({ data }: { data: DiagnosticsSnapshot }) {
@@ -512,6 +583,24 @@ function formatForGitHub(data: DiagnosticsSnapshot, includeRawJson = true): stri
     const inf = data.informers
     lines.push(`### Informers`)
     lines.push(`- Typed: ${inf.typedCount} | Dynamic: ${inf.dynamicCount}`)
+    if (inf.syncStatus) {
+      const sync = inf.syncStatus
+      lines.push(`- Sync Phase: \`${sync.phase}\` (${formatElapsed(sync.elapsedSec)})`)
+      lines.push(`- Critical: ${sync.criticalSynced}/${sync.criticalTotal} synced | Deferred: ${sync.deferredSynced}/${sync.deferredTotal} synced`)
+      if (sync.promotedKinds && sync.promotedKinds.length > 0) {
+        lines.push(`- **Promoted to Deferred:** ${sync.promotedKinds.join(', ')}`)
+      }
+      const pendingNames = new Set([
+        ...(sync.pendingCritical ?? []),
+        ...(sync.pendingDeferred ?? []),
+      ])
+      const pending = sync.informers.filter((i) => pendingNames.has(i.kind))
+      if (pending.length > 0) {
+        pending.sort((a, b) => Number(a.deferred) - Number(b.deferred) || a.kind.localeCompare(b.kind))
+        const parts = pending.map((i) => `${i.kind}(${i.deferred ? 'deferred' : 'critical'},${i.items.toLocaleString()} items)`)
+        lines.push(`- **Pending:** ${parts.join(', ')}`)
+      }
+    }
     if (inf.watchedCRDs && inf.watchedCRDs.length > 0) {
       lines.push(`- CRDs: ${inf.watchedCRDs.join(', ')}`)
     }

--- a/web/src/components/ui/DiagnosticsOverlay.tsx
+++ b/web/src/components/ui/DiagnosticsOverlay.tsx
@@ -321,7 +321,7 @@ function InformersSection({ data }: { data: DiagnosticsSnapshot }) {
   const promoted = sync?.promotedKinds ?? []
   const pendingCritical = sync?.pendingCritical ?? []
   const pendingDeferred = sync?.pendingDeferred ?? []
-  const sectionWarn = phaseWarn || promoted.length > 0
+  const sectionWarn = phaseWarn || criticalWarn || promoted.length > 0
   return (
     <Section title="Informers" warn={sectionWarn}>
       <Row label="Typed" value={inf.typedCount} />
@@ -390,11 +390,12 @@ function formatSyncPhase(phase: DiagSyncPhase): string {
 }
 
 function formatElapsed(sec: number): string {
-  if (sec < 1) return `${Math.round(sec * 1000)}ms`
-  if (sec < 60) return `${sec.toFixed(1)}s`
-  const m = Math.floor(sec / 60)
-  const s = Math.round(sec - m * 60)
-  return `${m}m ${s}s`
+  const s = Math.max(0, sec)
+  if (s < 1) return `${Math.round(s * 1000)}ms`
+  if (s < 60) return `${s.toFixed(1)}s`
+  const m = Math.floor(s / 60)
+  const rem = Math.round(s - m * 60)
+  return `${m}m ${rem}s`
 }
 
 function PrometheusSection({ data }: { data: DiagnosticsSnapshot }) {


### PR DESCRIPTION
## Why

While investigating #598 ("dashboard shows 0 for pods/deployments/cpu requests/memory requests on a 20k+ cluster"), the user's pasted diagnostics snapshot only showed:

```
### Cache
- Total Resources: 40,164 | Watched Kinds: 22

### Informers
- Typed: 22 | Dynamic: 18
```

…which is silent on the actual smoking gun: was the Pod informer synced? The backend's `cache.GetSyncStatus()` already returned the full per-informer state (phase, critical/deferred sync counts, pending kinds with item counts, promoted kinds). The frontend just dropped it on the floor — the overlay rendered only the typed/dynamic counts, and the markdown export omitted sync state entirely.

This wires both up. For a #598-style bug, the snapshot would now read:

```
### Informers
- Typed: 22 | Dynamic: 18
- Sync Phase: `syncing_critical` (6m 21s)
- Critical: 8/10 synced | Deferred: 9/12 synced
- **Promoted to Deferred:** Pod, Deployment
- **Pending:** Pod(critical,0 items), Deployment(critical,0 items), Secret(deferred,0 items)
```

…which is the answer at a glance.

## Changes

- `web/src/api/client.ts` — add `DiagSyncPhase`, `DiagInformerSyncStatus`, `DiagCacheSyncStatus` types (mirror `pkg/k8score.CacheSyncStatus`); add `syncStatus` field to `DiagnosticsSnapshot.informers`.
- `web/src/components/ui/DiagnosticsOverlay.tsx` — `InformersSection` renders sync phase + critical/deferred counts + promoted kinds + a per-informer pending list with live item counts. Section is highlighted yellow when phase is not complete or any kinds were promoted.
- Markdown export emits the same data so snapshots pasted into GitHub issues carry the sync state.
- No backend changes — purely frontend wiring of data the backend already produces.

## Notes

- Useful independently of #544 (the patience-window/minimal-set PR). Even after that lands, the diagnostics endpoint is the user's escape hatch when the cache is stuck — being able to see "Pod: critical, 0 items, not synced" is the difference between a triageable issue and a guessing game.
- Doesn't fix #598 itself — that needs the partial-data UI work (per-ring loading state in `ClusterHealthCard`) — but makes future bug reports of this category much faster to diagnose.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/type-only change that wires additional diagnostics fields through to the overlay and markdown export; main risk is minor formatting/logic mistakes in display of sync status.
> 
> **Overview**
> Adds frontend support for per-informer cache sync diagnostics by introducing `DiagSyncPhase`/`DiagCacheSyncStatus`/`DiagInformerSyncStatus` types and exposing them as `DiagnosticsSnapshot.informers.syncStatus`.
> 
> Updates the diagnostics overlay and markdown export to show sync phase, critical/deferred synced counts, promoted kinds, and a sorted list of pending informers with live item counts, with the Informers section highlighted when sync is incomplete or has promotions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41eed2726df653febf4b8478a5e0c8ca3c70ed1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->