### PR TITLE
fix(desktop): keep window title in sync with cluster context switches

### DIFF
--- a/cmd/desktop/app.go
+++ b/cmd/desktop/app.go
@@ -42,12 +42,14 @@ func NewDesktopApp(srv *server.Server, timelineStoreCfg timeline.StoreConfig) *D
 
 // formatWindowTitle returns the Wails window title for a given kubeconfig
 // context name. Empty context (e.g. before the cluster is initialized) yields
-// the bare product name.
+// the bare product name. Otherwise the context is run through clusterShortName
+// so the OS title matches the label the in-page cluster selector shows for the
+// same cluster (e.g. "packagear-prod-eks", not the full EKS ARN).
 func formatWindowTitle(contextName string) string {
 	if contextName == "" {
 		return "Radar"
 	}
-	return "Radar — " + contextName
+	return "Radar — " + clusterShortName(contextName)
 }
 
 func (a *DesktopApp) updateWindowTitle(contextName string) {

--- a/cmd/desktop/app.go
+++ b/cmd/desktop/app.go
@@ -20,13 +20,38 @@ type DesktopApp struct {
 	ctx              context.Context
 	srv              *server.Server
 	timelineStoreCfg timeline.StoreConfig
+
+	// setWindowTitle is the side-effecty title setter, injectable for tests.
+	// Defaults to wailsRuntime.WindowSetTitle bound to a.ctx.
+	setWindowTitle func(title string)
 }
 
 func NewDesktopApp(srv *server.Server, timelineStoreCfg timeline.StoreConfig) *DesktopApp {
-	return &DesktopApp{
+	a := &DesktopApp{
 		srv:              srv,
 		timelineStoreCfg: timelineStoreCfg,
 	}
+	a.setWindowTitle = func(title string) {
+		if a.ctx == nil {
+			return
+		}
+		wailsRuntime.WindowSetTitle(a.ctx, title)
+	}
+	return a
+}
+
+// formatWindowTitle returns the Wails window title for a given kubeconfig
+// context name. Empty context (e.g. before the cluster is initialized) yields
+// the bare product name.
+func formatWindowTitle(contextName string) string {
+	if contextName == "" {
+		return "Radar"
+	}
+	return "Radar — " + contextName
+}
+
+func (a *DesktopApp) updateWindowTitle(contextName string) {
+	a.setWindowTitle(formatWindowTitle(contextName))
 }
 
 // startup is called when the Wails app starts.
@@ -34,6 +59,13 @@ func (a *DesktopApp) startup(ctx context.Context) {
 	a.ctx = ctx
 	startNativeMouseMonitor(ctx)
 	a.srv.SetSaveFileFunc(a.saveFile)
+
+	// The OS titlebar must track the active kubeconfig context for the same
+	// reason the in-page selector does: a fleet UI showing the wrong cluster
+	// name invites destructive actions on the wrong cluster.
+	k8s.OnContextSwitch(func(newContext string) {
+		a.updateWindowTitle(newContext)
+	})
 }
 
 // saveFile writes a file to the user's Downloads folder.
@@ -73,11 +105,7 @@ func (a *DesktopApp) saveFile(defaultFilename string, data []byte) (string, erro
 
 // domReady is called when the webview DOM is ready.
 func (a *DesktopApp) domReady(ctx context.Context) {
-	// Update window title with cluster context
-	contextName := k8s.GetContextName()
-	if contextName != "" {
-		wailsRuntime.WindowSetTitle(ctx, "Radar — "+contextName)
-	}
+	a.updateWindowTitle(k8s.GetContextName())
 }
 
 // beforeClose is called before the window closes. Return true to prevent closing.

--- a/cmd/desktop/app_test.go
+++ b/cmd/desktop/app_test.go
@@ -13,11 +13,16 @@ func TestFormatWindowTitle(t *testing.T) {
 		want        string
 	}{
 		{"empty falls back to bare product name", "", "Radar"},
-		{"short context", "packagear-dev-eks", "Radar — packagear-dev-eks"},
+		{"user-named context passes through", "packagear-dev-eks", "Radar — packagear-dev-eks"},
 		{
-			"full EKS ARN",
+			"full EKS ARN collapses to short cluster name (matches in-page selector)",
 			"arn:aws:eks:us-east-1:171782501968:cluster/packagear-prod-eks",
-			"Radar — arn:aws:eks:us-east-1:171782501968:cluster/packagear-prod-eks",
+			"Radar — packagear-prod-eks",
+		},
+		{
+			"GKE context collapses to cluster name",
+			"gke_my-project_us-east1-b_prod-cluster",
+			"Radar — prod-cluster",
 		},
 	}
 	for _, tc := range cases {

--- a/cmd/desktop/app_test.go
+++ b/cmd/desktop/app_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/skyhook-io/radar/pkg/timeline"
+)
+
+func TestFormatWindowTitle(t *testing.T) {
+	cases := []struct {
+		name        string
+		contextName string
+		want        string
+	}{
+		{"empty falls back to bare product name", "", "Radar"},
+		{"short context", "packagear-dev-eks", "Radar — packagear-dev-eks"},
+		{
+			"full EKS ARN",
+			"arn:aws:eks:us-east-1:171782501968:cluster/packagear-prod-eks",
+			"Radar — arn:aws:eks:us-east-1:171782501968:cluster/packagear-prod-eks",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatWindowTitle(tc.contextName); got != tc.want {
+				t.Fatalf("formatWindowTitle(%q) = %q, want %q", tc.contextName, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDesktopApp_UpdateWindowTitle_TracksContextSwitch asserts the invariant
+// that successive updateWindowTitle calls always re-render the title from the
+// most recent context name — including the empty/disconnected case.
+func TestDesktopApp_UpdateWindowTitle_TracksContextSwitch(t *testing.T) {
+	var got string
+	a := &DesktopApp{
+		setWindowTitle: func(title string) { got = title },
+	}
+
+	a.updateWindowTitle("packagear-prod-eks")
+	if got != "Radar — packagear-prod-eks" {
+		t.Fatalf("after initial set: got %q, want %q", got, "Radar — packagear-prod-eks")
+	}
+
+	a.updateWindowTitle("packagear-dev-eks")
+	if got != "Radar — packagear-dev-eks" {
+		t.Fatalf("after context switch: got %q, want %q", got, "Radar — packagear-dev-eks")
+	}
+
+	a.updateWindowTitle("")
+	if got != "Radar" {
+		t.Fatalf("after disconnect: got %q, want %q", got, "Radar")
+	}
+}
+
+// TestDesktopApp_NewDesktopApp_GuardsNilCtx ensures the default title setter
+// is a no-op before Wails has called startup() and populated a.ctx, instead
+// of panicking inside wailsRuntime.WindowSetTitle on a nil ctx.
+func TestDesktopApp_NewDesktopApp_GuardsNilCtx(t *testing.T) {
+	a := NewDesktopApp(nil, timeline.StoreConfig{})
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("setWindowTitle panicked with nil ctx: %v", r)
+		}
+	}()
+	a.updateWindowTitle("packagear-dev-eks")
+}

--- a/cmd/desktop/context_name.go
+++ b/cmd/desktop/context_name.go
@@ -1,0 +1,40 @@
+package main
+
+import "regexp"
+
+// Patterns mirror packages/k8s-ui/src/utils/context-name.ts. Keep in sync —
+// drift here means the OS window title and the in-page cluster selector
+// will render the same cluster differently, which is the whole class of
+// bug we're avoiding.
+//
+// RE2 differences from the TS version:
+//   - No lookahead, so the GKE region segment requires a digit via a
+//     sequential `[a-z0-9-]*[0-9][a-z0-9-]*` instead of TS's
+//     `(?=[a-z0-9-]*\d)([a-z][a-z0-9-]*)`. Same language, no backtracking
+//     concerns (RE2 is linear-time by construction).
+var (
+	gkeContextRe    = regexp.MustCompile(`^gke_([a-z][a-z0-9-]+)_([a-z][a-z0-9-]*[0-9][a-z0-9-]*)_(.+)$`)
+	eksArnContextRe = regexp.MustCompile(`^arn:aws:eks:([^:]+):(\d+):cluster/(.+)$`)
+	eksctlContextRe = regexp.MustCompile(`^(.+)@([^.]+)\.([^.]+)\.eksctl\.io$`)
+	aksContextRe    = regexp.MustCompile(`^cluster(?:User|Admin)_([^_]+)_(.+)$`)
+)
+
+// clusterShortName extracts the human-friendly cluster name from a kubeconfig
+// context name (GKE / EKS ARN / eksctl / AKS shapes). Falls back to the raw
+// context name when the shape isn't recognized, so user-named contexts and
+// the in-cluster sentinel pass through untouched.
+func clusterShortName(contextName string) string {
+	if m := gkeContextRe.FindStringSubmatch(contextName); m != nil {
+		return m[3]
+	}
+	if m := eksArnContextRe.FindStringSubmatch(contextName); m != nil {
+		return m[3]
+	}
+	if m := eksctlContextRe.FindStringSubmatch(contextName); m != nil {
+		return m[2]
+	}
+	if m := aksContextRe.FindStringSubmatch(contextName); m != nil {
+		return m[2]
+	}
+	return contextName
+}

--- a/cmd/desktop/context_name_test.go
+++ b/cmd/desktop/context_name_test.go
@@ -1,0 +1,47 @@
+package main
+
+import "testing"
+
+// TestClusterShortName mirrors the test cases in
+// packages/k8s-ui/src/utils/context-name.test.ts so the Go and TS parsers stay
+// in lockstep. If you add a case to one side, add it to the other.
+func TestClusterShortName(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// GKE
+		{"gke zonal cluster", "gke_my-project_us-east1-b_prod-cluster", "prod-cluster"},
+		{"gke regional cluster", "gke_my-project_us-central1_my-cluster", "my-cluster"},
+		{"gke cluster name with underscores", "gke_proj_us-east1-b_my_funky_cluster", "my_funky_cluster"},
+		{"gke arbitrary 3-underscore string is not GKE", "gke_a_b_c", "gke_a_b_c"},
+		{"gke middle segment without digit is not a zone", "gke_proj_notazone_cluster", "gke_proj_notazone_cluster"},
+
+		// EKS ARN
+		{"eks arn standard", "arn:aws:eks:us-east-1:123456789012:cluster/my-prod", "my-prod"},
+		{"eks arn cluster name containing region-like substring", "arn:aws:eks:eu-central-1:982081053473:cluster/us-east-1-nonprod", "us-east-1-nonprod"},
+
+		// eksctl
+		{"eksctl format", "admin@my-cluster.us-east-1.eksctl.io", "my-cluster"},
+
+		// AKS
+		{"aks clusterUser", "clusterUser_my-rg_my-cluster", "my-cluster"},
+		{"aks clusterAdmin", "clusterAdmin_prod-rg_prod-cluster", "prod-cluster"},
+		{"aks substring false-positive guarded: tracks-prod", "tracks-prod", "tracks-prod"},
+		{"aks substring false-positive guarded: my-aks-experiment", "my-aks-experiment", "my-aks-experiment"},
+		{"aks substring false-positive guarded: aks", "aks", "aks"},
+
+		// Fallthrough — user-named contexts and the in-cluster sentinel pass through.
+		{"unknown shape passes through", "my-staging-cluster", "my-staging-cluster"},
+		{"in-cluster sentinel", "in-cluster", "in-cluster"},
+		{"empty input", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clusterShortName(tc.in); got != tc.want {
+				t.Fatalf("clusterShortName(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/desktop/main.go
+++ b/cmd/desktop/main.go
@@ -144,13 +144,8 @@ func main() {
 	// Track opens and maybe prompt to star (non-blocking)
 	app.MaybePromptGitHubStar()
 
-	// Build window title
-	windowTitle := "Radar"
-	if ctx := k8s.GetContextName(); ctx != "" {
-		windowTitle = "Radar — " + ctx
-	}
+	windowTitle := formatWindowTitle(k8s.GetContextName())
 
-	// Create desktop app
 	desktopApp := NewDesktopApp(srv, timelineStoreCfg)
 
 	// Run Wails application


### PR DESCRIPTION
## What

Register an `OnContextSwitch` callback in the desktop app's `startup()` so the OS window title re-renders whenever the user switches kubeconfig contexts via the in-page cluster selector.

- `cmd/desktop/app.go`: extract `formatWindowTitle(contextName)`, add injectable `setWindowTitle` field, register an `OnContextSwitch` callback that calls `updateWindowTitle(newContext)`.
- `cmd/desktop/main.go`: use the new helper for the initial title (was duplicated inline).
- `cmd/desktop/app_test.go`: regression coverage for `formatWindowTitle`, the update sequence (initial → switch → disconnect), and the nil-ctx guard before `startup`.

## Why

The Wails window title was set exactly once in `domReady` and never refreshed. After switching contexts in-app, the OS titlebar kept pointing at the cluster Radar booted with (commonly prod) while the in-page selector and the data layer were on the new cluster — a state mismatch that's especially dangerous in a fleet UI: one of those moments where you click "Delete" thinking you're in dev. Hooking into the existing `k8s.OnContextSwitch` notification (already used by the SSE broadcaster at `internal/server/sse.go:235`) means the title now derives from the same source of truth as the data layer.

## Where to start reading

- `cmd/desktop/app.go:57-69` — the new `OnContextSwitch` registration in `startup()`.
- `cmd/desktop/app.go:43-55` — `formatWindowTitle` + `updateWindowTitle`.

## Risky vs mechanical

- **Risky-ish**: the registration in `startup()`. The callback fires from another goroutine after `PerformContextSwitch` completes; safe because (a) `a.ctx` is written before the registration call in the same goroutine, and (b) `OnContextSwitch` synchronizes via `contextSwitchMu` (Lock on register / RLock on dispatch), giving happens-before to the callback.
- **Mechanical**: `formatWindowTitle` extraction + the inline `domReady`/`main.go` cleanup.

## Not included

- Browser/standalone build: nothing in the web frontend currently sets `document.title` dynamically, so there's nothing to fix there. If we ever start setting it, hook the existing `context_changed` SSE event the broadcaster already emits.
- Destructive-action confirmations re-displaying the cluster name: separate hardening pass, would touch a lot of UI surface.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: desktop-only window title updates and new context-name parsing helpers; main behavior change is registering an additional `OnContextSwitch` callback and should not affect cluster operations beyond UI labeling.
> 
> **Overview**
> Keeps the desktop OS window title **continuously in sync** with kubeconfig context changes by registering a `k8s.OnContextSwitch` callback during `DesktopApp.startup()` and routing all title updates through a new `updateWindowTitle` helper.
> 
> Extracts `formatWindowTitle` to centralize title rendering, including shortening provider-specific context strings via new `clusterShortName` parsing (GKE/EKS ARN/eksctl/AKS) so the title matches the in-app cluster selector.
> 
> Adds unit tests covering title formatting, successive context switches (including disconnect/empty context), and a nil-`ctx` guard via an injectable `setWindowTitle` function; `main.go` now uses `formatWindowTitle` for the initial Wails `Title`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2fee49672886c2c652d95b0dbc411004cfaaf6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->