### PR TITLE
fix: server-side apply, idempotent Helm install, RBAC pre-flight (SKY-843)

### DIFF
--- a/deploy/helm/radar/README.md
+++ b/deploy/helm/radar/README.md
@@ -99,6 +99,8 @@ Disabled by default for security:
 | Terminal | `rbac.podExec: true` | Shell access to pods |
 | Port Forward | `rbac.portForward: true` | Port forwarding to pods |
 | Logs | `rbac.podLogs: true` | View pod logs (**enabled by default**) |
+| Helm Write | `rbac.helm: true` | Install/upgrade/rollback/uninstall Helm releases. Under auth or cloud-mode, also emits a split helm add-on ClusterRole — `radar-helm` (member-safe: CRDs, storage, namespaces) and `radar-helm-admin` (owner-only: RBAC, webhooks, ApiServices) |
+| RBAC view | `rbac.viewRBAC: true` | Show ClusterRoles, ClusterRoleBindings, Roles, RoleBindings in the resource browser. Off by default — cache-served reads bypass per-user RBAC, so this exposes the cluster's authorization graph to every authenticated Radar user |
 
 ### In-app Agent Upgrades (opt-in, for Radar Cloud users)
 

--- a/deploy/helm/radar/templates/cloud-rbac-helm.yaml
+++ b/deploy/helm/radar/templates/cloud-rbac-helm.yaml
@@ -1,0 +1,42 @@
+{{- /*
+Bind the Helm-capable add-on ClusterRole to cloud:owner and cloud:member.
+RBAC is additive, so these grants stack on top of the admin/edit role each
+tier already gets via cloud-rbac.yaml.
+
+Viewer is intentionally not bound — viewers never install Helm releases.
+*/}}
+{{- if and .Values.cloud.enabled .Values.cloud.defaultRbac.create .Values.rbac.create .Values.rbac.helm (ne .Values.auth.mode "none") -}}
+{{- if .Values.cloud.defaultRbac.owner }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "radar.fullname" . }}-cloud-owner-helm
+  labels:
+    {{- include "radar.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "radar.fullname" . }}-helm
+subjects:
+  - kind: Group
+    name: cloud:owner
+    apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- if .Values.cloud.defaultRbac.member }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "radar.fullname" . }}-cloud-member-helm
+  labels:
+    {{- include "radar.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "radar.fullname" . }}-helm
+subjects:
+  - kind: Group
+    name: cloud:member
+    apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end -}}

--- a/deploy/helm/radar/templates/cloud-rbac-helm.yaml
+++ b/deploy/helm/radar/templates/cloud-rbac-helm.yaml
@@ -1,18 +1,7 @@
 {{- /*
-Bind the Helm add-on ClusterRoles to cloud role tiers.
-
-Two distinct grants:
-  - radar-helm (member-safe): CRDs, storage, runtime classes, PDBs,
-    namespaces. Bound to both cloud:owner and cloud:member.
-  - radar-helm-admin (cluster-admin-equivalent): RBAC, webhooks,
-    APIServices. Bound to cloud:owner ONLY — granting these to member
-    would let any member self-promote to cluster-admin via a one-apply
-    ClusterRoleBinding write.
-
-Viewer is intentionally not bound — viewers never install Helm releases.
-
-RBAC is additive, so these grants stack on top of the admin/edit role each
-tier already gets via cloud-rbac.yaml.
+Bind Helm add-on ClusterRoles to cloud tiers. radar-helm goes to owner +
+member; radar-helm-admin goes to owner only — see clusterrole-helm-admin.yaml
+for the rationale. Viewer is intentionally not bound; viewers never install.
 */}}
 {{- if and .Values.cloud.enabled .Values.cloud.defaultRbac.create .Values.rbac.create .Values.rbac.helm (ne .Values.auth.mode "none") -}}
 {{- if .Values.cloud.defaultRbac.owner }}

--- a/deploy/helm/radar/templates/cloud-rbac-helm.yaml
+++ b/deploy/helm/radar/templates/cloud-rbac-helm.yaml
@@ -1,9 +1,18 @@
 {{- /*
-Bind the Helm-capable add-on ClusterRole to cloud:owner and cloud:member.
-RBAC is additive, so these grants stack on top of the admin/edit role each
-tier already gets via cloud-rbac.yaml.
+Bind the Helm add-on ClusterRoles to cloud role tiers.
+
+Two distinct grants:
+  - radar-helm (member-safe): CRDs, storage, runtime classes, PDBs,
+    namespaces. Bound to both cloud:owner and cloud:member.
+  - radar-helm-admin (cluster-admin-equivalent): RBAC, webhooks,
+    APIServices. Bound to cloud:owner ONLY — granting these to member
+    would let any member self-promote to cluster-admin via a one-apply
+    ClusterRoleBinding write.
 
 Viewer is intentionally not bound — viewers never install Helm releases.
+
+RBAC is additive, so these grants stack on top of the admin/edit role each
+tier already gets via cloud-rbac.yaml.
 */}}
 {{- if and .Values.cloud.enabled .Values.cloud.defaultRbac.create .Values.rbac.create .Values.rbac.helm (ne .Values.auth.mode "none") -}}
 {{- if .Values.cloud.defaultRbac.owner }}
@@ -17,6 +26,21 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ include "radar.fullname" . }}-helm
+subjects:
+  - kind: Group
+    name: cloud:owner
+    apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "radar.fullname" . }}-cloud-owner-helm-admin
+  labels:
+    {{- include "radar.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "radar.fullname" . }}-helm-admin
 subjects:
   - kind: Group
     name: cloud:owner

--- a/deploy/helm/radar/templates/clusterrole-helm-admin.yaml
+++ b/deploy/helm/radar/templates/clusterrole-helm-admin.yaml
@@ -1,0 +1,35 @@
+{{- /*
+Cluster-admin-equivalent add-on ClusterRole. Emitted under the same gate as
+radar-helm but bound only to cloud:owner — never cloud:member.
+
+The verbs in this role are individually sufficient for self-promotion to
+cluster-admin or for bypassing admission control:
+  - rbac writes: bind your own user to cluster-admin in one apply
+  - webhook writes: delete the policy that blocks privileged pods
+  - apiservices: register a rogue aggregated API
+Granting these to a tier weaker than owner collapses the owner/member
+distinction. Charts that bundle their own RBAC, webhooks, or APIServices
+require an owner identity to install.
+*/}}
+{{- if and .Values.rbac.create .Values.rbac.helm (or (ne .Values.auth.mode "none") .Values.cloud.enabled) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "radar.fullname" . }}-helm-admin
+  labels:
+    {{- include "radar.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+      - validatingadmissionpolicies
+      - validatingadmissionpolicybindings
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apiregistration.k8s.io"]
+    resources: ["apiservices"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+{{- end }}

--- a/deploy/helm/radar/templates/clusterrole-helm.yaml
+++ b/deploy/helm/radar/templates/clusterrole-helm.yaml
@@ -1,18 +1,8 @@
 {{- /*
-Helm-capable add-on ClusterRole — the "member-safe" tier. Emitted when
-rbac.helm=true AND auth or cloud is on (so requests run under impersonated
-identities which need their own grant beyond the SA's).
-
-Covers chart resources whose write access is needed for installing typical
-operator-style charts (CRDs, storage classes, runtime classes, priority
-classes, PDBs, namespaces) but does NOT include the cluster-admin-equivalent
-surface (ClusterRole/Role writes, webhook configs, APIServices). Those live
-in radar-helm-admin and are bound to cloud:owner only.
-
-The split is deliberate: a cloud:member with ClusterRoleBinding-write can
-trivially self-promote to cluster-admin, collapsing the owner/member tier
-boundary. Charts that bundle their own RBAC (e.g. full operator installs)
-require an owner identity to install.
+Helm add-on ClusterRole — member-safe tier. Covers CRDs, storage classes,
+runtime/priority classes, PDBs, namespaces. Cluster-admin-equivalent verbs
+(RBAC writes, webhooks, APIServices) live in radar-helm-admin; see that
+template for the owner-only rationale.
 */}}
 {{- if and .Values.rbac.create .Values.rbac.helm (or (ne .Values.auth.mode "none") .Values.cloud.enabled) -}}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -36,8 +26,8 @@ rules:
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["policy"]
     resources: ["poddisruptionbudgets"]
-    verbs: ["create", "update", "patch", "delete"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["namespaces"]
-    verbs: ["create", "update", "patch", "delete"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 {{- end }}

--- a/deploy/helm/radar/templates/clusterrole-helm.yaml
+++ b/deploy/helm/radar/templates/clusterrole-helm.yaml
@@ -1,0 +1,55 @@
+{{- /*
+Helm-capable add-on ClusterRole. Emitted only when rbac.helm=true (so Helm
+write operations are allowed at all) AND auth or cloud is on (so requests run
+under impersonated identities, which need their own grant beyond the SA's).
+
+Helm's pre-flight existence check issues a Get on every object the chart will
+create. For charts that include cluster-scoped resources (ClusterRole,
+ClusterRoleBinding, CRD, ValidatingWebhookConfiguration, PriorityClass, ...)
+this requires cluster-scoped reads — which the K8s built-in admin/edit/view
+roles do not grant. Without this, in-cluster Radar agents fail every install
+of any chart that touches those resources.
+
+Cloud role tiers (owner/member) are bound to this role in cloud-rbac-helm.yaml.
+For non-cloud auth-mode setups, the cluster operator wires their own bindings.
+*/}}
+{{- if and .Values.rbac.create .Values.rbac.helm (or (ne .Values.auth.mode "none") .Values.cloud.enabled) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "radar.fullname" . }}-helm
+  labels:
+    {{- include "radar.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+      - validatingadmissionpolicies
+      - validatingadmissionpolicybindings
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apiregistration.k8s.io"]
+    resources: ["apiservices"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csidrivers", "volumeattachments"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["scheduling.k8s.io"]
+    resources: ["priorityclasses"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["node.k8s.io"]
+    resources: ["runtimeclasses"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["create", "update", "patch", "delete"]
+{{- end }}

--- a/deploy/helm/radar/templates/clusterrole-helm.yaml
+++ b/deploy/helm/radar/templates/clusterrole-helm.yaml
@@ -1,17 +1,18 @@
 {{- /*
-Helm-capable add-on ClusterRole. Emitted only when rbac.helm=true (so Helm
-write operations are allowed at all) AND auth or cloud is on (so requests run
-under impersonated identities, which need their own grant beyond the SA's).
+Helm-capable add-on ClusterRole — the "member-safe" tier. Emitted when
+rbac.helm=true AND auth or cloud is on (so requests run under impersonated
+identities which need their own grant beyond the SA's).
 
-Helm's pre-flight existence check issues a Get on every object the chart will
-create. For charts that include cluster-scoped resources (ClusterRole,
-ClusterRoleBinding, CRD, ValidatingWebhookConfiguration, PriorityClass, ...)
-this requires cluster-scoped reads — which the K8s built-in admin/edit/view
-roles do not grant. Without this, in-cluster Radar agents fail every install
-of any chart that touches those resources.
+Covers chart resources whose write access is needed for installing typical
+operator-style charts (CRDs, storage classes, runtime classes, priority
+classes, PDBs, namespaces) but does NOT include the cluster-admin-equivalent
+surface (ClusterRole/Role writes, webhook configs, APIServices). Those live
+in radar-helm-admin and are bound to cloud:owner only.
 
-Cloud role tiers (owner/member) are bound to this role in cloud-rbac-helm.yaml.
-For non-cloud auth-mode setups, the cluster operator wires their own bindings.
+The split is deliberate: a cloud:member with ClusterRoleBinding-write can
+trivially self-promote to cluster-admin, collapsing the owner/member tier
+boundary. Charts that bundle their own RBAC (e.g. full operator installs)
+require an owner identity to install.
 */}}
 {{- if and .Values.rbac.create .Values.rbac.helm (or (ne .Values.auth.mode "none") .Values.cloud.enabled) -}}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -21,21 +22,8 @@ metadata:
   labels:
     {{- include "radar.labels" . | nindent 4 }}
 rules:
-  - apiGroups: ["rbac.authorization.k8s.io"]
-    resources: ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["admissionregistration.k8s.io"]
-    resources:
-      - validatingwebhookconfigurations
-      - mutatingwebhookconfigurations
-      - validatingadmissionpolicies
-      - validatingadmissionpolicybindings
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["apiregistration.k8s.io"]
-    resources: ["apiservices"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses", "csidrivers", "volumeattachments"]

--- a/deploy/helm/radar/templates/clusterrole.yaml
+++ b/deploy/helm/radar/templates/clusterrole.yaml
@@ -76,9 +76,11 @@ rules:
       - selfsubjectaccessreviews
     verbs: ["create"]
 
-  # RBAC objects: read for the resource browser. Without this, ClusterRole/
-  # ClusterRoleBinding/Role/RoleBinding views cannot list anything even though
-  # the broad write rule above lets users create them when rbac.helm=true.
+  {{- if .Values.rbac.viewRBAC }}
+  # RBAC objects: opt-in read for the resource browser. Off by default —
+  # cache-served reads are not gated by per-user RBAC, so granting this
+  # exposes the cluster's authorization graph to anyone who can reach
+  # Radar's API regardless of their own permissions.
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources:
       - roles
@@ -86,6 +88,7 @@ rules:
       - clusterroles
       - clusterrolebindings
     verbs: ["get", "list", "watch"]
+  {{- end }}
 
   {{- if .Values.rbac.podLogs }}
   # Pod logs (opt-in - enables log viewer)

--- a/deploy/helm/radar/templates/clusterrole.yaml
+++ b/deploy/helm/radar/templates/clusterrole.yaml
@@ -76,6 +76,17 @@ rules:
       - selfsubjectaccessreviews
     verbs: ["create"]
 
+  # RBAC objects: read for the resource browser. Without this, ClusterRole/
+  # ClusterRoleBinding/Role/RoleBinding views cannot list anything even though
+  # the broad write rule above lets users create them when rbac.helm=true.
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources:
+      - roles
+      - rolebindings
+      - clusterroles
+      - clusterrolebindings
+    verbs: ["get", "list", "watch"]
+
   {{- if .Values.rbac.podLogs }}
   # Pod logs (opt-in - enables log viewer)
   - apiGroups: [""]

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -40,6 +40,13 @@ rbac:
   # Allow reading secrets (shows secrets in resource list)
   secrets: false
 
+  # Allow reading RBAC objects (Roles, RoleBindings, ClusterRoles, ClusterRoleBindings)
+  # so the resource browser can list them. Off by default: anyone reaching Radar's
+  # API sees the full RBAC graph through the shared informer cache regardless of
+  # their own K8s permissions, which is reconnaissance value for a low-trust user.
+  # Enable for clusters where Radar's audience is trusted with cluster RBAC visibility.
+  viewRBAC: false
+
   # Allow pod exec (enables terminal feature)
   podExec: false
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -11,7 +11,7 @@ User → [Auth Layer] → Radar Backend → K8s API (as user, via impersonation)
 ```
 
 1. **Authentication** identifies the user (proxy headers or OIDC login)
-2. **Reads** are filtered — Radar discovers which namespaces the user can access via `SubjectAccessReview` and only returns resources from those namespaces
+2. **Reads** are filtered by namespace — Radar discovers which namespaces the user can access via `SubjectAccessReview` and only returns resources from those namespaces. Cluster-scoped resources (Nodes, ClusterRoles when `rbac.viewRBAC` is on, StorageClasses, etc.) are served from the ServiceAccount-populated informer cache without per-user RBAC re-checks, so anyone reaching Radar's API sees them regardless of their own K8s permissions on those kinds.
 3. **Writes** use K8s impersonation — Radar makes the K8s API call as the authenticated user, so K8s RBAC decides whether it's allowed
 4. **UI adapts** — capability checks run per-user, so buttons (exec, restart, scale, Helm) only appear if the user has permission
 
@@ -164,6 +164,14 @@ Under cloud-mode (`RADAR_CLOUD_MODE=true`, set automatically by the chart when `
 - Forces `--auth-mode=proxy` with pinned `X-Forwarded-User` / `X-Forwarded-Groups` headers — the Cloud tunnel is the trust boundary.
 - Ships three default ClusterRoleBindings mapping Cloud's `cloud:owner` / `cloud:member` / `cloud:viewer` groups to the standard K8s `admin` / `edit` / `view` ClusterRoles. Configurable via `cloud.defaultRbac.*` in `values.yaml`.
 - Hardens the listener (no `/debug/pprof/*`, narrower exempt paths).
+
+<a id="cloud-mode-helm-bindings"></a>
+**Helm-specific bindings (when `rbac.helm=true`).** Helm's pre-flight existence check needs cluster-scoped reads/writes that the K8s built-in `admin`/`edit`/`view` ClusterRoles don't grant. The chart emits two add-on ClusterRoles, split by trust tier:
+
+- `radar-helm` — CRDs, StorageClasses, RuntimeClasses, PriorityClasses, PodDisruptionBudgets, Namespaces. Bound to `cloud:owner` AND `cloud:member`.
+- `radar-helm-admin` — RBAC objects (Roles/Bindings, Cluster variants), validating/mutating webhooks, ApiServices. Bound to `cloud:owner` ONLY. Granting these to a tier weaker than owner would let a member self-promote to cluster-admin in one `ClusterRoleBinding` write, collapsing the owner/member distinction.
+
+A `cloud:member` attempting to install a chart that bundles its own RBAC will get a typed `rbac_preflight` 403 with an actionable "ask an owner" message. Day-to-day app charts and operator-CRD installs still work for members.
 
 Customer-facing documentation for Radar Cloud lives on [radarhq.io](https://radarhq.io). The authoritative reference for the Cloud-mode chart values is the comment block in [`deploy/helm/radar/values.yaml`](../deploy/helm/radar/values.yaml) under `cloud:`.
 

--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -135,7 +135,8 @@ Some features require additional permissions. Most are disabled by default for s
 | Terminal | `rbac.podExec: true` | `false` | Shell access to pods |
 | Port Forward | `rbac.portForward: true` | `false` | Port forwarding to pods/services |
 | Logs | `rbac.podLogs: true` | `true` | View pod logs |
-| Helm Write | `rbac.helm: true` | `false` | Install/upgrade/rollback/uninstall Helm releases (grants broad write access; auto-enables secrets) |
+| Helm Write | `rbac.helm: true` | `false` | Install/upgrade/rollback/uninstall Helm releases (grants broad write access; auto-enables secrets). When auth or cloud is on, also emits a split helm add-on: `radar-helm` (CRDs/storage/PDBs/namespaces, bound to owner+member) and `radar-helm-admin` (RBAC/webhooks/APIServices, owner-only) — see [authentication.md](authentication.md#cloud-mode-helm-bindings) |
+| RBAC view | `rbac.viewRBAC: true` | `false` | Show ClusterRoles, ClusterRoleBindings, Roles, RoleBindings in the resource browser. Off by default: cache-served reads bypass per-user RBAC, so granting this exposes the cluster's authorization graph to every authenticated Radar user |
 | Traffic TLS | `rbac.traffic: true` | `true` | Read Hubble relay TLS certs for Cilium traffic observation |
 
 > **Node management** (cordon, uncordon, drain) is available via the MCP server and API. These operations require `patch` on nodes, `list` on pods, and `create` on `pods/eviction`, which are not included in the default ClusterRole. Add them via `rbac.additionalRules` or use [per-user authentication](authentication.md) so each user's own RBAC governs node operations.
@@ -283,6 +284,7 @@ See [Helm Chart README](../deploy/helm/radar/README.md) for all available values
 | `rbac.portForward` | Enable port forwarding | `false` |
 | `rbac.secrets` | Show secrets in resource list | `false` |
 | `rbac.helm` | Enable Helm write operations | `false` |
+| `rbac.viewRBAC` | Show RBAC objects in resource browser | `false` |
 | `rbac.traffic` | Read Hubble TLS certs | `true` |
 | `rbac.crdGroups.all` | Wildcard CRD read access | `false` |
 

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -1904,7 +1904,7 @@ func (c *Client) installWith(actionConfig *action.Configuration, req *InstallReq
 	}
 
 	if !fresh {
-		log.Printf("[helm] install %s/%s: prior release record exists, recovering via upgrade --install", req.Namespace, req.ReleaseName)
+		log.Printf("[helm] install %q/%q: prior release record exists, recovering via upgrade --install", req.Namespace, req.ReleaseName)
 	}
 	rel, err := runInstallOrUpgrade(actionConfig, req, chart, fresh)
 	if err != nil {

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -1885,28 +1885,25 @@ func (c *Client) installWith(actionConfig *action.Configuration, req *InstallReq
 		}
 	}
 
-	// Create install action
-	installAction := action.NewInstall(actionConfig)
-	installAction.ReleaseName = req.ReleaseName
-	installAction.Namespace = req.Namespace
-	installAction.CreateNamespace = req.CreateNamespace
-	installAction.Timeout = 120 * time.Second
-	installAction.Version = req.Version
+	// Pre-check: surface stuck pending releases before Helm's own guard.
+	fresh, err := preInstallCheck(actionConfig, req.ReleaseName, req.Namespace)
+	if err != nil {
+		return nil, err
+	}
 
-	// Locate/download chart
-	cp, err := installAction.ChartPathOptions.LocateChart(chartURL, c.settings)
+	// ChartPathOptions lives on Install — reuse it just to locate/download.
+	locator := action.NewInstall(actionConfig)
+	locator.Version = req.Version
+	cp, err := locator.ChartPathOptions.LocateChart(chartURL, c.settings)
 	if err != nil {
 		return nil, fmt.Errorf("failed to locate chart: %w", err)
 	}
-
-	// Load chart
 	chart, err := loader.Load(cp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load chart: %w", err)
 	}
 
-	// Run install
-	rel, err := installAction.Run(chart, req.Values)
+	rel, err := runInstallOrUpgrade(actionConfig, req, chart, fresh)
 	if err != nil {
 		return nil, fmt.Errorf("install failed: %w", err)
 	}
@@ -2106,19 +2103,21 @@ func (c *Client) installWithProgressUsing(actionConfig *action.Configuration, re
 		return nil, fmt.Errorf("failed to load chart: %w", err)
 	}
 
-	installAction := action.NewInstall(actionConfig)
-	installAction.ReleaseName = req.ReleaseName
-	installAction.Namespace = req.Namespace
-	installAction.CreateNamespace = req.CreateNamespace
-	installAction.Timeout = 120 * time.Second
-
-	sendProgress("installing", fmt.Sprintf("Installing %s to namespace %s...", req.ReleaseName, req.Namespace), "")
-
-	if req.CreateNamespace {
-		sendProgress("installing", fmt.Sprintf("Creating namespace %s if needed...", req.Namespace), "")
+	fresh, err := preInstallCheck(actionConfig, req.ReleaseName, req.Namespace)
+	if err != nil {
+		return nil, err
 	}
 
-	rel, err := installAction.Run(chart, req.Values)
+	if fresh {
+		sendProgress("installing", fmt.Sprintf("Installing %s to namespace %s...", req.ReleaseName, req.Namespace), "")
+		if req.CreateNamespace {
+			sendProgress("installing", fmt.Sprintf("Creating namespace %s if needed...", req.Namespace), "")
+		}
+	} else {
+		sendProgress("installing", fmt.Sprintf("Replacing prior failed release %s in %s...", req.ReleaseName, req.Namespace), "")
+	}
+
+	rel, err := runInstallOrUpgrade(actionConfig, req, chart, fresh)
 	if err != nil {
 		return nil, fmt.Errorf("install failed: %w", err)
 	}

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -1885,13 +1885,12 @@ func (c *Client) installWith(actionConfig *action.Configuration, req *InstallReq
 		}
 	}
 
-	// Pre-check: surface stuck pending releases before Helm's own guard.
 	fresh, err := preInstallCheck(actionConfig, req.ReleaseName, req.Namespace)
 	if err != nil {
 		return nil, err
 	}
 
-	// ChartPathOptions lives on Install — reuse it just to locate/download.
+	// action.Install carries ChartPathOptions; instantiated here as a locator only.
 	locator := action.NewInstall(actionConfig)
 	locator.Version = req.Version
 	cp, err := locator.ChartPathOptions.LocateChart(chartURL, c.settings)

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -2070,6 +2070,14 @@ func (c *Client) installWithProgressUsing(actionConfig *action.Configuration, re
 		}
 	}
 
+	// Pre-flight before downloading: a deployed/pending release is knowable
+	// from local Helm storage and we shouldn't waste bandwidth + show
+	// "Downloading..." progress to a user who'll get a 409 anyway.
+	mode, err := preInstallCheck(actionConfig, req.ReleaseName, req.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
 	sendProgress("downloading", fmt.Sprintf("Downloading chart %s-%s...", req.ChartName, req.Version), chartURL)
 
 	// Download the chart archive directly via HTTP, bypassing the Helm SDK's
@@ -2103,11 +2111,6 @@ func (c *Client) installWithProgressUsing(actionConfig *action.Configuration, re
 	chart, err := loader.Load(tmpChart.Name())
 	if err != nil {
 		return nil, fmt.Errorf("failed to load chart: %w", err)
-	}
-
-	mode, err := preInstallCheck(actionConfig, req.ReleaseName, req.Namespace)
-	if err != nil {
-		return nil, err
 	}
 
 	switch mode {

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -1903,6 +1903,9 @@ func (c *Client) installWith(actionConfig *action.Configuration, req *InstallReq
 		return nil, fmt.Errorf("failed to load chart: %w", err)
 	}
 
+	if !fresh {
+		log.Printf("[helm] install %s/%s: prior release record exists, recovering via upgrade --install", req.Namespace, req.ReleaseName)
+	}
 	rel, err := runInstallOrUpgrade(actionConfig, req, chart, fresh)
 	if err != nil {
 		return nil, fmt.Errorf("install failed: %w", err)

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -1885,7 +1885,7 @@ func (c *Client) installWith(actionConfig *action.Configuration, req *InstallReq
 		}
 	}
 
-	fresh, err := preInstallCheck(actionConfig, req.ReleaseName, req.Namespace)
+	mode, err := preInstallCheck(actionConfig, req.ReleaseName, req.Namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -1902,10 +1902,10 @@ func (c *Client) installWith(actionConfig *action.Configuration, req *InstallReq
 		return nil, fmt.Errorf("failed to load chart: %w", err)
 	}
 
-	if !fresh {
-		log.Printf("[helm] install %q/%q: prior release record exists, recovering via upgrade --install", req.Namespace, req.ReleaseName)
+	if mode != installFresh {
+		log.Printf("[helm] install %q/%q: prior release record exists, recovering via %s", req.Namespace, req.ReleaseName, recoveryMode(mode))
 	}
-	rel, err := runInstallOrUpgrade(actionConfig, req, chart, fresh)
+	rel, err := runInstallOrUpgrade(actionConfig, req, chart, mode)
 	if err != nil {
 		return nil, fmt.Errorf("install failed: %w", err)
 	}
@@ -2105,21 +2105,24 @@ func (c *Client) installWithProgressUsing(actionConfig *action.Configuration, re
 		return nil, fmt.Errorf("failed to load chart: %w", err)
 	}
 
-	fresh, err := preInstallCheck(actionConfig, req.ReleaseName, req.Namespace)
+	mode, err := preInstallCheck(actionConfig, req.ReleaseName, req.Namespace)
 	if err != nil {
 		return nil, err
 	}
 
-	if fresh {
+	switch mode {
+	case installFresh:
 		sendProgress("installing", fmt.Sprintf("Installing %s to namespace %s...", req.ReleaseName, req.Namespace), "")
 		if req.CreateNamespace {
 			sendProgress("installing", fmt.Sprintf("Creating namespace %s if needed...", req.Namespace), "")
 		}
-	} else {
-		sendProgress("installing", fmt.Sprintf("Replacing prior failed release %s in %s...", req.ReleaseName, req.Namespace), "")
+	case installReplace:
+		sendProgress("installing", fmt.Sprintf("Replacing prior uninstalled release %s in %s...", req.ReleaseName, req.Namespace), "")
+	case installUpgrade:
+		sendProgress("installing", fmt.Sprintf("Recovering prior failed release %s in %s...", req.ReleaseName, req.Namespace), "")
 	}
 
-	rel, err := runInstallOrUpgrade(actionConfig, req, chart, fresh)
+	rel, err := runInstallOrUpgrade(actionConfig, req, chart, mode)
 	if err != nil {
 		return nil, fmt.Errorf("install failed: %w", err)
 	}

--- a/internal/helm/handlers.go
+++ b/internal/helm/handlers.go
@@ -822,6 +822,7 @@ func (h *Handlers) handleInstall(w http.ResponseWriter, r *http.Request) {
 		release, installErr = client.Install(&req)
 	}
 	if err := installErr; err != nil {
+		log.Printf("[helm] install %s/%s (chart=%s repo=%s) failed: %v", req.Namespace, req.ReleaseName, req.ChartName, req.Repository, err)
 		writeInstallError(w, err)
 		return
 	}
@@ -920,6 +921,7 @@ func (h *Handlers) handleInstallStream(w http.ResponseWriter, r *http.Request) {
 
 		case result := <-resultCh:
 			if result.err != nil {
+				log.Printf("[helm] install %s/%s (chart=%s repo=%s) failed: %v", req.Namespace, req.ReleaseName, req.ChartName, req.Repository, result.err)
 				event := map[string]any{
 					"type":    "error",
 					"message": result.err.Error(),

--- a/internal/helm/handlers.go
+++ b/internal/helm/handlers.go
@@ -822,11 +822,7 @@ func (h *Handlers) handleInstall(w http.ResponseWriter, r *http.Request) {
 		release, installErr = client.Install(&req)
 	}
 	if err := installErr; err != nil {
-		if IsForbiddenError(err) {
-			writeError(w, http.StatusForbidden, "insufficient permissions to install Helm release")
-			return
-		}
-		writeError(w, http.StatusInternalServerError, err.Error())
+		writeInstallError(w, err)
 		return
 	}
 
@@ -927,6 +923,9 @@ func (h *Handlers) handleInstallStream(w http.ResponseWriter, r *http.Request) {
 				event := map[string]any{
 					"type":    "error",
 					"message": result.err.Error(),
+				}
+				if code := classifyInstallErrorCode(result.err); code != "" {
+					event["error_code"] = code
 				}
 				data, _ := json.Marshal(event)
 				w.Write([]byte("data: " + string(data) + "\n\n"))

--- a/internal/helm/handlers.go
+++ b/internal/helm/handlers.go
@@ -822,7 +822,7 @@ func (h *Handlers) handleInstall(w http.ResponseWriter, r *http.Request) {
 		release, installErr = client.Install(&req)
 	}
 	if err := installErr; err != nil {
-		log.Printf("[helm] install %s/%s (chart=%s repo=%s) failed: %v", req.Namespace, req.ReleaseName, req.ChartName, req.Repository, err)
+		log.Printf("[helm] install %q/%q (chart=%q repo=%q) failed: %v", req.Namespace, req.ReleaseName, req.ChartName, req.Repository, err)
 		writeInstallError(w, err)
 		return
 	}
@@ -921,7 +921,7 @@ func (h *Handlers) handleInstallStream(w http.ResponseWriter, r *http.Request) {
 
 		case result := <-resultCh:
 			if result.err != nil {
-				log.Printf("[helm] install %s/%s (chart=%s repo=%s) failed: %v", req.Namespace, req.ReleaseName, req.ChartName, req.Repository, result.err)
+				log.Printf("[helm] install %q/%q (chart=%q repo=%q) failed: %v", req.Namespace, req.ReleaseName, req.ChartName, req.Repository, result.err)
 				event := map[string]any{
 					"type":    "error",
 					"message": result.err.Error(),

--- a/internal/helm/handlers.go
+++ b/internal/helm/handlers.go
@@ -922,14 +922,7 @@ func (h *Handlers) handleInstallStream(w http.ResponseWriter, r *http.Request) {
 		case result := <-resultCh:
 			if result.err != nil {
 				log.Printf("[helm] install %q/%q (chart=%q repo=%q) failed: %v", req.Namespace, req.ReleaseName, req.ChartName, req.Repository, result.err)
-				event := map[string]any{
-					"type":    "error",
-					"message": result.err.Error(),
-				}
-				if code := classifyInstallErrorCode(result.err); code != "" {
-					event["error_code"] = code
-				}
-				data, _ := json.Marshal(event)
+				data, _ := json.Marshal(installStreamErrorEvent(result.err))
 				w.Write([]byte("data: " + string(data) + "\n\n"))
 			} else {
 				event := map[string]any{

--- a/internal/helm/install_preflight.go
+++ b/internal/helm/install_preflight.go
@@ -51,20 +51,18 @@ func (e *ReleaseExistsError) Error() string {
 //     can safely overwrite it
 //   - (_, *ReleasePendingError): a prior attempt is stuck in pending-* state
 //   - (_, *ReleaseExistsError): the release is currently deployed
+//
+// Reads the latest revision via Releases.Last. action.History.Run returns the
+// storage driver's raw Query output without sorting and ignores Max, so
+// hist[0] would silently pick whatever ordering the driver happens to use.
 func preInstallCheck(actionConfig *action.Configuration, name, namespace string) (fresh bool, err error) {
-	historian := action.NewHistory(actionConfig)
-	historian.Max = 1
-	hist, hErr := historian.Run(name)
-	if errors.Is(hErr, driver.ErrReleaseNotFound) {
+	last, lErr := actionConfig.Releases.Last(name)
+	if errors.Is(lErr, driver.ErrReleaseNotFound) {
 		return true, nil
 	}
-	if hErr != nil {
-		return false, fmt.Errorf("failed to inspect existing release: %w", hErr)
+	if lErr != nil {
+		return false, fmt.Errorf("failed to inspect existing release: %w", lErr)
 	}
-	if len(hist) == 0 {
-		return true, nil
-	}
-	last := hist[0]
 	switch last.Info.Status {
 	case release.StatusPendingInstall, release.StatusPendingUpgrade, release.StatusPendingRollback, release.StatusUninstalling:
 		return false, &ReleasePendingError{
@@ -78,7 +76,7 @@ func preInstallCheck(actionConfig *action.Configuration, name, namespace string)
 	case release.StatusFailed, release.StatusSuperseded, release.StatusUninstalled, release.StatusUnknown:
 		return false, nil
 	default:
-		log.Printf("[helm] preInstallCheck: unrecognized release status %q for %s/%s, treating as recoverable", last.Info.Status, namespace, name)
+		log.Printf("[helm] preInstallCheck: unrecognized release status %q for %q/%q, treating as recoverable", last.Info.Status, namespace, name)
 		return false, nil
 	}
 }

--- a/internal/helm/install_preflight.go
+++ b/internal/helm/install_preflight.go
@@ -1,0 +1,190 @@
+package helm
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"regexp"
+	"time"
+
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/storage/driver"
+)
+
+// ReleasePendingError is returned when a prior install/upgrade left the release
+// in a pending-* state. Callers should surface this to the user with a "clean
+// up and retry" affordance rather than blindly retrying — Helm itself refuses
+// to operate on pending releases to avoid concurrent-write corruption.
+type ReleasePendingError struct {
+	Name      string
+	Namespace string
+	Status    string
+	Revision  int
+}
+
+func (e *ReleasePendingError) Error() string {
+	return fmt.Sprintf("release %q in namespace %q is stuck in %s (revision %d)",
+		e.Name, e.Namespace, e.Status, e.Revision)
+}
+
+// ReleaseExistsError is returned when an install is requested for a release
+// that already exists in a healthy deployed state. This is distinct from the
+// pending case — caller can offer "upgrade instead" rather than "uninstall".
+type ReleaseExistsError struct {
+	Name      string
+	Namespace string
+	Revision  int
+}
+
+func (e *ReleaseExistsError) Error() string {
+	return fmt.Sprintf("release %q in namespace %q already exists (revision %d)",
+		e.Name, e.Namespace, e.Revision)
+}
+
+// preInstallCheck inspects existing Helm storage for the release name and
+// returns:
+//   - (true, nil): no record, fresh install path
+//   - (false, nil): a prior failed/uninstalled record exists; upgrade --install
+//     can safely overwrite it
+//   - (_, *ReleasePendingError): a prior attempt is stuck in pending-* state
+//   - (_, *ReleaseExistsError): the release is currently deployed
+func preInstallCheck(actionConfig *action.Configuration, name, namespace string) (fresh bool, err error) {
+	historian := action.NewHistory(actionConfig)
+	historian.Max = 1
+	hist, hErr := historian.Run(name)
+	if errors.Is(hErr, driver.ErrReleaseNotFound) {
+		return true, nil
+	}
+	if hErr != nil {
+		return false, fmt.Errorf("failed to inspect existing release: %w", hErr)
+	}
+	if len(hist) == 0 {
+		return true, nil
+	}
+	last := hist[0]
+	switch last.Info.Status {
+	case release.StatusPendingInstall, release.StatusPendingUpgrade, release.StatusPendingRollback:
+		return false, &ReleasePendingError{
+			Name: name, Namespace: namespace,
+			Status: last.Info.Status.String(), Revision: last.Version,
+		}
+	case release.StatusDeployed:
+		return false, &ReleaseExistsError{
+			Name: name, Namespace: namespace, Revision: last.Version,
+		}
+	}
+	// failed, superseded, uninstalled, uninstalling, unknown — upgrade --install handles these.
+	return false, nil
+}
+
+// runInstallOrUpgrade performs an idempotent install. When `fresh` is true it
+// uses action.Install (the existing path). Otherwise it uses action.Upgrade
+// with Install=true, which is the canonical Helm "upgrade --install" semantic
+// and overwrites a prior failed/uninstalled record without tripping the
+// name-in-use guard.
+func runInstallOrUpgrade(actionConfig *action.Configuration, req *InstallRequest, ch *chart.Chart, fresh bool) (*release.Release, error) {
+	if fresh {
+		install := action.NewInstall(actionConfig)
+		install.ReleaseName = req.ReleaseName
+		install.Namespace = req.Namespace
+		install.CreateNamespace = req.CreateNamespace
+		install.Timeout = 120 * time.Second
+		install.Version = req.Version
+		return install.Run(ch, req.Values)
+	}
+	upgrade := action.NewUpgrade(actionConfig)
+	upgrade.Install = true
+	upgrade.Namespace = req.Namespace
+	upgrade.Timeout = 120 * time.Second
+	upgrade.MaxHistory = 10
+	upgrade.Version = req.Version
+	// action.Upgrade has no CreateNamespace; the recovery path is only reached
+	// when a prior release record exists, which means a previous attempt already
+	// got past namespace creation. If the namespace was deleted manually after
+	// that, the user must recreate it (Helm install would have done the same).
+	return upgrade.Run(req.ReleaseName, ch, req.Values)
+}
+
+// rbacPreflightRe matches Helm's wrapped pre-flight RBAC error. Helm formats
+// it as: `could not get information about the resource <Kind> "<name>" in
+// namespace "<ns>": <gvr> "<name>" is forbidden: User "<u>" cannot <verb>
+// resource "<resource>" in API group "<group>" at the cluster scope`
+// (or "in the namespace" for namespaced resources).
+var rbacPreflightRe = regexp.MustCompile(
+	`is forbidden: User "([^"]*)" cannot (\w+) resource "([^"]+)" in API group "([^"]*)"`,
+)
+
+// RBACPreflightDetail describes a parsed Helm pre-flight RBAC denial.
+type RBACPreflightDetail struct {
+	User     string
+	Verb     string
+	Resource string
+	Group    string
+}
+
+// classifyHelmRBACError returns parsed detail if the error came from a Helm
+// pre-flight existence check that was denied by Kubernetes RBAC.
+func classifyHelmRBACError(err error) (*RBACPreflightDetail, bool) {
+	if err == nil {
+		return nil, false
+	}
+	m := rbacPreflightRe.FindStringSubmatch(err.Error())
+	if m == nil {
+		return nil, false
+	}
+	return &RBACPreflightDetail{User: m[1], Verb: m[2], Resource: m[3], Group: m[4]}, true
+}
+
+// classifyInstallErrorCode returns a stable machine-readable code for typed
+// install failures. Empty string means "no special code; use generic 500".
+func classifyInstallErrorCode(err error) string {
+	var pending *ReleasePendingError
+	if errors.As(err, &pending) {
+		return "release_pending"
+	}
+	var exists *ReleaseExistsError
+	if errors.As(err, &exists) {
+		return "release_exists"
+	}
+	if _, ok := classifyHelmRBACError(err); ok {
+		return "rbac_preflight"
+	}
+	return ""
+}
+
+// writeInstallError maps a Helm install error onto an HTTP response. It
+// surfaces typed errors (pending release, RBAC pre-flight denial, generic
+// forbidden) with stable error_code values the SPA can branch on.
+func writeInstallError(w http.ResponseWriter, err error) {
+	var pending *ReleasePendingError
+	if errors.As(err, &pending) {
+		writeErrorCode(w, http.StatusConflict, "release_pending",
+			fmt.Sprintf("a previous install of %q in namespace %q ended in %s — uninstall and retry, or wait for it to finish",
+				pending.Name, pending.Namespace, pending.Status))
+		return
+	}
+	var exists *ReleaseExistsError
+	if errors.As(err, &exists) {
+		writeErrorCode(w, http.StatusConflict, "release_exists",
+			fmt.Sprintf("release %q already exists in namespace %q (revision %d) — use upgrade",
+				exists.Name, exists.Namespace, exists.Revision))
+		return
+	}
+	if rbac, ok := classifyHelmRBACError(err); ok {
+		group := rbac.Group
+		if group == "" {
+			group = "core"
+		}
+		writeErrorCode(w, http.StatusForbidden, "rbac_preflight",
+			fmt.Sprintf("Radar identity %q is missing %s on %s.%s — see the in-cluster RBAC docs to expand permissions",
+				rbac.User, rbac.Verb, rbac.Resource, group))
+		return
+	}
+	if IsForbiddenError(err) {
+		writeError(w, http.StatusForbidden, "insufficient permissions to install Helm release")
+		return
+	}
+	writeError(w, http.StatusInternalServerError, err.Error())
+}

--- a/internal/helm/install_preflight.go
+++ b/internal/helm/install_preflight.go
@@ -3,6 +3,7 @@ package helm
 import (
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"regexp"
 	"time"
@@ -65,7 +66,7 @@ func preInstallCheck(actionConfig *action.Configuration, name, namespace string)
 	}
 	last := hist[0]
 	switch last.Info.Status {
-	case release.StatusPendingInstall, release.StatusPendingUpgrade, release.StatusPendingRollback:
+	case release.StatusPendingInstall, release.StatusPendingUpgrade, release.StatusPendingRollback, release.StatusUninstalling:
 		return false, &ReleasePendingError{
 			Name: name, Namespace: namespace,
 			Status: last.Info.Status.String(), Revision: last.Version,
@@ -74,9 +75,12 @@ func preInstallCheck(actionConfig *action.Configuration, name, namespace string)
 		return false, &ReleaseExistsError{
 			Name: name, Namespace: namespace, Revision: last.Version,
 		}
+	case release.StatusFailed, release.StatusSuperseded, release.StatusUninstalled, release.StatusUnknown:
+		return false, nil
+	default:
+		log.Printf("[helm] preInstallCheck: unrecognized release status %q for %s/%s, treating as recoverable", last.Info.Status, namespace, name)
+		return false, nil
 	}
-	// failed, superseded, uninstalled, uninstalling, unknown — upgrade --install handles these.
-	return false, nil
 }
 
 // runInstallOrUpgrade performs an idempotent install. When `fresh` is true it

--- a/internal/helm/install_preflight.go
+++ b/internal/helm/install_preflight.go
@@ -44,72 +44,95 @@ func (e *ReleaseExistsError) Error() string {
 		e.Name, e.Namespace, e.Revision)
 }
 
+// installMode is what preInstallCheck tells the caller about how to dispatch
+// the install. Three modes because Helm's SDK splits recovery semantics by
+// prior release status: only Failed/Superseded recover via action.Upgrade
+// (which has the deployed-base fallback at upgrade.go:231-233), Uninstalled
+// requires action.Install with Replace=true (upgrade rejects it with
+// ErrNoDeployedReleases), and a fresh install uses action.Install with no
+// replace.
+type installMode int
+
+const (
+	installFresh   installMode = iota // no prior record
+	installReplace                    // prior record is Uninstalled
+	installUpgrade                    // prior record is Failed or Superseded
+)
+
 // preInstallCheck inspects existing Helm storage for the release name and
 // returns:
-//   - (true, nil): no record, fresh install path
-//   - (false, nil): a prior failed/uninstalled record exists; upgrade --install
-//     can safely overwrite it
-//   - (_, *ReleasePendingError): a prior attempt is stuck in pending-* state,
-//     uninstalling, or in an unrecognized status (fail-closed)
+//   - (installFresh, nil): no record
+//   - (installReplace, nil): a prior Uninstalled record (use Install.Replace)
+//   - (installUpgrade, nil): a prior Failed/Superseded record (use Upgrade)
+//   - (_, *ReleasePendingError): a prior attempt is stuck in pending-* /
+//     uninstalling / unrecognized status (fail-closed)
 //   - (_, *ReleaseExistsError): the release is currently deployed
 //
 // Uses Releases.Last because action.History.Run returns the storage driver's
 // raw Query output (unsorted, ignores Max), so its hist[0] is non-deterministic.
-func preInstallCheck(actionConfig *action.Configuration, name, namespace string) (fresh bool, err error) {
+func preInstallCheck(actionConfig *action.Configuration, name, namespace string) (installMode, error) {
 	last, lErr := actionConfig.Releases.Last(name)
 	if errors.Is(lErr, driver.ErrReleaseNotFound) {
-		return true, nil
+		return installFresh, nil
 	}
 	if lErr != nil {
-		return false, fmt.Errorf("failed to inspect existing release: %w", lErr)
+		return installFresh, fmt.Errorf("failed to inspect existing release: %w", lErr)
 	}
 	switch last.Info.Status {
 	case release.StatusPendingInstall, release.StatusPendingUpgrade, release.StatusPendingRollback, release.StatusUninstalling:
-		return false, &ReleasePendingError{
+		return installFresh, &ReleasePendingError{
 			Name: name, Namespace: namespace,
 			Status: last.Info.Status.String(), Revision: last.Version,
 		}
 	case release.StatusDeployed:
-		return false, &ReleaseExistsError{
+		return installFresh, &ReleaseExistsError{
 			Name: name, Namespace: namespace, Revision: last.Version,
 		}
-	case release.StatusFailed, release.StatusSuperseded, release.StatusUninstalled, release.StatusUnknown:
-		return false, nil
+	case release.StatusFailed, release.StatusSuperseded:
+		return installUpgrade, nil
+	case release.StatusUninstalled:
+		return installReplace, nil
 	default:
-		// Future helm versions may add new in-flight statuses. Fail-closed
-		// (treat as pending) so we never fire upgrade against a status
-		// helm itself would refuse, instead of silently writing.
+		// StatusUnknown or any future helm tier: fail-closed. Neither
+		// action.Upgrade nor Install.Replace accepts arbitrary statuses
+		// (install.go:549 only allows Uninstalled+Failed for Replace;
+		// upgrade.go:232 only allows Failed+Superseded for fallback), so
+		// silently routing here would yield a confusing helm error.
 		log.Printf("[helm] preInstallCheck: unrecognized release status %q for %q/%q, refusing to overwrite", last.Info.Status, namespace, name)
-		return false, &ReleasePendingError{
+		return installFresh, &ReleasePendingError{
 			Name: name, Namespace: namespace,
 			Status: last.Info.Status.String(), Revision: last.Version,
 		}
 	}
 }
 
-// runInstallOrUpgrade dispatches to action.Install for a fresh install and
-// action.Upgrade with Install=true ("upgrade --install") for the recovery
-// path over a failed/uninstalled record.
-func runInstallOrUpgrade(actionConfig *action.Configuration, req *InstallRequest, ch *chart.Chart, fresh bool) (*release.Release, error) {
-	if fresh {
-		install := action.NewInstall(actionConfig)
-		install.ReleaseName = req.ReleaseName
-		install.Namespace = req.Namespace
-		install.CreateNamespace = req.CreateNamespace
-		install.Timeout = 120 * time.Second
-		install.Version = req.Version
-		return install.Run(ch, req.Values)
+// runInstallOrUpgrade dispatches to the right Helm action for the install
+// mode. Failed/Superseded go through action.Upgrade (with its
+// deployed-base fallback); Uninstalled goes through action.Install with
+// Replace=true (helm SDK exposes no equivalent fallback on Upgrade — the
+// CLI's `helm upgrade --install` is implemented at the CLI layer, not in
+// the action; see upgrade.go:49-58).
+func runInstallOrUpgrade(actionConfig *action.Configuration, req *InstallRequest, ch *chart.Chart, mode installMode) (*release.Release, error) {
+	if mode == installUpgrade {
+		upgrade := action.NewUpgrade(actionConfig)
+		upgrade.Install = true
+		upgrade.Namespace = req.Namespace
+		upgrade.Timeout = 120 * time.Second
+		upgrade.MaxHistory = 10
+		upgrade.Version = req.Version
+		// action.Upgrade has no CreateNamespace; reaching this branch implies a
+		// prior release record exists, so the namespace was created earlier. If
+		// it has been deleted manually since, the user must recreate it.
+		return upgrade.Run(req.ReleaseName, ch, req.Values)
 	}
-	upgrade := action.NewUpgrade(actionConfig)
-	upgrade.Install = true
-	upgrade.Namespace = req.Namespace
-	upgrade.Timeout = 120 * time.Second
-	upgrade.MaxHistory = 10
-	upgrade.Version = req.Version
-	// action.Upgrade has no CreateNamespace; reaching this branch implies a
-	// prior release record exists, so the namespace was created earlier. If
-	// it has been deleted manually since, the user must recreate it.
-	return upgrade.Run(req.ReleaseName, ch, req.Values)
+	install := action.NewInstall(actionConfig)
+	install.ReleaseName = req.ReleaseName
+	install.Namespace = req.Namespace
+	install.CreateNamespace = req.CreateNamespace
+	install.Timeout = 120 * time.Second
+	install.Version = req.Version
+	install.Replace = mode == installReplace
+	return install.Run(ch, req.Values)
 }
 
 // rbacPreflightRe matches Helm's wrapped pre-flight RBAC error. Helm formats
@@ -210,6 +233,18 @@ func writeInstallError(w http.ResponseWriter, err error) {
 		return
 	}
 	writeError(w, cls.Status, cls.Message)
+}
+
+// recoveryMode returns a short human-readable label for the non-fresh modes,
+// used in operational logs.
+func recoveryMode(m installMode) string {
+	switch m {
+	case installReplace:
+		return "install --replace"
+	case installUpgrade:
+		return "upgrade --install"
+	}
+	return "fresh"
 }
 
 // installStreamErrorEvent builds the SSE error envelope from a Helm install

--- a/internal/helm/install_preflight.go
+++ b/internal/helm/install_preflight.go
@@ -49,12 +49,12 @@ func (e *ReleaseExistsError) Error() string {
 //   - (true, nil): no record, fresh install path
 //   - (false, nil): a prior failed/uninstalled record exists; upgrade --install
 //     can safely overwrite it
-//   - (_, *ReleasePendingError): a prior attempt is stuck in pending-* state
+//   - (_, *ReleasePendingError): a prior attempt is stuck in pending-* state,
+//     uninstalling, or in an unrecognized status (fail-closed)
 //   - (_, *ReleaseExistsError): the release is currently deployed
 //
-// Reads the latest revision via Releases.Last. action.History.Run returns the
-// storage driver's raw Query output without sorting and ignores Max, so
-// hist[0] would silently pick whatever ordering the driver happens to use.
+// Uses Releases.Last because action.History.Run returns the storage driver's
+// raw Query output (unsorted, ignores Max), so its hist[0] is non-deterministic.
 func preInstallCheck(actionConfig *action.Configuration, name, namespace string) (fresh bool, err error) {
 	last, lErr := actionConfig.Releases.Last(name)
 	if errors.Is(lErr, driver.ErrReleaseNotFound) {
@@ -76,16 +76,20 @@ func preInstallCheck(actionConfig *action.Configuration, name, namespace string)
 	case release.StatusFailed, release.StatusSuperseded, release.StatusUninstalled, release.StatusUnknown:
 		return false, nil
 	default:
-		log.Printf("[helm] preInstallCheck: unrecognized release status %q for %q/%q, treating as recoverable", last.Info.Status, namespace, name)
-		return false, nil
+		// Future helm versions may add new in-flight statuses. Fail-closed
+		// (treat as pending) so we never fire upgrade against a status
+		// helm itself would refuse, instead of silently writing.
+		log.Printf("[helm] preInstallCheck: unrecognized release status %q for %q/%q, refusing to overwrite", last.Info.Status, namespace, name)
+		return false, &ReleasePendingError{
+			Name: name, Namespace: namespace,
+			Status: last.Info.Status.String(), Revision: last.Version,
+		}
 	}
 }
 
-// runInstallOrUpgrade performs an idempotent install. When `fresh` is true it
-// uses action.Install (the existing path). Otherwise it uses action.Upgrade
-// with Install=true, which is the canonical Helm "upgrade --install" semantic
-// and overwrites a prior failed/uninstalled record without tripping the
-// name-in-use guard.
+// runInstallOrUpgrade dispatches to action.Install for a fresh install and
+// action.Upgrade with Install=true ("upgrade --install") for the recovery
+// path over a failed/uninstalled record.
 func runInstallOrUpgrade(actionConfig *action.Configuration, req *InstallRequest, ch *chart.Chart, fresh bool) (*release.Release, error) {
 	if fresh {
 		install := action.NewInstall(actionConfig)
@@ -102,10 +106,9 @@ func runInstallOrUpgrade(actionConfig *action.Configuration, req *InstallRequest
 	upgrade.Timeout = 120 * time.Second
 	upgrade.MaxHistory = 10
 	upgrade.Version = req.Version
-	// action.Upgrade has no CreateNamespace; the recovery path is only reached
-	// when a prior release record exists, which means a previous attempt already
-	// got past namespace creation. If the namespace was deleted manually after
-	// that, the user must recreate it (Helm install would have done the same).
+	// action.Upgrade has no CreateNamespace; reaching this branch implies a
+	// prior release record exists, so the namespace was created earlier. If
+	// it has been deleted manually since, the user must recreate it.
 	return upgrade.Run(req.ReleaseName, ch, req.Values)
 }
 
@@ -139,54 +142,88 @@ func classifyHelmRBACError(err error) (*RBACPreflightDetail, bool) {
 	return &RBACPreflightDetail{User: m[1], Verb: m[2], Resource: m[3], Group: m[4]}, true
 }
 
-// classifyInstallErrorCode returns a stable machine-readable code for typed
-// install failures. Empty string means "no special code; use generic 500".
-func classifyInstallErrorCode(err error) string {
-	var pending *ReleasePendingError
-	if errors.As(err, &pending) {
-		return "release_pending"
-	}
-	var exists *ReleaseExistsError
-	if errors.As(err, &exists) {
-		return "release_exists"
-	}
-	if _, ok := classifyHelmRBACError(err); ok {
-		return "rbac_preflight"
-	}
-	return ""
+// InstallErrorClass is the unified mapping of a Helm install error onto a
+// user-facing response — same shape used by the JSON HTTP path
+// (writeInstallError) and the SSE streaming path (handleInstallStream).
+// Code is empty for unclassified errors; callers fall back to a generic 500.
+type InstallErrorClass struct {
+	Status  int
+	Code    string
+	Message string
 }
 
-// writeInstallError maps a Helm install error onto an HTTP response. It
-// surfaces typed errors (pending release, RBAC pre-flight denial, generic
-// forbidden) with stable error_code values the SPA can branch on.
-func writeInstallError(w http.ResponseWriter, err error) {
+// classifyInstallError builds the response shape (status, error_code, message)
+// from a Helm install error. Single source of truth so streaming and
+// non-streaming endpoints agree on the user-visible message and status.
+func classifyInstallError(err error) InstallErrorClass {
+	if err == nil {
+		return InstallErrorClass{}
+	}
 	var pending *ReleasePendingError
 	if errors.As(err, &pending) {
-		writeErrorCode(w, http.StatusConflict, "release_pending",
-			fmt.Sprintf("a previous install of %q in namespace %q ended in %s — uninstall and retry, or wait for it to finish",
-				pending.Name, pending.Namespace, pending.Status))
-		return
+		return InstallErrorClass{
+			Status: http.StatusConflict,
+			Code:   "release_pending",
+			Message: fmt.Sprintf("a previous install of %q in namespace %q ended in %s — uninstall and retry, or wait for it to finish",
+				pending.Name, pending.Namespace, pending.Status),
+		}
 	}
 	var exists *ReleaseExistsError
 	if errors.As(err, &exists) {
-		writeErrorCode(w, http.StatusConflict, "release_exists",
-			fmt.Sprintf("release %q already exists in namespace %q (revision %d) — use upgrade",
-				exists.Name, exists.Namespace, exists.Revision))
-		return
+		return InstallErrorClass{
+			Status: http.StatusConflict,
+			Code:   "release_exists",
+			Message: fmt.Sprintf("release %q already exists in namespace %q (revision %d) — use upgrade",
+				exists.Name, exists.Namespace, exists.Revision),
+		}
 	}
 	if rbac, ok := classifyHelmRBACError(err); ok {
 		group := rbac.Group
 		if group == "" {
 			group = "core"
 		}
-		writeErrorCode(w, http.StatusForbidden, "rbac_preflight",
-			fmt.Sprintf("Radar identity %q is missing %s on %s.%s — see the in-cluster RBAC docs to expand permissions",
-				rbac.User, rbac.Verb, rbac.Resource, group))
-		return
+		return InstallErrorClass{
+			Status: http.StatusForbidden,
+			Code:   "rbac_preflight",
+			Message: fmt.Sprintf("Radar identity %q is missing %s on %s.%s — see the in-cluster RBAC docs to expand permissions",
+				rbac.User, rbac.Verb, rbac.Resource, group),
+		}
 	}
 	if IsForbiddenError(err) {
-		writeError(w, http.StatusForbidden, "insufficient permissions to install Helm release")
+		return InstallErrorClass{
+			Status:  http.StatusForbidden,
+			Message: "insufficient permissions to install Helm release",
+		}
+	}
+	return InstallErrorClass{
+		Status:  http.StatusInternalServerError,
+		Message: err.Error(),
+	}
+}
+
+// writeInstallError maps a Helm install error onto an HTTP response with a
+// stable error_code the SPA can branch on.
+func writeInstallError(w http.ResponseWriter, err error) {
+	cls := classifyInstallError(err)
+	if cls.Code != "" {
+		writeErrorCode(w, cls.Status, cls.Code, cls.Message)
 		return
 	}
-	writeError(w, http.StatusInternalServerError, err.Error())
+	writeError(w, cls.Status, cls.Message)
+}
+
+// installStreamErrorEvent builds the SSE error envelope from a Helm install
+// error, using the same classifier as writeInstallError so the streaming
+// install endpoint surfaces the same friendly messages and error codes the
+// JSON endpoint does.
+func installStreamErrorEvent(err error) map[string]any {
+	cls := classifyInstallError(err)
+	event := map[string]any{
+		"type":    "error",
+		"message": cls.Message,
+	}
+	if cls.Code != "" {
+		event["error_code"] = cls.Code
+	}
+	return event
 }

--- a/internal/helm/install_preflight_test.go
+++ b/internal/helm/install_preflight_test.go
@@ -112,6 +112,28 @@ func TestPreInstallCheck_FailedAllowsRecovery(t *testing.T) {
 	}
 }
 
+// TestPreInstallCheck_MultiRevisionUsesLatest guards against reading an older
+// revision when storage holds more than one. The recovery scenario this PR
+// targets — an install fails (v1) and the user retries — produces multi-
+// revision history; classifying off the wrong revision misroutes the request.
+func TestPreInstallCheck_MultiRevisionUsesLatest(t *testing.T) {
+	cfg := memoryActionConfig(t)
+	seedRelease(t, cfg, "caretta", release.StatusDeployed, 1)
+	seedRelease(t, cfg, "caretta", release.StatusFailed, 2)
+
+	fresh, err := preInstallCheck(cfg, "caretta", "default")
+	if err != nil {
+		t.Fatalf("preInstallCheck: %v", err)
+	}
+	if fresh {
+		t.Error("fresh=true — latest revision is v2/failed, expected fresh=false for upgrade --install recovery")
+	}
+	var exists *ReleaseExistsError
+	if errors.As(err, &exists) {
+		t.Errorf("got ReleaseExistsError — classifier read v1/deployed instead of v2/failed: %+v", exists)
+	}
+}
+
 func TestClassifyHelmRBACError(t *testing.T) {
 	// Real Helm pre-flight error string from caretta install in cloud-mode.
 	raw := errors.New(`install failed: Unable to continue with install: ` +

--- a/internal/helm/install_preflight_test.go
+++ b/internal/helm/install_preflight_test.go
@@ -1,0 +1,153 @@
+package helm
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chartutil"
+	kubefake "helm.sh/helm/v3/pkg/kube/fake"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/storage"
+	"helm.sh/helm/v3/pkg/storage/driver"
+	helmtime "helm.sh/helm/v3/pkg/time"
+)
+
+func memoryActionConfig(t *testing.T) *action.Configuration {
+	t.Helper()
+	mem := driver.NewMemory()
+	mem.SetNamespace("default")
+	return &action.Configuration{
+		Releases:     storage.Init(mem),
+		KubeClient:   &kubefake.PrintingKubeClient{},
+		Capabilities: chartutil.DefaultCapabilities,
+		Log:          func(string, ...interface{}) {},
+	}
+}
+
+func seedRelease(t *testing.T, cfg *action.Configuration, name string, status release.Status, version int) {
+	t.Helper()
+	rel := &release.Release{
+		Name:      name,
+		Namespace: "default",
+		Version:   version,
+		Info: &release.Info{
+			Status:        status,
+			FirstDeployed: helmtime.Now(),
+			LastDeployed:  helmtime.Now(),
+		},
+	}
+	if err := cfg.Releases.Create(rel); err != nil {
+		t.Fatalf("seed release: %v", err)
+	}
+}
+
+func TestPreInstallCheck_NoPriorRelease(t *testing.T) {
+	cfg := memoryActionConfig(t)
+	fresh, err := preInstallCheck(cfg, "caretta", "default")
+	if err != nil {
+		t.Fatalf("preInstallCheck: %v", err)
+	}
+	if !fresh {
+		t.Error("expected fresh=true when no record exists")
+	}
+}
+
+func TestPreInstallCheck_PendingInstallSurfacesTypedError(t *testing.T) {
+	cfg := memoryActionConfig(t)
+	seedRelease(t, cfg, "caretta", release.StatusPendingInstall, 1)
+
+	fresh, err := preInstallCheck(cfg, "caretta", "default")
+	if fresh {
+		t.Error("expected fresh=false")
+	}
+	var pending *ReleasePendingError
+	if !errors.As(err, &pending) {
+		t.Fatalf("expected *ReleasePendingError, got %T: %v", err, err)
+	}
+	if pending.Name != "caretta" || pending.Status != "pending-install" || pending.Revision != 1 {
+		t.Errorf("unexpected detail: %+v", pending)
+	}
+}
+
+func TestPreInstallCheck_DeployedSurfacesExistsError(t *testing.T) {
+	cfg := memoryActionConfig(t)
+	seedRelease(t, cfg, "caretta", release.StatusDeployed, 3)
+
+	_, err := preInstallCheck(cfg, "caretta", "default")
+	var exists *ReleaseExistsError
+	if !errors.As(err, &exists) {
+		t.Fatalf("expected *ReleaseExistsError, got %T: %v", err, err)
+	}
+	if exists.Revision != 3 {
+		t.Errorf("revision = %d, want 3", exists.Revision)
+	}
+}
+
+func TestPreInstallCheck_FailedAllowsRecovery(t *testing.T) {
+	cfg := memoryActionConfig(t)
+	seedRelease(t, cfg, "caretta", release.StatusFailed, 1)
+
+	fresh, err := preInstallCheck(cfg, "caretta", "default")
+	if err != nil {
+		t.Fatalf("preInstallCheck: %v", err)
+	}
+	if fresh {
+		t.Error("expected fresh=false (an entry exists), so caller uses upgrade --install")
+	}
+}
+
+func TestClassifyHelmRBACError(t *testing.T) {
+	// Real Helm pre-flight error string from caretta install in cloud-mode.
+	raw := errors.New(`install failed: Unable to continue with install: ` +
+		`could not get information about the resource ClusterRole "caretta-grafana-clusterrole" in namespace "": ` +
+		`clusterroles.rbac.authorization.k8s.io "caretta-grafana-clusterrole" is forbidden: ` +
+		`User "user_01KPX4JSPW3G41BBD1NVM5BP2A" cannot get resource "clusterroles" in API group "rbac.authorization.k8s.io" at the cluster scope`)
+
+	d, ok := classifyHelmRBACError(raw)
+	if !ok {
+		t.Fatal("expected classifyHelmRBACError to recognize the Helm pre-flight RBAC error")
+	}
+	if d.User != "user_01KPX4JSPW3G41BBD1NVM5BP2A" {
+		t.Errorf("user = %q", d.User)
+	}
+	if d.Verb != "get" {
+		t.Errorf("verb = %q, want get", d.Verb)
+	}
+	if d.Resource != "clusterroles" {
+		t.Errorf("resource = %q, want clusterroles", d.Resource)
+	}
+	if d.Group != "rbac.authorization.k8s.io" {
+		t.Errorf("group = %q, want rbac.authorization.k8s.io", d.Group)
+	}
+}
+
+func TestClassifyHelmRBACError_NotMatching(t *testing.T) {
+	cases := []error{
+		nil,
+		errors.New("install failed: timeout"),
+		errors.New("cannot re-use a name that is still in use"),
+		fmt.Errorf("some random %s error", "transient"),
+	}
+	for _, e := range cases {
+		if _, ok := classifyHelmRBACError(e); ok {
+			t.Errorf("classifyHelmRBACError(%v) should not match", e)
+		}
+	}
+}
+
+func TestClassifyInstallErrorCode(t *testing.T) {
+	if got := classifyInstallErrorCode(&ReleasePendingError{Name: "x", Namespace: "y", Status: "pending-install"}); got != "release_pending" {
+		t.Errorf("got %q, want release_pending", got)
+	}
+	if got := classifyInstallErrorCode(&ReleaseExistsError{Name: "x", Namespace: "y", Revision: 2}); got != "release_exists" {
+		t.Errorf("got %q, want release_exists", got)
+	}
+	if got := classifyInstallErrorCode(errors.New("install failed: ... is forbidden: User \"u\" cannot get resource \"clusterroles\" in API group \"rbac.authorization.k8s.io\"")); got != "rbac_preflight" {
+		t.Errorf("got %q, want rbac_preflight", got)
+	}
+	if got := classifyInstallErrorCode(errors.New("connection refused")); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}

--- a/internal/helm/install_preflight_test.go
+++ b/internal/helm/install_preflight_test.go
@@ -3,6 +3,7 @@ package helm
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"helm.sh/helm/v3/pkg/action"
@@ -112,10 +113,10 @@ func TestPreInstallCheck_FailedAllowsRecovery(t *testing.T) {
 	}
 }
 
-// TestPreInstallCheck_MultiRevisionUsesLatest guards against reading an older
-// revision when storage holds more than one. The recovery scenario this PR
-// targets — an install fails (v1) and the user retries — produces multi-
-// revision history; classifying off the wrong revision misroutes the request.
+// TestPreInstallCheck_MultiRevisionUsesLatest pins that classification reads
+// the latest revision, not an arbitrary one. Multi-revision history (e.g. v1
+// failed, v2 retry) must route off the most recent state — reading an older
+// revision misroutes the install (recoverable vs in-flight vs deployed).
 func TestPreInstallCheck_MultiRevisionUsesLatest(t *testing.T) {
 	cfg := memoryActionConfig(t)
 	seedRelease(t, cfg, "caretta", release.StatusDeployed, 1)
@@ -131,6 +132,24 @@ func TestPreInstallCheck_MultiRevisionUsesLatest(t *testing.T) {
 	var exists *ReleaseExistsError
 	if errors.As(err, &exists) {
 		t.Errorf("got ReleaseExistsError — classifier read v1/deployed instead of v2/failed: %+v", exists)
+	}
+}
+
+// TestPreInstallCheck_UnknownStatusFailsClosed pins fail-closed behavior: a
+// status not enumerated in the switch (e.g. a future helm version adds a new
+// in-flight tier) must surface as ReleasePendingError, never silently flow
+// into the recoverable upgrade --install branch.
+func TestPreInstallCheck_UnknownStatusFailsClosed(t *testing.T) {
+	cfg := memoryActionConfig(t)
+	seedRelease(t, cfg, "caretta", release.Status("pending-test"), 1)
+
+	_, err := preInstallCheck(cfg, "caretta", "default")
+	var pending *ReleasePendingError
+	if !errors.As(err, &pending) {
+		t.Fatalf("expected *ReleasePendingError for unknown status, got %T: %v", err, err)
+	}
+	if pending.Status != "pending-test" {
+		t.Errorf("status = %q, want pending-test", pending.Status)
 	}
 }
 
@@ -173,17 +192,61 @@ func TestClassifyHelmRBACError_NotMatching(t *testing.T) {
 	}
 }
 
-func TestClassifyInstallErrorCode(t *testing.T) {
-	if got := classifyInstallErrorCode(&ReleasePendingError{Name: "x", Namespace: "y", Status: "pending-install"}); got != "release_pending" {
-		t.Errorf("got %q, want release_pending", got)
+// TestClassifyInstallError pins the (status, code, message) mapping for every
+// branch the SPA depends on. Streaming and non-streaming endpoints both go
+// through this classifier, so a regression here breaks both UIs at once.
+func TestClassifyInstallError(t *testing.T) {
+	rbacErr := errors.New(`Unable to continue: clusterroles.rbac.authorization.k8s.io "x" is forbidden: ` +
+		`User "u" cannot get resource "clusterroles" in API group "rbac.authorization.k8s.io" at the cluster scope`)
+
+	cases := []struct {
+		name        string
+		err         error
+		wantStatus  int
+		wantCode    string
+		msgContains string
+	}{
+		{"pending", &ReleasePendingError{Name: "x", Namespace: "y", Status: "pending-install", Revision: 1}, 409, "release_pending", "uninstall and retry"},
+		{"exists", &ReleaseExistsError{Name: "x", Namespace: "y", Revision: 2}, 409, "release_exists", "use upgrade"},
+		{"rbac_preflight", rbacErr, 403, "rbac_preflight", "missing get on clusterroles.rbac.authorization.k8s.io"},
+		{"forbidden_generic", errors.New("user is forbidden"), 403, "", "insufficient permissions"},
+		{"unclassified", errors.New("connection refused"), 500, "", "connection refused"},
 	}
-	if got := classifyInstallErrorCode(&ReleaseExistsError{Name: "x", Namespace: "y", Revision: 2}); got != "release_exists" {
-		t.Errorf("got %q, want release_exists", got)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cls := classifyInstallError(tc.err)
+			if cls.Status != tc.wantStatus {
+				t.Errorf("status = %d, want %d", cls.Status, tc.wantStatus)
+			}
+			if cls.Code != tc.wantCode {
+				t.Errorf("code = %q, want %q", cls.Code, tc.wantCode)
+			}
+			if !strings.Contains(cls.Message, tc.msgContains) {
+				t.Errorf("message %q missing %q", cls.Message, tc.msgContains)
+			}
+		})
 	}
-	if got := classifyInstallErrorCode(errors.New("install failed: ... is forbidden: User \"u\" cannot get resource \"clusterroles\" in API group \"rbac.authorization.k8s.io\"")); got != "rbac_preflight" {
-		t.Errorf("got %q, want rbac_preflight", got)
+}
+
+// TestInstallStreamErrorEvent ensures the SSE envelope carries the same
+// friendly message and error_code as the JSON HTTP path. A typo in the
+// field name ("errorCode" vs "error_code") would silently break the SPA's
+// install-stream branching; this pins the wire format.
+func TestInstallStreamErrorEvent(t *testing.T) {
+	event := installStreamErrorEvent(&ReleasePendingError{Name: "x", Namespace: "y", Status: "pending-install", Revision: 1})
+	if event["type"] != "error" {
+		t.Errorf(`type = %v, want "error"`, event["type"])
 	}
-	if got := classifyInstallErrorCode(errors.New("connection refused")); got != "" {
-		t.Errorf("got %q, want empty", got)
+	if event["error_code"] != "release_pending" {
+		t.Errorf("error_code = %v, want release_pending", event["error_code"])
+	}
+	msg, _ := event["message"].(string)
+	if !strings.Contains(msg, "uninstall and retry") {
+		t.Errorf("message = %q, want friendly text including %q", msg, "uninstall and retry")
+	}
+
+	noCode := installStreamErrorEvent(errors.New("connection refused"))
+	if _, present := noCode["error_code"]; present {
+		t.Errorf("unclassified error should omit error_code, got %v", noCode["error_code"])
 	}
 }

--- a/internal/helm/install_preflight_test.go
+++ b/internal/helm/install_preflight_test.go
@@ -85,6 +85,20 @@ func TestPreInstallCheck_DeployedSurfacesExistsError(t *testing.T) {
 	}
 }
 
+func TestPreInstallCheck_UninstallingSurfacesPendingError(t *testing.T) {
+	cfg := memoryActionConfig(t)
+	seedRelease(t, cfg, "caretta", release.StatusUninstalling, 2)
+
+	_, err := preInstallCheck(cfg, "caretta", "default")
+	var pending *ReleasePendingError
+	if !errors.As(err, &pending) {
+		t.Fatalf("expected *ReleasePendingError for an in-flight uninstall, got %T: %v", err, err)
+	}
+	if pending.Status != "uninstalling" {
+		t.Errorf("status = %q, want uninstalling", pending.Status)
+	}
+}
+
 func TestPreInstallCheck_FailedAllowsRecovery(t *testing.T) {
 	cfg := memoryActionConfig(t)
 	seedRelease(t, cfg, "caretta", release.StatusFailed, 1)

--- a/internal/helm/install_preflight_test.go
+++ b/internal/helm/install_preflight_test.go
@@ -46,12 +46,12 @@ func seedRelease(t *testing.T, cfg *action.Configuration, name string, status re
 
 func TestPreInstallCheck_NoPriorRelease(t *testing.T) {
 	cfg := memoryActionConfig(t)
-	fresh, err := preInstallCheck(cfg, "caretta", "default")
+	mode, err := preInstallCheck(cfg, "caretta", "default")
 	if err != nil {
 		t.Fatalf("preInstallCheck: %v", err)
 	}
-	if !fresh {
-		t.Error("expected fresh=true when no record exists")
+	if mode != installFresh {
+		t.Errorf("mode = %v, want installFresh", mode)
 	}
 }
 
@@ -59,10 +59,7 @@ func TestPreInstallCheck_PendingInstallSurfacesTypedError(t *testing.T) {
 	cfg := memoryActionConfig(t)
 	seedRelease(t, cfg, "caretta", release.StatusPendingInstall, 1)
 
-	fresh, err := preInstallCheck(cfg, "caretta", "default")
-	if fresh {
-		t.Error("expected fresh=false")
-	}
+	_, err := preInstallCheck(cfg, "caretta", "default")
 	var pending *ReleasePendingError
 	if !errors.As(err, &pending) {
 		t.Fatalf("expected *ReleasePendingError, got %T: %v", err, err)
@@ -100,16 +97,34 @@ func TestPreInstallCheck_UninstallingSurfacesPendingError(t *testing.T) {
 	}
 }
 
-func TestPreInstallCheck_FailedAllowsRecovery(t *testing.T) {
+func TestPreInstallCheck_FailedRoutesToUpgrade(t *testing.T) {
 	cfg := memoryActionConfig(t)
 	seedRelease(t, cfg, "caretta", release.StatusFailed, 1)
 
-	fresh, err := preInstallCheck(cfg, "caretta", "default")
+	mode, err := preInstallCheck(cfg, "caretta", "default")
 	if err != nil {
 		t.Fatalf("preInstallCheck: %v", err)
 	}
-	if fresh {
-		t.Error("expected fresh=false (an entry exists), so caller uses upgrade --install")
+	if mode != installUpgrade {
+		t.Errorf("mode = %v, want installUpgrade (action.Upgrade fallback handles Failed)", mode)
+	}
+}
+
+// TestPreInstallCheck_UninstalledRoutesToReplace pins routing for the
+// helm-uninstall-with-keep-history scenario. action.Upgrade rejects
+// Uninstalled with ErrNoDeployedReleases (upgrade.go:231-233 only falls back
+// for Failed/Superseded), so the recovery must use action.Install with
+// Replace=true (install.go:549 accepts Uninstalled+Failed for Replace).
+func TestPreInstallCheck_UninstalledRoutesToReplace(t *testing.T) {
+	cfg := memoryActionConfig(t)
+	seedRelease(t, cfg, "caretta", release.StatusUninstalled, 1)
+
+	mode, err := preInstallCheck(cfg, "caretta", "default")
+	if err != nil {
+		t.Fatalf("preInstallCheck: %v", err)
+	}
+	if mode != installReplace {
+		t.Errorf("mode = %v, want installReplace — Upgrade rejects Uninstalled, only Install.Replace handles it", mode)
 	}
 }
 
@@ -122,12 +137,12 @@ func TestPreInstallCheck_MultiRevisionUsesLatest(t *testing.T) {
 	seedRelease(t, cfg, "caretta", release.StatusDeployed, 1)
 	seedRelease(t, cfg, "caretta", release.StatusFailed, 2)
 
-	fresh, err := preInstallCheck(cfg, "caretta", "default")
+	mode, err := preInstallCheck(cfg, "caretta", "default")
 	if err != nil {
 		t.Fatalf("preInstallCheck: %v", err)
 	}
-	if fresh {
-		t.Error("fresh=true — latest revision is v2/failed, expected fresh=false for upgrade --install recovery")
+	if mode != installUpgrade {
+		t.Errorf("mode = %v — latest revision is v2/failed, expected installUpgrade", mode)
 	}
 	var exists *ReleaseExistsError
 	if errors.As(err, &exists) {

--- a/pkg/k8score/workload.go
+++ b/pkg/k8score/workload.go
@@ -72,7 +72,10 @@ func NewWorkloadManager(dynClient dynamic.Interface, discovery *ResourceDiscover
 	return &WorkloadManager{dynClient: dynClient, discovery: discovery}
 }
 
-// UpdateResource updates a Kubernetes resource from YAML.
+// UpdateResource updates a Kubernetes resource from YAML using server-side apply.
+// SSA avoids the resourceVersion round-trip that PUT requires and matches
+// kubectl apply --server-side / Lens semantics. Force=true takes ownership of
+// fields the user is editing even if another field manager last wrote them.
 func (m *WorkloadManager) UpdateResource(ctx context.Context, opts UpdateResourceOptions) (*unstructured.Unstructured, error) {
 	if m.discovery == nil {
 		return nil, fmt.Errorf("resource discovery not initialized")
@@ -98,18 +101,44 @@ func (m *WorkloadManager) UpdateResource(ctx context.Context, opts UpdateResourc
 		return nil, fmt.Errorf("resource namespace mismatch: expected %s, got %s", opts.Namespace, obj.GetNamespace())
 	}
 
-	var result *unstructured.Unstructured
-	var err error
-	if opts.Namespace != "" {
-		result, err = m.dynClient.Resource(gvr).Namespace(opts.Namespace).Update(ctx, obj, metav1.UpdateOptions{})
-	} else {
-		result, err = m.dynClient.Resource(gvr).Update(ctx, obj, metav1.UpdateOptions{})
+	stripServerManagedFields(obj)
+
+	body, err := json.Marshal(obj.Object)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal resource: %w", err)
 	}
+
+	var ri dynamic.ResourceInterface
+	if opts.Namespace != "" {
+		ri = m.dynClient.Resource(gvr).Namespace(opts.Namespace)
+	} else {
+		ri = m.dynClient.Resource(gvr)
+	}
+	result, err := ri.Patch(ctx, opts.Name, types.ApplyPatchType, body, metav1.PatchOptions{
+		FieldManager: "radar",
+		Force:        boolPtr(true),
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to update resource: %w", err)
 	}
-
 	return result, nil
+}
+
+// stripServerManagedFields removes metadata fields the apiserver owns. SSA
+// rejects ownership claims on these, and editor round-trips often round-trip
+// them back unchanged.
+func stripServerManagedFields(obj *unstructured.Unstructured) {
+	for _, f := range [][]string{
+		{"metadata", "resourceVersion"},
+		{"metadata", "managedFields"},
+		{"metadata", "uid"},
+		{"metadata", "generation"},
+		{"metadata", "creationTimestamp"},
+		{"metadata", "selfLink"},
+		{"status"},
+	} {
+		unstructured.RemoveNestedField(obj.Object, f...)
+	}
 }
 
 // ApplyResource creates or updates a Kubernetes resource from YAML.

--- a/pkg/k8score/workload.go
+++ b/pkg/k8score/workload.go
@@ -126,7 +126,9 @@ func (m *WorkloadManager) UpdateResource(ctx context.Context, opts UpdateResourc
 
 // stripServerManagedFields removes metadata fields the apiserver owns. SSA
 // rejects ownership claims on these, and editor round-trips often round-trip
-// them back unchanged.
+// them back unchanged. status is intentionally NOT stripped: for resources
+// with a status subresource the apiserver ignores it on /apply anyway, and
+// for CRDs without a status subresource the user's edit IS the way to set it.
 func stripServerManagedFields(obj *unstructured.Unstructured) {
 	for _, f := range [][]string{
 		{"metadata", "resourceVersion"},
@@ -135,7 +137,6 @@ func stripServerManagedFields(obj *unstructured.Unstructured) {
 		{"metadata", "generation"},
 		{"metadata", "creationTimestamp"},
 		{"metadata", "selfLink"},
-		{"status"},
 	} {
 		unstructured.RemoveNestedField(obj.Object, f...)
 	}

--- a/pkg/k8score/workload_update_test.go
+++ b/pkg/k8score/workload_update_test.go
@@ -51,9 +51,10 @@ func stubDiscovery(t *testing.T, kind string, gvr schema.GroupVersionResource) *
 	return rd
 }
 
-// TestUpdateResource_UsesServerSideApply locks in the fix for the resourceVersion bug.
-// Lens-style edits don't carry a resourceVersion; UpdateResource must PATCH via SSA
-// rather than PUT (which requires resourceVersion).
+// TestUpdateResource_UsesServerSideApply pins the SSA wire shape: PATCH with
+// ApplyPatchType, FieldManager=radar, Force=true, and server-managed metadata
+// stripped from the body. Editor flows submit YAML without a resourceVersion,
+// which PUT rejects — SSA is the contract.
 func TestUpdateResource_UsesServerSideApply(t *testing.T) {
 	dyn, gvr := newFakeDynamicWithClusterPolicy(t)
 	disc := stubDiscovery(t, "ClusterPolicy", gvr)

--- a/pkg/k8score/workload_update_test.go
+++ b/pkg/k8score/workload_update_test.go
@@ -1,0 +1,116 @@
+package k8score
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+const clusterPolicyYAML = `
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-image-registries
+  resourceVersion: "12345"
+  uid: 5e8a1b2c-3d4f-5a6b-7c8d-9e0f1a2b3c4d
+  managedFields:
+  - manager: kyverno
+    operation: Update
+spec:
+  validationFailureAction: Audit
+status:
+  ready: true
+`
+
+func newFakeDynamicWithClusterPolicy(t *testing.T) (*dynamicfake.FakeDynamicClient, schema.GroupVersionResource) {
+	t.Helper()
+	gvr := schema.GroupVersionResource{Group: "kyverno.io", Version: "v1", Resource: "clusterpolicies"}
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{gvr: "ClusterPolicyList"}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds), gvr
+}
+
+// stubDiscovery installs a single Kind→GVR mapping so UpdateResource skips the
+// real discovery client. ResourceDiscovery's exported API doesn't allow direct
+// seeding, but the unexported maps are package-internal — fine for tests.
+func stubDiscovery(t *testing.T, kind string, gvr schema.GroupVersionResource) *ResourceDiscovery {
+	t.Helper()
+	rd := &ResourceDiscovery{
+		resourceMap: map[string]APIResource{
+			strings.ToLower(kind): {Kind: kind, Name: gvr.Resource, Group: gvr.Group, Version: gvr.Version, Namespaced: false},
+		},
+		gvrMap: map[string]schema.GroupVersionResource{strings.ToLower(kind): gvr},
+	}
+	return rd
+}
+
+// TestUpdateResource_UsesServerSideApply locks in the fix for the resourceVersion bug.
+// Lens-style edits don't carry a resourceVersion; UpdateResource must PATCH via SSA
+// rather than PUT (which requires resourceVersion).
+func TestUpdateResource_UsesServerSideApply(t *testing.T) {
+	dyn, gvr := newFakeDynamicWithClusterPolicy(t)
+	disc := stubDiscovery(t, "ClusterPolicy", gvr)
+	mgr := NewWorkloadManager(dyn, disc)
+
+	var captured clienttesting.PatchAction
+	dyn.PrependReactor("patch", "clusterpolicies", func(a clienttesting.Action) (bool, runtime.Object, error) {
+		captured = a.(clienttesting.PatchAction)
+		// Return a minimal object so the call succeeds.
+		return true, nil, nil
+	})
+
+	_, err := mgr.UpdateResource(context.Background(), UpdateResourceOptions{
+		Kind: "ClusterPolicy",
+		Name: "restrict-image-registries",
+		YAML: clusterPolicyYAML,
+	})
+	if err != nil {
+		t.Fatalf("UpdateResource failed: %v", err)
+	}
+
+	if captured == nil {
+		t.Fatal("expected a PATCH action; got none")
+	}
+	if got := captured.GetPatchType(); got != types.ApplyPatchType {
+		t.Errorf("patch type = %v, want %v (server-side apply)", got, types.ApplyPatchType)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(captured.GetPatch(), &body); err != nil {
+		t.Fatalf("patch body is not JSON: %v", err)
+	}
+	meta, _ := body["metadata"].(map[string]any)
+	for _, banned := range []string{"resourceVersion", "uid", "managedFields", "generation", "creationTimestamp", "selfLink"} {
+		if _, present := meta[banned]; present {
+			t.Errorf("patch body still contains metadata.%s; SSA expects these stripped", banned)
+		}
+	}
+	if _, present := body["status"]; present {
+		t.Error("patch body still contains status; SSA edits should not declare ownership of status")
+	}
+}
+
+// TestUpdateResource_RejectsMismatchedName guards the existing safety check
+// (caller's URL params must match the YAML body).
+func TestUpdateResource_RejectsMismatchedName(t *testing.T) {
+	dyn, gvr := newFakeDynamicWithClusterPolicy(t)
+	disc := stubDiscovery(t, "ClusterPolicy", gvr)
+	mgr := NewWorkloadManager(dyn, disc)
+
+	_, err := mgr.UpdateResource(context.Background(), UpdateResourceOptions{
+		Kind: "ClusterPolicy",
+		Name: "different-name",
+		YAML: clusterPolicyYAML,
+	})
+	if err == nil || !strings.Contains(err.Error(), "name mismatch") {
+		t.Fatalf("expected name mismatch error, got: %v", err)
+	}
+}
+

--- a/pkg/k8score/workload_update_test.go
+++ b/pkg/k8score/workload_update_test.go
@@ -82,6 +82,17 @@ func TestUpdateResource_UsesServerSideApply(t *testing.T) {
 		t.Errorf("patch type = %v, want %v (server-side apply)", got, types.ApplyPatchType)
 	}
 
+	impl, ok := captured.(clienttesting.PatchActionImpl)
+	if !ok {
+		t.Fatalf("captured action is %T, want clienttesting.PatchActionImpl", captured)
+	}
+	if impl.PatchOptions.FieldManager != "radar" {
+		t.Errorf("FieldManager = %q, want %q", impl.PatchOptions.FieldManager, "radar")
+	}
+	if impl.PatchOptions.Force == nil || !*impl.PatchOptions.Force {
+		t.Errorf("Force = %v, want *true", impl.PatchOptions.Force)
+	}
+
 	var body map[string]any
 	if err := json.Unmarshal(captured.GetPatch(), &body); err != nil {
 		t.Fatalf("patch body is not JSON: %v", err)

--- a/pkg/k8score/workload_update_test.go
+++ b/pkg/k8score/workload_update_test.go
@@ -104,8 +104,11 @@ func TestUpdateResource_UsesServerSideApply(t *testing.T) {
 			t.Errorf("patch body still contains metadata.%s; SSA expects these stripped", banned)
 		}
 	}
-	if _, present := body["status"]; present {
-		t.Error("patch body still contains status; SSA edits should not declare ownership of status")
+	// status must NOT be stripped: CRDs without a status subresource treat it
+	// as a user-writable field, and stripping silently discards user edits.
+	// For subresourced kinds, the apiserver ignores status on /apply anyway.
+	if _, present := body["status"]; !present {
+		t.Error("status was stripped from the patch body; CRDs without status subresource need it preserved")
 	}
 }
 

--- a/pkg/k8score/workload_update_test.go
+++ b/pkg/k8score/workload_update_test.go
@@ -128,4 +128,3 @@ func TestUpdateResource_RejectsMismatchedName(t *testing.T) {
 		t.Fatalf("expected name mismatch error, got: %v", err)
 	}
 }
-

--- a/scripts/test-chart.sh
+++ b/scripts/test-chart.sh
@@ -132,6 +132,22 @@ assert_not_contains 'name: radar-cloud-owner-helm$'  "cloud-helm bindings requir
 assert_not_contains 'name: radar-cloud-member-helm$' "cloud-helm bindings require auth.mode != none"
 echo
 
+render "defaults — no RBAC reads (viewRBAC=false)"
+# The base radar ClusterRole should NOT include rbac.authorization.k8s.io reads
+# at default settings. This is the single test that pins the secure default.
+HELM_BASE=$(echo "$OUT" | awk '/^kind: ClusterRole$/,/^---$/{ if ($0 ~ /^---$/) exit; print }' | awk '/^  name: radar$/,EOF')
+if echo "$OUT" | awk '/  name: radar$/,/^---$/' | grep -Eq 'apiGroups: \["rbac.authorization.k8s.io"\]'; then
+  fail "default ClusterRole still grants rbac.authorization.k8s.io reads — viewRBAC should gate this"
+else
+  pass "no rbac.authorization.k8s.io reads in default ClusterRole"
+fi
+echo
+
+render "rbac.viewRBAC=true — RBAC reads granted" --set rbac.viewRBAC=true
+assert_contains 'apiGroups: \["rbac.authorization.k8s.io"\]' "RBAC reads granted when viewRBAC=true"
+assert_contains 'clusterrolebindings'                        "clusterrolebindings present"
+echo
+
 render "split content — radar-helm has CRDs but NOT clusterroles" \
   --set rbac.helm=true --set auth.mode=proxy
 # Pull the radar-helm ClusterRole specifically and check its contents

--- a/scripts/test-chart.sh
+++ b/scripts/test-chart.sh
@@ -90,6 +90,40 @@ assert_not_contains '^kind: ClusterRole$'           "no ClusterRole when rbac.cr
 assert_contains 'MY_POD_NAMESPACE'                  "env vars injected — feature is fully wired"
 echo
 
+render "defaults — no helm-write footprint"
+assert_not_contains 'name: radar-helm$'             "no helm add-on ClusterRole"
+assert_not_contains 'name: radar-cloud-owner-helm$' "no cloud helm bindings"
+assert_not_contains 'name: radar-cloud-member-helm$' "no cloud helm bindings"
+echo
+
+render "rbac.helm=true alone — gated off without auth or cloud" --set rbac.helm=true
+assert_not_contains 'name: radar-helm$'             "no helm add-on ClusterRole without auth/cloud"
+echo
+
+render "rbac.helm=true + auth.mode=proxy — helm CR emitted, no cloud bindings" \
+  --set rbac.helm=true --set auth.mode=proxy
+assert_contains 'name: radar-helm$'                 "helm add-on ClusterRole emitted"
+assert_not_contains 'name: radar-cloud-owner-helm$' "no cloud-owner-helm binding without cloud"
+assert_not_contains 'name: radar-cloud-member-helm$' "no cloud-member-helm binding without cloud"
+echo
+
+render "rbac.helm=true + cloud.enabled=true + auth.mode=proxy — helm CR + cloud bindings" \
+  --set rbac.helm=true --set auth.mode=proxy --set cloud.enabled=true \
+  --set cloud.url=wss://x --set cloud.token=t --set cloud.clusterName=c
+assert_contains 'name: radar-helm$'                 "helm add-on ClusterRole emitted"
+assert_contains 'name: radar-cloud-owner-helm$'     "cloud-owner-helm binding emitted"
+assert_contains 'name: radar-cloud-member-helm$'    "cloud-member-helm binding emitted"
+assert_not_contains 'name: radar-cloud-viewer-helm' "no helm binding for viewer tier"
+echo
+
+render "rbac.helm=true + cloud.enabled=true + auth.mode=none — no cloud-helm bindings" \
+  --set rbac.helm=true --set cloud.enabled=true \
+  --set cloud.url=wss://x --set cloud.token=t --set cloud.clusterName=c
+assert_contains 'name: radar-helm$'                 "helm add-on ClusterRole still emitted (cloud.enabled satisfies the OR-clause)"
+assert_not_contains 'name: radar-cloud-owner-helm$' "cloud-helm bindings require auth.mode != none"
+assert_not_contains 'name: radar-cloud-member-helm$' "cloud-helm bindings require auth.mode != none"
+echo
+
 if [[ $FAIL -eq 0 ]]; then
   echo "All chart template tests passed."
   exit 0

--- a/scripts/test-chart.sh
+++ b/scripts/test-chart.sh
@@ -123,6 +123,25 @@ assert_not_contains 'name: radar-cloud-member-helm-admin' "member is NEVER bound
 assert_not_contains 'name: radar-cloud-viewer-helm'       "no helm binding for viewer tier"
 echo
 
+render "cloud.defaultRbac.owner=false — owner bindings absent, member-helm still emits, no admin binding" \
+  --set rbac.helm=true --set auth.mode=proxy --set cloud.enabled=true \
+  --set cloud.url=wss://x --set cloud.token=t --set cloud.clusterName=c \
+  --set cloud.defaultRbac.owner=false
+assert_not_contains 'name: radar-cloud-owner-helm$'       "no owner-helm binding"
+assert_not_contains 'name: radar-cloud-owner-helm-admin$' "no owner-helm-admin binding"
+assert_contains 'name: radar-cloud-member-helm$'          "member-helm binding still emits"
+assert_not_contains 'name: radar-cloud-member-helm-admin' "member is NEVER bound to admin even when owner is disabled"
+echo
+
+render "cloud.defaultRbac.member=false — member binding absent, owner gets both" \
+  --set rbac.helm=true --set auth.mode=proxy --set cloud.enabled=true \
+  --set cloud.url=wss://x --set cloud.token=t --set cloud.clusterName=c \
+  --set cloud.defaultRbac.member=false
+assert_contains 'name: radar-cloud-owner-helm$'           "owner-helm binding emits"
+assert_contains 'name: radar-cloud-owner-helm-admin$'     "owner-helm-admin binding emits"
+assert_not_contains 'name: radar-cloud-member-helm$'      "no member-helm binding when member disabled"
+echo
+
 render "rbac.helm=true + cloud.enabled=true + auth.mode=none — no cloud-helm bindings" \
   --set rbac.helm=true --set cloud.enabled=true \
   --set cloud.url=wss://x --set cloud.token=t --set cloud.clusterName=c

--- a/scripts/test-chart.sh
+++ b/scripts/test-chart.sh
@@ -91,37 +91,60 @@ assert_contains 'MY_POD_NAMESPACE'                  "env vars injected — featu
 echo
 
 render "defaults — no helm-write footprint"
-assert_not_contains 'name: radar-helm$'             "no helm add-on ClusterRole"
-assert_not_contains 'name: radar-cloud-owner-helm$' "no cloud helm bindings"
-assert_not_contains 'name: radar-cloud-member-helm$' "no cloud helm bindings"
+assert_not_contains 'name: radar-helm$'                  "no helm add-on ClusterRole"
+assert_not_contains 'name: radar-helm-admin$'            "no helm-admin ClusterRole"
+assert_not_contains 'name: radar-cloud-owner-helm$'      "no cloud helm bindings"
+assert_not_contains 'name: radar-cloud-member-helm$'     "no cloud helm bindings"
+assert_not_contains 'name: radar-cloud-owner-helm-admin' "no cloud helm-admin bindings"
 echo
 
 render "rbac.helm=true alone — gated off without auth or cloud" --set rbac.helm=true
-assert_not_contains 'name: radar-helm$'             "no helm add-on ClusterRole without auth/cloud"
+assert_not_contains 'name: radar-helm$'                  "no helm add-on ClusterRole without auth/cloud"
+assert_not_contains 'name: radar-helm-admin$'            "no helm-admin ClusterRole without auth/cloud"
 echo
 
-render "rbac.helm=true + auth.mode=proxy — helm CR emitted, no cloud bindings" \
+render "rbac.helm=true + auth.mode=proxy — both CRs emitted, no cloud bindings" \
   --set rbac.helm=true --set auth.mode=proxy
-assert_contains 'name: radar-helm$'                 "helm add-on ClusterRole emitted"
-assert_not_contains 'name: radar-cloud-owner-helm$' "no cloud-owner-helm binding without cloud"
+assert_contains 'name: radar-helm$'                  "helm add-on ClusterRole emitted"
+assert_contains 'name: radar-helm-admin$'            "helm-admin ClusterRole emitted"
+assert_not_contains 'name: radar-cloud-owner-helm$'  "no cloud-owner-helm binding without cloud"
 assert_not_contains 'name: radar-cloud-member-helm$' "no cloud-member-helm binding without cloud"
 echo
 
-render "rbac.helm=true + cloud.enabled=true + auth.mode=proxy — helm CR + cloud bindings" \
+render "rbac.helm=true + cloud.enabled=true + auth.mode=proxy — split bindings (member excluded from admin)" \
   --set rbac.helm=true --set auth.mode=proxy --set cloud.enabled=true \
   --set cloud.url=wss://x --set cloud.token=t --set cloud.clusterName=c
-assert_contains 'name: radar-helm$'                 "helm add-on ClusterRole emitted"
-assert_contains 'name: radar-cloud-owner-helm$'     "cloud-owner-helm binding emitted"
-assert_contains 'name: radar-cloud-member-helm$'    "cloud-member-helm binding emitted"
-assert_not_contains 'name: radar-cloud-viewer-helm' "no helm binding for viewer tier"
+assert_contains 'name: radar-helm$'                       "helm add-on ClusterRole emitted"
+assert_contains 'name: radar-helm-admin$'                 "helm-admin ClusterRole emitted"
+assert_contains 'name: radar-cloud-owner-helm$'           "cloud-owner-helm binding emitted"
+assert_contains 'name: radar-cloud-member-helm$'          "cloud-member-helm binding emitted"
+assert_contains 'name: radar-cloud-owner-helm-admin$'     "cloud-owner-helm-admin binding emitted"
+assert_not_contains 'name: radar-cloud-member-helm-admin' "member is NEVER bound to helm-admin (RBAC self-promotion)"
+assert_not_contains 'name: radar-cloud-viewer-helm'       "no helm binding for viewer tier"
 echo
 
 render "rbac.helm=true + cloud.enabled=true + auth.mode=none — no cloud-helm bindings" \
   --set rbac.helm=true --set cloud.enabled=true \
   --set cloud.url=wss://x --set cloud.token=t --set cloud.clusterName=c
-assert_contains 'name: radar-helm$'                 "helm add-on ClusterRole still emitted (cloud.enabled satisfies the OR-clause)"
-assert_not_contains 'name: radar-cloud-owner-helm$' "cloud-helm bindings require auth.mode != none"
+assert_contains 'name: radar-helm$'                  "helm add-on ClusterRole still emitted (cloud.enabled satisfies the OR-clause)"
+assert_contains 'name: radar-helm-admin$'            "helm-admin ClusterRole still emitted (same gate)"
+assert_not_contains 'name: radar-cloud-owner-helm$'  "cloud-helm bindings require auth.mode != none"
 assert_not_contains 'name: radar-cloud-member-helm$' "cloud-helm bindings require auth.mode != none"
+echo
+
+render "split content — radar-helm has CRDs but NOT clusterroles" \
+  --set rbac.helm=true --set auth.mode=proxy
+# Pull the radar-helm ClusterRole specifically and check its contents
+HELM_RULES=$(echo "$OUT" | awk '/^kind: ClusterRole$/,/^---$/' | awk '/^metadata:$/,/^rules:$/{found=1} /  name: radar-helm$/{ok=1} END{print ok}')
+# Simpler approach: just confirm the cluster-admin verbs are NOT in radar-helm's rules
+# by checking the file was split (radar-helm-admin exists separately)
+assert_contains 'name: radar-helm-admin$'                 "helm-admin role exists as separate resource"
+# Member-safe role grants CRDs (operator charts)
+assert_contains 'customresourcedefinitions'               "CRDs writable in member-safe role"
+# Cluster-admin-equivalent verbs are present somewhere in the manifest (in radar-helm-admin)
+assert_contains 'clusterrolebindings'                     "RBAC writes present (in admin role)"
+assert_contains 'validatingwebhookconfigurations'         "webhook writes present (in admin role)"
+assert_contains 'apiservices'                             "apiservices writes present (in admin role)"
 echo
 
 if [[ $FAIL -eq 0 ]]; then


### PR DESCRIPTION
## Summary

Fixes [SKY-843](https://linear.app/skyhook-io/issue/SKY-843/install-bug-from-client) — a desktop user hitting Helm install errors against their own cluster — and bundles related in-cluster security hardening that surfaced while debugging the same code paths.

**Two scopes in this PR:**

1. **Bug fixes (helps the SKY-843 desktop user directly)** — Kubernetes resource updates and Helm install correctness. These run in the desktop binary against the user's own cluster.
2. **In-cluster security hardening (helps cloud-mode / auth-enabled deployments)** — Helm chart RBAC model. Does not affect desktop users; relevant when Radar is deployed *into* a cluster with cloud-mode or `auth.mode=proxy`.

## Bug fixes (desktop-relevant)

- **Bug 1 — ClusterPolicy update fails with `metadata.resourceVersion: must be specified for an update`.** The PUT path stripped the live `resourceVersion`. Switched to server-side apply (PATCH `application/apply-patch+yaml`, `fieldManager=radar`, `force=true`) — same contract as `kubectl apply --server-side`.
- **Bug 2 — `cannot re-use a name that is still in use` when installing caretta.** Plain `helm install` refused any release whose name had any record in storage, including orphaned `pending-install`. Now: `preInstallCheck` surfaces typed errors (`release_pending` 409, `release_exists` 409); recovery path uses `upgrade --install` to overwrite `failed`/`uninstalled` records idempotently.
- **Latest-revision read fix.** `preInstallCheck` originally used `action.History.Run()[0]`, which returns the storage driver's unsorted Query result and ignores `Max`. For multi-revision releases (the recovery scenario itself produces these), `hist[0]` would silently read the wrong revision and misroute the install. Switched to `Releases.Last(name)`, which sorts descending by revision.

## In-cluster security hardening

- **Bug 3 — Helm pre-flight RBAC.** When Radar is deployed in cloud-mode or with `auth.mode=proxy`, the impersonated user (bound to namespace-scoped admin/edit/view) lacks the cluster-scoped reads Helm's pre-flight existence check needs. RBAC denials are now classified into a typed 403 `rbac_preflight` with verb/resource detail so the UI can render an actionable message.
- **Helm-capable add-on ClusterRole, split by tier.** `rbac.helm=true && (auth.mode != none || cloud.enabled)` emits two ClusterRoles:
  - `radar-helm` (member-safe) — CRDs, StorageClasses, RuntimeClasses, PriorityClasses, PDBs, Namespaces. Bound to `cloud:owner` AND `cloud:member`.
  - `radar-helm-admin` (cluster-admin-equivalent) — RBAC objects, validating/mutating webhooks, ApiServices. Bound to `cloud:owner` ONLY.
  - Rationale: a `cloud:member` with `clusterrolebindings` write can self-promote to cluster-admin in one apply. Splitting preserves the owner/member trust boundary. Members can install most operator charts (CRDs, etc.); charts that bundle their own RBAC require an owner.
- **Opt-in `rbac.viewRBAC` flag (default `false`).** The base ClusterRole's RBAC-object reads are now gated. Reason: Radar's resource browser serves reads from the SA-populated informer cache without per-user SAR re-checks, so granting the SA cluster-wide RBAC reads exposes the cluster's authorization graph to every authenticated Radar user — including `cloud:viewer`, who is bound to K8s `view` and would not see RBAC objects via kubectl. Operators who want the resource browser to show RBAC opt in. The deeper architectural question (impersonate-on-reads vs. SAR-gating) is for a separate discussion.
- **Operational logging.** `handleInstall` and `handleInstallStream` now log release/namespace/chart/repo on failure (`%q`-escaped) so the underlying error is debuggable months later. `preInstallCheck` logs unrecognized release statuses (default branch) instead of silently treating them as recoverable.

## Behavior changes worth knowing about

- **SSA `Force: true` semantics.** Editing a resource via Radar takes ownership of fields previously owned by other field managers (controllers, GitOps). Matches `kubectl apply --server-side` behavior. UX-honest: "Save" means save.
- **`cloud:member` no longer has cluster-admin-equivalent Helm permissions.** Members attempting to install a chart that bundles its own RBAC/webhooks/ApiServices will hit the new `rbac_preflight` 403 with the actionable "expand permissions" message. Day-to-day app charts and operator-CRD installs still work for members. **This is a tightening, not a regression.**
- **Default RBAC read scope unchanged from pre-PR state.** Earlier iterations of this branch granted base RBAC reads unconditionally; the final shape gates them behind `rbac.viewRBAC=false` so the OSS install behavior is unchanged from `main`.
- **SSE error event `error_code` field.** New on the streaming install path so the SPA can branch on `release_pending` / `release_exists` / `rbac_preflight`. Forward-compatible — existing consumers only read `type`/`phase`/`message`/`detail`.

## Where to start reading

- Bug 1: `pkg/k8score/workload.go` (`UpdateResource`), `pkg/k8score/workload_update_test.go`
- Bug 2 logic: `internal/helm/install_preflight.go` (typed errors, `preInstallCheck` using `Releases.Last`), call sites in `internal/helm/client.go`
- Bug 2 error mapping: `internal/helm/install_preflight.go` (`classifyHelmRBACError`, `writeInstallError`)
- Chart RBAC split: `deploy/helm/radar/templates/clusterrole-helm.yaml` (member-safe), `deploy/helm/radar/templates/clusterrole-helm-admin.yaml` (owner-only), `deploy/helm/radar/templates/cloud-rbac-helm.yaml` (bindings)
- viewRBAC gate: `deploy/helm/radar/templates/clusterrole.yaml`, `deploy/helm/radar/values.yaml`
- Chart tests: `scripts/test-chart.sh`

## Test plan

**Automated (passing):**
- [x] `go build ./...` and `go vet ./...` clean (root + `pkg/`)
- [x] `go test ./internal/...` and `cd pkg && go test ./...` — all pass
- [x] New unit tests: SSA wire format including `FieldManager=radar` and `Force=true`; pending/exists/failed branches; multi-revision uses latest; uninstalling treated as in-flight; RBAC error classification with real Helm error string
- [x] `helm lint deploy/helm/radar` clean
- [x] `bash scripts/test-chart.sh` — 38 assertions covering: defaults emit no helm-write footprint; gating logic across `rbac.helm × auth.mode × cloud.enabled`; `cloud:member` is never bound to `radar-helm-admin`; `viewRBAC=false` default omits RBAC reads; `viewRBAC=true` emits them

**Live-verified on AWS nonprod (`us-east-1-nonprod`, k8s v1.33.8):**
- [x] ConfigMap update via PUT without `resourceVersion` succeeds; `fieldManager=radar` registered
- [x] ConfigMap update with stale `resourceVersion` + `managedFields` in YAML body succeeds (stripping path)
- [x] ClusterPolicy update via `/api/resources/apply` succeeds; `radar` registered as SSA field manager alongside existing `kyverno` and `kubectl-client-side-apply`
- [x] Install over deployed release returns HTTP 409 with `error_code: release_exists` and "use upgrade" hint
- [x] Install over failed release: `helm history` shows revision 2 with description starting "Upgrade …" — confirming the `upgrade --install` fallback executed instead of `install`
- [x] Fresh install (no prior record) succeeds normally

**Not live-verified (unit-tested only):**
- Multi-revision preflight (couldn't reliably reproduce the storage state via shell; unit test covers it with real Helm SDK + in-memory storage driver)
- `cloud:member` end-to-end install of a chart bundling its own RBAC → expected `rbac_preflight` 403 with actionable message. The chain (impersonated install → helm preflight denial → `classifyHelmRBACError` regex → `writeInstallError`) is unit-tested at each link but the full end-to-end flow has not been exercised in a live cloud-mode setup. Worst-case if the chain breaks: UX-only — confusing 500 instead of actionable 403; member still cannot install (correct outcome). Reversible with a small follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Kubernetes write paths (server-side apply with `Force=true`) and Helm install behavior/RBAC, which can affect cluster modifications and permission boundaries; changes are guarded by feature flags and include tests but still merit careful review in real clusters.
> 
> **Overview**
> Fixes Kubernetes YAML update and Helm install edge cases by switching `WorkloadManager.UpdateResource` from `Update` (PUT) to server-side apply (PATCH `ApplyPatchType`) with server-managed metadata stripping and a pinned `FieldManager=radar`.
> 
> Makes Helm installs more idempotent by adding a `preInstallCheck` that detects existing/pending releases, routes to `install --replace` or `upgrade --install` recovery modes, and returns typed 409/403 errors (`release_pending`, `release_exists`, `rbac_preflight`) consistently for both JSON and SSE install endpoints with improved failure logging.
> 
> Hardens in-cluster RBAC around Helm and RBAC visibility: introduces `rbac.viewRBAC` (default off) to gate reading RBAC objects, and when `rbac.helm=true` under auth/cloud emits split add-on ClusterRoles (`radar-helm` vs `radar-helm-admin`) plus cloud-tier bindings so `cloud:member` never receives cluster-admin-equivalent permissions; docs and chart tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25b9e2231703fd0a4af46f10d24d7d8883f15b82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->