### PR TITLE
fix(audit): clickable rows + persist group-by toggle (SKY-844)

### DIFF
--- a/packages/k8s-ui/src/components/audit/AuditFindingsTable.tsx
+++ b/packages/k8s-ui/src/components/audit/AuditFindingsTable.tsx
@@ -45,27 +45,16 @@ export interface AuditFindingsTableProps {
    *  Defaults to no-op; multi-cluster hosts pass a navigator that opens
    *  the cluster's per-cluster audit page. */
   onClusterClick?: (clusterId: string) => void
-  /** Controlled "group by namespace" toggle. When provided, the parent owns
-   *  the state (e.g. persists it to URL search params) so it survives
-   *  remounts caused by data refetches on namespace changes. */
-  groupByNS?: boolean
-  onGroupByNSChange?: (value: boolean) => void
 }
 
-export function AuditFindingsTable({ groups, findings, checks, onResourceClick, onHideCheck, onHideCategory, onHideNamespace, multiCluster, onClusterClick, groupByNS: groupByNSProp, onGroupByNSChange }: AuditFindingsTableProps) {
+export function AuditFindingsTable({ groups, findings, checks, onResourceClick, onHideCheck, onHideCategory, onHideNamespace, multiCluster, onClusterClick }: AuditFindingsTableProps) {
   const [categoryFilter, setCategoryFilter] = useState<string | null>(null)
   const [severityFilter, setSeverityFilter] = useState<string | null>(null)
   const [frameworkFilter, setFrameworkFilter] = useState<string | null>(null)
   const [searchTerm, setSearchTerm] = useState('')
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
   const [expandedNS, setExpandedNS] = useState<Set<string>>(new Set())
-  const [uncontrolledGroupByNS, setUncontrolledGroupByNS] = useState(false)
-  const isControlledGroupByNS = groupByNSProp !== undefined
-  const groupByNS = isControlledGroupByNS ? groupByNSProp : uncontrolledGroupByNS
-  const setGroupByNS = (value: boolean) => {
-    if (!isControlledGroupByNS) setUncontrolledGroupByNS(value)
-    onGroupByNSChange?.(value)
-  }
+  const [groupByNS, setGroupByNS] = useState(false)
   const searchInputRef = useRef<HTMLInputElement>(null)
 
   // "/" keyboard shortcut to focus search

--- a/packages/k8s-ui/src/components/audit/AuditFindingsTable.tsx
+++ b/packages/k8s-ui/src/components/audit/AuditFindingsTable.tsx
@@ -45,16 +45,27 @@ export interface AuditFindingsTableProps {
    *  Defaults to no-op; multi-cluster hosts pass a navigator that opens
    *  the cluster's per-cluster audit page. */
   onClusterClick?: (clusterId: string) => void
+  /** Controlled "group by namespace" toggle. When provided, the parent owns
+   *  the state (e.g. persists it to URL search params) so it survives
+   *  remounts caused by data refetches on namespace changes. */
+  groupByNS?: boolean
+  onGroupByNSChange?: (value: boolean) => void
 }
 
-export function AuditFindingsTable({ groups, findings, checks, onResourceClick, onHideCheck, onHideCategory, onHideNamespace, multiCluster, onClusterClick }: AuditFindingsTableProps) {
+export function AuditFindingsTable({ groups, findings, checks, onResourceClick, onHideCheck, onHideCategory, onHideNamespace, multiCluster, onClusterClick, groupByNS: groupByNSProp, onGroupByNSChange }: AuditFindingsTableProps) {
   const [categoryFilter, setCategoryFilter] = useState<string | null>(null)
   const [severityFilter, setSeverityFilter] = useState<string | null>(null)
   const [frameworkFilter, setFrameworkFilter] = useState<string | null>(null)
   const [searchTerm, setSearchTerm] = useState('')
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
   const [expandedNS, setExpandedNS] = useState<Set<string>>(new Set())
-  const [groupByNS, setGroupByNS] = useState(false)
+  const [uncontrolledGroupByNS, setUncontrolledGroupByNS] = useState(false)
+  const isControlledGroupByNS = groupByNSProp !== undefined
+  const groupByNS = isControlledGroupByNS ? groupByNSProp : uncontrolledGroupByNS
+  const setGroupByNS = (value: boolean) => {
+    if (!isControlledGroupByNS) setUncontrolledGroupByNS(value)
+    onGroupByNSChange?.(value)
+  }
   const searchInputRef = useRef<HTMLInputElement>(null)
 
   // "/" keyboard shortcut to focus search
@@ -309,9 +320,12 @@ export function AuditFindingsTable({ groups, findings, checks, onResourceClick, 
             const nsWarning = nsGroups.reduce((n, g) => n + g.warning, 0)
             return (
               <div key={ns}>
-                <button
+                <div
+                  role="button"
+                  tabIndex={0}
                   onClick={() => toggleNS(ns)}
-                  className="group flex items-center gap-3 w-full px-4 py-2 rounded-lg hover:bg-theme-hover/30 transition-colors text-left"
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleNS(ns) } }}
+                  className="group flex items-center gap-3 w-full px-4 py-2 rounded-lg hover:bg-theme-hover/30 transition-colors text-left cursor-pointer focus-visible:ring-2 focus-visible:ring-theme-text-primary/20 focus-visible:outline-none"
                 >
                   <ChevronRight className={clsx('w-4 h-4 text-theme-text-tertiary shrink-0 transition-transform duration-200', nsExpanded && 'rotate-90')} />
                   <span className="text-sm font-semibold text-theme-text-primary">{ns}</span>
@@ -324,7 +338,7 @@ export function AuditFindingsTable({ groups, findings, checks, onResourceClick, 
                   {onHideNamespace && ns !== '(cluster-scoped)' && (
                     <ContextMenu items={[{ label: `Hide ${ns} namespace`, onClick: () => onHideNamespace(ns) }]} />
                   )}
-                </button>
+                </div>
                 <div
                   className="grid transition-[grid-template-rows] duration-200 ease-out"
                   style={{ gridTemplateRows: nsExpanded ? '1fr' : '0fr' }}
@@ -422,9 +436,12 @@ function ResourceGroupRow({ group: g, checks, expanded, onToggle, onResourceClic
 
   return (
     <div>
-      <button
+      <div
+        role="button"
+        tabIndex={0}
         onClick={() => onToggle(key)}
-        className="group flex items-center gap-3 w-full px-4 py-2.5 rounded-lg hover:bg-theme-hover/50 transition-colors text-left focus-visible:ring-2 focus-visible:ring-theme-text-primary/20 focus-visible:outline-none"
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggle(key) } }}
+        className="group flex items-center gap-3 w-full px-4 py-2.5 rounded-lg hover:bg-theme-hover/50 transition-colors text-left cursor-pointer focus-visible:ring-2 focus-visible:ring-theme-text-primary/20 focus-visible:outline-none"
       >
         <ChevronRight className={clsx('w-3.5 h-3.5 text-theme-text-tertiary shrink-0 transition-transform duration-200', isExpanded && 'rotate-90')} />
         {hasDanger ? (
@@ -434,16 +451,14 @@ function ResourceGroupRow({ group: g, checks, expanded, onToggle, onResourceClic
         )}
         <span className="text-xs text-theme-text-tertiary shrink-0">{g.kind}</span>
         {onResourceClick ? (
-          <span
-            role="link"
-            tabIndex={0}
+          <button
+            type="button"
             onClick={(e) => { e.stopPropagation(); onResourceClick(g.kind, g.namespace, g.name) }}
-            onKeyDown={(e) => { if (e.key === 'Enter') { e.stopPropagation(); onResourceClick(g.kind, g.namespace, g.name) } }}
-            className="text-sm font-medium text-skyhook-500 hover:text-skyhook-400 hover:underline cursor-pointer truncate max-w-[300px] inline-flex items-center gap-1"
+            className="text-sm font-medium text-skyhook-500 hover:text-skyhook-400 hover:underline cursor-pointer truncate max-w-[300px] inline-flex items-center gap-1 text-left"
           >
             {showNamespace && g.namespace ? `${g.namespace} / ` : ''}{g.name}
             <ExternalLink className="w-3 h-3 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
-          </span>
+          </button>
         ) : (
           <span className="text-sm font-medium text-theme-text-primary truncate max-w-[300px]">
             {showNamespace && g.namespace ? `${g.namespace} / ` : ''}{g.name}
@@ -457,7 +472,7 @@ function ResourceGroupRow({ group: g, checks, expanded, onToggle, onResourceClic
         {showNamespace && onHideNamespace && g.namespace && (
           <ContextMenu items={[{ label: `Hide ${g.namespace} namespace`, onClick: () => onHideNamespace(g.namespace) }]} />
         )}
-      </button>
+      </div>
       <div
         className="grid transition-[grid-template-rows] duration-200 ease-out"
         style={{ gridTemplateRows: isExpanded ? '1fr' : '0fr' }}

--- a/packages/k8s-ui/src/components/audit/AuditFindingsTable.tsx
+++ b/packages/k8s-ui/src/components/audit/AuditFindingsTable.tsx
@@ -323,8 +323,12 @@ export function AuditFindingsTable({ groups, findings, checks, onResourceClick, 
                 <div
                   role="button"
                   tabIndex={0}
+                  aria-expanded={nsExpanded}
                   onClick={() => toggleNS(ns)}
-                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleNS(ns) } }}
+                  onKeyDown={(e) => {
+                    if (e.target !== e.currentTarget) return
+                    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleNS(ns) }
+                  }}
                   className="group flex items-center gap-3 w-full px-4 py-2 rounded-lg hover:bg-theme-hover/30 transition-colors text-left cursor-pointer focus-visible:ring-2 focus-visible:ring-theme-text-primary/20 focus-visible:outline-none"
                 >
                   <ChevronRight className={clsx('w-4 h-4 text-theme-text-tertiary shrink-0 transition-transform duration-200', nsExpanded && 'rotate-90')} />
@@ -439,8 +443,12 @@ function ResourceGroupRow({ group: g, checks, expanded, onToggle, onResourceClic
       <div
         role="button"
         tabIndex={0}
+        aria-expanded={isExpanded}
         onClick={() => onToggle(key)}
-        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggle(key) } }}
+        onKeyDown={(e) => {
+          if (e.target !== e.currentTarget) return
+          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggle(key) }
+        }}
         className="group flex items-center gap-3 w-full px-4 py-2.5 rounded-lg hover:bg-theme-hover/50 transition-colors text-left cursor-pointer focus-visible:ring-2 focus-visible:ring-theme-text-primary/20 focus-visible:outline-none"
       >
         <ChevronRight className={clsx('w-3.5 h-3.5 text-theme-text-tertiary shrink-0 transition-transform duration-200', isExpanded && 'rotate-90')} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -298,6 +298,7 @@ export function useAudit(namespaces: string[] = []) {
     queryFn: () => fetchJSON(`/audit${params}`),
     staleTime: 30000,
     refetchInterval: 60000,
+    placeholderData: (prev) => prev,
   })
 }
 

--- a/web/src/components/audit/AuditView.tsx
+++ b/web/src/components/audit/AuditView.tsx
@@ -1,5 +1,4 @@
 import { useState, useCallback } from 'react'
-import { useSearchParams } from 'react-router-dom'
 import { useAudit, useAuditSettings, useUpdateAuditSettings } from '../../api/client'
 import type { SelectedResource } from '../../types'
 import { AuditFindingsTable, PaneLoader } from '@skyhook-io/k8s-ui'
@@ -17,16 +16,6 @@ export function AuditView({ namespaces, onBack, onNavigateToResource }: AuditVie
   const { data: auditSettings } = useAuditSettings()
   const updateSettings = useUpdateAuditSettings()
   const [showSettings, setShowSettings] = useState(false)
-  const [searchParams, setSearchParams] = useSearchParams()
-  const groupByNS = searchParams.get('groupBy') === 'namespace'
-  const setGroupByNS = useCallback((value: boolean) => {
-    setSearchParams(prev => {
-      const next = new URLSearchParams(prev)
-      if (value) next.set('groupBy', 'namespace')
-      else next.delete('groupBy')
-      return next
-    }, { replace: true })
-  }, [setSearchParams])
 
   const ignoredCount = auditSettings?.ignoredNamespaces?.length ?? 0
 
@@ -119,8 +108,6 @@ export function AuditView({ namespaces, onBack, onNavigateToResource }: AuditVie
         onHideCheck={hideCheck}
         onHideCategory={hideCategory}
         onHideNamespace={hideNamespace}
-        groupByNS={groupByNS}
-        onGroupByNSChange={setGroupByNS}
       />
 
       {showSettings && <AuditSettingsDialog namespaces={namespaces} onClose={() => setShowSettings(false)} />}

--- a/web/src/components/audit/AuditView.tsx
+++ b/web/src/components/audit/AuditView.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { useAudit, useAuditSettings, useUpdateAuditSettings } from '../../api/client'
 import type { SelectedResource } from '../../types'
 import { AuditFindingsTable, PaneLoader } from '@skyhook-io/k8s-ui'
@@ -16,6 +17,16 @@ export function AuditView({ namespaces, onBack, onNavigateToResource }: AuditVie
   const { data: auditSettings } = useAuditSettings()
   const updateSettings = useUpdateAuditSettings()
   const [showSettings, setShowSettings] = useState(false)
+  const [searchParams, setSearchParams] = useSearchParams()
+  const groupByNS = searchParams.get('groupBy') === 'namespace'
+  const setGroupByNS = useCallback((value: boolean) => {
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev)
+      if (value) next.set('groupBy', 'namespace')
+      else next.delete('groupBy')
+      return next
+    }, { replace: true })
+  }, [setSearchParams])
 
   const ignoredCount = auditSettings?.ignoredNamespaces?.length ?? 0
 
@@ -108,6 +119,8 @@ export function AuditView({ namespaces, onBack, onNavigateToResource }: AuditVie
         onHideCheck={hideCheck}
         onHideCategory={hideCategory}
         onHideNamespace={hideNamespace}
+        groupByNS={groupByNS}
+        onGroupByNSChange={setGroupByNS}
       />
 
       {showSettings && <AuditSettingsDialog namespaces={namespaces} onClose={() => setShowSettings(false)} />}


### PR DESCRIPTION
## Summary
- Audit row collapse now triggers anywhere on the row (chevron, text, kebab area), not just the far-right counts area. Outer `<button>` swapped to `role=button` div + `tabIndex` + `onKeyDown`; inner span role=link promoted to real button.
- "Group by namespace" + every other piece of table state (search, filters, expanded rows) now persists across namespace filter changes. Root cause was `useAudit` lacking `placeholderData`, which caused `AuditView` to flash a `PaneLoader` and unmount the entire `AuditFindingsTable`.
- a11y: `aria-expanded` added to both disclosure rows; keyboard double-fire (inner button bubbling Enter/Space to outer row) gated with `e.target === e.currentTarget`.

## Why
SKY-844. User-reported audit page interaction bugs.

## Where to start
- `web/src/api/client.ts` line 296 — single-line `placeholderData: (prev) => prev` on `useAudit` (this is the load-bearing fix for state persistence).
- `packages/k8s-ui/src/components/audit/AuditFindingsTable.tsx` lines 322-344 (namespace header) + 425-475 (ResourceGroupRow) — disclosure-row refactor.

## Risky vs mechanical
- **Risky**: the `placeholderData` change replaces the previous "lift state to URL search param" approach. Consequence: auto-grouping `useEffect` no longer re-fires on namespace changes — toggle stays in user's last state instead of auto-flipping ON when they switch from a small to large namespace. Intended.
- **Risky**: outer disclosure widgets are `role=button` divs containing real `<button>` children (resource link, ContextMenu kebab). Technically invalid ARIA but click delegation works via existing `e.stopPropagation()`. Proper fix is a larger redesign — out of scope.
- **Mechanical**: aria-expanded additions, keydown gate.

## Open
- Original Bug 1 (audit toolbar buttons not clickable) could not be reproduced — see `NOTES.md` at the worktree root for handoff. If user still sees dead toolbar buttons after this lands, start there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI behavior change: refactors disclosure rows to custom `role=button` containers and adjusts keyboard handling, which could introduce subtle accessibility or event-propagation regressions. `placeholderData` alters loading/refetch behavior for `useAudit`, which may mask intermediate loading states but is unlikely to affect server data correctness.
> 
> **Overview**
> Improves audit table interactions by making namespace headers and resource-group rows toggle expansion when clicking anywhere on the row (not just the counts), with added `aria-expanded`, focus styling, and guarded `Enter`/`Space` key handling to avoid double-triggering.
> 
> Updates `useAudit` to retain previous query results during namespace changes via `placeholderData`, preventing the audit view from unmounting/reloading and thereby preserving table state (group-by toggle, filters, expanded rows) across namespace refetches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de18cec4923f0763400cc8f3163622629516cce6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->