### PR TITLE
fix(resources): scope Namespace column filter to result set (SKY-845)

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -156,7 +156,7 @@ const WORKLOAD_KINDS = new Set(['deployments', 'statefulsets', 'daemonsets'])
 
 // Columns to skip for auto-detected filters (high cardinality, text-like, or non-filterable)
 const SKIP_FILTER_COLUMNS = new Set([
-  'name', 'namespace', 'age', 'keys', 'size', 'images', 'domains', 'hosts', 'rules',
+  'name', 'age', 'keys', 'size', 'images', 'domains', 'hosts', 'rules',
   'ports', 'message', 'url', 'ref', 'revision', 'path', 'selector', 'ready', 'restarts',
   'completions', 'duration', 'schedule', 'lastRun', 'target', 'replicas', 'metrics',
   'capacity', 'accessModes', 'volume', 'step', 'progress', 'template', 'expires',

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -1636,6 +1636,8 @@ export function getCellFilterValue(resource: any, column: string, kind: string):
   const kindLower = kind.toLowerCase()
 
   switch (column) {
+    case 'namespace':
+      return resource.metadata?.namespace || ''
     case 'type':
       if (kindLower === 'secrets' || kindLower === 'sealedsecrets') return getSecretType(resource).type
       if (kindLower === 'services') return resource.spec?.type || ''


### PR DESCRIPTION
## Summary
- Drops `'namespace'` from `SKIP_FILTER_COLUMNS` so the Namespace column gets the existing low-cardinality multi-select dropdown that every other filterable column already uses.
- Adds `case 'namespace'` to `getCellFilterValue` reading `resource.metadata?.namespace || ''`.

Net effect: the Namespace column header now shows a funnel icon when a kind has 2..20 distinct namespaces in the (filtered) result set. Cluster-scoped kinds are auto-suppressed by the existing `if (val)` empty-string skip + 2..20 distinct gate.

## Why
SKY-845. User reported the namespace selector on /certs (which is the home Certificate Health card -> /resources/secrets?filters=type:TLS deep-link) didn't surface namespaces present in the filtered result set. The topbar selector is global and shows every cluster namespace — this PR adds a per-column scoped picker on top of that.

## Where to start
- `packages/k8s-ui/src/components/resources/ResourcesView.tsx` line 158 — `SKIP_FILTER_COLUMNS`.
- `packages/k8s-ui/src/components/resources/resource-utils.ts` line 1638 — `getCellFilterValue` switch.

## Risky vs mechanical
- **Mechanical**: 2 lines + tests pass. Existing dropdown machinery does the work.
- **Worth a smoke test**: confirm `/resources/secrets?filters=type:TLS` shows funnel on Namespace header, dropdown lists only TLS-secret namespaces with counts, selecting one narrows results.

## Caveat
Branch name `certs-page-namespace-selector-empty` describes the symptom; the change is broader (every namespaced resource list gets the column filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/filtering change that only affects client-side filter generation for the `namespace` column and should not impact data fetching or mutation paths.
> 
> **Overview**
> Adds support for per-result-set **Namespace** column filtering in the resources table.
> 
> This removes `namespace` from `SKIP_FILTER_COLUMNS` so it can participate in auto-detected dropdown filters, and updates `getCellFilterValue` to return `resource.metadata.namespace` for the `namespace` column.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10a63368e8436e8df7e5db1481c005fb8c36bb3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->