### PR TITLE
fix(gitops): reserve icon-column slot in ManagedResourcesList (SKY-846)

### DIFF
--- a/packages/k8s-ui/src/components/gitops/ManagedResourcesList.tsx
+++ b/packages/k8s-ui/src/components/gitops/ManagedResourcesList.tsx
@@ -132,8 +132,10 @@ function ResourceItem({ resource, onClick, showHealth }: ResourceItemProps) {
 
   const content = (
     <div className="flex items-center gap-2 py-0.5">
-      {showHealth && resource.health && (
-        <HealthDot health={resource.health} />
+      {showHealth && (
+        <span className="shrink-0 w-1.5 h-1.5 inline-flex items-center justify-center">
+          {resource.health && <HealthDot health={resource.health} />}
+        </span>
       )}
       <span className="text-xs text-theme-text-secondary truncate" title={displayName}>
         {displayName}


### PR DESCRIPTION
## Summary
- Wraps `HealthDot` in a fixed-width slot (`shrink-0 w-1.5 h-1.5 inline-flex items-center justify-center`) gated only on `showHealth`. Slot reserves space whether or not the resource has a `health` field, keeping the name column anchored across rows.

## Why
SKY-846. User reported "icons alignment, when no icon should have placeholder — repeating issue through all the product."

## Where to start
- `packages/k8s-ui/src/components/gitops/ManagedResourcesList.tsx` lines 133-147 — `ResourceItem` row layout.

## Important caveat — preventative fix
- Both current consumers (`ArgoApplicationRenderer.tsx:329`, `KustomizationRenderer.tsx:156`) construct `<ManagedResourcesList />` WITHOUT `showHealth`, and the prop default is `false`. **The patched branch is unreachable in OSS today.** Fix activates if/when a consumer flips the flag (Radar Hub, etc).
- I swept audit rows, helm releases, topology side panels, workload logs, ArgoApp sync rows, Flux renderers, ClusterSwitcher, TimelineList — the rest already render leading icons unconditionally or place optional icons trailing. One latent parallel exists at `packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx:283-287` (no consumer sets `item.status` today).
- If the user's "repeating issue through all the product" comment was about Radar Hub specifically, the visible-bug fix may live downstream.

## Risky vs mechanical
- Pure CSS slot reservation. Confirmed `w-1.5 h-1.5` slot matches the original `HealthDot` 6×6 footprint exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts layout/CSS for optional health indicators without affecting data flow or behavior beyond spacing.
> 
> **Overview**
> Reserves a fixed-size leading slot for the optional `HealthDot` in `ManagedResourcesList` rows whenever `showHealth` is enabled, so resource names stay aligned even when some items have no `health` value.
> 
> This changes the render condition from “only render when `resource.health` exists” to “always reserve space when `showHealth` is true”, with the dot rendered inside the slot only when present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd21726ac8e61fe5c283997c80dc2ac834cf1758. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->