### PR TITLE
fix(audit): multi-select OR semantics for filter chips (SKY-847)

### DIFF
--- a/packages/k8s-ui/src/components/audit/AuditFindingsTable.tsx
+++ b/packages/k8s-ui/src/components/audit/AuditFindingsTable.tsx
@@ -66,6 +66,13 @@ export function AuditFindingsTable({ groups, findings, checks, onResourceClick, 
     })
   }
 
+  const clearAllFilters = () => {
+    setCategoryFilter(new Set())
+    setSeverityFilter(new Set())
+    setFrameworkFilter(new Set())
+    setSearchTerm('')
+  }
+
   // "/" keyboard shortcut to focus search
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -258,7 +265,7 @@ export function AuditFindingsTable({ groups, findings, checks, onResourceClick, 
             Each chip is an independent toggle. Multiple chips within a dimension OR together;
             dimensions AND together. */}
         <div className="flex flex-wrap items-center gap-1.5">
-          <FilterPill label="All" active={!hasActiveFilters} onClick={() => { setCategoryFilter(new Set()); setSeverityFilter(new Set()); setFrameworkFilter(new Set()); setSearchTerm('') }} />
+          <FilterPill label="All" active={!hasActiveFilters} onClick={clearAllFilters} />
           <span className="w-px h-5 bg-theme-border mx-2" />
           {CATEGORIES.map(cat => (
             <FilterPill key={cat} label={cat} active={categoryFilter.has(cat)} onClick={() => toggleInSet(setCategoryFilter, cat)} />
@@ -305,7 +312,7 @@ export function AuditFindingsTable({ groups, findings, checks, onResourceClick, 
             action={
               <button
                 type="button"
-                onClick={() => { setCategoryFilter(new Set()); setSeverityFilter(new Set()); setFrameworkFilter(new Set()); setSearchTerm('') }}
+                onClick={clearAllFilters}
                 className="badge badge-sm border border-theme-border bg-theme-elevated text-theme-text-primary hover:bg-theme-hover transition-colors"
               >
                 Clear all filters

--- a/packages/k8s-ui/src/components/audit/AuditFindingsTable.tsx
+++ b/packages/k8s-ui/src/components/audit/AuditFindingsTable.tsx
@@ -66,10 +66,14 @@ export function AuditFindingsTable({ groups, findings, checks, onResourceClick, 
     })
   }
 
-  const clearAllFilters = () => {
+  const clearChipFilters = () => {
     setCategoryFilter(new Set())
     setSeverityFilter(new Set())
     setFrameworkFilter(new Set())
+  }
+
+  const clearAllFilters = () => {
+    clearChipFilters()
     setSearchTerm('')
   }
 
@@ -109,9 +113,8 @@ export function AuditFindingsTable({ groups, findings, checks, onResourceClick, 
   const matchesFinding = (f: AuditFinding) => {
     if (categoryFilter.size > 0 && !categoryFilter.has(f.category)) return false
     if (severityFilter.size > 0 && !severityFilter.has(f.severity)) return false
-    if (frameworkFilter.size > 0) {
-      const meta = checks?.[f.checkID]
-      const fws = meta?.frameworks
+    if (frameworkFilter.size > 0 && checks) {
+      const fws = checks[f.checkID]?.frameworks
       if (!fws || !fws.some(fw => frameworkFilter.has(fw))) return false
     }
     return true
@@ -159,7 +162,8 @@ export function AuditFindingsTable({ groups, findings, checks, onResourceClick, 
   }
 
   // Compute counts from filtered results (so summary reflects active filters)
-  const hasActiveFilters = categoryFilter.size > 0 || severityFilter.size > 0 || frameworkFilter.size > 0 || searchTerm !== ''
+  const hasActiveChipFilters = categoryFilter.size > 0 || severityFilter.size > 0 || frameworkFilter.size > 0
+  const hasActiveFilters = hasActiveChipFilters || searchTerm !== ''
   const filteredAllFindings = filteredGroups
     ? filteredGroups.flatMap(g => g.findings)
     : filteredFindings ?? []
@@ -265,7 +269,7 @@ export function AuditFindingsTable({ groups, findings, checks, onResourceClick, 
             Each chip is an independent toggle. Multiple chips within a dimension OR together;
             dimensions AND together. */}
         <div className="flex flex-wrap items-center gap-1.5">
-          <FilterPill label="All" active={!hasActiveFilters} onClick={clearAllFilters} />
+          <FilterPill label="All" active={!hasActiveChipFilters} onClick={clearChipFilters} />
           <span className="w-px h-5 bg-theme-border mx-2" />
           {CATEGORIES.map(cat => (
             <FilterPill key={cat} label={cat} active={categoryFilter.has(cat)} onClick={() => toggleInSet(setCategoryFilter, cat)} />

--- a/packages/k8s-ui/src/components/audit/AuditFindingsTable.tsx
+++ b/packages/k8s-ui/src/components/audit/AuditFindingsTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef, useEffect } from 'react'
+import { useState, useMemo, useRef, useEffect, type Dispatch, type SetStateAction } from 'react'
 import { ShieldAlert, AlertTriangle, ChevronRight, CheckCircle2, Search, ExternalLink, MoreHorizontal, EyeOff, Layers } from 'lucide-react'
 import { clsx } from 'clsx'
 import type { AuditFinding } from './AuditAlerts'
@@ -48,14 +48,23 @@ export interface AuditFindingsTableProps {
 }
 
 export function AuditFindingsTable({ groups, findings, checks, onResourceClick, onHideCheck, onHideCategory, onHideNamespace, multiCluster, onClusterClick }: AuditFindingsTableProps) {
-  const [categoryFilter, setCategoryFilter] = useState<string | null>(null)
-  const [severityFilter, setSeverityFilter] = useState<string | null>(null)
-  const [frameworkFilter, setFrameworkFilter] = useState<string | null>(null)
+  const [categoryFilter, setCategoryFilter] = useState<Set<string>>(new Set())
+  const [severityFilter, setSeverityFilter] = useState<Set<string>>(new Set())
+  const [frameworkFilter, setFrameworkFilter] = useState<Set<string>>(new Set())
   const [searchTerm, setSearchTerm] = useState('')
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
   const [expandedNS, setExpandedNS] = useState<Set<string>>(new Set())
   const [groupByNS, setGroupByNS] = useState(false)
   const searchInputRef = useRef<HTMLInputElement>(null)
+
+  const toggleInSet = (setter: Dispatch<SetStateAction<Set<string>>>, value: string) => {
+    setter(prev => {
+      const next = new Set(prev)
+      if (next.has(value)) next.delete(value)
+      else next.add(value)
+      return next
+    })
+  }
 
   // "/" keyboard shortcut to focus search
   useEffect(() => {
@@ -88,13 +97,15 @@ export function AuditFindingsTable({ groups, findings, checks, onResourceClick, 
 
   const searchLower = searchTerm.toLowerCase()
 
-  // Match a finding against category/severity/framework filters
+  // Match a finding against category/severity/framework filters.
+  // Within a dimension, multiple selected values are OR'd. Across dimensions, AND.
   const matchesFinding = (f: AuditFinding) => {
-    if (categoryFilter && f.category !== categoryFilter) return false
-    if (severityFilter && f.severity !== severityFilter) return false
-    if (frameworkFilter && checks) {
-      const meta = checks[f.checkID]
-      if (!meta?.frameworks?.includes(frameworkFilter)) return false
+    if (categoryFilter.size > 0 && !categoryFilter.has(f.category)) return false
+    if (severityFilter.size > 0 && !severityFilter.has(f.severity)) return false
+    if (frameworkFilter.size > 0) {
+      const meta = checks?.[f.checkID]
+      const fws = meta?.frameworks
+      if (!fws || !fws.some(fw => frameworkFilter.has(fw))) return false
     }
     return true
   }
@@ -141,7 +152,7 @@ export function AuditFindingsTable({ groups, findings, checks, onResourceClick, 
   }
 
   // Compute counts from filtered results (so summary reflects active filters)
-  const hasActiveFilters = !!(categoryFilter || severityFilter || frameworkFilter || searchTerm)
+  const hasActiveFilters = categoryFilter.size > 0 || severityFilter.size > 0 || frameworkFilter.size > 0 || searchTerm !== ''
   const filteredAllFindings = filteredGroups
     ? filteredGroups.flatMap(g => g.findings)
     : filteredFindings ?? []
@@ -243,28 +254,30 @@ export function AuditFindingsTable({ groups, findings, checks, onResourceClick, 
           )}
         </div>
 
-        {/* Row 2: Filter chips — three groups separated by dividers (All | Categories | Severities | Frameworks). */}
+        {/* Row 2: Filter chips — three groups separated by dividers (All | Categories | Severities | Frameworks).
+            Each chip is an independent toggle. Multiple chips within a dimension OR together;
+            dimensions AND together. */}
         <div className="flex flex-wrap items-center gap-1.5">
-          <FilterPill label="All" active={!categoryFilter && !severityFilter && !frameworkFilter} onClick={() => { setCategoryFilter(null); setSeverityFilter(null); setFrameworkFilter(null) }} />
+          <FilterPill label="All" active={!hasActiveFilters} onClick={() => { setCategoryFilter(new Set()); setSeverityFilter(new Set()); setFrameworkFilter(new Set()); setSearchTerm('') }} />
           <span className="w-px h-5 bg-theme-border mx-2" />
           {CATEGORIES.map(cat => (
-            <FilterPill key={cat} label={cat} active={categoryFilter === cat} onClick={() => setCategoryFilter(categoryFilter === cat ? null : cat)} />
+            <FilterPill key={cat} label={cat} active={categoryFilter.has(cat)} onClick={() => toggleInSet(setCategoryFilter, cat)} />
           ))}
           <span className="w-px h-5 bg-theme-border mx-2" />
           {SEVERITIES.map(sev => (
             <FilterPill
               key={sev}
               label={sev === 'danger' ? 'Critical' : 'Warning'}
-              active={severityFilter === sev}
+              active={severityFilter.has(sev)}
               tone={sev === 'danger' ? 'danger' : 'warn'}
-              onClick={() => setSeverityFilter(severityFilter === sev ? null : sev)}
+              onClick={() => toggleInSet(setSeverityFilter, sev)}
             />
           ))}
           {frameworks.length > 0 && (
             <>
               <span className="w-px h-5 bg-theme-border mx-2" />
               {frameworks.map(fw => (
-                <FilterPill key={fw} label={fw} active={frameworkFilter === fw} onClick={() => setFrameworkFilter(frameworkFilter === fw ? null : fw)} />
+                <FilterPill key={fw} label={fw} active={frameworkFilter.has(fw)} onClick={() => toggleInSet(setFrameworkFilter, fw)} />
               ))}
             </>
           )}
@@ -292,7 +305,7 @@ export function AuditFindingsTable({ groups, findings, checks, onResourceClick, 
             action={
               <button
                 type="button"
-                onClick={() => { setCategoryFilter(null); setSeverityFilter(null); setFrameworkFilter(null); setSearchTerm('') }}
+                onClick={() => { setCategoryFilter(new Set()); setSeverityFilter(new Set()); setFrameworkFilter(new Set()); setSearchTerm('') }}
                 className="badge badge-sm border border-theme-border bg-theme-elevated text-theme-text-primary hover:bg-theme-hover transition-colors"
               >
                 Clear all filters


### PR DESCRIPTION
## Summary
- `categoryFilter`, `severityFilter`, `frameworkFilter` converted from `string | null` (replace-on-click) to `Set<string>` (toggle-into-set, OR within dimension, AND across dimensions).
- Visual affordance was already pressable-chip multi-select; backing semantics now match.
- Mirror of the existing `VulnerabilityReportRenderer` pattern (same package).
- Extracted `clearAllFilters` helper to deduplicate the "All" chip and empty-state Clear button (4 setters had been duplicated in 2 places).

## Why
SKY-847. UI looked like multiple chips could be active simultaneously, but only the last clicked one applied — silent state lie.

## Where to start
- `packages/k8s-ui/src/components/audit/AuditFindingsTable.tsx` lines 50-160 — state declarations + `matchesFinding`.

## Risky vs mechanical
- **Mechanical**: Set-based toggling is a well-trodden pattern. `aria-pressed` per-pill correct ARIA for multi-toggle. Public API of `AuditFindingsTable` unchanged (state is component-internal) — Radar Hub safe.
- **Merge order**: this branch overlaps with PR #613 (SKY-844) on `AuditFindingsTable.tsx` state-declaration block. Whichever lands second will have a mechanical, additive conflict on adjacent lines (different fields). Resolve at merge — neither breaks the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes audit finding filtering semantics from single-select to multi-select sets, which can alter what findings are shown and the derived counts. Risk is limited to UI behavior but affects user-visible audit results and empty-state logic.
> 
> **Overview**
> Updates `AuditFindingsTable` filter chips to be true multi-select toggles by switching category/severity/framework filters from `string | null` to `Set<string>` and applying **OR-within-dimension, AND-across-dimensions** matching.
> 
> Adds shared helpers (`toggleInSet`, `clearChipFilters`, `clearAllFilters`) and wires them into the **All** chip and the empty-state clear action, with active-filter detection updated to reflect set-based state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3eadc3d773360009cd35422baed9ddf70d3b5bc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->