### PR TITLE
fix(topology): swap large-cluster picker for full NamespaceSelector (SKY-848)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -893,7 +893,12 @@ function AppInner() {
           {/* Namespace selector with search */}
           <NamespaceSelector
             value={namespaces}
-            onChange={setNamespaces}
+            onChange={(next) => {
+              setNamespaces(next)
+              if (forceNamespaceFilter !== undefined) {
+                setForceNamespaceFilter(next.length > 0 ? next : undefined)
+              }
+            }}
             namespaces={availableNamespaces}
             namespacesError={namespacesError}
             disabled={mainView === 'helm'}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1124,9 +1124,7 @@ function AppInner() {
                         value={namespaces}
                         onChange={(next) => {
                           setNamespaces(next)
-                          if (next.length > 0) {
-                            setForceNamespaceFilter(next)
-                          }
+                          setForceNamespaceFilter(next.length > 0 ? next : undefined)
                         }}
                         namespaces={availableNamespaces}
                         namespacesError={namespacesError}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -42,7 +42,6 @@ import radarLoadingIcon from '@skyhook-io/k8s-ui/assets/radar/radar-icon-loading
 import { RefreshCw, Network, List, Clock, Package, Sun, Moon, Activity, Home, Star, Search, Bug, Settings, SquareTerminal, ShieldCheck } from 'lucide-react'
 import { useTheme } from './context/ThemeContext'
 import { Tooltip } from './components/ui/Tooltip'
-import { LargeClusterNamespacePicker } from './components/shared/LargeClusterNamespacePicker'
 import { SettingsDialog } from './components/settings/SettingsDialog'
 import type { TopologyNode, GroupingMode, MainView, SelectedResource, SelectedHelmRelease, NodeKind, TopologyMode, Topology, K8sEvent } from './types'
 import { kindToPlural, openExternal } from './utils/navigation'
@@ -1120,14 +1119,17 @@ function AppInner() {
                       This cluster has too many resources to render the full topology.
                       Select a namespace to explore.
                     </p>
-                    <div className="relative">
-                      <LargeClusterNamespacePicker
-                        namespaces={availableNamespaces}
-                        onSelect={(ns) => {
-                          setNamespaces([ns])
-                          // Large clusters need server-side filtering — reconnect SSE with namespace
-                          setForceNamespaceFilter([ns])
+                    <div className="relative flex justify-center">
+                      <NamespaceSelector
+                        value={namespaces}
+                        onChange={(next) => {
+                          setNamespaces(next)
+                          if (next.length > 0) {
+                            setForceNamespaceFilter(next)
+                          }
                         }}
+                        namespaces={availableNamespaces}
+                        namespacesError={namespacesError}
                       />
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- Topology view's large-cluster namespace prompt swapped from `LargeClusterNamespacePicker` (stripped-down inline single-select) to full `NamespaceSelector` (autocomplete dropdown, multi-select checkboxes, search, Select All / Clear All).
- Wires `onChange` to set both `setNamespaces` and `setForceNamespaceFilter` — fix in commit `ba7f521` makes the SSE filter sync to selection on clear (prior asymmetric branch silently kept the old SSE filter, leaving the graph stale while app state said "all namespaces").
- Passes `namespacesError` so RBAC-restricted clusters still get the manual-entry fallback.
- **`56b910f`** — applies the same SSE-filter-sync fix to the sibling **toolbar** `NamespaceSelector` (top-right). Caught during visual testing: after selecting a namespace via the prompt, toolbar add/remove/Clear-All only updated `namespaces` and never synced `forceNamespaceFilter`, so SSE stayed locked to the original selection. Graph stuck on stale data forever; Clear All never returned to the prompt. Same one-liner pattern, guarded by `if (forceNamespaceFilter !== undefined)` to preserve small-cluster client-side filtering.

## Why
SKY-848. Fleet/large-cluster namespace input lacked autocompletion + multi-select.

## Where to start
- `web/src/App.tsx:1122` — large-cluster prompt render site (original PR change).
- `web/src/App.tsx:894` — toolbar `NamespaceSelector` (added in `56b910f`).

## Risky vs mechanical
- **Risky**: SSE reconnect on namespace change. If the new selection causes a flood of namespaces (e.g. "Select All" on a 2000-namespace cluster) the backend builds topology over every namespace — defeats the large-cluster guard. Pre-existing footgun, not introduced here, but more acute now that multi-select is easy.
- **Mechanical**: component swap, namespacesError fallback preserved, second-site fix applies the same pattern as the first.

## Manual test (added during review)
On a 53-namespace GKE cluster (threshold temporarily lowered to trigger the prompt; restored before commit):
- Prompt single-select → SSE reconnects with filter, topology renders ✓
- Toolbar multi-select → SSE reconnects with both namespaces, both render ✓ (was stuck on first selection before `56b910f`)
- Toolbar Clear All → SSE drops filter, prompt re-appears within seconds ✓ (was stuck forever before `56b910f`)
- Backend log: filtered computation (`23 estimated nodes`) gone, only unfiltered (`691 estimated nodes`) after clear ✓
- SSE connect events: 4 (one per change) vs 2 before fix ✓
- No console errors

## Open follow-ups (not blocking)
- `web/src/components/timeline/TimelineView.tsx:101` still uses `LargeClusterNamespacePicker`. Same UX problem on a sibling fleet-mode surface. Could fold in or split.
- `NamespaceSelector` has no virtualization (240px scroll renders all). Pre-existing in toolbar, more acute here.
- Closed-dropdown UX is one extra click vs the previous always-visible inline list. Could add a `defaultOpen` prop if the regression is meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)