### PR TITLE
fix(router): browser back works through resource drawer + relationship links (SKY-849)

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1850,6 +1850,9 @@ export function ResourcesView({
   const hasProcessedInitialResource = useRef(false)
   // Set by sidebar kind change to push a browser history entry (vs replace for filter changes)
   const shouldPushHistory = useRef(false)
+  // Used by the URL-write effect to distinguish drawer-to-drawer navigation (A -> B, push)
+  // from initial open (null -> X) and close (X -> null), which stay as URL replaces.
+  const prevSelectedResourceRef = useRef<SelectedResource | null>(null)
 
   // Ref to search input for keyboard shortcut
   const searchInputRef = useRef<HTMLInputElement>(null)
@@ -2446,12 +2449,12 @@ export function ResourcesView({
   useEffect(() => {
     // Skip URL update if we're syncing FROM the URL (e.g., browser back button)
     if (isSyncingFromURL.current) {
-
+      prevSelectedResourceRef.current = selectedResource ?? null
       return
     }
     // Skip on initial mount so we don't strip ?resource= before the mount effect reads it
     if (!hasProcessedInitialResource.current) {
-
+      prevSelectedResourceRef.current = selectedResource ?? null
       return
     }
     // Skip URL update if selectedResource's kind doesn't match selectedKind (still syncing)
@@ -2462,12 +2465,25 @@ export function ResourcesView({
         return // Wait for kind sync effect to run first
       }
     }
-    // Push history when kind changes (so browser back/forward works), replace for filter changes
-    const pushHistory = shouldPushHistory.current
+    // Push history for navigations (so browser back works); replace for filter / drawer-toggle changes.
+    // A navigation is one of: explicit sidebar/keyboard kind switch (shouldPushHistory),
+    // kind change driven by external setSelectedResource (pathname differs from target — e.g. clicking a
+    // Parent Gateway from a TCPRoute drawer), or a drawer-to-drawer switch within the same kind
+    // (selectedResource A -> B, both non-null and different). Initial open (null -> X) and close (X -> null)
+    // stay as replace because they don't represent a destination the user wants to "go back" to.
+    const targetPath = `${basePath}/${selectedKind.name}`
+    const pathChanged = window.location.pathname !== targetPath
+    const prev = prevSelectedResourceRef.current
+    const current = selectedResource ?? null
+    const drawerSwitched =
+      prev !== null && current !== null &&
+      (prev.namespace !== current.namespace || prev.name !== current.name || prev.kind !== current.kind)
+    const pushHistory = shouldPushHistory.current || pathChanged || drawerSwitched
     shouldPushHistory.current = false
+    prevSelectedResourceRef.current = current
 
     updateURL(selectedKind, searchTerm, columnFilters, problemFilters, showInactiveReplicaSets, selectedResource?.namespace, selectedResource?.name, pushHistory)
-  }, [selectedKind, searchTerm, columnFilters, problemFilters, showInactiveReplicaSets, selectedResource, updateURL])
+  }, [selectedKind, searchTerm, columnFilters, problemFilters, showInactiveReplicaSets, selectedResource, updateURL, basePath])
 
   // Handle resource click from URL on mount
   useEffect(() => {

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -2487,7 +2487,10 @@ export function ResourcesView({
     const current = selectedResource ?? null
     const drawerSwitched =
       prev !== null && current !== null &&
-      (prev.namespace !== current.namespace || prev.name !== current.name || prev.kind !== current.kind)
+      (prev.namespace !== current.namespace ||
+        prev.name !== current.name ||
+        prev.kind !== current.kind ||
+        (prev.group ?? '') !== (current.group ?? ''))
     const pushHistory = shouldPushHistory.current || pathChanged || drawerSwitched
     shouldPushHistory.current = false
     prevSelectedResourceRef.current = current

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -2472,7 +2472,17 @@ export function ResourcesView({
     // (selectedResource A -> B, both non-null and different). Initial open (null -> X) and close (X -> null)
     // stay as replace because they don't represent a destination the user wants to "go back" to.
     const targetPath = `${basePath}/${selectedKind.name}`
-    const pathChanged = window.location.pathname !== targetPath
+    // Compare basename-relative paths. Hosts that mount the app under a non-empty basename
+    // (e.g. Radar Hub at /c/{cluster}) inject `locationPathname` from useLocation(), which strips
+    // the basename — `window.location.pathname` still includes it, so reading window directly
+    // would never match `targetPath` (basename-relative) and force every URL write to push.
+    const currentPath =
+      locationPathname !== undefined
+        ? locationPathname
+        : typeof window !== 'undefined'
+          ? window.location.pathname
+          : ''
+    const pathChanged = currentPath !== targetPath
     const prev = prevSelectedResourceRef.current
     const current = selectedResource ?? null
     const drawerSwitched =
@@ -2483,7 +2493,7 @@ export function ResourcesView({
     prevSelectedResourceRef.current = current
 
     updateURL(selectedKind, searchTerm, columnFilters, problemFilters, showInactiveReplicaSets, selectedResource?.namespace, selectedResource?.name, pushHistory)
-  }, [selectedKind, searchTerm, columnFilters, problemFilters, showInactiveReplicaSets, selectedResource, updateURL, basePath])
+  }, [selectedKind, searchTerm, columnFilters, problemFilters, showInactiveReplicaSets, selectedResource, updateURL, basePath, locationPathname])
 
   // Handle resource click from URL on mount
   useEffect(() => {

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -2437,6 +2437,25 @@ export function ResourcesView({
     const newPath = `${basePath}/${kindInfo.name}`
     const queryStr = params.toString()
 
+    // No-op guard: if the target URL already matches the address bar, skip the
+    // navigate. Without this, a state catch-up after browser POP (App-level
+    // POP→state sync re-running this effect) would push a duplicate entry on
+    // top of the popped state — making the next Back appear to do nothing or
+    // (with multi-namespace name collisions) jump to a sibling resource via
+    // auto-resolution. Reading window.location avoids needing host-injected
+    // navigationType.
+    if (typeof window !== 'undefined') {
+      const currentPathname = window.location.pathname
+      const currentSearch = window.location.search.replace(/^\?/, '')
+      // Compare using basename-relative target path against window.pathname,
+      // which may include a host basename (e.g. /c/{cluster}). Treat a path
+      // suffix match as equal so embedded hosts don't false-trigger a write.
+      const pathMatches = currentPathname === newPath || currentPathname.endsWith(newPath)
+      if (pathMatches && currentSearch === queryStr) {
+        return
+      }
+    }
+
     // Route both push and replace through `navigate` (which honors the
     // onNavigate prop). The previous direct `window.history.replaceState`
     // bypass meant a host that wants to suppress URL writes (passing

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1321,7 +1321,7 @@ function AppInner() {
           onCollapse={handleCollapseFromExpanded}
           onNavigateToResource={(resource) => {
             setSelectedResource(resource)
-            navigate(`/workload/${resource.kind}/${resource.namespace}/${resource.name}`)
+            navigate(`/workload/${resource.kind}/${resource.namespace}/${resource.name}`, { replace: true })
           }}
         />
       )}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,7 +3,7 @@ import { flushSync } from 'react-dom'
 import { useRefreshAnimation } from './hooks/useRefreshAnimation'
 import { startViewTransitionSafe } from '@skyhook-io/k8s-ui/utils/view-transition'
 import { useQueryClient } from '@tanstack/react-query'
-import { useNavigate, useLocation, useSearchParams } from 'react-router-dom'
+import { useNavigate, useLocation, useSearchParams, useNavigationType, NavigationType } from 'react-router-dom'
 import { HomeView } from './components/home/HomeView'
 import { DebugOverlay } from './components/DebugOverlay'
 import { TopologyGraph, TopologyFilterSidebar, TopologyControls } from '@skyhook-io/k8s-ui'
@@ -172,6 +172,7 @@ function AuthBarrier({ authMode }: { authMode: string }) {
 function AppInner() {
   const navigate = useNavigate()
   const location = useLocation()
+  const navigationType = useNavigationType()
   const [searchParams, setSearchParams] = useSearchParams()
   const capabilities = useCapabilitiesContext()
   const openLocalTerminal = useOpenLocalTerminal()
@@ -680,11 +681,12 @@ function AppInner() {
       }
     }
 
-    // Restore resource drawer selection from URL (back/forward within /resources/{kind}).
-    // Cross-kind navigation re-mounts ResourcesView via key={location.pathname} so its
-    // own mount effect re-reads ?resource=; same-kind back/forward doesn't remount,
-    // so App must reconcile selectedResource here. Only acts on /resources/{kind}.
-    if (mainView === 'resources') {
+    // Restore resource drawer selection from URL on browser back/forward (POP) within
+    // /resources/{kind}. Cross-kind POP re-mounts ResourcesView via key={pathname} so its
+    // mount effect re-reads ?resource=; same-kind POP doesn't remount, so App must
+    // reconcile selectedResource here. Limited to POP to avoid clobbering deliberate
+    // setSelectedResource calls that race the URL writer (e.g. helm/audit -> resources).
+    if (navigationType === NavigationType.Pop && mainView === 'resources') {
       const kindFromPath = location.pathname.match(/^\/resources\/([^/]+)/)?.[1] ?? ''
       const resourceParam = searchParams.get('resource')
       if (kindFromPath && resourceParam) {
@@ -707,7 +709,7 @@ function AppInner() {
         setSelectedResource(prev => (prev === null ? prev : null))
       }
     }
-  }, [searchParams, location.pathname, mainView])
+  }, [searchParams, location.pathname, mainView, navigationType])
 
   // Auto-adjust grouping when namespaces change
   useEffect(() => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1291,7 +1291,7 @@ function AppInner() {
           onCollapse={handleCollapseFromExpanded}
           onNavigateToResource={(resource) => {
             setSelectedResource(resource)
-            navigate(`/workload/${resource.kind}/${resource.namespace}/${resource.name}`, { replace: true })
+            navigate(`/workload/${resource.kind}/${resource.namespace}/${resource.name}`)
           }}
         />
       )}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -679,7 +679,35 @@ function AppInner() {
         setSelectedHelmRelease({ namespace: ns, name })
       }
     }
-  }, [searchParams])
+
+    // Restore resource drawer selection from URL (back/forward within /resources/{kind}).
+    // Cross-kind navigation re-mounts ResourcesView via key={location.pathname} so its
+    // own mount effect re-reads ?resource=; same-kind back/forward doesn't remount,
+    // so App must reconcile selectedResource here. Only acts on /resources/{kind}.
+    if (mainView === 'resources') {
+      const kindFromPath = location.pathname.match(/^\/resources\/([^/]+)/)?.[1] ?? ''
+      const resourceParam = searchParams.get('resource')
+      if (kindFromPath && resourceParam) {
+        const slashIdx = resourceParam.indexOf('/')
+        const ns = slashIdx > 0 ? resourceParam.slice(0, slashIdx) : ''
+        const name = slashIdx > 0 ? resourceParam.slice(slashIdx + 1) : resourceParam
+        const apiGroup = searchParams.get('apiGroup') ?? ''
+        const next: SelectedResource = { kind: kindFromPath, namespace: ns, name, group: apiGroup }
+        setSelectedResource(prev => {
+          if (
+            prev &&
+            prev.kind === next.kind &&
+            prev.namespace === next.namespace &&
+            prev.name === next.name &&
+            (prev.group ?? '') === (next.group ?? '')
+          ) return prev
+          return next
+        })
+      } else if (kindFromPath && !resourceParam) {
+        setSelectedResource(prev => (prev === null ? prev : null))
+      }
+    }
+  }, [searchParams, location.pathname, mainView])
 
   // Auto-adjust grouping when namespaces change
   useEffect(() => {


### PR DESCRIPTION
## Summary
4 commits on this branch addressing two history bugs:
1. **Bug 8**: clicking a resource in the list deep-linked, then clicking another resource opened a drawer — back button skipped both intermediate states.
2. **Bug 11**: clicking "Parent Gateways" from a TCPRoute → Gateways list → back did nothing.

Changes:
- `122c82f` ResourcesView URL writer: pushes (instead of replaces) when pathname differs (cross-kind nav like Parent Gateways) or selectedResource A→B (same-list drawer-to-drawer). Initial open (null→X) and close (X→null) stay as replace.
- `122c82f` App.tsx L1294: dropped `{ replace: true }` from `onNavigateToResource` (expanded-drawer related-resource navigation).
- `796926e` + `c00e19a`: POP-only URL→drawer state sync — without this, back changed the URL but the drawer still showed the previous resource. Restricted to `NavigationType.Pop` to avoid clobbering helm/audit programmatic nav.
- `4487545`: basename-aware path compare — `window.location.pathname` includes a host's basename (e.g. `/c/{cluster}` under embed) while `targetPath` is basename-relative; reading window directly would force every URL write to push, polluting history with filter keystrokes.

## Why
SKY-849. The most invasive of the audit bugs — touches the URL writer directly. 4 review iterations across pre-pr + deep-deep.

## Where to start
- `packages/k8s-ui/src/components/resources/ResourcesView.tsx` lines 2466-2497 — push/replace decision logic.
- `web/src/App.tsx` lines 684-712 — POP-only URL→state sync effect.
- `web/src/App.tsx` line 1324 — `onNavigateToResource` push (no longer replace).

## Risky vs mechanical
- **Risky**: history strategy is fragile by nature. Walked all the paths in pre-pr review (sidebar click, keyboard, deep-link mount, Parent Gateways, drawer onClose, helm/audit programmatic nav) — all verified. POP-only sync uses `useNavigationType()` which reflects the LAST navigation; in extreme race conditions a non-POP nav between the back and the effect run could break sync, but no realistic trigger.
- **Risky**: legitimate replace sites left intentionally — App.tsx L188 (auth redirect), L234 (canonical route), L535 (cluster switch), L661/L1227/L1308 (filter/helm param updates).
- **Mechanical**: basename-aware compare matches the existing pattern in `getInitialKindFromURL` (line 1700-1705).

## Reviewer focus
- Walk the user repro for both bugs end-to-end on a real cluster before approving.
- Confirm helm + audit pages still navigate correctly (POP-only sync was specifically tightened to avoid race against those flows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches URL-writing and back/forward reconciliation logic in `ResourcesView`/`App`, which can subtly affect navigation history and embedded-basepath deployments. Scope is contained to resources-view URL updates and POP navigation handling.
> 
> **Overview**
> Fixes browser Back/Forward behavior for the resource drawer by adjusting when URL updates **push** vs **replace** history entries.
> 
> `ResourcesView` now (1) avoids redundant navigations when the computed target URL already matches the address bar, and (2) pushes history on kind/path changes or drawer-to-drawer resource switches while keeping initial open/close as replaces (with basename-aware path comparisons).
> 
> `App` adds POP-only URL→state reconciliation using `useNavigationType()` so same-kind back/forward updates the selected resource drawer state even when `ResourcesView` doesn’t remount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 990e9bec3adde08f13fef131478d857c9d036deb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->