### PR TITLE
fix(resources): reserve fixed-width slot for live Updated Xs counter (SKY-850)

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -3471,7 +3471,7 @@ export function ResourcesView({
           {lastUpdated && (
             <div className="flex items-center gap-1.5 text-xs text-theme-text-tertiary">
               <Clock className="w-3.5 h-3.5" />
-              <span>Updated {formatAge(lastUpdated.toISOString())}</span>
+              <span>Updated <span className="inline-block min-w-[4ch] tabular-nums">{formatAge(lastUpdated.toISOString())}</span></span>
             </div>
           )}
           {/* Column picker */}


### PR DESCRIPTION
## Summary
- Wraps `formatAge(lastUpdated)` output in `inline-block min-w-[4ch] tabular-nums` so the live counter slot stays the same width as the value rolls 1s → 10s → 100s. Stops the row from shifting horizontally on every tick.

## Why
SKY-850. User reported the row "moves a lot" because the column lacked a fixed-width placeholder.

## Where to start
- `packages/k8s-ui/src/components/resources/ResourcesView.tsx:3474` — single span change.

## Risky vs mechanical
- **Mechanical**: 1-line CSS. `min-w-[4ch]` accommodates `<1s` (3 chars) and `100s` (4 chars). `formatAge` rolls into `Nm/Nh/Nd` formats above 60s in the relevant codepath, so 4ch is sufficient.
- **Mechanical**: `tabular-nums` + `inline-block` work inside the parent `flex items-center gap-1.5` container.

## Merge order
- Conflicts with PR #572 (`feat/fix-list-refresh-age-shift-and-filter-open-refetch`), which extracts this widget into a `LastUpdatedLabel` component with `useNow`. If #572 lands first, this 1-line fold into that new component is trivial. Recommend merging #572 first.

## Open follow-ups (not blocking)
- `packages/k8s-ui/src/components/logs/LogCore.tsx:865-870` has the same bug class (15s log timestamp ticks shifting per-row content). Separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small CSS/markup tweak to the resources toolbar label to stabilize width, with no data, state, or behavior changes beyond layout.
> 
> **Overview**
> Prevents horizontal layout shift in the resources view header by wrapping the live "Updated" age text in a fixed-width, tabular-numerals span (`min-w-[4ch]` + `tabular-nums`) so the counter doesn’t change the row width as it ticks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22f9e63f8afacf78e00686aa1569015b2d9f5a04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->