### PR TITLE
fix(resources): highlight list row when drawer auto-opens for newly-created resource (SKY-851)

### DIFF
--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -13,7 +13,7 @@ import {
 } from '@skyhook-io/k8s-ui'
 import type { ResourceQueryResult } from '@skyhook-io/k8s-ui'
 import type { SelectedResource } from '../../types'
-import type { NavigateToResource } from '../../utils/navigation'
+import { kindToPlural, type NavigateToResource } from '../../utils/navigation'
 import { CreateResourceDialog } from '../shared/CreateResourceDialog'
 import { getSkeletonYaml } from '../../utils/skeleton-yaml'
 
@@ -204,7 +204,7 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
       initialYaml={createDialogYaml}
       title={createDialogTitle}
       onCreated={(result) => {
-        onResourceClick?.({ kind: result.kind, namespace: result.namespace, name: result.name, group: '' })
+        onResourceClick?.({ kind: kindToPlural(result.kind), namespace: result.namespace, name: result.name, group: '' })
       }}
     />
     </>

--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -8,7 +8,7 @@ import {
   type RendererOverrides,
 } from '@skyhook-io/k8s-ui'
 import type { SelectedResource, ResourceRef, ResolvedEnvFrom } from '../../types'
-import type { NavigateToResource } from '../../utils/navigation'
+import { kindToPlural, type NavigateToResource } from '../../utils/navigation'
 import {
   useChanges, useResourceWithRelationships, usePodLogs, useTopology, useUpdateResource,
   useDeleteResource, useTriggerCronJob, useSuspendCronJob, useResumeCronJob,
@@ -383,7 +383,7 @@ export function WorkloadView({
       initialYaml={duplicateYaml}
       title="Duplicate Resource"
       onCreated={(result) => {
-        rest.onNavigateToResource?.({ kind: result.kind, namespace: result.namespace, name: result.name, group: '' })
+        rest.onNavigateToResource?.({ kind: kindToPlural(result.kind), namespace: result.namespace, name: result.name, group: '' })
       }}
     />
     </>


### PR DESCRIPTION
## Summary
- When `CreateResourceDialog` succeeds, the auto-opened drawer's row in the list now correctly gets the "selected" highlight.
- Root cause: backend `ApplyResourceResult` returns the singular Kind ("Secret"), but `selectedKind.name` is the plural API resource name ("secrets"). Every navigation site already wraps with `kindToPlural`; the create-dialog wrapper was the lone outlier.
- Fix is a 2-line wrap (`kindToPlural(result.kind)`) at the create-dialog wrapper. Mirror fix landed in `WorkloadView` Duplicate flow (same singular-vs-plural bug found by review).

## Why
SKY-851. User created a secret externally, drawer auto-opened, but the row in the list had no highlight.

## Where to start
- `web/src/components/resources/ResourcesView.tsx:207` — primary fix.
- `web/src/components/workload/WorkloadView.tsx:386` — Duplicate-flow sibling.

## Risky vs mechanical
- **Mechanical**: `kindToPlural` is idempotent (verified by `navigation.test.ts`, 28 cases including irregular plurals like ingresses/storageclasses). Already-plural input is a no-op.

## Open (not blocking, out of scope per ticket)
- `pkg/k8score/workload.go:177` `ApplyResourceResult` doesn't include API group. CRDs created via dialog land with `selectedResource.group=''`. Equality check at row-render ignores group, so non-colliding kinds work fine. Only colliding kinds (e.g. KServe Service vs core Service) could highlight in the wrong list. Real but narrow risk — separate ticket.
- Library consumers (Radar Hub) need the same fix in any custom create flow.
- No lint enforcement that nav sites must use `kindToPlural`. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small UI navigation change that normalizes `kind` via `kindToPlural` when auto-opening drawers after create/duplicate, with no auth or data-handling impact.
> 
> **Overview**
> Fixes post-create and duplicate navigation to use the plural API resource name by wrapping `result.kind` with `kindToPlural` in `ResourcesView` and `WorkloadView`.
> 
> This ensures the auto-opened drawer matches the list’s selected-kind key so the newly created/duplicated resource row highlights correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5976cf8cd21d968981ad840da4cd771f0a2ce34a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->