### PR TITLE
Fix Karpenter NodePool CPU rendering

### DIFF
--- a/packages/k8s-ui/src/components/resources/renderers/KarpenterNodePoolRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KarpenterNodePoolRenderer.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import { KarpenterNodePoolRenderer } from './KarpenterNodePoolRenderer'
+
+describe('KarpenterNodePoolRenderer', () => {
+  it('renders CPU quantities expressed as millicore strings', () => {
+    const html = renderToString(
+      <KarpenterNodePoolRenderer
+        data={{
+          spec: { limits: { cpu: '12000m' } },
+          status: { resources: { cpu: '6000m' } },
+        }}
+      />,
+    )
+
+    expect(html).toContain('6 / 12')
+  })
+
+  it('renders non-string CPU quantities without throwing', () => {
+    expect(() =>
+      renderToString(
+        <KarpenterNodePoolRenderer
+          data={{
+            spec: { limits: { cpu: 16 } },
+            status: { resources: { cpu: 12 } },
+          }}
+        />,
+      ),
+    ).not.toThrow()
+  })
+})

--- a/packages/k8s-ui/src/components/resources/renderers/KarpenterNodePoolRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KarpenterNodePoolRenderer.tsx
@@ -9,13 +9,13 @@ import {
   getNodePoolWeight,
 } from '../resource-utils-karpenter'
 
-function formatCpuCores(value: string): string {
-  // Karpenter status.resources CPU is typically in millicores (e.g. "12000m") or cores (e.g. "12")
-  if (value.endsWith('m')) {
-    const millis = parseInt(value, 10)
+function formatCpuCores(value: unknown): string {
+  const quantity = String(value)
+  if (quantity.endsWith('m')) {
+    const millis = parseInt(quantity, 10)
     if (!isNaN(millis)) return String(millis / 1000)
   }
-  return value
+  return quantity
 }
 
 


### PR DESCRIPTION
Fixes #612.

Karpenter NodePool details could blank when CPU quantities from the CRD payload were numeric instead of strings. The NodePool renderer now normalizes CPU quantities before checking for millicore suffixes, so both string and numeric values render safely.

Added render-level coverage for millicore strings and numeric CPU values.

Verification:
- npm test -- src/components/resources/renderers/KarpenterNodePoolRenderer.test.tsx
- npm run tsc
- npm test
- Live visual check against EKS us-east-1-nonprod NodePools: general-purpose and gpu-workloads both opened successfully and rendered Resource Usage as 0 / 100 and 0 / 48.