### PR TITLE
fix(helm): stop guessing upstream when chart names collide across repos

### DIFF
--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -991,6 +991,7 @@ func (c *Client) checkForUpgrade(namespace, name, username string, groups []stri
 			if latestInRepo != "" {
 				candidates = append(candidates, repoVersionInfo{
 					repoName:          r.Name,
+					repoURL:           r.URL,
 					latestVersion:     latestInRepo,
 					hasCurrentVersion: hasCurrentVersion,
 				})
@@ -998,9 +999,15 @@ func (c *Client) checkForUpgrade(namespace, name, username string, groups []stri
 		}
 	}
 
-	latestVersion, repoName := findBestUpgradeVersion(candidates)
-	if latestVersion == "" {
+	if len(candidates) == 0 {
 		info.Error = "chart not found in configured repositories"
+		return info, nil
+	}
+
+	sourceHosts := chartSourceHosts(rel.Chart.Metadata.Home, rel.Chart.Metadata.Sources)
+	latestVersion, repoName := findBestUpgradeVersion(candidates, sourceHosts)
+	if latestVersion == "" {
+		info.Error = "could not identify upstream chart repository"
 		return info, nil
 	}
 
@@ -1014,34 +1021,131 @@ func (c *Client) checkForUpgrade(namespace, name, username string, groups []stri
 // repoVersionInfo holds version information from a single repository for upgrade comparison.
 type repoVersionInfo struct {
 	repoName          string
+	repoURL           string
 	latestVersion     string
 	hasCurrentVersion bool
 }
 
-// findBestUpgradeVersion picks the best upgrade version for a chart.
-// It prefers repos that contain the currently installed version (source repo heuristic),
-// which avoids suggesting upgrades from unrelated charts that share the same name.
-func findBestUpgradeVersion(candidates []repoVersionInfo) (latestVersion, repoName string) {
-	// First: try repos that have the current version (likely the source repo)
+// findBestUpgradeVersion picks the upstream repo for a release whose chart name
+// may collide across configured repos (e.g. Bitnami ships an `argo-cd` chart
+// that's unrelated to argoproj's `argo-cd`). Tiers, in order:
+//
+//  1. A repo that lists the currently installed version — strongest signal that
+//     the release came from there. Among ties, take the highest latest.
+//  2. A repo whose URL host matches the chart's declared Home/Sources hosts.
+//     Catches the "installed version was pruned from index.yaml" case without
+//     letting an unrelated mirror win.
+//  3. Single candidate — only one configured repo lists this chart name, so
+//     there is nothing to confuse it with.
+//
+// If none of these apply we return empty strings; the caller surfaces an
+// "upstream not detected" state rather than guessing.
+func findBestUpgradeVersion(candidates []repoVersionInfo, sourceHosts []string) (latestVersion, repoName string) {
 	for _, c := range candidates {
-		if c.hasCurrentVersion {
-			if latestVersion == "" || compareVersions(c.latestVersion, latestVersion) > 0 {
-				latestVersion = c.latestVersion
-				repoName = c.repoName
-			}
+		if !c.hasCurrentVersion {
+			continue
 		}
-	}
-	if latestVersion != "" {
-		return
-	}
-	// Fallback: pick highest across all repos (stale index case)
-	for _, c := range candidates {
 		if latestVersion == "" || compareVersions(c.latestVersion, latestVersion) > 0 {
 			latestVersion = c.latestVersion
 			repoName = c.repoName
 		}
 	}
-	return
+	if latestVersion != "" {
+		return
+	}
+
+	if len(sourceHosts) > 0 {
+		for _, c := range candidates {
+			if !repoURLMatchesAny(c.repoURL, sourceHosts) {
+				continue
+			}
+			if latestVersion == "" || compareVersions(c.latestVersion, latestVersion) > 0 {
+				latestVersion = c.latestVersion
+				repoName = c.repoName
+			}
+		}
+		if latestVersion != "" {
+			return
+		}
+	}
+
+	if len(candidates) == 1 {
+		return candidates[0].latestVersion, candidates[0].repoName
+	}
+
+	return "", ""
+}
+
+// chartSourceHosts collects the hostnames (and their registered domains)
+// declared on a chart's Home and Sources URLs, used to disambiguate which
+// configured Helm repo is actually upstream when chart names collide.
+func chartSourceHosts(home string, sources []string) []string {
+	urls := make([]string, 0, 1+len(sources))
+	if home != "" {
+		urls = append(urls, home)
+	}
+	urls = append(urls, sources...)
+
+	hosts := make([]string, 0, len(urls)*2)
+	seen := make(map[string]struct{}, len(urls)*2)
+	add := func(h string) {
+		if h == "" {
+			return
+		}
+		if _, dup := seen[h]; dup {
+			return
+		}
+		seen[h] = struct{}{}
+		hosts = append(hosts, h)
+	}
+	for _, raw := range urls {
+		u, err := url.Parse(strings.TrimSpace(raw))
+		if err != nil || u.Host == "" {
+			continue
+		}
+		h := strings.ToLower(u.Hostname())
+		add(h)
+		add(registeredDomain(h))
+	}
+	return hosts
+}
+
+// repoURLMatchesAny reports whether repoURL's host (or registered domain)
+// equals any of the supplied source hosts. Coarse on purpose — the goal is
+// to reject unrelated mirrors, not RFC-correct domain matching.
+func repoURLMatchesAny(repoURL string, hosts []string) bool {
+	if repoURL == "" || len(hosts) == 0 {
+		return false
+	}
+	u, err := url.Parse(strings.TrimSpace(repoURL))
+	if err != nil || u.Host == "" {
+		return false
+	}
+	h := strings.ToLower(u.Hostname())
+	candidates := []string{h}
+	if reg := registeredDomain(h); reg != "" && reg != h {
+		candidates = append(candidates, reg)
+	}
+	for _, c := range candidates {
+		for _, want := range hosts {
+			if c == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// registeredDomain returns a coarse "registered domain" form by taking the
+// last two host labels. Doesn't consult the Public Suffix List, but matching
+// is one-shot host equality so the worst case is a missed match (Tier 2
+// falls through to Tier 3 / bail-out), never a wrong one.
+func registeredDomain(host string) string {
+	parts := strings.Split(host, ".")
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[len(parts)-2] + "." + parts[len(parts)-1]
 }
 
 // compareVersions compares two semver strings
@@ -1286,39 +1390,54 @@ func (c *Client) BatchCheckUpgradesAsUser(namespace, username string, groups []s
 }
 
 func (c *Client) batchCheckUpgrades(namespace, username string, groups []string) (*BatchUpgradeInfo, error) {
-	// Get all releases
-	releases, err := c.ListReleasesAsUser(namespace, username, groups)
+	var actionConfig *action.Configuration
+	var err error
+	if username != "" {
+		actionConfig, err = c.getActionConfigForUser(namespace, username, groups)
+	} else {
+		actionConfig, err = c.getActionConfig(namespace)
+	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to list releases: %w", err)
+		return nil, err
+	}
+
+	// We need full *release.Release objects (Chart.Metadata.Home/Sources are
+	// used for source-affinity disambiguation), so call action.NewList here
+	// instead of going through ListReleases which projects to HelmRelease.
+	listAction := action.NewList(actionConfig)
+	listAction.All = true
+	listAction.AllNamespaces = namespace == ""
+	listAction.StateMask = action.ListAll
+	releases, err := listAction.Run()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list helm releases: %w", err)
 	}
 
 	result := &BatchUpgradeInfo{
 		Releases: make(map[string]*UpgradeInfo),
 	}
-
 	if len(releases) == 0 {
 		return result, nil
 	}
 
-	// Load repo indexes once
 	repoFile := c.settings.RepositoryConfig
 	f, err := repo.LoadFile(repoFile)
 	if err != nil {
-		// No repos configured - return empty results with error
 		for _, rel := range releases {
 			key := rel.Namespace + "/" + rel.Name
 			result.Releases[key] = &UpgradeInfo{
-				CurrentVersion: rel.ChartVersion,
+				CurrentVersion: rel.Chart.Metadata.Version,
 				Error:          "no helm repositories configured",
 			}
 		}
 		return result, nil
 	}
 
-	// Build a map of chart name -> per-repo version info (including all versions for source detection)
+	// chartName -> per-repo summary; chartName -> repoName -> all versions
+	// (used to test whether a release's currently installed version is in
+	// that repo's index).
 	chartRepoVersions := make(map[string][]repoVersionInfo)
-	// Also track all available versions per chart per repo, for current-version matching
-	chartAllVersions := make(map[string]map[string][]string) // chartName -> repoName -> []versions
+	chartAllVersions := make(map[string]map[string][]string)
 
 	cacheDir := c.settings.RepositoryCache
 	for _, r := range f.Repositories {
@@ -1343,6 +1462,7 @@ func (c *Client) batchCheckUpgrades(namespace, username string, groups []string)
 
 			chartRepoVersions[chartName] = append(chartRepoVersions[chartName], repoVersionInfo{
 				repoName:      r.Name,
+				repoURL:       r.URL,
 				latestVersion: latestInRepo,
 			})
 			if chartAllVersions[chartName] == nil {
@@ -1352,30 +1472,38 @@ func (c *Client) batchCheckUpgrades(namespace, username string, groups []string)
 		}
 	}
 
-	// Check each release against the chart versions map
 	for _, rel := range releases {
 		key := rel.Namespace + "/" + rel.Name
-		info := &UpgradeInfo{
-			CurrentVersion: rel.ChartVersion,
+		currentVersion := rel.Chart.Metadata.Version
+		info := &UpgradeInfo{CurrentVersion: currentVersion}
+
+		baseCandidates, ok := chartRepoVersions[rel.Chart.Metadata.Name]
+		if !ok {
+			info.Error = "chart not found in configured repositories"
+			result.Releases[key] = info
+			continue
 		}
 
-		if candidates, ok := chartRepoVersions[rel.Chart]; ok {
-			// Mark which repos contain the current version
-			for i := range candidates {
-				if repoVersions, ok := chartAllVersions[rel.Chart][candidates[i].repoName]; ok {
-					if slices.Contains(repoVersions, rel.ChartVersion) {
-						candidates[i].hasCurrentVersion = true
-					}
-				}
+		// Per-release copy: hasCurrentVersion depends on this release's own
+		// installed version, so the shared slice must not be mutated.
+		candidates := make([]repoVersionInfo, len(baseCandidates))
+		copy(candidates, baseCandidates)
+		for i := range candidates {
+			versionsInRepo := chartAllVersions[rel.Chart.Metadata.Name][candidates[i].repoName]
+			if slices.Contains(versionsInRepo, currentVersion) {
+				candidates[i].hasCurrentVersion = true
 			}
-			latestVersion, repoName := findBestUpgradeVersion(candidates)
+		}
+
+		sourceHosts := chartSourceHosts(rel.Chart.Metadata.Home, rel.Chart.Metadata.Sources)
+		latestVersion, repoName := findBestUpgradeVersion(candidates, sourceHosts)
+		if latestVersion == "" {
+			info.Error = "could not identify upstream chart repository"
+		} else {
 			info.LatestVersion = latestVersion
 			info.RepositoryName = repoName
-			info.UpdateAvailable = compareVersions(latestVersion, rel.ChartVersion) > 0
-		} else {
-			info.Error = "chart not found in configured repositories"
+			info.UpdateAvailable = compareVersions(latestVersion, currentVersion) > 0
 		}
-
 		result.Releases[key] = info
 	}
 

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -2,8 +2,12 @@ package helm
 
 import (
 	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -25,7 +29,9 @@ import (
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/releaseutil"
 	"helm.sh/helm/v3/pkg/repo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
@@ -260,7 +266,7 @@ func (c *Client) ListReleasesAsUser(namespace, username string, groups []string)
 	if err != nil {
 		return nil, err
 	}
-	return listReleasesWith(actionConfig, namespace)
+	return listReleasesWith(actionConfig, namespace, username, groups)
 }
 
 // ListReleases returns all Helm releases, optionally filtered by namespace
@@ -269,10 +275,10 @@ func (c *Client) ListReleases(namespace string) ([]HelmRelease, error) {
 	if err != nil {
 		return nil, err
 	}
-	return listReleasesWith(actionConfig, namespace)
+	return listReleasesWith(actionConfig, namespace, "", nil)
 }
 
-func listReleasesWith(actionConfig *action.Configuration, namespace string) ([]HelmRelease, error) {
+func listReleasesWith(actionConfig *action.Configuration, namespace, username string, groups []string) ([]HelmRelease, error) {
 	listAction := action.NewList(actionConfig)
 	listAction.All = true
 	listAction.AllNamespaces = namespace == ""
@@ -283,9 +289,10 @@ func listReleasesWith(actionConfig *action.Configuration, namespace string) ([]H
 		return nil, fmt.Errorf("failed to list helm releases: %w", err)
 	}
 
+	storageNamespaces := helmReleaseStorageNamespaces(username, groups)
 	result := make([]HelmRelease, 0, len(releases))
 	for _, rel := range releases {
-		result = append(result, toHelmRelease(rel))
+		result = append(result, toHelmRelease(rel, storageNamespaces[releaseStorageKey(rel)]))
 	}
 
 	// Sort by namespace, then name
@@ -349,7 +356,7 @@ func getReleaseWith(actionConfig *action.Configuration, namespace, name string) 
 	})
 
 	// Parse manifest to get owned resources
-	resources := parseManifestResources(rel.Manifest, namespace)
+	resources := parseManifestResources(rel.Manifest, rel.Namespace)
 
 	// Enrich resources with live status from k8s cache
 	enrichResourcesWithStatus(resources)
@@ -364,21 +371,25 @@ func getReleaseWith(actionConfig *action.Configuration, namespace, name string) 
 	dependencies := extractDependencies(rel)
 
 	detail := &HelmReleaseDetail{
-		Name:         rel.Name,
-		Namespace:    rel.Namespace,
-		Chart:        rel.Chart.Metadata.Name,
-		ChartVersion: rel.Chart.Metadata.Version,
-		AppVersion:   rel.Chart.Metadata.AppVersion,
-		Status:       rel.Info.Status.String(),
-		Revision:     rel.Version,
-		Updated:      rel.Info.LastDeployed.Time,
-		Description:  rel.Info.Description,
-		Notes:        rel.Info.Notes,
-		History:      revisions,
-		Resources:    resources,
-		Hooks:        hooks,
-		Readme:       readme,
-		Dependencies: dependencies,
+		Name:             rel.Name,
+		Namespace:        rel.Namespace,
+		StorageNamespace: namespace,
+		Chart:            rel.Chart.Metadata.Name,
+		ChartVersion:     rel.Chart.Metadata.Version,
+		AppVersion:       rel.Chart.Metadata.AppVersion,
+		Status:           rel.Info.Status.String(),
+		Revision:         rel.Version,
+		Updated:          rel.Info.LastDeployed.Time,
+		Description:      rel.Info.Description,
+		Notes:            rel.Info.Notes,
+		History:          revisions,
+		Resources:        resources,
+		Hooks:            hooks,
+		Readme:           readme,
+		Dependencies:     dependencies,
+	}
+	if detail.StorageNamespace == detail.Namespace {
+		detail.StorageNamespace = ""
 	}
 
 	return detail, nil
@@ -497,17 +508,31 @@ func (c *Client) getManifestDiff(namespace, name string, revision1, revision2 in
 	}, nil
 }
 
+// releaseStorageKey identifies a release independent of where Helm stored the
+// record. Flux commonly stores the release secret in its controller namespace
+// while the release targets a different namespace.
+func releaseStorageKey(rel *release.Release) string {
+	if rel == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s/%s/%d", rel.Namespace, rel.Name, rel.Version)
+}
+
 // toHelmRelease converts a helm release to our API type
-func toHelmRelease(rel *release.Release) HelmRelease {
+func toHelmRelease(rel *release.Release, storageNamespace string) HelmRelease {
 	hr := HelmRelease{
-		Name:         rel.Name,
-		Namespace:    rel.Namespace,
-		Chart:        rel.Chart.Metadata.Name,
-		ChartVersion: rel.Chart.Metadata.Version,
-		AppVersion:   rel.Chart.Metadata.AppVersion,
-		Status:       rel.Info.Status.String(),
-		Revision:     rel.Version,
-		Updated:      rel.Info.LastDeployed.Time,
+		Name:             rel.Name,
+		Namespace:        rel.Namespace,
+		StorageNamespace: storageNamespace,
+		Chart:            rel.Chart.Metadata.Name,
+		ChartVersion:     rel.Chart.Metadata.Version,
+		AppVersion:       rel.Chart.Metadata.AppVersion,
+		Status:           rel.Info.Status.String(),
+		Revision:         rel.Version,
+		Updated:          rel.Info.LastDeployed.Time,
+	}
+	if hr.StorageNamespace == hr.Namespace {
+		hr.StorageNamespace = ""
 	}
 
 	// Compute health from owned resources
@@ -519,6 +544,67 @@ func toHelmRelease(rel *release.Release) HelmRelease {
 	hr.HealthSummary = summary
 
 	return hr
+}
+
+func helmReleaseStorageNamespaces(username string, groups []string) map[string]string {
+	var client kubernetes.Interface = k8s.GetClient()
+	if username != "" {
+		impersonated, err := k8s.ImpersonatedClient(username, groups)
+		if err != nil {
+			log.Printf("[helm] failed to build impersonated client for release storage lookup: %v", err)
+			return nil
+		}
+		client = impersonated
+	}
+	if client == nil {
+		return nil
+	}
+
+	secrets, err := client.CoreV1().Secrets("").List(context.Background(), metav1.ListOptions{
+		LabelSelector: "owner=helm",
+	})
+	if err != nil {
+		log.Printf("[helm] failed to inspect release storage namespaces: %v", err)
+		return nil
+	}
+
+	result := make(map[string]string, len(secrets.Items))
+	for _, secret := range secrets.Items {
+		encoded := secret.Data["release"]
+		if len(encoded) == 0 {
+			continue
+		}
+		rel, err := decodeHelmReleaseData(string(encoded))
+		if err != nil {
+			log.Printf("[helm] failed to decode release secret %s/%s: %v", secret.Namespace, secret.Name, err)
+			continue
+		}
+		result[releaseStorageKey(rel)] = secret.Namespace
+	}
+	return result
+}
+
+func decodeHelmReleaseData(data string) (*release.Release, error) {
+	b, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		return nil, err
+	}
+	if len(b) > 3 && bytes.Equal(b[0:3], []byte{0x1f, 0x8b, 0x08}) {
+		r, err := gzip.NewReader(bytes.NewReader(b))
+		if err != nil {
+			return nil, err
+		}
+		defer r.Close()
+		b, err = io.ReadAll(r)
+		if err != nil {
+			return nil, err
+		}
+	}
+	var rel release.Release
+	if err := json.Unmarshal(b, &rel); err != nil {
+		return nil, err
+	}
+	return &rel, nil
 }
 
 // computeResourceHealth analyzes owned resources and returns overall health status
@@ -1323,7 +1409,7 @@ func (c *Client) UpgradeWithProgress(namespace, name, targetVersion string, prog
 	if err != nil {
 		return err
 	}
-	return c.upgradeWith(actionConfig, namespace, name, targetVersion, sendProgress)
+	return c.upgradeWith(actionConfig, name, targetVersion, sendProgress)
 }
 
 // UpgradeAsUser upgrades a release with K8s impersonation.
@@ -1333,10 +1419,10 @@ func (c *Client) UpgradeAsUser(namespace, name, targetVersion string, username s
 		return err
 	}
 	noop := func(phase, message, detail string) {}
-	return c.upgradeWith(actionConfig, namespace, name, targetVersion, noop)
+	return c.upgradeWith(actionConfig, name, targetVersion, noop)
 }
 
-func (c *Client) upgradeWith(actionConfig *action.Configuration, namespace, name, targetVersion string, sendProgress func(phase, message, detail string)) error {
+func (c *Client) upgradeWith(actionConfig *action.Configuration, name, targetVersion string, sendProgress func(phase, message, detail string)) error {
 	// First, get the current release to find chart info
 	getAction := action.NewGet(actionConfig)
 	rel, err := getAction.Run(name)
@@ -1392,7 +1478,7 @@ func (c *Client) upgradeWith(actionConfig *action.Configuration, namespace, name
 	// shows real-time resource status via SSE. Waiting blocks the dialog
 	// for minutes with zero feedback; users can monitor the rollout in the UI.
 	upgradeAction := action.NewUpgrade(actionConfig)
-	upgradeAction.Namespace = namespace
+	upgradeAction.Namespace = rel.Namespace
 	upgradeAction.Timeout = 120 * time.Second
 	upgradeAction.ReuseValues = true // Keep existing values
 
@@ -1574,7 +1660,7 @@ func (c *Client) PreviewValuesChange(namespace, name string, newValues map[strin
 
 	// Perform a dry-run upgrade with the new values
 	upgradeAction := action.NewUpgrade(actionConfig)
-	upgradeAction.Namespace = namespace
+	upgradeAction.Namespace = rel.Namespace
 	upgradeAction.DryRun = true
 	upgradeAction.DryRunOption = "client"
 	upgradeAction.ResetValues = true // Use only the provided values, don't merge
@@ -1601,7 +1687,7 @@ func (c *Client) ApplyValues(namespace, name string, newValues map[string]any) e
 	if err != nil {
 		return err
 	}
-	return c.applyValuesWith(actionConfig, namespace, name, newValues)
+	return c.applyValuesWith(actionConfig, name, newValues)
 }
 
 // ApplyValuesAsUser applies values with K8s impersonation.
@@ -1610,10 +1696,10 @@ func (c *Client) ApplyValuesAsUser(namespace, name string, newValues map[string]
 	if err != nil {
 		return err
 	}
-	return c.applyValuesWith(actionConfig, namespace, name, newValues)
+	return c.applyValuesWith(actionConfig, name, newValues)
 }
 
-func (c *Client) applyValuesWith(actionConfig *action.Configuration, namespace, name string, newValues map[string]any) error {
+func (c *Client) applyValuesWith(actionConfig *action.Configuration, name string, newValues map[string]any) error {
 	// Get the current release to reuse its chart
 	getAction := action.NewGet(actionConfig)
 	rel, err := getAction.Run(name)
@@ -1623,7 +1709,7 @@ func (c *Client) applyValuesWith(actionConfig *action.Configuration, namespace, 
 
 	// Create upgrade action — no Wait, Radar shows resource status in real-time
 	upgradeAction := action.NewUpgrade(actionConfig)
-	upgradeAction.Namespace = namespace
+	upgradeAction.Namespace = rel.Namespace
 	upgradeAction.Timeout = 120 * time.Second
 	upgradeAction.ResetValues = true // Use only the provided values, don't merge
 

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -968,15 +969,13 @@ func (c *Client) checkForUpgrade(namespace, name, username string, groups []stri
 	cacheDir := c.settings.RepositoryCache
 
 	for _, r := range f.Repositories {
-		// Load the index file for this repo
 		indexPath := filepath.Join(cacheDir, fmt.Sprintf("%s-index.yaml", r.Name))
 		indexFile, err := repo.LoadIndexFile(indexPath)
 		if err != nil {
-			// Skip repos with missing/invalid index
+			log.Printf("[helm] skipping repo %q: failed to load index %s: %v", r.Name, indexPath, err)
 			continue
 		}
 
-		// Look for the chart
 		if versions, ok := indexFile.Entries[chartName]; ok {
 			var latestInRepo string
 			hasCurrentVersion := false
@@ -1076,9 +1075,11 @@ func findBestUpgradeVersion(candidates []repoVersionInfo, sourceHosts []string) 
 	return "", ""
 }
 
-// chartSourceHosts collects the hostnames (and their registered domains)
-// declared on a chart's Home and Sources URLs, used to disambiguate which
-// configured Helm repo is actually upstream when chart names collide.
+// chartSourceHosts builds the host-affinity set for a chart from its declared
+// Home and Sources URLs. Most charts on github.com don't host their helm repo
+// on github.com itself, so we also derive `<org>.github.io` from any
+// `github.com/<org>/<repo>` URL — that's what lets a release of argoproj's
+// argo-cd recognize the `argoproj.github.io` repo as upstream.
 func chartSourceHosts(home string, sources []string) []string {
 	urls := make([]string, 0, 1+len(sources))
 	if home != "" {
@@ -1106,13 +1107,44 @@ func chartSourceHosts(home string, sources []string) []string {
 		h := strings.ToLower(u.Hostname())
 		add(h)
 		add(registeredDomain(h))
+		if h == "github.com" {
+			if org := firstPathSegment(u.Path); org != "" {
+				add(org + ".github.io")
+			}
+		}
 	}
 	return hosts
 }
 
-// repoURLMatchesAny reports whether repoURL's host (or registered domain)
-// equals any of the supplied source hosts. Coarse on purpose — the goal is
-// to reject unrelated mirrors, not RFC-correct domain matching.
+// markCurrentVersion returns a copy of base with hasCurrentVersion set on
+// each candidate whose repo's index lists installedVersion. The copy matters:
+// multiple releases share the base slice (indexed by chart name), so mutating
+// it would leak one release's flags onto another with the same chart name.
+func markCurrentVersion(base []repoVersionInfo, versionsByRepo map[string][]string, installedVersion string) []repoVersionInfo {
+	out := slices.Clone(base)
+	for i := range out {
+		if slices.Contains(versionsByRepo[out[i].repoName], installedVersion) {
+			out[i].hasCurrentVersion = true
+		}
+	}
+	return out
+}
+
+// firstPathSegment returns the first non-empty path segment lowercased,
+// e.g. "/argoproj/argo-helm" → "argoproj".
+func firstPathSegment(p string) string {
+	p = strings.Trim(p, "/")
+	if p == "" {
+		return ""
+	}
+	if i := strings.Index(p, "/"); i > 0 {
+		return strings.ToLower(p[:i])
+	}
+	return strings.ToLower(p)
+}
+
+// repoURLMatchesAny is coarse on purpose: reject unrelated mirrors, not
+// RFC-correct domain matching.
 func repoURLMatchesAny(repoURL string, hosts []string) bool {
 	if repoURL == "" || len(hosts) == 0 {
 		return false
@@ -1136,16 +1168,31 @@ func repoURLMatchesAny(repoURL string, hosts []string) bool {
 	return false
 }
 
-// registeredDomain returns a coarse "registered domain" form by taking the
-// last two host labels. Doesn't consult the Public Suffix List, but matching
-// is one-shot host equality so the worst case is a missed match (Tier 2
-// falls through to Tier 3 / bail-out), never a wrong one.
+// multiTenantSuffixes are two-label hosts where the registered-domain
+// fallback would produce false positives (every project hosts on the same
+// suffix). We treat the full host as the matching unit instead.
+var multiTenantSuffixes = map[string]bool{
+	"github.io": true,
+	"gitlab.io": true,
+}
+
+// registeredDomain returns the last two host labels (e.g. "charts.bitnami.com"
+// → "bitnami.com"), used as a fallback for source-affinity matching. Returns
+// "" for IP literals and for known multi-tenant suffixes (github.io etc.)
+// where the last two labels would collapse unrelated projects together.
 func registeredDomain(host string) string {
+	if host == "" || net.ParseIP(host) != nil {
+		return ""
+	}
 	parts := strings.Split(host, ".")
 	if len(parts) < 2 {
 		return ""
 	}
-	return parts[len(parts)-2] + "." + parts[len(parts)-1]
+	candidate := parts[len(parts)-2] + "." + parts[len(parts)-1]
+	if multiTenantSuffixes[candidate] {
+		return ""
+	}
+	return candidate
 }
 
 // compareVersions compares two semver strings
@@ -1398,7 +1445,7 @@ func (c *Client) batchCheckUpgrades(namespace, username string, groups []string)
 		actionConfig, err = c.getActionConfig(namespace)
 	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to build helm action config: %w", err)
 	}
 
 	// We need full *release.Release objects (Chart.Metadata.Home/Sources are
@@ -1433,9 +1480,9 @@ func (c *Client) batchCheckUpgrades(namespace, username string, groups []string)
 		return result, nil
 	}
 
-	// chartName -> per-repo summary; chartName -> repoName -> all versions
-	// (used to test whether a release's currently installed version is in
-	// that repo's index).
+	// Split into two maps: latest-per-repo drives ranking; per-repo full
+	// version lists let us detect whether a release's installed version
+	// (which may not be the latest) is present in that repo's index.
 	chartRepoVersions := make(map[string][]repoVersionInfo)
 	chartAllVersions := make(map[string]map[string][]string)
 
@@ -1444,6 +1491,7 @@ func (c *Client) batchCheckUpgrades(namespace, username string, groups []string)
 		indexPath := filepath.Join(cacheDir, fmt.Sprintf("%s-index.yaml", r.Name))
 		indexFile, err := repo.LoadIndexFile(indexPath)
 		if err != nil {
+			log.Printf("[helm] skipping repo %q: failed to load index %s: %v", r.Name, indexPath, err)
 			continue
 		}
 
@@ -1484,17 +1532,7 @@ func (c *Client) batchCheckUpgrades(namespace, username string, groups []string)
 			continue
 		}
 
-		// Per-release copy: hasCurrentVersion depends on this release's own
-		// installed version, so the shared slice must not be mutated.
-		candidates := make([]repoVersionInfo, len(baseCandidates))
-		copy(candidates, baseCandidates)
-		for i := range candidates {
-			versionsInRepo := chartAllVersions[rel.Chart.Metadata.Name][candidates[i].repoName]
-			if slices.Contains(versionsInRepo, currentVersion) {
-				candidates[i].hasCurrentVersion = true
-			}
-		}
-
+		candidates := markCurrentVersion(baseCandidates, chartAllVersions[rel.Chart.Metadata.Name], currentVersion)
 		sourceHosts := chartSourceHosts(rel.Chart.Metadata.Home, rel.Chart.Metadata.Sources)
 		latestVersion, repoName := findBestUpgradeVersion(candidates, sourceHosts)
 		if latestVersion == "" {

--- a/internal/helm/client_test.go
+++ b/internal/helm/client_test.go
@@ -4,10 +4,11 @@ import "testing"
 
 func TestFindBestUpgradeVersion(t *testing.T) {
 	tests := []struct {
-		name            string
-		candidates      []repoVersionInfo
-		wantVersion     string
-		wantRepo        string
+		name        string
+		candidates  []repoVersionInfo
+		sourceHosts []string
+		wantVersion string
+		wantRepo    string
 	}{
 		{
 			name:        "no candidates returns empty",
@@ -33,15 +34,6 @@ func TestFindBestUpgradeVersion(t *testing.T) {
 			wantRepo:    "metallb",
 		},
 		{
-			name: "multiple repos none has current version - falls back to highest",
-			candidates: []repoVersionInfo{
-				{repoName: "bitnami", latestVersion: "6.4.22", hasCurrentVersion: false},
-				{repoName: "metallb", latestVersion: "0.15.3", hasCurrentVersion: false},
-			},
-			wantVersion: "6.4.22",
-			wantRepo:    "bitnami",
-		},
-		{
 			name: "multiple repos both have current version - picks highest among them",
 			candidates: []repoVersionInfo{
 				{repoName: "repo-a", latestVersion: "2.0.0", hasCurrentVersion: true},
@@ -59,16 +51,131 @@ func TestFindBestUpgradeVersion(t *testing.T) {
 			wantVersion: "1.2.0",
 			wantRepo:    "official",
 		},
+		{
+			name: "ambiguous chart-name collision without affinity - bail out",
+			candidates: []repoVersionInfo{
+				{repoName: "bitnami", latestVersion: "6.4.22", hasCurrentVersion: false, repoURL: "https://charts.bitnami.com/bitnami"},
+				{repoName: "argo", latestVersion: "8.5.0", hasCurrentVersion: false, repoURL: "https://argoproj.github.io/argo-helm"},
+			},
+			wantVersion: "",
+			wantRepo:    "",
+		},
+		{
+			name: "single candidate without current version - accept (stale index case)",
+			candidates: []repoVersionInfo{
+				{repoName: "argo", latestVersion: "8.5.0", hasCurrentVersion: false, repoURL: "https://argoproj.github.io/argo-helm"},
+			},
+			wantVersion: "8.5.0",
+			wantRepo:    "argo",
+		},
+		{
+			name: "source-affinity host match picks correct repo",
+			candidates: []repoVersionInfo{
+				{repoName: "bitnami", latestVersion: "6.4.22", hasCurrentVersion: false, repoURL: "https://charts.bitnami.com/bitnami"},
+				{repoName: "argo", latestVersion: "8.5.0", hasCurrentVersion: false, repoURL: "https://argoproj.github.io/argo-helm"},
+			},
+			sourceHosts: []string{"argoproj.github.io"},
+			wantVersion: "8.5.0",
+			wantRepo:    "argo",
+		},
+		{
+			name: "source-affinity registered-domain match (charts.bitnami.com vs bitnami.com)",
+			candidates: []repoVersionInfo{
+				{repoName: "bitnami", latestVersion: "12.0.0", hasCurrentVersion: false, repoURL: "https://charts.bitnami.com/bitnami"},
+				{repoName: "argo", latestVersion: "8.5.0", hasCurrentVersion: false, repoURL: "https://argoproj.github.io/argo-helm"},
+			},
+			sourceHosts: []string{"bitnami.com"},
+			wantVersion: "12.0.0",
+			wantRepo:    "bitnami",
+		},
+		{
+			name: "source-affinity hosts present but none match - bail out",
+			candidates: []repoVersionInfo{
+				{repoName: "bitnami", latestVersion: "6.4.22", hasCurrentVersion: false, repoURL: "https://charts.bitnami.com/bitnami"},
+				{repoName: "argo", latestVersion: "8.5.0", hasCurrentVersion: false, repoURL: "https://argoproj.github.io/argo-helm"},
+			},
+			sourceHosts: []string{"github.com"}, // chart-declared, but not the repo's host
+			wantVersion: "",
+			wantRepo:    "",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotVersion, gotRepo := findBestUpgradeVersion(tt.candidates)
+			gotVersion, gotRepo := findBestUpgradeVersion(tt.candidates, tt.sourceHosts)
 			if gotVersion != tt.wantVersion {
 				t.Errorf("findBestUpgradeVersion() version = %q, want %q", gotVersion, tt.wantVersion)
 			}
 			if gotRepo != tt.wantRepo {
 				t.Errorf("findBestUpgradeVersion() repo = %q, want %q", gotRepo, tt.wantRepo)
+			}
+		})
+	}
+}
+
+func TestChartSourceHosts(t *testing.T) {
+	tests := []struct {
+		name    string
+		home    string
+		sources []string
+		want    []string
+	}{
+		{
+			name: "empty inputs",
+			want: nil,
+		},
+		{
+			name: "bitnami home only",
+			home: "https://bitnami.com",
+			want: []string{"bitnami.com"},
+		},
+		{
+			name:    "subdomain expands to registered domain",
+			home:    "https://charts.bitnami.com",
+			want:    []string{"charts.bitnami.com", "bitnami.com"},
+		},
+		{
+			name:    "deduplicates across home and sources",
+			home:    "https://github.com/argoproj/argo-helm",
+			sources: []string{"https://github.com/argoproj/argo-cd"},
+			want:    []string{"github.com"},
+		},
+		{
+			name:    "skips invalid urls",
+			sources: []string{"not a url", "ftp://", ""},
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := chartSourceHosts(tt.home, tt.sources)
+			if !equalStringSlices(got, tt.want) {
+				t.Errorf("chartSourceHosts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRepoURLMatchesAny(t *testing.T) {
+	tests := []struct {
+		name    string
+		repoURL string
+		hosts   []string
+		want    bool
+	}{
+		{name: "empty repo url", repoURL: "", hosts: []string{"bitnami.com"}, want: false},
+		{name: "empty hosts", repoURL: "https://charts.bitnami.com", hosts: nil, want: false},
+		{name: "exact host match", repoURL: "https://argoproj.github.io/argo-helm", hosts: []string{"argoproj.github.io"}, want: true},
+		{name: "registered-domain match", repoURL: "https://charts.bitnami.com/bitnami", hosts: []string{"bitnami.com"}, want: true},
+		{name: "no match", repoURL: "https://charts.bitnami.com", hosts: []string{"argoproj.github.io"}, want: false},
+		{name: "invalid url", repoURL: "://broken", hosts: []string{"bitnami.com"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := repoURLMatchesAny(tt.repoURL, tt.hosts); got != tt.want {
+				t.Errorf("repoURLMatchesAny(%q, %v) = %v, want %v", tt.repoURL, tt.hosts, got, tt.want)
 			}
 		})
 	}
@@ -95,4 +202,16 @@ func TestCompareVersions(t *testing.T) {
 			}
 		})
 	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/helm/client_test.go
+++ b/internal/helm/client_test.go
@@ -1,6 +1,12 @@
 package helm
 
-import "testing"
+import (
+	"testing"
+
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/release"
+	helmtime "helm.sh/helm/v3/pkg/time"
+)
 
 func TestFindBestUpgradeVersion(t *testing.T) {
 	tests := []struct {
@@ -221,6 +227,36 @@ func TestMarkCurrentVersion_DoesNotMutateBaseOrLeakAcrossReleases(t *testing.T) 
 	}
 	if base[0].hasCurrentVersion || base[1].hasCurrentVersion {
 		t.Errorf("base slice was mutated; per-release flags would leak across releases sharing a chart name: %+v", base)
+	}
+}
+
+func TestToHelmRelease_StorageNamespace(t *testing.T) {
+	rel := &release.Release{
+		Name:      "podinfo",
+		Namespace: "demo-flux-helm",
+		Version:   1,
+		Info: &release.Info{
+			Status:       release.StatusDeployed,
+			LastDeployed: helmtime.Unix(0, 0),
+		},
+		Chart: &chart.Chart{Metadata: &chart.Metadata{
+			Name:       "podinfo",
+			Version:    "6.11.2",
+			AppVersion: "6.11.2",
+		}},
+	}
+
+	same := toHelmRelease(rel, "demo-flux-helm")
+	if same.StorageNamespace != "" {
+		t.Fatalf("same storage namespace should be omitted, got %q", same.StorageNamespace)
+	}
+
+	different := toHelmRelease(rel, "flux-system")
+	if different.Namespace != "demo-flux-helm" {
+		t.Fatalf("target namespace changed: got %q", different.Namespace)
+	}
+	if different.StorageNamespace != "flux-system" {
+		t.Fatalf("storage namespace = %q, want flux-system", different.StorageNamespace)
 	}
 }
 

--- a/internal/helm/client_test.go
+++ b/internal/helm/client_test.go
@@ -130,15 +130,30 @@ func TestChartSourceHosts(t *testing.T) {
 			want: []string{"bitnami.com"},
 		},
 		{
-			name:    "subdomain expands to registered domain",
-			home:    "https://charts.bitnami.com",
-			want:    []string{"charts.bitnami.com", "bitnami.com"},
+			name: "subdomain expands to registered domain",
+			home: "https://charts.bitnami.com",
+			want: []string{"charts.bitnami.com", "bitnami.com"},
 		},
 		{
 			name:    "deduplicates across home and sources",
 			home:    "https://github.com/argoproj/argo-helm",
 			sources: []string{"https://github.com/argoproj/argo-cd"},
-			want:    []string{"github.com"},
+			want:    []string{"github.com", "argoproj.github.io"},
+		},
+		{
+			name: "argo-cd realistic chart metadata derives argoproj.github.io",
+			home: "https://github.com/argoproj/argo-helm",
+			want: []string{"github.com", "argoproj.github.io"},
+		},
+		{
+			name: "github.io chart home does not seed bare github.io (multi-tenant)",
+			home: "https://argoproj.github.io",
+			want: []string{"argoproj.github.io"},
+		},
+		{
+			name: "ipv4 host does not seed a bogus registered domain",
+			home: "http://127.0.0.1:8080/charts",
+			want: []string{"127.0.0.1"},
 		},
 		{
 			name:    "skips invalid urls",
@@ -169,6 +184,10 @@ func TestRepoURLMatchesAny(t *testing.T) {
 		{name: "exact host match", repoURL: "https://argoproj.github.io/argo-helm", hosts: []string{"argoproj.github.io"}, want: true},
 		{name: "registered-domain match", repoURL: "https://charts.bitnami.com/bitnami", hosts: []string{"bitnami.com"}, want: true},
 		{name: "no match", repoURL: "https://charts.bitnami.com", hosts: []string{"argoproj.github.io"}, want: false},
+		{name: "github.io is multi-tenant: unrelated github.io repos do not match each other", repoURL: "https://kubernetes-sigs.github.io/external-dns", hosts: []string{"argoproj.github.io"}, want: false},
+		{name: "oci registry host match", repoURL: "oci://registry-1.docker.io/bitnamicharts/argo-cd", hosts: []string{"docker.io"}, want: true},
+		{name: "https with explicit port", repoURL: "https://charts.example.com:8443/charts", hosts: []string{"example.com"}, want: true},
+		{name: "https with userinfo", repoURL: "https://user:pass@charts.bitnami.com/bitnami", hosts: []string{"bitnami.com"}, want: true},
 		{name: "invalid url", repoURL: "://broken", hosts: []string{"bitnami.com"}, want: false},
 	}
 
@@ -178,6 +197,30 @@ func TestRepoURLMatchesAny(t *testing.T) {
 				t.Errorf("repoURLMatchesAny(%q, %v) = %v, want %v", tt.repoURL, tt.hosts, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestMarkCurrentVersion_DoesNotMutateBaseOrLeakAcrossReleases(t *testing.T) {
+	base := []repoVersionInfo{
+		{repoName: "bitnami", latestVersion: "20.0.0"},
+		{repoName: "argo", latestVersion: "8.5.0"},
+	}
+	versions := map[string][]string{
+		"bitnami": {"19.0.0", "20.0.0"},
+		"argo":    {"8.4.0", "8.5.0"},
+	}
+
+	a := markCurrentVersion(base, versions, "20.0.0")
+	b := markCurrentVersion(base, versions, "8.5.0")
+
+	if !a[0].hasCurrentVersion || a[1].hasCurrentVersion {
+		t.Errorf("release A: bitnami should match, argo should not; got %+v", a)
+	}
+	if b[0].hasCurrentVersion || !b[1].hasCurrentVersion {
+		t.Errorf("release B: argo should match, bitnami should not; got %+v", b)
+	}
+	if base[0].hasCurrentVersion || base[1].hasCurrentVersion {
+		t.Errorf("base slice was mutated; per-release flags would leak across releases sharing a chart name: %+v", base)
 	}
 }
 

--- a/internal/helm/types.go
+++ b/internal/helm/types.go
@@ -6,14 +6,15 @@ import (
 
 // HelmRelease represents a Helm release in the list view
 type HelmRelease struct {
-	Name         string    `json:"name"`
-	Namespace    string    `json:"namespace"`
-	Chart        string    `json:"chart"`
-	ChartVersion string    `json:"chartVersion"`
-	AppVersion   string    `json:"appVersion"`
-	Status       string    `json:"status"`
-	Revision     int       `json:"revision"`
-	Updated      time.Time `json:"updated"`
+	Name             string    `json:"name"`
+	Namespace        string    `json:"namespace"`
+	StorageNamespace string    `json:"storageNamespace,omitempty"`
+	Chart            string    `json:"chart"`
+	ChartVersion     string    `json:"chartVersion"`
+	AppVersion       string    `json:"appVersion"`
+	Status           string    `json:"status"`
+	Revision         int       `json:"revision"`
+	Updated          time.Time `json:"updated"`
 	// Health summary from owned resources
 	ResourceHealth string `json:"resourceHealth,omitempty"` // healthy, degraded, unhealthy, unknown
 	HealthIssue    string `json:"healthIssue,omitempty"`    // Primary issue if unhealthy (e.g., "OOMKilled")
@@ -32,21 +33,22 @@ type HelmRevision struct {
 
 // HelmReleaseDetail contains full details of a Helm release
 type HelmReleaseDetail struct {
-	Name         string            `json:"name"`
-	Namespace    string            `json:"namespace"`
-	Chart        string            `json:"chart"`
-	ChartVersion string            `json:"chartVersion"`
-	AppVersion   string            `json:"appVersion"`
-	Status       string            `json:"status"`
-	Revision     int               `json:"revision"`
-	Updated      time.Time         `json:"updated"`
-	Description  string            `json:"description"`
-	Notes        string            `json:"notes"`
-	History      []HelmRevision    `json:"history"`
-	Resources    []OwnedResource   `json:"resources"`
-	Hooks        []HelmHook        `json:"hooks,omitempty"`
-	Readme       string            `json:"readme,omitempty"`
-	Dependencies []ChartDependency `json:"dependencies,omitempty"`
+	Name             string            `json:"name"`
+	Namespace        string            `json:"namespace"`
+	StorageNamespace string            `json:"storageNamespace,omitempty"`
+	Chart            string            `json:"chart"`
+	ChartVersion     string            `json:"chartVersion"`
+	AppVersion       string            `json:"appVersion"`
+	Status           string            `json:"status"`
+	Revision         int               `json:"revision"`
+	Updated          time.Time         `json:"updated"`
+	Description      string            `json:"description"`
+	Notes            string            `json:"notes"`
+	History          []HelmRevision    `json:"history"`
+	Resources        []OwnedResource   `json:"resources"`
+	Hooks            []HelmHook        `json:"hooks,omitempty"`
+	Readme           string            `json:"readme,omitempty"`
+	Dependencies     []ChartDependency `json:"dependencies,omitempty"`
 }
 
 // HelmHook represents a Helm hook (pre/post install, upgrade, etc.)

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -439,6 +439,7 @@ export interface APIResource {
 export interface HelmRelease {
   name: string
   namespace: string
+  storageNamespace?: string
   chart: string
   chartVersion: string
   appVersion: string
@@ -463,6 +464,7 @@ export interface HelmRevision {
 export interface HelmReleaseDetail {
   name: string
   namespace: string
+  storageNamespace?: string
   chart: string
   chartVersion: string
   appVersion: string
@@ -520,6 +522,7 @@ export interface ManifestDiff {
 export interface SelectedHelmRelease {
   namespace: string
   name: string
+  storageNamespace?: string
 }
 
 // Upgrade availability info

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -676,7 +676,7 @@ function AppInner() {
       if (slashIdx > 0) {
         const ns = releaseParam.slice(0, slashIdx)
         const name = releaseParam.slice(slashIdx + 1)
-        setSelectedHelmRelease({ namespace: ns, name })
+        setSelectedHelmRelease({ namespace: ns, name, storageNamespace: searchParams.get('releaseStorage') || undefined })
       }
     }
   }, [searchParams])
@@ -1220,10 +1220,15 @@ function AppInner() {
           <HelmView
             namespace=""
             selectedRelease={selectedHelmRelease}
-            onReleaseClick={(ns, name) => {
-              setSelectedHelmRelease({ namespace: ns, name })
+            onReleaseClick={(ns, name, storageNamespace) => {
+              setSelectedHelmRelease({ namespace: ns, name, storageNamespace })
               const params = new URLSearchParams(window.location.search)
               params.set('release', `${ns}/${name}`)
+              if (storageNamespace) {
+                params.set('releaseStorage', storageNamespace)
+              } else {
+                params.delete('releaseStorage')
+              }
               setSearchParams(params, { replace: true })
             }}
           />
@@ -1305,6 +1310,7 @@ function AppInner() {
             setSelectedHelmRelease(null)
             const params = new URLSearchParams(window.location.search)
             params.delete('release')
+            params.delete('releaseStorage')
             setSearchParams(params, { replace: true })
           }}
           onNavigateToResource={(resource) => {

--- a/web/src/components/helm/HelmReleaseDrawer.tsx
+++ b/web/src/components/helm/HelmReleaseDrawer.tsx
@@ -56,16 +56,17 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
   // transient error state under the role-gated panel.
   const { canAtLeast } = useCloudRole()
   const canViewSensitive = canAtLeast('member')
+  const helmNamespace = release.storageNamespace || release.namespace
 
   const { data: releaseDetail, isLoading, refetch: refetchRelease } = useHelmRelease(
-    release.namespace,
+    helmNamespace,
     release.name
   )
   const [refetch, isRefreshAnimating] = useRefreshAnimation(refetchRelease)
 
   // Fetch manifest for selected revision (or latest)
   const { data: manifest, isLoading: manifestLoading } = useHelmManifest(
-    release.namespace,
+    helmNamespace,
     release.name,
     selectedRevision,
     canViewSensitive,
@@ -73,7 +74,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
 
   // Fetch values
   const { data: values, isLoading: valuesLoading } = useHelmValues(
-    release.namespace,
+    helmNamespace,
     release.name,
     showAllValues,
     canViewSensitive,
@@ -81,7 +82,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
 
   // Fetch diff if comparing revisions
   const { data: diffData, isLoading: diffLoading } = useHelmManifestDiff(
-    release.namespace,
+    helmNamespace,
     release.name,
     diffRevisions?.rev1 || 0,
     diffRevisions?.rev2 || 0,
@@ -90,7 +91,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
 
   // Lazy check for upgrade availability
   const { data: upgradeInfo, isLoading: upgradeLoading } = useHelmUpgradeInfo(
-    release.namespace,
+    helmNamespace,
     release.name
   )
 
@@ -176,7 +177,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
 
     try {
       await rollbackWithProgress(
-        release.namespace,
+        helmNamespace,
         release.name,
         rollbackRevision,
         (event) => {
@@ -195,7 +196,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
       }])
 
       queryClient.invalidateQueries({ queryKey: ['helm-releases'] })
-      queryClient.invalidateQueries({ queryKey: ['helm-release', release.namespace, release.name] })
+      queryClient.invalidateQueries({ queryKey: ['helm-release', helmNamespace, release.name] })
 
       setTimeout(() => {
         setRollbackRevision(null)
@@ -215,7 +216,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
 
   const handleUninstallConfirm = () => {
     uninstallMutation.mutate(
-      { namespace: release.namespace, name: release.name },
+      { namespace: helmNamespace, name: release.name },
       {
         onSuccess: () => {
           setShowUninstallConfirm(false)
@@ -235,7 +236,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
 
     try {
       await upgradeWithProgress(
-        release.namespace,
+        helmNamespace,
         release.name,
         upgradeInfo.latestVersion,
         (event) => {
@@ -255,8 +256,8 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
 
       // Invalidate queries
       queryClient.invalidateQueries({ queryKey: ['helm-releases'] })
-      queryClient.invalidateQueries({ queryKey: ['helm-release', release.namespace, release.name] })
-      queryClient.invalidateQueries({ queryKey: ['helm-upgrade-info', release.namespace, release.name] })
+      queryClient.invalidateQueries({ queryKey: ['helm-release', helmNamespace, release.name] })
+      queryClient.invalidateQueries({ queryKey: ['helm-upgrade-info', helmNamespace, release.name] })
       queryClient.invalidateQueries({ queryKey: ['helm-batch-upgrade-info'] })
 
       setTimeout(() => {
@@ -457,7 +458,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
                   onToggleAllValues={setShowAllValues}
                   onCopy={(text) => copyToClipboard(text, 'values')}
                   copied={copied === 'values'}
-                  namespace={release.namespace}
+                  namespace={helmNamespace}
                   name={release.name}
                   onApplySuccess={() => refetch()}
                 />

--- a/web/src/components/helm/HelmReleaseDrawer.tsx
+++ b/web/src/components/helm/HelmReleaseDrawer.tsx
@@ -344,6 +344,13 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
               <span className={clsx('badge', SEVERITY_BADGE.success)} title="Chart is up to date">
                 latest
               </span>
+            ) : upgradeInfo?.error ? (
+              <span
+                className="badge bg-theme-hover/50 text-theme-text-secondary"
+                title={upgradeInfo.error}
+              >
+                upstream unknown
+              </span>
             ) : null}
           </div>
           <div className="flex items-center gap-1">

--- a/web/src/components/helm/HelmView.tsx
+++ b/web/src/components/helm/HelmView.tsx
@@ -17,7 +17,7 @@ type ViewTab = 'releases' | 'charts'
 interface HelmViewProps {
   namespace: string
   selectedRelease?: SelectedHelmRelease | null
-  onReleaseClick?: (namespace: string, name: string) => void
+  onReleaseClick?: (namespace: string, name: string, storageNamespace?: string) => void
 }
 
 export function HelmView({ namespace, selectedRelease, onReleaseClick }: HelmViewProps) {
@@ -132,7 +132,7 @@ export function HelmView({ namespace, selectedRelease, onReleaseClick }: HelmVie
       scope: 'helm',
       handler: () => {
         const release = getHighlightedRelease()
-        if (release) onReleaseClick?.(release.namespace, release.name)
+        if (release) onReleaseClick?.(release.namespace, release.name, release.storageNamespace)
       },
       enabled: highlightedIndex >= 0,
     },
@@ -300,7 +300,7 @@ export function HelmView({ namespace, selectedRelease, onReleaseClick }: HelmVie
                           selectedRelease?.name === release.name
                         }
                         isHighlighted={index === highlightedIndex}
-                        onClick={() => onReleaseClick?.(release.namespace, release.name)}
+                        onClick={() => onReleaseClick?.(release.namespace, release.name, release.storageNamespace)}
                         onMouseEnter={() => setHighlightedIndex(-1)}
                       />
                     ))}


### PR DESCRIPTION
Closes #629.

## What was happening

Radar's "latest version" / "upgrade available" indicator on a Helm release picked the highest version across every configured repo that happened to ship a chart with the same name. So a user with `bitnami` and `argo` both configured saw Bitnami's unrelated `argo-cd` chart presented as the upstream of an argoproj release — wrong version, wrong repo in the tooltip, and an upgrade pill that would have downgraded across providers.

During visual testing we also found a related Helm drawer bug with Flux-managed releases: Flux can store Helm release secrets in its controller namespace (`flux-system`) while the release targets another namespace (`demo-flux-helm`). Radar listed the target namespace, then used it for Helm detail lookups, which made the drawer show "Release not found" even though Helm could read the release from its storage namespace.

## What changed

`findBestUpgradeVersion` now selects in three explicit tiers, with no silent cross-repo fallback:

1. A repo whose `index.yaml` lists the currently installed version.
2. A repo whose URL host (or registered domain) matches one of the chart's declared `Home` / `Sources` hosts. For `github.com/<org>/<repo>` URLs we also derive `<org>.github.io` as a synthetic host — that's what makes the canonical argo-cd case (chart Home on `github.com/argoproj/...`, helm repo on `argoproj.github.io`) actually pick the right upstream.
3. A single candidate — when only one configured repo lists the chart name, there's no ambiguity.

If none apply, the result is empty and the response carries `error: "could not identify upstream chart repository"`. The drawer renders a muted "upstream unknown" chip with the actual reason as a tooltip — distinguishable from a genuinely up-to-date release without being alarming.

For Flux-managed releases, list responses now include `storageNamespace` when it differs from the release's target namespace. The UI still displays the target namespace, but uses the storage namespace for detail/manifest/values/upgrade-info and Helm actions. Upgrade/apply-values set the Helm action target namespace from the loaded release so storage-namespace lookup does not retarget writes.

## Notable details

- `registeredDomain` skips IP literals and a small denylist of multi-tenant suffixes (`github.io`, `gitlab.io`) where the last two labels would collapse unrelated projects together.
- Refactored `batchCheckUpgrades` to call `action.NewList` directly so it has access to `*release.Release` (and thus `Chart.Metadata.Home`/`Sources`); the previous code went through `ListReleases`, which discarded that info.
- Extracted `markCurrentVersion` and added a regression test pinning the per-release slice-copy invariant. Without it, `hasCurrentVersion` flags would leak across releases that share a chart name.
- Index-load failures are now logged with `[helm]` context so operators can diagnose stale-index cases.

## Tests

`internal/helm/client_test.go` covers all three tiers, including the bail-out, the realistic argo-cd metadata flow, GitHub-Pages multi-tenancy negative cases, OCI/port/userinfo URL parsing, IPv4 host handling, the slice-copy invariant, and storage namespace emission.

Local verification:

- `go test ./...`
- `go test ./internal/helm`
- `cd web && npx tsc --noEmit`
- Live upgrade collision check: installed `argo/argo-cd` `9.5.10` while both `argo` (`9.5.11`) and `bitnami` (`11.0.0`) repos were configured; Radar returned `latestVersion: "9.5.11"` and `repositoryName: "argo"`.
- `/visual-test` against the Flux-managed `podinfo` release now opens the Helm drawer successfully with no console errors. Screenshot: `helm-flux-storage-drawer.png` from the visual-test run.