### PR TITLE
feat(navigation): add keyboard shortcuts 'n' and 'c' for switching namespace and context

### DIFF
--- a/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
+++ b/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
@@ -4,6 +4,8 @@ import {
   useMemo,
   useRef,
   useState,
+  forwardRef,
+  useImperativeHandle,
 } from 'react'
 import { ChevronDown, Check, Loader2, Search, Server, X } from 'lucide-react'
 import { ClusterName } from '../ui/ClusterName'
@@ -25,6 +27,10 @@ export interface ClusterSwitcherItem {
    *  ClusterName supplies its own tooltip for the cluster name itself; this
    *  is for row-level affordances (e.g. "Cluster offline — reconnect…"). */
   title?: string
+}
+
+export interface ClusterSwitcherHandle {
+  open: () => void
 }
 
 export interface ClusterSwitcherProps {
@@ -54,7 +60,7 @@ export interface ClusterSwitcherProps {
 // full — comfortably covering parsed cluster names from any provider.
 const TRIGGER_NAME_MAX_WIDTH = 'max-w-[160px] sm:max-w-[260px] xl:max-w-[400px]'
 
-export function ClusterSwitcher({
+export const ClusterSwitcher = forwardRef<ClusterSwitcherHandle, ClusterSwitcherProps>(({
   currentId,
   currentName,
   items,
@@ -69,12 +75,18 @@ export function ClusterSwitcher({
   errorSlot,
   className = '',
   align = 'left',
-}: ClusterSwitcherProps) {
+}, ref) => {
   const [isOpen, setIsOpen] = useState(false)
   const [search, setSearch] = useState('')
   const [highlightedIndex, setHighlightedIndex] = useState(-1)
   const rootRef = useRef<HTMLDivElement>(null)
   const searchInputRef = useRef<HTMLInputElement>(null)
+
+  useImperativeHandle(ref, () => ({
+    open: () => {
+      if (!disabled && !loading) setIsOpen(true)
+    }
+  }), [disabled, loading])
 
   const groups = useMemo(() => {
     const q = search.trim().toLowerCase()
@@ -344,4 +356,4 @@ export function ClusterSwitcher({
       )}
     </div>
   )
-}
+})

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -28,7 +28,7 @@ import { ConnectionErrorView } from './components/ConnectionErrorView'
 import { CapabilitiesProvider, useCapabilitiesContext } from './contexts/CapabilitiesContext'
 import { UserMenu } from './components/UserMenu'
 import { ErrorBoundary } from './components/ui/ErrorBoundary'
-import { NamespaceSelector } from './components/ui/NamespaceSelector'
+import { NamespaceSelector, type NamespaceSelectorHandle } from './components/ui/NamespaceSelector'
 import { UpdateNotification } from './components/ui/UpdateNotification'
 import { ShortcutHelpOverlay } from './components/ui/ShortcutHelpOverlay'
 import { CommandPalette } from './components/ui/CommandPalette'
@@ -45,6 +45,7 @@ import { Tooltip } from './components/ui/Tooltip'
 import { SettingsDialog } from './components/settings/SettingsDialog'
 import type { TopologyNode, GroupingMode, MainView, SelectedResource, SelectedHelmRelease, NodeKind, TopologyMode, Topology, K8sEvent } from './types'
 import { kindToPlural, openExternal } from './utils/navigation'
+import type { ContextSwitcherHandle } from './components/ContextSwitcher'
 
 // All possible node kinds (core + GitOps)
 const ALL_NODE_KINDS: NodeKind[] = [
@@ -370,6 +371,10 @@ function AppInner() {
   // Context switching for command palette
   const switchContext = useSwitchContext()
 
+  // Refs for dropdown components to trigger them via shortcuts
+  const namespaceSelectorRef = useRef<NamespaceSelectorHandle>(null)
+  const contextSwitcherRef = useRef<ContextSwitcherHandle>(null)
+
   // View switching keyboard shortcuts
   const views: ExtendedMainView[] = ['home', 'topology', 'resources', 'timeline', 'helm', 'traffic', 'cost', 'audit']
   useRegisterShortcuts([
@@ -381,6 +386,22 @@ function AppInner() {
       scope: 'global' as const,
       handler: () => setMainView(view),
     })),
+    {
+      id: 'switch-namespace',
+      keys: 'n',
+      description: 'Switch namespace',
+      category: 'Navigation' as const,
+      scope: 'global' as const,
+      handler: () => namespaceSelectorRef.current?.open(),
+    },
+    {
+      id: 'switch-context',
+      keys: 'c',
+      description: 'Switch context',
+      category: 'Navigation' as const,
+      scope: 'global' as const,
+      handler: () => contextSwitcherRef.current?.open(),
+    },
     {
       id: 'theme-toggle',
       keys: 't',
@@ -797,7 +818,7 @@ function AppInner() {
           {navCustomization.brandSlot ?? <Logo />}
 
           <div className="flex items-center gap-2">
-            {navCustomization.contextSlot ?? <ContextSwitcher />}
+            {navCustomization.contextSlot ?? <ContextSwitcher ref={contextSwitcherRef} />}
             {/* Connection status - next to cluster name */}
             <div className="flex items-center gap-1.5 ml-1">
               <Tooltip
@@ -892,6 +913,7 @@ function AppInner() {
         <div className="flex items-center gap-3 shrink-0">
           {/* Namespace selector with search */}
           <NamespaceSelector
+            ref={namespaceSelectorRef}
             value={namespaces}
             onChange={(next) => {
               setNamespaces(next)

--- a/web/src/components/ContextSwitcher.tsx
+++ b/web/src/components/ContextSwitcher.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useState, forwardRef } from 'react'
 import { AlertTriangle } from 'lucide-react'
 import {
   ClusterSwitcher,
@@ -16,11 +16,15 @@ interface ContextSwitcherProps {
   className?: string
 }
 
+export interface ContextSwitcherHandle {
+  open: () => void
+}
+
 interface ParsedContext extends ParsedContextName {
   context: ContextInfo
 }
 
-export function ContextSwitcher({ className = '' }: ContextSwitcherProps) {
+export const ContextSwitcher = forwardRef<ContextSwitcherHandle, ContextSwitcherProps>(({ className = '' }, ref) => {
   const [showConfirm, setShowConfirm] = useState(false)
   const [pendingSwitch, setPendingSwitch] = useState<ParsedContext | null>(null)
   const [sessionCounts, setSessionCounts] = useState<SessionCounts | null>(null)
@@ -158,6 +162,7 @@ export function ContextSwitcher({ className = '' }: ContextSwitcherProps) {
   return (
     <>
       <ClusterSwitcher
+        ref={ref}
         className={className}
         currentId={currentId}
         currentName={currentRaw}
@@ -222,4 +227,4 @@ export function ContextSwitcher({ className = '' }: ContextSwitcherProps) {
       )}
     </>
   )
-}
+})

--- a/web/src/components/ui/NamespaceSelector.tsx
+++ b/web/src/components/ui/NamespaceSelector.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
+import { useState, useRef, useEffect, useCallback, useMemo, forwardRef, useImperativeHandle } from 'react'
 import { createPortal } from 'react-dom'
 import { clsx } from 'clsx'
 import { ChevronDown, Search, X, Check, Shield } from 'lucide-react'
@@ -7,6 +7,10 @@ import { isForbiddenError } from '../../api/client'
 
 interface Namespace {
   name: string
+}
+
+export interface NamespaceSelectorHandle {
+  open: () => void
 }
 
 interface NamespaceSelectorProps {
@@ -19,7 +23,7 @@ interface NamespaceSelectorProps {
   disabledTooltip?: string
 }
 
-export function NamespaceSelector({
+export const NamespaceSelector = forwardRef<NamespaceSelectorHandle, NamespaceSelectorProps>(({
   value,
   onChange,
   namespaces,
@@ -27,7 +31,7 @@ export function NamespaceSelector({
   className,
   disabled,
   disabledTooltip,
-}: NamespaceSelectorProps) {
+}, ref) => {
   const [isOpen, setIsOpen] = useState(false)
   const [search, setSearch] = useState('')
   const [manualInput, setManualInput] = useState('')
@@ -73,11 +77,17 @@ export function NamespaceSelector({
 
   // Open dropdown
   const openDropdown = useCallback(() => {
+    if (disabled) return
     setIsOpen(true)
     setSearch('')
     setHighlightedIndex(0)
     updatePosition()
-  }, [updatePosition])
+  }, [disabled, updatePosition])
+
+  // Expose open method via ref
+  useImperativeHandle(ref, () => ({
+    open: openDropdown
+  }), [openDropdown])
 
   // Close dropdown
   const closeDropdown = useCallback(() => {
@@ -433,4 +443,4 @@ export function NamespaceSelector({
         )}
     </>
   )
-}
+})


### PR DESCRIPTION
## Description

Adds global keyboard shortcuts `n` and `c` to trigger the existing header dropdowns for Namespaces and Contexts/Clusters. This provides a fast, mouse-less workflow for frequent context-switching tasks while reusing the established UI and safety checks (like active session warnings).

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## How has this been tested?

- [x] Tested locally with minikube/kind
- [x] Verified component structures and `forwardRef` implementations
- [x] Full build successful (`npm run build`)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Related issues

Fixes #634