### PR TITLE
fix(helm): enforce selected repo during upgrades

### DIFF
--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -289,7 +289,17 @@ func listReleasesWith(actionConfig *action.Configuration, namespace, username st
 		return nil, fmt.Errorf("failed to list helm releases: %w", err)
 	}
 
-	storageNamespaces := helmReleaseStorageNamespaces(username, groups)
+	storageNamespaces := make(map[string]string, len(releases))
+	if namespace == "" {
+		storageNamespaces, err = helmReleaseStorageNamespaces(username, groups)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		for _, rel := range releases {
+			storageNamespaces[releaseStorageKey(rel)] = namespace
+		}
+	}
 	result := make([]HelmRelease, 0, len(releases))
 	for _, rel := range releases {
 		result = append(result, toHelmRelease(rel, storageNamespaces[releaseStorageKey(rel)]))
@@ -546,26 +556,27 @@ func toHelmRelease(rel *release.Release, storageNamespace string) HelmRelease {
 	return hr
 }
 
-func helmReleaseStorageNamespaces(username string, groups []string) map[string]string {
+func helmReleaseStorageNamespaces(username string, groups []string) (map[string]string, error) {
 	var client kubernetes.Interface = k8s.GetClient()
 	if username != "" {
 		impersonated, err := k8s.ImpersonatedClient(username, groups)
 		if err != nil {
-			log.Printf("[helm] failed to build impersonated client for release storage lookup: %v", err)
-			return nil
+			return nil, fmt.Errorf("failed to build impersonated client for release storage lookup: %w", err)
 		}
 		client = impersonated
 	}
 	if client == nil {
-		return nil
+		return nil, fmt.Errorf("kubernetes client not initialized for release storage lookup")
 	}
+	return helmReleaseStorageNamespacesWithClient(client)
+}
 
+func helmReleaseStorageNamespacesWithClient(client kubernetes.Interface) (map[string]string, error) {
 	secrets, err := client.CoreV1().Secrets("").List(context.Background(), metav1.ListOptions{
 		LabelSelector: "owner=helm",
 	})
 	if err != nil {
-		log.Printf("[helm] failed to inspect release storage namespaces: %v", err)
-		return nil
+		return nil, fmt.Errorf("failed to inspect release storage namespaces: %w", err)
 	}
 
 	result := make(map[string]string, len(secrets.Items))
@@ -581,7 +592,7 @@ func helmReleaseStorageNamespaces(username string, groups []string) map[string]s
 		}
 		result[releaseStorageKey(rel)] = secret.Namespace
 	}
-	return result
+	return result, nil
 }
 
 func decodeHelmReleaseData(data string) (*release.Release, error) {
@@ -1116,8 +1127,8 @@ type repoVersionInfo struct {
 // that's unrelated to argoproj's `argo-cd`). Tiers, in order:
 //
 //  1. A repo that lists the currently installed version — strongest signal that
-//     the release came from there. Among ties, take the highest latest.
-//  2. A repo whose URL host matches the chart's declared Home/Sources hosts.
+//     the release came from there. Ties require source-affinity.
+//  2. A repo whose URL host matches source-affinity hosts from Home/Sources.
 //     Catches the "installed version was pruned from index.yaml" case without
 //     letting an unrelated mirror win.
 //  3. Single candidate — only one configured repo lists this chart name, so
@@ -1126,8 +1137,32 @@ type repoVersionInfo struct {
 // If none of these apply we return empty strings; the caller surfaces an
 // "upstream not detected" state rather than guessing.
 func findBestUpgradeVersion(candidates []repoVersionInfo, sourceHosts []string) (latestVersion, repoName string) {
+	var currentMatches []repoVersionInfo
 	for _, c := range candidates {
-		if !c.hasCurrentVersion {
+		if c.hasCurrentVersion {
+			currentMatches = append(currentMatches, c)
+		}
+	}
+	if len(currentMatches) == 1 {
+		return currentMatches[0].latestVersion, currentMatches[0].repoName
+	}
+	if len(currentMatches) > 1 {
+		return bestSourceAffinityVersion(currentMatches, sourceHosts)
+	}
+
+	return bestSourceAffinityVersion(candidates, sourceHosts)
+}
+
+func bestSourceAffinityVersion(candidates []repoVersionInfo, sourceHosts []string) (latestVersion, repoName string) {
+	if len(sourceHosts) == 0 {
+		if len(candidates) == 1 {
+			return candidates[0].latestVersion, candidates[0].repoName
+		}
+		return "", ""
+	}
+
+	for _, c := range candidates {
+		if !repoURLMatchesAny(c.repoURL, sourceHosts) {
 			continue
 		}
 		if latestVersion == "" || compareVersions(c.latestVersion, latestVersion) > 0 {
@@ -1135,37 +1170,16 @@ func findBestUpgradeVersion(candidates []repoVersionInfo, sourceHosts []string) 
 			repoName = c.repoName
 		}
 	}
-	if latestVersion != "" {
-		return
-	}
-
-	if len(sourceHosts) > 0 {
-		for _, c := range candidates {
-			if !repoURLMatchesAny(c.repoURL, sourceHosts) {
-				continue
-			}
-			if latestVersion == "" || compareVersions(c.latestVersion, latestVersion) > 0 {
-				latestVersion = c.latestVersion
-				repoName = c.repoName
-			}
-		}
-		if latestVersion != "" {
-			return
-		}
-	}
-
-	if len(candidates) == 1 {
+	if latestVersion == "" && len(candidates) == 1 {
 		return candidates[0].latestVersion, candidates[0].repoName
 	}
-
-	return "", ""
+	return latestVersion, repoName
 }
 
 // chartSourceHosts builds the host-affinity set for a chart from its declared
-// Home and Sources URLs. Most charts on github.com don't host their helm repo
-// on github.com itself, so we also derive `<org>.github.io` from any
-// `github.com/<org>/<repo>` URL — that's what lets a release of argoproj's
-// argo-cd recognize the `argoproj.github.io` repo as upstream.
+// Home and Sources URLs. Some charts declare GitHub source URLs while publishing
+// their Helm repo via GitHub Pages, so we also derive `<org>.github.io` from any
+// `github.com/<org>/<repo>` URL.
 func chartSourceHosts(home string, sources []string) []string {
 	urls := make([]string, 0, 1+len(sources))
 	if home != "" {
@@ -1386,13 +1400,13 @@ func (c *Client) uninstallWith(actionConfig *action.Configuration, name string) 
 }
 
 // Upgrade upgrades a release to a new version
-func (c *Client) Upgrade(namespace, name, targetVersion string) error {
-	return c.UpgradeWithProgress(namespace, name, targetVersion, nil)
+func (c *Client) Upgrade(namespace, name, targetVersion, repositoryName string) error {
+	return c.UpgradeWithProgress(namespace, name, targetVersion, repositoryName, nil)
 }
 
 // UpgradeWithProgress upgrades a release with progress reporting via a channel.
 // If progressCh is nil, progress messages are silently discarded.
-func (c *Client) UpgradeWithProgress(namespace, name, targetVersion string, progressCh chan<- InstallProgress) error {
+func (c *Client) UpgradeWithProgress(namespace, name, targetVersion, repositoryName string, progressCh chan<- InstallProgress) error {
 	sendProgress := func(phase, message, detail string) {
 		if progressCh == nil {
 			return
@@ -1409,20 +1423,20 @@ func (c *Client) UpgradeWithProgress(namespace, name, targetVersion string, prog
 	if err != nil {
 		return err
 	}
-	return c.upgradeWith(actionConfig, name, targetVersion, sendProgress)
+	return c.upgradeWith(actionConfig, name, targetVersion, repositoryName, sendProgress)
 }
 
 // UpgradeAsUser upgrades a release with K8s impersonation.
-func (c *Client) UpgradeAsUser(namespace, name, targetVersion string, username string, groups []string) error {
+func (c *Client) UpgradeAsUser(namespace, name, targetVersion, repositoryName string, username string, groups []string) error {
 	actionConfig, err := c.getActionConfigForUser(namespace, username, groups)
 	if err != nil {
 		return err
 	}
 	noop := func(phase, message, detail string) {}
-	return c.upgradeWith(actionConfig, name, targetVersion, noop)
+	return c.upgradeWith(actionConfig, name, targetVersion, repositoryName, noop)
 }
 
-func (c *Client) upgradeWith(actionConfig *action.Configuration, name, targetVersion string, sendProgress func(phase, message, detail string)) error {
+func (c *Client) upgradeWith(actionConfig *action.Configuration, name, targetVersion, repositoryName string, sendProgress func(phase, message, detail string)) error {
 	// First, get the current release to find chart info
 	getAction := action.NewGet(actionConfig)
 	rel, err := getAction.Run(name)
@@ -1433,46 +1447,12 @@ func (c *Client) upgradeWith(actionConfig *action.Configuration, name, targetVer
 	chartName := rel.Chart.Metadata.Name
 	sendProgress("resolving", fmt.Sprintf("Finding %s version %s in repositories...", chartName, targetVersion), "")
 
-	// Find the chart in local repos
-	repoFile := c.settings.RepositoryConfig
-	repoCache := c.settings.RepositoryCache
-
-	repos, err := repo.LoadFile(repoFile)
+	chartPath, resolvedRepo, err := c.resolveUpgradeChartPath(chartName, targetVersion, repositoryName, chartSourceHosts(rel.Chart.Metadata.Home, rel.Chart.Metadata.Sources))
 	if err != nil {
-		return fmt.Errorf("failed to load repo file: %w", err)
+		return err
 	}
 
-	var chartPath string
-	for _, r := range repos.Repositories {
-		indexPath := filepath.Join(repoCache, r.Name+"-index.yaml")
-		idx, err := repo.LoadIndexFile(indexPath)
-		if err != nil {
-			continue
-		}
-
-		if entries, ok := idx.Entries[chartName]; ok {
-			for _, entry := range entries {
-				if entry.Version == targetVersion {
-					if len(entry.URLs) > 0 {
-						chartPath = entry.URLs[0]
-						if !strings.HasPrefix(chartPath, "http://") && !strings.HasPrefix(chartPath, "https://") {
-							chartPath = strings.TrimSuffix(r.URL, "/") + "/" + chartPath
-						}
-						break
-					}
-				}
-			}
-		}
-		if chartPath != "" {
-			break
-		}
-	}
-
-	if chartPath == "" {
-		return fmt.Errorf("chart %s version %s not found in configured repositories", chartName, targetVersion)
-	}
-
-	sendProgress("downloading", fmt.Sprintf("Downloading %s-%s...", chartName, targetVersion), chartPath)
+	sendProgress("downloading", fmt.Sprintf("Downloading %s-%s from %s...", chartName, targetVersion, resolvedRepo), chartPath)
 
 	// Create upgrade action — don't use Wait=true because Radar already
 	// shows real-time resource status via SSE. Waiting blocks the dialog
@@ -1508,6 +1488,73 @@ func (c *Client) upgradeWith(actionConfig *action.Configuration, name, targetVer
 
 	sendProgress("complete", fmt.Sprintf("Successfully upgraded %s to %s", name, targetVersion), "")
 	return nil
+}
+
+type chartPathCandidate struct {
+	repoName  string
+	repoURL   string
+	chartPath string
+}
+
+func (c *Client) resolveUpgradeChartPath(chartName, targetVersion, repositoryName string, sourceHosts []string) (chartPath, resolvedRepo string, err error) {
+	repos, err := repo.LoadFile(c.settings.RepositoryConfig)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to load repo file: %w", err)
+	}
+
+	var candidates []chartPathCandidate
+	var indexErrors []string
+	for _, r := range repos.Repositories {
+		if repositoryName != "" && r.Name != repositoryName {
+			continue
+		}
+
+		indexPath := filepath.Join(c.settings.RepositoryCache, r.Name+"-index.yaml")
+		idx, err := repo.LoadIndexFile(indexPath)
+		if err != nil {
+			log.Printf("[helm] skipping repo %q during upgrade: failed to load index %s: %v", r.Name, indexPath, err)
+			indexErrors = append(indexErrors, fmt.Sprintf("%s: %v", r.Name, err))
+			continue
+		}
+
+		if entries, ok := idx.Entries[chartName]; ok {
+			for _, entry := range entries {
+				if entry.Version != targetVersion || len(entry.URLs) == 0 {
+					continue
+				}
+				path := entry.URLs[0]
+				if !strings.HasPrefix(path, "http://") && !strings.HasPrefix(path, "https://") {
+					path = strings.TrimSuffix(r.URL, "/") + "/" + path
+				}
+				candidates = append(candidates, chartPathCandidate{repoName: r.Name, repoURL: r.URL, chartPath: path})
+				break
+			}
+		}
+	}
+
+	if len(candidates) == 1 {
+		return candidates[0].chartPath, candidates[0].repoName, nil
+	}
+	if len(candidates) > 1 {
+		var sourceMatches []chartPathCandidate
+		for _, candidate := range candidates {
+			if repoURLMatchesAny(candidate.repoURL, sourceHosts) {
+				sourceMatches = append(sourceMatches, candidate)
+			}
+		}
+		if len(sourceMatches) == 1 {
+			return sourceMatches[0].chartPath, sourceMatches[0].repoName, nil
+		}
+		return "", "", fmt.Errorf("could not identify upstream chart repository for %s version %s", chartName, targetVersion)
+	}
+
+	if repositoryName != "" {
+		return "", "", fmt.Errorf("chart %s version %s not found in repository %s", chartName, targetVersion, repositoryName)
+	}
+	if len(indexErrors) > 0 {
+		return "", "", fmt.Errorf("chart %s version %s not found in configured repositories; failed to load indexes: %s", chartName, targetVersion, strings.Join(indexErrors, "; "))
+	}
+	return "", "", fmt.Errorf("chart %s version %s not found in configured repositories", chartName, targetVersion)
 }
 
 // BatchCheckUpgrades checks for upgrades for all releases at once (more efficient)
@@ -1556,11 +1603,17 @@ func (c *Client) batchCheckUpgrades(namespace, username string, groups []string)
 	repoFile := c.settings.RepositoryConfig
 	f, err := repo.LoadFile(repoFile)
 	if err != nil {
+		message := fmt.Sprintf("failed to load Helm repositories: %v", err)
+		if os.IsNotExist(err) {
+			message = "no helm repositories configured"
+		} else {
+			log.Printf("[helm] failed to load repository config %s: %v", repoFile, err)
+		}
 		for _, rel := range releases {
 			key := rel.Namespace + "/" + rel.Name
 			result.Releases[key] = &UpgradeInfo{
 				CurrentVersion: rel.Chart.Metadata.Version,
-				Error:          "no helm repositories configured",
+				Error:          message,
 			}
 		}
 		return result, nil

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -528,6 +528,13 @@ func releaseStorageKey(rel *release.Release) string {
 	return fmt.Sprintf("%s/%s/%d", rel.Namespace, rel.Name, rel.Version)
 }
 
+func releaseUpgradeKey(rel *release.Release, storageNamespace string) string {
+	if storageNamespace == "" {
+		storageNamespace = rel.Namespace
+	}
+	return storageNamespace + "/" + rel.Name
+}
+
 // toHelmRelease converts a helm release to our API type
 func toHelmRelease(rel *release.Release, storageNamespace string) HelmRelease {
 	hr := HelmRelease{
@@ -1407,19 +1414,22 @@ func (c *Client) Upgrade(namespace, name, targetVersion, repositoryName string) 
 // UpgradeWithProgress upgrades a release with progress reporting via a channel.
 // If progressCh is nil, progress messages are silently discarded.
 func (c *Client) UpgradeWithProgress(namespace, name, targetVersion, repositoryName string, progressCh chan<- InstallProgress) error {
-	sendProgress := func(phase, message, detail string) {
-		if progressCh == nil {
-			return
-		}
-		select {
-		case progressCh <- InstallProgress{Phase: phase, Message: message, Detail: detail}:
-		default:
-		}
-	}
-
+	sendProgress := progressSender(progressCh)
 	sendProgress("preparing", fmt.Sprintf("Getting current release %s...", name), "")
 
 	actionConfig, err := c.getActionConfig(namespace)
+	if err != nil {
+		return err
+	}
+	return c.upgradeWith(actionConfig, name, targetVersion, repositoryName, sendProgress)
+}
+
+// UpgradeWithProgressAsUser upgrades a release with K8s impersonation and progress reporting.
+func (c *Client) UpgradeWithProgressAsUser(namespace, name, targetVersion, repositoryName, username string, groups []string, progressCh chan<- InstallProgress) error {
+	sendProgress := progressSender(progressCh)
+	sendProgress("preparing", fmt.Sprintf("Getting current release %s...", name), "")
+
+	actionConfig, err := c.getActionConfigForUser(namespace, username, groups)
 	if err != nil {
 		return err
 	}
@@ -1434,6 +1444,18 @@ func (c *Client) UpgradeAsUser(namespace, name, targetVersion, repositoryName st
 	}
 	noop := func(phase, message, detail string) {}
 	return c.upgradeWith(actionConfig, name, targetVersion, repositoryName, noop)
+}
+
+func progressSender(progressCh chan<- InstallProgress) func(phase, message, detail string) {
+	return func(phase, message, detail string) {
+		if progressCh == nil {
+			return
+		}
+		select {
+		case progressCh <- InstallProgress{Phase: phase, Message: message, Detail: detail}:
+		default:
+		}
+	}
 }
 
 func (c *Client) upgradeWith(actionConfig *action.Configuration, name, targetVersion, repositoryName string, sendProgress func(phase, message, detail string)) error {
@@ -1549,6 +1571,9 @@ func (c *Client) resolveUpgradeChartPath(chartName, targetVersion, repositoryNam
 	}
 
 	if repositoryName != "" {
+		if len(indexErrors) > 0 {
+			return "", "", fmt.Errorf("failed to load Helm repository index for %s: %s", repositoryName, strings.Join(indexErrors, "; "))
+		}
 		return "", "", fmt.Errorf("chart %s version %s not found in repository %s", chartName, targetVersion, repositoryName)
 	}
 	if len(indexErrors) > 0 {
@@ -1600,6 +1625,18 @@ func (c *Client) batchCheckUpgrades(namespace, username string, groups []string)
 		return result, nil
 	}
 
+	storageNamespaces := make(map[string]string, len(releases))
+	if namespace == "" {
+		storageNamespaces, err = helmReleaseStorageNamespaces(username, groups)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		for _, rel := range releases {
+			storageNamespaces[releaseStorageKey(rel)] = namespace
+		}
+	}
+
 	repoFile := c.settings.RepositoryConfig
 	f, err := repo.LoadFile(repoFile)
 	if err != nil {
@@ -1610,7 +1647,7 @@ func (c *Client) batchCheckUpgrades(namespace, username string, groups []string)
 			log.Printf("[helm] failed to load repository config %s: %v", repoFile, err)
 		}
 		for _, rel := range releases {
-			key := rel.Namespace + "/" + rel.Name
+			key := releaseUpgradeKey(rel, storageNamespaces[releaseStorageKey(rel)])
 			result.Releases[key] = &UpgradeInfo{
 				CurrentVersion: rel.Chart.Metadata.Version,
 				Error:          message,
@@ -1660,7 +1697,7 @@ func (c *Client) batchCheckUpgrades(namespace, username string, groups []string)
 	}
 
 	for _, rel := range releases {
-		key := rel.Namespace + "/" + rel.Name
+		key := releaseUpgradeKey(rel, storageNamespaces[releaseStorageKey(rel)])
 		currentVersion := rel.Chart.Metadata.Version
 		info := &UpgradeInfo{CurrentVersion: currentVersion}
 

--- a/internal/helm/client_test.go
+++ b/internal/helm/client_test.go
@@ -1,8 +1,11 @@
 package helm
 
 import (
+	"bytes"
+	"compress/gzip"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -280,6 +283,15 @@ func TestToHelmRelease_StorageNamespace(t *testing.T) {
 }
 
 func TestHelmReleaseStorageNamespacesWithClient(t *testing.T) {
+	assertStorageNamespaceFromSecret(t, false)
+}
+
+func TestHelmReleaseStorageNamespacesWithClient_GzippedPayload(t *testing.T) {
+	assertStorageNamespaceFromSecret(t, true)
+}
+
+func assertStorageNamespaceFromSecret(t *testing.T, gzipped bool) {
+	t.Helper()
 	rel := &release.Release{
 		Name:      "podinfo",
 		Namespace: "demo-flux-helm",
@@ -290,6 +302,17 @@ func TestHelmReleaseStorageNamespacesWithClient(t *testing.T) {
 	payload, err := json.Marshal(rel)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if gzipped {
+		var b bytes.Buffer
+		w := gzip.NewWriter(&b)
+		if _, err := w.Write(payload); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		payload = b.Bytes()
 	}
 
 	client := fake.NewSimpleClientset(&corev1.Secret{
@@ -354,7 +377,29 @@ func TestResolveUpgradeChartPath_UsesSourceAffinity(t *testing.T) {
 	}
 }
 
+func TestResolveUpgradeChartPath_RepositoryHintDoesNotFallback(t *testing.T) {
+	client := testHelmClientWithRepoVersions(t, map[string][]string{
+		"bitnami": {"9.5.11"},
+		"argo":    {"9.5.10"},
+	})
+
+	_, _, err := client.resolveUpgradeChartPath("argo-cd", "9.5.11", "argo", nil)
+	if err == nil {
+		t.Fatal("expected target version missing from hinted repo")
+	}
+	if !strings.Contains(err.Error(), "chart argo-cd version 9.5.11 not found in repository argo") {
+		t.Fatalf("error = %q", err)
+	}
+}
+
 func testHelmClientWithRepos(t *testing.T) *Client {
+	return testHelmClientWithRepoVersions(t, map[string][]string{
+		"bitnami": {"9.5.11"},
+		"argo":    {"9.5.11"},
+	})
+}
+
+func testHelmClientWithRepoVersions(t *testing.T, versionsByRepo map[string][]string) *Client {
 	t.Helper()
 	dir := t.TempDir()
 	cacheDir := filepath.Join(dir, "cache")
@@ -373,22 +418,29 @@ repositories:
 		t.Fatal(err)
 	}
 
-	writeIndex := func(name, url string) {
+	writeIndex := func(name string, versions []string) {
 		t.Helper()
-		if err := os.WriteFile(filepath.Join(cacheDir, name+"-index.yaml"), []byte(`apiVersion: v1
+		var b strings.Builder
+		b.WriteString(`apiVersion: v1
 entries:
   argo-cd:
-  - name: argo-cd
-    version: 9.5.11
+`)
+		for _, version := range versions {
+			b.WriteString(fmt.Sprintf(`  - name: argo-cd
+    version: %s
     urls:
-    - `+url+`
-generated: "2026-05-05T00:00:00Z"
-`), 0o644); err != nil {
+    - argo-cd-%s.tgz
+`, version, version))
+		}
+		b.WriteString(`generated: "2026-05-05T00:00:00Z"
+`)
+		if err := os.WriteFile(filepath.Join(cacheDir, name+"-index.yaml"), []byte(b.String()), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
-	writeIndex("bitnami", "argo-cd-9.5.11.tgz")
-	writeIndex("argo", "argo-cd-9.5.11.tgz")
+	for name, versions := range versionsByRepo {
+		writeIndex(name, versions)
+	}
 
 	return &Client{settings: &cli.EnvSettings{
 		RepositoryConfig: repoFile,

--- a/internal/helm/client_test.go
+++ b/internal/helm/client_test.go
@@ -1,11 +1,20 @@
 package helm
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/release"
 	helmtime "helm.sh/helm/v3/pkg/time"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestFindBestUpgradeVersion(t *testing.T) {
@@ -40,11 +49,21 @@ func TestFindBestUpgradeVersion(t *testing.T) {
 			wantRepo:    "metallb",
 		},
 		{
-			name: "multiple repos both have current version - picks highest among them",
+			name: "multiple repos both have current version without affinity - bail out",
 			candidates: []repoVersionInfo{
-				{repoName: "repo-a", latestVersion: "2.0.0", hasCurrentVersion: true},
-				{repoName: "repo-b", latestVersion: "3.0.0", hasCurrentVersion: true},
+				{repoName: "repo-a", latestVersion: "2.0.0", hasCurrentVersion: true, repoURL: "https://charts.example-a.com"},
+				{repoName: "repo-b", latestVersion: "3.0.0", hasCurrentVersion: true, repoURL: "https://charts.example-b.com"},
 			},
+			wantVersion: "",
+			wantRepo:    "",
+		},
+		{
+			name: "multiple repos both have current version with affinity - picks matching repo",
+			candidates: []repoVersionInfo{
+				{repoName: "repo-a", latestVersion: "2.0.0", hasCurrentVersion: true, repoURL: "https://charts.example-a.com"},
+				{repoName: "repo-b", latestVersion: "3.0.0", hasCurrentVersion: true, repoURL: "https://charts.example-b.com"},
+			},
+			sourceHosts: []string{"example-b.com"},
 			wantVersion: "3.0.0",
 			wantRepo:    "repo-b",
 		},
@@ -258,6 +277,123 @@ func TestToHelmRelease_StorageNamespace(t *testing.T) {
 	if different.StorageNamespace != "flux-system" {
 		t.Fatalf("storage namespace = %q, want flux-system", different.StorageNamespace)
 	}
+}
+
+func TestHelmReleaseStorageNamespacesWithClient(t *testing.T) {
+	rel := &release.Release{
+		Name:      "podinfo",
+		Namespace: "demo-flux-helm",
+		Version:   1,
+		Info:      &release.Info{Status: release.StatusDeployed},
+		Chart:     &chart.Chart{Metadata: &chart.Metadata{Name: "podinfo", Version: "6.11.2"}},
+	}
+	payload, err := json.Marshal(rel)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := fake.NewSimpleClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sh.helm.release.v1.podinfo.v1",
+			Namespace: "flux-system",
+			Labels:    map[string]string{"owner": "helm"},
+		},
+		Data: map[string][]byte{
+			"release": []byte(base64.StdEncoding.EncodeToString(payload)),
+		},
+	})
+
+	storageNamespaces, err := helmReleaseStorageNamespacesWithClient(client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := storageNamespaces[releaseStorageKey(rel)]; got != "flux-system" {
+		t.Fatalf("storage namespace = %q, want flux-system", got)
+	}
+}
+
+func TestResolveUpgradeChartPath_UsesRepositoryHint(t *testing.T) {
+	client := testHelmClientWithRepos(t)
+
+	chartPath, repoName, err := client.resolveUpgradeChartPath("argo-cd", "9.5.11", "argo", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repoName != "argo" {
+		t.Fatalf("repo = %q, want argo", repoName)
+	}
+	if !strings.Contains(chartPath, "argoproj.github.io") {
+		t.Fatalf("chart path = %q, want argo repo URL", chartPath)
+	}
+}
+
+func TestResolveUpgradeChartPath_AmbiguousWithoutHintOrAffinity(t *testing.T) {
+	client := testHelmClientWithRepos(t)
+
+	_, _, err := client.resolveUpgradeChartPath("argo-cd", "9.5.11", "", nil)
+	if err == nil {
+		t.Fatal("expected ambiguous chart error")
+	}
+	if !strings.Contains(err.Error(), "could not identify upstream chart repository") {
+		t.Fatalf("error = %q", err)
+	}
+}
+
+func TestResolveUpgradeChartPath_UsesSourceAffinity(t *testing.T) {
+	client := testHelmClientWithRepos(t)
+
+	chartPath, repoName, err := client.resolveUpgradeChartPath("argo-cd", "9.5.11", "", []string{"argoproj.github.io"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repoName != "argo" {
+		t.Fatalf("repo = %q, want argo", repoName)
+	}
+	if !strings.Contains(chartPath, "argoproj.github.io") {
+		t.Fatalf("chart path = %q, want argo repo URL", chartPath)
+	}
+}
+
+func testHelmClientWithRepos(t *testing.T) *Client {
+	t.Helper()
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+	if err := os.Mkdir(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	repoFile := filepath.Join(dir, "repositories.yaml")
+	if err := os.WriteFile(repoFile, []byte(`apiVersion: v1
+generated: "2026-05-05T00:00:00Z"
+repositories:
+- name: bitnami
+  url: https://charts.bitnami.com/bitnami
+- name: argo
+  url: https://argoproj.github.io/argo-helm
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	writeIndex := func(name, url string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(cacheDir, name+"-index.yaml"), []byte(`apiVersion: v1
+entries:
+  argo-cd:
+  - name: argo-cd
+    version: 9.5.11
+    urls:
+    - `+url+`
+generated: "2026-05-05T00:00:00Z"
+`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeIndex("bitnami", "argo-cd-9.5.11.tgz")
+	writeIndex("argo", "argo-cd-9.5.11.tgz")
+
+	return &Client{settings: &cli.EnvSettings{
+		RepositoryConfig: repoFile,
+		RepositoryCache:  cacheDir,
+	}}
 }
 
 func TestCompareVersions(t *testing.T) {

--- a/internal/helm/handlers.go
+++ b/internal/helm/handlers.go
@@ -539,6 +539,10 @@ func (h *Handlers) handleUpgradeStream(w http.ResponseWriter, r *http.Request) {
 
 	resultCh := make(chan error, 1)
 	go func() {
+		if user := auth.UserFromContext(r.Context()); user != nil {
+			resultCh <- client.UpgradeWithProgressAsUser(namespace, name, version, repositoryName, user.Username, user.Groups, progressCh)
+			return
+		}
 		resultCh <- client.UpgradeWithProgress(namespace, name, version, repositoryName, progressCh)
 	}()
 

--- a/internal/helm/handlers.go
+++ b/internal/helm/handlers.go
@@ -476,13 +476,14 @@ func (h *Handlers) handleUpgrade(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "version parameter is required")
 		return
 	}
+	repositoryName := r.URL.Query().Get("repository")
 
 	auth.AuditLog(r, namespace, name)
 	var upgradeErr error
 	if user := auth.UserFromContext(r.Context()); user != nil {
-		upgradeErr = client.UpgradeAsUser(namespace, name, version, user.Username, user.Groups)
+		upgradeErr = client.UpgradeAsUser(namespace, name, version, repositoryName, user.Username, user.Groups)
 	} else {
-		upgradeErr = client.Upgrade(namespace, name, version)
+		upgradeErr = client.Upgrade(namespace, name, version, repositoryName)
 	}
 	if err := upgradeErr; err != nil {
 		if IsForbiddenError(err) {
@@ -519,6 +520,7 @@ func (h *Handlers) handleUpgradeStream(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "version parameter is required")
 		return
 	}
+	repositoryName := r.URL.Query().Get("repository")
 
 	// Set up SSE headers
 	w.Header().Set("Content-Type", "text/event-stream")
@@ -537,7 +539,7 @@ func (h *Handlers) handleUpgradeStream(w http.ResponseWriter, r *http.Request) {
 
 	resultCh := make(chan error, 1)
 	go func() {
-		resultCh <- client.UpgradeWithProgress(namespace, name, version, progressCh)
+		resultCh <- client.UpgradeWithProgress(namespace, name, version, repositoryName, progressCh)
 	}()
 
 	for {

--- a/internal/helm/types.go
+++ b/internal/helm/types.go
@@ -6,8 +6,9 @@ import (
 
 // HelmRelease represents a Helm release in the list view
 type HelmRelease struct {
-	Name             string    `json:"name"`
-	Namespace        string    `json:"namespace"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	// Empty means Helm stores release metadata in Namespace.
 	StorageNamespace string    `json:"storageNamespace,omitempty"`
 	Chart            string    `json:"chart"`
 	ChartVersion     string    `json:"chartVersion"`
@@ -33,8 +34,9 @@ type HelmRevision struct {
 
 // HelmReleaseDetail contains full details of a Helm release
 type HelmReleaseDetail struct {
-	Name             string            `json:"name"`
-	Namespace        string            `json:"namespace"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	// Empty means Helm stores release metadata in Namespace.
 	StorageNamespace string            `json:"storageNamespace,omitempty"`
 	Chart            string            `json:"chart"`
 	ChartVersion     string            `json:"chartVersion"`

--- a/internal/helm/types.go
+++ b/internal/helm/types.go
@@ -107,7 +107,8 @@ type UpgradeInfo struct {
 
 // BatchUpgradeInfo contains upgrade info for multiple releases
 type BatchUpgradeInfo struct {
-	// Map of "namespace/name" to UpgradeInfo
+	// Map of "storageNamespace/name" to UpgradeInfo. For ordinary releases,
+	// storageNamespace is the same as the release namespace.
 	Releases map[string]*UpgradeInfo `json:"releases"`
 }
 

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -536,7 +536,7 @@ export interface UpgradeInfo {
   error?: string
 }
 
-// Batch upgrade info (map of "namespace/name" to UpgradeInfo)
+// Batch upgrade info keyed by "storageNamespace/name".
 export interface BatchUpgradeInfo {
   releases: Record<string, UpgradeInfo>
 }

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -439,6 +439,7 @@ export interface APIResource {
 export interface HelmRelease {
   name: string
   namespace: string
+  // Empty means Helm stores release metadata in namespace.
   storageNamespace?: string
   chart: string
   chartVersion: string
@@ -464,6 +465,7 @@ export interface HelmRevision {
 export interface HelmReleaseDetail {
   name: string
   namespace: string
+  // Empty means Helm stores release metadata in namespace.
   storageNamespace?: string
   chart: string
   chartVersion: string

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1987,10 +1987,13 @@ export function upgradeWithProgress(
   namespace: string,
   name: string,
   version: string,
+  repositoryName: string | undefined,
   onProgress: (event: InstallProgressEvent) => void
 ): Promise<void> {
+  const params = new URLSearchParams({ version })
+  if (repositoryName) params.set('repository', repositoryName)
   return streamHelmProgress(
-    `${getApiBase()}/helm/releases/${namespace}/${name}/upgrade-stream?version=${encodeURIComponent(version)}`,
+    `${getApiBase()}/helm/releases/${namespace}/${name}/upgrade-stream?${params.toString()}`,
     { method: 'POST' },
     onProgress,
     'Upgrade failed',

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1950,6 +1950,7 @@ function streamHelmProgress(
 
         const decoder = new TextDecoder()
         let buffer = ''
+        let terminalEventReceived = false
 
         while (true) {
           const { done, value } = await reader.read()
@@ -1967,15 +1968,24 @@ function streamHelmProgress(
                 onProgress(data)
 
                 if (data.type === 'complete') {
+                  terminalEventReceived = true
                   resolve(data)
+                  return
                 } else if (data.type === 'error') {
+                  terminalEventReceived = true
                   reject(new Error(data.message || failureLabel))
+                  return
                 }
-              } catch {
-                // Ignore parse errors
+              } catch (err) {
+                reject(err instanceof Error ? err : new Error(`${failureLabel}: invalid progress event`))
+                return
               }
             }
           }
+        }
+
+        if (!terminalEventReceived) {
+          reject(new Error(`${failureLabel}: stream ended before completion`))
         }
       })
       .catch(reject)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1950,7 +1950,6 @@ function streamHelmProgress(
 
         const decoder = new TextDecoder()
         let buffer = ''
-        let terminalEventReceived = false
 
         while (true) {
           const { done, value } = await reader.read()
@@ -1968,11 +1967,9 @@ function streamHelmProgress(
                 onProgress(data)
 
                 if (data.type === 'complete') {
-                  terminalEventReceived = true
                   resolve(data)
                   return
                 } else if (data.type === 'error') {
-                  terminalEventReceived = true
                   reject(new Error(data.message || failureLabel))
                   return
                 }
@@ -1984,9 +1981,7 @@ function streamHelmProgress(
           }
         }
 
-        if (!terminalEventReceived) {
-          reject(new Error(`${failureLabel}: stream ended before completion`))
-        }
+        reject(new Error(`${failureLabel}: stream ended before completion`))
       })
       .catch(reject)
   })

--- a/web/src/components/helm/HelmReleaseDrawer.tsx
+++ b/web/src/components/helm/HelmReleaseDrawer.tsx
@@ -90,10 +90,11 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
   )
 
   // Lazy check for upgrade availability
-  const { data: upgradeInfo, isLoading: upgradeLoading } = useHelmUpgradeInfo(
+  const { data: upgradeInfo, isLoading: upgradeLoading, error: upgradeError } = useHelmUpgradeInfo(
     helmNamespace,
     release.name
   )
+  const upgradeErrorMessage = upgradeError instanceof Error ? upgradeError.message : 'Upgrade check failed'
 
   // Mutations for actions
   const uninstallMutation = useHelmUninstall()
@@ -239,6 +240,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
         helmNamespace,
         release.name,
         upgradeInfo.latestVersion,
+        upgradeInfo.repositoryName,
         (event) => {
           if (event.type === 'progress' && event.message) {
             setUpgradeProgress(prev => [...prev, {
@@ -327,6 +329,13 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
             {upgradeLoading ? (
               <span className="badge bg-theme-hover/50 text-theme-text-secondary animate-pulse">
                 checking...
+              </span>
+            ) : upgradeError ? (
+              <span
+                className="badge bg-theme-hover/50 text-theme-text-secondary"
+                title={upgradeErrorMessage}
+              >
+                upgrade check failed
               </span>
             ) : upgradeInfo?.updateAvailable ? (
               <button

--- a/web/src/components/helm/HelmView.tsx
+++ b/web/src/components/helm/HelmView.tsx
@@ -27,6 +27,7 @@ export function HelmView({ namespace, selectedRelease, onReleaseClick }: HelmVie
 
   const { data: releases, isLoading, error: releasesError, refetch: refetchReleases } = useHelmReleases(namespace || undefined)
   const isForbidden = isForbiddenError(releasesError)
+  const releasesErrorMessage = releasesError instanceof Error ? releasesError.message : 'Failed to load Helm releases'
 
   // Lazy load upgrade info after releases are loaded
   const { data: upgradeInfo, isLoading: upgradeLoading, error: upgradeError, refetch: refetchUpgradeInfo } = useHelmBatchUpgradeInfo(
@@ -246,6 +247,20 @@ export function HelmView({ namespace, selectedRelease, onReleaseClick }: HelmVie
                   <p className="text-theme-text-secondary font-medium">Access Restricted</p>
                   <p className="text-sm mt-1">Insufficient permissions to list Helm releases</p>
                 </div>
+              ) : releasesError ? (
+                <div className="flex flex-col items-center justify-center h-full text-theme-text-tertiary gap-3 px-6 text-center">
+                  <Package className="w-10 h-10 text-amber-400" />
+                  <div>
+                    <p className="text-theme-text-secondary font-medium">Failed to load Helm releases</p>
+                    <p className="text-sm mt-1 break-all">{releasesErrorMessage}</p>
+                  </div>
+                  <button
+                    onClick={() => refetchReleases()}
+                    className="px-3 py-1.5 text-sm text-theme-text-primary border border-theme-border rounded-lg hover:bg-theme-elevated transition-colors"
+                  >
+                    Retry
+                  </button>
+                </div>
               ) : filteredReleases.length === 0 ? (
                 <div className="flex flex-col items-center justify-center h-full text-theme-text-tertiary gap-2">
                   <Package className="w-12 h-12 text-theme-text-disabled" />
@@ -297,13 +312,14 @@ export function HelmView({ namespace, selectedRelease, onReleaseClick }: HelmVie
                   <tbody className="table-divide-subtle">
                     {filteredReleases.map((release, index) => (
                       <ReleaseRow
-                        key={`${release.namespace}-${release.name}`}
+                        key={releaseIdentityKey(release)}
                         ref={index === highlightedIndex ? highlightedRowRef : null}
                         release={release}
-                        upgradeInfo={upgradeInfo?.releases[`${release.namespace}/${release.name}`]}
+                        upgradeInfo={upgradeInfo?.releases[releaseIdentityKey(release)]}
                         isSelected={
                           selectedRelease?.namespace === release.namespace &&
-                          selectedRelease?.name === release.name
+                          selectedRelease?.name === release.name &&
+                          (selectedRelease?.storageNamespace || selectedRelease?.namespace) === (release.storageNamespace || release.namespace)
                         }
                         isHighlighted={index === highlightedIndex}
                         onClick={() => onReleaseClick?.(release.namespace, release.name, release.storageNamespace)}
@@ -333,6 +349,10 @@ export function HelmView({ namespace, selectedRelease, onReleaseClick }: HelmVie
       )}
     </div>
   )
+}
+
+function releaseIdentityKey(release: Pick<HelmRelease, 'namespace' | 'name' | 'storageNamespace'>): string {
+  return `${release.storageNamespace || release.namespace}/${release.name}`
 }
 
 interface ReleaseRowProps {

--- a/web/src/components/helm/HelmView.tsx
+++ b/web/src/components/helm/HelmView.tsx
@@ -29,10 +29,11 @@ export function HelmView({ namespace, selectedRelease, onReleaseClick }: HelmVie
   const isForbidden = isForbiddenError(releasesError)
 
   // Lazy load upgrade info after releases are loaded
-  const { data: upgradeInfo, isLoading: upgradeLoading, refetch: refetchUpgradeInfo } = useHelmBatchUpgradeInfo(
+  const { data: upgradeInfo, isLoading: upgradeLoading, error: upgradeError, refetch: refetchUpgradeInfo } = useHelmBatchUpgradeInfo(
     namespace || undefined,
     Boolean(releases && releases.length > 0)
   )
+  const upgradeErrorMessage = upgradeError instanceof Error ? upgradeError.message : 'Upgrade checks failed'
 
   const [handleRefresh, isRefreshAnimating] = useRefreshAnimation(async () => {
     await Promise.all([refetchReleases(), refetchUpgradeInfo()])
@@ -232,6 +233,11 @@ export function HelmView({ namespace, selectedRelease, onReleaseClick }: HelmVie
 
             {/* Releases Table */}
             <div className="flex-1 overflow-auto">
+              {upgradeError && (
+                <div className="m-4 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-300">
+                  Upgrade checks failed: {upgradeErrorMessage}
+                </div>
+              )}
               {isLoading ? (
                 <PaneLoader className="h-full" />
               ) : isForbidden ? (


### PR DESCRIPTION
## Summary

This is a follow-up to #630 after review found that upgrade detection and upgrade execution could diverge. Radar could show the correct upstream repository for a colliding chart name, but the upgrade action only received a version and scanned every configured repo again.

This PR keeps the selected repository attached to the upgrade action, tightens ambiguous current-version matching so ties require source affinity, and makes Helm storage namespace discovery fail explicitly instead of silently falling back to the target namespace.

## Changes

- Pass `repositoryName` from `UpgradeInfo` through the upgrade stream API and constrain chart resolution to that repo.
- Reuse source affinity during upgrade chart resolution when a repo hint is absent, and return `upstream unknown` on ambiguity.
- Surface upgrade-check query failures in the Helm drawer/list UI.
- Return errors for storage namespace discovery failures instead of omitting `storageNamespace` and later producing misleading release lookup failures.
- Add tests for ambiguous repo selection, repository-constrained upgrade resolution, source-affinity resolution, and Helm release secret storage namespace decoding.

## Tests

- `go test ./internal/helm`
- `cd web && npm run tsc`

Note: I also accidentally ran `npm run tsc` at repo root first; it failed because the root package has no `tsc` script.

Made with [Cursor](https://cursor.com)