### PR TITLE
fix(desktop): disable WebKit DMABUF renderer by default on Linux

### DIFF
--- a/cmd/desktop/boot_env_linux.go
+++ b/cmd/desktop/boot_env_linux.go
@@ -25,6 +25,26 @@ func logBootEnv() {
 	}
 }
 
+// applyWebKitDefaults sets WEBKIT_DISABLE_DMABUF_RENDERER=1 unless the user
+// has set it explicitly. WebKitGTK's DMABUF renderer produces blank windows
+// on a range of Wayland setups (NVIDIA, KDE KWin, some Mesa stacks) and
+// upstream considers this an application-level concern, not a WebKit fix.
+// The legacy renderer is stable everywhere.
+//
+// Must run before Wails initializes WebKit. LookupEnv (not an empty-string
+// check) lets users opt back in to DMABUF with WEBKIT_DISABLE_DMABUF_RENDERER=0.
+func applyWebKitDefaults() {
+	const key = "WEBKIT_DISABLE_DMABUF_RENDERER"
+	if _, set := os.LookupEnv(key); set {
+		return
+	}
+	if err := os.Setenv(key, "1"); err != nil {
+		log.Printf("[desktop] failed to set %s: %v", key, err)
+		return
+	}
+	log.Printf("[desktop] applied %s=1 (default; set %s=0 to opt out)", key, key)
+}
+
 // joinEnv formats env vars as "KEY=value" pairs. When includeUnset is true,
 // unset vars are rendered as "KEY=" so the reader can tell they were checked.
 // When false, unset vars are omitted (noise reduction for overrides).

--- a/cmd/desktop/boot_env_other.go
+++ b/cmd/desktop/boot_env_other.go
@@ -3,3 +3,5 @@
 package main
 
 func logBootEnv() {}
+
+func applyWebKitDefaults() {}

--- a/cmd/desktop/main.go
+++ b/cmd/desktop/main.go
@@ -64,6 +64,11 @@ func main() {
 	// No-op on macOS/Windows.
 	logBootEnv()
 
+	// Disable WebKit's DMABUF renderer on Linux unless the user opts in —
+	// it produces blank windows on Wayland+KDE/NVIDIA and upstream won't fix.
+	// Must run before Wails initializes WebKit.
+	applyWebKitDefaults()
+
 	// GUI apps (macOS .app, Linux .desktop) get a minimal PATH that
 	// doesn't include user-installed tools like gke-gcloud-auth-plugin,
 	// gcloud, aws CLI, etc. Enrich PATH from the user's login shell.


### PR DESCRIPTION
## Summary

WebKitGTK's DMABUF renderer (the default since 2.42) produces blank/black windows on a number of Wayland setups — KDE KWin, NVIDIA, some Mesa stacks. The user in #465 hit this on Fedora 43 KDE; the standard `WEBKIT_DISABLE_DMABUF_RENDERER=1` workaround fixed it.

Upstream WebKit considers this an application-level concern (won't fix in WebKitGTK), and the Tauri / Wails / WebKit2GTK app ecosystem has converged on shipping the workaround by default. The legacy renderer is stable everywhere — no known regressions from disabling DMABUF.

## What changed

- `applyWebKitDefaults()` sets `WEBKIT_DISABLE_DMABUF_RENDERER=1` at startup, only when the variable is unset. Users can opt back in with `WEBKIT_DISABLE_DMABUF_RENDERER=0`.
- `LookupEnv` (not empty-string check) so an explicit `=0` is respected.
- Linux-only via build tags; no-op stub on macOS / Windows (where this WebKitGTK var has no meaning).
- Wired in `main()` right after `logBootEnv()`, before Wails initializes WebKit.

If users still see blank windows after this ships, the next escape hatch is `WEBKIT_DISABLE_COMPOSITING_MODE=1` — kept as a manual fallback rather than another default, since it forces a much slower software-rendered path.

Closes #465.