### PR TITLE
fix(portforward): keep floating panel on-screen on narrow viewports

### DIFF
--- a/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
+++ b/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
@@ -187,7 +187,7 @@ export const ClusterSwitcher = forwardRef<ClusterSwitcherHandle, ClusterSwitcher
         onClick={() => setIsOpen(v => !v)}
         disabled={disabled || loading}
         className={`
-          flex items-center gap-1.5 px-2.5 py-1.5
+          flex items-center gap-1.5 px-2.5 py-1.5 min-w-[140px]
           bg-theme-elevated border border-theme-border rounded text-sm font-medium
           text-theme-text-primary hover:bg-theme-hover hover:border-theme-border-light
           transition-colors cursor-pointer
@@ -214,7 +214,7 @@ export const ClusterSwitcher = forwardRef<ClusterSwitcherHandle, ClusterSwitcher
             noTooltip={isOpen}
           />
         )}
-        <ChevronDown className={`w-3 h-3 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+        <ChevronDown className={`w-3 h-3 ml-auto transition-transform ${isOpen ? 'rotate-180' : ''}`} />
       </button>
 
       {isOpen && (

--- a/web/src/components/portforward/PortForwardManager.tsx
+++ b/web/src/components/portforward/PortForwardManager.tsx
@@ -139,10 +139,25 @@ export function PortForwardProvider({ children }: { children: ReactNode }) {
   const measureAnchor = useCallback(() => {
     if (!indicatorRef.current) return
     const rect = indicatorRef.current.getBoundingClientRect()
+    // Align panel right edge with indicator right edge, but clamp so the
+    // panel's left edge never runs off the viewport's left edge — happens on
+    // narrow windows / split-screens where the indicator is closer to the
+    // left edge than the panel is wide. PANEL_WIDTH must match the panel's
+    // Tailwind w-80 (20rem = 320px).
+    const PANEL_WIDTH = 320
+    const MARGIN = 8
+    const desiredRight = Math.max(MARGIN, window.innerWidth - rect.right)
+    const maxRight = Math.max(MARGIN, window.innerWidth - PANEL_WIDTH - MARGIN)
+    const right = Math.min(desiredRight, maxRight)
+    // Keep the caret pointing at the indicator's horizontal center even after
+    // the panel has been clamped away from the indicator.
+    const panelRightX = window.innerWidth - right
+    const indicatorCenterX = rect.right - rect.width / 2
+    const caretRight = panelRightX - indicatorCenterX - 6
     setAnchor({
       top: rect.bottom + 10,
-      right: Math.max(16, window.innerWidth - rect.right),
-      caretRight: rect.width / 2 - 6,
+      right,
+      caretRight,
     })
   }, [])
 


### PR DESCRIPTION
## Summary

Reported in #625: the floating port-forward panel gets cut off on the left edge in some browser configurations.

The panel right-anchors to the header indicator using `right: window.innerWidth - rect.right` and is `w-80` (320px). With no clamp, it runs off the viewport's left edge whenever the indicator's right edge is closer to the left edge than the panel is wide — narrow windows, split-screens, certain fullscreen layouts.

## Fix

**1. Clamp the panel position** (load-bearing)
- Cap the panel's `right` offset so its left edge stays at least 8px inside the viewport.
- Recompute `caretRight` from panel position vs. indicator center so the caret keeps pointing at the indicator after a clamp shifts the panel away from it.
- Coupled magic number: `PANEL_WIDTH = 320` must match the panel's `w-80` Tailwind class — called out in a comment.

**2. Cluster-picker `min-w-[140px]` + right-aligned chevron** (visual consistency)
- Independent improvement that surfaced during review: short context names ("k", "local") collapse the picker to a tiny pill, looking inconsistent with the rest of the header.
- A 140px min-width and `ml-auto` on the chevron give the picker a stable shape regardless of context-name length.
- Helps slightly with the bug condition (indicator can't sit at extreme low x) but is not load-bearing for the fix — the clamp handles all viewport-width edge cases independently.

## Visual verification

- Forced indicator to x=87 (simulating short cluster name + small viewport): panel correctly clamped to `right: 1112px`, panel left edge at 8px (the MARGIN). Without the fix the panel left would have been at -183px.
- Normal viewport (1440px, indicator at x=387): panel naturally aligned under indicator, behavior unchanged.
- Cluster picker chevron now right-aligned regardless of context name length.

Reproduction screenshot from the issue:

![cut-off panel](https://github.com/user-attachments/assets/955eb87a-4e8d-4077-9519-91fb783e1960)

Closes #625.