### PR TITLE
fix(cluster-switcher): disambiguate kubeconfigs by source folder

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -683,6 +683,14 @@ type ContextInfo struct {
 	User      string `json:"user"`
 	Namespace string `json:"namespace"`
 	IsCurrent bool   `json:"isCurrent"`
+	// Source is a short, human-recognisable label for the kubeconfig file
+	// this context lives in (e.g. "kube-cluster-paris" for
+	// ~/.kube-cluster-paris/config, or "prod" for ~/.kube/prod.yaml).
+	// Only set in multi-kubeconfig mode; empty for single-file and
+	// in-cluster modes where there's no ambiguity to disambiguate.
+	// Populated even when context names don't collide so the dropdown
+	// can show users which kubeconfig each context came from.
+	Source string `json:"source,omitempty"`
 }
 
 // GetAvailableContexts returns all available contexts from the kubeconfig
@@ -758,6 +766,7 @@ func GetAvailableContexts() ([]ContextInfo, error) {
 				User:      ctx.AuthInfo,
 				Namespace: ctx.Namespace,
 				IsCurrent: qName == currentCtx,
+				Source:    kubeconfigSourceLabel(entry.SourceFile),
 			})
 		}
 		return contexts, nil

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -683,13 +683,10 @@ type ContextInfo struct {
 	User      string `json:"user"`
 	Namespace string `json:"namespace"`
 	IsCurrent bool   `json:"isCurrent"`
-	// Source is a short, human-recognisable label for the kubeconfig file
-	// this context lives in (e.g. "kube-cluster-paris" for
-	// ~/.kube-cluster-paris/config, or "prod" for ~/.kube/prod.yaml).
-	// Only set in multi-kubeconfig mode; empty for single-file and
-	// in-cluster modes where there's no ambiguity to disambiguate.
-	// Populated even when context names don't collide so the dropdown
-	// can show users which kubeconfig each context came from.
+	// Source labels the kubeconfig file this context came from
+	// (e.g. "kube-cluster-paris" or "prod"). Set only in multi-file
+	// mode; populated for every context — not just colliding ones — so
+	// the dropdown can show provenance even without ambiguity.
 	Source string `json:"source,omitempty"`
 }
 

--- a/internal/k8s/context_registry.go
+++ b/internal/k8s/context_registry.go
@@ -104,19 +104,45 @@ func buildContextRegistry(paths []string) (map[string]contextEntry, map[string]*
 	return registry, fileConfigs
 }
 
+// kubeconfigSourceLabel returns a short, human-recognisable label for the
+// kubeconfig file at `path`. It's used both as the disambiguation suffix
+// in qualifyContextName and as the frontend-facing Source on ContextInfo.
+//
+// When the file's basename is generic (`config` / `kubeconfig`) the
+// parent directory carries the meaning — users typically organise as
+// ~/.kube-cluster-paris/config, ~/.kube-cluster-london/config etc., and
+// "config" alone disambiguates nothing. We fall back to the parent dir
+// name (with any leading dot stripped) in that case. Otherwise the file
+// basename without extension is the right label (e.g. "paris.yaml" -> "paris").
+//
+// See issue #651 — without this, three "admin@cluster" contexts each
+// sourced from a different ~/.kube-cluster-<city>/config produced the
+// useless dropdown labels admin@cluster, admin@cluster (config),
+// admin@cluster (config #2).
+func kubeconfigSourceLabel(path string) string {
+	base := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	if base == "config" || base == "kubeconfig" {
+		parent := filepath.Base(filepath.Dir(path))
+		if parent != "" && parent != "." && parent != string(filepath.Separator) {
+			return strings.TrimPrefix(parent, ".")
+		}
+	}
+	return base
+}
+
 // qualifyContextName returns a globally-unique context name for a context
 // called `name` coming from file `path`. When `name` isn't taken yet, it
 // returns `name` unchanged — most contexts across most files don't collide
 // (it's the users/clusters that typically share names, not the context
 // names themselves), and the user-visible dropdown should show the
 // original names wherever possible. On collision it falls back to
-// "<name> (<file-basename-without-ext>)", and then "<name> (<base> #N)"
-// for further collisions from a third+ file with the same basename.
+// "<name> (<source-label>)", and then "<name> (<source-label> #N)"
+// for further collisions from a third+ file with the same source label.
 func qualifyContextName(registry map[string]contextEntry, name, path string) string {
 	if _, taken := registry[name]; !taken {
 		return name
 	}
-	base := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	base := kubeconfigSourceLabel(path)
 	qualified := fmt.Sprintf("%s (%s)", name, base)
 	if _, taken := registry[qualified]; !taken {
 		return qualified
@@ -367,7 +393,7 @@ func aggregateExecPluginCommands(
 			seenCmds[c] = struct{}{}
 			cmds = append(cmds, c)
 		}
-		base := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+		base := kubeconfigSourceLabel(path)
 		for _, ai := range fileEmpty {
 			// Scope by file so diagnostics aren't ambiguous when the same
 			// AuthInfo name appears in multiple files.

--- a/internal/k8s/context_registry.go
+++ b/internal/k8s/context_registry.go
@@ -105,20 +105,15 @@ func buildContextRegistry(paths []string) (map[string]contextEntry, map[string]*
 }
 
 // kubeconfigSourceLabel returns a short, human-recognisable label for the
-// kubeconfig file at `path`. It's used both as the disambiguation suffix
-// in qualifyContextName and as the frontend-facing Source on ContextInfo.
+// kubeconfig file at `path`. Used both as the disambiguation suffix in
+// qualifyContextName and as the frontend-facing Source on ContextInfo.
 //
-// When the file's basename is generic (`config` / `kubeconfig`) the
-// parent directory carries the meaning — users typically organise as
-// ~/.kube-cluster-paris/config, ~/.kube-cluster-london/config etc., and
-// "config" alone disambiguates nothing. We fall back to the parent dir
-// name (with any leading dot stripped) in that case. Otherwise the file
-// basename without extension is the right label (e.g. "paris.yaml" -> "paris").
-//
-// See issue #651 — without this, three "admin@cluster" contexts each
-// sourced from a different ~/.kube-cluster-<city>/config produced the
-// useless dropdown labels admin@cluster, admin@cluster (config),
-// admin@cluster (config #2).
+// When the basename is generic (`config` / `kubeconfig`) the parent
+// directory carries the meaning — users typically organise as
+// ~/.kube-cluster-paris/config, where "config" alone disambiguates
+// nothing. We fall back to the parent dir name (leading dot stripped)
+// in that case. Otherwise the file basename without extension is the
+// right label (e.g. "paris.yaml" -> "paris").
 func kubeconfigSourceLabel(path string) string {
 	base := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
 	if base == "config" || base == "kubeconfig" {

--- a/internal/k8s/context_registry_test.go
+++ b/internal/k8s/context_registry_test.go
@@ -207,6 +207,82 @@ func TestBuildContextRegistry_ThreeWayCollision(t *testing.T) {
 	}
 }
 
+// Issue #651 scenario: each kubeconfig is named "config" inside a
+// distinctly-named directory (e.g. ~/.kube-cluster-paris/config). The
+// disambiguation label must come from the parent directory — the
+// filename "config" by itself disambiguates nothing. Without this, the
+// user sees three useless "admin@cluster", "admin@cluster (config)",
+// "admin@cluster (config #2)" rows.
+func TestBuildContextRegistry_GenericFilenameUsesParentDir(t *testing.T) {
+	dirParis := filepath.Join(t.TempDir(), ".kube-cluster-paris")
+	dirLondon := filepath.Join(t.TempDir(), ".kube-cluster-london")
+	dirRome := filepath.Join(t.TempDir(), ".kube-cluster-rome")
+	for _, d := range []string{dirParis, dirLondon, dirRome} {
+		if err := os.MkdirAll(d, 0o700); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	f1 := writeKubeconfig(t, dirParis, "config", "admin@cluster", []kubeEntry{
+		{ctxName: "admin@cluster", userName: "admin", clusterName: "cluster"},
+	})
+	f2 := writeKubeconfig(t, dirLondon, "config", "admin@cluster", []kubeEntry{
+		{ctxName: "admin@cluster", userName: "admin", clusterName: "cluster"},
+	})
+	f3 := writeKubeconfig(t, dirRome, "config", "admin@cluster", []kubeEntry{
+		{ctxName: "admin@cluster", userName: "admin", clusterName: "cluster"},
+	})
+
+	registry, _ := buildContextRegistry([]string{f1, f2, f3})
+
+	if len(registry) != 3 {
+		t.Fatalf("registry size: got %d, want 3", len(registry))
+	}
+	// First file keeps the original name.
+	if e, ok := registry["admin@cluster"]; !ok || e.SourceFile != f1 {
+		t.Errorf("'admin@cluster' should resolve to f1")
+	}
+	// Subsequent collisions use the leading-dot-stripped parent dir name.
+	if e, ok := registry["admin@cluster (kube-cluster-london)"]; !ok || e.SourceFile != f2 {
+		names := []string{}
+		for n := range registry {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		t.Errorf("'admin@cluster (kube-cluster-london)' should resolve to f2; registry has: %v", names)
+	}
+	if e, ok := registry["admin@cluster (kube-cluster-rome)"]; !ok || e.SourceFile != f3 {
+		names := []string{}
+		for n := range registry {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		t.Errorf("'admin@cluster (kube-cluster-rome)' should resolve to f3; registry has: %v", names)
+	}
+}
+
+func TestKubeconfigSourceLabel(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		// Generic filenames -> parent dir, leading dot stripped.
+		{"/home/u/.kube-cluster-paris/config", "kube-cluster-paris"},
+		{"/home/u/.kube/config", "kube"},
+		{"/home/u/clusters/prod/kubeconfig", "prod"},
+		// Meaningful filenames -> filename without extension.
+		{"/home/u/.kube/configs/prod.yaml", "prod"},
+		{"/home/u/clusters/staging.yml", "staging"},
+		{"/tmp/eks-east.kubeconfig.yaml", "eks-east.kubeconfig"},
+		// Edge: file at root with generic name — parent is "/", fall through to base.
+		{"/config", "config"},
+	}
+	for _, c := range cases {
+		if got := kubeconfigSourceLabel(c.path); got != c.want {
+			t.Errorf("kubeconfigSourceLabel(%q) = %q, want %q", c.path, got, c.want)
+		}
+	}
+}
+
 func TestPickInitialContext_PrefersFirstFileCurrentContext(t *testing.T) {
 	dir := t.TempDir()
 	f1 := writeKubeconfig(t, dir, "first.yaml", "from-first", []kubeEntry{

--- a/internal/k8s/context_registry_test.go
+++ b/internal/k8s/context_registry_test.go
@@ -207,12 +207,11 @@ func TestBuildContextRegistry_ThreeWayCollision(t *testing.T) {
 	}
 }
 
-// Issue #651 scenario: each kubeconfig is named "config" inside a
-// distinctly-named directory (e.g. ~/.kube-cluster-paris/config). The
-// disambiguation label must come from the parent directory — the
-// filename "config" by itself disambiguates nothing. Without this, the
-// user sees three useless "admin@cluster", "admin@cluster (config)",
-// "admin@cluster (config #2)" rows.
+// Generic "config" basenames in distinctly-named parent dirs must
+// disambiguate via parent dir, not basename — three kubeconfigs at
+// ~/.kube-cluster-{paris,london,rome}/config sharing context name
+// "admin@cluster" should yield three distinct qualified names, not
+// "admin@cluster (config)" / "(config #2)".
 func TestBuildContextRegistry_GenericFilenameUsesParentDir(t *testing.T) {
 	dirParis := filepath.Join(t.TempDir(), ".kube-cluster-paris")
 	dirLondon := filepath.Join(t.TempDir(), ".kube-cluster-london")
@@ -275,11 +274,82 @@ func TestKubeconfigSourceLabel(t *testing.T) {
 		{"/tmp/eks-east.kubeconfig.yaml", "eks-east.kubeconfig"},
 		// Edge: file at root with generic name — parent is "/", fall through to base.
 		{"/config", "config"},
+		// Relative paths — SourceFile is normalised to absolute upstream,
+		// but pin the helper's behaviour so a future drift doesn't sneak
+		// silently past callers like aggregateExecPluginCommands.
+		{"config", "config"},                  // no parent
+		{"./config", "config"},                // current-dir parent rejected
+		{"kube-cluster-paris/config", "kube-cluster-paris"}, // relative parent honored
 	}
 	for _, c := range cases {
 		if got := kubeconfigSourceLabel(c.path); got != c.want {
 			t.Errorf("kubeconfigSourceLabel(%q) = %q, want %q", c.path, got, c.want)
 		}
+	}
+}
+
+// In multi-kubeconfig mode, every ContextInfo returned from
+// GetAvailableContexts must carry the source label of the file it came
+// from, even when context names don't collide. The frontend uses this
+// to render a "from kubeconfig X" affordance, and the contract is
+// invisible from the registry-level tests above.
+func TestGetAvailableContexts_PopulatesSourceInMultiFileMode(t *testing.T) {
+	parisDir := filepath.Join(t.TempDir(), ".kube-cluster-paris")
+	londonDir := filepath.Join(t.TempDir(), ".kube-cluster-london")
+	for _, d := range []string{parisDir, londonDir} {
+		if err := os.MkdirAll(d, 0o700); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	f1 := writeKubeconfig(t, parisDir, "config", "ctx-paris", []kubeEntry{
+		{ctxName: "ctx-paris", userName: "u1", clusterName: "c1"},
+	})
+	f2 := writeKubeconfig(t, londonDir, "config", "ctx-london", []kubeEntry{
+		{ctxName: "ctx-london", userName: "u2", clusterName: "c2"},
+	})
+
+	clientMu.Lock()
+	prevRegistry := contextRegistry
+	prevConfigs := perFileConfigs
+	prevMtimes := perFileMtimes
+	prevPaths := kubeconfigPaths
+	prevName := contextName
+	registry, fileConfigs := buildContextRegistry([]string{f1, f2})
+	mtimes := make(map[string]time.Time, 2)
+	for _, p := range []string{f1, f2} {
+		if info, err := os.Stat(p); err == nil {
+			mtimes[p] = info.ModTime()
+		}
+	}
+	contextRegistry = registry
+	perFileConfigs = fileConfigs
+	perFileMtimes = mtimes
+	kubeconfigPaths = []string{f1, f2}
+	contextName = "ctx-paris"
+	clientMu.Unlock()
+	t.Cleanup(func() {
+		clientMu.Lock()
+		contextRegistry = prevRegistry
+		perFileConfigs = prevConfigs
+		perFileMtimes = prevMtimes
+		kubeconfigPaths = prevPaths
+		contextName = prevName
+		clientMu.Unlock()
+	})
+
+	contexts, err := GetAvailableContexts()
+	if err != nil {
+		t.Fatalf("GetAvailableContexts: %v", err)
+	}
+	bySource := map[string]string{} // qName -> source
+	for _, c := range contexts {
+		bySource[c.Name] = c.Source
+	}
+	if got, want := bySource["ctx-paris"], "kube-cluster-paris"; got != want {
+		t.Errorf("ctx-paris Source: got %q, want %q (all: %v)", got, want, bySource)
+	}
+	if got, want := bySource["ctx-london"], "kube-cluster-london"; got != want {
+		t.Errorf("ctx-london Source: got %q, want %q (all: %v)", got, want, bySource)
 	}
 }
 

--- a/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
+++ b/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
@@ -19,12 +19,9 @@ export interface ClusterSwitcherItem {
   name: string
   secondary?: string
   badge?: string
-  /** Origin/source label, rendered as a small folder-icon chip after the
-   *  badge. Use for "where this cluster came from" when multiple sources
-   *  could otherwise produce visually-identical rows (e.g. kubeconfig
-   *  source folder when many files contain the same context name). The
-   *  caller is responsible for only setting this when 2+ distinct sources
-   *  exist — the chip surfaces unconditionally when present. */
+  /** Origin label, rendered as a folder-icon line under the name.
+   *  Caller must only set this when 2+ distinct sources exist — the
+   *  chip surfaces unconditionally when present. */
   sourceLabel?: string
   group?: { key: string; label?: string }
   disabled?: boolean
@@ -46,11 +43,8 @@ export interface ClusterSwitcherProps {
   /** Raw context / display string. Pass it as-is — the trigger renders
    *  through ClusterName, which handles parse + provider badge + tooltip. */
   currentName: string
-  /** When set, the trigger renders a small folder-icon chip next to the
-   *  current cluster name so the user can tell apart kubeconfig sources
-   *  at a glance — same visual language as the per-row sourceLabel. Only
-   *  pass when 2+ distinct sources are loaded; otherwise the chip is
-   *  noise. */
+  /** Trigger-side counterpart to {@link ClusterSwitcherItem.sourceLabel}.
+   *  Only pass when 2+ kubeconfig sources are loaded. */
   currentSourceLabel?: string
   items: ClusterSwitcherItem[]
   onSelect?: (item: ClusterSwitcherItem) => void

--- a/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
+++ b/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
@@ -7,8 +7,9 @@ import {
   forwardRef,
   useImperativeHandle,
 } from 'react'
-import { ChevronDown, Check, Loader2, Search, Server, X } from 'lucide-react'
+import { ChevronDown, Check, FolderOpen, Loader2, Search, Server, X } from 'lucide-react'
 import { ClusterName } from '../ui/ClusterName'
+import { MiddleEllipsis } from '../ui/MiddleEllipsis'
 import { StatusDot, type StatusTone } from '../ui/status-tone'
 
 export interface ClusterSwitcherItem {
@@ -18,6 +19,13 @@ export interface ClusterSwitcherItem {
   name: string
   secondary?: string
   badge?: string
+  /** Origin/source label, rendered as a small folder-icon chip after the
+   *  badge. Use for "where this cluster came from" when multiple sources
+   *  could otherwise produce visually-identical rows (e.g. kubeconfig
+   *  source folder when many files contain the same context name). The
+   *  caller is responsible for only setting this when 2+ distinct sources
+   *  exist — the chip surfaces unconditionally when present. */
+  sourceLabel?: string
   group?: { key: string; label?: string }
   disabled?: boolean
   status?: StatusTone
@@ -38,6 +46,12 @@ export interface ClusterSwitcherProps {
   /** Raw context / display string. Pass it as-is — the trigger renders
    *  through ClusterName, which handles parse + provider badge + tooltip. */
   currentName: string
+  /** When set, the trigger renders a small folder-icon chip next to the
+   *  current cluster name so the user can tell apart kubeconfig sources
+   *  at a glance — same visual language as the per-row sourceLabel. Only
+   *  pass when 2+ distinct sources are loaded; otherwise the chip is
+   *  noise. */
+  currentSourceLabel?: string
   items: ClusterSwitcherItem[]
   onSelect?: (item: ClusterSwitcherItem) => void
   searchable?: boolean
@@ -63,6 +77,7 @@ const TRIGGER_NAME_MAX_WIDTH = 'max-w-[160px] sm:max-w-[260px] xl:max-w-[400px]'
 export const ClusterSwitcher = forwardRef<ClusterSwitcherHandle, ClusterSwitcherProps>(({
   currentId,
   currentName,
+  currentSourceLabel,
   items,
   onSelect,
   searchable = true,
@@ -96,6 +111,7 @@ export const ClusterSwitcher = forwardRef<ClusterSwitcherHandle, ClusterSwitcher
         item.name.toLowerCase().includes(q) ||
         item.secondary?.toLowerCase().includes(q) ||
         item.badge?.toLowerCase().includes(q) ||
+        item.sourceLabel?.toLowerCase().includes(q) ||
         item.group?.label?.toLowerCase().includes(q)
       )
     }
@@ -207,12 +223,29 @@ export const ClusterSwitcher = forwardRef<ClusterSwitcherHandle, ClusterSwitcher
           // while the dropdown is open — the popover already shows the raw
           // context inline (per-row secondary line), and an extra hover
           // tooltip would just overlap the search input.
-          <ClusterName
-            name={currentName}
-            fallbackBadge={<Server className="w-3.5 h-3.5 text-theme-text-secondary" />}
-            className={TRIGGER_NAME_MAX_WIDTH}
-            noTooltip={isOpen}
-          />
+          <>
+            <ClusterName
+              name={currentName}
+              fallbackBadge={<Server className="w-3.5 h-3.5 text-theme-text-secondary" />}
+              className={TRIGGER_NAME_MAX_WIDTH}
+              noTooltip={isOpen}
+            />
+            {currentSourceLabel && (
+              // Icon-only on the trigger: long folder paths (the very case
+              // that motivates the chip) middle-truncate to something
+              // useless like "kube-cluster-pro…ion-eu" and steal width
+              // from the cluster name + nav. The folder icon signals
+              // "multi-source — disambiguation in dropdown"; hover or
+              // open the dropdown for the full label.
+              <span
+                className="shrink-0 inline-flex items-center text-theme-text-tertiary opacity-80"
+                title={`From kubeconfig: ${currentSourceLabel}`}
+                aria-label={`From kubeconfig: ${currentSourceLabel}`}
+              >
+                <FolderOpen className="w-3 h-3" />
+              </span>
+            )}
+          </>
         )}
         <ChevronDown className={`w-3 h-3 ml-auto transition-transform ${isOpen ? 'rotate-180' : ''}`} />
       </button>
@@ -320,6 +353,20 @@ export const ClusterSwitcher = forwardRef<ClusterSwitcherHandle, ClusterSwitcher
                               </span>
                             )}
                           </div>
+                          {item.sourceLabel && (
+                            // Source chip lives on its own line under the
+                            // name so long folder paths get the full row
+                            // width to render via MiddleEllipsis. Inline
+                            // would steal width from the name and force
+                            // both to truncate.
+                            <div
+                              className="flex items-center gap-0.5 text-[10px] text-theme-text-tertiary opacity-80 mt-0.5"
+                              title={`From kubeconfig: ${item.sourceLabel}`}
+                            >
+                              <FolderOpen className="w-2.5 h-2.5 shrink-0" />
+                              <MiddleEllipsis text={item.sourceLabel} className="font-mono" />
+                            </div>
+                          )}
                           {item.secondary && (
                             <div
                               className="text-[10px] text-theme-text-tertiary opacity-70 truncate mt-0.5"

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -329,6 +329,11 @@ export interface ContextInfo {
   user: string
   namespace: string
   isCurrent: boolean
+  /** Short, human-recognisable label for the kubeconfig file this context
+   *  came from (e.g. "kube-cluster-paris" for ~/.kube-cluster-paris/config).
+   *  Backend sets this only in multi-kubeconfig mode; empty for single-file
+   *  and in-cluster modes where there's no ambiguity to disambiguate. */
+  source?: string
 }
 
 // Namespace

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -329,10 +329,8 @@ export interface ContextInfo {
   user: string
   namespace: string
   isCurrent: boolean
-  /** Short, human-recognisable label for the kubeconfig file this context
-   *  came from (e.g. "kube-cluster-paris" for ~/.kube-cluster-paris/config).
-   *  Backend sets this only in multi-kubeconfig mode; empty for single-file
-   *  and in-cluster modes where there's no ambiguity to disambiguate. */
+  /** Source kubeconfig label (e.g. "kube-cluster-paris"). Set by backend
+   *  only when 2+ kubeconfig files are loaded; empty otherwise. */
   source?: string
 }
 

--- a/web/src/components/ContextSwitcher.tsx
+++ b/web/src/components/ContextSwitcher.tsx
@@ -46,10 +46,10 @@ export const ContextSwitcher = forwardRef<ContextSwitcherHandle, ContextSwitcher
       hasMultipleAccounts: false,
       hasMultipleSources: false,
     }
-    // Strip the disambiguation suffix (e.g. " (kube-cluster-paris)" or
-    // " (kube-cluster-paris #2)") from the name BEFORE parsing — qualified
-    // names won't match the GKE/EKS/AKS regexes otherwise, and the suffix
-    // is redundant with the source chip we'll render separately.
+    // Strip the disambiguation suffix (" (<source>)" or " (<source> #N)")
+    // before parsing — qualified names won't match the GKE/EKS/AKS regexes
+    // otherwise, and the suffix is redundant with the source chip we
+    // render separately.
     const stripSourceSuffix = (name: string, source?: string): string => {
       if (!source) return name
       const escaped = source.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -89,14 +89,6 @@ export const ContextSwitcher = forwardRef<ContextSwitcherHandle, ContextSwitcher
         : hasMultipleAccounts
           ? 'Other'
           : undefined
-      // `id` is the canonical qualified name (e.g. "admin@cluster
-      // (kube-cluster-paris)") — used for selection and as the unique key.
-      // `name` is the source-stripped form ClusterName parses for display,
-      // since the qualified " (...)" suffix would otherwise prevent the
-      // cloud regexes from matching and clutter custom names. The dropped
-      // suffix is restored in the row via `sourceLabel`, which renders as
-      // a small folder-icon chip — but only when 2+ kubeconfig sources are
-      // in play, so single-kubeconfig setups stay clean.
       return {
         id: p.context.name,
         name: p.raw,

--- a/web/src/components/ContextSwitcher.tsx
+++ b/web/src/components/ContextSwitcher.tsx
@@ -37,13 +37,37 @@ export const ContextSwitcher = forwardRef<ContextSwitcherHandle, ContextSwitcher
   const { tabs } = useDock()
 
   // Parse contexts and decide whether to render group headers (multi-account only).
-  const { parsedById, hasMultipleAccounts } = useMemo(() => {
-    if (!contexts) return { parsedById: new Map<string, ParsedContext>(), hasMultipleAccounts: false }
-    const parsed: ParsedContext[] = contexts.map(ctx => ({ context: ctx, ...parseContextName(ctx.name) }))
+  // hasMultipleSources gates the kubeconfig-source chip — only useful when 2+
+  // distinct kubeconfig files are in play. Single-source setups (the common
+  // case) skip the chip entirely so the dropdown stays clean.
+  const { parsedById, hasMultipleAccounts, hasMultipleSources } = useMemo(() => {
+    if (!contexts) return {
+      parsedById: new Map<string, ParsedContext>(),
+      hasMultipleAccounts: false,
+      hasMultipleSources: false,
+    }
+    // Strip the disambiguation suffix (e.g. " (kube-cluster-paris)" or
+    // " (kube-cluster-paris #2)") from the name BEFORE parsing — qualified
+    // names won't match the GKE/EKS/AKS regexes otherwise, and the suffix
+    // is redundant with the source chip we'll render separately.
+    const stripSourceSuffix = (name: string, source?: string): string => {
+      if (!source) return name
+      const escaped = source.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      return name.replace(new RegExp(`\\s+\\(${escaped}(?:\\s+#\\d+)?\\)$`), '')
+    }
+    const parsed: ParsedContext[] = contexts.map(ctx => ({
+      context: ctx,
+      ...parseContextName(stripSourceSuffix(ctx.name, ctx.source)),
+    }))
     const accounts = new Set(parsed.map(p => `${p.provider}:${p.account}`))
+    const sources = new Set(contexts.map(c => c.source).filter(Boolean))
     const byId = new Map<string, ParsedContext>()
     for (const p of parsed) byId.set(p.context.name, p)
-    return { parsedById: byId, hasMultipleAccounts: accounts.size > 1 }
+    return {
+      parsedById: byId,
+      hasMultipleAccounts: accounts.size > 1,
+      hasMultipleSources: sources.size > 1,
+    }
   }, [contexts])
 
   // Map parsed contexts → generic ClusterSwitcher items, sorted GKE/EKS/AKS/Other → account → name.
@@ -65,20 +89,24 @@ export const ContextSwitcher = forwardRef<ContextSwitcherHandle, ContextSwitcher
         : hasMultipleAccounts
           ? 'Other'
           : undefined
-      // `name` is the raw context — ClusterSwitcher renders it through
-      // ClusterName, which collapses GKE/EKS/AKS shapes to the meaningful
-      // tail. `secondary` shows the original raw when we collapsed it,
-      // so users always see the full context at a glance (rather than
-      // having to hover to reveal it).
+      // `id` is the canonical qualified name (e.g. "admin@cluster
+      // (kube-cluster-paris)") — used for selection and as the unique key.
+      // `name` is the source-stripped form ClusterName parses for display,
+      // since the qualified " (...)" suffix would otherwise prevent the
+      // cloud regexes from matching and clutter custom names. The dropped
+      // suffix is restored in the row via `sourceLabel`, which renders as
+      // a small folder-icon chip — but only when 2+ kubeconfig sources are
+      // in play, so single-kubeconfig setups stay clean.
       return {
         id: p.context.name,
-        name: p.context.name,
+        name: p.raw,
         secondary: p.provider ? p.raw : undefined,
         badge: p.region || undefined,
+        sourceLabel: hasMultipleSources ? p.context.source : undefined,
         group: { key: groupKey, label: groupLabel },
       }
     })
-  }, [parsedById, hasMultipleAccounts])
+  }, [parsedById, hasMultipleAccounts, hasMultipleSources])
 
   const performSwitch = async (parsed: ParsedContext) => {
     startSwitch({
@@ -156,8 +184,15 @@ export const ContextSwitcher = forwardRef<ContextSwitcherHandle, ContextSwitcher
     )
   }
 
-  const currentRaw = clusterInfo?.context || contexts?.find(c => c.isCurrent)?.name || 'Unknown'
-  const currentId = contexts?.find(c => c.isCurrent)?.name
+  const currentCtx = contexts?.find(c => c.isCurrent)
+  const currentId = currentCtx?.name
+  // Use parsed.raw (the source-stripped form) for the trigger so the
+  // disambiguation suffix doesn't double up with the source chip.
+  // Fall back to clusterInfo.context for the very-early window before
+  // /api/contexts has resolved.
+  const currentParsed = currentId ? parsedById.get(currentId) : undefined
+  const currentRaw = currentParsed?.raw || clusterInfo?.context || currentCtx?.name || 'Unknown'
+  const currentSourceLabel = hasMultipleSources ? currentCtx?.source || undefined : undefined
 
   return (
     <>
@@ -166,6 +201,7 @@ export const ContextSwitcher = forwardRef<ContextSwitcherHandle, ContextSwitcher
         className={className}
         currentId={currentId}
         currentName={currentRaw}
+        currentSourceLabel={currentSourceLabel}
         items={items}
         onSelect={handleSelect}
         loading={switchContext.isPending}


### PR DESCRIPTION
Closes #651.

## Problem

Users with multiple kubeconfigs each named `config` inside distinct directories (`~/.kube-cluster-paris/config`, `~/.kube-cluster-london/config`, …) saw useless dropdown labels like `admin@cluster`, `admin@cluster (config)`, `admin@cluster (config #2)`. The disambiguator was the file basename, which collapses to `config` for the common per-directory layout — disambiguating nothing.

## Fix

**Backend** (`internal/k8s/`):
- New `kubeconfigSourceLabel(path)` helper: when the file basename is generic (`config`/`kubeconfig`), use the parent directory name with leading dot stripped (`.kube-cluster-paris/config` → `kube-cluster-paris`); otherwise use the filename without extension. Both `qualifyContextName` and `aggregateExecPluginCommands` use it for consistency.
- New `Source` field on `ContextInfo` JSON, populated only in multi-kubeconfig mode.

**Frontend** (`packages/k8s-ui/`, `web/src/`):
- Per-row source label rendered as a small folder-icon line **under** the cluster name, full row width, with `MiddleEllipsis` as a fallback for very long paths. Source is included in the search predicate so typing a folder name filters the list.
- Trigger button gets a folder-icon affordance (with full label in `title`/`aria-label`); kept icon-only because long folder paths middle-truncate to useless prefixes (`kube-cluster-pro…ion-eu`) and were squeezing the header nav into a hamburger.
- Both surface the source only when 2+ distinct kubeconfig sources are loaded — single-file setups remain visually unchanged.
- The qualified-name suffix (e.g. ` (kube-cluster-paris)`) is stripped from the display name so cloud-provider parsing still kicks in for `gke_…`/`arn:aws:…` names that ended up qualified.

## Tests

- Two new Go tests: `TestBuildContextRegistry_GenericFilenameUsesParentDir` (issue #651 repro) and `TestKubeconfigSourceLabel` (table-driven for path → label mapping including dot-stripped parents, meaningful filenames, and root-path edge case).
- Visually verified across four scenarios in a real cluster (`/visual-test`): single kubeconfig (no chip), 2 meaningfully-named files, the issue #651 repro, and a long-name stress test (`kube-cluster-production-eu-central-1` etc.).