### PR TITLE
fix(desktop): show version in Help > About Radar dialog

### DIFF
--- a/cmd/desktop/main.go
+++ b/cmd/desktop/main.go
@@ -168,7 +168,7 @@ func main() {
 			Handler: NewRedirectHandler(srv.ActualAddr(), cfg.Namespace),
 		},
 
-		Menu: createMenu(desktopApp),
+		Menu: createMenu(desktopApp, version),
 
 		BackgroundColour: options.NewRGBA(10, 10, 15, 255),
 

--- a/cmd/desktop/menu.go
+++ b/cmd/desktop/menu.go
@@ -6,7 +6,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
-func createMenu(desktopApp *DesktopApp) *menu.Menu {
+func createMenu(desktopApp *DesktopApp, version string) *menu.Menu {
 	appMenu := menu.NewMenu()
 
 	// File menu
@@ -105,7 +105,7 @@ func createMenu(desktopApp *DesktopApp) *menu.Menu {
 		runtime.MessageDialog(desktopApp.ctx, runtime.MessageDialogOptions{
 			Type:    runtime.InfoDialog,
 			Title:   "About Radar",
-			Message: "Radar — Kubernetes Visibility Tool\nBuilt by Skyhook\n\nhttps://github.com/skyhook-io/radar",
+			Message: "Radar — Kubernetes Visibility Tool\nBuilt by Skyhook\n\nVersion: " + version + "\n\nhttps://github.com/skyhook-io/radar",
 		})
 	})
 	helpMenu.AddText("Documentation", nil, func(_ *menu.CallbackData) {


### PR DESCRIPTION
## Summary
- Pass the build-time `version` string into `createMenu` and include it in the Help > About Radar dialog message.
- The macOS-native About panel (`mac.Options.About`) already shows the version; Windows and Linux users only see the Help menu dialog, which previously listed name + URL with no version. This mirrors the Mac panel for parity.

Closes #649

## Test plan
- [ ] On Windows/Linux desktop builds, open Help > About Radar and confirm "Version: <semver>" appears below the tagline.
- [ ] On macOS, confirm both the system About panel and Help > About Radar show the same version string.
- [ ] In a `wails dev`/unreleased build, confirm the dialog shows "Version: dev" (no ldflags) without crashing.