### PR TITLE
fix(layout): scope BottomDock and ResourceDetailDrawer to their container instead of the viewport

### DIFF
--- a/packages/k8s-ui/src/components/dock/BottomDock.tsx
+++ b/packages/k8s-ui/src/components/dock/BottomDock.tsx
@@ -105,11 +105,11 @@ export function BottomDock({ renderTabContent, renderTabHeaderExtra, leftOffset:
     return null
   }
 
-  const effectiveHeight = !isExpanded ? 36 : isMaximized ? `calc(100vh - ${MAXIMIZED_TOP_OFFSET}px)` : height
+  const effectiveHeight = !isExpanded ? 36 : isMaximized ? `calc(100% - ${MAXIMIZED_TOP_OFFSET}px)` : height
 
   return (
     <div
-      className="fixed bottom-0 right-0 bg-theme-base border-t border-theme-border flex flex-col z-40 overflow-hidden"
+      className="absolute bottom-0 right-0 bg-theme-base border-t border-theme-border flex flex-col z-40 overflow-hidden"
       style={{ height: effectiveHeight, left: leftOffset, transition: `height ${DURATION_DOCK}ms cubic-bezier(0.4, 0, 0.2, 1), left ${DURATION_DOCK}ms ease-out` }}
     >
       {isExpanded && !isMaximized && (

--- a/packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx
+++ b/packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx
@@ -115,7 +115,7 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
   return (
     <div
       className={clsx(
-        'fixed right-0 bg-theme-surface border-l border-theme-border flex flex-col shadow-drawer z-40',
+        'absolute right-0 bg-theme-surface border-l border-theme-border flex flex-col shadow-drawer z-40',
         TRANSITION_DRAWER,
         isOpen
           ? 'translate-x-0 opacity-100'
@@ -123,9 +123,9 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
         expanded && '!border-l-0',
       )}
       style={{
-        width: expanded ? `calc(100vw - ${leftOffset}px)` : drawerWidth,
+        width: expanded ? `calc(100% - ${leftOffset}px)` : drawerWidth,
         top: headerHeight,
-        height: `calc(100vh - ${headerHeight}px)`,
+        height: `calc(100% - ${headerHeight}px)`,
         // Collapse is instant — no animation, content and width snap together.
         // Expand + slide-in/out animate via TRANSITION_DRAWER class.
         ...(isCollapsing && { transition: 'none' }),

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -828,7 +828,7 @@ function AppInner() {
 
   return (
     <PortForwardProvider>
-    <div className="flex flex-col h-screen bg-theme-base min-w-[800px]">
+    <div className="relative flex flex-col h-screen bg-theme-base min-w-[800px]">
       {/* Header */}
       <header className="relative z-50 flex items-center justify-between px-4 py-2 bg-theme-base/90 backdrop-blur-sm border-b border-theme-border/50">
         {/* Left: Logo + Cluster info */}


### PR DESCRIPTION
## Summary
- Switch `BottomDock` from `fixed` to `absolute` positioning and base maximized height on `100%` of the parent.
- Apply the same fix to `ResourceDetailDrawer`: `fixed` → `absolute`, with width/height based on `100%` of the parent (covers the expanded full-screen mode too).
- Mark the App shell `relative` so both surfaces anchor to the Radar surface, not the viewport.

## Why
When Radar is consumed as an embedded library (e.g. Radar Hub), viewport-anchored positioning made the dock and the expanded resource drawer escape the Radar surface and overlap the host app's chrome. Scoping these surfaces to their container lets them size correctly inside any embedding context while remaining unchanged for the standalone app.

## Test plan
- [x] Standalone Radar: open dock, expand, maximize — verify height/position match previous behavior.
- [x] Standalone Radar: open the resource drawer, expand it to full-screen — verify it fills the Radar surface as before.
- [x] Embedded (Radar Hub): dock no longer escapes the Radar surface or overlaps host chrome.
- [x] Embedded (Radar Hub): expanded resource drawer stays scoped to the Radar surface.
- [x] Resize window with dock open at each size mode (collapsed / expanded / maximized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)