### PR TITLE
fix(install): add `radar` symlink alongside `kubectl-radar`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -67,16 +67,26 @@ else
   tar -xzf "$FILENAME"
 fi
 
-# Install. Also create a `radar` symlink so the binary can be invoked as
-# `kubectl radar` (plugin), `kubectl-radar`, or just `radar` — matches the
-# Homebrew formula's bin.install_symlink behavior.
+# Install
 if [ -w "$INSTALL_DIR" ]; then
   mv "$BINARY_NAME" "$INSTALL_DIR/"
-  [ "$OS" = "windows" ] || ln -sf "$BINARY_NAME" "$INSTALL_DIR/radar"
+  SUDO=""
 else
   echo "Installing to ${INSTALL_DIR} (requires sudo)..."
   sudo mv "$BINARY_NAME" "$INSTALL_DIR/"
-  [ "$OS" = "windows" ] || sudo ln -sf "$BINARY_NAME" "$INSTALL_DIR/radar"
+  SUDO="sudo"
+fi
+
+# Symlink so the binary can also be invoked as `radar`. Best-effort —
+# the primary install already succeeded, and `radar` is a common-enough
+# name that we refuse to clobber an unrelated regular file.
+if [ "$OS" != "windows" ]; then
+  if [ -e "$INSTALL_DIR/radar" ] && [ ! -L "$INSTALL_DIR/radar" ]; then
+    echo "Note: ${INSTALL_DIR}/radar already exists and is not a symlink — skipping shorthand. Use 'kubectl-radar' or 'kubectl radar'." >&2
+  else
+    $SUDO ln -sf "$BINARY_NAME" "$INSTALL_DIR/radar" || \
+      echo "Warning: could not create 'radar' symlink — use 'kubectl-radar' or 'kubectl radar'." >&2
+  fi
 fi
 
 # Cleanup

--- a/install.sh
+++ b/install.sh
@@ -67,12 +67,16 @@ else
   tar -xzf "$FILENAME"
 fi
 
-# Install
+# Install. Also create a `radar` symlink so the binary can be invoked as
+# `kubectl radar` (plugin), `kubectl-radar`, or just `radar` — matches the
+# Homebrew formula's bin.install_symlink behavior.
 if [ -w "$INSTALL_DIR" ]; then
   mv "$BINARY_NAME" "$INSTALL_DIR/"
+  [ "$OS" = "windows" ] || ln -sf "$BINARY_NAME" "$INSTALL_DIR/radar"
 else
   echo "Installing to ${INSTALL_DIR} (requires sudo)..."
   sudo mv "$BINARY_NAME" "$INSTALL_DIR/"
+  [ "$OS" = "windows" ] || sudo ln -sf "$BINARY_NAME" "$INSTALL_DIR/radar"
 fi
 
 # Cleanup
@@ -82,7 +86,7 @@ echo ""
 echo "Radar v${VERSION} installed successfully!"
 echo ""
 echo "Usage:"
+echo "  radar                  # standalone"
 echo "  kubectl radar          # as kubectl plugin"
-echo "  kubectl-radar          # standalone"
 echo ""
-echo "Run 'kubectl radar --help' for more options."
+echo "Run 'radar --help' for more options."


### PR DESCRIPTION
## Summary

The curl installer (`curl -fsSL https://get.radarhq.io | sh`) only installed `kubectl-radar`, but the Homebrew formula has always also created a `radar` symlink (`.goreleaser.yaml:161` — `bin.install_symlink "kubectl-radar" => "radar"`). Users installing via curl ended up without the short `radar` command, even though docs and the post-install message imply it exists.

## Changes

- Symlink `kubectl-radar` → `radar` after install on macOS/Linux (skipped on Windows where symlinks aren't reliably available; Windows users get the binary via scoop or install.ps1).
- Update the post-install usage hint to lead with `radar` since it's the shortest invocation.

## Test plan

- [ ] `curl -fsSL https://get.radarhq.io | sh` (after release) — verify `radar --help` works
- [ ] Confirm `kubectl radar` and `kubectl-radar` still work (same binary)