### PR TITLE
chart: reject replicaCount>1 when persistence+sqlite enabled (#622)

### DIFF
--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.persistence.enabled (eq .Values.timeline.storage "sqlite") (gt (int .Values.replicaCount) 1) }}
+{{- fail "replicaCount must be 1 when persistence.enabled=true and timeline.storage=sqlite: a single PVC cannot be safely shared across pods (RWO volumes won't attach to a second pod, RWX volumes risk SQLite corruption)" }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -1,5 +1,11 @@
 # Default values for radar.
 
+# Radar is designed to run as a single replica. Each pod holds its own
+# in-memory K8s informer cache, SSE streams, exec/port-forward sessions, and
+# (in memory mode) timeline buffer — none of which are shared across pods.
+# Setting replicaCount > 1 produces a confusing UX even when it doesn't fail
+# outright. The chart hard-fails replicaCount > 1 when persistence+sqlite are
+# enabled (single PVC + SQLite cannot be safely shared across pods).
 replicaCount: 1
 
 image:


### PR DESCRIPTION
Closes #622.

Adds a Helm `fail` guard that rejects `replicaCount > 1` when both `persistence.enabled=true` and `timeline.storage=sqlite`. A single PVC cannot be safely shared across pods: RWO volumes (EBS, GCP PD) refuse to attach to a second pod, and RWX volumes (EFS, NFS) risk SQLite corruption from concurrent writers. Catching this at install/upgrade time is much friendlier than the alternatives — stuck `Pending` pods, or silent DB corruption.

Also added a comment in `values.yaml` noting that Radar is designed for single-replica operation in general: each pod holds its own informer cache, SSE streams, exec/port-forward sessions, and (in `memory` mode) timeline buffer. Multi-replica produces a confusing UX even when it doesn't fail outright. We don't hard-fail that broader case — only the sqlite combination, where it's actively broken — but the comment flags the intent.

Verified:
- Default values: renders cleanly
- `replicaCount=2 + persistence + sqlite`: fails with the expected message
- `replicaCount=2 + timeline.storage=memory` (default): still allowed

Note: the issue also references `skyhook-io/helm-charts#13`. This PR only patches the chart in this repo (`deploy/helm/radar/`); the public `helm-charts` repo may need the same fix synced separately.