### PR TITLE
portforward: infer https/http for forwarded URLs (#656)

### DIFF
--- a/internal/server/portforward.go
+++ b/internal/server/portforward.go
@@ -37,7 +37,7 @@ type PortForwardSession struct {
 	LocalPort     int       `json:"localPort"`
 	ListenAddress string    `json:"listenAddress"` // "127.0.0.1" or "0.0.0.0"
 	ServiceName   string    `json:"serviceName,omitempty"` // If forwarding to a service
-	Scheme        string    `json:"scheme,omitempty"`      // "https" / "http" / "" — guessed from appProtocol/name/port
+	Scheme        string    `json:"scheme,omitempty"`      // "https", "http", or "" if unknown
 	StartedAt     time.Time `json:"startedAt"`
 	Status        string    `json:"status"` // "running", "stopped", "error"
 	Error         string    `json:"error,omitempty"`
@@ -445,8 +445,7 @@ func resolveNamedPort(pod *corev1.Pod, portName string) (int, bool) {
 }
 
 // validatePodPort checks if the pod actually exposes the requested port and
-// returns the URL scheme inferred from the matching container port's
-// appProtocol/name/number ("https"/"http"/"" — empty when no signal).
+// returns the URL scheme inferred from the matching container port.
 // Uses the caller-supplied impersonated client so the pod read is subject
 // to the user's K8s RBAC.
 func validatePodPort(ctx context.Context, client kubernetes.Interface, namespace, podName string, port int) (string, error) {
@@ -518,7 +517,7 @@ type AvailablePort struct {
 	Protocol      string `json:"protocol"`
 	ContainerName string `json:"containerName"`
 	Name          string `json:"name,omitempty"` // Named port
-	Scheme        string `json:"scheme,omitempty"` // "https" / "http" / "" — guessed from appProtocol/name/port
+	Scheme        string `json:"scheme,omitempty"` // "https", "http", or "" if unknown
 }
 
 // AvailablePortsResponse is the response for the available ports endpoint

--- a/internal/server/portforward.go
+++ b/internal/server/portforward.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -26,6 +25,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/skyhook-io/radar/internal/auth"
+	"github.com/skyhook-io/radar/pkg/k8score"
 )
 
 // PortForwardSession represents an active port forward
@@ -37,6 +37,7 @@ type PortForwardSession struct {
 	LocalPort     int       `json:"localPort"`
 	ListenAddress string    `json:"listenAddress"` // "127.0.0.1" or "0.0.0.0"
 	ServiceName   string    `json:"serviceName,omitempty"` // If forwarding to a service
+	Scheme        string    `json:"scheme,omitempty"`      // "https" / "http" / "" — guessed from appProtocol/name/port
 	StartedAt     time.Time `json:"startedAt"`
 	Status        string    `json:"status"` // "running", "stopped", "error"
 	Error         string    `json:"error,omitempty"`
@@ -134,25 +135,29 @@ func (s *Server) handleStartPortForward(w http.ResponseWriter, r *http.Request) 
 	// If service name provided, find a pod backing it and resolve the target port
 	podName := req.PodName
 	podPort := req.PodPort
+	scheme := ""
 	serviceResolved := false
 	if req.ServiceName != "" && podName == "" {
-		foundPod, containerPort, err := findPodForService(r.Context(), client, req.Namespace, req.ServiceName, req.PodPort)
+		foundPod, containerPort, svcScheme, err := findPodForService(r.Context(), client, req.Namespace, req.ServiceName, req.PodPort)
 		if err != nil {
 			s.writeError(w, http.StatusNotFound, fmt.Sprintf("No pod found for service %s: %v", req.ServiceName, err))
 			return
 		}
 		podName = foundPod
 		podPort = containerPort
+		scheme = svcScheme
 		serviceResolved = true
 	}
 
 	// Validate that the pod actually exposes this port (skip for service-resolved ports
 	// since the service spec is authoritative and containers may not declare ports)
 	if !serviceResolved {
-		if err := validatePodPort(r.Context(), client, req.Namespace, podName, podPort); err != nil {
+		podScheme, err := validatePodPort(r.Context(), client, req.Namespace, podName, podPort)
+		if err != nil {
 			s.writeError(w, http.StatusBadRequest, err.Error())
 			return
 		}
+		scheme = podScheme
 	}
 
 	// Find available local port if not specified
@@ -196,6 +201,7 @@ func (s *Server) handleStartPortForward(w http.ResponseWriter, r *http.Request) 
 		LocalPort:     localPort,
 		ListenAddress: listenAddr,
 		ServiceName:   req.ServiceName,
+		Scheme:        scheme,
 		StartedAt:     time.Now(),
 		Status:        "starting",
 		cancel:        cancel,
@@ -330,7 +336,9 @@ func runPortForward(ctx context.Context, session *PortForwardSession) error {
 }
 
 // findPodForService resolves a service port to a backing pod and the container target port.
-// It returns the pod name and the resolved container port to forward to.
+// It returns the pod name, the resolved container port to forward to, and the
+// inferred URL scheme ("https"/"http"/"") guessed from the matching service
+// port's appProtocol/name/number.
 // This follows the same resolution logic as kubectl port-forward:
 //   - Headless services (ClusterIP=None): use the service port directly
 //   - Integer targetPort: use the targetPort value (defaults to service port if unset)
@@ -338,33 +346,39 @@ func runPortForward(ctx context.Context, session *PortForwardSession) error {
 //
 // Callers pass the impersonated client from getClientForRequest so the
 // service/pod reads are subject to the user's K8s RBAC.
-func findPodForService(ctx context.Context, client kubernetes.Interface, namespace, serviceName string, servicePort int) (string, int, error) {
+func findPodForService(ctx context.Context, client kubernetes.Interface, namespace, serviceName string, servicePort int) (string, int, string, error) {
 	if client == nil {
-		return "", 0, fmt.Errorf("cluster client not available")
+		return "", 0, "", fmt.Errorf("cluster client not available")
 	}
 
 	// Get service
 	svc, err := client.CoreV1().Services(namespace).Get(ctx, serviceName, metav1.GetOptions{})
 	if err != nil {
-		return "", 0, fmt.Errorf("failed to get service: %w", err)
+		return "", 0, "", fmt.Errorf("failed to get service: %w", err)
 	}
 
 	if len(svc.Spec.Selector) == 0 {
-		return "", 0, fmt.Errorf("service has no selector")
+		return "", 0, "", fmt.Errorf("service has no selector")
 	}
 
 	// Find the matching service port entry
 	var targetPort intstr.IntOrString
+	var scheme string
 	found := false
 	for _, port := range svc.Spec.Ports {
 		if int(port.Port) == servicePort {
 			targetPort = port.TargetPort
+			appProto := ""
+			if port.AppProtocol != nil {
+				appProto = *port.AppProtocol
+			}
+			scheme = k8score.InferPortScheme(port.Name, appProto, port.Port)
 			found = true
 			break
 		}
 	}
 	if !found {
-		return "", 0, fmt.Errorf("service does not expose port %d", servicePort)
+		return "", 0, "", fmt.Errorf("service does not expose port %d", servicePort)
 	}
 
 	// Find pods matching selector
@@ -372,21 +386,21 @@ func findPodForService(ctx context.Context, client kubernetes.Interface, namespa
 		LabelSelector: labels.Set(svc.Spec.Selector).String(),
 	})
 	if err != nil {
-		return "", 0, fmt.Errorf("failed to list pods: %w", err)
+		return "", 0, "", fmt.Errorf("failed to list pods: %w", err)
 	}
 
 	if len(pods.Items) == 0 {
-		return "", 0, fmt.Errorf("no pods found matching selector")
+		return "", 0, "", fmt.Errorf("no pods found matching selector")
 	}
 
 	// Headless services (ClusterIP=None) skip targetPort resolution (matches kubectl behavior)
 	if svc.Spec.ClusterIP == corev1.ClusterIPNone {
 		for _, pod := range pods.Items {
 			if pod.Status.Phase == corev1.PodRunning {
-				return pod.Name, servicePort, nil
+				return pod.Name, servicePort, scheme, nil
 			}
 		}
-		return "", 0, fmt.Errorf("no running pod found")
+		return "", 0, "", fmt.Errorf("no running pod found")
 	}
 
 	// Named targetPort: resolve against running pods by looking up container port names
@@ -394,11 +408,11 @@ func findPodForService(ctx context.Context, client kubernetes.Interface, namespa
 		for _, pod := range pods.Items {
 			if pod.Status.Phase == corev1.PodRunning {
 				if resolved, ok := resolveNamedPort(&pod, targetPort.StrVal); ok {
-					return pod.Name, resolved, nil
+					return pod.Name, resolved, scheme, nil
 				}
 			}
 		}
-		return "", 0, fmt.Errorf("no running pod found with named port %q", targetPort.StrVal)
+		return "", 0, "", fmt.Errorf("no running pod found with named port %q", targetPort.StrVal)
 	}
 
 	// Numeric targetPort: use the value, or default to the service port if unset
@@ -411,11 +425,11 @@ func findPodForService(ctx context.Context, client kubernetes.Interface, namespa
 	// and containers can listen on ports without declaring them in the pod spec.
 	for _, pod := range pods.Items {
 		if pod.Status.Phase == corev1.PodRunning {
-			return pod.Name, containerPort, nil
+			return pod.Name, containerPort, scheme, nil
 		}
 	}
 
-	return "", 0, fmt.Errorf("no running pod found")
+	return "", 0, "", fmt.Errorf("no running pod found")
 }
 
 // resolveNamedPort looks up a named port in a pod's containers and returns the container port number.
@@ -430,24 +444,27 @@ func resolveNamedPort(pod *corev1.Pod, portName string) (int, bool) {
 	return 0, false
 }
 
-// validatePodPort checks if the pod actually exposes the requested port.
+// validatePodPort checks if the pod actually exposes the requested port and
+// returns the URL scheme inferred from the matching container port's
+// appProtocol/name/number ("https"/"http"/"" — empty when no signal).
 // Uses the caller-supplied impersonated client so the pod read is subject
 // to the user's K8s RBAC.
-func validatePodPort(ctx context.Context, client kubernetes.Interface, namespace, podName string, port int) error {
+func validatePodPort(ctx context.Context, client kubernetes.Interface, namespace, podName string, port int) (string, error) {
 	if client == nil {
-		return fmt.Errorf("cluster client not available")
+		return "", fmt.Errorf("cluster client not available")
 	}
 
 	pod, err := client.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to get pod: %w", err)
+		return "", fmt.Errorf("failed to get pod: %w", err)
 	}
 
 	if pod.Status.Phase != corev1.PodRunning {
-		return fmt.Errorf("pod is not running (status: %s)", pod.Status.Phase)
+		return "", fmt.Errorf("pod is not running (status: %s)", pod.Status.Phase)
 	}
 
-	if !podHasPort(pod, port) {
+	scheme, ok := podPortScheme(pod, port)
+	if !ok {
 		// List available ports for better error message
 		var availablePorts []string
 		for _, container := range pod.Spec.Containers {
@@ -456,24 +473,27 @@ func validatePodPort(ctx context.Context, client kubernetes.Interface, namespace
 			}
 		}
 		if len(availablePorts) == 0 {
-			return fmt.Errorf("pod does not expose any ports")
+			return "", fmt.Errorf("pod does not expose any ports")
 		}
-		return fmt.Errorf("pod does not expose port %d. Available ports: %s", port, strings.Join(availablePorts, ", "))
+		return "", fmt.Errorf("pod does not expose port %d. Available ports: %s", port, strings.Join(availablePorts, ", "))
 	}
 
-	return nil
+	return scheme, nil
 }
 
-// podHasPort checks if a pod has a container exposing the given port
-func podHasPort(pod *corev1.Pod, port int) bool {
+// podPortScheme finds the container port matching `port` and returns the
+// inferred URL scheme. Second return is false if no container exposes the port.
+// ContainerPort has no AppProtocol field (unlike ServicePort), so we infer
+// from name + number only.
+func podPortScheme(pod *corev1.Pod, port int) (string, bool) {
 	for _, container := range pod.Spec.Containers {
 		for _, p := range container.Ports {
 			if int(p.ContainerPort) == port {
-				return true
+				return k8score.InferPortScheme(p.Name, "", p.ContainerPort), true
 			}
 		}
 	}
-	return false
+	return "", false
 }
 
 func findFreePort() (int, error) {
@@ -491,10 +511,6 @@ func findFreePort() (int, error) {
 	return l.Addr().(*net.TCPAddr).Port, nil
 }
 
-// GetPortForwardURL returns a helper to format port forward URLs
-func GetPortForwardURL(localPort int) string {
-	return "http://localhost:" + strconv.Itoa(localPort)
-}
 
 // AvailablePort represents a port that can be forwarded
 type AvailablePort struct {
@@ -502,6 +518,7 @@ type AvailablePort struct {
 	Protocol      string `json:"protocol"`
 	ContainerName string `json:"containerName"`
 	Name          string `json:"name,omitempty"` // Named port
+	Scheme        string `json:"scheme,omitempty"` // "https" / "http" / "" — guessed from appProtocol/name/port
 }
 
 // AvailablePortsResponse is the response for the available ports endpoint
@@ -538,6 +555,7 @@ func (s *Server) handleGetAvailablePorts(w http.ResponseWriter, r *http.Request)
 					Protocol:      string(p.Protocol),
 					ContainerName: container.Name,
 					Name:          p.Name,
+					Scheme:        k8score.InferPortScheme(p.Name, "", p.ContainerPort),
 				})
 			}
 		}
@@ -550,10 +568,15 @@ func (s *Server) handleGetAvailablePorts(w http.ResponseWriter, r *http.Request)
 		}
 
 		for _, p := range svc.Spec.Ports {
+			appProto := ""
+			if p.AppProtocol != nil {
+				appProto = *p.AppProtocol
+			}
 			port := AvailablePort{
 				Port:     int(p.Port),
 				Protocol: string(p.Protocol),
 				Name:     p.Name,
+				Scheme:   k8score.InferPortScheme(p.Name, appProto, p.Port),
 			}
 			// If targetPort is different, note it
 			if p.TargetPort.Type == intstr.String && p.TargetPort.StrVal != "" {

--- a/pkg/k8score/portscheme.go
+++ b/pkg/k8score/portscheme.go
@@ -1,0 +1,40 @@
+package k8score
+
+import "strings"
+
+// InferPortScheme guesses the URL scheme for a Kubernetes Service or
+// Container port from the strongest available signal:
+//
+//  1. appProtocol — the K8s-native, authoritative hint when set
+//  2. port name   — common conventions (https, https-web, tls, http, h2c)
+//  3. port number — well-known web ports (443/8443/… vs 80/8080/…)
+//
+// Returns "https", "http", or "" when no signal is strong enough to guess.
+// Callers that need a default should treat "" as http.
+func InferPortScheme(name, appProtocol string, port int32) string {
+	switch strings.ToLower(strings.TrimSpace(appProtocol)) {
+	case "https", "tls":
+		return "https"
+	case "http", "http2", "h2c", "grpc", "grpc-web":
+		return "http"
+	}
+
+	lname := strings.ToLower(strings.TrimSpace(name))
+	switch {
+	case lname == "":
+		// fall through
+	case strings.Contains(lname, "https"), strings.Contains(lname, "tls"):
+		return "https"
+	case strings.Contains(lname, "http"), strings.Contains(lname, "h2c"):
+		return "http"
+	}
+
+	switch port {
+	case 443, 6443, 8443, 9443:
+		return "https"
+	case 80, 8000, 8080, 3000, 5000, 5001:
+		return "http"
+	}
+
+	return ""
+}

--- a/pkg/k8score/portscheme_test.go
+++ b/pkg/k8score/portscheme_test.go
@@ -1,0 +1,65 @@
+package k8score
+
+import "testing"
+
+func TestInferPortScheme(t *testing.T) {
+	tests := []struct {
+		name        string
+		portName    string
+		appProtocol string
+		port        int32
+		want        string
+	}{
+		{"appProtocol https wins over name and port", "http", "https", 80, "https"},
+		{"appProtocol tls -> https", "", "tls", 0, "https"},
+		{"appProtocol HTTPS case-insensitive", "", "HTTPS", 0, "https"},
+		{"appProtocol http", "", "http", 0, "http"},
+		{"appProtocol http2", "", "http2", 0, "http"},
+		{"appProtocol h2c", "", "h2c", 0, "http"},
+		{"appProtocol grpc -> http (cleartext)", "", "grpc", 0, "http"},
+		{"appProtocol grpc-web -> http", "", "grpc-web", 0, "http"},
+		{"appProtocol unrecognized falls through to name", "https", "kafka", 0, "https"},
+		{"appProtocol unrecognized + no name + arbitrary port -> empty", "", "kafka", 9092, ""},
+
+		{"name https", "https", "", 0, "https"},
+		{"name https-web", "https-web", "", 0, "https"},
+		{"name HTTPS-TLS case-insensitive", "HTTPS-TLS", "", 0, "https"},
+		{"name tls", "tls", "", 0, "https"},
+		{"name tls-grpc", "tls-grpc", "", 0, "https"},
+		{"name http", "http", "", 0, "http"},
+		{"name http-web", "http-web", "", 0, "http"},
+		{"name http2", "http2", "", 0, "http"},
+		{"name h2c", "h2c", "", 0, "http"},
+		{"name web alone -> empty (defer to port)", "web", "", 0, ""},
+		{"name web + port 80 -> http", "web", "", 80, "http"},
+
+		{"port 443", "", "", 443, "https"},
+		{"port 6443 (kube-apiserver)", "", "", 6443, "https"},
+		{"port 8443", "", "", 8443, "https"},
+		{"port 9443", "", "", 9443, "https"},
+		{"port 80", "", "", 80, "http"},
+		{"port 8080", "", "", 8080, "http"},
+		{"port 8000", "", "", 8000, "http"},
+		{"port 3000", "", "", 3000, "http"},
+		{"port 5000", "", "", 5000, "http"},
+
+		{"port 22 (ssh) -> empty", "", "", 22, ""},
+		{"port 5432 (postgres) -> empty", "", "", 5432, ""},
+		{"all empty -> empty", "", "", 0, ""},
+
+		{"appProtocol overrides conflicting name", "https", "http", 80, "http"},
+		{"name overrides conflicting port", "https", "", 80, "https"},
+		{"https in middle of name still matches", "x-https-y", "", 0, "https"},
+		{"name with whitespace trimmed", "  https  ", "", 0, "https"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := InferPortScheme(tt.portName, tt.appProtocol, tt.port)
+			if got != tt.want {
+				t.Errorf("InferPortScheme(%q, %q, %d) = %q, want %q",
+					tt.portName, tt.appProtocol, tt.port, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/k8score/portscheme_test.go
+++ b/pkg/k8score/portscheme_test.go
@@ -48,6 +48,7 @@ func TestInferPortScheme(t *testing.T) {
 		{"all empty -> empty", "", "", 0, ""},
 
 		{"appProtocol overrides conflicting name", "https", "http", 80, "http"},
+		{"appProtocol cleartext (grpc) wins over https name", "https", "grpc", 443, "http"},
 		{"name overrides conflicting port", "https", "", 80, "https"},
 		{"https in middle of name still matches", "x-https-y", "", 0, "https"},
 		{"name with whitespace trimmed", "  https  ", "", 0, "https"},

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1348,6 +1348,7 @@ export interface AvailablePort {
   protocol: string
   containerName?: string
   name?: string
+  scheme?: 'http' | 'https'
 }
 
 export function useAvailablePorts(type: 'pod' | 'service', namespace: string, name: string) {

--- a/web/src/components/portforward/PortForwardManager.tsx
+++ b/web/src/components/portforward/PortForwardManager.tsx
@@ -42,9 +42,14 @@ interface PortForwardSession {
   localPort: number
   listenAddress: string
   serviceName?: string
+  scheme?: 'http' | 'https'
   startedAt: string
   status: 'running' | 'stopped' | 'error'
   error?: string
+}
+
+function sessionUrl(session: PortForwardSession): string {
+  return `${session.scheme || 'http'}://localhost:${session.localPort}`
 }
 
 // --- Shared query ------------------------------------------------------------
@@ -521,7 +526,7 @@ export function PortForwardPanel() {
     async (session: PortForwardSession) => {
       commitInteraction()
       try {
-        await navigator.clipboard.writeText(`http://localhost:${session.localPort}`)
+        await navigator.clipboard.writeText(sessionUrl(session))
       } catch (err) {
         // Clipboard API can reject in non-secure contexts, denied permissions, or
         // when the document isn't focused. Surface the failure — the checkmark
@@ -544,7 +549,7 @@ export function PortForwardPanel() {
   const handleOpenUrl = useCallback(
     (session: PortForwardSession) => {
       commitInteraction()
-      openExternal(`http://localhost:${session.localPort}`)
+      openExternal(sessionUrl(session))
     },
     [commitInteraction]
   )


### PR DESCRIPTION
Closes #656.

Copy URL and Open in browser hardcoded `http://localhost:<port>`, so forwarding any HTTPS service (port 8443, named `https`, etc.) produced a broken link.

**Detection.** New `pkg/k8score.InferPortScheme(name, appProtocol, port)` helper that checks signals in order of authority:

1. `appProtocol` — the K8s-native, authoritative hint (`https`/`tls` → https; `http`/`http2`/`h2c`/`grpc`/`grpc-web` → http)
2. Port **name** — common conventions (contains `https`/`tls` → https; contains `http`/`h2c` → http)
3. Port **number** — well-known web ports (443, 6443, 8443, 9443 → https; 80, 8000, 8080, 3000, 5000 → http)
4. Otherwise `""` — frontend treats this as http

Wired into both `findPodForService` and `validatePodPort` (which already fetch the spec) and the `AvailablePort` picker response, so anywhere we surface a forwarded URL gets the same answer.

**Frontend.** `PortForwardSession` and `AvailablePort` both gain an optional `scheme` field. URL construction now goes through one helper:

\`\`\`ts
function sessionUrl(session) {
  return \`\${session.scheme || 'http'}://localhost:\${session.localPort}\`
}
\`\`\`

used by both Copy URL and Open in browser.

**Bonus.** Removed an unused `GetPortForwardURL` helper that also hardcoded `http://`.

**Tests.** New table-driven `TestInferPortScheme` covers 38 cases including precedence ordering, case-insensitivity, whitespace trimming, all the well-known port numbers, and ambiguous inputs that should return empty (port 22, port 5432, etc.). All passing.

**Limitation.** ContainerPort has no `appProtocol` field in K8s (only ServicePort does), so for pod port-forwards we infer from name + number only. In practice the picker for pods is a less common path; service forwards (where `appProtocol` lives) are the typical case.