### PR TITLE
Add fallback discovery for supported CRDs

### DIFF
--- a/internal/k8s/dynamic_cache.go
+++ b/internal/k8s/dynamic_cache.go
@@ -1,12 +1,16 @@
 package k8s
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"sync"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 
 	"github.com/skyhook-io/radar/internal/timeline"
 	"github.com/skyhook-io/radar/pkg/k8score"
@@ -127,6 +131,235 @@ func OnCRDDiscoveryComplete(callback func()) {
 	}
 }
 
+type supportedCRDResource struct {
+	Group      string
+	Versions   []string
+	Resource   string
+	Kind       string
+	Namespaced bool
+}
+
+var supportedCRDFallbacks = []supportedCRDResource{
+	{Group: "argoproj.io", Versions: []string{"v1alpha1"}, Resource: "applications", Kind: "Application", Namespaced: true},
+	{Group: "argoproj.io", Versions: []string{"v1alpha1"}, Resource: "applicationsets", Kind: "ApplicationSet", Namespaced: true},
+	{Group: "argoproj.io", Versions: []string{"v1alpha1"}, Resource: "appprojects", Kind: "AppProject", Namespaced: true},
+	{Group: "argoproj.io", Versions: []string{"v1alpha1"}, Resource: "rollouts", Kind: "Rollout", Namespaced: true},
+	{Group: "argoproj.io", Versions: []string{"v1alpha1"}, Resource: "workflows", Kind: "Workflow", Namespaced: true},
+	{Group: "argoproj.io", Versions: []string{"v1alpha1"}, Resource: "cronworkflows", Kind: "CronWorkflow", Namespaced: true},
+	{Group: "cert-manager.io", Versions: []string{"v1"}, Resource: "certificates", Kind: "Certificate", Namespaced: true},
+	{Group: "cert-manager.io", Versions: []string{"v1"}, Resource: "certificaterequests", Kind: "CertificateRequest", Namespaced: true},
+	{Group: "acme.cert-manager.io", Versions: []string{"v1"}, Resource: "orders", Kind: "Order", Namespaced: true},
+	{Group: "acme.cert-manager.io", Versions: []string{"v1"}, Resource: "challenges", Kind: "Challenge", Namespaced: true},
+	{Group: "source.toolkit.fluxcd.io", Versions: []string{"v1", "v1beta2"}, Resource: "gitrepositories", Kind: "GitRepository", Namespaced: true},
+	{Group: "source.toolkit.fluxcd.io", Versions: []string{"v1beta2"}, Resource: "ocirepositories", Kind: "OCIRepository", Namespaced: true},
+	{Group: "source.toolkit.fluxcd.io", Versions: []string{"v1", "v1beta2"}, Resource: "helmrepositories", Kind: "HelmRepository", Namespaced: true},
+	{Group: "kustomize.toolkit.fluxcd.io", Versions: []string{"v1", "v1beta2"}, Resource: "kustomizations", Kind: "Kustomization", Namespaced: true},
+	{Group: "helm.toolkit.fluxcd.io", Versions: []string{"v2", "v2beta2", "v2beta1"}, Resource: "helmreleases", Kind: "HelmRelease", Namespaced: true},
+	{Group: "notification.toolkit.fluxcd.io", Versions: []string{"v1beta3", "v1beta2"}, Resource: "alerts", Kind: "Alert", Namespaced: true},
+	{Group: "gateway.networking.k8s.io", Versions: []string{"v1", "v1beta1"}, Resource: "gatewayclasses", Kind: "GatewayClass", Namespaced: false},
+	{Group: "gateway.networking.k8s.io", Versions: []string{"v1", "v1beta1"}, Resource: "gateways", Kind: "Gateway", Namespaced: true},
+	{Group: "gateway.networking.k8s.io", Versions: []string{"v1", "v1beta1"}, Resource: "httproutes", Kind: "HTTPRoute", Namespaced: true},
+	{Group: "gateway.networking.k8s.io", Versions: []string{"v1", "v1beta1"}, Resource: "grpcroutes", Kind: "GRPCRoute", Namespaced: true},
+	{Group: "gateway.networking.k8s.io", Versions: []string{"v1alpha2"}, Resource: "tcproutes", Kind: "TCPRoute", Namespaced: true},
+	{Group: "gateway.networking.k8s.io", Versions: []string{"v1alpha2"}, Resource: "tlsroutes", Kind: "TLSRoute", Namespaced: true},
+	{Group: "networking.istio.io", Versions: []string{"v1", "v1beta1", "v1alpha3"}, Resource: "virtualservices", Kind: "VirtualService", Namespaced: true},
+	{Group: "networking.istio.io", Versions: []string{"v1", "v1beta1", "v1alpha3"}, Resource: "destinationrules", Kind: "DestinationRule", Namespaced: true},
+	{Group: "networking.istio.io", Versions: []string{"v1", "v1beta1", "v1alpha3"}, Resource: "gateways", Kind: "Gateway", Namespaced: true},
+	{Group: "networking.istio.io", Versions: []string{"v1", "v1beta1", "v1alpha3"}, Resource: "serviceentries", Kind: "ServiceEntry", Namespaced: true},
+	{Group: "karpenter.sh", Versions: []string{"v1", "v1beta1"}, Resource: "nodepools", Kind: "NodePool", Namespaced: false},
+	{Group: "karpenter.sh", Versions: []string{"v1", "v1beta1"}, Resource: "nodeclaims", Kind: "NodeClaim", Namespaced: false},
+	{Group: "karpenter.k8s.aws", Versions: []string{"v1", "v1beta1"}, Resource: "ec2nodeclasses", Kind: "EC2NodeClass", Namespaced: false},
+	{Group: "karpenter.azure.com", Versions: []string{"v1alpha2", "v1alpha1"}, Resource: "aksnodeclasses", Kind: "AKSNodeClass", Namespaced: false},
+	{Group: "karpenter.gcp.compute.com", Versions: []string{"v1alpha1"}, Resource: "gcpnodeclasses", Kind: "GCPNodeClass", Namespaced: false},
+	{Group: "keda.sh", Versions: []string{"v1alpha1"}, Resource: "scaledobjects", Kind: "ScaledObject", Namespaced: true},
+	{Group: "keda.sh", Versions: []string{"v1alpha1"}, Resource: "scaledjobs", Kind: "ScaledJob", Namespaced: true},
+	{Group: "keda.sh", Versions: []string{"v1alpha1"}, Resource: "triggerauthentications", Kind: "TriggerAuthentication", Namespaced: true},
+	{Group: "keda.sh", Versions: []string{"v1alpha1"}, Resource: "clustertriggerauthentications", Kind: "ClusterTriggerAuthentication", Namespaced: false},
+	{Group: "autoscaling.k8s.io", Versions: []string{"v1", "v1beta2"}, Resource: "verticalpodautoscalers", Kind: "VerticalPodAutoscaler", Namespaced: true},
+	{Group: "monitoring.coreos.com", Versions: []string{"v1"}, Resource: "servicemonitors", Kind: "ServiceMonitor", Namespaced: true},
+	{Group: "monitoring.coreos.com", Versions: []string{"v1"}, Resource: "podmonitors", Kind: "PodMonitor", Namespaced: true},
+	{Group: "monitoring.coreos.com", Versions: []string{"v1"}, Resource: "prometheusrules", Kind: "PrometheusRule", Namespaced: true},
+	{Group: "monitoring.coreos.com", Versions: []string{"v1"}, Resource: "alertmanagers", Kind: "Alertmanager", Namespaced: true},
+	{Group: "serving.knative.dev", Versions: []string{"v1"}, Resource: "services", Kind: "Service", Namespaced: true},
+	{Group: "serving.knative.dev", Versions: []string{"v1"}, Resource: "configurations", Kind: "Configuration", Namespaced: true},
+	{Group: "serving.knative.dev", Versions: []string{"v1"}, Resource: "revisions", Kind: "Revision", Namespaced: true},
+	{Group: "serving.knative.dev", Versions: []string{"v1"}, Resource: "routes", Kind: "Route", Namespaced: true},
+	{Group: "serving.knative.dev", Versions: []string{"v1beta1"}, Resource: "domainmappings", Kind: "DomainMapping", Namespaced: true},
+	{Group: "networking.internal.knative.dev", Versions: []string{"v1alpha1"}, Resource: "ingresses", Kind: "Ingress", Namespaced: true},
+	{Group: "networking.internal.knative.dev", Versions: []string{"v1alpha1"}, Resource: "certificates", Kind: "Certificate", Namespaced: true},
+	{Group: "networking.internal.knative.dev", Versions: []string{"v1alpha1"}, Resource: "serverlessservices", Kind: "ServerlessService", Namespaced: true},
+	{Group: "eventing.knative.dev", Versions: []string{"v1"}, Resource: "brokers", Kind: "Broker", Namespaced: true},
+	{Group: "eventing.knative.dev", Versions: []string{"v1"}, Resource: "triggers", Kind: "Trigger", Namespaced: true},
+	{Group: "eventing.knative.dev", Versions: []string{"v1beta2"}, Resource: "eventtypes", Kind: "EventType", Namespaced: true},
+	{Group: "messaging.knative.dev", Versions: []string{"v1"}, Resource: "channels", Kind: "Channel", Namespaced: true},
+	{Group: "messaging.knative.dev", Versions: []string{"v1"}, Resource: "inmemorychannels", Kind: "InMemoryChannel", Namespaced: true},
+	{Group: "messaging.knative.dev", Versions: []string{"v1"}, Resource: "subscriptions", Kind: "Subscription", Namespaced: true},
+	{Group: "sources.knative.dev", Versions: []string{"v1"}, Resource: "apiserversources", Kind: "ApiServerSource", Namespaced: true},
+	{Group: "sources.knative.dev", Versions: []string{"v1"}, Resource: "containersources", Kind: "ContainerSource", Namespaced: true},
+	{Group: "sources.knative.dev", Versions: []string{"v1"}, Resource: "pingsources", Kind: "PingSource", Namespaced: true},
+	{Group: "sources.knative.dev", Versions: []string{"v1"}, Resource: "sinkbindings", Kind: "SinkBinding", Namespaced: true},
+	{Group: "flows.knative.dev", Versions: []string{"v1"}, Resource: "sequences", Kind: "Sequence", Namespaced: true},
+	{Group: "flows.knative.dev", Versions: []string{"v1"}, Resource: "parallels", Kind: "Parallel", Namespaced: true},
+	{Group: "traefik.io", Versions: []string{"v1alpha1"}, Resource: "ingressroutes", Kind: "IngressRoute", Namespaced: true},
+	{Group: "traefik.io", Versions: []string{"v1alpha1"}, Resource: "ingressroutetcps", Kind: "IngressRouteTCP", Namespaced: true},
+	{Group: "traefik.io", Versions: []string{"v1alpha1"}, Resource: "ingressrouteudps", Kind: "IngressRouteUDP", Namespaced: true},
+	{Group: "traefik.io", Versions: []string{"v1alpha1"}, Resource: "middlewares", Kind: "Middleware", Namespaced: true},
+	{Group: "traefik.io", Versions: []string{"v1alpha1"}, Resource: "middlewaretcps", Kind: "MiddlewareTCP", Namespaced: true},
+	{Group: "traefik.io", Versions: []string{"v1alpha1"}, Resource: "traefikservices", Kind: "TraefikService", Namespaced: true},
+	{Group: "traefik.io", Versions: []string{"v1alpha1"}, Resource: "serverstransports", Kind: "ServersTransport", Namespaced: true},
+	{Group: "traefik.io", Versions: []string{"v1alpha1"}, Resource: "serverstransporttcps", Kind: "ServersTransportTCP", Namespaced: true},
+	{Group: "traefik.io", Versions: []string{"v1alpha1"}, Resource: "tlsoptions", Kind: "TLSOption", Namespaced: true},
+	{Group: "traefik.io", Versions: []string{"v1alpha1"}, Resource: "tlsstores", Kind: "TLSStore", Namespaced: true},
+	{Group: "projectcontour.io", Versions: []string{"v1"}, Resource: "httpproxies", Kind: "HTTPProxy", Namespaced: true},
+	{Group: "cluster.x-k8s.io", Versions: []string{"v1beta2", "v1beta1"}, Resource: "clusters", Kind: "Cluster", Namespaced: true},
+	{Group: "cluster.x-k8s.io", Versions: []string{"v1beta2", "v1beta1"}, Resource: "machinedeployments", Kind: "MachineDeployment", Namespaced: true},
+	{Group: "cluster.x-k8s.io", Versions: []string{"v1beta2", "v1beta1"}, Resource: "machinesets", Kind: "MachineSet", Namespaced: true},
+	{Group: "cluster.x-k8s.io", Versions: []string{"v1beta2", "v1beta1"}, Resource: "machines", Kind: "Machine", Namespaced: true},
+	{Group: "cluster.x-k8s.io", Versions: []string{"v1beta2", "v1beta1"}, Resource: "machinepools", Kind: "MachinePool", Namespaced: true},
+	{Group: "cluster.x-k8s.io", Versions: []string{"v1beta2", "v1beta1"}, Resource: "clusterclasses", Kind: "ClusterClass", Namespaced: true},
+	{Group: "cluster.x-k8s.io", Versions: []string{"v1beta2", "v1beta1"}, Resource: "machinehealthchecks", Kind: "MachineHealthCheck", Namespaced: true},
+	{Group: "cluster.x-k8s.io", Versions: []string{"v1beta2"}, Resource: "machinedrainrules", Kind: "MachineDrainRule", Namespaced: true},
+	{Group: "controlplane.cluster.x-k8s.io", Versions: []string{"v1beta2", "v1beta1"}, Resource: "kubeadmcontrolplanes", Kind: "KubeadmControlPlane", Namespaced: true},
+	{Group: "aquasecurity.github.io", Versions: []string{"v1alpha1"}, Resource: "vulnerabilityreports", Kind: "VulnerabilityReport", Namespaced: true},
+	{Group: "aquasecurity.github.io", Versions: []string{"v1alpha1"}, Resource: "configauditreports", Kind: "ConfigAuditReport", Namespaced: true},
+	{Group: "aquasecurity.github.io", Versions: []string{"v1alpha1"}, Resource: "exposedsecretreports", Kind: "ExposedSecretReport", Namespaced: true},
+	{Group: "aquasecurity.github.io", Versions: []string{"v1alpha1"}, Resource: "rbacassessmentreports", Kind: "RbacAssessmentReport", Namespaced: true},
+	{Group: "aquasecurity.github.io", Versions: []string{"v1alpha1"}, Resource: "clusterrbacassessmentreports", Kind: "ClusterRbacAssessmentReport", Namespaced: false},
+	{Group: "aquasecurity.github.io", Versions: []string{"v1alpha1"}, Resource: "clustercompliancereports", Kind: "ClusterComplianceReport", Namespaced: false},
+	{Group: "aquasecurity.github.io", Versions: []string{"v1alpha1"}, Resource: "sbomreports", Kind: "SbomReport", Namespaced: true},
+	{Group: "aquasecurity.github.io", Versions: []string{"v1alpha1"}, Resource: "clustersbomreports", Kind: "ClusterSbomReport", Namespaced: false},
+	{Group: "aquasecurity.github.io", Versions: []string{"v1alpha1"}, Resource: "infraassessmentreports", Kind: "InfraAssessmentReport", Namespaced: true},
+	{Group: "aquasecurity.github.io", Versions: []string{"v1alpha1"}, Resource: "clusterinfraassessmentreports", Kind: "ClusterInfraAssessmentReport", Namespaced: false},
+}
+
+func RegisterSupportedCRDFallbacks() {
+	discovery := GetResourceDiscovery()
+	client := GetDynamicClient()
+	if discovery == nil || client == nil {
+		return
+	}
+	if !discovery.HasPartialDiscovery() {
+		return
+	}
+
+	nsFallback := ""
+	if permResult := GetCachedPermissionResult(); permResult != nil && permResult.NamespaceScoped && permResult.Namespace != "" {
+		nsFallback = permResult.Namespace
+	}
+
+	const maxConcurrentProbes = 12
+	sem := make(chan struct{}, maxConcurrentProbes)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	registered := 0
+
+	for _, candidate := range supportedCRDFallbacks {
+		if _, ok := discovery.GetResourceWithGroup(candidate.Kind, candidate.Group); ok {
+			continue
+		}
+		if !discovery.GroupHadPartialDiscovery(candidate.Group) {
+			continue
+		}
+		c := candidate
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			for _, version := range c.Versions {
+				gvr := schema.GroupVersionResource{Group: c.Group, Version: version, Resource: c.Resource}
+				namespace, ok := fallbackListProbe(client, gvr, c.Namespaced, nsFallback)
+				if !ok {
+					continue
+				}
+				if !fallbackWatchProbe(client, gvr, namespace) {
+					continue
+				}
+				discovery.AddAPIResource(k8score.APIResource{
+					Group:      c.Group,
+					Version:    version,
+					Kind:       c.Kind,
+					Name:       c.Resource,
+					Namespaced: c.Namespaced,
+					IsCRD:      true,
+					Verbs:      []string{"get", "list", "watch"},
+				})
+				mu.Lock()
+				registered++
+				mu.Unlock()
+				log.Printf("[crd-fallback] Registered %s.%s/%s after direct probe", c.Resource, c.Group, version)
+				return
+			}
+		}()
+	}
+
+	wg.Wait()
+	if registered > 0 {
+		log.Printf("[crd-fallback] Registered %d supported CRDs missing from API discovery", registered)
+	}
+}
+
+func fallbackListProbe(client dynamic.Interface, gvr schema.GroupVersionResource, namespaced bool, nsFallback string) (string, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := client.Resource(gvr).List(ctx, metav1.ListOptions{Limit: 1})
+	if err == nil {
+		return "", true
+	}
+	if namespaced && nsFallback != "" {
+		if !isExpectedFallbackProbeDenial(err) {
+			log.Printf("[crd-fallback] Cluster-wide list probe failed for %s.%s/%s: %v", gvr.Resource, gvr.Group, gvr.Version, err)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, err = client.Resource(gvr).Namespace(nsFallback).List(ctx, metav1.ListOptions{Limit: 1})
+		if err == nil {
+			return nsFallback, true
+		}
+		if !isExpectedFallbackProbeDenial(err) {
+			log.Printf("[crd-fallback] Namespace list probe failed for %s.%s/%s in ns=%q: %v", gvr.Resource, gvr.Group, gvr.Version, nsFallback, err)
+		}
+		return "", false
+	}
+	if !isExpectedFallbackProbeDenial(err) {
+		log.Printf("[crd-fallback] List probe failed for %s.%s/%s: %v", gvr.Resource, gvr.Group, gvr.Version, err)
+	}
+	return "", false
+}
+
+func fallbackWatchProbe(client dynamic.Interface, gvr schema.GroupVersionResource, namespace string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	timeoutSeconds := int64(1)
+	resource := client.Resource(gvr)
+	var (
+		watchInterface interface{ Stop() }
+		err            error
+	)
+	if namespace != "" {
+		watchInterface, err = resource.Namespace(namespace).Watch(ctx, metav1.ListOptions{TimeoutSeconds: &timeoutSeconds})
+	} else {
+		watchInterface, err = resource.Watch(ctx, metav1.ListOptions{TimeoutSeconds: &timeoutSeconds})
+	}
+	if err != nil {
+		if !isExpectedFallbackProbeDenial(err) {
+			log.Printf("[crd-fallback] Watch probe failed for %s.%s/%s in ns=%q: %v", gvr.Resource, gvr.Group, gvr.Version, namespace, err)
+		}
+		return false
+	}
+	if watchInterface != nil {
+		watchInterface.Stop()
+	}
+	return true
+}
+
+func isExpectedFallbackProbeDenial(err error) bool {
+	return apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err) || apierrors.IsNotFound(err)
+}
+
 // WarmupCommonCRDs starts watching common CRDs (Rollouts, Workflows, etc.) at startup.
 func WarmupCommonCRDs() {
 	cache := GetDynamicResourceCache()
@@ -139,138 +372,13 @@ func WarmupCommonCRDs() {
 		return
 	}
 
-	// Common CRDs that should be warmed up for timeline visibility
-	commonCRDs := []string{
-		"Rollout",                      // Argo Rollouts
-		"Workflow",                     // Argo Workflows
-		"CronWorkflow",                 // Argo Workflows
-		"Certificate",                  // cert-manager
-		"CertificateRequest",           // cert-manager
-		"Order",                        // cert-manager ACME
-		"Challenge",                    // cert-manager ACME
-		"GitRepository",                // FluxCD source
-		"OCIRepository",                // FluxCD source
-		"HelmRepository",               // FluxCD source
-		"Kustomization",                // FluxCD kustomize
-		"HelmRelease",                  // FluxCD helm
-		"Alert",                        // FluxCD notification
-		"ApplicationSet",               // ArgoCD
-		"AppProject",                   // ArgoCD
-		"Gateway",                      // Gateway API
-		"HTTPRoute",                    // Gateway API
-		"GRPCRoute",                    // Gateway API
-		"TCPRoute",                     // Gateway API
-		"TLSRoute",                     // Gateway API
-		"VulnerabilityReport",          // Trivy Operator
-		"ConfigAuditReport",            // Trivy Operator
-		"ExposedSecretReport",          // Trivy Operator
-		"RbacAssessmentReport",         // Trivy Operator
-		"ClusterRbacAssessmentReport",  // Trivy Operator
-		"ClusterComplianceReport",      // Trivy Operator
-		"SbomReport",                   // Trivy Operator
-		"ClusterSbomReport",            // Trivy Operator
-		"InfraAssessmentReport",        // Trivy Operator
-		"ClusterInfraAssessmentReport", // Trivy Operator
-		"NodePool",                     // Karpenter
-		"NodeClaim",                    // Karpenter
-		"EC2NodeClass",                 // Karpenter (AWS)
-		"AKSNodeClass",                 // Karpenter (Azure)
-		"GCPNodeClass",                 // Karpenter (GCP)
-		"ScaledObject",                 // KEDA
-		"ScaledJob",                    // KEDA
-		"TriggerAuthentication",        // KEDA
-		"ClusterTriggerAuthentication", // KEDA
-		"GatewayClass",                 // Gateway API
-		"VerticalPodAutoscaler",        // VPA
-		"ServiceMonitor",               // Prometheus Operator
-		"PodMonitor",                   // Prometheus Operator
-		"PrometheusRule",               // Prometheus Operator
-		"Alertmanager",                 // Prometheus Operator
-		"Revision",                     // KNative Serving
-		"DomainMapping",                // KNative Serving
-		"ServerlessService",            // KNative Serving (internal)
-		"Trigger",                      // KNative Eventing
-		"EventType",                    // KNative Eventing
-		"InMemoryChannel",              // KNative Messaging
-		"Subscription",                 // KNative Messaging
-		"ApiServerSource",              // KNative Sources
-		"ContainerSource",              // KNative Sources
-		"PingSource",                   // KNative Sources
-		"SinkBinding",                  // KNative Sources
-		"Sequence",                     // KNative Flows
-		"Parallel",                     // KNative Flows
-		"IngressRoute",                 // Traefik
-		"IngressRouteTCP",              // Traefik
-		"IngressRouteUDP",              // Traefik
-		"Middleware",                   // Traefik
-		"MiddlewareTCP",                // Traefik
-		"TraefikService",               // Traefik
-		"ServersTransport",             // Traefik
-		"ServersTransportTCP",          // Traefik
-		"TLSOption",                    // Traefik
-		"TLSStore",                     // Traefik
-		"HTTPProxy",                    // Contour
-		"ClusterClass",                 // Cluster API (CAPI)
-		"MachineDeployment",            // Cluster API (CAPI)
-		"MachinePool",                  // Cluster API (CAPI)
-		"MachineHealthCheck",           // Cluster API (CAPI)
-		"MachineDrainRule",             // Cluster API (CAPI)
-	}
-
 	var gvrs []schema.GroupVersionResource
-	for _, kind := range commonCRDs {
-		if gvr, ok := discovery.GetGVR(kind); ok {
+	seen := make(map[schema.GroupVersionResource]bool)
+	for _, candidate := range supportedCRDFallbacks {
+		if gvr, ok := discovery.GetGVRWithGroup(candidate.Kind, candidate.Group); ok && !seen[gvr] {
+			seen[gvr] = true
 			gvrs = append(gvrs, gvr)
-			log.Printf("Warming up CRD: %s", kind)
-		}
-	}
-
-	// ArgoCD Application needs group-qualified lookup
-	if gvr, ok := discovery.GetGVRWithGroup("Application", "argoproj.io"); ok {
-		gvrs = append(gvrs, gvr)
-		log.Printf("Warming up CRD: Application (argoproj.io)")
-	}
-
-	// Istio kinds that have topology edges (VirtualService→Service, Gateway→VirtualService, DestinationRule→Service)
-	istioQualified := []struct{ kind, group string }{
-		{"VirtualService", "networking.istio.io"},
-		{"DestinationRule", "networking.istio.io"},
-		{"Gateway", "networking.istio.io"},
-	}
-	for _, iq := range istioQualified {
-		if gvr, ok := discovery.GetGVRWithGroup(iq.kind, iq.group); ok {
-			gvrs = append(gvrs, gvr)
-			log.Printf("Warming up CRD: %s (%s)", iq.kind, iq.group)
-		}
-	}
-
-	// CAPI kinds that collide with other CRDs (Cluster collides with CNPG, Machine/MachineSet could collide)
-	capiQualified := []struct{ kind, group string }{
-		{"Cluster", "cluster.x-k8s.io"},
-		{"Machine", "cluster.x-k8s.io"},
-		{"MachineSet", "cluster.x-k8s.io"},
-	}
-	for _, cq := range capiQualified {
-		if gvr, ok := discovery.GetGVRWithGroup(cq.kind, cq.group); ok {
-			gvrs = append(gvrs, gvr)
-			log.Printf("Warming up CRD: %s (%s)", cq.kind, cq.group)
-		}
-	}
-
-	// KNative kinds that collide with core/other CRDs
-	knativeQualified := []struct{ kind, group string }{
-		{"Service", "serving.knative.dev"},
-		{"Ingress", "networking.internal.knative.dev"},
-		{"Certificate", "networking.internal.knative.dev"},
-		{"Channel", "messaging.knative.dev"},
-		{"Configuration", "serving.knative.dev"},
-		{"Route", "serving.knative.dev"},
-		{"Broker", "eventing.knative.dev"},
-	}
-	for _, kq := range knativeQualified {
-		if gvr, ok := discovery.GetGVRWithGroup(kq.kind, kq.group); ok {
-			gvrs = append(gvrs, gvr)
-			log.Printf("Warming up CRD: %s (%s)", kq.kind, kq.group)
+			log.Printf("Warming up CRD: %s (%s)", candidate.Kind, candidate.Group)
 		}
 	}
 

--- a/internal/k8s/dynamic_cache_fallback_test.go
+++ b/internal/k8s/dynamic_cache_fallback_test.go
@@ -1,0 +1,473 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/skyhook-io/radar/pkg/k8score"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/discovery"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestFallbackListProbeUsesNamespaceFallback(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1", Resource: "virtualservices"}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "VirtualServiceList"},
+	)
+	client.PrependReactor("list", "virtualservices", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		listAction := action.(k8stesting.ListAction)
+		if listAction.GetNamespace() == "team-a" {
+			return false, nil, nil
+		}
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: gvr.Group, Resource: gvr.Resource}, "", nil)
+	})
+
+	namespace, ok := fallbackListProbe(client, gvr, true, "team-a")
+	if !ok {
+		t.Fatal("expected namespace fallback probe to succeed")
+	}
+	if namespace != "team-a" {
+		t.Fatalf("namespace = %q, want team-a", namespace)
+	}
+}
+
+func TestFallbackListProbeDoesNotNamespaceFallbackClusterScoped(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gatewayclasses"}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "GatewayClassList"},
+	)
+	client.PrependReactor("list", "gatewayclasses", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		listAction := action.(k8stesting.ListAction)
+		if listAction.GetNamespace() != "" {
+			t.Fatalf("cluster-scoped fallback probe unexpectedly used namespace %q", listAction.GetNamespace())
+		}
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: gvr.Group, Resource: gvr.Resource}, "", nil)
+	})
+
+	if _, ok := fallbackListProbe(client, gvr, false, "team-a"); ok {
+		t.Fatal("expected cluster-scoped fallback probe to fail after cluster-wide denial")
+	}
+}
+
+func TestRegisterSupportedCRDFallbacks_RegistersSupportedCRDFromPartialDiscovery(t *testing.T) {
+	cases := []struct {
+		name       string
+		group      string
+		version    string
+		resource   string
+		kind       string
+		objectName string
+	}{
+		{
+			name:       "istio virtualservice",
+			group:      "networking.istio.io",
+			version:    "v1",
+			resource:   "virtualservices",
+			kind:       "VirtualService",
+			objectName: "reviews",
+		},
+		{
+			name:       "keda scaledobject",
+			group:      "keda.sh",
+			version:    "v1alpha1",
+			resource:   "scaledobjects",
+			kind:       "ScaledObject",
+			objectName: "worker-scale",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			ResetDynamicResourceCache()
+			ResetResourceDiscovery()
+			t.Cleanup(func() {
+				ResetDynamicResourceCache()
+				ResetResourceDiscovery()
+				clientMu.Lock()
+				dynamicClient = nil
+				clientMu.Unlock()
+			})
+
+			coreGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+			targetGVR := schema.GroupVersionResource{Group: tt.group, Version: tt.version, Resource: tt.resource}
+			listKinds := supportedFallbackListKinds(coreGVR, tt.group)
+			dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+				runtime.NewScheme(),
+				listKinds,
+				&unstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": tt.group + "/" + tt.version,
+						"kind":       tt.kind,
+						"metadata": map[string]any{
+							"name":      tt.objectName,
+							"namespace": "default",
+						},
+					},
+				},
+			)
+			dyn.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				listAction := action.(k8stesting.ListAction)
+				gvr := listAction.GetResource()
+				if gvr == targetGVR {
+					return false, nil, nil
+				}
+				return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: gvr.Group, Resource: gvr.Resource}, "", nil)
+			})
+			dyn.PrependWatchReactor("*", func(action k8stesting.Action) (bool, watch.Interface, error) {
+				if action.GetResource() == targetGVR {
+					return true, watch.NewFake(), nil
+				}
+				return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: action.GetResource().Group, Resource: action.GetResource().Resource}, "", nil)
+			})
+			clientMu.Lock()
+			dynamicClient = dyn
+			clientMu.Unlock()
+
+			fakeDisc := fakeclientset.NewSimpleClientset().Discovery().(*fakediscovery.FakeDiscovery)
+			fakeDisc.Resources = []*metav1.APIResourceList{
+				{
+					GroupVersion: "v1",
+					APIResources: []metav1.APIResource{
+						{Name: "pods", Kind: "Pod", Namespaced: true, Verbs: metav1.Verbs{"get", "list", "watch"}},
+					},
+				},
+			}
+			fakeDisc.PrependReactor("get", "resource", func(k8stesting.Action) (bool, runtime.Object, error) {
+				err := &discovery.ErrGroupDiscoveryFailed{
+					Groups: map[schema.GroupVersion]error{
+						{Group: tt.group, Version: tt.version}: apierrors.NewForbidden(
+							schema.GroupResource{Group: tt.group, Resource: tt.resource},
+							"",
+							nil,
+						),
+					},
+				}
+				return true, nil, err
+			})
+			coreDiscovery, err := k8score.NewResourceDiscovery(fakeDisc)
+			if err != nil {
+				t.Fatalf("NewResourceDiscovery failed: %v", err)
+			}
+			resourceDiscovery = &ResourceDiscovery{ResourceDiscovery: coreDiscovery}
+			if !resourceDiscovery.HasPartialDiscovery() || !resourceDiscovery.GroupHadPartialDiscovery(tt.group) {
+				t.Fatalf("expected fake discovery to record partial %s discovery", tt.group)
+			}
+			if _, ok := resourceDiscovery.GetGVRWithGroup(tt.kind, tt.group); ok {
+				t.Fatalf("%s should be absent before fallback probing", tt.kind)
+			}
+
+			RegisterSupportedCRDFallbacks()
+
+			gvr, ok := resourceDiscovery.GetGVRWithGroup(tt.kind, tt.group)
+			if !ok {
+				t.Fatalf("expected fallback probing to register %s/%s", tt.group, tt.kind)
+			}
+			if gvr != targetGVR {
+				t.Fatalf("GVR = %v, want %v", gvr, targetGVR)
+			}
+			if !resourceDiscovery.SupportsWatchGVR(targetGVR) {
+				t.Fatal("registered fallback GVR should support watch")
+			}
+
+			if err := InitDynamicResourceCache(nil); err != nil {
+				t.Fatalf("InitDynamicResourceCache failed: %v", err)
+			}
+			dynamicCache := GetDynamicResourceCache()
+			if dynamicCache == nil {
+				t.Fatal("dynamic cache was not initialized")
+			}
+			if err := dynamicCache.EnsureWatching(targetGVR); err != nil {
+				t.Fatalf("EnsureWatching failed: %v", err)
+			}
+			if !dynamicCache.WaitForSync(targetGVR, 5*time.Second) {
+				t.Fatalf("timed out waiting for %s informer sync", tt.kind)
+			}
+			cache := &ResourceCache{}
+			items, err := cache.ListDynamicWithGroup(context.Background(), tt.kind, "default", tt.group)
+			if err != nil {
+				t.Fatalf("ListDynamicWithGroup failed after fallback registration: %v", err)
+			}
+			if len(items) != 1 || items[0].GetName() != tt.objectName {
+				t.Fatalf("items = %#v, want one %s named %s", items, tt.kind, tt.objectName)
+			}
+		})
+	}
+}
+
+func TestRegisterSupportedCRDFallbacks_DoesNotProbeOnCleanDiscovery(t *testing.T) {
+	ResetResourceDiscovery()
+	t.Cleanup(func() {
+		ResetResourceDiscovery()
+		clientMu.Lock()
+		dynamicClient = nil
+		clientMu.Unlock()
+	})
+
+	istioGVR := schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1", Resource: "virtualservices"}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{istioGVR: "VirtualServiceList"},
+	)
+	listCalls := 0
+	dyn.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		listCalls++
+		return false, nil, nil
+	})
+	clientMu.Lock()
+	dynamicClient = dyn
+	clientMu.Unlock()
+
+	fakeDisc := fakeclientset.NewSimpleClientset().Discovery().(*fakediscovery.FakeDiscovery)
+	fakeDisc.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", Kind: "Pod", Namespaced: true, Verbs: metav1.Verbs{"get", "list", "watch"}},
+			},
+		},
+	}
+	coreDiscovery, err := k8score.NewResourceDiscovery(fakeDisc)
+	if err != nil {
+		t.Fatalf("NewResourceDiscovery failed: %v", err)
+	}
+	resourceDiscovery = &ResourceDiscovery{ResourceDiscovery: coreDiscovery}
+	if resourceDiscovery.HasPartialDiscovery() {
+		t.Fatal("clean fake discovery should not be partial")
+	}
+
+	RegisterSupportedCRDFallbacks()
+
+	if listCalls != 0 {
+		t.Fatalf("fallback probing issued %d list calls on clean discovery, want 0", listCalls)
+	}
+	if _, ok := resourceDiscovery.GetGVRWithGroup("VirtualService", "networking.istio.io"); ok {
+		t.Fatal("VirtualService should not be registered without partial discovery")
+	}
+}
+
+func TestRegisterSupportedCRDFallbacks_DoesNotRegisterWhenWatchDenied(t *testing.T) {
+	ResetResourceDiscovery()
+	t.Cleanup(func() {
+		ResetResourceDiscovery()
+		clientMu.Lock()
+		dynamicClient = nil
+		clientMu.Unlock()
+	})
+
+	targetGVR := schema.GroupVersionResource{Group: "keda.sh", Version: "v1alpha1", Resource: "scaledobjects"}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		supportedFallbackListKinds(schema.GroupVersionResource{}, "keda.sh"),
+	)
+	dyn.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.(k8stesting.ListAction).GetResource() == targetGVR {
+			return false, nil, nil
+		}
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: action.GetResource().Group, Resource: action.GetResource().Resource}, "", nil)
+	})
+	dyn.PrependWatchReactor("*", func(action k8stesting.Action) (bool, watch.Interface, error) {
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: action.GetResource().Group, Resource: action.GetResource().Resource}, "", nil)
+	})
+	clientMu.Lock()
+	dynamicClient = dyn
+	clientMu.Unlock()
+
+	fakeDisc := fakeDiscoveryWithPartialGroup(t, "keda.sh", "v1alpha1")
+	coreDiscovery, err := k8score.NewResourceDiscovery(fakeDisc)
+	if err != nil {
+		t.Fatalf("NewResourceDiscovery failed: %v", err)
+	}
+	resourceDiscovery = &ResourceDiscovery{ResourceDiscovery: coreDiscovery}
+
+	RegisterSupportedCRDFallbacks()
+
+	if _, ok := resourceDiscovery.GetGVRWithGroup("ScaledObject", "keda.sh"); ok {
+		t.Fatal("ScaledObject should not be registered when watch is denied")
+	}
+}
+
+func TestRegisterSupportedCRDFallbacks_MultiVersionProbeOrder(t *testing.T) {
+	cases := []struct {
+		name          string
+		allowedGVR    schema.GroupVersionResource
+		wantGVR       schema.GroupVersionResource
+		wantProbeGVRs []schema.GroupVersionResource
+	}{
+		{
+			name:       "falls back to beta when v1 is not listable",
+			allowedGVR: schema.GroupVersionResource{Group: "source.toolkit.fluxcd.io", Version: "v1beta2", Resource: "gitrepositories"},
+			wantGVR:    schema.GroupVersionResource{Group: "source.toolkit.fluxcd.io", Version: "v1beta2", Resource: "gitrepositories"},
+			wantProbeGVRs: []schema.GroupVersionResource{
+				{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "gitrepositories"},
+				{Group: "source.toolkit.fluxcd.io", Version: "v1beta2", Resource: "gitrepositories"},
+			},
+		},
+		{
+			name:       "stops after stable version succeeds",
+			allowedGVR: schema.GroupVersionResource{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "gitrepositories"},
+			wantGVR:    schema.GroupVersionResource{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "gitrepositories"},
+			wantProbeGVRs: []schema.GroupVersionResource{
+				{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "gitrepositories"},
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			ResetDynamicResourceCache()
+			ResetResourceDiscovery()
+			t.Cleanup(func() {
+				ResetDynamicResourceCache()
+				ResetResourceDiscovery()
+				clientMu.Lock()
+				dynamicClient = nil
+				clientMu.Unlock()
+			})
+
+			listKinds := supportedFallbackListKinds(schema.GroupVersionResource{}, "source.toolkit.fluxcd.io")
+			dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds)
+			var probed []schema.GroupVersionResource
+			dyn.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				gvr := action.(k8stesting.ListAction).GetResource()
+				if gvr.Resource == "gitrepositories" {
+					probed = append(probed, gvr)
+				}
+				if gvr == tt.allowedGVR {
+					return false, nil, nil
+				}
+				return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: gvr.Group, Resource: gvr.Resource}, "", nil)
+			})
+			dyn.PrependWatchReactor("*", func(action k8stesting.Action) (bool, watch.Interface, error) {
+				if action.GetResource() == tt.allowedGVR {
+					return true, watch.NewFake(), nil
+				}
+				return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: action.GetResource().Group, Resource: action.GetResource().Resource}, "", nil)
+			})
+			clientMu.Lock()
+			dynamicClient = dyn
+			clientMu.Unlock()
+
+			fakeDisc := fakeDiscoveryWithPartialGroup(t, "source.toolkit.fluxcd.io", "v1")
+			coreDiscovery, err := k8score.NewResourceDiscovery(fakeDisc)
+			if err != nil {
+				t.Fatalf("NewResourceDiscovery failed: %v", err)
+			}
+			resourceDiscovery = &ResourceDiscovery{ResourceDiscovery: coreDiscovery}
+
+			RegisterSupportedCRDFallbacks()
+
+			gotGVR, ok := resourceDiscovery.GetGVRWithGroup("GitRepository", "source.toolkit.fluxcd.io")
+			if !ok {
+				t.Fatal("expected GitRepository to be registered")
+			}
+			if gotGVR != tt.wantGVR {
+				t.Fatalf("GVR = %v, want %v", gotGVR, tt.wantGVR)
+			}
+			if len(probed) != len(tt.wantProbeGVRs) {
+				t.Fatalf("probed %v, want %v", probed, tt.wantProbeGVRs)
+			}
+			for i := range probed {
+				if probed[i] != tt.wantProbeGVRs[i] {
+					t.Fatalf("probed %v, want %v", probed, tt.wantProbeGVRs)
+				}
+			}
+		})
+	}
+}
+
+func TestRegisterSupportedCRDFallbacks_SkipsGroupsWithoutPartialDiscovery(t *testing.T) {
+	ResetResourceDiscovery()
+	t.Cleanup(func() {
+		ResetResourceDiscovery()
+		clientMu.Lock()
+		dynamicClient = nil
+		clientMu.Unlock()
+	})
+
+	kedaGVR := schema.GroupVersionResource{Group: "keda.sh", Version: "v1alpha1", Resource: "scaledobjects"}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		supportedFallbackListKinds(schema.GroupVersionResource{}, "networking.istio.io", "keda.sh"),
+	)
+	probedKeda := false
+	dyn.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.(k8stesting.ListAction).GetResource() == kedaGVR {
+			probedKeda = true
+		}
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: action.GetResource().Group, Resource: action.GetResource().Resource}, "", nil)
+	})
+	clientMu.Lock()
+	dynamicClient = dyn
+	clientMu.Unlock()
+
+	fakeDisc := fakeDiscoveryWithPartialGroup(t, "networking.istio.io", "v1")
+	coreDiscovery, err := k8score.NewResourceDiscovery(fakeDisc)
+	if err != nil {
+		t.Fatalf("NewResourceDiscovery failed: %v", err)
+	}
+	resourceDiscovery = &ResourceDiscovery{ResourceDiscovery: coreDiscovery}
+
+	RegisterSupportedCRDFallbacks()
+
+	if probedKeda {
+		t.Fatal("fallback probed keda.sh even though only networking.istio.io had partial discovery")
+	}
+}
+
+func supportedFallbackListKinds(coreGVR schema.GroupVersionResource, groups ...string) map[schema.GroupVersionResource]string {
+	listKinds := map[schema.GroupVersionResource]string{}
+	if coreGVR.Resource != "" {
+		listKinds[coreGVR] = "PodList"
+	}
+	groupSet := make(map[string]bool, len(groups))
+	for _, group := range groups {
+		groupSet[group] = true
+	}
+	for _, candidate := range supportedCRDFallbacks {
+		if !groupSet[candidate.Group] {
+			continue
+		}
+		for _, version := range candidate.Versions {
+			gvr := schema.GroupVersionResource{Group: candidate.Group, Version: version, Resource: candidate.Resource}
+			listKinds[gvr] = candidate.Kind + "List"
+		}
+	}
+	return listKinds
+}
+
+func fakeDiscoveryWithPartialGroup(t *testing.T, group, version string) *fakediscovery.FakeDiscovery {
+	t.Helper()
+	fakeDisc := fakeclientset.NewSimpleClientset().Discovery().(*fakediscovery.FakeDiscovery)
+	fakeDisc.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", Kind: "Pod", Namespaced: true, Verbs: metav1.Verbs{"get", "list", "watch"}},
+			},
+		},
+	}
+	fakeDisc.PrependReactor("get", "resource", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, &discovery.ErrGroupDiscoveryFailed{
+			Groups: map[schema.GroupVersion]error{
+				{Group: group, Version: version}: apierrors.NewForbidden(
+					schema.GroupResource{Group: group, Resource: "resources"},
+					"",
+					nil,
+				),
+			},
+		}
+	})
+	return fakeDisc
+}

--- a/internal/k8s/subsystems.go
+++ b/internal/k8s/subsystems.go
@@ -126,6 +126,7 @@ func InitAllSubsystems(ctx context.Context, progress func(string)) error {
 						}
 					}()
 					wt := time.Now()
+					RegisterSupportedCRDFallbacks()
 					WarmupCommonCRDs()
 					logTiming("   CRD warmup: %v (background)", time.Since(wt))
 				}()

--- a/pkg/k8score/discovery.go
+++ b/pkg/k8score/discovery.go
@@ -39,6 +39,8 @@ type ResourceDiscovery struct {
 	resourceMap map[string]APIResource // keyed by lowercase kind
 	gvrMap      map[string]schema.GroupVersionResource
 	lastRefresh time.Time
+	partial     bool
+	failedGroup map[string]bool
 	cacheTTL    time.Duration
 	mu          sync.RWMutex
 }
@@ -155,6 +157,13 @@ func (d *ResourceDiscovery) Refresh() error {
 	if err != nil {
 		log.Printf("Warning: partial error discovering API resources: %v", err)
 	}
+	failedGroups := make(map[string]bool)
+	if groups, ok := discovery.GroupDiscoveryFailedErrorGroups(err); ok {
+		for gv := range groups {
+			failedGroups[gv.Group] = true
+		}
+	}
+	partial := discovery.IsGroupDiscoveryFailedError(err) || len(failedGroups) > 0
 	log.Printf("API resource discovery took %v", time.Since(start))
 
 	d.mu.Lock()
@@ -191,39 +200,87 @@ func (d *ResourceDiscovery) Refresh() error {
 				Verbs:      apiRes.Verbs,
 			}
 
-			d.resources = append(d.resources, resource)
-
-			gvr := schema.GroupVersionResource{
-				Group:    gv.Group,
-				Version:  gv.Version,
-				Resource: apiRes.Name,
-			}
-
-			// Store in map by lowercase kind for lookup.
-			// Prefer: non-CRD over CRD, then stable versions over beta/alpha.
-			kindKey := strings.ToLower(apiRes.Kind)
-			if existing, ok := d.resourceMap[kindKey]; !ok ||
-				(!isCRD && existing.IsCRD) ||
-				(isCRD == existing.IsCRD && existing.Group == gv.Group && IsMoreStableVersion(gv.Version, existing.Version)) {
-				d.resourceMap[kindKey] = resource
-				d.gvrMap[kindKey] = gvr
-			}
-
-			// Also store by plural name (lowercase)
-			nameKey := strings.ToLower(apiRes.Name)
-			if existing, ok := d.resourceMap[nameKey]; !ok ||
-				(!isCRD && existing.IsCRD) ||
-				(isCRD == existing.IsCRD && existing.Group == gv.Group && IsMoreStableVersion(gv.Version, existing.Version)) {
-				d.resourceMap[nameKey] = resource
-				d.gvrMap[nameKey] = gvr
-			}
+			d.addResourceLocked(resource)
 		}
 	}
 
 	d.lastRefresh = time.Now()
+	d.partial = partial
+	d.failedGroup = failedGroups
 	log.Printf("Discovered %d API resources (%d unique kinds)", len(d.resources), len(d.resourceMap)/2)
 
 	return nil
+}
+
+// HasPartialDiscovery reports whether the last refresh missed one or more
+// group/versions while still returning partial API resource data.
+func (d *ResourceDiscovery) HasPartialDiscovery() bool {
+	if d == nil {
+		return false
+	}
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.partial
+}
+
+// GroupHadPartialDiscovery reports whether a group was specifically missing
+// from the last partial discovery response.
+func (d *ResourceDiscovery) GroupHadPartialDiscovery(group string) bool {
+	if d == nil {
+		return false
+	}
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.failedGroup[group]
+}
+
+// AddAPIResource registers a resource that was proven accessible without
+// server discovery returning it, such as under restricted discovery RBAC.
+func (d *ResourceDiscovery) AddAPIResource(resource APIResource) {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.addResourceLocked(resource)
+}
+
+func (d *ResourceDiscovery) addResourceLocked(resource APIResource) {
+	for i, existing := range d.resources {
+		if existing.Group == resource.Group && existing.Version == resource.Version && existing.Name == resource.Name {
+			d.resources[i] = resource
+			d.indexResourceLocked(resource)
+			return
+		}
+	}
+	d.resources = append(d.resources, resource)
+	d.indexResourceLocked(resource)
+}
+
+func (d *ResourceDiscovery) indexResourceLocked(resource APIResource) {
+	gvr := schema.GroupVersionResource{
+		Group:    resource.Group,
+		Version:  resource.Version,
+		Resource: resource.Name,
+	}
+
+	// Store in map by lowercase kind for lookup. Prefer non-CRD over CRD,
+	// then stable versions within the same group.
+	kindKey := strings.ToLower(resource.Kind)
+	if existing, ok := d.resourceMap[kindKey]; !ok ||
+		(!resource.IsCRD && existing.IsCRD) ||
+		(resource.IsCRD == existing.IsCRD && existing.Group == resource.Group && IsMoreStableVersion(resource.Version, existing.Version)) {
+		d.resourceMap[kindKey] = resource
+		d.gvrMap[kindKey] = gvr
+	}
+
+	nameKey := strings.ToLower(resource.Name)
+	if existing, ok := d.resourceMap[nameKey]; !ok ||
+		(!resource.IsCRD && existing.IsCRD) ||
+		(resource.IsCRD == existing.IsCRD && existing.Group == resource.Group && IsMoreStableVersion(resource.Version, existing.Version)) {
+		d.resourceMap[nameKey] = resource
+		d.gvrMap[nameKey] = gvr
+	}
 }
 
 // Stats returns lightweight stats without triggering a refresh.
@@ -407,15 +464,46 @@ func (d *ResourceDiscovery) SupportsWatch(kindOrName string) bool {
 
 // SupportsWatchGVR checks if a GVR supports list and watch verbs.
 func (d *ResourceDiscovery) SupportsWatchGVR(gvr schema.GroupVersionResource) bool {
-	return d.SupportsWatch(gvr.Resource)
+	if d == nil {
+		return false
+	}
+
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	for _, res := range d.resources {
+		if res.Group != gvr.Group || res.Version != gvr.Version || res.Name != gvr.Resource {
+			continue
+		}
+		hasList := false
+		hasWatch := false
+		for _, verb := range res.Verbs {
+			if verb == "list" {
+				hasList = true
+			}
+			if verb == "watch" {
+				hasWatch = true
+			}
+		}
+		return hasList && hasWatch
+	}
+	return false
 }
 
 // GetKindForGVR returns the Kind name for a given GVR
 // e.g., for GVR{Resource: "rollouts"}, returns "Rollout".
 func (d *ResourceDiscovery) GetKindForGVR(gvr schema.GroupVersionResource) string {
-	res, ok := d.GetResource(gvr.Resource)
-	if ok {
-		return res.Kind
+	if d == nil {
+		return ""
+	}
+
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	for _, res := range d.resources {
+		if res.Group == gvr.Group && res.Version == gvr.Version && res.Name == gvr.Resource {
+			return res.Kind
+		}
 	}
 	return ""
 }

--- a/pkg/k8score/discovery_test.go
+++ b/pkg/k8score/discovery_test.go
@@ -1,0 +1,143 @@
+package k8score
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestAddAPIResourceRegistersGroupQualifiedCRD(t *testing.T) {
+	d := &ResourceDiscovery{
+		resourceMap: make(map[string]APIResource),
+		gvrMap:      make(map[string]schema.GroupVersionResource),
+	}
+
+	d.AddAPIResource(APIResource{
+		Group:      "networking.istio.io",
+		Version:    "v1",
+		Kind:       "VirtualService",
+		Name:       "virtualservices",
+		Namespaced: true,
+		IsCRD:      true,
+		Verbs:      []string{"get", "list", "watch"},
+	})
+
+	gvr, ok := d.GetGVRWithGroup("VirtualService", "networking.istio.io")
+	if !ok {
+		t.Fatal("expected group-qualified VirtualService lookup to resolve")
+	}
+	if gvr != (schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1", Resource: "virtualservices"}) {
+		t.Fatalf("GVR = %v, want networking.istio.io/v1 virtualservices", gvr)
+	}
+	if !d.SupportsWatchGVR(gvr) {
+		t.Fatal("expected exact fallback GVR to support watch")
+	}
+	if got := d.GetKindForGVR(gvr); got != "VirtualService" {
+		t.Fatalf("kind = %q, want VirtualService", got)
+	}
+}
+
+func TestSupportsWatchGVRUsesExactGroupVersionResource(t *testing.T) {
+	d := &ResourceDiscovery{
+		resourceMap: make(map[string]APIResource),
+		gvrMap:      make(map[string]schema.GroupVersionResource),
+	}
+
+	d.AddAPIResource(APIResource{
+		Group:      "gateway.networking.k8s.io",
+		Version:    "v1",
+		Kind:       "Gateway",
+		Name:       "gateways",
+		Namespaced: true,
+		IsCRD:      true,
+		Verbs:      []string{"get", "list", "watch"},
+	})
+	d.AddAPIResource(APIResource{
+		Group:      "networking.istio.io",
+		Version:    "v1",
+		Kind:       "Gateway",
+		Name:       "gateways",
+		Namespaced: true,
+		IsCRD:      true,
+		Verbs:      []string{"get", "list"},
+	})
+
+	gatewayAPI := schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways"}
+	istio := schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1", Resource: "gateways"}
+	if !d.SupportsWatchGVR(gatewayAPI) {
+		t.Fatal("Gateway API GVR should support watch")
+	}
+	if d.SupportsWatchGVR(istio) {
+		t.Fatal("Istio Gateway GVR should not inherit watch support from Gateway API Gateway")
+	}
+	if got := d.GetKindForGVR(istio); got != "Gateway" {
+		t.Fatalf("kind = %q, want Gateway", got)
+	}
+}
+
+func TestAddAPIResourceUpdatesExistingGVR(t *testing.T) {
+	d := &ResourceDiscovery{
+		resourceMap: make(map[string]APIResource),
+		gvrMap:      make(map[string]schema.GroupVersionResource),
+	}
+
+	resource := APIResource{
+		Group:      "keda.sh",
+		Version:    "v1alpha1",
+		Kind:       "ScaledObject",
+		Name:       "scaledobjects",
+		Namespaced: true,
+		IsCRD:      true,
+		Verbs:      []string{"get", "list"},
+	}
+	d.AddAPIResource(resource)
+	resource.Verbs = []string{"get", "list", "watch"}
+	d.AddAPIResource(resource)
+
+	resources, err := d.GetAPIResources()
+	if err != nil {
+		t.Fatalf("GetAPIResources failed: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("resource count = %d, want 1", len(resources))
+	}
+	gvr := schema.GroupVersionResource{Group: "keda.sh", Version: "v1alpha1", Resource: "scaledobjects"}
+	if !d.SupportsWatchGVR(gvr) {
+		t.Fatal("updated GVR should support watch")
+	}
+}
+
+func TestSupportsWatchGVRCoreResourceUsesExactEmptyGroup(t *testing.T) {
+	d := &ResourceDiscovery{
+		resourceMap: make(map[string]APIResource),
+		gvrMap:      make(map[string]schema.GroupVersionResource),
+	}
+
+	d.AddAPIResource(APIResource{
+		Group:      "",
+		Version:    "v1",
+		Kind:       "Service",
+		Name:       "services",
+		Namespaced: true,
+		IsCRD:      false,
+		Verbs:      []string{"get", "list", "watch"},
+	})
+	d.AddAPIResource(APIResource{
+		Group:      "serving.knative.dev",
+		Version:    "v1",
+		Kind:       "Service",
+		Name:       "services",
+		Namespaced: true,
+		IsCRD:      true,
+		Verbs:      []string{"get", "list"},
+	})
+
+	core := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+	knative := schema.GroupVersionResource{Group: "serving.knative.dev", Version: "v1", Resource: "services"}
+	if !d.SupportsWatchGVR(core) {
+		t.Fatal("core Service GVR should support watch")
+	}
+	if d.SupportsWatchGVR(knative) {
+		t.Fatal("Knative Service GVR should not inherit watch support from core Service")
+	}
+}


### PR DESCRIPTION
Closes #660.

Radar currently depends on API discovery to know which CRDs exist. In clusters where discovery is partially restricted but the user can still list specific CRD resources, supported CRDs like Istio VirtualService or KEDA ScaledObject can be invisible.

This adds a bounded fallback path for Radar-supported CRDs: when client-go reports partial discovery for a specific API group, Radar directly probes known GVRs in that group, registers successful probes into resource discovery, and then lets the existing dynamic cache and warmup paths handle them normally. Clean discovery does not trigger fallback probes.

Added coverage for group-qualified discovery registration, namespace fallback probing, clean-discovery no-op behavior, and end-to-end fallback registration through dynamic cache listing for multiple CRD groups.