### PR TITLE
fix(timeline): faster startup, eager cleanup, bounded WAL (#662)

### DIFF
--- a/internal/timeline/sqlite_store.go
+++ b/internal/timeline/sqlite_store.go
@@ -82,22 +82,7 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 	// short-circuit in IsResourceSeen instead of re-running historical-event
 	// extraction for every resource. Best-effort: a query failure means we
 	// behave like a fresh store, not a fatal error.
-	if rows, err := db.Query("SELECT resource_key FROM seen_resources"); err != nil {
-		log.Printf("Warning: failed to load seen resources: %v", err)
-	} else {
-		var loaded int
-		for rows.Next() {
-			var key string
-			if err := rows.Scan(&key); err == nil {
-				store.seenResources[key] = true
-				loaded++
-			}
-		}
-		rows.Close()
-		if loaded > 0 {
-			log.Printf("[timeline] loaded %d seen resources from %s", loaded, dbPath)
-		}
-	}
+	store.hydrateSeenResources()
 
 	return store, nil
 }
@@ -555,6 +540,39 @@ func (s *SQLiteStore) StartCleanupLoop(retention, interval time.Duration) {
 			}
 		}
 	})
+}
+
+// hydrateSeenResources populates the in-memory seenResources map from the
+// persisted table. Best-effort: any error leaves the map in whatever state it
+// reached, which is no worse than a fresh store. Safe to call only from the
+// constructor — no locking, since no other goroutine has the store yet.
+func (s *SQLiteStore) hydrateSeenResources() {
+	rows, err := s.db.Query("SELECT resource_key FROM seen_resources")
+	if err != nil {
+		log.Printf("[timeline] failed to load seen resources from %s: %v", s.path, err)
+		return
+	}
+	defer rows.Close()
+
+	var loaded, skipped int
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			skipped++
+			continue
+		}
+		s.seenResources[key] = true
+		loaded++
+	}
+	if err := rows.Err(); err != nil {
+		log.Printf("[timeline] seen_resources iteration ended with error after %d rows: %v", loaded, err)
+	}
+	if skipped > 0 {
+		log.Printf("[timeline] skipped %d unreadable seen_resources rows in %s (loaded %d)", skipped, s.path, loaded)
+	}
+	if loaded > 0 {
+		log.Printf("[timeline] loaded %d seen resources from %s", loaded, s.path)
+	}
 }
 
 // runCleanup deletes events older than retention and truncates the WAL so the

--- a/internal/timeline/sqlite_store.go
+++ b/internal/timeline/sqlite_store.go
@@ -77,10 +77,26 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 		return nil, fmt.Errorf("failed to initialize schema: %w", err)
 	}
 
-	// Clear seen_resources on startup so historical events get re-extracted
-	// The events table will handle deduplication via INSERT OR IGNORE
-	if _, err := db.Exec("DELETE FROM seen_resources"); err != nil {
-		log.Printf("Warning: failed to clear seen resources: %v", err)
+	// Hydrate the in-memory seenResources map from the persisted table so
+	// that on restart, informer Add events for previously-seen resources
+	// short-circuit in IsResourceSeen instead of re-running historical-event
+	// extraction for every resource. Best-effort: a query failure means we
+	// behave like a fresh store, not a fatal error.
+	if rows, err := db.Query("SELECT resource_key FROM seen_resources"); err != nil {
+		log.Printf("Warning: failed to load seen resources: %v", err)
+	} else {
+		var loaded int
+		for rows.Next() {
+			var key string
+			if err := rows.Scan(&key); err == nil {
+				store.seenResources[key] = true
+				loaded++
+			}
+		}
+		rows.Close()
+		if loaded > 0 {
+			log.Printf("[timeline] loaded %d seen resources from %s", loaded, dbPath)
+		}
 	}
 
 	return store, nil
@@ -518,8 +534,10 @@ func (s *SQLiteStore) Cleanup(ctx context.Context, maxAge time.Duration) (int64,
 }
 
 // StartCleanupLoop spawns a goroutine that periodically deletes events older
-// than retention. Without this, the events table grows unbounded. The loop
-// exits when Close is called. retention <= 0 disables cleanup entirely.
+// than retention. Without this, the events table grows unbounded. Runs once
+// immediately so post-upgrade users with bloated DBs don't wait an hour for
+// the first cleanup. The loop exits when Close is called. retention <= 0
+// (or interval <= 0) disables cleanup entirely.
 func (s *SQLiteStore) StartCleanupLoop(retention, interval time.Duration) {
 	if retention <= 0 || interval <= 0 {
 		return
@@ -527,22 +545,32 @@ func (s *SQLiteStore) StartCleanupLoop(retention, interval time.Duration) {
 	s.wg.Go(func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
+		s.runCleanup(retention)
 		for {
 			select {
 			case <-s.quit:
 				return
 			case <-ticker.C:
-				n, err := s.Cleanup(context.Background(), retention)
-				if err != nil {
-					log.Printf("[timeline] cleanup failed for %s: %v", s.path, err)
-					continue
-				}
-				if n > 0 {
-					log.Printf("[timeline] cleanup: deleted %d events older than %s from %s", n, retention, s.path)
-				}
+				s.runCleanup(retention)
 			}
 		}
 	})
+}
+
+// runCleanup deletes events older than retention and truncates the WAL so the
+// sidecar file stays bounded. WAL truncation is best-effort.
+func (s *SQLiteStore) runCleanup(retention time.Duration) {
+	n, err := s.Cleanup(context.Background(), retention)
+	if err != nil {
+		log.Printf("[timeline] cleanup failed for %s: %v", s.path, err)
+		return
+	}
+	if n > 0 {
+		log.Printf("[timeline] cleanup: deleted %d events older than %s from %s", n, retention, s.path)
+	}
+	if _, err := s.db.Exec("PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		log.Printf("[timeline] wal_checkpoint failed for %s: %v", s.path, err)
+	}
 }
 
 // scanEvent scans a row into a TimelineEvent

--- a/internal/timeline/sqlite_store_test.go
+++ b/internal/timeline/sqlite_store_test.go
@@ -456,6 +456,39 @@ func TestSQLiteStore_LabelsStorage(t *testing.T) {
 	}
 }
 
+func TestSQLiteStore_SeenResources_PersistAcrossRestart(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "timeline-seen-persist-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	dbPath := filepath.Join(tmpDir, "seen.db")
+
+	store1, err := NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	store1.MarkResourceSeen("Pod", "default", "p1")
+	store1.MarkResourceSeen("Deployment", "kube-system", "d1")
+	store1.Close()
+
+	store2, err := NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer store2.Close()
+
+	if !store2.IsResourceSeen("Pod", "default", "p1") {
+		t.Error("expected Pod default/p1 to be seen after restart")
+	}
+	if !store2.IsResourceSeen("Deployment", "kube-system", "d1") {
+		t.Error("expected Deployment kube-system/d1 to be seen after restart")
+	}
+	if store2.IsResourceSeen("Pod", "default", "never-marked") {
+		t.Error("did not expect unmarked resource to be seen")
+	}
+}
+
 func TestSQLiteStore_StartCleanupLoop_RunsAndStopsOnClose(t *testing.T) {
 	store, cleanup := createTestSQLiteStore(t)
 	defer cleanup()

--- a/internal/timeline/sqlite_store_test.go
+++ b/internal/timeline/sqlite_store_test.go
@@ -489,6 +489,44 @@ func TestSQLiteStore_SeenResources_PersistAcrossRestart(t *testing.T) {
 	}
 }
 
+func TestSQLiteStore_StartCleanupLoop_RunsImmediately(t *testing.T) {
+	// Use an interval far longer than the test window so the only way
+	// the old event can be deleted within the deadline is the eager
+	// pre-ticker run. Catches a regression where someone moves the
+	// runCleanup call back inside the for-loop / below the case branch.
+	store, cleanup := createTestSQLiteStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	old := TimelineEvent{
+		ID:        "old",
+		Timestamp: time.Now().Add(-2 * time.Hour),
+		Source:    SourceInformer,
+		Kind:      "Pod",
+		Namespace: "default",
+		Name:      "old-pod",
+		EventType: EventTypeAdd,
+	}
+	if err := store.Append(ctx, old); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	store.StartCleanupLoop(time.Hour, time.Hour)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		events, err := store.Query(ctx, QueryOptions{Limit: 10, IncludeManaged: true})
+		if err != nil {
+			t.Fatalf("Query: %v", err)
+		}
+		if len(events) == 0 {
+			return // eager cleanup ran
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("eager cleanup did not run within 2s — old event still present")
+}
+
 func TestSQLiteStore_StartCleanupLoop_RunsAndStopsOnClose(t *testing.T) {
 	store, cleanup := createTestSQLiteStore(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

Three small follow-ups to #667 that address the parts of #662 the first PR didn't:

### 1. Hydrate `seen_resources` at startup (slow-startup fix)

Previously, `NewSQLiteStore` wiped the `seen_resources` table on every boot with the comment *"so historical events get re-extracted."* But the in-memory `seenResources` map starts empty regardless — and the persisted table was never being read back into it. So the writes from `MarkResourceSeen` were dead, and on every restart `IsResourceSeen` returned false for everything.

Consequence: every informer Add event during sync fell through to `extractTimelineHistoricalEvents` + a SQLite write. On Moulick's 5,657-resource cluster (#662), that's 5,657 synchronous DB-touching calls during informer sync — plausibly a chunk of his 6+ minute startup.

Fix: replace the `DELETE` with a `SELECT` that hydrates the map. Restart-after-seen now short-circuits in `IsResourceSeen` like it was always supposed to.

### 2. Run cleanup eagerly at startup

`StartCleanupLoop` now runs `Cleanup` once before entering the ticker loop. Users upgrading with already-bloated DBs (e.g. Moulick's 10 GB) get retention applied within seconds of restart instead of waiting up to an hour.

### 3. `PRAGMA wal_checkpoint(TRUNCATE)` after cleanup

Keeps the WAL sidecar file bounded on heavily-written stores. Best-effort; failure is logged and ignored.

## Tests

New `TestSQLiteStore_SeenResources_PersistAcrossRestart` exercises the hydration path. Existing lifecycle tests still cover the cleanup loop's run + shutdown semantics.

## Caveats

- DB on-disk size still won't shrink for already-bloated DBs without a `VACUUM`. WAL truncation only bounds the sidecar; the main file's free pages stay reserved. `VACUUM` is a separate, riskier change (locks the DB, needs 2× disk free) — separate issue.
- `--history-limit` is still ignored for sqlite — separate issue, needs a UX call on whether it should mean "row cap" or stay memory-only.

Refs #662