### PR TITLE
feat(timeline): expose retention/cleanup state in /api/diagnostics + storage choice docs

### DIFF
--- a/deploy/helm/radar/README.md
+++ b/deploy/helm/radar/README.md
@@ -65,12 +65,24 @@ helm upgrade --install radar skyhook/radar \
 | `ingress.enabled` | Enable ingress | `false` |
 | `ingress.className` | Ingress class name | `""` |
 | `timeline.storage` | Timeline storage (memory/sqlite) | `memory` |
+| `timeline.retention` | SQLite retention (Go duration; `0` disables) | `168h` |
 | `persistence.enabled` | Enable PVC for SQLite | `false` |
 | `traffic.prometheusUrl` | Manual Prometheus/VictoriaMetrics URL (skips auto-discovery) | `""` |
 | `resources.limits.memory` | Memory limit | `512Mi` |
 | `resources.requests.memory` | Memory request | `128Mi` |
 
 See `values.yaml` for all configuration options.
+
+### Timeline storage: memory vs sqlite
+
+Radar's timeline records every cluster change so you can scrub backwards through "what happened, when." Two backends:
+
+- **`memory`** (default): events live in-process. Lost on pod restart. Lower memory footprint per retention window than SQLite (no indexes, no WAL). Pick this if you only need recent activity (last few hours), don't care about losing history when a pod cycles, or want the simplest setup.
+- **`sqlite`**: events persist to a PVC across restarts. Pick this if you want a multi-day audit trail, need to inspect changes that happened while you weren't looking, or run Radar in-cluster long-term. Adds operational concerns: the PVC will fill if retention is unbounded; restarting on a multi-GB DB is slower (more rows to load).
+
+**Sizing**: a busy cluster (~5k resources, active controllers) generates ~1.5 MB/min of timeline events. With the default 7-day retention, expect ~15 GB at steady state. Tune `timeline.retention` and `persistence.size` together. Set `timeline.retention=0` to disable cleanup (events grow unbounded — not recommended).
+
+`/api/diagnostics` surfaces `timeline.retentionAge`, `timeline.lastCleanupAt`, `timeline.lastCleanupDeletedRows`, `timeline.lastCleanupError`, and `timeline.storageBytes` so you can confirm cleanup is keeping up without tailing logs.
 
 ## RBAC
 

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -44,6 +44,9 @@ spec:
             - --timeline-storage={{ .Values.timeline.storage }}
             {{- if eq .Values.timeline.storage "sqlite" }}
             - --timeline-db={{ .Values.timeline.dbPath }}
+            {{- if .Values.timeline.retention }}
+            - --timeline-retention={{ .Values.timeline.retention }}
+            {{- end }}
             {{- end }}
             - --history-limit={{ .Values.timeline.historyLimit }}
             {{- if .Values.traffic.prometheusUrl }}

--- a/deploy/helm/radar/values.schema.json
+++ b/deploy/helm/radar/values.schema.json
@@ -161,7 +161,11 @@
       "properties": {
         "storage": { "type": "string", "enum": ["memory", "sqlite"] },
         "dbPath": { "type": "string" },
-        "historyLimit": { "type": "integer", "minimum": 1 }
+        "historyLimit": { "type": "integer", "minimum": 1 },
+        "retention": {
+          "type": "string",
+          "description": "SQLite retention as a Go duration (e.g. 168h). \"0\" disables cleanup."
+        }
       }
     },
     "auth": {

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -174,14 +174,35 @@ resources:
     memory: 128Mi
 
 # Timeline storage configuration
+#
+# When to pick which:
+#   memory (default) — events live in-process and are lost on pod restart.
+#     Pick this if you only need recent activity (last few hours), don't
+#     care about losing history when a pod cycles, or want the simplest
+#     setup. Lower memory footprint than sqlite for the same retention
+#     window because there's no overhead for indexes / WAL.
+#   sqlite — events persist across restarts to a PVC. Pick this if you want
+#     a multi-day audit trail (who did what, when), need to inspect changes
+#     that happened while you weren't looking, or run Radar in-cluster as a
+#     long-lived deployment. Adds operational concerns: the PVC fills if
+#     retention is unbounded; restart on a multi-GB DB is slower.
+#
+# Sizing rule of thumb: a busy cluster (~5k resources, active controllers)
+# generates ~1.5 MB/min of timeline events. With the default 7d retention,
+# expect ~15 GB at steady state. Tune with `retention` and PVC `size` below.
 timeline:
   # Storage backend: "memory" or "sqlite"
   storage: memory
   # Path to SQLite database (only used when storage is "sqlite")
   # Note: Requires a PVC when using sqlite
   dbPath: /data/timeline.db
-  # Maximum number of events to retain
+  # Maximum number of events to retain (memory store only — currently
+  # ignored by sqlite; use `retention` instead).
   historyLimit: 10000
+  # SQLite retention: how long to keep events. Go duration (e.g. 168h, 720h).
+  # "0" disables cleanup (events table grows unbounded — not recommended for
+  # in-cluster deployments). Cleanup runs hourly + once at startup.
+  retention: 168h
 
 # Authentication and RBAC configuration
 auth:

--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -263,6 +263,17 @@ When deploying Radar in-cluster:
 
 4. **Network access**: Consider using NetworkPolicies to restrict which pods can reach Radar.
 
+## Timeline Storage: memory vs sqlite
+
+Radar's timeline records every cluster change. Two backends:
+
+- **`memory`** (default): events live in-process, lost on pod restart. Lowest footprint; pick this if you only need recent activity (last few hours).
+- **`sqlite`**: events persist to a PVC across restarts. Multi-day audit trail; pick this for long-running in-cluster deployments where you care about history surviving pod cycles.
+
+A busy cluster (~5k resources, active controllers) generates ~1.5 MB/min of events. With the default 7-day retention, expect ~15 GB at steady state. Tune `timeline.retention` (Go duration; `0` disables cleanup — not recommended) and `persistence.size` together.
+
+Cleanup runs hourly + once at startup. Confirm it's keeping up via `/api/diagnostics` — the `timeline.lastCleanupAt`, `timeline.lastCleanupDeletedRows`, `timeline.lastCleanupError`, and `timeline.storageBytes` fields surface the state without requiring `kubectl logs`.
+
 ## Configuration Reference
 
 See [Helm Chart README](../deploy/helm/radar/README.md) for all available values.
@@ -277,7 +288,8 @@ See [Helm Chart README](../deploy/helm/radar/README.md) for all available values
 | `mcp.enabled` | Enable MCP server for AI tools | `true` |
 | `timeline.storage` | Event storage (memory/sqlite) | `memory` |
 | `timeline.dbPath` | SQLite database path | `/data/timeline.db` |
-| `timeline.historyLimit` | Max events to retain | `10000` |
+| `timeline.historyLimit` | Max events to retain (memory only) | `10000` |
+| `timeline.retention` | SQLite retention (Go duration; `0` disables) | `168h` |
 | `traffic.prometheusUrl` | Manual Prometheus/VictoriaMetrics URL | `""` (auto-discover) |
 | `persistence.enabled` | Enable PVC for SQLite storage | `false` |
 | `persistence.size` | PVC size | `1Gi` |

--- a/internal/server/diagnostics.go
+++ b/internal/server/diagnostics.go
@@ -104,12 +104,19 @@ type DiagCache struct {
 
 // DiagTimeline holds timeline store info.
 type DiagTimeline struct {
-	StorageType string `json:"storageType"`
-	TotalEvents int64  `json:"totalEvents"`
-	OldestEvent string `json:"oldestEvent,omitempty"`
-	NewestEvent string `json:"newestEvent,omitempty"`
-	StoreErrors int64  `json:"storeErrors"`
-	TotalDrops  int64  `json:"totalDrops"`
+	StorageType  string `json:"storageType"`
+	TotalEvents  int64  `json:"totalEvents"`
+	OldestEvent  string `json:"oldestEvent,omitempty"`
+	NewestEvent  string `json:"newestEvent,omitempty"`
+	StorageBytes int64  `json:"storageBytes,omitempty"`
+	StoreErrors  int64  `json:"storeErrors"`
+	TotalDrops   int64  `json:"totalDrops"`
+
+	// SQLite-only retention/cleanup state.
+	RetentionAge       string `json:"retentionAge,omitempty"`
+	LastCleanupAt      string `json:"lastCleanupAt,omitempty"`
+	LastCleanupDeleted int64  `json:"lastCleanupDeletedRows,omitempty"`
+	LastCleanupError   string `json:"lastCleanupError,omitempty"`
 }
 
 // DiagEventPipeline holds event pipeline metrics.
@@ -284,15 +291,24 @@ func (s *Server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
 		}
 		stats := store.Stats()
 		diag := &DiagTimeline{
-			TotalEvents: stats.TotalEvents,
-			StoreErrors: timeline.GetStoreErrorCount(),
-			TotalDrops:  timeline.GetTotalDropCount(),
+			TotalEvents:        stats.TotalEvents,
+			StorageBytes:       stats.StorageBytes,
+			StoreErrors:        timeline.GetStoreErrorCount(),
+			TotalDrops:         timeline.GetTotalDropCount(),
+			LastCleanupDeleted: stats.LastCleanupDeletedRows,
+			LastCleanupError:   stats.LastCleanupError,
 		}
 		if !stats.OldestEvent.IsZero() {
 			diag.OldestEvent = stats.OldestEvent.Format(time.RFC3339)
 		}
 		if !stats.NewestEvent.IsZero() {
 			diag.NewestEvent = stats.NewestEvent.Format(time.RFC3339)
+		}
+		if !stats.LastCleanupAt.IsZero() {
+			diag.LastCleanupAt = stats.LastCleanupAt.Format(time.RFC3339)
+		}
+		if stats.RetentionAge > 0 {
+			diag.RetentionAge = stats.RetentionAge.String()
 		}
 		if s.diagConfig != nil {
 			diag.StorageType = s.diagConfig.TimelineStorage

--- a/internal/timeline/sqlite_store.go
+++ b/internal/timeline/sqlite_store.go
@@ -29,6 +29,12 @@ type SQLiteStore struct {
 	quit          chan struct{}
 	wg            sync.WaitGroup
 	closeOnce     sync.Once
+
+	cleanupMu     sync.RWMutex
+	retentionAge  time.Duration
+	lastCleanupAt time.Time
+	lastCleanupN  int64
+	lastCleanupEr string
 }
 
 // NewSQLiteStore creates a new SQLite-backed event store.
@@ -496,6 +502,13 @@ func (s *SQLiteStore) Stats() StoreStats {
 	stats.SeenResources = len(s.seenResources)
 	s.seenMu.RUnlock()
 
+	s.cleanupMu.RLock()
+	stats.RetentionAge = s.retentionAge
+	stats.LastCleanupAt = s.lastCleanupAt
+	stats.LastCleanupDeletedRows = s.lastCleanupN
+	stats.LastCleanupError = s.lastCleanupEr
+	s.cleanupMu.RUnlock()
+
 	return stats
 }
 
@@ -527,6 +540,9 @@ func (s *SQLiteStore) StartCleanupLoop(retention, interval time.Duration) {
 	if retention <= 0 || interval <= 0 {
 		return
 	}
+	s.cleanupMu.Lock()
+	s.retentionAge = retention
+	s.cleanupMu.Unlock()
 	s.wg.Go(func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
@@ -576,9 +592,23 @@ func (s *SQLiteStore) hydrateSeenResources() {
 }
 
 // runCleanup deletes events older than retention and truncates the WAL so the
-// sidecar file stays bounded. WAL truncation is best-effort.
+// sidecar file stays bounded. WAL truncation is best-effort. Records outcome
+// (timestamp, deleted count, last error) so it's surfaceable via Stats() and
+// /api/diagnostics — operators shouldn't need to tail logs to know retention
+// is working.
 func (s *SQLiteStore) runCleanup(retention time.Duration) {
 	n, err := s.Cleanup(context.Background(), retention)
+	now := time.Now()
+	s.cleanupMu.Lock()
+	s.lastCleanupAt = now
+	if err != nil {
+		s.lastCleanupEr = err.Error()
+	} else {
+		s.lastCleanupEr = ""
+		s.lastCleanupN = n
+	}
+	s.cleanupMu.Unlock()
+
 	if err != nil {
 		log.Printf("[timeline] cleanup failed for %s: %v", s.path, err)
 		return

--- a/internal/timeline/sqlite_store_test.go
+++ b/internal/timeline/sqlite_store_test.go
@@ -489,6 +489,50 @@ func TestSQLiteStore_SeenResources_PersistAcrossRestart(t *testing.T) {
 	}
 }
 
+func TestSQLiteStore_Stats_RecordsCleanupState(t *testing.T) {
+	store, cleanup := createTestSQLiteStore(t)
+	defer cleanup()
+
+	if got := store.Stats(); !got.LastCleanupAt.IsZero() || got.RetentionAge != 0 {
+		t.Errorf("expected zero cleanup state before StartCleanupLoop, got %+v", got)
+	}
+
+	ctx := context.Background()
+	old := TimelineEvent{
+		ID:        "old",
+		Timestamp: time.Now().Add(-2 * time.Hour),
+		Source:    SourceInformer,
+		Kind:      "Pod",
+		Namespace: "default",
+		Name:      "old-pod",
+		EventType: EventTypeAdd,
+	}
+	if err := store.Append(ctx, old); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	store.StartCleanupLoop(time.Hour, time.Hour)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		stats := store.Stats()
+		if !stats.LastCleanupAt.IsZero() {
+			if stats.RetentionAge != time.Hour {
+				t.Errorf("RetentionAge = %s, want 1h", stats.RetentionAge)
+			}
+			if stats.LastCleanupDeletedRows != 1 {
+				t.Errorf("LastCleanupDeletedRows = %d, want 1", stats.LastCleanupDeletedRows)
+			}
+			if stats.LastCleanupError != "" {
+				t.Errorf("LastCleanupError = %q, want empty", stats.LastCleanupError)
+			}
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("LastCleanupAt remained zero — cleanup state not recorded")
+}
+
 func TestSQLiteStore_StartCleanupLoop_RunsImmediately(t *testing.T) {
 	// Use an interval far longer than the test window so the only way
 	// the old event can be deleted within the deadline is the eager

--- a/pkg/timeline/store.go
+++ b/pkg/timeline/store.go
@@ -84,6 +84,12 @@ type StoreStats struct {
 	NewestEvent   time.Time `json:"newestEvent"`
 	StorageBytes  int64     `json:"storageBytes,omitempty"`
 	SeenResources int       `json:"seenResources"`
+
+	// SQLite-only retention/cleanup state. Zero values for memory store.
+	RetentionAge           time.Duration `json:"retentionAge,omitempty"`
+	LastCleanupAt          time.Time     `json:"lastCleanupAt,omitempty"`
+	LastCleanupDeletedRows int64         `json:"lastCleanupDeletedRows,omitempty"`
+	LastCleanupError       string        `json:"lastCleanupError,omitempty"`
 }
 
 // CompiledFilter is a pre-compiled filter for efficient event filtering


### PR DESCRIPTION
Two follow-ups to the timeline retention work (#667, #670) addressing **visibility** and the question Moulick raised in #662 (*\"what's the benefit of enabling sqlite persistence?\"*).

## Diagnostics

`/api/diagnostics` now surfaces SQLite-only retention/cleanup state:

- \`timeline.retentionAge\` — configured retention (or omitted if disabled)
- \`timeline.lastCleanupAt\` — when cleanup last ran
- \`timeline.lastCleanupDeletedRows\` — rows deleted last run
- \`timeline.lastCleanupError\` — last cleanup error
- \`timeline.storageBytes\` — DB file size (was already in \`StoreStats\`, just newly piped through)

All fields use \`omitempty\` so memory-store users see nothing extra. Lets operators answer *\"is retention working?\"* without tailing logs — was a stated concern from review of #667 that we deferred at the time.

## Helm chart

- Wires \`--timeline-retention\` (added in #667 but never reached the chart). Defaults to 168h.
- New \"Timeline storage: memory vs sqlite\" section in the chart README + \`docs/in-cluster.md\` covering when to pick which.
- Sizing rule of thumb so operators can size the PVC sensibly: ~1.5 MB/min on busy clusters → ~15 GB at 7d retention.

## Tests

\`TestSQLiteStore_Stats_RecordsCleanupState\` pins that \`Stats()\` reflects retention + cleanup outcomes after \`StartCleanupLoop\` runs.

## Considered & deferred

- **\`walBytes\`** for the \`.db-wal\` sidecar — trivial to add but the practical motivation is weak. We already explicitly truncate it after every cleanup; a checkpoint failure logs an error. With \`MaxOpenConns=1\` the \"reader pinning the WAL\" failure mode is essentially impossible.

Refs #662