### PR TITLE
fix(update): give script-installed users a copy-chip update command

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -281,9 +281,11 @@ func getUpdateCommand(method InstallMethod) string {
 	return getUpdateCommandForOS(method, runtime.GOOS)
 }
 
-// getUpdateCommandForOS is the OS-parameterized variant for testability.
-// For InstallDirect it returns the public install one-liner — the same script
-// is idempotent and upgrades an existing binary at /usr/local/bin/kubectl-radar.
+// getUpdateCommandForOS returns the update command for a given install method
+// and OS. For InstallDirect, the install one-liner is idempotent — re-running
+// it upgrades an existing binary in place. Returns "" for any GOOS that the
+// public install script doesn't support, so the frontend falls through to the
+// GitHub release-download link.
 func getUpdateCommandForOS(method InstallMethod, goos string) string {
 	switch method {
 	case InstallHomebrew:
@@ -293,10 +295,14 @@ func getUpdateCommandForOS(method InstallMethod, goos string) string {
 	case InstallScoop:
 		return "scoop update radar"
 	case InstallDirect:
-		if goos == "windows" {
+		switch goos {
+		case "darwin", "linux":
+			return "curl -fsSL https://get.radarhq.io | sh"
+		case "windows":
 			return "irm https://get.radarhq.io/install.ps1 | iex"
+		default:
+			return ""
 		}
-		return "curl -fsSL https://get.radarhq.io | sh"
 	case InstallDesktop:
 		return "" // in-app update, no CLI command
 	default:

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -278,6 +278,13 @@ func detectInstallMethodFromPath(exe string) InstallMethod {
 // getUpdateCommand returns the command to update based on install method.
 // Desktop returns empty since updates are handled in-app.
 func getUpdateCommand(method InstallMethod) string {
+	return getUpdateCommandForOS(method, runtime.GOOS)
+}
+
+// getUpdateCommandForOS is the OS-parameterized variant for testability.
+// For InstallDirect it returns the public install one-liner — the same script
+// is idempotent and upgrades an existing binary at /usr/local/bin/kubectl-radar.
+func getUpdateCommandForOS(method InstallMethod, goos string) string {
 	switch method {
 	case InstallHomebrew:
 		return "brew upgrade skyhook-io/tap/radar"
@@ -285,6 +292,11 @@ func getUpdateCommand(method InstallMethod) string {
 		return "kubectl krew upgrade radar"
 	case InstallScoop:
 		return "scoop update radar"
+	case InstallDirect:
+		if goos == "windows" {
+			return "irm https://get.radarhq.io/install.ps1 | iex"
+		}
+		return "curl -fsSL https://get.radarhq.io | sh"
 	case InstallDesktop:
 		return "" // in-app update, no CLI command
 	default:

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -54,6 +54,8 @@ func TestGetUpdateCommand(t *testing.T) {
 		{"direct linux", InstallDirect, "linux", "curl -fsSL https://get.radarhq.io | sh"},
 		{"direct darwin", InstallDirect, "darwin", "curl -fsSL https://get.radarhq.io | sh"},
 		{"direct windows", InstallDirect, "windows", "irm https://get.radarhq.io/install.ps1 | iex"},
+		{"direct freebsd falls through", InstallDirect, "freebsd", ""},
+		{"direct empty goos falls through", InstallDirect, "", ""},
 		{"desktop", InstallDesktop, "darwin", ""},
 		{"unknown", InstallMethod("unknown"), "linux", ""},
 	}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -43,22 +43,26 @@ func TestIsNewerVersion(t *testing.T) {
 
 func TestGetUpdateCommand(t *testing.T) {
 	tests := []struct {
+		name   string
 		method InstallMethod
+		goos   string
 		want   string
 	}{
-		{InstallHomebrew, "brew upgrade skyhook-io/tap/radar"},
-		{InstallKrew, "kubectl krew upgrade radar"},
-		{InstallScoop, "scoop update radar"},
-		{InstallDirect, ""},
-		{InstallDesktop, ""},
-		{InstallMethod("unknown"), ""},
+		{"homebrew", InstallHomebrew, "darwin", "brew upgrade skyhook-io/tap/radar"},
+		{"krew", InstallKrew, "linux", "kubectl krew upgrade radar"},
+		{"scoop", InstallScoop, "windows", "scoop update radar"},
+		{"direct linux", InstallDirect, "linux", "curl -fsSL https://get.radarhq.io | sh"},
+		{"direct darwin", InstallDirect, "darwin", "curl -fsSL https://get.radarhq.io | sh"},
+		{"direct windows", InstallDirect, "windows", "irm https://get.radarhq.io/install.ps1 | iex"},
+		{"desktop", InstallDesktop, "darwin", ""},
+		{"unknown", InstallMethod("unknown"), "linux", ""},
 	}
 
 	for _, tt := range tests {
-		t.Run(string(tt.method), func(t *testing.T) {
-			got := getUpdateCommand(tt.method)
+		t.Run(tt.name, func(t *testing.T) {
+			got := getUpdateCommandForOS(tt.method, tt.goos)
 			if got != tt.want {
-				t.Errorf("getUpdateCommand(%q) = %q, want %q", tt.method, got, tt.want)
+				t.Errorf("getUpdateCommandForOS(%q, %q) = %q, want %q", tt.method, tt.goos, got, tt.want)
 			}
 		})
 	}

--- a/web/src/components/ui/UpdateNotification.tsx
+++ b/web/src/components/ui/UpdateNotification.tsx
@@ -8,6 +8,7 @@ import {
   useApplyDesktopUpdate,
 } from '../../api/client'
 import type { DesktopUpdateState } from '../../api/client'
+import { WithTooltip } from './Tooltip'
 
 const DISMISSED_KEY = 'radar-update-dismissed'
 
@@ -141,14 +142,15 @@ export function UpdateNotification() {
           {/* CLI: show update command with copy button for package managers */}
           {!isDesktop && versionInfo.updateCommand ? (
             <>
-              <button
-                onClick={handleCopyCommand}
-                title={versionInfo.updateCommand}
-                className="flex items-center gap-2 mt-2 px-2 py-1.5 bg-theme-elevated rounded text-xs font-mono text-theme-text-primary hover:bg-theme-surface-hover transition-colors w-full"
-              >
-                <code className="flex-1 text-left truncate">{versionInfo.updateCommand}</code>
-                <CopyIcon copied={copied} failed={copyFailed} />
-              </button>
+              <WithTooltip tip={versionInfo.updateCommand} delay={100}>
+                <button
+                  onClick={handleCopyCommand}
+                  className="flex items-center gap-2 mt-2 px-2 py-1.5 bg-theme-elevated rounded font-mono text-theme-text-primary hover:bg-theme-surface-hover transition-colors w-full"
+                >
+                  <code className="flex-1 text-left truncate text-[11px]">{versionInfo.updateCommand}</code>
+                  <CopyIcon copied={copied} failed={copyFailed} />
+                </button>
+              </WithTooltip>
               {/* Direct installs may have placed the binary somewhere the install
                   script won't touch — surface a download link as a fallback. */}
               {versionInfo.installMethod === 'direct' && versionInfo.releaseUrl && (

--- a/web/src/components/ui/UpdateNotification.tsx
+++ b/web/src/components/ui/UpdateNotification.tsx
@@ -143,9 +143,9 @@ export function UpdateNotification() {
             <>
               <button
                 onClick={handleCopyCommand}
-                className="flex items-center gap-2 mt-2 px-2 py-1.5 bg-theme-elevated rounded text-xs font-mono text-theme-text-primary hover:bg-theme-surface-hover transition-colors w-full"
+                className="flex items-start gap-2 mt-2 px-2 py-1.5 bg-theme-elevated rounded text-xs font-mono text-theme-text-primary hover:bg-theme-surface-hover transition-colors w-full"
               >
-                <code className="flex-1 text-left truncate">{versionInfo.updateCommand}</code>
+                <code className="flex-1 text-left break-all">{versionInfo.updateCommand}</code>
                 <CopyIcon copied={copied} failed={copyFailed} />
               </button>
               {/* Direct installs may have placed the binary somewhere the install

--- a/web/src/components/ui/UpdateNotification.tsx
+++ b/web/src/components/ui/UpdateNotification.tsx
@@ -140,15 +140,28 @@ export function UpdateNotification() {
 
           {/* CLI: show update command with copy button for package managers */}
           {!isDesktop && versionInfo.updateCommand ? (
-            <button
-              onClick={handleCopyCommand}
-              className="flex items-center gap-2 mt-2 px-2 py-1.5 bg-theme-elevated rounded text-xs font-mono text-theme-text-primary hover:bg-theme-surface-hover transition-colors w-full"
-            >
-              <code className="flex-1 text-left truncate">{versionInfo.updateCommand}</code>
-              <CopyIcon copied={copied} failed={copyFailed} />
-            </button>
+            <>
+              <button
+                onClick={handleCopyCommand}
+                className="flex items-center gap-2 mt-2 px-2 py-1.5 bg-theme-elevated rounded text-xs font-mono text-theme-text-primary hover:bg-theme-surface-hover transition-colors w-full"
+              >
+                <code className="flex-1 text-left truncate">{versionInfo.updateCommand}</code>
+                <CopyIcon copied={copied} failed={copyFailed} />
+              </button>
+              {/* Direct installs may have placed the binary somewhere the install
+                  script won't touch — surface a download link as a fallback. */}
+              {versionInfo.installMethod === 'direct' && versionInfo.releaseUrl && (
+                <a
+                  href={versionInfo.releaseUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 mt-1.5 text-xs text-theme-text-tertiary hover:text-theme-text-secondary hover:underline"
+                >
+                  or download from GitHub →
+                </a>
+              )}
+            </>
           ) : (
-            /* Direct download - show release link */
             !isDesktop && versionInfo.releaseUrl && (
               <a
                 href={versionInfo.releaseUrl}

--- a/web/src/components/ui/UpdateNotification.tsx
+++ b/web/src/components/ui/UpdateNotification.tsx
@@ -143,9 +143,10 @@ export function UpdateNotification() {
             <>
               <button
                 onClick={handleCopyCommand}
-                className="flex items-start gap-2 mt-2 px-2 py-1.5 bg-theme-elevated rounded text-xs font-mono text-theme-text-primary hover:bg-theme-surface-hover transition-colors w-full"
+                title={versionInfo.updateCommand}
+                className="flex items-center gap-2 mt-2 px-2 py-1.5 bg-theme-elevated rounded text-xs font-mono text-theme-text-primary hover:bg-theme-surface-hover transition-colors w-full"
               >
-                <code className="flex-1 text-left break-all">{versionInfo.updateCommand}</code>
+                <code className="flex-1 text-left truncate">{versionInfo.updateCommand}</code>
                 <CopyIcon copied={copied} failed={copyFailed} />
               </button>
               {/* Direct installs may have placed the binary somewhere the install

--- a/web/src/components/ui/UpdateNotification.tsx
+++ b/web/src/components/ui/UpdateNotification.tsx
@@ -117,7 +117,7 @@ export function UpdateNotification() {
           <UpdateIcon state={effectiveState} />
         </div>
         <div className="flex-1 min-w-0">
-          <h4 className="text-sm font-medium text-theme-text-primary">
+          <h4 className="text-sm font-medium text-theme-text-primary pr-6">
             <UpdateTitle state={effectiveState} />
           </h4>
           <p className="text-xs text-theme-text-secondary mt-1">
@@ -175,17 +175,18 @@ export function UpdateNotification() {
             )
           )}
         </div>
-        {/* Don't show dismiss during active update */}
-        {effectiveState !== 'downloading' && effectiveState !== 'applying' && (
-          <button
-            onClick={handleDismiss}
-            className="p-1 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded shrink-0"
-            aria-label="Dismiss"
-          >
-            <X className="w-4 h-4" />
-          </button>
-        )}
       </div>
+      {/* Dismiss is absolute so it doesn't compress the chip's width.
+          fixed on the parent already establishes the positioning context. */}
+      {effectiveState !== 'downloading' && effectiveState !== 'applying' && (
+        <button
+          onClick={handleDismiss}
+          className="absolute top-2 right-2 p-1 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
+          aria-label="Dismiss"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## What

The update popup gave package-manager users (Homebrew, Krew, Scoop) a tidy one-click copy chip with the right upgrade command, but anyone who installed via the quick install script (`curl -fsSL https://get.radarhq.io | sh`) — or any other "direct" path — got punted to a generic "Download from GitHub" link.

That direct-install bucket is likely the most common path for Linux users, since the script is what we recommend in the README and on the marketing site.

## Change

- `InstallDirect` now returns the install one-liner as its update command:
  - unix: `curl -fsSL https://get.radarhq.io | sh`
  - Windows: `irm https://get.radarhq.io/install.ps1 | iex`
- The script is idempotent — re-running upgrades the existing binary at `/usr/local/bin/kubectl-radar`.
- For the edge case where someone manually placed the binary outside the standard path, the popup keeps a small "or download from GitHub →" link beneath the copy chip (only for `direct` installs, not for the package-manager paths).

Other install methods (homebrew/krew/scoop/desktop) are unchanged.