### PR TITLE
feat(timeline): drop no-diff updates after filling diff-function gaps (#662)

### DIFF
--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -396,6 +396,9 @@ func recordToTimelineStore(kind, namespace, name, uid, op string, oldObj, newObj
 			// managedFields-only, reconcile counter. Recording these produces
 			// content-free timeline rows; drop instead.
 			timeline.RecordDrop(kind, namespace, name, timeline.DropReasonNoDiff, op)
+			if DebugEvents {
+				log.Printf("[DEBUG] No-diff update, skipping: %s/%s/%s", kind, namespace, name)
+			}
 			return
 		}
 	}

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -391,6 +391,12 @@ func recordToTimelineStore(kind, namespace, name, uid, op string, oldObj, newObj
 					NewValue: f.NewValue,
 				}
 			}
+		} else if KindHasDiffer(kind) {
+			// Audited diff function found nothing observable — heartbeat,
+			// managedFields-only, reconcile counter. Recording these produces
+			// content-free timeline rows; drop instead.
+			timeline.RecordDrop(kind, namespace, name, timeline.DropReasonNoDiff, op)
+			return
 		}
 	}
 

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -314,6 +314,11 @@ func isNoisyResource(kind, name, op string) bool {
 	switch kind {
 	case "Lease", "Endpoints", "EndpointSlice", "Event":
 		return true
+	case "VerticalPodAutoscalerCheckpoint":
+		// VPA writes per-container resource recommendations here on every
+		// reconcile (~1m). The whole point of the resource is to be a live
+		// ticker — per-update is never user-meaningful.
+		return true
 	}
 
 	if kind == "ConfigMap" {

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -344,6 +344,20 @@ func isNoisyResource(kind, name, op string) bool {
 	return false
 }
 
+// getGeneration returns the metadata.generation of an informer object, or 0
+// if the object is nil or doesn't expose metav1.Object. Both typed K8s
+// resources and *unstructured.Unstructured satisfy metav1.Object.
+func getGeneration(obj any) int64 {
+	if obj == nil {
+		return 0
+	}
+	m, ok := obj.(metav1.Object)
+	if !ok {
+		return 0
+	}
+	return m.GetGeneration()
+}
+
 // recordToTimelineStore records an event to the timeline store
 func recordToTimelineStore(kind, namespace, name, uid, op string, oldObj, newObj any) {
 	store := timeline.GetStore()
@@ -397,14 +411,29 @@ func recordToTimelineStore(kind, namespace, name, uid, op string, oldObj, newObj
 				}
 			}
 		} else if KindHasDiffer(kind) {
-			// Audited diff function found nothing observable — heartbeat,
-			// managedFields-only, reconcile counter. Recording these produces
-			// content-free timeline rows; drop instead.
-			timeline.RecordDrop(kind, namespace, name, timeline.DropReasonNoDiff, op)
-			if DebugEvents {
-				log.Printf("[DEBUG] No-diff update, skipping: %s/%s/%s", kind, namespace, name)
+			// Audited diff function found nothing observable — usually a
+			// heartbeat, managedFields-only update, or reconcile counter.
+			// Before dropping, check metadata.generation: it bumps only on
+			// spec changes (status updates don't touch it), so a generation
+			// flip with a nil diff means our diff function missed a real spec
+			// field. Record those with a fallback summary instead of silently
+			// losing them — diff coverage gaps shouldn't become silent drops.
+			if oldGen, newGen := getGeneration(oldObj), getGeneration(newObj); oldGen != newGen && oldGen > 0 && newGen > 0 {
+				diff = &timeline.DiffInfo{
+					Fields: []timeline.FieldChange{{
+						Path:     "metadata.generation",
+						OldValue: oldGen,
+						NewValue: newGen,
+					}},
+					Summary: fmt.Sprintf("spec changed (gen %d→%d, fields not specifically tracked)", oldGen, newGen),
+				}
+			} else {
+				timeline.RecordDrop(kind, namespace, name, timeline.DropReasonNoDiff, op)
+				if DebugEvents {
+					log.Printf("[DEBUG] No-diff update, skipping: %s/%s/%s", kind, namespace, name)
+				}
+				return
 			}
-			return
 		}
 	}
 

--- a/internal/k8s/history.go
+++ b/internal/k8s/history.go
@@ -3,7 +3,9 @@ package k8s
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
+	"sync"
 
 	"github.com/skyhook-io/radar/pkg/k8score"
 	appsv1 "k8s.io/api/apps/v1"
@@ -19,53 +21,51 @@ type OwnerInfo = k8score.OwnerInfo
 type DiffInfo = k8score.DiffInfo
 type FieldChange = k8score.FieldChange
 
-// ComputeDiff computes the diff between old and new objects based on kind
-// Returns nil if no meaningful changes detected or kind not supported
-func ComputeDiff(kind string, oldObj, newObj any) *DiffInfo {
-	var changes []FieldChange
-	var summaryParts []string
+// kindDiffFunc is the per-kind diff dispatcher signature used by diffFunctions.
+type kindDiffFunc func(oldObj, newObj any) ([]FieldChange, []string)
 
-	switch kind {
-	case "Deployment":
-		changes, summaryParts = diffDeployment(oldObj, newObj)
-	case "Pod":
-		changes, summaryParts = diffPod(oldObj, newObj)
-	case "Service":
-		changes, summaryParts = diffService(oldObj, newObj)
-	case "ConfigMap":
-		changes, summaryParts = diffConfigMap(oldObj, newObj)
-	case "Ingress":
-		changes, summaryParts = diffIngress(oldObj, newObj)
-	case "ReplicaSet":
-		changes, summaryParts = diffReplicaSet(oldObj, newObj)
-	case "DaemonSet":
-		changes, summaryParts = diffDaemonSet(oldObj, newObj)
-	case "StatefulSet":
-		changes, summaryParts = diffStatefulSet(oldObj, newObj)
-	case "HorizontalPodAutoscaler":
-		changes, summaryParts = diffHPA(oldObj, newObj)
-	case "Job":
-		changes, summaryParts = diffJob(oldObj, newObj)
-	case "Node":
-		changes, summaryParts = diffNode(oldObj, newObj)
-	case "PersistentVolumeClaim":
-		changes, summaryParts = diffPVC(oldObj, newObj)
-	case "Application":
-		changes, summaryParts = diffApplication(oldObj, newObj)
-	case "Kustomization":
-		changes, summaryParts = diffKustomization(oldObj, newObj)
-	case "HelmRelease":
-		changes, summaryParts = diffFluxHelmRelease(oldObj, newObj)
-	case "GitRepository", "OCIRepository", "HelmRepository":
-		changes, summaryParts = diffFluxSource(oldObj, newObj, kind)
-	case "Gateway":
-		changes, summaryParts = diffGateway(oldObj, newObj)
-	case "HTTPRoute", "GRPCRoute", "TCPRoute", "TLSRoute":
-		changes, summaryParts = diffGatewayRoute(oldObj, newObj)
-	default:
+// diffFunctions is the single source of truth for kinds with audited diff
+// coverage. ComputeDiff dispatches via this map, KindHasDiffer reads its
+// keys — no separate "kinds we know about" list to drift out of sync.
+//
+// Adding a kind here is a CONTRACT: the diff function MUST surface every
+// status field a user would care about, because for kinds in this map,
+// recordToTimelineStore drops update events when the diff is empty.
+var diffFunctions = map[string]kindDiffFunc{
+	"Deployment":              diffDeployment,
+	"Pod":                     diffPod,
+	"Service":                 diffService,
+	"ConfigMap":               diffConfigMap,
+	"Ingress":                 diffIngress,
+	"ReplicaSet":              diffReplicaSet,
+	"DaemonSet":               diffDaemonSet,
+	"StatefulSet":             diffStatefulSet,
+	"HorizontalPodAutoscaler": diffHPA,
+	"Job":                     diffJob,
+	"Node":                    diffNode,
+	"PersistentVolumeClaim":   diffPVC,
+	"Application":             diffApplication,
+	"Kustomization":           diffKustomization,
+	"HelmRelease":             diffFluxHelmRelease,
+	"GitRepository":           func(o, n any) ([]FieldChange, []string) { return diffFluxSource(o, n, "GitRepository") },
+	"OCIRepository":           func(o, n any) ([]FieldChange, []string) { return diffFluxSource(o, n, "OCIRepository") },
+	"HelmRepository":          func(o, n any) ([]FieldChange, []string) { return diffFluxSource(o, n, "HelmRepository") },
+	"Gateway":                 diffGateway,
+	"HTTPRoute":               diffGatewayRoute,
+	"GRPCRoute":               diffGatewayRoute,
+	"TCPRoute":                diffGatewayRoute,
+	"TLSRoute":                diffGatewayRoute,
+}
+
+// ComputeDiff computes the diff between old and new objects based on kind.
+// Returns nil if the kind has no audited diff function or if no meaningful
+// changes were detected.
+func ComputeDiff(kind string, oldObj, newObj any) *DiffInfo {
+	fn, ok := diffFunctions[kind]
+	if !ok {
 		return nil
 	}
-
+	changes, summaryParts := fn(oldObj, newObj)
 	if len(changes) == 0 {
 		return nil
 	}
@@ -86,23 +86,27 @@ func ComputeDiff(kind string, oldObj, newObj any) *DiffInfo {
 	}
 }
 
-// KindHasDiffer returns true for kinds where ComputeDiff has audited coverage —
-// i.e. an update producing a nil diff means there was no observable state
-// change. Callers use this to filter out the heartbeat / managedFields-only /
-// reconcile-counter updates that would otherwise become content-free timeline
-// rows. Adding a kind here is a contract: the diff function must cover every
-// status field a user would care about.
-func KindHasDiffer(kind string) bool {
-	switch kind {
-	case "Deployment", "Pod", "Service", "ConfigMap", "Ingress",
-		"ReplicaSet", "DaemonSet", "StatefulSet",
-		"HorizontalPodAutoscaler", "Job", "Node", "PersistentVolumeClaim",
-		"Application", "Kustomization", "HelmRelease",
-		"GitRepository", "OCIRepository", "HelmRepository",
-		"Gateway", "HTTPRoute", "GRPCRoute", "TCPRoute", "TLSRoute":
-		return true
+// typeAssertWarnedKinds dedups one-time warnings about type-assertion failures
+// inside the per-kind diff helpers. A failure means an informer for a kind in
+// KindHasDiffer is wired with the wrong factory — every update for that kind
+// would silently drop as "no diff." Logging once per kind keeps it diagnosable
+// without spamming.
+var typeAssertWarnedKinds sync.Map
+
+// warnUnstructuredAssertFailed logs once per kind when an unstructured diff
+// helper receives a non-unstructured object.
+func warnUnstructuredAssertFailed(kind string, got any) {
+	if _, loaded := typeAssertWarnedKinds.LoadOrStore(kind, true); loaded {
+		return
 	}
-	return false
+	log.Printf("[history] WARN: %s diff received non-unstructured object (%T) — every %s update will silently drop. Likely informer wired to wrong factory.", kind, got, kind)
+}
+
+// KindHasDiffer reports whether the given kind has audited ComputeDiff
+// coverage. The no-diff drop only fires for kinds in this set.
+func KindHasDiffer(kind string) bool {
+	_, ok := diffFunctions[kind]
+	return ok
 }
 
 // diffDeployment computes diff for Deployment resources
@@ -313,7 +317,43 @@ func diffPod(oldObj, newObj any) ([]FieldChange, []string) {
 		summary = append(summary, fmt.Sprintf("IP: %s", newPod.Status.PodIP))
 	}
 
+	// Ephemeral containers (kubectl debug attach). Status surfaces them as a
+	// new EphemeralContainerStatuses entry — invisible to phase/restart/state.
+	if len(newPod.Status.EphemeralContainerStatuses) > len(oldPod.Status.EphemeralContainerStatuses) {
+		changes = append(changes, FieldChange{
+			Path:     "status.ephemeralContainerStatuses",
+			OldValue: len(oldPod.Status.EphemeralContainerStatuses),
+			NewValue: len(newPod.Status.EphemeralContainerStatuses),
+		})
+		summary = append(summary, fmt.Sprintf("debug container attached (%d total)", len(newPod.Status.EphemeralContainerStatuses)))
+	}
+
+	// PodReady and ContainersReady transitions. Probe failures on a Running
+	// container flip these without changing container state, so we'd otherwise
+	// miss them entirely.
+	for _, condType := range []corev1.PodConditionType{corev1.PodReady, corev1.ContainersReady} {
+		oldStatus := getPodConditionStatus(oldPod, condType)
+		newStatus := getPodConditionStatus(newPod, condType)
+		if oldStatus != newStatus && (oldStatus != "" || newStatus != "") {
+			changes = append(changes, FieldChange{
+				Path:     fmt.Sprintf("status.conditions[%s]", condType),
+				OldValue: oldStatus,
+				NewValue: newStatus,
+			})
+			summary = append(summary, fmt.Sprintf("%s: %s→%s", condType, oldStatus, newStatus))
+		}
+	}
+
 	return changes, summary
+}
+
+func getPodConditionStatus(p *corev1.Pod, condType corev1.PodConditionType) string {
+	for _, c := range p.Status.Conditions {
+		if c.Type == condType {
+			return string(c.Status)
+		}
+	}
+	return ""
 }
 
 // getContainerState returns a string describing the container's current state
@@ -977,6 +1017,12 @@ func diffJob(oldObj, newObj any) ([]FieldChange, []string) {
 
 	// Check terminal conditions. CompletionTime alone misses Failed jobs
 	// (which never set CompletionTime) and the FailureTarget signal.
+	jobCondSummary := map[batchv1.JobConditionType]string{
+		batchv1.JobComplete:       "completed",
+		batchv1.JobFailed:         "failed",
+		batchv1.JobFailureTarget:  "failure target",
+		batchv1.JobSuspended:      "suspended",
+	}
 	for _, condType := range []batchv1.JobConditionType{batchv1.JobComplete, batchv1.JobFailed, batchv1.JobSuspended, batchv1.JobFailureTarget} {
 		oldStatus := getJobConditionStatus(oldJob, condType)
 		newStatus := getJobConditionStatus(newJob, condType)
@@ -986,9 +1032,17 @@ func diffJob(oldObj, newObj any) ([]FieldChange, []string) {
 				OldValue: oldStatus,
 				NewValue: newStatus,
 			})
-			if newStatus == "True" {
-				summary = append(summary, strings.ToLower(string(condType)))
-			} else {
+			label := jobCondSummary[condType]
+			switch newStatus {
+			case "True":
+				summary = append(summary, label)
+			case "False":
+				if oldStatus == "True" {
+					summary = append(summary, "no longer "+label)
+				} else {
+					summary = append(summary, fmt.Sprintf("%s: %s→%s", condType, oldStatus, newStatus))
+				}
+			default:
 				summary = append(summary, fmt.Sprintf("%s: %s→%s", condType, oldStatus, newStatus))
 			}
 		}
@@ -1104,6 +1158,23 @@ func diffNode(oldObj, newObj any) ([]FieldChange, []string) {
 		summary = append(summary, "kernel upgraded")
 	}
 
+	// Allocatable capacity (cpu / memory / pods). Reduction during draining or
+	// kubelet --reserved tuning is operator-relevant; expansion during hot-add
+	// likewise. Capacity is the underlying physical; Allocatable is what the
+	// scheduler sees and what changes more often, so we diff that one.
+	for _, res := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory, corev1.ResourcePods} {
+		oldVal := oldNode.Status.Allocatable[res]
+		newVal := newNode.Status.Allocatable[res]
+		if oldVal.Cmp(newVal) != 0 {
+			changes = append(changes, FieldChange{
+				Path:     fmt.Sprintf("status.allocatable.%s", res),
+				OldValue: oldVal.String(),
+				NewValue: newVal.String(),
+			})
+			summary = append(summary, fmt.Sprintf("allocatable %s: %s→%s", res, oldVal.String(), newVal.String()))
+		}
+	}
+
 	return changes, summary
 }
 
@@ -1176,6 +1247,7 @@ func diffApplication(oldObj, newObj any) ([]FieldChange, []string) {
 	oldApp, ok1 := oldObj.(*unstructured.Unstructured)
 	newApp, ok2 := newObj.(*unstructured.Unstructured)
 	if !ok1 || !ok2 {
+		warnUnstructuredAssertFailed("Application", oldObj)
 		return nil, nil
 	}
 
@@ -1333,6 +1405,29 @@ func diffApplication(oldObj, newObj any) ([]FieldChange, []string) {
 		summary = append(summary, fmt.Sprintf("destination ns: %s→%s", oldDestNS, newDestNS))
 	}
 
+	// Image rolls — an already-Synced+Healthy app can roll new images via auto-sync
+	// without flipping sync.status or health.status. Without this, those updates
+	// drop as no-diff and the timeline misses the actual deploy event.
+	oldImages, _, _ := unstructured.NestedStringSlice(oldStatus, "summary", "images")
+	newImages, _, _ := unstructured.NestedStringSlice(newStatus, "summary", "images")
+	if !equalStringSlices(oldImages, newImages) {
+		added := diffStringSlices(newImages, oldImages)
+		removed := diffStringSlices(oldImages, newImages)
+		changes = append(changes, FieldChange{
+			Path:     "status.summary.images",
+			OldValue: oldImages,
+			NewValue: newImages,
+		})
+		switch {
+		case len(added) > 0 && len(removed) == 0:
+			summary = append(summary, fmt.Sprintf("images +%d", len(added)))
+		case len(removed) > 0 && len(added) == 0:
+			summary = append(summary, fmt.Sprintf("images -%d", len(removed)))
+		default:
+			summary = append(summary, "images changed")
+		}
+	}
+
 	return changes, summary
 }
 
@@ -1357,6 +1452,7 @@ func diffKustomization(oldObj, newObj any) ([]FieldChange, []string) {
 	oldKs, ok1 := oldObj.(*unstructured.Unstructured)
 	newKs, ok2 := newObj.(*unstructured.Unstructured)
 	if !ok1 || !ok2 {
+		warnUnstructuredAssertFailed("Kustomization", oldObj)
 		return nil, nil
 	}
 
@@ -1474,6 +1570,7 @@ func diffFluxHelmRelease(oldObj, newObj any) ([]FieldChange, []string) {
 	oldHR, ok1 := oldObj.(*unstructured.Unstructured)
 	newHR, ok2 := newObj.(*unstructured.Unstructured)
 	if !ok1 || !ok2 {
+		warnUnstructuredAssertFailed("HelmRelease", oldObj)
 		return nil, nil
 	}
 
@@ -1499,11 +1596,11 @@ func diffFluxHelmRelease(oldObj, newObj any) ([]FieldChange, []string) {
 	// Released / Stalled conditions — Released=False is the canonical Helm install
 	// failure signal; Stalled=True is the give-up state that Ready alone obscures.
 	for _, condType := range []string{"Released", "Stalled"} {
-		oldStatus := getFluxConditionStatus(oldStatus, condType)
-		newStatus := getFluxConditionStatus(newStatus, condType)
-		if oldStatus != newStatus && (oldStatus != "" || newStatus != "") {
-			changes = append(changes, FieldChange{Path: fmt.Sprintf("status.conditions[%s]", condType), OldValue: oldStatus, NewValue: newStatus})
-			summary = append(summary, fmt.Sprintf("%s: %s→%s", condType, oldStatus, newStatus))
+		oldCond := getFluxConditionStatus(oldStatus, condType)
+		newCond := getFluxConditionStatus(newStatus, condType)
+		if oldCond != newCond && (oldCond != "" || newCond != "") {
+			changes = append(changes, FieldChange{Path: fmt.Sprintf("status.conditions[%s]", condType), OldValue: oldCond, NewValue: newCond})
+			summary = append(summary, fmt.Sprintf("%s: %s→%s", condType, oldCond, newCond))
 		}
 	}
 
@@ -1592,6 +1689,7 @@ func diffFluxSource(oldObj, newObj any, kind string) ([]FieldChange, []string) {
 	oldSrc, ok1 := oldObj.(*unstructured.Unstructured)
 	newSrc, ok2 := newObj.(*unstructured.Unstructured)
 	if !ok1 || !ok2 {
+		warnUnstructuredAssertFailed(kind, oldObj)
 		return nil, nil
 	}
 
@@ -1617,11 +1715,11 @@ func diffFluxSource(oldObj, newObj any, kind string) ([]FieldChange, []string) {
 	// Stalled / FetchFailed — fetch errors flip these without flipping Ready
 	// the same way (Stalled implies give-up; FetchFailed is the upstream signal).
 	for _, condType := range []string{"Stalled", "FetchFailed"} {
-		oldStatus := getFluxConditionStatus(oldStatus, condType)
-		newStatus := getFluxConditionStatus(newStatus, condType)
-		if oldStatus != newStatus && (oldStatus != "" || newStatus != "") {
-			changes = append(changes, FieldChange{Path: fmt.Sprintf("status.conditions[%s]", condType), OldValue: oldStatus, NewValue: newStatus})
-			summary = append(summary, fmt.Sprintf("%s: %s→%s", condType, oldStatus, newStatus))
+		oldCond := getFluxConditionStatus(oldStatus, condType)
+		newCond := getFluxConditionStatus(newStatus, condType)
+		if oldCond != newCond && (oldCond != "" || newCond != "") {
+			changes = append(changes, FieldChange{Path: fmt.Sprintf("status.conditions[%s]", condType), OldValue: oldCond, NewValue: newCond})
+			summary = append(summary, fmt.Sprintf("%s: %s→%s", condType, oldCond, newCond))
 		}
 	}
 
@@ -1988,6 +2086,7 @@ func diffGateway(oldObj, newObj any) ([]FieldChange, []string) {
 	oldGW, ok1 := oldObj.(*unstructured.Unstructured)
 	newGW, ok2 := newObj.(*unstructured.Unstructured)
 	if !ok1 || !ok2 {
+		warnUnstructuredAssertFailed("Gateway", oldObj)
 		return nil, nil
 	}
 
@@ -2042,6 +2141,7 @@ func diffGatewayRoute(oldObj, newObj any) ([]FieldChange, []string) {
 	oldRoute, ok1 := oldObj.(*unstructured.Unstructured)
 	newRoute, ok2 := newObj.(*unstructured.Unstructured)
 	if !ok1 || !ok2 {
+		warnUnstructuredAssertFailed("GatewayRoute", oldObj)
 		return nil, nil
 	}
 
@@ -2088,8 +2188,20 @@ func diffGatewayRoute(oldObj, newObj any) ([]FieldChange, []string) {
 	}
 	oldByParent := indexParentConditions(oldParents)
 	newByParent := indexParentConditions(newParents)
-	for parentKey, newConds := range newByParent {
+
+	// Walk the union of parent keys so we catch parents that disappeared from
+	// the new snapshot too — a parent vanishing is a real signal even when
+	// total parent count is unchanged (one removed + one added).
+	parentKeys := make(map[string]struct{}, len(oldByParent)+len(newByParent))
+	for k := range oldByParent {
+		parentKeys[k] = struct{}{}
+	}
+	for k := range newByParent {
+		parentKeys[k] = struct{}{}
+	}
+	for parentKey := range parentKeys {
 		oldConds := oldByParent[parentKey]
+		newConds := newByParent[parentKey]
 		for _, condType := range []string{"Accepted", "ResolvedRefs", "Programmed"} {
 			oldStatus, oldHas := oldConds[condType]
 			newStatus, newHas := newConds[condType]
@@ -2111,9 +2223,12 @@ func diffGatewayRoute(oldObj, newObj any) ([]FieldChange, []string) {
 }
 
 // indexParentConditions extracts {parentKey -> {conditionType -> status}} from
-// a Gateway-API route's status.parents. parentKey is "<group>/<kind>/<ns>/<name>"
-// (group/ns may be empty), enough to disambiguate per-parent without parsing
-// every field.
+// a Gateway-API route's status.parents. The parent key is
+// "<group>/<kind>/<ns>/<name>/<sectionName>/<port>" — Gateway API permits a
+// route to attach to the same Gateway twice via different listeners
+// disambiguated by sectionName / port, so omitting them collapses distinct
+// per-listener conditions into one bucket and silently loses flips on the
+// second listener.
 func indexParentConditions(parents []any) map[string]map[string]string {
 	out := make(map[string]map[string]string, len(parents))
 	for _, p := range parents {
@@ -2125,7 +2240,9 @@ func indexParentConditions(parents []any) map[string]map[string]string {
 		kind, _, _ := unstructured.NestedString(pMap, "parentRef", "kind")
 		ns, _, _ := unstructured.NestedString(pMap, "parentRef", "namespace")
 		name, _, _ := unstructured.NestedString(pMap, "parentRef", "name")
-		key := fmt.Sprintf("%s/%s/%s/%s", group, kind, ns, name)
+		sectionName, _, _ := unstructured.NestedString(pMap, "parentRef", "sectionName")
+		port, _, _ := unstructured.NestedInt64(pMap, "parentRef", "port")
+		key := fmt.Sprintf("%s/%s/%s/%s/%s/%d", group, kind, ns, name, sectionName, port)
 		conds := make(map[string]string)
 		conditions, _, _ := unstructured.NestedSlice(pMap, "conditions")
 		for _, c := range conditions {

--- a/internal/k8s/history.go
+++ b/internal/k8s/history.go
@@ -86,6 +86,25 @@ func ComputeDiff(kind string, oldObj, newObj any) *DiffInfo {
 	}
 }
 
+// KindHasDiffer returns true for kinds where ComputeDiff has audited coverage —
+// i.e. an update producing a nil diff means there was no observable state
+// change. Callers use this to filter out the heartbeat / managedFields-only /
+// reconcile-counter updates that would otherwise become content-free timeline
+// rows. Adding a kind here is a contract: the diff function must cover every
+// status field a user would care about.
+func KindHasDiffer(kind string) bool {
+	switch kind {
+	case "Deployment", "Pod", "Service", "ConfigMap", "Ingress",
+		"ReplicaSet", "DaemonSet", "StatefulSet",
+		"HorizontalPodAutoscaler", "Job", "Node", "PersistentVolumeClaim",
+		"Application", "Kustomization", "HelmRelease",
+		"GitRepository", "OCIRepository", "HelmRepository",
+		"Gateway", "HTTPRoute", "GRPCRoute", "TCPRoute", "TLSRoute":
+		return true
+	}
+	return false
+}
+
 // diffDeployment computes diff for Deployment resources
 func diffDeployment(oldObj, newObj any) ([]FieldChange, []string) {
 	oldDep, ok1 := oldObj.(*appsv1.Deployment)
@@ -177,6 +196,21 @@ func diffDeployment(oldObj, newObj any) ([]FieldChange, []string) {
 		// Only add to summary if not already showing ready replicas change
 		if oldDep.Status.ReadyReplicas == newDep.Status.ReadyReplicas {
 			summary = append(summary, fmt.Sprintf("updated: %d→%d", oldDep.Status.UpdatedReplicas, newDep.Status.UpdatedReplicas))
+		}
+	}
+
+	// Available=False = rollout failed minAvailable check; Progressing=False =
+	// rollout stalled / deadline exceeded. Replica counts alone don't reveal these.
+	for _, condType := range []appsv1.DeploymentConditionType{appsv1.DeploymentAvailable, appsv1.DeploymentProgressing} {
+		oldStatus := getDeploymentConditionStatus(oldDep, condType)
+		newStatus := getDeploymentConditionStatus(newDep, condType)
+		if oldStatus != newStatus && (oldStatus != "" || newStatus != "") {
+			changes = append(changes, FieldChange{
+				Path:     fmt.Sprintf("status.conditions[%s]", condType),
+				OldValue: oldStatus,
+				NewValue: newStatus,
+			})
+			summary = append(summary, fmt.Sprintf("%s: %s→%s", condType, oldStatus, newStatus))
 		}
 	}
 
@@ -443,6 +477,32 @@ func diffConfigMap(oldObj, newObj any) ([]FieldChange, []string) {
 		summary = append(summary, fmt.Sprintf("modified keys: %v", modifiedKeys))
 	}
 
+	// binaryData (separate field for non-UTF-8 payloads). Same key-only semantic.
+	oldBinKeys := getBinaryMapKeys(oldCM.BinaryData)
+	newBinKeys := getBinaryMapKeys(newCM.BinaryData)
+	addedBin := diffStringSlices(newBinKeys, oldBinKeys)
+	removedBin := diffStringSlices(oldBinKeys, newBinKeys)
+	if len(addedBin) > 0 {
+		changes = append(changes, FieldChange{Path: "binaryData (added keys)", OldValue: nil, NewValue: addedBin})
+		summary = append(summary, fmt.Sprintf("added binaryData keys: %v", addedBin))
+	}
+	if len(removedBin) > 0 {
+		changes = append(changes, FieldChange{Path: "binaryData (removed keys)", OldValue: removedBin, NewValue: nil})
+		summary = append(summary, fmt.Sprintf("removed binaryData keys: %v", removedBin))
+	}
+
+	// Immutable flag flips are user-meaningful (locks the CM until recreated).
+	oldImmut := oldCM.Immutable != nil && *oldCM.Immutable
+	newImmut := newCM.Immutable != nil && *newCM.Immutable
+	if oldImmut != newImmut {
+		changes = append(changes, FieldChange{Path: "immutable", OldValue: oldImmut, NewValue: newImmut})
+		if newImmut {
+			summary = append(summary, "marked immutable")
+		} else {
+			summary = append(summary, "immutable cleared")
+		}
+	}
+
 	return changes, summary
 }
 
@@ -585,6 +645,29 @@ func diffReplicaSet(oldObj, newObj any) ([]FieldChange, []string) {
 		summary = append(summary, fmt.Sprintf("ready: %d→%d", oldRS.Status.ReadyReplicas, newRS.Status.ReadyReplicas))
 	}
 
+	if oldRS.Status.AvailableReplicas != newRS.Status.AvailableReplicas {
+		changes = append(changes, FieldChange{
+			Path:     "status.availableReplicas",
+			OldValue: oldRS.Status.AvailableReplicas,
+			NewValue: newRS.Status.AvailableReplicas,
+		})
+		if oldRS.Status.ReadyReplicas == newRS.Status.ReadyReplicas {
+			summary = append(summary, fmt.Sprintf("available: %d→%d", oldRS.Status.AvailableReplicas, newRS.Status.AvailableReplicas))
+		}
+	}
+
+	// ReplicaFailure=True surfaces pod-create failures (quota, image pull, scheduling).
+	oldRF := getReplicaSetConditionStatus(oldRS, appsv1.ReplicaSetReplicaFailure)
+	newRF := getReplicaSetConditionStatus(newRS, appsv1.ReplicaSetReplicaFailure)
+	if oldRF != newRF && (oldRF != "" || newRF != "") {
+		changes = append(changes, FieldChange{
+			Path:     "status.conditions[ReplicaFailure]",
+			OldValue: oldRF,
+			NewValue: newRF,
+		})
+		summary = append(summary, fmt.Sprintf("ReplicaFailure: %s→%s", oldRF, newRF))
+	}
+
 	return changes, summary
 }
 
@@ -654,6 +737,19 @@ func diffDaemonSet(oldObj, newObj any) ([]FieldChange, []string) {
 		})
 		if newDS.Status.NumberUnavailable > 0 {
 			summary = append(summary, fmt.Sprintf("unavailable: %d", newDS.Status.NumberUnavailable))
+		}
+	}
+
+	// NumberMisscheduled = pods running on nodes the selector now excludes
+	// (e.g. taint added). Real signal that a tolerations/selector change took effect.
+	if oldDS.Status.NumberMisscheduled != newDS.Status.NumberMisscheduled {
+		changes = append(changes, FieldChange{
+			Path:     "status.numberMisscheduled",
+			OldValue: oldDS.Status.NumberMisscheduled,
+			NewValue: newDS.Status.NumberMisscheduled,
+		})
+		if newDS.Status.NumberMisscheduled > 0 {
+			summary = append(summary, fmt.Sprintf("misscheduled: %d", newDS.Status.NumberMisscheduled))
 		}
 	}
 
@@ -737,6 +833,17 @@ func diffStatefulSet(oldObj, newObj any) ([]FieldChange, []string) {
 		summary = append(summary, "revision updated")
 	}
 
+	if oldSTS.Status.AvailableReplicas != newSTS.Status.AvailableReplicas {
+		changes = append(changes, FieldChange{
+			Path:     "status.availableReplicas",
+			OldValue: oldSTS.Status.AvailableReplicas,
+			NewValue: newSTS.Status.AvailableReplicas,
+		})
+		if oldSTS.Status.ReadyReplicas == newSTS.Status.ReadyReplicas {
+			summary = append(summary, fmt.Sprintf("available: %d→%d", oldSTS.Status.AvailableReplicas, newSTS.Status.AvailableReplicas))
+		}
+	}
+
 	return changes, summary
 }
 
@@ -806,6 +913,24 @@ func diffHPA(oldObj, newObj any) ([]FieldChange, []string) {
 		}
 	}
 
+	// Conditions: ScalingActive=False means HPA can't fetch metrics. AbleToScale=False
+	// means it's hit a cooldown / spec error. ScalingLimited=True means the policy
+	// capped the decision. All three are silent failures without this.
+	for _, condType := range []autoscalingv2.HorizontalPodAutoscalerConditionType{
+		autoscalingv2.ScalingActive, autoscalingv2.AbleToScale, autoscalingv2.ScalingLimited,
+	} {
+		oldStatus := getHPAConditionStatus(oldHPA, condType)
+		newStatus := getHPAConditionStatus(newHPA, condType)
+		if oldStatus != newStatus && (oldStatus != "" || newStatus != "") {
+			changes = append(changes, FieldChange{
+				Path:     fmt.Sprintf("status.conditions[%s]", condType),
+				OldValue: oldStatus,
+				NewValue: newStatus,
+			})
+			summary = append(summary, fmt.Sprintf("%s: %s→%s", condType, oldStatus, newStatus))
+		}
+	}
+
 	return changes, summary
 }
 
@@ -850,14 +975,33 @@ func diffJob(oldObj, newObj any) ([]FieldChange, []string) {
 		summary = append(summary, fmt.Sprintf("failed: %d→%d", oldJob.Status.Failed, newJob.Status.Failed))
 	}
 
-	// Check completion
-	if oldJob.Status.CompletionTime == nil && newJob.Status.CompletionTime != nil {
+	// Check terminal conditions. CompletionTime alone misses Failed jobs
+	// (which never set CompletionTime) and the FailureTarget signal.
+	for _, condType := range []batchv1.JobConditionType{batchv1.JobComplete, batchv1.JobFailed, batchv1.JobSuspended, batchv1.JobFailureTarget} {
+		oldStatus := getJobConditionStatus(oldJob, condType)
+		newStatus := getJobConditionStatus(newJob, condType)
+		if oldStatus != newStatus && (oldStatus != "" || newStatus != "") {
+			changes = append(changes, FieldChange{
+				Path:     fmt.Sprintf("status.conditions[%s]", condType),
+				OldValue: oldStatus,
+				NewValue: newStatus,
+			})
+			if newStatus == "True" {
+				summary = append(summary, strings.ToLower(string(condType)))
+			} else {
+				summary = append(summary, fmt.Sprintf("%s: %s→%s", condType, oldStatus, newStatus))
+			}
+		}
+	}
+
+	// First scheduling — startTime fills in when the controller picks up the job.
+	if oldJob.Status.StartTime == nil && newJob.Status.StartTime != nil {
 		changes = append(changes, FieldChange{
-			Path:     "status.completionTime",
+			Path:     "status.startTime",
 			OldValue: nil,
-			NewValue: newJob.Status.CompletionTime.Time,
+			NewValue: newJob.Status.StartTime.Time,
 		})
-		summary = append(summary, "completed")
+		summary = append(summary, "started")
 	}
 
 	// Check suspended
@@ -923,16 +1067,41 @@ func diffNode(oldObj, newObj any) ([]FieldChange, []string) {
 		}
 	}
 
-	// Check Ready condition
-	oldReady := getNodeConditionStatus(oldNode, corev1.NodeReady)
-	newReady := getNodeConditionStatus(newNode, corev1.NodeReady)
-	if oldReady != newReady {
+	// Check pressure + ready conditions. MemoryPressure / DiskPressure /
+	// PIDPressure flips signal imminent eviction or scheduling failures —
+	// just as actionable as Ready, and previously missed entirely.
+	for _, condType := range []corev1.NodeConditionType{
+		corev1.NodeReady, corev1.NodeMemoryPressure, corev1.NodeDiskPressure,
+		corev1.NodePIDPressure, corev1.NodeNetworkUnavailable,
+	} {
+		oldStatus := getNodeConditionStatus(oldNode, condType)
+		newStatus := getNodeConditionStatus(newNode, condType)
+		if oldStatus != newStatus {
+			changes = append(changes, FieldChange{
+				Path:     fmt.Sprintf("status.conditions[%s]", condType),
+				OldValue: oldStatus,
+				NewValue: newStatus,
+			})
+			summary = append(summary, fmt.Sprintf("%s: %s→%s", condType, oldStatus, newStatus))
+		}
+	}
+
+	// Kubelet / kernel upgrades — captured by version flips on Node.Status.NodeInfo.
+	if oldNode.Status.NodeInfo.KubeletVersion != newNode.Status.NodeInfo.KubeletVersion {
 		changes = append(changes, FieldChange{
-			Path:     "status.conditions[Ready]",
-			OldValue: oldReady,
-			NewValue: newReady,
+			Path:     "status.nodeInfo.kubeletVersion",
+			OldValue: oldNode.Status.NodeInfo.KubeletVersion,
+			NewValue: newNode.Status.NodeInfo.KubeletVersion,
 		})
-		summary = append(summary, fmt.Sprintf("Ready: %s→%s", oldReady, newReady))
+		summary = append(summary, fmt.Sprintf("kubelet: %s→%s", oldNode.Status.NodeInfo.KubeletVersion, newNode.Status.NodeInfo.KubeletVersion))
+	}
+	if oldNode.Status.NodeInfo.KernelVersion != newNode.Status.NodeInfo.KernelVersion {
+		changes = append(changes, FieldChange{
+			Path:     "status.nodeInfo.kernelVersion",
+			OldValue: oldNode.Status.NodeInfo.KernelVersion,
+			NewValue: newNode.Status.NodeInfo.KernelVersion,
+		})
+		summary = append(summary, "kernel upgraded")
 	}
 
 	return changes, summary
@@ -979,6 +1148,24 @@ func diffPVC(oldObj, newObj any) ([]FieldChange, []string) {
 			NewValue: newCap.String(),
 		})
 		summary = append(summary, fmt.Sprintf("capacity: %s→%s", oldCap.String(), newCap.String()))
+	}
+
+	// Resize lifecycle conditions — Resizing=True signals an in-flight expansion;
+	// FileSystemResizePending=True signals the volume needs a pod restart to grow.
+	for _, condType := range []corev1.PersistentVolumeClaimConditionType{
+		corev1.PersistentVolumeClaimResizing,
+		corev1.PersistentVolumeClaimFileSystemResizePending,
+	} {
+		oldStatus := getPVCConditionStatus(oldPVC, condType)
+		newStatus := getPVCConditionStatus(newPVC, condType)
+		if oldStatus != newStatus && (oldStatus != "" || newStatus != "") {
+			changes = append(changes, FieldChange{
+				Path:     fmt.Sprintf("status.conditions[%s]", condType),
+				OldValue: oldStatus,
+				NewValue: newStatus,
+			})
+			summary = append(summary, fmt.Sprintf("%s: %s→%s", condType, oldStatus, newStatus))
+		}
 	}
 
 	return changes, summary
@@ -1203,6 +1390,14 @@ func diffKustomization(oldObj, newObj any) ([]FieldChange, []string) {
 		}
 	}
 
+	// Stalled=True means Flux gave up retrying — terminal failure that Ready alone hides.
+	oldStalled := getFluxConditionStatus(oldStatus, "Stalled")
+	newStalled := getFluxConditionStatus(newStatus, "Stalled")
+	if oldStalled != newStalled && (oldStalled != "" || newStalled != "") {
+		changes = append(changes, FieldChange{Path: "status.conditions[Stalled]", OldValue: oldStalled, NewValue: newStalled})
+		summary = append(summary, fmt.Sprintf("stalled: %s→%s", oldStalled, newStalled))
+	}
+
 	// Check last applied revision
 	oldRevision, _, _ := unstructured.NestedString(oldStatus, "lastAppliedRevision")
 	newRevision, _, _ := unstructured.NestedString(newStatus, "lastAppliedRevision")
@@ -1299,6 +1494,17 @@ func diffFluxHelmRelease(oldObj, newObj any) ([]FieldChange, []string) {
 			NewValue: newReady,
 		})
 		summary = append(summary, fmt.Sprintf("ready: %s→%s", oldReady, newReady))
+	}
+
+	// Released / Stalled conditions — Released=False is the canonical Helm install
+	// failure signal; Stalled=True is the give-up state that Ready alone obscures.
+	for _, condType := range []string{"Released", "Stalled"} {
+		oldStatus := getFluxConditionStatus(oldStatus, condType)
+		newStatus := getFluxConditionStatus(newStatus, condType)
+		if oldStatus != newStatus && (oldStatus != "" || newStatus != "") {
+			changes = append(changes, FieldChange{Path: fmt.Sprintf("status.conditions[%s]", condType), OldValue: oldStatus, NewValue: newStatus})
+			summary = append(summary, fmt.Sprintf("%s: %s→%s", condType, oldStatus, newStatus))
+		}
 	}
 
 	// Check last applied revision (Helm chart version)
@@ -1406,6 +1612,17 @@ func diffFluxSource(oldObj, newObj any, kind string) ([]FieldChange, []string) {
 			NewValue: newReady,
 		})
 		summary = append(summary, fmt.Sprintf("ready: %s→%s", oldReady, newReady))
+	}
+
+	// Stalled / FetchFailed — fetch errors flip these without flipping Ready
+	// the same way (Stalled implies give-up; FetchFailed is the upstream signal).
+	for _, condType := range []string{"Stalled", "FetchFailed"} {
+		oldStatus := getFluxConditionStatus(oldStatus, condType)
+		newStatus := getFluxConditionStatus(newStatus, condType)
+		if oldStatus != newStatus && (oldStatus != "" || newStatus != "") {
+			changes = append(changes, FieldChange{Path: fmt.Sprintf("status.conditions[%s]", condType), OldValue: oldStatus, NewValue: newStatus})
+			summary = append(summary, fmt.Sprintf("%s: %s→%s", condType, oldStatus, newStatus))
+		}
 	}
 
 	// Check artifact revision (commit SHA or chart version)
@@ -1548,6 +1765,55 @@ func getNodeConditionStatus(node *corev1.Node, condType corev1.NodeConditionType
 	return "Unknown"
 }
 
+// Per-kind condition lookups. Each Conditions field on the typed K8s structs
+// has a different element type, so we can't share one generic helper without
+// reflection — and the per-kind helpers stay short.
+
+func getDeploymentConditionStatus(d *appsv1.Deployment, condType appsv1.DeploymentConditionType) string {
+	for _, c := range d.Status.Conditions {
+		if c.Type == condType {
+			return string(c.Status)
+		}
+	}
+	return ""
+}
+
+func getReplicaSetConditionStatus(rs *appsv1.ReplicaSet, condType appsv1.ReplicaSetConditionType) string {
+	for _, c := range rs.Status.Conditions {
+		if c.Type == condType {
+			return string(c.Status)
+		}
+	}
+	return ""
+}
+
+func getJobConditionStatus(j *batchv1.Job, condType batchv1.JobConditionType) string {
+	for _, c := range j.Status.Conditions {
+		if c.Type == condType {
+			return string(c.Status)
+		}
+	}
+	return ""
+}
+
+func getHPAConditionStatus(h *autoscalingv2.HorizontalPodAutoscaler, condType autoscalingv2.HorizontalPodAutoscalerConditionType) string {
+	for _, c := range h.Status.Conditions {
+		if c.Type == condType {
+			return string(c.Status)
+		}
+	}
+	return ""
+}
+
+func getPVCConditionStatus(pvc *corev1.PersistentVolumeClaim, condType corev1.PersistentVolumeClaimConditionType) string {
+	for _, c := range pvc.Status.Conditions {
+		if c.Type == condType {
+			return string(c.Status)
+		}
+	}
+	return ""
+}
+
 // Helper functions
 
 func getContainerImages(containers []corev1.Container) map[string]string {
@@ -1586,6 +1852,14 @@ func getServicePorts(ports []corev1.ServicePort) []string {
 }
 
 func getMapKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func getBinaryMapKeys(m map[string][]byte) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -1798,21 +2072,76 @@ func diffGatewayRoute(oldObj, newObj any) ([]FieldChange, []string) {
 		summary = append(summary, fmt.Sprintf("rules: %d→%d", len(oldRules), len(newRules)))
 	}
 
-	// Check parent acceptance status
+	// Per-parent per-condition diff. Counting "accepted parents" misses
+	// flips on Programmed / ResolvedRefs (which are how a route signals
+	// "config invalid" or "backend missing") — those leave Accepted=True
+	// while the route is functionally broken.
 	oldParents, _, _ := unstructured.NestedSlice(oldRoute.Object, "status", "parents")
 	newParents, _, _ := unstructured.NestedSlice(newRoute.Object, "status", "parents")
-	oldAccepted := countAcceptedParents(oldParents)
-	newAccepted := countAcceptedParents(newParents)
-	if oldAccepted != newAccepted || len(oldParents) != len(newParents) {
+	if len(oldParents) != len(newParents) {
 		changes = append(changes, FieldChange{
 			Path:     "status.parents",
-			OldValue: fmt.Sprintf("%d/%d accepted", oldAccepted, len(oldParents)),
-			NewValue: fmt.Sprintf("%d/%d accepted", newAccepted, len(newParents)),
+			OldValue: fmt.Sprintf("%d parents", len(oldParents)),
+			NewValue: fmt.Sprintf("%d parents", len(newParents)),
 		})
-		summary = append(summary, fmt.Sprintf("accepted: %d/%d→%d/%d", oldAccepted, len(oldParents), newAccepted, len(newParents)))
+		summary = append(summary, fmt.Sprintf("parents: %d→%d", len(oldParents), len(newParents)))
+	}
+	oldByParent := indexParentConditions(oldParents)
+	newByParent := indexParentConditions(newParents)
+	for parentKey, newConds := range newByParent {
+		oldConds := oldByParent[parentKey]
+		for _, condType := range []string{"Accepted", "ResolvedRefs", "Programmed"} {
+			oldStatus, oldHas := oldConds[condType]
+			newStatus, newHas := newConds[condType]
+			if !oldHas && !newHas {
+				continue
+			}
+			if oldStatus != newStatus {
+				changes = append(changes, FieldChange{
+					Path:     fmt.Sprintf("status.parents[%s].conditions[%s]", parentKey, condType),
+					OldValue: oldStatus,
+					NewValue: newStatus,
+				})
+				summary = append(summary, fmt.Sprintf("%s/%s: %s→%s", parentKey, condType, oldStatus, newStatus))
+			}
+		}
 	}
 
 	return changes, summary
+}
+
+// indexParentConditions extracts {parentKey -> {conditionType -> status}} from
+// a Gateway-API route's status.parents. parentKey is "<group>/<kind>/<ns>/<name>"
+// (group/ns may be empty), enough to disambiguate per-parent without parsing
+// every field.
+func indexParentConditions(parents []any) map[string]map[string]string {
+	out := make(map[string]map[string]string, len(parents))
+	for _, p := range parents {
+		pMap, ok := p.(map[string]any)
+		if !ok {
+			continue
+		}
+		group, _, _ := unstructured.NestedString(pMap, "parentRef", "group")
+		kind, _, _ := unstructured.NestedString(pMap, "parentRef", "kind")
+		ns, _, _ := unstructured.NestedString(pMap, "parentRef", "namespace")
+		name, _, _ := unstructured.NestedString(pMap, "parentRef", "name")
+		key := fmt.Sprintf("%s/%s/%s/%s", group, kind, ns, name)
+		conds := make(map[string]string)
+		conditions, _, _ := unstructured.NestedSlice(pMap, "conditions")
+		for _, c := range conditions {
+			cMap, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+			t, _ := cMap["type"].(string)
+			s, _ := cMap["status"].(string)
+			if t != "" {
+				conds[t] = s
+			}
+		}
+		out[key] = conds
+	}
+	return out
 }
 
 // getConditionMap extracts a map of condition type -> status from nested conditions
@@ -1833,25 +2162,3 @@ func getConditionMap(obj map[string]any, path ...string) map[string]string {
 	return result
 }
 
-// countAcceptedParents counts how many parent refs have Accepted=True condition
-func countAcceptedParents(parents []any) int {
-	count := 0
-	for _, p := range parents {
-		pMap, ok := p.(map[string]any)
-		if !ok {
-			continue
-		}
-		conditions, _, _ := unstructured.NestedSlice(pMap, "conditions")
-		for _, c := range conditions {
-			cMap, ok := c.(map[string]any)
-			if !ok {
-				continue
-			}
-			if cMap["type"] == "Accepted" && cMap["status"] == "True" {
-				count++
-				break
-			}
-		}
-	}
-	return count
-}

--- a/internal/k8s/history.go
+++ b/internal/k8s/history.go
@@ -51,10 +51,12 @@ var diffFunctions = map[string]kindDiffFunc{
 	"OCIRepository":           func(o, n any) ([]FieldChange, []string) { return diffFluxSource(o, n, "OCIRepository") },
 	"HelmRepository":          func(o, n any) ([]FieldChange, []string) { return diffFluxSource(o, n, "HelmRepository") },
 	"Gateway":                 diffGateway,
+	"GatewayClass":            diffGatewayClass,
 	"HTTPRoute":               diffGatewayRoute,
 	"GRPCRoute":               diffGatewayRoute,
 	"TCPRoute":                diffGatewayRoute,
 	"TLSRoute":                diffGatewayRoute,
+	"ReferenceGrant":          diffReferenceGrant,
 }
 
 // ComputeDiff computes the diff between old and new objects based on kind.
@@ -1405,6 +1407,33 @@ func diffApplication(oldObj, newObj any) ([]FieldChange, []string) {
 		summary = append(summary, fmt.Sprintf("destination ns: %s→%s", oldDestNS, newDestNS))
 	}
 
+	// status.conditions — Argo surfaces non-standard signals here:
+	// SyncError, ComparisonError, OrphanedResourceWarning, ExcludedResourceWarning,
+	// SharedResourceWarning, RepeatedResourceWarning. These flip on operator
+	// config issues that don't show in sync.status / health.status.
+	oldAppConds := getConditionMap(oldStatus, "conditions")
+	newAppConds := getConditionMap(newStatus, "conditions")
+	for condType, newCond := range newAppConds {
+		if oldAppConds[condType] != newCond {
+			changes = append(changes, FieldChange{
+				Path:     fmt.Sprintf("status.conditions[%s]", condType),
+				OldValue: oldAppConds[condType],
+				NewValue: newCond,
+			})
+			summary = append(summary, fmt.Sprintf("%s: %s→%s", condType, oldAppConds[condType], newCond))
+		}
+	}
+	for condType, oldCond := range oldAppConds {
+		if _, present := newAppConds[condType]; !present {
+			changes = append(changes, FieldChange{
+				Path:     fmt.Sprintf("status.conditions[%s]", condType),
+				OldValue: oldCond,
+				NewValue: nil,
+			})
+			summary = append(summary, fmt.Sprintf("%s cleared", condType))
+		}
+	}
+
 	// Image rolls — an already-Synced+Healthy app can roll new images via auto-sync
 	// without flipping sync.status or health.status. Without this, those updates
 	// drop as no-diff and the timeline misses the actual deploy event.
@@ -2217,6 +2246,75 @@ func diffGatewayRoute(oldObj, newObj any) ([]FieldChange, []string) {
 				summary = append(summary, fmt.Sprintf("%s/%s: %s→%s", parentKey, condType, oldStatus, newStatus))
 			}
 		}
+	}
+
+	return changes, summary
+}
+
+// diffGatewayClass computes diff for Gateway-API GatewayClass resources.
+// GatewayClass is a cluster-scoped declaration that controllers reconcile;
+// status updates fire on every reconcile and are noise except when the
+// Accepted/SupportedVersion conditions flip or the controller name changes.
+func diffGatewayClass(oldObj, newObj any) ([]FieldChange, []string) {
+	oldGC, ok1 := oldObj.(*unstructured.Unstructured)
+	newGC, ok2 := newObj.(*unstructured.Unstructured)
+	if !ok1 || !ok2 {
+		warnUnstructuredAssertFailed("GatewayClass", oldObj)
+		return nil, nil
+	}
+
+	var changes []FieldChange
+	var summary []string
+
+	// Controller name change (rebinding to a different implementation).
+	oldCtrl, _, _ := unstructured.NestedString(oldGC.Object, "spec", "controllerName")
+	newCtrl, _, _ := unstructured.NestedString(newGC.Object, "spec", "controllerName")
+	if oldCtrl != newCtrl && (oldCtrl != "" || newCtrl != "") {
+		changes = append(changes, FieldChange{Path: "spec.controllerName", OldValue: oldCtrl, NewValue: newCtrl})
+		summary = append(summary, fmt.Sprintf("controller: %s→%s", oldCtrl, newCtrl))
+	}
+
+	// Accepted / SupportedVersion conditions.
+	oldConditions := getConditionMap(oldGC.Object, "status", "conditions")
+	newConditions := getConditionMap(newGC.Object, "status", "conditions")
+	for _, condType := range []string{"Accepted", "SupportedVersion"} {
+		oldStatus := oldConditions[condType]
+		newStatus := newConditions[condType]
+		if oldStatus != newStatus && (oldStatus != "" || newStatus != "") {
+			changes = append(changes, FieldChange{Path: fmt.Sprintf("status.conditions.%s", condType), OldValue: oldStatus, NewValue: newStatus})
+			summary = append(summary, fmt.Sprintf("%s: %s→%s", condType, oldStatus, newStatus))
+		}
+	}
+
+	return changes, summary
+}
+
+// diffReferenceGrant computes diff for Gateway-API ReferenceGrant resources.
+// ReferenceGrant is cross-namespace permission. The interesting state lives
+// entirely in spec.from / spec.to — everything else is reconcile noise.
+func diffReferenceGrant(oldObj, newObj any) ([]FieldChange, []string) {
+	oldRG, ok1 := oldObj.(*unstructured.Unstructured)
+	newRG, ok2 := newObj.(*unstructured.Unstructured)
+	if !ok1 || !ok2 {
+		warnUnstructuredAssertFailed("ReferenceGrant", oldObj)
+		return nil, nil
+	}
+
+	var changes []FieldChange
+	var summary []string
+
+	oldFrom, _, _ := unstructured.NestedSlice(oldRG.Object, "spec", "from")
+	newFrom, _, _ := unstructured.NestedSlice(newRG.Object, "spec", "from")
+	if len(oldFrom) != len(newFrom) {
+		changes = append(changes, FieldChange{Path: "spec.from", OldValue: len(oldFrom), NewValue: len(newFrom)})
+		summary = append(summary, fmt.Sprintf("from: %d→%d", len(oldFrom), len(newFrom)))
+	}
+
+	oldTo, _, _ := unstructured.NestedSlice(oldRG.Object, "spec", "to")
+	newTo, _, _ := unstructured.NestedSlice(newRG.Object, "spec", "to")
+	if len(oldTo) != len(newTo) {
+		changes = append(changes, FieldChange{Path: "spec.to", OldValue: len(oldTo), NewValue: len(newTo)})
+		summary = append(summary, fmt.Sprintf("to: %d→%d", len(oldTo), len(newTo)))
 	}
 
 	return changes, summary

--- a/internal/k8s/noisy_filter_audit_test.go
+++ b/internal/k8s/noisy_filter_audit_test.go
@@ -383,6 +383,54 @@ func resourceQty(s string) resource.Quantity {
 	return resource.MustParse(s)
 }
 
+func TestComputeDiff_GatewayClassAcceptedFlip_Detected(t *testing.T) {
+	mk := func(accepted string) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"spec":   map[string]any{"controllerName": "example.com/gateway-controller"},
+			"status": map[string]any{"conditions": []any{map[string]any{"type": "Accepted", "status": accepted}}},
+		}}
+	}
+	diff := ComputeDiff("GatewayClass", mk("True"), mk("False"))
+	if diff == nil || !containsPath(diff, "status.conditions.Accepted") {
+		t.Fatalf("expected GatewayClass Accepted flip detected, got %+v", diff)
+	}
+}
+
+func TestComputeDiff_ReferenceGrantSpecChange_Detected(t *testing.T) {
+	mk := func(toCount int) *unstructured.Unstructured {
+		toItems := make([]any, toCount)
+		for i := range toItems {
+			toItems[i] = map[string]any{"group": "", "kind": "Service"}
+		}
+		return &unstructured.Unstructured{Object: map[string]any{
+			"spec": map[string]any{"from": []any{}, "to": toItems},
+		}}
+	}
+	diff := ComputeDiff("ReferenceGrant", mk(1), mk(2))
+	if diff == nil || !containsPath(diff, "spec.to") {
+		t.Fatalf("expected ReferenceGrant spec.to change detected, got %+v", diff)
+	}
+}
+
+func TestComputeDiff_ApplicationConditionAdded_Detected(t *testing.T) {
+	mk := func(conds []any) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"status": map[string]any{
+				"sync":       map[string]any{"status": "Synced"},
+				"health":     map[string]any{"status": "Healthy"},
+				"conditions": conds,
+			},
+		}}
+	}
+	diff := ComputeDiff("Application",
+		mk([]any{}),
+		mk([]any{map[string]any{"type": "OrphanedResourceWarning", "status": "True"}}),
+	)
+	if diff == nil || !containsPath(diff, "status.conditions[OrphanedResourceWarning]") {
+		t.Fatalf("expected Application condition addition detected, got %+v", diff)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------

--- a/internal/k8s/noisy_filter_audit_test.go
+++ b/internal/k8s/noisy_filter_audit_test.go
@@ -1,0 +1,257 @@
+package k8s
+
+// Audit tests for ComputeDiff. Two goals:
+//   1. Pin that pure-noise updates (heartbeats, managedFields) still produce
+//      nil diffs — those are what KindHasDiffer + the no-diff drop filter out.
+//   2. Pin that real signal we previously missed (Node pressure flips,
+//      HTTPRoute Programmed flips, Job Failed condition, HPA ScalingActive
+//      flip) now produces a non-nil diff. If a future refactor removes
+//      coverage, the test catches it before the no-diff drop silently hides
+//      the regression.
+
+import (
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestComputeDiff_PodHeartbeatOnly_ReturnsNil(t *testing.T) {
+	t0 := time.Now()
+	t1 := t0.Add(10 * time.Second)
+
+	base := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "p", ResourceVersion: "1"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastProbeTime: metav1.NewTime(t0), LastTransitionTime: metav1.NewTime(t0)},
+				{Type: corev1.ContainersReady, Status: corev1.ConditionTrue, LastProbeTime: metav1.NewTime(t0), LastTransitionTime: metav1.NewTime(t0)},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app", Ready: true, RestartCount: 0, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(t0)}}},
+			},
+		},
+	}
+
+	updated := base.DeepCopy()
+	updated.ResourceVersion = "2"
+	for i := range updated.Status.Conditions {
+		updated.Status.Conditions[i].LastProbeTime = metav1.NewTime(t1)
+	}
+
+	diff := ComputeDiff("Pod", base, updated)
+	if diff != nil {
+		t.Fatalf("expected nil diff for heartbeat-only update, got %+v", diff)
+	}
+}
+
+func TestComputeDiff_NodeHeartbeatOnly_ReturnsNil(t *testing.T) {
+	t0 := time.Now()
+	t1 := t0.Add(10 * time.Second)
+
+	base := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n", ResourceVersion: "1"},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue, LastHeartbeatTime: metav1.NewTime(t0), LastTransitionTime: metav1.NewTime(t0)},
+				{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionFalse, LastHeartbeatTime: metav1.NewTime(t0), LastTransitionTime: metav1.NewTime(t0)},
+			},
+		},
+	}
+
+	updated := base.DeepCopy()
+	updated.ResourceVersion = "2"
+	for i := range updated.Status.Conditions {
+		updated.Status.Conditions[i].LastHeartbeatTime = metav1.NewTime(t1)
+	}
+
+	diff := ComputeDiff("Node", base, updated)
+	if diff != nil {
+		t.Fatalf("expected nil diff for heartbeat-only Node update, got %+v", diff)
+	}
+}
+
+func TestComputeDiff_ServiceManagedFieldsOnly_ReturnsNil(t *testing.T) {
+	base := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "svc", ResourceVersion: "1"},
+		Spec:       corev1.ServiceSpec{ClusterIP: "10.0.0.1", Ports: []corev1.ServicePort{{Port: 80}}},
+	}
+	updated := base.DeepCopy()
+	updated.ResourceVersion = "2"
+	updated.ManagedFields = []metav1.ManagedFieldsEntry{{Manager: "kube-controller-manager", Operation: "Update"}}
+
+	diff := ComputeDiff("Service", base, updated)
+	if diff != nil {
+		t.Fatalf("expected nil diff for managedFields-only Service update, got %+v", diff)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Positive coverage: signal that previously slipped through must now be caught.
+// ---------------------------------------------------------------------------
+
+func TestComputeDiff_NodeMemoryPressureFlip_Detected(t *testing.T) {
+	t0 := time.Now()
+	base := &corev1.Node{
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue, LastHeartbeatTime: metav1.NewTime(t0)},
+				{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionFalse, LastHeartbeatTime: metav1.NewTime(t0)},
+			},
+		},
+	}
+	updated := base.DeepCopy()
+	updated.Status.Conditions[1].Status = corev1.ConditionTrue
+	updated.Status.Conditions[1].LastHeartbeatTime = metav1.NewTime(t0.Add(time.Second))
+
+	diff := ComputeDiff("Node", base, updated)
+	if diff == nil {
+		t.Fatal("expected non-nil diff when MemoryPressure flips True — previously missed")
+	}
+	if !containsPath(diff, "status.conditions[MemoryPressure]") {
+		t.Errorf("expected MemoryPressure path in diff, got %+v", diff.Fields)
+	}
+}
+
+func TestComputeDiff_NodeKubeletUpgrade_Detected(t *testing.T) {
+	base := &corev1.Node{Status: corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{KubeletVersion: "v1.30.0"}}}
+	updated := base.DeepCopy()
+	updated.Status.NodeInfo.KubeletVersion = "v1.30.5"
+
+	diff := ComputeDiff("Node", base, updated)
+	if diff == nil || !containsPath(diff, "status.nodeInfo.kubeletVersion") {
+		t.Fatalf("expected kubelet upgrade to be detected, got %+v", diff)
+	}
+}
+
+func TestComputeDiff_HPAScalingActiveFlip_Detected(t *testing.T) {
+	base := &autoscalingv2.HorizontalPodAutoscaler{
+		Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+			Conditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+				{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	updated := base.DeepCopy()
+	updated.Status.Conditions[0].Status = corev1.ConditionFalse
+
+	diff := ComputeDiff("HorizontalPodAutoscaler", base, updated)
+	if diff == nil || !containsPath(diff, "status.conditions[ScalingActive]") {
+		t.Fatalf("expected ScalingActive flip to be detected, got %+v", diff)
+	}
+}
+
+func TestComputeDiff_JobFailedCondition_Detected(t *testing.T) {
+	base := &batchv1.Job{}
+	updated := base.DeepCopy()
+	updated.Status.Conditions = []batchv1.JobCondition{
+		{Type: batchv1.JobFailed, Status: corev1.ConditionTrue, Reason: "BackoffLimitExceeded"},
+	}
+	diff := ComputeDiff("Job", base, updated)
+	if diff == nil || !containsPath(diff, "status.conditions[Failed]") {
+		t.Fatalf("expected JobFailed condition to be detected, got %+v", diff)
+	}
+}
+
+func TestComputeDiff_DeploymentAvailableFlip_Detected(t *testing.T) {
+	base := &appsv1.Deployment{
+		Status: appsv1.DeploymentStatus{
+			Conditions: []appsv1.DeploymentCondition{
+				{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	updated := base.DeepCopy()
+	updated.Status.Conditions[0].Status = corev1.ConditionFalse
+
+	diff := ComputeDiff("Deployment", base, updated)
+	if diff == nil || !containsPath(diff, "status.conditions[Available]") {
+		t.Fatalf("expected Available flip to be detected, got %+v", diff)
+	}
+}
+
+func TestComputeDiff_HTTPRouteProgrammedFlip_PerParent(t *testing.T) {
+	// One parent, one route — Accepted stays True, Programmed flips False.
+	// The previous count-based logic (count of Accepted parents) would not have
+	// noticed; the per-parent per-condition logic must.
+	parent := func(programmed string) map[string]any {
+		return map[string]any{
+			"parentRef": map[string]any{"group": "gateway.networking.k8s.io", "kind": "Gateway", "namespace": "infra", "name": "g"},
+			"conditions": []any{
+				map[string]any{"type": "Accepted", "status": "True"},
+				map[string]any{"type": "Programmed", "status": programmed},
+			},
+		}
+	}
+	old := &unstructured.Unstructured{Object: map[string]any{
+		"status": map[string]any{"parents": []any{parent("True")}},
+	}}
+	upd := &unstructured.Unstructured{Object: map[string]any{
+		"status": map[string]any{"parents": []any{parent("False")}},
+	}}
+	diff := ComputeDiff("HTTPRoute", old, upd)
+	if diff == nil {
+		t.Fatal("expected non-nil diff when Programmed flips on a parent")
+	}
+	if !containsPathSubstring(diff, "Programmed") {
+		t.Errorf("expected per-parent Programmed in diff, got %+v", diff.Fields)
+	}
+}
+
+func TestKindHasDiffer_ContractMatchesComputeDiff(t *testing.T) {
+	// Drift guard: if a kind is in KindHasDiffer but ComputeDiff doesn't recognize
+	// it, the no-diff drop fires for a kind that always returns nil — silently
+	// dropping every update. Verify each KindHasDiffer kind actually reaches a
+	// non-default case in ComputeDiff (proxy: a no-op old/new of the right type
+	// returns nil only when ComputeDiff dispatched).
+	kinds := []string{
+		"Deployment", "Pod", "Service", "ConfigMap", "Ingress",
+		"ReplicaSet", "DaemonSet", "StatefulSet",
+		"HorizontalPodAutoscaler", "Job", "Node", "PersistentVolumeClaim",
+		"Application", "Kustomization", "HelmRelease",
+		"GitRepository", "OCIRepository", "HelmRepository",
+		"Gateway", "HTTPRoute", "GRPCRoute", "TCPRoute", "TLSRoute",
+	}
+	for _, k := range kinds {
+		if !KindHasDiffer(k) {
+			t.Errorf("%s: KindHasDiffer should return true for kinds in ComputeDiff", k)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func containsPath(d *DiffInfo, path string) bool {
+	for _, f := range d.Fields {
+		if f.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+func containsPathSubstring(d *DiffInfo, substr string) bool {
+	for _, f := range d.Fields {
+		if len(f.Path) > 0 && stringContains(f.Path, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func stringContains(s, substr string) bool {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/k8s/noisy_filter_audit_test.go
+++ b/internal/k8s/noisy_filter_audit_test.go
@@ -412,6 +412,56 @@ func TestComputeDiff_ReferenceGrantSpecChange_Detected(t *testing.T) {
 	}
 }
 
+// TestRecordToTimelineStore_GenerationFallback verifies that a spec change a
+// diff function happens to miss (e.g. env-var edit on a Deployment) does not
+// silently drop. We rely on metadata.generation as the universal "spec
+// changed" signal — without this, diff coverage gaps become silent drops.
+func TestRecordToTimelineStore_GenerationFallback(t *testing.T) {
+	// Bypass the global timeline store wiring — we just want to confirm that
+	// the diff/drop logic produces the right outcome. Easiest path is to
+	// invoke ComputeDiff + getGeneration directly, mirroring the cache.go
+	// branch shape.
+	old := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Generation: 5},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "app", Image: "app:v1",
+						Env: []corev1.EnvVar{{Name: "FOO", Value: "1"}},
+					}},
+				},
+			},
+		},
+	}
+	updated := old.DeepCopy()
+	updated.Generation = 6
+	updated.Spec.Template.Spec.Containers[0].Env[0].Value = "2" // env change — diffDeployment doesn't track this
+
+	// Pre-condition: the existing diff function would return nil for this
+	// (the env change isn't in its tracked-fields list).
+	if diff := ComputeDiff("Deployment", old, updated); diff != nil {
+		t.Fatalf("test premise wrong: diffDeployment should not catch env-var changes; got %+v", diff)
+	}
+
+	// The fallback: generation differs, so callers should treat this as a
+	// real spec change and record it. Verify getGeneration reports the flip.
+	if got := getGeneration(old); got != 5 {
+		t.Errorf("getGeneration(old) = %d, want 5", got)
+	}
+	if got := getGeneration(updated); got != 6 {
+		t.Errorf("getGeneration(updated) = %d, want 6", got)
+	}
+
+	// And for an unstructured object (CRD path) the same helper works.
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"generation": int64(42)},
+	}}
+	if got := getGeneration(u); got != 42 {
+		t.Errorf("getGeneration(unstructured) = %d, want 42", got)
+	}
+}
+
 func TestComputeDiff_ApplicationConditionAdded_Detected(t *testing.T) {
 	mk := func(conds []any) *unstructured.Unstructured {
 		return &unstructured.Unstructured{Object: map[string]any{

--- a/internal/k8s/noisy_filter_audit_test.go
+++ b/internal/k8s/noisy_filter_audit_test.go
@@ -17,6 +17,7 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -204,25 +205,182 @@ func TestComputeDiff_HTTPRouteProgrammedFlip_PerParent(t *testing.T) {
 	}
 }
 
-func TestKindHasDiffer_ContractMatchesComputeDiff(t *testing.T) {
-	// Drift guard: if a kind is in KindHasDiffer but ComputeDiff doesn't recognize
-	// it, the no-diff drop fires for a kind that always returns nil — silently
-	// dropping every update. Verify each KindHasDiffer kind actually reaches a
-	// non-default case in ComputeDiff (proxy: a no-op old/new of the right type
-	// returns nil only when ComputeDiff dispatched).
-	kinds := []string{
-		"Deployment", "Pod", "Service", "ConfigMap", "Ingress",
-		"ReplicaSet", "DaemonSet", "StatefulSet",
-		"HorizontalPodAutoscaler", "Job", "Node", "PersistentVolumeClaim",
-		"Application", "Kustomization", "HelmRelease",
-		"GitRepository", "OCIRepository", "HelmRepository",
-		"Gateway", "HTTPRoute", "GRPCRoute", "TCPRoute", "TLSRoute",
+// Note: contract drift between KindHasDiffer and ComputeDiff dispatch is
+// structurally impossible — both read the same diffFunctions map. No test
+// needed for that anymore.
+
+func TestComputeDiff_ReplicaSetReplicaFailure_Detected(t *testing.T) {
+	base := &appsv1.ReplicaSet{
+		Status: appsv1.ReplicaSetStatus{
+			Conditions: []appsv1.ReplicaSetCondition{
+				{Type: appsv1.ReplicaSetReplicaFailure, Status: corev1.ConditionFalse},
+			},
+		},
 	}
-	for _, k := range kinds {
-		if !KindHasDiffer(k) {
-			t.Errorf("%s: KindHasDiffer should return true for kinds in ComputeDiff", k)
+	updated := base.DeepCopy()
+	updated.Status.Conditions[0].Status = corev1.ConditionTrue
+
+	diff := ComputeDiff("ReplicaSet", base, updated)
+	if diff == nil || !containsPath(diff, "status.conditions[ReplicaFailure]") {
+		t.Fatalf("expected ReplicaFailure flip detected, got %+v", diff)
+	}
+}
+
+func TestComputeDiff_DaemonSetMisscheduled_Detected(t *testing.T) {
+	base := &appsv1.DaemonSet{Status: appsv1.DaemonSetStatus{NumberMisscheduled: 0}}
+	updated := base.DeepCopy()
+	updated.Status.NumberMisscheduled = 3
+	diff := ComputeDiff("DaemonSet", base, updated)
+	if diff == nil || !containsPath(diff, "status.numberMisscheduled") {
+		t.Fatalf("expected NumberMisscheduled change detected, got %+v", diff)
+	}
+}
+
+func TestComputeDiff_FluxKustomizationStalled_Detected(t *testing.T) {
+	mk := func(stalledStatus string) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{"type": "Stalled", "status": stalledStatus},
+				},
+			},
+		}}
+	}
+	diff := ComputeDiff("Kustomization", mk("False"), mk("True"))
+	if diff == nil || !containsPath(diff, "status.conditions[Stalled]") {
+		t.Fatalf("expected Kustomization Stalled flip detected, got %+v", diff)
+	}
+}
+
+func TestComputeDiff_HTTPRouteMultiParent_PerListener(t *testing.T) {
+	// Two parents on the same Gateway via different sectionNames. Parent A
+	// stays Accepted=True; parent B flips Programmed False→True. Without
+	// per-listener keying, the second parent overwrites the first in the
+	// per-parent map and the Programmed flip is invisible.
+	parent := func(section, programmed string) map[string]any {
+		return map[string]any{
+			"parentRef": map[string]any{
+				"group": "gateway.networking.k8s.io", "kind": "Gateway",
+				"namespace": "infra", "name": "g", "sectionName": section,
+			},
+			"conditions": []any{
+				map[string]any{"type": "Accepted", "status": "True"},
+				map[string]any{"type": "Programmed", "status": programmed},
+			},
 		}
 	}
+	old := &unstructured.Unstructured{Object: map[string]any{
+		"status": map[string]any{"parents": []any{parent("http", "True"), parent("https", "False")}},
+	}}
+	upd := &unstructured.Unstructured{Object: map[string]any{
+		"status": map[string]any{"parents": []any{parent("http", "True"), parent("https", "True")}},
+	}}
+	diff := ComputeDiff("HTTPRoute", old, upd)
+	if diff == nil {
+		t.Fatal("expected non-nil diff when one of two listener parents flips Programmed")
+	}
+	// We should see the https listener flip but not the http listener.
+	httpsHit, httpHit := false, false
+	for _, f := range diff.Fields {
+		if stringContains(f.Path, "https") && stringContains(f.Path, "Programmed") {
+			httpsHit = true
+		}
+		if stringContains(f.Path, "/http/") && stringContains(f.Path, "Programmed") {
+			httpHit = true
+		}
+	}
+	if !httpsHit {
+		t.Errorf("expected https listener Programmed flip in diff, got %+v", diff.Fields)
+	}
+	if httpHit {
+		t.Errorf("did not expect http listener flip in diff (was unchanged), got %+v", diff.Fields)
+	}
+}
+
+func TestComputeDiff_HTTPRouteRemovedParent_Detected(t *testing.T) {
+	// One parent in old, zero parents in new — both per-parent walk and the
+	// length check should fire. Worst case: one parent removed + one added so
+	// the count stays the same; the union-walk catches the disappearance.
+	mk := func(parents []any) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"status": map[string]any{"parents": parents},
+		}}
+	}
+	parentA := map[string]any{
+		"parentRef":  map[string]any{"group": "gateway.networking.k8s.io", "kind": "Gateway", "namespace": "infra", "name": "a"},
+		"conditions": []any{map[string]any{"type": "Accepted", "status": "True"}},
+	}
+	parentB := map[string]any{
+		"parentRef":  map[string]any{"group": "gateway.networking.k8s.io", "kind": "Gateway", "namespace": "infra", "name": "b"},
+		"conditions": []any{map[string]any{"type": "Accepted", "status": "True"}},
+	}
+	diff := ComputeDiff("HTTPRoute", mk([]any{parentA}), mk([]any{parentB}))
+	if diff == nil {
+		t.Fatal("expected non-nil diff when one parent disappears and another appears")
+	}
+}
+
+func TestComputeDiff_PodReadinessGateFlip_Detected(t *testing.T) {
+	base := &corev1.Pod{Status: corev1.PodStatus{
+		Conditions: []corev1.PodCondition{
+			{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+		},
+	}}
+	updated := base.DeepCopy()
+	updated.Status.Conditions[0].Status = corev1.ConditionFalse
+	diff := ComputeDiff("Pod", base, updated)
+	if diff == nil || !containsPath(diff, "status.conditions[Ready]") {
+		t.Fatalf("expected PodReady flip detected, got %+v", diff)
+	}
+}
+
+func TestComputeDiff_PodEphemeralContainerAttached_Detected(t *testing.T) {
+	base := &corev1.Pod{}
+	updated := base.DeepCopy()
+	updated.Status.EphemeralContainerStatuses = []corev1.ContainerStatus{{Name: "debugger"}}
+	diff := ComputeDiff("Pod", base, updated)
+	if diff == nil || !containsPath(diff, "status.ephemeralContainerStatuses") {
+		t.Fatalf("expected ephemeral container attach detected, got %+v", diff)
+	}
+}
+
+func TestComputeDiff_NodeAllocatableChanged_Detected(t *testing.T) {
+	base := &corev1.Node{Status: corev1.NodeStatus{
+		Allocatable: corev1.ResourceList{
+			corev1.ResourceCPU:    resourceQty("4"),
+			corev1.ResourceMemory: resourceQty("8Gi"),
+		},
+	}}
+	updated := base.DeepCopy()
+	updated.Status.Allocatable[corev1.ResourceMemory] = resourceQty("4Gi")
+	diff := ComputeDiff("Node", base, updated)
+	if diff == nil || !containsPath(diff, "status.allocatable.memory") {
+		t.Fatalf("expected allocatable memory change detected, got %+v", diff)
+	}
+}
+
+func TestComputeDiff_ApplicationImageRoll_Detected(t *testing.T) {
+	mk := func(images []string) *unstructured.Unstructured {
+		imgs := make([]any, len(images))
+		for i, s := range images {
+			imgs[i] = s
+		}
+		return &unstructured.Unstructured{Object: map[string]any{
+			"status": map[string]any{
+				"sync":    map[string]any{"status": "Synced"},
+				"health":  map[string]any{"status": "Healthy"},
+				"summary": map[string]any{"images": imgs},
+			},
+		}}
+	}
+	diff := ComputeDiff("Application", mk([]string{"app:v1"}), mk([]string{"app:v2"}))
+	if diff == nil || !containsPath(diff, "status.summary.images") {
+		t.Fatalf("expected Application image roll detected (Synced+Healthy app rolling images), got %+v", diff)
+	}
+}
+
+func resourceQty(s string) resource.Quantity {
+	return resource.MustParse(s)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/timeline/metrics.go
+++ b/internal/timeline/metrics.go
@@ -45,6 +45,10 @@ const (
 	DropReasonHistoryNil     = "history_nil"
 	DropReasonStoreFailed    = "store_failed"
 	DropReasonSubscriberFull = "subscriber_full"
+	// DropReasonNoDiff: update event for a kind whose diff function found no
+	// observable change. Heartbeats, managed-fields-only updates, reconcile
+	// counters — see KindHasDiffer for the audited set.
+	DropReasonNoDiff = "no_diff"
 )
 
 var (

--- a/internal/timeline/metrics.go
+++ b/internal/timeline/metrics.go
@@ -49,6 +49,11 @@ const (
 	// observable change. Heartbeats, managed-fields-only updates, reconcile
 	// counters — see KindHasDiffer for the audited set.
 	DropReasonNoDiff = "no_diff"
+	// DropReasonTypeMismatch: a diff function received an object that wasn't
+	// the expected type (e.g. dynamic informer wired with the wrong factory).
+	// Distinguished from no_diff so a sudden spike is visible — these would
+	// otherwise look like healthy heartbeat suppression.
+	DropReasonTypeMismatch = "type_mismatch"
 )
 
 var (


### PR DESCRIPTION
## What & why

Empirical baseline on a 1059-resource live cluster (256 pods): **83% of UPDATE rows recorded for "diffable" kinds carried no useful diff** — heartbeats, managedFields-only updates, reconcile counters. Bare row, no \`diff.fields\`, no value to a timeline reader. They were the bulk of the post-#667 retention bleed.

Naive "drop no-diff updates" was tempting but unsafe — several diff functions were incomplete, and dropping blindly would silently lose real signal (Node pressure conditions, HTTPRoute Programmed flips, HPA ScalingActive, env-var edits on Deployments, etc.).

## Three parts

### 1. Audited and extended every diff function

| Kind | Added |
|---|---|
| Node | MemoryPressure, DiskPressure, PIDPressure, NetworkUnavailable, NodeInfo (kubelet/kernel upgrade), Allocatable (cpu/memory/pods) |
| Pod | Ephemeral container attaches, PodReady / ContainersReady flips |
| Deployment | Available, Progressing |
| ReplicaSet | AvailableReplicas + ReplicaFailure |
| DaemonSet | NumberMisscheduled |
| StatefulSet | AvailableReplicas |
| HPA | ScalingActive, AbleToScale, ScalingLimited |
| Job | Complete / Failed / Suspended / FailureTarget conditions + StartTime |
| PVC | Resizing, FileSystemResizePending |
| ConfigMap | binaryData keys + Immutable flag |
| Application (Argo) | status.summary.images, status.conditions (SyncError / Orphaned / Excluded warnings) |
| Flux Kustomization / HelmRelease / Source | Stalled / Released / FetchFailed |
| GatewayClass *(new diff)* | spec.controllerName, Accepted, SupportedVersion |
| ReferenceGrant *(new diff)* | spec.from / spec.to size changes |
| Gateway | (already covered Accepted, Programmed, listeners, addresses) |
| GatewayRoute | per-parent per-condition keyed by group/kind/ns/name/sectionName/port (replaces "count of Accepted parents" which collapsed multi-listener attaches into one bucket) |

### 2. Single-source dispatch + the no-diff drop

\`ComputeDiff\` now dispatches via a single \`diffFunctions\` map; \`KindHasDiffer\` reads the same map. Drift between "kind ComputeDiff handles" and "kind the no-diff drop applies to" is structurally impossible.

In \`recordToTimelineStore\`: for op=update on kinds in \`diffFunctions\`, if \`ComputeDiff\` returns nil, drop the event. CRDs without diff coverage flow through unchanged.

### 3. \`metadata.generation\` fallback (independent reviewer catch)

Diff functions are necessarily incomplete — \`diffDeployment\` doesn't track env vars, args, probes, volumes, etc. Without a fallback, those edits would silently drop.

Fix: when \`ComputeDiff\` returns nil for a covered kind, check \`metadata.generation\` (which bumps **only** on spec changes — status updates don't touch it). If it changed, record with a fallback summary like \`"spec changed (gen 5→6, fields not specifically tracked)"\` instead of dropping. Future K8s API additions are covered automatically.

This makes the whole drop strategy safe regardless of diff coverage gaps.

## Live measurement

Same nonprod cluster, fresh DB, 3-minute steady-state window:

| | Before | After |
|---|---|---|
| Timeline rows recorded | +116 | **+41** |
| DIFFABLE-kind no-diff rows | 395 (83%) | **0** |
| Total reduction | — | **65%** |

Of the remaining 41 rows: ~21 K8s events (separate path), ~20 CRD updates we don't have diff functions for.

## Other improvements bundled

- **VerticalPodAutoscalerCheckpoint** added to the noisy-update filter (by design it's a per-minute live ticker — never user-meaningful per update).
- **\`warnUnstructuredAssertFailed\`** (one-time-per-kind log) so a misconfigured informer wiring is diagnosable, not a silent 100% drop.
- **\`--debug-events\` log** for no-diff drops so operators can see suppressions by name.
- **\`diffJob\` summary fixes**: \`"complete"\` → \`"completed"\`, \`Suspended:True→False\` reads as "no longer suspended" instead of misleadingly "suspended".
- **Variable shadowing** in Flux helpers cleaned up (renamed inner vars to \`oldCond\`/\`newCond\`).

## Tests

\`internal/k8s/noisy_filter_audit_test.go\` — 17 tests:
- Negative: heartbeat-only Pod / Node / Service-managedFields → \`ComputeDiff\` returns nil (so the drop fires).
- Positive: Node MemoryPressure, kubelet upgrade, Allocatable; HPA ScalingActive flip; Job Failed; Deployment Available; HTTPRoute single-parent + multi-parent (per-listener) + removed-parent; Pod readiness gate + ephemeral container; Application image roll + condition added; GatewayClass Accepted flip; ReferenceGrant spec change; Flux Kustomization Stalled; ReplicaFailure; NumberMisscheduled.
- Generation fallback: pins that diffDeployment misses env-var edits today (so the fallback is needed) and that \`getGeneration\` works for both typed + unstructured objects.

## Follow-ups (not this PR)

- Watch \`/api/diagnostics → recentDrops\` post-merge for noise from Argo \`ComparisonError\` / \`ReconciliationError\` flapping under transient repo-server hiccups. Surgical filter possible if it materializes.
- Add diff functions for vendor-specific high-volume CRDs only when users on those stacks report missing signals: \`DatadogAgent\` (Datadog operator), \`DeletingPolicy\` (Kyverno-style).
- Augment specific diff functions as users report missed signals — the generation fallback means "missed" produces a generic row, not silent drop.

Refs #662