### PR TITLE
feat(renderers): show container port names alongside port/protocol

### DIFF
--- a/packages/k8s-ui/src/components/resources/renderers/KnativeConfigurationRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KnativeConfigurationRenderer.tsx
@@ -55,7 +55,7 @@ export function KnativeConfigurationRenderer({ data, onNavigate }: KnativeConfig
                 <div className="text-xs text-theme-text-secondary truncate" title={c.image}>{c.image}</div>
                 {c.ports && c.ports.length > 0 && (
                   <div className="text-xs text-theme-text-tertiary mt-1">
-                    Ports: {c.ports.map((p: any) => `${p.containerPort}/${p.protocol || 'TCP'}`).join(', ')}
+                    Ports: {c.ports.map((p: any) => `${p.name ? `${p.name}: ` : ''}${p.containerPort}/${p.protocol || 'TCP'}`).join(', ')}
                   </div>
                 )}
               </div>

--- a/packages/k8s-ui/src/components/resources/renderers/KnativeRevisionRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KnativeRevisionRenderer.tsx
@@ -67,7 +67,7 @@ export function KnativeRevisionRenderer({ data }: KnativeRevisionRendererProps) 
                 <div className="text-xs text-theme-text-secondary truncate" title={c.image}>{c.image}</div>
                 {c.ports && c.ports.length > 0 && (
                   <div className="text-xs text-theme-text-tertiary mt-1">
-                    Ports: {c.ports.map((p: any) => `${p.containerPort}/${p.protocol || 'TCP'}`).join(', ')}
+                    Ports: {c.ports.map((p: any) => `${p.name ? `${p.name}: ` : ''}${p.containerPort}/${p.protocol || 'TCP'}`).join(', ')}
                   </div>
                 )}
                 {c.resources && (c.resources.requests || c.resources.limits) && (

--- a/packages/k8s-ui/src/components/resources/renderers/KnativeServiceRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KnativeServiceRenderer.tsx
@@ -123,7 +123,7 @@ export function KnativeServiceRenderer({ data, onNavigate }: KnativeServiceRende
                 <div className="text-xs text-theme-text-secondary truncate" title={c.image}>{c.image}</div>
                 {c.ports && c.ports.length > 0 && (
                   <div className="text-xs text-theme-text-tertiary mt-1">
-                    Ports: {c.ports.map((p: any) => `${p.containerPort}/${p.protocol || 'TCP'}`).join(', ')}
+                    Ports: {c.ports.map((p: any) => `${p.name ? `${p.name}: ` : ''}${p.containerPort}/${p.protocol || 'TCP'}`).join(', ')}
                   </div>
                 )}
               </div>

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
@@ -635,7 +635,8 @@ export function PodRenderer({
                       <span>Ports:</span>
                       {container.ports.map((p: any) => (
                         canPortForward && renderPortAction ? (
-                          <span key={`${p.containerPort}-${p.protocol || 'TCP'}`}>
+                          <span key={`${p.name || ''}-${p.containerPort}-${p.protocol || 'TCP'}`} className="inline-flex items-center gap-1">
+                            {p.name && <span className="text-theme-text-tertiary">{p.name}:</span>}
                             {renderPortAction({
                               namespace,
                               podName,
@@ -645,8 +646,8 @@ export function PodRenderer({
                             })}
                           </span>
                         ) : (
-                          <span key={`${p.containerPort}-${p.protocol || 'TCP'}`} className="text-theme-text-tertiary">
-                            {p.containerPort}/{p.protocol || 'TCP'}
+                          <span key={`${p.name || ''}-${p.containerPort}-${p.protocol || 'TCP'}`} className="text-theme-text-tertiary">
+                            {p.name ? `${p.name}: ` : ''}{p.containerPort}/{p.protocol || 'TCP'}
                           </span>
                         )
                       ))}

--- a/packages/k8s-ui/src/components/ui/drawer-components.tsx
+++ b/packages/k8s-ui/src/components/ui/drawer-components.tsx
@@ -519,7 +519,7 @@ export function PodTemplateSection({ template }: { template: any }) {
           <div className="text-xs text-theme-text-secondary truncate" title={c.image}>{c.image}</div>
           {c.ports && (
             <div className="text-xs text-theme-text-tertiary mt-1">
-              Ports: {c.ports.map((p: any) => `${p.containerPort}/${p.protocol || 'TCP'}`).join(', ')}
+              Ports: {c.ports.map((p: any) => `${p.name ? `${p.name}: ` : ''}${p.containerPort}/${p.protocol || 'TCP'}`).join(', ')}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary

Container ports in K8s often carry a name (`http`, `grpc`, `metrics`) that Services bind to as a `targetPort`. Today Radar's container renderers drop the name and only show `port/protocol`, which makes it harder to correlate a Service's `targetPort: http` back to the container that exposes it.

This change renders the name as a tertiary prefix when present (e.g. `http: 8080/TCP`) and falls back to the existing `8080/TCP` format when the port has no name.

## Changes

- `PodRenderer` — both the port-forward branch (name renders as a label to the left of the clickable port chip) and the read-only branch
- `drawer-components.tsx` `ContainersList` — used by Deployment / StatefulSet / DaemonSet workload renderers
- Knative `Service` / `Configuration` / `Revision` renderers