### PR TITLE
feat(yaml): add Download button to resource YAML view

### DIFF
--- a/packages/k8s-ui/src/components/resources/renderers/SecretRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/SecretRenderer.tsx
@@ -6,6 +6,7 @@ import { Section, PropertyList, Property, AlertBanner } from '../../ui/drawer-co
 import { ConfirmDialog } from '../../ui/ConfirmDialog'
 import type { SecretCertificateInfo, CertificateInfo } from '../../../types'
 import { pluralize } from '../../../utils/pluralize'
+import { cleanResourceForYaml } from '../../../utils/yaml'
 
 interface SecretRendererProps {
   data: any
@@ -74,16 +75,9 @@ export function SecretRenderer({ data, certificateInfo, resourceData, onSaveSecr
 
   const handleSave = useCallback(async (key: string, newValue: string) => {
     if (!onSaveSecretValue || !resourceData) return
-    const cleaned = structuredClone(resourceData)
-    delete cleaned.status
-    if (cleaned.metadata) {
-      delete cleaned.metadata.managedFields
-      delete cleaned.metadata.resourceVersion
-      delete cleaned.metadata.uid
-      delete cleaned.metadata.creationTimestamp
-      delete cleaned.metadata.generation
-    }
-    // Encode with UTF-8 support
+    const cleaned = cleanResourceForYaml(resourceData)
+    if (!cleaned.data) cleaned.data = {}
+    // btoa is byte-only; round-trip through encodeURIComponent/unescape so non-ASCII secret values survive base64 encoding.
     cleaned.data[key] = btoa(unescape(encodeURIComponent(newValue)))
     const yaml = yamlStringify(cleaned, { lineWidth: 0, indent: 2 })
     try {

--- a/packages/k8s-ui/src/components/shared/EditableYamlView.tsx
+++ b/packages/k8s-ui/src/components/shared/EditableYamlView.tsx
@@ -157,23 +157,20 @@ export function EditableYamlView({ resource, data, onCopy, copied, onSaved, onSa
     }
   }, [isEditing, editedYaml, draftKey])
 
-  // Convert resource to YAML for editing — strips server-generated metadata (status, managedFields, etc.)
-  const convertToYaml = useCallback((d: any) => resourceToYaml(d), [])
-
   const handleDownload = useCallback(() => {
-    const yaml = convertToYaml(data)
+    const yaml = resourceToYaml(data)
     if (!yaml) return
     // Prefer the canonical singular Kind from the manifest (e.g. "Pod") over the URL plural ("pods").
     const kindForFile = (data?.kind || resource.kind || 'resource').toLowerCase()
     const slug = `${kindForFile}-${resource.name}`.replace(/[^a-z0-9._-]+/g, '-')
     triggerDownload(yaml, 'application/yaml', `${slug}.yaml`, onDownload)
-  }, [data, resource.kind, resource.name, convertToYaml, onDownload])
+  }, [data, resource.kind, resource.name, onDownload])
 
   const handleStartEdit = useCallback(() => {
-    setEditedYaml(convertToYaml(data))
+    setEditedYaml(resourceToYaml(data))
     setYamlErrors([])
     setIsEditing(true)
-  }, [data, convertToYaml])
+  }, [data])
 
   const handleCancelEdit = useCallback(() => {
     setIsEditing(false)

--- a/packages/k8s-ui/src/components/shared/EditableYamlView.tsx
+++ b/packages/k8s-ui/src/components/shared/EditableYamlView.tsx
@@ -9,11 +9,14 @@ import {
   XCircle,
   AlertTriangle,
 } from 'lucide-react'
+import { Download } from 'lucide-react'
 import { stringify as yamlStringify } from 'yaml'
 import { CodeViewer } from '../ui/CodeViewer'
 import { YamlEditor } from '../ui/YamlEditor'
 import { Tooltip } from '../ui/Tooltip'
 import type { SelectedResource } from '../../types'
+import { resourceToYaml } from '../../utils/yaml'
+import { triggerDownload } from '../../utils/download'
 
 // ============================================================================
 // SUCCESS ANIMATION
@@ -118,9 +121,14 @@ interface EditableYamlViewProps {
   saveError?: string | null
   /** Duplicate handler — opens create dialog with this resource's YAML */
   onDuplicate?: (params: { kind: string; namespace: string; name: string; yaml: string }) => void
+  /**
+   * Optional override for the download trigger — desktop builds inject a native save dialog here.
+   * Falls back to a browser blob download when omitted.
+   */
+  onDownload?: (content: string, mime: string, filename: string) => void
 }
 
-export function EditableYamlView({ resource, data, onCopy, copied, onSaved, onSave, isSaving, saveError, onDuplicate }: EditableYamlViewProps) {
+export function EditableYamlView({ resource, data, onCopy, copied, onSaved, onSave, isSaving, saveError, onDuplicate, onDownload }: EditableYamlViewProps) {
   const draftKey = `radar_yaml_draft:${resource.kind}/${resource.namespace}/${resource.name}`
 
   // Restore draft from sessionStorage (e.g., after session-expiry redirect).
@@ -149,20 +157,17 @@ export function EditableYamlView({ resource, data, onCopy, copied, onSaved, onSa
     }
   }, [isEditing, editedYaml, draftKey])
 
-  // Convert resource to YAML for editing
-  const convertToYaml = useCallback((d: any) => {
-    if (!d) return ''
-    const cleaned = { ...d }
-    delete cleaned.status
-    if (cleaned.metadata) {
-      delete cleaned.metadata.managedFields
-      delete cleaned.metadata.resourceVersion
-      delete cleaned.metadata.uid
-      delete cleaned.metadata.creationTimestamp
-      delete cleaned.metadata.generation
-    }
-    return yamlStringify(cleaned, { lineWidth: 0, indent: 2 })
-  }, [])
+  // Convert resource to YAML for editing — strips server-generated metadata (status, managedFields, etc.)
+  const convertToYaml = useCallback((d: any) => resourceToYaml(d), [])
+
+  const handleDownload = useCallback(() => {
+    const yaml = convertToYaml(data)
+    if (!yaml) return
+    // Prefer the canonical singular Kind from the manifest (e.g. "Pod") over the URL plural ("pods").
+    const kindForFile = (data?.kind || resource.kind || 'resource').toLowerCase()
+    const slug = `${kindForFile}-${resource.name}`.replace(/[^a-z0-9._-]+/g, '-')
+    triggerDownload(yaml, 'application/yaml', `${slug}.yaml`, onDownload)
+  }, [data, resource.kind, resource.name, convertToYaml, onDownload])
 
   const handleStartEdit = useCallback(() => {
     setEditedYaml(convertToYaml(data))
@@ -328,6 +333,15 @@ export function EditableYamlView({ resource, data, onCopy, copied, onSaved, onSa
             {copied ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
             Copy
           </button>
+          <Tooltip content="Download manifest as YAML (server-generated fields stripped)">
+            <button
+              onClick={handleDownload}
+              className="flex items-center gap-1 px-2 py-1 text-xs text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
+            >
+              <Download className="w-3.5 h-3.5" />
+              Download
+            </button>
+          </Tooltip>
           {onDuplicate && (
             <Tooltip content="Duplicate as new resource">
               <button

--- a/packages/k8s-ui/src/components/workload/WorkloadView.tsx
+++ b/packages/k8s-ui/src/components/workload/WorkloadView.tsx
@@ -136,10 +136,7 @@ interface WorkloadViewProps {
   onDuplicate?: (params: { kind: string; namespace: string; name: string; yaml: string }) => void
 
   // ── Download ─────────────────────────────────────────────────────────────
-  /**
-   * Optional override for the YAML download trigger — desktop builds inject a native save dialog here.
-   * Falls back to a browser blob download when omitted.
-   */
+  /** Forwarded to EditableYamlView; see there. */
   onDownload?: (content: string, mime: string, filename: string) => void
 
   // ── ResourceActionsBar props (passed through) ────────────────────────────

--- a/packages/k8s-ui/src/components/workload/WorkloadView.tsx
+++ b/packages/k8s-ui/src/components/workload/WorkloadView.tsx
@@ -135,6 +135,13 @@ interface WorkloadViewProps {
   /** Duplicate handler — opens create dialog with this resource's YAML */
   onDuplicate?: (params: { kind: string; namespace: string; name: string; yaml: string }) => void
 
+  // ── Download ─────────────────────────────────────────────────────────────
+  /**
+   * Optional override for the YAML download trigger — desktop builds inject a native save dialog here.
+   * Falls back to a browser blob download when omitted.
+   */
+  onDownload?: (content: string, mime: string, filename: string) => void
+
   // ── ResourceActionsBar props (passed through) ────────────────────────────
   /** All props for the actions bar (forwarded as-is) */
   actionsBarProps?: Record<string, any>
@@ -186,6 +193,7 @@ export function WorkloadView({
   isMetricsAvailable,
   // Duplicate
   onDuplicate,
+  onDownload,
   renderOverviewExtra,
   // Actions bar
   actionsBarProps,
@@ -451,6 +459,7 @@ export function WorkloadView({
               isSaving={isUpdatingResource}
               saveError={updateResourceError}
               onDuplicate={onDuplicate}
+              onDownload={onDownload}
             />
           ) : (
             <>
@@ -675,6 +684,7 @@ export function WorkloadView({
                 isSaving={isUpdatingResource}
                 saveError={updateResourceError}
                 onDuplicate={onDuplicate}
+                onDownload={onDownload}
               />
             )}
           </div>

--- a/packages/k8s-ui/src/utils/yaml.test.ts
+++ b/packages/k8s-ui/src/utils/yaml.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import { parse as yamlParse } from 'yaml'
+import { cleanResourceForYaml, resourceToYaml } from './yaml'
+
+function makePod() {
+  return {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: {
+      name: 'nginx',
+      namespace: 'default',
+      uid: 'abcd-1234',
+      resourceVersion: '99999',
+      creationTimestamp: '2026-01-01T00:00:00Z',
+      generation: 1,
+      managedFields: [{ manager: 'kubectl', operation: 'Update' }],
+      labels: { app: 'nginx' },
+      annotations: { 'kubectl.kubernetes.io/last-applied-configuration': '{}' },
+      ownerReferences: [{ kind: 'ReplicaSet', name: 'nginx-rs', uid: 'rs-uid' }],
+    },
+    spec: {
+      containers: [{ name: 'nginx', image: 'nginx:1.25' }],
+    },
+    status: {
+      phase: 'Running',
+      podIP: '10.0.0.1',
+    },
+  }
+}
+
+describe('cleanResourceForYaml', () => {
+  it('strips status', () => {
+    const cleaned = cleanResourceForYaml(makePod())
+    expect(cleaned.status).toBeUndefined()
+  })
+
+  it('strips all 5 server-generated metadata fields', () => {
+    const cleaned = cleanResourceForYaml(makePod())
+    expect(cleaned.metadata.uid).toBeUndefined()
+    expect(cleaned.metadata.resourceVersion).toBeUndefined()
+    expect(cleaned.metadata.creationTimestamp).toBeUndefined()
+    expect(cleaned.metadata.generation).toBeUndefined()
+    expect(cleaned.metadata.managedFields).toBeUndefined()
+  })
+
+  it('preserves user metadata', () => {
+    const cleaned = cleanResourceForYaml(makePod())
+    expect(cleaned.metadata.name).toBe('nginx')
+    expect(cleaned.metadata.namespace).toBe('default')
+    expect(cleaned.metadata.labels).toEqual({ app: 'nginx' })
+    expect(cleaned.metadata.annotations).toEqual({
+      'kubectl.kubernetes.io/last-applied-configuration': '{}',
+    })
+    expect(cleaned.metadata.ownerReferences).toHaveLength(1)
+  })
+
+  it('preserves spec', () => {
+    const cleaned = cleanResourceForYaml(makePod())
+    expect(cleaned.spec).toEqual({
+      containers: [{ name: 'nginx', image: 'nginx:1.25' }],
+    })
+  })
+
+  it('does not mutate the input', () => {
+    const input = makePod()
+    cleanResourceForYaml(input)
+    expect(input.status).toBeDefined()
+    expect(input.metadata.uid).toBe('abcd-1234')
+    expect(input.metadata.managedFields).toHaveLength(1)
+  })
+
+  it('returns null/undefined/primitives unchanged', () => {
+    expect(cleanResourceForYaml(null)).toBeNull()
+    expect(cleanResourceForYaml(undefined)).toBeUndefined()
+    expect(cleanResourceForYaml('not an object' as any)).toBe('not an object')
+    expect(cleanResourceForYaml(42 as any)).toBe(42)
+  })
+
+  it('handles object with no metadata field', () => {
+    const cleaned = cleanResourceForYaml({ kind: 'Pod', spec: {} })
+    expect(cleaned).toEqual({ kind: 'Pod', spec: {} })
+  })
+
+  it('handles metadata present but null', () => {
+    const cleaned = cleanResourceForYaml({ kind: 'Pod', metadata: null, spec: {} })
+    expect(cleaned).toEqual({ kind: 'Pod', metadata: null, spec: {} })
+  })
+})
+
+describe('resourceToYaml', () => {
+  it('returns empty string for null/undefined', () => {
+    expect(resourceToYaml(null)).toBe('')
+    expect(resourceToYaml(undefined)).toBe('')
+  })
+
+  it('round-trips through yaml.parse to the cleaned object', () => {
+    const cleaned = cleanResourceForYaml(makePod())
+    const yaml = resourceToYaml(makePod())
+    expect(yamlParse(yaml)).toEqual(cleaned)
+  })
+})

--- a/packages/k8s-ui/src/utils/yaml.ts
+++ b/packages/k8s-ui/src/utils/yaml.ts
@@ -1,0 +1,26 @@
+import { stringify as yamlStringify } from 'yaml'
+
+const SERVER_GENERATED_METADATA = [
+  'managedFields',
+  'resourceVersion',
+  'uid',
+  'creationTimestamp',
+  'generation',
+] as const
+
+export function cleanResourceForYaml<T = any>(data: T): T {
+  if (!data || typeof data !== 'object') return data
+  const cleaned = structuredClone(data) as any
+  delete cleaned.status
+  if (cleaned.metadata && typeof cleaned.metadata === 'object') {
+    for (const field of SERVER_GENERATED_METADATA) {
+      delete cleaned.metadata[field]
+    }
+  }
+  return cleaned
+}
+
+export function resourceToYaml(data: any): string {
+  if (!data) return ''
+  return yamlStringify(cleanResourceForYaml(data), { lineWidth: 0, indent: 2 })
+}

--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -35,6 +35,7 @@ import { ServiceRenderer } from '../resources/renderers/ServiceRenderer'
 import { WorkloadRenderer } from '../resources/renderers/WorkloadRenderer'
 import { CreateResourceDialog } from '../shared/CreateResourceDialog'
 import { cleanYamlForDuplicate } from '../../utils/skeleton-yaml'
+import { useDesktopDownload } from '../../hooks/useDesktopDownload'
 
 type TabType = 'overview' | 'timeline' | 'logs' | 'metrics' | 'yaml'
 
@@ -315,6 +316,7 @@ export function WorkloadView({
   const canUpdateSecrets = useCanUpdateSecrets()
   const updateResource = useUpdateResource()
   const actionsBarProps = useActionsBarProps(kindProp, namespace, name)
+  const desktopDownload = useDesktopDownload()
 
   const handleUpdateResource = useCallback(async (params: { kind: string; namespace: string; name: string; yaml: string }) => {
     await updateResource.mutateAsync(params)
@@ -370,6 +372,7 @@ export function WorkloadView({
         isPrometheusSupported(kind) && !(kind === 'Pod' && res?.status?.phase === 'Pending')
       }
       onDuplicate={handleDuplicate}
+      onDownload={desktopDownload}
       actionsBarProps={actionsBarProps}
       rendererOverrides={rendererOverrides}
       resolvedEnvFrom={resolvedEnvFrom}


### PR DESCRIPTION
## Summary

Adds a **Download** button to the resource YAML view toolbar (next to Edit / Copy / Duplicate) so users can save any resource manifest to disk in one click without copy-pasting.

The downloaded YAML is *cleaned* — `status`, `managedFields`, `resourceVersion`, `uid`, `creationTimestamp`, and `generation` are stripped — so the file is immediately re-applyable with `kubectl apply -f`. Same cleanup the in-place Edit flow already does. Filename is `<kind>-<name>.yaml` using the canonical singular Kind from the manifest (e.g. `pod-argocd-server-676494847f-bkwx8.yaml`).

The button only appears inside the YAML view, not in the always-visible drawer header, so the drawer toolbar stays uncluttered.

## Notes

- Strip-and-stringify logic was duplicated in 3 places (EditableYamlView, SecretRenderer save, the new download). Extracted to `packages/k8s-ui/src/utils/yaml.ts` (`cleanResourceForYaml`, `resourceToYaml`) — three call sites now share one source of truth.
- Desktop builds get the native save dialog via the existing `useDesktopDownload` hook, mirroring how log downloads already work.