### PR TITLE
Fix namespace selection sync

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3053,8 +3053,17 @@ func (s *Server) getUserNamespaces(r *http.Request, requested []string) []string
 
 // handleSSE wraps the SSEBroadcaster's HandleSSE with per-user namespace filtering.
 func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
-	// Apply user namespace filtering to SSE subscriptions
-	namespaces := s.parseNamespacesForUser(r)
+	// SSE is usually opened without an explicit namespace filter so the
+	// frontend can keep one all-namespace stream and filter topology/events
+	// locally. Do not fall back to the saved namespace picker here; only
+	// server-filter when the request explicitly asks for it (large-cluster
+	// mode), while still intersecting with RBAC for authenticated users.
+	namespaces := parseNamespaces(r.URL.Query())
+	if namespaces == nil {
+		namespaces = s.getUserNamespaces(r, nil)
+	} else {
+		namespaces = s.getUserNamespaces(r, namespaces)
+	}
 	// Re-encode filtered namespaces back into query params for the broadcaster
 	q := r.URL.Query()
 	q.Del("namespace")

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -34,7 +34,7 @@ import { ShortcutHelpOverlay } from './components/ui/ShortcutHelpOverlay'
 import { CommandPalette } from './components/ui/CommandPalette'
 import { DiagnosticsOverlay } from './components/ui/DiagnosticsOverlay'
 import { useEventSource } from './hooks/useEventSource'
-import { useNamespaces, useNamespaceScope, useSetActiveNamespace, useSwitchContext, useAuthMe } from './api/client'
+import { debugNamespaceLog, useNamespaces, useNamespaceScope, useSetActiveNamespace, useSwitchContext, useAuthMe } from './api/client'
 import { routePath, apiUrl, getAuthHeaders, getCredentialsMode } from './api/config'
 import { KeyboardShortcutProvider, useRegisterShortcut, useRegisterShortcuts } from './hooks/useKeyboardShortcuts'
 import { useAnimatedUnmount } from './hooks/useAnimatedUnmount'
@@ -680,6 +680,12 @@ function AppInner() {
     const sortedScope = [...scopeActives].sort()
     const sortedState = [...namespaces].sort()
     const sameAsState = sortedScope.length === sortedState.length && sortedScope.every((ns, i) => ns === sortedState[i])
+    debugNamespaceLog('app:scope-mirror', {
+      scopeActives,
+      stateNamespaces: namespaces,
+      sameAsState,
+      initialBookmarkReconciled: initialBookmarkReconciledRef.current,
+    })
 
     // First-load bookmark reconciliation: if the URL had namespaces that
     // differ from the server pick when the scope first arrives, push the
@@ -689,12 +695,17 @@ function AppInner() {
     if (!initialBookmarkReconciledRef.current) {
       initialBookmarkReconciledRef.current = true
       if (!sameAsState && sortedState.length > 0) {
+        debugNamespaceLog('app:scope-mirror-bookmark-to-server', {
+          stateNamespaces: sortedState,
+          scopeActives: sortedScope,
+        })
         setActiveNamespace.mutate({ namespaces: sortedState })
         return
       }
     }
 
     if (!sameAsState) {
+      debugNamespaceLog('app:scope-mirror-set-namespaces', { nextNamespaces: scopeActives })
       setNamespaces(scopeActives)
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps -- namespaces and setActiveNamespace are intentionally excluded; we only react to server-side changes.
@@ -735,31 +746,48 @@ function AppInner() {
 
     // Only update if params actually changed vs current URL
     if (params.toString() !== new URLSearchParams(currentSearch).toString()) {
+      debugNamespaceLog('app:url-write', {
+        namespaces,
+        currentSearch,
+        nextSearch: params.toString(),
+        mainView,
+      })
       setSearchParams(params, { replace: true })
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps -- reads window.location.search, not searchParams
   }, [namespacesKey, topologyMode, groupingMode, mainView, setSearchParams])
 
-  // Sync state from URL when navigating (back/forward). Push the URL choice
-  // to the server too so the canonical pick stays in lockstep — otherwise a
-  // back-nav would visually update but leave the next reload pulling the
-  // server's previous (forward-nav) pick.
+  // Sync namespace + helm picks from the query string only when the query
+  // string changes. If this also ran on pathname / mainView changes, a view
+  // whose URL omits ?namespaces= would clear App state and POST [] to the
+  // server while the per-user pick was still narrowed — the picker would
+  // show the server scope but lists/dashboard would stay on "all namespaces".
   useEffect(() => {
     const urlNamespaces = parseNamespacesFromURL(searchParams)
+    debugNamespaceLog('app:url-sync', {
+      search: searchParams.toString(),
+      urlNamespaces,
+      stateNamespaces: namespaces,
+      namespacesKey,
+    })
 
     if (urlNamespaces.join(',') !== namespacesKey) {
+      debugNamespaceLog('app:url-sync-set-namespaces', { nextNamespaces: urlNamespaces })
       setNamespaces(urlNamespaces)
       if (namespaceScope) {
         const sortedURL = [...urlNamespaces].sort()
         const sortedScope = [...(namespaceScope.actives ?? [])].sort()
         const same = sortedURL.length === sortedScope.length && sortedURL.every((ns, i) => ns === sortedScope[i])
         if (!same) {
+          debugNamespaceLog('app:url-sync-mutate-server', {
+            urlNamespaces,
+            scopeActives: namespaceScope.actives ?? [],
+          })
           setActiveNamespace.mutate({ namespaces: urlNamespaces })
         }
       }
     }
 
-    // Restore helm release from URL (back navigation)
     const releaseParam = searchParams.get('release')
     if (releaseParam) {
       const slashIdx = releaseParam.indexOf('/')
@@ -769,36 +797,33 @@ function AppInner() {
         setSelectedHelmRelease({ namespace: ns, name, storageNamespace: searchParams.get('releaseStorage') || undefined })
       }
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- run only when searchParams change; namespacesKey/namespaceScope are read for that transition
+  }, [searchParams])
 
-    // Restore resource drawer selection from URL on browser back/forward (POP) within
-    // /resources/{kind}. Cross-kind POP re-mounts ResourcesView via key={pathname} so its
-    // mount effect re-reads ?resource=; same-kind POP doesn't remount, so App must
-    // reconcile selectedResource here. Limited to POP to avoid clobbering deliberate
-    // setSelectedResource calls that race the URL writer (e.g. helm/audit -> resources).
-    if (navigationType === NavigationType.Pop && mainView === 'resources') {
-      const kindFromPath = location.pathname.match(/^\/resources\/([^/]+)/)?.[1] ?? ''
-      const resourceParam = searchParams.get('resource')
-      if (kindFromPath && resourceParam) {
-        const slashIdx = resourceParam.indexOf('/')
-        const ns = slashIdx > 0 ? resourceParam.slice(0, slashIdx) : ''
-        const name = slashIdx > 0 ? resourceParam.slice(slashIdx + 1) : resourceParam
-        const apiGroup = searchParams.get('apiGroup') ?? ''
-        const next: SelectedResource = { kind: kindFromPath, namespace: ns, name, group: apiGroup }
-        setSelectedResource(prev => {
-          if (
-            prev &&
-            prev.kind === next.kind &&
-            prev.namespace === next.namespace &&
-            prev.name === next.name &&
-            (prev.group ?? '') === (next.group ?? '')
-          ) return prev
-          return next
-        })
-      } else if (kindFromPath && !resourceParam) {
-        setSelectedResource(prev => (prev === null ? prev : null))
-      }
+  useEffect(() => {
+    if (navigationType !== NavigationType.Pop || mainView !== 'resources') return
+    const kindFromPath = location.pathname.match(/^\/resources\/([^/]+)/)?.[1] ?? ''
+    const resourceParam = searchParams.get('resource')
+    if (kindFromPath && resourceParam) {
+      const slashIdx = resourceParam.indexOf('/')
+      const ns = slashIdx > 0 ? resourceParam.slice(0, slashIdx) : ''
+      const name = slashIdx > 0 ? resourceParam.slice(slashIdx + 1) : resourceParam
+      const apiGroup = searchParams.get('apiGroup') ?? ''
+      const next: SelectedResource = { kind: kindFromPath, namespace: ns, name, group: apiGroup }
+      setSelectedResource(prev => {
+        if (
+          prev &&
+          prev.kind === next.kind &&
+          prev.namespace === next.namespace &&
+          prev.name === next.name &&
+          (prev.group ?? '') === (next.group ?? '')
+        ) return prev
+        return next
+      })
+    } else if (kindFromPath && !resourceParam) {
+      setSelectedResource(prev => (prev === null ? prev : null))
     }
-  }, [searchParams, location.pathname, mainView, navigationType])
+  }, [navigationType, mainView, location.pathname, searchParams])
 
   // Auto-adjust grouping when namespaces change
   useEffect(() => {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2481,6 +2481,17 @@ export function useNamespaceScope() {
 
 const NAMESPACE_SWITCH_TIMEOUT = 5000
 
+export function debugNamespaceLog(label: string, payload?: Record<string, unknown>) {
+  if (typeof window === 'undefined') return
+  const enabled = window.localStorage.getItem('radar:debug:namespaces')
+  if (enabled !== '1' && enabled !== 'true') return
+  console.log(`[namespace-debug] ${label}`, {
+    t: Math.round(performance.now()),
+    href: window.location.href,
+    ...payload,
+  })
+}
+
 export function useSetActiveNamespace() {
   const queryClient = useQueryClient()
   return useMutation<NamespaceScope, Error, { namespaces: string[] }>({
@@ -2493,8 +2504,10 @@ export function useSetActiveNamespace() {
       errorMessage: 'Failed to update namespace selection',
     },
     mutationFn: async ({ namespaces }) => {
+      debugNamespaceLog('mutation:start', { namespaces })
       const controller = new AbortController()
       const timeoutId = setTimeout(() => controller.abort(), NAMESPACE_SWITCH_TIMEOUT)
+      const startedAt = performance.now()
       try {
         const response = await apiFetch(`${getApiBase()}/cluster/namespace`, {
           method: 'POST',
@@ -2503,6 +2516,11 @@ export function useSetActiveNamespace() {
           signal: controller.signal,
         })
         clearTimeout(timeoutId)
+        debugNamespaceLog('mutation:response', {
+          namespaces,
+          status: response.status,
+          durationMs: Math.round(performance.now() - startedAt),
+        })
         if (!response.ok) {
           const error = await response.json().catch(() => ({ error: 'Unknown error' }))
           throw new Error(error.error || `HTTP ${response.status}`)
@@ -2510,23 +2528,32 @@ export function useSetActiveNamespace() {
         return response.json()
       } catch (error) {
         clearTimeout(timeoutId)
+        debugNamespaceLog('mutation:error', {
+          namespaces,
+          durationMs: Math.round(performance.now() - startedAt),
+          error: error instanceof Error ? error.message : String(error),
+        })
         if (error instanceof Error && error.name === 'AbortError') {
           throw new Error('Namespace switch timed out. The cluster may be unreachable.')
         }
         throw error
       }
     },
-    onSuccess: () => {
-      // The user's view filter changed; every cached query result was
-      // shaped by the previous filter, so drop and refetch.
-      queryClient.removeQueries()
-      queryClient.invalidateQueries()
+    onSuccess: (scope) => {
+      debugNamespaceLog('mutation:success-before-scope-cache-write', {
+        actives: scope.actives,
+        mode: scope.mode,
+        accessibleCount: scope.accessibleNamespaces.length,
+      })
+      queryClient.setQueryData<NamespaceScope>(['namespace-scope'], scope)
+      debugNamespaceLog('mutation:success-after-scope-cache-write')
     },
     onError: () => {
       // A failed switch can leave the server's stored pick out of sync
       // with the cached scope (network timeout after the server wrote;
       // partial mutation). Refetch so the displayed picker matches what
       // the server actually persisted instead of what we assumed.
+      debugNamespaceLog('mutation:on-error-invalidate-scope')
       queryClient.invalidateQueries({ queryKey: ['namespace-scope'] })
     },
   })

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useCallback, useEffect } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { ApiError, fetchJSON, isForbiddenError, useSecretCertExpiry, useTopPodMetrics, useTopNodeMetrics } from '../../api/client'
+import { ApiError, debugNamespaceLog, fetchJSON, isForbiddenError, useSecretCertExpiry, useTopPodMetrics, useTopNodeMetrics } from '../../api/client'
 import { apiUrl, getAuthHeaders, getCredentialsMode, getBasename } from '../../api/config'
 import { useAPIResources } from '../../api/apiResources'
 import { initNavigationMap } from '@skyhook-io/k8s-ui'
@@ -52,7 +52,17 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
     queryFn: async () => {
       const params = new URLSearchParams()
       if (namespaces.length > 0) params.set('namespaces', namespacesParam)
-      return fetchJSON<ResourceCountsResponse>(`/resource-counts?${params}`)
+      const startedAt = performance.now()
+      debugNamespaceLog('resources:counts-fetch-start', { namespaces, params: params.toString() })
+      try {
+        return await fetchJSON<ResourceCountsResponse>(`/resource-counts?${params}`)
+      } finally {
+        debugNamespaceLog('resources:counts-fetch-end', {
+          namespaces,
+          params: params.toString(),
+          durationMs: Math.round(performance.now() - startedAt),
+        })
+      }
     },
     staleTime: 10000,
     refetchInterval: 60000, // Safety net — SSE k8s_event drives near-real-time invalidation
@@ -75,9 +85,24 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
       const params = new URLSearchParams()
       if (namespaces.length > 0) params.set('namespaces', namespacesParam)
       if (isSelectedCrd && selectedKind.group) params.set('group', selectedKind.group)
+      const startedAt = performance.now()
+      debugNamespaceLog('resources:selected-kind-fetch-start', {
+        kind: selectedKind.name,
+        group: isSelectedCrd ? selectedKind.group : '',
+        namespaces,
+        params: params.toString(),
+      })
       const res = await fetch(apiUrl(`/resources/${selectedKind.name}?${params}`), {
         credentials: getCredentialsMode(),
         headers: getAuthHeaders(),
+      })
+      debugNamespaceLog('resources:selected-kind-fetch-response', {
+        kind: selectedKind.name,
+        group: isSelectedCrd ? selectedKind.group : '',
+        namespaces,
+        params: params.toString(),
+        status: res.status,
+        durationMs: Math.round(performance.now() - startedAt),
       })
       if (!res.ok) {
         const errorData = await res.json().catch(() => ({ error: `HTTP ${res.status}` }))


### PR DESCRIPTION
## Summary
- Keep namespace selection state in sync by writing the mutation response directly into the namespace-scope query cache instead of flushing all React Query data.
- Split URL namespace sync from resource drawer POP handling so view/path changes do not accidentally clear namespace picks.
- Keep SSE all-namespace for client-side filtering unless a request explicitly asks for server-side namespace filtering, while still enforcing RBAC.
- Add gated namespace debug logging via localStorage for future diagnosis.

## Test plan
- npm run build
- go test ./internal/server
- Verified locally against kind-radar-gitops-demo that Resources updates URL and refetches immediately after changing namespace selection.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches namespace scoping across frontend URL/state sync, React Query caching, and backend SSE filtering; mistakes could cause missing data, stale views, or over/under-filtered event streams for some users.
> 
> **Overview**
> Fixes namespace-selection drift by updating `useSetActiveNamespace` to write the mutation response directly into the `['namespace-scope']` React Query cache (instead of flushing all queries) and adds gated `debugNamespaceLog` instrumentation for diagnosing sync issues.
> 
> Refactors `App.tsx` URL/state effects so namespace state sync runs only when the query string changes (separately from resource-drawer POP handling), avoiding accidental namespace clears/empty `POST []` during view navigation.
> 
> Updates backend `handleSSE` to keep SSE unfiltered by default (no fallback to the saved namespace picker) and only apply server-side namespace filtering when explicitly requested, while still intersecting with RBAC; adds additional frontend fetch timing/status logs in `ResourcesView` for counts and resource listing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abab66d5968abd478bbd74b8873f0c7729a4ecb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->