### PR TITLE
fix(drawer): inset resource/helm drawers above bottom dock (#678)

### DIFF
--- a/packages/k8s-ui/src/components/dock/BottomDock.tsx
+++ b/packages/k8s-ui/src/components/dock/BottomDock.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect, ReactNode } from 'react'
+import { useCallback, useRef, useEffect, ReactNode } from 'react'
 import { DURATION_DOCK } from '../../utils/animation'
 import { X, ChevronDown, ChevronUp, Terminal, FileText, Trash2, Layers, Maximize2, Minimize2, Activity } from 'lucide-react'
 import { clsx } from 'clsx'
@@ -6,7 +6,6 @@ import { useDock, DockTab } from './DockContext'
 import { useRegisterShortcuts } from '../../hooks/useKeyboardShortcuts'
 
 const MIN_HEIGHT = 200
-const DEFAULT_HEIGHT = 400
 const MAX_HEIGHT_RATIO = 0.7
 const MAXIMIZED_TOP_OFFSET = 48
 
@@ -21,28 +20,27 @@ interface BottomDockProps {
 }
 
 export function BottomDock({ renderTabContent, renderTabHeaderExtra, leftOffset: leftOffsetProp, defaultHeight }: BottomDockProps) {
-  const { tabs, activeTabId, isExpanded, leftOffset: leftOffsetCtx, removeTab, setActiveTab, toggleExpanded, closeAll } = useDock()
+  const { tabs, activeTabId, isExpanded, leftOffset: leftOffsetCtx, height, isMaximized, isResizing, setHeight, setMaximized, setResizing, removeTab, setActiveTab, toggleExpanded, closeAll } = useDock()
   const leftOffset = leftOffsetProp ?? leftOffsetCtx
-  const [height, setHeight] = useState(defaultHeight ?? DEFAULT_HEIGHT)
   const prevDefaultHeight = useRef(defaultHeight)
   useEffect(() => {
     if (defaultHeight != null && defaultHeight !== prevDefaultHeight.current) {
       setHeight(defaultHeight)
     }
     prevDefaultHeight.current = defaultHeight
-  }, [defaultHeight])
-  const [isMaximized, setIsMaximized] = useState(false)
+  }, [defaultHeight, setHeight])
   const isDragging = useRef(false)
   const startY = useRef(0)
   const startHeight = useRef(0)
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     isDragging.current = true
+    setResizing(true)
     startY.current = e.clientY
     startHeight.current = height
     document.body.style.cursor = 'ns-resize'
     document.body.style.userSelect = 'none'
-  }, [height])
+  }, [height, setResizing])
 
   useEffect(() => {
     const handleMouseMove = (e: MouseEvent) => {
@@ -53,7 +51,10 @@ export function BottomDock({ renderTabContent, renderTabHeaderExtra, leftOffset:
     }
 
     const handleMouseUp = () => {
-      isDragging.current = false
+      if (isDragging.current) {
+        isDragging.current = false
+        setResizing(false)
+      }
       document.body.style.cursor = ''
       document.body.style.userSelect = ''
     }
@@ -65,20 +66,20 @@ export function BottomDock({ renderTabContent, renderTabHeaderExtra, leftOffset:
       document.removeEventListener('mousemove', handleMouseMove)
       document.removeEventListener('mouseup', handleMouseUp)
     }
-  }, [])
+  }, [setHeight, setResizing])
 
   const toggleMaximized = useCallback(() => {
-    setIsMaximized(prev => !prev)
-  }, [])
+    setMaximized(!isMaximized)
+  }, [isMaximized, setMaximized])
 
   useEffect(() => {
     if (!isMaximized) return
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setIsMaximized(false)
+      if (e.key === 'Escape') setMaximized(false)
     }
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [isMaximized])
+  }, [isMaximized, setMaximized])
 
   useRegisterShortcuts([
     {
@@ -110,7 +111,13 @@ export function BottomDock({ renderTabContent, renderTabHeaderExtra, leftOffset:
   return (
     <div
       className="absolute bottom-0 right-0 bg-theme-base border-t border-theme-border flex flex-col z-40 overflow-hidden"
-      style={{ height: effectiveHeight, left: leftOffset, transition: `height ${DURATION_DOCK}ms cubic-bezier(0.4, 0, 0.2, 1), left ${DURATION_DOCK}ms ease-out` }}
+      style={{
+        height: effectiveHeight,
+        left: leftOffset,
+        transition: isResizing
+          ? `left ${DURATION_DOCK}ms ease-out`
+          : `height ${DURATION_DOCK}ms cubic-bezier(0.4, 0, 0.2, 1), left ${DURATION_DOCK}ms ease-out`,
+      }}
     >
       {isExpanded && !isMaximized && (
         <div
@@ -165,7 +172,7 @@ export function BottomDock({ renderTabContent, renderTabHeaderExtra, leftOffset:
             </button>
           )}
           <button
-            onClick={() => { if (isMaximized) setIsMaximized(false); toggleExpanded() }}
+            onClick={() => { if (isMaximized) setMaximized(false); toggleExpanded() }}
             className="p-1 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
             title={isExpanded ? 'Collapse' : 'Expand'}
           >

--- a/packages/k8s-ui/src/components/dock/DockContext.tsx
+++ b/packages/k8s-ui/src/components/dock/DockContext.tsx
@@ -29,12 +29,18 @@ export interface DockContextValue {
   activeTabId: string | null
   isExpanded: boolean
   leftOffset: number
+  height: number
+  isMaximized: boolean
+  isResizing: boolean
   addTab: (tab: Omit<DockTab, 'id'>) => string
   removeTab: (id: string) => void
   setActiveTab: (id: string) => void
   toggleExpanded: () => void
   setExpanded: (expanded: boolean) => void
   setLeftOffset: (offset: number) => void
+  setHeight: (height: number) => void
+  setMaximized: (maximized: boolean) => void
+  setResizing: (resizing: boolean) => void
   closeAll: () => void
 }
 
@@ -42,11 +48,17 @@ const DockContext = createContext<DockContextValue | null>(null)
 
 let tabIdCounter = 0
 
+const DOCK_DEFAULT_HEIGHT = 400
+const DOCK_COLLAPSED_HEIGHT = 36
+
 export function DockProvider({ children }: { children: ReactNode }) {
   const [tabs, setTabs] = useState<DockTab[]>([])
   const [activeTabId, setActiveTabId] = useState<string | null>(null)
   const [isExpanded, setIsExpanded] = useState(false)
   const [leftOffset, setLeftOffset] = useState(0)
+  const [height, setHeight] = useState(DOCK_DEFAULT_HEIGHT)
+  const [isMaximized, setIsMaximized] = useState(false)
+  const [isResizing, setIsResizing] = useState(false)
   // Keep a ref to the latest tabs for deduplication without stale-closure issues
   const tabsRef = useRef<DockTab[]>(tabs)
   useEffect(() => { tabsRef.current = tabs }, [tabs])
@@ -126,12 +138,18 @@ export function DockProvider({ children }: { children: ReactNode }) {
       activeTabId,
       isExpanded,
       leftOffset,
+      height,
+      isMaximized,
+      isResizing,
       addTab,
       removeTab,
       setActiveTab,
       toggleExpanded,
       setExpanded: setIsExpanded,
       setLeftOffset,
+      setHeight,
+      setMaximized: setIsMaximized,
+      setResizing: setIsResizing,
       closeAll,
     }}>
       {children}
@@ -145,6 +163,19 @@ export function useDock() {
     throw new Error('useDock must be used within a DockProvider')
   }
   return context
+}
+
+/**
+ * Reserved vertical space at the bottom of the viewport for the dock, in px.
+ * Drawers and main-content spacers subtract this so they don't sit behind the dock.
+ * Maximized returns 0 — the dock covers everything by design.
+ */
+export function useDockReservedHeight(): number {
+  const { tabs, isExpanded, isMaximized, height } = useDock()
+  if (tabs.length === 0) return 0
+  if (isMaximized) return 0
+  if (!isExpanded) return DOCK_COLLAPSED_HEIGHT
+  return height
 }
 
 // Convenience hooks for adding specific tab types

--- a/packages/k8s-ui/src/components/dock/DockContext.tsx
+++ b/packages/k8s-ui/src/components/dock/DockContext.tsx
@@ -169,12 +169,20 @@ export function useDock() {
  * Reserved vertical space at the bottom of the viewport for the dock, in px.
  * Drawers and main-content spacers subtract this so they don't sit behind the dock.
  * Maximized returns 0 — the dock covers everything by design.
+ *
+ * Safe to call without a DockProvider ancestor (returns 0) — the shared
+ * @skyhook/k8s-ui package exports drawers that may be consumed without a dock.
  */
 export function useDockReservedHeight(): number {
-  const { tabs, isExpanded, isMaximized, height } = useDock()
+  const context = useContext(DockContext)
+  if (!context) return 0
+  const { tabs, isExpanded, isMaximized, height } = context
   if (tabs.length === 0) return 0
-  if (isMaximized) return 0
+  // Order matches BottomDock's effectiveHeight: collapsed tab bar wins over
+  // maximized so the (maximized=true, expanded=false) state — reachable by
+  // Cmd+J / Ctrl+` while maximized — still reserves the 36px tab bar height.
   if (!isExpanded) return DOCK_COLLAPSED_HEIGHT
+  if (isMaximized) return 0
   return height
 }
 

--- a/packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx
+++ b/packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useRef, type ReactNode } from 'react'
 import { TRANSITION_DRAWER } from '../../utils/animation'
 import { clsx } from 'clsx'
 import type { SelectedResource } from '../../types'
+import { useDockReservedHeight } from '../dock/DockContext'
 
 interface ResourceDetailDrawerProps {
   resource: SelectedResource
@@ -111,6 +112,7 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
   }, [expanded, onNavigateToResource, onNavigate])
 
   const headerHeight = headerHeightProp ?? 49
+  const dockInset = useDockReservedHeight()
 
   return (
     <div
@@ -125,7 +127,7 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
       style={{
         width: expanded ? `calc(100% - ${leftOffset}px)` : drawerWidth,
         top: headerHeight,
-        height: `calc(100% - ${headerHeight}px)`,
+        height: `calc(100% - ${headerHeight}px - ${dockInset}px)`,
         // Collapse is instant — no animation, content and width snap together.
         // Expand + slide-in/out animate via TRANSITION_DRAWER class.
         ...(isCollapsing && { transition: 'none' }),

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,7 +18,7 @@ import { CostView } from './components/cost/CostView'
 import { AuditView } from './components/audit/AuditView'
 import { HelmReleaseDrawer } from './components/helm/HelmReleaseDrawer'
 import { PortForwardProvider, PortForwardIndicator, PortForwardPanel } from './components/portforward/PortForwardManager'
-import { DockProvider, BottomDock, useDock, useOpenLocalTerminal } from './components/dock'
+import { DockProvider, BottomDock, useDock, useDockReservedHeight, useOpenLocalTerminal } from './components/dock'
 import { DURATION_DOCK } from '@skyhook-io/k8s-ui/utils/animation'
 import { ContextSwitcher } from './components/ContextSwitcher'
 import { NamespaceSwitcher, type NamespaceSwitcherHandle } from './components/NamespaceSwitcher'
@@ -1539,11 +1539,20 @@ function AppInner() {
 
 // Spacer component that adds padding when dock is open
 function DockSpacer() {
-  const { tabs, isExpanded } = useDock()
+  const { tabs, isResizing } = useDock()
+  const dockInset = useDockReservedHeight()
   const location = useLocation()
   // Traffic view manages its own layout — spacer would break its flex sizing
   if (tabs.length === 0 || location.pathname === '/traffic') return null
-  return <div className="shrink-0" style={{ height: isExpanded ? 300 : 36, transition: `height ${DURATION_DOCK}ms cubic-bezier(0.4, 0, 0.2, 1)` }} />
+  return (
+    <div
+      className="shrink-0"
+      style={{
+        height: dockInset,
+        transition: isResizing ? 'none' : `height ${DURATION_DOCK}ms cubic-bezier(0.4, 0, 0.2, 1)`,
+      }}
+    />
+  )
 }
 
 // Floating action buttons that position themselves above the dock

--- a/web/src/components/dock/DockContext.tsx
+++ b/web/src/components/dock/DockContext.tsx
@@ -2,6 +2,7 @@
 export {
   DockProvider,
   useDock,
+  useDockReservedHeight,
   useOpenTerminal,
   useOpenLogs,
   useOpenWorkloadLogs,

--- a/web/src/components/dock/index.ts
+++ b/web/src/components/dock/index.ts
@@ -1,2 +1,2 @@
-export { DockProvider, useDock, useOpenTerminal, useOpenLogs, useOpenWorkloadLogs, useOpenNodeTerminal, useOpenLocalTerminal } from './DockContext'
+export { DockProvider, useDock, useDockReservedHeight, useOpenTerminal, useOpenLogs, useOpenWorkloadLogs, useOpenNodeTerminal, useOpenLocalTerminal } from './DockContext'
 export { BottomDock } from './BottomDock'

--- a/web/src/components/helm/HelmReleaseDrawer.tsx
+++ b/web/src/components/helm/HelmReleaseDrawer.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { flushSync } from 'react-dom'
-import { PaneLoader } from '@skyhook-io/k8s-ui'
+import { PaneLoader, useDockReservedHeight } from '@skyhook-io/k8s-ui'
 import { startViewTransitionSafe } from '@skyhook-io/k8s-ui/utils/view-transition'
 import { TRANSITION_DRAWER } from '../../utils/animation'
 import { useRefreshAnimation } from '../../hooks/useRefreshAnimation'
@@ -279,6 +279,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
   }
 
   const headerHeight = 49
+  const dockInset = useDockReservedHeight()
 
   const tabs: { id: TabId; label: string; icon: typeof Package }[] = [
     { id: 'overview', label: 'Overview', icon: Package },
@@ -301,7 +302,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
         TRANSITION_DRAWER,
         isOpen ? 'translate-x-0 opacity-100' : 'translate-x-full opacity-0'
       )}
-      style={{ width: drawerWidth, top: headerHeight, height: `calc(100vh - ${headerHeight}px)` }}
+      style={{ width: drawerWidth, top: headerHeight, height: `calc(100vh - ${headerHeight}px - ${dockInset}px)` }}
     >
       {/* Resize handle */}
       <div


### PR DESCRIPTION
## Summary

Closes #678 — the right-side resource drawer (and the Helm release drawer) were sized to the full window height, so their bottom content and trailing scrollbar lived behind the bottom dock and couldn't be reached.

The dock's rendered height is now the single source of truth on `DockContext`, exposed via a new `useDockReservedHeight()` helper that knows about three states:

- no dock open → 0
- tab bar only (collapsed) → 36
- expanded → live drag height
- maximized → 0 (drawer should reflow to full viewport)

`ResourceDetailDrawer`, `HelmReleaseDrawer`, and `DockSpacer` all read from it, so each one shrinks to end exactly at the dock's top edge. The scrollbar tracks the visible region and bottom content is reachable.

## Resize sync

While dragging the dock's resize handle, the dock and `DockSpacer` had a 150ms height transition but the drawer had none, so the dock visibly trailed the drawer during fast drags. Added an `isResizing` flag on the context: while a drag is in flight, dock + spacer drop the height transition and follow the mouse 1:1. Collapse / expand / maximize still animate smoothly.

## Files

- `packages/k8s-ui/src/components/dock/DockContext.tsx` — lifted `height` / `isMaximized` / `isResizing` into the provider; added `useDockReservedHeight()`
- `packages/k8s-ui/src/components/dock/BottomDock.tsx` — reads from context; toggles `isResizing` around drag; suppresses height transition during drag
- `packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx` — bottom inset via `useDockReservedHeight()`
- `web/src/components/helm/HelmReleaseDrawer.tsx` — same treatment for Helm
- `web/src/App.tsx` — `DockSpacer` reads the live inset; suppresses transition during drag
- `web/src/components/dock/{DockContext,index}.tsx` — re-export the new helper

## Test plan

- [x] `make tsc` clean
- [x] Visual: drawer + dock at collapsed / expanded / resized / maximized
- [x] Drag dock handle — dock stays glued to mouse and drawer edge, no chasing
- [x] Same checks for the Helm release drawer

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes `DockContext` state shape and propagates dock sizing/maximize/resizing behavior across multiple UI surfaces, which could affect layout and animations in consumers.
> 
> **Overview**
> Fixes right-side drawers and main-content spacing being obscured by the bottom dock by making the dock’s *reserved height* a single source of truth.
> 
> `DockContext` now owns dock `height`, `isMaximized`, and a new `isResizing` flag, and exposes `useDockReservedHeight()`; `ResourceDetailDrawer`, `HelmReleaseDrawer`, and the app’s `DockSpacer` subtract this inset so scrollable content remains reachable above the dock.
> 
> While dragging the dock resize handle, the dock and spacer now suppress height transitions (via `isResizing`) so the dock edge tracks the mouse and stays visually aligned with drawers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4ed9ca53e61d8c28094400db512126ef6297c12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->