### PR TITLE
Preserve API group when navigating CRDs (#461) + fix large-cluster ns sync

### DIFF
--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -734,14 +734,16 @@ func parseManifestResources(manifest, defaultNamespace string) []OwnedResource {
 	manifests := releaseutil.SplitManifests(manifest)
 
 	for _, m := range manifests {
-		// Simple parsing - look for kind, name, and namespace
+		// Simple parsing - look for kind, apiVersion, name, and namespace
 		lines := strings.Split(m, "\n")
-		var kind, name, namespace string
+		var kind, apiVersion, name, namespace string
 
 		for _, line := range lines {
 			line = strings.TrimSpace(line)
 			if after, ok := strings.CutPrefix(line, "kind:"); ok {
 				kind = strings.TrimSpace(after)
+			} else if after, ok := strings.CutPrefix(line, "apiVersion:"); ok {
+				apiVersion = strings.Trim(strings.TrimSpace(after), `"'`)
 			} else if strings.HasPrefix(line, "name:") && name == "" {
 				// Only take first name (metadata.name, not container names etc)
 				name = strings.TrimSpace(strings.TrimPrefix(line, "name:"))
@@ -758,9 +760,10 @@ func parseManifestResources(manifest, defaultNamespace string) []OwnedResource {
 				namespace = defaultNamespace
 			}
 			resources = append(resources, OwnedResource{
-				Kind:      kind,
-				Name:      name,
-				Namespace: namespace,
+				Kind:       kind,
+				APIVersion: apiVersion,
+				Name:       name,
+				Namespace:  namespace,
 			})
 		}
 	}

--- a/internal/helm/types.go
+++ b/internal/helm/types.go
@@ -73,14 +73,15 @@ type ChartDependency struct {
 
 // OwnedResource represents a K8s resource created by a Helm release
 type OwnedResource struct {
-	Kind      string `json:"kind"`
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
-	Status    string `json:"status,omitempty"`  // Running, Pending, Failed, etc.
-	Ready     string `json:"ready,omitempty"`   // e.g., "3/3" for deployments
-	Message   string `json:"message,omitempty"` // Status message or reason
-	Summary   string `json:"summary,omitempty"` // Brief status like "0/3 OOMKilled"
-	Issue     string `json:"issue,omitempty"`   // Primary issue if unhealthy
+	Kind       string `json:"kind"`
+	APIVersion string `json:"apiVersion,omitempty"` // e.g. "apps/v1", "cluster.x-k8s.io/v1beta1" — disambiguates CRD kind collisions on navigation
+	Name       string `json:"name"`
+	Namespace  string `json:"namespace"`
+	Status     string `json:"status,omitempty"`  // Running, Pending, Failed, etc.
+	Ready      string `json:"ready,omitempty"`   // e.g., "3/3" for deployments
+	Message    string `json:"message,omitempty"` // Status message or reason
+	Summary    string `json:"summary,omitempty"` // Brief status like "0/3 OOMKilled"
+	Issue      string `json:"issue,omitempty"`   // Primary issue if unhealthy
 }
 
 // HelmValues represents the values for a release

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -385,6 +385,7 @@ func recordToTimelineStore(kind, namespace, name, uid, op string, oldObj, newObj
 	owner := timeline.ExtractOwner(obj)
 	labels := timeline.ExtractLabels(obj)
 	healthState := timeline.DetermineHealthState(kind, obj)
+	apiVersion := extractAPIVersion(obj)
 
 	var createdAt *time.Time
 	if obj != nil {
@@ -438,7 +439,7 @@ func recordToTimelineStore(kind, namespace, name, uid, op string, oldObj, newObj
 	}
 
 	event := timeline.NewInformerEvent(
-		kind, namespace, name, uid,
+		kind, apiVersion, namespace, name, uid,
 		timeline.OperationToEventType(op),
 		healthState,
 		diff,
@@ -449,7 +450,7 @@ func recordToTimelineStore(kind, namespace, name, uid, op string, oldObj, newObj
 
 	var events []timeline.TimelineEvent
 	if op == "add" && newObj != nil {
-		historicalEvents := extractTimelineHistoricalEvents(kind, namespace, name, newObj, owner, labels)
+		historicalEvents := extractTimelineHistoricalEvents(kind, apiVersion, namespace, name, newObj, owner, labels)
 		events = append(events, historicalEvents...)
 	}
 
@@ -503,19 +504,30 @@ func recordToTimelineStore(kind, namespace, name, uid, op string, oldObj, newObj
 	}
 }
 
+// extractAPIVersion returns the resource's apiVersion (e.g. "cluster.x-k8s.io/v1beta1")
+// for unstructured/CRD objects. Typed informer objects strip kind/apiVersion, so they
+// fall through to "" — the navigation layer treats an empty group as "core/typed kind",
+// which is correct since core kinds don't collide.
+func extractAPIVersion(obj any) string {
+	if u, ok := obj.(*unstructured.Unstructured); ok {
+		return u.GetAPIVersion()
+	}
+	return ""
+}
+
 // extractTimelineHistoricalEvents extracts historical events from resource metadata/status
-func extractTimelineHistoricalEvents(kind, namespace, name string, obj any, owner *timeline.OwnerInfo, labels map[string]string) []timeline.TimelineEvent {
+func extractTimelineHistoricalEvents(kind, apiVersion, namespace, name string, obj any, owner *timeline.OwnerInfo, labels map[string]string) []timeline.TimelineEvent {
 	var events []timeline.TimelineEvent
 
 	switch kind {
 	case "Pod":
 		if pod, ok := obj.(*corev1.Pod); ok {
 			if !pod.CreationTimestamp.IsZero() {
-				events = append(events, timeline.NewHistoricalEvent(kind, namespace, name,
+				events = append(events, timeline.NewHistoricalEvent(kind, apiVersion, namespace, name,
 					pod.CreationTimestamp.Time, "created", "", timeline.HealthUnknown, owner, labels))
 			}
 			if pod.Status.StartTime != nil && !pod.Status.StartTime.IsZero() {
-				events = append(events, timeline.NewHistoricalEvent(kind, namespace, name,
+				events = append(events, timeline.NewHistoricalEvent(kind, apiVersion, namespace, name,
 					pod.Status.StartTime.Time, "started", "", timeline.HealthDegraded, owner, labels))
 			}
 			for _, cond := range pod.Status.Conditions {
@@ -528,7 +540,7 @@ func extractTimelineHistoricalEvents(kind, namespace, name string, obj any, owne
 				} else if cond.Status == corev1.ConditionFalse {
 					health = timeline.HealthDegraded
 				}
-				events = append(events, timeline.NewHistoricalEvent(kind, namespace, name,
+				events = append(events, timeline.NewHistoricalEvent(kind, apiVersion, namespace, name,
 					cond.LastTransitionTime.Time, string(cond.Type), cond.Message, health, owner, labels))
 			}
 		}
@@ -536,7 +548,7 @@ func extractTimelineHistoricalEvents(kind, namespace, name string, obj any, owne
 	case "Deployment":
 		if deploy, ok := obj.(*appsv1.Deployment); ok {
 			if !deploy.CreationTimestamp.IsZero() {
-				events = append(events, timeline.NewHistoricalEvent(kind, namespace, name,
+				events = append(events, timeline.NewHistoricalEvent(kind, apiVersion, namespace, name,
 					deploy.CreationTimestamp.Time, "created", "", timeline.HealthUnknown, owner, labels))
 			}
 			for _, cond := range deploy.Status.Conditions {
@@ -549,7 +561,7 @@ func extractTimelineHistoricalEvents(kind, namespace, name string, obj any, owne
 				} else if cond.Status == corev1.ConditionFalse {
 					health = timeline.HealthDegraded
 				}
-				events = append(events, timeline.NewHistoricalEvent(kind, namespace, name,
+				events = append(events, timeline.NewHistoricalEvent(kind, apiVersion, namespace, name,
 					cond.LastTransitionTime.Time, string(cond.Type), cond.Message, health, owner, labels))
 			}
 		}
@@ -561,7 +573,7 @@ func extractTimelineHistoricalEvents(kind, namespace, name string, obj any, owne
 				if rs.Status.ReadyReplicas > 0 && rs.Status.ReadyReplicas == rs.Status.Replicas {
 					health = timeline.HealthHealthy
 				}
-				events = append(events, timeline.NewHistoricalEvent(kind, namespace, name,
+				events = append(events, timeline.NewHistoricalEvent(kind, apiVersion, namespace, name,
 					rs.CreationTimestamp.Time, "created", "", health, owner, labels))
 			}
 		}
@@ -569,7 +581,7 @@ func extractTimelineHistoricalEvents(kind, namespace, name string, obj any, owne
 	case "StatefulSet":
 		if sts, ok := obj.(*appsv1.StatefulSet); ok {
 			if !sts.CreationTimestamp.IsZero() {
-				events = append(events, timeline.NewHistoricalEvent(kind, namespace, name,
+				events = append(events, timeline.NewHistoricalEvent(kind, apiVersion, namespace, name,
 					sts.CreationTimestamp.Time, "created", "", timeline.HealthUnknown, owner, labels))
 			}
 		}
@@ -577,7 +589,7 @@ func extractTimelineHistoricalEvents(kind, namespace, name string, obj any, owne
 	case "DaemonSet":
 		if ds, ok := obj.(*appsv1.DaemonSet); ok {
 			if !ds.CreationTimestamp.IsZero() {
-				events = append(events, timeline.NewHistoricalEvent(kind, namespace, name,
+				events = append(events, timeline.NewHistoricalEvent(kind, apiVersion, namespace, name,
 					ds.CreationTimestamp.Time, "created", "", timeline.HealthUnknown, owner, labels))
 			}
 		}
@@ -585,7 +597,7 @@ func extractTimelineHistoricalEvents(kind, namespace, name string, obj any, owne
 	case "Service":
 		if svc, ok := obj.(*corev1.Service); ok {
 			if !svc.CreationTimestamp.IsZero() {
-				events = append(events, timeline.NewHistoricalEvent(kind, namespace, name,
+				events = append(events, timeline.NewHistoricalEvent(kind, apiVersion, namespace, name,
 					svc.CreationTimestamp.Time, "created", "", timeline.HealthHealthy, owner, labels))
 			}
 		}
@@ -593,7 +605,7 @@ func extractTimelineHistoricalEvents(kind, namespace, name string, obj any, owne
 	case "Ingress":
 		if ing, ok := obj.(*networkingv1.Ingress); ok {
 			if !ing.CreationTimestamp.IsZero() {
-				events = append(events, timeline.NewHistoricalEvent(kind, namespace, name,
+				events = append(events, timeline.NewHistoricalEvent(kind, apiVersion, namespace, name,
 					ing.CreationTimestamp.Time, "created", "", timeline.HealthHealthy, owner, labels))
 			}
 		}
@@ -601,7 +613,7 @@ func extractTimelineHistoricalEvents(kind, namespace, name string, obj any, owne
 	case "CronJob":
 		if cj, ok := obj.(*batchv1.CronJob); ok {
 			if !cj.CreationTimestamp.IsZero() {
-				events = append(events, timeline.NewHistoricalEvent(kind, namespace, name,
+				events = append(events, timeline.NewHistoricalEvent(kind, apiVersion, namespace, name,
 					cj.CreationTimestamp.Time, "created", "", timeline.HealthHealthy, owner, labels))
 			}
 		}
@@ -609,7 +621,7 @@ func extractTimelineHistoricalEvents(kind, namespace, name string, obj any, owne
 	case "HorizontalPodAutoscaler":
 		if hpa, ok := obj.(*autoscalingv2.HorizontalPodAutoscaler); ok {
 			if !hpa.CreationTimestamp.IsZero() {
-				events = append(events, timeline.NewHistoricalEvent(kind, namespace, name,
+				events = append(events, timeline.NewHistoricalEvent(kind, apiVersion, namespace, name,
 					hpa.CreationTimestamp.Time, "created", "", timeline.HealthHealthy, owner, labels))
 			}
 		}
@@ -617,11 +629,11 @@ func extractTimelineHistoricalEvents(kind, namespace, name string, obj any, owne
 	case "Job":
 		if job, ok := obj.(*batchv1.Job); ok {
 			if !job.CreationTimestamp.IsZero() {
-				events = append(events, timeline.NewHistoricalEvent(kind, namespace, name,
+				events = append(events, timeline.NewHistoricalEvent(kind, apiVersion, namespace, name,
 					job.CreationTimestamp.Time, "created", "", timeline.HealthUnknown, owner, labels))
 			}
 			if job.Status.StartTime != nil && !job.Status.StartTime.IsZero() {
-				events = append(events, timeline.NewHistoricalEvent(kind, namespace, name,
+				events = append(events, timeline.NewHistoricalEvent(kind, apiVersion, namespace, name,
 					job.Status.StartTime.Time, "started", "", timeline.HealthDegraded, owner, labels))
 			}
 			if job.Status.CompletionTime != nil && !job.Status.CompletionTime.IsZero() {
@@ -629,7 +641,7 @@ func extractTimelineHistoricalEvents(kind, namespace, name string, obj any, owne
 				if job.Status.Failed > 0 {
 					health = timeline.HealthUnhealthy
 				}
-				events = append(events, timeline.NewHistoricalEvent(kind, namespace, name,
+				events = append(events, timeline.NewHistoricalEvent(kind, apiVersion, namespace, name,
 					job.Status.CompletionTime.Time, "completed", "", health, owner, labels))
 			}
 		}
@@ -638,7 +650,7 @@ func extractTimelineHistoricalEvents(kind, namespace, name string, obj any, owne
 		if u, ok := obj.(*unstructured.Unstructured); ok {
 			ct := u.GetCreationTimestamp()
 			if !ct.IsZero() {
-				events = append(events, timeline.NewHistoricalEvent(kind, namespace, name,
+				events = append(events, timeline.NewHistoricalEvent(kind, apiVersion, namespace, name,
 					ct.Time, "created", "", timeline.HealthUnknown, owner, labels))
 			}
 		}

--- a/internal/timeline/manager.go
+++ b/internal/timeline/manager.go
@@ -85,14 +85,14 @@ func ResourceKey(kind, namespace, name string) string {
 }
 
 // Converter functions.
-func NewInformerEvent(kind, namespace, name, uid string, operation EventType, healthState HealthState, diff *DiffInfo, owner *OwnerInfo, labels map[string]string, createdAt *time.Time) TimelineEvent {
-	return pkgtimeline.NewInformerEvent(kind, namespace, name, uid, operation, healthState, diff, owner, labels, createdAt)
+func NewInformerEvent(kind, apiVersion, namespace, name, uid string, operation EventType, healthState HealthState, diff *DiffInfo, owner *OwnerInfo, labels map[string]string, createdAt *time.Time) TimelineEvent {
+	return pkgtimeline.NewInformerEvent(kind, apiVersion, namespace, name, uid, operation, healthState, diff, owner, labels, createdAt)
 }
 func NewK8sEventTimelineEvent(event *corev1.Event, owner *OwnerInfo) TimelineEvent {
 	return pkgtimeline.NewK8sEventTimelineEvent(event, owner)
 }
-func NewHistoricalEvent(kind, namespace, name string, ts time.Time, reason, message string, healthState HealthState, owner *OwnerInfo, labels map[string]string) TimelineEvent {
-	return pkgtimeline.NewHistoricalEvent(kind, namespace, name, ts, reason, message, healthState, owner, labels)
+func NewHistoricalEvent(kind, apiVersion, namespace, name string, ts time.Time, reason, message string, healthState HealthState, owner *OwnerInfo, labels map[string]string) TimelineEvent {
+	return pkgtimeline.NewHistoricalEvent(kind, apiVersion, namespace, name, ts, reason, message, healthState, owner, labels)
 }
 func ExtractOwner(obj any) *OwnerInfo         { return pkgtimeline.ExtractOwner(obj) }
 func ExtractLabels(obj any) map[string]string { return pkgtimeline.ExtractLabels(obj) }

--- a/internal/timeline/sqlite_store.go
+++ b/internal/timeline/sqlite_store.go
@@ -131,8 +131,39 @@ func (s *SQLiteStore) initSchema() error {
 	);
 	`
 
-	_, err := s.db.Exec(schema)
-	return err
+	if _, err := s.db.Exec(schema); err != nil {
+		return err
+	}
+
+	// Additive migration: api_version column added to disambiguate CRD kind collisions
+	// on navigation. ALTER TABLE on an existing column errors with "duplicate column",
+	// so detect via PRAGMA before adding.
+	rows, err := s.db.Query("PRAGMA table_info(events)")
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	hasAPIVersion := false
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var notnull, pk int
+		var dfltValue sql.NullString
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dfltValue, &pk); err != nil {
+			return err
+		}
+		if name == "api_version" {
+			hasAPIVersion = true
+			break
+		}
+	}
+	if !hasAPIVersion {
+		if _, err := s.db.Exec("ALTER TABLE events ADD COLUMN api_version TEXT"); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // Append adds a single event to the store
@@ -154,10 +185,10 @@ func (s *SQLiteStore) AppendBatch(ctx context.Context, events []TimelineEvent) e
 
 	stmt, err := tx.PrepareContext(ctx, `
 		INSERT OR IGNORE INTO events (
-			id, timestamp, source, kind, namespace, name, uid, event_type,
+			id, timestamp, source, kind, api_version, namespace, name, uid, event_type,
 			reason, message, diff_json, health_state, owner_kind, owner_name,
 			labels_json, count, correlation_id
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare statement: %w", err)
@@ -195,6 +226,7 @@ func (s *SQLiteStore) AppendBatch(ctx context.Context, events []TimelineEvent) e
 			event.Timestamp.Format(time.RFC3339Nano),
 			string(event.Source),
 			event.Kind,
+			event.APIVersion,
 			event.Namespace,
 			event.Name,
 			event.UID,
@@ -221,7 +253,7 @@ func (s *SQLiteStore) AppendBatch(ctx context.Context, events []TimelineEvent) e
 func (s *SQLiteStore) Query(ctx context.Context, opts QueryOptions) ([]TimelineEvent, error) {
 	// Build query
 	query := strings.Builder{}
-	query.WriteString("SELECT id, timestamp, source, kind, namespace, name, uid, event_type, ")
+	query.WriteString("SELECT id, timestamp, source, kind, api_version, namespace, name, uid, event_type, ")
 	query.WriteString("reason, message, diff_json, health_state, owner_kind, owner_name, ")
 	query.WriteString("labels_json, count, correlation_id FROM events WHERE 1=1")
 
@@ -390,7 +422,7 @@ func (s *SQLiteStore) QueryGrouped(ctx context.Context, opts QueryOptions) (*Tim
 
 // GetEvent retrieves a single event by ID
 func (s *SQLiteStore) GetEvent(ctx context.Context, id string) (*TimelineEvent, error) {
-	query := `SELECT id, timestamp, source, kind, namespace, name, uid, event_type,
+	query := `SELECT id, timestamp, source, kind, api_version, namespace, name, uid, event_type,
 		reason, message, diff_json, health_state, owner_kind, owner_name,
 		labels_json, count, correlation_id FROM events WHERE id = ?`
 
@@ -411,7 +443,7 @@ func (s *SQLiteStore) GetChangesForOwner(ctx context.Context, ownerKind, ownerNa
 		limit = 100
 	}
 
-	query := `SELECT id, timestamp, source, kind, namespace, name, uid, event_type,
+	query := `SELECT id, timestamp, source, kind, api_version, namespace, name, uid, event_type,
 		reason, message, diff_json, health_state, owner_kind, owner_name,
 		labels_json, count, correlation_id FROM events
 		WHERE owner_kind = ? AND owner_name = ? AND namespace = ?`
@@ -626,7 +658,7 @@ func (s *SQLiteStore) scanEvent(rows *sql.Rows) (TimelineEvent, error) {
 	var event TimelineEvent
 	var timestamp string
 	var source, eventType, healthState string
-	var uid, reason, message, diffJSON, labelsJSON sql.NullString
+	var apiVersion, uid, reason, message, diffJSON, labelsJSON sql.NullString
 	var ownerKind, ownerName, correlationID sql.NullString
 
 	err := rows.Scan(
@@ -634,6 +666,7 @@ func (s *SQLiteStore) scanEvent(rows *sql.Rows) (TimelineEvent, error) {
 		&timestamp,
 		&source,
 		&event.Kind,
+		&apiVersion,
 		&event.Namespace,
 		&event.Name,
 		&uid,
@@ -657,6 +690,9 @@ func (s *SQLiteStore) scanEvent(rows *sql.Rows) (TimelineEvent, error) {
 	event.EventType = EventType(eventType)
 	event.HealthState = HealthState(healthState)
 
+	if apiVersion.Valid {
+		event.APIVersion = apiVersion.String
+	}
 	if uid.Valid {
 		event.UID = uid.String
 	}
@@ -696,7 +732,7 @@ func (s *SQLiteStore) scanEventRow(row *sql.Row) (TimelineEvent, error) {
 	var event TimelineEvent
 	var timestamp string
 	var source, eventType, healthState string
-	var uid, reason, message, diffJSON, labelsJSON sql.NullString
+	var apiVersion, uid, reason, message, diffJSON, labelsJSON sql.NullString
 	var ownerKind, ownerName, correlationID sql.NullString
 
 	err := row.Scan(
@@ -704,6 +740,7 @@ func (s *SQLiteStore) scanEventRow(row *sql.Row) (TimelineEvent, error) {
 		&timestamp,
 		&source,
 		&event.Kind,
+		&apiVersion,
 		&event.Namespace,
 		&event.Name,
 		&uid,
@@ -727,6 +764,9 @@ func (s *SQLiteStore) scanEventRow(row *sql.Row) (TimelineEvent, error) {
 	event.EventType = EventType(eventType)
 	event.HealthState = HealthState(healthState)
 
+	if apiVersion.Valid {
+		event.APIVersion = apiVersion.String
+	}
 	if uid.Valid {
 		event.UID = uid.String
 	}

--- a/packages/k8s-ui/src/components/timeline/TimelineList.tsx
+++ b/packages/k8s-ui/src/components/timeline/TimelineList.tsx
@@ -22,7 +22,7 @@ import { isChangeEvent, isK8sEvent, isHistoricalEvent, isOperation } from '../..
 import { getOperationColor, getHealthBadgeColor, SEVERITY_BADGE } from '../../utils/badge-colors'
 import { ResourceRefBadge } from '../ui/drawer-components'
 import type { NavigateToResource } from '../../utils/navigation'
-import { kindToPlural, refToSelectedResource } from '../../utils/navigation'
+import { kindToPlural, refToSelectedResource, apiVersionToGroup } from '../../utils/navigation'
 import { pluralize } from '../../utils/pluralize'
 import { useRegisterShortcut } from '../../hooks/useKeyboardShortcuts'
 
@@ -589,7 +589,7 @@ function ActivityCard({ item, expanded, onToggle, onResourceClick }: ActivityCar
               <button
                 onClick={(e) => {
                   e.stopPropagation()
-                  onResourceClick?.({ kind: kindToPlural(item.kind), namespace: item.namespace, name: item.name })
+                  onResourceClick?.({ kind: kindToPlural(item.kind), namespace: item.namespace, name: item.name, group: apiVersionToGroup(item.apiVersion) })
                 }}
                 className="flex items-center gap-2 hover:bg-theme-elevated/50 rounded px-1 -ml-1 transition-colors group"
               >
@@ -732,7 +732,7 @@ function AggregatedActivityCard({ first, last, count, reason, expanded, onToggle
               <button
                 onClick={(e) => {
                   e.stopPropagation()
-                  onResourceClick?.({ kind: kindToPlural(first.kind), namespace: first.namespace, name: first.name })
+                  onResourceClick?.({ kind: kindToPlural(first.kind), namespace: first.namespace, name: first.name, group: apiVersionToGroup(first.apiVersion) })
                 }}
                 className="flex items-center gap-2 hover:bg-theme-elevated/50 rounded px-1 -ml-1 transition-colors group"
               >

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -237,6 +237,7 @@ export interface TimelineEvent {
 
   // Resource identity
   kind: string
+  apiVersion?: string // e.g. "apps/v1", "cluster.x-k8s.io/v1beta1" — empty for older backends
   namespace: string
   name: string
   uid?: string
@@ -507,6 +508,7 @@ export interface ChartDependency {
 
 export interface HelmOwnedResource {
   kind: string
+  apiVersion?: string // e.g. "apps/v1", "cluster.x-k8s.io/v1beta1" — empty for older backends
   name: string
   namespace: string
   status?: string   // Running, Pending, Failed, Active, etc.

--- a/packages/k8s-ui/src/utils/navigation.ts
+++ b/packages/k8s-ui/src/utils/navigation.ts
@@ -142,3 +142,17 @@ export function refToSelectedResource(ref: ResourceRef): SelectedResource {
     group: ref.group,
   }
 }
+
+/**
+ * Extract the API group from an apiVersion string.
+ * Returns '' for core resources (e.g. "v1") and for missing/empty input.
+ * Examples:
+ *   "v1"                          → ""
+ *   "apps/v1"                     → "apps"
+ *   "cluster.x-k8s.io/v1beta1"    → "cluster.x-k8s.io"
+ */
+export function apiVersionToGroup(apiVersion?: string | null): string {
+  if (!apiVersion) return ''
+  const i = apiVersion.indexOf('/')
+  return i === -1 ? '' : apiVersion.slice(0, i)
+}

--- a/packages/k8s-ui/src/utils/resource-hierarchy.ts
+++ b/packages/k8s-ui/src/utils/resource-hierarchy.ts
@@ -13,6 +13,7 @@
 
 import type { TimelineEvent, Topology } from '../types/core'
 import { isWorkloadKind } from '../types/core'
+import { apiVersionToGroup } from './navigation'
 
 /**
  * Resource lane representing a single resource and its timeline events.
@@ -21,6 +22,12 @@ import { isWorkloadKind } from '../types/core'
 export interface ResourceLane {
   id: string
   kind: string
+  /**
+   * API group for the resource (e.g. "cluster.x-k8s.io"). Empty for core
+   * resources. Needed to disambiguate CRDs whose kind collides with another
+   * (e.g. CAPI Cluster vs CNPG Cluster) when the lane is clicked.
+   */
+  group?: string
   namespace: string
   name: string
   events: TimelineEvent[]
@@ -179,6 +186,25 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
   const { events, topology, rootResource, groupByApp = true } = options
   const laneMap = new Map<string, ResourceLane>()
 
+  // API group lookup by lane ID (kind/namespace/name) sourced from topology nodes.
+  // Lanes built from events (which carry apiVersion) take precedence over this fallback,
+  // but parent lanes that exist only as edge endpoints still need a group.
+  const topoGroupByLaneId = new Map<string, string>()
+  if (topology?.nodes) {
+    for (const node of topology.nodes) {
+      const laneId = nodeIdToLaneId(node.id)
+      if (!laneId) continue
+      const apiVersion = node.data?.apiVersion as string | undefined
+      const group = apiVersionToGroup(apiVersion)
+      if (group) topoGroupByLaneId.set(laneId, group)
+    }
+  }
+  const resolveGroup = (laneId: string, event?: TimelineEvent): string => {
+    const fromEvent = apiVersionToGroup(event?.apiVersion)
+    if (fromEvent) return fromEvent
+    return topoGroupByLaneId.get(laneId) ?? ''
+  }
+
   // Track events that should be attached to their owner instead of their own lane
   const eventsToAttach: { event: TimelineEvent; ownerLaneId: string }[] = []
 
@@ -192,19 +218,28 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
     }
 
     const laneId = `${event.kind}/${event.namespace}/${event.name}`
-    if (!laneMap.has(laneId)) {
+    const existing = laneMap.get(laneId)
+    if (!existing) {
       laneMap.set(laneId, {
         id: laneId,
         kind: event.kind,
+        group: resolveGroup(laneId, event),
         namespace: event.namespace,
         name: event.name,
-        events: [],
+        events: [event],
         isWorkload: isWorkloadKind(event.kind),
         children: [],
         childEventCount: 0,
       })
+    } else {
+      // Older SQLite-stored events may lack apiVersion (column added by migration);
+      // pick up the group from any subsequent event that carries it.
+      if (!existing.group) {
+        const fromEvent = apiVersionToGroup(event.apiVersion)
+        if (fromEvent) existing.group = fromEvent
+      }
+      existing.events.push(event)
     }
-    laneMap.get(laneId)!.events.push(event)
   }
 
   // Attach K8s Events to their owner lanes
@@ -218,6 +253,7 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
       laneMap.set(ownerLaneId, {
         id: ownerLaneId,
         kind: parts[0],
+        group: resolveGroup(ownerLaneId),
         namespace: parts[1],
         name: parts.slice(2).join('/'),
         events: [event],
@@ -242,6 +278,7 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
         laneMap.set(ownerLaneId, {
           id: ownerLaneId,
           kind: eventWithOwner.owner.kind,
+          group: resolveGroup(ownerLaneId),
           namespace: lane.namespace,
           name: eventWithOwner.owner.name,
           events: [],
@@ -277,6 +314,7 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
             laneMap.set(sourceLaneId, {
               id: sourceLaneId,
               kind: parts[0],
+              group: resolveGroup(sourceLaneId),
               namespace: parts[1],
               name: parts.slice(2).join('/'),
               events: [],
@@ -304,6 +342,7 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
               laneMap.set(sourceLaneId, {
                 id: sourceLaneId,
                 kind: parts[0],
+                group: resolveGroup(sourceLaneId),
                 namespace: parts[1],
                 name: parts.slice(2).join('/'),
                 events: [],
@@ -323,6 +362,7 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
               laneMap.set(targetLaneId, {
                 id: targetLaneId,
                 kind: parts[0],
+                group: resolveGroup(targetLaneId),
                 namespace: parts[1],
                 name: parts.slice(2).join('/'),
                 events: [],
@@ -342,6 +382,7 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
               laneMap.set(targetLaneId, {
                 id: targetLaneId,
                 kind: parts[0],
+                group: resolveGroup(targetLaneId),
                 namespace: parts[1],
                 name: parts.slice(2).join('/'),
                 events: [],
@@ -361,6 +402,7 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
               laneMap.set(sourceLaneId, {
                 id: sourceLaneId,
                 kind: parts[0],
+                group: resolveGroup(sourceLaneId),
                 namespace: parts[1],
                 name: parts.slice(2).join('/'),
                 events: [],
@@ -382,6 +424,7 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
             laneMap.set(targetLaneId, {
               id: targetLaneId,
               kind: parts[0],
+              group: resolveGroup(targetLaneId),
               namespace: parts[1],
               name: parts.slice(2).join('/'),
               events: [],
@@ -582,6 +625,7 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
     const placeholderLane: ResourceLane = {
       id: rootLaneId,
       kind: rootResource.kind,
+      group: resolveGroup(rootLaneId),
       namespace: rootResource.namespace,
       name: rootResource.name,
       events: [],

--- a/pkg/timeline/converter.go
+++ b/pkg/timeline/converter.go
@@ -13,12 +13,15 @@ import (
 
 // NewInformerEvent creates a TimelineEvent from an informer callback
 // createdAt is the resource's metadata.creationTimestamp (when K8s actually created it)
-func NewInformerEvent(kind, namespace, name, uid string, operation EventType, healthState HealthState, diff *DiffInfo, owner *OwnerInfo, labels map[string]string, createdAt *time.Time) TimelineEvent {
+// apiVersion (e.g. "apps/v1", "cluster.x-k8s.io/v1beta1") disambiguates CRD kind
+// collisions on navigation; pass "" if unknown (older callers).
+func NewInformerEvent(kind, apiVersion, namespace, name, uid string, operation EventType, healthState HealthState, diff *DiffInfo, owner *OwnerInfo, labels map[string]string, createdAt *time.Time) TimelineEvent {
 	return TimelineEvent{
 		ID:          uuid.New().String(),
 		Timestamp:   time.Now(),
 		Source:      SourceInformer,
 		Kind:        kind,
+		APIVersion:  apiVersion,
 		Namespace:   namespace,
 		Name:        name,
 		UID:         uid,
@@ -48,23 +51,26 @@ func NewK8sEventTimelineEvent(event *corev1.Event, owner *OwnerInfo) TimelineEve
 	}
 
 	return TimelineEvent{
-		ID:        string(event.UID),
-		Timestamp: ts,
-		Source:    SourceK8sEvent,
-		Kind:      event.InvolvedObject.Kind,
-		Namespace: event.Namespace,
-		Name:      event.InvolvedObject.Name,
-		EventType: evtType,
-		Reason:    event.Reason,
-		Message:   event.Message,
-		Owner:     owner,
-		Count:     event.Count,
+		ID:         string(event.UID),
+		Timestamp:  ts,
+		Source:     SourceK8sEvent,
+		Kind:       event.InvolvedObject.Kind,
+		APIVersion: event.InvolvedObject.APIVersion,
+		Namespace:  event.Namespace,
+		Name:       event.InvolvedObject.Name,
+		EventType:  evtType,
+		Reason:     event.Reason,
+		Message:    event.Message,
+		Owner:      owner,
+		Count:      event.Count,
 	}
 }
 
 // NewHistoricalEvent creates a historical TimelineEvent
 // The ID is deterministic based on the event content to avoid duplicates on restart
-func NewHistoricalEvent(kind, namespace, name string, ts time.Time, reason, message string, healthState HealthState, owner *OwnerInfo, labels map[string]string) TimelineEvent {
+// apiVersion (e.g. "apps/v1", "cluster.x-k8s.io/v1beta1") disambiguates CRD kind
+// collisions on navigation; pass "" if unknown.
+func NewHistoricalEvent(kind, apiVersion, namespace, name string, ts time.Time, reason, message string, healthState HealthState, owner *OwnerInfo, labels map[string]string) TimelineEvent {
 	// Create deterministic ID from event attributes to avoid duplicates
 	hashInput := fmt.Sprintf("historical:%s/%s/%s:%d:%s", kind, namespace, name, ts.UnixNano(), reason)
 	hash := sha256.Sum256([]byte(hashInput))
@@ -75,6 +81,7 @@ func NewHistoricalEvent(kind, namespace, name string, ts time.Time, reason, mess
 		Timestamp:   ts,
 		Source:      SourceHistorical,
 		Kind:        kind,
+		APIVersion:  apiVersion,
 		Namespace:   namespace,
 		Name:        name,
 		EventType:   EventTypeUpdate, // Historical events are shown as updates

--- a/pkg/timeline/types.go
+++ b/pkg/timeline/types.go
@@ -76,10 +76,11 @@ type TimelineEvent struct {
 	Source    EventSource `json:"source"`
 
 	// Resource identity
-	Kind      string `json:"kind"`
-	Namespace string `json:"namespace"`
-	Name      string `json:"name"`
-	UID       string `json:"uid,omitempty"`
+	Kind       string `json:"kind"`
+	APIVersion string `json:"apiVersion,omitempty"` // e.g. "apps/v1", "cluster.x-k8s.io/v1beta1" — disambiguates CRD kind collisions on navigation
+	Namespace  string `json:"namespace"`
+	Name       string `json:"name"`
+	UID        string `json:"uid,omitempty"`
 
 	// Resource metadata - when the resource was actually created in K8s
 	// This is different from Timestamp which is when we observed the event

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -357,6 +357,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 					"totalReplicas": total,
 					"strategy":      strategy,
 					"labels":        rollout.GetLabels(),
+					"apiVersion":    rollout.GetAPIVersion(),
 				},
 			})
 
@@ -387,9 +388,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	if resourceDiscovery != nil {
 		applicationGVR, hasApplications = resourceDiscovery.GetGVRWithGroup("Application", "argoproj.io")
 	}
-	applicationIDs := make(map[string]string)                          // ns/name -> applicationID
-	var applicationResources []*unstructured.Unstructured              // Store for second pass
-	applicationDestNamespaces := make(map[string]string)               // appID -> destNamespace
+	applicationIDs := make(map[string]string)             // ns/name -> applicationID
+	var applicationResources []*unstructured.Unstructured // Store for second pass
+	applicationDestNamespaces := make(map[string]string)  // appID -> destNamespace
 	if hasApplications && dynamicCache != nil {
 		applications, err := dynamicCache.List(applicationGVR, opts.NamespaceFilter())
 		if err != nil {
@@ -461,12 +462,13 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: nodeStatus,
 				Data: map[string]any{
-					"namespace":         ns,
-					"syncStatus":        syncStatus,
-					"healthStatus":      healthStatus,
-					"destination":       destination,
-					"destNamespace":     destNamespace,
-					"labels":            app.GetLabels(),
+					"namespace":     ns,
+					"syncStatus":    syncStatus,
+					"healthStatus":  healthStatus,
+					"destination":   destination,
+					"destNamespace": destNamespace,
+					"labels":        app.GetLabels(),
+					"apiVersion":    app.GetAPIVersion(),
 				},
 			})
 
@@ -483,8 +485,8 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	if resourceDiscovery != nil {
 		kustomizationGVR, hasKustomizations = resourceDiscovery.GetGVR("Kustomization")
 	}
-	kustomizationIDs := make(map[string]string)               // ns/name -> kustomizationID
-	var kustomizationResources []*unstructured.Unstructured   // Store for second pass
+	kustomizationIDs := make(map[string]string)             // ns/name -> kustomizationID
+	var kustomizationResources []*unstructured.Unstructured // Store for second pass
 	if hasKustomizations && dynamicCache != nil {
 		kustomizations, err := dynamicCache.List(kustomizationGVR, opts.NamespaceFilter())
 		if err != nil {
@@ -539,6 +541,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 					"resourceCount": resourceCount,
 					"sourceRef":     sourceRef,
 					"labels":        ks.GetLabels(),
+					"apiVersion":    ks.GetAPIVersion(),
 				},
 			})
 
@@ -601,11 +604,12 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: nodeStatus,
 				Data: map[string]any{
-					"namespace": ns,
-					"ready":     readyStatus,
-					"branch":    branch,
-					"url":       url,
-					"labels":    repo.GetLabels(),
+					"namespace":  ns,
+					"ready":      readyStatus,
+					"branch":     branch,
+					"url":        url,
+					"labels":     repo.GetLabels(),
+					"apiVersion": repo.GetAPIVersion(),
 				},
 			})
 		}
@@ -677,6 +681,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 					"chartName":    chartName,
 					"chartVersion": chartVersion,
 					"labels":       hr.GetLabels(),
+					"apiVersion":   hr.GetAPIVersion(),
 				},
 			})
 		}
@@ -710,8 +715,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractCertificateStatus(*cert),
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    cert.GetLabels(),
+					"namespace":  ns,
+					"labels":     cert.GetLabels(),
+					"apiVersion": cert.GetAPIVersion(),
 				},
 			})
 			certificateResources = append(certificateResources, *cert)
@@ -750,8 +756,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractKarpenterNodePoolStatus(*np),
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    np.GetLabels(),
+					"namespace":  ns,
+					"labels":     np.GetLabels(),
+					"apiVersion": np.GetAPIVersion(),
 				},
 			})
 		}
@@ -782,8 +789,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractKarpenterNodeClaimStatus(*nc),
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    nc.GetLabels(),
+					"namespace":  ns,
+					"labels":     nc.GetLabels(),
+					"apiVersion": nc.GetAPIVersion(),
 				},
 			})
 
@@ -888,8 +896,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractKarpenterNodePoolStatus(*nc), // Same Ready condition pattern
 				Data: map[string]any{
-					"namespace": "",
-					"labels":    nc.GetLabels(),
+					"namespace":  "",
+					"labels":     nc.GetLabels(),
+					"apiVersion": nc.GetAPIVersion(),
 				},
 			})
 		}
@@ -945,8 +954,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractKedaScaledObjectStatus(*so),
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    so.GetLabels(),
+					"namespace":  ns,
+					"labels":     so.GetLabels(),
+					"apiVersion": so.GetAPIVersion(),
 				},
 			})
 
@@ -1004,8 +1014,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractKedaScaledJobStatus(*sj),
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    sj.GetLabels(),
+					"namespace":  ns,
+					"labels":     sj.GetLabels(),
+					"apiVersion": sj.GetAPIVersion(),
 				},
 			})
 		}
@@ -1041,8 +1052,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractCAPIPhaseStatus(*cl),
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    cl.GetLabels(),
+					"namespace":  ns,
+					"labels":     cl.GetLabels(),
+					"apiVersion": cl.GetAPIVersion(),
 				},
 			})
 		}
@@ -1075,8 +1087,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractCAPIReadyConditionStatus(*cc),
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    cc.GetLabels(),
+					"namespace":  ns,
+					"labels":     cc.GetLabels(),
+					"apiVersion": cc.GetAPIVersion(),
 				},
 			})
 		}
@@ -1140,8 +1153,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractCAPIReadyConditionStatus(*kcp),
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    kcp.GetLabels(),
+					"namespace":  ns,
+					"labels":     kcp.GetLabels(),
+					"apiVersion": kcp.GetAPIVersion(),
 				},
 			})
 
@@ -1188,8 +1202,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractCAPIPhaseStatus(*md),
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    md.GetLabels(),
+					"namespace":  ns,
+					"labels":     md.GetLabels(),
+					"apiVersion": md.GetAPIVersion(),
 				},
 			})
 
@@ -1236,8 +1251,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractCAPIPhaseStatus(*mp),
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    mp.GetLabels(),
+					"namespace":  ns,
+					"labels":     mp.GetLabels(),
+					"apiVersion": mp.GetAPIVersion(),
 				},
 			})
 
@@ -1284,8 +1300,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractCAPIPhaseStatus(*ms),
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    ms.GetLabels(),
+					"namespace":  ns,
+					"labels":     ms.GetLabels(),
+					"apiVersion": ms.GetAPIVersion(),
 				},
 			})
 
@@ -1331,8 +1348,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractCAPIPhaseStatus(*m),
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    m.GetLabels(),
+					"namespace":  ns,
+					"labels":     m.GetLabels(),
+					"apiVersion": m.GetAPIVersion(),
 				},
 			})
 
@@ -1425,8 +1443,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractCAPIReadyConditionStatus(*mhc),
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    mhc.GetLabels(),
+					"namespace":  ns,
+					"labels":     mhc.GetLabels(),
+					"apiVersion": mhc.GetAPIVersion(),
 				},
 			})
 
@@ -1471,7 +1490,8 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractGatewayClassStatus(*gc),
 				Data: map[string]any{
-					"labels": gc.GetLabels(),
+					"labels":     gc.GetLabels(),
+					"apiVersion": gc.GetAPIVersion(),
 				},
 			})
 		}
@@ -1484,8 +1504,8 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	if resourceDiscovery != nil {
 		virtualServiceGVR, hasVirtualServices = resourceDiscovery.GetGVRWithGroup("VirtualService", "networking.istio.io")
 	}
-	virtualServiceIDs := make(map[string]string)                       // ns/name -> vsID
-	var virtualServiceResources []*unstructured.Unstructured           // Store for second pass
+	virtualServiceIDs := make(map[string]string)             // ns/name -> vsID
+	var virtualServiceResources []*unstructured.Unstructured // Store for second pass
 	if hasVirtualServices && dynamicCache != nil {
 		virtualServices, vsErr := dynamicCache.List(virtualServiceGVR, opts.NamespaceFilter())
 		if vsErr != nil {
@@ -1528,6 +1548,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 					"gateways":   gateways,
 					"routeCount": routeCount,
 					"labels":     vs.GetLabels(),
+					"apiVersion": vs.GetAPIVersion(),
 				},
 			})
 
@@ -1542,8 +1563,8 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	if resourceDiscovery != nil {
 		destinationRuleGVR, hasDestinationRules = resourceDiscovery.GetGVRWithGroup("DestinationRule", "networking.istio.io")
 	}
-	destinationRuleIDs := make(map[string]string)                      // ns/name -> drID
-	var destinationRuleResources []*unstructured.Unstructured          // Store for second pass
+	destinationRuleIDs := make(map[string]string)             // ns/name -> drID
+	var destinationRuleResources []*unstructured.Unstructured // Store for second pass
 	if hasDestinationRules && dynamicCache != nil {
 		destinationRules, drErr := dynamicCache.List(destinationRuleGVR, opts.NamespaceFilter())
 		if drErr != nil {
@@ -1578,6 +1599,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 					"host":        host,
 					"subsetCount": len(subsets),
 					"labels":      dr.GetLabels(),
+					"apiVersion":  dr.GetAPIVersion(),
 				},
 			})
 
@@ -1627,6 +1649,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 					"serverCount": len(servers),
 					"selector":    selector,
 					"labels":      igw.GetLabels(),
+					"apiVersion":  igw.GetAPIVersion(),
 				},
 			})
 		}
@@ -1642,8 +1665,8 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	if resourceDiscovery != nil {
 		knativeServiceGVR, hasKnativeServices = resourceDiscovery.GetGVRWithGroup("Service", "serving.knative.dev")
 	}
-	knativeServiceIDs := make(map[string]string)                          // ns/name -> ksvcID
-	var knativeServiceResources []*unstructured.Unstructured              // Store for second pass
+	knativeServiceIDs := make(map[string]string)             // ns/name -> ksvcID
+	var knativeServiceResources []*unstructured.Unstructured // Store for second pass
 	if hasKnativeServices && dynamicCache != nil {
 		knativeServices, ksvcErr := dynamicCache.List(knativeServiceGVR, opts.NamespaceFilter())
 		if ksvcErr != nil {
@@ -1666,8 +1689,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractGenericStatus(ksvc),
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    ksvc.GetLabels(),
+					"namespace":  ns,
+					"labels":     ksvc.GetLabels(),
+					"apiVersion": ksvc.GetAPIVersion(),
 				},
 			})
 
@@ -1681,8 +1705,8 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	if resourceDiscovery != nil {
 		knativeConfigGVR, hasKnativeConfigs = resourceDiscovery.GetGVRWithGroup("Configuration", "serving.knative.dev")
 	}
-	knativeConfigIDs := make(map[string]string)                              // ns/name -> kcfgID
-	var knativeConfigResources []*unstructured.Unstructured                  // Store for edge creation
+	knativeConfigIDs := make(map[string]string)             // ns/name -> kcfgID
+	var knativeConfigResources []*unstructured.Unstructured // Store for edge creation
 	if hasKnativeConfigs && dynamicCache != nil {
 		knativeConfigs, kcfgErr := dynamicCache.List(knativeConfigGVR, opts.NamespaceFilter())
 		if kcfgErr != nil {
@@ -1706,8 +1730,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractGenericStatus(kcfg),
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    kcfg.GetLabels(),
+					"namespace":  ns,
+					"labels":     kcfg.GetLabels(),
+					"apiVersion": kcfg.GetAPIVersion(),
 				},
 			})
 		}
@@ -1719,8 +1744,8 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	if resourceDiscovery != nil {
 		knativeRevisionGVR, hasKnativeRevisions = resourceDiscovery.GetGVR("Revision")
 	}
-	knativeRevisionIDs := make(map[string]string)                              // ns/name -> krevID
-	var knativeRevisionResources []*unstructured.Unstructured                  // Store for edge creation
+	knativeRevisionIDs := make(map[string]string)             // ns/name -> krevID
+	var knativeRevisionResources []*unstructured.Unstructured // Store for edge creation
 	if hasKnativeRevisions && dynamicCache != nil {
 		knativeRevisions, krevErr := dynamicCache.List(knativeRevisionGVR, opts.NamespaceFilter())
 		if krevErr != nil {
@@ -1744,8 +1769,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractGenericStatus(krev),
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    krev.GetLabels(),
+					"namespace":  ns,
+					"labels":     krev.GetLabels(),
+					"apiVersion": krev.GetAPIVersion(),
 				},
 			})
 		}
@@ -1757,8 +1783,8 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	if resourceDiscovery != nil {
 		knativeRouteGVR, hasKnativeRoutes = resourceDiscovery.GetGVRWithGroup("Route", "serving.knative.dev")
 	}
-	knativeRouteIDs := make(map[string]string)                          // ns/name -> krouteID
-	var knativeRouteResources []*unstructured.Unstructured              // Store for second pass
+	knativeRouteIDs := make(map[string]string)             // ns/name -> krouteID
+	var knativeRouteResources []*unstructured.Unstructured // Store for second pass
 	if hasKnativeRoutes && dynamicCache != nil {
 		knativeRoutes, krouteErr := dynamicCache.List(knativeRouteGVR, opts.NamespaceFilter())
 		if krouteErr != nil {
@@ -1781,8 +1807,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractGenericStatus(kroute),
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    kroute.GetLabels(),
+					"namespace":  ns,
+					"labels":     kroute.GetLabels(),
+					"apiVersion": kroute.GetAPIVersion(),
 				},
 			})
 
@@ -1822,8 +1849,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractGenericStatus(broker),
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    broker.GetLabels(),
+					"namespace":  ns,
+					"labels":     broker.GetLabels(),
+					"apiVersion": broker.GetAPIVersion(),
 				},
 			})
 		}
@@ -1835,8 +1863,8 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	if resourceDiscovery != nil {
 		knativeTriggerGVR, hasKnativeTriggers = resourceDiscovery.GetGVRWithGroup("Trigger", "eventing.knative.dev")
 	}
-	knativeTriggerIDs := make(map[string]string)                        // ns/name -> triggerID
-	var knativeTriggerResources []*unstructured.Unstructured            // Store for second pass
+	knativeTriggerIDs := make(map[string]string)             // ns/name -> triggerID
+	var knativeTriggerResources []*unstructured.Unstructured // Store for second pass
 	if hasKnativeTriggers && dynamicCache != nil {
 		knativeTriggers, triggerErr := dynamicCache.List(knativeTriggerGVR, opts.NamespaceFilter())
 		if triggerErr != nil {
@@ -1859,8 +1887,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractGenericStatus(trigger),
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    trigger.GetLabels(),
+					"namespace":  ns,
+					"labels":     trigger.GetLabels(),
+					"apiVersion": trigger.GetAPIVersion(),
 				},
 			})
 
@@ -1912,8 +1941,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractGenericStatus(src),
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    src.GetLabels(),
+					"namespace":  ns,
+					"labels":     src.GetLabels(),
+					"apiVersion": src.GetAPIVersion(),
 				},
 			})
 
@@ -1951,8 +1981,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractGenericStatus(ch),
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    ch.GetLabels(),
+					"namespace":  ns,
+					"labels":     ch.GetLabels(),
+					"apiVersion": ch.GetAPIVersion(),
 				},
 			})
 		}
@@ -1975,8 +2006,8 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	}
 
 	// Maps for edge creation in second pass
-	traefikRouteIDs := make(map[string]string)                           // prefix:ns/name -> routeID
-	var traefikRouteResources []*unstructured.Unstructured               // Store for edge creation
+	traefikRouteIDs := make(map[string]string)                                // prefix:ns/name -> routeID
+	var traefikRouteResources []*unstructured.Unstructured                    // Store for edge creation
 	traefikRouteKinds := make(map[*unstructured.Unstructured]traefikRouteDef) // resource -> def
 
 	for _, def := range traefikRouteDefs {
@@ -2031,6 +2062,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 					"entryPoints": entryPoints,
 					"routeCount":  len(routes),
 					"labels":      res.GetLabels(),
+					"apiVersion":  res.GetAPIVersion(),
 				},
 			})
 
@@ -2049,8 +2081,8 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		{"Middleware", KindMiddleware, "middleware"},
 		{"MiddlewareTCP", KindMiddlewareTCP, "middlewaretcp"},
 	}
-	middlewareIDs := make(map[string]string)                     // ns/name -> mwID
-	var middlewareResources []*unstructured.Unstructured         // Store for chain edge creation
+	middlewareIDs := make(map[string]string)             // ns/name -> mwID
+	var middlewareResources []*unstructured.Unstructured // Store for chain edge creation
 	for _, def := range traefikMiddlewareDefs {
 		var gvr schema.GroupVersionResource
 		hasKind := false
@@ -2082,8 +2114,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: extractGenericStatus(res),
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    res.GetLabels(),
+					"namespace":  ns,
+					"labels":     res.GetLabels(),
+					"apiVersion": res.GetAPIVersion(),
 				},
 			})
 
@@ -2099,8 +2132,8 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	if resourceDiscovery != nil {
 		traefikServiceGVR, hasTraefikServices = resourceDiscovery.GetGVR("TraefikService")
 	}
-	traefikServiceIDs := make(map[string]string)                 // ns/name -> tsID
-	var traefikServiceResources []*unstructured.Unstructured     // Store for edge creation
+	traefikServiceIDs := make(map[string]string)             // ns/name -> tsID
+	var traefikServiceResources []*unstructured.Unstructured // Store for edge creation
 	if hasTraefikServices && dynamicCache != nil {
 		tsvcs, tsErr := dynamicCache.List(traefikServiceGVR, opts.NamespaceFilter())
 		if tsErr != nil {
@@ -2160,6 +2193,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 					"type":         tsType,
 					"serviceCount": svcCount,
 					"labels":       ts.GetLabels(),
+					"apiVersion":   ts.GetAPIVersion(),
 				},
 			})
 
@@ -2213,8 +2247,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: StatusHealthy,
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    res.GetLabels(),
+					"namespace":  ns,
+					"labels":     res.GetLabels(),
+					"apiVersion": res.GetAPIVersion(),
 				},
 			})
 
@@ -2231,8 +2266,8 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 
 	// 1q. Add Contour HTTPProxy nodes (CRD - fetched via dynamic cache)
 	// Edges are created in a second pass after service IDs are populated.
-	httpProxyIDs := make(map[string]string)                   // ns/name → nodeID
-	var httpProxyResources []*unstructured.Unstructured       // Store for edge creation
+	httpProxyIDs := make(map[string]string)             // ns/name → nodeID
+	var httpProxyResources []*unstructured.Unstructured // Store for edge creation
 	{
 		var httpProxyGVR schema.GroupVersionResource
 		hasHTTPProxy := false
@@ -2285,6 +2320,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 						"includeCount": len(includes),
 						"hasTLS":       hasTLS,
 						"labels":       res.GetLabels(),
+						"apiVersion":   res.GetAPIVersion(),
 					},
 				})
 
@@ -2885,10 +2921,10 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	}
 
 	// 7b. Add Gateway API nodes (CRD - fetched via dynamic cache)
-	gatewayIDs := make(map[string]string)                             // ns/name -> gatewayID
-	routeIDs := make(map[string]string)                               // kind/ns/name -> routeID
-	var gatewayRouteResources []*unstructured.Unstructured             // all routes for second-pass edge creation
-	var gatewayRouteKinds []string                                     // kind for each entry in gatewayRouteResources
+	gatewayIDs := make(map[string]string)                  // ns/name -> gatewayID
+	routeIDs := make(map[string]string)                    // kind/ns/name -> routeID
+	var gatewayRouteResources []*unstructured.Unstructured // all routes for second-pass edge creation
+	var gatewayRouteKinds []string                         // kind for each entry in gatewayRouteResources
 
 	var gatewayGVR schema.GroupVersionResource
 	hasGateways := false
@@ -2933,6 +2969,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 					"listenerCount": len(listeners),
 					"addresses":     addrList,
 					"labels":        gw.GetLabels(),
+					"apiVersion":    gw.GetAPIVersion(),
 				},
 			})
 		}
@@ -3009,6 +3046,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 					"hostnames":  hostnames,
 					"rulesCount": len(rules),
 					"labels":     route.GetLabels(),
+					"apiVersion": route.GetAPIVersion(),
 				},
 			})
 
@@ -3433,8 +3471,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 			cnpID := fmt.Sprintf("ciliumnetworkpolicy/%s/%s", ns, name)
 
 			nodeData := map[string]any{
-				"namespace": ns,
-				"labels":    cnp.GetLabels(),
+				"namespace":  ns,
+				"labels":     cnp.GetLabels(),
+				"apiVersion": cnp.GetAPIVersion(),
 			}
 
 			nodes = append(nodes, Node{
@@ -3512,7 +3551,8 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: StatusHealthy,
 				Data: map[string]any{
-					"labels": ccnp.GetLabels(),
+					"labels":     ccnp.GetLabels(),
+					"apiVersion": ccnp.GetAPIVersion(),
 				},
 			})
 			// Cluster-wide policies use endpointSelector or nodeSelector across all namespaces.
@@ -3542,7 +3582,8 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: StatusHealthy,
 				Data: map[string]any{
-					"labels": cnp.GetLabels(),
+					"labels":     cnp.GetLabels(),
+					"apiVersion": cnp.GetAPIVersion(),
 				},
 			})
 			// ClusterNetworkPolicy uses spec.subject with namespace/pod selectors.
@@ -3576,8 +3617,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 				Name:   name,
 				Status: StatusHealthy,
 				Data: map[string]any{
-					"namespace": ns,
-					"labels":    vpa.GetLabels(),
+					"namespace":  ns,
+					"labels":     vpa.GetLabels(),
+					"apiVersion": vpa.GetAPIVersion(),
 				},
 			})
 
@@ -5371,7 +5413,6 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 		}
 	}
 
-
 	// Collect Traefik IngressRoute resources from dynamic cache
 	var trafficTraefikRoutes []*unstructured.Unstructured
 	var trafficTraefikRouteKinds []string
@@ -5421,7 +5462,6 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 			}
 		}
 	}
-
 
 	// Step 1e: Find services referenced by Traefik IngressRoutes
 	servicesFromTraefik := make(map[string]bool)
@@ -5684,6 +5724,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 				"listenerCount": len(listeners),
 				"addresses":     addrList,
 				"labels":        gw.GetLabels(),
+				"apiVersion":    gw.GetAPIVersion(),
 			},
 		})
 	}
@@ -5711,6 +5752,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 				"hostnames":  hostnames,
 				"rulesCount": len(rules),
 				"labels":     route.GetLabels(),
+				"apiVersion": route.GetAPIVersion(),
 			},
 		})
 
@@ -5805,6 +5847,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 				"serverCount": len(servers),
 				"selector":    selector,
 				"labels":      igw.GetLabels(),
+				"apiVersion":  igw.GetAPIVersion(),
 			},
 		})
 	}
@@ -5846,6 +5889,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 				"gateways":   gateways,
 				"routeCount": routeCount,
 				"labels":     vs.GetLabels(),
+				"apiVersion": vs.GetAPIVersion(),
 			},
 		})
 
@@ -5952,11 +5996,12 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 			Name:   name,
 			Status: extractGenericStatus(ksvc),
 			Data: map[string]any{
-				"namespace":       ns,
-				"url":             url,
-				"latestRevision":  latestRevision,
-				"trafficSummary":  trafficSummary,
-				"labels":          ksvc.GetLabels(),
+				"namespace":      ns,
+				"url":            url,
+				"latestRevision": latestRevision,
+				"trafficSummary": trafficSummary,
+				"labels":         ksvc.GetLabels(),
+				"apiVersion":     ksvc.GetAPIVersion(),
 			},
 		})
 
@@ -5998,13 +6043,12 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 		}
 	}
 
-
 	// Step 3e: Build Traefik IngressRoute nodes/edges for traffic view
 	// Traffic flow: Internet → IngressRoute → (TraefikService →) Service → Pods
 	trafficTraefikRouteIDs := make([]string, 0)
-	trafficTraefikRouteIDMap := make(map[string]string) // prefix:ns/name → ID
+	trafficTraefikRouteIDMap := make(map[string]string)   // prefix:ns/name → ID
 	trafficTraefikServiceIDMap := make(map[string]string) // ns/name → ID
-	trafficMiddlewareIDMap := make(map[string]string) // prefix:ns/name → ID
+	trafficMiddlewareIDMap := make(map[string]string)     // prefix:ns/name → ID
 	trafficTraefikEdgeSeen := make(map[string]bool)
 
 	// TraefikService nodes — Phase 1: create all nodes and populate ID map
@@ -6035,9 +6079,10 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 			Name:   name,
 			Status: StatusHealthy,
 			Data: map[string]any{
-				"namespace":       ns,
-				"traefikSvcType":  tsType,
-				"labels":          ts.GetLabels(),
+				"namespace":      ns,
+				"traefikSvcType": tsType,
+				"labels":         ts.GetLabels(),
+				"apiVersion":     ts.GetAPIVersion(),
 			},
 		})
 	}
@@ -6188,8 +6233,9 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 			Name:   name,
 			Status: extractGenericStatus(mw),
 			Data: map[string]any{
-				"namespace": ns,
-				"labels":    mw.GetLabels(),
+				"namespace":  ns,
+				"labels":     mw.GetLabels(),
+				"apiVersion": mw.GetAPIVersion(),
 			},
 		})
 	}
@@ -6208,12 +6254,12 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 			Name:   name,
 			Status: extractGenericStatus(mw),
 			Data: map[string]any{
-				"namespace": ns,
-				"labels":    mw.GetLabels(),
+				"namespace":  ns,
+				"labels":     mw.GetLabels(),
+				"apiVersion": mw.GetAPIVersion(),
 			},
 		})
 	}
-
 
 	// IngressRoute nodes and edges (after TraefikService/Middleware so maps are populated)
 	for i, rt := range trafficTraefikRoutes {
@@ -6256,6 +6302,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 				"serviceCount": totalSvcCount,
 				"entryPoints":  entryPoints,
 				"labels":       rt.GetLabels(),
+				"apiVersion":   rt.GetAPIVersion(),
 			},
 		})
 
@@ -6350,7 +6397,6 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 		}
 	}
 
-
 	// Step 3f: Build Contour HTTPProxy nodes/edges for traffic view
 	// Traffic flow: Internet → HTTPProxy (root) → HTTPProxy (child) → Service → Pods
 	trafficHTTPProxyIDs := make([]string, 0)
@@ -6401,6 +6447,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 				"includeCount": len(includes),
 				"hasTLS":       hasTLS,
 				"labels":       hp.GetLabels(),
+				"apiVersion":   hp.GetAPIVersion(),
 			},
 		})
 	}
@@ -7451,28 +7498,28 @@ func (b *Builder) addGenericCRDNodes(nodes []Node, edges []Edge, opts BuildOptio
 		"rollout": true, "application": true, "kustomization": true,
 		"helmrelease": true, "gitrepository": true, "certificate": true,
 		"gateway": true, "httproute": true, "grpcroute": true, "tcproute": true, "tlsroute": true,
-		"nodepool": true, "nodeclaim": true,             // Karpenter
+		"nodepool": true, "nodeclaim": true, // Karpenter
 		"ec2nodeclass": true, "aksnodeclass": true, "gcpnodeclass": true, // Karpenter NodeClass
-		"scaledobject": true, "scaledjob": true,   // KEDA
-		"gatewayclass": true,                       // Gateway API
+		"scaledobject": true, "scaledjob": true, // KEDA
+		"gatewayclass":   true,                                                // Gateway API
 		"virtualservice": true, "destinationrule": true, "serviceentry": true, // Istio networking
-		"peerauthentication": true, "authorizationpolicy": true,               // Istio security
+		"peerauthentication": true, "authorizationpolicy": true, // Istio security
 		"knativeservice": true, "configuration": true, "revision": true, "route": true, // KNative Serving
-		"domainmapping": true, "serverlessservice": true,                                // KNative Serving (internal)
-		"broker": true, "trigger": true, "eventtype": true,                              // KNative Eventing
-		"channel": true, "inmemorychannel": true, "subscription": true,                  // KNative Messaging
+		"domainmapping": true, "serverlessservice": true, // KNative Serving (internal)
+		"broker": true, "trigger": true, "eventtype": true, // KNative Eventing
+		"channel": true, "inmemorychannel": true, "subscription": true, // KNative Messaging
 		"apiserversource": true, "containersource": true, "pingsource": true, "sinkbinding": true, // KNative Sources
-		"sequence": true, "parallel": true,                                              // KNative Flows
-		"ingressroute": true, "ingressroutetcp": true, "ingressrouteudp": true,          // Traefik routing
-		"middleware": true, "middlewaretcp": true,                                        // Traefik middleware
-		"traefikservice": true,                                                          // Traefik service
-		"serverstransport": true, "serverstransporttcp": true,                           // Traefik transport
-		"tlsoption": true, "tlsstore": true,                                             // Traefik TLS
-		"httpproxy": true,                                                               // Contour
-		"clusterclass": true,                                                            // Cluster API
-		"machine": true, "machineset": true, "machinedeployment": true,                  // Cluster API
-		"machinepool": true, "kubeadmcontrolplane": true, "machinehealthcheck": true,    // Cluster API
-		"machinedrainrule": true,                                                        // Cluster API
+		"sequence": true, "parallel": true, // KNative Flows
+		"ingressroute": true, "ingressroutetcp": true, "ingressrouteudp": true, // Traefik routing
+		"middleware": true, "middlewaretcp": true, // Traefik middleware
+		"traefikservice":   true,                              // Traefik service
+		"serverstransport": true, "serverstransporttcp": true, // Traefik transport
+		"tlsoption": true, "tlsstore": true, // Traefik TLS
+		"httpproxy":    true,                                                // Contour
+		"clusterclass": true,                                                // Cluster API
+		"machine":      true, "machineset": true, "machinedeployment": true, // Cluster API
+		"machinepool": true, "kubeadmcontrolplane": true, "machinehealthcheck": true, // Cluster API
+		"machinedrainrule": true, // Cluster API
 		// Trivy Operator reports - high cardinality, excluded from topology
 		"vulnerabilityreport": true, "configauditreport": true,
 		"exposedsecretreport": true, "sbomreport": true,
@@ -7557,8 +7604,9 @@ func (b *Builder) addGenericCRDNodes(nodes []Node, edges []Edge, opts BuildOptio
 					Name:   name,
 					Status: extractGenericStatus(resource),
 					Data: map[string]any{
-						"namespace": ns,
-						"labels":    resource.GetLabels(),
+						"namespace":  ns,
+						"labels":     resource.GetLabels(),
+						"apiVersion": resource.GetAPIVersion(),
 					},
 				},
 				ownerRefs: ownerNodeIDs,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -45,7 +45,7 @@ import { Tooltip } from './components/ui/Tooltip'
 import { LargeClusterNamespacePicker } from './components/shared/LargeClusterNamespacePicker'
 import { SettingsDialog } from './components/settings/SettingsDialog'
 import type { TopologyNode, GroupingMode, MainView, SelectedResource, SelectedHelmRelease, NodeKind, TopologyMode, Topology, K8sEvent } from './types'
-import { kindToPlural, openExternal } from './utils/navigation'
+import { kindToPlural, openExternal, apiVersionToGroup, buildWorkloadPath } from './utils/navigation'
 import type { ContextSwitcherHandle } from './components/ContextSwitcher'
 
 // All possible node kinds (core + GitOps)
@@ -592,6 +592,34 @@ function AppInner() {
   }, forceNamespaceFilter, showPolicyEffect)
   const [reconnect, isReconnecting] = useRefreshAnimation(reconnectSSE)
 
+  // Engage SSE server-side filtering on large clusters and keep the filter
+  // in lockstep with the user's pick. Two failure modes this covers:
+  //   * Header switcher: SSE was already filtered (large-cluster picker
+  //     engaged forceNamespaceFilter once); switching namespaces only updated
+  //     `namespaces`, so SSE kept streaming the previous pick → blank graph
+  //     with stale sidebar counts.
+  //   * URL bookmark on a large cluster: forceNamespaceFilter starts
+  //     undefined, SSE opens with no filter, server replies
+  //     requiresNamespaceFilter=true. The LargeClusterPicker fallback only
+  //     renders when `namespaces` is empty, so a deep link with a namespace
+  //     showed "No resources found".
+  // Small clusters never see requiresNamespaceFilter and leave
+  // forceNamespaceFilter === undefined — frontend filtering is unaffected.
+  useEffect(() => {
+    const isLarge = forceNamespaceFilter !== undefined || topology?.requiresNamespaceFilter === true
+    if (!isLarge) return
+    if (namespaces.length === 0) {
+      setForceNamespaceFilter(prev => (prev === undefined ? prev : undefined))
+      return
+    }
+    setForceNamespaceFilter(prev => {
+      const cur = prev ? [...prev].sort() : []
+      const next = [...namespaces].sort()
+      if (cur.length === next.length && cur.every((ns, i) => ns === next[i])) return prev
+      return [...namespaces]
+    })
+  }, [namespaces, forceNamespaceFilter, topology?.requiresNamespaceFilter])
+
   // Apply live topology updates only when not paused. While paused, buffer the
   // latest snapshot so we can apply it instantly when the user resumes.
   useEffect(() => {
@@ -661,6 +689,7 @@ function AppInner() {
       kind: kindToPlural(node.kind),
       namespace: (node.data.namespace as string) || '',
       name: node.name,
+      group: apiVersionToGroup(node.data.apiVersion as string | undefined),
     })
   }, [])
 
@@ -1346,7 +1375,7 @@ function AppInner() {
           <TimelineView
             namespaces={namespaces}
             onResourceClick={(resource) => {
-              navigate(`/workload/${resource.kind}/${resource.namespace}/${resource.name}`)
+              navigate(buildWorkloadPath(resource))
             }}
             initialViewMode={(searchParams.get('view') as 'list' | 'swimlane') || undefined}
             initialFilter={(searchParams.get('filter') as 'all' | 'changes' | 'k8s_events' | 'warnings' | 'unhealthy') || undefined}
@@ -1416,7 +1445,7 @@ function AppInner() {
         {mainView === 'workload' && !drawerExpanded && (
           <WorkloadViewRoute
             onNavigateToResource={(resource) => {
-              navigate(`/workload/${resource.kind}/${resource.namespace}/${resource.name}`)
+              navigate(buildWorkloadPath(resource))
             }}
           />
         )}
@@ -1436,12 +1465,12 @@ function AppInner() {
           onExpand={(res) => {
             suppressViewClearRef.current = true
             setDrawerExpanded(true)
-            navigate(`/workload/${res.kind}/${res.namespace}/${res.name}`)
+            navigate(buildWorkloadPath(res))
           }}
           onCollapse={handleCollapseFromExpanded}
           onNavigateToResource={(resource) => {
             setSelectedResource(resource)
-            navigate(`/workload/${resource.kind}/${resource.namespace}/${resource.name}`, { replace: true })
+            navigate(buildWorkloadPath(resource), { replace: true })
           }}
         />
       )}
@@ -1459,11 +1488,11 @@ function AppInner() {
             setSearchParams(params, { replace: true })
           }}
           onNavigateToResource={(resource) => {
-            // Navigate to resources view with kind in path and open the resource detail drawer
             setSelectedHelmRelease(null)
             const newParams = new URLSearchParams()
             const globalNamespaces = searchParams.get('namespaces')
             if (globalNamespaces) newParams.set('namespaces', globalNamespaces)
+            if (resource.group) newParams.set('apiGroup', resource.group)
             navigate({ pathname: `/resources/${resource.kind}`, search: newParams.toString() })
             setSelectedResource(resource)
           }}

--- a/web/src/components/helm/OwnedResources.tsx
+++ b/web/src/components/helm/OwnedResources.tsx
@@ -4,7 +4,7 @@ import { getResourceIcon } from '../../utils/resource-icons'
 import { clsx } from 'clsx'
 import type { HelmOwnedResource } from '../../types'
 import type { NavigateToResource } from '../../utils/navigation'
-import { kindToPlural } from '../../utils/navigation'
+import { kindToPlural, apiVersionToGroup } from '../../utils/navigation'
 import { getResourceStatusColor, SEVERITY_BADGE } from '../../utils/badge-colors'
 import { useQueryClient } from '@tanstack/react-query'
 import { useOpenTerminal, useOpenLogs } from '../dock'
@@ -205,7 +205,7 @@ function ResourceItem({ resource, onNavigate }: ResourceItemProps) {
 
   const handleClick = () => {
     if (onNavigate) {
-      onNavigate({ kind: kindToPlural(resource.kind), namespace: resource.namespace, name: resource.name })
+      onNavigate({ kind: kindToPlural(resource.kind), namespace: resource.namespace, name: resource.name, group: apiVersionToGroup(resource.apiVersion) })
     }
   }
 

--- a/web/src/components/timeline/TimelineSwimlanes.tsx
+++ b/web/src/components/timeline/TimelineSwimlanes.tsx
@@ -26,7 +26,7 @@ import {
 import { useHasLimitedAccess } from '../../contexts/CapabilitiesContext'
 import type { TimelineEvent, Topology } from '../../types'
 import type { NavigateToResource } from '../../utils/navigation'
-import { kindToPlural } from '../../utils/navigation'
+import { kindToPlural, apiVersionToGroup } from '../../utils/navigation'
 import { PaneLoader, pluralize } from '@skyhook-io/k8s-ui'
 import { isChangeEvent, isHistoricalEvent, isOperation, displayKind } from '../../types'
 import { DiffViewer } from './DiffViewer'
@@ -682,7 +682,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
                         )}
                         <div
                           className="flex-1 min-w-0 cursor-pointer hover:bg-theme-surface/30 rounded px-1 -mx-1 group"
-                          onClick={() => onResourceClick?.({ kind: kindToPlural(lane.kind), namespace: lane.namespace, name: lane.name })}
+                          onClick={() => onResourceClick?.({ kind: kindToPlural(lane.kind), namespace: lane.namespace, name: lane.name, group: lane.group })}
                         >
                           <div className="flex items-center gap-1">
                             <span className={clsx(
@@ -760,7 +760,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
                           <div className="flex">
                             <div
                               className="w-[19.25rem] shrink-0 border-r border-theme-border/50 pl-4 pr-3 py-1.5 flex items-center gap-2 cursor-pointer hover:bg-theme-elevated/30 group"
-                              onClick={() => onResourceClick?.({ kind: kindToPlural(lane.kind), namespace: lane.namespace, name: lane.name })}
+                              onClick={() => onResourceClick?.({ kind: kindToPlural(lane.kind), namespace: lane.namespace, name: lane.name, group: lane.group })}
                             >
                               <div className="flex-1 min-w-0">
                                 <div className="flex items-center gap-1">
@@ -812,7 +812,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
                             {/* Child lane label - indented */}
                             <div
                               className="w-[19.25rem] shrink-0 border-r border-theme-border/50 pl-4 pr-3 py-1.5 flex items-center gap-2 cursor-pointer hover:bg-theme-elevated/30 group"
-                              onClick={() => onResourceClick?.({ kind: kindToPlural(child.kind), namespace: child.namespace, name: child.name })}
+                              onClick={() => onResourceClick?.({ kind: kindToPlural(child.kind), namespace: child.namespace, name: child.name, group: child.group })}
                             >
                               <div className="flex-1 min-w-0">
                                 <div className="flex items-center gap-1">
@@ -1234,7 +1234,7 @@ function EventDetailPanel({ event, onClose, onResourceClick }: EventDetailPanelP
               {displayKind(event.kind)}
             </span>
             <button
-              onClick={() => onResourceClick?.({ kind: kindToPlural(event.kind), namespace: event.namespace, name: event.name })}
+              onClick={() => onResourceClick?.({ kind: kindToPlural(event.kind), namespace: event.namespace, name: event.name, group: apiVersionToGroup(event.apiVersion) })}
               className="text-theme-text-primary font-medium hover:text-accent-text"
             >
               {event.name}

--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -8,7 +8,7 @@ import {
   type RendererOverrides,
 } from '@skyhook-io/k8s-ui'
 import type { SelectedResource, ResourceRef, ResolvedEnvFrom } from '../../types'
-import { kindToPlural, type NavigateToResource } from '../../utils/navigation'
+import { kindToPlural, buildWorkloadPath, type NavigateToResource } from '../../utils/navigation'
 import {
   useChanges, useResourceWithRelationships, usePodLogs, useTopology, useUpdateResource,
   useDeleteResource, useTriggerCronJob, useSuspendCronJob, useResumeCronJob,
@@ -55,6 +55,7 @@ interface WorkloadViewRouteProps {
 export function WorkloadViewRoute({ onNavigateToResource }: WorkloadViewRouteProps) {
   const location = useLocation()
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
 
   // Parse /workload/:kind/:ns/:name from pathname
   const parts = location.pathname.replace(/^\//, '').split('/')
@@ -62,6 +63,7 @@ export function WorkloadViewRoute({ onNavigateToResource }: WorkloadViewRoutePro
   const kind = parts[1] || ''
   const namespace = parts[2] || ''
   const name = parts.slice(3).join('/') || ''
+  const group = searchParams.get('apiGroup') || ''
 
   if (!kind || !namespace || !name) {
     return (
@@ -80,8 +82,7 @@ export function WorkloadViewRoute({ onNavigateToResource }: WorkloadViewRoutePro
   }, [navigate])
 
   const handleNavigate = useCallback((resource: SelectedResource) => {
-    // Navigate to another workload view
-    navigate(`/workload/${resource.kind}/${resource.namespace}/${resource.name}`)
+    navigate(buildWorkloadPath(resource))
   }, [navigate])
 
   return (
@@ -89,6 +90,7 @@ export function WorkloadViewRoute({ onNavigateToResource }: WorkloadViewRoutePro
       kind={kind}
       namespace={namespace}
       name={name}
+      group={group}
       onBack={handleBack}
       onNavigateToResource={onNavigateToResource || handleNavigate}
     />

--- a/web/src/utils/navigation.ts
+++ b/web/src/utils/navigation.ts
@@ -1,8 +1,18 @@
 import { apiUrl, getAuthHeaders, getCredentialsMode } from '../api/config'
+import type { SelectedResource } from '@skyhook-io/k8s-ui/types/core'
 
 // Re-export shared navigation utilities from @skyhook-io/k8s-ui.
-export { kindToPlural, pluralToKind, refToSelectedResource } from '@skyhook-io/k8s-ui/utils/navigation'
+export { kindToPlural, pluralToKind, refToSelectedResource, apiVersionToGroup } from '@skyhook-io/k8s-ui/utils/navigation'
 export type { NavigateToResource } from '@skyhook-io/k8s-ui/utils/navigation'
+
+/**
+ * Build a /workload/:kind/:namespace/:name URL, preserving the API group as a
+ * query param so the WorkloadView can resolve CRDs with colliding kind names.
+ */
+export function buildWorkloadPath(resource: SelectedResource): string {
+  const base = `/workload/${resource.kind}/${resource.namespace}/${resource.name}`
+  return resource.group ? `${base}?apiGroup=${encodeURIComponent(resource.group)}` : base
+}
 
 // radar-specific: open URL in system browser (desktop app support)
 export function openExternal(url: string): void {


### PR DESCRIPTION
## Summary

CRD navigation dropped the API group on every hop, so links landing on
`/workload/{kind}/...` or `/resources/{kind}` 404'd or rendered the wrong
resource whenever a CRD kind collided with a core kind (e.g. ArgoCD
`Application`, FluxCD `HelmRelease`, Knative `Service`, CAPI vs CNPG
`Cluster`). Closes #461.

End-to-end propagation:

- **Backend**: `apiVersion` is now carried on `TimelineEvent`,
  `helm.OwnedResource`, and CRD topology node `Data` maps. SQLite
  timeline picks up an additive `api_version` migration.
- **Frontend**: new `apiVersionToGroup` helper + `buildWorkloadPath` URL
  builder. All click sites — topology node clicks, timeline swimlanes,
  timeline list, Helm owned resources, `WorkloadView` back-nav — thread
  the group through `SelectedResource` or the `?apiGroup=` query param.

## Bonus: large-cluster namespace sync

While visual-testing on a 1227-node cluster I hit a separate bug: the
topology view went blank after a header namespace switch, and URL
bookmarks like `?namespaces=argocd` rendered "No resources found" on
first load.

Root cause: SSE reconnection is gated solely on `forceNamespaceFilter`,
but that state was only ever set by the `LargeClusterNamespacePicker`.
The header switcher and URL deep links updated `namespaces` but left
SSE streaming the previous filter (or none at all, in which case the
server replied `requiresNamespaceFilter=true` with an empty graph and
the picker fallback didn't render because `namespaces.length > 0`).

Added an effect in `App.tsx` that keeps `forceNamespaceFilter` in
lockstep with `namespaces` whenever the cluster is large — either
already engaged (`forceNamespaceFilter !== undefined`) or the server
just flagged it (`topology?.requiresNamespaceFilter`). Drops back to
undefined when the user clears so the picker reappears. Small clusters
keep `forceNamespaceFilter === undefined` and continue to filter
client-side; no behavior change.

## Test plan

Verified on a large GKE cluster (1227 nodes):

- [x] URL bookmark `/topology?namespaces=argocd` fresh-loads with 44 nodes
- [x] Header switch argocd → demo-drift renders 3 nodes; SSE
      re-subscribes with `namespaces=[demo-drift]`
- [x] Header clear-all returns the LargeClusterNamespacePicker; SSE
      reverts to `namespaces=[]`
- [x] Multi-namespace pick (argocd + demo-drift) renders 47 resources
- [x] CRD navigation paths (topology → drawer → full workload view,
      timeline swimlane → workload, Helm drawer → `/resources/`) all
      carry `?apiGroup=...` end-to-end
- [x] `make tsc` + `go test ./...`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes persisted timeline storage/querying (SQLite additive migration + new `api_version` column) and modifies navigation URL construction across multiple UI entry points, which could surface routing/selection regressions if group handling is wrong.
> 
> **Overview**
> Preserves CRD identity across the stack by carrying `apiVersion` alongside `kind` in timeline events, Helm owned resources, and topology nodes, and by using the derived API *group* in frontend navigation so colliding CRD kinds resolve correctly.
> 
> Adds an additive SQLite migration (`events.api_version`) and threads `apiVersion` through informer/historical/K8s-event conversion, cache event creation, Helm manifest parsing, and UI click targets (timeline list/swimlanes, Helm resources, topology nodes, workload routes via `buildWorkloadPath`).
> 
> Fixes large-cluster namespace switching/deep-links by adding an `App.tsx` effect that keeps `forceNamespaceFilter` aligned with the current `namespaces` when the server requires namespace filtering, ensuring SSE resubscribes with the correct filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a36dd70f4751a3752be9497ca19bf55cd4a6b413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->