### PR TITLE
chore: review cleanup follow-up for #699

### DIFF
--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -734,20 +734,19 @@ func parseManifestResources(manifest, defaultNamespace string) []OwnedResource {
 	manifests := releaseutil.SplitManifests(manifest)
 
 	for _, m := range manifests {
-		// Simple parsing - look for kind, apiVersion, name, and namespace
 		lines := strings.Split(m, "\n")
 		var kind, apiVersion, name, namespace string
 
+		// Take the first occurrence of each top-level field; nested specs
+		// (e.g. spec.template) can repeat the same keys with different values.
 		for _, line := range lines {
 			line = strings.TrimSpace(line)
-			if after, ok := strings.CutPrefix(line, "kind:"); ok {
-				kind = strings.TrimSpace(after)
-			} else if after, ok := strings.CutPrefix(line, "apiVersion:"); ok {
+			if after, ok := strings.CutPrefix(line, "kind:"); ok && kind == "" {
+				kind = strings.Trim(strings.TrimSpace(after), `"'`)
+			} else if after, ok := strings.CutPrefix(line, "apiVersion:"); ok && apiVersion == "" {
 				apiVersion = strings.Trim(strings.TrimSpace(after), `"'`)
 			} else if strings.HasPrefix(line, "name:") && name == "" {
-				// Only take first name (metadata.name, not container names etc)
 				name = strings.TrimSpace(strings.TrimPrefix(line, "name:"))
-				// Remove quotes if present
 				name = strings.Trim(name, `"'`)
 			} else if strings.HasPrefix(line, "namespace:") && namespace == "" {
 				namespace = strings.TrimSpace(strings.TrimPrefix(line, "namespace:"))

--- a/internal/timeline/sqlite_store.go
+++ b/internal/timeline/sqlite_store.go
@@ -135,9 +135,8 @@ func (s *SQLiteStore) initSchema() error {
 		return err
 	}
 
-	// Additive migration: api_version column added to disambiguate CRD kind collisions
-	// on navigation. ALTER TABLE on an existing column errors with "duplicate column",
-	// so detect via PRAGMA before adding.
+	// SQLite's ALTER TABLE ADD COLUMN errors with "duplicate column" when the
+	// schema is already current; PRAGMA-detect before adding.
 	rows, err := s.db.Query("PRAGMA table_info(events)")
 	if err != nil {
 		return err

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -237,7 +237,7 @@ export interface TimelineEvent {
 
   // Resource identity
   kind: string
-  apiVersion?: string // e.g. "apps/v1", "cluster.x-k8s.io/v1beta1" — empty for older backends
+  apiVersion?: string // e.g. "apps/v1", "cluster.x-k8s.io/v1beta1"
   namespace: string
   name: string
   uid?: string
@@ -508,7 +508,7 @@ export interface ChartDependency {
 
 export interface HelmOwnedResource {
   kind: string
-  apiVersion?: string // e.g. "apps/v1", "cluster.x-k8s.io/v1beta1" — empty for older backends
+  apiVersion?: string // e.g. "apps/v1", "cluster.x-k8s.io/v1beta1"
   name: string
   namespace: string
   status?: string   // Running, Pending, Failed, Active, etc.

--- a/packages/k8s-ui/src/utils/resource-hierarchy.ts
+++ b/packages/k8s-ui/src/utils/resource-hierarchy.ts
@@ -232,8 +232,8 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
         childEventCount: 0,
       })
     } else {
-      // Older SQLite-stored events may lack apiVersion (column added by migration);
-      // pick up the group from any subsequent event that carries it.
+      // Stored events may lack apiVersion; upgrade the lane's group from any
+      // later event that carries it.
       if (!existing.group) {
         const fromEvent = apiVersionToGroup(event.apiVersion)
         if (fromEvent) existing.group = fromEvent

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -592,19 +592,11 @@ function AppInner() {
   }, forceNamespaceFilter, showPolicyEffect)
   const [reconnect, isReconnecting] = useRefreshAnimation(reconnectSSE)
 
-  // Engage SSE server-side filtering on large clusters and keep the filter
-  // in lockstep with the user's pick. Two failure modes this covers:
-  //   * Header switcher: SSE was already filtered (large-cluster picker
-  //     engaged forceNamespaceFilter once); switching namespaces only updated
-  //     `namespaces`, so SSE kept streaming the previous pick → blank graph
-  //     with stale sidebar counts.
-  //   * URL bookmark on a large cluster: forceNamespaceFilter starts
-  //     undefined, SSE opens with no filter, server replies
-  //     requiresNamespaceFilter=true. The LargeClusterPicker fallback only
-  //     renders when `namespaces` is empty, so a deep link with a namespace
-  //     showed "No resources found".
-  // Small clusters never see requiresNamespaceFilter and leave
-  // forceNamespaceFilter === undefined — frontend filtering is unaffected.
+  // On large clusters (where the server requires namespace filtering), keep
+  // SSE's server-side filter in lockstep with the user's namespace pick.
+  // Without this, header switches and deep-link loads can leave SSE filtered
+  // to a stale namespace while sidebar/topology show a different one. Small
+  // clusters never set forceNamespaceFilter and skip this path entirely.
   useEffect(() => {
     const isLarge = forceNamespaceFilter !== undefined || topology?.requiresNamespaceFilter === true
     if (!isLarge) return

--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -61,11 +61,11 @@ export function WorkloadViewRoute({ onNavigateToResource }: WorkloadViewRoutePro
   // buildWorkloadPath; names can also contain literal slashes (e.g. some CRD names),
   // which survive encoding as %2F and reassemble correctly here.
   const parts = location.pathname.replace(/^\//, '').split('/')
-  const decode = (s: string | undefined) => {
-    try { return s ? decodeURIComponent(s) : '' } catch { return s || '' }
+  const decode = (s: string): string => {
+    try { return decodeURIComponent(s) } catch { return s }
   }
-  const kind = decode(parts[1])
-  const namespace = decode(parts[2])
+  const kind = decode(parts[1] ?? '')
+  const namespace = decode(parts[2] ?? '')
   const name = parts.slice(3).map(decode).join('/')
   const group = searchParams.get('apiGroup') || ''
 

--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -57,12 +57,16 @@ export function WorkloadViewRoute({ onNavigateToResource }: WorkloadViewRoutePro
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
 
-  // Parse /workload/:kind/:ns/:name from pathname
+  // Parse /workload/:kind/:ns/:name from pathname. Segments are URL-encoded by
+  // buildWorkloadPath; names can also contain literal slashes (e.g. some CRD names),
+  // which survive encoding as %2F and reassemble correctly here.
   const parts = location.pathname.replace(/^\//, '').split('/')
-  // parts[0] = 'workload', parts[1] = kind, parts[2] = ns, parts[3+] = name (may contain slashes)
-  const kind = parts[1] || ''
-  const namespace = parts[2] || ''
-  const name = parts.slice(3).join('/') || ''
+  const decode = (s: string | undefined) => {
+    try { return s ? decodeURIComponent(s) : '' } catch { return s || '' }
+  }
+  const kind = decode(parts[1])
+  const namespace = decode(parts[2])
+  const name = parts.slice(3).map(decode).join('/')
   const group = searchParams.get('apiGroup') || ''
 
   if (!kind || !namespace || !name) {

--- a/web/src/utils/navigation.ts
+++ b/web/src/utils/navigation.ts
@@ -10,7 +10,10 @@ export type { NavigateToResource } from '@skyhook-io/k8s-ui/utils/navigation'
  * query param so the WorkloadView can resolve CRDs with colliding kind names.
  */
 export function buildWorkloadPath(resource: SelectedResource): string {
-  const base = `/workload/${resource.kind}/${resource.namespace}/${resource.name}`
+  const kind = encodeURIComponent(resource.kind)
+  const namespace = encodeURIComponent(resource.namespace)
+  const name = encodeURIComponent(resource.name)
+  const base = `/workload/${kind}/${namespace}/${name}`
   return resource.group ? `${base}?apiGroup=${encodeURIComponent(resource.group)}` : base
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #699 — addresses the suggestions surfaced by the post-merge review pass that weren't applied before merge.

- **Comments**: strip changelog/migration-history phrasing from `sqlite_store.go`, `resource-hierarchy.ts`, `App.tsx`, and the two `apiVersion?` field docs in `core.ts`. Delete a pure WHAT-restating comment in `parseManifestResources`. Project rule (CLAUDE.md): default to no comments; if you must, explain WHY, never narrate diff history.
- **Helm manifest parser** (`internal/helm/client.go`): add `kind == ""` / `apiVersion == ""` guards mirroring the existing `name`/`namespace` ones. Without them, a CRD with nested `apiVersion:` lines (e.g. inside `spec.template`) ended up with the last match instead of the top-level value.
- **`buildWorkloadPath`** (`web/src/utils/navigation.ts`): URL-encode `kind`/`namespace`/`name` path segments. The previous template-literal interpolation passed raw strings through, which is fine for typical K8s names but produces broken paths for anything with `/`, `%`, `?`, etc.

## Test plan

- [x] `go build ./...` clean
- [x] `npm run tsc` clean
- [x] `/visual-test` on `kind-radar-gitops-demo`: ArgoCD Application drawer, `/workload/Application/...?apiGroup=argoproj.io`, `/workload/HelmRelease/.../?apiGroup=helm.toolkit.fluxcd.io`, Timeline, Helm, Topology — all render, no console errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes Helm manifest resource extraction and workload route encoding/decoding, which can affect displayed owned resources and deep links if any edge cases are missed; no auth or data-destructive logic changes.
> 
> **Overview**
> Fixes Helm owned-resource extraction by ensuring `parseManifestResources` only captures the **first** top-level `kind`/`apiVersion` in each rendered manifest doc, avoiding nested spec fields overwriting the resource identity.
> 
> Makes workload deep links more robust by URL-encoding `kind`/`namespace`/`name` in `buildWorkloadPath` and decoding them in `WorkloadViewRoute`, allowing names with reserved characters (including embedded `/`) to round-trip correctly.
> 
> Cleans up several comments across timeline/SQLite migration checks, resource hierarchy lane grouping, and SSE namespace-filter syncing to describe intent rather than diff history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 593e227b63416d3b46f3a2daca3eabefabd89fa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->