### PR TITLE
fix(deps): align react-dom with react to unbreak v1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3265,15 +3265,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.5"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-markdown": {
@@ -4121,7 +4121,7 @@
         "elkjs": "^0.11.1",
         "lucide-react": "^1.12.0",
         "react": "^19.2.6",
-        "react-dom": "^19.2.4",
+        "react-dom": "^19.2.6",
         "typescript": "^6.0.2",
         "vitest": "^4.1.5",
         "yaml": "^2.9.0"
@@ -4197,7 +4197,7 @@
         "postcss": "^8.5.14",
         "prettier": "^3.8.1",
         "react": "^19.2.6",
-        "react-dom": "^19.2.5",
+        "react-dom": "^19.2.6",
         "react-router-dom": "^7.15.0",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.4",

--- a/packages/k8s-ui/package.json
+++ b/packages/k8s-ui/package.json
@@ -87,7 +87,7 @@
     "elkjs": "^0.11.1",
     "lucide-react": "^1.12.0",
     "react": "^19.2.6",
-    "react-dom": "^19.2.4",
+    "react-dom": "^19.2.6",
     "typescript": "^6.0.2",
     "vitest": "^4.1.5",
     "yaml": "^2.9.0"

--- a/web/package.json
+++ b/web/package.json
@@ -67,7 +67,7 @@
     "postcss": "^8.5.14",
     "prettier": "^3.8.1",
     "react": "^19.2.6",
-    "react-dom": "^19.2.5",
+    "react-dom": "^19.2.6",
     "react-router-dom": "^7.15.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.4",


### PR DESCRIPTION
## Summary
- v1.6.0 ships a blank window on Windows/Linux/macOS and in browsers (issue #705). Root cause is React error #527: `react@19.2.6` and `react-dom@19.2.5` were bundled side by side, and React's runtime refuses to mount when the two packages disagree.
- The dependabot batch in #700 bumped `react` to `^19.2.6` but left `react-dom` at `^19.2.4` / `^19.2.5`. This aligns both to `^19.2.6` and regenerates the lockfile.

## Verification
- Downloaded the shipped `radar_v1.6.0_darwin_arm64` binary and reproduced #705 — browser console shows `Minified React error #527; args[]=19.2.6&args[]=19.2.5`.
- Rebuilt from this branch, loaded the page in Playwright/Chromium: page renders, zero console errors.

## Test plan
- [x] Reproduce blank-window with shipped v1.6.0
- [x] Confirm console clean after fix
- [ ] Cut v1.6.1 once merged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency alignment change with no application logic modifications; main risk is unforeseen behavior changes from the `react-dom` patch update.
> 
> **Overview**
> Fixes a production-breaking React runtime mismatch by bumping `react-dom` to `^19.2.6` wherever `react@^19.2.6` is used (in `web` and `packages/k8s-ui`).
> 
> Regenerates `package-lock.json` so the resolved `react-dom` package (and its `react` peer constraint) is consistently `19.2.6`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3fb29aea9ace1a282e3324b8ed9311c7107e5e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->