### PR TITLE
fix(helm): make manifest diff view scrollable

### DIFF
--- a/web/src/components/helm/ManifestDiffViewer.tsx
+++ b/web/src/components/helm/ManifestDiffViewer.tsx
@@ -44,7 +44,7 @@ export function ManifestDiffViewer({ diff, isLoading, revision1, revision2, onCl
         </button>
       </div>
 
-      <div className="rounded-lg overflow-hidden max-h-[calc(100vh-300px)] overflow-auto bg-theme-base/50 font-mono text-xs">
+      <div className="rounded-lg max-h-[calc(100vh-300px)] overflow-auto bg-theme-base/50 font-mono text-xs">
         <div className="p-3">
           {diff.split('\n').map((line, index) => (
             <DiffLine key={index} line={line} />


### PR DESCRIPTION
## Summary

When comparing two Helm release revisions, the diff view clipped its content at `max-h-[calc(100vh-300px)]` with no scrollbar — releases with many changes were unreachable past the fold.

The scroll container in `ManifestDiffViewer.tsx` had both `overflow-hidden` and `overflow-auto`. Tailwind emits `overflow-hidden` after `overflow-auto` in its generated CSS (alphabetical ordering), so `overflow-hidden` won and clipped the diff. Dropping `overflow-hidden` lets `overflow-auto` apply — it already clips at the rounded corners on its own.

Co-authored with @amanfrinati, who independently found and fixed the same issue in #703.

Fixes #702

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts Tailwind overflow classes to ensure the diff container scrolls; no data or business logic is affected.
>
> **Overview**
> Ensures the Helm `ManifestDiffViewer` diff area is actually scrollable for large diffs by removing the conflicting `overflow-hidden` class so `overflow-auto` takes effect while keeping the existing max-height constraint.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cd6384a5452babafc57ca258c8b041d0574c7e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->