### PR TITLE
Respect per-user Secret RBAC in cache-served reads (#688)

### DIFF
--- a/internal/mcp/permissions.go
+++ b/internal/mcp/permissions.go
@@ -176,6 +176,62 @@ func canReadClusterScopedKind(ctx context.Context, kind, group, verb string) boo
 	return allowed
 }
 
+// canReadInNamespace authorizes a single (verb, group, resource, namespace)
+// read via SubjectAccessReview, memoizing on UserPermissions.canI. Use when
+// per-kind RBAC inside a namespace differs from namespace-list discovery
+// (e.g. user can list pods but not secrets in `team-a`).
+//
+// namespace="" issues an any-namespace SAR — for a *namespaced* kind that
+// asks "can the user list this kind cluster-wide?" (useful as the
+// cluster-wide-scan branch in search RBAC). For *cluster-scoped* kinds
+// keep using canReadClusterScopedKind; it routes via ClassifyKindScope.
+//
+// Returns true (passthrough) when no user is on context — auth-mode=none
+// applies the SA's RBAC at the cache layer.
+func canReadInNamespace(ctx context.Context, group, resource, namespace, verb string) bool {
+	user, perms := resolveUserPerms(ctx)
+	if user == nil {
+		return true
+	}
+	if perms != nil {
+		if v, ok := perms.CanI(verb, group, resource, namespace); ok {
+			return v
+		}
+	}
+	client := k8s.GetClient()
+	if client == nil {
+		log.Printf("[mcp] canReadInNamespace: no K8s client, denying %s on %s/%s in %q for %s", k8s.SanitizeForLog(verb), k8s.SanitizeForLog(group), k8s.SanitizeForLog(resource), k8s.SanitizeForLog(namespace), k8s.SanitizeForLog(user.Username))
+		return false
+	}
+	allowed, err := subjectCanI(ctx, client, user.Username, user.Groups, namespace, group, resource, verb)
+	if err != nil {
+		log.Printf("[mcp] canReadInNamespace SAR failed for %s on %s/%s in %q: %v", k8s.SanitizeForLog(user.Username), k8s.SanitizeForLog(group), k8s.SanitizeForLog(resource), k8s.SanitizeForLog(namespace), err)
+		return false
+	}
+	if perms != nil {
+		perms.SetCanI(verb, group, resource, namespace, allowed)
+	}
+	return allowed
+}
+
+// filterNamespacesByCanRead returns the subset of `namespaces` where the
+// calling user passes a per-namespace SAR for (group, resource, verb). The
+// MCP-side mirror of Server.filterNamespacesByCanRead.
+//
+// nil or empty input is returned unchanged.
+func filterNamespacesByCanRead(ctx context.Context, group, resource, verb string, namespaces []string) []string {
+	if len(namespaces) == 0 {
+		return namespaces
+	}
+	out := make([]string, 0, len(namespaces))
+	for _, ns := range namespaces {
+		if canReadInNamespace(ctx, group, resource, ns, verb) {
+			out = append(out, ns)
+		}
+	}
+	return out
+}
+
 // retainAllowedObjects post-filters cache results for namespace-restricted users.
 // FetchResourceList accepts an `allowed` namespace slice for namespaced kinds
 // (it iterates per-namespace), but cluster-scoped lookups (e.g. cache.Nodes)

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -413,6 +413,26 @@ func handleListResources(ctx context.Context, req *mcp.CallToolRequest, input li
 		return toJSONResult([]any{})
 	}
 
+	// Per-kind RBAC inside a namespace for Secrets. The cache reads as the SA,
+	// and the chart can grant the SA cluster-wide secrets (rbac.secrets,
+	// rbac.helm, auth.mode != "none", or cloud.enabled — Helm release
+	// visibility), so per-user RBAC must gate the read. canReadInNamespace
+	// and filterNamespacesByCanRead pass through when no user is on context
+	// (auth-mode=none — SA RBAC at the cache layer is the only gate). Other
+	// namespaced kinds are deferred.
+	if kind == "secrets" || kind == "secret" {
+		if allowed == nil {
+			if !canReadInNamespace(ctx, "", "secrets", "", "list") {
+				return toJSONResult([]any{})
+			}
+		} else {
+			allowed = filterNamespacesByCanRead(ctx, "", "secrets", "list", allowed)
+			if len(allowed) == 0 {
+				return toJSONResult([]any{})
+			}
+		}
+	}
+
 	// For cluster-scoped reads, force a cluster-wide list (don't iterate
 	// per allowed namespace — cluster-scoped resources don't live there).
 	listScope := allowed
@@ -510,6 +530,14 @@ func handleGetResource(ctx context.Context, req *mcp.CallToolRequest, input getR
 		}
 	} else if !checkNamespaceAccess(ctx, namespace) {
 		return nil, nil, fmt.Errorf("forbidden: no access to namespace %q", namespace)
+	} else if kind == "secrets" || kind == "secret" {
+		// Per-kind RBAC inside the namespace — the chart can grant the SA
+		// cluster-wide secrets (Helm release visibility), so namespace-list
+		// discovery is not a sufficient gate. The list handler has the
+		// matching list-SAR.
+		if !canReadInNamespace(ctx, "", "secrets", namespace, "get") {
+			return nil, nil, fmt.Errorf("forbidden: no access to secrets in namespace %q", namespace)
+		}
 	}
 
 	// Try typed cache first
@@ -1849,12 +1877,15 @@ func intersectAllowedNamespaces(allowed, requested []string) []string {
 	return out
 }
 
+// mcpSensitiveSearchKinds is the MCP mirror of the REST sensitiveSearchKinds —
+// cluster-scoped kinds that need their own list-SAR per user. Secrets are
+// namespaced and handled by mcpSearchSecretsRBAC instead, which supports
+// per-namespace permission.
 var mcpSensitiveSearchKinds = []struct {
 	Kind     string
 	Resource string
 	Group    string
 }{
-	{"Secret", "secrets", ""},
 	{"Node", "nodes", ""},
 	{"PersistentVolume", "persistentvolumes", ""},
 	{"StorageClass", "storageclasses", "storage.k8s.io"},
@@ -1900,6 +1931,39 @@ func mcpSearchSkipKinds(ctx context.Context) map[string]bool {
 	return out
 }
 
+// mcpSearchSecretsRBAC mirrors Server.computeSearchSecretsRBAC for MCP. See
+// that function for the three-case semantics. scanNamespaces is the
+// effective scan scope (intersection of the user's RBAC-allowed namespaces
+// and any `ns:` modifier in the query) — nil means a true cluster-wide scan.
+//
+// Cached canI hits short-circuit before the live-client path, so a seeded
+// test cache authorizes without needing a real K8s client.
+func mcpSearchSecretsRBAC(ctx context.Context, scanNamespaces []string) (decision string, scopedNamespaces []string) {
+	if user, _ := resolveUserPerms(ctx); user == nil {
+		return "", nil
+	}
+
+	if scanNamespaces == nil {
+		if canReadInNamespace(ctx, "", "secrets", "", "list") {
+			return "", nil
+		}
+		return "skip", nil
+	}
+	if len(scanNamespaces) == 0 {
+		return "skip", nil
+	}
+	scoped := make([]string, 0, len(scanNamespaces))
+	for _, ns := range scanNamespaces {
+		if canReadInNamespace(ctx, "", "secrets", ns, "list") {
+			scoped = append(scoped, ns)
+		}
+	}
+	if len(scoped) == 0 {
+		return "skip", nil
+	}
+	return "override", scoped
+}
+
 func handleSearch(ctx context.Context, req *mcp.CallToolRequest, input searchInput) (*mcp.CallToolResult, any, error) {
 	provider := search.NewCacheProvider()
 	if provider == nil {
@@ -1926,11 +1990,33 @@ func handleSearch(ctx context.Context, req *mcp.CallToolRequest, input searchInp
 	default:
 		return nil, nil, fmt.Errorf("unknown include=%q (want: summary, raw, none)", input.Include)
 	}
+
+	skipKinds := mcpSearchSkipKinds(ctx)
+	// Secrets: per-namespace SAR fanout. See REST handleSearch for rationale.
+	// scanNamespaces (not allowed) is the SAR-fanout input — a user with
+	// AllowedNamespaces==nil (cluster-wide-pods sentinel) who constrains
+	// with `ns:team-a` should fanout over team-a, not run a cluster-scope
+	// `list secrets` SAR they may not have.
+	var namespacesByKind map[string][]string
+	switch decision, scoped := mcpSearchSecretsRBAC(ctx, scanNamespaces); decision {
+	case "skip":
+		if skipKinds == nil {
+			skipKinds = make(map[string]bool)
+		}
+		skipKinds["Secret"] = true
+	case "override":
+		// scoped ⊆ scanNamespaces ⊆ parsed.NSFilter already (the SAR fanout
+		// iterates scanNamespaces, which is the upstream intersection of
+		// allowed and parsed.NSFilter). Use the SAR result directly.
+		namespacesByKind = map[string][]string{"Secret": scoped}
+	}
+
 	opts := search.Options{
-		Limit:      input.Limit,
-		Include:    include,
-		Namespaces: scanNamespaces,
-		SkipKinds:  mcpSearchSkipKinds(ctx),
+		Limit:            input.Limit,
+		Include:          include,
+		Namespaces:       scanNamespaces,
+		SkipKinds:        skipKinds,
+		NamespacesByKind: namespacesByKind,
 		CanReadClusterScoped: func(kind, group, resource string) bool {
 			return canReadClusterScopedKind(ctx, kind, group, "list")
 		},

--- a/internal/mcp/tools_filter_test.go
+++ b/internal/mcp/tools_filter_test.go
@@ -38,6 +38,14 @@ func setupFakeCacheForFilterTests(t *testing.T) {
 
 		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
 		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-2"}},
+
+		// Seeded for per-namespace Secret RBAC tests. The cache holds
+		// secrets across all three namespaces (mirrors the chart's optional
+		// cluster-wide secrets grant for the SA); per-user RBAC must narrow
+		// the view at read time.
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "alpha-secret", Namespace: "alpha"}, Type: corev1.SecretTypeOpaque},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "beta-secret", Namespace: "beta"}, Type: corev1.SecretTypeOpaque},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "gamma-secret", Namespace: "gamma"}, Type: corev1.SecretTypeOpaque},
 	)
 
 	if err := k8s.InitTestResourceCache(fakeClient); err != nil {
@@ -390,5 +398,231 @@ func TestHandleGetEvents_RestrictedAggregatesAllowed(t *testing.T) {
 	body := extractText(t, result)
 	if !strings.Contains(body, "[]") {
 		t.Errorf("expected empty result for denied namespace, got: %s", body)
+	}
+}
+
+// --- Per-namespace Secret RBAC ---
+//
+// The chart grants the Radar SA cluster-wide secrets so Helm release
+// visibility works under auth modes. The cache therefore holds secrets
+// across all namespaces; the server must gate reads per-user, per-namespace.
+// These tests pin the gate at the MCP layer for list_resources / get_resource.
+
+// seedSecretListCanI seeds the per-namespace canI cache for `list` on
+// secrets only. Each list-handler test should call this (not both verbs)
+// so a regression where the handler accidentally checks the wrong verb
+// surfaces as a failed assertion.
+func seedSecretListCanI(t *testing.T, username string, allowedNamespaces []string, deniedNamespaces []string) {
+	t.Helper()
+	seedSecretCanIVerb(t, username, "list", allowedNamespaces, deniedNamespaces)
+}
+
+// seedSecretGetCanI is the `get`-verb counterpart. See seedSecretListCanI.
+func seedSecretGetCanI(t *testing.T, username string, allowedNamespaces []string, deniedNamespaces []string) {
+	t.Helper()
+	seedSecretCanIVerb(t, username, "get", allowedNamespaces, deniedNamespaces)
+}
+
+func seedSecretCanIVerb(t *testing.T, username, verb string, allowedNamespaces []string, deniedNamespaces []string) {
+	t.Helper()
+	perms := getPermCache().Get(username)
+	if perms == nil {
+		t.Fatalf("user %q not in perm cache", username)
+	}
+	for _, ns := range allowedNamespaces {
+		perms.SetCanI(verb, "", "secrets", ns, true)
+	}
+	for _, ns := range deniedNamespaces {
+		perms.SetCanI(verb, "", "secrets", ns, false)
+	}
+}
+
+func TestHandleListResources_Secrets_DeniedInAllNamespaces(t *testing.T) {
+	setupFakeCacheForFilterTests(t)
+	// alice has namespace access to alpha but no per-namespace secret read.
+	ctx := withRestrictedUser(t, "alice", []string{"alpha"})
+	seedSecretListCanI(t, "alice", nil, []string{"alpha"})
+
+	result, _, err := handleListResources(ctx, nil, listResourcesInput{Kind: "secrets"})
+	if err != nil {
+		t.Fatalf("handleListResources: %v", err)
+	}
+	body := extractText(t, result)
+	if containsName(body, "alpha-secret") {
+		t.Errorf("denied secret leaked through namespace-only gate: %s", body)
+	}
+}
+
+func TestHandleListResources_Secrets_PartialNamespaceAccess(t *testing.T) {
+	// alice has namespace access to alpha AND beta, but per-namespace secret
+	// read only in alpha. Should see alpha-secret only, not beta-secret —
+	// even though beta is in her namespace allow-list.
+	setupFakeCacheForFilterTests(t)
+	ctx := withRestrictedUser(t, "alice", []string{"alpha", "beta"})
+	seedSecretListCanI(t, "alice", []string{"alpha"}, []string{"beta"})
+
+	result, _, err := handleListResources(ctx, nil, listResourcesInput{Kind: "secrets"})
+	if err != nil {
+		t.Fatalf("handleListResources: %v", err)
+	}
+	body := extractText(t, result)
+	if !containsName(body, "alpha-secret") {
+		t.Errorf("expected alpha-secret in result: %s", body)
+	}
+	if containsName(body, "beta-secret") {
+		t.Errorf("beta-secret leaked despite per-namespace secret deny: %s", body)
+	}
+}
+
+func TestHandleListResources_Secrets_ClusterWideShape_NoSecretRBAC(t *testing.T) {
+	// User with AllowedNamespaces==nil (cluster-wide namespace sentinel from
+	// DiscoverNamespaces stage 1: list-pods cluster-wide) but no cluster-scope
+	// secrets RBAC. Cluster-wide pod visibility does NOT imply cluster-wide
+	// secret visibility — pin the cluster-scope SAR gate so this conflation
+	// can't return.
+	setupFakeCacheForFilterTests(t)
+	ctx := withClusterAdmin(t, "broad-reader")
+	perms := getPermCache().Get("broad-reader")
+	if perms == nil {
+		t.Fatalf("broad-reader not in cache")
+	}
+	perms.SetCanI("list", "", "secrets", "", false)
+
+	result, _, err := handleListResources(ctx, nil, listResourcesInput{Kind: "secrets"})
+	if err != nil {
+		t.Fatalf("handleListResources: %v", err)
+	}
+	body := extractText(t, result)
+	for _, want := range []string{"alpha-secret", "beta-secret", "gamma-secret"} {
+		if containsName(body, want) {
+			t.Errorf("secret %q leaked to cluster-wide-pods user without secrets SAR: %s", want, body)
+		}
+	}
+}
+
+func TestHandleListResources_Secrets_ClusterWideShape_WithSecretRBAC(t *testing.T) {
+	// Same shape as the previous test but with the cluster-scope secrets SAR
+	// allowed — user sees every secret in the cache.
+	setupFakeCacheForFilterTests(t)
+	ctx := withClusterAdmin(t, "broad-reader")
+	perms := getPermCache().Get("broad-reader")
+	if perms == nil {
+		t.Fatalf("broad-reader not in cache")
+	}
+	perms.SetCanI("list", "", "secrets", "", true)
+
+	result, _, err := handleListResources(ctx, nil, listResourcesInput{Kind: "secrets"})
+	if err != nil {
+		t.Fatalf("handleListResources: %v", err)
+	}
+	body := extractText(t, result)
+	for _, want := range []string{"alpha-secret", "beta-secret", "gamma-secret"} {
+		if !containsName(body, want) {
+			t.Errorf("cluster-wide secret reader missing %s: %s", want, body)
+		}
+	}
+}
+
+func TestHandleListResources_Secrets_NoAuthPassthrough(t *testing.T) {
+	// auth.mode=none: no user on context. Helpers passthrough; the SA's cache
+	// RBAC is the only gate. Every cached secret is visible.
+	setupFakeCacheForFilterTests(t)
+
+	result, _, err := handleListResources(context.Background(), nil, listResourcesInput{Kind: "secrets"})
+	if err != nil {
+		t.Fatalf("handleListResources: %v", err)
+	}
+	body := extractText(t, result)
+	for _, want := range []string{"alpha-secret", "beta-secret", "gamma-secret"} {
+		if !containsName(body, want) {
+			t.Errorf("no-auth passthrough missing %s: %s", want, body)
+		}
+	}
+}
+
+func TestHandleGetResource_Secret_DeniedInNamespace(t *testing.T) {
+	// alice has namespace access to alpha and to the alpha namespace's
+	// other resources, but the per-namespace secret get SAR denies. The
+	// cache has alpha-secret; without the gate this would 200 with the
+	// secret object.
+	setupFakeCacheForFilterTests(t)
+	ctx := withRestrictedUser(t, "alice", []string{"alpha"})
+	seedSecretGetCanI(t, "alice", nil, []string{"alpha"})
+
+	_, _, err := handleGetResource(ctx, nil, getResourceInput{Kind: "secrets", Namespace: "alpha", Name: "alpha-secret"})
+	if err == nil {
+		t.Fatal("expected forbidden error for secret in denied-secret namespace, got nil")
+	}
+	if !strings.Contains(err.Error(), "forbidden") {
+		t.Errorf("expected 'forbidden' in error, got: %v", err)
+	}
+}
+
+func TestHandleGetResource_Secret_AllowedInNamespace(t *testing.T) {
+	setupFakeCacheForFilterTests(t)
+	ctx := withRestrictedUser(t, "alice", []string{"alpha"})
+	seedSecretGetCanI(t, "alice", []string{"alpha"}, nil)
+
+	result, _, err := handleGetResource(ctx, nil, getResourceInput{Kind: "secrets", Namespace: "alpha", Name: "alpha-secret"})
+	if err != nil {
+		t.Fatalf("handleGetResource: %v", err)
+	}
+	body := extractText(t, result)
+	if !containsName(body, "alpha-secret") {
+		t.Errorf("expected alpha-secret in result, got: %s", body)
+	}
+}
+
+func TestHandleSearch_Secrets_PerNamespaceFanout(t *testing.T) {
+	// /api/search (and the MCP equivalent) must do per-namespace SAR fanout
+	// for Secrets so the resource browser and search agree on visibility.
+	// A cluster-scope SAR alone would silently drop Secret for any
+	// namespace-bounded user. Pin: secrets in allowed namespaces are
+	// searchable; those in denied namespaces are not.
+	setupFakeCacheForFilterTests(t)
+	ctx := withRestrictedUser(t, "alice", []string{"alpha", "beta"})
+	seedSecretListCanI(t, "alice", []string{"alpha"}, []string{"beta"})
+
+	result, _, err := handleSearch(ctx, nil, searchInput{Q: "kind:Secret"})
+	if err != nil {
+		t.Fatalf("handleSearch: %v", err)
+	}
+	body := extractText(t, result)
+	if !containsName(body, "alpha-secret") {
+		t.Errorf("expected alpha-secret in search hits: %s", body)
+	}
+	if containsName(body, "beta-secret") {
+		t.Errorf("beta-secret leaked in search despite per-ns deny: %s", body)
+	}
+}
+
+func TestHandleSearch_Secrets_ClusterWideShape_NsFilter(t *testing.T) {
+	// Regression for the bug where AllowedNamespaces==nil (cluster-wide
+	// namespace sentinel) plus a concrete `ns:` filter took the cluster-
+	// scope SAR branch and skipped Secret entirely. The user has list-pods
+	// cluster-wide but secrets only in alpha — the search-RBAC decision
+	// must fan out over the requested namespaces, not run a cluster-scope
+	// `list secrets` SAR.
+	setupFakeCacheForFilterTests(t)
+	ctx := withClusterAdmin(t, "broad-reader")
+	perms := getPermCache().Get("broad-reader")
+	if perms == nil {
+		t.Fatalf("broad-reader not in cache")
+	}
+	// No cluster-scope secrets RBAC — only per-namespace in alpha.
+	perms.SetCanI("list", "", "secrets", "", false)
+	perms.SetCanI("list", "", "secrets", "alpha", true)
+	perms.SetCanI("list", "", "secrets", "beta", false)
+
+	result, _, err := handleSearch(ctx, nil, searchInput{Q: "kind:Secret ns:alpha"})
+	if err != nil {
+		t.Fatalf("handleSearch: %v", err)
+	}
+	body := extractText(t, result)
+	if !containsName(body, "alpha-secret") {
+		t.Errorf("expected alpha-secret in search hits (cluster-wide-shape user with per-ns secret RBAC): %s", body)
+	}
+	if containsName(body, "beta-secret") {
+		t.Errorf("beta-secret leaked despite ns:alpha filter + per-ns RBAC: %s", body)
 	}
 }

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -156,7 +156,11 @@ func Search(ctx context.Context, p Provider, q Query, opts Options) (Result, err
 				continue
 			}
 			listNs = nil
-		} else if override, ok := opts.NamespacesByKind[tk.Kind]; ok {
+		} else if override, ok := opts.NamespacesByKind[tk.Kind]; ok && override != nil {
+			// nil overrides fall back to Options.Namespaces (per doc): without
+			// this guard a nil entry would set listNs=nil and trigger a
+			// cluster-wide list — silent bypass of the namespace constraint
+			// in security-sensitive code.
 			listNs = override
 		}
 		objs, err := p.ListTyped(tk.Plural, listNs)

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -82,13 +82,19 @@ type Options struct {
 	Namespaces []string
 	// SkipKinds names kinds the walker must NOT scan, regardless of
 	// query/filter content. The handler populates this from per-user
-	// SubjectAccessReviews against sensitive kinds (Secret, Node,
-	// PersistentVolume, StorageClass, Namespace) — users without the
-	// list verb at cluster scope don't see those rows even if the
-	// underlying SA's informer cache holds them. Without this gate, a
-	// k8s `view` Cloud viewer would see Secret names, Node IPs, etc.
-	// because the cache reads happen as the SA, not the end user.
+	// SubjectAccessReviews against sensitive kinds (Node, PersistentVolume,
+	// StorageClass, Namespace, and Secrets when the user has no per-namespace
+	// access at all) — users without the list verb don't see those rows even
+	// if the underlying SA's informer cache holds them. Without this gate, a
+	// k8s `view` Cloud viewer would see Secret names, Node IPs, etc. because
+	// the cache reads happen as the SA, not the end user.
 	SkipKinds map[string]bool
+	// NamespacesByKind, when set for a typed kind, replaces Options.Namespaces
+	// for that kind only. Use this when per-kind RBAC narrows access below
+	// the namespace-discovery boundary (e.g. user can list pods cluster-wide
+	// but secrets only in `team-a`). Cluster-scoped kinds and dynamic CRDs
+	// ignore this map. nil entries fall back to Options.Namespaces.
+	NamespacesByKind map[string][]string
 	// CanReadClusterScoped authorizes cluster-scoped resources before the
 	// cache walker scans them. Handlers provide a per-user SAR-backed
 	// predicate; nil preserves auth-mode=none behavior where the service
@@ -141,13 +147,17 @@ func Search(ctx context.Context, p Provider, q Query, opts Options) (Result, err
 			continue
 		}
 		// Cluster-scoped kinds ignore the namespace constraint — they're
-		// orthogonal to namespace RBAC.
+		// orthogonal to namespace RBAC. Namespaced kinds may have a per-kind
+		// override (e.g. user has list-secrets only in a subset of their
+		// allowed namespaces); fall back to Options.Namespaces otherwise.
 		listNs := opts.Namespaces
 		if isClusterScopedKind(tk.Kind) {
 			if opts.CanReadClusterScoped != nil && !opts.CanReadClusterScoped(tk.Kind, tk.Group, tk.Plural) {
 				continue
 			}
 			listNs = nil
+		} else if override, ok := opts.NamespacesByKind[tk.Kind]; ok {
+			listNs = override
 		}
 		objs, err := p.ListTyped(tk.Plural, listNs)
 		if err != nil {

--- a/internal/search/skipkinds_test.go
+++ b/internal/search/skipkinds_test.go
@@ -90,3 +90,74 @@ func TestSearch_SkipKinds_PreservesOtherKinds(t *testing.T) {
 // Keep appsv1 referenced so future test cases retain the import without
 // linter churn.
 var _ = appsv1.SchemeGroupVersion
+
+// recordingProvider wraps fakeProvider to capture the namespaces argument
+// each ListTyped call receives. Used to verify per-kind namespace scoping.
+type recordingProvider struct {
+	*fakeProvider
+	listedWith map[string][]string // kind → namespaces last passed
+}
+
+func (r *recordingProvider) ListTyped(kind string, namespaces []string) ([]runtime.Object, error) {
+	if r.listedWith == nil {
+		r.listedWith = make(map[string][]string)
+	}
+	r.listedWith[kind] = append([]string(nil), namespaces...)
+	return r.fakeProvider.ListTyped(kind, namespaces)
+}
+
+func TestSearch_NamespacesByKind_OverridesPerKind(t *testing.T) {
+	// Per-kind namespace override. When Secrets get a tighter scope than the
+	// global Options.Namespaces (e.g. user has list pods in ns-a+ns-b but
+	// list secrets only in ns-a), Secrets must list only the override set
+	// while other kinds keep using Options.Namespaces.
+	rec := &recordingProvider{
+		fakeProvider: &fakeProvider{
+			typed: map[string][]runtime.Object{
+				"secrets": {
+					&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "ns-a", Name: "redis-cred"}},
+				},
+				"pods": {
+					&corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "ns-a", Name: "redis-loader"},
+						Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "redis"}}},
+					},
+				},
+			},
+		},
+	}
+	res, _ := Search(context.Background(), rec, Parse("redis"), Options{
+		Include:          IncludeNone,
+		Namespaces:       []string{"ns-a", "ns-b"},
+		NamespacesByKind: map[string][]string{"Secret": {"ns-a"}},
+	})
+
+	if got := rec.listedWith["pods"]; len(got) != 2 || got[0] != "ns-a" || got[1] != "ns-b" {
+		t.Errorf("pods listed with %v, want [ns-a ns-b]", got)
+	}
+	if got := rec.listedWith["secrets"]; len(got) != 1 || got[0] != "ns-a" {
+		t.Errorf("secrets listed with %v, want [ns-a]", got)
+	}
+	if len(res.Hits) == 0 {
+		t.Error("expected at least one hit")
+	}
+}
+
+func TestSearch_NamespacesByKind_NilFallsThroughToNamespaces(t *testing.T) {
+	rec := &recordingProvider{
+		fakeProvider: &fakeProvider{
+			typed: map[string][]runtime.Object{
+				"secrets": {&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "ns-a", Name: "redis-cred"}}},
+			},
+		},
+	}
+	_, _ = Search(context.Background(), rec, Parse("redis"), Options{
+		Include:          IncludeNone,
+		Namespaces:       []string{"ns-a"},
+		NamespacesByKind: nil,
+	})
+
+	if got := rec.listedWith["secrets"]; len(got) != 1 || got[0] != "ns-a" {
+		t.Errorf("secrets listed with %v, want [ns-a] (Options.Namespaces fallback)", got)
+	}
+}

--- a/internal/search/skipkinds_test.go
+++ b/internal/search/skipkinds_test.go
@@ -161,3 +161,26 @@ func TestSearch_NamespacesByKind_NilFallsThroughToNamespaces(t *testing.T) {
 		t.Errorf("secrets listed with %v, want [ns-a] (Options.Namespaces fallback)", got)
 	}
 }
+
+func TestSearch_NamespacesByKind_NilEntryDoesNotBypass(t *testing.T) {
+	// A nil entry in the per-kind map must fall back to Options.Namespaces,
+	// not become a cluster-wide list. Pin the doc/code agreement so a future
+	// caller passing map[string][]string{"Secret": nil} can't silently widen
+	// scope past the user's RBAC-allowed namespaces.
+	rec := &recordingProvider{
+		fakeProvider: &fakeProvider{
+			typed: map[string][]runtime.Object{
+				"secrets": {&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "ns-a", Name: "redis-cred"}}},
+			},
+		},
+	}
+	_, _ = Search(context.Background(), rec, Parse("redis"), Options{
+		Include:          IncludeNone,
+		Namespaces:       []string{"ns-a"},
+		NamespacesByKind: map[string][]string{"Secret": nil},
+	})
+
+	if got := rec.listedWith["secrets"]; len(got) != 1 || got[0] != "ns-a" {
+		t.Errorf("secrets listed with %v, want [ns-a] (nil override should fall back, not go cluster-wide)", got)
+	}
+}

--- a/internal/server/search_handler.go
+++ b/internal/server/search_handler.go
@@ -57,18 +57,44 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	skipKinds := s.computeSearchSkipKinds(r)
+	// Secrets are namespaced and get per-namespace RBAC treatment so a user
+	// with per-namespace Secret access (e.g. a Role-bound viewer) sees those
+	// rows in search instead of having Secret dropped at cluster scope.
+	// scanNamespaces (not allowed) is the right input: a user with
+	// AllowedNamespaces==nil (cluster-wide-pods sentinel) who queries
+	// `ns:team-a` should get per-namespace fanout over team-a, not a
+	// cluster-scope `list secrets` SAR — they may have list-secrets in
+	// team-a but not cluster-wide. nil scanNamespaces (truly cluster-wide
+	// query) still routes to the cluster-scope SAR branch.
+	var namespacesByKind map[string][]string
+	switch decision, scoped := s.computeSearchSecretsRBAC(r, scanNamespaces); decision {
+	case "skip":
+		if skipKinds == nil {
+			skipKinds = make(map[string]bool)
+		}
+		skipKinds["Secret"] = true
+	case "override":
+		// scoped ⊆ scanNamespaces ⊆ parsed.NSFilter already (the SAR fanout
+		// iterates scanNamespaces, which is the upstream intersection of
+		// allowed and parsed.NSFilter). Use the SAR result directly.
+		namespacesByKind = map[string][]string{"Secret": scoped}
+	}
+
 	opts := search.Options{
 		Limit:      parseLimit(r.URL.Query().Get("limit")),
 		Include:    include,
 		Namespaces: scanNamespaces,
-		// SAR-gate sensitive kinds (Secret + cluster-scoped) by the
-		// END user's identity, not the SA's. The cache itself reads
-		// as the SA so it carries Secrets/Nodes/etc., but exposing
-		// them through search to a namespace-bound viewer would let
-		// them enumerate cluster-scope info their k8s RBAC denies.
-		// In auth-mode=none, returns nil and the SA's own RBAC at
-		// the cache lister layer is the only filter.
-		SkipKinds: s.computeSearchSkipKinds(r),
+		// SAR-gate sensitive cluster-scoped kinds (Node, PV, StorageClass,
+		// Namespace) by the END user's identity, not the SA's. The cache
+		// itself reads as the SA so it carries those rows, but exposing
+		// them through search to a namespace-bound viewer would let them
+		// enumerate cluster-scope info their k8s RBAC denies. Secrets get
+		// per-namespace RBAC via NamespacesByKind/SkipKinds above. In
+		// auth-mode=none, computeSearchSkipKinds returns nil and the SA's
+		// own RBAC at the cache lister layer is the only filter.
+		SkipKinds:        skipKinds,
+		NamespacesByKind: namespacesByKind,
 		CanReadClusterScoped: func(kind, group, resource string) bool {
 			if auth.UserFromContext(r.Context()) == nil {
 				return true

--- a/internal/server/search_rbac.go
+++ b/internal/server/search_rbac.go
@@ -10,31 +10,23 @@ import (
 	pkgauth "github.com/skyhook-io/radar/pkg/auth"
 )
 
-// sensitiveSearchKinds enumerates kinds whose default presence in
-// /api/search results would leak information beyond what the calling
-// user can fetch via /api/resources/{kind} under their own RBAC.
-// Secrets are sensitive even when redacted (names, label keys, env-
-// var names already enough for a recon foothold). Cluster-scoped
-// kinds (Node, PersistentVolume, StorageClass, Namespace) imply
-// cluster-wide read which a namespace-bounded Cloud viewer doesn't
-// have.
+// sensitiveSearchKinds enumerates cluster-scoped kinds whose default presence
+// in /api/search results would leak information beyond what the calling user
+// can fetch via /api/resources/{kind} under their own RBAC. Read access to a
+// namespace doesn't imply read access to Node, PersistentVolume,
+// StorageClass, or Namespace metadata — these need their own cluster-scope
+// SAR. Secrets are namespaced and handled separately by
+// computeSearchSecretsRBAC, which supports per-namespace permission.
 //
-// The walker in internal/search consults Options.SkipKinds, populated
-// by SAR per (user, kind) at cluster scope. Users without `list X`
-// at cluster scope have X dropped from the scan — including for
-// explicit `kind:X` queries, which return zero hits silently.
-// Trade-off: a user with per-namespace `list secrets` permission
-// loses /api/search coverage for secrets; they can still hit
-// /api/resources/secrets?namespace=X directly, which the cache layer
-// handles with its own SA-level gating. Deemed acceptable for v1.
-// Per-namespace SAR fanout (one SAR per requested namespace per
-// kind) is a follow-up if customer evidence demands it.
+// The walker in internal/search consults Options.SkipKinds, populated by SAR
+// per (user, kind) at cluster scope. Users without `list X` at cluster scope
+// have X dropped from the scan — including for explicit `kind:X` queries,
+// which return zero hits silently.
 var sensitiveSearchKinds = []struct {
 	Kind     string // singular Kind for SkipKinds map
 	Resource string // plural for SAR ResourceAttributes
 	Group    string // API group; empty for core
 }{
-	{"Secret", "secrets", ""},
 	{"Node", "nodes", ""},
 	{"PersistentVolume", "persistentvolumes", ""},
 	{"StorageClass", "storageclasses", "storage.k8s.io"},
@@ -101,6 +93,54 @@ func (s *Server) computeSearchSkipKinds(r *http.Request) map[string]bool {
 		}
 	}
 	return skip
+}
+
+// computeSearchSecretsRBAC decides how /api/search should treat Secrets for
+// the calling user. scanNamespaces is the effective set of namespaces the
+// walker would scan absent per-kind RBAC — the intersection of the user's
+// RBAC-allowed namespaces and any `ns:` modifier in the query. Three cases:
+//
+//   - Auth disabled (no user on context): returns ("", nil). SA RBAC at the
+//     cache layer is the only gate.
+//   - Cluster-wide scan (scanNamespaces == nil): the user is reading at
+//     cluster scope (cluster-wide-namespace sentinel from DiscoverNamespaces
+//     stage 1 — list-pods cluster-wide — AND no `ns:` modifier narrowed it).
+//     Cluster-wide list-pods does NOT imply cluster-wide list-secrets, so
+//     gate via a `list secrets` SAR at cluster scope. Returns ("skip", nil)
+//     when denied; ("", nil) when allowed (cluster-wide informer scan runs).
+//   - Namespace-scoped scan (scanNamespaces != nil): per-namespace SAR
+//     fanout. Returns ("skip", nil) when the user can't list secrets in any
+//     scan namespace; ("override", subset) when they can in a subset (walker
+//     uses NamespacesByKind for Secrets only).
+//
+// Fail-closed on SAR API errors at any step — a transient apiserver hiccup
+// drops Secret rather than leaking through.
+func (s *Server) computeSearchSecretsRBAC(r *http.Request, scanNamespaces []string) (decision string, scopedNamespaces []string) {
+	if auth.UserFromContext(r.Context()) == nil {
+		return "", nil
+	}
+
+	if scanNamespaces == nil {
+		if s.canRead(r, "", "secrets", "", "list") {
+			return "", nil
+		}
+		return "skip", nil
+	}
+
+	if len(scanNamespaces) == 0 {
+		return "skip", nil
+	}
+
+	scoped := make([]string, 0, len(scanNamespaces))
+	for _, ns := range scanNamespaces {
+		if s.canRead(r, "", "secrets", ns, "list") {
+			scoped = append(scoped, ns)
+		}
+	}
+	if len(scoped) == 0 {
+		return "skip", nil
+	}
+	return "override", scoped
 }
 
 // _ context.Context — kept to make ctx threading explicit if a future

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -774,6 +774,32 @@ func (s *Server) canRead(r *http.Request, group, resource, namespace, verb strin
 	return allowed
 }
 
+// filterNamespacesByCanRead returns the subset of `namespaces` where the
+// calling user passes a per-namespace SAR for (group, resource, verb).
+// Fail-closed: SAR errors drop the namespace.
+//
+// Used to enforce per-kind RBAC inside a namespace when the cache reads as
+// the SA and the SA has broader permissions than individual users (the chart
+// can grant the SA cluster-wide secrets — any of rbac.secrets / rbac.helm /
+// auth.mode != "none" / cloud.enabled triggers it, for Helm release
+// visibility). Results memoize through UserPermissions.canI, so repeated
+// reads within the cache TTL don't re-SAR.
+//
+// nil or empty input is returned unchanged; the caller's namespace-access
+// gate (parseNamespacesForUser / noNamespaceAccess) is the upstream decision.
+func (s *Server) filterNamespacesByCanRead(r *http.Request, group, resource, verb string, namespaces []string) []string {
+	if len(namespaces) == 0 {
+		return namespaces
+	}
+	out := make([]string, 0, len(namespaces))
+	for _, ns := range namespaces {
+		if s.canRead(r, group, resource, ns, verb) {
+			out = append(out, ns)
+		}
+	}
+	return out
+}
+
 // clusterScopedTopologyKinds maps topology NodeKinds for cluster-scoped
 // resources to the (group, resource) tuple a SAR needs. Mirrors the MCP
 // table — kept in sync manually since each side gates with its own helper.
@@ -1034,6 +1060,32 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 	} else if !isNamespacesKind && noNamespaceAccess(namespaces) {
 		s.writeJSON(w, []any{})
 		return
+	}
+
+	// Per-kind RBAC inside a namespace. Helm release storage IS K8s Secrets,
+	// so the chart can grant the SA cluster-wide secrets (rbac.secrets,
+	// rbac.helm, auth.mode != "none", or cloud.enabled — see deploy/helm/
+	// radar/templates/clusterrole.yaml). When any of those triggers fires
+	// the cache holds every secret in the cluster, so per-user RBAC must
+	// gate the read. Other namespaced kinds are deferred.
+	if (kind == "secrets" || kind == "secret") && !isClusterScoped {
+		if auth.UserFromContext(r.Context()) != nil {
+			if namespaces == nil {
+				// Auth user with cluster-wide namespace access (e.g. picked up
+				// via DiscoverNamespaces stage 1: cluster-wide list pods). The
+				// cache will serve all secrets — gate on cluster-scope SAR.
+				if !s.canRead(r, "", "secrets", "", "list") {
+					s.writeJSON(w, []any{})
+					return
+				}
+			} else {
+				namespaces = s.filterNamespacesByCanRead(r, "", "secrets", "list", namespaces)
+				if len(namespaces) == 0 {
+					s.writeJSON(w, []any{})
+					return
+				}
+			}
+		}
 	}
 
 	cache := k8s.GetResourceCache()
@@ -1433,6 +1485,14 @@ func (s *Server) handleGetResource(w http.ResponseWriter, r *http.Request) {
 		allowed := s.getUserNamespaces(r, []string{namespace})
 		if noNamespaceAccess(allowed) {
 			s.writeError(w, http.StatusForbidden, fmt.Sprintf("no access to namespace %q", namespace))
+			return
+		}
+		// Per-kind RBAC inside the namespace for Secrets — the chart can
+		// grant the SA cluster-wide secrets (Helm release visibility), so
+		// namespace-list discovery is not a sufficient gate here. The list
+		// handler has the matching list-SAR.
+		if (kind == "secrets" || kind == "secret") && !s.canRead(r, "", "secrets", namespace, "get") {
+			s.writeError(w, http.StatusForbidden, fmt.Sprintf("no access to secrets in namespace %q", namespace))
 			return
 		}
 	}

--- a/internal/server/server_secrets_rbac_test.go
+++ b/internal/server/server_secrets_rbac_test.go
@@ -1,0 +1,317 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/skyhook-io/radar/internal/auth"
+)
+
+// Per-namespace Secret RBAC at the REST layer.
+//
+// The chart can grant the Radar ServiceAccount cluster-wide list/get/watch
+// on secrets (any of rbac.secrets / rbac.helm / auth.mode != "none" /
+// cloud.enabled triggers it — Helm release metadata IS K8s Secrets, and the
+// K8s `view` role excludes them, so Helm visibility requires the elevated
+// grant). Whenever the cache holds secrets the user can't read directly,
+// handleListResources / handleGetResource must enforce per-user Secret
+// RBAC server-side instead of relying on the chart's coarse grant.
+
+// seedServerSecretListCanI seeds the per-namespace canI cache for `list` on
+// secrets only. Each list-handler test should call this (not the both-verbs
+// variant) so a regression where the handler checks the wrong verb surfaces
+// as a failed assertion.
+func seedServerSecretListCanI(t *testing.T, env *authTestEnv, username string, allowedNamespaces []string, deniedNamespaces []string) {
+	t.Helper()
+	seedServerSecretCanIVerb(t, env, username, "list", allowedNamespaces, deniedNamespaces)
+}
+
+// seedServerSecretGetCanI is the `get`-verb counterpart. See seedServerSecretListCanI.
+func seedServerSecretGetCanI(t *testing.T, env *authTestEnv, username string, allowedNamespaces []string, deniedNamespaces []string) {
+	t.Helper()
+	seedServerSecretCanIVerb(t, env, username, "get", allowedNamespaces, deniedNamespaces)
+}
+
+func seedServerSecretCanIVerb(t *testing.T, env *authTestEnv, username, verb string, allowedNamespaces []string, deniedNamespaces []string) {
+	t.Helper()
+	perms := env.srv.permCache.Get(username)
+	if perms == nil {
+		t.Fatalf("user %q not in perm cache; call permCache.Set first", username)
+	}
+	for _, ns := range allowedNamespaces {
+		perms.SetCanI(verb, "", "secrets", ns, true)
+	}
+	for _, ns := range deniedNamespaces {
+		perms.SetCanI(verb, "", "secrets", ns, false)
+	}
+}
+
+func TestProxyAuth_SecretsList_NamespaceRestricted_Denied(t *testing.T) {
+	// alice has namespace access to default (where nginx-tls lives) but the
+	// per-namespace canRead("","secrets","default","list") returns false.
+	// The cache reads as the SA and may carry secrets her ClusterRole
+	// excludes — the per-namespace SAR gate must intercept.
+	env := newAuthTestServer(t)
+	env.srv.permCache.Set("alice", &auth.UserPermissions{
+		AllowedNamespaces: []string{"default"},
+	})
+	seedServerSecretListCanI(t, env, "alice", nil, []string{"default"})
+
+	resp := env.authGet(t, "/api/resources/secrets", "alice", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var items []any
+	json.NewDecoder(resp.Body).Decode(&items)
+	if len(items) != 0 {
+		t.Errorf("secret leaked through namespace-only gate: %d items", len(items))
+	}
+}
+
+func TestProxyAuth_SecretsList_NamespaceRestricted_Allowed(t *testing.T) {
+	// bob has both namespace access AND per-namespace secret RBAC for
+	// default. The gate must pass through.
+	env := newAuthTestServer(t)
+	env.srv.permCache.Set("bob", &auth.UserPermissions{
+		AllowedNamespaces: []string{"default"},
+	})
+	seedServerSecretListCanI(t, env, "bob", []string{"default"}, nil)
+
+	resp := env.authGet(t, "/api/resources/secrets", "bob", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var items []any
+	json.NewDecoder(resp.Body).Decode(&items)
+	if len(items) == 0 {
+		t.Errorf("authorized user got 0 secrets, expected the seeded nginx-tls")
+	}
+}
+
+func TestProxyAuth_SecretsList_ClusterWideShape_NoSecretRBAC(t *testing.T) {
+	// AllowedNamespaces==nil is the cluster-wide-namespace sentinel
+	// (DiscoverNamespaces stage 1: cluster-wide list pods). It does NOT
+	// imply cluster-wide list-secrets — a user can have cluster-wide pod
+	// visibility and still lack secrets RBAC. Pin the cluster-scope SAR
+	// gate so this conflation doesn't return.
+	env := newAuthTestServer(t)
+	env.srv.permCache.Set("broad-reader", &auth.UserPermissions{
+		AllowedNamespaces: nil,
+	})
+	perms := env.srv.permCache.Get("broad-reader")
+	perms.SetCanI("list", "", "secrets", "", false)
+
+	resp := env.authGet(t, "/api/resources/secrets", "broad-reader", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var items []any
+	json.NewDecoder(resp.Body).Decode(&items)
+	if len(items) != 0 {
+		t.Errorf("secrets leaked to cluster-wide-pods user without cluster-scope secrets SAR: %d items", len(items))
+	}
+}
+
+func TestProxyAuth_SecretsList_ClusterWideShape_WithSecretRBAC(t *testing.T) {
+	// Same cluster-wide-namespace shape, but with explicit cluster-scope
+	// `list secrets` RBAC seeded. Cache returns every secret.
+	env := newAuthTestServer(t)
+	env.srv.permCache.Set("admin", &auth.UserPermissions{
+		AllowedNamespaces: nil,
+	})
+	perms := env.srv.permCache.Get("admin")
+	perms.SetCanI("list", "", "secrets", "", true)
+
+	resp := env.authGet(t, "/api/resources/secrets", "admin", "system:masters")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var items []any
+	json.NewDecoder(resp.Body).Decode(&items)
+	if len(items) == 0 {
+		t.Errorf("cluster-wide-namespace user with cluster-scope secrets SAR should see all secrets")
+	}
+}
+
+func TestProxyAuth_SecretsGet_Denied(t *testing.T) {
+	// 403 (not 404) when the namespace is allowed but per-kind RBAC denies.
+	// 404 would let the user probe secret existence by observing 200 vs 404;
+	// 403 is the explicit deny.
+	env := newAuthTestServer(t)
+	env.srv.permCache.Set("alice", &auth.UserPermissions{
+		AllowedNamespaces: []string{"default"},
+	})
+	seedServerSecretGetCanI(t, env, "alice", nil, []string{"default"})
+
+	resp := env.authGet(t, "/api/resources/secrets/default/nginx-tls", "alice", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestProxyAuth_SecretsGet_Allowed(t *testing.T) {
+	env := newAuthTestServer(t)
+	env.srv.permCache.Set("bob", &auth.UserPermissions{
+		AllowedNamespaces: []string{"default"},
+	})
+	seedServerSecretGetCanI(t, env, "bob", []string{"default"}, nil)
+
+	resp := env.authGet(t, "/api/resources/secrets/default/nginx-tls", "bob", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+// TestProxyAuth_SearchSecrets_PerNamespaceFanout pins the search-side gate.
+// /api/search must do per-namespace fanout for Secrets so a user with
+// per-namespace secret RBAC sees those rows in search, matching the resource
+// browser. A cluster-scope SAR alone would silently drop Secret for any
+// namespace-bounded user.
+func TestProxyAuth_SearchSecrets_PerNamespaceFanout(t *testing.T) {
+	env := newAuthTestServer(t)
+	env.srv.permCache.Set("alice", &auth.UserPermissions{
+		AllowedNamespaces: []string{"default"},
+	})
+	seedServerSecretListCanI(t, env, "alice", []string{"default"}, nil)
+
+	resp := env.authGet(t, "/api/search?q=kind:Secret", "alice", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body struct {
+		Hits []struct {
+			Name string `json:"name"`
+		} `json:"hits"`
+	}
+	json.NewDecoder(resp.Body).Decode(&body)
+
+	found := false
+	for _, h := range body.Hits {
+		if h.Name == "nginx-tls" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected nginx-tls in search hits for per-namespace-allowed user, got %d hits: %+v", len(body.Hits), body.Hits)
+	}
+}
+
+func TestProxyAuth_SearchSecrets_NamespaceDenied(t *testing.T) {
+	// Same alice setup but per-namespace secret denied — search should drop
+	// Secret entirely (no hits) instead of leaking through.
+	env := newAuthTestServer(t)
+	env.srv.permCache.Set("alice", &auth.UserPermissions{
+		AllowedNamespaces: []string{"default"},
+	})
+	seedServerSecretListCanI(t, env, "alice", nil, []string{"default"})
+
+	resp := env.authGet(t, "/api/search?q=kind:Secret", "alice", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body struct {
+		Hits []struct {
+			Name string `json:"name"`
+		} `json:"hits"`
+	}
+	json.NewDecoder(resp.Body).Decode(&body)
+
+	for _, h := range body.Hits {
+		if h.Name == "nginx-tls" {
+			t.Errorf("secret leaked in search despite per-ns deny: %+v", body.Hits)
+		}
+	}
+}
+
+// TestSmokeSecretsList_NoAuthPassthrough verifies that auth.mode=none lets
+// callers see every cached Secret. The Secret gate in handleListResources
+// short-circuits on a nil user context (auth.UserFromContext); a regression
+// that inverted that check would silently break Radar's primary local mode.
+// Uses the auth-disabled global testServer (Config{DevMode: true}, no auth
+// config) — distinct from the auth-enabled tests above.
+func TestSmokeSecretsList_NoAuthPassthrough(t *testing.T) {
+	resp := get(t, "/api/resources/secrets")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var items []struct {
+		Metadata struct {
+			Name      string `json:"name"`
+			Namespace string `json:"namespace"`
+		} `json:"metadata"`
+	}
+	json.NewDecoder(resp.Body).Decode(&items)
+
+	want := map[string]string{"nginx-tls": "default", "system-token": "kube-system"}
+	got := make(map[string]string, len(items))
+	for _, it := range items {
+		got[it.Metadata.Name] = it.Metadata.Namespace
+	}
+	for name, ns := range want {
+		if got[name] != ns {
+			t.Errorf("no-auth passthrough missing seeded secret %s/%s; got: %+v", ns, name, got)
+		}
+	}
+}
+
+// TestProxyAuth_SecretsList_PartialNamespaceAccess verifies the
+// filterNamespacesByCanRead helper preserves the allowed subset when a user
+// has namespace access to multiple namespaces but per-namespace secret RBAC
+// in only some of them. The REST path uses s.filterNamespacesByCanRead +
+// s.canRead (distinct from MCP's filterNamespacesByCanRead path), so the
+// equivalent MCP test alone doesn't pin this code.
+func TestProxyAuth_SecretsList_PartialNamespaceAccess(t *testing.T) {
+	env := newAuthTestServer(t)
+	env.srv.permCache.Set("alice", &auth.UserPermissions{
+		AllowedNamespaces: []string{"default", "kube-system"},
+	})
+	seedServerSecretListCanI(t, env, "alice", []string{"default"}, []string{"kube-system"})
+
+	resp := env.authGet(t, "/api/resources/secrets?namespaces=default,kube-system", "alice", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var items []struct {
+		Metadata struct {
+			Name      string `json:"name"`
+			Namespace string `json:"namespace"`
+		} `json:"metadata"`
+	}
+	json.NewDecoder(resp.Body).Decode(&items)
+
+	var foundNginx, foundSystem bool
+	for _, it := range items {
+		if it.Metadata.Name == "nginx-tls" && it.Metadata.Namespace == "default" {
+			foundNginx = true
+		}
+		if it.Metadata.Name == "system-token" && it.Metadata.Namespace == "kube-system" {
+			foundSystem = true
+		}
+	}
+	if !foundNginx {
+		t.Errorf("expected nginx-tls (default, allowed) in result, got: %+v", items)
+	}
+	if foundSystem {
+		t.Errorf("system-token (kube-system, denied) leaked despite per-namespace SAR deny: %+v", items)
+	}
+}

--- a/internal/server/server_smoke_test.go
+++ b/internal/server/server_smoke_test.go
@@ -120,6 +120,17 @@ func TestMain(m *testing.M) {
 				Ports:    []corev1.ServicePort{{Port: 80, TargetPort: intstr.FromInt(80)}},
 			},
 		},
+		// Seed Secrets in two namespaces so per-user RBAC tests can
+		// distinguish "gate denied → []" from "no secrets in cache" and can
+		// exercise the partial-allow case (one ns allowed, the other denied).
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "nginx-tls", Namespace: "default"},
+			Type:       corev1.SecretTypeOpaque,
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "system-token", Namespace: "kube-system"},
+			Type:       corev1.SecretTypeOpaque,
+		},
 	)
 
 	// Initialize cache from fake client (bypasses RBAC checks)

--- a/scripts/test-rbac.sh
+++ b/scripts/test-rbac.sh
@@ -63,7 +63,8 @@ cleanup() {
   info "removing test RBAC + namespaces + CRD"
   kubectl delete clusterrolebinding "radar-rbac-test-impersonator" "radar-rbac-test-carol" "radar-rbac-test-erin" --ignore-not-found >/dev/null 2>&1
   kubectl delete clusterrole "radar-rbac-test-pods-only" "radar-rbac-test-nodes-only" --ignore-not-found >/dev/null 2>&1
-  kubectl delete -n "$NS_ALICE" rolebinding "radar-test-alice" "radar-test-dave-a" --ignore-not-found >/dev/null 2>&1
+  kubectl delete -n "$NS_ALICE" rolebinding "radar-test-alice" "radar-test-dave-a" "radar-test-frank" "radar-test-frank-view" --ignore-not-found >/dev/null 2>&1
+  kubectl delete -n "$NS_ALICE" role "radar-rbac-test-secret-reader" --ignore-not-found >/dev/null 2>&1
   kubectl delete -n "$NS_BOB" rolebinding "radar-test-bob" "radar-test-dave-b" --ignore-not-found >/dev/null 2>&1
   kubectl delete namespace "$NS_ALICE" "$NS_BOB" --ignore-not-found >/dev/null 2>&1
   # Delete CRD instances first, then the CRD itself
@@ -100,6 +101,14 @@ kubectl create namespace "$NS_BOB"   --dry-run=client -o yaml | kubectl apply -f
 kubectl run -n "$NS_ALICE" rbac-test-pod-a --image=registry.k8s.io/pause:3.9 --restart=Never \
   --dry-run=client -o yaml 2>/dev/null | kubectl apply -f - >/dev/null
 kubectl run -n "$NS_BOB"   rbac-test-pod-b --image=registry.k8s.io/pause:3.9 --restart=Never \
+  --dry-run=client -o yaml 2>/dev/null | kubectl apply -f - >/dev/null
+
+# Seed a Secret in NS_ALICE so per-namespace Secret RBAC tests have something
+# to leak (or correctly hide). When the chart grants the SA cluster-wide
+# secrets (rbac.secrets / rbac.helm / auth.mode != "none" / cloud.enabled),
+# the cache holds it and per-user RBAC must decide visibility on read.
+kubectl create secret generic -n "$NS_ALICE" rbac-test-secret-a \
+  --from-literal=token=ignored \
   --dry-run=client -o yaml 2>/dev/null | kubectl apply -f - >/dev/null
 
 info "installing test CRD (cluster-scoped, not in static cluster-only list)"
@@ -256,6 +265,50 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: radar-rbac-test-nodes-only
+  apiGroup: rbac.authorization.k8s.io
+---
+# frank: view in NS_ALICE PLUS explicit secret list/get. Same namespace
+# ceiling as alice (who is bound to view, which excludes secrets) — frank
+# is the positive control. He must see Secrets where alice can't, proving
+# the per-namespace SAR gate honors RBAC grants rather than blanket-denying
+# secrets to all namespace-bound users.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: radar-rbac-test-secret-reader
+  namespace: $NS_ALICE
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: radar-test-frank
+  namespace: $NS_ALICE
+subjects:
+- kind: User
+  name: frank
+roleRef:
+  kind: Role
+  name: radar-rbac-test-secret-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+# frank also needs view (pods/services/etc.) so DiscoverNamespaces picks
+# up NS_ALICE as accessible. Without the view-binding, list-pods SAR fails
+# and AllowedNamespaces is empty, so the secret-only Role wouldn't matter.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: radar-test-frank-view
+  namespace: $NS_ALICE
+subjects:
+- kind: User
+  name: frank
+roleRef:
+  kind: ClusterRole
+  name: view
   apiGroup: rbac.authorization.k8s.io
 EOF
 
@@ -628,6 +681,69 @@ if [[ "$DAVE_DASH_CRDS" != *"RadarTest"* ]]; then
   ok "dave's /api/dashboard/crds does not include cluster-scoped RadarTest"
 else
   fail "dave's /api/dashboard/crds leaked RadarTest: $DAVE_DASH_CRDS"
+fi
+
+echo
+echo -e "${B}=== Per-namespace Secret RBAC (alice's view role excludes secrets) ===${N}"
+# The K8s `view` ClusterRole does NOT include secrets. The chart can grant
+# the SA cluster-wide secrets (rbac.helm / auth.mode != "none" / etc.), so
+# the cache may hold rbac-test-secret-a; the server's per-namespace
+# `list secrets` SAR must gate the read. alice's view role fails that SAR
+# and she sees nothing. frank (same namespace, plus explicit secret-reader
+# Role) sees the secret.
+
+ALICE_SECRETS=$(as_user alice GET /api/resources/secrets | arr_len)
+expect_zero "REST alice cannot list secrets (view role excludes them)" "$ALICE_SECRETS"
+
+ALICE_SECRET_GET_HTTP=$(curl -s -o /dev/null -w '%{http_code}' -H "X-Forwarded-User: alice" \
+  "http://localhost:$PORT/api/resources/secrets/$NS_ALICE/rbac-test-secret-a")
+if [[ "$ALICE_SECRET_GET_HTTP" == "403" ]]; then
+  ok "REST alice GET secret returns 403"
+else
+  fail "REST alice GET secret returned $ALICE_SECRET_GET_HTTP; expected 403"
+fi
+
+ALICE_MCP_SECRETS=$(mcp_call alice list_resources '{"kind":"secrets"}' | arr_len)
+expect_zero "MCP alice list_resources kind=secrets returns 0" "$ALICE_MCP_SECRETS"
+
+# MCP get_resource returns an error string on forbidden — not a structured
+# 403. Check for the substring instead of HTTP code.
+ALICE_MCP_SECRET_GET=$(mcp_call alice get_resource "{\"kind\":\"secrets\",\"namespace\":\"$NS_ALICE\",\"name\":\"rbac-test-secret-a\"}")
+if [[ -z "$ALICE_MCP_SECRET_GET" ]] || ! echo "$ALICE_MCP_SECRET_GET" | jq -e '.name == "rbac-test-secret-a"' >/dev/null 2>&1; then
+  ok "MCP alice get_resource secrets denied (no rbac-test-secret-a in payload)"
+else
+  fail "MCP alice get_resource leaked secret: $ALICE_MCP_SECRET_GET"
+fi
+
+ALICE_SEARCH_SECRETS=$(as_user alice GET "/api/search?q=kind:Secret" | jq -r '[.hits[]?.name] | join(",")' 2>/dev/null || echo "ERR")
+if [[ "$ALICE_SEARCH_SECRETS" != *"rbac-test-secret-a"* ]]; then
+  ok "REST search kind:Secret hides rbac-test-secret-a from alice"
+else
+  fail "REST search leaked secret to alice: [$ALICE_SEARCH_SECRETS]"
+fi
+
+# frank: positive control. Same namespace ceiling as alice, but with explicit
+# secret-reader Role bound. He must see the secret.
+FRANK_SECRETS=$(as_user frank GET /api/resources/secrets | jq -r '[.[].metadata.name] | join(",")')
+if [[ "$FRANK_SECRETS" == *"rbac-test-secret-a"* ]]; then
+  ok "REST frank can list secrets (explicit secret-reader Role)"
+else
+  fail "REST frank should see rbac-test-secret-a, got: [$FRANK_SECRETS]"
+fi
+
+FRANK_SECRET_GET_HTTP=$(curl -s -o /dev/null -w '%{http_code}' -H "X-Forwarded-User: frank" \
+  "http://localhost:$PORT/api/resources/secrets/$NS_ALICE/rbac-test-secret-a")
+if [[ "$FRANK_SECRET_GET_HTTP" == "200" ]]; then
+  ok "REST frank GET secret returns 200"
+else
+  fail "REST frank GET secret returned $FRANK_SECRET_GET_HTTP; expected 200"
+fi
+
+FRANK_SEARCH_SECRETS=$(as_user frank GET "/api/search?q=kind:Secret" | jq -r '[.hits[]?.name] | join(",")' 2>/dev/null || echo "ERR")
+if [[ "$FRANK_SEARCH_SECRETS" == *"rbac-test-secret-a"* ]]; then
+  ok "REST search kind:Secret shows rbac-test-secret-a to frank"
+else
+  fail "REST search missing secret for frank: [$FRANK_SEARCH_SECRETS]"
 fi
 
 # --- Summary ---


### PR DESCRIPTION
## Summary

Closes #688. Users bound to a ClusterRole that explicitly excludes `secrets` could still see them through Radar because the cache reads as the ServiceAccount (which the chart can grant cluster-wide secrets so Helm release visibility works) and the read paths only checked namespace access. This PR adds per-user, per-namespace SAR gating for Secret reads across REST, MCP, and search — picking up the deferred follow-up from #609's commit message.

## What changed

- **REST `handleListResources` / `handleGetResource`** gate Secret reads via per-namespace SAR (or cluster-scope SAR when `AllowedNamespaces==nil`). List returns `[]` on deny; get returns `403`. New `Server.filterNamespacesByCanRead` reuses the existing `UserPermissions.canI` cache.
- **MCP mirrors** the same shape via new `canReadInNamespace` + `filterNamespacesByCanRead` in `internal/mcp/permissions.go`.
- **Search** gets a new `Options.NamespacesByKind` field so the walker can scope one kind tighter than the global `Options.Namespaces`. `computeSearchSecretsRBAC` / `mcpSearchSecretsRBAC` do per-namespace SAR fanout for Secrets — a user with per-namespace secret RBAC now sees those rows in search instead of having Secret silently skipped at cluster scope. Cluster-scoped sensitive kinds (Node, PV, StorageClass, Namespace) keep their existing cluster-scope-SAR gate.
- **Chart unchanged.** The chart's job is the cache ceiling; per-user RBAC is the server's responsibility. Removing the chart's secrets grant would silently break Helm visibility for non-admin authenticated users — a worse regression than the reported leak.

## Scope

Narrowed to Secrets specifically. ConfigMaps and other namespaced kinds have the same architectural shape (cache reads as SA, no per-kind gate) but no customer evidence yet and a wider blast radius — the helpers introduced here generalize trivially when that follow-up lands. PR title is deliberately scoped: "Respect per-user Secret RBAC", not "per-kind namespace RBAC".

## Test plan

- [x] `go test ./internal/...` green (added 10 REST scenarios, 9 MCP scenarios, 2 search-walker tests for `NamespacesByKind`).
- [x] `scripts/test-rbac.sh` against `kind-radar-gitops-demo` — **36/36 assertions pass**, including 8 new Secret RBAC E2E checks. Added a `frank` persona with explicit secret-reader Role as a positive control next to alice (whose `view` role excludes secrets).
- [x] `cd web && npm run tsc` clean.

## Follow-ups (not in this PR)

- Extend per-namespace SAR gating to ConfigMaps / other namespaced kinds when customer evidence demands it.
- Make `/api/capabilities` per-namespace aware so the sidebar can hide Secrets based on the active namespace pick (coordinate with #709's `GetCachedPermissionResult` pattern).
- Factor the `parallelCanRead` primitive into `pkg/auth` once a third caller appears (currently three near-duplicate loops: search-skipkinds, REST helper, MCP helper).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization logic around Secrets in REST/MCP handlers and search scoping, so mistakes could either reintroduce data leaks or over-restrict legitimate visibility. Changes are narrowly scoped to `Secret` with added unit/E2E coverage to reduce regression risk.
> 
> **Overview**
> Prevents **Secret visibility leaks** when the cache is populated using the Radar ServiceAccount by adding per-user SAR checks for `secrets` on both list and get paths.
> 
> REST and MCP resource handlers now apply **per-namespace Secret RBAC** (and a cluster-scope `list secrets` gate when the user has cluster-wide namespace shape), and search no longer treats Secrets as a purely cluster-skip kind; instead it supports **per-kind namespace scoping** via new `search.Options.NamespacesByKind` with per-namespace SAR fanout for Secrets.
> 
> Adds focused tests for MCP, REST, and search walker behavior, plus extends `scripts/test-rbac.sh` to validate the new Secret RBAC scenarios end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffd1671b294eebe98083aedc65f3e13bf26500d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->