### PR TITLE
feat(agentlog): structured request log lines for MCP + /api/ai/*

### DIFF
--- a/internal/logsafe/logsafe.go
+++ b/internal/logsafe/logsafe.go
@@ -1,0 +1,32 @@
+// Package logsafe provides minimal helpers for embedding user-controlled
+// values in structured log lines without inviting log forgery.
+//
+// The agent-context log paths (internal/mcp, internal/server) both write
+// logfmt-style lines that include attacker-influenceable fields (MCP tool
+// input, chi URL params). Without sanitization, a value like
+// "Pod\nlevel=error fake=line" would inject a forged log entry that
+// downstream scrapers parse as a separate event.
+//
+// This package intentionally lives at the internal/ root (not inside one
+// of the consumers) because both internal/mcp and internal/server import
+// it; internal subpackages can't import each other peer-to-peer.
+package logsafe
+
+import "strings"
+
+// Sanitize strips newlines, carriage returns, and other control characters
+// from s, replacing each with '_'. Replacement (rather than removal) keeps
+// the untrusted value visibly present in the line so operators can still
+// see what was attempted.
+//
+// This is intentionally narrow: callers should pass only the small set of
+// genuinely user-controlled fields (kind, namespace, route pattern, etc.).
+// Internally-set values (tool names, component identifiers) don't need it.
+func Sanitize(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\r' || r < 0x20 || r == 0x7f {
+			return '_'
+		}
+		return r
+	}, s)
+}

--- a/internal/logsafe/logsafe.go
+++ b/internal/logsafe/logsafe.go
@@ -46,3 +46,16 @@ func Sanitize(s string) string {
 		return r
 	}, s)
 }
+
+// EstimateTokens converts a response byte count into a rough token estimate
+// using an English-JSON heuristic of ~4 characters per token. Cheap,
+// deterministic, and good enough for "is this response 200 tokens or 200k
+// tokens?" budgeting decisions. Real tokenization happens client-side; this
+// is only a budget signal.
+//
+// Lives here (alongside Sanitize) so MCP and REST log emitters share a single
+// definition. Without this, divergence between the two log-line `est_tokens`
+// fields is one heuristic change away.
+func EstimateTokens(bytes int) int {
+	return bytes / 4
+}

--- a/internal/logsafe/logsafe.go
+++ b/internal/logsafe/logsafe.go
@@ -1,11 +1,21 @@
 // Package logsafe provides minimal helpers for embedding user-controlled
-// values in structured log lines without inviting log forgery.
+// values in structured (logfmt-style) log lines without inviting log forgery.
 //
 // The agent-context log paths (internal/mcp, internal/server) both write
 // logfmt-style lines that include attacker-influenceable fields (MCP tool
-// input, chi URL params). Without sanitization, a value like
-// "Pod\nlevel=error fake=line" would inject a forged log entry that
-// downstream scrapers parse as a separate event.
+// input, chi URL params). Two attack vectors must be neutralized:
+//
+//  1. Multi-line injection: a value like "Pod\nlevel=error fake=line"
+//     splits onto a new line that scrapers parse as a separate event.
+//  2. Same-line field injection: a value like "Pod level=error fake=line"
+//     introduces NEW logfmt fields on the SAME line — "level=error" would
+//     override the legitimate level= field earlier on the line.
+//
+// Sanitize neutralizes both: it replaces newlines, carriage returns, other
+// control characters, AND the two logfmt field separators (space and "=")
+// with '_'. Legitimate values (Kubernetes kind names, RFC 1123 namespace
+// names, chi route patterns) never contain these characters; attacker-
+// crafted values do.
 //
 // This package intentionally lives at the internal/ root (not inside one
 // of the consumers) because both internal/mcp and internal/server import
@@ -14,17 +24,23 @@ package logsafe
 
 import "strings"
 
-// Sanitize strips newlines, carriage returns, and other control characters
-// from s, replacing each with '_'. Replacement (rather than removal) keeps
-// the untrusted value visibly present in the line so operators can still
-// see what was attempted.
+// Sanitize replaces dangerous runes in s with '_'. Replacement (rather
+// than removal) keeps the untrusted value visibly present in the line so
+// operators can still see what was attempted, while preventing the value
+// from being parsed as logfmt structure.
+//
+// Replaced runes:
+//   - '\n', '\r' — multi-line injection
+//   - control chars (<0x20), DEL (0x7f) — malformed-output evasion
+//   - ' ' (space) — logfmt field separator; prevents same-line injection
+//   - '=' — logfmt key/value separator; prevents same-line injection
 //
 // This is intentionally narrow: callers should pass only the small set of
 // genuinely user-controlled fields (kind, namespace, route pattern, etc.).
 // Internally-set values (tool names, component identifiers) don't need it.
 func Sanitize(s string) string {
 	return strings.Map(func(r rune) rune {
-		if r == '\n' || r == '\r' || r < 0x20 || r == 0x7f {
+		if r == '\n' || r == '\r' || r < 0x20 || r == 0x7f || r == ' ' || r == '=' {
 			return '_'
 		}
 		return r

--- a/internal/logsafe/logsafe_test.go
+++ b/internal/logsafe/logsafe_test.go
@@ -2,6 +2,24 @@ package logsafe
 
 import "testing"
 
+func TestEstimateTokens(t *testing.T) {
+	// English-JSON heuristic: 4 chars/token. Cheap and deterministic.
+	cases := []struct {
+		bytes int
+		want  int
+	}{
+		{0, 0},
+		{1, 0},
+		{4, 1},
+		{2156, 539},
+	}
+	for _, c := range cases {
+		if got := EstimateTokens(c.bytes); got != c.want {
+			t.Errorf("EstimateTokens(%d) = %d, want %d", c.bytes, got, c.want)
+		}
+	}
+}
+
 func TestSanitize(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/logsafe/logsafe_test.go
+++ b/internal/logsafe/logsafe_test.go
@@ -1,0 +1,28 @@
+package logsafe
+
+import "testing"
+
+func TestSanitize(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no control chars", "Pod", "Pod"},
+		{"empty", "", ""},
+		{"newline replaced", "Pod\nlevel=error", "Pod_level=error"},
+		{"carriage return replaced", "Pod\rfake=ns", "Pod_fake=ns"},
+		{"tab replaced (control char)", "Pod\tx", "Pod_x"},
+		{"DEL replaced", "Pod\x7fx", "Pod_x"},
+		{"NUL replaced", "Pod\x00x", "Pod_x"},
+		{"unicode passes through", "Pôd-ñs", "Pôd-ñs"},
+		{"mixed", "a\nb\rc\td", "a_b_c_d"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Sanitize(c.in); got != c.want {
+				t.Errorf("Sanitize(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/logsafe/logsafe_test.go
+++ b/internal/logsafe/logsafe_test.go
@@ -8,15 +8,27 @@ func TestSanitize(t *testing.T) {
 		in   string
 		want string
 	}{
-		{"no control chars", "Pod", "Pod"},
+		// Legitimate values pass through unchanged.
+		{"plain ASCII passes", "Pod", "Pod"},
 		{"empty", "", ""},
-		{"newline replaced", "Pod\nlevel=error", "Pod_level=error"},
-		{"carriage return replaced", "Pod\rfake=ns", "Pod_fake=ns"},
+		{"unicode passes through", "Pôd-ñs", "Pôd-ñs"},
+		{"dash and digits pass through", "my-svc-7", "my-svc-7"},
+
+		// Multi-line injection (newlines / CR / control chars / DEL).
+		{"newline replaced", "Pod\nlevel=error", "Pod_level_error"},
+		{"carriage return replaced", "Pod\rfake=ns", "Pod_fake_ns"},
 		{"tab replaced (control char)", "Pod\tx", "Pod_x"},
 		{"DEL replaced", "Pod\x7fx", "Pod_x"},
 		{"NUL replaced", "Pod\x00x", "Pod_x"},
-		{"unicode passes through", "Pôd-ñs", "Pôd-ñs"},
-		{"mixed", "a\nb\rc\td", "a_b_c_d"},
+
+		// Same-line logfmt field injection — space and '=' would otherwise
+		// introduce new key=value tokens into the log line.
+		{"space replaced", "Pod level=error", "Pod_level_error"},
+		{"equals replaced", "kind=Pod", "kind_Pod"},
+		{"full logfmt injection neutralized", "Pod level=error fake=injected", "Pod_level_error_fake_injected"},
+
+		// Mixed.
+		{"newline + space + equals all replaced", "a\nb c=d", "a_b_c_d"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/mcp/agentlog.go
+++ b/internal/mcp/agentlog.go
@@ -52,14 +52,6 @@ func emitAgentLog(f agentLogFields) {
 	)
 }
 
-// estimateTokens is an English-JSON heuristic: ~4 characters per token.
-// Cheap, deterministic, and good enough for "is this response 200 tokens or
-// 200k tokens?" budgeting decisions on the agent side. Real tokenization
-// happens client-side; this is only a rough budget signal.
-func estimateTokens(bytes int) int {
-	return bytes / 4
-}
-
 // resultBytes computes the wire-payload size of a CallToolResult. We sum the
 // text length of every TextContent (the only content type radar tools emit
 // today) plus a marshaled view of any StructuredContent. JSON-marshaling the
@@ -149,7 +141,7 @@ func logToolCall[In any](
 			Tool:        name,
 			DurationMS:  dur.Milliseconds(),
 			Bytes:       bytes,
-			EstTokens:   estimateTokens(bytes),
+			EstTokens:   logsafe.EstimateTokens(bytes),
 			ContextTier: "none",
 			Kind:        kind,
 			Namespace:   ns,

--- a/internal/mcp/agentlog.go
+++ b/internal/mcp/agentlog.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -17,23 +18,35 @@ import (
 // agent-context enrichment work will populate; today they are emitted as
 // zero / false / "none" so the line shape stays stable across releases.
 type agentLogFields struct {
-	Component    string // "mcp" or "rest"
-	Tool         string // MCP tool name (empty for REST)
-	Handler      string // REST route pattern (empty for MCP)
-	DurationMS   int64
-	Bytes        int
-	EstTokens    int
-	Truncated    bool
-	Omitted      int
-	ContextTier  string // "none" | "basic" | "diagnostic"
-	Kind         string
-	Namespace    string
-	Err          error
+	Tool        string
+	DurationMS  int64
+	Bytes       int
+	EstTokens   int
+	Truncated   bool
+	Omitted     int
+	ContextTier string // "none" | "basic" | "diagnostic"
+	Kind        string
+	Namespace   string
+	Err         error
 }
 
-// emitAgentLog writes a single logfmt-style line summarizing one
-// MCP tool call or one /api/ai/* REST request. Format is intentionally flat
-// and parser-friendly:
+// sanitizeLogValue strips newlines, carriage returns, and other control
+// characters from user-controlled strings before they go into a log line.
+// Prevents log forgery via an attacker crafting tool input or URL params
+// containing `\n` to inject fake log entries that confuse log scrapers.
+// Replaces dangerous runes with '_' rather than dropping them so the
+// untrusted value is still visibly present in the line.
+func sanitizeLogValue(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\r' || r < 0x20 || r == 0x7f {
+			return '_'
+		}
+		return r
+	}, s)
+}
+
+// emitAgentLog writes a single logfmt-style line summarizing one MCP tool
+// call. Format is intentionally flat and parser-friendly:
 //
 //	level=info component=mcp tool=get_resource duration_ms=42 bytes=2156 \
 //	  est_tokens=539 truncated=false omitted=0 context_tier=none kind=Pod ns=prod
@@ -46,19 +59,10 @@ func emitAgentLog(f agentLogFields) {
 	if tier == "" {
 		tier = "none"
 	}
-	// Build the line; we use a fixed field order so log scrapers can rely on it.
-	if f.Component == "mcp" {
-		log.Printf(
-			"level=%s component=%s tool=%s duration_ms=%d bytes=%d est_tokens=%d truncated=%t omitted=%d context_tier=%s kind=%s ns=%s",
-			level, f.Component, f.Tool, f.DurationMS, f.Bytes, f.EstTokens,
-			f.Truncated, f.Omitted, tier, f.Kind, f.Namespace,
-		)
-		return
-	}
 	log.Printf(
-		"level=%s component=%s handler=%s duration_ms=%d bytes=%d est_tokens=%d truncated=%t omitted=%d context_tier=%s kind=%s ns=%s",
-		level, f.Component, f.Handler, f.DurationMS, f.Bytes, f.EstTokens,
-		f.Truncated, f.Omitted, tier, f.Kind, f.Namespace,
+		"level=%s component=mcp tool=%s duration_ms=%d bytes=%d est_tokens=%d truncated=%t omitted=%d context_tier=%s kind=%s ns=%s",
+		level, f.Tool, f.DurationMS, f.Bytes, f.EstTokens,
+		f.Truncated, f.Omitted, tier, sanitizeLogValue(f.Kind), sanitizeLogValue(f.Namespace),
 	)
 }
 
@@ -156,7 +160,6 @@ func logToolCall[In any](
 		bytes := resultBytes(result)
 		kind, ns := extractKindNamespace(input)
 		emitAgentLog(agentLogFields{
-			Component:   "mcp",
 			Tool:        name,
 			DurationMS:  dur.Milliseconds(),
 			Bytes:       bytes,

--- a/internal/mcp/agentlog.go
+++ b/internal/mcp/agentlog.go
@@ -1,0 +1,172 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// agentLogFields is the fixed shape of the agent-context log line emitted
+// after every MCP tool call. Field names are stable and parsed by downstream
+// tooling.
+//
+// `Truncated`, `Omitted`, and `ContextTier` are reserved fields that future
+// agent-context enrichment work will populate; today they are emitted as
+// zero / false / "none" so the line shape stays stable across releases.
+type agentLogFields struct {
+	Component    string // "mcp" or "rest"
+	Tool         string // MCP tool name (empty for REST)
+	Handler      string // REST route pattern (empty for MCP)
+	DurationMS   int64
+	Bytes        int
+	EstTokens    int
+	Truncated    bool
+	Omitted      int
+	ContextTier  string // "none" | "basic" | "diagnostic"
+	Kind         string
+	Namespace    string
+	Err          error
+}
+
+// emitAgentLog writes a single logfmt-style line summarizing one
+// MCP tool call or one /api/ai/* REST request. Format is intentionally flat
+// and parser-friendly:
+//
+//	level=info component=mcp tool=get_resource duration_ms=42 bytes=2156 \
+//	  est_tokens=539 truncated=false omitted=0 context_tier=none kind=Pod ns=prod
+func emitAgentLog(f agentLogFields) {
+	level := "info"
+	if f.Err != nil {
+		level = "error"
+	}
+	tier := f.ContextTier
+	if tier == "" {
+		tier = "none"
+	}
+	// Build the line; we use a fixed field order so log scrapers can rely on it.
+	if f.Component == "mcp" {
+		log.Printf(
+			"level=%s component=%s tool=%s duration_ms=%d bytes=%d est_tokens=%d truncated=%t omitted=%d context_tier=%s kind=%s ns=%s",
+			level, f.Component, f.Tool, f.DurationMS, f.Bytes, f.EstTokens,
+			f.Truncated, f.Omitted, tier, f.Kind, f.Namespace,
+		)
+		return
+	}
+	log.Printf(
+		"level=%s component=%s handler=%s duration_ms=%d bytes=%d est_tokens=%d truncated=%t omitted=%d context_tier=%s kind=%s ns=%s",
+		level, f.Component, f.Handler, f.DurationMS, f.Bytes, f.EstTokens,
+		f.Truncated, f.Omitted, tier, f.Kind, f.Namespace,
+	)
+}
+
+// estimateTokens is an English-JSON heuristic: ~4 characters per token.
+// Cheap, deterministic, and good enough for "is this response 200 tokens or
+// 200k tokens?" budgeting decisions on the agent side. Real tokenization
+// happens client-side; this is only a rough budget signal.
+func estimateTokens(bytes int) int {
+	return bytes / 4
+}
+
+// resultBytes computes the wire-payload size of a CallToolResult. We sum the
+// text length of every TextContent (the only content type radar tools emit
+// today) plus a marshaled view of any StructuredContent. JSON-marshaling the
+// whole result would double-count, so we approximate the body size instead.
+func resultBytes(result *mcp.CallToolResult) int {
+	if result == nil {
+		return 0
+	}
+	total := 0
+	for _, c := range result.Content {
+		switch tc := c.(type) {
+		case *mcp.TextContent:
+			total += len(tc.Text)
+		default:
+			// For non-text content types (image/audio/embedded), fall back to
+			// JSON marshal length. Not exact but stable.
+			if b, err := json.Marshal(c); err == nil {
+				total += len(b)
+			}
+		}
+	}
+	if result.StructuredContent != nil {
+		if b, err := json.Marshal(result.StructuredContent); err == nil {
+			total += len(b)
+		}
+	}
+	return total
+}
+
+// extractKindNamespace pulls "kind" and "namespace" (or "ns") fields out of
+// the marshaled tool input. Tools that don't carry these fields produce
+// empty strings, which is fine — the log line shape stays consistent.
+//
+// We go through json.Marshal so we get whatever the tool author's `json:` tag
+// names are, rather than reflecting over field names directly.
+func extractKindNamespace(input any) (kind string, ns string) {
+	if input == nil {
+		return "", ""
+	}
+	b, err := json.Marshal(input)
+	if err != nil {
+		return "", ""
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		return "", ""
+	}
+	if v, ok := m["kind"].(string); ok {
+		kind = v
+	}
+	if v, ok := m["namespace"].(string); ok {
+		ns = v
+	} else if v, ok := m["ns"].(string); ok {
+		ns = v
+	}
+	return kind, ns
+}
+
+// logToolCall wraps an MCP tool handler with both the existing human-readable
+// dev log AND a structured agent-log line. Every `mcp.AddTool` registration
+// goes through this single wrap point so the log surface is uniform.
+//
+// The dev log preserves the colored, terminal-friendly behavior radar already
+// had; the structured line is the machine-readable companion that downstream
+// tooling parses for response-size and latency data.
+func logToolCall[In any](
+	name string,
+	handler func(context.Context, *mcp.CallToolRequest, In) (*mcp.CallToolResult, any, error),
+) func(context.Context, *mcp.CallToolRequest, In) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, input In) (*mcp.CallToolResult, any, error) {
+		args, _ := json.Marshal(input)
+		log.Printf("\033[1;35m[MCP]\033[0m \033[1m%s\033[0m %s", name, string(args))
+
+		start := time.Now()
+		result, extra, err := handler(ctx, req, input)
+		dur := time.Since(start)
+
+		if err != nil {
+			log.Printf("\033[1;35m[MCP]\033[0m \033[1m%s\033[0m \033[31mERROR\033[0m (%s) %v", name, dur.Round(time.Millisecond), err)
+		} else {
+			log.Printf("\033[1;35m[MCP]\033[0m \033[1m%s\033[0m \033[32mOK\033[0m (%s)", name, dur.Round(time.Millisecond))
+		}
+
+		bytes := resultBytes(result)
+		kind, ns := extractKindNamespace(input)
+		emitAgentLog(agentLogFields{
+			Component:   "mcp",
+			Tool:        name,
+			DurationMS:  dur.Milliseconds(),
+			Bytes:       bytes,
+			EstTokens:   estimateTokens(bytes),
+			ContextTier: "none",
+			Kind:        kind,
+			Namespace:   ns,
+			Err:         err,
+		})
+
+		return result, extra, err
+	}
+}

--- a/internal/mcp/agentlog.go
+++ b/internal/mcp/agentlog.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/skyhook-io/radar/internal/logsafe"
 )
 
 // agentLogFields is the fixed shape of the agent-context log line emitted
@@ -30,21 +31,6 @@ type agentLogFields struct {
 	Err         error
 }
 
-// sanitizeLogValue strips newlines, carriage returns, and other control
-// characters from user-controlled strings before they go into a log line.
-// Prevents log forgery via an attacker crafting tool input or URL params
-// containing `\n` to inject fake log entries that confuse log scrapers.
-// Replaces dangerous runes with '_' rather than dropping them so the
-// untrusted value is still visibly present in the line.
-func sanitizeLogValue(s string) string {
-	return strings.Map(func(r rune) rune {
-		if r == '\n' || r == '\r' || r < 0x20 || r == 0x7f {
-			return '_'
-		}
-		return r
-	}, s)
-}
-
 // emitAgentLog writes a single logfmt-style line summarizing one MCP tool
 // call. Format is intentionally flat and parser-friendly:
 //
@@ -62,7 +48,7 @@ func emitAgentLog(f agentLogFields) {
 	log.Printf(
 		"level=%s component=mcp tool=%s duration_ms=%d bytes=%d est_tokens=%d truncated=%t omitted=%d context_tier=%s kind=%s ns=%s",
 		level, f.Tool, f.DurationMS, f.Bytes, f.EstTokens,
-		f.Truncated, f.Omitted, tier, sanitizeLogValue(f.Kind), sanitizeLogValue(f.Namespace),
+		f.Truncated, f.Omitted, tier, logsafe.Sanitize(f.Kind), logsafe.Sanitize(f.Namespace),
 	)
 }
 

--- a/internal/mcp/agentlog_test.go
+++ b/internal/mcp/agentlog_test.go
@@ -11,24 +11,6 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-func TestEstimateTokens(t *testing.T) {
-	// English JSON heuristic: 4 chars/token. Cheap and deterministic.
-	cases := []struct {
-		bytes int
-		want  int
-	}{
-		{0, 0},
-		{1, 0},
-		{4, 1},
-		{2156, 539},
-	}
-	for _, c := range cases {
-		if got := estimateTokens(c.bytes); got != c.want {
-			t.Errorf("estimateTokens(%d) = %d, want %d", c.bytes, got, c.want)
-		}
-	}
-}
-
 func TestResultBytesTextContent(t *testing.T) {
 	res := &mcp.CallToolResult{
 		Content: []mcp.Content{

--- a/internal/mcp/agentlog_test.go
+++ b/internal/mcp/agentlog_test.go
@@ -1,0 +1,153 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestEstimateTokens(t *testing.T) {
+	// English JSON heuristic: 4 chars/token. Cheap and deterministic.
+	cases := []struct {
+		bytes int
+		want  int
+	}{
+		{0, 0},
+		{1, 0},
+		{4, 1},
+		{2156, 539},
+	}
+	for _, c := range cases {
+		if got := estimateTokens(c.bytes); got != c.want {
+			t.Errorf("estimateTokens(%d) = %d, want %d", c.bytes, got, c.want)
+		}
+	}
+}
+
+func TestResultBytesTextContent(t *testing.T) {
+	res := &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: "hello"},
+			&mcp.TextContent{Text: "world!"},
+		},
+	}
+	got := resultBytes(res)
+	want := len("hello") + len("world!")
+	if got != want {
+		t.Errorf("resultBytes = %d, want %d", got, want)
+	}
+}
+
+func TestResultBytesNil(t *testing.T) {
+	if got := resultBytes(nil); got != 0 {
+		t.Errorf("resultBytes(nil) = %d, want 0", got)
+	}
+}
+
+func TestExtractKindNamespace(t *testing.T) {
+	type input struct {
+		Kind      string `json:"kind"`
+		Namespace string `json:"namespace"`
+		Name      string `json:"name"`
+	}
+	in := input{Kind: "Pod", Namespace: "prod", Name: "x"}
+	kind, ns := extractKindNamespace(in)
+	if kind != "Pod" || ns != "prod" {
+		t.Errorf("extractKindNamespace = %q,%q; want Pod,prod", kind, ns)
+	}
+}
+
+func TestExtractKindNamespaceNsField(t *testing.T) {
+	type input struct {
+		Kind string `json:"kind"`
+		NS   string `json:"ns"`
+	}
+	kind, ns := extractKindNamespace(input{Kind: "Pod", NS: "kube-system"})
+	if kind != "Pod" || ns != "kube-system" {
+		t.Errorf("extractKindNamespace = %q,%q; want Pod,kube-system", kind, ns)
+	}
+}
+
+func TestExtractKindNamespaceEmpty(t *testing.T) {
+	type input struct {
+		Other string `json:"other"`
+	}
+	kind, ns := extractKindNamespace(input{Other: "foo"})
+	if kind != "" || ns != "" {
+		t.Errorf("extractKindNamespace = %q,%q; want empty", kind, ns)
+	}
+}
+
+// TestWrapToolCallEmitsStructuredLog verifies the wrap point produces the
+// exact agent-log log line shape that downstream scrapers parse.
+// Field renames or reordering must be caught here, not in production.
+func TestWrapToolCallEmitsStructuredLog(t *testing.T) {
+	var buf bytes.Buffer
+	defer log.SetOutput(log.Writer())
+	log.SetOutput(&buf)
+
+	type input struct {
+		Kind      string `json:"kind"`
+		Namespace string `json:"namespace"`
+		Name      string `json:"name"`
+	}
+
+	wrapped := logToolCall("test_tool", func(_ context.Context, _ *mcp.CallToolRequest, _ input) (*mcp.CallToolResult, any, error) {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: "hello"}},
+		}, nil, nil
+	})
+
+	_, _, err := wrapped(context.Background(), &mcp.CallToolRequest{}, input{Kind: "Pod", Namespace: "prod", Name: "x"})
+	if err != nil {
+		t.Fatalf("wrapped handler returned unexpected error: %v", err)
+	}
+
+	line := buf.String()
+	wants := []string{
+		"level=info",
+		"component=mcp",
+		"tool=test_tool",
+		"truncated=false",
+		"omitted=0",
+		"context_tier=none",
+		"kind=Pod",
+		"ns=prod",
+		"bytes=5",
+		"est_tokens=1",
+	}
+	for _, w := range wants {
+		if !strings.Contains(line, w) {
+			t.Errorf("log output missing %q\nfull output:\n%s", w, line)
+		}
+	}
+}
+
+// TestWrapToolCallErrorChangesLevel verifies that a handler returning an error
+// flips the structured line's level field from info to error, so scrapers can
+// distinguish failures without parsing the colored dev log.
+func TestWrapToolCallErrorChangesLevel(t *testing.T) {
+	var buf bytes.Buffer
+	defer log.SetOutput(log.Writer())
+	log.SetOutput(&buf)
+
+	type input struct{}
+
+	wrapped := logToolCall("err_tool", func(_ context.Context, _ *mcp.CallToolRequest, _ input) (*mcp.CallToolResult, any, error) {
+		return nil, nil, errors.New("boom")
+	})
+
+	_, _, _ = wrapped(context.Background(), &mcp.CallToolRequest{}, input{})
+
+	line := buf.String()
+	// Must find the structured line specifically (the dev log also includes
+	// "ERROR" but as a colored prefix, not the level= field).
+	if !strings.Contains(line, "level=error component=mcp tool=err_tool") {
+		t.Errorf("expected level=error on the structured line for failed tool call\nfull output:\n%s", line)
+	}
+}

--- a/internal/mcp/agentlog_test.go
+++ b/internal/mcp/agentlog_test.go
@@ -128,12 +128,17 @@ func TestWrapToolCallEmitsStructuredLog(t *testing.T) {
 	}
 }
 
-// TestLogToolCallSanitizesUserControlledFields verifies that newline /
-// carriage-return / control characters in user-supplied tool input fields
-// (kind, namespace) are replaced before reaching the log line. Without
-// this, a tool input of `{"kind": "Pod\nlevel=error fake=line"}` would
-// inject a forged log entry that downstream scrapers would parse as a
-// separate event.
+// TestLogToolCallSanitizesUserControlledFields verifies that BOTH classes
+// of log injection are neutralized:
+//
+//  1. Multi-line injection — `\n`, `\r`, control chars: would otherwise
+//     forge a separate log "event" that scrapers parse as its own entry.
+//  2. Same-line logfmt field injection — space and `=`: would otherwise
+//     introduce new key=value tokens on the SAME line that scrapers
+//     parse as legitimate fields (e.g. forging `level=error`).
+//
+// A tool input of `{"kind": "Pod level=error fake=line"}` is enough to
+// inject same-line fields; control chars aren't required.
 func TestLogToolCallSanitizesUserControlledFields(t *testing.T) {
 	var buf bytes.Buffer
 	defer log.SetOutput(log.Writer())
@@ -149,28 +154,47 @@ func TestLogToolCallSanitizesUserControlledFields(t *testing.T) {
 	})
 
 	_, _, _ = wrapped(context.Background(), &mcp.CallToolRequest{}, input{
+		// Newline (multi-line attack) + same-line attack in one payload.
 		Kind:      "Pod\nlevel=error fake=line",
 		Namespace: "prod\rfake=ns",
 	})
 
-	line := buf.String()
-	// The single emitted structured log line should not contain literal newlines
-	// or CRs in the values. Split on newline; only ONE structured line should appear.
-	structuredLines := 0
-	for _, l := range strings.Split(line, "\n") {
+	full := buf.String()
+
+	// Isolate the structured log line — the dev log (colored `[MCP]` lines)
+	// legitimately contains the raw JSON-marshaled args including
+	// `\nlevel=error fake=line`, but those are inside JSON quotes and don't
+	// pollute logfmt parsers. The structured line is what scrapers consume.
+	var structured string
+	structuredCount := 0
+	for _, l := range strings.Split(full, "\n") {
 		if strings.Contains(l, "component=mcp tool=inject_tool") {
-			structuredLines++
+			structured = l
+			structuredCount++
 		}
 	}
-	if structuredLines != 1 {
-		t.Errorf("expected exactly 1 structured log line, found %d (injection succeeded?)\nfull output:\n%s", structuredLines, line)
+	if structuredCount != 1 {
+		t.Fatalf("expected exactly 1 structured log line, found %d (multi-line injection succeeded?)\nfull output:\n%s", structuredCount, full)
 	}
-	if strings.Contains(line, "kind=Pod\nlevel=error") || strings.Contains(line, "ns=prod\rfake=ns") {
-		t.Errorf("user-controlled control chars reached the log line unchanged\nfull output:\n%s", line)
+
+	// Multi-line attack: structured line must not be broken across newlines.
+	// (Already guaranteed by structuredCount == 1 + log.Printf semantics.)
+
+	// Same-line attack: forged "level=error" / "fake=line" / "fake=ns" must
+	// NOT appear as standalone kv tokens on the structured line.
+	for _, forged := range []string{" level=error", " fake=line", " fake=ns"} {
+		if strings.Contains(structured, forged) {
+			t.Errorf("same-line logfmt injection reached the structured line (substring %q present)\nstructured: %s", forged, structured)
+		}
 	}
-	// The sanitized form should still surface the values so the operator sees them.
-	if !strings.Contains(line, "kind=Pod_level=error fake=line") {
-		t.Errorf("expected sanitized kind value with underscore replacement\nfull output:\n%s", line)
+
+	// Sanitized form: spaces, `=`, and newlines all collapse to '_'. Values
+	// stay visible so operators still see what was attempted.
+	if !strings.Contains(structured, "kind=Pod_level_error_fake_line") {
+		t.Errorf("expected sanitized kind value with underscore replacement\nstructured: %s", structured)
+	}
+	if !strings.Contains(structured, "ns=prod_fake_ns") {
+		t.Errorf("expected sanitized ns value with underscore replacement\nstructured: %s", structured)
 	}
 }
 

--- a/internal/mcp/agentlog_test.go
+++ b/internal/mcp/agentlog_test.go
@@ -128,6 +128,52 @@ func TestWrapToolCallEmitsStructuredLog(t *testing.T) {
 	}
 }
 
+// TestLogToolCallSanitizesUserControlledFields verifies that newline /
+// carriage-return / control characters in user-supplied tool input fields
+// (kind, namespace) are replaced before reaching the log line. Without
+// this, a tool input of `{"kind": "Pod\nlevel=error fake=line"}` would
+// inject a forged log entry that downstream scrapers would parse as a
+// separate event.
+func TestLogToolCallSanitizesUserControlledFields(t *testing.T) {
+	var buf bytes.Buffer
+	defer log.SetOutput(log.Writer())
+	log.SetOutput(&buf)
+
+	type input struct {
+		Kind      string `json:"kind"`
+		Namespace string `json:"namespace"`
+	}
+
+	wrapped := logToolCall("inject_tool", func(_ context.Context, _ *mcp.CallToolRequest, _ input) (*mcp.CallToolResult, any, error) {
+		return &mcp.CallToolResult{}, nil, nil
+	})
+
+	_, _, _ = wrapped(context.Background(), &mcp.CallToolRequest{}, input{
+		Kind:      "Pod\nlevel=error fake=line",
+		Namespace: "prod\rfake=ns",
+	})
+
+	line := buf.String()
+	// The single emitted structured log line should not contain literal newlines
+	// or CRs in the values. Split on newline; only ONE structured line should appear.
+	structuredLines := 0
+	for _, l := range strings.Split(line, "\n") {
+		if strings.Contains(l, "component=mcp tool=inject_tool") {
+			structuredLines++
+		}
+	}
+	if structuredLines != 1 {
+		t.Errorf("expected exactly 1 structured log line, found %d (injection succeeded?)\nfull output:\n%s", structuredLines, line)
+	}
+	if strings.Contains(line, "kind=Pod\nlevel=error") || strings.Contains(line, "ns=prod\rfake=ns") {
+		t.Errorf("user-controlled control chars reached the log line unchanged\nfull output:\n%s", line)
+	}
+	// The sanitized form should still surface the values so the operator sees them.
+	if !strings.Contains(line, "kind=Pod_level=error fake=line") {
+		t.Errorf("expected sanitized kind value with underscore replacement\nfull output:\n%s", line)
+	}
+}
+
 // TestWrapToolCallErrorChangesLevel verifies that a handler returning an error
 // flips the structured line's level field from info to error, so scrapers can
 // distinguish failures without parsing the colored dev log.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -24,23 +24,6 @@ import (
 	topology "github.com/skyhook-io/radar/pkg/topology"
 )
 
-// logToolCall logs an MCP tool invocation with colored formatting for terminal visibility.
-func logToolCall[In any](name string, handler func(context.Context, *mcp.CallToolRequest, In) (*mcp.CallToolResult, any, error)) func(context.Context, *mcp.CallToolRequest, In) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, input In) (*mcp.CallToolResult, any, error) {
-		args, _ := json.Marshal(input)
-		log.Printf("\033[1;35m[MCP]\033[0m \033[1m%s\033[0m %s", name, string(args))
-		start := time.Now()
-		result, extra, err := handler(ctx, req, input)
-		dur := time.Since(start)
-		if err != nil {
-			log.Printf("\033[1;35m[MCP]\033[0m \033[1m%s\033[0m \033[31mERROR\033[0m (%s) %v", name, dur.Round(time.Millisecond), err)
-		} else {
-			log.Printf("\033[1;35m[MCP]\033[0m \033[1m%s\033[0m \033[32mOK\033[0m (%s)", name, dur.Round(time.Millisecond))
-		}
-		return result, extra, err
-	}
-}
-
 func registerTools(server *mcp.Server) {
 	readOnly := &mcp.ToolAnnotations{ReadOnlyHint: true}
 

--- a/internal/server/ai_agentlog.go
+++ b/internal/server/ai_agentlog.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// aiAgentLogResponseWriter wraps http.ResponseWriter to count bytes written
+// to the wire. Status capture is a bonus — useful for debugging.
+type aiAgentLogResponseWriter struct {
+	http.ResponseWriter
+	bytes  int
+	status int
+}
+
+func (w *aiAgentLogResponseWriter) WriteHeader(code int) {
+	w.status = code
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *aiAgentLogResponseWriter) Write(b []byte) (int, error) {
+	n, err := w.ResponseWriter.Write(b)
+	w.bytes += n
+	return n, err
+}
+
+// aiAgentLogMiddleware emits one structured log line per request on the
+// `/api/ai/*` subrouter. Fields match the MCP agent-log line (same scraper
+// can parse both) — `handler` replaces `tool` for the REST side.
+//
+// Format:
+//
+//	level=info component=rest handler=/api/ai/resources/{kind}/{namespace}/{name} \
+//	  duration_ms=42 bytes=2156 est_tokens=539 truncated=false omitted=0 \
+//	  context_tier=none kind=Pod ns=prod
+//
+// `truncated`, `omitted`, and `context_tier` are reserved fields that future
+// agent-context enrichment work will populate; today they emit as zero /
+// false / "none" so the line shape stays stable across releases.
+func aiAgentLogMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tw := &aiAgentLogResponseWriter{ResponseWriter: w, status: http.StatusOK}
+		start := time.Now()
+
+		// Emit the log line on the way out — even on panic. chi's
+		// Recoverer middleware is mounted OUTERMOST (it converts panics into
+		// 500s), so without this defer a panicking handler would unwind past
+		// this middleware before any log.Printf ran, and the most-interesting
+		// failures would silently miss the log line. Status remains 200 on the
+		// wrapped writer in that case because WriteHeader was never called;
+		// downstream scrapers can disambiguate via the duration outlier or by
+		// cross-referencing the Recoverer's own log line.
+		defer func() {
+			dur := time.Since(start)
+
+			// chi populates URL params after route matching. Read them inside
+			// the defer so we capture the matched values (and the route pattern)
+			// even on panic paths.
+			var pattern, kind, ns string
+			if rctx := chi.RouteContext(r.Context()); rctx != nil {
+				pattern = rctx.RoutePattern()
+				kind = rctx.URLParam("kind")
+				ns = rctx.URLParam("namespace")
+			}
+			if pattern == "" {
+				pattern = r.URL.Path
+			}
+			// "_" is the cluster-scoped placeholder used by the AI routes — surface
+			// the empty-namespace meaning cleanly to log scrapers.
+			if ns == "_" {
+				ns = ""
+			}
+
+			level := "info"
+			if tw.status >= 500 {
+				level = "error"
+			}
+
+			log.Printf(
+				"level=%s component=rest handler=%s duration_ms=%d bytes=%d est_tokens=%d truncated=%t omitted=%d context_tier=%s kind=%s ns=%s status=%d",
+				level, pattern, dur.Milliseconds(), tw.bytes, tw.bytes/4,
+				false, 0, "none", kind, ns, tw.status,
+			)
+		}()
+
+		next.ServeHTTP(tw, r)
+	})
+}

--- a/internal/server/ai_agentlog.go
+++ b/internal/server/ai_agentlog.go
@@ -3,10 +3,27 @@ package server
 import (
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 )
+
+// sanitizeLogValue strips newlines, carriage returns, and other control
+// characters from user-controlled strings (URL params) before they go into
+// a log line. Prevents log forgery via attacker-crafted requests like
+// `/api/ai/resources/Pod%0Alevel=error fake=line/...` that would otherwise
+// inject extra "log entries" into the stream and confuse log scrapers.
+// Replaces dangerous runes with '_' rather than dropping them so the
+// untrusted value is still visibly present.
+func sanitizeLogValue(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\r' || r < 0x20 || r == 0x7f {
+			return '_'
+		}
+		return r
+	}, s)
+}
 
 // aiAgentLogResponseWriter wraps http.ResponseWriter to count bytes written
 // to the wire. Status capture is a bonus — useful for debugging.
@@ -82,7 +99,7 @@ func aiAgentLogMiddleware(next http.Handler) http.Handler {
 			log.Printf(
 				"level=%s component=rest handler=%s duration_ms=%d bytes=%d est_tokens=%d truncated=%t omitted=%d context_tier=%s kind=%s ns=%s status=%d",
 				level, pattern, dur.Milliseconds(), tw.bytes, tw.bytes/4,
-				false, 0, "none", kind, ns, tw.status,
+				false, 0, "none", sanitizeLogValue(kind), sanitizeLogValue(ns), tw.status,
 			)
 		}()
 

--- a/internal/server/ai_agentlog.go
+++ b/internal/server/ai_agentlog.go
@@ -47,15 +47,26 @@ func aiAgentLogMiddleware(next http.Handler) http.Handler {
 		tw := &aiAgentLogResponseWriter{ResponseWriter: w, status: http.StatusOK}
 		start := time.Now()
 
-		// Emit the log line on the way out — even on panic. chi's
-		// Recoverer middleware is mounted OUTERMOST (it converts panics into
-		// 500s), so without this defer a panicking handler would unwind past
-		// this middleware before any log.Printf ran, and the most-interesting
-		// failures would silently miss the log line. Status remains 200 on the
-		// wrapped writer in that case because WriteHeader was never called;
-		// downstream scrapers can disambiguate via the duration outlier or by
-		// cross-referencing the Recoverer's own log line.
+		// Emit the log line on the way out — even on panic. chi's Recoverer
+		// middleware is mounted OUTERMOST (it converts panics into 500s).
+		// Without this defer, a panicking handler would unwind past this
+		// middleware before log.Printf ran, and the most-interesting failures
+		// would silently miss the log line.
+		//
+		// recover() is used here NOT to swallow the panic — we re-panic so
+		// the outer Recoverer still writes the 500 and logs the trace — but
+		// to (a) update tw.status to 500 before the line is emitted, so
+		// scrapers tracking error-rate SLOs see the correct status, and (b)
+		// flip the level field to "error" via the existing tw.status >= 500
+		// branch. Without this, the line would say status=200 while the
+		// wire response is 500, breaking observability for the exact failure
+		// mode the defer was meant to cover.
 		defer func() {
+			rec := recover()
+			if rec != nil {
+				tw.status = http.StatusInternalServerError
+			}
+
 			dur := time.Since(start)
 
 			// chi populates URL params after route matching. Read them inside
@@ -92,6 +103,10 @@ func aiAgentLogMiddleware(next http.Handler) http.Handler {
 				level, logsafe.Sanitize(pattern), dur.Milliseconds(), tw.bytes, tw.bytes/4,
 				false, 0, "none", logsafe.Sanitize(kind), logsafe.Sanitize(ns), tw.status,
 			)
+
+			if rec != nil {
+				panic(rec) // let outer Recoverer write the 500 + log the trace
+			}
 		}()
 
 		next.ServeHTTP(tw, r)

--- a/internal/server/ai_agentlog.go
+++ b/internal/server/ai_agentlog.go
@@ -100,7 +100,7 @@ func aiAgentLogMiddleware(next http.Handler) http.Handler {
 			// we sanitize kind/ns to stay consistent.
 			log.Printf(
 				"level=%s component=rest handler=%s duration_ms=%d bytes=%d est_tokens=%d truncated=%t omitted=%d context_tier=%s kind=%s ns=%s status=%d",
-				level, logsafe.Sanitize(pattern), dur.Milliseconds(), tw.bytes, tw.bytes/4,
+				level, logsafe.Sanitize(pattern), dur.Milliseconds(), tw.bytes, logsafe.EstimateTokens(tw.bytes),
 				false, 0, "none", logsafe.Sanitize(kind), logsafe.Sanitize(ns), tw.status,
 			)
 

--- a/internal/server/ai_agentlog.go
+++ b/internal/server/ai_agentlog.go
@@ -3,27 +3,12 @@ package server
 import (
 	"log"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
-)
 
-// sanitizeLogValue strips newlines, carriage returns, and other control
-// characters from user-controlled strings (URL params) before they go into
-// a log line. Prevents log forgery via attacker-crafted requests like
-// `/api/ai/resources/Pod%0Alevel=error fake=line/...` that would otherwise
-// inject extra "log entries" into the stream and confuse log scrapers.
-// Replaces dangerous runes with '_' rather than dropping them so the
-// untrusted value is still visibly present.
-func sanitizeLogValue(s string) string {
-	return strings.Map(func(r rune) rune {
-		if r == '\n' || r == '\r' || r < 0x20 || r == 0x7f {
-			return '_'
-		}
-		return r
-	}, s)
-}
+	"github.com/skyhook-io/radar/internal/logsafe"
+)
 
 // aiAgentLogResponseWriter wraps http.ResponseWriter to count bytes written
 // to the wire. Status capture is a bonus — useful for debugging.
@@ -96,10 +81,16 @@ func aiAgentLogMiddleware(next http.Handler) http.Handler {
 				level = "error"
 			}
 
+			// `pattern` comes from chi.RouteContext().RoutePattern() — which is
+			// the static route template like "/api/ai/resources/{kind}/...",
+			// safe by construction — but we fall back to r.URL.Path when the
+			// route didn't match (e.g. middleware misfiring on a 404). The
+			// fallback path IS user-controlled, so sanitize it the same way
+			// we sanitize kind/ns to stay consistent.
 			log.Printf(
 				"level=%s component=rest handler=%s duration_ms=%d bytes=%d est_tokens=%d truncated=%t omitted=%d context_tier=%s kind=%s ns=%s status=%d",
-				level, pattern, dur.Milliseconds(), tw.bytes, tw.bytes/4,
-				false, 0, "none", sanitizeLogValue(kind), sanitizeLogValue(ns), tw.status,
+				level, logsafe.Sanitize(pattern), dur.Milliseconds(), tw.bytes, tw.bytes/4,
+				false, 0, "none", logsafe.Sanitize(kind), logsafe.Sanitize(ns), tw.status,
 			)
 		}()
 

--- a/internal/server/ai_agentlog_test.go
+++ b/internal/server/ai_agentlog_test.go
@@ -86,6 +86,50 @@ func TestAIAgentLogMiddlewareClusterScopedNamespace(t *testing.T) {
 	}
 }
 
+// TestAIAgentLogMiddlewareSanitizesURLParams verifies that URL-param-derived
+// kind/ns values containing newline / CR / control chars do NOT inject extra
+// "log entries" into the structured line. A request like
+// `/api/ai/resources/Pod%0Alevel=error fake=line/prod/x` would otherwise
+// produce a forged log entry that downstream scrapers parse as a separate
+// event.
+func TestAIAgentLogMiddlewareSanitizesURLParams(t *testing.T) {
+	var buf bytes.Buffer
+	defer log.SetOutput(log.Writer())
+	log.SetOutput(&buf)
+
+	r := chi.NewRouter()
+	r.Route("/api", func(r chi.Router) {
+		r.Group(func(r chi.Router) {
+			r.Use(aiAgentLogMiddleware)
+			r.Get("/ai/resources/{kind}/{namespace}/{name}", func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+		})
+	})
+
+	// Build the request with raw control chars in the URL path. httptest
+	// won't percent-decode for us, so we set the chi URL params via Path
+	// after construction. Simpler: just include literal newline characters
+	// in the path components — chi.RouteContext will surface them verbatim.
+	req := httptest.NewRequest("GET", "/api/ai/resources/Pod%0Alevel=error/prod%0Dfake=ns/x", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	line := buf.String()
+	structuredLines := 0
+	for _, l := range strings.Split(line, "\n") {
+		if strings.Contains(l, "component=rest") {
+			structuredLines++
+		}
+	}
+	if structuredLines != 1 {
+		t.Errorf("expected exactly 1 structured log line, found %d (injection succeeded?)\nfull output:\n%s", structuredLines, line)
+	}
+	if strings.Contains(line, "level=error fake=") {
+		t.Errorf("user-controlled control chars reached the log line and forged a kv pair\nfull output:\n%s", line)
+	}
+}
+
 // TestAIAgentLogMiddlewareEmitsOnPanic verifies the middleware emits a
 // log line even when the handler panics. Without the deferred logger
 // the most-interesting failures (handler crashes) would silently miss

--- a/internal/server/ai_agentlog_test.go
+++ b/internal/server/ai_agentlog_test.go
@@ -87,11 +87,15 @@ func TestAIAgentLogMiddlewareClusterScopedNamespace(t *testing.T) {
 }
 
 // TestAIAgentLogMiddlewareSanitizesURLParams verifies that URL-param-derived
-// kind/ns values containing newline / CR / control chars do NOT inject extra
-// "log entries" into the structured line. A request like
-// `/api/ai/resources/Pod%0Alevel=error fake=line/prod/x` would otherwise
-// produce a forged log entry that downstream scrapers parse as a separate
-// event.
+// kind/ns values can't inject log structure. Two attack vectors:
+//
+//  1. Multi-line: a request like `/api/ai/resources/Pod%0Alevel=error/...`
+//     decodes to a literal newline that would otherwise split the log entry.
+//  2. Same-line logfmt injection: even without control chars, spaces and
+//     `=` in URL values introduce new key=value tokens on the SAME line
+//     that scrapers parse as legitimate fields.
+//
+// Both vectors must be neutralized via logsafe.Sanitize.
 func TestAIAgentLogMiddlewareSanitizesURLParams(t *testing.T) {
 	var buf bytes.Buffer
 	defer log.SetOutput(log.Writer())
@@ -107,15 +111,15 @@ func TestAIAgentLogMiddlewareSanitizesURLParams(t *testing.T) {
 		})
 	})
 
-	// Build the request with raw control chars in the URL path. httptest
-	// won't percent-decode for us, so we set the chi URL params via Path
-	// after construction. Simpler: just include literal newline characters
-	// in the path components — chi.RouteContext will surface them verbatim.
-	req := httptest.NewRequest("GET", "/api/ai/resources/Pod%0Alevel=error/prod%0Dfake=ns/x", nil)
+	// %0A = newline (multi-line attack); %20 = space + literal `=` (same-line
+	// attack). Combined into one request to exercise both vectors.
+	req := httptest.NewRequest("GET", "/api/ai/resources/Pod%0Alevel=error%20fake=ns/prod%0Dfake=ns2/x", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
 	line := buf.String()
+
+	// Multi-line vector: exactly ONE structured line in the output.
 	structuredLines := 0
 	for _, l := range strings.Split(line, "\n") {
 		if strings.Contains(l, "component=rest") {
@@ -123,10 +127,16 @@ func TestAIAgentLogMiddlewareSanitizesURLParams(t *testing.T) {
 		}
 	}
 	if structuredLines != 1 {
-		t.Errorf("expected exactly 1 structured log line, found %d (injection succeeded?)\nfull output:\n%s", structuredLines, line)
+		t.Errorf("expected exactly 1 structured log line, found %d (multi-line injection succeeded?)\nfull output:\n%s", structuredLines, line)
 	}
-	if strings.Contains(line, "level=error fake=") {
-		t.Errorf("user-controlled control chars reached the log line and forged a kv pair\nfull output:\n%s", line)
+
+	// Same-line vector: forged "level=error" / "fake=ns" / "fake=ns2"
+	// fields must NOT appear as standalone kv tokens. Sanitizer collapses
+	// space+`=` to underscores, so these key= patterns can't form.
+	for _, forged := range []string{" level=error", " fake=ns", " fake=ns2"} {
+		if strings.Contains(line, forged) {
+			t.Errorf("same-line logfmt injection reached the wire (substring %q present)\nfull output:\n%s", forged, line)
+		}
 	}
 }
 

--- a/internal/server/ai_agentlog_test.go
+++ b/internal/server/ai_agentlog_test.go
@@ -164,6 +164,16 @@ func TestAIAgentLogMiddlewareEmitsOnPanic(t *testing.T) {
 	if !strings.Contains(line, "handler=/api/ai/resources/{kind}/{namespace}/{name}") {
 		t.Errorf("log line missing route pattern on panic path; got:\n%s", line)
 	}
+	// Panic path MUST log status=500 and level=error, not the default 200 /
+	// info. The wire response is 500 (chi.Recoverer writes it after the
+	// middleware re-panics), so the structured line must agree — otherwise
+	// scrapers tracking error-rate SLOs miss the failures.
+	if !strings.Contains(line, "status=500") {
+		t.Errorf("panic-path log line must report status=500 (not the default 200); got:\n%s", line)
+	}
+	if !strings.Contains(line, "level=error") {
+		t.Errorf("panic-path log line must report level=error (not info); got:\n%s", line)
+	}
 	if !strings.Contains(line, "kind=Pod") {
 		t.Errorf("log line missing kind on panic path; got:\n%s", line)
 	}

--- a/internal/server/ai_agentlog_test.go
+++ b/internal/server/ai_agentlog_test.go
@@ -1,0 +1,126 @@
+package server
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
+)
+
+// TestAIAgentLogMiddlewareEmitsLogLine verifies the middleware emits a
+// structured log line with the expected fields after the handler runs.
+func TestAIAgentLogMiddlewareEmitsLogLine(t *testing.T) {
+	var buf bytes.Buffer
+	defer log.SetOutput(log.Writer())
+	log.SetOutput(&buf)
+
+	r := chi.NewRouter()
+	r.Route("/api", func(r chi.Router) {
+		r.Group(func(r chi.Router) {
+			r.Use(aiAgentLogMiddleware)
+			r.Get("/ai/resources/{kind}/{namespace}/{name}", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"kind":"Pod","ns":"prod"}`))
+			})
+		})
+	})
+
+	req := httptest.NewRequest("GET", "/api/ai/resources/Pod/prod/my-pod", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	line := buf.String()
+	wants := []string{
+		"component=rest",
+		"handler=/api/ai/resources/{kind}/{namespace}/{name}",
+		"kind=Pod",
+		"ns=prod",
+		"context_tier=none",
+		"truncated=false",
+		"omitted=0",
+		"status=200",
+	}
+	for _, w := range wants {
+		if !strings.Contains(line, w) {
+			t.Errorf("log line missing %q\nfull line: %s", w, line)
+		}
+	}
+}
+
+// TestAIAgentLogMiddlewareClusterScopedNamespace verifies the "_" cluster-scoped
+// placeholder gets normalized to an empty ns field for log scrapers.
+func TestAIAgentLogMiddlewareClusterScopedNamespace(t *testing.T) {
+	var buf bytes.Buffer
+	defer log.SetOutput(log.Writer())
+	log.SetOutput(&buf)
+
+	r := chi.NewRouter()
+	r.Route("/api", func(r chi.Router) {
+		r.Group(func(r chi.Router) {
+			r.Use(aiAgentLogMiddleware)
+			r.Get("/ai/resources/{kind}/{namespace}/{name}", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+		})
+	})
+
+	req := httptest.NewRequest("GET", "/api/ai/resources/Node/_/node-1", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	line := buf.String()
+	if !strings.Contains(line, "kind=Node") {
+		t.Errorf("expected kind=Node in log line: %s", line)
+	}
+	// Log line format ends with `... kind=<k> ns=<v> status=<n>`. For cluster-
+	// scoped resources, ns is normalized from "_" to "" — so the substring
+	// " ns= status=" deterministically pins an empty ns value followed by the
+	// next field, with no spillover from other fields.
+	if !strings.Contains(line, " ns= status=") {
+		t.Errorf("expected empty ns followed by status= in log line for cluster-scoped resource: %s", line)
+	}
+}
+
+// TestAIAgentLogMiddlewareEmitsOnPanic verifies the middleware emits a
+// log line even when the handler panics. Without the deferred logger
+// the most-interesting failures (handler crashes) would silently miss
+// the log line — chi's outer Recoverer would absorb the panic but our
+// line would never run.
+func TestAIAgentLogMiddlewareEmitsOnPanic(t *testing.T) {
+	var buf bytes.Buffer
+	defer log.SetOutput(log.Writer())
+	log.SetOutput(&buf)
+
+	r := chi.NewRouter()
+	// Mirror production: Recoverer wraps the agent-log subrouter, so panics
+	// unwind through agent-log middleware before being caught.
+	r.Use(chimiddleware.Recoverer)
+	r.Route("/api", func(r chi.Router) {
+		r.Group(func(r chi.Router) {
+			r.Use(aiAgentLogMiddleware)
+			r.Get("/ai/resources/{kind}/{namespace}/{name}", func(_ http.ResponseWriter, _ *http.Request) {
+				panic("synthetic handler panic for log-line test")
+			})
+		})
+	})
+
+	req := httptest.NewRequest("GET", "/api/ai/resources/Pod/prod/oops", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	line := buf.String()
+	if !strings.Contains(line, "component=rest") {
+		t.Errorf("log line missing on panic path; got:\n%s", line)
+	}
+	if !strings.Contains(line, "handler=/api/ai/resources/{kind}/{namespace}/{name}") {
+		t.Errorf("log line missing route pattern on panic path; got:\n%s", line)
+	}
+	if !strings.Contains(line, "kind=Pod") {
+		t.Errorf("log line missing kind on panic path; got:\n%s", line)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -371,9 +371,14 @@ func (s *Server) setupRoutes() {
 			r.Post("/argo/applications/{namespace}/{name}/suspend", s.handleArgoSuspend)
 			r.Post("/argo/applications/{namespace}/{name}/resume", s.handleArgoResume)
 
-			// AI resource preview (minified output for MCP/debugging)
-			r.Get("/ai/resources/{kind}", s.handleAIListResources)
-			r.Get("/ai/resources/{kind}/{namespace}/{name}", s.handleAIGetResource)
+			// AI resource preview (minified output for MCP/debugging).
+			// Mounted as a sub-group so agent-log middleware applies only
+			// to /api/ai/* — UI-facing /api/resources/* stays untouched.
+			r.Group(func(r chi.Router) {
+				r.Use(aiAgentLogMiddleware)
+				r.Get("/ai/resources/{kind}", s.handleAIListResources)
+				r.Get("/ai/resources/{kind}/{namespace}/{name}", s.handleAIGetResource)
+			})
 
 			// Debug routes (for event pipeline diagnostics)
 			r.Get("/debug/events", s.handleDebugEvents)


### PR DESCRIPTION
Phase 0 of the resource-context plan. Emits a single structured `logfmt`-style line via stdlib `log.Printf` after every MCP tool call and every `/api/ai/*` REST request, so operators can locally measure response size and tool latency before later phases start changing the response shape.

**Local logging, not phone-home telemetry** — no network calls, no Prometheus, no aggregation, no third-party transport. Same destination + privacy profile as the existing colored `[MCP] tool_name OK (42ms)` dev log already in radar OSS.

Fields are stable and parser-friendly: `component=mcp|rest`, `tool=<name>` (MCP) or `handler=<route pattern>` (REST), `duration_ms`, `bytes`, `est_tokens`, `truncated`, `omitted`, `context_tier=none`, `kind`, `ns`, `status` (REST). The last four are placeholders that later phases populate when the resourceContext generator and diagnostic tier land; emitting them now keeps the line shape forward-compatible.

Middleware mounts on the `/api/ai/*` subrouter only — `/api/resources/*` (the UI-facing endpoint) stays untouched.

### Defense-in-depth additions across the branch

- **`internal/logsafe`** — small shared package that sanitizes user-controlled log values. Replaces newlines, CRs, control chars, AND space + `=` with `_` to close both multi-line log forgery and same-line logfmt field injection. Applied to `kind`, `ns`, and the chi route `pattern` fallback (which is user-controlled when no route matches).
- **Panic-path correctness** — REST middleware wraps emission in `defer` so panicking handlers still log. The defer uses `recover()` to set `tw.status = 500` before emission (so scrapers tracking error-rate SLOs see the correct status) then re-panics so the outer chi `Recoverer` still writes the wire response.

Tests assert the full log-line shape for both MCP and REST paths including the panic path; logsafe has a per-rune table covering both attack classes.

E2E verified against a live cluster: MCP `list_namespaces` and `GET /api/ai/resources/{kind}/{ns}/{name}` both produce the expected line with all fields populated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new logging and HTTP middleware on `/api/ai/*`, including panic-path `recover`/re-panic behavior and response-writer wrapping, which could affect request handling and log volume if misconfigured. Security risk is reduced via new sanitization, but correctness of emitted fields and panic/status reporting is important.
> 
> **Overview**
> Adds a **new structured logfmt-style “agent log” line** after every MCP tool call and every `/api/ai/*` REST request, emitting stable fields like `duration_ms`, `bytes`, `est_tokens`, `kind`, `ns`, and error/status signals for downstream scraping.
> 
> Introduces `internal/logsafe` to **sanitize user-controlled log values** (control chars, newline/CR, space, `=`) to prevent multi-line and same-line logfmt injection, and shares a single `EstimateTokens` heuristic across MCP and REST.
> 
> Mounts a new `/api/ai/*` middleware that counts response bytes, logs on normal and panic paths (with status normalization to 500 on panic), and updates MCP tooling by moving the tool-call wrapper into a dedicated `agentlog.go`; adds focused tests to lock the log-line shape and injection defenses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8362a02d83eaaec06d9a29d91aa9339271043faf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->