### PR TITLE
fix(topology): split Relationships.Policies + fix B1 PDB→ScaleTarget bug (T1)

### DIFF
--- a/packages/k8s-ui/src/components/ui/drawer-components.tsx
+++ b/packages/k8s-ui/src/components/ui/drawer-components.tsx
@@ -709,27 +709,8 @@ function dedupeRefs(refs: ResourceRef[]): ResourceRef[] {
   })
 }
 
-const NETPOL_KINDS = new Set(['NetworkPolicy', 'CiliumNetworkPolicy', 'CiliumClusterwideNetworkPolicy', 'ClusterNetworkPolicy'])
-
 export function RelatedResourcesSection({ relationships, onNavigate }: RelatedResourcesSectionProps) {
   if (!relationships) return null
-
-  // Resolve PDBs and NetworkPolicies: prefer the split fields the backend emits
-  // after the T1/Phase 1a migration. Fall back to filtering `policies` by kind
-  // only when BOTH new fields are absent — that handles older radar instances
-  // (e.g. through a hub) that still emit just the legacy `policies` union.
-  const usingLegacyPolicies = relationships.pdbs === undefined && relationships.networkPolicies === undefined
-  const resolvedPDBs: ResourceRef[] = usingLegacyPolicies
-    ? (relationships.policies ?? []).filter(r => r.kind === 'PodDisruptionBudget')
-    : (relationships.pdbs ?? [])
-  const resolvedNetPols: ResourceRef[] = usingLegacyPolicies
-    ? (relationships.policies ?? []).filter(r => NETPOL_KINDS.has(r.kind))
-    : (relationships.networkPolicies ?? [])
-  // Any "Policies" entries that aren't PDB or NetworkPolicy variants — only
-  // surfaces on the legacy fallback path; the new split has no "other" bucket.
-  const resolvedOtherPolicies: ResourceRef[] = usingLegacyPolicies
-    ? (relationships.policies ?? []).filter(r => r.kind !== 'PodDisruptionBudget' && !NETPOL_KINDS.has(r.kind))
-    : []
 
   const hasRelationships =
     relationships.owner ||
@@ -743,9 +724,8 @@ export function RelatedResourcesSection({ relationships, onNavigate }: RelatedRe
     (relationships.configRefs && relationships.configRefs.length > 0) ||
     (relationships.consumers && relationships.consumers.length > 0) ||
     (relationships.scalers && relationships.scalers.length > 0) ||
-    resolvedPDBs.length > 0 ||
-    resolvedNetPols.length > 0 ||
-    resolvedOtherPolicies.length > 0 ||
+    (relationships.pdbs && relationships.pdbs.length > 0) ||
+    (relationships.networkPolicies && relationships.networkPolicies.length > 0) ||
     relationships.scaleTarget
 
   if (!hasRelationships) return null
@@ -786,14 +766,11 @@ export function RelatedResourcesSection({ relationships, onNavigate }: RelatedRe
         {relationships.scalers && relationships.scalers.length > 0 && (
           <RelationshipGroup label="Autoscaler" refs={dedupeRefs(relationships.scalers)} onNavigate={onNavigate} />
         )}
-        {resolvedPDBs.length > 0 && (
-          <RelationshipGroup label="Disruption Budget" refs={dedupeRefs(resolvedPDBs)} onNavigate={onNavigate} />
+        {relationships.pdbs && relationships.pdbs.length > 0 && (
+          <RelationshipGroup label="Disruption Budget" refs={dedupeRefs(relationships.pdbs)} onNavigate={onNavigate} />
         )}
-        {resolvedNetPols.length > 0 && (
-          <RelationshipGroup label="Network Policies" refs={dedupeRefs(resolvedNetPols)} onNavigate={onNavigate} />
-        )}
-        {resolvedOtherPolicies.length > 0 && (
-          <RelationshipGroup label="Policies" refs={dedupeRefs(resolvedOtherPolicies)} onNavigate={onNavigate} />
+        {relationships.networkPolicies && relationships.networkPolicies.length > 0 && (
+          <RelationshipGroup label="Network Policies" refs={dedupeRefs(relationships.networkPolicies)} onNavigate={onNavigate} />
         )}
         {relationships.scaleTarget && (
           <RelationshipGroup label="Scale Target" refs={[relationships.scaleTarget]} onNavigate={onNavigate} />

--- a/packages/k8s-ui/src/components/ui/drawer-components.tsx
+++ b/packages/k8s-ui/src/components/ui/drawer-components.tsx
@@ -709,6 +709,8 @@ function dedupeRefs(refs: ResourceRef[]): ResourceRef[] {
   })
 }
 
+const NETPOL_KINDS = new Set(['NetworkPolicy', 'CiliumNetworkPolicy', 'CiliumClusterwideNetworkPolicy', 'ClusterNetworkPolicy'])
+
 export function RelatedResourcesSection({ relationships, onNavigate }: RelatedResourcesSectionProps) {
   if (!relationships) return null
 
@@ -716,7 +718,6 @@ export function RelatedResourcesSection({ relationships, onNavigate }: RelatedRe
   // after the T1/Phase 1a migration. Fall back to filtering `policies` by kind
   // only when BOTH new fields are absent — that handles older radar instances
   // (e.g. through a hub) that still emit just the legacy `policies` union.
-  const NETPOL_KINDS = new Set(['NetworkPolicy', 'CiliumNetworkPolicy', 'CiliumClusterwideNetworkPolicy', 'ClusterNetworkPolicy'])
   const usingLegacyPolicies = relationships.pdbs === undefined && relationships.networkPolicies === undefined
   const resolvedPDBs: ResourceRef[] = usingLegacyPolicies
     ? (relationships.policies ?? []).filter(r => r.kind === 'PodDisruptionBudget')

--- a/packages/k8s-ui/src/components/ui/drawer-components.tsx
+++ b/packages/k8s-ui/src/components/ui/drawer-components.tsx
@@ -712,6 +712,24 @@ function dedupeRefs(refs: ResourceRef[]): ResourceRef[] {
 export function RelatedResourcesSection({ relationships, onNavigate }: RelatedResourcesSectionProps) {
   if (!relationships) return null
 
+  // Resolve PDBs and NetworkPolicies: prefer the split fields the backend emits
+  // after the T1/Phase 1a migration. Fall back to filtering `policies` by kind
+  // only when BOTH new fields are absent — that handles older radar instances
+  // (e.g. through a hub) that still emit just the legacy `policies` union.
+  const NETPOL_KINDS = new Set(['NetworkPolicy', 'CiliumNetworkPolicy', 'CiliumClusterwideNetworkPolicy', 'ClusterNetworkPolicy'])
+  const usingLegacyPolicies = relationships.pdbs === undefined && relationships.networkPolicies === undefined
+  const resolvedPDBs: ResourceRef[] = usingLegacyPolicies
+    ? (relationships.policies ?? []).filter(r => r.kind === 'PodDisruptionBudget')
+    : (relationships.pdbs ?? [])
+  const resolvedNetPols: ResourceRef[] = usingLegacyPolicies
+    ? (relationships.policies ?? []).filter(r => NETPOL_KINDS.has(r.kind))
+    : (relationships.networkPolicies ?? [])
+  // Any "Policies" entries that aren't PDB or NetworkPolicy variants — only
+  // surfaces on the legacy fallback path; the new split has no "other" bucket.
+  const resolvedOtherPolicies: ResourceRef[] = usingLegacyPolicies
+    ? (relationships.policies ?? []).filter(r => r.kind !== 'PodDisruptionBudget' && !NETPOL_KINDS.has(r.kind))
+    : []
+
   const hasRelationships =
     relationships.owner ||
     relationships.deployment ||
@@ -724,7 +742,9 @@ export function RelatedResourcesSection({ relationships, onNavigate }: RelatedRe
     (relationships.configRefs && relationships.configRefs.length > 0) ||
     (relationships.consumers && relationships.consumers.length > 0) ||
     (relationships.scalers && relationships.scalers.length > 0) ||
-    (relationships.policies && relationships.policies.length > 0) ||
+    resolvedPDBs.length > 0 ||
+    resolvedNetPols.length > 0 ||
+    resolvedOtherPolicies.length > 0 ||
     relationships.scaleTarget
 
   if (!hasRelationships) return null
@@ -765,25 +785,15 @@ export function RelatedResourcesSection({ relationships, onNavigate }: RelatedRe
         {relationships.scalers && relationships.scalers.length > 0 && (
           <RelationshipGroup label="Autoscaler" refs={dedupeRefs(relationships.scalers)} onNavigate={onNavigate} />
         )}
-        {relationships.policies && relationships.policies.length > 0 && (() => {
-          const policyKinds = new Set(['NetworkPolicy', 'CiliumNetworkPolicy', 'CiliumClusterwideNetworkPolicy', 'ClusterNetworkPolicy'])
-          const pdbs = relationships.policies.filter(r => r.kind === 'PodDisruptionBudget')
-          const netpols = relationships.policies.filter(r => policyKinds.has(r.kind))
-          const other = relationships.policies.filter(r => r.kind !== 'PodDisruptionBudget' && !policyKinds.has(r.kind))
-          return (
-            <>
-              {pdbs.length > 0 && (
-                <RelationshipGroup label="Disruption Budget" refs={dedupeRefs(pdbs)} onNavigate={onNavigate} />
-              )}
-              {netpols.length > 0 && (
-                <RelationshipGroup label="Network Policies" refs={dedupeRefs(netpols)} onNavigate={onNavigate} />
-              )}
-              {other.length > 0 && (
-                <RelationshipGroup label="Policies" refs={dedupeRefs(other)} onNavigate={onNavigate} />
-              )}
-            </>
-          )
-        })()}
+        {resolvedPDBs.length > 0 && (
+          <RelationshipGroup label="Disruption Budget" refs={dedupeRefs(resolvedPDBs)} onNavigate={onNavigate} />
+        )}
+        {resolvedNetPols.length > 0 && (
+          <RelationshipGroup label="Network Policies" refs={dedupeRefs(resolvedNetPols)} onNavigate={onNavigate} />
+        )}
+        {resolvedOtherPolicies.length > 0 && (
+          <RelationshipGroup label="Policies" refs={dedupeRefs(resolvedOtherPolicies)} onNavigate={onNavigate} />
+        )}
         {relationships.scaleTarget && (
           <RelationshipGroup label="Scale Target" refs={[relationships.scaleTarget]} onNavigate={onNavigate} />
         )}

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -403,7 +403,15 @@ export interface Relationships {
   consumers?: ResourceRef[]
   scalers?: ResourceRef[]
   scaleTarget?: ResourceRef
+  /**
+   * @deprecated Use `pdbs` and `networkPolicies` instead. Backend populates this
+   * as the union of both for one release; renderers should prefer the split
+   * fields and only fall back to `policies` when both are absent (e.g. an older
+   * radar instance behind a hub).
+   */
   policies?: ResourceRef[]
+  pdbs?: ResourceRef[]              // PodDisruptionBudgets protecting this workload
+  networkPolicies?: ResourceRef[]   // NetworkPolicy / CiliumNetworkPolicy / ClusterNetworkPolicy variants selecting this workload
   pods?: ResourceRef[]
 }
 

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -403,13 +403,6 @@ export interface Relationships {
   consumers?: ResourceRef[]
   scalers?: ResourceRef[]
   scaleTarget?: ResourceRef
-  /**
-   * @deprecated Use `pdbs` and `networkPolicies` instead. Backend populates this
-   * as the union of both for one release; renderers should prefer the split
-   * fields and only fall back to `policies` when both are absent (e.g. an older
-   * radar instance behind a hub).
-   */
-  policies?: ResourceRef[]
   pdbs?: ResourceRef[]              // PodDisruptionBudgets protecting this workload
   networkPolicies?: ResourceRef[]   // NetworkPolicy / CiliumNetworkPolicy / ClusterNetworkPolicy variants selecting this workload
   pods?: ResourceRef[]

--- a/pkg/topology/relationships.go
+++ b/pkg/topology/relationships.go
@@ -204,15 +204,13 @@ func GetRelationships(kind, namespace, name string, topo *Topology, provider Res
 				rel.Scalers = append(rel.Scalers, *ref)
 			case EdgeProtects:
 				// Incoming EdgeProtects: dispatch on source kind so PDBs and
-				// NetworkPolicies land in distinct fields. rel.Policies is
-				// still populated as the union for one release (deprecated alias).
+				// NetworkPolicies land in distinct fields.
 				switch ref.Kind {
 				case "PodDisruptionBudget":
 					rel.PDBs = append(rel.PDBs, *ref)
 				case "NetworkPolicy", "CiliumNetworkPolicy", "ClusterNetworkPolicy", "CiliumClusterwideNetworkPolicy":
 					rel.NetworkPolicies = append(rel.NetworkPolicies, *ref)
 				}
-				rel.Policies = append(rel.Policies, *ref)
 			case EdgeConfigures:
 				// A ConfigMap/Secret is used by this resource
 				rel.ConfigRefs = append(rel.ConfigRefs, *ref)
@@ -314,7 +312,7 @@ func GetRelationships(kind, namespace, name string, topo *Topology, provider Res
 	if rel.Owner == nil && rel.Deployment == nil && len(rel.Children) == 0 && len(rel.Services) == 0 &&
 		len(rel.Ingresses) == 0 && len(rel.Gateways) == 0 && len(rel.Routes) == 0 &&
 		len(rel.ConfigRefs) == 0 && len(rel.Consumers) == 0 && len(rel.Scalers) == 0 &&
-		len(rel.Policies) == 0 && len(rel.PDBs) == 0 && len(rel.NetworkPolicies) == 0 &&
+		len(rel.PDBs) == 0 && len(rel.NetworkPolicies) == 0 &&
 		rel.ScaleTarget == nil && len(rel.Pods) == 0 {
 		return nil
 	}

--- a/pkg/topology/relationships.go
+++ b/pkg/topology/relationships.go
@@ -147,8 +147,13 @@ func GetRelationships(kind, namespace, name string, topo *Topology, provider Res
 				// HPA/ScaledObject/ScaledJob scales a workload
 				rel.ScaleTarget = ref
 			case EdgeProtects:
-				// PDB protects a workload (outgoing from PDB)
-				rel.ScaleTarget = ref
+				// Outgoing EdgeProtects: this resource protects the target workload.
+				// Per the plan, the queried source is a PDB here, so its outgoing
+				// "protects" target lands in rel.PDBs (and the deprecated union).
+				// Previously this overwrote rel.ScaleTarget, which is semantically
+				// reserved for HPA/ScaledObject scale targets (bug B1).
+				rel.PDBs = append(rel.PDBs, *ref)
+				rel.Policies = append(rel.Policies, *ref)
 			case EdgeConfigures:
 				// ConfigMap/Secret is used by a workload (outgoing from config)
 				rel.Consumers = append(rel.Consumers, *ref)
@@ -185,7 +190,15 @@ func GetRelationships(kind, namespace, name string, topo *Topology, provider Res
 				// An HPA/ScaledObject/ScaledJob scales this resource
 				rel.Scalers = append(rel.Scalers, *ref)
 			case EdgeProtects:
-				// A PDB protects this workload
+				// Incoming EdgeProtects: dispatch on source kind so PDBs and
+				// NetworkPolicies land in distinct fields. rel.Policies is
+				// still populated as the union for one release (deprecated alias).
+				switch ref.Kind {
+				case "PodDisruptionBudget":
+					rel.PDBs = append(rel.PDBs, *ref)
+				case "NetworkPolicy", "CiliumNetworkPolicy", "ClusterNetworkPolicy", "CiliumClusterwideNetworkPolicy":
+					rel.NetworkPolicies = append(rel.NetworkPolicies, *ref)
+				}
 				rel.Policies = append(rel.Policies, *ref)
 			case EdgeConfigures:
 				// A ConfigMap/Secret is used by this resource
@@ -288,7 +301,8 @@ func GetRelationships(kind, namespace, name string, topo *Topology, provider Res
 	if rel.Owner == nil && rel.Deployment == nil && len(rel.Children) == 0 && len(rel.Services) == 0 &&
 		len(rel.Ingresses) == 0 && len(rel.Gateways) == 0 && len(rel.Routes) == 0 &&
 		len(rel.ConfigRefs) == 0 && len(rel.Consumers) == 0 && len(rel.Scalers) == 0 &&
-		len(rel.Policies) == 0 && rel.ScaleTarget == nil && len(rel.Pods) == 0 {
+		len(rel.Policies) == 0 && len(rel.PDBs) == 0 && len(rel.NetworkPolicies) == 0 &&
+		rel.ScaleTarget == nil && len(rel.Pods) == 0 {
 		return nil
 	}
 

--- a/pkg/topology/relationships.go
+++ b/pkg/topology/relationships.go
@@ -147,13 +147,26 @@ func GetRelationships(kind, namespace, name string, topo *Topology, provider Res
 				// HPA/ScaledObject/ScaledJob scales a workload
 				rel.ScaleTarget = ref
 			case EdgeProtects:
-				// Outgoing EdgeProtects: this resource protects the target workload.
-				// Per the plan, the queried source is a PDB here, so its outgoing
-				// "protects" target lands in rel.PDBs (and the deprecated union).
-				// Previously this overwrote rel.ScaleTarget, which is semantically
-				// reserved for HPA/ScaledObject scale targets (bug B1).
-				rel.PDBs = append(rel.PDBs, *ref)
-				rel.Policies = append(rel.Policies, *ref)
+				// Outgoing EdgeProtects fires when the queried resource IS a
+				// PDB, NetworkPolicy, CiliumNetworkPolicy, or MachineHealthCheck —
+				// each of these emits a "protects/selects target workload" edge.
+				//
+				// Intentionally NOT surfaced today. The existing per-resource
+				// relationship fields (PDBs, NetworkPolicies, Scalers, etc.)
+				// describe "things that act on me," not "things I act on" —
+				// so there's no semantically correct field to land outgoing
+				// protects refs in.
+				//
+				// Previously this case wrote to rel.ScaleTarget (bug B1) and
+				// then briefly to rel.PDBs (which conflated PDB-side and NP-
+				// side outgoing edges into the same incoming-direction field).
+				// Both were wrong.
+				//
+				// TODO: when we introduce a target-side "Protects []ResourceRef"
+				// field on Relationships, surface these refs there with their
+				// source kind preserved. Until then, leave the outgoing direction
+				// of EdgeProtects unsurfaced. The topology graph itself still
+				// carries these edges; only the per-resource projection skips them.
 			case EdgeConfigures:
 				// ConfigMap/Secret is used by a workload (outgoing from config)
 				rel.Consumers = append(rel.Consumers, *ref)

--- a/pkg/topology/relationships_test.go
+++ b/pkg/topology/relationships_test.go
@@ -74,21 +74,22 @@ func TestGetRelationships_IncomingEdgeProtects_DispatchesByKind(t *testing.T) {
 // which conflated PDB-side and NP-side outgoing edges).
 func TestGetRelationships_OutgoingEdgeProtects_NotSurfaced(t *testing.T) {
 	cases := []struct {
-		name     string
-		queryKnd string
-		sourceID string
-		sourceKd NodeKind
+		name       string
+		queryKind  string
+		queryName  string // must match the name component of sourceID below
+		sourceID   string
+		sourceKind NodeKind
 	}{
-		{"PDB outgoing", "PodDisruptionBudget", "poddisruptionbudget/demo/web-pdb", KindPDB},
-		{"NetworkPolicy outgoing", "NetworkPolicy", "networkpolicy/demo/deny-egress", KindNetworkPolicy},
-		{"CiliumNetworkPolicy outgoing", "CiliumNetworkPolicy", "ciliumnetworkpolicy/demo/cnp-1", KindCiliumNetworkPolicy},
+		{"PDB outgoing", "PodDisruptionBudget", "web-pdb", "poddisruptionbudget/demo/web-pdb", KindPDB},
+		{"NetworkPolicy outgoing", "NetworkPolicy", "deny-egress", "networkpolicy/demo/deny-egress", KindNetworkPolicy},
+		{"CiliumNetworkPolicy outgoing", "CiliumNetworkPolicy", "cnp-1", "ciliumnetworkpolicy/demo/cnp-1", KindCiliumNetworkPolicy},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			topo := &Topology{
 				Nodes: []Node{
-					{ID: c.sourceID, Kind: c.sourceKd, Name: "src"},
+					{ID: c.sourceID, Kind: c.sourceKind, Name: c.queryName},
 					{ID: "deployment/demo/web", Kind: KindDeployment, Name: "web"},
 					{ID: "deployment/demo/api", Kind: KindDeployment, Name: "api"},
 				},
@@ -98,7 +99,30 @@ func TestGetRelationships_OutgoingEdgeProtects_NotSurfaced(t *testing.T) {
 				},
 			}
 
-			rel := GetRelationships(c.queryKnd, "demo", "src", topo, nil, nil)
+			// Control: the SAME topology, queried from the workload side, MUST
+			// surface the policy via incoming-EdgeProtects dispatch. If this
+			// fails, the test below would pass for the wrong reason — the
+			// edges or node IDs aren't matching at all. Catches the
+			// vacuous-pass class of mistakes.
+			incoming := GetRelationships("Deployment", "demo", "web", topo, nil, nil)
+			if incoming == nil {
+				t.Fatalf("control assertion failed: querying the target Deployment should surface the policy via incoming EdgeProtects, got nil relationships")
+			}
+			switch c.sourceKind {
+			case KindPDB:
+				if len(incoming.PDBs) == 0 {
+					t.Fatalf("control: expected workload to see incoming PDB, got %+v", incoming)
+				}
+			case KindNetworkPolicy, KindCiliumNetworkPolicy:
+				if len(incoming.NetworkPolicies) == 0 {
+					t.Fatalf("control: expected workload to see incoming NetworkPolicy, got %+v", incoming)
+				}
+			}
+
+			// Actual assertion: querying from the source policy side should
+			// NOT surface its targets (outgoing direction intentionally
+			// unsurfaced until a Protects[] field exists).
+			rel := GetRelationships(c.queryKind, "demo", c.queryName, topo, nil, nil)
 			if rel != nil {
 				t.Errorf("want nil (outgoing protects intentionally not surfaced), got %+v", rel)
 			}

--- a/pkg/topology/relationships_test.go
+++ b/pkg/topology/relationships_test.go
@@ -59,40 +59,50 @@ func TestGetRelationships_IncomingEdgeProtects_DispatchesByKind(t *testing.T) {
 	}
 }
 
-// TestGetRelationships_OutgoingEdgeProtects_PDBLandsInPDBs verifies the B1 bug
-// fix: outgoing "protects" edges from a PDB land in rel.PDBs instead of being
-// silently overwritten into rel.ScaleTarget (which is reserved for HPA targets).
-func TestGetRelationships_OutgoingEdgeProtects_PDBLandsInPDBs(t *testing.T) {
-	topo := &Topology{
-		Nodes: []Node{
-			{ID: "poddisruptionbudget/demo/web-pdb", Kind: KindPDB, Name: "web-pdb"},
-			{ID: "deployment/demo/web", Kind: KindDeployment, Name: "web"},
-			{ID: "deployment/demo/api", Kind: KindDeployment, Name: "api"},
-		},
-		Edges: []Edge{
-			{ID: "pdb-to-web", Source: "poddisruptionbudget/demo/web-pdb", Target: "deployment/demo/web", Type: EdgeProtects},
-			{ID: "pdb-to-api", Source: "poddisruptionbudget/demo/web-pdb", Target: "deployment/demo/api", Type: EdgeProtects},
-		},
+// TestGetRelationships_OutgoingEdgeProtects_NotSurfaced verifies that outgoing
+// EdgeProtects edges (a PDB / NetworkPolicy / CiliumNetworkPolicy / etc. pointing
+// at the workloads it protects) are intentionally NOT projected into the
+// Relationships of the source resource. The PDBs / NetworkPolicies fields are
+// reserved for the INCOMING-direction semantic ("things that act on me").
+//
+// Surfacing the outgoing direction requires a new Protects/SelectedWorkloads
+// field, which is out of scope here. Until that field lands, querying a PDB
+// or NetworkPolicy that has only outgoing protects edges returns nil.
+//
+// This also guards B1 (the old bug that wrote outgoing protects into
+// rel.ScaleTarget) and the post-B1 over-fix (writing them into rel.PDBs,
+// which conflated PDB-side and NP-side outgoing edges).
+func TestGetRelationships_OutgoingEdgeProtects_NotSurfaced(t *testing.T) {
+	cases := []struct {
+		name     string
+		queryKnd string
+		sourceID string
+		sourceKd NodeKind
+	}{
+		{"PDB outgoing", "PodDisruptionBudget", "poddisruptionbudget/demo/web-pdb", KindPDB},
+		{"NetworkPolicy outgoing", "NetworkPolicy", "networkpolicy/demo/deny-egress", KindNetworkPolicy},
+		{"CiliumNetworkPolicy outgoing", "CiliumNetworkPolicy", "ciliumnetworkpolicy/demo/cnp-1", KindCiliumNetworkPolicy},
 	}
 
-	rel := GetRelationships("PodDisruptionBudget", "demo", "web-pdb", topo, nil, nil)
-	if rel == nil {
-		t.Fatal("GetRelationships returned nil for PDB with outgoing protects edges")
-	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			topo := &Topology{
+				Nodes: []Node{
+					{ID: c.sourceID, Kind: c.sourceKd, Name: "src"},
+					{ID: "deployment/demo/web", Kind: KindDeployment, Name: "web"},
+					{ID: "deployment/demo/api", Kind: KindDeployment, Name: "api"},
+				},
+				Edges: []Edge{
+					{ID: "src-to-web", Source: c.sourceID, Target: "deployment/demo/web", Type: EdgeProtects},
+					{ID: "src-to-api", Source: c.sourceID, Target: "deployment/demo/api", Type: EdgeProtects},
+				},
+			}
 
-	// Bug B1: previously these went into rel.ScaleTarget, overwriting each
-	// other. rel.ScaleTarget must remain nil for PDBs.
-	if rel.ScaleTarget != nil {
-		t.Errorf("rel.ScaleTarget: want nil (reserved for HPA scale targets), got %+v", rel.ScaleTarget)
-	}
-
-	if len(rel.PDBs) != 2 {
-		t.Fatalf("rel.PDBs: want 2 entries (web and api Deployments), got %d (%+v)", len(rel.PDBs), rel.PDBs)
-	}
-
-	// Both should also flow through to the deprecated Policies union.
-	if len(rel.Policies) != 2 {
-		t.Errorf("rel.Policies (deprecated union): want 2 entries, got %d (%+v)", len(rel.Policies), rel.Policies)
+			rel := GetRelationships(c.queryKnd, "demo", "src", topo, nil, nil)
+			if rel != nil {
+				t.Errorf("want nil (outgoing protects intentionally not surfaced), got %+v", rel)
+			}
+		})
 	}
 }
 

--- a/pkg/topology/relationships_test.go
+++ b/pkg/topology/relationships_test.go
@@ -1,0 +1,126 @@
+package topology
+
+import (
+	"testing"
+)
+
+// TestGetRelationships_IncomingEdgeProtects_DispatchesByKind verifies that
+// incoming "protects" edges split into rel.PDBs vs rel.NetworkPolicies based
+// on the source kind, and that rel.Policies stays populated as the union for
+// the deprecation period (so old clients/hub-fed responses keep working).
+func TestGetRelationships_IncomingEdgeProtects_DispatchesByKind(t *testing.T) {
+	// A Deployment receives incoming EdgeProtects from a PDB, a NetworkPolicy,
+	// and a CiliumNetworkPolicy. Each should land in its appropriate field;
+	// all three should appear in rel.Policies (deprecated union).
+	// (Cluster-scoped NetworkPolicy variants like ClusterNetworkPolicy and
+	// CiliumClusterwideNetworkPolicy use a 2-segment node ID — parseNodeID
+	// rejects those today, so they never reach this dispatch. That's
+	// pre-existing behavior and out of scope for this change.)
+	topo := &Topology{
+		Nodes: []Node{
+			{ID: "deployment/demo/web", Kind: KindDeployment, Name: "web"},
+			{ID: "poddisruptionbudget/demo/web-pdb", Kind: KindPDB, Name: "web-pdb"},
+			{ID: "networkpolicy/demo/web-np", Kind: KindNetworkPolicy, Name: "web-np"},
+			{ID: "ciliumnetworkpolicy/demo/web-cnp", Kind: KindCiliumNetworkPolicy, Name: "web-cnp"},
+		},
+		Edges: []Edge{
+			{ID: "pdb-to-web", Source: "poddisruptionbudget/demo/web-pdb", Target: "deployment/demo/web", Type: EdgeProtects},
+			{ID: "np-to-web", Source: "networkpolicy/demo/web-np", Target: "deployment/demo/web", Type: EdgeProtects},
+			{ID: "cnp-to-web", Source: "ciliumnetworkpolicy/demo/web-cnp", Target: "deployment/demo/web", Type: EdgeProtects},
+		},
+	}
+
+	rel := GetRelationships("Deployment", "demo", "web", topo, nil, nil)
+	if rel == nil {
+		t.Fatal("GetRelationships returned nil for deployment with 3 incoming protects edges")
+	}
+
+	if len(rel.PDBs) != 1 || rel.PDBs[0].Kind != "PodDisruptionBudget" || rel.PDBs[0].Name != "web-pdb" {
+		t.Errorf("rel.PDBs: want [PodDisruptionBudget/web-pdb], got %+v", rel.PDBs)
+	}
+
+	if len(rel.NetworkPolicies) != 2 {
+		t.Fatalf("rel.NetworkPolicies: want 2 entries (NetworkPolicy + CiliumNetworkPolicy), got %d (%+v)", len(rel.NetworkPolicies), rel.NetworkPolicies)
+	}
+	gotKinds := make(map[string]bool, 2)
+	for _, ref := range rel.NetworkPolicies {
+		gotKinds[ref.Kind] = true
+	}
+	for _, expected := range []string{"NetworkPolicy", "CiliumNetworkPolicy"} {
+		if !gotKinds[expected] {
+			t.Errorf("rel.NetworkPolicies missing %s; got kinds=%v", expected, gotKinds)
+		}
+	}
+
+	// rel.Policies must contain the union of all three, since we keep it
+	// populated for one release as a deprecated alias.
+	if len(rel.Policies) != 3 {
+		t.Errorf("rel.Policies (deprecated union): want 3 entries, got %d (%+v)", len(rel.Policies), rel.Policies)
+	}
+}
+
+// TestGetRelationships_OutgoingEdgeProtects_PDBLandsInPDBs verifies the B1 bug
+// fix: outgoing "protects" edges from a PDB land in rel.PDBs instead of being
+// silently overwritten into rel.ScaleTarget (which is reserved for HPA targets).
+func TestGetRelationships_OutgoingEdgeProtects_PDBLandsInPDBs(t *testing.T) {
+	topo := &Topology{
+		Nodes: []Node{
+			{ID: "poddisruptionbudget/demo/web-pdb", Kind: KindPDB, Name: "web-pdb"},
+			{ID: "deployment/demo/web", Kind: KindDeployment, Name: "web"},
+			{ID: "deployment/demo/api", Kind: KindDeployment, Name: "api"},
+		},
+		Edges: []Edge{
+			{ID: "pdb-to-web", Source: "poddisruptionbudget/demo/web-pdb", Target: "deployment/demo/web", Type: EdgeProtects},
+			{ID: "pdb-to-api", Source: "poddisruptionbudget/demo/web-pdb", Target: "deployment/demo/api", Type: EdgeProtects},
+		},
+	}
+
+	rel := GetRelationships("PodDisruptionBudget", "demo", "web-pdb", topo, nil, nil)
+	if rel == nil {
+		t.Fatal("GetRelationships returned nil for PDB with outgoing protects edges")
+	}
+
+	// Bug B1: previously these went into rel.ScaleTarget, overwriting each
+	// other. rel.ScaleTarget must remain nil for PDBs.
+	if rel.ScaleTarget != nil {
+		t.Errorf("rel.ScaleTarget: want nil (reserved for HPA scale targets), got %+v", rel.ScaleTarget)
+	}
+
+	if len(rel.PDBs) != 2 {
+		t.Fatalf("rel.PDBs: want 2 entries (web and api Deployments), got %d (%+v)", len(rel.PDBs), rel.PDBs)
+	}
+
+	// Both should also flow through to the deprecated Policies union.
+	if len(rel.Policies) != 2 {
+		t.Errorf("rel.Policies (deprecated union): want 2 entries, got %d (%+v)", len(rel.Policies), rel.Policies)
+	}
+}
+
+// TestGetRelationships_NoProtects_FieldsOmitted ensures the new split fields
+// stay nil when no protects edges exist, so JSON omitempty keeps the wire
+// format identical for unrelated resources.
+func TestGetRelationships_NoProtects_FieldsOmitted(t *testing.T) {
+	topo := &Topology{
+		Nodes: []Node{
+			{ID: "deployment/demo/lone", Kind: KindDeployment, Name: "lone"},
+			{ID: "replicaset/demo/lone-abc", Kind: KindReplicaSet, Name: "lone-abc"},
+		},
+		Edges: []Edge{
+			{ID: "lone-rs", Source: "deployment/demo/lone", Target: "replicaset/demo/lone-abc", Type: EdgeManages},
+		},
+	}
+
+	rel := GetRelationships("Deployment", "demo", "lone", topo, nil, nil)
+	if rel == nil {
+		t.Fatal("GetRelationships returned nil for deployment with a child")
+	}
+	if len(rel.PDBs) != 0 {
+		t.Errorf("rel.PDBs: want empty, got %+v", rel.PDBs)
+	}
+	if len(rel.NetworkPolicies) != 0 {
+		t.Errorf("rel.NetworkPolicies: want empty, got %+v", rel.NetworkPolicies)
+	}
+	if len(rel.Policies) != 0 {
+		t.Errorf("rel.Policies: want empty, got %+v", rel.Policies)
+	}
+}

--- a/pkg/topology/relationships_test.go
+++ b/pkg/topology/relationships_test.go
@@ -6,16 +6,13 @@ import (
 
 // TestGetRelationships_IncomingEdgeProtects_DispatchesByKind verifies that
 // incoming "protects" edges split into rel.PDBs vs rel.NetworkPolicies based
-// on the source kind, and that rel.Policies stays populated as the union for
-// the deprecation period (so old clients/hub-fed responses keep working).
+// on the source kind.
+//
+// (Cluster-scoped NetworkPolicy variants like ClusterNetworkPolicy and
+// CiliumClusterwideNetworkPolicy use a 2-segment node ID — parseNodeID
+// rejects those today, so they never reach this dispatch. Pre-existing
+// behavior, out of scope here.)
 func TestGetRelationships_IncomingEdgeProtects_DispatchesByKind(t *testing.T) {
-	// A Deployment receives incoming EdgeProtects from a PDB, a NetworkPolicy,
-	// and a CiliumNetworkPolicy. Each should land in its appropriate field;
-	// all three should appear in rel.Policies (deprecated union).
-	// (Cluster-scoped NetworkPolicy variants like ClusterNetworkPolicy and
-	// CiliumClusterwideNetworkPolicy use a 2-segment node ID — parseNodeID
-	// rejects those today, so they never reach this dispatch. That's
-	// pre-existing behavior and out of scope for this change.)
 	topo := &Topology{
 		Nodes: []Node{
 			{ID: "deployment/demo/web", Kind: KindDeployment, Name: "web"},
@@ -50,12 +47,6 @@ func TestGetRelationships_IncomingEdgeProtects_DispatchesByKind(t *testing.T) {
 		if !gotKinds[expected] {
 			t.Errorf("rel.NetworkPolicies missing %s; got kinds=%v", expected, gotKinds)
 		}
-	}
-
-	// rel.Policies must contain the union of all three, since we keep it
-	// populated for one release as a deprecated alias.
-	if len(rel.Policies) != 3 {
-		t.Errorf("rel.Policies (deprecated union): want 3 entries, got %d (%+v)", len(rel.Policies), rel.Policies)
 	}
 }
 
@@ -153,8 +144,5 @@ func TestGetRelationships_NoProtects_FieldsOmitted(t *testing.T) {
 	}
 	if len(rel.NetworkPolicies) != 0 {
 		t.Errorf("rel.NetworkPolicies: want empty, got %+v", rel.NetworkPolicies)
-	}
-	if len(rel.Policies) != 0 {
-		t.Errorf("rel.Policies: want empty, got %+v", rel.Policies)
 	}
 }

--- a/pkg/topology/types.go
+++ b/pkg/topology/types.go
@@ -291,8 +291,13 @@ type Relationships struct {
 	Consumers   []ResourceRef `json:"consumers,omitempty"`   // For ConfigMap/Secret: workloads that reference this
 	Scalers     []ResourceRef `json:"scalers,omitempty"`     // HPA/ScaledObject/ScaledJob scaling this
 	ScaleTarget *ResourceRef  `json:"scaleTarget,omitempty"` // For HPA/ScaledObject: what it scales
-	Policies    []ResourceRef `json:"policies,omitempty"`    // PDBs protecting this workload
-	Pods        []ResourceRef `json:"pods,omitempty"`        // For Service: pods it routes to
+	// Deprecated: use PDBs and NetworkPolicies instead. Populated as the union of both
+	// for one release to give old clients (and pre-split hub-fed responses) a fallback;
+	// will be removed in a future release.
+	Policies        []ResourceRef `json:"policies,omitempty"`
+	PDBs            []ResourceRef `json:"pdbs,omitempty"`            // PodDisruptionBudgets protecting this workload
+	NetworkPolicies []ResourceRef `json:"networkPolicies,omitempty"` // NetworkPolicy / CiliumNetworkPolicy / ClusterNetworkPolicy / CiliumClusterwideNetworkPolicy selecting this workload
+	Pods            []ResourceRef `json:"pods,omitempty"`            // For Service: pods it routes to
 }
 
 // CertificateInfo holds parsed X.509 certificate metadata for a single certificate.

--- a/pkg/topology/types.go
+++ b/pkg/topology/types.go
@@ -291,10 +291,6 @@ type Relationships struct {
 	Consumers   []ResourceRef `json:"consumers,omitempty"`   // For ConfigMap/Secret: workloads that reference this
 	Scalers     []ResourceRef `json:"scalers,omitempty"`     // HPA/ScaledObject/ScaledJob scaling this
 	ScaleTarget *ResourceRef  `json:"scaleTarget,omitempty"` // For HPA/ScaledObject: what it scales
-	// Deprecated: use PDBs and NetworkPolicies instead. Populated as the union of both
-	// for one release to give old clients (and pre-split hub-fed responses) a fallback;
-	// will be removed in a future release.
-	Policies        []ResourceRef `json:"policies,omitempty"`
 	PDBs            []ResourceRef `json:"pdbs,omitempty"`            // PodDisruptionBudgets protecting this workload
 	NetworkPolicies []ResourceRef `json:"networkPolicies,omitempty"` // NetworkPolicy / CiliumNetworkPolicy / ClusterNetworkPolicy / CiliumClusterwideNetworkPolicy selecting this workload
 	Pods            []ResourceRef `json:"pods,omitempty"`            // For Service: pods it routes to


### PR DESCRIPTION
Phase 1a of the resource-context plan — paired correctness fixes in `pkg/topology` plus the matching UI migration.

**Bug B1 (correctness).** Outgoing `EdgeProtects` in `GetRelationships` was assigning to `rel.ScaleTarget`, a field semantically reserved for HPA / ScaledObject scale targets. Silent in practice — overwrote between iterations and would have produced misleading context once we surfaced ScaleTarget elsewhere.

**Schema split.** `Relationships.Policies` merged PDBs and NetworkPolicies into one list, forcing every consumer to filter by `ref.kind`. Replaced with typed `pdbs[]` and `networkPolicies[]` fields. **The old `policies[]` field is removed outright — no deprecated alias.** Old radar binaries behind a hub will still emit it on the wire; the UI silently ignores it. PDB/NetworkPolicy sections will be empty for those clusters until the radar binary upgrades, which is the right pressure direction.

**Outgoing EdgeProtects (refined after deep review).** The initial fix routed all outgoing protects refs into `rel.PDBs`, but PDB isn't the only kind producing outgoing `EdgeProtects` — NetworkPolicy, CiliumNetworkPolicy, and MachineHealthCheck do too. No semantically correct field exists today for "workloads this resource selects/protects," so the outgoing direction is intentionally not surfaced. A future `Protects []ResourceRef` field would expose it; left as a TODO.

**Test discipline.** First-pass test on the outgoing-protect dispatch passed vacuously (edge node-IDs didn't match the query name). Fixed in a follow-up commit plus added a control assertion that the same topology, queried from the workload side, MUST surface the policy via incoming-edge dispatch — locks the "no edges matched" failure mode out.

UI: `RelatedResourcesSection` in `packages/k8s-ui` consumes the split fields directly. The previously-introduced legacy-policies fallback (`usingLegacyPolicies`, `resolvedOtherPolicies`, the `NETPOL_KINDS` constant) is also gone.

E2E verified on kind cluster (Deployment selected by both a PDB and a NetworkPolicy): Deployment relationships show `pdbs[]` + `networkPolicies[]` cleanly disjoint; PDB / NetworkPolicy themselves return `null` relationships.