### PR TITLE
feat(resourcecontext): canonical DTO package for normalized resource context

### DIFF
--- a/pkg/resourcecontext/types.go
+++ b/pkg/resourcecontext/types.go
@@ -1,0 +1,186 @@
+// Package resourcecontext defines the canonical data-transfer types for
+// radar's normalized resource-context layer.
+//
+// The layer is the unified server-side projection of facts that today are
+// scattered across topology relationships, the audit engine, the issues
+// composer, PolicyReport informers, GitOps owner detection, and other
+// per-resource lookups. Consumers — both MCP tools and REST handlers —
+// receive the same shape; presentation specifics (token budgets, prose
+// hints, tier-based filtering) live in the caller, not in this package.
+//
+// This package is types-only: it deliberately depends on nothing from
+// pkg/topology or internal/* so that it can be imported by any layer
+// (handlers, generators, tests) without producing import cycles.
+//
+// All enum string values are snake_case — both for readability in Go code
+// and for stable, machine-friendly JSON output.
+package resourcecontext
+
+// ResourceContext is the top-level enrichment block attached to a resource
+// response. Every field is optional; the zero value is a valid (empty)
+// "basic"-tier context.
+//
+// Hints is an optional, presentation-only field — populated by AI-facing
+// callers (MCP, /api/ai/*) and omitted by UI-facing callers. The structured
+// fields above are the canonical facts; hints are a derived prose
+// projection.
+type ResourceContext struct {
+	Tier          ContextTier    `json:"tier"`
+	ManagedBy     []ContextRef   `json:"managedBy,omitempty"`
+	Exposes       []ContextRef   `json:"exposes,omitempty"`
+	SelectedBy    []ContextRef   `json:"selectedBy,omitempty"`
+	Uses          *UsesBlock     `json:"uses,omitempty"`
+	RunsOn        *ContextRef    `json:"runsOn,omitempty"`
+	ScaledBy      []ContextRef   `json:"scaledBy,omitempty"`
+	IssueSummary  *IssueSummary  `json:"issueSummary,omitempty"`
+	AuditSummary  *AuditSummary  `json:"auditSummary,omitempty"`
+	PolicySummary *PolicySummary `json:"policySummary,omitempty"`
+	Hints         []string       `json:"hints,omitempty"`
+	Omitted       []OmittedField `json:"omitted,omitempty"`
+	Truncated     bool           `json:"truncated,omitempty"`
+}
+
+// ContextTier signals how much enrichment is included. "basic" is the
+// always-on tier; "diagnostic" carries extra signals (added in a later
+// phase) and is only produced when explicitly requested.
+type ContextTier string
+
+const (
+	TierBasic      ContextTier = "basic"
+	TierDiagnostic ContextTier = "diagnostic"
+)
+
+// ContextRef is a typed pointer to another Kubernetes object that the
+// subject relates to. Group is omitted for core/v1 kinds; Namespace is
+// omitted for cluster-scoped objects.
+type ContextRef struct {
+	Kind       string    `json:"kind"`
+	Group      string    `json:"group,omitempty"`
+	Namespace  string    `json:"namespace,omitempty"`
+	Name       string    `json:"name"`
+	Reason     RefReason `json:"reason,omitempty"`
+	Source     RefSource `json:"source,omitempty"`
+	Confidence string    `json:"confidence,omitempty"` // reserved; not populated in v1
+}
+
+// RefReason describes WHY a ContextRef is being emitted — the structural
+// link between subject and target.
+type RefReason string
+
+const (
+	ReasonOwnerReference   RefReason = "owner_reference"
+	ReasonLabelSelector    RefReason = "label_selector"
+	ReasonPodSelector      RefReason = "pod_selector_match"
+	ReasonPolicyReportSubj RefReason = "policy_report_subject"
+	ReasonVolumeMount      RefReason = "volume_mount_ref"
+	ReasonEnvVarRef        RefReason = "env_var_ref"
+	ReasonScaleTargetRef   RefReason = "scale_target_ref"
+	ReasonClaimRef         RefReason = "claim_ref"
+	ReasonNodeName         RefReason = "node_name"
+	ReasonSAName           RefReason = "service_account_name"
+)
+
+// RefSource describes WHERE the link came from — which subsystem produced
+// the ref. Useful for debugging and for filtering on the agent side.
+type RefSource string
+
+const (
+	SourceTopology     RefSource = "topology"
+	SourceOwnerChain   RefSource = "owner_chain"
+	SourcePolicyReport RefSource = "policy_report"
+	SourceAuditEngine  RefSource = "audit_engine"
+	SourceK8sSpec      RefSource = "k8s_spec"
+)
+
+// ManagedByRef is the compact form of a "managed-by" pointer used in
+// SummaryContext (list/search rows). Carries Kind alongside Source so
+// consumers can distinguish e.g. a Flux Kustomization from a Flux
+// HelmRelease without re-parsing the Source string. Intentionally lacks
+// Group, Reason, and Confidence to keep per-row bytes minimal.
+type ManagedByRef struct {
+	Kind      string `json:"kind"`             // "Application" | "Kustomization" | "HelmRelease" | "Deployment" | "DaemonSet" | "StatefulSet" | "Rollout" | …
+	Source    string `json:"source"`           // "argocd" | "flux" | "helm" | "native"
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// SummaryContext is the per-row enrichment attached to list_resources
+// and search hits. Always-on, intentionally minimal (≤ ~60 bytes).
+type SummaryContext struct {
+	ManagedBy  *ManagedByRef `json:"managedBy,omitempty"`
+	Health     string        `json:"health,omitempty"`
+	IssueCount int           `json:"issueCount,omitempty"`
+}
+
+// UsesBlock groups the namespaced configuration objects a workload reads
+// at runtime (env, mounts, identity).
+type UsesBlock struct {
+	ConfigMaps     []ContextRef `json:"configMaps,omitempty"`
+	Secrets        []ContextRef `json:"secrets,omitempty"`
+	ServiceAccount *ContextRef  `json:"serviceAccount,omitempty"`
+	PVCs           []ContextRef `json:"pvcs,omitempty"`
+}
+
+// IssueSummary is a rollup of internal issue-engine findings scoped to
+// the subject resource. Pre-computed by callers and passed into the
+// generator — this package does not import internal/issues.
+type IssueSummary struct {
+	Count           int            `json:"count"`
+	HighestSeverity string         `json:"highestSeverity,omitempty"`
+	TopReason       string         `json:"topReason,omitempty"`
+	BySource        map[string]int `json:"bySource,omitempty"`
+}
+
+// AuditSummary is a rollup of audit-engine findings scoped to the
+// subject resource.
+type AuditSummary struct {
+	Count           int    `json:"count"`
+	HighestSeverity string `json:"highestSeverity,omitempty"`
+	TopFinding      string `json:"topFinding,omitempty"`
+}
+
+// PolicySummary aggregates external policy-engine signals. Only Kyverno
+// is wired in v1; the type is a struct (not a map) so additional engines
+// can be added without breaking JSON consumers.
+type PolicySummary struct {
+	Kyverno *KyvernoSummary `json:"kyverno,omitempty"`
+}
+
+// KyvernoSummary rolls up PolicyReport results for the subject. Top
+// carries up to 3 noteworthy findings.
+type KyvernoSummary struct {
+	Fail int              `json:"fail"`
+	Warn int              `json:"warn"`
+	Pass int              `json:"pass"`
+	Top  []KyvernoFinding `json:"top,omitempty"`
+}
+
+// KyvernoFinding is a single PolicyReport result for the subject.
+type KyvernoFinding struct {
+	Policy  string `json:"policy"`
+	Rule    string `json:"rule"`
+	Result  string `json:"result"`
+	Message string `json:"message,omitempty"`
+}
+
+// OmittedField records a field that was intentionally dropped from the
+// response. See the "omitted.field path convention" in the v1 contract:
+//   - top-level field: bare name (e.g. "selectedBy")
+//   - nested: dotted path (e.g. "policySummary.kyverno")
+//   - whole resourceContext skipped: "*"
+type OmittedField struct {
+	Field  string        `json:"field"`
+	Reason OmittedReason `json:"reason"`
+}
+
+// OmittedReason is the closed enum of reasons a field can be omitted.
+type OmittedReason string
+
+const (
+	OmittedRBACDenied       OmittedReason = "rbac_denied"
+	OmittedBudgetExceeded   OmittedReason = "budget_exceeded"
+	OmittedCacheCold        OmittedReason = "cache_cold"
+	OmittedNotInstalled     OmittedReason = "not_installed"
+	OmittedKindUnsupported  OmittedReason = "kind_unsupported"
+	OmittedProviderDisabled OmittedReason = "provider_disabled"
+)

--- a/pkg/resourcecontext/types_test.go
+++ b/pkg/resourcecontext/types_test.go
@@ -1,0 +1,396 @@
+package resourcecontext
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestRefReasonMarshalsSnakeCase asserts every RefReason constant
+// marshals to its locked snake_case literal — the wire contract.
+func TestRefReasonMarshalsSnakeCase(t *testing.T) {
+	cases := map[RefReason]string{
+		ReasonOwnerReference:   "owner_reference",
+		ReasonLabelSelector:    "label_selector",
+		ReasonPodSelector:      "pod_selector_match",
+		ReasonPolicyReportSubj: "policy_report_subject",
+		ReasonVolumeMount:      "volume_mount_ref",
+		ReasonEnvVarRef:        "env_var_ref",
+		ReasonScaleTargetRef:   "scale_target_ref",
+		ReasonClaimRef:         "claim_ref",
+		ReasonNodeName:         "node_name",
+		ReasonSAName:           "service_account_name",
+	}
+	for c, want := range cases {
+		got, err := json.Marshal(c)
+		if err != nil {
+			t.Fatalf("marshal RefReason %q: %v", c, err)
+		}
+		if string(got) != `"`+want+`"` {
+			t.Errorf("RefReason marshal: got %s, want %q", got, want)
+		}
+	}
+}
+
+// TestRefReasonUnmarshalsSnakeCase asserts each locked snake_case literal
+// round-trips into the matching constant.
+func TestRefReasonUnmarshalsSnakeCase(t *testing.T) {
+	cases := map[string]RefReason{
+		"owner_reference":       ReasonOwnerReference,
+		"label_selector":        ReasonLabelSelector,
+		"pod_selector_match":    ReasonPodSelector,
+		"policy_report_subject": ReasonPolicyReportSubj,
+		"volume_mount_ref":      ReasonVolumeMount,
+		"env_var_ref":           ReasonEnvVarRef,
+		"scale_target_ref":      ReasonScaleTargetRef,
+		"claim_ref":             ReasonClaimRef,
+		"node_name":             ReasonNodeName,
+		"service_account_name":  ReasonSAName,
+	}
+	for in, want := range cases {
+		var got RefReason
+		if err := json.Unmarshal([]byte(`"`+in+`"`), &got); err != nil {
+			t.Fatalf("unmarshal RefReason %q: %v", in, err)
+		}
+		if got != want {
+			t.Errorf("RefReason unmarshal %q: got %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestRefSourceMarshalsSnakeCase(t *testing.T) {
+	cases := map[RefSource]string{
+		SourceTopology:     "topology",
+		SourceOwnerChain:   "owner_chain",
+		SourcePolicyReport: "policy_report",
+		SourceAuditEngine:  "audit_engine",
+		SourceK8sSpec:      "k8s_spec",
+	}
+	for c, want := range cases {
+		got, err := json.Marshal(c)
+		if err != nil {
+			t.Fatalf("marshal RefSource %q: %v", c, err)
+		}
+		if string(got) != `"`+want+`"` {
+			t.Errorf("RefSource marshal: got %s, want %q", got, want)
+		}
+	}
+}
+
+func TestRefSourceUnmarshalsSnakeCase(t *testing.T) {
+	cases := map[string]RefSource{
+		"topology":      SourceTopology,
+		"owner_chain":   SourceOwnerChain,
+		"policy_report": SourcePolicyReport,
+		"audit_engine":  SourceAuditEngine,
+		"k8s_spec":      SourceK8sSpec,
+	}
+	for in, want := range cases {
+		var got RefSource
+		if err := json.Unmarshal([]byte(`"`+in+`"`), &got); err != nil {
+			t.Fatalf("unmarshal RefSource %q: %v", in, err)
+		}
+		if got != want {
+			t.Errorf("RefSource unmarshal %q: got %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestContextTierMarshalsSnakeCase(t *testing.T) {
+	cases := map[ContextTier]string{
+		TierBasic:      "basic",
+		TierDiagnostic: "diagnostic",
+	}
+	for c, want := range cases {
+		got, err := json.Marshal(c)
+		if err != nil {
+			t.Fatalf("marshal ContextTier %q: %v", c, err)
+		}
+		if string(got) != `"`+want+`"` {
+			t.Errorf("ContextTier marshal: got %s, want %q", got, want)
+		}
+	}
+}
+
+func TestContextTierUnmarshalsSnakeCase(t *testing.T) {
+	cases := map[string]ContextTier{
+		"basic":      TierBasic,
+		"diagnostic": TierDiagnostic,
+	}
+	for in, want := range cases {
+		var got ContextTier
+		if err := json.Unmarshal([]byte(`"`+in+`"`), &got); err != nil {
+			t.Fatalf("unmarshal ContextTier %q: %v", in, err)
+		}
+		if got != want {
+			t.Errorf("ContextTier unmarshal %q: got %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestOmittedReasonMarshalsSnakeCase(t *testing.T) {
+	cases := map[OmittedReason]string{
+		OmittedRBACDenied:       "rbac_denied",
+		OmittedBudgetExceeded:   "budget_exceeded",
+		OmittedCacheCold:        "cache_cold",
+		OmittedNotInstalled:     "not_installed",
+		OmittedKindUnsupported:  "kind_unsupported",
+		OmittedProviderDisabled: "provider_disabled",
+	}
+	for c, want := range cases {
+		got, err := json.Marshal(c)
+		if err != nil {
+			t.Fatalf("marshal OmittedReason %q: %v", c, err)
+		}
+		if string(got) != `"`+want+`"` {
+			t.Errorf("OmittedReason marshal: got %s, want %q", got, want)
+		}
+	}
+}
+
+func TestOmittedReasonUnmarshalsSnakeCase(t *testing.T) {
+	cases := map[string]OmittedReason{
+		"rbac_denied":       OmittedRBACDenied,
+		"budget_exceeded":   OmittedBudgetExceeded,
+		"cache_cold":        OmittedCacheCold,
+		"not_installed":     OmittedNotInstalled,
+		"kind_unsupported":  OmittedKindUnsupported,
+		"provider_disabled": OmittedProviderDisabled,
+	}
+	for in, want := range cases {
+		var got OmittedReason
+		if err := json.Unmarshal([]byte(`"`+in+`"`), &got); err != nil {
+			t.Fatalf("unmarshal OmittedReason %q: %v", in, err)
+		}
+		if got != want {
+			t.Errorf("OmittedReason unmarshal %q: got %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestEmptyResourceContextMarshalsStable pins the wire shape of a zero-value
+// ResourceContext. omitempty handling means every nilable field disappears
+// and only "tier" remains, with the empty string.
+func TestEmptyResourceContextMarshalsStable(t *testing.T) {
+	got, err := json.Marshal(ResourceContext{})
+	if err != nil {
+		t.Fatalf("marshal empty ResourceContext: %v", err)
+	}
+	want := `{"tier":""}`
+	if string(got) != want {
+		t.Errorf("empty ResourceContext marshal: got %s, want %s", got, want)
+	}
+}
+
+// TestResourceContextFieldOrdering pins the on-the-wire field order by
+// inspecting the marshaled JSON for a fully populated value. Go's
+// encoder emits struct fields in declaration order, so this guards
+// against accidental field reshuffling.
+func TestResourceContextFieldOrdering(t *testing.T) {
+	ac := ResourceContext{
+		Tier:          TierBasic,
+		ManagedBy:     []ContextRef{{Kind: "Deployment", Name: "api"}},
+		Exposes:       []ContextRef{{Kind: "Service", Name: "api"}},
+		SelectedBy:    []ContextRef{{Kind: "NetworkPolicy", Name: "default-deny"}},
+		Uses:          &UsesBlock{},
+		RunsOn:        &ContextRef{Kind: "Node", Name: "node-1"},
+		ScaledBy:      []ContextRef{{Kind: "HorizontalPodAutoscaler", Name: "api-hpa"}},
+		IssueSummary:  &IssueSummary{Count: 1},
+		AuditSummary:  &AuditSummary{Count: 2},
+		PolicySummary: &PolicySummary{},
+		Hints:         []string{"hint"},
+		Omitted:       []OmittedField{{Field: "selectedBy", Reason: OmittedRBACDenied}},
+		Truncated:     true,
+	}
+	b, err := json.Marshal(ac)
+	if err != nil {
+		t.Fatalf("marshal populated ResourceContext: %v", err)
+	}
+	s := string(b)
+	wantOrder := []string{
+		`"tier"`,
+		`"managedBy"`,
+		`"exposes"`,
+		`"selectedBy"`,
+		`"uses"`,
+		`"runsOn"`,
+		`"scaledBy"`,
+		`"issueSummary"`,
+		`"auditSummary"`,
+		`"policySummary"`,
+		`"hints"`,
+		`"omitted"`,
+		`"truncated"`,
+	}
+	prev := -1
+	for _, key := range wantOrder {
+		idx := strings.Index(s, key)
+		if idx == -1 {
+			t.Fatalf("missing key %s in %s", key, s)
+		}
+		if idx <= prev {
+			t.Fatalf("field %s out of order in %s", key, s)
+		}
+		prev = idx
+	}
+}
+
+// TestResourceContextRoundTrip marshals a populated ResourceContext, unmarshals
+// it back, and asserts deep equality. Covers every type defined in this
+// package.
+func TestResourceContextRoundTrip(t *testing.T) {
+	orig := ResourceContext{
+		Tier: TierDiagnostic,
+		ManagedBy: []ContextRef{{
+			Kind:      "Deployment",
+			Group:     "apps",
+			Namespace: "prod",
+			Name:      "api",
+			Reason:    ReasonOwnerReference,
+			Source:    SourceOwnerChain,
+		}},
+		Exposes: []ContextRef{{
+			Kind:      "Service",
+			Namespace: "prod",
+			Name:      "api",
+			Reason:    ReasonLabelSelector,
+			Source:    SourceTopology,
+		}},
+		SelectedBy: []ContextRef{{
+			Kind:      "NetworkPolicy",
+			Group:     "networking.k8s.io",
+			Namespace: "prod",
+			Name:      "default-deny",
+			Reason:    ReasonPodSelector,
+			Source:    SourceTopology,
+		}},
+		Uses: &UsesBlock{
+			ConfigMaps: []ContextRef{{Kind: "ConfigMap", Name: "api-config", Reason: ReasonEnvVarRef, Source: SourceK8sSpec}},
+			Secrets:    []ContextRef{{Kind: "Secret", Name: "api-creds", Reason: ReasonVolumeMount, Source: SourceK8sSpec}},
+			ServiceAccount: &ContextRef{
+				Kind: "ServiceAccount", Name: "api-sa",
+				Reason: ReasonSAName, Source: SourceK8sSpec,
+			},
+			PVCs: []ContextRef{{Kind: "PersistentVolumeClaim", Name: "data", Reason: ReasonClaimRef, Source: SourceK8sSpec}},
+		},
+		RunsOn: &ContextRef{Kind: "Node", Name: "node-1", Reason: ReasonNodeName, Source: SourceK8sSpec},
+		ScaledBy: []ContextRef{{
+			Kind:   "HorizontalPodAutoscaler",
+			Group:  "autoscaling",
+			Name:   "api-hpa",
+			Reason: ReasonScaleTargetRef,
+			Source: SourceTopology,
+		}},
+		IssueSummary: &IssueSummary{
+			Count:           3,
+			HighestSeverity: "critical",
+			TopReason:       "ImagePullBackOff",
+			BySource:        map[string]int{"problem": 2, "condition": 1},
+		},
+		AuditSummary: &AuditSummary{
+			Count:           4,
+			HighestSeverity: "warning",
+			TopFinding:      "CKV_K8S_8",
+		},
+		PolicySummary: &PolicySummary{
+			Kyverno: &KyvernoSummary{
+				Fail: 1, Warn: 2, Pass: 3,
+				Top: []KyvernoFinding{{
+					Policy:  "require-labels",
+					Rule:    "check-app",
+					Result:  "fail",
+					Message: "missing label",
+				}},
+			},
+		},
+		Hints: []string{"Managed by Deployment api"},
+		Omitted: []OmittedField{
+			{Field: "selectedBy.networkPolicies", Reason: OmittedRBACDenied},
+			{Field: "policySummary.kyverno", Reason: OmittedNotInstalled},
+		},
+		Truncated: true,
+	}
+
+	b, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got ResourceContext
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(orig, got) {
+		t.Fatalf("round-trip mismatch:\nwant %#v\ngot  %#v", orig, got)
+	}
+}
+
+// TestSummaryContextRoundTrip covers SummaryContext + ManagedByRef
+// which are not embedded in ResourceContext.
+func TestSummaryContextRoundTrip(t *testing.T) {
+	orig := SummaryContext{
+		ManagedBy:  &ManagedByRef{Kind: "Application", Source: "argocd", Name: "storefront", Namespace: "argocd"},
+		Health:     "degraded",
+		IssueCount: 2,
+	}
+	b, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got SummaryContext
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(orig, got) {
+		t.Fatalf("round-trip mismatch:\nwant %#v\ngot  %#v", orig, got)
+	}
+
+	// Compact wire shape: kind + source + name (+ optional namespace) only.
+	// No group, reason, or confidence — those would inflate per-row bytes
+	// in list/search responses with no consumer benefit at this tier.
+	wantSubstr := []string{`"kind":"Application"`, `"source":"argocd"`, `"name":"storefront"`, `"namespace":"argocd"`, `"health":"degraded"`, `"issueCount":2`}
+	s := string(b)
+	for _, sub := range wantSubstr {
+		if !strings.Contains(s, sub) {
+			t.Errorf("SummaryContext JSON missing %s: %s", sub, s)
+		}
+	}
+	for _, forbidden := range []string{`"group"`, `"reason"`, `"confidence"`} {
+		if strings.Contains(s, forbidden) {
+			t.Errorf("SummaryContext JSON leaks %s: %s", forbidden, s)
+		}
+	}
+}
+
+// TestManagedByRefDistinguishesFluxKinds pins the reason Kind was added:
+// without it, Flux Kustomization vs HelmRelease serialize to identical
+// JSON, forcing consumers to parse the Source string.
+func TestManagedByRefDistinguishesFluxKinds(t *testing.T) {
+	kustomization := SummaryContext{ManagedBy: &ManagedByRef{Kind: "Kustomization", Source: "flux", Name: "prod-apps", Namespace: "flux-system"}}
+	helmRelease := SummaryContext{ManagedBy: &ManagedByRef{Kind: "HelmRelease", Source: "flux", Name: "prod-apps", Namespace: "flux-system"}}
+
+	kJSON, _ := json.Marshal(kustomization)
+	hJSON, _ := json.Marshal(helmRelease)
+	if string(kJSON) == string(hJSON) {
+		t.Fatalf("Flux Kustomization and HelmRelease must serialize to different JSON when Kind is set\nboth: %s", kJSON)
+	}
+	if !strings.Contains(string(kJSON), `"kind":"Kustomization"`) {
+		t.Errorf("Kustomization JSON missing kind: %s", kJSON)
+	}
+	if !strings.Contains(string(hJSON), `"kind":"HelmRelease"`) {
+		t.Errorf("HelmRelease JSON missing kind: %s", hJSON)
+	}
+}
+
+// TestConfidenceOmittedWhenEmpty pins the contract that the reserved
+// Confidence field is dropped from the wire when not populated.
+func TestConfidenceOmittedWhenEmpty(t *testing.T) {
+	ref := ContextRef{Kind: "Pod", Name: "p"}
+	b, err := json.Marshal(ref)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "confidence") {
+		t.Errorf("expected confidence omitted when empty, got %s", b)
+	}
+}


### PR DESCRIPTION
Defines the v1 contract for radar's **resource-context layer** — a single normalized server-side projection of facts that today are scattered across topology relationships, the audit engine, the issues composer, PolicyReport informers, GitOps owner detection (currently inferred client-side via `detectGitOpsOwner`), and several per-renderer lookups in the resource drawer.

## Positioning

- **Shared infrastructure, not agent-only.** The structured fields are canonical for both UI and agent consumers. The MCP / `/api/ai/*` handlers are the first forcing function (they expose token-economics pain most clearly), but the same types power UI consolidation over time (replacing `detectGitOpsOwner`, env-from configmap fetches, ad-hoc audit/event drawer hooks, etc.).
- **Presentation lives in the caller.** Token budgets, tier-based filtering, and prose hints (the `Hints []string` field) are populated only by AI-facing callers. UI-facing callers get the same canonical fields without the presentation noise.
- **Types-only package.** No logic, no builders, no lifecycle. Imports nothing from the rest of the codebase.

## Shape

- `ResourceContext` (top-level) with `ContextTier` (`basic` | `diagnostic`).
- `ContextRef` carrying snake_case `RefReason` + `RefSource` enums; `Confidence` is reserved but not populated in v1.
- Compact **`ManagedByRef`** with `Kind` + `Source` + `Name` + optional `Namespace`. `Kind` disambiguates within a source family (e.g. Flux Kustomization vs Flux HelmRelease) so consumers don't have to parse the `Source` string. Still omits `Group` / `Reason` / `Confidence` to keep per-row bytes minimal for list/search projections.
- `SummaryContext`, `UsesBlock`, `IssueSummary`, `AuditSummary`, `PolicySummary` + `KyvernoSummary` + `KyvernoFinding`.
- `OmittedField` with closed `OmittedReason` enum (`rbac_denied`, `budget_exceeded`, `cache_cold`, `not_installed`, `kind_unsupported`, `provider_disabled`). So both agents and UI can deterministically distinguish "no data exists" from "data was filtered."

## Tests

Pin the wire format: snake_case JSON for every enum value, round-trip equality, stable field ordering, and explicit guards that `ManagedByRef` carries `kind` but does NOT serialize `group` / `reason` / `confidence`. Includes a test asserting Flux Kustomization vs HelmRelease produce different JSON when serialized.

Nothing imports these types yet — generator + handlers wire in follow-up PRs.