### PR TITLE
feat(policy-reports): PolicyReport index + conditional Kyverno warmup (T5)

### DIFF
--- a/internal/k8s/dynamic_cache.go
+++ b/internal/k8s/dynamic_cache.go
@@ -230,6 +230,17 @@ var supportedCRDFallbacks = []supportedCRDResource{
 	{Group: "aquasecurity.github.io", Versions: []string{"v1alpha1"}, Resource: "clustersbomreports", Kind: "ClusterSbomReport", Namespaced: false},
 	{Group: "aquasecurity.github.io", Versions: []string{"v1alpha1"}, Resource: "infraassessmentreports", Kind: "InfraAssessmentReport", Namespaced: true},
 	{Group: "aquasecurity.github.io", Versions: []string{"v1alpha1"}, Resource: "clusterinfraassessmentreports", Kind: "ClusterInfraAssessmentReport", Namespaced: false},
+	// Kyverno admission/policy CRDs. Watching Policy/ClusterPolicy directly
+	// is what flips the conditional PolicyReport warmup (see policy_reports.go) —
+	// presence of these in discovery is the signal that the cluster runs Kyverno.
+	{Group: "kyverno.io", Versions: []string{"v1", "v2", "v2beta1"}, Resource: "policies", Kind: "Policy", Namespaced: true},
+	{Group: "kyverno.io", Versions: []string{"v1", "v2", "v2beta1"}, Resource: "clusterpolicies", Kind: "ClusterPolicy", Namespaced: false},
+	// NOTE: the wgpolicyk8s.io PolicyReport CRDs are intentionally NOT in
+	// this list. They are warmed up conditionally — only when Kyverno is
+	// detected — via WarmupKyvernoPolicyReports in policy_reports.go. Adding
+	// them here would warm them up on every cluster that has the CRD
+	// installed (e.g. for Trivy reports), which we don't want until we have
+	// a generic per-engine policy index. See T5 in the plan.
 }
 
 func RegisterSupportedCRDFallbacks() {

--- a/internal/k8s/policy_reports.go
+++ b/internal/k8s/policy_reports.go
@@ -42,10 +42,15 @@ const kyvernoReportWarmupCap = policyreports.MaxIndexedReports
 // Kyverno is detected and kept up to date by PolicyReport informer
 // events. Nil when Kyverno is absent — callers must nil-check.
 var (
-	policyReportIndex   atomic.Pointer[policyreports.Index]
-	policyReportInit    sync.Once
-	policyReportWatched []schema.GroupVersionResource // set during warmup, used by event-driven refresh
-	policyReportMu      sync.Mutex                    // guards rebuild (debounce)
+	policyReportIndex atomic.Pointer[policyreports.Index]
+	// policyReportInit is a *sync.Once (pointer), not a value, because
+	// ResetPolicyReportIndex replaces it on context switch. Overwriting a
+	// value-type sync.Once whose mutex is currently held by a concurrent
+	// Do() crashes with "unlock of unlocked mutex". Every other sync.Once
+	// in internal/k8s/ uses this same pointer pattern for the same reason.
+	policyReportInit    = new(sync.Once)
+	policyReportWatched []schema.GroupVersionResource // guarded by policyReportMu
+	policyReportMu      sync.Mutex                    // guards policyReportWatched + serializes rebuild
 	policyReportPending atomic.Bool                   // true when a rebuild is already queued
 
 	// debounceDelay is how long after an informer event we wait before
@@ -157,8 +162,16 @@ func WarmupKyvernoPolicyReports() {
 		// with the informer's initial event burst.
 		idx := policyreports.NewIndex()
 		idx.Replace(listPolicyReportsAll(watched))
+		// Publish index + watched-GVR list together under the mutex. The
+		// rebuild path reads policyReportWatched while holding the same
+		// mutex, and ResetPolicyReportIndex (context switch) takes it to
+		// clear both. Without the lock here, a concurrent Reset would race
+		// with this assignment and could leave the new context with stale
+		// GVRs from the prior cluster.
+		policyReportMu.Lock()
 		policyReportIndex.Store(idx)
 		policyReportWatched = watched
+		policyReportMu.Unlock()
 
 		// Register event handlers for live updates. Each handler does a
 		// debounced rebuild — PolicyReport events arrive in bursts when
@@ -256,5 +269,9 @@ func ResetPolicyReportIndex() {
 	policyReportIndex.Store(nil)
 	policyReportWatched = nil
 	policyReportPending.Store(false)
-	policyReportInit = sync.Once{}
+	// Replace the pointer rather than zeroing the value — see the comment
+	// on policyReportInit's declaration. Any Do() lambda still running on
+	// the old *sync.Once finishes against that instance without
+	// corrupting the new one.
+	policyReportInit = new(sync.Once)
 }

--- a/internal/k8s/policy_reports.go
+++ b/internal/k8s/policy_reports.go
@@ -1,0 +1,221 @@
+package k8s
+
+import (
+	"log"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	toolscache "k8s.io/client-go/tools/cache"
+
+	"github.com/skyhook-io/radar/pkg/policyreports"
+)
+
+// PolicyReport GVRs. Kept here (not in supportedCRDFallbacks) because
+// warmup is conditional — we only register informers for these CRDs when
+// Kyverno's own Policy/ClusterPolicy CRDs are present in discovery.
+//
+// We try v1alpha2 first (the dominant version Kyverno emits) and fall back
+// to v1beta1 if v1alpha2 is not registered. Most clusters in the wild
+// (Kyverno 1.10+) ship v1alpha2.
+var (
+	policyReportGVRs = []schema.GroupVersionResource{
+		{Group: "wgpolicyk8s.io", Version: "v1alpha2", Resource: "policyreports"},
+		{Group: "wgpolicyk8s.io", Version: "v1beta1", Resource: "policyreports"},
+	}
+	clusterPolicyReportGVRs = []schema.GroupVersionResource{
+		{Group: "wgpolicyk8s.io", Version: "v1alpha2", Resource: "clusterpolicyreports"},
+		{Group: "wgpolicyk8s.io", Version: "v1beta1", Resource: "clusterpolicyreports"},
+	}
+)
+
+// kyvernoReportWarmupCap caps how many PolicyReport documents the index
+// keeps in memory. The pkg/policyreports.MaxIndexedReports constant is the
+// authoritative number; this re-export lives here for easy operator-side
+// tuning at the integration boundary (so anyone grepping the codebase for
+// "Kyverno" finds the tunable without having to know the package layout).
+const kyvernoReportWarmupCap = policyreports.MaxIndexedReports
+
+// policyReportIndex is the singleton index instance, populated when
+// Kyverno is detected and kept up to date by PolicyReport informer
+// events. Nil when Kyverno is absent — callers must nil-check.
+var (
+	policyReportIndex   atomic.Pointer[policyreports.Index]
+	policyReportInit    sync.Once
+	policyReportWatched []schema.GroupVersionResource // set during warmup, used by event-driven refresh
+	policyReportMu      sync.Mutex                    // guards rebuild (debounce)
+	policyReportPending atomic.Bool                   // true when a rebuild is already queued
+
+	// debounceDelay is how long after an informer event we wait before
+	// rebuilding the index. PolicyReport updates often arrive in bursts
+	// (Kyverno re-evaluates all matched resources on a single Policy
+	// change), so coalescing them avoids redundant rebuilds.
+	rebuildDebounce = 500 * time.Millisecond
+)
+
+// GetPolicyReportIndex returns the singleton PolicyReport index, or nil
+// when Kyverno is not installed on the cluster. Callers must treat the
+// nil return as "no Kyverno findings available" and degrade gracefully.
+//
+// Returned indexes are safe for concurrent reads; the index swaps its
+// internal state atomically during rebuilds.
+func GetPolicyReportIndex() *policyreports.Index {
+	return policyReportIndex.Load()
+}
+
+// WarmupKyvernoPolicyReports conditionally enables PolicyReport tracking.
+// Called once after CRD discovery completes. Decision tree:
+//
+//  1. If Kyverno is NOT installed (no kyverno.io/Policy or ClusterPolicy
+//     in discovery) → no-op, leave reports in the deferred-fetch tier.
+//  2. If Kyverno is installed → start informers for the working-group
+//     PolicyReport CRDs, build the index from current contents, and
+//     register event handlers for live updates.
+//
+// Safe to call multiple times; only the first invocation does work.
+// Subsequent calls are no-ops (sync.Once-guarded). Reset via
+// ResetPolicyReportIndex on context switch.
+func WarmupKyvernoPolicyReports() {
+	policyReportInit.Do(func() {
+		discovery := GetResourceDiscovery()
+		if discovery == nil || discovery.ResourceDiscovery == nil {
+			log.Printf("[policy-reports] No resource discovery available; skipping Kyverno detection")
+			return
+		}
+		if !discovery.IsKyvernoInstalled() {
+			log.Printf("[policy-reports] Kyverno not detected (no kyverno.io/Policy or ClusterPolicy); leaving PolicyReports deferred")
+			return
+		}
+
+		cache := GetDynamicResourceCache()
+		if cache == nil || cache.DynamicResourceCache == nil {
+			log.Printf("[policy-reports] Dynamic resource cache not initialized; cannot warm up PolicyReports")
+			return
+		}
+
+		// Pick the actual GVRs registered on this cluster — there are two
+		// candidate versions per kind. We prefer v1alpha2 (most common)
+		// but accept v1beta1 if that's what's installed.
+		watched := make([]schema.GroupVersionResource, 0, 2)
+		for _, candidate := range policyReportGVRs {
+			if discovery.SupportsWatchGVR(candidate) {
+				watched = append(watched, candidate)
+				break
+			}
+		}
+		for _, candidate := range clusterPolicyReportGVRs {
+			if discovery.SupportsWatchGVR(candidate) {
+				watched = append(watched, candidate)
+				break
+			}
+		}
+
+		if len(watched) == 0 {
+			log.Printf("[policy-reports] Kyverno detected but no wgpolicyk8s.io PolicyReport CRDs are registered for watch; nothing to warm up")
+			return
+		}
+
+		log.Printf("[policy-reports] Kyverno detected; warming up %d PolicyReport CRDs (cap=%d reports)", len(watched), kyvernoReportWarmupCap)
+		cache.WarmupParallel(watched, 30*time.Second)
+
+		// Initialize the index from current cache contents so the first
+		// lookup after warmup is hot — without this, callers would race
+		// with the informer's initial event burst.
+		idx := policyreports.NewIndex()
+		idx.Replace(listPolicyReportsAll(watched))
+		policyReportIndex.Store(idx)
+		policyReportWatched = watched
+
+		// Register event handlers for live updates. Each handler does a
+		// debounced rebuild — PolicyReport events arrive in bursts when
+		// Kyverno re-evaluates a policy, and rebuilding once per burst
+		// is cheaper than per-event incremental updates given how small
+		// the index is (≤500 reports).
+		handler := toolscache.ResourceEventHandlerFuncs{
+			AddFunc:    func(_ any) { scheduleRebuild() },
+			UpdateFunc: func(_, _ any) { scheduleRebuild() },
+			DeleteFunc: func(_ any) { scheduleRebuild() },
+		}
+		for _, gvr := range watched {
+			if err := cache.AddGVRChangeHandler(gvr, handler); err != nil {
+				// Non-fatal: index is still populated from the initial
+				// build, just won't update until the next context switch.
+				log.Printf("[policy-reports] Failed to register event handler for %s: %v", gvr, err)
+			}
+		}
+
+		log.Printf("[policy-reports] Index initialized with %d subjects", idx.Size())
+	})
+}
+
+// listPolicyReportsAll concatenates reports from every watched GVR.
+// Used both for the initial index build and for each debounced rebuild.
+func listPolicyReportsAll(gvrs []schema.GroupVersionResource) []*unstructured.Unstructured {
+	cache := GetDynamicResourceCache()
+	if cache == nil {
+		return nil
+	}
+	var all []*unstructured.Unstructured
+	for _, gvr := range gvrs {
+		items, err := cache.List(gvr, "")
+		if err != nil {
+			log.Printf("[policy-reports] list %s: %v", gvr, err)
+			continue
+		}
+		all = append(all, items...)
+	}
+	return all
+}
+
+// scheduleRebuild coalesces back-to-back informer events into a single
+// rebuild. The first event in a burst arms a timer; subsequent events
+// during the debounce window do nothing (the pending flag is already
+// set). When the timer fires, we re-list and Replace the index contents.
+//
+// The debounce window (rebuildDebounce) is well under any realistic
+// staleness budget: agents reading the index see at most ~500ms-stale
+// data, which is well below Kyverno's own reconcile cadence.
+func scheduleRebuild() {
+	if !policyReportPending.CompareAndSwap(false, true) {
+		return // rebuild already scheduled
+	}
+	time.AfterFunc(rebuildDebounce, func() {
+		// Clear the pending flag BEFORE the rebuild — any event that
+		// arrives between this line and Replace() arms a fresh timer,
+		// which is the desired behavior. Without clearing first, an
+		// event firing concurrently could be lost.
+		policyReportPending.Store(false)
+		rebuildPolicyReportIndex()
+	})
+}
+
+// rebuildPolicyReportIndex re-lists all watched PolicyReport GVRs from
+// the dynamic cache and atomically swaps the index contents. Serialized
+// by policyReportMu so concurrent triggers don't waste CPU rebuilding
+// the same data.
+func rebuildPolicyReportIndex() {
+	policyReportMu.Lock()
+	defer policyReportMu.Unlock()
+
+	idx := policyReportIndex.Load()
+	if idx == nil {
+		return // index was reset (context switch) — drop event
+	}
+	idx.Replace(listPolicyReportsAll(policyReportWatched))
+}
+
+// ResetPolicyReportIndex clears the index and re-arms warmup-once. Called
+// during context switch (alongside ResetDynamicResourceCache) so the new
+// cluster gets a fresh detection pass. Safe to call when nothing was
+// warmed up.
+func ResetPolicyReportIndex() {
+	policyReportMu.Lock()
+	defer policyReportMu.Unlock()
+
+	policyReportIndex.Store(nil)
+	policyReportWatched = nil
+	policyReportPending.Store(false)
+	policyReportInit = sync.Once{}
+}

--- a/internal/k8s/policy_reports.go
+++ b/internal/k8s/policy_reports.go
@@ -126,7 +126,30 @@ func WarmupKyvernoPolicyReports() {
 			return
 		}
 
-		log.Printf("[policy-reports] Kyverno detected; warming up %d PolicyReport CRDs (cap=%d reports)", len(watched), kyvernoReportWarmupCap)
+		// Probe cluster size before starting informers. The index caps what we
+		// keep in memory (MaxIndexedReports), but informers themselves
+		// list/watch/cache every PolicyReport object cluster-wide — on a
+		// Kyverno-heavy cluster with tens of thousands of reports, that's
+		// exactly the high-cardinality cost we're trying to avoid. If the
+		// aggregate count across watched GVRs exceeds the cap, leave reports
+		// in the deferred-fetch tier so callers can resolve them on demand.
+		var total int
+		for _, gvr := range watched {
+			count := cache.ProbeCount(gvr)
+			if count < 0 {
+				// -1 RBAC denied, -2 transient probe error. Either way, we
+				// can't bound the warmup cost; defer rather than gamble.
+				log.Printf("[policy-reports] Probe for %s returned %d; deferring PolicyReport warmup", gvr, count)
+				return
+			}
+			total += count
+		}
+		if total > kyvernoReportWarmupCap {
+			log.Printf("[policy-reports] Cluster has %d PolicyReports across %d CRDs (cap=%d); leaving deferred to avoid full-cluster watch cost", total, len(watched), kyvernoReportWarmupCap)
+			return
+		}
+
+		log.Printf("[policy-reports] Kyverno detected; warming up %d PolicyReport CRDs (probed %d reports, cap=%d)", len(watched), total, kyvernoReportWarmupCap)
 		cache.WarmupParallel(watched, 30*time.Second)
 
 		// Initialize the index from current cache contents so the first

--- a/internal/k8s/policy_reports.go
+++ b/internal/k8s/policy_reports.go
@@ -77,6 +77,15 @@ func GetPolicyReportIndex() *policyreports.Index {
 // Safe to call multiple times; only the first invocation does work.
 // Subsequent calls are no-ops (sync.Once-guarded). Reset via
 // ResetPolicyReportIndex on context switch.
+//
+// TODO(post-T5): mid-runtime Kyverno install is not handled. If Kyverno is
+// installed AFTER initial CRD discovery completes (e.g. operator deployed
+// post-boot), this function won't re-fire and PolicyReports stay in the
+// deferred tier until the next context switch resets the once. To support
+// this, hook OnCRDDiscoveryComplete in pkg/k8score/dynamic_cache.go (around
+// the rediscovery path) to re-evaluate IsKyvernoInstalled and warm up
+// lazily. Documented limitation, not blocking — context switches are the
+// dominant lifecycle event in practice.
 func WarmupKyvernoPolicyReports() {
 	policyReportInit.Do(func() {
 		discovery := GetResourceDiscovery()
@@ -182,10 +191,17 @@ func scheduleRebuild() {
 		return // rebuild already scheduled
 	}
 	time.AfterFunc(rebuildDebounce, func() {
-		// Clear the pending flag BEFORE the rebuild — any event that
-		// arrives between this line and Replace() arms a fresh timer,
-		// which is the desired behavior. Without clearing first, an
-		// event firing concurrently could be lost.
+		// Clear the pending flag BEFORE the rebuild, not after. The
+		// hazard avoided: if we cleared after, an event arriving between
+		// rebuild's List() snapshot and the final Store(false) would
+		// neither be visible to the current rebuild nor able to arm a
+		// fresh timer (CAS would fail while pending=true), and would
+		// only be picked up when *some later* event happened to fire.
+		// Clearing first means any event during the rebuild always
+		// either lands in the current rebuild's snapshot OR arms a
+		// fresh timer. The cost is one extra rebuild per event that
+		// arrives during the rebuild window — cheaper than chasing
+		// silent staleness.
 		policyReportPending.Store(false)
 		rebuildPolicyReportIndex()
 	})

--- a/internal/k8s/policy_reports.go
+++ b/internal/k8s/policy_reports.go
@@ -61,8 +61,21 @@ var (
 )
 
 // GetPolicyReportIndex returns the singleton PolicyReport index, or nil
-// when Kyverno is not installed on the cluster. Callers must treat the
-// nil return as "no Kyverno findings available" and degrade gracefully.
+// when no findings are available for any reason.
+//
+// "Nil" collapses several distinct conditions today — discovery not
+// available, Kyverno not installed, dynamic cache not initialized, no
+// PolicyReport CRDs registered, RBAC denied on the count probe, or the
+// aggregate report count exceeded the warmup cap (deferred). Callers
+// that need to distinguish these — e.g. to emit the correct
+// `resourcecontext.OmittedReason` (not_installed vs rbac_denied vs
+// budget_exceeded vs cache_cold) — cannot do so today.
+//
+// TODO(T10): when the diagnostic `policySummary.kyverno` consumer
+// arrives, introduce a sibling accessor that returns an enum status
+// alongside the index so consumers can populate `omitted` faithfully.
+// The reason isn't tracked yet because there's no consumer to need it;
+// adding it speculatively is YAGNI surface.
 //
 // Returned indexes are safe for concurrent reads; the index swaps its
 // internal state atomically during rebuilds.

--- a/internal/k8s/subsystems.go
+++ b/internal/k8s/subsystems.go
@@ -133,6 +133,13 @@ func InitAllSubsystems(ctx context.Context, progress func(string)) error {
 				dt := time.Now()
 				dc.DiscoverAllCRDs()
 				logTiming("   CRD full discovery: %v (background)", time.Since(dt))
+				// Conditional Kyverno warmup runs after discovery so the
+				// IsKyvernoInstalled() signal sees every CRD that landed
+				// during WarmupCommonCRDs or DiscoverAllCRDs (admin may
+				// have installed Kyverno after Radar started).
+				pt := time.Now()
+				WarmupKyvernoPolicyReports()
+				logTiming("   Kyverno PolicyReport warmup: %v (background)", time.Since(pt))
 				logTiming("   CRD total (warmup+discovery): %v (background)", time.Since(crdStart))
 			}()
 		}
@@ -232,7 +239,11 @@ func ResetAllSubsystems() {
 
 	safeReset("metrics history", ResetMetricsHistory)
 
-	// Step 3: dynamic cache
+	// Step 3: dynamic cache. Reset the PolicyReport index first because
+	// it holds references into the dynamic cache's informer indexers —
+	// clearing the index before tearing down the informers avoids using
+	// half-disposed informers on the next event-driven rebuild.
+	safeReset("policy report index", ResetPolicyReportIndex)
 	safeReset("dynamic resource cache", ResetDynamicResourceCache)
 
 	// Step 2: resource discovery + resource cache

--- a/pkg/k8score/discovery.go
+++ b/pkg/k8score/discovery.go
@@ -490,6 +490,63 @@ func (d *ResourceDiscovery) SupportsWatchGVR(gvr schema.GroupVersionResource) bo
 	return false
 }
 
+// HasGroup reports whether at least one resource from the given API group
+// is present in discovery. Useful for cheap "is X installed" feature gates
+// (e.g. Kyverno → kyverno.io group) without having to enumerate the full
+// resources list at call sites.
+func (d *ResourceDiscovery) HasGroup(group string) bool {
+	if d == nil {
+		return false
+	}
+
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	for _, res := range d.resources {
+		if res.Group == group {
+			return true
+		}
+	}
+	return false
+}
+
+// HasKindInGroup reports whether a specific Kind exists within an API
+// group. Stricter than HasGroup — use this when you depend on a specific
+// CRD being registered, not just any resource from the operator's group.
+func (d *ResourceDiscovery) HasKindInGroup(kind, group string) bool {
+	if d == nil {
+		return false
+	}
+
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	kindLower := strings.ToLower(kind)
+	for _, res := range d.resources {
+		if res.Group == group && strings.ToLower(res.Kind) == kindLower {
+			return true
+		}
+	}
+	return false
+}
+
+// IsKyvernoInstalled reports whether the Kyverno admission controller's
+// CRDs are present on the cluster. The check uses Kyverno's own Policy
+// and ClusterPolicy CRDs as the signal — these are unique to Kyverno
+// itself, whereas the PolicyReport CRDs (wgpolicyk8s.io) are emitted by
+// several engines (Kyverno, Trivy, etc.) and so do not by themselves
+// imply Kyverno is the source.
+//
+// The signal drives conditional eager warmup of PolicyReport informers:
+// clusters without Kyverno keep the reports in the deferred-fetch tier
+// and pay no extra memory or watch budget.
+func (d *ResourceDiscovery) IsKyvernoInstalled() bool {
+	if d == nil {
+		return false
+	}
+	return d.HasKindInGroup("Policy", "kyverno.io") || d.HasKindInGroup("ClusterPolicy", "kyverno.io")
+}
+
 // GetKindForGVR returns the Kind name for a given GVR
 // e.g., for GVR{Resource: "rollouts"}, returns "Rollout".
 func (d *ResourceDiscovery) GetKindForGVR(gvr schema.GroupVersionResource) string {

--- a/pkg/k8score/discovery.go
+++ b/pkg/k8score/discovery.go
@@ -490,29 +490,8 @@ func (d *ResourceDiscovery) SupportsWatchGVR(gvr schema.GroupVersionResource) bo
 	return false
 }
 
-// HasGroup reports whether at least one resource from the given API group
-// is present in discovery. Useful for cheap "is X installed" feature gates
-// (e.g. Kyverno → kyverno.io group) without having to enumerate the full
-// resources list at call sites.
-func (d *ResourceDiscovery) HasGroup(group string) bool {
-	if d == nil {
-		return false
-	}
-
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
-	for _, res := range d.resources {
-		if res.Group == group {
-			return true
-		}
-	}
-	return false
-}
-
 // HasKindInGroup reports whether a specific Kind exists within an API
-// group. Stricter than HasGroup — use this when you depend on a specific
-// CRD being registered, not just any resource from the operator's group.
+// group. Use this when you depend on a specific CRD being registered.
 func (d *ResourceDiscovery) HasKindInGroup(kind, group string) bool {
 	if d == nil {
 		return false

--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -290,10 +290,14 @@ func (d *DynamicResourceCache) factoryForGVR(gvr schema.GroupVersionResource) dy
 	return d.factory
 }
 
-// probeCount does a quick list with limit=1 and returns the approximate resource count.
+// ProbeCount does a quick list with limit=1 and returns the approximate resource count.
 // Returns -1 if access is denied, -2 if the probe failed for non-auth reasons (caller
 // should defer), or the count (items + remainingItemCount) on success.
-func (d *DynamicResourceCache) probeCount(gvr schema.GroupVersionResource) int {
+//
+// Exported so callers outside this package (e.g. internal/k8s when deciding
+// whether to eager-warm high-cardinality CRDs like PolicyReports) can gate
+// informer creation on cluster size before paying the watch-layer cost.
+func (d *DynamicResourceCache) ProbeCount(gvr schema.GroupVersionResource) int {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -945,7 +949,7 @@ func (d *DynamicResourceCache) DiscoverAllCRDs() {
 						results <- probeResult{gvr: g, count: -1}
 					}
 				}()
-				count := d.probeCount(g)
+				count := d.ProbeCount(g)
 				results <- probeResult{gvr: g, count: count}
 			}(gvr)
 		}

--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -1061,6 +1061,37 @@ func (d *DynamicResourceCache) GetInformerCount() int {
 	return len(d.informers)
 }
 
+// AddGVRChangeHandler registers a change handler on the informer for the
+// given GVR. The handler fires for add/update/delete events (including the
+// initial sync). Returns an error if no informer exists yet for the GVR —
+// callers should warm up or EnsureWatching the resource before registering.
+//
+// Used by derived caches (PolicyReport index, etc.) that need to react to
+// changes on a single resource kind without subscribing to the global
+// OnChange callback (which would fire for every dynamic resource).
+//
+// The handler runs on the informer's event-processing goroutine; it must
+// be non-blocking. A panic in the handler is contained by the upstream
+// informer machinery (no impact on other handlers).
+func (d *DynamicResourceCache) AddGVRChangeHandler(gvr schema.GroupVersionResource, handler cache.ResourceEventHandler) error {
+	if d == nil {
+		return fmt.Errorf("dynamic resource cache not initialized")
+	}
+
+	d.mu.RLock()
+	informer, exists := d.informers[gvr]
+	d.mu.RUnlock()
+
+	if !exists {
+		return fmt.Errorf("no informer for %s.%s/%s; warm up the resource before registering a handler", gvr.Resource, gvr.Group, gvr.Version)
+	}
+
+	if _, err := informer.AddEventHandler(handler); err != nil {
+		return fmt.Errorf("add event handler for %v: %w", gvr, err)
+	}
+	return nil
+}
+
 // ---------------------------------------------------------------------------
 // CRD discovery callbacks
 // ---------------------------------------------------------------------------

--- a/pkg/policyreports/index.go
+++ b/pkg/policyreports/index.go
@@ -79,8 +79,13 @@ func (i *Index) Replace(reports []*unstructured.Unstructured) {
 }
 
 // FindingsFor returns the findings indexed for the given subject. Returns
-// nil if no findings are recorded for that subject. The returned slice is
-// safe to read but must not be mutated — it is shared with the index.
+// nil if no findings are recorded for that subject.
+//
+// The returned slice is a defensive copy: callers may freely sort, truncate,
+// or filter it without racing the index's own rebuild path. The cost is
+// modest — findings per subject are bounded (Kyverno emits at most one
+// PolicyReport entry per (policy, rule, resource) tuple, and pathological
+// reports are capped during BuildIndex anyway).
 func (i *Index) FindingsFor(kind, namespace, name string) []Finding {
 	if i == nil {
 		return nil
@@ -88,7 +93,13 @@ func (i *Index) FindingsFor(kind, namespace, name string) []Finding {
 	key := audit.ResourceKey(kind, namespace, name)
 	i.mu.RLock()
 	defer i.mu.RUnlock()
-	return i.bySubject[key]
+	src := i.bySubject[key]
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([]Finding, len(src))
+	copy(out, src)
+	return out
 }
 
 // Size returns the number of distinct subjects with at least one indexed
@@ -247,4 +258,3 @@ func stringField(m map[string]any, key string) string {
 	s, _ := v.(string)
 	return s
 }
-

--- a/pkg/policyreports/index.go
+++ b/pkg/policyreports/index.go
@@ -1,0 +1,250 @@
+package policyreports
+
+import (
+	"sort"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/skyhook-io/radar/pkg/audit"
+)
+
+// MaxIndexedReports caps how many PolicyReport documents the index keeps,
+// chosen by newest `metadata.creationTimestamp` first. Reports beyond the
+// cap are silently dropped on rebuild. Tunable here for clusters where a
+// single namespace generates a runaway number of reports — the index is
+// purely diagnostic, so dropping the oldest is acceptable.
+const MaxIndexedReports = 500
+
+// Index maps subject keys ("Kind/namespace/name", per audit.ResourceKey) to
+// the policy findings that apply to that subject. It is safe for concurrent
+// read/write: callers building the index from informer events may swap
+// contents while other callers serve `FindingsFor` lookups.
+//
+// The index is a pure projection of the input reports — it owns no
+// underlying state and does not refetch.
+type Index struct {
+	mu        sync.RWMutex
+	bySubject map[string][]Finding
+}
+
+// NewIndex returns an empty Index.
+func NewIndex() *Index {
+	return &Index{bySubject: make(map[string][]Finding)}
+}
+
+// BuildIndex constructs an Index from a slice of PolicyReport documents
+// (both namespaced PolicyReport and cluster-scoped ClusterPolicyReport).
+// Reports are processed newest-first by `metadata.creationTimestamp`, and
+// only the first MaxIndexedReports are considered — older reports are
+// dropped to bound memory.
+//
+// For each report, every entry in `results[]` becomes one Finding per
+// resource in `results[].resources[]`. When a result has no `resources[]`
+// (single-target reports), the enclosing `report.scope` is used as the
+// subject. Reports with neither resources nor a scope contribute no
+// findings (there is no subject to index by).
+func BuildIndex(reports []*unstructured.Unstructured) *Index {
+	idx := NewIndex()
+	idx.Replace(reports)
+	return idx
+}
+
+// Replace rebuilds the index in-place from the given reports. Existing
+// entries are discarded. Used by the live-update path: an informer event
+// handler re-lists the cache and calls Replace to keep the index fresh.
+func (i *Index) Replace(reports []*unstructured.Unstructured) {
+	if i == nil {
+		return
+	}
+
+	// Sort newest-first so the cap drops the oldest reports.
+	sorted := make([]*unstructured.Unstructured, len(reports))
+	copy(sorted, reports)
+	sort.SliceStable(sorted, func(a, b int) bool {
+		return sorted[a].GetCreationTimestamp().Time.After(sorted[b].GetCreationTimestamp().Time)
+	})
+	if len(sorted) > MaxIndexedReports {
+		sorted = sorted[:MaxIndexedReports]
+	}
+
+	next := make(map[string][]Finding)
+	for _, r := range sorted {
+		extractFindings(r, next)
+	}
+
+	i.mu.Lock()
+	i.bySubject = next
+	i.mu.Unlock()
+}
+
+// FindingsFor returns the findings indexed for the given subject. Returns
+// nil if no findings are recorded for that subject. The returned slice is
+// safe to read but must not be mutated — it is shared with the index.
+func (i *Index) FindingsFor(kind, namespace, name string) []Finding {
+	if i == nil {
+		return nil
+	}
+	key := audit.ResourceKey(kind, namespace, name)
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.bySubject[key]
+}
+
+// Size returns the number of distinct subjects with at least one indexed
+// finding. Useful for diagnostics and tests.
+func (i *Index) Size() int {
+	if i == nil {
+		return 0
+	}
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return len(i.bySubject)
+}
+
+// extractFindings appends one Finding per (result, resource) pair into the
+// destination map. The map's keys are `audit.ResourceKey` values; the
+// helper centralizes the shape so callers don't have to know about the
+// PolicyReport schema.
+//
+// Schema reference (https://github.com/kubernetes-sigs/wg-policy-prototypes):
+//
+//	apiVersion: wgpolicyk8s.io/v1alpha2
+//	kind: PolicyReport
+//	metadata: { ... }
+//	scope: { apiVersion, kind, namespace, name, uid }  # optional
+//	results:
+//	  - policy: string
+//	    rule: string
+//	    result: pass|fail|warn|error|skip
+//	    severity: info|low|medium|high|critical
+//	    category: string
+//	    message: string
+//	    resources:
+//	      - apiVersion, kind, namespace, name, uid     # optional, can be []
+//	    ...
+func extractFindings(report *unstructured.Unstructured, dst map[string][]Finding) {
+	if report == nil {
+		return
+	}
+
+	scopeKind, scopeNS, scopeName := reportScope(report)
+
+	results, found, err := unstructured.NestedSlice(report.Object, "results")
+	if err != nil || !found {
+		return
+	}
+
+	reportNamespace := report.GetNamespace() // for ClusterPolicyReport, "".
+
+	for _, raw := range results {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		f := Finding{
+			Policy:   stringField(entry, "policy"),
+			Rule:     stringField(entry, "rule"),
+			Result:   stringField(entry, "result"),
+			Severity: stringField(entry, "severity"),
+			Category: stringField(entry, "category"),
+			Message:  stringField(entry, "message"),
+		}
+
+		subjects, hasResources := resultResources(entry)
+
+		if !hasResources || len(subjects) == 0 {
+			// Scope-only report: the report itself is bound to one subject
+			// via `report.scope`. The PolicyReport namespace overrides the
+			// scope's namespace when scope.namespace is unset (some
+			// engines emit only kind/name in scope for namespaced reports
+			// and rely on metadata.namespace).
+			if scopeKind != "" && scopeName != "" {
+				ns := scopeNS
+				if ns == "" {
+					ns = reportNamespace
+				}
+				key := audit.ResourceKey(scopeKind, ns, scopeName)
+				dst[key] = append(dst[key], f)
+			}
+			continue
+		}
+
+		for _, s := range subjects {
+			if s.kind == "" || s.name == "" {
+				continue
+			}
+			ns := s.namespace
+			// Namespaced PolicyReports default subject namespace to the
+			// report's namespace when not set on the resource ref — this
+			// mirrors how Kyverno emits namespaced reports.
+			if ns == "" {
+				ns = reportNamespace
+			}
+			key := audit.ResourceKey(s.kind, ns, s.name)
+			dst[key] = append(dst[key], f)
+		}
+	}
+}
+
+// reportScope returns the `report.scope` subject as (kind, namespace, name).
+// All three are empty strings when scope is missing — the caller treats
+// that case as "no scope-only fallback available".
+func reportScope(report *unstructured.Unstructured) (string, string, string) {
+	scope, found, err := unstructured.NestedMap(report.Object, "scope")
+	if err != nil || !found {
+		return "", "", ""
+	}
+	return stringField(scope, "kind"), stringField(scope, "namespace"), stringField(scope, "name")
+}
+
+type subjectRef struct {
+	kind      string
+	namespace string
+	name      string
+}
+
+// resultResources reads `results[].resources[]` into subjectRefs. Returns
+// (refs, true) when the `resources` key was present at all (even if empty),
+// (nil, false) when the key was absent — the caller distinguishes
+// "explicitly no resources" (empty slice) from "scope-only report" (key
+// absent / single-target) so the scope fallback only fires in the latter.
+//
+// In practice both engines we've observed (Kyverno, Trivy) either emit
+// `resources` populated or omit it entirely when the report is scope-only,
+// so we treat empty-but-present the same as scope-only as well — this is
+// the more useful behavior and matches operator intent.
+func resultResources(entry map[string]any) ([]subjectRef, bool) {
+	raw, ok := entry["resources"]
+	if !ok || raw == nil {
+		return nil, false
+	}
+	list, ok := raw.([]any)
+	if !ok {
+		return nil, false
+	}
+	refs := make([]subjectRef, 0, len(list))
+	for _, item := range list {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		refs = append(refs, subjectRef{
+			kind:      stringField(m, "kind"),
+			namespace: stringField(m, "namespace"),
+			name:      stringField(m, "name"),
+		})
+	}
+	return refs, true
+}
+
+func stringField(m map[string]any, key string) string {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return ""
+	}
+	s, _ := v.(string)
+	return s
+}
+

--- a/pkg/policyreports/index.go
+++ b/pkg/policyreports/index.go
@@ -165,12 +165,24 @@ func extractFindings(report *unstructured.Unstructured, dst map[string][]Finding
 
 		subjects, hasResources := resultResources(entry)
 
-		if !hasResources || len(subjects) == 0 {
-			// Scope-only report: the report itself is bound to one subject
-			// via `report.scope`. The PolicyReport namespace overrides the
-			// scope's namespace when scope.namespace is unset (some
-			// engines emit only kind/name in scope for namespaced reports
-			// and rely on metadata.namespace).
+		// Pre-filter to subjects that can actually be indexed. A non-empty
+		// resources[] slice of empty objects (e.g. `resources: [{}]` from
+		// a malformed CRD) would otherwise skip scope fallback below AND
+		// then get filtered to nothing in the index loop — silently
+		// dropping a finding that the report's scope could have rescued.
+		validSubjects := make([]subjectRef, 0, len(subjects))
+		for _, s := range subjects {
+			if s.kind != "" && s.name != "" {
+				validSubjects = append(validSubjects, s)
+			}
+		}
+
+		if !hasResources || len(validSubjects) == 0 {
+			// Scope-only report (or all subjects malformed): the report
+			// itself is bound to one subject via `report.scope`. The
+			// PolicyReport namespace overrides the scope's namespace when
+			// scope.namespace is unset (some engines emit only kind/name
+			// in scope for namespaced reports and rely on metadata.namespace).
 			if scopeKind != "" && scopeName != "" {
 				ns := scopeNS
 				if ns == "" {
@@ -182,10 +194,7 @@ func extractFindings(report *unstructured.Unstructured, dst map[string][]Finding
 			continue
 		}
 
-		for _, s := range subjects {
-			if s.kind == "" || s.name == "" {
-				continue
-			}
+		for _, s := range validSubjects {
 			ns := s.namespace
 			// Namespaced PolicyReports default subject namespace to the
 			// report's namespace when not set on the resource ref — this

--- a/pkg/policyreports/index_test.go
+++ b/pkg/policyreports/index_test.go
@@ -258,6 +258,37 @@ func TestBuildIndex_EmptyResourcesArray_FallsBackToScope(t *testing.T) {
 	}
 }
 
+// TestBuildIndex_MalformedResourcesEntries_FallsBackToScope pins the edge case
+// reviewer caught: `resources: [{}]` is a non-empty slice that previously
+// skipped scope fallback (because hasResources && len(subjects) > 0) but then
+// got filtered to nothing in the index loop (every subject has empty kind/name).
+// The finding was silently dropped even when scope could have rescued it.
+func TestBuildIndex_MalformedResourcesEntries_FallsBackToScope(t *testing.T) {
+	scope := map[string]any{
+		"kind":      "Deployment",
+		"namespace": "prod",
+		"name":      "cart",
+	}
+	report := makeReport(t, "PolicyReport", "prod", "malformed-resources", scope, time.Now(), []map[string]any{
+		{
+			"policy": "require-resource-limits",
+			"result": "fail",
+			// Non-empty resources[] but every entry is empty — produced
+			// by some buggy emitters when policy match conditions fail.
+			"resources": []any{
+				map[string]any{},
+				map[string]any{},
+			},
+		},
+	})
+
+	idx := BuildIndex([]*unstructured.Unstructured{report})
+	got := idx.FindingsFor("Deployment", "prod", "cart")
+	if len(got) != 1 {
+		t.Fatalf("expected scope fallback when all resources entries are empty, got %d findings", len(got))
+	}
+}
+
 func TestBuildIndex_FindingsForUnknownSubject(t *testing.T) {
 	report := makeReport(t, "PolicyReport", "prod", "rep", nil, time.Now(), []map[string]any{
 		{

--- a/pkg/policyreports/index_test.go
+++ b/pkg/policyreports/index_test.go
@@ -1,0 +1,363 @@
+package policyreports
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// makeReport constructs a synthetic PolicyReport (or ClusterPolicyReport)
+// as the dynamic cache would surface it. namespace is set on the report's
+// metadata for namespaced PolicyReports; pass "" for ClusterPolicyReport.
+// scope is optional (pass nil to omit). created controls
+// metadata.creationTimestamp for ordering tests.
+func makeReport(t *testing.T, kind, namespace, name string, scope map[string]any, created time.Time, results []map[string]any) *unstructured.Unstructured {
+	t.Helper()
+	r := &unstructured.Unstructured{}
+	r.SetKind(kind)
+	r.SetAPIVersion("wgpolicyk8s.io/v1alpha2")
+	r.SetName(name)
+	if namespace != "" {
+		r.SetNamespace(namespace)
+	}
+	r.SetCreationTimestamp(metav1.NewTime(created))
+
+	// Build into Object so unstructured.Nested* sees nested keys.
+	if scope != nil {
+		if err := unstructured.SetNestedMap(r.Object, scope, "scope"); err != nil {
+			t.Fatalf("set scope: %v", err)
+		}
+	}
+	// `results` is []any of map[string]any when read via NestedSlice.
+	resultsAny := make([]any, 0, len(results))
+	for _, res := range results {
+		resultsAny = append(resultsAny, res)
+	}
+	if err := unstructured.SetNestedSlice(r.Object, resultsAny, "results"); err != nil {
+		t.Fatalf("set results: %v", err)
+	}
+	return r
+}
+
+func resourceRef(kind, ns, name string) map[string]any {
+	m := map[string]any{"kind": kind, "name": name}
+	if ns != "" {
+		m["namespace"] = ns
+	}
+	return m
+}
+
+func TestBuildIndex_PerResourceFindings(t *testing.T) {
+	// One report with two results, each targeting a distinct subject.
+	report := makeReport(t, "PolicyReport", "prod", "kyverno-report-1", nil, time.Now(), []map[string]any{
+		{
+			"policy":   "disallow-privileged",
+			"rule":     "no-privileged",
+			"result":   "fail",
+			"severity": "high",
+			"category": "Pod Security",
+			"message":  "container is privileged",
+			"resources": []any{
+				resourceRef("Pod", "prod", "web-abc123"),
+			},
+		},
+		{
+			"policy":   "require-labels",
+			"rule":     "app-label",
+			"result":   "warn",
+			"severity": "low",
+			"category": "Best Practices",
+			"message":  "missing app label",
+			"resources": []any{
+				resourceRef("Deployment", "prod", "web"),
+			},
+		},
+	})
+
+	idx := BuildIndex([]*unstructured.Unstructured{report})
+
+	podFindings := idx.FindingsFor("Pod", "prod", "web-abc123")
+	if len(podFindings) != 1 {
+		t.Fatalf("expected 1 finding for Pod/prod/web-abc123, got %d", len(podFindings))
+	}
+	if podFindings[0].Policy != "disallow-privileged" || podFindings[0].Result != "fail" {
+		t.Errorf("unexpected pod finding: %+v", podFindings[0])
+	}
+	if podFindings[0].Severity != "high" || podFindings[0].Category != "Pod Security" {
+		t.Errorf("severity/category not preserved: %+v", podFindings[0])
+	}
+
+	depFindings := idx.FindingsFor("Deployment", "prod", "web")
+	if len(depFindings) != 1 {
+		t.Fatalf("expected 1 finding for Deployment/prod/web, got %d", len(depFindings))
+	}
+	if depFindings[0].Rule != "app-label" || depFindings[0].Result != "warn" {
+		t.Errorf("unexpected deployment finding: %+v", depFindings[0])
+	}
+}
+
+func TestBuildIndex_MultipleResourcesPerResult(t *testing.T) {
+	// One result targeting three pods → three index entries from one
+	// finding row. This is the common shape for cluster-wide policies.
+	report := makeReport(t, "PolicyReport", "prod", "rep-multi", nil, time.Now(), []map[string]any{
+		{
+			"policy": "require-cpu-limits",
+			"rule":   "cpu-limits",
+			"result": "fail",
+			"resources": []any{
+				resourceRef("Pod", "prod", "a"),
+				resourceRef("Pod", "prod", "b"),
+				resourceRef("Pod", "prod", "c"),
+			},
+		},
+	})
+
+	idx := BuildIndex([]*unstructured.Unstructured{report})
+
+	for _, name := range []string{"a", "b", "c"} {
+		got := idx.FindingsFor("Pod", "prod", name)
+		if len(got) != 1 {
+			t.Errorf("expected 1 finding for Pod/prod/%s, got %d", name, len(got))
+		}
+	}
+	if idx.Size() != 3 {
+		t.Errorf("expected 3 distinct subjects, got %d", idx.Size())
+	}
+}
+
+func TestBuildIndex_ScopeOnlyReport(t *testing.T) {
+	// Single-target report: no `results[].resources` array — the report
+	// itself is scoped to one subject via `report.scope`. Each result row
+	// should still produce a finding indexed under the scope subject.
+	scope := map[string]any{
+		"kind":      "Deployment",
+		"namespace": "prod",
+		"name":      "api",
+	}
+	report := makeReport(t, "PolicyReport", "prod", "scope-only", scope, time.Now(), []map[string]any{
+		{
+			"policy":   "disallow-latest-tag",
+			"rule":     "no-latest",
+			"result":   "fail",
+			"severity": "medium",
+			"message":  "image tag is latest",
+			// no "resources" key
+		},
+		{
+			"policy":  "require-readiness",
+			"rule":    "readiness-probe",
+			"result":  "warn",
+			"message": "missing readinessProbe",
+		},
+	})
+
+	idx := BuildIndex([]*unstructured.Unstructured{report})
+
+	got := idx.FindingsFor("Deployment", "prod", "api")
+	if len(got) != 2 {
+		t.Fatalf("expected 2 findings under scope subject, got %d", len(got))
+	}
+
+	policies := []string{got[0].Policy, got[1].Policy}
+	sort.Strings(policies)
+	want := []string{"disallow-latest-tag", "require-readiness"}
+	for i := range policies {
+		if policies[i] != want[i] {
+			t.Errorf("policy[%d]=%q want %q", i, policies[i], want[i])
+		}
+	}
+}
+
+func TestBuildIndex_ScopeFallback_NamespaceFromReportMetadata(t *testing.T) {
+	// Scope omits namespace but the report is namespaced — common shape
+	// when engines emit only kind+name in scope and rely on the report's
+	// own metadata.namespace.
+	scope := map[string]any{
+		"kind": "Pod",
+		"name": "lonely",
+		// no namespace
+	}
+	report := makeReport(t, "PolicyReport", "dev", "rep-scope-no-ns", scope, time.Now(), []map[string]any{
+		{
+			"policy": "no-host-network",
+			"result": "fail",
+		},
+	})
+
+	idx := BuildIndex([]*unstructured.Unstructured{report})
+	got := idx.FindingsFor("Pod", "dev", "lonely")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 finding inherited from report namespace, got %d", len(got))
+	}
+}
+
+func TestBuildIndex_ClusterPolicyReport(t *testing.T) {
+	// ClusterPolicyReport: no report.metadata.namespace; cluster-scoped
+	// resources (Node, ClusterRole) get empty-namespace keys.
+	report := makeReport(t, "ClusterPolicyReport", "", "cluster-rep", nil, time.Now(), []map[string]any{
+		{
+			"policy": "node-ssh-disabled",
+			"result": "fail",
+			"resources": []any{
+				resourceRef("Node", "", "gke-pool-a-1"),
+			},
+		},
+	})
+
+	idx := BuildIndex([]*unstructured.Unstructured{report})
+
+	got := idx.FindingsFor("Node", "", "gke-pool-a-1")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 finding on Node, got %d", len(got))
+	}
+	if got[0].Policy != "node-ssh-disabled" {
+		t.Errorf("policy not preserved: %+v", got[0])
+	}
+}
+
+func TestBuildIndex_NoScopeNoResources_DropsFinding(t *testing.T) {
+	// Pathological / malformed report: no scope, no resources. There is
+	// no subject to index against, so the finding is dropped silently.
+	report := makeReport(t, "PolicyReport", "ns", "bad-rep", nil, time.Now(), []map[string]any{
+		{
+			"policy": "orphaned",
+			"result": "error",
+		},
+	})
+
+	idx := BuildIndex([]*unstructured.Unstructured{report})
+	if idx.Size() != 0 {
+		t.Errorf("expected empty index for orphaned finding, got %d entries", idx.Size())
+	}
+}
+
+func TestBuildIndex_EmptyResourcesArray_FallsBackToScope(t *testing.T) {
+	// `resources: []` (empty but present) is treated the same as
+	// scope-only — both engines we've seen emit it interchangeably.
+	scope := map[string]any{
+		"kind":      "Service",
+		"namespace": "default",
+		"name":      "svc",
+	}
+	report := makeReport(t, "PolicyReport", "default", "empty-resources", scope, time.Now(), []map[string]any{
+		{
+			"policy":    "no-loadbalancer",
+			"result":    "fail",
+			"resources": []any{},
+		},
+	})
+
+	idx := BuildIndex([]*unstructured.Unstructured{report})
+	got := idx.FindingsFor("Service", "default", "svc")
+	if len(got) != 1 {
+		t.Fatalf("expected scope fallback to trigger on empty resources, got %d findings", len(got))
+	}
+}
+
+func TestBuildIndex_FindingsForUnknownSubject(t *testing.T) {
+	report := makeReport(t, "PolicyReport", "prod", "rep", nil, time.Now(), []map[string]any{
+		{
+			"policy": "p",
+			"result": "fail",
+			"resources": []any{
+				resourceRef("Pod", "prod", "a"),
+			},
+		},
+	})
+	idx := BuildIndex([]*unstructured.Unstructured{report})
+
+	if got := idx.FindingsFor("Pod", "prod", "missing"); got != nil {
+		t.Errorf("expected nil for unknown subject, got %v", got)
+	}
+}
+
+func TestBuildIndex_Cap_OldestDropped(t *testing.T) {
+	// Build with MaxIndexedReports + 5 reports, each targeting a unique
+	// pod. The 5 oldest should be dropped — only the newest
+	// MaxIndexedReports survive.
+	base := time.Now()
+	reports := make([]*unstructured.Unstructured, 0, MaxIndexedReports+5)
+	for i := 0; i < MaxIndexedReports+5; i++ {
+		// Older reports first; index sorts newest-first internally.
+		created := base.Add(time.Duration(i) * time.Second)
+		reports = append(reports, makeReport(t, "PolicyReport", "ns", fmt.Sprintf("rep-%d", i), nil, created, []map[string]any{
+			{
+				"policy": "p",
+				"result": "fail",
+				"resources": []any{
+					resourceRef("Pod", "ns", fmt.Sprintf("pod-%d", i)),
+				},
+			},
+		}))
+	}
+
+	idx := BuildIndex(reports)
+	if idx.Size() != MaxIndexedReports {
+		t.Fatalf("expected exactly MaxIndexedReports=%d subjects after cap, got %d", MaxIndexedReports, idx.Size())
+	}
+	// The 5 oldest (indexes 0..4) should be absent. The newest (index
+	// MaxIndexedReports+4) should be present.
+	if got := idx.FindingsFor("Pod", "ns", "pod-0"); got != nil {
+		t.Errorf("pod-0 should have been dropped by cap, got %v", got)
+	}
+	newestName := fmt.Sprintf("pod-%d", MaxIndexedReports+4)
+	if got := idx.FindingsFor("Pod", "ns", newestName); len(got) != 1 {
+		t.Errorf("newest pod %s should be present, got %v", newestName, got)
+	}
+}
+
+func TestIndex_ReplaceSwapsContents(t *testing.T) {
+	// Live-update pattern: build, then replace contents on event.
+	idx := NewIndex()
+
+	idx.Replace([]*unstructured.Unstructured{
+		makeReport(t, "PolicyReport", "ns", "first", nil, time.Now(), []map[string]any{
+			{
+				"policy": "p1",
+				"result": "fail",
+				"resources": []any{
+					resourceRef("Pod", "ns", "first"),
+				},
+			},
+		}),
+	})
+	if got := idx.FindingsFor("Pod", "ns", "first"); len(got) != 1 {
+		t.Fatalf("first build missed: %v", got)
+	}
+
+	// Replace with a different report — old subject must disappear.
+	idx.Replace([]*unstructured.Unstructured{
+		makeReport(t, "PolicyReport", "ns", "second", nil, time.Now(), []map[string]any{
+			{
+				"policy": "p2",
+				"result": "warn",
+				"resources": []any{
+					resourceRef("Pod", "ns", "second"),
+				},
+			},
+		}),
+	})
+
+	if got := idx.FindingsFor("Pod", "ns", "first"); got != nil {
+		t.Errorf("old subject leaked after Replace: %v", got)
+	}
+	if got := idx.FindingsFor("Pod", "ns", "second"); len(got) != 1 {
+		t.Errorf("new subject missing after Replace: %v", got)
+	}
+}
+
+func TestIndex_NilSafe(t *testing.T) {
+	var idx *Index
+	if got := idx.FindingsFor("Pod", "ns", "name"); got != nil {
+		t.Errorf("nil index FindingsFor returned %v", got)
+	}
+	if got := idx.Size(); got != 0 {
+		t.Errorf("nil index Size returned %d", got)
+	}
+	// Replace on nil receiver should not panic.
+	idx.Replace(nil)
+}

--- a/pkg/policyreports/types.go
+++ b/pkg/policyreports/types.go
@@ -1,0 +1,36 @@
+// Package policyreports builds a per-subject lookup of Kyverno PolicyReport
+// findings from the dynamic-cache informers. It does not talk to the
+// Kubernetes API directly — callers (typically `internal/k8s`) feed it
+// `*unstructured.Unstructured` objects fetched from the dynamic cache.
+//
+// The shape `wgpolicyk8s.io/v1alpha2/PolicyReport` (and its cluster-scoped
+// sibling `ClusterPolicyReport`) is the Working Group on Policy reporting
+// CRD, populated by Kyverno (and other policy engines). Each report
+// contains a `results[]` list of per-rule findings and, for each result,
+// either a `resources[]` array of subject refs or an enclosing `scope`
+// when the report itself is scoped to a single subject.
+package policyreports
+
+// Finding is one entry from a PolicyReport's `results[]`, projected to the
+// subject it applies to. It is the minimum useful surface for an agent or a
+// human triaging policy violations: which policy/rule triggered, what the
+// result was, and the human-readable message.
+//
+// `Result` follows the upstream reporting API enum:
+//   - "pass"  — policy allowed the resource
+//   - "fail"  — policy rejected the resource
+//   - "warn"  — policy flagged the resource (non-blocking)
+//   - "error" — engine error evaluating the policy
+//   - "skip"  — policy did not apply (e.g. exclusion match)
+//
+// `Severity` and `Category` are free-form strings (e.g. "high", "medium",
+// "low" for severity; "Pod Security", "Best Practices" for category) — they
+// come straight from the report and are not normalized.
+type Finding struct {
+	Policy   string
+	Rule     string
+	Result   string
+	Severity string
+	Category string
+	Message  string
+}


### PR DESCRIPTION
Phase 4a of the resource-context plan. Standalone infrastructure — the index is built but not consumed by any user-facing surface in this PR. T10 wires it into `resourceContext.policySummary.kyverno`; T11 adds `source=kyverno` to `/api/issues`.

**New `pkg/policyreports` package:**
- `Index` keyed by `"Kind/namespace/name"` (matches `audit.ResourceKey` convention so consumers share a key format).
- `BuildIndex([]*unstructured.Unstructured) *Index` walks each report's `results[].resources[]` and falls back to `report.scope` for single-target reports — covers both shapes emitted in the wild (Kyverno + Trivy).
- `FindingsFor(kind, namespace, name) []Finding` returns a **defensive copy** — callers can sort / truncate / filter per request without racing the rebuild path.
- Cap of `MaxIndexedReports = 500` (newest-first by `creationTimestamp`) bounds memory at the projection layer.

**Conditional Kyverno warmup (in `internal/k8s`):**
- Detect `kyverno.io/Policy` or `ClusterPolicy` CRD presence via discovery.
- If absent → no-op; leave `wgpolicyk8s.io` reports in the deferred-fetch tier.
- If present → **probe cluster size first** via `DynamicResourceCache.ProbeCount` (exported from package-private for this use). If the aggregate report count exceeds the cap, defer — `WarmupParallel` itself doesn't bound cardinality at the watch layer, so on a 10k-report cluster we'd otherwise eat the full informer cost regardless of our index cap.
- If under cap → eager-watch via `WarmupParallel`, build initial index, register debounced rebuild handlers on add/update/delete (500ms coalesce so a Kyverno re-evaluation burst rebuilds once).

**Concurrency correctness.** `policyReportInit` is `*sync.Once` (pointer), not a value, so `ResetPolicyReportIndex` can replace it on context switch without zeroing a mutex held by a concurrent `Do()`. `policyReportWatched` writes are mutex-protected. The debounce clears its pending flag BEFORE running the rebuild — intentional: an event arriving mid-rebuild then either lands in the current snapshot or arms a fresh timer, never both-lost. All documented inline. `go test -race` clean across `pkg/policyreports`, `pkg/k8score`, and `internal/k8s`.

**Documented limitations.** `GetPolicyReportIndex` returns nil for six distinct conditions (Kyverno absent, RBAC denied, cap exceeded, cache cold, etc.) but currently can't tell consumers which. T10 will add a sibling status accessor when the diagnostic consumer arrives. Mid-runtime Kyverno install isn't picked up until the next context switch — also documented with a TODO referencing `OnCRDDiscoveryComplete`.

E2E verified on kind cluster with no Kyverno installed: `[policy-reports] Kyverno not detected (no kyverno.io/Policy or ClusterPolicy); leaving PolicyReports deferred`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new dynamic-informer warmup and event-handler paths gated by Kyverno detection; mistakes could impact cache lifecycle, memory/watch load, or context-switch correctness.
> 
> **Overview**
> Introduces a new `pkg/policyreports` in-memory index that projects `wgpolicyk8s.io` PolicyReport/ClusterPolicyReport objects into per-subject findings (keyed by `audit.ResourceKey`) with a capped newest-first rebuild and defensive-copy lookups.
> 
> Adds conditional Kyverno integration: discovery now detects Kyverno via `kyverno.io` `Policy`/`ClusterPolicy` CRDs, then (only if present and the report count probe is under cap) warms PolicyReport informers, builds the initial index, and keeps it fresh via debounced rebuilds on add/update/delete events.
> 
> Extends the dynamic cache API to support this flow by exporting `ProbeCount` and adding `AddGVRChangeHandler`, and wires initialization/reset ordering so the PolicyReport index is warmed after CRD discovery and reset before tearing down the dynamic cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a49986bdc2162060d199d38c86b7243d3b97516. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->