### PR TITLE
feat(topology): cheap relationship fields + inverted index, retire client-side GitOps owner detection (T2+T3)

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -523,8 +523,11 @@ func handleGetResource(ctx context.Context, req *mcp.CallToolRequest, input getR
 		}
 	}
 
-	// Try typed cache first
+	// Try typed cache first. rawObj is the un-minified resource, threaded
+	// into attachResourceExtras so ManagedBy synthesis can disambiguate by
+	// group (avoids Knative Service vs core Service kind/plural collisions).
 	var resourceData any
+	var rawObj any
 	obj, err := k8s.FetchResource(cache, kind, namespace, name)
 	if err == k8s.ErrUnknownKind {
 		// Fall through to dynamic cache for CRDs
@@ -533,6 +536,7 @@ func handleGetResource(ctx context.Context, req *mcp.CallToolRequest, input getR
 			return nil, nil, fmt.Errorf("resource not found: %w", dynErr)
 		}
 		resourceData = aicontext.MinifyUnstructured(u, aicontext.LevelDetail)
+		rawObj = u
 	} else if err != nil {
 		return nil, nil, fmt.Errorf("resource not found: %w", err)
 	} else {
@@ -542,6 +546,7 @@ func handleGetResource(ctx context.Context, req *mcp.CallToolRequest, input getR
 			return nil, nil, fmt.Errorf("failed to minify: %w", minErr)
 		}
 		resourceData = minified
+		rawObj = obj
 	}
 
 	includes := parseIncludes(input.Include)
@@ -551,13 +556,15 @@ func handleGetResource(ctx context.Context, req *mcp.CallToolRequest, input getR
 
 	// Build enriched response with requested extras
 	result := map[string]any{"resource": resourceData}
-	attachResourceExtras(ctx, cache, result, includes, kind, namespace, name)
+	attachResourceExtras(ctx, cache, result, includes, kind, namespace, name, rawObj)
 	return toJSONResult(result)
 }
 
 // attachResourceExtras populates optional extras (events, relationships, metrics, logs)
-// on the result map based on the includes set.
-func attachResourceExtras(ctx context.Context, cache *k8s.ResourceCache, result map[string]any, includes map[string]bool, kind, namespace, name string) {
+// on the result map based on the includes set. rawObj is the already-fetched
+// resource (typed or *unstructured); passed through so relationship synthesis
+// uses the authoritative object instead of a group-blind kind/name lookup.
+func attachResourceExtras(ctx context.Context, cache *k8s.ResourceCache, result map[string]any, includes map[string]bool, kind, namespace, name string, rawObj any) {
 	if includes["events"] {
 		if eventLister := cache.Events(); eventLister != nil {
 			var events []*corev1.Event
@@ -599,9 +606,9 @@ func attachResourceExtras(ctx context.Context, cache *k8s.ResourceCache, result 
 			log.Printf("[mcp] Failed to build topology for relationships %s/%s/%s: %v", kind, namespace, name, err)
 		} else {
 			displayKind := normalizeDisplayKind(kind)
-			if rels := topology.GetRelationships(displayKind, namespace, name, topo,
+			if rels := topology.GetRelationshipsWithObject(displayKind, namespace, name, rawObj, topo,
 				k8s.NewTopologyResourceProvider(k8s.GetResourceCache()),
-				k8s.NewTopologyDynamicProvider(k8s.GetDynamicResourceCache(), k8s.GetResourceDiscovery())); rels != nil {
+				k8s.NewTopologyDynamicProvider(k8s.GetDynamicResourceCache(), k8s.GetResourceDiscovery()), nil); rels != nil {
 				result["relationships"] = rels
 			}
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1546,12 +1546,14 @@ func (s *Server) handleGetResource(w http.ResponseWriter, r *http.Request) {
 		}
 		setTypeMeta(resource)
 
-		// Get relationships from cached topology
+		// Get relationships from cached topology. Pass the already-fetched
+		// resource so ManagedBy synthesis disambiguates by group (avoids
+		// kind/plural collisions like Knative Service vs core Service).
 		var relationships *topology.Relationships
 		if cachedTopo := s.broadcaster.GetCachedTopology(); cachedTopo != nil {
-			relationships = topology.GetRelationships(kind, namespace, name, cachedTopo,
+			relationships = topology.GetRelationshipsWithObject(kind, namespace, name, resource, cachedTopo,
 				k8s.NewTopologyResourceProvider(k8s.GetResourceCache()),
-				k8s.NewTopologyDynamicProvider(k8s.GetDynamicResourceCache(), k8s.GetResourceDiscovery()))
+				k8s.NewTopologyDynamicProvider(k8s.GetDynamicResourceCache(), k8s.GetResourceDiscovery()), nil)
 		}
 
 		s.writeJSON(w, topology.ResourceWithRelationships{
@@ -1710,12 +1712,14 @@ func (s *Server) handleGetResource(w http.ResponseWriter, r *http.Request) {
 	// Set APIVersion and Kind for typed resources (informers don't populate these)
 	setTypeMeta(resource)
 
-	// Get relationships from cached topology
+	// Get relationships from cached topology. Pass the already-fetched
+	// resource so ManagedBy synthesis uses the authoritative object instead
+	// of a group-blind kind/name lookup.
 	var relationships *topology.Relationships
 	if cachedTopo := s.broadcaster.GetCachedTopology(); cachedTopo != nil {
-		relationships = topology.GetRelationships(kind, namespace, name, cachedTopo,
+		relationships = topology.GetRelationshipsWithObject(kind, namespace, name, resource, cachedTopo,
 			k8s.NewTopologyResourceProvider(k8s.GetResourceCache()),
-			k8s.NewTopologyDynamicProvider(k8s.GetDynamicResourceCache(), k8s.GetResourceDiscovery()))
+			k8s.NewTopologyDynamicProvider(k8s.GetDynamicResourceCache(), k8s.GetResourceDiscovery()), nil)
 	}
 
 	// Return resource with relationships

--- a/packages/k8s-ui/src/components/workload/WorkloadView.tsx
+++ b/packages/k8s-ui/src/components/workload/WorkloadView.tsx
@@ -23,7 +23,7 @@ import {
 import type { TimelineEvent, ResourceRef, Relationships, SelectedResource, ResolvedEnvFrom } from '../../types'
 import type { NavigateToResource } from '../../utils/navigation'
 import { refToSelectedResource, pluralToKind } from '../../utils/navigation'
-import { detectGitOpsOwner, type GitOpsOwnerRef } from '../../utils/gitops-owner'
+import { gitOpsOwnerFromRelationships, type GitOpsOwnerRef } from '../../utils/gitops-owner'
 import { gitOpsRouteForResource } from '../../utils/gitops-route'
 import { isChangeEvent, isHistoricalEvent } from '../../types'
 import { getKindBadgeColor, getHealthBadgeColor } from '../../utils/badge-colors'
@@ -311,7 +311,7 @@ export function WorkloadView({
 
   // Metadata
   const metadata = useMemo(() => extractMetadata(kind, resource), [kind, resource])
-  const gitopsOwner = useMemo(() => detectGitOpsOwner(resource), [resource])
+  const gitopsOwner = useMemo(() => gitOpsOwnerFromRelationships(relationships), [relationships])
   // When the resource itself is a portal GitOps CR (Application, Kustomization,
   // HelmRelease, etc.), surface a link to its dedicated GitOps detail page —
   // the drawer's renderer is thorough but the tab has the tree + insights +

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -415,6 +415,7 @@ export interface ResourceRef {
 export interface Relationships {
   owner?: ResourceRef
   deployment?: ResourceRef   // Grandparent Deployment (for Pods owned by ReplicaSets)
+  managedBy?: ResourceRef[]  // Topmost meaningful manager(s): GitOps controller (ArgoCD Application / Flux Kustomization / Flux HelmRelease), Helm release, or the topmost K8s owner. Synthesized server-side; replaces client-side detectGitOpsOwner.
   children?: ResourceRef[]
   services?: ResourceRef[]
   ingresses?: ResourceRef[]
@@ -427,6 +428,8 @@ export interface Relationships {
   pdbs?: ResourceRef[]              // PodDisruptionBudgets protecting this workload
   networkPolicies?: ResourceRef[]   // NetworkPolicy / CiliumNetworkPolicy / ClusterNetworkPolicy variants selecting this workload
   pods?: ResourceRef[]
+  serviceAccount?: ResourceRef      // For Pods: derived from pod.spec.serviceAccountName
+  node?: ResourceRef                // For scheduled Pods: derived from pod.spec.nodeName
 }
 
 // Parsed X.509 certificate metadata (from backend cert parsing)

--- a/packages/k8s-ui/src/utils/gitops-owner.test.ts
+++ b/packages/k8s-ui/src/utils/gitops-owner.test.ts
@@ -1,136 +1,95 @@
 import { describe, it, expect } from 'vitest'
-import { detectGitOpsOwner } from './gitops-owner'
 
-const FLUX_HELM_NAME = 'helm.toolkit.fluxcd.io/name'
-const FLUX_HELM_NS = 'helm.toolkit.fluxcd.io/namespace'
-const FLUX_KUSTOMIZE_NAME = 'kustomize.toolkit.fluxcd.io/name'
-const FLUX_KUSTOMIZE_NS = 'kustomize.toolkit.fluxcd.io/namespace'
-const ARGO_TRACKING_ID = 'argocd.argoproj.io/tracking-id'
-const ARGO_INSTANCE = 'argocd.argoproj.io/instance'
-const HELM_INSTANCE = 'app.kubernetes.io/instance'
+import type { Relationships } from '../types/core'
 
-function resource(labels: Record<string, string> = {}, annotations: Record<string, string> = {}) {
-  return { metadata: { labels, annotations } }
-}
+import { gitOpsOwnerFromRelationships } from './gitops-owner'
 
-describe('detectGitOpsOwner', () => {
-  it('returns null for non-objects', () => {
-    expect(detectGitOpsOwner(null)).toBeNull()
-    expect(detectGitOpsOwner(undefined)).toBeNull()
-    expect(detectGitOpsOwner('string')).toBeNull()
+describe('gitOpsOwnerFromRelationships', () => {
+  it('returns null when relationships is undefined', () => {
+    expect(gitOpsOwnerFromRelationships(undefined)).toBeNull()
   })
 
-  it('returns null when no GitOps labels/annotations present', () => {
-    expect(detectGitOpsOwner(resource({ app: 'foo' }))).toBeNull()
+  it('returns null when managedBy is absent', () => {
+    expect(gitOpsOwnerFromRelationships({})).toBeNull()
   })
 
-  describe('Flux HelmRelease labels', () => {
-    it('extracts name + namespace', () => {
-      const got = detectGitOpsOwner(resource({
-        [FLUX_HELM_NAME]: 'podinfo',
-        [FLUX_HELM_NS]: 'flux-system',
-      }))
-      expect(got).toEqual({ tool: 'fluxcd', kind: 'helmreleases', namespace: 'flux-system', name: 'podinfo' })
-    })
+  it('returns null when managedBy is empty', () => {
+    expect(gitOpsOwnerFromRelationships({ managedBy: [] })).toBeNull()
+  })
 
-    it('wins over Flux Kustomize labels when both are present (most-direct owner)', () => {
-      const got = detectGitOpsOwner(resource({
-        [FLUX_HELM_NAME]: 'podinfo',
-        [FLUX_HELM_NS]: 'flux-system',
-        [FLUX_KUSTOMIZE_NAME]: 'parent',
-        [FLUX_KUSTOMIZE_NS]: 'flux-system',
-      }))
-      expect(got?.kind).toBe('helmreleases')
-      expect(got?.name).toBe('podinfo')
-    })
-
-    it('requires both name and namespace', () => {
-      expect(detectGitOpsOwner(resource({ [FLUX_HELM_NAME]: 'podinfo' }))).toBeNull()
-      expect(detectGitOpsOwner(resource({ [FLUX_HELM_NS]: 'flux-system' }))).toBeNull()
+  it('maps an ArgoCD Application ref', () => {
+    const rel: Relationships = {
+      managedBy: [{ kind: 'Application', group: 'argoproj.io', namespace: 'argocd', name: 'storefront' }],
+    }
+    expect(gitOpsOwnerFromRelationships(rel)).toEqual({
+      tool: 'argocd',
+      kind: 'applications',
+      namespace: 'argocd',
+      name: 'storefront',
     })
   })
 
-  describe('Flux Kustomize labels', () => {
-    it('extracts name + namespace', () => {
-      const got = detectGitOpsOwner(resource({
-        [FLUX_KUSTOMIZE_NAME]: 'infra',
-        [FLUX_KUSTOMIZE_NS]: 'flux-system',
-      }))
-      expect(got).toEqual({ tool: 'fluxcd', kind: 'kustomizations', namespace: 'flux-system', name: 'infra' })
+  it('maps a Flux Kustomization ref', () => {
+    const rel: Relationships = {
+      managedBy: [{ kind: 'Kustomization', group: 'kustomize.toolkit.fluxcd.io', namespace: 'flux-system', name: 'prod-apps' }],
+    }
+    expect(gitOpsOwnerFromRelationships(rel)).toEqual({
+      tool: 'fluxcd',
+      kind: 'kustomizations',
+      namespace: 'flux-system',
+      name: 'prod-apps',
     })
   })
 
-  describe('Argo tracking-id annotation', () => {
-    it('parses the namespaced form (<ns>_<name>:...)', () => {
-      const got = detectGitOpsOwner(resource({}, {
-        [ARGO_TRACKING_ID]: 'argocd_my-app:apps/Deployment:default/web',
-      }))
-      expect(got).toEqual({ tool: 'argocd', kind: 'applications', namespace: 'argocd', name: 'my-app' })
-    })
-
-    it('parses the legacy single-name form (no underscore)', () => {
-      const got = detectGitOpsOwner(resource({}, {
-        [ARGO_TRACKING_ID]: 'my-app:apps/Deployment:default/web',
-      }))
-      // Empty namespace is the contract — caller defaults / routes accordingly.
-      expect(got).toEqual({ tool: 'argocd', kind: 'applications', namespace: '', name: 'my-app' })
-    })
-
-    it('returns null on a malformed tracking-id (no colon)', () => {
-      const got = detectGitOpsOwner(resource({}, { [ARGO_TRACKING_ID]: 'just-garbage-no-colon' }))
-      // Falls through to label scan; with no labels present, returns null.
-      expect(got).toBeNull()
-    })
-
-    it('returns null on tracking-id with empty name after underscore', () => {
-      const got = detectGitOpsOwner(resource({}, { [ARGO_TRACKING_ID]: 'my-ns_:apps/Deployment:default/web' }))
-      expect(got).toBeNull()
-    })
-
-    it('wins over the bare instance label (most authoritative)', () => {
-      const got = detectGitOpsOwner(resource(
-        { [ARGO_INSTANCE]: 'wrong-app' },
-        { [ARGO_TRACKING_ID]: 'argocd_right-app:apps/Deployment:default/web' },
-      ))
-      expect(got?.name).toBe('right-app')
-      expect(got?.namespace).toBe('argocd')
+  it('maps a Flux HelmRelease ref', () => {
+    const rel: Relationships = {
+      managedBy: [{ kind: 'HelmRelease', group: 'helm.toolkit.fluxcd.io', namespace: 'flux-system', name: 'cert-manager' }],
+    }
+    expect(gitOpsOwnerFromRelationships(rel)).toEqual({
+      tool: 'fluxcd',
+      kind: 'helmreleases',
+      namespace: 'flux-system',
+      name: 'cert-manager',
     })
   })
 
-  describe('Argo instance label fallback', () => {
-    it('extracts name from argocd-specific instance label', () => {
-      const got = detectGitOpsOwner(resource({ [ARGO_INSTANCE]: 'guestbook' }))
-      expect(got).toEqual({ tool: 'argocd', kind: 'applications', namespace: '', name: 'guestbook' })
-    })
-
-    it('does NOT fall back to standard k8s instance label', () => {
-      // app.kubernetes.io/instance is stamped by virtually every Helm chart.
-      // Treating it as an Argo signal produced a false "Managed by <release>"
-      // chip on plain Helm-installed resources, so detection now requires an
-      // Argo-specific signal (tracking-id annotation or argocd.argoproj.io/instance).
-      expect(detectGitOpsOwner(resource({ [HELM_INSTANCE]: 'guestbook-healthy' }))).toBeNull()
-    })
-
-    it('argocd-specific label still wins when both labels present', () => {
-      const got = detectGitOpsOwner(resource({
-        [ARGO_INSTANCE]: 'argo-pick',
-        [HELM_INSTANCE]: 'helm-pick',
-      }))
-      expect(got?.name).toBe('argo-pick')
-    })
+  it('disambiguates Flux HelmRelease from native Helm via API group', () => {
+    // A native Helm release would not carry the helm.toolkit.fluxcd.io group;
+    // server-side SynthesizeManagedBy only assigns that group for Flux.
+    const rel: Relationships = {
+      managedBy: [{ kind: 'HelmRelease', group: 'helm.sh', namespace: 'default', name: 'native-helm' }],
+    }
+    expect(gitOpsOwnerFromRelationships(rel)).toBeNull()
   })
 
-  describe('Flux labels beat Argo annotations', () => {
-    it('Flux HelmRelease wins over Argo tracking-id', () => {
-      const got = detectGitOpsOwner(resource(
-        {
-          [FLUX_HELM_NAME]: 'podinfo',
-          [FLUX_HELM_NS]: 'flux-system',
-        },
-        { [ARGO_TRACKING_ID]: 'argocd_some-app:apps/Deployment:default/web' },
-      ))
-      expect(got?.tool).toBe('fluxcd')
-      expect(got?.kind).toBe('helmreleases')
+  it('returns null for native K8s owners (no GitOps chip)', () => {
+    const rel: Relationships = {
+      managedBy: [{ kind: 'Deployment', namespace: 'prod', name: 'web' }],
+    }
+    expect(gitOpsOwnerFromRelationships(rel)).toBeNull()
+  })
+
+  it('returns null for an unrecognized manager kind', () => {
+    const rel: Relationships = {
+      managedBy: [{ kind: 'CustomController', group: 'example.com', namespace: 'prod', name: 'thing' }],
+    }
+    expect(gitOpsOwnerFromRelationships(rel)).toBeNull()
+  })
+
+  it('only considers the first managedBy entry', () => {
+    // The server emits the topmost meaningful manager first; if there are
+    // multiple, downstream chips intentionally only render the primary.
+    const rel: Relationships = {
+      managedBy: [
+        { kind: 'Application', group: 'argoproj.io', namespace: 'argocd', name: 'primary' },
+        { kind: 'Kustomization', group: 'kustomize.toolkit.fluxcd.io', namespace: 'flux-system', name: 'secondary' },
+      ],
+    }
+    expect(gitOpsOwnerFromRelationships(rel)).toEqual({
+      tool: 'argocd',
+      kind: 'applications',
+      namespace: 'argocd',
+      name: 'primary',
     })
   })
 })

--- a/packages/k8s-ui/src/utils/gitops-owner.ts
+++ b/packages/k8s-ui/src/utils/gitops-owner.ts
@@ -1,13 +1,12 @@
-// Detect whether a Kubernetes resource is managed by a GitOps controller
-// (ArgoCD or FluxCD) and return a navigable ref to its owning GitOps CR so the
-// drawer can render a "Managed by <app>" affordance.
+// Map a resource's server-side `Relationships.managedBy` to a navigable
+// GitOps owner ref, used by the drawer to render the "Managed by <app>" chip.
 //
-// Precedence (most-specific wins):
-//   1. Flux HelmRelease labels
-//   2. Flux Kustomize labels
-//   3. Argo tracking-id annotation
-//   4. Argo-specific instance label
-//   5. Standard k8s instance label (best-effort; false positives possible)
+// The detection (label/annotation parsing, Argo tracking-id decoding, Flux
+// label inspection, Helm release annotation, owner-chain walk) lives server-
+// side in pkg/topology.SynthesizeManagedBy. This file is now a thin mapper
+// from the structured ref into the discriminated union the chip + router need.
+
+import type { Relationships, ResourceRef } from '../types/core'
 
 // GitOpsOwnerRef is a discriminated union — the tool determines which kind is
 // valid. Modeling it this way prevents callers (and consumers of the returned
@@ -20,73 +19,37 @@ export type GitOpsOwnerRef =
 // Vocabulary mirrors `pkg/gitops/tree.Tool` so the wire labels match end-to-end.
 export type GitOpsOwnerTool = GitOpsOwnerRef['tool']
 
-const ARGO_TRACKING_ID_ANNOTATION = 'argocd.argoproj.io/tracking-id'
-const ARGO_INSTANCE_LABEL = 'argocd.argoproj.io/instance'
-// app.kubernetes.io/instance is intentionally NOT a fallback signal here.
-// It's the standard k8s recommended label and stamped by virtually every
-// Helm chart in existence, not just Argo. Treating it as an Argo ownership
-// hint produced false positives on plain Helm-installed resources, which
-// surfaced as a misleading "Managed by <release>" chip on ordinary workload
-// drawers. Argo installs that rely on this default can still be detected
-// via the tracking-id annotation; the `argocd.argoproj.io/instance` label
-// (above) covers Argo deployments that explicitly set their own label key.
+// API groups for GitOps manager kinds. Used to disambiguate Flux HelmRelease
+// from a future native-Helm kind, etc.
+const ARGO_APPLICATION_GROUP = 'argoproj.io'
+const FLUX_KUSTOMIZE_GROUP = 'kustomize.toolkit.fluxcd.io'
+const FLUX_HELM_GROUP = 'helm.toolkit.fluxcd.io'
 
-const FLUX_KUSTOMIZE_NAME = 'kustomize.toolkit.fluxcd.io/name'
-const FLUX_KUSTOMIZE_NS = 'kustomize.toolkit.fluxcd.io/namespace'
-const FLUX_HELM_NAME = 'helm.toolkit.fluxcd.io/name'
-const FLUX_HELM_NS = 'helm.toolkit.fluxcd.io/namespace'
-
-export function detectGitOpsOwner(resource: unknown): GitOpsOwnerRef | null {
-  if (!resource || typeof resource !== 'object') return null
-  const meta = (resource as { metadata?: { labels?: Record<string, string>; annotations?: Record<string, string> } }).metadata
-  const labels = meta?.labels ?? {}
-  const annotations = meta?.annotations ?? {}
-
-  const helmName = labels[FLUX_HELM_NAME]
-  const helmNs = labels[FLUX_HELM_NS]
-  if (helmName && helmNs) {
-    return { tool: 'fluxcd', kind: 'helmreleases', namespace: helmNs, name: helmName }
-  }
-  const kustName = labels[FLUX_KUSTOMIZE_NAME]
-  const kustNs = labels[FLUX_KUSTOMIZE_NS]
-  if (kustName && kustNs) {
-    return { tool: 'fluxcd', kind: 'kustomizations', namespace: kustNs, name: kustName }
-  }
-
-  const trackingID = annotations[ARGO_TRACKING_ID_ANNOTATION]
-  if (trackingID) {
-    const parsed = parseArgoTrackingID(trackingID)
-    if (parsed) {
-      return { tool: 'argocd', kind: 'applications', namespace: parsed.namespace, name: parsed.name }
-    }
-  }
-
-  const instance = labels[ARGO_INSTANCE_LABEL]
-  if (instance) {
-    // App namespace unknown without tracking-id; emit empty so the consumer can
-    // either skip the link or default to a well-known namespace.
-    return { tool: 'argocd', kind: 'applications', namespace: '', name: instance }
-  }
-
-  return null
+// gitOpsOwnerFromRelationships reads relationships.managedBy[0] and maps it to
+// a GitOpsOwnerRef when the manager is a GitOps controller. Returns null when
+// the manager is a native K8s owner (Deployment, ReplicaSet, etc.), a plain
+// Helm release, or when no manager is reported.
+//
+// Old radar binaries (pre-T2) emit no managedBy field; this returns null in
+// that case and the drawer silently skips the chip — natural pressure to
+// upgrade rather than carry a label-parsing fallback in the client.
+export function gitOpsOwnerFromRelationships(
+  rel: Relationships | undefined | null,
+): GitOpsOwnerRef | null {
+  const refs = rel?.managedBy
+  if (!refs || refs.length === 0) return null
+  return refToGitOpsOwner(refs[0])
 }
 
-// Argo CD writes its tracking-id in one of two forms depending on whether
-// installationID / namespaced-install is configured:
-//   "<appName>:<group>/<kind>:<resourceNs>/<resourceName>"                   default
-//   "<appNamespace>_<appName>:<group>/<kind>:<resourceNs>/<resourceName>"    namespaced install
-// We accept both. The legacy single-name form yields an empty namespace so the
-// caller can route to a "find this app" search instead of guessing.
-function parseArgoTrackingID(value: string): { namespace: string; name: string } | null {
-  const firstColon = value.indexOf(':')
-  if (firstColon < 0) return null
-  const head = value.slice(0, firstColon)
-  const sep = head.indexOf('_')
-  if (sep < 0) {
-    return head ? { namespace: '', name: head } : null
+function refToGitOpsOwner(ref: ResourceRef): GitOpsOwnerRef | null {
+  switch (true) {
+    case ref.kind === 'Application' && ref.group === ARGO_APPLICATION_GROUP:
+      return { tool: 'argocd', kind: 'applications', namespace: ref.namespace, name: ref.name }
+    case ref.kind === 'Kustomization' && ref.group === FLUX_KUSTOMIZE_GROUP:
+      return { tool: 'fluxcd', kind: 'kustomizations', namespace: ref.namespace, name: ref.name }
+    case ref.kind === 'HelmRelease' && ref.group === FLUX_HELM_GROUP:
+      return { tool: 'fluxcd', kind: 'helmreleases', namespace: ref.namespace, name: ref.name }
+    default:
+      return null
   }
-  const namespace = head.slice(0, sep)
-  const name = head.slice(sep + 1)
-  if (!name) return null
-  return { namespace, name }
 }

--- a/pkg/topology/index_test.go
+++ b/pkg/topology/index_test.go
@@ -1,0 +1,100 @@
+package topology
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestIndexByResource_EquivalentToLinearScan pins the contract that the
+// inverted index returns the same set of edges as an inline linear scan over
+// topo.Edges. This is the load-bearing invariant for the perf path: T6 and
+// T12 will pass the index instead of nil, and any divergence between the two
+// paths would surface as wrong relationships.
+func TestIndexByResource_EquivalentToLinearScan(t *testing.T) {
+	topo := buildSyntheticTopology(500)
+	idx := IndexByResource(topo)
+
+	for _, n := range topo.Nodes {
+		incIdx, outIdx := idx.EdgesFor(n.ID)
+		var incLin, outLin []Edge
+		for _, e := range topo.Edges {
+			if e.Source == n.ID {
+				outLin = append(outLin, e)
+			}
+			if e.Target == n.ID {
+				incLin = append(incLin, e)
+			}
+		}
+		if !edgesEqual(incIdx, incLin) {
+			t.Errorf("node %s: incoming edges differ; index=%v linear=%v", n.ID, incIdx, incLin)
+		}
+		if !edgesEqual(outIdx, outLin) {
+			t.Errorf("node %s: outgoing edges differ; index=%v linear=%v", n.ID, outIdx, outLin)
+		}
+	}
+}
+
+func TestIndexByResource_NilTopologySafe(t *testing.T) {
+	idx := IndexByResource(nil)
+	if idx == nil {
+		t.Fatal("IndexByResource(nil) returned nil; want non-nil empty index")
+	}
+	inc, out := idx.EdgesFor("anything")
+	if inc != nil || out != nil {
+		t.Errorf("EdgesFor on empty index should return nil/nil, got inc=%v out=%v", inc, out)
+	}
+}
+
+func TestRelationshipsIndex_NilReceiver(t *testing.T) {
+	var idx *RelationshipsIndex
+	inc, out := idx.EdgesFor("any")
+	if inc != nil || out != nil {
+		t.Errorf("nil receiver EdgesFor should return nil/nil, got inc=%v out=%v", inc, out)
+	}
+}
+
+// TestGetRelationshipsWithIndex_MatchesUnindexed pins the back-compat
+// contract: passing a non-nil index must yield identical output to the inline
+// scan. If this drifts, T6/T12 callers (using the index) will silently see
+// different relationships than REST users (using GetRelationships).
+func TestGetRelationshipsWithIndex_MatchesUnindexed(t *testing.T) {
+	topo := buildSyntheticTopology(500)
+	idx := IndexByResource(topo)
+
+	cases := []struct {
+		kind, ns, name string
+	}{
+		{"Deployment", "ns-0", "app-0"},
+		{"Pod", "ns-0", "app-0-pod-0"},
+		{"Service", "ns-0", "app-0-svc"},
+		{"ConfigMap", "ns-0", "app-0-config"},
+		{"PodDisruptionBudget", "ns-0", "app-0-pdb"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.kind, func(t *testing.T) {
+			plain := GetRelationships(c.kind, c.ns, c.name, topo, nil, nil)
+			indexed := GetRelationshipsWithIndex(c.kind, c.ns, c.name, topo, nil, nil, idx)
+			if !reflect.DeepEqual(plain, indexed) {
+				t.Errorf("%s/%s/%s: indexed result differs from unindexed\n plain:   %+v\n indexed: %+v",
+					c.kind, c.ns, c.name, plain, indexed)
+			}
+		})
+	}
+}
+
+// edgesEqual treats slice ordering as significant — IndexByResource preserves
+// the original iteration order over topo.Edges, so an order-sensitive
+// comparison catches accidental reordering that would alter "first wins"
+// semantics in GetRelationships (e.g. rel.Owner).
+func edgesEqual(a, b []Edge) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/topology/managedby.go
+++ b/pkg/topology/managedby.go
@@ -195,8 +195,11 @@ func walkTopmostOwner(kind, namespace, name string, topo *Topology, dp DynamicPr
 		ownerOf = func(target string) string { return owners[target] }
 	}
 
-	visited := make(map[string]bool)
+	// Seed visited with the starting node so a cycle that loops back to the
+	// queried resource (A→B→A) returns the first found owner (B) instead of
+	// walking one extra hop and producing a self-referential ManagedBy ref.
 	cur := buildNodeID(kind, namespace, name, dp)
+	visited := map[string]bool{cur: true}
 	var topRef *ResourceRef
 	for {
 		next := ownerOf(cur)

--- a/pkg/topology/managedby.go
+++ b/pkg/topology/managedby.go
@@ -41,8 +41,14 @@ const (
 // owner references via the topology graph. If obj is nil, only the topology
 // owner walk runs.
 //
+// idx is the topology inverted edges index. When non-nil, the owner walk
+// uses it for O(depth) lookup; when nil, the walk falls back to scanning
+// topo.Edges (O(E) per call). High-fanout callers (T6/T89/T12 list/search
+// enrichment) MUST pass a shared index — without it, the per-row managed-by
+// path is O(N × E).
+//
 // Returns nil when no meaningful manager is detectable.
-func SynthesizeManagedBy(obj metav1.Object, kind, namespace, name string, topo *Topology, dp DynamicProvider) []ResourceRef {
+func SynthesizeManagedBy(obj metav1.Object, kind, namespace, name string, topo *Topology, dp DynamicProvider, idx *RelationshipsIndex) []ResourceRef {
 	if ref := detectManagedByFromMeta(obj); ref != nil {
 		// detectManagedByFromMeta hand-sets Group for GitOps/Flux managers; do
 		// NOT call enrichRef here — it would overwrite the deliberate group
@@ -51,7 +57,7 @@ func SynthesizeManagedBy(obj metav1.Object, kind, namespace, name string, topo *
 		// native Helm.
 		return []ResourceRef{*ref}
 	}
-	if top := walkTopmostOwner(kind, namespace, name, topo, dp); top != nil {
+	if top := walkTopmostOwner(kind, namespace, name, topo, dp, idx); top != nil {
 		return []ResourceRef{*top}
 	}
 	return nil
@@ -149,29 +155,52 @@ func parseArgoTrackingID(value string) (namespace, name string, ok bool) {
 // until no further owner exists, returning the topmost ancestor's ResourceRef.
 // Returns nil when the queried resource has no owner in the topology. Cycle-
 // safe: stops at the first revisit.
-func walkTopmostOwner(kind, namespace, name string, topo *Topology, dp DynamicProvider) *ResourceRef {
+//
+// When idx is non-nil, each step is an O(in-degree) hop via the inverted edge
+// index, making the whole walk O(depth × avg-in-degree). When idx is nil, the
+// function falls back to scanning topo.Edges once to build a transient owners
+// map (O(E)) — fine for single-resource calls, but high-fanout callers
+// (list/search enrichment) MUST pass a shared index to avoid O(N × E).
+func walkTopmostOwner(kind, namespace, name string, topo *Topology, dp DynamicProvider, idx *RelationshipsIndex) *ResourceRef {
 	if topo == nil {
 		return nil
 	}
-	// target -> source for EdgeManages edges. Multiple owners are rare in
-	// practice (K8s allows multiple ownerReferences but only one controller);
+
+	// Owner lookup for the current node: returns the source ID of the first
+	// EdgeManages edge pointing at it, or "" if none. Multiple owners are
+	// rare (K8s allows multiple ownerReferences but only one controller);
 	// the first wins, matching ownerReferences[].controller==true semantics.
-	owners := make(map[string]string, len(topo.Edges))
-	for _, e := range topo.Edges {
-		if e.Type != EdgeManages {
-			continue
+	var ownerOf func(target string) string
+	if idx != nil {
+		ownerOf = func(target string) string {
+			incoming, _ := idx.EdgesFor(target)
+			for _, e := range incoming {
+				if e.Type == EdgeManages {
+					return e.Source
+				}
+			}
+			return ""
 		}
-		if _, exists := owners[e.Target]; !exists {
-			owners[e.Target] = e.Source
+	} else {
+		// Fallback: one-time O(E) scan to build target->source map.
+		owners := make(map[string]string, len(topo.Edges))
+		for _, e := range topo.Edges {
+			if e.Type != EdgeManages {
+				continue
+			}
+			if _, exists := owners[e.Target]; !exists {
+				owners[e.Target] = e.Source
+			}
 		}
+		ownerOf = func(target string) string { return owners[target] }
 	}
 
 	visited := make(map[string]bool)
 	cur := buildNodeID(kind, namespace, name, dp)
 	var topRef *ResourceRef
 	for {
-		next, ok := owners[cur]
-		if !ok {
+		next := ownerOf(cur)
+		if next == "" {
 			break
 		}
 		if visited[next] {

--- a/pkg/topology/managedby.go
+++ b/pkg/topology/managedby.go
@@ -1,0 +1,190 @@
+package topology
+
+import (
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GitOps / Helm ownership signal keys. Detection precedence mirrors
+// packages/k8s-ui/src/utils/gitops-owner.ts so server-side ManagedBy synthesis
+// agrees with the legacy client-side derivation. T14 retires the frontend copy
+// once UI consumes Relationships.ManagedBy from the server.
+const (
+	argoTrackingIDAnnotation = "argocd.argoproj.io/tracking-id"
+	argoInstanceLabel        = "argocd.argoproj.io/instance"
+	fluxKustomizeNameLabel   = "kustomize.toolkit.fluxcd.io/name"
+	fluxKustomizeNSLabel     = "kustomize.toolkit.fluxcd.io/namespace"
+	fluxHelmNameLabel        = "helm.toolkit.fluxcd.io/name"
+	fluxHelmNSLabel          = "helm.toolkit.fluxcd.io/namespace"
+	helmReleaseNameAnno      = "meta.helm.sh/release-name"
+	helmReleaseNSAnno        = "meta.helm.sh/release-namespace"
+)
+
+// API groups for the synthesized manager refs.
+const (
+	argoApplicationGroup = "argoproj.io"
+	fluxKustomizeGroup   = "kustomize.toolkit.fluxcd.io"
+	fluxHelmGroup        = "helm.toolkit.fluxcd.io"
+)
+
+// SynthesizeManagedBy returns the topmost meaningful manager(s) for the given
+// resource. Detection order returns on the first hit:
+//  1. Flux HelmRelease via helm.toolkit.fluxcd.io/{name,namespace} labels
+//  2. Flux Kustomization via kustomize.toolkit.fluxcd.io/{name,namespace} labels
+//  3. ArgoCD Application via argocd.argoproj.io/tracking-id annotation
+//  4. ArgoCD Application via argocd.argoproj.io/instance label
+//  5. Helm release via meta.helm.sh/release-name annotation
+//  6. Topmost K8s owner via topology EdgeManages chain (Pod -> ReplicaSet -> Deployment)
+//
+// Cases 1-5 inspect the queried resource's own labels/annotations. Case 6 walks
+// owner references via the topology graph. If obj is nil, only the topology
+// owner walk runs.
+//
+// Returns nil when no meaningful manager is detectable.
+func SynthesizeManagedBy(obj metav1.Object, kind, namespace, name string, topo *Topology, dp DynamicProvider) []ResourceRef {
+	if ref := detectManagedByFromMeta(obj); ref != nil {
+		// detectManagedByFromMeta hand-sets Group for GitOps/Flux managers; do
+		// NOT call enrichRef here — it would overwrite the deliberate group
+		// with the result of a dp lookup keyed on the manager kind, which
+		// resolves wrong for cross-group kinds like Flux's HelmRelease vs
+		// native Helm.
+		return []ResourceRef{*ref}
+	}
+	if top := walkTopmostOwner(kind, namespace, name, topo, dp); top != nil {
+		return []ResourceRef{*top}
+	}
+	return nil
+}
+
+// detectManagedByFromMeta inspects labels/annotations on obj for GitOps / Helm
+// ownership signals and returns the implied manager ref. Returns nil if no
+// signal is present. Mirrors detectGitOpsOwner precedence in the web package.
+func detectManagedByFromMeta(obj metav1.Object) *ResourceRef {
+	if obj == nil {
+		return nil
+	}
+	labels := obj.GetLabels()
+	annos := obj.GetAnnotations()
+
+	if name, ns := labels[fluxHelmNameLabel], labels[fluxHelmNSLabel]; name != "" && ns != "" {
+		return &ResourceRef{
+			Kind:      "HelmRelease",
+			Group:     fluxHelmGroup,
+			Namespace: ns,
+			Name:      name,
+		}
+	}
+	if name, ns := labels[fluxKustomizeNameLabel], labels[fluxKustomizeNSLabel]; name != "" && ns != "" {
+		return &ResourceRef{
+			Kind:      "Kustomization",
+			Group:     fluxKustomizeGroup,
+			Namespace: ns,
+			Name:      name,
+		}
+	}
+
+	if id := annos[argoTrackingIDAnnotation]; id != "" {
+		if ns, n, ok := parseArgoTrackingID(id); ok {
+			return &ResourceRef{
+				Kind:      "Application",
+				Group:     argoApplicationGroup,
+				Namespace: ns,
+				Name:      n,
+			}
+		}
+	}
+	if n := labels[argoInstanceLabel]; n != "" {
+		return &ResourceRef{
+			Kind:      "Application",
+			Group:     argoApplicationGroup,
+			Namespace: "",
+			Name:      n,
+		}
+	}
+
+	if n := annos[helmReleaseNameAnno]; n != "" {
+		// Helm releases are stored as Secrets in the release namespace; ref
+		// kind "HelmRelease" here is the *logical* Helm install, not the Flux
+		// HelmRelease CR. Group left empty to distinguish from Flux's CR.
+		return &ResourceRef{
+			Kind:      "HelmRelease",
+			Namespace: annos[helmReleaseNSAnno],
+			Name:      n,
+		}
+	}
+
+	return nil
+}
+
+// parseArgoTrackingID parses ArgoCD's tracking-id annotation in either format:
+//
+//	"<appName>:<group>/<kind>:<resourceNs>/<resourceName>"               (default)
+//	"<appNamespace>_<appName>:<group>/<kind>:<resourceNs>/<resourceName>" (namespaced)
+//
+// Returns (namespace, name, ok). The legacy single-name form yields an empty
+// namespace — callers route to a search or skip the link.
+func parseArgoTrackingID(value string) (namespace, name string, ok bool) {
+	firstColon := strings.Index(value, ":")
+	if firstColon < 0 {
+		return "", "", false
+	}
+	head := value[:firstColon]
+	sep := strings.Index(head, "_")
+	if sep < 0 {
+		if head == "" {
+			return "", "", false
+		}
+		return "", head, true
+	}
+	ns := head[:sep]
+	n := head[sep+1:]
+	if n == "" {
+		return "", "", false
+	}
+	return ns, n, true
+}
+
+// walkTopmostOwner follows EdgeManages edges upward from the queried node
+// until no further owner exists, returning the topmost ancestor's ResourceRef.
+// Returns nil when the queried resource has no owner in the topology. Cycle-
+// safe: stops at the first revisit.
+func walkTopmostOwner(kind, namespace, name string, topo *Topology, dp DynamicProvider) *ResourceRef {
+	if topo == nil {
+		return nil
+	}
+	// target -> source for EdgeManages edges. Multiple owners are rare in
+	// practice (K8s allows multiple ownerReferences but only one controller);
+	// the first wins, matching ownerReferences[].controller==true semantics.
+	owners := make(map[string]string, len(topo.Edges))
+	for _, e := range topo.Edges {
+		if e.Type != EdgeManages {
+			continue
+		}
+		if _, exists := owners[e.Target]; !exists {
+			owners[e.Target] = e.Source
+		}
+	}
+
+	visited := make(map[string]bool)
+	cur := buildNodeID(kind, namespace, name, dp)
+	var topRef *ResourceRef
+	for {
+		next, ok := owners[cur]
+		if !ok {
+			break
+		}
+		if visited[next] {
+			break
+		}
+		visited[next] = true
+		ref := parseNodeID(next, dp)
+		if ref == nil {
+			break
+		}
+		enrichRef(ref, dp)
+		topRef = ref
+		cur = next
+	}
+	return topRef
+}

--- a/pkg/topology/managedby_test.go
+++ b/pkg/topology/managedby_test.go
@@ -227,10 +227,11 @@ func TestSynthesizeManagedBy_LabelsBeatTopologyWalk(t *testing.T) {
 }
 
 // TestSynthesizeManagedBy_CycleSafe pins behavior on a self-referential
-// EdgeManages chain. Without the visited-set guard, walkTopmostOwner would
-// loop forever. Such a cycle is impossible from real K8s ownerReferences
-// (single controller, parent set before child) but a corrupted topology
-// should degrade gracefully rather than hang.
+// EdgeManages chain. The walk must terminate AND must not return the
+// starting node itself (which would produce a self-referential ManagedBy).
+// Such a cycle is impossible from real K8s ownerReferences (single
+// controller, parent set before child) but a corrupted topology should
+// degrade gracefully — returning the first found owner, not self.
 func TestSynthesizeManagedBy_CycleSafe(t *testing.T) {
 	topo := &Topology{
 		Nodes: []Node{
@@ -243,9 +244,14 @@ func TestSynthesizeManagedBy_CycleSafe(t *testing.T) {
 		},
 	}
 	got := SynthesizeManagedBy(nil, "Deployment", "demo", "a", topo, nil, nil)
-	// Either ref is acceptable — the test only asserts termination + a non-nil ref.
 	if len(got) != 1 {
 		t.Fatalf("want 1 manager ref under cycle, got %d (%+v)", len(got), got)
+	}
+	if got[0].Name == "a" {
+		t.Errorf("walkTopmostOwner returned the starting node as its own owner: %+v", got[0])
+	}
+	if got[0].Name != "b" {
+		t.Errorf("want first found owner b, got %+v", got[0])
 	}
 }
 
@@ -272,13 +278,20 @@ func TestGetRelationships_BackCompat_PDBManagedByPreserved(t *testing.T) {
 	provider := &stubProvider{pdbs: []*policyv1.PodDisruptionBudget{pdb}}
 	topo := &Topology{Nodes: []Node{{ID: "poddisruptionbudget/prod/api-pdb", Kind: KindPDB, Name: "api-pdb"}}}
 
-	rel := GetRelationships("PodDisruptionBudget", "prod", "api-pdb", topo, provider, nil)
-	if rel == nil || len(rel.ManagedBy) != 1 {
-		t.Fatalf("want 1 ManagedBy ref for PDB with Argo annotation via back-compat path, got %+v", rel)
-	}
-	got := rel.ManagedBy[0]
-	if got.Kind != "Application" || got.Namespace != "argocd" || got.Name != "storefront" {
-		t.Errorf("want Argo Application/argocd/storefront from PDB annotation, got %+v", got)
+	// Long-form and short-form aliases must both surface the chip; production
+	// callers and back-compat callers can pass either, matching the other
+	// switches in this file (storage chain) and server.go's kind resolution.
+	for _, kind := range []string{"PodDisruptionBudget", "poddisruptionbudgets", "pdb", "pdbs"} {
+		t.Run(kind, func(t *testing.T) {
+			rel := GetRelationships(kind, "prod", "api-pdb", topo, provider, nil)
+			if rel == nil || len(rel.ManagedBy) != 1 {
+				t.Fatalf("want 1 ManagedBy ref for PDB via kind=%q, got %+v", kind, rel)
+			}
+			got := rel.ManagedBy[0]
+			if got.Kind != "Application" || got.Namespace != "argocd" || got.Name != "storefront" {
+				t.Errorf("want Argo Application/argocd/storefront via kind=%q, got %+v", kind, got)
+			}
+		})
 	}
 }
 

--- a/pkg/topology/managedby_test.go
+++ b/pkg/topology/managedby_test.go
@@ -248,6 +248,59 @@ func TestSynthesizeManagedBy_CycleSafe(t *testing.T) {
 	}
 }
 
+// TestGetRelationshipsWithObject_KindCollision_DisambiguatesByObject pins the
+// reviewer's blocker on PR #720: a CRD whose plural collides with a core
+// resource (Knative serving.knative.dev/Service vs core/v1 Service) MUST
+// surface ManagedBy from the CRD's annotations, not from a co-named core
+// Service that happens to share the namespace/name. The old kind/name-based
+// lookup picked the core Service (no annotation) and silently dropped the
+// chip; the new caller-passes-obj path uses the authoritative resource.
+func TestGetRelationshipsWithObject_KindCollision_DisambiguatesByObject(t *testing.T) {
+	knativeGVR := schema.GroupVersionResource{Group: "serving.knative.dev", Version: "v1", Resource: "services"}
+	knativeSvc := &unstructured.Unstructured{}
+	knativeSvc.SetGroupVersionKind(schema.GroupVersionKind{Group: "serving.knative.dev", Version: "v1", Kind: "Service"})
+	knativeSvc.SetNamespace("prod")
+	knativeSvc.SetName("api")
+	knativeSvc.SetAnnotations(map[string]string{
+		argoTrackingIDAnnotation: "argocd_storefront:serving.knative.dev/Service:prod/api",
+	})
+
+	// Core Service shares ns/name and has NO managed-by signal. With the
+	// old kind/name-only lookup path this was what lookupTypedMetadata
+	// returned first, masking the Knative annotation.
+	coreSvc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "prod", Name: "api"}}
+	provider := &stubProvider{services: []*corev1.Service{coreSvc}}
+	dp := &stubDP{
+		gvr: map[string]schema.GroupVersionResource{
+			"service":  knativeGVR,
+			"services": knativeGVR,
+		},
+		obj: map[string]*unstructured.Unstructured{"prod/api": knativeSvc},
+	}
+	topo := &Topology{Nodes: []Node{{ID: "service/prod/api", Kind: KindService, Name: "api"}}}
+
+	// New canonical path: caller passes the authoritative CRD object.
+	rel := GetRelationshipsWithObject("Service", "prod", "api", knativeSvc, topo, provider, dp, nil)
+	if rel == nil || len(rel.ManagedBy) != 1 {
+		t.Fatalf("want 1 ManagedBy ref via caller-passed CRD obj, got %+v", rel)
+	}
+	got := rel.ManagedBy[0]
+	if got.Kind != "Application" || got.Namespace != "argocd" || got.Name != "storefront" {
+		t.Errorf("want Argo Application/argocd/storefront from CRD annotation, got %+v", got)
+	}
+
+	// Back-compat path (obj=nil): the fallback hits the core Service first
+	// via lookupTypedMetadata and produces no ManagedBy. This pins the
+	// collision behavior — callers that want correctness MUST migrate to
+	// GetRelationshipsWithObject. If this assertion ever flips, the
+	// fallback path has been made group-aware and the migration note in
+	// the back-compat doc should be revisited.
+	relFallback := GetRelationshipsWithIndex("Service", "prod", "api", topo, provider, dp, nil)
+	if relFallback != nil && len(relFallback.ManagedBy) > 0 {
+		t.Errorf("back-compat path unexpectedly produced ManagedBy from CRD annotation: %+v — fallback should still be group-blind; if this now works, update the doc on GetRelationships", relFallback.ManagedBy)
+	}
+}
+
 // TestGetRelationships_CRD_ManagedByPreserved is the regression for the
 // silent-disappear bug the reviewer flagged on #720: a CRD resource (e.g.
 // cert-manager Certificate) with an ArgoCD tracking-id annotation must still

--- a/pkg/topology/managedby_test.go
+++ b/pkg/topology/managedby_test.go
@@ -1,0 +1,216 @@
+package topology
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func meta(labels, annos map[string]string) metav1.Object {
+	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Labels: labels, Annotations: annos}}
+}
+
+// TestSynthesizeManagedBy_LabelsAndAnnotations covers precedence rules that
+// mirror packages/k8s-ui/src/utils/gitops-owner.ts. The test order is the
+// detection order — a stable contract because T14 will retire the frontend
+// copy and assert equivalence.
+func TestSynthesizeManagedBy_LabelsAndAnnotations(t *testing.T) {
+	cases := []struct {
+		name     string
+		labels   map[string]string
+		annos    map[string]string
+		wantKind string
+		wantNS   string
+		wantName string
+		wantGrp  string
+	}{
+		{
+			name:     "Flux HelmRelease labels",
+			labels:   map[string]string{fluxHelmNameLabel: "podinfo", fluxHelmNSLabel: "flux-system"},
+			wantKind: "HelmRelease", wantNS: "flux-system", wantName: "podinfo", wantGrp: fluxHelmGroup,
+		},
+		{
+			name: "Flux HelmRelease wins over Flux Kustomization",
+			labels: map[string]string{
+				fluxHelmNameLabel:      "podinfo",
+				fluxHelmNSLabel:        "flux-system",
+				fluxKustomizeNameLabel: "infra",
+				fluxKustomizeNSLabel:   "flux-system",
+			},
+			wantKind: "HelmRelease", wantName: "podinfo", wantGrp: fluxHelmGroup, wantNS: "flux-system",
+		},
+		{
+			name:     "Flux Kustomization labels",
+			labels:   map[string]string{fluxKustomizeNameLabel: "infra", fluxKustomizeNSLabel: "flux-system"},
+			wantKind: "Kustomization", wantNS: "flux-system", wantName: "infra", wantGrp: fluxKustomizeGroup,
+		},
+		{
+			name: "Flux labels beat Argo tracking-id",
+			labels: map[string]string{
+				fluxHelmNameLabel: "podinfo",
+				fluxHelmNSLabel:   "flux-system",
+			},
+			annos:    map[string]string{argoTrackingIDAnnotation: "argocd_other-app:apps/Deployment:default/web"},
+			wantKind: "HelmRelease", wantName: "podinfo", wantGrp: fluxHelmGroup, wantNS: "flux-system",
+		},
+		{
+			name:     "Argo tracking-id namespaced form",
+			annos:    map[string]string{argoTrackingIDAnnotation: "argocd_my-app:apps/Deployment:default/web"},
+			wantKind: "Application", wantNS: "argocd", wantName: "my-app", wantGrp: argoApplicationGroup,
+		},
+		{
+			name:     "Argo tracking-id legacy single-name form yields empty namespace",
+			annos:    map[string]string{argoTrackingIDAnnotation: "my-app:apps/Deployment:default/web"},
+			wantKind: "Application", wantNS: "", wantName: "my-app", wantGrp: argoApplicationGroup,
+		},
+		{
+			name:     "Argo instance label fallback",
+			labels:   map[string]string{argoInstanceLabel: "guestbook"},
+			wantKind: "Application", wantNS: "", wantName: "guestbook", wantGrp: argoApplicationGroup,
+		},
+		{
+			name:     "Argo tracking-id beats instance label",
+			labels:   map[string]string{argoInstanceLabel: "wrong"},
+			annos:    map[string]string{argoTrackingIDAnnotation: "argocd_right:apps/Deployment:default/web"},
+			wantKind: "Application", wantNS: "argocd", wantName: "right", wantGrp: argoApplicationGroup,
+		},
+		{
+			name:     "Helm release annotation",
+			annos:    map[string]string{helmReleaseNameAnno: "cert-manager", helmReleaseNSAnno: "cert-manager"},
+			wantKind: "HelmRelease", wantNS: "cert-manager", wantName: "cert-manager", wantGrp: "",
+		},
+		{
+			// app.kubernetes.io/instance is stamped by every Helm chart and was
+			// the legacy false-positive trigger for "Managed by …" chips on
+			// plain Helm installs. Frontend dropped it; we don't fall back on it.
+			name:   "standard k8s instance label is NOT treated as Argo",
+			labels: map[string]string{"app.kubernetes.io/instance": "guestbook-healthy"},
+		},
+		{
+			name: "no signals returns no manager",
+		},
+		{
+			name:   "Flux HelmRelease requires both name and namespace labels",
+			labels: map[string]string{fluxHelmNameLabel: "podinfo"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := SynthesizeManagedBy(meta(c.labels, c.annos), "Deployment", "default", "web", nil, nil)
+			if c.wantKind == "" {
+				if got != nil {
+					t.Fatalf("want nil ManagedBy, got %+v", got)
+				}
+				return
+			}
+			if len(got) != 1 {
+				t.Fatalf("want 1 manager ref, got %d (%+v)", len(got), got)
+			}
+			r := got[0]
+			if r.Kind != c.wantKind || r.Namespace != c.wantNS || r.Name != c.wantName || r.Group != c.wantGrp {
+				t.Errorf("want {Kind:%q Group:%q NS:%q Name:%q}, got %+v",
+					c.wantKind, c.wantGrp, c.wantNS, c.wantName, r)
+			}
+		})
+	}
+}
+
+// TestSynthesizeManagedBy_TopologyOwnerChain verifies the case-6 fallback:
+// when no GitOps/Helm signals are on the resource itself, we walk the
+// EdgeManages chain in topology to the topmost ancestor. Pod -> ReplicaSet ->
+// Deployment yields the Deployment.
+func TestSynthesizeManagedBy_TopologyOwnerChain(t *testing.T) {
+	topo := &Topology{
+		Nodes: []Node{
+			{ID: "deployment/demo/web", Kind: KindDeployment, Name: "web"},
+			{ID: "replicaset/demo/web-abc", Kind: KindReplicaSet, Name: "web-abc"},
+			{ID: "pod/demo/web-abc-xyz", Kind: KindPod, Name: "web-abc-xyz"},
+		},
+		Edges: []Edge{
+			{ID: "d-rs", Source: "deployment/demo/web", Target: "replicaset/demo/web-abc", Type: EdgeManages},
+			{ID: "rs-p", Source: "replicaset/demo/web-abc", Target: "pod/demo/web-abc-xyz", Type: EdgeManages},
+		},
+	}
+
+	got := SynthesizeManagedBy(nil, "Pod", "demo", "web-abc-xyz", topo, nil)
+	if len(got) != 1 {
+		t.Fatalf("want 1 manager ref via topology walk, got %d (%+v)", len(got), got)
+	}
+	if got[0].Kind != "Deployment" || got[0].Name != "web" || got[0].Namespace != "demo" {
+		t.Errorf("want topmost owner Deployment/demo/web, got %+v", got[0])
+	}
+}
+
+// TestSynthesizeManagedBy_LabelsBeatTopologyWalk verifies precedence: a Pod
+// carrying an Argo tracking-id annotation surfaces the Application instead
+// of the topmost K8s owner from the topology.
+func TestSynthesizeManagedBy_LabelsBeatTopologyWalk(t *testing.T) {
+	topo := &Topology{
+		Nodes: []Node{
+			{ID: "deployment/demo/web", Kind: KindDeployment, Name: "web"},
+			{ID: "replicaset/demo/web-abc", Kind: KindReplicaSet, Name: "web-abc"},
+			{ID: "pod/demo/web-abc-xyz", Kind: KindPod, Name: "web-abc-xyz"},
+		},
+		Edges: []Edge{
+			{ID: "d-rs", Source: "deployment/demo/web", Target: "replicaset/demo/web-abc", Type: EdgeManages},
+			{ID: "rs-p", Source: "replicaset/demo/web-abc", Target: "pod/demo/web-abc-xyz", Type: EdgeManages},
+		},
+	}
+	pod := meta(nil, map[string]string{argoTrackingIDAnnotation: "argocd_guestbook:apps/Deployment:demo/web"})
+
+	got := SynthesizeManagedBy(pod, "Pod", "demo", "web-abc-xyz", topo, nil)
+	if len(got) != 1 {
+		t.Fatalf("want 1 manager ref, got %d (%+v)", len(got), got)
+	}
+	if got[0].Kind != "Application" || got[0].Name != "guestbook" || got[0].Namespace != "argocd" {
+		t.Errorf("want Argo Application/argocd/guestbook, got %+v", got[0])
+	}
+}
+
+// TestSynthesizeManagedBy_CycleSafe pins behavior on a self-referential
+// EdgeManages chain. Without the visited-set guard, walkTopmostOwner would
+// loop forever. Such a cycle is impossible from real K8s ownerReferences
+// (single controller, parent set before child) but a corrupted topology
+// should degrade gracefully rather than hang.
+func TestSynthesizeManagedBy_CycleSafe(t *testing.T) {
+	topo := &Topology{
+		Nodes: []Node{
+			{ID: "deployment/demo/a", Kind: KindDeployment, Name: "a"},
+			{ID: "deployment/demo/b", Kind: KindDeployment, Name: "b"},
+		},
+		Edges: []Edge{
+			{ID: "a-b", Source: "deployment/demo/a", Target: "deployment/demo/b", Type: EdgeManages},
+			{ID: "b-a", Source: "deployment/demo/b", Target: "deployment/demo/a", Type: EdgeManages},
+		},
+	}
+	got := SynthesizeManagedBy(nil, "Deployment", "demo", "a", topo, nil)
+	// Either ref is acceptable — the test only asserts termination + a non-nil ref.
+	if len(got) != 1 {
+		t.Fatalf("want 1 manager ref under cycle, got %d (%+v)", len(got), got)
+	}
+}
+
+func TestParseArgoTrackingID(t *testing.T) {
+	cases := []struct {
+		in       string
+		ns, name string
+		ok       bool
+	}{
+		{"argocd_my-app:apps/Deployment:default/web", "argocd", "my-app", true},
+		{"my-app:apps/Deployment:default/web", "", "my-app", true},
+		{"just-garbage-no-colon", "", "", false},
+		{"my-ns_:apps/Deployment:default/web", "", "", false},
+		{":apps/Deployment:default/web", "", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			ns, name, ok := parseArgoTrackingID(c.in)
+			if ok != c.ok || ns != c.ns || name != c.name {
+				t.Errorf("parseArgoTrackingID(%q) = (%q,%q,%v); want (%q,%q,%v)",
+					c.in, ns, name, ok, c.ns, c.name, c.ok)
+			}
+		})
+	}
+}

--- a/pkg/topology/managedby_test.go
+++ b/pkg/topology/managedby_test.go
@@ -5,7 +5,37 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	k8score "github.com/skyhook-io/radar/pkg/k8score"
 )
+
+// stubDP is a minimal DynamicProvider for CRD-fallback regression tests in
+// the topology package. Only GetGVR and Get are exercised by the metadata
+// lookup path; the rest are stubs sufficient to satisfy the interface.
+type stubDP struct {
+	gvr map[string]schema.GroupVersionResource
+	obj map[string]*unstructured.Unstructured // key = "ns/name"
+}
+
+func (s *stubDP) List(_ schema.GroupVersionResource, _ string) ([]*unstructured.Unstructured, error) {
+	return nil, nil
+}
+func (s *stubDP) Get(_ schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+	if u, ok := s.obj[namespace+"/"+name]; ok {
+		return u, nil
+	}
+	return nil, nil
+}
+func (s *stubDP) GetWatchedResources() []schema.GroupVersionResource          { return nil }
+func (s *stubDP) GetDiscoveryStatus() k8score.CRDDiscoveryStatus { return k8score.CRDDiscoveryIdle }
+func (s *stubDP) GetGVR(kindOrName string) (schema.GroupVersionResource, bool) { g, ok := s.gvr[kindOrName]; return g, ok }
+func (s *stubDP) GetGVRWithGroup(kindOrName, _ string) (schema.GroupVersionResource, bool) {
+	return s.GetGVR(kindOrName)
+}
+func (s *stubDP) GetKindForGVR(_ schema.GroupVersionResource) string { return "" }
+func (s *stubDP) IsCRD(_ string) bool                                { return true }
 
 func meta(labels, annos map[string]string) metav1.Object {
 	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Labels: labels, Annotations: annos}}
@@ -98,7 +128,7 @@ func TestSynthesizeManagedBy_LabelsAndAnnotations(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := SynthesizeManagedBy(meta(c.labels, c.annos), "Deployment", "default", "web", nil, nil)
+			got := SynthesizeManagedBy(meta(c.labels, c.annos), "Deployment", "default", "web", nil, nil, nil)
 			if c.wantKind == "" {
 				if got != nil {
 					t.Fatalf("want nil ManagedBy, got %+v", got)
@@ -134,9 +164,35 @@ func TestSynthesizeManagedBy_TopologyOwnerChain(t *testing.T) {
 		},
 	}
 
-	got := SynthesizeManagedBy(nil, "Pod", "demo", "web-abc-xyz", topo, nil)
+	got := SynthesizeManagedBy(nil, "Pod", "demo", "web-abc-xyz", topo, nil, nil)
 	if len(got) != 1 {
 		t.Fatalf("want 1 manager ref via topology walk, got %d (%+v)", len(got), got)
+	}
+	if got[0].Kind != "Deployment" || got[0].Name != "web" || got[0].Namespace != "demo" {
+		t.Errorf("want topmost owner Deployment/demo/web, got %+v", got[0])
+	}
+}
+
+// TestSynthesizeManagedBy_TopologyOwnerChain_Indexed verifies the indexed walk
+// produces the same ref as the O(E) fallback. High-fanout callers (T6/T89/T12)
+// will always pass an index; this asserts they get identical results.
+func TestSynthesizeManagedBy_TopologyOwnerChain_Indexed(t *testing.T) {
+	topo := &Topology{
+		Nodes: []Node{
+			{ID: "deployment/demo/web", Kind: KindDeployment, Name: "web"},
+			{ID: "replicaset/demo/web-abc", Kind: KindReplicaSet, Name: "web-abc"},
+			{ID: "pod/demo/web-abc-xyz", Kind: KindPod, Name: "web-abc-xyz"},
+		},
+		Edges: []Edge{
+			{ID: "d-rs", Source: "deployment/demo/web", Target: "replicaset/demo/web-abc", Type: EdgeManages},
+			{ID: "rs-p", Source: "replicaset/demo/web-abc", Target: "pod/demo/web-abc-xyz", Type: EdgeManages},
+		},
+	}
+	idx := IndexByResource(topo)
+
+	got := SynthesizeManagedBy(nil, "Pod", "demo", "web-abc-xyz", topo, nil, idx)
+	if len(got) != 1 {
+		t.Fatalf("want 1 manager ref via indexed walk, got %d (%+v)", len(got), got)
 	}
 	if got[0].Kind != "Deployment" || got[0].Name != "web" || got[0].Namespace != "demo" {
 		t.Errorf("want topmost owner Deployment/demo/web, got %+v", got[0])
@@ -160,7 +216,7 @@ func TestSynthesizeManagedBy_LabelsBeatTopologyWalk(t *testing.T) {
 	}
 	pod := meta(nil, map[string]string{argoTrackingIDAnnotation: "argocd_guestbook:apps/Deployment:demo/web"})
 
-	got := SynthesizeManagedBy(pod, "Pod", "demo", "web-abc-xyz", topo, nil)
+	got := SynthesizeManagedBy(pod, "Pod", "demo", "web-abc-xyz", topo, nil, nil)
 	if len(got) != 1 {
 		t.Fatalf("want 1 manager ref, got %d (%+v)", len(got), got)
 	}
@@ -185,10 +241,50 @@ func TestSynthesizeManagedBy_CycleSafe(t *testing.T) {
 			{ID: "b-a", Source: "deployment/demo/b", Target: "deployment/demo/a", Type: EdgeManages},
 		},
 	}
-	got := SynthesizeManagedBy(nil, "Deployment", "demo", "a", topo, nil)
+	got := SynthesizeManagedBy(nil, "Deployment", "demo", "a", topo, nil, nil)
 	// Either ref is acceptable — the test only asserts termination + a non-nil ref.
 	if len(got) != 1 {
 		t.Fatalf("want 1 manager ref under cycle, got %d (%+v)", len(got), got)
+	}
+}
+
+// TestGetRelationships_CRD_ManagedByPreserved is the regression for the
+// silent-disappear bug the reviewer flagged on #720: a CRD resource (e.g.
+// cert-manager Certificate) with an ArgoCD tracking-id annotation must still
+// surface ManagedBy. Before the lookupObjectMetadata split, CRDs fell off the
+// typed switch and the chip disappeared without an "omitted" trace.
+func TestGetRelationships_CRD_ManagedByPreserved(t *testing.T) {
+	certGVR := schema.GroupVersionResource{Group: "cert-manager.io", Version: "v1", Resource: "certificates"}
+	cert := &unstructured.Unstructured{}
+	cert.SetGroupVersionKind(schema.GroupVersionKind{Group: "cert-manager.io", Version: "v1", Kind: "Certificate"})
+	cert.SetNamespace("prod")
+	cert.SetName("api-tls")
+	cert.SetAnnotations(map[string]string{
+		argoTrackingIDAnnotation: "argocd_storefront:cert-manager.io/Certificate:prod/api-tls",
+	})
+
+	dp := &stubDP{
+		gvr: map[string]schema.GroupVersionResource{
+			"certificate":  certGVR,
+			"certificates": certGVR,
+		},
+		obj: map[string]*unstructured.Unstructured{
+			"prod/api-tls": cert,
+		},
+	}
+
+	// Topology with the Certificate node only (no owner chain — annotation alone drives the chip).
+	topo := &Topology{
+		Nodes: []Node{{ID: "certificate/prod/api-tls", Kind: KindCertificate, Name: "api-tls"}},
+	}
+
+	rel := GetRelationshipsWithIndex("Certificate", "prod", "api-tls", topo, nil, dp, nil)
+	if rel == nil || len(rel.ManagedBy) != 1 {
+		t.Fatalf("want 1 ManagedBy ref for CRD with Argo tracking-id, got %+v", rel)
+	}
+	got := rel.ManagedBy[0]
+	if got.Kind != "Application" || got.Namespace != "argocd" || got.Name != "storefront" {
+		t.Errorf("want Argo Application/argocd/storefront from CRD annotation, got %+v", got)
 	}
 }
 

--- a/pkg/topology/managedby_test.go
+++ b/pkg/topology/managedby_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -245,6 +246,39 @@ func TestSynthesizeManagedBy_CycleSafe(t *testing.T) {
 	// Either ref is acceptable — the test only asserts termination + a non-nil ref.
 	if len(got) != 1 {
 		t.Fatalf("want 1 manager ref under cycle, got %d (%+v)", len(got), got)
+	}
+}
+
+// TestGetRelationships_BackCompat_PDBManagedByPreserved pins the regression
+// Bugbot flagged on the original T2 commit: kinds with ResourceProvider
+// methods but absent from the typed switch (PDB, NetworkPolicy, HPA, PVC, PV,
+// Node) dropped the GitOps chip even though the old client-side
+// detectGitOpsOwner worked on any kind. Production callers now pass obj
+// directly via GetRelationshipsWithObject so this only matters for the
+// back-compat path — but the typed switch should still cover them so the
+// back-compat path matches old-UI parity. PDB is the canonical case since it
+// connects via EdgeProtects (not EdgeManages), so the topology-walk fallback
+// also can't recover the chip.
+func TestGetRelationships_BackCompat_PDBManagedByPreserved(t *testing.T) {
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "prod",
+			Name:      "api-pdb",
+			Annotations: map[string]string{
+				argoTrackingIDAnnotation: "argocd_storefront:policy/PodDisruptionBudget:prod/api-pdb",
+			},
+		},
+	}
+	provider := &stubProvider{pdbs: []*policyv1.PodDisruptionBudget{pdb}}
+	topo := &Topology{Nodes: []Node{{ID: "poddisruptionbudget/prod/api-pdb", Kind: KindPDB, Name: "api-pdb"}}}
+
+	rel := GetRelationships("PodDisruptionBudget", "prod", "api-pdb", topo, provider, nil)
+	if rel == nil || len(rel.ManagedBy) != 1 {
+		t.Fatalf("want 1 ManagedBy ref for PDB with Argo annotation via back-compat path, got %+v", rel)
+	}
+	got := rel.ManagedBy[0]
+	if got.Kind != "Application" || got.Namespace != "argocd" || got.Name != "storefront" {
+		t.Errorf("want Argo Application/argocd/storefront from PDB annotation, got %+v", got)
 	}
 }
 

--- a/pkg/topology/memo.go
+++ b/pkg/topology/memo.go
@@ -27,8 +27,10 @@ type Memoizer struct {
 }
 
 type memoEntry struct {
-	topo    *Topology
-	builtAt time.Time
+	topo      *Topology
+	builtAt   time.Time
+	indexOnce sync.Once          // guards lazy build of index
+	index     *RelationshipsIndex // populated by Memoizer.GetIndex on first call
 }
 
 // NewMemoizer returns a Memoizer with the given TTL. A zero or negative TTL
@@ -75,6 +77,35 @@ func (m *Memoizer) lookup(key string) (*Topology, bool) {
 		return e.topo, true
 	}
 	return nil, false
+}
+
+// GetIndex returns the RelationshipsIndex for the topology produced by build
+// under opts. The index is computed lazily on first call and cached alongside
+// the topology entry, so subsequent GetIndex calls for the same entry are O(1)
+// map lookups. Falls through to an inline build when the underlying entry has
+// been evicted between the topology fetch and the index fetch, or when the
+// Memoizer is disabled (ttl ≤ 0).
+func (m *Memoizer) GetIndex(opts BuildOptions, build func() (*Topology, error)) (*RelationshipsIndex, error) {
+	topo, err := m.Get(opts, build)
+	if err != nil {
+		return nil, err
+	}
+	if m == nil || m.ttl <= 0 {
+		return IndexByResource(topo), nil
+	}
+	key := memoKey(opts)
+	m.mu.Lock()
+	entry := m.entries[key]
+	m.mu.Unlock()
+	// Entry evicted between Get() and GetIndex() — build inline and return.
+	// Costs one extra walk but keeps the API correct under aggressive eviction.
+	if entry == nil || entry.topo != topo {
+		return IndexByResource(topo), nil
+	}
+	entry.indexOnce.Do(func() {
+		entry.index = IndexByResource(entry.topo)
+	})
+	return entry.index, nil
 }
 
 func (m *Memoizer) store(key string, topo *Topology) {

--- a/pkg/topology/memo_test.go
+++ b/pkg/topology/memo_test.go
@@ -176,6 +176,58 @@ func TestMemoizer_EvictsStaleEntries(t *testing.T) {
 	}
 }
 
+// TestMemoizer_GetIndex_CachesAlongsideTopology pins that GetIndex returns
+// the same *RelationshipsIndex across calls for the same key, proving the
+// lazy index is cached on the memoEntry (not rebuilt per call). T6/T12
+// hot paths depend on this: they call Get + GetIndex on every per-resource
+// request.
+func TestMemoizer_GetIndex_CachesAlongsideTopology(t *testing.T) {
+	m := NewMemoizer(1 * time.Second)
+	topo := &Topology{
+		Nodes: []Node{{ID: "deployment/demo/web", Kind: KindDeployment, Name: "web"}},
+		Edges: []Edge{},
+	}
+	build := func() (*Topology, error) { return topo, nil }
+	opts := DefaultBuildOptions()
+
+	idx1, err := m.GetIndex(opts, build)
+	if err != nil {
+		t.Fatalf("GetIndex 1: %v", err)
+	}
+	idx2, err := m.GetIndex(opts, build)
+	if err != nil {
+		t.Fatalf("GetIndex 2: %v", err)
+	}
+	if idx1 != idx2 {
+		t.Errorf("expected same *RelationshipsIndex across calls (cached), got two distinct pointers")
+	}
+}
+
+// TestMemoizer_GetIndex_ZeroTTL_BuildsInline mirrors TestMemoizer_ZeroTTLDisables:
+// with caching disabled, every GetIndex call must produce a fresh index.
+// Required for tests that drive Memoizer with ttl=0.
+func TestMemoizer_GetIndex_ZeroTTL_BuildsInline(t *testing.T) {
+	m := NewMemoizer(0)
+	topo := &Topology{
+		Nodes: []Node{{ID: "deployment/demo/web", Kind: KindDeployment, Name: "web"}},
+		Edges: []Edge{},
+	}
+	build := func() (*Topology, error) { return topo, nil }
+	opts := DefaultBuildOptions()
+
+	idx1, err := m.GetIndex(opts, build)
+	if err != nil {
+		t.Fatalf("GetIndex 1: %v", err)
+	}
+	idx2, err := m.GetIndex(opts, build)
+	if err != nil {
+		t.Fatalf("GetIndex 2: %v", err)
+	}
+	if idx1 == idx2 {
+		t.Errorf("ttl=0 should rebuild index inline each call, got identical pointers")
+	}
+}
+
 func TestMemoizer_DoesNotCacheErrors(t *testing.T) {
 	m := NewMemoizer(1 * time.Second)
 	var calls int32

--- a/pkg/topology/relationships.go
+++ b/pkg/topology/relationships.go
@@ -574,35 +574,35 @@ func lookupTypedMetadata(kindLower, namespace, name string, provider ResourcePro
 				return i
 			}
 		}
-	case "poddisruptionbudget", "poddisruptionbudgets":
+	case "poddisruptionbudget", "poddisruptionbudgets", "pdb", "pdbs":
 		pdbs, _ := provider.PodDisruptionBudgets()
 		for _, p := range pdbs {
 			if p.Namespace == namespace && p.Name == name {
 				return p
 			}
 		}
-	case "networkpolicy", "networkpolicies":
+	case "networkpolicy", "networkpolicies", "netpol":
 		nps, _ := provider.NetworkPolicies()
 		for _, n := range nps {
 			if n.Namespace == namespace && n.Name == name {
 				return n
 			}
 		}
-	case "horizontalpodautoscaler", "horizontalpodautoscalers":
+	case "horizontalpodautoscaler", "horizontalpodautoscalers", "hpa", "hpas":
 		hpas, _ := provider.HorizontalPodAutoscalers()
 		for _, h := range hpas {
 			if h.Namespace == namespace && h.Name == name {
 				return h
 			}
 		}
-	case "persistentvolumeclaim", "persistentvolumeclaims":
+	case "persistentvolumeclaim", "persistentvolumeclaims", "pvc", "pvcs":
 		pvcs, _ := provider.PersistentVolumeClaims()
 		for _, p := range pvcs {
 			if p.Namespace == namespace && p.Name == name {
 				return p
 			}
 		}
-	case "persistentvolume", "persistentvolumes":
+	case "persistentvolume", "persistentvolumes", "pv", "pvs":
 		// Cluster-scoped: ignore namespace.
 		pvs, _ := provider.PersistentVolumes()
 		for _, p := range pvs {

--- a/pkg/topology/relationships.go
+++ b/pkg/topology/relationships.go
@@ -399,7 +399,7 @@ func GetRelationshipsWithIndex(kind, namespace, name string, topo *Topology, pro
 
 	// Hygiene fields (T2): ServiceAccount + Node from Pod.Spec, ManagedBy from
 	// labels/annotations on the queried object (or topology owner chain fallback).
-	queriedObj := lookupObjectMetadata(kindLower, namespace, name, provider)
+	queriedObj := lookupObjectMetadata(kindLower, namespace, name, provider, dp)
 	if pod, ok := queriedObj.(*corev1.Pod); ok {
 		if sa := pod.Spec.ServiceAccountName; sa != "" {
 			saRef := ResourceRef{Kind: "ServiceAccount", Namespace: namespace, Name: sa}
@@ -416,7 +416,7 @@ func GetRelationshipsWithIndex(kind, namespace, name string, topo *Topology, pro
 	if m, ok := queriedObj.(metav1.Object); ok {
 		managedByMeta = m
 	}
-	if mb := SynthesizeManagedBy(managedByMeta, kind, namespace, name, topo, dp); len(mb) > 0 {
+	if mb := SynthesizeManagedBy(managedByMeta, kind, namespace, name, topo, dp, idx); len(mb) > 0 {
 		rel.ManagedBy = mb
 	}
 
@@ -433,15 +433,37 @@ func GetRelationshipsWithIndex(kind, namespace, name string, topo *Topology, pro
 	return rel
 }
 
-// lookupObjectMetadata returns the typed K8s object for kind/namespace/name
-// from provider, or nil if not found. Used to source labels/annotations for
+// lookupObjectMetadata returns the typed K8s object (or *unstructured.Unstructured
+// for CRDs) for kind/namespace/name. Used to source labels/annotations for
 // ManagedBy synthesis and Pod spec fields (ServiceAccountName, NodeName).
-// Only supports the typed kinds available on ResourceProvider — CRDs and
-// kinds without a provider method return nil and skip synthesis.
-func lookupObjectMetadata(kindLower, namespace, name string, provider ResourceProvider) any {
-	if provider == nil {
-		return nil
+//
+// Typed-resource lookups go through the ResourceProvider's accessor methods
+// (Pods, Deployments, …). For CRDs and any kind without a provider method,
+// falls back to the DynamicProvider so GitOps annotations on managed CRs
+// (HelmRelease, ExternalSecret, Certificate, etc.) still drive the chip —
+// without the fallback, the UI's chip would silently disappear for any
+// resource kind not in the typed switch below.
+func lookupObjectMetadata(kindLower, namespace, name string, provider ResourceProvider, dp DynamicProvider) any {
+	if provider != nil {
+		if obj := lookupTypedMetadata(kindLower, namespace, name, provider); obj != nil {
+			return obj
+		}
 	}
+	// Fallback for CRDs and any kind not in the typed switch. dp.Get
+	// returns a *unstructured.Unstructured, which satisfies metav1.Object.
+	if dp != nil {
+		if gvr, ok := dp.GetGVR(kindLower); ok {
+			if u, err := dp.Get(gvr, namespace, name); err == nil && u != nil {
+				return u
+			}
+		}
+	}
+	return nil
+}
+
+// lookupTypedMetadata is the original typed-resource switch. Split out from
+// lookupObjectMetadata so the CRD fallback path is clearly the second tier.
+func lookupTypedMetadata(kindLower, namespace, name string, provider ResourceProvider) any {
 	switch kindLower {
 	case "pod", "pods":
 		pods, _ := provider.Pods()

--- a/pkg/topology/relationships.go
+++ b/pkg/topology/relationships.go
@@ -180,8 +180,13 @@ func isRouteKind(kindLower string) bool {
 // edge lookups; callers with many GetRelationships calls against the same
 // topology should use GetRelationshipsWithIndex with a shared
 // RelationshipsIndex instead.
+//
+// Prefer GetRelationshipsWithObject when the resource has already been fetched
+// by the caller — the kind/name lookup used inside this entry point is
+// group-blind and can return the wrong typed object for CRDs whose plural
+// collides with a core resource (e.g. Knative Service vs core Service).
 func GetRelationships(kind, namespace, name string, topo *Topology, provider ResourceProvider, dp DynamicProvider) *Relationships {
-	return GetRelationshipsWithIndex(kind, namespace, name, topo, provider, dp, nil)
+	return GetRelationshipsWithObject(kind, namespace, name, nil, topo, provider, dp, nil)
 }
 
 // GetRelationshipsWithIndex is the indexed variant of GetRelationships. When
@@ -190,7 +195,26 @@ func GetRelationships(kind, namespace, name string, topo *Topology, provider Res
 // exactly. Callers that issue many per-resource queries against the same
 // topology (T6 BuildResourceContext, T12 get_neighborhood) should build idx
 // once and reuse it.
+//
+// Prefer GetRelationshipsWithObject when the resource has already been fetched —
+// see the doc on GetRelationships for the kind/group collision rationale.
 func GetRelationshipsWithIndex(kind, namespace, name string, topo *Topology, provider ResourceProvider, dp DynamicProvider, idx *RelationshipsIndex) *Relationships {
+	return GetRelationshipsWithObject(kind, namespace, name, nil, topo, provider, dp, idx)
+}
+
+// GetRelationshipsWithObject is the canonical entry point. When obj is non-nil
+// it is used directly for Pod spec extraction (ServiceAccountName, NodeName)
+// and ManagedBy synthesis, eliminating the group-blind kind/name lookup
+// inside lookupObjectMetadata. Callers that have already fetched the resource
+// — REST GET, MCP get_resource — MUST pass obj here, otherwise CRDs whose
+// plural collides with a core resource (e.g. Knative serving.knative.dev/Service
+// vs core/v1 Service) silently surface the wrong managed-by ref.
+//
+// obj may be any typed K8s object or *unstructured.Unstructured (both satisfy
+// metav1.Object and the *corev1.Pod type assertion remains nil-safe). When
+// obj is nil, behavior matches the pre-refactor path: lookupObjectMetadata
+// is called, with the group-collision risk noted above.
+func GetRelationshipsWithObject(kind, namespace, name string, obj any, topo *Topology, provider ResourceProvider, dp DynamicProvider, idx *RelationshipsIndex) *Relationships {
 	if topo == nil {
 		return nil
 	}
@@ -399,7 +423,15 @@ func GetRelationshipsWithIndex(kind, namespace, name string, topo *Topology, pro
 
 	// Hygiene fields (T2): ServiceAccount + Node from Pod.Spec, ManagedBy from
 	// labels/annotations on the queried object (or topology owner chain fallback).
-	queriedObj := lookupObjectMetadata(kindLower, namespace, name, provider, dp)
+	//
+	// Use the caller-provided obj when available — it is the authoritative
+	// resource (already disambiguated by group at fetch time) and avoids the
+	// group-blind kind/name lookup. Fall back to lookupObjectMetadata only
+	// when obj is nil (back-compat path).
+	queriedObj := obj
+	if queriedObj == nil {
+		queriedObj = lookupObjectMetadata(kindLower, namespace, name, provider, dp)
+	}
 	if pod, ok := queriedObj.(*corev1.Pod); ok {
 		if sa := pod.Spec.ServiceAccountName; sa != "" {
 			saRef := ResourceRef{Kind: "ServiceAccount", Namespace: namespace, Name: sa}

--- a/pkg/topology/relationships.go
+++ b/pkg/topology/relationships.go
@@ -574,6 +574,50 @@ func lookupTypedMetadata(kindLower, namespace, name string, provider ResourcePro
 				return i
 			}
 		}
+	case "poddisruptionbudget", "poddisruptionbudgets":
+		pdbs, _ := provider.PodDisruptionBudgets()
+		for _, p := range pdbs {
+			if p.Namespace == namespace && p.Name == name {
+				return p
+			}
+		}
+	case "networkpolicy", "networkpolicies":
+		nps, _ := provider.NetworkPolicies()
+		for _, n := range nps {
+			if n.Namespace == namespace && n.Name == name {
+				return n
+			}
+		}
+	case "horizontalpodautoscaler", "horizontalpodautoscalers":
+		hpas, _ := provider.HorizontalPodAutoscalers()
+		for _, h := range hpas {
+			if h.Namespace == namespace && h.Name == name {
+				return h
+			}
+		}
+	case "persistentvolumeclaim", "persistentvolumeclaims":
+		pvcs, _ := provider.PersistentVolumeClaims()
+		for _, p := range pvcs {
+			if p.Namespace == namespace && p.Name == name {
+				return p
+			}
+		}
+	case "persistentvolume", "persistentvolumes":
+		// Cluster-scoped: ignore namespace.
+		pvs, _ := provider.PersistentVolumes()
+		for _, p := range pvs {
+			if p.Name == name {
+				return p
+			}
+		}
+	case "node", "nodes":
+		// Cluster-scoped: ignore namespace.
+		nodes, _ := provider.Nodes()
+		for _, n := range nodes {
+			if n.Name == name {
+				return n
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/topology/relationships.go
+++ b/pkg/topology/relationships.go
@@ -4,7 +4,86 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// RelationshipsIndex is a precomputed map from node ID to the edges touching
+// that node, derived from a single pass over Topology.Edges. Repeated
+// per-resource lookups via GetRelationshipsWithIndex skip the O(E) edge scan
+// in exchange for one O(E) build per topology refresh.
+//
+// Build once via IndexByResource(topo). Pass to GetRelationshipsWithIndex on
+// each call. Lookups are read-only and goroutine-safe; mutation is not.
+type RelationshipsIndex struct {
+	byNodeID map[string]*nodeEdgeSlots
+}
+
+type nodeEdgeSlots struct {
+	incoming []Edge
+	outgoing []Edge
+}
+
+// IndexByResource builds a RelationshipsIndex over topo. Safe to call with a
+// nil topology — returns an empty index whose lookups all miss.
+func IndexByResource(topo *Topology) *RelationshipsIndex {
+	if topo == nil {
+		return &RelationshipsIndex{byNodeID: map[string]*nodeEdgeSlots{}}
+	}
+	idx := &RelationshipsIndex{byNodeID: make(map[string]*nodeEdgeSlots, len(topo.Nodes))}
+	for _, e := range topo.Edges {
+		if e.Source != "" {
+			slot := idx.byNodeID[e.Source]
+			if slot == nil {
+				slot = &nodeEdgeSlots{}
+				idx.byNodeID[e.Source] = slot
+			}
+			slot.outgoing = append(slot.outgoing, e)
+		}
+		if e.Target != "" {
+			slot := idx.byNodeID[e.Target]
+			if slot == nil {
+				slot = &nodeEdgeSlots{}
+				idx.byNodeID[e.Target] = slot
+			}
+			slot.incoming = append(slot.incoming, e)
+		}
+	}
+	return idx
+}
+
+// EdgesFor returns the incoming and outgoing edges touching nodeID. Both
+// slices alias the index's internal storage — callers MUST NOT mutate them.
+// Returns (nil, nil) when the node has no edges or the index is nil.
+func (r *RelationshipsIndex) EdgesFor(nodeID string) (incoming, outgoing []Edge) {
+	if r == nil {
+		return nil, nil
+	}
+	slot := r.byNodeID[nodeID]
+	if slot == nil {
+		return nil, nil
+	}
+	return slot.incoming, slot.outgoing
+}
+
+// edgesForNode returns incoming/outgoing edges for nodeID, preferring the
+// index when supplied and falling back to a linear scan over topo.Edges.
+func edgesForNode(topo *Topology, idx *RelationshipsIndex, nodeID string) (incoming, outgoing []Edge) {
+	if idx != nil {
+		return idx.EdgesFor(nodeID)
+	}
+	if topo == nil {
+		return nil, nil
+	}
+	for _, e := range topo.Edges {
+		if e.Source == nodeID {
+			outgoing = append(outgoing, e)
+		}
+		if e.Target == nodeID {
+			incoming = append(incoming, e)
+		}
+	}
+	return incoming, outgoing
+}
 
 // GetCascadeDeletePreview returns a preview of all resources that will be garbage-collected
 // when the specified resource is deleted. It walks EdgeManages edges recursively
@@ -95,145 +174,153 @@ func isRouteKind(kindLower string) bool {
 	return false
 }
 
-// GetRelationships computes relationships for a specific resource
-// by finding all edges in the topology that involve this resource.
-// The topology should be pre-built and cached for performance.
+// GetRelationships computes relationships for a specific resource by finding
+// all edges in the topology that involve this resource. The topology should be
+// pre-built and cached for performance. Builds a per-call inline index for
+// edge lookups; callers with many GetRelationships calls against the same
+// topology should use GetRelationshipsWithIndex with a shared
+// RelationshipsIndex instead.
 func GetRelationships(kind, namespace, name string, topo *Topology, provider ResourceProvider, dp DynamicProvider) *Relationships {
+	return GetRelationshipsWithIndex(kind, namespace, name, topo, provider, dp, nil)
+}
+
+// GetRelationshipsWithIndex is the indexed variant of GetRelationships. When
+// idx is non-nil, edge lookups go through the precomputed inverted index
+// instead of scanning topo.Edges; when nil, behavior matches GetRelationships
+// exactly. Callers that issue many per-resource queries against the same
+// topology (T6 BuildResourceContext, T12 get_neighborhood) should build idx
+// once and reuse it.
+func GetRelationshipsWithIndex(kind, namespace, name string, topo *Topology, provider ResourceProvider, dp DynamicProvider, idx *RelationshipsIndex) *Relationships {
 	if topo == nil {
 		return nil
 	}
 
 	// Build the node ID for this resource (matches format used in builder.go)
 	nodeID := buildNodeID(kind, namespace, name, dp)
+	incomingEdges, outgoingEdges := edgesForNode(topo, idx, nodeID)
 
 	rel := &Relationships{}
+	kindLower := strings.ToLower(kind)
 
-	for _, edge := range topo.Edges {
-		if edge.Source == nodeID {
-			// This resource points TO something (outgoing edge)
-			ref := parseNodeID(edge.Target, dp)
-			if ref == nil {
-				continue
-			}
-			enrichRef(ref, dp)
-
-			switch edge.Type {
-			case EdgeManages:
-				// This resource manages/owns the target
-				rel.Children = append(rel.Children, *ref)
-			case EdgeExposes:
-				// This is a Service exposing something
-				rel.Pods = append(rel.Pods, *ref)
-			case EdgeRoutesTo:
-				// This is an Ingress, Gateway, route, or Service routing to something
-				kindLower := strings.ToLower(kind)
-				targetKindLower := strings.ToLower(ref.Kind)
-				if kindLower == "gateway" || kindLower == "gateways" {
-					// Gateway routes to routes or services
-					if isRouteKind(targetKindLower) {
-						rel.Routes = append(rel.Routes, *ref)
-					} else {
-						rel.Services = append(rel.Services, *ref)
-					}
-				} else if kindLower == "ingress" || kindLower == "ingresses" ||
-					isRouteKind(kindLower) {
-					// Ingress/Route routes to Service
-					rel.Services = append(rel.Services, *ref)
-				} else {
-					// Service routes to Pod
-					rel.Pods = append(rel.Pods, *ref)
-				}
-			case EdgeUses:
-				// HPA/ScaledObject/ScaledJob scales a workload
-				rel.ScaleTarget = ref
-			case EdgeProtects:
-				// Outgoing EdgeProtects fires when the queried resource IS a
-				// PDB, NetworkPolicy, CiliumNetworkPolicy, or MachineHealthCheck —
-				// each of these emits a "protects/selects target workload" edge.
-				//
-				// Intentionally NOT surfaced today. The existing per-resource
-				// relationship fields (PDBs, NetworkPolicies, Scalers, etc.)
-				// describe "things that act on me," not "things I act on" —
-				// so there's no semantically correct field to land outgoing
-				// protects refs in.
-				//
-				// Previously this case wrote to rel.ScaleTarget (bug B1) and
-				// then briefly to rel.PDBs (which conflated PDB-side and NP-
-				// side outgoing edges into the same incoming-direction field).
-				// Both were wrong.
-				//
-				// TODO: when we introduce a target-side "Protects []ResourceRef"
-				// field on Relationships, surface these refs there with their
-				// source kind preserved. Until then, leave the outgoing direction
-				// of EdgeProtects unsurfaced. The topology graph itself still
-				// carries these edges; only the per-resource projection skips them.
-			case EdgeConfigures:
-				// ConfigMap/Secret is used by a workload (outgoing from config)
-				rel.Consumers = append(rel.Consumers, *ref)
-			}
+	for _, edge := range outgoingEdges {
+		// This resource points TO something (outgoing edge)
+		ref := parseNodeID(edge.Target, dp)
+		if ref == nil {
+			continue
 		}
+		enrichRef(ref, dp)
 
-		if edge.Target == nodeID {
-			// Something points TO this resource (incoming edge)
-			ref := parseNodeID(edge.Source, dp)
-			if ref == nil {
-				continue
-			}
-			enrichRef(ref, dp)
-
-			switch edge.Type {
-			case EdgeManages:
-				// Something manages/owns this resource
-				rel.Owner = ref
-			case EdgeExposes:
-				// A Service exposes this resource
-				rel.Services = append(rel.Services, *ref)
-			case EdgeRoutesTo:
-				// An Ingress, Gateway, route, or Service routes to this resource
-				sourceKind := strings.ToLower(ref.Kind)
-				if sourceKind == "ingress" {
-					rel.Ingresses = append(rel.Ingresses, *ref)
-				} else if sourceKind == "gateway" || sourceKind == "httproute" ||
-					sourceKind == "grpcroute" || sourceKind == "tcproute" || sourceKind == "tlsroute" {
-					rel.Gateways = append(rel.Gateways, *ref)
-				} else if sourceKind == "service" {
+		switch edge.Type {
+		case EdgeManages:
+			// This resource manages/owns the target
+			rel.Children = append(rel.Children, *ref)
+		case EdgeExposes:
+			// This is a Service exposing something
+			rel.Pods = append(rel.Pods, *ref)
+		case EdgeRoutesTo:
+			// This is an Ingress, Gateway, route, or Service routing to something
+			targetKindLower := strings.ToLower(ref.Kind)
+			if kindLower == "gateway" || kindLower == "gateways" {
+				// Gateway routes to routes or services
+				if isRouteKind(targetKindLower) {
+					rel.Routes = append(rel.Routes, *ref)
+				} else {
 					rel.Services = append(rel.Services, *ref)
 				}
-			case EdgeUses:
-				// An HPA/ScaledObject/ScaledJob scales this resource
-				rel.Scalers = append(rel.Scalers, *ref)
-			case EdgeProtects:
-				// Incoming EdgeProtects: dispatch on source kind so PDBs and
-				// NetworkPolicies land in distinct fields.
-				switch ref.Kind {
-				case "PodDisruptionBudget":
-					rel.PDBs = append(rel.PDBs, *ref)
-				case "NetworkPolicy", "CiliumNetworkPolicy", "ClusterNetworkPolicy", "CiliumClusterwideNetworkPolicy":
-					rel.NetworkPolicies = append(rel.NetworkPolicies, *ref)
-				}
-			case EdgeConfigures:
-				// A ConfigMap/Secret is used by this resource
-				rel.ConfigRefs = append(rel.ConfigRefs, *ref)
+			} else if kindLower == "ingress" || kindLower == "ingresses" ||
+				isRouteKind(kindLower) {
+				// Ingress/Route routes to Service
+				rel.Services = append(rel.Services, *ref)
+			} else {
+				// Service routes to Pod
+				rel.Pods = append(rel.Pods, *ref)
 			}
+		case EdgeUses:
+			// HPA/ScaledObject/ScaledJob scales a workload
+			rel.ScaleTarget = ref
+		case EdgeProtects:
+			// Outgoing EdgeProtects fires when the queried resource IS a
+			// PDB, NetworkPolicy, CiliumNetworkPolicy, or MachineHealthCheck —
+			// each of these emits a "protects/selects target workload" edge.
+			//
+			// Intentionally NOT surfaced today. The existing per-resource
+			// relationship fields (PDBs, NetworkPolicies, Scalers, etc.)
+			// describe "things that act on me," not "things I act on" —
+			// so there's no semantically correct field to land outgoing
+			// protects refs in.
+			//
+			// TODO: when we introduce a target-side "Protects []ResourceRef"
+			// field on Relationships, surface these refs there with their
+			// source kind preserved. Until then, leave the outgoing direction
+			// of EdgeProtects unsurfaced. The topology graph itself still
+			// carries these edges; only the per-resource projection skips them.
+		case EdgeConfigures:
+			// ConfigMap/Secret is used by a workload (outgoing from config)
+			rel.Consumers = append(rel.Consumers, *ref)
+		}
+	}
+
+	for _, edge := range incomingEdges {
+		// Something points TO this resource (incoming edge)
+		ref := parseNodeID(edge.Source, dp)
+		if ref == nil {
+			continue
+		}
+		enrichRef(ref, dp)
+
+		switch edge.Type {
+		case EdgeManages:
+			// Something manages/owns this resource
+			rel.Owner = ref
+		case EdgeExposes:
+			// A Service exposes this resource
+			rel.Services = append(rel.Services, *ref)
+		case EdgeRoutesTo:
+			// An Ingress, Gateway, route, or Service routes to this resource
+			sourceKind := strings.ToLower(ref.Kind)
+			if sourceKind == "ingress" {
+				rel.Ingresses = append(rel.Ingresses, *ref)
+			} else if sourceKind == "gateway" || sourceKind == "httproute" ||
+				sourceKind == "grpcroute" || sourceKind == "tcproute" || sourceKind == "tlsroute" {
+				rel.Gateways = append(rel.Gateways, *ref)
+			} else if sourceKind == "service" {
+				rel.Services = append(rel.Services, *ref)
+			}
+		case EdgeUses:
+			// An HPA/ScaledObject/ScaledJob scales this resource
+			rel.Scalers = append(rel.Scalers, *ref)
+		case EdgeProtects:
+			// Incoming EdgeProtects: dispatch on source kind so PDBs and
+			// NetworkPolicies land in distinct fields.
+			switch ref.Kind {
+			case "PodDisruptionBudget":
+				rel.PDBs = append(rel.PDBs, *ref)
+			case "NetworkPolicy", "CiliumNetworkPolicy", "ClusterNetworkPolicy", "CiliumClusterwideNetworkPolicy":
+				rel.NetworkPolicies = append(rel.NetworkPolicies, *ref)
+			}
+		case EdgeConfigures:
+			// A ConfigMap/Secret is used by this resource
+			rel.ConfigRefs = append(rel.ConfigRefs, *ref)
 		}
 	}
 
 	// Convenience shortcuts: bridge the Deployment↔ReplicaSet↔Pod gap
 	// so users see Pods directly under Deployments and vice versa.
-	kindLower := strings.ToLower(kind)
 
 	// Deployment → show grandchild Pods (Deployment→ReplicaSet→Pod)
 	if kindLower == "deployments" || kindLower == "deployment" {
 		for _, child := range rel.Children {
 			if strings.EqualFold(child.Kind, "ReplicaSet") {
 				childID := buildNodeID(child.Kind, child.Namespace, child.Name, dp)
-				for _, edge := range topo.Edges {
-					if edge.Source == childID && edge.Type == EdgeManages {
-						podRef := parseNodeID(edge.Target, dp)
-						if podRef != nil && strings.EqualFold(podRef.Kind, "Pod") {
-							enrichRef(podRef, dp)
-							rel.Pods = append(rel.Pods, *podRef)
-						}
+				_, childOutgoing := edgesForNode(topo, idx, childID)
+				for _, edge := range childOutgoing {
+					if edge.Type != EdgeManages {
+						continue
+					}
+					podRef := parseNodeID(edge.Target, dp)
+					if podRef != nil && strings.EqualFold(podRef.Kind, "Pod") {
+						enrichRef(podRef, dp)
+						rel.Pods = append(rel.Pods, *podRef)
 					}
 				}
 			}
@@ -244,14 +331,16 @@ func GetRelationships(kind, namespace, name string, topo *Topology, provider Res
 	if kindLower == "pods" || kindLower == "pod" {
 		if rel.Owner != nil && strings.EqualFold(rel.Owner.Kind, "ReplicaSet") {
 			ownerID := buildNodeID(rel.Owner.Kind, rel.Owner.Namespace, rel.Owner.Name, dp)
-			for _, edge := range topo.Edges {
-				if edge.Target == ownerID && edge.Type == EdgeManages {
-					deployRef := parseNodeID(edge.Source, dp)
-					if deployRef != nil && strings.EqualFold(deployRef.Kind, "Deployment") {
-						enrichRef(deployRef, dp)
-						rel.Deployment = deployRef
-						break
-					}
+			ownerIncoming, _ := edgesForNode(topo, idx, ownerID)
+			for _, edge := range ownerIncoming {
+				if edge.Type != EdgeManages {
+					continue
+				}
+				deployRef := parseNodeID(edge.Source, dp)
+				if deployRef != nil && strings.EqualFold(deployRef.Kind, "Deployment") {
+					enrichRef(deployRef, dp)
+					rel.Deployment = deployRef
+					break
 				}
 			}
 		}
@@ -308,16 +397,131 @@ func GetRelationships(kind, namespace, name string, topo *Topology, provider Res
 		}
 	}
 
+	// Hygiene fields (T2): ServiceAccount + Node from Pod.Spec, ManagedBy from
+	// labels/annotations on the queried object (or topology owner chain fallback).
+	queriedObj := lookupObjectMetadata(kindLower, namespace, name, provider)
+	if pod, ok := queriedObj.(*corev1.Pod); ok {
+		if sa := pod.Spec.ServiceAccountName; sa != "" {
+			saRef := ResourceRef{Kind: "ServiceAccount", Namespace: namespace, Name: sa}
+			enrichRef(&saRef, dp)
+			rel.ServiceAccount = &saRef
+		}
+		if nodeName := pod.Spec.NodeName; nodeName != "" {
+			nodeRef := ResourceRef{Kind: "Node", Name: nodeName}
+			enrichRef(&nodeRef, dp)
+			rel.Node = &nodeRef
+		}
+	}
+	var managedByMeta metav1.Object
+	if m, ok := queriedObj.(metav1.Object); ok {
+		managedByMeta = m
+	}
+	if mb := SynthesizeManagedBy(managedByMeta, kind, namespace, name, topo, dp); len(mb) > 0 {
+		rel.ManagedBy = mb
+	}
+
 	// Return nil if no relationships found
 	if rel.Owner == nil && rel.Deployment == nil && len(rel.Children) == 0 && len(rel.Services) == 0 &&
 		len(rel.Ingresses) == 0 && len(rel.Gateways) == 0 && len(rel.Routes) == 0 &&
 		len(rel.ConfigRefs) == 0 && len(rel.Consumers) == 0 && len(rel.Scalers) == 0 &&
 		len(rel.PDBs) == 0 && len(rel.NetworkPolicies) == 0 &&
-		rel.ScaleTarget == nil && len(rel.Pods) == 0 {
+		rel.ScaleTarget == nil && len(rel.Pods) == 0 &&
+		rel.ServiceAccount == nil && rel.Node == nil && len(rel.ManagedBy) == 0 {
 		return nil
 	}
 
 	return rel
+}
+
+// lookupObjectMetadata returns the typed K8s object for kind/namespace/name
+// from provider, or nil if not found. Used to source labels/annotations for
+// ManagedBy synthesis and Pod spec fields (ServiceAccountName, NodeName).
+// Only supports the typed kinds available on ResourceProvider — CRDs and
+// kinds without a provider method return nil and skip synthesis.
+func lookupObjectMetadata(kindLower, namespace, name string, provider ResourceProvider) any {
+	if provider == nil {
+		return nil
+	}
+	switch kindLower {
+	case "pod", "pods":
+		pods, _ := provider.Pods()
+		for _, p := range pods {
+			if p.Namespace == namespace && p.Name == name {
+				return p
+			}
+		}
+	case "deployment", "deployments":
+		ds, _ := provider.Deployments()
+		for _, d := range ds {
+			if d.Namespace == namespace && d.Name == name {
+				return d
+			}
+		}
+	case "statefulset", "statefulsets":
+		ss, _ := provider.StatefulSets()
+		for _, s := range ss {
+			if s.Namespace == namespace && s.Name == name {
+				return s
+			}
+		}
+	case "daemonset", "daemonsets":
+		ds, _ := provider.DaemonSets()
+		for _, d := range ds {
+			if d.Namespace == namespace && d.Name == name {
+				return d
+			}
+		}
+	case "replicaset", "replicasets":
+		rs, _ := provider.ReplicaSets()
+		for _, r := range rs {
+			if r.Namespace == namespace && r.Name == name {
+				return r
+			}
+		}
+	case "job", "jobs":
+		jobs, _ := provider.Jobs()
+		for _, j := range jobs {
+			if j.Namespace == namespace && j.Name == name {
+				return j
+			}
+		}
+	case "cronjob", "cronjobs":
+		cjs, _ := provider.CronJobs()
+		for _, c := range cjs {
+			if c.Namespace == namespace && c.Name == name {
+				return c
+			}
+		}
+	case "service", "services":
+		svcs, _ := provider.Services()
+		for _, s := range svcs {
+			if s.Namespace == namespace && s.Name == name {
+				return s
+			}
+		}
+	case "configmap", "configmaps":
+		cms, _ := provider.ConfigMaps()
+		for _, c := range cms {
+			if c.Namespace == namespace && c.Name == name {
+				return c
+			}
+		}
+	case "secret", "secrets":
+		ss, _ := provider.Secrets()
+		for _, s := range ss {
+			if s.Namespace == namespace && s.Name == name {
+				return s
+			}
+		}
+	case "ingress", "ingresses":
+		is, _ := provider.Ingresses()
+		for _, i := range is {
+			if i.Namespace == namespace && i.Name == name {
+				return i
+			}
+		}
+	}
+	return nil
 }
 
 // buildNodeID constructs a node ID from kind, namespace, and name

--- a/pkg/topology/relationships_bench_test.go
+++ b/pkg/topology/relationships_bench_test.go
@@ -1,0 +1,118 @@
+package topology
+
+import (
+	"fmt"
+	"testing"
+)
+
+// buildSyntheticTopology returns a topology with ~targetNodes nodes shaped
+// like a realistic workload tree: namespaces × (Deployments + each their
+// ReplicaSet + N Pods + a Service exposing them + a ConfigMap and Secret
+// referenced by each Deployment + a PDB and NetworkPolicy selecting each).
+//
+// Edge count grows roughly linearly with node count, giving a 5k-node
+// topology around 6-8k edges — representative of a busy production cluster.
+func buildSyntheticTopology(targetNodes int) *Topology {
+	// Per-deployment: 1 Deployment + 1 ReplicaSet + 3 Pods + 1 Service + 1
+	// ConfigMap + 1 Secret + 1 PDB + 1 NetworkPolicy = 10 nodes. Edges per
+	// deployment: deploy->rs, rs->3pods, svc->3pods, cm->deploy, secret->deploy,
+	// pdb->deploy, np->deploy = 11 edges.
+	perDeploy := 10
+	deploysPerNS := 10
+	namespaces := targetNodes / (perDeploy * deploysPerNS)
+	if namespaces < 1 {
+		namespaces = 1
+	}
+
+	topo := &Topology{}
+	for nsIdx := range namespaces {
+		ns := fmt.Sprintf("ns-%d", nsIdx)
+		for d := range deploysPerNS {
+			deployName := fmt.Sprintf("app-%d", d)
+			rsName := fmt.Sprintf("app-%d-rs", d)
+			svcName := fmt.Sprintf("app-%d-svc", d)
+			cmName := fmt.Sprintf("app-%d-config", d)
+			secretName := fmt.Sprintf("app-%d-secret", d)
+			pdbName := fmt.Sprintf("app-%d-pdb", d)
+			npName := fmt.Sprintf("app-%d-np", d)
+
+			deployID := fmt.Sprintf("deployment/%s/%s", ns, deployName)
+			rsID := fmt.Sprintf("replicaset/%s/%s", ns, rsName)
+			svcID := fmt.Sprintf("service/%s/%s", ns, svcName)
+			cmID := fmt.Sprintf("configmap/%s/%s", ns, cmName)
+			secretID := fmt.Sprintf("secret/%s/%s", ns, secretName)
+			pdbID := fmt.Sprintf("poddisruptionbudget/%s/%s", ns, pdbName)
+			npID := fmt.Sprintf("networkpolicy/%s/%s", ns, npName)
+
+			topo.Nodes = append(topo.Nodes,
+				Node{ID: deployID, Kind: KindDeployment, Name: deployName},
+				Node{ID: rsID, Kind: KindReplicaSet, Name: rsName},
+				Node{ID: svcID, Kind: KindService, Name: svcName},
+				Node{ID: cmID, Kind: KindConfigMap, Name: cmName},
+				Node{ID: secretID, Kind: KindSecret, Name: secretName},
+				Node{ID: pdbID, Kind: KindPDB, Name: pdbName},
+				Node{ID: npID, Kind: KindNetworkPolicy, Name: npName},
+			)
+			topo.Edges = append(topo.Edges,
+				Edge{ID: deployID + "->rs", Source: deployID, Target: rsID, Type: EdgeManages},
+				Edge{ID: cmID + "->deploy", Source: cmID, Target: deployID, Type: EdgeConfigures},
+				Edge{ID: secretID + "->deploy", Source: secretID, Target: deployID, Type: EdgeConfigures},
+				Edge{ID: pdbID + "->deploy", Source: pdbID, Target: deployID, Type: EdgeProtects},
+				Edge{ID: npID + "->deploy", Source: npID, Target: deployID, Type: EdgeProtects},
+			)
+
+			for p := range 3 {
+				podName := fmt.Sprintf("app-%d-pod-%d", d, p)
+				podID := fmt.Sprintf("pod/%s/%s", ns, podName)
+				topo.Nodes = append(topo.Nodes, Node{ID: podID, Kind: KindPod, Name: podName})
+				topo.Edges = append(topo.Edges,
+					Edge{ID: rsID + "->" + podName, Source: rsID, Target: podID, Type: EdgeManages},
+					Edge{ID: svcID + "->" + podName, Source: svcID, Target: podID, Type: EdgeRoutesTo},
+				)
+			}
+		}
+	}
+	return topo
+}
+
+// BenchmarkGetRelationships_NoIndex measures the cost of GetRelationships on a
+// synthetic ~5k-node topology with no precomputed index. Each call rescans
+// topo.Edges in full, so cost is O(E) per call — what every consumer pays
+// today.
+func BenchmarkGetRelationships_NoIndex(b *testing.B) {
+	topo := buildSyntheticTopology(5000)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		nsIdx := i % 50
+		_ = GetRelationships("Deployment", fmt.Sprintf("ns-%d", nsIdx), "app-0", topo, nil, nil)
+	}
+}
+
+// BenchmarkGetRelationships_WithIndex measures the same call shape but with
+// a precomputed RelationshipsIndex shared across calls. Edge lookups become
+// O(degree(node)) instead of O(E). The index build cost is amortized: T6 /
+// T12 build it once per topology refresh (every 5s) and reuse it for many
+// per-resource queries.
+func BenchmarkGetRelationships_WithIndex(b *testing.B) {
+	topo := buildSyntheticTopology(5000)
+	idx := IndexByResource(topo)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		nsIdx := i % 50
+		_ = GetRelationshipsWithIndex("Deployment", fmt.Sprintf("ns-%d", nsIdx), "app-0", topo, nil, nil, idx)
+	}
+}
+
+// BenchmarkIndexByResource measures the one-time index build cost so callers
+// can reason about whether caching the index pays for itself. With ~5k nodes
+// and ~6k edges, the build is dominated by map allocation, not iteration.
+func BenchmarkIndexByResource(b *testing.B) {
+	topo := buildSyntheticTopology(5000)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = IndexByResource(topo)
+	}
+}

--- a/pkg/topology/relationships_test.go
+++ b/pkg/topology/relationships_test.go
@@ -18,6 +18,7 @@ import (
 type stubProvider struct {
 	pods     []*corev1.Pod
 	services []*corev1.Service
+	pdbs     []*policyv1.PodDisruptionBudget
 }
 
 func (s *stubProvider) Pods() ([]*corev1.Pod, error)         { return s.pods, nil }
@@ -41,7 +42,7 @@ func (s *stubProvider) HorizontalPodAutoscalers() ([]*autoscalingv2.HorizontalPo
 	return nil, nil
 }
 func (s *stubProvider) PodDisruptionBudgets() ([]*policyv1.PodDisruptionBudget, error) {
-	return nil, nil
+	return s.pdbs, nil
 }
 func (s *stubProvider) NetworkPolicies() ([]*networkingv1.NetworkPolicy, error) { return nil, nil }
 func (s *stubProvider) Nodes() ([]*corev1.Node, error)                          { return nil, nil }

--- a/pkg/topology/relationships_test.go
+++ b/pkg/topology/relationships_test.go
@@ -16,11 +16,12 @@ import (
 // inspects for Pod hygiene fields and ManagedBy synthesis. Other methods
 // return empty slices so calls fall through cleanly.
 type stubProvider struct {
-	pods []*corev1.Pod
+	pods     []*corev1.Pod
+	services []*corev1.Service
 }
 
-func (s *stubProvider) Pods() ([]*corev1.Pod, error)             { return s.pods, nil }
-func (s *stubProvider) Services() ([]*corev1.Service, error)     { return nil, nil }
+func (s *stubProvider) Pods() ([]*corev1.Pod, error)         { return s.pods, nil }
+func (s *stubProvider) Services() ([]*corev1.Service, error) { return s.services, nil }
 func (s *stubProvider) Deployments() ([]*appsv1.Deployment, error) {
 	return nil, nil
 }

--- a/pkg/topology/relationships_test.go
+++ b/pkg/topology/relationships_test.go
@@ -2,7 +2,109 @@ package topology
 
 import (
 	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// stubProvider supplies a typed K8s resource for the kinds GetRelationships
+// inspects for Pod hygiene fields and ManagedBy synthesis. Other methods
+// return empty slices so calls fall through cleanly.
+type stubProvider struct {
+	pods []*corev1.Pod
+}
+
+func (s *stubProvider) Pods() ([]*corev1.Pod, error)             { return s.pods, nil }
+func (s *stubProvider) Services() ([]*corev1.Service, error)     { return nil, nil }
+func (s *stubProvider) Deployments() ([]*appsv1.Deployment, error) {
+	return nil, nil
+}
+func (s *stubProvider) DaemonSets() ([]*appsv1.DaemonSet, error)         { return nil, nil }
+func (s *stubProvider) StatefulSets() ([]*appsv1.StatefulSet, error)     { return nil, nil }
+func (s *stubProvider) ReplicaSets() ([]*appsv1.ReplicaSet, error)       { return nil, nil }
+func (s *stubProvider) Jobs() ([]*batchv1.Job, error)                    { return nil, nil }
+func (s *stubProvider) CronJobs() ([]*batchv1.CronJob, error)            { return nil, nil }
+func (s *stubProvider) Ingresses() ([]*networkingv1.Ingress, error)      { return nil, nil }
+func (s *stubProvider) ConfigMaps() ([]*corev1.ConfigMap, error)         { return nil, nil }
+func (s *stubProvider) Secrets() ([]*corev1.Secret, error)               { return nil, nil }
+func (s *stubProvider) PersistentVolumeClaims() ([]*corev1.PersistentVolumeClaim, error) {
+	return nil, nil
+}
+func (s *stubProvider) PersistentVolumes() ([]*corev1.PersistentVolume, error) { return nil, nil }
+func (s *stubProvider) HorizontalPodAutoscalers() ([]*autoscalingv2.HorizontalPodAutoscaler, error) {
+	return nil, nil
+}
+func (s *stubProvider) PodDisruptionBudgets() ([]*policyv1.PodDisruptionBudget, error) {
+	return nil, nil
+}
+func (s *stubProvider) NetworkPolicies() ([]*networkingv1.NetworkPolicy, error) { return nil, nil }
+func (s *stubProvider) Nodes() ([]*corev1.Node, error)                          { return nil, nil }
+func (s *stubProvider) GetResourceStatus(kind, namespace, name string) *ResourceStatus {
+	return nil
+}
+
+// TestGetRelationships_PodHygieneFields covers T2: pods carry
+// ServiceAccount, Node, and ManagedBy refs derived from spec + labels.
+func TestGetRelationships_PodHygieneFields(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "demo",
+			Name:      "web-abc-xyz",
+			Annotations: map[string]string{
+				argoTrackingIDAnnotation: "argocd_guestbook:apps/Deployment:demo/web",
+			},
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "web-sa",
+			NodeName:           "node-1",
+		},
+	}
+	provider := &stubProvider{pods: []*corev1.Pod{pod}}
+
+	topo := &Topology{
+		Nodes: []Node{{ID: "pod/demo/web-abc-xyz", Kind: KindPod, Name: "web-abc-xyz"}},
+		Edges: []Edge{},
+	}
+
+	rel := GetRelationships("Pod", "demo", "web-abc-xyz", topo, provider, nil)
+	if rel == nil {
+		t.Fatal("expected non-nil Relationships for pod with hygiene fields")
+	}
+	if rel.ServiceAccount == nil || rel.ServiceAccount.Kind != "ServiceAccount" || rel.ServiceAccount.Name != "web-sa" || rel.ServiceAccount.Namespace != "demo" {
+		t.Errorf("ServiceAccount: want {Kind:ServiceAccount NS:demo Name:web-sa}, got %+v", rel.ServiceAccount)
+	}
+	if rel.Node == nil || rel.Node.Kind != "Node" || rel.Node.Name != "node-1" {
+		t.Errorf("Node: want {Kind:Node Name:node-1}, got %+v", rel.Node)
+	}
+	if len(rel.ManagedBy) != 1 || rel.ManagedBy[0].Kind != "Application" || rel.ManagedBy[0].Name != "guestbook" {
+		t.Errorf("ManagedBy: want [{Application/argocd/guestbook}], got %+v", rel.ManagedBy)
+	}
+}
+
+// TestGetRelationships_PodHygieneFields_EmptySAandUnscheduled verifies that
+// optional fields are properly omitted when the source data is empty. The
+// nil-result short-circuit must also still kick in.
+func TestGetRelationships_PodHygieneFields_EmptySAandUnscheduled(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "demo", Name: "lone"},
+		Spec:       corev1.PodSpec{ /* SA empty, NodeName empty */ },
+	}
+	provider := &stubProvider{pods: []*corev1.Pod{pod}}
+	topo := &Topology{
+		Nodes: []Node{{ID: "pod/demo/lone", Kind: KindPod, Name: "lone"}},
+	}
+
+	rel := GetRelationships("Pod", "demo", "lone", topo, provider, nil)
+	if rel != nil {
+		t.Errorf("expected nil for pod with no edges and no hygiene data, got %+v", rel)
+	}
+}
+
 
 // TestGetRelationships_IncomingEdgeProtects_DispatchesByKind verifies that
 // incoming "protects" edges split into rel.PDBs vs rel.NetworkPolicies based

--- a/pkg/topology/types.go
+++ b/pkg/topology/types.go
@@ -294,6 +294,18 @@ type Relationships struct {
 	PDBs            []ResourceRef `json:"pdbs,omitempty"`            // PodDisruptionBudgets protecting this workload
 	NetworkPolicies []ResourceRef `json:"networkPolicies,omitempty"` // NetworkPolicy / CiliumNetworkPolicy / ClusterNetworkPolicy / CiliumClusterwideNetworkPolicy selecting this workload
 	Pods            []ResourceRef `json:"pods,omitempty"`            // For Service: pods it routes to
+
+	// ServiceAccount is the ServiceAccount bound to this Pod (Pod-only field,
+	// derived from pod.Spec.ServiceAccountName). Omitted when the SA name is empty.
+	ServiceAccount *ResourceRef `json:"serviceAccount,omitempty"`
+	// Node is the Node this Pod is scheduled on (Pod-only field, derived from
+	// pod.Spec.NodeName). Omitted when the Pod is unscheduled.
+	Node *ResourceRef `json:"node,omitempty"`
+	// ManagedBy walks the owner-ref chain up to the topmost meaningful manager
+	// — ArgoCD Application > Flux Kustomization/HelmRelease > Helm release >
+	// topmost K8s owner (Deployment > ReplicaSet > Pod). Empty when no
+	// meaningful manager is detectable.
+	ManagedBy []ResourceRef `json:"managedBy,omitempty"`
 }
 
 // CertificateInfo holds parsed X.509 certificate metadata for a single certificate.


### PR DESCRIPTION
Wave 2 / Phase 1b + 1c combined: server-side hygiene on `Relationships` + a topology inverted index — plus the first UI consolidation that retires the client-side `detectGitOpsOwner` heuristic in favor of the new server-side projection.

## Backend (T2 + T3)

**Relationships gains three cheap fields:**
- `ServiceAccount *ResourceRef` — for Pods, derived from `pod.spec.serviceAccountName`.
- `Node *ResourceRef` — for scheduled Pods, derived from `pod.spec.nodeName`.
- `ManagedBy []ResourceRef` — owner-chain walker with GitOps + Helm detection. Mirrors the precedence the frontend `detectGitOpsOwner` previously did (Flux HelmRelease labels → Flux Kustomization → Argo tracking-id annotation → Argo instance label → Helm release annotation → topmost K8s owner via topology edge chain).

New file `pkg/topology/managedby.go` hosts the walker + GitOps/Helm/owner-chain rules.

**Topology inverted index** — `pkg/topology/relationships.go::IndexByResource` builds `{kind, ns, name} → []Edge` once per topology refresh. Hooked into `pkg/topology/memo.go` so the index is rebuilt alongside the topology. `GetRelationshipsWithIndex` is the indexed entry point; `GetRelationships` still works for callers that haven't migrated. Benchmark covers a 5k-resource topology.

## Review fixes

Three blockers from deep review, addressed across two follow-up commits:

- **CRD GitOps chip preservation.** `lookupObjectMetadata` originally only covered typed built-ins, so any CRD (Certificate, HelmRelease, ExternalSecret, …) carrying an ArgoCD tracking-id or Flux label produced no `ManagedBy` — chip silently disappeared. Split into outer `lookupObjectMetadata` with a `DynamicProvider` fallback path + inner `lookupTypedMetadata` for the typed switch. CRDs now hit `dp.Get → *unstructured`, which satisfies `metav1.Object` and feeds `detectManagedByFromMeta` unchanged.
- **Indexed owner walk.** `walkTopmostOwner` previously built an owners map by scanning all topology edges per call (O(E)). Threaded `*RelationshipsIndex` through `SynthesizeManagedBy` → `walkTopmostOwner`; when non-nil, each hop uses `idx.EdgesFor` for O(in-degree) lookup, making the whole walk O(depth × avg-in-degree). High-fanout callers (T6/T89/T12 list/search enrichment in later waves) MUST pass the shared index; nil-index callers retain the one-time O(E) fallback.
- **Kind/group collision in synthesis lookup.** `GetRelationships(kind, ns, name, …)` dropped `group`. Inside, `lookupTypedMetadata("services", "prod", "api", …)` would return a core/v1 Service even when the caller had fetched a Knative `serving.knative.dev/Service` with the same ns/name. New canonical entry `GetRelationshipsWithObject(…, obj any, …)` accepts the already-fetched resource and skips the lookup entirely. The three production callers (REST GET CRD path, REST GET typed path, MCP `get_resource`) all migrate to pass `obj`. Old entry points become back-compat shims that delegate with `obj=nil`; the group-blind path is documented as a known limitation.

## UI (first T14 retirement)

The frontend `detectGitOpsOwner` (92 LoC of label/annotation parsing) is **deleted**. Replaced by a 35-line `gitOpsOwnerFromRelationships` mapper that reads `relationships.managedBy[0]` and maps it to the existing `GitOpsOwnerRef` discriminated union the chip + router consume.

- `packages/k8s-ui/src/types/core.ts`: `Relationships` gains `managedBy?`, `serviceAccount?`, `node?` mirroring the Go shape.
- `packages/k8s-ui/src/utils/gitops-owner.ts`: parser deleted; mapper introduced.
- `packages/k8s-ui/src/utils/gitops-owner.test.ts`: rewritten to test the ref→GitOpsOwnerRef mapper.
- `packages/k8s-ui/src/components/workload/WorkloadView.tsx`: `detectGitOpsOwner(resource)` → `gitOpsOwnerFromRelationships(relationships)`.

No fallback for old radar binaries — they emit no `managedBy` and the mapper returns null, so the chip silently disappears. Natural upgrade pressure rather than carried-forward label parsing.

## Verification

`go build ./...` + `go test ./pkg/topology ./internal/server ./internal/mcp` green (including new CRD, indexed-walk, and kind-collision regression tests). `cd packages/k8s-ui && npx tsc --noEmit && npx vitest run` → 204/204 passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core relationship/topology computation and API response shapes, which can affect multiple callers and correctness (especially CRD/group disambiguation), though changes are well-covered by new tests/benchmarks.
> 
> **Overview**
> Adds server-side *relationship “hygiene”* fields and performance optimizations: `Relationships` now includes `serviceAccount`, `node`, and `managedBy` (GitOps/Helm/owner-chain synthesis), and relationship computation can use a new inverted `RelationshipsIndex` (`IndexByResource`, `GetRelationshipsWithIndex`) to avoid per-call full edge scans.
> 
> Updates REST and MCP resource fetch paths to pass the already-fetched object into `GetRelationshipsWithObject`, fixing group/kind collisions (e.g., Knative `Service` vs core `Service`) and preserving `managedBy` for CRDs via dynamic metadata fallback.
> 
> Migrates the UI “Managed by …” chip off client-side label/annotation parsing by replacing `detectGitOpsOwner` with a thin `relationships.managedBy` mapper, and extends the TS `Relationships` type accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ebb062f4ed78e8704a0f5149f81531bc78685c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->