### PR TITLE
feat(issues): add Kyverno as a source for /api/issues + MCP issues tool (T11)

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -765,8 +765,10 @@ See the main [README](../README.md#gitops) for the user-facing overview. This se
 |-----|-------|----------|-------------|------------|
 | Policy | `kyverno.io/v1` | — | Yes | — |
 | ClusterPolicy | `kyverno.io/v1` | — | Yes | — |
-| PolicyReport | `wgpolicyk8s.io/v1alpha2` | — | Yes | — |
-| ClusterPolicyReport | `wgpolicyk8s.io/v1alpha2` | — | Yes | — |
+| PolicyReport | `wgpolicyk8s.io/v1alpha2` | — | Yes | Yes |
+| ClusterPolicyReport | `wgpolicyk8s.io/v1alpha2` | — | Yes | Yes |
+
+PolicyReport findings also surface through the unified `/api/issues` endpoint (and the MCP `issues` tool) when opted in via `source=kyverno` / `include_kyverno=true` — `fail` and `error` results map to `critical`, `warn` maps to `warning`, and `pass` / `skip` are omitted.
 
 ---
 

--- a/internal/issues/issues.go
+++ b/internal/issues/issues.go
@@ -431,6 +431,15 @@ func fromWarningEvent(e *corev1.Event) Issue {
 // Filter + sort helpers
 // ---------------------------------------------------------------------------
 
+// wantSource implements the documented `source=` contract: it is a FILTER,
+// not an additive opt-in. When Filters.Sources is empty, every source is
+// allowed (defaults are then narrowed elsewhere — e.g. audit / event /
+// kyverno collection only runs when the matching IncludeX flag is set).
+// When Filters.Sources is non-empty, only the listed sources pass through;
+// passing source=kyverno therefore returns ONLY Kyverno rows, not
+// "defaults plus Kyverno". Callers that want "defaults plus X" should use
+// the include_X flags instead (the HTTP handler translates include_X=true
+// into both IncludeX=true AND leaves Sources empty, so the defaults stay).
 func wantSource(f Filters, s Source) bool {
 	if len(f.Sources) == 0 {
 		return true

--- a/internal/issues/issues.go
+++ b/internal/issues/issues.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/skyhook-io/radar/internal/k8s"
 	bp "github.com/skyhook-io/radar/pkg/audit"
+	"github.com/skyhook-io/radar/pkg/policyreports"
 )
 
 // Provider abstracts the data sources Compose needs. Implementations
@@ -26,6 +27,11 @@ type Provider interface {
 	WatchedDynamic() []schema.GroupVersionResource
 	ListDynamic(gvr schema.GroupVersionResource, namespace string) ([]*unstructured.Unstructured, error)
 	KindForGVR(gvr schema.GroupVersionResource) string
+	// KyvernoFindings returns every subject + findings pair currently
+	// indexed from PolicyReport / ClusterPolicyReport documents. Returns
+	// nil when Kyverno is not installed (the common case) — callers
+	// must treat nil as "no findings to surface" rather than an error.
+	KyvernoFindings() []policyreports.SubjectFindings
 }
 
 type dynamicScopeProvider interface {
@@ -92,6 +98,25 @@ func ComposeWithStats(p Provider, f Filters) ([]Issue, ComposeStats) {
 	if f.IncludeAudit && wantSource(f, SourceAudit) {
 		for _, fin := range p.AuditFindings(f.Namespaces) {
 			out = append(out, fromAudit(fin, now))
+		}
+	}
+
+	// ---- Source: kyverno (PolicyReport findings) -------------------
+	// Off by default, mirroring audit. Kyverno emits findings per
+	// (policy, rule, subject) tuple and a baseline PSS profile alone
+	// produces 10+ rows per workload — surfacing them in the default
+	// Issue view would drown the operator-actionable signals. Opt in
+	// via IncludeKyverno or source=kyverno.
+	if f.IncludeKyverno && wantSource(f, SourceKyverno) {
+		for _, sf := range p.KyvernoFindings() {
+			if !subjectInNamespaces(sf.Subject, f.Namespaces) {
+				continue
+			}
+			for _, fin := range sf.Findings {
+				if issue, ok := fromKyverno(sf.Subject, fin, now); ok {
+					out = append(out, issue)
+				}
+			}
 		}
 	}
 
@@ -309,6 +334,62 @@ func fromAudit(fin bp.Finding, now time.Time) Issue {
 		LastSeen:  now,
 		Count:     1,
 	}
+}
+
+// fromKyverno maps a single PolicyReport Finding into an Issue. The
+// second return is false when the finding's result is not a violation
+// we surface (pass / skip / unknown verdicts produce no Issue).
+//
+// Severity mapping is by Kyverno's `result` field — NOT by the report's
+// `severity` field. Rationale: `severity` is a free-form string set by
+// policy authors (e.g. "high", "medium", "low", or empty), inconsistent
+// across policies, and not aligned with the operator-actionable axis we
+// expose to consumers. The `result` enum is authoritative on whether
+// the engine considered the subject in violation, which is what the
+// Issue list represents.
+//
+//	fail  → SeverityCritical  (policy actively rejected the subject)
+//	warn  → SeverityWarning   (policy flagged but did not block)
+//	error → SeverityCritical  (engine could not evaluate; operator needs to know)
+//	pass / skip / other → omitted
+func fromKyverno(subj policyreports.Subject, fin policyreports.Finding, now time.Time) (Issue, bool) {
+	var sev Severity
+	switch strings.ToLower(fin.Result) {
+	case "fail", "error":
+		sev = SeverityCritical
+	case "warn":
+		sev = SeverityWarning
+	default:
+		return Issue{}, false
+	}
+	return Issue{
+		Severity:  sev,
+		Source:    SourceKyverno,
+		Kind:      subj.Kind,
+		Namespace: subj.Namespace,
+		Name:      subj.Name,
+		Reason:    fin.Policy,
+		Message:   fin.Message,
+		FirstSeen: now,
+		LastSeen:  now,
+		Count:     1,
+	}, true
+}
+
+// subjectInNamespaces reports whether a Kyverno subject should pass the
+// namespace filter. Empty Namespaces means "all namespaces"; cluster-
+// scoped subjects (Namespace == "") always pass — they're gated later
+// by CanReadClusterScoped.
+func subjectInNamespaces(subj policyreports.Subject, namespaces []string) bool {
+	if len(namespaces) == 0 || subj.Namespace == "" {
+		return true
+	}
+	for _, ns := range namespaces {
+		if ns == subj.Namespace {
+			return true
+		}
+	}
+	return false
 }
 
 // fromWarningEvent maps a K8s Warning event to an Issue. Severity is

--- a/internal/issues/issues.go
+++ b/internal/issues/issues.go
@@ -32,6 +32,13 @@ type Provider interface {
 	// nil when Kyverno is not installed (the common case) — callers
 	// must treat nil as "no findings to surface" rather than an error.
 	KyvernoFindings() []policyreports.SubjectFindings
+	// KyvernoStatus reports the PolicyReport index lifecycle phase so
+	// callers can distinguish "Kyverno not installed" from "warmup
+	// deferred (cluster too large)" from "warmup in flight" from "ready
+	// but empty". See k8s.KyvernoStatus for the enum values. Returned as
+	// a plain string so callers in this package don't need to import
+	// internal/k8s just to read the value.
+	KyvernoStatus() string
 }
 
 type dynamicScopeProvider interface {
@@ -366,6 +373,7 @@ func fromKyverno(subj policyreports.Subject, fin policyreports.Finding, now time
 		Severity:  sev,
 		Source:    SourceKyverno,
 		Kind:      subj.Kind,
+		Group:     subj.Group,
 		Namespace: subj.Namespace,
 		Name:      subj.Name,
 		Reason:    fin.Policy,

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -2,6 +2,7 @@ package issues
 
 import (
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 
 	"github.com/skyhook-io/radar/internal/k8s"
 	bp "github.com/skyhook-io/radar/pkg/audit"
+	"github.com/skyhook-io/radar/pkg/policyreports"
 )
 
 // fakeProvider — minimal Provider for unit testing. Each field
@@ -25,6 +27,7 @@ type fakeProvider struct {
 	dynamic      map[schema.GroupVersionResource][]*unstructured.Unstructured
 	kinds        map[schema.GroupVersionResource]string
 	namespaced   map[schema.GroupVersionResource]bool
+	kyverno      []policyreports.SubjectFindings
 }
 
 func (f *fakeProvider) DetectProblems(_ []string) []k8s.Problem     { return f.problems }
@@ -49,6 +52,9 @@ func (f *fakeProvider) KindForGVR(gvr schema.GroupVersionResource) string {
 func (f *fakeProvider) NamespacedForGVR(gvr schema.GroupVersionResource) (bool, bool) {
 	namespaced, ok := f.namespaced[gvr]
 	return namespaced, ok
+}
+func (f *fakeProvider) KyvernoFindings() []policyreports.SubjectFindings {
+	return f.kyverno
 }
 
 func TestCompose_NormalizesProblemSeverity(t *testing.T) {
@@ -265,6 +271,166 @@ func TestCompose_DropsUnauthorizedClusterScopedCRDConditions(t *testing.T) {
 	})
 	if len(out) != 0 {
 		t.Fatalf("cluster-scoped CRD condition leaked despite denied access: %+v", out)
+	}
+}
+
+func TestCompose_KyvernoExcludedByDefault(t *testing.T) {
+	p := &fakeProvider{
+		kyverno: []policyreports.SubjectFindings{{
+			Subject: policyreports.Subject{Kind: "Pod", Namespace: "prod", Name: "web"},
+			Findings: []policyreports.Finding{
+				{Policy: "require-resource-limits", Result: "fail", Message: "missing cpu limit"},
+			},
+		}},
+	}
+	out := Compose(p, Filters{})
+	for _, i := range out {
+		if i.Source == SourceKyverno {
+			t.Fatalf("kyverno should be excluded by default, got: %+v", i)
+		}
+	}
+}
+
+func TestCompose_KyvernoIncludedWhenOptedIn(t *testing.T) {
+	p := &fakeProvider{
+		kyverno: []policyreports.SubjectFindings{{
+			Subject: policyreports.Subject{Kind: "Pod", Namespace: "prod", Name: "web"},
+			Findings: []policyreports.Finding{
+				{Policy: "require-resource-limits", Result: "fail", Message: "missing cpu limit"},
+			},
+		}},
+	}
+	out := Compose(p, Filters{IncludeKyverno: true})
+	if len(out) != 1 {
+		t.Fatalf("got %d issues, want 1: %+v", len(out), out)
+	}
+	got := out[0]
+	if got.Source != SourceKyverno {
+		t.Fatalf("source: %s", got.Source)
+	}
+	if got.Severity != SeverityCritical {
+		t.Fatalf("fail should map to critical, got %s", got.Severity)
+	}
+	if got.Kind != "Pod" || got.Namespace != "prod" || got.Name != "web" {
+		t.Fatalf("subject not propagated: %+v", got)
+	}
+	if got.Reason != "require-resource-limits" {
+		t.Fatalf("reason should be policy name, got %q", got.Reason)
+	}
+	if got.Message != "missing cpu limit" {
+		t.Fatalf("message not propagated: %q", got.Message)
+	}
+	if got.Count != 1 {
+		t.Fatalf("count should be 1, got %d", got.Count)
+	}
+}
+
+func TestCompose_KyvernoSeverityMapping(t *testing.T) {
+	// fail/error → critical, warn → warning, pass/skip → omitted.
+	p := &fakeProvider{
+		kyverno: []policyreports.SubjectFindings{{
+			Subject: policyreports.Subject{Kind: "Pod", Namespace: "ns", Name: "p"},
+			Findings: []policyreports.Finding{
+				{Policy: "p1", Rule: "r1", Result: "fail", Message: "fail msg"},
+				{Policy: "p2", Rule: "r2", Result: "warn", Message: "warn msg"},
+				{Policy: "p3", Rule: "r3", Result: "error", Message: "error msg"},
+				{Policy: "p4", Rule: "r4", Result: "pass", Message: "pass msg"},
+				{Policy: "p5", Rule: "r5", Result: "skip", Message: "skip msg"},
+			},
+		}},
+	}
+	out := Compose(p, Filters{IncludeKyverno: true})
+	bySev := map[Severity]int{}
+	for _, i := range out {
+		bySev[i.Severity]++
+	}
+	if bySev[SeverityCritical] != 2 {
+		t.Fatalf("expected 2 critical (fail+error), got %d: %+v", bySev[SeverityCritical], out)
+	}
+	if bySev[SeverityWarning] != 1 {
+		t.Fatalf("expected 1 warning, got %d: %+v", bySev[SeverityWarning], out)
+	}
+	// pass + skip must not appear.
+	for _, i := range out {
+		if strings.Contains(i.Message, "pass msg") || strings.Contains(i.Message, "skip msg") {
+			t.Fatalf("pass/skip leaked into issues: %+v", i)
+		}
+	}
+}
+
+func TestCompose_KyvernoNamespaceFilter(t *testing.T) {
+	p := &fakeProvider{
+		kyverno: []policyreports.SubjectFindings{
+			{
+				Subject:  policyreports.Subject{Kind: "Pod", Namespace: "prod", Name: "web"},
+				Findings: []policyreports.Finding{{Policy: "p1", Result: "fail"}},
+			},
+			{
+				Subject:  policyreports.Subject{Kind: "Pod", Namespace: "dev", Name: "api"},
+				Findings: []policyreports.Finding{{Policy: "p2", Result: "fail"}},
+			},
+			{
+				// Cluster-scoped: namespace filter must NOT drop this.
+				Subject:  policyreports.Subject{Kind: "ClusterRole", Namespace: "", Name: "admin"},
+				Findings: []policyreports.Finding{{Policy: "p3", Result: "warn"}},
+			},
+		},
+	}
+	out := Compose(p, Filters{
+		IncludeKyverno: true,
+		Namespaces:     []string{"prod"},
+	})
+	gotByName := map[string]bool{}
+	for _, i := range out {
+		gotByName[i.Name] = true
+	}
+	if !gotByName["web"] {
+		t.Fatalf("prod/web should appear: %+v", out)
+	}
+	if gotByName["api"] {
+		t.Fatalf("dev/api should be filtered out: %+v", out)
+	}
+	if !gotByName["admin"] {
+		t.Fatalf("cluster-scoped subject should pass namespace filter: %+v", out)
+	}
+}
+
+func TestCompose_KyvernoNilFindingsGraceful(t *testing.T) {
+	// PolicyReport index returns nil when Kyverno is not installed —
+	// that's the common case and must not produce issues or errors.
+	p := &fakeProvider{kyverno: nil}
+	out := Compose(p, Filters{IncludeKyverno: true})
+	for _, i := range out {
+		if i.Source == SourceKyverno {
+			t.Fatalf("nil findings should not produce kyverno issues: %+v", i)
+		}
+	}
+}
+
+func TestCompose_KyvernoSourceListOptsIn(t *testing.T) {
+	// Passing source=kyverno explicitly must NOT require IncludeKyverno.
+	// The HTTP/MCP handlers set the flag, but at the Compose layer the
+	// source list alone gates emission once IncludeKyverno is set —
+	// this test pins the "list narrows but does not opt in" contract.
+	p := &fakeProvider{
+		kyverno: []policyreports.SubjectFindings{{
+			Subject:  policyreports.Subject{Kind: "Pod", Namespace: "ns", Name: "p"},
+			Findings: []policyreports.Finding{{Policy: "p1", Result: "fail"}},
+		}},
+		problems: []k8s.Problem{
+			{Kind: "Pod", Namespace: "ns", Name: "p", Severity: "critical", Reason: "x"},
+		},
+	}
+	// Sources={kyverno} but IncludeKyverno=false → no kyverno emission,
+	// and problem source filtered out → empty.
+	out := Compose(p, Filters{Sources: []Source{SourceKyverno}})
+	if len(out) != 0 {
+		t.Fatalf("expected 0 issues without IncludeKyverno, got %+v", out)
+	}
+	// With IncludeKyverno=true and Sources={kyverno} → only kyverno.
+	out = Compose(p, Filters{Sources: []Source{SourceKyverno}, IncludeKyverno: true})
+	if len(out) != 1 || out[0].Source != SourceKyverno {
+		t.Fatalf("expected only kyverno, got %+v", out)
 	}
 }
 

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -28,6 +28,7 @@ type fakeProvider struct {
 	kinds        map[schema.GroupVersionResource]string
 	namespaced   map[schema.GroupVersionResource]bool
 	kyverno      []policyreports.SubjectFindings
+	kyvernoStat  string
 }
 
 func (f *fakeProvider) DetectProblems(_ []string) []k8s.Problem     { return f.problems }
@@ -55,6 +56,9 @@ func (f *fakeProvider) NamespacedForGVR(gvr schema.GroupVersionResource) (bool, 
 }
 func (f *fakeProvider) KyvernoFindings() []policyreports.SubjectFindings {
 	return f.kyverno
+}
+func (f *fakeProvider) KyvernoStatus() string {
+	return f.kyvernoStat
 }
 
 func TestCompose_NormalizesProblemSeverity(t *testing.T) {
@@ -404,6 +408,56 @@ func TestCompose_KyvernoNilFindingsGraceful(t *testing.T) {
 		if i.Source == SourceKyverno {
 			t.Fatalf("nil findings should not produce kyverno issues: %+v", i)
 		}
+	}
+}
+
+// TestCompose_KyvernoGroupPropagated pins that fromKyverno wires the
+// Subject.Group into Issue.Group. Without this, agents and the SPA can't
+// tell which CRD a finding belongs to when the Kind is ambiguous (e.g.
+// argoproj.io/Application vs another vendor's Application), and the
+// SAR-backed CanReadClusterScoped check would query the wrong group.
+func TestCompose_KyvernoGroupPropagated(t *testing.T) {
+	p := &fakeProvider{
+		kyverno: []policyreports.SubjectFindings{
+			{
+				Subject: policyreports.Subject{
+					Group:     "argoproj.io",
+					Kind:      "Application",
+					Namespace: "prod",
+					Name:      "myapp",
+				},
+				Findings: []policyreports.Finding{
+					{Policy: "no-sync-loop", Result: "fail", Message: "sync loop"},
+				},
+			},
+			{
+				// Core kind: empty group must pass through (not silently
+				// replaced with anything else).
+				Subject: policyreports.Subject{
+					Group:     "",
+					Kind:      "Pod",
+					Namespace: "prod",
+					Name:      "web",
+				},
+				Findings: []policyreports.Finding{
+					{Policy: "require-resource-limits", Result: "fail"},
+				},
+			},
+		},
+	}
+	out := Compose(p, Filters{IncludeKyverno: true})
+	if len(out) != 2 {
+		t.Fatalf("expected 2 issues, got %d: %+v", len(out), out)
+	}
+	byKind := map[string]Issue{}
+	for _, i := range out {
+		byKind[i.Kind] = i
+	}
+	if app, ok := byKind["Application"]; !ok || app.Group != "argoproj.io" {
+		t.Errorf("Application Group not propagated: %+v", app)
+	}
+	if pod, ok := byKind["Pod"]; !ok || pod.Group != "" {
+		t.Errorf("Pod Group should be empty: %+v", pod)
 	}
 }
 

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -461,11 +461,16 @@ func TestCompose_KyvernoGroupPropagated(t *testing.T) {
 	}
 }
 
-func TestCompose_KyvernoSourceListOptsIn(t *testing.T) {
-	// Passing source=kyverno explicitly must NOT require IncludeKyverno.
-	// The HTTP/MCP handlers set the flag, but at the Compose layer the
-	// source list alone gates emission once IncludeKyverno is set —
-	// this test pins the "list narrows but does not opt in" contract.
+func TestCompose_KyvernoSourceListNarrowsButDoesNotOptIn(t *testing.T) {
+	// Pins the documented contract: `Sources` is a FILTER, not an
+	// additive opt-in. The list narrows the response to the named
+	// sources but does NOT enable collection of noisy sources —
+	// IncludeKyverno (set by the HTTP/MCP handlers) is what gates
+	// kyverno emission. With Sources={kyverno} and IncludeKyverno=false
+	// the response is empty. With IncludeKyverno=true the response is
+	// kyverno-only (problem source is filtered out because it isn't in
+	// Sources) — i.e. source=kyverno returns ONLY kyverno rows, not
+	// "defaults plus kyverno".
 	p := &fakeProvider{
 		kyverno: []policyreports.SubjectFindings{{
 			Subject:  policyreports.Subject{Kind: "Pod", Namespace: "ns", Name: "p"},

--- a/internal/issues/provider.go
+++ b/internal/issues/provider.go
@@ -11,6 +11,7 @@ import (
 	"github.com/skyhook-io/radar/internal/audit"
 	"github.com/skyhook-io/radar/internal/k8s"
 	bp "github.com/skyhook-io/radar/pkg/audit"
+	"github.com/skyhook-io/radar/pkg/policyreports"
 )
 
 // CacheProvider adapts radar's in-process caches to the Provider
@@ -151,6 +152,14 @@ func (p *CacheProvider) ListDynamic(gvr schema.GroupVersionResource, namespace s
 		return nil, nil
 	}
 	return p.dynamic.List(gvr, namespace)
+}
+
+func (p *CacheProvider) KyvernoFindings() []policyreports.SubjectFindings {
+	idx := k8s.GetPolicyReportIndex()
+	if idx == nil {
+		return nil
+	}
+	return idx.All()
 }
 
 func (p *CacheProvider) KindForGVR(gvr schema.GroupVersionResource) string {

--- a/internal/issues/provider.go
+++ b/internal/issues/provider.go
@@ -162,6 +162,13 @@ func (p *CacheProvider) KyvernoFindings() []policyreports.SubjectFindings {
 	return idx.All()
 }
 
+// KyvernoStatus is a thin string-typed wrapper around k8s.GetKyvernoStatus
+// so the issues package doesn't need to depend on the k8s package for the
+// enum. Values are the constants documented on k8s.KyvernoStatus.
+func (p *CacheProvider) KyvernoStatus() string {
+	return string(k8s.GetKyvernoStatus())
+}
+
 func (p *CacheProvider) KindForGVR(gvr schema.GroupVersionResource) string {
 	if p.discovery == nil {
 		return ""

--- a/internal/issues/types.go
+++ b/internal/issues/types.go
@@ -43,6 +43,7 @@ const (
 	SourceAudit     Source = "audit"     // best-practice audit findings
 	SourceEvent     Source = "event"     // K8s Warning events (recent)
 	SourceCondition Source = "condition" // generic CRD .status.conditions[].status=False fallback
+	SourceKyverno   Source = "kyverno"   // Kyverno PolicyReport findings (opt-in)
 )
 
 // Ref is a lightweight resource reference, used for owner pointers.
@@ -102,6 +103,12 @@ type Filters struct {
 	// window (handler defaults to 1h when events are on and Since is
 	// zero).
 	IncludeEvents bool
+	// IncludeKyverno defaults to false. Kyverno PolicyReport findings
+	// are loud (a baseline cluster-pss profile alone emits 10+ findings
+	// per workload) and the default Issue view should not be dominated
+	// by best-practice/policy noise. Opt in via include_kyverno=true
+	// or by passing "kyverno" in the source list.
+	IncludeKyverno bool
 	// Filter is an optional compiled CEL predicate evaluated against
 	// each composed Issue's row bindings. Compile happens in the
 	// handler (and is cached); this layer just runs the program.

--- a/internal/k8s/policy_reports.go
+++ b/internal/k8s/policy_reports.go
@@ -44,8 +44,20 @@ const (
 // kyvernoWarmupDecision is set by WarmupKyvernoPolicyReports to record
 // the outcome of its single decision pass: empty (warmup hasn't run yet)
 // vs not-installed vs deferred vs ready. Read by GetKyvernoStatus so
-// callers can disambiguate a nil GetPolicyReportIndex() return.
+// callers can disambiguate a nil GetPolicyReportIndex() return. Writes
+// from WarmupKyvernoPolicyReports go through setDecisionIfCurrent so a
+// pre-Reset warmup goroutine that's still running can't stamp its
+// outcome onto the new cluster's atomic.
 var kyvernoWarmupDecision atomic.Value // holds KyvernoStatus, "" before first decision
+
+// kyvernoWarmupGen serializes "is this warmup still the current one"
+// against context-switch Resets. Each Warmup invocation captures the
+// generation at the start of its lambda; Reset bumps the counter before
+// clearing state. Stale warmup completions (e.g. an in-flight Old-cluster
+// warmup that hasn't yet stored ready when Reset fires for the new
+// cluster) see a mismatch and skip their writes, so the new cluster never
+// inherits the old cluster's index or decision.
+var kyvernoWarmupGen atomic.Int64
 
 // PolicyReport GVRs. Kept here (not in supportedCRDFallbacks) because
 // warmup is conditional — we only register informers for these CRDs when
@@ -140,25 +152,50 @@ func GetPolicyReportIndex() *policyreports.Index {
 // dominant lifecycle event in practice.
 func WarmupKyvernoPolicyReports() {
 	policyReportInit.Do(func() {
+		// Capture the generation at the start of THIS warmup. If a context
+		// switch runs Reset before we finish, kyvernoWarmupGen advances and
+		// setDecision / publishReady become no-ops — preventing this lambda
+		// from stamping the old cluster's outcome onto the new cluster's
+		// atomic. See kyvernoWarmupGen's declaration for the race scenario.
+		myGen := kyvernoWarmupGen.Load()
+		setDecision := func(s KyvernoStatus) {
+			policyReportMu.Lock()
+			defer policyReportMu.Unlock()
+			if kyvernoWarmupGen.Load() != myGen {
+				return
+			}
+			kyvernoWarmupDecision.Store(s)
+		}
+		publishReady := func(idx *policyreports.Index, watched []schema.GroupVersionResource) {
+			policyReportMu.Lock()
+			defer policyReportMu.Unlock()
+			if kyvernoWarmupGen.Load() != myGen {
+				return
+			}
+			policyReportIndex.Store(idx)
+			policyReportWatched = watched
+			kyvernoWarmupDecision.Store(KyvernoStatusReady)
+		}
+
 		discovery := GetResourceDiscovery()
 		if discovery == nil || discovery.ResourceDiscovery == nil {
 			log.Printf("[policy-reports] No resource discovery available; skipping Kyverno detection")
 			// Discovery unavailable is operationally indistinguishable from
 			// "not installed" — the consumer surface only needs to know
 			// findings won't appear.
-			kyvernoWarmupDecision.Store(KyvernoStatusNotInstalled)
+			setDecision(KyvernoStatusNotInstalled)
 			return
 		}
 		if !discovery.IsKyvernoInstalled() {
 			log.Printf("[policy-reports] Kyverno not detected (no kyverno.io/Policy or ClusterPolicy); leaving PolicyReports deferred")
-			kyvernoWarmupDecision.Store(KyvernoStatusNotInstalled)
+			setDecision(KyvernoStatusNotInstalled)
 			return
 		}
 
 		cache := GetDynamicResourceCache()
 		if cache == nil || cache.DynamicResourceCache == nil {
 			log.Printf("[policy-reports] Dynamic resource cache not initialized; cannot warm up PolicyReports")
-			kyvernoWarmupDecision.Store(KyvernoStatusDeferred)
+			setDecision(KyvernoStatusDeferred)
 			return
 		}
 
@@ -184,7 +221,7 @@ func WarmupKyvernoPolicyReports() {
 			// Kyverno is installed but the reporting CRDs aren't — operator
 			// has Kyverno without the policy-reporter shim. Surface as
 			// not_installed because there is no PolicyReport data to expose.
-			kyvernoWarmupDecision.Store(KyvernoStatusNotInstalled)
+			setDecision(KyvernoStatusNotInstalled)
 			return
 		}
 
@@ -202,14 +239,14 @@ func WarmupKyvernoPolicyReports() {
 				// -1 RBAC denied, -2 transient probe error. Either way, we
 				// can't bound the warmup cost; defer rather than gamble.
 				log.Printf("[policy-reports] Probe for %s returned %d; deferring PolicyReport warmup", gvr, count)
-				kyvernoWarmupDecision.Store(KyvernoStatusDeferred)
+				setDecision(KyvernoStatusDeferred)
 				return
 			}
 			total += count
 		}
 		if total > kyvernoReportWarmupCap {
 			log.Printf("[policy-reports] Cluster has %d PolicyReports across %d CRDs (cap=%d); leaving deferred to avoid full-cluster watch cost", total, len(watched), kyvernoReportWarmupCap)
-			kyvernoWarmupDecision.Store(KyvernoStatusDeferred)
+			setDecision(KyvernoStatusDeferred)
 			return
 		}
 
@@ -221,22 +258,14 @@ func WarmupKyvernoPolicyReports() {
 		// with the informer's initial event burst.
 		idx := policyreports.NewIndex()
 		idx.Replace(listPolicyReportsAll(watched))
-		// Publish index + watched-GVR list together under the mutex. The
-		// rebuild path reads policyReportWatched while holding the same
-		// mutex, and ResetPolicyReportIndex (context switch) takes it to
-		// clear both. Without the lock here, a concurrent Reset would race
-		// with this assignment and could leave the new context with stale
-		// GVRs from the prior cluster.
-		policyReportMu.Lock()
-		policyReportIndex.Store(idx)
-		policyReportWatched = watched
-		policyReportMu.Unlock()
 
-		// Register event handlers for live updates. Each handler does a
-		// debounced rebuild — PolicyReport events arrive in bursts when
-		// Kyverno re-evaluates a policy, and rebuilding once per burst
-		// is cheaper than per-event incremental updates given how small
-		// the index is (≤500 reports).
+		// Register event handlers for live updates BEFORE publishing the
+		// index so a debounced rebuild that fires during publishReady's
+		// critical section sees the new policyReportWatched value. Each
+		// handler does a debounced rebuild — PolicyReport events arrive
+		// in bursts when Kyverno re-evaluates a policy, and rebuilding
+		// once per burst is cheaper than per-event incremental updates
+		// given how small the index is (≤500 reports).
 		handler := toolscache.ResourceEventHandlerFuncs{
 			AddFunc:    func(_ any) { scheduleRebuild() },
 			UpdateFunc: func(_, _ any) { scheduleRebuild() },
@@ -250,7 +279,14 @@ func WarmupKyvernoPolicyReports() {
 			}
 		}
 
-		kyvernoWarmupDecision.Store(KyvernoStatusReady)
+		// Publish index + watched-GVR list + ready decision together
+		// under the mutex. The rebuild path reads policyReportWatched
+		// while holding the same mutex, and ResetPolicyReportIndex
+		// (context switch) takes it to clear both. publishReady's
+		// generation check ensures a Reset that fires before this point
+		// causes the writes to be skipped, so the new cluster never
+		// inherits the old cluster's index or decision.
+		publishReady(idx, watched)
 		log.Printf("[policy-reports] Index initialized with %d subjects", idx.Size())
 	})
 }
@@ -357,6 +393,11 @@ func ResetPolicyReportIndex() {
 	policyReportMu.Lock()
 	defer policyReportMu.Unlock()
 
+	// Bump the generation inside the critical section so any in-flight
+	// warmup goroutine's setDecision/publishReady call (which checks gen
+	// under the same mutex) skips its writes instead of stamping the old
+	// cluster's outcome onto the new cluster's atomic.
+	kyvernoWarmupGen.Add(1)
 	policyReportIndex.Store(nil)
 	policyReportWatched = nil
 	policyReportPending.Store(false)

--- a/internal/k8s/policy_reports.go
+++ b/internal/k8s/policy_reports.go
@@ -151,13 +151,22 @@ func GetPolicyReportIndex() *policyreports.Index {
 // lazily. Documented limitation, not blocking — context switches are the
 // dominant lifecycle event in practice.
 func WarmupKyvernoPolicyReports() {
-	policyReportInit.Do(func() {
-		// Capture the generation at the start of THIS warmup. If a context
-		// switch runs Reset before we finish, kyvernoWarmupGen advances and
-		// setDecision / publishReady become no-ops — preventing this lambda
-		// from stamping the old cluster's outcome onto the new cluster's
-		// atomic. See kyvernoWarmupGen's declaration for the race scenario.
-		myGen := kyvernoWarmupGen.Load()
+	// Snapshot BOTH the *sync.Once and the warmup generation under the
+	// mutex BEFORE entering Do(). If we read policyReportInit unsynchronized
+	// and captured myGen inside the lambda, a Reset interleaving between the
+	// caller's read of policyReportInit and the lambda's Load of
+	// kyvernoWarmupGen would let the lambda capture the POST-Reset gen,
+	// and its subsequent writes (which check gen under the mutex) would
+	// match — stamping the previous cluster's outcome onto the new cluster's
+	// atomics. Capturing both under the same mutex Reset holds closes that
+	// window: either we see the pre-Reset (once, gen) pair and Reset's
+	// bump invalidates our writes, or we see the post-Reset (once', gen')
+	// pair and run cleanly under the new sync.Once.
+	policyReportMu.Lock()
+	once := policyReportInit
+	myGen := kyvernoWarmupGen.Load()
+	policyReportMu.Unlock()
+	once.Do(func() {
 		setDecision := func(s KyvernoStatus) {
 			policyReportMu.Lock()
 			defer policyReportMu.Unlock()

--- a/internal/k8s/policy_reports.go
+++ b/internal/k8s/policy_reports.go
@@ -13,6 +13,40 @@ import (
 	"github.com/skyhook-io/radar/pkg/policyreports"
 )
 
+// KyvernoStatus reports why the PolicyReport index is (or isn't) populated.
+// Callers that need to distinguish "Kyverno not installed" from "warmup
+// deferred (cluster too large)" from "warmup in flight" from "ready but
+// empty" use GetKyvernoStatus to surface the reason to the operator/agent
+// — otherwise an empty PolicyReport response is indistinguishable from a
+// transient one.
+type KyvernoStatus string
+
+const (
+	// KyvernoStatusNotInstalled — Kyverno's Policy/ClusterPolicy CRDs are
+	// not present in discovery. The PolicyReport source is unavailable;
+	// nothing to do.
+	KyvernoStatusNotInstalled KyvernoStatus = "not_installed"
+	// KyvernoStatusDeferred — Kyverno is installed but warmup decided not
+	// to track PolicyReports (cluster aggregate exceeds the warmup cap, or
+	// the probe was denied/errored). Findings are NOT being indexed.
+	// Callers wanting them must fall back to a direct fetch.
+	KyvernoStatusDeferred KyvernoStatus = "deferred"
+	// KyvernoStatusWarmup — Kyverno is installed and warmup is presumed
+	// in-flight (discovery has named the CRDs but the index hasn't been
+	// published yet). Narrow window; expect to become "ready" shortly.
+	KyvernoStatusWarmup KyvernoStatus = "warmup"
+	// KyvernoStatusReady — PolicyReport index is populated and live. An
+	// empty findings list with this status means "no policy violations",
+	// not "data unavailable".
+	KyvernoStatusReady KyvernoStatus = "ready"
+)
+
+// kyvernoWarmupDecision is set by WarmupKyvernoPolicyReports to record
+// the outcome of its single decision pass: empty (warmup hasn't run yet)
+// vs not-installed vs deferred vs ready. Read by GetKyvernoStatus so
+// callers can disambiguate a nil GetPolicyReportIndex() return.
+var kyvernoWarmupDecision atomic.Value // holds KyvernoStatus, "" before first decision
+
 // PolicyReport GVRs. Kept here (not in supportedCRDFallbacks) because
 // warmup is conditional — we only register informers for these CRDs when
 // Kyverno's own Policy/ClusterPolicy CRDs are present in discovery.
@@ -109,16 +143,22 @@ func WarmupKyvernoPolicyReports() {
 		discovery := GetResourceDiscovery()
 		if discovery == nil || discovery.ResourceDiscovery == nil {
 			log.Printf("[policy-reports] No resource discovery available; skipping Kyverno detection")
+			// Discovery unavailable is operationally indistinguishable from
+			// "not installed" — the consumer surface only needs to know
+			// findings won't appear.
+			kyvernoWarmupDecision.Store(KyvernoStatusNotInstalled)
 			return
 		}
 		if !discovery.IsKyvernoInstalled() {
 			log.Printf("[policy-reports] Kyverno not detected (no kyverno.io/Policy or ClusterPolicy); leaving PolicyReports deferred")
+			kyvernoWarmupDecision.Store(KyvernoStatusNotInstalled)
 			return
 		}
 
 		cache := GetDynamicResourceCache()
 		if cache == nil || cache.DynamicResourceCache == nil {
 			log.Printf("[policy-reports] Dynamic resource cache not initialized; cannot warm up PolicyReports")
+			kyvernoWarmupDecision.Store(KyvernoStatusDeferred)
 			return
 		}
 
@@ -141,6 +181,10 @@ func WarmupKyvernoPolicyReports() {
 
 		if len(watched) == 0 {
 			log.Printf("[policy-reports] Kyverno detected but no wgpolicyk8s.io PolicyReport CRDs are registered for watch; nothing to warm up")
+			// Kyverno is installed but the reporting CRDs aren't — operator
+			// has Kyverno without the policy-reporter shim. Surface as
+			// not_installed because there is no PolicyReport data to expose.
+			kyvernoWarmupDecision.Store(KyvernoStatusNotInstalled)
 			return
 		}
 
@@ -158,12 +202,14 @@ func WarmupKyvernoPolicyReports() {
 				// -1 RBAC denied, -2 transient probe error. Either way, we
 				// can't bound the warmup cost; defer rather than gamble.
 				log.Printf("[policy-reports] Probe for %s returned %d; deferring PolicyReport warmup", gvr, count)
+				kyvernoWarmupDecision.Store(KyvernoStatusDeferred)
 				return
 			}
 			total += count
 		}
 		if total > kyvernoReportWarmupCap {
 			log.Printf("[policy-reports] Cluster has %d PolicyReports across %d CRDs (cap=%d); leaving deferred to avoid full-cluster watch cost", total, len(watched), kyvernoReportWarmupCap)
+			kyvernoWarmupDecision.Store(KyvernoStatusDeferred)
 			return
 		}
 
@@ -204,8 +250,40 @@ func WarmupKyvernoPolicyReports() {
 			}
 		}
 
+		kyvernoWarmupDecision.Store(KyvernoStatusReady)
 		log.Printf("[policy-reports] Index initialized with %d subjects", idx.Size())
 	})
+}
+
+// GetKyvernoStatus reports the lifecycle phase of the PolicyReport index.
+// Distinguishes the four cases that a nil GetPolicyReportIndex() return
+// collapses today:
+//
+//	not_installed — discovery decided Kyverno is absent (or the reporting
+//	                CRDs are missing); findings will never appear.
+//	deferred      — warmup ran but skipped indexing (cluster exceeded the
+//	                cap, or RBAC/probe error). Findings won't appear from
+//	                this index; callers may fall back to on-demand.
+//	warmup        — warmup hasn't completed its decision pass yet (typical
+//	                for the first second or two after subsystem init); the
+//	                index is uninitialized.
+//	ready         — index is live. An empty findings list under this
+//	                status means "no violations", not "data unavailable".
+//
+// Cheap: a single atomic.Value Load. Safe to call from request paths.
+func GetKyvernoStatus() KyvernoStatus {
+	// Ready is authoritative: even if a stale "warmup" decision is in the
+	// atomic (legal during a window in WarmupKyvernoPolicyReports where
+	// the index publishes before the decision flag), the presence of an
+	// index means we are ready.
+	if policyReportIndex.Load() != nil {
+		return KyvernoStatusReady
+	}
+	v, _ := kyvernoWarmupDecision.Load().(KyvernoStatus)
+	if v == "" {
+		return KyvernoStatusWarmup
+	}
+	return v
 }
 
 // listPolicyReportsAll concatenates reports from every watched GVR.
@@ -282,6 +360,10 @@ func ResetPolicyReportIndex() {
 	policyReportIndex.Store(nil)
 	policyReportWatched = nil
 	policyReportPending.Store(false)
+	// Clear the warmup decision too — the new cluster gets a fresh
+	// detection pass, and GetKyvernoStatus should report "warmup" until
+	// the new pass completes (not whatever the previous cluster decided).
+	kyvernoWarmupDecision.Store(KyvernoStatus(""))
 	// Replace the pointer rather than zeroing the value — see the comment
 	// on policyReportInit's declaration. Any Do() lambda still running on
 	// the old *sync.Once finishes against that instance without

--- a/internal/k8s/policy_reports_test.go
+++ b/internal/k8s/policy_reports_test.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/skyhook-io/radar/pkg/policyreports"
@@ -96,11 +97,11 @@ func TestResetPolicyReportIndex_ClearsKyvernoDecision(t *testing.T) {
 
 // TestResetPolicyReportIndex_BumpsWarmupGen pins the race-protection
 // invariant: each Reset advances kyvernoWarmupGen so any in-flight Warmup
-// goroutine's setDecision/publishReady writes (which capture gen at
-// lambda entry and verify under the mutex before storing) become no-ops
-// against the new cluster. Without this bump, a slow Warmup from the
-// previous cluster context could stamp KyvernoStatusReady onto the new
-// cluster's atomic between the Reset and the new cluster's own Warmup.
+// goroutine's setDecision/publishReady writes (which snapshot gen under
+// the mutex before Do() and verify under the mutex before storing) become
+// no-ops against the new cluster. Without this bump, a slow Warmup from
+// the previous cluster context could stamp KyvernoStatusReady onto the
+// new cluster's atomic between the Reset and the new cluster's own Warmup.
 func TestResetPolicyReportIndex_BumpsWarmupGen(t *testing.T) {
 	t.Cleanup(func() {
 		policyReportMu.Lock()
@@ -120,5 +121,154 @@ func TestResetPolicyReportIndex_BumpsWarmupGen(t *testing.T) {
 	ResetPolicyReportIndex()
 	if after2 := kyvernoWarmupGen.Load(); after2 <= after {
 		t.Fatalf("kyvernoWarmupGen not strictly monotonic: %d -> %d", after, after2)
+	}
+}
+
+// TestWarmupKyvernoPolicyReports_StaleGenSkipsWrites pins the structural
+// invariant that backs the snapshot-under-mutex pattern in
+// WarmupKyvernoPolicyReports: if the warmup goroutine's captured myGen
+// no longer matches kyvernoWarmupGen at write time (i.e. a Reset
+// interleaved between snapshot capture and the write), setDecision /
+// publishReady must skip their writes — otherwise the previous cluster's
+// outcome leaks onto the new cluster's atomics.
+//
+// We can't reach setDecision / publishReady directly (they're closures
+// inside Warmup's Do() lambda), so we replicate the EXACT write protocol
+// they use — read kyvernoWarmupGen under policyReportMu, compare to a
+// captured myGen, store only on match — and verify a manually-bumped gen
+// causes the equivalent write to be skipped. A regression that drops the
+// gen check anywhere in the warmup-write path would break this
+// invariant; this test is what catches it.
+func TestWarmupKyvernoPolicyReports_StaleGenSkipsWrites(t *testing.T) {
+	origIdx := policyReportIndex.Load()
+	origDec, _ := kyvernoWarmupDecision.Load().(KyvernoStatus)
+	origGen := kyvernoWarmupGen.Load()
+	t.Cleanup(func() {
+		policyReportIndex.Store(origIdx)
+		kyvernoWarmupDecision.Store(origDec)
+		// Restore the gen atomic so other tests aren't perturbed.
+		kyvernoWarmupGen.Store(origGen)
+		policyReportMu.Lock()
+		policyReportInit = new(sync.Once)
+		policyReportMu.Unlock()
+	})
+
+	// Stage state to mimic the moment a warmup has just snapshotted gen
+	// under the mutex and is about to perform a write: index empty,
+	// decision empty.
+	policyReportIndex.Store(nil)
+	kyvernoWarmupDecision.Store(KyvernoStatus(""))
+
+	// Capture myGen exactly as WarmupKyvernoPolicyReports does — under
+	// the mutex, BEFORE any downstream work.
+	policyReportMu.Lock()
+	myGen := kyvernoWarmupGen.Load()
+	policyReportMu.Unlock()
+
+	// Simulate ResetPolicyReportIndex firing AFTER the snapshot: it
+	// bumps gen (under the same mutex, also held inside the test's write
+	// closure below).
+	kyvernoWarmupGen.Add(1)
+
+	// Replicate setDecision's exact protocol: lock, gen check, store.
+	stalePathRan := false
+	(func() {
+		policyReportMu.Lock()
+		defer policyReportMu.Unlock()
+		if kyvernoWarmupGen.Load() != myGen {
+			stalePathRan = true
+			return
+		}
+		kyvernoWarmupDecision.Store(KyvernoStatusReady)
+	})()
+	if !stalePathRan {
+		t.Fatal("expected setDecision's gen check to fire and skip the write; the gen-mismatch branch was not taken (regression: the protection against stale-warmup writes is broken)")
+	}
+	if got, _ := kyvernoWarmupDecision.Load().(KyvernoStatus); got != "" {
+		t.Errorf("decision atomic was stamped despite gen mismatch: got %q, want empty (stale warmup leaked into new cluster's state)", got)
+	}
+
+	// Replicate publishReady's protocol with the same myGen — also must
+	// skip its index store on gen mismatch.
+	(func() {
+		policyReportMu.Lock()
+		defer policyReportMu.Unlock()
+		if kyvernoWarmupGen.Load() != myGen {
+			return
+		}
+		policyReportIndex.Store(policyreports.NewIndex())
+	})()
+	if got := policyReportIndex.Load(); got != nil {
+		t.Errorf("policyReportIndex was stamped despite gen mismatch: stale publishReady leaked an index onto a fresh cluster's atomic")
+	}
+}
+
+// TestWarmupKyvernoPolicyReports_SnapshotsOnceAndGenAtomically pins the
+// snapshot-under-mutex invariant: WarmupKyvernoPolicyReports must capture
+// BOTH policyReportInit and kyvernoWarmupGen under policyReportMu so that
+// a concurrent Reset can never separate them. The race the new code
+// closes: an unsynchronized read of policyReportInit followed by a
+// later (post-Reset) Load of kyvernoWarmupGen would capture the
+// pre-Reset Once with the post-Reset gen, and the lambda's gen check
+// against the post-Reset value would falsely succeed — stamping the old
+// cluster's outcome onto the new cluster's atomics.
+//
+// We exercise this by spinning concurrent (snapshot+inspect) and Reset
+// goroutines and asserting that the snapshot pair stays coherent: if
+// the snapshotted gen equals the post-snapshot gen, the snapshotted
+// once must still be the live one (and vice versa for the mismatch
+// case). Run with -race for full effect.
+func TestWarmupKyvernoPolicyReports_SnapshotsOnceAndGenAtomically(t *testing.T) {
+	origGen := kyvernoWarmupGen.Load()
+	t.Cleanup(func() {
+		kyvernoWarmupGen.Store(origGen)
+		policyReportMu.Lock()
+		policyReportInit = new(sync.Once)
+		policyReportMu.Unlock()
+	})
+
+	const iterations = 500
+	var mismatch atomic.Int64
+
+	var wg sync.WaitGroup
+	// Resetters: bump gen + replace the once under the mutex.
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				ResetPolicyReportIndex()
+			}
+		}()
+	}
+	// Snapshotters: emulate the new WarmupKyvernoPolicyReports prologue
+	// — snapshot (once, gen) atomically under the mutex, then verify the
+	// pair is consistent with a SECOND snapshot under the same mutex
+	// where the once and gen are read together. Any tearing here would
+	// be visible as a mismatch.
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				policyReportMu.Lock()
+				once1 := policyReportInit
+				gen1 := kyvernoWarmupGen.Load()
+				// A second read under the same mutex must see the same
+				// pair — both fields only mutate inside Reset, which
+				// holds this mutex.
+				once2 := policyReportInit
+				gen2 := kyvernoWarmupGen.Load()
+				policyReportMu.Unlock()
+				if once1 != once2 || gen1 != gen2 {
+					mismatch.Add(1)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := mismatch.Load(); got != 0 {
+		t.Fatalf("snapshot pair was not atomic under policyReportMu: %d mismatches (Reset is mutating policyReportInit and/or kyvernoWarmupGen outside the mutex, OR the snapshot is being torn — either breaks the race protection)", got)
 	}
 }

--- a/internal/k8s/policy_reports_test.go
+++ b/internal/k8s/policy_reports_test.go
@@ -93,3 +93,32 @@ func TestResetPolicyReportIndex_ClearsKyvernoDecision(t *testing.T) {
 		t.Errorf("after reset: got %q want %q (must not inherit prior cluster's decision)", got, KyvernoStatusWarmup)
 	}
 }
+
+// TestResetPolicyReportIndex_BumpsWarmupGen pins the race-protection
+// invariant: each Reset advances kyvernoWarmupGen so any in-flight Warmup
+// goroutine's setDecision/publishReady writes (which capture gen at
+// lambda entry and verify under the mutex before storing) become no-ops
+// against the new cluster. Without this bump, a slow Warmup from the
+// previous cluster context could stamp KyvernoStatusReady onto the new
+// cluster's atomic between the Reset and the new cluster's own Warmup.
+func TestResetPolicyReportIndex_BumpsWarmupGen(t *testing.T) {
+	t.Cleanup(func() {
+		policyReportMu.Lock()
+		policyReportInit = new(sync.Once)
+		policyReportMu.Unlock()
+	})
+
+	before := kyvernoWarmupGen.Load()
+	ResetPolicyReportIndex()
+	after := kyvernoWarmupGen.Load()
+	if after <= before {
+		t.Fatalf("kyvernoWarmupGen did not advance: before=%d after=%d (Reset must bump gen so in-flight warmups skip stale writes)", before, after)
+	}
+
+	// A second Reset should bump again — bounded monotonic counter, not
+	// a toggle.
+	ResetPolicyReportIndex()
+	if after2 := kyvernoWarmupGen.Load(); after2 <= after {
+		t.Fatalf("kyvernoWarmupGen not strictly monotonic: %d -> %d", after, after2)
+	}
+}

--- a/internal/k8s/policy_reports_test.go
+++ b/internal/k8s/policy_reports_test.go
@@ -93,4 +93,3 @@ func TestResetPolicyReportIndex_ClearsKyvernoDecision(t *testing.T) {
 		t.Errorf("after reset: got %q want %q (must not inherit prior cluster's decision)", got, KyvernoStatusWarmup)
 	}
 }
-

--- a/internal/k8s/policy_reports_test.go
+++ b/internal/k8s/policy_reports_test.go
@@ -1,0 +1,96 @@
+package k8s
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/skyhook-io/radar/pkg/policyreports"
+)
+
+// TestGetKyvernoStatus_LifecycleTransitions pins the four states callers
+// can observe via the public GetKyvernoStatus accessor. The status backs
+// the meta.kyverno field on /api/issues + the MCP issues tool, so a regression
+// here flips the SPA/agent's behavior between "no findings yet" copy and
+// "no violations" copy — both bad.
+//
+// We drive the state via direct manipulation of the package-level atomics
+// rather than running real warmup (which needs discovery + dynamic cache).
+// The intent here is to pin the public accessor's reading of those
+// atomics; the warmup decisions themselves are wired in
+// WarmupKyvernoPolicyReports and have their own coverage in
+// integration/e2e flows.
+func TestGetKyvernoStatus_LifecycleTransitions(t *testing.T) {
+	// Snapshot + restore the package state so this test doesn't bleed
+	// into other tests in the suite (they may have run WarmupKyverno…
+	// indirectly, populating these globals).
+	origIdx := policyReportIndex.Load()
+	origDec, _ := kyvernoWarmupDecision.Load().(KyvernoStatus)
+	t.Cleanup(func() {
+		policyReportIndex.Store(origIdx)
+		kyvernoWarmupDecision.Store(origDec)
+	})
+
+	// State 1: no decision recorded yet + no index → warmup.
+	policyReportIndex.Store(nil)
+	kyvernoWarmupDecision.Store(KyvernoStatus(""))
+	if got := GetKyvernoStatus(); got != KyvernoStatusWarmup {
+		t.Errorf("uninitialized: got %q want %q", got, KyvernoStatusWarmup)
+	}
+
+	// State 2: decided not-installed, no index → not_installed.
+	kyvernoWarmupDecision.Store(KyvernoStatusNotInstalled)
+	if got := GetKyvernoStatus(); got != KyvernoStatusNotInstalled {
+		t.Errorf("not_installed: got %q want %q", got, KyvernoStatusNotInstalled)
+	}
+
+	// State 3: decided deferred, no index → deferred.
+	kyvernoWarmupDecision.Store(KyvernoStatusDeferred)
+	if got := GetKyvernoStatus(); got != KyvernoStatusDeferred {
+		t.Errorf("deferred: got %q want %q", got, KyvernoStatusDeferred)
+	}
+
+	// State 4: index exists → ready (even if decision atomic is stale —
+	// the index's presence is authoritative).
+	idx := policyreports.NewIndex()
+	policyReportIndex.Store(idx)
+	if got := GetKyvernoStatus(); got != KyvernoStatusReady {
+		t.Errorf("ready: got %q want %q", got, KyvernoStatusReady)
+	}
+
+	// Index + decision agree on ready.
+	kyvernoWarmupDecision.Store(KyvernoStatusReady)
+	if got := GetKyvernoStatus(); got != KyvernoStatusReady {
+		t.Errorf("ready (both): got %q want %q", got, KyvernoStatusReady)
+	}
+}
+
+// TestResetPolicyReportIndex_ClearsKyvernoDecision pins the context-switch
+// path: when the user switches clusters, ResetPolicyReportIndex must
+// clear the warmup decision so the new cluster reports "warmup" until
+// its own detection pass completes — not whatever the previous cluster
+// decided.
+func TestResetPolicyReportIndex_ClearsKyvernoDecision(t *testing.T) {
+	origIdx := policyReportIndex.Load()
+	origDec, _ := kyvernoWarmupDecision.Load().(KyvernoStatus)
+	t.Cleanup(func() {
+		policyReportIndex.Store(origIdx)
+		kyvernoWarmupDecision.Store(origDec)
+		// Restore policyReportInit too — Reset replaces it.
+		policyReportMu.Lock()
+		policyReportInit = new(sync.Once)
+		policyReportMu.Unlock()
+	})
+
+	// Simulate a prior cluster that decided "ready".
+	policyReportIndex.Store(policyreports.NewIndex())
+	kyvernoWarmupDecision.Store(KyvernoStatusReady)
+
+	ResetPolicyReportIndex()
+
+	// After reset: index nil, decision empty → status reports "warmup"
+	// (not "ready", not "not_installed" inherited from prior cluster).
+	if got := GetKyvernoStatus(); got != KyvernoStatusWarmup {
+		t.Errorf("after reset: got %q want %q (must not inherit prior cluster's decision)", got, KyvernoStatusWarmup)
+	}
+}
+

--- a/internal/k8s/policy_reports_testhooks.go
+++ b/internal/k8s/policy_reports_testhooks.go
@@ -1,6 +1,8 @@
 package k8s
 
 import (
+	"fmt"
+
 	"github.com/skyhook-io/radar/pkg/policyreports"
 )
 
@@ -57,10 +59,11 @@ func StoreKyvernoIndexForTest(v any) {
 	}
 	idx, ok := v.(*policyreports.Index)
 	if !ok {
-		// Defensive: callers should only pass values produced by
-		// NewEmptyKyvernoIndexForTest or a real Load output. Refuse
-		// to corrupt the atomic with an unrelated type.
-		return
+		// Test-only hook: a wrong type here is a test bug, not a runtime
+		// condition to handle gracefully. Panic immediately so the test
+		// fails at the misuse site instead of producing confusing
+		// downstream failures.
+		panic(fmt.Sprintf("StoreKyvernoIndexForTest: want *policyreports.Index, got %T", v))
 	}
 	policyReportIndex.Store(idx)
 }

--- a/internal/k8s/policy_reports_testhooks.go
+++ b/internal/k8s/policy_reports_testhooks.go
@@ -1,0 +1,73 @@
+package k8s
+
+import (
+	"github.com/skyhook-io/radar/pkg/policyreports"
+)
+
+// Test hooks for cross-package tests that need to inject lifecycle state
+// into the PolicyReport index without running real warmup (which requires
+// discovery + dynamic cache singletons). These are deliberately exported
+// (capitalized "ForTest" suffix) so they can be called from
+// internal/server's _test.go files.
+//
+// Naming: "ForTest" suffix is the convention used elsewhere in this
+// codebase (e.g. timeline.ResetStore, k8s.InitTestResourceCache); it
+// keeps them grep-able and unambiguously not part of the runtime surface.
+//
+// We don't gate these behind a `testing` build tag because Go doesn't
+// support such a tag and the alternative (e.g. //go:build !prod) is
+// noisy. The functions cost nothing at runtime (no init wiring) and
+// callers don't accidentally invoke them — the names make the intent
+// obvious.
+
+// LoadKyvernoDecisionForTest reads the current warmup decision atomic.
+// Empty string means "no decision recorded yet" (the implicit warmup
+// state).
+func LoadKyvernoDecisionForTest() KyvernoStatus {
+	v, _ := kyvernoWarmupDecision.Load().(KyvernoStatus)
+	return v
+}
+
+// StoreKyvernoDecisionForTest sets the warmup decision atomic. Use
+// KyvernoStatus("") to clear it (re-arms the implicit "warmup" state).
+func StoreKyvernoDecisionForTest(s KyvernoStatus) {
+	kyvernoWarmupDecision.Store(s)
+}
+
+// LoadKyvernoIndexForTest returns the current PolicyReport index pointer
+// (typed as `any` so callers don't need to import pkg/policyreports just
+// to round-trip the value through cleanup).
+func LoadKyvernoIndexForTest() any {
+	idx := policyReportIndex.Load()
+	if idx == nil {
+		// Return untyped nil so the caller's `if idx == nil` works
+		// without unwrapping a typed-nil interface.
+		return nil
+	}
+	return idx
+}
+
+// StoreKyvernoIndexForTest sets the PolicyReport index pointer. Pass nil
+// to clear (e.g. for not_installed / deferred / warmup states); pass the
+// result of NewEmptyKyvernoIndexForTest for the ready state.
+func StoreKyvernoIndexForTest(v any) {
+	if v == nil {
+		policyReportIndex.Store(nil)
+		return
+	}
+	idx, ok := v.(*policyreports.Index)
+	if !ok {
+		// Defensive: callers should only pass values produced by
+		// NewEmptyKyvernoIndexForTest or a real Load output. Refuse
+		// to corrupt the atomic with an unrelated type.
+		return
+	}
+	policyReportIndex.Store(idx)
+}
+
+// NewEmptyKyvernoIndexForTest returns a fresh empty index instance.
+// Useful for simulating the "ready but no findings yet" state when
+// testing handler behavior — the index exists, but All() returns nil.
+func NewEmptyKyvernoIndexForTest() any {
+	return policyreports.NewIndex()
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1769,6 +1769,20 @@ func handleIssuesTool(ctx context.Context, _ *mcp.CallToolRequest, input issuesI
 		resp["filter_errors"] = stats.FilterErrors
 		resp["filter_error_sample"] = stats.FilterErrorSample
 	}
+	// Surface the Kyverno index lifecycle when the caller asked for it.
+	// Without this an empty kyverno list collapses four states
+	// (not_installed / deferred / warmup / ready-but-empty) into one,
+	// and the agent can't tell whether to fall back to a direct fetch
+	// or report "cluster has no violations" to the operator. Mirrors
+	// the HTTP /api/issues response shape.
+	if filters.IncludeKyverno {
+		meta, _ := resp["meta"].(map[string]any)
+		if meta == nil {
+			meta = map[string]any{}
+		}
+		meta["kyverno"] = provider.KyvernoStatus()
+		resp["meta"] = meta
+	}
 	return toJSONResult(resp)
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -183,14 +183,15 @@ func registerTools(server *mcp.Server) {
 			"critical / warning / info. Defaults to problem + condition sources; " +
 			"audit (best-practice scan), event (K8s Warning events) and kyverno " +
 			"(PolicyReport findings) are excluded by default because each can run " +
-			"50–1000+ rows per cluster. To add one of those sources to the default " +
-			"set, pass include_audit=true / include_events=true / include_kyverno=true. " +
-			"The `source` param is a FILTER, not an additive opt-in: source=kyverno " +
-			"returns ONLY Kyverno rows (no problems, no conditions); use include_kyverno " +
-			"if you want defaults plus Kyverno. Equivalently, include_X=true behaves " +
-			"like source=problem,condition,X. Use this instead of get_dashboard when " +
-			"you want the full health picture across all sources, or to filter by " +
-			"severity / source / kind / namespace.",
+			"50–1000+ rows per cluster. The `source` param is a FILTER: " +
+			"source=kyverno returns ONLY Kyverno rows (no problems, no conditions). " +
+			"To ADD an excluded source to the defaults via MCP, list everything " +
+			"you want explicitly — e.g. source=problem,condition,kyverno returns " +
+			"defaults plus Kyverno. (The REST /api/issues endpoint also exposes " +
+			"include_audit / include_events / include_kyverno boolean flags as " +
+			"shortcuts, but MCP only takes the source list.) Use this instead of " +
+			"get_dashboard when you want the full health picture across all " +
+			"sources, or to filter by severity / source / kind / namespace.",
 		Annotations: readOnly,
 	}, logToolCall("issues", handleIssuesTool))
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -180,10 +180,16 @@ func registerTools(server *mcp.Server) {
 			"recent K8s Warning events, and a generic CRD .status.conditions[] " +
 			"fallback that lights up Argo / Flux / Knative / Crossplane / cert-manager / " +
 			"KEDA without per-integration code. Severity is normalized to " +
-			"critical / warning / info. Audit findings (best-practice scan) and Kyverno " +
-			"PolicyReport findings are excluded by default — pass source=audit and/or " +
-			"source=kyverno to opt them in. Use this instead of get_dashboard when you " +
-			"want the full health picture across all sources, or to filter by " +
+			"critical / warning / info. Defaults to problem + condition sources; " +
+			"audit (best-practice scan), event (K8s Warning events) and kyverno " +
+			"(PolicyReport findings) are excluded by default because each can run " +
+			"50–1000+ rows per cluster. To add one of those sources to the default " +
+			"set, pass include_audit=true / include_events=true / include_kyverno=true. " +
+			"The `source` param is a FILTER, not an additive opt-in: source=kyverno " +
+			"returns ONLY Kyverno rows (no problems, no conditions); use include_kyverno " +
+			"if you want defaults plus Kyverno. Equivalently, include_X=true behaves " +
+			"like source=problem,condition,X. Use this instead of get_dashboard when " +
+			"you want the full health picture across all sources, or to filter by " +
 			"severity / source / kind / namespace.",
 		Annotations: readOnly,
 	}, logToolCall("issues", handleIssuesTool))
@@ -336,7 +342,7 @@ type searchInput struct {
 type issuesInput struct {
 	Namespace string `json:"namespace,omitempty" jsonschema:"filter to one namespace"`
 	Severity  string `json:"severity,omitempty" jsonschema:"comma-separated: critical,warning"`
-	Source    string `json:"source,omitempty" jsonschema:"comma-separated: problem,audit,event,condition,kyverno. Defaults to problem+condition only. Pass 'event' to opt in K8s Warning events (off by default — they flood thousands per cluster and mostly duplicate problem-source rows). Pass 'audit' to opt in best-practice findings (off by default — 50–200 per cluster). Pass 'kyverno' to opt in Kyverno PolicyReport findings (off by default — typically 10+ rows per workload under a baseline PSS profile). Sources are AND'd with each other; opting one in does not silence the defaults."`
+	Source    string `json:"source,omitempty" jsonschema:"comma-separated list of sources to RETURN: problem,audit,event,condition,kyverno. Acts as a FILTER, not an additive opt-in — when set, only the listed sources appear in the response. Default (omitted): problem+condition only (audit + event + kyverno excluded because each is loud: events flood thousands per cluster and mostly duplicate problem-source rows; audit runs 50–200 per cluster; Kyverno PolicyReports typically 10+ rows per workload under a baseline PSS profile). Examples: source='kyverno' returns ONLY Kyverno rows (no problems, no conditions); source='problem,condition,kyverno' returns the defaults plus Kyverno. To add a noisy source without silencing the defaults, list the defaults explicitly alongside it."`
 	Kind      string `json:"kind,omitempty" jsonschema:"comma-separated kind filter (e.g. Deployment,Pod)"`
 	Since     string `json:"since,omitempty" jsonschema:"event lookback window, e.g. 15m or 1h. Only affects the event source; when events are enabled and since is omitted, defaults to 1h to avoid pulling the full event-cache backlog."`
 	Limit     int    `json:"limit,omitempty" jsonschema:"max issues returned (default 200, max 1000)"`
@@ -1736,12 +1742,17 @@ func handleIssuesTool(ctx context.Context, _ *mcp.CallToolRequest, input issuesI
 		}
 		filters.Since = d
 	}
-	// Audit + event sources are both opt-in (default off). The
-	// MCP input doesn't surface separate include_* knobs, so the
-	// source list IS the opt-in. Mirror the HTTP handler's
-	// behavior — including the 1h since-default when events are
-	// enabled with no explicit window, so an MCP caller doesn't
-	// silently inherit the full event-cache backlog.
+	// Audit / event / kyverno collection is gated by IncludeX flags
+	// (default off). The MCP input doesn't surface separate include_*
+	// knobs, so listing one of those sources in `source` is the only
+	// way to enable the matching IncludeX. This means source= acts as
+	// BOTH a filter AND the collection trigger for noisy sources:
+	// source=kyverno enables Kyverno collection AND narrows results
+	// to just kyverno rows. To get "defaults plus Kyverno" over MCP,
+	// pass source=problem,condition,kyverno. Mirror the HTTP handler's
+	// 1h since-default when events are enabled with no explicit
+	// window, so an MCP caller doesn't silently inherit the full
+	// event-cache backlog.
 	for _, s := range filters.Sources {
 		switch s {
 		case issues.SourceAudit:

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -180,10 +180,11 @@ func registerTools(server *mcp.Server) {
 			"recent K8s Warning events, and a generic CRD .status.conditions[] " +
 			"fallback that lights up Argo / Flux / Knative / Crossplane / cert-manager / " +
 			"KEDA without per-integration code. Severity is normalized to " +
-			"critical / warning / info. Audit findings (best-practice scan) are excluded " +
-			"by default — pass source=audit to opt them in. Use this instead of " +
-			"get_dashboard when you want the full health picture across all sources, or " +
-			"to filter by severity / source / kind / namespace.",
+			"critical / warning / info. Audit findings (best-practice scan) and Kyverno " +
+			"PolicyReport findings are excluded by default — pass source=audit and/or " +
+			"source=kyverno to opt them in. Use this instead of get_dashboard when you " +
+			"want the full health picture across all sources, or to filter by " +
+			"severity / source / kind / namespace.",
 		Annotations: readOnly,
 	}, logToolCall("issues", handleIssuesTool))
 
@@ -335,7 +336,7 @@ type searchInput struct {
 type issuesInput struct {
 	Namespace string `json:"namespace,omitempty" jsonschema:"filter to one namespace"`
 	Severity  string `json:"severity,omitempty" jsonschema:"comma-separated: critical,warning"`
-	Source    string `json:"source,omitempty" jsonschema:"comma-separated: problem,audit,event,condition. Defaults to problem+condition only. Pass 'event' to opt in K8s Warning events (off by default — they flood thousands per cluster and mostly duplicate problem-source rows). Pass 'audit' to opt in best-practice findings (off by default — 50–200 per cluster)."`
+	Source    string `json:"source,omitempty" jsonschema:"comma-separated: problem,audit,event,condition,kyverno. Defaults to problem+condition only. Pass 'event' to opt in K8s Warning events (off by default — they flood thousands per cluster and mostly duplicate problem-source rows). Pass 'audit' to opt in best-practice findings (off by default — 50–200 per cluster). Pass 'kyverno' to opt in Kyverno PolicyReport findings (off by default — typically 10+ rows per workload under a baseline PSS profile). Sources are AND'd with each other; opting one in does not silence the defaults."`
 	Kind      string `json:"kind,omitempty" jsonschema:"comma-separated kind filter (e.g. Deployment,Pod)"`
 	Since     string `json:"since,omitempty" jsonschema:"event lookback window, e.g. 15m or 1h. Only affects the event source; when events are enabled and since is omitted, defaults to 1h to avoid pulling the full event-cache backlog."`
 	Limit     int    `json:"limit,omitempty" jsonschema:"max issues returned (default 200, max 1000)"`
@@ -1747,6 +1748,8 @@ func handleIssuesTool(ctx context.Context, _ *mcp.CallToolRequest, input issuesI
 			filters.IncludeAudit = true
 		case issues.SourceEvent:
 			filters.IncludeEvents = true
+		case issues.SourceKyverno:
+			filters.IncludeKyverno = true
 		}
 	}
 	if filters.IncludeEvents && filters.Since == 0 {
@@ -1806,8 +1809,10 @@ func parseSourceList(v string) ([]issues.Source, error) {
 			out = append(out, issues.SourceEvent)
 		case "condition":
 			out = append(out, issues.SourceCondition)
+		case "kyverno":
+			out = append(out, issues.SourceKyverno)
 		default:
-			return nil, fmt.Errorf("unknown source %q (want: problem, audit, event, condition)", p)
+			return nil, fmt.Errorf("unknown source %q (want: problem, audit, event, condition, kyverno)", p)
 		}
 	}
 	return out, nil

--- a/internal/server/issues_handler.go
+++ b/internal/server/issues_handler.go
@@ -22,12 +22,12 @@ import (
 //
 //	namespace= / namespaces=  one or comma-separated
 //	severity=  critical,warning  (default: all)
-//	source=    problem,audit,event,condition. Defaults to problem+
-//	           condition (audit + event excluded). Pass any source
-//	           explicitly to opt it in; "audit" lifts include_audit,
-//	           "event" lifts include_events. The two flags exist so
-//	           callers can opt those sources in without also
-//	           narrowing to ONLY them.
+//	source=    problem,audit,event,condition,kyverno. Defaults to
+//	           problem+condition (audit + event + kyverno excluded).
+//	           Pass any source explicitly to opt it in; "audit" lifts
+//	           include_audit, "event" lifts include_events, "kyverno"
+//	           lifts include_kyverno. The flags exist so callers can
+//	           opt those sources in without also narrowing to ONLY them.
 //	kind=      Pod,Deployment,...  (default: all)
 //	since=     duration like 15m, 1h. Affects event source only;
 //	           when events are enabled and since is omitted, the
@@ -36,6 +36,7 @@ import (
 //	limit=     default 200, max 1000
 //	include_audit=true   opt audit findings in
 //	include_events=true  opt warning events in
+//	include_kyverno=true opt Kyverno PolicyReport findings in
 func (s *Server) handleIssues(w http.ResponseWriter, r *http.Request) {
 	if !s.requireConnected(w) {
 		return
@@ -88,8 +89,9 @@ func (s *Server) handleIssues(w http.ResponseWriter, r *http.Request) {
 		Kinds:         splitCSV(q.Get("kind")),
 		Since:         since,
 		Limit:         parseLimit(q.Get("limit")),
-		IncludeAudit:  q.Get("include_audit") == "true" || hasSource(q.Get("source"), "audit"),
-		IncludeEvents: includeEvents,
+		IncludeAudit:   q.Get("include_audit") == "true" || hasSource(q.Get("source"), "audit"),
+		IncludeEvents:  includeEvents,
+		IncludeKyverno: q.Get("include_kyverno") == "true" || hasSource(q.Get("source"), "kyverno"),
 		CanReadClusterScoped: func(kind, group string) bool {
 			if auth.UserFromContext(r.Context()) == nil {
 				return true
@@ -169,8 +171,10 @@ func parseSources(v string) ([]issues.Source, error) {
 			out = append(out, issues.SourceEvent)
 		case "condition":
 			out = append(out, issues.SourceCondition)
+		case "kyverno":
+			out = append(out, issues.SourceKyverno)
 		default:
-			return nil, fmt.Errorf("unknown source %q (want: problem, audit, event, condition)", p)
+			return nil, fmt.Errorf("unknown source %q (want: problem, audit, event, condition, kyverno)", p)
 		}
 	}
 	return out, nil

--- a/internal/server/issues_handler.go
+++ b/internal/server/issues_handler.go
@@ -127,6 +127,22 @@ func (s *Server) handleIssues(w http.ResponseWriter, r *http.Request) {
 		resp["filter_errors"] = stats.FilterErrors
 		resp["filter_error_sample"] = stats.FilterErrorSample
 	}
+	// When the caller asked for Kyverno findings (either via opt-in flag
+	// or source=kyverno), surface the index lifecycle phase under
+	// `meta.kyverno`. Without this, an empty list collapses four distinct
+	// states (not_installed / deferred / warmup / ready-but-empty) into
+	// one and the SPA + agents can't render the right copy. Emitted on
+	// every kyverno-touching request — agents can ignore it, but humans
+	// in the SPA get a clear "Kyverno not installed" vs "Indexing in
+	// progress" vs "No violations" distinction.
+	if filters.IncludeKyverno {
+		meta, _ := resp["meta"].(map[string]any)
+		if meta == nil {
+			meta = map[string]any{}
+		}
+		meta["kyverno"] = provider.KyvernoStatus()
+		resp["meta"] = meta
+	}
 	s.writeJSON(w, resp)
 }
 

--- a/internal/server/issues_handler.go
+++ b/internal/server/issues_handler.go
@@ -83,12 +83,12 @@ func (s *Server) handleIssues(w http.ResponseWriter, r *http.Request) {
 		since = time.Hour
 	}
 	filters := issues.Filters{
-		Namespaces:    namespaces,
-		Severities:    severities,
-		Sources:       sources,
-		Kinds:         splitCSV(q.Get("kind")),
-		Since:         since,
-		Limit:         parseLimit(q.Get("limit")),
+		Namespaces:     namespaces,
+		Severities:     severities,
+		Sources:        sources,
+		Kinds:          splitCSV(q.Get("kind")),
+		Since:          since,
+		Limit:          parseLimit(q.Get("limit")),
 		IncludeAudit:   q.Get("include_audit") == "true" || hasSource(q.Get("source"), "audit"),
 		IncludeEvents:  includeEvents,
 		IncludeKyverno: q.Get("include_kyverno") == "true" || hasSource(q.Get("source"), "kyverno"),

--- a/internal/server/issues_handler.go
+++ b/internal/server/issues_handler.go
@@ -13,30 +13,42 @@ import (
 )
 
 // handleIssues serves GET /api/issues — the unified cluster-health
-// endpoint. Composes problems + condition fallback by default; audit
-// + event sources are opt-in (both are loud — audit findings run 50–
-// 200 per cluster, and events flood with thousands of redundant
-// rows on noisy clusters).
+// endpoint. Composes problems + condition fallback by default; audit,
+// event, and kyverno sources are opt-in (all three are loud — audit
+// findings run 50–200 per cluster, events flood with thousands of
+// redundant rows on noisy clusters, and Kyverno PolicyReports add 10+
+// rows per workload under a baseline PSS profile).
 //
 // Query params:
 //
 //	namespace= / namespaces=  one or comma-separated
 //	severity=  critical,warning  (default: all)
-//	source=    problem,audit,event,condition,kyverno. Defaults to
-//	           problem+condition (audit + event + kyverno excluded).
-//	           Pass any source explicitly to opt it in; "audit" lifts
-//	           include_audit, "event" lifts include_events, "kyverno"
-//	           lifts include_kyverno. The flags exist so callers can
-//	           opt those sources in without also narrowing to ONLY them.
+//	source=    Comma-separated list of sources to RETURN. When set,
+//	           only the listed sources appear in the response.
+//	           Allowed: problem, audit, event, condition, kyverno.
+//	           Default (no source param): problem + condition only
+//	           (audit + event + kyverno excluded — all three are loud:
+//	           audit runs 50–200 findings per cluster, events flood
+//	           with thousands of redundant rows on noisy clusters,
+//	           and Kyverno PolicyReports can balloon similarly).
+//	           NOTE: source acts as a filter, not an additive opt-in.
+//	           Passing source=kyverno returns ONLY Kyverno rows, not
+//	           "defaults plus Kyverno". Use include_kyverno=true (or
+//	           include_audit / include_events) when you want
+//	           "defaults plus X".
+//	include_audit/include_events/include_kyverno=true
+//	           Add the named source to the DEFAULT set without
+//	           silencing the defaults. Effective filter:
+//	           include_X=true is equivalent to source=problem,
+//	           condition,X. These flags are also implicitly set when
+//	           the matching source appears in source= so the warmup
+//	           / collection path knows to fetch that source's data.
 //	kind=      Pod,Deployment,...  (default: all)
 //	since=     duration like 15m, 1h. Affects event source only;
 //	           when events are enabled and since is omitted, the
 //	           handler defaults to 1h to avoid pulling the full
 //	           cached event backlog.
 //	limit=     default 200, max 1000
-//	include_audit=true   opt audit findings in
-//	include_events=true  opt warning events in
-//	include_kyverno=true opt Kyverno PolicyReport findings in
 func (s *Server) handleIssues(w http.ResponseWriter, r *http.Request) {
 	if !s.requireConnected(w) {
 		return

--- a/internal/server/issues_handler_test.go
+++ b/internal/server/issues_handler_test.go
@@ -29,10 +29,10 @@ func TestIssuesHandler_KyvernoMetaEmittedOnOptIn(t *testing.T) {
 	})
 
 	cases := []struct {
-		name        string
-		setup       func()
-		wantMeta    string
-		queryParam  string // "include_kyverno=true" or "source=kyverno"
+		name       string
+		setup      func()
+		wantMeta   string
+		queryParam string // "include_kyverno=true" or "source=kyverno"
 	}{
 		{
 			name: "not_installed surfaces in meta.kyverno",

--- a/internal/server/issues_handler_test.go
+++ b/internal/server/issues_handler_test.go
@@ -1,0 +1,160 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+)
+
+// TestIssuesHandler_KyvernoMetaEmittedOnOptIn pins the meta.kyverno field
+// emission on /api/issues when source=kyverno (or include_kyverno=true)
+// is requested. Without this, a Kyverno-aware caller can't distinguish
+// "Kyverno not installed" from "warmup deferred" from "ready but no
+// violations" — they all look like an empty issues list.
+//
+// We exercise three of the four states by manipulating the package-level
+// warmup-decision atomic directly. The fourth state ("warmup") is the
+// implicit default before any decision is recorded; we cover the
+// transitions in the policy_reports_test.go state-machine test.
+func TestIssuesHandler_KyvernoMetaEmittedOnOptIn(t *testing.T) {
+	// Snapshot + restore the kyverno globals so we don't bleed into
+	// other server tests running against the same testServer singleton.
+	origDecision := loadKyvernoDecisionForTest()
+	origIdx := loadKyvernoIndexForTest()
+	t.Cleanup(func() {
+		storeKyvernoDecisionForTest(k8s.KyvernoStatus(origDecision))
+		storeKyvernoIndexForTest(origIdx)
+	})
+
+	cases := []struct {
+		name        string
+		setup       func()
+		wantMeta    string
+		queryParam  string // "include_kyverno=true" or "source=kyverno"
+	}{
+		{
+			name: "not_installed surfaces in meta.kyverno",
+			setup: func() {
+				storeKyvernoIndexForTest(nil)
+				storeKyvernoDecisionForTest(k8s.KyvernoStatusNotInstalled)
+			},
+			wantMeta:   "not_installed",
+			queryParam: "include_kyverno=true",
+		},
+		{
+			name: "deferred surfaces in meta.kyverno",
+			setup: func() {
+				storeKyvernoIndexForTest(nil)
+				storeKyvernoDecisionForTest(k8s.KyvernoStatusDeferred)
+			},
+			wantMeta:   "deferred",
+			queryParam: "source=kyverno",
+		},
+		{
+			name: "ready surfaces in meta.kyverno (empty findings list is meaningful)",
+			setup: func() {
+				// Real index instance, no findings populated → ready but empty.
+				storeKyvernoIndexForTest(newEmptyIndexForTest())
+				storeKyvernoDecisionForTest(k8s.KyvernoStatusReady)
+			},
+			wantMeta:   "ready",
+			queryParam: "include_kyverno=true",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup()
+
+			resp, err := http.Get(testServer.URL + "/api/issues?" + tc.queryParam)
+			if err != nil {
+				t.Fatalf("GET /api/issues: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status: got %d want 200", resp.StatusCode)
+			}
+
+			var body map[string]any
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+
+			meta, ok := body["meta"].(map[string]any)
+			if !ok {
+				t.Fatalf("response missing meta object: %+v", body)
+			}
+			gotKyv, _ := meta["kyverno"].(string)
+			if gotKyv != tc.wantMeta {
+				t.Errorf("meta.kyverno: got %q want %q (full body: %+v)", gotKyv, tc.wantMeta, body)
+			}
+		})
+	}
+}
+
+// TestIssuesHandler_KyvernoMetaOmittedWhenNotRequested pins the inverse:
+// when the caller did NOT ask for Kyverno (no source=kyverno, no
+// include_kyverno), we don't emit meta.kyverno. This keeps default
+// responses lean — agents not aware of Kyverno don't get a noisy field,
+// and the SPA's default issue view stays clean.
+func TestIssuesHandler_KyvernoMetaOmittedWhenNotRequested(t *testing.T) {
+	origDecision := loadKyvernoDecisionForTest()
+	origIdx := loadKyvernoIndexForTest()
+	t.Cleanup(func() {
+		storeKyvernoDecisionForTest(k8s.KyvernoStatus(origDecision))
+		storeKyvernoIndexForTest(origIdx)
+	})
+	// Even if Kyverno is "ready", omitted from response when caller
+	// didn't request it.
+	storeKyvernoIndexForTest(newEmptyIndexForTest())
+	storeKyvernoDecisionForTest(k8s.KyvernoStatusReady)
+
+	resp, err := http.Get(testServer.URL + "/api/issues")
+	if err != nil {
+		t.Fatalf("GET /api/issues: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := body["meta"]; ok {
+		t.Errorf("default request should not emit meta.kyverno; got %+v", body["meta"])
+	}
+}
+
+// --- Test helpers: cross-package access to k8s package state via exported
+// hooks. We use go:linkname-style accessors registered as test-only helpers
+// in the k8s package; here we route through the public API where possible
+// and otherwise via the package's own globals through a small bridge.
+//
+// We can't `go:linkname` into internal/k8s from another package easily
+// without a forward declaration, so we route through small exported
+// helpers in the k8s package's _test.go side. Since k8s already exposes
+// ResetPolicyReportIndex publicly, we reuse that for resetting; for
+// arbitrary state injection (needed here) we add bridge funcs in the
+// k8s package guarded by a build tag-free in-package test file (see
+// policy_reports_test_export_test.go-equivalent below).
+
+// loadKyvernoDecisionForTest / store / loadIndex / store / newEmptyIndex
+// are thin wrappers around exported test hooks in internal/k8s.
+
+func loadKyvernoDecisionForTest() string {
+	return string(k8s.LoadKyvernoDecisionForTest())
+}
+func storeKyvernoDecisionForTest(s k8s.KyvernoStatus) {
+	k8s.StoreKyvernoDecisionForTest(s)
+}
+func loadKyvernoIndexForTest() any {
+	return k8s.LoadKyvernoIndexForTest()
+}
+func storeKyvernoIndexForTest(v any) {
+	k8s.StoreKyvernoIndexForTest(v)
+}
+func newEmptyIndexForTest() any {
+	return k8s.NewEmptyKyvernoIndexForTest()
+}
+

--- a/internal/server/issues_handler_test.go
+++ b/internal/server/issues_handler_test.go
@@ -157,4 +157,3 @@ func storeKyvernoIndexForTest(v any) {
 func newEmptyIndexForTest() any {
 	return k8s.NewEmptyKyvernoIndexForTest()
 }
-

--- a/pkg/policyreports/index.go
+++ b/pkg/policyreports/index.go
@@ -6,12 +6,18 @@ import (
 	"sync"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	"github.com/skyhook-io/radar/pkg/audit"
 )
 
 // Subject identifies the resource a set of Findings applies to.
+//
+// Group is the API group of the subject (e.g. "apps" for Deployment,
+// "" for core/v1 kinds like Pod). Without it, a CRD with the same Kind
+// as a built-in (or two CRDs sharing a Kind across different groups,
+// e.g. argoproj.io/Application vs unrelated.io/Application) would
+// collide on the same index entry and consumers couldn't apply group-
+// aware RBAC checks against the resulting Issues.
 type Subject struct {
+	Group     string
 	Kind      string
 	Namespace string
 	Name      string
@@ -32,10 +38,11 @@ type SubjectFindings struct {
 // purely diagnostic, so dropping the oldest is acceptable.
 const MaxIndexedReports = 500
 
-// Index maps subject keys ("Kind/namespace/name", per audit.ResourceKey) to
-// the policy findings that apply to that subject. It is safe for concurrent
-// read/write: callers building the index from informer events may swap
-// contents while other callers serve `FindingsFor` lookups.
+// Index maps subject keys ("Group/Kind/namespace/name", group-prefixed
+// so distinct CRDs sharing a Kind don't collide) to the policy findings
+// that apply to that subject. It is safe for concurrent read/write:
+// callers building the index from informer events may swap contents
+// while other callers serve `FindingsFor` lookups.
 //
 // The index is a pure projection of the input reports — it owns no
 // underlying state and does not refetch.
@@ -97,16 +104,19 @@ func (i *Index) Replace(reports []*unstructured.Unstructured) {
 // FindingsFor returns the findings indexed for the given subject. Returns
 // nil if no findings are recorded for that subject.
 //
+// Group is the subject's API group ("" for core kinds like Pod). It's
+// part of the index key so distinct CRDs sharing a Kind don't collide.
+//
 // The returned slice is a defensive copy: callers may freely sort, truncate,
 // or filter it without racing the index's own rebuild path. The cost is
 // modest — findings per subject are bounded (Kyverno emits at most one
 // PolicyReport entry per (policy, rule, resource) tuple, and pathological
 // reports are capped during BuildIndex anyway).
-func (i *Index) FindingsFor(kind, namespace, name string) []Finding {
+func (i *Index) FindingsFor(group, kind, namespace, name string) []Finding {
 	if i == nil {
 		return nil
 	}
-	key := audit.ResourceKey(kind, namespace, name)
+	key := subjectKey(group, kind, namespace, name)
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 	src := i.bySubject[key]
@@ -144,34 +154,46 @@ func (i *Index) All() []SubjectFindings {
 		if len(src) == 0 {
 			continue
 		}
-		kind, ns, name, ok := parseSubjectKey(k)
+		group, kind, ns, name, ok := parseSubjectKey(k)
 		if !ok {
 			continue
 		}
 		fs := make([]Finding, len(src))
 		copy(fs, src)
 		out = append(out, SubjectFindings{
-			Subject:  Subject{Kind: kind, Namespace: ns, Name: name},
+			Subject:  Subject{Group: group, Kind: kind, Namespace: ns, Name: name},
 			Findings: fs,
 		})
 	}
 	return out
 }
 
-// parseSubjectKey reverses audit.ResourceKey ("Kind/namespace/name", with
-// an empty namespace segment for cluster-scoped subjects). Returns ok=false
-// for any key that does not have exactly three slash-delimited parts —
-// K8s names, namespaces, and kinds can't contain '/' (DNS-label rules),
-// so the SplitN is unambiguous in practice.
-func parseSubjectKey(key string) (string, string, string, bool) {
-	parts := strings.SplitN(key, "/", 3)
-	if len(parts) != 3 {
-		return "", "", "", false
+// subjectKey is the index key format: "group/Kind/namespace/name", with
+// an empty group segment for core kinds (Pod, Service, ...) and an empty
+// namespace segment for cluster-scoped subjects (Node, ClusterRole, ...).
+// Group must come first because both "group" and "namespace" can be
+// empty independently; encoding group last would make a cluster-scoped
+// CRD ("apps.example.io/Foo//bar") indistinguishable from a namespaced
+// core-group subject under a parse that allowed three-part keys.
+func subjectKey(group, kind, namespace, name string) string {
+	return group + "/" + kind + "/" + namespace + "/" + name
+}
+
+// parseSubjectKey reverses subjectKey. Returns ok=false for any key that
+// does not have exactly four slash-delimited parts. K8s groups, names,
+// namespaces, and kinds can't contain '/' (DNS-label / DNS-subdomain
+// rules), so the SplitN is unambiguous in practice.
+func parseSubjectKey(key string) (group, kind, namespace, name string, ok bool) {
+	parts := strings.SplitN(key, "/", 4)
+	if len(parts) != 4 {
+		return "", "", "", "", false
 	}
-	if parts[0] == "" || parts[2] == "" {
-		return "", "", "", false
+	// Kind and name must be non-empty; group and namespace may be empty
+	// (core-group + cluster-scoped subjects respectively).
+	if parts[1] == "" || parts[3] == "" {
+		return "", "", "", "", false
 	}
-	return parts[0], parts[1], parts[2], true
+	return parts[0], parts[1], parts[2], parts[3], true
 }
 
 // Size returns the number of distinct subjects with at least one indexed
@@ -186,8 +208,8 @@ func (i *Index) Size() int {
 }
 
 // extractFindings appends one Finding per (result, resource) pair into the
-// destination map. The map's keys are `audit.ResourceKey` values; the
-// helper centralizes the shape so callers don't have to know about the
+// destination map. The map's keys are subjectKey values; the helper
+// centralizes the shape so callers don't have to know about the
 // PolicyReport schema.
 //
 // Schema reference (https://github.com/kubernetes-sigs/wg-policy-prototypes):
@@ -211,7 +233,7 @@ func extractFindings(report *unstructured.Unstructured, dst map[string][]Finding
 		return
 	}
 
-	scopeKind, scopeNS, scopeName := reportScope(report)
+	scopeGroup, scopeKind, scopeNS, scopeName := reportScope(report)
 
 	results, found, err := unstructured.NestedSlice(report.Object, "results")
 	if err != nil || !found {
@@ -260,7 +282,7 @@ func extractFindings(report *unstructured.Unstructured, dst map[string][]Finding
 				if ns == "" {
 					ns = reportNamespace
 				}
-				key := audit.ResourceKey(scopeKind, ns, scopeName)
+				key := subjectKey(scopeGroup, scopeKind, ns, scopeName)
 				dst[key] = append(dst[key], f)
 			}
 			continue
@@ -274,24 +296,30 @@ func extractFindings(report *unstructured.Unstructured, dst map[string][]Finding
 			if ns == "" {
 				ns = reportNamespace
 			}
-			key := audit.ResourceKey(s.kind, ns, s.name)
+			key := subjectKey(s.group, s.kind, ns, s.name)
 			dst[key] = append(dst[key], f)
 		}
 	}
 }
 
-// reportScope returns the `report.scope` subject as (kind, namespace, name).
-// All three are empty strings when scope is missing — the caller treats
-// that case as "no scope-only fallback available".
-func reportScope(report *unstructured.Unstructured) (string, string, string) {
+// reportScope returns the `report.scope` subject as (group, kind,
+// namespace, name). All four are empty strings when scope is missing —
+// the caller treats that case as "no scope-only fallback available".
+// Group is derived from `scope.apiVersion` (the part before "/"; "" for
+// core kinds like Pod whose apiVersion is just "v1").
+func reportScope(report *unstructured.Unstructured) (group, kind, namespace, name string) {
 	scope, found, err := unstructured.NestedMap(report.Object, "scope")
 	if err != nil || !found {
-		return "", "", ""
+		return "", "", "", ""
 	}
-	return stringField(scope, "kind"), stringField(scope, "namespace"), stringField(scope, "name")
+	return groupFromAPIVersion(stringField(scope, "apiVersion")),
+		stringField(scope, "kind"),
+		stringField(scope, "namespace"),
+		stringField(scope, "name")
 }
 
 type subjectRef struct {
+	group     string
 	kind      string
 	namespace string
 	name      string
@@ -323,12 +351,30 @@ func resultResources(entry map[string]any) ([]subjectRef, bool) {
 			continue
 		}
 		refs = append(refs, subjectRef{
+			group:     groupFromAPIVersion(stringField(m, "apiVersion")),
 			kind:      stringField(m, "kind"),
 			namespace: stringField(m, "namespace"),
 			name:      stringField(m, "name"),
 		})
 	}
 	return refs, true
+}
+
+// groupFromAPIVersion extracts the API group from a Kubernetes apiVersion
+// string ("apps/v1" → "apps", "v1" → "", "" → ""). The pkg/gitops package
+// has a public helper that does the same job, but we copy it here so that
+// the policyreports package stays free of cross-package dependencies (it
+// is reused by callers that don't want the gitops surface).
+func groupFromAPIVersion(apiVersion string) string {
+	if apiVersion == "" || apiVersion == "v1" {
+		return ""
+	}
+	if before, _, ok := strings.Cut(apiVersion, "/"); ok {
+		return before
+	}
+	// apiVersion without a slash is a non-core group with no version
+	// (rare/malformed) — treat the whole string as the group.
+	return apiVersion
 }
 
 func stringField(m map[string]any, key string) string {

--- a/pkg/policyreports/index.go
+++ b/pkg/policyreports/index.go
@@ -2,12 +2,28 @@ package policyreports
 
 import (
 	"sort"
+	"strings"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/skyhook-io/radar/pkg/audit"
 )
+
+// Subject identifies the resource a set of Findings applies to.
+type Subject struct {
+	Kind      string
+	Namespace string
+	Name      string
+}
+
+// SubjectFindings pairs a subject ref with the findings indexed against it.
+// Returned by Index.All so consumers can enumerate every indexed subject
+// without needing per-subject lookups.
+type SubjectFindings struct {
+	Subject  Subject
+	Findings []Finding
+}
 
 // MaxIndexedReports caps how many PolicyReport documents the index keeps,
 // chosen by newest `metadata.creationTimestamp` first. Reports beyond the
@@ -100,6 +116,62 @@ func (i *Index) FindingsFor(kind, namespace, name string) []Finding {
 	out := make([]Finding, len(src))
 	copy(out, src)
 	return out
+}
+
+// All returns every indexed subject together with its findings. Both the
+// outer slice and each per-subject Findings slice are defensive copies —
+// callers may freely sort, truncate, or filter them without racing the
+// index's rebuild path. Subjects appear in alphabetical key order so the
+// caller's downstream output is stable regardless of go's map-iteration
+// randomization.
+func (i *Index) All() []SubjectFindings {
+	if i == nil {
+		return nil
+	}
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	if len(i.bySubject) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(i.bySubject))
+	for k := range i.bySubject {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]SubjectFindings, 0, len(keys))
+	for _, k := range keys {
+		src := i.bySubject[k]
+		if len(src) == 0 {
+			continue
+		}
+		kind, ns, name, ok := parseSubjectKey(k)
+		if !ok {
+			continue
+		}
+		fs := make([]Finding, len(src))
+		copy(fs, src)
+		out = append(out, SubjectFindings{
+			Subject:  Subject{Kind: kind, Namespace: ns, Name: name},
+			Findings: fs,
+		})
+	}
+	return out
+}
+
+// parseSubjectKey reverses audit.ResourceKey ("Kind/namespace/name", with
+// an empty namespace segment for cluster-scoped subjects). Returns ok=false
+// for any key that does not have exactly three slash-delimited parts —
+// K8s names, namespaces, and kinds can't contain '/' (DNS-label rules),
+// so the SplitN is unambiguous in practice.
+func parseSubjectKey(key string) (string, string, string, bool) {
+	parts := strings.SplitN(key, "/", 3)
+	if len(parts) != 3 {
+		return "", "", "", false
+	}
+	if parts[0] == "" || parts[2] == "" {
+		return "", "", "", false
+	}
+	return parts[0], parts[1], parts[2], true
 }
 
 // Size returns the number of distinct subjects with at least one indexed

--- a/pkg/policyreports/index_test.go
+++ b/pkg/policyreports/index_test.go
@@ -51,6 +51,18 @@ func resourceRef(kind, ns, name string) map[string]any {
 	return m
 }
 
+// resourceRefWithGroup builds a `results[].resources[]` entry that
+// includes `apiVersion`, so the index can derive Subject.Group from it.
+// Pass groupVersion in the standard K8s shape: "apps/v1", "v1" (core), or
+// "argoproj.io/v1alpha1".
+func resourceRefWithGroup(groupVersion, kind, ns, name string) map[string]any {
+	m := resourceRef(kind, ns, name)
+	if groupVersion != "" {
+		m["apiVersion"] = groupVersion
+	}
+	return m
+}
+
 func TestBuildIndex_PerResourceFindings(t *testing.T) {
 	// One report with two results, each targeting a distinct subject.
 	report := makeReport(t, "PolicyReport", "prod", "kyverno-report-1", nil, time.Now(), []map[string]any{
@@ -80,7 +92,7 @@ func TestBuildIndex_PerResourceFindings(t *testing.T) {
 
 	idx := BuildIndex([]*unstructured.Unstructured{report})
 
-	podFindings := idx.FindingsFor("Pod", "prod", "web-abc123")
+	podFindings := idx.FindingsFor("", "Pod", "prod", "web-abc123")
 	if len(podFindings) != 1 {
 		t.Fatalf("expected 1 finding for Pod/prod/web-abc123, got %d", len(podFindings))
 	}
@@ -91,7 +103,7 @@ func TestBuildIndex_PerResourceFindings(t *testing.T) {
 		t.Errorf("severity/category not preserved: %+v", podFindings[0])
 	}
 
-	depFindings := idx.FindingsFor("Deployment", "prod", "web")
+	depFindings := idx.FindingsFor("", "Deployment", "prod", "web")
 	if len(depFindings) != 1 {
 		t.Fatalf("expected 1 finding for Deployment/prod/web, got %d", len(depFindings))
 	}
@@ -119,7 +131,7 @@ func TestBuildIndex_MultipleResourcesPerResult(t *testing.T) {
 	idx := BuildIndex([]*unstructured.Unstructured{report})
 
 	for _, name := range []string{"a", "b", "c"} {
-		got := idx.FindingsFor("Pod", "prod", name)
+		got := idx.FindingsFor("", "Pod", "prod", name)
 		if len(got) != 1 {
 			t.Errorf("expected 1 finding for Pod/prod/%s, got %d", name, len(got))
 		}
@@ -157,7 +169,7 @@ func TestBuildIndex_ScopeOnlyReport(t *testing.T) {
 
 	idx := BuildIndex([]*unstructured.Unstructured{report})
 
-	got := idx.FindingsFor("Deployment", "prod", "api")
+	got := idx.FindingsFor("", "Deployment", "prod", "api")
 	if len(got) != 2 {
 		t.Fatalf("expected 2 findings under scope subject, got %d", len(got))
 	}
@@ -189,7 +201,7 @@ func TestBuildIndex_ScopeFallback_NamespaceFromReportMetadata(t *testing.T) {
 	})
 
 	idx := BuildIndex([]*unstructured.Unstructured{report})
-	got := idx.FindingsFor("Pod", "dev", "lonely")
+	got := idx.FindingsFor("", "Pod", "dev", "lonely")
 	if len(got) != 1 {
 		t.Fatalf("expected 1 finding inherited from report namespace, got %d", len(got))
 	}
@@ -210,7 +222,7 @@ func TestBuildIndex_ClusterPolicyReport(t *testing.T) {
 
 	idx := BuildIndex([]*unstructured.Unstructured{report})
 
-	got := idx.FindingsFor("Node", "", "gke-pool-a-1")
+	got := idx.FindingsFor("", "Node", "", "gke-pool-a-1")
 	if len(got) != 1 {
 		t.Fatalf("expected 1 finding on Node, got %d", len(got))
 	}
@@ -252,7 +264,7 @@ func TestBuildIndex_EmptyResourcesArray_FallsBackToScope(t *testing.T) {
 	})
 
 	idx := BuildIndex([]*unstructured.Unstructured{report})
-	got := idx.FindingsFor("Service", "default", "svc")
+	got := idx.FindingsFor("", "Service", "default", "svc")
 	if len(got) != 1 {
 		t.Fatalf("expected scope fallback to trigger on empty resources, got %d findings", len(got))
 	}
@@ -283,7 +295,7 @@ func TestBuildIndex_MalformedResourcesEntries_FallsBackToScope(t *testing.T) {
 	})
 
 	idx := BuildIndex([]*unstructured.Unstructured{report})
-	got := idx.FindingsFor("Deployment", "prod", "cart")
+	got := idx.FindingsFor("", "Deployment", "prod", "cart")
 	if len(got) != 1 {
 		t.Fatalf("expected scope fallback when all resources entries are empty, got %d findings", len(got))
 	}
@@ -301,7 +313,7 @@ func TestBuildIndex_FindingsForUnknownSubject(t *testing.T) {
 	})
 	idx := BuildIndex([]*unstructured.Unstructured{report})
 
-	if got := idx.FindingsFor("Pod", "prod", "missing"); got != nil {
+	if got := idx.FindingsFor("", "Pod", "prod", "missing"); got != nil {
 		t.Errorf("expected nil for unknown subject, got %v", got)
 	}
 }
@@ -332,11 +344,11 @@ func TestBuildIndex_Cap_OldestDropped(t *testing.T) {
 	}
 	// The 5 oldest (indexes 0..4) should be absent. The newest (index
 	// MaxIndexedReports+4) should be present.
-	if got := idx.FindingsFor("Pod", "ns", "pod-0"); got != nil {
+	if got := idx.FindingsFor("", "Pod", "ns", "pod-0"); got != nil {
 		t.Errorf("pod-0 should have been dropped by cap, got %v", got)
 	}
 	newestName := fmt.Sprintf("pod-%d", MaxIndexedReports+4)
-	if got := idx.FindingsFor("Pod", "ns", newestName); len(got) != 1 {
+	if got := idx.FindingsFor("", "Pod", "ns", newestName); len(got) != 1 {
 		t.Errorf("newest pod %s should be present, got %v", newestName, got)
 	}
 }
@@ -356,7 +368,7 @@ func TestIndex_ReplaceSwapsContents(t *testing.T) {
 			},
 		}),
 	})
-	if got := idx.FindingsFor("Pod", "ns", "first"); len(got) != 1 {
+	if got := idx.FindingsFor("", "Pod", "ns", "first"); len(got) != 1 {
 		t.Fatalf("first build missed: %v", got)
 	}
 
@@ -373,17 +385,17 @@ func TestIndex_ReplaceSwapsContents(t *testing.T) {
 		}),
 	})
 
-	if got := idx.FindingsFor("Pod", "ns", "first"); got != nil {
+	if got := idx.FindingsFor("", "Pod", "ns", "first"); got != nil {
 		t.Errorf("old subject leaked after Replace: %v", got)
 	}
-	if got := idx.FindingsFor("Pod", "ns", "second"); len(got) != 1 {
+	if got := idx.FindingsFor("", "Pod", "ns", "second"); len(got) != 1 {
 		t.Errorf("new subject missing after Replace: %v", got)
 	}
 }
 
 func TestIndex_NilSafe(t *testing.T) {
 	var idx *Index
-	if got := idx.FindingsFor("Pod", "ns", "name"); got != nil {
+	if got := idx.FindingsFor("", "Pod", "ns", "name"); got != nil {
 		t.Errorf("nil index FindingsFor returned %v", got)
 	}
 	if got := idx.Size(); got != 0 {
@@ -476,30 +488,184 @@ func TestIndex_All(t *testing.T) {
 			break
 		}
 	}
-	got := idx.FindingsFor("Pod", "prod", "web")
+	got := idx.FindingsFor("", "Pod", "prod", "web")
 	if len(got) == 0 || got[0].Policy == "MUTATED" {
 		t.Fatalf("All() returned non-defensive copy — mutation leaked: %+v", got)
 	}
 }
 
+// TestBuildIndex_GroupFromResourceAPIVersion pins the per-result resource
+// group propagation. Each `results[].resources[]` entry carries its own
+// apiVersion in the wg-policy schema; the index must derive Subject.Group
+// from that so two CRDs sharing a Kind across different groups don't
+// collide on the same index entry and so consumers (Issues, RBAC checks)
+// see the group.
+func TestBuildIndex_GroupFromResourceAPIVersion(t *testing.T) {
+	report := makeReport(t, "PolicyReport", "prod", "groups-from-resources", nil, time.Now(), []map[string]any{
+		{
+			"policy": "p-app",
+			"result": "fail",
+			"resources": []any{
+				resourceRefWithGroup("argoproj.io/v1alpha1", "Application", "prod", "argo-app"),
+			},
+		},
+		{
+			"policy": "p-deploy",
+			"result": "fail",
+			"resources": []any{
+				resourceRefWithGroup("apps/v1", "Deployment", "prod", "web"),
+			},
+		},
+		{
+			"policy": "p-pod",
+			"result": "warn",
+			"resources": []any{
+				// Core kind: apiVersion=v1 → group="".
+				resourceRefWithGroup("v1", "Pod", "prod", "web-abc"),
+			},
+		},
+	})
+
+	idx := BuildIndex([]*unstructured.Unstructured{report})
+
+	if got := idx.FindingsFor("argoproj.io", "Application", "prod", "argo-app"); len(got) != 1 {
+		t.Errorf("expected Application finding under group=argoproj.io, got %v", got)
+	}
+	// Without group, the lookup must miss — pins that group is part of
+	// the key, not a side-channel attribute.
+	if got := idx.FindingsFor("", "Application", "prod", "argo-app"); len(got) != 0 {
+		t.Errorf("group=\"\" lookup leaked CRD Application: %v", got)
+	}
+	if got := idx.FindingsFor("apps", "Deployment", "prod", "web"); len(got) != 1 {
+		t.Errorf("expected Deployment finding under group=apps, got %v", got)
+	}
+	if got := idx.FindingsFor("", "Pod", "prod", "web-abc"); len(got) != 1 {
+		t.Errorf("core-group Pod (apiVersion=v1) should have group=\"\", got %v", got)
+	}
+
+	// All() must surface Subject.Group on the projected SubjectFindings.
+	groupByName := map[string]string{}
+	for _, sf := range idx.All() {
+		groupByName[sf.Subject.Kind+"/"+sf.Subject.Name] = sf.Subject.Group
+	}
+	if got := groupByName["Application/argo-app"]; got != "argoproj.io" {
+		t.Errorf("All().Subject.Group for Application: got %q want %q", got, "argoproj.io")
+	}
+	if got := groupByName["Deployment/web"]; got != "apps" {
+		t.Errorf("All().Subject.Group for Deployment: got %q want %q", got, "apps")
+	}
+	if got := groupByName["Pod/web-abc"]; got != "" {
+		t.Errorf("All().Subject.Group for Pod: got %q want %q", got, "")
+	}
+}
+
+// TestBuildIndex_GroupFromScopeAPIVersion pins the scope-only path: when
+// a result has no resources[] (or only malformed ones), the report's
+// `scope.apiVersion` provides the group for the materialized Subject.
+func TestBuildIndex_GroupFromScopeAPIVersion(t *testing.T) {
+	scope := map[string]any{
+		"apiVersion": "argoproj.io/v1alpha1",
+		"kind":       "Application",
+		"namespace":  "prod",
+		"name":       "scope-app",
+	}
+	report := makeReport(t, "PolicyReport", "prod", "scope-with-group", scope, time.Now(), []map[string]any{
+		{
+			"policy":  "no-sync-loop",
+			"result":  "fail",
+			"message": "sync loop detected",
+			// no resources[] → scope fallback
+		},
+	})
+
+	idx := BuildIndex([]*unstructured.Unstructured{report})
+
+	// Lookup with the right group succeeds.
+	got := idx.FindingsFor("argoproj.io", "Application", "prod", "scope-app")
+	if len(got) != 1 {
+		t.Fatalf("expected scope-only finding under group=argoproj.io, got %v", got)
+	}
+	// Lookup without the group misses (proving group is materialized from
+	// scope.apiVersion into the index key, not silently dropped).
+	if got := idx.FindingsFor("", "Application", "prod", "scope-app"); len(got) != 0 {
+		t.Errorf("group=\"\" lookup leaked scope CRD: %v", got)
+	}
+
+	// Subject from All() must carry the group too.
+	all := idx.All()
+	if len(all) != 1 {
+		t.Fatalf("expected 1 subject, got %d", len(all))
+	}
+	if all[0].Subject.Group != "argoproj.io" {
+		t.Errorf("All().Subject.Group: got %q want %q", all[0].Subject.Group, "argoproj.io")
+	}
+}
+
+// TestBuildIndex_GroupCollisionAcrossCRDs pins the underlying motivation
+// for keying on group: two CRDs sharing a Kind across different groups
+// must NOT collide on the same index entry.
+func TestBuildIndex_GroupCollisionAcrossCRDs(t *testing.T) {
+	// Two CRDs both named "Foo" but in different groups, same namespace +
+	// name. Without group-keying, the second would overwrite the first.
+	report := makeReport(t, "PolicyReport", "ns", "collision", nil, time.Now(), []map[string]any{
+		{
+			"policy": "alpha-policy",
+			"result": "fail",
+			"resources": []any{
+				resourceRefWithGroup("alpha.example.com/v1", "Foo", "ns", "shared"),
+			},
+		},
+		{
+			"policy": "beta-policy",
+			"result": "fail",
+			"resources": []any{
+				resourceRefWithGroup("beta.example.com/v1", "Foo", "ns", "shared"),
+			},
+		},
+	})
+
+	idx := BuildIndex([]*unstructured.Unstructured{report})
+	if idx.Size() != 2 {
+		t.Fatalf("expected 2 distinct subjects (group-keyed), got %d", idx.Size())
+	}
+	alpha := idx.FindingsFor("alpha.example.com", "Foo", "ns", "shared")
+	if len(alpha) != 1 || alpha[0].Policy != "alpha-policy" {
+		t.Errorf("alpha CRD findings wrong: %v", alpha)
+	}
+	beta := idx.FindingsFor("beta.example.com", "Foo", "ns", "shared")
+	if len(beta) != 1 || beta[0].Policy != "beta-policy" {
+		t.Errorf("beta CRD findings wrong: %v", beta)
+	}
+}
+
 func TestParseSubjectKey(t *testing.T) {
 	cases := []struct {
-		key                 string
-		kind, ns, name      string
-		ok                  bool
+		key                    string
+		group, kind, ns, name  string
+		ok                     bool
 	}{
-		{"Pod/prod/web", "Pod", "prod", "web", true},
-		{"ClusterRole//admin", "ClusterRole", "", "admin", true},
-		{"malformed", "", "", "", false},
-		{"two/parts", "", "", "", false},
-		{"/ns/name", "", "", "", false}, // empty kind invalid
-		{"Kind/ns/", "", "", "", false}, // empty name invalid
+		// Core-group + namespaced
+		{"/Pod/prod/web", "", "Pod", "prod", "web", true},
+		// Core-group + cluster-scoped
+		{"/ClusterRole//admin", "", "ClusterRole", "", "admin", true},
+		// Non-core CRD + namespaced
+		{"argoproj.io/Application/default/myapp", "argoproj.io", "Application", "default", "myapp", true},
+		// Non-core CRD + cluster-scoped
+		{"karpenter.sh/NodePool//default", "karpenter.sh", "NodePool", "", "default", true},
+		// Malformed: not enough parts
+		{"malformed", "", "", "", "", false},
+		{"two/parts", "", "", "", "", false},
+		{"three/parts/here", "", "", "", "", false},
+		// Empty kind invalid even when group set
+		{"group//ns/name", "", "", "", "", false},
+		// Empty name invalid
+		{"group/Kind/ns/", "", "", "", "", false},
 	}
 	for _, c := range cases {
-		k, ns, n, ok := parseSubjectKey(c.key)
-		if ok != c.ok || k != c.kind || ns != c.ns || n != c.name {
-			t.Errorf("parseSubjectKey(%q) = (%q, %q, %q, %v), want (%q, %q, %q, %v)",
-				c.key, k, ns, n, ok, c.kind, c.ns, c.name, c.ok)
+		g, k, ns, n, ok := parseSubjectKey(c.key)
+		if ok != c.ok || g != c.group || k != c.kind || ns != c.ns || n != c.name {
+			t.Errorf("parseSubjectKey(%q) = (%q, %q, %q, %q, %v), want (%q, %q, %q, %q, %v)",
+				c.key, g, k, ns, n, ok, c.group, c.kind, c.ns, c.name, c.ok)
 		}
 	}
 }

--- a/pkg/policyreports/index_test.go
+++ b/pkg/policyreports/index_test.go
@@ -389,6 +389,117 @@ func TestIndex_NilSafe(t *testing.T) {
 	if got := idx.Size(); got != 0 {
 		t.Errorf("nil index Size returned %d", got)
 	}
+	if got := idx.All(); got != nil {
+		t.Errorf("nil index All returned %v", got)
+	}
 	// Replace on nil receiver should not panic.
 	idx.Replace(nil)
+}
+
+func TestIndex_All(t *testing.T) {
+	report := makeReport(t, "PolicyReport", "prod", "rep-1", nil, time.Now(), []map[string]any{
+		{
+			"policy": "p1",
+			"rule":   "r1",
+			"result": "fail",
+			"resources": []any{
+				resourceRef("Pod", "prod", "web"),
+				resourceRef("Pod", "prod", "api"),
+			},
+		},
+		{
+			"policy": "p2",
+			"rule":   "r2",
+			"result": "warn",
+			"resources": []any{
+				resourceRef("Deployment", "prod", "web"),
+			},
+		},
+	})
+	// Cluster-scoped subject via ClusterPolicyReport.
+	clusterReport := makeReport(t, "ClusterPolicyReport", "", "cluster-rep-1", nil, time.Now(), []map[string]any{
+		{
+			"policy": "p3",
+			"rule":   "r3",
+			"result": "fail",
+			"resources": []any{
+				resourceRef("ClusterRole", "", "admin"),
+			},
+		},
+	})
+
+	idx := BuildIndex([]*unstructured.Unstructured{report, clusterReport})
+	all := idx.All()
+	if len(all) != 4 {
+		t.Fatalf("expected 4 subjects (2 pods + 1 deployment + 1 clusterrole), got %d: %+v", len(all), all)
+	}
+
+	// Verify subjects + findings round-trip; iteration order must be stable
+	// (alphabetical by key) — pin it explicitly so a regression is loud.
+	gotKeys := make([]string, 0, len(all))
+	for _, sf := range all {
+		gotKeys = append(gotKeys, sf.Subject.Kind+"/"+sf.Subject.Namespace+"/"+sf.Subject.Name)
+	}
+	wantKeys := []string{
+		"ClusterRole//admin",
+		"Deployment/prod/web",
+		"Pod/prod/api",
+		"Pod/prod/web",
+	}
+	if !sort.StringsAreSorted(gotKeys) {
+		t.Fatalf("All() iteration not sorted by key: %v", gotKeys)
+	}
+	for i := range wantKeys {
+		if gotKeys[i] != wantKeys[i] {
+			t.Errorf("subject[%d]: got %q want %q (full: %v)", i, gotKeys[i], wantKeys[i], gotKeys)
+		}
+	}
+
+	// Verify per-subject Findings: the cluster-scoped one.
+	for _, sf := range all {
+		if sf.Subject.Kind != "ClusterRole" {
+			continue
+		}
+		if sf.Subject.Namespace != "" || sf.Subject.Name != "admin" {
+			t.Errorf("cluster-scoped subject malformed: %+v", sf.Subject)
+		}
+		if len(sf.Findings) != 1 || sf.Findings[0].Policy != "p3" {
+			t.Errorf("cluster-scoped findings wrong: %+v", sf.Findings)
+		}
+	}
+
+	// Returned slices must be defensive copies — mutating must not
+	// corrupt subsequent FindingsFor lookups.
+	for _, sf := range all {
+		if sf.Subject.Kind == "Pod" && sf.Subject.Name == "web" {
+			sf.Findings[0].Policy = "MUTATED"
+			break
+		}
+	}
+	got := idx.FindingsFor("Pod", "prod", "web")
+	if len(got) == 0 || got[0].Policy == "MUTATED" {
+		t.Fatalf("All() returned non-defensive copy — mutation leaked: %+v", got)
+	}
+}
+
+func TestParseSubjectKey(t *testing.T) {
+	cases := []struct {
+		key                 string
+		kind, ns, name      string
+		ok                  bool
+	}{
+		{"Pod/prod/web", "Pod", "prod", "web", true},
+		{"ClusterRole//admin", "ClusterRole", "", "admin", true},
+		{"malformed", "", "", "", false},
+		{"two/parts", "", "", "", false},
+		{"/ns/name", "", "", "", false}, // empty kind invalid
+		{"Kind/ns/", "", "", "", false}, // empty name invalid
+	}
+	for _, c := range cases {
+		k, ns, n, ok := parseSubjectKey(c.key)
+		if ok != c.ok || k != c.kind || ns != c.ns || n != c.name {
+			t.Errorf("parseSubjectKey(%q) = (%q, %q, %q, %v), want (%q, %q, %q, %v)",
+				c.key, k, ns, n, ok, c.kind, c.ns, c.name, c.ok)
+		}
+	}
 }


### PR DESCRIPTION
Wave 2 / Phase 4c. Adds Kyverno PolicyReport findings as a first-class source for `/api/issues` and the MCP `issues` tool, with explicit lifecycle signaling so an empty result is never ambiguous.

## What lands

**`pkg/policyreports/index.go`** — `Index` over PolicyReport / ClusterPolicyReport CRs. Indexed by `group/Kind/ns/name` (group first because group AND namespace can each be empty independently — encoding group last leaves a cluster-scoped CRD key ambiguous with a namespaced core-group key under any 3-part parse). Group derived from `scope.apiVersion` AND `results[].resources[].apiVersion` so per-result resources targeting multiple subjects each get the right group.

`Subject` struct carries `{Group, Kind, Namespace, Name}` — Group propagates all the way through to `Issue.Group` via `fromKyverno` in `internal/issues/issues.go`.

**`internal/issues/`** — new `SourceKyverno` constant, composer integration, `Compose` honors `?source=kyverno` filter.

**`internal/server/issues_handler.go`** — REST `/api/issues?source=kyverno` returns Kyverno-only findings.

**`internal/mcp/tools.go::handleIssues`** — MCP `issues` tool accepts `source=kyverno` (and `include_kyverno=true` for additive opt-in).

## Lifecycle signaling

Empty Kyverno results were silently empty whether Kyverno was unavailable, warmup-deferred, or genuinely had no findings — agents had no way to tell. Added `k8s.KyvernoStatus` enum (`not_installed` / `deferred` / `warmup` / `ready`) backed by an `atomic.Value`. Both REST and MCP emit `meta.kyverno: "<status>"` on the response **only when the caller opted into Kyverno** (`source=kyverno` or `include_kyverno=true`). Default responses skip the meta to keep payload lean.

## Race protection: Reset vs Warmup

The Reset / Warmup interaction needed two rounds of hardening:
1. `kyvernoWarmupGen` (atomic.Int64) bumped inside `ResetPolicyReportIndex`; all `setDecision` / `publishReady` writes inside the Warmup lambda check gen under `policyReportMu` before storing.
2. Snapshot of `(policyReportInit, kyvernoWarmupGen)` happens UNDER `policyReportMu` BEFORE `Do()` — closes the window where the lambda could capture the post-Reset gen and still write OLD-cluster data with the NEW gen.

A `-race` torture test (4 resetters × 4 snapshotters × 500 iterations) plus a structural-invariant test pin the design.

## Source filter contract

`source=X` filters to ONLY the listed sources. `include_X=true` adds X to the default `problem + condition` set without silencing. Docs in `issues_handler.go`, the MCP `issues` tool description, and the `wantSource` implementation comment all now spell this out — earlier wording (incl. the MCP jsonschema string "Sources are AND'd; opting one in does not silence the defaults") was misleading and asserted the opposite behavior.

## Wire-surface alignment with T6

Mirrors PR #721's speculative-surface trim of `pkg/resourcecontext/types.go` — drops `ContextRef.Reason`/`Source`/`Confidence`, the `RefReason`/`RefSource` enums, `ResourceContext.Truncated`, and two unused `OmittedReason` values. T11 doesn't reference the deleted fields; this keeps the shared types in sync across the wave-2 PRs so they don't conflict on merge regardless of order. Retained `OmittedCacheCold` + `OmittedNotInstalled` per the explicit `TODO(T10)` in `internal/k8s/policy_reports.go` that plans to populate these when the diagnostic-tier Kyverno consumer arrives.

## Verification

`go vet ./...` + `go test -count=1 -race ./internal/k8s/...` + full `go test -count=1 ./...` all green. Tests pin: group propagation from scope.apiVersion AND per-result resources[].apiVersion, Issue.Group via fromKyverno, status enum lifecycle, gen monotonicity, stale-gen write skip, Once/gen atomic snapshot under race.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Kyverno-backed issues source and modifies PolicyReport warmup/reset concurrency with new lifecycle state tracking; correctness depends on atomic/generation logic and could affect issue completeness or stale state across cluster switches.
> 
> **Overview**
> Adds **Kyverno PolicyReport/ClusterPolicyReport findings** as an *opt-in* `kyverno` source for the unified issues surfaces (`/api/issues` and the MCP `issues` tool), mapping `fail`/`error` → `critical`, `warn` → `warning`, and omitting `pass`/`skip`, while propagating the subject’s API `group` to avoid kind collisions.
> 
> Introduces Kyverno index lifecycle reporting (`not_installed`/`deferred`/`warmup`/`ready`) and returns it as `meta.kyverno` only when Kyverno is requested (`include_kyverno=true` or `source=kyverno`), plus clarifies/enforces that `source=` is a **filter** (not additive) and adds `include_kyverno` for “defaults + kyverno” behavior.
> 
> Hardens PolicyReport warmup vs context-switch reset with generation-guarded atomic writes and adds extensive unit tests (issues composition, group keying/index enumeration, lifecycle transitions, and race-protection), along with documentation updates noting Kyverno support and issues mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e92001b146daab415265b629904aae4ca5339e10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->