### PR TITLE
fix(auth): request "groups" OIDC scope by default

### DIFF
--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -73,6 +74,7 @@ func main() {
 	authOIDCClientSecret := flag.String("auth-oidc-client-secret", "", "OIDC client secret")
 	authOIDCRedirectURL := flag.String("auth-oidc-redirect-url", "", "OIDC redirect URL")
 	authOIDCGroupsClaim := flag.String("auth-oidc-groups-claim", "groups", "JWT claim for groups")
+	authOIDCScopes := flag.String("auth-oidc-scopes", "openid,profile,email,groups", "Comma-separated OAuth2 scopes requested at OIDC authorization (e.g. 'openid,profile,email,groups,offline_access')")
 	authOIDCPostLogoutRedirectURL := flag.String("auth-oidc-post-logout-redirect-url", "", "URL to redirect after OIDC provider logout (must be registered with IdP)")
 	authOIDCUsernamePrefix := flag.String("auth-oidc-username-prefix", "", "Prefix added to OIDC username for K8s impersonation (must match kube-apiserver --oidc-username-prefix)")
 	authOIDCGroupsPrefix := flag.String("auth-oidc-groups-prefix", "", "Prefix added to OIDC groups for K8s impersonation (must match kube-apiserver --oidc-groups-prefix)")
@@ -172,6 +174,7 @@ func main() {
 			OIDCClientSecret:          *authOIDCClientSecret,
 			OIDCRedirectURL:           *authOIDCRedirectURL,
 			OIDCGroupsClaim:           *authOIDCGroupsClaim,
+			OIDCScopes:                parseCSV(*authOIDCScopes),
 			OIDCPostLogoutRedirectURL: *authOIDCPostLogoutRedirectURL,
 			OIDCUsernamePrefix:        *authOIDCUsernamePrefix,
 			OIDCGroupsPrefix:          *authOIDCGroupsPrefix,
@@ -281,4 +284,15 @@ func main() {
 
 	// Block forever (server is running in background)
 	select {}
+}
+
+func parseCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -77,6 +77,9 @@ spec:
             {{- if .Values.auth.oidc.groupsClaim }}
             - --auth-oidc-groups-claim={{ .Values.auth.oidc.groupsClaim }}
             {{- end }}
+            {{- if .Values.auth.oidc.scopes }}
+            - --auth-oidc-scopes={{ join "," .Values.auth.oidc.scopes }}
+            {{- end }}
             {{- if .Values.auth.oidc.postLogoutRedirectURL }}
             - --auth-oidc-post-logout-redirect-url={{ .Values.auth.oidc.postLogoutRedirectURL }}
             {{- end }}

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -233,6 +233,11 @@ auth:
     clientSecretKey: "client-secret"
     redirectURL: ""
     groupsClaim: "groups"
+    # OAuth2 scopes requested at authorization. Defaults to
+    # ["openid", "profile", "email", "groups"] inside the binary when empty.
+    # Override if your IdP rejects "groups" (e.g., Google — drop it) or you
+    # need extras like "offline_access".
+    scopes: []
     # URL to redirect after OIDC provider logout (must be registered with IdP)
     postLogoutRedirectURL: ""
     # Prefix for OIDC username/groups to match kube-apiserver --oidc-username-prefix / --oidc-groups-prefix

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -77,7 +77,10 @@ auth:
     clientSecret: your-client-secret
     redirectURL: https://radar.example.com/auth/callback
     groupsClaim: groups                        # JWT claim containing group membership
+    # scopes: ["openid", "profile", "email", "groups"]  # Default — uncomment to override (e.g., drop "groups" for Google)
 ```
+
+**Scopes:** by default Radar requests `openid profile email groups` at the authorization endpoint. The `groups` scope is required by Dex, Keycloak, and most IdPs to actually include the groups claim in the ID token. If your IdP rejects unknown scopes (Google in particular doesn't define `groups`), override via `auth.oidc.scopes` / `--auth-oidc-scopes` to drop it or substitute the provider-specific equivalent.
 
 **Logout behavior:**
 
@@ -387,6 +390,7 @@ Radar uses stateless HMAC-SHA256 signed cookies for sessions. The cookie contain
 | OIDC client secret key | — | `auth.oidc.clientSecretKey` | `client-secret` |
 | OIDC redirect URL | `--auth-oidc-redirect-url` | `auth.oidc.redirectURL` | — |
 | OIDC groups claim | `--auth-oidc-groups-claim` | `auth.oidc.groupsClaim` | `groups` |
+| OIDC scopes | `--auth-oidc-scopes` | `auth.oidc.scopes` | `openid,profile,email,groups` |
 | OIDC post-logout redirect | `--auth-oidc-post-logout-redirect-url` | `auth.oidc.postLogoutRedirectURL` | — |
 | OIDC username prefix | `--auth-oidc-username-prefix` | `auth.oidc.usernamePrefix` | — |
 | OIDC groups prefix | `--auth-oidc-groups-prefix` | `auth.oidc.groupsPrefix` | — |

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -73,13 +73,18 @@ func NewOIDCHandler(ctx context.Context, cfg Config) (*OIDCHandler, error) {
 		return nil, err
 	}
 
+	scopes := cfg.OIDCScopes
+	if len(scopes) == 0 {
+		scopes = []string{oidc.ScopeOpenID, "profile", "email", "groups"}
+	}
 	oauthCfg := oauth2.Config{
 		ClientID:     cfg.OIDCClientID,
 		ClientSecret: cfg.OIDCClientSecret,
 		RedirectURL:  cfg.OIDCRedirectURL,
 		Endpoint:     provider.Endpoint(),
-		Scopes:       []string{oidc.ScopeOpenID, "profile", "email"},
+		Scopes:       scopes,
 	}
+	log.Printf("[oidc] Requesting scopes: %v", scopes)
 
 	verifier := provider.Verifier(&oidc.Config{ClientID: cfg.OIDCClientID})
 

--- a/pkg/auth/config_test.go
+++ b/pkg/auth/config_test.go
@@ -44,6 +44,15 @@ func TestConfig_Defaults(t *testing.T) {
 	if cfg.OIDCGroupsClaim != "groups" {
 		t.Errorf("OIDCGroupsClaim = %q, want %q", cfg.OIDCGroupsClaim, "groups")
 	}
+	wantScopes := []string{"openid", "profile", "email", "groups"}
+	if len(cfg.OIDCScopes) != len(wantScopes) {
+		t.Fatalf("OIDCScopes = %v, want %v", cfg.OIDCScopes, wantScopes)
+	}
+	for i, s := range wantScopes {
+		if cfg.OIDCScopes[i] != s {
+			t.Errorf("OIDCScopes[%d] = %q, want %q", i, cfg.OIDCScopes[i], s)
+		}
+	}
 	if cfg.Secret == "" {
 		t.Error("Secret should be auto-generated when auth is enabled")
 	}
@@ -66,6 +75,7 @@ func TestConfig_Defaults_PreservesExistingValues(t *testing.T) {
 		UserHeader:      "X-Custom-User",
 		GroupsHeader:    "X-Custom-Groups",
 		OIDCGroupsClaim: "roles",
+		OIDCScopes:      []string{"openid", "email"},
 	}
 	cfg.Defaults()
 
@@ -83,6 +93,9 @@ func TestConfig_Defaults_PreservesExistingValues(t *testing.T) {
 	}
 	if cfg.OIDCGroupsClaim != "roles" {
 		t.Error("Defaults should not overwrite existing OIDCGroupsClaim")
+	}
+	if len(cfg.OIDCScopes) != 2 || cfg.OIDCScopes[0] != "openid" || cfg.OIDCScopes[1] != "email" {
+		t.Errorf("Defaults should not overwrite existing OIDCScopes, got %v", cfg.OIDCScopes)
 	}
 }
 

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -29,7 +29,8 @@ type Config struct {
 	OIDCClientID     string
 	OIDCClientSecret string
 	OIDCRedirectURL           string
-	OIDCGroupsClaim           string // default "groups"
+	OIDCGroupsClaim           string   // default "groups"
+	OIDCScopes                []string // OAuth2 scopes requested at authorization; default ["openid", "profile", "email", "groups"]
 	OIDCPostLogoutRedirectURL  string // optional, URL to redirect after IdP logout
 	OIDCUsernamePrefix         string // prefix added to OIDC username for K8s impersonation (e.g., "oidc:")
 	OIDCGroupsPrefix           string // prefix added to OIDC groups for K8s impersonation (e.g., "oidc:")
@@ -63,6 +64,9 @@ func (c *Config) Defaults() {
 	}
 	if c.OIDCGroupsClaim == "" {
 		c.OIDCGroupsClaim = "groups"
+	}
+	if len(c.OIDCScopes) == 0 {
+		c.OIDCScopes = []string{"openid", "profile", "email", "groups"}
 	}
 	// Fall back to env vars for secrets (used by Helm chart)
 	if c.Secret == "" {


### PR DESCRIPTION
## Summary

Group-based RBAC was silently broken on Dex (and any IdP that gates the groups claim on the `groups` scope being requested). The OIDC handler hard-coded the OAuth2 scopes to `[openid, profile, email]`, so the IdP never put groups in the ID token — login succeeded with an empty groups list and the user saw no cluster resources.

## Change

- Add `OIDCScopes` to `auth.Config`, defaulting to `[openid, profile, email, groups]`.
- Expose `--auth-oidc-scopes` CLI flag and `auth.oidc.scopes` Helm value for operators on providers that reject unknown scopes (e.g., Google doesn't define `groups`) or that need extras like `offline_access`.
- Log requested scopes at startup so the wire contract is observable.
- Helm chart only emits the flag when `auth.oidc.scopes` is set, so the binary's default kicks in for the common case.

Fixes #712.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OIDC authorization scope requests and adds new configuration surface (CLI/Helm), which can affect login behavior depending on IdP scope validation and group-claim availability.
> 
> **Overview**
> Fixes OIDC group-based RBAC by **requesting the `groups` scope by default** during authorization, and wires this through a new `OIDCScopes` field in `auth.Config`.
> 
> Adds operator overrides via `--auth-oidc-scopes` (with CSV parsing) and `auth.oidc.scopes` Helm values (only emitting the flag when set), logs the requested scopes at startup for observability, and updates docs/tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2e754cd2dff2c8eabd2b44d813523ab6158d20d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->