### PR TITLE
docs(cloud): explain why URL discovery is dormant on managed K8s

### DIFF
--- a/internal/cloud/cluster_info.go
+++ b/internal/cloud/cluster_info.go
@@ -25,6 +25,15 @@ import (
 //
 // All of the empty-string cases are fine: the hub falls back to name-based
 // correlation. A non-empty URL just gives correlation a stronger signal.
+//
+// Practical reach: since EKS/GKE/AKS omit cluster-info, URL correlation
+// is dormant on the cloud-K8s majority and only fires for kubeadm-style
+// installs (kind, k3d, on-prem, kubeadm). Closing this gap is a chart-
+// level escape hatch (helm value -> RADAR_API_SERVER_URL env var fed in
+// at install time from the operator's kubeconfig), not an in-cluster
+// discovery problem — pods can't see the external API server URL
+// without external input. Tracked as a follow-up; not blocking.
+//
 // Caller should pass a short timeout via ctx — a single ConfigMap GET
 // should resolve in well under a second.
 func DiscoverAPIServerURL(ctx context.Context, client kubernetes.Interface) string {


### PR DESCRIPTION
## Summary

Small doc-only follow-up to PR #719 (fleet GitOps URL correlation).

The existing comment on `DiscoverAPIServerURL` explains when it returns empty (CM absent, RBAC denied, malformed kubeconfig) but doesn't tell future contributors *where* the actual fix lives. Pods can't see the external API server URL without external input — extending discovery further here can't close the gap. The realistic fix is at the chart layer (a helm value → `RADAR_API_SERVER_URL` env var fed from the operator's kubeconfig at install time).

Without this note, the next contributor poking at "why doesn't URL correlation fire on my EKS cluster?" might burn a session trying to make in-cluster discovery work. Adding 7 lines saves that.

No runtime change. Tracked at the hub side in `radar-hub/docs/STATUS.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: comment-only change that adds guidance on why URL correlation is typically unavailable on managed K8s and where the real fix should live (chart/installation inputs).
> 
> **Overview**
> Clarifies `DiscoverAPIServerURL`’s practical limitations by documenting that managed K8s (EKS/GKE/AKS) typically lacks `kube-public/cluster-info`, so URL-based cluster correlation is usually dormant.
> 
> Adds guidance that closing the gap requires an install/chart-level escape hatch (feeding `RADAR_API_SERVER_URL` from the operator’s kubeconfig), not further in-cluster discovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86c56521cd04d15e5b2a460ccc5fb0ce140a6740. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->