### PR TITLE
feat(flux): add Message column to HelmRelease list view

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -793,6 +793,7 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
     { key: 'chart', label: 'Chart', width: 'w-40' },
     { key: 'version', label: 'Version', width: 'w-24' },
     { key: 'status', label: 'Status', width: 'w-24' },
+    { key: 'message', label: 'Message', width: 'w-64', hideOnMobile: true, tooltip: 'Last diagnostic message — distinguishes dependency-wait, install/upgrade failure, and test failure' },
     { key: 'revision', label: 'Rev', width: 'w-16', hideOnMobile: true, tooltip: 'Helm release revision number' },
     { key: 'lastUpdated', label: 'Last Updated', width: 'w-28', tooltip: 'Time since last successful reconciliation' },
     { key: 'age', label: 'Age', width: 'w-24' },

--- a/packages/k8s-ui/src/components/resources/renderers/flux-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/flux-cells.tsx
@@ -22,6 +22,7 @@ import {
   getFluxHelmReleaseVersion,
   getFluxHelmReleaseStatus,
   getFluxHelmReleaseRevision,
+  getFluxHelmReleaseMessage,
   getFluxAlertProvider,
   getFluxAlertEventCount,
   getFluxAlertStatus,
@@ -200,6 +201,17 @@ export function FluxHelmReleaseCell({ resource, column }: { resource: any; colum
         <span className={clsx('badge', status.color)}>
           {status.text}
         </span>
+      )
+    }
+    case 'message': {
+      const message = getFluxHelmReleaseMessage(resource)
+      if (!message) {
+        return <span className="text-sm text-theme-text-tertiary">-</span>
+      }
+      return (
+        <Tooltip content={message}>
+          <span className="text-sm text-theme-text-secondary truncate block">{message}</span>
+        </Tooltip>
       )
     }
     case 'revision': {

--- a/packages/k8s-ui/src/components/resources/resource-utils-flux.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-flux.ts
@@ -86,6 +86,20 @@ export function getFluxHelmReleaseStatus(hr: any): StatusBadge {
   return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
 }
 
+/**
+ * Last diagnostic message for a HelmRelease — surfaces dependency-wait vs install/upgrade failure
+ * vs test failure, which is otherwise hidden inside conditions. Returns '' for healthy releases
+ * (Ready=True) so the table column stays quiet on a green cluster.
+ */
+export function getFluxHelmReleaseMessage(hr: any): string {
+  const conditions: FluxCondition[] = hr.status?.conditions || []
+  const readyCondition = conditions.find((c) => c.type === 'Ready')
+  if (readyCondition?.status === 'True') return ''
+  if (readyCondition?.message) return readyCondition.message
+  const releasedCondition = conditions.find((c) => c.type === 'Released')
+  return releasedCondition?.message || ''
+}
+
 // ============================================================================
 // FLUXCD TABLE CELL UTILITIES
 // ============================================================================

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -1263,6 +1263,7 @@ export {
   getFluxHelmReleaseChart,
   getFluxHelmReleaseVersion,
   getFluxHelmReleaseRevision,
+  getFluxHelmReleaseMessage,
   getFluxAlertProvider,
   getFluxAlertEventCount,
 } from './resource-utils-flux'


### PR DESCRIPTION
## Summary

Flux HelmRelease's list view doesn't show *why* a release failed — you have to drill into the resource to find out whether it's waiting on a dependency, blocked on a bad chart reference, or genuinely failing to install. This PR adds a `Message` column to the HelmRelease table that surfaces the `Ready` condition's diagnostic message directly in the list.

Closes #728.

## What changed

- New accessor `getFluxHelmReleaseMessage(hr)` reads `status.conditions[?type=Ready].message` (falls back to `Released.message`).
- `FluxHelmReleaseCell` renders the message truncated to `w-64`, with full text in a Tooltip on hover.
- Column inserted between `Status` and `Rev`, `hideOnMobile: true`.
- For healthy releases (`Ready=True`), returns `''` so the cell renders as `-` — column stays quiet on a green cluster.

## Notes

- **Zero new API calls.** The Ready/Released conditions are already loaded with the HelmRelease list; this is pure presentation.
- **Diagnostic categories surfaced**: dependency wait (`dependency 'foo/bar' is not ready`), install/upgrade failure (`Helm install failed: …`), test failure (`chart test failed: …`).
- **Test coverage**: no existing tests for `getFluxHelmReleaseStatus` or other Flux accessors. Filed for a separate hygiene PR rather than adding a one-off test for this 4-branch accessor.

## Test plan

- [x] `npm run tsc` clean
- [x] Visually verified on `kind-radar-gitops-demo` (Flux fixtures): healthy `podinfo` shows `-`; broken `podinfo-broken` shows the truncated `HelmChart … is not ready: invalid chart reference …`, full text in tooltip on hover
- [x] Dark mode renders correctly (theme tokens, no washout)
- [x] Console clean (0 errors, 0 warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that reads existing `status.conditions` data and adds a new table column; main risk is minor layout/tooltip rendering issues or unexpected condition shapes.
> 
> **Overview**
> Adds a **new `Message` column** to the Flux `HelmRelease` list in `ResourcesView`, hidden on mobile and described via a tooltip.
> 
> Implements `getFluxHelmReleaseMessage()` (re-exported via `resource-utils`) to surface the latest diagnostic message from the `Ready` condition (falling back to `Released`), and updates `FluxHelmReleaseCell` to render it truncated with a hover tooltip and `-` when empty/healthy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b597ae6859d6f3e3fca3ab79357e0563c2a14b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->