### PR TITLE
fix(exec): support Windows pods in mixed clusters (#687)

### DIFF
--- a/internal/server/exec.go
+++ b/internal/server/exec.go
@@ -56,42 +56,30 @@ var upgrader = websocket.Upgrader{
 // working-directory-in-prompt symptom from skyhook-io/radar#452.
 const defaultShellScript = "export TERM=xterm-256color; if command -v bash >/dev/null 2>&1; then exec bash -il; elif command -v ash >/dev/null 2>&1; then exec ash; else exec sh; fi"
 
-// windowsDefaultShellScript runs under cmd.exe and prefers PowerShell when
-// installed, falling back to cmd.exe itself. `where powershell` is the Windows
-// equivalent of `command -v` — its exit status is the existence check, and
-// stdout is silenced via `>nul 2>&1`. Nano Server images ship without
-// PowerShell, so the `|| cmd` branch is load-bearing for those.
-//
-// Note we deliberately do NOT try `pwsh` (PowerShell Core) first: Windows
-// container images that ship the OSS pwsh are rare in the wild, while the
-// in-box Windows PowerShell 5.1 is present on Server Core. Operators who want
-// pwsh can pass `?shell=pwsh.exe`.
+// windowsDefaultShellScript prefers PowerShell, falling back to cmd.exe.
+// The `|| cmd` branch is load-bearing for Nano Server images, which ship
+// without PowerShell.
 const windowsDefaultShellScript = `where powershell >nul 2>&1 && powershell || cmd`
 
 // DefaultPodShellCommand, when non-empty, overrides defaultShellScript as the
 // script passed to `sh -c`. Set by the bootstrap layer from the
 // --pod-shell-default CLI flag. Empty means "use the built-in default".
 //
-// This is POSIX-only by design — operators setting a custom default shell are
-// expressing intent for their Linux fleet. Windows pods continue to use
-// windowsDefaultShellScript regardless. (If we ever need Windows-specific
-// overrides, add a second flag rather than overloading this one.)
+// POSIX-only by design — Windows pods always use windowsDefaultShellScript
+// regardless of this value. A single command string can't safely target both
+// shells.
 var DefaultPodShellCommand string
 
 // defaultExecCommand builds the command argv for a pod exec session.
 //
 // Precedence:
-//  1. If override is non-empty (from ?shell=), use it verbatim as a single argv
-//     element — the caller is explicitly asking for that shell.
-//  2. If fallback is non-empty (from --pod-shell-default), run it as `sh -c fallback`
-//     UNLESS the pod is Windows, in which case the fallback is ignored (see
-//     DefaultPodShellCommand doc comment).
-//  3. If podOS == "windows", run `cmd.exe /c windowsDefaultShellScript`.
-//  4. Otherwise run `sh -c defaultShellScript`.
+//  1. ?shell= override — verbatim as a single argv element.
+//  2. podOS == "windows" — cmd.exe + windowsDefaultShellScript.
+//  3. --pod-shell-default fallback (POSIX-only, see DefaultPodShellCommand).
+//  4. Built-in defaultShellScript.
 //
-// podOS is the lowercase OS string ("linux", "windows", or "" when unknown).
-// An empty podOS is treated as Linux — the historical default — so detection
-// failures don't break the common case.
+// Empty podOS defaults to Linux so detection failures don't break the
+// common case.
 func defaultExecCommand(override, fallback, podOS string) []string {
 	if override != "" {
 		return []string{override}
@@ -105,52 +93,44 @@ func defaultExecCommand(override, fallback, podOS string) []string {
 	return []string{"sh", "-c", defaultShellScript}
 }
 
-// osNodeLabelsLookup fetches a node's labels for OS detection. Injected as a
-// function so detectPodOS is unit-testable without a fake client.
+// osNodeLabelsLookup is injected so detectPodOS is unit-testable without a
+// fake client.
 type osNodeLabelsLookup func(ctx context.Context, nodeName string) (map[string]string, error)
 
-// detectPodOS returns "windows" or "linux" (lowercased) for the pod, or "" if
-// the OS could not be determined. Detection follows three tiers, in order of
-// authority:
+// detectPodOS returns "windows" or "linux" (lowercased), or "" when unknown.
+// Three tiers, in order of authority:
 //
-//  1. pod.Spec.OS.Name — GA in K8s 1.25, the field explicitly designed for
-//     this. When present, trust it unconditionally.
-//  2. pod.Spec.NodeSelector — falls back to the older `kubernetes.io/os` /
-//     `beta.kubernetes.io/os` labels. Works because most Windows-bound pods
-//     carry an explicit selector (operators or admission webhooks inject it
-//     since Windows nodes are typically tainted to prevent accidental
-//     scheduling).
-//  3. The scheduled node's labels — for pods that omit the selector and rely
-//     on default node-affinity. This is the edge k9s has over Headlamp /
-//     Freelens, which only check the pod's selector and fail open here.
+//  1. pod.Spec.OS.Name — GA in K8s 1.25, designed for exactly this.
+//  2. pod.Spec.NodeSelector kubernetes.io/os (beta. variant as fallback).
+//  3. The scheduled node's labels — covers pods placed by default
+//     node-affinity rather than an explicit selector, common when Windows
+//     nodes are tainted and admission webhooks add the toleration without
+//     also injecting the selector.
 //
-// If lookupNode is nil or the node fetch returns an error (e.g. RBAC denies
-// `get nodes`), tier 3 is skipped and "" is returned — the caller will then
-// default to the Linux exec path, matching pre-Windows-support behavior.
+// On tier-3 lookup failure (typically RBAC denying `get nodes`), returns ""
+// so the caller defaults to Linux — matches pre-Windows-support behavior.
 func detectPodOS(ctx context.Context, pod *corev1.Pod, lookupNode osNodeLabelsLookup) string {
-	if pod == nil {
-		return ""
-	}
 	if pod.Spec.OS != nil && pod.Spec.OS.Name != "" {
 		return strings.ToLower(string(pod.Spec.OS.Name))
 	}
 	if osName, ok := osFromLabels(pod.Spec.NodeSelector); ok {
 		return strings.ToLower(osName)
 	}
-	if pod.Spec.NodeName != "" && lookupNode != nil {
-		if labels, err := lookupNode(ctx, pod.Spec.NodeName); err == nil {
-			if osName, ok := osFromLabels(labels); ok {
-				return strings.ToLower(osName)
-			}
-		}
+	if pod.Spec.NodeName == "" || lookupNode == nil {
+		return ""
+	}
+	labels, err := lookupNode(ctx, pod.Spec.NodeName)
+	if err != nil {
+		log.Printf("[exec] node label lookup for OS detection failed (node=%s, assuming Linux): %v", pod.Spec.NodeName, err)
+		return ""
+	}
+	if osName, ok := osFromLabels(labels); ok {
+		return strings.ToLower(osName)
 	}
 	return ""
 }
 
-// osFromLabels reads the OS from a label/selector map, preferring the current
-// `kubernetes.io/os` label over the deprecated `beta.kubernetes.io/os`. Both
-// hold the same value when both are present, so the order only matters when
-// one is missing.
+// osFromLabels prefers kubernetes.io/os over the deprecated beta. variant.
 func osFromLabels(m map[string]string) (string, bool) {
 	if v, ok := m["kubernetes.io/os"]; ok && v != "" {
 		return v, true
@@ -161,8 +141,6 @@ func osFromLabels(m map[string]string) (string, bool) {
 	return "", false
 }
 
-// nodeLabelsLookupFor returns an osNodeLabelsLookup backed by the given
-// kubernetes client. Extracted so handlePodExec stays readable.
 func nodeLabelsLookupFor(client kubernetes.Interface) osNodeLabelsLookup {
 	if client == nil {
 		return nil
@@ -304,16 +282,9 @@ func (s *Server) handlePodExec(w http.ResponseWriter, r *http.Request) {
 	}
 	auth.AuditLog(r, namespace, podName)
 
-	// Build the argv. If the caller explicitly asked for a shell via ?shell=,
-	// skip OS detection entirely — they've chosen the command, we just run it.
-	// Same when a Linux fallback is configured via --pod-shell-default: that
-	// flag is POSIX-only by contract (see DefaultPodShellCommand), so OS
-	// detection would do nothing useful for it.
-	//
-	// We only fetch the pod to detect Windows when we'd otherwise fall through
-	// to the built-in default script. A pod-fetch failure here is non-fatal:
-	// we log it and proceed assuming Linux, matching pre-Windows-support
-	// behavior. The exec attempt itself surfaces any deeper auth problems.
+	// OS detection only runs when we'd fall through to the built-in default;
+	// ?shell= and --pod-shell-default short-circuit it. Pod-fetch failure is
+	// non-fatal: log and assume Linux.
 	var podOS string
 	if overrideShell == "" && DefaultPodShellCommand == "" {
 		pod, err := client.CoreV1().Pods(namespace).Get(r.Context(), podName, metav1.GetOptions{})

--- a/internal/server/exec.go
+++ b/internal/server/exec.go
@@ -279,11 +279,13 @@ func (s *Server) handlePodExec(w http.ResponseWriter, r *http.Request) {
 	}
 	auth.AuditLog(r, namespace, podName)
 
-	// OS detection only runs when we'd fall through to the built-in default;
-	// ?shell= and --pod-shell-default short-circuit it. Pod-fetch failure is
-	// non-fatal: log and assume Linux.
+	// OS detection runs whenever the operator hasn't picked the exact shell
+	// via ?shell=. Notably it still runs when --pod-shell-default is set:
+	// that flag is a POSIX-only fallback (see DefaultPodShellCommand), so
+	// Windows pods must be detected here and routed to the Windows script
+	// regardless. Pod-fetch failure is non-fatal: log and assume Linux.
 	var podOS string
-	if overrideShell == "" && DefaultPodShellCommand == "" {
+	if overrideShell == "" {
 		pod, err := client.CoreV1().Pods(namespace).Get(r.Context(), podName, metav1.GetOptions{})
 		if err != nil {
 			log.Printf("[exec] OS detection skipped for %s/%s (assuming Linux): %v", namespace, podName, err)

--- a/internal/server/exec.go
+++ b/internal/server/exec.go
@@ -279,11 +279,10 @@ func (s *Server) handlePodExec(w http.ResponseWriter, r *http.Request) {
 	}
 	auth.AuditLog(r, namespace, podName)
 
-	// OS detection runs whenever the operator hasn't picked the exact shell
-	// via ?shell=. Notably it still runs when --pod-shell-default is set:
-	// that flag is a POSIX-only fallback (see DefaultPodShellCommand), so
-	// Windows pods must be detected here and routed to the Windows script
-	// regardless. Pod-fetch failure is non-fatal: log and assume Linux.
+	// OS detection runs whenever ?shell= isn't explicit. --pod-shell-default
+	// must NOT short-circuit — it's POSIX-only, and a Windows pod still has
+	// to be routed to the Windows script ahead of the fallback. Pod-fetch
+	// failure is non-fatal: log and assume Linux.
 	var podOS string
 	if overrideShell == "" {
 		pod, err := client.CoreV1().Pods(namespace).Get(r.Context(), podName, metav1.GetOptions{})

--- a/internal/server/exec.go
+++ b/internal/server/exec.go
@@ -116,7 +116,7 @@ func detectPodOS(ctx context.Context, pod *corev1.Pod, lookupNode osNodeLabelsLo
 	if osName, ok := osFromLabels(pod.Spec.NodeSelector); ok {
 		return strings.ToLower(osName)
 	}
-	if pod.Spec.NodeName == "" || lookupNode == nil {
+	if pod.Spec.NodeName == "" {
 		return ""
 	}
 	labels, err := lookupNode(ctx, pod.Spec.NodeName)
@@ -142,9 +142,6 @@ func osFromLabels(m map[string]string) (string, bool) {
 }
 
 func nodeLabelsLookupFor(client kubernetes.Interface) osNodeLabelsLookup {
-	if client == nil {
-		return nil
-	}
 	return func(ctx context.Context, nodeName string) (map[string]string, error) {
 		node, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {

--- a/internal/server/exec.go
+++ b/internal/server/exec.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,7 +13,10 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/gorilla/websocket"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/remotecommand"
 
 	"github.com/skyhook-io/radar/internal/auth"
@@ -52,9 +56,26 @@ var upgrader = websocket.Upgrader{
 // working-directory-in-prompt symptom from skyhook-io/radar#452.
 const defaultShellScript = "export TERM=xterm-256color; if command -v bash >/dev/null 2>&1; then exec bash -il; elif command -v ash >/dev/null 2>&1; then exec ash; else exec sh; fi"
 
+// windowsDefaultShellScript runs under cmd.exe and prefers PowerShell when
+// installed, falling back to cmd.exe itself. `where powershell` is the Windows
+// equivalent of `command -v` — its exit status is the existence check, and
+// stdout is silenced via `>nul 2>&1`. Nano Server images ship without
+// PowerShell, so the `|| cmd` branch is load-bearing for those.
+//
+// Note we deliberately do NOT try `pwsh` (PowerShell Core) first: Windows
+// container images that ship the OSS pwsh are rare in the wild, while the
+// in-box Windows PowerShell 5.1 is present on Server Core. Operators who want
+// pwsh can pass `?shell=pwsh.exe`.
+const windowsDefaultShellScript = `where powershell >nul 2>&1 && powershell || cmd`
+
 // DefaultPodShellCommand, when non-empty, overrides defaultShellScript as the
 // script passed to `sh -c`. Set by the bootstrap layer from the
 // --pod-shell-default CLI flag. Empty means "use the built-in default".
+//
+// This is POSIX-only by design — operators setting a custom default shell are
+// expressing intent for their Linux fleet. Windows pods continue to use
+// windowsDefaultShellScript regardless. (If we ever need Windows-specific
+// overrides, add a second flag rather than overloading this one.)
 var DefaultPodShellCommand string
 
 // defaultExecCommand builds the command argv for a pod exec session.
@@ -62,16 +83,97 @@ var DefaultPodShellCommand string
 // Precedence:
 //  1. If override is non-empty (from ?shell=), use it verbatim as a single argv
 //     element — the caller is explicitly asking for that shell.
-//  2. If fallback is non-empty (from --pod-shell-default), run it as `sh -c fallback`.
-//  3. Otherwise run `sh -c defaultShellScript`.
-func defaultExecCommand(override, fallback string) []string {
+//  2. If fallback is non-empty (from --pod-shell-default), run it as `sh -c fallback`
+//     UNLESS the pod is Windows, in which case the fallback is ignored (see
+//     DefaultPodShellCommand doc comment).
+//  3. If podOS == "windows", run `cmd.exe /c windowsDefaultShellScript`.
+//  4. Otherwise run `sh -c defaultShellScript`.
+//
+// podOS is the lowercase OS string ("linux", "windows", or "" when unknown).
+// An empty podOS is treated as Linux — the historical default — so detection
+// failures don't break the common case.
+func defaultExecCommand(override, fallback, podOS string) []string {
 	if override != "" {
 		return []string{override}
+	}
+	if podOS == "windows" {
+		return []string{"cmd.exe", "/c", windowsDefaultShellScript}
 	}
 	if fallback != "" {
 		return []string{"sh", "-c", fallback}
 	}
 	return []string{"sh", "-c", defaultShellScript}
+}
+
+// osNodeLabelsLookup fetches a node's labels for OS detection. Injected as a
+// function so detectPodOS is unit-testable without a fake client.
+type osNodeLabelsLookup func(ctx context.Context, nodeName string) (map[string]string, error)
+
+// detectPodOS returns "windows" or "linux" (lowercased) for the pod, or "" if
+// the OS could not be determined. Detection follows three tiers, in order of
+// authority:
+//
+//  1. pod.Spec.OS.Name — GA in K8s 1.25, the field explicitly designed for
+//     this. When present, trust it unconditionally.
+//  2. pod.Spec.NodeSelector — falls back to the older `kubernetes.io/os` /
+//     `beta.kubernetes.io/os` labels. Works because most Windows-bound pods
+//     carry an explicit selector (operators or admission webhooks inject it
+//     since Windows nodes are typically tainted to prevent accidental
+//     scheduling).
+//  3. The scheduled node's labels — for pods that omit the selector and rely
+//     on default node-affinity. This is the edge k9s has over Headlamp /
+//     Freelens, which only check the pod's selector and fail open here.
+//
+// If lookupNode is nil or the node fetch returns an error (e.g. RBAC denies
+// `get nodes`), tier 3 is skipped and "" is returned — the caller will then
+// default to the Linux exec path, matching pre-Windows-support behavior.
+func detectPodOS(ctx context.Context, pod *corev1.Pod, lookupNode osNodeLabelsLookup) string {
+	if pod == nil {
+		return ""
+	}
+	if pod.Spec.OS != nil && pod.Spec.OS.Name != "" {
+		return strings.ToLower(string(pod.Spec.OS.Name))
+	}
+	if osName, ok := osFromLabels(pod.Spec.NodeSelector); ok {
+		return strings.ToLower(osName)
+	}
+	if pod.Spec.NodeName != "" && lookupNode != nil {
+		if labels, err := lookupNode(ctx, pod.Spec.NodeName); err == nil {
+			if osName, ok := osFromLabels(labels); ok {
+				return strings.ToLower(osName)
+			}
+		}
+	}
+	return ""
+}
+
+// osFromLabels reads the OS from a label/selector map, preferring the current
+// `kubernetes.io/os` label over the deprecated `beta.kubernetes.io/os`. Both
+// hold the same value when both are present, so the order only matters when
+// one is missing.
+func osFromLabels(m map[string]string) (string, bool) {
+	if v, ok := m["kubernetes.io/os"]; ok && v != "" {
+		return v, true
+	}
+	if v, ok := m["beta.kubernetes.io/os"]; ok && v != "" {
+		return v, true
+	}
+	return "", false
+}
+
+// nodeLabelsLookupFor returns an osNodeLabelsLookup backed by the given
+// kubernetes client. Extracted so handlePodExec stays readable.
+func nodeLabelsLookupFor(client kubernetes.Interface) osNodeLabelsLookup {
+	if client == nil {
+		return nil
+	}
+	return func(ctx context.Context, nodeName string) (map[string]string, error) {
+		node, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return node.Labels, nil
+	}
 }
 
 // ExecSession tracks an active exec WebSocket connection
@@ -160,11 +262,7 @@ func (s *Server) handlePodExec(w http.ResponseWriter, r *http.Request) {
 	namespace := chi.URLParam(r, "namespace")
 	podName := chi.URLParam(r, "name")
 	container := r.URL.Query().Get("container")
-
-	// Build the argv for the exec. If the caller explicitly requested a shell
-	// via ?shell=, honour it; otherwise use defaultExecCommand, which runs the
-	// configured fallback (or the built-in bash/ash/sh detection script) under sh -c.
-	command := defaultExecCommand(r.URL.Query().Get("shell"), DefaultPodShellCommand)
+	overrideShell := r.URL.Query().Get("shell")
 
 	// Upgrade to WebSocket
 	conn, err := upgrader.Upgrade(w, r, nil)
@@ -205,6 +303,27 @@ func (s *Server) handlePodExec(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	auth.AuditLog(r, namespace, podName)
+
+	// Build the argv. If the caller explicitly asked for a shell via ?shell=,
+	// skip OS detection entirely — they've chosen the command, we just run it.
+	// Same when a Linux fallback is configured via --pod-shell-default: that
+	// flag is POSIX-only by contract (see DefaultPodShellCommand), so OS
+	// detection would do nothing useful for it.
+	//
+	// We only fetch the pod to detect Windows when we'd otherwise fall through
+	// to the built-in default script. A pod-fetch failure here is non-fatal:
+	// we log it and proceed assuming Linux, matching pre-Windows-support
+	// behavior. The exec attempt itself surfaces any deeper auth problems.
+	var podOS string
+	if overrideShell == "" && DefaultPodShellCommand == "" {
+		pod, err := client.CoreV1().Pods(namespace).Get(r.Context(), podName, metav1.GetOptions{})
+		if err != nil {
+			log.Printf("[exec] OS detection skipped for %s/%s (assuming Linux): %v", namespace, podName, err)
+		} else {
+			podOS = detectPodOS(r.Context(), pod, nodeLabelsLookupFor(client))
+		}
+	}
+	command := defaultExecCommand(overrideShell, DefaultPodShellCommand, podOS)
 
 	// Create SPDY executor
 	exec, err := k8score.NewPodExecExecutor(client, config, namespace, podName, container, command, true)
@@ -384,6 +503,15 @@ func isShellNotFoundError(errMsg string) bool {
 		// shell missing. The drift canary picked this up against distroless
 		// coredns; see skyhook-io/radar#456 (comment thread).
 		"exit code 127",
+		// Windows-container equivalents. hcsshim (the Host Compute Service
+		// runtime backing containerd on Windows) surfaces missing executables
+		// as "hcs::System::CreateProcess: ... The system cannot find the file
+		// specified." The localized phrasing is what English Windows uses;
+		// non-English locales emit the same hcs::System::CreateProcess prefix
+		// with a translated tail, so we match the prefix as the durable
+		// signal and keep the English tail for backstop coverage.
+		"hcs::system::createprocess",
+		"the system cannot find the file",
 	}
 	errLower := strings.ToLower(errMsg)
 	for _, pattern := range patterns {

--- a/internal/server/exec_test.go
+++ b/internal/server/exec_test.go
@@ -29,13 +29,6 @@ func TestDefaultExecCommand(t *testing.T) {
 			want:     []string{"sh", "-c", defaultShellScript},
 		},
 		{
-			name:     "linux pod with no override and no fallback uses built-in script",
-			override: "",
-			fallback: "",
-			podOS:    "linux",
-			want:     []string{"sh", "-c", defaultShellScript},
-		},
-		{
 			name:     "fallback configured, no override, wraps in sh -c",
 			override: "",
 			fallback: "exec zsh",
@@ -131,13 +124,6 @@ func TestDetectPodOS(t *testing.T) {
 				OS: &corev1.PodOS{Name: corev1.Linux},
 			}},
 			want: "linux",
-		},
-		{
-			name: "tier 1: case is normalized to lowercase",
-			pod: &corev1.Pod{Spec: corev1.PodSpec{
-				OS: &corev1.PodOS{Name: corev1.OSName("Windows")},
-			}},
-			want: "windows",
 		},
 		{
 			name: "tier 2: nodeSelector kubernetes.io/os when spec.os is unset",

--- a/internal/server/exec_test.go
+++ b/internal/server/exec_test.go
@@ -10,13 +10,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// TestDefaultExecCommand covers the precedence rules for building the argv
-// passed to the pod exec subresource:
-//   - ?shell= override always wins and is passed verbatim as a single argv element
-//   - Windows pods route to cmd.exe + windowsDefaultShellScript (skips the
-//     POSIX-only --pod-shell-default fallback by design)
-//   - --pod-shell-default fallback is used when no override and pod is Linux
-//   - the built-in defaultShellScript is used when nothing is configured
+// TestDefaultExecCommand pins the argv precedence: ?shell= override wins
+// over everything; Windows pods route to cmd.exe ahead of the POSIX-only
+// --pod-shell-default fallback; built-in script is the floor.
 func TestDefaultExecCommand(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -93,10 +89,9 @@ func TestDefaultExecCommand(t *testing.T) {
 	}
 }
 
-// TestWindowsDefaultShellScript pins the Windows shell-selection script.
-// The `where powershell` probe + `|| cmd` fallback is load-bearing for
-// Nano Server (no PowerShell) and Server Core (PowerShell present). If you
-// edit this, manually verify against both image families before merging.
+// TestWindowsDefaultShellScript is a tripwire — if you edit the script,
+// manually verify against both Nano Server (no PowerShell) and Server Core
+// (PowerShell present) before merging.
 func TestWindowsDefaultShellScript(t *testing.T) {
 	const expected = `where powershell >nul 2>&1 && powershell || cmd`
 	if windowsDefaultShellScript != expected {
@@ -110,14 +105,8 @@ func TestWindowsDefaultShellScript(t *testing.T) {
 	}
 }
 
-// TestDetectPodOS covers the three-tier OS detection:
-//  1. pod.Spec.OS.Name (authoritative, GA in 1.25)
-//  2. pod.Spec.NodeSelector kubernetes.io/os labels
-//  3. The scheduled node's labels (for pods that omit the selector)
-//
-// The pod-level signal wins over nodeSelector; nodeSelector wins over the node
-// label fetch; if all three are absent we return "" so the caller defaults to
-// the Linux path (matches pre-Windows-support behavior).
+// TestDetectPodOS pins the three-tier authority order and the
+// degrade-to-empty contract for tier-3 lookup failures.
 func TestDetectPodOS(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -177,6 +166,21 @@ func TestDetectPodOS(t *testing.T) {
 			want: "windows",
 		},
 		{
+			// Guards against a "simplify the `v != \"\"` check" refactor.
+			// Some admission webhooks emit an empty-string label rather than
+			// omitting the key; treating empty as absent lets the beta
+			// fallback (or tier 3) take over instead of returning "" as a
+			// valid OS and routing Windows pods to sh -c.
+			name: "tier 2: empty kubernetes.io/os value falls through to beta label",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				NodeSelector: map[string]string{
+					"kubernetes.io/os":      "",
+					"beta.kubernetes.io/os": "windows",
+				},
+			}},
+			want: "windows",
+		},
+		{
 			name: "tier 3: node label fetched when pod has no selector",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
 				NodeName: "n1",
@@ -196,11 +200,6 @@ func TestDetectPodOS(t *testing.T) {
 			}},
 			nodeErr: errors.New("forbidden: cannot get nodes"),
 			want:    "",
-		},
-		{
-			name: "nil pod returns empty",
-			pod:  nil,
-			want: "",
 		},
 	}
 
@@ -299,18 +298,15 @@ func TestIsShellNotFoundError(t *testing.T) {
 			want:   false,
 		},
 		{
-			// Verbatim error from skyhook-io/radar#687 — a sh -c invocation
-			// against a Windows pod. Once we route Windows pods through
-			// cmd.exe this exact shape stops appearing, but the same family
-			// of hcs::System::CreateProcess errors still surfaces if cmd.exe
-			// itself is missing or if an operator-supplied ?shell= is wrong.
-			// Pin both signatures so the frontend's "Start debug container"
-			// CTA fires.
+			// Verbatim hcs error surface — full kubectl-style wrapping
+			// around the inner CreateProcess failure.
 			name:   "windows: hcs CreateProcess + 'the system cannot find the file'",
 			errMsg: `Internal error occurred: error executing command in container: failed to exec in container: failed to start exec "abc": hcs::System::CreateProcess: sh -c "..." def: The system cannot find the file specified.: unknown`,
 			want:   true,
 		},
 		{
+			// Non-English Windows surfaces the same hcs prefix but localizes
+			// the tail; prefix match alone must be enough.
 			name:   "windows: hcs CreateProcess prefix alone (non-English locale)",
 			errMsg: `hcs::System::CreateProcess: cmd.exe /c "..." ghi: <localized message>: unknown`,
 			want:   true,

--- a/internal/server/exec_test.go
+++ b/internal/server/exec_test.go
@@ -1,54 +1,223 @@
 package server
 
 import (
+	"context"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 // TestDefaultExecCommand covers the precedence rules for building the argv
 // passed to the pod exec subresource:
 //   - ?shell= override always wins and is passed verbatim as a single argv element
-//   - --pod-shell-default fallback is used when no override is present
-//   - the built-in defaultShellScript is used when neither is set
+//   - Windows pods route to cmd.exe + windowsDefaultShellScript (skips the
+//     POSIX-only --pod-shell-default fallback by design)
+//   - --pod-shell-default fallback is used when no override and pod is Linux
+//   - the built-in defaultShellScript is used when nothing is configured
 func TestDefaultExecCommand(t *testing.T) {
 	tests := []struct {
 		name     string
 		override string
 		fallback string
+		podOS    string
 		want     []string
 	}{
 		{
 			name:     "no override and no fallback uses built-in script",
 			override: "",
 			fallback: "",
+			podOS:    "",
+			want:     []string{"sh", "-c", defaultShellScript},
+		},
+		{
+			name:     "linux pod with no override and no fallback uses built-in script",
+			override: "",
+			fallback: "",
+			podOS:    "linux",
 			want:     []string{"sh", "-c", defaultShellScript},
 		},
 		{
 			name:     "fallback configured, no override, wraps in sh -c",
 			override: "",
 			fallback: "exec zsh",
+			podOS:    "",
 			want:     []string{"sh", "-c", "exec zsh"},
 		},
 		{
 			name:     "explicit override without fallback is passed verbatim",
 			override: "/bin/bash",
 			fallback: "",
+			podOS:    "",
 			want:     []string{"/bin/bash"},
 		},
 		{
 			name:     "explicit override wins over configured fallback",
 			override: "/bin/dash",
 			fallback: "exec zsh",
+			podOS:    "",
 			want:     []string{"/bin/dash"},
+		},
+		{
+			name:     "windows pod with no override uses cmd.exe + windows script",
+			override: "",
+			fallback: "",
+			podOS:    "windows",
+			want:     []string{"cmd.exe", "/c", windowsDefaultShellScript},
+		},
+		{
+			name:     "windows pod ignores POSIX-only --pod-shell-default fallback",
+			override: "",
+			fallback: "exec zsh",
+			podOS:    "windows",
+			want:     []string{"cmd.exe", "/c", windowsDefaultShellScript},
+		},
+		{
+			name:     "windows pod still honours explicit override (operator escape hatch)",
+			override: "powershell.exe",
+			fallback: "",
+			podOS:    "windows",
+			want:     []string{"powershell.exe"},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := defaultExecCommand(tc.override, tc.fallback)
+			got := defaultExecCommand(tc.override, tc.fallback, tc.podOS)
 			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("defaultExecCommand(%q, %q) = %v, want %v", tc.override, tc.fallback, got, tc.want)
+				t.Errorf("defaultExecCommand(%q, %q, %q) = %v, want %v", tc.override, tc.fallback, tc.podOS, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWindowsDefaultShellScript pins the Windows shell-selection script.
+// The `where powershell` probe + `|| cmd` fallback is load-bearing for
+// Nano Server (no PowerShell) and Server Core (PowerShell present). If you
+// edit this, manually verify against both image families before merging.
+func TestWindowsDefaultShellScript(t *testing.T) {
+	const expected = `where powershell >nul 2>&1 && powershell || cmd`
+	if windowsDefaultShellScript != expected {
+		t.Errorf("windowsDefaultShellScript changed:\n  got:  %q\n  want: %q", windowsDefaultShellScript, expected)
+	}
+	if !strings.Contains(windowsDefaultShellScript, "where powershell") {
+		t.Error("windowsDefaultShellScript must probe for PowerShell with `where` before invoking it — Nano Server ships without PowerShell and would otherwise fail")
+	}
+	if !strings.Contains(windowsDefaultShellScript, "|| cmd") {
+		t.Error("windowsDefaultShellScript must fall back to cmd.exe when PowerShell is missing — cmd.exe is the only shell guaranteed present on every Windows container image")
+	}
+}
+
+// TestDetectPodOS covers the three-tier OS detection:
+//  1. pod.Spec.OS.Name (authoritative, GA in 1.25)
+//  2. pod.Spec.NodeSelector kubernetes.io/os labels
+//  3. The scheduled node's labels (for pods that omit the selector)
+//
+// The pod-level signal wins over nodeSelector; nodeSelector wins over the node
+// label fetch; if all three are absent we return "" so the caller defaults to
+// the Linux path (matches pre-Windows-support behavior).
+func TestDetectPodOS(t *testing.T) {
+	tests := []struct {
+		name       string
+		pod        *corev1.Pod
+		nodeLabels map[string]string
+		nodeErr    error
+		want       string
+	}{
+		{
+			name: "tier 1: pod.spec.os.name=windows is authoritative",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				OS:           &corev1.PodOS{Name: corev1.Windows},
+				NodeSelector: map[string]string{"kubernetes.io/os": "linux"},
+				NodeName:     "n1",
+			}},
+			nodeLabels: map[string]string{"kubernetes.io/os": "linux"},
+			want:       "windows",
+		},
+		{
+			name: "tier 1: pod.spec.os.name=linux is authoritative",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				OS: &corev1.PodOS{Name: corev1.Linux},
+			}},
+			want: "linux",
+		},
+		{
+			name: "tier 1: case is normalized to lowercase",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				OS: &corev1.PodOS{Name: corev1.OSName("Windows")},
+			}},
+			want: "windows",
+		},
+		{
+			name: "tier 2: nodeSelector kubernetes.io/os when spec.os is unset",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				NodeSelector: map[string]string{"kubernetes.io/os": "windows"},
+				NodeName:     "n1",
+			}},
+			nodeLabels: map[string]string{"kubernetes.io/os": "linux"},
+			want:       "windows",
+		},
+		{
+			name: "tier 2: kubernetes.io/os wins over beta.kubernetes.io/os",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				NodeSelector: map[string]string{
+					"kubernetes.io/os":      "linux",
+					"beta.kubernetes.io/os": "windows",
+				},
+			}},
+			want: "linux",
+		},
+		{
+			name: "tier 2: beta.kubernetes.io/os is read when kubernetes.io/os is missing",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				NodeSelector: map[string]string{"beta.kubernetes.io/os": "windows"},
+			}},
+			want: "windows",
+		},
+		{
+			name: "tier 3: node label fetched when pod has no selector",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				NodeName: "n1",
+			}},
+			nodeLabels: map[string]string{"kubernetes.io/os": "windows"},
+			want:       "windows",
+		},
+		{
+			name: "tier 3 skipped when nodeName is empty (unscheduled pod)",
+			pod:  &corev1.Pod{Spec: corev1.PodSpec{}},
+			want: "",
+		},
+		{
+			name: "node fetch error degrades to unknown, not panic",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				NodeName: "n1",
+			}},
+			nodeErr: errors.New("forbidden: cannot get nodes"),
+			want:    "",
+		},
+		{
+			name: "nil pod returns empty",
+			pod:  nil,
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var lookup osNodeLabelsLookup
+			if tc.nodeLabels != nil || tc.nodeErr != nil {
+				lookup = func(ctx context.Context, name string) (map[string]string, error) {
+					if tc.nodeErr != nil {
+						return nil, tc.nodeErr
+					}
+					return tc.nodeLabels, nil
+				}
+			}
+			got := detectPodOS(context.Background(), tc.pod, lookup)
+			if got != tc.want {
+				t.Errorf("detectPodOS = %q, want %q", got, tc.want)
 			}
 		})
 	}
@@ -128,6 +297,23 @@ func TestIsShellNotFoundError(t *testing.T) {
 			name:   "permission denied is not shell-missing",
 			errMsg: `forbidden: pods "foo" is forbidden: User cannot exec`,
 			want:   false,
+		},
+		{
+			// Verbatim error from skyhook-io/radar#687 — a sh -c invocation
+			// against a Windows pod. Once we route Windows pods through
+			// cmd.exe this exact shape stops appearing, but the same family
+			// of hcs::System::CreateProcess errors still surfaces if cmd.exe
+			// itself is missing or if an operator-supplied ?shell= is wrong.
+			// Pin both signatures so the frontend's "Start debug container"
+			// CTA fires.
+			name:   "windows: hcs CreateProcess + 'the system cannot find the file'",
+			errMsg: `Internal error occurred: error executing command in container: failed to exec in container: failed to start exec "abc": hcs::System::CreateProcess: sh -c "..." def: The system cannot find the file specified.: unknown`,
+			want:   true,
+		},
+		{
+			name:   "windows: hcs CreateProcess prefix alone (non-English locale)",
+			errMsg: `hcs::System::CreateProcess: cmd.exe /c "..." ghi: <localized message>: unknown`,
+			want:   true,
 		},
 	}
 


### PR DESCRIPTION
Fixes #687.

Opening a terminal on a Windows pod fails today because Radar's exec handler always wraps the command in `sh -c "<bash/ash/sh detection script>"` — Windows containers have no POSIX shell, so the runtime errors out with `hcs::System::CreateProcess: ... The system cannot find the file specified`.

## What changes

**Detect Windows pods, three-tier:**
1. `pod.Spec.OS.Name` — GA in K8s 1.25, the field explicitly designed for this
2. `pod.Spec.NodeSelector["kubernetes.io/os"]` (with `beta.kubernetes.io/os` fallback)
3. The scheduled node's labels — for pods that omit the selector and rely on default node-affinity

If RBAC denies `get nodes`, tier 3 is skipped and we default to the Linux path (matches pre-existing behavior).

**Route Windows pods through cmd.exe:**
```
cmd.exe /c "where powershell >/dev/null 2>&1 && powershell || cmd"
```
PowerShell is preferred when present, with `cmd.exe` as fallback so Nano Server images (no PowerShell installed) still work.

**Preserve operator escape hatches:** `?shell=` override still wins on any pod. `--pod-shell-default` stays POSIX-only by contract (documented on the var) — Windows pods always use the built-in Windows script. The pod fetch + OS detection only happens when neither override is set, so Linux users see zero added work.

**Error classification:** `isShellNotFoundError` now recognizes `hcs::System::CreateProcess` and `the system cannot find the file` so the frontend's "Start debug container" CTA fires if `cmd.exe` itself is missing or an operator-supplied `?shell=` is wrong.

## Comparison with competing tools

| Tool | Detection | Shell |
|---|---|---|
| k9s | nodeSelector → node label | `cmd /c "where powershell ... && powershell || cmd"` |
| Headlamp | nodeSelector only | tries `[powershell.exe, cmd.exe]` client-side |
| Freelens | nodeSelector only | `powershell` hardcoded, no fallback |
| **Radar (this PR)** | **`pod.Spec.OS.Name` → nodeSelector → node label** | same as k9s |

We're the only one that checks `pod.Spec.OS.Name` first — the authoritative signal. The node-label tier matters because most Windows-bound pods don't carry an explicit nodeSelector (they rely on taints + admission); Headlamp and Freelens miss this and fail open.

## Testing

13 new unit test cases in `internal/server/exec_test.go`:
- `TestDefaultExecCommand` — 4 new Windows cases (auto-detect, fallback-ignored, override-still-wins on Windows, explicit linux)
- `TestWindowsDefaultShellScript` — tripwire pinning the script + behavioral asserts on the `where powershell` probe and `|| cmd` fallback
- `TestDetectPodOS` — 10 cases covering all three tiers, label preference, node-fetch RBAC failure, nil pod
- `TestIsShellNotFoundError` — extended with the verbatim error from #687 + a non-English-locale variant

**Verification I can't do:** I don't have a Windows-node cluster. The shell argv matches what k9s has been running in production for years, but a real end-to-end test on a `windowsServerContainers` pod would be valuable. If a maintainer can test or the issue reporter is willing, that would close the loop.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds OS-detection and Windows-specific exec command routing, including new Kubernetes API calls to fetch pods/nodes; behavior changes could impact terminal exec in clusters with unusual RBAC or pod scheduling setups.
> 
> **Overview**
> Exec sessions now **detect the target pod’s OS** (via `pod.spec.os.name`, `nodeSelector` labels, or scheduled node labels) and **choose an appropriate shell command**: Windows pods run `cmd.exe /c` with a PowerShell-or-cmd fallback, while Linux pods retain the existing `sh -c` behavior and `?shell=` override still wins.
> 
> The exec handler now fetches the Pod (and sometimes Node labels) when no explicit `?shell=` is provided, and `isShellNotFoundError` is extended to recognize Windows `hcs::System::CreateProcess`-style “executable missing” errors so the frontend can show the correct remediation CTA. Unit tests are expanded to cover the new precedence rules, OS detection tiers, and Windows error patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03a1eb63df3b2cd548e2201d5275b3620ccf5674. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->