### PR TITLE
feat(auth): per-user API keys for programmatic access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ web/package.json.md5
 .env
 .env.local
 dist/
+
+# Local deployment & contribution drafts
+deploy.sh
+CONTRIBUTE_API_KEY.md

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -79,6 +80,7 @@ func main() {
 	authOIDCInsecureSkipVerify := flag.Bool("auth-oidc-insecure-skip-verify", false, "Skip TLS certificate verification for OIDC provider (insecure, dev/test only)")
 	authOIDCCACert := flag.String("auth-oidc-ca-cert", "", "Path to CA certificate file for OIDC provider TLS verification")
 	authOIDCBackchannelLogout := flag.Bool("auth-oidc-backchannel-logout", false, "Enable OIDC Back-Channel Logout endpoint (single-replica only)")
+	authAPIKeysFile := flag.String("auth-api-keys-file", "", "Path to API keys JSON file (default: ~/.config/radar/api-keys.json when auth is enabled)")
 	// Radar Cloud flags — enable hosted mode when --cloud-url is set.
 	// Local-binary behavior is unchanged when these flags are empty. Each
 	// flag falls back to an env var so Kubernetes deployments can source
@@ -130,6 +132,13 @@ func main() {
 
 	log.Printf("Radar %s starting...", version)
 
+	// Default API keys file path when auth is enabled
+	if *authAPIKeysFile == "" && *authMode != "none" {
+		if home, err := os.UserHomeDir(); err == nil {
+			*authAPIKeysFile = filepath.Join(home, ".config", "radar", "api-keys.db")
+		}
+	}
+
 	// Validate flags
 	switch *authMode {
 	case "none", "proxy", "oidc":
@@ -139,6 +148,16 @@ func main() {
 	}
 	if *kubeconfig != "" && *kubeconfigDir != "" {
 		log.Fatalf("--kubeconfig and --kubeconfig-dir are mutually exclusive")
+	}
+
+	var apiKeyStore *auth.APIKeyStore
+	if *authAPIKeysFile != "" {
+		var err error
+		apiKeyStore, err = auth.NewAPIKeyStore(*authAPIKeysFile)
+		if err != nil {
+			log.Fatalf("[auth] Failed to load API key store at %q: %v", *authAPIKeysFile, err)
+		}
+		log.Printf("[auth] API key store: %s", *authAPIKeysFile)
 	}
 
 	cfg := app.AppConfig{
@@ -178,6 +197,7 @@ func main() {
 			OIDCInsecureSkipVerify:    *authOIDCInsecureSkipVerify,
 			OIDCCACert:                *authOIDCCACert,
 			OIDCBackchannelLogout:     *authOIDCBackchannelLogout,
+			APIKeys:                   apiKeyStore,
 		},
 	}
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,23 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REMOTE="${REMOTE:-a000s-itsentry}"
 REPO_URL="${REPO_URL:-https://tfs.astra.co.id/tfs/CIST/DevSecOps/_git/radar}"
 SRC_DIR="${SRC_DIR:-/opt/radar/src}"
 RADAR_SH="${RADAR_SH:-/opt/radar/radar.sh}"
 GO_VERSION="${GO_VERSION:-1.26.0}"
 NODE_VERSION="${NODE_VERSION:-22}"
-
-echo "→ Deploying radar to ${REMOTE}..."
-
-ssh "$REMOTE" \
-    GO_VERSION="$GO_VERSION" \
-    NODE_VERSION="$NODE_VERSION" \
-    REPO_URL="$REPO_URL" \
-    SRC_DIR="$SRC_DIR" \
-    RADAR_SH="$RADAR_SH" \
-    bash <<'EOF'
-set -euo pipefail
 
 export PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
 
@@ -72,4 +60,3 @@ cp radar "${RADAR_BIN}"
 echo "→ Restarting..."
 "${RADAR_SH}" restart
 echo "✓ Done"
-EOF

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REMOTE="${REMOTE:-a000s-itsentry}"
+REPO_URL="${REPO_URL:-https://tfs.astra.co.id/tfs/CIST/DevSecOps/_git/radar}"
+SRC_DIR="${SRC_DIR:-/opt/radar/src}"
+RADAR_SH="${RADAR_SH:-/opt/radar/radar.sh}"
+GO_VERSION="${GO_VERSION:-1.26.0}"
+NODE_VERSION="${NODE_VERSION:-22}"
+
+echo "→ Deploying radar to ${REMOTE}..."
+
+ssh "$REMOTE" \
+    GO_VERSION="$GO_VERSION" \
+    NODE_VERSION="$NODE_VERSION" \
+    REPO_URL="$REPO_URL" \
+    SRC_DIR="$SRC_DIR" \
+    RADAR_SH="$RADAR_SH" \
+    bash <<'EOF'
+set -euo pipefail
+
+export PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
+
+# ── Go ───────────────────────────────────────────────────────────────────────
+install_go() {
+    echo "→ Installing Go ${GO_VERSION}..."
+    curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o /tmp/go.tar.gz
+    rm -rf /usr/local/go
+    tar -C /usr/local -xzf /tmp/go.tar.gz
+    rm /tmp/go.tar.gz
+}
+
+current_go=$(go version 2>/dev/null | awk '{print $3}' | tr -d 'go' || echo "")
+if [[ "$current_go" != "$GO_VERSION" ]]; then
+    install_go
+    echo "✓ Go ${GO_VERSION} installed"
+else
+    echo "✓ Go ${current_go} already installed"
+fi
+
+# ── Node.js ──────────────────────────────────────────────────────────────────
+if ! command -v node &>/dev/null; then
+    echo "→ Installing Node.js ${NODE_VERSION}..."
+    curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash -
+    apt-get install -y nodejs
+    echo "✓ Node.js $(node --version) installed"
+else
+    echo "✓ Node.js $(node --version) already installed"
+fi
+
+# ── Clone or pull ────────────────────────────────────────────────────────────
+if [[ -d "${SRC_DIR}/.git" ]]; then
+    echo "→ Pulling latest..."
+    git -C "${SRC_DIR}" pull
+else
+    echo "→ Cloning repo..."
+    git clone "${REPO_URL}" "${SRC_DIR}"
+fi
+
+# ── Build ────────────────────────────────────────────────────────────────────
+echo "→ Building..."
+cd "${SRC_DIR}"
+make build
+
+# ── Replace binary ───────────────────────────────────────────────────────────
+RADAR_BIN=$(which radar)
+echo "→ Replacing ${RADAR_BIN}..."
+cp "${RADAR_BIN}" "${RADAR_BIN}.bak"
+cp radar "${RADAR_BIN}"
+
+# ── Restart ──────────────────────────────────────────────────────────────────
+echo "→ Restarting..."
+"${RADAR_SH}" restart
+echo "✓ Done"
+EOF

--- a/deploy.sh
+++ b/deploy.sh
@@ -52,11 +52,14 @@ make build
 
 # ── Replace binary ───────────────────────────────────────────────────────────
 RADAR_BIN=$(which radar)
+echo "→ Stopping radar..."
+"${RADAR_SH}" stop || true
+
 echo "→ Replacing ${RADAR_BIN}..."
 cp "${RADAR_BIN}" "${RADAR_BIN}.bak"
 cp radar "${RADAR_BIN}"
 
 # ── Restart ──────────────────────────────────────────────────────────────────
-echo "→ Restarting..."
-"${RADAR_SH}" restart
+echo "→ Starting radar..."
+"${RADAR_SH}" start
 echo "✓ Done"

--- a/deploy.sh
+++ b/deploy.sh
@@ -50,6 +50,14 @@ echo "→ Building..."
 cd "${SRC_DIR}"
 make build
 
+# ── Smoke test ───────────────────────────────────────────────────────────────
+echo "→ Testing binary..."
+if ! ./radar --version &>/dev/null; then
+    echo "✗ Build smoke test failed — aborting, existing binary untouched"
+    exit 1
+fi
+echo "✓ Binary OK"
+
 # ── Replace binary ───────────────────────────────────────────────────────────
 RADAR_BIN=$(which radar)
 echo "→ Stopping radar..."

--- a/internal/auth/apikey_handlers.go
+++ b/internal/auth/apikey_handlers.go
@@ -1,0 +1,122 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type apiKeyResponse struct {
+	ID          string     `json:"id"`
+	Description string     `json:"description"`
+	Username    string     `json:"username"`
+	Groups      []string   `json:"groups"`
+	CreatedAt   time.Time  `json:"createdAt"`
+	LastUsedAt  *time.Time `json:"lastUsedAt,omitempty"`
+	// Key is only populated on creation — never returned again.
+	Key string `json:"key,omitempty"`
+}
+
+func toAPIKeyResponse(k *APIKey) apiKeyResponse {
+	return apiKeyResponse{
+		ID:          k.ID,
+		Description: k.Description,
+		Username:    k.Username,
+		Groups:      k.Groups,
+		CreatedAt:   k.CreatedAt,
+		LastUsedAt:  k.LastUsedAt,
+	}
+}
+
+func writeAPIKeyJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}
+
+func writeAPIKeyError(w http.ResponseWriter, status int, msg string) {
+	writeAPIKeyJSON(w, status, map[string]string{"error": msg})
+}
+
+// HandleListAPIKeys returns the caller's API keys (no hash, no plaintext).
+func HandleListAPIKeys(cfg Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if cfg.APIKeys == nil {
+			writeAPIKeyError(w, http.StatusNotImplemented, "API key management is not configured")
+			return
+		}
+		user := UserFromContext(r.Context())
+		if user == nil {
+			writeAPIKeyError(w, http.StatusUnauthorized, "authentication required")
+			return
+		}
+		keys := cfg.APIKeys.ListForUser(user.Username)
+		resp := make([]apiKeyResponse, 0, len(keys))
+		for _, k := range keys {
+			resp = append(resp, toAPIKeyResponse(k))
+		}
+		writeAPIKeyJSON(w, http.StatusOK, resp)
+	}
+}
+
+// HandleCreateAPIKey generates a new API key for the authenticated user.
+// The plaintext key is returned exactly once in the response field "key".
+// Requires auth to be enabled (mode != "none") — otherwise there is no
+// stable user identity to bind the key to.
+func HandleCreateAPIKey(cfg Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if cfg.APIKeys == nil {
+			writeAPIKeyError(w, http.StatusNotImplemented, "API key management is not configured")
+			return
+		}
+		if !cfg.Enabled() {
+			writeAPIKeyError(w, http.StatusNotImplemented, "API key creation requires auth-mode to be set (proxy or oidc)")
+			return
+		}
+		user := UserFromContext(r.Context())
+		if user == nil {
+			writeAPIKeyError(w, http.StatusUnauthorized, "authentication required")
+			return
+		}
+
+		var body struct {
+			Description string `json:"description"`
+		}
+		// Ignore decode error — empty description is fine
+		json.NewDecoder(r.Body).Decode(&body)
+
+		entry, plaintext, err := cfg.APIKeys.Create(user.Username, user.Groups, body.Description)
+		if err != nil {
+			writeAPIKeyError(w, http.StatusInternalServerError, "failed to create API key")
+			return
+		}
+		resp := toAPIKeyResponse(entry)
+		resp.Key = plaintext
+		writeAPIKeyJSON(w, http.StatusCreated, resp)
+	}
+}
+
+// HandleDeleteAPIKey revokes the key with {id} belonging to the caller.
+// Returns 404 whether the key doesn't exist or belongs to a different user
+// to avoid leaking existence of other users' keys.
+func HandleDeleteAPIKey(cfg Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if cfg.APIKeys == nil {
+			writeAPIKeyError(w, http.StatusNotImplemented, "API key management is not configured")
+			return
+		}
+		user := UserFromContext(r.Context())
+		if user == nil {
+			writeAPIKeyError(w, http.StatusUnauthorized, "authentication required")
+			return
+		}
+		id := chi.URLParam(r, "id")
+		if !cfg.APIKeys.Delete(id, user.Username) {
+			writeAPIKeyError(w, http.StatusNotFound, "API key not found")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -14,6 +14,8 @@ type SessionRevoker = pkgauth.SessionRevoker
 type UserPermissions = pkgauth.UserPermissions
 type PermissionCache = pkgauth.PermissionCache
 type CloudRole = pkgauth.CloudRole
+type APIKeyStore = pkgauth.APIKeyStore
+type APIKey = pkgauth.APIKey
 
 // Re-export constants from pkg/auth
 const DefaultCookieName = pkgauth.DefaultCookieName
@@ -44,4 +46,5 @@ var (
 	ClearSessionCookie       = pkgauth.ClearSessionCookie
 	CloudRoleFromGroups      = pkgauth.CloudRoleFromGroups
 	CloudRoleFromContext     = pkgauth.CloudRoleFromContext
+	NewAPIKeyStore           = pkgauth.NewAPIKeyStore
 )

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -74,6 +74,19 @@ func Authenticate(cfg Config) func(http.Handler) http.Handler {
 				return
 			}
 
+			// Try API key — stateless per-request, no session cookie set.
+			// Works in all auth modes; inherits stored username+groups from key creation time.
+			if cfg.APIKeys != nil {
+				if raw := extractAPIKey(r); raw != "" {
+					if entry := cfg.APIKeys.Lookup(raw); entry != nil {
+						user := &User{Username: entry.Username, Groups: entry.Groups}
+						ctx := ContextWithUser(r.Context(), user)
+						next.ServeHTTP(w, r.WithContext(ctx))
+						return
+					}
+				}
+			}
+
 			// In proxy mode, extract from headers and create session
 			if cfg.Mode == "proxy" {
 				username := r.Header.Get(cfg.UserHeader)
@@ -153,6 +166,15 @@ func isExemptPath(path string) bool {
 // require it. These endpoints work with or without a user in context.
 func isSoftAuthPath(path string) bool {
 	return path == "/api/auth/me"
+}
+
+// extractAPIKey extracts a raw API key from the request.
+// Tries Authorization: Bearer first, then X-Api-Key header.
+func extractAPIKey(r *http.Request) string {
+	if v := r.Header.Get("Authorization"); strings.HasPrefix(v, "Bearer ") {
+		return strings.TrimPrefix(v, "Bearer ")
+	}
+	return r.Header.Get("X-Api-Key")
 }
 
 // AuditLog logs a write operation with user identity

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -102,6 +102,17 @@ func registerTools(server *mcp.Server) {
 	}, logToolCall("list_namespaces", handleListNamespaces))
 
 	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_contexts",
+		Description: "List all available kubeconfig contexts. Shows which context is currently active. Use before switch_context to discover valid context names.",
+		Annotations: readOnly,
+	}, logToolCall("list_contexts", handleListContexts))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "switch_context",
+		Description: "Switch the active Kubernetes context. All subsequent tool calls will target the new cluster. Use list_contexts first to see available context names.",
+	}, logToolCall("switch_context", handleSwitchContext))
+
+	mcp.AddTool(server, &mcp.Tool{
 		Name: "get_changes",
 		Description: "Get recent resource changes (creates, updates, deletes) from the cluster timeline. " +
 			"Use to investigate what changed before an incident. " +

--- a/internal/mcp/tools_context.go
+++ b/internal/mcp/tools_context.go
@@ -12,7 +12,7 @@ import (
 type listContextsInput struct{}
 
 type switchContextInput struct {
-	Name string `json:"name" jsonschema:"description=kubeconfig context name to switch to"`
+	Name string `json:"name" jsonschema:"kubeconfig context name to switch to"`
 }
 
 func handleListContexts(ctx context.Context, req *mcp.CallToolRequest, _ listContextsInput) (*mcp.CallToolResult, any, error) {

--- a/internal/mcp/tools_context.go
+++ b/internal/mcp/tools_context.go
@@ -1,0 +1,51 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+)
+
+type listContextsInput struct{}
+
+type switchContextInput struct {
+	Name string `json:"name" jsonschema:"description=kubeconfig context name to switch to"`
+}
+
+func handleListContexts(ctx context.Context, req *mcp.CallToolRequest, _ listContextsInput) (*mcp.CallToolResult, any, error) {
+	contexts, err := k8s.GetAvailableContexts()
+	if err != nil {
+		return nil, nil, err
+	}
+	return toJSONResult(contexts)
+}
+
+func handleSwitchContext(ctx context.Context, req *mcp.CallToolRequest, input switchContextInput) (*mcp.CallToolResult, any, error) {
+	if input.Name == "" {
+		return nil, nil, fmt.Errorf("context name is required")
+	}
+	if k8s.IsInCluster() {
+		return nil, nil, fmt.Errorf("cannot switch context when running in-cluster")
+	}
+	if err := k8s.PerformContextSwitch(input.Name); err != nil {
+		k8s.SetConnectionStatus(k8s.ConnectionStatus{
+			State:   k8s.StateDisconnected,
+			Context: input.Name,
+			Error:   err.Error(),
+		})
+		return nil, nil, err
+	}
+	k8s.SetConnectionStatus(k8s.ConnectionStatus{
+		State:       k8s.StateConnected,
+		Context:     k8s.GetContextName(),
+		ClusterName: k8s.GetClusterName(),
+	})
+	return toJSONResult(map[string]string{
+		"status":  "ok",
+		"context": k8s.GetContextName(),
+		"cluster": k8s.GetClusterName(),
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -186,7 +186,7 @@ func (s *Server) setupRoutes() {
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   []string{"http://localhost:*", "http://127.0.0.1:*"},
 		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
-		AllowedHeaders:   []string{"Accept", "Content-Type"},
+		AllowedHeaders:   []string{"Accept", "Content-Type", "Authorization", "X-Api-Key"},
 		AllowCredentials: true,
 	}))
 
@@ -249,6 +249,9 @@ func (s *Server) setupRoutes() {
 			r.Get("/health", s.handleHealth)
 			r.Get("/diagnostics", s.handleDiagnostics)
 			r.Get("/auth/me", s.handleAuthMe)
+			r.Get("/auth/api-keys", auth.HandleListAPIKeys(s.authConfig))
+			r.Post("/auth/api-keys", auth.HandleCreateAPIKey(s.authConfig))
+			r.Delete("/auth/api-keys/{id}", auth.HandleDeleteAPIKey(s.authConfig))
 			r.Get("/version-check", s.handleVersionCheck)
 			r.Get("/dashboard", s.handleDashboard)
 			r.Get("/dashboard/crds", s.handleDashboardCRDs)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -141,9 +141,22 @@ func New(cfg Config) *Server {
 			if s.authConfig.OIDCRedirectURL == "" {
 				log.Fatalf("[auth] --auth-oidc-redirect-url is required when auth-mode=oidc")
 			}
-			oidcHandler, err := auth.NewOIDCHandler(context.Background(), s.authConfig)
-			if err != nil {
-				log.Fatalf("[auth] OIDC initialization failed (issuer=%s): %v — cannot start with auth-mode=oidc", s.authConfig.OIDCIssuer, err)
+			var (
+				oidcHandler *auth.OIDCHandler
+				oidcErr     error
+			)
+			for attempt := 1; attempt <= 5; attempt++ {
+				oidcHandler, oidcErr = auth.NewOIDCHandler(context.Background(), s.authConfig)
+				if oidcErr == nil {
+					break
+				}
+				if attempt < 5 {
+					log.Printf("[auth] OIDC discovery failed (attempt %d/5, issuer=%s): %v — retrying in 5s", attempt, s.authConfig.OIDCIssuer, oidcErr)
+					time.Sleep(5 * time.Second)
+				}
+			}
+			if oidcErr != nil {
+				log.Fatalf("[auth] OIDC initialization failed after 5 attempts (issuer=%s): %v — cannot start with auth-mode=oidc", s.authConfig.OIDCIssuer, oidcErr)
 			}
 
 			// Wire up backchannel logout revocation store

--- a/pkg/auth/apikeys.go
+++ b/pkg/auth/apikeys.go
@@ -1,0 +1,250 @@
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// APIKey is a stored API key entry. The plaintext is never persisted —
+// only the SHA-256 hash. The plaintext is returned exactly once at creation.
+type APIKey struct {
+	ID          string
+	Description string
+	Hash        string // hex(sha256(plaintext)) — never exposed via API
+	Username    string
+	Groups      []string
+	CreatedAt   time.Time
+	LastUsedAt  *time.Time
+}
+
+// APIKeyStore manages per-user API keys backed by SQLite.
+// All methods are safe for concurrent use.
+type APIKeyStore struct {
+	db   *sql.DB
+	mu   sync.Mutex // serialises writes (SQLite allows one writer)
+	path string
+}
+
+// NewAPIKeyStore opens or creates the SQLite key store at path.
+func NewAPIKeyStore(path string) (*APIKeyStore, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("create api key store dir: %w", err)
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("open api key store: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	for _, pragma := range []string{
+		"PRAGMA journal_mode=WAL",
+		"PRAGMA synchronous=NORMAL",
+		"PRAGMA busy_timeout=5000",
+	} {
+		if _, err := db.Exec(pragma); err != nil {
+			log.Printf("[auth] api key store pragma warning: %v", err)
+		}
+	}
+
+	if _, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS api_keys (
+			id          TEXT PRIMARY KEY,
+			description TEXT NOT NULL DEFAULT '',
+			hash        TEXT NOT NULL,
+			username    TEXT NOT NULL,
+			groups      TEXT NOT NULL DEFAULT '',
+			created_at  DATETIME NOT NULL,
+			last_used_at DATETIME
+		)
+	`); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("create api_keys table: %w", err)
+	}
+
+	return &APIKeyStore{db: db, path: path}, nil
+}
+
+// Close releases the SQLite connection.
+func (s *APIKeyStore) Close() error {
+	return s.db.Close()
+}
+
+func hashKey(plaintext string) string {
+	sum := sha256.Sum256([]byte(plaintext))
+	return hex.EncodeToString(sum[:])
+}
+
+func randHex(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// Lookup finds the key matching plaintext. Returns nil if not found.
+// Updates last_used_at asynchronously on a hit.
+func (s *APIKeyStore) Lookup(plaintext string) *APIKey {
+	want := hashKey(plaintext)
+
+	rows, err := s.db.Query(`SELECT id, description, hash, username, groups, created_at, last_used_at FROM api_keys`)
+	if err != nil {
+		log.Printf("[auth] api key lookup error: %v", err)
+		return nil
+	}
+	defer rows.Close()
+
+	var found *APIKey
+	for rows.Next() {
+		k, err := scanKey(rows)
+		if err != nil {
+			continue
+		}
+		if subtle.ConstantTimeCompare([]byte(k.Hash), []byte(want)) == 1 {
+			found = k
+			break
+		}
+	}
+	if found == nil {
+		return nil
+	}
+
+	go func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		now := time.Now().UTC()
+		if _, err := s.db.Exec(`UPDATE api_keys SET last_used_at=? WHERE id=?`, now, found.ID); err != nil {
+			log.Printf("[auth] api key update last_used_at: %v", err)
+		}
+	}()
+	return found
+}
+
+// Create generates a new API key for username/groups.
+// Returns the stored entry and the plaintext key (returned exactly once).
+func (s *APIKeyStore) Create(username string, groups []string, description string) (*APIKey, string, error) {
+	plaintext, err := randHex(32)
+	if err != nil {
+		return nil, "", fmt.Errorf("generate key: %w", err)
+	}
+	id, err := randHex(16)
+	if err != nil {
+		return nil, "", fmt.Errorf("generate key id: %w", err)
+	}
+	key := &APIKey{
+		ID:          "rk_" + id,
+		Description: description,
+		Hash:        hashKey(plaintext),
+		Username:    username,
+		Groups:      groups,
+		CreatedAt:   time.Now().UTC(),
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, err = s.db.Exec(
+		`INSERT INTO api_keys (id, description, hash, username, groups, created_at) VALUES (?,?,?,?,?,?)`,
+		key.ID, key.Description, key.Hash, key.Username, encodeGroups(key.Groups), key.CreatedAt,
+	)
+	if err != nil {
+		return nil, "", fmt.Errorf("insert api key: %w", err)
+	}
+	return key, plaintext, nil
+}
+
+// ListForUser returns all keys belonging to username (hash is never included).
+func (s *APIKeyStore) ListForUser(username string) []*APIKey {
+	rows, err := s.db.Query(
+		`SELECT id, description, hash, username, groups, created_at, last_used_at FROM api_keys WHERE username=? ORDER BY created_at DESC`,
+		username,
+	)
+	if err != nil {
+		log.Printf("[auth] api key list error: %v", err)
+		return nil
+	}
+	defer rows.Close()
+
+	var out []*APIKey
+	for rows.Next() {
+		k, err := scanKey(rows)
+		if err != nil {
+			continue
+		}
+		k.Hash = "" // never expose hash
+		out = append(out, k)
+	}
+	return out
+}
+
+// Delete removes the key with id belonging to username.
+// Returns false if not found or owned by a different user.
+func (s *APIKeyStore) Delete(id, username string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	res, err := s.db.Exec(`DELETE FROM api_keys WHERE id=? AND username=?`, id, username)
+	if err != nil {
+		log.Printf("[auth] api key delete error: %v", err)
+		return false
+	}
+	n, _ := res.RowsAffected()
+	return n > 0
+}
+
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+func scanKey(s scanner) (*APIKey, error) {
+	var k APIKey
+	var groups string
+	var lastUsed sql.NullTime
+	if err := s.Scan(&k.ID, &k.Description, &k.Hash, &k.Username, &groups, &k.CreatedAt, &lastUsed); err != nil {
+		return nil, err
+	}
+	k.Groups = decodeGroups(groups)
+	if lastUsed.Valid {
+		k.LastUsedAt = &lastUsed.Time
+	}
+	return &k, nil
+}
+
+// Groups are stored as comma-separated string in SQLite.
+func encodeGroups(groups []string) string {
+	result := ""
+	for i, g := range groups {
+		if i > 0 {
+			result += ","
+		}
+		result += g
+	}
+	return result
+}
+
+func decodeGroups(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var out []string
+	start := 0
+	for i := 0; i <= len(s); i++ {
+		if i == len(s) || s[i] == ',' {
+			if part := s[start:i]; part != "" {
+				out = append(out, part)
+			}
+			start = i + 1
+		}
+	}
+	return out
+}

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -24,6 +24,10 @@ type Config struct {
 	// Session revocation (optional, used by backchannel logout)
 	Revoker SessionRevoker
 
+	// APIKeys enables per-user API key authentication when non-nil.
+	// Keys are matched after session cookies but before proxy headers.
+	APIKeys *APIKeyStore
+
 	// OIDC mode
 	OIDCIssuer       string
 	OIDCClientID     string

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { createPortal } from 'react-dom'
-import { Settings, X, RotateCcw, Loader2, Copy, Check, Pin } from 'lucide-react'
+import { Settings, X, RotateCcw, Loader2, Copy, Check, Pin, KeyRound, Trash2, Plus } from 'lucide-react'
 import { clsx } from 'clsx'
 import { useAnimatedUnmount } from '../../hooks/useAnimatedUnmount'
 import { TRANSITION_BACKDROP, TRANSITION_PANEL } from '../../utils/animation'
 import { apiUrl, getAuthHeaders, getCredentialsMode } from '../../api/config'
+import { useAuthMe } from '../../api/client'
 
 interface Config {
   kubeconfig?: string
@@ -33,6 +34,7 @@ interface SettingsDialogProps {
 export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
   const dialogRef = useRef<HTMLDivElement>(null)
   const { shouldRender, isOpen } = useAnimatedUnmount(open, 200)
+  const { data: authMe } = useAuthMe()
   const [configData, setConfigData] = useState<ConfigResponse | null>(null)
   const [editedConfig, setEditedConfig] = useState<Config>({})
   const [saving, setSaving] = useState(false)
@@ -173,6 +175,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
             isDesktop={isDesktop}
             onChange={updateConfigField}
           />
+          {authMe?.authEnabled && <APIKeysSection open={open} />}
         </div>
 
         {/* Footer */}
@@ -411,6 +414,208 @@ function MCPSection({
               Port is pinned. MCP endpoint will remain stable across restarts.
             </p>
           )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// -- API Keys Section ---------------------------------------------------------
+
+interface APIKeyEntry {
+  id: string
+  description: string
+  username: string
+  groups: string[]
+  createdAt: string
+  lastUsedAt?: string
+}
+
+function APIKeysSection({ open }: { open: boolean }) {
+  const [keys, setKeys] = useState<APIKeyEntry[]>([])
+  const [loading, setLoading] = useState(false)
+  const [description, setDescription] = useState('')
+  const [creating, setCreating] = useState(false)
+  const [newKey, setNewKey] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+  const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const loadKeys = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch(apiUrl('/auth/api-keys'), {
+        credentials: getCredentialsMode(),
+        headers: getAuthHeaders(),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      setKeys(await res.json())
+    } catch (e) {
+      setError('Failed to load API keys.')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (open) loadKeys()
+  }, [open, loadKeys])
+
+  const handleCreate = async () => {
+    if (creating) return
+    setCreating(true)
+    setError(null)
+    setNewKey(null)
+    try {
+      const res = await fetch(apiUrl('/auth/api-keys'), {
+        method: 'POST',
+        credentials: getCredentialsMode(),
+        headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+        body: JSON.stringify({ description }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`)
+      setNewKey(data.key)
+      setDescription('')
+      setKeys((prev) => [data, ...prev])
+    } catch (e: any) {
+      setError(e.message || 'Failed to create API key.')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    if (deleteConfirm !== id) {
+      setDeleteConfirm(id)
+      return
+    }
+    setDeleteConfirm(null)
+    setError(null)
+    try {
+      const res = await fetch(apiUrl(`/auth/api-keys/${id}`), {
+        method: 'DELETE',
+        credentials: getCredentialsMode(),
+        headers: getAuthHeaders(),
+      })
+      if (!res.ok && res.status !== 204) throw new Error(`HTTP ${res.status}`)
+      setKeys((prev) => prev.filter((k) => k.id !== id))
+    } catch {
+      setError('Failed to revoke key.')
+    }
+  }
+
+  const handleCopy = () => {
+    if (!newKey) return
+    navigator.clipboard.writeText(newKey)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className="border-t border-theme-border pt-4 mt-4">
+      <div className="flex items-center gap-2 mb-3">
+        <KeyRound className="w-3.5 h-3.5 text-theme-text-secondary" />
+        <h4 className="text-xs font-medium text-theme-text-secondary uppercase tracking-wider">
+          API Keys
+        </h4>
+      </div>
+
+      <p className="text-xs text-theme-text-tertiary mb-3">
+        API keys let headless clients (MCP, CI, scripts) authenticate without a browser login.
+        Each key inherits your current permissions.
+      </p>
+
+      {error && (
+        <div className="mb-3 px-3 py-2 text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-md">
+          {error}
+        </div>
+      )}
+
+      {/* Revealed key — shown once immediately after creation */}
+      {newKey && (
+        <div className="mb-3 p-3 bg-green-500/10 border border-green-500/30 rounded-md space-y-1.5">
+          <p className="text-xs font-medium text-green-400">
+            Save this key now — it won't be shown again.
+          </p>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 px-2 py-1 text-xs font-mono bg-theme-elevated border border-theme-border rounded text-theme-text-primary break-all">
+              {newKey}
+            </code>
+            <button
+              onClick={handleCopy}
+              className="shrink-0 p-1.5 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-elevated rounded-md transition-colors"
+              title="Copy key"
+            >
+              {copied ? <Check className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5" />}
+            </button>
+          </div>
+          <p className="text-xs text-theme-text-tertiary">
+            Use as: <code className="font-mono">Authorization: Bearer {newKey.slice(0, 8)}…</code>
+          </p>
+        </div>
+      )}
+
+      {/* Create new key */}
+      <div className="flex gap-2 mb-3">
+        <input
+          type="text"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && description && handleCreate()}
+          placeholder="Key description (e.g. MCP tool, CI pipeline)"
+          className="flex-1 px-3 py-1.5 text-sm bg-theme-elevated border border-theme-border rounded-md text-theme-text-primary placeholder:text-theme-text-tertiary focus:outline-none focus:border-blue-500"
+        />
+        <button
+          onClick={handleCreate}
+          disabled={!description || creating}
+          className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium btn-brand rounded-md disabled:opacity-50"
+        >
+          {creating ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Plus className="w-3.5 h-3.5" />}
+          Create
+        </button>
+      </div>
+
+      {/* Key list */}
+      {loading ? (
+        <div className="flex items-center gap-2 text-xs text-theme-text-tertiary py-2">
+          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          Loading keys…
+        </div>
+      ) : keys.length === 0 ? (
+        <p className="text-xs text-theme-text-tertiary py-1">No API keys yet.</p>
+      ) : (
+        <div className="space-y-1.5">
+          {keys.map((key) => (
+            <div
+              key={key.id}
+              className="flex items-center justify-between gap-2 px-3 py-2 bg-theme-elevated border border-theme-border rounded-md"
+            >
+              <div className="min-w-0">
+                <p className="text-sm text-theme-text-primary truncate">
+                  {key.description || <span className="text-theme-text-tertiary italic">no description</span>}
+                </p>
+                <p className="text-xs text-theme-text-tertiary">
+                  {key.id} · created {new Date(key.createdAt).toLocaleDateString()}
+                  {key.lastUsedAt && ` · last used ${new Date(key.lastUsedAt).toLocaleDateString()}`}
+                </p>
+              </div>
+              <button
+                onClick={() => handleDelete(key.id)}
+                className={clsx(
+                  'shrink-0 flex items-center gap-1 px-2 py-1 text-xs rounded-md transition-colors',
+                  deleteConfirm === key.id
+                    ? 'bg-red-500/20 text-red-400 hover:bg-red-500/30'
+                    : 'text-theme-text-tertiary hover:text-red-400 hover:bg-theme-elevated'
+                )}
+                title={deleteConfirm === key.id ? 'Click again to confirm revoke' : 'Revoke key'}
+              >
+                <Trash2 className="w-3 h-3" />
+                {deleteConfirm === key.id ? 'Confirm' : 'Revoke'}
+              </button>
+            </div>
+          ))}
         </div>
       )}
     </div>


### PR DESCRIPTION
Closes #733

## Summary

- Adds \`APIKeyStore\` backed by SQLite (\`pkg/auth/apikeys.go\`) — stores \`hex(sha256(plaintext))\` only, plaintext returned once at creation
- Inserts API key check in \`Authenticate\` middleware between cookie and proxy-header blocks (stateless, no session cookie set)
- Three new endpoints: \`GET/POST /api/auth/api-keys\`, \`DELETE /api/auth/api-keys/{id}\`
- Settings UI section to create, list, and revoke keys (only shown when auth is enabled)
- New flag: \`--auth-api-keys-file\` (default \`~/.config/radar/api-keys.db\`)
- Adds \`list_contexts\` and \`switch_context\` MCP tools so AI agents can discover and switch between kubeconfig contexts without leaving the MCP session
- Retries OIDC discovery up to 5× (5 s backoff) before fataling — tolerates transient IdP 500s at startup

## Test plan

- [ ] \`go test ./internal/auth/...\` passes
- [ ] \`cd web && npm run tsc\` passes
- [ ] With \`--auth-mode=oidc\`: log in via browser, open Settings → API Keys, create a key, copy plaintext
- [ ] \`curl -H "Authorization: Bearer <key>" /api/dashboard\` → 200
- [ ] \`curl -H "X-Api-Key: <key>" /api/dashboard\` → 200
- [ ] Wrong key → 401
- [ ] Revoke key in UI → subsequent requests with that key → 401
- [ ] \`GET /api/auth/api-keys\` shows remaining keys, no hash/plaintext exposed
- [ ] MCP \`list_contexts\` returns all kubeconfig contexts
- [ ] MCP \`switch_context\` switches active cluster; subsequent MCP calls reflect the new cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)