### PR TITLE
fix(home): scope topology preview legend by ns + count restricted ns (#655)

### DIFF
--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -446,6 +446,9 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 			nss, _ := nsLister.List(labels.Everything())
 			resp.ResourceCounts.Namespaces = len(nss)
 		}
+	} else if len(namespaces) > 0 {
+		// Restricted user — surface their accessible count instead of "0".
+		resp.ResourceCounts.Namespaces = len(namespaces)
 	}
 
 	if canReadNodes && cache.Nodes() != nil {

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { useDashboard, useDashboardCRDs, useDashboardHelm } from '../../api/client'
 import type { DashboardResponse } from '../../api/client'
 import type { ExtendedMainView, Topology, SelectedResource } from '../../types'
@@ -25,6 +26,21 @@ interface HomeViewProps {
 
 export function HomeView({ namespaces, topology, onNavigateToView, onNavigateToResourceKind, onNavigateToResource }: HomeViewProps) {
   const { data, isLoading, error } = useDashboard(namespaces)
+
+  // SSE is cluster-wide on small/medium clusters; the picker only narrows the
+  // dashboard summary, so re-apply the filter here or the legend disagrees.
+  const scopedTopology = useMemo<Topology | null>(() => {
+    if (!topology) return null
+    if (namespaces.length === 0) return topology
+    const nsSet = new Set(namespaces)
+    const nodes = topology.nodes.filter(n => {
+      const ns = n.data.namespace as string | undefined
+      return !ns || nsSet.has(ns)
+    })
+    const nodeIds = new Set(nodes.map(n => n.id))
+    const edges = topology.edges.filter(e => nodeIds.has(e.source) && nodeIds.has(e.target))
+    return { nodes, edges }
+  }, [topology, namespaces])
   // CRDs and Helm load lazily after main dashboard to keep initial load fast
   const { data: crdsData } = useDashboardCRDs(namespaces)
   const { data: helmData } = useDashboardHelm(namespaces)
@@ -100,7 +116,7 @@ export function HomeView({ namespaces, topology, onNavigateToView, onNavigateToR
             {/* Primary cards — 2-col grid */}
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
               <TopologyPreview
-                topology={topology}
+                topology={scopedTopology}
                 summary={data.topologySummary}
                 onNavigate={() => onNavigateToView('topology')}
               />
@@ -110,7 +126,7 @@ export function HomeView({ namespaces, topology, onNavigateToView, onNavigateToR
               />
               <ActivitySummary
                 namespaces={namespaces}
-                topology={topology}
+                topology={scopedTopology}
                 onNavigate={() => onNavigateToView('timeline')}
               />
               <TrafficSummary


### PR DESCRIPTION
## Summary

Two of the three follow-ups from [#655](https://github.com/skyhook-io/radar/issues/655) (per-user RBAC visual-test pass on #609). Item #2 from that issue is intentionally left out — it's a product call, not a clear fix.

### 1. Home topology preview: legend stayed cluster-wide when a namespace was picked

The SSE topology stream is cluster-wide for small/medium clusters; only the dashboard `summary` (the "X resources · Y conn" header) is namespace-filtered server-side. So picking a namespace updated the header but left the kind legend reflecting cluster-wide totals.

Verified end-to-end on `prod-cluster-us-east1` with the `autopush` namespace selected:

| | Header | Legend |
|---|---|---|
| **Pre-fix** | 4 resources · 2 conn | 65 Deployment · 37 DaemonSet · 5 StatefulSet · 70 Service · 16 Ingress · 1 Gateway · 8 HTTPRoute · 133 Pod … (cluster-wide) |
| **Post-fix** | 4 resources · 2 conn | 1 Deployment · 1 Pod · 1 ConfigMap · 1 GatewayClass (matches header) |

Fix: a `scopedTopology` memo in `HomeView` filters the topology to the active namespace set on the client (cluster-scoped nodes pass through, dangling edges dropped) before passing it to `TopologyPreview` and `ActivitySummary`. No-op on large clusters (≥1000 nodes) where `forceNamespaceFilter` already filters SSE server-side.

### 2. Cluster info card: "0 namespaces" for restricted users

`dashboard.go` only populated `ResourceCounts.Namespaces` when the user could `list namespaces` cluster-wide. For users restricted to N specific namespaces (no cluster-wide SAR), the count stayed at `0` — misleading. Fall back to `len(allowedNamespaces)`, mirroring the same pattern already in `resource_counts.go`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to dashboard display logic (client-side topology filtering) and a small server-side fallback for namespace counts, with no auth or data-write behavior modified.
> 
> **Overview**
> Fixes mismatches on the Home dashboard when a namespace filter is active by **client-filtering the SSE topology** before rendering, so `TopologyPreview` and `ActivitySummary` legends/edges align with the namespace-scoped summary.
> 
> Also corrects the cluster info/resource counts for RBAC-restricted users by **reporting the number of accessible namespaces** when the user cannot `list namespaces` cluster-wide (instead of showing `0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2056fb0210fa5d716bda80557b84c4671b21fcd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->