### PR TITLE
chore(deps): add 7-day cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: weekly
     commit-message:
       prefix: "deps(go):"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
     groups:
       k8s:
         patterns:
@@ -21,6 +24,9 @@ updates:
       interval: weekly
     commit-message:
       prefix: "deps(npm):"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
 
   - package-ecosystem: github-actions
     directory: /
@@ -28,3 +34,6 @@ updates:
       interval: weekly
     commit-message:
       prefix: "deps(actions):"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14


### PR DESCRIPTION
## Summary

Adds a `cooldown` block to each ecosystem in `.github/dependabot.yml` so Dependabot waits before opening a PR for a freshly published version:

- **7 days** default (any update)
- **14 days** for major version bumps

This reduces our exposure to short-lived malicious releases — the typical pattern with the recent npm supply-chain incidents (chalk/debug, eslint-config-prettier, etc.) was that compromised versions were yanked within 24–72h. A week of latency catches almost all of them without meaningfully slowing down dependency hygiene.

Applies to all three ecosystems in this repo (`gomod`, `npm`, `github-actions`).

## Notes

- GHSA-flagged security advisories still raise PRs immediately — cooldown is bypassed for known CVEs, which is what we want.
- Cooldown is a native Dependabot feature (GA in 2025); no extra tooling required.
- Doesn't replace lockfile / `go.sum` review on update PRs — transitive deps can still arrive in the window.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Dependabot configuration to delay update PR creation, with no runtime or application code changes.
> 
> **Overview**
> Adds a `cooldown` policy to `.github/dependabot.yml` for `gomod`, `npm`, and `github-actions` updates, delaying Dependabot PRs by **7 days by default** and **14 days for semver-major bumps**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2d271488269f97e73781275a7c8840122bbe8ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->