### PR TITLE
fix(helm): use yaml.stringify for Values viewer + cluster fix

### DIFF
--- a/web/src/components/gitops/GitOpsView.tsx
+++ b/web/src/components/gitops/GitOpsView.tsx
@@ -685,7 +685,7 @@ function extractHelmValues(kind: string, resource: any): HelmValuesData | null {
 
 function safeStringifyYaml(value: unknown): string {
   try {
-    return yaml.stringify(value)
+    return yaml.stringify(value, { lineWidth: 0 })
   } catch {
     return JSON.stringify(value, null, 2)
   }

--- a/web/src/components/helm/InstallWizard.tsx
+++ b/web/src/components/helm/InstallWizard.tsx
@@ -106,11 +106,11 @@ export function InstallWizard({ repo, chartName, version, source, repoUrl, defau
       }
     }
     if (baseValues && defaultValues) {
-      setValuesYaml(yaml.stringify(deepMerge(baseValues, defaultValues)))
+      setValuesYaml(yaml.stringify(deepMerge(baseValues, defaultValues), { lineWidth: 0 }))
     } else if (defaultValues && !baseValues) {
-      setValuesYaml(yaml.stringify(defaultValues))
+      setValuesYaml(yaml.stringify(defaultValues, { lineWidth: 0 }))
     } else if (baseValues) {
-      setValuesYaml(yaml.stringify(baseValues))
+      setValuesYaml(yaml.stringify(baseValues, { lineWidth: 0 }))
     }
   }, [localChartDetail?.values, artifactHubDetail?.values, isLocal, defaultValues])
 
@@ -349,7 +349,7 @@ export function InstallWizard({ repo, chartName, version, source, repoUrl, defau
                   valuesYaml={valuesYaml}
                   defaultValuesYaml={
                     isLocal
-                      ? (localChartDetail?.values ? yaml.stringify(localChartDetail.values) : '')
+                      ? (localChartDetail?.values ? yaml.stringify(localChartDetail.values, { lineWidth: 0 }) : '')
                       : (artifactHubDetail?.values || '')
                   }
                 />
@@ -664,7 +664,7 @@ function ValuesStep({ valuesYaml, setValuesYaml, yamlError, setYamlError, chartD
   const ahDetail = chartDetail as ArtifactHubChartDetail | undefined
 
   const defaultValues = isLocal
-    ? (localDetail?.values ? yaml.stringify(localDetail.values) : '')
+    ? (localDetail?.values ? yaml.stringify(localDetail.values, { lineWidth: 0 }) : '')
     : (ahDetail?.values || '')
 
   const hasDefaults = Boolean(defaultValues)

--- a/web/src/components/helm/ValuesViewer.tsx
+++ b/web/src/components/helm/ValuesViewer.tsx
@@ -320,43 +320,7 @@ function ToggleButton({ showAll, onToggle, disabled }: { showAll: boolean; onTog
   )
 }
 
-// Simple JSON to YAML converter for display
-function jsonToYaml(obj: Record<string, unknown>, indent = 0): string {
-  const spaces = '  '.repeat(indent)
-  let result = ''
-
-  for (const [key, value] of Object.entries(obj)) {
-    if (value === null || value === undefined) {
-      result += `${spaces}${key}: null\n`
-    } else if (typeof value === 'object' && !Array.isArray(value)) {
-      result += `${spaces}${key}:\n`
-      result += jsonToYaml(value as Record<string, unknown>, indent + 1)
-    } else if (Array.isArray(value)) {
-      result += `${spaces}${key}:\n`
-      for (const item of value) {
-        if (typeof item === 'object' && item !== null) {
-          result += `${spaces}- \n`
-          const itemYaml = jsonToYaml(item as Record<string, unknown>, indent + 2)
-          result += itemYaml
-        } else {
-          result += `${spaces}- ${formatValue(item)}\n`
-        }
-      }
-    } else {
-      result += `${spaces}${key}: ${formatValue(value)}\n`
-    }
-  }
-
-  return result
-}
-
-function formatValue(value: unknown): string {
-  if (typeof value === 'string') {
-    // Quote strings that contain special characters
-    if (value.includes(':') || value.includes('#') || value.includes('\n') || value.startsWith(' ') || value.endsWith(' ')) {
-      return `"${value.replace(/"/g, '\\"')}"`
-    }
-    return value
-  }
-  return String(value)
+function jsonToYaml(obj: Record<string, unknown>): string {
+  if (!obj || Object.keys(obj).length === 0) return ''
+  return yaml.stringify(obj, { lineWidth: 0 })
 }


### PR DESCRIPTION
## Summary

The Helm release Values viewer used a hand-rolled JSON→YAML converter that emitted `-` on its own line for array-of-object items, then indented the object body by 2 extra levels. The result was broken rendering for any nested list-of-objects, e.g. Istio `VirtualService`:

```yaml
http:
  -
    route:
      -
        destination:
          host: …
```

instead of the canonical:

```yaml
http:
  - route:
      - destination:
          host: …
```

Replaces the custom serializer with `yaml.stringify` from the `yaml` v2 package — the same library Radar already uses for parsing, and the same approach Headlamp's Flux plugin takes. The only non-default option is `lineWidth: 0`, which disables line folding so long image tags / repo URLs / paths don't wrap mid-token.

While in the neighborhood, applied the same `{ lineWidth: 0 }` option to the other five `yaml.stringify` call sites in `InstallWizard.tsx` and the GitOps detail page's `safeStringifyYaml` helper, which all silently inherited the 80-col default and had the same latent wrap bug.

Net change: −38 / +4 lines (`ValuesViewer.tsx`) plus one option added at six other sites. No new imports.

## Test plan
- [x] `make tsc` passes
- [x] Helm > Values renders nested arrays correctly in `prometheus` chart (`scrape_configs`, `relabel_configs`)
- [x] Sanity-checked `yaml.stringify` output against the Istio VirtualService case from the bug report
- [ ] Spot-check Install Wizard initial state for a chart with long image tags (no mid-tag wrapping)
- [ ] Spot-check GitOps detail page for an Argo `Application` with Helm values (no line wrap)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that affects how Helm/GitOps values are serialized for display/defaults; main risk is minor formatting differences in rendered YAML.
> 
> **Overview**
> Fixes Helm values YAML rendering by replacing the hand-rolled JSON→YAML serializer in `ValuesViewer.tsx` with `yaml.stringify`, eliminating incorrect list-of-object formatting.
> 
> Also standardizes YAML output across the Helm install wizard and GitOps Helm-values display by passing `lineWidth: 0` to `yaml.stringify` (via `safeStringifyYaml` and related call sites) to prevent mid-token line folding/wrapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 649b0c1b75acbb85b7a24f80dcde8ed6cdefbb18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->