### PR TITLE
feature(helm): add pod labels to helm chart

### DIFF
--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -24,6 +24,9 @@ spec:
       {{- end }}
       labels:
         {{- include "radar.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/deploy/helm/radar/values.schema.json
+++ b/deploy/helm/radar/values.schema.json
@@ -103,6 +103,7 @@
       }
     },
     "podAnnotations": { "type": "object", "additionalProperties": { "type": "string" } },
+    "podLabels": { "type": "object", "additionalProperties": { "type": "string" } },
     "podSecurityContext": { "type": "object" },
     "securityContext": { "type": "object" },
     "service": {

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -131,6 +131,8 @@ rbac:
 
 podAnnotations: {}
 
+podLabels: {}
+
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65532


### PR DESCRIPTION
## Description

Updates the helm chart to allow the user to add their own "podLabels" the same way they can add their own "podAnnotations" to the radar pod.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

Describe the tests you ran to verify your changes.

- [ ] Tested locally with minikube/kind
- [x] Tested against a remote cluster
- [ ] Added/updated unit tests

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

## Related issues

Fixes #756

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Helm chart change that only affects Kubernetes manifest metadata rendering; main risk is user-supplied `podLabels` unintentionally overriding/altering selector-related labels if misused.
> 
> **Overview**
> Adds a new Helm value, `podLabels`, and renders it into the Deployment pod template `metadata.labels` (similar to existing `podAnnotations`).
> 
> Updates `values.yaml` defaults and `values.schema.json` so `podLabels` is supported and schema-validated as a string map.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e0f57a47b2e576e61972f73289b1bae5ec3640f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->