### PR TITLE
Cross-cluster compare hooks + search dedup + splash polish

### DIFF
--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -327,6 +327,32 @@ func Search(ctx context.Context, p Provider, q Query, opts Options) (Result, err
 		}
 	}
 
+	// Dedup before sorting. A resource can land in the pending slice
+	// twice when it's reachable via both the typed loop (Deployment,
+	// Pod, …) and the dynamic loop (an integration registered
+	// Deployment/Pod as a watched GVR — e.g. a controller indexing
+	// built-in workloads as dynamic resources). Without dedup the table
+	// shows visible doubles. Keep the highest-scoring instance so the
+	// typed-path match (which usually has richer per-kind scoring) wins
+	// ties.
+	if len(pending) > 1 {
+		type hitKey struct{ kind, group, ns, name string }
+		seen := make(map[hitKey]int, len(pending))
+		out := pending[:0]
+		for _, p := range pending {
+			k := hitKey{p.hit.Kind, p.hit.Group, p.hit.Namespace, p.hit.Name}
+			if idx, ok := seen[k]; ok {
+				if p.hit.Score > out[idx].hit.Score {
+					out[idx] = p
+				}
+				continue
+			}
+			seen[k] = len(out)
+			out = append(out, p)
+		}
+		pending = out
+	}
+
 	sort.SliceStable(pending, func(i, j int) bool {
 		if pending[i].hit.Score != pending[j].hit.Score {
 			return pending[i].hit.Score > pending[j].hit.Score

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -155,11 +155,10 @@ func TestSearch_DefaultSkipsEvents(t *testing.T) {
 
 func TestSearch_DedupsResourceIndexedTwice(t *testing.T) {
 	// A Deployment that's also registered as a watched dynamic GVR (e.g.
-	// by a controller indexing built-in workloads as CRDs) used to surface
-	// in both the typed loop and the dynamic loop, producing visible
-	// duplicate rows in the UI. We dedup by (kind, group, ns, name) at
-	// the end so each resource appears at most once regardless of how
-	// many indexing paths reached it.
+	// by a controller indexing built-in workloads as CRDs) would surface
+	// in both the typed loop and the dynamic loop. Dedup by
+	// (kind, group, ns, name) keeps a single hit regardless of how many
+	// indexing paths reached the resource.
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 	u := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "apps/v1",

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -119,9 +120,11 @@ func TestSearch_ImageMatch(t *testing.T) {
 }
 
 func TestSearch_LimitTruncates(t *testing.T) {
+	// Unique names per pod — dedup-by-(kind,group,ns,name) collapses
+	// identical entries, so a limit-truncation test needs distinct inputs.
 	pods := make([]runtime.Object, 0, 100)
 	for i := 0; i < 100; i++ {
-		pods = append(pods, newPod("ns", "pod-with-redis", "redis:6.2", nil))
+		pods = append(pods, newPod("ns", fmt.Sprintf("pod-with-redis-%03d", i), "redis:6.2", nil))
 	}
 	p := &fakeProvider{typed: map[string][]runtime.Object{"pods": pods}}
 	res, _ := Search(context.Background(), p, Parse("redis"), Options{Limit: 10, Include: IncludeNone})
@@ -147,6 +150,38 @@ func TestSearch_DefaultSkipsEvents(t *testing.T) {
 	res, _ = Search(context.Background(), p, Parse("kind:Event redis"), Options{Include: IncludeNone})
 	if len(res.Hits) != 1 {
 		t.Fatalf("kind:Event should opt in, got %+v", res.Hits)
+	}
+}
+
+func TestSearch_DedupsResourceIndexedTwice(t *testing.T) {
+	// A Deployment that's also registered as a watched dynamic GVR (e.g.
+	// by a controller indexing built-in workloads as CRDs) used to surface
+	// in both the typed loop and the dynamic loop, producing visible
+	// duplicate rows in the UI. We dedup by (kind, group, ns, name) at
+	// the end so each resource appears at most once regardless of how
+	// many indexing paths reached it.
+	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]any{
+			"name":      "coredns",
+			"namespace": "kube-system",
+		},
+	}}
+	p := &fakeProvider{
+		typed: map[string][]runtime.Object{
+			"deployments": {newDeploy("kube-system", "coredns", "coredns:1.10", nil)},
+		},
+		dynamic: map[schema.GroupVersionResource][]*unstructured.Unstructured{gvr: {u}},
+		kinds:   map[schema.GroupVersionResource]string{gvr: "Deployment"},
+	}
+	res, _ := Search(context.Background(), p, Parse("coredns"), Options{Include: IncludeNone})
+	if len(res.Hits) != 1 {
+		t.Fatalf("expected 1 hit after dedup, got %d: %+v", len(res.Hits), res.Hits)
+	}
+	if res.Hits[0].Name != "coredns" || res.Hits[0].Kind != "Deployment" {
+		t.Fatalf("unexpected hit: %+v", res.Hits[0])
 	}
 }
 

--- a/packages/k8s-ui/src/components/compare/ResourceCompareView.tsx
+++ b/packages/k8s-ui/src/components/compare/ResourceCompareView.tsx
@@ -133,17 +133,13 @@ export function ResourceCompareView({
   const bError = errors?.find(e => e.side === 'b')?.message
   const anyError = !!(aError || bError)
 
-  // First-settle gate. The cold-start splash should NOT reappear when the
-  // user re-picks one side after the editor has mounted — once both sides
-  // have produced data or an error at least once, we mark the editor as
-  // "settled" and from then on Monaco re-renders in place even if a side's
-  // query data briefly clears during a re-fetch. Without this, the entire
-  // diff view flashed back to the loader on every pencil click.
-  //
-  // The settle ref is keyed on the A/B identity so that navigating to a
-  // different pair (e.g. /compare?a=X&b=Y → /compare?a=Z&b=W on the same
-  // route) re-triggers the loader instead of flashing a blank diff while
-  // the new fetches are in flight.
+  // Settle gate, keyed on the rendered A/B identity. Mount the diff
+  // editor only after both sides have first settled (data or error) for
+  // the current pair. Once settled, Monaco stays mounted across re-picks
+  // — clearing a side's data transiently during a refetch must not
+  // blank the editor. When the A/B identity changes (navigating to a
+  // new pair on the same route), the latch resets so the loader shows
+  // again until the new fetches settle.
   const settleKey = `${a.kind}|${a.namespace}|${a.name}|${a.group ?? ''}|${aSubtitle ?? ''}` +
     `|${b.kind}|${b.namespace}|${b.name}|${b.group ?? ''}|${bSubtitle ?? ''}`
   const settleKeyRef = useRef(settleKey)
@@ -225,16 +221,6 @@ export function ResourceCompareView({
       )}
 
       <div className={clsx('flex-1 min-h-0', bleed ? '' : 'p-3')}>
-        {/*
-          Defer mounting the diff editor until BOTH sides have settled
-          (data or per-side error) on FIRST load. Mounting Monaco when
-          only one side has data flashes a second loading state — its own
-          internal "Loading…" placeholder — before re-rendering with the
-          full diff. After the initial settle (tracked via hasSettledRef
-          above), Monaco stays mounted even when a side's query data
-          briefly clears during a pencil re-pick — re-rendering in place
-          rather than blanking the whole diff.
-        */}
         {showInitialLoader ? (
           <PaneLoader label="Loading resources…" className="h-full" />
         ) : (

--- a/packages/k8s-ui/src/components/compare/ResourceCompareView.tsx
+++ b/packages/k8s-ui/src/components/compare/ResourceCompareView.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import { clsx } from 'clsx'
 import { ArrowLeftRight, GitCompare, Rows, FileText, FileCode2, X, Pencil, AlertTriangle, Sparkles } from 'lucide-react'
 import { YamlDiffEditor } from '../ui/YamlEditor'
+import { PaneLoader } from '../ui/PaneLoader'
 import { Tooltip } from '../ui/Tooltip'
 import { pluralToKind } from '../../utils/navigation'
 import { toComparableYaml } from './normalize'
@@ -38,6 +39,20 @@ export interface ResourceCompareViewProps {
   /** Optional — when provided, the resource pill shows a pencil button to re-pick. */
   onChangeA?: () => void
   onChangeB?: () => void
+  /**
+   * Optional small label rendered after the resource name in each pill.
+   * Used by cross-cluster compare to surface the cluster identity for
+   * each side; single-cluster compare leaves these undefined.
+   */
+  aSubtitle?: string
+  bSubtitle?: string
+  /**
+   * When true, the diff editor area drops its padding + rounded border.
+   * Use when the host renders compare as a full-bleed page (the diff IS
+   * the page). Default false preserves the inset-card look that works
+   * inside OSS Radar's narrower compare route.
+   */
+  bleed?: boolean
 }
 
 function ResourcePill({
@@ -45,11 +60,13 @@ function ResourcePill({
   side,
   error,
   onChange,
+  subtitle,
 }: {
   resource: CompareResourceRef
   side: CompareSide
   error?: string
   onChange?: () => void
+  subtitle?: string
 }) {
   const tones = SIDE_TONES[side]
   const errTone = 'border-red-400/50 bg-red-500/10'
@@ -70,6 +87,11 @@ function ResourcePill({
       <span className={clsx('truncate min-w-0', error ? 'text-red-300' : 'text-theme-text-primary')}>
         {resource.namespace && <span className="opacity-60">{resource.namespace}/</span>}
         {resource.name}
+        {subtitle && (
+          <span className="opacity-60 ml-1" aria-label={`Source: ${subtitle}`}>
+            · {subtitle}
+          </span>
+        )}
       </span>
       {onChange && (
         <Tooltip content="Pick a different resource">
@@ -90,14 +112,21 @@ export function ResourceCompareView({
   b,
   aData,
   bData,
-  aLoading,
-  bLoading,
+  // aLoading / bLoading remain in the props for host wiring stability,
+  // but the cold-start gate below derives loading purely from data
+  // presence — flashing Monaco when only one side has data was worse
+  // than a slightly delayed initial render. Per-side spinners after
+  // the editor mounts aren't needed: Monaco re-renders in place when
+  // a side's content swaps.
   errors,
   editorTheme = 'vs-dark',
   onSwap,
   onClose,
   onChangeA,
   onChangeB,
+  aSubtitle,
+  bSubtitle,
+  bleed = false,
 }: ResourceCompareViewProps) {
   const [specOnly, setSpecOnly] = useState(false)
   const [unified, setUnified] = useState(false)
@@ -125,7 +154,7 @@ export function ResourceCompareView({
         </h2>
 
         <div className="flex items-center gap-2 min-w-0 flex-1">
-          <ResourcePill resource={a} side="a" error={aError} onChange={onChangeA} />
+          <ResourcePill resource={a} side="a" error={aError} onChange={onChangeA} subtitle={aSubtitle} />
           <Tooltip content="Swap A and B">
             <button
               onClick={onSwap}
@@ -134,7 +163,7 @@ export function ResourceCompareView({
               <ArrowLeftRight className="w-3.5 h-3.5" />
             </button>
           </Tooltip>
-          <ResourcePill resource={b} side="b" error={bError} onChange={onChangeB} />
+          <ResourcePill resource={b} side="b" error={bError} onChange={onChangeB} subtitle={bSubtitle} />
         </div>
 
         <div className="flex items-center gap-1 shrink-0">
@@ -181,11 +210,21 @@ export function ResourceCompareView({
         </div>
       )}
 
-      <div className="flex-1 min-h-0 p-3">
-        {aLoading && bLoading ? (
-          <div className="flex items-center justify-center h-full text-theme-text-secondary text-sm">
-            Loading resources…
-          </div>
+      <div className={clsx('flex-1 min-h-0', bleed ? '' : 'p-3')}>
+        {/*
+          Defer mounting the diff editor until BOTH sides have settled
+          (data or per-side error). Mounting Monaco when only one side
+          has data flashes a second loading state — its own internal
+          "Loading…" placeholder — before re-rendering with the full
+          diff, producing the double-flash on cold start. With this
+          gate the user sees one consistent splash, then the full diff
+          appears in a single transition. After the initial settle,
+          re-picking one side stays per-side (the existing aLoading /
+          bLoading props flow into Monaco's input — Monaco itself just
+          re-renders without re-initializing).
+        */}
+        {(!aData && !aError) || (!bData && !bError) ? (
+          <PaneLoader label="Loading resources…" className="h-full" />
         ) : (
           <YamlDiffEditor
             original={aYaml}
@@ -194,6 +233,7 @@ export function ResourceCompareView({
             hideUnchanged={hideUnchanged && !identical}
             theme={editorTheme}
             height="100%"
+            bleed={bleed}
           />
         )}
       </div>

--- a/packages/k8s-ui/src/components/compare/ResourceCompareView.tsx
+++ b/packages/k8s-ui/src/components/compare/ResourceCompareView.tsx
@@ -27,9 +27,6 @@ export interface ResourceCompareViewProps {
   b: CompareResourceRef
   aData: unknown
   bData: unknown
-  /** Per-side loading — a ready side renders while the slow side spins. */
-  aLoading?: boolean
-  bLoading?: boolean
   /** Per-side fetch errors. Each side renders independently — a working side stays useful. */
   errors?: CompareSideError[]
   /** Caller-supplied theme passthrough for the Monaco editor. */
@@ -112,12 +109,6 @@ export function ResourceCompareView({
   b,
   aData,
   bData,
-  // aLoading / bLoading remain in the props for host wiring stability,
-  // but the cold-start gate below derives loading purely from data
-  // presence — flashing Monaco when only one side has data was worse
-  // than a slightly delayed initial render. Per-side spinners after
-  // the editor mounts aren't needed: Monaco re-renders in place when
-  // a side's content swaps.
   errors,
   editorTheme = 'vs-dark',
   onSwap,

--- a/packages/k8s-ui/src/components/compare/ResourceCompareView.tsx
+++ b/packages/k8s-ui/src/components/compare/ResourceCompareView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { clsx } from 'clsx'
 import { ArrowLeftRight, GitCompare, Rows, FileText, FileCode2, X, Pencil, AlertTriangle, Sparkles } from 'lucide-react'
 import { YamlDiffEditor } from '../ui/YamlEditor'
@@ -142,6 +142,17 @@ export function ResourceCompareView({
   const bError = errors?.find(e => e.side === 'b')?.message
   const anyError = !!(aError || bError)
 
+  // First-settle gate. The cold-start splash should NOT reappear when the
+  // user re-picks one side after the editor has mounted — once both sides
+  // have produced data or an error at least once, we mark the editor as
+  // "settled" and from then on Monaco re-renders in place even if a side's
+  // query data briefly clears during a re-fetch. Without this, the entire
+  // diff view flashed back to the loader on every pencil click.
+  const bothSettled = (!!aData || !!aError) && (!!bData || !!bError)
+  const hasSettledRef = useRef(false)
+  if (bothSettled) hasSettledRef.current = true
+  const showInitialLoader = !hasSettledRef.current && !bothSettled
+
   return (
     <div className="flex-1 min-w-0 flex flex-col h-full bg-theme-base">
       <div className="h-0.5 w-full bg-gradient-to-r from-blue-400/70 via-skyhook-400/40 to-emerald-400/70" />
@@ -213,17 +224,15 @@ export function ResourceCompareView({
       <div className={clsx('flex-1 min-h-0', bleed ? '' : 'p-3')}>
         {/*
           Defer mounting the diff editor until BOTH sides have settled
-          (data or per-side error). Mounting Monaco when only one side
-          has data flashes a second loading state — its own internal
-          "Loading…" placeholder — before re-rendering with the full
-          diff, producing the double-flash on cold start. With this
-          gate the user sees one consistent splash, then the full diff
-          appears in a single transition. After the initial settle,
-          re-picking one side stays per-side (the existing aLoading /
-          bLoading props flow into Monaco's input — Monaco itself just
-          re-renders without re-initializing).
+          (data or per-side error) on FIRST load. Mounting Monaco when
+          only one side has data flashes a second loading state — its own
+          internal "Loading…" placeholder — before re-rendering with the
+          full diff. After the initial settle (tracked via hasSettledRef
+          above), Monaco stays mounted even when a side's query data
+          briefly clears during a pencil re-pick — re-rendering in place
+          rather than blanking the whole diff.
         */}
-        {(!aData && !aError) || (!bData && !bError) ? (
+        {showInitialLoader ? (
           <PaneLoader label="Loading resources…" className="h-full" />
         ) : (
           <YamlDiffEditor

--- a/packages/k8s-ui/src/components/compare/ResourceCompareView.tsx
+++ b/packages/k8s-ui/src/components/compare/ResourceCompareView.tsx
@@ -148,8 +148,20 @@ export function ResourceCompareView({
   // "settled" and from then on Monaco re-renders in place even if a side's
   // query data briefly clears during a re-fetch. Without this, the entire
   // diff view flashed back to the loader on every pencil click.
-  const bothSettled = (!!aData || !!aError) && (!!bData || !!bError)
+  //
+  // The settle ref is keyed on the A/B identity so that navigating to a
+  // different pair (e.g. /compare?a=X&b=Y → /compare?a=Z&b=W on the same
+  // route) re-triggers the loader instead of flashing a blank diff while
+  // the new fetches are in flight.
+  const settleKey = `${a.kind}|${a.namespace}|${a.name}|${a.group ?? ''}|${aSubtitle ?? ''}` +
+    `|${b.kind}|${b.namespace}|${b.name}|${b.group ?? ''}|${bSubtitle ?? ''}`
+  const settleKeyRef = useRef(settleKey)
   const hasSettledRef = useRef(false)
+  if (settleKeyRef.current !== settleKey) {
+    settleKeyRef.current = settleKey
+    hasSettledRef.current = false
+  }
+  const bothSettled = (!!aData || !!aError) && (!!bData || !!bError)
   if (bothSettled) hasSettledRef.current = true
   const showInitialLoader = !hasSettledRef.current && !bothSettled
 

--- a/packages/k8s-ui/src/components/compare/picks.test.ts
+++ b/packages/k8s-ui/src/components/compare/picks.test.ts
@@ -68,3 +68,30 @@ describe('pickIndex', () => {
     expect(pickIndex([ref('prod', 'api')], ref('prod', ''))).toBe(-1)
   })
 })
+
+describe('togglePick — cross-cluster scope', () => {
+  // Same ns/name in DIFFERENT clusters must be treated as distinct
+  // picks. Otherwise the second click on the same resource name in the
+  // second cluster would deselect the first.
+  const refC = (cid: string, namespace: string, name: string): NamespacedRef => (
+    { namespace, name, clusterId: cid }
+  )
+
+  it('keeps two same-ns-name picks from different clusters', () => {
+    const start: NamespacedRef[] = [refC('cl_a', 'kube-system', 'coredns')]
+    expect(togglePick(start, refC('cl_b', 'kube-system', 'coredns'))).toEqual([
+      refC('cl_a', 'kube-system', 'coredns'),
+      refC('cl_b', 'kube-system', 'coredns'),
+    ])
+  })
+
+  it('removes a pick keyed by clusterId when same ref re-clicked', () => {
+    const start: NamespacedRef[] = [refC('cl_a', 'kube-system', 'coredns')]
+    expect(togglePick(start, refC('cl_a', 'kube-system', 'coredns'))).toEqual([])
+  })
+
+  it('does not match scoped ref against unscoped pick of same ns+name', () => {
+    const unscoped: NamespacedRef = { namespace: 'kube-system', name: 'coredns' }
+    expect(pickIndex([unscoped], refC('cl_a', 'kube-system', 'coredns'))).toBe(-1)
+  })
+})

--- a/packages/k8s-ui/src/components/compare/picks.ts
+++ b/packages/k8s-ui/src/components/compare/picks.ts
@@ -8,9 +8,17 @@ export const COMPARE_PICK_CAP = 2
  * Existing pick → remove. Below cap → append. At cap → drop the oldest so the
  * row click always changes state (no silent no-op).
  */
+function sameRef(a: NamespacedRef, b: NamespacedRef): boolean {
+  // clusterId may be undefined on both (OSS single-cluster compare) or
+  // set on both (cross-cluster compare). When set, two picks with the
+  // same kind+ns+name in DIFFERENT clusters must be treated as distinct
+  // — otherwise the second pick would toggle off the first.
+  return a.clusterId === b.clusterId && a.namespace === b.namespace && a.name === b.name
+}
+
 export function togglePick(picks: NamespacedRef[], ref: NamespacedRef): NamespacedRef[] {
   if (!ref.name) return picks
-  const existingIdx = picks.findIndex(p => p.namespace === ref.namespace && p.name === ref.name)
+  const existingIdx = picks.findIndex(p => sameRef(p, ref))
   if (existingIdx >= 0) {
     return picks.filter((_, i) => i !== existingIdx)
   }
@@ -23,5 +31,5 @@ export function togglePick(picks: NamespacedRef[], ref: NamespacedRef): Namespac
 /** -1 if not picked; otherwise the slot index (0 = A, 1 = B). */
 export function pickIndex(picks: NamespacedRef[], ref: NamespacedRef): number {
   if (!ref.name) return -1
-  return picks.findIndex(p => p.namespace === ref.namespace && p.name === ref.name)
+  return picks.findIndex(p => sameRef(p, ref))
 }

--- a/packages/k8s-ui/src/components/compare/types.ts
+++ b/packages/k8s-ui/src/components/compare/types.ts
@@ -1,6 +1,15 @@
 export interface NamespacedRef {
   namespace: string
   name: string
+  /**
+   * Optional cluster scope. Populated by cross-cluster compare flows
+   * (Radar Hub fleet search) so the same `kube-system/coredns` in two
+   * different clusters can both be picked. Undefined in OSS single-
+   * cluster compare; equality then falls back to namespace+name only.
+   */
+  clusterId?: string
+  /** Display name for the cluster — surfaced in tray pills + diff side titles. */
+  clusterName?: string
 }
 
 export type CompareSide = 'a' | 'b'

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -151,7 +151,7 @@ import { AzureManagedControlPlaneCell, AzureManagedMachinePoolCell, AzureMachine
 import { useRegisterShortcut, useRegisterShortcuts } from '../../hooks/useKeyboardShortcuts'
 import { ResourcesSidebar } from './ResourcesSidebar'
 import type { SelectedKindInfo } from './ResourcesSidebar'
-import { CompareTray, togglePick, pickIndex, refToParam, SIDE_TONES, type CompareTrayPick } from '../compare'
+import { CompareTray, togglePick, pickIndex, refToParam, SIDE_TONES, type CompareTrayPick, type NamespacedRef } from '../compare'
 
 // Pod problem filter options (special multi-select, not a single column value)
 const POD_PROBLEMS = ['CrashLoopBackOff', 'ImagePullBackOff', 'OOMKilled', 'Unschedulable', 'Not Ready', 'High Restarts', 'Init Failed', 'Exit Code Error', 'Failed', 'Other'] as const
@@ -1755,6 +1755,29 @@ interface ResourcesViewProps {
    *  should also wire onResourceClick to handle the deep-link-on-load
    *  case. */
   onRowSelect?: (resource: any) => void
+  /**
+   * When provided, replaces the built-in compare-mode submit (which
+   * navigates to `/compare?kind=...&a=...&b=...`). Hosts use this to
+   * route to a different URL — e.g. Radar Hub's `/fleet/compare` with
+   * cluster IDs in the URL. Picks are passed in click order; each carries
+   * `clusterId`/`clusterName` when the host stamps them via
+   * `extraLeadingColumns` row data, so cross-cluster picks survive the
+   * pick-equality check that would otherwise collapse same-named rows
+   * from different clusters into one. When undefined, default same-
+   * cluster navigation behavior is preserved.
+   */
+  onCompareSubmit?: (
+    picks: NamespacedRef[],
+    kind: { name: string; group?: string },
+  ) => void
+  /**
+   * Resolves the cluster scope for a row when compare-mode is enabled.
+   * Used to stamp `clusterId`/`clusterName` onto each pick so the same
+   * `ns/name` in two different clusters is treated as two distinct picks.
+   * Hub-web returns `row._cluster` here; OSS leaves this unset and picks
+   * key on namespace+name only (same as before).
+   */
+  resolveRowCluster?: (resource: any) => { id: string; name: string } | undefined
 }
 
 // Default selected kind
@@ -1899,6 +1922,8 @@ export function ResourcesView({
   defaultKind = DEFAULT_KIND_INFO,
   extraLeadingColumns,
   onRowSelect,
+  onCompareSubmit,
+  resolveRowCluster,
 }: ResourcesViewProps) {
   const initialFilters = getInitialFiltersFromURL()
   const [selectedKind, setSelectedKind] = useState<SelectedKindInfo>(() => getInitialKindFromURL(basePath, defaultKind, locationPathname, locationSearch))
@@ -2042,6 +2067,13 @@ export function ResourcesView({
 
   useEffect(() => {
     const saved = loadColumnSettings(selectedKind.name, selectedKind.group)
+    // Host-injected extra columns (e.g. fleet Cluster) default to visible
+    // regardless of saved state. The saved blob was written by an earlier
+    // mount that didn't know these columns existed, so a naive Set(saved)
+    // would silently hide them. Union the saved set with extra keys so
+    // user-hidden built-in columns still respect their saved hidden state,
+    // while newly-introduced host extras appear by default.
+    const extraKeys = extraLeadingColumns?.map(c => c.key) ?? []
     if (saved) {
       // If saved columns are just the defaults but this kind has specialized columns,
       // discard the stale save and use the specialized columns instead
@@ -2054,14 +2086,16 @@ export function ResourcesView({
         setVisibleColumns(getDefaultVisibleColumns(allColumns))
         setColumnWidths({})
       } else {
-        setVisibleColumns(new Set(saved.visible))
+        const merged = new Set(saved.visible)
+        for (const k of extraKeys) merged.add(k)
+        setVisibleColumns(merged)
         setColumnWidths(saved.widths || {})
       }
     } else {
       setVisibleColumns(getDefaultVisibleColumns(allColumns))
       setColumnWidths({})
     }
-  }, [selectedKind.name, selectedKind.group, allColumns])
+  }, [selectedKind.name, selectedKind.group, allColumns, extraLeadingColumns])
 
   // Save column settings when they change (skip initial load)
   const isColumnSettingsLoaded = useRef(false)
@@ -2197,9 +2231,11 @@ export function ResourcesView({
   const [highlightedIndex, setHighlightedIndex] = useState(-1)
   const virtuosoRef = useRef<TableVirtuosoHandle>(null)
 
-  // Compare mode is only meaningful when the host wired onNavigate — without it the Compare
-  // CTA in the tray would silently no-op. Gate everything below on this capability.
-  const compareEnabled = !!onNavigate
+  // Compare mode is only meaningful when the host can route picks. Either
+  // path qualifies: onNavigate for the default same-cluster `/compare?...`
+  // URL, or onCompareSubmit for hosts that build their own URL (e.g.
+  // Radar Hub's `/fleet/compare` with cluster IDs).
+  const compareEnabled = !!onNavigate || !!onCompareSubmit
   const [compareMode, setCompareMode] = useState(false)
   const [comparePicks, setComparePicks] = useState<CompareTrayPick[]>([])
 
@@ -2218,18 +2254,32 @@ export function ResourcesView({
   const toggleComparePick = useCallback((resource: any) => {
     if (!resource?.metadata?.name) return
     const ns = resource.metadata.namespace || ''
-    setComparePicks(prev => togglePick(prev, { namespace: ns, name: resource.metadata.name }))
-  }, [])
+    // Stamp clusterId on the pick when the host provides a resolver
+    // (cross-cluster compare). Without it, two rows with the same ns+name
+    // from different clusters would collapse into one pick.
+    const cluster = resolveRowCluster?.(resource)
+    setComparePicks(prev => togglePick(prev, {
+      namespace: ns,
+      name: resource.metadata.name,
+      clusterId: cluster?.id,
+      clusterName: cluster?.name,
+    }))
+  }, [resolveRowCluster])
 
   const handleCompareNavigate = useCallback(() => {
-    if (comparePicks.length !== 2 || !onNavigate) return
+    if (comparePicks.length !== 2) return
+    if (onCompareSubmit) {
+      onCompareSubmit(comparePicks, { name: selectedKind.name, group: selectedKind.group })
+      return
+    }
+    if (!onNavigate) return
     const params = new URLSearchParams()
     params.set('kind', selectedKind.name)
     if (selectedKind.group) params.set('apiGroup', selectedKind.group)
     params.set('a', refToParam(comparePicks[0]))
     params.set('b', refToParam(comparePicks[1]))
     onNavigate(`/compare?${params.toString()}`)
-  }, [comparePicks, selectedKind.name, selectedKind.group, onNavigate])
+  }, [comparePicks, selectedKind.name, selectedKind.group, onNavigate, onCompareSubmit])
 
   // Reset highlight when kind, search, sort, or namespace changes
   const namespacesKey = namespaces.join(',')
@@ -3274,6 +3324,14 @@ export function ResourcesView({
           style={{ ...props.style, tableLayout: 'fixed' }}
         >
           <colgroup>
+            {/*
+              Compare-mode adds a leading <th>/<td> per row but isn't part
+              of `columns`. Under table-layout:fixed the <colgroup> must
+              match the actual column count, otherwise the browser pads
+              the missing entry by stealing width from a sized neighbour
+              — typically blowing this narrow column out to ~200px.
+            */}
+            {compareMode && <col style={{ width: 36 }} />}
             {columns.map(col => (
               <col
                 key={col.key}
@@ -3291,7 +3349,7 @@ export function ResourcesView({
       )
     }),
     TableRow: VirtuosoTableRow,
-  }), [columns, columnWidths, hasResizedColumns])
+  }), [columns, columnWidths, hasResizedColumns, compareMode])
 
   // Calculate filter options with counts based on current resources (before filtering)
   const filterOptions = useMemo(() => {
@@ -3883,7 +3941,14 @@ export function ResourcesView({
                 <tr>
                   {compareMode && (
                     <th
-                      className="w-9 px-2 py-3 text-xs font-medium uppercase tracking-wide bg-theme-base border-b border-r-subtle border-theme-border text-center text-skyhook-400"
+                      // Force a narrow width — Tailwind's w-9 is honored
+                      // as a hint under table-layout:auto, but the browser
+                      // distributes extra row width to whichever column
+                      // doesn't have a definitive width, and this column's
+                      // single small icon makes it that target. Inline
+                      // px width clamps it before that happens.
+                      style={{ width: 36, minWidth: 36, maxWidth: 36 }}
+                      className="px-2 py-3 text-xs font-medium uppercase tracking-wide bg-theme-base border-b border-r-subtle border-theme-border text-center text-skyhook-400"
                       title="Compare mode"
                     >
                       <GitCompare className="w-3.5 h-3.5 inline-block opacity-70" />
@@ -4061,7 +4126,11 @@ export function ResourcesView({
                   selectedResource?.name === resource.metadata?.name
                 const isHighlighted = index === highlightedIndex
                 const pickIdx = compareMode
-                  ? pickIndex(comparePicks, { namespace: resource.metadata?.namespace || '', name: resource.metadata?.name || '' })
+                  ? pickIndex(comparePicks, {
+                      namespace: resource.metadata?.namespace || '',
+                      name: resource.metadata?.name || '',
+                      clusterId: resolveRowCluster?.(resource)?.id,
+                    })
                   : -1
                 return (
                   <ResourceRowCells
@@ -4151,7 +4220,8 @@ function ResourceRowCells({ resource, kind, group, columns, extraColumnsByKey, h
         <td
           onClick={onClick}
           onMouseEnter={onMouseEnter}
-          className={clsx('w-9 px-2 py-3 border-b-subtle cursor-pointer text-center align-middle transition-colors', rowHighlight)}
+          style={{ width: 36, minWidth: 36, maxWidth: 36 }}
+          className={clsx('px-2 py-3 border-b-subtle cursor-pointer text-center align-middle transition-colors', rowHighlight)}
         >
           {pickedSide ? (
             <span

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1756,15 +1756,12 @@ interface ResourcesViewProps {
    *  case. */
   onRowSelect?: (resource: any) => void
   /**
-   * When provided, replaces the built-in compare-mode submit (which
-   * navigates to `/compare?kind=...&a=...&b=...`). Hosts use this to
-   * route to a different URL — e.g. Radar Hub's `/fleet/compare` with
-   * cluster IDs in the URL. Picks are passed in click order; each carries
-   * `clusterId`/`clusterName` when the host stamps them via
-   * `extraLeadingColumns` row data, so cross-cluster picks survive the
-   * pick-equality check that would otherwise collapse same-named rows
-   * from different clusters into one. When undefined, default same-
-   * cluster navigation behavior is preserved.
+   * Overrides the default compare-mode submit (which navigates to
+   * `/compare?kind=...&a=...&b=...`). Hosts use this to route to a
+   * different URL — e.g. Radar Hub's `/fleet/compare` with cluster IDs.
+   * Picks arrive in click order, each carrying `clusterId`/`clusterName`
+   * when `resolveRowCluster` is set (which is what keeps cross-cluster
+   * picks distinct in the equality check).
    */
   onCompareSubmit?: (
     picks: NamespacedRef[],
@@ -1772,10 +1769,10 @@ interface ResourcesViewProps {
   ) => void
   /**
    * Resolves the cluster scope for a row when compare-mode is enabled.
-   * Used to stamp `clusterId`/`clusterName` onto each pick so the same
-   * `ns/name` in two different clusters is treated as two distinct picks.
-   * Hub-web returns `row._cluster` here; OSS leaves this unset and picks
-   * key on namespace+name only (same as before).
+   * Stamps `clusterId`/`clusterName` onto each pick so the same `ns/name`
+   * in two different clusters is treated as two distinct picks. Hub-web
+   * returns `row._cluster` here; OSS leaves it unset and picks key on
+   * namespace+name only.
    */
   resolveRowCluster?: (resource: any) => { id: string; name: string } | undefined
 }
@@ -2068,11 +2065,9 @@ export function ResourcesView({
   useEffect(() => {
     const saved = loadColumnSettings(selectedKind.name, selectedKind.group)
     // Host-injected extra columns (e.g. fleet Cluster) default to visible
-    // regardless of saved state. The saved blob was written by an earlier
-    // mount that didn't know these columns existed, so a naive Set(saved)
-    // would silently hide them. Union the saved set with extra keys so
-    // user-hidden built-in columns still respect their saved hidden state,
-    // while newly-introduced host extras appear by default.
+    // even when the saved column-visibility blob predates them — a naive
+    // Set(saved.visible) would silently hide host columns the user has
+    // never been shown.
     const extraKeys = extraLeadingColumns?.map(c => c.key) ?? []
     if (saved) {
       // If saved columns are just the defaults but this kind has specialized columns,
@@ -3941,12 +3936,9 @@ export function ResourcesView({
                 <tr>
                   {compareMode && (
                     <th
-                      // Force a narrow width — Tailwind's w-9 is honored
-                      // as a hint under table-layout:auto, but the browser
-                      // distributes extra row width to whichever column
-                      // doesn't have a definitive width, and this column's
-                      // single small icon makes it that target. Inline
-                      // px width clamps it before that happens.
+                      // Inline px width — under `table-layout:fixed`,
+                      // `w-9` is a hint the browser absorbs into leftover
+                      // row width on an icon-only column.
                       style={{ width: 36, minWidth: 36, maxWidth: 36 }}
                       className="px-2 py-3 text-xs font-medium uppercase tracking-wide bg-theme-base border-b border-r-subtle border-theme-border text-center text-skyhook-400"
                       title="Compare mode"

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -2067,7 +2067,9 @@ export function ResourcesView({
     // Host-injected extra columns (e.g. fleet Cluster) default to visible
     // even when the saved column-visibility blob predates them — a naive
     // Set(saved.visible) would silently hide host columns the user has
-    // never been shown.
+    // never been shown. Trade-off: a user can't permanently hide a host
+    // extra column via the column picker — next mount re-adds it. Track
+    // a sibling "hidden-extras" set if this becomes a real complaint.
     const extraKeys = extraLeadingColumns?.map(c => c.key) ?? []
     if (saved) {
       // If saved columns are just the defaults but this kind has specialized columns,

--- a/packages/k8s-ui/src/components/shared/ResourceActionsBar.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceActionsBar.tsx
@@ -40,6 +40,15 @@ interface ResourceActionsBarProps {
   /** When provided, renders a "Compare" button that opens the compare picker. */
   onCompareTo?: () => void
 
+  /**
+   * Host-supplied callback for cross-cluster compare. When set alongside
+   * onCompareTo, the Compare button becomes a small dropdown offering both
+   * scopes. When set alone, the button opens cross-cluster compare directly.
+   * Only embedded hosts (Radar Hub) wire this; standalone Radar leaves it
+   * undefined and the button stays single-cluster.
+   */
+  onCompareAcrossClusters?: () => void
+
   // Capabilities (injected by platform)
   canExec?: boolean
   canViewLogs?: boolean
@@ -115,6 +124,7 @@ interface ResourceActionsBarProps {
 export function ResourceActionsBar({
   resource, data, onClose, hideLogs, showYaml, onToggleYaml,
   onCompareTo,
+  onCompareAcrossClusters,
   canExec, canViewLogs, canPortForward,
   onOpenTerminal, onOpenLogs: openLogs, onOpenWorkloadLogs: openWorkloadLogs, onCopyCommand,
   renderPortForward,
@@ -192,6 +202,16 @@ export function ResourceActionsBar({
 
   const [showLogsMenu, setShowLogsMenu] = useState(false)
   const logsMenuTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const [showCompareMenu, setShowCompareMenu] = useState(false)
+  const compareMenuTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const handleCompareMouseEnter = () => {
+    if (compareMenuTimeout.current) clearTimeout(compareMenuTimeout.current)
+    if (onCompareTo && onCompareAcrossClusters) setShowCompareMenu(true)
+  }
+  const handleCompareMouseLeave = () => {
+    compareMenuTimeout.current = setTimeout(() => setShowCompareMenu(false), 150)
+  }
 
   const handleLogsMouseEnter = () => {
     if (logsMenuTimeout.current) clearTimeout(logsMenuTimeout.current)
@@ -487,16 +507,57 @@ export function ResourceActionsBar({
         </button>
       )}
 
-      {onCompareTo && (
-        <Tooltip content={`Compare to another ${formatKindName(resource.kind).toLowerCase()}`}>
-          <button
-            onClick={onCompareTo}
-            aria-label={`Compare to another ${formatKindName(resource.kind).toLowerCase()}`}
-            className="p-1.5 text-theme-text-secondary border border-theme-border-light rounded-lg hover:text-theme-text-primary hover:bg-theme-elevated transition-colors"
+      {(onCompareTo || onCompareAcrossClusters) && (
+        <div
+          className="relative"
+          onMouseEnter={handleCompareMouseEnter}
+          onMouseLeave={handleCompareMouseLeave}
+        >
+          <Tooltip
+            content={
+              onCompareTo && onCompareAcrossClusters
+                ? `Compare ${formatKindName(resource.kind).toLowerCase()}`
+                : onCompareAcrossClusters
+                  ? `Compare across clusters`
+                  : `Compare to another ${formatKindName(resource.kind).toLowerCase()}`
+            }
           >
-            <GitCompare className="w-3.5 h-3.5" />
-          </button>
-        </Tooltip>
+            <button
+              onClick={onCompareTo ?? onCompareAcrossClusters}
+              aria-label={
+                onCompareTo && onCompareAcrossClusters
+                  ? `Compare ${formatKindName(resource.kind).toLowerCase()}`
+                  : onCompareAcrossClusters
+                    ? `Compare across clusters`
+                    : `Compare to another ${formatKindName(resource.kind).toLowerCase()}`
+              }
+              className="p-1.5 text-theme-text-secondary border border-theme-border-light rounded-lg hover:text-theme-text-primary hover:bg-theme-elevated transition-colors flex items-center"
+            >
+              <GitCompare className="w-3.5 h-3.5" />
+              {onCompareTo && onCompareAcrossClusters && (
+                <ChevronDown className="w-3 h-3 ml-0.5" />
+              )}
+            </button>
+          </Tooltip>
+          {showCompareMenu && onCompareTo && onCompareAcrossClusters && (
+            <div className="absolute top-full right-0 mt-1 min-w-[220px] py-1 bg-theme-surface border border-theme-border rounded-lg shadow-lg z-50">
+              <button
+                onClick={() => { onCompareTo(); setShowCompareMenu(false) }}
+                className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-theme-text-primary hover:bg-theme-hover transition-colors text-left"
+              >
+                <GitCompare className="w-3 h-3 text-theme-text-tertiary shrink-0" />
+                <span>Compare in this cluster</span>
+              </button>
+              <button
+                onClick={() => { onCompareAcrossClusters(); setShowCompareMenu(false) }}
+                className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-theme-text-primary hover:bg-theme-hover transition-colors text-left"
+              >
+                <GitCompare className="w-3 h-3 text-theme-text-tertiary shrink-0" />
+                <span>Compare across clusters</span>
+              </button>
+            </div>
+          )}
+        </div>
       )}
 
       {onDelete && (

--- a/packages/k8s-ui/src/components/shared/ResourceActionsBar.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceActionsBar.tsx
@@ -540,7 +540,7 @@ export function ResourceActionsBar({
             </button>
           </Tooltip>
           {showCompareMenu && onCompareTo && onCompareAcrossClusters && (
-            <div className="absolute top-full right-0 mt-1 min-w-[220px] py-1 bg-theme-surface border border-theme-border rounded-lg shadow-lg z-50">
+            <div className="absolute top-full right-0 mt-1 min-w-[220px] py-1 bg-theme-surface border border-theme-border rounded-lg shadow-theme-lg z-50">
               <button
                 onClick={() => { onCompareTo(); setShowCompareMenu(false) }}
                 className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-theme-text-primary hover:bg-theme-hover transition-colors text-left"

--- a/packages/k8s-ui/src/components/ui/YamlEditor.tsx
+++ b/packages/k8s-ui/src/components/ui/YamlEditor.tsx
@@ -1,5 +1,6 @@
 import { useRef, useCallback, useEffect } from 'react'
 import Editor, { DiffEditor, OnMount, OnChange, type Monaco } from '@monaco-editor/react'
+import { PaneLoader } from './PaneLoader'
 import type { editor } from 'monaco-editor'
 
 interface YamlEditorProps {
@@ -250,6 +251,8 @@ interface YamlDiffEditorProps {
   hideUnchanged?: boolean
   /** Caller-controlled theme. Defaults to dark to match YamlEditor. */
   theme?: 'vs-dark' | 'vs'
+  /** When true, drops the rounded border so the editor reaches its container's edges. */
+  bleed?: boolean
 }
 
 export function YamlDiffEditor({
@@ -259,9 +262,10 @@ export function YamlDiffEditor({
   unified = false,
   hideUnchanged = false,
   theme = 'vs-dark',
+  bleed = false,
 }: YamlDiffEditorProps) {
   return (
-    <div className="rounded-lg overflow-hidden border border-theme-border" style={{ height }}>
+    <div className={bleed ? 'overflow-hidden' : 'rounded-lg overflow-hidden border border-theme-border'} style={{ height }}>
       <DiffEditor
         original={original}
         modified={modified}
@@ -282,11 +286,7 @@ export function YamlDiffEditor({
           ignoreTrimWhitespace: false,
           automaticLayout: true,
         }}
-        loading={
-          <div className="flex items-center justify-center h-full bg-theme-surface text-theme-text-secondary">
-            Loading diff...
-          </div>
-        }
+        loading={<PaneLoader label="Loading resources…" className="h-full" />}
       />
     </div>
   )

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -146,10 +146,20 @@ function AuthBarrier({ authMode }: { authMode: string }) {
 
   if (authMode === 'oidc') {
     return (
-      <div className="flex-1 flex items-center justify-center bg-theme-base">
-        <div className="flex flex-col items-center gap-4">
-          <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
-          <p className="text-sm text-theme-text-secondary">Redirecting to login…</p>
+      <div className="flex-1 relative bg-theme-base">
+        <div className="fixed inset-0 pointer-events-none">
+          <img
+            src={radarLoadingIcon}
+            alt=""
+            aria-hidden
+            className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-11 h-11"
+          />
+          <p
+            className="absolute left-1/2 -translate-x-1/2 whitespace-nowrap text-[17px] font-semibold tracking-tight text-theme-text-primary"
+            style={{ top: 'calc(50% + 34px)' }}
+          >
+            Redirecting to login…
+          </p>
         </div>
       </div>
     )
@@ -1189,13 +1199,39 @@ function AppInner() {
         />
       )}
 
-      {/* Connecting view - show during initial connection or retry */}
+      {/* Connecting view - show during initial connection or retry.
+          Icon is viewport-anchored (fixed inset-0 + pointer-events-none)
+          so it sits at the same screen position as the host hub splash —
+          centering in the flex-1 content area would push it below the
+          navbar and visibly drift the icon when transitioning from a
+          hub splash on cluster open. */}
       {!isSwitching && !(authMe?.authEnabled && !authMe?.username) && connection.state === 'connecting' && (
-        <div className="flex-1 flex items-center justify-center bg-theme-base">
-          <div className="flex flex-col items-center gap-4 text-theme-text-secondary">
-            <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
-            <div className="text-center">
-              <p className="font-medium text-theme-text-primary">Connecting to cluster</p>
+        <div className="flex-1 relative bg-theme-base">
+          {/* Icon absolutely anchored to viewport-center. The label block
+              sits at a fixed offset below — independent of label height
+              so multi-line messages (context + progress) don't shift the
+              icon's screen position. */}
+          <div className="fixed inset-0 pointer-events-none">
+            <img
+              src={radarLoadingIcon}
+              alt=""
+              aria-hidden
+              // Integer offset (vw/2 - 22) — avoids 1-2px sub-pixel jitter
+              // from translate(-50%, -50%) on odd-pixel viewports.
+              className="absolute w-11 h-11"
+              style={{ left: 'calc(50% - 22px)', top: 'calc(50% - 22px)' }}
+            />
+            <div
+              className="absolute left-1/2 -translate-x-1/2 text-center"
+              style={{ top: 'calc(50% + 34px)' }}
+            >
+              {/* Title style mirrors every other splash (RadarSplash,
+                  LoadingState, pre-React) — 17px semibold so the font
+                  doesn't visibly swap across the hub → cluster splash
+                  chain. Subtitles below stay smaller/dimmer. */}
+              <p className="whitespace-nowrap text-[17px] font-semibold tracking-tight text-theme-text-primary">
+                Connecting to cluster
+              </p>
               {connection.context && (
                 <p className="text-sm text-theme-text-secondary mt-1">{connection.context}</p>
               )}
@@ -1209,13 +1245,24 @@ function AppInner() {
         </div>
       )}
 
-      {/* Context switching overlay */}
+      {/* Context switching overlay — icon viewport-anchored, label below. */}
       {isSwitching && (
-        <div className="flex-1 flex items-center justify-center bg-theme-base">
-          <div className="flex flex-col items-center gap-4 text-theme-text-secondary">
-            <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
-            <div className="text-center">
-              <div className="text-sm font-medium text-theme-text-primary">Switching context</div>
+        <div className="flex-1 relative bg-theme-base">
+          <div className="fixed inset-0 pointer-events-none">
+            <img
+              src={radarLoadingIcon}
+              alt=""
+              aria-hidden
+              // Integer offset (vw/2 - 22) — avoids 1-2px sub-pixel jitter
+              // from translate(-50%, -50%) on odd-pixel viewports.
+              className="absolute w-11 h-11"
+              style={{ left: 'calc(50% - 22px)', top: 'calc(50% - 22px)' }}
+            />
+            <div
+              className="absolute left-1/2 -translate-x-1/2 text-center"
+              style={{ top: 'calc(50% + 34px)' }}
+            >
+              <div className="whitespace-nowrap text-[17px] font-semibold tracking-tight text-theme-text-primary">Switching context</div>
               {targetContext && (
                 <div className="text-xs mt-2 text-theme-text-tertiary">
                   {targetContext.provider ? (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1199,12 +1199,9 @@ function AppInner() {
         />
       )}
 
-      {/* Connecting view - show during initial connection or retry.
-          Icon is viewport-anchored (fixed inset-0 + pointer-events-none)
-          so it sits at the same screen position as the host hub splash —
-          centering in the flex-1 content area would push it below the
-          navbar and visibly drift the icon when transitioning from a
-          hub splash on cluster open. */}
+      {/* Connecting view — shown during initial connection or retry.
+          Icon is viewport-anchored so its screen position matches the
+          host hub splash across cross-document transitions. */}
       {!isSwitching && !(authMe?.authEnabled && !authMe?.username) && connection.state === 'connecting' && (
         <div className="flex-1 relative bg-theme-base">
           {/* Icon absolutely anchored to viewport-center. The label block
@@ -1216,8 +1213,8 @@ function AppInner() {
               src={radarLoadingIcon}
               alt=""
               aria-hidden
-              // Integer offset (vw/2 - 22) — avoids 1-2px sub-pixel jitter
-              // from translate(-50%, -50%) on odd-pixel viewports.
+              // Integer offset (vw/2 − 22) — avoids sub-pixel jitter from
+              // `translate(-50%, -50%)` on odd-width viewports.
               className="absolute w-11 h-11"
               style={{ left: 'calc(50% - 22px)', top: 'calc(50% - 22px)' }}
             />
@@ -1225,10 +1222,9 @@ function AppInner() {
               className="absolute left-1/2 -translate-x-1/2 text-center"
               style={{ top: 'calc(50% + 34px)' }}
             >
-              {/* Title style mirrors every other splash (RadarSplash,
-                  LoadingState, pre-React) — 17px semibold so the font
-                  doesn't visibly swap across the hub → cluster splash
-                  chain. Subtitles below stay smaller/dimmer. */}
+              {/* 17px semibold matches the other splash surfaces so font
+                  weight doesn't visibly swap during hub → cluster
+                  transitions. Subtitles below stay smaller/dimmer. */}
               <p className="whitespace-nowrap text-[17px] font-semibold tracking-tight text-theme-text-primary">
                 Connecting to cluster
               </p>
@@ -1253,8 +1249,8 @@ function AppInner() {
               src={radarLoadingIcon}
               alt=""
               aria-hidden
-              // Integer offset (vw/2 - 22) — avoids 1-2px sub-pixel jitter
-              // from translate(-50%, -50%) on odd-pixel viewports.
+              // Integer offset (vw/2 − 22) — avoids sub-pixel jitter from
+              // `translate(-50%, -50%)` on odd-width viewports.
               className="absolute w-11 h-11"
               style={{ left: 'calc(50% - 22px)', top: 'calc(50% - 22px)' }}
             />

--- a/web/src/components/compare/CompareViewRoute.tsx
+++ b/web/src/components/compare/CompareViewRoute.tsx
@@ -92,8 +92,6 @@ export function CompareViewRoute() {
         b={b}
         aData={aQuery.data}
         bData={bQuery.data}
-        aLoading={aQuery.isPending}
-        bLoading={bQuery.isPending}
         errors={errors}
         editorTheme={theme === 'dark' ? 'vs-dark' : 'vs'}
         onSwap={handleSwap}

--- a/web/src/components/compare/useCompareLauncher.tsx
+++ b/web/src/components/compare/useCompareLauncher.tsx
@@ -37,7 +37,7 @@ export function useCompareLauncher({ kind, namespace, name, group }: UseCompareL
 
   const onCompareAcrossClusters = useCallback(() => {
     if (!crossClusterCompareHref) return
-    const href = crossClusterCompareHref({ kind: kindLower, namespace, name, apiGroup: group })
+    const href = crossClusterCompareHref({ kind: kindLower, namespace, name, group })
     window.location.assign(href)
   }, [crossClusterCompareHref, kindLower, namespace, name, group])
 

--- a/web/src/components/compare/useCompareLauncher.tsx
+++ b/web/src/components/compare/useCompareLauncher.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { CompareResourcePicker, refToParam, type CompareResourceRef } from '@skyhook-io/k8s-ui'
 import { useCompareCandidates } from './useCompareCandidates'
+import { useNavCustomization } from '../../context/NavCustomization'
 
 interface UseCompareLauncherArgs {
   /** API plural kind (e.g. "deployments") — must match the route segment used by `/api/resources/{kind}`. */
@@ -15,6 +16,12 @@ interface UseCompareLauncherArgs {
 interface CompareLauncher {
   /** Wire this to ResourceActionsBar's `onCompareTo` prop. */
   onCompareTo: () => void
+  /**
+   * Wire this to ResourceActionsBar's `onCompareAcrossClusters` prop. Undefined
+   * when the host (NavCustomization.crossClusterCompareHref) hasn't opted in
+   * — keeps the standalone Radar experience identical.
+   */
+  onCompareAcrossClusters?: () => void
   /** Render this anywhere in the same tree to surface the picker dialog. */
   picker: React.ReactNode
 }
@@ -24,8 +31,15 @@ export function useCompareLauncher({ kind, namespace, name, group }: UseCompareL
   const [open, setOpen] = useState(false)
   const kindLower = kind.toLowerCase()
   const { candidates, isPending, error } = useCompareCandidates(kindLower, group, open)
+  const { crossClusterCompareHref } = useNavCustomization()
 
   const onCompareTo = useCallback(() => setOpen(true), [])
+
+  const onCompareAcrossClusters = useCallback(() => {
+    if (!crossClusterCompareHref) return
+    const href = crossClusterCompareHref({ kind: kindLower, namespace, name, apiGroup: group })
+    window.location.assign(href)
+  }, [crossClusterCompareHref, kindLower, namespace, name, group])
 
   const handlePick = useCallback(
     (picked: CompareResourceRef) => {
@@ -54,5 +68,9 @@ export function useCompareLauncher({ kind, namespace, name, group }: UseCompareL
     />
   )
 
-  return { onCompareTo, picker }
+  return {
+    onCompareTo,
+    onCompareAcrossClusters: crossClusterCompareHref ? onCompareAcrossClusters : undefined,
+    picker,
+  }
 }

--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -348,7 +348,7 @@ export function WorkloadView({
     () => (resource?.apiVersion ? apiVersionToGroup(resource.apiVersion) : undefined),
     [resource?.apiVersion],
   )
-  const { onCompareTo, picker: comparePicker } = useCompareLauncher({
+  const { onCompareTo, onCompareAcrossClusters, picker: comparePicker } = useCompareLauncher({
     kind: kindProp,
     namespace,
     name,
@@ -358,8 +358,8 @@ export function WorkloadView({
     group: rest.group || resourceGroup || undefined,
   })
   const actionsBarProps = useMemo(
-    () => ({ ...baseActionsBarProps, onCompareTo }),
-    [baseActionsBarProps, onCompareTo],
+    () => ({ ...baseActionsBarProps, onCompareTo, onCompareAcrossClusters }),
+    [baseActionsBarProps, onCompareTo, onCompareAcrossClusters],
   )
 
   const handleUpdateResource = useCallback(async (params: { kind: string; namespace: string; name: string; yaml: string }) => {

--- a/web/src/context/NavCustomization.tsx
+++ b/web/src/context/NavCustomization.tsx
@@ -29,7 +29,7 @@ interface NavCustomizationBase {
     kind: string;
     namespace: string;
     name: string;
-    apiGroup?: string;
+    group?: string;
   }) => string;
 }
 

--- a/web/src/context/NavCustomization.tsx
+++ b/web/src/context/NavCustomization.tsx
@@ -18,6 +18,19 @@ interface NavCustomizationBase {
   brandSlot?: ReactNode;
   /** Replaces the ContextSwitcher (kubeconfig-context picker). */
   contextSlot?: ReactNode;
+  /**
+   * When set, a "Compare across clusters" option is added to the Compare
+   * button in resource action bars. The host returns the URL that should
+   * be navigated to (via window.location.assign — typically a hub fleet
+   * route). Standalone Radar omits this and the compare action stays
+   * single-cluster.
+   */
+  crossClusterCompareHref?: (ref: {
+    kind: string;
+    namespace: string;
+    name: string;
+    apiGroup?: string;
+  }) => string;
 }
 
 /**


### PR DESCRIPTION
## Summary

OSS-side support for Radar Hub's cross-cluster `/fleet/compare` flow, plus two adjacent fixes uncovered along the way (search dedup, splash drift).

## What changed

**Cross-cluster compare in `@skyhook-io/k8s-ui`** — `NamespacedRef` gains optional `clusterId`/`clusterName`; `togglePick`/`pickIndex` now treat same `ns+name` in different clusters as distinct picks. `ResourcesView` gets `onCompareSubmit` + `resolveRowCluster` props so a host can route compare-mode submits to its own URL with cluster IDs (OSS single-cluster compare unchanged via existing `onNavigate`). `ResourceCompareView` gets `aSubtitle`/`bSubtitle` for cluster identity in pills + a `bleed` prop for full-bleed page hosts. `ResourceActionsBar`'s Compare button becomes a hover dropdown when both `onCompareTo` and the new `onCompareAcrossClusters` are wired.

**Cold-start flash fix in `ResourceCompareView`** — Monaco now mounts only when both sides have settled (data or per-side error). Both the pre-mount loader and Monaco's own init loader use `PaneLoader` so the cold-start reads as a single splash → diff transition.

**Search dedup in `internal/search`** — `/api/search` was emitting each Deployment twice when a resource was reachable via both the typed loop and the dynamic-watched loop (some integrations register `apps/v1.deployments` as a dynamic GVR). Hits now dedup by `(kind, group, ns, name)` before sort. Plus a fix to a pre-existing test that was passing accidentally (100 identical pods, never deduped) and a new test pinning the dedup behavior.

**NavCustomization extension in `@skyhook-io/radar-app`** — new optional `crossClusterCompareHref` slot. Embedded hosts return the URL the Compare button should navigate to. Standalone Radar omits it.

**Splash polish in `web/App.tsx`** — Connecting / Switching / Redirecting splashes now anchor the icon to the viewport via integer-pixel positioning (`calc(50% - 22px)`) instead of flex-centering, so the icon doesn't shift across hub → cluster transitions when ancestor padding differs (Radar Hub's cluster shell uses `md:pl-14`). Label fonts unified across all three (17px semibold).

**Column-visibility fix in `ResourcesView`** — persisted `radar-columns-*` from prior in-cluster use was hiding host-injected `extraLeadingColumns` (e.g. Radar Hub's fleet Cluster column). Now unions saved visibility with extra-column keys so new host columns are default-visible.

## Coordination

Once merged, tag `k8s-ui-v1.7.0` and `radar-app-v1.2.0` so Radar Hub can bump its `package.json` to a published version (currently linked via `npm link` for E2E).

## Test plan

- [x] `make tsc` clean
- [x] `npm test --run compare` — 55/55 passing
- [x] `go test ./internal/search/...` — passing (including new dedup test)
- [x] Manual: standalone Radar — single-cluster compare unchanged, dropdown-mode Compare button only appears when host wires `onCompareAcrossClusters`
- [x] E2E (with Radar Hub): drawer dropdown → cross-cluster compare; SearchPage compare-mode → cross-cluster picks; per-side error states render correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to behavioral changes in search result composition (dedup) and multiple compare/navigation UI flows; regressions would primarily affect result counts, compare selection, and routing/loader UX rather than data integrity.
> 
> **Overview**
> **Adds cross-cluster compare support and improves compare UX.** `NamespacedRef` now optionally carries `clusterId`/`clusterName`, compare picking (`togglePick`/`pickIndex`) keys on cluster scope when present, and `ResourcesView` can stamp row cluster identity (`resolveRowCluster`) and submit picks via a host-defined handler (`onCompareSubmit`) instead of always navigating to `/compare`.
> 
> **Refines compare and action-bar UI.** `ResourceCompareView` adds side subtitles + optional full-bleed rendering, and introduces a “settled” gate/loader so Monaco mounts only after both sides resolve; `ResourceActionsBar`’s Compare action can now offer a dropdown for in-cluster vs cross-cluster compare, wired through a new `NavCustomization.crossClusterCompareHref` and `useCompareLauncher` support.
> 
> **Fixes duplicated search hits and table/column quirks.** Search results now deduplicate by `(kind, group, namespace, name)` before sorting/limiting (with updated/new tests), resources table compare-mode column sizing is stabilized under `table-layout:fixed`, and saved column visibility is merged with host-injected `extraLeadingColumns` so new host columns default to visible.
> 
> **Polishes splash/loading screens.** Connecting/switching/redirecting views in `web/App.tsx` anchor the icon to the viewport for consistent positioning across shells and align typography; Monaco diff loading uses the shared `PaneLoader`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f5a33e6a0cb7edda3c8c02d4506619be060e27a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->