### PR TITLE
fix(finops-v2): stale prom client cache race + multi-bucket efficiency merge

### DIFF
--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -233,13 +233,20 @@ func (c *Client) getPromClient() *prom.Client {
 	tr.Headers = headers
 	p := prom.NewClient(tr)
 	c.mu.Lock()
-	// Double-check in case another goroutine built one.
-	if c.prom == nil {
-		c.prom = p
-	} else {
-		p = c.prom
+	defer c.mu.Unlock()
+	// Three things can have changed under us while the RLock was released:
+	//   1. Another goroutine cached its own client (c.prom != nil) — use theirs.
+	//   2. baseURL/basePath changed under us (concurrent markConnected/Reset).
+	//      Our client points at the old address — discard it. Return nil so
+	//      the caller can re-snapshot on its next attempt; the next request
+	//      will rebuild against the new address.
+	if c.prom != nil {
+		return c.prom
 	}
-	c.mu.Unlock()
+	if c.baseURL != base || c.basePath != bp {
+		return nil
+	}
+	c.prom = p
 	return p
 }
 

--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -211,9 +211,14 @@ func (c *Client) Prom() *prom.Client {
 	return c.getPromClient()
 }
 
-// getPromClient returns a pkg/prom.Client pointed at the current baseURL/basePath,
-// building (and caching) one if necessary. Callers must hold the read or
-// write lock appropriately; see QueryRange/Query.
+// getPromClient returns a pkg/prom.Client pointed at the current
+// baseURL/basePath, building (and caching) one if necessary.
+//
+// Fast path: cached client under RLock. Slow path: take the write lock and
+// build from the live state, which guarantees baseURL/basePath/headers all
+// reflect the same point-in-time view. Transport construction is just
+// struct-field assignments (no I/O) so holding the write lock across it
+// is cheap, and avoids the read-then-rebuild-then-recheck race entirely.
 func (c *Client) getPromClient() *prom.Client {
 	c.mu.RLock()
 	if c.prom != nil {
@@ -221,33 +226,20 @@ func (c *Client) getPromClient() *prom.Client {
 		c.mu.RUnlock()
 		return p
 	}
-	base, bp, httpC := c.baseURL, c.basePath, c.httpClient
-	headers := copyHeaders(c.headers)
 	c.mu.RUnlock()
 
-	if base == "" {
-		return nil
-	}
-
-	tr := prom.NewHTTPTransport(base, bp, httpC)
-	tr.Headers = headers
-	p := prom.NewClient(tr)
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	// Three things can have changed under us while the RLock was released:
-	//   1. Another goroutine cached its own client (c.prom != nil) — use theirs.
-	//   2. baseURL/basePath changed under us (concurrent markConnected/Reset).
-	//      Our client points at the old address — discard it. Return nil so
-	//      the caller can re-snapshot on its next attempt; the next request
-	//      will rebuild against the new address.
 	if c.prom != nil {
 		return c.prom
 	}
-	if c.baseURL != base || c.basePath != bp {
+	if c.baseURL == "" {
 		return nil
 	}
-	c.prom = p
-	return p
+	tr := prom.NewHTTPTransport(c.baseURL, c.basePath, c.httpClient)
+	tr.Headers = copyHeaders(c.headers)
+	c.prom = prom.NewClient(tr)
+	return c.prom
 }
 
 // probe checks if a Prometheus endpoint at `addr` is reachable and has at

--- a/pkg/opencost/compute.go
+++ b/pkg/opencost/compute.go
@@ -143,6 +143,18 @@ func ComputeCostSummary(ctx context.Context, client *RESTClient, opts SummaryOpt
 				}
 			}
 			if existing, ok := combined[name]; ok {
+				// Weight TotalEfficiency by the per-bucket allocation cost
+				// BEFORE adding this bucket's cost into the running total.
+				// Each row's TotalEfficiency is independently per-bucket;
+				// the merged row's effective efficiency is the cost-weighted
+				// average. Without this, the merged efficiency would just
+				// be the first bucket's value.
+				existingAlloc := existing.CPUCost + existing.RAMCost
+				bucketAlloc := a.CPUCost + a.RAMCost
+				if totalAlloc := existingAlloc + bucketAlloc; totalAlloc > 0 {
+					existing.TotalEfficiency =
+						(existing.TotalEfficiency*existingAlloc + a.TotalEfficiency*bucketAlloc) / totalAlloc
+				}
 				existing.CPUCost += a.CPUCost
 				existing.RAMCost += a.RAMCost
 				existing.PVCost += a.PVCost


### PR DESCRIPTION
Two follow-up fixes that landed too late to make it into #492 (squash-merged just before they were pushed). Both surfaced by cursor bugbot review on the original branch.

### `internal/prometheus/client.go` — race in getPromClient cache

`getPromClient` originally snapshotted `baseURL`/`basePath` under RLock, built the transport outside the lock, then took the write lock to cache. A concurrent `markConnected("B")` could race the cache-set and leave a client bound to A as `c.prom` while `c.baseURL` was now B.

Simpler shape: skip the read-snapshot-then-build dance entirely. After the fast-path RLock miss, take the write lock and build from live state. The transport constructor is just struct-field assignments (no I/O) so holding the write lock across it is cheap, and the build always sees a consistent (baseURL, basePath, httpClient, headers) tuple.

### `pkg/opencost/compute.go` — multi-bucket TotalEfficiency merge

`ComputeCostSummary`'s merge across multi-window `/allocation` buckets copied the first bucket's allocation (`cp := *a`) which preserved its `TotalEfficiency`, then accumulated subsequent buckets' costs but never updated efficiency. Multi-bucket responses reported efficiency from only the first bucket.

Radar's current usage doesn't set `Step` on summary calls so this never triggers in-process, but the path is published library API and external consumers may use `Step`. Fix: weight `TotalEfficiency` by per-bucket allocation cost during the merge.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/prometheus/...` and `go test ./pkg/opencost/...` green