### PR TITLE
Fix self-upgrade field ownership conflicts

### DIFF
--- a/internal/server/selfupgrade.go
+++ b/internal/server/selfupgrade.go
@@ -6,45 +6,47 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 
+	"helm.sh/helm/v3/pkg/releaseutil"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/yaml"
 
+	"github.com/skyhook-io/radar/internal/helm"
 	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/internal/logsafe"
 )
 
+var radarImageTagPattern = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_.-]{0,63}$`)
+
 // selfUpgradePatchOptions returns the PatchOptions used by the self-upgrade
-// endpoint. FieldManager "helm" is what keeps `.image` ownership stable
-// across self-upgrade and `helm upgrade` cycles: with an empty FieldManager
-// the apiserver derives one from User-Agent → "radar", which then
-// permanently owns .image and breaks every subsequent helm upgrade with a
-// server-side-apply conflict.
-//
-// We deliberately do NOT set Force here. K8s apimachinery rejects Force on
-// non-Apply patches (apimachinery/pkg/apis/meta/v1/validation:
-// `field.Forbidden("force", "may not be specified for non-apply patch")`)
-// so a StrategicMergePatch with Force=true returns 422 Invalid and the
-// upgrade never runs. If we ever need to reclaim conflicting ownership,
-// the route is to switch the request to ApplyPatchType with a full apply
-// object — not to flip Force back on a strategic merge.
+// endpoint. The patch is Server-Side Apply using Helm's field manager and the
+// full Deployment manifest from the Helm release, not a tiny image-only object.
+// SSA treats each apply as the manager's full desired field set, so applying
+// only `.image` would make Helm drop ownership of selector/template fields and
+// fail on immutable-field validation. Force reclaims `.image` from stale
+// strategic-merge self-upgrades that recorded ownership as (helm, Update).
 //
 // Extracted for tripwire test; if a refactor reverts these values, the
 // test in selfupgrade_test.go fails before the bug ships.
 func selfUpgradePatchOptions() metav1.PatchOptions {
-	return metav1.PatchOptions{FieldManager: "helm"}
+	force := true
+	return metav1.PatchOptions{FieldManager: "helm", Force: &force}
 }
 
 // handleSelfUpgrade patches this Radar Deployment's container image so the
 // pod restarts on a new version. Called by Radar Cloud's upgrade-agent endpoint
 // over the yamux tunnel — no user terminal or cloud credentials needed.
 //
-// Security: only images under ghcr.io/skyhook-io/radar: are accepted.
-// The patch uses the pod's ServiceAccount (not user impersonation) — the SA
-// must have patch rights on its own Deployment (Helm rbac.selfUpgrade: true).
-// MY_POD_NAMESPACE and MY_DEPLOYMENT_NAME must be set by the chart (downward
-// API + static template value respectively) or the endpoint returns 503.
+// Security: only images under ghcr.io/skyhook-io/radar: are accepted. The
+// apply body is the Helm release's rendered Deployment with only that image
+// swapped, so the SA must also be able to read Helm release storage and patch
+// its own Deployment (Helm rbac.selfUpgrade: true). MY_POD_NAMESPACE and
+// MY_DEPLOYMENT_NAME must be set by the chart (downward API + static template
+// value respectively) or the endpoint returns 503.
 func (s *Server) handleSelfUpgrade(w http.ResponseWriter, r *http.Request) {
 	ns := os.Getenv("MY_POD_NAMESPACE")
 	deployment := os.Getenv("MY_DEPLOYMENT_NAME")
@@ -68,7 +70,7 @@ func (s *Server) handleSelfUpgrade(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	tag := strings.TrimPrefix(req.Image, allowedRepo)
-	if tag == "" || len(tag) > 64 {
+	if !isValidRadarImageTag(tag) {
 		s.writeError(w, http.StatusBadRequest, "invalid image tag")
 		return
 	}
@@ -83,15 +85,35 @@ func (s *Server) handleSelfUpgrade(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	patch := []byte(fmt.Sprintf(
-		`{"spec":{"template":{"spec":{"containers":[{"name":"radar","image":%q}]}}}}`,
-		req.Image,
-	))
+	deploy, err := client.AppsV1().Deployments(ns).Get(r.Context(), deployment, metav1.GetOptions{})
+	if err != nil {
+		switch {
+		case apierrors.IsNotFound(err):
+			s.writeError(w, http.StatusNotFound, "deployment not found")
+		case apierrors.IsForbidden(err):
+			s.writeError(w, http.StatusForbidden, "SA lacks get permission on this Deployment (rbac.selfUpgrade=true?)")
+		default:
+			log.Printf("[self-upgrade] get deployment failed: ns=%s deploy=%s tag=%s err=%v", ns, deployment, logsafe.Sanitize(tag), err)
+			s.writeError(w, http.StatusInternalServerError, "deployment lookup failed")
+		}
+		return
+	}
+	releaseName := deploy.Annotations["meta.helm.sh/release-name"]
+	if releaseName == "" {
+		releaseName = deployment
+	}
 
-	_, err := client.AppsV1().Deployments(ns).Patch(
+	patch, err := selfUpgradeApplyPatch(ns, releaseName, deployment, req.Image)
+	if err != nil {
+		log.Printf("[self-upgrade] failed to build apply patch: ns=%s deploy=%s tag=%s err=%v", ns, deployment, logsafe.Sanitize(tag), err)
+		s.writeError(w, http.StatusServiceUnavailable, "helm release manifest not available")
+		return
+	}
+
+	_, err = client.AppsV1().Deployments(ns).Patch(
 		r.Context(),
 		deployment,
-		types.StrategicMergePatchType,
+		types.ApplyPatchType,
 		patch,
 		selfUpgradePatchOptions(),
 	)
@@ -102,22 +124,117 @@ func (s *Server) handleSelfUpgrade(w http.ResponseWriter, r *http.Request) {
 		case apierrors.IsForbidden(err):
 			s.writeError(w, http.StatusForbidden, "SA lacks patch permission on this Deployment (rbac.selfUpgrade=true?)")
 		case apierrors.IsConflict(err):
-			// A concurrent helm upgrade or apply can race the patch.
-			// Retryable on the caller's side. (We could reclaim
-			// ownership via server-side apply, but the StrategicMerge
-			// path keeps the request small and a retry is cheap.)
+			// Force=true handles field-manager conflicts. A remaining
+			// conflict here means a concurrent write raced this apply.
 			s.writeError(w, http.StatusConflict, "concurrent modification, retry")
 		case apierrors.IsTooManyRequests(err) || apierrors.IsServerTimeout(err):
 			s.writeError(w, http.StatusServiceUnavailable, "apiserver throttled, retry")
 		case apierrors.IsInvalid(err):
 			s.writeError(w, http.StatusBadRequest, "invalid patch")
 		default:
-			log.Printf("[self-upgrade] patch failed: ns=%s deploy=%s tag=%s err=%v", ns, deployment, tag, err)
+			log.Printf("[self-upgrade] patch failed: ns=%s deploy=%s tag=%s err=%v", ns, deployment, logsafe.Sanitize(tag), err)
 			s.writeError(w, http.StatusInternalServerError, "patch failed")
 		}
 		return
 	}
 
-	log.Printf("[self-upgrade] initiated: ns=%s deploy=%s tag=%s", ns, deployment, tag)
+	log.Printf("[self-upgrade] initiated: ns=%s deploy=%s tag=%s", ns, deployment, logsafe.Sanitize(tag))
 	s.writeJSON(w, map[string]string{"status": "upgrade initiated", "image": req.Image})
+}
+
+func isValidRadarImageTag(tag string) bool {
+	return radarImageTagPattern.MatchString(tag)
+}
+
+func selfUpgradeApplyPatch(namespace, releaseName, deployment, image string) ([]byte, error) {
+	helmClient := helm.GetClient()
+	if helmClient == nil {
+		return nil, fmt.Errorf("helm client not initialized")
+	}
+
+	manifest, err := helmClient.GetManifest(namespace, releaseName, 0)
+	if err != nil {
+		return nil, fmt.Errorf("get release manifest: %w", err)
+	}
+
+	return buildSelfUpgradeApplyPatch(manifest, namespace, releaseName, deployment, image)
+}
+
+func buildSelfUpgradeApplyPatch(manifest, namespace, releaseName, deployment, image string) ([]byte, error) {
+	for _, doc := range releaseutil.SplitManifests(manifest) {
+		var obj map[string]any
+		if err := yaml.Unmarshal([]byte(doc), &obj); err != nil {
+			return nil, fmt.Errorf("parse manifest document: %w", err)
+		}
+		if len(obj) == 0 || obj["apiVersion"] != "apps/v1" || obj["kind"] != "Deployment" {
+			continue
+		}
+
+		metadata, ok := obj["metadata"].(map[string]any)
+		if !ok || metadata["name"] != deployment {
+			continue
+		}
+		if manifestNamespace, ok := metadata["namespace"].(string); ok && manifestNamespace != "" && manifestNamespace != namespace {
+			continue
+		}
+
+		if err := setContainerImage(obj, "radar", image); err != nil {
+			return nil, err
+		}
+
+		metadata["namespace"] = namespace
+		annotations, ok := metadata["annotations"].(map[string]any)
+		if !ok {
+			annotations = map[string]any{}
+			metadata["annotations"] = annotations
+		}
+		annotations["meta.helm.sh/release-name"] = releaseName
+		annotations["meta.helm.sh/release-namespace"] = namespace
+		return json.Marshal(obj)
+	}
+
+	return nil, fmt.Errorf("deployment %s/%s not found in helm manifest", namespace, deployment)
+}
+
+func setContainerImage(obj map[string]any, containerName, image string) error {
+	containers, ok, err := nestedSlice(obj, "spec", "template", "spec", "containers")
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("deployment manifest has no containers")
+	}
+
+	for _, item := range containers {
+		container, ok := item.(map[string]any)
+		if !ok {
+			return fmt.Errorf("deployment manifest contains a non-object container")
+		}
+		if container["name"] == containerName {
+			container["image"] = image
+			return nil
+		}
+	}
+
+	return fmt.Errorf("container %q not found in deployment manifest", containerName)
+}
+
+func nestedSlice(obj map[string]any, fields ...string) ([]any, bool, error) {
+	var current any = obj
+	for _, field := range fields {
+		currentMap, ok := current.(map[string]any)
+		if !ok {
+			return nil, false, fmt.Errorf("manifest path %q is not an object", field)
+		}
+		current, ok = currentMap[field]
+		if !ok {
+			return nil, false, nil
+		}
+	}
+
+	items, ok := current.([]any)
+	if !ok {
+		return nil, false, fmt.Errorf("manifest path %q is not a list", strings.Join(fields, "."))
+	}
+	return items, true, nil
 }

--- a/internal/server/selfupgrade_test.go
+++ b/internal/server/selfupgrade_test.go
@@ -1,21 +1,165 @@
 package server
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
-// TestSelfUpgradePatchOptions is a tripwire: it pins the PatchOptions used
-// by handleSelfUpgrade. FieldManager "helm" is what prevents the apiserver
-// from recording "radar" as the owner of .image (derived from User-Agent
-// when FieldManager is empty), which would break every later `helm
-// upgrade` with a server-side-apply conflict. Force MUST stay unset on a
-// StrategicMergePatch — apimachinery rejects it with a 422 Invalid so
-// flipping Force back on regresses self-upgrade to "always fails."
-// See selfupgrade.go for the full rationale.
+// TestSelfUpgradePatchOptions is a tripwire: handleSelfUpgrade must use
+// Server-Side Apply as Helm's field manager and force-conflicts to reclaim
+// .image from old strategic-merge self-upgrades.
 func TestSelfUpgradePatchOptions(t *testing.T) {
 	opts := selfUpgradePatchOptions()
 	if opts.FieldManager != "helm" {
 		t.Errorf("FieldManager = %q, want %q", opts.FieldManager, "helm")
 	}
-	if opts.Force != nil {
-		t.Errorf("Force = %v, want nil (Force is forbidden on StrategicMergePatch and a non-nil value 422s the request)", opts.Force)
+	if opts.Force == nil || !*opts.Force {
+		t.Errorf("Force = %v, want non-nil true", opts.Force)
 	}
+}
+
+func TestIsValidRadarImageTag(t *testing.T) {
+	tests := []struct {
+		name string
+		tag  string
+		want bool
+	}{
+		{name: "semver", tag: "1.6.2", want: true},
+		{name: "underscore and dash", tag: "v1_6-rc.1", want: true},
+		{name: "empty", tag: "", want: false},
+		{name: "too long", tag: "12345678901234567890123456789012345678901234567890123456789012345", want: false},
+		{name: "starts with dot", tag: ".1.6.2", want: false},
+		{name: "newline injection", tag: "1.6.2\nlevel=error", want: false},
+		{name: "space injection", tag: "1.6.2 level=error", want: false},
+		{name: "slash", tag: "release/1.6.2", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidRadarImageTag(tt.tag); got != tt.want {
+				t.Fatalf("isValidRadarImageTag(%q) = %v, want %v", tt.tag, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildSelfUpgradeApplyPatchUsesFullHelmDeploymentManifest(t *testing.T) {
+	manifest := `---
+# Source: radar/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: radar
+---
+# Source: radar/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: radar
+  labels:
+    app.kubernetes.io/name: radar
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: radar
+      app.kubernetes.io/instance: radar
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: radar
+        app.kubernetes.io/instance: radar
+    spec:
+      serviceAccountName: radar
+      containers:
+        - name: radar
+          image: "ghcr.io/skyhook-io/radar:1.6.1"
+          imagePullPolicy: IfNotPresent
+        - name: sidecar
+          image: "example.com/sidecar:v1"
+`
+
+	patch, err := buildSelfUpgradeApplyPatch(manifest, "radar", "radar", "radar", "ghcr.io/skyhook-io/radar:1.6.2")
+	if err != nil {
+		t.Fatalf("buildSelfUpgradeApplyPatch() error = %v", err)
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal(patch, &obj); err != nil {
+		t.Fatalf("patch is not valid JSON: %v", err)
+	}
+
+	if got := nestedString(t, obj, "metadata", "namespace"); got != "radar" {
+		t.Errorf("metadata.namespace = %q, want radar", got)
+	}
+	if got := nestedString(t, obj, "metadata", "annotations", "meta.helm.sh/release-name"); got != "radar" {
+		t.Errorf("release-name annotation = %q, want radar", got)
+	}
+	if got := nestedString(t, obj, "metadata", "annotations", "meta.helm.sh/release-namespace"); got != "radar" {
+		t.Errorf("release-namespace annotation = %q, want radar", got)
+	}
+	if got := nestedFloat(t, obj, "spec", "replicas"); got != 1 {
+		t.Errorf("spec.replicas = %v, want 1", got)
+	}
+	if got := nestedString(t, obj, "spec", "selector", "matchLabels", "app.kubernetes.io/name"); got != "radar" {
+		t.Errorf("selector label = %q, want radar", got)
+	}
+	if got := nestedString(t, obj, "spec", "template", "spec", "serviceAccountName"); got != "radar" {
+		t.Errorf("serviceAccountName = %q, want radar", got)
+	}
+
+	containers, ok, err := nestedSlice(obj, "spec", "template", "spec", "containers")
+	if err != nil || !ok {
+		t.Fatalf("containers lookup ok=%v err=%v", ok, err)
+	}
+	if got := containers[0].(map[string]any)["image"]; got != "ghcr.io/skyhook-io/radar:1.6.2" {
+		t.Errorf("radar image = %q, want upgraded image", got)
+	}
+	if got := containers[0].(map[string]any)["imagePullPolicy"]; got != "IfNotPresent" {
+		t.Errorf("radar imagePullPolicy = %q, want preserved", got)
+	}
+	if got := containers[1].(map[string]any)["image"]; got != "example.com/sidecar:v1" {
+		t.Errorf("sidecar image = %q, want unchanged", got)
+	}
+}
+
+func TestBuildSelfUpgradeApplyPatchRejectsMissingDeployment(t *testing.T) {
+	_, err := buildSelfUpgradeApplyPatch("apiVersion: v1\nkind: Service\nmetadata:\n  name: radar\n", "radar", "radar", "radar", "ghcr.io/skyhook-io/radar:1.6.2")
+	if err == nil {
+		t.Fatal("buildSelfUpgradeApplyPatch() error = nil, want missing deployment error")
+	}
+}
+
+func nestedString(t *testing.T, obj map[string]any, fields ...string) string {
+	t.Helper()
+	var current any = obj
+	for _, field := range fields {
+		currentMap, ok := current.(map[string]any)
+		if !ok {
+			t.Fatalf("path %v: %q is not an object", fields, field)
+		}
+		current = currentMap[field]
+	}
+	value, ok := current.(string)
+	if !ok {
+		t.Fatalf("path %v: value is %T, want string", fields, current)
+	}
+	return value
+}
+
+func nestedFloat(t *testing.T, obj map[string]any, fields ...string) float64 {
+	t.Helper()
+	var current any = obj
+	for _, field := range fields {
+		currentMap, ok := current.(map[string]any)
+		if !ok {
+			t.Fatalf("path %v: %q is not an object", fields, field)
+		}
+		current = currentMap[field]
+	}
+	value, ok := current.(float64)
+	if !ok {
+		t.Fatalf("path %v: value is %T, want number", fields, current)
+	}
+	return value
 }


### PR DESCRIPTION
## Summary

Radar self-upgrade now patches its Deployment with Server-Side Apply using Helm's field manager and the full Deployment manifest from the Helm release. This keeps ownership in Helm's apply field set while updating only the Radar container image, preserves Helm release ownership annotations, and force-conflicts reclaims image ownership from clusters that already ran the strategic-merge self-upgrade path.

This prevents later `helm upgrade --install` runs from failing on managedFields conflicts after a Cloud-triggered agent upgrade, without requiring install commands to use `--force-conflicts` going forward.

## Verification

- `go test ./internal/server/ -run 'Test(SelfUpgradePatchOptions|BuildSelfUpgradeApplyPatch)' -v`
- `go build ./internal/server/...`
- `git diff --check`
- Server-side dry-run against an affected cluster: full Helm Deployment manifest apply with `--field-manager=helm --force-conflicts` succeeded and preserved `meta.helm.sh/*` annotations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the self-upgrade mechanism to read Helm release manifests and apply a full Deployment via server-side apply with `Force`, which could fail if RBAC/Helm storage access or manifest parsing behaves unexpectedly in some clusters.
> 
> **Overview**
> Self-upgrade no longer does a small strategic-merge `.image` patch; it now builds a **server-side apply** payload from the Helm release’s rendered Deployment manifest and applies it with `FieldManager=helm` and `Force=true` to reclaim `.image` ownership and prevent later `helm upgrade` managedFields conflicts.
> 
> The endpoint now fetches the current Deployment to derive the Helm `release-name`, requires access to Helm release storage, tightens tag validation via a regex, sanitizes tag values in logs, and adds tests covering patch options, tag validation, and manifest-to-apply-patch construction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efbe3fc503852dd01604f6a8cce84d740579ea28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

