### PR TITLE
perf(topology): instrumentation + summary mode for large clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ web/package.json.md5
 .env
 .env.local
 dist/
+
+# Visual-test + scratch artifacts
+.playwright-mcp/
+tmp/

--- a/internal/server/diagnostics.go
+++ b/internal/server/diagnostics.go
@@ -15,6 +15,7 @@ import (
 	"github.com/skyhook-io/radar/internal/traffic"
 	"github.com/skyhook-io/radar/internal/version"
 	"github.com/skyhook-io/radar/pkg/k8score"
+	"github.com/skyhook-io/radar/pkg/perfstats"
 )
 
 // DiagConfig holds sanitized configuration for the diagnostics endpoint.
@@ -54,6 +55,7 @@ type DiagnosticsSnapshot struct {
 	Permissions         *DiagPermissions             `json:"permissions,omitempty"`
 	APIDiscovery        *DiagAPIDiscovery            `json:"apiDiscovery,omitempty"`
 	SSE                 *DiagSSE                     `json:"sse,omitempty"`
+	Perf                *perfstats.Snapshot          `json:"perf,omitempty"`
 	Runtime             *DiagRuntime                 `json:"runtime,omitempty"`
 	Config              *DiagConfig                  `json:"config,omitempty"`
 	RecentErrors        []errorlog.ErrorEntry        `json:"recentErrors,omitempty"`
@@ -470,6 +472,14 @@ func (s *Server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
 		snap.SSE = &DiagSSE{
 			ConnectedClients: s.broadcaster.ClientCount(),
 		}
+	})
+
+	// Perf — always-on counters + sample windows for topology build/SSE
+	// behavior at scale. Cheap to collect (atomic loads + copy of a
+	// 100-entry ring buffer per metric).
+	collectSafe("perf", &errs, func() {
+		perf := perfstats.GetSnapshot()
+		snap.Perf = &perf
 	})
 
 	// Runtime

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -42,6 +42,7 @@ import (
 	"github.com/skyhook-io/radar/internal/timeline"
 	"github.com/skyhook-io/radar/internal/updater"
 	"github.com/skyhook-io/radar/internal/version"
+	"github.com/skyhook-io/radar/pkg/perfstats"
 	"github.com/skyhook-io/radar/pkg/rbac"
 	topology "github.com/skyhook-io/radar/pkg/topology"
 )
@@ -943,7 +944,16 @@ func (s *Server) handleTopology(w http.ResponseWriter, r *http.Request) {
 		topo.StripNodeKinds(deny)
 	}
 
-	s.writeJSON(w, topo)
+	// Marshal once so we can record the exact wire size in perfstats.
+	// (writeJSON streams, which would force a counting-writer wrapper.)
+	data, err := json.Marshal(topo)
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	perfstats.RecordTopologyPayload(len(data))
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(data)
 }
 
 func (s *Server) handleNamespaces(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -563,6 +563,11 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() {
 		b.cachedTopologyMu.Lock()
 		b.cachedTopologyDirty = true
 		b.cachedTopologyMu.Unlock()
+		// Forget the last cycle's estimate so a future session doesn't inherit
+		// a disconnected session's debounce (a small namespace shouldn't keep a
+		// big one's 15s cadence). topologyDebounceFor falls back to the resource-
+		// count proxy until the next broadcast records a real estimate.
+		b.lastBroadcastMaxEstimated.Store(0)
 		return
 	}
 

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -30,11 +30,11 @@ type SSEBroadcaster struct {
 
 	// lastBroadcastMaxEstimated holds the max EstimatedNodes across all
 	// per-group topology builds in the most recent broadcast cycle. Drives
-	// the debounce ladder (see topologyDebounceFor). Sourced here — not
-	// from perfstats — because perfstats' 100-sample ring buffer keeps a
-	// single 5k-pod-namespace visit visible for ~8 minutes after the user
-	// switches away, which produced sticky-high debounce post-namespace-
-	// switch. This reflects only currently-active client groups.
+	// the debounce ladder (see topologyDebounceFor). It reflects only the
+	// currently-active client groups: a sample window over recent builds
+	// would let a brief visit to a big namespace keep the debounce
+	// sticky-high long after the user filtered to a small one, whereas this
+	// settles within one cycle of a namespace switch.
 	lastBroadcastMaxEstimated atomic.Int64
 
 	// watchStopCh is closed to stop the current watchResourceChanges goroutine.
@@ -88,9 +88,9 @@ type SSEEvent struct {
 // The lastBroadcastMaxEstimated input reflects only currently-active client
 // groups, which means a namespace switch settles within one debounce cycle
 // (the next broadcast updates the value, and the cycle after that uses the
-// fresh value). A historical max — eg. from perfstats' 100-sample ring —
-// would keep a brief stint on a big namespace visible for ~8 minutes after
-// the user switched away.
+// fresh value). A max taken over a sample window of recent builds would
+// instead keep a brief stint on a big namespace visible for many cycles
+// after the user switched away.
 func topologyDebounceFor(lastBroadcastMaxEstimated int64, cache interface{ GetResourceCount() int }) time.Duration {
 	estimated := lastBroadcastMaxEstimated
 	if estimated == 0 && cache != nil {

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -9,9 +9,11 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/pkg/perfstats"
 	topology "github.com/skyhook-io/radar/pkg/topology"
 )
 
@@ -25,6 +27,15 @@ type SSEBroadcaster struct {
 	unregister chan chan SSEEvent
 	mu         sync.RWMutex
 	stopCh     chan struct{}
+
+	// lastBroadcastMaxEstimated holds the max EstimatedNodes across all
+	// per-group topology builds in the most recent broadcast cycle. Drives
+	// the debounce ladder (see topologyDebounceFor). Sourced here — not
+	// from perfstats — because perfstats' 100-sample ring buffer keeps a
+	// single 5k-pod-namespace visit visible for ~8 minutes after the user
+	// switches away, which produced sticky-high debounce post-namespace-
+	// switch. This reflects only currently-active client groups.
+	lastBroadcastMaxEstimated atomic.Int64
 
 	// watchStopCh is closed to stop the current watchResourceChanges goroutine.
 	// On context switch, it is replaced with a fresh channel to restart the watcher.
@@ -62,6 +73,45 @@ type SSEEvent struct {
 	Data  any    `json:"data"`
 }
 
+// topologyDebounceFor returns the topology-broadcast debounce duration based
+// on the max estimated topology node count across the most recent broadcast
+// cycle's per-group builds. Falls back to a crude derivation from total
+// resource count before the first broadcast (or when all clients have been
+// disconnected for an entire cycle).
+//
+// Ladder: ≤500 → 1s, ≤2000 → 2s, ≤5000 → 5s, >5000 → 15s. Minimum is 1s by
+// design — even at the smallest cluster scale we don't need faster topology
+// refreshes than that, and SSE k8s_event frames (which fire immediately, not
+// on this debounce) cover the case where the user wants to see individual
+// resource state changes in real time.
+//
+// The lastBroadcastMaxEstimated input reflects only currently-active client
+// groups, which means a namespace switch settles within one debounce cycle
+// (the next broadcast updates the value, and the cycle after that uses the
+// fresh value). A historical max — eg. from perfstats' 100-sample ring —
+// would keep a brief stint on a big namespace visible for ~8 minutes after
+// the user switched away.
+func topologyDebounceFor(lastBroadcastMaxEstimated int64, cache interface{ GetResourceCount() int }) time.Duration {
+	estimated := lastBroadcastMaxEstimated
+	if estimated == 0 && cache != nil {
+		// No broadcasts recorded yet, or no clients connected during the
+		// last cycle. Use raw resource count divided by 5 as a crude proxy —
+		// most resources don't become topology nodes (events, secrets,
+		// configmaps).
+		estimated = int64(cache.GetResourceCount()) / 5
+	}
+	switch {
+	case estimated > 5000:
+		return 15 * time.Second
+	case estimated > 2000:
+		return 5 * time.Second
+	case estimated > 500:
+		return 2 * time.Second
+	default:
+		return 1 * time.Second
+	}
+}
+
 // safeSend sends an event to a channel, recovering from panic if the channel is closed
 func safeSend(ch chan SSEEvent, event SSEEvent) {
 	defer func() {
@@ -70,7 +120,9 @@ func safeSend(ch chan SSEEvent, event SSEEvent) {
 	select {
 	case ch <- event:
 	default:
-		// Channel full, skip
+		// Channel full, skip. Counted in perfstats so users can see drops
+		// in /api/diagnostics without enabling any flag.
+		perfstats.IncSSEDrop()
 	}
 }
 
@@ -412,14 +464,16 @@ func (b *SSEBroadcaster) watchResourceChanges() {
 	//   jump on every arrival, so we coalesce into 5s windows. The UI is
 	//   already on the home view by this point with a "loading more" hint;
 	//   the slight delay is preferable to a fidgety graph.
-	// - After warmup: re-evaluate based on cluster size. Large clusters (>5000
-	//   resources) use 5s; smaller clusters use 500ms.
+	// - After warmup: scale debounce by the estimated topology node count
+	//   from the most recent builds (the same signal driving the in-builder
+	//   large-cluster optimizations). Minimum 1s — even at small scale we
+	//   don't need faster topology refreshes than that.
 	const warmupDebounce = 5 * time.Second
-	debounceDuration := warmupDebounce
 	b.watchMu.Lock()
 	warmupCh := b.warmupDone // local copy under lock; nil-ed after firing to avoid closed-channel spin
 	b.watchMu.Unlock()
-	log.Printf("SSE watcher: using %v warmup debounce until initial sync completes", debounceDuration)
+	warmupComplete := false
+	log.Printf("SSE watcher: using %v warmup debounce until initial sync completes", warmupDebounce)
 
 	debounceTimer := time.NewTimer(0)
 	<-debounceTimer.C // drain initial timer
@@ -434,15 +488,9 @@ func (b *SSEBroadcaster) watchResourceChanges() {
 			return
 
 		case <-warmupCh:
-			// Warmup complete — re-evaluate debounce based on actual cluster size
 			warmupCh = nil // prevent closed-channel spin on next iteration
-			resourceCount := cache.GetResourceCount()
-			if resourceCount > 5000 {
-				debounceDuration = 5 * time.Second
-			} else {
-				debounceDuration = 500 * time.Millisecond
-			}
-			log.Printf("SSE watcher: warmup complete (%d resources), switching to %v debounce", resourceCount, debounceDuration)
+			warmupComplete = true
+			log.Printf("SSE watcher: warmup complete (%d resources), debounce now dynamic by estimated node count (min 1s)", cache.GetResourceCount())
 
 		case change, ok := <-changes:
 			if !ok {
@@ -472,9 +520,18 @@ func (b *SSEBroadcaster) watchResourceChanges() {
 				})
 			}
 
-			// Schedule debounced topology update
+			// Schedule debounced topology update. Re-evaluate debounce on
+			// every reset so a cluster that grows past a ladder threshold
+			// starts coalescing more aggressively without restart, and so
+			// a namespace switch (which changes the active client groups
+			// and therefore the next broadcast's max estimate) settles
+			// within one debounce cycle.
 			if !pendingUpdate {
-				debounceTimer.Reset(debounceDuration)
+				dur := warmupDebounce
+				if warmupComplete {
+					dur = topologyDebounceFor(b.lastBroadcastMaxEstimated.Load(), cache)
+				}
+				debounceTimer.Reset(dur)
 				pendingUpdate = true
 			}
 
@@ -510,6 +567,11 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() {
 	}
 
 	log.Printf("Broadcasting topology update to %d clients", len(clients))
+
+	// One broadcast cycle = one debounce fire that reaches clients. Counted
+	// here (not in the per-group loop below) so the metric reflects cycles,
+	// not the number of distinct namespace/view/policy groups.
+	perfstats.IncSSEBroadcast()
 
 	// During warmup, skip the expensive full-topology cache build. Nobody is
 	// clicking into resource details while the connecting spinner is showing,
@@ -551,7 +613,13 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() {
 		clientGroups[key].channels = append(clientGroups[key].channels, ch)
 	}
 
-	// Build topology for each group and send
+	// Build topology for each group and send. Pre-marshal once per group so
+	// the same bytes go out to every client in the group (the per-client SSE
+	// writer would otherwise re-marshal the same large topology N times).
+	// Also gives us a single point to record payload bytes and the max
+	// estimated node count across active groups — the latter drives the
+	// next cycle's debounce ladder.
+	var maxEstimated int64
 	for key, group := range clientGroups {
 		opts := topology.DefaultBuildOptions()
 		opts.Namespaces = group.namespaces
@@ -566,15 +634,31 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() {
 			continue
 		}
 
+		if int64(topo.EstimatedNodes) > maxEstimated {
+			maxEstimated = int64(topo.EstimatedNodes)
+		}
+
+		data, marshalErr := json.Marshal(topo)
+		if marshalErr != nil {
+			log.Printf("Error marshaling topology for broadcast: %v", marshalErr)
+			continue
+		}
+		perfstats.RecordTopologyPayload(len(data))
+
 		event := SSEEvent{
 			Event: "topology",
-			Data:  topo,
+			Data:  json.RawMessage(data),
 		}
 
 		for _, ch := range group.channels {
 			safeSend(ch, event)
 		}
 	}
+
+	// Store the max for the next cycle's debounce decision. Stored even
+	// when maxEstimated stayed 0 (eg. every build errored) — that just
+	// falls through to the bootstrap proxy in topologyDebounceFor.
+	b.lastBroadcastMaxEstimated.Store(maxEstimated)
 }
 
 // heartbeat sends periodic heartbeats to keep connections alive

--- a/internal/server/sse_debounce_test.go
+++ b/internal/server/sse_debounce_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+type fakeResourceCache struct{ count int }
+
+func (f fakeResourceCache) GetResourceCount() int { return f.count }
+
+func TestTopologyDebounceForFallsBackToResourceCountBeforeFirstBroadcast(t *testing.T) {
+	cases := []struct {
+		name     string
+		count    int
+		expected time.Duration
+	}{
+		{"empty cluster", 0, 1 * time.Second},
+		{"small (count/5 ≤ 500)", 2500, 1 * time.Second},
+		{"medium (count/5 = 600)", 3000, 2 * time.Second},
+		{"large (count/5 = 3000)", 15000, 5 * time.Second},
+		{"huge (count/5 = 6000)", 30000, 15 * time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// lastBroadcastMaxEstimated=0 → fallback path
+			got := topologyDebounceFor(0, fakeResourceCache{count: tc.count})
+			if got != tc.expected {
+				t.Errorf("got %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestTopologyDebounceForUsesEstimatedNodesOnceBroadcast(t *testing.T) {
+	cases := []struct {
+		name      string
+		estimated int64
+		expected  time.Duration
+	}{
+		{"under 500", 100, 1 * time.Second},
+		{"500 boundary", 500, 1 * time.Second},
+		{"501–2000", 1500, 2 * time.Second},
+		{"2001–5000", 4000, 5 * time.Second},
+		{"over 5000", 8000, 15 * time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Resource count should be ignored once lastBroadcastMaxEstimated > 0
+			got := topologyDebounceFor(tc.estimated, fakeResourceCache{count: 999999})
+			if got != tc.expected {
+				t.Errorf("got %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}
+
+// TestTopologyDebounceForResetsAfterNamespaceSwitch verifies the property we
+// care about: a brief stint on a big namespace does NOT keep debounce sticky
+// after the user switches back to a small one. (The fix for the perfstats
+// historical-max bug: lastBroadcastMaxEstimated reflects only the current
+// broadcast cycle's builds, so one cycle of stale debounce after a switch
+// then it adapts.)
+func TestTopologyDebounceForResetsAfterNamespaceSwitch(t *testing.T) {
+	// User was viewing a 5000-pod namespace → debounce was 15s
+	big := topologyDebounceFor(5500, fakeResourceCache{count: 999999})
+	if big != 15*time.Second {
+		t.Errorf("expected 15s for 5500 estimated, got %v", big)
+	}
+	// After the next broadcast post-switch, lastBroadcastMaxEstimated reflects
+	// the new small namespace's build (eg. 80 nodes). Debounce should drop.
+	small := topologyDebounceFor(80, fakeResourceCache{count: 999999})
+	if small != 1*time.Second {
+		t.Errorf("expected 1s post-switch (estimated=80), got %v", small)
+	}
+}

--- a/packages/k8s-ui/src/components/topology/K8sResourceNode.tsx
+++ b/packages/k8s-ui/src/components/topology/K8sResourceNode.tsx
@@ -5,7 +5,7 @@ import {
   ChevronUp,
 } from 'lucide-react'
 import { clsx } from 'clsx'
-import type { NodeKind, HealthStatus } from '../../types'
+import type { NodeKind, HealthStatus, PodSummary } from '../../types'
 import { displayKind } from '../../types'
 import { healthToSeverity, SEVERITY_DOT } from '../../utils/badge-colors'
 import { Tooltip } from '../ui/Tooltip'
@@ -176,7 +176,7 @@ function getStatusStyle(status: HealthStatus): React.CSSProperties {
 // count of pods (and any unhealthy/pending) is still visible without children.
 function getSubtitle(kind: NodeKind, nodeData: Record<string, unknown>): string {
   const base = baseSubtitle(kind, nodeData)
-  const ps = nodeData.podSummary as { total: number; healthy: number; degraded: number; unhealthy: number } | undefined
+  const ps = nodeData.podSummary as PodSummary | undefined
   if (ps && SUMMARY_POD_KINDS.has(kind)) {
     let suffix = `${ps.total} pods`
     if (ps.unhealthy > 0) suffix += ` (${ps.unhealthy} unhealthy)`

--- a/packages/k8s-ui/src/components/topology/K8sResourceNode.tsx
+++ b/packages/k8s-ui/src/components/topology/K8sResourceNode.tsx
@@ -171,8 +171,27 @@ function getStatusStyle(status: HealthStatus): React.CSSProperties {
 }
 
 
-// Format subtitle based on node kind
+// Format subtitle based on node kind. In summary mode the pod tier is
+// collapsed, so workload/service nodes carry a podSummary — append it so the
+// count of pods (and any unhealthy/pending) is still visible without children.
 function getSubtitle(kind: NodeKind, nodeData: Record<string, unknown>): string {
+  const base = baseSubtitle(kind, nodeData)
+  const ps = nodeData.podSummary as { total: number; healthy: number; degraded: number; unhealthy: number } | undefined
+  if (ps && SUMMARY_POD_KINDS.has(kind)) {
+    let suffix = `${ps.total} pods`
+    if (ps.unhealthy > 0) suffix += ` (${ps.unhealthy} unhealthy)`
+    else if (ps.degraded > 0) suffix += ` (${ps.degraded} pending)`
+    return base ? `${base} • ${suffix}` : suffix
+  }
+  return base
+}
+
+// Kinds that own pods and therefore carry a podSummary in summary mode.
+const SUMMARY_POD_KINDS = new Set<NodeKind>([
+  'Deployment', 'StatefulSet', 'DaemonSet', 'Rollout', 'Job', 'Service',
+])
+
+function baseSubtitle(kind: NodeKind, nodeData: Record<string, unknown>): string {
   switch (kind) {
     case 'Deployment':
     case 'Rollout':

--- a/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
+++ b/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
@@ -446,12 +446,13 @@ export function TopologyGraph({
 
   // Structure key for change detection — includes groupLevels so chip↔cardGrid triggers relayout.
   //
-  // Uses an order-independent XOR fold of FNV-1a hashes per ID instead of
-  // sort+join. At 3000+ nodes the join allocated a ~50KB string every time
-  // (and the sort dominated for short ID arrays); the fold is O(n) with
-  // constant memory and detects the same structural changes (add/remove/
-  // rename). Pure reorders no longer trigger a layout, which is correct —
-  // ELK relayouts on reorder were wasted work.
+  // Uses an order-independent fold of per-ID hashes (see foldHash) instead of
+  // sort+join. At thousands of nodes the join allocated tens of KB of string
+  // every render (and the sort dominated for short ID arrays); the fold is
+  // O(n) with constant memory and detects the same structural changes
+  // (add/remove/rename) — combined with the element count in the key. Pure
+  // reorders no longer trigger a layout, which is correct: ELK relayouts on
+  // reorder were wasted work.
   const structureKey = useMemo(() => {
     const t0 = performance.now()
     const nodeHash = foldHash(workingNodes, n => n.id)

--- a/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
+++ b/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
@@ -588,9 +588,11 @@ export function TopologyGraph({
       // nodes (summary mode) hold counts only, so they get no expand affordance.
       const nodesWithHandlers = positionedNodes.map(node => {
         const isPodGroup = node.data?.kind === 'PodGroup'
-        const podsArray = (node.data as Record<string, unknown> | undefined)?.pods
-        const isExpandablePodGroup = isPodGroup && Array.isArray(podsArray) && podsArray.length > 0
         const nodeData = node.data?.nodeData as Record<string, unknown> | undefined
+        // The per-pod array lives on the backend node data (nodeData.pods).
+        // Summary-only orphan nodes omit it, so they get no expand affordance.
+        const podsArray = nodeData?.pods
+        const isExpandablePodGroup = isPodGroup && Array.isArray(podsArray) && podsArray.length > 0
         const expandedFromGroup = nodeData?.expandedFromGroup as string | undefined
 
         return {

--- a/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
+++ b/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
@@ -583,9 +583,13 @@ export function TopologyGraph({
         savedPositionsRef.current.set(node.id, node.position)
       }
 
-      // Add expand/collapse handlers to pod-related nodes
+      // Add expand/collapse handlers to pod-related nodes. Only PodGroups that
+      // actually carry a per-pod array are expandable — summary-only orphan
+      // nodes (summary mode) hold counts only, so they get no expand affordance.
       const nodesWithHandlers = positionedNodes.map(node => {
         const isPodGroup = node.data?.kind === 'PodGroup'
+        const podsArray = (node.data as Record<string, unknown> | undefined)?.pods
+        const isExpandablePodGroup = isPodGroup && Array.isArray(podsArray) && podsArray.length > 0
         const nodeData = node.data?.nodeData as Record<string, unknown> | undefined
         const expandedFromGroup = nodeData?.expandedFromGroup as string | undefined
 
@@ -593,9 +597,9 @@ export function TopologyGraph({
           ...node,
           data: {
             ...node.data,
-            onExpand: isPodGroup ? handleExpandPodGroup : undefined,
+            onExpand: isExpandablePodGroup ? handleExpandPodGroup : undefined,
             onCollapse: expandedFromGroup ? handleCollapsePodGroup : undefined,
-            isExpanded: isPodGroup ? expandedPodGroups.has(node.id) : undefined,
+            isExpanded: isExpandablePodGroup ? expandedPodGroups.has(node.id) : undefined,
           },
         }
       })

--- a/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
+++ b/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
@@ -20,7 +20,7 @@ import {
 import '@xyflow/react/dist/style.css'
 import { toCanvas } from 'html-to-image'
 
-import { AlertTriangle, Download, LayoutGrid, Loader2, Maximize, Minus, Pause, Play, Plus, RotateCw, Shield, Workflow } from 'lucide-react'
+import { AlertTriangle, Download, Layers, LayoutGrid, Loader2, Maximize, Minus, Pause, Play, Plus, RotateCw, Shield, Workflow } from 'lucide-react'
 import { PaneLoader } from '../ui/PaneLoader'
 import { Tooltip } from '../ui/Tooltip'
 import { useToast } from '../ui/Toast'
@@ -31,6 +31,8 @@ import { GroupNode } from './GroupNode'
 import { buildHierarchicalElkGraph, applyHierarchicalLayout, getGroupKey, type GroupDisplayLevel } from './layout'
 import type { Topology, TopologyNode, TopologyEdge, ViewMode, GroupingMode } from '../../types'
 import { pluralize } from '../../utils/pluralize'
+import { foldHash } from '../../utils/structure-hash'
+import { recordLayoutDuration, recordLayoutSkipped, recordStructureKeyDuration } from '../../perf'
 
 // Edge colors by type
 const EDGE_COLORS = {
@@ -442,13 +444,28 @@ export function TopologyGraph({
     if (topoNode) onNodeClick(topoNode)
   }, [topology, workingNodes, onNodeClick])
 
-  // Structure key for change detection — includes groupLevels so chip↔cardGrid triggers relayout
+  // Structure key for change detection — includes groupLevels so chip↔cardGrid triggers relayout.
+  //
+  // Uses an order-independent XOR fold of FNV-1a hashes per ID instead of
+  // sort+join. At 3000+ nodes the join allocated a ~50KB string every time
+  // (and the sort dominated for short ID arrays); the fold is O(n) with
+  // constant memory and detects the same structural changes (add/remove/
+  // rename). Pure reorders no longer trigger a layout, which is correct —
+  // ELK relayouts on reorder were wasted work.
   const structureKey = useMemo(() => {
-    const nodeIds = workingNodes.map(n => n.id).sort().join(',')
-    const edgeIds = workingEdges.map(e => `${e.source}->${e.target}:${e.type}`).sort().join(',')
-    const levels = Array.from(groupLevels.entries()).sort().map(([k, v]) => `${k}:${v}`).join(',')
-    const expanded = Array.from(expandedPodGroups).sort().join(',')
-    return `${viewMode}|${nodeIds}|${edgeIds}|${levels}|${expanded}|${groupingMode}|${layoutRetryCount}`
+    const t0 = performance.now()
+    const nodeHash = foldHash(workingNodes, n => n.id)
+    const edgeHash = foldHash(workingEdges, e => `${e.source}->${e.target}:${e.type}`)
+    const levelsHash = foldHash(Array.from(groupLevels.entries()), ([k, v]) => `${k}:${v}`)
+    const expandedHash = foldHash(Array.from(expandedPodGroups), s => s)
+    const key =
+      `${viewMode}|${groupingMode}|${layoutRetryCount}` +
+      `|n${workingNodes.length}:${nodeHash}` +
+      `|e${workingEdges.length}:${edgeHash}` +
+      `|l${groupLevels.size}:${levelsHash}` +
+      `|x${expandedPodGroups.size}:${expandedHash}`
+    recordStructureKeyDuration((performance.now() - t0) * 1000)
+    return key
   }, [viewMode, workingNodes, workingEdges, groupLevels, expandedPodGroups, groupingMode, layoutRetryCount])
 
   // Layout when structure changes - use hierarchical ELK layout
@@ -465,6 +482,7 @@ export function TopologyGraph({
     const structureChanged = structureKey !== prevStructureRef.current
 
     if (!structureChanged) {
+      recordLayoutSkipped()
       return
     }
 
@@ -517,6 +535,7 @@ export function TopologyGraph({
     groupMapRef.current = groupMap
 
     // Apply layout and get positioned nodes
+    const layoutStartMs = performance.now()
     applyHierarchicalLayout(
       elkGraph,
       workingNodes,
@@ -540,6 +559,7 @@ export function TopologyGraph({
         return
       }
       setLayoutError(null)
+      recordLayoutDuration(performance.now() - layoutStartMs, workingNodes.length, workingEdges.length)
 
       // Preserve positions for nodes that already have a saved position (i.e. were
       // present in a previous layout). New nodes use the ELK-computed position.
@@ -778,6 +798,15 @@ export function TopologyGraph({
               <p className="mt-1 text-xs text-theme-text-tertiary font-mono">{layoutError}</p>
             </div>
           </div>
+        </div>
+      )}
+      {/* Summary-mode pill — pod tier collapsed to per-workload/service counts */}
+      {topology?.summaryMode && (
+        <div className="absolute bottom-3 left-1/2 -translate-x-1/2 z-10 flex items-center gap-1.5 bg-blue-500/10 border border-blue-500/30 rounded-full px-3 py-1 backdrop-blur-sm">
+          <Layers className="w-3.5 h-3.5 text-blue-400 shrink-0" />
+          <span className="text-xs text-theme-text-secondary">
+            Summary view — pods collapsed to counts. Filter to a smaller namespace to see individual pods.
+          </span>
         </div>
       )}
       <ReactFlow

--- a/packages/k8s-ui/src/index.ts
+++ b/packages/k8s-ui/src/index.ts
@@ -45,3 +45,6 @@ export * from './components/cluster-switcher'
 
 // Compare (ResourceCompareView, CompareResourcePicker, normalize utilities)
 export * from './components/compare'
+
+// Perf instrumentation (ELK + structureKey timers, surfaced in diagnostics overlay)
+export * from './perf'

--- a/packages/k8s-ui/src/perf/index.ts
+++ b/packages/k8s-ui/src/perf/index.ts
@@ -1,0 +1,1 @@
+export * from './store'

--- a/packages/k8s-ui/src/perf/store.ts
+++ b/packages/k8s-ui/src/perf/store.ts
@@ -1,0 +1,110 @@
+// Always-on, in-memory performance instrumentation for k8s-ui internals.
+// Records ELK layout duration and structureKey rebuild duration so users can
+// include them in bug reports via the host app's diagnostics overlay.
+// Cost is one performance.now() pair + a 50-entry ring buffer append per
+// topology layout — negligible.
+
+const RING_SIZE = 50
+
+interface Ring {
+  samples: number[]
+  next: number
+  count: number
+  last: number
+}
+
+function makeRing(): Ring {
+  return { samples: new Array(RING_SIZE), next: 0, count: 0, last: 0 }
+}
+
+function ringAdd(r: Ring, v: number): void {
+  r.samples[r.next] = v
+  r.next = (r.next + 1) % RING_SIZE
+  if (r.count < RING_SIZE) r.count++
+  r.last = v
+}
+
+export interface SampleWindow {
+  count: number
+  last: number
+  min: number
+  p50: number
+  p95: number
+  p99: number
+  max: number
+}
+
+function ringSnapshot(r: Ring): SampleWindow {
+  if (r.count === 0) return { count: 0, last: 0, min: 0, p50: 0, p95: 0, p99: 0, max: 0 }
+  const buf = r.samples.slice(0, r.count).sort((a, b) => a - b)
+  const pick = (p: number) => buf[Math.min(buf.length - 1, Math.floor((buf.length - 1) * p))]
+  return {
+    count: r.count,
+    last: r.last,
+    min: buf[0],
+    p50: pick(0.5),
+    p95: pick(0.95),
+    p99: pick(0.99),
+    max: buf[buf.length - 1],
+  }
+}
+
+const layoutMs = makeRing()
+const structureKeyUs = makeRing()
+const lastLayoutNodeCount = { value: 0 }
+const lastLayoutEdgeCount = { value: 0 }
+let totalLayouts = 0
+let totalLayoutsSkipped = 0
+let totalStructureKeyComputes = 0
+
+export interface K8sUIPerfSnapshot {
+  totalLayouts: number
+  totalLayoutsSkipped: number
+  totalStructureKeyComputes: number
+  lastLayoutNodeCount: number
+  lastLayoutEdgeCount: number
+  layoutMs: SampleWindow
+  structureKeyUs: SampleWindow
+}
+
+export function recordLayoutDuration(ms: number, nodeCount: number, edgeCount: number): void {
+  totalLayouts++
+  ringAdd(layoutMs, ms)
+  lastLayoutNodeCount.value = nodeCount
+  lastLayoutEdgeCount.value = edgeCount
+}
+
+export function recordLayoutSkipped(): void {
+  totalLayoutsSkipped++
+}
+
+export function recordStructureKeyDuration(us: number): void {
+  totalStructureKeyComputes++
+  ringAdd(structureKeyUs, us)
+}
+
+export function getK8sUIPerfSnapshot(): K8sUIPerfSnapshot {
+  return {
+    totalLayouts,
+    totalLayoutsSkipped,
+    totalStructureKeyComputes,
+    lastLayoutNodeCount: lastLayoutNodeCount.value,
+    lastLayoutEdgeCount: lastLayoutEdgeCount.value,
+    layoutMs: ringSnapshot(layoutMs),
+    structureKeyUs: ringSnapshot(structureKeyUs),
+  }
+}
+
+// Test seam — reset all counters and windows. Not safe to call concurrently
+// with the record functions.
+export function resetK8sUIPerf(): void {
+  layoutMs.samples = new Array(RING_SIZE)
+  layoutMs.next = 0; layoutMs.count = 0; layoutMs.last = 0
+  structureKeyUs.samples = new Array(RING_SIZE)
+  structureKeyUs.next = 0; structureKeyUs.count = 0; structureKeyUs.last = 0
+  totalLayouts = 0
+  totalLayoutsSkipped = 0
+  totalStructureKeyComputes = 0
+  lastLayoutNodeCount.value = 0
+  lastLayoutEdgeCount.value = 0
+}

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -212,7 +212,17 @@ export interface Topology {
   largeCluster?: boolean // True if cluster exceeds large cluster threshold
   hiddenKinds?: string[] // Resource kinds auto-hidden for performance
   requiresNamespaceFilter?: boolean // True if cluster is too large for all-namespace topology
+  estimatedNodes?: number // Pre-build node count estimate
+  summaryMode?: boolean // True when the pod tier was collapsed into per-workload/service counts
   crdDiscoveryStatus?: 'idle' | 'discovering' | 'ready' // CRD discovery status
+}
+
+// PodSummary is stamped onto a workload or service node's data in summary mode.
+export interface PodSummary {
+  total: number
+  healthy: number
+  degraded: number
+  unhealthy: number
 }
 
 // K8s Event (from SSE stream)

--- a/packages/k8s-ui/src/utils/structure-hash.test.ts
+++ b/packages/k8s-ui/src/utils/structure-hash.test.ts
@@ -69,3 +69,26 @@ describe('foldHash', () => {
     expect(foldHash(['a', 'a'], id)).not.toBe(foldHash(['b', 'b'], id))
   })
 })
+
+// The production guard against skipped relayouts is the *composed* key
+// (count + foldHash), exactly as TopologyGraph builds it. These tests pin that
+// composition, not just the bare fold — a genuine same-count add/remove/rename
+// must change the composed key so the layout effect doesn't short-circuit.
+describe('composed structure key (count + foldHash)', () => {
+  const id = (s: string) => s
+  // Mirrors TopologyGraph's structureKey shape for the node portion.
+  const composed = (nodeIds: string[]) => `n${nodeIds.length}:${foldHash(nodeIds, id)}`
+
+  it('changes on a same-count rename', () => {
+    expect(composed(['a', 'b', 'c'])).not.toBe(composed(['a', 'b', 'x']))
+  })
+
+  it('changes on add and on remove', () => {
+    expect(composed(['a', 'b'])).not.toBe(composed(['a', 'b', 'c']))
+    expect(composed(['a', 'b', 'c'])).not.toBe(composed(['a', 'b']))
+  })
+
+  it('is stable across reorder (no wasted relayout)', () => {
+    expect(composed(['a', 'b', 'c'])).toBe(composed(['c', 'b', 'a']))
+  })
+})

--- a/packages/k8s-ui/src/utils/structure-hash.test.ts
+++ b/packages/k8s-ui/src/utils/structure-hash.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { fnv1a32, foldHash } from './structure-hash'
+
+describe('fnv1a32', () => {
+  it('is deterministic', () => {
+    expect(fnv1a32('hello')).toBe(fnv1a32('hello'))
+  })
+
+  it('distinguishes similar strings', () => {
+    expect(fnv1a32('pod/default/a')).not.toBe(fnv1a32('pod/default/b'))
+    expect(fnv1a32('a')).not.toBe(fnv1a32('A'))
+  })
+
+  it('handles empty string', () => {
+    expect(typeof fnv1a32('')).toBe('number')
+  })
+})
+
+describe('foldHash', () => {
+  const id = (s: string) => s
+
+  it('is order-independent', () => {
+    const a = foldHash(['a', 'b', 'c'], id)
+    const b = foldHash(['c', 'a', 'b'], id)
+    expect(a).toBe(b)
+  })
+
+  it('changes when an element is added', () => {
+    const before = foldHash(['a', 'b'], id)
+    const after = foldHash(['a', 'b', 'c'], id)
+    expect(before).not.toBe(after)
+  })
+
+  it('changes when an element is removed', () => {
+    const before = foldHash(['a', 'b', 'c'], id)
+    const after = foldHash(['a', 'b'], id)
+    expect(before).not.toBe(after)
+  })
+
+  it('changes when an element is renamed', () => {
+    const before = foldHash(['a', 'b', 'c'], id)
+    const after = foldHash(['a', 'b', 'd'], id)
+    expect(before).not.toBe(after)
+  })
+
+  it('returns the zero fingerprint for empty input', () => {
+    expect(foldHash([], id)).toBe('0.0')
+  })
+
+  it('works with object items via keyOf', () => {
+    const items = [{ id: 'x' }, { id: 'y' }]
+    expect(foldHash(items, i => i.id)).toBe(foldHash(['x', 'y'], id))
+  })
+
+  it('emits a "<xor>.<sum>" shape', () => {
+    expect(foldHash(['a', 'b'], id)).toMatch(/^\d+\.\d+$/)
+  })
+
+  // The dual accumulator's whole point: a swap that preserves the XOR fold
+  // (a^b stays constant) must still change the fingerprint via the sum fold.
+  // Single-XOR would have collided here. Construct two sets with equal XOR
+  // but different members.
+  it('distinguishes sets that share an XOR but differ in membership', () => {
+    // {x} vs {y, z} where hash(x) === hash(y) ^ hash(z) would collide under
+    // pure XOR. We can't easily force that, so instead verify the additive
+    // fold breaks a known XOR-preserving transform: doubling an element.
+    // ['a','a'] XOR-folds to 0 (a^a), same as [] — but sum differs.
+    expect(foldHash(['a', 'a'], id)).not.toBe(foldHash([], id))
+    expect(foldHash(['a', 'a'], id)).not.toBe(foldHash(['b', 'b'], id))
+  })
+})

--- a/packages/k8s-ui/src/utils/structure-hash.ts
+++ b/packages/k8s-ui/src/utils/structure-hash.ts
@@ -10,8 +10,8 @@ export function fnv1a32(s: string): number {
 
 // foldHash returns an order-independent fingerprint of the given items as a
 // "<xor>.<sum>" string. Used by TopologyGraph's structureKey change-detection
-// — at 10k+ nodes, sort+join over IDs allocated 50KB+ strings every render;
-// this is O(n) with two uint32 accumulators.
+// — at thousands of nodes, sort+join over IDs allocated tens of KB of string
+// every render; this is O(n) with two uint32 accumulators.
 //
 // Two independent commutative folds (XOR and 32-bit additive sum) are combined
 // because a single collision in the structure key is a false negative on the

--- a/packages/k8s-ui/src/utils/structure-hash.ts
+++ b/packages/k8s-ui/src/utils/structure-hash.ts
@@ -1,0 +1,35 @@
+// FNV-1a 32-bit string hash. Cheap, well-distributed, no allocations.
+export function fnv1a32(s: string): number {
+  let h = 0x811c9dc5
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  return h >>> 0
+}
+
+// foldHash returns an order-independent fingerprint of the given items as a
+// "<xor>.<sum>" string. Used by TopologyGraph's structureKey change-detection
+// — at 10k+ nodes, sort+join over IDs allocated 50KB+ strings every render;
+// this is O(n) with two uint32 accumulators.
+//
+// Two independent commutative folds (XOR and 32-bit additive sum) are combined
+// because a single collision in the structure key is a false negative on the
+// exact path that serves big, high-churn graphs: the layout effect bails on an
+// unchanged key, so a real shape change would silently skip setNodes/setEdges.
+// A collision now requires BOTH folds to collide simultaneously across the
+// difference set, which is vanishingly unlikely. Combine with element count
+// (caller composes "count.xor.sum") for full structural identity.
+//
+// Order independence is intentional: pure reorders of the same node/edge set
+// produce an identical graph and shouldn't trigger an ELK relayout.
+export function foldHash<T>(items: ArrayLike<T>, keyOf: (item: T) => string): string {
+  let xor = 0
+  let sum = 0
+  for (let i = 0; i < items.length; i++) {
+    const h = fnv1a32(keyOf(items[i]))
+    xor ^= h
+    sum = (sum + h) >>> 0
+  }
+  return `${xor >>> 0}.${sum}`
+}

--- a/pkg/perfstats/perfstats.go
+++ b/pkg/perfstats/perfstats.go
@@ -36,9 +36,8 @@ type TopologyStats struct {
 
 // SSEStats covers the SSE broadcaster.
 type SSEStats struct {
-	TotalBroadcasts         int64 `json:"totalBroadcasts"`
-	TotalDrops              int64 `json:"totalDrops"`
-	TotalTopologyOverwrites int64 `json:"totalTopologyOverwrites"`
+	TotalBroadcasts int64 `json:"totalBroadcasts"`
+	TotalDrops      int64 `json:"totalDrops"`
 }
 
 // SampleWindow is the rendered view of one ring buffer.
@@ -115,9 +114,8 @@ type store struct {
 	topologyPayloadBytes   ringBuffer
 	topologyEstimatedNodes ringBuffer
 
-	sseBroadcasts         atomic.Int64
-	sseDrops              atomic.Int64
-	sseTopologyOverwrites atomic.Int64
+	sseBroadcasts atomic.Int64
+	sseDrops      atomic.Int64
 }
 
 var global = &store{}
@@ -150,12 +148,6 @@ func IncSSEBroadcast() { global.sseBroadcasts.Add(1) }
 // IncSSEDrop increments the silent-drop counter (safeSend default case).
 func IncSSEDrop() { global.sseDrops.Add(1) }
 
-// IncSSETopologyOverwrite increments the count of topology snapshots that
-// were superseded by a newer snapshot before the client read them. Placeholder
-// for the 1C coalesce-latest design — wired now so the metric pre-exists
-// when the feature lands.
-func IncSSETopologyOverwrite() { global.sseTopologyOverwrites.Add(1) }
-
 // GetSnapshot returns a consistent point-in-time view of all counters
 // and sample windows for inclusion in /api/diagnostics responses.
 func GetSnapshot() Snapshot {
@@ -169,9 +161,8 @@ func GetSnapshot() Snapshot {
 			EstimatedNodes: global.topologyEstimatedNodes.snapshot(),
 		},
 		SSE: SSEStats{
-			TotalBroadcasts:         global.sseBroadcasts.Load(),
-			TotalDrops:              global.sseDrops.Load(),
-			TotalTopologyOverwrites: global.sseTopologyOverwrites.Load(),
+			TotalBroadcasts: global.sseBroadcasts.Load(),
+			TotalDrops:      global.sseDrops.Load(),
 		},
 	}
 }

--- a/pkg/perfstats/perfstats.go
+++ b/pkg/perfstats/perfstats.go
@@ -1,0 +1,183 @@
+// Package perfstats provides always-on, lightweight performance counters
+// and sample windows for the diagnostics endpoint. All operations are cheap
+// (atomic counter increment, or a fixed-size ring-buffer append under a
+// short-lived mutex) and safe to call from hot paths.
+//
+// The data shape is shared with the frontend diagnostics overlay so users
+// can include perf state in bug reports without enabling any flag.
+package perfstats
+
+import (
+	"slices"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// ringSize is the per-metric sample window. Sized so percentiles are
+// meaningful but memory stays trivial (100 × int64 = 800 bytes per metric).
+const ringSize = 100
+
+// Snapshot is the rendered view of all counters + sample windows.
+type Snapshot struct {
+	Topology TopologyStats `json:"topology"`
+	SSE      SSEStats      `json:"sse"`
+}
+
+// TopologyStats covers the topology build hot path.
+type TopologyStats struct {
+	TotalBuilds    int64        `json:"totalBuilds"`
+	DurationUs     SampleWindow `json:"durationUs"`
+	NodeCount      SampleWindow `json:"nodeCount"`
+	EdgeCount      SampleWindow `json:"edgeCount"`
+	PayloadBytes   SampleWindow `json:"payloadBytes"`
+	EstimatedNodes SampleWindow `json:"estimatedNodes"`
+}
+
+// SSEStats covers the SSE broadcaster.
+type SSEStats struct {
+	TotalBroadcasts         int64 `json:"totalBroadcasts"`
+	TotalDrops              int64 `json:"totalDrops"`
+	TotalTopologyOverwrites int64 `json:"totalTopologyOverwrites"`
+}
+
+// SampleWindow is the rendered view of one ring buffer.
+type SampleWindow struct {
+	Count int   `json:"count"` // samples in the window (capped at ringSize)
+	Last  int64 `json:"last"`
+	Min   int64 `json:"min"`
+	P50   int64 `json:"p50"`
+	P95   int64 `json:"p95"`
+	P99   int64 `json:"p99"`
+	Max   int64 `json:"max"`
+}
+
+type ringBuffer struct {
+	mu      sync.Mutex
+	samples [ringSize]int64
+	count   int
+	next    int
+	last    int64
+}
+
+func (r *ringBuffer) add(v int64) {
+	r.mu.Lock()
+	r.samples[r.next] = v
+	r.next = (r.next + 1) % ringSize
+	if r.count < ringSize {
+		r.count++
+	}
+	r.last = v
+	r.mu.Unlock()
+}
+
+func (r *ringBuffer) snapshot() SampleWindow {
+	r.mu.Lock()
+	n := r.count
+	last := r.last
+	if n == 0 {
+		r.mu.Unlock()
+		return SampleWindow{}
+	}
+	buf := make([]int64, n)
+	copy(buf, r.samples[:n])
+	r.mu.Unlock()
+
+	slices.Sort(buf)
+	return SampleWindow{
+		Count: n,
+		Last:  last,
+		Min:   buf[0],
+		P50:   percentile(buf, 0.50),
+		P95:   percentile(buf, 0.95),
+		P99:   percentile(buf, 0.99),
+		Max:   buf[n-1],
+	}
+}
+
+// percentile returns the value at the given quantile from a pre-sorted
+// slice using nearest-rank. Cheap and good enough for a 100-sample window.
+func percentile(sorted []int64, p float64) int64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := int(float64(len(sorted)-1) * p)
+	idx = max(idx, 0)
+	idx = min(idx, len(sorted)-1)
+	return sorted[idx]
+}
+
+type store struct {
+	topologyBuilds         atomic.Int64
+	topologyDuration       ringBuffer
+	topologyNodeCount      ringBuffer
+	topologyEdgeCount      ringBuffer
+	topologyPayloadBytes   ringBuffer
+	topologyEstimatedNodes ringBuffer
+
+	sseBroadcasts         atomic.Int64
+	sseDrops              atomic.Int64
+	sseTopologyOverwrites atomic.Int64
+}
+
+var global = &store{}
+
+// RecordTopologyBuild records one topology build's duration and the
+// resulting graph size, plus the estimator's pre-build node count guess
+// (the same value used to drive large-cluster optimizations and debounce
+// tuning — exposing it here lets us see when the estimator drifts from
+// reality).
+func RecordTopologyBuild(d time.Duration, nodes, edges, estimated int) {
+	global.topologyBuilds.Add(1)
+	global.topologyDuration.add(d.Microseconds())
+	global.topologyNodeCount.add(int64(nodes))
+	global.topologyEdgeCount.add(int64(edges))
+	global.topologyEstimatedNodes.add(int64(estimated))
+}
+
+// RecordTopologyPayload records the marshaled byte size of one /api/topology
+// response or one broadcast frame. Tracks what we actually ship over the
+// wire (post-JSON encoding) — the metric most relevant to "did the frontend
+// OOM on parse" bug reports.
+func RecordTopologyPayload(bytes int) {
+	global.topologyPayloadBytes.add(int64(bytes))
+}
+
+// IncSSEBroadcast increments the SSE broadcast counter (one per
+// broadcastTopologyUpdate fire, not per client).
+func IncSSEBroadcast() { global.sseBroadcasts.Add(1) }
+
+// IncSSEDrop increments the silent-drop counter (safeSend default case).
+func IncSSEDrop() { global.sseDrops.Add(1) }
+
+// IncSSETopologyOverwrite increments the count of topology snapshots that
+// were superseded by a newer snapshot before the client read them. Placeholder
+// for the 1C coalesce-latest design — wired now so the metric pre-exists
+// when the feature lands.
+func IncSSETopologyOverwrite() { global.sseTopologyOverwrites.Add(1) }
+
+// GetSnapshot returns a consistent point-in-time view of all counters
+// and sample windows for inclusion in /api/diagnostics responses.
+func GetSnapshot() Snapshot {
+	return Snapshot{
+		Topology: TopologyStats{
+			TotalBuilds:    global.topologyBuilds.Load(),
+			DurationUs:     global.topologyDuration.snapshot(),
+			NodeCount:      global.topologyNodeCount.snapshot(),
+			EdgeCount:      global.topologyEdgeCount.snapshot(),
+			PayloadBytes:   global.topologyPayloadBytes.snapshot(),
+			EstimatedNodes: global.topologyEstimatedNodes.snapshot(),
+		},
+		SSE: SSEStats{
+			TotalBroadcasts:         global.sseBroadcasts.Load(),
+			TotalDrops:              global.sseDrops.Load(),
+			TotalTopologyOverwrites: global.sseTopologyOverwrites.Load(),
+		},
+	}
+}
+
+// Reset clears all counters and windows. Intended for tests; not safe to
+// call concurrently with the Record/Inc/Get functions.
+func Reset() {
+	global = &store{}
+}

--- a/pkg/perfstats/perfstats_test.go
+++ b/pkg/perfstats/perfstats_test.go
@@ -77,16 +77,11 @@ func TestSSECounters(t *testing.T) {
 	IncSSEBroadcast()
 	IncSSEBroadcast()
 	IncSSEDrop()
-	IncSSETopologyOverwrite()
-	IncSSETopologyOverwrite()
 	snap := GetSnapshot()
 	if snap.SSE.TotalBroadcasts != 3 {
 		t.Errorf("TotalBroadcasts = %d, want 3", snap.SSE.TotalBroadcasts)
 	}
 	if snap.SSE.TotalDrops != 1 {
 		t.Errorf("TotalDrops = %d, want 1", snap.SSE.TotalDrops)
-	}
-	if snap.SSE.TotalTopologyOverwrites != 2 {
-		t.Errorf("TotalTopologyOverwrites = %d, want 2", snap.SSE.TotalTopologyOverwrites)
 	}
 }

--- a/pkg/perfstats/perfstats_test.go
+++ b/pkg/perfstats/perfstats_test.go
@@ -1,0 +1,92 @@
+package perfstats
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRingBufferPercentiles(t *testing.T) {
+	Reset()
+	for i := 1; i <= 50; i++ {
+		RecordTopologyBuild(time.Duration(i)*time.Microsecond, i*10, i*20, i)
+	}
+	snap := GetSnapshot()
+	if snap.Topology.TotalBuilds != 50 {
+		t.Errorf("TotalBuilds = %d, want 50", snap.Topology.TotalBuilds)
+	}
+	if snap.Topology.DurationUs.Count != 50 {
+		t.Errorf("DurationUs.Count = %d, want 50", snap.Topology.DurationUs.Count)
+	}
+	if snap.Topology.DurationUs.Last != 50 {
+		t.Errorf("DurationUs.Last = %d, want 50", snap.Topology.DurationUs.Last)
+	}
+	if snap.Topology.DurationUs.Min != 1 {
+		t.Errorf("DurationUs.Min = %d, want 1", snap.Topology.DurationUs.Min)
+	}
+	if snap.Topology.DurationUs.Max != 50 {
+		t.Errorf("DurationUs.Max = %d, want 50", snap.Topology.DurationUs.Max)
+	}
+	// P50 over [1..50]: nearest-rank gives sorted[int(49*0.5)] = sorted[24] = 25
+	if snap.Topology.DurationUs.P50 != 25 {
+		t.Errorf("DurationUs.P50 = %d, want 25", snap.Topology.DurationUs.P50)
+	}
+	// P95: sorted[int(49*0.95)] = sorted[46] = 47
+	if snap.Topology.DurationUs.P95 != 47 {
+		t.Errorf("DurationUs.P95 = %d, want 47", snap.Topology.DurationUs.P95)
+	}
+}
+
+func TestRingBufferWrapsAt100(t *testing.T) {
+	Reset()
+	for i := 1; i <= 250; i++ {
+		RecordTopologyBuild(time.Duration(i)*time.Microsecond, 0, 0, 0)
+	}
+	snap := GetSnapshot()
+	if snap.Topology.TotalBuilds != 250 {
+		t.Errorf("TotalBuilds = %d, want 250", snap.Topology.TotalBuilds)
+	}
+	if snap.Topology.DurationUs.Count != 100 {
+		t.Errorf("DurationUs.Count = %d, want 100", snap.Topology.DurationUs.Count)
+	}
+	// Window should hold samples 151..250 (the last 100).
+	if snap.Topology.DurationUs.Min != 151 {
+		t.Errorf("DurationUs.Min = %d, want 151", snap.Topology.DurationUs.Min)
+	}
+	if snap.Topology.DurationUs.Max != 250 {
+		t.Errorf("DurationUs.Max = %d, want 250", snap.Topology.DurationUs.Max)
+	}
+	if snap.Topology.DurationUs.Last != 250 {
+		t.Errorf("DurationUs.Last = %d, want 250", snap.Topology.DurationUs.Last)
+	}
+}
+
+func TestEmptyWindow(t *testing.T) {
+	Reset()
+	snap := GetSnapshot()
+	if snap.Topology.DurationUs.Count != 0 {
+		t.Errorf("expected empty window, got count %d", snap.Topology.DurationUs.Count)
+	}
+	if snap.Topology.TotalBuilds != 0 {
+		t.Errorf("expected 0 builds, got %d", snap.Topology.TotalBuilds)
+	}
+}
+
+func TestSSECounters(t *testing.T) {
+	Reset()
+	IncSSEBroadcast()
+	IncSSEBroadcast()
+	IncSSEBroadcast()
+	IncSSEDrop()
+	IncSSETopologyOverwrite()
+	IncSSETopologyOverwrite()
+	snap := GetSnapshot()
+	if snap.SSE.TotalBroadcasts != 3 {
+		t.Errorf("TotalBroadcasts = %d, want 3", snap.SSE.TotalBroadcasts)
+	}
+	if snap.SSE.TotalDrops != 1 {
+		t.Errorf("TotalDrops = %d, want 1", snap.SSE.TotalDrops)
+	}
+	if snap.SSE.TotalTopologyOverwrites != 2 {
+		t.Errorf("TotalTopologyOverwrites = %d, want 2", snap.SSE.TotalTopologyOverwrites)
+	}
+}

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -2696,14 +2696,19 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	if len(pods) > 0 && opts.SummaryMode {
 		// Summary mode: collapse the pod tier entirely. Roll each pod's health
 		// onto its owning workload node. Pods with no resolvable workload
-		// (standalone, bare ReplicaSet) fall back to a collapsed PodGroup so
-		// they stay visible without re-introducing thousands of pod nodes.
+		// (standalone, bare ReplicaSet, or a controller whose node wasn't
+		// created) fall back to a collapsed PodGroup so they stay visible
+		// without re-introducing thousands of pod nodes.
+		existingNodeIDs := make(map[string]bool, len(nodes))
+		for _, n := range nodes {
+			existingNodeIDs[n.ID] = true
+		}
 		var orphanPods []*corev1.Pod
 		for _, pod := range pods {
 			if !opts.MatchesNamespaceFilter(pod.Namespace) {
 				continue
 			}
-			workloadID := b.resolvePodWorkloadID(pod, replicaSetToDeployment, replicaSetToRollout, jobIDs)
+			workloadID := b.resolvePodWorkloadID(pod, existingNodeIDs, replicaSetToDeployment, replicaSetToRollout, jobIDs)
 			if workloadID == "" {
 				orphanPods = append(orphanPods, pod)
 				continue
@@ -6790,6 +6795,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 // by default and not the unit a user reasons about at scale).
 func (b *Builder) resolvePodWorkloadID(
 	pod *corev1.Pod,
+	existingNodeIDs map[string]bool,
 	replicaSetToDeployment map[string]string,
 	replicaSetToRollout map[string]string,
 	jobIDs map[string]string,
@@ -6801,6 +6807,7 @@ func (b *Builder) resolvePodWorkloadID(
 		ownerKey := pod.Namespace + "/" + ownerRef.Name
 		switch ownerRef.Kind {
 		case "ReplicaSet":
+			// These maps only hold IDs of nodes that were actually created.
 			if deployID, ok := replicaSetToDeployment[ownerKey]; ok {
 				return deployID
 			}
@@ -6809,9 +6816,20 @@ func (b *Builder) resolvePodWorkloadID(
 			}
 			return "" // bare ReplicaSet — no workload node to attribute to
 		case "DaemonSet":
-			return fmt.Sprintf("daemonset/%s/%s", pod.Namespace, ownerRef.Name)
+			// Unlike the map-backed cases, the DaemonSet/StatefulSet node ID is
+			// synthesized from the owner ref — so it may name a node that was
+			// never created (e.g. the controller list was denied by RBAC while
+			// pods are listable). Gate on the real node set so those pods fall
+			// through to the orphan PodGroup instead of vanishing.
+			if id := fmt.Sprintf("daemonset/%s/%s", pod.Namespace, ownerRef.Name); existingNodeIDs[id] {
+				return id
+			}
+			return ""
 		case "StatefulSet":
-			return fmt.Sprintf("statefulset/%s/%s", pod.Namespace, ownerRef.Name)
+			if id := fmt.Sprintf("statefulset/%s/%s", pod.Namespace, ownerRef.Name); existingNodeIDs[id] {
+				return id
+			}
+			return ""
 		case "Job":
 			if jobID, ok := jobIDs[ownerKey]; ok {
 				return jobID

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -2697,32 +2697,29 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		// Summary mode: collapse the pod tier entirely. Roll each pod's health
 		// onto its owning workload node. Pods with no resolvable workload
 		// (standalone, bare ReplicaSet, or a controller whose node wasn't
-		// created) fall back to a collapsed PodGroup so they stay visible
-		// without re-introducing thousands of pod nodes.
+		// created) are aggregated into ONE summary-only node per namespace —
+		// counts only, no per-pod array and no expand affordance — so a large
+		// orphan set can't re-introduce the pod-tier payload/render cost.
 		existingNodeIDs := make(map[string]bool, len(nodes))
 		for _, n := range nodes {
 			existingNodeIDs[n.ID] = true
 		}
-		var orphanPods []*corev1.Pod
+		orphanByNS := make(map[string]*PodSummary)
+		orphanRestarts := make(map[string]int32)
 		for _, pod := range pods {
 			if !opts.MatchesNamespaceFilter(pod.Namespace) {
 				continue
 			}
 			workloadID := b.resolvePodWorkloadID(pod, existingNodeIDs, replicaSetToDeployment, replicaSetToRollout, jobIDs)
 			if workloadID == "" {
-				orphanPods = append(orphanPods, pod)
+				addPodHealth(orphanByNS, pod.Namespace, pod)
+				orphanRestarts[pod.Namespace] += ComputePodRestarts(pod)
 				continue
 			}
 			addPodHealth(podSummaries, workloadID, pod)
 		}
-		if len(orphanPods) > 0 {
-			orphanResult := GroupPods(orphanPods, PodGroupingOptions{Namespaces: opts.Namespaces})
-			for _, group := range orphanResult.Groups {
-				podGroupID := GetPodGroupID(group)
-				nodes = append(nodes, CreatePodGroupNode(group, b.provider))
-				firstPod := group.Pods[0]
-				edges = append(edges, b.createPodOwnerEdges(firstPod, podGroupID, opts, replicaSetIDs, replicaSetToDeployment, replicaSetToRollout, jobIDs, jobToCronJob)...)
-			}
+		for ns, summary := range orphanByNS {
+			nodes = append(nodes, CreateOrphanPodSummaryNode(ns, *summary, orphanRestarts[ns]))
 		}
 	} else if len(pods) > 0 {
 		// Group pods using shared grouping logic

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -13,6 +14,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/skyhook-io/radar/pkg/perfstats"
 )
 
 // Builder constructs topology graphs from K8s resources
@@ -40,14 +43,17 @@ func (b *Builder) Build(opts BuildOptions) (*Topology, error) {
 		return nil, fmt.Errorf("resource provider not initialized")
 	}
 
+	start := time.Now()
+
 	// Detect large cluster and apply optimizations
-	isLargeCluster, hiddenKinds := b.detectLargeClusterAndOptimize(&opts)
+	isLargeCluster, hiddenKinds, estimatedNodes := b.detectLargeClusterAndOptimize(&opts)
 
 	// Large clusters without a namespace filter: skip the expensive build entirely.
 	// The frontend shows a "select namespace" prompt instead of a blank graph.
 	// ForRelationshipCache bypasses this guard — internal builds need the full graph
 	// for resource detail "Related Resources" lookups.
 	if isLargeCluster && len(opts.Namespaces) == 0 && !opts.ForRelationshipCache {
+		perfstats.RecordTopologyBuild(time.Since(start), 0, 0, estimatedNodes)
 		return &Topology{
 			Nodes:                   []Node{},
 			Edges:                   []Edge{},
@@ -55,7 +61,18 @@ func (b *Builder) Build(opts BuildOptions) (*Topology, error) {
 			LargeCluster:            true,
 			HiddenKinds:             hiddenKinds,
 			RequiresNamespaceFilter: true,
+			EstimatedNodes:          estimatedNodes,
 		}, nil
+	}
+
+	// Summary mode: a namespace the user has filtered to is still big enough
+	// to hang the tab if we render every pod. Collapse the pod tier into
+	// per-workload / per-service counts. Only kicks in for real (non-cache)
+	// namespace-filtered builds — the all-namespace large path already returns
+	// the RequiresNamespaceFilter prompt above, and the relationship cache
+	// needs the full graph.
+	if estimatedNodes >= SummaryModeThreshold && len(opts.Namespaces) > 0 && !opts.ForRelationshipCache {
+		opts.SummaryMode = true
 	}
 
 	var topo *Topology
@@ -77,13 +94,18 @@ func (b *Builder) Build(opts BuildOptions) (*Topology, error) {
 		topo.LargeCluster = true
 		topo.HiddenKinds = hiddenKinds
 	}
+	topo.EstimatedNodes = estimatedNodes
+	topo.SummaryMode = opts.SummaryMode
 
+	perfstats.RecordTopologyBuild(time.Since(start), len(topo.Nodes), len(topo.Edges), estimatedNodes)
 	return topo, nil
 }
 
-// detectLargeClusterAndOptimize checks if cluster is large and applies optimizations
-// Returns true if large cluster detected, and list of hidden kinds
-func (b *Builder) detectLargeClusterAndOptimize(opts *BuildOptions) (bool, []string) {
+// detectLargeClusterAndOptimize checks if cluster is large and applies optimizations.
+// Returns: large-cluster flag, hidden kinds, and the estimated node count itself
+// (exposed so callers — eg. the SSE broadcaster — can drive debounce / render-mode
+// decisions off the same signal that drives the in-builder optimizations here).
+func (b *Builder) detectLargeClusterAndOptimize(opts *BuildOptions) (bool, []string, int) {
 	// Quick count of workload resources to estimate total node count
 	// This is a lightweight check - we count core resources that contribute most to topology
 	estimatedNodes := 0
@@ -186,7 +208,7 @@ func (b *Builder) detectLargeClusterAndOptimize(opts *BuildOptions) (bool, []str
 
 	// Check if large cluster
 	if estimatedNodes < LargeClusterThreshold {
-		return false, nil
+		return false, nil, estimatedNodes
 	}
 
 	// Large cluster detected - apply optimizations
@@ -205,7 +227,7 @@ func (b *Builder) detectLargeClusterAndOptimize(opts *BuildOptions) (bool, []str
 		hiddenKinds = append(hiddenKinds, "PersistentVolumeClaim")
 	}
 
-	return true, hiddenKinds
+	return true, hiddenKinds, estimatedNodes
 }
 
 // buildResourcesTopology creates a comprehensive resource view
@@ -2667,7 +2689,37 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		}
 		pods = ps
 	}
-	if len(pods) > 0 {
+	// podSummaries accumulates per-workload pod health in summary mode; stamped
+	// onto the workload nodes just before return. Empty (and the stamp a no-op)
+	// in normal mode.
+	podSummaries := make(map[string]*PodSummary)
+	if len(pods) > 0 && opts.SummaryMode {
+		// Summary mode: collapse the pod tier entirely. Roll each pod's health
+		// onto its owning workload node. Pods with no resolvable workload
+		// (standalone, bare ReplicaSet) fall back to a collapsed PodGroup so
+		// they stay visible without re-introducing thousands of pod nodes.
+		var orphanPods []*corev1.Pod
+		for _, pod := range pods {
+			if !opts.MatchesNamespaceFilter(pod.Namespace) {
+				continue
+			}
+			workloadID := b.resolvePodWorkloadID(pod, replicaSetToDeployment, replicaSetToRollout, jobIDs)
+			if workloadID == "" {
+				orphanPods = append(orphanPods, pod)
+				continue
+			}
+			addPodHealth(podSummaries, workloadID, pod)
+		}
+		if len(orphanPods) > 0 {
+			orphanResult := GroupPods(orphanPods, PodGroupingOptions{Namespaces: opts.Namespaces})
+			for _, group := range orphanResult.Groups {
+				podGroupID := GetPodGroupID(group)
+				nodes = append(nodes, CreatePodGroupNode(group, b.provider))
+				firstPod := group.Pods[0]
+				edges = append(edges, b.createPodOwnerEdges(firstPod, podGroupID, opts, replicaSetIDs, replicaSetToDeployment, replicaSetToRollout, jobIDs, jobToCronJob)...)
+			}
+		}
+	} else if len(pods) > 0 {
 		// Group pods using shared grouping logic
 		groupingResult := GroupPods(pods, PodGroupingOptions{
 			Namespaces: opts.Namespaces,
@@ -5180,6 +5232,9 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		annotateNodePolicyCoverage(nodes, edges, netpols, deployments, statefulsets, daemonsets)
 	}
 
+	// Summary mode: stamp collapsed pod counts onto their workload nodes.
+	stampPodSummaries(nodes, podSummaries)
+
 	topo := &Topology{Nodes: nodes, Edges: edges, Warnings: warnings}
 
 	// Add CRD discovery status
@@ -6656,43 +6711,59 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 		ServiceIDs:      serviceIDs,
 	})
 
-	// Create nodes and edges for each group
-	// Use MaxIndividualPods threshold to decide whether to show individual pods or group them
-	maxIndividualPods := opts.MaxIndividualPods
-	if maxIndividualPods <= 0 {
-		maxIndividualPods = 5 // Default threshold
-	}
+	if opts.SummaryMode {
+		// Summary mode: collapse the pod tier. In traffic view the routing
+		// Service is the unit a user reasons about, so roll each group's pod
+		// health onto every Service that routes to it. No Pod / PodGroup nodes
+		// are emitted; the Service nodes (built above) carry the counts.
+		podSummaries := make(map[string]*PodSummary)
+		for _, group := range groupingResult.Groups {
+			for svcID := range group.ServiceIDs {
+				for _, pod := range group.Pods {
+					addPodHealth(podSummaries, svcID, pod)
+				}
+			}
+		}
+		stampPodSummaries(nodes, podSummaries)
+	} else {
+		// Create nodes and edges for each group
+		// Use MaxIndividualPods threshold to decide whether to show individual pods or group them
+		maxIndividualPods := opts.MaxIndividualPods
+		if maxIndividualPods <= 0 {
+			maxIndividualPods = 5 // Default threshold
+		}
 
-	for _, group := range groupingResult.Groups {
-		if len(group.Pods) <= maxIndividualPods {
-			// Small group - show as individual nodes
-			for _, pod := range group.Pods {
-				podID := GetPodID(pod)
-				nodes = append(nodes, CreatePodNode(pod, b.provider, false)) // includeNodeName=false for traffic view
+		for _, group := range groupingResult.Groups {
+			if len(group.Pods) <= maxIndividualPods {
+				// Small group - show as individual nodes
+				for _, pod := range group.Pods {
+					podID := GetPodID(pod)
+					nodes = append(nodes, CreatePodNode(pod, b.provider, false)) // includeNodeName=false for traffic view
 
-				// Add edges from services to pod (traffic view specific)
+					// Add edges from services to pod (traffic view specific)
+					for svcID := range group.ServiceIDs {
+						edges = append(edges, Edge{
+							ID:     fmt.Sprintf("%s-to-%s", svcID, podID),
+							Source: svcID,
+							Target: podID,
+							Type:   EdgeRoutesTo,
+						})
+					}
+				}
+			} else {
+				// Large group - create PodGroup node
+				podGroupID := GetPodGroupID(group)
+				nodes = append(nodes, CreatePodGroupNode(group, b.provider))
+
+				// Add edges from services to pod group (traffic view specific)
 				for svcID := range group.ServiceIDs {
 					edges = append(edges, Edge{
-						ID:     fmt.Sprintf("%s-to-%s", svcID, podID),
+						ID:     fmt.Sprintf("%s-to-%s", svcID, podGroupID),
 						Source: svcID,
-						Target: podID,
+						Target: podGroupID,
 						Type:   EdgeRoutesTo,
 					})
 				}
-			}
-		} else {
-			// Large group - create PodGroup node
-			podGroupID := GetPodGroupID(group)
-			nodes = append(nodes, CreatePodGroupNode(group, b.provider))
-
-			// Add edges from services to pod group (traffic view specific)
-			for svcID := range group.ServiceIDs {
-				edges = append(edges, Edge{
-					ID:     fmt.Sprintf("%s-to-%s", svcID, podGroupID),
-					Source: svcID,
-					Target: podGroupID,
-					Type:   EdgeRoutesTo,
-				})
 			}
 		}
 	}
@@ -6705,6 +6776,93 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 	}
 
 	return topo, nil
+}
+
+// resolvePodWorkloadID returns the node ID of the top-level workload that owns
+// the pod and that actually exists as a node in the current build — used by
+// summary mode to attribute pod health counts. Returns "" when the pod has no
+// resolvable workload node (standalone pods, bare ReplicaSets with no Deployment
+// parent); those callers fall back to a collapsed PodGroup so the pods stay
+// visible without flooding the graph.
+//
+// Mirrors the owner resolution in createPodOwnerEdges, but resolves through
+// ReplicaSet → Deployment/Rollout (ReplicaSets are noisy intermediates hidden
+// by default and not the unit a user reasons about at scale).
+func (b *Builder) resolvePodWorkloadID(
+	pod *corev1.Pod,
+	replicaSetToDeployment map[string]string,
+	replicaSetToRollout map[string]string,
+	jobIDs map[string]string,
+) string {
+	for _, ownerRef := range pod.OwnerReferences {
+		if ownerRef.Controller == nil || !*ownerRef.Controller {
+			continue
+		}
+		ownerKey := pod.Namespace + "/" + ownerRef.Name
+		switch ownerRef.Kind {
+		case "ReplicaSet":
+			if deployID, ok := replicaSetToDeployment[ownerKey]; ok {
+				return deployID
+			}
+			if rolloutID, ok := replicaSetToRollout[ownerKey]; ok {
+				return rolloutID
+			}
+			return "" // bare ReplicaSet — no workload node to attribute to
+		case "DaemonSet":
+			return fmt.Sprintf("daemonset/%s/%s", pod.Namespace, ownerRef.Name)
+		case "StatefulSet":
+			return fmt.Sprintf("statefulset/%s/%s", pod.Namespace, ownerRef.Name)
+		case "Job":
+			if jobID, ok := jobIDs[ownerKey]; ok {
+				return jobID
+			}
+			return ""
+		}
+	}
+	return ""
+}
+
+// addPodHealth accumulates a single pod's health into a PodSummary map keyed by
+// node ID. Used by summary mode to roll pods up onto workloads/services.
+func addPodHealth(summaries map[string]*PodSummary, nodeID string, pod *corev1.Pod) {
+	s := summaries[nodeID]
+	if s == nil {
+		s = &PodSummary{}
+		summaries[nodeID] = s
+	}
+	s.Total++
+	switch getPodStatus(string(pod.Status.Phase)) {
+	case StatusHealthy:
+		s.Healthy++
+	case StatusDegraded:
+		s.Degraded++
+	default:
+		s.Unhealthy++
+	}
+}
+
+// stampPodSummaries writes accumulated PodSummary counts onto the matching
+// nodes' Data under "podSummary". Nodes is a value slice, so we mutate in place
+// by index.
+func stampPodSummaries(nodes []Node, summaries map[string]*PodSummary) {
+	if len(summaries) == 0 {
+		return
+	}
+	for i := range nodes {
+		s, ok := summaries[nodes[i].ID]
+		if !ok {
+			continue
+		}
+		if nodes[i].Data == nil {
+			nodes[i].Data = map[string]any{}
+		}
+		nodes[i].Data["podSummary"] = map[string]any{
+			"total":     s.Total,
+			"healthy":   s.Healthy,
+			"degraded":  s.Degraded,
+			"unhealthy": s.Unhealthy,
+		}
+	}
 }
 
 // Helper functions

--- a/pkg/topology/builder_test.go
+++ b/pkg/topology/builder_test.go
@@ -168,7 +168,7 @@ func TestLargeClusterDetection(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := NewBuilder(tt.provider)
 			opts := DefaultBuildOptions()
-			gotLarge, _ := b.detectLargeClusterAndOptimize(&opts)
+			gotLarge, _, _ := b.detectLargeClusterAndOptimize(&opts)
 			if gotLarge != tt.wantLarge {
 				t.Errorf("detectLargeClusterAndOptimize() = %v, want %v (%s)", gotLarge, tt.wantLarge, tt.description)
 			}
@@ -187,7 +187,7 @@ func TestLargeClusterOptimizations(t *testing.T) {
 		t.Fatal("precondition: IncludePVCs should default to true")
 	}
 
-	isLarge, hiddenKinds := b.detectLargeClusterAndOptimize(&opts)
+	isLarge, hiddenKinds, _ := b.detectLargeClusterAndOptimize(&opts)
 	if !isLarge {
 		t.Fatal("expected large cluster detection")
 	}
@@ -216,7 +216,7 @@ func TestSmallClusterUnaffected(t *testing.T) {
 	b := NewBuilder(smallProvider())
 	opts := DefaultBuildOptions()
 
-	isLarge, hiddenKinds := b.detectLargeClusterAndOptimize(&opts)
+	isLarge, hiddenKinds, _ := b.detectLargeClusterAndOptimize(&opts)
 	if isLarge {
 		t.Error("small cluster should not be detected as large")
 	}
@@ -339,7 +339,7 @@ func TestNamespaceFilterReducesEstimate(t *testing.T) {
 
 	// All namespaces → large
 	allOpts := DefaultBuildOptions()
-	isLarge, _ := b.detectLargeClusterAndOptimize(&allOpts)
+	isLarge, _, _ := b.detectLargeClusterAndOptimize(&allOpts)
 	if !isLarge {
 		t.Error("all-namespace should be detected as large (2000 deployments)")
 	}
@@ -347,7 +347,7 @@ func TestNamespaceFilterReducesEstimate(t *testing.T) {
 	// Single namespace → small
 	filteredOpts := DefaultBuildOptions()
 	filteredOpts.Namespaces = []string{"ns-0"}
-	isLarge, _ = b.detectLargeClusterAndOptimize(&filteredOpts)
+	isLarge, _, _ = b.detectLargeClusterAndOptimize(&filteredOpts)
 	if isLarge {
 		t.Error("single namespace (100 deployments) should NOT be detected as large")
 	}

--- a/pkg/topology/pod_grouping.go
+++ b/pkg/topology/pod_grouping.go
@@ -251,6 +251,36 @@ func CreatePodGroupNode(group *PodGroup, provider ResourceProvider) Node {
 	}
 }
 
+// CreateOrphanPodSummaryNode creates a single summary-only node for pods that
+// couldn't be attributed to a workload in summary mode (standalone pods, bare
+// ReplicaSets, or controllers whose node wasn't created — e.g. RBAC-denied).
+// It carries counts/status/restarts only — NO per-pod "pods" array and no
+// expand affordance — so a large orphan set can't re-introduce the pod-tier
+// payload/render cost that summary mode exists to avoid.
+func CreateOrphanPodSummaryNode(namespace string, summary PodSummary, totalRestarts int32) Node {
+	status := StatusHealthy
+	if summary.Unhealthy > 0 {
+		status = StatusUnhealthy
+	} else if summary.Degraded > 0 {
+		status = StatusDegraded
+	}
+	return Node{
+		ID:     "podgroup-orphans-" + namespace,
+		Kind:   KindPodGroup,
+		Name:   "unattributed pods",
+		Status: status,
+		Data: map[string]any{
+			"namespace":     namespace,
+			"podCount":      summary.Total,
+			"healthy":       summary.Healthy,
+			"degraded":      summary.Degraded,
+			"unhealthy":     summary.Unhealthy,
+			"totalRestarts": totalRestarts,
+			"summaryOnly":   true,
+		},
+	}
+}
+
 // GetPodGroupID returns the node ID for a pod group
 func GetPodGroupID(group *PodGroup) string {
 	return fmt.Sprintf("podgroup-%s", strings.ReplaceAll(group.Key, "/", "-"))

--- a/pkg/topology/summary_mode_test.go
+++ b/pkg/topology/summary_mode_test.go
@@ -186,6 +186,119 @@ func TestSummaryModeRequiresNamespaceFilter(t *testing.T) {
 	}
 }
 
+// makeDSOwnedPods creates n pods controlled by the named DaemonSet.
+func makeDSOwnedPods(n int, ns, dsName string) []*corev1.Pod {
+	ctrl := true
+	pods := make([]*corev1.Pod, n)
+	for i := range n {
+		pods[i] = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-pod-%d", dsName, i),
+				Namespace: ns,
+				OwnerReferences: []metav1.OwnerReference{
+					{Kind: "DaemonSet", Name: dsName, Controller: &ctrl},
+				},
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		}
+	}
+	return pods
+}
+
+func TestSummaryModeDaemonSetPodsAttributed(t *testing.T) {
+	provider := &mockProvider{
+		daemonSets: []*appsv1.DaemonSet{
+			{ObjectMeta: metav1.ObjectMeta{Name: "ds1", Namespace: "big"}},
+		},
+		pods: makeDSOwnedPods(10000, "big", "ds1"),
+	}
+	opts := DefaultBuildOptions()
+	opts.Namespaces = []string{"big"}
+	topo, err := NewBuilder(provider).Build(opts)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !topo.SummaryMode {
+		t.Fatalf("expected SummaryMode=true (estimated %d)", topo.EstimatedNodes)
+	}
+	ds := findNode(topo, "daemonset/big/ds1")
+	if ds == nil {
+		t.Fatal("daemonset node missing")
+	}
+	summary, ok := ds.Data["podSummary"].(map[string]any)
+	if !ok {
+		t.Fatalf("daemonset node missing podSummary, Data=%v", ds.Data)
+	}
+	if summary["total"] != 10000 {
+		t.Errorf("podSummary.total = %v, want 10000", summary["total"])
+	}
+}
+
+// Regression: when a DaemonSet/StatefulSet controller node was never created
+// (e.g. the controller list was denied by RBAC while pods are listable), its
+// pods must still be visible via an orphan PodGroup — not silently dropped.
+func TestSummaryModeMissingControllerPodsNotDropped(t *testing.T) {
+	provider := &mockProvider{
+		// daemonSets intentionally empty — simulates RBAC denial of the list.
+		pods: makeDSOwnedPods(10000, "big", "ds1"),
+	}
+	opts := DefaultBuildOptions()
+	opts.Namespaces = []string{"big"}
+	topo, err := NewBuilder(provider).Build(opts)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !topo.SummaryMode {
+		t.Fatalf("expected SummaryMode=true (estimated %d)", topo.EstimatedNodes)
+	}
+	// The controller node does not exist...
+	if findNode(topo, "daemonset/big/ds1") != nil {
+		t.Fatal("did not expect a daemonset node (controller was not listed)")
+	}
+	// ...and there must be no phantom podSummary stamped anywhere.
+	for _, n := range topo.Nodes {
+		if _, ok := n.Data["podSummary"]; ok {
+			t.Errorf("unexpected podSummary on node %s — pods attributed to a non-existent controller", n.ID)
+		}
+	}
+	// ...but the pods are NOT dropped: they fall back to a collapsed PodGroup.
+	if countKind(topo, KindPodGroup) == 0 {
+		t.Error("expected orphan PodGroup for pods whose controller node is absent")
+	}
+}
+
+func TestSummaryModeStandalonePodsFallBackToPodGroup(t *testing.T) {
+	// 10000 deployment-owned pods cross the threshold and attribute to the
+	// Deployment; a handful of standalone pods have no owner and must surface
+	// as orphan PodGroups rather than being attributed or dropped.
+	pods := makeOwnedPods(10000, "big", "web-rs", corev1.PodRunning)
+	standalone := makePods(3, "big") // no OwnerReferences
+	for i, p := range standalone {
+		p.Name = fmt.Sprintf("standalone-%d", i)
+	}
+	pods = append(pods, standalone...)
+	provider := deploymentWithReplicaSet("big", "web", "web-rs", pods)
+
+	opts := DefaultBuildOptions()
+	opts.Namespaces = []string{"big"}
+	topo, err := NewBuilder(provider).Build(opts)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	dep := findNode(topo, "deployment/big/web")
+	if dep == nil {
+		t.Fatal("deployment node missing")
+	}
+	// Standalone pods are not attributed to the deployment.
+	if summary := dep.Data["podSummary"].(map[string]any); summary["total"] != 10000 {
+		t.Errorf("deployment podSummary.total = %v, want 10000 (standalone pods excluded)", summary["total"])
+	}
+	// They surface as orphan PodGroups instead.
+	if countKind(topo, KindPodGroup) == 0 {
+		t.Error("expected orphan PodGroup nodes for standalone pods")
+	}
+}
+
 func TestSummaryModeTrafficAttributesToService(t *testing.T) {
 	// Pods labeled app=web, selected by svc "web-svc"; enough to cross threshold.
 	pods := makeOwnedPods(10000, "big", "web-rs", corev1.PodRunning)

--- a/pkg/topology/summary_mode_test.go
+++ b/pkg/topology/summary_mode_test.go
@@ -261,9 +261,23 @@ func TestSummaryModeMissingControllerPodsNotDropped(t *testing.T) {
 			t.Errorf("unexpected podSummary on node %s — pods attributed to a non-existent controller", n.ID)
 		}
 	}
-	// ...but the pods are NOT dropped: they fall back to a collapsed PodGroup.
-	if countKind(topo, KindPodGroup) == 0 {
-		t.Error("expected orphan PodGroup for pods whose controller node is absent")
+	// ...the pods are NOT dropped, but collapse into a single bounded summary
+	// node per namespace — NOT a PodGroup carrying 10000 per-pod records.
+	if got := countKind(topo, KindPodGroup); got != 1 {
+		t.Fatalf("expected exactly 1 orphan summary node, got %d", got)
+	}
+	orphan := findNode(topo, "podgroup-orphans-big")
+	if orphan == nil {
+		t.Fatal("expected orphan summary node podgroup-orphans-big")
+	}
+	if _, hasPods := orphan.Data["pods"]; hasPods {
+		t.Error("orphan summary node must NOT carry a per-pod 'pods' array (would defeat the summary guard + stay expandable)")
+	}
+	if orphan.Data["podCount"] != 10000 {
+		t.Errorf("orphan podCount = %v, want 10000", orphan.Data["podCount"])
+	}
+	if orphan.Data["summaryOnly"] != true {
+		t.Errorf("orphan node should be marked summaryOnly")
 	}
 }
 
@@ -293,9 +307,20 @@ func TestSummaryModeStandalonePodsFallBackToPodGroup(t *testing.T) {
 	if summary := dep.Data["podSummary"].(map[string]any); summary["total"] != 10000 {
 		t.Errorf("deployment podSummary.total = %v, want 10000 (standalone pods excluded)", summary["total"])
 	}
-	// They surface as orphan PodGroups instead.
-	if countKind(topo, KindPodGroup) == 0 {
-		t.Error("expected orphan PodGroup nodes for standalone pods")
+	// They surface as a single bounded orphan summary node (not 3 per-pod
+	// PodGroups, and not one carrying a 'pods' array).
+	if got := countKind(topo, KindPodGroup); got != 1 {
+		t.Fatalf("expected exactly 1 orphan summary node for standalone pods, got %d", got)
+	}
+	orphan := findNode(topo, "podgroup-orphans-big")
+	if orphan == nil {
+		t.Fatal("expected orphan summary node podgroup-orphans-big")
+	}
+	if _, hasPods := orphan.Data["pods"]; hasPods {
+		t.Error("orphan summary node must NOT carry a per-pod 'pods' array")
+	}
+	if orphan.Data["podCount"] != 3 {
+		t.Errorf("orphan podCount = %v, want 3", orphan.Data["podCount"])
 	}
 }
 

--- a/pkg/topology/summary_mode_test.go
+++ b/pkg/topology/summary_mode_test.go
@@ -1,0 +1,227 @@
+package topology
+
+import (
+	"fmt"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// makeOwnedPods creates n pods controlled by the named ReplicaSet, with the
+// given phase, in namespace ns.
+func makeOwnedPods(n int, ns, rsName string, phase corev1.PodPhase) []*corev1.Pod {
+	ctrl := true
+	pods := make([]*corev1.Pod, n)
+	for i := range n {
+		pods[i] = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-pod-%d", rsName, i),
+				Namespace: ns,
+				OwnerReferences: []metav1.OwnerReference{
+					{Kind: "ReplicaSet", Name: rsName, Controller: &ctrl},
+				},
+			},
+			Status: corev1.PodStatus{Phase: phase},
+		}
+	}
+	return pods
+}
+
+// deploymentWithReplicaSet wires a Deployment, its ReplicaSet, and pods so the
+// builder's RS→Deployment resolution attributes pod counts to the Deployment.
+func deploymentWithReplicaSet(ns, depName, rsName string, pods []*corev1.Pod) *mockProvider {
+	ctrl := true
+	replicas := int32(len(pods))
+	return &mockProvider{
+		deployments: []*appsv1.Deployment{
+			{ObjectMeta: metav1.ObjectMeta{Name: depName, Namespace: ns}},
+		},
+		replicaSets: []*appsv1.ReplicaSet{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            rsName,
+					Namespace:       ns,
+					OwnerReferences: []metav1.OwnerReference{{Kind: "Deployment", Name: depName, Controller: &ctrl}},
+				},
+				Spec: appsv1.ReplicaSetSpec{Replicas: &replicas},
+			},
+		},
+		pods: pods,
+	}
+}
+
+func countKind(topo *Topology, kind NodeKind) int {
+	n := 0
+	for _, node := range topo.Nodes {
+		if node.Kind == kind {
+			n++
+		}
+	}
+	return n
+}
+
+func findNode(topo *Topology, id string) *Node {
+	for i := range topo.Nodes {
+		if topo.Nodes[i].ID == id {
+			return &topo.Nodes[i]
+		}
+	}
+	return nil
+}
+
+// 10000 pods → estimate 2000 (pods/5) + 1 deployment ≥ SummaryModeThreshold.
+func TestSummaryModeResourcesCollapsesPodTier(t *testing.T) {
+	provider := deploymentWithReplicaSet("big", "web", "web-rs",
+		makeOwnedPods(10000, "big", "web-rs", corev1.PodRunning))
+
+	opts := DefaultBuildOptions()
+	opts.Namespaces = []string{"big"}
+	topo, err := NewBuilder(provider).Build(opts)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	if !topo.SummaryMode {
+		t.Fatalf("expected SummaryMode=true (estimated %d)", topo.EstimatedNodes)
+	}
+	if got := countKind(topo, KindPod); got != 0 {
+		t.Errorf("expected 0 Pod nodes in summary mode, got %d", got)
+	}
+	if got := countKind(topo, KindPodGroup); got != 0 {
+		t.Errorf("expected 0 PodGroup nodes in summary mode, got %d", got)
+	}
+
+	dep := findNode(topo, "deployment/big/web")
+	if dep == nil {
+		t.Fatal("deployment node missing")
+	}
+	summary, ok := dep.Data["podSummary"].(map[string]any)
+	if !ok {
+		t.Fatalf("deployment node missing podSummary, Data=%v", dep.Data)
+	}
+	if summary["total"] != 10000 {
+		t.Errorf("podSummary.total = %v, want 10000", summary["total"])
+	}
+	if summary["healthy"] != 10000 {
+		t.Errorf("podSummary.healthy = %v, want 10000", summary["healthy"])
+	}
+}
+
+func TestSummaryModePodHealthBreakdown(t *testing.T) {
+	var pods []*corev1.Pod
+	pods = append(pods, makeOwnedPods(7000, "big", "web-rs", corev1.PodRunning)...)
+	pods = append(pods, makeOwnedPods(2000, "big", "web-rs", corev1.PodPending)...)
+	pods = append(pods, makeOwnedPods(1000, "big", "web-rs", corev1.PodFailed)...)
+	// distinct names across phases
+	for i, p := range pods {
+		p.Name = fmt.Sprintf("web-rs-pod-%d", i)
+	}
+	provider := deploymentWithReplicaSet("big", "web", "web-rs", pods)
+
+	opts := DefaultBuildOptions()
+	opts.Namespaces = []string{"big"}
+	topo, err := NewBuilder(provider).Build(opts)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	dep := findNode(topo, "deployment/big/web")
+	if dep == nil {
+		t.Fatal("deployment node missing")
+	}
+	summary := dep.Data["podSummary"].(map[string]any)
+	if summary["total"] != 10000 {
+		t.Errorf("total = %v, want 10000", summary["total"])
+	}
+	if summary["healthy"] != 7000 {
+		t.Errorf("healthy = %v, want 7000", summary["healthy"])
+	}
+	if summary["degraded"] != 2000 {
+		t.Errorf("degraded = %v, want 2000 (Pending)", summary["degraded"])
+	}
+	if summary["unhealthy"] != 1000 {
+		t.Errorf("unhealthy = %v, want 1000 (Failed)", summary["unhealthy"])
+	}
+}
+
+// Below the threshold, normal mode still emits the pod tier.
+func TestSummaryModeOffBelowThreshold(t *testing.T) {
+	// 1000 pods → estimate 200, well under SummaryModeThreshold.
+	provider := deploymentWithReplicaSet("small", "web", "web-rs",
+		makeOwnedPods(1000, "small", "web-rs", corev1.PodRunning))
+
+	opts := DefaultBuildOptions()
+	opts.Namespaces = []string{"small"}
+	topo, err := NewBuilder(provider).Build(opts)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if topo.SummaryMode {
+		t.Fatal("expected SummaryMode=false below threshold")
+	}
+	// 1000 pods under one RS → one PodGroup (well over maxIndividualPods)
+	if got := countKind(topo, KindPodGroup); got == 0 {
+		t.Error("expected PodGroup nodes in normal mode")
+	}
+}
+
+// Summary mode requires a namespace filter — an unfiltered large cluster gets
+// the RequiresNamespaceFilter prompt instead, never reaches summary mode.
+func TestSummaryModeRequiresNamespaceFilter(t *testing.T) {
+	provider := deploymentWithReplicaSet("big", "web", "web-rs",
+		makeOwnedPods(10000, "big", "web-rs", corev1.PodRunning))
+
+	opts := DefaultBuildOptions() // no Namespaces
+	topo, err := NewBuilder(provider).Build(opts)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if topo.SummaryMode {
+		t.Error("summary mode should not trigger without a namespace filter")
+	}
+	if !topo.RequiresNamespaceFilter {
+		t.Error("expected RequiresNamespaceFilter for unfiltered large cluster")
+	}
+}
+
+func TestSummaryModeTrafficAttributesToService(t *testing.T) {
+	// Pods labeled app=web, selected by svc "web-svc"; enough to cross threshold.
+	pods := makeOwnedPods(10000, "big", "web-rs", corev1.PodRunning)
+	for _, p := range pods {
+		p.Labels = map[string]string{"app": "web"}
+	}
+	provider := deploymentWithReplicaSet("big", "web", "web-rs", pods)
+	provider.services = []*corev1.Service{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "web-svc", Namespace: "big"},
+			Spec:       corev1.ServiceSpec{Selector: map[string]string{"app": "web"}},
+		},
+	}
+
+	opts := DefaultBuildOptions()
+	opts.Namespaces = []string{"big"}
+	opts.ViewMode = ViewModeTraffic
+	topo, err := NewBuilder(provider).Build(opts)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !topo.SummaryMode {
+		t.Fatalf("expected SummaryMode=true (estimated %d)", topo.EstimatedNodes)
+	}
+	if got := countKind(topo, KindPod) + countKind(topo, KindPodGroup); got != 0 {
+		t.Errorf("expected no pod tier nodes in traffic summary mode, got %d", got)
+	}
+	svc := findNode(topo, "service/big/web-svc")
+	if svc == nil {
+		t.Fatal("service node missing")
+	}
+	summary, ok := svc.Data["podSummary"].(map[string]any)
+	if !ok {
+		t.Fatalf("service node missing podSummary, Data=%v", svc.Data)
+	}
+	if summary["total"] != 10000 {
+		t.Errorf("service podSummary.total = %v, want 10000", summary["total"])
+	}
+}

--- a/pkg/topology/types.go
+++ b/pkg/topology/types.go
@@ -229,7 +229,9 @@ const LargeClusterThreshold = 1000
 const SummaryModeThreshold = 2000
 
 // PodSummary aggregates pod health for a workload or service in summary mode,
-// stamped onto the owning node's Data as "podSummary".
+// stamped onto the owning node's Data as "podSummary". Invariant maintained by
+// addPodHealth: Total == Healthy + Degraded + Unhealthy. Unknown-phase pods are
+// counted as Unhealthy (matching the bucketing GroupPods uses for PodGroups).
 type PodSummary struct {
 	Total     int `json:"total"`
 	Healthy   int `json:"healthy"`

--- a/pkg/topology/types.go
+++ b/pkg/topology/types.go
@@ -171,6 +171,8 @@ type Topology struct {
 	HiddenKinds             []string `json:"hiddenKinds,omitempty"`             // Resource kinds auto-hidden for performance
 	RequiresNamespaceFilter bool     `json:"requiresNamespaceFilter,omitempty"` // True if cluster is too large for all-namespace topology
 	CRDDiscoveryStatus      string   `json:"crdDiscoveryStatus,omitempty"`      // CRD discovery status: idle, discovering, ready
+	EstimatedNodes          int      `json:"estimatedNodes,omitempty"`          // Pre-build node count estimate from the large-cluster optimizer; exposed so SSE / UI can tune debounce + render mode off the same signal
+	SummaryMode             bool     `json:"summaryMode,omitempty"`             // True when the pod tier was collapsed into per-workload/service counts (see SummaryModeThreshold)
 }
 
 // StripNodeKinds removes nodes whose Kind is in deny, plus every edge that
@@ -214,7 +216,26 @@ const (
 )
 
 // Large cluster threshold - when pre-grouped node count exceeds this, apply optimizations
+// (aggressive pod grouping + auto-hide ConfigMaps/PVCs).
 const LargeClusterThreshold = 1000
+
+// Summary mode threshold - a second, higher tier above LargeClusterThreshold.
+// When a namespace-filtered build's estimated node count crosses this, the
+// builder drops the entire pod tier (no Pod / PodGroup nodes) and instead
+// rolls pod health up onto the owning workload (resources view) or routing
+// Service (traffic view) as a PodSummary. This bounds rendered nodes to
+// workloads + networking regardless of pod count — the fix for tabs hanging
+// on namespaces with thousands of pods.
+const SummaryModeThreshold = 2000
+
+// PodSummary aggregates pod health for a workload or service in summary mode,
+// stamped onto the owning node's Data as "podSummary".
+type PodSummary struct {
+	Total     int `json:"total"`
+	Healthy   int `json:"healthy"`
+	Degraded  int `json:"degraded"`
+	Unhealthy int `json:"unhealthy"`
+}
 
 // BuildOptions configures topology building
 type BuildOptions struct {
@@ -228,6 +249,7 @@ type BuildOptions struct {
 	IncludeGenericCRDs     bool // Include CRDs with owner refs to topology nodes (default: true)
 	ForRelationshipCache   bool // Skip large cluster guard — used for internal relationship cache builds
 	ShowPolicyEffect       bool // Evaluate NetworkPolicies and annotate edges with allow/block/unprotected
+	SummaryMode            bool // Collapse the pod tier into per-workload/service counts (set by Build when estimate ≥ SummaryModeThreshold)
 }
 
 // MatchesNamespace returns true if ns is in the allowed list.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -957,6 +957,7 @@ function AppInner() {
     })
 
     return {
+      ...displayedTopology,
       nodes: filteredNodes,
       edges: filteredEdges,
     }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3064,7 +3064,6 @@ export interface DiagPerfSnapshot {
   sse: {
     totalBroadcasts: number
     totalDrops: number
-    totalTopologyOverwrites: number
   }
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3042,6 +3042,32 @@ export interface DiagCacheSyncStatus {
   promotedKinds?: string[]
 }
 
+export interface DiagSampleWindow {
+  count: number
+  last: number
+  min: number
+  p50: number
+  p95: number
+  p99: number
+  max: number
+}
+
+export interface DiagPerfSnapshot {
+  topology: {
+    totalBuilds: number
+    durationUs: DiagSampleWindow
+    nodeCount: DiagSampleWindow
+    edgeCount: DiagSampleWindow
+    payloadBytes: DiagSampleWindow
+    estimatedNodes: DiagSampleWindow
+  }
+  sse: {
+    totalBroadcasts: number
+    totalDrops: number
+    totalTopologyOverwrites: number
+  }
+}
+
 export interface DiagnosticsSnapshot {
   timestamp: string
   radarVersion: string
@@ -3136,6 +3162,7 @@ export interface DiagnosticsSnapshot {
   sse?: {
     connectedClients: number
   }
+  perf?: DiagPerfSnapshot
   runtime?: {
     heapMB: number
     heapObjectsK: number

--- a/web/src/components/ui/DiagnosticsOverlay.tsx
+++ b/web/src/components/ui/DiagnosticsOverlay.tsx
@@ -4,7 +4,8 @@ import { clsx } from 'clsx'
 import { TRANSITION_BACKDROP, TRANSITION_PANEL } from '../../utils/animation'
 import { openExternal } from '../../utils/navigation'
 import { useDiagnostics } from '../../api/client'
-import type { DiagnosticsSnapshot, DiagMetricsSourceHealth, DiagDropRecord, DiagErrorEntry, DiagCacheSyncStatus, DiagInformerSyncStatus, DiagSyncPhase } from '../../api/client'
+import type { DiagnosticsSnapshot, DiagMetricsSourceHealth, DiagDropRecord, DiagErrorEntry, DiagCacheSyncStatus, DiagInformerSyncStatus, DiagSyncPhase, DiagSampleWindow } from '../../api/client'
+import { getK8sUIPerfSnapshot, type K8sUIPerfSnapshot } from '@skyhook-io/k8s-ui'
 
 interface DiagnosticsOverlayProps {
   onClose: () => void
@@ -31,9 +32,10 @@ export function DiagnosticsOverlay({ onClose, isOpen = true }: DiagnosticsOverla
 
   const copyToClipboard = useCallback(async (type: 'json' | 'formatted') => {
     if (!data) return
+    const frontendPerf = getK8sUIPerfSnapshot()
     const text = type === 'json'
-      ? JSON.stringify(data, null, 2)
-      : formatForGitHub(data)
+      ? JSON.stringify({ ...data, frontendPerf }, null, 2)
+      : formatForGitHub(data, frontendPerf)
     try {
       await navigator.clipboard.writeText(text)
       setCopied(type)
@@ -46,7 +48,7 @@ export function DiagnosticsOverlay({ onClose, isOpen = true }: DiagnosticsOverla
 
   const openBugReport = useCallback(() => {
     if (!data) return
-    const body = formatForBugReport(data)
+    const body = formatForBugReport(data, getK8sUIPerfSnapshot())
     const url = `https://github.com/skyhook-io/radar/issues/new?labels=bug&body=${encodeURIComponent(body)}`
     if (url.length > 8000) {
       // URL too long for GitHub — copy diagnostics to clipboard and open blank issue
@@ -116,6 +118,7 @@ export function DiagnosticsOverlay({ onClose, isOpen = true }: DiagnosticsOverla
               <TrafficSection data={data} />
               <PermissionsSection data={data} />
               <APIDiscoverySection data={data} />
+              <PerfSection data={data} />
               <RuntimeSection data={data} />
               <ConfigSection data={data} />
               {data.errors && data.errors.length > 0 && (
@@ -459,6 +462,73 @@ function APIDiscoverySection({ data }: { data: DiagnosticsSnapshot }) {
   )
 }
 
+function PerfSection({ data }: { data: DiagnosticsSnapshot }) {
+  const backend = data.perf
+  const frontend = getK8sUIPerfSnapshot()
+  if (!backend && frontend.totalLayouts === 0 && frontend.totalStructureKeyComputes === 0) return null
+  // Warn when SSE has dropped frames, the topology payload window's p95 exceeds
+  // 5 MB, or the frontend ELK layout p95 exceeds 1s — these are the load-bearing
+  // thresholds for "the tab is going to feel bad."
+  const warn =
+    (backend?.sse.totalDrops ?? 0) > 0 ||
+    (backend?.topology.payloadBytes.p95 ?? 0) > 5 * 1024 * 1024 ||
+    frontend.layoutMs.p95 > 1000
+  return (
+    <Section title="Performance" warn={warn}>
+      {backend && (
+        <>
+          <Row label="Topology Builds" value={backend.topology.totalBuilds.toLocaleString()} />
+          <Row label="  Duration" value={formatSampleDuration(backend.topology.durationUs)} />
+          <Row label="  Node Count" value={formatSampleCount(backend.topology.nodeCount)} />
+          <Row label="  Edge Count" value={formatSampleCount(backend.topology.edgeCount)} />
+          <Row label="  Payload" value={formatSampleBytes(backend.topology.payloadBytes)} warn={backend.topology.payloadBytes.p95 > 5 * 1024 * 1024} />
+          <Row label="  Estimated Nodes" value={formatSampleCount(backend.topology.estimatedNodes)} />
+          <Row label="SSE Broadcasts" value={backend.sse.totalBroadcasts.toLocaleString()} />
+          <Row label="SSE Drops" value={backend.sse.totalDrops.toLocaleString()} warn={backend.sse.totalDrops > 0} />
+        </>
+      )}
+      {(frontend.totalLayouts > 0 || frontend.totalStructureKeyComputes > 0) && (
+        <>
+          <Row label="Frontend Layouts" value={`${frontend.totalLayouts.toLocaleString()} (skipped ${frontend.totalLayoutsSkipped.toLocaleString()})`} />
+          <Row label="  ELK Duration" value={formatFrontendMs(frontend.layoutMs)} warn={frontend.layoutMs.p95 > 1000} />
+          <Row label="  Last Rendered" value={`${frontend.lastLayoutNodeCount.toLocaleString()} nodes / ${frontend.lastLayoutEdgeCount.toLocaleString()} edges`} />
+          <Row label="Frontend structureKey" value={`${frontend.totalStructureKeyComputes.toLocaleString()} computes`} />
+          <Row label="  Duration" value={formatFrontendUs(frontend.structureKeyUs)} />
+        </>
+      )}
+    </Section>
+  )
+}
+
+function formatSampleDuration(w: DiagSampleWindow): string {
+  if (w.count === 0) return 'no samples'
+  const ms = (us: number) => (us / 1000).toFixed(us < 1000 ? 2 : 1)
+  return `last ${ms(w.last)}ms · p50 ${ms(w.p50)} · p95 ${ms(w.p95)} · max ${ms(w.max)}ms (n=${w.count})`
+}
+
+function formatSampleCount(w: DiagSampleWindow): string {
+  if (w.count === 0) return 'no samples'
+  return `last ${w.last.toLocaleString()} · p50 ${w.p50.toLocaleString()} · p95 ${w.p95.toLocaleString()} · max ${w.max.toLocaleString()}`
+}
+
+function formatSampleBytes(w: DiagSampleWindow): string {
+  if (w.count === 0) return 'no samples'
+  const kb = (b: number) => b < 1024 * 1024 ? `${(b / 1024).toFixed(1)}KB` : `${(b / 1024 / 1024).toFixed(2)}MB`
+  return `last ${kb(w.last)} · p50 ${kb(w.p50)} · p95 ${kb(w.p95)} · max ${kb(w.max)}`
+}
+
+function formatFrontendMs(w: { count: number; last: number; p50: number; p95: number; max: number }): string {
+  if (w.count === 0) return 'no samples'
+  const fmt = (v: number) => v < 100 ? v.toFixed(1) : Math.round(v).toString()
+  return `last ${fmt(w.last)}ms · p50 ${fmt(w.p50)} · p95 ${fmt(w.p95)} · max ${fmt(w.max)}ms (n=${w.count})`
+}
+
+function formatFrontendUs(w: { count: number; last: number; p50: number; p95: number; max: number }): string {
+  if (w.count === 0) return 'no samples'
+  const fmt = (v: number) => v < 1000 ? `${v.toFixed(0)}μs` : `${(v / 1000).toFixed(2)}ms`
+  return `last ${fmt(w.last)} · p50 ${fmt(w.p50)} · p95 ${fmt(w.p95)} · max ${fmt(w.max)} (n=${w.count})`
+}
+
 function RuntimeSection({ data }: { data: DiagnosticsSnapshot }) {
   if (!data.runtime) return null
   const rt = data.runtime
@@ -510,7 +580,7 @@ function CopyButton({ label, onClick, copied }: { label: string; onClick: () => 
 
 // --- GitHub-friendly formatting ---
 
-function formatForGitHub(data: DiagnosticsSnapshot, includeRawJson = true): string {
+function formatForGitHub(data: DiagnosticsSnapshot, frontendPerf?: K8sUIPerfSnapshot, includeRawJson = true): string {
   const lines: string[] = []
   lines.push(`## Radar Diagnostics`)
   lines.push(``)
@@ -640,6 +710,37 @@ function formatForGitHub(data: DiagnosticsSnapshot, includeRawJson = true): stri
     lines.push(``)
   }
 
+  if (data.perf || (frontendPerf && (frontendPerf.totalLayouts > 0 || frontendPerf.totalStructureKeyComputes > 0))) {
+    lines.push(`### Performance`)
+    if (data.perf) {
+      const p = data.perf
+      const fmtMs = (us: number) => (us / 1000).toFixed(us < 1000 ? 2 : 1)
+      const fmtKB = (b: number) => b < 1024 * 1024 ? `${(b / 1024).toFixed(1)}KB` : `${(b / 1024 / 1024).toFixed(2)}MB`
+      lines.push(`- Topology Builds: ${p.topology.totalBuilds.toLocaleString()}`)
+      if (p.topology.durationUs.count > 0) {
+        lines.push(`  - Duration (ms): last ${fmtMs(p.topology.durationUs.last)} · p50 ${fmtMs(p.topology.durationUs.p50)} · p95 ${fmtMs(p.topology.durationUs.p95)} · max ${fmtMs(p.topology.durationUs.max)}`)
+        lines.push(`  - Nodes: last ${p.topology.nodeCount.last} · p95 ${p.topology.nodeCount.p95} · max ${p.topology.nodeCount.max}`)
+        lines.push(`  - Edges: last ${p.topology.edgeCount.last} · p95 ${p.topology.edgeCount.p95} · max ${p.topology.edgeCount.max}`)
+        lines.push(`  - Payload: last ${fmtKB(p.topology.payloadBytes.last)} · p95 ${fmtKB(p.topology.payloadBytes.p95)} · max ${fmtKB(p.topology.payloadBytes.max)}`)
+        lines.push(`  - Estimated Nodes: last ${p.topology.estimatedNodes.last} · p95 ${p.topology.estimatedNodes.p95}`)
+      }
+      lines.push(`- SSE: ${p.sse.totalBroadcasts.toLocaleString()} broadcasts, ${p.sse.totalDrops.toLocaleString()} drops`)
+    }
+    if (frontendPerf && (frontendPerf.totalLayouts > 0 || frontendPerf.totalStructureKeyComputes > 0)) {
+      const fmt = (v: number) => v < 100 ? v.toFixed(1) : Math.round(v).toString()
+      lines.push(`- Frontend Layouts: ${frontendPerf.totalLayouts.toLocaleString()} (${frontendPerf.totalLayoutsSkipped.toLocaleString()} skipped)`)
+      if (frontendPerf.layoutMs.count > 0) {
+        lines.push(`  - ELK (ms): last ${fmt(frontendPerf.layoutMs.last)} · p50 ${fmt(frontendPerf.layoutMs.p50)} · p95 ${fmt(frontendPerf.layoutMs.p95)} · max ${fmt(frontendPerf.layoutMs.max)}`)
+        lines.push(`  - Last rendered: ${frontendPerf.lastLayoutNodeCount.toLocaleString()} nodes / ${frontendPerf.lastLayoutEdgeCount.toLocaleString()} edges`)
+      }
+      if (frontendPerf.structureKeyUs.count > 0) {
+        const fmtUs = (v: number) => v < 1000 ? `${Math.round(v)}μs` : `${(v / 1000).toFixed(2)}ms`
+        lines.push(`  - structureKey: ${frontendPerf.totalStructureKeyComputes.toLocaleString()} computes · p50 ${fmtUs(frontendPerf.structureKeyUs.p50)} · p95 ${fmtUs(frontendPerf.structureKeyUs.p95)} · max ${fmtUs(frontendPerf.structureKeyUs.max)}`)
+      }
+    }
+    lines.push(``)
+  }
+
   if (data.runtime) {
     const rt = data.runtime
     lines.push(`### Runtime`)
@@ -683,8 +784,8 @@ function formatForGitHub(data: DiagnosticsSnapshot, includeRawJson = true): stri
   return lines.join('\n')
 }
 
-function formatForBugReport(data: DiagnosticsSnapshot): string {
-  const diagnostics = formatForGitHub(data, false)
+function formatForBugReport(data: DiagnosticsSnapshot, frontendPerf?: K8sUIPerfSnapshot): string {
+  const diagnostics = formatForGitHub(data, frontendPerf, false)
 
   const lines: string[] = []
   lines.push(`## Describe the bug`)


### PR DESCRIPTION
## Summary

First slice of work on Chrome tabs hanging/crashing at 10k+ pod scale — the reported failure was the topology view in a namespace with thousands of pods. This PR lands the measurement layer plus the most direct fix, and two cheap wins.

**Instrumentation (always-on, no flag).** New `pkg/perfstats` keeps lightweight atomic counters + 100-sample windows for topology build duration, node/edge counts, payload bytes, estimated nodes, and SSE broadcasts/drops. Surfaced in the existing Diagnostics overlay and its "Report Bug" markdown so users can include scale state in reports. A frontend perf store times ELK layout + structureKey. This is purely observational — it doesn't drive behavior — but gives us before/after numbers for everything that follows.

**Topology summary mode (the crash fix).** Above a new 2000 estimated-node tier (sitting above the existing 1000 large-cluster threshold), a namespace-filtered build collapses the entire pod tier instead of emitting thousands of Pod/PodGroup nodes. Pod health rolls up onto the owning workload (resources view) or routing Service (traffic view) as a `podSummary`, rendered as a count on the node. This is **semantic degradation, not first-N truncation** — a namespace with 10k pods behind 50 Deployments renders ~50 workload nodes each showing its pod count, not an arbitrary 500. A blue "Summary view" pill explains the mode.

**Two cheap wins.** `structureKey` (topology change-detection) drops its ~50KB-per-render sort+join in favor of a dual xor+sum fold — O(n), constant memory, collision-resistant. SSE topology debounce now scales by the max estimated node count across the current broadcast cycle (min 1s), so big namespaces coalesce updates more aggressively, and it settles within one cycle after a namespace switch rather than staying sticky-high.

## Notes / follow-ups

- **Not visually verified at scale.** Triggering summary mode needs a namespace with 2000+ estimated nodes, which requires a kwok-based perf cluster (next on the list). Backend is unit-tested (topology summary mode, debounce ladder, perfstats, structure-hash); frontend is type-checked but the banner/badges haven't been seen against real 10k-pod data yet.
- **Known limitation (intentional, deferred):** a pathological namespace with thousands of *distinct* workloads, or thousands of truly standalone pods, still emits many nodes — the hard node-cap backstop for that is a planned follow-up. Summary mode bounds the common case (many pods behind few workloads).
- Remaining from the plan: kwok perf-cluster recipe, SSE coalesce-latest, then a measurement pass before deciding on the larger Phase 2/3 items (React Query invalidation, SAR dedup, server-side list pagination).

## Test plan

- [x] `go build ./...`, Go tests pass (perfstats, topology summary mode, SSE debounce ladder, server)
- [x] `make tsc` + k8s-ui unit tests (structure-hash) pass
- [ ] Visual verification of summary-mode banner + workload pod-count badges against a 10k-pod cluster (blocked on perf-cluster)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Summary mode changes topology shape and SSE/HTTP response paths at scale; behavior is heavily unit-tested but large-cluster UI is not yet visually verified.
> 
> **Overview**
> Adds **always-on performance telemetry** (`pkg/perfstats`, k8s-ui perf store) and surfaces it in **Diagnostics** / bug-report exports (topology build stats, payload sizes, SSE broadcasts/drops, ELK layout timings).
> 
> For **large namespace-filtered graphs** (≥2000 estimated nodes), topology **summary mode** drops individual Pod/PodGroup nodes and rolls health into **`podSummary`** on workloads/services (plus bounded orphan summary nodes). The UI shows pod counts on nodes, a summary banner, and only expandable PodGroups that still carry a `pods` array.
> 
> **SSE** topology debounce is now a **1s–15s ladder** from the current cycle’s max estimated nodes (resets on namespace switch / no clients); broadcasts **marshal once per client group** and record payload bytes. **HTTP topology** responses marshal once for the same metrics.
> 
> Frontend **structureKey** uses **order-independent `foldHash`** instead of sort+join to avoid relayout churn and allocation at scale. **`App.tsx`** preserves `summaryMode` / related topology flags when filtering nodes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c76d99391596dcac118b87bcc351927a1bb1c768. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->