### PR TITLE
Bundle Monaco editor for airgapped deployments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1110,8 +1110,7 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -1609,7 +1608,6 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
       "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -2197,7 +2195,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -3043,7 +3040,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -4173,6 +4169,7 @@
         "@fontsource/dm-mono": "^5.2.7",
         "@monaco-editor/react": "^4.7.0",
         "diff": "^9.0.0",
+        "monaco-editor": "^0.55.1",
         "react-markdown": "^10.1.0",
         "react-virtuoso": "^4.18.6",
         "remark-gfm": "^4.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -31,6 +31,7 @@
     "@fontsource/dm-mono": "^5.2.7",
     "@monaco-editor/react": "^4.7.0",
     "diff": "^9.0.0",
+    "monaco-editor": "^0.55.1",
     "react-markdown": "^10.1.0",
     "react-virtuoso": "^4.18.6",
     "remark-gfm": "^4.0.1",

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import './monaco-setup'
 import { RadarApp } from './RadarApp'
 import { openExternal } from './utils/navigation'
 import './index.css'

--- a/web/src/monaco-deep.d.ts
+++ b/web/src/monaco-deep.d.ts
@@ -1,0 +1,8 @@
+// monaco-editor's package `exports` map ("./*": "./*") doesn't surface type
+// declarations for deep ESM subpaths, so TS can't resolve these imports even
+// though the .js/.d.ts files exist on disk. Re-export the root types for the
+// editor API and declare the YAML grammar as a side-effect-only module.
+declare module 'monaco-editor/esm/vs/editor/editor.api' {
+  export * from 'monaco-editor'
+}
+declare module 'monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution'

--- a/web/src/monaco-setup.ts
+++ b/web/src/monaco-setup.ts
@@ -1,0 +1,26 @@
+// Load the Monaco editor from the bundled npm package instead of the default
+// jsdelivr CDN. Without this, @monaco-editor/react fetches the editor at runtime
+// over the network, so the YAML editor never loads in airgapped / offline
+// deployments. Bundling makes the binary fully self-contained.
+//
+// Imported for side effects from main.tsx (Radar's binary entry) only — library
+// consumers (e.g. Radar Hub) keep the default CDN loader unless they opt in.
+//
+// Import the editor API + YAML grammar directly rather than the `monaco-editor`
+// barrel: the barrel pulls in the JSON/CSS/HTML/TypeScript language services,
+// each of which bundles a heavy web worker (the TS one alone is ~7MB) that Radar
+// never uses — it only ever edits YAML.
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api'
+import 'monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution'
+import { loader } from '@monaco-editor/react'
+import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
+
+// YAML has no dedicated Monaco language worker — the base editor worker covers
+// everything we use, so route every label to it.
+;(self as typeof self & { MonacoEnvironment?: { getWorker(): Worker } }).MonacoEnvironment = {
+  getWorker() {
+    return new EditorWorker()
+  },
+}
+
+loader.config({ monaco })

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -33,7 +33,8 @@ export default defineConfig({
           // Trailing slashes on react/ and react-dom/ prevent matching react-router, react-resizable, etc.
           const chunks: Record<string, string[]> = {
             vendor: ['react/', 'react-dom/', 'react-router'],
-            ui: ['@xyflow/', '@monaco-editor/', '@xterm/'],
+            monaco: ['monaco-editor/', '@monaco-editor/'],
+            ui: ['@xyflow/', '@xterm/'],
           }
 
           for (const [chunk, prefixes] of Object.entries(chunks)) {


### PR DESCRIPTION
## Summary

Fixes #738. The YAML editor (`@monaco-editor/react`) fetches Monaco from `cdn.jsdelivr.net` at runtime, so it never loads in airgapped / offline deployments — the editor sits blank. This points the loader at the bundled `monaco-editor` package via `loader.config({ monaco })`, making the binary fully self-contained.

To avoid bloating the embedded binary, it imports `editor.api` + the YAML grammar directly instead of the `monaco-editor` barrel. The barrel drags in the JSON/CSS/HTML/TypeScript language services, each bundling a web worker (~9MB total, the TypeScript one alone is 6.9MB) that Radar never uses — it only edits YAML. Only the base `editor.worker` ships now.

The setup is wired into `main.tsx` (Radar's binary entry) **only**, so library consumers of `@skyhook-io/radar-app` / `@skyhook-io/k8s-ui` (e.g. Radar Hub) keep the default CDN loader unless they opt in — no change to the public surface.

## Verification

- `make tsc` + `make build` clean.
- Build output: `editor.worker` is the only worker emitted; the json/css/html/ts workers are gone.
- Visual test against a live EKS cluster: opened a ConfigMap's YAML view — editor mounts and renders with syntax highlighting, and the only Monaco network request is `GET /assets/monaco-*.js` served from the binary itself. **Zero requests to jsdelivr.** No Monaco console errors.

I also audited the rest of the frontend for runtime network fetches: Monaco was the only one. Fonts (`@fontsource`), Shiki's wasm, and the elk/topology workers are all bundled and served same-origin already.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the standalone app entry and build chunking; no auth or API changes, and library embed paths keep the CDN default.
> 
> **Overview**
> Fixes offline/airgapped YAML editing by **bundling Monaco** instead of letting `@monaco-editor/react` load it from jsdelivr at runtime. A new **`monaco-setup`** module (imported only from **`main.tsx`**, the standalone Radar entry) calls **`loader.config({ monaco })`**, wires **`MonacoEnvironment.getWorker`** to a bundled **`editor.worker`**, and pulls in **`editor.api` plus YAML grammar** only—avoiding the full `monaco-editor` barrel and unused language-service workers.
> 
> **`monaco-editor`** is added as a direct dependency; **`monaco-deep.d.ts`** satisfies TypeScript for deep ESM subpath imports. Vite **`manualChunks`** now emits a dedicated **`monaco`** chunk (separate from other UI vendors). Library consumers of `@skyhook-io/radar-app` that mount via **`index.ts`** are unchanged and still use the default CDN loader unless they opt in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f3bf096f0bc24f17a0da86cfde9046799dd0cf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->