### PR TITLE
Configurable debug-pod image (--debug-image / helm debug.image)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ radar
 | `--disable-exec` | `false` | Disable terminal and debug shell |
 | `--disable-helm-write` | `false` | Disable Helm write operations |
 | `--disable-local-terminal` | `false` | Disable local terminal feature |
+| `--debug-image` | `busybox:latest` | Image for ephemeral debug containers and node debug pods. Point at a mirror for air-gapped / private-registry clusters. |
 | `--prometheus-url` | (auto-discover) | Manual Prometheus/VictoriaMetrics URL (skips auto-discovery) |
 | `--prometheus-header` | | HTTP header sent with every Prometheus request, format `Key=Value` (repeatable). Required for auth-protected backends. |
 | `--auth-mode` | `none` | Authentication mode: `none`, `proxy`, or `oidc` ([details](docs/authentication.md)) |

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -58,6 +58,7 @@ func main() {
 	disableExec := flag.Bool("disable-exec", false, "Simulate restricted exec permissions (disables terminal, debug shell)")
 	disableLocalTerminal := flag.Bool("disable-local-terminal", false, "Disable local terminal feature")
 	podShellDefault := flag.String("pod-shell-default", "", "Override the default pod exec shell command (runs as 'sh -c <value>'; empty = built-in bash -il → ash → sh cascade)")
+	debugImage := flag.String("debug-image", "", "Image for ephemeral debug containers and node debug pods (empty = busybox:latest; point at a mirror for air-gapped/private-registry clusters)")
 	// Timeline storage options
 	timelineStorage := flag.String("timeline-storage", fileCfg.TimelineStorageOr("memory"), "Timeline storage backend: memory or sqlite")
 	timelineDBPath := flag.String("timeline-db", fileCfg.TimelineDBPath, "Path to timeline database file (default: ~/.radar/timeline.db)")
@@ -165,6 +166,7 @@ func main() {
 		DisableExec:          *disableExec,
 		DisableLocalTerminal: *disableLocalTerminal,
 		PodShellDefault:      *podShellDefault,
+		DebugImage:           *debugImage,
 		TimelineStorage:      *timelineStorage,
 		TimelineDBPath:       *timelineDBPath,
 		TimelineRetention:    *timelineRetention,

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -58,7 +58,7 @@ func main() {
 	disableExec := flag.Bool("disable-exec", false, "Simulate restricted exec permissions (disables terminal, debug shell)")
 	disableLocalTerminal := flag.Bool("disable-local-terminal", false, "Disable local terminal feature")
 	podShellDefault := flag.String("pod-shell-default", "", "Override the default pod exec shell command (runs as 'sh -c <value>'; empty = built-in bash -il → ash → sh cascade)")
-	debugImage := flag.String("debug-image", "", "Image for ephemeral debug containers and node debug pods (empty = busybox:latest; point at a mirror for air-gapped/private-registry clusters)")
+	debugImage := flag.String("debug-image", fileCfg.DebugImage, "Image for ephemeral debug containers and node debug pods (empty = busybox:latest; point at a mirror for air-gapped/private-registry clusters)")
 	// Timeline storage options
 	timelineStorage := flag.String("timeline-storage", fileCfg.TimelineStorageOr("memory"), "Timeline storage backend: memory or sqlite")
 	timelineDBPath := flag.String("timeline-db", fileCfg.TimelineDBPath, "Path to timeline database file (default: ~/.radar/timeline.db)")

--- a/deploy/helm/radar/README.md
+++ b/deploy/helm/radar/README.md
@@ -86,6 +86,7 @@ touches its contents.
 | `image.tag` | Image tag | Chart appVersion |
 | `service.type` | Service type | `ClusterIP` |
 | `service.port` | Service port | `9280` |
+| `debug.image` | Image for ephemeral debug containers and node debug pods (point at a mirror for air-gapped / private-registry clusters) | `""` (busybox:latest) |
 | `ingress.enabled` | Enable ingress | `false` |
 | `ingress.className` | Ingress class name | `""` |
 | `timeline.storage` | Timeline storage (memory/sqlite) | `memory` |

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -61,6 +61,9 @@ spec:
             {{- if not .Values.mcp.enabled }}
             - --no-mcp
             {{- end }}
+            {{- if .Values.debug.image }}
+            - --debug-image={{ .Values.debug.image }}
+            {{- end }}
             {{- if ne .Values.auth.mode "none" }}
             - --auth-mode={{ .Values.auth.mode }}
             - --auth-cookie-ttl={{ .Values.auth.cookieTTL }}

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -22,9 +22,10 @@ fullnameOverride: ""
 # containers attached to pods and for privileged node debug pods. Point this at
 # a reachable mirror in air-gapped / private-registry clusters where the default
 # busybox:latest cannot be pulled. Empty = busybox:latest.
-# Note: ephemeral debug containers cannot carry their own imagePullSecrets — they
-# rely on the target pod's pull secrets / node registry config — so the image
-# must be pullable by the workloads being debugged.
+# Note: Radar does not attach imagePullSecrets to debug containers/pods —
+# ephemeral containers inherit the target pod's, and node debug pods rely on the
+# default namespace's ServiceAccount / node registry config — so the image must
+# be pullable without extra credentials from Radar.
 debug:
   image: ""
 

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -18,6 +18,16 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Debug feature (terminal "Debug" tab): the image used for ephemeral debug
+# containers attached to pods and for privileged node debug pods. Point this at
+# a reachable mirror in air-gapped / private-registry clusters where the default
+# busybox:latest cannot be pulled. Empty = busybox:latest.
+# Note: ephemeral debug containers cannot carry their own imagePullSecrets — they
+# rely on the target pod's pull secrets / node registry config — so the image
+# must be pullable by the workloads being debugged.
+debug:
+  image: ""
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,7 +22,8 @@ Persistent defaults for CLI flags. CLI flags always override these values. Manag
   "historyLimit": 10000,
   "prometheusUrl": "",
   "prometheusHeaders": {},
-  "mcp": true
+  "mcp": true,
+  "debugImage": ""
 }
 ```
 
@@ -41,6 +42,7 @@ All fields are optional — omitted fields use built-in defaults.
 | `prometheusUrl` | Manual Prometheus/VictoriaMetrics URL — skips auto-discovery. Useful when Prometheus is not in the same cluster or uses a non-standard service name. |
 | `prometheusHeaders` | HTTP headers sent with every Prometheus request. Required for auth-protected backends — e.g. `{"Authorization": "Bearer <token>", "X-Scope-OrgID": "my-org"}`. Equivalent CLI: `--prometheus-header Key=Value` (repeatable). Stored in plain text in `config.json` — protect the file accordingly. |
 | `mcp` | Enable/disable MCP server for AI tools (default: enabled) |
+| `debugImage` | Image for ephemeral debug containers and node debug pods (same as `--debug-image`). Empty = `busybox:latest`; point at a mirror for air-gapped / private-registry clusters. |
 
 ### Settings File (`~/.radar/settings.json`)
 

--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -153,6 +153,16 @@ rbac:
   helm: false         # Enable Helm write operations (broad permissions)
 ```
 
+The terminal's **Debug** action launches a throwaway container (ephemeral container on a pod, or a privileged pod on a node) using `busybox:latest` by default. In air-gapped or private-registry clusters where that image can't be pulled, point it at a reachable mirror:
+
+```yaml
+# values.yaml
+debug:
+  image: my-registry.internal/busybox:1.36
+```
+
+Ephemeral debug containers can't carry their own image-pull secrets — they reuse the target pod's — so the image must be pullable by the workload being debugged.
+
 ### CRD Permissions
 
 Radar reads CRDs from many popular tools. Each CRD group can be toggled individually:
@@ -286,6 +296,7 @@ See [Helm Chart README](../deploy/helm/radar/README.md) for all available values
 | `ingress.className` | Ingress class | `""` |
 | `service.port` | Service port | `9280` |
 | `mcp.enabled` | Enable MCP server for AI tools | `true` |
+| `debug.image` | Image for ephemeral debug containers and node debug pods (point at a mirror for air-gapped / private-registry clusters) | `""` (busybox:latest) |
 | `timeline.storage` | Event storage (memory/sqlite) | `memory` |
 | `timeline.dbPath` | SQLite database path | `/data/timeline.db` |
 | `timeline.historyLimit` | Max events to retain (memory only) | `10000` |

--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -161,7 +161,7 @@ debug:
   image: my-registry.internal/busybox:1.36
 ```
 
-Ephemeral debug containers can't carry their own image-pull secrets — they reuse the target pod's — so the image must be pullable by the workload being debugged.
+Radar doesn't attach image-pull secrets to debug containers or pods — ephemeral containers inherit the target pod's, and node debug pods rely on the `default` namespace's ServiceAccount / node registry config — so the image must be pullable without Radar supplying credentials.
 
 ### CRD Permissions
 

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -39,6 +39,7 @@ type AppConfig struct {
 	DisableExec          bool
 	DisableLocalTerminal bool
 	PodShellDefault      string
+	DebugImage           string
 	TimelineStorage      string
 	TimelineDBPath       string
 	TimelineRetention    time.Duration
@@ -166,6 +167,7 @@ func CreateServer(cfg AppConfig) *server.Server {
 		HistoryLimit:      cfg.HistoryLimit,
 		PrometheusURL:     cfg.PrometheusURL,
 		PrometheusHeaders: cfg.PrometheusHeaders,
+		DebugImage:        cfg.DebugImage,
 		MCP:               &cfg.MCPEnabled,
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,10 @@ type Config struct {
 	// Stored in plain text in ~/.radar/config.json — protect the file accordingly.
 	PrometheusHeaders map[string]string `json:"prometheusHeaders,omitempty"`
 	MCP               *bool             `json:"mcp,omitempty"` // nil = default (true), false = disabled
+	// DebugImage is the image used for ephemeral debug containers and node debug
+	// pods. Empty falls back to busybox:latest; set it to a reachable mirror for
+	// air-gapped / private-registry clusters.
+	DebugImage string `json:"debugImage,omitempty"`
 }
 
 // mu serializes Load-mutate-Save cycles to prevent concurrent writes

--- a/internal/server/exec.go
+++ b/internal/server/exec.go
@@ -517,6 +517,19 @@ func looksLikeShellNotFound(errMsg string) bool {
 	return false
 }
 
+// resolveDebugImage returns the image to use for a debug container/pod: an
+// explicit per-request override, else the operator-configured --debug-image,
+// else the built-in busybox default.
+func (s *Server) resolveDebugImage(requested string) string {
+	if requested != "" {
+		return requested
+	}
+	if s.effectiveConfig != nil && s.effectiveConfig.DebugImage != "" {
+		return s.effectiveConfig.DebugImage
+	}
+	return k8score.DefaultDebugImage
+}
+
 // NodeDebugRequest is the request body for creating a node debug pod
 type NodeDebugRequest struct {
 	Image string `json:"image,omitempty"`
@@ -554,7 +567,7 @@ func (s *Server) handleNodeDebug(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create the debug pod
-	result, err := k8score.CreateNodeDebugPod(r.Context(), client, nodeName, req.Image)
+	result, err := k8score.CreateNodeDebugPod(r.Context(), client, nodeName, s.resolveDebugImage(req.Image))
 	if err != nil {
 		if apierrors.IsForbidden(err) {
 			s.writeError(w, http.StatusForbidden, err.Error())
@@ -646,7 +659,7 @@ func (s *Server) handleCreateDebugContainer(w http.ResponseWriter, r *http.Reque
 		Namespace:       namespace,
 		PodName:         podName,
 		TargetContainer: req.TargetContainer,
-		Image:           req.Image,
+		Image:           s.resolveDebugImage(req.Image),
 	}, client)
 	if err != nil {
 		errMsg := err.Error()

--- a/internal/server/exec_debug_image_test.go
+++ b/internal/server/exec_debug_image_test.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/skyhook-io/radar/internal/config"
+	"github.com/skyhook-io/radar/pkg/k8score"
+)
+
+func TestResolveDebugImage(t *testing.T) {
+	tests := []struct {
+		name      string
+		configImg string
+		requested string
+		want      string
+	}{
+		{"request override wins over config", "mirror/busybox:1.36", "custom/alpine:3", "custom/alpine:3"},
+		{"config used when no request override", "mirror/busybox:1.36", "", "mirror/busybox:1.36"},
+		{"request override wins over default", "", "custom/alpine:3", "custom/alpine:3"},
+		{"falls back to busybox default", "", "", k8score.DefaultDebugImage},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Server{effectiveConfig: &config.Config{DebugImage: tt.configImg}}
+			if got := s.resolveDebugImage(tt.requested); got != tt.want {
+				t.Errorf("resolveDebugImage(%q) with config %q = %q, want %q", tt.requested, tt.configImg, got, tt.want)
+			}
+		})
+	}
+
+	// A nil effectiveConfig must not panic and falls back to the built-in default.
+	s := &Server{}
+	if got := s.resolveDebugImage(""); got != k8score.DefaultDebugImage {
+		t.Errorf("resolveDebugImage with nil config = %q, want %q", got, k8score.DefaultDebugImage)
+	}
+}

--- a/pkg/k8score/node_debug.go
+++ b/pkg/k8score/node_debug.go
@@ -56,7 +56,7 @@ func CreateNodeDebugPod(ctx context.Context, client kubernetes.Interface, nodeNa
 	}
 
 	if image == "" {
-		image = "busybox:latest"
+		image = DefaultDebugImage
 	}
 
 	containerName := "debug"

--- a/web/src/components/dock/TerminalTab.tsx
+++ b/web/src/components/dock/TerminalTab.tsx
@@ -19,7 +19,7 @@ export function TerminalTab({ namespace, podName, containerName, containers, isA
     const response = await fetch(apiUrl(`/pods/${namespace}/${podName}/debug`), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ targetContainer, image: 'busybox:latest' }),
+      body: JSON.stringify({ targetContainer }),
     })
     if (!response.ok) {
       const err = await response.json().catch(() => ({ error: 'Unknown error' }))


### PR DESCRIPTION
## Summary

Closes #737. Debug containers — both pod ephemeral containers and privileged node debug pods — were hardcoded to `busybox:latest`. In air-gapped / private-registry clusters that image is unreachable, so the terminal "Debug" feature fails. This adds a `--debug-image` flag (helm value `debug.image`) so operators can point at a reachable mirror.

The image is resolved with clear precedence: **per-request override > `--debug-image` > `busybox:latest`**. The value flows through `config.Config` (so it's also visible on `GET /api/config`) and is applied in both debug handlers via a shared `resolveDebugImage()`. The frontend stops hardcoding `busybox:latest` in the pod-debug request, so the server-configured default takes effect (node debug already sent an empty body).

The helm chart gets a documented `debug.image` value that renders `--debug-image` only when set, keeping the default behavior unchanged.

## Scope note

I did **not** add `imagePullSecrets` for debug containers (the reporter mentioned it). Ephemeral debug containers can't carry their own pull secrets — they inherit the target pod's — so they need an image pullable by the workload being debugged, which the image override provides. This constraint is documented in `values.yaml`. Pull-secret support on node debug pods (where Radar owns the full pod spec) is a clean follow-up if wanted.

## Verification

- `go build ./...`, `go test` (server + config + k8score), `make tsc`, `helm lint` all pass; new unit test pins the resolution precedence + nil-config safety.
- Verified end-to-end against a live EKS cluster: launched with `--debug-image=alpine:3.20`, created a debug container via the same request the UI sends (no image), and confirmed via the endpoint response, `kubectl` (ephemeral container image = `alpine:3.20`), and Radar's own pod events that the configured image — not busybox — was used.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration and debug-path image selection only; default behavior unchanged when unset, with a small test-backed resolver change.
> 
> **Overview**
> **Debug containers and node debug pods** no longer rely on a hardcoded `busybox:latest` everywhere. Operators can set **`--debug-image`**, **`debugImage`** in `~/.radar/config.json`, or Helm **`debug.image`** so the terminal **Debug** feature uses a mirror in air-gapped or private-registry clusters.
> 
> Resolution is centralized in **`resolveDebugImage`**: per-request `image` in the API body wins, then the configured default, then **`k8score.DefaultDebugImage`** (`busybox:latest`). Pod ephemeral debug and node debug handlers both use this helper; **`CreateNodeDebugPod`** empty-image fallback now references the same constant.
> 
> The **UI** stops sending `image: 'busybox:latest'` on pod debug POSTs so the server default applies. **Helm** passes `--debug-image` only when `debug.image` is set, preserving unchanged defaults. Docs and README describe pull-secret limitations (ephemeral containers inherit the target pod’s credentials).
> 
> A unit test covers precedence and nil-config safety.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36eaf8d04d99250b537afcbcdca9d945474c1855. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->