### PR TITLE
feat(mcp): top/resources endpoint, embedding access opt-outs, diagnose steering

### DIFF
--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -133,6 +133,32 @@ func TestCompose_EventsExcludedByDefault(t *testing.T) {
 	}
 }
 
+func TestCompose_MissingRefsDefaultAndSourceFilter(t *testing.T) {
+	p := &fakeProvider{
+		problems: []k8s.Problem{
+			{Kind: "Service", Namespace: "prod", Name: "api", Severity: "warning", Reason: "Selector matches no pods"},
+		},
+		missingRefs: []k8s.Problem{
+			{Kind: "Pod", Namespace: "prod", Name: "web", Severity: "critical", Reason: "Missing PVC"},
+		},
+	}
+
+	out := Compose(p, Filters{})
+	if !hasIssueSource(out, SourceProblem) || !hasIssueSource(out, SourceMissingRef) {
+		t.Fatalf("default Compose should include problem + missing_ref, got %+v", out)
+	}
+
+	out = Compose(p, Filters{Sources: []Source{SourceMissingRef}})
+	if len(out) != 1 || out[0].Source != SourceMissingRef || out[0].Reason != "Missing PVC" {
+		t.Fatalf("source=missing_ref should return only missing refs, got %+v", out)
+	}
+
+	out = Compose(p, Filters{Sources: []Source{SourceProblem}})
+	if len(out) != 1 || out[0].Source != SourceProblem || out[0].Reason != "Selector matches no pods" {
+		t.Fatalf("source=problem should exclude missing refs, got %+v", out)
+	}
+}
+
 func TestCompose_GenericCRDConditionFallback(t *testing.T) {
 	gvr := schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}
 	app := &unstructured.Unstructured{Object: map[string]any{
@@ -537,6 +563,15 @@ func TestCompose_DeterministicOrderForTies(t *testing.T) {
 
 // silence unused-import lint when sort isn't used elsewhere
 var _ = sort.Strings
+
+func hasIssueSource(issues []Issue, source Source) bool {
+	for _, issue := range issues {
+		if issue.Source == source {
+			return true
+		}
+	}
+	return false
+}
 
 // flattenNamespacedProblems exists to keep CacheProvider's per-
 // namespace fan-out from leaking + duplicating cluster-scoped

--- a/internal/k8s/capabilities.go
+++ b/internal/k8s/capabilities.go
@@ -85,6 +85,7 @@ type Capabilities struct {
 	AuthEnabled   bool                 `json:"authEnabled,omitempty"` // Auth is enabled on the server
 	Username      string               `json:"username,omitempty"`    // Authenticated username (when auth enabled)
 	Resources     *ResourcePermissions `json:"resources,omitempty"`   // Per-resource-type permissions
+	Visibility    *VisibilitySummary   `json:"visibility,omitempty"`  // Present when resource visibility is limited enough to make diagnostics incomplete
 }
 
 // NamespaceCapabilities holds the effective exec/logs/portForward capabilities

--- a/internal/k8s/missing_refs_test.go
+++ b/internal/k8s/missing_refs_test.go
@@ -11,6 +11,10 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -287,6 +291,113 @@ func TestDetectMissingRefs(t *testing.T) {
 		} else if p.Severity != "critical" {
 			t.Errorf("non-TLS missing-ref should be critical severity, got %q: %+v", p.Severity, p)
 		}
+	}
+}
+
+func TestDetectMissingWebhookRefs(t *testing.T) {
+	defer ResetTestState()
+	defer ResetTestDynamicState()
+
+	now := metav1.NewTime(time.Now().Add(-5 * time.Minute))
+	existingSvc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "webhook-ok", Namespace: "hooks", CreationTimestamp: now}}
+	client := fake.NewClientset(existingSvc)
+	if err := InitTestResourceCache(client); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+
+	vwhGVR := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "validatingwebhookconfigurations"}
+	mwhGVR := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "mutatingwebhookconfigurations"}
+	scheme := runtime.NewScheme()
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{
+			vwhGVR: "ValidatingWebhookConfigurationList",
+			mwhGVR: "MutatingWebhookConfigurationList",
+		},
+		webhookConfig("ValidatingWebhookConfiguration", "validate-hooks", now, []any{
+			webhookWithService("missing", "hooks", "does-not-exist"),
+			webhookWithService("existing", "hooks", "webhook-ok"),
+			webhookWithURL("external"),
+		}),
+		webhookConfig("MutatingWebhookConfiguration", "mutate-hooks", now, []any{
+			webhookWithService("missing-mutating", "hooks", "mutating-missing"),
+		}),
+	)
+	if err := InitTestDynamicResourceCache(dynClient, []APIResource{
+		{Group: "admissionregistration.k8s.io", Version: "v1", Kind: "ValidatingWebhookConfiguration", Name: "validatingwebhookconfigurations", Verbs: []string{"list", "watch"}},
+		{Group: "admissionregistration.k8s.io", Version: "v1", Kind: "MutatingWebhookConfiguration", Name: "mutatingwebhookconfigurations", Verbs: []string{"list", "watch"}},
+	}); err != nil {
+		t.Fatalf("InitTestDynamicResourceCache: %v", err)
+	}
+
+	dynCache := GetDynamicResourceCache()
+	discovery := GetResourceDiscovery()
+	if err := dynCache.EnsureWatching(vwhGVR); err != nil {
+		t.Fatalf("EnsureWatching validating webhooks: %v", err)
+	}
+	if err := dynCache.EnsureWatching(mwhGVR); err != nil {
+		t.Fatalf("EnsureWatching mutating webhooks: %v", err)
+	}
+	if !dynCache.WaitForSync(vwhGVR, 2*time.Second) {
+		t.Fatal("validating webhook dynamic cache did not sync")
+	}
+	if !dynCache.WaitForSync(mwhGVR, 2*time.Second) {
+		t.Fatal("mutating webhook dynamic cache did not sync")
+	}
+
+	problems := DetectMissingWebhookRefs(GetResourceCache(), dynCache, discovery, "")
+	if !findProblem(problems, "ValidatingWebhookConfiguration", "", "validate-hooks", "Missing webhook backend Service") {
+		t.Fatalf("missing validating webhook Service not detected: %+v", problems)
+	}
+	if !findProblem(problems, "MutatingWebhookConfiguration", "", "mutate-hooks", "Missing webhook backend Service") {
+		t.Fatalf("missing mutating webhook Service not detected: %+v", problems)
+	}
+	if len(problems) != 2 {
+		t.Fatalf("expected exactly 2 missing webhook refs, got %+v", problems)
+	}
+	for _, p := range problems {
+		if p.Namespace != "" {
+			t.Errorf("webhook configs are cluster-scoped; got namespace on problem: %+v", p)
+		}
+		if hasSubstr(p.Message, "webhook-ok") || hasSubstr(p.Message, "external") {
+			t.Errorf("existing Service or URL-based webhook should not flag: %+v", p)
+		}
+	}
+	if scoped := DetectMissingWebhookRefs(GetResourceCache(), dynCache, discovery, "hooks"); len(scoped) != 0 {
+		t.Fatalf("namespace-scoped call should omit cluster-scoped webhook configs, got %+v", scoped)
+	}
+}
+
+func webhookConfig(kind, name string, ts metav1.Time, webhooks []any) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "admissionregistration.k8s.io/v1",
+		"kind":       kind,
+		"metadata": map[string]any{
+			"name":              name,
+			"creationTimestamp": ts.Format(time.RFC3339),
+		},
+		"webhooks": webhooks,
+	}}
+}
+
+func webhookWithService(name, namespace, service string) map[string]any {
+	return map[string]any{
+		"name": name,
+		"clientConfig": map[string]any{
+			"service": map[string]any{
+				"name":      service,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+func webhookWithURL(name string) map[string]any {
+	return map[string]any{
+		"name": name,
+		"clientConfig": map[string]any{
+			"url": "https://example.com/webhook",
+		},
 	}
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,7 +1,10 @@
 package mcp
 
 import (
+	"log"
 	"net/http"
+	"os"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -22,12 +25,52 @@ func NewHandler() http.Handler {
 	registerTools(server)
 	registerResources(server)
 
+	streamOpts := &mcp.StreamableHTTPOptions{Stateless: true}
+	// The MCP SDK auto-enables DNS-rebinding protection (Host header must be
+	// loopback) when the server binds to a loopback address. That blocks
+	// Docker-isolated callers reaching us via host.docker.internal. Allow
+	// opt-out via env for bench setups.
+	if os.Getenv("RADAR_MCP_DISABLE_LOCALHOST_PROTECTION") == "1" {
+		streamOpts.DisableLocalhostProtection = true
+		log.Printf("[mcp] WARNING: DNS-rebinding Host check DISABLED via env (bench mode)")
+	}
+
 	handler := mcp.NewStreamableHTTPHandler(
 		func(r *http.Request) *mcp.Server { return server },
-		&mcp.StreamableHTTPOptions{Stateless: true},
+		streamOpts,
 	)
 
 	// go-sdk v1.6 removed the implicit cross-origin protection default;
 	// wrap the handler so a malicious page can't drive the local MCP server.
-	return http.NewCrossOriginProtection().Handler(handler)
+	//
+	// RADAR_MCP_DISABLE_ORIGIN_PROTECTION=1 fully bypasses the wrapper. Use
+	// ONLY in trusted environments where radar is reached from a known
+	// non-localhost address (e.g. Docker-isolated bench agents calling via
+	// host.docker.internal). Never set in user-facing installs.
+	if os.Getenv("RADAR_MCP_DISABLE_ORIGIN_PROTECTION") == "1" {
+		log.Printf("[mcp] WARNING: cross-origin protection DISABLED via env (bench mode)")
+		return handler
+	}
+
+	prot := http.NewCrossOriginProtection()
+
+	// Allow additional origins for browser-style callers. Does NOT affect
+	// Host header validation — for Docker/external-host access use the
+	// DISABLE env above. RADAR_MCP_TRUSTED_ORIGINS is a comma-separated
+	// list of scheme://host[:port] entries.
+	if env := strings.TrimSpace(os.Getenv("RADAR_MCP_TRUSTED_ORIGINS")); env != "" {
+		for _, origin := range strings.Split(env, ",") {
+			origin = strings.TrimSpace(origin)
+			if origin == "" {
+				continue
+			}
+			if err := prot.AddTrustedOrigin(origin); err != nil {
+				log.Printf("[mcp] WARNING: failed to add trusted origin %q: %v", origin, err)
+				continue
+			}
+			log.Printf("[mcp] trusted cross-origin: %s", origin)
+		}
+	}
+
+	return prot.Handler(handler)
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -155,18 +155,19 @@ func registerTools(server *mcp.Server) {
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name: "diagnose",
-		Description: "Use when the agent's decision is 'this thing is broken — give me " +
-			"everything in one call'. Bundles for a single Pod/Deployment/StatefulSet/" +
-			"DaemonSet: the resource (Kubernetes-shaped detail) + diagnostic resourceContext " +
-			"(managedBy, exposes, selectedBy, uses, runsOn, issue/audit/policy rollups) + " +
-			"current AND previous container logs across the workload's pods + recent " +
-			"Warning events filtered to this resource. Use for CrashLoopBackOff, failed " +
-			"deploys, image-pull errors, readiness flaps, scheduling failures, or any " +
-			"first-pass triage where you would otherwise call get_resource → events → " +
-			"get_pod_logs → get_pod_logs(previous=true) in sequence. If you only need ONE " +
-			"facet (e.g. just spec, just logs), prefer the targeted tool — diagnose is " +
-			"heavier. Not for CRDs or non-workload kinds; use get_resource " +
-			"(with optional include=events) for those.",
+		Description: "Use when the agent's decision is 'this workload is broken — find the " +
+			"root cause / localize the failure'. Bundles for a single Pod/Deployment/" +
+			"StatefulSet/DaemonSet: the resource (Kubernetes-shaped detail) + diagnostic " +
+			"resourceContext (managedBy, exposes, selectedBy, uses, runsOn, " +
+			"issue/audit/policy rollups) + current AND previous container logs across the " +
+			"workload's pods + recent Warning events filtered to this resource. Use for " +
+			"CrashLoopBackOff, OOMKills, failed deploys, image-pull errors, readiness " +
+			"flaps, scheduling failures, error-spewing services, or any workload " +
+			"root-causing where you would otherwise call get_resource → events → " +
+			"get_pod_logs → get_pod_logs(previous=true) in sequence — this returns the " +
+			"same data in one round-trip. If you only need ONE facet (e.g. just spec, " +
+			"just logs), prefer the targeted tool. Not for CRDs or non-workload kinds; " +
+			"use get_resource (with optional include=events) for those.",
 		Annotations: readOnly,
 	}, logToolCall("diagnose", handleDiagnose))
 
@@ -284,9 +285,11 @@ func registerTools(server *mcp.Server) {
 			"crashing pod can have zero). The `source` param is a FILTER: source=kyverno " +
 			"returns ONLY Kyverno rows. To ADD an opt-in source to the defaults, list " +
 			"everything explicitly — e.g. source=problem,missing_ref,condition,kyverno. " +
-			"After identifying a suspect issue, call get_resource (or diagnose for a " +
-			"full debug bundle) for spec/status, or get_neighborhood when the failure " +
-			"likely crosses Services/workloads/Pods/dependencies.",
+			"After identifying a suspect issue, call diagnose when the affected resource " +
+			"is a workload (Pod/Deployment/StatefulSet/DaemonSet) — it bundles spec + " +
+			"logs + events + context in one call. For non-workload kinds, call " +
+			"get_resource. Use get_neighborhood when the failure likely crosses " +
+			"Services/workloads/Pods/dependencies.",
 		Annotations: readOnly,
 	}, logToolCall("issues", handleIssuesTool))
 
@@ -1630,22 +1633,22 @@ func handleListNamespaces(ctx context.Context, req *mcp.CallToolRequest, input s
 // Dashboard builder for MCP (simplified version of server/dashboard.go)
 
 type mcpDashboard struct {
-	Cluster        mcpClusterInfo         `json:"cluster"`
-	Nodes          mcpNodeSummary         `json:"nodes"`
-	VersionSkew    []string               `json:"versionSkew,omitempty"`
-	Health         mcpHealthSummary       `json:"health"`
-	Problems       []mcpProblem           `json:"problems"`
-	TotalProblems  int                    `json:"totalProblems"`           // count before the dashboard cap was applied
-	ProblemsBySeverity map[string]int     `json:"problemsBySeverity,omitempty"` // critical/high/medium/warning counts across the full set
-	RecentChanges  []mcpChange            `json:"recentChanges,omitempty"`
-	WarningEvents  int                    `json:"warningEvents"`
-	TopWarnings    []mcpWarning           `json:"topWarnings"`
-	HelmReleases   mcpHelmSummary         `json:"helmReleases"`
-	Metrics        *mcpMetrics            `json:"metrics,omitempty"`
-	TopologyNodes  int                    `json:"topologyNodes"`
-	TopologyEdges  int                    `json:"topologyEdges"`
-	ResourceCounts map[string]int         `json:"resourceCounts"`
-	Visibility     *k8s.VisibilitySummary `json:"visibility,omitempty"`
+	Cluster            mcpClusterInfo         `json:"cluster"`
+	Nodes              mcpNodeSummary         `json:"nodes"`
+	VersionSkew        []string               `json:"versionSkew,omitempty"`
+	Health             mcpHealthSummary       `json:"health"`
+	Problems           []mcpProblem           `json:"problems"`
+	TotalProblems      int                    `json:"totalProblems"`                // count before the dashboard cap was applied
+	ProblemsBySeverity map[string]int         `json:"problemsBySeverity,omitempty"` // critical/high/medium/warning counts across the full set
+	RecentChanges      []mcpChange            `json:"recentChanges,omitempty"`
+	WarningEvents      int                    `json:"warningEvents"`
+	TopWarnings        []mcpWarning           `json:"topWarnings"`
+	HelmReleases       mcpHelmSummary         `json:"helmReleases"`
+	Metrics            *mcpMetrics            `json:"metrics,omitempty"`
+	TopologyNodes      int                    `json:"topologyNodes"`
+	TopologyEdges      int                    `json:"topologyEdges"`
+	ResourceCounts     map[string]int         `json:"resourceCounts"`
+	Visibility         *k8s.VisibilitySummary `json:"visibility,omitempty"`
 }
 
 type mcpChange struct {
@@ -1872,9 +1875,6 @@ func buildDashboard(ctx context.Context, cache *k8s.ResourceCache, namespace str
 	// loop above only catches running-but-broken pods (CrashLoopBackOff,
 	// not-ready); Pods that fail to schedule on a missing PVC stay Pending
 	// without container statuses and would otherwise be invisible. Dedupe
-	// by (kind, ns, name) so a Pod already flagged by the pod-error loop
-	// (e.g. CreateContainerConfigError on a missing ConfigMap) doesn't
-	// appear twice.
 	// Dedupe exact-duplicate rows, not resource identities. Keying on
 	// (kind, ns, name, reason) lets distinct missing-ref reasons on the
 	// same Pod survive — a Pod missing both PVC and ConfigMap emits two

--- a/internal/mcp/tools_catalog_test.go
+++ b/internal/mcp/tools_catalog_test.go
@@ -1,0 +1,83 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestRegisteredToolAnnotations(t *testing.T) {
+	tools := listRegisteredTools(t)
+	writeTools := map[string]bool{
+		"manage_workload": true,
+		"manage_cronjob":  true,
+		"manage_gitops":   true,
+		"apply_resource":  true,
+		"manage_node":     true,
+	}
+
+	seenWriteTools := map[string]bool{}
+	for _, tool := range tools {
+		if tool.Annotations == nil {
+			t.Fatalf("tool %q missing annotations", tool.Name)
+		}
+		if tool.Annotations.OpenWorldHint == nil || *tool.Annotations.OpenWorldHint {
+			t.Errorf("tool %q should set openWorldHint=false", tool.Name)
+		}
+		if writeTools[tool.Name] {
+			seenWriteTools[tool.Name] = true
+			if tool.Annotations.ReadOnlyHint {
+				t.Errorf("write tool %q should not set readOnlyHint=true", tool.Name)
+			}
+			if tool.Annotations.DestructiveHint == nil || !*tool.Annotations.DestructiveHint {
+				t.Errorf("write tool %q should set destructiveHint=true", tool.Name)
+			}
+			continue
+		}
+		if !tool.Annotations.ReadOnlyHint {
+			t.Errorf("read tool %q should set readOnlyHint=true", tool.Name)
+		}
+		if tool.Annotations.DestructiveHint != nil && *tool.Annotations.DestructiveHint {
+			t.Errorf("read tool %q should not set destructiveHint=true", tool.Name)
+		}
+	}
+
+	for name := range writeTools {
+		if !seenWriteTools[name] {
+			t.Errorf("write tool %q was not registered", name)
+		}
+	}
+}
+
+func listRegisteredTools(t *testing.T) []*mcpsdk.Tool {
+	t.Helper()
+
+	server := mcpsdk.NewServer(&mcpsdk.Implementation{Name: "radar-test", Version: "test"}, nil)
+	registerTools(server)
+
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "radar-test-client", Version: "test"}, nil)
+	ctx := context.Background()
+	serverTransport, clientTransport := mcpsdk.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server.Connect: %v", err)
+	}
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client.Connect: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = clientSession.Close()
+		_ = serverSession.Wait()
+	})
+
+	result, err := clientSession.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if len(result.Tools) == 0 {
+		t.Fatal("no MCP tools registered")
+	}
+	return result.Tools
+}

--- a/internal/server/issues_handler_test.go
+++ b/internal/server/issues_handler_test.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/skyhook-io/radar/internal/k8s"
@@ -123,6 +125,25 @@ func TestIssuesHandler_KyvernoMetaOmittedWhenNotRequested(t *testing.T) {
 	}
 	if _, ok := body["meta"]; ok {
 		t.Errorf("default request should not emit meta.kyverno; got %+v", body["meta"])
+	}
+}
+
+func TestIssuesHandlerRejectsAuditSource(t *testing.T) {
+	resp, err := http.Get(testServer.URL + "/api/issues?source=audit")
+	if err != nil {
+		t.Fatalf("GET /api/issues: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if !strings.Contains(string(body), "use GET /api/audit") {
+		t.Fatalf("error did not point caller to /api/audit: %q", string(body))
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -340,6 +340,7 @@ func (s *Server) setupRoutes() {
 			r.Get("/metrics/nodes/{name}/history", s.handleNodeMetricsHistory)
 			r.Get("/metrics/top/pods", s.handleTopPods)
 			r.Get("/metrics/top/nodes", s.handleTopNodes)
+			r.Get("/metrics/top/resources", s.handleTopResources)
 
 			// Port forwarding
 			r.Get("/portforwards", s.handleListPortForwards)
@@ -721,9 +722,11 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 	// state to distinguish loading from RBAC restrictions.
 	if result := k8s.GetCachedPermissionResult(); result != nil {
 		caps.Resources = result.Perms
+		caps.Visibility = k8s.BuildVisibilitySummary(result, r.URL.Query().Get("namespace"))
 	} else if k8s.GetResourceCache() != nil {
 		if result := k8s.CheckResourcePermissions(r.Context()); result != nil {
 			caps.Resources = result.Perms
+			caps.Visibility = k8s.BuildVisibilitySummary(result, r.URL.Query().Get("namespace"))
 		}
 	}
 
@@ -1530,7 +1533,7 @@ func setTypeMeta(resource any) {
 //  1. kind == "namespaces"        → full Namespace object requires get-namespaces SAR
 //  2. cluster-scoped (Node/CRD/…) → per-kind get SAR (ClassifyKindScope)
 //  3. namespaced                   → namespace access via getUserNamespaces,
-//                                    plus per-namespace get SAR for Secrets
+//     plus per-namespace get SAR for Secrets
 func (s *Server) preflightResourceGet(r *http.Request, kind, namespace, name, group string) (int, string, bool) {
 	isNamespacesKind := kind == "namespaces" || kind == "namespace"
 	isClusterScoped, gvrGroup, gvrResource := k8s.ClassifyKindScope(kind, group)
@@ -2116,6 +2119,80 @@ func (s *Server) handleTopNodes(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.writeJSON(w, result)
+}
+
+// handleTopResources returns ranked live metrics for agents and compact
+// diagnostics. It is intentionally separate from /metrics/top/{pods,nodes},
+// which back UI tables and preserve their unsorted array shape.
+func (s *Server) handleTopResources(w http.ResponseWriter, r *http.Request) {
+	if !s.requireConnected(w) {
+		return
+	}
+	q := r.URL.Query()
+	kind := q.Get("kind")
+	if kind == "" {
+		kind = k8s.TopMetricsKindPods
+	}
+	opts := k8s.NormalizeTopMetricsOptions(k8s.TopMetricsOptions{
+		Kind:      kind,
+		Namespace: q.Get("namespace"),
+		Sort:      q.Get("sort"),
+		Limit:     parseLimit(q.Get("limit")),
+	})
+
+	if opts.Kind == k8s.TopMetricsKindNodes {
+		if !s.canRead(r, "", "nodes", "", "list") {
+			s.writeJSON(w, k8s.TopMetricsResponse{
+				Kind:   opts.Kind,
+				Sort:   opts.Sort,
+				Reason: "no access to nodes (cluster-scoped resource requires explicit RBAC)",
+			})
+			return
+		}
+		s.writeJSON(w, k8s.BuildTopMetrics(opts))
+		return
+	}
+
+	namespaces := s.parseNamespacesForUser(r)
+	if opts.Namespace != "" {
+		if !namespaceAllowed(namespaces, opts.Namespace) {
+			s.writeJSON(w, k8s.TopMetricsResponse{
+				Kind:      opts.Kind,
+				Sort:      opts.Sort,
+				Namespace: opts.Namespace,
+				Reason:    "no access to namespace",
+			})
+			return
+		}
+		s.writeJSON(w, k8s.BuildTopMetrics(opts))
+		return
+	}
+	if noNamespaceAccess(namespaces) {
+		s.writeJSON(w, k8s.TopMetricsResponse{Kind: opts.Kind, Sort: opts.Sort, Reason: "no namespace access"})
+		return
+	}
+	if namespaces == nil {
+		s.writeJSON(w, k8s.BuildTopMetrics(opts))
+		return
+	}
+	if len(namespaces) == 1 {
+		opts.Namespace = namespaces[0]
+		s.writeJSON(w, k8s.BuildTopMetrics(opts))
+		return
+	}
+	s.writeError(w, http.StatusBadRequest, "namespace is required when access is limited to multiple namespaces")
+}
+
+func namespaceAllowed(namespaces []string, namespace string) bool {
+	if namespaces == nil {
+		return true
+	}
+	for _, ns := range namespaces {
+		if ns == namespace {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {

--- a/pkg/k8score/metrics_history.go
+++ b/pkg/k8score/metrics_history.go
@@ -553,6 +553,13 @@ func parseCPU(s string) int64 {
 		}
 		return 0
 	}
+	if len(s) > 1 && s[len(s)-1] == 'u' {
+		var n int64
+		if _, err := fmt.Sscanf(s[:len(s)-1], "%d", &n); err == nil {
+			return n * 1000
+		}
+		return 0
+	}
 	if len(s) > 1 && s[len(s)-1] == 'm' {
 		var n int64
 		if _, err := fmt.Sscanf(s[:len(s)-1], "%d", &n); err == nil {

--- a/pkg/k8score/metrics_history_test.go
+++ b/pkg/k8score/metrics_history_test.go
@@ -1,0 +1,22 @@
+package k8score
+
+import "testing"
+
+func TestParseCPU(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int64
+	}{
+		{"", 0},
+		{"137492n", 137492},
+		{"188u", 188000},
+		{"250m", 250000000},
+		{"1", 1000000000},
+	}
+
+	for _, tt := range tests {
+		if got := parseCPU(tt.input); got != tt.want {
+			t.Errorf("parseCPU(%q) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #755. Agent- and embedding-facing diagnostics improvements, plus test backfill for already-merged detectors.

## What changed

**`GET /api/metrics/top/resources`** — ranked live metrics for agents and compact diagnostics. RBAC-gated (nodes need explicit cluster-scoped access; namespaced reads intersect the user's allowed namespaces and require an explicit `namespace` when access spans multiple). Intentionally separate from `/metrics/top/{pods,nodes}`, which back UI tables and must keep their unsorted array shape.

**`parseCPU` micro-unit (`u`)** — metrics-server reports some idle pods in microcores (e.g. `188u`). These were parsing to `0` and getting flagged as having *unavailable* metrics; now they parse correctly.

**`Visibility` on `/api/capabilities`** — surfaces a visibility summary when RBAC limits make diagnostics incomplete, so callers can tell "nothing wrong" from "can't see it."

**MCP embedding/bench access opt-outs** (`internal/mcp/server.go`) — env vars for Docker-isolated or embedded callers reaching Radar via a non-loopback host:
- `RADAR_MCP_DISABLE_ORIGIN_PROTECTION=1` — bypass the cross-origin wrapper
- `RADAR_MCP_DISABLE_LOCALHOST_PROTECTION=1` — disable the SDK's DNS-rebinding Host check
- `RADAR_MCP_TRUSTED_ORIGINS=a,b` — add browser-style trusted origins

All off by default and documented as "never for user-facing installs."

**`diagnose` + `issues` tool descriptions** — retuned toward workload root-causing / failure localization (CrashLoopBackOff, OOMKills, image-pull, scheduling, error-spewing services), with an explicit `issues → diagnose` (workload) vs `issues → get_resource` (non-workload) handoff.

**Test backfill** — `parseCPU` unit table, MCP tool annotation contract (read vs write hints), missing-ref source filter, webhook backend-Service detection, and `issues?source=audit` rejection.

## Test plan
- `go build ./...` clean
- `go test ./internal/{mcp,server,issues,k8s}/` + `pkg/k8score` (separate module) all pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New HTTP and MCP paths plus optional security bypass env vars increase exposure if misconfigured; ranked metrics and capabilities visibility are read-only but depend on correct RBAC gating.
> 
> **Overview**
> Agent- and API-facing diagnostics: **`GET /api/metrics/top/resources`** returns ranked live metrics (pods/workloads/nodes) with namespace and RBAC rules aligned to user access, separate from the unsorted UI top endpoints. **`parseCPU`** now accepts microcores (`u`) so idle pods are not treated as missing metrics.
> 
> **`/api/capabilities`** can include a **`visibility`** summary when RBAC limits make issue/metrics diagnostics incomplete. MCP **`server.go`** adds opt-in env flags to disable localhost Host checks, bypass cross-origin protection, or register trusted origins for Docker/bench callers (off by default).
> 
> MCP **`diagnose`** and **`issues`** descriptions steer agents toward workload root-cause (`diagnose`) vs non-workload drill-down (`get_resource`). Tests cover missing-ref default/source filtering, webhook backend Service detection, `issues?source=audit` → 400, MCP tool read/write annotations, and `parseCPU` units.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6069070f0f707463842a4ee7a578b087ecdbfc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->