### PR TITLE
Show CPU/memory requests + capacity when metrics-server is unavailable

### DIFF
--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -168,6 +168,10 @@ type WorkloadCount struct {
 type DashboardMetrics struct {
 	CPU    *MetricSummary `json:"cpu,omitempty"`
 	Memory *MetricSummary `json:"memory,omitempty"`
+	// UsageAvailable reports whether live usage (UsageMillis/UsagePercent) came
+	// from metrics-server. When false, only RequestsMillis/CapacityMillis are
+	// meaningful — usage fields are zero.
+	UsageAvailable bool `json:"usageAvailable"`
 }
 
 type MetricSummary struct {
@@ -465,7 +469,10 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 
 	resp.Cluster = cluster
 	resp.Metrics = metrics
-	resp.MetricsServerAvailable = metrics != nil
+	// "Available" means live usage is present — not merely that capacity/request
+	// data exists. metrics is now non-nil whenever nodes are cached, so gate the
+	// flag on actual usage so the frontend's "usage unavailable" hint still fires.
+	resp.MetricsServerAvailable = metrics != nil && metrics.UsageAvailable
 	resp.TrafficSummary = trafficSummary
 
 	k8s.LogTiming(" [dashboard] total: %v", time.Since(dashStart))
@@ -1390,45 +1397,16 @@ func (s *Server) countWarningEvents(cache *k8s.ResourceCache, namespace string) 
 	return count
 }
 
+// metricsServerTimeout bounds the metrics-server query so a slow or unreachable
+// metrics endpoint can't consume the dashboard's whole request budget (the
+// handler runs this in a goroutine and blocks on it in wg.Wait()).
+const metricsServerTimeout = 8 * time.Second
+
 func (s *Server) getDashboardMetrics(ctx context.Context, allowedNamespaces []string) *DashboardMetrics {
-	client := k8s.ClientFromContext(ctx)
-	if client == nil {
-		return nil
-	}
-
-	// Query metrics-server via raw REST to avoid adding k8s.io/metrics dependency.
-	// GET /apis/metrics.k8s.io/v1beta1/nodes. Metrics-server forwards the
-	// impersonation headers, so a user without metrics.k8s.io/nodes access
-	// gets a 403 here and dashboard metrics are silently omitted.
-	data, err := client.CoreV1().RESTClient().Get().
-		AbsPath("/apis/metrics.k8s.io/v1beta1/nodes").
-		DoRaw(ctx)
-	if err != nil {
-		// metrics-server not installed or not accessible — that's fine
-		return nil
-	}
-
-	var nodeMetricsList struct {
-		Items []struct {
-			Metadata struct {
-				Name string `json:"name"`
-			} `json:"metadata"`
-			Usage struct {
-				CPU    string `json:"cpu"`
-				Memory string `json:"memory"`
-			} `json:"usage"`
-		} `json:"items"`
-	}
-	if err := json.Unmarshal(data, &nodeMetricsList); err != nil {
-		log.Printf("Failed to parse node metrics: %v", err)
-		return nil
-	}
-
-	if len(nodeMetricsList.Items) == 0 {
-		return nil
-	}
-
-	// Get node capacity from the cache
+	// Node capacity and pod requests come from the cache — they don't need
+	// metrics-server. Live usage does. Compute the cached values first and
+	// treat usage as best-effort so a missing/slow metrics-server still leaves
+	// requests vs. capacity on the dashboard.
 	cache := k8s.GetResourceCache()
 	if cache == nil {
 		return nil
@@ -1442,7 +1420,7 @@ func (s *Server) getDashboardMetrics(ctx context.Context, allowedNamespaces []st
 		return nil
 	}
 
-	// Sum capacity across all nodes
+	// Sum capacity across all nodes (cached)
 	var cpuCapacityMillis int64
 	var memCapacityBytes int64
 	for _, n := range nodes {
@@ -1450,18 +1428,10 @@ func (s *Server) getDashboardMetrics(ctx context.Context, allowedNamespaces []st
 		memCapacityBytes += n.Status.Capacity.Memory().Value()
 	}
 
-	// Sum usage across all nodes
-	var cpuUsageMillis int64
-	var memUsageBytes int64
-	for _, item := range nodeMetricsList.Items {
-		cpuUsageMillis += parseCPUToMillis(item.Usage.CPU)
-		memUsageBytes += parseMemoryToBytes(item.Usage.Memory)
-	}
-
-	// Sum requests across pods the user can see. For namespace-restricted
-	// users this scopes to allowedNamespaces — without it, the dashboard
-	// would expose aggregate pod-resource totals from namespaces they have
-	// no read access to.
+	// Sum requests across pods the user can see (cached). For namespace-
+	// restricted users this scopes to allowedNamespaces — without it, the
+	// dashboard would expose aggregate pod-resource totals from namespaces they
+	// have no read access to.
 	var cpuRequestsMillis int64
 	var memRequestsBytes int64
 	var metricPods []*corev1.Pod
@@ -1492,7 +1462,44 @@ func (s *Server) getDashboardMetrics(ctx context.Context, allowedNamespaces []st
 		}
 	}
 
-	metrics := &DashboardMetrics{}
+	// Live usage from metrics-server — best-effort. Query via raw REST to avoid
+	// adding k8s.io/metrics dependency; metrics-server forwards impersonation
+	// headers, so a user without metrics.k8s.io/nodes access gets a 403. A
+	// missing, forbidden, or slow metrics-server leaves usageAvailable false
+	// rather than discarding the capacity/request data computed above.
+	var cpuUsageMillis int64
+	var memUsageBytes int64
+	usageAvailable := false
+	if client := k8s.ClientFromContext(ctx); client != nil {
+		mctx, cancel := context.WithTimeout(ctx, metricsServerTimeout)
+		defer cancel()
+		data, err := client.CoreV1().RESTClient().Get().
+			AbsPath("/apis/metrics.k8s.io/v1beta1/nodes").
+			DoRaw(mctx)
+		if err != nil {
+			log.Printf("[dashboard] node metrics unavailable (showing requests/capacity only): %v", err)
+		} else {
+			var nodeMetricsList struct {
+				Items []struct {
+					Usage struct {
+						CPU    string `json:"cpu"`
+						Memory string `json:"memory"`
+					} `json:"usage"`
+				} `json:"items"`
+			}
+			if err := json.Unmarshal(data, &nodeMetricsList); err != nil {
+				log.Printf("[dashboard] failed to parse node metrics: %v", err)
+			} else if len(nodeMetricsList.Items) > 0 {
+				for _, item := range nodeMetricsList.Items {
+					cpuUsageMillis += parseCPUToMillis(item.Usage.CPU)
+					memUsageBytes += parseMemoryToBytes(item.Usage.Memory)
+				}
+				usageAvailable = true
+			}
+		}
+	}
+
+	metrics := &DashboardMetrics{UsageAvailable: usageAvailable}
 	if cpuCapacityMillis > 0 {
 		metrics.CPU = &MetricSummary{
 			UsageMillis:    cpuUsageMillis,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3029,6 +3029,9 @@ export interface DiagInformerSyncStatus {
   synced: boolean
   syncedAt?: string
   items: number
+  lastError?: string
+  lastErrorAt?: string
+  forbiddenSeen?: boolean
 }
 
 export interface DiagCacheSyncStatus {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -140,6 +140,9 @@ export interface WorkloadCount {
 export interface DashboardMetrics {
   cpu?: MetricSummary
   memory?: MetricSummary
+  // When false, only requests/capacity are meaningful — live usage (from
+  // metrics-server) is unavailable and usage fields are zero.
+  usageAvailable: boolean
 }
 
 export interface MetricSummary {

--- a/web/src/components/home/ClusterHealthCard.tsx
+++ b/web/src/components/home/ClusterHealthCard.tsx
@@ -389,12 +389,14 @@ export function ClusterHealthCard({
                     <Cpu className="w-3.5 h-3.5 text-theme-text-tertiary" />
                     CPU
                   </div>
-                  <ResourceBar
-                    label="Used"
-                    used={formatCPUMillicores(metrics.cpu.usageMillis)}
-                    total={formatCPUMillicores(metrics.cpu.capacityMillis)}
-                    percent={metrics.cpu.usagePercent}
-                  />
+                  {metricsServerAvailable && (
+                    <ResourceBar
+                      label="Used"
+                      used={formatCPUMillicores(metrics.cpu.usageMillis)}
+                      total={formatCPUMillicores(metrics.cpu.capacityMillis)}
+                      percent={metrics.cpu.usagePercent}
+                    />
+                  )}
                   <ResourceBar
                     label="Requested"
                     used={formatCPUMillicores(metrics.cpu.requestsMillis)}
@@ -409,12 +411,14 @@ export function ClusterHealthCard({
                     <MemoryStick className="w-3.5 h-3.5 text-theme-text-tertiary" />
                     Memory
                   </div>
-                  <ResourceBar
-                    label="Used"
-                    used={formatMemoryMiB(metrics.memory.usageMillis)}
-                    total={formatMemoryMiB(metrics.memory.capacityMillis)}
-                    percent={metrics.memory.usagePercent}
-                  />
+                  {metricsServerAvailable && (
+                    <ResourceBar
+                      label="Used"
+                      used={formatMemoryMiB(metrics.memory.usageMillis)}
+                      total={formatMemoryMiB(metrics.memory.capacityMillis)}
+                      percent={metrics.memory.usagePercent}
+                    />
+                  )}
                   <ResourceBar
                     label="Requested"
                     used={formatMemoryMiB(metrics.memory.requestsMillis)}
@@ -423,7 +427,7 @@ export function ClusterHealthCard({
                   />
                 </div>
               )}
-              {!metrics?.cpu && !metrics?.memory && (
+              {!metricsServerAvailable && (
                 <MetricsUnavailableHint platform={cluster.platform} metricsServerAvailable={metricsServerAvailable} />
               )}
             </div>

--- a/web/src/components/ui/DiagnosticsOverlay.tsx
+++ b/web/src/components/ui/DiagnosticsOverlay.tsx
@@ -600,8 +600,25 @@ function formatForGitHub(data: DiagnosticsSnapshot, includeRawJson = true): stri
       }
       const pending = getPendingInformers(sync)
       if (pending.length > 0) {
-        const parts = pending.map((i) => `${i.kind}(${i.deferred ? 'deferred' : 'critical'},${i.items.toLocaleString()} items)`)
+        const parts = pending.map((i) => {
+          const flags = [i.deferred ? 'deferred' : 'critical', `${i.items.toLocaleString()} items`]
+          if (i.forbiddenSeen) flags.push('forbidden')
+          if (i.lastError) flags.push(`err: ${i.lastError}`)
+          return `${i.kind}(${flags.join(', ')})`
+        })
         lines.push(`- **Pending:** ${parts.join(', ')}`)
+      }
+      // Synced informers that have since hit a watch error or 403 — a count of 0
+      // from one of these is a stale/forbidden lister, not an empty cluster.
+      const errored = sync.informers.filter((i) => !pending.includes(i) && (i.lastError || i.forbiddenSeen))
+      if (errored.length > 0) {
+        const parts = errored.map((i) => {
+          const flags: string[] = []
+          if (i.forbiddenSeen) flags.push('forbidden')
+          if (i.lastError) flags.push(`err: ${i.lastError}`)
+          return `${i.kind}(${flags.join(', ')})`
+        })
+        lines.push(`- **Informer errors:** ${parts.join(', ')}`)
       }
     }
     if (inf.watchedCRDs && inf.watchedCRDs.length > 0) {


### PR DESCRIPTION
## Summary

Fixes part of #598. Two related changes:

### 1. Dashboard: show CPU/memory requests + capacity when metrics-server is down

`getDashboardMetrics` returned `nil` as soon as the metrics-server query failed — but node **capacity** and pod-**request** totals are derived from the cache, not metrics-server. So on clusters without metrics-server (or where it's slow/unreachable), the dashboard showed *no* CPU/memory request data, even though all the inputs were cached. The reporter's diagnostics show exactly this (metrics-server `context deadline exceeded`).

- Capacity (cached Nodes) and requests (cached Pods) are now computed unconditionally; metrics-server is queried best-effort for *usage* only.
- The metrics-server query is **bounded to 8s** so a hung endpoint can't consume the full 60s request budget and time out the whole dashboard (a likely cause of the broader "everything is 0" on large clusters).
- New `DashboardMetrics.usageAvailable`; `metrics` is non-nil whenever nodes are cached; `MetricsServerAvailable` gates on actual usage.
- Frontend (`ClusterHealthCard`): render the **Requested** bar whenever data exists; render **Used** only when live usage is present; keep the metrics-server install hint.

### 2. Diagnostics: surface informer `lastError`/`forbiddenSeen` in the Markdown export

The pods/deployments=0 half of #598 couldn't be diagnosed from the reporter's pasted snapshot — it showed `Total Resources` and pending-informer item counts but **not why** an informer failed. A count of 0 from an informer that never synced (e.g. the Pods lister failing its initial LIST under client rate-limiter pressure — the same `context deadline exceeded` we see for metrics) is indistinguishable from an empty cluster.

The Go side already records per-kind `lastError`/`lastErrorAt`/`forbiddenSeen`; this just surfaces them in the copy-as-Markdown export: enriches the **Pending** line and adds an **Informer errors** line for synced-but-errored informers. The next large-cluster report should be self-diagnosing.

## Verification

Reproduced #1 against a live EKS cluster **without** a functioning metrics-server (`metricsServerAvailable: false`):
- `/api/dashboard` now returns `cpu: {usage:0, requests:1540, capacity:4000, requestPercent:38}` / `memory: {usage:0, requests:1860, capacity:7668, requestPercent:24}` (previously `metrics: null`).
- Visual test: Resource Utilization card shows **CPU Requested 1.5/4 cores (38%)** and **Memory Requested 1.8/7.5 GiB (24%)** with the metrics-server hint — instead of an empty section.
- `go build`, `go test ./internal/server`, `make tsc` all pass.

## Note on pods/deployments=0

That count comes from a separate cache-listing path (rendered fine on my test cluster: 21 pods, 8 deployments). The most likely driver on the reporter's 40k-object cluster is client rate-limiter starvation of the initial informer LIST → unsynced Pods lister → a misleading `0`. The 8s metrics bound here removes the metrics-induced handler stall; the diagnostics change (#2) makes the informer-sync cause visible in the next report. The underlying rate-limiter/QPS fix is a separate follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostics display and TypeScript types only; no runtime behavior change beyond richer exported markdown when the backend sends the new fields.
> 
> **Overview**
> Adds optional **`lastError`**, **`lastErrorAt`**, and **`forbiddenSeen`** on `DiagInformerSyncStatus` so diagnostics JSON can carry per-informer watch failures and 403 signals from the backend.
> 
> Updates **Copy as Markdown** / bug-report formatting in `DiagnosticsOverlay`: pending informers list `forbidden` and `err: …` alongside item counts, and a new **Informer errors** line calls out informers that finished sync but later broke (so a zero count reads as stale/forbidden lister, not an empty cluster).
> 
> Note: the PR description discusses dashboard CPU/memory when metrics-server is down; **this diff is only the diagnostics overlay + API types**, not those dashboard changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58cf43a061c4b1e8cb7fa31fdff42189acb47e74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->