### PR TITLE
fix(resources): return 403 not 500 when CRD list is forbidden

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1188,6 +1188,10 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 						s.writeError(w, http.StatusBadRequest, listErr.Error())
 						return
 					}
+					if apierrors.IsForbidden(listErr) || apierrors.IsUnauthorized(listErr) {
+						forbiddenMsg(kind)
+						return
+					}
 					log.Printf("[resources] Failed to list %s in namespace %s (group=%s): %v", kind, ns, group, listErr)
 					s.writeError(w, http.StatusInternalServerError, listErr.Error())
 					return
@@ -1202,6 +1206,10 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				if strings.Contains(err.Error(), "unknown resource kind") {
 					s.writeError(w, http.StatusBadRequest, err.Error())
+					return
+				}
+				if apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err) {
+					forbiddenMsg(kind)
 					return
 				}
 				log.Printf("[resources] Failed to list %s (group=%s): %v", kind, group, err)

--- a/pkg/k8score/cache_test.go
+++ b/pkg/k8score/cache_test.go
@@ -1134,6 +1134,34 @@ func TestDynamicResourceCache_ForcedNamespaceScopesEveryGVR(t *testing.T) {
 	}
 }
 
+// EnsureWatching must surface a probe that's forbidden everywhere it looks
+// (cluster-wide AND the fallback namespace) as an apierrors.IsForbidden-
+// classifiable error through the %w wrap — that's what lets the resources
+// handler map a denied CRD list to 403 instead of 500. Mirrors #768: a user
+// who can read the CRD only in a namespace the cache never probes.
+func TestDynamicResourceCache_EnsureWatching_ForbiddenIsClassifiable(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}
+	dyn := fakeDynamicForListAccess(t, map[schema.GroupVersionResource]string{
+		gvr: "ApplicationList",
+	}, func(schema.GroupVersionResource, string) bool { return false })
+
+	d, err := NewDynamicResourceCache(DynamicCacheConfig{
+		DynamicClient:     dyn,
+		NamespaceFallback: "other-ns",
+	})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+
+	err = d.EnsureWatching(gvr)
+	if err == nil {
+		t.Fatal("EnsureWatching succeeded, want forbidden error")
+	}
+	if !apierrors.IsForbidden(err) {
+		t.Fatalf("EnsureWatching error not classifiable as forbidden (handler would 500 instead of 403): %v", err)
+	}
+}
+
 func fakeDynamicForListAccess(
 	t *testing.T,
 	listKinds map[schema.GroupVersionResource]string,


### PR DESCRIPTION
## Summary

The dynamic CRD list path in `handleListResources` (the `group != ""` branch) mapped **every** `ListDynamicWithGroup` error to HTTP 500 — including RBAC denials. A namespace-restricted user listing a CRD (e.g. Argo `Applications`) they can't read cluster-wide, or in the namespace the dynamic cache happens to probe, got a scary **500** instead of the **403** the rest of the handler already returns for denied reads.

This classifies `apierrors.IsForbidden` / `IsUnauthorized` and returns the standard `insufficient permissions to list <kind>` 403. The cache wraps the apiserver `Forbidden` with `%w`, so it stays classifiable through the error chain (`apimachinery` `ReasonForError` unwraps via `errors.As`).

This is the **error-code half of #768**. The namespace-scoping half — the list still can't reach the namespaces the user *can* read, because the dynamic cache watches a single namespace — is a larger follow-up (per-`{GVR, namespace}` informers) tracked separately.

## Test

Added `TestDynamicResourceCache_EnsureWatching_ForbiddenIsClassifiable` in `pkg/k8score`: with a CRD forbidden everywhere the cache probes (cluster-wide + fallback namespace — the #768 shape), `EnsureWatching` returns an error that `apierrors.IsForbidden` classifies. This pins the cache→handler contract, so a future change to the cache's error wrapping that broke the chain (reverting the handler to 500) would fail the test.

`go test ./internal/server/` and `go test ./pkg/k8score/` both green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small HTTP status change on an existing RBAC-denial path; no auth or data-model changes.
> 
> **Overview**
> When listing CRDs with an explicit API **group** (`handleListResources`), RBAC denials from `ListDynamicWithGroup` were treated like internal failures and returned **500**. The handler now checks `apierrors.IsForbidden` / `IsUnauthorized` and responds with the same **403** message used elsewhere (`insufficient permissions to list <kind>`).
> 
> A new **`TestDynamicResourceCache_EnsureWatching_ForbiddenIsClassifiable`** test locks in that `EnsureWatching` still returns `%w`-wrapped forbidden errors when list is denied everywhere the cache probes, so this mapping keeps working.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f72602550fd80533b15280f84f11ce15c32c07a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->