### PR TITLE
fix(k8score): per-namespace dynamic informers for namespace-restricted CRD reads

### DIFF
--- a/internal/audit/runner.go
+++ b/internal/audit/runner.go
@@ -93,7 +93,7 @@ func listCrossplaneDynamic(namespaces []string) (mrs, xrs []*unstructured.Unstru
 		if gvr.Group == "pkg.crossplane.io" || gvr.Group == "apiextensions.crossplane.io" {
 			continue
 		}
-		items, err := cache.List(gvr, "")
+		items, err := cache.ListWatched(gvr)
 		if err != nil {
 			if !apierrors.IsForbidden(err) && !apierrors.IsUnauthorized(err) {
 				log.Printf("[audit] Crossplane scan: skipping %s/%s: %v", gvr.GroupResource(), gvr.Version, err)

--- a/internal/k8s/policy_reports.go
+++ b/internal/k8s/policy_reports.go
@@ -340,7 +340,7 @@ func listPolicyReportsAll(gvrs []schema.GroupVersionResource) []*unstructured.Un
 	}
 	var all []*unstructured.Unstructured
 	for _, gvr := range gvrs {
-		items, err := cache.List(gvr, "")
+		items, err := cache.ListWatched(gvr)
 		if err != nil {
 			log.Printf("[policy-reports] list %s: %v", gvr, err)
 			continue

--- a/internal/k8s/topology_adapter.go
+++ b/internal/k8s/topology_adapter.go
@@ -207,6 +207,10 @@ func (a *topologyDynamicProvider) List(gvr schema.GroupVersionResource, namespac
 	return a.dynCache.List(gvr, namespace)
 }
 
+func (a *topologyDynamicProvider) ListNamespaces(gvr schema.GroupVersionResource, namespaces []string) ([]*unstructured.Unstructured, error) {
+	return a.dynCache.ListNamespaces(gvr, namespaces)
+}
+
 func (a *topologyDynamicProvider) Get(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
 	return a.dynCache.Get(gvr, namespace, name)
 }

--- a/pkg/k8score/cache_test.go
+++ b/pkg/k8score/cache_test.go
@@ -1,6 +1,7 @@
 package k8score
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -14,11 +15,13 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
 )
 
 func TestNewResourceCache_Basic(t *testing.T) {
@@ -1093,18 +1096,20 @@ func TestDynamicResourceCache_NamespaceFallbackIsPerGVR(t *testing.T) {
 		t.Fatalf("NewDynamicResourceCache failed: %v", err)
 	}
 
-	if err := d.probeAccess(clusterGVR); err != nil {
+	clusterScope, err := d.probeScope(clusterGVR, "")
+	if err != nil {
 		t.Fatalf("cluster GVR probe failed: %v", err)
 	}
-	if err := d.probeAccess(namespacedGVR); err != nil {
-		t.Fatalf("namespaced GVR probe failed: %v", err)
+	if clusterScope != "" {
+		t.Errorf("cluster GVR scope = %q, want cluster-wide", clusterScope)
 	}
 
-	if got := d.informerScopes[clusterGVR]; got != "" {
-		t.Errorf("cluster GVR scope = %q, want cluster-wide", got)
+	nsScope, err := d.probeScope(namespacedGVR, "")
+	if err != nil {
+		t.Fatalf("namespaced GVR probe failed: %v", err)
 	}
-	if got := d.informerScopes[namespacedGVR]; got != ns {
-		t.Errorf("namespaced GVR scope = %q, want %q", got, ns)
+	if nsScope != ns {
+		t.Errorf("namespaced GVR scope = %q, want %q", nsScope, ns)
 	}
 }
 
@@ -1126,11 +1131,312 @@ func TestDynamicResourceCache_ForcedNamespaceScopesEveryGVR(t *testing.T) {
 		t.Fatalf("NewDynamicResourceCache failed: %v", err)
 	}
 
-	if err := d.probeAccess(gvr); err != nil {
+	scope, err := d.probeScope(gvr, "")
+	if err != nil {
 		t.Fatalf("forced namespace probe failed: %v", err)
 	}
-	if got := d.informerScopes[gvr]; got != ns {
-		t.Errorf("GVR scope = %q, want %q", got, ns)
+	if scope != ns {
+		t.Errorf("GVR scope = %q, want %q", scope, ns)
+	}
+}
+
+// The #768 core: when cluster-wide list is denied but the caller names a
+// specific namespace they CAN list, the probe scopes to that namespace —
+// not to the configured single fallback. This is what lets a namespace-
+// restricted user read a CRD in the namespaces they actually have access to.
+func TestDynamicResourceCache_ProbeScope_HonorsRequestedNamespace(t *testing.T) {
+	const fallbackNs, wantedNs = "fallback-ns", "argocd"
+	gvr := schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}
+	dyn := fakeDynamicForListAccess(t, map[schema.GroupVersionResource]string{
+		gvr: "ApplicationList",
+	}, func(_ schema.GroupVersionResource, namespace string) bool {
+		return namespace == wantedNs // not cluster-wide, not the fallback
+	})
+
+	d, err := NewDynamicResourceCache(DynamicCacheConfig{
+		DynamicClient:     dyn,
+		NamespaceFallback: fallbackNs,
+	})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+
+	// Requesting the namespace the user can list scopes the informer there.
+	scope, err := d.probeScope(gvr, wantedNs)
+	if err != nil {
+		t.Fatalf("probeScope(%q) failed: %v", wantedNs, err)
+	}
+	if scope != wantedNs {
+		t.Errorf("scope = %q, want %q", scope, wantedNs)
+	}
+
+	// With no requested namespace, it falls back to the configured fallback,
+	// which the user cannot list — so the probe is forbidden.
+	if _, err := d.probeScope(gvr, ""); !apierrors.IsForbidden(err) {
+		t.Errorf("probeScope(\"\") err = %v, want forbidden", err)
+	}
+}
+
+// List(gvr, "") must be served ONLY by a cluster-wide informer — it must not
+// union incidental per-namespace informers, which would make results depend on
+// what other requests warmed. ListNamespaces is the explicit union path.
+func TestDynamicResourceCache_ListEmptyNamespaceDoesNotUnion(t *testing.T) {
+	const nsA, nsB = "team-a", "team-b"
+	gvr := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"}
+	dyn := fakeDynamicForListAccess(t, map[schema.GroupVersionResource]string{
+		gvr: "WidgetList",
+	}, func(_ schema.GroupVersionResource, namespace string) bool {
+		return namespace == nsA || namespace == nsB // namespaced only, never cluster-wide
+	})
+
+	d, err := NewDynamicResourceCache(DynamicCacheConfig{DynamicClient: dyn})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+
+	// Warm per-namespace informers for both namespaces.
+	if _, err := d.ListBlocking(gvr, nsA, 2*time.Second); err != nil {
+		t.Fatalf("ListBlocking(%q) failed: %v", nsA, err)
+	}
+	if _, err := d.ListBlocking(gvr, nsB, 2*time.Second); err != nil {
+		t.Fatalf("ListBlocking(%q) failed: %v", nsB, err)
+	}
+
+	// List(gvr, "") finds no cluster-wide informer and must NOT union the two
+	// per-namespace informers.
+	if got := d.readEntries(gvr, ""); got != nil {
+		t.Errorf("readEntries(gvr, \"\") returned %d entries, want none (no cluster-wide informer)", len(got))
+	}
+}
+
+// ListWatched is the internal "scan what's already cached" path: it unions
+// every watched scope so namespace-restricted callers (audit, PolicyReport
+// indexing) don't silently drop namespace-scoped contents the way List(gvr,
+// "") would.
+func TestDynamicResourceCache_ListWatchedUnionsNamespaceInformers(t *testing.T) {
+	const nsA, nsB = "team-a", "team-b"
+	gvr := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"}
+	dyn := fakeDynamicForListAccess(t, map[schema.GroupVersionResource]string{
+		gvr: "WidgetList",
+	}, func(_ schema.GroupVersionResource, namespace string) bool {
+		return namespace == nsA || namespace == nsB // namespaced only, never cluster-wide
+	})
+
+	// Seed one object in each namespace so the informers have content.
+	for _, ns := range []string{nsA, nsB} {
+		obj := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "example.com/v1",
+			"kind":       "Widget",
+			"metadata":   map[string]any{"name": "w-" + ns, "namespace": ns},
+		}}
+		if _, err := dyn.Resource(gvr).Namespace(ns).Create(context.Background(), obj, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("seed %s: %v", ns, err)
+		}
+	}
+
+	d, err := NewDynamicResourceCache(DynamicCacheConfig{DynamicClient: dyn})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+	for _, ns := range []string{nsA, nsB} {
+		if _, err := d.ListBlocking(gvr, ns, 2*time.Second); err != nil {
+			t.Fatalf("ListBlocking(%q) failed: %v", ns, err)
+		}
+	}
+
+	got, err := d.ListWatched(gvr)
+	if err != nil {
+		t.Fatalf("ListWatched failed: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("ListWatched returned %d objects, want 2 (union of both namespace-scoped informers)", len(got))
+	}
+}
+
+// ListNamespaces must short-circuit a cluster-scoped GVR to a cluster-wide
+// read even when given a namespace set: cluster-scoped objects live under the
+// "" namespace, so a per-namespace filter would index them to nothing. Pins
+// the gvrIsNamespaced guard the topology paths rely on for Karpenter
+// NodePool/NodeClaim and other cluster-scoped CRDs.
+func TestDynamicResourceCache_ListNamespacesClusterScopedReadsClusterWide(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "karpenter.sh", Version: "v1", Resource: "nodepools"}
+	disc := &ResourceDiscovery{
+		resources: []APIResource{{
+			Group: gvr.Group, Version: gvr.Version, Kind: "NodePool", Name: gvr.Resource,
+			Namespaced: false, IsCRD: true, Verbs: []string{"get", "list", "watch"},
+		}},
+		resourceMap: map[string]APIResource{},
+		gvrMap:      map[string]schema.GroupVersionResource{},
+		lastRefresh: time.Now(),
+		cacheTTL:    time.Hour,
+	}
+	dyn := fakeDynamicForListAccess(t, map[schema.GroupVersionResource]string{
+		gvr: "NodePoolList",
+	}, func(schema.GroupVersionResource, string) bool { return true }) // cluster-wide allowed
+
+	// Seed a cluster-scoped object (no namespace).
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "karpenter.sh/v1",
+		"kind":       "NodePool",
+		"metadata":   map[string]any{"name": "default"},
+	}}
+	if _, err := dyn.Resource(gvr).Create(context.Background(), obj, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed cluster-scoped object: %v", err)
+	}
+
+	d, err := NewDynamicResourceCache(DynamicCacheConfig{DynamicClient: dyn, Discovery: disc})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+	if _, err := d.ListBlocking(gvr, "", 2*time.Second); err != nil {
+		t.Fatalf("ListBlocking failed: %v", err)
+	}
+
+	// A namespace filter must NOT zero out a cluster-scoped resource.
+	got, err := d.ListNamespaces(gvr, []string{"ns-a"})
+	if err != nil {
+		t.Fatalf("ListNamespaces failed: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("ListNamespaces(clusterScopedGVR, [ns-a]) = %d objects, want 1 (cluster-wide short-circuit)", len(got))
+	}
+}
+
+// Starting a cluster-wide informer must supersede (stop + drop) any
+// namespace-scoped informers for the same GVR — the "never both" invariant —
+// so reads (ListWatched) and change callbacks don't double up.
+func TestDynamicResourceCache_ClusterWideSupersedesNamespaceInformers(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"}
+	dyn := fakeDynamicForListAccess(t, map[schema.GroupVersionResource]string{
+		gvr: "WidgetList",
+	}, func(schema.GroupVersionResource, string) bool { return true })
+	d, err := NewDynamicResourceCache(DynamicCacheConfig{DynamicClient: dyn})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+	defer d.Stop()
+
+	has := func(ns string) bool {
+		d.mu.RLock()
+		defer d.mu.RUnlock()
+		_, ok := d.informers[informerKey{gvr: gvr, ns: ns}]
+		return ok
+	}
+
+	if err := d.startWatching(gvr, "team-a"); err != nil {
+		t.Fatalf("startWatching(team-a): %v", err)
+	}
+	if err := d.startWatching(gvr, "team-b"); err != nil {
+		t.Fatalf("startWatching(team-b): %v", err)
+	}
+	if !has("team-a") || !has("team-b") {
+		t.Fatal("expected both namespace-scoped informers before supersede")
+	}
+
+	if err := d.startWatching(gvr, ""); err != nil {
+		t.Fatalf("startWatching(cluster-wide): %v", err)
+	}
+	if !has("") {
+		t.Error("expected cluster-wide informer after supersede")
+	}
+	if has("team-a") || has("team-b") {
+		t.Error("namespace-scoped informers must be superseded by the cluster-wide one")
+	}
+}
+
+// A handler registered via AddGVRChangeHandler must reach informers created
+// AFTER registration (lazy per-namespace watches, reap re-creations) — not
+// only those present at call time — or derived caches miss those events.
+func TestDynamicResourceCache_GVRChangeHandlerAppliesToLaterInformers(t *testing.T) {
+	const nsA, nsB = "team-a", "team-b"
+	gvr := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"}
+	dyn := fakeDynamicForListAccess(t, map[schema.GroupVersionResource]string{
+		gvr: "WidgetList",
+	}, func(_ schema.GroupVersionResource, ns string) bool { return ns != "" }) // namespaced only
+
+	// Seed an object in nsB so its (later-created) informer has an add to deliver.
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "example.com/v1",
+		"kind":       "Widget",
+		"metadata":   map[string]any{"name": "w", "namespace": nsB},
+	}}
+	if _, err := dyn.Resource(gvr).Namespace(nsB).Create(context.Background(), obj, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed nsB: %v", err)
+	}
+
+	d, err := NewDynamicResourceCache(DynamicCacheConfig{DynamicClient: dyn})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+	defer d.Stop()
+
+	// Warm nsA so the handler has an existing informer to attach to at registration.
+	if _, err := d.ListBlocking(gvr, nsA, 2*time.Second); err != nil {
+		t.Fatalf("ListBlocking(nsA): %v", err)
+	}
+
+	var adds atomic.Int64
+	h := cache.ResourceEventHandlerFuncs{AddFunc: func(any) { adds.Add(1) }}
+	if err := d.AddGVRChangeHandler(gvr, h); err != nil {
+		t.Fatalf("AddGVRChangeHandler: %v", err)
+	}
+
+	// nsB's informer is created lazily after registration; it must still get h.
+	if _, err := d.ListBlocking(gvr, nsB, 2*time.Second); err != nil {
+		t.Fatalf("ListBlocking(nsB): %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && adds.Load() == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if adds.Load() == 0 {
+		t.Error("handler did not fire for an informer created after registration")
+	}
+}
+
+// GVR-level status APIs must span namespace-scoped informers: with only
+// per-namespace watches (no cluster-wide one), the kind is still watched and
+// synced, so IsSynced/WaitForSync must report true and AddGVRChangeHandler
+// must register — they resolve via entriesForGVR, not readEntries(gvr, "").
+func TestDynamicResourceCache_StatusAPIsSpanNamespaceInformers(t *testing.T) {
+	const ns = "team-a"
+	gvr := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"}
+	dyn := fakeDynamicForListAccess(t, map[schema.GroupVersionResource]string{
+		gvr: "WidgetList",
+	}, func(_ schema.GroupVersionResource, namespace string) bool {
+		return namespace == ns // namespaced only, never cluster-wide
+	})
+
+	d, err := NewDynamicResourceCache(DynamicCacheConfig{DynamicClient: dyn})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+
+	if _, err := d.ListBlocking(gvr, ns, 2*time.Second); err != nil {
+		t.Fatalf("ListBlocking(%q) failed: %v", ns, err)
+	}
+
+	if !d.IsSynced(gvr) {
+		t.Error("IsSynced = false for a GVR watched only via a namespace-scoped informer, want true")
+	}
+	if !d.WaitForSync(gvr, 2*time.Second) {
+		t.Error("WaitForSync = false for a namespace-scoped-only GVR, want true")
+	}
+	if err := d.AddGVRChangeHandler(gvr, cache.ResourceEventHandlerFuncs{}); err != nil {
+		t.Errorf("AddGVRChangeHandler failed for a namespace-scoped-only GVR: %v", err)
+	}
+
+	// A subsequent List(gvr, "") must NOT short-circuit on the existing
+	// namespace-scoped informer and then find nothing. With no cluster-wide
+	// informer it re-probes cluster-wide (denied here) and returns a clean
+	// forbidden — never a spurious "informer not found".
+	_, err = d.List(gvr, "")
+	if err == nil {
+		t.Fatal("List(gvr, \"\") = nil error, want forbidden (cluster-wide denied)")
+	}
+	if !apierrors.IsForbidden(err) {
+		t.Errorf("List(gvr, \"\") err = %v, want a re-probed forbidden (not 'informer not found')", err)
 	}
 }
 

--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -18,22 +18,44 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// informerKey identifies one informer. ns == "" means a cluster-wide watch;
+// a non-empty ns is a namespace-scoped watch. A GVR can have one cluster-wide
+// informer OR several namespace-scoped ones (for users denied cluster-wide
+// list but allowed in specific namespaces) — never both, since the
+// cluster-wide informer already covers every namespace.
+type informerKey struct {
+	gvr schema.GroupVersionResource
+	ns  string
+}
+
+// informerEntry is one running informer plus its lifecycle handle. synced is
+// guarded by DynamicResourceCache.mu.
+type informerEntry struct {
+	informer cache.SharedIndexInformer
+	cancel   context.CancelFunc
+	synced   bool
+}
+
 // DynamicResourceCache provides on-demand caching for CRDs and other dynamic
 // resources. It is safe for concurrent use. Application-specific callbacks
 // (timeline, metrics) are injected via DynamicCacheConfig.
 type DynamicResourceCache struct {
 	factory         dynamicinformer.DynamicSharedInformerFactory
-	nsFactory       dynamicinformer.DynamicSharedInformerFactory
-	informers       map[schema.GroupVersionResource]cache.SharedIndexInformer
-	informerScopes  map[schema.GroupVersionResource]string
-	syncComplete    map[schema.GroupVersionResource]bool
-	stopCh          chan struct{}
+	nsFactories     map[string]dynamicinformer.DynamicSharedInformerFactory // one per watched namespace, lazily created
+	informers       map[informerKey]*informerEntry
+	stopCh          chan struct{} // global shutdown; parent of every per-informer context
 	stopOnce        sync.Once
 	mu              sync.RWMutex
 	config          DynamicCacheConfig
 	discoveryStatus CRDDiscoveryStatus
 	discoveryMu     sync.RWMutex
 	discoveryDone   chan struct{} // closed when DiscoverAllCRDs() completes
+
+	// gvrHandlers holds change handlers registered via AddGVRChangeHandler,
+	// keyed by GVR. They are re-applied to every informer started for that GVR
+	// — including namespace-scoped informers created lazily after registration
+	// — so derived caches keep receiving events. Guarded by mu.
+	gvrHandlers map[schema.GroupVersionResource][]cache.ResourceEventHandler
 
 	// CRD discovery completion callbacks
 	crdCallbacks   []func()
@@ -53,33 +75,40 @@ func NewDynamicResourceCache(cfg DynamicCacheConfig) (*DynamicResourceCache, err
 		cfg.DynamicClient,
 		0, // no resync — updates come via watch
 	)
-	var nsFactory dynamicinformer.DynamicSharedInformerFactory
 	if cfg.NamespaceScoped && cfg.Namespace != "" {
-		nsFactory = dynamicinformer.NewFilteredDynamicSharedInformerFactory(
-			cfg.DynamicClient, 0, cfg.Namespace, nil,
-		)
 		log.Printf("Using namespace-scoped dynamic informers for namespace %q", cfg.Namespace)
 	} else if cfg.NamespaceFallback != "" {
-		nsFactory = dynamicinformer.NewFilteredDynamicSharedInformerFactory(
-			cfg.DynamicClient, 0, cfg.NamespaceFallback, nil,
-		)
 		log.Printf("Using namespace fallback for dynamic informers: %q", cfg.NamespaceFallback)
 	}
 
 	d := &DynamicResourceCache{
 		factory:         factory,
-		nsFactory:       nsFactory,
-		informers:       make(map[schema.GroupVersionResource]cache.SharedIndexInformer),
-		informerScopes:  make(map[schema.GroupVersionResource]string),
-		syncComplete:    make(map[schema.GroupVersionResource]bool),
+		nsFactories:     make(map[string]dynamicinformer.DynamicSharedInformerFactory),
+		informers:       make(map[informerKey]*informerEntry),
 		stopCh:          make(chan struct{}),
 		config:          cfg,
 		discoveryStatus: CRDDiscoveryIdle,
 		discoveryDone:   make(chan struct{}),
+		gvrHandlers:     make(map[schema.GroupVersionResource][]cache.ResourceEventHandler),
 	}
 
 	log.Println("Dynamic resource cache initialized")
 	return d, nil
+}
+
+// factoryForNs returns the informer factory for ns, creating and caching a
+// namespace-filtered factory on first use. ns == "" is the cluster-wide
+// factory. Caller must hold d.mu.
+func (d *DynamicResourceCache) factoryForNs(ns string) dynamicinformer.DynamicSharedInformerFactory {
+	if ns == "" {
+		return d.factory
+	}
+	if f, ok := d.nsFactories[ns]; ok {
+		return f
+	}
+	f := dynamicinformer.NewFilteredDynamicSharedInformerFactory(d.config.DynamicClient, 0, ns, nil)
+	d.nsFactories[ns] = f
+	return f
 }
 
 // ---------------------------------------------------------------------------
@@ -89,6 +118,17 @@ func NewDynamicResourceCache(cfg DynamicCacheConfig) (*DynamicResourceCache, err
 // EnsureWatching starts watching a resource type if not already watching.
 // The sync happens asynchronously — callers should use WaitForSync if they need to wait.
 func (d *DynamicResourceCache) EnsureWatching(gvr schema.GroupVersionResource) error {
+	return d.ensureWatching(gvr, "")
+}
+
+// ensureWatching guarantees an informer covering preferredNS exists for gvr.
+// preferredNS == "" means "any/all namespaces": probe cluster-wide and, if
+// denied, fall back to the configured NamespaceFallback. A non-empty
+// preferredNS is a specific request: a cluster-wide informer (if the identity
+// can list cluster-wide) covers it; otherwise we watch that one namespace.
+// This is what lets a namespace-restricted user read a CRD in the namespaces
+// they actually have access to, instead of being pinned to a single fallback.
+func (d *DynamicResourceCache) ensureWatching(gvr schema.GroupVersionResource, preferredNS string) error {
 	if d == nil {
 		return fmt.Errorf("dynamic resource cache not initialized")
 	}
@@ -98,11 +138,7 @@ func (d *DynamicResourceCache) EnsureWatching(gvr schema.GroupVersionResource) e
 		return fmt.Errorf("resource %s.%s/%s does not support list/watch", gvr.Resource, gvr.Group, gvr.Version)
 	}
 
-	// Quick check under read lock
-	d.mu.RLock()
-	_, exists := d.informers[gvr]
-	d.mu.RUnlock()
-	if exists {
+	if d.hasCoveringInformer(gvr, preferredNS) {
 		return nil
 	}
 
@@ -113,33 +149,77 @@ func (d *DynamicResourceCache) EnsureWatching(gvr schema.GroupVersionResource) e
 		case <-time.After(45 * time.Second):
 			log.Printf("[dynamic cache] Timeout waiting for CRD discovery, probing %s independently", gvr.Resource)
 		}
-
-		d.mu.RLock()
-		_, exists = d.informers[gvr]
-		d.mu.RUnlock()
-		if exists {
+		if d.hasCoveringInformer(gvr, preferredNS) {
 			return nil
 		}
 	}
 
-	// Probe access BEFORE acquiring write lock
-	if err := d.probeAccess(gvr); err != nil {
+	// Probe access (cluster-wide first, then a specific namespace) BEFORE
+	// acquiring the write lock; the result tells us which scope to watch.
+	scopeNS, err := d.probeScope(gvr, preferredNS)
+	if err != nil {
 		return fmt.Errorf("no access to %s.%s/%s: %w", gvr.Resource, gvr.Group, gvr.Version, err)
 	}
 
-	return d.startWatching(gvr)
+	return d.startWatching(gvr, scopeNS)
 }
 
-// startWatching creates and starts an informer for a GVR (no access probe).
-func (d *DynamicResourceCache) startWatching(gvr schema.GroupVersionResource) error {
+// hasCoveringInformer reports whether an existing informer already serves
+// reads for (gvr, ns), and must agree with readEntries: a cluster-wide
+// informer covers every namespace; a specific ns is also covered by its own
+// namespace-scoped informer. ns == "" is covered ONLY by a cluster-wide
+// informer — not by incidental namespace-scoped ones, since readEntries(gvr,
+// "") won't read those. Treating them as covering here would let
+// ensureWatching skip the probe and then have List(gvr, "") find nothing,
+// returning a spurious "informer not found" instead of probing cluster-wide
+// (or returning a clean forbidden).
+func (d *DynamicResourceCache) hasCoveringInformer(gvr schema.GroupVersionResource, ns string) bool {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	if _, ok := d.informers[informerKey{gvr: gvr}]; ok {
+		return true
+	}
+	if ns == "" {
+		return false
+	}
+	_, ok := d.informers[informerKey{gvr: gvr, ns: ns}]
+	return ok
+}
+
+// startWatching creates and starts an informer for (gvr, scopeNS), where
+// scopeNS == "" is cluster-wide. No access probe — the caller has decided the
+// scope. Each informer runs under its own context derived from the global
+// stop channel, so a single informer can be cancelled independently (the
+// idle reaper relies on this) while Stop() still tears them all down.
+func (d *DynamicResourceCache) startWatching(gvr schema.GroupVersionResource, scopeNS string) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	if _, exists := d.informers[gvr]; exists {
+	key := informerKey{gvr: gvr, ns: scopeNS}
+	if _, exists := d.informers[key]; exists {
 		return nil
 	}
+	// Enforce the "never both" invariant: a GVR has either one cluster-wide
+	// informer OR namespace-scoped ones, never both (overlap would duplicate
+	// objects in ListWatched and double-fire change callbacks).
+	if scopeNS != "" {
+		// A cluster-wide informer already covers this namespace — don't add a
+		// redundant namespaced watch.
+		if _, exists := d.informers[informerKey{gvr: gvr}]; exists {
+			return nil
+		}
+	} else {
+		// Starting cluster-wide supersedes any namespace-scoped informers for
+		// this GVR; stop and drop them.
+		for k, e := range d.informers {
+			if k.gvr == gvr && k.ns != "" {
+				e.cancel()
+				delete(d.informers, k)
+			}
+		}
+	}
 
-	factory := d.factoryForGVR(gvr)
+	factory := d.factoryForNs(scopeNS)
 	informer := factory.ForResource(gvr).Informer()
 	// Apply the dynamic-cache transform BEFORE informer.Run so every
 	// object entering the store is shrunk in place. SetTransform must
@@ -149,73 +229,99 @@ func (d *DynamicResourceCache) startWatching(gvr schema.GroupVersionResource) er
 	if err := informer.SetTransform(DropUnstructuredManagedFields); err != nil {
 		log.Printf("Warning: SetTransform failed for %v: %v (cache will retain managedFields/CRD schemas)", gvr, err)
 	}
-	d.informers[gvr] = informer
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		select {
+		case <-d.stopCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	d.informers[key] = &informerEntry{informer: informer, cancel: cancel}
 
 	kind := d.gvrToKind(gvr)
 	d.addDynamicChangeHandlers(informer, kind, gvr)
+	// Re-apply handlers registered via AddGVRChangeHandler so informers created
+	// lazily (or re-created after an idle reap) still feed derived caches.
+	for _, h := range d.gvrHandlers[gvr] {
+		if _, err := informer.AddEventHandler(h); err != nil {
+			log.Printf("Warning: re-applying change handler for %v failed: %v", gvr, err)
+		}
+	}
 
-	go informer.Run(d.stopCh)
+	go informer.Run(ctx.Done())
 
 	informerCount := len(d.informers)
-	log.Printf("Started watching dynamic resource: %s.%s/%s (total dynamic informers: %d)", gvr.Resource, gvr.Group, gvr.Version, informerCount)
+	scopeDesc := "cluster-wide"
+	if scopeNS != "" {
+		scopeDesc = "namespace " + scopeNS
+	}
+	log.Printf("Started watching dynamic resource: %s.%s/%s (%s) (total dynamic informers: %d)", gvr.Resource, gvr.Group, gvr.Version, scopeDesc, informerCount)
 
 	go func() {
-		syncCtx, syncCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		syncCtx, syncCancel := context.WithTimeout(ctx, 30*time.Second)
 		defer syncCancel()
-		go func() {
-			select {
-			case <-d.stopCh:
-				syncCancel()
-			case <-syncCtx.Done():
-			}
-		}()
 
 		if !cache.WaitForCacheSync(syncCtx.Done(), informer.HasSynced) {
 			select {
-			case <-d.stopCh:
+			case <-ctx.Done():
 				return
 			default:
-				log.Printf("Warning: cache sync timeout for %v", gvr)
+				log.Printf("Warning: cache sync timeout for %v (%s)", gvr, scopeDesc)
 			}
 		} else {
-			log.Printf("Dynamic resource synced: %s.%s/%s", gvr.Resource, gvr.Group, gvr.Version)
+			log.Printf("Dynamic resource synced: %s.%s/%s (%s)", gvr.Resource, gvr.Group, gvr.Version, scopeDesc)
 		}
 
 		d.mu.Lock()
-		d.syncComplete[gvr] = true
+		if e := d.informers[key]; e != nil {
+			e.synced = true
+		}
 		d.mu.Unlock()
 	}()
 	return nil
 }
 
-// probeAccess does a quick list with limit=1 to verify the user can access this resource.
-func (d *DynamicResourceCache) probeAccess(gvr schema.GroupVersionResource) error {
+// probeScope decides which namespace to watch for gvr via a limit=1 list
+// probe. It returns the scope ("" = cluster-wide) on success, or a forbidden
+// error when the identity can list the resource neither cluster-wide nor in
+// the candidate namespace. preferredNS is the namespace the caller actually
+// wants; when cluster-wide is denied it becomes the fallback target (falling
+// back to the configured NamespaceFallback only when the caller named none).
+func (d *DynamicResourceCache) probeScope(gvr schema.GroupVersionResource, preferredNS string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	// Forced namespace mode: only ever watch the configured namespace.
 	if d.config.NamespaceScoped && d.config.Namespace != "" {
-		err := d.listProbe(ctx, gvr, d.config.Namespace)
-		if err == nil {
-			d.setInformerScope(gvr, d.config.Namespace)
-			return nil
-		}
-		return d.classifyProbeError(gvr, err, d.config.Namespace)
+		return d.classifyScope(gvr, d.config.Namespace, d.listProbe(ctx, gvr, d.config.Namespace))
 	}
 
+	// Cluster-wide first — one informer then serves every namespace.
 	err := d.listProbe(ctx, gvr, "")
 	if err == nil {
-		d.setInformerScope(gvr, "")
-		return nil
+		return "", nil
 	}
-	if isAuthProbeError(err) && d.config.NamespaceFallback != "" && d.gvrIsNamespaced(gvr) {
-		nsErr := d.listProbe(ctx, gvr, d.config.NamespaceFallback)
-		if nsErr == nil {
-			d.setInformerScope(gvr, d.config.NamespaceFallback)
-			return nil
-		}
-		return d.classifyProbeError(gvr, nsErr, d.config.NamespaceFallback)
+	if !isAuthProbeError(err) {
+		// Transient/NotFound on proxy-fronted clusters — fail open to a
+		// cluster-wide informer rather than disabling the kind; real
+		// problems surface when the informer lists.
+		log.Printf("[dynamic cache] Cluster-wide probe for %s.%s/%s returned non-auth error (allowing): %v", gvr.Resource, gvr.Group, gvr.Version, err)
+		return "", nil
 	}
-	return d.classifyProbeError(gvr, err, "")
+	if !d.gvrIsNamespaced(gvr) {
+		return "", err // cluster-scoped resource, no namespace to fall back to
+	}
+
+	fallbackNS := preferredNS
+	if fallbackNS == "" {
+		fallbackNS = d.config.NamespaceFallback
+	}
+	if fallbackNS == "" {
+		return "", err
+	}
+	return d.classifyScope(gvr, fallbackNS, d.listProbe(ctx, gvr, fallbackNS))
 }
 
 func (d *DynamicResourceCache) listProbe(ctx context.Context, gvr schema.GroupVersionResource, namespace string) error {
@@ -227,16 +333,18 @@ func (d *DynamicResourceCache) listProbe(ctx context.Context, gvr schema.GroupVe
 	return err
 }
 
-func (d *DynamicResourceCache) classifyProbeError(gvr schema.GroupVersionResource, err error, namespace string) error {
+// classifyScope maps a namespace probe result to (scope, err): success → watch
+// ns; auth error → forbidden (no scope); non-auth error → fail open and watch
+// ns anyway, matching the cluster-wide fail-open path.
+func (d *DynamicResourceCache) classifyScope(gvr schema.GroupVersionResource, ns string, err error) (string, error) {
 	if err == nil {
-		return nil
+		return ns, nil
 	}
 	if isAuthProbeError(err) {
-		return err
+		return "", err
 	}
-	log.Printf("[dynamic cache] Probe for %s.%s/%s returned non-auth error (allowing): %v", gvr.Resource, gvr.Group, gvr.Version, err)
-	d.setInformerScope(gvr, namespace)
-	return nil
+	log.Printf("[dynamic cache] Probe for %s.%s/%s in namespace %q returned non-auth error (allowing): %v", gvr.Resource, gvr.Group, gvr.Version, ns, err)
+	return ns, nil
 }
 
 // isAuthProbeError classifies an error as an auth (403/401) failure as
@@ -266,28 +374,6 @@ func (d *DynamicResourceCache) gvrIsNamespaced(gvr schema.GroupVersionResource) 
 		}
 	}
 	return true
-}
-
-func (d *DynamicResourceCache) setInformerScope(gvr schema.GroupVersionResource, namespace string) {
-	d.mu.Lock()
-	d.informerScopes[gvr] = namespace
-	d.mu.Unlock()
-}
-
-func (d *DynamicResourceCache) factoryForGVR(gvr schema.GroupVersionResource) dynamicinformer.DynamicSharedInformerFactory {
-	if d == nil {
-		return nil
-	}
-	if d.config.NamespaceScoped && d.config.Namespace != "" {
-		if d.nsFactory != nil {
-			return d.nsFactory
-		}
-		return d.factory
-	}
-	if d.nsFactory != nil && d.informerScopes[gvr] != "" {
-		return d.nsFactory
-	}
-	return d.factory
 }
 
 // ProbeCount does a quick list with limit=1 and returns the approximate resource count.
@@ -323,24 +409,15 @@ func (d *DynamicResourceCache) ProbeCount(gvr schema.GroupVersionResource) int {
 
 func (d *DynamicResourceCache) probeCountList(ctx context.Context, gvr schema.GroupVersionResource) (*unstructured.UnstructuredList, error) {
 	if d.config.NamespaceScoped && d.config.Namespace != "" {
-		list, err := d.config.DynamicClient.Resource(gvr).Namespace(d.config.Namespace).List(ctx, metav1.ListOptions{Limit: 1})
-		if err == nil {
-			d.setInformerScope(gvr, d.config.Namespace)
-		}
-		return list, err
+		return d.config.DynamicClient.Resource(gvr).Namespace(d.config.Namespace).List(ctx, metav1.ListOptions{Limit: 1})
 	}
 
 	list, err := d.config.DynamicClient.Resource(gvr).List(ctx, metav1.ListOptions{Limit: 1})
 	if err == nil {
-		d.setInformerScope(gvr, "")
 		return list, nil
 	}
 	if isAuthProbeError(err) && d.config.NamespaceFallback != "" && d.gvrIsNamespaced(gvr) {
-		list, nsErr := d.config.DynamicClient.Resource(gvr).Namespace(d.config.NamespaceFallback).List(ctx, metav1.ListOptions{Limit: 1})
-		if nsErr == nil {
-			d.setInformerScope(gvr, d.config.NamespaceFallback)
-		}
-		return list, nsErr
+		return d.config.DynamicClient.Resource(gvr).Namespace(d.config.NamespaceFallback).List(ctx, metav1.ListOptions{Limit: 1})
 	}
 	return list, err
 }
@@ -417,7 +494,7 @@ func (d *DynamicResourceCache) enqueueDynamicChange(kind string, gvr schema.Grou
 	isSyncAdd := false
 	if op == OpAdd {
 		d.mu.RLock()
-		synced := d.syncComplete[gvr]
+		synced := d.gvrSyncedLocked(gvr, namespace)
 		d.mu.RUnlock()
 
 		if !synced {
@@ -491,36 +568,161 @@ func (d *DynamicResourceCache) WatchedGVRs() []schema.GroupVersionResource {
 	}
 	d.mu.RLock()
 	defer d.mu.RUnlock()
+	return d.distinctGVRsLocked()
+}
+
+// distinctGVRsLocked returns the unique GVRs that have at least one informer,
+// collapsing the per-namespace keys. Caller must hold d.mu.
+func (d *DynamicResourceCache) distinctGVRsLocked() []schema.GroupVersionResource {
+	seen := make(map[schema.GroupVersionResource]struct{}, len(d.informers))
 	out := make([]schema.GroupVersionResource, 0, len(d.informers))
-	for gvr := range d.informers {
-		out = append(out, gvr)
+	for k := range d.informers {
+		if _, ok := seen[k.gvr]; ok {
+			continue
+		}
+		seen[k.gvr] = struct{}{}
+		out = append(out, k.gvr)
 	}
 	return out
 }
 
+// readEntries returns the informer(s) that serve reads for (gvr, ns). A
+// cluster-wide informer alone covers every namespace; otherwise reads come
+// from namespace-scoped informers — the one matching a specific ns, or all of
+// the matching namespace-scoped informer for a specific ns. e.informer is
+// immutable after creation, so the returned entries are safe to read outside
+// the lock (e.synced is not touched here). Returns nil when nothing covers
+// (gvr, ns).
+//
+// ns == "" means cluster-wide and is served ONLY by a cluster-wide informer —
+// it deliberately does NOT union whatever per-namespace informers happen to
+// exist, which would make results depend on incidental cache state (and, in a
+// shared cache, on namespaces another request warmed). Callers wanting a union
+// over a known namespace set must name it via ListNamespaces.
+func (d *DynamicResourceCache) readEntries(gvr schema.GroupVersionResource, ns string) []*informerEntry {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	if e, ok := d.informers[informerKey{gvr: gvr}]; ok {
+		return []*informerEntry{e}
+	}
+	if ns == "" {
+		return nil
+	}
+	if e, ok := d.informers[informerKey{gvr: gvr, ns: ns}]; ok {
+		return []*informerEntry{e}
+	}
+	return nil
+}
+
+// indexerItems gathers raw store objects from the given entries, filtered to
+// namespace when non-empty. Namespace-scoped informers hold disjoint
+// namespaces, so unioning across entries cannot duplicate an object.
+func indexerItems(entries []*informerEntry, namespace string) ([]any, error) {
+	var items []any
+	for _, e := range entries {
+		idx := e.informer.GetIndexer()
+		if namespace != "" {
+			got, err := idx.ByIndex(cache.NamespaceIndex, namespace)
+			if err != nil {
+				return nil, err
+			}
+			items = append(items, got...)
+		} else {
+			items = append(items, idx.List()...)
+		}
+	}
+	return items, nil
+}
+
+// gvrSyncedLocked reports whether the informer holding objects of gvr in
+// namespace has finished its initial sync (cluster-wide informer first, else
+// the namespace-scoped one). Caller must hold d.mu.
+func (d *DynamicResourceCache) gvrSyncedLocked(gvr schema.GroupVersionResource, namespace string) bool {
+	if e, ok := d.informers[informerKey{gvr: gvr}]; ok {
+		return e.synced
+	}
+	if e, ok := d.informers[informerKey{gvr: gvr, ns: namespace}]; ok {
+		return e.synced
+	}
+	return false
+}
+
+// getByKeyFromEntries returns the first store object matching key across the
+// entries. Namespace-scoped informers hold disjoint namespaces, so at most one
+// can hold a given namespaced key.
+func getByKeyFromEntries(entries []*informerEntry, key string) (any, bool, error) {
+	for _, e := range entries {
+		item, ok, err := e.informer.GetIndexer().GetByKey(key)
+		if err != nil {
+			return nil, false, err
+		}
+		if ok {
+			return item, true, nil
+		}
+	}
+	return nil, false, nil
+}
+
+// entriesSynced reports whether every entry's informer has completed its
+// initial sync (informer.HasSynced is the thread-safe source of truth).
+func entriesSynced(entries []*informerEntry) bool {
+	for _, e := range entries {
+		if !e.informer.HasSynced() {
+			return false
+		}
+	}
+	return len(entries) > 0
+}
+
 // Count returns the number of resources for a given GVR, optionally filtered by namespaces.
 // Unlike List(), this avoids allocating a result slice and skips StripUnstructuredFields.
+// Count reads only what is already watched and synced; it does not start informers.
+//
+// A cluster-wide informer serves any namespace filter. Without one, Count can
+// only answer for explicitly-named namespaces (each must have its own synced
+// informer); counting "all" (nil namespaces) is unsupported in that mode and
+// returns a not-synced error rather than an incidental per-namespace union.
 func (d *DynamicResourceCache) Count(gvr schema.GroupVersionResource, namespaces []string) (int, error) {
 	if d == nil {
 		return 0, fmt.Errorf("dynamic resource cache not initialized")
 	}
 
 	d.mu.RLock()
-	informer, exists := d.informers[gvr]
-	synced := d.syncComplete[gvr]
-	d.mu.RUnlock()
+	defer d.mu.RUnlock()
 
-	if !exists || !synced {
-		return 0, fmt.Errorf("informer not found or not synced for %v", gvr)
+	if e, ok := d.informers[informerKey{gvr: gvr}]; ok {
+		if !e.synced {
+			return 0, fmt.Errorf("informer not found or not synced for %v", gvr)
+		}
+		if len(namespaces) == 0 {
+			return len(e.informer.GetIndexer().List()), nil
+		}
+		return countByNamespaces(e, namespaces)
 	}
 
 	if len(namespaces) == 0 {
-		return len(informer.GetIndexer().List()), nil
+		return 0, fmt.Errorf("informer not found or not synced for %v", gvr)
 	}
 
 	total := 0
 	for _, ns := range namespaces {
-		items, err := informer.GetIndexer().ByIndex(cache.NamespaceIndex, ns)
+		e, ok := d.informers[informerKey{gvr: gvr, ns: ns}]
+		if !ok || !e.synced {
+			return 0, fmt.Errorf("informer not found or not synced for %v in namespace %s", gvr, ns)
+		}
+		n, err := countByNamespaces(e, []string{ns})
+		if err != nil {
+			return 0, err
+		}
+		total += n
+	}
+	return total, nil
+}
+
+func countByNamespaces(e *informerEntry, namespaces []string) (int, error) {
+	total := 0
+	for _, ns := range namespaces {
+		items, err := e.informer.GetIndexer().ByIndex(cache.NamespaceIndex, ns)
 		if err != nil {
 			return 0, fmt.Errorf("failed to count resources in namespace %s: %w", ns, err)
 		}
@@ -536,27 +738,16 @@ func (d *DynamicResourceCache) List(gvr schema.GroupVersionResource, namespace s
 		return nil, fmt.Errorf("dynamic resource cache not initialized")
 	}
 
-	if err := d.EnsureWatching(gvr); err != nil {
+	if err := d.ensureWatching(gvr, namespace); err != nil {
 		return nil, err
 	}
 
-	d.mu.RLock()
-	informer, exists := d.informers[gvr]
-	d.mu.RUnlock()
-
-	if !exists {
+	entries := d.readEntries(gvr, namespace)
+	if len(entries) == 0 {
 		return nil, fmt.Errorf("informer not found for %v", gvr)
 	}
 
-	var items []any
-	var err error
-
-	if namespace != "" {
-		items, err = informer.GetIndexer().ByIndex(cache.NamespaceIndex, namespace)
-	} else {
-		items = informer.GetIndexer().List()
-	}
-
+	items, err := indexerItems(entries, namespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list resources: %w", err)
 	}
@@ -564,11 +755,67 @@ func (d *DynamicResourceCache) List(gvr schema.GroupVersionResource, namespace s
 	result := make([]*unstructured.Unstructured, 0, len(items))
 	for _, item := range items {
 		if u, ok := item.(*unstructured.Unstructured); ok {
-			u = StripUnstructuredFields(u)
-			result = append(result, u)
+			result = append(result, StripUnstructuredFields(u))
 		}
 	}
 
+	return result, nil
+}
+
+// ListWatched returns every cached object for gvr across all currently-watched
+// scopes (cluster-wide and/or per-namespace), unioned. It does NOT start or
+// re-probe informers — it reads whatever is already watched. This is for
+// internal "scan what's already cached" callers (Crossplane audit, Kyverno
+// PolicyReport indexing) that iterate WatchedGVRs(): unlike List(gvr, ""),
+// which is cluster-wide-only, it surfaces namespace-scoped contents so those
+// scanners don't silently drop them in a namespace-restricted install.
+// Request-facing reads must stay on List / ListNamespaces with explicit
+// namespaces.
+func (d *DynamicResourceCache) ListWatched(gvr schema.GroupVersionResource) ([]*unstructured.Unstructured, error) {
+	if d == nil {
+		return nil, fmt.Errorf("dynamic resource cache not initialized")
+	}
+	entries := d.entriesForGVR(gvr)
+	items, err := indexerItems(entries, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list resources: %w", err)
+	}
+	result := make([]*unstructured.Unstructured, 0, len(items))
+	for _, item := range items {
+		if u, ok := item.(*unstructured.Unstructured); ok {
+			result = append(result, StripUnstructuredFields(u))
+		}
+	}
+	return result, nil
+}
+
+// ListNamespaces returns resources of gvr unioned across an explicit set of
+// namespaces. This is the sanctioned multi-namespace path — callers with a
+// known, RBAC-filtered namespace set use it instead of List(gvr, ""), so the
+// union is driven by the caller's explicit list rather than by whatever
+// per-namespace informers incidentally exist. Namespace-scoped informers hold
+// disjoint namespaces, so the union cannot duplicate an object.
+//
+// Two cases short-circuit to a cluster-wide read: an empty/nil set ("all"),
+// and a cluster-scoped resource (no namespace dimension — a per-namespace
+// filter would match nothing, so always read it cluster-wide regardless of the
+// requested namespaces). The cluster-scoped check makes this safe to call
+// uniformly over a mix of namespaced and cluster-scoped GVRs.
+func (d *DynamicResourceCache) ListNamespaces(gvr schema.GroupVersionResource, namespaces []string) ([]*unstructured.Unstructured, error) {
+	if d == nil {
+		return nil, fmt.Errorf("dynamic resource cache not initialized")
+	}
+	if len(namespaces) == 0 || !d.gvrIsNamespaced(gvr) {
+		return d.List(gvr, "")
+	}
+	result := make([]*unstructured.Unstructured, 0)
+	for _, ns := range namespaces {
+		items, err := d.List(gvr, ns)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, items...)
+	}
 	return result, nil
 }
 
@@ -578,33 +825,24 @@ func (d *DynamicResourceCache) ListBlocking(gvr schema.GroupVersionResource, nam
 		return nil, fmt.Errorf("dynamic resource cache not initialized")
 	}
 
-	if err := d.EnsureWatching(gvr); err != nil {
+	if err := d.ensureWatching(gvr, namespace); err != nil {
 		return nil, err
 	}
 
-	d.mu.RLock()
-	informer, exists := d.informers[gvr]
-	d.mu.RUnlock()
-
-	if !exists {
+	entries := d.readEntries(gvr, namespace)
+	if len(entries) == 0 {
 		return nil, fmt.Errorf("informer not found for %v", gvr)
 	}
 
-	if !informer.HasSynced() {
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		defer cancel()
-		cache.WaitForCacheSync(ctx.Done(), informer.HasSynced)
+	for _, e := range entries {
+		if !e.informer.HasSynced() {
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			cache.WaitForCacheSync(ctx.Done(), e.informer.HasSynced)
+			cancel()
+		}
 	}
 
-	var items []any
-	var err error
-
-	if namespace != "" {
-		items, err = informer.GetIndexer().ByIndex(cache.NamespaceIndex, namespace)
-	} else {
-		items = informer.GetIndexer().List()
-	}
-
+	items, err := indexerItems(entries, namespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list resources: %w", err)
 	}
@@ -612,8 +850,7 @@ func (d *DynamicResourceCache) ListBlocking(gvr schema.GroupVersionResource, nam
 	result := make([]*unstructured.Unstructured, 0, len(items))
 	for _, item := range items {
 		if u, ok := item.(*unstructured.Unstructured); ok {
-			u = StripUnstructuredFields(u)
-			result = append(result, u)
+			result = append(result, StripUnstructuredFields(u))
 		}
 	}
 
@@ -636,15 +873,12 @@ func (d *DynamicResourceCache) get(gvr schema.GroupVersionResource, namespace, n
 		return nil, fmt.Errorf("dynamic resource cache not initialized")
 	}
 
-	if err := d.EnsureWatching(gvr); err != nil {
+	if err := d.ensureWatching(gvr, namespace); err != nil {
 		return nil, err
 	}
 
-	d.mu.RLock()
-	informer, exists := d.informers[gvr]
-	d.mu.RUnlock()
-
-	if !exists {
+	entries := d.readEntries(gvr, namespace)
+	if len(entries) == 0 {
 		return nil, fmt.Errorf("informer not found for %v", gvr)
 	}
 
@@ -655,23 +889,25 @@ func (d *DynamicResourceCache) get(gvr schema.GroupVersionResource, namespace, n
 		key = name
 	}
 
-	item, exists, err := informer.GetIndexer().GetByKey(key)
+	item, found, err := getByKeyFromEntries(entries, key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get resource: %w", err)
 	}
 
-	if !exists && !informer.HasSynced() {
+	if !found && !entriesSynced(entries) {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-		cache.WaitForCacheSync(ctx.Done(), informer.HasSynced)
+		for _, e := range entries {
+			cache.WaitForCacheSync(ctx.Done(), e.informer.HasSynced)
+		}
+		cancel()
 
-		item, exists, err = informer.GetIndexer().GetByKey(key)
+		item, found, err = getByKeyFromEntries(entries, key)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get resource: %w", err)
 		}
 	}
 
-	if !exists {
+	if !found {
 		return nil, fmt.Errorf("resource not found: %s", key)
 	}
 
@@ -781,48 +1017,49 @@ func (d *DynamicResourceCache) WarmupParallel(gvrs []schema.GroupVersionResource
 
 	const maxConcurrentProbes = 50
 	type probeResult struct {
-		gvr schema.GroupVersionResource
-		ok  bool
+		gvr   schema.GroupVersionResource
+		scope string
+		ok    bool
 	}
 	results := make(chan probeResult, len(gvrs))
 	sem := make(chan struct{}, maxConcurrentProbes)
 	for _, gvr := range gvrs {
 		go func(g schema.GroupVersionResource) {
 			sem <- struct{}{}
-			err := d.probeAccess(g)
+			scope, err := d.probeScope(g, "")
 			<-sem
-			results <- probeResult{gvr: g, ok: err == nil}
+			results <- probeResult{gvr: g, scope: scope, ok: err == nil}
 		}(gvr)
 	}
 
-	var accessibleGVRs []schema.GroupVersionResource
+	var accessible []probeResult
 	for range gvrs {
 		r := <-results
 		if r.ok {
-			accessibleGVRs = append(accessibleGVRs, r.gvr)
+			accessible = append(accessible, r)
 		}
 	}
 
-	if len(accessibleGVRs) == 0 {
+	if len(accessible) == 0 {
 		return
 	}
 
-	var validGVRs []schema.GroupVersionResource
-	for _, gvr := range accessibleGVRs {
-		if err := d.startWatching(gvr); err == nil {
-			validGVRs = append(validGVRs, gvr)
+	var started []informerKey
+	for _, r := range accessible {
+		if err := d.startWatching(r.gvr, r.scope); err == nil {
+			started = append(started, informerKey{gvr: r.gvr, ns: r.scope})
 		}
 	}
 
-	if len(validGVRs) == 0 {
+	if len(started) == 0 {
 		return
 	}
 
 	d.mu.RLock()
-	syncFuncs := make([]cache.InformerSynced, 0, len(validGVRs))
-	for _, gvr := range validGVRs {
-		if informer, ok := d.informers[gvr]; ok {
-			syncFuncs = append(syncFuncs, informer.HasSynced)
+	syncFuncs := make([]cache.InformerSynced, 0, len(started))
+	for _, key := range started {
+		if e, ok := d.informers[key]; ok {
+			syncFuncs = append(syncFuncs, e.informer.HasSynced)
 		}
 	}
 	d.mu.RUnlock()
@@ -937,10 +1174,14 @@ func (d *DynamicResourceCache) DiscoverAllCRDs() {
 
 		// Filter out GVRs already watched from Phase 1 warmup
 		d.mu.RLock()
-		alreadyWatching := len(d.informers)
+		watched := make(map[schema.GroupVersionResource]struct{}, len(d.informers))
+		for k := range d.informers {
+			watched[k.gvr] = struct{}{}
+		}
+		alreadyWatching := len(watched)
 		var remaining []schema.GroupVersionResource
 		for _, gvr := range gvrs {
-			if _, exists := d.informers[gvr]; !exists {
+			if _, exists := watched[gvr]; !exists {
 				remaining = append(remaining, gvr)
 			}
 		}
@@ -1027,33 +1268,46 @@ func (d *DynamicResourceCache) GetDiscoveryStatus() CRDDiscoveryStatus {
 	return d.discoveryStatus
 }
 
-// WaitForSync waits for a resource's cache to be synced (with timeout).
-func (d *DynamicResourceCache) WaitForSync(gvr schema.GroupVersionResource, timeout time.Duration) bool {
+// entriesForGVR returns every informer entry watching gvr across all scopes —
+// the cluster-wide entry and/or per-namespace entries. GVR-level status and
+// handler-registration APIs ask "is this kind watched?" rather than returning
+// resource data, so they span all of a GVR's namespace-scoped informers —
+// unlike readEntries, whose ns == "" path is cluster-wide-only to keep data
+// reads deterministic. Using readEntries(gvr, "") here would wrongly report a
+// namespace-restricted (no cluster-wide informer) GVR as unwatched/unsynced.
+func (d *DynamicResourceCache) entriesForGVR(gvr schema.GroupVersionResource) []*informerEntry {
 	d.mu.RLock()
-	informer, exists := d.informers[gvr]
-	d.mu.RUnlock()
+	defer d.mu.RUnlock()
+	var out []*informerEntry
+	for k, e := range d.informers {
+		if k.gvr == gvr {
+			out = append(out, e)
+		}
+	}
+	return out
+}
 
-	if !exists {
+// WaitForSync waits for a resource's cache(s) to be synced (with timeout).
+// A GVR may have several namespace-scoped informers; all must sync.
+func (d *DynamicResourceCache) WaitForSync(gvr schema.GroupVersionResource, timeout time.Duration) bool {
+	entries := d.entriesForGVR(gvr)
+	if len(entries) == 0 {
 		return false
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	return cache.WaitForCacheSync(ctx.Done(), informer.HasSynced)
+	syncFuncs := make([]cache.InformerSynced, 0, len(entries))
+	for _, e := range entries {
+		syncFuncs = append(syncFuncs, e.informer.HasSynced)
+	}
+	return cache.WaitForCacheSync(ctx.Done(), syncFuncs...)
 }
 
-// IsSynced checks if a resource's cache is synced (non-blocking).
+// IsSynced checks if a resource's cache(s) are synced (non-blocking).
 func (d *DynamicResourceCache) IsSynced(gvr schema.GroupVersionResource) bool {
-	d.mu.RLock()
-	informer, exists := d.informers[gvr]
-	d.mu.RUnlock()
-
-	if !exists {
-		return false
-	}
-
-	return informer.HasSynced()
+	return entriesSynced(d.entriesForGVR(gvr))
 }
 
 // ---------------------------------------------------------------------------
@@ -1069,11 +1323,7 @@ func (d *DynamicResourceCache) GetWatchedResources() []schema.GroupVersionResour
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
-	result := make([]schema.GroupVersionResource, 0, len(d.informers))
-	for gvr := range d.informers {
-		result = append(result, gvr)
-	}
-	return result
+	return d.distinctGVRsLocked()
 }
 
 // GetInformerCount returns the number of active dynamic informers.
@@ -1105,16 +1355,28 @@ func (d *DynamicResourceCache) AddGVRChangeHandler(gvr schema.GroupVersionResour
 		return fmt.Errorf("dynamic resource cache not initialized")
 	}
 
-	d.mu.RLock()
-	informer, exists := d.informers[gvr]
-	d.mu.RUnlock()
+	d.mu.Lock()
+	defer d.mu.Unlock()
 
-	if !exists {
+	var entries []*informerEntry
+	for k, e := range d.informers {
+		if k.gvr == gvr {
+			entries = append(entries, e)
+		}
+	}
+	if len(entries) == 0 {
 		return fmt.Errorf("no informer for %s.%s/%s; warm up the resource before registering a handler", gvr.Resource, gvr.Group, gvr.Version)
 	}
 
-	if _, err := informer.AddEventHandler(handler); err != nil {
-		return fmt.Errorf("add event handler for %v: %w", gvr, err)
+	// Remember the handler so informers started later for this GVR (lazy
+	// per-namespace watches, or re-creations after an idle reap) get it too —
+	// otherwise derived caches silently miss those namespaces' events.
+	d.gvrHandlers[gvr] = append(d.gvrHandlers[gvr], handler)
+
+	for _, e := range entries {
+		if _, err := e.informer.AddEventHandler(handler); err != nil {
+			return fmt.Errorf("add event handler for %v: %w", gvr, err)
+		}
 	}
 	return nil
 }
@@ -1158,14 +1420,23 @@ func (d *DynamicResourceCache) Stop() {
 		}
 		d.discoveryMu.Unlock()
 
+		// Closing stopCh cancels every per-informer context (each informer's
+		// watchdog goroutine selects on it), stopping all watches.
 		close(d.stopCh)
+
+		d.mu.RLock()
+		nsFactories := make([]dynamicinformer.DynamicSharedInformerFactory, 0, len(d.nsFactories))
+		for _, f := range d.nsFactories {
+			nsFactories = append(nsFactories, f)
+		}
+		d.mu.RUnlock()
 
 		go func() {
 			done := make(chan struct{})
 			go func() {
 				d.factory.Shutdown()
-				if d.nsFactory != nil {
-					d.nsFactory.Shutdown()
+				for _, f := range nsFactories {
+					f.Shutdown()
 				}
 				close(done)
 			}()

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -330,7 +330,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		rolloutGVR, hasRollouts = resourceDiscovery.GetGVR("Rollout")
 	}
 	if hasRollouts && dynamicCache != nil {
-		rollouts, err := dynamicCache.List(rolloutGVR, opts.NamespaceFilter())
+		rollouts, err := dynamicCache.ListNamespaces(rolloutGVR, opts.Namespaces)
 		if err != nil {
 			log.Printf("WARNING [topology] Failed to list Rollouts: %v", err)
 			warnings = append(warnings, fmt.Sprintf("Failed to list Rollouts: %v", err))
@@ -414,7 +414,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	var applicationResources []*unstructured.Unstructured // Store for second pass
 	applicationDestNamespaces := make(map[string]string)  // appID -> destNamespace
 	if hasApplications && dynamicCache != nil {
-		applications, err := dynamicCache.List(applicationGVR, opts.NamespaceFilter())
+		applications, err := dynamicCache.ListNamespaces(applicationGVR, opts.Namespaces)
 		if err != nil {
 			log.Printf("WARNING [topology] Failed to list ArgoCD Applications: %v", err)
 			warnings = append(warnings, fmt.Sprintf("Failed to list ArgoCD Applications: %v", err))
@@ -510,7 +510,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	kustomizationIDs := make(map[string]string)             // ns/name -> kustomizationID
 	var kustomizationResources []*unstructured.Unstructured // Store for second pass
 	if hasKustomizations && dynamicCache != nil {
-		kustomizations, err := dynamicCache.List(kustomizationGVR, opts.NamespaceFilter())
+		kustomizations, err := dynamicCache.ListNamespaces(kustomizationGVR, opts.Namespaces)
 		if err != nil {
 			log.Printf("WARNING [topology] Failed to list FluxCD Kustomizations: %v", err)
 			warnings = append(warnings, fmt.Sprintf("Failed to list FluxCD Kustomizations: %v", err))
@@ -580,7 +580,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	}
 	gitRepoIDs := make(map[string]string) // ns/name -> gitRepoID
 	if hasGitRepos && dynamicCache != nil {
-		gitRepos, err := dynamicCache.List(gitRepoGVR, opts.NamespaceFilter())
+		gitRepos, err := dynamicCache.ListNamespaces(gitRepoGVR, opts.Namespaces)
 		if err != nil {
 			log.Printf("WARNING [topology] Failed to list FluxCD GitRepositories: %v", err)
 			warnings = append(warnings, fmt.Sprintf("Failed to list FluxCD GitRepositories: %v", err))
@@ -645,7 +645,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	}
 	helmReleaseIDs := make(map[string]string) // ns/name -> helmReleaseID
 	if hasHelmReleases && dynamicCache != nil {
-		helmReleases, err := dynamicCache.List(helmReleaseGVR, opts.NamespaceFilter())
+		helmReleases, err := dynamicCache.ListNamespaces(helmReleaseGVR, opts.Namespaces)
 		if err != nil {
 			log.Printf("WARNING [topology] Failed to list FluxCD HelmReleases: %v", err)
 			warnings = append(warnings, fmt.Sprintf("Failed to list FluxCD HelmReleases: %v", err))
@@ -718,7 +718,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	}
 	var certificateResources []unstructured.Unstructured
 	if hasCertificates && dynamicCache != nil {
-		certs, certErr := dynamicCache.List(certificateGVR, opts.NamespaceFilter())
+		certs, certErr := dynamicCache.ListNamespaces(certificateGVR, opts.Namespaces)
 		if certErr != nil {
 			log.Printf("WARNING [topology] Failed to list cert-manager Certificates: %v", certErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list cert-manager Certificates: %v", certErr))
@@ -757,7 +757,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	}
 	var cachedNodePools []*unstructured.Unstructured // reused for NodePool→NodeClass edges
 	if hasNodePools && dynamicCache != nil {
-		nodePools, npErr := dynamicCache.List(nodePoolGVR, opts.NamespaceFilter())
+		nodePools, npErr := dynamicCache.ListNamespaces(nodePoolGVR, opts.Namespaces)
 		if npErr != nil {
 			log.Printf("WARNING [topology] Failed to list Karpenter NodePools: %v", npErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list Karpenter NodePools: %v", npErr))
@@ -792,7 +792,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		nodeClaimGVR, hasNodeClaims = resourceDiscovery.GetGVR("NodeClaim")
 	}
 	if hasNodeClaims && dynamicCache != nil {
-		nodeClaims, ncErr := dynamicCache.List(nodeClaimGVR, opts.NamespaceFilter())
+		nodeClaims, ncErr := dynamicCache.ListNamespaces(nodeClaimGVR, opts.Namespaces)
 		if ncErr != nil {
 			log.Printf("WARNING [topology] Failed to list Karpenter NodeClaims: %v", ncErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list Karpenter NodeClaims: %v", ncErr))
@@ -957,7 +957,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		scaledObjectGVR, hasScaledObjects = resourceDiscovery.GetGVR("ScaledObject")
 	}
 	if hasScaledObjects && dynamicCache != nil {
-		scaledObjects, soErr := dynamicCache.List(scaledObjectGVR, opts.NamespaceFilter())
+		scaledObjects, soErr := dynamicCache.ListNamespaces(scaledObjectGVR, opts.Namespaces)
 		if soErr != nil {
 			log.Printf("WARNING [topology] Failed to list KEDA ScaledObjects: %v", soErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list KEDA ScaledObjects: %v", soErr))
@@ -1017,7 +1017,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		scaledJobGVR, hasScaledJobs = resourceDiscovery.GetGVR("ScaledJob")
 	}
 	if hasScaledJobs && dynamicCache != nil {
-		scaledJobs, sjErr := dynamicCache.List(scaledJobGVR, opts.NamespaceFilter())
+		scaledJobs, sjErr := dynamicCache.ListNamespaces(scaledJobGVR, opts.Namespaces)
 		if sjErr != nil {
 			log.Printf("WARNING [topology] Failed to list KEDA ScaledJobs: %v", sjErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list KEDA ScaledJobs: %v", sjErr))
@@ -1054,7 +1054,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		capiClusterGVR, hasCAPIClusters = resourceDiscovery.GetGVRWithGroup("Cluster", "cluster.x-k8s.io")
 	}
 	if hasCAPIClusters && dynamicCache != nil {
-		clusters, clErr := dynamicCache.List(capiClusterGVR, opts.NamespaceFilter())
+		clusters, clErr := dynamicCache.ListNamespaces(capiClusterGVR, opts.Namespaces)
 		if clErr != nil {
 			log.Printf("WARNING [topology] Failed to list CAPI Clusters: %v", clErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list CAPI Clusters: %v", clErr))
@@ -1090,7 +1090,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		capiClusterClassGVR, hasCAPIClusterClasses = resourceDiscovery.GetGVR("ClusterClass")
 	}
 	if hasCAPIClusterClasses && dynamicCache != nil {
-		clusterClasses, ccErr := dynamicCache.List(capiClusterClassGVR, opts.NamespaceFilter())
+		clusterClasses, ccErr := dynamicCache.ListNamespaces(capiClusterClassGVR, opts.Namespaces)
 		if ccErr != nil {
 			log.Printf("WARNING [topology] Failed to list CAPI ClusterClasses: %v", ccErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list CAPI ClusterClasses: %v", ccErr))
@@ -1156,7 +1156,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		kcpGVR, hasKCPs = resourceDiscovery.GetGVR("KubeadmControlPlane")
 	}
 	if hasKCPs && dynamicCache != nil {
-		kcps, kcpErr := dynamicCache.List(kcpGVR, opts.NamespaceFilter())
+		kcps, kcpErr := dynamicCache.ListNamespaces(kcpGVR, opts.Namespaces)
 		if kcpErr != nil {
 			log.Printf("WARNING [topology] Failed to list CAPI KubeadmControlPlanes: %v", kcpErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list CAPI KubeadmControlPlanes: %v", kcpErr))
@@ -1205,7 +1205,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		mdGVR, hasMDs = resourceDiscovery.GetGVR("MachineDeployment")
 	}
 	if hasMDs && dynamicCache != nil {
-		mds, mdErr := dynamicCache.List(mdGVR, opts.NamespaceFilter())
+		mds, mdErr := dynamicCache.ListNamespaces(mdGVR, opts.Namespaces)
 		if mdErr != nil {
 			log.Printf("WARNING [topology] Failed to list CAPI MachineDeployments: %v", mdErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list CAPI MachineDeployments: %v", mdErr))
@@ -1254,7 +1254,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		mpGVR, hasMPs = resourceDiscovery.GetGVR("MachinePool")
 	}
 	if hasMPs && dynamicCache != nil {
-		mps, mpErr := dynamicCache.List(mpGVR, opts.NamespaceFilter())
+		mps, mpErr := dynamicCache.ListNamespaces(mpGVR, opts.Namespaces)
 		if mpErr != nil {
 			log.Printf("WARNING [topology] Failed to list CAPI MachinePools: %v", mpErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list CAPI MachinePools: %v", mpErr))
@@ -1303,7 +1303,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		capiMsGVR, hasCAPIMachineSets = resourceDiscovery.GetGVRWithGroup("MachineSet", "cluster.x-k8s.io")
 	}
 	if hasCAPIMachineSets && dynamicCache != nil {
-		machineSets, msErr := dynamicCache.List(capiMsGVR, opts.NamespaceFilter())
+		machineSets, msErr := dynamicCache.ListNamespaces(capiMsGVR, opts.Namespaces)
 		if msErr != nil {
 			log.Printf("WARNING [topology] Failed to list CAPI MachineSets: %v", msErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list CAPI MachineSets: %v", msErr))
@@ -1352,7 +1352,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		capiMachineGVR, hasCAPIMachines = resourceDiscovery.GetGVRWithGroup("Machine", "cluster.x-k8s.io")
 	}
 	if hasCAPIMachines && dynamicCache != nil {
-		machines, mErr := dynamicCache.List(capiMachineGVR, opts.NamespaceFilter())
+		machines, mErr := dynamicCache.ListNamespaces(capiMachineGVR, opts.Namespaces)
 		if mErr != nil {
 			log.Printf("WARNING [topology] Failed to list CAPI Machines: %v", mErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list CAPI Machines: %v", mErr))
@@ -1447,7 +1447,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		mhcGVR, hasMHCs = resourceDiscovery.GetGVR("MachineHealthCheck")
 	}
 	if hasMHCs && dynamicCache != nil {
-		mhcs, mhcErr := dynamicCache.List(mhcGVR, opts.NamespaceFilter())
+		mhcs, mhcErr := dynamicCache.ListNamespaces(mhcGVR, opts.Namespaces)
 		if mhcErr != nil {
 			log.Printf("WARNING [topology] Failed to list CAPI MachineHealthChecks: %v", mhcErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list CAPI MachineHealthChecks: %v", mhcErr))
@@ -1529,7 +1529,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	virtualServiceIDs := make(map[string]string)             // ns/name -> vsID
 	var virtualServiceResources []*unstructured.Unstructured // Store for second pass
 	if hasVirtualServices && dynamicCache != nil {
-		virtualServices, vsErr := dynamicCache.List(virtualServiceGVR, opts.NamespaceFilter())
+		virtualServices, vsErr := dynamicCache.ListNamespaces(virtualServiceGVR, opts.Namespaces)
 		if vsErr != nil {
 			log.Printf("WARNING [topology] Failed to list Istio VirtualServices: %v", vsErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list Istio VirtualServices: %v", vsErr))
@@ -1588,7 +1588,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	destinationRuleIDs := make(map[string]string)             // ns/name -> drID
 	var destinationRuleResources []*unstructured.Unstructured // Store for second pass
 	if hasDestinationRules && dynamicCache != nil {
-		destinationRules, drErr := dynamicCache.List(destinationRuleGVR, opts.NamespaceFilter())
+		destinationRules, drErr := dynamicCache.ListNamespaces(destinationRuleGVR, opts.Namespaces)
 		if drErr != nil {
 			log.Printf("WARNING [topology] Failed to list Istio DestinationRules: %v", drErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list Istio DestinationRules: %v", drErr))
@@ -1638,7 +1638,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	}
 	istioGatewayIDs := make(map[string]string) // ns/name -> igwID
 	if hasIstioGateways && dynamicCache != nil {
-		istioGateways, igwErr := dynamicCache.List(istioGatewayGVR, opts.NamespaceFilter())
+		istioGateways, igwErr := dynamicCache.ListNamespaces(istioGatewayGVR, opts.Namespaces)
 		if igwErr != nil {
 			log.Printf("WARNING [topology] Failed to list Istio Gateways: %v", igwErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list Istio Gateways: %v", igwErr))
@@ -1690,7 +1690,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	knativeServiceIDs := make(map[string]string)             // ns/name -> ksvcID
 	var knativeServiceResources []*unstructured.Unstructured // Store for second pass
 	if hasKnativeServices && dynamicCache != nil {
-		knativeServices, ksvcErr := dynamicCache.List(knativeServiceGVR, opts.NamespaceFilter())
+		knativeServices, ksvcErr := dynamicCache.ListNamespaces(knativeServiceGVR, opts.Namespaces)
 		if ksvcErr != nil {
 			log.Printf("WARNING [topology] Failed to list KNative Services: %v", ksvcErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list KNative Services: %v", ksvcErr))
@@ -1730,7 +1730,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	knativeConfigIDs := make(map[string]string)             // ns/name -> kcfgID
 	var knativeConfigResources []*unstructured.Unstructured // Store for edge creation
 	if hasKnativeConfigs && dynamicCache != nil {
-		knativeConfigs, kcfgErr := dynamicCache.List(knativeConfigGVR, opts.NamespaceFilter())
+		knativeConfigs, kcfgErr := dynamicCache.ListNamespaces(knativeConfigGVR, opts.Namespaces)
 		if kcfgErr != nil {
 			log.Printf("WARNING [topology] Failed to list KNative Configurations: %v", kcfgErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list KNative Configurations: %v", kcfgErr))
@@ -1769,7 +1769,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	knativeRevisionIDs := make(map[string]string)             // ns/name -> krevID
 	var knativeRevisionResources []*unstructured.Unstructured // Store for edge creation
 	if hasKnativeRevisions && dynamicCache != nil {
-		knativeRevisions, krevErr := dynamicCache.List(knativeRevisionGVR, opts.NamespaceFilter())
+		knativeRevisions, krevErr := dynamicCache.ListNamespaces(knativeRevisionGVR, opts.Namespaces)
 		if krevErr != nil {
 			log.Printf("WARNING [topology] Failed to list KNative Revisions: %v", krevErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list KNative Revisions: %v", krevErr))
@@ -1808,7 +1808,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	knativeRouteIDs := make(map[string]string)             // ns/name -> krouteID
 	var knativeRouteResources []*unstructured.Unstructured // Store for second pass
 	if hasKnativeRoutes && dynamicCache != nil {
-		knativeRoutes, krouteErr := dynamicCache.List(knativeRouteGVR, opts.NamespaceFilter())
+		knativeRoutes, krouteErr := dynamicCache.ListNamespaces(knativeRouteGVR, opts.Namespaces)
 		if krouteErr != nil {
 			log.Printf("WARNING [topology] Failed to list KNative Routes: %v", krouteErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list KNative Routes: %v", krouteErr))
@@ -1850,7 +1850,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	}
 	knativeBrokerIDs := make(map[string]string) // ns/name -> brokerID
 	if hasKnativeBrokers && dynamicCache != nil {
-		knativeBrokers, brokerErr := dynamicCache.List(knativeBrokerGVR, opts.NamespaceFilter())
+		knativeBrokers, brokerErr := dynamicCache.ListNamespaces(knativeBrokerGVR, opts.Namespaces)
 		if brokerErr != nil {
 			log.Printf("WARNING [topology] Failed to list KNative Brokers: %v", brokerErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list KNative Brokers: %v", brokerErr))
@@ -1888,7 +1888,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	knativeTriggerIDs := make(map[string]string)             // ns/name -> triggerID
 	var knativeTriggerResources []*unstructured.Unstructured // Store for second pass
 	if hasKnativeTriggers && dynamicCache != nil {
-		knativeTriggers, triggerErr := dynamicCache.List(knativeTriggerGVR, opts.NamespaceFilter())
+		knativeTriggers, triggerErr := dynamicCache.ListNamespaces(knativeTriggerGVR, opts.Namespaces)
 		if triggerErr != nil {
 			log.Printf("WARNING [topology] Failed to list KNative Triggers: %v", triggerErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list KNative Triggers: %v", triggerErr))
@@ -1942,7 +1942,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		if !hasSrc || dynamicCache == nil {
 			continue
 		}
-		sources, srcErr := dynamicCache.List(srcGVR, opts.NamespaceFilter())
+		sources, srcErr := dynamicCache.ListNamespaces(srcGVR, opts.Namespaces)
 		if srcErr != nil {
 			log.Printf("WARNING [topology] Failed to list KNative %s: %v", srcDef.kind, srcErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list KNative %s: %v", srcDef.kind, srcErr))
@@ -1982,7 +1982,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	}
 	knativeChannelIDs := make(map[string]string) // ns/name -> channelID
 	if hasKnativeChannels && dynamicCache != nil {
-		knativeChannels, chanErr := dynamicCache.List(knativeChannelGVR, opts.NamespaceFilter())
+		knativeChannels, chanErr := dynamicCache.ListNamespaces(knativeChannelGVR, opts.Namespaces)
 		if chanErr != nil {
 			log.Printf("WARNING [topology] Failed to list KNative Channels: %v", chanErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list KNative Channels: %v", chanErr))
@@ -2041,7 +2041,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		if !hasKind || dynamicCache == nil {
 			continue
 		}
-		resources, listErr := dynamicCache.List(gvr, opts.NamespaceFilter())
+		resources, listErr := dynamicCache.ListNamespaces(gvr, opts.Namespaces)
 		if listErr != nil {
 			log.Printf("WARNING [topology] Failed to list Traefik %s: %v", def.kind, listErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list Traefik %s: %v", def.kind, listErr))
@@ -2114,7 +2114,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		if !hasKind || dynamicCache == nil {
 			continue
 		}
-		resources, listErr := dynamicCache.List(gvr, opts.NamespaceFilter())
+		resources, listErr := dynamicCache.ListNamespaces(gvr, opts.Namespaces)
 		if listErr != nil {
 			log.Printf("WARNING [topology] Failed to list Traefik %s: %v", def.kind, listErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list Traefik %s: %v", def.kind, listErr))
@@ -2157,7 +2157,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	traefikServiceIDs := make(map[string]string)             // ns/name -> tsID
 	var traefikServiceResources []*unstructured.Unstructured // Store for edge creation
 	if hasTraefikServices && dynamicCache != nil {
-		tsvcs, tsErr := dynamicCache.List(traefikServiceGVR, opts.NamespaceFilter())
+		tsvcs, tsErr := dynamicCache.ListNamespaces(traefikServiceGVR, opts.Namespaces)
 		if tsErr != nil {
 			log.Printf("WARNING [topology] Failed to list Traefik TraefikServices: %v", tsErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list Traefik TraefikServices: %v", tsErr))
@@ -2247,7 +2247,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		if !hasKind || dynamicCache == nil {
 			continue
 		}
-		resources, listErr := dynamicCache.List(gvr, opts.NamespaceFilter())
+		resources, listErr := dynamicCache.ListNamespaces(gvr, opts.Namespaces)
 		if listErr != nil {
 			log.Printf("WARNING [topology] Failed to list Traefik %s: %v", def.kind, listErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list Traefik %s: %v", def.kind, listErr))
@@ -2297,7 +2297,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 			httpProxyGVR, hasHTTPProxy = resourceDiscovery.GetGVR("HTTPProxy")
 		}
 		if hasHTTPProxy && dynamicCache != nil {
-			resources, listErr := dynamicCache.List(httpProxyGVR, opts.NamespaceFilter())
+			resources, listErr := dynamicCache.ListNamespaces(httpProxyGVR, opts.Namespaces)
 			if listErr != nil {
 				log.Printf("WARNING [topology] Failed to list Contour HTTPProxy: %v", listErr)
 				warnings = append(warnings, fmt.Sprintf("Failed to list Contour HTTPProxy: %v", listErr))
@@ -2986,7 +2986,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		gatewayGVR, hasGateways = resourceDiscovery.GetGVR("Gateway")
 	}
 	if hasGateways && dynamicCache != nil {
-		gateways, gwErr := dynamicCache.List(gatewayGVR, opts.NamespaceFilter())
+		gateways, gwErr := dynamicCache.ListNamespaces(gatewayGVR, opts.Namespaces)
 		if gwErr != nil {
 			log.Printf("WARNING [topology] Failed to list Gateways: %v", gwErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list Gateways: %v", gwErr))
@@ -3031,7 +3031,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 
 	// Create GatewayClass → Gateway edges (match via spec.gatewayClassName on Gateway)
 	if hasGateways && dynamicCache != nil {
-		gateways, gwEdgeErr := dynamicCache.List(gatewayGVR, opts.NamespaceFilter())
+		gateways, gwEdgeErr := dynamicCache.ListNamespaces(gatewayGVR, opts.Namespaces)
 		if gwEdgeErr != nil {
 			log.Printf("WARNING [topology] Failed to list Gateways for GatewayClass edges: %v", gwEdgeErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list Gateways for GatewayClass edges: %v", gwEdgeErr))
@@ -3071,7 +3071,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		if !hasRoutes || dynamicCache == nil {
 			continue
 		}
-		routes, routeErr := dynamicCache.List(routeGVR, opts.NamespaceFilter())
+		routes, routeErr := dynamicCache.ListNamespaces(routeGVR, opts.Namespaces)
 		if routeErr != nil {
 			log.Printf("WARNING [topology] Failed to list %s: %v", routeKind, routeErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list %s: %v", routeKind, routeErr))
@@ -3511,7 +3511,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		cnpGVR, hasCNPs = resourceDiscovery.GetGVR("CiliumNetworkPolicy")
 	}
 	if hasCNPs && dynamicCache != nil {
-		cnps, cnpErr := dynamicCache.List(cnpGVR, opts.NamespaceFilter())
+		cnps, cnpErr := dynamicCache.ListNamespaces(cnpGVR, opts.Namespaces)
 		if cnpErr != nil {
 			log.Printf("WARNING [topology] Failed to list CiliumNetworkPolicies: %v", cnpErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list CiliumNetworkPolicies: %v", cnpErr))
@@ -3652,7 +3652,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 		vpaGVR, hasVPAs = resourceDiscovery.GetGVR("VerticalPodAutoscaler")
 	}
 	if hasVPAs && dynamicCache != nil {
-		vpas, vpaErr := dynamicCache.List(vpaGVR, opts.NamespaceFilter())
+		vpas, vpaErr := dynamicCache.ListNamespaces(vpaGVR, opts.Namespaces)
 		if vpaErr != nil {
 			log.Printf("WARNING [topology] Failed to list VerticalPodAutoscalers: %v", vpaErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list VerticalPodAutoscalers: %v", vpaErr))
@@ -5292,7 +5292,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 	var trafficRouteKinds []string
 	if trafficDynamicCache != nil && trafficResourceDiscovery != nil {
 		if gwGVR, ok := trafficResourceDiscovery.GetGVR("Gateway"); ok {
-			gws, err := trafficDynamicCache.List(gwGVR, opts.NamespaceFilter())
+			gws, err := trafficDynamicCache.ListNamespaces(gwGVR, opts.Namespaces)
 			if err != nil {
 				log.Printf("WARNING [topology/traffic] Failed to list Gateways: %v", err)
 				warnings = append(warnings, fmt.Sprintf("Failed to list Gateways: %v", err))
@@ -5302,7 +5302,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 		}
 		for _, routeKind := range []string{"HTTPRoute", "GRPCRoute", "TCPRoute", "TLSRoute"} {
 			if rGVR, ok := trafficResourceDiscovery.GetGVR(routeKind); ok {
-				rts, err := trafficDynamicCache.List(rGVR, opts.NamespaceFilter())
+				rts, err := trafficDynamicCache.ListNamespaces(rGVR, opts.Namespaces)
 				if err != nil {
 					log.Printf("WARNING [topology/traffic] Failed to list %s: %v", routeKind, err)
 					warnings = append(warnings, fmt.Sprintf("Failed to list %s: %v", routeKind, err))
@@ -5321,7 +5321,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 	var trafficIstioGateways []*unstructured.Unstructured
 	if trafficDynamicCache != nil && trafficResourceDiscovery != nil {
 		if vsGVR, ok := trafficResourceDiscovery.GetGVRWithGroup("VirtualService", "networking.istio.io"); ok {
-			vss, err := trafficDynamicCache.List(vsGVR, opts.NamespaceFilter())
+			vss, err := trafficDynamicCache.ListNamespaces(vsGVR, opts.Namespaces)
 			if err != nil {
 				log.Printf("WARNING [topology/traffic] Failed to list Istio VirtualServices: %v", err)
 				warnings = append(warnings, fmt.Sprintf("Failed to list Istio VirtualServices: %v", err))
@@ -5330,7 +5330,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 			}
 		}
 		if igwGVR, ok := trafficResourceDiscovery.GetGVRWithGroup("Gateway", "networking.istio.io"); ok {
-			igws, err := trafficDynamicCache.List(igwGVR, opts.NamespaceFilter())
+			igws, err := trafficDynamicCache.ListNamespaces(igwGVR, opts.Namespaces)
 			if err != nil {
 				log.Printf("WARNING [topology/traffic] Failed to list Istio Gateways: %v", err)
 				warnings = append(warnings, fmt.Sprintf("Failed to list Istio Gateways: %v", err))
@@ -5344,7 +5344,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 	var trafficKnativeServices []*unstructured.Unstructured
 	if trafficDynamicCache != nil && trafficResourceDiscovery != nil {
 		if ksvcGVR, ok := trafficResourceDiscovery.GetGVRWithGroup("Service", "serving.knative.dev"); ok {
-			ksvcs, err := trafficDynamicCache.List(ksvcGVR, opts.NamespaceFilter())
+			ksvcs, err := trafficDynamicCache.ListNamespaces(ksvcGVR, opts.Namespaces)
 			if err != nil {
 				log.Printf("WARNING [topology/traffic] Failed to list KNative Services: %v", err)
 				warnings = append(warnings, fmt.Sprintf("Failed to list KNative Services: %v", err))
@@ -5479,7 +5479,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 	if trafficDynamicCache != nil && trafficResourceDiscovery != nil {
 		for _, routeKind := range []string{"IngressRoute", "IngressRouteTCP", "IngressRouteUDP"} {
 			if gvr, ok := trafficResourceDiscovery.GetGVR(routeKind); ok {
-				rts, err := trafficDynamicCache.List(gvr, opts.NamespaceFilter())
+				rts, err := trafficDynamicCache.ListNamespaces(gvr, opts.Namespaces)
 				if err != nil {
 					log.Printf("WARNING [topology/traffic] Failed to list Traefik %s: %v", routeKind, err)
 					warnings = append(warnings, fmt.Sprintf("Failed to list Traefik %s: %v", routeKind, err))
@@ -5492,7 +5492,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 			}
 		}
 		if tsGVR, ok := trafficResourceDiscovery.GetGVR("TraefikService"); ok {
-			tss, err := trafficDynamicCache.List(tsGVR, opts.NamespaceFilter())
+			tss, err := trafficDynamicCache.ListNamespaces(tsGVR, opts.Namespaces)
 			if err != nil {
 				log.Printf("WARNING [topology/traffic] Failed to list TraefikServices: %v", err)
 				warnings = append(warnings, fmt.Sprintf("Failed to list TraefikServices: %v", err))
@@ -5501,7 +5501,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 			}
 		}
 		if mwGVR, ok := trafficResourceDiscovery.GetGVR("Middleware"); ok {
-			mws, err := trafficDynamicCache.List(mwGVR, opts.NamespaceFilter())
+			mws, err := trafficDynamicCache.ListNamespaces(mwGVR, opts.Namespaces)
 			if err != nil {
 				log.Printf("WARNING [topology/traffic] Failed to list Traefik Middlewares: %v", err)
 				warnings = append(warnings, fmt.Sprintf("Failed to list Traefik Middlewares: %v", err))
@@ -5510,7 +5510,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 			}
 		}
 		if mtGVR, ok := trafficResourceDiscovery.GetGVR("MiddlewareTCP"); ok {
-			mts, err := trafficDynamicCache.List(mtGVR, opts.NamespaceFilter())
+			mts, err := trafficDynamicCache.ListNamespaces(mtGVR, opts.Namespaces)
 			if err != nil {
 				log.Printf("WARNING [topology/traffic] Failed to list Traefik MiddlewareTCPs: %v", err)
 				warnings = append(warnings, fmt.Sprintf("Failed to list Traefik MiddlewareTCPs: %v", err))
@@ -5614,7 +5614,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 	var trafficHTTPProxies []*unstructured.Unstructured
 	if trafficDynamicCache != nil && trafficResourceDiscovery != nil {
 		if gvr, ok := trafficResourceDiscovery.GetGVR("HTTPProxy"); ok {
-			hps, err := trafficDynamicCache.List(gvr, opts.NamespaceFilter())
+			hps, err := trafficDynamicCache.ListNamespaces(gvr, opts.Namespaces)
 			if err != nil {
 				log.Printf("WARNING [topology/traffic] Failed to list Contour HTTPProxy: %v", err)
 				warnings = append(warnings, fmt.Sprintf("Failed to list Contour HTTPProxy: %v", err))
@@ -7737,7 +7737,7 @@ func (b *Builder) addGenericCRDNodes(nodes []Node, edges []Edge, opts BuildOptio
 		}
 		processedKinds[kindLower] = true
 
-		resources, err := dynamicCache.List(gvr, opts.NamespaceFilter())
+		resources, err := dynamicCache.ListNamespaces(gvr, opts.Namespaces)
 		if err != nil {
 			log.Printf("WARNING [topology] Failed to list %s resources for generic CRD support: %v", kind, err)
 			continue

--- a/pkg/topology/managedby_test.go
+++ b/pkg/topology/managedby_test.go
@@ -23,15 +23,21 @@ type stubDP struct {
 func (s *stubDP) List(_ schema.GroupVersionResource, _ string) ([]*unstructured.Unstructured, error) {
 	return nil, nil
 }
+func (s *stubDP) ListNamespaces(_ schema.GroupVersionResource, _ []string) ([]*unstructured.Unstructured, error) {
+	return nil, nil
+}
 func (s *stubDP) Get(_ schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
 	if u, ok := s.obj[namespace+"/"+name]; ok {
 		return u, nil
 	}
 	return nil, nil
 }
-func (s *stubDP) GetWatchedResources() []schema.GroupVersionResource          { return nil }
-func (s *stubDP) GetDiscoveryStatus() k8score.CRDDiscoveryStatus { return k8score.CRDDiscoveryIdle }
-func (s *stubDP) GetGVR(kindOrName string) (schema.GroupVersionResource, bool) { g, ok := s.gvr[kindOrName]; return g, ok }
+func (s *stubDP) GetWatchedResources() []schema.GroupVersionResource { return nil }
+func (s *stubDP) GetDiscoveryStatus() k8score.CRDDiscoveryStatus     { return k8score.CRDDiscoveryIdle }
+func (s *stubDP) GetGVR(kindOrName string) (schema.GroupVersionResource, bool) {
+	g, ok := s.gvr[kindOrName]
+	return g, ok
+}
 func (s *stubDP) GetGVRWithGroup(kindOrName, _ string) (schema.GroupVersionResource, bool) {
 	return s.GetGVR(kindOrName)
 }

--- a/pkg/topology/types.go
+++ b/pkg/topology/types.go
@@ -270,16 +270,6 @@ func (opts BuildOptions) MatchesNamespaceFilter(ns string) bool {
 	return MatchesNamespace(opts.Namespaces, ns)
 }
 
-// NamespaceFilter returns the namespace to use for API queries.
-// If exactly one namespace is filtered, return it (for efficient API filtering).
-// Otherwise return empty string (query all, filter client-side).
-func (opts BuildOptions) NamespaceFilter() string {
-	if len(opts.Namespaces) == 1 {
-		return opts.Namespaces[0]
-	}
-	return ""
-}
-
 // DefaultBuildOptions returns sensible defaults
 func DefaultBuildOptions() BuildOptions {
 	return BuildOptions{
@@ -403,6 +393,11 @@ type ResourceProvider interface {
 // It combines DynamicResourceCache + ResourceDiscovery methods.
 type DynamicProvider interface {
 	List(gvr schema.GroupVersionResource, namespace string) ([]*unstructured.Unstructured, error)
+	// ListNamespaces unions a GVR across an explicit namespace set (or reads
+	// cluster-wide for an empty set / cluster-scoped resource). Topology uses
+	// this instead of List(gvr, "") so namespace-restricted users with several
+	// allowed namespaces still see CRD nodes from all of them.
+	ListNamespaces(gvr schema.GroupVersionResource, namespaces []string) ([]*unstructured.Unstructured, error)
 	Get(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error)
 	GetWatchedResources() []schema.GroupVersionResource
 	GetDiscoveryStatus() k8score.CRDDiscoveryStatus


### PR DESCRIPTION
## Summary

Closes #768. A user who can list a CRD (e.g. Argo `Applications`) only in **specific namespaces** — not cluster-wide — got nothing and a 500. The dynamic CRD cache kept **one informer per GVR**, scoped either cluster-wide or pinned to a single shared fallback namespace; the namespace the request actually asked for never entered the scope decision.

This keys the informer map by `{GVR, namespace}`, so a GVR can have one cluster-wide informer **or** several namespace-scoped ones. `List(gvr, ns)` threads the requested namespace into the access probe: cluster-wide first (one informer serves everything), and on denial it watches that **specific** namespace — the one the restricted user can actually read.

The resources handler already loops per-namespace over the user's `parseNamespacesForUser` set, so the fix flows through without handler changes (the 403 classification from #769 still applies if a probed namespace is genuinely denied).

## Read contract (kept deliberately tight)

Because `pkg/k8score` is a process-global, user-blind cache, the read semantics must be deterministic and must not leak across requests:

- **`List(gvr, "")` is served ONLY by a cluster-wide informer** — it never unions whatever per-namespace informers happen to exist (which would make results depend on incidental cache state).
- **`ListNamespaces(gvr, []string)`** is the explicit multi-namespace union, driven by the caller's known, RBAC-filtered namespace set.
- **`Count`** stays non-warming (never lazily creates informers — `resource_counts` iterates every CRD) and applies the same no-implicit-union rule.
- RBAC/namespace intersection stays entirely in the HTTP/MCP layer; the cache only ever sees explicit namespaces.

## Lifecycle / correctness

- Per-namespace informer factories created lazily; each informer runs under its own cancelable context (`Stop()` cancels all — groundwork for the idle reaper in the follow-up).
- Initial-sync suppression is **per-entry**: a later namespace's initial adds aren't mistaken for live events because an earlier namespace already synced.
- All read/introspection methods (`Get`, `ListBlocking`, `WaitForSync`, `IsSynced`, `WatchedGVRs`, `GetWatchedResources`, `AddGVRChangeHandler`, `DiscoverAllCRDs`, `WarmupParallel`, `Stop`) updated around the `{GVR, namespace}` key.

**Common case unchanged:** in a cluster-wide-RBAC deployment a single cluster-wide informer is created exactly as before, and every read path behaves identically. Only namespace-restricted identities change — and there the specific-namespace path now works.

## Tests

`pkg/k8score`: probe-scope honors a requested namespace when cluster-wide is denied; `List(gvr,"")` does not union per-namespace informers; forced-namespace and per-GVR fallback scope decisions (rewritten for the new model). `go build ./...`, `go test ./internal/server/ ./internal/k8s/ ./pkg/k8score/` all green.

## Follow-ups (not in this PR)

- **Idle reaper + SSE lease** to evict unused per-namespace informers in long-running (hosted) deployments — tracked separately; intentionally deferred until the scope semantics here are settled.
- Migrating other `List(gvr,"")` call sites (dashboard, packages, gitops scan) to `ListNamespaces` for full restricted-mode coverage of those surfaces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a large refactor of shared dynamic cache read/watch semantics and informer lifecycle; mistakes could cause wrong CRD data, duplicate/missed events, or RBAC-sensitive leakage across namespaces if union rules regress.
> 
> **Overview**
> Fixes **#768** by reworking the dynamic CRD cache so a GVR can be watched **cluster-wide or per namespace**, instead of one informer pinned to cluster-wide or a single fallback namespace.
> 
> **`DynamicResourceCache`** now keys informers by `{GVR, namespace}`, uses **`probeScope(gvr, preferredNS)`** so `List`/`Get` can start watches in the namespace the caller actually requested when cluster-wide list is denied, and enforces **never both** cluster-wide and namespace-scoped informers for the same GVR (cluster-wide supersedes). Read semantics are tightened: **`List(gvr, "")`** only uses a cluster-wide informer (no implicit union); **`ListNamespaces`** is the explicit multi-namespace union (with cluster-scoped GVRs short-circuiting to cluster-wide); **`ListWatched`** unions already-watched scopes for internal scanners. GVR change handlers are stored and re-applied on lazily created informers; sync/status APIs span all scopes for a GVR.
> 
> **Call sites:** Crossplane audit and Kyverno PolicyReport indexing switch from `List(gvr, "")` to **`ListWatched`**. Topology CRD listing moves from `List(..., NamespaceFilter())` to **`ListNamespaces(..., opts.Namespaces)`** via an extended **`DynamicProvider`**; **`NamespaceFilter()`** is removed from build options.
> 
> **Tests** in `pkg/k8score` cover requested-namespace probing, no-union empty-namespace reads, `ListWatched` union, cluster-scoped `ListNamespaces`, supersede, late handler registration, and status APIs under namespace-only watches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12ad04edca17ffbbd04ba14e61aef6f2dba24e5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->