### PR TITLE
perf(sse): two-tier cache invalidation to throttle status churn

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -533,10 +533,11 @@ function AppInner() {
   //   FAST (3s): detail drawer for any change (one cheap mounted object), and
   //     on add/delete: the list, counts, and dashboard. GitOps + cert keep
   //     their existing every-batch behavior — Phase 2 makes GitOps relevance-aware.
-  //   SLOW (15s): list + dashboard for kinds that had *update-only* changes.
-  //     Kinds with add/delete are already refreshed by the fast structural pass,
-  //     so the slow tier skips them (no double refetch); dashboard health still
-  //     refreshes on any update.
+  //   SLOW (15s): list + dashboard for kinds with update churn. A kind that also
+  //     had an add/delete in the window gets refreshed by both tiers (an extra
+  //     refetch per 15s at most) — that's fine and avoids a stale-list bug:
+  //     deduping by "was structural this window" would wrongly suppress an
+  //     update that arrived *after* the fast structural flush already ran.
   const fastInvalidationRef = useRef<{
     changedKinds: Set<string>   // every changed kind (any op) → detail drawer
     structuralKinds: Set<string> // add/delete kinds → list membership + counts + dashboard
@@ -545,9 +546,8 @@ function AppInner() {
   }>({ changedKinds: new Set(), structuralKinds: new Set(), secretsChanged: false, timer: null })
   const slowInvalidationRef = useRef<{
     updatedKinds: Set<string>    // update-only churn → throttled list + dashboard
-    structuralKinds: Set<string> // mirror of fast structural, so slow can skip already-refreshed kinds
     timer: number | null
-  }>({ updatedKinds: new Set(), structuralKinds: new Set(), timer: null })
+  }>({ updatedKinds: new Set(), timer: null })
 
   const handleK8sEvent = useCallback((event: K8sEvent) => {
     // Skip K8s Event kind — informational, not resource mutations
@@ -562,8 +562,7 @@ function AppInner() {
     if (kind === 'secrets') fast.secretsChanged = true
 
     const slow = slowInvalidationRef.current
-    if (structural) slow.structuralKinds.add(kind)
-    else slow.updatedKinds.add(kind)
+    if (!structural) slow.updatedKinds.add(kind)
 
     // FAST tier — membership-sensitive + cheap, bounded 3s latency.
     if (fast.timer === null) {
@@ -590,18 +589,16 @@ function AppInner() {
       }, 3000)
     }
 
-    // SLOW tier — throttle the expensive queries for status-only churn.
-    if (slow.timer === null) {
+    // SLOW tier — throttle the expensive queries for status-only churn. Only
+    // updates schedule it; structural changes are fully handled by the fast tier.
+    if (!structural && slow.timer === null) {
       slow.timer = window.setTimeout(() => {
         const s = slowInvalidationRef.current
         for (const k of s.updatedKinds) {
-          if (s.structuralKinds.has(k)) continue // already refreshed by the fast structural pass
           queryClient.invalidateQueries({ queryKey: ['resources', k] })
         }
-        if (s.updatedKinds.size > 0) {
-          queryClient.invalidateQueries({ queryKey: ['dashboard'] }) // health reflects status updates
-        }
-        slowInvalidationRef.current = { updatedKinds: new Set(), structuralKinds: new Set(), timer: null }
+        queryClient.invalidateQueries({ queryKey: ['dashboard'] }) // health reflects status updates
+        slowInvalidationRef.current = { updatedKinds: new Set(), timer: null }
       }, 15000)
     }
   }, [queryClient])
@@ -630,7 +627,7 @@ function AppInner() {
       if (fastInvalidationRef.current.timer !== null) clearTimeout(fastInvalidationRef.current.timer)
       if (slowInvalidationRef.current.timer !== null) clearTimeout(slowInvalidationRef.current.timer)
       fastInvalidationRef.current = { changedKinds: new Set(), structuralKinds: new Set(), secretsChanged: false, timer: null }
-      slowInvalidationRef.current = { updatedKinds: new Set(), structuralKinds: new Set(), timer: null }
+      slowInvalidationRef.current = { updatedKinds: new Set(), timer: null }
 
       // Close any open drawers/overlays — old cluster's resources don't exist on the new one
       setSelectedResource(null)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -523,57 +523,94 @@ function AppInner() {
   // Query client for cache invalidation
   const queryClient = useQueryClient()
 
-  // SSE-driven cache invalidation for resource lists, counts, and detail views.
-  // Uses a 3-second throttle window: first event starts the timer, all events within the
-  // window accumulate, then fire a single batch invalidation. This keeps max latency at 3s
-  // while coalescing burst events (e.g., 100-pod rollout → ~10 invalidations total).
-  const pendingInvalidationRef = useRef<{
-    kinds: Set<string>
-    hasCountChange: boolean
+  // SSE-driven cache invalidation, split into two cadences so constant status
+  // churn on large clusters doesn't force the *expensive* queries (big resource
+  // lists + dashboard) to refetch every 3s. The core distinction: add/delete
+  // changes what rows/counts exist (membership — keep fast); update is mostly
+  // status/restart/health noise that can fire constantly on a 10k-pod cluster
+  // and shouldn't drag a giant list onto a 3s cadence.
+  //
+  //   FAST (3s): detail drawer for any change (one cheap mounted object), and
+  //     on add/delete: the list, counts, and dashboard. GitOps + cert keep
+  //     their existing every-batch behavior — Phase 2 makes GitOps relevance-aware.
+  //   SLOW (15s): list + dashboard for kinds that had *update-only* changes.
+  //     Kinds with add/delete are already refreshed by the fast structural pass,
+  //     so the slow tier skips them (no double refetch); dashboard health still
+  //     refreshes on any update.
+  const fastInvalidationRef = useRef<{
+    changedKinds: Set<string>   // every changed kind (any op) → detail drawer
+    structuralKinds: Set<string> // add/delete kinds → list membership + counts + dashboard
+    secretsChanged: boolean
     timer: number | null
-  }>({ kinds: new Set(), hasCountChange: false, timer: null })
+  }>({ changedKinds: new Set(), structuralKinds: new Set(), secretsChanged: false, timer: null })
+  const slowInvalidationRef = useRef<{
+    updatedKinds: Set<string>    // update-only churn → throttled list + dashboard
+    structuralKinds: Set<string> // mirror of fast structural, so slow can skip already-refreshed kinds
+    timer: number | null
+  }>({ updatedKinds: new Set(), structuralKinds: new Set(), timer: null })
 
   const handleK8sEvent = useCallback((event: K8sEvent) => {
     // Skip K8s Event kind — informational, not resource mutations
     if (event.kind === 'Event') return
 
-    const pending = pendingInvalidationRef.current
-    pending.kinds.add(kindToPlural(event.kind))
-    if (event.operation === 'add' || event.operation === 'delete') {
-      pending.hasCountChange = true
+    const kind = kindToPlural(event.kind)
+    const structural = event.operation === 'add' || event.operation === 'delete'
+
+    const fast = fastInvalidationRef.current
+    fast.changedKinds.add(kind)
+    if (structural) fast.structuralKinds.add(kind)
+    if (kind === 'secrets') fast.secretsChanged = true
+
+    const slow = slowInvalidationRef.current
+    if (structural) slow.structuralKinds.add(kind)
+    else slow.updatedKinds.add(kind)
+
+    // FAST tier — membership-sensitive + cheap, bounded 3s latency.
+    if (fast.timer === null) {
+      fast.timer = window.setTimeout(() => {
+        const f = fastInvalidationRef.current
+        for (const k of f.changedKinds) {
+          queryClient.invalidateQueries({ queryKey: ['resource', k] }) // open detail drawer stays live
+        }
+        for (const k of f.structuralKinds) {
+          queryClient.invalidateQueries({ queryKey: ['resources', k] }) // list membership changed
+        }
+        if (f.structuralKinds.size > 0) {
+          queryClient.invalidateQueries({ queryKey: ['resource-counts'] })
+          queryClient.invalidateQueries({ queryKey: ['dashboard'] })
+        }
+        if (f.secretsChanged) {
+          queryClient.invalidateQueries({ queryKey: ['secret-cert-expiry'] })
+        }
+        // GitOps behavior unchanged from before — refreshes every batch when a
+        // GitOps view is mounted (Phase 2 will make this relevance-aware).
+        queryClient.invalidateQueries({ queryKey: ['gitops-tree'] })
+        queryClient.invalidateQueries({ queryKey: ['gitops-insights'] })
+        fastInvalidationRef.current = { changedKinds: new Set(), structuralKinds: new Set(), secretsChanged: false, timer: null }
+      }, 3000)
     }
 
-    // Start throttle window on first event (don't reset — bounded 3s latency)
-    if (pending.timer !== null) return
-    pending.timer = window.setTimeout(() => {
-      for (const kind of pending.kinds) {
-        // Invalidate list queries (['resources', kind, ...]) and detail queries (['resource', kind, ...])
-        queryClient.invalidateQueries({ queryKey: ['resources', kind] })
-        queryClient.invalidateQueries({ queryKey: ['resource', kind] })
-      }
-      if (pending.hasCountChange) {
-        queryClient.invalidateQueries({ queryKey: ['resource-counts'] })
-      }
-      queryClient.invalidateQueries({ queryKey: ['dashboard'] })
-      if (pending.kinds.has('secrets')) {
-        queryClient.invalidateQueries({ queryKey: ['secret-cert-expiry'] })
-      }
-      // GitOps tree + insights are derived views over the same informer
-      // cache that produced this SSE event — when *anything* changes, the
-      // managed-resource tree and the insights pipeline can have stale
-      // changes/events/drift. Invalidating broadly here is cheap (only the
-      // currently-mounted GitOps view re-fetches; other views have no
-      // matching keys) and is what makes the detail page actually live.
-      // Without this the failure card + topology lag behind the title chips
-      // until window focus or a manual refresh.
-      queryClient.invalidateQueries({ queryKey: ['gitops-tree'] })
-      queryClient.invalidateQueries({ queryKey: ['gitops-insights'] })
-      // Reset accumulator
-      pending.kinds = new Set()
-      pending.hasCountChange = false
-      pending.timer = null
-    }, 3000)
+    // SLOW tier — throttle the expensive queries for status-only churn.
+    if (slow.timer === null) {
+      slow.timer = window.setTimeout(() => {
+        const s = slowInvalidationRef.current
+        for (const k of s.updatedKinds) {
+          if (s.structuralKinds.has(k)) continue // already refreshed by the fast structural pass
+          queryClient.invalidateQueries({ queryKey: ['resources', k] })
+        }
+        if (s.updatedKinds.size > 0) {
+          queryClient.invalidateQueries({ queryKey: ['dashboard'] }) // health reflects status updates
+        }
+        slowInvalidationRef.current = { updatedKinds: new Set(), structuralKinds: new Set(), timer: null }
+      }, 15000)
+    }
   }, [queryClient])
+
+  // Clear pending invalidation timers on unmount.
+  useEffect(() => () => {
+    if (fastInvalidationRef.current.timer !== null) clearTimeout(fastInvalidationRef.current.timer)
+    if (slowInvalidationRef.current.timer !== null) clearTimeout(slowInvalidationRef.current.timer)
+  }, [])
 
   // SSE connection for real-time updates — no namespace filter for small/medium clusters (frontend filters).
   // forceNamespaceFilter is only set for large clusters that require server-side filtering.
@@ -590,10 +627,10 @@ function AppInner() {
       queryClient.invalidateQueries()
 
       // Cancel any pending SSE-driven invalidation — old cluster's events are irrelevant
-      if (pendingInvalidationRef.current.timer !== null) {
-        clearTimeout(pendingInvalidationRef.current.timer)
-        pendingInvalidationRef.current = { kinds: new Set(), hasCountChange: false, timer: null }
-      }
+      if (fastInvalidationRef.current.timer !== null) clearTimeout(fastInvalidationRef.current.timer)
+      if (slowInvalidationRef.current.timer !== null) clearTimeout(slowInvalidationRef.current.timer)
+      fastInvalidationRef.current = { changedKinds: new Set(), structuralKinds: new Set(), secretsChanged: false, timer: null }
+      slowInvalidationRef.current = { updatedKinds: new Set(), structuralKinds: new Set(), timer: null }
 
       // Close any open drawers/overlays — old cluster's resources don't exist on the new one
       setSelectedResource(null)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -603,10 +603,15 @@ function AppInner() {
     }
   }, [queryClient])
 
-  // Clear pending invalidation timers on unmount.
+  // Clear pending invalidation timers on unmount. Reset the refs (not just
+  // clearTimeout) so a same-instance remount doesn't inherit a non-null timer
+  // id — handleK8sEvent only schedules when timer === null, so a stale id would
+  // silently wedge all further SSE-driven invalidation.
   useEffect(() => () => {
     if (fastInvalidationRef.current.timer !== null) clearTimeout(fastInvalidationRef.current.timer)
     if (slowInvalidationRef.current.timer !== null) clearTimeout(slowInvalidationRef.current.timer)
+    fastInvalidationRef.current = { changedKinds: new Set(), structuralKinds: new Set(), secretsChanged: false, timer: null }
+    slowInvalidationRef.current = { updatedKinds: new Set(), timer: null }
   }, [])
 
   // SSE connection for real-time updates — no namespace filter for small/medium clusters (frontend filters).


### PR DESCRIPTION
## Summary

On large clusters, the single 3-second SSE invalidation batch was forcing whichever heavy query is mounted to refetch every 3s — overriding that query's own `staleTime`. On a 10k-pod cluster under churn that meant the **dashboard aggregation** (when on Home) or the **full resource list** (when on Resources) refetched every 3s, even though most SSE events are `update`s (status/restart/health) that don't change list membership at all.

This splits invalidation into two cadences by operation:

- **FAST (3s):** the open detail drawer (any change), and on **add/delete** the resource list, counts, and dashboard (membership/counts actually changed). GitOps + cert-expiry keep their existing every-batch behavior.
- **SLOW (15s):** the resource list + dashboard for kinds with **update** churn. A kind that also had an add/delete in the same window is refreshed by **both** tiers (at most one extra refetch per 15s) — deliberately, since deduping by "was structural this window" would wrongly suppress an update that arrived *after* the fast structural flush already ran. The dashboard refreshes on any update so health stays live within 15s.

Net effect: constant status churn no longer drags the big list or dashboard onto a 3s cadence — they settle to 15s — while membership changes, counts, and the open drawer stay live at 3s. Both timers reset on context switch and on unmount.

## Scope / follow-ups

- **GitOps is deliberately untouched.** It still invalidates every batch when a GitOps view is mounted (unchanged from before). The relevance-aware fix (invalidate only when an SSE event matches a node in the mounted tree — GitOps crosses namespaces, so namespace filtering would miss changes) is a separate follow-up.
- **Surgical `setQueryData`** (delete-only first) to keep big lists live without any refetch is a later optional step if 15s proves insufficient.

## Test plan

- [x] `make tsc` clean
- [ ] On radar-test-prod under churn: confirm via React Query devtools / network panel that the active heavy query drops from ~20 refetches/min (every 3s) to ~4/min (every 15s) when sitting on Home and on Resources/pods, with counts + open drawer still updating promptly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live-update timing for lists and dashboard under SSE churn; structural paths stay at 3s but status-only views may be up to 15s stale.
> 
> **Overview**
> Replaces the single **3s** SSE-driven React Query invalidation batch in `App.tsx` with **two throttled tiers** so high-volume `update` events on large clusters no longer force heavy **resource list** and **dashboard** refetches every few seconds.
> 
> **FAST (3s):** still invalidates open **detail** queries for any changed kind; **list**, **resource-counts**, and **dashboard** only on **add/delete** (membership changes). **Secret cert expiry**, **gitops-tree**, and **gitops-insights** keep the prior every-batch behavior.
> 
> **SLOW (15s):** for **update-only** churn, invalidates **resources** lists for affected kinds and **dashboard** so status/health can lag up to ~15s without resetting list `staleTime` on every pod restart.
> 
> Adds **unmount cleanup** that clears both timers and resets refs (avoids wedging invalidation after remount), and extends **context switch** handling to cancel/reset both tiers alongside the existing full cache clear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12c99030427c5d299644db1fd39054b8c725b5d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->