### PR TITLE
perf(frontend): kill O(n²)/thrash hotspots in traffic, topology, timeline

### DIFF
--- a/packages/k8s-ui/src/components/topology/layout.ts
+++ b/packages/k8s-ui/src/components/topology/layout.ts
@@ -164,20 +164,19 @@ async function runLayoutOnMainThread(
 
   const groupLayouts: LayoutResult['groupLayouts'] = []
   const ungroupedNodes: LayoutResult['ungroupedNodes'] = []
-  const groupNodeIds = new Map<string, Set<string>>()
-
-  // Pre-bucket intra-group edges in a single O(edges) pass — filtering all of
-  // elkGraph.edges inside the per-group loop below is O(groups × edges).
-  const nodeGroupId = new Map<string, string>()
+  // Map each node to its group once. Serves both the intra-group edge bucketing
+  // here (filtering all edges per group would be O(groups × edges)) and the
+  // node→group lookup for Phase 2's inter-group edges below.
+  const nodeToGroup = new Map<string, string>()
   for (const child of elkGraph.children) {
     if (child.id.startsWith('group-') && child.children) {
-      for (const c of child.children) nodeGroupId.set(c.id, child.id)
+      for (const c of child.children) nodeToGroup.set(c.id, child.id)
     }
   }
   const intraEdgesByGroup = new Map<string, ElkEdge[]>()
   for (const e of elkGraph.edges) {
-    const sg = nodeGroupId.get(e.sources[0])
-    if (sg && sg === nodeGroupId.get(e.targets[0])) {
+    const sg = nodeToGroup.get(e.sources[0])
+    if (sg && sg === nodeToGroup.get(e.targets[0])) {
       const arr = intraEdgesByGroup.get(sg)
       if (arr) arr.push(e)
       else intraEdgesByGroup.set(sg, [e])
@@ -191,8 +190,6 @@ async function runLayoutOnMainThread(
     if (isGroup && child.children && child.children.length > 0) {
       const groupKey = child.id.replace(`group-${groupingMode}-`, '')
       const minWidth = hideGroupHeader ? 300 : Math.max(500, groupKey.length * 16 + 200)
-      const nodeIds = new Set(child.children.map(c => c.id))
-      groupNodeIds.set(child.id, nodeIds)
 
       const intraGroupEdges = intraEdgesByGroup.get(child.id) ?? []
 
@@ -233,11 +230,7 @@ async function runLayoutOnMainThread(
   }
 
   // Phase 2: Build meta-graph and position groups based on inter-group edges
-  const nodeToGroup = new Map<string, string>()
-  for (const [groupId, nodeIds] of groupNodeIds) {
-    for (const nodeId of nodeIds) nodeToGroup.set(nodeId, groupId)
-  }
-
+  // (nodeToGroup was built once above).
   const interGroupEdges: ElkEdge[] = []
   const seen = new Set<string>()
   for (const edge of elkGraph.edges) {

--- a/packages/k8s-ui/src/components/topology/layout.ts
+++ b/packages/k8s-ui/src/components/topology/layout.ts
@@ -166,6 +166,24 @@ async function runLayoutOnMainThread(
   const ungroupedNodes: LayoutResult['ungroupedNodes'] = []
   const groupNodeIds = new Map<string, Set<string>>()
 
+  // Pre-bucket intra-group edges in a single O(edges) pass — filtering all of
+  // elkGraph.edges inside the per-group loop below is O(groups × edges).
+  const nodeGroupId = new Map<string, string>()
+  for (const child of elkGraph.children) {
+    if (child.id.startsWith('group-') && child.children) {
+      for (const c of child.children) nodeGroupId.set(c.id, child.id)
+    }
+  }
+  const intraEdgesByGroup = new Map<string, ElkEdge[]>()
+  for (const e of elkGraph.edges) {
+    const sg = nodeGroupId.get(e.sources[0])
+    if (sg && sg === nodeGroupId.get(e.targets[0])) {
+      const arr = intraEdgesByGroup.get(sg)
+      if (arr) arr.push(e)
+      else intraEdgesByGroup.set(sg, [e])
+    }
+  }
+
   // Phase 1: Layout each group independently
   for (const child of elkGraph.children) {
     const isGroup = child.id.startsWith('group-')
@@ -176,9 +194,7 @@ async function runLayoutOnMainThread(
       const nodeIds = new Set(child.children.map(c => c.id))
       groupNodeIds.set(child.id, nodeIds)
 
-      const intraGroupEdges = elkGraph.edges.filter(e =>
-        nodeIds.has(e.sources[0]) && nodeIds.has(e.targets[0])
-      )
+      const intraGroupEdges = intraEdgesByGroup.get(child.id) ?? []
 
       const layoutResult = await elk.layout({
         id: child.id,

--- a/packages/k8s-ui/src/components/topology/layout.worker.ts
+++ b/packages/k8s-ui/src/components/topology/layout.worker.ts
@@ -116,22 +116,20 @@ self.onmessage = async (e: MessageEvent<LayoutRequest>) => {
     const groupLayouts: GroupLayoutResult[] = []
     const ungroupedNodes: UngroupedNodeResult[] = []
 
-    // Build a set of node IDs in each group for edge filtering
-    const groupNodeIds = new Map<string, Set<string>>()
-
-    // Pre-bucket intra-group edges in a single O(edges) pass — filtering all of
-    // elkGraph.edges inside the per-group loop below is O(groups × edges). This
-    // is the default (worker) layout path, so the win actually lands here.
-    const nodeGroupId = new Map<string, string>()
+    // Map each node to its group once. Serves both the intra-group edge
+    // bucketing here (filtering all edges per group would be O(groups × edges))
+    // and the node→group lookup for Phase 2's inter-group edges. This is the
+    // default (worker) layout path, so the win actually lands here.
+    const nodeToGroup = new Map<string, string>()
     for (const child of elkGraph.children) {
       if (child.id.startsWith('group-') && child.children) {
-        for (const c of child.children) nodeGroupId.set(c.id, child.id)
+        for (const c of child.children) nodeToGroup.set(c.id, child.id)
       }
     }
     const intraEdgesByGroup = new Map<string, ElkEdge[]>()
     for (const e of elkGraph.edges) {
-      const sg = nodeGroupId.get(e.sources[0])
-      if (sg && sg === nodeGroupId.get(e.targets[0])) {
+      const sg = nodeToGroup.get(e.sources[0])
+      if (sg && sg === nodeToGroup.get(e.targets[0])) {
         const arr = intraEdgesByGroup.get(sg)
         if (arr) arr.push(e)
         else intraEdgesByGroup.set(sg, [e])
@@ -145,10 +143,6 @@ self.onmessage = async (e: MessageEvent<LayoutRequest>) => {
       if (isGroup && child.children && child.children.length > 0) {
         const groupKey = child.id.replace(`group-${groupingMode}-`, '')
         const minWidth = hideGroupHeader ? 300 : Math.max(500, groupKey.length * 16 + 200)
-
-        // Track node IDs in this group
-        const nodeIds = new Set(child.children.map(c => c.id))
-        groupNodeIds.set(child.id, nodeIds)
 
         // Layout this group independently with only intra-group edges
         const intraGroupEdges = intraEdgesByGroup.get(child.id) ?? []
@@ -203,14 +197,7 @@ self.onmessage = async (e: MessageEvent<LayoutRequest>) => {
       }
     }
 
-    // Phase 2: Build meta-graph and position groups
-    const nodeToGroup = new Map<string, string>()
-    for (const [groupId, nodeIds] of groupNodeIds) {
-      for (const nodeId of nodeIds) {
-        nodeToGroup.set(nodeId, groupId)
-      }
-    }
-
+    // Phase 2: Build meta-graph and position groups (nodeToGroup built once above).
     // Find inter-group edges
     const interGroupEdges: ElkEdge[] = []
     const seenInterGroupEdges = new Set<string>()

--- a/packages/k8s-ui/src/components/topology/layout.worker.ts
+++ b/packages/k8s-ui/src/components/topology/layout.worker.ts
@@ -119,6 +119,25 @@ self.onmessage = async (e: MessageEvent<LayoutRequest>) => {
     // Build a set of node IDs in each group for edge filtering
     const groupNodeIds = new Map<string, Set<string>>()
 
+    // Pre-bucket intra-group edges in a single O(edges) pass — filtering all of
+    // elkGraph.edges inside the per-group loop below is O(groups × edges). This
+    // is the default (worker) layout path, so the win actually lands here.
+    const nodeGroupId = new Map<string, string>()
+    for (const child of elkGraph.children) {
+      if (child.id.startsWith('group-') && child.children) {
+        for (const c of child.children) nodeGroupId.set(c.id, child.id)
+      }
+    }
+    const intraEdgesByGroup = new Map<string, ElkEdge[]>()
+    for (const e of elkGraph.edges) {
+      const sg = nodeGroupId.get(e.sources[0])
+      if (sg && sg === nodeGroupId.get(e.targets[0])) {
+        const arr = intraEdgesByGroup.get(sg)
+        if (arr) arr.push(e)
+        else intraEdgesByGroup.set(sg, [e])
+      }
+    }
+
     // Phase 1: Layout each group independently
     for (const child of elkGraph.children) {
       const isGroup = child.id.startsWith('group-')
@@ -132,9 +151,7 @@ self.onmessage = async (e: MessageEvent<LayoutRequest>) => {
         groupNodeIds.set(child.id, nodeIds)
 
         // Layout this group independently with only intra-group edges
-        const intraGroupEdges = elkGraph.edges.filter(e =>
-          nodeIds.has(e.sources[0]) && nodeIds.has(e.targets[0])
-        )
+        const intraGroupEdges = intraEdgesByGroup.get(child.id) ?? []
 
         const groupGraph: ElkGraph = {
           id: child.id,

--- a/packages/k8s-ui/src/utils/resource-hierarchy.ts
+++ b/packages/k8s-ui/src/utils/resource-hierarchy.ts
@@ -559,13 +559,23 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
           TraefikService: 2, Middleware: 3, MiddlewareTCP: 3,
           HTTPProxy: 1, // Contour
         }
+        // Precompute each child's latest event time once — otherwise the
+        // comparator below reparses every child's event timestamps on every
+        // comparison (O(children log children × events) Date parses).
+        const latestByChildId = new Map<string, number>()
+        for (const c of lane.children) {
+          let latest = 0
+          for (const e of c.events) {
+            const t = new Date(e.timestamp).getTime()
+            if (t > latest) latest = t
+          }
+          latestByChildId.set(c.id, latest)
+        }
         lane.children.sort((a, b) => {
           const aPriority = kindPriority[a.kind] || 10
           const bPriority = kindPriority[b.kind] || 10
           if (aPriority !== bPriority) return aPriority - bPriority
-          const aLatest = a.events.length > 0 ? Math.max(...a.events.map(e => new Date(e.timestamp).getTime())) : 0
-          const bLatest = b.events.length > 0 ? Math.max(...b.events.map(e => new Date(e.timestamp).getTime())) : 0
-          return bLatest - aLatest
+          return (latestByChildId.get(b.id) ?? 0) - (latestByChildId.get(a.id) ?? 0)
         })
       }
 

--- a/web/src/components/traffic/TrafficFlowList.tsx
+++ b/web/src/components/traffic/TrafficFlowList.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react'
+import { Virtuoso } from 'react-virtuoso'
 import type { TrafficFlow } from '../../types'
 import { clsx } from 'clsx'
 import { ChevronDown, ChevronUp, ShieldCheck } from 'lucide-react'
@@ -141,14 +142,18 @@ export function TrafficFlowList({ flows }: TrafficFlowListProps) {
         <span className="text-right">Verdict</span>
       </div>
 
-      {/* Flow rows */}
-      <div className="flex-1 overflow-y-auto">
-        {sorted.length === 0 ? (
-          <div className="flex items-center justify-center h-32 text-sm text-theme-text-tertiary">
-            {search ? 'No flows match the search' : 'No flows to display'}
-          </div>
-        ) : (
-          sorted.map((flow, i) => {
+      {/* Flow rows — virtualized so tens of thousands of Hubble/Cilium flows
+          don't all become DOM. Virtuoso measures variable row heights, so the
+          expand/collapse panel still works. */}
+      {sorted.length === 0 ? (
+        <div className="flex-1 flex items-center justify-center text-sm text-theme-text-tertiary">
+          {search ? 'No flows match the search' : 'No flows to display'}
+        </div>
+      ) : (
+        <Virtuoso
+          className="flex-1"
+          data={sorted}
+          itemContent={(i, flow) => {
             const isExpanded = expandedIdx === i
             const isHTTP = flow.l7Protocol === 'HTTP'
             const isDNS = flow.l7Protocol === 'DNS'
@@ -316,9 +321,9 @@ export function TrafficFlowList({ flows }: TrafficFlowListProps) {
                 )}
               </div>
             )
-          })
-        )}
-      </div>
+          }}
+        />
+      )}
 
       {/* Footer */}
       <div className="px-3 py-1.5 border-t border-theme-border text-[10px] text-theme-text-tertiary">

--- a/web/src/components/traffic/TrafficGraph.tsx
+++ b/web/src/components/traffic/TrafficGraph.tsx
@@ -1264,9 +1264,13 @@ export function TrafficGraph({ flows, hotPathThreshold = 0, showNamespaceGroups 
     try {
       const layoutResult = await elk.layout(elkGraph)
 
+      // Index ELK's positioned children by id once — a .find() per node here is
+      // O(nodes²) and bites on dense traffic graphs.
+      const elkPositions = new Map((layoutResult.children ?? []).map(n => [n.id, n]))
+
       // Apply positions from ELK to nodes
       let positionedNodes = rawNodes.map(node => {
-        const elkNode = layoutResult.children?.find(n => n.id === node.id)
+        const elkNode = elkPositions.get(node.id)
         return {
           ...node,
           position: {


### PR DESCRIPTION
## Summary

A focused pass over avoidable algorithmic waste in the frontend views the topology PRs (#762, #771) didn't touch — Traffic, Timeline, and shared topology layout. These are "remove obvious waste," not the rendering-ceiling fix; each is small and low-risk.

- **TrafficGraph — O(nodes²) → Map.** After ELK layout it did `layoutResult.children?.find(n => n.id === node.id)` for every node inside `rawNodes.map(...)`. Replaced with a `Map<id, elkNode>` built once.
- **TrafficFlowList — virtualized.** It rendered every sorted/filtered flow as a DOM row; with high Hubble/Cilium volume that's a straightforward tab killer. Now wrapped in `react-virtuoso` (variable-height rows, so expand/collapse still works).
- **Topology layout — O(groups × edges) → O(edges).** `applyHierarchicalLayout` filtered all of `elkGraph.edges` inside the per-group loop. Pre-bucketed intra-group edges in a single pass.
- **resource-hierarchy (timeline) — comparator no longer reparses timestamps.** The child-lane sort recomputed `Math.max(...events.map(new Date().getTime()))` for both operands on every comparison. Precompute each child's latest event time once, then compare.

**Deliberately skipped:** the topology click/selection `.find()` lookups (`handleNodeClick`, `handleCardClick`, `expandPodGroup`). They're single-shot O(N) per user click — not per-render or in a loop — so indexing them would add sync'd-map complexity for sub-millisecond, imperceptible gain.

## Test plan

- [x] `make tsc` clean
- [x] k8s-ui unit suite: 400/400 pass
- [x] Smoke: Traffic view (graph + flow list) and a Timeline swimlane render correctly with the new code paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure rendering/layout performance refactors in UI code paths; no auth, data persistence, or API contract changes.
> 
> **Overview**
> This PR removes avoidable algorithmic and DOM cost in **Traffic**, **Timeline**, and shared **topology layout** without changing user-visible behavior.
> 
> **Topology layout** (`layout.ts`, `layout.worker.ts`): Intra-group ELK edges are **pre-bucketed in one pass** over the graph instead of filtering the full edge list inside each group loop. A single **`nodeToGroup`** map is built up front and reused for Phase 2 inter-group edge wiring.
> 
> **Traffic flow list**: The sorted flow table is **virtualized with `react-virtuoso`**, so large Hubble/Cilium volumes no longer mount every row in the DOM; variable row heights preserve expand/collapse details.
> 
> **Traffic graph**: After ELK layout, node positions are applied via a **one-time `Map` by id** instead of **`find` per node**, avoiding quadratic work on dense graphs.
> 
> **Timeline hierarchy**: Child lane ordering **precomputes each child’s latest event timestamp once** before sort, instead of reparsing dates on every comparator call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d022e0f6dcc5ef86d078199cacd153dd7d88d7d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->