### PR TITLE
Optional paginated initial LIST for large clusters (--list-page-size)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ radar
 | `--disable-helm-write` | `false` | Disable Helm write operations |
 | `--disable-local-terminal` | `false` | Disable local terminal feature |
 | `--debug-image` | `busybox:latest` | Image for ephemeral debug containers and node debug pods. Point at a mirror for air-gapped / private-registry clusters. |
+| `--list-page-size` | `0` (off) | Paginate the initial LIST of high-cardinality kinds (Pods, ReplicaSets) at this size. Helps very large clusters that fail to sync; only used when WatchList streaming is unavailable. Try `2000`. |
 | `--prometheus-url` | (auto-discover) | Manual Prometheus/VictoriaMetrics URL (skips auto-discovery) |
 | `--prometheus-header` | | HTTP header sent with every Prometheus request, format `Key=Value` (repeatable). Required for auth-protected backends. |
 | `--auth-mode` | `none` | Authentication mode: `none`, `proxy`, or `oidc` ([details](docs/authentication.md)) |

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -59,6 +59,7 @@ func main() {
 	disableLocalTerminal := flag.Bool("disable-local-terminal", false, "Disable local terminal feature")
 	podShellDefault := flag.String("pod-shell-default", "", "Override the default pod exec shell command (runs as 'sh -c <value>'; empty = built-in bash -il → ash → sh cascade)")
 	debugImage := flag.String("debug-image", fileCfg.DebugImage, "Image for ephemeral debug containers and node debug pods (empty = busybox:latest; point at a mirror for air-gapped/private-registry clusters)")
+	listPageSize := flag.Int64("list-page-size", 0, "Paginate the initial LIST of high-cardinality kinds (Pods, ReplicaSets) at this page size on clusters without WatchList streaming. 0 = off (single LIST). Try 2000 if a very large cluster fails to sync.")
 	// Timeline storage options
 	timelineStorage := flag.String("timeline-storage", fileCfg.TimelineStorageOr("memory"), "Timeline storage backend: memory or sqlite")
 	timelineDBPath := flag.String("timeline-db", fileCfg.TimelineDBPath, "Path to timeline database file (default: ~/.radar/timeline.db)")
@@ -167,6 +168,7 @@ func main() {
 		DisableLocalTerminal: *disableLocalTerminal,
 		PodShellDefault:      *podShellDefault,
 		DebugImage:           *debugImage,
+		ListPageSize:         *listPageSize,
 		TimelineStorage:      *timelineStorage,
 		TimelineDBPath:       *timelineDBPath,
 		TimelineRetention:    *timelineRetention,

--- a/deploy/helm/radar/README.md
+++ b/deploy/helm/radar/README.md
@@ -87,6 +87,7 @@ touches its contents.
 | `service.type` | Service type | `ClusterIP` |
 | `service.port` | Service port | `9280` |
 | `debug.image` | Image for ephemeral debug containers and node debug pods (point at a mirror for air-gapped / private-registry clusters) | `""` (busybox:latest) |
+| `listPageSize` | Paginate the initial LIST of high-cardinality kinds (Pods, ReplicaSets) on very large clusters; `0` = off, try `2000`. Only used when the apiserver lacks WatchList streaming. | `0` |
 | `ingress.enabled` | Enable ingress | `false` |
 | `ingress.className` | Ingress class name | `""` |
 | `timeline.storage` | Timeline storage (memory/sqlite) | `memory` |

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -64,6 +64,9 @@ spec:
             {{- if .Values.debug.image }}
             - --debug-image={{ .Values.debug.image }}
             {{- end }}
+            {{- if .Values.listPageSize }}
+            - --list-page-size={{ .Values.listPageSize }}
+            {{- end }}
             {{- if ne .Values.auth.mode "none" }}
             - --auth-mode={{ .Values.auth.mode }}
             - --auth-cookie-ttl={{ .Values.auth.cookieTTL }}

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -29,6 +29,14 @@ fullnameOverride: ""
 debug:
   image: ""
 
+# Initial-sync tuning for very large clusters. When > 0, the initial LIST of
+# high-cardinality kinds (Pods, ReplicaSets) is fetched in pages of this size
+# instead of one response — avoids response-read timeouts / memory spikes during
+# startup on clusters with tens of thousands of objects. Only takes effect when
+# the apiserver lacks WatchList streaming (otherwise the initial state streams).
+# 0 = off (single LIST). Try 2000 if a large cluster fails to sync.
+listPageSize: 0
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -297,6 +297,7 @@ See [Helm Chart README](../deploy/helm/radar/README.md) for all available values
 | `service.port` | Service port | `9280` |
 | `mcp.enabled` | Enable MCP server for AI tools | `true` |
 | `debug.image` | Image for ephemeral debug containers and node debug pods (point at a mirror for air-gapped / private-registry clusters) | `""` (busybox:latest) |
+| `listPageSize` | Paginate the initial LIST of high-cardinality kinds (Pods, ReplicaSets) on very large clusters that fail to sync; `0` = off, try `2000`. Only used when the apiserver lacks WatchList streaming. | `0` |
 | `timeline.storage` | Event storage (memory/sqlite) | `memory` |
 | `timeline.dbPath` | SQLite database path | `/data/timeline.db` |
 | `timeline.historyLimit` | Max events to retain (memory only) | `10000` |

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -40,6 +40,7 @@ type AppConfig struct {
 	DisableLocalTerminal bool
 	PodShellDefault      string
 	DebugImage           string
+	ListPageSize         int64
 	TimelineStorage      string
 	TimelineDBPath       string
 	TimelineRetention    time.Duration
@@ -58,6 +59,7 @@ func SetGlobals(cfg AppConfig) {
 	k8s.ForceDisableHelmWrite = cfg.DisableHelmWrite
 	k8s.ForceDisableExec = cfg.DisableExec
 	k8s.ForceDisableLocalTerminal = cfg.DisableLocalTerminal
+	k8s.ListPageSize = cfg.ListPageSize
 	server.DefaultPodShellCommand = cfg.PodShellDefault
 	versionpkg.SetCurrent(cfg.Version)
 }

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -28,6 +28,12 @@ import (
 // DebugEvents enables verbose event debugging when true (set via --debug-events flag)
 var DebugEvents bool
 
+// ListPageSize, when > 0, makes high-cardinality informers (Pods, ReplicaSets)
+// paginate their initial LIST instead of pulling it in one response (set via
+// --list-page-size flag). Opt-in hardening for very large clusters where
+// WatchList streaming isn't available; 0 keeps the standard behavior.
+var ListPageSize int64
+
 // TimingLogs enables [startup-timing] log lines when true (set via --dev flag).
 // These are useful for profiling startup but too noisy for production.
 var TimingLogs bool
@@ -156,6 +162,7 @@ func InitResourceCache(ctx context.Context) error {
 			SyncTimeout:         firstPaintBackstop,
 			SyncProgress:        emitSyncProgress,
 			DeferredSyncTimeout: 3 * time.Minute,
+			ListPageSize:        ListPageSize,
 
 			OnReceived: func(kind string) {
 				timeline.IncrementReceived(kind)

--- a/pkg/k8score/cache.go
+++ b/pkg/k8score/cache.go
@@ -1,6 +1,7 @@
 package k8score
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"maps"
@@ -12,9 +13,15 @@ import (
 	"sync/atomic"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/pager"
 )
 
 // ResourceCache provides fast, eventually-consistent access to K8s resources
@@ -24,6 +31,7 @@ type ResourceCache struct {
 	factory          informers.SharedInformerFactory            // cluster-wide factory (always present)
 	nsFactories      map[string]informers.SharedInformerFactory // per-namespace factories (for mixed-scope mode)
 	factoryByKind    map[string]informers.SharedInformerFactory // resolved factory per enabled kind — listers MUST go through this
+	pagedInformers   map[string]cache.SharedIndexInformer       // per-kind paginating informers (ListPageSize>0); listers read these instead of the factory's
 	changes          chan ResourceChange
 	stopCh           chan struct{}
 	stopOnce         sync.Once
@@ -87,6 +95,43 @@ type informerSetup struct {
 	setup           func(factory informers.SharedInformerFactory) cache.SharedIndexInformer
 	isEvent         bool
 	isClusterScoped bool // true for nodes, namespaces, PV, storageclasses, ingressclasses
+	// pagedSetup, when non-nil and CacheConfig.ListPageSize > 0, builds a
+	// paginating informer for this kind instead of the factory one. Set only
+	// for high-cardinality kinds whose single-shot initial LIST can fail on
+	// very large clusters.
+	pagedSetup func(client kubernetes.Interface, namespace string, pageSize int64) cache.SharedIndexInformer
+}
+
+// newPagedInformer builds a SharedIndexInformer whose initial LIST is fetched in
+// pages via a consistent (resourceVersion="") read rather than one unpaginated
+// response. The watch is unchanged. On clusters without WatchList streaming, a
+// single giant LIST of a high-cardinality kind can exceed the response-read
+// deadline or spike memory; paging bounds each request. When WatchList IS
+// available, client-go streams the initial state and never calls this ListFunc.
+func newPagedInformer(
+	example apiruntime.Object,
+	pageSize int64,
+	listFn pager.ListPageFunc,
+	watchFn func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error),
+) cache.SharedIndexInformer {
+	lw := &cache.ListWatch{
+		ListWithContextFunc: func(ctx context.Context, _ metav1.ListOptions) (apiruntime.Object, error) {
+			p := pager.New(listFn)
+			p.PageSize = pageSize
+			// resourceVersion="" forces a consistent read the apiserver will
+			// paginate — RV=0 (watch-cache) reads ignore limit. We deliberately
+			// override the reflector's default RV here.
+			obj, _, err := p.List(ctx, metav1.ListOptions{ResourceVersion: ""})
+			return obj, err
+		},
+		WatchFuncWithContext: watchFn,
+	}
+	inf := cache.NewSharedIndexInformer(lw, example, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	// Factory informers get DropManagedFields via WithTransform; these are built
+	// outside the factory, so apply the same transform directly. SetTransform
+	// only errors once started, which hasn't happened yet.
+	_ = inf.SetTransform(DropManagedFields)
+	return inf
 }
 
 // NewResourceCache creates and starts a ResourceCache from the given config.
@@ -232,6 +277,7 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 		factory:          clusterFactory,
 		nsFactories:      nsFactories,
 		factoryByKind:    map[string]informers.SharedInformerFactory{},
+		pagedInformers:   map[string]cache.SharedIndexInformer{},
 		changes:          changes,
 		stopCh:           stopCh,
 		enabledResources: enabled,
@@ -257,7 +303,18 @@ func NewResourceCache(cfg CacheConfig) (*ResourceCache, error) {
 		enabledCount++
 		factory := pickFactory(s)
 		rc.factoryByKind[s.key] = factory
-		inf := s.setup(factory)
+
+		var inf cache.SharedIndexInformer
+		if cfg.ListPageSize > 0 && s.pagedSetup != nil {
+			// scopes[s.key].Namespace is "" for cluster-wide access or the
+			// single namespace a restricted user is scoped to.
+			inf = s.pagedSetup(cfg.Client, scopes[s.key].Namespace, cfg.ListPageSize)
+			// Listers must read this informer's store, not the factory's
+			// (the factory's informer for this kind is never started).
+			rc.pagedInformers[s.key] = inf
+		} else {
+			inf = s.setup(factory)
+		}
 
 		var err error
 		if s.isEvent {
@@ -777,12 +834,26 @@ func buildInformerSetups() []informerSetup {
 	mk := func(key, kind string, isEvent, clusterScoped bool, fn func(f informers.SharedInformerFactory) cache.SharedIndexInformer) entry {
 		return entry{key: key, kind: kind, setup: fn, isEvent: isEvent, isClusterScoped: clusterScoped}
 	}
+	// withPaging marks a high-cardinality kind as paginatable: when
+	// CacheConfig.ListPageSize > 0, its initial LIST is fetched in pages.
+	withPaging := func(e entry, paged func(client kubernetes.Interface, namespace string, pageSize int64) cache.SharedIndexInformer) entry {
+		e.pagedSetup = paged
+		return e
+	}
 	return []informerSetup{
 		mk(Services, "Service", false, false, func(f informers.SharedInformerFactory) cache.SharedIndexInformer {
 			return f.Core().V1().Services().Informer()
 		}),
-		mk(Pods, "Pod", false, false, func(f informers.SharedInformerFactory) cache.SharedIndexInformer {
+		withPaging(mk(Pods, "Pod", false, false, func(f informers.SharedInformerFactory) cache.SharedIndexInformer {
 			return f.Core().V1().Pods().Informer()
+		}), func(client kubernetes.Interface, ns string, pageSize int64) cache.SharedIndexInformer {
+			return newPagedInformer(&corev1.Pod{}, pageSize,
+				func(ctx context.Context, o metav1.ListOptions) (apiruntime.Object, error) {
+					return client.CoreV1().Pods(ns).List(ctx, o)
+				},
+				func(ctx context.Context, o metav1.ListOptions) (watch.Interface, error) {
+					return client.CoreV1().Pods(ns).Watch(ctx, o)
+				})
 		}),
 		mk(Nodes, "Node", false, true, func(f informers.SharedInformerFactory) cache.SharedIndexInformer {
 			return f.Core().V1().Nodes().Informer()
@@ -814,8 +885,16 @@ func buildInformerSetups() []informerSetup {
 		mk(StatefulSets, "StatefulSet", false, false, func(f informers.SharedInformerFactory) cache.SharedIndexInformer {
 			return f.Apps().V1().StatefulSets().Informer()
 		}),
-		mk(ReplicaSets, "ReplicaSet", false, false, func(f informers.SharedInformerFactory) cache.SharedIndexInformer {
+		withPaging(mk(ReplicaSets, "ReplicaSet", false, false, func(f informers.SharedInformerFactory) cache.SharedIndexInformer {
 			return f.Apps().V1().ReplicaSets().Informer()
+		}), func(client kubernetes.Interface, ns string, pageSize int64) cache.SharedIndexInformer {
+			return newPagedInformer(&appsv1.ReplicaSet{}, pageSize,
+				func(ctx context.Context, o metav1.ListOptions) (apiruntime.Object, error) {
+					return client.AppsV1().ReplicaSets(ns).List(ctx, o)
+				},
+				func(ctx context.Context, o metav1.ListOptions) (watch.Interface, error) {
+					return client.AppsV1().ReplicaSets(ns).Watch(ctx, o)
+				})
 		}),
 		mk(Ingresses, "Ingress", false, false, func(f informers.SharedInformerFactory) cache.SharedIndexInformer {
 			return f.Networking().V1().Ingresses().Informer()

--- a/pkg/k8score/cache_paged_test.go
+++ b/pkg/k8score/cache_paged_test.go
@@ -1,0 +1,111 @@
+package k8score
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
+	"k8s.io/client-go/tools/cache"
+)
+
+// fakePagedPods serves `total` pods through the limit/continue protocol so we
+// can exercise newPagedInformer's pager without a real apiserver (the fake
+// clientset ignores Limit/Continue). The continue token is just the next
+// offset encoded as a string.
+func fakePagedPods(total int, calls *int32) func(ctx context.Context, opts metav1.ListOptions) (apiruntime.Object, error) {
+	return func(_ context.Context, opts metav1.ListOptions) (apiruntime.Object, error) {
+		atomic.AddInt32(calls, 1)
+		start := 0
+		if opts.Continue != "" {
+			// token is "<offset>"
+			for _, c := range opts.Continue {
+				start = start*10 + int(c-'0')
+			}
+		}
+		end := total
+		if opts.Limit > 0 && start+int(opts.Limit) < end {
+			end = start + int(opts.Limit)
+		}
+		list := &corev1.PodList{ListMeta: metav1.ListMeta{ResourceVersion: "1"}}
+		for i := start; i < end; i++ {
+			list.Items = append(list.Items, corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-" + itoa(i), Namespace: "default", ResourceVersion: "1"},
+			})
+		}
+		if end < total { // more remain → hand back a continue token
+			list.Continue = itoa(end)
+		}
+		return list, nil
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+func TestNewPagedInformer_AssemblesAllPages(t *testing.T) {
+	// Pagination is the LIST-fallback path: it only runs when WatchList
+	// streaming is unavailable. With WatchListClient on (the client-go
+	// default), the reflector would stream and bypass our ListFunc entirely.
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, false)
+
+	const pageSize = 5
+	cases := []struct {
+		name          string
+		total         int
+		wantMultiPage bool
+	}{
+		{"empty", 0, false},
+		{"under one page", 3, false},
+		{"exactly one page", pageSize, false},
+		{"one over a page", pageSize + 1, true},
+		{"several pages", pageSize*2 + 2, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls int32
+			fw := watch.NewFake()
+			inf := newPagedInformer(&corev1.Pod{}, pageSize,
+				fakePagedPods(tc.total, &calls),
+				func(_ context.Context, _ metav1.ListOptions) (watch.Interface, error) { return fw, nil },
+			)
+
+			stop := make(chan struct{})
+			defer close(stop)
+			go inf.Run(stop)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if !cache.WaitForCacheSync(ctx.Done(), inf.HasSynced) {
+				t.Fatal("informer did not sync")
+			}
+
+			if got := len(inf.GetStore().ListKeys()); got != tc.total {
+				t.Errorf("store has %d pods, want %d (pagination dropped or duplicated items)", got, tc.total)
+			}
+			gotCalls := atomic.LoadInt32(&calls)
+			if tc.wantMultiPage && gotCalls < 2 {
+				t.Errorf("expected pagination (>=2 list calls) for %d items at pageSize %d, got %d", tc.total, pageSize, gotCalls)
+			}
+			if gotCalls < 1 {
+				t.Errorf("expected at least one list call, got %d", gotCalls)
+			}
+		})
+	}
+}

--- a/pkg/k8score/listers.go
+++ b/pkg/k8score/listers.go
@@ -36,6 +36,9 @@ func (rc *ResourceCache) Pods() listerscorev1.PodLister {
 	if rc == nil || !rc.isEnabled(Pods) {
 		return nil
 	}
+	if inf := rc.pagedInformers[Pods]; inf != nil {
+		return listerscorev1.NewPodLister(inf.GetIndexer())
+	}
 	return rc.factoryFor(Pods).Core().V1().Pods().Lister()
 }
 
@@ -112,6 +115,9 @@ func (rc *ResourceCache) StatefulSets() listersappsv1.StatefulSetLister {
 func (rc *ResourceCache) ReplicaSets() listersappsv1.ReplicaSetLister {
 	if rc == nil || !rc.isEnabled(ReplicaSets) {
 		return nil
+	}
+	if inf := rc.pagedInformers[ReplicaSets]; inf != nil {
+		return listersappsv1.NewReplicaSetLister(inf.GetIndexer())
 	}
 	return rc.factoryFor(ReplicaSets).Apps().V1().ReplicaSets().Lister()
 }

--- a/pkg/k8score/types.go
+++ b/pkg/k8score/types.go
@@ -209,6 +209,16 @@ type CacheConfig struct {
 	// unaffected. Zero means wait indefinitely.
 	DeferredSyncTimeout time.Duration
 
+	// ListPageSize, when > 0, makes high-cardinality informers fetch their
+	// initial LIST in pages of this size via a consistent (resourceVersion="")
+	// read instead of one unpaginated response. This mitigates response-read
+	// timeouts and memory spikes during initial sync on very large clusters
+	// where WatchList streaming isn't available — when it is, client-go streams
+	// the initial state and this path is never exercised. 0 (the default)
+	// keeps the standard factory behavior. Only kinds flagged in
+	// buildInformerSetups (currently Pods, ReplicaSets) paginate.
+	ListPageSize int64
+
 	// DebugEvents enables verbose event debug logging.
 	DebugEvents bool
 


### PR DESCRIPTION
## Summary

Addresses the pods/deployments=0 half of #598. On very large clusters **without WatchList streaming**, an informer's single-shot initial LIST of a high-cardinality kind (Pods, ReplicaSets) can exceed the response-read deadline or spike memory, so the informer never syncs and the resource shows `0` in the UI.

This adds an **opt-in** `--list-page-size` flag (Helm: `listPageSize`) that fetches those kinds' initial LIST in **pages** via a consistent (`resourceVersion=""`) read, following `continue` tokens, instead of one giant response.

## Why it's safe / self-targeting

- **Default `0` = off.** Zero behavior change unless an operator opts in. This is hardening for the few very large clusters, not a change for everyone.
- **It only runs where it's needed.** client-go's reflector uses **WatchList streaming** wherever the apiserver supports it (default-on in our client-go v0.36) and only falls back to the paginated LIST when WatchList is unavailable — i.e. exactly the WatchList-off clusters (e.g. managed 1.33) that hit the giant-LIST problem. Where WatchList is on, this path is never exercised.
- Scoped to **Pods + ReplicaSets** only (the critical-path high-cardinality kinds); everything else is untouched.

## Implementation notes

- Paginated kinds use a custom `ListWatch` + `NewSharedIndexInformer` — the `SharedInformerFactory` can't paginate the `RV=0` initial list (the apiserver ignores `limit` on watch-cache reads), so we force a consistent read driven by a `pager`. The watch is unchanged.
- Because these informers are built outside the factory (and the factory's informer for the kind is never started), the typed listers (`Pods()`, `ReplicaSets()`) read the paginated informer's store directly. The `DropManagedFields` transform is applied to match factory behavior.

## Validation

- **Spike (Step 0):** confirmed against live EKS that `resourceVersion=""` + `limit`/`continue` paginates and the informer syncs + hands off to a single incremental watch with no relist loop.
- **Unit test:** `newPagedInformer` assembles all items across pages (boundary counts 0 / under / exactly one page / +1 / several), with `WatchListClient` disabled to exercise the fallback.
- **Live, all three modes return the correct pod count (no regression):**
  - flag off (factory path)
  - flag on + WatchList on (paged informer streams)
  - flag on + WatchList off (paginated LIST fallback)

## Tradeoff (documented in values.yaml)

On `<1.34` clusters, paginating forces consistent reads served from **etcd** (more control-plane load) rather than the cheap watch-cache read. On `1.34+` (`ListFromCacheSnapshot`, beta) the same paged reads are served from cache. That's why it's opt-in.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core informer startup and lister paths for high-cardinality kinds; default off limits blast radius, but enabled paging can add apiserver/etcd load on older clusters.
> 
> **Overview**
> Adds an **opt-in** `--list-page-size` flag (Helm: `listPageSize`, default `0` = unchanged behavior) so very large clusters can paginate the initial LIST for **Pods** and **ReplicaSets** instead of one huge response—aimed at sync failures when WatchList streaming is unavailable.
> 
> When the flag is set, those kinds use a custom paginated `ListWatch` (`resourceVersion=""` + client-go `pager`) and dedicated informers; `Pods()` / `ReplicaSets()` listers read the paginated store. Wiring runs from CLI → `AppConfig` / `k8s.ListPageSize` → `CacheConfig.ListPageSize`. Docs and Helm pass the flag when non-zero. A unit test covers multi-page assembly with WatchList disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 426973797fe470e3b123a3e806b8dc57e341ec88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->