### PR TITLE
fix(resources): reflect YAML edits immediately instead of re-reading stale cache

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1609,8 +1609,24 @@ export function useUpdateResource() {
       errorMessage: 'Failed to update resource',
       successMessage: 'Resource updated',
     },
-    onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({ queryKey: ['resource', variables.kind, variables.namespace, variables.name] })
+    onSuccess: (updated: any, variables) => {
+      // The PUT goes straight to the apiserver and returns the authoritative
+      // object, but the GET behind this query reads Radar's informer cache,
+      // which lags a write by one watch round-trip. Seed the detail cache with
+      // the PUT response so the edit shows immediately. Invalidating here
+      // instead would trigger a refetch that races the seed and re-reads the
+      // lagging cache — the change appears not to have taken effect.
+      if (updated && typeof updated === 'object' && updated.metadata) {
+        queryClient.setQueriesData(
+          { queryKey: ['resource', variables.kind, variables.namespace, variables.name] },
+          (old: any) =>
+            old && typeof old === 'object' && 'resource' in old
+              ? { ...old, resource: updated }
+              : { resource: updated }
+        )
+      } else {
+        queryClient.invalidateQueries({ queryKey: ['resource', variables.kind, variables.namespace, variables.name] })
+      }
       queryClient.invalidateQueries({ queryKey: ['resources', variables.kind] })
       queryClient.invalidateQueries({ queryKey: ['topology'] })
     },


### PR DESCRIPTION
## Summary

Editing a resource's YAML and hitting Apply sometimes looked like it did nothing — the change appeared not to take effect. Reported by a customer.

The apply itself was fine. The PUT goes straight to the apiserver, but the GET behind the resource-detail query reads Radar's **informer cache**, which lags a write by one watch round-trip. The mutation's `onSuccess` *invalidated* the detail query, forcing an immediate refetch that re-read the still-stale cache — so the editor reverted to the old YAML and the edit read as lost.

## Change

`useUpdateResource.onSuccess` now **seeds** the detail cache (`setQueriesData`) with the authoritative object returned by the PUT instead of invalidating it, so the edit shows immediately. The component's existing delayed refetch reconciles once the informer catches up. Falls back to invalidation if the response isn't a usable object. List and topology queries are still invalidated as before.

One-file change; `make tsc` passes. Verified against a live cluster.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single client-side cache update on an existing mutation path; fallback invalidation unchanged for bad responses.
> 
> **Overview**
> Fixes a UX bug where **Apply** on a resource YAML edit could look like a no-op: the PUT succeeded, but the UI refetched detail from Radar’s **informer-backed GET**, which can lag the apiserver by one watch round-trip, so the editor snapped back to old YAML.
> 
> **`useUpdateResource.onSuccess`** now **seeds** the React Query detail cache with the authoritative object returned by the PUT (`setQueriesData`), preserving the existing `{ resource, relationships }` shape when present. It only **invalidates** the detail query if the response isn’t a usable object. **List** (`resources`) and **topology** queries are still invalidated unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac11e1bbee5211c8286516680642014ac49352aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->