### PR TITLE
Deep links: keep URL-asserted selection through mount + export path builders

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -948,22 +948,30 @@ function AppInner() {
     const navigatingToHelm = mainView === 'helm' && prevMainView.current !== 'helm'
     prevMainView.current = mainView
 
-    // Don't clear selectedResource when navigating TO resources view (deep link from Helm)
-    if (!navigatingToResources) {
+    // The URL is the source of truth for what's selected. A deep link
+    // (?resource=, ?release=) seeds the selection on mount; the effects that
+    // run during that same mount must not wipe a selection the URL still
+    // asserts. (On a real view switch the URL no longer carries the param, so
+    // the clear proceeds.) Without this, deep-linking straight to a Helm
+    // release lands on the release list with no drawer.
+    const params = new URLSearchParams(window.location.search)
+    if (!navigatingToResources && !params.has('resource')) {
       setSelectedResource(null)
     }
-    // Don't clear helm release when navigating TO helm (back button restores from URL)
-    if (!navigatingToHelm) {
+    if (!navigatingToHelm && !params.has('release')) {
       setSelectedHelmRelease(null)
     }
     setDrawerExpanded(false)
   }, [mainView])
 
-  // Clear resource selection when namespaces change
+  // Clear resource selection when namespaces change — but keep a selection the
+  // URL still asserts (deep link, or a release/resource the user is viewing
+  // while they adjust the namespace scope filter).
   useEffect(() => {
-    setSelectedResource(null)
+    const params = new URLSearchParams(window.location.search)
+    if (!params.has('resource')) setSelectedResource(null)
+    if (!params.has('release')) setSelectedHelmRelease(null)
     setDrawerExpanded(false)
-    setSelectedHelmRelease(null)
   }, [namespacesKey])
 
   // Filter topology based on visible kinds (uses displayedTopology which respects pause)

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -22,3 +22,12 @@ export { ShortcutHelpOverlay } from './components/ui/ShortcutHelpOverlay';
 // kubeconfig ContextSwitcher without taking a direct dep on k8s-ui internals.
 export { ClusterSwitcher } from '@skyhook-io/k8s-ui';
 export type { ClusterSwitcherProps, ClusterSwitcherItem } from '@skyhook-io/k8s-ui';
+
+// Deep-link builders — so consumers (Radar Hub) construct deep links into a
+// cluster view without hand-rolling Radar's internal URL format, which drifts
+// silently when Radar re-routes. `resourcePath` opens the detail drawer for any
+// kind incl. cluster-scoped; `buildWorkloadPath` is the namespaced-workload
+// full-page view. Both return basename-relative paths; embedders prepend their
+// cluster prefix (e.g. /c/:id).
+export { resourcePath, buildWorkloadPath } from './utils/navigation';
+export type { SelectedResource } from '@skyhook-io/k8s-ui/types/core';

--- a/web/src/utils/navigation.ts
+++ b/web/src/utils/navigation.ts
@@ -1,4 +1,5 @@
 import { apiUrl, getAuthHeaders, getCredentialsMode } from '../api/config'
+import { kindToPlural } from '@skyhook-io/k8s-ui/utils/navigation'
 import type { SelectedResource } from '@skyhook-io/k8s-ui/types/core'
 
 // Re-export shared navigation utilities from @skyhook-io/k8s-ui.
@@ -8,6 +9,8 @@ export type { NavigateToResource } from '@skyhook-io/k8s-ui/utils/navigation'
 /**
  * Build a /workload/:kind/:namespace/:name URL, preserving the API group as a
  * query param so the WorkloadView can resolve CRDs with colliding kind names.
+ * Namespaced workloads only — WorkloadView requires a namespace. For arbitrary
+ * kinds (including cluster-scoped) use resourcePath.
  */
 export function buildWorkloadPath(resource: SelectedResource): string {
   const kind = encodeURIComponent(resource.kind)
@@ -15,6 +18,30 @@ export function buildWorkloadPath(resource: SelectedResource): string {
   const name = encodeURIComponent(resource.name)
   const base = `/workload/${kind}/${namespace}/${name}`
   return resource.group ? `${base}?apiGroup=${encodeURIComponent(resource.group)}` : base
+}
+
+/**
+ * Build a /resources/:plural?resource=:namespace/:name URL — the deep link that
+ * opens a resource's detail drawer in the resources view. Cluster-scoped
+ * resources use ?resource=:name (no slash); the API group rides in ?apiGroup=
+ * to disambiguate CRD/core kind collisions. This is the exact form the
+ * ResourcesView mount effect parses (the `?resource=` reader in
+ * packages/k8s-ui/src/components/resources/ResourcesView.tsx) — keep the two in
+ * lockstep.
+ *
+ * Unlike buildWorkloadPath, this opens the detail drawer for ANY kind,
+ * including cluster-scoped resources. Returns a basename-relative path;
+ * embedders (Radar Hub) prepend their cluster prefix (e.g. /c/:id).
+ */
+export function resourcePath(resource: SelectedResource): string {
+  const params = new URLSearchParams()
+  // No name → nothing to open; the kind list is the sane fallback.
+  if (resource.name) {
+    params.set('resource', resource.namespace ? `${resource.namespace}/${resource.name}` : resource.name)
+  }
+  if (resource.group) params.set('apiGroup', resource.group)
+  const query = params.toString()
+  return `/resources/${kindToPlural(resource.kind)}${query ? `?${query}` : ''}`
 }
 
 // radar-specific: open URL in system browser (desktop app support)


### PR DESCRIPTION
Two related fixes for deep-linking into the single-cluster view (surfaced while fixing fleet→cluster deep links; hub companion: **skyhook-dev/radar-hub-web#62**).

## 1. Keep a URL-asserted selection through mount (`web/src/App.tsx`)

Deep-linking to `/helm?release={ns}/{name}` (or `/resources/{kind}?resource=`) set the selection from the URL, but the view-change **and** namespace-change effects both fire during the same mount and immediately cleared it — so a cold deep link to a Helm release landed on the release list with no drawer. Resources happened to survive via a separate re-apply path; Helm had none.

Both clear effects are now **URL-aware**: don't wipe `selectedResource` / `selectedHelmRelease` when the URL still carries `?resource=` / `?release=`. On a real view switch the URL no longer carries the param, so the clear still proceeds. (A first-run `useRef` guard was tried first and doesn't work — StrictMode double-invokes the effect and consumes it; confirmed via console trace.)

Verified live: cold deep link to a Helm release opens the drawer; resource deep links still open; an open drawer now also survives a namespace-scope change (deliberate — the URL still asserts the selection).

## 2. Export deep-link builders so consumers stop hand-rolling our URL format (`web/src/utils/navigation.ts`, `index.ts`)

The fleet deep-link breakage's root cause was **contract drift**: Radar Hub hand-rolled Radar's internal URL format, and it rotted when the format changed. Radar exported no deep-link builders, so consumers had no choice. Now it does:

- `resourcePath(resource)` — builds `/resources/{plural}?resource={ns}/{name}` (cluster-scoped → `?resource={name}`; `apiGroup` in query). Opens the detail drawer for **any** kind, including cluster-scoped — unlike `buildWorkloadPath`, which requires a namespace (`WorkloadView` is namespaced-workloads only).
- Exported `resourcePath` + `buildWorkloadPath` + `SelectedResource` from `index.ts`. Additive to the public surface (non-breaking).

Once this ships in a new `@skyhook-io/radar-app` release, Radar Hub drops its interim hand-rolled `clusterResourcePath` helper (in #62) and re-exports these — making the drift impossible to reintroduce.

## Notes
- Helm has no path-segment route, only `/helm?release=`, so the per-cluster Packages→Helm link still depends on fix #1 above (plus the hub bumping the radar-app pin).
- We considered repointing resource deep links to the path-segment `/workload/` route, but rejected it: `WorkloadView` requires a namespace, so it can't represent cluster-scoped resources (Nodes, ClusterRoles, PVs, cluster-scoped CRDs) that fleet search/issues surface. The `?resource=` drawer is the general all-kinds surface.