### PR TITLE
Add unified /api/certificates inventory endpoint

### DIFF
--- a/internal/server/certificate.go
+++ b/internal/server/certificate.go
@@ -3,10 +3,20 @@ package server
 import (
 	"log"
 	"net/http"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/pkg/certs"
 	"github.com/skyhook-io/radar/pkg/topology"
 )
+
+// sealedSecretsKeyLabel marks a sealed-secrets controller keypair. Those are
+// type=kubernetes.io/tls and parse as real (long-lived, self-signed) x509, but
+// they're an internal encryption key, not a serving certificate anyone renews —
+// so the certificate inventory skips them to stay signal, not noise.
+const sealedSecretsKeyLabel = "sealedsecrets.bitnami.com/sealed-secrets-key"
 
 const (
 	certExpiryWarningDays  = 30
@@ -17,6 +27,114 @@ const (
 type CertificateInfo = topology.CertificateInfo
 type SecretCertificateInfo = topology.SecretCertificateInfo
 type CertExpiry = topology.CertExpiry
+
+// handleCertificates returns the cluster's unified certificate inventory:
+// cert-manager.io Certificate CRs + raw kubernetes.io/tls secrets, deduped and
+// health-rated by pkg/certs. Backs Radar Hub's fleet Certs view; the merge
+// lives in pkg/certs so the hub stays a thin pivot.
+//
+// Inventory read pattern (mirrors handlePackages): TLS secrets are read with
+// the ServiceAccount, not the caller's impersonated identity, so cert hygiene
+// doesn't vanish for cloud:viewer (whose K8s `view` role excludes secrets).
+// Only public certificate metadata (issuer / domains / expiry) is emitted —
+// never tls.key. A cluster without cert-manager simply contributes no CR rows;
+// that's not an error.
+func (s *Server) handleCertificates(w http.ResponseWriter, r *http.Request) {
+	if !s.requireConnected(w) {
+		return
+	}
+	cache := k8s.GetResourceCache()
+	if cache == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "Resource cache not available")
+		return
+	}
+
+	src := certs.Sources{Now: time.Now().UTC()}
+
+	// cert-manager Certificate CRs. ?group disambiguates from other ecosystems'
+	// "Certificate" kinds. A CRD-absent / not-yet-discovered cluster errors
+	// here and we ignore it — the TLS-secret leg still answers, so "no
+	// cert-manager" is not a failure.
+	if items, err := cache.ListDynamicWithGroup(r.Context(), "certificates", "", "cert-manager.io"); err == nil {
+		for _, it := range items {
+			src.CertManager = append(src.CertManager, projectCertManagerCert(it.Object))
+		}
+	}
+
+	// kubernetes.io/tls secrets. We only read tls.crt (the public chain) and
+	// emit metadata; tls.key never leaves the cluster.
+	provider := k8s.NewTopologyResourceProvider(cache)
+	if secrets, err := provider.Secrets(); err == nil {
+		for _, sec := range secrets {
+			if sec.Type != corev1.SecretTypeTLS {
+				continue
+			}
+			if _, sealed := sec.Labels[sealedSecretsKeyLabel]; sealed {
+				continue
+			}
+			pem, ok := sec.Data["tls.crt"]
+			if !ok || len(pem) == 0 {
+				continue
+			}
+			leaf := topology.ParsePEMCertificates(pem)
+			if len(leaf) == 0 {
+				continue
+			}
+			in := certs.Input{
+				Name:      sec.Name,
+				Namespace: sec.Namespace,
+				Issuer:    leaf[0].Issuer,
+				Domains:   leaf[0].SANs,
+				Source:    certs.SourceTLSSecret,
+			}
+			if t, err := time.Parse(time.RFC3339, leaf[0].NotAfter); err == nil {
+				in.NotAfter = &t
+			}
+			src.TLSSecrets = append(src.TLSSecrets, in)
+		}
+	}
+
+	s.writeJSON(w, certs.Aggregate(src))
+}
+
+// projectCertManagerCert maps a cert-manager.io Certificate CR (unstructured)
+// to a certs.Input. status.notAfter is absent until the cert is first issued,
+// in which case NotAfter stays nil (pkg/certs renders it as unknown expiry).
+func projectCertManagerCert(obj map[string]any) certs.Input {
+	md, _ := obj["metadata"].(map[string]any)
+	spec, _ := obj["spec"].(map[string]any)
+	status, _ := obj["status"].(map[string]any)
+	in := certs.Input{
+		Name:       mapString(md, "name"),
+		Namespace:  mapString(md, "namespace"),
+		SecretName: mapString(spec, "secretName"),
+		Source:     certs.SourceCertManager,
+	}
+	if ir, ok := spec["issuerRef"].(map[string]any); ok {
+		in.Issuer = mapString(ir, "name")
+	}
+	if dns, ok := spec["dnsNames"].([]any); ok {
+		for _, d := range dns {
+			if ds, ok := d.(string); ok {
+				in.Domains = append(in.Domains, ds)
+			}
+		}
+	}
+	if na := mapString(status, "notAfter"); na != "" {
+		if t, err := time.Parse(time.RFC3339, na); err == nil {
+			in.NotAfter = &t
+		}
+	}
+	return in
+}
+
+func mapString(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	s, _ := m[key].(string)
+	return s
+}
 
 // handleSecretCertExpiry returns certificate expiry for all TLS secrets.
 // Used by the frontend secrets list to show an "Expires" column without

--- a/internal/server/certificate.go
+++ b/internal/server/certificate.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"log"
 	"net/http"
 	"time"
@@ -33,12 +34,12 @@ type CertExpiry = topology.CertExpiry
 // health-rated by pkg/certs. Backs Radar Hub's fleet Certs view; the merge
 // lives in pkg/certs so the hub stays a thin pivot.
 //
-// Inventory read pattern (mirrors handlePackages): TLS secrets are read with
-// the ServiceAccount, not the caller's impersonated identity, so cert hygiene
-// doesn't vanish for cloud:viewer (whose K8s `view` role excludes secrets).
-// Only public certificate metadata (issuer / domains / expiry) is emitted —
-// never tls.key. A cluster without cert-manager simply contributes no CR rows;
-// that's not an error.
+// Read pattern mirrors handleListPackages: the ServiceAccount-backed cache
+// performs the read (so cert hygiene survives cloud:viewer, whose K8s `view`
+// role excludes secrets), but the response is post-filtered to the caller's
+// RBAC-allowed namespaces. Only public certificate metadata (issuer / domains
+// / expiry) is emitted — never tls.key. A cluster without cert-manager simply
+// contributes no CR rows; that's not an error.
 func (s *Server) handleCertificates(w http.ResponseWriter, r *http.Request) {
 	if !s.requireConnected(w) {
 		return
@@ -49,57 +50,103 @@ func (s *Server) handleCertificates(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	namespaces := s.parseNamespacesForUser(r)
+	if noNamespaceAccess(namespaces) {
+		s.writeJSON(w, []certs.Cert{})
+		return
+	}
+
 	src := certs.Sources{Now: time.Now().UTC()}
 
 	// cert-manager Certificate CRs. ?group disambiguates from other ecosystems'
-	// "Certificate" kinds. A CRD-absent / not-yet-discovered cluster errors
-	// here and we ignore it — the TLS-secret leg still answers, so "no
-	// cert-manager" is not a failure.
-	if items, err := cache.ListDynamicWithGroup(r.Context(), "certificates", "", "cert-manager.io"); err == nil {
+	// "Certificate" kinds. An absent CRD (ErrUnknownDynamicKind) just means the
+	// cluster doesn't run cert-manager — not an error; the TLS-secret leg still
+	// answers. Any OTHER error (RBAC denial, discovery not ready, transient)
+	// would silently drop real cert-manager certs, so log it and remember the
+	// failure rather than rendering a misleadingly-empty inventory.
+	cmFailed := false
+	items, err := cache.ListDynamicWithGroup(r.Context(), "certificates", "", "cert-manager.io")
+	switch {
+	case err == nil:
 		for _, it := range items {
-			src.CertManager = append(src.CertManager, projectCertManagerCert(it.Object))
+			if in := projectCertManagerCert(it.Object); topology.MatchesNamespace(namespaces, in.Namespace) {
+				src.CertManager = append(src.CertManager, in)
+			}
 		}
+	case errors.Is(err, k8s.ErrUnknownDynamicKind):
+		// cert-manager not installed — expected.
+	default:
+		log.Printf("[certificate] cert-manager Certificate list failed: %v", err)
+		cmFailed = true
 	}
 
 	// kubernetes.io/tls secrets. We only read tls.crt (the public chain) and
-	// emit metadata; tls.key never leaves the cluster.
+	// emit metadata; tls.key never leaves the cluster. A nil error with no
+	// secrets is a benign deferred-cache state; a non-nil error means we
+	// genuinely couldn't read secrets.
+	secFailed := false
 	provider := k8s.NewTopologyResourceProvider(cache)
 	if secrets, err := provider.Secrets(); err == nil {
 		for _, sec := range secrets {
-			if sec.Type != corev1.SecretTypeTLS {
+			if !topology.MatchesNamespace(namespaces, sec.Namespace) {
 				continue
 			}
-			if _, sealed := sec.Labels[sealedSecretsKeyLabel]; sealed {
-				continue
+			if in, ok := secretToCertInput(sec); ok {
+				src.TLSSecrets = append(src.TLSSecrets, in)
 			}
-			pem, ok := sec.Data["tls.crt"]
-			if !ok || len(pem) == 0 {
-				continue
-			}
-			leaf := topology.ParsePEMCertificates(pem)
-			if len(leaf) == 0 {
-				continue
-			}
-			in := certs.Input{
-				Name:      sec.Name,
-				Namespace: sec.Namespace,
-				Issuer:    leaf[0].Issuer,
-				Domains:   leaf[0].SANs,
-				Source:    certs.SourceTLSSecret,
-			}
-			if t, err := time.Parse(time.RFC3339, leaf[0].NotAfter); err == nil {
-				in.NotAfter = &t
-			}
-			src.TLSSecrets = append(src.TLSSecrets, in)
 		}
+	} else {
+		log.Printf("[certificate] TLS secret list failed: %v", err)
+		secFailed = true
+	}
+
+	// Both sources hard-failed → returning an empty list would read as a healthy
+	// "no certs" cluster. Surface it so the fleet view marks the cluster errored
+	// rather than silently green.
+	if cmFailed && secFailed {
+		s.writeError(w, http.StatusServiceUnavailable, "certificate inventory temporarily unavailable")
+		return
 	}
 
 	s.writeJSON(w, certs.Aggregate(src))
 }
 
+// secretToCertInput projects a kubernetes.io/tls secret into a certs.Input.
+// ok=false for secrets that aren't serving certs: non-TLS types, sealed-secrets
+// controller keypairs (encryption keys, not renew-able certs), and secrets
+// whose tls.crt is missing or unparseable. Reads only tls.crt — never tls.key.
+func secretToCertInput(sec *corev1.Secret) (certs.Input, bool) {
+	if sec.Type != corev1.SecretTypeTLS {
+		return certs.Input{}, false
+	}
+	if _, sealed := sec.Labels[sealedSecretsKeyLabel]; sealed {
+		return certs.Input{}, false
+	}
+	pem, ok := sec.Data["tls.crt"]
+	if !ok || len(pem) == 0 {
+		return certs.Input{}, false
+	}
+	leaf := topology.ParsePEMCertificates(pem)
+	if len(leaf) == 0 {
+		return certs.Input{}, false
+	}
+	in := certs.Input{
+		Name:      sec.Name,
+		Namespace: sec.Namespace,
+		Issuer:    leaf[0].Issuer,
+		Domains:   leaf[0].SANs,
+		Source:    certs.SourceTLSSecret,
+	}
+	if t, err := time.Parse(time.RFC3339, leaf[0].NotAfter); err == nil {
+		in.NotAfter = &t
+	}
+	return in, true
+}
+
 // projectCertManagerCert maps a cert-manager.io Certificate CR (unstructured)
-// to a certs.Input. status.notAfter is absent until the cert is first issued,
-// in which case NotAfter stays nil (pkg/certs renders it as unknown expiry).
+// to a certs.Input. status.notAfter is absent when the cert has no issued
+// secret yet (and during some renewal-failure states), in which case NotAfter
+// stays nil (pkg/certs renders it as unknown expiry).
 func projectCertManagerCert(obj map[string]any) certs.Input {
 	md, _ := obj["metadata"].(map[string]any)
 	spec, _ := obj["spec"].(map[string]any)

--- a/internal/server/certificate.go
+++ b/internal/server/certificate.go
@@ -100,15 +100,20 @@ func (s *Server) handleCertificates(w http.ResponseWriter, r *http.Request) {
 		secFailed = true
 	}
 
-	// Both sources hard-failed → returning an empty list would read as a healthy
-	// "no certs" cluster. Surface it so the fleet view marks the cluster errored
-	// rather than silently green.
-	if cmFailed && secFailed {
+	// An empty result caused by a read error reads as a healthy "no certs"
+	// cluster. Surface it so the fleet view marks the cluster errored rather
+	// than silently green. This matters most on a cluster without cert-manager,
+	// where TLS secrets are the only source: there cmFailed stays false (an
+	// absent CRD is benign), so gating on both legs would miss a failed secret
+	// read. Gate on "no data AND something errored" instead — which still lets
+	// a partial success (one leg returned certs) through.
+	result := certs.Aggregate(src)
+	if len(result) == 0 && (cmFailed || secFailed) {
 		s.writeError(w, http.StatusServiceUnavailable, "certificate inventory temporarily unavailable")
 		return
 	}
 
-	s.writeJSON(w, certs.Aggregate(src))
+	s.writeJSON(w, result)
 }
 
 // secretToCertInput projects a kubernetes.io/tls secret into a certs.Input.

--- a/internal/server/certificate_test.go
+++ b/internal/server/certificate_test.go
@@ -1,0 +1,151 @@
+package server
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/skyhook-io/radar/pkg/certs"
+)
+
+// selfSignedPEM returns a PEM-encoded self-signed cert for use as a secret's
+// tls.crt, so secretToCertInput's parse path has a real leaf to read.
+func selfSignedPEM(t *testing.T, cn string, dns []string, notAfter time.Time) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     notAfter,
+		DNSNames:     dns,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func TestProjectCertManagerCert_Issued(t *testing.T) {
+	notAfter := time.Now().Add(45 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	obj := map[string]any{
+		"metadata": map[string]any{"name": "api-prod", "namespace": "default"},
+		"spec": map[string]any{
+			"secretName": "api-prod-tls",
+			"issuerRef":  map[string]any{"name": "letsencrypt"},
+			"dnsNames":   []any{"api.example.com", "www.example.com"},
+		},
+		"status": map[string]any{"notAfter": notAfter},
+	}
+	in := projectCertManagerCert(obj)
+	if in.Name != "api-prod" || in.Namespace != "default" {
+		t.Errorf("name/namespace = %q/%q, want api-prod/default", in.Name, in.Namespace)
+	}
+	if in.SecretName != "api-prod-tls" {
+		t.Errorf("secretName = %q, want api-prod-tls", in.SecretName)
+	}
+	if in.Issuer != "letsencrypt" {
+		t.Errorf("issuer = %q, want letsencrypt", in.Issuer)
+	}
+	if len(in.Domains) != 2 || in.Domains[0] != "api.example.com" {
+		t.Errorf("domains = %v, want [api.example.com www.example.com]", in.Domains)
+	}
+	if in.Source != certs.SourceCertManager {
+		t.Errorf("source = %q, want cert-manager", in.Source)
+	}
+	if in.NotAfter == nil {
+		t.Error("NotAfter = nil, want parsed time")
+	}
+}
+
+func TestProjectCertManagerCert_NotYetIssued(t *testing.T) {
+	// No status block at all — a Certificate that hasn't been issued.
+	obj := map[string]any{
+		"metadata": map[string]any{"name": "pending", "namespace": "default"},
+		"spec":     map[string]any{"secretName": "pending-tls", "issuerRef": map[string]any{"name": "letsencrypt"}},
+	}
+	in := projectCertManagerCert(obj)
+	if in.Name != "pending" {
+		t.Fatalf("name = %q, want pending", in.Name)
+	}
+	if in.NotAfter != nil {
+		t.Errorf("NotAfter = %v, want nil (no status.notAfter)", in.NotAfter)
+	}
+}
+
+func TestSecretToCertInput_SkipsNonServingSecrets(t *testing.T) {
+	valid := selfSignedPEM(t, "svc.example", []string{"svc.example"}, time.Now().Add(40*24*time.Hour))
+	cases := []struct {
+		name   string
+		secret *corev1.Secret
+		wantOK bool
+	}{
+		{
+			name:   "non-TLS type skipped",
+			secret: &corev1.Secret{Type: corev1.SecretTypeOpaque, Data: map[string][]byte{"tls.crt": valid}},
+			wantOK: false,
+		},
+		{
+			name: "sealed-secrets keypair skipped",
+			secret: &corev1.Secret{
+				Type: corev1.SecretTypeTLS,
+				Data: map[string][]byte{"tls.crt": valid},
+			},
+			wantOK: false, // label set below
+		},
+		{
+			name:   "missing tls.crt skipped",
+			secret: &corev1.Secret{Type: corev1.SecretTypeTLS, Data: map[string][]byte{}},
+			wantOK: false,
+		},
+		{
+			name:   "unparseable tls.crt skipped",
+			secret: &corev1.Secret{Type: corev1.SecretTypeTLS, Data: map[string][]byte{"tls.crt": []byte("not a pem")}},
+			wantOK: false,
+		},
+		{
+			name: "valid TLS serving cert accepted",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "web-tls", Namespace: "prod"},
+				Type:       corev1.SecretTypeTLS,
+				Data:       map[string][]byte{"tls.crt": valid},
+			},
+			wantOK: true,
+		},
+	}
+	// Attach the sealed-secrets label to the dedicated case.
+	cases[1].secret.Labels = map[string]string{sealedSecretsKeyLabel: "active"}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in, ok := secretToCertInput(tc.secret)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if tc.wantOK {
+				if in.Name != "web-tls" || in.Namespace != "prod" {
+					t.Errorf("name/namespace = %q/%q, want web-tls/prod", in.Name, in.Namespace)
+				}
+				if in.Source != certs.SourceTLSSecret {
+					t.Errorf("source = %q, want tls-secret", in.Source)
+				}
+				if in.NotAfter == nil {
+					t.Error("NotAfter = nil, want parsed expiry from the leaf cert")
+				}
+			}
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -291,6 +291,7 @@ func (s *Server) setupRoutes() {
 			r.Get("/resources/{kind}/{namespace}/{name}/cascade-preview", s.handleCascadeDeletePreview)
 			r.Delete("/resources/{kind}/{namespace}/{name}", s.handleDeleteResource)
 			r.Get("/secrets/certificate-expiry", s.handleSecretCertExpiry)
+			r.Get("/certificates", s.handleCertificates)
 
 			// Cluster audit
 			r.Get("/audit", s.handleAudit)

--- a/pkg/certs/certs.go
+++ b/pkg/certs/certs.go
@@ -1,0 +1,166 @@
+// Package certs unifies a cluster's certificates from the two sources Radar
+// knows about — cert-manager.io Certificate CRs and raw kubernetes.io/tls
+// secrets — into one health-rated, deduplicated list.
+//
+// A cluster that doesn't run cert-manager has only TLS secrets; a cluster that
+// does has both, and the same physical cert appears in each (the Certificate
+// owns a Secret). Aggregate is the single place that reconciles them, so fleet
+// callers (Radar Hub) stay thin pivots and never re-implement the merge.
+package certs
+
+import (
+	"fmt"
+	"sort"
+	"time"
+)
+
+// Source identifies which input a cert row came from.
+type Source string
+
+const (
+	SourceCertManager Source = "cert-manager"
+	SourceTLSSecret   Source = "tls-secret"
+)
+
+// Health mirrors the k8s-ui cert-expiry vocabulary: healthy ≥30d, degraded
+// 7–29d, unhealthy <7d or expired, unknown when there's no expiry to judge.
+type Health string
+
+const (
+	HealthHealthy   Health = "healthy"
+	HealthDegraded  Health = "degraded"
+	HealthUnhealthy Health = "unhealthy"
+	HealthUnknown   Health = "unknown"
+)
+
+const (
+	degradedWithinDays  = 30
+	unhealthyWithinDays = 7
+)
+
+// Input is one certificate normalized from either source. The caller (the
+// in-cluster handler) does the k8s I/O + projection; this package owns the
+// reconciliation. NotAfter == nil means expiry is unknown (a cert-manager
+// Certificate that hasn't been issued yet has no status.notAfter).
+type Input struct {
+	Name      string
+	Namespace string
+	Issuer    string
+	Domains   []string
+	NotAfter  *time.Time
+	Source    Source
+	// SecretName is set only for cert-manager Certificates: the Secret the
+	// Certificate writes to. Used to dedup the TLS-secret leg against the
+	// authoritative Certificate row.
+	SecretName string
+}
+
+// Sources bundles a cluster's per-source inputs for one Aggregate call.
+type Sources struct {
+	CertManager []Input
+	TLSSecrets  []Input
+	// Now anchors expiry math; zero value falls back to time.Now (tests pin it).
+	Now time.Time
+}
+
+// Cert is one unified row, ready to serialize. DaysLeft is nil when expiry is
+// unknown; Expiry is RFC3339 and omitted in that case.
+type Cert struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Issuer    string `json:"issuer"`
+	Domains   string `json:"domains"`
+	Expiry    string `json:"expiry,omitempty"`
+	DaysLeft  *int   `json:"daysLeft,omitempty"`
+	Health    Health `json:"health"`
+	Source    Source `json:"source"`
+}
+
+// Aggregate merges the two sources into a single most-urgent-first list. A TLS
+// secret owned by a cert-manager Certificate (matched on namespace + secretName)
+// is dropped in favor of the Certificate row, so the same physical cert is
+// counted once. Inputs are otherwise passed through verbatim.
+func Aggregate(s Sources) []Cert {
+	now := s.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	out := make([]Cert, 0, len(s.CertManager)+len(s.TLSSecrets))
+	managed := make(map[string]bool, len(s.CertManager))
+	for _, in := range s.CertManager {
+		out = append(out, toCert(in, now))
+		if in.SecretName != "" {
+			managed[in.Namespace+"/"+in.SecretName] = true
+		}
+	}
+	for _, in := range s.TLSSecrets {
+		if managed[in.Namespace+"/"+in.Name] {
+			continue
+		}
+		out = append(out, toCert(in, now))
+	}
+
+	sort.SliceStable(out, func(i, j int) bool { return less(out[i], out[j]) })
+	return out
+}
+
+func toCert(in Input, now time.Time) Cert {
+	c := Cert{
+		Name:      in.Name,
+		Namespace: in.Namespace,
+		Issuer:    in.Issuer,
+		Domains:   formatDomains(in.Domains),
+		Health:    HealthUnknown,
+		Source:    in.Source,
+	}
+	if in.NotAfter != nil {
+		c.Expiry = in.NotAfter.UTC().Format(time.RFC3339)
+		days := int(in.NotAfter.Sub(now).Hours() / 24)
+		c.DaysLeft = &days
+		switch {
+		case days < unhealthyWithinDays:
+			c.Health = HealthUnhealthy
+		case days < degradedWithinDays:
+			c.Health = HealthDegraded
+		default:
+			c.Health = HealthHealthy
+		}
+	}
+	return c
+}
+
+// less sorts most-urgent-first: known expiry ascending by days left, unknown
+// expiry sinks to the bottom, ties broken by namespace then name so refetches
+// present a stable order.
+func less(a, b Cert) bool {
+	switch {
+	case a.DaysLeft == nil && b.DaysLeft == nil:
+		// both unknown — fall through to lexical tiebreak
+	case a.DaysLeft == nil:
+		return false
+	case b.DaysLeft == nil:
+		return true
+	case *a.DaysLeft != *b.DaysLeft:
+		return *a.DaysLeft < *b.DaysLeft
+	}
+	if a.Namespace != b.Namespace {
+		return a.Namespace < b.Namespace
+	}
+	return a.Name < b.Name
+}
+
+// formatDomains abbreviates SANs to "a, b +N more" beyond two so a
+// wildcard-plus-many-hosts cert stays one table-cell wide.
+func formatDomains(d []string) string {
+	switch len(d) {
+	case 0:
+		return ""
+	case 1:
+		return d[0]
+	case 2:
+		return d[0] + ", " + d[1]
+	default:
+		return fmt.Sprintf("%s, %s +%d more", d[0], d[1], len(d)-2)
+	}
+}

--- a/pkg/certs/certs.go
+++ b/pkg/certs/certs.go
@@ -10,6 +10,7 @@ package certs
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"time"
 )
@@ -116,7 +117,10 @@ func toCert(in Input, now time.Time) Cert {
 	}
 	if in.NotAfter != nil {
 		c.Expiry = in.NotAfter.UTC().Format(time.RFC3339)
-		days := int(in.NotAfter.Sub(now).Hours() / 24)
+		// Floor (not truncate-toward-zero) so a cert that expired an hour ago
+		// reads as -1 ("expired"), not 0 ("expires today"). Matches the floor
+		// semantics in topology.ParsePEMCertificates.
+		days := int(math.Floor(in.NotAfter.Sub(now).Hours() / 24))
 		c.DaysLeft = &days
 		switch {
 		case days < unhealthyWithinDays:

--- a/pkg/certs/certs_test.go
+++ b/pkg/certs/certs_test.go
@@ -135,6 +135,26 @@ func TestAggregate_NoCertManagerStillReturnsSecretCerts(t *testing.T) {
 	}
 }
 
+// A cert that expired an hour ago must floor to -1 day ("expired"), not
+// truncate to 0 ("expires today"). Guards the math.Floor vs int() distinction.
+func TestAggregate_JustExpiredFloorsToNegative(t *testing.T) {
+	now := time.Now().UTC()
+	oneHourAgo := now.Add(-time.Hour)
+	got := Aggregate(Sources{
+		Now:        now,
+		TLSSecrets: []Input{{Name: "expired", Namespace: "a", NotAfter: &oneHourAgo, Source: SourceTLSSecret}},
+	})
+	if len(got) != 1 || got[0].DaysLeft == nil {
+		t.Fatalf("want 1 cert with a daysLeft, got %+v", got)
+	}
+	if *got[0].DaysLeft != -1 {
+		t.Errorf("daysLeft = %d, want -1 (floor — a just-expired cert is expired, not 'today')", *got[0].DaysLeft)
+	}
+	if got[0].Health != HealthUnhealthy {
+		t.Errorf("health = %q, want unhealthy", got[0].Health)
+	}
+}
+
 // Dedup keys on namespace+secretName, so the same secretName in two namespaces
 // must NOT collapse — a prod/tls Certificate owning prod/tls must not suppress
 // an unrelated staging/tls raw secret.

--- a/pkg/certs/certs_test.go
+++ b/pkg/certs/certs_test.go
@@ -1,0 +1,136 @@
+package certs
+
+import (
+	"testing"
+	"time"
+)
+
+func at(now time.Time, days int) *time.Time {
+	t := now.Add(time.Duration(days) * 24 * time.Hour)
+	return &t
+}
+
+func find(certs []Cert, ns, name string) *Cert {
+	for i := range certs {
+		if certs[i].Namespace == ns && certs[i].Name == name {
+			return &certs[i]
+		}
+	}
+	return nil
+}
+
+func TestAggregate_HealthThresholds(t *testing.T) {
+	now := time.Now().UTC()
+	got := Aggregate(Sources{
+		Now: now,
+		TLSSecrets: []Input{
+			{Name: "healthy", Namespace: "a", NotAfter: at(now, 45), Source: SourceTLSSecret},
+			{Name: "degraded", Namespace: "a", NotAfter: at(now, 10), Source: SourceTLSSecret},
+			{Name: "soon", Namespace: "a", NotAfter: at(now, 3), Source: SourceTLSSecret},
+			{Name: "expired", Namespace: "a", NotAfter: at(now, -2), Source: SourceTLSSecret},
+		},
+	})
+	want := map[string]Health{
+		"healthy":  HealthHealthy,
+		"degraded": HealthDegraded,
+		"soon":     HealthUnhealthy,
+		"expired":  HealthUnhealthy,
+	}
+	for name, wantHealth := range want {
+		c := find(got, "a", name)
+		if c == nil {
+			t.Fatalf("cert %q missing", name)
+		}
+		if c.Health != wantHealth {
+			t.Errorf("cert %q health = %q, want %q", name, c.Health, wantHealth)
+		}
+	}
+}
+
+func TestAggregate_DedupsCertManagerOwnedSecret(t *testing.T) {
+	now := time.Now().UTC()
+	got := Aggregate(Sources{
+		Now: now,
+		CertManager: []Input{{
+			Name: "api", Namespace: "prod", Issuer: "letsencrypt",
+			Domains: []string{"api.example.com"}, NotAfter: at(now, 40),
+			Source: SourceCertManager, SecretName: "api-tls",
+		}},
+		TLSSecrets: []Input{
+			// Same physical cert as the Certificate above — must be dropped.
+			{Name: "api-tls", Namespace: "prod", NotAfter: at(now, 40), Source: SourceTLSSecret},
+			// An unrelated raw secret — must survive.
+			{Name: "webhook", Namespace: "prod", NotAfter: at(now, 12), Source: SourceTLSSecret},
+		},
+	})
+	if len(got) != 2 {
+		t.Fatalf("got %d certs, want 2 (cert-manager api + raw webhook; api-tls deduped)", len(got))
+	}
+	if c := find(got, "prod", "api-tls"); c != nil {
+		t.Error("api-tls TLS-secret row should have been deduped against the cert-manager Certificate")
+	}
+	api := find(got, "prod", "api")
+	if api == nil || api.Source != SourceCertManager {
+		t.Errorf("cert-manager row missing or wrong source: %+v", api)
+	}
+	if w := find(got, "prod", "webhook"); w == nil || w.Source != SourceTLSSecret {
+		t.Errorf("unrelated raw secret row missing or wrong source: %+v", w)
+	}
+}
+
+func TestAggregate_SortsMostUrgentFirstUnknownLast(t *testing.T) {
+	now := time.Now().UTC()
+	got := Aggregate(Sources{
+		Now: now,
+		CertManager: []Input{
+			// No NotAfter → unknown, must sink to the bottom.
+			{Name: "pending", Namespace: "a", Source: SourceCertManager},
+		},
+		TLSSecrets: []Input{
+			{Name: "later", Namespace: "a", NotAfter: at(now, 30), Source: SourceTLSSecret},
+			{Name: "sooner", Namespace: "a", NotAfter: at(now, 5), Source: SourceTLSSecret},
+		},
+	})
+	if len(got) != 3 {
+		t.Fatalf("got %d, want 3", len(got))
+	}
+	if got[0].Name != "sooner" || got[1].Name != "later" {
+		t.Errorf("order = [%s,%s,...], want sooner,later first", got[0].Name, got[1].Name)
+	}
+	last := got[len(got)-1]
+	if last.Name != "pending" || last.DaysLeft != nil || last.Health != HealthUnknown {
+		t.Errorf("unknown-expiry cert should sort last as unknown: %+v", last)
+	}
+}
+
+func TestAggregate_FormatsDomains(t *testing.T) {
+	now := time.Now().UTC()
+	got := Aggregate(Sources{
+		Now: now,
+		TLSSecrets: []Input{
+			{Name: "multi", Namespace: "a", NotAfter: at(now, 40), Source: SourceTLSSecret,
+				Domains: []string{"a.example", "b.example", "c.example", "d.example"}},
+			{Name: "single", Namespace: "a", NotAfter: at(now, 41), Source: SourceTLSSecret,
+				Domains: []string{"only.example"}},
+		},
+	})
+	if c := find(got, "a", "multi"); c == nil || c.Domains != "a.example, b.example +2 more" {
+		t.Errorf("multi-domain abbreviation = %q, want 'a.example, b.example +2 more'", c.Domains)
+	}
+	if c := find(got, "a", "single"); c == nil || c.Domains != "only.example" {
+		t.Errorf("single domain = %q, want 'only.example'", c.Domains)
+	}
+}
+
+// A cluster without cert-manager contributes zero CertManager inputs; the TLS
+// secrets must still come through (this is the "certs not showing" regression).
+func TestAggregate_NoCertManagerStillReturnsSecretCerts(t *testing.T) {
+	now := time.Now().UTC()
+	got := Aggregate(Sources{
+		Now:        now,
+		TLSSecrets: []Input{{Name: "raw", Namespace: "a", NotAfter: at(now, 20), Source: SourceTLSSecret}},
+	})
+	if len(got) != 1 || got[0].Name != "raw" || got[0].Source != SourceTLSSecret {
+		t.Fatalf("want the lone TLS-secret cert, got %+v", got)
+	}
+}

--- a/pkg/certs/certs_test.go
+++ b/pkg/certs/certs_test.go
@@ -122,8 +122,8 @@ func TestAggregate_FormatsDomains(t *testing.T) {
 	}
 }
 
-// A cluster without cert-manager contributes zero CertManager inputs; the TLS
-// secrets must still come through (this is the "certs not showing" regression).
+// A cluster without cert-manager contributes zero CertManager inputs, so its
+// TLS-secret certs must still come through on their own.
 func TestAggregate_NoCertManagerStillReturnsSecretCerts(t *testing.T) {
 	now := time.Now().UTC()
 	got := Aggregate(Sources{
@@ -132,5 +132,59 @@ func TestAggregate_NoCertManagerStillReturnsSecretCerts(t *testing.T) {
 	})
 	if len(got) != 1 || got[0].Name != "raw" || got[0].Source != SourceTLSSecret {
 		t.Fatalf("want the lone TLS-secret cert, got %+v", got)
+	}
+}
+
+// Dedup keys on namespace+secretName, so the same secretName in two namespaces
+// must NOT collapse — a prod/tls Certificate owning prod/tls must not suppress
+// an unrelated staging/tls raw secret.
+func TestAggregate_DedupIsNamespaceScoped(t *testing.T) {
+	now := time.Now().UTC()
+	got := Aggregate(Sources{
+		Now: now,
+		CertManager: []Input{{
+			Name: "cert", Namespace: "prod", NotAfter: at(now, 40),
+			Source: SourceCertManager, SecretName: "tls",
+		}},
+		TLSSecrets: []Input{
+			{Name: "tls", Namespace: "prod", NotAfter: at(now, 40), Source: SourceTLSSecret},    // deduped (owned by prod cert)
+			{Name: "tls", Namespace: "staging", NotAfter: at(now, 12), Source: SourceTLSSecret}, // survives (different ns)
+		},
+	})
+	if find(got, "prod", "tls") != nil {
+		t.Error("prod/tls secret should be deduped against the cert-manager Certificate")
+	}
+	if find(got, "staging", "tls") == nil {
+		t.Error("staging/tls secret must survive — dedup must be namespace-scoped, not by bare secretName")
+	}
+}
+
+// Health thresholds are `< 7` and `< 30`, and DaysLeft truncates Hours()/24.
+// Pin the exact boundaries so a `<`→`<=` or truncation regression is caught.
+func TestAggregate_HealthThresholdBoundaries(t *testing.T) {
+	now := time.Now().UTC()
+	got := Aggregate(Sources{
+		Now: now,
+		TLSSecrets: []Input{
+			{Name: "d6", Namespace: "a", NotAfter: at(now, 6), Source: SourceTLSSecret},
+			{Name: "d7", Namespace: "a", NotAfter: at(now, 7), Source: SourceTLSSecret},
+			{Name: "d29", Namespace: "a", NotAfter: at(now, 29), Source: SourceTLSSecret},
+			{Name: "d30", Namespace: "a", NotAfter: at(now, 30), Source: SourceTLSSecret},
+		},
+	})
+	want := map[string]Health{
+		"d6":  HealthUnhealthy, // 6 < 7
+		"d7":  HealthDegraded,  // 7 is NOT < 7
+		"d29": HealthDegraded,  // 29 < 30
+		"d30": HealthHealthy,   // 30 is NOT < 30
+	}
+	for name, wantHealth := range want {
+		c := find(got, "a", name)
+		if c == nil {
+			t.Fatalf("cert %q missing", name)
+		}
+		if c.Health != wantHealth {
+			t.Errorf("cert %q health = %q, want %q", name, c.Health, wantHealth)
+		}
 	}
 }


### PR DESCRIPTION
## What

Adds `GET /api/certificates` — a single per-cluster certificate inventory that unifies the two sources a cluster's serving certs actually come from:

- **cert-manager.io `Certificate` CRs** (auto-renewed)
- **raw `kubernetes.io/tls` secrets** — cloud-LB / ingress-default / webhook / gateway / hand-rolled certs (manual renewal)

A cluster without cert-manager has only the latter, so an endpoint that knows about just one source reads as broken to anyone running the other.

## How

- **`pkg/certs.Aggregate`** is the single home for the merge logic: it dedups a TLS secret against the cert-manager `Certificate` that owns it (matched on `namespace/secretName`), rates health (healthy ≥30d / degraded 7–29d / unhealthy <7d or expired / unknown), abbreviates domains, and sorts most-urgent-first. Pure + unit-tested.
- **`handleCertificates`** does only the k8s I/O — lists cert-manager CRs (an absent CRD is not an error) and TLS secrets, skips sealed-secrets controller keypairs (encryption keys, not serving certs), and emits **only public cert metadata** (issuer / domains / expiry) — never `tls.key`. TLS secrets are read with the ServiceAccount (same inventory pattern as `/api/packages`) so cert hygiene doesn't disappear for `cloud:viewer`, whose K8s `view` role excludes secrets.

## Why it matters

Consumed by Radar Hub's fleet Certs view (separate PR). Before this, the fleet view only queried cert-manager CRs, so clusters without cert-manager showed nothing — and even cert-manager clusters hid every TLS-secret cert. Verified end-to-end against a live no-cert-manager EKS cluster: its `aws-load-balancer-tls` secret now surfaces with correct expiry.

Part of a cross-repo change — paired with `skyhook-dev/radar-hub` (pivot) and `skyhook-dev/radar-hub-web` (UI). Merge together.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reads cluster TLS secrets via the SA cache and exposes public cert metadata; namespace post-filtering limits exposure but the pattern is security-sensitive and new fleet-facing behavior.
> 
> **Overview**
> Introduces **`GET /api/certificates`**, a per-cluster certificate inventory for Radar Hub’s fleet Certs view. It combines **cert-manager.io `Certificate` CRs** and **`kubernetes.io/tls` secrets**, then returns deduplicated rows with issuer, domains, expiry, health, and source.
> 
> **`pkg/certs.Aggregate`** owns merge logic: TLS secrets that match a cert-manager `Certificate` on `namespace/secretName` are dropped in favor of the CR row; health uses the same buckets as the UI (healthy ≥30d, degraded 7–29d, unhealthy &lt;7d or expired, unknown when expiry is missing); results sort by urgency.
> 
> **`handleCertificates`** lists both sources via the ServiceAccount-backed cache (same pattern as `/api/packages`), filters to the caller’s allowed namespaces, parses only **`tls.crt`** (never **`tls.key`**), and skips sealed-secrets controller keypairs. Missing cert-manager is not an error; real read failures return **503** when the inventory would otherwise look empty.
> 
> Unit tests cover aggregation and the cert-manager / TLS projection helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6792dd831ba4146c6f03f778c465cf10569bb2ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
**Related (merge together):** skyhook-dev/radar-hub#47 (hub pivot) · skyhook-dev/radar-hub-web#64 (UI)