### PR TITLE
fix(k8s-ui): map Endpoints to its already-plural resource name

### DIFF
--- a/packages/k8s-ui/src/utils/navigation.test.ts
+++ b/packages/k8s-ui/src/utils/navigation.test.ts
@@ -25,6 +25,13 @@ describe('kindToPlural', () => {
     expect(kindToPlural('NetworkPolicy')).toBe('networkpolicies')
   })
 
+  test('handles already-plural kind names (Endpoints)', () => {
+    // The Kind "Endpoints" IS its resource name; englishPlural would wrongly
+    // yield "endpointses" (ends in s → +es) without the builtin map entry.
+    expect(kindToPlural('Endpoints')).toBe('endpoints')
+    expect(pluralToKind('endpoints')).toBe('Endpoints')
+  })
+
   test('handles kinds ending in ss (Class-suffix)', () => {
     expect(kindToPlural('StorageClass')).toBe('storageclasses')
     expect(kindToPlural('IngressClass')).toBe('ingressclasses')

--- a/packages/k8s-ui/src/utils/navigation.ts
+++ b/packages/k8s-ui/src/utils/navigation.ts
@@ -11,6 +11,7 @@ export type NavigateToResource = (resource: SelectedResource) => void
 const BUILTIN_PLURAL_TO_KIND: Record<string, string> = {
   pods: 'Pod',
   services: 'Service',
+  endpoints: 'Endpoints', // already-plural resource name; englishPlural would yield "endpointses"
   deployments: 'Deployment',
   daemonsets: 'DaemonSet',
   statefulsets: 'StatefulSet',


### PR DESCRIPTION
## Problem

`kindToPlural('Endpoints')` returns `endpointses`. The Kind `Endpoints` is already plural (its resource name is `endpoints`), but it was missing from `BUILTIN_PLURAL_TO_KIND`, so `kindToPlural` fell through to `englishPlural`, which appends `-es` to anything ending in `s`.

With a discovered API-resource map (`initNavigationMap`) this is masked — the real plural wins. But consumers that pluralize **without** a discovery map hit the bug. Concretely: Radar Hub's cross-cluster fleet pages (Search/Issues) build per-cluster deep links from the singular kind while running outside any per-cluster `RadarApp`, so an `Endpoints` hit produced `/c/{id}/resources/endpointses?resource=…` — landing on an empty/wrong kind list with no error.

Surfaced by review of the fleet deep-link work (radar#781 / skyhook-dev/radar-hub-web#62).

## Fix

Add `endpoints: 'Endpoints'` to `BUILTIN_PLURAL_TO_KIND`. `kindToPlural` then returns it as-is via the idempotency check, and the `pluralToKind` inverse resolves correctly too. Regression test added (`navigation.test.ts`, 21 passing).

## Scope note
This is a static-table fix for the one already-plural **core** kind. Arbitrary dash-plural CRDs (e.g. `NetworkAttachmentDefinition` → `network-attachment-definitions`) can't be resolved client-side without per-cluster discovery — the correct fix there is the fleet backend returning the authoritative resource name, tracked separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 291f55eb9a0fdff55d7d9a6bea25ebebc5524b97. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->