### PR TITLE
Fix RBAC Permissions panel: grant + graceful degradation + chart drift guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,26 @@ jobs:
         run: npm run build
         working-directory: web
 
+  k8s-ui:
+    name: k8s-ui (shared UI)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+        working-directory: packages/k8s-ui
+
   helm:
     name: Helm chart
     runs-on: ubuntu-latest

--- a/deploy/helm/radar/README.md
+++ b/deploy/helm/radar/README.md
@@ -165,8 +165,9 @@ This overrides individual settings below. Simpler but broader — some orgs may 
 |--------|------------|
 | `argo` | `argoproj.io` |
 | `awx` | `awx.ansible.com` |
-| `certManager` | `cert-manager.io` |
-| `cloudnativePg` | `cloudnative-pg.io` |
+| `certManager` | `cert-manager.io`, `acme.cert-manager.io` |
+| `cilium` | `cilium.io` |
+| `cloudnativePg` | `postgresql.cnpg.io` |
 | `crossplane` | `crossplane.io`, `pkg.crossplane.io`, `apiextensions.crossplane.io`, `helm.crossplane.io`, `kubernetes.crossplane.io`. For Upbound provider groups (e.g. `s3.aws.upbound.io`, `compute.gcp.upbound.io`) use `additionalCrdGroups` — K8s RBAC has no apiGroup wildcards. |
 | `descheduler` | `descheduler.alpha.kubernetes.io` |
 | `envoyGateway` | `gateway.envoyproxy.io` |
@@ -177,13 +178,14 @@ This overrides individual settings below. Simpler but broader — some orgs may 
 | `gcpMonitoring` | `monitoring.googleapis.com` |
 | `grafana` | `monitoring.grafana.com`, `tempo.grafana.com`, `loki.grafana.com` |
 | `istio` | `networking.istio.io`, `security.istio.io` |
-| `karpenter` | `karpenter.sh`, `karpenter.k8s.aws`, `karpenter.azure.com`, `karpenter.gcp.compute.com` |
+| `karpenter` | `karpenter.sh`, `karpenter.k8s.aws`, `karpenter.azure.com`, `karpenter.k8s.gcp` |
 | `keda` | `keda.sh` |
 | `knative` | `serving.knative.dev`, `eventing.knative.dev`, `sources.knative.dev`, `messaging.knative.dev`, `flows.knative.dev`, `networking.internal.knative.dev` |
 | `kubeshark` | `kubeshark.io` |
 | `kured` | `kured.io` |
-| `kyverno` | `kyverno.io`, `wgpolicyk8s.io`, `reports.kyverno.io` |
+| `kyverno` | `kyverno.io`, `wgpolicyk8s.io`, `reports.kyverno.io`, `openreports.io` |
 | `mariadb` | `mariadb.mmontes.io` |
+| `networkPolicyApi` | `policy.networking.k8s.io` |
 | `nginx` | `nginx.org` |
 | `openshift` | `observability.openshift.io` |
 | `opentelemetry` | `opentelemetry.io` |

--- a/deploy/helm/radar/README.md
+++ b/deploy/helm/radar/README.md
@@ -168,6 +168,8 @@ This overrides individual settings below. Simpler but broader — some orgs may 
 | `certManager` | `cert-manager.io`, `acme.cert-manager.io` |
 | `cilium` | `cilium.io` |
 | `cloudnativePg` | `postgresql.cnpg.io` |
+| `clusterApi` | `cluster.x-k8s.io`, `infrastructure.cluster.x-k8s.io`, `controlplane.cluster.x-k8s.io`, `bootstrap.cluster.x-k8s.io`, `addons.cluster.x-k8s.io` |
+| `contour` | `projectcontour.io` |
 | `crossplane` | `crossplane.io`, `pkg.crossplane.io`, `apiextensions.crossplane.io`, `helm.crossplane.io`, `kubernetes.crossplane.io`. For Upbound provider groups (e.g. `s3.aws.upbound.io`, `compute.gcp.upbound.io`) use `additionalCrdGroups` — K8s RBAC has no apiGroup wildcards. |
 | `descheduler` | `descheduler.alpha.kubernetes.io` |
 | `envoyGateway` | `gateway.envoyproxy.io` |
@@ -176,7 +178,7 @@ This overrides individual settings below. Simpler but broader — some orgs may 
 | `flux` | `*.toolkit.fluxcd.io` |
 | `gatewayApi` | `gateway.networking.k8s.io` |
 | `gcpMonitoring` | `monitoring.googleapis.com` |
-| `grafana` | `monitoring.grafana.com`, `tempo.grafana.com`, `loki.grafana.com` |
+| `grafana` | `monitoring.grafana.com`, `tempo.grafana.com`, `loki.grafana.com`, `grafana.integreatly.org` |
 | `istio` | `networking.istio.io`, `security.istio.io` |
 | `karpenter` | `karpenter.sh`, `karpenter.k8s.aws`, `karpenter.azure.com`, `karpenter.k8s.gcp` |
 | `keda` | `keda.sh` |
@@ -196,7 +198,9 @@ This overrides individual settings below. Simpler but broader — some orgs may 
 | `strimzi` | `strimzi.io`, `kafka.strimzi.io` |
 | `tekton` | `tekton.dev` |
 | `traefik` | `traefik.io`, `traefik.containo.us` |
+| `trivy` | `aquasecurity.github.io` |
 | `velero` | `velero.io` |
+| `verticalPodAutoscaler` | `autoscaling.k8s.io` |
 
 **Disable groups:** `--set rbac.crdGroups.istio=false`
 

--- a/deploy/helm/radar/templates/clusterrole.yaml
+++ b/deploy/helm/radar/templates/clusterrole.yaml
@@ -69,6 +69,7 @@ rules:
   - apiGroups: ["networking.k8s.io"]
     resources:
       - ingresses
+      - ingressclasses
       - networkpolicies
     verbs: ["get", "list", "watch"]
 
@@ -91,11 +92,14 @@ rules:
       - selfsubjectaccessreviews
     verbs: ["create"]
 
-  {{- if .Values.rbac.viewRBAC }}
-  # RBAC objects: opt-in read for the resource browser. Off by default —
-  # cache-served reads are not gated by per-user RBAC, so granting this
-  # exposes the cluster's authorization graph to anyone who can reach
-  # Radar's API regardless of their own permissions.
+  {{- if or .Values.rbac.viewRBAC (ne .Values.auth.mode "none") .Values.cloud.enabled }}
+  # RBAC objects (read): powers the resource browser's RBAC views and the
+  # per-ServiceAccount "blast radius" Permissions panel on Pod/Workload pages.
+  # Auto-enabled when auth is on or in cloud mode — there, every RBAC read is
+  # re-checked against the requesting user's own permissions, so the shared
+  # informer cache cannot leak the cluster's authorization graph. For no-auth
+  # installs it stays opt-in via rbac.viewRBAC, since cache-served reads there
+  # are not gated per-user and would expose the graph to any viewer.
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources:
       - roles
@@ -174,12 +178,19 @@ rules:
     verbs: ["get", "list", "watch"]
   {{- end }}
   {{- if .Values.rbac.crdGroups.certManager }}
-  - apiGroups: ["cert-manager.io"]
+  # acme.cert-manager.io carries Orders + Challenges — the ACME issuance flow
+  # surfaced when diagnosing a stuck Certificate.
+  - apiGroups: ["cert-manager.io", "acme.cert-manager.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.cilium }}
+  - apiGroups: ["cilium.io"]
     resources: ["*"]
     verbs: ["get", "list", "watch"]
   {{- end }}
   {{- if .Values.rbac.crdGroups.cloudnativePg }}
-  - apiGroups: ["cloudnative-pg.io"]
+  - apiGroups: ["postgresql.cnpg.io"]
     resources: ["*"]
     verbs: ["get", "list", "watch"]
   {{- end }}
@@ -249,7 +260,7 @@ rules:
     verbs: ["get", "list", "watch"]
   {{- end }}
   {{- if .Values.rbac.crdGroups.karpenter }}
-  - apiGroups: ["karpenter.sh", "karpenter.k8s.aws", "karpenter.azure.com", "karpenter.gcp.compute.com"]
+  - apiGroups: ["karpenter.sh", "karpenter.k8s.aws", "karpenter.azure.com", "karpenter.k8s.gcp"]
     resources: ["*"]
     verbs: ["get", "list", "watch"]
   {{- end }}
@@ -280,6 +291,14 @@ rules:
   {{- end }}
   {{- if .Values.rbac.crdGroups.mariadb }}
   - apiGroups: ["mariadb.mmontes.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.networkPolicyApi }}
+  # SIG-network Network Policy API (out-of-tree CRDs): AdminNetworkPolicy +
+  # BaselineAdminNetworkPolicy (v1alpha1), merged into ClusterNetworkPolicy
+  # (v1alpha2). Cluster-scoped; surfaced in topology.
+  - apiGroups: ["policy.networking.k8s.io"]
     resources: ["*"]
     verbs: ["get", "list", "watch"]
   {{- end }}

--- a/deploy/helm/radar/templates/clusterrole.yaml
+++ b/deploy/helm/radar/templates/clusterrole.yaml
@@ -295,9 +295,8 @@ rules:
     verbs: ["get", "list", "watch"]
   {{- end }}
   {{- if .Values.rbac.crdGroups.networkPolicyApi }}
-  # SIG-network Network Policy API (out-of-tree CRDs): AdminNetworkPolicy +
-  # BaselineAdminNetworkPolicy (v1alpha1), merged into ClusterNetworkPolicy
-  # (v1alpha2). Cluster-scoped; surfaced in topology.
+  # SIG-network out-of-tree Network Policy API; ClusterNetworkPolicy is
+  # cluster-scoped and surfaced in topology.
   - apiGroups: ["policy.networking.k8s.io"]
     resources: ["*"]
     verbs: ["get", "list", "watch"]

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -66,10 +66,14 @@ rbac:
   secrets: false
 
   # Allow reading RBAC objects (Roles, RoleBindings, ClusterRoles, ClusterRoleBindings)
-  # so the resource browser can list them. Off by default: anyone reaching Radar's
-  # API sees the full RBAC graph through the shared informer cache regardless of
-  # their own K8s permissions, which is reconnaissance value for a low-trust user.
-  # Enable for clusters where Radar's audience is trusted with cluster RBAC visibility.
+  # so the resource browser can list them and the per-ServiceAccount "blast radius"
+  # Permissions panel can render. Auto-enabled when auth is on (auth.mode != none)
+  # or in cloud mode, where every RBAC read is re-checked against the requesting
+  # user's own permissions so the shared cache can't leak the authorization graph.
+  # This flag therefore only matters for no-auth installs: there, cache-served reads
+  # aren't gated per-user, so anyone reaching Radar's API would see the full RBAC
+  # graph — reconnaissance value for a low-trust user. Enable only if that audience
+  # is trusted with cluster RBAC visibility.
   viewRBAC: false
 
   # Allow pod exec (enables terminal feature)
@@ -109,8 +113,9 @@ rbac:
 
     argo: true              # argoproj.io
     awx: true               # awx.ansible.com
-    certManager: true       # cert-manager.io
-    cloudnativePg: true     # cloudnative-pg.io
+    certManager: true       # cert-manager.io, acme.cert-manager.io
+    cilium: true            # cilium.io (CiliumClusterwideNetworkPolicy etc. in topology)
+    cloudnativePg: true     # postgresql.cnpg.io (CloudNativePG: Clusters, Poolers, Backups)
     clusterApi: true        # *.cluster.x-k8s.io (CAPI core + infrastructure / controlplane / bootstrap / addons)
     contour: true           # projectcontour.io
     crossplane: true        # crossplane.io, pkg.crossplane.io, apiextensions.crossplane.io, helm.crossplane.io, kubernetes.crossplane.io. For Upbound provider CRDs (s3.aws.upbound.io, compute.gcp.upbound.io, etc.) list them in additionalCrdGroups — K8s RBAC has no apiGroup wildcards.
@@ -123,13 +128,14 @@ rbac:
     gcpMonitoring: true     # monitoring.googleapis.com
     grafana: true           # monitoring.grafana.com, tempo/loki/grafana.integreatly.org
     istio: true             # networking.istio.io, security.istio.io
-    karpenter: true         # karpenter.sh, karpenter.k8s.aws, karpenter.azure.com, karpenter.gcp.compute.com
+    karpenter: true         # karpenter.sh, karpenter.k8s.aws, karpenter.azure.com, karpenter.k8s.gcp
     keda: true              # keda.sh
     knative: true           # serving.knative.dev, eventing.knative.dev, sources/messaging/flows/networking.internal.knative.dev
     kubeshark: true         # kubeshark.io
     kured: true             # kured.io
     kyverno: true           # kyverno.io, wgpolicyk8s.io, reports.kyverno.io
     mariadb: true           # mariadb.mmontes.io
+    networkPolicyApi: true  # policy.networking.k8s.io (Admin/Baseline/ClusterNetworkPolicy — SIG-network)
     nginx: true             # nginx.org
     openshift: true         # observability.openshift.io
     opentelemetry: true     # opentelemetry.io

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -133,7 +133,7 @@ rbac:
     knative: true           # serving.knative.dev, eventing.knative.dev, sources/messaging/flows/networking.internal.knative.dev
     kubeshark: true         # kubeshark.io
     kured: true             # kured.io
-    kyverno: true           # kyverno.io, wgpolicyk8s.io, reports.kyverno.io
+    kyverno: true           # kyverno.io, wgpolicyk8s.io, reports.kyverno.io, openreports.io
     mariadb: true           # mariadb.mmontes.io
     networkPolicyApi: true  # policy.networking.k8s.io (Admin/Baseline/ClusterNetworkPolicy — SIG-network)
     nginx: true             # nginx.org

--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -176,7 +176,7 @@ rbac:
     certManager: true   # cert-manager.io
     flux: true          # *.toolkit.fluxcd.io
     istio: true         # networking.istio.io, security.istio.io
-    karpenter: true     # karpenter.sh, karpenter.k8s.aws, karpenter.azure.com, karpenter.gcp.compute.com
+    karpenter: true     # karpenter.sh, karpenter.k8s.aws, karpenter.azure.com, karpenter.k8s.gcp
     keda: true          # keda.sh
     knative: true       # serving, eventing, sources, messaging, flows, networking.internal (.knative.dev)
     prometheus: true    # monitoring.coreos.com

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -59,7 +59,7 @@ Radar automatically discovers and displays **any** Custom Resource Definition (C
 | NodeClaim | `karpenter.sh/v1` | Yes | Yes | Yes |
 | EC2NodeClass | `karpenter.k8s.aws/v1` | Yes | Yes | Yes |
 | AKSNodeClass | `karpenter.azure.com/v1alpha2` | Yes | Generic | Yes |
-| GCPNodeClass | `karpenter.gcp.compute.com/v1alpha1` | Yes | Generic | Yes |
+| GCENodeClass | `karpenter.k8s.gcp/v1alpha1` | Yes | Generic | Yes |
 
 All provider-specific NodeClass variants are automatically detected and supported.
 

--- a/internal/k8s/chart_rbac_coverage_test.go
+++ b/internal/k8s/chart_rbac_coverage_test.go
@@ -10,14 +10,12 @@ import (
 	"github.com/skyhook-io/radar/pkg/topology"
 )
 
-// TestChartGrantsEveryWatchedCRDGroup guards against the recurring drift where
-// Radar watches an API group the Helm chart never grants. That failure is
-// silent: the informer's list call 403s, the reflector backs off, and the
-// resource simply never appears in the UI — no error, no log most operators
-// would notice. It has bitten us repeatedly (CloudNativePG's dead
-// "cloudnative-pg.io" group, the missing "acme.cert-manager.io", the
-// "karpenter.gcp.compute.com" typo), because the (group, resource, kind) tuples
-// live in several independent places that must agree and nothing enforced it.
+// TestChartGrantsEveryWatchedCRDGroup guards against the drift where Radar
+// watches an API group the Helm chart never grants. That failure is silent: the
+// informer's list call 403s, the reflector backs off, and the resource simply
+// never appears in the UI — no error, no log most operators would notice. The
+// drift recurs because the (group, resource, kind) tuples live in several
+// independent places that must agree and nothing else cross-checks them.
 //
 // Scope: GROUP-level coverage for the CRD / extension watch lists
 // (supportedCRDFallbacks + topology.ClusterScopedKinds), which is exactly where

--- a/internal/k8s/chart_rbac_coverage_test.go
+++ b/internal/k8s/chart_rbac_coverage_test.go
@@ -1,0 +1,100 @@
+package k8s
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/skyhook-io/radar/pkg/topology"
+)
+
+// TestChartGrantsEveryWatchedCRDGroup guards against the recurring drift where
+// Radar watches an API group the Helm chart never grants. That failure is
+// silent: the informer's list call 403s, the reflector backs off, and the
+// resource simply never appears in the UI — no error, no log most operators
+// would notice. It has bitten us repeatedly (CloudNativePG's dead
+// "cloudnative-pg.io" group, the missing "acme.cert-manager.io", the
+// "karpenter.gcp.compute.com" typo), because the (group, resource, kind) tuples
+// live in several independent places that must agree and nothing enforced it.
+//
+// Scope: GROUP-level coverage for the CRD / extension watch lists
+// (supportedCRDFallbacks + topology.ClusterScopedKinds), which is exactly where
+// the drift happens. It deliberately does NOT verify resource-level grants
+// inside core/typed groups (e.g. ingressclasses under networking.k8s.io) —
+// those rules enumerate resources explicitly on a small, stable surface.
+//
+// Opt-in wildcard rules (rbac.helm, rbac.crdGroups.all) are ignored: they're
+// off by default, so the guard insists every watched group has its own explicit
+// per-group rule rather than leaning on a broad wildcard a deployment may not enable.
+func TestChartGrantsEveryWatchedCRDGroup(t *testing.T) {
+	granted := chartGrantedAPIGroups(t)
+
+	// group -> a human-readable pointer to where Radar watches it, for the failure message.
+	watched := map[string]string{}
+	for _, c := range supportedCRDFallbacks {
+		if c.Group != "" {
+			watched[c.Group] = "supportedCRDFallbacks (internal/k8s/dynamic_cache.go)"
+		}
+	}
+	for _, e := range topology.ClusterScopedKinds {
+		if e.Group != "" {
+			watched[e.Group] = "topology.ClusterScopedKinds (pkg/topology/cluster_scoped_kinds.go)"
+		}
+	}
+
+	for group, source := range watched {
+		if !granted[group] {
+			t.Errorf("API group %q is watched by Radar (%s) but no rule in "+
+				"deploy/helm/radar/templates/clusterrole.yaml grants it. The informer "+
+				"will 403 and the resource will silently never appear. Add a per-group "+
+				"rule (and values.yaml toggle) granting get/list/watch on %q.",
+				group, source, group)
+		}
+	}
+}
+
+// chartGrantedAPIGroups extracts the set of API groups the ClusterRole template
+// can grant. It walks the raw template rather than rendering it (the file is Helm,
+// not valid YAML), skipping comments and {{ }} directives so groups named in prose
+// don't count, and reading both inline (apiGroups: ["a","b"]) and block-style
+// (apiGroups:\n  - "a") rules. Conditional per-group rules are counted as granted
+// because their toggles default to true; the wildcard "*" is excluded on purpose.
+func chartGrantedAPIGroups(t *testing.T) map[string]bool {
+	t.Helper()
+	path := filepath.Join("..", "..", "deploy", "helm", "radar", "templates", "clusterrole.yaml")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read chart ClusterRole template: %v", err)
+	}
+
+	quoted := regexp.MustCompile(`"([^"]*)"`)
+	add := func(set map[string]bool, line string) {
+		for _, m := range quoted.FindAllStringSubmatch(line, -1) {
+			if m[1] != "*" {
+				set[m[1]] = true
+			}
+		}
+	}
+
+	groups := map[string]bool{}
+	inAPIGroups := false
+	for line := range strings.SplitSeq(string(raw), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "{{") {
+			continue // preserve inAPIGroups across comments / template directives
+		}
+		switch {
+		case strings.Contains(trimmed, "apiGroups:"):
+			add(groups, trimmed)
+			// Inline arrays close on the same line; block style spills onto "- " items.
+			inAPIGroups = !strings.Contains(trimmed, "]")
+		case inAPIGroups && strings.HasPrefix(trimmed, "- "):
+			add(groups, trimmed)
+		default:
+			inAPIGroups = false
+		}
+	}
+	return groups
+}

--- a/internal/k8s/dynamic_cache.go
+++ b/internal/k8s/dynamic_cache.go
@@ -170,7 +170,7 @@ var supportedCRDFallbacks = []supportedCRDResource{
 	{Group: "karpenter.sh", Versions: []string{"v1", "v1beta1"}, Resource: "nodeclaims", Kind: "NodeClaim", Namespaced: false},
 	{Group: "karpenter.k8s.aws", Versions: []string{"v1", "v1beta1"}, Resource: "ec2nodeclasses", Kind: "EC2NodeClass", Namespaced: false},
 	{Group: "karpenter.azure.com", Versions: []string{"v1alpha2", "v1alpha1"}, Resource: "aksnodeclasses", Kind: "AKSNodeClass", Namespaced: false},
-	{Group: "karpenter.gcp.compute.com", Versions: []string{"v1alpha1"}, Resource: "gcpnodeclasses", Kind: "GCPNodeClass", Namespaced: false},
+	{Group: "karpenter.k8s.gcp", Versions: []string{"v1alpha1"}, Resource: "gcenodeclasses", Kind: "GCENodeClass", Namespaced: false},
 	{Group: "keda.sh", Versions: []string{"v1alpha1"}, Resource: "scaledobjects", Kind: "ScaledObject", Namespaced: true},
 	{Group: "keda.sh", Versions: []string{"v1alpha1"}, Resource: "scaledjobs", Kind: "ScaledJob", Namespaced: true},
 	{Group: "keda.sh", Versions: []string{"v1alpha1"}, Resource: "triggerauthentications", Kind: "TriggerAuthentication", Namespaced: true},

--- a/internal/mcp/tools_neighborhood.go
+++ b/internal/mcp/tools_neighborhood.go
@@ -53,7 +53,7 @@ func handleGetNeighborhood(ctx context.Context, req *mcp.CallToolRequest, input 
 
 	// RBAC for the root. Topology pseudo-kinds (NodeClass, NodePool, NodeClaim,
 	// …) FIRST: ClassifyKindScope doesn't recognize them ("nodeclass" isn't a
-	// real K8s kind — the variants are EC2NodeClass / AKSNodeClass / GCPNodeClass).
+	// real K8s kind — the variants are EC2NodeClass / AKSNodeClass / GCENodeClass).
 	// Without this branch we fall into the namespaced arm below and reject as
 	// "namespace is required" even though the agent sees these kinds in
 	// get_topology output. topology.RBACTuplesForKind returns the per-variant

--- a/internal/mcp/tools_neighborhood_test.go
+++ b/internal/mcp/tools_neighborhood_test.go
@@ -100,7 +100,7 @@ func TestCanReadNeighborhoodNodeMCP_NoAuthPassthrough(t *testing.T) {
 
 // makeNodeClassNode builds a topology pseudo-kind NodeClass node. The Kind is
 // the synthesized topology label ("NodeClass"), not a real K8s resource — the
-// actual variants are EC2NodeClass / AKSNodeClass / GCPNodeClass.
+// actual variants are EC2NodeClass / AKSNodeClass / GCENodeClass.
 func makeNodeClassNode(name string) *topology.Node {
 	return &topology.Node{
 		ID:     "nodeclass/" + name,
@@ -140,7 +140,7 @@ func TestCanReadNeighborhoodNodeMCP_NodeClassDeniedWithoutSAR(t *testing.T) {
 	// — the discovery filter is skip-when-missing).
 	perms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", false)
 	perms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
-	perms.SetCanI("get", "karpenter.k8s.gcp", "gcpnodeclasses", "", false)
+	perms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
 
 	n := makeNodeClassNode("default-class")
 	if canReadNeighborhoodNodeMCP(ctx, n) {
@@ -157,7 +157,7 @@ func TestCanReadNeighborhoodNodeMCP_NodeClassAllowedWithProviderSAR(t *testing.T
 	// Bob has EC2 access only — should still pass for NodeClass.
 	perms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", true)
 	perms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
-	perms.SetCanI("get", "karpenter.k8s.gcp", "gcpnodeclasses", "", false)
+	perms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
 
 	n := makeNodeClassNode("default-class")
 	if !canReadNeighborhoodNodeMCP(ctx, n) {
@@ -173,7 +173,7 @@ func TestCanReadNeighborhoodNodeMCP_NodeClassPerVariantDeniesWrongProvider(t *te
 	perms := getPermCache().Get("bob")
 	perms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", true)
 	perms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
-	perms.SetCanI("get", "karpenter.k8s.gcp", "gcpnodeclasses", "", false)
+	perms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
 
 	aks := &topology.Node{
 		ID:     "nodeclass/aks-default",
@@ -234,7 +234,7 @@ func TestAllowPseudoKindTuplesMCP_NodeClass_DeniedWithoutSAR(t *testing.T) {
 	perms := getPermCache().Get("alice")
 	perms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", false)
 	perms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
-	perms.SetCanI("get", "karpenter.k8s.gcp", "gcpnodeclasses", "", false)
+	perms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
 
 	tuples, fallthroughAllow := pseudoKindTuplesForTestMCP("nodeclass", "")
 	if len(tuples) == 0 {
@@ -251,7 +251,7 @@ func TestAllowPseudoKindTuplesMCP_NodeClass_AllowedWithProviderSAR(t *testing.T)
 	// EC2 only — single-provider grant must be enough for the kind-level gate.
 	perms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", true)
 	perms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
-	perms.SetCanI("get", "karpenter.k8s.gcp", "gcpnodeclasses", "", false)
+	perms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
 
 	tuples, fallthroughAllow := pseudoKindTuplesForTestMCP("nodeclass", "")
 	if !allowPseudoKindTuplesMCP(ctx, tuples, fallthroughAllow) {
@@ -279,7 +279,7 @@ func TestHandleGetNeighborhoodMCP_NodeClassRootNotNamespaceRequired(t *testing.T
 	denyPerms := getPermCache().Get("alice")
 	denyPerms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", false)
 	denyPerms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
-	denyPerms.SetCanI("get", "karpenter.k8s.gcp", "gcpnodeclasses", "", false)
+	denyPerms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
 	_, _, err := handleGetNeighborhood(ctxDeny, nil, getNeighborhoodInput{
 		Kind: "nodeclass",
 		Name: "foo",
@@ -299,7 +299,7 @@ func TestHandleGetNeighborhoodMCP_NodeClassRootNotNamespaceRequired(t *testing.T
 	allowPerms := getPermCache().Get("bob")
 	allowPerms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", true)
 	allowPerms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
-	allowPerms.SetCanI("get", "karpenter.k8s.gcp", "gcpnodeclasses", "", false)
+	allowPerms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
 	_, _, err2 := handleGetNeighborhood(ctxAllow, nil, getNeighborhoodInput{
 		Kind: "nodeclass",
 		Name: "foo",

--- a/internal/server/neighborhood_handler.go
+++ b/internal/server/neighborhood_handler.go
@@ -62,7 +62,7 @@ func (s *Server) handleAINeighborhood(w http.ResponseWriter, r *http.Request) {
 	// Topology pseudo-kinds (NodeClass, NodePool, NodeClaim, …) FIRST: these
 	// are synthesized labels that ClassifyKindScope doesn't recognize ("nodeclass"
 	// isn't a real K8s kind — the variants are EC2NodeClass / AKSNodeClass /
-	// GCPNodeClass). Without this branch the call falls into the namespaced
+	// GCENodeClass). Without this branch the call falls into the namespaced
 	// arm below and 400s with "namespace is required" even though "_" was
 	// supplied (URL → namespace == ""). topology.RBACTuplesForKind returns the
 	// per-variant SAR tuples — we iterate through s.canRead and allow on any

--- a/internal/server/neighborhood_rbac_test.go
+++ b/internal/server/neighborhood_rbac_test.go
@@ -104,7 +104,7 @@ func TestCanReadNeighborhoodNode_ConfigMapStaysOnNamespaceGate(t *testing.T) {
 
 // makeNodeClassNode builds a topology pseudo-kind NodeClass node. The Kind is
 // the synthesized topology label ("NodeClass"), not a real K8s resource — the
-// actual variants are EC2NodeClass / AKSNodeClass / GCPNodeClass.
+// actual variants are EC2NodeClass / AKSNodeClass / GCENodeClass.
 func makeNodeClassNode(name string) *topology.Node {
 	return &topology.Node{
 		ID:     "nodeclass/" + name,
@@ -145,7 +145,7 @@ func TestCanReadNeighborhoodNode_NodeClassDeniedWithoutSAR(t *testing.T) {
 	// disc=nil in tests → no entries filtered out → all 3 SARs run.
 	perms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", false)
 	perms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
-	perms.SetCanI("get", "karpenter.k8s.gcp", "gcpnodeclasses", "", false)
+	perms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
 	s.permCache.Set("alice", perms)
 
 	r := requestWithUser("GET", "/api/ai/neighborhood/nodeclass/_/x", &auth.User{Username: "alice"})
@@ -164,7 +164,7 @@ func TestCanReadNeighborhoodNode_NodeClassAllowedWithProviderSAR(t *testing.T) {
 	// Bob has EC2 access only — should still pass for NodeClass.
 	perms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", true)
 	perms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
-	perms.SetCanI("get", "karpenter.k8s.gcp", "gcpnodeclasses", "", false)
+	perms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
 	s.permCache.Set("bob", perms)
 
 	r := requestWithUser("GET", "/api/ai/neighborhood/nodeclass/_/x", &auth.User{Username: "bob"})
@@ -190,7 +190,7 @@ func TestCanReadNeighborhoodNode_NodeClassPerVariantDeniesWrongProvider(t *testi
 	perms := &auth.UserPermissions{AllowedNamespaces: nil}
 	perms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", true)
 	perms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
-	perms.SetCanI("get", "karpenter.k8s.gcp", "gcpnodeclasses", "", false)
+	perms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
 	s.permCache.Set("bob", perms)
 
 	r := requestWithUser("GET", "/api/ai/neighborhood/nodeclass/_/x", &auth.User{Username: "bob"})
@@ -267,7 +267,7 @@ func TestAllowPseudoKindTuples_NodeClass_DeniedWithoutSAR(t *testing.T) {
 	perms := &auth.UserPermissions{AllowedNamespaces: nil}
 	perms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", false)
 	perms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
-	perms.SetCanI("get", "karpenter.k8s.gcp", "gcpnodeclasses", "", false)
+	perms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
 	s.permCache.Set("alice", perms)
 
 	r := requestWithUser("GET", "/api/ai/neighborhood/nodeclass/_/x", &auth.User{Username: "alice"})
@@ -289,7 +289,7 @@ func TestAllowPseudoKindTuples_NodeClass_AllowedWithProviderSAR(t *testing.T) {
 	// grant is sufficient for the kind-level gate.
 	perms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", true)
 	perms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
-	perms.SetCanI("get", "karpenter.k8s.gcp", "gcpnodeclasses", "", false)
+	perms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
 	s.permCache.Set("bob", perms)
 
 	r := requestWithUser("GET", "/api/ai/neighborhood/nodeclass/_/x", &auth.User{Username: "bob"})
@@ -343,7 +343,7 @@ func TestNeighborhood_NodeClassRootPreflightNotBadRequest(t *testing.T) {
 	denyPerms := &auth.UserPermissions{AllowedNamespaces: nil}
 	denyPerms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", false)
 	denyPerms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
-	denyPerms.SetCanI("get", "karpenter.k8s.gcp", "gcpnodeclasses", "", false)
+	denyPerms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
 	env.srv.permCache.Set("alice", denyPerms)
 
 	resp := env.authGet(t, "/api/ai/neighborhood/nodeclass/_/foo", "alice", "")
@@ -360,7 +360,7 @@ func TestNeighborhood_NodeClassRootPreflightNotBadRequest(t *testing.T) {
 	allowPerms := &auth.UserPermissions{AllowedNamespaces: nil}
 	allowPerms.SetCanI("get", "karpenter.k8s.aws", "ec2nodeclasses", "", true)
 	allowPerms.SetCanI("get", "karpenter.azure.com", "aksnodeclasses", "", false)
-	allowPerms.SetCanI("get", "karpenter.k8s.gcp", "gcpnodeclasses", "", false)
+	allowPerms.SetCanI("get", "karpenter.k8s.gcp", "gcenodeclasses", "", false)
 	env.srv.permCache.Set("bob", allowPerms)
 
 	resp2 := env.authGet(t, "/api/ai/neighborhood/nodeclass/_/foo", "bob", "")

--- a/packages/k8s-ui/src/components/resources/renderers/NamespaceRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/NamespaceRenderer.tsx
@@ -3,6 +3,7 @@ import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ResourceLink } from '../../ui/drawer-components'
 import type { RBACNamespaceResponse, RBACBindingWithSubjects, RBACSubject, ResourceRef } from '../../../types'
 import { rbacKindBadgeClass } from '../../../utils/rbac-badges'
+import { RBACErrorSection } from './RBACErrorSection'
 import { SEVERITY_TEXT, SEVERITY_DOT } from '../../../utils/badge-colors'
 import { parseCPUToNanocores, parseMemoryToBytes } from '../../../utils/format'
 
@@ -197,11 +198,7 @@ function NamespaceRBACSection({
     )
   }
   if (error) {
-    return (
-      <Section title="RBAC" icon={Shield}>
-        <div className="text-sm text-red-400">Could not load RBAC summary: {error.message}</div>
-      </Section>
-    )
+    return <RBACErrorSection title="RBAC" error={error} errorPrefix="Could not load RBAC summary" />
   }
   if (!rbacData) return null
 

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
@@ -10,7 +10,7 @@ import {
   rbacApiGroupBadgeClass,
 } from '../../../utils/rbac-badges'
 import { detectBlastRadius, rulePermissivenessScore } from '../../../utils/rbac-blast-radius'
-import { RBACErrorSection } from './RBACErrorSection'
+import { RBACErrorSection, isRBACUnavailable } from './RBACErrorSection'
 import type { ResolvedEnvFrom, RBACSubjectResponse, RBACPolicyRule } from '../../../types'
 import { Tooltip } from '../../ui/Tooltip'
 import { MetricsChart } from '../../ui/MetricsChart'
@@ -878,6 +878,10 @@ function PodPermissionsSection({
     )
   }
   if (error) {
+    // Permissions is a bonus section here; when RBAC is simply not available
+    // (cluster-static) or forbidden, hide it rather than repeat a note on every
+    // Pod. Genuine faults still surface.
+    if (isRBACUnavailable(error)) return null
     return <RBACErrorSection title={title} error={error} />
   }
   if (!rbacData) return null

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
@@ -10,6 +10,7 @@ import {
   rbacApiGroupBadgeClass,
 } from '../../../utils/rbac-badges'
 import { detectBlastRadius, rulePermissivenessScore } from '../../../utils/rbac-blast-radius'
+import { RBACErrorSection } from './RBACErrorSection'
 import type { ResolvedEnvFrom, RBACSubjectResponse, RBACPolicyRule } from '../../../types'
 import { Tooltip } from '../../ui/Tooltip'
 import { MetricsChart } from '../../ui/MetricsChart'
@@ -877,13 +878,7 @@ function PodPermissionsSection({
     )
   }
   if (error) {
-    return (
-      <Section title={title} icon={Shield}>
-        <div className="text-sm text-red-400">
-          Could not load permissions: {error.message}
-        </div>
-      </Section>
-    )
+    return <RBACErrorSection title={title} error={error} />
   }
   if (!rbacData) return null
 

--- a/packages/k8s-ui/src/components/resources/renderers/RBACErrorSection.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/RBACErrorSection.test.tsx
@@ -15,6 +15,14 @@ describe('RBACErrorSection', () => {
     expect(html).not.toContain('text-red-400')
   })
 
+  it('renders a non-RBAC 503 (e.g. cluster disconnect) in red, not the calm RBAC note', () => {
+    const html = renderToString(
+      <RBACErrorSection title="Permissions" error={err('Not connected to cluster', 503)} />,
+    )
+    expect(html).toContain('text-red-400')
+    expect(html).not.toContain('RBAC visibility')
+  })
+
   it('renders 403 (viewer lacks permission) as a calm note, not a red error', () => {
     const html = renderToString(
       <RBACErrorSection title="Permissions" error={err('forbidden', 403)} />,

--- a/packages/k8s-ui/src/components/resources/renderers/RBACErrorSection.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/RBACErrorSection.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import { RBACErrorSection } from './RBACErrorSection'
+
+function err(message: string, status?: number): Error {
+  return Object.assign(new Error(message), status === undefined ? {} : { status })
+}
+
+describe('RBACErrorSection', () => {
+  it('renders 503 (SA cannot read RBAC) as a calm note, not a red error', () => {
+    const html = renderToString(
+      <RBACErrorSection title="Permissions" error={err('RBAC cache not available', 503)} />,
+    )
+    expect(html).toContain('RBAC visibility')
+    expect(html).not.toContain('text-red-400')
+  })
+
+  it('renders 403 (viewer lacks permission) as a calm note, not a red error', () => {
+    const html = renderToString(
+      <RBACErrorSection title="Permissions" error={err('forbidden', 403)} />,
+    )
+    expect(html).toContain('permission to view RBAC bindings')
+    expect(html).not.toContain('text-red-400')
+  })
+
+  it('renders genuine failures (500 / no status) in red with the prefix', () => {
+    const html = renderToString(
+      <RBACErrorSection title="Permissions" error={err('boom', 500)} />,
+    )
+    expect(html).toContain('text-red-400')
+    expect(html).toContain('Could not load permissions')
+    expect(html).toContain('boom')
+  })
+
+  it('honors a custom errorPrefix for genuine failures', () => {
+    const html = renderToString(
+      <RBACErrorSection title="Bindings" error={err('boom')} errorPrefix="Could not load RBAC data" />,
+    )
+    expect(html).toContain('Could not load RBAC data')
+  })
+})

--- a/packages/k8s-ui/src/components/resources/renderers/RBACErrorSection.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/RBACErrorSection.test.tsx
@@ -1,10 +1,23 @@
 import { describe, expect, it } from 'vitest'
 import { renderToString } from 'react-dom/server'
-import { RBACErrorSection } from './RBACErrorSection'
+import { RBACErrorSection, isRBACUnavailable } from './RBACErrorSection'
 
 function err(message: string, status?: number): Error {
   return Object.assign(new Error(message), status === undefined ? {} : { status })
 }
+
+describe('isRBACUnavailable', () => {
+  it('is true for the RBAC-cache 503 and any 403 (expected, non-actionable)', () => {
+    expect(isRBACUnavailable(err('RBAC cache not available', 503))).toBe(true)
+    expect(isRBACUnavailable(err('forbidden', 403))).toBe(true)
+  })
+
+  it('is false for genuine faults so they still surface', () => {
+    expect(isRBACUnavailable(err('Not connected to cluster', 503))).toBe(false)
+    expect(isRBACUnavailable(err('boom', 500))).toBe(false)
+    expect(isRBACUnavailable(err('Failed to fetch'))).toBe(false)
+  })
+})
 
 describe('RBACErrorSection', () => {
   it('renders 503 (SA cannot read RBAC) as a calm note, not a red error', () => {

--- a/packages/k8s-ui/src/components/resources/renderers/RBACErrorSection.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/RBACErrorSection.tsx
@@ -13,6 +13,17 @@ interface RBACErrorSectionProps {
   errorPrefix?: string
 }
 
+// True for the two expected, non-actionable RBAC states: 503 because Radar's SA
+// can't read RBAC (so the informers never synced — cluster-static, same on every
+// resource), and 403 because the viewer lacks list permission. Surfaces that treat
+// the RBAC section as a bonus (Pod/Workload Permissions) hide it entirely for these.
+// Genuine faults — connectivity 503, 500, network errors — are deliberately NOT
+// included, so they still surface rather than being silently dropped.
+export function isRBACUnavailable(error: Error): boolean {
+  const status = (error as { status?: number }).status
+  return status === 403 || (status === 503 && error.message.includes('RBAC cache'))
+}
+
 // RBAC reverse-lookup fails for two expected, non-alarming reasons that should
 // not render as red errors:
 //   503 with an "RBAC cache not available" message — the identity Radar connects

--- a/packages/k8s-ui/src/components/resources/renderers/RBACErrorSection.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/RBACErrorSection.tsx
@@ -1,0 +1,51 @@
+import { Shield } from 'lucide-react'
+import { Section } from '../../ui/drawer-components'
+
+interface RBACErrorSectionProps {
+  title: string
+  error: Error
+  // Prefix for the genuine-error line; copy differs slightly across renderers
+  // ("permissions" on Pod/Workload, "RBAC data" on ServiceAccount).
+  errorPrefix?: string
+}
+
+// RBAC reverse-lookup fails for two expected, non-alarming reasons that should
+// not render as red errors:
+//   503 — the identity Radar connects with can't read RBAC, so the informers
+//         never synced (feature not granted). A config state, not a failure.
+//   403 — the requesting user lacks list permission on bindings.
+// Reserve the red treatment for genuine failures (network / 500).
+export function RBACErrorSection({
+  title,
+  error,
+  errorPrefix = 'Could not load permissions',
+}: RBACErrorSectionProps) {
+  const status = (error as { status?: number }).status
+
+  if (status === 503) {
+    return (
+      <Section title={title} icon={Shield}>
+        <div className="text-sm text-theme-text-tertiary">
+          RBAC visibility isn’t available — the identity Radar connects with can’t read
+          RBAC resources in this cluster.
+        </div>
+      </Section>
+    )
+  }
+  if (status === 403) {
+    return (
+      <Section title={title} icon={Shield}>
+        <div className="text-sm text-theme-text-tertiary">
+          You don’t have permission to view RBAC bindings here.
+        </div>
+      </Section>
+    )
+  }
+  return (
+    <Section title={title} icon={Shield}>
+      <div className="text-sm text-red-400">
+        {errorPrefix}: {error.message}
+      </div>
+    </Section>
+  )
+}

--- a/packages/k8s-ui/src/components/resources/renderers/RBACErrorSection.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/RBACErrorSection.tsx
@@ -1,9 +1,13 @@
 import { Shield } from 'lucide-react'
+import type { ComponentType } from 'react'
 import { Section } from '../../ui/drawer-components'
 
 interface RBACErrorSectionProps {
   title: string
   error: Error
+  // Matches the icon of the section's success/loading state (Shield for most,
+  // Users for the Role bindings section) so the error state isn't jarring.
+  icon?: ComponentType<{ className?: string }>
   // Prefix for the genuine-error line; copy differs slightly across renderers
   // ("permissions" on Pod/Workload, "RBAC data" on ServiceAccount).
   errorPrefix?: string
@@ -18,13 +22,14 @@ interface RBACErrorSectionProps {
 export function RBACErrorSection({
   title,
   error,
+  icon = Shield,
   errorPrefix = 'Could not load permissions',
 }: RBACErrorSectionProps) {
   const status = (error as { status?: number }).status
 
   if (status === 503) {
     return (
-      <Section title={title} icon={Shield}>
+      <Section title={title} icon={icon}>
         <div className="text-sm text-theme-text-tertiary">
           RBAC visibility isn’t available — the identity Radar connects with can’t read
           RBAC resources in this cluster.
@@ -34,7 +39,7 @@ export function RBACErrorSection({
   }
   if (status === 403) {
     return (
-      <Section title={title} icon={Shield}>
+      <Section title={title} icon={icon}>
         <div className="text-sm text-theme-text-tertiary">
           You don’t have permission to view RBAC bindings here.
         </div>
@@ -42,7 +47,7 @@ export function RBACErrorSection({
     )
   }
   return (
-    <Section title={title} icon={Shield}>
+    <Section title={title} icon={icon}>
       <div className="text-sm text-red-400">
         {errorPrefix}: {error.message}
       </div>

--- a/packages/k8s-ui/src/components/resources/renderers/RBACErrorSection.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/RBACErrorSection.tsx
@@ -15,10 +15,13 @@ interface RBACErrorSectionProps {
 
 // RBAC reverse-lookup fails for two expected, non-alarming reasons that should
 // not render as red errors:
-//   503 — the identity Radar connects with can't read RBAC, so the informers
-//         never synced (feature not granted). A config state, not a failure.
+//   503 with an "RBAC cache not available" message — the identity Radar connects
+//         with can't read RBAC, so the informers never synced (feature not
+//         granted). A config state, not a failure. (A generic connectivity 503,
+//         "Not connected to cluster", is a real fault and must NOT be downplayed
+//         as an RBAC-grant problem — it falls through to the red branch.)
 //   403 — the requesting user lacks list permission on bindings.
-// Reserve the red treatment for genuine failures (network / 500).
+// Reserve the red treatment for genuine failures (connectivity / network / 500).
 export function RBACErrorSection({
   title,
   error,
@@ -27,7 +30,7 @@ export function RBACErrorSection({
 }: RBACErrorSectionProps) {
   const status = (error as { status?: number }).status
 
-  if (status === 503) {
+  if (status === 503 && error.message.includes('RBAC cache')) {
     return (
       <Section title={title} icon={icon}>
         <div className="text-sm text-theme-text-tertiary">

--- a/packages/k8s-ui/src/components/resources/renderers/RBACErrorSection.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/RBACErrorSection.tsx
@@ -13,35 +13,37 @@ interface RBACErrorSectionProps {
   errorPrefix?: string
 }
 
-// True for the two expected, non-actionable RBAC states: 503 because Radar's SA
-// can't read RBAC (so the informers never synced — cluster-static, same on every
-// resource), and 403 because the viewer lacks list permission. Surfaces that treat
+const errorStatus = (error: Error): number | undefined => (error as { status?: number }).status
+
+// 503 because Radar's SA can't read RBAC, so the informers never synced — a
+// cluster-static config state (same on every resource), not a failure. The message
+// check distinguishes it from a generic connectivity 503 ("Not connected to
+// cluster"), which is a real fault and must stay loud (red).
+const isRBACCacheUnavailable = (error: Error): boolean =>
+  errorStatus(error) === 503 && error.message.includes('RBAC cache')
+
+// 403 because the requesting user lacks list permission on bindings.
+const isRBACForbidden = (error: Error): boolean => errorStatus(error) === 403
+
+// True for the two expected, non-actionable RBAC states above. Surfaces that treat
 // the RBAC section as a bonus (Pod/Workload Permissions) hide it entirely for these.
 // Genuine faults — connectivity 503, 500, network errors — are deliberately NOT
 // included, so they still surface rather than being silently dropped.
 export function isRBACUnavailable(error: Error): boolean {
-  const status = (error as { status?: number }).status
-  return status === 403 || (status === 503 && error.message.includes('RBAC cache'))
+  return isRBACForbidden(error) || isRBACCacheUnavailable(error)
 }
 
-// RBAC reverse-lookup fails for two expected, non-alarming reasons that should
-// not render as red errors:
-//   503 with an "RBAC cache not available" message — the identity Radar connects
-//         with can't read RBAC, so the informers never synced (feature not
-//         granted). A config state, not a failure. (A generic connectivity 503,
-//         "Not connected to cluster", is a real fault and must NOT be downplayed
-//         as an RBAC-grant problem — it falls through to the red branch.)
-//   403 — the requesting user lacks list permission on bindings.
-// Reserve the red treatment for genuine failures (connectivity / network / 500).
+// RBACErrorSection renders each expected state as a calm note (distinct copy per
+// state) and reserves the red treatment for genuine failures. It shares the two
+// sub-predicates with isRBACUnavailable so the "what counts as unavailable" rule
+// has a single source of truth and can't drift.
 export function RBACErrorSection({
   title,
   error,
   icon = Shield,
   errorPrefix = 'Could not load permissions',
 }: RBACErrorSectionProps) {
-  const status = (error as { status?: number }).status
-
-  if (status === 503 && error.message.includes('RBAC cache')) {
+  if (isRBACCacheUnavailable(error)) {
     return (
       <Section title={title} icon={icon}>
         <div className="text-sm text-theme-text-tertiary">
@@ -51,7 +53,7 @@ export function RBACErrorSection({
       </Section>
     )
   }
-  if (status === 403) {
+  if (isRBACForbidden(error)) {
     return (
       <Section title={title} icon={icon}>
         <div className="text-sm text-theme-text-tertiary">

--- a/packages/k8s-ui/src/components/resources/renderers/RoleRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/RoleRenderer.tsx
@@ -3,6 +3,7 @@ import { clsx } from 'clsx'
 import { Section, PropertyList, Property, AlertBanner, ResourceLink } from '../../ui/drawer-components'
 import type { RBACRoleResponse, RBACSubject, ResourceRef } from '../../../types'
 import { rbacKindBadgeClass, rbacVerbBadgeClass } from '../../../utils/rbac-badges'
+import { RBACErrorSection } from './RBACErrorSection'
 
 interface RoleRendererProps {
   data: any
@@ -216,13 +217,7 @@ function RoleBindingsSection({ rbacRoleData, loading, error, onNavigate }: RoleB
     )
   }
   if (error) {
-    return (
-      <Section title="Bindings" icon={Users}>
-        <div className="text-sm text-red-400">
-          Could not load bindings: {error.message}
-        </div>
-      </Section>
-    )
+    return <RBACErrorSection title="Bindings" error={error} icon={Users} errorPrefix="Could not load bindings" />
   }
   if (!rbacRoleData) return null
 

--- a/packages/k8s-ui/src/components/resources/renderers/ServiceAccountRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ServiceAccountRenderer.tsx
@@ -16,6 +16,7 @@ import {
   rbacKindBadgeClass,
 } from '../../../utils/rbac-badges'
 import { RBAC_BLAST_ESCALATION_VERBS } from '../../../utils/rbac-blast-radius'
+import { RBACErrorSection } from './RBACErrorSection'
 import { BADGE_SEVERITY_COLORS } from '../../ui/Badge'
 
 interface ServiceAccountRendererProps {
@@ -194,13 +195,7 @@ function RBACSections({ rbacData, loading, error, onNavigate }: RBACSectionsProp
     )
   }
   if (error) {
-    return (
-      <Section title="Bindings" icon={Shield}>
-        <div className="text-sm text-red-400">
-          Could not load RBAC data: {error.message}
-        </div>
-      </Section>
-    )
+    return <RBACErrorSection title="Bindings" error={error} errorPrefix="Could not load RBAC data" />
   }
   if (!rbacData) return null
 

--- a/packages/k8s-ui/src/components/resources/renderers/WorkloadRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/WorkloadRenderer.tsx
@@ -5,7 +5,7 @@ import { Section, PropertyList, Property, ConditionsSection, PodTemplateSection,
 import { DialogPortal } from '../../ui/DialogPortal'
 import type { RBACSubjectResponse, RBACPolicyRule } from '../../../types'
 import { detectBlastRadius, rulePermissivenessScore } from '../../../utils/rbac-blast-radius'
-import { RBACErrorSection } from './RBACErrorSection'
+import { RBACErrorSection, isRBACUnavailable } from './RBACErrorSection'
 import {
   rbacVerbBadgeClass,
   rbacResourceBadgeClass,
@@ -380,6 +380,10 @@ function WorkloadPermissionsSection({
     )
   }
   if (error) {
+    // Permissions is a bonus section here; when RBAC is simply not available
+    // (cluster-static) or forbidden, hide it rather than repeat a note on every
+    // workload. Genuine faults still surface.
+    if (isRBACUnavailable(error)) return null
     return <RBACErrorSection title={title} error={error} />
   }
   if (!rbacData) return null

--- a/packages/k8s-ui/src/components/resources/renderers/WorkloadRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/WorkloadRenderer.tsx
@@ -5,6 +5,7 @@ import { Section, PropertyList, Property, ConditionsSection, PodTemplateSection,
 import { DialogPortal } from '../../ui/DialogPortal'
 import type { RBACSubjectResponse, RBACPolicyRule } from '../../../types'
 import { detectBlastRadius, rulePermissivenessScore } from '../../../utils/rbac-blast-radius'
+import { RBACErrorSection } from './RBACErrorSection'
 import {
   rbacVerbBadgeClass,
   rbacResourceBadgeClass,
@@ -379,11 +380,7 @@ function WorkloadPermissionsSection({
     )
   }
   if (error) {
-    return (
-      <Section title={title} icon={Shield}>
-        <div className="text-sm text-red-400">Could not load permissions: {error.message}</div>
-      </Section>
-    )
+    return <RBACErrorSection title={title} error={error} />
   }
   if (!rbacData) return null
 

--- a/packages/k8s-ui/src/utils/resource-icons.ts
+++ b/packages/k8s-ui/src/utils/resource-icons.ts
@@ -145,7 +145,7 @@ const KIND_ICON_MAP: Record<string, LucideIcon> = {
   nodeclaim: Server,
   ec2nodeclass: Server,
   aksnodeclass: Server,
-  gcpnodeclass: Server,
+  gcenodeclass: Server,
 
   // KEDA
   scaledobject: Scaling,

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -892,7 +892,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	nodeClassIDs := make(map[string]string) // "kind/name" -> nodeClassID (cluster-scoped, keyed by kind to avoid collision)
 
 	// Try common NodeClass kinds across cloud providers
-	nodeClassKinds := []string{"EC2NodeClass", "AKSNodeClass", "GCPNodeClass"}
+	nodeClassKinds := []string{"EC2NodeClass", "AKSNodeClass", "GCENodeClass"}
 	for _, ncKind := range nodeClassKinds {
 		var ncGVR schema.GroupVersionResource
 		var hasKind bool

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -7672,7 +7672,7 @@ func (b *Builder) addGenericCRDNodes(nodes []Node, edges []Edge, opts BuildOptio
 		"helmrelease": true, "gitrepository": true, "certificate": true,
 		"gateway": true, "httproute": true, "grpcroute": true, "tcproute": true, "tlsroute": true,
 		"nodepool": true, "nodeclaim": true, // Karpenter
-		"ec2nodeclass": true, "aksnodeclass": true, "gcpnodeclass": true, // Karpenter NodeClass
+		"ec2nodeclass": true, "aksnodeclass": true, "gcenodeclass": true, // Karpenter NodeClass
 		"scaledobject": true, "scaledjob": true, // KEDA
 		"gatewayclass":   true,                                                // Gateway API
 		"virtualservice": true, "destinationrule": true, "serviceentry": true, // Istio networking

--- a/pkg/topology/cluster_scoped_kinds.go
+++ b/pkg/topology/cluster_scoped_kinds.go
@@ -32,7 +32,7 @@ var ClusterScopedKinds = []ClusterScopedKindEntry{
 	{KindNodeClaim, "karpenter.sh", "nodeclaims"},
 	{KindNodeClass, "karpenter.k8s.aws", "ec2nodeclasses"},
 	{KindNodeClass, "karpenter.azure.com", "aksnodeclasses"},
-	{KindNodeClass, "karpenter.k8s.gcp", "gcpnodeclasses"},
+	{KindNodeClass, "karpenter.k8s.gcp", "gcenodeclasses"},
 	{KindGatewayClass, "gateway.networking.k8s.io", "gatewayclasses"},
 	{KindPV, "", "persistentvolumes"},
 	{KindStorageClass, "storage.k8s.io", "storageclasses"},

--- a/pkg/topology/neighborhood_test.go
+++ b/pkg/topology/neighborhood_test.go
@@ -804,7 +804,7 @@ func TestBuildNeighborhood_SecretFilteredByAllow(t *testing.T) {
 
 // TestBuildNeighborhood_NodeClassPerVariantSAR pins the per-variant
 // authorization at the topology layer: a single NodeKind (NodeClass) has
-// three discriminated variants (EC2NodeClass / AKSNodeClass / GCPNodeClass)
+// three discriminated variants (EC2NodeClass / AKSNodeClass / GCENodeClass)
 // keyed by apiVersion-group. The caller's Allow predicate must be able to
 // pass one variant while denying another so a user with EC2-only RBAC
 // doesn't see AKS or GCP NodeClass nodes on a multi-provider cluster.

--- a/pkg/topology/relationships.go
+++ b/pkg/topology/relationships.go
@@ -662,7 +662,7 @@ func buildNodeID(kind, namespace, name string, dp DynamicProvider) string {
 		"nodeclasses":     "nodeclass",
 		"ec2nodeclasses":  "nodeclass",
 		"aksnodeclasses":  "nodeclass",
-		"gcpnodeclasses":  "nodeclass",
+		"gcenodeclasses":  "nodeclass",
 		"scaledobjects":            "scaledobject",
 		"scaledjobs":               "scaledjob",
 		"gatewayclasses":           "gatewayclass",


### PR DESCRIPTION
## Why

The per-ServiceAccount **Permissions** panel (Pod / Workload detail) showed a red `Could not load permissions` error whenever Radar's ServiceAccount couldn't read RBAC — even though RBAC read is opt-in (`rbac.viewRBAC`) and **off by default**. That's an incoherent state: off-by-default *and* alarming loudly. Surfaced on a cloud/Hub deployment where the connector SA had `list pods` but no RBAC read.

## What changed

**Grant (chart).** Auto-enable RBAC read when `auth.mode != none` or `cloud.enabled`, mirroring the existing secrets rule. In those modes every RBAC read is re-checked against the requesting user, so the shared informer cache can't leak the authorization graph — the concern that kept it opt-in only applies to no-auth installs, where it stays gated behind `rbac.viewRBAC`. So the Permissions panel works out-of-the-box where it's safe.

**Graceful UI.** `503` (SA can't read RBAC) and `403` (viewer lacks permission) now render as calm muted notes; red is reserved for genuine failures. Extracted a shared `RBACErrorSection` so the Pod / Workload / ServiceAccount renderers can't drift (+ unit tests pinning the status branches).

**Chart API-group corrections** (each verified against upstream while auditing coverage):
- CloudNativePG: `cloudnative-pg.io` (not a real group) → `postgresql.cnpg.io`
- cert-manager: add `acme.cert-manager.io` (Orders / Challenges — the ACME flow you debug when a cert is stuck)
- `networking.k8s.io`: add `ingressclasses` (always-on cluster-scoped informer)
- Karpenter GCP: `karpenter.gcp.compute.com` → `karpenter.k8s.gcp`, and resource/kind `gcpnodeclasses`/`GCPNodeClass` → `gcenodeclasses`/`GCENodeClass` across `dynamic_cache`, topology, relationships, builder + tests
- new `cilium` and `networkPolicyApi` (`policy.networking.k8s.io`) toggles

**Drift guard.** `internal/k8s/chart_rbac_coverage_test.go` asserts every API group in Radar's server-side watch lists (`supportedCRDFallbacks` + `topology.ClusterScopedKinds`) is granted by the default ClusterRole — so a watched group with no grant (silent informer 403) fails CI. Scope is group-level for the CRD/extension surface; it does not cover resource-level grants in core groups (e.g. `ingressclasses`) or frontend-renderer-only groups (e.g. the CNPG case) — a renderer-group ↔ chart check would be the natural follow-up.

## Verification
`go build ./...`, `go vet`, `internal/{k8s,server,mcp}` + `pkg` module tests (incl. the new guard), `make tsc`, k8s-ui vitest (incl. 4 new `RBACErrorSection` tests), and `helm template` (RBAC rule absent at default, present with `--auth-mode=proxy`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default ClusterRole grants when auth or cloud is on (broader RBAC read for the Radar SA) and touches authorization-adjacent UI/API behavior; mitigated by per-user re-checks in those modes and read-only verbs on new CRD groups.
> 
> **Overview**
> Fixes the **Permissions** panel showing loud red errors when RBAC read was off by default, and aligns the Helm chart with what Radar actually watches.
> 
> **Helm / cluster RBAC:** RBAC object read (`roles`, `bindings`, etc.) is now **auto-enabled** when `auth.mode != none` or `cloud.enabled`, mirroring the existing secrets rule—so the blast-radius panel works where per-user SAR re-checks prevent cache leaks. No-auth installs still require `rbac.viewRBAC`. The chart gains corrected and expanded grants: `ingressclasses`, cert-manager **`acme.cert-manager.io`**, CloudNativePG **`postgresql.cnpg.io`**, Karpenter GCP **`karpenter.k8s.gcp`**, new **`cilium`** and **`networkPolicyApi`** toggles, plus doc/value updates for Kyverno, Grafana, Trivy, VPA, etc.
> 
> **Backend:** Karpenter GCP NodeClass is renamed end-to-end from `GCPNodeClass` / `gcpnodeclasses` to **`GCENodeClass` / `gcenodeclasses`** (cache, topology, neighborhood RBAC tests). **`TestChartGrantsEveryWatchedCRDGroup`** fails CI if a watched CRD API group lacks a matching ClusterRole rule.
> 
> **UI (`k8s-ui`):** Shared **`RBACErrorSection`** treats RBAC-cache **503** and viewer **403** as calm notes; Pod/Workload bonus Permissions sections **hide** entirely for those expected cases. Vitest covers the branches.
> 
> **CI:** New **`k8s-ui`** job runs `npm test` in `packages/k8s-ui`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7876e032fba5b0d92d3bd6976fe8c82d041e670f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->