### PR TITLE
k8s-ui/ClusterName: stop ResizeObserver render loop from the truncation tooltip

### DIFF
--- a/packages/k8s-ui/src/components/ui/ClusterName.tsx
+++ b/packages/k8s-ui/src/components/ui/ClusterName.tsx
@@ -91,10 +91,18 @@ export function ClusterName({ name, variant = 'inline', noBadge, fallbackBadge, 
   const showFallback = !noBadge && !hasProvider && fallbackBadge != null
   const showRegion = parsed.region !== null && variant === 'stacked'
   const collapsed = parsed.raw !== parsed.clusterName
-  // Tooltip when there's something to disclose — either we collapsed the
-  // raw, or the displayed name is being middle-truncated to fit. Callers
-  // can opt out via `noTooltip` when the raw is already visible elsewhere.
-  const needsTooltip = !noTooltip && (collapsed || truncated)
+  // The styled <Tooltip> wrapper is gated ONLY on `collapsed` — a stable,
+  // string-derived fact. Truncation must NOT gate the wrapper: wrapping
+  // changes the layout box MiddleEllipsis measures, so a truncated↔untruncated
+  // flip oscillates through its ResizeObserver (the exact feedback its
+  // onTruncatedChange note warns against). For the truncation case we disclose
+  // the full name via MiddleEllipsis's native `title` instead — an attribute,
+  // not a layout change — so the measurement can't feed back.
+  const showRawTooltip = !noTooltip && collapsed
+  // Don't also set a native title when the raw is already shown via the
+  // wrapper (collapsed) — that would double up. Only the non-collapsed
+  // truncation path uses it; there raw === clusterName.
+  const truncationTitle = !noTooltip && !collapsed && truncated ? parsed.clusterName : undefined
 
   const body = (
     <span className={['inline-flex items-center gap-1.5 min-w-0', className ?? ''].join(' ')}>
@@ -102,7 +110,7 @@ export function ClusterName({ name, variant = 'inline', noBadge, fallbackBadge, 
       {showFallback && fallbackBadge}
       {variant === 'stacked' ? (
         <span className="flex flex-col min-w-0 flex-1">
-          <MiddleEllipsis text={parsed.clusterName} onTruncatedChange={onTruncatedChange} />
+          <MiddleEllipsis text={parsed.clusterName} title={truncationTitle} onTruncatedChange={onTruncatedChange} />
           {showRegion && (
             <span className="text-[10px] text-theme-text-tertiary truncate">
               {parsed.provider} · {parsed.region}
@@ -110,12 +118,12 @@ export function ClusterName({ name, variant = 'inline', noBadge, fallbackBadge, 
           )}
         </span>
       ) : (
-        <MiddleEllipsis text={parsed.clusterName} onTruncatedChange={onTruncatedChange} />
+        <MiddleEllipsis text={parsed.clusterName} title={truncationTitle} onTruncatedChange={onTruncatedChange} />
       )}
     </span>
   )
 
-  if (!needsTooltip) return body
+  if (!showRawTooltip) return body
 
   return (
     <Tooltip content={parsed.raw} delay={250}>


### PR DESCRIPTION
## The bug

`ClusterName` gated its `<Tooltip>` wrapper on `collapsed || truncated` and wrapped `body` in `<Tooltip>` when either was true. The `truncated` half is **measurement-derived** (set by `MiddleEllipsis` via `onTruncatedChange`), and wrapping/unwrapping `<Tooltip>` changes the layout box `MiddleEllipsis` observes. So a `truncated ↔ untruncated` flip oscillates through its `ResizeObserver` → re-render → re-measure → flip → … without bound: **`Maximum update depth exceeded`**, logged on a tight loop.

`MiddleEllipsis`'s own `onTruncatedChange` docstring warns about exactly this: *"Do NOT use the value to alter the width of the measured container — a truncated→untruncated swap that resizes the parent would oscillate through the ResizeObserver."* `ClusterName` did precisely that.

Because `<ClusterName>` renders wherever a cluster name appears, the loop fires app-wide on any surface holding a name near its truncation width — most visible with several clusters in a narrow rail, and re-triggered on every window resize.

## The fix

- Gate the styled `<Tooltip>` wrapper on **`collapsed` only** — a stable, string-derived fact (`parsed.raw !== parsed.clusterName`), so the wrap decision never changes after mount.
- For the **truncation** case, disclose the full name via `MiddleEllipsis`'s native **`title`** attribute instead of a layout-affecting wrapper. An attribute change isn't a layout change, so the measurement can't feed back.

Content is preserved: collapsed contexts (ARN/GKE) keep the styled tooltip showing `parsed.raw`; a plain name that's merely middle-truncated now gets a native `title` showing the full name (there `raw === clusterName`).

## Regression

Introduced by the width-aware `ClusterName` change (commit that added `MiddleEllipsis` + the `truncated`→`Tooltip` wiring), first shipped in **k8s-ui v1.5.8**. Not a long-standing issue — ~4 weeks old.

## Verification

Reproduced against a live multi-cluster Radar Hub: the home page and the fleet Checks→Findings tab each threw ~90–200 `Maximum update depth` errors and re-triggered on resize. With this fix (same provocation: tab switch + 8 resize events + settle), the count is **0** on both surfaces. `tsc` clean.

## Downstream

Radar Hub (`radar-hub-web`) consumes the published `@skyhook-io/k8s-ui` — needs a new k8s-ui release tag, then a version bump in `radar-hub-web/package.json` to pick this up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI fix in cluster name rendering with no auth, data, or API changes; behavior is preserved with a safer tooltip strategy.
> 
> **Overview**
> Fixes an infinite re-render loop (`Maximum update depth exceeded`) when cluster names sit near their truncation width.
> 
> **`ClusterName` no longer wraps content in the styled `<Tooltip>` when only middle-truncation applies.** The wrapper is gated on **`collapsed`** (parsed raw differs from display name), which is stable after mount. Previously, **`truncated`** from `MiddleEllipsis` also gated the wrapper; adding/removing `<Tooltip>` changed layout and fed back into `MiddleEllipsis`'s `ResizeObserver`, causing oscillation.
> 
> When the name is truncated but not collapsed, the full string is shown via **`MiddleEllipsis`'s native `title`** instead, avoiding layout changes. Collapsed contexts (e.g. GKE/EKS) still use the styled tooltip with **`parsed.raw`**; native `title` is omitted in that case to avoid duplicate hovers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64202be1b5a74fdfb878d9ffb6637d1ac5553097. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->