### PR TITLE
feat(audit): add ?raw=true to /api/audit (Checks cloud-config unwind)

### DIFF
--- a/internal/server/audit_handlers.go
+++ b/internal/server/audit_handlers.go
@@ -145,7 +145,12 @@ func (s *Server) handleAuditResource(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	results := getCachedResults(cache, namespaces)
-	results = applyAuditSettings(results, getAuditConfig())
+	// Honor ?raw=true here too (mirrors handleAudit), so the per-resource
+	// drill-down and the list endpoint can't drift on the raw contract: Radar
+	// Cloud's Hub owns effective Checks config, standalone keeps local settings.
+	if !queryTrue(r, "raw") {
+		results = applyAuditSettings(results, getAuditConfig())
+	}
 	index := bp.IndexByResource(results.Findings)
 
 	// Try exact kind first, then map API resource name (e.g. "deployments") to Go kind (e.g. "Deployment").

--- a/internal/server/audit_handlers.go
+++ b/internal/server/audit_handlers.go
@@ -101,8 +101,26 @@ func (s *Server) handleAudit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	results := getCachedResults(cache, namespaces)
-	results = applyAuditSettings(results, getAuditConfig())
+	// `?raw=true` returns the unfiltered scan, skipping the local
+	// ~/.radar/settings.json audit filters. Radar Cloud's Hub requests raw so
+	// it can own the effective Checks config (org policy) centrally rather than
+	// inheriting each cluster's local settings as if they were team policy.
+	// Standalone Radar and the embedded per-cluster audit view omit the param
+	// and keep applying local settings.
+	if !queryTrue(r, "raw") {
+		results = applyAuditSettings(results, getAuditConfig())
+	}
 	s.writeJSON(w, results)
+}
+
+// queryTrue reports whether a query param parses as a truthy boolean. Tolerant
+// of the usual forms (true/1/t); anything else (incl. absent) reads false.
+func queryTrue(r *http.Request, key string) bool {
+	switch strings.ToLower(r.URL.Query().Get(key)) {
+	case "true", "1", "t", "yes":
+		return true
+	}
+	return false
 }
 
 // handleAuditResource returns findings for a specific resource.

--- a/internal/server/audit_raw_test.go
+++ b/internal/server/audit_raw_test.go
@@ -1,0 +1,35 @@
+package server
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+// TestQueryTrue pins the truthy forms queryTrue accepts. The load-bearing case
+// is "true": Radar Cloud's Hub fleet fan-out requests /api/audit?raw=true to
+// skip local audit settings (the Hub owns effective Checks config). A silent
+// drift here would re-introduce the settings-inversion the cloud unwind fixed.
+func TestQueryTrue(t *testing.T) {
+	cases := map[string]bool{
+		"true":  true,
+		"True":  true,
+		"1":     true,
+		"t":     true,
+		"yes":   true,
+		"false": false,
+		"0":     false,
+		"":      false,
+		"raw":   false,
+	}
+	for val, want := range cases {
+		r := httptest.NewRequest("GET", "/api/audit?raw="+val, nil)
+		if got := queryTrue(r, "raw"); got != want {
+			t.Errorf("queryTrue(raw=%q) = %v, want %v", val, got, want)
+		}
+	}
+	// Absent param reads false.
+	r := httptest.NewRequest("GET", "/api/audit", nil)
+	if queryTrue(r, "raw") {
+		t.Error("queryTrue with absent param = true, want false")
+	}
+}


### PR DESCRIPTION
Part of **Radar Hub Checks V1**. Radar Cloud's Hub becomes the owner of effective Checks (audit posture) config as *org policy*, and resolves raw scans centrally — so a cluster's local `~/.radar/settings.json` audit filters should no longer be treated as team policy for the fleet view.

## Change
- `/api/audit` and `/api/audit/resource` accept `?raw=true`, which returns the unfiltered scan (skips `applyAuditSettings`).
- The Hub fleet fan-out requests `?raw=true`; it then applies org Checks config in its own resolver.
- Standalone Radar and the embedded per-cluster audit view omit the param and keep applying local settings — **single-cluster behavior is unchanged**.

## Tests
- `TestQueryTrue` pins the truthy-param parsing (the Hub sends `raw=true`).
- Existing audit + cloud-mode suites green.

Hub side: skyhook-dev/radar-hub Checks PR (resolver requests `?raw=true`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes audit API response semantics for a new query param; default paths are unchanged, but Hub relies on exact `raw=true` parsing and unfiltered payloads for fleet Checks policy.
> 
> **Overview**
> **Adds a `?raw=true` query flag** on `GET /api/audit` and `GET /api/audit/resource/{kind}/{namespace}/{name}`. When set, responses skip `applyAuditSettings` (local `~/.radar/settings.json` ignored/disabled checks and namespaces). When omitted, behavior is unchanged: local audit settings still filter results.
> 
> Radar Cloud’s Hub is expected to call with `raw=true` and apply org-level Checks policy in its own resolver; standalone Radar and embedded per-cluster views keep the default filtered path.
> 
> A shared **`queryTrue`** helper parses truthy query values (`true`, `1`, `t`, `yes`, case-insensitive). **`TestQueryTrue`** locks that contract so Hub fan-out (`raw=true`) cannot silently regress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a99ed4fb9b061b91f350696eb802a23ad2ce143c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->