### PR TITLE
feat(k8s-ui): shared Checks remediation-queue components

### DIFF
--- a/packages/k8s-ui/src/components/checks/ActionItemDrawer.tsx
+++ b/packages/k8s-ui/src/components/checks/ActionItemDrawer.tsx
@@ -1,0 +1,240 @@
+import { useEffect } from 'react'
+import { createPortal } from 'react-dom'
+import { X, ExternalLink, Wrench, ArrowRight, Layers } from 'lucide-react'
+import { ClusterName } from '../ui'
+import type { CheckMeta } from '../audit'
+import type { CheckActionItem, EffectiveCheckFinding, CheckResourceRef } from './types'
+import { SEVERITY_BADGE_CLASS, SEVERITY_FILL_CLASS, SEVERITY_GLOW_CLASS, SEVERITY_LABEL } from './severity'
+
+// The remediation cockpit for one action item. A right-side slide-over portaled
+// to document.body. Host-agnostic: deep-links come from `resourceHref` and the
+// cluster label from `clusterLabel`, so Hub (cross-SPA links, fleet cluster
+// names) and OSS (in-app links, single cluster) both drive it.
+
+export interface ActionItemDrawerProps {
+  item: CheckActionItem
+  meta?: CheckMeta
+  /** Resolve a deep-link href for a resource. Omit to render non-link text. */
+  resourceHref?: (ref: CheckResourceRef) => string
+  /** Display label for the item's source cluster. Omit (or return falsy) to
+   *  hide the cluster line — e.g. single-cluster OSS. */
+  clusterLabel?: (item: CheckActionItem) => string | undefined
+  onClose: () => void
+}
+
+export function ActionItemDrawer({ item, meta, resourceHref, clusterLabel, onClose }: ActionItemDrawerProps) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [onClose])
+
+  const rep = item.representativeFinding
+  const sev = item.effectiveSeverity
+  const fromOrgConfig = rep.state.source === 'org_config'
+  const cluster = clusterLabel?.(item)
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex justify-end bg-theme-base/50 backdrop-blur-sm"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="action-item-drawer-title"
+    >
+      <div className="flex h-full w-full max-w-xl flex-col border-l border-theme-border/80 bg-theme-surface shadow-2xl">
+        {/* Severity-themed header band */}
+        <div className={`relative shrink-0 px-5 py-4 ring-1 ring-inset ${SEVERITY_GLOW_CLASS[sev]}`}>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="absolute right-3 top-3 rounded-md p-1 text-theme-text-tertiary transition-colors hover:bg-theme-hover hover:text-theme-text-secondary"
+          >
+            <X className="h-5 w-5" />
+          </button>
+          <div className="flex flex-col gap-2 pr-8">
+            <div className="flex items-center gap-2">
+              <span className={`badge-sm text-[11px] font-semibold ${SEVERITY_BADGE_CLASS[sev]}`}>{SEVERITY_LABEL[sev]}</span>
+              <span className="text-[11px] font-medium uppercase tracking-wide text-theme-text-tertiary">{item.category}</span>
+            </div>
+            <h2 id="action-item-drawer-title" className="text-lg font-semibold leading-snug text-theme-text-primary">
+              {item.title}
+            </h2>
+            <div className="flex items-center gap-1.5 text-xs text-theme-text-secondary">
+              <Layers className="h-3.5 w-3.5 text-theme-text-tertiary" />
+              {cluster ? (
+                <>
+                  <ClusterName name={cluster} />
+                  <span aria-hidden>·</span>
+                </>
+              ) : null}
+              <span className="tabular-nums">
+                {item.affectedResources} {item.affectedResources === 1 ? 'resource' : 'resources'}
+                {item.affectedFindings !== item.affectedResources && ` · ${item.affectedFindings} findings`}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-1 flex-col gap-5 overflow-y-auto px-5 py-5">
+          {/* How to fix — the primary, actionable card. */}
+          {meta?.remediation && (
+            <section className="rounded-xl border border-[var(--color-radar-accent)]/25 bg-[var(--color-radar-accent)]/[0.06] p-3.5">
+              <h3 className="mb-1 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-[var(--color-radar-accent)]">
+                <Wrench className="h-3.5 w-3.5" /> How to fix
+              </h3>
+              <p className="text-sm leading-relaxed text-theme-text-primary">{meta.remediation}</p>
+            </section>
+          )}
+
+          {meta?.description && (
+            <section className="flex flex-col gap-1">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-theme-text-tertiary">What this checks</h3>
+              <p className="text-sm leading-relaxed text-theme-text-secondary">{meta.description}</p>
+            </section>
+          )}
+
+          {/* Severity story: detector reading → effective ladder value. */}
+          <section className="flex flex-col gap-2">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-theme-text-tertiary">Severity</h3>
+            <div className="flex items-center gap-3 rounded-xl border border-theme-border bg-theme-base px-3.5 py-3">
+              <div className="flex flex-col">
+                <span className="text-[10px] uppercase tracking-wide text-theme-text-tertiary">Detector</span>
+                <span className="text-sm font-medium capitalize text-theme-text-secondary">{rep.originalSeverity}</span>
+              </div>
+              <ArrowRight className="h-4 w-4 text-theme-text-tertiary" />
+              <div className="flex flex-col">
+                <span className="text-[10px] uppercase tracking-wide text-theme-text-tertiary">Effective</span>
+                <span className="text-sm font-semibold text-theme-text-primary">{SEVERITY_LABEL[sev]}</span>
+              </div>
+              <span className="flex-1" />
+              <span
+                className={[
+                  'rounded-full px-2 py-0.5 text-[11px] font-medium',
+                  fromOrgConfig
+                    ? 'bg-[var(--color-radar-accent)]/10 text-[var(--color-radar-accent)]'
+                    : 'bg-theme-elevated text-theme-text-tertiary',
+                ].join(' ')}
+                title={rep.state.reason || undefined}
+              >
+                {fromOrgConfig ? 'Org policy' : 'Detector default'}
+              </span>
+            </div>
+          </section>
+
+          <PriorityBreakdown item={item} />
+
+          {/* Affected resources — exact identity + deep link per resource. */}
+          <section className="flex flex-col gap-1.5">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-theme-text-tertiary">
+              Affected resources <span className="tabular-nums">({item.affectedResources})</span>
+            </h3>
+            <ul className="flex flex-col gap-px">
+              {item.findings.map((f) => (
+                <ResourceRow
+                  key={`${f.resource.group}/${f.resource.kind}/${f.resource.namespace}/${f.resource.name}`}
+                  finding={f}
+                  resourceHref={resourceHref}
+                />
+              ))}
+            </ul>
+            {resourceHref && (
+              <a
+                href={resourceHref(rep.resource)}
+                className="mt-1 inline-flex w-fit items-center gap-1 text-xs font-medium text-[var(--color-radar-accent)] hover:underline"
+              >
+                Open representative resource <ArrowRight className="h-3 w-3" />
+              </a>
+            )}
+          </section>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}
+
+// Visualized explainable priority: each weighted factor as a proportional bar,
+// summing to the score. Zero-weight factors render as quiet context chips.
+function PriorityBreakdown({ item }: { item: CheckActionItem }) {
+  const weighted = item.priorityFactors.filter((f) => f.weight > 0)
+  const context = item.priorityFactors.filter((f) => f.weight === 0)
+  if (weighted.length === 0 && context.length === 0) return null
+  const max = Math.max(...weighted.map((f) => f.weight), 1)
+  const total = weighted.reduce((n, f) => n + f.weight, 0)
+
+  return (
+    <section className="flex flex-col gap-2">
+      <div className="flex items-baseline justify-between">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-theme-text-tertiary">Why this priority</h3>
+        <span className="text-xs text-theme-text-tertiary">
+          score <span className="font-semibold tabular-nums text-theme-text-secondary">{total}</span>
+        </span>
+      </div>
+      <ul className="flex flex-col gap-2">
+        {weighted.map((f) => (
+          <li key={f.key} className="flex items-center gap-3 text-xs">
+            <span className="w-32 shrink-0 truncate text-theme-text-secondary">
+              {f.label}
+              {f.detail ? <span className="text-theme-text-tertiary"> · {f.detail}</span> : null}
+            </span>
+            <span className="h-1.5 flex-1 overflow-hidden rounded-full bg-theme-elevated">
+              <span
+                className="block h-full rounded-full bg-[var(--color-radar-accent)] transition-[width] duration-500 ease-out"
+                style={{ width: `${(f.weight / max) * 100}%` }}
+              />
+            </span>
+            <span className="w-8 shrink-0 text-right font-mono text-theme-text-tertiary tabular-nums">+{f.weight}</span>
+          </li>
+        ))}
+      </ul>
+      {context.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 pt-0.5">
+          {context.map((f) => (
+            <span key={f.key} className="rounded-md bg-theme-elevated px-2 py-0.5 text-[11px] text-theme-text-tertiary ring-1 ring-theme-border">
+              {f.label}
+              {f.detail ? `: ${f.detail}` : ''}
+            </span>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function ResourceRow({
+  finding,
+  resourceHref,
+}: {
+  finding: EffectiveCheckFinding
+  resourceHref?: (ref: CheckResourceRef) => string
+}) {
+  const r = finding.resource
+  const body = (
+    <>
+      <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${SEVERITY_FILL_CLASS[finding.effectiveSeverity]}`} />
+      <span className="shrink-0 font-mono text-[11px] uppercase tracking-wide text-theme-text-tertiary">{r.kind}</span>
+      <span className={`truncate font-medium ${resourceHref ? 'text-[var(--color-radar-accent)]' : 'text-theme-text-primary'}`}>
+        {r.namespace ? `${r.namespace} / ` : ''}
+        {r.name}
+      </span>
+      {resourceHref && <ExternalLink className="h-3 w-3 shrink-0 text-theme-text-tertiary opacity-0 transition-opacity group-hover:opacity-100" />}
+    </>
+  )
+  return (
+    <li>
+      {resourceHref ? (
+        <a href={resourceHref(r)} className="group flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-theme-hover/60">
+          {body}
+        </a>
+      ) : (
+        <span className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm">{body}</span>
+      )}
+    </li>
+  )
+}

--- a/packages/k8s-ui/src/components/checks/ActionItemDrawer.tsx
+++ b/packages/k8s-ui/src/components/checks/ActionItemDrawer.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { X, ExternalLink, Wrench, ArrowRight, Layers } from 'lucide-react'
 import { ClusterName } from '../ui'
@@ -23,6 +23,7 @@ export interface ActionItemDrawerProps {
 }
 
 export function ActionItemDrawer({ item, meta, resourceHref, clusterLabel, onClose }: ActionItemDrawerProps) {
+  const closeRef = useRef<HTMLButtonElement>(null)
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose()
@@ -30,6 +31,12 @@ export function ActionItemDrawer({ item, meta, resourceHref, clusterLabel, onClo
     document.addEventListener('keydown', handler)
     return () => document.removeEventListener('keydown', handler)
   }, [onClose])
+
+  // Move focus into the panel on open so keyboard/SR focus doesn't stay behind
+  // it on the underlying queue. (A full focus-trap is a follow-up.)
+  useEffect(() => {
+    closeRef.current?.focus()
+  }, [])
 
   const rep = item.representativeFinding
   const sev = item.effectiveSeverity
@@ -50,6 +57,7 @@ export function ActionItemDrawer({ item, meta, resourceHref, clusterLabel, onClo
         {/* Severity-themed header band */}
         <div className={`relative shrink-0 px-5 py-4 ring-1 ring-inset ${SEVERITY_GLOW_CLASS[sev]}`}>
           <button
+            ref={closeRef}
             type="button"
             onClick={onClose}
             aria-label="Close"
@@ -135,9 +143,11 @@ export function ActionItemDrawer({ item, meta, resourceHref, clusterLabel, onClo
               Affected resources <span className="tabular-nums">({item.affectedResources})</span>
             </h3>
             <ul className="flex flex-col gap-px">
-              {item.findings.map((f) => (
+              {item.findings.map((f, i) => (
+                // Index-suffixed: a check can fire more than once on the same
+                // resource (per-container), so the resource ref isn't unique.
                 <ResourceRow
-                  key={`${f.resource.group}/${f.resource.kind}/${f.resource.namespace}/${f.resource.name}`}
+                  key={`${f.resource.group}/${f.resource.kind}/${f.resource.namespace}/${f.resource.name}#${i}`}
                   finding={f}
                   resourceHref={resourceHref}
                 />

--- a/packages/k8s-ui/src/components/checks/ActionItemsView.tsx
+++ b/packages/k8s-ui/src/components/checks/ActionItemsView.tsx
@@ -1,0 +1,341 @@
+import { useMemo, useState, type ReactNode } from 'react'
+import { ChevronRight, ExternalLink, Search, ShieldCheck, X } from 'lucide-react'
+import { ClusterName, EmptyState, FilterPill } from '../ui'
+import type { CheckMeta } from '../audit'
+import { ActionItemDrawer } from './ActionItemDrawer'
+import { CHECK_SEVERITIES, CHECK_SEVERITY_RANK, type CheckActionItem, type CheckSeverity, type EffectiveCheckFinding, type CheckResourceRef } from './types'
+import {
+  SEVERITY_BADGE_CLASS,
+  SEVERITY_FILL_CLASS,
+  SEVERITY_LABEL,
+  SEVERITY_RAIL_CLASS,
+  SEVERITY_TEXT_CLASS,
+  categoryBadgeClass,
+} from './severity'
+
+const CATEGORIES: readonly string[] = ['Security', 'Reliability', 'Efficiency']
+
+export interface ActionItemsViewProps {
+  /** Action items, typically flattened across the fleet by the host. */
+  items: CheckActionItem[]
+  /** Check metadata (id → meta) for the drawer's title/description/remediation. */
+  checks: Record<string, CheckMeta>
+  /** True when at least one source returned audit data — distinguishes "clean"
+   *  from "nothing audited / everything errored". */
+  anyData: boolean
+  /** Resolve a deep-link href for a resource (host-specific routing). Omit to
+   *  render non-link text. */
+  resourceHref?: (ref: CheckResourceRef) => string
+  /** Display label for an item's source cluster. Omit (or return falsy) to hide
+   *  the cluster line — e.g. single-cluster OSS. */
+  clusterLabel?: (item: CheckActionItem) => string | undefined
+  /** Empty-state CTA shown when there's no data (host-specific: connect a
+   *  cluster vs run an audit). */
+  emptyAction?: ReactNode
+}
+
+export function ActionItemsView({ items, checks, anyData, resourceHref, clusterLabel, emptyAction }: ActionItemsViewProps) {
+  const [severityFilter, setSeverityFilter] = useState<Set<CheckSeverity>>(new Set())
+  const [categoryFilter, setCategoryFilter] = useState<Set<string>>(new Set())
+  const [search, setSearch] = useState('')
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const [detailId, setDetailId] = useState<string | null>(null)
+
+  const { totals, totalFindings, clusterCount } = useMemo(() => {
+    const totals: Record<CheckSeverity, number> = { critical: 0, high: 0, medium: 0, low: 0 }
+    const clusters = new Set<string>()
+    let totalFindings = 0
+    for (const it of items) {
+      totals[it.effectiveSeverity] += 1
+      totalFindings += it.affectedFindings
+      clusters.add(it.subject.cluster_id)
+    }
+    return { totals, totalFindings, clusterCount: clusters.size }
+  }, [items])
+
+  const searchLower = search.toLowerCase()
+  const filtered = useMemo(() => {
+    const out = items.filter((it) => {
+      if (severityFilter.size > 0 && !severityFilter.has(it.effectiveSeverity)) return false
+      if (categoryFilter.size > 0 && !categoryFilter.has(it.category)) return false
+      if (searchLower) {
+        const hay = `${it.title} ${it.checkID} ${it.message} ${it.subject.namespace} ${it.subject.name}`.toLowerCase()
+        if (!hay.includes(searchLower)) return false
+      }
+      return true
+    })
+    // Worst-first across the whole queue (severity, then blast radius, then title).
+    return out.sort((a, b) => {
+      const r = CHECK_SEVERITY_RANK[b.effectiveSeverity] - CHECK_SEVERITY_RANK[a.effectiveSeverity]
+      if (r !== 0) return r
+      if (b.affectedResources !== a.affectedResources) return b.affectedResources - a.affectedResources
+      return a.title.localeCompare(b.title)
+    })
+  }, [items, severityFilter, categoryFilter, searchLower])
+
+  const toggle = <T,>(setter: React.Dispatch<React.SetStateAction<Set<T>>>, v: T) =>
+    setter((prev) => {
+      const next = new Set(prev)
+      if (next.has(v)) next.delete(v)
+      else next.add(v)
+      return next
+    })
+
+  const hasFilters = severityFilter.size > 0 || categoryFilter.size > 0 || search !== ''
+  const clearAll = () => {
+    setSeverityFilter(new Set())
+    setCategoryFilter(new Set())
+    setSearch('')
+  }
+
+  const detail = detailId ? filtered.find((it) => it.id === detailId) ?? items.find((it) => it.id === detailId) ?? null : null
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Triage header: distribution bar + filter chips + search. */}
+      <div className="flex flex-col gap-3.5 rounded-2xl border border-theme-border bg-theme-surface p-4 shadow-theme-sm">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div className="flex items-baseline gap-2">
+            <span className="text-2xl font-semibold tabular-nums text-theme-text-primary">{items.length}</span>
+            <span className="text-sm text-theme-text-secondary">
+              {items.length === 1 ? 'action item' : 'action items'}
+              {totalFindings > items.length && <span className="text-theme-text-tertiary"> · {totalFindings} findings</span>}
+              {clusterCount > 1 && <span className="text-theme-text-tertiary"> · {clusterCount} clusters</span>}
+            </span>
+          </div>
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-theme-text-tertiary" />
+            <input
+              type="text"
+              placeholder="Search action items…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-64 rounded-lg border border-theme-border-light bg-theme-base py-1.5 pl-9 pr-8 text-sm text-theme-text-primary placeholder-theme-text-disabled focus:outline-none focus:ring-2 focus:ring-[var(--color-radar-accent)]"
+            />
+            {search && (
+              <button
+                type="button"
+                onClick={() => setSearch('')}
+                aria-label="Clear search"
+                className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-theme-text-tertiary hover:text-theme-text-primary"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            )}
+          </div>
+        </div>
+
+        <SeverityBar totals={totals} />
+
+        <div className="flex flex-wrap items-center gap-1.5">
+          {CHECK_SEVERITIES.map((s) => (
+            <SeverityChip key={s} severity={s} count={totals[s]} active={severityFilter.has(s)} onClick={() => toggle(setSeverityFilter, s)} />
+          ))}
+          <span className="mx-1.5 h-5 w-px bg-theme-border" />
+          {CATEGORIES.map((c) => (
+            <FilterPill key={c} label={c} active={categoryFilter.has(c)} onClick={() => toggle(setCategoryFilter, c)} />
+          ))}
+        </div>
+      </div>
+
+      {filtered.length === 0 ? (
+        hasFilters ? (
+          <EmptyState
+            tone="filtered"
+            variant="card"
+            headline="No action items match the current filters"
+            body="Clear a filter to see more of the queue."
+            action={
+              <button
+                type="button"
+                onClick={clearAll}
+                className="badge badge-sm border border-theme-border bg-theme-elevated text-theme-text-primary transition-colors hover:bg-theme-hover"
+              >
+                Clear all filters
+              </button>
+            }
+          />
+        ) : anyData ? (
+          <EmptyState
+            tone="healthy"
+            variant="card"
+            icon={ShieldCheck}
+            headline="Nothing to remediate"
+            body="Every audited resource passed its checks."
+          />
+        ) : (
+          <EmptyState headline="No check data yet" body="Run an audit to populate the remediation queue." action={emptyAction} />
+        )
+      ) : (
+        <ol className="flex flex-col gap-1.5">
+          {filtered.map((item) => (
+            <ActionItemRow
+              key={item.id}
+              item={item}
+              clusterLabel={clusterLabel}
+              expanded={expanded.has(item.id)}
+              onToggle={() => toggle(setExpanded, item.id)}
+              onOpen={() => setDetailId(item.id)}
+              resourceHref={resourceHref}
+            />
+          ))}
+        </ol>
+      )}
+
+      {detail && (
+        <ActionItemDrawer item={detail} meta={checks[detail.checkID]} resourceHref={resourceHref} clusterLabel={clusterLabel} onClose={() => setDetailId(null)} />
+      )}
+    </div>
+  )
+}
+
+function SeverityBar({ totals }: { totals: Record<CheckSeverity, number> }) {
+  const sum = CHECK_SEVERITIES.reduce((n, s) => n + totals[s], 0)
+  return (
+    <div className="flex h-1.5 overflow-hidden rounded-full bg-theme-elevated" role="img" aria-label="Severity distribution">
+      {sum === 0
+        ? null
+        : CHECK_SEVERITIES.map((s) =>
+            totals[s] > 0 ? (
+              <div key={s} className={`${SEVERITY_FILL_CLASS[s]} transition-[width] duration-500 ease-out`} style={{ width: `${(totals[s] / sum) * 100}%` }} />
+            ) : null,
+          )}
+    </div>
+  )
+}
+
+function SeverityChip({ severity, count, active, onClick }: { severity: CheckSeverity; count: number; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={[
+        'group inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-colors',
+        active ? 'border-theme-border bg-theme-elevated text-theme-text-primary' : 'border-transparent text-theme-text-secondary hover:bg-theme-hover/60',
+      ].join(' ')}
+    >
+      <span className={`h-2 w-2 rounded-full ${SEVERITY_FILL_CLASS[severity]} ${count === 0 ? 'opacity-30' : ''}`} />
+      <span className={`font-semibold tabular-nums ${count > 0 ? SEVERITY_TEXT_CLASS[severity] : 'text-theme-text-tertiary'}`}>{count}</span>
+      <span>{SEVERITY_LABEL[severity]}</span>
+    </button>
+  )
+}
+
+function ActionItemRow({
+  item,
+  clusterLabel,
+  expanded,
+  onToggle,
+  onOpen,
+  resourceHref,
+}: {
+  item: CheckActionItem
+  clusterLabel?: (item: CheckActionItem) => string | undefined
+  expanded: boolean
+  onToggle: () => void
+  onOpen: () => void
+  resourceHref?: (ref: CheckResourceRef) => string
+}) {
+  // Only the environment factor is genuinely additive on the row — severity is
+  // the badge, category is the tag, blast_radius is the resource count.
+  const extraFactors = item.priorityFactors.filter(
+    (f) => f.weight > 0 && f.key !== 'severity' && f.key !== 'category' && f.key !== 'blast_radius',
+  )
+  const cluster = clusterLabel?.(item)
+
+  return (
+    <li className="overflow-hidden rounded-xl border border-theme-border bg-theme-surface shadow-theme-sm">
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={onOpen}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            onOpen()
+          }
+        }}
+        className={`group flex cursor-pointer items-center gap-3 border-l-2 py-3 pl-3 pr-4 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-radar-accent)]/40 ${SEVERITY_RAIL_CLASS[item.effectiveSeverity]}`}
+      >
+        <button
+          type="button"
+          aria-label={expanded ? 'Collapse affected resources' : 'Show affected resources'}
+          aria-expanded={expanded}
+          onClick={(e) => {
+            e.stopPropagation()
+            onToggle()
+          }}
+          className="-my-1 shrink-0 rounded-md p-1 text-theme-text-tertiary transition-colors hover:bg-theme-hover hover:text-theme-text-secondary"
+        >
+          <ChevronRight className={`h-4 w-4 transition-transform duration-200 ${expanded ? 'rotate-90' : ''}`} />
+        </button>
+
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate text-sm font-medium text-theme-text-primary">{item.title}</span>
+            <span className={`badge-sm shrink-0 text-[10px] ${categoryBadgeClass(item.category)}`}>{item.category}</span>
+          </div>
+          <div className="flex min-w-0 items-center gap-1.5 text-xs text-theme-text-tertiary">
+            {cluster ? (
+              <>
+                <span className="max-w-[180px] truncate">
+                  <ClusterName name={cluster} />
+                </span>
+                <span aria-hidden>·</span>
+              </>
+            ) : null}
+            <span className="shrink-0 font-medium text-theme-text-secondary tabular-nums">
+              {item.affectedResources} {item.affectedResources === 1 ? 'resource' : 'resources'}
+            </span>
+            {extraFactors.map((f) => (
+              <span key={f.key} className="hidden shrink-0 items-center gap-1 capitalize sm:inline-flex">
+                <span aria-hidden>·</span>
+                {f.detail || f.label}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <span className={`badge-sm shrink-0 text-[10px] font-semibold ${SEVERITY_BADGE_CLASS[item.effectiveSeverity]}`}>{SEVERITY_LABEL[item.effectiveSeverity]}</span>
+        <ExternalLink className="h-3.5 w-3.5 shrink-0 text-theme-text-tertiary opacity-0 transition-opacity group-hover:opacity-100" />
+      </div>
+
+      <div className="grid transition-[grid-template-rows] duration-200 ease-out" style={{ gridTemplateRows: expanded ? '1fr' : '0fr' }}>
+        <div className="overflow-hidden">
+          <ul className="flex flex-col gap-px border-t border-theme-border bg-theme-base/40 px-3 py-2 pl-12">
+            {item.findings.map((f) => (
+              <FindingLine key={`${f.resource.group}/${f.resource.kind}/${f.resource.namespace}/${f.resource.name}`} finding={f} resourceHref={resourceHref} />
+            ))}
+          </ul>
+        </div>
+      </div>
+    </li>
+  )
+}
+
+function FindingLine({ finding, resourceHref }: { finding: EffectiveCheckFinding; resourceHref?: (ref: CheckResourceRef) => string }) {
+  const r = finding.resource
+  const body = (
+    <>
+      <span className="shrink-0 font-mono text-[11px] uppercase tracking-wide text-theme-text-tertiary">{r.kind}</span>
+      <span className={`truncate font-medium ${resourceHref ? 'text-[var(--color-radar-accent)]' : 'text-theme-text-primary'}`}>
+        {r.namespace ? `${r.namespace} / ` : ''}
+        {r.name}
+      </span>
+      {resourceHref && <ExternalLink className="h-3 w-3 shrink-0 text-theme-text-tertiary opacity-0 transition-opacity group-hover/f:opacity-100" />}
+      <span className="ml-1 hidden truncate text-xs text-theme-text-tertiary md:inline">{finding.message}</span>
+    </>
+  )
+  return (
+    <li>
+      {resourceHref ? (
+        <a href={resourceHref(r)} className="group/f flex items-center gap-2 rounded-md px-2 py-1 text-sm transition-colors hover:bg-theme-hover/60">
+          {body}
+        </a>
+      ) : (
+        <span className="flex items-center gap-2 rounded-md px-2 py-1 text-sm">{body}</span>
+      )}
+    </li>
+  )
+}

--- a/packages/k8s-ui/src/components/checks/ActionItemsView.tsx
+++ b/packages/k8s-ui/src/components/checks/ActionItemsView.tsx
@@ -302,10 +302,15 @@ function ActionItemRow({
       </div>
 
       <div className="grid transition-[grid-template-rows] duration-200 ease-out" style={{ gridTemplateRows: expanded ? '1fr' : '0fr' }}>
-        <div className="overflow-hidden">
+        {/* inert when collapsed: the rows are visually clipped (0fr + overflow)
+            but would otherwise stay keyboard-tabbable + screen-reader-reachable. */}
+        <div className="overflow-hidden" inert={!expanded || undefined}>
           <ul className="flex flex-col gap-px border-t border-theme-border bg-theme-base/40 px-3 py-2 pl-12">
-            {item.findings.map((f) => (
-              <FindingLine key={`${f.resource.group}/${f.resource.kind}/${f.resource.namespace}/${f.resource.name}`} finding={f} resourceHref={resourceHref} />
+            {item.findings.map((f, i) => (
+              // Index-suffixed: a check can fire more than once on the same
+              // resource (e.g. per-container), so the resource ref alone isn't
+              // a unique key within one action item's findings.
+              <FindingLine key={`${f.resource.group}/${f.resource.kind}/${f.resource.namespace}/${f.resource.name}#${i}`} finding={f} resourceHref={resourceHref} />
             ))}
           </ul>
         </div>

--- a/packages/k8s-ui/src/components/checks/checks.test.ts
+++ b/packages/k8s-ui/src/components/checks/checks.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { resourceKey, resourceRefKey, checkFindingKey, mapRadarSeverity, SOURCE_RADAR_BUILTIN, type CheckResourceRef } from './types'
+
+describe('resourceKey', () => {
+  // Same kind/ns/name across two API groups must not collide. Mirrors
+  // radar/pkg/audit helpers_test.go's group-aware key.
+  it('disambiguates the same kind/ns/name across API groups', () => {
+    expect(resourceKey('', 'Service', 'prod', 'api')).not.toBe(resourceKey('serving.knative.dev', 'Service', 'prod', 'api'))
+  })
+})
+
+describe('checkFindingKey', () => {
+  const ref = (cluster_id: string): CheckResourceRef => ({ cluster_id, group: 'apps', kind: 'Deployment', namespace: 'prod', name: 'api' })
+
+  // The same resource identity + check on two clusters must produce distinct
+  // keys — even when the clusters' display names collapse to the same label.
+  it('disambiguates identical findings across cluster IDs', () => {
+    const a = checkFindingKey('cl_aaa', SOURCE_RADAR_BUILTIN, resourceRefKey(ref('cl_aaa')), 'run-as-root')
+    const b = checkFindingKey('cl_bbb', SOURCE_RADAR_BUILTIN, resourceRefKey(ref('cl_bbb')), 'run-as-root')
+    expect(a).not.toBe(b)
+  })
+
+  it('disambiguates by the optional detail discriminator', () => {
+    const rk = resourceRefKey(ref('cl_aaa'))
+    const noDetail = checkFindingKey('cl_aaa', SOURCE_RADAR_BUILTIN, rk, 'container-checks')
+    const a = checkFindingKey('cl_aaa', SOURCE_RADAR_BUILTIN, rk, 'container-checks', 'sidecar')
+    const b = checkFindingKey('cl_aaa', SOURCE_RADAR_BUILTIN, rk, 'container-checks', 'app')
+    expect(new Set([noDetail, a, b]).size).toBe(3)
+  })
+})
+
+describe('mapRadarSeverity', () => {
+  it('maps danger→high and warning→medium', () => {
+    expect(mapRadarSeverity('danger')).toBe('high')
+    expect(mapRadarSeverity('warning')).toBe('medium')
+  })
+})

--- a/packages/k8s-ui/src/components/checks/checks.test.ts
+++ b/packages/k8s-ui/src/components/checks/checks.test.ts
@@ -34,4 +34,7 @@ describe('mapRadarSeverity', () => {
     expect(mapRadarSeverity('danger')).toBe('high')
     expect(mapRadarSeverity('warning')).toBe('medium')
   })
+  it('falls back to medium for an unrecognized severity', () => {
+    expect(mapRadarSeverity('unknown')).toBe('medium')
+  })
 })

--- a/packages/k8s-ui/src/components/checks/index.ts
+++ b/packages/k8s-ui/src/components/checks/index.ts
@@ -1,0 +1,4 @@
+export { ActionItemsView, type ActionItemsViewProps } from './ActionItemsView'
+export { ActionItemDrawer, type ActionItemDrawerProps } from './ActionItemDrawer'
+export * from './types'
+export * from './severity'

--- a/packages/k8s-ui/src/components/checks/severity.ts
+++ b/packages/k8s-ui/src/components/checks/severity.ts
@@ -1,0 +1,71 @@
+import type { CheckSeverity } from './types'
+
+// The visual language for the 4-tier Checks severity ladder. Pale-pastel tints
+// with hand-rolled dark variants (no theme token covers these). One hue per
+// tier: red=critical, orange=high, amber=medium, slate=low — read the queue's
+// left rail top-to-bottom and severity is obvious without reading a word.
+//
+// Class strings are literal so each consuming app's Tailwind @source scan emits
+// them.
+
+export const SEVERITY_LABEL: Record<CheckSeverity, string> = {
+  critical: 'Critical',
+  high: 'High',
+  medium: 'Medium',
+  low: 'Low',
+}
+
+// Pill badge — the loud, explicit severity signal on rows + drawer header.
+export const SEVERITY_BADGE_CLASS: Record<CheckSeverity, string> = {
+  critical: 'bg-red-50 text-red-700 ring-1 ring-red-200 dark:bg-red-950/50 dark:text-red-300 dark:ring-red-900',
+  high: 'bg-orange-50 text-orange-700 ring-1 ring-orange-200 dark:bg-orange-950/50 dark:text-orange-300 dark:ring-orange-900',
+  medium: 'bg-amber-50 text-amber-700 ring-1 ring-amber-200 dark:bg-amber-950/50 dark:text-amber-300 dark:ring-amber-900',
+  low: 'bg-slate-100 text-slate-600 ring-1 ring-slate-200 dark:bg-slate-800/60 dark:text-slate-300 dark:ring-slate-700',
+}
+
+// Solid fill — dots + the proportional distribution bar segments.
+export const SEVERITY_FILL_CLASS: Record<CheckSeverity, string> = {
+  critical: 'bg-red-500',
+  high: 'bg-orange-500',
+  medium: 'bg-amber-500',
+  low: 'bg-slate-400',
+}
+
+export const SEVERITY_TEXT_CLASS: Record<CheckSeverity, string> = {
+  critical: 'text-red-600 dark:text-red-400',
+  high: 'text-orange-600 dark:text-orange-400',
+  medium: 'text-amber-600 dark:text-amber-400',
+  low: 'text-slate-500 dark:text-slate-400',
+}
+
+// Left accent rail on a queue row — the scan-down severity cue. Pairs a colored
+// 2px border with a faint severity-tinted background that deepens on hover.
+export const SEVERITY_RAIL_CLASS: Record<CheckSeverity, string> = {
+  critical: 'border-l-red-500 hover:bg-red-50/40 dark:hover:bg-red-950/20',
+  high: 'border-l-orange-500 hover:bg-orange-50/40 dark:hover:bg-orange-950/20',
+  medium: 'border-l-amber-500 hover:bg-amber-50/30 dark:hover:bg-amber-950/15',
+  low: 'border-l-slate-300 dark:border-l-slate-600 hover:bg-theme-hover/40',
+}
+
+// Soft glow ring for the drawer's severity header band.
+export const SEVERITY_GLOW_CLASS: Record<CheckSeverity, string> = {
+  critical: 'bg-red-50 ring-red-100 dark:bg-red-950/30 dark:ring-red-900/50',
+  high: 'bg-orange-50 ring-orange-100 dark:bg-orange-950/30 dark:ring-orange-900/50',
+  medium: 'bg-amber-50 ring-amber-100 dark:bg-amber-950/30 dark:ring-amber-900/50',
+  low: 'bg-slate-50 ring-slate-200 dark:bg-slate-900/40 dark:ring-slate-800',
+}
+
+// Category accent — a quiet tag (severity is the loud one). Security is the
+// headline beat, so it gets the most distinct hue.
+const CATEGORY_BADGE_CLASS: Record<string, string> = {
+  Security: 'bg-violet-50 text-violet-700 ring-1 ring-violet-200 dark:bg-violet-950/40 dark:text-violet-300 dark:ring-violet-900',
+  Reliability: 'bg-sky-50 text-sky-700 ring-1 ring-sky-200 dark:bg-sky-950/40 dark:text-sky-300 dark:ring-sky-900',
+  Efficiency: 'bg-teal-50 text-teal-700 ring-1 ring-teal-200 dark:bg-teal-950/40 dark:text-teal-300 dark:ring-teal-900',
+}
+
+export function categoryBadgeClass(category: string): string {
+  return (
+    CATEGORY_BADGE_CLASS[category] ??
+    'bg-theme-elevated text-theme-text-secondary ring-1 ring-theme-border'
+  )
+}

--- a/packages/k8s-ui/src/components/checks/types.ts
+++ b/packages/k8s-ui/src/components/checks/types.ts
@@ -1,0 +1,144 @@
+// Shared Checks identity contract + data shapes + severity vocabulary.
+//
+// k8s-ui owns these because the Checks queue presentation (ActionItemsView,
+// ActionItemDrawer) is host-agnostic: Radar Hub feeds it fleet-resolved data,
+// and OSS Radar can feed a single-cluster ("fleet of one") resolve. Hosts map
+// their wire payloads onto these types; the components render against them.
+//
+// Mirrors Radar OSS's resource-key convention (radar/pkg/audit.ResourceKey).
+
+/** Canonical Checks severity ladder — distinct from the raw detector severity
+ *  (danger/warning) so operational criticality and compliance risk stay
+ *  separate axes. */
+export type CheckSeverity = 'critical' | 'high' | 'medium' | 'low';
+
+/** Raw detector severity Radar emits. */
+export type RadarSeverity = 'danger' | 'warning';
+
+/** Ordered worst→least, for rendering severity filters/sorts consistently. */
+export const CHECK_SEVERITIES: CheckSeverity[] = ['critical', 'high', 'medium', 'low'];
+
+/** Worst-first ordering rank for the ladder. */
+export const CHECK_SEVERITY_RANK: Record<CheckSeverity, number> = {
+  critical: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+};
+
+export function isCheckSeverity(s: string): s is CheckSeverity {
+  return s === 'critical' || s === 'high' || s === 'medium' || s === 'low';
+}
+
+/** mapRadarSeverity maps a raw detector severity to the Checks ladder
+ *  (danger→high, warning→medium). critical/low are only reachable via an org
+ *  severity override; the detector never emits them. */
+export function mapRadarSeverity(raw: RadarSeverity | string): CheckSeverity {
+  switch (raw) {
+    case 'danger':
+      return 'high';
+    case 'warning':
+      return 'medium';
+    default:
+      return 'medium';
+  }
+}
+
+/**
+ * Canonical resource identity. `group` is '' for the core API group;
+ * `namespace` is '' for cluster-scoped resources. Both are always present.
+ * `cluster_id` scopes the ref to its source cluster — the disambiguator when
+ * two clusters' display names collapse to the same label.
+ */
+export interface CheckResourceRef {
+  cluster_id: string;
+  group: string;
+  kind: string;
+  namespace: string;
+  name: string;
+}
+
+/** Built-in (Radar-detected) finding source. The only V1 source. */
+export const SOURCE_RADAR_BUILTIN = 'radar_builtin';
+
+/**
+ * resourceKey mirrors Go `audit.ResourceKey(group, kind, namespace, name)`:
+ * `group|Kind|namespace|name`. Group first because group and namespace can each
+ * independently be empty; `|` is delimiter-safe (K8s API groups follow
+ * DNS-subdomain rules and can't contain it).
+ */
+export function resourceKey(group: string, kind: string, namespace: string, name: string): string {
+  return `${group}|${kind}|${namespace}|${name}`;
+}
+
+export function resourceRefKey(ref: CheckResourceRef): string {
+  return resourceKey(ref.group, ref.kind, ref.namespace, ref.name);
+}
+
+/**
+ * checkFindingKey is the canonical built-in finding key:
+ * `cluster_id + source + resourceKey + checkID + optional detail`. cluster_id is
+ * part of the key so identical resources across two clusters never collide,
+ * even when display names render the same.
+ */
+export function checkFindingKey(
+  clusterId: string,
+  source: string,
+  resKey: string,
+  checkID: string,
+  detail?: string,
+): string {
+  const base = `${clusterId} ${source} ${resKey} ${checkID}`;
+  return detail ? `${base} ${detail}` : base;
+}
+
+/** Explains how org config shaped a finding. */
+export interface EffectiveFindingState {
+  visibility: 'visible' | 'hidden';
+  source: 'detector_default' | 'org_config';
+  scoreImpact: 'counts' | 'excluded';
+  alertImpact: 'alerts' | 'muted';
+  complianceImpact: 'counts' | 'excluded_by_config';
+  reason?: string;
+}
+
+export interface EffectiveCheckFinding {
+  source: 'radar_builtin';
+  resource: CheckResourceRef;
+  checkID: string;
+  category: string;
+  originalSeverity: RadarSeverity;
+  effectiveSeverity: CheckSeverity;
+  message: string;
+  state: EffectiveFindingState;
+}
+
+/** One explainable contribution to an action item's queue ordering. Shown in
+ *  the UI so priority is transparent — there is no hidden score. */
+export interface PriorityFactor {
+  key: string;
+  label: string;
+  detail?: string;
+  weight: number;
+}
+
+/**
+ * A grouped remediation-queue row: one row per failing check, rolling up every
+ * resource that fails it. `subject` is the most-severe representative resource;
+ * `findings` holds the per-resource detail underneath.
+ */
+export interface CheckActionItem {
+  id: string;
+  source: 'radar_builtin';
+  subject: CheckResourceRef;
+  checkID: string;
+  category: string;
+  effectiveSeverity: CheckSeverity;
+  title: string;
+  message: string;
+  affectedFindings: number;
+  affectedResources: number;
+  representativeFinding: EffectiveCheckFinding;
+  findings: EffectiveCheckFinding[];
+  priorityFactors: PriorityFactor[];
+}

--- a/packages/k8s-ui/src/index.ts
+++ b/packages/k8s-ui/src/index.ts
@@ -40,6 +40,11 @@ export * from './components/topology'
 // Cluster audit (AuditCard, AuditAlerts, AuditFindingsTable)
 export * from './components/audit'
 
+// Checks remediation queue (ActionItemsView, ActionItemDrawer, shared types +
+// severity vocabulary). Host-agnostic: Hub feeds fleet-resolved data, OSS can
+// feed a single-cluster resolve.
+export * from './components/checks'
+
 // Cluster switcher (shared trigger+dropdown for OSS Radar and Radar Hub)
 export * from './components/cluster-switcher'
 


### PR DESCRIPTION
Adds a **host-agnostic Checks remediation queue** to `@skyhook-io/k8s-ui` so Radar Hub and OSS Radar share one audit/Checks UX instead of maintaining divergent implementations. (Radar Hub built this bespoke first; this promotes it to the shared layer, same pattern as `AuditFindingsTable`.)

## Components
- **`ActionItemsView`** — triage header (proportional severity distribution bar + severity/category filter chips + search) and a severity-railed, priority-sorted queue. Rows open the drawer; a chevron peeks affected resources inline.
- **`ActionItemDrawer`** — per-item cockpit: check metadata, "How to fix" remediation, the **detector→effective severity** transition, a **visualized priority breakdown** (proportional weight bars summing to the score — no hidden number), and the affected-resource list.
- **Types + identity helpers** — `CheckResourceRef`, `EffectiveCheckFinding`, `CheckActionItem`, `PriorityFactor`, `CheckSeverity`, `resourceKey`/`checkFindingKey`, plus the 4-tier severity styling.

## Host-agnostic by injection
- `resourceHref(ref)` → deep-link href (Hub cross-SPA `/c/:id/...` vs OSS in-app); omit to render non-link text.
- `clusterLabel(item)` → fleet cluster label; omit for single-cluster OSS (no cluster column).
- `emptyAction` → host-specific empty-state CTA.

Named **`CheckResourceRef`** (not `ResourceRef`) to avoid colliding with the existing relationship `ResourceRef` in `types/core.ts`.

## Tests
`checks.test.ts` pins the identity contract (cross-group + cross-cluster collision, detail discriminator) and severity mapping. Full k8s-ui suite green (`416 passed`); `tsc` clean.

## Consumers
- radar-hub-web fleet Checks page (Hub) — consumes these now (separate PR).
- OSS Radar can adopt the queue for a single-cluster resolve as a follow-up.

Publish: tag `k8s-ui-v<next-minor>` after merge so hub-web (`^1.7.2`) picks it up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New UI library surface and types only; no auth, data, or backend changes. Hosts must map payloads correctly when adopting.
> 
> **Overview**
> Introduces a **host-agnostic Checks remediation queue** in `@skyhook-io/k8s-ui` so Radar Hub and OSS Radar can share one UX (same idea as `AuditFindingsTable`).
> 
> **`ActionItemsView`** drives triage: severity distribution bar, severity/category filters, search, and a worst-first queue with expandable affected resources. Rows open **`ActionItemDrawer`**, a portaled slide-over with remediation copy, detector→effective severity, a visual priority breakdown, and per-resource deep links.
> 
> Shared **`types`** define `CheckActionItem`, `CheckResourceRef` (avoids clashing with relationship `ResourceRef`), identity helpers (`resourceKey`, `checkFindingKey`), and a 4-tier severity ladder plus **`severity`** styling. Hosts inject **`resourceHref`**, **`clusterLabel`**, and **`emptyAction`** for routing, fleet vs single-cluster, and empty CTAs.
> 
> **`checks.test.ts`** locks identity and severity mapping; the package **`index`** re-exports the new module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36efcb1663e43bc4bf9454db64c291f1dedfe050. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->