### PR TITLE
feat(resources,gitops): add Clear filters button with namespace reset

### DIFF
--- a/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
@@ -503,7 +503,7 @@ export function GitOpsTableView({
             <div className="p-4 text-sm text-red-500">Failed to load GitOps applications: {error.message}</div>
           ) : filteredRows.length === 0 ? (
             <div className="flex h-full flex-col items-center justify-center gap-3 text-sm text-theme-text-secondary">
-              <p>{allRows.length === 0 ? 'No applications found.' : 'No applications match the current filters.'}</p>
+              <p>{allRows.length === 0 && !hasGlobalNamespaceFilter ? 'No applications found.' : 'No applications match the current filters.'}</p>
               {hasGlobalNamespaceFilter && globalNamespaces && (
                 <p className="text-xs text-theme-text-tertiary">
                   Viewing {globalNamespaces.length === 1 ? `namespace: ${globalNamespaces[0]}` : `${globalNamespaces.length} namespaces`}

--- a/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
@@ -513,7 +513,7 @@ export function GitOpsTableView({
                   Viewing {globalNamespaces.length === 1 ? `namespace: ${globalNamespaces[0]}` : `${globalNamespaces.length} namespaces`}
                 </p>
               )}
-              {hasAnyFilter && (
+              {(hasGlobalNamespaceFilter || (allRows.length > 0 && hasLocalFilters)) && (
                 <button
                   type="button"
                   onClick={clearAllFilters}

--- a/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
@@ -11,6 +11,7 @@ import {
   List,
   Loader2,
   RefreshCw,
+  RotateCcw,
   Search,
   Tag,
   Trash2,
@@ -153,6 +154,18 @@ export interface GitOpsTableViewProps {
   // detected" copy. Hub passes "No GitOps resources across the fleet".
   emptyStateTitle?: string
   emptyStateBody?: string
+  /**
+   * Global namespace pick from the host's NamespaceSwitcher. Used to
+   * surface "viewing in namespace: X" context and to power the Clear
+   * filters affordance when no rows match. Host owns the state; shared
+   * component is read-only.
+   */
+  globalNamespaces?: string[]
+  /**
+   * Resets the global namespace pick. When wired, the "Clear filters"
+   * button drops it alongside view-local filter state.
+   */
+  onClearNamespaces?: () => void
 }
 
 // ----- Main component --------------------------------------------------------
@@ -172,6 +185,8 @@ export function GitOpsTableView({
   searchHotkey,
   emptyStateTitle,
   emptyStateBody,
+  globalNamespaces,
+  onClearNamespaces,
 }: GitOpsTableViewProps) {
   const searchInputRef = useRef<HTMLInputElement>(null)
   const [mode, setMode] = useState<GitOpsMode>('applications')
@@ -187,6 +202,34 @@ export function GitOpsTableView({
   const [automationFilter, setAutomationFilter] = useState<'all' | 'auto' | 'manual' | 'suspended'>('all')
   const [lifecycleFilter, setLifecycleFilter] = useState<'all' | 'terminating' | 'active'>('all')
   const [sortKey, setSortKey] = useState<SortKey>('health')
+
+  const hasLocalFilters =
+    !!search ||
+    syncFilters.size > 0 ||
+    healthFilters.size > 0 ||
+    projectFilters.size > 0 ||
+    namespaceFilters.size > 0 ||
+    labelFilters.size > 0 ||
+    automationFilter !== 'all' ||
+    lifecycleFilter !== 'all'
+  const hasGlobalNamespaceFilter = !!onClearNamespaces && (globalNamespaces?.length ?? 0) > 0
+  const hasAnyFilter = hasLocalFilters || hasGlobalNamespaceFilter
+
+  const clearLocalFilters = () => {
+    setSearch('')
+    setSyncFilters(new Set())
+    setHealthFilters(new Set())
+    setProjectFilters(new Set())
+    setNamespaceFilters(new Set())
+    setLabelFilters(new Set())
+    setAutomationFilter('all')
+    setLifecycleFilter('all')
+  }
+
+  const clearAllFilters = () => {
+    clearLocalFilters()
+    onClearNamespaces?.()
+  }
 
   // Optional '/' keyboard shortcut to focus search. Avoided as a default to
   // not collide with other surfaces' keyboard maps; OSS opts in via prop.
@@ -319,16 +362,7 @@ export function GitOpsTableView({
         namespaces={rowNamespaces}
         namespaceFilters={namespaceFilters}
         onToggleNamespace={(value) => toggleSet(namespaceFilters, setNamespaceFilters, value)}
-        onClear={() => {
-          setSearch('')
-          setSyncFilters(new Set())
-          setHealthFilters(new Set())
-          setProjectFilters(new Set())
-          setNamespaceFilters(new Set())
-          setLabelFilters(new Set())
-          setAutomationFilter('all')
-          setLifecycleFilter('all')
-        }}
+        onClear={clearAllFilters}
       />
 
       <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
@@ -426,6 +460,18 @@ export function GitOpsTableView({
                 ))}
               </div>
             )}
+            {hasAnyFilter && (
+              <Tooltip content="Reset all filters and the active namespace">
+                <button
+                  type="button"
+                  onClick={clearAllFilters}
+                  className="inline-flex h-8 items-center gap-1.5 rounded-md border border-theme-border bg-theme-base px-2.5 text-xs text-theme-text-secondary hover:bg-theme-hover hover:text-theme-text-primary"
+                >
+                  <RotateCcw className="h-3.5 w-3.5" />
+                  Clear filters
+                </button>
+              </Tooltip>
+            )}
             <div className="flex shrink-0 items-center gap-0 overflow-hidden rounded-md border border-theme-border">
               <GitOpsIconToggle active={viewMode === 'table'} label="Table view" icon={List} onClick={() => setViewMode('table')} />
               <GitOpsIconToggle active={viewMode === 'tiles'} label="Tiles view" icon={LayoutGrid} onClick={() => setViewMode('tiles')} />
@@ -456,8 +502,23 @@ export function GitOpsTableView({
           ) : error ? (
             <div className="p-4 text-sm text-red-500">Failed to load GitOps applications: {error.message}</div>
           ) : filteredRows.length === 0 ? (
-            <div className="flex h-full items-center justify-center text-sm text-theme-text-secondary">
-              No applications match the current filters.
+            <div className="flex h-full flex-col items-center justify-center gap-3 text-sm text-theme-text-secondary">
+              <p>{allRows.length === 0 ? 'No applications found.' : 'No applications match the current filters.'}</p>
+              {hasGlobalNamespaceFilter && globalNamespaces && (
+                <p className="text-xs text-theme-text-tertiary">
+                  Viewing {globalNamespaces.length === 1 ? `namespace: ${globalNamespaces[0]}` : `${globalNamespaces.length} namespaces`}
+                </p>
+              )}
+              {hasAnyFilter && (
+                <button
+                  type="button"
+                  onClick={clearAllFilters}
+                  className="inline-flex items-center gap-1.5 rounded-md bg-theme-elevated px-3 py-1.5 text-sm text-theme-text-secondary transition-colors hover:bg-theme-border hover:text-theme-text-primary"
+                >
+                  <RotateCcw className="h-3.5 w-3.5" />
+                  Clear filters
+                </button>
+              )}
             </div>
           ) : viewMode === 'tiles' ? (
             <GitOpsTiles rows={filteredRows} onOpen={onRowClick} />

--- a/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
@@ -465,7 +465,7 @@ export function GitOpsTableView({
               </div>
             )}
             {hasAnyFilter && (
-              <Tooltip content="Reset all filters and the active namespace">
+              <Tooltip content={hasGlobalNamespaceFilter ? 'Reset all filters and the active namespace' : 'Reset all filters'}>
                 <button
                   type="button"
                   onClick={clearAllFilters}

--- a/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
@@ -321,7 +321,11 @@ export function GitOpsTableView({
   const terminatingCount = useMemo(() => allRows.filter((row) => row.terminating).length, [allRows])
 
   // Empty-state — when there's truly nothing to show across all kinds.
-  if (totalGitOps === 0 && !loading) {
+  // `counts` is server-filtered by the global namespace pick, so a
+  // namespace-scoped zero is NOT the same as cluster-empty. Fall through
+  // to the actionable empty state below when the host owns a namespace
+  // pick we can clear; otherwise the user lands here with no escape hatch.
+  if (totalGitOps === 0 && !loading && !hasGlobalNamespaceFilter) {
     return (
       <div className="flex h-full min-h-0 flex-1 items-center justify-center bg-theme-base p-4">
         <div className="rounded-lg border border-theme-border bg-theme-surface p-8 text-center">

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -2703,6 +2703,7 @@ export function ResourcesView({
     setOwnerName('')
     setShowInactiveReplicaSets(false)
     // Drop filter-only URL params; leave path + kind + cross-view params alone.
+    // Host-owned params (namespaces, etc.) are cleaned by onClearNamespaces.
     const params = new URLSearchParams(window.location.search)
     for (const key of ['search', 'filters', 'problems', 'labels', 'ownerKind', 'ownerName', 'showInactive']) {
       params.delete(key)

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1776,6 +1776,13 @@ interface ResourcesViewProps {
    * namespace+name only.
    */
   resolveRowCluster?: (resource: any) => { id: string; name: string } | undefined
+  /**
+   * Clears the global namespace selection (the header NamespaceSwitcher state).
+   * When wired, the "Clear filters" button also drops the active namespaces;
+   * otherwise it only resets the view-local filter state. Host-owned because
+   * the switcher lives outside this component and may persist server-side.
+   */
+  onClearNamespaces?: () => void
 }
 
 // Default selected kind
@@ -1922,6 +1929,7 @@ export function ResourcesView({
   onRowSelect,
   onCompareSubmit,
   resolveRowCluster,
+  onClearNamespaces,
 }: ResourcesViewProps) {
   const initialFilters = getInitialFiltersFromURL()
   const [selectedKind, setSelectedKind] = useState<SelectedKindInfo>(() => getInitialKindFromURL(basePath, defaultKind, locationPathname, locationSearch))
@@ -2683,6 +2691,25 @@ export function ResourcesView({
     // updates — they'd still rewrite the address bar through history.
     navigate({ pathname: newPath, search: queryStr }, { replace: !pushHistory })
   }, [navigate, basePath])
+
+  // One-click reset of every view-local filter + optional global namespace
+  // clear. Wired to the toolbar and empty-state "Clear filters" affordance.
+  const clearAllFilters = useCallback(() => {
+    setSearchTerm('')
+    setColumnFilters({})
+    setProblemFilters([])
+    setLabelSelector('')
+    setOwnerKind('')
+    setOwnerName('')
+    setShowInactiveReplicaSets(false)
+    // Drop filter-only URL params; leave path + kind + cross-view params alone.
+    const params = new URLSearchParams(window.location.search)
+    for (const key of ['search', 'filters', 'problems', 'labels', 'ownerKind', 'ownerName', 'showInactive']) {
+      params.delete(key)
+    }
+    navigate({ pathname: window.location.pathname, search: params.toString() }, { replace: true })
+    onClearNamespaces?.()
+  }, [navigate, onClearNamespaces])
 
   // Update URL when any filter changes
   useEffect(() => {
@@ -3505,6 +3532,16 @@ export function ResourcesView({
 
   // Check if any filters are active
   const hasOwnerFilter = ownerKind !== '' && ownerName !== ''
+  // Any view-local filter, the global namespace pick (when host wires a
+  // clearer), or just a stray search term — gates "Clear filters" visibility.
+  const hasAnyFilter =
+    !!searchTerm ||
+    !!labelSelector ||
+    hasOwnerFilter ||
+    problemFilters.length > 0 ||
+    Object.values(columnFilters).some((vals) => vals.length > 0) ||
+    showInactiveReplicaSets ||
+    (!!onClearNamespaces && namespaces.length > 0)
 
 
   // Toggle problem filter
@@ -3799,6 +3836,19 @@ export function ResourcesView({
             </span>
           )}
 
+          {hasAnyFilter && (
+            <Tooltip content="Reset all filters and the active namespace">
+              <button
+                type="button"
+                onClick={clearAllFilters}
+                className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated transition-colors"
+              >
+                <RotateCcw className="w-3.5 h-3.5" />
+                <span>Clear filters</span>
+              </button>
+            </Tooltip>
+          )}
+
           {lastUpdated && <LastUpdatedLabel lastUpdated={lastUpdated} />}
           {/* Column picker */}
           <div className="relative" ref={columnPickerRef}>
@@ -3978,6 +4028,16 @@ export function ResourcesView({
                   </div>
                 )
               })()}
+              {hasAnyFilter && (
+                <button
+                  type="button"
+                  onClick={clearAllFilters}
+                  className="flex items-center gap-1.5 mt-3 px-3 py-1.5 text-sm rounded-md bg-theme-elevated hover:bg-theme-border text-theme-text-secondary hover:text-theme-text-primary transition-colors"
+                >
+                  <RotateCcw className="w-3.5 h-3.5" />
+                  Clear filters
+                </button>
+              )}
             </div>
           ) : (
             <MetricsContext.Provider value={metricsLookup}>

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -3837,7 +3837,7 @@ export function ResourcesView({
           )}
 
           {hasAnyFilter && (
-            <Tooltip content="Reset all filters and the active namespace">
+            <Tooltip content={!!onClearNamespaces && namespaces.length > 0 ? 'Reset all filters and the active namespace' : 'Reset all filters'}>
               <button
                 type="button"
                 onClick={clearAllFilters}

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -2692,8 +2692,6 @@ export function ResourcesView({
     navigate({ pathname: newPath, search: queryStr }, { replace: !pushHistory })
   }, [navigate, basePath])
 
-  // One-click reset of every view-local filter + optional global namespace
-  // clear. Wired to the toolbar and empty-state "Clear filters" affordance.
   const clearAllFilters = useCallback(() => {
     setSearchTerm('')
     setColumnFilters({})
@@ -2702,8 +2700,9 @@ export function ResourcesView({
     setOwnerKind('')
     setOwnerName('')
     setShowInactiveReplicaSets(false)
-    // Drop filter-only URL params; leave path + kind + cross-view params alone.
-    // Host-owned params (namespaces, etc.) are cleaned by onClearNamespaces.
+    // Filter-only URL params. Path + kind + namespace + other cross-view
+    // params are out of scope here; the host's onClearNamespaces (and its
+    // own state→URL sync) owns namespace cleanup.
     const params = new URLSearchParams(window.location.search)
     for (const key of ['search', 'filters', 'problems', 'labels', 'ownerKind', 'ownerName', 'showInactive']) {
       params.delete(key)
@@ -3533,8 +3532,9 @@ export function ResourcesView({
 
   // Check if any filters are active
   const hasOwnerFilter = ownerKind !== '' && ownerName !== ''
-  // Any view-local filter, the global namespace pick (when host wires a
-  // clearer), or just a stray search term — gates "Clear filters" visibility.
+  // Namespace contribution gated on a host-wired clearer: without it the
+  // Clear filters button can't drop the namespace, so showing it would be
+  // a no-op for that case.
   const hasAnyFilter =
     !!searchTerm ||
     !!labelSelector ||

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1491,6 +1491,10 @@ function AppInner() {
             onResourceClickYaml={(res) => navigateToResource(res, 'yaml')}
             onKindChange={() => setSelectedResource(null)}
             onClearNamespaces={() => {
+              const params = new URLSearchParams(window.location.search)
+              params.delete('namespaces')
+              params.delete('namespace')
+              setSearchParams(params, { replace: true })
               setNamespaces([])
               setActiveNamespace.mutate({ namespaces: [] })
             }}
@@ -1543,6 +1547,10 @@ function AppInner() {
               setSelectedResource(resource)
             }}
             onClearNamespaces={() => {
+              const params = new URLSearchParams(window.location.search)
+              params.delete('namespaces')
+              params.delete('namespace')
+              setSearchParams(params, { replace: true })
               setNamespaces([])
               setActiveNamespace.mutate({ namespaces: [] })
             }}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -769,18 +769,21 @@ function AppInner() {
   // lists) stay in lockstep with the picker. The dedicated URL-write effect
   // below propagates the mirrored state to `?namespaces=`.
   const setActiveNamespace = useSetActiveNamespace()
-  // Defer state-clear until the mutation lands. setNamespaces([]) immediately
-  // would refetch under the new empty key while the server still holds the
-  // previous per-user pref, caching that stale scope under the new key with
-  // no key change to trigger a later refresh. Touching the URL synchronously
-  // here would also trip the URL→state sync at L878 into firing the clear
-  // (and a duplicate mutation) ahead of onSettled, so the state→URL effect
-  // below propagates state=[] → URL after onSettled instead.
+  // Defer state-clear to onSuccess (NOT onSettled): flipping state before
+  // the server pref is actually cleared triggers a refetch under the new
+  // empty key while the server still holds the previous pick, caching that
+  // stale scope under the new key with no key change to trigger a later
+  // refresh. onSettled fires on errors too, which would produce the same
+  // stale cache for a failed clear; onSuccess keeps state aligned with the
+  // server. Touching the URL synchronously here would also trip the URL→
+  // state sync at L878 into firing the clear (and a duplicate mutation)
+  // ahead of onSuccess, so the state→URL effect below propagates state=[]
+  // → URL after onSuccess instead.
   const clearAllNamespaces = useCallback(() => {
     if (namespaces.length === 0) return
     setActiveNamespace.mutate(
       { namespaces: [] },
-      { onSettled: () => setNamespaces([]) },
+      { onSuccess: () => setNamespaces([]) },
     )
   }, [namespaces.length, setActiveNamespace])
   const initialBookmarkReconciledRef = useRef(false)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1490,6 +1490,10 @@ function AppInner() {
             onResourceClick={(res) => res ? navigateToResource(res) : setSelectedResource(null)}
             onResourceClickYaml={(res) => navigateToResource(res, 'yaml')}
             onKindChange={() => setSelectedResource(null)}
+            onClearNamespaces={() => {
+              setNamespaces([])
+              setActiveNamespace.mutate({ namespaces: [] })
+            }}
           />
         )}
 
@@ -1537,6 +1541,10 @@ function AppInner() {
             namespaces={namespaces}
             onOpenResource={(resource) => {
               setSelectedResource(resource)
+            }}
+            onClearNamespaces={() => {
+              setNamespaces([])
+              setActiveNamespace.mutate({ namespaces: [] })
             }}
           />
         )}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -772,19 +772,17 @@ function AppInner() {
   // Defer state-clear until the mutation lands. setNamespaces([]) immediately
   // would refetch under the new empty key while the server still holds the
   // previous per-user pref, caching that stale scope under the new key with
-  // no key change to trigger a later refresh. URL drops synchronously so the
-  // URL→state sync doesn't re-hydrate the previous pick.
+  // no key change to trigger a later refresh. Touching the URL synchronously
+  // here would also trip the URL→state sync at L878 into firing the clear
+  // (and a duplicate mutation) ahead of onSettled, so the state→URL effect
+  // below propagates state=[] → URL after onSettled instead.
   const clearAllNamespaces = useCallback(() => {
-    const params = new URLSearchParams(window.location.search)
-    params.delete('namespaces')
-    params.delete('namespace')
-    setSearchParams(params, { replace: true })
     if (namespaces.length === 0) return
     setActiveNamespace.mutate(
       { namespaces: [] },
       { onSettled: () => setNamespaces([]) },
     )
-  }, [namespaces.length, setSearchParams, setActiveNamespace])
+  }, [namespaces.length, setActiveNamespace])
   const initialBookmarkReconciledRef = useRef(false)
   const scopeActives = useMemo(() => namespaceScope?.actives ?? [], [namespaceScope?.actives])
   const namespaceScopeKey = useMemo(() => namespaceScope ? [...scopeActives].sort().join(',') : null, [namespaceScope, scopeActives])

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -769,16 +769,20 @@ function AppInner() {
   // lists) stay in lockstep with the picker. The dedicated URL-write effect
   // below propagates the mirrored state to `?namespaces=`.
   const setActiveNamespace = useSetActiveNamespace()
-  // Clear the global namespace pick atomically with its URL param so the
-  // URL→state sync at L862 doesn't re-hydrate the old pick before the
-  // state→URL sync can clean it.
+  // Defer state-clear until the mutation lands. setNamespaces([]) immediately
+  // would refetch under the new empty key while the server still holds the
+  // previous per-user pref, caching that stale scope under the new key with
+  // no key change to trigger a later refresh. URL drops synchronously so the
+  // URL→state sync doesn't re-hydrate the previous pick.
   const clearAllNamespaces = useCallback(() => {
     const params = new URLSearchParams(window.location.search)
     params.delete('namespaces')
     params.delete('namespace')
     setSearchParams(params, { replace: true })
-    setNamespaces([])
-    setActiveNamespace.mutate({ namespaces: [] })
+    setActiveNamespace.mutate(
+      { namespaces: [] },
+      { onSettled: () => setNamespaces([]) },
+    )
   }, [setSearchParams, setActiveNamespace])
   const initialBookmarkReconciledRef = useRef(false)
   const scopeActives = useMemo(() => namespaceScope?.actives ?? [], [namespaceScope?.actives])

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -769,6 +769,17 @@ function AppInner() {
   // lists) stay in lockstep with the picker. The dedicated URL-write effect
   // below propagates the mirrored state to `?namespaces=`.
   const setActiveNamespace = useSetActiveNamespace()
+  // Clear the global namespace pick atomically with its URL param so the
+  // URL→state sync at L862 doesn't re-hydrate the old pick before the
+  // state→URL sync can clean it.
+  const clearAllNamespaces = useCallback(() => {
+    const params = new URLSearchParams(window.location.search)
+    params.delete('namespaces')
+    params.delete('namespace')
+    setSearchParams(params, { replace: true })
+    setNamespaces([])
+    setActiveNamespace.mutate({ namespaces: [] })
+  }, [setSearchParams, setActiveNamespace])
   const initialBookmarkReconciledRef = useRef(false)
   const scopeActives = useMemo(() => namespaceScope?.actives ?? [], [namespaceScope?.actives])
   const namespaceScopeKey = useMemo(() => namespaceScope ? [...scopeActives].sort().join(',') : null, [namespaceScope, scopeActives])
@@ -1490,14 +1501,7 @@ function AppInner() {
             onResourceClick={(res) => res ? navigateToResource(res) : setSelectedResource(null)}
             onResourceClickYaml={(res) => navigateToResource(res, 'yaml')}
             onKindChange={() => setSelectedResource(null)}
-            onClearNamespaces={() => {
-              const params = new URLSearchParams(window.location.search)
-              params.delete('namespaces')
-              params.delete('namespace')
-              setSearchParams(params, { replace: true })
-              setNamespaces([])
-              setActiveNamespace.mutate({ namespaces: [] })
-            }}
+            onClearNamespaces={clearAllNamespaces}
           />
         )}
 
@@ -1546,14 +1550,7 @@ function AppInner() {
             onOpenResource={(resource) => {
               setSelectedResource(resource)
             }}
-            onClearNamespaces={() => {
-              const params = new URLSearchParams(window.location.search)
-              params.delete('namespaces')
-              params.delete('namespace')
-              setSearchParams(params, { replace: true })
-              setNamespaces([])
-              setActiveNamespace.mutate({ namespaces: [] })
-            }}
+            onClearNamespaces={clearAllNamespaces}
           />
         )}
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -769,16 +769,18 @@ function AppInner() {
   // lists) stay in lockstep with the picker. The dedicated URL-write effect
   // below propagates the mirrored state to `?namespaces=`.
   const setActiveNamespace = useSetActiveNamespace()
-  // Defer state-clear to onSuccess (NOT onSettled): flipping state before
-  // the server pref is actually cleared triggers a refetch under the new
-  // empty key while the server still holds the previous pick, caching that
-  // stale scope under the new key with no key change to trigger a later
-  // refresh. onSettled fires on errors too, which would produce the same
-  // stale cache for a failed clear; onSuccess keeps state aligned with the
-  // server. Touching the URL synchronously here would also trip the URL→
-  // state sync at L878 into firing the clear (and a duplicate mutation)
-  // ahead of onSuccess, so the state→URL effect below propagates state=[]
-  // → URL after onSuccess instead.
+  // Defer the state flip to onSuccess. Setting namespaces to [] before the
+  // server-side pref has actually been cleared makes React Query refetch
+  // under the new empty key while the server still returns the previous
+  // pick's scope, caching stale data under the new key with no later
+  // invalidation. onSettled would do the same on errors, leaving the UI
+  // showing "All namespaces" while data is still namespace-scoped — onSuccess
+  // keeps state aligned with the server.
+  //
+  // Don't touch the URL here either: setSearchParams on a still-set state
+  // trips the URL→state sync into firing setNamespaces([]) and a duplicate
+  // mutation immediately, which re-introduces the same race. The state→URL
+  // effect propagates state=[] → URL on its own after onSuccess flips state.
   const clearAllNamespaces = useCallback(() => {
     if (namespaces.length === 0) return
     setActiveNamespace.mutate(

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -779,11 +779,12 @@ function AppInner() {
     params.delete('namespaces')
     params.delete('namespace')
     setSearchParams(params, { replace: true })
+    if (namespaces.length === 0) return
     setActiveNamespace.mutate(
       { namespaces: [] },
       { onSettled: () => setNamespaces([]) },
     )
-  }, [setSearchParams, setActiveNamespace])
+  }, [namespaces.length, setSearchParams, setActiveNamespace])
   const initialBookmarkReconciledRef = useRef(false)
   const scopeActives = useMemo(() => namespaceScope?.actives ?? [], [namespaceScope?.actives])
   const namespaceScopeKey = useMemo(() => namespaceScope ? [...scopeActives].sort().join(',') : null, [namespaceScope, scopeActives])

--- a/web/src/components/gitops/GitOpsView.tsx
+++ b/web/src/components/gitops/GitOpsView.tsx
@@ -86,17 +86,18 @@ interface ResourceCountsResponse {
 interface GitOpsViewProps {
   namespaces: string[]
   onOpenResource: (resource: SelectedResource) => void
+  onClearNamespaces?: () => void
 }
 
-export function GitOpsView({ namespaces, onOpenResource }: GitOpsViewProps) {
+export function GitOpsView({ namespaces, onOpenResource, onClearNamespaces }: GitOpsViewProps) {
   const location = useLocation()
   if (location.pathname.startsWith('/gitops/detail/')) {
     return <GitOpsDetailView namespaces={namespaces} onOpenResource={onOpenResource} />
   }
-  return <GitOpsTableView namespaces={namespaces} />
+  return <GitOpsTableView namespaces={namespaces} onClearNamespaces={onClearNamespaces} />
 }
 
-function GitOpsTableView({ namespaces }: { namespaces: string[] }) {
+function GitOpsTableView({ namespaces, onClearNamespaces }: { namespaces: string[]; onClearNamespaces?: () => void }) {
   const navigate = useNavigate()
   const namespacesParam = namespaces.join(',')
   const { data: apiResources, isLoading: apiResourcesLoading } = useAPIResources()
@@ -170,6 +171,8 @@ function GitOpsTableView({ namespaces }: { namespaces: string[] }) {
         navigate({ pathname: gitOpsDetailPath(row.kindName, ns, row.name), search: params.toString() })
       }}
       searchHotkey
+      globalNamespaces={namespaces}
+      onClearNamespaces={onClearNamespaces}
     />
   )
 }

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -28,9 +28,10 @@ interface ResourcesViewProps {
   onResourceClick?: (resource: SelectedResource | null) => void
   onResourceClickYaml?: NavigateToResource
   onKindChange?: () => void
+  onClearNamespaces?: () => void
 }
 
-export function ResourcesView({ namespaces, selectedResource, onResourceClick, onResourceClickYaml, onKindChange }: ResourcesViewProps) {
+export function ResourcesView({ namespaces, selectedResource, onResourceClick, onResourceClickYaml, onKindChange, onClearNamespaces }: ResourcesViewProps) {
   const location = useLocation()
   const navigate = useNavigate()
 
@@ -191,6 +192,7 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
       onResourceClick={onResourceClick}
       onResourceClickYaml={onResourceClickYaml}
       onKindChange={onKindChange}
+      onClearNamespaces={onClearNamespaces}
       // Injected data
       apiResources={apiResources}
       // Lightweight counts for sidebar (replaces 233 parallel queries)


### PR DESCRIPTION
## Summary

Deep-linking into the Resources viewer or GitOps list often leaves the user in a filtered context (namespace, owner, labels, etc.) with no quick way back to "show me everything". This adds:

- **Toolbar `[⟲ Clear filters]` button** on both views, visible whenever any filter is active.
- **Actionable empty state** — the "No applications match the current filters." message now ships a matching Clear button beside it, and disambiguates "no rows at all" (`No applications found.`) from "filtered out" (`No applications match...`) so the regression of "the button vanishes leaving a misleading message" is resolved.
- **Namespace reset** — a new optional `onClearNamespaces?` prop is threaded through `ResourcesView` (k8s-ui) and `GitOpsTableView` (k8s-ui) to the host. `web/src/App.tsx` wires it to a `clearAllNamespaces` callback that drops the URL param synchronously and clears React state in the mutation's `onSettled`, so the refetch happens after the server-side per-user pref clears.

One click clears search, label, owner, problem, column, automation/lifecycle/sync/health filters, the per-view namespace facets, AND the global namespace selection. The GitOps sidebar `onClear` now routes through the same path so its Clear is also full-fat.

## Why this matters

The most common stuck state today is `?namespaces=...` deep links into an empty list. Users had to navigate up to the header NamespaceSwitcher to recover; the previous in-empty-state copy ("No applications match the current filters.") implied there was something to clear, but exposed no affordance to do so.

## Visual / style

Matches the existing column-picker `Reset` button (`RotateCcw` icon + label) and the toolbar owner chip for tone parity. Theme tokens only — no hardcoded colors.

## Test plan

Visually verified on `gke_koalabackend_us-east1-b_nonprod-cluster-us-east1` at 1920×1080, screenshots in `.playwright-mcp/visual-test/20260528-091201/`.

- [x] `/resources/deployments?ownerKind=Deployment&ownerName=caretta-grafana` shows toolbar Clear filters; click drops chip + URL param. ✓
- [x] Toolbar Clear filters button appears on Resources whenever any filter is active. ✓
- [x] With a namespace picked, Resources Clear filters also drops the namespace; header switcher reflects "All namespaces" and the sidebar counts + list refresh to all-namespaces scope (validated the `onSettled` fix — without it, the refetch raced the mutation and stale-cached). ✓
- [x] `/gitops?namespaces=nonexistent-ns-xyz` shows the empty state with "Viewing namespace: nonexistent-ns-xyz" line + Clear button; click loads all 14 Argo applications across the cluster. ✓
- [ ] Cluster with zero Argo Applications: empty state reads "No applications found." with no button. **Could not exercise** — test cluster has 14 Argo Applications; the branch is gated by `allRows.length === 0 && !hasGlobalNamespaceFilter` and was verified by code review with Bugbot.
- [x] GitOps sidebar `Clear` link also drops the global namespace and surfaces all applications. ✓
- [x] Tooltip on the Clear filters button reads "Reset all filters and the active namespace" when a namespace is set, and "Reset all filters" otherwise. ✓
- [x] No new JS console errors introduced by the change.

<!-- CURSOR_SUMMARY -->
---