### PR TITLE
Issues: symptom classification + owner-grouping (engine)

### DIFF
--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -11,12 +11,12 @@
 //
 // Two compile entry points:
 //
-//   CompileObjectFilter — bindings shaped to a K8s object:
-//     kind, apiVersion, metadata, spec, status, labels, annotations
+//	CompileObjectFilter — bindings shaped to a K8s object:
+//	  kind, apiVersion, metadata, spec, status, labels, annotations
 //
-//   CompileIssueFilter — bindings shaped to an issues.Issue:
-//     severity, source, kind, group, namespace, name, reason, message,
-//     count, last_seen, cluster
+//	CompileIssueFilter — bindings shaped to an issues.Issue:
+//	  severity, source, category, category_group, kind, group, ns,
+//	  name, reason, message, count, last_seen, cluster
 //
 // Both return a Filter whose Match(activation) yields (bool, error).
 // Compile errors are returned verbatim (CEL's parser produces
@@ -96,6 +96,8 @@ var envObject = mustNewEnv(
 var envIssue = mustNewEnv(
 	cel.Variable("severity", cel.StringType),
 	cel.Variable("source", cel.StringType),
+	cel.Variable("category", cel.StringType),
+	cel.Variable("category_group", cel.StringType),
 	cel.Variable("kind", cel.StringType),
 	cel.Variable("group", cel.StringType),
 	cel.Variable("ns", cel.StringType),
@@ -264,4 +266,3 @@ func CachedIssueFilter(expr string) (*Filter, error) {
 	defaultCache.put(key, f)
 	return f, nil
 }
-

--- a/internal/issues/activation.go
+++ b/internal/issues/activation.go
@@ -11,10 +11,12 @@ func issueToActivation(i Issue) map[string]any {
 		lastSeen = i.LastSeen.Unix()
 	}
 	return map[string]any{
-		"severity":  string(i.Severity),
-		"source":    string(i.Source),
-		"kind":      i.Kind,
-		"group":     i.Group,
+		"severity":       string(i.Severity),
+		"source":         string(i.Source),
+		"category":       string(i.Category),
+		"category_group": string(i.CategoryGroup),
+		"kind":           i.Kind,
+		"group":          i.Group,
 		// `ns` rather than `namespace` — `namespace` is a CEL reserved
 		// identifier and bare references fail at parse time. See
 		// internal/filter.envIssue for the rationale.

--- a/internal/issues/category.go
+++ b/internal/issues/category.go
@@ -1,0 +1,262 @@
+package issues
+
+import "strings"
+
+// Category is the user-facing symptom taxonomy for an issue — "what kind of
+// problem is this" from an operator's mental model. It is DERIVED from the
+// detection signal (Source + Kind + Reason + Message + crash context), not a
+// new detector: the classifier below is a pure mapping over what radar already
+// emits.
+//
+// Distinct from Source (the detection channel: problem|missing_ref|scheduling|
+// condition) and from the resource's API Group. Category is the axis users
+// filter and group by; Source stays an output label / CEL binding.
+//
+// `unknown` is first-class — an unmapped signal is honestly labeled, never
+// dropped or force-fit into a neat bucket.
+type Category string
+
+const (
+	CategoryUnknown Category = "unknown"
+
+	// scheduling — can't get onto a node / rejected at admission
+	CategoryUnschedulable            Category = "unschedulable"
+	CategoryQuotaExceeded            Category = "quota_exceeded"
+	CategoryAdmissionWebhookBlocking Category = "admission_webhook_blocking"
+
+	// startup — scheduled, can't start the container
+	CategoryImagePullFailed     Category = "image_pull_failed"
+	CategoryContainerWaiting    Category = "container_waiting"
+	CategoryInitContainerFailed Category = "init_container_failed"
+
+	// runtime — started, won't stay healthy
+	CategoryCrashLoop         Category = "crashloop"
+	CategoryOOMKilled         Category = "oom_killed"
+	CategoryLivenessProbeFail Category = "liveness_probe_failed"
+	CategoryReadinessFailed   Category = "readiness_failed"
+	CategoryWorkloadDegraded  Category = "workload_degraded"
+
+	// configuration
+	CategoryMissingConfigRef Category = "missing_config_ref"
+
+	// networking
+	CategoryServiceNoEndpoints    Category = "service_no_endpoints"
+	CategoryIngressBackendMissing Category = "ingress_backend_missing"
+	CategoryDNSFailure            Category = "dns_failure"
+	CategoryNetworkPolicyBlock    Category = "network_policy_block"
+
+	// storage
+	CategoryPVCPending        Category = "pvc_pending"
+	CategoryVolumeMountFailed Category = "volume_mount_failed"
+
+	// scaling / rollout
+	CategoryRolloutStalled     Category = "rollout_stalled"
+	CategoryHPALimitedOrFailed Category = "hpa_limited_or_failed"
+
+	// security
+	CategoryRBACForbidden       Category = "rbac_forbidden"
+	CategoryCertificateNotReady Category = "certificate_not_ready"
+
+	// control plane / operators / cluster infra
+	CategoryNodeNotReady          Category = "node_not_ready"
+	CategoryOperatorConditionFail Category = "operator_condition_failed"
+	CategoryGitOpsSyncFailed      Category = "gitops_sync_failed"
+	CategoryWebhookBackendDown    Category = "webhook_backend_down"
+)
+
+// Group is the coarse rollup over categories — the ~10 buckets used for the UI
+// facet + summary strip. Derived from Category via categoryGroup; never set
+// independently.
+type Group string
+
+const (
+	GroupUnknown       Group = "unknown"
+	GroupScheduling    Group = "scheduling"
+	GroupStartup       Group = "startup"
+	GroupRuntime       Group = "runtime"
+	GroupConfiguration Group = "configuration"
+	GroupNetworking    Group = "networking"
+	GroupStorage       Group = "storage"
+	GroupScaling       Group = "scaling"
+	GroupSecurity      Group = "security"
+	GroupControlPlane  Group = "control_plane"
+	GroupApplication   Group = "application"
+)
+
+// categoryGroup is the fixed category→group rollup. Server-side source of
+// truth: the UI renders whatever group the server reports, so adding a
+// category needs no frontend change.
+var categoryGroup = map[Category]Group{
+	CategoryUnschedulable:            GroupScheduling,
+	CategoryQuotaExceeded:            GroupScheduling,
+	CategoryAdmissionWebhookBlocking: GroupScheduling,
+	CategoryImagePullFailed:          GroupStartup,
+	CategoryContainerWaiting:         GroupStartup,
+	CategoryInitContainerFailed:      GroupStartup,
+	CategoryCrashLoop:                GroupRuntime,
+	CategoryOOMKilled:                GroupRuntime,
+	CategoryLivenessProbeFail:        GroupRuntime,
+	CategoryReadinessFailed:          GroupRuntime,
+	CategoryWorkloadDegraded:         GroupRuntime,
+	CategoryMissingConfigRef:         GroupConfiguration,
+	CategoryServiceNoEndpoints:       GroupNetworking,
+	CategoryIngressBackendMissing:    GroupNetworking,
+	CategoryDNSFailure:               GroupNetworking,
+	CategoryNetworkPolicyBlock:       GroupNetworking,
+	CategoryPVCPending:               GroupStorage,
+	CategoryVolumeMountFailed:        GroupStorage,
+	CategoryRolloutStalled:           GroupScaling,
+	CategoryHPALimitedOrFailed:       GroupScaling,
+	CategoryRBACForbidden:            GroupSecurity,
+	CategoryCertificateNotReady:      GroupSecurity,
+	CategoryNodeNotReady:             GroupControlPlane,
+	CategoryOperatorConditionFail:    GroupControlPlane,
+	CategoryGitOpsSyncFailed:         GroupControlPlane,
+	CategoryWebhookBackendDown:       GroupControlPlane,
+}
+
+// GroupOf returns the rollup group for a category. Unknown/unmapped → unknown.
+func GroupOf(c Category) Group {
+	if g, ok := categoryGroup[c]; ok {
+		return g
+	}
+	return GroupUnknown
+}
+
+// classifyInput is the minimal signal the classifier reads. It mirrors the
+// fields an Issue already carries, so wiring is a field read (no new data).
+type classifyInput struct {
+	Source               Source
+	APIGroup             string // the resource's API group (Issue.Group)
+	Kind                 string
+	Reason               string
+	LastTerminatedReason string
+}
+
+// Classify maps a detection signal to a user-facing Category. Pure and
+// deterministic — same inputs always yield the same category, so the
+// category-in-issue-id contract stays stable (no oscillation). Grounded in the
+// exact reason vocabulary emitted by internal/k8s/{health,problems,scheduling,
+// missing_refs}.go and internal/issues/conditions.go.
+//
+// Coverage is intentionally partial: signals without a clean mapping (and
+// categories whose detectors don't exist yet — probes, DNS, network policy,
+// real RBAC-forbidden) fall to CategoryUnknown rather than being force-fit.
+func Classify(in classifyInput) Category {
+	switch in.Source {
+	case SourceScheduling:
+		switch in.Reason {
+		case "Unschedulable":
+			return CategoryUnschedulable
+		case "QuotaExceeded", "LimitRangeViolation":
+			return CategoryQuotaExceeded
+		case "PodSecurityViolation", "WebhookDenied":
+			return CategoryAdmissionWebhookBlocking
+		case "IPExhaustion", "SandboxCreationFailed":
+			// scheduled but stuck creating the sandbox — a startup-stage stall
+			return CategoryContainerWaiting
+		case "VolumeMultiAttach", "VolumeAttach", "VolumeMount":
+			return CategoryVolumeMountFailed
+		}
+		return CategoryUnknown
+
+	case SourceMissingRef:
+		// Ingress backend refs are their own category; webhook backends map to
+		// the control-plane "backend down"; everything else is a dangling
+		// config/resource reference.
+		switch in.Reason {
+		case "Missing backend Service", "Missing backend Service port":
+			return CategoryIngressBackendMissing
+		case "Missing webhook backend Service":
+			return CategoryWebhookBackendDown
+		case "Missing StorageClass":
+			// the dangling ref is a StorageClass, but the user-facing effect is
+			// a PVC that can't provision — surface it under storage.
+			return CategoryPVCPending
+		}
+		// Missing PVC/ConfigMap/Secret/ServiceAccount/imagePullSecret (Pod),
+		// Missing scaleTargetRef (HPA), Missing headless Service (StatefulSet),
+		// Missing TLS Secret (Ingress), Missing roleRef target (RoleBinding).
+		return CategoryMissingConfigRef
+
+	case SourceCondition:
+		// Generic CRD .status.conditions[]=False fallback. Discriminate the
+		// well-known controller families by API group.
+		g := strings.ToLower(in.APIGroup)
+		switch {
+		case strings.Contains(g, "cert-manager.io"):
+			return CategoryCertificateNotReady
+		case strings.Contains(g, "argoproj.io") || strings.Contains(g, "fluxcd"):
+			return CategoryGitOpsSyncFailed
+		default:
+			return CategoryOperatorConditionFail
+		}
+
+	case SourceProblem:
+		return classifyProblem(in)
+	}
+	return CategoryUnknown
+}
+
+// classifyProblem handles the broad source=problem channel (radar's per-kind
+// detection). Split out to keep Classify readable.
+func classifyProblem(in classifyInput) Category {
+	switch in.Kind {
+	case "Pod":
+		// OOM can show as the current Reason or only in the last-terminated
+		// reason of a now-restarting container; check both.
+		if in.Reason == "OOMKilled" || in.LastTerminatedReason == "OOMKilled" {
+			return CategoryOOMKilled
+		}
+		switch in.Reason {
+		case "ImagePullBackOff", "ErrImagePull":
+			return CategoryImagePullFailed
+		case "CrashLoopBackOff":
+			return CategoryCrashLoop
+		case "CreateContainerConfigError", "Pending", "ContainerCreating":
+			return CategoryContainerWaiting
+		case "Error", "Failed":
+			// a terminated/failed pod that isn't image-pull/OOM/scheduling —
+			// closest runtime bucket is a crash.
+			return CategoryCrashLoop
+		}
+		return CategoryUnknown
+
+	case "Service":
+		// "Selector matches no pods" / "0/N selected pods ready" /
+		// "Unresolved named targetPort" all mean: no healthy endpoints.
+		return CategoryServiceNoEndpoints
+
+	case "Deployment", "StatefulSet", "DaemonSet":
+		if in.Reason == "Rollout stuck" {
+			return CategoryRolloutStalled
+		}
+		// "{avail}/{desired} available" / "{ready}/{desired} ready" /
+		// "{n} unavailable" — workload under its desired healthy count. The
+		// pod-level root (crashloop/image/etc.) groups under this once owner
+		// grouping lands.
+		return CategoryWorkloadDegraded
+
+	case "HorizontalPodAutoscaler":
+		return CategoryHPALimitedOrFailed
+
+	case "Node":
+		switch in.Reason {
+		case "NotReady", "MemoryPressure", "DiskPressure", "PIDPressure":
+			return CategoryNodeNotReady
+		}
+		// "Cordoned" is an intentional admin action, not a failure → unknown.
+		return CategoryUnknown
+
+	case "PersistentVolumeClaim":
+		if in.Reason == "Pending" {
+			return CategoryPVCPending
+		}
+		// "Lost" (bound volume gone) has no dedicated category yet.
+		return CategoryUnknown
+	}
+
+	// CronJob, Job, and the CAPI kinds (Cluster/Machine/MachineDeployment/…)
+	// have no category yet — see the taxonomy gaps noted in ISSUES_PLAN.
+	return CategoryUnknown
+}

--- a/internal/issues/category_test.go
+++ b/internal/issues/category_test.go
@@ -1,0 +1,101 @@
+package issues
+
+import "testing"
+
+func TestClassify(t *testing.T) {
+	cases := []struct {
+		name string
+		in   classifyInput
+		want Category
+	}{
+		// scheduling
+		{"unschedulable", classifyInput{Source: SourceScheduling, Kind: "Pod", Reason: "Unschedulable"}, CategoryUnschedulable},
+		{"quota", classifyInput{Source: SourceScheduling, Kind: "Deployment", Reason: "QuotaExceeded"}, CategoryQuotaExceeded},
+		{"limitrange", classifyInput{Source: SourceScheduling, Kind: "Deployment", Reason: "LimitRangeViolation"}, CategoryQuotaExceeded},
+		{"podsecurity", classifyInput{Source: SourceScheduling, Kind: "Deployment", Reason: "PodSecurityViolation"}, CategoryAdmissionWebhookBlocking},
+		{"webhook denied", classifyInput{Source: SourceScheduling, Kind: "StatefulSet", Reason: "WebhookDenied"}, CategoryAdmissionWebhookBlocking},
+		{"ip exhaustion is startup stall", classifyInput{Source: SourceScheduling, Kind: "Pod", Reason: "IPExhaustion"}, CategoryContainerWaiting},
+		{"sandbox failed is startup stall", classifyInput{Source: SourceScheduling, Kind: "Pod", Reason: "SandboxCreationFailed"}, CategoryContainerWaiting},
+		{"volume multiattach", classifyInput{Source: SourceScheduling, Kind: "Pod", Reason: "VolumeMultiAttach"}, CategoryVolumeMountFailed},
+		{"volume mount", classifyInput{Source: SourceScheduling, Kind: "Pod", Reason: "VolumeMount"}, CategoryVolumeMountFailed},
+
+		// problem / Pod
+		{"image pull backoff", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "ImagePullBackOff"}, CategoryImagePullFailed},
+		{"err image pull", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "ErrImagePull"}, CategoryImagePullFailed},
+		{"crashloop", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "CrashLoopBackOff"}, CategoryCrashLoop},
+		{"oom by reason", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "OOMKilled"}, CategoryOOMKilled},
+		{"oom by last-terminated, crashloop reason", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "CrashLoopBackOff", LastTerminatedReason: "OOMKilled"}, CategoryOOMKilled},
+		{"config error waiting", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "CreateContainerConfigError"}, CategoryContainerWaiting},
+		{"pending pod (non-scheduling)", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "Pending"}, CategoryContainerWaiting},
+		{"errored pod", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "Error"}, CategoryCrashLoop},
+
+		// problem / workloads
+		{"deploy degraded", classifyInput{Source: SourceProblem, Kind: "Deployment", Reason: "3/5 available"}, CategoryWorkloadDegraded},
+		{"deploy rollout stuck", classifyInput{Source: SourceProblem, Kind: "Deployment", Reason: "Rollout stuck"}, CategoryRolloutStalled},
+		{"statefulset degraded", classifyInput{Source: SourceProblem, Kind: "StatefulSet", Reason: "2/3 ready"}, CategoryWorkloadDegraded},
+		{"daemonset degraded", classifyInput{Source: SourceProblem, Kind: "DaemonSet", Reason: "1 unavailable"}, CategoryWorkloadDegraded},
+
+		// problem / service
+		{"service no pods", classifyInput{Source: SourceProblem, Kind: "Service", Reason: "Selector matches no pods"}, CategoryServiceNoEndpoints},
+		{"service 0 ready", classifyInput{Source: SourceProblem, Kind: "Service", Reason: "0/3 selected pods ready"}, CategoryServiceNoEndpoints},
+
+		// problem / hpa, node, pvc
+		{"hpa maxed", classifyInput{Source: SourceProblem, Kind: "HorizontalPodAutoscaler", Reason: "maxed"}, CategoryHPALimitedOrFailed},
+		{"node notready", classifyInput{Source: SourceProblem, Kind: "Node", Reason: "NotReady"}, CategoryNodeNotReady},
+		{"node mempressure", classifyInput{Source: SourceProblem, Kind: "Node", Reason: "MemoryPressure"}, CategoryNodeNotReady},
+		{"node cordoned is intentional", classifyInput{Source: SourceProblem, Kind: "Node", Reason: "Cordoned"}, CategoryUnknown},
+		{"pvc pending", classifyInput{Source: SourceProblem, Kind: "PersistentVolumeClaim", Reason: "Pending"}, CategoryPVCPending},
+		{"pvc lost is a gap", classifyInput{Source: SourceProblem, Kind: "PersistentVolumeClaim", Reason: "Lost"}, CategoryUnknown},
+
+		// missing_ref
+		{"missing configmap", classifyInput{Source: SourceMissingRef, Kind: "Pod", Reason: "Missing ConfigMap"}, CategoryMissingConfigRef},
+		{"missing secret", classifyInput{Source: SourceMissingRef, Kind: "Pod", Reason: "Missing Secret"}, CategoryMissingConfigRef},
+		{"missing pvc", classifyInput{Source: SourceMissingRef, Kind: "Pod", Reason: "Missing PVC"}, CategoryMissingConfigRef},
+		{"missing sa", classifyInput{Source: SourceMissingRef, Kind: "Pod", Reason: "Missing ServiceAccount"}, CategoryMissingConfigRef},
+		{"ingress backend missing", classifyInput{Source: SourceMissingRef, Kind: "Ingress", APIGroup: "networking.k8s.io", Reason: "Missing backend Service"}, CategoryIngressBackendMissing},
+		{"ingress tls secret is config", classifyInput{Source: SourceMissingRef, Kind: "Ingress", APIGroup: "networking.k8s.io", Reason: "Missing TLS Secret"}, CategoryMissingConfigRef},
+		{"webhook backend down", classifyInput{Source: SourceMissingRef, Kind: "ValidatingWebhookConfiguration", APIGroup: "admissionregistration.k8s.io", Reason: "Missing webhook backend Service"}, CategoryWebhookBackendDown},
+		{"missing storageclass is pvc pending", classifyInput{Source: SourceMissingRef, Kind: "PersistentVolumeClaim", Reason: "Missing StorageClass"}, CategoryPVCPending},
+		{"missing roleref is config", classifyInput{Source: SourceMissingRef, Kind: "RoleBinding", APIGroup: "rbac.authorization.k8s.io", Reason: "Missing roleRef target"}, CategoryMissingConfigRef},
+
+		// condition (CRD fallback) — discriminated by API group
+		{"argo sync failed", classifyInput{Source: SourceCondition, Kind: "Application", APIGroup: "argoproj.io", Reason: "Synced: ComparisonError"}, CategoryGitOpsSyncFailed},
+		{"flux helmrelease", classifyInput{Source: SourceCondition, Kind: "HelmRelease", APIGroup: "helm.toolkit.fluxcd.io", Reason: "Ready=False"}, CategoryGitOpsSyncFailed},
+		{"cert-manager not ready", classifyInput{Source: SourceCondition, Kind: "Certificate", APIGroup: "cert-manager.io", Reason: "Ready: DoesNotExist"}, CategoryCertificateNotReady},
+		{"generic operator condition", classifyInput{Source: SourceCondition, Kind: "Foo", APIGroup: "example.com", Reason: "Ready=False"}, CategoryOperatorConditionFail},
+
+		// gaps → unknown (CronJob/Job/CAPI)
+		{"cronjob is a gap", classifyInput{Source: SourceProblem, Kind: "CronJob", Reason: "stale"}, CategoryUnknown},
+		{"capi machine is a gap", classifyInput{Source: SourceProblem, Kind: "Machine", APIGroup: "cluster.x-k8s.io", Reason: "Machine in Failed phase"}, CategoryUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Classify(tc.in); got != tc.want {
+				t.Errorf("Classify(%+v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGroupOf pins the category→group rollup and that every mapped category has
+// a group (no silent GroupUnknown for a real category).
+func TestGroupOf(t *testing.T) {
+	if got := GroupOf(CategoryImagePullFailed); got != GroupStartup {
+		t.Errorf("image_pull_failed group = %q, want startup", got)
+	}
+	if got := GroupOf(CategoryUnschedulable); got != GroupScheduling {
+		t.Errorf("unschedulable group = %q, want scheduling", got)
+	}
+	if got := GroupOf(CategoryGitOpsSyncFailed); got != GroupControlPlane {
+		t.Errorf("gitops_sync_failed group = %q, want control_plane", got)
+	}
+	if got := GroupOf(CategoryUnknown); got != GroupUnknown {
+		t.Errorf("unknown group = %q, want unknown", got)
+	}
+	// Every category constant that Classify can return must map to a non-unknown group.
+	for c := range categoryGroup {
+		if categoryGroup[c] == GroupUnknown {
+			t.Errorf("category %q maps to GroupUnknown", c)
+		}
+	}
+}

--- a/internal/issues/filter_integration_test.go
+++ b/internal/issues/filter_integration_test.go
@@ -88,6 +88,35 @@ func TestCompose_WithCELFilter_SourceBinding(t *testing.T) {
 	}
 }
 
+func TestCompose_WithCELFilter_CategoryBinding(t *testing.T) {
+	// category + category_group are filterable bindings, not just output
+	// labels — the UI facet and agents slice on them. Guard that both
+	// compile and match against the derived classification.
+	p := &fakeProvider{
+		problems: []k8s.Problem{
+			{Kind: "Pod", Namespace: "ns", Name: "img", Severity: "critical", Reason: "ImagePullBackOff"},
+			{Kind: "Pod", Namespace: "ns", Name: "crash", Severity: "critical", Reason: "CrashLoopBackOff"},
+		},
+	}
+	f, err := filter.CompileIssueFilter(`category == "image_pull_failed"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, _ := ComposeWithStats(p, Filters{Filter: f})
+	if len(out) != 1 || out[0].Name != "img" {
+		t.Fatalf(`category=="image_pull_failed" should keep only the image-pull row, got %+v`, out)
+	}
+
+	f, err = filter.CompileIssueFilter(`category_group == "startup"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, _ = ComposeWithStats(p, Filters{Filter: f})
+	if len(out) != 1 || out[0].Name != "img" {
+		t.Fatalf(`category_group=="startup" should keep only the startup row, got %+v`, out)
+	}
+}
+
 func TestCompose_FilterEvalError_StatsPopulated(t *testing.T) {
 	// Reference an unbound-but-syntactically-valid path that won't
 	// resolve on any actual issue row — the dyn-typed env declares

--- a/internal/issues/grouping.go
+++ b/internal/issues/grouping.go
@@ -1,0 +1,173 @@
+package issues
+
+import "sort"
+
+// maxInlineMembers bounds the member refs carried inline on a grouped issue.
+// Enough for a human or agent to see what folded without a second call;
+// full member state stays lazy (evidence). Past this, membersTruncated is
+// set and the slice is capped.
+const maxInlineMembers = 10
+
+// Affected counts the underlying resources folded into a grouped issue, by
+// kind bucket. Empty for single-resource issues (no fan-out) — there the
+// subject row already says everything.
+type Affected struct {
+	Pods      int `json:"pods,omitempty"`
+	Workloads int `json:"workloads,omitempty"`
+	Services  int `json:"services,omitempty"`
+	PVCs      int `json:"pvcs,omitempty"`
+	Nodes     int `json:"nodes,omitempty"`
+}
+
+// GroupIssues folds flat issue rows into the public grouped model: one row
+// per shared ID (subject + category). The flat rows are the evidence; a
+// grouped row is the operational issue an operator or agent triages.
+//
+// Deterministic by construction — the representative member and member
+// ordering are chosen by total comparators, so the same input always
+// yields the same output regardless of input order. Input is not mutated.
+func GroupIssues(flat []Issue) []Issue {
+	buckets := make(map[string][]Issue)
+	for _, r := range flat {
+		buckets[r.ID] = append(buckets[r.ID], r)
+	}
+	out := make([]Issue, 0, len(buckets))
+	for _, members := range buckets {
+		out = append(out, foldGroup(members))
+	}
+	sort.SliceStable(out, func(i, j int) bool { return lessIssue(out[i], out[j]) })
+	return out
+}
+
+// foldGroup collapses one group's member rows into a single grouped issue,
+// applying the representative rules: the worst member drives severity +
+// reason/message/crash context; age is the oldest onset; last_seen the
+// newest. members are the folded underlying resources (the fan-out),
+// excluding the subject itself.
+func foldGroup(members []Issue) Issue {
+	rep := members[0]
+	for _, m := range members[1:] {
+		if betterRepresentative(m, rep) {
+			rep = m
+		}
+	}
+
+	subject := Ref{Group: rep.Group, Kind: rep.Kind, Namespace: rep.Namespace, Name: rep.Name}
+	if rep.Owner.Kind != "" {
+		subject = rep.Owner
+	}
+
+	g := Issue{
+		Severity:             rep.Severity,
+		Source:               rep.Source,
+		Category:             rep.Category,
+		CategoryGroup:        rep.CategoryGroup,
+		ID:                   rep.ID,
+		GroupingScope:        rep.GroupingScope,
+		Kind:                 subject.Kind,
+		Group:                subject.Group,
+		Namespace:            subject.Namespace,
+		Name:                 subject.Name,
+		Reason:               rep.Reason,
+		Message:              rep.Message,
+		RestartCount:         rep.RestartCount,
+		LastTerminatedReason: rep.LastTerminatedReason,
+		FirstSeen:            rep.FirstSeen,
+		LastSeen:             rep.LastSeen,
+		Count:                len(members),
+	}
+
+	var refs []Ref
+	for _, m := range members {
+		if !m.FirstSeen.IsZero() && (g.FirstSeen.IsZero() || m.FirstSeen.Before(g.FirstSeen)) {
+			g.FirstSeen = m.FirstSeen
+		}
+		if m.LastSeen.After(g.LastSeen) {
+			g.LastSeen = m.LastSeen
+		}
+		own := Ref{Group: m.Group, Kind: m.Kind, Namespace: m.Namespace, Name: m.Name}
+		if own != subject {
+			refs = append(refs, own)
+		}
+	}
+	sortRefs(refs)
+	g.Affected = affectedOf(refs)
+	if len(refs) > maxInlineMembers {
+		g.MembersTruncated = true
+		refs = refs[:maxInlineMembers]
+	}
+	g.Members = refs
+	return g
+}
+
+// betterRepresentative reports whether cand should replace cur as a group's
+// representative: worst severity wins, then newest last_seen, then name
+// (member names are unique within a group, so the order is total →
+// deterministic regardless of iteration order).
+func betterRepresentative(cand, cur Issue) bool {
+	if c, r := severityRank(cand.Severity), severityRank(cur.Severity); c != r {
+		return c > r
+	}
+	if !cand.LastSeen.Equal(cur.LastSeen) {
+		return cand.LastSeen.After(cur.LastSeen)
+	}
+	return cand.Name < cur.Name
+}
+
+func affectedOf(refs []Ref) Affected {
+	var a Affected
+	for _, r := range refs {
+		switch r.Kind {
+		case "Pod":
+			a.Pods++
+		case "Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Job", "CronJob":
+			a.Workloads++
+		case "Service":
+			a.Services++
+		case "PersistentVolumeClaim":
+			a.PVCs++
+		case "Node":
+			a.Nodes++
+		}
+	}
+	return a
+}
+
+func sortRefs(refs []Ref) {
+	sort.SliceStable(refs, func(i, j int) bool {
+		if refs[i].Namespace != refs[j].Namespace {
+			return refs[i].Namespace < refs[j].Namespace
+		}
+		if refs[i].Name != refs[j].Name {
+			return refs[i].Name < refs[j].Name
+		}
+		if refs[i].Kind != refs[j].Kind {
+			return refs[i].Kind < refs[j].Kind
+		}
+		return refs[i].Group < refs[j].Group
+	})
+}
+
+// lessIssue is the canonical issue sort: severity desc, last_seen desc, then
+// category / kind / namespace / name for a stable total order. Shared by the
+// flat compose path and the grouped fold so both surfaces order identically.
+func lessIssue(a, b Issue) bool {
+	if a.Severity != b.Severity {
+		return severityRank(a.Severity) > severityRank(b.Severity)
+	}
+	if !a.LastSeen.Equal(b.LastSeen) {
+		return a.LastSeen.After(b.LastSeen)
+	}
+	if a.Kind != b.Kind {
+		return a.Kind < b.Kind
+	}
+	if a.Namespace != b.Namespace {
+		return a.Namespace < b.Namespace
+	}
+	if a.Name != b.Name {
+		return a.Name < b.Name
+	}
+	// Final tiebreak: two grouped rows can share a subject (kind/ns/name)
+	// and differ only by category. Keeps the order total + deterministic.
+	return a.Category < b.Category
+}

--- a/internal/issues/grouping_test.go
+++ b/internal/issues/grouping_test.go
@@ -1,0 +1,160 @@
+package issues
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+)
+
+// flatPod builds a flat pod issue the way Compose would — classified +
+// identity-enriched — so grouping tests exercise the real id/owner/scope.
+func flatPod(name, reason string, sev Severity, owner Ref, first, last time.Time) Issue {
+	i := Issue{
+		Source: SourceProblem, Kind: "Pod", Namespace: "ns", Name: name,
+		Reason: reason, Severity: sev, Owner: owner,
+		FirstSeen: first, LastSeen: last, Count: 1,
+	}
+	classifyIssue(&i)
+	enrichIdentity(&i)
+	return i
+}
+
+func TestGroupIssues_FoldsMembersUnderOwner(t *testing.T) {
+	dep := Ref{Group: "apps", Kind: "Deployment", Namespace: "ns", Name: "web"}
+	t0, t1, t2 := time.Unix(1000, 0), time.Unix(2000, 0), time.Unix(3000, 0)
+	// web-b is the worst member: critical, oldest onset, newest last_seen,
+	// and a distinct (same-category) reason — it must drive the rep fields.
+	flat := []Issue{
+		flatPod("web-a", "ImagePullBackOff", SeverityWarning, dep, t1, t1),
+		flatPod("web-b", "ErrImagePull", SeverityCritical, dep, t0, t2),
+		flatPod("web-c", "ImagePullBackOff", SeverityWarning, dep, t1, t1),
+	}
+	got := GroupIssues(flat)
+	if len(got) != 1 {
+		t.Fatalf("want 1 grouped row, got %d", len(got))
+	}
+	g := got[0]
+	if g.Group != "apps" || g.Kind != "Deployment" || g.Name != "web" {
+		t.Errorf("subject = %s/%s/%s, want apps/Deployment/web", g.Group, g.Kind, g.Name)
+	}
+	if g.Count != 3 || g.Affected.Pods != 3 || len(g.Members) != 3 {
+		t.Errorf("count=%d affected.pods=%d members=%d, want 3/3/3", g.Count, g.Affected.Pods, len(g.Members))
+	}
+	if g.Severity != SeverityCritical {
+		t.Errorf("severity = %q, want critical (max of members)", g.Severity)
+	}
+	if g.Reason != "ErrImagePull" {
+		t.Errorf("reason = %q, want the worst member's ErrImagePull", g.Reason)
+	}
+	if !g.FirstSeen.Equal(t0) {
+		t.Errorf("first_seen = %v, want oldest %v", g.FirstSeen, t0)
+	}
+	if !g.LastSeen.Equal(t2) {
+		t.Errorf("last_seen = %v, want newest %v", g.LastSeen, t2)
+	}
+	if g.Members[0].Name != "web-a" || g.Members[2].Name != "web-c" {
+		t.Errorf("members not sorted by name: %+v", g.Members)
+	}
+	if g.Owner.Kind != "" {
+		t.Errorf("grouped row should not carry Owner (subject is top-level): %+v", g.Owner)
+	}
+}
+
+func TestGroupIssues_StandalonePodIsOwnSubject(t *testing.T) {
+	flat := []Issue{flatPod("solo", "CrashLoopBackOff", SeverityCritical, Ref{}, time.Unix(1, 0), time.Unix(1, 0))}
+	got := GroupIssues(flat)
+	if len(got) != 1 {
+		t.Fatalf("want 1, got %d", len(got))
+	}
+	g := got[0]
+	if g.Kind != "Pod" || g.Name != "solo" {
+		t.Errorf("subject = %s/%s, want Pod/solo", g.Kind, g.Name)
+	}
+	// No fan-out: the subject is the only resource.
+	if g.Count != 1 || len(g.Members) != 0 || g.Affected.Pods != 0 {
+		t.Errorf("single-resource issue: count=%d members=%d affected.pods=%d, want 1/0/0", g.Count, len(g.Members), g.Affected.Pods)
+	}
+}
+
+func TestGroupIssues_DistinctCategoriesStaySeparate(t *testing.T) {
+	dep := Ref{Group: "apps", Kind: "Deployment", Namespace: "ns", Name: "web"}
+	flat := []Issue{
+		flatPod("web-a", "ImagePullBackOff", SeverityCritical, dep, time.Unix(1, 0), time.Unix(1, 0)),
+		flatPod("web-b", "CrashLoopBackOff", SeverityCritical, dep, time.Unix(1, 0), time.Unix(1, 0)),
+	}
+	got := GroupIssues(flat)
+	if len(got) != 2 {
+		t.Fatalf("same owner, different categories must stay separate: got %d rows", len(got))
+	}
+}
+
+func TestGroupIssues_MemberTruncation(t *testing.T) {
+	dep := Ref{Group: "apps", Kind: "Deployment", Namespace: "ns", Name: "web"}
+	var flat []Issue
+	for i := 0; i < 12; i++ {
+		flat = append(flat, flatPod(fmt.Sprintf("web-%02d", i), "ImagePullBackOff", SeverityCritical, dep, time.Unix(1, 0), time.Unix(1, 0)))
+	}
+	got := GroupIssues(flat)
+	if len(got) != 1 {
+		t.Fatalf("want 1, got %d", len(got))
+	}
+	g := got[0]
+	// Counts reflect all 12; the inline member slice is capped + flagged.
+	if g.Count != 12 || g.Affected.Pods != 12 {
+		t.Errorf("count=%d affected.pods=%d, want 12/12", g.Count, g.Affected.Pods)
+	}
+	if !g.MembersTruncated || len(g.Members) != maxInlineMembers {
+		t.Errorf("members len=%d truncated=%v, want %d/true", len(g.Members), g.MembersTruncated, maxInlineMembers)
+	}
+}
+
+func TestGroupIssues_Deterministic(t *testing.T) {
+	dep := Ref{Group: "apps", Kind: "Deployment", Namespace: "ns", Name: "web"}
+	sts := Ref{Group: "apps", Kind: "StatefulSet", Namespace: "ns", Name: "db"}
+	mk := func() []Issue {
+		return []Issue{
+			flatPod("web-a", "ImagePullBackOff", SeverityWarning, dep, time.Unix(1, 0), time.Unix(1, 0)),
+			flatPod("web-b", "ErrImagePull", SeverityCritical, dep, time.Unix(1, 0), time.Unix(2, 0)),
+			flatPod("db-x", "CrashLoopBackOff", SeverityCritical, sts, time.Unix(1, 0), time.Unix(3, 0)),
+		}
+	}
+	a := GroupIssues(mk())
+	in := mk()
+	in[0], in[2] = in[2], in[0] // reorder input
+	b := GroupIssues(in)
+	if len(a) != len(b) {
+		t.Fatalf("len differs: %d vs %d", len(a), len(b))
+	}
+	for i := range a {
+		if a[i].ID != b[i].ID || a[i].Reason != b[i].Reason || a[i].Name != b[i].Name {
+			t.Errorf("non-deterministic at %d: %+v vs %+v", i, a[i], b[i])
+		}
+	}
+}
+
+func TestComposeWithStats_GroupedCapsOnGroups(t *testing.T) {
+	var probs []k8s.Problem
+	for i := 0; i < 5; i++ {
+		probs = append(probs, k8s.Problem{
+			Kind: "Pod", Namespace: "ns", Name: fmt.Sprintf("web-%d", i),
+			Severity: "critical", Reason: "ImagePullBackOff",
+			OwnerKind: "Deployment", OwnerName: "web",
+		})
+	}
+	p := &fakeProvider{problems: probs}
+
+	flat, fstats := ComposeWithStats(p, Filters{})
+	if len(flat) != 5 || fstats.TotalMatched != 5 {
+		t.Fatalf("flat: want 5 rows / matched 5, got %d / %d", len(flat), fstats.TotalMatched)
+	}
+
+	g, gstats := ComposeWithStats(p, Filters{Grouped: true})
+	if len(g) != 1 || gstats.TotalMatched != 1 {
+		t.Fatalf("grouped: want 1 row / matched 1 (cap counts groups), got %d / %d", len(g), gstats.TotalMatched)
+	}
+	if g[0].Affected.Pods != 5 || g[0].Count != 5 {
+		t.Errorf("grouped row should reflect 5 members: affected.pods=%d count=%d", g[0].Affected.Pods, g[0].Count)
+	}
+}

--- a/internal/issues/identity.go
+++ b/internal/issues/identity.go
@@ -1,0 +1,70 @@
+package issues
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	bp "github.com/skyhook-io/radar/pkg/audit"
+)
+
+// Scope is the kind of subject an issue groups under — the coarse bucket
+// for the UI section and part of the deterministic ID. `unknown` is
+// first-class (CRDs, HPAs, PVs, and anything outside the core set), never
+// an error.
+type Scope string
+
+const (
+	ScopeUnknown  Scope = "unknown"
+	ScopeWorkload Scope = "workload"
+	ScopeService  Scope = "service"
+	ScopeIngress  Scope = "ingress"
+	ScopePVC      Scope = "pvc"
+	ScopeNode     Scope = "node"
+)
+
+// scopeForKind maps a grouping-subject Kind to its scope.
+func scopeForKind(kind string) Scope {
+	switch kind {
+	case "Pod", "Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Job", "CronJob":
+		return ScopeWorkload
+	case "Service":
+		return ScopeService
+	case "Ingress":
+		return ScopeIngress
+	case "PersistentVolumeClaim":
+		return ScopePVC
+	case "Node":
+		return ScopeNode
+	}
+	return ScopeUnknown
+}
+
+// resourceKey is the canonical group|kind|namespace|name key, shared with
+// pkg/audit so issue grouping and audit deep-links never drift apart.
+func resourceKey(group, kind, namespace, name string) string {
+	return bp.ResourceKey(group, kind, namespace, name)
+}
+
+// issueID is the deterministic, cluster-local identity for an issue:
+// sha256(scope, grouping key, category), truncated to 8 bytes. Pure inputs
+// keep it stable across recomposes (no oscillation), and identical for
+// every member row of the same subject+category group. The hub namespaces
+// it by cluster_id for global uniqueness.
+func issueID(scope Scope, groupingKey string, cat Category) string {
+	sum := sha256.Sum256([]byte(string(scope) + "\x00" + groupingKey + "\x00" + string(cat)))
+	return hex.EncodeToString(sum[:8])
+}
+
+// enrichIdentity derives the grouping subject, scope, and deterministic ID
+// for a classified issue. The subject is the topmost owner when one was
+// resolved (member pods collapse under their workload), otherwise the
+// resource itself. Must run after classifyIssue — the category is part of
+// the ID.
+func enrichIdentity(i *Issue) {
+	subject := Ref{Group: i.Group, Kind: i.Kind, Namespace: i.Namespace, Name: i.Name}
+	if i.Owner.Kind != "" {
+		subject = i.Owner
+	}
+	i.GroupingScope = scopeForKind(subject.Kind)
+	i.ID = issueID(i.GroupingScope, resourceKey(subject.Group, subject.Kind, subject.Namespace, subject.Name), i.Category)
+}

--- a/internal/issues/identity_test.go
+++ b/internal/issues/identity_test.go
@@ -1,0 +1,69 @@
+package issues
+
+import "testing"
+
+func TestScopeForKind(t *testing.T) {
+	cases := map[string]Scope{
+		"Pod":                     ScopeWorkload,
+		"Deployment":              ScopeWorkload,
+		"StatefulSet":             ScopeWorkload,
+		"DaemonSet":               ScopeWorkload,
+		"Job":                     ScopeWorkload,
+		"CronJob":                 ScopeWorkload,
+		"Service":                 ScopeService,
+		"Ingress":                 ScopeIngress,
+		"PersistentVolumeClaim":   ScopePVC,
+		"Node":                    ScopeNode,
+		"HorizontalPodAutoscaler": ScopeUnknown,
+		"Certificate":             ScopeUnknown,
+	}
+	for kind, want := range cases {
+		if got := scopeForKind(kind); got != want {
+			t.Errorf("scopeForKind(%q) = %q, want %q", kind, got, want)
+		}
+	}
+}
+
+func TestIssueID_DeterministicAndDistinct(t *testing.T) {
+	key := resourceKey("apps", "Deployment", "ns", "web")
+	base := issueID(ScopeWorkload, key, CategoryImagePullFailed)
+
+	if base != issueID(ScopeWorkload, key, CategoryImagePullFailed) {
+		t.Error("issueID not deterministic for identical inputs")
+	}
+	// Each component must change the ID.
+	if base == issueID(ScopeWorkload, key, CategoryCrashLoop) {
+		t.Error("category must change the ID")
+	}
+	if base == issueID(ScopeWorkload, resourceKey("apps", "Deployment", "ns", "other"), CategoryImagePullFailed) {
+		t.Error("subject must change the ID")
+	}
+	if base == issueID(ScopeService, key, CategoryImagePullFailed) {
+		t.Error("scope must change the ID")
+	}
+}
+
+func TestEnrichIdentity_SubjectIsOwnerElseSelf(t *testing.T) {
+	// A pod with a resolved owner groups under the owner — the ID is keyed
+	// on the workload, not the pod.
+	pod := Issue{
+		Source: SourceProblem, Kind: "Pod", Namespace: "ns", Name: "web-abc-1", Reason: "ImagePullBackOff",
+		Owner: Ref{Group: "apps", Kind: "Deployment", Namespace: "ns", Name: "web"},
+	}
+	classifyIssue(&pod)
+	enrichIdentity(&pod)
+	if pod.GroupingScope != ScopeWorkload {
+		t.Errorf("scope = %q, want workload", pod.GroupingScope)
+	}
+	if want := issueID(ScopeWorkload, resourceKey("apps", "Deployment", "ns", "web"), CategoryImagePullFailed); pod.ID != want {
+		t.Errorf("ID = %q, want owner-keyed %q", pod.ID, want)
+	}
+
+	// A standalone pod (no owner) is its own subject.
+	solo := Issue{Source: SourceProblem, Kind: "Pod", Namespace: "ns", Name: "solo", Reason: "CrashLoopBackOff"}
+	classifyIssue(&solo)
+	enrichIdentity(&solo)
+	if want := issueID(ScopeWorkload, resourceKey("", "Pod", "ns", "solo"), CategoryCrashLoop); solo.ID != want {
+		t.Errorf("standalone pod ID = %q, want self-keyed %q", solo.ID, want)
+	}
+}

--- a/internal/issues/issues.go
+++ b/internal/issues/issues.go
@@ -251,7 +251,7 @@ func detectGenericCRDIssues(p Provider, f Filters) []Issue {
 					continue
 				}
 				lastSeen := time.Now().Add(-since)
-				out = append(out, Issue{
+				iss := Issue{
 					Severity:  SeverityWarning,
 					Source:    SourceCondition,
 					Kind:      kind,
@@ -263,7 +263,9 @@ func detectGenericCRDIssues(p Provider, f Filters) []Issue {
 					FirstSeen: lastSeen,
 					LastSeen:  lastSeen,
 					Count:     1,
-				})
+				}
+				classifyIssue(&iss)
+				out = append(out, iss)
 			}
 		}
 	}
@@ -329,7 +331,7 @@ func fromProblem(p k8s.Problem, now time.Time, source Source) Issue {
 		sev = SeverityCritical
 	}
 	since := now.Add(-time.Duration(p.DurationSeconds) * time.Second)
-	return Issue{
+	iss := Issue{
 		Severity:             sev,
 		Source:               source,
 		Kind:                 p.Kind,
@@ -344,6 +346,23 @@ func fromProblem(p k8s.Problem, now time.Time, source Source) Issue {
 		RestartCount:         p.RestartCount,
 		LastTerminatedReason: p.LastTerminatedReason,
 	}
+	classifyIssue(&iss)
+	return iss
+}
+
+// classifyIssue derives the user-facing Category + its CategoryGroup rollup
+// from the row's detection signal. Pure: same inputs always yield the same
+// labels, so the category stays stable across recomposes (a prerequisite for
+// the future category-in-issue-id contract).
+func classifyIssue(i *Issue) {
+	i.Category = Classify(classifyInput{
+		Source:               i.Source,
+		APIGroup:             i.Group,
+		Kind:                 i.Kind,
+		Reason:               i.Reason,
+		LastTerminatedReason: i.LastTerminatedReason,
+	})
+	i.CategoryGroup = GroupOf(i.Category)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/issues/issues.go
+++ b/internal/issues/issues.go
@@ -168,21 +168,16 @@ func ComposeWithStats(p Provider, f Filters) ([]Issue, ComposeStats) {
 		out = filtered
 	}
 
-	sort.SliceStable(out, func(i, j int) bool {
-		if out[i].Severity != out[j].Severity {
-			return severityRank(out[i].Severity) > severityRank(out[j].Severity)
-		}
-		if !out[i].LastSeen.Equal(out[j].LastSeen) {
-			return out[i].LastSeen.After(out[j].LastSeen)
-		}
-		if out[i].Kind != out[j].Kind {
-			return out[i].Kind < out[j].Kind
-		}
-		if out[i].Namespace != out[j].Namespace {
-			return out[i].Namespace < out[j].Namespace
-		}
-		return out[i].Name < out[j].Name
-	})
+	// Grouped folds the flat evidence rows into the public issue model
+	// before the cap, so the limit counts issue groups rather than replica
+	// fan-out (a 50-pod crashloop is one issue). Flat callers keep the
+	// per-object rows. GroupIssues sorts deterministically; the flat path
+	// uses the same comparator so both orders agree.
+	if f.Grouped {
+		out = GroupIssues(out)
+	} else {
+		sort.SliceStable(out, func(i, j int) bool { return lessIssue(out[i], out[j]) })
+	}
 	stats.TotalMatched = len(out)
 	if !uncapped && len(out) > f.Limit {
 		out = out[:f.Limit]

--- a/internal/issues/issues.go
+++ b/internal/issues/issues.go
@@ -265,6 +265,7 @@ func detectGenericCRDIssues(p Provider, f Filters) []Issue {
 					Count:     1,
 				}
 				classifyIssue(&iss)
+				enrichIdentity(&iss)
 				out = append(out, iss)
 			}
 		}
@@ -346,7 +347,16 @@ func fromProblem(p k8s.Problem, now time.Time, source Source) Issue {
 		RestartCount:         p.RestartCount,
 		LastTerminatedReason: p.LastTerminatedReason,
 	}
+	if p.OwnerKind != "" {
+		iss.Owner = Ref{
+			Group:     resolveGroup("", p.OwnerKind),
+			Kind:      p.OwnerKind,
+			Namespace: p.Namespace,
+			Name:      p.OwnerName,
+		}
+	}
 	classifyIssue(&iss)
+	enrichIdentity(&iss)
 	return iss
 }
 

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -67,6 +67,35 @@ func TestCompose_NormalizesProblemSeverity(t *testing.T) {
 	}
 }
 
+func TestCompose_PopulatesCategoryAndGroup(t *testing.T) {
+	// Every composed row carries the derived symptom category + its rollup
+	// group, classified from the detection signal across all sources.
+	p := &fakeProvider{
+		problems:    []k8s.Problem{{Kind: "Pod", Namespace: "ns", Name: "img", Severity: "high", Reason: "ImagePullBackOff"}},
+		scheduling:  []k8s.Problem{{Kind: "Pod", Namespace: "ns", Name: "sched", Severity: "high", Reason: "Unschedulable"}},
+		missingRefs: []k8s.Problem{{Kind: "Pod", Namespace: "ns", Name: "ref", Severity: "high", Reason: "Missing ConfigMap"}},
+	}
+	got := map[string]Issue{}
+	for _, i := range Compose(p, Filters{}) {
+		got[i.Name] = i
+	}
+	checks := []struct {
+		name     string
+		category Category
+		group    Group
+	}{
+		{"img", CategoryImagePullFailed, GroupStartup},
+		{"sched", CategoryUnschedulable, GroupScheduling},
+		{"ref", CategoryMissingConfigRef, GroupConfiguration},
+	}
+	for _, c := range checks {
+		if got[c.name].Category != c.category || got[c.name].CategoryGroup != c.group {
+			t.Errorf("%s: category=%q group=%q, want %q/%q",
+				c.name, got[c.name].Category, got[c.name].CategoryGroup, c.category, c.group)
+		}
+	}
+}
+
 func TestCompose_PodSchedulingWinsOverProblem(t *testing.T) {
 	// A pod stuck post-bind trips both sources: DetectProblems flags it
 	// Pending>5m and DetectScheduling names the actual CNI/volume blocker.

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -96,6 +96,35 @@ func TestCompose_PopulatesCategoryAndGroup(t *testing.T) {
 	}
 }
 
+func TestCompose_GroupsMemberPodsUnderOwner(t *testing.T) {
+	// Two pods of the same Deployment failing the same way share one issue
+	// ID (the future collapse target); a third pod failing differently gets
+	// its own. Owner + scope are propagated onto every member row.
+	p := &fakeProvider{
+		problems: []k8s.Problem{
+			{Kind: "Pod", Namespace: "ns", Name: "web-a", Severity: "critical", Reason: "ImagePullBackOff", OwnerKind: "Deployment", OwnerName: "web"},
+			{Kind: "Pod", Namespace: "ns", Name: "web-b", Severity: "critical", Reason: "ImagePullBackOff", OwnerKind: "Deployment", OwnerName: "web"},
+			{Kind: "Pod", Namespace: "ns", Name: "web-c", Severity: "critical", Reason: "CrashLoopBackOff", OwnerKind: "Deployment", OwnerName: "web"},
+		},
+	}
+	got := map[string]Issue{}
+	for _, i := range Compose(p, Filters{}) {
+		got[i.Name] = i
+	}
+	if got["web-a"].ID == "" || got["web-a"].ID != got["web-b"].ID {
+		t.Errorf("same owner+category pods must share an ID: a=%q b=%q", got["web-a"].ID, got["web-b"].ID)
+	}
+	if got["web-c"].ID == got["web-a"].ID {
+		t.Error("a different category under the same owner must get a distinct ID")
+	}
+	if want := (Ref{Group: "apps", Kind: "Deployment", Namespace: "ns", Name: "web"}); got["web-a"].Owner != want {
+		t.Errorf("owner not propagated: got %+v, want %+v", got["web-a"].Owner, want)
+	}
+	if got["web-a"].GroupingScope != ScopeWorkload {
+		t.Errorf("scope = %q, want workload", got["web-a"].GroupingScope)
+	}
+}
+
 func TestCompose_PodSchedulingWinsOverProblem(t *testing.T) {
 	// A pod stuck post-bind trips both sources: DetectProblems flags it
 	// Pending>5m and DetectScheduling names the actual CNI/volume blocker.

--- a/internal/issues/types.go
+++ b/internal/issues/types.go
@@ -120,6 +120,14 @@ type Issue struct {
 	// Completed) without the agent needing a follow-up get_resource call.
 	RestartCount         int32  `json:"restart_count,omitempty"`
 	LastTerminatedReason string `json:"last_terminated_reason,omitempty"`
+	// Affected, Members, and MembersTruncated are populated only on grouped
+	// rows (GroupIssues). Affected counts the folded underlying resources by
+	// kind; Members lists them (bounded by maxInlineMembers, with
+	// MembersTruncated set past the cap). Empty on flat rows and on
+	// single-resource grouped issues (no fan-out).
+	Affected         Affected `json:"affected,omitzero"`
+	Members          []Ref    `json:"members,omitempty"`
+	MembersTruncated bool     `json:"members_truncated,omitempty"`
 	// Cluster is left empty here; the hub injects it when emitting
 	// cross-cluster envelopes via fleet_issues.
 	Cluster string `json:"cluster,omitempty"`
@@ -142,6 +150,12 @@ type Filters struct {
 	// nil preserves auth-mode=none and tests where the provider's own
 	// permissions are the only gate.
 	CanReadClusterScoped func(kind, group string) bool
+	// Grouped folds the flat rows into the public grouped model
+	// (GroupIssues) before the cap, so the limit counts issue groups, not
+	// replica fan-out. The public /api/issues + MCP issues set this; flat
+	// callers (summarycontext per-resource index, /api/issues?view=flat)
+	// leave it false.
+	Grouped bool
 }
 
 const (

--- a/internal/issues/types.go
+++ b/internal/issues/types.go
@@ -80,18 +80,25 @@ type Ref struct {
 // off by the observed problem duration; for condition rows, both timestamps
 // are the condition's lastTransitionTime.
 type Issue struct {
-	Severity  Severity  `json:"severity"`
-	Source    Source    `json:"source"`
-	Kind      string    `json:"kind"`
-	Group     string    `json:"group,omitempty"`
-	Namespace string    `json:"namespace,omitempty"`
-	Name      string    `json:"name"`
-	Reason    string    `json:"reason"`
-	Message   string    `json:"message,omitempty"`
-	FirstSeen time.Time `json:"first_seen,omitzero"`
-	LastSeen  time.Time `json:"last_seen,omitzero"`
-	Count     int       `json:"count,omitempty"`
-	Owner     Ref       `json:"owner,omitzero"`
+	Severity Severity `json:"severity"`
+	Source   Source   `json:"source"`
+	// Category is the user-facing symptom taxonomy (image_pull_failed,
+	// crashloop, …), derived from Source+Kind+Reason by Classify;
+	// CategoryGroup is its coarse rollup (GroupOf). Both are server-emitted
+	// labels so the UI renders them without its own category→group map.
+	// Distinct from Group below, which is the resource's API group.
+	Category      Category  `json:"category,omitempty"`
+	CategoryGroup Group     `json:"category_group,omitempty"`
+	Kind          string    `json:"kind"`
+	Group         string    `json:"group,omitempty"`
+	Namespace     string    `json:"namespace,omitempty"`
+	Name          string    `json:"name"`
+	Reason        string    `json:"reason"`
+	Message       string    `json:"message,omitempty"`
+	FirstSeen     time.Time `json:"first_seen,omitzero"`
+	LastSeen      time.Time `json:"last_seen,omitzero"`
+	Count         int       `json:"count,omitempty"`
+	Owner         Ref       `json:"owner,omitzero"`
 	// RestartCount + LastTerminatedReason carry Pod crash-debugging
 	// context from k8s.Problem through to issues consumers (MCP `issues`
 	// tool + /api/issues + hub fleet_issues). Populated only for Pod

--- a/internal/issues/types.go
+++ b/internal/issues/types.go
@@ -66,8 +66,11 @@ const (
 	SourceCondition  Source = "condition"   // generic CRD .status.conditions[].status=False fallback
 )
 
-// Ref is a lightweight resource reference, used for owner pointers.
+// Ref is a lightweight resource reference for the grouping subject and
+// owner pointers. Group is the API group (empty for core) — carried so
+// owner/affected deep-links can disambiguate CRDs from core kinds.
 type Ref struct {
+	Group     string `json:"group,omitempty"`
 	Kind      string `json:"kind"`
 	Namespace string `json:"namespace,omitempty"`
 	Name      string `json:"name"`
@@ -87,8 +90,17 @@ type Issue struct {
 	// CategoryGroup is its coarse rollup (GroupOf). Both are server-emitted
 	// labels so the UI renders them without its own category→group map.
 	// Distinct from Group below, which is the resource's API group.
-	Category      Category  `json:"category,omitempty"`
-	CategoryGroup Group     `json:"category_group,omitempty"`
+	Category      Category `json:"category,omitempty"`
+	CategoryGroup Group    `json:"category_group,omitempty"`
+	// ID is the deterministic, cluster-local issue identity —
+	// hash(grouping_scope, subject key, category). Shared by every row that
+	// rolls up to the same subject+category, so consumers can group on it;
+	// the hub namespaces it by cluster_id for global uniqueness.
+	ID string `json:"id,omitempty"`
+	// GroupingScope is the kind of subject this issue groups under
+	// (workload|service|pvc|ingress|node|unknown) — drives the UI section
+	// and is part of ID.
+	GroupingScope Scope     `json:"grouping_scope,omitempty"`
 	Kind          string    `json:"kind"`
 	Group         string    `json:"group,omitempty"`
 	Namespace     string    `json:"namespace,omitempty"`

--- a/internal/k8s/problems.go
+++ b/internal/k8s/problems.go
@@ -38,6 +38,25 @@ type Problem struct {
 	// mean either non-Pod problem or no crash data on this Pod yet.
 	RestartCount         int32
 	LastTerminatedReason string
+	// OwnerKind + OwnerName name the topmost stable controller of a Pod
+	// problem (Pod→Deployment, not the intermediate ReplicaSet), resolved
+	// via topOwnerForPod when the Pod is detected. Empty for non-Pod and
+	// standalone-pod problems — those are their own subject. Lets the
+	// issues layer group member pods under one workload without re-walking
+	// ownerReferences.
+	OwnerKind string
+	OwnerName string
+}
+
+// podOwnerKindName resolves a Pod's topmost stable controller for issue
+// grouping (Pod→Deployment, not ReplicaSet), returning empty strings for
+// standalone pods. Thin wrapper over topOwnerForPod so the pod
+// problem-emission sites stay terse.
+func podOwnerKindName(pod *corev1.Pod) (kind, name string) {
+	if to := topOwnerForPod(pod); to != nil {
+		return to.Kind, to.Name
+	}
+	return "", ""
 }
 
 // DetectProblems scans workloads in cache and returns detected problems.
@@ -181,6 +200,7 @@ func DetectProblems(cache *ResourceCache, namespace string) []Problem {
 				severity = "critical"
 			}
 			restartCount, lastTermReason := PodRestartContext(pod)
+			ownerKind, ownerName := podOwnerKindName(pod)
 			problems = append(problems, Problem{
 				Kind:                 "Pod",
 				Namespace:            pod.Namespace,
@@ -193,6 +213,8 @@ func DetectProblems(cache *ResourceCache, namespace string) []Problem {
 				DurationSeconds:      int64(ageDur.Seconds()),
 				RestartCount:         restartCount,
 				LastTerminatedReason: lastTermReason,
+				OwnerKind:            ownerKind,
+				OwnerName:            ownerName,
 			})
 		}
 	}

--- a/internal/k8s/scheduling.go
+++ b/internal/k8s/scheduling.go
@@ -461,6 +461,7 @@ func DetectSchedulingProblems(cache *ResourceCache, namespace string) []Problem 
 			if !cond.LastTransitionTime.IsZero() {
 				dur = now.Sub(cond.LastTransitionTime.Time)
 			}
+			ownerKind, ownerName := podOwnerKindName(pod)
 			problems = append(problems, Problem{
 				Kind:            "Pod",
 				Namespace:       pod.Namespace,
@@ -472,6 +473,8 @@ func DetectSchedulingProblems(cache *ResourceCache, namespace string) []Problem 
 				AgeSeconds:      int64(ageDur.Seconds()),
 				Duration:        FormatAge(dur),
 				DurationSeconds: int64(dur.Seconds()),
+				OwnerKind:       ownerKind,
+				OwnerName:       ownerName,
 			})
 		}
 	}
@@ -920,6 +923,7 @@ func DetectPostBindProblems(cache *ResourceCache, namespace string) []Problem {
 			severity = "high"
 		}
 		ageDur := now.Sub(pod.CreationTimestamp.Time)
+		ownerKind, ownerName := podOwnerKindName(pod)
 		problems = append(problems, Problem{
 			Kind:            "Pod",
 			Namespace:       pod.Namespace,
@@ -931,6 +935,8 @@ func DetectPostBindProblems(cache *ResourceCache, namespace string) []Problem {
 			AgeSeconds:      int64(ageDur.Seconds()),
 			Duration:        FormatAge(ageDur),
 			DurationSeconds: int64(ageDur.Seconds()),
+			OwnerKind:       ownerKind,
+			OwnerName:       ownerName,
 		})
 	}
 	return problems

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2300,6 +2300,10 @@ func handleIssuesTool(ctx context.Context, _ *mcp.CallToolRequest, input issuesI
 		Kinds:      splitCSVStr(input.Kind),
 		Limit:      input.Limit,
 		Namespaces: allowedNamespaces,
+		// Agents get the grouped issue model — structured triage objects,
+		// not per-pod evidence rows they'd have to re-aggregate. Raw object
+		// state stays available via get_resource / get_events.
+		Grouped: true,
 		CanReadClusterScoped: func(kind, group string) bool {
 			return canReadClusterScopedKind(ctx, kind, group, "list")
 		},

--- a/internal/server/issues_handler.go
+++ b/internal/server/issues_handler.go
@@ -27,7 +27,8 @@ import (
 //	severity=  critical,warning  (default: all)
 //	kind=      Pod,Deployment,...  (default: all)
 //	filter=    optional CEL predicate over each row (bindings include source)
-//	limit=     default 200, max 1000
+//	limit=     default 200, max 1000 (counts issue groups, not member objects)
+//	view=      flat → raw pre-fold evidence rows (debug); default → grouped
 func (s *Server) handleIssues(w http.ResponseWriter, r *http.Request) {
 	if !s.requireConnected(w) {
 		return
@@ -59,6 +60,10 @@ func (s *Server) handleIssues(w http.ResponseWriter, r *http.Request) {
 		Severities: severities,
 		Kinds:      splitCSV(q.Get("kind")),
 		Limit:      parseLimit(q.Get("limit")),
+		// Grouped is the product default — one row per subject+category.
+		// ?view=flat returns the raw pre-fold evidence rows for debugging
+		// ("what folded into this group?") and internal inspection.
+		Grouped: q.Get("view") != "flat",
 		CanReadClusterScoped: func(kind, group string) bool {
 			if auth.UserFromContext(r.Context()) == nil {
 				return true


### PR DESCRIPTION
Builds the Radar Issues engine: every operational issue is classified by symptom **category**, gets a stable **identity**, and is **grouped** under its owning workload — so `/api/issues` and the MCP `issues` tool emit a triage queue, not a per-object feed. Pure/deterministic, table-tested, MCP-first.

### What changed (3 commits)

1. **Classify** — a pure `(Source, Kind, Reason)` → `category` classifier (~25 categories → 11 groups, `unknown` first-class), wired into `Compose`. Every row carries `category` + `category_group`, both server-emitted labels and CEL filter bindings. Grounded in radar's actual reason vocabulary.
2. **Identity** — resolve each Pod problem's topmost stable controller (Pod→Deployment, not the intermediate ReplicaSet) at detection time; derive a `grouping_scope` and a deterministic cluster-local `id = hash(scope, subject key, category)`. `resourceKey` reuses `pkg/audit.ResourceKey` so issues and audit deep-links share one key format.
3. **Group** — `GroupIssues` folds the flat evidence rows into the public model: one row per `id` with `affected` counts + bounded member refs. Grouped by default on `/api/issues` + MCP; the cap now counts issue groups, not replica fan-out.

### Notes for review

- **`?view=flat`** on `/api/issues` returns the raw pre-fold rows for debugging ("what folded into this group?"). MCP stays grouped-only — agents use `get_resource`/`get_events` for raw state.
- `Compose()` stays flat internally, so `summarycontext`'s per-resource index is unchanged; a `Filters.Grouped` flag gates the fold.
- Representative rules are deterministic: severity = max member, subject = topmost owner, reason/message/crash-context from the worst member, age = oldest onset, last_seen = newest, members sorted + capped at 10 with `members_truncated`.
- Taxonomy gaps fall through to `unknown` deliberately (CronJob/Job/CAPI/PVC-Lost/Node-Cordoned, and categories whose detectors don't exist yet).

Pairs with skyhook-dev/radar-hub#52 (forwards the new fields through the fleet pivot). SPA grouped `IssuesView` is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)