### PR TITLE
feat(mcp): state-derived advisory warnings on read/apply/diagnose/logs

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -867,14 +867,16 @@ func handleGetResource(ctx context.Context, req *mcp.CallToolRequest, input getR
 	skipContext := contextMode == "none"
 
 	var resourceCtx *resourcecontext.ResourceContext
+	var warnings []string
 	if !skipContext {
 		resourceCtx = buildMCPResourceContext(ctx, rawObj, kind, namespace, name, resourcecontext.TierBasic)
-	}
 
-	// State-derived advisory warnings (deletionTimestamp, external manager,
-	// terminating namespace, workload health-condition history, PVC stuck
-	// Pending). Cheap — operates on the object we already fetched.
-	warnings := k8score.EnrichRuntimeObjectWarnings(rawObj)
+		// State-derived advisory warnings (deletionTimestamp, external manager,
+		// terminating namespace, workload health-condition history, PVC stuck
+		// Pending). Cheap — operates on the object we already fetched. Skipped
+		// for context=none so that mode stays a bare object for raw jq work.
+		warnings = k8score.EnrichRuntimeObjectWarnings(rawObj)
+	}
 
 	// Three shapes:
 	//   - bare resource: no includes, context=none
@@ -1581,12 +1583,13 @@ func handleGetPodLogs(ctx context.Context, req *mcp.CallToolRequest, input podLo
 // computePodLogsWarnings inspects the pod's status to surface common
 // pitfalls in interpreting an empty/short logs response:
 //
-//   - D: when the pod isn't Running, application logs are usually unavailable
+//   - when the pod isn't Running, application logs are usually unavailable
 //     because the container hasn't started yet. The agent thinks the app
 //     isn't writing logs when actually the pod is still scheduling/pulling.
-//   - E: when a container has restarted recently and the caller didn't pass
-//     previous=true, the current container's logs are likely the next-crash
-//     in progress; the error that killed the last container is in previous.
+//   - when a container has restarted (restartCount > 0) and the caller didn't
+//     pass previous=true, the current container's logs are likely the
+//     next-crash in progress; the error that killed the last container is in
+//     previous.
 //
 // Best-effort — if the pod can't be fetched, return no warnings rather than
 // failing the logs call (the caller already has whatever logs we returned).
@@ -1606,7 +1609,6 @@ func computePodLogsWarnings(namespace, name, container string, previous bool, ra
 
 	var out []string
 
-	// D — non-Running phase: app logs likely unavailable
 	if pod.Status.Phase != corev1.PodRunning && pod.Status.Phase != corev1.PodSucceeded {
 		out = append(out, fmt.Sprintf(
 			"Pod is in phase `%s`; application logs are typically unavailable until containers start. Inspect scheduling/pull state via `diagnose` (kind=pod), `get_resource` with include=events, or check pod conditions for the underlying blocker.",
@@ -1638,9 +1640,9 @@ func computePodLogsWarnings(namespace, name, container string, previous bool, ra
 	return out
 }
 
-// pickCrashIndicator returns the most informative ContainerStatus for crashloop
-// warnings: a container with restartCount > 0 whose previous termination has a
-// recorded reason. Returns nil when no container looks crash-loopy.
+// pickCrashIndicator returns the first container with restartCount > 0 that has
+// a recorded previous termination, or nil when no container has crashed. The
+// previous termination may have an empty reason; the caller renders that.
 func pickCrashIndicator(statuses []corev1.ContainerStatus) *corev1.ContainerStatus {
 	for i := range statuses {
 		cs := &statuses[i]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -25,6 +25,7 @@ import (
 	"github.com/skyhook-io/radar/internal/summarycontext"
 	"github.com/skyhook-io/radar/internal/timeline"
 	aicontext "github.com/skyhook-io/radar/pkg/ai/context"
+	"github.com/skyhook-io/radar/pkg/k8score"
 	"github.com/skyhook-io/radar/pkg/resourcecontext"
 	topology "github.com/skyhook-io/radar/pkg/topology"
 )
@@ -870,17 +871,25 @@ func handleGetResource(ctx context.Context, req *mcp.CallToolRequest, input getR
 		resourceCtx = buildMCPResourceContext(ctx, rawObj, kind, namespace, name, resourcecontext.TierBasic)
 	}
 
+	// State-derived advisory warnings (deletionTimestamp, external manager,
+	// terminating namespace, workload health-condition history, PVC stuck
+	// Pending). Cheap — operates on the object we already fetched.
+	warnings := k8score.EnrichRuntimeObjectWarnings(rawObj)
+
 	// Three shapes:
 	//   - bare resource: no includes, context=none
 	//   - resource + resourceContext: no includes, default context
 	//   - resource + resourceContext + extras: includes set
-	if len(includes) == 0 && resourceCtx == nil {
+	if len(includes) == 0 && resourceCtx == nil && len(warnings) == 0 {
 		return toJSONResult(resourceData)
 	}
 
 	result := map[string]any{"resource": resourceData}
 	if resourceCtx != nil {
 		result["resourceContext"] = resourceCtx
+	}
+	if len(warnings) > 0 {
+		result["warnings"] = warnings
 	}
 	if len(includes) > 0 {
 		attachResourceExtras(ctx, cache, result, includes, kind, namespace, name)
@@ -1548,18 +1557,118 @@ func handleGetPodLogs(ctx context.Context, req *mcp.CallToolRequest, input podLo
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid grep regex: %w", err)
 	}
+
+	warnings := computePodLogsWarnings(input.Namespace, input.Name, input.Container, input.Previous, rawLines)
+	var narrowHint string
 	// Heuristic: if we received tailLines or more raw lines, the kubectl
 	// stream was likely capped (there may be older lines we didn't fetch).
 	if int64(rawLines) >= tailLines {
-		return toJSONResult(podLogsResponseMCP{
-			FilteredLogs: filtered,
-			NarrowHint: fmt.Sprintf(
-				"log stream tailed to %d lines (cap reached) — narrow with since= (e.g. 10m), grep= regex, container=, or raise tail_lines",
-				rawLines,
-			),
-		})
+		narrowHint = fmt.Sprintf(
+			"log stream tailed to %d lines (cap reached) — narrow with since= (e.g. 10m), grep= regex, container=, or raise tail_lines",
+			rawLines,
+		)
 	}
-	return toJSONResult(filtered)
+	if narrowHint == "" && len(warnings) == 0 {
+		return toJSONResult(filtered)
+	}
+	return toJSONResult(podLogsResponseMCP{
+		FilteredLogs: filtered,
+		NarrowHint:   narrowHint,
+		Warnings:     warnings,
+	})
+}
+
+// computePodLogsWarnings inspects the pod's status to surface common
+// pitfalls in interpreting an empty/short logs response:
+//
+//   - D: when the pod isn't Running, application logs are usually unavailable
+//     because the container hasn't started yet. The agent thinks the app
+//     isn't writing logs when actually the pod is still scheduling/pulling.
+//   - E: when a container has restarted recently and the caller didn't pass
+//     previous=true, the current container's logs are likely the next-crash
+//     in progress; the error that killed the last container is in previous.
+//
+// Best-effort — if the pod can't be fetched, return no warnings rather than
+// failing the logs call (the caller already has whatever logs we returned).
+func computePodLogsWarnings(namespace, name, container string, previous bool, rawLines int) []string {
+	cache := k8s.GetResourceCache()
+	if cache == nil {
+		return nil
+	}
+	obj, err := k8s.FetchResource(cache, "pods", namespace, name)
+	if err != nil {
+		return nil
+	}
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return nil
+	}
+
+	var out []string
+
+	// D — non-Running phase: app logs likely unavailable
+	if pod.Status.Phase != corev1.PodRunning && pod.Status.Phase != corev1.PodSucceeded {
+		out = append(out, fmt.Sprintf(
+			"Pod is in phase `%s`; application logs are typically unavailable until containers start. Inspect scheduling/pull state via `diagnose` (kind=pod), `get_resource` with include=events, or check pod conditions for the underlying blocker.",
+			pod.Status.Phase,
+		))
+	}
+
+	if !previous {
+		statuses := pod.Status.ContainerStatuses
+		if container != "" {
+			statuses = filterContainerStatuses(statuses, container)
+		}
+		if cs := pickCrashIndicator(statuses); cs != nil {
+			reason := cs.LastTerminationState.Terminated.Reason
+			if reason == "" {
+				reason = "(reason unset)"
+			}
+			out = append(out, fmt.Sprintf(
+				"Container `%s` has restarted %d time(s); last termination: `%s` (exit code %d). The error that triggered the previous crash is in the previous container's logs — call again with `previous: true`%s.",
+				cs.Name,
+				cs.RestartCount,
+				reason,
+				cs.LastTerminationState.Terminated.ExitCode,
+				crashloopSuffix(rawLines),
+			))
+		}
+	}
+
+	return out
+}
+
+// pickCrashIndicator returns the most informative ContainerStatus for crashloop
+// warnings: a container with restartCount > 0 whose previous termination has a
+// recorded reason. Returns nil when no container looks crash-loopy.
+func pickCrashIndicator(statuses []corev1.ContainerStatus) *corev1.ContainerStatus {
+	for i := range statuses {
+		cs := &statuses[i]
+		if cs.RestartCount == 0 {
+			continue
+		}
+		if cs.LastTerminationState.Terminated == nil {
+			continue
+		}
+		return cs
+	}
+	return nil
+}
+
+func filterContainerStatuses(statuses []corev1.ContainerStatus, name string) []corev1.ContainerStatus {
+	for i := range statuses {
+		if statuses[i].Name == name {
+			return statuses[i : i+1]
+		}
+	}
+	return nil
+}
+
+func crashloopSuffix(rawLines int) string {
+	if rawLines == 0 {
+		return " (current logs returned empty — likely captured between restarts)"
+	}
+	return ""
 }
 
 // countLines returns the number of newline-delimited lines in s, treating
@@ -1577,10 +1686,11 @@ func countLines(s string) int {
 }
 
 // podLogsResponseMCP embeds FilteredLogs so the JSON shape stays identical
-// except for the added narrowHint field.
+// except for added narrowHint + warnings fields.
 type podLogsResponseMCP struct {
 	aicontext.FilteredLogs
-	NarrowHint string `json:"narrowHint,omitempty"`
+	NarrowHint string   `json:"narrowHint,omitempty"`
+	Warnings   []string `json:"warnings,omitempty"`
 }
 
 func handleListNamespaces(ctx context.Context, req *mcp.CallToolRequest, input struct{}) (*mcp.CallToolResult, any, error) {

--- a/internal/mcp/tools_apply.go
+++ b/internal/mcp/tools_apply.go
@@ -66,6 +66,9 @@ func handleApplyResource(ctx context.Context, req *mcp.CallToolRequest, input ap
 		if input.DryRun {
 			entry["dry_run"] = true
 		}
+		if len(result.Warnings) > 0 {
+			entry["warnings"] = result.Warnings
+		}
 		results = append(results, entry)
 	}
 

--- a/internal/mcp/tools_diagnose.go
+++ b/internal/mcp/tools_diagnose.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/skyhook-io/radar/internal/k8s"
 	aicontext "github.com/skyhook-io/radar/pkg/ai/context"
+	"github.com/skyhook-io/radar/pkg/k8score"
 	"github.com/skyhook-io/radar/pkg/resourcecontext"
 )
 
@@ -56,6 +57,10 @@ type diagnoseResponse struct {
 	StartupBlockers []startupBlocker `json:"startupBlockers,omitempty"`
 	Pods            int              `json:"pods"`
 	NarrowHint      string           `json:"narrowHint,omitempty"`
+	// Warnings are state-derived advisories on the diagnosed object — e.g.,
+	// "resource is being deleted", "managed by Helm, edits may revert",
+	// "condition has been False since creation". Empty when nothing notable.
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 // startupBlocker is the compact row diagnose embeds for one reason a workload
@@ -215,6 +220,7 @@ func handleDiagnose(ctx context.Context, _ *mcp.CallToolRequest, input diagnoseI
 	}
 
 	resp.StartupBlockers = startupBlockersForWorkload(cache, kindNorm, input.Namespace, input.Name, pods)
+	resp.Warnings = k8score.EnrichRuntimeObjectWarnings(obj)
 	return toJSONResult(resp)
 }
 

--- a/internal/mcp/tools_workloads.go
+++ b/internal/mcp/tools_workloads.go
@@ -339,8 +339,8 @@ func schedulingBlockerWarnings(kind, namespace, name string) []string {
 	)}
 }
 
-// computeWorkloadLogsWarnings aggregates the same D/E logs hints that
-// get_pod_logs surfaces, summarized across all pods of the workload.
+// computeWorkloadLogsWarnings aggregates the not-Running and crashloop logs
+// hints that get_pod_logs surfaces, summarized across all pods of the workload.
 func computeWorkloadLogsWarnings(pods []*corev1.Pod, previous bool) []string {
 	var notRunning, crashloop int
 	for _, p := range pods {

--- a/internal/mcp/tools_workloads.go
+++ b/internal/mcp/tools_workloads.go
@@ -84,13 +84,18 @@ func handleManageWorkload(ctx context.Context, req *mcp.CallToolRequest, input m
 
 	switch strings.ToLower(input.Action) {
 	case "restart":
+		warnings := schedulingBlockerWarnings(kind, input.Namespace, input.Name)
 		if err := k8s.RestartWorkloadWithClient(ctx, kind, input.Namespace, input.Name, dynClient); err != nil {
 			return nil, nil, fmt.Errorf("restart failed: %w", err)
 		}
-		return toJSONResult(map[string]string{
+		resp := map[string]any{
 			"status":  "ok",
 			"message": fmt.Sprintf("Rolling restart initiated for %s %s/%s", kind, input.Namespace, input.Name),
-		})
+		}
+		if len(warnings) > 0 {
+			resp["warnings"] = warnings
+		}
+		return toJSONResult(resp)
 
 	case "scale":
 		if input.Replicas == nil {
@@ -266,7 +271,100 @@ func handleGetWorkloadLogs(ctx context.Context, req *mcp.CallToolRequest, input 
 			break
 		}
 	}
+	if w := computeWorkloadLogsWarnings(pods, input.Previous); len(w) > 0 {
+		resp["warnings"] = w
+	}
 	return toJSONResult(resp)
+}
+
+// schedulingBlockerWarnings detects when a restart won't accomplish what the
+// agent likely wants: if the workload currently has Pending pods blocked on
+// scheduling/admission/post-bind issues, a rolling restart just creates more
+// Pending pods. The agent should fix the underlying constraint instead
+// (taints/affinity/capacity/quota). Best-effort — never blocks the restart.
+func schedulingBlockerWarnings(kind, namespace, name string) []string {
+	cache := k8s.GetResourceCache()
+	if cache == nil {
+		return nil
+	}
+	selector, err := k8s.GetWorkloadSelector(cache, kind, namespace, name)
+	if err != nil {
+		return nil
+	}
+	pods := cache.GetPodsForWorkload(namespace, selector)
+	if len(pods) == 0 {
+		return nil
+	}
+
+	var pendingCount int
+	podNames := make(map[string]bool, len(pods))
+	for _, p := range pods {
+		if p.Status.Phase == corev1.PodPending {
+			pendingCount++
+		}
+		podNames[p.Name] = true
+	}
+	if pendingCount == 0 {
+		return nil
+	}
+
+	all := k8s.DetectSchedulingProblems(cache, namespace)
+	all = append(all, k8s.DetectAdmissionProblems(cache, namespace)...)
+	all = append(all, k8s.DetectPostBindProblems(cache, namespace)...)
+
+	reasons := map[string]struct{}{}
+	for _, p := range all {
+		if p.Kind != "Pod" || !podNames[p.Name] {
+			continue
+		}
+		if p.Reason != "" {
+			reasons[p.Reason] = struct{}{}
+		}
+	}
+	if len(reasons) == 0 {
+		// Pending pods exist but with no detected scheduling/admission cause —
+		// could be initial pull or short transient. Skip the warning rather
+		// than surface a generic "pending" note that the agent will ignore.
+		return nil
+	}
+
+	rs := make([]string, 0, len(reasons))
+	for r := range reasons {
+		rs = append(rs, r)
+	}
+	sort.Strings(rs)
+	return []string{fmt.Sprintf(
+		"%d of %d pod(s) are currently `Pending` with cause(s): %s. A rolling restart replaces existing pods with new ones that face the same constraint — fix the underlying issue (taints/affinity/resources/quota/PSA) before restarting.",
+		pendingCount, len(pods), strings.Join(rs, ", "),
+	)}
+}
+
+// computeWorkloadLogsWarnings aggregates the same D/E logs hints that
+// get_pod_logs surfaces, summarized across all pods of the workload.
+func computeWorkloadLogsWarnings(pods []*corev1.Pod, previous bool) []string {
+	var notRunning, crashloop int
+	for _, p := range pods {
+		if p.Status.Phase != corev1.PodRunning && p.Status.Phase != corev1.PodSucceeded {
+			notRunning++
+		}
+		if !previous && pickCrashIndicator(p.Status.ContainerStatuses) != nil {
+			crashloop++
+		}
+	}
+	var out []string
+	if notRunning > 0 {
+		out = append(out, fmt.Sprintf(
+			"%d of %d pod(s) are not in `Running` phase; their containers haven't produced application logs yet. Inspect scheduling/pull state via `diagnose` or `get_resource` with include=events.",
+			notRunning, len(pods),
+		))
+	}
+	if crashloop > 0 {
+		out = append(out, fmt.Sprintf(
+			"%d of %d pod(s) have container restarts on record; the error(s) that killed prior containers are in the previous instance's logs — call again with `previous: true` to see them.",
+			crashloop, len(pods),
+		))
+	}
+	return out
 }
 
 // podLogEntry is the per-pod-per-container log row returned by fetchPodLogs.

--- a/internal/mcp/tools_workloads.go
+++ b/internal/mcp/tools_workloads.go
@@ -279,9 +279,14 @@ func handleGetWorkloadLogs(ctx context.Context, req *mcp.CallToolRequest, input 
 
 // schedulingBlockerWarnings detects when a restart won't accomplish what the
 // agent likely wants: if the workload currently has Pending pods blocked on
-// scheduling/admission/post-bind issues, a rolling restart just creates more
-// Pending pods. The agent should fix the underlying constraint instead
-// (taints/affinity/capacity/quota). Best-effort — never blocks the restart.
+// scheduling or post-bind (CNI/volume) issues, a rolling restart just creates
+// more pods that hit the same wall. The agent should fix the underlying
+// constraint instead (taints/affinity/capacity/CNI/storage). Best-effort —
+// never blocks the restart.
+//
+// Admission failures (quota/PSA/webhook) are intentionally out of scope: they
+// block pod creation entirely, so there are no Pending pods to key on, and the
+// FailedCreate event names the controller rather than a Pod.
 func schedulingBlockerWarnings(kind, namespace, name string) []string {
 	cache := k8s.GetResourceCache()
 	if cache == nil {
@@ -309,7 +314,6 @@ func schedulingBlockerWarnings(kind, namespace, name string) []string {
 	}
 
 	all := k8s.DetectSchedulingProblems(cache, namespace)
-	all = append(all, k8s.DetectAdmissionProblems(cache, namespace)...)
 	all = append(all, k8s.DetectPostBindProblems(cache, namespace)...)
 
 	reasons := map[string]struct{}{}

--- a/pkg/k8score/apply_warnings.go
+++ b/pkg/k8score/apply_warnings.go
@@ -3,6 +3,7 @@ package k8score
 import (
 	"context"
 	"fmt"
+	"log"
 	"sort"
 	"strings"
 
@@ -149,12 +150,7 @@ func checkFieldRemoval(submitted, pre, post *unstructured.Unstructured) []string
 			if _, in := postC[field]; !in {
 				continue
 			}
-			fieldRef := fmt.Sprintf("spec.template.spec.containers[name=%s].%s", name, field)
-			if specPath[0] == "spec" && len(specPath) == 5 {
-				fieldRef = fmt.Sprintf("spec.jobTemplate.spec.template.spec.containers[name=%s].%s", name, field)
-			} else if len(specPath) == 1 {
-				fieldRef = fmt.Sprintf("spec.containers[name=%s].%s", name, field)
-			}
+			fieldRef := fmt.Sprintf("%s.containers[name=%s].%s", strings.Join(specPath, "."), name, field)
 			warnings = append(warnings, formatFieldRemovalWarning(fieldRef, otherManagers))
 		}
 	}
@@ -231,22 +227,29 @@ func nonRadarManagers(obj *unstructured.Unstructured) []string {
 // findConfigMapSecretConsumers returns the qualified names (Kind/Name) of
 // workloads in the same namespace whose PodSpec references the given
 // ConfigMap or Secret via env, envFrom, volumes, or projected volumes.
-func findConfigMapSecretConsumers(ctx context.Context, dynClient dynamic.Interface, discovery *ResourceDiscovery, namespace, refKind, refName string) []string {
+//
+// partial is true when a workload kind could not be listed (e.g. RBAC denied
+// the user the apply path impersonates, or the kind isn't in discovery). An
+// empty result with partial=true means "scan incomplete", NOT "verified no
+// consumers" — the caller must not present it as the latter.
+func findConfigMapSecretConsumers(ctx context.Context, dynClient dynamic.Interface, discovery *ResourceDiscovery, namespace, refKind, refName string) (consumers []string, partial bool) {
 	if dynClient == nil || discovery == nil || namespace == "" || refName == "" {
-		return nil
+		return nil, false
 	}
 	if refKind != "ConfigMap" && refKind != "Secret" {
-		return nil
+		return nil, false
 	}
 
-	var consumers []string
 	for _, kind := range []string{"Deployment", "StatefulSet", "DaemonSet", "CronJob", "Job"} {
 		gvr, ok := discovery.GetGVR(kind)
 		if !ok {
+			partial = true
 			continue
 		}
 		list, err := dynClient.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
+			log.Printf("[k8s] apply_resource: consumer scan list %s in %s failed: %v", kind, namespace, err)
+			partial = true
 			continue
 		}
 		for i := range list.Items {
@@ -257,7 +260,7 @@ func findConfigMapSecretConsumers(ctx context.Context, dynClient dynamic.Interfa
 		}
 	}
 	sort.Strings(consumers)
-	return consumers
+	return consumers, partial
 }
 
 func podSpecReferences(obj *unstructured.Unstructured, refKind, refName string) bool {
@@ -377,8 +380,11 @@ func volumeReferences(v map[string]any, refKind, refName string) bool {
 	return false
 }
 
-func formatConsumerWarning(refKind, refName string, consumers []string) string {
+func formatConsumerWarning(refKind, refName string, consumers []string, partial bool) string {
 	if len(consumers) == 0 {
+		if partial {
+			return fmt.Sprintf("Could not fully enumerate workloads referencing `%s` (some list calls failed — likely RBAC). If you changed its contents, manually verify which workloads mount it and restart any that don't watch for changes.", refName)
+		}
 		return ""
 	}
 	preview := consumers
@@ -387,5 +393,9 @@ func formatConsumerWarning(refKind, refName string, consumers []string) string {
 		preview = preview[:5]
 		tail = fmt.Sprintf(" (+%d more)", len(consumers)-5)
 	}
-	return fmt.Sprintf("%s changes typically reach pod filesystems within ~60s, but most applications must detect and reload the new contents. %d workload(s) reference `%s`: %s%s. If those apps don't watch for changes, restart them (e.g., `manage_workload restart`) so they pick up the edit.", refKind, len(consumers), refName, strings.Join(preview, ", "), tail)
+	incomplete := ""
+	if partial {
+		incomplete = " (consumer list may be incomplete — some list calls failed)"
+	}
+	return fmt.Sprintf("%s changes typically reach pod filesystems within ~60s, but most applications must detect and reload the new contents. %d workload(s) reference `%s`: %s%s%s. If those apps don't watch for changes, restart them (e.g., `manage_workload restart`) so they pick up the edit.", refKind, len(consumers), refName, strings.Join(preview, ", "), tail, incomplete)
 }

--- a/pkg/k8score/apply_warnings.go
+++ b/pkg/k8score/apply_warnings.go
@@ -1,0 +1,391 @@
+package k8score
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+)
+
+// detectExternalManager inspects labels and annotations for evidence that the
+// resource is reconciled by Helm, Argo CD, Flux, or another controller. Returns
+// the manager display name and a best-effort instance identifier; both empty
+// when nothing was detected. Detection is deliberately conservative — radar and
+// kubectl are not considered "external".
+func detectExternalManager(obj *unstructured.Unstructured) (string, string) {
+	if obj == nil {
+		return "", ""
+	}
+	labels := obj.GetLabels()
+	annotations := obj.GetAnnotations()
+
+	if v := annotations["argocd.argoproj.io/instance"]; v != "" {
+		return "Argo CD", v
+	}
+	if v := annotations["argocd.argoproj.io/tracking-id"]; v != "" {
+		return "Argo CD", v
+	}
+
+	if v := annotations["kustomize.toolkit.fluxcd.io/name"]; v != "" {
+		if ns := annotations["kustomize.toolkit.fluxcd.io/namespace"]; ns != "" {
+			return "Flux (Kustomization)", ns + "/" + v
+		}
+		return "Flux (Kustomization)", v
+	}
+	if v := annotations["helm.toolkit.fluxcd.io/name"]; v != "" {
+		if ns := annotations["helm.toolkit.fluxcd.io/namespace"]; ns != "" {
+			return "Flux (HelmRelease)", ns + "/" + v
+		}
+		return "Flux (HelmRelease)", v
+	}
+
+	helmRelease := annotations["meta.helm.sh/release-name"]
+	helmManaged := strings.EqualFold(labels["app.kubernetes.io/managed-by"], "Helm")
+	if helmRelease != "" || helmManaged {
+		instance := helmRelease
+		if instance == "" {
+			instance = labels["app.kubernetes.io/instance"]
+		}
+		return "Helm", instance
+	}
+
+	if mb := labels["app.kubernetes.io/managed-by"]; mb != "" {
+		low := strings.ToLower(mb)
+		if low != "kubectl" && low != "radar" {
+			return mb, labels["app.kubernetes.io/instance"]
+		}
+	}
+	return "", ""
+}
+
+func formatExternalManagerWarning(manager, instance string) string {
+	if manager == "" {
+		return ""
+	}
+	frag := ""
+	if instance != "" {
+		frag = fmt.Sprintf(" (instance: %s)", instance)
+	}
+	return fmt.Sprintf("Resource is reconciled by %s%s. Direct edits may be reverted by the next reconciliation; prefer changing the source of truth (chart values / Application spec / operator CR).", manager, frag)
+}
+
+// podSpecPath returns the field path that contains the PodSpec for the given
+// workload kind, or nil for kinds without an embedded PodSpec. Used by both
+// the field-removal verification and the ConfigMap/Secret consumer lookup.
+func podSpecPath(kind string) []string {
+	switch kind {
+	case "Deployment", "ReplicaSet", "StatefulSet", "DaemonSet", "Job":
+		return []string{"spec", "template", "spec"}
+	case "CronJob":
+		return []string{"spec", "jobTemplate", "spec", "template", "spec"}
+	case "Pod":
+		return []string{"spec"}
+	}
+	return nil
+}
+
+// checkFieldRemoval verifies that fields the agent intended to remove are
+// actually gone after apply. Server-side apply does not remove fields owned by
+// other managers when those fields are merely omitted from the submission —
+// the agent must explicitly set them to null. We check a focused set of
+// high-impact paths under the PodSpec (probes, resources, scheduling).
+//
+// Returns one warning per field that survived the apply despite being omitted.
+func checkFieldRemoval(submitted, pre, post *unstructured.Unstructured) []string {
+	if submitted == nil || pre == nil || post == nil {
+		return nil
+	}
+	specPath := podSpecPath(pre.GetKind())
+	if len(specPath) == 0 {
+		return nil
+	}
+
+	otherManagers := nonRadarManagers(post)
+
+	var warnings []string
+
+	for _, field := range []string{"nodeSelector", "affinity", "tolerations", "nodeName", "topologySpreadConstraints"} {
+		path := append(append([]string{}, specPath...), field)
+		if !hasPath(pre, path) || hasPath(submitted, path) {
+			continue
+		}
+		if !hasPath(post, path) {
+			continue
+		}
+		warnings = append(warnings, formatFieldRemovalWarning(strings.Join(path, "."), otherManagers))
+	}
+
+	preCs, _, _ := unstructured.NestedSlice(pre.Object, append(specPath, "containers")...)
+	submCs, _, _ := unstructured.NestedSlice(submitted.Object, append(specPath, "containers")...)
+	postCs, _, _ := unstructured.NestedSlice(post.Object, append(specPath, "containers")...)
+	submByName := containersByName(submCs)
+	postByName := containersByName(postCs)
+
+	for _, raw := range preCs {
+		preC, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := preC["name"].(string)
+		if name == "" {
+			continue
+		}
+		submC, hasSubm := submByName[name]
+		postC, hasPost := postByName[name]
+		if !hasSubm || !hasPost {
+			continue
+		}
+		for _, field := range []string{"readinessProbe", "livenessProbe", "startupProbe", "resources"} {
+			if _, in := preC[field]; !in {
+				continue
+			}
+			if _, in := submC[field]; in {
+				continue
+			}
+			if _, in := postC[field]; !in {
+				continue
+			}
+			fieldRef := fmt.Sprintf("spec.template.spec.containers[name=%s].%s", name, field)
+			if specPath[0] == "spec" && len(specPath) == 5 {
+				fieldRef = fmt.Sprintf("spec.jobTemplate.spec.template.spec.containers[name=%s].%s", name, field)
+			} else if len(specPath) == 1 {
+				fieldRef = fmt.Sprintf("spec.containers[name=%s].%s", name, field)
+			}
+			warnings = append(warnings, formatFieldRemovalWarning(fieldRef, otherManagers))
+		}
+	}
+
+	return warnings
+}
+
+func formatFieldRemovalWarning(field string, otherManagers []string) string {
+	tail := "Server-side apply does not claim fields by omission. To actually remove the field, set its value to null in your YAML."
+	if len(otherManagers) > 0 {
+		tail = fmt.Sprintf("It is still owned by another field manager (%s). %s", strings.Join(otherManagers, ", "), tail)
+	}
+	return fmt.Sprintf("Field `%s` was omitted from your submission but is still present after apply. %s", field, tail)
+}
+
+func hasPath(obj *unstructured.Unstructured, path []string) bool {
+	if obj == nil {
+		return false
+	}
+	_, found, _ := unstructured.NestedFieldNoCopy(obj.Object, path...)
+	return found
+}
+
+func containersByName(cs []any) map[string]map[string]any {
+	out := make(map[string]map[string]any, len(cs))
+	for _, c := range cs {
+		m, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := m["name"].(string)
+		if name == "" {
+			continue
+		}
+		out[name] = m
+	}
+	return out
+}
+
+// nonRadarManagers returns the names of field managers on the object other
+// than radar itself, deduplicated and sorted for stable output. Used to tell
+// the agent who else owns fields on the resource.
+func nonRadarManagers(obj *unstructured.Unstructured) []string {
+	if obj == nil {
+		return nil
+	}
+	mfRaw, found, _ := unstructured.NestedSlice(obj.Object, "metadata", "managedFields")
+	if !found {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	for _, entry := range mfRaw {
+		em, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := em["manager"].(string)
+		if name == "" || strings.EqualFold(name, "radar") {
+			continue
+		}
+		seen[name] = struct{}{}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// findConfigMapSecretConsumers returns the qualified names (Kind/Name) of
+// workloads in the same namespace whose PodSpec references the given
+// ConfigMap or Secret via env, envFrom, volumes, or projected volumes.
+func findConfigMapSecretConsumers(ctx context.Context, dynClient dynamic.Interface, discovery *ResourceDiscovery, namespace, refKind, refName string) []string {
+	if dynClient == nil || discovery == nil || namespace == "" || refName == "" {
+		return nil
+	}
+	if refKind != "ConfigMap" && refKind != "Secret" {
+		return nil
+	}
+
+	var consumers []string
+	for _, kind := range []string{"Deployment", "StatefulSet", "DaemonSet", "CronJob", "Job"} {
+		gvr, ok := discovery.GetGVR(kind)
+		if !ok {
+			continue
+		}
+		list, err := dynClient.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			continue
+		}
+		for i := range list.Items {
+			item := &list.Items[i]
+			if podSpecReferences(item, refKind, refName) {
+				consumers = append(consumers, fmt.Sprintf("%s/%s", kind, item.GetName()))
+			}
+		}
+	}
+	sort.Strings(consumers)
+	return consumers
+}
+
+func podSpecReferences(obj *unstructured.Unstructured, refKind, refName string) bool {
+	specPath := podSpecPath(obj.GetKind())
+	if len(specPath) == 0 {
+		return false
+	}
+
+	for _, group := range []string{"containers", "initContainers"} {
+		cs, _, _ := unstructured.NestedSlice(obj.Object, append(specPath, group)...)
+		for _, raw := range cs {
+			c, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			if containerReferences(c, refKind, refName) {
+				return true
+			}
+		}
+	}
+
+	volumes, _, _ := unstructured.NestedSlice(obj.Object, append(specPath, "volumes")...)
+	for _, raw := range volumes {
+		v, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if volumeReferences(v, refKind, refName) {
+			return true
+		}
+	}
+	return false
+}
+
+func containerReferences(c map[string]any, refKind, refName string) bool {
+	envFromKey := "configMapRef"
+	envKey := "configMapKeyRef"
+	if refKind == "Secret" {
+		envFromKey = "secretRef"
+		envKey = "secretKeyRef"
+	}
+
+	if envFrom, ok := c["envFrom"].([]any); ok {
+		for _, raw := range envFrom {
+			ef, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			if ref, ok := ef[envFromKey].(map[string]any); ok {
+				if n, _ := ref["name"].(string); n == refName {
+					return true
+				}
+			}
+		}
+	}
+
+	if env, ok := c["env"].([]any); ok {
+		for _, raw := range env {
+			ev, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			vf, ok := ev["valueFrom"].(map[string]any)
+			if !ok {
+				continue
+			}
+			if ref, ok := vf[envKey].(map[string]any); ok {
+				if n, _ := ref["name"].(string); n == refName {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func volumeReferences(v map[string]any, refKind, refName string) bool {
+	if refKind == "ConfigMap" {
+		if src, ok := v["configMap"].(map[string]any); ok {
+			if n, _ := src["name"].(string); n == refName {
+				return true
+			}
+		}
+	}
+	if refKind == "Secret" {
+		if src, ok := v["secret"].(map[string]any); ok {
+			if n, _ := src["secretName"].(string); n == refName {
+				return true
+			}
+		}
+	}
+
+	if proj, ok := v["projected"].(map[string]any); ok {
+		if sources, ok := proj["sources"].([]any); ok {
+			for _, raw := range sources {
+				sm, ok := raw.(map[string]any)
+				if !ok {
+					continue
+				}
+				if refKind == "ConfigMap" {
+					if src, ok := sm["configMap"].(map[string]any); ok {
+						if n, _ := src["name"].(string); n == refName {
+							return true
+						}
+					}
+				}
+				if refKind == "Secret" {
+					if src, ok := sm["secret"].(map[string]any); ok {
+						if n, _ := src["name"].(string); n == refName {
+							return true
+						}
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+func formatConsumerWarning(refKind, refName string, consumers []string) string {
+	if len(consumers) == 0 {
+		return ""
+	}
+	preview := consumers
+	tail := ""
+	if len(preview) > 5 {
+		preview = preview[:5]
+		tail = fmt.Sprintf(" (+%d more)", len(consumers)-5)
+	}
+	return fmt.Sprintf("%s changes typically reach pod filesystems within ~60s, but most applications must detect and reload the new contents. %d workload(s) reference `%s`: %s%s. If those apps don't watch for changes, restart them (e.g., `manage_workload restart`) so they pick up the edit.", refKind, len(consumers), refName, strings.Join(preview, ", "), tail)
+}

--- a/pkg/k8score/apply_warnings_test.go
+++ b/pkg/k8score/apply_warnings_test.go
@@ -1,0 +1,383 @@
+package k8score
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func ctr(name string, presentFields ...string) map[string]any {
+	c := map[string]any{"name": name}
+	for _, f := range presentFields {
+		c[f] = map[string]any{}
+	}
+	return c
+}
+
+// mkWorkload builds an unstructured workload of the given kind with podSpec
+// placed at the kind's PodSpec path, plus optional field-manager names in
+// metadata.managedFields.
+func mkWorkload(t *testing.T, kind string, podSpec map[string]any, managers ...string) *unstructured.Unstructured {
+	t.Helper()
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       kind,
+		"metadata":   map[string]any{"name": "w", "namespace": "ns"},
+	}}
+	if podSpec != nil {
+		if err := unstructured.SetNestedMap(obj.Object, podSpec, podSpecPath(kind)...); err != nil {
+			t.Fatalf("set podSpec for %s: %v", kind, err)
+		}
+	}
+	if len(managers) > 0 {
+		mf := make([]any, 0, len(managers))
+		for _, m := range managers {
+			mf = append(mf, map[string]any{"manager": m})
+		}
+		if err := unstructured.SetNestedSlice(obj.Object, mf, "metadata", "managedFields"); err != nil {
+			t.Fatalf("set managedFields: %v", err)
+		}
+	}
+	return obj
+}
+
+func TestDetectExternalManager(t *testing.T) {
+	mk := func(labels, annotations map[string]any) *unstructured.Unstructured {
+		md := map[string]any{"name": "x"}
+		if labels != nil {
+			md["labels"] = labels
+		}
+		if annotations != nil {
+			md["annotations"] = annotations
+		}
+		return &unstructured.Unstructured{Object: map[string]any{"kind": "Deployment", "metadata": md}}
+	}
+
+	tests := []struct {
+		name         string
+		obj          *unstructured.Unstructured
+		wantManager  string
+		wantInstance string
+	}{
+		{
+			// Argo apps frequently carry Helm annotations because Argo renders
+			// charts — Argo must win the precedence ladder.
+			name:         "argo beats helm",
+			obj:          mk(nil, map[string]any{"argocd.argoproj.io/instance": "my-app", "meta.helm.sh/release-name": "rel"}),
+			wantManager:  "Argo CD",
+			wantInstance: "my-app",
+		},
+		{
+			name:         "argo tracking-id only",
+			obj:          mk(nil, map[string]any{"argocd.argoproj.io/tracking-id": "track-1"}),
+			wantManager:  "Argo CD",
+			wantInstance: "track-1",
+		},
+		{
+			name:         "flux kustomization namespace-qualified",
+			obj:          mk(nil, map[string]any{"kustomize.toolkit.fluxcd.io/name": "ks", "kustomize.toolkit.fluxcd.io/namespace": "flux-system"}),
+			wantManager:  "Flux (Kustomization)",
+			wantInstance: "flux-system/ks",
+		},
+		{
+			name:         "flux kustomization bare name",
+			obj:          mk(nil, map[string]any{"kustomize.toolkit.fluxcd.io/name": "ks"}),
+			wantManager:  "Flux (Kustomization)",
+			wantInstance: "ks",
+		},
+		{
+			name:         "flux helmrelease namespace-qualified",
+			obj:          mk(nil, map[string]any{"helm.toolkit.fluxcd.io/name": "hr", "helm.toolkit.fluxcd.io/namespace": "apps"}),
+			wantManager:  "Flux (HelmRelease)",
+			wantInstance: "apps/hr",
+		},
+		{
+			name:         "flux kustomization beats helm label",
+			obj:          mk(map[string]any{"app.kubernetes.io/managed-by": "Helm"}, map[string]any{"kustomize.toolkit.fluxcd.io/name": "ks"}),
+			wantManager:  "Flux (Kustomization)",
+			wantInstance: "ks",
+		},
+		{
+			name:         "helm release annotation",
+			obj:          mk(nil, map[string]any{"meta.helm.sh/release-name": "rel"}),
+			wantManager:  "Helm",
+			wantInstance: "rel",
+		},
+		{
+			name:         "helm label only uses instance label",
+			obj:          mk(map[string]any{"app.kubernetes.io/managed-by": "Helm", "app.kubernetes.io/instance": "inst"}, nil),
+			wantManager:  "Helm",
+			wantInstance: "inst",
+		},
+		{
+			name:        "kubectl excluded",
+			obj:         mk(map[string]any{"app.kubernetes.io/managed-by": "kubectl"}, nil),
+			wantManager: "",
+		},
+		{
+			// Case-insensitive exclusion — a regression making this case-sensitive
+			// would warn on every radar-applied resource.
+			name:        "radar excluded case-insensitive",
+			obj:         mk(map[string]any{"app.kubernetes.io/managed-by": "Radar"}, nil),
+			wantManager: "",
+		},
+		{
+			name:         "generic operator",
+			obj:          mk(map[string]any{"app.kubernetes.io/managed-by": "my-operator", "app.kubernetes.io/instance": "inst"}, nil),
+			wantManager:  "my-operator",
+			wantInstance: "inst",
+		},
+		{
+			name:        "no metadata",
+			obj:         mk(nil, nil),
+			wantManager: "",
+		},
+		{
+			name:        "nil object",
+			obj:         nil,
+			wantManager: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr, inst := detectExternalManager(tt.obj)
+			if mgr != tt.wantManager {
+				t.Errorf("manager = %q, want %q", mgr, tt.wantManager)
+			}
+			if tt.wantManager != "" && inst != tt.wantInstance {
+				t.Errorf("instance = %q, want %q", inst, tt.wantInstance)
+			}
+		})
+	}
+}
+
+func TestCheckFieldRemoval(t *testing.T) {
+	t.Run("deployment container probe survives", func(t *testing.T) {
+		pre := mkWorkload(t, "Deployment", map[string]any{"containers": []any{ctr("app", "readinessProbe")}})
+		subm := mkWorkload(t, "Deployment", map[string]any{"containers": []any{ctr("app")}})
+		post := mkWorkload(t, "Deployment", map[string]any{"containers": []any{ctr("app", "readinessProbe")}}, "kube-controller-manager", "radar")
+
+		w := checkFieldRemoval(subm, pre, post)
+		if len(w) != 1 {
+			t.Fatalf("want 1 warning, got %d: %v", len(w), w)
+		}
+		if !strings.Contains(w[0], "spec.template.spec.containers[name=app].readinessProbe") {
+			t.Errorf("fieldRef wrong: %s", w[0])
+		}
+		if !strings.Contains(w[0], "kube-controller-manager") {
+			t.Errorf("expected other-manager attribution: %s", w[0])
+		}
+	})
+
+	t.Run("cronjob field path", func(t *testing.T) {
+		pre := mkWorkload(t, "CronJob", map[string]any{"containers": []any{ctr("app", "livenessProbe")}})
+		subm := mkWorkload(t, "CronJob", map[string]any{"containers": []any{ctr("app")}})
+		post := mkWorkload(t, "CronJob", map[string]any{"containers": []any{ctr("app", "livenessProbe")}})
+
+		w := checkFieldRemoval(subm, pre, post)
+		if len(w) != 1 {
+			t.Fatalf("want 1 warning, got %d: %v", len(w), w)
+		}
+		if !strings.Contains(w[0], "spec.jobTemplate.spec.template.spec.containers[name=app].livenessProbe") {
+			t.Errorf("cronjob fieldRef wrong: %s", w[0])
+		}
+	})
+
+	t.Run("pod field path", func(t *testing.T) {
+		pre := mkWorkload(t, "Pod", map[string]any{"containers": []any{ctr("app", "resources")}})
+		subm := mkWorkload(t, "Pod", map[string]any{"containers": []any{ctr("app")}})
+		post := mkWorkload(t, "Pod", map[string]any{"containers": []any{ctr("app", "resources")}})
+
+		w := checkFieldRemoval(subm, pre, post)
+		if len(w) != 1 {
+			t.Fatalf("want 1 warning, got %d: %v", len(w), w)
+		}
+		if !strings.Contains(w[0], "spec.containers[name=app].resources") {
+			t.Errorf("pod fieldRef wrong: %s", w[0])
+		}
+	})
+
+	t.Run("pod-level nodeSelector survives", func(t *testing.T) {
+		pre := mkWorkload(t, "Deployment", map[string]any{"nodeSelector": map[string]any{"disktype": "ssd"}, "containers": []any{ctr("app")}})
+		subm := mkWorkload(t, "Deployment", map[string]any{"containers": []any{ctr("app")}})
+		post := mkWorkload(t, "Deployment", map[string]any{"nodeSelector": map[string]any{"disktype": "ssd"}, "containers": []any{ctr("app")}})
+
+		w := checkFieldRemoval(subm, pre, post)
+		if len(w) != 1 {
+			t.Fatalf("want 1 warning, got %d: %v", len(w), w)
+		}
+		if !strings.Contains(w[0], "spec.template.spec.nodeSelector") {
+			t.Errorf("nodeSelector fieldRef wrong: %s", w[0])
+		}
+		// No other manager → the plain "set it to null" remediation.
+		if !strings.Contains(w[0], "set its value to null") {
+			t.Errorf("expected null-removal remediation: %s", w[0])
+		}
+	})
+
+	t.Run("field still in submission is not flagged", func(t *testing.T) {
+		pre := mkWorkload(t, "Deployment", map[string]any{"containers": []any{ctr("app", "readinessProbe")}})
+		subm := mkWorkload(t, "Deployment", map[string]any{"containers": []any{ctr("app", "readinessProbe")}})
+		post := mkWorkload(t, "Deployment", map[string]any{"containers": []any{ctr("app", "readinessProbe")}})
+
+		if w := checkFieldRemoval(subm, pre, post); len(w) != 0 {
+			t.Fatalf("want no warning when field kept, got %v", w)
+		}
+	})
+
+	t.Run("successful removal is not flagged", func(t *testing.T) {
+		pre := mkWorkload(t, "Deployment", map[string]any{"containers": []any{ctr("app", "readinessProbe")}})
+		subm := mkWorkload(t, "Deployment", map[string]any{"containers": []any{ctr("app")}})
+		post := mkWorkload(t, "Deployment", map[string]any{"containers": []any{ctr("app")}})
+
+		if w := checkFieldRemoval(subm, pre, post); len(w) != 0 {
+			t.Fatalf("want no warning when field actually removed, got %v", w)
+		}
+	})
+
+	t.Run("matches container by name not index", func(t *testing.T) {
+		pre := mkWorkload(t, "Deployment", map[string]any{"containers": []any{ctr("app", "resources"), ctr("side")}})
+		subm := mkWorkload(t, "Deployment", map[string]any{"containers": []any{ctr("side"), ctr("app")}})
+		post := mkWorkload(t, "Deployment", map[string]any{"containers": []any{ctr("side"), ctr("app", "resources")}})
+
+		w := checkFieldRemoval(subm, pre, post)
+		if len(w) != 1 {
+			t.Fatalf("want 1 warning, got %d: %v", len(w), w)
+		}
+		if !strings.Contains(w[0], "name=app") || strings.Contains(w[0], "name=side") {
+			t.Errorf("warning should key on app, not side: %s", w[0])
+		}
+	})
+
+	t.Run("nil inputs", func(t *testing.T) {
+		ok := mkWorkload(t, "Deployment", map[string]any{"containers": []any{ctr("app")}})
+		if w := checkFieldRemoval(nil, ok, ok); w != nil {
+			t.Errorf("nil submitted should yield nil, got %v", w)
+		}
+		if w := checkFieldRemoval(ok, nil, ok); w != nil {
+			t.Errorf("nil pre should yield nil, got %v", w)
+		}
+	})
+}
+
+func TestPodSpecReferences(t *testing.T) {
+	tests := []struct {
+		name    string
+		kind    string
+		podSpec map[string]any
+		refKind string
+		refName string
+		want    bool
+	}{
+		{
+			name:    "env configMapKeyRef",
+			kind:    "Deployment",
+			podSpec: map[string]any{"containers": []any{map[string]any{"name": "app", "env": []any{map[string]any{"name": "X", "valueFrom": map[string]any{"configMapKeyRef": map[string]any{"name": "cfg"}}}}}}},
+			refKind: "ConfigMap", refName: "cfg", want: true,
+		},
+		{
+			name:    "env secretKeyRef",
+			kind:    "Deployment",
+			podSpec: map[string]any{"containers": []any{map[string]any{"name": "app", "env": []any{map[string]any{"name": "X", "valueFrom": map[string]any{"secretKeyRef": map[string]any{"name": "sec"}}}}}}},
+			refKind: "Secret", refName: "sec", want: true,
+		},
+		{
+			name:    "envFrom configMapRef",
+			kind:    "Deployment",
+			podSpec: map[string]any{"containers": []any{map[string]any{"name": "app", "envFrom": []any{map[string]any{"configMapRef": map[string]any{"name": "cfg"}}}}}},
+			refKind: "ConfigMap", refName: "cfg", want: true,
+		},
+		{
+			name:    "volume configMap.name",
+			kind:    "Deployment",
+			podSpec: map[string]any{"containers": []any{ctr("app")}, "volumes": []any{map[string]any{"name": "v", "configMap": map[string]any{"name": "cfg"}}}},
+			refKind: "ConfigMap", refName: "cfg", want: true,
+		},
+		{
+			// Secret volumes key on secretName, not name — a regression copying
+			// the ConfigMap shape would silently miss every secret-volume consumer.
+			name:    "volume secret.secretName",
+			kind:    "Deployment",
+			podSpec: map[string]any{"containers": []any{ctr("app")}, "volumes": []any{map[string]any{"name": "v", "secret": map[string]any{"secretName": "sec"}}}},
+			refKind: "Secret", refName: "sec", want: true,
+		},
+		{
+			name:    "volume secret.name does not match",
+			kind:    "Deployment",
+			podSpec: map[string]any{"containers": []any{ctr("app")}, "volumes": []any{map[string]any{"name": "v", "secret": map[string]any{"name": "sec"}}}},
+			refKind: "Secret", refName: "sec", want: false,
+		},
+		{
+			name:    "projected configMap source",
+			kind:    "Deployment",
+			podSpec: map[string]any{"containers": []any{ctr("app")}, "volumes": []any{map[string]any{"name": "v", "projected": map[string]any{"sources": []any{map[string]any{"configMap": map[string]any{"name": "cfg"}}}}}}},
+			refKind: "ConfigMap", refName: "cfg", want: true,
+		},
+		{
+			// Projected secret sources key on name (unlike a plain secret volume).
+			name:    "projected secret source uses name",
+			kind:    "Deployment",
+			podSpec: map[string]any{"containers": []any{ctr("app")}, "volumes": []any{map[string]any{"name": "v", "projected": map[string]any{"sources": []any{map[string]any{"secret": map[string]any{"name": "sec"}}}}}}},
+			refKind: "Secret", refName: "sec", want: true,
+		},
+		{
+			name:    "initContainer env match",
+			kind:    "Deployment",
+			podSpec: map[string]any{"initContainers": []any{map[string]any{"name": "init", "envFrom": []any{map[string]any{"configMapRef": map[string]any{"name": "cfg"}}}}}, "containers": []any{ctr("app")}},
+			refKind: "ConfigMap", refName: "cfg", want: true,
+		},
+		{
+			name:    "name mismatch",
+			kind:    "Deployment",
+			podSpec: map[string]any{"containers": []any{map[string]any{"name": "app", "envFrom": []any{map[string]any{"configMapRef": map[string]any{"name": "other"}}}}}},
+			refKind: "ConfigMap", refName: "cfg", want: false,
+		},
+		{
+			name:    "wrong refKind",
+			kind:    "Deployment",
+			podSpec: map[string]any{"containers": []any{map[string]any{"name": "app", "envFrom": []any{map[string]any{"configMapRef": map[string]any{"name": "cfg"}}}}}},
+			refKind: "Secret", refName: "cfg", want: false,
+		},
+		{
+			name:    "cronjob nested path",
+			kind:    "CronJob",
+			podSpec: map[string]any{"containers": []any{map[string]any{"name": "app", "envFrom": []any{map[string]any{"configMapRef": map[string]any{"name": "cfg"}}}}}},
+			refKind: "ConfigMap", refName: "cfg", want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := mkWorkload(t, tt.kind, tt.podSpec)
+			if got := podSpecReferences(obj, tt.refKind, tt.refName); got != tt.want {
+				t.Errorf("podSpecReferences = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatConsumerWarning(t *testing.T) {
+	if got := formatConsumerWarning("ConfigMap", "cfg", nil, false); got != "" {
+		t.Errorf("verified-empty should yield no warning, got %q", got)
+	}
+	if got := formatConsumerWarning("ConfigMap", "cfg", nil, true); !strings.Contains(got, "Could not fully enumerate") {
+		t.Errorf("partial-empty should hedge, got %q", got)
+	}
+	full := formatConsumerWarning("ConfigMap", "cfg", []string{"Deployment/a", "Deployment/b"}, false)
+	if !strings.Contains(full, "2 workload(s)") || strings.Contains(full, "incomplete") {
+		t.Errorf("complete list should not be marked incomplete: %q", full)
+	}
+	partial := formatConsumerWarning("ConfigMap", "cfg", []string{"Deployment/a"}, true)
+	if !strings.Contains(partial, "incomplete") {
+		t.Errorf("partial list should be flagged incomplete: %q", partial)
+	}
+	many := make([]string, 7)
+	for i := range many {
+		many[i] = "Deployment/d"
+	}
+	if got := formatConsumerWarning("Secret", "s", many, false); !strings.Contains(got, "(+2 more)") {
+		t.Errorf("expected truncation marker for >5 consumers: %q", got)
+	}
+}

--- a/pkg/k8score/object_warnings.go
+++ b/pkg/k8score/object_warnings.go
@@ -1,0 +1,197 @@
+package k8score
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// EnrichRuntimeObjectWarnings converts a typed K8s runtime.Object to
+// *unstructured.Unstructured (if needed) and runs EnrichObjectWarnings.
+// Returns nil on conversion error — best-effort, never blocks the caller.
+func EnrichRuntimeObjectWarnings(obj runtime.Object) []string {
+	if obj == nil {
+		return nil
+	}
+	if u, ok := obj.(*unstructured.Unstructured); ok {
+		return EnrichObjectWarnings(u)
+	}
+	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil
+	}
+	return EnrichObjectWarnings(&unstructured.Unstructured{Object: raw})
+}
+
+// EnrichObjectWarnings derives advisory warnings purely from an object's own
+// state — no API calls. Safe to invoke per-row on list responses. Surfaces
+// state that an agent commonly skims past (deletionTimestamp, terminating
+// namespace, never-healthy workloads, external reconciliation by Helm/Argo/Flux).
+//
+// All entries are self-contained factual sentences. Empty result means
+// "nothing notable about this object's state."
+func EnrichObjectWarnings(obj *unstructured.Unstructured) []string {
+	if obj == nil {
+		return nil
+	}
+	var out []string
+
+	if mgr, instance := detectExternalManager(obj); mgr != "" {
+		out = append(out, formatExternalManagerWarning(mgr, instance))
+	}
+
+	if w := deletionTimestampWarning(obj); w != "" {
+		out = append(out, w)
+	}
+
+	if w := namespaceTerminatingWarning(obj); w != "" {
+		out = append(out, w)
+	}
+
+	if w := workloadHealthWarning(obj); w != "" {
+		out = append(out, w)
+	}
+
+	if w := pvcPendingWarning(obj); w != "" {
+		out = append(out, w)
+	}
+
+	return out
+}
+
+func deletionTimestampWarning(obj *unstructured.Unstructured) string {
+	dt := obj.GetDeletionTimestamp()
+	if dt == nil || dt.IsZero() {
+		return ""
+	}
+	finalizers := obj.GetFinalizers()
+	if len(finalizers) == 0 {
+		return fmt.Sprintf("Resource is being deleted (deletionTimestamp: %s, no finalizers remaining); it may disappear shortly. Any edits will not persist.", dt.Format(time.RFC3339))
+	}
+	return fmt.Sprintf("Resource is being deleted (deletionTimestamp: %s) with %d finalizer(s) still active: %s. The resource is in cleanup; edits and reads can behave unexpectedly until finalizers are removed.", dt.Format(time.RFC3339), len(finalizers), strings.Join(finalizers, ", "))
+}
+
+func namespaceTerminatingWarning(obj *unstructured.Unstructured) string {
+	if obj.GetKind() != "Namespace" {
+		return ""
+	}
+	phase, _, _ := unstructured.NestedString(obj.Object, "status", "phase")
+	if phase != "Terminating" {
+		return ""
+	}
+	return "Namespace is in `Terminating` phase. The apiserver will reject new resource creates in this namespace until termination completes (or until a stuck finalizer is removed)."
+}
+
+// workloadHealthWarning surfaces (1) how long the workload's primary health
+// condition has been False and (2) whether that failure has been continuous
+// since the workload was created — a strong "this state is baseline, not new"
+// signal. We don't recommend an interpretation: agents reading current state
+// will treat "broken since deploy" as the problem to fix; agents debugging an
+// incident will treat it as a baseline distractor.
+func workloadHealthWarning(obj *unstructured.Unstructured) string {
+	kind := obj.GetKind()
+	var conditionType string
+	switch kind {
+	case "Deployment", "StatefulSet":
+		conditionType = "Available"
+	case "Pod":
+		conditionType = "Ready"
+	default:
+		return ""
+	}
+
+	conds, _, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if len(conds) == 0 {
+		return ""
+	}
+
+	var failingFor time.Duration
+	var foundFailing bool
+	for _, c := range conds {
+		cm, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		cType, _ := cm["type"].(string)
+		if cType != conditionType {
+			continue
+		}
+		cStatus, _ := cm["status"].(string)
+		if cStatus != "False" {
+			return ""
+		}
+		foundFailing = true
+		if ltt, _ := cm["lastTransitionTime"].(string); ltt != "" {
+			if t, err := time.Parse(time.RFC3339, ltt); err == nil {
+				failingFor = time.Since(t)
+			}
+		}
+		break
+	}
+	if !foundFailing {
+		return ""
+	}
+
+	createdAt := obj.GetCreationTimestamp().Time
+	if createdAt.IsZero() || failingFor <= 0 {
+		return ""
+	}
+	age := time.Since(createdAt)
+
+	// "never healthy" = condition has been False for essentially the entire
+	// resource lifetime. The 30s slop accommodates the brief moment after
+	// creation when conditions haven't been written yet.
+	if age-failingFor < 30*time.Second {
+		return fmt.Sprintf("Condition `%s=False` for ~%s — continuously since this resource was created. The failure has been present from the moment it was first applied; check whether this matches what you were asked to investigate (a recently-introduced fault vs. a long-standing misconfiguration).", conditionType, durationShort(failingFor))
+	}
+	return fmt.Sprintf("Condition `%s=False` for ~%s (resource age: %s).", conditionType, durationShort(failingFor), durationShort(age))
+}
+
+func pvcPendingWarning(obj *unstructured.Unstructured) string {
+	if obj.GetKind() != "PersistentVolumeClaim" {
+		return ""
+	}
+	phase, _, _ := unstructured.NestedString(obj.Object, "status", "phase")
+	if phase != "Pending" {
+		return ""
+	}
+	createdAt := obj.GetCreationTimestamp().Time
+	if createdAt.IsZero() {
+		return ""
+	}
+	age := time.Since(createdAt)
+	if age < 30*time.Second {
+		return ""
+	}
+	return fmt.Sprintf("PVC has been `Pending` for %s. Common causes: no matching StorageClass, `volumeBindingMode: WaitForFirstConsumer` with no consumer pod scheduled yet, or capacity exhaustion in the underlying provisioner. Check `status.conditions` and recent Warning events on this PVC.", durationShort(age))
+}
+
+func durationShort(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		m := int(d.Minutes())
+		s := int(d.Seconds()) - m*60
+		if s == 0 {
+			return fmt.Sprintf("%dm", m)
+		}
+		return fmt.Sprintf("%dm%ds", m, s)
+	}
+	if d < 24*time.Hour {
+		h := int(d.Hours())
+		m := int(d.Minutes()) - h*60
+		if m == 0 {
+			return fmt.Sprintf("%dh", h)
+		}
+		return fmt.Sprintf("%dh%dm", h, m)
+	}
+	days := int(d.Hours()) / 24
+	return fmt.Sprintf("%dd", days)
+}

--- a/pkg/k8score/object_warnings_test.go
+++ b/pkg/k8score/object_warnings_test.go
@@ -1,0 +1,118 @@
+package k8score
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestDurationShort(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{0, "0s"},
+		{-5 * time.Second, "0s"},
+		{59 * time.Second, "59s"},
+		{60 * time.Second, "1m"},
+		{90 * time.Second, "1m30s"},
+		{59*time.Minute + 59*time.Second, "59m59s"},
+		{time.Hour, "1h"},
+		{time.Hour + time.Minute, "1h1m"},
+		{23*time.Hour + 59*time.Minute, "23h59m"},
+		{24 * time.Hour, "1d"},
+		{49 * time.Hour, "2d"},
+	}
+	for _, tt := range tests {
+		if got := durationShort(tt.d); got != tt.want {
+			t.Errorf("durationShort(%v) = %q, want %q", tt.d, got, tt.want)
+		}
+	}
+}
+
+func mkHealthObj(kind, condType, condStatus string, created, ltt time.Time) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"kind":     kind,
+		"metadata": map[string]any{"name": "w"},
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{
+					"type":               condType,
+					"status":             condStatus,
+					"lastTransitionTime": ltt.UTC().Format(time.RFC3339),
+				},
+			},
+		},
+	}}
+	obj.SetCreationTimestamp(metav1.NewTime(created))
+	return obj
+}
+
+func TestWorkloadHealthWarning(t *testing.T) {
+	now := time.Now()
+
+	t.Run("never healthy since creation", func(t *testing.T) {
+		// Condition went False essentially at creation → continuous-failure phrasing.
+		obj := mkHealthObj("Deployment", "Available", "False", now.Add(-2*time.Minute), now.Add(-2*time.Minute+time.Second))
+		w := workloadHealthWarning(obj)
+		if !strings.Contains(w, "continuously since this resource was created") {
+			t.Errorf("want never-healthy phrasing, got %q", w)
+		}
+	})
+
+	t.Run("regressed long after creation", func(t *testing.T) {
+		obj := mkHealthObj("Deployment", "Available", "False", now.Add(-time.Hour), now.Add(-5*time.Minute))
+		w := workloadHealthWarning(obj)
+		if strings.Contains(w, "continuously since this resource was created") {
+			t.Errorf("should not use never-healthy phrasing, got %q", w)
+		}
+		if !strings.Contains(w, "(resource age:") {
+			t.Errorf("want regressed phrasing with resource age, got %q", w)
+		}
+	})
+
+	t.Run("available true yields nothing", func(t *testing.T) {
+		obj := mkHealthObj("Deployment", "Available", "True", now.Add(-time.Hour), now.Add(-time.Hour))
+		if w := workloadHealthWarning(obj); w != "" {
+			t.Errorf("healthy workload should yield no warning, got %q", w)
+		}
+	})
+
+	t.Run("pod uses Ready condition", func(t *testing.T) {
+		obj := mkHealthObj("Pod", "Ready", "False", now.Add(-time.Hour), now.Add(-5*time.Minute))
+		if w := workloadHealthWarning(obj); !strings.Contains(w, "`Ready=False`") {
+			t.Errorf("pod should report Ready, got %q", w)
+		}
+		// A Pod's Available condition is irrelevant — only Ready drives the warning.
+		other := mkHealthObj("Pod", "Available", "False", now.Add(-time.Hour), now.Add(-5*time.Minute))
+		if w := workloadHealthWarning(other); w != "" {
+			t.Errorf("pod with no Ready condition should yield nothing, got %q", w)
+		}
+	})
+
+	t.Run("unhandled kind yields nothing", func(t *testing.T) {
+		obj := mkHealthObj("DaemonSet", "Available", "False", now.Add(-time.Hour), now.Add(-5*time.Minute))
+		if w := workloadHealthWarning(obj); w != "" {
+			t.Errorf("DaemonSet has no Available condition; want nothing, got %q", w)
+		}
+	})
+
+	t.Run("future lastTransitionTime is guarded", func(t *testing.T) {
+		// Clock skew: condition stamped in the future → negative failingFor must
+		// not produce a "~-Xs" warning.
+		obj := mkHealthObj("StatefulSet", "Available", "False", now.Add(-time.Hour), now.Add(5*time.Minute))
+		if w := workloadHealthWarning(obj); w != "" {
+			t.Errorf("future lastTransitionTime should yield nothing, got %q", w)
+		}
+	})
+
+	t.Run("no conditions yields nothing", func(t *testing.T) {
+		obj := &unstructured.Unstructured{Object: map[string]any{"kind": "Deployment", "metadata": map[string]any{"name": "w"}}}
+		if w := workloadHealthWarning(obj); w != "" {
+			t.Errorf("no conditions should yield nothing, got %q", w)
+		}
+	})
+}

--- a/pkg/k8score/workload.go
+++ b/pkg/k8score/workload.go
@@ -59,6 +59,13 @@ type ApplyResourceResult struct {
 	Namespace string `json:"namespace"`
 	Kind      string `json:"kind"`
 	Created   bool   `json:"created"` // true if newly created, false if updated
+
+	// Warnings are advisory notes derived from the actual state of the cluster
+	// (e.g., "this resource is reconciled by Helm" or "field X you omitted is
+	// still present after apply because manager Y owns it"). They never block
+	// the apply — the apply succeeded if no error was returned. Treat each
+	// entry as a self-contained sentence.
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 // WorkloadManager provides workload lifecycle operations using injected clients.
@@ -217,12 +224,27 @@ func (m *WorkloadManager) ApplyResource(ctx context.Context, opts ApplyResourceO
 		client = m.dynClient.Resource(gvr)
 	}
 
+	// Pre-apply GET: feeds the external-manager warning and the SSA
+	// field-removal verification. Best-effort — a NotFound just means the
+	// resource is being newly created, and other errors shouldn't block the
+	// apply itself.
+	var pre *unstructured.Unstructured
+	if !opts.DryRun {
+		got, getErr := client.Get(ctx, name, metav1.GetOptions{})
+		if getErr == nil {
+			pre = got
+		} else if !apierrors.IsNotFound(getErr) {
+			log.Printf("[k8s] apply_resource: pre-apply GET %s/%s/%s failed: %v", kind, ns, name, getErr)
+		}
+	}
+
 	if mode == "create" {
 		_, err := client.Create(ctx, obj, metav1.CreateOptions{DryRun: dryRun})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create resource: %w", err)
 		}
 		result.Created = true
+		m.populateApplyWarnings(ctx, result, obj, pre, nil, ns, kind, name)
 		return result, nil
 	}
 
@@ -245,7 +267,49 @@ func (m *WorkloadManager) ApplyResource(ctx context.Context, opts ApplyResourceO
 	// With server-side apply we can't easily distinguish, so we default to false (updated).
 	// The caller can check if the resource was newly created by other means if needed.
 	result.Created = false
+
+	var post *unstructured.Unstructured
+	if !opts.DryRun && pre != nil {
+		got, getErr := client.Get(ctx, name, metav1.GetOptions{})
+		if getErr == nil {
+			post = got
+		} else {
+			log.Printf("[k8s] apply_resource: post-apply GET %s/%s/%s failed: %v", kind, ns, name, getErr)
+		}
+	}
+
+	m.populateApplyWarnings(ctx, result, obj, pre, post, ns, kind, name)
 	return result, nil
+}
+
+// populateApplyWarnings appends advisory warnings to result.Warnings.
+//
+//   - State-derived warnings (external manager, deletionTimestamp, etc.) come
+//     from the shared EnrichObjectWarnings; we run it against the post-apply
+//     object so the agent sees the resource the way any read of it would.
+//   - Apply-specific checks (SSA field-removal verification, ConfigMap/Secret
+//     consumer reload reminder) require knowledge of what was submitted vs.
+//     what landed and so live here.
+//
+// Best-effort throughout — a failed check never fails the apply itself.
+func (m *WorkloadManager) populateApplyWarnings(ctx context.Context, result *ApplyResourceResult, submitted, pre, post *unstructured.Unstructured, namespace, kind, name string) {
+	// State-derived: prefer post-apply (reflects what the agent just landed),
+	// fall back to pre when post wasn't fetched (dry run or post-GET failed).
+	target := post
+	if target == nil {
+		target = pre
+	}
+	result.Warnings = append(result.Warnings, EnrichObjectWarnings(target)...)
+
+	if pre != nil && post != nil {
+		result.Warnings = append(result.Warnings, checkFieldRemoval(submitted, pre, post)...)
+	}
+	if (kind == "ConfigMap" || kind == "Secret") && namespace != "" {
+		consumers := findConfigMapSecretConsumers(ctx, m.dynClient, m.discovery, namespace, kind, name)
+		if w := formatConsumerWarning(kind, name, consumers); w != "" {
+			result.Warnings = append(result.Warnings, w)
+		}
+	}
 }
 
 func boolPtr(b bool) *bool { return &b }

--- a/pkg/k8score/workload.go
+++ b/pkg/k8score/workload.go
@@ -268,8 +268,13 @@ func (m *WorkloadManager) ApplyResource(ctx context.Context, opts ApplyResourceO
 	// The caller can check if the resource was newly created by other means if needed.
 	result.Created = false
 
+	// Post-apply GET feeds the state-derived warnings (run against what
+	// actually landed) and the field-removal diff. Fetch it for creates too,
+	// not just updates — an SSA apply that creates a resource still wants the
+	// external-manager / terminating-namespace warnings (field-removal stays
+	// gated on pre != nil below).
 	var post *unstructured.Unstructured
-	if !opts.DryRun && pre != nil {
+	if !opts.DryRun {
 		got, getErr := client.Get(ctx, name, metav1.GetOptions{})
 		if getErr == nil {
 			post = got

--- a/pkg/k8score/workload.go
+++ b/pkg/k8score/workload.go
@@ -244,7 +244,7 @@ func (m *WorkloadManager) ApplyResource(ctx context.Context, opts ApplyResourceO
 			return nil, fmt.Errorf("failed to create resource: %w", err)
 		}
 		result.Created = true
-		m.populateApplyWarnings(ctx, result, obj, pre, nil, ns, kind, name)
+		m.populateApplyWarnings(ctx, result, obj, pre, nil, ns, kind, name, opts.DryRun)
 		return result, nil
 	}
 
@@ -278,7 +278,7 @@ func (m *WorkloadManager) ApplyResource(ctx context.Context, opts ApplyResourceO
 		}
 	}
 
-	m.populateApplyWarnings(ctx, result, obj, pre, post, ns, kind, name)
+	m.populateApplyWarnings(ctx, result, obj, pre, post, ns, kind, name, opts.DryRun)
 	return result, nil
 }
 
@@ -292,7 +292,7 @@ func (m *WorkloadManager) ApplyResource(ctx context.Context, opts ApplyResourceO
 //     what landed and so live here.
 //
 // Best-effort throughout — a failed check never fails the apply itself.
-func (m *WorkloadManager) populateApplyWarnings(ctx context.Context, result *ApplyResourceResult, submitted, pre, post *unstructured.Unstructured, namespace, kind, name string) {
+func (m *WorkloadManager) populateApplyWarnings(ctx context.Context, result *ApplyResourceResult, submitted, pre, post *unstructured.Unstructured, namespace, kind, name string, dryRun bool) {
 	// State-derived: prefer post-apply (reflects what the agent just landed),
 	// fall back to pre when post wasn't fetched (dry run or post-GET failed).
 	target := post
@@ -304,9 +304,12 @@ func (m *WorkloadManager) populateApplyWarnings(ctx context.Context, result *App
 	if pre != nil && post != nil {
 		result.Warnings = append(result.Warnings, checkFieldRemoval(submitted, pre, post)...)
 	}
-	if (kind == "ConfigMap" || kind == "Secret") && namespace != "" {
-		consumers := findConfigMapSecretConsumers(ctx, m.dynClient, m.discovery, namespace, kind, name)
-		if w := formatConsumerWarning(kind, name, consumers); w != "" {
+	// The consumer-reload reminder only makes sense for a persisted edit — on a
+	// dry run nothing landed, so the "restart consumers" advice would be
+	// premature (and the namespace-wide LISTs wasted).
+	if !dryRun && (kind == "ConfigMap" || kind == "Secret") && namespace != "" {
+		consumers, partial := findConfigMapSecretConsumers(ctx, m.dynClient, m.discovery, namespace, kind, name)
+		if w := formatConsumerWarning(kind, name, consumers, partial); w != "" {
 			result.Warnings = append(result.Warnings, w)
 		}
 	}


### PR DESCRIPTION
## Summary

Adds a lightweight **advisory warnings** layer to the MCP tools so an AI agent gets told about cluster state it commonly skims past — without any extra round-trips on the hot read paths. Each warning is a self-contained factual sentence; warnings never block the operation.

State-derived checks (no API calls — operate on the object already in hand) live in `pkg/k8score/object_warnings.go` so reads and applies share one implementation. Apply-specific checks live in `pkg/k8score/apply_warnings.go`.

## What surfaces where

- **`get_resource` / `diagnose`** — `deletionTimestamp` + remaining finalizers, terminating namespace, external manager (Helm / Argo CD / Flux), never-healthy workloads (primary condition `False` continuously since creation), PVC stuck `Pending`.
- **`get_pod_logs` / workload logs** — pod not in `Running` phase (app logs typically unavailable until containers start) and a crashloop hint (the error that killed the last container is in `previous: true`).
- **`manage_workload restart`** — warns when pods are currently `Pending` on a scheduling or post-bind constraint that a rolling restart won't fix (taints/affinity/capacity/CNI/storage). Admission failures (quota/PSA/webhook) are out of scope here — they block pod creation entirely, so there are no Pending pods to key on.
- **`apply_resource`** — external-manager reconciliation note (edits may revert), SSA field-removal verification (omitting a field under SSA does **not** remove it; you must set it to null), and a ConfigMap/Secret consumer reload reminder listing workloads that mount the object.

## Notes

- All checks are best-effort: a failed pre/post GET, cache miss, or conversion error yields no warning rather than failing the call.
- `apply_resource` adds a pre-apply GET (and a post-apply GET on update) to feed the external-manager note and SSA field-removal diff; both GETs and the ConfigMap/Secret consumer scan are skipped on dry-run.
- The consumer scan degrades honestly under partial RBAC: if a workload kind can't be listed (the apply path impersonates the user), it reports the result as incomplete rather than implying "nothing consumes this."
- `get_resource context=none` stays a bare object — warnings are part of the context sidecar, so raw-`jq` pipelines are unaffected.
- Adds unit tests for the pure warning logic: external-manager precedence, SSA field-removal (path formats, container-by-name, omit-vs-remove), ConfigMap/Secret consumer matching (incl. the `secret.secretName` vs `name` asymmetry), duration formatting, and workload-health never-healthy/regressed/clock-skew branches. Both module test suites pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends apply with pre/post GETs and namespace workload lists for ConfigMap/Secret warnings; behavior is advisory-only but touches write paths and SSA reconciliation awareness.
> 
> **Overview**
> Introduces a shared **`warnings`** sidecar on several MCP tools so agents get short, factual advisories about cluster state they often misread—without failing the underlying call.
> 
> **Read paths:** `get_resource` (when context is not `none`) and `diagnose` attach **`k8score.EnrichRuntimeObjectWarnings`** on the object already fetched—deletion in progress, Helm/Argo/Flux reconciliation, terminating namespaces, long-lived `Available`/`Ready=False`, PVC stuck `Pending`. **`get_pod_logs`** and **`get_workload_logs`** add best-effort pod-status hints (non-Running → logs usually empty; restarts without `previous: true` → crash logs are on the prior instance). **`manage_workload restart`** can warn when pods are `Pending` for detected scheduling/admission/post-bind reasons, so a rolling restart likely won't help.
> 
> **Apply path:** `ApplyResourceResult` and MCP **`apply_resource`** responses now include **`warnings`**. Applies gain optional pre/post GETs (skipped on dry-run) to run shared state warnings, **SSA field-removal checks** (omitted PodSpec fields that still exist after apply), and **ConfigMap/Secret consumer** scan with honest partial-RBAC messaging.
> 
> New logic lives in **`pkg/k8score`** (`object_warnings.go`, `apply_warnings.go`) with unit tests; hot read paths avoid extra API calls except where apply explicitly adds GETs/lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ff421ccc19b1dc666d14cbe6c6aa00124d2eed7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
