### PR TITLE
Keep CRD API versions out of package versions

### DIFF
--- a/pkg/packages/aggregate.go
+++ b/pkg/packages/aggregate.go
@@ -173,7 +173,7 @@ func Aggregate(s Sources) []PackageRow {
 		// silently expose mutation across rows if the literal were
 		// shared.
 		newContribution := func() SourceContribution {
-			return SourceContribution{Source: SourceCRDs, Version: version}
+			return SourceContribution{Source: SourceCRDs, APIVersion: version}
 		}
 		if known {
 			matched := false

--- a/pkg/packages/aggregate_test.go
+++ b/pkg/packages/aggregate_test.go
@@ -72,10 +72,10 @@ func TestAggregate_CertManager_AllThreeSources(t *testing.T) {
 			Health: "healthy",
 		}},
 		CRDs: []CRD{{
-			Name:    "certificates.cert-manager.io",
-			Group:   "cert-manager.io",
-			Kind:    "Certificate",
-			Plural:  "certificates",
+			Name:     "certificates.cert-manager.io",
+			Group:    "cert-manager.io",
+			Kind:     "Certificate",
+			Plural:   "certificates",
 			Versions: []string{"v1"},
 		}},
 	})
@@ -136,10 +136,10 @@ func TestAggregate_Karpenter_NoHelmAccess(t *testing.T) {
 func TestAggregate_RawOperator_KnownGroup(t *testing.T) {
 	rows := Aggregate(Sources{
 		CRDs: []CRD{{
-			Name:    "certificates.cert-manager.io",
-			Group:   "cert-manager.io",
-			Kind:    "Certificate",
-			Plural:  "certificates",
+			Name:     "certificates.cert-manager.io",
+			Group:    "cert-manager.io",
+			Kind:     "Certificate",
+			Plural:   "certificates",
 			Versions: []string{"v1"},
 		}},
 	})
@@ -150,8 +150,15 @@ func TestAggregate_RawOperator_KnownGroup(t *testing.T) {
 	if r.Chart != "cert-manager" || r.Health != "unknown" || r.FromCRDGroup != "" {
 		t.Errorf("bad CRD-only row: %+v", r)
 	}
+	if r.Version != "" {
+		t.Errorf("CRD API version must not populate package Version, got %q", r.Version)
+	}
 	if !equalSources(r.Sources, []SourceCode{SourceCRDs}) {
 		t.Errorf("want sources=[C], got %v", r.Sources)
+	}
+	crd := findContrib(r, SourceCRDs)
+	if crd.APIVersion != "v1" {
+		t.Errorf("CRD contribution APIVersion = %+v, want v1", crd)
 	}
 }
 
@@ -160,10 +167,10 @@ func TestAggregate_RawOperator_KnownGroup(t *testing.T) {
 func TestAggregate_RawOperator_UnknownGroup(t *testing.T) {
 	rows := Aggregate(Sources{
 		CRDs: []CRD{{
-			Name:    "widgets.example.com",
-			Group:   "example.com",
-			Kind:    "Widget",
-			Plural:  "widgets",
+			Name:     "widgets.example.com",
+			Group:    "example.com",
+			Kind:     "Widget",
+			Plural:   "widgets",
 			Versions: []string{"v1alpha1"},
 		}},
 	})
@@ -173,6 +180,13 @@ func TestAggregate_RawOperator_UnknownGroup(t *testing.T) {
 	r := rows[0]
 	if r.Chart != "example.com" || r.FromCRDGroup != "example.com" {
 		t.Errorf("bad unknown-group row: %+v", r)
+	}
+	if r.Version != "" {
+		t.Errorf("CRD API version must not populate package Version, got %q", r.Version)
+	}
+	crd := findContrib(r, SourceCRDs)
+	if crd.APIVersion != "v1alpha1" {
+		t.Errorf("CRD contribution APIVersion = %+v, want v1alpha1", crd)
 	}
 }
 
@@ -274,11 +288,11 @@ func TestWorseHealth_Ranking(t *testing.T) {
 		{HealthHealthy, HealthUnknown, HealthUnknown},
 		{HealthDegraded, HealthUnknown, HealthDegraded},
 		{HealthHealthy, HealthDegraded, HealthDegraded},
-		{"stalled", HealthDegraded, "stalled"},          // stalled ranks with unhealthy
-		{"progressing", HealthHealthy, "progressing"},   // progressing ranks with degraded
-		{"", HealthHealthy, HealthHealthy},              // empty = no opinion
-		{HealthDegraded, "", HealthDegraded},            // empty = no opinion
-		{"weirdo", HealthHealthy, "weirdo"},             // unrecognized → "unknown" rank, beats healthy
+		{"stalled", HealthDegraded, "stalled"},        // stalled ranks with unhealthy
+		{"progressing", HealthHealthy, "progressing"}, // progressing ranks with degraded
+		{"", HealthHealthy, HealthHealthy},            // empty = no opinion
+		{HealthDegraded, "", HealthDegraded},          // empty = no opinion
+		{"weirdo", HealthHealthy, "weirdo"},           // unrecognized → "unknown" rank, beats healthy
 	}
 	for _, c := range cases {
 		if got := worseHealth(c.a, c.b); got != c.want {
@@ -490,8 +504,11 @@ func TestAggregate_CRDOnlyContributionShape(t *testing.T) {
 	if c.Source != SourceCRDs {
 		t.Errorf("Source = %q, want C", c.Source)
 	}
-	if c.Version != "v1" {
-		t.Errorf("Version = %q, want v1", c.Version)
+	if c.Version != "" {
+		t.Errorf("Version = %q, want empty package version", c.Version)
+	}
+	if c.APIVersion != "v1" {
+		t.Errorf("APIVersion = %q, want v1", c.APIVersion)
 	}
 	if c.ReleaseName != "" || c.ReleaseNamespace != "" {
 		t.Errorf("CRD contribution should have no release identity, got name=%q ns=%q",

--- a/pkg/packages/aggregate_test.go
+++ b/pkg/packages/aggregate_test.go
@@ -523,6 +523,34 @@ func TestAggregate_CRDOnlyContributionShape(t *testing.T) {
 	}
 }
 
+func TestAddContribution_NormalizesVersionFieldsBySource(t *testing.T) {
+	var r PackageRow
+	r.AddContribution(SourceContribution{
+		Source:  SourceCRDs,
+		Version: "v1",
+	})
+	crd := findContrib(r, SourceCRDs)
+	if r.Version != "" {
+		t.Errorf("CRD contribution should not populate row Version, got %q", r.Version)
+	}
+	if crd.Version != "" || crd.APIVersion != "v1" {
+		t.Errorf("CRD contribution = %+v, want empty Version + APIVersion v1", crd)
+	}
+
+	r.AddContribution(SourceContribution{
+		Source:     SourceHelm,
+		Version:    "1.2.3",
+		APIVersion: "v1",
+	})
+	helm := findContrib(r, SourceHelm)
+	if r.Version != "1.2.3" {
+		t.Errorf("Helm contribution should populate row Version, got %q", r.Version)
+	}
+	if helm.Version != "1.2.3" || helm.APIVersion != "" {
+		t.Errorf("Helm contribution = %+v, want Version 1.2.3 + empty APIVersion", helm)
+	}
+}
+
 // Hub fan-in: contributions from different clusters with the same
 // SourceCode must coexist (not collapse). This is what lets Hub deep-
 // link to per-cluster Argo App identity in the "same chart, two

--- a/pkg/packages/types.go
+++ b/pkg/packages/types.go
@@ -238,6 +238,7 @@ func (r *PackageRow) MergeHealth(h Health) {
 //     first-seen wins) — preserves the existing on-wire semantics
 //     for simple consumers that ignore Contributors.
 func (r *PackageRow) AddContribution(c SourceContribution) {
+	c = normalizeContribution(c)
 	r.AddSource(c.Source)
 	r.MergeHealth(c.Health)
 	if r.Version == "" && c.Source != SourceCRDs {
@@ -277,6 +278,19 @@ func (r *PackageRow) AddContribution(c SourceContribution) {
 	}
 	r.Contributors = append(r.Contributors, c)
 	sortContributors(r.Contributors)
+}
+
+func normalizeContribution(c SourceContribution) SourceContribution {
+	if c.Source == SourceCRDs {
+		if c.APIVersion == "" {
+			c.APIVersion = c.Version
+		}
+		c.Version = ""
+		c.AppVersion = ""
+		return c
+	}
+	c.APIVersion = ""
+	return c
 }
 
 // Contributor returns the first contribution from the given source

--- a/pkg/packages/types.go
+++ b/pkg/packages/types.go
@@ -142,6 +142,7 @@ type SourceContribution struct {
 	Source           SourceCode `json:"source"`
 	Health           Health     `json:"health,omitempty"`
 	Version          string     `json:"version,omitempty"`
+	APIVersion       string     `json:"apiVersion,omitempty"`
 	AppVersion       string     `json:"appVersion,omitempty"`
 	ReleaseName      string     `json:"releaseName,omitempty"`
 	ReleaseNamespace string     `json:"releaseNamespace,omitempty"`
@@ -179,10 +180,11 @@ type PackageRow struct {
 	// cluster-scoped registrations with no namespaced release identity).
 	Namespace   string `json:"namespace,omitempty"`
 	ReleaseName string `json:"releaseName,omitempty"`
-	// Version (Helm chart version > label version > CRD spec.versions[0].name
-	// > GitOps declared version). Empty if no source supplied one. For
-	// per-source values (and to detect same-cluster version disagreement),
-	// read Contributors.
+	// Version (Helm chart version > label version > GitOps declared
+	// version). Empty if no package source supplied one. CRD API
+	// versions are source metadata and live on Contributors.APIVersion.
+	// For per-source values (and to detect same-cluster version
+	// disagreement), read Contributors.
 	Version string `json:"version,omitempty"`
 	// AppVersion if Helm provided one. Optional.
 	AppVersion string `json:"appVersion,omitempty"`
@@ -238,7 +240,7 @@ func (r *PackageRow) MergeHealth(h Health) {
 func (r *PackageRow) AddContribution(c SourceContribution) {
 	r.AddSource(c.Source)
 	r.MergeHealth(c.Health)
-	if r.Version == "" {
+	if r.Version == "" && c.Source != SourceCRDs {
 		r.Version = c.Version
 	}
 	if r.AppVersion == "" {
@@ -252,6 +254,9 @@ func (r *PackageRow) AddContribution(c SourceContribution) {
 		existing.Health = worseHealth(existing.Health, c.Health)
 		if existing.Version == "" {
 			existing.Version = c.Version
+		}
+		if existing.APIVersion == "" {
+			existing.APIVersion = c.APIVersion
 		}
 		if existing.AppVersion == "" {
 			existing.AppVersion = c.AppVersion


### PR DESCRIPTION
## Summary
- Move CRD API versions into per-source contributor metadata instead of aggregate package versions.
- Keep CRD-only package rows visible while preventing `PackageRow.version` from representing Kubernetes API versions.
- Normalize source contributions so CRD sources cannot retain package-version fields and package sources cannot retain CRD API-version fields.
- Add tests that pin CRD-only rows to empty package versions with `apiVersion` on the CRD contribution and cover contribution normalization.

## Test plan
- [x] `cd pkg && go test ./packages`
- [x] `go test ./internal/server`
- [x] `git diff --check`