### PR TITLE
feat(chart): grant missing reads + opt-in webhooks for resource browser

### DIFF
--- a/deploy/helm/radar/Chart.yaml
+++ b/deploy/helm/radar/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: radar
 description: Modern Kubernetes visibility - topology, traffic, Helm and GitOps management
 type: application
-version: 1.6.0
+version: 1.5.10
 appVersion: "1.5.7"
 icon: https://radarhq.io/radar/icon-512.png
 keywords:

--- a/deploy/helm/radar/Chart.yaml
+++ b/deploy/helm/radar/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: radar
 description: Modern Kubernetes visibility - topology, traffic, Helm and GitOps management
 type: application
-version: 1.5.10
+version: 1.6.0
 appVersion: "1.5.7"
 icon: https://radarhq.io/radar/icon-512.png
 keywords:

--- a/deploy/helm/radar/README.md
+++ b/deploy/helm/radar/README.md
@@ -139,7 +139,8 @@ Disabled by default for security:
 | Port Forward | `rbac.portForward: true` | Port forwarding to pods |
 | Logs | `rbac.podLogs: true` | View pod logs (**enabled by default**) |
 | Helm Write | `rbac.helm: true` | Install/upgrade/rollback/uninstall Helm releases. Under auth or cloud-mode, also emits a split helm add-on ClusterRole — `radar-helm` (member-safe: CRDs, storage, namespaces) and `radar-helm-admin` (owner-only: RBAC, webhooks, ApiServices) |
-| RBAC view | `rbac.viewRBAC: true` | Show ClusterRoles, ClusterRoleBindings, Roles, RoleBindings in the resource browser. Off by default — cache-served reads bypass per-user RBAC, so this exposes the cluster's authorization graph to every authenticated Radar user |
+| RBAC view | `rbac.viewRBAC: true` | Show ClusterRoles, ClusterRoleBindings, Roles, RoleBindings in the resource browser. Off by default — cache-served reads bypass per-user RBAC, so this exposes the cluster's authorization graph to every authenticated Radar user. Auto-enabled under auth or cloud mode (every read is re-checked per user there). |
+| Webhooks view | `rbac.viewWebhooks: true` | Show MutatingWebhookConfigurations and ValidatingWebhookConfigurations in the resource browser. Off by default — the configurations reveal which admission controls are enforced (Gatekeeper / Kyverno policies, image scanners, DLP) and where the gaps are, which is recon value for a low-trust viewer. Auto-enabled under auth or cloud mode. |
 
 ### In-app Agent Upgrades (opt-in, for Radar Cloud users)
 

--- a/deploy/helm/radar/templates/clusterrole.yaml
+++ b/deploy/helm/radar/templates/clusterrole.yaml
@@ -73,6 +73,22 @@ rules:
       - networkpolicies
     verbs: ["get", "list", "watch"]
 
+  # Scheduling / runtime / coordination metadata (read-only). PriorityClass
+  # and RuntimeClass are cluster-scoped infra; Leases are namespaced but
+  # surface in the resource browser and feed GitOps controller readiness.
+  - apiGroups: ["scheduling.k8s.io"]
+    resources:
+      - priorityclasses
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["node.k8s.io"]
+    resources:
+      - runtimeclasses
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources:
+      - leases
+    verbs: ["get", "list", "watch"]
+
   # Batch resources (read-only)
   - apiGroups: ["batch"]
     resources:
@@ -106,6 +122,20 @@ rules:
       - rolebindings
       - clusterroles
       - clusterrolebindings
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+
+  {{- if or .Values.rbac.viewWebhooks (ne .Values.auth.mode "none") .Values.cloud.enabled }}
+  # Admission webhook configurations (read): surfaces the cluster's admission
+  # plane (Gatekeeper, Kyverno, image scanners, DLP, etc.) in the resource
+  # browser. Auto-enabled under auth/cloud for the same reason as viewRBAC —
+  # responses are re-checked per user. For no-auth installs this is opt-in
+  # since the configurations reveal which controls are enforced (and where the
+  # gaps are), which is recon value for a low-trust viewer.
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
     verbs: ["get", "list", "watch"]
   {{- end }}
 

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -76,6 +76,17 @@ rbac:
   # is trusted with cluster RBAC visibility.
   viewRBAC: false
 
+  # Allow reading admission webhook configurations (MutatingWebhookConfiguration,
+  # ValidatingWebhookConfiguration) so the resource browser can list them.
+  # Auto-enabled when auth is on (auth.mode != none) or in cloud mode, where
+  # every read is re-checked against the requesting user's own permissions.
+  # For no-auth installs this stays opt-in: the configurations reveal which
+  # admission controls are enforced (Gatekeeper / Kyverno policies, image
+  # scanners, DLP, etc.) and where the gaps are — reconnaissance value for a
+  # low-trust viewer. Enable only if that audience is trusted with admission
+  # plane visibility.
+  viewWebhooks: false
+
   # Allow pod exec (enables terminal feature)
   podExec: false
 


### PR DESCRIPTION
## Summary

Radar's UI surfaces six resource kinds that the chart never granted read access to. Each has a dedicated renderer in `packages/k8s-ui/src/components/resources/renderers/` and is enumerated in `internal/k8s/kinds.go`. Before this change, opening any of them from the resource browser produced a 403 with no values-level workaround.

**Default-on** (low sensitivity; matches the existing PersistentVolume / StorageClass / IngressClass / PodDisruptionBudget treatment):

- `scheduling.k8s.io/priorityclasses`
- `node.k8s.io/runtimeclasses`
- `coordination.k8s.io/leases` (namespaced; also used by GitOps controller readiness checks)

**Opt-in via the new `rbac.viewWebhooks` flag** (mirrors the existing `rbac.viewRBAC` gate exactly: off by default for no-auth installs; auto-enabled under `auth.mode != "none"` or `cloud.enabled`, where every read is re-checked against the requesting user's permissions):

- `admissionregistration.k8s.io/mutatingwebhookconfigurations`
- `admissionregistration.k8s.io/validatingwebhookconfigurations`

Admission webhook configurations reveal which controls are enforced (Gatekeeper, Kyverno, image scanners, DLP) and where the gaps are — that is reconnaissance value for a low-trust viewer. The threat model matches RBAC visibility, so the gate uses the same shape.

## Files changed

```
deploy/helm/radar/README.md                  |  3 ++-
deploy/helm/radar/templates/clusterrole.yaml | 30 ++++++++++++++++++++++++++++
deploy/helm/radar/values.yaml                | 11 ++++++++++
```

`Chart.yaml` is intentionally not bumped here: `release.yml`'s "Update Chart.yaml version" step rewrites `version:` and `appVersion:` from the radar release tag at publish time, so any hand bump would just drift on the next release.

## Test plan

- [x] `helm lint deploy/helm/radar` — passes.
- [x] `helm template radar deploy/helm/radar` — the three always-on rules render in the ClusterRole; `mutatingwebhookconfigurations` and `validatingwebhookconfigurations` are absent.
- [x] `helm template radar deploy/helm/radar --set auth.mode=oidc` — webhook rules auto-appear, matching the `viewRBAC` precedent.
- [x] `go test -run TestChartGrantsEveryWatchedCRDGroup ./internal/k8s/...` — passes. (The existing guard is scoped to CRD-group coverage; this PR adds typed-K8s-group resources, which are explicitly out of that test's scope per its own comment.)
- [x] Live install on a `kind` cluster, verified per-scenario via `kubectl auth can-i list <resource> --as=system:serviceaccount:default:radar`:
  - Defaults — `priorityclasses` / `runtimeclasses` / `leases` allowed; `clusterroles` / webhooks denied.
  - `--set rbac.viewWebhooks=true` — webhooks allowed; `clusterroles` still denied.
  - `--set auth.mode=oidc` — both `clusterroles` and webhooks allowed via the auto-enable path.

## Related

- `skyhook-io/radar#805` (frontend): makes the 403 render as "Access denied" with the server message instead of a generic "Resource not found", so the cause is legible while this chart change rolls out.