### PR TITLE
feat(gitops): make summary tiles clickable filter shortcuts

### DIFF
--- a/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ComponentType, type ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ComponentType, type ReactNode } from 'react'
 import { clsx } from 'clsx'
 import {
   AlertTriangle,
@@ -117,6 +117,17 @@ export interface GitOpsRow {
 
 export type DestinationFilter = 'all' | 'this-cluster' | 'cross-cluster' | 'unmatched'
 
+type SummaryTone = 'neutral' | 'warning' | 'error' | 'info'
+
+interface SummaryTileSpec {
+  key: string
+  label: string
+  value: number
+  tone: SummaryTone
+  active: boolean
+  apply?: () => void
+}
+
 // ----- Component props -------------------------------------------------------
 
 export interface GitOpsTableViewProps {
@@ -186,6 +197,7 @@ export function GitOpsTableView({
   const [labelSearch, setLabelSearch] = useState('')
   const [automationFilter, setAutomationFilter] = useState<'all' | 'auto' | 'manual' | 'suspended'>('all')
   const [lifecycleFilter, setLifecycleFilter] = useState<'all' | 'terminating' | 'active'>('all')
+  const [reconcilingOnly, setReconcilingOnly] = useState(false)
   const [sortKey, setSortKey] = useState<SortKey>('health')
 
   // Optional '/' keyboard shortcut to focus search. Avoided as a default to
@@ -260,6 +272,7 @@ export function GitOpsTableView({
       if (automationFilter === 'suspended' && !row.suspended) return false
       if (lifecycleFilter === 'terminating' && !row.terminating) return false
       if (lifecycleFilter === 'active' && row.terminating) return false
+      if (reconcilingOnly && row.sync !== 'Reconciling' && row.health !== 'Progressing') return false
       if (destinationFilter && destinationFilter !== 'all') {
         const match = row._destination?.match
         if (destinationFilter === 'this-cluster' && match !== 'in_cluster') return false
@@ -273,9 +286,52 @@ export function GitOpsTableView({
       return true
     })
     return [...rows].sort((a, b) => compareRows(a, b, sortKey))
-  }, [allRows, automationFilter, healthFilters, labelFilters, lifecycleFilter, mode, namespaceFilters, projectFilters, search, sortKey, syncFilters, destinationFilter])
+  }, [allRows, automationFilter, healthFilters, labelFilters, lifecycleFilter, mode, namespaceFilters, projectFilters, search, sortKey, syncFilters, destinationFilter, reconcilingOnly])
 
   const terminatingCount = useMemo(() => allRows.filter((row) => row.terminating).length, [allRows])
+
+  const clearAllFilters = useCallback(() => {
+    setSearch('')
+    setSyncFilters(new Set())
+    setHealthFilters(new Set())
+    setProjectFilters(new Set())
+    setNamespaceFilters(new Set())
+    setLabelFilters(new Set())
+    setAutomationFilter('all')
+    setLifecycleFilter('all')
+    setReconcilingOnly(false)
+    onDestinationFilterChange?.('all')
+  }, [onDestinationFilterChange])
+
+  const noOtherFiltersActive = useCallback(
+    (
+      exclude: 'sync' | 'health' | 'automation' | 'destination' | 'reconciling' | null = null,
+    ) => {
+      if (search !== '') return false
+      if (exclude !== 'sync' && syncFilters.size > 0) return false
+      if (exclude !== 'health' && healthFilters.size > 0) return false
+      if (projectFilters.size > 0) return false
+      if (namespaceFilters.size > 0) return false
+      if (labelFilters.size > 0) return false
+      if (exclude !== 'automation' && automationFilter !== 'all') return false
+      if (lifecycleFilter !== 'all') return false
+      if (exclude !== 'destination' && destinationFilter && destinationFilter !== 'all') return false
+      if (exclude !== 'reconciling' && reconcilingOnly) return false
+      return true
+    },
+    [
+      search,
+      syncFilters,
+      healthFilters,
+      projectFilters,
+      namespaceFilters,
+      labelFilters,
+      automationFilter,
+      lifecycleFilter,
+      destinationFilter,
+      reconcilingOnly,
+    ],
+  )
 
   // Empty-state — when there's truly nothing to show across all kinds.
   if (totalGitOps === 0 && !loading) {
@@ -295,6 +351,62 @@ export function GitOpsTableView({
   }
 
   const showCrossClusterTile = typeof crossClusterCount === 'number' && mode === 'applications'
+
+  const summaryTiles: SummaryTileSpec[] = [
+    {
+      key: 'total',
+      label: 'Total Applications',
+      value: allRows.length,
+      tone: 'neutral',
+      active: noOtherFiltersActive(),
+    },
+    {
+      key: 'outOfSync',
+      label: 'Out of sync',
+      value: statusSummary.outOfSync,
+      tone: 'warning',
+      active:
+        syncFilters.size === 1 && syncFilters.has('OutOfSync') && noOtherFiltersActive('sync'),
+      apply: () => setSyncFilters(new Set(['OutOfSync'])),
+    },
+    {
+      key: 'degraded',
+      label: 'Degraded',
+      value: statusSummary.degraded,
+      tone: 'error',
+      active:
+        healthFilters.size === 1 && healthFilters.has('Degraded') && noOtherFiltersActive('health'),
+      apply: () => setHealthFilters(new Set(['Degraded'])),
+    },
+    {
+      key: 'suspended',
+      label: 'Suspended',
+      value: statusSummary.suspended,
+      tone: 'warning',
+      active: automationFilter === 'suspended' && noOtherFiltersActive('automation'),
+      apply: () => setAutomationFilter('suspended'),
+    },
+    {
+      key: 'reconciling',
+      label: 'Reconciling',
+      value: statusSummary.reconciling,
+      tone: 'info',
+      active: reconcilingOnly && noOtherFiltersActive('reconciling'),
+      apply: () => setReconcilingOnly(true),
+    },
+    ...(showCrossClusterTile
+      ? [
+          {
+            key: 'crossCluster',
+            label: 'Cross-cluster',
+            value: crossClusterCount!,
+            tone: 'info' as const,
+            active: destinationFilter === 'cross-cluster' && noOtherFiltersActive('destination'),
+            apply: () => onDestinationFilterChange?.('cross-cluster'),
+          },
+        ]
+      : []),
+  ]
 
   return (
     <div className="flex h-full min-w-0 flex-1 overflow-hidden bg-theme-base max-lg:flex-col">
@@ -319,16 +431,7 @@ export function GitOpsTableView({
         namespaces={rowNamespaces}
         namespaceFilters={namespaceFilters}
         onToggleNamespace={(value) => toggleSet(namespaceFilters, setNamespaceFilters, value)}
-        onClear={() => {
-          setSearch('')
-          setSyncFilters(new Set())
-          setHealthFilters(new Set())
-          setProjectFilters(new Set())
-          setNamespaceFilters(new Set())
-          setLabelFilters(new Set())
-          setAutomationFilter('all')
-          setLifecycleFilter('all')
-        }}
+        onClear={clearAllFilters}
       />
 
       <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
@@ -341,14 +444,19 @@ export function GitOpsTableView({
               </p>
             </div>
             <div className="flex shrink-0 flex-wrap justify-end gap-2">
-              <SummaryTile label="Applications" value={allRows.length} />
-              <SummaryTile label="Out of sync" value={statusSummary.outOfSync} tone="warning" />
-              <SummaryTile label="Degraded" value={statusSummary.degraded} tone="error" />
-              <SummaryTile label="Suspended" value={statusSummary.suspended} tone="warning" />
-              <SummaryTile label="Reconciling" value={statusSummary.reconciling} tone="info" />
-              {showCrossClusterTile && (
-                <SummaryTile label="Cross-cluster" value={crossClusterCount!} tone="info" />
-              )}
+              {summaryTiles.map((tile) => (
+                <SummaryTile
+                  key={tile.key}
+                  label={tile.label}
+                  value={tile.value}
+                  tone={tile.tone}
+                  active={tile.active}
+                  onClick={() => {
+                    clearAllFilters()
+                    if (!tile.active && tile.apply) tile.apply()
+                  }}
+                />
+              ))}
             </div>
           </div>
         </div>
@@ -1021,18 +1129,54 @@ function GitOpsTile({
   )
 }
 
-function SummaryTile({ label, value, tone = 'neutral' }: { label: string; value: number; tone?: 'neutral' | 'warning' | 'error' | 'info' }) {
+function SummaryTile({
+  label,
+  value,
+  tone = 'neutral',
+  onClick,
+  active = false,
+}: {
+  label: string
+  value: number
+  tone?: SummaryTone
+  onClick?: () => void
+  active?: boolean
+}) {
   const toneClass = {
     neutral: 'text-theme-text-primary',
     warning: 'text-amber-600 dark:text-amber-300',
     error: 'text-red-600 dark:text-red-300',
     info: 'text-sky-600 dark:text-sky-300',
   }[tone]
+  const activeBorderClass = {
+    neutral: 'border-skyhook-500',
+    warning: 'border-amber-500',
+    error: 'border-red-500',
+    info: 'border-sky-500',
+  }[tone]
+  const value$ = <div className={`text-sm font-semibold ${toneClass}`}>{value}</div>
+  const label$ = <div className="text-xs text-theme-text-tertiary">{label}</div>
+  if (!onClick) {
+    return (
+      <div className="rounded-md border border-theme-border bg-theme-base px-3 py-2">
+        {value$}
+        {label$}
+      </div>
+    )
+  }
   return (
-    <div className="rounded-md border border-theme-border bg-theme-base px-3 py-2">
-      <div className={`text-sm font-semibold ${toneClass}`}>{value}</div>
-      <div className="text-xs text-theme-text-tertiary">{label}</div>
-    </div>
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={clsx(
+        'cursor-pointer rounded-md border bg-theme-base px-3 py-2 text-left transition-colors hover:bg-theme-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-skyhook-500',
+        active ? activeBorderClass : 'border-theme-border',
+      )}
+    >
+      {value$}
+      {label$}
+    </button>
   )
 }
 


### PR DESCRIPTION
## Description

User feedback flagged "two competing filter UIs" on the GitOps Applications page (left rail facets + inline destination/labels row). Rather than removing either, this PR makes the row of summary tiles above the table double as discoverable filter shortcuts:

- **Applications** → renamed to **Total Applications**; clicking it clears all filters.
- **Out of sync / Degraded / Suspended / Reconciling / Cross-cluster** → clicking each filters the table to that facet only.
- Active tiles get a tone-colored border. Re-clicking an active tile clears back to all (equivalent to clicking Total Applications).
- Sidebar facet rail stays in place — both surfaces share state, so changes from a tile are reflected in the sidebar and vice versa.

### Notes

- Reconciling needed a dedicated `reconcilingOnly` flag because its count is OR-of-two (`sync==='Reconciling' || health==='Progressing'`) while the existing `syncFilters` / `healthFilters` are AND. Without it, clicking Reconciling on a fleet of Argo apps (which never emit `sync==='Reconciling'`, only `health==='Progressing'`) produced an empty table even when the count said `3`.
- All changes live in `packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx`, so Radar OSS and Radar Hub both pick up the upgrade.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## How has this been tested?

- [x] `make tsc` clean
- [x] `npm run test` in `packages/k8s-ui` — 412/412 pass
- [x] `go test ./...` green
- [x] Full `make build` succeeds
- [x] Tested locally against a remote cluster with a mix of Synced / OutOfSync / Healthy / Degraded / Progressing applications

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Related issues

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only filter wiring in GitOpsTableView with no API or auth changes; main risk is incorrect filter combinations, mitigated by shared clear/active helpers.
> 
> **Overview**
> GitOps **summary tiles** above the application table are now **clickable filter shortcuts** that stay in sync with the left filter rail. **Total Applications** clears all filters (including hub **destination** and the new reconciling mode); **Out of sync**, **Degraded**, **Suspended**, **Reconciling**, and **Cross-cluster** (when shown) apply a single facet. Active tiles get a tone-colored border; clicking an active tile clears filters like Total Applications.
> 
> A dedicated **`reconcilingOnly`** filter matches the summary count’s OR logic (`sync === 'Reconciling'` or `health === 'Progressing'`) so the Reconciling tile does not empty the table on Argo apps that only show **Progressing** health. Shared **`clearAllFilters`** and **`noOtherFiltersActive`** drive sidebar Clear, tile active state, and click handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4fe0cb82e604d6578e81bfbf109f1602892e16c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->