### PR TITLE
fix(k8s-ui): distinguish forbidden vs orphan in RoleBinding rules section

### DIFF
--- a/packages/k8s-ui/src/components/resources/renderers/RoleBindingRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/RoleBindingRenderer.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import { RoleBindingRenderer } from './RoleBindingRenderer'
+
+function shaped(message: string, status: number) {
+  return Object.assign(new Error(message), { status })
+}
+
+const binding = {
+  metadata: { name: 'rb-1', namespace: 'dev' },
+  roleRef: { kind: 'ClusterRole', name: 'view', apiGroup: 'rbac.authorization.k8s.io' },
+  subjects: [
+    { kind: 'ServiceAccount', name: 'alice', namespace: 'dev' },
+  ],
+}
+
+describe('RoleBindingRenderer rules section', () => {
+  it('renders rule rows when rules are present', () => {
+    const html = renderToString(
+      <RoleBindingRenderer
+        data={binding}
+        roleRules={[{ verbs: ['get', 'list'], resources: ['pods'], apiGroups: [''] }]}
+      />,
+    )
+    expect(html).toContain('Rules Granted')
+    expect(html).toContain('pods')
+  })
+
+  it('renders "no rules" when rules array is empty (loaded but role has none)', () => {
+    const html = renderToString(<RoleBindingRenderer data={binding} roleRules={[]} />)
+    expect(html).toContain('no rules')
+  })
+
+  it('renders the orphan-or-unavailable fallback when rules is null and no error', () => {
+    const html = renderToString(<RoleBindingRenderer data={binding} roleRules={null} />)
+    expect(html).toContain('Could not resolve referenced role')
+    expect(html).toContain('orphan binding')
+  })
+
+  it('renders the Access denied message when rules is null and the fetch was 403', () => {
+    const html = renderToString(
+      <RoleBindingRenderer
+        data={binding}
+        roleRules={null}
+        roleRulesError={shaped('forbidden', 403)}
+      />,
+    )
+    expect(html).toContain('Access denied reading referenced role')
+    expect(html).toContain('view')
+    expect(html).not.toContain('orphan binding')
+  })
+
+  it('falls back to the orphan-or-unavailable message for non-403 errors (404, 500, network)', () => {
+    const html = renderToString(
+      <RoleBindingRenderer
+        data={binding}
+        roleRules={null}
+        roleRulesError={shaped('not found', 404)}
+      />,
+    )
+    expect(html).toContain('Could not resolve referenced role')
+    expect(html).not.toContain('Access denied')
+  })
+})

--- a/packages/k8s-ui/src/components/resources/renderers/RoleBindingRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/RoleBindingRenderer.test.tsx
@@ -61,4 +61,16 @@ describe('RoleBindingRenderer rules section', () => {
     expect(html).toContain('Could not resolve referenced role')
     expect(html).not.toContain('Access denied')
   })
+
+  it('keeps showing cached rules when a refetch fails with 403 (stale data preserved)', () => {
+    const html = renderToString(
+      <RoleBindingRenderer
+        data={binding}
+        roleRules={[{ verbs: ['get'], resources: ['secrets'], apiGroups: [''] }]}
+        roleRulesError={shaped('forbidden', 403)}
+      />,
+    )
+    expect(html).toContain('secrets')
+    expect(html).not.toContain('Access denied')
+  })
 })

--- a/packages/k8s-ui/src/components/resources/renderers/RoleBindingRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/RoleBindingRenderer.tsx
@@ -2,6 +2,7 @@ import { Shield, Users, Eye } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ResourceLink, AlertBanner } from '../../ui/drawer-components'
 import type { ResourceRef, RBACPolicyRule } from '../../../types'
+import { isForbiddenError } from '../../../types/fetch-error'
 import {
   rbacVerbBadgeClass,
   rbacResourceBadgeClass,
@@ -15,9 +16,14 @@ interface RoleBindingRendererProps {
   onNavigate?: (ref: ResourceRef) => void
   /** Rules from the referenced Role/ClusterRole. Undefined means the host
    *  hasn't wired the fetch (inline rules preview is omitted). Null means
-   *  the fetch failed; the section shows a tactful note instead of silence. */
+   *  the fetch finished without a resource (orphan binding); the section
+   *  says so. */
   roleRules?: RBACPolicyRule[] | null
   roleRulesLoading?: boolean
+  /** Error from the role/clusterrole fetch. When present and shaped like
+   *  a FetchErrorShape (status + message), the rules section distinguishes
+   *  a 403 ("Access denied") from the orphan-or-unavailable fallback. */
+  roleRulesError?: unknown
 }
 
 // Wide groups whose membership effectively widens a binding beyond a named
@@ -57,7 +63,7 @@ function getSubjectKindBadgeClass(kind: string): string {
   }
 }
 
-export function RoleBindingRenderer({ data, onNavigate, roleRules, roleRulesLoading }: RoleBindingRendererProps) {
+export function RoleBindingRenderer({ data, onNavigate, roleRules, roleRulesLoading, roleRulesError }: RoleBindingRendererProps) {
   const roleRef = data.roleRef || {}
   const subjects: any[] = data.subjects || []
   const isClusterRoleBinding = data.kind === 'ClusterRoleBinding'
@@ -117,6 +123,7 @@ export function RoleBindingRenderer({ data, onNavigate, roleRules, roleRulesLoad
         <RulesPreviewSection
           rules={roleRules}
           loading={!!roleRulesLoading}
+          error={roleRulesError}
           roleName={roleRef.name}
         />
       )}
@@ -152,16 +159,24 @@ export function RoleBindingRenderer({ data, onNavigate, roleRules, roleRulesLoad
 function RulesPreviewSection({
   rules,
   loading,
+  error,
   roleName,
 }: {
   rules: RBACPolicyRule[] | null
   loading: boolean
+  error?: unknown
   roleName?: string
 }) {
+  const forbidden = isForbiddenError(error)
   return (
     <Section title="Rules Granted" icon={Eye} defaultExpanded={false}>
       {loading ? (
         <div className="text-sm text-theme-text-tertiary">Loading rules…</div>
+      ) : forbidden ? (
+        <div className="text-sm text-theme-text-tertiary">
+          Access denied reading referenced role
+          {roleName ? ` "${roleName}"` : ''}.
+        </div>
       ) : !rules ? (
         <div className="text-sm text-theme-text-tertiary">
           Could not resolve referenced role

--- a/packages/k8s-ui/src/components/resources/renderers/RoleBindingRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/RoleBindingRenderer.tsx
@@ -167,22 +167,23 @@ function RulesPreviewSection({
   error?: unknown
   roleName?: string
 }) {
-  const forbidden = isForbiddenError(error)
   return (
     <Section title="Rules Granted" icon={Eye} defaultExpanded={false}>
       {loading ? (
         <div className="text-sm text-theme-text-tertiary">Loading rules…</div>
-      ) : forbidden ? (
-        <div className="text-sm text-theme-text-tertiary">
-          Access denied reading referenced role
-          {roleName ? ` "${roleName}"` : ''}.
-        </div>
       ) : !rules ? (
-        <div className="text-sm text-theme-text-tertiary">
-          Could not resolve referenced role
-          {roleName ? ` "${roleName}"` : ''} — it may not exist (orphan binding)
-          or be unavailable.
-        </div>
+        isForbiddenError(error) ? (
+          <div className="text-sm text-theme-text-tertiary">
+            Access denied reading referenced role
+            {roleName ? ` "${roleName}"` : ''}.
+          </div>
+        ) : (
+          <div className="text-sm text-theme-text-tertiary">
+            Could not resolve referenced role
+            {roleName ? ` "${roleName}"` : ''} — it may not exist (orphan binding)
+            or be unavailable.
+          </div>
+        )
       ) : rules.length === 0 ? (
         <div className="text-sm text-theme-text-tertiary">
           The referenced role has no rules.

--- a/web/src/components/resources/renderers/RoleBindingRenderer.tsx
+++ b/web/src/components/resources/renderers/RoleBindingRenderer.tsx
@@ -21,10 +21,11 @@ export function RoleBindingRenderer({ data, onNavigate }: RoleBindingRendererPro
   const namespace = isClusterRole ? '' : (data?.metadata?.namespace ?? '')
   const name = roleRef.name ?? ''
 
-  const { data: role, isLoading } = useResource<any>(kind, namespace, name)
+  const { data: role, isLoading, error } = useResource<any>(kind, namespace, name)
   // `role` is undefined while loading, then the resource, then potentially
-  // null on 404. Pass [] for "loaded but no rules" so the base renderer's
-  // `rules === null` branch fires only on outright fetch failure (orphan).
+  // null on 404 / 403. Pass [] for "loaded but no rules" so the base
+  // renderer's `rules === null` branch fires only on outright fetch failure
+  // (orphan or forbidden); `roleRulesError` then disambiguates the two.
   const rules =
     isLoading
       ? undefined
@@ -38,6 +39,7 @@ export function RoleBindingRenderer({ data, onNavigate }: RoleBindingRendererPro
       onNavigate={onNavigate}
       roleRules={rules ?? null}
       roleRulesLoading={isLoading}
+      roleRulesError={error}
     />
   )
 }


### PR DESCRIPTION
## Summary

The base `RoleBindingRenderer`'s rules-preview section collapsed every fetch failure into a single line:

> "Could not resolve referenced role 'X' — it may not exist (orphan binding) or be unavailable."

A 403 on the referenced Role/ClusterRole therefore reads as "this binding is broken", when in reality the binding may be fine and the viewer just lacks RBAC visibility on the role itself. Operators making access-control decisions need to tell those two cases apart.

This PR adds an optional `roleRulesError` prop. When the error shapes as a 403, the section renders:

> "Access denied reading referenced role 'X'."

Non-403 errors keep the existing fallback wording — no regression on 404 / 500 / network.

## Architectural note

This is NOT the same fix shape as PR #805 / PR #816. The renderer doesn't have a drawer body to swap into `<FetchResult>`; it feeds `roleRules: rules[] | null` into a section that already had a three-way branch (loading / no-rules / rules). The 403 branch slots into the same shape, before the existing `!rules` fallthrough.

## Changes

- `packages/k8s-ui/src/components/resources/renderers/RoleBindingRenderer.tsx`
  - Add `roleRulesError?: unknown` to `RoleBindingRendererProps`.
  - Import `isForbiddenError` from the shared `types/fetch-error` module (added in PR #805).
  - In `RulesPreviewSection`, add the forbidden branch before the existing `!rules` branch.
- `web/src/components/resources/renderers/RoleBindingRenderer.tsx`
  - Destructure `error` from `useResource`, thread to the base.
- `packages/k8s-ui/src/components/resources/renderers/RoleBindingRenderer.test.tsx` (new)
  - 5 cases: rules present, empty rules ("no rules"), null + no error (orphan-or-unavailable), null + 403 (Access denied), null + 404 (still orphan-or-unavailable; non-403 stays generic).

## Depends on

This PR targets `radar-rbac-cluster-scoped-errors` (the #805 branch) as its base because it imports `isForbiddenError` from the shared fetch-error module added in #805. Retarget to `main` after #805 merges; the stacked commits drop out.

## Test plan

- [x] `make tsc` — clean
- [x] `cd packages/k8s-ui && npm test` — 435/435 (5 new RoleBindingRenderer tests)
- [x] Visual against real backend + targeted mock middleware:
  - BEFORE (stashed fix): RoleBinding `argocd/argocd-application-controller`, role fetch mocked to 403 → Rules Granted section shows "Could not resolve referenced role … — it may not exist (orphan binding) or be unavailable."
  - AFTER: same scenario → shows "Access denied reading referenced role 'argocd-application-controller'."
- [x] Non-403 errors preserve the existing wording (covered by the 404 unit test).

Screenshots:
- `2026-05-28_130001_pr3-before-403.png`
- `2026-05-28_130000_pr3-after-403.png`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only RBAC messaging in the k8s-ui renderer; no auth or API behavior changes.
> 
> **Overview**
> RoleBinding **Rules Granted** preview no longer treats every failed role fetch like a broken binding. When the referenced Role/ClusterRole fetch returns **403**, the UI shows **Access denied reading referenced role** instead of the orphan/unavailable wording; **404**, **500**, and other errors keep the existing message.
> 
> The shared `RoleBindingRenderer` gains an optional **`roleRulesError`** prop and branches in **`RulesPreviewSection`** via **`isForbiddenError`**. The web wrapper passes **`useResource`**’s **`error`** through to the base renderer. New Vitest coverage exercises rules present, empty rules, null without error, 403, non-403 errors, and **cached rules still shown** when a refetch fails with 403.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2a6970e8853ffdcb9cce9ac2ccd470cf91c1bb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->