### PR TITLE
fix(gitops): remove duplicate clearAllFilters in GitOpsTableView

### DIFF
--- a/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
@@ -227,22 +227,6 @@ export function GitOpsTableView({
   const hasGlobalNamespaceFilter = !!onClearNamespaces && (globalNamespaces?.length ?? 0) > 0
   const hasAnyFilter = hasLocalFilters || hasGlobalNamespaceFilter
 
-  const clearLocalFilters = () => {
-    setSearch('')
-    setSyncFilters(new Set())
-    setHealthFilters(new Set())
-    setProjectFilters(new Set())
-    setNamespaceFilters(new Set())
-    setLabelFilters(new Set())
-    setAutomationFilter('all')
-    setLifecycleFilter('all')
-  }
-
-  const clearAllFilters = () => {
-    clearLocalFilters()
-    onClearNamespaces?.()
-  }
-
   // Optional '/' keyboard shortcut to focus search. Avoided as a default to
   // not collide with other surfaces' keyboard maps; OSS opts in via prop.
   useEffect(() => {
@@ -343,8 +327,9 @@ export function GitOpsTableView({
     setAutomationFilter('all')
     setLifecycleFilter('all')
     setReconcilingOnly(false)
+    onClearNamespaces?.()
     onDestinationFilterChange?.('all')
-  }, [onDestinationFilterChange])
+  }, [onClearNamespaces, onDestinationFilterChange])
 
   const noOtherFiltersActive = useCallback(
     (


### PR DESCRIPTION
## What
`GitOpsTableView.tsx` declared `const clearAllFilters` **twice** in the same component scope (TS2451 "Cannot redeclare block-scoped variable"):
- the plain version from #802 (`clearLocalFilters()` + `onClearNamespaces?.()`)
- the comprehensive `useCallback` from #812 ("clickable filter shortcuts"), which inlined the resets + reconciling + destination but **didn't remove #802's version**.

## Why it matters
`@skyhook-io/k8s-ui` ships **source**, so this type error rode into the published **1.7.4** and breaks any strict `tsc -b` consumer (e.g. `radar-hub-web` / its Vercel build). radar's own esbuild/vite build tolerates a duplicate `const`, which is how it slipped through CI.

## Fix
Keep #812's `useCallback` (the canonical one the post-#812 call sites use), **fold in the dropped `onClearNamespaces?.()`** global-namespace reset that only the old version had (so the global namespace filter is still cleared), and remove the now-orphaned `clearLocalFilters` helper (its 8 resets are already inlined). Net: one `clearAllFilters`, same behavior as both combined.

## Follow-up
Needs a **k8s-ui 1.7.5** republish so consumers (radar-hub-web #69) can pin a fixed version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor in GitOps filter UI only; no auth, data, or API changes, and behavior is intended to match the two previously overlapping implementations combined.
> 
> **Overview**
> Fixes a **duplicate `clearAllFilters` declaration** in `GitOpsTableView` that broke strict TypeScript builds (TS2451) in published `@skyhook-io/k8s-ui` source.
> 
> The PR **removes** the older `clearLocalFilters` helper and its separate `clearAllFilters` wrapper, and keeps the single **`useCallback`-based `clearAllFilters`** used by summary tiles, the sidebar, and empty states. That callback now also calls **`onClearNamespaces?.()`** so “Clear filters” still drops the host’s global namespace pick, and its dependency array includes **`onClearNamespaces`** alongside **`onDestinationFilterChange`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2821561e9811d77a852ab7c73f154d459bdab42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->