### PR TITLE
fix(mcp): show all tools in setup dialog + guard against drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,7 +198,7 @@ Pod **Permissions** is the differentiator — frames the SA's grant as blast rad
 
 ### MCP Server
 
-Stateless HTTP at `/mcp` (JSON-RPC). Read tools use `readOnlyHint`, write tools use `destructiveHint: true`. Respects cluster RBAC (impersonates via `DynamicClientFromContext` for write/exec/logs). Enabled by default; `--no-mcp` to disable. Tool catalogue + design rationale lives in `internal/mcp/tools.go` + [docs/mcp.md](docs/mcp.md) — don't restate it here.
+Stateless HTTP at `/mcp` (JSON-RPC). Read tools use `readOnlyHint`, write tools use `destructiveHint: true`. Respects cluster RBAC (impersonates via `DynamicClientFromContext` for write/exec/logs). Enabled by default; `--no-mcp` to disable. Tool catalogue + design rationale lives in `internal/mcp/tools.go` + [docs/mcp.md](docs/mcp.md) — don't restate it here. **When adding/removing a tool in `registerTools`, also update the user-facing setup dialog catalog `web/src/components/home/mcpToolCatalog.ts`** — `TestSetupDialogCoversAllTools` fails CI if the two diverge.
 
 ### Error Handling (Backend)
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -30,6 +30,10 @@ import (
 	topology "github.com/skyhook-io/radar/pkg/topology"
 )
 
+// registerTools registers every MCP tool exposed at /mcp. The user-facing
+// setup dialog catalog (web/src/components/home/mcpToolCatalog.ts) must list
+// the same set — TestSetupDialogCoversAllTools fails CI when they diverge, so
+// add/remove the catalog entry alongside any change here.
 func registerTools(server *mcp.Server) {
 	boolPtr := func(b bool) *bool { return &b }
 	// All radar tools operate against the connected cluster (closed world),

--- a/internal/mcp/tools_catalog_test.go
+++ b/internal/mcp/tools_catalog_test.go
@@ -2,10 +2,70 @@ package mcp
 
 import (
 	"context"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
 	"testing"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+// setupDialogCatalogPath is the human-facing tool catalog rendered by the MCP
+// setup dialog. It must list exactly the tools registered here.
+const setupDialogCatalogPath = "../../web/src/components/home/mcpToolCatalog.ts"
+
+// toolNameInCatalog matches the `name: 'tool_name'` entries in the catalog.
+// Tool names use the `name:` key; parameters use `arg:`, so this only catches
+// tools. The TS interface declarations (`name: string`) have no quote after
+// the colon and don't match.
+var toolNameInCatalog = regexp.MustCompile(`name:\s*'([a-z][a-z0-9_]*)'`)
+
+// TestSetupDialogCoversAllTools fails when the registered MCP tools and the
+// setup-dialog catalog drift apart — a tool added to registerTools without a
+// catalog entry (or vice versa). Keep both in sync; users discover tools
+// through that dialog.
+func TestSetupDialogCoversAllTools(t *testing.T) {
+	registered := map[string]bool{}
+	for _, tool := range listRegisteredTools(t) {
+		registered[tool.Name] = true
+	}
+
+	raw, err := os.ReadFile(setupDialogCatalogPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", setupDialogCatalogPath, err)
+	}
+	catalog := map[string]bool{}
+	for _, m := range toolNameInCatalog.FindAllStringSubmatch(string(raw), -1) {
+		catalog[m[1]] = true
+	}
+	if len(catalog) == 0 {
+		t.Fatalf("no tool names parsed from %s — did the catalog format change?", setupDialogCatalogPath)
+	}
+
+	var missingFromDialog, staleInDialog []string
+	for name := range registered {
+		if !catalog[name] {
+			missingFromDialog = append(missingFromDialog, name)
+		}
+	}
+	for name := range catalog {
+		if !registered[name] {
+			staleInDialog = append(staleInDialog, name)
+		}
+	}
+	sort.Strings(missingFromDialog)
+	sort.Strings(staleInDialog)
+
+	if len(missingFromDialog) > 0 {
+		t.Errorf("MCP tools registered but missing from the setup dialog catalog (%s) — add them: %s",
+			setupDialogCatalogPath, strings.Join(missingFromDialog, ", "))
+	}
+	if len(staleInDialog) > 0 {
+		t.Errorf("setup dialog catalog (%s) lists tools that are not registered — remove them: %s",
+			setupDialogCatalogPath, strings.Join(staleInDialog, ", "))
+	}
+}
 
 func TestRegisteredToolAnnotations(t *testing.T) {
 	tools := listRegisteredTools(t)

--- a/internal/mcp/tools_catalog_test.go
+++ b/internal/mcp/tools_catalog_test.go
@@ -16,10 +16,12 @@ import (
 const setupDialogCatalogPath = "../../web/src/components/home/mcpToolCatalog.ts"
 
 // toolNameInCatalog matches the `name: 'tool_name'` entries in the catalog.
-// Tool names use the `name:` key; parameters use `arg:`, so this only catches
-// tools. The TS interface declarations (`name: string`) have no quote after
-// the colon and don't match.
-var toolNameInCatalog = regexp.MustCompile(`name:\s*'([a-z][a-z0-9_]*)'`)
+// Anchored to line start (catalog entries always sit at line-start
+// indentation) so a `name: '...'` substring appearing mid-line inside a
+// description string can't false-match. Tool names use the `name:` key;
+// parameters use `arg:`; the TS interface decl `name: string` has no quote
+// after the colon. None of those match.
+var toolNameInCatalog = regexp.MustCompile(`(?m)^\s*name:\s*'([a-z][a-z0-9_]*)'`)
 
 // TestSetupDialogCoversAllTools fails when the registered MCP tools and the
 // setup-dialog catalog drift apart — a tool added to registerTools without a

--- a/web/src/components/home/MCPSetupDialog.tsx
+++ b/web/src/components/home/MCPSetupDialog.tsx
@@ -1,6 +1,7 @@
 import { useRef, useEffect, useState, useCallback } from 'react'
 import { X, Copy, Check, Radio, Terminal, MessageSquare, Code2, ChevronRight, Pin } from 'lucide-react'
 import { apiUrl, getAuthHeaders, getCredentialsMode } from '../../api/config'
+import { MCP_TOOL_CATALOG } from './mcpToolCatalog'
 
 interface MCPSetupDialogProps {
   open: boolean
@@ -208,8 +209,9 @@ export function MCPSetupDialog({ open, onClose, mcpUrl }: MCPSetupDialogProps) {
               verbose YAML output.
             </p>
             <p className="text-sm text-theme-text-secondary leading-relaxed">
-              Read tools are strictly read-only. Write tools (restart, scale, sync) are
-              non-destructive and annotated so your AI client can distinguish them.
+              Read tools are strictly read-only. Write tools (restart, scale, sync, apply,
+              node drain) are annotated as destructive so your AI client can flag them and
+              prompt before running.
             </p>
           </div>
 
@@ -296,95 +298,27 @@ export function MCPSetupDialog({ open, onClose, mcpUrl }: MCPSetupDialogProps) {
 
           {/* Available tools */}
           <div className="space-y-2">
-            <h4 className="text-sm font-semibold text-theme-text-primary">Tools</h4>
+            <div className="flex items-baseline justify-between">
+              <h4 className="text-sm font-semibold text-theme-text-primary">Tools</h4>
+              <span className="text-[11px] text-theme-text-tertiary">{MCP_TOOL_CATALOG.length} tools</span>
+            </div>
             <div className="grid grid-cols-1 gap-1.5">
-              {[
-                { name: 'get_dashboard', desc: 'Get cluster health overview including resource counts, problems (failing pods, unhealthy deployments), recent warning events, and Helm release status. Start here to understand cluster state before drilling into specific resources.', params: [
-                  { name: 'namespace', required: false, desc: 'filter to a specific namespace' },
-                ]},
-                { name: 'list_resources', desc: 'List Kubernetes resources of a given kind with minified summaries. Supports all built-in kinds (pods, deployments, services, etc.) and CRDs. Use to discover what\'s running before inspecting individual resources.', params: [
-                  { name: 'kind', required: true, desc: 'resource kind, e.g. pods, deployments, services' },
-                  { name: 'namespace', required: false, desc: 'filter to a specific namespace' },
-                ]},
-                { name: 'get_resource', desc: 'Get a single Kubernetes resource: minified spec/status/metadata plus default-on resourceContext (managedBy, exposes, selectedBy, uses, runsOn, issue/audit rollups). Optionally include heavier sidecars (events, metrics, logs).', params: [
-                  { name: 'kind', required: true, desc: 'resource kind, e.g. pod, deployment, service' },
-                  { name: 'namespace', required: false, desc: 'omit for cluster-scoped kinds (Node, ClusterRole, IngressClass, etc.)' },
-                  { name: 'name', required: true, desc: 'resource name' },
-                  { name: 'group', required: false, desc: 'API group when the kind is ambiguous (e.g. serving.knative.dev for Knative Service vs core Service)' },
-                  { name: 'include', required: false, desc: 'events, metrics, logs' },
-                  { name: 'context', required: false, desc: 'resourceContext tier: basic (default) or none (bare minified)' },
-                ]},
-                { name: 'get_topology', desc: 'Get the topology graph showing relationships between Kubernetes resources. Returns nodes and edges representing Deployments, Services, Ingresses, Pods, etc. Use \'traffic\' view for network flow or \'resources\' view for ownership hierarchy. Use \'summary\' format for LLM-friendly text descriptions.', params: [
-                  { name: 'namespace', required: false, desc: 'filter to a specific namespace' },
-                  { name: 'view', required: false, desc: 'traffic or resources' },
-                  { name: 'format', required: false, desc: 'graph (default) or summary (text)' },
-                ]},
-                { name: 'get_events', desc: 'Get recent Kubernetes warning events, deduplicated and sorted by recency. Useful for diagnosing issues — shows event reason, message, and occurrence count. Filter by resource kind/name to scope to a specific resource.', params: [
-                  { name: 'namespace', required: false, desc: 'filter to a specific namespace' },
-                  { name: 'limit', required: false, desc: 'max events to return (default 20)' },
-                  { name: 'kind', required: false, desc: 'filter to events for this resource kind' },
-                  { name: 'name', required: false, desc: 'filter to events for this resource name' },
-                ]},
-                { name: 'get_pod_logs', desc: 'Get filtered log lines from a pod, prioritizing errors and warnings. Returns diagnostically relevant lines (errors, panics, stack traces) or falls back to the last 20 lines if no error patterns match.', params: [
-                  { name: 'namespace', required: true, desc: 'pod namespace' },
-                  { name: 'name', required: true, desc: 'pod name' },
-                  { name: 'container', required: false, desc: 'container name (defaults to first)' },
-                  { name: 'tail_lines', required: false, desc: 'lines from end (default 200)' },
-                ]},
-                { name: 'list_namespaces', desc: 'List all Kubernetes namespaces with their status. Use to discover available namespaces before filtering other queries.', params: [] },
-                { name: 'get_changes', desc: 'Get recent resource changes (creates, updates, deletes) from the cluster timeline. Use to investigate what changed before an incident. Filter by namespace, resource kind, or specific resource name.', params: [
-                  { name: 'namespace', required: false, desc: 'filter to a specific namespace' },
-                  { name: 'kind', required: false, desc: 'filter to a resource kind (e.g. Deployment)' },
-                  { name: 'name', required: false, desc: 'filter to a specific resource name' },
-                  { name: 'since', required: false, desc: 'lookback duration, e.g. 1h, 30m (default 1h)' },
-                  { name: 'limit', required: false, desc: 'max changes to return (default 20, max 50)' },
-                ]},
-                { name: 'list_helm_releases', desc: 'List all Helm releases in the cluster with their status and health. Returns release name, namespace, chart, version, status, and resource health.', params: [
-                  { name: 'namespace', required: false, desc: 'filter to a specific namespace' },
-                ]},
-                { name: 'get_helm_release', desc: 'Get detailed information about a specific Helm release including owned resources and their status. Optionally include values, revision history, or manifest diff between revisions.', params: [
-                  { name: 'namespace', required: true, desc: 'release namespace' },
-                  { name: 'name', required: true, desc: 'release name' },
-                  { name: 'include', required: false, desc: 'values, history, diff' },
-                  { name: 'diff_revision_1', required: false, desc: 'first revision for diff' },
-                  { name: 'diff_revision_2', required: false, desc: 'second revision for diff (defaults to current)' },
-                ]},
-                { name: 'get_workload_logs', desc: 'Get aggregated, AI-filtered logs from all pods of a workload (Deployment, StatefulSet, or DaemonSet). Logs are collected from all matching pods, filtered for errors/warnings, and deduplicated.', params: [
-                  { name: 'kind', required: true, desc: 'deployment, statefulset, or daemonset' },
-                  { name: 'namespace', required: true, desc: 'workload namespace' },
-                  { name: 'name', required: true, desc: 'workload name' },
-                  { name: 'container', required: false, desc: 'specific container name' },
-                  { name: 'tail_lines', required: false, desc: 'lines per pod (default 100)' },
-                ]},
-                { name: 'manage_workload', desc: 'Perform operations on a workload. \'restart\' triggers a rolling restart, \'scale\' changes the replica count, \'rollback\' reverts to a previous revision.', params: [
-                  { name: 'action', required: true, desc: 'restart, scale, or rollback' },
-                  { name: 'kind', required: true, desc: 'deployment, statefulset, or daemonset' },
-                  { name: 'namespace', required: true, desc: 'workload namespace' },
-                  { name: 'name', required: true, desc: 'workload name' },
-                  { name: 'replicas', required: false, desc: 'target replica count (for scale)' },
-                  { name: 'revision', required: false, desc: 'target revision (for rollback)' },
-                ]},
-                { name: 'manage_cronjob', desc: 'Perform operations on a CronJob. \'trigger\' creates a manual Job run, \'suspend\' pauses the schedule, \'resume\' re-enables it.', params: [
-                  { name: 'action', required: true, desc: 'trigger, suspend, or resume' },
-                  { name: 'namespace', required: true, desc: 'cronjob namespace' },
-                  { name: 'name', required: true, desc: 'cronjob name' },
-                ]},
-                { name: 'manage_gitops', desc: 'Perform operations on GitOps resources. ArgoCD: sync, suspend, resume. FluxCD: reconcile, suspend, resume.', params: [
-                  { name: 'action', required: true, desc: 'sync/reconcile, suspend, or resume' },
-                  { name: 'tool', required: true, desc: 'argocd or fluxcd' },
-                  { name: 'namespace', required: true, desc: 'resource namespace' },
-                  { name: 'name', required: true, desc: 'resource name' },
-                  { name: 'kind', required: false, desc: 'FluxCD resource kind (e.g. kustomization, helmrelease)' },
-                ]},
-              ].map((tool) => (
+              {MCP_TOOL_CATALOG.map((tool) => (
                 <div key={tool.name} className="card-inner space-y-1.5">
-                  <code className="text-[11px] font-mono text-purple-400">{tool.name}</code>
+                  <div className="flex items-center gap-2">
+                    <code className="text-[11px] font-mono text-purple-400">{tool.name}</code>
+                    {tool.write && (
+                      <span className="badge-sm bg-amber-500/10 text-amber-600 dark:text-amber-400" title="Write tool — annotated as destructive">
+                        write
+                      </span>
+                    )}
+                  </div>
                   <p className="text-[11px] text-theme-text-tertiary leading-relaxed">{tool.desc}</p>
                   {tool.params.length > 0 && (
                     <div className="flex flex-wrap gap-1.5 pt-0.5">
                       {tool.params.map((p) => (
-                        <span key={p.name} className="badge-sm font-mono bg-theme-elevated text-theme-text-secondary" title={p.desc}>
-                          <span className="text-theme-text-secondary">{p.name}</span>
+                        <span key={p.arg} className="badge-sm font-mono bg-theme-elevated text-theme-text-secondary" title={p.desc}>
+                          <span className="text-theme-text-secondary">{p.arg}</span>
                           {p.required && <span className="text-red-400">*</span>}
                         </span>
                       ))}

--- a/web/src/components/home/mcpToolCatalog.ts
+++ b/web/src/components/home/mcpToolCatalog.ts
@@ -1,0 +1,276 @@
+// Human-facing catalog for the MCP setup dialog (MCPSetupDialog.tsx).
+//
+// Source of truth for the *set* of tools is the backend registration in
+// internal/mcp/tools.go. This list must stay in sync with it — the Go test
+// TestSetupDialogCoversAllTools (internal/mcp/tools_catalog_test.go) parses
+// this file and fails CI if the tool names here don't exactly match the
+// registered tools. When you add or remove an MCP tool there, update this
+// catalog too.
+//
+// Descriptions here are intentionally shorter and more human-facing than the
+// LLM-oriented routing descriptions in tools.go — different audience, so they
+// are not shared verbatim.
+
+export interface MCPToolParam {
+  arg: string
+  required?: boolean
+  desc: string
+}
+
+export interface MCPToolInfo {
+  name: string
+  write?: boolean
+  desc: string
+  params: MCPToolParam[]
+}
+
+export const MCP_TOOL_CATALOG: MCPToolInfo[] = [
+  {
+    name: 'get_dashboard',
+    desc: 'Cluster or namespace health overview: resource counts, failing pods, unhealthy workloads, recent warning events, and Helm status. Start here before drilling into specific resources.',
+    params: [{ arg: 'namespace', desc: 'filter to a specific namespace' }],
+  },
+  {
+    name: 'top_resources',
+    desc: 'Live CPU/memory ranking (like `kubectl top`) joined with Kubernetes context — pod status, restarts, owner workload, requests, and limits. Ranks pods, workloads, or nodes.',
+    params: [
+      { arg: 'kind', desc: 'pods (default), workloads, or nodes' },
+      { arg: 'namespace', desc: 'filter pods/workloads to a namespace' },
+      { arg: 'sort', desc: 'cpu (default) or memory' },
+      { arg: 'limit', desc: 'max rows (default 20, max 100)' },
+    ],
+  },
+  {
+    name: 'list_resources',
+    desc: 'List Kubernetes resources of a given kind with compact summaries plus per-row health, managedBy, and issue counts. Supports built-in kinds and CRDs.',
+    params: [
+      { arg: 'kind', required: true, desc: 'resource kind, e.g. pods, deployments, services' },
+      { arg: 'group', desc: 'API group when the kind is ambiguous (e.g. serving.knative.dev)' },
+      { arg: 'namespace', desc: 'filter to a specific namespace' },
+      { arg: 'context', desc: 'per-row context: default (summaryContext) or none' },
+    ],
+  },
+  {
+    name: 'get_resource',
+    desc: 'A single resource: minified spec/status/metadata plus resourceContext (relationships, refs, issue/audit/policy rollups). Optionally include heavier event/metrics sidecars.',
+    params: [
+      { arg: 'kind', required: true, desc: 'resource kind, e.g. pod, deployment, service' },
+      { arg: 'name', required: true, desc: 'resource name' },
+      { arg: 'namespace', desc: 'omit for cluster-scoped kinds (Node, ClusterRole, IngressClass, etc.)' },
+      { arg: 'group', desc: 'API group when the kind is ambiguous (e.g. serving.knative.dev for Knative Service vs core Service)' },
+      { arg: 'include', desc: 'events, metrics' },
+      { arg: 'context', desc: 'resourceContext tier: basic (default) or none' },
+    ],
+  },
+  {
+    name: 'get_topology',
+    desc: 'Topology graph of relationships between resources — Services, workloads, Pods, Ingresses, owners. Use traffic view for network flow or resources view for ownership hierarchy.',
+    params: [
+      { arg: 'namespace', desc: 'filter to a specific namespace' },
+      { arg: 'view', desc: 'traffic or resources' },
+      { arg: 'format', desc: 'graph (default) or summary (text)' },
+    ],
+  },
+  {
+    name: 'get_neighborhood',
+    desc: 'BFS-expanded topology around one resource — its upstream/downstream Services, workloads, Pods, refs, and owners. Cheaper and more focused than full topology once you have a suspect.',
+    params: [
+      { arg: 'kind', required: true, desc: 'resource kind, e.g. pod, deployment, service, application' },
+      { arg: 'name', required: true, desc: 'resource name' },
+      { arg: 'namespace', desc: 'resource namespace; omit for cluster-scoped kinds' },
+      { arg: 'group', desc: 'API group to disambiguate colliding kinds' },
+      { arg: 'profile', desc: 'auto (default) or all (every edge type, heavier)' },
+      { arg: 'hops', desc: 'BFS depth (default 1, max 2)' },
+      { arg: 'max_nodes', desc: 'node budget (default 25)' },
+    ],
+  },
+  {
+    name: 'get_events',
+    desc: 'Recent Kubernetes warning events, deduplicated and sorted by recency. Shows reason, message, and occurrence count. Filter to a specific resource by kind/name.',
+    params: [
+      { arg: 'namespace', desc: 'filter to a specific namespace' },
+      { arg: 'limit', desc: 'max events (default 20, max 100)' },
+      { arg: 'kind', desc: 'filter to events for this resource kind' },
+      { arg: 'name', desc: 'filter to events for this resource name' },
+    ],
+  },
+  {
+    name: 'get_pod_logs',
+    desc: 'Filtered log lines from a pod, prioritizing errors and warnings, falling back to recent tail lines. Optional grep, since, and previous-container logs.',
+    params: [
+      { arg: 'namespace', required: true, desc: 'pod namespace' },
+      { arg: 'name', required: true, desc: 'pod name' },
+      { arg: 'container', desc: 'container name (defaults to first)' },
+      { arg: 'tail_lines', desc: 'lines from end (default 200)' },
+      { arg: 'grep', desc: 'regex to filter lines, like kubectl logs | grep' },
+      { arg: 'since', desc: 'only logs newer than this duration (e.g. 30s, 10m, 1h)' },
+      { arg: 'previous', desc: 'logs from the previous terminated container (CrashLoopBackOff)' },
+    ],
+  },
+  {
+    name: 'diagnose',
+    desc: 'One-call workload root-cause bundle: spec + resourceContext + current AND previous logs across all pods + warning events + startup-blocker analysis. For Pod/Deployment/StatefulSet/DaemonSet.',
+    params: [
+      { arg: 'kind', required: true, desc: 'pod, deployment, statefulset, or daemonset' },
+      { arg: 'namespace', required: true, desc: 'workload namespace' },
+      { arg: 'name', required: true, desc: 'resource name' },
+      { arg: 'container', desc: 'specific container (defaults to all)' },
+      { arg: 'tail_lines', desc: 'lines per pod/stream (default 100)' },
+      { arg: 'since', desc: 'only logs newer than this duration' },
+    ],
+  },
+  {
+    name: 'list_namespaces',
+    desc: 'List all Kubernetes namespaces with their status. Use to discover available namespaces before filtering other queries.',
+    params: [],
+  },
+  {
+    name: 'get_changes',
+    desc: 'Recent resource creates, updates, and deletes from the cluster timeline. Use to investigate what changed before an incident.',
+    params: [
+      { arg: 'namespace', desc: 'filter to a specific namespace' },
+      { arg: 'kind', desc: 'filter to a resource kind (e.g. Deployment)' },
+      { arg: 'name', desc: 'filter to a specific resource name' },
+      { arg: 'since', desc: 'lookback duration, e.g. 1h, 30m (default 1h)' },
+      { arg: 'limit', desc: 'max changes (default 20, max 50)' },
+    ],
+  },
+  {
+    name: 'get_cluster_audit',
+    desc: 'Best-practice and security posture findings — Security, Reliability, Efficiency — each with remediation guidance. Static config posture, independent of live operational health.',
+    params: [
+      { arg: 'namespace', desc: 'filter to a specific namespace' },
+      { arg: 'category', desc: 'Security, Reliability, or Efficiency' },
+      { arg: 'severity', desc: 'danger or warning' },
+      { arg: 'limit', desc: 'max findings (default 30, max 100)' },
+    ],
+  },
+  {
+    name: 'list_helm_releases',
+    desc: 'All Helm releases in the cluster with status and resource health — name, namespace, chart, version.',
+    params: [{ arg: 'namespace', desc: 'filter to a specific namespace' }],
+  },
+  {
+    name: 'get_helm_release',
+    desc: 'Detailed Helm release info with owned resources and their status. Optionally include values, revision history, or a manifest diff between revisions.',
+    params: [
+      { arg: 'namespace', required: true, desc: 'release namespace' },
+      { arg: 'name', required: true, desc: 'release name' },
+      { arg: 'include', desc: 'values, history, diff' },
+      { arg: 'diff_revision_1', desc: 'first revision for diff' },
+      { arg: 'diff_revision_2', desc: 'second revision for diff (defaults to current)' },
+    ],
+  },
+  {
+    name: 'list_packages',
+    desc: 'Unified "what\'s installed" view across Helm releases, workload labels, CRD registrations, and GitOps declarations (Argo + Flux), with sources, versions, and health.',
+    params: [
+      { arg: 'namespace', desc: 'filter to a specific namespace' },
+      { arg: 'source', desc: 'H (Helm), L (labels), C (CRDs), A (Argo), F (Flux)' },
+      { arg: 'chart', desc: 'case-insensitive chart-name substring' },
+    ],
+  },
+  {
+    name: 'issues',
+    desc: 'Ranked list of what is broken right now — failing workloads, dangling references, scheduling blockers, and false CRD conditions. Live operational state (distinct from get_cluster_audit posture).',
+    params: [
+      { arg: 'namespace', desc: 'filter to one namespace' },
+      { arg: 'severity', desc: 'comma-separated: critical, warning' },
+      { arg: 'kind', desc: 'comma-separated kind filter' },
+      { arg: 'limit', desc: 'max issues (default 200, max 1000)' },
+      { arg: 'filter', desc: 'optional CEL boolean expression' },
+    ],
+  },
+  {
+    name: 'search',
+    desc: 'Find resources by content/term match — config keys, env refs, images, label values, ConfigMap data, CRD fields, status messages. Secret values are never indexed.',
+    params: [
+      { arg: 'query', required: true, desc: 'tokens AND\'d; modifiers kind:, ns:, label:, image:' },
+      { arg: 'limit', desc: 'max hits (default 50, max 500)' },
+      { arg: 'include', desc: 'summary (default), raw, or none' },
+      { arg: 'filter', desc: 'optional CEL boolean expression' },
+      { arg: 'context', desc: 'per-hit context: default (summaryContext) or none' },
+    ],
+  },
+  {
+    name: 'get_subject_permissions',
+    desc: 'Effective RBAC for a ServiceAccount, User, or Group: the bindings that grant access, a flattened rule list, and (for SAs) the Pods running as it. Answers "what\'s the blast radius if compromised?".',
+    params: [
+      { arg: 'kind', required: true, desc: 'ServiceAccount, User, or Group' },
+      { arg: 'name', required: true, desc: 'subject name' },
+      { arg: 'namespace', desc: 'required for ServiceAccount; omit for User/Group' },
+    ],
+  },
+  {
+    name: 'get_workload_logs',
+    desc: 'Aggregated, filtered logs across all pods of a workload (Deployment, StatefulSet, or DaemonSet) — collected concurrently, filtered for errors/warnings, and deduplicated.',
+    params: [
+      { arg: 'kind', desc: 'deployment (default), statefulset, or daemonset' },
+      { arg: 'namespace', required: true, desc: 'workload namespace' },
+      { arg: 'name', required: true, desc: 'workload name' },
+      { arg: 'container', desc: 'specific container (defaults to all)' },
+      { arg: 'tail_lines', desc: 'lines per pod (default 100)' },
+      { arg: 'grep', desc: 'regex to filter lines, like kubectl logs | grep' },
+      { arg: 'since', desc: 'only logs newer than this duration' },
+      { arg: 'previous', desc: 'logs from the previous terminated container' },
+    ],
+  },
+  {
+    name: 'manage_workload',
+    write: true,
+    desc: 'Operate on a workload: restart triggers a rolling restart, scale changes the replica count, rollback reverts to a previous revision.',
+    params: [
+      { arg: 'action', required: true, desc: 'restart, scale, or rollback' },
+      { arg: 'kind', required: true, desc: 'deployment, statefulset, or daemonset' },
+      { arg: 'namespace', required: true, desc: 'workload namespace' },
+      { arg: 'name', required: true, desc: 'workload name' },
+      { arg: 'replicas', desc: 'target replica count (for scale)' },
+      { arg: 'revision', desc: 'target revision (for rollback)' },
+    ],
+  },
+  {
+    name: 'manage_cronjob',
+    write: true,
+    desc: 'Operate on a CronJob: trigger creates a manual Job run, suspend pauses the schedule, resume re-enables it.',
+    params: [
+      { arg: 'action', required: true, desc: 'trigger, suspend, or resume' },
+      { arg: 'namespace', required: true, desc: 'cronjob namespace' },
+      { arg: 'name', required: true, desc: 'cronjob name' },
+    ],
+  },
+  {
+    name: 'manage_gitops',
+    write: true,
+    desc: 'Operate on GitOps resources. ArgoCD: sync, refresh, terminate, rollback, suspend, resume. FluxCD: reconcile, sync-with-source, suspend, resume.',
+    params: [
+      { arg: 'action', required: true, desc: 'sync/reconcile, refresh, terminate, rollback, suspend, or resume' },
+      { arg: 'tool', required: true, desc: 'argocd or fluxcd' },
+      { arg: 'namespace', required: true, desc: 'resource namespace' },
+      { arg: 'name', required: true, desc: 'resource name' },
+      { arg: 'kind', desc: 'FluxCD resource kind (e.g. kustomization, helmrelease)' },
+    ],
+  },
+  {
+    name: 'apply_resource',
+    write: true,
+    desc: 'Create or update a resource from YAML. apply mode is a server-side apply with Force=true (can take field ownership from Helm/Flux); create mode fails if it exists. Multi-document YAML supported.',
+    params: [
+      { arg: 'yaml', required: true, desc: 'YAML manifest (multi-document with --- supported)' },
+      { arg: 'mode', desc: 'apply (default) or create' },
+      { arg: 'dry_run', desc: 'validate without persisting' },
+      { arg: 'namespace', desc: 'override namespace for the resource' },
+    ],
+  },
+  {
+    name: 'manage_node',
+    write: true,
+    desc: 'Operate on a node: cordon marks it unschedulable, uncordon reverses that, drain cordons then evicts all non-DaemonSet pods.',
+    params: [
+      { arg: 'action', required: true, desc: 'cordon, uncordon, or drain' },
+      { arg: 'name', required: true, desc: 'node name' },
+      { arg: 'delete_empty_dir_data', desc: 'evict pods with emptyDir volumes (default true)' },
+      { arg: 'force', desc: 'evict pods not managed by a controller (default false)' },
+      { arg: 'timeout', desc: 'drain timeout in seconds (default 60)' },
+    ],
+  },
+]


### PR DESCRIPTION
## Summary

The MCP setup dialog (Home → "MCP Server Live") hardcoded its tool list inline in JSX, while tools are registered in Go (`internal/mcp/tools.go`). Nothing linked the two, so 10 tools added over time had silently drifted out — the dialog advertised **14 of 24** tools.

- **Extract** the catalog into a single source of truth, `web/src/components/home/mcpToolCatalog.ts`, and render the dialog from it (drops ~85 lines of inline JSX).
- **Add the 10 missing tools**: `top_resources`, `get_neighborhood`, `diagnose`, `get_cluster_audit`, `list_packages`, `issues`, `search`, `get_subject_permissions`, `apply_resource`, `manage_node`. Write tools now carry a `write` badge.
- **Fix inaccurate copy**: the dialog claimed write tools are "non-destructive" — they're annotated `destructiveHint: true`. Also dropped the stale `logs` option from `get_resource`'s `include` param.
- **Guard against future drift**: `TestSetupDialogCoversAllTools` parses the catalog and fails CI if its tool set ever diverges from what `registerTools` exposes. Added a pointer comment on `registerTools` and a note in `CLAUDE.md`.

Verified with the existing `listRegisteredTools` harness (24 registered == 24 in catalog), `make tsc`, and a visual test of the dialog in light + dark mode.

## Related

Radar Hub's cloud MCP aggregator reflects tools dynamically, so it needed no implementation change — but its display catalog (Settings → Tool Catalog) had the same drift. Synced in skyhook-dev/radar-hub-web#81.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing documentation and a sync test only; MCP tool registration and handlers are unchanged.
> 
> **Overview**
> The MCP setup dialog no longer hardcodes its tool list in JSX. It reads from **`mcpToolCatalog.ts`**, which now documents all **24** registered tools (previously ~14 were shown), with updated human-facing descriptions and params—including tools like `top_resources`, `diagnose`, `issues`, `search`, `apply_resource`, and `manage_node`.
> 
> **`MCPSetupDialog`** renders that catalog, shows a tool count, marks write tools with an amber **write** badge, and fixes misleading copy (write tools are **destructive**, not “non-destructive”). **`get_resource`**’s documented `include` values drop stale **`logs`**.
> 
> **`TestSetupDialogCoversAllTools`** compares `registerTools` to the TS catalog via regex on `name: '…'` and fails CI on missing or stale entries. Pointers were added on **`registerTools`** and in **`CLAUDE.md`** to keep the catalog in sync when tools change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ad42735a6984953d75296566452b7b09b6b340f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->