### PR TITLE
fix(home): self-tiling dashboard bands eliminate data-dependent card gaps

### DIFF
--- a/web/src/components/home/GitOpsControllersCard.tsx
+++ b/web/src/components/home/GitOpsControllersCard.tsx
@@ -41,21 +41,23 @@ export function GitOpsControllersCard({ data, onNavigate }: GitOpsControllersCar
     <button
       type="button"
       onClick={onNavigate}
-      className="flex flex-col gap-3 rounded-xl bg-theme-surface p-4 text-left shadow-theme-sm transition-colors hover:bg-theme-hover"
+      className="group h-[260px] rounded-xl bg-theme-surface shadow-theme-sm hover:-translate-y-1 hover:shadow-theme-md transition-all duration-200 text-left animate-fade-in-up"
     >
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <GitBranch className="h-4 w-4 text-theme-text-tertiary" />
-          <span className="text-xs font-semibold uppercase tracking-wider text-theme-text-secondary">
-            GitOps Controllers
-          </span>
+      <div className="flex flex-col h-full w-full">
+        <div className="flex items-center justify-between px-5 py-3 border-b border-theme-border/50">
+          <div className="flex items-center gap-2">
+            <GitBranch className={clsx('h-4 w-4', headerTone)} />
+            <span className={clsx('text-xs font-semibold uppercase tracking-wider', headerTone)}>
+              GitOps Controllers
+            </span>
+          </div>
+          <span className={clsx('text-[11px] font-medium', headerTone)}>{headerLabel}</span>
         </div>
-        <span className={clsx('text-[11px] font-medium', headerTone)}>{headerLabel}</span>
-      </div>
 
-      <div className="flex flex-col gap-2">
-        {argo.length > 0 && <ControllerSection label="Argo CD" controllers={argo} />}
-        {flux.length > 0 && <ControllerSection label="Flux CD" controllers={flux} />}
+        <div className="flex-1 min-h-0 overflow-y-auto px-5 py-3 flex flex-col gap-3">
+          {argo.length > 0 && <ControllerSection label="Argo CD" controllers={argo} />}
+          {flux.length > 0 && <ControllerSection label="Flux CD" controllers={flux} />}
+        </div>
       </div>
     </button>
   )

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, type ReactNode } from 'react'
 import { useDashboard, useDashboardCRDs, useDashboardHelm } from '../../api/client'
 import type { DashboardResponse } from '../../api/client'
 import type { ExtendedMainView, Topology, SelectedResource } from '../../types'
@@ -113,71 +113,81 @@ export function HomeView({ namespaces, topology, onNavigateToView, onNavigateToR
         )}>
           {/* Left column: teaser cards */}
           <div className="flex flex-col gap-6 auto-rows-min">
-            {/* Primary cards — 2-col grid */}
+            {/* Live band — Topology + Timeline always render, so a fixed 2-up never strands.
+                These are the richest visuals and the most-used live views, so they get the width. */}
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
               <TopologyPreview
                 topology={scopedTopology}
                 summary={data.topologySummary}
                 onNavigate={() => onNavigateToView('topology')}
               />
-              <HelmSummary
-                data={helmData}
-                onNavigate={() => onNavigateToView('helm')}
-              />
               <ActivitySummary
                 namespaces={namespaces}
                 topology={scopedTopology}
                 onNavigate={() => onNavigateToView('timeline')}
               />
-              <TrafficSummary
-                data={data.trafficSummary}
-                onNavigate={() => onNavigateToView('traffic')}
-              />
-              <CostCard onNavigate={() => onNavigateToView('cost')} />
             </div>
 
-            {/* Health & compliance cards — 3-col when enough cards, 2-col fallback */}
-            {(data.certificateHealth || data.networkPolicyCoverage || data.audit || data.gitopsControllers) && (() => {
-              const healthCards = [
-                data.certificateHealth && (
-                  <CertificateHealthCard
-                    key="certs"
-                    data={data.certificateHealth}
-                    onNavigate={() => onNavigateToResourceKind('secrets', undefined, { type: ['TLS'] })}
-                  />
-                ),
-                data.networkPolicyCoverage && (
-                  <NetworkPolicyCoverageCard
-                    key="netpol"
-                    data={data.networkPolicyCoverage}
-                    onNavigate={() => onNavigateToResourceKind('networkpolicies', 'networking.k8s.io')}
-                  />
-                ),
-                data.gitopsControllers && (
-                  <GitOpsControllersCard
-                    key="gitops-controllers"
-                    data={data.gitopsControllers}
-                    onNavigate={() => onNavigateToView('gitops')}
-                  />
-                ),
-                data.audit && (
-                  <AuditCard
-                    key="audit"
-                    data={data.audit}
-                    onNavigate={() => onNavigateToView('audit')}
-                  />
-                ),
-              ].filter(Boolean)
+            {/* Explore band — flex-grow wrap so the row always fills. The conditional
+                Cost card self-hides via BandItem's empty:hidden when OpenCost is absent,
+                leaving Traffic + Helm to stretch rather than stranding an empty cell. */}
+            <div className="flex flex-wrap gap-6">
+              <BandItem>
+                <TrafficSummary
+                  data={data.trafficSummary}
+                  onNavigate={() => onNavigateToView('traffic')}
+                />
+              </BandItem>
+              <BandItem>
+                <HelmSummary
+                  data={helmData}
+                  onNavigate={() => onNavigateToView('helm')}
+                />
+              </BandItem>
+              <BandItem>
+                <CostCard onNavigate={() => onNavigateToView('cost')} />
+              </BandItem>
+            </div>
 
-              return (
-                <div className={clsx(
-                  'grid gap-6',
-                  healthCards.length >= 3 ? 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3' : 'grid-cols-1 sm:grid-cols-2'
-                )}>
-                  {healthCards}
-                </div>
-              )
-            })()}
+            {/* Posture band — same flex-grow wrap so any subset of compliance cards
+                fills its row instead of stranding the last one (the old 3-col grid
+                left Cluster Audit alone with two empty cells beside it). */}
+            {(data.certificateHealth || data.networkPolicyCoverage || data.audit || data.gitopsControllers) && (
+              <div className="flex flex-wrap gap-6">
+                {data.certificateHealth && (
+                  <BandItem>
+                    <CertificateHealthCard
+                      data={data.certificateHealth}
+                      onNavigate={() => onNavigateToResourceKind('secrets', undefined, { type: ['TLS'] })}
+                    />
+                  </BandItem>
+                )}
+                {data.networkPolicyCoverage && (
+                  <BandItem>
+                    <NetworkPolicyCoverageCard
+                      data={data.networkPolicyCoverage}
+                      onNavigate={() => onNavigateToResourceKind('networkpolicies', 'networking.k8s.io')}
+                    />
+                  </BandItem>
+                )}
+                {data.gitopsControllers && (
+                  <BandItem>
+                    <GitOpsControllersCard
+                      data={data.gitopsControllers}
+                      onNavigate={() => onNavigateToView('gitops')}
+                    />
+                  </BandItem>
+                )}
+                {data.audit && (
+                  <BandItem>
+                    <AuditCard
+                      data={data.audit}
+                      onNavigate={() => onNavigateToView('audit')}
+                    />
+                  </BandItem>
+                )}
+              </div>
+            )}
           </div>
 
           {/* Right column: problems panel */}
@@ -191,6 +201,13 @@ export function HomeView({ namespaces, topology, onNavigateToView, onNavigateToR
       </div>
     </div>
   )
+}
+
+// A self-tiling flex item: grows to share the row, clamps to a sensible min
+// width, and removes itself (empty:hidden) when its card renders null — so a
+// data-gated card (e.g. Cost without OpenCost) can't leave a phantom column.
+function BandItem({ children }: { children: ReactNode }) {
+  return <div className="flex-1 min-w-[260px] empty:hidden [&>*]:w-full">{children}</div>
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

The home dashboard laid cards out in **fixed-column grids against variable card counts**, so the remainder stranded depending on which data sources were connected — producing awkward whitespace that changed shape per cluster.

Three concrete bugs:
- **Void beside Cost Insights** — 5 primary cards in a fixed 2-col grid left an empty 6th cell. `CostCard` only renders when OpenCost is live, so the gap appeared *only when cost data was present* (the "depending on available data" symptom).
- **Stranded Cluster Audit** — 4 compliance cards in a 3-col grid put Audit alone on a second row with two empty cells beside it.
- **GitOps card floated** — it was the only card without a fixed `h-[260px]`, so it never aligned with its row-mates.

## Changes

Reorganized into three priority-ordered bands under the Cluster Health hero:

| Band | Cards | Mechanism |
|------|-------|-----------|
| **Live** | Topology · Timeline | fixed 2-up (both always present → never strands) |
| **Explore** | Traffic · Helm · Cost | `flex-wrap` + `flex-grow` |
| **Posture** | Certs · NetPol · GitOps · Audit | `flex-wrap` + `flex-grow` |

Bands use **flex-grow wrapping rather than CSS `auto-fit`** so the trailing row fills for *any* card count — `auto-fit` only stretches the last row when the count fits in a single row, and would re-strand the 4th posture card when it wraps on a narrow column. A `BandItem` wrapper uses `empty:hidden` so a data-gated card (e.g. Cost without OpenCost) drops out of flow instead of leaving a phantom column. `GitOpsControllersCard` is normalized to the canonical 260px card skeleton with a status-tinted header.

## Verification

`make tsc` clean. Visual-tested against a live cluster across 1280 / 1920 / 2560 and dark mode:
- Explore band fills with Cost auto-hidden (no phantom cell); posture trio tiles evenly at wide widths.
- At 1280 the posture column is too narrow for 3-up, so Audit wraps and **flex-grow stretches it to full width** — no gap (the case `auto-fit` would have stranded).
- GitOps card now flush at 260px with its row-mates; status tint legible in both themes. 0 console errors.

> Note: verified on the gitops-demo cluster (3-card posture row). The dense 4-card posture + OpenCost-present case (matching the original report) wasn't re-shot due to an expired GKE token.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only changes in home dashboard UI; no API, auth, or data logic changes.
> 
> **Overview**
> Replaces fixed multi-column grids on the home dashboard with **three priority bands** so card count and optional data sources no longer leave empty cells.
> 
> The **Live** band keeps only Topology and Timeline in a stable 2-column grid. **Explore** (Traffic, Helm, Cost) and **Posture** (certs, netpol, GitOps, audit) use `flex-wrap` with a new **`BandItem`** wrapper (`flex-1`, `min-w-[260px]`, `empty:hidden`) so rows stretch to fill width and slots disappear when a child renders nothing (e.g. Cost without OpenCost).
> 
> **`GitOpsControllersCard`** is aligned with other teasers: fixed **`h-[260px]`**, header border/status tint, and a scrollable body so it lines up with neighboring cards and picks up the same hover/elevation treatment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 399b61a1e8849bb57ae6a6749ab24b532708e50c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->