### PR TITLE
feat: Applications backend + package overlay data

### DIFF
--- a/internal/server/applications.go
+++ b/internal/server/applications.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"net/http"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -15,39 +16,59 @@ import (
 	"github.com/skyhook-io/radar/internal/k8s"
 	"github.com/skyhook-io/radar/pkg/packages"
 	"github.com/skyhook-io/radar/pkg/subject"
+	"github.com/skyhook-io/radar/pkg/topology"
 )
 
 // Applications is the workload-centric twin of /api/packages. Where packages
 // answers "what software is installed" (chart/GitOps-declaration centric, the
 // Add-ons surface), Applications answers "what are MY services and what version
-// runs where" — the unit is a logical app: the set of workloads sharing a
-// pkg/subject Tier-2 app-overlay key, anchored on the container image:tag (the
-// real running version, not a chart version that's empty for git-based apps).
+// runs where" — the unit is a logical app.
 //
-// Why a separate path (not the packages feed): collectWorkloadInputs only
-// admits Helm-labeled workloads and carries no image, so the packages feed
-// structurally cannot represent a non-Helm app's services or their versions.
-// See ADDONS-AND-APPLICATIONS-PLAN.md §8.3 (the row-identity change) — this is
-// that change done on the right entities.
+// What defines an app boundary: the K8s STRUCTURAL relationship graph is the
+// spine. A workload's app is its topmost EdgeManages ancestor — the root that
+// collapses native owner chains (Pod→RS→Deployment), in-cluster GitOps managers
+// (an ArgoCD Application / Flux Kustomization / Flux HelmRelease that manages a
+// set of workloads), and generic-CRD owners. The pkg/subject Tier-2 label
+// overlay (app.kubernetes.io/part-of, Argo/Flux/Helm signals) then CONSOLIDATES
+// roots the graph can't connect — hub-spoke Argo (controller in another
+// cluster), native-Helm release annotations — with a confidence score. Roots
+// and overlay keys are unioned per workload; satellites (Services/Ingress/
+// config/scalers/PDBs) are ATTACHED to an app via the same graph but never
+// merge two apps that merely share one (the over-merge guardrail). Nothing is
+// hidden: a singleton workload with no signal is its own raw row, and add-on
+// machinery is classified with evidence rather than dropped.
 
 // applicationsResponse is the GET /api/applications body.
 type applicationsResponse struct {
 	Applications []appRow `json:"applications"`
 }
 
-// appRow is one logical app in this cluster: workloads collapsed by app-overlay
-// key. Raw-always: a workload with no app signal (no overlay) is its own row
-// keyed by "<ns>/<kind>/<name>" — nothing is hidden.
+// appRow is one logical app in this cluster.
 type appRow struct {
-	Key        string         `json:"key"`                  // overlay key, or "<ns>/<kind>/<name>" raw
-	Name       string         `json:"name"`                 // display name
-	Namespace  string         `json:"namespace,omitempty"`  // overlay namespace (grouping scope)
-	Tier       int            `json:"tier,omitempty"`       // pkg/subject overlay tier (0 = raw, no overlay)
-	Confidence string         `json:"confidence,omitempty"` // high | medium | low
-	Health     string         `json:"health"`               // worst-of across workloads
-	Versions   []string       `json:"versions,omitempty"`   // distinct image tags (the running version)
-	Workloads  []appWorkload  `json:"workloads"`
-	Events     []appEvent     `json:"events,omitempty"`     // recent Warning events across the app's workloads/pods
+	Key         string `json:"key"`                  // overlay key, structural-root key, or "<ns>/<kind>/<name>" raw
+	Name        string `json:"name"`                 // display name
+	Namespace   string `json:"namespace,omitempty"`  // grouping scope
+	Tier        int    `json:"tier,omitempty"`       // pkg/subject overlay tier (0 = raw, no signal)
+	Confidence  string `json:"confidence,omitempty"` // high | medium | low
+	Category    string `json:"category,omitempty"`   // "app" (your service) | "addon" (3rd-party platform machinery)
+	AddonReason string `json:"addonReason,omitempty"`// evidence when Category == "addon" — never hidden, always explained
+	Health      string `json:"health"`               // worst-of across workloads
+	Versions    []string          `json:"versions,omitempty"` // distinct image tags (the running version)
+	Workloads   []appWorkload     `json:"workloads"`
+	Events      []appEvent        `json:"events,omitempty"`        // recent Warning events across the app's workloads/pods
+	Relationships *appRelationships `json:"relationships,omitempty"` // structural satellites attached via topology
+}
+
+// appRelationships is the structural neighborhood of an app, derived from the
+// topology graph: what fronts it (Services/Ingress/Routes) and what supports it
+// (config, autoscalers, disruption budgets). Counts where names add no value.
+type appRelationships struct {
+	Services  []string `json:"services,omitempty"`
+	Ingresses []string `json:"ingresses,omitempty"`
+	Routes    []string `json:"routes,omitempty"`
+	Configs   int      `json:"configs,omitempty"`
+	Scalers   int      `json:"scalers,omitempty"`
+	PDBs      int      `json:"pdbs,omitempty"`
 }
 
 // appEvent is a recent k8s Warning event correlated to an app's workloads/pods
@@ -70,10 +91,10 @@ type appWorkload struct {
 	Image     string `json:"image,omitempty"`   // full primary-container image ref
 	Version   string `json:"version,omitempty"` // image tag (digest-only → empty)
 	Health    string `json:"health"`
-	Ready     int    `json:"ready"`             // ready/available replicas
-	Desired   int    `json:"desired"`           // desired replicas
-	Restarts  int    `json:"restarts"`          // total container restarts across the workload's pods
-	Reason    string `json:"reason,omitempty"`  // last-terminated reason of the worst pod (CrashLoopBackOff/OOMKilled/…)
+	Ready     int    `json:"ready"`            // ready/available replicas
+	Desired   int    `json:"desired"`          // desired replicas
+	Restarts  int    `json:"restarts"`         // total container restarts across the workload's pods
+	Reason    string `json:"reason,omitempty"` // last-terminated reason of the worst pod (CrashLoopBackOff/OOMKilled/…)
 }
 
 // handleListApplications serves GET /api/applications.
@@ -96,52 +117,184 @@ func (s *Server) handleListApplications(w http.ResponseWriter, r *http.Request) 
 	s.writeJSON(w, resp)
 }
 
-// ListApplications enumerates the cluster's app workloads, resolves each to its
-// pkg/subject app-overlay, and groups them into logical apps. Add-on workloads
-// (cert-manager et al.) are excluded — they belong to the Add-ons surface.
+// appGraph bundles the topology graph and the primitives derived from it that
+// the collection pass needs. A nil graph (build failure / no cache) degrades
+// cleanly: every workload becomes its own structural root and carries no
+// satellites — identity then rests on the label overlay alone, raw-always.
+type appGraph struct {
+	topo     *topology.Topology
+	idx      *topology.RelationshipsIndex
+	provider topology.ResourceProvider
+	dp       topology.DynamicProvider
+	byID     map[string]topology.Node
+	byKNN    map[string]string // lower(kind)|ns|name → node ID
+}
+
+// ListApplications builds the structural topology graph, resolves each app
+// workload to its graph root + label overlay, and groups them into logical
+// apps. Add-on machinery is classified (not dropped); nothing is hidden.
 func ListApplications(ctx context.Context, namespaces []string) (*applicationsResponse, error) {
 	cache := k8s.GetResourceCache()
 	if cache == nil {
 		return nil, errResourceCacheUnavailable
 	}
-	wls := collectAppWorkloads(cache, namespaces)
+	g := buildAppGraph(cache, namespaces)
+	wls := collectAppWorkloads(cache, namespaces, g)
 	return &applicationsResponse{Applications: groupApplications(wls)}, nil
 }
 
-// appWorkloadInput is the pre-grouping shape: a workload plus its resolved
-// overlay (nil when no app signal at/above tier 7).
+// buildAppGraph constructs the same resources-view topology the /api/topology
+// handler builds, then indexes it for root walks and satellite lookups.
+func buildAppGraph(cache *k8s.ResourceCache, namespaces []string) *appGraph {
+	g := &appGraph{byID: map[string]topology.Node{}, byKNN: map[string]string{}}
+	provider := k8s.NewTopologyResourceProvider(cache)
+	if provider == nil {
+		return g
+	}
+	g.provider = provider
+	g.dp = k8s.NewTopologyDynamicProvider(k8s.GetDynamicResourceCache(), k8s.GetResourceDiscovery())
+
+	opts := topology.DefaultBuildOptions()
+	opts.Namespaces = namespaces
+	b := topology.NewBuilder(provider)
+	if g.dp != nil {
+		b = b.WithDynamic(g.dp)
+	}
+	topo, err := b.Build(opts)
+	if err != nil || topo == nil {
+		return g
+	}
+	g.topo = topo
+	g.idx = topology.IndexByResource(topo)
+	for _, n := range topo.Nodes {
+		g.byID[n.ID] = n
+		ns, _ := n.Data["namespace"].(string)
+		g.byKNN[knnKey(string(n.Kind), ns, n.Name)] = n.ID
+	}
+	return g
+}
+
+func knnKey(kind, ns, name string) string {
+	return strings.ToLower(kind) + "|" + ns + "|" + name
+}
+
+// structuralRoot walks incoming EdgeManages edges from startID to the topmost
+// ancestor — the same walk pkg/topology uses for managed-by synthesis. The
+// topmost node is the app's structural root: a manager (ArgoCD Application,
+// Flux Kustomization/HelmRelease, generic-CRD owner) when one manages the
+// workload in-cluster, otherwise the workload's own top controller.
+func (g *appGraph) structuralRoot(startID string) (topology.Node, bool) {
+	cur := startID
+	top, ok := g.byID[cur]
+	if g.idx == nil {
+		return top, ok
+	}
+	visited := map[string]bool{cur: true}
+	for {
+		next := ""
+		incoming, _ := g.idx.EdgesFor(cur)
+		for _, e := range incoming {
+			if e.Type == topology.EdgeManages {
+				next = e.Source
+				break
+			}
+		}
+		if next == "" || visited[next] {
+			break
+		}
+		visited[next] = true
+		if n, exists := g.byID[next]; exists {
+			top = n
+			ok = true
+		}
+		cur = next
+	}
+	return top, ok
+}
+
+// rootOf returns the structural-root key ("<ns>/<Kind>/<name>") and root Kind
+// for a workload, falling back to the workload itself when the graph is absent.
+func (g *appGraph) rootOf(kind, ns, name string) (rootKey, rootKind string) {
+	rootKey = ns + "/" + kind + "/" + name
+	rootKind = kind
+	if g.topo == nil {
+		return
+	}
+	nodeID, found := g.byKNN[knnKey(kind, ns, name)]
+	if !found {
+		return
+	}
+	rn, ok := g.structuralRoot(nodeID)
+	if !ok {
+		return
+	}
+	rns, _ := rn.Data["namespace"].(string)
+	return rns + "/" + string(rn.Kind) + "/" + rn.Name, string(rn.Kind)
+}
+
+// relationshipsFor pulls the workload's structural satellites from the graph.
+func (g *appGraph) relationshipsFor(kind, ns, name string) *appRelationships {
+	if g.topo == nil {
+		return nil
+	}
+	rel := topology.GetRelationshipsWithIndex(kind, ns, name, g.topo, g.provider, g.dp, g.idx)
+	if rel == nil {
+		return nil
+	}
+	out := &appRelationships{Configs: len(rel.ConfigRefs), Scalers: len(rel.Scalers), PDBs: len(rel.PDBs)}
+	for _, s := range rel.Services {
+		out.Services = append(out.Services, s.Name)
+	}
+	for _, i := range rel.Ingresses {
+		out.Ingresses = append(out.Ingresses, i.Name)
+	}
+	for _, r := range rel.Routes {
+		out.Routes = append(out.Routes, r.Name)
+	}
+	if len(out.Services) == 0 && len(out.Ingresses) == 0 && len(out.Routes) == 0 &&
+		out.Configs == 0 && out.Scalers == 0 && out.PDBs == 0 {
+		return nil
+	}
+	return out
+}
+
+// appWorkloadInput is the pre-grouping shape: one workload plus the signals
+// that decide which app it belongs to (structural root + label overlay) and how
+// it is classified.
 type appWorkloadInput struct {
-	wl      appWorkload
-	overlay *subject.AppOverlay
-	events  []appEvent
+	wl       appWorkload
+	overlay  *subject.AppOverlay
+	events   []appEvent
+	rels     *appRelationships
+	rootKey  string
+	rootKind string
+	addon    bool
+	addonWhy string
 }
 
 // collectAppWorkloads walks Deployments/StatefulSets/DaemonSets, captures the
-// primary container image, resolves the app-overlay, and drops add-on workloads.
-func collectAppWorkloads(cache *k8s.ResourceCache, namespaces []string) []appWorkloadInput {
+// primary container image + replica health, resolves each to its structural
+// root and label overlay, and classifies add-on machinery. Pods and Warning
+// events are indexed once per namespace and joined, not re-listed per workload.
+func collectAppWorkloads(cache *k8s.ResourceCache, namespaces []string, g *appGraph) []appWorkloadInput {
 	var out []appWorkloadInput
 
+	podsByNS := indexPodsByNamespace(cache, namespaces)
+	eventsByObj := indexWarningEventsByObject(cache, namespaces)
+
 	add := func(kind, ns, name string, lbls, anns map[string]string, image string, health packages.Health, ready, desired int, selector *metav1.LabelSelector) {
-		// Cluster plumbing (kube-proxy, kindnet, CNI, local-path) is never a
-		// user service — exclude system namespaces outright.
+		// Cluster plumbing (kube-proxy, kindnet, CNI, local-path) is K8s control
+		// plane, never a user service — exclude these namespaces outright. This
+		// is a namespace-scoped infra filter, distinct from add-on NAME matching
+		// below, which only classifies (never hides) user-namespace workloads.
 		if systemNamespaces[ns] {
 			return
 		}
-		// Add-ons live on their own surface — keep 3rd-party platform machinery
-		// out of "your services". (Interim chart/name match; consolidate with
-		// the SPA's KNOWN_ADDON list + OSS catalog later — plan §12 Q3.)
-		if isAddonWorkload(lbls, name) {
-			return
-		}
-		// One pod fetch powers both restarts (crashloop signal) and the Warning
-		// event feed (image-pull / scheduling / mount failures restarts miss).
-		var pods []*corev1.Pod
-		if selector != nil {
-			pods = cache.GetPodsForWorkload(ns, selector)
-		}
+		pods := podsForSelector(podsByNS[ns], selector)
 		restarts, reason := podsRestarts(pods)
 		meta := metav1.ObjectMeta{Namespace: ns, Name: name, Labels: lbls, Annotations: anns}
-		ov := subject.ResolveOverlay(&meta, false)
+		rootKey, rootKind := g.rootOf(kind, ns, name)
+		addon, why := packages.ClassifyAddon(lbls["helm.sh/chart"], lbls["app.kubernetes.io/name"], lbls["app.kubernetes.io/part-of"], name)
 		out = append(out, appWorkloadInput{
 			wl: appWorkload{
 				Kind:      kind,
@@ -155,8 +308,13 @@ func collectAppWorkloads(cache *k8s.ResourceCache, namespaces []string) []appWor
 				Restarts:  restarts,
 				Reason:    reason,
 			},
-			overlay: ov,
-			events:  podsEvents(cache, ns, name, pods),
+			overlay:  subject.ResolveOverlay(&meta, false),
+			events:   eventsForWorkload(eventsByObj[ns], name, pods),
+			rels:     g.relationshipsFor(kind, ns, name),
+			rootKey:  rootKey,
+			rootKind: rootKind,
+			addon:    addon,
+			addonWhy: why,
 		})
 	}
 
@@ -221,53 +379,60 @@ func collectAppWorkloads(cache *k8s.ResourceCache, namespaces []string) []appWor
 	return out
 }
 
-// groupApplications collapses workloads by app-overlay key. Workloads with no
-// overlay (raw-always) become their own single-workload row keyed on identity.
+// --- grouping ------------------------------------------------------------
+
+// groupApplications partitions workloads into logical apps. Each workload
+// contributes atoms — its structural-root key, its overlay key, and a canonical
+// ArgoCD key (so tracking-id and instance label modes collapse) — that are
+// union-found together. Workloads sharing any atom (transitively) are one app.
+// Satellites are attached but never used to merge: two apps that share a Service
+// stay two apps.
 func groupApplications(inputs []appWorkloadInput) []appRow {
-	rows := map[string]*appRow{}
-	order := []string{}
+	d := newDSU()
 	for _, in := range inputs {
-		var key, name, ns string
-		var tier int
-		var conf string
-		if in.overlay != nil {
-			win := in.overlay.Winner
-			key = win.Key
-			name = appNameFromKey(win.Key)
-			ns = namespaceFromKey(win.Key)
-			tier = int(win.Tier)
-			conf = string(win.Confidence)
-		} else {
-			// Raw-always: identifiable on its own, never hidden.
-			key = in.wl.Namespace + "/" + in.wl.Kind + "/" + in.wl.Name
-			name = in.wl.Name
-			ns = in.wl.Namespace
-		}
-		r, ok := rows[key]
-		if !ok {
-			r = &appRow{Key: key, Name: name, Namespace: ns, Tier: tier, Confidence: conf}
-			rows[key] = r
-			order = append(order, key)
-		}
-		r.Workloads = append(r.Workloads, in.wl)
-		r.Events = append(r.Events, in.events...)
-		r.Health = string(worstAppHealth(packages.Health(r.Health), packages.Health(in.wl.Health)))
-		if v := in.wl.Version; v != "" && !contains(r.Versions, v) {
-			r.Versions = append(r.Versions, v)
+		atoms := inputAtoms(in)
+		for i := 1; i < len(atoms); i++ {
+			d.union(atoms[0], atoms[i])
 		}
 	}
-	out := make([]appRow, 0, len(order))
-	for _, k := range order {
-		r := rows[k]
+
+	rows := map[string]*appRow{}
+	order := []string{}
+	members := map[string][]appWorkloadInput{}
+	for _, in := range inputs {
+		comp := d.find("S:" + in.rootKey)
+		if _, ok := members[comp]; !ok {
+			order = append(order, comp)
+		}
+		members[comp] = append(members[comp], in)
+	}
+
+	for _, comp := range order {
+		ins := members[comp]
+		r := &appRow{}
+		identifyApp(r, ins)
+		for _, in := range ins {
+			r.Workloads = append(r.Workloads, in.wl)
+			r.Events = append(r.Events, in.events...)
+			r.Health = string(worstAppHealth(packages.Health(r.Health), packages.Health(in.wl.Health)))
+			if v := in.wl.Version; v != "" && !slices.Contains(r.Versions, v) {
+				r.Versions = append(r.Versions, v)
+			}
+			mergeRelationships(r, in.rels)
+		}
+		finalizeRelationships(r)
 		sort.Strings(r.Versions)
-		// Newest events first; cap the feed.
 		sort.SliceStable(r.Events, func(i, j int) bool { return r.Events[i].LastSeen > r.Events[j].LastSeen })
 		if len(r.Events) > 12 {
 			r.Events = r.Events[:12]
 		}
-		out = append(out, *r)
+		rows[comp] = r
 	}
-	// Deterministic: by name then key.
+
+	out := make([]appRow, 0, len(order))
+	for _, comp := range order {
+		out = append(out, *rows[comp])
+	}
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].Name != out[j].Name {
 			return out[i].Name < out[j].Name
@@ -277,7 +442,269 @@ func groupApplications(inputs []appWorkloadInput) []appRow {
 	return out
 }
 
+// inputAtoms returns the union-find atoms for a workload. The structural-root
+// atom is always present; overlay and canonical-Argo atoms consolidate roots
+// the graph can't connect.
+func inputAtoms(in appWorkloadInput) []string {
+	atoms := []string{"S:" + in.rootKey}
+	if a, ok := argoCanonicalAtom(in.rootKind, in.rootKey); ok {
+		atoms = append(atoms, a)
+	}
+	if in.overlay != nil {
+		atoms = append(atoms, "O:"+in.overlay.Winner.Key)
+		if a, ok := argoCanonicalAtom("Application", in.overlay.Winner.Key); ok {
+			atoms = append(atoms, a)
+		}
+	}
+	return atoms
+}
+
+// identifyApp sets a row's identity (key/name/namespace/tier/confidence) and
+// add-on classification from its member workloads. A label overlay wins (it
+// carries an explicit tier + confidence); otherwise the structural root — and
+// when that root is a GitOps manager, its kind synthesizes the tier so the
+// surface still attributes provenance (Argo/Flux) for unlabeled in-cluster apps.
+func identifyApp(r *appRow, ins []appWorkloadInput) {
+	var best *subject.Signal
+	for i := range ins {
+		if ins[i].overlay == nil {
+			continue
+		}
+		w := ins[i].overlay.Winner
+		if best == nil || w.Tier < best.Tier || (w.Tier == best.Tier && w.Key < best.Key) {
+			sig := w
+			best = &sig
+		}
+	}
+	if best != nil {
+		r.Key = best.Key
+		r.Name = appNameFromKey(best.Key)
+		r.Namespace = namespaceFromKey(best.Key)
+		r.Tier = int(best.Tier)
+		r.Confidence = string(best.Confidence)
+	} else {
+		root := pickRoot(ins)
+		r.Key = root.rootKey
+		r.Name = appNameFromKey(root.rootKey)
+		r.Namespace = namespaceFromKey(root.rootKey)
+		if t, c, ok := managerTier(root.rootKind); ok {
+			r.Tier = t
+			r.Confidence = c
+		}
+	}
+
+	r.Category = "app"
+	for _, in := range ins {
+		if in.addon {
+			r.Category = "addon"
+			r.AddonReason = in.addonWhy
+			break
+		}
+	}
+}
+
+// pickRoot prefers a GitOps-manager root over a raw workload root for identity.
+func pickRoot(ins []appWorkloadInput) appWorkloadInput {
+	for _, in := range ins {
+		if _, _, ok := managerTier(in.rootKind); ok {
+			return in
+		}
+	}
+	return ins[0]
+}
+
+// managerTier maps a structural manager-root kind to the overlay tier it stands
+// in for, so an in-cluster GitOps-managed app without labels still attributes.
+func managerTier(kind string) (tier int, confidence string, ok bool) {
+	switch kind {
+	case string(topology.KindHelmRelease):
+		return int(subject.TierFluxHelmRelease), string(subject.ConfidenceHigh), true
+	case string(topology.KindKustomization):
+		return int(subject.TierFluxKustomize), string(subject.ConfidenceHigh), true
+	case string(topology.KindApplication):
+		return int(subject.TierArgoTrackingID), string(subject.ConfidenceHigh), true
+	}
+	return 0, "", false
+}
+
+// argoCanonicalAtom extracts a tracking-mode-independent atom from an ArgoCD
+// Application key. ResolveOverlay emits "<ns>/Application/<name>" for tracking-id
+// (tier 3) but "/Application/<name>" (empty ns) for the instance label (tier 4);
+// the in-cluster Application node's structural key is "<argo-ns>/Application/<name>".
+// Reducing all three to the app name unions them so the declaration and its
+// workloads collapse into one app regardless of which Argo tracking mode is used.
+func argoCanonicalAtom(kind, key string) (string, bool) {
+	if kind != string(topology.KindApplication) {
+		return "", false
+	}
+	const marker = "/Application/"
+	i := strings.Index(key, marker)
+	if i < 0 {
+		return "", false
+	}
+	name := key[i+len(marker):]
+	if name == "" || strings.Contains(name, "/") {
+		return "", false
+	}
+	return "A:application:" + name, true
+}
+
+func mergeRelationships(r *appRow, rel *appRelationships) {
+	if rel == nil {
+		return
+	}
+	if r.Relationships == nil {
+		r.Relationships = &appRelationships{}
+	}
+	agg := r.Relationships
+	agg.Services = append(agg.Services, rel.Services...)
+	agg.Ingresses = append(agg.Ingresses, rel.Ingresses...)
+	agg.Routes = append(agg.Routes, rel.Routes...)
+	agg.Configs += rel.Configs
+	agg.Scalers += rel.Scalers
+	agg.PDBs += rel.PDBs
+}
+
+func finalizeRelationships(r *appRow) {
+	if r.Relationships == nil {
+		return
+	}
+	r.Relationships.Services = dedupSorted(r.Relationships.Services, 20)
+	r.Relationships.Ingresses = dedupSorted(r.Relationships.Ingresses, 20)
+	r.Relationships.Routes = dedupSorted(r.Relationships.Routes, 20)
+}
+
 // --- small helpers --------------------------------------------------------
+
+// dsu is a string union-find for partitioning workloads by shared atoms.
+type dsu struct{ parent map[string]string }
+
+func newDSU() *dsu { return &dsu{parent: map[string]string{}} }
+
+func (d *dsu) find(x string) string {
+	p, ok := d.parent[x]
+	if !ok {
+		d.parent[x] = x
+		return x
+	}
+	if p != x {
+		d.parent[x] = d.find(p)
+	}
+	return d.parent[x]
+}
+
+func (d *dsu) union(a, b string) {
+	ra, rb := d.find(a), d.find(b)
+	if ra != rb {
+		d.parent[ra] = rb
+	}
+}
+
+func dedupSorted(in []string, cap int) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	if len(out) > cap {
+		out = out[:cap]
+	}
+	return out
+}
+
+// indexPodsByNamespace lists pods once per namespace and buckets them, so the
+// per-workload restart/event join is O(pods) total, not O(workloads × pods).
+func indexPodsByNamespace(cache *k8s.ResourceCache, namespaces []string) map[string][]*corev1.Pod {
+	out := map[string][]*corev1.Pod{}
+	lister := cache.Pods()
+	if lister == nil {
+		return out
+	}
+	add := func(ns string) {
+		var pods []*corev1.Pod
+		if ns == "" {
+			pods, _ = lister.List(labels.Everything())
+		} else {
+			pods, _ = lister.Pods(ns).List(labels.Everything())
+		}
+		for _, p := range pods {
+			out[p.Namespace] = append(out[p.Namespace], p)
+		}
+	}
+	if namespaces == nil {
+		add("")
+	} else {
+		for _, ns := range namespaces {
+			add(ns)
+		}
+	}
+	return out
+}
+
+// indexWarningEventsByObject lists events once per namespace and indexes the
+// Warnings by involvedObject name, so each workload joins its events in O(1)
+// instead of re-scanning the whole namespace event stream.
+func indexWarningEventsByObject(cache *k8s.ResourceCache, namespaces []string) map[string]map[string][]*corev1.Event {
+	out := map[string]map[string][]*corev1.Event{}
+	lister := cache.Events()
+	if lister == nil {
+		return out
+	}
+	add := func(ns string) {
+		var evs []*corev1.Event
+		if ns == "" {
+			evs, _ = lister.List(labels.Everything())
+		} else {
+			evs, _ = lister.Events(ns).List(labels.Everything())
+		}
+		for _, e := range evs {
+			if e.Type != "Warning" {
+				continue
+			}
+			m := out[e.Namespace]
+			if m == nil {
+				m = map[string][]*corev1.Event{}
+				out[e.Namespace] = m
+			}
+			m[e.InvolvedObject.Name] = append(m[e.InvolvedObject.Name], e)
+		}
+	}
+	if namespaces == nil {
+		add("")
+	} else {
+		for _, ns := range namespaces {
+			add(ns)
+		}
+	}
+	return out
+}
+
+// podsForSelector filters an already-listed namespace pod set by a workload's
+// selector — no extra API/cache calls.
+func podsForSelector(pods []*corev1.Pod, selector *metav1.LabelSelector) []*corev1.Pod {
+	if selector == nil || len(pods) == 0 {
+		return nil
+	}
+	sel, err := metav1.LabelSelectorAsSelector(selector)
+	if err != nil {
+		return nil
+	}
+	var out []*corev1.Pod
+	for _, p := range pods {
+		if sel.Matches(labels.Set(p.Labels)) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
 
 // primaryImage returns the first container's image (the conventional "the app"
 // container — mirrors pkg/ai/context/summary.go's first-container choice).
@@ -306,44 +733,43 @@ func podsRestarts(pods []*corev1.Pod) (int, string) {
 	return total, reason
 }
 
-// podsEvents collects recent Warning events involving the workload or its pods,
-// deduped by (object, reason) with summed counts — the "why is it broken" feed
-// (FailedScheduling, ImagePullBackOff, FailedMount, …) that restarts alone miss.
-func podsEvents(cache *k8s.ResourceCache, ns, workloadName string, pods []*corev1.Pod) []appEvent {
-	lister := cache.Events()
-	if lister == nil {
+// eventsForWorkload joins a workload's Warning events from the per-namespace
+// index (the workload object + its pods), deduped by (object, reason) with
+// summed counts — the "why is it broken" feed (FailedScheduling, ImagePullBackOff,
+// FailedMount, …) that restarts alone miss.
+func eventsForWorkload(byObject map[string][]*corev1.Event, workloadName string, pods []*corev1.Pod) []appEvent {
+	if byObject == nil {
 		return nil
 	}
-	names := map[string]bool{workloadName: true}
+	names := make([]string, 0, len(pods)+1)
+	names = append(names, workloadName)
 	for _, p := range pods {
-		names[p.Name] = true
-	}
-	evs, err := lister.Events(ns).List(labels.Everything())
-	if err != nil {
-		return nil
+		names = append(names, p.Name)
 	}
 	byKey := map[string]*appEvent{}
 	order := []string{}
-	for _, e := range evs {
-		if e.Type != "Warning" || !names[e.InvolvedObject.Name] {
-			continue
-		}
-		key := e.InvolvedObject.Kind + "/" + e.InvolvedObject.Name + "/" + e.Reason
-		c := int(e.Count)
-		if c < 1 {
-			c = 1
-		}
-		if a, ok := byKey[key]; ok {
-			a.Count += c
-			if ts := e.LastTimestamp.Format(time.RFC3339); ts > a.LastSeen {
-				a.LastSeen = ts
-				a.Message = e.Message
+	for _, n := range names {
+		for _, e := range byObject[n] {
+			key := e.InvolvedObject.Kind + "/" + e.InvolvedObject.Name + "/" + e.Reason
+			c := int(e.Count)
+			if c < 1 {
+				c = 1
 			}
-			continue
+			if a, ok := byKey[key]; ok {
+				a.Count += c
+				if ts := e.LastTimestamp.Format(time.RFC3339); ts > a.LastSeen {
+					a.LastSeen = ts
+					a.Message = e.Message
+				}
+				continue
+			}
+			byKey[key] = &appEvent{
+				Type: e.Type, Reason: e.Reason, Message: e.Message, Count: c,
+				Object: e.InvolvedObject.Kind + "/" + e.InvolvedObject.Name,
+				LastSeen: e.LastTimestamp.Format(time.RFC3339),
+			}
+			order = append(order, key)
 		}
-		ae := &appEvent{Type: e.Type, Reason: e.Reason, Message: e.Message, Count: c, Object: e.InvolvedObject.Kind + "/" + e.InvolvedObject.Name, LastSeen: e.LastTimestamp.Format(time.RFC3339)}
-		byKey[key] = ae
-		order = append(order, key)
 	}
 	out := make([]appEvent, 0, len(order))
 	for _, k := range order {
@@ -381,15 +807,6 @@ func namespaceFromKey(key string) string {
 		return key[:i]
 	}
 	return ""
-}
-
-func contains(ss []string, s string) bool {
-	for _, x := range ss {
-		if x == s {
-			return true
-		}
-	}
-	return false
 }
 
 // worstAppHealth merges two health values (local copy of pkg/packages's
@@ -430,64 +847,3 @@ var systemNamespaces = map[string]bool{
 	"local-path-storage": true,
 }
 
-// knownAddonNames — interim add-on allowlist (mirrors radar-hub-web
-// packagesModel.KNOWN_ADDON_CHARTS; consolidate into the OSS catalog later).
-var knownAddonNames = map[string]bool{
-	"cert-manager": true, "argo-cd": true, "argocd": true, "argo-rollouts": true,
-	"argo-workflows": true, "argo-events": true, "flux": true, "flux2": true,
-	"karpenter": true, "external-secrets": true, "velero": true, "kyverno": true,
-	"kube-prometheus-stack": true, "prometheus": true, "prometheus-operator": true,
-	"grafana": true, "loki": true, "tempo": true, "mimir": true, "istio": true,
-	"istiod": true, "istio-base": true, "traefik": true, "cloudnative-pg": true,
-	"cnpg": true, "opentelemetry-operator": true, "opentelemetry-collector": true,
-	"keda": true, "cluster-api": true, "trivy-operator": true, "cilium": true,
-	"ingress-nginx": true, "nginx-ingress": true, "external-dns": true,
-	"metrics-server": true, "cluster-autoscaler": true, "sealed-secrets": true,
-	"vault": true, "fluent-bit": true, "fluentd": true, "vector": true,
-	"opencost": true, "kubecost": true, "reloader": true, "descheduler": true,
-	"aws-load-balancer-controller": true, "gatekeeper": true, "kube-state-metrics": true,
-	"coredns": true, "calico": true, "longhorn": true, "crossplane": true, "metallb": true,
-}
-
-// isAddonWorkload returns true when a workload belongs to 3rd-party platform
-// machinery (so it stays on Add-ons, not Applications). Matches the helm chart
-// name, app.kubernetes.io/name, part-of, or the workload name against the
-// allowlist — exact or hyphen-prefixed ("kube-prometheus-stack-…").
-func isAddonWorkload(lbls map[string]string, name string) bool {
-	candidates := []string{
-		chartBaseName(lbls["helm.sh/chart"]),
-		lbls["app.kubernetes.io/name"],
-		lbls["app.kubernetes.io/part-of"],
-		name,
-	}
-	for _, c := range candidates {
-		c = strings.ToLower(strings.TrimSpace(c))
-		if c == "" {
-			continue
-		}
-		if knownAddonNames[c] {
-			return true
-		}
-		for known := range knownAddonNames {
-			if strings.HasPrefix(c, known+"-") {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// chartBaseName strips a trailing -<version> from a helm.sh/chart value
-// ("cert-manager-v1.14.0" → "cert-manager").
-func chartBaseName(chart string) string {
-	for i := len(chart) - 1; i >= 1; i-- {
-		if chart[i-1] != '-' {
-			continue
-		}
-		c := chart[i]
-		if (c >= '0' && c <= '9') || c == 'v' {
-			return chart[:i-1]
-		}
-	}
-	return chart
-}

--- a/internal/server/applications.go
+++ b/internal/server/applications.go
@@ -182,11 +182,29 @@ func knnKey(kind, ns, name string) string {
 	return strings.ToLower(kind) + "|" + ns + "|" + name
 }
 
-// structuralRoot walks incoming EdgeManages edges from startID to the topmost
-// ancestor — the same walk pkg/topology uses for managed-by synthesis. The
-// topmost node is the app's structural root: a manager (ArgoCD Application,
-// Flux Kustomization/HelmRelease, generic-CRD owner) when one manages the
-// workload in-cluster, otherwise the workload's own top controller.
+// isGitOpsManagerKind reports whether a node is an in-cluster GitOps manager —
+// the boundary structuralRoot stops climbing AT. Above a manager lies either a
+// source ref (GitRepository → Kustomization is an EdgeManages edge too) or a
+// parent manager (app-of-apps); climbing THROUGH one would resolve every
+// installation sharing that source/parent to the same structural root and
+// union-find would merge them all into one app. ownerRef chains — including
+// operator CRs (CNPG Cluster, Strimzi Kafka) — are not managers and keep
+// climbing to the topmost owner.
+func isGitOpsManagerKind(k topology.NodeKind) bool {
+	switch k {
+	case topology.KindApplication, topology.KindKustomization, topology.KindHelmRelease:
+		return true
+	default:
+		return false
+	}
+}
+
+// structuralRoot walks incoming EdgeManages edges from startID toward the
+// app's structural root: the lowest in-cluster GitOps manager (ArgoCD
+// Application, Flux Kustomization/HelmRelease) when one manages the workload,
+// otherwise the workload's topmost ownerRef ancestor (incl. operator CRs). It
+// stops AT the first manager — it does not climb through to the manager's
+// source ref or parent manager.
 func (g *appGraph) structuralRoot(startID string) (topology.Node, bool) {
 	cur := startID
 	top, ok := g.byID[cur]
@@ -207,11 +225,15 @@ func (g *appGraph) structuralRoot(startID string) (topology.Node, bool) {
 			break
 		}
 		visited[next] = true
-		if n, exists := g.byID[next]; exists {
+		n, exists := g.byID[next]
+		if exists {
 			top = n
 			ok = true
 		}
 		cur = next
+		if exists && isGitOpsManagerKind(n.Kind) {
+			break
+		}
 	}
 	return top, ok
 }

--- a/internal/server/applications.go
+++ b/internal/server/applications.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -21,8 +22,9 @@ import (
 
 // Applications is the workload-centric twin of /api/packages. Where packages
 // answers "what software is installed" (chart/GitOps-declaration centric, the
-// Add-ons surface), Applications answers "what are MY services and what version
-// runs where" — the unit is a logical app.
+// Add-ons surface), Applications answers "what deployable/owned software units
+// run here, what runtime class they have, and what version they run" — the unit
+// is a logical app/release grouping over concrete workloads.
 //
 // What defines an app boundary: the K8s STRUCTURAL relationship graph is the
 // spine. A workload's app is its topmost EdgeManages ancestor — the root that
@@ -45,17 +47,18 @@ type applicationsResponse struct {
 
 // appRow is one logical app in this cluster.
 type appRow struct {
-	Key         string `json:"key"`                  // overlay key, structural-root key, or "<ns>/<kind>/<name>" raw
-	Name        string `json:"name"`                 // display name
-	Namespace   string `json:"namespace,omitempty"`  // grouping scope
-	Tier        int    `json:"tier,omitempty"`       // pkg/subject overlay tier (0 = raw, no signal)
-	Confidence  string `json:"confidence,omitempty"` // high | medium | low
-	Category    string `json:"category,omitempty"`   // "app" (your service) | "addon" (3rd-party platform machinery)
-	AddonReason string `json:"addonReason,omitempty"`// evidence when Category == "addon" — never hidden, always explained
-	Health      string `json:"health"`               // worst-of across workloads
-	Versions    []string          `json:"versions,omitempty"` // distinct image tags (the running version)
-	Workloads   []appWorkload     `json:"workloads"`
-	Events      []appEvent        `json:"events,omitempty"`        // recent Warning events across the app's workloads/pods
+	Key           string            `json:"key"`                      // overlay key, structural-root key, or "<ns>/<kind>/<name>" raw
+	Name          string            `json:"name"`                     // display name
+	Namespace     string            `json:"namespace,omitempty"`      // grouping scope
+	Tier          int               `json:"tier,omitempty"`           // pkg/subject overlay tier (0 = raw, no signal)
+	Confidence    string            `json:"confidence,omitempty"`     // high | medium | low
+	Category      string            `json:"category,omitempty"`       // app | addon | mixed; classification hint, never identity
+	AddonReason   string            `json:"addonReason,omitempty"`    // add-on evidence when Category == addon/mixed
+	WorkloadClass string            `json:"workload_class,omitempty"` // service | worker | job | unknown
+	Health        string            `json:"health"`                   // worst-of across workloads
+	Versions      []string          `json:"versions,omitempty"`       // distinct image tags (the running version)
+	Workloads     []appWorkload     `json:"workloads"`
+	Events        []appEvent        `json:"events,omitempty"`        // recent Warning events across the app's workloads/pods
 	Relationships *appRelationships `json:"relationships,omitempty"` // structural satellites attached via topology
 }
 
@@ -82,19 +85,20 @@ type appEvent struct {
 	LastSeen string `json:"lastSeen,omitempty"`
 }
 
-// appWorkload is one running controller (Deployment/StatefulSet/DaemonSet)
-// belonging to an app, with its primary container image as the version anchor.
+// appWorkload is one concrete workload belonging to an app, with its primary
+// container image as the version anchor when the workload has a pod template.
 type appWorkload struct {
-	Kind      string `json:"kind"`
-	Namespace string `json:"namespace"`
-	Name      string `json:"name"`
-	Image     string `json:"image,omitempty"`   // full primary-container image ref
-	Version   string `json:"version,omitempty"` // image tag (digest-only → empty)
-	Health    string `json:"health"`
-	Ready     int    `json:"ready"`            // ready/available replicas
-	Desired   int    `json:"desired"`          // desired replicas
-	Restarts  int    `json:"restarts"`         // total container restarts across the workload's pods
-	Reason    string `json:"reason,omitempty"` // last-terminated reason of the worst pod (CrashLoopBackOff/OOMKilled/…)
+	Kind          string `json:"kind"`
+	Namespace     string `json:"namespace"`
+	Name          string `json:"name"`
+	WorkloadClass string `json:"workload_class,omitempty"` // service | worker | job | unknown
+	Image         string `json:"image,omitempty"`          // full primary-container image ref
+	Version       string `json:"version,omitempty"`        // image tag (digest-only → empty)
+	Health        string `json:"health"`
+	Ready         int    `json:"ready"`            // ready/available replicas
+	Desired       int    `json:"desired"`          // desired replicas
+	Restarts      int    `json:"restarts"`         // total container restarts across the workload's pods
+	Reason        string `json:"reason,omitempty"` // last-terminated reason of the worst pod (CrashLoopBackOff/OOMKilled/…)
 }
 
 // handleListApplications serves GET /api/applications.
@@ -272,10 +276,11 @@ type appWorkloadInput struct {
 	addonWhy string
 }
 
-// collectAppWorkloads walks Deployments/StatefulSets/DaemonSets, captures the
-// primary container image + replica health, resolves each to its structural
-// root and label overlay, and classifies add-on machinery. Pods and Warning
-// events are indexed once per namespace and joined, not re-listed per workload.
+// collectAppWorkloads walks Deployments/StatefulSets/DaemonSets plus
+// Jobs/CronJobs, captures the primary container image + runtime health, resolves
+// each to its structural root and label overlay, and classifies add-on
+// machinery. Pods and Warning events are indexed once per namespace and joined,
+// not re-listed per workload.
 func collectAppWorkloads(cache *k8s.ResourceCache, namespaces []string, g *appGraph) []appWorkloadInput {
 	var out []appWorkloadInput
 
@@ -283,34 +288,29 @@ func collectAppWorkloads(cache *k8s.ResourceCache, namespaces []string, g *appGr
 	eventsByObj := indexWarningEventsByObject(cache, namespaces)
 
 	add := func(kind, ns, name string, lbls, anns map[string]string, image string, health packages.Health, ready, desired int, selector *metav1.LabelSelector) {
-		// Cluster plumbing (kube-proxy, kindnet, CNI, local-path) is K8s control
-		// plane, never a user service — exclude these namespaces outright. This
-		// is a namespace-scoped infra filter, distinct from add-on NAME matching
-		// below, which only classifies (never hides) user-namespace workloads.
-		if systemNamespaces[ns] {
-			return
-		}
 		pods := podsForSelector(podsByNS[ns], selector)
 		restarts, reason := podsRestarts(pods)
 		meta := metav1.ObjectMeta{Namespace: ns, Name: name, Labels: lbls, Annotations: anns}
 		rootKey, rootKind := g.rootOf(kind, ns, name)
+		rels := g.relationshipsFor(kind, ns, name)
 		addon, why := packages.ClassifyAddon(lbls["helm.sh/chart"], lbls["app.kubernetes.io/name"], lbls["app.kubernetes.io/part-of"], name)
 		out = append(out, appWorkloadInput{
 			wl: appWorkload{
-				Kind:      kind,
-				Namespace: ns,
-				Name:      name,
-				Image:     image,
-				Version:   imageTag(image),
-				Health:    string(health),
-				Ready:     ready,
-				Desired:   desired,
-				Restarts:  restarts,
-				Reason:    reason,
+				Kind:          kind,
+				Namespace:     ns,
+				Name:          name,
+				WorkloadClass: classifyWorkload(kind, rels),
+				Image:         image,
+				Version:       imageTag(image),
+				Health:        string(health),
+				Ready:         ready,
+				Desired:       desired,
+				Restarts:      restarts,
+				Reason:        reason,
 			},
 			overlay:  subject.ResolveOverlay(&meta, false),
 			events:   eventsForWorkload(eventsByObj[ns], name, pods),
-			rels:     g.relationshipsFor(kind, ns, name),
+			rels:     rels,
 			rootKey:  rootKey,
 			rootKind: rootKind,
 			addon:    addon,
@@ -373,6 +373,41 @@ func collectAppWorkloads(cache *k8s.ResourceCache, namespaces []string, g *appGr
 					primaryImage(d.Spec.Template.Spec.Containers),
 					statefulsetHealth(int(d.Status.Replicas), int(d.Status.ReadyReplicas)),
 					int(d.Status.ReadyReplicas), int(d.Status.Replicas), d.Spec.Selector)
+			}
+		})
+	}
+	if jobLister := cache.Jobs(); jobLister != nil {
+		forEachNamespace(func(ns string) {
+			var items []*batchv1.Job
+			if ns == "" {
+				items, _ = jobLister.List(labels.Everything())
+			} else {
+				items, _ = jobLister.Jobs(ns).List(labels.Everything())
+			}
+			for _, j := range items {
+				if ownedByCronJob(j) {
+					continue
+				}
+				add("Job", j.Namespace, j.Name, j.Labels, j.Annotations,
+					primaryImage(j.Spec.Template.Spec.Containers),
+					jobHealth(j),
+					int(j.Status.Succeeded), jobDesired(j), j.Spec.Selector)
+			}
+		})
+	}
+	if cjLister := cache.CronJobs(); cjLister != nil {
+		forEachNamespace(func(ns string) {
+			var items []*batchv1.CronJob
+			if ns == "" {
+				items, _ = cjLister.List(labels.Everything())
+			} else {
+				items, _ = cjLister.CronJobs(ns).List(labels.Everything())
+			}
+			for _, cj := range items {
+				add("CronJob", cj.Namespace, cj.Name, cj.Labels, cj.Annotations,
+					primaryImage(cj.Spec.JobTemplate.Spec.Template.Spec.Containers),
+					cronJobHealth(cj),
+					0, 0, nil)
 			}
 		})
 	}
@@ -493,14 +528,8 @@ func identifyApp(r *appRow, ins []appWorkloadInput) {
 		}
 	}
 
-	r.Category = "app"
-	for _, in := range ins {
-		if in.addon {
-			r.Category = "addon"
-			r.AddonReason = in.addonWhy
-			break
-		}
-	}
+	r.Category, r.AddonReason = classifyAppCategory(ins)
+	r.WorkloadClass = classifyAppWorkloads(ins)
 }
 
 // pickRoot prefers a GitOps-manager root over a raw workload root for identity.
@@ -572,6 +601,76 @@ func finalizeRelationships(r *appRow) {
 	r.Relationships.Services = dedupSorted(r.Relationships.Services, 20)
 	r.Relationships.Ingresses = dedupSorted(r.Relationships.Ingresses, 20)
 	r.Relationships.Routes = dedupSorted(r.Relationships.Routes, 20)
+}
+
+func classifyWorkload(kind string, rels *appRelationships) string {
+	switch kind {
+	case "Job", "CronJob":
+		return "job"
+	case "Deployment", "StatefulSet", "DaemonSet":
+		if rels != nil && (len(rels.Services) > 0 || len(rels.Ingresses) > 0 || len(rels.Routes) > 0) {
+			return "service"
+		}
+		return "worker"
+	default:
+		return "unknown"
+	}
+}
+
+func classifyAppWorkloads(ins []appWorkloadInput) string {
+	seenService := false
+	seenWorker := false
+	seenJob := false
+	seenUnknown := false
+	for _, in := range ins {
+		switch in.wl.WorkloadClass {
+		case "service":
+			seenService = true
+		case "worker":
+			seenWorker = true
+		case "job":
+			seenJob = true
+		default:
+			seenUnknown = true
+		}
+	}
+	switch {
+	case seenService && !seenJob && !seenUnknown:
+		// A deployable unit with an API Deployment and a background worker is
+		// still operated primarily as a service.
+		return "service"
+	case seenWorker && !seenService && !seenJob && !seenUnknown:
+		return "worker"
+	case seenJob && !seenService && !seenWorker && !seenUnknown:
+		return "job"
+	default:
+		return "unknown"
+	}
+}
+
+func classifyAppCategory(ins []appWorkloadInput) (category, reason string) {
+	addonCount := 0
+	reasons := []string{}
+	for _, in := range ins {
+		if !in.addon {
+			continue
+		}
+		addonCount++
+		if in.addonWhy != "" && !slices.Contains(reasons, in.addonWhy) {
+			reasons = append(reasons, in.addonWhy)
+		}
+	}
+	if addonCount == 0 {
+		return "app", ""
+	}
+	reason = strings.Join(reasons, "; ")
+	if addonCount == len(ins) {
+		return "addon", reason
+	}
+	if reason != "" {
+		reason = "mixed add-on evidence: " + reason
+	}
+	return "mixed", reason
 }
 
 // --- small helpers --------------------------------------------------------
@@ -765,7 +864,7 @@ func eventsForWorkload(byObject map[string][]*corev1.Event, workloadName string,
 			}
 			byKey[key] = &appEvent{
 				Type: e.Type, Reason: e.Reason, Message: e.Message, Count: c,
-				Object: e.InvolvedObject.Kind + "/" + e.InvolvedObject.Name,
+				Object:   e.InvolvedObject.Kind + "/" + e.InvolvedObject.Name,
 				LastSeen: e.LastTimestamp.Format(time.RFC3339),
 			}
 			order = append(order, key)
@@ -793,6 +892,47 @@ func imageTag(image string) string {
 		return image[colon+1:]
 	}
 	return ""
+}
+
+func ownedByCronJob(j *batchv1.Job) bool {
+	for _, owner := range j.OwnerReferences {
+		if owner.Kind == "CronJob" {
+			return true
+		}
+	}
+	return false
+}
+
+func jobDesired(j *batchv1.Job) int {
+	if j.Spec.Completions != nil && *j.Spec.Completions > 0 {
+		return int(*j.Spec.Completions)
+	}
+	return 1
+}
+
+func jobHealth(j *batchv1.Job) packages.Health {
+	for _, c := range j.Status.Conditions {
+		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
+			return packages.HealthUnhealthy
+		}
+		if c.Type == batchv1.JobComplete && c.Status == corev1.ConditionTrue {
+			return packages.HealthHealthy
+		}
+	}
+	if int(j.Status.Succeeded) >= jobDesired(j) {
+		return packages.HealthHealthy
+	}
+	if j.Status.Failed > 0 && j.Status.Active == 0 && j.Status.Succeeded == 0 {
+		return packages.HealthUnhealthy
+	}
+	if j.Status.Active > 0 {
+		return packages.HealthHealthy
+	}
+	return packages.HealthUnknown
+}
+
+func cronJobHealth(cj *batchv1.CronJob) packages.Health {
+	return packages.HealthHealthy
 }
 
 func appNameFromKey(key string) string {
@@ -838,12 +978,3 @@ func appHealthRank(h packages.Health) int {
 	}
 	return 2
 }
-
-// systemNamespaces hold cluster plumbing, never user services.
-var systemNamespaces = map[string]bool{
-	"kube-system":        true,
-	"kube-public":        true,
-	"kube-node-lease":    true,
-	"local-path-storage": true,
-}
-

--- a/internal/server/applications.go
+++ b/internal/server/applications.go
@@ -1,0 +1,493 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/pkg/packages"
+	"github.com/skyhook-io/radar/pkg/subject"
+)
+
+// Applications is the workload-centric twin of /api/packages. Where packages
+// answers "what software is installed" (chart/GitOps-declaration centric, the
+// Add-ons surface), Applications answers "what are MY services and what version
+// runs where" — the unit is a logical app: the set of workloads sharing a
+// pkg/subject Tier-2 app-overlay key, anchored on the container image:tag (the
+// real running version, not a chart version that's empty for git-based apps).
+//
+// Why a separate path (not the packages feed): collectWorkloadInputs only
+// admits Helm-labeled workloads and carries no image, so the packages feed
+// structurally cannot represent a non-Helm app's services or their versions.
+// See ADDONS-AND-APPLICATIONS-PLAN.md §8.3 (the row-identity change) — this is
+// that change done on the right entities.
+
+// applicationsResponse is the GET /api/applications body.
+type applicationsResponse struct {
+	Applications []appRow `json:"applications"`
+}
+
+// appRow is one logical app in this cluster: workloads collapsed by app-overlay
+// key. Raw-always: a workload with no app signal (no overlay) is its own row
+// keyed by "<ns>/<kind>/<name>" — nothing is hidden.
+type appRow struct {
+	Key        string         `json:"key"`                  // overlay key, or "<ns>/<kind>/<name>" raw
+	Name       string         `json:"name"`                 // display name
+	Namespace  string         `json:"namespace,omitempty"`  // overlay namespace (grouping scope)
+	Tier       int            `json:"tier,omitempty"`       // pkg/subject overlay tier (0 = raw, no overlay)
+	Confidence string         `json:"confidence,omitempty"` // high | medium | low
+	Health     string         `json:"health"`               // worst-of across workloads
+	Versions   []string       `json:"versions,omitempty"`   // distinct image tags (the running version)
+	Workloads  []appWorkload  `json:"workloads"`
+	Events     []appEvent     `json:"events,omitempty"`     // recent Warning events across the app's workloads/pods
+}
+
+// appEvent is a recent k8s Warning event correlated to an app's workloads/pods
+// (the "why is it broken" feed — BackOff, FailedScheduling, FailedMount, …).
+type appEvent struct {
+	Type     string `json:"type"`
+	Reason   string `json:"reason"`
+	Message  string `json:"message,omitempty"`
+	Count    int    `json:"count"`
+	Object   string `json:"object"` // "<Kind>/<name>"
+	LastSeen string `json:"lastSeen,omitempty"`
+}
+
+// appWorkload is one running controller (Deployment/StatefulSet/DaemonSet)
+// belonging to an app, with its primary container image as the version anchor.
+type appWorkload struct {
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	Image     string `json:"image,omitempty"`   // full primary-container image ref
+	Version   string `json:"version,omitempty"` // image tag (digest-only → empty)
+	Health    string `json:"health"`
+	Ready     int    `json:"ready"`             // ready/available replicas
+	Desired   int    `json:"desired"`           // desired replicas
+	Restarts  int    `json:"restarts"`          // total container restarts across the workload's pods
+	Reason    string `json:"reason,omitempty"`  // last-terminated reason of the worst pod (CrashLoopBackOff/OOMKilled/…)
+}
+
+// handleListApplications serves GET /api/applications.
+//
+//	?namespaces=a,b,c | ?namespace=a — limit to workloads in the namespace set.
+func (s *Server) handleListApplications(w http.ResponseWriter, r *http.Request) {
+	if !s.requireConnected(w) {
+		return
+	}
+	namespaces := s.parseNamespacesForUser(r)
+	resp, err := ListApplications(r.Context(), namespaces)
+	if err != nil {
+		if err == errResourceCacheUnavailable {
+			s.writeError(w, http.StatusServiceUnavailable, err.Error())
+			return
+		}
+		s.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.writeJSON(w, resp)
+}
+
+// ListApplications enumerates the cluster's app workloads, resolves each to its
+// pkg/subject app-overlay, and groups them into logical apps. Add-on workloads
+// (cert-manager et al.) are excluded — they belong to the Add-ons surface.
+func ListApplications(ctx context.Context, namespaces []string) (*applicationsResponse, error) {
+	cache := k8s.GetResourceCache()
+	if cache == nil {
+		return nil, errResourceCacheUnavailable
+	}
+	wls := collectAppWorkloads(cache, namespaces)
+	return &applicationsResponse{Applications: groupApplications(wls)}, nil
+}
+
+// appWorkloadInput is the pre-grouping shape: a workload plus its resolved
+// overlay (nil when no app signal at/above tier 7).
+type appWorkloadInput struct {
+	wl      appWorkload
+	overlay *subject.AppOverlay
+	events  []appEvent
+}
+
+// collectAppWorkloads walks Deployments/StatefulSets/DaemonSets, captures the
+// primary container image, resolves the app-overlay, and drops add-on workloads.
+func collectAppWorkloads(cache *k8s.ResourceCache, namespaces []string) []appWorkloadInput {
+	var out []appWorkloadInput
+
+	add := func(kind, ns, name string, lbls, anns map[string]string, image string, health packages.Health, ready, desired int, selector *metav1.LabelSelector) {
+		// Cluster plumbing (kube-proxy, kindnet, CNI, local-path) is never a
+		// user service — exclude system namespaces outright.
+		if systemNamespaces[ns] {
+			return
+		}
+		// Add-ons live on their own surface — keep 3rd-party platform machinery
+		// out of "your services". (Interim chart/name match; consolidate with
+		// the SPA's KNOWN_ADDON list + OSS catalog later — plan §12 Q3.)
+		if isAddonWorkload(lbls, name) {
+			return
+		}
+		// One pod fetch powers both restarts (crashloop signal) and the Warning
+		// event feed (image-pull / scheduling / mount failures restarts miss).
+		var pods []*corev1.Pod
+		if selector != nil {
+			pods = cache.GetPodsForWorkload(ns, selector)
+		}
+		restarts, reason := podsRestarts(pods)
+		meta := metav1.ObjectMeta{Namespace: ns, Name: name, Labels: lbls, Annotations: anns}
+		ov := subject.ResolveOverlay(&meta, false)
+		out = append(out, appWorkloadInput{
+			wl: appWorkload{
+				Kind:      kind,
+				Namespace: ns,
+				Name:      name,
+				Image:     image,
+				Version:   imageTag(image),
+				Health:    string(health),
+				Ready:     ready,
+				Desired:   desired,
+				Restarts:  restarts,
+				Reason:    reason,
+			},
+			overlay: ov,
+			events:  podsEvents(cache, ns, name, pods),
+		})
+	}
+
+	forEachNamespace := func(fn func(ns string)) {
+		if namespaces == nil {
+			fn("")
+			return
+		}
+		for _, ns := range namespaces {
+			fn(ns)
+		}
+	}
+
+	if depLister := cache.Deployments(); depLister != nil {
+		forEachNamespace(func(ns string) {
+			var items []*appsv1.Deployment
+			if ns == "" {
+				items, _ = depLister.List(labels.Everything())
+			} else {
+				items, _ = depLister.Deployments(ns).List(labels.Everything())
+			}
+			for _, d := range items {
+				add("Deployment", d.Namespace, d.Name, d.Labels, d.Annotations,
+					primaryImage(d.Spec.Template.Spec.Containers),
+					deploymentHealth(int(d.Status.Replicas), int(d.Status.AvailableReplicas)),
+					int(d.Status.AvailableReplicas), int(d.Status.Replicas), d.Spec.Selector)
+			}
+		})
+	}
+	if dsLister := cache.DaemonSets(); dsLister != nil {
+		forEachNamespace(func(ns string) {
+			var items []*appsv1.DaemonSet
+			if ns == "" {
+				items, _ = dsLister.List(labels.Everything())
+			} else {
+				items, _ = dsLister.DaemonSets(ns).List(labels.Everything())
+			}
+			for _, d := range items {
+				add("DaemonSet", d.Namespace, d.Name, d.Labels, d.Annotations,
+					primaryImage(d.Spec.Template.Spec.Containers),
+					daemonsetHealth(int(d.Status.DesiredNumberScheduled), int(d.Status.NumberReady)),
+					int(d.Status.NumberReady), int(d.Status.DesiredNumberScheduled), d.Spec.Selector)
+			}
+		})
+	}
+	if ssLister := cache.StatefulSets(); ssLister != nil {
+		forEachNamespace(func(ns string) {
+			var items []*appsv1.StatefulSet
+			if ns == "" {
+				items, _ = ssLister.List(labels.Everything())
+			} else {
+				items, _ = ssLister.StatefulSets(ns).List(labels.Everything())
+			}
+			for _, d := range items {
+				add("StatefulSet", d.Namespace, d.Name, d.Labels, d.Annotations,
+					primaryImage(d.Spec.Template.Spec.Containers),
+					statefulsetHealth(int(d.Status.Replicas), int(d.Status.ReadyReplicas)),
+					int(d.Status.ReadyReplicas), int(d.Status.Replicas), d.Spec.Selector)
+			}
+		})
+	}
+	return out
+}
+
+// groupApplications collapses workloads by app-overlay key. Workloads with no
+// overlay (raw-always) become their own single-workload row keyed on identity.
+func groupApplications(inputs []appWorkloadInput) []appRow {
+	rows := map[string]*appRow{}
+	order := []string{}
+	for _, in := range inputs {
+		var key, name, ns string
+		var tier int
+		var conf string
+		if in.overlay != nil {
+			win := in.overlay.Winner
+			key = win.Key
+			name = appNameFromKey(win.Key)
+			ns = namespaceFromKey(win.Key)
+			tier = int(win.Tier)
+			conf = string(win.Confidence)
+		} else {
+			// Raw-always: identifiable on its own, never hidden.
+			key = in.wl.Namespace + "/" + in.wl.Kind + "/" + in.wl.Name
+			name = in.wl.Name
+			ns = in.wl.Namespace
+		}
+		r, ok := rows[key]
+		if !ok {
+			r = &appRow{Key: key, Name: name, Namespace: ns, Tier: tier, Confidence: conf}
+			rows[key] = r
+			order = append(order, key)
+		}
+		r.Workloads = append(r.Workloads, in.wl)
+		r.Events = append(r.Events, in.events...)
+		r.Health = string(worstAppHealth(packages.Health(r.Health), packages.Health(in.wl.Health)))
+		if v := in.wl.Version; v != "" && !contains(r.Versions, v) {
+			r.Versions = append(r.Versions, v)
+		}
+	}
+	out := make([]appRow, 0, len(order))
+	for _, k := range order {
+		r := rows[k]
+		sort.Strings(r.Versions)
+		// Newest events first; cap the feed.
+		sort.SliceStable(r.Events, func(i, j int) bool { return r.Events[i].LastSeen > r.Events[j].LastSeen })
+		if len(r.Events) > 12 {
+			r.Events = r.Events[:12]
+		}
+		out = append(out, *r)
+	}
+	// Deterministic: by name then key.
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].Key < out[j].Key
+	})
+	return out
+}
+
+// --- small helpers --------------------------------------------------------
+
+// primaryImage returns the first container's image (the conventional "the app"
+// container — mirrors pkg/ai/context/summary.go's first-container choice).
+func primaryImage(containers []corev1.Container) string {
+	if len(containers) > 0 {
+		return containers[0].Image
+	}
+	return ""
+}
+
+// podsRestarts sums container restarts across a workload's pods and returns the
+// last-terminated reason of the worst (most-restarting) pod — the crash signal
+// (CrashLoopBackOff / OOMKilled / Error).
+func podsRestarts(pods []*corev1.Pod) (int, string) {
+	total := 0
+	var worst int32 = -1
+	reason := ""
+	for _, p := range pods {
+		rc, r := k8s.PodRestartContext(p)
+		total += int(rc)
+		if rc > worst {
+			worst = rc
+			reason = r
+		}
+	}
+	return total, reason
+}
+
+// podsEvents collects recent Warning events involving the workload or its pods,
+// deduped by (object, reason) with summed counts — the "why is it broken" feed
+// (FailedScheduling, ImagePullBackOff, FailedMount, …) that restarts alone miss.
+func podsEvents(cache *k8s.ResourceCache, ns, workloadName string, pods []*corev1.Pod) []appEvent {
+	lister := cache.Events()
+	if lister == nil {
+		return nil
+	}
+	names := map[string]bool{workloadName: true}
+	for _, p := range pods {
+		names[p.Name] = true
+	}
+	evs, err := lister.Events(ns).List(labels.Everything())
+	if err != nil {
+		return nil
+	}
+	byKey := map[string]*appEvent{}
+	order := []string{}
+	for _, e := range evs {
+		if e.Type != "Warning" || !names[e.InvolvedObject.Name] {
+			continue
+		}
+		key := e.InvolvedObject.Kind + "/" + e.InvolvedObject.Name + "/" + e.Reason
+		c := int(e.Count)
+		if c < 1 {
+			c = 1
+		}
+		if a, ok := byKey[key]; ok {
+			a.Count += c
+			if ts := e.LastTimestamp.Format(time.RFC3339); ts > a.LastSeen {
+				a.LastSeen = ts
+				a.Message = e.Message
+			}
+			continue
+		}
+		ae := &appEvent{Type: e.Type, Reason: e.Reason, Message: e.Message, Count: c, Object: e.InvolvedObject.Kind + "/" + e.InvolvedObject.Name, LastSeen: e.LastTimestamp.Format(time.RFC3339)}
+		byKey[key] = ae
+		order = append(order, key)
+	}
+	out := make([]appEvent, 0, len(order))
+	for _, k := range order {
+		out = append(out, *byKey[k])
+	}
+	return out
+}
+
+// imageTag extracts the tag from an image ref. Digest-pinned refs (@sha256:…)
+// and untagged refs (implicit :latest) return "" — no false version.
+func imageTag(image string) string {
+	if image == "" {
+		return ""
+	}
+	if at := strings.Index(image, "@"); at >= 0 {
+		image = image[:at]
+	}
+	slash := strings.LastIndex(image, "/")
+	colon := strings.LastIndex(image, ":")
+	if colon > slash {
+		return image[colon+1:]
+	}
+	return ""
+}
+
+func appNameFromKey(key string) string {
+	if i := strings.LastIndex(key, "/"); i >= 0 && i < len(key)-1 {
+		return key[i+1:]
+	}
+	return key
+}
+
+func namespaceFromKey(key string) string {
+	if i := strings.Index(key, "/"); i > 0 {
+		return key[:i]
+	}
+	return ""
+}
+
+func contains(ss []string, s string) bool {
+	for _, x := range ss {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
+// worstAppHealth merges two health values (local copy of pkg/packages's
+// unexported worseHealth): unhealthy > degraded > unknown > healthy; "" defers
+// to the other side.
+func worstAppHealth(a, b packages.Health) packages.Health {
+	if a == "" {
+		return b
+	}
+	if b == "" {
+		return a
+	}
+	if appHealthRank(a) >= appHealthRank(b) {
+		return a
+	}
+	return b
+}
+
+func appHealthRank(h packages.Health) int {
+	switch h {
+	case packages.HealthUnhealthy:
+		return 4
+	case packages.HealthDegraded:
+		return 3
+	case packages.HealthUnknown:
+		return 2
+	case packages.HealthHealthy:
+		return 1
+	}
+	return 2
+}
+
+// systemNamespaces hold cluster plumbing, never user services.
+var systemNamespaces = map[string]bool{
+	"kube-system":        true,
+	"kube-public":        true,
+	"kube-node-lease":    true,
+	"local-path-storage": true,
+}
+
+// knownAddonNames — interim add-on allowlist (mirrors radar-hub-web
+// packagesModel.KNOWN_ADDON_CHARTS; consolidate into the OSS catalog later).
+var knownAddonNames = map[string]bool{
+	"cert-manager": true, "argo-cd": true, "argocd": true, "argo-rollouts": true,
+	"argo-workflows": true, "argo-events": true, "flux": true, "flux2": true,
+	"karpenter": true, "external-secrets": true, "velero": true, "kyverno": true,
+	"kube-prometheus-stack": true, "prometheus": true, "prometheus-operator": true,
+	"grafana": true, "loki": true, "tempo": true, "mimir": true, "istio": true,
+	"istiod": true, "istio-base": true, "traefik": true, "cloudnative-pg": true,
+	"cnpg": true, "opentelemetry-operator": true, "opentelemetry-collector": true,
+	"keda": true, "cluster-api": true, "trivy-operator": true, "cilium": true,
+	"ingress-nginx": true, "nginx-ingress": true, "external-dns": true,
+	"metrics-server": true, "cluster-autoscaler": true, "sealed-secrets": true,
+	"vault": true, "fluent-bit": true, "fluentd": true, "vector": true,
+	"opencost": true, "kubecost": true, "reloader": true, "descheduler": true,
+	"aws-load-balancer-controller": true, "gatekeeper": true, "kube-state-metrics": true,
+	"coredns": true, "calico": true, "longhorn": true, "crossplane": true, "metallb": true,
+}
+
+// isAddonWorkload returns true when a workload belongs to 3rd-party platform
+// machinery (so it stays on Add-ons, not Applications). Matches the helm chart
+// name, app.kubernetes.io/name, part-of, or the workload name against the
+// allowlist — exact or hyphen-prefixed ("kube-prometheus-stack-…").
+func isAddonWorkload(lbls map[string]string, name string) bool {
+	candidates := []string{
+		chartBaseName(lbls["helm.sh/chart"]),
+		lbls["app.kubernetes.io/name"],
+		lbls["app.kubernetes.io/part-of"],
+		name,
+	}
+	for _, c := range candidates {
+		c = strings.ToLower(strings.TrimSpace(c))
+		if c == "" {
+			continue
+		}
+		if knownAddonNames[c] {
+			return true
+		}
+		for known := range knownAddonNames {
+			if strings.HasPrefix(c, known+"-") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// chartBaseName strips a trailing -<version> from a helm.sh/chart value
+// ("cert-manager-v1.14.0" → "cert-manager").
+func chartBaseName(chart string) string {
+	for i := len(chart) - 1; i >= 1; i-- {
+		if chart[i-1] != '-' {
+			continue
+		}
+		c := chart[i]
+		if (c >= '0' && c <= '9') || c == 'v' {
+			return chart[:i-1]
+		}
+	}
+	return chart
+}

--- a/internal/server/applications_test.go
+++ b/internal/server/applications_test.go
@@ -1,0 +1,158 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/skyhook-io/radar/pkg/packages"
+	"github.com/skyhook-io/radar/pkg/subject"
+)
+
+// rawInput builds a workload with no label overlay and its own structural root
+// (a singleton, raw-always).
+func rawInput(kind, ns, name, version, health string) appWorkloadInput {
+	return appWorkloadInput{
+		wl:       appWorkload{Kind: kind, Namespace: ns, Name: name, Version: version, Health: health},
+		rootKey:  ns + "/" + kind + "/" + name,
+		rootKind: kind,
+	}
+}
+
+// overlayInput builds a workload carrying a Tier-2 label overlay (Argo/Flux/Helm
+// /part-of), keyed by its own structural root.
+func overlayInput(kind, ns, name, version, health string, tier subject.Tier, key string, conf subject.Confidence) appWorkloadInput {
+	in := rawInput(kind, ns, name, version, health)
+	in.overlay = &subject.AppOverlay{Winner: subject.Signal{Tier: tier, Key: key, Confidence: conf}}
+	return in
+}
+
+func rowByName(rows []appRow, name string) *appRow {
+	for i := range rows {
+		if rows[i].Name == name {
+			return &rows[i]
+		}
+	}
+	return nil
+}
+
+// A label overlay shared by two workloads collapses them into one app; an
+// unrelated raw workload stays its own app (raw-always).
+func TestGroupApplications_OverlayConsolidationAndRawAlways(t *testing.T) {
+	rows := groupApplications([]appWorkloadInput{
+		overlayInput("Deployment", "prod", "api", "1.2.0", "healthy", subject.TierPartOf, "prod/app/checkout", subject.ConfidenceMedium),
+		overlayInput("Deployment", "prod", "worker", "1.2.0", "healthy", subject.TierPartOf, "prod/app/checkout", subject.ConfidenceMedium),
+		rawInput("StatefulSet", "prod", "lonely-db", "15", "healthy"),
+	})
+
+	if len(rows) != 2 {
+		t.Fatalf("want 2 apps (checkout + lonely-db), got %d: %+v", len(rows), rows)
+	}
+	checkout := rowByName(rows, "checkout")
+	if checkout == nil {
+		t.Fatalf("checkout app missing: %+v", rows)
+	}
+	if len(checkout.Workloads) != 2 {
+		t.Errorf("checkout should hold api+worker (2 workloads), got %d", len(checkout.Workloads))
+	}
+	if checkout.Tier != int(subject.TierPartOf) || checkout.Confidence != string(subject.ConfidenceMedium) {
+		t.Errorf("checkout tier/confidence = %d/%s, want %d/%s", checkout.Tier, checkout.Confidence, subject.TierPartOf, subject.ConfidenceMedium)
+	}
+	lonely := rowByName(rows, "lonely-db")
+	if lonely == nil || lonely.Tier != 0 || len(lonely.Workloads) != 1 {
+		t.Errorf("lonely-db should be a raw single-workload app at tier 0, got %+v", lonely)
+	}
+}
+
+// ArgoCD tracking-id mode ("<ns>/Application/<name>") and instance-label mode
+// ("/Application/<name>", empty ns) name the same app — they must collapse into
+// one row. This is the declaration/workload-collapse fix.
+func TestGroupApplications_ArgoTrackingModesCollapse(t *testing.T) {
+	rows := groupApplications([]appWorkloadInput{
+		overlayInput("Deployment", "prod", "api", "2.0.0", "healthy", subject.TierArgoTrackingID, "argocd/Application/storefront", subject.ConfidenceHigh),
+		overlayInput("Deployment", "prod", "cache", "7.2", "healthy", subject.TierArgoInstance, "/Application/storefront", subject.ConfidenceHigh),
+	})
+
+	if len(rows) != 1 {
+		t.Fatalf("Argo tracking-id + instance modes must collapse to 1 app, got %d: %+v", len(rows), rows)
+	}
+	if len(rows[0].Workloads) != 2 {
+		t.Errorf("collapsed Argo app should hold both workloads, got %d", len(rows[0].Workloads))
+	}
+	// Tracking-id (tier 3) outranks instance (tier 4) for identity.
+	if rows[0].Tier != int(subject.TierArgoTrackingID) {
+		t.Errorf("identity tier = %d, want tracking-id %d", rows[0].Tier, subject.TierArgoTrackingID)
+	}
+}
+
+// An in-cluster GitOps manager (an ArgoCD Application node managing workloads
+// via EdgeManages) collapses its workloads even when they carry no label, and
+// its kind synthesizes provenance (Argo/Flux tier) for the surface.
+func TestGroupApplications_StructuralManagerRoot(t *testing.T) {
+	// Two unlabeled Deployments whose structural root is the same Argo App node.
+	a := rawInput("Deployment", "prod", "api", "3.1.0", "healthy")
+	a.rootKey, a.rootKind = "argocd/Application/billing", "Application"
+	b := rawInput("Deployment", "prod", "worker", "3.1.0", "degraded")
+	b.rootKey, b.rootKind = "argocd/Application/billing", "Application"
+
+	rows := groupApplications([]appWorkloadInput{a, b})
+	if len(rows) != 1 {
+		t.Fatalf("workloads under one Argo App must be one app, got %d: %+v", len(rows), rows)
+	}
+	r := rows[0]
+	if r.Name != "billing" || len(r.Workloads) != 2 {
+		t.Errorf("billing app malformed: name=%q workloads=%d", r.Name, len(r.Workloads))
+	}
+	if r.Tier != int(subject.TierArgoTrackingID) || r.Confidence != string(subject.ConfidenceHigh) {
+		t.Errorf("structural Argo root should synthesize Argo tier/high, got %d/%s", r.Tier, r.Confidence)
+	}
+	if r.Health != "degraded" {
+		t.Errorf("app health is worst-of workloads, want degraded got %q", r.Health)
+	}
+}
+
+// Over-merge guardrail: two distinct apps that share a satellite Service must
+// NOT fuse. Satellites are attached, never used to partition.
+func TestGroupApplications_SharedSatelliteDoesNotMerge(t *testing.T) {
+	a := overlayInput("Deployment", "prod", "api", "1.0", "healthy", subject.TierPartOf, "prod/app/alpha", subject.ConfidenceMedium)
+	a.rels = &appRelationships{Services: []string{"shared-gateway"}}
+	b := overlayInput("Deployment", "prod", "web", "1.0", "healthy", subject.TierPartOf, "prod/app/beta", subject.ConfidenceMedium)
+	b.rels = &appRelationships{Services: []string{"shared-gateway"}}
+
+	rows := groupApplications([]appWorkloadInput{a, b})
+	if len(rows) != 2 {
+		t.Fatalf("apps sharing only a Service must stay separate, got %d: %+v", len(rows), rows)
+	}
+	for _, r := range rows {
+		if r.Relationships == nil || len(r.Relationships.Services) != 1 || r.Relationships.Services[0] != "shared-gateway" {
+			t.Errorf("each app should still list the shared service, got %+v", r.Relationships)
+		}
+	}
+}
+
+// Add-ons are classified with evidence, never dropped (raw-always). A user
+// workload named "grafana" still appears — tagged, explained, foldable.
+func TestClassifyAddon_ClassifiesNotHides(t *testing.T) {
+	addon, why := packages.ClassifyAddon("", "grafana", "", "grafana-0")
+	if !addon || why == "" {
+		t.Fatalf("grafana should classify as addon with evidence, got addon=%v why=%q", addon, why)
+	}
+
+	rows := groupApplications([]appWorkloadInput{
+		func() appWorkloadInput {
+			in := rawInput("Deployment", "monitoring", "grafana", "10.0", "healthy")
+			in.addon, in.addonWhy = packages.ClassifyAddon("", "grafana", "", "grafana")
+			return in
+		}(),
+		rawInput("Deployment", "prod", "my-service", "1.0", "healthy"),
+	})
+	if len(rows) != 2 {
+		t.Fatalf("add-on must remain a row (not dropped), got %d apps", len(rows))
+	}
+	g := rowByName(rows, "grafana")
+	if g == nil || g.Category != "addon" || g.AddonReason == "" {
+		t.Errorf("grafana row should be Category=addon with a reason, got %+v", g)
+	}
+	svc := rowByName(rows, "my-service")
+	if svc == nil || svc.Category != "app" {
+		t.Errorf("my-service should be Category=app, got %+v", svc)
+	}
+}

--- a/internal/server/applications_test.go
+++ b/internal/server/applications_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/skyhook-io/radar/pkg/packages"
 	"github.com/skyhook-io/radar/pkg/subject"
+	"github.com/skyhook-io/radar/pkg/topology"
 )
 
 // rawInput builds a workload with no label overlay and its own structural root
@@ -125,6 +126,55 @@ func TestGroupApplications_SharedSatelliteDoesNotMerge(t *testing.T) {
 		if r.Relationships == nil || len(r.Relationships.Services) != 1 || r.Relationships.Services[0] != "shared-gateway" {
 			t.Errorf("each app should still list the shared service, got %+v", r.Relationships)
 		}
+	}
+}
+
+// structuralRoot must stop AT the in-cluster GitOps manager (Flux
+// Kustomization) and NOT climb the EdgeManages edge to the GitRepository source
+// that feeds it. The topology builder models GitRepository → Kustomization as
+// EdgeManages too, so without the stop-at-manager rule a Flux mono-repo (one
+// GitRepository sourcing N Kustomizations) resolves every workload to the same
+// GitRepository root and union-find merges all installations into one app.
+func TestStructuralRoot_StopsAtManagerNotSource(t *testing.T) {
+	node := func(id, kind, ns, name string) topology.Node {
+		return topology.Node{ID: id, Kind: topology.NodeKind(kind), Name: name, Data: map[string]any{"namespace": ns}}
+	}
+	manages := func(src, dst string) topology.Edge {
+		return topology.Edge{ID: src + "->" + dst, Source: src, Target: dst, Type: topology.EdgeManages}
+	}
+	topo := &topology.Topology{
+		Nodes: []topology.Node{
+			node("gitrepo", "GitRepository", "flux-system", "monorepo"),
+			node("ks-apps", "Kustomization", "flux-system", "apps"),
+			node("ks-infra", "Kustomization", "flux-system", "infrastructure"),
+			node("dep-api", "Deployment", "prod", "api"),
+			node("dep-grafana", "Deployment", "monitoring", "grafana"),
+		},
+		Edges: []topology.Edge{
+			manages("gitrepo", "ks-apps"),       // source ref — must NOT be climbed through
+			manages("gitrepo", "ks-infra"),      // source ref — must NOT be climbed through
+			manages("ks-apps", "dep-api"),       // manager → workload
+			manages("ks-infra", "dep-grafana"),  // manager → workload
+		},
+	}
+	g := &appGraph{byID: map[string]topology.Node{}, byKNN: map[string]string{}, topo: topo, idx: topology.IndexByResource(topo)}
+	for _, n := range topo.Nodes {
+		g.byID[n.ID] = n
+		ns, _ := n.Data["namespace"].(string)
+		g.byKNN[knnKey(string(n.Kind), ns, n.Name)] = n.ID
+	}
+
+	apiRoot, _ := g.rootOf("Deployment", "prod", "api")
+	grafanaRoot, _ := g.rootOf("Deployment", "monitoring", "grafana")
+
+	if apiRoot != "flux-system/Kustomization/apps" {
+		t.Errorf("api root = %q, want the apps Kustomization (not the GitRepository)", apiRoot)
+	}
+	if grafanaRoot != "flux-system/Kustomization/infrastructure" {
+		t.Errorf("grafana root = %q, want the infrastructure Kustomization (not the GitRepository)", grafanaRoot)
+	}
+	if apiRoot == grafanaRoot {
+		t.Fatalf("two Kustomizations under one GitRepository share root %q — the mono-repo over-merge", apiRoot)
 	}
 }
 

--- a/internal/server/applications_test.go
+++ b/internal/server/applications_test.go
@@ -11,7 +11,7 @@ import (
 // (a singleton, raw-always).
 func rawInput(kind, ns, name, version, health string) appWorkloadInput {
 	return appWorkloadInput{
-		wl:       appWorkload{Kind: kind, Namespace: ns, Name: name, Version: version, Health: health},
+		wl:       appWorkload{Kind: kind, Namespace: ns, Name: name, Version: version, Health: health, WorkloadClass: classifyWorkload(kind, nil)},
 		rootKey:  ns + "/" + kind + "/" + name,
 		rootKind: kind,
 	}
@@ -154,5 +154,43 @@ func TestClassifyAddon_ClassifiesNotHides(t *testing.T) {
 	svc := rowByName(rows, "my-service")
 	if svc == nil || svc.Category != "app" {
 		t.Errorf("my-service should be Category=app, got %+v", svc)
+	}
+}
+
+func TestClassifyAddon_MixedEvidenceDoesNotForceAddon(t *testing.T) {
+	addon := rawInput("Deployment", "prod", "grafana-sidecar", "10.0", "healthy")
+	addon.addon, addon.addonWhy = packages.ClassifyAddon("", "grafana", "", "grafana-sidecar")
+	app := rawInput("Deployment", "prod", "api", "1.0", "healthy")
+	addon.overlay = &subject.AppOverlay{Winner: subject.Signal{Tier: subject.TierPartOf, Key: "prod/app/checkout", Confidence: subject.ConfidenceMedium}}
+	app.overlay = &subject.AppOverlay{Winner: subject.Signal{Tier: subject.TierPartOf, Key: "prod/app/checkout", Confidence: subject.ConfidenceMedium}}
+
+	rows := groupApplications([]appWorkloadInput{addon, app})
+	if len(rows) != 1 {
+		t.Fatalf("shared overlay should produce one app, got %d: %+v", len(rows), rows)
+	}
+	if rows[0].Category != "mixed" {
+		t.Fatalf("mixed add-on evidence should classify as mixed, got %q", rows[0].Category)
+	}
+	if rows[0].AddonReason == "" {
+		t.Fatalf("mixed classification should preserve add-on evidence")
+	}
+}
+
+func TestWorkloadClass_FacetIsDerivedFromRuntimeShape(t *testing.T) {
+	service := rawInput("Deployment", "prod", "api", "1.0", "healthy")
+	service.wl.WorkloadClass = classifyWorkload("Deployment", &appRelationships{Services: []string{"api"}})
+	service.rels = &appRelationships{Services: []string{"api"}}
+	worker := rawInput("Deployment", "prod", "worker", "1.0", "healthy")
+	job := rawInput("CronJob", "prod", "nightly", "", "healthy")
+
+	rows := groupApplications([]appWorkloadInput{service, worker, job})
+	if got := rowByName(rows, "api"); got == nil || got.WorkloadClass != "service" {
+		t.Fatalf("service row class = %+v, want service", got)
+	}
+	if got := rowByName(rows, "worker"); got == nil || got.WorkloadClass != "worker" {
+		t.Fatalf("worker row class = %+v, want worker", got)
+	}
+	if got := rowByName(rows, "nightly"); got == nil || got.WorkloadClass != "job" {
+		t.Fatalf("cronjob row class = %+v, want job", got)
 	}
 }

--- a/internal/server/packages.go
+++ b/internal/server/packages.go
@@ -11,13 +11,47 @@ import (
 	"sync"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/skyhook-io/radar/internal/auth"
 	"github.com/skyhook-io/radar/internal/helm"
 	"github.com/skyhook-io/radar/internal/k8s"
 	"github.com/skyhook-io/radar/pkg/packages"
+	"github.com/skyhook-io/radar/pkg/subject"
 )
+
+// toPackagesOverlay maps the unified resolver's app-overlay (pkg/subject) into
+// the plain packages.Overlay carried on the wire. nil → nil (raw-always: no
+// app-overlay degrades to package/subject-only on the Applications surface).
+func toPackagesOverlay(ao *subject.AppOverlay) *packages.Overlay {
+	if ao == nil {
+		return nil
+	}
+	return &packages.Overlay{
+		Key:        ao.Winner.Key,
+		Tier:       int(ao.Winner.Tier),
+		Confidence: string(ao.Winner.Confidence),
+	}
+}
+
+// declarationOverlay derives the app-overlay for a GitOps declaration from its
+// own identity, mirroring the key format pkg/subject.ResolveOverlay produces
+// for the workloads the controller stamps — so a Helm-labeled workload and its
+// managing declaration collapse to one app. Argo App → tier 3; Flux HelmRelease
+// (has a chart) → tier 1; Flux Kustomization (no chart) → tier 2.
+func declarationOverlay(d packages.Declaration) *packages.Overlay {
+	switch strings.ToLower(d.Source) {
+	case "argocd", "argo-cd", "argo":
+		return &packages.Overlay{Key: d.Namespace + "/Application/" + d.Name, Tier: int(subject.TierArgoTrackingID), Confidence: string(subject.ConfidenceHigh)}
+	case "flux", "fluxcd":
+		if d.Chart != "" {
+			return &packages.Overlay{Key: d.Namespace + "/HelmRelease/" + d.Name, Tier: int(subject.TierFluxHelmRelease), Confidence: string(subject.ConfidenceHigh)}
+		}
+		return &packages.Overlay{Key: d.Namespace + "/Kustomization/" + d.Name, Tier: int(subject.TierFluxKustomize), Confidence: string(subject.ConfidenceHigh)}
+	}
+	return nil
+}
 
 // packagesCacheTTL bounds how often we recompute the merged package
 // list. Aggregate is cheap; the inputs (Helm secret reads, dynamic-cache
@@ -529,6 +563,10 @@ func collectWorkloadInputs(cache *k8s.ResourceCache, namespaces []string) ([]pac
 		if lbls["helm.sh/chart"] == "" && anns["meta.helm.sh/release-name"] == "" {
 			return
 		}
+		// Resolve the Tier-2 app-overlay from the workload's metadata via the
+		// unified resolver. allowBareApp=false: a bare `app` label alone never
+		// silently groups (raw-always — see pkg/subject.ResolveOverlay).
+		meta := metav1.ObjectMeta{Namespace: ns, Name: name, Labels: lbls, Annotations: anns}
 		out = append(out, packages.Workload{
 			Kind:        kind,
 			Namespace:   ns,
@@ -536,6 +574,7 @@ func collectWorkloadInputs(cache *k8s.ResourceCache, namespaces []string) ([]pac
 			Labels:      lbls,
 			Annotations: anns,
 			Health:      health,
+			Overlay:     toPackagesOverlay(subject.ResolveOverlay(&meta, false)),
 		})
 	}
 
@@ -636,6 +675,7 @@ func collectGitOpsDeclarations(ctx context.Context, cache *k8s.ResourceCache, er
 	if items, err := cache.ListDynamicWithGroup(ctx, "Application", "", "argoproj.io"); err == nil {
 		for _, item := range items {
 			if d, ok := packages.ParseArgoApplication(item.Object); ok {
+					d.Overlay = declarationOverlay(d)
 				out = append(out, d)
 			} else {
 				log.Printf("[packages] failed to parse Argo Application %s/%s — skipping", item.GetNamespace(), item.GetName())
@@ -648,6 +688,7 @@ func collectGitOpsDeclarations(ctx context.Context, cache *k8s.ResourceCache, er
 	if items, err := cache.ListDynamicWithGroup(ctx, "HelmRelease", "", "helm.toolkit.fluxcd.io"); err == nil {
 		for _, item := range items {
 			if d, ok := packages.ParseFluxHelmRelease(item.Object); ok {
+					d.Overlay = declarationOverlay(d)
 				out = append(out, d)
 			} else {
 				log.Printf("[packages] failed to parse Flux HelmRelease %s/%s — skipping", item.GetNamespace(), item.GetName())
@@ -660,6 +701,7 @@ func collectGitOpsDeclarations(ctx context.Context, cache *k8s.ResourceCache, er
 	if items, err := cache.ListDynamicWithGroup(ctx, "Kustomization", "", "kustomize.toolkit.fluxcd.io"); err == nil {
 		for _, item := range items {
 			if d, ok := packages.ParseFluxKustomization(item.Object); ok {
+					d.Overlay = declarationOverlay(d)
 				out = append(out, d)
 			} else {
 				log.Printf("[packages] failed to parse Flux Kustomization %s/%s — skipping", item.GetNamespace(), item.GetName())

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -305,6 +305,11 @@ func (s *Server) setupRoutes() {
 			// declarations. See pkg/packages for merge semantics.
 			r.Get("/packages", s.handleListPackages)
 
+			// Applications — the workload-centric twin of /packages: the
+			// cluster's own services grouped by pkg/subject app-overlay,
+			// anchored on container image:tag. See applications.go.
+			r.Get("/applications", s.handleListApplications)
+
 			// Free-text resource search (name + namespace + labels +
 			// annotations + container images). Used by the hub fan-out
 			// for cross-cluster search; safe to call directly per-cluster.

--- a/pkg/packages/addons.go
+++ b/pkg/packages/addons.go
@@ -1,0 +1,108 @@
+package packages
+
+import "strings"
+
+// The add-on catalog — the single Go-side source of truth for "is this 3rd-party
+// platform machinery?". It is derived from two parts:
+//
+//  1. crdGroupToChart's canonical chart names — so any operator we already
+//     recognize by its CRD group also classifies as an add-on, with zero extra
+//     maintenance: add a CRD group, its chart joins the catalog automatically.
+//  2. addonChartsExtra — platform/security charts that ship NO CRD group of
+//     their own (ingress controllers, DNS, metrics, logging, secrets managers),
+//     so (1) can't catch them.
+//
+// The Applications and Add-ons surfaces share this classifier rather than each
+// carrying a private allowlist. The SPA's interim KNOWN_ADDON_CHARTS
+// (radar-hub-web packagesModel.ts) mirrors this list until the hub forwards the
+// classification on the wire; keep the two in sync until then.
+
+// addonChartsExtra lists add-on charts not keyed by a crdGroupToChart entry.
+// Kept in lockstep with radar-hub-web's KNOWN_ADDON_CHARTS extras.
+var addonChartsExtra = []string{
+	// Argo family beyond the argoproj.io→argo-cd catalog entry
+	"argocd", "argo-rollouts", "argo-workflows", "argo-events", "flux2", "capi",
+	// observability / logging / cost
+	"prometheus", "prometheus-operator", "grafana", "loki", "tempo", "mimir",
+	"fluent-bit", "fluentd", "vector", "opencost", "kubecost",
+	"kube-state-metrics", "node-problem-detector", "datadog", "newrelic-bundle",
+	// service mesh / ingress / dns
+	"istiod", "istio-base", "ingress-nginx", "nginx-ingress", "external-dns",
+	// secrets / policy
+	"sealed-secrets", "vault", "vault-secrets-operator", "gatekeeper",
+	// autoscaling / scheduling / ops
+	"metrics-server", "cluster-autoscaler", "vertical-pod-autoscaler", "vpa",
+	"reloader", "descheduler", "aws-load-balancer-controller",
+	// platform / storage / networking
+	"cnpg", "opentelemetry-collector", "crossplane", "crossplane-rbac-manager",
+	"coredns", "calico", "longhorn", "metallb",
+}
+
+// knownAddonCharts is the resolved catalog: every canonical chart name
+// crdGroupToChart maps to, unioned with addonChartsExtra. Built once at init so
+// the catalog stays a derivative of crdGroupToChart, not a parallel copy.
+var knownAddonCharts = buildAddonCatalog()
+
+func buildAddonCatalog() map[string]bool {
+	m := make(map[string]bool, len(crdGroupToChart)+len(addonChartsExtra))
+	for _, chart := range crdGroupToChart {
+		m[chart] = true
+	}
+	for _, chart := range addonChartsExtra {
+		m[chart] = true
+	}
+	return m
+}
+
+// matchAddonChart reports the catalog entry a value matches — exact, or
+// hyphen-prefixed so a versioned/sub-named value ("kube-prometheus-stack-45",
+// "cert-manager-webhook") still hits its base. Returns ("", false) on no match.
+func matchAddonChart(value string) (base string, ok bool) {
+	v := strings.ToLower(strings.TrimSpace(value))
+	if v == "" {
+		return "", false
+	}
+	if knownAddonCharts[v] {
+		return v, true
+	}
+	for known := range knownAddonCharts {
+		if strings.HasPrefix(v, known+"-") {
+			return known, true
+		}
+	}
+	return "", false
+}
+
+// ClassifyAddon reports whether a workload belongs to 3rd-party platform
+// machinery, matching its helm.sh/chart base, app.kubernetes.io/{name,part-of},
+// or workload name against the shared add-on catalog. Returns the evidence
+// ("field=value", with the matched catalog base in parens on a prefix hit) when
+// classified.
+//
+// This is a CLASSIFIER, never a drop filter: callers keep the row visible
+// (raw-always) and tag it, so the UI can fold add-ons away while still
+// explaining WHY each was tagged.
+func ClassifyAddon(chart, appName, partOf, name string) (addon bool, why string) {
+	chartBase, _ := splitChart(chart)
+	candidates := []struct{ field, value string }{
+		{"chart", chartBase},
+		{"app.kubernetes.io/name", appName},
+		{"app.kubernetes.io/part-of", partOf},
+		{"name", name},
+	}
+	for _, c := range candidates {
+		v := strings.ToLower(strings.TrimSpace(c.value))
+		if v == "" {
+			continue
+		}
+		base, ok := matchAddonChart(v)
+		if !ok {
+			continue
+		}
+		if base == v {
+			return true, c.field + "=" + v
+		}
+		return true, c.field + "=" + v + " (" + base + ")"
+	}
+	return false, ""
+}

--- a/pkg/packages/addons_test.go
+++ b/pkg/packages/addons_test.go
@@ -1,0 +1,67 @@
+package packages
+
+import "testing"
+
+func TestClassifyAddon(t *testing.T) {
+	cases := []struct {
+		name              string
+		chart, app, partOf, wl string
+		wantAddon         bool
+		wantWhy           string
+	}{
+		{
+			name: "catalog chart, exact", chart: "cert-manager-v1.14.0",
+			wantAddon: true, wantWhy: "chart=cert-manager",
+		},
+		{
+			name: "catalog chart with numeric version suffix", chart: "kube-prometheus-stack-45.27.2",
+			wantAddon: true, wantWhy: "chart=kube-prometheus-stack",
+		},
+		{
+			name: "sub-name hits base via prefix", app: "cert-manager-webhook",
+			wantAddon: true, wantWhy: "app.kubernetes.io/name=cert-manager-webhook (cert-manager)",
+		},
+		{
+			name: "part-of label", partOf: "flux",
+			wantAddon: true, wantWhy: "app.kubernetes.io/part-of=flux",
+		},
+		{
+			name: "extras-only chart (no CRD group)", wl: "ingress-nginx-controller",
+			wantAddon: true, wantWhy: "name=ingress-nginx-controller (ingress-nginx)",
+		},
+		{
+			name: "crossplane (extras)", chart: "crossplane",
+			wantAddon: true, wantWhy: "chart=crossplane",
+		},
+		{
+			name: "user service, no match", chart: "payments-1.2.0", app: "payments", wl: "payments-api",
+			wantAddon: false, wantWhy: "",
+		},
+		{
+			name: "empty", wantAddon: false, wantWhy: "",
+		},
+		{
+			name: "chart wins over later candidates", chart: "argo-cd", app: "payments",
+			wantAddon: true, wantWhy: "chart=argo-cd",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotAddon, gotWhy := ClassifyAddon(c.chart, c.app, c.partOf, c.wl)
+			if gotAddon != c.wantAddon || gotWhy != c.wantWhy {
+				t.Errorf("ClassifyAddon(%q,%q,%q,%q) = (%v,%q), want (%v,%q)",
+					c.chart, c.app, c.partOf, c.wl, gotAddon, gotWhy, c.wantAddon, c.wantWhy)
+			}
+		})
+	}
+}
+
+// Every canonical chart name crdGroupToChart resolves to must classify as an
+// add-on — the catalog is derived from it, so a new CRD group joins for free.
+func TestAddonCatalogCoversCRDGroups(t *testing.T) {
+	for group, chart := range crdGroupToChart {
+		if addon, _ := ClassifyAddon(chart, "", "", ""); !addon {
+			t.Errorf("crdGroupToChart[%q]=%q not classified as add-on", group, chart)
+		}
+	}
+}

--- a/pkg/packages/aggregate.go
+++ b/pkg/packages/aggregate.go
@@ -113,6 +113,7 @@ func Aggregate(s Sources) []PackageRow {
 			ReleaseName:      releaseName,
 			ReleaseNamespace: releaseNs,
 		})
+		r.mergeOverlay(w.Overlay)
 	}
 
 	// 3. GitOps declarations (sources A / F) — declared installs, may
@@ -152,6 +153,7 @@ func Aggregate(s Sources) []PackageRow {
 			DeclarationName:      d.Name,
 			DeclarationNamespace: d.Namespace,
 		})
+		r.mergeOverlay(d.Overlay)
 	}
 
 	// 4. CRD registrations (source C). Two cases:
@@ -295,6 +297,19 @@ func splitChart(s string) (name, version string) {
 		}
 	}
 	return s, ""
+}
+
+// mergeOverlay keeps the highest-confidence app-overlay across a row's
+// contributing workloads/declarations — lowest Tier wins (tier 1 Flux
+// HelmRelease beats tier 7 app-name). Nil candidate is a no-op; first non-nil
+// sets it. Deterministic: ties keep the first-seen (caller iteration order).
+func (r *PackageRow) mergeOverlay(o *Overlay) {
+	if o == nil {
+		return
+	}
+	if r.Overlay == nil || o.Tier < r.Overlay.Tier {
+		r.Overlay = o
+	}
 }
 
 // worseHealth returns the worse of two Health values using the order:

--- a/pkg/packages/types.go
+++ b/pkg/packages/types.go
@@ -49,6 +49,22 @@ const (
 	HealthUnknown   Health = "unknown"
 )
 
+// Overlay is the optional Tier-2 "application" identity ABOVE a package — the
+// grouping key the Applications fleet surface uses (see
+// radar-hub/docs/ADDONS-AND-APPLICATIONS-PLAN.md). It mirrors
+// pkg/subject.AppOverlay but with plain fields, so pkg/packages stays free of
+// pkg/subject + metav1: the caller resolves subject.ResolveOverlay (for
+// workloads) or maps a GitOps declaration's identity, then sets this.
+//
+//	Tier   — 1-8, mirrors pkg/subject.Tier (lower = higher precedence/confidence).
+//	Key    — stable grouping key, e.g. "<ns>/Application/<name>" or "<ns>/app/<name>".
+//	Confidence — "high" (tiers 1-4) | "medium" (5-7) | "low" (8).
+type Overlay struct {
+	Key        string `json:"key"`
+	Tier       int    `json:"tier"`
+	Confidence string `json:"confidence,omitempty"`
+}
+
 // HelmRelease is the Helm-side input shape. Mirrors the on-wire shape
 // of `internal/helm.HelmRelease` but lives here so pkg/packages stays
 // dependency-free of internal/.
@@ -76,6 +92,10 @@ type Workload struct {
 	// Health is the workload's aggregated runtime status. Caller decides
 	// the rule (e.g. ready/desired ratio for Deployments).
 	Health Health `json:"health"`
+	// Overlay is the resolved Tier-2 app identity for this workload (the
+	// caller runs pkg/subject.ResolveOverlay on the workload's metadata).
+	// Optional — nil when no app-overlay signal reached tier 7.
+	Overlay *Overlay `json:"overlay,omitempty"`
 }
 
 // CRD is the CRD-side input shape. We need just enough to map
@@ -115,6 +135,10 @@ type Declaration struct {
 	// reasons collapse to degraded. Suspended (spec.suspend) is not yet
 	// surfaced separately.
 	Status Health `json:"status"`
+	// Overlay is the app identity derived from the declaration's own GitOps
+	// identity (Argo Application → tier 3, Flux HelmRelease → tier 1, Flux
+	// Kustomization → tier 2). Set by the caller. Optional.
+	Overlay *Overlay `json:"overlay,omitempty"`
 }
 
 // Sources is the input struct fed to Aggregate. Every field is optional;
@@ -204,6 +228,11 @@ type PackageRow struct {
 	// itself in that case. Lets the SPA render with appropriate framing
 	// ("cert-manager.io CRDs detected") vs a real chart row.
 	FromCRDGroup string `json:"fromCRDGroup,omitempty"`
+	// Overlay is the resolved Tier-2 app identity for this package (the
+	// highest-confidence overlay across its contributing workloads /
+	// declarations — lowest Tier wins). Drives the Applications fleet
+	// surface's app grouping. Optional — nil when no app-overlay resolved.
+	Overlay *Overlay `json:"overlay,omitempty"`
 }
 
 // AddSource appends src to r.Sources if not already present and

--- a/pkg/packages/types.go
+++ b/pkg/packages/types.go
@@ -56,9 +56,9 @@ const (
 // pkg/subject + metav1: the caller resolves subject.ResolveOverlay (for
 // workloads) or maps a GitOps declaration's identity, then sets this.
 //
-//	Tier   — 1-8, mirrors pkg/subject.Tier (lower = higher precedence/confidence).
+//	Tier   — 1-9, mirrors pkg/subject.Tier (lower = higher precedence/confidence).
 //	Key    — stable grouping key, e.g. "<ns>/Application/<name>" or "<ns>/app/<name>".
-//	Confidence — "high" (tiers 1-4) | "medium" (5-7) | "low" (8).
+//	Confidence — "high" (tiers 1-4) | "medium" (5-8) | "low" (9).
 type Overlay struct {
 	Key        string `json:"key"`
 	Tier       int    `json:"tier"`

--- a/pkg/subject/overlay.go
+++ b/pkg/subject/overlay.go
@@ -21,9 +21,10 @@ const (
 	helmReleaseNameAnno      = "meta.helm.sh/release-name"
 	helmReleaseNSAnno        = "meta.helm.sh/release-namespace"
 
-	partOfLabel  = "app.kubernetes.io/part-of"
-	appNameLabel = "app.kubernetes.io/name"
-	bareAppLabel = "app"
+	appInstanceLabel = "app.kubernetes.io/instance"
+	partOfLabel      = "app.kubernetes.io/part-of"
+	appNameLabel     = "app.kubernetes.io/name"
+	bareAppLabel     = "app"
 )
 
 // API groups for the synthesized manager refs (tiers 1-5). The
@@ -35,10 +36,10 @@ const (
 	fluxHelmGroup        = "helm.toolkit.fluxcd.io"
 )
 
-// Tier is the 8-tier precedence rank of the winning app signal. Tiers 1-5 are
+// Tier is the 9-tier precedence rank of the winning app signal. Tiers 1-5 are
 // the CONSOLIDATED managedby.go precedence, in its native order (argo-instance
 // #4, Helm-release #5 — matching managedby.go). The locked rule is "Helm ranks
-// above the app.kubernetes.io label tiers (6-8)", NOT above Argo. Tiers 6-8 are
+// above the app.kubernetes.io label tiers (6-9)", NOT above Argo. Tiers 6-9 are
 // NET-NEW.
 type Tier int
 
@@ -48,10 +49,16 @@ const (
 	TierFluxKustomize   Tier = 2 // kustomize.toolkit.fluxcd.io/{name,namespace}
 	TierArgoTrackingID  Tier = 3 // argocd.argoproj.io/tracking-id
 	TierArgoInstance    Tier = 4 // argocd.argoproj.io/instance (legacy Argo app label)
-	TierHelmRelease     Tier = 5 // meta.helm.sh/release-name — above the label tiers (6-8)
-	TierPartOf          Tier = 6 // app.kubernetes.io/part-of   NET-NEW
-	TierAppName         Tier = 7 // app.kubernetes.io/name      NET-NEW
-	TierBareApp         Tier = 8 // bare `app` / name heuristic NET-NEW
+	TierHelmRelease     Tier = 5 // meta.helm.sh/release-name — above the label tiers (6-9)
+	// TierInstance is Argo CD's DEFAULT resource-tracking label and Helm's
+	// standard installation-identity label. It disambiguates installations the
+	// way the semantic name/part-of labels cannot (two releases of one chart
+	// share app.kubernetes.io/name but differ on /instance), so it ranks above
+	// them — but below the explicit Helm-release annotation. NET-NEW.
+	TierInstance Tier = 6 // app.kubernetes.io/instance  NET-NEW
+	TierPartOf   Tier = 7 // app.kubernetes.io/part-of   NET-NEW
+	TierAppName  Tier = 8 // app.kubernetes.io/name      NET-NEW
+	TierBareApp  Tier = 9 // bare `app` / name heuristic NET-NEW
 )
 
 // Confidence is the rendered trust tier.
@@ -59,8 +66,8 @@ type Confidence string
 
 const (
 	ConfidenceHigh   Confidence = "high"   // tiers 1-4 (Flux / Argo) — core GitOps
-	ConfidenceMedium Confidence = "medium" // tiers 5-7 (Helm-release / part-of / name) — badge
-	ConfidenceLow    Confidence = "low"    // tier 8 (bare app) — opt-in, never silent
+	ConfidenceMedium Confidence = "medium" // tiers 5-8 (Helm-release / instance / part-of / name) — badge
+	ConfidenceLow    Confidence = "low"    // tier 9 (bare app) — opt-in, never silent
 )
 
 func confidenceForTier(t Tier) Confidence {
@@ -86,7 +93,8 @@ type Signal struct {
 }
 
 // AppOverlay is the OPTIONAL Tier-2 key ABOVE the Subject. Absent (nil) when no
-// signal at/above tier 7 exists -> raw-always: surface degrades to Subject-only.
+// signal at/above tier 8 (TierAppName) exists -> raw-always: surface degrades to
+// Subject-only.
 type AppOverlay struct {
 	Winner    Signal   // highest-precedence signal (provenance: which tier won)
 	Conflicts []Signal // retained runner-ups (NET-NEW: collection + retention)
@@ -94,7 +102,7 @@ type AppOverlay struct {
 
 // ResolveOverlay is the Tier-2 entrypoint. It COLLECTS ALL matching signals from
 // obj's labels/annotations, sorts by Tier, returns the winner + retained
-// conflicts, or nil when nothing reaches tier 7 (TierBareApp alone is opt-in via
+// conflicts, or nil when nothing reaches tier 8 (TierBareApp alone is opt-in via
 // allowBareApp; default off => never silent). SUBSUMES detectManagedByFromMeta
 // (tiers 1-5, first-hit-return REPLACED by collect-all). The native-Helm
 // sentinel {Kind:"HelmRelease",Group:""} the Source classifier keys on is set
@@ -147,6 +155,18 @@ func ResolveOverlay(obj metav1.Object, allowBareApp bool) *AppOverlay {
 			Tier: TierArgoInstance,
 			Key:  "/Application/" + n,
 			Ref:  Ref{Kind: "Application", Group: argoApplicationGroup, Namespace: "", Name: n},
+		})
+	}
+	if n := labels[appInstanceLabel]; n != "" {
+		// Same "/app/" key shape as part-of/name: an instance value unifies with
+		// matching name/part-of values (same app). Argo's default tracking writes
+		// the app name here; Helm writes the release name — both are the grouping
+		// we want. Env-specific by nature, so this is excluded as a CROSS-cluster
+		// join key in the Hub (single-cluster overlay only).
+		signals = append(signals, Signal{
+			Tier: TierInstance,
+			Key:  ns + "/app/" + n,
+			Ref:  Ref{Kind: "app", Name: n, Namespace: ns},
 		})
 	}
 	if n := labels[partOfLabel]; n != "" {

--- a/pkg/subject/subject_test.go
+++ b/pkg/subject/subject_test.go
@@ -222,15 +222,41 @@ func TestResolveOverlay_ArgoInstanceBeatsHelm(t *testing.T) {
 }
 
 func TestResolveOverlay_HelmBeatsLabelTiers(t *testing.T) {
-	// Helm release (tier 5) ranks above the app.kubernetes.io label tiers (6-7).
+	// Helm release (tier 5) ranks above the app.kubernetes.io label tiers (7-8).
 	ov := ResolveOverlay(obj("ns", "x",
 		map[string]string{appNameLabel: "web", partOfLabel: "store"},
 		map[string]string{helmReleaseNameAnno: "web"}), false)
 	if ov == nil || ov.Winner.Tier != TierHelmRelease {
 		t.Fatalf("helm must beat labels: got %+v", ov)
 	}
-	if len(ov.Conflicts) != 2 { // part-of (6) + name (7) retained
+	if len(ov.Conflicts) != 2 { // part-of (7) + name (8) retained
 		t.Errorf("label tiers must be retained as conflicts: %+v", ov.Conflicts)
+	}
+}
+
+func TestResolveOverlay_InstanceTierDisambiguatesInstallations(t *testing.T) {
+	// app.kubernetes.io/instance is Argo's default tracking label and Helm's
+	// install-identity label. It must rank above the semantic name/part-of tiers
+	// (so two releases of one chart — identical app.kubernetes.io/name — split on
+	// instance) but below the explicit Helm-release annotation.
+	ov := ResolveOverlay(obj("ns", "x",
+		map[string]string{appInstanceLabel: "grafana-prod", appNameLabel: "grafana", partOfLabel: "platform"}, nil), false)
+	if ov == nil || ov.Winner.Tier != TierInstance {
+		t.Fatalf("instance must win over name/part-of: got %+v", ov)
+	}
+	if ov.Winner.Key != "ns/app/grafana-prod" || ov.Winner.Confidence != ConfidenceMedium {
+		t.Errorf("instance winner key/confidence = %q/%q, want ns/app/grafana-prod/medium", ov.Winner.Key, ov.Winner.Confidence)
+	}
+	if len(ov.Conflicts) != 2 { // name + part-of retained
+		t.Errorf("name + part-of must be retained as conflicts: %+v", ov.Conflicts)
+	}
+
+	// The explicit Helm-release annotation still outranks the instance label.
+	ov2 := ResolveOverlay(obj("ns", "x",
+		map[string]string{appInstanceLabel: "grafana-prod"},
+		map[string]string{helmReleaseNameAnno: "grafana-prod", helmReleaseNSAnno: "ns"}), false)
+	if ov2 == nil || ov2.Winner.Tier != TierHelmRelease {
+		t.Fatalf("Helm-release annotation must beat the instance label: got %+v", ov2)
 	}
 }
 
@@ -271,7 +297,7 @@ func TestParseArgoTrackingID(t *testing.T) {
 }
 
 // TestConfidenceForTier pins every tier→confidence band, including the boundary
-// tiers (Argo-instance #4 / Helm #5 = high/medium edge, name #7 / bare-app #8 =
+// tiers (Argo-instance #4 / Helm #5 = high/medium edge, name #8 / bare-app #9 =
 // medium/low edge) that the overlay spot-checks don't cover — an off-by-one in
 // the range checks would silently mislabel trust.
 func TestConfidenceForTier(t *testing.T) {
@@ -284,6 +310,7 @@ func TestConfidenceForTier(t *testing.T) {
 		{TierArgoTrackingID, ConfidenceHigh},
 		{TierArgoInstance, ConfidenceHigh},
 		{TierHelmRelease, ConfidenceMedium},
+		{TierInstance, ConfidenceMedium},
 		{TierPartOf, ConfidenceMedium},
 		{TierAppName, ConfidenceMedium},
 		{TierBareApp, ConfidenceLow},


### PR DESCRIPTION
Adds the per-cluster Applications backend surface on top of the shared subject/app-overlay model.

Current scope:

- Exposes `/api/applications`, grouping concrete workloads into deployable app/release rows using topology structural roots plus the `pkg/subject` Tier-2 overlay.
- Rows carry provenance tier/confidence, image-tag versions, health, warning events, relationships, and workload-scoped debug inputs.
- Includes `workload_class` (`service`, `worker`, `job`, `unknown`) on rows and workloads.
- Treats Jobs and CronJobs as first-class application/release units.
- Treats add-on as classification evidence, not identity: mixed app/add-on groups report `category=mixed` instead of forcing the whole app to `addon`.
- Keeps system-namespace workloads visible; classification/UI can fold or badge them, but the raw row remains present.
- Threads app-overlay metadata through `/api/packages` as data-layer support for Applications and future package/add-on UI iteration.

This PR does not add or require package UI changes.

## Grouping-accuracy fixes

Two over-merge fixes from pressure-testing the model against the full topology edge inventory:

- **`structuralRoot` stops at GitOps managers.** The `EdgeManages` walk had no kind discrimination, so it climbed past a Flux Kustomization through the `GitRepository→Kustomization` source-ref edge (also an `EdgeManages` edge) to the GitRepository — collapsing a whole Flux mono-repo (one GitRepository, N Kustomizations) into one app via the structural union-find atom. It now halts at the first in-cluster manager (Application/Kustomization/HelmRelease); ownerRef chains + operator CRs still climb to the topmost owner. Regression test added.
- **`app.kubernetes.io/instance` added as overlay tier 6 (medium confidence).** It's Argo CD's *default* tracking label and Helm's install-identity label — its absence meant default-config Argo apps fell through to the semantic name/part-of tiers and two releases of one chart (identical `app.kubernetes.io/name`) over-merged. Placed above name/part-of, below the explicit Helm-release annotation (tiers renumbered to 9). Env-specific, so it stays a single-cluster overlay signal and is excluded as a cross-cluster join key in the Hub.

**Lockstep:** the tier renumber is a wire contract — the SPA's `TIER_PROVENANCE` / `sourceOf` consumers are updated in radar-hub-web #92; merge/deploy together.

Consumed by radar-hub #55 and radar-hub-web #92.