### PR TITLE
fix(k8s-ui): open Checks resource links in a new tab (SKY-931)

### DIFF
--- a/packages/k8s-ui/src/components/checks/ChecksView.tsx
+++ b/packages/k8s-ui/src/components/checks/ChecksView.tsx
@@ -703,7 +703,11 @@ function FindingLine({
           {body}
         </button>
       ) : resourceHref ? (
-        <a href={resourceHref(r)} className={cls}>
+        // Opens in a new tab to match the ExternalLink glyph in `body`. For the
+        // Hub fleet view this href crosses the Hub→Cluster SPA boundary (a full
+        // document nav); a new tab keeps the Checks queue intact and avoids the
+        // cross-tree browser-Back dead-end (SKY-931).
+        <a href={resourceHref(r)} target="_blank" rel="noreferrer" className={cls}>
           {body}
         </a>
       ) : (


### PR DESCRIPTION
## What

Fleet **Checks** finding rows render an `ExternalLink` (open-in-new-window) glyph, but the `resourceHref` `<a>` navigated in the **same tab** — icon and behavior disagreed. Add `target="_blank" rel="noreferrer"` so the link opens in a new tab, matching the affordance.

Fixes [SKY-931](https://linear.app/skyhook-io/issue/SKY-931).

## Why this also fixes the follow-up bug

In the Hub fleet view this href crosses the **Hub → Cluster SPA boundary** as a full document navigation. Same-tab nav meant hitting browser **Back** from the cluster view dropped the user into a cross-tree dead-end (the second bug Roy reported on the ticket). Opening in a new tab keeps the Checks queue intact in the original tab, so Back is never pressed across the boundary — both bugs resolved in one change.

## Scope

- Only the `resourceHref` branch of `FindingLine` changes. The OSS per-cluster **Audit** view uses the `onResourceClick`/button branch (in-app drawer) and is unaffected.
- `tsc --noEmit` clean; the 5 existing `checks` tests pass.

## Release / downstream

Tag-driven publish (`publish-k8s-ui.yml`): cut `k8s-ui-v1.7.8` once merged, then bump `@skyhook-io/k8s-ui` in `radar-hub-web` from `^1.7.7` → `^1.7.8`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single anchor attribute change on the `resourceHref` branch only; no auth, data, or routing logic changes.
> 
> **Overview**
> **FindingLine** resource rows that use **`resourceHref`** (Hub fleet Checks) now open with **`target="_blank"`** and **`rel="noreferrer"`**, so behavior matches the **ExternalLink** icon on those rows.
> 
> Same-tab navigation had replaced the Hub Checks queue when the link crossed into the cluster SPA; **Back** could land in a bad cross-app state (SKY-931). The **`onResourceClick`** button path (OSS Audit in-app drawer) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bdde280a5eec5633c758f6d6e860797a8d23b61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->