### PR TITLE
fix: 404 the whole /.well-known/* tree for MCP discovery probes

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -496,21 +496,31 @@ func (s *Server) setupRoutes() {
 		r.Get("/traffic/flows/stream", s.handleTrafficFlowsStream)
 	})
 
+	// OAuth/OIDC discovery probes from MCP HTTP clients. Without these
+	// explicit 404s, two failure modes appear:
+	//   (a) the SPA fallback below answers root-level /.well-known/* with the
+	//       React index.html (HTTP 200, text/html);
+	//   (b) the /mcp Mount answers /mcp/.well-known/* with 405 because the
+	//       MCP handler only accepts POST.
+	// Both responses trigger claude-code's MCP transport (per upstream issue
+	// anthropics/claude-code#46879) to flip the server status to "needs-auth"
+	// — Claude Code probes /.well-known/oauth-{protected-resource,
+	// authorization-server} and /.well-known/openid-configuration before the
+	// MCP initialize and treats any non-404 as "this server is OAuth-
+	// protected." That leaks synthetic mcp__<server>__authenticate /
+	// complete_authentication tools into the model's tool catalog, which the
+	// agent then invents calls for. Per the MCP spec (RFC 9728 + RFC 8414),
+	// servers that do not implement OAuth should return 404 here so the
+	// client infers no auth is needed. Registered BEFORE the /mcp Mount so
+	// chi's radix tree resolves /mcp/.well-known/* to NotFound instead of
+	// letting the MCP handler answer with 405.
+	r.Handle("/.well-known/*", http.NotFoundHandler())
+	r.Handle("/mcp/.well-known/*", http.NotFoundHandler())
+
 	// MCP server (Model Context Protocol for AI tools)
 	if s.mcpHandler != nil {
 		r.Mount("/mcp", s.mcpHandler)
 	}
-
-	// Discovery probes from MCP HTTP clients. Without this, the SPA
-	// catch-all answers /.well-known/* with HTML 200, which newer claude-code
-	// parses as a broken OAuth flow and either aborts MCP registration or
-	// nudges the model to invent phantom mcp__<server>__authenticate calls.
-	// RFC 9728 / RFC 8414 / OIDC discovery all probe under /.well-known/ at
-	// both bare paths AND the resource-scoped variants (e.g.
-	// /.well-known/oauth-protected-resource/mcp). Radar's MCP endpoint is
-	// unauthenticated when running locally; serve a clean 404 across the
-	// whole /.well-known/* tree so clients infer "no auth needed."
-	r.Handle("/.well-known/*", http.NotFoundHandler())
 
 	// Static files (frontend) - SPA fallback to index.html
 	if s.staticFS != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -501,6 +501,17 @@ func (s *Server) setupRoutes() {
 		r.Mount("/mcp", s.mcpHandler)
 	}
 
+	// Discovery probes from MCP HTTP clients. Without this, the SPA
+	// catch-all answers /.well-known/* with HTML 200, which newer claude-code
+	// parses as a broken OAuth flow and either aborts MCP registration or
+	// nudges the model to invent phantom mcp__<server>__authenticate calls.
+	// RFC 9728 / RFC 8414 / OIDC discovery all probe under /.well-known/ at
+	// both bare paths AND the resource-scoped variants (e.g.
+	// /.well-known/oauth-protected-resource/mcp). Radar's MCP endpoint is
+	// unauthenticated when running locally; serve a clean 404 across the
+	// whole /.well-known/* tree so clients infer "no auth needed."
+	r.Handle("/.well-known/*", http.NotFoundHandler())
+
 	// Static files (frontend) - SPA fallback to index.html
 	if s.staticFS != nil {
 		r.Handle("/*", spaHandler(http.FS(s.staticFS)))


### PR DESCRIPTION
## Summary

The SPA catch-all route was answering `/.well-known/*` discovery probes with an HTML `200`. Newer MCP HTTP clients (claude-code et al.) probe `/.well-known/oauth-protected-resource`, `/.well-known/oauth-authorization-server`, and the resource-scoped variants (e.g. `/.well-known/oauth-protected-resource/mcp`) per RFC 9728 / RFC 8414 / OIDC discovery. Getting an HTML 200 back instead of a proper JSON document or a 404 makes them treat it as a *broken* OAuth flow — they either abort MCP registration outright or infer a phantom authenticate step that doesn't exist.

Radar's MCP endpoint is unauthenticated when run locally. The fix replaces the two previously-hardcoded `oauth-*` paths with a single tree-wide handler that returns a clean `404` for the entire `/.well-known/*` subtree, so clients correctly infer "no auth handshake needed" and proceed with registration.

## Scope
- One-line route change in `internal/server/server.go` (+ explanatory comment).
- No behavior change for any non-`/.well-known` route.
- Standalone — independent of the in-flight Issues work (#811).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routing-only change for discovery URLs; no auth, API, or SPA behavior outside `/.well-known` paths.
> 
> **Overview**
> MCP HTTP clients (e.g. Claude Code) probe **`/.well-known/*`** and **`/mcp/.well-known/*`** before MCP initialize. Without explicit handlers, those paths were answered by the SPA catch-all (**200 + HTML**) or the **`/mcp`** mount (**405** on non-POST), which clients treat as a broken OAuth-protected server and surface phantom authenticate tools.
> 
> This change registers **`http.NotFoundHandler()`** for both subtrees in **`setupRoutes`**, **before** the **`/mcp`** mount and SPA **`/*`** fallback, so unauthenticated local MCP gets a spec-correct **404** and clients infer no OAuth handshake is required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bbfa36a96315d380234bb654479fdfa08c54d15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->