### PR TITLE
Disable manual scale for controller-managed workloads

### DIFF
--- a/.agents/skills/test-radar/SKILL.md
+++ b/.agents/skills/test-radar/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: test-radar
+description: Use when building and testing Radar changes with the repository's real-instance smoke-test workflow.
+---
+
+Follow the workflow in `.claude/commands/test-radar.md`.
+
+Do not modify the Claude command file. Treat it as the canonical workflow source for this repository.

--- a/.agents/skills/visual-test/SKILL.md
+++ b/.agents/skills/visual-test/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: visual-test
+description: Use when visually testing Radar UI changes against a real Kubernetes cluster with Playwright screenshots.
+---
+
+Follow the workflow in `.claude/commands/visual-test.md`.
+
+Do not modify the Claude command file. Treat it as the canonical workflow source for this repository.

--- a/packages/k8s-ui/src/components/resources/renderers/WorkloadRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/WorkloadRenderer.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import { WorkloadRenderer } from './WorkloadRenderer'
+
+const deployment = {
+  metadata: { name: 'api', namespace: 'prod' },
+  spec: { replicas: 3 },
+  status: { readyReplicas: 3, availableReplicas: 3, updatedReplicas: 3 },
+}
+
+describe('WorkloadRenderer', () => {
+  it('enables manual scaling when no replica controller targets the workload', () => {
+    const html = renderToString(
+      <WorkloadRenderer kind="deployments" data={deployment} onScale={async () => {}} />,
+    )
+
+    expect(html).toContain('Scale')
+    expect(html).not.toContain('disabled=""')
+    expect(html).not.toContain('Manual scaling is disabled')
+  })
+
+  it('disables manual scaling when an HPA or KEDA ScaledObject owns replicas', () => {
+    const html = renderToString(
+      <WorkloadRenderer
+        kind="deployments"
+        data={deployment}
+        onScale={async () => {}}
+        scaleBlockedBy={[
+          { kind: 'HorizontalPodAutoscaler', namespace: 'prod', name: 'api' },
+          { kind: 'ScaledObject', namespace: 'prod', name: 'api-queue' },
+        ]}
+      />,
+    )
+
+    expect(html).toContain('disabled=""')
+    expect(html).toContain('Manual scaling is disabled')
+    expect(html).toContain('HorizontalPodAutoscaler prod/api')
+    expect(html).toContain('ScaledObject prod/api-queue')
+  })
+})

--- a/packages/k8s-ui/src/components/resources/renderers/WorkloadRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/WorkloadRenderer.tsx
@@ -3,7 +3,8 @@ import { Server, ExternalLink, Scale, Minus, Plus, Loader2, Shield } from 'lucid
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, PodTemplateSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
 import { DialogPortal } from '../../ui/DialogPortal'
-import type { RBACSubjectResponse, RBACPolicyRule } from '../../../types'
+import { Tooltip } from '../../ui/Tooltip'
+import type { RBACSubjectResponse, RBACPolicyRule, ResourceRef } from '../../../types'
 import { detectBlastRadius, rulePermissivenessScore } from '../../../utils/rbac-blast-radius'
 import { RBACErrorSection, isRBACUnavailable } from './RBACErrorSection'
 import {
@@ -19,6 +20,7 @@ interface WorkloadRendererProps {
   onViewPods?: () => void
   onScale?: (replicas: number) => Promise<void>
   isScalePending?: boolean
+  scaleBlockedBy?: ResourceRef[]
   onRequestRefresh?: () => void
   /**
    * RBAC reverse-lookup for the workload's pod-template ServiceAccount.
@@ -103,14 +105,23 @@ function getWorkloadProgress(status: any, spec: any, kind: string): string | nul
   return null
 }
 
-export function WorkloadRenderer({ kind, data, onNavigate, onViewPods, onScale, isScalePending, onRequestRefresh, rbacData, rbacLoading, rbacError }: WorkloadRendererProps) {
+function formatScalerLabel(ref: ResourceRef): string {
+  const prefix = ref.namespace ? `${ref.namespace}/` : ''
+  return `${ref.kind} ${prefix}${ref.name}`
+}
+
+export function WorkloadRenderer({ kind, data, onNavigate, onViewPods, onScale, isScalePending, scaleBlockedBy, onRequestRefresh, rbacData, rbacLoading, rbacError }: WorkloadRendererProps) {
   const status = data.status || {}
   const spec = data.spec || {}
   const metadata = data.metadata || {}
 
   const isDaemonSet = kind === 'daemonsets'
   const isStatefulSet = kind === 'statefulsets'
-  const isScalable = (kind === 'deployments' || kind === 'statefulsets') && !!onScale
+  const isScalableKind = kind === 'deployments' || kind === 'statefulsets'
+  const isScaleBlocked = !!scaleBlockedBy?.length
+  const isScalable = isScalableKind && !!onScale && !isScaleBlocked
+  const scaleBlockedLabel = scaleBlockedBy?.map(formatScalerLabel).join(', ')
+  const scaleBlockedReason = `Manual scaling is disabled because replicas are controlled by ${scaleBlockedLabel}. Manage scaling there instead.`
 
   // Scale dialog state
   const [showScaleDialog, setShowScaleDialog] = useState(false)
@@ -139,8 +150,14 @@ export function WorkloadRenderer({ kind, data, onNavigate, onViewPods, onScale, 
     return () => clearInterval(interval)
   }, [isScaling, onRequestRefresh])
 
+  useEffect(() => {
+    if (isScaleBlocked) {
+      setShowScaleDialog(false)
+    }
+  }, [isScaleBlocked])
+
   const handleScale = async () => {
-    if (!onScale) return
+    if (!onScale || isScaleBlocked) return
     try {
       await onScale(targetReplicas)
       setScaledTo(targetReplicas)
@@ -218,7 +235,7 @@ export function WorkloadRenderer({ kind, data, onNavigate, onViewPods, onScale, 
               View Managed Pods
             </button>
           )}
-          {isScalable && (
+          {isScalable ? (
             <button
               onClick={openScaleDialog}
               className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-emerald-400 hover:text-emerald-300 bg-emerald-500/10 hover:bg-emerald-500/20 border border-emerald-500/30 rounded transition-colors"
@@ -226,7 +243,20 @@ export function WorkloadRenderer({ kind, data, onNavigate, onViewPods, onScale, 
               <Scale className="w-3 h-3" />
               Scale
             </button>
-          )}
+          ) : isScalableKind && !!onScale && isScaleBlocked ? (
+            <Tooltip content={scaleBlockedReason}>
+              <button
+                type="button"
+                disabled
+                title={scaleBlockedReason}
+                aria-label={scaleBlockedReason}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-theme-text-tertiary bg-theme-elevated border border-theme-border rounded cursor-not-allowed"
+              >
+                <Scale className="w-3 h-3" />
+                Scale
+              </button>
+            </Tooltip>
+          ) : null}
         </div>
       </Section>
 

--- a/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.test.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import { ResourceRendererDispatch, type RendererOverrides } from './ResourceRendererDispatch'
+import type { ResourceRef } from '../../types'
+
+function renderWithScalers(scalers: ResourceRef[]): string {
+  const overrides: RendererOverrides = {
+    WorkloadRenderer: ({ scaleBlockedBy }) => (
+      <span>{scaleBlockedBy?.map((ref) => ref.kind).join(',') || 'none'}</span>
+    ),
+  }
+
+  return renderToString(
+    <ResourceRendererDispatch
+      resource={{ kind: 'deployments', namespace: 'prod', name: 'api' }}
+      data={{ metadata: { name: 'api', namespace: 'prod' } }}
+      relationships={{ scalers }}
+      onCopy={() => {}}
+      copied={null}
+      rendererOverrides={overrides}
+      showCommonSections={false}
+    />,
+  )
+}
+
+describe('ResourceRendererDispatch', () => {
+  it('blocks manual replica scaling for HPA and KEDA ScaledObject scalers only', () => {
+    const html = renderWithScalers([
+      { kind: 'VerticalPodAutoscaler', namespace: 'prod', name: 'api-vpa' },
+      { kind: 'HorizontalPodAutoscaler', namespace: 'prod', name: 'api-hpa' },
+      { kind: 'ScaledObject', namespace: 'prod', name: 'api-keda' },
+    ])
+
+    expect(html).toContain('HorizontalPodAutoscaler,ScaledObject')
+    expect(html).not.toContain('VerticalPodAutoscaler')
+  })
+
+  it('does not block manual replica scaling for VPA-only relationships', () => {
+    const html = renderWithScalers([
+      { kind: 'VerticalPodAutoscaler', namespace: 'prod', name: 'api-vpa' },
+    ])
+
+    expect(html).toContain('none')
+  })
+})

--- a/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
@@ -245,6 +245,8 @@ export interface RendererOverrides {
   WorkloadRenderer?: React.ComponentType<{
     kind: string; data: any
     onNavigate?: (ref: ResourceRef) => void
+    relationships?: Relationships
+    scaleBlockedBy?: ResourceRef[]
   }>
   // Optional override for Crossplane Composite / Claim — host wraps the
   // package renderer to fan out per-composed-ref status fetches via React Query.
@@ -351,6 +353,14 @@ const KNOWN_KINDS = new Set([
   'compositeresourcedefinitions', 'compositions', 'compositionrevisions',
   'functions', 'configurations',
 ])
+
+function replicaScalers(scalers?: ResourceRef[]): ResourceRef[] | undefined {
+  const result = scalers?.filter((ref) => {
+    const kind = ref.kind.toLowerCase()
+    return kind === 'horizontalpodautoscaler' || kind === 'scaledobject'
+  })
+  return result && result.length > 0 ? result : undefined
+}
 
 // ============================================================================
 // RESOURCE CONTENT - Delegates to specific renderers
@@ -464,6 +474,7 @@ export function ResourceRendererDispatch({
   const NamespaceComp = rendererOverrides?.NamespaceRenderer ?? NamespaceRenderer
   const HPAComp = rendererOverrides?.HPARenderer ?? HPARenderer
   const PVCComp = rendererOverrides?.PVCRenderer ?? PVCRenderer
+  const scaleBlockedBy = replicaScalers(relationships?.scalers)
 
   const sidebarContent = showCommonSections && (
     <>
@@ -480,7 +491,15 @@ export function ResourceRendererDispatch({
       <div className={clsx('p-4 space-y-4', renderSidebar && 'lg:flex-1 lg:min-w-0')}>
         {/* Kind-specific content - delegates to modular renderers */}
         {kind === 'pods' && <PodComp data={data} onCopy={onCopy} copied={copied} onNavigate={onNavigate} onOpenLogs={onOpenLogs} resolvedEnvFrom={resolvedEnvFrom} />}
-        {['deployments', 'statefulsets', 'daemonsets'].includes(kind) && <WorkloadComp kind={kind} data={data} onNavigate={onNavigate} />}
+        {['deployments', 'statefulsets', 'daemonsets'].includes(kind) && (
+          <WorkloadComp
+            kind={kind}
+            data={data}
+            onNavigate={onNavigate}
+            relationships={relationships}
+            scaleBlockedBy={scaleBlockedBy}
+          />
+        )}
         {kind === 'replicasets' && <ReplicaSetRenderer data={data} />}
         {kind === 'services' && !data?.apiVersion?.includes('serving.knative.dev') && <ServiceComp data={data} onCopy={onCopy} copied={copied} />}
         {kind === 'ingresses' && !data?.apiVersion?.includes('networking.internal.knative.dev') && <IngressRenderer data={data} onNavigate={onNavigate} />}

--- a/web/src/components/resources/renderers/WorkloadRenderer.tsx
+++ b/web/src/components/resources/renderers/WorkloadRenderer.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useScaleWorkload } from '../../../api/client'
 import { useRBACSubject } from '../../../api/rbac'
 import { useQueryClient } from '@tanstack/react-query'
+import type { Relationships, ResourceRef } from '../../../types'
 
 // Map plural lowercase kind to singular PascalCase for ownerReferences matching
 function getOwnerKind(kind: string): string {
@@ -19,10 +20,12 @@ function getOwnerKind(kind: string): string {
 interface WorkloadRendererProps {
   kind: string
   data: any
-  onNavigate?: (ref: { kind: string; namespace: string; name: string }) => void
+  onNavigate?: (ref: ResourceRef) => void
+  relationships?: Relationships
+  scaleBlockedBy?: ResourceRef[]
 }
 
-export function WorkloadRenderer({ kind, data, onNavigate }: WorkloadRendererProps) {
+export function WorkloadRenderer({ kind, data, onNavigate, scaleBlockedBy }: WorkloadRendererProps) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const scaleMutation = useScaleWorkload()
@@ -47,6 +50,7 @@ export function WorkloadRenderer({ kind, data, onNavigate }: WorkloadRendererPro
       rbacData={rbacData ?? null}
       rbacLoading={rbacLoading}
       rbacError={rbacError as Error | null}
+      scaleBlockedBy={scaleBlockedBy}
       onScale={async (replicas) => {
         await scaleMutation.mutateAsync({
           kind,


### PR DESCRIPTION
Manual scaling now uses the existing relationship graph to detect when a Deployment or StatefulSet is targeted by an HPA or KEDA ScaledObject. In those cases Radar disables the Scale action and explains which controller owns replica count, while leaving VPA-only relationships alone.

This also adds repo-local Codex skill shims for the existing Radar test and visual-test workflows so future Codex sessions can discover them without duplicating the canonical command docs.

Validated with:
- npm test --workspace @skyhook-io/k8s-ui -- WorkloadRenderer ResourceRendererDispatch
- make tsc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only guardrails on an existing scale mutation; misclassified relationships could wrongly enable or disable scaling, but scope is limited to workload detail actions.
> 
> **Overview**
> Manual **Scale** on Deployments and StatefulSets is now gated on relationship data: when `relationships.scalers` includes an **HorizontalPodAutoscaler** or **KEDA ScaledObject**, Radar treats replica count as controller-owned and blocks the scale action. **VerticalPodAutoscaler** (and other scaler kinds) do not trigger this block.
> 
> `ResourceRendererDispatch` derives `scaleBlockedBy` via a new `replicaScalers` helper and passes it into workload renderers. The shared `WorkloadRenderer` shows a disabled Scale control with a tooltip naming the owning controllers, closes the scale dialog if blocking appears, and ignores scale handlers while blocked. The web `WorkloadRenderer` wrapper forwards `scaleBlockedBy` into the base component.
> 
> Vitest coverage was added for the dispatch filter and the workload UI behavior. Two **Codex agent skill** stubs (`test-radar`, `visual-test`) point at the existing `.claude/commands/*` workflows without duplicating them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 261b40f80dfb92448d5f2832e05a4f6eafc198bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->