### PR TITLE
Show autoscaler control in workload status

### DIFF
--- a/packages/k8s-ui/src/components/resources/renderers/WorkloadRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/WorkloadRenderer.test.tsx
@@ -34,6 +34,7 @@ describe('WorkloadRenderer', () => {
 
     expect(html).toContain('disabled=""')
     expect(html).toContain('Manual scaling is disabled')
+    expect(html).toContain('Controlled by')
     expect(html).toContain('HorizontalPodAutoscaler prod/api')
     expect(html).toContain('ScaledObject prod/api-queue')
   })

--- a/packages/k8s-ui/src/components/resources/renderers/WorkloadRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/WorkloadRenderer.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Server, ExternalLink, Scale, Minus, Plus, Loader2, Shield } from 'lucide-react'
 import { clsx } from 'clsx'
-import { Section, PropertyList, Property, ConditionsSection, PodTemplateSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
+import { Section, PropertyList, Property, ConditionsSection, PodTemplateSection, AlertBanner, ResourceLink, ResourceRefBadge } from '../../ui/drawer-components'
 import { DialogPortal } from '../../ui/DialogPortal'
 import { Tooltip } from '../../ui/Tooltip'
 import type { RBACSubjectResponse, RBACPolicyRule, ResourceRef } from '../../../types'
@@ -219,6 +219,18 @@ export function WorkloadRenderer({ kind, data, onNavigate, onViewPods, onScale, 
           ) : (
             <>
               <Property label="Replicas" value={`${status.readyReplicas || 0}/${spec.replicas || 0}`} />
+              {scaleBlockedBy && scaleBlockedBy.length > 0 && (
+                <Property
+                  label="Controlled by"
+                  value={
+                    <div className="flex flex-wrap gap-1">
+                      {scaleBlockedBy.map((ref) => (
+                        <ResourceRefBadge key={`${ref.kind}/${ref.namespace}/${ref.name}`} resourceRef={ref} onClick={onNavigate} />
+                      ))}
+                    </div>
+                  }
+                />
+              )}
               <Property label="Updated" value={status.updatedReplicas} />
               <Property label="Available" value={status.availableReplicas} />
               <Property label="Unavailable" value={status.unavailableReplicas} />

--- a/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
@@ -220,6 +220,7 @@ import {
 import type { SelectedResource, Relationships, ResourceRef, SecretCertificateInfo, ResolvedEnvFrom, TimelineEvent } from '../../types'
 import type { CopyHandler } from '../ui/drawer-components'
 import { AlertBanner } from '../ui/drawer-components'
+import { replicaScalers } from '../../utils/replica-scalers'
 
 /**
  * Override map letting each platform consumer swap in its own renderer components.
@@ -353,14 +354,6 @@ const KNOWN_KINDS = new Set([
   'compositeresourcedefinitions', 'compositions', 'compositionrevisions',
   'functions', 'configurations',
 ])
-
-function replicaScalers(scalers?: ResourceRef[]): ResourceRef[] | undefined {
-  const result = scalers?.filter((ref) => {
-    const kind = ref.kind.toLowerCase()
-    return kind === 'horizontalpodautoscaler' || kind === 'scaledobject'
-  })
-  return result && result.length > 0 ? result : undefined
-}
 
 // ============================================================================
 // RESOURCE CONTENT - Delegates to specific renderers

--- a/packages/k8s-ui/src/utils/replica-scalers.ts
+++ b/packages/k8s-ui/src/utils/replica-scalers.ts
@@ -1,0 +1,9 @@
+import type { ResourceRef } from '../types'
+
+export function replicaScalers(scalers?: ResourceRef[]): ResourceRef[] | undefined {
+  const result = scalers?.filter((ref) => {
+    const kind = ref.kind.toLowerCase()
+    return kind === 'horizontalpodautoscaler' || kind === 'scaledobject'
+  })
+  return result && result.length > 0 ? result : undefined
+}


### PR DESCRIPTION
Adds replica-controller context directly to the workload Status section so HPA/KEDA-managed replicas are visible where the replica count and Scale action appear.

This keeps GitOps ownership in the drawer header and leaves Related Resources as the exhaustive relationship list, while the Status section now shows a concise `Controlled by` row for HPA/KEDA controllers. The same HPA/KEDA filter used by the manual-scale guard is shared through a small utility so the disabled Scale button and Status context stay aligned.

Verified with targeted k8s-ui tests, `make tsc`, `make build`, and a local Radar review against the HPA-managed `envoy-gateway-system/envoy-gateway` deployment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only UI change plus a small refactor; no scaling or API behavior changes beyond existing scaleBlockedBy wiring.
> 
> **Overview**
> When manual scaling is blocked by an **HorizontalPodAutoscaler** or **ScaledObject**, the workload **Status** section now includes a **Controlled by** row next to replica counts, with clickable badges for each controller.
> 
> The HPA/KEDA filter used to derive `scaleBlockedBy` is moved from `ResourceRendererDispatch` into shared **`replicaScalers`** in `utils/replica-scalers.ts`, so the disabled Scale control and the new Status row use the same source. Tests assert the **Controlled by** label and controller references in the blocked-scaling case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02b82a8d6648f42f9c89bb66cbe3f8b64c2ab02c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->