### PR TITLE
Move permissions action out of header

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -41,7 +41,7 @@ import { routePath, apiUrl, getAuthHeaders, getCredentialsMode } from './api/con
 import { KeyboardShortcutProvider, useRegisterShortcut, useRegisterShortcuts } from './hooks/useKeyboardShortcuts'
 import { useAnimatedUnmount } from './hooks/useAnimatedUnmount'
 import radarLoadingIcon from '@skyhook-io/k8s-ui/assets/radar/radar-icon-loading.svg'
-import { RefreshCw, Network, List, Clock, Package, Sun, Moon, Activity, Home, Star, Search, Bug, Settings, SquareTerminal, ShieldCheck, GitBranch, Shield as ShieldIcon } from 'lucide-react'
+import { RefreshCw, Network, List, Clock, Package, Sun, Moon, Activity, Home, Star, Search, Bug, Settings, SquareTerminal, ShieldCheck, GitBranch } from 'lucide-react'
 import { useTheme } from './context/ThemeContext'
 import { Tooltip } from './components/ui/Tooltip'
 import { LargeClusterNamespacePicker } from './components/shared/LargeClusterNamespacePicker'
@@ -1277,18 +1277,6 @@ function AppInner() {
             </button>
           )}
 
-          {/* My Permissions — what the current user can do in the cluster,
-              computed live by the apiserver via SelfSubjectRulesReview.
-              Available in embedded mode too — Radar Hub users still benefit
-              from "why can't I do X" debugging. */}
-          <button
-            onClick={() => setShowMyPermissions(true)}
-            className="p-1.5 rounded-md bg-theme-elevated hover:bg-theme-hover text-theme-text-secondary hover:text-theme-text-primary transition-colors"
-            title="My permissions in this cluster"
-          >
-            <ShieldIcon className="w-4 h-4" />
-          </button>
-
           {/* User menu (when auth enabled) — hidden in embedded mode;
               host app typically provides its own via rightExtras. */}
           {!navCustomization.embedded && <UserMenu />}
@@ -1787,7 +1775,14 @@ function AppInner() {
       {diagnosticsOverlay.shouldRender && <DiagnosticsOverlay isOpen={diagnosticsOverlay.isOpen} onClose={() => setShowDiagnostics(false)} />}
 
       {/* Settings dialog */}
-      <SettingsDialog open={showSettings} onClose={() => setShowSettings(false)} />
+      <SettingsDialog
+        open={showSettings}
+        onClose={() => setShowSettings(false)}
+        onShowMyPermissions={() => {
+          setShowSettings(false)
+          setShowMyPermissions(true)
+        }}
+      />
       <MyPermissionsDialog open={showMyPermissions} onClose={() => setShowMyPermissions(false)} />
 
       {/* Debug overlay - only in dev mode */}

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { createPortal } from 'react-dom'
-import { Settings, X, RotateCcw, Loader2, Copy, Check, Pin } from 'lucide-react'
+import { Settings, X, RotateCcw, Loader2, Copy, Check, Pin, Shield } from 'lucide-react'
 import { clsx } from 'clsx'
 import { useAnimatedUnmount } from '../../hooks/useAnimatedUnmount'
 import { TRANSITION_BACKDROP, TRANSITION_PANEL } from '../../utils/animation'
@@ -28,9 +28,10 @@ interface ConfigResponse {
 interface SettingsDialogProps {
   open: boolean
   onClose: () => void
+  onShowMyPermissions?: () => void
 }
 
-export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
+export function SettingsDialog({ open, onClose, onShowMyPermissions }: SettingsDialogProps) {
   const dialogRef = useRef<HTMLDivElement>(null)
   const { shouldRender, isOpen } = useAnimatedUnmount(open, 200)
   const [configData, setConfigData] = useState<ConfigResponse | null>(null)
@@ -165,6 +166,25 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
           {loadError && (
             <div className="mb-3 px-3 py-2 text-xs text-amber-700 dark:text-amber-300 bg-amber-500/10 border border-amber-500/20 rounded-md">
               {loadError}
+            </div>
+          )}
+          {onShowMyPermissions && (
+            <div className="mb-4 rounded-md border border-theme-border bg-theme-elevated/50 p-3">
+              <div className="flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <h3 className="text-sm font-medium text-theme-text-primary">My permissions</h3>
+                  <p className="mt-0.5 text-xs text-theme-text-tertiary">
+                    View what your current identity can do in this cluster.
+                  </p>
+                </div>
+                <button
+                  onClick={onShowMyPermissions}
+                  className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-hover rounded-md transition-colors"
+                >
+                  <Shield className="w-3.5 h-3.5" />
+                  Open
+                </button>
+              </div>
             </div>
           )}
           <StartupConfigTab


### PR DESCRIPTION
## What

Moves the My permissions entry out of the always-visible top header and into Settings.

## Why

The extra topbar icon consumed scarce right-side header width, making long namespace labels more likely to collide with the centered navigation at laptop widths.

## Verification

- npx tsc --noEmit
- Built and ran local Radar; confirmed the header has more room with the permissions action removed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI relocation with no backend or RBAC logic changes; only discoverability of permissions moves behind Settings.
> 
> **Overview**
> **My permissions** is no longer a top-header icon; it lives in **Settings** as a card with an **Open** action that closes Settings and opens the existing `MyPermissionsDialog`.
> 
> This frees right-side header space so long namespace labels are less likely to collide with the centered nav on laptop widths. Behavior is unchanged aside from the entry path—`App` still owns `showMyPermissions` and wires `onShowMyPermissions` on `SettingsDialog`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47e86a58c778aaa51e81073763a4dae474c899cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->