### PR TITLE
Add env-sourced Prometheus headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ radar
 | `--list-page-size` | `0` (off) | Paginate the initial LIST of high-cardinality kinds (Pods, ReplicaSets) at this size. Helps very large clusters that fail to sync; only used when WatchList streaming is unavailable. Try `2000`. |
 | `--prometheus-url` | (auto-discover) | Manual Prometheus/VictoriaMetrics URL (skips auto-discovery) |
 | `--prometheus-header` | | HTTP header sent with every Prometheus request, format `Key=Value` (repeatable). Required for auth-protected backends. |
+| `--prometheus-header-from-env` | | HTTP header sent with every Prometheus request, sourced from an environment variable, format `Key=ENV_VAR` (repeatable). |
 | `--auth-mode` | `none` | Authentication mode: `none`, `proxy`, or `oidc` ([details](docs/authentication.md)) |
 | `--no-mcp` | `false` | Disable MCP server for AI tool integration |
 | `--version` | | Show version and exit |

--- a/cmd/desktop/main.go
+++ b/cmd/desktop/main.go
@@ -84,25 +84,32 @@ func main() {
 		log.Printf("ERROR: --kubeconfig and --kubeconfig-dir are mutually exclusive")
 		os.Exit(1)
 	}
+	resolvedPrometheusHeaders, err := app.ResolvePrometheusHeaders(fileCfg.PrometheusHeaders, fileCfg.PrometheusHeadersFromEnv)
+	if err != nil {
+		log.Printf("ERROR: invalid Prometheus header configuration: %v", err)
+		os.Exit(1)
+	}
 
 	cfg := app.AppConfig{
-		Kubeconfig:        *kubeconfig,
-		KubeconfigDirs:    app.ParseKubeconfigDirs(*kubeconfigDir),
-		Namespace:         *namespace,
-		Port:              fileCfg.PortOr(0), // Configured port, or random to avoid conflicts with CLI
-		DevMode:           false,
-		HistoryLimit:      *historyLimit,
-		DebugEvents:       *debugEvents,
-		FakeInCluster:     *fakeInCluster,
-		DisableHelmWrite:  *disableHelmWrite,
-		DisableExec:       *disableExec,
-		PodShellDefault:   *podShellDefault,
-		TimelineStorage:   *timelineStorage,
-		TimelineDBPath:    *timelineDBPath,
-		TimelineRetention: *timelineRetention,
-		PrometheusURL:     *prometheusURL,
-		Version:           version,
-		MCPEnabled:        fileCfg.MCPEnabledOr(true),
+		Kubeconfig:               *kubeconfig,
+		KubeconfigDirs:           app.ParseKubeconfigDirs(*kubeconfigDir),
+		Namespace:                *namespace,
+		Port:                     fileCfg.PortOr(0), // Configured port, or random to avoid conflicts with CLI
+		DevMode:                  false,
+		HistoryLimit:             *historyLimit,
+		DebugEvents:              *debugEvents,
+		FakeInCluster:            *fakeInCluster,
+		DisableHelmWrite:         *disableHelmWrite,
+		DisableExec:              *disableExec,
+		PodShellDefault:          *podShellDefault,
+		TimelineStorage:          *timelineStorage,
+		TimelineDBPath:           *timelineDBPath,
+		TimelineRetention:        *timelineRetention,
+		PrometheusURL:            *prometheusURL,
+		PrometheusHeaders:        resolvedPrometheusHeaders,
+		PrometheusHeadersFromEnv: fileCfg.PrometheusHeadersFromEnv,
+		Version:                  version,
+		MCPEnabled:               fileCfg.MCPEnabledOr(true),
 	}
 
 	app.SetGlobals(cfg)
@@ -157,7 +164,7 @@ func main() {
 	desktopApp := NewDesktopApp(srv, timelineStoreCfg)
 
 	// Run Wails application
-	err := wails.Run(&options.App{
+	err = wails.Run(&options.App{
 		Title:            windowTitle,
 		Width:            1440,
 		Height:           900,

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -71,6 +71,8 @@ func main() {
 	// than merging — matches kubectl semantics (file is the default, CLI wins).
 	promHeaders := newHeaderFlag(fileCfg.PrometheusHeaders)
 	flag.Var(promHeaders, "prometheus-header", "HTTP header to send with Prometheus requests, e.g. 'Authorization=Bearer <token>' (repeatable). Required for auth-protected backends.")
+	promHeadersFromEnv := newHeaderFromEnvFlag(fileCfg.PrometheusHeadersFromEnv)
+	flag.Var(promHeadersFromEnv, "prometheus-header-from-env", "HTTP header to send with Prometheus requests, sourced from an env var, e.g. 'Authorization=PROMETHEUS_TOKEN' (repeatable).")
 	// MCP server
 	noMCP := flag.Bool("no-mcp", !fileCfg.MCPEnabledOr(true), "Disable MCP (Model Context Protocol) server for AI tools")
 	// Auth flags
@@ -152,30 +154,35 @@ func main() {
 	if *kubeconfig != "" && *kubeconfigDir != "" {
 		log.Fatalf("--kubeconfig and --kubeconfig-dir are mutually exclusive")
 	}
+	resolvedPrometheusHeaders, err := app.ResolvePrometheusHeaders(promHeaders.value(), promHeadersFromEnv.value())
+	if err != nil {
+		log.Fatalf("Invalid Prometheus header configuration: %v", err)
+	}
 
 	cfg := app.AppConfig{
-		Kubeconfig:           *kubeconfig,
-		KubeconfigDirs:       app.ParseKubeconfigDirs(*kubeconfigDir),
-		Namespace:            *namespace,
-		Port:                 *port,
-		NoBrowser:            *noBrowser,
-		DevMode:              *devMode,
-		HistoryLimit:         *historyLimit,
-		DebugEvents:          *debugEvents,
-		FakeInCluster:        *fakeInCluster,
-		DisableHelmWrite:     *disableHelmWrite,
-		DisableExec:          *disableExec,
-		DisableLocalTerminal: *disableLocalTerminal,
-		PodShellDefault:      *podShellDefault,
-		DebugImage:           *debugImage,
-		ListPageSize:         *listPageSize,
-		TimelineStorage:      *timelineStorage,
-		TimelineDBPath:       *timelineDBPath,
-		TimelineRetention:    *timelineRetention,
-		PrometheusURL:        *prometheusURL,
-		PrometheusHeaders:    promHeaders.value(),
-		MCPEnabled:           !*noMCP,
-		Version:              version,
+		Kubeconfig:               *kubeconfig,
+		KubeconfigDirs:           app.ParseKubeconfigDirs(*kubeconfigDir),
+		Namespace:                *namespace,
+		Port:                     *port,
+		NoBrowser:                *noBrowser,
+		DevMode:                  *devMode,
+		HistoryLimit:             *historyLimit,
+		DebugEvents:              *debugEvents,
+		FakeInCluster:            *fakeInCluster,
+		DisableHelmWrite:         *disableHelmWrite,
+		DisableExec:              *disableExec,
+		DisableLocalTerminal:     *disableLocalTerminal,
+		PodShellDefault:          *podShellDefault,
+		DebugImage:               *debugImage,
+		ListPageSize:             *listPageSize,
+		TimelineStorage:          *timelineStorage,
+		TimelineDBPath:           *timelineDBPath,
+		TimelineRetention:        *timelineRetention,
+		PrometheusURL:            *prometheusURL,
+		PrometheusHeaders:        resolvedPrometheusHeaders,
+		PrometheusHeadersFromEnv: promHeadersFromEnv.value(),
+		MCPEnabled:               !*noMCP,
+		Version:                  version,
 		AuthConfig: auth.Config{
 			Mode:                      *authMode,
 			Secret:                    *authSecret,
@@ -396,5 +403,77 @@ func (h *headerFlag) Set(raw string) error {
 		h.overrides = true
 	}
 	h.m[key] = val
+	return nil
+}
+
+type headerFromEnvFlag struct {
+	m         map[string]string
+	overrides bool
+}
+
+func newHeaderFromEnvFlag(defaults map[string]string) *headerFromEnvFlag {
+	out := make(map[string]string, len(defaults))
+	for k, v := range defaults {
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		if !httpguts.ValidHeaderFieldName(k) {
+			log.Printf("[config] Dropping invalid prometheus header-from-env name %q (must be RFC 7230 tokens)", k)
+			continue
+		}
+		if !app.ValidEnvVarName(v) {
+			log.Printf("[config] Dropping prometheus header-from-env %q: invalid env var name %q", k, v)
+			continue
+		}
+		out[k] = v
+	}
+	return &headerFromEnvFlag{m: out}
+}
+
+func (h *headerFromEnvFlag) value() map[string]string {
+	if len(h.m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(h.m))
+	maps.Copy(out, h.m)
+	return out
+}
+
+func (h *headerFromEnvFlag) String() string {
+	if len(h.m) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(h.m))
+	for k := range h.m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+"="+h.m[k])
+	}
+	return strings.Join(parts, ",")
+}
+
+func (h *headerFromEnvFlag) Set(raw string) error {
+	idx := strings.IndexByte(raw, '=')
+	if idx <= 0 {
+		return fmt.Errorf("expected Key=ENV_VAR, got %q", raw)
+	}
+	key := strings.TrimSpace(raw[:idx])
+	envName := strings.TrimSpace(raw[idx+1:])
+	if key == "" {
+		return fmt.Errorf("empty header key in %q", raw)
+	}
+	if !httpguts.ValidHeaderFieldName(key) {
+		return fmt.Errorf("invalid header name %q (must be RFC 7230 tokens)", key)
+	}
+	if !app.ValidEnvVarName(envName) {
+		return fmt.Errorf("invalid env var name %q for header %q", envName, key)
+	}
+	if !h.overrides {
+		h.m = make(map[string]string)
+		h.overrides = true
+	}
+	h.m[key] = envName
 	return nil
 }

--- a/cmd/explorer/main_test.go
+++ b/cmd/explorer/main_test.go
@@ -146,3 +146,110 @@ func TestHeaderFlagValueCopies(t *testing.T) {
 		t.Error("value() must return a defensive copy — caller mutation leaked into headerFlag state")
 	}
 }
+
+func TestHeaderFromEnvFlagSet(t *testing.T) {
+	cases := []struct {
+		name    string
+		inputs  []string
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name:   "simple key=env",
+			inputs: []string{"Authorization=PROMETHEUS_TOKEN"},
+			want:   map[string]string{"Authorization": "PROMETHEUS_TOKEN"},
+		},
+		{
+			name:   "two flags accumulate",
+			inputs: []string{"Authorization=PROMETHEUS_TOKEN", "X-Scope-OrgID=PROMETHEUS_TENANT"},
+			want: map[string]string{
+				"Authorization": "PROMETHEUS_TOKEN",
+				"X-Scope-OrgID": "PROMETHEUS_TENANT",
+			},
+		},
+		{
+			name:   "key and env trimmed",
+			inputs: []string{"  Authorization  =  PROMETHEUS_TOKEN  "},
+			want:   map[string]string{"Authorization": "PROMETHEUS_TOKEN"},
+		},
+		{
+			name:    "no equals",
+			inputs:  []string{"Authorization"},
+			wantErr: true,
+		},
+		{
+			name:    "empty key",
+			inputs:  []string{"=PROMETHEUS_TOKEN"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid header name",
+			inputs:  []string{"Bad Header=PROMETHEUS_TOKEN"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid env var name",
+			inputs:  []string{"Authorization=prometheus-token"},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHeaderFromEnvFlag(nil)
+			var lastErr error
+			for _, in := range tc.inputs {
+				lastErr = h.Set(in)
+				if lastErr != nil {
+					break
+				}
+			}
+			if tc.wantErr {
+				if lastErr == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if lastErr != nil {
+				t.Fatalf("unexpected error: %v", lastErr)
+			}
+			if !reflect.DeepEqual(h.value(), tc.want) {
+				t.Errorf("got %v, want %v", h.value(), tc.want)
+			}
+		})
+	}
+}
+
+func TestHeaderFromEnvFlagOverridesFileDefaults(t *testing.T) {
+	defaults := map[string]string{
+		"Authorization": "PROMETHEUS_TOKEN",
+		"X-Tenant":      "PROMETHEUS_TENANT",
+	}
+
+	t.Run("no CLI flags keeps defaults", func(t *testing.T) {
+		h := newHeaderFromEnvFlag(defaults)
+		if !reflect.DeepEqual(h.value(), defaults) {
+			t.Errorf("got %v, want %v", h.value(), defaults)
+		}
+	})
+
+	t.Run("one CLI flag wipes defaults", func(t *testing.T) {
+		h := newHeaderFromEnvFlag(defaults)
+		if err := h.Set("X-New=PROMETHEUS_NEW"); err != nil {
+			t.Fatalf("Set failed: %v", err)
+		}
+		want := map[string]string{"X-New": "PROMETHEUS_NEW"}
+		if !reflect.DeepEqual(h.value(), want) {
+			t.Errorf("got %v, want %v", h.value(), want)
+		}
+	})
+}
+
+func TestHeaderFromEnvFlagValueCopies(t *testing.T) {
+	h := newHeaderFromEnvFlag(map[string]string{"A": "PROMETHEUS_TOKEN"})
+	got := h.value()
+	got["A"] = "MUTATED"
+	if h.value()["A"] != "PROMETHEUS_TOKEN" {
+		t.Error("value() must return a defensive copy — caller mutation leaked into headerFromEnvFlag state")
+	}
+}

--- a/deploy/helm/radar/README.md
+++ b/deploy/helm/radar/README.md
@@ -95,6 +95,7 @@ touches its contents.
 | `persistence.enabled` | Enable PVC for SQLite | `false` |
 | `traffic.prometheusUrl` | Manual Prometheus/VictoriaMetrics URL (skips auto-discovery) | `""` |
 | `traffic.prometheusHeaders` | HTTP headers sent with every Prometheus request (auth-protected backends) | `{}` |
+| `traffic.prometheusHeadersFromEnv` | Prometheus headers sourced from environment variables, for secret-backed auth headers | `{}` |
 | `resources.limits.memory` | Memory limit | `512Mi` |
 | `resources.requests.memory` | Memory request | `128Mi` |
 

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -58,6 +58,9 @@ spec:
             {{- range $k, $v := .Values.traffic.prometheusHeaders }}
             - {{ printf "--prometheus-header=%s=%s" $k $v | quote }}
             {{- end }}
+            {{- range $k, $v := .Values.traffic.prometheusHeadersFromEnv }}
+            - {{ printf "--prometheus-header-from-env=%s=%s" $k $v | quote }}
+            {{- end }}
             {{- if not .Values.mcp.enabled }}
             - --no-mcp
             {{- end }}

--- a/deploy/helm/radar/values.schema.json
+++ b/deploy/helm/radar/values.schema.json
@@ -252,6 +252,10 @@
         "prometheusHeaders": {
           "type": "object",
           "additionalProperties": { "type": "string" }
+        },
+        "prometheusHeadersFromEnv": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
         }
       }
     },

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -361,14 +361,25 @@ traffic:
   prometheusUrl: ""
   # HTTP headers sent with every Prometheus request. Required for
   # auth-protected backends (Bearer tokens, X-Scope-OrgID multi-tenancy, etc.).
-  # Values are rendered into the pod spec — for secrets, mount them via env
-  # and reference the env var in your own values file, or template these
-  # values from an external secret store (sealed-secrets, external-secrets).
+  # Values are rendered into the pod spec; use prometheusHeadersFromEnv for
+  # secrets.
   # Example:
   #   prometheusHeaders:
-  #     Authorization: "Bearer <token>"
   #     X-Scope-OrgID: "my-org"
   prometheusHeaders: {}
+  # HTTP headers sourced from environment variables at Radar startup. Use with
+  # env[].valueFrom.secretKeyRef to keep tokens out of container args and pod
+  # specs.
+  # Example:
+  #   prometheusHeadersFromEnv:
+  #     Authorization: PROMETHEUS_TOKEN
+  #   env:
+  #     - name: PROMETHEUS_TOKEN
+  #       valueFrom:
+  #         secretKeyRef:
+  #           name: prometheus-auth
+  #           key: token
+  prometheusHeadersFromEnv: {}
 
 # Persistence for SQLite timeline storage
 # Required when timeline.storage is "sqlite" (readOnlyRootFilesystem prevents local writes)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,8 @@ All fields are optional — omitted fields use built-in defaults.
 | `timelineDbPath` | Path to SQLite database |
 | `historyLimit` | Max timeline events to retain |
 | `prometheusUrl` | Manual Prometheus/VictoriaMetrics URL — skips auto-discovery. Useful when Prometheus is not in the same cluster or uses a non-standard service name. |
-| `prometheusHeaders` | HTTP headers sent with every Prometheus request. Required for auth-protected backends — e.g. `{"Authorization": "Bearer <token>", "X-Scope-OrgID": "my-org"}`. Equivalent CLI: `--prometheus-header Key=Value` (repeatable). Stored in plain text in `config.json` — protect the file accordingly. |
+| `prometheusHeaders` | HTTP headers sent with every Prometheus request. Required for auth-protected backends — e.g. `{"X-Scope-OrgID": "my-org"}`. Equivalent CLI: `--prometheus-header Key=Value` (repeatable). Stored in plain text in `config.json` — protect the file accordingly. |
+| `prometheusHeadersFromEnv` | Header values read from environment variables at startup — e.g. `{"Authorization": "PROMETHEUS_TOKEN"}`. Equivalent CLI: `--prometheus-header-from-env Key=ENV_VAR` (repeatable). Use this with Kubernetes Secret-backed env vars in Helm deployments. |
 | `mcp` | Enable/disable MCP server for AI tools (default: enabled) |
 | `debugImage` | Image for ephemeral debug containers and node debug pods (same as `--debug-image`). Empty = `busybox:latest`; point at a mirror for air-gapped / private-registry clusters. |
 

--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -303,6 +303,7 @@ See [Helm Chart README](../deploy/helm/radar/README.md) for all available values
 | `timeline.historyLimit` | Max events to retain (memory only) | `10000` |
 | `timeline.retention` | SQLite retention (Go duration; `0` disables) | `168h` |
 | `traffic.prometheusUrl` | Manual Prometheus/VictoriaMetrics URL | `""` (auto-discover) |
+| `traffic.prometheusHeadersFromEnv` | Prometheus headers sourced from environment variables, for secret-backed auth headers | `{}` |
 | `persistence.enabled` | Enable PVC for SQLite storage | `false` |
 | `persistence.size` | PVC size | `1Gi` |
 | `rbac.podLogs` | Enable log viewer | `true` |

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -26,29 +26,30 @@ import (
 
 // AppConfig holds all parsed configuration for the Radar application.
 type AppConfig struct {
-	Kubeconfig           string
-	KubeconfigDirs       []string
-	Namespace            string
-	Port                 int
-	NoBrowser            bool
-	DevMode              bool
-	HistoryLimit         int
-	DebugEvents          bool
-	FakeInCluster        bool
-	DisableHelmWrite     bool
-	DisableExec          bool
-	DisableLocalTerminal bool
-	PodShellDefault      string
-	DebugImage           string
-	ListPageSize         int64
-	TimelineStorage      string
-	TimelineDBPath       string
-	TimelineRetention    time.Duration
-	PrometheusURL        string
-	PrometheusHeaders    map[string]string
-	Version              string
-	MCPEnabled           bool
-	AuthConfig           auth.Config
+	Kubeconfig               string
+	KubeconfigDirs           []string
+	Namespace                string
+	Port                     int
+	NoBrowser                bool
+	DevMode                  bool
+	HistoryLimit             int
+	DebugEvents              bool
+	FakeInCluster            bool
+	DisableHelmWrite         bool
+	DisableExec              bool
+	DisableLocalTerminal     bool
+	PodShellDefault          string
+	DebugImage               string
+	ListPageSize             int64
+	TimelineStorage          string
+	TimelineDBPath           string
+	TimelineRetention        time.Duration
+	PrometheusURL            string
+	PrometheusHeaders        map[string]string
+	PrometheusHeadersFromEnv map[string]string
+	Version                  string
+	MCPEnabled               bool
+	AuthConfig               auth.Config
 }
 
 // SetGlobals applies debug/test flags to global state.
@@ -159,18 +160,19 @@ func RegisterCallbacks(cfg AppConfig, timelineStoreCfg timeline.StoreConfig) {
 // CreateServer creates the HTTP server with the given configuration.
 func CreateServer(cfg AppConfig) *server.Server {
 	effectiveCfg := &config.Config{
-		Kubeconfig:        cfg.Kubeconfig,
-		KubeconfigDirs:    cfg.KubeconfigDirs,
-		Namespace:         cfg.Namespace,
-		Port:              cfg.Port,
-		NoBrowser:         cfg.NoBrowser,
-		TimelineStorage:   cfg.TimelineStorage,
-		TimelineDBPath:    cfg.TimelineDBPath,
-		HistoryLimit:      cfg.HistoryLimit,
-		PrometheusURL:     cfg.PrometheusURL,
-		PrometheusHeaders: cfg.PrometheusHeaders,
-		DebugImage:        cfg.DebugImage,
-		MCP:               &cfg.MCPEnabled,
+		Kubeconfig:               cfg.Kubeconfig,
+		KubeconfigDirs:           cfg.KubeconfigDirs,
+		Namespace:                cfg.Namespace,
+		Port:                     cfg.Port,
+		NoBrowser:                cfg.NoBrowser,
+		TimelineStorage:          cfg.TimelineStorage,
+		TimelineDBPath:           cfg.TimelineDBPath,
+		HistoryLimit:             cfg.HistoryLimit,
+		PrometheusURL:            cfg.PrometheusURL,
+		PrometheusHeaders:        cfg.PrometheusHeaders,
+		PrometheusHeadersFromEnv: cfg.PrometheusHeadersFromEnv,
+		DebugImage:               cfg.DebugImage,
+		MCP:                      &cfg.MCPEnabled,
 	}
 
 	serverCfg := server.Config{

--- a/internal/app/prometheus_headers.go
+++ b/internal/app/prometheus_headers.go
@@ -1,0 +1,80 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/net/http/httpguts"
+)
+
+// ResolvePrometheusHeaders combines literal headers with headers sourced from
+// environment variables. Env-sourced entries fail closed when the variable is
+// unset so auth-protected Prometheus backends do not silently receive bad creds.
+func ResolvePrometheusHeaders(headers, headersFromEnv map[string]string) (map[string]string, error) {
+	if len(headers) == 0 && len(headersFromEnv) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(headers)+len(headersFromEnv))
+	for key, val := range headers {
+		key = strings.TrimSpace(key)
+		if err := validatePrometheusHeader(key, val); err != nil {
+			return nil, err
+		}
+		out[key] = val
+	}
+	for key, envName := range headersFromEnv {
+		key = strings.TrimSpace(key)
+		envName = strings.TrimSpace(envName)
+		if key == "" {
+			return nil, fmt.Errorf("empty prometheus header key for env var %q", envName)
+		}
+		if _, exists := out[key]; exists {
+			return nil, fmt.Errorf("prometheus header %q configured both as a literal value and from env", key)
+		}
+		if !ValidEnvVarName(envName) {
+			return nil, fmt.Errorf("invalid env var name %q for prometheus header %q", envName, key)
+		}
+		val, ok := os.LookupEnv(envName)
+		if !ok {
+			return nil, fmt.Errorf("prometheus header %q references unset env var %q", key, envName)
+		}
+		if err := validatePrometheusHeader(key, val); err != nil {
+			return nil, err
+		}
+		out[key] = val
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+func validatePrometheusHeader(key, val string) error {
+	if key == "" {
+		return fmt.Errorf("empty prometheus header key")
+	}
+	if !httpguts.ValidHeaderFieldName(key) {
+		return fmt.Errorf("invalid prometheus header name %q (must be RFC 7230 tokens)", key)
+	}
+	if !httpguts.ValidHeaderFieldValue(val) {
+		return fmt.Errorf("invalid prometheus header value for %q (control characters not allowed)", key)
+	}
+	return nil
+}
+
+func ValidEnvVarName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		if r == '_' || ('A' <= r && r <= 'Z') || ('a' <= r && r <= 'z') {
+			continue
+		}
+		if i > 0 && '0' <= r && r <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/internal/app/prometheus_headers_test.go
+++ b/internal/app/prometheus_headers_test.go
@@ -1,0 +1,97 @@
+package app
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestResolvePrometheusHeaders(t *testing.T) {
+	t.Setenv("PROM_TOKEN", "Bearer secret")
+	t.Setenv("PROM_TENANT", "tenant-1")
+
+	got, err := ResolvePrometheusHeaders(
+		map[string]string{"X-Static": "literal"},
+		map[string]string{
+			"Authorization": "PROM_TOKEN",
+			"X-Scope-OrgID": "PROM_TENANT",
+		},
+	)
+	if err != nil {
+		t.Fatalf("ResolvePrometheusHeaders failed: %v", err)
+	}
+	want := map[string]string{
+		"X-Static":      "literal",
+		"Authorization": "Bearer secret",
+		"X-Scope-OrgID": "tenant-1",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestResolvePrometheusHeadersFailures(t *testing.T) {
+	t.Setenv("PROM_TOKEN", "Bearer secret")
+	t.Setenv("BAD_VALUE", "safe\r\nInjected: bad")
+
+	cases := []struct {
+		name           string
+		headers        map[string]string
+		headersFromEnv map[string]string
+		wantErr        string
+	}{
+		{
+			name:           "unset env var",
+			headersFromEnv: map[string]string{"Authorization": "MISSING_TOKEN"},
+			wantErr:        "unset env var",
+		},
+		{
+			name:           "invalid env var name",
+			headersFromEnv: map[string]string{"Authorization": "1TOKEN"},
+			wantErr:        "invalid env var name",
+		},
+		{
+			name:           "duplicate source",
+			headers:        map[string]string{"Authorization": "literal"},
+			headersFromEnv: map[string]string{"Authorization": "PROM_TOKEN"},
+			wantErr:        "configured both",
+		},
+		{
+			name:           "invalid resolved value",
+			headersFromEnv: map[string]string{"Authorization": "BAD_VALUE"},
+			wantErr:        "control characters",
+		},
+		{
+			name:           "invalid header name",
+			headersFromEnv: map[string]string{"Bad Header": "PROM_TOKEN"},
+			wantErr:        "invalid prometheus header name",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ResolvePrometheusHeaders(tc.headers, tc.headersFromEnv)
+			if err == nil {
+				t.Fatalf("expected error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("got error %q, want substring %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidEnvVarName(t *testing.T) {
+	valid := []string{"PROM_TOKEN", "_PROM_TOKEN", "PROM_TOKEN_1"}
+	for _, name := range valid {
+		if !ValidEnvVarName(name) {
+			t.Errorf("%q should be valid", name)
+		}
+	}
+	invalid := []string{"", "1PROM_TOKEN", "PROM-TOKEN", "PROM.TOKEN"}
+	for _, name := range invalid {
+		if ValidEnvVarName(name) {
+			t.Errorf("%q should be invalid", name)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,8 +26,9 @@ type Config struct {
 	// PrometheusHeaders are sent with every request to the Prometheus API.
 	// Required for auth-protected backends (Bearer tokens, X-Scope-OrgID, etc.).
 	// Stored in plain text in ~/.radar/config.json — protect the file accordingly.
-	PrometheusHeaders map[string]string `json:"prometheusHeaders,omitempty"`
-	MCP               *bool             `json:"mcp,omitempty"` // nil = default (true), false = disabled
+	PrometheusHeaders        map[string]string `json:"prometheusHeaders,omitempty"`
+	PrometheusHeadersFromEnv map[string]string `json:"prometheusHeadersFromEnv,omitempty"`
+	MCP                      *bool             `json:"mcp,omitempty"` // nil = default (true), false = disabled
 	// DebugImage is the image used for ephemeral debug containers and node debug
 	// pods. Empty falls back to busybox:latest; set it to a reachable mirror for
 	// air-gapped / private-registry clusters.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -41,6 +41,9 @@ func TestSaveAndLoad(t *testing.T) {
 			"Authorization": "Bearer abc",
 			"X-Scope-OrgID": "tenant-1",
 		},
+		PrometheusHeadersFromEnv: map[string]string{
+			"X-Api-Key": "PROMETHEUS_API_KEY",
+		},
 		MCP: &mcp,
 	}
 
@@ -83,6 +86,10 @@ func TestSaveAndLoad(t *testing.T) {
 		got.PrometheusHeaders["Authorization"] != "Bearer abc" ||
 		got.PrometheusHeaders["X-Scope-OrgID"] != "tenant-1" {
 		t.Errorf("PrometheusHeaders = %v, want %v", got.PrometheusHeaders, want.PrometheusHeaders)
+	}
+	if len(got.PrometheusHeadersFromEnv) != 1 ||
+		got.PrometheusHeadersFromEnv["X-Api-Key"] != "PROMETHEUS_API_KEY" {
+		t.Errorf("PrometheusHeadersFromEnv = %v, want %v", got.PrometheusHeadersFromEnv, want.PrometheusHeadersFromEnv)
 	}
 }
 

--- a/scripts/test-chart.sh
+++ b/scripts/test-chart.sh
@@ -25,13 +25,13 @@ pass() {
 
 assert_contains() {
   local pattern="$1" label="$2"
-  if echo "$OUT" | grep -Eq "$pattern"; then pass "$label"
+  if echo "$OUT" | grep -Eq -- "$pattern"; then pass "$label"
   else fail "$label — no match for: $pattern"; fi
 }
 
 assert_not_contains() {
   local pattern="$1" label="$2"
-  if echo "$OUT" | grep -Eq "$pattern"; then fail "$label — unexpected match for: $pattern"
+  if echo "$OUT" | grep -Eq -- "$pattern"; then fail "$label — unexpected match for: $pattern"
   else pass "$label"; fi
 }
 
@@ -54,6 +54,21 @@ assert_not_contains '^kind: RoleBinding$'           "no namespaced RoleBinding"
 assert_not_contains 'MY_POD_NAMESPACE'              "no downward-API env var"
 assert_not_contains 'MY_DEPLOYMENT_NAME'            "no deployment-name env var"
 assert_not_contains 'self-upgrade'                  "no self-upgrade references anywhere"
+echo
+
+render "prometheusHeadersFromEnv — flag and secret env stay separate" \
+  --set traffic.prometheusHeaders.X-Scope-OrgID=tenant-1 \
+  --set traffic.prometheusHeadersFromEnv.Authorization=PROMETHEUS_TOKEN \
+  --set 'env[0].name=PROMETHEUS_TOKEN' \
+  --set 'env[0].valueFrom.secretKeyRef.name=prometheus-auth' \
+  --set 'env[0].valueFrom.secretKeyRef.key=token'
+assert_contains '--prometheus-header=X-Scope-OrgID=tenant-1'           "literal Prometheus header rendered"
+assert_contains '--prometheus-header-from-env=Authorization=PROMETHEUS_TOKEN' "env-sourced Prometheus header flag rendered"
+assert_contains 'name: PROMETHEUS_TOKEN'                              "custom env var rendered"
+assert_contains 'secretKeyRef:'                                       "secretKeyRef rendered"
+assert_contains 'name: prometheus-auth'                               "secret name rendered"
+assert_contains 'key: token'                                          "secret key rendered"
+assert_not_contains '--prometheus-header=Authorization='               "secret value not rendered as a literal header"
 echo
 
 render "rbac.selfUpgrade=true — full feature wiring" --set rbac.selfUpgrade=true


### PR DESCRIPTION
## Summary

Adds an env-backed Prometheus header path so Helm deployments can source auth headers from Kubernetes Secret-backed environment variables instead of rendering secret values into container args.

The CLI now accepts repeatable `--prometheus-header-from-env Key=ENV_VAR`, startup resolves those env vars with header validation and fail-fast errors, and the Helm chart exposes `traffic.prometheusHeadersFromEnv` alongside the existing literal `traffic.prometheusHeaders` map.

Closes #779.

## Verification

- `go test ./cmd/explorer ./internal/app ./internal/config`
- `go test ./cmd/desktop`
- `helm lint deploy/helm/radar`
- `make build`
- Focused `helm template` check for literal + env-sourced Prometheus headers
- Local smoke against `gke_koalabackend_us-central1_radar-test-autopilot`: ran built `./radar` with `PROMETHEUS_TOKEN='Bearer smoke-secret-835' --prometheus-header-from-env Authorization=PROMETHEUS_TOKEN`, verified `/api/health`, `/api/cluster-info`, and `/api/resource-counts`
- In-cluster Secret smoke on `kind-radar-gitops-demo`: built the branch Linux binary into image `radar-pr-835:secret-env`, loaded it into kind, installed the local chart with `traffic.prometheusHeadersFromEnv.Authorization=PROMETHEUS_TOKEN` and `env[].valueFrom.secretKeyRef`, verified the pod was `1/1 Running`, the Deployment args contained only `PROMETHEUS_TOKEN` (not the secret value), and `/api/health` returned healthy through the Service
- Negative startup check: unset `PROMETHEUS_TOKEN` fails fast before server startup

Playwright browser smoke was skipped because the MCP browser profile was already in use.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration and metrics-client auth wiring only; fail-closed validation reduces risk of misconfigured Prometheus access. No changes to core K8s RBAC or user auth paths.
> 
> **Overview**
> Adds **`--prometheus-header-from-env Key=ENV_VAR`** (repeatable) and config/Helm **`prometheusHeadersFromEnv`** so Prometheus auth headers can be loaded from environment variables at startup instead of literals in args or `config.json`.
> 
> Startup now runs **`ResolvePrometheusHeaders`**, merging literal and env-backed headers with RFC 7230 validation, duplicate-key rejection, and **fail-fast** if a referenced env var is missing (avoids silently calling protected Prometheus without credentials). Explorer and desktop wire resolved headers into **`AppConfig`**; the Helm chart renders **`--prometheus-header-from-env`** from **`traffic.prometheusHeadersFromEnv`** and documents pairing with **`env[].valueFrom.secretKeyRef`**.
> 
> Docs/README/values cover the new option; chart smoke tests assert secret env vars and header flags stay separate (no token in pod args). Minor **`scripts/test-chart.sh`** change: **`grep -Eq --`** for safer pattern matching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c62b75400543d6e53a244c9c59754f3c29ed8f61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->