### PR TITLE
Reduce timeline storage growth

### DIFF
--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -420,9 +420,9 @@ func recordToTimelineStore(kind, namespace, name, uid, op string, oldObj, newObj
 					NewValue: f.NewValue,
 				}
 			}
-		} else if KindHasDiffer(kind) {
-			// Audited diff function found nothing observable — usually a
-			// heartbeat, managedFields-only update, or reconcile counter.
+		} else if KindHasDiffer(kind) || isUnstructuredUpdate(oldObj, newObj) {
+			// Diff handling found nothing observable — usually a heartbeat,
+			// managedFields-only update, or reconcile counter.
 			// Before dropping, check metadata.generation: it bumps only on
 			// spec changes (status updates don't touch it), so a generation
 			// flip with a nil diff means our diff function missed a real spec
@@ -491,8 +491,11 @@ func recordToTimelineStore(kind, namespace, name, uid, op string, oldObj, newObj
 				ctx := context.Background()
 				if err := timeline.RecordEventsWithBroadcast(ctx, events); err != nil {
 					log.Printf("Warning: failed to record historical events: %v", err)
+					timeline.RecordDrop(kind, namespace, name, timeline.DropReasonStoreFailed, op)
+					return
 				}
 			}
+			store.MarkResourceSeen(kind, namespace, name)
 			return
 		}
 	}
@@ -511,6 +514,12 @@ func recordToTimelineStore(kind, namespace, name, uid, op string, oldObj, newObj
 	if op == "add" {
 		store.MarkResourceSeen(kind, namespace, name)
 	}
+}
+
+func isUnstructuredUpdate(oldObj, newObj any) bool {
+	_, oldOK := oldObj.(*unstructured.Unstructured)
+	_, newOK := newObj.(*unstructured.Unstructured)
+	return oldOK && newOK
 }
 
 // extractAPIVersion returns the resource's apiVersion (e.g. "cluster.x-k8s.io/v1beta1")

--- a/internal/k8s/history.go
+++ b/internal/k8s/history.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"reflect"
 	"strings"
 	"sync"
 
@@ -65,13 +66,25 @@ var diffFunctions = map[string]kindDiffFunc{
 func ComputeDiff(kind string, oldObj, newObj any) *DiffInfo {
 	fn, ok := diffFunctions[kind]
 	if !ok {
-		return nil
+		oldU, newU, ok := unstructuredPair(oldObj, newObj)
+		if !ok {
+			return nil
+		}
+		changes, summaryParts := diffGenericUnstructured(oldU, newU)
+		if len(changes) == 0 {
+			return nil
+		}
+		return buildDiff(changes, summaryParts)
 	}
 	changes, summaryParts := fn(oldObj, newObj)
 	if len(changes) == 0 {
 		return nil
 	}
 
+	return buildDiff(changes, summaryParts)
+}
+
+func buildDiff(changes []FieldChange, summaryParts []string) *DiffInfo {
 	var summary strings.Builder
 	if len(summaryParts) > 0 {
 		for i, part := range summaryParts {
@@ -86,6 +99,12 @@ func ComputeDiff(kind string, oldObj, newObj any) *DiffInfo {
 		Fields:  changes,
 		Summary: summary.String(),
 	}
+}
+
+func unstructuredPair(oldObj, newObj any) (*unstructured.Unstructured, *unstructured.Unstructured, bool) {
+	oldU, ok1 := oldObj.(*unstructured.Unstructured)
+	newU, ok2 := newObj.(*unstructured.Unstructured)
+	return oldU, newU, ok1 && ok2 && oldU != nil && newU != nil
 }
 
 // typeAssertWarnedKinds dedups one-time warnings about type-assertion failures
@@ -109,6 +128,124 @@ func warnUnstructuredAssertFailed(kind string, got any) {
 func KindHasDiffer(kind string) bool {
 	_, ok := diffFunctions[kind]
 	return ok
+}
+
+func diffGenericUnstructured(oldU, newU *unstructured.Unstructured) ([]FieldChange, []string) {
+	var changes []FieldChange
+	var summary []string
+
+	if oldGen, newGen := oldU.GetGeneration(), newU.GetGeneration(); oldGen != newGen && oldGen > 0 && newGen > 0 {
+		changes = append(changes, FieldChange{
+			Path:     "metadata.generation",
+			OldValue: oldGen,
+			NewValue: newGen,
+		})
+		summary = append(summary, fmt.Sprintf("spec changed (gen %d→%d, fields not specifically tracked)", oldGen, newGen))
+	}
+
+	for _, change := range genericConditionChanges(oldU, newU, "status", "conditions") {
+		changes = append(changes, change)
+		summary = append(summary, fmt.Sprintf("%s changed", change.Path))
+	}
+
+	if len(changes) > 0 {
+		return changes, summary
+	}
+
+	oldNorm := normalizedUnstructuredForTimeline(oldU)
+	newNorm := normalizedUnstructuredForTimeline(newU)
+	if reflect.DeepEqual(oldNorm, newNorm) {
+		return nil, nil
+	}
+
+	return []FieldChange{{
+		Path:     "resource",
+		OldValue: "changed",
+		NewValue: "changed",
+	}}, []string{"resource changed"}
+}
+
+func genericConditionChanges(oldU, newU *unstructured.Unstructured, fields ...string) []FieldChange {
+	oldConditions := genericConditionSignalMap(oldU.Object, fields...)
+	newConditions := genericConditionSignalMap(newU.Object, fields...)
+	keys := make(map[string]struct{}, len(oldConditions)+len(newConditions))
+	for k := range oldConditions {
+		keys[k] = struct{}{}
+	}
+	for k := range newConditions {
+		keys[k] = struct{}{}
+	}
+
+	var changes []FieldChange
+	for key := range keys {
+		oldVal, oldOK := oldConditions[key]
+		newVal, newOK := newConditions[key]
+		if oldOK != newOK || oldVal != newVal {
+			changes = append(changes, FieldChange{
+				Path:     fmt.Sprintf("%s[%s]", strings.Join(fields, "."), key),
+				OldValue: oldVal,
+				NewValue: newVal,
+			})
+		}
+	}
+	return changes
+}
+
+func genericConditionSignalMap(obj map[string]any, fields ...string) map[string]string {
+	conditions, found, _ := unstructured.NestedSlice(obj, fields...)
+	if !found {
+		return nil
+	}
+	out := make(map[string]string, len(conditions))
+	for _, item := range conditions {
+		cond, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		typ, _ := cond["type"].(string)
+		if typ == "" {
+			continue
+		}
+		status, _ := cond["status"].(string)
+		reason, _ := cond["reason"].(string)
+		out[typ] = status + "\x00" + reason
+	}
+	return out
+}
+
+func normalizedUnstructuredForTimeline(u *unstructured.Unstructured) map[string]any {
+	cp := u.DeepCopy().Object
+	normalizeTimelineObject(cp)
+	return cp
+}
+
+func normalizeTimelineObject(v any) {
+	switch typed := v.(type) {
+	case map[string]any:
+		for k, child := range typed {
+			if isTimelineNoiseKey(k) {
+				delete(typed, k)
+				continue
+			}
+			normalizeTimelineObject(child)
+		}
+	case []any:
+		for _, child := range typed {
+			normalizeTimelineObject(child)
+		}
+	}
+}
+
+func isTimelineNoiseKey(key string) bool {
+	switch key {
+	case "resourceVersion", "managedFields", "observedGeneration",
+		"lastTransitionTime", "lastUpdateTime", "lastHeartbeatTime", "lastProbeTime",
+		"lastReconcileTime", "lastReconciledTime", "lastSyncTime",
+		"lastHandledReconcileAt", "lastHandledRefresh":
+		return true
+	default:
+		return false
+	}
 }
 
 // diffDeployment computes diff for Deployment resources
@@ -1020,10 +1157,10 @@ func diffJob(oldObj, newObj any) ([]FieldChange, []string) {
 	// Check terminal conditions. CompletionTime alone misses Failed jobs
 	// (which never set CompletionTime) and the FailureTarget signal.
 	jobCondSummary := map[batchv1.JobConditionType]string{
-		batchv1.JobComplete:       "completed",
-		batchv1.JobFailed:         "failed",
-		batchv1.JobFailureTarget:  "failure target",
-		batchv1.JobSuspended:      "suspended",
+		batchv1.JobComplete:      "completed",
+		batchv1.JobFailed:        "failed",
+		batchv1.JobFailureTarget: "failure target",
+		batchv1.JobSuspended:     "suspended",
 	}
 	for _, condType := range []batchv1.JobConditionType{batchv1.JobComplete, batchv1.JobFailed, batchv1.JobSuspended, batchv1.JobFailureTarget} {
 		oldStatus := getJobConditionStatus(oldJob, condType)
@@ -2376,4 +2513,3 @@ func getConditionMap(obj map[string]any, path ...string) map[string]string {
 	}
 	return result
 }
-

--- a/internal/k8s/noisy_filter_audit_test.go
+++ b/internal/k8s/noisy_filter_audit_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/skyhook-io/radar/internal/timeline"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
@@ -75,6 +76,111 @@ func TestComputeDiff_NodeHeartbeatOnly_ReturnsNil(t *testing.T) {
 	diff := ComputeDiff("Node", base, updated)
 	if diff != nil {
 		t.Fatalf("expected nil diff for heartbeat-only Node update, got %+v", diff)
+	}
+}
+
+func TestComputeDiff_UnknownCRDMetadataOnly_ReturnsNil(t *testing.T) {
+	base := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "example.io/v1",
+		"kind":       "Widget",
+		"metadata": map[string]any{
+			"name":            "w",
+			"namespace":       "default",
+			"resourceVersion": "1",
+			"generation":      int64(3),
+		},
+		"status": map[string]any{
+			"observedGeneration": int64(3),
+			"conditions": []any{map[string]any{
+				"type":               "Ready",
+				"status":             "True",
+				"reason":             "Available",
+				"lastTransitionTime": "2026-05-31T10:00:00Z",
+			}},
+		},
+	}}
+
+	updated := base.DeepCopy()
+	updated.SetResourceVersion("2")
+	_ = unstructured.SetNestedField(updated.Object, int64(3), "status", "observedGeneration")
+	_ = unstructured.SetNestedSlice(updated.Object, []any{map[string]any{
+		"type":               "Ready",
+		"status":             "True",
+		"reason":             "Available",
+		"lastTransitionTime": "2026-05-31T10:05:00Z",
+	}}, "status", "conditions")
+
+	if diff := ComputeDiff("Widget", base, updated); diff != nil {
+		t.Fatalf("expected nil diff for metadata/timestamp-only unknown CRD update, got %+v", diff)
+	}
+}
+
+func TestComputeDiff_UnknownCRDConditionStatus_Detected(t *testing.T) {
+	base := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "example.io/v1",
+		"kind":       "Widget",
+		"metadata": map[string]any{
+			"name":       "w",
+			"namespace":  "default",
+			"generation": int64(3),
+		},
+		"status": map[string]any{
+			"conditions": []any{map[string]any{"type": "Ready", "status": "False", "reason": "Reconciling"}},
+		},
+	}}
+	updated := base.DeepCopy()
+	_ = unstructured.SetNestedSlice(updated.Object, []any{map[string]any{"type": "Ready", "status": "True", "reason": "Available"}}, "status", "conditions")
+
+	diff := ComputeDiff("Widget", base, updated)
+	if diff == nil || !containsPath(diff, "status.conditions[Ready]") {
+		t.Fatalf("expected Ready condition diff for unknown CRD, got %+v", diff)
+	}
+}
+
+func TestComputeDiff_UnknownCRDArbitraryStatus_Detected(t *testing.T) {
+	base := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "example.io/v1",
+		"kind":       "Widget",
+		"metadata":   map[string]any{"name": "w", "namespace": "default", "generation": int64(1)},
+		"status":     map[string]any{"endpoint": "10.0.0.1"},
+	}}
+	updated := base.DeepCopy()
+	_ = unstructured.SetNestedField(updated.Object, "10.0.0.2", "status", "endpoint")
+
+	diff := ComputeDiff("Widget", base, updated)
+	if diff == nil || !containsPath(diff, "resource") {
+		t.Fatalf("expected generic resource diff for unknown status field, got %+v", diff)
+	}
+}
+
+func TestRecordToTimelineStore_SyncAddMarksResourceSeen(t *testing.T) {
+	prev := initialSyncComplete
+	initialSyncComplete = false
+	defer func() { initialSyncComplete = prev }()
+
+	timeline.ResetStore()
+	if err := timeline.InitStore(timeline.DefaultStoreConfig()); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+	defer timeline.ResetStore()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "p",
+			Namespace:         "default",
+			UID:               "pod-uid",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Minute)),
+		},
+	}
+
+	recordToTimelineStore("Pod", "default", "p", "pod-uid", "add", nil, pod)
+
+	store := timeline.GetStore()
+	if store == nil {
+		t.Fatal("timeline store is nil")
+	}
+	if !store.IsResourceSeen("Pod", "default", "p") {
+		t.Fatal("sync add should mark resource seen after historical event recording")
 	}
 }
 

--- a/internal/timeline/metrics.go
+++ b/internal/timeline/metrics.go
@@ -1,6 +1,7 @@
 package timeline
 
 import (
+	"context"
 	"maps"
 	"sync"
 	"time"
@@ -280,7 +281,7 @@ func GetDiagnosis(kind, namespace, name string) DiagnoseResponse {
 
 	if store != nil {
 		// Query for events matching this resource
-		events, err := store.Query(nil, QueryOptions{
+		events, err := store.Query(context.Background(), QueryOptions{
 			Namespaces:       []string{namespace},
 			Kinds:            []string{kind},
 			Limit:            50,

--- a/internal/timeline/sqlite_store_test.go
+++ b/internal/timeline/sqlite_store_test.go
@@ -489,6 +489,46 @@ func TestSQLiteStore_SeenResources_PersistAcrossRestart(t *testing.T) {
 	}
 }
 
+func TestGetDiagnosis_WithSQLiteStore(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "timeline-diagnose-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	ResetStore()
+	defer ResetStore()
+
+	dbPath := filepath.Join(tmpDir, "diagnose.db")
+	if err := InitStore(StoreConfig{Type: StoreTypeSQLite, Path: dbPath}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+
+	event := TimelineEvent{
+		ID:        "event-1",
+		Timestamp: time.Now(),
+		Source:    SourceInformer,
+		Kind:      "TimelineWidget",
+		Namespace: "radar-timeline-test",
+		Name:      "noise-check",
+		EventType: EventTypeUpdate,
+	}
+	if err := RecordEvent(context.Background(), event); err != nil {
+		t.Fatalf("RecordEvent: %v", err)
+	}
+
+	resp := GetDiagnosis("TimelineWidget", "radar-timeline-test", "noise-check")
+	if !resp.StorePresent {
+		t.Fatal("expected diagnostics to see the global store")
+	}
+	if len(resp.TimelineEvents) != 1 {
+		t.Fatalf("expected one matching event, got %d: %+v", len(resp.TimelineEvents), resp.TimelineEvents)
+	}
+	if resp.TimelineEvents[0].ID != event.ID {
+		t.Fatalf("diagnosis returned wrong event: got %q want %q", resp.TimelineEvents[0].ID, event.ID)
+	}
+}
+
 func TestSQLiteStore_Stats_RecordsCleanupState(t *testing.T) {
 	store, cleanup := createTestSQLiteStore(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

This attacks the storage growth from both sides:

- Reduces low-signal timeline writes for dynamic CRDs that do not have a dedicated diff function. Unknown unstructured updates now record universal signals like generation changes and condition status/reason changes, drop metadata/reconcile timestamp-only updates, and fall back to a generic resource-changed row for real object changes.
- Marks resources as seen after initial-sync historical event recording, so restarts do not repeatedly re-run historical extraction and SQLite insert attempts for stable resources.
- Adds a SQLite storage cap via `--timeline-max-size` / Helm `timeline.maxSize`. When DB + WAL exceed the cap, cleanup checkpoints WAL, deletes oldest events down toward a low-water mark, and vacuums to reclaim disk. Helm defaults this to `800Mi` for SQLite deployments so the default `1Gi` PVC has headroom.
- Removes live SQLite event counts from `/api/health`; detailed timeline counts and cleanup state stay in `/api/diagnostics`.

Related: #662

## Tests

- go test ./internal/config ./internal/timeline ./internal/server ./internal/k8s
- go test ./internal/server -run TestSmokeHealth
- git diff --check
- make build