### PR TITLE
Show GitOps tracking details in workload views

### DIFF
--- a/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
@@ -552,7 +552,7 @@ export function GitOpsTableView({
           // understand why some destinations show as unmatched.
           <div className="shrink-0 border-b border-amber-500/30 bg-amber-500/10 px-4 py-2 text-xs text-amber-700 dark:text-amber-300">
             <span className="font-medium">Cross-cluster mapping limited for {forbiddenSecretsClusters.join(', ')}.</span>{' '}
-            Owner needs <code>get secrets</code> in the <code>argocd</code> namespace there; destination
+            Owner needs <code className="inline-code">get secrets</code> in the <code className="inline-code">argocd</code> namespace there; destination
             correlation falls back to name-only resolution.
           </div>
         )}
@@ -1915,4 +1915,3 @@ function newestConditionTime(resource: any): string {
     .sort()
   return times[times.length - 1] ?? ''
 }
-

--- a/packages/k8s-ui/src/components/gitops/insights/GitOpsInsightViews.tsx
+++ b/packages/k8s-ui/src/components/gitops/insights/GitOpsInsightViews.tsx
@@ -818,12 +818,12 @@ export function GitOpsChangesView({ insight, error, onOpenResource, focusKey, tr
           <div className="border-b border-theme-border bg-theme-base/40 px-4 py-2 text-[11px] text-theme-text-tertiary">
             Radar reads each resource's drift status from the controller. For a line-by-line diff, {insight.summary.tool === 'fluxcd' ? (
               insight.summary.kind === 'HelmRelease' ? (
-                <>run <code className="rounded bg-theme-elevated px-1 py-0.5 font-mono text-[10px]">helm diff upgrade {insight.summary.name} &lt;chart&gt;</code> (requires the helm-diff plugin).</>
+                <>run <code className="inline-code text-[10px]">helm diff upgrade {insight.summary.name} &lt;chart&gt;</code> (requires the helm-diff plugin).</>
               ) : (
-                <>run <code className="rounded bg-theme-elevated px-1 py-0.5 font-mono text-[10px]">flux diff kustomization {insight.summary.name} --path &lt;local-manifests&gt;</code>.</>
+                <>run <code className="inline-code text-[10px]">flux diff kustomization {insight.summary.name} --path &lt;local-manifests&gt;</code>.</>
               )
             ) : (
-              <>use the Argo CD UI or run <code className="rounded bg-theme-elevated px-1 py-0.5 font-mono text-[10px]">argocd app diff {insight.summary.name}</code>.</>
+              <>use the Argo CD UI or run <code className="inline-code text-[10px]">argocd app diff {insight.summary.name}</code>.</>
             )}
           </div>
         )}

--- a/packages/k8s-ui/src/components/resources/renderers/CAPIKubeadmControlPlaneRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CAPIKubeadmControlPlaneRenderer.tsx
@@ -115,7 +115,7 @@ export function CAPIKubeadmControlPlaneRenderer({ data, onNavigate }: Props) {
 
       {/* Owned Machines hint */}
       <div className="px-3 py-1.5 text-xs text-theme-text-tertiary">
-        Machines with label <code className="bg-theme-surface px-1 py-0.5 rounded text-[10px] font-mono select-all">cluster.x-k8s.io/control-plane-name={data.metadata?.name}</code>
+        Machines with label <code className="inline-code text-[10px] select-all">cluster.x-k8s.io/control-plane-name={data.metadata?.name}</code>
       </div>
 
       <ConditionsSection conditions={conditions} />

--- a/packages/k8s-ui/src/components/resources/renderers/CAPIMachineDeploymentRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CAPIMachineDeploymentRenderer.tsx
@@ -119,7 +119,7 @@ export function CAPIMachineDeploymentRenderer({ data, onNavigate }: Props) {
 
       {/* Owned Machines hint */}
       <div className="px-3 py-1.5 text-xs text-theme-text-tertiary">
-        Machines with label <code className="bg-theme-surface px-1 py-0.5 rounded text-[10px] font-mono select-all">cluster.x-k8s.io/deployment-name={data.metadata?.name}</code>
+        Machines with label <code className="inline-code text-[10px] select-all">cluster.x-k8s.io/deployment-name={data.metadata?.name}</code>
       </div>
 
       <ConditionsSection conditions={conditions} />

--- a/packages/k8s-ui/src/components/resources/renderers/CAPIMachineSetRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CAPIMachineSetRenderer.tsx
@@ -92,7 +92,7 @@ export function CAPIMachineSetRenderer({ data, onNavigate }: Props) {
 
       {/* Owned Machines hint */}
       <div className="px-3 py-1.5 text-xs text-theme-text-tertiary">
-        Machines with label <code className="bg-theme-surface px-1 py-0.5 rounded text-[10px] font-mono select-all">cluster.x-k8s.io/set-name={data.metadata?.name}</code>
+        Machines with label <code className="inline-code text-[10px] select-all">cluster.x-k8s.io/set-name={data.metadata?.name}</code>
       </div>
 
       <ConditionsSection conditions={conditions} />

--- a/packages/k8s-ui/src/components/resources/renderers/CNPGPoolerRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CNPGPoolerRenderer.tsx
@@ -50,7 +50,7 @@ export function CNPGPoolerRenderer({ data, onNavigate }: CNPGPoolerRendererProps
           <PropertyList>
             {authQuery && (
               <Property label="Auth Query" value={
-                <code className="text-xs font-mono bg-theme-elevated px-1.5 py-0.5 rounded break-all">{authQuery}</code>
+                <code className="inline-code text-xs break-all">{authQuery}</code>
               } />
             )}
             {authQuerySecret && (

--- a/packages/k8s-ui/src/components/shared/ManagedByChip.tsx
+++ b/packages/k8s-ui/src/components/shared/ManagedByChip.tsx
@@ -1,6 +1,14 @@
-import { GitBranch } from 'lucide-react'
+import { GitBranch, Package } from 'lucide-react'
 import { clsx } from 'clsx'
 import type { GitOpsOwnerRef } from '../../utils/gitops-owner'
+import type { GitOpsStatus } from '../../types/gitops'
+import { StatusDot, type StatusTone } from '../ui/status-tone'
+import { Tooltip } from '../ui/Tooltip'
+
+export type HelmOwnerRef = {
+  namespace: string
+  name: string
+}
 
 // ManagedByChip renders the "Managed by <ArgoCD/FluxCD app>" affordance for
 // resources detected (via labels/annotations) to be GitOps-managed. The chip
@@ -13,33 +21,158 @@ import type { GitOpsOwnerRef } from '../../utils/gitops-owner'
 //   - block: starts a new line with mt-1 spacing, used in WorkloadView title strip
 export function ManagedByChip({
   owner,
+  status,
   onOpen,
+  verified = true,
+  pending = false,
+  source,
   variant = 'inline',
 }: {
   owner: GitOpsOwnerRef
+  status?: GitOpsStatus | null
   onOpen?: (ref: GitOpsOwnerRef) => void
+  verified?: boolean
+  pending?: boolean
+  source?: string | null
   variant?: 'inline' | 'block'
 }) {
   const toolLabel = owner.tool === 'argocd' ? 'ArgoCD' : 'FluxCD'
+  const ownerKindLabel = gitOpsOwnerKindLabel(owner)
   const label = owner.namespace ? `${owner.namespace}/${owner.name}` : owner.name
-  const title = `Managed by ${toolLabel} · ${label}`
+  const statusLabel = status ? gitOpsStatusLabel(status) : null
+  const prefix = pending ? 'Resolving' : verified ? 'Managed by' : 'Tracked by'
+  const tooltipContent = (
+    <span className="flex flex-col gap-1">
+      <span>
+        {pending ? (
+          <>
+            Looking up matching {ownerKindLabel} <TooltipCode>{label}</TooltipCode> in this cluster.
+          </>
+        ) : verified ? (
+          <>
+            Managed by {toolLabel} · <TooltipCode>{label}</TooltipCode>
+            {statusLabel && <> · {statusLabel}{status?.message ? `: ${status.message}` : ''}</>}
+          </>
+        ) : (
+          <>
+            {toolLabel} tracking metadata references <TooltipCode>{label}</TooltipCode>, but the matching {ownerKindLabel} is not visible in this cluster.
+          </>
+        )}
+      </span>
+      {source && (
+        <span>
+          Inferred from <TooltipCode>{source}</TooltipCode>.
+        </span>
+      )}
+    </span>
+  )
   const interactive = !!onOpen
   const Wrapper = interactive ? 'button' : 'span'
   return (
-    <Wrapper
-      {...(interactive
-        ? { type: 'button' as const, onClick: () => onOpen?.(owner) }
-        : {})}
-      title={title}
-      className={clsx(
-        'inline-flex items-center gap-1 rounded border border-theme-border bg-theme-elevated px-1.5 py-0.5 text-[11px] text-theme-text-secondary',
-        variant === 'block' && 'mt-1',
-        interactive && 'hover:border-skyhook-500/60 hover:text-skyhook-500 transition-colors',
-      )}
-    >
-      <GitBranch className="h-3 w-3 shrink-0" />
-      <span className="shrink-0 text-theme-text-tertiary">Managed by</span>
-      <span className="truncate max-w-[180px]">{label}</span>
-    </Wrapper>
+    <Tooltip content={tooltipContent} delay={500} position="bottom" wrapperClassName={variant === 'block' ? 'mt-1' : undefined}>
+      <Wrapper
+        {...(interactive
+          ? { type: 'button' as const, onClick: () => onOpen?.(owner) }
+          : {})}
+        className={clsx(
+          'inline-flex min-w-0 items-center gap-1 rounded border border-theme-border bg-theme-elevated px-1.5 py-0.5 text-[11px] text-theme-text-secondary',
+          interactive && 'hover:border-skyhook-500/60 hover:text-skyhook-500 transition-colors',
+        )}
+      >
+        <GitBranch className="h-3 w-3 shrink-0" />
+        <span className="shrink-0 text-theme-text-tertiary">{prefix}</span>
+        <span className="truncate max-w-[180px]">{label}</span>
+        {statusLabel && (
+          <>
+            <span className="mx-0.5 h-3 w-px shrink-0 bg-theme-border" aria-hidden />
+            <span className="inline-flex shrink-0 items-center gap-1 text-theme-text-tertiary">
+              <StatusDot tone={gitOpsStatusTone(status!)} size="xs" />
+              <span>{statusLabel}</span>
+            </span>
+          </>
+        )}
+      </Wrapper>
+    </Tooltip>
   )
+}
+
+export function HelmManagedByChip({
+  owner,
+  onOpen,
+  source,
+  variant = 'inline',
+}: {
+  owner: HelmOwnerRef
+  onOpen?: (ref: HelmOwnerRef) => void
+  source?: string | null
+  variant?: 'inline' | 'block'
+}) {
+  const label = owner.namespace ? `${owner.namespace}/${owner.name}` : owner.name
+  const tooltipContent = (
+    <span className="flex flex-col gap-1">
+      <span>
+        Managed by Helm release <TooltipCode>{label}</TooltipCode>.
+      </span>
+      {source && (
+        <span>
+          Inferred from <TooltipCode>{source}</TooltipCode>.
+        </span>
+      )}
+    </span>
+  )
+  const interactive = !!onOpen
+  const Wrapper = interactive ? 'button' : 'span'
+  return (
+    <Tooltip content={tooltipContent} delay={500} position="bottom" wrapperClassName={variant === 'block' ? 'mt-1' : undefined}>
+      <Wrapper
+        {...(interactive
+          ? { type: 'button' as const, onClick: () => onOpen?.(owner) }
+          : {})}
+        className={clsx(
+          'inline-flex min-w-0 items-center gap-1 rounded border border-theme-border bg-theme-elevated px-1.5 py-0.5 text-[11px] text-theme-text-secondary',
+          interactive && 'hover:border-skyhook-500/60 hover:text-skyhook-500 transition-colors',
+        )}
+      >
+        <Package className="h-3 w-3 shrink-0" />
+        <span className="shrink-0 text-theme-text-tertiary">Managed by Helm</span>
+        <span className="truncate max-w-[180px]">{label}</span>
+      </Wrapper>
+    </Tooltip>
+  )
+}
+
+function gitOpsOwnerKindLabel(owner: GitOpsOwnerRef): string {
+  if (owner.tool === 'argocd') return 'Application'
+  if (owner.kind === 'helmreleases') return 'HelmRelease'
+  if (owner.kind === 'kustomizations') return 'Kustomization'
+  return 'GitOps resource'
+}
+
+function TooltipCode({ children }: { children: string }) {
+  return (
+    <code className="inline-code break-all">
+      {children}
+    </code>
+  )
+}
+
+function gitOpsStatusLabel(status: GitOpsStatus): string {
+  if (status.suspended) return 'Suspended'
+  if (status.sync === 'Reconciling') return 'Syncing'
+  if (status.health === 'Degraded') return 'Degraded'
+  if (status.health === 'Missing') return 'Missing'
+  if (status.sync === 'OutOfSync') return 'OutOfSync'
+  if (status.health === 'Progressing') return 'Progressing'
+  if (status.sync === 'Synced' && status.health === 'Healthy') return 'Synced'
+  if (status.sync !== 'Unknown') return status.sync
+  return status.health
+}
+
+function gitOpsStatusTone(status: GitOpsStatus): StatusTone {
+  if (status.suspended) return 'degraded'
+  if (status.sync === 'Synced' && status.health === 'Healthy') return 'healthy'
+  if (status.health === 'Degraded' || status.health === 'Missing') return 'unhealthy'
+  if (status.sync === 'OutOfSync') return 'degraded'
+  if (status.sync === 'Reconciling' || status.health === 'Progressing') return 'neutral'
+  return 'unknown'
 }

--- a/packages/k8s-ui/src/components/shared/index.ts
+++ b/packages/k8s-ui/src/components/shared/index.ts
@@ -2,4 +2,4 @@ export { ResourceRendererDispatch, getResourceStatus, type RendererOverrides } f
 export { EditableYamlView, SaveSuccessAnimation } from './EditableYamlView'
 export { ResourceActionsBar, RevisionHistoryDialog } from './ResourceActionsBar'
 export { CreateResourceDialog, type CreateResourceDialogProps, type ApplyResult } from './CreateResourceDialog'
-export { ManagedByChip } from './ManagedByChip'
+export { HelmManagedByChip, ManagedByChip, type HelmOwnerRef } from './ManagedByChip'

--- a/packages/k8s-ui/src/components/ui/Tooltip.tsx
+++ b/packages/k8s-ui/src/components/ui/Tooltip.tsx
@@ -54,6 +54,7 @@ export function Tooltip({
   const triggerRef = useRef<HTMLSpanElement>(null)
   const tooltipRef = useRef<HTMLSpanElement>(null)
   const timeoutRef = useRef<number | null>(null)
+  const hideTimeoutRef = useRef<number | null>(null)
   const rafRef = useRef<number | null>(null)
 
   const updatePosition = useCallback(() => {
@@ -94,12 +95,24 @@ export function Tooltip({
       clearTimeout(timeoutRef.current)
       timeoutRef.current = null
     }
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current)
+      hideTimeoutRef.current = null
+    }
     setIsVisible(false)
     setCoords(null)
   }
 
+  const cancelHide = () => {
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current)
+      hideTimeoutRef.current = null
+    }
+  }
+
   const showTooltip = () => {
     if (disabled || !content) return
+    cancelHide()
     timeoutRef.current = window.setTimeout(() => {
       // Singleton: hide whoever was visible before us, register self
       // as the new active tooltip. Guards against stuck duplicates.
@@ -116,11 +129,24 @@ export function Tooltip({
       clearTimeout(timeoutRef.current)
       timeoutRef.current = null
     }
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current)
+      hideTimeoutRef.current = null
+    }
     if (activeHide === hideRef.current) {
       activeHide = null
     }
     setIsVisible(false)
     setCoords(null)
+  }
+
+  const scheduleHideTooltip = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current)
+      timeoutRef.current = null
+    }
+    if (hideTimeoutRef.current) return
+    hideTimeoutRef.current = window.setTimeout(hideTooltip, 80)
   }
 
   useEffect(() => {
@@ -143,6 +169,9 @@ export function Tooltip({
     return () => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current)
+      }
+      if (hideTimeoutRef.current) {
+        clearTimeout(hideTimeoutRef.current)
       }
       if (rafRef.current !== null) {
         cancelAnimationFrame(rafRef.current)
@@ -168,6 +197,10 @@ export function Tooltip({
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current)
         timeoutRef.current = null
+      }
+      if (hideTimeoutRef.current) {
+        clearTimeout(hideTimeoutRef.current)
+        hideTimeoutRef.current = null
       }
       setIsVisible(false)
       setCoords(null)
@@ -202,7 +235,7 @@ export function Tooltip({
         className={clsx('inline-flex max-w-full', wrapperClassName)}
         style={wrapperStyle}
         onMouseEnter={showTooltip}
-        onMouseLeave={hideTooltip}
+        onMouseLeave={scheduleHideTooltip}
         onFocus={showTooltip}
         onBlur={hideTooltip}
         // pointerdown fires before click, so the tooltip is gone before
@@ -227,7 +260,7 @@ export function Tooltip({
               // max-w-xs (320px) + whitespace-normal, short tooltips
               // still fit on one line (content shorter than max-width)
               // and long ones wrap naturally near the trigger.
-              'max-w-xs whitespace-normal break-words pointer-events-none',
+              'max-w-xs whitespace-normal break-words',
               className
             )}
             style={{
@@ -238,6 +271,8 @@ export function Tooltip({
             }}
             role="tooltip"
             aria-hidden={coords ? undefined : true}
+            onMouseEnter={cancelHide}
+            onMouseLeave={scheduleHideTooltip}
           >
             {content}
           </span>,

--- a/packages/k8s-ui/src/components/workload/WorkloadView.tsx
+++ b/packages/k8s-ui/src/components/workload/WorkloadView.tsx
@@ -21,6 +21,7 @@ import {
   BarChart3,
 } from 'lucide-react'
 import type { TimelineEvent, ResourceRef, Relationships, SelectedResource, ResolvedEnvFrom } from '../../types'
+import type { GitOpsStatus } from '../../types/gitops'
 import type { NavigateToResource } from '../../utils/navigation'
 import { refToSelectedResource, pluralToKind } from '../../utils/navigation'
 import { gitOpsOwnerFromRelationships, type GitOpsOwnerRef } from '../../utils/gitops-owner'
@@ -44,7 +45,7 @@ import {
 import { ResourceActionsBar } from '../shared/ResourceActionsBar'
 import { EditableYamlView, SaveSuccessAnimation } from '../shared/EditableYamlView'
 import { ResourceRendererDispatch, getResourceStatus, type RendererOverrides } from '../shared/ResourceRendererDispatch'
-import { ManagedByChip } from '../shared/ManagedByChip'
+import { HelmManagedByChip, ManagedByChip, type HelmOwnerRef } from '../shared/ManagedByChip'
 import { getKindColorOutline, formatKindName } from '../ui/drawer-components'
 
 type TabType = 'overview' | 'timeline' | 'logs' | 'metrics' | 'yaml'
@@ -126,6 +127,22 @@ interface WorkloadViewProps {
    * visible (useful for hosts that haven't routed the GitOps tab yet).
    */
   onOpenGitOpsResource?: (ref: GitOpsOwnerRef) => void
+  /** Owner ref resolved by the host when relationships lack enough detail, e.g. Argo labels without namespace. */
+  resolvedGitOpsOwner?: GitOpsOwnerRef | null
+  /** True when the owner exists locally and can be opened as a GitOps detail page. */
+  gitOpsOwnerVerified?: boolean
+  /** True while the host is still resolving whether the owner exists locally. */
+  gitOpsOwnerPending?: boolean
+  /** Metadata key/value that caused GitOps ownership inference, when known. */
+  gitOpsOwnerSource?: string | null
+  /** Sync/health status for the GitOps owner, when the host can resolve it. */
+  gitOpsOwnerStatus?: GitOpsStatus | null
+  /** Native Helm release that manages this resource, when detected. */
+  helmOwner?: HelmOwnerRef | null
+  /** Metadata key/value that caused native Helm ownership inference, when known. */
+  helmOwnerSource?: string | null
+  /** Open the native Helm release drawer. */
+  onOpenHelmRelease?: (ref: HelmOwnerRef) => void
   /**
    * Open the GitOps detail page for the resource itself, when the resource
    * is a portal-classified GitOps CR (Argo Application/ApplicationSet/
@@ -226,6 +243,14 @@ export function WorkloadView({
   resolvedEnvFrom,
   // GitOps
   onOpenGitOpsResource,
+  resolvedGitOpsOwner,
+  gitOpsOwnerVerified = true,
+  gitOpsOwnerPending = false,
+  gitOpsOwnerSource,
+  gitOpsOwnerStatus,
+  helmOwner,
+  helmOwnerSource,
+  onOpenHelmRelease,
   onNavigateGitOpsPath,
 }: WorkloadViewProps) {
   // Normalize kind: URL has plural lowercase, internal logic uses singular PascalCase
@@ -315,7 +340,8 @@ export function WorkloadView({
 
   // Metadata
   const metadata = useMemo(() => extractMetadata(kind, resource), [kind, resource])
-  const gitopsOwner = useMemo(() => gitOpsOwnerFromRelationships(relationships), [relationships])
+  const relationshipGitOpsOwner = useMemo(() => gitOpsOwnerFromRelationships(relationships), [relationships])
+  const gitopsOwner = resolvedGitOpsOwner ?? relationshipGitOpsOwner
   // When the resource itself is a portal GitOps CR (Application, Kustomization,
   // HelmRelease, etc.), surface a link to its dedicated GitOps detail page —
   // the drawer's renderer is thorough but the tab has the tree + insights +
@@ -465,9 +491,10 @@ export function WorkloadView({
               </button>
             </div>
             <p className="text-sm text-theme-text-tertiary">{namespace}</p>
-            {(gitopsOwner || (gitOpsResourcePath && onNavigateGitOpsPath)) && (
+            {(gitopsOwner || helmOwner || (gitOpsResourcePath && onNavigateGitOpsPath)) && (
               <div className="mt-1 flex flex-wrap items-center gap-1.5">
-                {gitopsOwner && <ManagedByChip owner={gitopsOwner} onOpen={onOpenGitOpsResource} />}
+                {gitopsOwner && <ManagedByChip owner={gitopsOwner} status={gitOpsOwnerStatus} verified={gitOpsOwnerVerified} pending={gitOpsOwnerPending} source={gitOpsOwnerSource} onOpen={onOpenGitOpsResource} />}
+                {helmOwner && <HelmManagedByChip owner={helmOwner} source={helmOwnerSource} onOpen={onOpenHelmRelease} />}
                 {gitOpsResourcePath && onNavigateGitOpsPath && (
                   <OpenInGitOpsChip onClick={() => onNavigateGitOpsPath(gitOpsResourcePath)} />
                 )}
@@ -575,7 +602,10 @@ export function WorkloadView({
                 <span className="truncate max-w-md font-mono text-xs">{metadata.find(m => m.label === 'Image')?.value}</span>
               )}
               {gitopsOwner && (
-                <ManagedByChip owner={gitopsOwner} onOpen={onOpenGitOpsResource} variant="block" />
+                <ManagedByChip owner={gitopsOwner} status={gitOpsOwnerStatus} verified={gitOpsOwnerVerified} pending={gitOpsOwnerPending} source={gitOpsOwnerSource} onOpen={onOpenGitOpsResource} variant="block" />
+              )}
+              {helmOwner && (
+                <HelmManagedByChip owner={helmOwner} source={helmOwnerSource} onOpen={onOpenHelmRelease} variant="block" />
               )}
               {gitOpsResourcePath && onNavigateGitOpsPath && (
                 <OpenInGitOpsChip onClick={() => onNavigateGitOpsPath(gitOpsResourcePath)} />

--- a/packages/k8s-ui/src/theme/components.css
+++ b/packages/k8s-ui/src/theme/components.css
@@ -65,6 +65,22 @@
     box-shadow: var(--shadow-lg);
   }
 
+  /* ── INLINE CODE ── */
+
+  .inline-code {
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
+    border: 0.5px solid color-mix(in srgb, var(--color-brand) 24%, var(--border-default));
+    border-radius: 0.25rem;
+    background-color: color-mix(in srgb, var(--color-brand) 8%, var(--bg-elevated));
+    padding: 0.0625rem 0.3125rem;
+    font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
+    font-size: 0.9em;
+    font-weight: 500;
+    line-height: 1.5;
+    color: var(--text-primary);
+  }
+
   /* ── BADGES ── */
 
   .badge {

--- a/web/src/components/helm/ChartBrowser.tsx
+++ b/web/src/components/helm/ChartBrowser.tsx
@@ -307,7 +307,7 @@ export function ChartBrowser({ onChartSelect }: ChartBrowserProps) {
                   <div className="text-sm mt-1">
                     <p>No Helm repositories configured.</p>
                     <p className="mt-1">
-                      Add repositories using <code className="bg-theme-elevated px-1 rounded">helm repo add</code>
+                      Add repositories using <code className="inline-code">helm repo add</code>
                     </p>
                     <p className="mt-2">
                       Or try searching on <button onClick={() => setChartSource('artifacthub')} className="text-accent-text hover:underline">ArtifactHub</button>

--- a/web/src/components/helm/InstallWizard.tsx
+++ b/web/src/components/helm/InstallWizard.tsx
@@ -893,7 +893,7 @@ function ReviewStep({
           <div>
             <p className="text-sm font-medium text-amber-400">Installing from ArtifactHub</p>
             <p className="text-xs text-theme-text-secondary mt-1">
-              This chart will be installed from: <code className="bg-theme-elevated px-1 rounded">{artifactHubRepoUrl || repo}</code>
+              This chart will be installed from: <code className="inline-code">{artifactHubRepoUrl || repo}</code>
             </p>
           </div>
         </div>

--- a/web/src/components/home/ClusterHealthCard.tsx
+++ b/web/src/components/home/ClusterHealthCard.tsx
@@ -52,7 +52,7 @@ function MetricsUnavailableHint({ platform, metricsServerAvailable }: { platform
       content={
         <div className="space-y-1">
           <div className="font-medium">How to fix</div>
-          <div>{isPreInstalled ? hint : <>Install by running:<br /><code className="text-[10px] opacity-80">{hint}</code></>}</div>
+          <div>{isPreInstalled ? hint : <>Install by running:<br /><code className="inline-code text-[10px] opacity-80">{hint}</code></>}</div>
         </div>
       }
       position="bottom"

--- a/web/src/components/home/MCPSetupDialog.tsx
+++ b/web/src/components/home/MCPSetupDialog.tsx
@@ -221,7 +221,7 @@ export function MCPSetupDialog({ open, onClose, mcpUrl }: MCPSetupDialogProps) {
             <div className="relative">
               <div className="flex items-center gap-3 bg-theme-base rounded-md px-3 py-2.5">
                 <span className="badge text-purple-400 bg-purple-500/10">HTTP</span>
-                <code className="text-sm font-mono text-theme-text-primary">{mcpUrl}</code>
+                <code className="inline-code text-sm">{mcpUrl}</code>
               </div>
               <CopyButton text={mcpUrl} />
             </div>
@@ -306,7 +306,7 @@ export function MCPSetupDialog({ open, onClose, mcpUrl }: MCPSetupDialogProps) {
               {MCP_TOOL_CATALOG.map((tool) => (
                 <div key={tool.name} className="card-inner space-y-1.5">
                   <div className="flex items-center gap-2">
-                    <code className="text-[11px] font-mono text-purple-400">{tool.name}</code>
+                    <code className="inline-code text-[11px]">{tool.name}</code>
                     {tool.write && (
                       <span className="badge-sm bg-amber-500/10 text-amber-600 dark:text-amber-400" title="Write tool — annotated as destructive">
                         write

--- a/web/src/components/settings/MyPermissionsDialog.tsx
+++ b/web/src/components/settings/MyPermissionsDialog.tsx
@@ -109,7 +109,7 @@ export function MyPermissionsDialog({ open, onClose }: MyPermissionsDialogProps)
 
           <p className="text-xs text-theme-text-tertiary">
             Computed by the Kubernetes API via{' '}
-            <code className="bg-theme-elevated px-1 rounded">SelfSubjectRulesReview</code>.
+            <code className="inline-code">SelfSubjectRulesReview</code>.
             Shows what you can do in <span className="text-theme-text-secondary">{namespace}</span>,
             plus any cluster-scoped rules that apply everywhere.
           </p>

--- a/web/src/components/ui/Markdown.tsx
+++ b/web/src/components/ui/Markdown.tsx
@@ -51,7 +51,7 @@ export function Markdown({ children, className }: MarkdownProps) {
           const isInline = !className
           if (isInline) {
             return (
-              <code className="px-1.5 py-0.5 bg-theme-elevated rounded text-theme-text-primary font-mono text-[0.9em]">
+              <code className="inline-code">
                 {children}
               </code>
             )

--- a/web/src/components/ui/UpdateNotification.tsx
+++ b/web/src/components/ui/UpdateNotification.tsx
@@ -147,7 +147,7 @@ export function UpdateNotification() {
                   onClick={handleCopyCommand}
                   className="flex items-center gap-2 mt-2 px-2 py-1.5 bg-theme-elevated rounded font-mono text-theme-text-primary hover:bg-theme-surface-hover transition-colors w-full"
                 >
-                  <code className="flex-1 text-left truncate text-[11px]">{versionInfo.updateCommand}</code>
+                  <code className="inline-code flex-1 truncate text-left text-[11px]">{versionInfo.updateCommand}</code>
                   <CopyIcon copied={copied} failed={copyFailed} />
                 </button>
               </WithTooltip>

--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -7,10 +7,14 @@ import {
   WorkloadView as BaseWorkloadView,
   type RendererOverrides,
   type GitOpsOwnerRef,
+  type GitOpsStatus,
+  type HelmOwnerRef,
   gitOpsRouteForOwner,
+  gitOpsOwnerFromRelationships,
+  getGitOpsResourceStatus,
   resolvedEnvFromKey,
 } from '@skyhook-io/k8s-ui'
-import type { SelectedResource, ResourceRef, ResolvedEnvFrom } from '../../types'
+import type { SelectedResource, ResourceRef, Relationships, ResolvedEnvFrom } from '../../types'
 import { kindToPlural, buildWorkloadPath, type NavigateToResource } from '../../utils/navigation'
 import {
   useChanges, useResourceWithRelationships, usePodLogs, useTopology, useUpdateResource,
@@ -21,6 +25,7 @@ import {
   useCordonNode, useUncordonNode, useDrainNode,
   useCascadeDeletePreview,
   useResourceEvents,
+  useResource,
   fetchJSON,
 } from '../../api/client'
 import { PrometheusCharts, isPrometheusSupported } from '../resource/PrometheusCharts'
@@ -260,6 +265,61 @@ export function WorkloadView({
   const resource = resourceResponse?.resource
   const relationships = resourceResponse?.relationships
   const certificateInfo = resourceResponse?.certificateInfo
+  const relationshipGitopsOwner = useMemo(() => gitOpsOwnerFromRelationships(relationships), [relationships])
+  const inheritedGitOpsLookupRef = useMemo(
+    () => findInheritedGitOpsLookupRef(relationships, relationshipGitopsOwner, { kind: kindProp, namespace, name, group: rest.group }),
+    [relationships, relationshipGitopsOwner, kindProp, namespace, name, rest.group],
+  )
+  const inheritedGitOpsResponse = useResourceWithRelationships<any>(
+    inheritedGitOpsLookupRef ? kindToPlural(inheritedGitOpsLookupRef.kind) : '',
+    inheritedGitOpsLookupRef?.namespace ?? '',
+    inheritedGitOpsLookupRef?.name ?? '',
+    inheritedGitOpsLookupRef?.group,
+  )
+  const inheritedGitopsOwner = useMemo(
+    () => gitOpsOwnerFromRelationships(inheritedGitOpsResponse.data?.relationships),
+    [inheritedGitOpsResponse.data?.relationships],
+  )
+  const relationshipHelmOwner = useMemo(
+    () => nativeHelmOwnerFromRelationships(relationships, resource?.metadata?.namespace ?? namespace),
+    [relationships, resource?.metadata?.namespace, namespace],
+  )
+  const inheritedHelmOwner = useMemo(
+    () => nativeHelmOwnerFromRelationships(inheritedGitOpsResponse.data?.relationships, inheritedGitOpsResponse.data?.resource?.metadata?.namespace ?? namespace),
+    [inheritedGitOpsResponse.data?.relationships, inheritedGitOpsResponse.data?.resource?.metadata?.namespace, namespace],
+  )
+  const rawGitopsOwner = relationshipGitopsOwner ?? inheritedGitopsOwner
+  const gitOpsSourceResource = relationshipGitopsOwner ? resource : inheritedGitOpsResponse.data?.resource
+  const helmOwner = relationshipHelmOwner ?? inheritedHelmOwner
+  const helmSourceResource = relationshipHelmOwner ? resource : inheritedGitOpsResponse.data?.resource
+  const shouldResolveArgoOwner = rawGitopsOwner?.tool === 'argocd' && !rawGitopsOwner.namespace
+  const { data: argoApplications } = useResources<any>('applications', undefined, 'argoproj.io', { enabled: shouldResolveArgoOwner })
+  const gitopsOwner = useMemo(
+    () => resolveGitOpsOwner(rawGitopsOwner, argoApplications),
+    [rawGitopsOwner, argoApplications],
+  )
+  const gitopsOwnerGroup = gitopsOwner ? gitOpsOwnerGroup(gitopsOwner) : ''
+  const shouldFetchGitOpsOwner = Boolean(gitopsOwner?.namespace)
+  const gitopsOwnerQuery = useResource<any>(
+    shouldFetchGitOpsOwner ? gitopsOwner!.kind : '',
+    gitopsOwner?.namespace ?? '',
+    gitopsOwner?.name ?? '',
+    gitopsOwnerGroup,
+  )
+  const gitOpsOwnerStatus = useMemo(
+    () => deriveGitOpsOwnerStatus(gitopsOwner, gitopsOwnerQuery.data),
+    [gitopsOwner, gitopsOwnerQuery.data],
+  )
+  const gitOpsOwnerVerified = Boolean(gitopsOwner?.namespace && gitopsOwnerQuery.data)
+  const gitOpsOwnerPending = Boolean(gitopsOwner?.namespace && gitopsOwnerQuery.isLoading && !gitopsOwnerQuery.data)
+  const gitOpsOwnerSource = useMemo(
+    () => describeGitOpsOwnerSource(rawGitopsOwner, gitOpsSourceResource),
+    [rawGitopsOwner, gitOpsSourceResource],
+  )
+  const helmOwnerSource = useMemo(
+    () => describeHelmOwnerSource(helmOwner, helmSourceResource),
+    [helmOwner, helmSourceResource],
+  )
 
   // For pods: extract envFrom ConfigMap/Secret names and resolve their keys
   const isPod = kindProp.toLowerCase() === 'pods'
@@ -369,12 +429,27 @@ export function WorkloadView({
 
   const navigateRouter = useNavigate()
   const handleOpenGitOpsResource = useCallback(
-    (ref: GitOpsOwnerRef) => navigateRouter(gitOpsRouteForOwner(ref)),
-    [navigateRouter],
+    (ref: GitOpsOwnerRef) => {
+      const params = new URLSearchParams()
+      const namespaces = searchParams.get('namespaces')
+      if (namespaces) params.set('namespaces', namespaces)
+      navigateRouter({ pathname: gitOpsRouteForOwner(ref), search: params.toString() })
+    },
+    [navigateRouter, searchParams],
   )
   const handleNavigateGitOpsPath = useCallback(
     (path: string) => navigateRouter(path),
     [navigateRouter],
+  )
+  const handleOpenHelmRelease = useCallback(
+    (ref: HelmOwnerRef) => {
+      const params = new URLSearchParams()
+      const namespaces = searchParams.get('namespaces')
+      if (namespaces) params.set('namespaces', namespaces)
+      params.set('release', `${ref.namespace}/${ref.name}`)
+      navigateRouter({ pathname: '/helm', search: params.toString() })
+    },
+    [navigateRouter, searchParams],
   )
 
   // Duplicate dialog
@@ -438,7 +513,15 @@ export function WorkloadView({
           <FluxSourceConsumersSection kind={k} namespace={ns} name={n} />
         </>
       )}
-      onOpenGitOpsResource={handleOpenGitOpsResource}
+      onOpenGitOpsResource={gitopsOwnerQuery.data ? handleOpenGitOpsResource : undefined}
+      resolvedGitOpsOwner={gitopsOwner}
+      gitOpsOwnerVerified={gitOpsOwnerVerified}
+      gitOpsOwnerPending={gitOpsOwnerPending}
+      gitOpsOwnerSource={gitOpsOwnerSource}
+      gitOpsOwnerStatus={gitOpsOwnerStatus}
+      helmOwner={helmOwner}
+      helmOwnerSource={helmOwnerSource}
+      onOpenHelmRelease={handleOpenHelmRelease}
       onNavigateGitOpsPath={handleNavigateGitOpsPath}
     />
     <CreateResourceDialog
@@ -453,6 +536,104 @@ export function WorkloadView({
     {comparePicker}
     </>
   )
+}
+
+function resolveGitOpsOwner(owner: GitOpsOwnerRef | null, argoApplications: any[] | undefined): GitOpsOwnerRef | null {
+  if (!owner || owner.namespace || owner.tool !== 'argocd') return owner
+  const matches = (argoApplications ?? []).filter((app) => app?.metadata?.name === owner.name)
+  if (matches.length !== 1) return owner
+  const namespace = matches[0]?.metadata?.namespace
+  return namespace ? { ...owner, namespace } : owner
+}
+
+function findInheritedGitOpsLookupRef(
+  relationships: Relationships | undefined,
+  directOwner: GitOpsOwnerRef | null,
+  current: ResourceRef,
+): ResourceRef | null {
+  if (directOwner) return null
+  const inheritedManagerRefs = (relationships?.managedBy ?? []).filter((ref) =>
+    !gitOpsOwnerFromRelationships({ managedBy: [ref] })
+    && !isNativeHelmManager(ref)
+  )
+  const candidates = [
+    relationships?.deployment,
+    ...inheritedManagerRefs,
+    relationships?.owner,
+  ].filter(Boolean) as ResourceRef[]
+
+  return candidates.find((ref) => !isCurrentResource(ref, current)) ?? null
+}
+
+function nativeHelmOwnerFromRelationships(relationships: Relationships | undefined, fallbackNamespace: string): HelmOwnerRef | null {
+  const ref = relationships?.managedBy?.[0]
+  if (!ref || !isNativeHelmManager(ref)) return null
+  return {
+    namespace: ref.namespace || fallbackNamespace,
+    name: ref.name,
+  }
+}
+
+function isCurrentResource(ref: ResourceRef, current: ResourceRef): boolean {
+  return kindToPlural(ref.kind) === kindToPlural(current.kind)
+    && ref.namespace === current.namespace
+    && ref.name === current.name
+    && (ref.group ?? '') === (current.group ?? '')
+}
+
+function isNativeHelmManager(ref: ResourceRef): boolean {
+  return ref.kind === 'HelmRelease' && ref.group !== 'helm.toolkit.fluxcd.io'
+}
+
+function describeGitOpsOwnerSource(owner: GitOpsOwnerRef | null, resource: any): string | null {
+  if (!owner || !resource) return null
+  const labels = resource.metadata?.labels ?? {}
+  const annotations = resource.metadata?.annotations ?? {}
+
+  if (owner.tool === 'fluxcd') {
+    const nameKey = owner.kind === 'helmreleases' ? 'helm.toolkit.fluxcd.io/name' : 'kustomize.toolkit.fluxcd.io/name'
+    const nsKey = owner.kind === 'helmreleases' ? 'helm.toolkit.fluxcd.io/namespace' : 'kustomize.toolkit.fluxcd.io/namespace'
+    if (labels[nameKey] || labels[nsKey]) {
+      return `${nameKey}=${labels[nameKey] ?? ''}, ${nsKey}=${labels[nsKey] ?? ''}`
+    }
+  }
+
+  const trackingID = annotations['argocd.argoproj.io/tracking-id']
+  if (trackingID) return `argocd.argoproj.io/tracking-id=${trackingID}`
+  const argoInstance = labels['argocd.argoproj.io/instance']
+  if (argoInstance) return `argocd.argoproj.io/instance=${argoInstance}`
+  return null
+}
+
+function describeHelmOwnerSource(owner: HelmOwnerRef | null, resource: any): string | null {
+  if (!owner || !resource) return null
+  const annotations = resource.metadata?.annotations ?? {}
+  const releaseName = annotations['meta.helm.sh/release-name']
+  const releaseNamespace = annotations['meta.helm.sh/release-namespace']
+  if (releaseName || releaseNamespace) {
+    return `meta.helm.sh/release-name=${releaseName ?? ''}, meta.helm.sh/release-namespace=${releaseNamespace ?? ''}`
+  }
+  return null
+}
+
+function gitOpsOwnerGroup(owner: GitOpsOwnerRef): string {
+  if (owner.tool === 'argocd') return 'argoproj.io'
+  if (owner.kind === 'kustomizations') return 'kustomize.toolkit.fluxcd.io'
+  return 'helm.toolkit.fluxcd.io'
+}
+
+function deriveGitOpsOwnerStatus(owner: GitOpsOwnerRef | null, resource: any): GitOpsStatus | null {
+  if (!owner || !resource || !hasGitOpsStatusPayload(owner, resource)) return null
+  return getGitOpsResourceStatus(owner.kind, resource)
+}
+
+function hasGitOpsStatusPayload(owner: GitOpsOwnerRef, resource: any): boolean {
+  if (owner.kind === 'applications') {
+    const status = resource.status ?? {}
+    return Boolean(status.sync?.status || status.health?.status || status.operationState?.phase)
+  }
+  if (resource.spec?.suspend === true) return true
+  return Array.isArray(resource.status?.conditions) && resource.status.conditions.length > 0
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- show GitOps owner sync/health status in workload Managed by chips when the owner resource is visible
- distinguish unresolved Argo tracking metadata as Tracked by, with tooltip source details and no broken deep link
- infer pod/controller GitOps ownership without letting native Helm ownership block controller lookup
- surface native Helm release ownership as a separate `Managed by Helm` chip that links to `/helm?release=<namespace>/<name>`
- use the shared app-wide inline code style in rich tooltips and inline text

## Validation
- `make tsc`
- `npm test --workspace @skyhook-io/k8s-ui -- gitops-owner gitops-route`
- `make build`
- visual check on `http://localhost:9398/workload/pods/staging/billing-6745d54fc6-kcsrp`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds conditional extra resource/list queries in the workload drawer and changes navigation when GitOps owners are unverified; behavior is UI-only with no auth or data-mutation paths.
> 
> **Overview**
> Workload drawers now show **richer ownership chips**: GitOps owners can display sync/health status, **Managed by** vs **Tracked by** vs **Resolving** when the owner CR is verified, missing, or still loading, plus tooltips that cite the label/annotation source. A separate **Managed by Helm** chip links to the native Helm release (not Flux `HelmRelease`).
> 
> The web app **resolves ownership beyond direct relationships**—walking deployment/managedBy/owner refs for inherited GitOps metadata, resolving namespace-less Argo apps via a cluster Application list, fetching the owner resource for status, and only wiring GitOps deep links when the owner exists.
> 
> **Tooltips** allow a short hover delay before hide and are hoverable (removed `pointer-events-none`) so multi-line chip tooltips stay readable.
> 
> A shared **`.inline-code`** theme class replaces ad hoc inline `<code>` styling across GitOps, CAPI/CNPG renderers, Markdown, Helm, and settings UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 258960215437bfa583f2e7f1f61cbb95b86c45fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->