### PR TITLE
Bound SQLite timeline storage growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ radar
 | `--no-browser` | `false` | Don't auto-open browser |
 | `--timeline-storage` | `memory` | Timeline storage backend: `memory` or `sqlite` |
 | `--timeline-db` | `~/.radar/timeline.db` | Path to SQLite database (when using sqlite storage) |
+| `--timeline-max-size` | `0` | Maximum SQLite DB + WAL size before pruning oldest events (e.g. `800Mi`, `8Gi`; `0` disables) |
 | `--history-limit` | `10000` | Maximum events to retain in timeline |
 | `--disable-exec` | `false` | Disable terminal and debug shell |
 | `--disable-helm-write` | `false` | Disable Helm write operations |

--- a/cmd/desktop/main.go
+++ b/cmd/desktop/main.go
@@ -44,6 +44,7 @@ func main() {
 	timelineStorage := flag.String("timeline-storage", fileCfg.TimelineStorageOr("memory"), "Timeline storage backend: memory or sqlite")
 	timelineDBPath := flag.String("timeline-db", fileCfg.TimelineDBPath, "Path to timeline database file (default: ~/.radar/timeline.db)")
 	timelineRetention := flag.Duration("timeline-retention", fileCfg.TimelineRetentionOr(7*24*time.Hour), "How long to retain timeline events when --timeline-storage=sqlite (e.g. 168h, 720h). 0 disables cleanup (unbounded growth).")
+	timelineMaxSize := flag.String("timeline-max-size", fileCfg.TimelineMaxSizeOr("0"), "Maximum SQLite timeline storage size before pruning oldest events (e.g. 800Mi, 8Gi). 0 disables size-based pruning.")
 	prometheusURL := flag.String("prometheus-url", fileCfg.PrometheusURL, "Manual Prometheus/VictoriaMetrics URL (skips auto-discovery)")
 	flag.Parse()
 
@@ -84,6 +85,11 @@ func main() {
 		log.Printf("ERROR: --kubeconfig and --kubeconfig-dir are mutually exclusive")
 		os.Exit(1)
 	}
+	timelineMaxSizeBytes, err := config.ParseByteSize(*timelineMaxSize)
+	if err != nil {
+		log.Printf("ERROR: invalid --timeline-max-size %q: %v", *timelineMaxSize, err)
+		os.Exit(1)
+	}
 	resolvedPrometheusHeaders, err := app.ResolvePrometheusHeaders(fileCfg.PrometheusHeaders, fileCfg.PrometheusHeadersFromEnv)
 	if err != nil {
 		log.Printf("ERROR: invalid Prometheus header configuration: %v", err)
@@ -105,6 +111,7 @@ func main() {
 		TimelineStorage:          *timelineStorage,
 		TimelineDBPath:           *timelineDBPath,
 		TimelineRetention:        *timelineRetention,
+		TimelineMaxSizeBytes:     timelineMaxSizeBytes,
 		PrometheusURL:            *prometheusURL,
 		PrometheusHeaders:        resolvedPrometheusHeaders,
 		PrometheusHeadersFromEnv: fileCfg.PrometheusHeadersFromEnv,

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -64,6 +64,7 @@ func main() {
 	timelineStorage := flag.String("timeline-storage", fileCfg.TimelineStorageOr("memory"), "Timeline storage backend: memory or sqlite")
 	timelineDBPath := flag.String("timeline-db", fileCfg.TimelineDBPath, "Path to timeline database file (default: ~/.radar/timeline.db)")
 	timelineRetention := flag.Duration("timeline-retention", fileCfg.TimelineRetentionOr(7*24*time.Hour), "How long to retain timeline events when --timeline-storage=sqlite (e.g. 168h, 720h). 0 disables cleanup (unbounded growth).")
+	timelineMaxSize := flag.String("timeline-max-size", fileCfg.TimelineMaxSizeOr("0"), "Maximum SQLite timeline storage size before pruning oldest events (e.g. 800Mi, 8Gi). 0 disables size-based pruning.")
 	// Traffic/metrics options
 	prometheusURL := flag.String("prometheus-url", fileCfg.PrometheusURL, "Manual Prometheus/VictoriaMetrics URL (skips auto-discovery)")
 	// --prometheus-header Key=Value, repeatable. Defaults populated from
@@ -154,6 +155,10 @@ func main() {
 	if *kubeconfig != "" && *kubeconfigDir != "" {
 		log.Fatalf("--kubeconfig and --kubeconfig-dir are mutually exclusive")
 	}
+	timelineMaxSizeBytes, err := config.ParseByteSize(*timelineMaxSize)
+	if err != nil {
+		log.Fatalf("Invalid --timeline-max-size %q: %v", *timelineMaxSize, err)
+	}
 	resolvedPrometheusHeaders, err := app.ResolvePrometheusHeaders(promHeaders.value(), promHeadersFromEnv.value())
 	if err != nil {
 		log.Fatalf("Invalid Prometheus header configuration: %v", err)
@@ -178,6 +183,7 @@ func main() {
 		TimelineStorage:          *timelineStorage,
 		TimelineDBPath:           *timelineDBPath,
 		TimelineRetention:        *timelineRetention,
+		TimelineMaxSizeBytes:     timelineMaxSizeBytes,
 		PrometheusURL:            *prometheusURL,
 		PrometheusHeaders:        resolvedPrometheusHeaders,
 		PrometheusHeadersFromEnv: promHeadersFromEnv.value(),

--- a/deploy/helm/radar/README.md
+++ b/deploy/helm/radar/README.md
@@ -92,6 +92,7 @@ touches its contents.
 | `ingress.className` | Ingress class name | `""` |
 | `timeline.storage` | Timeline storage (memory/sqlite) | `memory` |
 | `timeline.retention` | SQLite retention (Go duration; `0` disables) | `168h` |
+| `timeline.maxSize` | SQLite max DB + WAL size before oldest events are pruned (`0` disables) | `800Mi` |
 | `persistence.enabled` | Enable PVC for SQLite | `false` |
 | `traffic.prometheusUrl` | Manual Prometheus/VictoriaMetrics URL (skips auto-discovery) | `""` |
 | `traffic.prometheusHeaders` | HTTP headers sent with every Prometheus request (auth-protected backends) | `{}` |
@@ -108,9 +109,9 @@ Radar's timeline records every cluster change so you can scrub backwards through
 - **`memory`** (default): events live in-process. Lost on pod restart. Lower memory footprint per retention window than SQLite (no indexes, no WAL). Pick this if you only need recent activity (last few hours), don't care about losing history when a pod cycles, or want the simplest setup.
 - **`sqlite`**: events persist to a PVC across restarts. Pick this if you want a multi-day audit trail, need to inspect changes that happened while you weren't looking, or run Radar in-cluster long-term. Adds operational concerns: the PVC will fill if retention is unbounded; restarting on a multi-GB DB is slower (more rows to load).
 
-**Sizing**: a busy cluster (~5k resources, active controllers) generates ~1.5 MB/min of timeline events. With the default 7-day retention, expect ~15 GB at steady state. Tune `timeline.retention` and `persistence.size` together. Set `timeline.retention=0` to disable cleanup (events grow unbounded — not recommended).
+**Sizing**: timeline volume depends on cluster size and controller churn. Tune `timeline.retention`, `timeline.maxSize`, and `persistence.size` together. Set `timeline.retention=0` to disable age cleanup; keep `timeline.maxSize` enabled for in-cluster deployments so Radar prunes oldest events before the PVC fills.
 
-`/api/diagnostics` surfaces `timeline.retentionAge`, `timeline.lastCleanupAt`, `timeline.lastCleanupDeletedRows`, `timeline.lastCleanupError`, and `timeline.storageBytes` so you can confirm cleanup is keeping up without tailing logs.
+`/api/diagnostics` surfaces `timeline.retentionAge`, `timeline.maxStorageBytes`, `timeline.lastCleanupAt`, `timeline.lastCleanupDeletedRows`, `timeline.lastCleanupError`, and `timeline.storageBytes` so you can confirm cleanup is keeping up without tailing logs.
 
 ## RBAC
 

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
             {{- if .Values.timeline.retention }}
             - --timeline-retention={{ .Values.timeline.retention }}
             {{- end }}
+            {{- if .Values.timeline.maxSize }}
+            - --timeline-max-size={{ .Values.timeline.maxSize }}
+            {{- end }}
             {{- end }}
             - --history-limit={{ .Values.timeline.historyLimit }}
             {{- if .Values.traffic.prometheusUrl }}

--- a/deploy/helm/radar/values.schema.json
+++ b/deploy/helm/radar/values.schema.json
@@ -167,6 +167,10 @@
         "retention": {
           "type": "string",
           "description": "SQLite retention as a Go duration (e.g. 168h). \"0\" disables cleanup."
+        },
+        "maxSize": {
+          "type": "string",
+          "description": "SQLite max storage size before pruning oldest events (e.g. 800Mi, 8Gi). \"0\" disables size pruning."
         }
       }
     },

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -227,9 +227,9 @@ resources:
 #     long-lived deployment. Adds operational concerns: the PVC fills if
 #     retention is unbounded; restart on a multi-GB DB is slower.
 #
-# Sizing rule of thumb: a busy cluster (~5k resources, active controllers)
-# generates ~1.5 MB/min of timeline events. With the default 7d retention,
-# expect ~15 GB at steady state. Tune with `retention` and PVC `size` below.
+# Timeline volume depends on cluster size and controller churn. Keep `maxSize`
+# below the PVC `size` so Radar can prune before the volume fills; tune
+# `retention`, `maxSize`, and PVC `size` together.
 timeline:
   # Storage backend: "memory" or "sqlite"
   storage: memory
@@ -243,6 +243,10 @@ timeline:
   # "0" disables cleanup (events table grows unbounded — not recommended for
   # in-cluster deployments). Cleanup runs hourly + once at startup.
   retention: 168h
+  # SQLite max storage size. When the DB + WAL exceed this value, Radar prunes
+  # oldest events until storage is back under the low-water mark. Set "0" to
+  # disable size-based pruning.
+  maxSize: 800Mi
 
 # Authentication and RBAC configuration
 auth:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,7 @@ Persistent defaults for CLI flags. CLI flags always override these values. Manag
   "noBrowser": false,
   "timelineStorage": "memory",
   "timelineDbPath": "~/.radar/timeline.db",
+  "timelineMaxSize": "0",
   "historyLimit": 10000,
   "prometheusUrl": "",
   "prometheusHeaders": {},
@@ -38,6 +39,7 @@ All fields are optional — omitted fields use built-in defaults.
 | `noBrowser` | Don't auto-open browser |
 | `timelineStorage` | `memory` or `sqlite` |
 | `timelineDbPath` | Path to SQLite database |
+| `timelineMaxSize` | Max SQLite DB + WAL size before pruning oldest events (`0` disables) |
 | `historyLimit` | Max timeline events to retain |
 | `prometheusUrl` | Manual Prometheus/VictoriaMetrics URL — skips auto-discovery. Useful when Prometheus is not in the same cluster or uses a non-standard service name. |
 | `prometheusHeaders` | HTTP headers sent with every Prometheus request. Required for auth-protected backends — e.g. `{"X-Scope-OrgID": "my-org"}`. Equivalent CLI: `--prometheus-header Key=Value` (repeatable). Stored in plain text in `config.json` — protect the file accordingly. |

--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -280,9 +280,9 @@ Radar's timeline records every cluster change. Two backends:
 - **`memory`** (default): events live in-process, lost on pod restart. Lowest footprint; pick this if you only need recent activity (last few hours).
 - **`sqlite`**: events persist to a PVC across restarts. Multi-day audit trail; pick this for long-running in-cluster deployments where you care about history surviving pod cycles.
 
-A busy cluster (~5k resources, active controllers) generates ~1.5 MB/min of events. With the default 7-day retention, expect ~15 GB at steady state. Tune `timeline.retention` (Go duration; `0` disables cleanup — not recommended) and `persistence.size` together.
+Timeline volume depends on cluster size and controller churn. Tune `timeline.retention` (Go duration; `0` disables age cleanup), `timeline.maxSize`, and `persistence.size` together. Keep `timeline.maxSize` below the PVC size so Radar prunes oldest events before the volume fills.
 
-Cleanup runs hourly + once at startup. Confirm it's keeping up via `/api/diagnostics` — the `timeline.lastCleanupAt`, `timeline.lastCleanupDeletedRows`, `timeline.lastCleanupError`, and `timeline.storageBytes` fields surface the state without requiring `kubectl logs`.
+Cleanup runs hourly + once at startup. Confirm it's keeping up via `/api/diagnostics` — the `timeline.maxStorageBytes`, `timeline.lastCleanupAt`, `timeline.lastCleanupDeletedRows`, `timeline.lastCleanupError`, and `timeline.storageBytes` fields surface the state without requiring `kubectl logs`.
 
 ## Configuration Reference
 
@@ -302,6 +302,7 @@ See [Helm Chart README](../deploy/helm/radar/README.md) for all available values
 | `timeline.dbPath` | SQLite database path | `/data/timeline.db` |
 | `timeline.historyLimit` | Max events to retain (memory only) | `10000` |
 | `timeline.retention` | SQLite retention (Go duration; `0` disables) | `168h` |
+| `timeline.maxSize` | SQLite max DB + WAL size before oldest events are pruned (`0` disables) | `800Mi` |
 | `traffic.prometheusUrl` | Manual Prometheus/VictoriaMetrics URL | `""` (auto-discover) |
 | `traffic.prometheusHeadersFromEnv` | Prometheus headers sourced from environment variables, for secret-backed auth headers | `{}` |
 | `persistence.enabled` | Enable PVC for SQLite storage | `false` |

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -44,6 +44,7 @@ type AppConfig struct {
 	TimelineStorage          string
 	TimelineDBPath           string
 	TimelineRetention        time.Duration
+	TimelineMaxSizeBytes     int64
 	PrometheusURL            string
 	PrometheusHeaders        map[string]string
 	PrometheusHeadersFromEnv map[string]string
@@ -111,6 +112,7 @@ func BuildTimelineStoreConfig(cfg AppConfig) timeline.StoreConfig {
 		}
 		storeCfg.Path = dbPath
 		storeCfg.RetentionAge = cfg.TimelineRetention
+		storeCfg.MaxStorageBytes = cfg.TimelineMaxSizeBytes
 	}
 	return storeCfg
 }
@@ -167,6 +169,7 @@ func CreateServer(cfg AppConfig) *server.Server {
 		NoBrowser:                cfg.NoBrowser,
 		TimelineStorage:          cfg.TimelineStorage,
 		TimelineDBPath:           cfg.TimelineDBPath,
+		TimelineMaxSize:          fmt.Sprintf("%d", cfg.TimelineMaxSizeBytes),
 		HistoryLimit:             cfg.HistoryLimit,
 		PrometheusURL:            cfg.PrometheusURL,
 		PrometheusHeaders:        cfg.PrometheusHeaders,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -21,6 +22,7 @@ type Config struct {
 	TimelineStorage   string   `json:"timelineStorage,omitempty"`
 	TimelineDBPath    string   `json:"timelineDbPath,omitempty"`
 	TimelineRetention string   `json:"timelineRetention,omitempty"` // Go duration (e.g. "168h" for 7d); "0" disables
+	TimelineMaxSize   string   `json:"timelineMaxSize,omitempty"`   // Byte size (e.g. "800Mi", "8Gi"); "0" disables
 	HistoryLimit      int      `json:"historyLimit,omitempty"`
 	PrometheusURL     string   `json:"prometheusUrl,omitempty"`
 	// PrometheusHeaders are sent with every request to the Prometheus API.
@@ -148,6 +150,60 @@ func (c Config) TimelineRetentionOr(def time.Duration) time.Duration {
 		return def
 	}
 	return d
+}
+
+func (c Config) TimelineMaxSizeOr(def string) string {
+	if c.TimelineMaxSize == "" {
+		return def
+	}
+	return c.TimelineMaxSize
+}
+
+func ParseByteSize(raw string) (int64, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return 0, strconv.ErrSyntax
+	}
+	lower := strings.ToLower(s)
+	multipliers := []struct {
+		suffix string
+		value  int64
+	}{
+		{"gib", 1 << 30},
+		{"gb", 1000 * 1000 * 1000},
+		{"gi", 1 << 30},
+		{"g", 1000 * 1000 * 1000},
+		{"mib", 1 << 20},
+		{"mb", 1000 * 1000},
+		{"mi", 1 << 20},
+		{"m", 1000 * 1000},
+		{"kib", 1 << 10},
+		{"kb", 1000},
+		{"ki", 1 << 10},
+		{"k", 1000},
+		{"b", 1},
+	}
+	for _, m := range multipliers {
+		if strings.HasSuffix(lower, m.suffix) {
+			num := strings.TrimSpace(s[:len(s)-len(m.suffix)])
+			v, err := strconv.ParseFloat(num, 64)
+			if err != nil {
+				return 0, err
+			}
+			if v < 0 {
+				return 0, strconv.ErrSyntax
+			}
+			return int64(v * float64(m.value)), nil
+		}
+	}
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	if v < 0 {
+		return 0, strconv.ErrSyntax
+	}
+	return v, nil
 }
 
 // KubeconfigDirsFlag returns KubeconfigDirs joined as a comma-separated string

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -180,6 +180,37 @@ func TestHelpers(t *testing.T) {
 		}
 	})
 
+	t.Run("TimelineMaxSizeOr", func(t *testing.T) {
+		if (Config{}).TimelineMaxSizeOr("123") != "123" {
+			t.Error("empty TimelineMaxSize should return default")
+		}
+		if got := (Config{TimelineMaxSize: "800Mi"}).TimelineMaxSizeOr("0"); got != "800Mi" {
+			t.Errorf("TimelineMaxSizeOr(800Mi) = %q", got)
+		}
+		if got := (Config{TimelineMaxSize: "bad"}).TimelineMaxSizeOr("123"); got != "bad" {
+			t.Errorf("TimelineMaxSizeOr(bad) = %q, want bad", got)
+		}
+	})
+
+	t.Run("ParseByteSize", func(t *testing.T) {
+		cases := map[string]int64{
+			"42":    42,
+			"1Ki":   1024,
+			"1.5Mi": int64(1.5 * float64(1<<20)),
+			"2Gi":   2 << 30,
+			"3GB":   3_000_000_000,
+		}
+		for in, want := range cases {
+			got, err := ParseByteSize(in)
+			if err != nil {
+				t.Fatalf("ParseByteSize(%q): %v", in, err)
+			}
+			if got != want {
+				t.Errorf("ParseByteSize(%q) = %d, want %d", in, got, want)
+			}
+		}
+	})
+
 	t.Run("KubeconfigDirsFlag", func(t *testing.T) {
 		if (Config{}).KubeconfigDirsFlag() != "" {
 			t.Error("nil dirs should return empty string")

--- a/internal/server/diagnostics.go
+++ b/internal/server/diagnostics.go
@@ -117,6 +117,7 @@ type DiagTimeline struct {
 
 	// SQLite-only retention/cleanup state.
 	RetentionAge       string `json:"retentionAge,omitempty"`
+	MaxStorageBytes    int64  `json:"maxStorageBytes,omitempty"`
 	LastCleanupAt      string `json:"lastCleanupAt,omitempty"`
 	LastCleanupDeleted int64  `json:"lastCleanupDeletedRows,omitempty"`
 	LastCleanupError   string `json:"lastCleanupError,omitempty"`
@@ -313,6 +314,7 @@ func (s *Server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
 		if stats.RetentionAge > 0 {
 			diag.RetentionAge = stats.RetentionAge.String()
 		}
+		diag.MaxStorageBytes = stats.MaxStorageBytes
 		if s.diagConfig != nil {
 			diag.StorageType = s.diagConfig.TimelineStorage
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -636,14 +636,13 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		status = "degraded"
 	}
 
-	// Get timeline store stats (informational only - doesn't affect overall status)
+	// Timeline store status is informational only and doesn't affect overall status.
 	var timelineStats map[string]any
 	if store := timeline.GetStore(); store != nil {
-		stats := store.Stats()
 		timelineStats = map[string]any{
-			"total_events": stats.TotalEvents,
-			"store_errors": timeline.GetStoreErrorCount(),
-			"total_drops":  timeline.GetTotalDropCount(),
+			"store_present": true,
+			"store_errors":  timeline.GetStoreErrorCount(),
+			"total_drops":   timeline.GetTotalDropCount(),
 		}
 	}
 

--- a/internal/server/server_smoke_test.go
+++ b/internal/server/server_smoke_test.go
@@ -304,6 +304,17 @@ func TestSmokeHealth(t *testing.T) {
 	if count < 1 {
 		t.Errorf("expected resourceCount >= 1, got %v", count)
 	}
+
+	timelineStats, ok := body["timeline"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected timeline stats object, got %T", body["timeline"])
+	}
+	if _, ok := timelineStats["total_events"]; ok {
+		t.Error("health endpoint should not run live timeline event counts")
+	}
+	if timelineStats["store_present"] != true {
+		t.Errorf("expected store_present=true, got %v", timelineStats["store_present"])
+	}
 }
 
 func TestSmokeMetricsEndpoint(t *testing.T) {

--- a/internal/timeline/manager.go
+++ b/internal/timeline/manager.go
@@ -141,9 +141,9 @@ func InitStore(cfg StoreConfig) error {
 				return
 			}
 			globalStore = store
-			if cfg.RetentionAge > 0 {
-				store.StartCleanupLoop(cfg.RetentionAge, time.Hour)
-				log.Printf("Initialized SQLite event store at %s (retention: %s)", cfg.Path, cfg.RetentionAge)
+			if cfg.RetentionAge > 0 || cfg.MaxStorageBytes > 0 {
+				store.StartCleanupLoop(cfg.RetentionAge, time.Hour, cfg.MaxStorageBytes)
+				log.Printf("Initialized SQLite event store at %s (retention: %s, max size: %d bytes)", cfg.Path, cfg.RetentionAge, cfg.MaxStorageBytes)
 			} else {
 				log.Printf("Initialized SQLite event store at %s (retention: disabled — events table will grow unbounded)", cfg.Path)
 			}

--- a/internal/timeline/sqlite_store.go
+++ b/internal/timeline/sqlite_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -32,6 +33,7 @@ type SQLiteStore struct {
 
 	cleanupMu     sync.RWMutex
 	retentionAge  time.Duration
+	maxStorage    int64
 	lastCleanupAt time.Time
 	lastCleanupN  int64
 	lastCleanupEr string
@@ -525,9 +527,7 @@ func (s *SQLiteStore) Stats() StoreStats {
 	}
 
 	// Get database file size
-	if info, err := os.Stat(s.path); err == nil {
-		stats.StorageBytes = info.Size()
-	}
+	stats.StorageBytes = s.storageBytes()
 
 	s.seenMu.RLock()
 	stats.SeenResources = len(s.seenResources)
@@ -535,6 +535,7 @@ func (s *SQLiteStore) Stats() StoreStats {
 
 	s.cleanupMu.RLock()
 	stats.RetentionAge = s.retentionAge
+	stats.MaxStorageBytes = s.maxStorage
 	stats.LastCleanupAt = s.lastCleanupAt
 	stats.LastCleanupDeletedRows = s.lastCleanupN
 	stats.LastCleanupError = s.lastCleanupEr
@@ -562,28 +563,111 @@ func (s *SQLiteStore) Cleanup(ctx context.Context, maxAge time.Duration) (int64,
 	return result.RowsAffected()
 }
 
+func (s *SQLiteStore) PruneToMaxSize(ctx context.Context, maxBytes int64) (int64, error) {
+	if maxBytes <= 0 {
+		return 0, nil
+	}
+	if current := s.storageBytes(); current <= maxBytes {
+		return 0, nil
+	}
+	if err := s.checkpointWAL(ctx); err != nil {
+		return 0, err
+	}
+	if current := s.storageBytes(); current <= maxBytes {
+		return 0, nil
+	}
+
+	target := maxBytes * 85 / 100
+	if target <= 0 {
+		target = maxBytes
+	}
+
+	var totalDeleted int64
+	for attempts := 0; attempts < 5; attempts++ {
+		current := s.storageBytes()
+		if current <= maxBytes {
+			return totalDeleted, nil
+		}
+
+		count, err := s.countEvents(ctx)
+		if err != nil {
+			return totalDeleted, err
+		}
+		if count == 0 {
+			if err := s.reclaimStorage(ctx); err != nil {
+				return totalDeleted, err
+			}
+			break
+		}
+		if count == 1 {
+			deleted, err := s.deleteOldestEvents(ctx, 1)
+			totalDeleted += deleted
+			if err != nil {
+				return totalDeleted, err
+			}
+			if err := s.reclaimStorage(ctx); err != nil {
+				return totalDeleted, err
+			}
+			continue
+		}
+
+		avgBytes := current / count
+		if avgBytes < 1 {
+			avgBytes = 1
+		}
+		toDelete := ((current - target) / avgBytes) + 1
+		if toDelete < 1000 && count > 1000 {
+			toDelete = 1000
+		}
+		if toDelete < 1 {
+			toDelete = 1
+		}
+		if toDelete >= count {
+			toDelete = count - 1
+		}
+
+		deleted, err := s.deleteOldestEvents(ctx, toDelete)
+		totalDeleted += deleted
+		if err != nil {
+			return totalDeleted, err
+		}
+		if deleted == 0 {
+			break
+		}
+		if err := s.reclaimStorage(ctx); err != nil {
+			return totalDeleted, err
+		}
+	}
+
+	if current := s.storageBytes(); current > maxBytes {
+		return totalDeleted, fmt.Errorf("timeline storage still above max size after pruning (%d > %d bytes)", current, maxBytes)
+	}
+	return totalDeleted, nil
+}
+
 // StartCleanupLoop spawns a goroutine that periodically deletes events older
-// than retention. Without this, the events table grows unbounded. Runs once
-// immediately so post-upgrade users with bloated DBs don't wait an hour for
-// the first cleanup. The loop exits when Close is called. retention <= 0
-// (or interval <= 0) disables cleanup entirely.
-func (s *SQLiteStore) StartCleanupLoop(retention, interval time.Duration) {
-	if retention <= 0 || interval <= 0 {
+// than retention and prunes oldest events when the DB exceeds maxStorageBytes.
+// Runs once immediately so post-upgrade users with bloated DBs don't wait an
+// hour for the first cleanup. The loop exits when Close is called. Both
+// retention <= 0 and maxStorageBytes <= 0 together disable cleanup entirely.
+func (s *SQLiteStore) StartCleanupLoop(retention, interval time.Duration, maxStorageBytes int64) {
+	if interval <= 0 || (retention <= 0 && maxStorageBytes <= 0) {
 		return
 	}
 	s.cleanupMu.Lock()
 	s.retentionAge = retention
+	s.maxStorage = maxStorageBytes
 	s.cleanupMu.Unlock()
 	s.wg.Go(func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
-		s.runCleanup(retention)
+		s.runCleanup(retention, maxStorageBytes)
 		for {
 			select {
 			case <-s.quit:
 				return
 			case <-ticker.C:
-				s.runCleanup(retention)
+				s.runCleanup(retention, maxStorageBytes)
 			}
 		}
 	})
@@ -627,16 +711,32 @@ func (s *SQLiteStore) hydrateSeenResources() {
 // (timestamp, deleted count, last error) so it's surfaceable via Stats() and
 // /api/diagnostics — operators shouldn't need to tail logs to know retention
 // is working.
-func (s *SQLiteStore) runCleanup(retention time.Duration) {
-	n, err := s.Cleanup(context.Background(), retention)
+func (s *SQLiteStore) runCleanup(retention time.Duration, maxStorageBytes int64) {
+	var n int64
+	var cleanupErr error
+	var checkpointErr error
+	var pruneErr error
+	ctx := context.Background()
+	if retention > 0 {
+		n, cleanupErr = s.Cleanup(ctx, retention)
+		if cleanupErr == nil {
+			checkpointErr = s.checkpointWAL(ctx)
+		}
+	}
+	if maxStorageBytes > 0 {
+		var pruned int64
+		pruned, pruneErr = s.PruneToMaxSize(ctx, maxStorageBytes)
+		n += pruned
+	}
+	err := errors.Join(cleanupErr, checkpointErr, pruneErr)
 	now := time.Now()
 	s.cleanupMu.Lock()
 	s.lastCleanupAt = now
+	s.lastCleanupN = n
 	if err != nil {
 		s.lastCleanupEr = err.Error()
 	} else {
 		s.lastCleanupEr = ""
-		s.lastCleanupN = n
 	}
 	s.cleanupMu.Unlock()
 
@@ -645,11 +745,58 @@ func (s *SQLiteStore) runCleanup(retention time.Duration) {
 		return
 	}
 	if n > 0 {
-		log.Printf("[timeline] cleanup: deleted %d events older than %s from %s", n, retention, s.path)
+		log.Printf("[timeline] cleanup: deleted %d events from %s", n, s.path)
 	}
-	if _, err := s.db.Exec("PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
-		log.Printf("[timeline] wal_checkpoint failed for %s: %v", s.path, err)
+}
+
+func (s *SQLiteStore) storageBytes() int64 {
+	var total int64
+	for _, path := range []string{s.path, s.path + "-wal"} {
+		if info, err := os.Stat(path); err == nil {
+			total += info.Size()
+		}
 	}
+	return total
+}
+
+func (s *SQLiteStore) countEvents(ctx context.Context) (int64, error) {
+	var count int64
+	if err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM events").Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func (s *SQLiteStore) deleteOldestEvents(ctx context.Context, limit int64) (int64, error) {
+	result, err := s.db.ExecContext(ctx, `
+		DELETE FROM events
+		WHERE id IN (
+			SELECT id FROM events
+			ORDER BY timestamp ASC, created_at ASC
+			LIMIT ?
+		)
+	`, limit)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+func (s *SQLiteStore) reclaimStorage(ctx context.Context) error {
+	if err := s.checkpointWAL(ctx); err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, "VACUUM"); err != nil {
+		return fmt.Errorf("vacuum failed: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) checkpointWAL(ctx context.Context) error {
+	if _, err := s.db.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		return fmt.Errorf("wal checkpoint failed: %w", err)
+	}
+	return nil
 }
 
 // scanEvent scans a row into a TimelineEvent

--- a/internal/timeline/sqlite_store_test.go
+++ b/internal/timeline/sqlite_store_test.go
@@ -2,8 +2,10 @@ package timeline
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -30,6 +32,18 @@ func createTestSQLiteStore(t *testing.T) (*SQLiteStore, func()) {
 	}
 
 	return store, cleanup
+}
+
+func sqliteFileSize(t *testing.T, path string) int64 {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return info.Size()
 }
 
 func TestSQLiteStore_Append(t *testing.T) {
@@ -551,7 +565,7 @@ func TestSQLiteStore_Stats_RecordsCleanupState(t *testing.T) {
 		t.Fatalf("Append: %v", err)
 	}
 
-	store.StartCleanupLoop(time.Hour, time.Hour)
+	store.StartCleanupLoop(time.Hour, time.Hour, 0)
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
@@ -571,6 +585,165 @@ func TestSQLiteStore_Stats_RecordsCleanupState(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 	t.Fatal("LastCleanupAt remained zero — cleanup state not recorded")
+}
+
+func TestSQLiteStore_PruneToMaxSize_DropsOldestEvents(t *testing.T) {
+	store, cleanup := createTestSQLiteStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	base := time.Now().Add(-time.Hour)
+	events := make([]TimelineEvent, 0, 300)
+	for i := range 300 {
+		events = append(events, TimelineEvent{
+			ID:        fmt.Sprintf("event-%03d", i),
+			Timestamp: base.Add(time.Duration(i) * time.Second),
+			Source:    SourceInformer,
+			Kind:      "TimelineWidget",
+			Namespace: "default",
+			Name:      "noise-check",
+			EventType: EventTypeUpdate,
+			Message:   strings.Repeat("x", 2048),
+		})
+	}
+	if err := store.AppendBatch(ctx, events); err != nil {
+		t.Fatalf("AppendBatch: %v", err)
+	}
+
+	if err := store.checkpointWAL(ctx); err != nil {
+		t.Fatalf("checkpointWAL: %v", err)
+	}
+	before := store.storageBytes()
+	deleted, err := store.PruneToMaxSize(ctx, before*9/10)
+	if err != nil {
+		t.Fatalf("PruneToMaxSize: %v", err)
+	}
+	if deleted == 0 {
+		t.Fatal("expected size pruning to delete old events")
+	}
+
+	got, err := store.Query(ctx, QueryOptions{Limit: 1000, IncludeManaged: true})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(got) >= len(events) {
+		t.Fatalf("expected fewer than %d events after pruning, got %d", len(events), len(got))
+	}
+	if len(got) == 0 || got[0].ID != "event-299" {
+		t.Fatalf("expected newest event to remain after pruning, got %+v", got)
+	}
+}
+
+func TestSQLiteStore_PruneToMaxSize_CanDeleteLastOversizedEvent(t *testing.T) {
+	store, cleanup := createTestSQLiteStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	maxBytes := store.storageBytes() + 128*1024
+	if err := store.Append(ctx, TimelineEvent{
+		ID:        "oversized",
+		Timestamp: time.Now(),
+		Source:    SourceInformer,
+		Kind:      "TimelineWidget",
+		Namespace: "default",
+		Name:      "noise-check",
+		EventType: EventTypeUpdate,
+		Message:   strings.Repeat("x", 2*1024*1024),
+	}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if store.storageBytes() <= maxBytes {
+		t.Fatalf("test setup did not exceed max size: storage=%d max=%d", store.storageBytes(), maxBytes)
+	}
+
+	deleted, err := store.PruneToMaxSize(ctx, maxBytes)
+	if err != nil {
+		t.Fatalf("PruneToMaxSize: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1", deleted)
+	}
+	got, err := store.Query(ctx, QueryOptions{Limit: 10, IncludeManaged: true})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected oversized event to be pruned, got %+v", got)
+	}
+	if storage := store.storageBytes(); storage > maxBytes {
+		t.Fatalf("storage still above max after pruning: %d > %d", storage, maxBytes)
+	}
+}
+
+func TestSQLiteStore_RunCleanup_CheckpointsWALForRetentionOnly(t *testing.T) {
+	store, cleanup := createTestSQLiteStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	events := make([]TimelineEvent, 0, 300)
+	for i := range 300 {
+		events = append(events, TimelineEvent{
+			ID:        fmt.Sprintf("event-%03d", i),
+			Timestamp: time.Now(),
+			Source:    SourceInformer,
+			Kind:      "TimelineWidget",
+			Namespace: "default",
+			Name:      "noise-check",
+			EventType: EventTypeUpdate,
+			Message:   strings.Repeat("x", 2048),
+		})
+	}
+	if err := store.AppendBatch(ctx, events); err != nil {
+		t.Fatalf("AppendBatch: %v", err)
+	}
+	walBefore := sqliteFileSize(t, store.path+"-wal")
+	if walBefore == 0 {
+		t.Fatal("test setup did not create a WAL file")
+	}
+
+	store.runCleanup(time.Hour, 0)
+
+	if walAfter := sqliteFileSize(t, store.path+"-wal"); walAfter != 0 {
+		t.Fatalf("expected retention cleanup to truncate WAL, before=%d after=%d", walBefore, walAfter)
+	}
+}
+
+func TestSQLiteStore_StartCleanupLoop_PrunesByMaxSizeWithoutRetention(t *testing.T) {
+	store, cleanup := createTestSQLiteStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	base := time.Now().Add(-time.Hour)
+	events := make([]TimelineEvent, 0, 300)
+	for i := range 300 {
+		events = append(events, TimelineEvent{
+			ID:        fmt.Sprintf("event-%03d", i),
+			Timestamp: base.Add(time.Duration(i) * time.Second),
+			Source:    SourceInformer,
+			Kind:      "TimelineWidget",
+			Namespace: "default",
+			Name:      "noise-check",
+			EventType: EventTypeUpdate,
+			Message:   strings.Repeat("x", 2048),
+		})
+	}
+	if err := store.AppendBatch(ctx, events); err != nil {
+		t.Fatalf("AppendBatch: %v", err)
+	}
+
+	before := store.storageBytes()
+	store.StartCleanupLoop(0, time.Hour, before*9/10)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		stats := store.Stats()
+		if stats.LastCleanupDeletedRows > 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatal("max-size-only cleanup did not prune events")
 }
 
 func TestSQLiteStore_StartCleanupLoop_RunsImmediately(t *testing.T) {
@@ -595,7 +768,7 @@ func TestSQLiteStore_StartCleanupLoop_RunsImmediately(t *testing.T) {
 		t.Fatalf("Append: %v", err)
 	}
 
-	store.StartCleanupLoop(time.Hour, time.Hour)
+	store.StartCleanupLoop(time.Hour, time.Hour, 0)
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
@@ -639,7 +812,7 @@ func TestSQLiteStore_StartCleanupLoop_RunsAndStopsOnClose(t *testing.T) {
 		t.Fatalf("AppendBatch: %v", err)
 	}
 
-	store.StartCleanupLoop(time.Hour, 20*time.Millisecond)
+	store.StartCleanupLoop(time.Hour, 20*time.Millisecond, 0)
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
@@ -675,10 +848,11 @@ func TestSQLiteStore_StartCleanupLoop_ZeroIsNoop(t *testing.T) {
 		name      string
 		retention time.Duration
 		interval  time.Duration
+		maxBytes  int64
 	}{
-		{"zero retention", 0, time.Hour},
-		{"zero interval", time.Hour, 0},
-		{"both zero", 0, 0},
+		{"zero retention and max size", 0, time.Hour, 0},
+		{"zero interval", time.Hour, 0, 1024},
+		{"both cleanup modes disabled", 0, time.Hour, 0},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -693,7 +867,7 @@ func TestSQLiteStore_StartCleanupLoop_ZeroIsNoop(t *testing.T) {
 				t.Fatalf("NewSQLiteStore: %v", err)
 			}
 
-			store.StartCleanupLoop(tc.retention, tc.interval)
+			store.StartCleanupLoop(tc.retention, tc.interval, tc.maxBytes)
 
 			done := make(chan error, 1)
 			go func() { done <- store.Close() }()

--- a/pkg/timeline/config.go
+++ b/pkg/timeline/config.go
@@ -12,10 +12,11 @@ const (
 
 // StoreConfig holds configuration for the event store
 type StoreConfig struct {
-	Type         StoreType
-	Path         string        // For SQLite: database file path
-	MaxSize      int           // For Memory: ring buffer size
-	RetentionAge time.Duration // For SQLite: delete events older than this; 0 = never
+	Type            StoreType
+	Path            string        // For SQLite: database file path
+	MaxSize         int           // For Memory: ring buffer size
+	RetentionAge    time.Duration // For SQLite: delete events older than this; 0 = never
+	MaxStorageBytes int64         // For SQLite: prune oldest events to stay under this size; 0 = never
 }
 
 // DefaultStoreConfig returns sensible defaults

--- a/pkg/timeline/store.go
+++ b/pkg/timeline/store.go
@@ -87,6 +87,7 @@ type StoreStats struct {
 
 	// SQLite-only retention/cleanup state. Zero values for memory store.
 	RetentionAge           time.Duration `json:"retentionAge,omitempty"`
+	MaxStorageBytes        int64         `json:"maxStorageBytes,omitempty"`
 	LastCleanupAt          time.Time     `json:"lastCleanupAt,omitempty"`
 	LastCleanupDeletedRows int64         `json:"lastCleanupDeletedRows,omitempty"`
 	LastCleanupError       string        `json:"lastCleanupError,omitempty"`


### PR DESCRIPTION
## Summary

Adds SQLite timeline size pruning so in-cluster deployments can bound storage growth and avoid filling the PVC.

- Adds `--timeline-max-size`, config `timelineMaxSize`, and Helm `timeline.maxSize`.
- Prunes DB + WAL usage during cleanup by checkpointing, deleting oldest events toward a low-water mark, and vacuuming to reclaim disk.
- Defaults Helm SQLite deployments to `800Mi`, below the chart default `1Gi` PVC.
- Removes live SQLite event counting from `/api/health`; detailed counts and cleanup state remain in `/api/diagnostics`.
- Updates sizing docs to avoid fixed storage estimates and guide operators to tune retention, max size, and PVC size together.

Related: #662

## Tests

- `go test ./internal/config ./internal/timeline ./internal/server ./internal/k8s ./cmd/desktop ./cmd/explorer`
- `git diff --check`
- `make build`
- Smoke-tested against `kind-radar-bench` with SQLite, `--timeline-max-size=512Ki`, and controlled ConfigMap churn; verified cleanup deleted old rows and checkpointing brought DB+WAL back under the cap.
