### PR TITLE
Add namespace-scoped informer mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ radar
 | `--kubeconfig` | `~/.kube/config` | Path to kubeconfig file |
 | `--kubeconfig-dir` | | Comma-separated directories containing kubeconfig files |
 | `--namespace` | (all) | Initial namespace filter (supports multi-select in the UI; also used as RBAC fallback for namespace-scoped users) |
+| `--namespace-scope` | `false` | Pin namespaced informer caches to one namespace for large clusters. Requires `--namespace`, a kubeconfig context namespace, or a saved local single-namespace pick. Local mode can rebuild the cache when switching namespaces; auth/cloud mode locks the shared cache to the startup namespace. |
 | `--port` | `9280` | Server port |
 | `--no-browser` | `false` | Don't auto-open browser |
 | `--browser` | | Browser to use when opening the UI, e.g. `firefox`, `google-chrome`, or `Google Chrome` on macOS |

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ radar
 | `--kubeconfig` | `~/.kube/config` | Path to kubeconfig file |
 | `--kubeconfig-dir` | | Comma-separated directories containing kubeconfig files |
 | `--namespace` | (all) | Initial namespace filter (supports multi-select in the UI; also used as RBAC fallback for namespace-scoped users) |
-| `--namespace-scope` | `false` | Pin namespaced informer caches to one namespace for large clusters. Requires `--namespace`, a kubeconfig context namespace, or a saved local single-namespace pick. Local mode can rebuild the cache when switching namespaces; auth/cloud mode locks the shared cache to the startup namespace. |
+| `--namespace-scope` | `false` | Pin namespaced informer caches to a **single** namespace for large clusters (scoping to multiple namespaces is not supported yet). Requires `--namespace`, a kubeconfig context namespace, or a saved local single-namespace pick. Local mode can rebuild the cache when switching namespaces; auth/cloud mode locks the shared cache to the startup namespace. |
 | `--port` | `9280` | Server port |
 | `--no-browser` | `false` | Don't auto-open browser |
 | `--browser` | | Browser to use when opening the UI, e.g. `firefox`, `google-chrome`, or `Google Chrome` on macOS |

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -63,7 +63,7 @@ func main() {
 	podShellDefault := flag.String("pod-shell-default", "", "Override the default pod exec shell command (runs as 'sh -c <value>'; empty = built-in bash -il → ash → sh cascade)")
 	debugImage := flag.String("debug-image", fileCfg.DebugImage, "Image for ephemeral debug containers and node debug pods (empty = busybox:latest; point at a mirror for air-gapped/private-registry clusters)")
 	listPageSize := flag.Int64("list-page-size", 0, "Paginate the initial LIST of high-cardinality kinds (Pods, ReplicaSets) at this page size on clusters without WatchList streaming. 0 = off (single LIST). Try 2000 if a very large cluster fails to sync.")
-	namespaceScope := flag.Bool("namespace-scope", false, "Scope namespaced informer caches to one namespace. Requires --namespace or a kubeconfig context namespace. Local mode can rescope by switching namespaces; auth/cloud mode locks to the startup namespace.")
+	namespaceScope := flag.Bool("namespace-scope", false, "Scope namespaced informer caches to a single namespace (multiple namespaces are not supported yet). Requires --namespace or a kubeconfig context namespace. Local mode can rescope by switching namespaces; auth/cloud mode locks to the startup namespace.")
 	// Timeline storage options
 	timelineStorage := flag.String("timeline-storage", fileCfg.TimelineStorageOr("memory"), "Timeline storage backend: memory or sqlite")
 	timelineDBPath := flag.String("timeline-db", fileCfg.TimelineDBPath, "Path to timeline database file (default: ~/.radar/timeline.db)")

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -63,6 +63,7 @@ func main() {
 	podShellDefault := flag.String("pod-shell-default", "", "Override the default pod exec shell command (runs as 'sh -c <value>'; empty = built-in bash -il → ash → sh cascade)")
 	debugImage := flag.String("debug-image", fileCfg.DebugImage, "Image for ephemeral debug containers and node debug pods (empty = busybox:latest; point at a mirror for air-gapped/private-registry clusters)")
 	listPageSize := flag.Int64("list-page-size", 0, "Paginate the initial LIST of high-cardinality kinds (Pods, ReplicaSets) at this page size on clusters without WatchList streaming. 0 = off (single LIST). Try 2000 if a very large cluster fails to sync.")
+	namespaceScope := flag.Bool("namespace-scope", false, "Scope namespaced informer caches to one namespace. Requires --namespace or a kubeconfig context namespace. Local mode can rescope by switching namespaces; auth/cloud mode locks to the startup namespace.")
 	// Timeline storage options
 	timelineStorage := flag.String("timeline-storage", fileCfg.TimelineStorageOr("memory"), "Timeline storage backend: memory or sqlite")
 	timelineDBPath := flag.String("timeline-db", fileCfg.TimelineDBPath, "Path to timeline database file (default: ~/.radar/timeline.db)")
@@ -212,6 +213,7 @@ func main() {
 		PodShellDefault:          *podShellDefault,
 		DebugImage:               *debugImage,
 		ListPageSize:             *listPageSize,
+		NamespaceScope:           *namespaceScope,
 		TimelineStorage:          *timelineStorage,
 		TimelineDBPath:           *timelineDBPath,
 		TimelineRetention:        *timelineRetention,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,6 +124,8 @@ The header has a namespace picker on the right. Pick a single namespace to focus
 
 The pick is a per-user view filter — it doesn't change anything for other users sharing the same Radar instance. Locally, your pick is remembered per kubeconfig context across restarts. In shared (auth-enabled) deployments the pick lives for the session.
 
+When Radar starts with `--namespace-scope`, the picker controls the process-wide cache scope instead of just a view filter. Namespaced informer caches are pinned to one namespace while cluster-scoped resources remain cluster-wide. Local/no-auth sessions can switch the scoped namespace, which rebuilds the cache in place. Auth-enabled and Radar Cloud sessions lock the picker to the startup namespace so one user cannot reshape the shared backend cache for everyone.
+
 ## Related Documentation
 
 - [README](../README.md#usage) — CLI flags and basic usage

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,6 +126,8 @@ The pick is a per-user view filter — it doesn't change anything for other user
 
 When Radar starts with `--namespace-scope`, the picker controls the process-wide cache scope instead of just a view filter. Namespaced informer caches are pinned to one namespace while cluster-scoped resources remain cluster-wide. Local/no-auth sessions can switch the scoped namespace, which rebuilds the cache in place. Auth-enabled and Radar Cloud sessions lock the picker to the startup namespace so one user cannot reshape the shared backend cache for everyone.
 
+**Single namespace only.** `--namespace-scope` pins the cache to exactly one namespace; scoping to several namespaces at once is not supported yet. Passing more than one (e.g. `--namespace=a,b`) fails at startup with a clear error rather than silently caching nothing. When scoped, the namespace picker becomes single-select, and a switch re-points the whole cache to the new namespace rather than adding to it.
+
 ## Related Documentation
 
 - [README](../README.md#usage) — CLI flags and basic usage

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -11,6 +11,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/validation"
+
 	"github.com/skyhook-io/radar/internal/auth"
 	"github.com/skyhook-io/radar/internal/config"
 	"github.com/skyhook-io/radar/internal/helm"
@@ -84,8 +86,10 @@ func InitializeK8s(cfg AppConfig) error {
 		k8s.SetFallbackNamespace(cfg.Namespace)
 	}
 	configureNamespaceScopePreferenceResolver(cfg)
-	if cfg.NamespaceScope && k8s.GetNamespaceScopeTarget() == "" {
-		return fmt.Errorf("--namespace-scope requires --namespace or a namespace on the current kubeconfig context")
+	if cfg.NamespaceScope {
+		if err := validateNamespaceScopeTarget(k8s.GetNamespaceScopeTarget()); err != nil {
+			return err
+		}
 	}
 
 	if len(cfg.KubeconfigDirs) > 0 {
@@ -105,11 +109,28 @@ func InitializeK8s(cfg AppConfig) error {
 	return nil
 }
 
+// validateNamespaceScopeTarget enforces that --namespace-scope resolves to
+// exactly one valid namespace. Multiple namespaces (e.g. --namespace=a,b) are
+// not supported yet — the informer cache pins to a single namespace — so reject
+// them at startup with a clear message instead of silently caching an invalid one.
+func validateNamespaceScopeTarget(target string) error {
+	if target == "" {
+		return fmt.Errorf("--namespace-scope requires --namespace or a namespace on the current kubeconfig context")
+	}
+	if errs := validation.IsDNS1123Label(target); len(errs) > 0 {
+		return fmt.Errorf("--namespace-scope supports a single namespace; %q is not a valid namespace name (multiple namespaces are not supported yet): %s", target, strings.Join(errs, "; "))
+	}
+	return nil
+}
+
 func configureNamespaceScopePreferenceResolver(cfg AppConfig) {
 	k8s.SetNamespaceScopePreferenceResolver(nil)
-	if !cfg.NamespaceScope || cfg.Namespace != "" || cfg.AuthConfig.Enabled() {
+	if !cfg.NamespaceScope || cfg.AuthConfig.Enabled() {
 		return
 	}
+	// Resolve the scoped namespace from the local per-context pick. Registered
+	// even when --namespace is set, so a UI rescope (which persists its pick)
+	// survives a reconnect / context switch instead of snapping back.
 	k8s.SetNamespaceScopePreferenceResolver(func(ctxName string) (string, bool) {
 		activeNamespaces := settings.Load().ActiveNamespaces
 		if len(activeNamespaces[ctxName]) == 1 && activeNamespaces[ctxName][0] != "" {
@@ -117,7 +138,30 @@ func configureNamespaceScopePreferenceResolver(cfg AppConfig) {
 		}
 		return "", false
 	})
+	// Treat an explicit --namespace like a UI pick of that namespace: seed it as
+	// this run's authoritative starting scope (overwriting a stale pick from a
+	// previous run). A later UI rescope overwrites it, and that rescope is what
+	// then survives reconnects.
+	if cfg.Namespace != "" {
+		seedNamespaceScopePick(k8s.GetContextName(), cfg.Namespace)
+	}
 	k8s.RestoreNamespaceScopePreference(k8s.GetContextName())
+}
+
+// seedNamespaceScopePick persists ns as the single active namespace for ctxName,
+// mirroring what a UI namespace pick stores. No-op on an empty context name.
+func seedNamespaceScopePick(ctxName, ns string) {
+	if ctxName == "" {
+		return
+	}
+	if _, err := settings.Update(func(st *settings.Settings) {
+		if st.ActiveNamespaces == nil {
+			st.ActiveNamespaces = map[string][]string{}
+		}
+		st.ActiveNamespaces[ctxName] = []string{ns}
+	}); err != nil {
+		log.Printf("[namespace] failed to seed namespace pick for context %q: %v", ctxName, err)
+	}
 }
 
 // BuildTimelineStoreConfig creates the timeline store configuration from app config.

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -18,6 +18,7 @@ import (
 	mcppkg "github.com/skyhook-io/radar/internal/mcp"
 	prometheuspkg "github.com/skyhook-io/radar/internal/prometheus"
 	"github.com/skyhook-io/radar/internal/server"
+	"github.com/skyhook-io/radar/internal/settings"
 	"github.com/skyhook-io/radar/internal/static"
 	"github.com/skyhook-io/radar/internal/timeline"
 	"github.com/skyhook-io/radar/internal/traffic"
@@ -42,6 +43,7 @@ type AppConfig struct {
 	PodShellDefault          string
 	DebugImage               string
 	ListPageSize             int64
+	NamespaceScope           bool
 	TimelineStorage          string
 	TimelineDBPath           string
 	TimelineRetention        time.Duration
@@ -63,6 +65,7 @@ func SetGlobals(cfg AppConfig) {
 	k8s.ForceDisableExec = cfg.DisableExec
 	k8s.ForceDisableLocalTerminal = cfg.DisableLocalTerminal
 	k8s.ListPageSize = cfg.ListPageSize
+	k8s.ForceNamespaceScope = cfg.NamespaceScope
 	server.DefaultPodShellCommand = cfg.PodShellDefault
 	versionpkg.SetCurrent(cfg.Version)
 }
@@ -80,6 +83,10 @@ func InitializeK8s(cfg AppConfig) error {
 	if cfg.Namespace != "" {
 		k8s.SetFallbackNamespace(cfg.Namespace)
 	}
+	configureNamespaceScopePreferenceResolver(cfg)
+	if cfg.NamespaceScope && k8s.GetNamespaceScopeTarget() == "" {
+		return fmt.Errorf("--namespace-scope requires --namespace or a namespace on the current kubeconfig context")
+	}
 
 	if len(cfg.KubeconfigDirs) > 0 {
 		log.Printf("Using kubeconfigs from directories: %v", cfg.KubeconfigDirs)
@@ -96,6 +103,21 @@ func InitializeK8s(cfg AppConfig) error {
 	})
 
 	return nil
+}
+
+func configureNamespaceScopePreferenceResolver(cfg AppConfig) {
+	k8s.SetNamespaceScopePreferenceResolver(nil)
+	if !cfg.NamespaceScope || cfg.Namespace != "" || cfg.AuthConfig.Enabled() {
+		return
+	}
+	k8s.SetNamespaceScopePreferenceResolver(func(ctxName string) (string, bool) {
+		activeNamespaces := settings.Load().ActiveNamespaces
+		if len(activeNamespaces[ctxName]) == 1 && activeNamespaces[ctxName][0] != "" {
+			return activeNamespaces[ctxName][0], true
+		}
+		return "", false
+	})
+	k8s.RestoreNamespaceScopePreference(k8s.GetContextName())
 }
 
 // BuildTimelineStoreConfig creates the timeline store configuration from app config.

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -1,0 +1,82 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/skyhook-io/radar/internal/auth"
+	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/internal/settings"
+)
+
+func TestConfigureNamespaceScopePreferenceResolverUsesSingleSavedLocalPick(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	k8s.ResetTestState()
+	t.Cleanup(k8s.ResetTestState)
+	k8s.SetTestContextName("ctx-a")
+
+	if _, err := settings.Update(func(st *settings.Settings) {
+		st.ActiveNamespaces = map[string][]string{"ctx-a": {"prod"}}
+	}); err != nil {
+		t.Fatalf("settings.Update: %v", err)
+	}
+
+	configureNamespaceScopePreferenceResolver(AppConfig{NamespaceScope: true})
+
+	if got := k8s.GetNamespaceScopeTarget(); got != "prod" {
+		t.Fatalf("GetNamespaceScopeTarget() = %q, want prod", got)
+	}
+
+	k8s.ClearNamespaceScopeOverride()
+	k8s.RestoreNamespaceScopePreference("ctx-a")
+	if got := k8s.GetNamespaceScopeTarget(); got != "prod" {
+		t.Fatalf("GetNamespaceScopeTarget() after restore = %q, want prod", got)
+	}
+}
+
+func TestConfigureNamespaceScopePreferenceResolverExplicitNamespaceWins(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	k8s.ResetTestState()
+	t.Cleanup(k8s.ResetTestState)
+	k8s.SetTestContextName("ctx-a")
+	k8s.SetFallbackNamespace("cli-ns")
+
+	if _, err := settings.Update(func(st *settings.Settings) {
+		st.ActiveNamespaces = map[string][]string{"ctx-a": {"saved-ns"}}
+	}); err != nil {
+		t.Fatalf("settings.Update: %v", err)
+	}
+
+	configureNamespaceScopePreferenceResolver(AppConfig{NamespaceScope: true, Namespace: "cli-ns"})
+
+	if got := k8s.GetNamespaceScopeTarget(); got != "cli-ns" {
+		t.Fatalf("GetNamespaceScopeTarget() = %q, want cli-ns", got)
+	}
+
+	k8s.RestoreNamespaceScopePreference("ctx-a")
+	if got := k8s.GetNamespaceScopeTarget(); got != "cli-ns" {
+		t.Fatalf("GetNamespaceScopeTarget() after restore = %q, want cli-ns", got)
+	}
+}
+
+func TestConfigureNamespaceScopePreferenceResolverAuthDoesNotUseLocalSettings(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	k8s.ResetTestState()
+	t.Cleanup(k8s.ResetTestState)
+	k8s.SetTestContextName("ctx-a")
+
+	if _, err := settings.Update(func(st *settings.Settings) {
+		st.ActiveNamespaces = map[string][]string{"ctx-a": {"saved-ns"}}
+	}); err != nil {
+		t.Fatalf("settings.Update: %v", err)
+	}
+
+	configureNamespaceScopePreferenceResolver(AppConfig{
+		NamespaceScope: true,
+		AuthConfig:     auth.Config{Mode: "proxy"},
+	})
+
+	k8s.RestoreNamespaceScopePreference("ctx-a")
+	if got := k8s.GetNamespaceScopeTarget(); got != "" {
+		t.Fatalf("GetNamespaceScopeTarget() = %q, want empty", got)
+	}
+}

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -8,6 +8,31 @@ import (
 	"github.com/skyhook-io/radar/internal/settings"
 )
 
+func TestValidateNamespaceScopeTarget(t *testing.T) {
+	cases := []struct {
+		name    string
+		target  string
+		wantErr bool
+	}{
+		{"single valid namespace", "team-prod", false},
+		{"empty target", "", true},
+		{"comma-separated (multiple)", "team-a,team-b", true},
+		{"whitespace", "team a", true},
+		{"uppercase invalid", "TeamProd", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateNamespaceScopeTarget(tc.target)
+			if tc.wantErr && err == nil {
+				t.Fatalf("validateNamespaceScopeTarget(%q) = nil, want error", tc.target)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("validateNamespaceScopeTarget(%q) = %v, want nil", tc.target, err)
+			}
+		})
+	}
+}
+
 func TestConfigureNamespaceScopePreferenceResolverUsesSingleSavedLocalPick(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	k8s.ResetTestState()
@@ -55,6 +80,40 @@ func TestConfigureNamespaceScopePreferenceResolverExplicitNamespaceWins(t *testi
 	k8s.RestoreNamespaceScopePreference("ctx-a")
 	if got := k8s.GetNamespaceScopeTarget(); got != "cli-ns" {
 		t.Fatalf("GetNamespaceScopeTarget() after restore = %q, want cli-ns", got)
+	}
+}
+
+func TestConfigureNamespaceScopePreferenceResolverRescopeSurvivesReconnect(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	k8s.ResetTestState()
+	t.Cleanup(k8s.ResetTestState)
+	k8s.SetTestContextName("ctx-a")
+	k8s.SetFallbackNamespace("foo")
+
+	// --namespace=foo seeds the starting scope, overriding any stale saved pick.
+	if _, err := settings.Update(func(st *settings.Settings) {
+		st.ActiveNamespaces = map[string][]string{"ctx-a": {"stale"}}
+	}); err != nil {
+		t.Fatalf("settings.Update: %v", err)
+	}
+	configureNamespaceScopePreferenceResolver(AppConfig{NamespaceScope: true, Namespace: "foo"})
+	if got := k8s.GetNamespaceScopeTarget(); got != "foo" {
+		t.Fatalf("startup target = %q, want foo (seeded over stale pick)", got)
+	}
+
+	// The user rescopes to bar in the UI, which persists the pick.
+	if _, err := settings.Update(func(st *settings.Settings) {
+		st.ActiveNamespaces["ctx-a"] = []string{"bar"}
+	}); err != nil {
+		t.Fatalf("settings.Update: %v", err)
+	}
+
+	// A reconnect / context switch clears the override then restores from the pick:
+	// the rescope to bar must survive, not snap back to the startup --namespace.
+	k8s.ClearNamespaceScopeOverride()
+	k8s.RestoreNamespaceScopePreference("ctx-a")
+	if got := k8s.GetNamespaceScopeTarget(); got != "bar" {
+		t.Fatalf("target after rescope+reconnect = %q, want bar", got)
 	}
 }
 

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -34,6 +34,10 @@ var DebugEvents bool
 // WatchList streaming isn't available; 0 keeps the standard behavior.
 var ListPageSize int64
 
+// ForceNamespaceScope pins all namespaced informer caches to one namespace.
+// Cluster-scoped resources still use cluster-wide informers.
+var ForceNamespaceScope bool
+
 // TimingLogs enables [startup-timing] log lines when true (set via --dev flag).
 // These are useful for profiling startup but too noisy for production.
 var TimingLogs bool

--- a/internal/k8s/capabilities.go
+++ b/internal/k8s/capabilities.go
@@ -900,9 +900,17 @@ func CheckResourcePermissions(ctx context.Context) *PermissionCheckResult {
 		return &PermissionCheckResult{Perms: &ResourcePermissions{}, Scopes: map[string]k8score.ResourceScope{}}
 	}
 
+	forceNamespace := ForceNamespaceScope
 	scopeNamespaces := buildScopeCandidates(ctx)
+	if forceNamespace {
+		if target := GetNamespaceScopeTarget(); target != "" {
+			scopeNamespaces = mergeForcedScopeCandidate(target, scopeNamespaces)
+		} else {
+			log.Printf("Warning: --namespace-scope enabled but no namespace target is configured")
+		}
+	}
 
-	result, hadErrors := probeResourceAccess(ctx, GetDynamicClient(), scopeNamespaces, false)
+	result, hadErrors := probeResourceAccess(ctx, GetDynamicClient(), scopeNamespaces, forceNamespace)
 
 	resourcePermsMu.Lock()
 	cachedPermResult = result
@@ -951,6 +959,20 @@ func buildScopeCandidates(ctx context.Context) []string {
 		// the kubeconfig context) so it sits ahead of the alphabetical
 		// accessible list and survives truncation.
 		log.Printf("RBAC: candidate namespaces truncated (cap=%d, %d dropped); kinds reachable only in dropped namespaces will be marked denied", MaxScopeCandidates, dropped)
+	}
+	return out
+}
+
+func mergeForcedScopeCandidate(target string, candidates []string) []string {
+	if target == "" {
+		return candidates
+	}
+	out := []string{target}
+	for _, ns := range candidates {
+		if ns == "" || ns == target {
+			continue
+		}
+		out = append(out, ns)
 	}
 	return out
 }
@@ -1036,9 +1058,8 @@ func pickPrimaryNs(scopeNamespaces []string, scopes map[string]k8score.ResourceS
 //     internal/server/namespace_scope.go), so the cache preferentially boots
 //     cluster-wide.
 //   - true: probe namespaced kinds ONLY in the first scopeNamespaces entry.
-//     Reserved for tests / a hypothetical future per-cache pin; not reachable
-//     from CheckResourcePermissions today. Cluster-only kinds (nodes,
-//     namespaces, PV, storageclasses, ingressclasses) are still probed
+//     Used by --namespace-scope to pin the informer cache. Cluster-only kinds
+//     (nodes, namespaces, PV, storageclasses, ingressclasses) are still probed
 //     cluster-wide since they have no namespace dimension to pin to.
 func probeResourceAccess(ctx context.Context, dyn dynamic.Interface, scopeNamespaces []string, forceNamespace bool) (*PermissionCheckResult, bool) {
 	perms := &ResourcePermissions{}

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -59,8 +59,13 @@ var (
 	clusterName            string
 	contextNamespace       string // Default namespace from kubeconfig context
 	fallbackNamespace      string // Explicit namespace from --namespace flag
-	namespaceScopeOverride string // Runtime namespace selected by local --namespace-scope rescope
-	namespaceScopeResolver func(contextName string) (string, bool)
+	// fallbackNamespaceContext is the context that was active when --namespace was
+	// set at startup. --namespace is an *initial* value, so it only pins the cache
+	// scope for that context — after switching clusters, the scope target comes
+	// from the new context's namespace (or a saved pick), not the stale startup value.
+	fallbackNamespaceContext string
+	namespaceScopeOverride   string // Runtime namespace selected by local --namespace-scope rescope
+	namespaceScopeResolver   func(contextName string) (string, bool)
 	contextUsesExec        bool // True when the current context uses an exec credential plugin
 	// execPluginCommands is the set of unique exec-auth plugin command basenames
 	// referenced by any context in the merged kubeconfig. Populated from
@@ -671,6 +676,9 @@ func SetFallbackNamespace(ns string) {
 	clientMu.Lock()
 	defer clientMu.Unlock()
 	fallbackNamespace = ns
+	// Record the context this --namespace applies to, so it only pins the cache
+	// scope while we're on that context (see GetNamespaceScopeTarget).
+	fallbackNamespaceContext = contextName
 }
 
 // SetNamespaceScopeOverride sets the runtime namespace used by local
@@ -709,17 +717,54 @@ func RestoreNamespaceScopePreference(contextName string) {
 
 // GetNamespaceScopeTarget returns the namespace used when informer caches are
 // explicitly namespace-scoped. A local runtime rescope wins first, then the
-// explicit CLI namespace, then the kubeconfig context namespace.
+// explicit CLI namespace (only while on the context it was set for), then the
+// kubeconfig context namespace.
 func GetNamespaceScopeTarget() string {
 	clientMu.RLock()
 	defer clientMu.RUnlock()
 	if namespaceScopeOverride != "" {
 		return namespaceScopeOverride
 	}
-	if fallbackNamespace != "" {
+	// --namespace is an *initial* filter, so it only pins the scope while we're on
+	// the context it was set for. After a cross-cluster switch the new context's own
+	// namespace takes over — the stale startup value must not follow across clusters.
+	if fallbackNamespace != "" && contextName == fallbackNamespaceContext {
 		return fallbackNamespace
 	}
 	return contextNamespace
+}
+
+// ProspectiveNamespaceScopeTarget resolves what GetNamespaceScopeTarget would
+// return after switching to newContext, without mutating any client state. The
+// context-switch path uses it to reject a --namespace-scope switch that would
+// land on a context with no usable scope target *before* tearing down the
+// current caches. Keep its precedence in sync with GetNamespaceScopeTarget:
+// saved pick → startup --namespace (only for its context) → context namespace.
+func ProspectiveNamespaceScopeTarget(newContext string) string {
+	clientMu.RLock()
+	resolver := namespaceScopeResolver
+	startupFallback := fallbackNamespace
+	startupContext := fallbackNamespaceContext
+	clientMu.RUnlock()
+
+	if resolver != nil {
+		if ns, ok := resolver(newContext); ok && ns != "" {
+			return ns
+		}
+	}
+	if startupFallback != "" && newContext == startupContext {
+		return startupFallback
+	}
+	// GetAvailableContexts reads the kubeconfig off disk and takes clientMu, so
+	// it must run after the snapshot above is released.
+	if contexts, err := GetAvailableContexts(); err == nil {
+		for _, c := range contexts {
+			if c.Name == newContext {
+				return c.Namespace
+			}
+		}
+	}
+	return ""
 }
 
 // GetEffectiveNamespace returns the namespace to use for RBAC fallback checks.

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -54,12 +54,14 @@ var (
 	// destroyed clusters / removed contexts linger in the dropdown
 	// (they only error out when the user tries to switch to them).
 	// Same lifecycle / lock as perFileConfigs.
-	perFileMtimes     map[string]time.Time
-	contextName       string
-	clusterName       string
-	contextNamespace  string // Default namespace from kubeconfig context
-	fallbackNamespace string // Explicit namespace from --namespace flag
-	contextUsesExec   bool   // True when the current context uses an exec credential plugin
+	perFileMtimes          map[string]time.Time
+	contextName            string
+	clusterName            string
+	contextNamespace       string // Default namespace from kubeconfig context
+	fallbackNamespace      string // Explicit namespace from --namespace flag
+	namespaceScopeOverride string // Runtime namespace selected by local --namespace-scope rescope
+	namespaceScopeResolver func(contextName string) (string, bool)
+	contextUsesExec        bool // True when the current context uses an exec credential plugin
 	// execPluginCommands is the set of unique exec-auth plugin command basenames
 	// referenced by any context in the merged kubeconfig. Populated from
 	// rawConfig.AuthInfos at load time and refreshed on SwitchContext. Stored
@@ -669,6 +671,55 @@ func SetFallbackNamespace(ns string) {
 	clientMu.Lock()
 	defer clientMu.Unlock()
 	fallbackNamespace = ns
+}
+
+// SetNamespaceScopeOverride sets the runtime namespace used by local
+// --namespace-scope rescope. It is separate from fallbackNamespace so a real
+// kubeconfig context switch can drop the runtime pick without losing the
+// explicit --namespace startup flag.
+func SetNamespaceScopeOverride(ns string) {
+	clientMu.Lock()
+	defer clientMu.Unlock()
+	namespaceScopeOverride = ns
+}
+
+func ClearNamespaceScopeOverride() {
+	clientMu.Lock()
+	defer clientMu.Unlock()
+	namespaceScopeOverride = ""
+}
+
+func SetNamespaceScopePreferenceResolver(resolver func(contextName string) (string, bool)) {
+	clientMu.Lock()
+	defer clientMu.Unlock()
+	namespaceScopeResolver = resolver
+}
+
+func RestoreNamespaceScopePreference(contextName string) {
+	clientMu.RLock()
+	resolver := namespaceScopeResolver
+	clientMu.RUnlock()
+	if resolver == nil {
+		return
+	}
+	if namespace, ok := resolver(contextName); ok && namespace != "" {
+		SetNamespaceScopeOverride(namespace)
+	}
+}
+
+// GetNamespaceScopeTarget returns the namespace used when informer caches are
+// explicitly namespace-scoped. A local runtime rescope wins first, then the
+// explicit CLI namespace, then the kubeconfig context namespace.
+func GetNamespaceScopeTarget() string {
+	clientMu.RLock()
+	defer clientMu.RUnlock()
+	if namespaceScopeOverride != "" {
+		return namespaceScopeOverride
+	}
+	if fallbackNamespace != "" {
+		return fallbackNamespace
+	}
+	return contextNamespace
 }
 
 // GetEffectiveNamespace returns the namespace to use for RBAC fallback checks.

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -169,6 +169,56 @@ func TestCollectExecPluginCommands(t *testing.T) {
 	}
 }
 
+func TestNamespaceScopeOverrideClearsBackToStartupFallback(t *testing.T) {
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+
+	clientMu.Lock()
+	prevContextNamespace := contextNamespace
+	contextNamespace = "ctx-ns"
+	clientMu.Unlock()
+	t.Cleanup(func() {
+		clientMu.Lock()
+		contextNamespace = prevContextNamespace
+		clientMu.Unlock()
+	})
+
+	SetFallbackNamespace("cli-ns")
+	SetNamespaceScopeOverride("runtime-ns")
+	if got := GetNamespaceScopeTarget(); got != "runtime-ns" {
+		t.Fatalf("GetNamespaceScopeTarget() = %q, want runtime-ns", got)
+	}
+
+	ClearNamespaceScopeOverride()
+	if got := GetNamespaceScopeTarget(); got != "cli-ns" {
+		t.Fatalf("GetNamespaceScopeTarget() after clearing override = %q, want cli-ns", got)
+	}
+
+	SetFallbackNamespace("")
+	if got := GetNamespaceScopeTarget(); got != "ctx-ns" {
+		t.Fatalf("GetNamespaceScopeTarget() after clearing fallback = %q, want ctx-ns", got)
+	}
+}
+
+func TestRequireNamespaceScopeTarget(t *testing.T) {
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+
+	if err := requireNamespaceScopeTarget("ctx-a"); err != nil {
+		t.Fatalf("requireNamespaceScopeTarget without ForceNamespaceScope = %v, want nil", err)
+	}
+
+	ForceNamespaceScope = true
+	if err := requireNamespaceScopeTarget("ctx-a"); err == nil {
+		t.Fatal("requireNamespaceScopeTarget with empty target = nil, want error")
+	}
+
+	SetNamespaceScopeOverride("saved-ns")
+	if err := requireNamespaceScopeTarget("ctx-a"); err != nil {
+		t.Fatalf("requireNamespaceScopeTarget with saved target = %v, want nil", err)
+	}
+}
+
 func TestScrubPathError(t *testing.T) {
 	// Simulate the shape os.ReadDir returns: a *PathError with the path
 	// and an underlying syscall error. We want the path stripped and only

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -200,6 +200,116 @@ func TestNamespaceScopeOverrideClearsBackToStartupFallback(t *testing.T) {
 	}
 }
 
+// The startup --namespace is an *initial* filter, so it must only pin the cache
+// scope on the context it was set for. After a cross-cluster switch the new
+// context's own namespace takes over — the stale startup value must not follow.
+func TestStartupFallbackNamespaceDoesNotFollowContextSwitch(t *testing.T) {
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+
+	setContextState := func(name, ns string) {
+		clientMu.Lock()
+		contextName = name
+		contextNamespace = ns
+		clientMu.Unlock()
+	}
+	t.Cleanup(func() { setContextState("", "") })
+
+	// Boot: --namespace=cli-ns on the startup context, which has no context ns.
+	setContextState("startup-ctx", "")
+	SetFallbackNamespace("cli-ns")
+	if got := GetNamespaceScopeTarget(); got != "cli-ns" {
+		t.Fatalf("scope target on startup context = %q, want cli-ns", got)
+	}
+
+	// Switch to a different cluster whose context carries its own namespace.
+	setContextState("other-ctx", "other-ns")
+	if got := GetNamespaceScopeTarget(); got != "other-ns" {
+		t.Fatalf("scope target after switch = %q, want other-ns (not stale cli-ns)", got)
+	}
+
+	// Switch to a cluster with no context namespace and no saved pick: the stale
+	// startup value must not leak in — the target is empty so the switch can
+	// surface the "pick a namespace" requirement.
+	setContextState("bare-ctx", "")
+	if got := GetNamespaceScopeTarget(); got != "" {
+		t.Fatalf("scope target on bare context = %q, want empty", got)
+	}
+
+	// Switching back to the startup context re-activates --namespace.
+	setContextState("startup-ctx", "")
+	if got := GetNamespaceScopeTarget(); got != "cli-ns" {
+		t.Fatalf("scope target back on startup context = %q, want cli-ns", got)
+	}
+}
+
+func TestProspectiveNamespaceScopeTarget(t *testing.T) {
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+
+	clientMu.Lock()
+	contextName = "startup-ctx"
+	clientMu.Unlock()
+	t.Cleanup(func() {
+		clientMu.Lock()
+		contextName = ""
+		clientMu.Unlock()
+	})
+
+	// A saved pick for the target context wins.
+	SetNamespaceScopePreferenceResolver(func(ctx string) (string, bool) {
+		if ctx == "picked-ctx" {
+			return "saved-ns", true
+		}
+		return "", false
+	})
+	if got := ProspectiveNamespaceScopeTarget("picked-ctx"); got != "saved-ns" {
+		t.Fatalf("prospective target with saved pick = %q, want saved-ns", got)
+	}
+
+	// The startup --namespace only applies to its own context, never to others.
+	SetFallbackNamespace("cli-ns") // captures contextName == "startup-ctx"
+	if got := ProspectiveNamespaceScopeTarget("startup-ctx"); got != "cli-ns" {
+		t.Fatalf("prospective target on startup context = %q, want cli-ns", got)
+	}
+	// A different context with no pick and no kubeconfig on disk resolves empty —
+	// the switch guard treats that as "no usable scope target".
+	if got := ProspectiveNamespaceScopeTarget("other-ctx"); got != "" {
+		t.Fatalf("prospective target on foreign context = %q, want empty", got)
+	}
+}
+
+// A --namespace-scope switch to a context with no usable scope target must fail
+// at the pre-flight guard *before* tearing down or stopping sessions, so the
+// user keeps their current caches and port-forwards / exec terminals.
+func TestContextSwitchPreflightLeavesSessionsAlone(t *testing.T) {
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+
+	stopped := false
+	SetSessionStopper(func() { stopped = true })
+	t.Cleanup(func() { SetSessionStopper(nil) })
+
+	ForceNamespaceScope = true
+	t.Cleanup(func() { ForceNamespaceScope = false })
+
+	// No saved pick, no startup --namespace, and the context isn't in any
+	// kubeconfig → prospective scope target is empty → the switch must bail before
+	// CancelOngoingOperations / ResetAllSubsystems / stopActiveSessions.
+	err := PerformContextSwitch("nonexistent-ctx")
+	if err == nil {
+		t.Fatal("expected pre-flight failure for a context with no scope target")
+	}
+	// Must be a typed preflight error so the handler keeps the current connection
+	// instead of marking the app disconnected (nothing was torn down).
+	if !errors.Is(err, ErrContextSwitchPreflight) {
+		t.Fatalf("expected ErrContextSwitchPreflight, got %v", err)
+	}
+	if stopped {
+		t.Fatal("sessions were stopped before a switch that failed pre-flight")
+	}
+}
+
 func TestRequireNamespaceScopeTarget(t *testing.T) {
 	ResetTestState()
 	t.Cleanup(ResetTestState)

--- a/internal/k8s/context_manager.go
+++ b/internal/k8s/context_manager.go
@@ -24,6 +24,10 @@ const ConnectionTestTimeout = 5 * time.Second
 // ContextSwitchCallback is called when the context is switched
 type ContextSwitchCallback func(newContext string)
 
+// NamespaceRescopeCallback is called when the active cache namespace changes
+// without switching kubeconfig contexts.
+type NamespaceRescopeCallback func(namespace string)
+
 // ContextSwitchProgressCallback is called with progress updates during context switch
 type ContextSwitchProgressCallback func(message string)
 
@@ -55,6 +59,7 @@ type PrometheusReinitFunc func() error
 
 var (
 	contextSwitchCallbacks         []ContextSwitchCallback
+	namespaceRescopeCallbacks      []NamespaceRescopeCallback
 	contextSwitchProgressCallbacks []ContextSwitchProgressCallback
 	contextSwitchMu                sync.RWMutex
 	helmResetFunc                  HelmResetFunc
@@ -112,6 +117,14 @@ func OnContextSwitch(callback ContextSwitchCallback) {
 	contextSwitchMu.Lock()
 	defer contextSwitchMu.Unlock()
 	contextSwitchCallbacks = append(contextSwitchCallbacks, callback)
+}
+
+// OnNamespaceRescope registers a callback for local --namespace-scope cache
+// rescope completion.
+func OnNamespaceRescope(callback NamespaceRescopeCallback) {
+	contextSwitchMu.Lock()
+	defer contextSwitchMu.Unlock()
+	namespaceRescopeCallbacks = append(namespaceRescopeCallbacks, callback)
 }
 
 // OnContextSwitchProgress registers a callback for progress updates during context switch
@@ -245,6 +258,11 @@ func PerformContextSwitch(newContext string) error {
 		return fmt.Errorf("failed to switch context: %w", err)
 	}
 	logTiming("   [ops] SwitchContext: %v", time.Since(t))
+	ClearNamespaceScopeOverride()
+	RestoreNamespaceScopePreference(GetContextName())
+	if err := requireNamespaceScopeTarget(newContext); err != nil {
+		return err
+	}
 
 	// Invalidate caches - permissions and cluster info may differ between clusters
 	InvalidateCapabilitiesCache()
@@ -296,4 +314,97 @@ func PerformContextSwitch(newContext string) error {
 	}
 
 	return nil
+}
+
+func requireNamespaceScopeTarget(contextName string) error {
+	if !ForceNamespaceScope || GetNamespaceScopeTarget() != "" {
+		return nil
+	}
+	return fmt.Errorf("--namespace-scope requires --namespace, a namespace on context %q, or a saved namespace pick", contextName)
+}
+
+// PerformNamespaceRescope rebuilds all cache-backed subsystems for a new
+// namespace while keeping the current kubeconfig context. It is intended for
+// local --namespace-scope sessions only; multi-user deployments must not let
+// one user's namespace pick reshape the process-wide cache for everyone.
+func PerformNamespaceRescope(namespace string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	previousNamespace := GetNamespaceScopeTarget()
+	if namespace == previousNamespace {
+		return nil
+	}
+
+	rescopeStart := time.Now()
+	safeNamespace := SanitizeForLog(namespace)
+	safePreviousNamespace := SanitizeForLog(previousNamespace)
+	log.Printf("[ops] Namespace rescope START → %q", safeNamespace)
+
+	CancelOngoingOperations()
+	reportProgress("Testing cluster connectivity...")
+	t := time.Now()
+	connCtx, connCancel := NewOperationContext(ConnectionTestTimeout)
+	defer connCancel()
+	if err := TestClusterConnection(connCtx); err != nil {
+		elapsed := time.Since(rescopeStart).Truncate(time.Millisecond)
+		log.Printf("[ops] Namespace rescope FAILED at connectivity test: %v (%v since rescope start)", err, elapsed)
+		errorlog.Record("namespace-rescope", "error",
+			"stage=TestClusterConnection namespace=%q elapsed=%v: %v", safeNamespace, elapsed, err)
+		return fmt.Errorf("cluster connection failed: %w", err)
+	}
+	log.Printf("[ops] Cluster connectivity verified (%v)", time.Since(t))
+
+	if err := reinitializeNamespaceScope(namespace, "Stopping caches..."); err != nil {
+		elapsed := time.Since(rescopeStart).Truncate(time.Millisecond)
+		log.Printf("[ops] Namespace rescope FAILED at subsystem init: %v (%v since rescope start)", err, elapsed)
+		errorlog.Record("namespace-rescope", "error",
+			"stage=InitAllSubsystems namespace=%q elapsed=%v: %v", safeNamespace, elapsed, err)
+		if rollbackErr := reinitializeNamespaceScope(previousNamespace, "Restoring previous namespace..."); rollbackErr != nil {
+			log.Printf("[ops] Namespace rescope rollback to %q FAILED: %v", safePreviousNamespace, rollbackErr)
+			errorlog.Record("namespace-rescope", "error",
+				"stage=Rollback namespace=%q elapsed=%v: %v", safePreviousNamespace, time.Since(rescopeStart).Truncate(time.Millisecond), rollbackErr)
+			return fmt.Errorf("subsystem init failed: %w; rollback to previous namespace %q failed: %v", err, previousNamespace, rollbackErr)
+		}
+		notifyNamespaceRescopeCallbacks(previousNamespace)
+		return fmt.Errorf("subsystem init failed: %w; restored previous namespace %q", err, previousNamespace)
+	}
+
+	reportProgress("Building topology...")
+	log.Printf("[ops] Namespace rescope to %q COMPLETE (%v total)", safeNamespace, time.Since(rescopeStart))
+	notifyNamespaceRescopeCallbacks(namespace)
+
+	return nil
+}
+
+func reinitializeNamespaceScope(namespace, resetMessage string) error {
+	reportProgress(resetMessage)
+	t := time.Now()
+	ResetAllSubsystems()
+	logTiming("   [ops] ResetAllSubsystems: %v", time.Since(t))
+
+	SetNamespaceScopeOverride(namespace)
+	InvalidateCapabilitiesCache()
+	InvalidateResourcePermissionsCache()
+	InvalidateServerVersionCache()
+
+	t = time.Now()
+	initCtx, initCancel := NewOperationContext(ContextSwitchTimeout)
+	defer initCancel()
+	if err := InitAllSubsystems(initCtx, reportProgress); err != nil {
+		return err
+	}
+	logTiming("   [ops] InitAllSubsystems: %v", time.Since(t))
+	return nil
+}
+
+func notifyNamespaceRescopeCallbacks(namespace string) {
+	contextSwitchMu.RLock()
+	callbacks := make([]NamespaceRescopeCallback, len(namespaceRescopeCallbacks))
+	copy(callbacks, namespaceRescopeCallbacks)
+	contextSwitchMu.RUnlock()
+
+	for _, callback := range callbacks {
+		callback(namespace)
+	}
 }

--- a/internal/k8s/context_manager.go
+++ b/internal/k8s/context_manager.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"sync"
@@ -70,6 +71,19 @@ var (
 	trafficReinitFunc              TrafficReinitFunc
 	prometheusResetFunc            PrometheusResetFunc
 	prometheusReinitFunc           PrometheusReinitFunc
+	// sessionStopFunc terminates active port-forward / exec sessions. Invoked at
+	// the point of no return — immediately before the cache is torn down — so a
+	// pre-teardown failure (connectivity test, scope-target validation) doesn't
+	// kill the user's sessions for an operation that never changed the cache.
+	sessionStopFunc func()
+
+	// contextOpMu serializes the destructive context-changing operations
+	// (PerformContextSwitch, PerformNamespaceRescope). operationGen only decides
+	// which operation gets to roll back / notify; it does NOT stop two operations
+	// from running ResetAllSubsystems + InitAllSubsystems concurrently on the
+	// shared cache singletons. This mutex does — a second request waits for the
+	// first to finish rather than interleaving teardown/init.
+	contextOpMu sync.Mutex
 
 	// operationCtx is canceled at the start of every context switch and retry.
 	// API calls that should not survive a context switch (RBAC checks, capability
@@ -77,6 +91,12 @@ var (
 	operationCtx    context.Context
 	operationCancel context.CancelFunc
 	operationMu     sync.Mutex
+	// operationGen bumps on every CancelOngoingOperations (i.e. at the start of
+	// every context switch / rescope). An operation captures the generation it
+	// owns; if a newer operation has since started, the older one must not apply
+	// destructive side effects (e.g. a namespace-rescope rollback against the
+	// context a newer switch already moved to).
+	operationGen uint64
 )
 
 func init() {
@@ -92,6 +112,15 @@ func CancelOngoingOperations() {
 	log.Printf("[ops] Canceling ongoing operations (previous API calls will be interrupted)")
 	operationCancel()
 	operationCtx, operationCancel = context.WithCancel(context.Background())
+	operationGen++
+}
+
+// currentOperationGen returns the generation of the most recently started
+// operation. Compare against a captured generation to detect supersession.
+func currentOperationGen() uint64 {
+	operationMu.Lock()
+	defer operationMu.Unlock()
+	return operationGen
 }
 
 // NewOperationContext returns a context derived from the current operation
@@ -110,6 +139,25 @@ func OperationContext() context.Context {
 	operationMu.Lock()
 	defer operationMu.Unlock()
 	return operationCtx
+}
+
+// SetSessionStopper registers the callback that terminates active port-forward /
+// exec sessions. The destructive cache operations call it once they commit to
+// tearing the cache down. Registered by the server (which owns sessions) to
+// avoid a server→k8s import cycle.
+func SetSessionStopper(fn func()) {
+	contextSwitchMu.Lock()
+	defer contextSwitchMu.Unlock()
+	sessionStopFunc = fn
+}
+
+func stopActiveSessions() {
+	contextSwitchMu.RLock()
+	fn := sessionStopFunc
+	contextSwitchMu.RUnlock()
+	if fn != nil {
+		fn()
+	}
 }
 
 // OnContextSwitch registers a callback to be called when the context is switched
@@ -231,16 +279,40 @@ func TestClusterConnection(ctx context.Context) error {
 // 3. Tests connectivity to ensure cluster is reachable
 // 4. Reinitializes all subsystems (same sequence as initial boot)
 // 5. Notifies all registered callbacks
+// ErrContextSwitchPreflight is returned by PerformContextSwitch when the switch
+// is rejected BEFORE any teardown (e.g. --namespace-scope with no usable target
+// for the new context). Callers must treat it as "request rejected, still
+// connected to the current cluster" and NOT mark the connection disconnected.
+var ErrContextSwitchPreflight = errors.New("context switch preflight rejected")
+
 func PerformContextSwitch(newContext string) error {
 	switchStart := time.Now()
 	log.Printf("[ops] Context switch START → %q", newContext)
+
+	// Serialize against any other in-flight switch / rescope so their teardown +
+	// init can't interleave on the shared cache. A queued request waits here.
+	contextOpMu.Lock()
+	defer contextOpMu.Unlock()
+
+	// Under --namespace-scope, validate the new context has a usable scope target
+	// BEFORE tearing anything down. Otherwise a switch to a context with no
+	// namespace (and no saved pick) would reset and repoint the client, then fail
+	// at requireNamespaceScopeTarget below — leaving us on the new context with no
+	// informer caches until a full reconnect succeeds. This is a preflight failure
+	// (nothing torn down yet) so the caller must keep the current connection intact.
+	if ForceNamespaceScope && ProspectiveNamespaceScopeTarget(newContext) == "" {
+		return fmt.Errorf("%w: --namespace-scope requires --namespace, a namespace on context %q, or a saved namespace pick", ErrContextSwitchPreflight, newContext)
+	}
 
 	// Cancel any in-flight API calls from the previous context (RBAC checks,
 	// capability probes, etc.) so they don't serialize through the old exec
 	// plugin and block the new context's connectivity test.
 	CancelOngoingOperations()
 
-	// Step 1: Tear down all subsystems
+	// Step 1: Tear down all subsystems. Stop sessions first — past this point the
+	// previous cluster's caches are gone, so lingering port-forwards / exec
+	// terminals would be reading state we can no longer serve.
+	stopActiveSessions()
 	reportProgress("Stopping caches...")
 	t := time.Now()
 	ResetAllSubsystems()
@@ -331,6 +403,11 @@ func PerformNamespaceRescope(namespace string) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
+	// Serialize against any other in-flight switch / rescope (see contextOpMu).
+	// previousNamespace is read under the lock so two rescopes can't both decide
+	// the namespace changed and run teardown/init concurrently.
+	contextOpMu.Lock()
+	defer contextOpMu.Unlock()
 	previousNamespace := GetNamespaceScopeTarget()
 	if namespace == previousNamespace {
 		return nil
@@ -342,6 +419,7 @@ func PerformNamespaceRescope(namespace string) error {
 	log.Printf("[ops] Namespace rescope START → %q", safeNamespace)
 
 	CancelOngoingOperations()
+	myGen := currentOperationGen()
 	reportProgress("Testing cluster connectivity...")
 	t := time.Now()
 	connCtx, connCancel := NewOperationContext(ConnectionTestTimeout)
@@ -355,11 +433,24 @@ func PerformNamespaceRescope(namespace string) error {
 	}
 	log.Printf("[ops] Cluster connectivity verified (%v)", time.Since(t))
 
+	// Connectivity passed, so we're committed to rebuilding the cache for the new
+	// namespace. Stop sessions now (not before the connectivity test) so a failed
+	// pre-rescope check doesn't tear down port-forwards / exec for nothing.
+	stopActiveSessions()
 	if err := reinitializeNamespaceScope(namespace, "Stopping caches..."); err != nil {
 		elapsed := time.Since(rescopeStart).Truncate(time.Millisecond)
 		log.Printf("[ops] Namespace rescope FAILED at subsystem init: %v (%v since rescope start)", err, elapsed)
 		errorlog.Record("namespace-rescope", "error",
 			"stage=InitAllSubsystems namespace=%q elapsed=%v: %v", safeNamespace, elapsed, err)
+		// If a newer context switch / rescope started while our init was running,
+		// it canceled our operation context (hence this failure) and now owns the
+		// cache state. Rolling back here would reset the newer operation's
+		// subsystems and pin the cache to OUR previous namespace — clobbering it.
+		// Bail without rolling back; the newer operation is authoritative.
+		if currentOperationGen() != myGen {
+			log.Printf("[ops] Namespace rescope to %q superseded by a newer operation; skipping rollback", safeNamespace)
+			return fmt.Errorf("namespace rescope to %q superseded by a newer operation", namespace)
+		}
 		if rollbackErr := reinitializeNamespaceScope(previousNamespace, "Restoring previous namespace..."); rollbackErr != nil {
 			log.Printf("[ops] Namespace rescope rollback to %q FAILED: %v", safePreviousNamespace, rollbackErr)
 			errorlog.Record("namespace-rescope", "error",
@@ -368,6 +459,13 @@ func PerformNamespaceRescope(namespace string) error {
 		}
 		notifyNamespaceRescopeCallbacks(previousNamespace)
 		return fmt.Errorf("subsystem init failed: %w; restored previous namespace %q", err, previousNamespace)
+	}
+
+	// A newer operation may have started after our init completed; it now owns
+	// the cache, so don't announce our (now-stale) namespace to callbacks.
+	if currentOperationGen() != myGen {
+		log.Printf("[ops] Namespace rescope to %q superseded by a newer operation after init", safeNamespace)
+		return fmt.Errorf("namespace rescope to %q superseded by a newer operation", namespace)
 	}
 
 	reportProgress("Building topology...")

--- a/internal/k8s/dynamic_cache.go
+++ b/internal/k8s/dynamic_cache.go
@@ -47,6 +47,18 @@ func InitDynamicResourceCache(changeCh chan k8score.ResourceChange) error {
 			nsFallback = permResult.Namespace
 		}
 
+		// --namespace-scope pins namespaced CRD informers to the target namespace
+		// (typed informers are pinned via probeResourceAccess). Cluster-scoped CRDs
+		// stay cluster-wide — enforced by the gvrIsNamespaced guard in probeScope.
+		var nsScoped bool
+		var nsTarget string
+		if ForceNamespaceScope {
+			if t := GetNamespaceScopeTarget(); t != "" {
+				nsScoped = true
+				nsTarget = t
+			}
+		}
+
 		discovery := GetResourceDiscovery()
 		var sharedDiscovery *k8score.ResourceDiscovery
 		if discovery != nil {
@@ -58,6 +70,8 @@ func InitDynamicResourceCache(changeCh chan k8score.ResourceChange) error {
 			Discovery:         sharedDiscovery,
 			Changes:           changeCh,
 			NamespaceFallback: nsFallback,
+			NamespaceScoped:   nsScoped,
+			Namespace:         nsTarget,
 			DebugEvents:       DebugEvents,
 			OnReceived: func(kind string) {
 				timeline.IncrementReceived(kind)

--- a/internal/k8s/testing.go
+++ b/internal/k8s/testing.go
@@ -171,6 +171,10 @@ func ResetTestState() {
 	resourcePermsMu.Lock()
 	cachedPermResult = nil
 	resourcePermsMu.Unlock()
+	ForceNamespaceScope = false
+	SetFallbackNamespace("")
+	ClearNamespaceScopeOverride()
+	SetNamespaceScopePreferenceResolver(nil)
 
 	// Reset operation context so stale cancellations don't leak between tests
 	CancelOngoingOperations()

--- a/internal/server/namespace_scope.go
+++ b/internal/server/namespace_scope.go
@@ -220,8 +220,18 @@ func (s *Server) handleGetNamespaceScope(w http.ResponseWriter, r *http.Request)
 			actives = []string{cacheScopeNs}
 		}
 		if s.authConfig.Enabled() {
-			namespaces = actives
-			authoritative = true
+			// Only advertise the pinned namespace as accessible to THIS user if
+			// they can actually list it. The shared cache holds only cacheScopeNs,
+			// but RBAC still gates each user's reads of it — claiming access the
+			// read paths then deny would make the picker lie.
+			if cacheScopeNs != "" && len(intersectPicksWithAllowed([]string{cacheScopeNs}, namespaces)) > 0 {
+				namespaces = []string{cacheScopeNs}
+				authoritative = true
+			} else {
+				actives = []string{}
+				namespaces = []string{}
+				authoritative = false
+			}
 		}
 	}
 
@@ -337,11 +347,45 @@ func (s *Server) handleSetActiveNamespace(w http.ResponseWriter, r *http.Request
 		}
 	}
 
+	// Forced-scope requests must name exactly one namespace. Validate before any
+	// persistence so a malformed (empty / multi) request can't mutate the saved
+	// pick and then 400.
+	if k8s.ForceNamespaceScope && len(cleaned) != 1 {
+		s.writeError(w, http.StatusBadRequest, "--namespace-scope requires exactly one active namespace")
+		return
+	}
+
+	// Under --namespace-scope the persisted pick and the live cache scope must
+	// move as one commit. Serialize the whole section (persist → rescope →
+	// re-sync) so two concurrent requests can't persist one namespace while the
+	// cache ends on another. (PerformNamespaceRescope's own lock only serializes
+	// the rebuild, not this handler's persist.)
 	if k8s.ForceNamespaceScope {
-		if len(cleaned) != 1 {
-			s.writeError(w, http.StatusBadRequest, "--namespace-scope requires exactly one active namespace")
-			return
+		s.scopeMutationMu.Lock()
+		defer s.scopeMutationMu.Unlock()
+	}
+
+	// Persist the no-auth (single-user) pick across restarts before acting on it.
+	// Auth-enabled deploys skip persistence — it'd require user-keyed storage we
+	// don't have. Under --namespace-scope a reconnect restores the cache scope
+	// from this saved value, so a rescope must NOT proceed if we can't save the
+	// pick: the cache would rebuild for the new namespace but snap back to the
+	// stale saved one on the next reconnect, diverging from the live override.
+	// Outside scope mode the pick is just a view filter, so a save failure is
+	// non-fatal — log and continue.
+	if auth.UserFromContext(r.Context()) == nil {
+		if ctxName := k8s.GetContextName(); ctxName != "" {
+			if err := persistNamespacePick(ctxName, cleaned); err != nil {
+				log.Printf("[namespace] failed to persist namespace pick for context %q: %v", ctxName, err)
+				if k8s.ForceNamespaceScope {
+					s.writeError(w, http.StatusServiceUnavailable, "failed to save namespace pick: "+err.Error())
+					return
+				}
+			}
 		}
+	}
+
+	if k8s.ForceNamespaceScope {
 		currentScope := k8s.GetNamespaceScopeTarget()
 		if s.authConfig.Enabled() {
 			if cleaned[0] != currentScope {
@@ -349,7 +393,24 @@ func (s *Server) handleSetActiveNamespace(w http.ResponseWriter, r *http.Request
 				return
 			}
 		} else if cleaned[0] != currentScope {
+			// A rescope tears down and rebuilds the informer caches for a different
+			// namespace. PerformNamespaceRescope stops active sessions itself, but
+			// only once it commits to the teardown (after its connectivity check),
+			// so a failed rescope doesn't kill port-forwards / exec for nothing.
 			if err := k8s.PerformNamespaceRescope(cleaned[0]); err != nil {
+				// We persisted the requested pick above, but the rescope didn't take
+				// (rolled back to the previous namespace, or superseded by a newer op).
+				// Re-sync the saved pick to whatever scope is actually live now, so a
+				// later reconnect doesn't restore the namespace we just rejected.
+				if ctxName := k8s.GetContextName(); ctxName != "" {
+					var livePick []string
+					if live := k8s.GetNamespaceScopeTarget(); live != "" {
+						livePick = []string{live}
+					}
+					if perr := persistNamespacePick(ctxName, livePick); perr != nil {
+						log.Printf("[namespace] failed to restore saved pick after rescope failure for context %q: %v", ctxName, perr)
+					}
+				}
 				safeNamespace := strings.ReplaceAll(strings.ReplaceAll(cleaned[0], "\n", ""), "\r", "")
 				safeErr := strings.ReplaceAll(strings.ReplaceAll(err.Error(), "\n", ""), "\r", "")
 				log.Printf("[namespace] failed to rescope cache to namespace %q: %s", safeNamespace, safeErr)
@@ -362,28 +423,22 @@ func (s *Server) handleSetActiveNamespace(w http.ResponseWriter, r *http.Request
 
 	s.setActiveNamespaceForUser(r, cleaned)
 
-	// Persist the no-auth (single-user) pick across restarts. Auth-enabled
-	// deploys skip persistence — it'd require user-keyed storage we don't
-	// have. The in-memory pick already took effect, so a persistence failure
-	// is non-fatal — we log and continue.
-	if auth.UserFromContext(r.Context()) == nil {
-		ctxName := k8s.GetContextName()
-		if ctxName != "" {
-			if _, err := settings.Update(func(st *settings.Settings) {
-				if st.ActiveNamespaces == nil {
-					st.ActiveNamespaces = map[string][]string{}
-				}
-				if len(cleaned) == 0 {
-					delete(st.ActiveNamespaces, ctxName)
-				} else {
-					st.ActiveNamespaces[ctxName] = append([]string(nil), cleaned...)
-				}
-			}); err != nil {
-				log.Printf("[namespace] failed to persist namespace pick for context %q: %v", ctxName, err)
-			}
-		}
-	}
-
 	// Return the fresh scope state so the UI can update without a follow-up GET.
 	s.handleGetNamespaceScope(w, r)
+}
+
+// persistNamespacePick saves the single-user namespace pick for ctxName so it
+// survives restarts and is restored on reconnect. An empty pick clears it.
+func persistNamespacePick(ctxName string, cleaned []string) error {
+	_, err := settings.Update(func(st *settings.Settings) {
+		if st.ActiveNamespaces == nil {
+			st.ActiveNamespaces = map[string][]string{}
+		}
+		if len(cleaned) == 0 {
+			delete(st.ActiveNamespaces, ctxName)
+		} else {
+			st.ActiveNamespaces[ctxName] = append([]string(nil), cleaned...)
+		}
+	})
+	return err
 }

--- a/internal/server/namespace_scope.go
+++ b/internal/server/namespace_scope.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/skyhook-io/radar/internal/auth"
 	"github.com/skyhook-io/radar/internal/k8s"
@@ -43,6 +44,9 @@ type NamespaceScopeResponse struct {
 	AccessibleNamespaces []string           `json:"accessibleNamespaces"`
 	Authoritative        bool               `json:"authoritative"`
 	CanClearNamespace    bool               `json:"canClearNamespace"`
+	CacheScoped          bool               `json:"cacheScoped"`
+	CacheScopeNamespace  string             `json:"cacheScopeNamespace,omitempty"`
+	NamespaceRescope     bool               `json:"namespaceRescope"`
 }
 
 // nsPreferenceKey builds the per-user, per-context key for nsPreferences.
@@ -175,6 +179,7 @@ func (s *Server) handleGetNamespaceScope(w http.ResponseWriter, r *http.Request)
 	s.loadSavedNamespacePreference(r)
 	actives := s.getActiveNamespaceForUser(r)
 	kubeNs := k8s.GetContextNamespace()
+	cacheScopeNs := k8s.GetNamespaceScopeTarget()
 
 	// What the SA / kubeconfig identity sees — used as the input set for
 	// per-user filtering below. authoritative=true means "we got a real
@@ -210,6 +215,16 @@ func (s *Server) handleGetNamespaceScope(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
+	if k8s.ForceNamespaceScope {
+		if cacheScopeNs != "" {
+			actives = []string{cacheScopeNs}
+		}
+		if s.authConfig.Enabled() {
+			namespaces = actives
+			authoritative = true
+		}
+	}
+
 	mode := NamespaceScopeClusterWide
 	switch {
 	case len(actives) > 0:
@@ -223,6 +238,9 @@ func (s *Server) handleGetNamespaceScope(w http.ResponseWriter, r *http.Request)
 	// require a kubeconfig or --namespace fallback so the UI has something
 	// to fall back to.
 	canClear := authoritative || k8s.HasNamespaceFallback()
+	if k8s.ForceNamespaceScope {
+		canClear = false
+	}
 
 	// Force non-nil slices so the wire shape matches the TS contract
 	// (`string[]`, never `null`). A nil []string marshals to JSON null,
@@ -241,6 +259,9 @@ func (s *Server) handleGetNamespaceScope(w http.ResponseWriter, r *http.Request)
 		AccessibleNamespaces: namespaces,
 		Authoritative:        authoritative,
 		CanClearNamespace:    canClear,
+		CacheScoped:          k8s.ForceNamespaceScope,
+		CacheScopeNamespace:  cacheScopeNs,
+		NamespaceRescope:     k8s.ForceNamespaceScope && !s.authConfig.Enabled(),
 	})
 }
 
@@ -313,6 +334,29 @@ func (s *Server) handleSetActiveNamespace(w http.ResponseWriter, r *http.Request
 					return
 				}
 			}
+		}
+	}
+
+	if k8s.ForceNamespaceScope {
+		if len(cleaned) != 1 {
+			s.writeError(w, http.StatusBadRequest, "--namespace-scope requires exactly one active namespace")
+			return
+		}
+		currentScope := k8s.GetNamespaceScopeTarget()
+		if s.authConfig.Enabled() {
+			if cleaned[0] != currentScope {
+				s.writeError(w, http.StatusForbidden, "--namespace-scope locks the shared cache to namespace "+currentScope)
+				return
+			}
+		} else if cleaned[0] != currentScope {
+			if err := k8s.PerformNamespaceRescope(cleaned[0]); err != nil {
+				safeNamespace := strings.ReplaceAll(strings.ReplaceAll(cleaned[0], "\n", ""), "\r", "")
+				safeErr := strings.ReplaceAll(strings.ReplaceAll(err.Error(), "\n", ""), "\r", "")
+				log.Printf("[namespace] failed to rescope cache to namespace %q: %s", safeNamespace, safeErr)
+				s.writeError(w, http.StatusServiceUnavailable, "failed to rescope namespace cache: "+err.Error())
+				return
+			}
+			s.finalizePostContextSwitch()
 		}
 	}
 

--- a/internal/server/namespace_scope_test.go
+++ b/internal/server/namespace_scope_test.go
@@ -304,3 +304,32 @@ func restoreHelmNamespaceFallbackState(t *testing.T) {
 	k8s.SetFallbackNamespace("backend-fallback")
 	t.Cleanup(func() { k8s.SetFallbackNamespace("") })
 }
+
+func TestParseNamespacesForUser_ForcedCacheScope(t *testing.T) {
+	s := newTestServer(t)
+	k8s.ForceNamespaceScope = true
+	k8s.SetFallbackNamespace("prod")
+	t.Cleanup(func() {
+		k8s.ForceNamespaceScope = false
+		k8s.SetFallbackNamespace("")
+	})
+
+	cases := []struct {
+		name string
+		url  string
+		want []string
+	}{
+		{name: "no query uses cache scope", url: "/api/resources/pods", want: []string{"prod"}},
+		{name: "query including cache scope narrows to cache scope", url: "/api/resources/pods?namespaces=prod,staging", want: []string{"prod"}},
+		{name: "query outside cache scope returns no access", url: "/api/resources/pods?namespace=staging", want: []string{}},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.url, nil)
+			if got := s.parseNamespacesForUser(req); !slices.Equal(got, tt.want) {
+				t.Fatalf("parseNamespacesForUser(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"reflect"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -816,6 +817,19 @@ func mergeNamespaceCapability(global, namespaced, checkErrored bool) bool {
 func (s *Server) parseNamespacesForUser(r *http.Request) []string {
 	namespaces := parseNamespaces(r.URL.Query())
 	pickFallback := false
+	if k8s.ForceNamespaceScope {
+		target := k8s.GetNamespaceScopeTarget()
+		if target == "" {
+			return []string{}
+		}
+		if namespaces == nil {
+			namespaces = []string{target}
+		} else if slices.Contains(namespaces, target) {
+			namespaces = []string{target}
+		} else {
+			return []string{}
+		}
+	}
 	if namespaces == nil {
 		// No explicit filter — use the user's saved picks if any.
 		s.loadSavedNamespacePreference(r)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -79,6 +80,13 @@ type Server struct {
 	// other users' views).
 	nsPreferences sync.Map
 
+	// scopeMutationMu serializes a forced (--namespace-scope) namespace change so
+	// its persisted pick and the live cache scope move as one commit. Without it,
+	// two concurrent rescope requests could persist one namespace while the cache
+	// ends on another (PerformNamespaceRescope's own lock only serializes the
+	// rebuild, not this handler's persist step).
+	scopeMutationMu sync.Mutex
+
 	// Short-TTL cache for topology builds. The Topology graph is a
 	// deterministic projection of the informer cache; rebuilding it walks
 	// every resource of every kind. A 5s TTL absorbs the typical bursts
@@ -132,6 +140,12 @@ func New(cfg Config) *Server {
 	k8s.OnContextSwitch(func(_ string) {
 		s.finalizePostContextSwitch()
 	})
+
+	// Let the destructive cache operations (context switch, namespace rescope)
+	// terminate active sessions at their point of no return, rather than the
+	// handlers stopping them up front — a switch/rescope that fails before
+	// teardown must leave port-forwards / exec terminals intact.
+	k8s.SetSessionStopper(StopAllSessions)
 
 	// Initialize auth components when auth is enabled
 	if s.authConfig.Enabled() {
@@ -877,6 +891,16 @@ func (s *Server) resolveHelmNamespaces(r *http.Request) ([]string, bool) {
 	// explicit filter" and fall through, rather than short-circuiting to a
 	// zero-namespace (empty) result.
 	if explicit := parseNamespaces(r.URL.Query()); len(explicit) > 0 {
+		// Under --namespace-scope the informer cache holds only the pinned
+		// namespace; keep Helm consistent with the rest of the UI by clamping an
+		// explicit filter to the pinned namespace (empty when it's out of scope)
+		// instead of reading releases the cache doesn't cover.
+		if k8s.ForceNamespaceScope {
+			if target := k8s.GetNamespaceScopeTarget(); target != "" && slices.Contains(explicit, target) {
+				return []string{target}, true
+			}
+			return []string{}, true
+		}
 		return explicit, true
 	}
 
@@ -3236,10 +3260,13 @@ func (s *Server) handleSwitchContext(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Stop all active sessions before switching
-	StopAllSessions()
-
 	if err := k8s.PerformContextSwitch(name); err != nil {
+		// A preflight rejection fails before any teardown — the current cluster is
+		// still connected, so don't poison the global connection status.
+		if errors.Is(err, k8s.ErrContextSwitchPreflight) {
+			s.writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
 		k8s.SetConnectionStatus(k8s.ConnectionStatus{
 			State:     k8s.StateDisconnected,
 			Context:   name,
@@ -3294,11 +3321,13 @@ func (s *Server) handleConnectionRetry(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Stop all active sessions before retrying
-	StopAllSessions()
-
-	// Reconnect to the same context (reuses PerformContextSwitch which handles full reinit)
+	// Reconnect to the same context (reuses PerformContextSwitch which handles full
+	// reinit, including stopping active sessions at teardown)
 	if err := k8s.PerformContextSwitch(ctx); err != nil {
+		if errors.Is(err, k8s.ErrContextSwitchPreflight) {
+			s.writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
 		// Set disconnected state with error
 		k8s.SetConnectionStatus(k8s.ConnectionStatus{
 			State:     k8s.StateDisconnected,
@@ -3450,9 +3479,11 @@ func (s *Server) handleCAPIClusterConnect(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	StopAllSessions()
-
 	if err := k8s.PerformContextSwitch(qualifiedName); err != nil {
+		if errors.Is(err, k8s.ErrContextSwitchPreflight) {
+			s.writeError(w, http.StatusBadRequest, "failed to switch context: "+err.Error())
+			return
+		}
 		k8s.SetConnectionStatus(k8s.ConnectionStatus{
 			State:     k8s.StateDisconnected,
 			Context:   qualifiedName,

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -290,10 +290,7 @@ func (b *SSEBroadcaster) registerContextSwitchCallback() {
 		})
 	})
 
-	// Register for context switch completion
-	k8s.OnContextSwitch(func(newContext string) {
-		log.Printf("SSE broadcaster: context switched to %q, clearing cached topology", newContext)
-
+	resetCacheView := func() {
 		// Clear cached topology and dirty flag for the old context
 		b.cachedTopologyMu.Lock()
 		b.cachedTopology = nil
@@ -308,6 +305,12 @@ func (b *SSEBroadcaster) registerContextSwitchCallback() {
 
 		// Restart the resource change watcher for the new cache
 		b.restartResourceWatcher()
+	}
+
+	// Register for context switch completion
+	k8s.OnContextSwitch(func(newContext string) {
+		log.Printf("SSE broadcaster: context switched to %q, clearing cached topology", newContext)
+		resetCacheView()
 
 		// Broadcast context_changed event to all clients
 		b.mu.RLock()
@@ -324,6 +327,13 @@ func (b *SSEBroadcaster) registerContextSwitchCallback() {
 
 		// Broadcast the new topology so clients can complete the switch
 		// Run in goroutine to not block the context switch
+		log.Printf("SSE broadcaster: scheduling topology broadcast")
+		go b.broadcastTopologyUpdate()
+	})
+
+	k8s.OnNamespaceRescope(func(namespace string) {
+		log.Printf("SSE broadcaster: namespace cache rescoped to %q, clearing cached topology", k8s.SanitizeForLog(namespace))
+		resetCacheView()
 		log.Printf("SSE broadcaster: scheduling topology broadcast")
 		go b.broadcastTopologyUpdate()
 	})

--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -299,8 +299,11 @@ func (d *DynamicResourceCache) probeScope(gvr schema.GroupVersionResource, prefe
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	// Forced namespace mode: only ever watch the configured namespace.
-	if d.config.NamespaceScoped && d.config.Namespace != "" {
+	// Forced namespace mode (--namespace-scope): pin NAMESPACED resources to the
+	// configured namespace. Cluster-scoped resources have no namespace dimension,
+	// so they fall through to the cluster-wide path below — pinning them to a
+	// namespace would list nothing.
+	if d.config.NamespaceScoped && d.config.Namespace != "" && d.gvrIsNamespaced(gvr) {
 		return d.classifyScope(gvr, d.config.Namespace, d.listProbe(ctx, gvr, d.config.Namespace))
 	}
 
@@ -418,7 +421,11 @@ func (d *DynamicResourceCache) ProbeCount(gvr schema.GroupVersionResource) int {
 }
 
 func (d *DynamicResourceCache) probeCountList(ctx context.Context, gvr schema.GroupVersionResource) (*unstructured.UnstructuredList, error) {
-	if d.config.NamespaceScoped && d.config.Namespace != "" {
+	// Match probeScope: under --namespace-scope only NAMESPACED resources are
+	// pinned to the configured namespace. Counting a cluster-scoped resource
+	// inside a namespace lists nothing (or errors), which would misgate the
+	// size-based eager-warm decision, so it stays cluster-wide.
+	if d.config.NamespaceScoped && d.config.Namespace != "" && d.gvrIsNamespaced(gvr) {
 		return d.config.DynamicClient.Resource(gvr).Namespace(d.config.Namespace).List(ctx, metav1.ListOptions{Limit: 1})
 	}
 

--- a/pkg/k8score/dynamic_cache_count_test.go
+++ b/pkg/k8score/dynamic_cache_count_test.go
@@ -96,6 +96,52 @@ func TestDynamicResourceCache_CountDirectProbeUnavailableWithoutRemainingCount(t
 	}
 }
 
+func TestDynamicResourceCache_ProbeCountClusterScopedStaysClusterWide(t *testing.T) {
+	// Under --namespace-scope, counting a cluster-scoped CRD must stay cluster-wide:
+	// a namespaced list of a cluster-scoped resource returns nothing and would
+	// misgate the size-based eager-warm decision.
+	gvr := schema.GroupVersionResource{Group: "karpenter.sh", Version: "v1", Resource: "nodepools"}
+	disc := &ResourceDiscovery{
+		resources: []APIResource{{
+			Group: gvr.Group, Version: gvr.Version, Kind: "NodePool", Name: gvr.Resource,
+			Namespaced: false, IsCRD: true, Verbs: []string{"get", "list", "watch"},
+		}},
+		resourceMap: map[string]APIResource{},
+		gvrMap:      map[string]schema.GroupVersionResource{},
+		lastRefresh: time.Now(),
+		cacheTTL:    time.Hour,
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "NodePoolList"},
+	)
+	dyn.PrependReactor("list", "nodepools", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		// Any namespaced list returns empty, so the test fails if the pin guard
+		// regresses and counts a cluster-scoped resource inside the namespace.
+		if action.GetNamespace() != "" {
+			return true, &unstructured.UnstructuredList{}, nil
+		}
+		remaining := int64(11)
+		list := &unstructured.UnstructuredList{Items: []unstructured.Unstructured{{}}}
+		list.SetRemainingItemCount(&remaining)
+		return true, list, nil
+	})
+
+	d, err := NewDynamicResourceCache(DynamicCacheConfig{
+		DynamicClient:   dyn,
+		Discovery:       disc,
+		NamespaceScoped: true,
+		Namespace:       "foo",
+	})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+
+	if got := d.ProbeCount(gvr); got != 12 {
+		t.Fatalf("ProbeCount(cluster-scoped under --namespace-scope) = %d, want 12 (cluster-wide)", got)
+	}
+}
+
 func TestDynamicResourceCache_ProbeCountUsesRemainingCount(t *testing.T) {
 	gvr := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"}
 	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -986,12 +986,13 @@ function AppInner() {
   // mutation immediately, which re-introduces the same race. The state→URL
   // effect propagates state=[] → URL on its own after onSuccess flips state.
   const clearAllNamespaces = useCallback(() => {
+    if (namespaceScope?.cacheScoped) return
     if (namespaces.length === 0) return
     setActiveNamespace.mutate(
       { namespaces: [] },
       { onSuccess: () => setNamespaces([]) },
     )
-  }, [namespaces.length, setActiveNamespace])
+  }, [namespaceScope?.cacheScoped, namespaces.length, setActiveNamespace])
   const initialBookmarkReconciledRef = useRef(false)
   const scopeActives = useMemo(() => namespaceScope?.actives ?? [], [namespaceScope?.actives])
   const namespaceScopeKey = useMemo(() => namespaceScope ? [...scopeActives].sort().join(',') : null, [namespaceScope, scopeActives])
@@ -1015,6 +1016,14 @@ function AppInner() {
     if (!initialBookmarkReconciledRef.current) {
       initialBookmarkReconciledRef.current = true
       if (!sameAsState && sortedState.length > 0) {
+        if (namespaceScope.cacheScoped && (!namespaceScope.namespaceRescope || sortedState.length !== 1)) {
+          debugNamespaceLog('app:scope-mirror-cache-scope-preserve', {
+            stateNamespaces: sortedState,
+            scopeActives: sortedScope,
+          })
+          setNamespaces(scopeActives)
+          return
+        }
         debugNamespaceLog('app:scope-mirror-bookmark-to-server', {
           stateNamespaces: sortedState,
           scopeActives: sortedScope,
@@ -1117,6 +1126,12 @@ function AppInner() {
     })
 
     if (urlNamespaces.join(',') !== namespacesKey) {
+      if (namespaceScope?.cacheScoped && (!namespaceScope.namespaceRescope || urlNamespaces.length !== 1)) {
+        const scopedNamespaces = namespaceScope.actives ?? []
+        debugNamespaceLog('app:url-sync-cache-scope-preserve', { scopedNamespaces })
+        setNamespaces(scopedNamespaces)
+        return
+      }
       debugNamespaceLog('app:url-sync-set-namespaces', { nextNamespaces: urlNamespaces })
       setNamespaces(urlNamespaces)
       if (namespaceScope) {
@@ -2081,6 +2096,7 @@ function AppInner() {
             { onSettled: () => setNamespaces([]) },
           )}
           onSetNamespaces={(ns) => {
+            if (namespaceScope?.cacheScoped && ns.length !== 1) return
             setNamespaces(ns)
             setActiveNamespace.mutate({ namespaces: ns })
           }}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3191,7 +3191,14 @@ export function useSetActiveNamespace() {
       debugNamespaceLog('mutation:start', { namespaces })
       const controller = new AbortController()
       const currentScope = queryClient.getQueryData<NamespaceScope>(['namespace-scope'])
-      const timeoutMs = currentScope?.cacheScoped ? NAMESPACE_RESCOPE_TIMEOUT : NAMESPACE_SWITCH_TIMEOUT
+      // cacheScoped is a stable per-process property (the server's --namespace-scope
+      // flag). If the scope query is missing/stale we can't yet tell a cheap
+      // view-filter change from a cache-rebuilding rescope, so bias to the long
+      // timeout — only a confirmed non-scoped session gets the fast switch timeout.
+      // Aborting a real rebuild at 5s surfaces a spurious failure while the server
+      // keeps going.
+      const isRescope = currentScope?.cacheScoped !== false
+      const timeoutMs = isRescope ? NAMESPACE_RESCOPE_TIMEOUT : NAMESPACE_SWITCH_TIMEOUT
       const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
       const startedAt = performance.now()
       try {
@@ -3220,9 +3227,9 @@ export function useSetActiveNamespace() {
           error: error instanceof Error ? error.message : String(error),
         })
         if (error instanceof Error && error.name === 'AbortError') {
-          throw new Error(currentScope?.cacheScoped
+          throw new Error(isRescope
             ? 'Namespace rescope timed out. The cluster may still be loading.'
-            : 'Namespace switch timed out. The cluster may be unreachable.')
+            : 'Namespace switch timed out. The cluster may be unreachable.', { cause: error })
         }
         throw error
       }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3147,6 +3147,11 @@ export interface NamespaceScope {
   authoritative: boolean
   /** false when clearing would leave no usable namespace fallback. */
   canClearNamespace: boolean
+  /** true when the backend informer cache is pinned to a namespace. */
+  cacheScoped: boolean
+  cacheScopeNamespace?: string
+  /** true when this client may rebuild the local cache for another namespace. */
+  namespaceRescope: boolean
 }
 
 export function useNamespaceScope() {
@@ -3158,6 +3163,7 @@ export function useNamespaceScope() {
 }
 
 const NAMESPACE_SWITCH_TIMEOUT = 5000
+const NAMESPACE_RESCOPE_TIMEOUT = 120000
 
 export function debugNamespaceLog(label: string, payload?: Record<string, unknown>) {
   if (typeof window === 'undefined') return
@@ -3184,7 +3190,9 @@ export function useSetActiveNamespace() {
     mutationFn: async ({ namespaces }) => {
       debugNamespaceLog('mutation:start', { namespaces })
       const controller = new AbortController()
-      const timeoutId = setTimeout(() => controller.abort(), NAMESPACE_SWITCH_TIMEOUT)
+      const currentScope = queryClient.getQueryData<NamespaceScope>(['namespace-scope'])
+      const timeoutMs = currentScope?.cacheScoped ? NAMESPACE_RESCOPE_TIMEOUT : NAMESPACE_SWITCH_TIMEOUT
+      const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
       const startedAt = performance.now()
       try {
         const response = await apiFetch(`${getApiBase()}/cluster/namespace`, {
@@ -3212,7 +3220,9 @@ export function useSetActiveNamespace() {
           error: error instanceof Error ? error.message : String(error),
         })
         if (error instanceof Error && error.name === 'AbortError') {
-          throw new Error('Namespace switch timed out. The cluster may be unreachable.', { cause: error })
+          throw new Error(currentScope?.cacheScoped
+            ? 'Namespace rescope timed out. The cluster may still be loading.'
+            : 'Namespace switch timed out. The cluster may be unreachable.')
         }
         throw error
       }
@@ -3223,7 +3233,13 @@ export function useSetActiveNamespace() {
         mode: scope.mode,
         accessibleCount: scope.accessibleNamespaces.length,
       })
+      if (scope.cacheScoped) {
+        queryClient.removeQueries({ predicate: query => query.queryKey[0] !== 'namespace-scope' })
+      }
       queryClient.setQueryData<NamespaceScope>(['namespace-scope'], scope)
+      if (scope.cacheScoped) {
+        queryClient.invalidateQueries()
+      }
       debugNamespaceLog('mutation:success-after-scope-cache-write')
     },
     onError: () => {

--- a/web/src/components/NamespaceSwitcher.tsx
+++ b/web/src/components/NamespaceSwitcher.tsx
@@ -15,10 +15,9 @@ interface NamespaceSwitcherProps {
 }
 
 /**
- * NamespaceSwitcher is a per-user multi-select view filter for the cluster
- * view. It does NOT reshape the shared informer cache — picks are saved
- * server-side per user and intersected with the user's RBAC-allowed
- * namespaces on each read.
+ * NamespaceSwitcher is normally a per-user multi-select view filter. When the
+ * backend reports cacheScoped=true, it becomes a single-namespace cache scope
+ * control; local sessions may rebuild the cache for a different namespace.
  *
  * Three states reflect what the backend reports:
  *   - cluster-wide: empty trigger label "All namespaces", picker lets the
@@ -71,6 +70,7 @@ export const NamespaceSwitcher = forwardRef<NamespaceSwitcherHandle, NamespaceSw
   const applySelection = useCallback((next: Set<string>) => {
     if (!scope) return
     const nextArr = Array.from(next).sort()
+    if (scope.cacheScoped && nextArr.length !== 1) return
     if (nextArr.join(',') === activesKey) return
     setActive.mutate({ namespaces: nextArr })
   }, [activesKey, scope, setActive])
@@ -120,6 +120,10 @@ export const NamespaceSwitcher = forwardRef<NamespaceSwitcherHandle, NamespaceSw
   if (!scope) return null
 
   const toggle = (ns: string) => {
+    if (scope.cacheScoped) {
+      setDraft(new Set([ns]))
+      return
+    }
     const next = new Set(draft)
     if (next.has(ns)) next.delete(ns)
     else next.add(ns)
@@ -127,6 +131,7 @@ export const NamespaceSwitcher = forwardRef<NamespaceSwitcherHandle, NamespaceSw
   }
 
   const clearAll = () => {
+    if (scope.cacheScoped) return
     setDraft(new Set())
     setIsOpen(false)
     setSearch('')
@@ -150,11 +155,16 @@ export const NamespaceSwitcher = forwardRef<NamespaceSwitcherHandle, NamespaceSw
     activeCount === 0 ? 'All namespaces' : activeCount === 1 ? scopeActives[0] : `${activeCount} namespaces`
   const isClusterWide = activeCount === 0
   const restrictedHint = scope.mode === 'restricted'
-  const isDisabled = disabled || isLoading || setActive.isPending
+  const cacheScopeLocked = scope.cacheScoped && !scope.namespaceRescope
+  const isDisabled = disabled || isLoading || setActive.isPending || cacheScopeLocked
   const canClearAll = scope.canClearNamespace || activeCount === 0
   const tooltipContent = disabled && disabledTooltip
     ? disabledTooltip
-    : restrictedHint
+    : scope.cacheScoped
+      ? scope.namespaceRescope
+        ? 'Cache is scoped to one namespace. Switching rebuilds the local cache.'
+        : `Cache is scoped to namespace ${scope.cacheScopeNamespace || triggerLabel}.`
+      : restrictedHint
       ? 'Limited namespace visibility — only namespaces granted by your RBAC are shown.'
       : isClusterWide
         ? 'Currently viewing all namespaces. Click to narrow the view.'
@@ -213,28 +223,34 @@ export const NamespaceSwitcher = forwardRef<NamespaceSwitcherHandle, NamespaceSw
               </div>
             )}
 
-            <div className="flex items-center justify-between px-2 py-1.5 border-b border-theme-border text-xs text-theme-text-secondary">
-              <button
-                onClick={canClearAll ? clearAll : undefined}
-                disabled={!canClearAll || activeCount === 0}
-                className="flex items-center gap-1 px-1.5 py-0.5 rounded hover:bg-theme-hover disabled:opacity-50 disabled:hover:bg-transparent"
-                aria-label="Clear namespace selection"
-              >
-                <X className="w-3 h-3" />
-                Clear all
-              </button>
-              <button
-                onClick={allVisibleSelected ? clearVisible : selectAllVisible}
-                disabled={filteredItems.length === 0}
-                className="px-1.5 py-0.5 rounded hover:bg-theme-hover disabled:opacity-50 disabled:hover:bg-transparent"
-              >
-                {allVisibleSelected
-                  ? `Clear ${filteredItems.length} visible`
-                  : search.trim()
-                    ? `Select ${filteredItems.length} visible`
-                    : 'Select all'}
-              </button>
-            </div>
+            {scope.cacheScoped ? (
+              <div className="px-3 py-1.5 border-b border-theme-border text-xs text-theme-text-secondary">
+                Cache scope
+              </div>
+            ) : (
+              <div className="flex items-center justify-between px-2 py-1.5 border-b border-theme-border text-xs text-theme-text-secondary">
+                <button
+                  onClick={canClearAll ? clearAll : undefined}
+                  disabled={!canClearAll || activeCount === 0}
+                  className="flex items-center gap-1 px-1.5 py-0.5 rounded hover:bg-theme-hover disabled:opacity-50 disabled:hover:bg-transparent"
+                  aria-label="Clear namespace selection"
+                >
+                  <X className="w-3 h-3" />
+                  Clear all
+                </button>
+                <button
+                  onClick={allVisibleSelected ? clearVisible : selectAllVisible}
+                  disabled={filteredItems.length === 0}
+                  className="px-1.5 py-0.5 rounded hover:bg-theme-hover disabled:opacity-50 disabled:hover:bg-transparent"
+                >
+                  {allVisibleSelected
+                    ? `Clear ${filteredItems.length} visible`
+                    : search.trim()
+                      ? `Select ${filteredItems.length} visible`
+                      : 'Select all'}
+                </button>
+              </div>
+            )}
 
             <ul className="max-h-80 overflow-y-auto py-1">
               {filteredItems.length === 0 && (
@@ -253,7 +269,8 @@ export const NamespaceSwitcher = forwardRef<NamespaceSwitcherHandle, NamespaceSw
                     >
                       <span className="flex items-center gap-2 min-w-0">
                         <input
-                          type="checkbox"
+                          type={scope.cacheScoped ? 'radio' : 'checkbox'}
+                          name={scope.cacheScoped ? 'namespace-cache-scope' : undefined}
                           checked={isChecked}
                           onChange={() => toggle(ns)}
                           className="shrink-0 accent-current"
@@ -273,7 +290,9 @@ export const NamespaceSwitcher = forwardRef<NamespaceSwitcherHandle, NamespaceSw
 
             <div className="flex items-center justify-between px-3 py-1.5 border-t border-theme-border text-[11px] text-theme-text-tertiary">
               <span>
-                {draft.size === 0 ? 'All namespaces' : `${draft.size} selected`}
+                {scope.cacheScoped
+                  ? (draft.size === 1 ? Array.from(draft)[0] : 'Select a namespace')
+                  : draft.size === 0 ? 'All namespaces' : `${draft.size} selected`}
               </span>
               <button
                 onClick={closeAndApply}

--- a/web/src/components/NamespaceSwitcher.tsx
+++ b/web/src/components/NamespaceSwitcher.tsx
@@ -162,8 +162,8 @@ export const NamespaceSwitcher = forwardRef<NamespaceSwitcherHandle, NamespaceSw
     ? disabledTooltip
     : scope.cacheScoped
       ? scope.namespaceRescope
-        ? 'Cache is scoped to one namespace. Switching rebuilds the local cache.'
-        : `Cache is scoped to namespace ${scope.cacheScopeNamespace || triggerLabel}.`
+        ? `Radar is watching only ${scope.cacheScopeNamespace || triggerLabel} to stay fast on large clusters. Pick another namespace to re-point it (takes a moment; closes open terminals).`
+        : `Radar is watching only ${scope.cacheScopeNamespace || triggerLabel} on this cluster.`
       : restrictedHint
       ? 'Limited namespace visibility — only namespaces granted by your RBAC are shown.'
       : isClusterWide
@@ -224,8 +224,11 @@ export const NamespaceSwitcher = forwardRef<NamespaceSwitcherHandle, NamespaceSw
             )}
 
             {scope.cacheScoped ? (
-              <div className="px-3 py-1.5 border-b border-theme-border text-xs text-theme-text-secondary">
-                Cache scope
+              <div className="px-3 py-1.5 border-b border-theme-border text-[11px] leading-snug text-theme-text-secondary">
+                Radar is watching one namespace to stay fast on large clusters.
+                {scope.namespaceRescope
+                  ? ' Pick another to re-point it — takes a moment and closes open terminals.'
+                  : ' This instance is locked to its startup namespace.'}
               </div>
             ) : (
               <div className="flex items-center justify-between px-2 py-1.5 border-b border-theme-border text-xs text-theme-text-secondary">


### PR DESCRIPTION
Adds an opt-in `--namespace-scope` mode for large clusters where watching every namespace cluster-wide makes Radar's informer caches too heavy (memory pressure, slow first paint). When enabled, namespaced informers are pinned to a single namespace while cluster-scoped resources (Nodes, Namespaces, PVs, StorageClasses, CRDs without a namespace) continue to load cluster-wide. It's an operator escape hatch — off by default; the existing namespace picker keeps acting as a per-user view filter when the flag isn't set.

Fixes #684.

## What changed

**Scope resolution.** The pinned namespace is resolved by precedence: a runtime rescope override → the startup `--namespace` (only while on the context it was set for) → the kubeconfig context namespace → a saved local single-namespace pick. `--namespace` is treated as an *initial* value, not a permanent pin: after a cross-cluster switch the new context's own namespace takes over instead of dragging the old value along.

**Per-kind pinning.** RBAC probes, typed informers, and dynamic/CRD informers all honor the pin for namespaced kinds. Cluster-scoped kinds — including cluster-scoped CRDs and their size-gating count probe — stay cluster-wide (a namespaced list of a cluster-scoped resource returns nothing, so pinning them would blank them out).

**Local rescope vs. multi-user lock.** In local/no-auth sessions, picking a different namespace rebuilds the scoped cache in place (`PerformNamespaceRescope`) and the pick persists per kubeconfig context, so it survives reconnects and restarts. In auth/proxy/OIDC/cloud mode the picker is locked to the process cache scope — a different pick returns 403 — so one user cannot reshape the shared backend cache for everyone. Per-user reads (REST + MCP + Helm) are clamped to the pinned namespace; an out-of-scope request resolves to an empty view, never a widened one.

**Context-switch / rescope lifecycle.** The destructive operations (context switch, reconnect, CAPI connect, namespace rescope) are serialized under one lock so two concurrent requests can't interleave cache teardown/rebuild. A switch validates the new context has a usable scope target *before* any teardown — if it doesn't, the request is rejected as a typed preflight error and the current connection is left intact (no false "disconnected"). Active port-forward/exec sessions are stopped only at the point of no return, so a switch/rescope that fails before teardown leaves them running. The saved pick, the live cache scope, and the rescope move as one committed unit: the pick is validated and persisted before the rebuild and re-synced to the live scope if the rebuild fails, so a later reconnect can never restore a namespace the cache isn't actually serving.

**API / UI.** The namespace-scope response exposes `cacheScoped`, `cacheScopeNamespace`, and `namespaceRescope`. When scoped, the picker becomes single-select and explains, in plain language, that Radar is watching one namespace to stay fast on large clusters, that re-pointing rebuilds the cache (takes a moment, closes open terminals), and that auth/cloud instances are locked. A rescope POST uses a longer client timeout (a cache rebuild far outlasts a view-filter change) and refetches data once the new cache is live.

### Unit / static
- `go test ./internal/k8s/... ./internal/server/... ./internal/app/... ./pkg/k8score/...`
- `go test -race ./internal/k8s/...` on the context-switch/rescope paths
- `cd web && npx tsc --noEmit`
- visual-test: skipped — the only UI change is picker copy/affordances that render only under `--namespace-scope`; no layout change.

### Live verification (kind, real EKS, real GKE-on-IAM), driven via the HTTP API + server logs
- **Cache pins:** scoped to one namespace, only that namespace's resources are cached; other namespaces return empty. Cluster-scoped resources stay cluster-wide — Node counts served by the scoped cache match `kubectl` on multi-node EKS (2) and GKE (9).
- **CRD scope:** namespaced CRDs pinned (Argo `Application`); cluster-scoped CRDs served cluster-wide (Crossplane `Composition`/`CompositeResourceDefinition`).
- **Probe-based RBAC gating across authorizers:** correct under standard RBAC (EKS — denies the kinds the identity can't list) and under a GKE IAM/webhook authorizer (admits all listable kinds) — the case where `SelfSubjectAccessReview` and real list access can disagree.
- **Multi-user lock:** with auth enabled, a cluster-admin user's attempt to rescope to a different namespace is rejected (403) and the shared cache is left unchanged.
- **Connection safety:** a context switch to a context with no usable scope target is rejected before any teardown and leaves the current cluster connected.
- **Rescope:** rebuilds the cache in place against real clusters (~1.1–1.4s) and persists the pick per context.
- **Startup:** a multi/invalid namespace under `--namespace-scope` is rejected with a clear error.
- **Memory:** the cluster-wide cache shows a higher initial-sync peak than a scoped cache; at steady state, memory is dominated by the Go runtime + the cluster-scoped informers both modes run, so the saving scales with cluster size and is most significant on the large clusters this flag targets (negligible on small/mid clusters).

## Notes / limitations

- **Single namespace only.** The cache pins to exactly one namespace; scoping to several at once is not supported yet (a client-go informer watches one namespace or all, so N namespaces would mean N informers per kind across the whole typed cache). A multi/invalid target (e.g. `--namespace=a,b`) is rejected at startup with a clear error. Scoping to a small set of namespaces is the most likely follow-up; the dynamic/CRD cache, persistence, and per-user read filtering are already list-shaped, so the remaining work is the typed cache (per-(kind, namespace) informers with unioned reads) plus widening the scope target to a list.
- Under `--namespace-scope`, a resource that exists outside the pinned namespace isn't in the cache, so a direct GET/bookmark to it returns not-found — expected for a deliberately scoped instance, but a clearer "outside Radar's current scope" signal on that path is a possible follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core informer lifecycle, context switching, and shared-cache behavior in auth mode; mistakes could leave users disconnected or serving wrong namespace data, but preflight guards, rollback, and extensive tests mitigate this.
> 
> **Overview**
> Adds **`--namespace-scope`**, an opt-in mode that pins **namespaced** informer caches to **one** namespace (cluster-scoped kinds stay cluster-wide) to cut memory and sync cost on large clusters.
> 
> **Scope resolution** uses runtime override → startup `--namespace` (only on the context it was set for) → kubeconfig context namespace → saved local pick. Startup rejects empty, multi-namespace, or invalid targets. Auth/cloud skips local settings and locks the shared cache to the startup namespace.
> 
> **Local rescope** (`PerformNamespaceRescope`) rebuilds caches when the picker changes namespace; persisted picks stay aligned with the live scope on failure. **Context switch / rescope** are serialized, preflight-validated (`ErrContextSwitchPreflight`), and stop port-forward/exec only at teardown commit; session stopping moved out of HTTP handlers into k8s.
> 
> **API/UI**: namespace-scope response adds `cacheScoped`, `cacheScopeNamespace`, `namespaceRescope`; reads and Helm clamp to the pinned namespace. Picker becomes single-select with rescope messaging and a longer client timeout during cache rebuilds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26a13e2920769c1ede74abbe17b2cb72cf838a9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->