### PR TITLE
Use shared inline code styling across UI

### DIFF
--- a/packages/k8s-ui/src/components/resources/renderers/CompositionRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CompositionRenderer.tsx
@@ -57,13 +57,13 @@ function CompositionBody({ data, onNavigate, revision }: CompositionRendererProp
           {xrdKind && (
             <Property
               label="Composite Kind"
-              value={<span className="font-mono text-theme-text-secondary">{xrdKind}</span>}
+              value={<span className="inline-code">{xrdKind}</span>}
             />
           )}
           {compositeTypeRef.apiVersion && (
             <Property
               label="API Version"
-              value={<span className="font-mono text-theme-text-tertiary text-xs">{compositeTypeRef.apiVersion}</span>}
+              value={<span className="inline-code text-xs">{compositeTypeRef.apiVersion}</span>}
             />
           )}
           {writeConnNs && <Property label="Connection Secret Namespace" value={writeConnNs} />}
@@ -149,7 +149,7 @@ function CompositionBody({ data, onNavigate, revision }: CompositionRendererProp
               return (
                 <div key={i} className="card-inner text-sm flex items-center gap-2 flex-wrap">
                   <span className="badge-sm status-neutral">{baseKind || 'Unknown'}</span>
-                  <span className="font-mono text-theme-text-secondary break-all">{res.name || `resource-${i}`}</span>
+                  <span className="inline-code break-all">{res.name || `resource-${i}`}</span>
                   {baseApiVersion && (
                     <span className="text-theme-text-tertiary text-xs">{baseApiVersion}</span>
                   )}

--- a/packages/k8s-ui/src/components/resources/renderers/CrossplanePackageRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CrossplanePackageRenderer.tsx
@@ -54,7 +54,7 @@ export function CrossplanePackageRenderer({ data, kindLabel, onNavigate }: Cross
 
       <Section title={kindLabel} icon={Package} defaultExpanded>
         <PropertyList>
-          <Property label="Package" value={<span className="font-mono break-all">{pkg}</span>} />
+          <Property label="Package" value={<span className="inline-code break-all">{pkg}</span>} />
           {pullPolicy && <Property label="Pull Policy" value={pullPolicy} />}
           {data?.spec?.revisionActivationPolicy && (
             <Property label="Revision Activation" value={data.spec.revisionActivationPolicy} />
@@ -73,12 +73,12 @@ export function CrossplanePackageRenderer({ data, kindLabel, onNavigate }: Cross
         <Section title="Revision" icon={ScrollText} defaultExpanded>
           <PropertyList>
             {currentRevision && (
-              <Property label="Current Revision" value={<span className="font-mono break-all">{currentRevision}</span>} />
+              <Property label="Current Revision" value={<span className="inline-code break-all">{currentRevision}</span>} />
             )}
             {data?.status?.currentIdentifier && (
               <Property
                 label="Current Identifier"
-                value={<span className="font-mono break-all">{data.status.currentIdentifier}</span>}
+                value={<span className="inline-code break-all">{data.status.currentIdentifier}</span>}
               />
             )}
           </PropertyList>
@@ -112,7 +112,7 @@ export function CrossplanePackageRenderer({ data, kindLabel, onNavigate }: Cross
               return (
                 <div key={i} className="card-inner text-sm flex items-center gap-2 flex-wrap">
                   <span className="badge-sm status-neutral">{depKind}</span>
-                  <span className="font-mono text-theme-text-secondary break-all">{ref || '-'}</span>
+                  <span className="inline-code break-all">{ref || '-'}</span>
                   {dep.version && (
                     <span className="text-theme-text-tertiary text-xs">version: {dep.version}</span>
                   )}
@@ -129,7 +129,7 @@ export function CrossplanePackageRenderer({ data, kindLabel, onNavigate }: Cross
             {objectRefs.map((ref: any, i: number) => (
               <div key={i} className="card-inner text-sm flex items-center gap-2 flex-wrap">
                 <span className="badge-sm status-neutral">{ref.kind || 'Unknown'}</span>
-                <span className="font-mono text-theme-text-secondary break-all">{ref.name}</span>
+                <span className="inline-code break-all">{ref.name}</span>
                 {ref.apiVersion && (
                   <span className="text-theme-text-tertiary text-xs">{ref.apiVersion}</span>
                 )}

--- a/packages/k8s-ui/src/components/resources/renderers/CrossplaneProviderConfigRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CrossplaneProviderConfigRenderer.tsx
@@ -56,7 +56,7 @@ export function CrossplaneProviderConfigRenderer({ data, onNavigate }: Crossplan
               }
             />
             {secretRef.namespace && <Property label="Namespace" value={secretRef.namespace} />}
-            {secretRef.key && <Property label="Key" value={<span className="font-mono">{secretRef.key}</span>} />}
+            {secretRef.key && <Property label="Key" value={<span className="inline-code">{secretRef.key}</span>} />}
           </PropertyList>
         </Section>
       )}

--- a/packages/k8s-ui/src/components/resources/renderers/KnativeSourceRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KnativeSourceRenderer.tsx
@@ -58,7 +58,7 @@ export function PingSourceRenderer({ data, onNavigate }: RendererProps) {
           <Property label="Timezone" value={spec.timezone} />
           <Property label="Content Type" value={spec.contentType} />
           <Property label="Data" value={spec.data ? (
-            <span className="font-mono text-xs break-all">{spec.data.length > 200 ? spec.data.slice(0, 200) + '...' : spec.data}</span>
+            <span className="inline-code text-xs break-all">{spec.data.length > 200 ? spec.data.slice(0, 200) + '...' : spec.data}</span>
           ) : undefined} />
           <SinkProperty sink={spec.sink} ns={ns} onNavigate={onNavigate} />
         </PropertyList>

--- a/packages/k8s-ui/src/components/resources/renderers/VeleroBackupRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/VeleroBackupRenderer.tsx
@@ -161,7 +161,7 @@ export function VeleroBackupRenderer({ data }: VeleroBackupRendererProps) {
             )}
             {data.spec?.labelSelector && (
               <Property label="Label Selector" value={
-                <span className="text-sm font-mono text-theme-text-secondary break-all">
+                <span className="inline-code break-all">
                   {JSON.stringify(data.spec.labelSelector)}
                 </span>
               } />

--- a/packages/k8s-ui/src/components/resources/renderers/XRDRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/XRDRenderer.tsx
@@ -51,9 +51,9 @@ export function XRDRenderer({ data, onNavigate }: XRDRendererProps) {
             <Property label="Singular" value={<span className="font-mono">{names.singular}</span>} />
           )}
           {names.listKind && (
-            <Property label="List Kind" value={<span className="font-mono">{names.listKind}</span>} />
+            <Property label="List Kind" value={<span className="inline-code">{names.listKind}</span>} />
           )}
-          <Property label="Group" value={<span className="font-mono break-all">{group}</span>} />
+          <Property label="Group" value={<span className="inline-code break-all">{group}</span>} />
           {scope && (
             <Property
               label="Scope"

--- a/web/src/components/ConnectionErrorView.tsx
+++ b/web/src/components/ConnectionErrorView.tsx
@@ -197,13 +197,13 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
             Context: {connection.context ? (
               <ClusterName name={connection.context} />
             ) : (
-              <span className="font-mono text-theme-text-primary">(none)</span>
+              <span className="inline-code">(none)</span>
             )}
           </p>
 
           {connection.clusterName && (
             <p className="text-sm text-theme-text-secondary mb-4">
-              Cluster: <span className="font-mono text-theme-text-primary">{connection.clusterName}</span>
+              Cluster: <span className="inline-code">{connection.clusterName}</span>
             </p>
           )}
 

--- a/web/src/components/helm/RoleGatedPanel.tsx
+++ b/web/src/components/helm/RoleGatedPanel.tsx
@@ -38,8 +38,8 @@ export function RoleGatedPanel({ min, feature, children }: RoleGatedPanelProps) 
         Your role can't view {feature}
       </div>
       <div className="mt-1 max-w-md text-xs text-theme-text-secondary">
-        You're signed in as <span className="font-mono text-theme-text-primary">{role ?? 'viewer'}</span>.
-        This view requires <span className="font-mono text-theme-text-primary">{min}</span> or higher.
+        You're signed in as <span className="inline-code">{role ?? 'viewer'}</span>.
+        This view requires <span className="inline-code">{min}</span> or higher.
         Ask a {min} or owner if you need access.
       </div>
     </div>

--- a/web/src/components/home/MCPSetupDialog.tsx
+++ b/web/src/components/home/MCPSetupDialog.tsx
@@ -317,8 +317,8 @@ export function MCPSetupDialog({ open, onClose, mcpUrl }: MCPSetupDialogProps) {
                   {tool.params.length > 0 && (
                     <div className="flex flex-wrap gap-1.5 pt-0.5">
                       {tool.params.map((p) => (
-                        <span key={p.arg} className="badge-sm font-mono bg-theme-elevated text-theme-text-secondary" title={p.desc}>
-                          <span className="text-theme-text-secondary">{p.arg}</span>
+                        <span key={p.arg} className="inline-code text-[11px]" title={p.desc}>
+                          <span>{p.arg}</span>
                           {p.required && <span className="text-red-400">*</span>}
                         </span>
                       ))}

--- a/web/src/components/portforward/PortForwardButton.tsx
+++ b/web/src/components/portforward/PortForwardButton.tsx
@@ -308,7 +308,7 @@ export function PortForwardButton({
                 className="w-full px-3 py-2 text-left text-sm text-theme-text-primary hover:bg-theme-elevated flex items-center justify-between"
               >
                 <span className="flex items-center gap-2 shrink-0">
-                  <code className="text-accent-text">{port.port}</code>
+                  <code className="inline-code">{port.port}</code>
                   <span className="text-theme-text-disabled">/{port.protocol || 'TCP'}</span>
                 </span>
                 {port.name && (

--- a/web/src/components/portforward/PortForwardManager.tsx
+++ b/web/src/components/portforward/PortForwardManager.tsx
@@ -794,7 +794,7 @@ export function PortForwardPanel() {
                           <Tooltip content="Click to change local port" delay={300} position="bottom" disabled={!isPanelOpen}>
                           <code
                             className={clsx(
-                              'group/port text-xs bg-theme-base px-2 py-1 rounded text-accent-text transition-all inline-flex items-center gap-1',
+                              'inline-code group/port text-xs transition-all inline-flex items-center gap-1',
                               changingPortId === session.id
                                 ? 'opacity-50'
                                 : 'cursor-pointer hover:ring-1 hover:ring-blue-500/50'

--- a/web/src/components/resources/ImageFilesystemModal.tsx
+++ b/web/src/components/resources/ImageFilesystemModal.tsx
@@ -444,7 +444,7 @@ function AuthenticationHelp({ image, registryType, onRetry }: AuthenticationHelp
       </p>
 
       <p className="text-xs text-theme-text-tertiary text-center max-w-md mb-6">
-        Registry: <span className="font-mono text-theme-text-secondary">{registry}</span>
+        Registry: <span className="inline-code">{registry}</span>
         {registryType && registryType !== 'generic' && (
           <> ({formatAuthMethod(registryType)})</>
         )}
@@ -743,4 +743,3 @@ function FileTreeNode({ node, depth, defaultExpanded = true, image, namespace, p
     </div>
   )
 }
-


### PR DESCRIPTION
Unifies several remaining ad-hoc inline code treatments onto the shared `.inline-code` style. This covers resource renderer fields, MCP tool parameter chips, connection details, Helm role-gating text, port-forward port affordances, and registry/auth helper copy.

This keeps prose-level code references visually consistent without changing block code, logs, YAML, or terminal-style surfaces.

Validation:
- make tsc
- git diff --check
- visual-test screenshots in `.playwright-mcp/visual-test/20260531-164521`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS class-only changes with no logic or data-path modifications; minor visual differences possible where old styles differed from `.inline-code`.
> 
> **Overview**
> Replaces remaining one-off inline code styling (`font-mono`, accent-colored `code`, badge-like parameter chips) with the shared **`inline-code`** class across k8s resource drawers and web surfaces.
> 
> **Resource renderers** (Crossplane composition/packages/XRD, Velero label selectors, Knative PingSource data, provider config secret keys) now show API versions, package IDs, resource names, and similar values through the same inline treatment.
> 
> **Web app** updates include connection error context/cluster labels, Helm role-gating copy, MCP tool parameter chips, port-forward port labels in the dropdown and active-session panel, and private-registry names in the image filesystem auth helper.
> 
> Presentation-only: no behavior, data, or API changes; block code, logs, and full command blocks are left as-is.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f94212849710b0a671a4a548f8e94e4ba9e9cb78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->