### PR TITLE
Polish pod container indicators

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -256,7 +256,7 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
   pods: [
     { key: 'name', label: 'Name' },
     { key: 'namespace', label: 'Namespace', width: 'w-48' },
-    { key: 'containers', label: 'Containers', width: 'w-32' },
+    { key: 'containers', label: 'Containers', width: 'w-32', tooltip: 'Container readiness; hover each square for name and state' },
     { key: 'status', label: 'Status', width: 'w-40' },
     { key: 'cpu', label: 'CPU', width: 'w-40', tooltip: 'CPU usage / limit (marker = request)' },
     { key: 'memory', label: 'Memory', width: 'w-40', tooltip: 'Memory usage / limit (marker = request)' },
@@ -4916,7 +4916,7 @@ function PodCell({ resource, column }: { resource: any; column: string }) {
       const squares = getContainerSquareStates(resource)
       const hasInit = squares.some(s => s.isInit)
       return (
-        <div className="flex items-center gap-1">
+        <div className="flex w-full items-center justify-center gap-1">
           {squares.map((sq, i) => {
             const showSeparator = hasInit && i > 0 && sq.isInit !== squares[i - 1].isInit
             const bgClass =


### PR DESCRIPTION
## Summary
- Center the pod table container readiness indicators so the compact glyphs read as intentional column content.
- Add a header tooltip explaining that each square represents container readiness and exposes name/state on hover.

## Test plan
- `make tsc`
- Visual test on `gke_koalabackend_me-west1-a_management-cluster` at 1920x1080 and 1280x800
- Screenshots: `.playwright-mcp/visual-test/20260531-171258/`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only tweaks in the k8s-ui pods table with no API, auth, or data-handling changes.
> 
> **Overview**
> Small **presentation polish** for the pods table **Containers** column in `ResourcesView`.
> 
> The column header now uses the existing `tooltip` field to explain that each square is container readiness and that hover shows name and state, matching how **CPU** and **Memory** headers are documented.
> 
> The readiness squares in `PodCell` are **centered** in the column (`w-full`, `justify-center`) so the glyphs read as deliberate column content instead of left-aligned clutter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00aded337794f86a0cb647308f6729abeb70bbdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->