### PR TITLE
Expose Issues from the home dashboard

### DIFF
--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -940,7 +940,7 @@ export interface TrafficFilters {
 // Library consumers (Radar Hub) get all GitOps surfaces — the package
 // IS the public surface, so adding new top-level views must extend
 // this type rather than rely on app-local extensions.
-export type ExtendedMainView = MainView | 'traffic' | 'cost' | 'audit' | 'gitops'
+export type ExtendedMainView = MainView | 'traffic' | 'cost' | 'audit' | 'gitops' | 'issues'
 
 // ============================================================================
 // Image Filesystem Types

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -194,6 +194,7 @@ export function HomeView({ namespaces, topology, onNavigateToView, onNavigateToR
           {hasProblems && (
             <ProblemsPanel
               problems={data.problems}
+              onNavigateToIssues={() => onNavigateToView('issues')}
               onResourceClick={onNavigateToResource}
             />
           )}
@@ -216,19 +217,29 @@ function BandItem({ children }: { children: ReactNode }) {
 
 interface ProblemsPanelProps {
   problems: DashboardResponse['problems']
+  onNavigateToIssues: () => void
   onResourceClick: (resource: SelectedResource) => void
 }
 
 
-function ProblemsPanel({ problems, onResourceClick }: ProblemsPanelProps) {
+function ProblemsPanel({ problems, onNavigateToIssues, onResourceClick }: ProblemsPanelProps) {
   return (
     <div className="rounded-xl bg-theme-surface shadow-theme-sm flex flex-col lg:max-h-[calc(100vh-280px)] lg:sticky lg:top-0">
       <div className="flex items-center justify-between px-5 py-3 border-b border-theme-border/50 shrink-0">
         <div className="flex items-center gap-2">
           <AlertTriangle className="w-4 h-4 text-red-500" />
-          <span className="text-xs font-semibold uppercase tracking-wider text-red-500">Unhealthy Workloads</span>
+          <span className="text-xs font-semibold uppercase tracking-wider text-red-500">Active Issues</span>
         </div>
-        <span className="badge status-unhealthy rounded-full">{problems.length}</span>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className="rounded-md px-2 py-1 text-xs font-medium text-accent-text transition-colors hover:bg-accent-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-radar-accent)]/40"
+            onClick={onNavigateToIssues}
+          >
+            View all
+          </button>
+          <span className="badge status-unhealthy rounded-full">{problems.length}</span>
+        </div>
       </div>
       <div className="overflow-y-auto flex-1 min-h-0">
         <div className="divide-y divide-theme-border">


### PR DESCRIPTION
## Summary
- Rename the home dashboard problems card to Active Issues
- Add a quiet View all action that opens the existing Issues queue
- Include issues in the shared ExtendedMainView type so dashboard navigation can target it

## Verification
- make tsc
- make build
- Ran the rebuilt app locally at http://localhost:9280/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy and navigation wiring only; no API or auth changes.
> 
> **Overview**
> The home dashboard **Active Issues** sidebar (renamed from “Unhealthy Workloads”) now includes a **View all** control that navigates to the existing **Issues** queue via `onNavigateToView('issues')`; individual rows still open the resource drawer.
> 
> Shared navigation typing adds **`issues`** to **`ExtendedMainView`** in `@skyhook-io/k8s-ui` so home (and Hub consumers) can target that view without app-local type hacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a197c7a5666632841cc515b6cf5f06074b45495d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->