### PR TITLE
Export Issues subpaths from k8s-ui package

### DIFF
--- a/packages/k8s-ui/package.json
+++ b/packages/k8s-ui/package.json
@@ -31,6 +31,11 @@
       "./src/components/gitops/*.tsx",
       "./src/components/gitops/*.ts"
     ],
+    "./components/issues": "./src/components/issues/index.ts",
+    "./components/issues/*": [
+      "./src/components/issues/*.tsx",
+      "./src/components/issues/*.ts"
+    ],
     "./components/timeline/*": [
       "./src/components/timeline/*.tsx",
       "./src/components/timeline/*.ts"


### PR DESCRIPTION
## Summary
- Add package exports for @skyhook-io/k8s-ui/components/issues and its files
- Keeps the published package contract aligned with the top-level IssuesView export added by the Issues UI work

## Verification
- make tsc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Package export map only; no runtime or API behavior changes inside the library.
> 
> **Overview**
> Extends the **`@skyhook-io/k8s-ui`** `exports` map with **`./components/issues`** (barrel) and **`./components/issues/*`** (per-file), matching the pattern used for gitops, timeline, and charts.
> 
> This lets apps import **`IssuesView`** and related issue types/helpers via subpath imports instead of relying only on the root package entry, keeping the published contract aligned with the Issues UI work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5e1ff3c04d1d46f41a7cdfd429eb90c470ed09d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->