### PR TITLE
Export shared Issues API contract

### DIFF
--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
+	"github.com/skyhook-io/radar/pkg/issuesapi"
 )
 
 // Filter is a compiled boolean predicate.
@@ -94,34 +95,20 @@ var envObject = mustNewEnv(
 // short form rather than fight cel-go's reservation list; `ns:` is
 // also the short modifier in the search query parser, so the two
 // surfaces stay parallel.
-var envIssue = mustNewEnv(
-	cel.Variable("severity", cel.StringType),
-	cel.Variable("source", cel.StringType),
-	cel.Variable("category", cel.StringType),
-	cel.Variable("category_group", cel.StringType),
-	cel.Variable("kind", cel.StringType),
-	cel.Variable("group", cel.StringType),
-	cel.Variable("ns", cel.StringType),
-	cel.Variable("name", cel.StringType),
-	cel.Variable("reason", cel.StringType),
-	cel.Variable("message", cel.StringType),
-	cel.Variable("count", cel.IntType),
-	// No `cluster` binding: a single Radar is one cluster. Cross-cluster scoping
-	// is the hub's `clusters=`/target mechanism (applied at fan-out), not a
-	// per-issue CEL predicate — Issue.Cluster was always empty here, so a
-	// forwarded `cluster == "x"` matched nothing.
-	// first_seen/last_seen are int unix-second timestamps so the agent can
-	// write `first_seen > timestamp("2025-01-01T00:00:00Z")` or compare
-	// against a "now - 1h" delta. Prefer first_seen for "issues older
-	// than…": last_seen churns to compose-time on every poll.
-	cel.Variable("first_seen", cel.IntType),
-	cel.Variable("last_seen", cel.IntType),
-	// grouping_scope (node|workload|…) slices node-level vs workload issues;
-	// restart_count + last_terminated_reason are the chronic-vs-acute fields.
-	cel.Variable("grouping_scope", cel.StringType),
-	cel.Variable("restart_count", cel.IntType),
-	cel.Variable("last_terminated_reason", cel.StringType),
-)
+var envIssue = mustNewEnv(issueCELVariables()...)
+
+func issueCELVariables() []cel.EnvOption {
+	out := make([]cel.EnvOption, 0, len(issuesapi.CELBindings))
+	for _, b := range issuesapi.CELBindings {
+		switch b.Type {
+		case issuesapi.BindingString:
+			out = append(out, cel.Variable(b.Name, cel.StringType))
+		case issuesapi.BindingInt:
+			out = append(out, cel.Variable(b.Name, cel.IntType))
+		}
+	}
+	return out
+}
 
 func mustNewEnv(opts ...cel.EnvOption) *cel.Env {
 	env, err := cel.NewEnv(opts...)

--- a/internal/issues/category.go
+++ b/internal/issues/category.go
@@ -1,156 +1,10 @@
 package issues
 
-import "strings"
+import (
+	"strings"
 
-// Category is the user-facing symptom taxonomy for an issue — "what kind of
-// problem is this" from an operator's mental model. It is DERIVED from the
-// detection signal (Source + Kind + Reason + Message + crash context), not a
-// new detector: the classifier below is a pure mapping over what radar already
-// emits.
-//
-// Distinct from Source (the detection channel: problem|missing_ref|scheduling|
-// condition) and from the resource's API Group. Category is the axis users
-// filter and group by; Source stays an output label / CEL binding.
-//
-// `unknown` is first-class — an unmapped signal is honestly labeled, never
-// dropped or force-fit into a neat bucket.
-type Category string
-
-const (
-	CategoryUnknown Category = "unknown"
-
-	// scheduling — can't get onto a node / rejected at admission
-	CategoryUnschedulable            Category = "unschedulable"
-	CategoryQuotaExceeded            Category = "quota_exceeded"
-	CategoryAdmissionWebhookBlocking Category = "admission_webhook_blocking"
-
-	// startup — scheduled, can't start the container
-	CategoryImagePullFailed     Category = "image_pull_failed"
-	CategoryContainerWaiting    Category = "container_waiting"
-	CategoryInitContainerFailed Category = "init_container_failed"
-
-	// runtime — started, won't stay healthy
-	CategoryCrashLoop         Category = "crashloop"
-	CategoryOOMKilled         Category = "oom_killed"
-	CategoryLivenessProbeFail Category = "liveness_probe_failed"
-	CategoryReadinessFailed   Category = "readiness_failed"
-	CategoryWorkloadDegraded  Category = "workload_degraded"
-	// CategoryHighRestart is a container with a high cumulative restart count
-	// that is still unhealthy and churning, but isn't a classic
-	// CrashLoopBackOff (e.g. readiness-probe churn with clean exits). Sits
-	// alongside CategoryCrashLoop rather than replacing it.
-	CategoryHighRestart Category = "high_restart"
-	// batch workload failures (Job/CronJob) — runtime-stage failures of
-	// one-shot / scheduled workloads.
-	CategoryJobFailed     Category = "job_failed"
-	CategoryCronJobFailed Category = "cronjob_failed"
-
-	// configuration
-	CategoryMissingConfigRef   Category = "missing_config_ref"
-	CategoryPDBBlocksEvictions Category = "pdb_blocks_evictions"
-
-	// networking
-	CategoryServiceNoEndpoints    Category = "service_no_endpoints"
-	CategoryIngressBackendMissing Category = "ingress_backend_missing"
-	CategoryDNSFailure            Category = "dns_failure"
-	CategoryNetworkPolicyBlock    Category = "network_policy_block"
-
-	// storage
-	CategoryPVCPending        Category = "pvc_pending"
-	CategoryPVCLost           Category = "pvc_lost"
-	CategoryVolumeMountFailed Category = "volume_mount_failed"
-	// CategoryVolumeAccessModeConflict is a config-level storage fault: a
-	// multi-replica Deployment mounts a ReadWriteOnce volume, which only one
-	// node can attach — surplus replicas can never start. Distinct from
-	// volume_mount_failed (the observed attach error) because this is the
-	// proactive root cause, detected from spec, before/independent of the symptom.
-	CategoryVolumeAccessModeConflict Category = "volume_access_mode_conflict"
-
-	// scaling / rollout
-	CategoryRolloutStalled     Category = "rollout_stalled"
-	CategoryHPALimitedOrFailed Category = "hpa_limited_or_failed"
-
-	// security
-	CategoryRBACForbidden        Category = "rbac_forbidden"
-	CategoryCertificateNotReady  Category = "certificate_not_ready"
-	CategoryPodSecurityViolation Category = "pod_security_violation"
-
-	// control plane / operators / cluster infra
-	CategoryNodeNotReady          Category = "node_not_ready"
-	CategoryOperatorConditionFail Category = "operator_condition_failed"
-	CategoryGitOpsSyncFailed      Category = "gitops_sync_failed"
-	CategoryWebhookBackendDown    Category = "webhook_backend_down"
-	CategoryControlPlaneNotReady  Category = "control_plane_not_ready"
-	CategoryMachineNotReady       Category = "machine_not_ready"
+	"github.com/skyhook-io/radar/pkg/issuesapi"
 )
-
-// CategoryGroup is the coarse rollup over categories — the ~10 buckets used for
-// the UI facet + summary strip. Derived from Category via categoryGroup; never
-// set independently. Named distinctly from Issue.Group (the resource's API
-// group) to avoid the two colliding.
-type CategoryGroup string
-
-const (
-	GroupUnknown       CategoryGroup = "unknown"
-	GroupScheduling    CategoryGroup = "scheduling"
-	GroupStartup       CategoryGroup = "startup"
-	GroupRuntime       CategoryGroup = "runtime"
-	GroupConfiguration CategoryGroup = "configuration"
-	GroupNetworking    CategoryGroup = "networking"
-	GroupStorage       CategoryGroup = "storage"
-	GroupScaling       CategoryGroup = "scaling"
-	GroupSecurity      CategoryGroup = "security"
-	GroupControlPlane  CategoryGroup = "control_plane"
-)
-
-// categoryGroup is the fixed category→group rollup. Server-side source of
-// truth: the UI renders whatever group the server reports, so adding a
-// category needs no frontend change.
-var categoryGroup = map[Category]CategoryGroup{
-	CategoryUnschedulable:            GroupScheduling,
-	CategoryQuotaExceeded:            GroupScheduling,
-	CategoryAdmissionWebhookBlocking: GroupScheduling,
-	CategoryImagePullFailed:          GroupStartup,
-	CategoryContainerWaiting:         GroupStartup,
-	CategoryInitContainerFailed:      GroupStartup,
-	CategoryCrashLoop:                GroupRuntime,
-	CategoryOOMKilled:                GroupRuntime,
-	CategoryLivenessProbeFail:        GroupRuntime,
-	CategoryReadinessFailed:          GroupRuntime,
-	CategoryWorkloadDegraded:         GroupRuntime,
-	CategoryHighRestart:              GroupRuntime,
-	CategoryJobFailed:                GroupRuntime,
-	CategoryCronJobFailed:            GroupRuntime,
-	CategoryMissingConfigRef:         GroupConfiguration,
-	CategoryPDBBlocksEvictions:       GroupConfiguration,
-	CategoryServiceNoEndpoints:       GroupNetworking,
-	CategoryIngressBackendMissing:    GroupNetworking,
-	CategoryDNSFailure:               GroupNetworking,
-	CategoryNetworkPolicyBlock:       GroupNetworking,
-	CategoryPVCPending:               GroupStorage,
-	CategoryPVCLost:                  GroupStorage,
-	CategoryVolumeMountFailed:        GroupStorage,
-	CategoryVolumeAccessModeConflict: GroupStorage,
-	CategoryRolloutStalled:           GroupScaling,
-	CategoryHPALimitedOrFailed:       GroupScaling,
-	CategoryRBACForbidden:            GroupSecurity,
-	CategoryCertificateNotReady:      GroupSecurity,
-	CategoryPodSecurityViolation:     GroupSecurity,
-	CategoryNodeNotReady:             GroupControlPlane,
-	CategoryOperatorConditionFail:    GroupControlPlane,
-	CategoryGitOpsSyncFailed:         GroupControlPlane,
-	CategoryWebhookBackendDown:       GroupControlPlane,
-	CategoryControlPlaneNotReady:     GroupControlPlane,
-	CategoryMachineNotReady:          GroupControlPlane,
-}
-
-// GroupOf returns the rollup group for a category. Unknown/unmapped → unknown.
-func GroupOf(c Category) CategoryGroup {
-	if g, ok := categoryGroup[c]; ok {
-		return g
-	}
-	return GroupUnknown
-}
 
 // classifyInput is the minimal signal the classifier reads. It mirrors the
 // fields an Issue already carries, so wiring is a field read (no new data).
@@ -162,7 +16,7 @@ type classifyInput struct {
 	LastTerminatedReason string
 }
 
-// Classify maps a detection signal to a user-facing Category. Pure and
+// Classify maps a detection signal to a user-facing issue category. Pure and
 // deterministic — same inputs always yield the same category, so the
 // category-in-issue-id contract stays stable (no oscillation). Grounded in the
 // exact reason vocabulary emitted by the detector layer in internal/k8s and the
@@ -170,28 +24,28 @@ type classifyInput struct {
 //
 // Coverage is intentionally partial: signals without a clean mapping (and
 // categories whose detectors don't exist yet — probes, DNS, network policy,
-// real RBAC-forbidden) fall to CategoryUnknown rather than being force-fit.
-func Classify(in classifyInput) Category {
+// real RBAC-forbidden) fall to unknown rather than being force-fit.
+func Classify(in classifyInput) issuesapi.Category {
 	switch in.Source {
 	case SourceScheduling:
 		switch in.Reason {
 		case "Unschedulable":
-			return CategoryUnschedulable
+			return issuesapi.CategoryUnschedulable
 		case "QuotaExceeded", "LimitRangeViolation":
-			return CategoryQuotaExceeded
+			return issuesapi.CategoryQuotaExceeded
 		case "PodSecurityViolation":
 			// Pod Security admission (built-in PSA) is NOT a webhook — don't
 			// mislabel it as such.
-			return CategoryPodSecurityViolation
+			return issuesapi.CategoryPodSecurityViolation
 		case "WebhookDenied":
-			return CategoryAdmissionWebhookBlocking
+			return issuesapi.CategoryAdmissionWebhookBlocking
 		case "IPExhaustion", "SandboxCreationFailed":
 			// scheduled but stuck creating the sandbox — a startup-stage stall
-			return CategoryContainerWaiting
+			return issuesapi.CategoryContainerWaiting
 		case "VolumeMultiAttach", "VolumeAttach", "VolumeMount":
-			return CategoryVolumeMountFailed
+			return issuesapi.CategoryVolumeMountFailed
 		}
-		return CategoryUnknown
+		return issuesapi.CategoryUnknown
 
 	case SourceMissingRef:
 		// Ingress backend refs are their own category; webhook backends map to
@@ -199,18 +53,18 @@ func Classify(in classifyInput) Category {
 		// config/resource reference.
 		switch in.Reason {
 		case "Missing backend Service", "Missing backend Service port":
-			return CategoryIngressBackendMissing
+			return issuesapi.CategoryIngressBackendMissing
 		case "Missing webhook backend Service":
-			return CategoryWebhookBackendDown
+			return issuesapi.CategoryWebhookBackendDown
 		case "Missing StorageClass":
 			// the dangling ref is a StorageClass, but the user-facing effect is
 			// a PVC that can't provision — surface it under storage.
-			return CategoryPVCPending
+			return issuesapi.CategoryPVCPending
 		}
 		// Missing PVC/ConfigMap/Secret/ServiceAccount/imagePullSecret (Pod),
 		// Missing scaleTargetRef (HPA), Missing headless Service (StatefulSet),
 		// Missing TLS Secret (Ingress), Missing roleRef target (RoleBinding).
-		return CategoryMissingConfigRef
+		return issuesapi.CategoryMissingConfigRef
 
 	case SourceCondition:
 		// Generic CRD .status.conditions[]=False fallback. Discriminate the
@@ -222,101 +76,101 @@ func Classify(in classifyInput) Category {
 			// Order/Challenge are different objects — a not-ready Issuer is a
 			// control-plane condition, not a certificate problem.
 			if in.Kind == "Certificate" {
-				return CategoryCertificateNotReady
+				return issuesapi.CategoryCertificateNotReady
 			}
-			return CategoryOperatorConditionFail
+			return issuesapi.CategoryOperatorConditionFail
 		case strings.Contains(g, "argoproj.io"):
 			switch in.Kind {
 			case "Application":
-				return CategoryGitOpsSyncFailed
+				return issuesapi.CategoryGitOpsSyncFailed
 			case "Rollout":
 				// Progressive-delivery workload, not a sync operation.
-				return CategoryRolloutStalled
+				return issuesapi.CategoryRolloutStalled
 			}
 			// AppProject/ApplicationSet/etc. are control-plane CRDs, not a sync.
-			return CategoryOperatorConditionFail
+			return issuesapi.CategoryOperatorConditionFail
 		default:
-			return CategoryOperatorConditionFail
+			return issuesapi.CategoryOperatorConditionFail
 		}
 
 	case SourceProblem:
 		return classifyProblem(in)
 	}
-	return CategoryUnknown
+	return issuesapi.CategoryUnknown
 }
 
 // classifyProblem handles the broad source=problem channel (radar's per-kind
 // detection). Split out to keep Classify readable.
-func classifyProblem(in classifyInput) Category {
+func classifyProblem(in classifyInput) issuesapi.Category {
 	switch in.Kind {
 	case "Pod":
 		// OOM can show as the current Reason or only in the last-terminated
 		// reason of a now-restarting container; check both.
 		if in.Reason == "OOMKilled" || in.LastTerminatedReason == "OOMKilled" {
-			return CategoryOOMKilled
+			return issuesapi.CategoryOOMKilled
 		}
 		switch in.Reason {
 		case "ImagePullBackOff", "ErrImagePull", "InvalidImageName", "ImageInspectError":
-			return CategoryImagePullFailed
+			return issuesapi.CategoryImagePullFailed
 		case "CrashLoopBackOff":
-			return CategoryCrashLoop
+			return issuesapi.CategoryCrashLoop
 		case "HighRestartCount":
-			return CategoryHighRestart
+			return issuesapi.CategoryHighRestart
 		case "CreateContainerConfigError", "CreateContainerError", "RunContainerError", "Pending", "ContainerCreating":
-			return CategoryContainerWaiting
+			return issuesapi.CategoryContainerWaiting
 		case "Error", "Failed":
 			// a terminated/failed pod that isn't image-pull/OOM/scheduling —
 			// closest runtime bucket is a crash.
-			return CategoryCrashLoop
+			return issuesapi.CategoryCrashLoop
 		}
-		return CategoryUnknown
+		return issuesapi.CategoryUnknown
 
 	case "Service":
 		// "Selector matches no pods" / "0/N selected pods ready" /
 		// "Unresolved named targetPort" all mean: no healthy endpoints.
-		return CategoryServiceNoEndpoints
+		return issuesapi.CategoryServiceNoEndpoints
 
 	case "Deployment", "StatefulSet", "DaemonSet":
 		if in.Reason == "Rollout stuck" {
-			return CategoryRolloutStalled
+			return issuesapi.CategoryRolloutStalled
 		}
 		// Stable reason literal emitted by sharedRWOVolumeConflicts —
 		// a multi-replica Deployment mounting a ReadWriteOnce volume.
 		if in.Reason == "ReadWriteOnce volume shared across replicas" {
-			return CategoryVolumeAccessModeConflict
+			return issuesapi.CategoryVolumeAccessModeConflict
 		}
 		// "{avail}/{desired} available" / "{ready}/{desired} ready" /
 		// "{n} unavailable" — workload under its desired healthy count. The
 		// pod-level root (crashloop/image/etc.) groups under this once owner
 		// grouping lands.
-		return CategoryWorkloadDegraded
+		return issuesapi.CategoryWorkloadDegraded
 
 	case "HorizontalPodAutoscaler":
-		return CategoryHPALimitedOrFailed
+		return issuesapi.CategoryHPALimitedOrFailed
 
 	case "Node":
 		switch in.Reason {
 		case "NotReady", "MemoryPressure", "DiskPressure", "PIDPressure":
-			return CategoryNodeNotReady
+			return issuesapi.CategoryNodeNotReady
 		}
 		// "Cordoned" is an intentional admin action, not a failure → unknown.
-		return CategoryUnknown
+		return issuesapi.CategoryUnknown
 
 	case "PersistentVolumeClaim":
 		switch in.Reason {
 		case "Pending":
-			return CategoryPVCPending
+			return issuesapi.CategoryPVCPending
 		case "Lost":
 			// bound volume gone — a storage failure, not unknown.
-			return CategoryPVCLost
+			return issuesapi.CategoryPVCLost
 		}
-		return CategoryUnknown
+		return issuesapi.CategoryUnknown
 
 	case "PodDisruptionBudget":
 		if in.Reason == "Voluntary evictions blocked" {
-			return CategoryPDBBlocksEvictions
+			return issuesapi.CategoryPDBBlocksEvictions
 		}
-		return CategoryUnknown
+		return issuesapi.CategoryUnknown
 
 	case "Job":
 		// DetectProblems only emits Job problems for genuine failures: a
@@ -324,51 +178,51 @@ func classifyProblem(in classifyInput) Category {
 		// DeadlineExceeded, or the "Failed" fallback) or a stuck-active job
 		// ("Running for … with no completions"). All map to the batch
 		// workload-failure category rather than being discarded.
-		return CategoryJobFailed
+		return issuesapi.CategoryJobFailed
 
 	case "CronJob":
 		// "stale" (no recent run) / "never-scheduled" — the CronJob is not
 		// producing the Jobs it's meant to.
 		switch in.Reason {
 		case "stale", "never-scheduled":
-			return CategoryCronJobFailed
+			return issuesapi.CategoryCronJobFailed
 		}
-		return CategoryUnknown
+		return issuesapi.CategoryUnknown
 
 	case "Application":
 		// ArgoCD Application health/sync failure from DetectGitOpsProblems.
 		// Gate on group so a same-named CRD from another controller can't be
 		// force-fit into the GitOps bucket.
 		if strings.Contains(strings.ToLower(in.APIGroup), "argoproj.io") {
-			return CategoryGitOpsSyncFailed
+			return issuesapi.CategoryGitOpsSyncFailed
 		}
-		return CategoryUnknown
+		return issuesapi.CategoryUnknown
 
 	case "Kustomization", "HelmRelease":
 		// Flux reconciler failure from DetectGitOpsProblems.
 		g := strings.ToLower(in.APIGroup)
 		if g == "kustomize.toolkit.fluxcd.io" || g == "helm.toolkit.fluxcd.io" {
-			return CategoryGitOpsSyncFailed
+			return issuesapi.CategoryGitOpsSyncFailed
 		}
-		return CategoryUnknown
+		return issuesapi.CategoryUnknown
 
 	case "Cluster", "KubeadmControlPlane":
 		// Cluster API control plane (cluster.x-k8s.io / controlplane.
 		// cluster.x-k8s.io). Gate on the group so a same-named CRD from
 		// another controller can't be force-fit.
 		if strings.Contains(strings.ToLower(in.APIGroup), "cluster.x-k8s.io") {
-			return CategoryControlPlaneNotReady
+			return issuesapi.CategoryControlPlaneNotReady
 		}
-		return CategoryUnknown
+		return issuesapi.CategoryUnknown
 
 	case "Machine", "MachineDeployment", "MachineHealthCheck":
 		// Cluster API machine layer — node-backing infra, distinct from the
 		// control plane it forms.
 		if strings.Contains(strings.ToLower(in.APIGroup), "cluster.x-k8s.io") {
-			return CategoryMachineNotReady
+			return issuesapi.CategoryMachineNotReady
 		}
-		return CategoryUnknown
+		return issuesapi.CategoryUnknown
 	}
 
-	return CategoryUnknown
+	return issuesapi.CategoryUnknown
 }

--- a/internal/issues/category_test.go
+++ b/internal/issues/category_test.go
@@ -1,103 +1,107 @@
 package issues
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/skyhook-io/radar/pkg/issuesapi"
+)
 
 func TestClassify(t *testing.T) {
 	cases := []struct {
 		name string
 		in   classifyInput
-		want Category
+		want issuesapi.Category
 	}{
 		// scheduling
-		{"unschedulable", classifyInput{Source: SourceScheduling, Kind: "Pod", Reason: "Unschedulable"}, CategoryUnschedulable},
-		{"quota", classifyInput{Source: SourceScheduling, Kind: "Deployment", Reason: "QuotaExceeded"}, CategoryQuotaExceeded},
-		{"limitrange", classifyInput{Source: SourceScheduling, Kind: "Deployment", Reason: "LimitRangeViolation"}, CategoryQuotaExceeded},
-		{"podsecurity", classifyInput{Source: SourceScheduling, Kind: "Deployment", Reason: "PodSecurityViolation"}, CategoryPodSecurityViolation},
-		{"webhook denied", classifyInput{Source: SourceScheduling, Kind: "StatefulSet", Reason: "WebhookDenied"}, CategoryAdmissionWebhookBlocking},
-		{"ip exhaustion is startup stall", classifyInput{Source: SourceScheduling, Kind: "Pod", Reason: "IPExhaustion"}, CategoryContainerWaiting},
-		{"sandbox failed is startup stall", classifyInput{Source: SourceScheduling, Kind: "Pod", Reason: "SandboxCreationFailed"}, CategoryContainerWaiting},
-		{"volume multiattach", classifyInput{Source: SourceScheduling, Kind: "Pod", Reason: "VolumeMultiAttach"}, CategoryVolumeMountFailed},
-		{"volume mount", classifyInput{Source: SourceScheduling, Kind: "Pod", Reason: "VolumeMount"}, CategoryVolumeMountFailed},
+		{"unschedulable", classifyInput{Source: SourceScheduling, Kind: "Pod", Reason: "Unschedulable"}, issuesapi.CategoryUnschedulable},
+		{"quota", classifyInput{Source: SourceScheduling, Kind: "Deployment", Reason: "QuotaExceeded"}, issuesapi.CategoryQuotaExceeded},
+		{"limitrange", classifyInput{Source: SourceScheduling, Kind: "Deployment", Reason: "LimitRangeViolation"}, issuesapi.CategoryQuotaExceeded},
+		{"podsecurity", classifyInput{Source: SourceScheduling, Kind: "Deployment", Reason: "PodSecurityViolation"}, issuesapi.CategoryPodSecurityViolation},
+		{"webhook denied", classifyInput{Source: SourceScheduling, Kind: "StatefulSet", Reason: "WebhookDenied"}, issuesapi.CategoryAdmissionWebhookBlocking},
+		{"ip exhaustion is startup stall", classifyInput{Source: SourceScheduling, Kind: "Pod", Reason: "IPExhaustion"}, issuesapi.CategoryContainerWaiting},
+		{"sandbox failed is startup stall", classifyInput{Source: SourceScheduling, Kind: "Pod", Reason: "SandboxCreationFailed"}, issuesapi.CategoryContainerWaiting},
+		{"volume multiattach", classifyInput{Source: SourceScheduling, Kind: "Pod", Reason: "VolumeMultiAttach"}, issuesapi.CategoryVolumeMountFailed},
+		{"volume mount", classifyInput{Source: SourceScheduling, Kind: "Pod", Reason: "VolumeMount"}, issuesapi.CategoryVolumeMountFailed},
 
 		// problem / Pod
-		{"image pull backoff", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "ImagePullBackOff"}, CategoryImagePullFailed},
-		{"err image pull", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "ErrImagePull"}, CategoryImagePullFailed},
-		{"crashloop", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "CrashLoopBackOff"}, CategoryCrashLoop},
-		{"oom by reason", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "OOMKilled"}, CategoryOOMKilled},
-		{"oom by last-terminated, crashloop reason", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "CrashLoopBackOff", LastTerminatedReason: "OOMKilled"}, CategoryOOMKilled},
-		{"config error waiting", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "CreateContainerConfigError"}, CategoryContainerWaiting},
-		{"pending pod (non-scheduling)", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "Pending"}, CategoryContainerWaiting},
-		{"errored pod", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "Error"}, CategoryCrashLoop},
-		{"high restart thrash", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "HighRestartCount"}, CategoryHighRestart},
+		{"image pull backoff", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "ImagePullBackOff"}, issuesapi.CategoryImagePullFailed},
+		{"err image pull", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "ErrImagePull"}, issuesapi.CategoryImagePullFailed},
+		{"crashloop", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "CrashLoopBackOff"}, issuesapi.CategoryCrashLoop},
+		{"oom by reason", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "OOMKilled"}, issuesapi.CategoryOOMKilled},
+		{"oom by last-terminated, crashloop reason", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "CrashLoopBackOff", LastTerminatedReason: "OOMKilled"}, issuesapi.CategoryOOMKilled},
+		{"config error waiting", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "CreateContainerConfigError"}, issuesapi.CategoryContainerWaiting},
+		{"pending pod (non-scheduling)", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "Pending"}, issuesapi.CategoryContainerWaiting},
+		{"errored pod", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "Error"}, issuesapi.CategoryCrashLoop},
+		{"high restart thrash", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "HighRestartCount"}, issuesapi.CategoryHighRestart},
 
 		// problem / GitOps reconcilers (DetectGitOpsProblems → SourceProblem)
-		{"argo app degraded", classifyInput{Source: SourceProblem, Kind: "Application", APIGroup: "argoproj.io", Reason: "HealthDegraded"}, CategoryGitOpsSyncFailed},
-		{"argo app outofsync", classifyInput{Source: SourceProblem, Kind: "Application", APIGroup: "argoproj.io", Reason: "OutOfSync"}, CategoryGitOpsSyncFailed},
-		{"flux kustomization problem", classifyInput{Source: SourceProblem, Kind: "Kustomization", APIGroup: "kustomize.toolkit.fluxcd.io", Reason: "ReconciliationFailed"}, CategoryGitOpsSyncFailed},
-		{"flux helmrelease problem", classifyInput{Source: SourceProblem, Kind: "HelmRelease", APIGroup: "helm.toolkit.fluxcd.io", Reason: "InstallFailed"}, CategoryGitOpsSyncFailed},
-		{"flux-looking kustomization group is not gitops", classifyInput{Source: SourceProblem, Kind: "Kustomization", APIGroup: "custom-fluxcd.io", Reason: "ReconciliationFailed"}, CategoryUnknown},
-		{"non-argo Application kind is not gitops", classifyInput{Source: SourceProblem, Kind: "Application", APIGroup: "other.example.com", Reason: "whatever"}, CategoryUnknown},
+		{"argo app degraded", classifyInput{Source: SourceProblem, Kind: "Application", APIGroup: "argoproj.io", Reason: "HealthDegraded"}, issuesapi.CategoryGitOpsSyncFailed},
+		{"argo app outofsync", classifyInput{Source: SourceProblem, Kind: "Application", APIGroup: "argoproj.io", Reason: "OutOfSync"}, issuesapi.CategoryGitOpsSyncFailed},
+		{"flux kustomization problem", classifyInput{Source: SourceProblem, Kind: "Kustomization", APIGroup: "kustomize.toolkit.fluxcd.io", Reason: "ReconciliationFailed"}, issuesapi.CategoryGitOpsSyncFailed},
+		{"flux helmrelease problem", classifyInput{Source: SourceProblem, Kind: "HelmRelease", APIGroup: "helm.toolkit.fluxcd.io", Reason: "InstallFailed"}, issuesapi.CategoryGitOpsSyncFailed},
+		{"flux-looking kustomization group is not gitops", classifyInput{Source: SourceProblem, Kind: "Kustomization", APIGroup: "custom-fluxcd.io", Reason: "ReconciliationFailed"}, issuesapi.CategoryUnknown},
+		{"non-argo Application kind is not gitops", classifyInput{Source: SourceProblem, Kind: "Application", APIGroup: "other.example.com", Reason: "whatever"}, issuesapi.CategoryUnknown},
 
 		// argo Rollout is progressive delivery, NOT a sync failure
-		{"argo rollout condition is rollout_stalled", classifyInput{Source: SourceCondition, Kind: "Rollout", APIGroup: "argoproj.io", Reason: "Ready: ProgressDeadlineExceeded"}, CategoryRolloutStalled},
+		{"argo rollout condition is rollout_stalled", classifyInput{Source: SourceCondition, Kind: "Rollout", APIGroup: "argoproj.io", Reason: "Ready: ProgressDeadlineExceeded"}, issuesapi.CategoryRolloutStalled},
 
 		// problem / workloads
-		{"deploy degraded", classifyInput{Source: SourceProblem, Kind: "Deployment", Reason: "3/5 available"}, CategoryWorkloadDegraded},
-		{"deploy rollout stuck", classifyInput{Source: SourceProblem, Kind: "Deployment", Reason: "Rollout stuck"}, CategoryRolloutStalled},
-		{"statefulset degraded", classifyInput{Source: SourceProblem, Kind: "StatefulSet", Reason: "2/3 ready"}, CategoryWorkloadDegraded},
-		{"daemonset degraded", classifyInput{Source: SourceProblem, Kind: "DaemonSet", Reason: "1 unavailable"}, CategoryWorkloadDegraded},
+		{"deploy degraded", classifyInput{Source: SourceProblem, Kind: "Deployment", Reason: "3/5 available"}, issuesapi.CategoryWorkloadDegraded},
+		{"deploy rollout stuck", classifyInput{Source: SourceProblem, Kind: "Deployment", Reason: "Rollout stuck"}, issuesapi.CategoryRolloutStalled},
+		{"statefulset degraded", classifyInput{Source: SourceProblem, Kind: "StatefulSet", Reason: "2/3 ready"}, issuesapi.CategoryWorkloadDegraded},
+		{"daemonset degraded", classifyInput{Source: SourceProblem, Kind: "DaemonSet", Reason: "1 unavailable"}, issuesapi.CategoryWorkloadDegraded},
 
 		// problem / service
-		{"service no pods", classifyInput{Source: SourceProblem, Kind: "Service", Reason: "Selector matches no pods"}, CategoryServiceNoEndpoints},
-		{"service 0 ready", classifyInput{Source: SourceProblem, Kind: "Service", Reason: "0/3 selected pods ready"}, CategoryServiceNoEndpoints},
+		{"service no pods", classifyInput{Source: SourceProblem, Kind: "Service", Reason: "Selector matches no pods"}, issuesapi.CategoryServiceNoEndpoints},
+		{"service 0 ready", classifyInput{Source: SourceProblem, Kind: "Service", Reason: "0/3 selected pods ready"}, issuesapi.CategoryServiceNoEndpoints},
 
 		// problem / hpa, node, pvc
-		{"hpa maxed", classifyInput{Source: SourceProblem, Kind: "HorizontalPodAutoscaler", Reason: "maxed"}, CategoryHPALimitedOrFailed},
-		{"node notready", classifyInput{Source: SourceProblem, Kind: "Node", Reason: "NotReady"}, CategoryNodeNotReady},
-		{"node mempressure", classifyInput{Source: SourceProblem, Kind: "Node", Reason: "MemoryPressure"}, CategoryNodeNotReady},
-		{"node cordoned is intentional", classifyInput{Source: SourceProblem, Kind: "Node", Reason: "Cordoned"}, CategoryUnknown},
-		{"pvc pending", classifyInput{Source: SourceProblem, Kind: "PersistentVolumeClaim", Reason: "Pending"}, CategoryPVCPending},
-		{"pvc lost is storage", classifyInput{Source: SourceProblem, Kind: "PersistentVolumeClaim", Reason: "Lost"}, CategoryPVCLost},
-		{"pdb blocks evictions", classifyInput{Source: SourceProblem, Kind: "PodDisruptionBudget", Reason: "Voluntary evictions blocked"}, CategoryPDBBlocksEvictions},
+		{"hpa maxed", classifyInput{Source: SourceProblem, Kind: "HorizontalPodAutoscaler", Reason: "maxed"}, issuesapi.CategoryHPALimitedOrFailed},
+		{"node notready", classifyInput{Source: SourceProblem, Kind: "Node", Reason: "NotReady"}, issuesapi.CategoryNodeNotReady},
+		{"node mempressure", classifyInput{Source: SourceProblem, Kind: "Node", Reason: "MemoryPressure"}, issuesapi.CategoryNodeNotReady},
+		{"node cordoned is intentional", classifyInput{Source: SourceProblem, Kind: "Node", Reason: "Cordoned"}, issuesapi.CategoryUnknown},
+		{"pvc pending", classifyInput{Source: SourceProblem, Kind: "PersistentVolumeClaim", Reason: "Pending"}, issuesapi.CategoryPVCPending},
+		{"pvc lost is storage", classifyInput{Source: SourceProblem, Kind: "PersistentVolumeClaim", Reason: "Lost"}, issuesapi.CategoryPVCLost},
+		{"pdb blocks evictions", classifyInput{Source: SourceProblem, Kind: "PodDisruptionBudget", Reason: "Voluntary evictions blocked"}, issuesapi.CategoryPDBBlocksEvictions},
 
 		// problem / batch (Job/CronJob)
-		{"job failed condition", classifyInput{Source: SourceProblem, Kind: "Job", Reason: "BackoffLimitExceeded"}, CategoryJobFailed},
-		{"job failed fallback", classifyInput{Source: SourceProblem, Kind: "Job", Reason: "Failed"}, CategoryJobFailed},
-		{"job stuck active", classifyInput{Source: SourceProblem, Kind: "Job", Reason: "Running for 3h with no completions"}, CategoryJobFailed},
-		{"cronjob stale", classifyInput{Source: SourceProblem, Kind: "CronJob", Reason: "stale"}, CategoryCronJobFailed},
-		{"cronjob never scheduled", classifyInput{Source: SourceProblem, Kind: "CronJob", Reason: "never-scheduled"}, CategoryCronJobFailed},
+		{"job failed condition", classifyInput{Source: SourceProblem, Kind: "Job", Reason: "BackoffLimitExceeded"}, issuesapi.CategoryJobFailed},
+		{"job failed fallback", classifyInput{Source: SourceProblem, Kind: "Job", Reason: "Failed"}, issuesapi.CategoryJobFailed},
+		{"job stuck active", classifyInput{Source: SourceProblem, Kind: "Job", Reason: "Running for 3h with no completions"}, issuesapi.CategoryJobFailed},
+		{"cronjob stale", classifyInput{Source: SourceProblem, Kind: "CronJob", Reason: "stale"}, issuesapi.CategoryCronJobFailed},
+		{"cronjob never scheduled", classifyInput{Source: SourceProblem, Kind: "CronJob", Reason: "never-scheduled"}, issuesapi.CategoryCronJobFailed},
 
 		// missing_ref
-		{"missing configmap", classifyInput{Source: SourceMissingRef, Kind: "Pod", Reason: "Missing ConfigMap"}, CategoryMissingConfigRef},
-		{"missing secret", classifyInput{Source: SourceMissingRef, Kind: "Pod", Reason: "Missing Secret"}, CategoryMissingConfigRef},
-		{"missing pvc", classifyInput{Source: SourceMissingRef, Kind: "Pod", Reason: "Missing PVC"}, CategoryMissingConfigRef},
-		{"missing sa", classifyInput{Source: SourceMissingRef, Kind: "Pod", Reason: "Missing ServiceAccount"}, CategoryMissingConfigRef},
-		{"ingress backend missing", classifyInput{Source: SourceMissingRef, Kind: "Ingress", APIGroup: "networking.k8s.io", Reason: "Missing backend Service"}, CategoryIngressBackendMissing},
-		{"ingress tls secret is config", classifyInput{Source: SourceMissingRef, Kind: "Ingress", APIGroup: "networking.k8s.io", Reason: "Missing TLS Secret"}, CategoryMissingConfigRef},
-		{"webhook backend down", classifyInput{Source: SourceMissingRef, Kind: "ValidatingWebhookConfiguration", APIGroup: "admissionregistration.k8s.io", Reason: "Missing webhook backend Service"}, CategoryWebhookBackendDown},
-		{"missing storageclass is pvc pending", classifyInput{Source: SourceMissingRef, Kind: "PersistentVolumeClaim", Reason: "Missing StorageClass"}, CategoryPVCPending},
-		{"missing roleref is config", classifyInput{Source: SourceMissingRef, Kind: "RoleBinding", APIGroup: "rbac.authorization.k8s.io", Reason: "Missing roleRef target"}, CategoryMissingConfigRef},
+		{"missing configmap", classifyInput{Source: SourceMissingRef, Kind: "Pod", Reason: "Missing ConfigMap"}, issuesapi.CategoryMissingConfigRef},
+		{"missing secret", classifyInput{Source: SourceMissingRef, Kind: "Pod", Reason: "Missing Secret"}, issuesapi.CategoryMissingConfigRef},
+		{"missing pvc", classifyInput{Source: SourceMissingRef, Kind: "Pod", Reason: "Missing PVC"}, issuesapi.CategoryMissingConfigRef},
+		{"missing sa", classifyInput{Source: SourceMissingRef, Kind: "Pod", Reason: "Missing ServiceAccount"}, issuesapi.CategoryMissingConfigRef},
+		{"ingress backend missing", classifyInput{Source: SourceMissingRef, Kind: "Ingress", APIGroup: "networking.k8s.io", Reason: "Missing backend Service"}, issuesapi.CategoryIngressBackendMissing},
+		{"ingress tls secret is config", classifyInput{Source: SourceMissingRef, Kind: "Ingress", APIGroup: "networking.k8s.io", Reason: "Missing TLS Secret"}, issuesapi.CategoryMissingConfigRef},
+		{"webhook backend down", classifyInput{Source: SourceMissingRef, Kind: "ValidatingWebhookConfiguration", APIGroup: "admissionregistration.k8s.io", Reason: "Missing webhook backend Service"}, issuesapi.CategoryWebhookBackendDown},
+		{"missing storageclass is pvc pending", classifyInput{Source: SourceMissingRef, Kind: "PersistentVolumeClaim", Reason: "Missing StorageClass"}, issuesapi.CategoryPVCPending},
+		{"missing roleref is config", classifyInput{Source: SourceMissingRef, Kind: "RoleBinding", APIGroup: "rbac.authorization.k8s.io", Reason: "Missing roleRef target"}, issuesapi.CategoryMissingConfigRef},
 
 		// condition (CRD fallback) — discriminated by API group
-		{"argo sync failed", classifyInput{Source: SourceCondition, Kind: "Application", APIGroup: "argoproj.io", Reason: "Synced: ComparisonError"}, CategoryGitOpsSyncFailed},
-		{"flux helmrelease condition fallback is not sync", classifyInput{Source: SourceCondition, Kind: "HelmRelease", APIGroup: "helm.toolkit.fluxcd.io", Reason: "Ready=False"}, CategoryOperatorConditionFail},
-		{"flux-looking helmrelease group is not sync", classifyInput{Source: SourceCondition, Kind: "HelmRelease", APIGroup: "custom-fluxcd.io", Reason: "Ready=False"}, CategoryOperatorConditionFail},
-		{"cert-manager not ready", classifyInput{Source: SourceCondition, Kind: "Certificate", APIGroup: "cert-manager.io", Reason: "Ready: DoesNotExist"}, CategoryCertificateNotReady},
-		{"cert-manager Issuer is NOT certificate_not_ready", classifyInput{Source: SourceCondition, Kind: "ClusterIssuer", APIGroup: "cert-manager.io", Reason: "Ready=False"}, CategoryOperatorConditionFail},
-		{"generic operator condition", classifyInput{Source: SourceCondition, Kind: "Foo", APIGroup: "example.com", Reason: "Ready=False"}, CategoryOperatorConditionFail},
+		{"argo sync failed", classifyInput{Source: SourceCondition, Kind: "Application", APIGroup: "argoproj.io", Reason: "Synced: ComparisonError"}, issuesapi.CategoryGitOpsSyncFailed},
+		{"flux helmrelease condition fallback is not sync", classifyInput{Source: SourceCondition, Kind: "HelmRelease", APIGroup: "helm.toolkit.fluxcd.io", Reason: "Ready=False"}, issuesapi.CategoryOperatorConditionFail},
+		{"flux-looking helmrelease group is not sync", classifyInput{Source: SourceCondition, Kind: "HelmRelease", APIGroup: "custom-fluxcd.io", Reason: "Ready=False"}, issuesapi.CategoryOperatorConditionFail},
+		{"cert-manager not ready", classifyInput{Source: SourceCondition, Kind: "Certificate", APIGroup: "cert-manager.io", Reason: "Ready: DoesNotExist"}, issuesapi.CategoryCertificateNotReady},
+		{"cert-manager Issuer is NOT certificate_not_ready", classifyInput{Source: SourceCondition, Kind: "ClusterIssuer", APIGroup: "cert-manager.io", Reason: "Ready=False"}, issuesapi.CategoryOperatorConditionFail},
+		{"generic operator condition", classifyInput{Source: SourceCondition, Kind: "Foo", APIGroup: "example.com", Reason: "Ready=False"}, issuesapi.CategoryOperatorConditionFail},
 		// Flux source CRDs are NOT sync failures — they fall to operator condition.
-		{"flux source repo is not sync", classifyInput{Source: SourceCondition, Kind: "GitRepository", APIGroup: "source.toolkit.fluxcd.io", Reason: "Ready: GitOperationFailed"}, CategoryOperatorConditionFail},
-		{"argo non-app CRD is not sync", classifyInput{Source: SourceCondition, Kind: "AppProject", APIGroup: "argoproj.io", Reason: "Ready=False"}, CategoryOperatorConditionFail},
+		{"flux source repo is not sync", classifyInput{Source: SourceCondition, Kind: "GitRepository", APIGroup: "source.toolkit.fluxcd.io", Reason: "Ready: GitOperationFailed"}, issuesapi.CategoryOperatorConditionFail},
+		{"argo non-app CRD is not sync", classifyInput{Source: SourceCondition, Kind: "AppProject", APIGroup: "argoproj.io", Reason: "Ready=False"}, issuesapi.CategoryOperatorConditionFail},
 
 		// CAPI: control-plane vs machine layer, gated on the CAPI group.
-		{"capi cluster failed", classifyInput{Source: SourceProblem, Kind: "Cluster", APIGroup: "cluster.x-k8s.io", Reason: "Cluster in Failed phase"}, CategoryControlPlaneNotReady},
-		{"capi control plane not ready", classifyInput{Source: SourceProblem, Kind: "KubeadmControlPlane", APIGroup: "controlplane.cluster.x-k8s.io", Reason: "Ready=False"}, CategoryControlPlaneNotReady},
-		{"capi machine failed", classifyInput{Source: SourceProblem, Kind: "Machine", APIGroup: "cluster.x-k8s.io", Reason: "Machine in Failed phase"}, CategoryMachineNotReady},
-		{"capi machinedeployment", classifyInput{Source: SourceProblem, Kind: "MachineDeployment", APIGroup: "cluster.x-k8s.io", Reason: "Ready=False"}, CategoryMachineNotReady},
-		{"non-capi Cluster kind is not control plane", classifyInput{Source: SourceProblem, Kind: "Cluster", APIGroup: "postgresql.cnpg.io", Reason: "whatever"}, CategoryUnknown},
+		{"capi cluster failed", classifyInput{Source: SourceProblem, Kind: "Cluster", APIGroup: "cluster.x-k8s.io", Reason: "Cluster in Failed phase"}, issuesapi.CategoryControlPlaneNotReady},
+		{"capi control plane not ready", classifyInput{Source: SourceProblem, Kind: "KubeadmControlPlane", APIGroup: "controlplane.cluster.x-k8s.io", Reason: "Ready=False"}, issuesapi.CategoryControlPlaneNotReady},
+		{"capi machine failed", classifyInput{Source: SourceProblem, Kind: "Machine", APIGroup: "cluster.x-k8s.io", Reason: "Machine in Failed phase"}, issuesapi.CategoryMachineNotReady},
+		{"capi machinedeployment", classifyInput{Source: SourceProblem, Kind: "MachineDeployment", APIGroup: "cluster.x-k8s.io", Reason: "Ready=False"}, issuesapi.CategoryMachineNotReady},
+		{"non-capi Cluster kind is not control plane", classifyInput{Source: SourceProblem, Kind: "Cluster", APIGroup: "postgresql.cnpg.io", Reason: "whatever"}, issuesapi.CategoryUnknown},
 		// new pod waiting reasons (bad image tag / container create)
-		{"invalid image name", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "InvalidImageName"}, CategoryImagePullFailed},
-		{"run container error", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "RunContainerError"}, CategoryContainerWaiting},
+		{"invalid image name", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "InvalidImageName"}, issuesapi.CategoryImagePullFailed},
+		{"run container error", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "RunContainerError"}, issuesapi.CategoryContainerWaiting},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -106,35 +110,12 @@ func TestClassify(t *testing.T) {
 			}
 			// Every category Classify emits must have a group rollup — a category
 			// wired into Classify but missing from categoryGroup rolls up to
-			// GroupUnknown silently. Asserted here, at the (mandatory) Classify
-			// case, because TestGroupOf's map-iteration can't see a category
-			// that's absent from the map.
-			if tc.want != CategoryUnknown && GroupOf(tc.want) == GroupUnknown {
-				t.Errorf("category %q has no categoryGroup rollup (→ GroupUnknown)", tc.want)
+			// issuesapi.GroupUnknown silently. Asserted here, at the (mandatory) Classify
+			// case, because the shared rollup table's own test cannot see a category
+			// that Classify emits but the table omits.
+			if tc.want != issuesapi.CategoryUnknown && issuesapi.GroupOf(tc.want) == issuesapi.GroupUnknown {
+				t.Errorf("category %q has no categoryGroup rollup (→ issuesapi.GroupUnknown)", tc.want)
 			}
 		})
-	}
-}
-
-// TestGroupOf pins the category→group rollup and that every mapped category has
-// a group (no silent GroupUnknown for a real category).
-func TestGroupOf(t *testing.T) {
-	if got := GroupOf(CategoryImagePullFailed); got != GroupStartup {
-		t.Errorf("image_pull_failed group = %q, want startup", got)
-	}
-	if got := GroupOf(CategoryUnschedulable); got != GroupScheduling {
-		t.Errorf("unschedulable group = %q, want scheduling", got)
-	}
-	if got := GroupOf(CategoryGitOpsSyncFailed); got != GroupControlPlane {
-		t.Errorf("gitops_sync_failed group = %q, want control_plane", got)
-	}
-	if got := GroupOf(CategoryUnknown); got != GroupUnknown {
-		t.Errorf("unknown group = %q, want unknown", got)
-	}
-	// Every category constant that Classify can return must map to a non-unknown group.
-	for c := range categoryGroup {
-		if categoryGroup[c] == GroupUnknown {
-			t.Errorf("category %q maps to GroupUnknown", c)
-		}
 	}
 }

--- a/internal/issues/compose.go
+++ b/internal/issues/compose.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/pkg/issuesapi"
 )
 
 // Provider abstracts the data sources Compose needs. Implementations
@@ -71,15 +72,7 @@ type ComposeStats struct {
 // them (and the hub mirrors one shape). Visibility and NarrowHint are set by the
 // caller — visibility is server-side RBAC data; NarrowHint is the MCP steering
 // string for a capped result.
-type ListResponse struct {
-	Issues            []Issue `json:"issues"`
-	Total             int     `json:"total"`
-	TotalMatched      int     `json:"total_matched"`
-	FilterErrors      int     `json:"filter_errors,omitempty"`
-	FilterErrorSample string  `json:"filter_error_sample,omitempty"`
-	Visibility        any     `json:"visibility,omitempty"`
-	NarrowHint        string  `json:"narrowHint,omitempty"`
-}
+type ListResponse = issuesapi.Response
 
 // NewListResponse fills the shared fields from a Compose result. out==nil
 // becomes [] so the wire always carries a JSON array, never null.

--- a/internal/issues/dedupe.go
+++ b/internal/issues/dedupe.go
@@ -1,5 +1,7 @@
 package issues
 
+import "github.com/skyhook-io/radar/pkg/issuesapi"
+
 // dedupePodSchedulingOverProblem drops the generic problem-source row for a
 // Pod when the scheduling source emitted one for the same Pod. A pod stuck
 // post-bind (ContainerCreating on a CNI/volume stall) trips both: DetectProblems
@@ -45,27 +47,27 @@ func subjectRef(i Issue) Ref {
 // rollout_stalled) redundant. A degraded Deployment with crashlooping pods is
 // ONE incident — the crashloop — not two; keeping both is the inverse of
 // "50 pods = 1 row".
-var childCategories = map[Category]bool{
-	CategoryCrashLoop:           true,
-	CategoryHighRestart:         true,
-	CategoryImagePullFailed:     true,
-	CategoryOOMKilled:           true,
-	CategoryContainerWaiting:    true,
-	CategoryInitContainerFailed: true,
-	CategoryLivenessProbeFail:   true,
-	CategoryReadinessFailed:     true,
-	CategoryUnschedulable:       true,
-	CategoryQuotaExceeded:       true,
-	CategoryMissingConfigRef:    true,
-	CategoryVolumeMountFailed:   true,
-	CategoryPVCPending:          true,
+var childCategories = map[issuesapi.Category]bool{
+	issuesapi.CategoryCrashLoop:           true,
+	issuesapi.CategoryHighRestart:         true,
+	issuesapi.CategoryImagePullFailed:     true,
+	issuesapi.CategoryOOMKilled:           true,
+	issuesapi.CategoryContainerWaiting:    true,
+	issuesapi.CategoryInitContainerFailed: true,
+	issuesapi.CategoryLivenessProbeFail:   true,
+	issuesapi.CategoryReadinessFailed:     true,
+	issuesapi.CategoryUnschedulable:       true,
+	issuesapi.CategoryQuotaExceeded:       true,
+	issuesapi.CategoryMissingConfigRef:    true,
+	issuesapi.CategoryVolumeMountFailed:   true,
+	issuesapi.CategoryPVCPending:          true,
 }
 
 // parentRollupCategories are the workload-level summaries that should be
 // suppressed when a more-specific child symptom exists for the same subject.
-var parentRollupCategories = map[Category]bool{
-	CategoryWorkloadDegraded: true,
-	CategoryRolloutStalled:   true,
+var parentRollupCategories = map[issuesapi.Category]bool{
+	issuesapi.CategoryWorkloadDegraded: true,
+	issuesapi.CategoryRolloutStalled:   true,
 }
 
 // dedupeWorkloadDegradedOverChild drops the parent workload rollup row

--- a/internal/issues/grouping.go
+++ b/internal/issues/grouping.go
@@ -3,6 +3,8 @@ package issues
 import (
 	"sort"
 	"strings"
+
+	"github.com/skyhook-io/radar/pkg/issuesapi"
 )
 
 // RelatedIssues returns the grouped issues whose subject OR an affected member
@@ -49,13 +51,7 @@ const maxInlineMembers = 10
 // Affected counts the underlying resources folded into a grouped issue, by
 // kind bucket. Empty for single-resource issues (no fan-out) — there the
 // subject row already says everything.
-type Affected struct {
-	Pods      int `json:"pods,omitempty"`
-	Workloads int `json:"workloads,omitempty"`
-	Services  int `json:"services,omitempty"`
-	PVCs      int `json:"pvcs,omitempty"`
-	Nodes     int `json:"nodes,omitempty"`
-}
+type Affected = issuesapi.Affected
 
 // GroupIssues folds flat issue rows into the public grouped model: one row
 // per shared ID (subject + category). The flat rows are the evidence; a

--- a/internal/issues/identity.go
+++ b/internal/issues/identity.go
@@ -1,22 +1,9 @@
 package issues
 
 import (
+	"github.com/skyhook-io/radar/pkg/issuesapi"
 	"github.com/skyhook-io/radar/pkg/resourceid"
 	"github.com/skyhook-io/radar/pkg/subject"
-)
-
-// Scope aliases the shared subject.Scope — issues consumes the unified resolver's
-// scope enum so issues, topology, and checks can't drift on it. The constants are
-// re-exported so existing issues.Scope* references keep working.
-type Scope = subject.Scope
-
-const (
-	ScopeUnknown  = subject.ScopeUnknown
-	ScopeWorkload = subject.ScopeWorkload
-	ScopeService  = subject.ScopeService
-	ScopeIngress  = subject.ScopeIngress
-	ScopePVC      = subject.ScopePVC
-	ScopeNode     = subject.ScopeNode
 )
 
 // resourceKey is the canonical group|kind|namespace|name key, shared with
@@ -37,8 +24,9 @@ func enrichIdentity(i *Issue) {
 	if i.Owner.Kind != "" {
 		subjRef = i.Owner
 	}
-	i.GroupingScope = subject.ScopeForKind(subjRef.Kind)
-	i.ID = subject.StableID(i.GroupingScope, resourceKey(subjRef.Group, subjRef.Kind, subjRef.Namespace, subjRef.Name), discriminator(i))
+	scope := subject.ScopeForKind(subjRef.Kind)
+	i.GroupingScope = issuesapi.Scope(scope)
+	i.ID = subject.StableID(scope, resourceKey(subjRef.Group, subjRef.Kind, subjRef.Namespace, subjRef.Name), discriminator(i))
 }
 
 // discriminator is the cause portion of the issue ID. Category alone is the
@@ -54,7 +42,7 @@ func discriminator(i *Issue) string {
 	switch {
 	case i.Fingerprint != "":
 		return string(i.Category) + "\x00" + i.Fingerprint
-	case i.Category == CategoryUnknown:
+	case i.Category == issuesapi.CategoryUnknown:
 		return string(i.Category) + "\x00" + string(i.Source) + "\x00" + i.Reason
 	default:
 		return string(i.Category)

--- a/internal/issues/identity_test.go
+++ b/internal/issues/identity_test.go
@@ -3,6 +3,7 @@ package issues
 import (
 	"testing"
 
+	"github.com/skyhook-io/radar/pkg/issuesapi"
 	"github.com/skyhook-io/radar/pkg/subject"
 )
 
@@ -20,10 +21,10 @@ func TestEnrichIdentity_SubjectIsOwnerElseSelf(t *testing.T) {
 	}
 	classifyIssue(&pod)
 	enrichIdentity(&pod)
-	if pod.GroupingScope != ScopeWorkload {
+	if pod.GroupingScope != issuesapi.ScopeWorkload {
 		t.Errorf("scope = %q, want workload", pod.GroupingScope)
 	}
-	if want := subject.StableID(ScopeWorkload, resourceKey("apps", "Deployment", "ns", "web"), string(CategoryImagePullFailed)); pod.ID != want {
+	if want := subject.StableID(subject.Scope(issuesapi.ScopeWorkload), resourceKey("apps", "Deployment", "ns", "web"), string(issuesapi.CategoryImagePullFailed)); pod.ID != want {
 		t.Errorf("ID = %q, want owner-keyed %q", pod.ID, want)
 	}
 
@@ -31,7 +32,7 @@ func TestEnrichIdentity_SubjectIsOwnerElseSelf(t *testing.T) {
 	solo := Issue{Source: SourceProblem, Kind: "Pod", Namespace: "ns", Name: "solo", Reason: "CrashLoopBackOff"}
 	classifyIssue(&solo)
 	enrichIdentity(&solo)
-	if want := subject.StableID(ScopeWorkload, resourceKey("", "Pod", "ns", "solo"), string(CategoryCrashLoop)); solo.ID != want {
+	if want := subject.StableID(subject.Scope(issuesapi.ScopeWorkload), resourceKey("", "Pod", "ns", "solo"), string(issuesapi.CategoryCrashLoop)); solo.ID != want {
 		t.Errorf("standalone pod ID = %q, want self-keyed %q", solo.ID, want)
 	}
 }
@@ -51,7 +52,7 @@ func TestEnrichIdentity_DistinctCausesDoNotCollapse(t *testing.T) {
 	}
 	cm := mk("Missing ConfigMap", `Missing ConfigMap|references ConfigMap "foo"`)
 	sec := mk("Missing Secret", `Missing Secret|references Secret "bar"`)
-	if cm.Category != CategoryMissingConfigRef || sec.Category != CategoryMissingConfigRef {
+	if cm.Category != issuesapi.CategoryMissingConfigRef || sec.Category != issuesapi.CategoryMissingConfigRef {
 		t.Fatalf("precondition: both should classify missing_config_ref, got %q/%q", cm.Category, sec.Category)
 	}
 	if cm.ID == sec.ID {
@@ -66,7 +67,7 @@ func TestEnrichIdentity_DistinctCausesDoNotCollapse(t *testing.T) {
 	cl := Issue{Source: SourceProblem, Kind: "Pod", Namespace: "ns", Name: "web-x", Reason: "CrashLoopBackOff", Owner: owner}
 	classifyIssue(&cl)
 	enrichIdentity(&cl)
-	if want := subject.StableID(ScopeWorkload, resourceKey("apps", "Deployment", "ns", "web"), string(CategoryCrashLoop)); cl.ID != want {
+	if want := subject.StableID(subject.Scope(issuesapi.ScopeWorkload), resourceKey("apps", "Deployment", "ns", "web"), string(issuesapi.CategoryCrashLoop)); cl.ID != want {
 		t.Errorf("single-cause category must stay category-keyed (no re-key): %q want %q", cl.ID, want)
 	}
 }

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/pkg/issuesapi"
 )
 
 // fakeProvider — minimal Provider for unit testing. Each field
@@ -86,12 +87,12 @@ func TestCompose_PopulatesCategoryAndGroup(t *testing.T) {
 	}
 	checks := []struct {
 		name     string
-		category Category
-		group    CategoryGroup
+		category issuesapi.Category
+		group    issuesapi.CategoryGroup
 	}{
-		{"img", CategoryImagePullFailed, GroupStartup},
-		{"sched", CategoryUnschedulable, GroupScheduling},
-		{"ref", CategoryMissingConfigRef, GroupConfiguration},
+		{"img", issuesapi.CategoryImagePullFailed, issuesapi.GroupStartup},
+		{"sched", issuesapi.CategoryUnschedulable, issuesapi.GroupScheduling},
+		{"ref", issuesapi.CategoryMissingConfigRef, issuesapi.GroupConfiguration},
 	}
 	for _, c := range checks {
 		if got[c.name].Category != c.category || got[c.name].CategoryGroup != c.group {
@@ -125,7 +126,7 @@ func TestCompose_GroupsMemberPodsUnderOwner(t *testing.T) {
 	if want := (Ref{Group: "apps", Kind: "Deployment", Namespace: "ns", Name: "web"}); got["web-a"].Owner != want {
 		t.Errorf("owner not propagated: got %+v, want %+v", got["web-a"].Owner, want)
 	}
-	if got["web-a"].GroupingScope != ScopeWorkload {
+	if got["web-a"].GroupingScope != issuesapi.ScopeWorkload {
 		t.Errorf("scope = %q, want workload", got["web-a"].GroupingScope)
 	}
 }
@@ -237,10 +238,10 @@ func TestCompose_SuppressesWorkloadDegradedWhenChildSymptomExists(t *testing.T) 
 
 	var sawDegraded, sawCrashloop bool
 	for _, i := range out {
-		if i.Category == CategoryWorkloadDegraded {
+		if i.Category == issuesapi.CategoryWorkloadDegraded {
 			sawDegraded = true
 		}
-		if i.Category == CategoryCrashLoop {
+		if i.Category == issuesapi.CategoryCrashLoop {
 			sawCrashloop = true
 		}
 	}
@@ -270,11 +271,11 @@ func TestCompose_KeepsCriticalParentWhenOnlyChildIsWarning(t *testing.T) {
 	var sawDegraded, sawChild bool
 	var degradedSev Severity
 	for _, i := range out {
-		if i.Category == CategoryWorkloadDegraded {
+		if i.Category == issuesapi.CategoryWorkloadDegraded {
 			sawDegraded = true
 			degradedSev = i.Severity
 		}
-		if i.Category == CategoryContainerWaiting {
+		if i.Category == issuesapi.CategoryContainerWaiting {
 			sawChild = true
 		}
 	}
@@ -303,7 +304,7 @@ func TestCompose_KeepsWorkloadDegradedWhenNoChildSymptom(t *testing.T) {
 	out := Compose(p, Filters{})
 	var sawDegraded bool
 	for _, i := range out {
-		if i.Kind == "Deployment" && i.Name == "web" && i.Category == CategoryWorkloadDegraded {
+		if i.Kind == "Deployment" && i.Name == "web" && i.Category == issuesapi.CategoryWorkloadDegraded {
 			sawDegraded = true
 		}
 	}
@@ -322,7 +323,7 @@ func TestCompose_SuppressesRolloutStalledWhenChildSymptomExists(t *testing.T) {
 	}
 	out := Compose(p, Filters{})
 	for _, i := range out {
-		if i.Category == CategoryRolloutStalled {
+		if i.Category == issuesapi.CategoryRolloutStalled {
 			t.Errorf("rollout_stalled must be suppressed when a child symptom exists: %+v", out)
 		}
 	}

--- a/internal/issues/normalize.go
+++ b/internal/issues/normalize.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/pkg/issuesapi"
 	"github.com/skyhook-io/radar/pkg/resourceid"
 )
 
@@ -83,7 +84,7 @@ func classifyIssue(i *Issue) {
 		Reason:               i.Reason,
 		LastTerminatedReason: i.LastTerminatedReason,
 	})
-	i.CategoryGroup = GroupOf(i.Category)
+	i.CategoryGroup = issuesapi.GroupOf(i.Category)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/issues/types.go
+++ b/internal/issues/types.go
@@ -29,9 +29,7 @@
 // compose.go) — the issue stream is "what's broken now", not an audit.
 package issues
 
-import (
-	"time"
-)
+import "github.com/skyhook-io/radar/pkg/issuesapi"
 
 // Severity is the normalized issue severity. The public Issues contract is
 // critical|warning only:
@@ -45,35 +43,30 @@ import (
 // singleton-StatefulSet headless-DNS trivia) are DROPPED at the Problem→Issue
 // boundary in Compose and never become Issues — they belong to audit/posture,
 // not the live "what's broken now" stream.
-type Severity string
+type Severity = issuesapi.Severity
 
 const (
-	SeverityCritical Severity = "critical"
-	SeverityWarning  Severity = "warning"
+	SeverityCritical = issuesapi.SeverityCritical
+	SeverityWarning  = issuesapi.SeverityWarning
 )
 
 // Source records which underlying detection channel emitted this issue.
 // It is an OUTPUT label (for SPA copy that explains why a row appeared,
 // and as a CEL filter binding), not an input filter — issues composes all
 // four sources unconditionally; detection provenance is not a triage axis.
-type Source string
+type Source = issuesapi.Source
 
 const (
-	SourceProblem    Source = "problem"     // radar's hardcoded per-kind detection
-	SourceMissingRef Source = "missing_ref" // dangling-ref detection (Pod→missing PVC/CM/Secret/SA, HPA→missing target, Ingress→missing backend, etc.)
-	SourceScheduling Source = "scheduling"  // placement/admission/post-bind failures (unschedulable, quota/PodSecurity/webhook, CNI/volume)
-	SourceCondition  Source = "condition"   // generic CRD .status.conditions[].status=False fallback
+	SourceProblem    = issuesapi.SourceProblem
+	SourceMissingRef = issuesapi.SourceMissingRef
+	SourceScheduling = issuesapi.SourceScheduling
+	SourceCondition  = issuesapi.SourceCondition
 )
 
 // Ref is a lightweight resource reference for the grouping subject and
 // owner pointers. Group is the API group (empty for core) — carried so
 // owner/affected deep-links can disambiguate CRDs from core kinds.
-type Ref struct {
-	Group     string `json:"group,omitempty"`
-	Kind      string `json:"kind"`
-	Namespace string `json:"namespace,omitempty"`
-	Name      string `json:"name"`
-}
+type Ref = issuesapi.Ref
 
 // Issue is the unified cluster-health record.
 //
@@ -84,63 +77,4 @@ type Ref struct {
 // has Count = 50. For problem / missing_ref / scheduling, LastSeen is the
 // compose time and FirstSeen backs off by the observed problem duration; for
 // condition rows, both timestamps are the condition's lastTransitionTime.
-type Issue struct {
-	Severity Severity `json:"severity"`
-	Source   Source   `json:"source"`
-	// Category is the user-facing symptom taxonomy (image_pull_failed,
-	// crashloop, …), derived from Source+Kind+Reason by Classify;
-	// CategoryGroup is its coarse rollup (GroupOf). Both are server-emitted
-	// labels so the UI renders them without its own category→group map.
-	// Distinct from Group below, which is the resource's API group.
-	Category      Category      `json:"category,omitempty"`
-	CategoryGroup CategoryGroup `json:"category_group,omitempty"`
-	// ID is the deterministic, cluster-local issue identity —
-	// hash(grouping_scope, subject key, category). Shared by every row that
-	// rolls up to the same subject+category, so consumers can group on it;
-	// the hub namespaces it by cluster_id for global uniqueness.
-	ID string `json:"id,omitempty"`
-	// GroupingScope is the kind of subject this issue groups under
-	// (workload|service|pvc|ingress|node|unknown) — drives the UI section
-	// and is part of ID.
-	GroupingScope Scope     `json:"grouping_scope,omitempty"`
-	Kind          string    `json:"kind"`
-	Group         string    `json:"group,omitempty"`
-	Namespace     string    `json:"namespace,omitempty"`
-	Name          string    `json:"name"`
-	Reason        string    `json:"reason"`
-	Message       string    `json:"message,omitempty"`
-	FirstSeen     time.Time `json:"first_seen,omitzero"`
-	LastSeen      time.Time `json:"last_seen,omitzero"`
-	Count         int       `json:"count,omitempty"`
-	// Owner is flat-only: it's present on ?view=flat / pre-fold MCP rows so a
-	// consumer can see the resolved top-owner. Grouped rows hoist the owner
-	// into the subject (Kind/Group/Namespace/Name) and leave Owner zero, so
-	// the TS Issue type (which only consumes grouped output) doesn't model it.
-	Owner Ref `json:"owner,omitzero"`
-	// Fingerprint is an internal, stable per-cause key (NOT on the wire): it
-	// feeds the ID discriminator so distinct causes on the same subject+category
-	// (e.g. two different missing refs) don't collapse into one row. Empty for
-	// single-cause categories, which fold by category as before.
-	Fingerprint string `json:"-"`
-	// RestartCount + LastTerminatedReason carry Pod crash-debugging
-	// context from k8s.Problem through to issues consumers (MCP `issues`
-	// tool + /api/issues + hub fleet_issues). Populated only for Pod
-	// problem rows where the kubelet has recorded crash data. Together
-	// they answer "is this chronic or acute?" (RestartCount) and "what
-	// kind of failure?" (LastTerminatedReason: OOMKilled / Error /
-	// Completed) without the agent needing a follow-up get_resource call.
-	RestartCount         int32  `json:"restart_count,omitempty"`
-	LastTerminatedReason string `json:"last_terminated_reason,omitempty"`
-	// Affected, Members, and MembersTruncated are populated only on grouped
-	// rows (GroupIssues). Affected counts the folded underlying resources by
-	// kind; Members lists them (bounded by maxInlineMembers, with
-	// MembersTruncated set past the cap). Empty on flat rows and on
-	// single-resource grouped issues (no fan-out).
-	Affected         Affected `json:"affected,omitzero"`
-	Members          []Ref    `json:"members,omitempty"`
-	MembersTruncated bool     `json:"members_truncated,omitempty"`
-	// Cluster identity is NOT an OSS-issue concept (a Radar is one cluster). The
-	// hub adds cluster_id/cluster_name in its own fleet DTO post-fan-out; cross-
-	// cluster scoping is the hub's clusters=/target mechanism, not a per-issue
-	// field or CEL predicate.
-}
+type Issue = issuesapi.Issue

--- a/packages/k8s-ui/package.json
+++ b/packages/k8s-ui/package.json
@@ -31,6 +31,11 @@
       "./src/components/gitops/*.tsx",
       "./src/components/gitops/*.ts"
     ],
+    "./components/issues": "./src/components/issues/index.ts",
+    "./components/issues/*": [
+      "./src/components/issues/*.tsx",
+      "./src/components/issues/*.ts"
+    ],
     "./components/timeline/*": [
       "./src/components/timeline/*.tsx",
       "./src/components/timeline/*.ts"

--- a/pkg/issuesapi/types.go
+++ b/pkg/issuesapi/types.go
@@ -1,0 +1,226 @@
+// Package issuesapi defines the stable JSON contract for Radar's /api/issues
+// response. It is intentionally data-only so Radar Cloud can share the wire
+// shape without importing Radar's internal issue detection implementation.
+package issuesapi
+
+import "time"
+
+type Severity string
+
+const (
+	SeverityCritical Severity = "critical"
+	SeverityWarning  Severity = "warning"
+)
+
+type Source string
+
+const (
+	SourceProblem    Source = "problem"
+	SourceMissingRef Source = "missing_ref"
+	SourceScheduling Source = "scheduling"
+	SourceCondition  Source = "condition"
+)
+
+var Sources = []Source{
+	SourceProblem,
+	SourceMissingRef,
+	SourceScheduling,
+	SourceCondition,
+}
+
+type Category string
+
+const (
+	CategoryUnknown Category = "unknown"
+
+	CategoryUnschedulable            Category = "unschedulable"
+	CategoryQuotaExceeded            Category = "quota_exceeded"
+	CategoryAdmissionWebhookBlocking Category = "admission_webhook_blocking"
+
+	CategoryImagePullFailed     Category = "image_pull_failed"
+	CategoryContainerWaiting    Category = "container_waiting"
+	CategoryInitContainerFailed Category = "init_container_failed"
+
+	CategoryCrashLoop         Category = "crashloop"
+	CategoryOOMKilled         Category = "oom_killed"
+	CategoryLivenessProbeFail Category = "liveness_probe_failed"
+	CategoryReadinessFailed   Category = "readiness_failed"
+	CategoryWorkloadDegraded  Category = "workload_degraded"
+	CategoryHighRestart       Category = "high_restart"
+	CategoryJobFailed         Category = "job_failed"
+	CategoryCronJobFailed     Category = "cronjob_failed"
+
+	CategoryMissingConfigRef         Category = "missing_config_ref"
+	CategoryPDBBlocksEvictions       Category = "pdb_blocks_evictions"
+	CategoryServiceNoEndpoints       Category = "service_no_endpoints"
+	CategoryIngressBackendMissing    Category = "ingress_backend_missing"
+	CategoryDNSFailure               Category = "dns_failure"
+	CategoryNetworkPolicyBlock       Category = "network_policy_block"
+	CategoryPVCPending               Category = "pvc_pending"
+	CategoryPVCLost                  Category = "pvc_lost"
+	CategoryVolumeMountFailed        Category = "volume_mount_failed"
+	CategoryVolumeAccessModeConflict Category = "volume_access_mode_conflict"
+	CategoryRolloutStalled           Category = "rollout_stalled"
+	CategoryHPALimitedOrFailed       Category = "hpa_limited_or_failed"
+	CategoryRBACForbidden            Category = "rbac_forbidden"
+	CategoryCertificateNotReady      Category = "certificate_not_ready"
+	CategoryPodSecurityViolation     Category = "pod_security_violation"
+	CategoryNodeNotReady             Category = "node_not_ready"
+	CategoryOperatorConditionFail    Category = "operator_condition_failed"
+	CategoryGitOpsSyncFailed         Category = "gitops_sync_failed"
+	CategoryWebhookBackendDown       Category = "webhook_backend_down"
+	CategoryControlPlaneNotReady     Category = "control_plane_not_ready"
+	CategoryMachineNotReady          Category = "machine_not_ready"
+)
+
+type CategoryGroup string
+
+const (
+	GroupUnknown       CategoryGroup = "unknown"
+	GroupScheduling    CategoryGroup = "scheduling"
+	GroupStartup       CategoryGroup = "startup"
+	GroupRuntime       CategoryGroup = "runtime"
+	GroupConfiguration CategoryGroup = "configuration"
+	GroupNetworking    CategoryGroup = "networking"
+	GroupStorage       CategoryGroup = "storage"
+	GroupScaling       CategoryGroup = "scaling"
+	GroupSecurity      CategoryGroup = "security"
+	GroupControlPlane  CategoryGroup = "control_plane"
+)
+
+var categoryGroup = map[Category]CategoryGroup{
+	CategoryUnschedulable:            GroupScheduling,
+	CategoryQuotaExceeded:            GroupScheduling,
+	CategoryAdmissionWebhookBlocking: GroupScheduling,
+	CategoryImagePullFailed:          GroupStartup,
+	CategoryContainerWaiting:         GroupStartup,
+	CategoryInitContainerFailed:      GroupStartup,
+	CategoryCrashLoop:                GroupRuntime,
+	CategoryOOMKilled:                GroupRuntime,
+	CategoryLivenessProbeFail:        GroupRuntime,
+	CategoryReadinessFailed:          GroupRuntime,
+	CategoryWorkloadDegraded:         GroupRuntime,
+	CategoryHighRestart:              GroupRuntime,
+	CategoryJobFailed:                GroupRuntime,
+	CategoryCronJobFailed:            GroupRuntime,
+	CategoryMissingConfigRef:         GroupConfiguration,
+	CategoryPDBBlocksEvictions:       GroupConfiguration,
+	CategoryServiceNoEndpoints:       GroupNetworking,
+	CategoryIngressBackendMissing:    GroupNetworking,
+	CategoryDNSFailure:               GroupNetworking,
+	CategoryNetworkPolicyBlock:       GroupNetworking,
+	CategoryPVCPending:               GroupStorage,
+	CategoryPVCLost:                  GroupStorage,
+	CategoryVolumeMountFailed:        GroupStorage,
+	CategoryVolumeAccessModeConflict: GroupStorage,
+	CategoryRolloutStalled:           GroupScaling,
+	CategoryHPALimitedOrFailed:       GroupScaling,
+	CategoryRBACForbidden:            GroupSecurity,
+	CategoryCertificateNotReady:      GroupSecurity,
+	CategoryPodSecurityViolation:     GroupSecurity,
+	CategoryNodeNotReady:             GroupControlPlane,
+	CategoryOperatorConditionFail:    GroupControlPlane,
+	CategoryGitOpsSyncFailed:         GroupControlPlane,
+	CategoryWebhookBackendDown:       GroupControlPlane,
+	CategoryControlPlaneNotReady:     GroupControlPlane,
+	CategoryMachineNotReady:          GroupControlPlane,
+}
+
+func GroupOf(c Category) CategoryGroup {
+	if g, ok := categoryGroup[c]; ok {
+		return g
+	}
+	return GroupUnknown
+}
+
+type Scope string
+
+const (
+	ScopeUnknown  Scope = "unknown"
+	ScopeWorkload Scope = "workload"
+	ScopeService  Scope = "service"
+	ScopeIngress  Scope = "ingress"
+	ScopePVC      Scope = "pvc"
+	ScopeNode     Scope = "node"
+)
+
+type Ref struct {
+	Group     string `json:"group,omitempty"`
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name"`
+}
+
+type Affected struct {
+	Pods      int `json:"pods,omitempty"`
+	Workloads int `json:"workloads,omitempty"`
+	Services  int `json:"services,omitempty"`
+	PVCs      int `json:"pvcs,omitempty"`
+	Nodes     int `json:"nodes,omitempty"`
+}
+
+type Issue struct {
+	Severity             Severity      `json:"severity"`
+	Source               Source        `json:"source"`
+	Category             Category      `json:"category,omitempty"`
+	CategoryGroup        CategoryGroup `json:"category_group,omitempty"`
+	ID                   string        `json:"id,omitempty"`
+	GroupingScope        Scope         `json:"grouping_scope,omitempty"`
+	Kind                 string        `json:"kind"`
+	Group                string        `json:"group,omitempty"`
+	Namespace            string        `json:"namespace,omitempty"`
+	Name                 string        `json:"name"`
+	Reason               string        `json:"reason"`
+	Message              string        `json:"message,omitempty"`
+	FirstSeen            time.Time     `json:"first_seen,omitzero"`
+	LastSeen             time.Time     `json:"last_seen,omitzero"`
+	Count                int           `json:"count,omitempty"`
+	Owner                Ref           `json:"owner,omitzero"`
+	Fingerprint          string        `json:"-"`
+	RestartCount         int32         `json:"restart_count,omitempty"`
+	LastTerminatedReason string        `json:"last_terminated_reason,omitempty"`
+	Affected             Affected      `json:"affected,omitzero"`
+	Members              []Ref         `json:"members,omitempty"`
+	MembersTruncated     bool          `json:"members_truncated,omitempty"`
+}
+
+type Response struct {
+	Issues            []Issue `json:"issues"`
+	Total             int     `json:"total"`
+	TotalMatched      int     `json:"total_matched"`
+	FilterErrors      int     `json:"filter_errors,omitempty"`
+	FilterErrorSample string  `json:"filter_error_sample,omitempty"`
+	Visibility        any     `json:"visibility,omitempty"`
+	NarrowHint        string  `json:"narrowHint,omitempty"`
+}
+
+type BindingType string
+
+const (
+	BindingString BindingType = "string"
+	BindingInt    BindingType = "int"
+)
+
+type CELBinding struct {
+	Name string
+	Type BindingType
+}
+
+var CELBindings = []CELBinding{
+	{Name: "severity", Type: BindingString},
+	{Name: "source", Type: BindingString},
+	{Name: "category", Type: BindingString},
+	{Name: "category_group", Type: BindingString},
+	{Name: "kind", Type: BindingString},
+	{Name: "group", Type: BindingString},
+	{Name: "ns", Type: BindingString},
+	{Name: "name", Type: BindingString},
+	{Name: "reason", Type: BindingString},
+	{Name: "message", Type: BindingString},
+	{Name: "count", Type: BindingInt},
+	{Name: "first_seen", Type: BindingInt},
+	{Name: "last_seen", Type: BindingInt},
+	{Name: "grouping_scope", Type: BindingString},
+	{Name: "restart_count", Type: BindingInt},
+	{Name: "last_terminated_reason", Type: BindingString},
+}

--- a/pkg/issuesapi/types_test.go
+++ b/pkg/issuesapi/types_test.go
@@ -1,0 +1,31 @@
+package issuesapi
+
+import "testing"
+
+func TestGroupOf(t *testing.T) {
+	cases := []struct {
+		name string
+		in   Category
+		want CategoryGroup
+	}{
+		{"image pull", CategoryImagePullFailed, GroupStartup},
+		{"unschedulable", CategoryUnschedulable, GroupScheduling},
+		{"gitops sync", CategoryGitOpsSyncFailed, GroupControlPlane},
+		{"unknown", CategoryUnknown, GroupUnknown},
+		{"unmapped", Category("future_category"), GroupUnknown},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := GroupOf(tc.in); got != tc.want {
+				t.Fatalf("GroupOf(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+
+	for c, g := range categoryGroup {
+		if g == GroupUnknown {
+			t.Fatalf("category %q maps to GroupUnknown", c)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Extracts Radar's public `/api/issues` wire contract into `github.com/skyhook-io/radar/pkg/issuesapi` so Radar Cloud can consume the same Go types instead of mirroring local DTOs.

- Adds shared Issues API types: `Issue`, `Response`, `Ref`, `Affected`, severity/source/category/scope constants, and category-group rollups
- Adds shared issue CEL binding metadata used by Radar filter compilation and the hub pre-validator
- Keeps Radar's detection, classification, grouping, and identity logic in `internal/issues`, while making it consume the public API vocabulary directly
- Exports the k8s-ui Issues subpaths needed by downstream consumers

## Why

Radar Hub is a client of Radar OSS for fleet fan-out. `/api/issues` is now a Cloud integration surface, so the API shape and filter vocabulary should live in `pkg` rather than being copied between repos.

## Verification

- `(cd pkg && go test ./issuesapi)`
- `go test ./internal/issues ./internal/filter ./internal/server ./internal/mcp`
