### PR TITLE
Reduce issues row layout work

### DIFF
--- a/packages/k8s-ui/src/components/issues/IssuesView.tsx
+++ b/packages/k8s-ui/src/components/issues/IssuesView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { ChevronRight, CircleCheck, Clock, ExternalLink } from 'lucide-react';
 import { ClusterName, EmptyState } from '../ui';
 import { formatCompactAge, formatRelativeAgeTime } from '../../utils/format';
@@ -108,9 +108,24 @@ function IssueRow({
   const cluster = clusterLabel?.(issue);
   const affected = affectedSummary(issue.affected);
   const { headline } = issueMessageParts(issue);
+  const [renderDetails, setRenderDetails] = useState(open);
+
+  useEffect(() => {
+    if (open) {
+      setRenderDetails(true);
+      return;
+    }
+    if (!renderDetails) return;
+
+    const timeout = window.setTimeout(() => setRenderDetails(false), 200);
+    return () => window.clearTimeout(timeout);
+  }, [open, renderDetails]);
 
   return (
-    <li className="overflow-hidden rounded-xl border border-theme-border bg-theme-surface shadow-theme-sm">
+    <li
+      className="overflow-hidden rounded-xl border border-theme-border bg-theme-surface shadow-theme-sm"
+      style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 72px' }}
+    >
       {/* The whole header is the single toggle target — chevron is just the
           open/closed indicator, not a separate action. Deep-links live in the
           expanded body (a link nested in a button would be invalid). */}
@@ -187,20 +202,27 @@ function IssueRow({
         </span>
       </div>
 
-      <div className="grid transition-[grid-template-rows] duration-200 ease-out" style={{ gridTemplateRows: open ? '1fr' : '0fr' }}>
-        {/* Kept mounted (not `open &&`) so the grid-rows transition animates the
-            collapse too; inert when closed so SR + tab skip the clipped content. */}
-        <div className="overflow-hidden" inert={!open || undefined}>
-          <div className="border-t border-theme-border bg-theme-base/40 px-4 py-4 pl-11">
-            <div className="flex flex-col gap-4">
-              <Diagnosis issue={issue} />
-              <div className="border-t border-theme-border/70 pt-3">
-                <AffectedResources issue={issue} resourceHref={resourceHref} onResourceClick={onResourceClick} />
+      {renderDetails ? (
+        <div
+          className={`issue-details-motion ${open ? 'issue-details-motion-open' : ''}`}
+          onTransitionEnd={(event) => {
+            if (event.target !== event.currentTarget) return;
+            if (event.propertyName !== 'grid-template-rows') return;
+            if (!open) setRenderDetails(false);
+          }}
+        >
+          <div className="overflow-hidden">
+            <div className="border-t border-theme-border bg-theme-base/40 px-4 py-4 pl-11">
+              <div className="flex flex-col gap-4">
+                <Diagnosis issue={issue} />
+                <div className="border-t border-theme-border/70 pt-3">
+                  <AffectedResources issue={issue} resourceHref={resourceHref} onResourceClick={onResourceClick} />
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
+      ) : null}
     </li>
   );
 }

--- a/packages/k8s-ui/src/theme/components.css
+++ b/packages/k8s-ui/src/theme/components.css
@@ -126,6 +126,25 @@
     padding: 0.75rem;
   }
 
+  /* ── ISSUE ROW DETAILS ── */
+
+  .issue-details-motion {
+    display: grid;
+    grid-template-rows: 0fr;
+    overflow: hidden;
+    transition: grid-template-rows 200ms ease-out;
+  }
+
+  .issue-details-motion-open {
+    grid-template-rows: 1fr;
+  }
+
+  @starting-style {
+    .issue-details-motion-open {
+      grid-template-rows: 0fr;
+    }
+  }
+
   /* ── SUBTLE BORDERS ── */
 
   .table-divide-subtle > * + * {


### PR DESCRIPTION
## Summary
- skip mounting collapsed issue row detail bodies until a row opens
- preserve smooth expand/collapse with shared CSS keyframe classes
- add content visibility containment for issue rows

## Tests
- make tsc
- visual test: /issues at 1280, 1920, 2560

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only performance tuning in IssuesView; accordion behavior and content should match prior UX, with minor edge cases around animation timing if transitions are unsupported.
> 
> **Overview**
> **Reduces layout and render work on the issues queue** by not mounting diagnosis/affected-resource content until a row is opened, instead of keeping every row’s body in the DOM with `inert` while collapsed.
> 
> Expand/collapse animation moves to shared **`issue-details-motion`** classes in `components.css` (grid-row transition plus `@starting-style` so opening still animates after a fresh mount). Collapse waits for the transition (with a 200ms timeout fallback) before unmounting so the close animation still runs.
> 
> Each issue **`<li>`** gets **`contentVisibility: auto`** and an intrinsic height hint so off-screen rows cost less during scroll on large fleets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cce26c1b4e406d68a77f117908945cf6459ee2ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->