### PR TITLE
fix(k8s-ui): stop MiddleEllipsis over-truncating names under scale() animations

### DIFF
--- a/packages/k8s-ui/src/components/ui/MiddleEllipsis.tsx
+++ b/packages/k8s-ui/src/components/ui/MiddleEllipsis.tsx
@@ -64,8 +64,21 @@ export function MiddleEllipsis({ text, className, title, onTruncatedChange }: Mi
       // ctx.measureText says 173.4px and clientWidth rounds to 173 — the
       // integer comparison decides we don't fit and middle-truncates a
       // name that visually would have rendered fine.
-      const width = node.getBoundingClientRect().width
-      if (width <= 0) return
+      const rawWidth = node.getBoundingClientRect().width
+      if (rawWidth <= 0) return
+      // getBoundingClientRect() returns the *rendered* width, which a CSS
+      // transform on this node or any ancestor scales — e.g. the `scale()` in a
+      // menu/popup/dialog entry animation. Measuring during that animation
+      // compares a visually-shrunk container against unscaled canvas text
+      // (measureText is transform-independent) and middle-truncates a name that
+      // actually fits. Worse, a transform never changes the layout box, so the
+      // ResizeObserver below doesn't fire to re-measure once the animation
+      // settles — the wrong truncation then sticks. Divide out the cumulative
+      // ancestor scaleX to recover the unscaled (still subpixel) layout width.
+      // With no transform the scale is 1 and this is a no-op, so the just-fits
+      // subpixel precision noted above is preserved.
+      const scaleX = cumulativeScaleX(node)
+      const width = scaleX > 0 ? rawWidth / scaleX : rawWidth
       const cs = window.getComputedStyle(node)
       // Include fontStyle in the shorthand so italic faces measure correctly.
       // If the assignment ever silently fails (malformed family quoting,
@@ -126,6 +139,29 @@ export function MiddleEllipsis({ text, className, title, onTruncatedChange }: Mi
       </span>
     </span>
   )
+}
+
+// Cumulative horizontal scale applied to `el` by CSS transforms on it and its
+// ancestors. Used to convert a transform-scaled getBoundingClientRect() width
+// back to the unscaled layout width, so a `scale()` entry animation on an
+// ancestor (menu/popup/dialog) can't make text middle-truncate when it would
+// otherwise fit. Reads the computed transform matrix's scaleX (`a`) at each
+// level — exact for the scale()/translate() animations this guards against
+// (no rotation, where `a` would fold in cos θ). Returns 1 when nothing in the
+// chain is transformed, making the caller a no-op in the common case.
+function cumulativeScaleX(el: HTMLElement | null): number {
+  let scale = 1
+  for (let cur: HTMLElement | null = el; cur; cur = cur.parentElement) {
+    const t = window.getComputedStyle(cur).transform
+    if (t && t !== 'none') {
+      try {
+        scale *= new DOMMatrixReadOnly(t).a
+      } catch {
+        // Unparseable transform value — skip this level rather than throw.
+      }
+    }
+  }
+  return scale
 }
 
 // Binary-search the largest `n` such that `prefix(n) + … + suffix(n)` fits


### PR DESCRIPTION
## Summary

`MiddleEllipsis` middle-truncated cluster names that comfortably fit (`a…a`, `demo-…uster`, `radar-…-nonprod`), most visibly in consumer popovers whose entry animation triggers it.

## Root cause

It decides fit by comparing the container width from `getBoundingClientRect().width` against canvas `ctx.measureText(...)`. `getBoundingClientRect()` returns the rendered width, which any CSS `transform` on the node or an ancestor scales; `measureText` is transform independent. During a menu/popup/dialog `scale()` entry animation the shrunk container loses to full size text, and a name that fits gets truncated. A transform never changes the layout box, so the `ResizeObserver` never re fires once the animation settles and the wrong truncation sticks permanently.

## Fix

Divide the rendered width by the cumulative ancestor scaleX before comparing, recovering the unscaled (still subpixel) layout width. When nothing in the chain is transformed the scale is 1 and the change is a no op, preserving the existing just fits precision. Reads each ancestor's computed transform matrix scaleX (`a`), exact for the `scale()`/`translate()` animations this guards against.

## Context

Consumers (e.g. radar-hub-web) currently work around this with a `patch-package` patch, which silently breaks on every k8s-ui version bump. Fixing it at the source removes that fragility. Tag `k8s-ui-v1.7.10` after merge to publish; radar-hub-web then drops its patch and bumps the pin.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI measurement fix in MiddleEllipsis with no-op when no transforms; minor edge case if rotated transforms are used (documented limitation).
> 
> **Overview**
> **`MiddleEllipsis`** now normalizes container width before deciding whether to middle-truncate: it divides **`getBoundingClientRect()`** width by the cumulative ancestor **`scaleX`** from computed transforms, so a **`scale()`** entry animation on menus/popovers/dialogs cannot make names look too wide vs. canvas **`measureText`** and get stuck truncated after the animation ends (layout box unchanged → **`ResizeObserver`** never re-runs).
> 
> Adds **`cumulativeScaleX`**, walking the DOM and multiplying **`DOMMatrixReadOnly`** **`a`** per transformed ancestor; no transform means scale **1**, preserving the existing subpixel width behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0146baf4bd3d741f4b5b6c2c275168b276dbbb41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->