### PR TITLE
feat(k8s-ui): GitOpsTableView filtersSide prop (left|right)

### DIFF
--- a/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
@@ -202,6 +202,14 @@ export interface GitOpsTableViewProps {
   emptyStateTitle?: string
   emptyStateBody?: string
   /**
+   * Which side the filter rail sits on. Default 'left' (OSS Radar, which
+   * has no app sidebar). A host with its own left navigation rail (the
+   * Cloud hub) passes 'right' so the GitOps filters don't stack a second
+   * column against that nav and instead match the host's other faceted
+   * pages. Mobile stacking (filters above the table) is unaffected.
+   */
+  filtersSide?: 'left' | 'right'
+  /**
    * Global namespace pick from the host's NamespaceSwitcher. Used to
    * surface "viewing in namespace: X" context and to power the Clear
    * filters affordance when no rows match. Host owns the state; shared
@@ -249,6 +257,7 @@ export function GitOpsTableView({
   onClearNamespaces,
   onRowAction,
   pendingRowActions,
+  filtersSide = 'left',
 }: GitOpsTableViewProps) {
   const searchInputRef = useRef<HTMLInputElement>(null)
   const [mode, setMode] = useState<GitOpsMode>('applications')
@@ -492,8 +501,13 @@ export function GitOpsTableView({
   ]
 
   return (
-    <div className="flex h-full min-w-0 flex-1 overflow-hidden bg-theme-base max-lg:flex-col">
+    <div
+      className={`flex h-full min-w-0 flex-1 overflow-hidden bg-theme-base max-lg:flex-col ${
+        filtersSide === 'right' ? 'lg:flex-row-reverse' : ''
+      }`}
+    >
       <GitOpsFilterSidebar
+        side={filtersSide}
         mode={mode}
         onModeChange={setMode}
         modeCounts={modeCounts}
@@ -707,6 +721,7 @@ export function GitOpsTableView({
 // =============================================================================
 
 function GitOpsFilterSidebar({
+  side,
   mode,
   onModeChange,
   modeCounts,
@@ -729,6 +744,7 @@ function GitOpsFilterSidebar({
   onToggleNamespace,
   onClear,
 }: {
+  side: 'left' | 'right'
   mode: GitOpsMode
   onModeChange: (mode: GitOpsMode) => void
   modeCounts: Record<GitOpsMode, number>
@@ -752,7 +768,11 @@ function GitOpsFilterSidebar({
   onClear: () => void
 }) {
   return (
-    <aside className="flex w-72 shrink-0 flex-col overflow-hidden border-r border-theme-border bg-theme-surface/90 max-lg:max-h-72 max-lg:w-full max-lg:border-b max-lg:border-r-0">
+    <aside
+      className={`flex w-72 shrink-0 flex-col overflow-hidden border-theme-border bg-theme-surface/90 max-lg:max-h-72 max-lg:w-full max-lg:border-b ${
+        side === 'right' ? 'border-l max-lg:border-l-0' : 'border-r max-lg:border-r-0'
+      }`}
+    >
       <div className="flex items-center justify-between border-b border-theme-border px-3 py-2">
         <span className="text-sm font-medium text-theme-text-secondary">GitOps Filters</span>
         <button type="button" onClick={onClear} className="text-[10px] font-medium text-blue-500 hover:text-blue-400">


### PR DESCRIPTION
## Summary

Adds an optional `filtersSide?: 'left' | 'right'` (default `'left'`) to `GitOpsTableView`. The default keeps OSS Radar's layout (filter rail on the left, which is right for an app with no navigation sidebar).

A host that already has its own left navigation rail (the Cloud hub) can pass `filtersSide="right"` so the GitOps filter rail doesn't stack a second column directly against that nav, and instead matches the host's other faceted pages (which put facets on the right).

## Implementation

`lg:flex-row-reverse` on the row container plus a flipped border side on the filter `<aside>` (`border-l` vs `border-r`, and the mobile `border-*-0` analog). Mobile stacking (filters above the table) is unchanged.

Backwards-compatible: the only current consumer (OSS `web/`) omits the prop and gets `'left'`. `tsc` clean.

## Context

Consumed by the Cloud hub (radar-hub-web), which passes `'right'`. The hub's GitOps topology detail grid is composed host-side, so it flips its own filter rail to the right separately, no k8s-ui change needed there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational layout-only change with a backward-compatible default; no data, auth, or API behavior changes.
> 
> **Overview**
> Adds optional **`filtersSide?: 'left' | 'right'`** (default **`'left'`**) to **`GitOpsTableView`** so hosts can place the GitOps filter rail on the right when they already have a left app nav (e.g. Cloud hub), instead of stacking two left columns.
> 
> On large screens, **`filtersSide="right"`** applies **`lg:flex-row-reverse`** on the main flex row and switches the filter **`<aside>`** divider from **`border-r`** to **`border-l`** (with matching mobile **`border-*-0`** resets). **Mobile** layout—filters above the table—is unchanged. Existing OSS consumers omit the prop and keep the current left-rail layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34e3c0b3d26ec69768f6a6c91a2d9ed0c16fcebe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->