### PR TITLE
Add logout in proxy auth mode with optional proxy sign-out URL

### DIFF
--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -82,6 +82,7 @@ func main() {
 	authCookieTTL := flag.Duration("auth-cookie-ttl", 4*time.Hour, "Session cookie TTL (sliding — extends on activity)")
 	authUserHeader := flag.String("auth-user-header", "X-Forwarded-User", "Header for username (proxy mode)")
 	authGroupsHeader := flag.String("auth-groups-header", "X-Forwarded-Groups", "Header for groups (proxy mode)")
+	authProxyLogoutURL := flag.String("auth-proxy-logout-url", "", "URL the logout button redirects to in proxy mode, to tear down the upstream proxy session (e.g. oauth2-proxy's /oauth2/sign_out). The proxy must actually invalidate the session at this URL — Radar only clears its own cookie (Basic Auth has no logout). Empty = clear Radar's cookie only.")
 	authOIDCIssuer := flag.String("auth-oidc-issuer", "", "OIDC issuer URL")
 	authOIDCClientID := flag.String("auth-oidc-client-id", "", "OIDC client ID")
 	authOIDCClientSecret := flag.String("auth-oidc-client-secret", "", "OIDC client secret")
@@ -195,6 +196,7 @@ func main() {
 			CookieTTL:                 *authCookieTTL,
 			UserHeader:                *authUserHeader,
 			GroupsHeader:              *authGroupsHeader,
+			ProxyLogoutURL:            *authProxyLogoutURL,
 			OIDCIssuer:                *authOIDCIssuer,
 			OIDCClientID:              *authOIDCClientID,
 			OIDCClientSecret:          *authOIDCClientSecret,

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -82,6 +82,9 @@ spec:
             {{- if .Values.auth.proxy.groupsHeader }}
             - {{ printf "--auth-groups-header=%s" .Values.auth.proxy.groupsHeader | quote }}
             {{- end }}
+            {{- if .Values.auth.proxy.logoutURL }}
+            - {{ printf "--auth-proxy-logout-url=%s" .Values.auth.proxy.logoutURL | quote }}
+            {{- end }}
             {{- if .Values.auth.oidc.issuerURL }}
             - {{ printf "--auth-oidc-issuer=%s" .Values.auth.oidc.issuerURL | quote }}
             {{- end }}

--- a/deploy/helm/radar/values.schema.json
+++ b/deploy/helm/radar/values.schema.json
@@ -189,7 +189,8 @@
           "additionalProperties": false,
           "properties": {
             "userHeader": { "type": "string" },
-            "groupsHeader": { "type": "string" }
+            "groupsHeader": { "type": "string" },
+            "logoutURL": { "type": "string" }
           }
         },
         "oidc": {

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -264,6 +264,11 @@ auth:
   proxy:
     userHeader: "X-Forwarded-User"
     groupsHeader: "X-Forwarded-Groups"
+    # URL the logout button redirects to, to tear down the upstream proxy
+    # session (e.g. oauth2-proxy's "/oauth2/sign_out"). The proxy must actually
+    # invalidate the session at this URL — Radar only clears its own cookie
+    # (Basic Auth has no logout). Empty = clear Radar's cookie only.
+    logoutURL: ""
   # OIDC mode settings
   oidc:
     issuerURL: ""

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -57,6 +57,14 @@ radar --auth-mode=proxy \
 
 > **Security:** Your ingress must strip `X-Forwarded-User` and `X-Forwarded-Groups` headers from external requests to prevent spoofing. The auth proxy should be the **only** path to Radar. Radar logs a warning at startup as a reminder.
 
+**Logout behavior:**
+
+The user menu always shows a **Logout** button. Clicking it clears Radar's session cookie. On its own, that isn't enough to switch users: your proxy re-injects the identity header on the next request and signs the same user back in.
+
+To make logout actually switch users, point Radar at your proxy's sign-out URL with `--auth-proxy-logout-url` (or `auth.proxy.logoutURL` in Helm) — e.g. oauth2-proxy's `/oauth2/sign_out`. Radar then redirects the browser there after clearing its own cookie, so the upstream session is torn down too. When unset, the menu shows a note that the proxy may re-authenticate automatically.
+
+> **Note:** HTTP Basic Auth has no reliable logout mechanism — browsers cache credentials and resend them. If you need user-switching, prefer a proxy with a real sign-out endpoint (oauth2-proxy, Authelia) over plain Basic Auth.
+
 ### OIDC Mode
 
 Use this when you want Radar to handle login directly — no separate auth proxy needed. Radar redirects to your identity provider (Google, Okta, Dex, Keycloak, etc.), validates the token, and creates a session cookie.
@@ -383,6 +391,7 @@ Radar uses stateless HMAC-SHA256 signed cookies for sessions. The cookie contain
 | Cookie TTL | `--auth-cookie-ttl` | `auth.cookieTTL` | `4h` (sliding) |
 | User header (proxy) | `--auth-user-header` | `auth.proxy.userHeader` | `X-Forwarded-User` |
 | Groups header (proxy) | `--auth-groups-header` | `auth.proxy.groupsHeader` | `X-Forwarded-Groups` |
+| Proxy logout URL (proxy) | `--auth-proxy-logout-url` | `auth.proxy.logoutURL` | — |
 | OIDC issuer | `--auth-oidc-issuer` | `auth.oidc.issuerURL` | — |
 | OIDC client ID | `--auth-oidc-client-id` | `auth.oidc.clientID` | — |
 | OIDC client secret | `--auth-oidc-client-secret` | `auth.oidc.clientSecret` | — |

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3285,13 +3285,25 @@ func (s *Server) requireConnected(w http.ResponseWriter) bool {
 func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
 	http.SetCookie(w, auth.ClearSessionCookie())
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"status": "logged out"})
+	resp := map[string]string{"status": "logged out"}
+	// Clearing Radar's cookie alone doesn't switch users: the proxy
+	// re-injects the identity header on the next request. Redirect to the
+	// proxy's sign-out URL so the upstream session is torn down too.
+	if s.authConfig.ProxyLogoutURL != "" {
+		resp["redirectTo"] = s.authConfig.ProxyLogoutURL
+	}
+	json.NewEncoder(w).Encode(resp)
 }
 
 func (s *Server) handleAuthMe(w http.ResponseWriter, r *http.Request) {
 	resp := map[string]any{
 		"authEnabled": s.authConfig.Enabled(),
 		"authMode":    s.authConfig.Mode,
+	}
+	// Tells the SPA whether proxy-mode logout can tear down the upstream
+	// session (vs only clearing Radar's cookie), so it can warn the user.
+	if s.authConfig.Mode == "proxy" {
+		resp["proxyLogoutConfigured"] = s.authConfig.ProxyLogoutURL != ""
 	}
 	if user := auth.UserFromContext(r.Context()); user != nil {
 		resp["username"] = user.Username

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -18,8 +18,9 @@ type Config struct {
 	CookieTTL time.Duration // default 4h, sliding
 
 	// Proxy mode
-	UserHeader   string // default "X-Forwarded-User"
-	GroupsHeader string // default "X-Forwarded-Groups"
+	UserHeader     string // default "X-Forwarded-User"
+	GroupsHeader   string // default "X-Forwarded-Groups"
+	ProxyLogoutURL string // optional, URL the logout button redirects to so the upstream proxy session is torn down (e.g. oauth2-proxy /oauth2/sign_out)
 
 	// Session revocation (optional, used by backchannel logout)
 	Revoker SessionRevoker

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -738,6 +738,10 @@ export interface AuthMe {
   /** Pre-computed Cloud tier from `cloud:<tier>` group prefix.
    *  Absent when not running under Cloud (OSS, OIDC, no role group). */
   cloudRole?: CloudRole
+  /** Proxy mode only: whether an upstream sign-out URL is configured.
+   *  When false, logout clears Radar's cookie but the proxy may re-auth
+   *  the same user on the next request. */
+  proxyLogoutConfigured?: boolean
 }
 
 export function useAuthMe() {

--- a/web/src/components/UserMenu.tsx
+++ b/web/src/components/UserMenu.tsx
@@ -67,18 +67,17 @@ export function UserMenu() {
               </p>
             )}
           </div>
-          {authMe.authMode === 'proxy' ? (
-            <p className="px-3 py-1.5 text-[11px] text-theme-text-tertiary">
-              Session managed by auth proxy
+          <button
+            onClick={handleLogout}
+            className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-theme-text-secondary hover:bg-theme-hover transition-colors"
+          >
+            <LogOut className="w-3.5 h-3.5" />
+            Logout
+          </button>
+          {authMe.authMode === 'proxy' && !authMe.proxyLogoutConfigured && (
+            <p className="px-3 py-1.5 text-[11px] text-theme-text-tertiary border-t border-theme-border">
+              Logout clears the Radar session. The auth proxy may sign you back in automatically.
             </p>
-          ) : (
-            <button
-              onClick={handleLogout}
-              className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-theme-text-secondary hover:bg-theme-hover transition-colors"
-            >
-              <LogOut className="w-3.5 h-3.5" />
-              Logout
-            </button>
           )}
         </div>
       )}


### PR DESCRIPTION
Fixes #864.

## Problem

In proxy auth mode the user menu hid the logout control behind a "Session managed by auth proxy" note. A user authenticated via a reverse proxy (e.g. static user/pass) had no way to end their Radar session or switch identities — exactly the dead end reported in #864.

## Change

- **Always show the Logout button in proxy mode.** It clears Radar's session cookie via the existing `/auth/logout` endpoint.
- **New `--auth-proxy-logout-url` flag** (Helm: `auth.proxy.logoutURL`). When set, logout redirects the browser to the upstream proxy's sign-out endpoint (e.g. oauth2-proxy's `/oauth2/sign_out`) so the proxy session is torn down too — mirroring how OIDC mode already uses the discovered `end_session_endpoint`.
- **Honest fallback:** when no logout URL is configured, the menu notes that the proxy may re-authenticate the same user. Clearing Radar's cookie alone doesn't switch users behind a proxy — the proxy re-injects the identity header on the next request.

`/auth/me` now reports `proxyLogoutConfigured` so the SPA can show that note only when relevant.

## Caveat (documented)

The flag only helps if the proxy actually invalidates the session at that URL. Plain HTTP Basic Auth has no logout mechanism — browsers cache and auto-resend credentials — so user-switching there requires a proxy with a real sign-out endpoint (oauth2-proxy, Authelia). Called out in the flag help, Helm comment, and `docs/authentication.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session logout and optional open redirects to operator-configured URLs; misconfiguration could send users to the wrong sign-out endpoint but does not broaden K8s access.
> 
> **Overview**
> **Proxy auth mode now exposes a real Logout path** instead of hiding it behind “Session managed by auth proxy.” The user menu always shows **Logout**, which clears Radar’s session cookie via `/auth/logout`.
> 
> Optional **`--auth-proxy-logout-url`** / Helm **`auth.proxy.logoutURL`** (wired through **`ProxyLogoutURL`** on **`auth.Config`**) lets logout also send the browser to an upstream sign-out URL (e.g. oauth2-proxy **`/oauth2/sign_out`**) so the proxy session is torn down, not just Radar’s cookie. When set, **`handleLogout`** returns **`redirectTo`** in JSON; the SPA follows it after logout.
> 
> **`/auth/me`** adds **`proxyLogoutConfigured`** in proxy mode so the UI only shows a footnote when no proxy logout URL is configured (cookie-only logout may re-auth via forwarded headers). Docs and Helm schema/values document Basic Auth limitations and configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6358b43e2af41a09df51bf136291ac3d62bb7eb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->