### PR TITLE
Honor kubectl.kubernetes.io/default-container for pod terminal/logs

### DIFF
--- a/internal/server/exec.go
+++ b/internal/server/exec.go
@@ -314,7 +314,7 @@ func (s *Server) handlePodExec(w http.ResponseWriter, r *http.Request) {
 	if overrideShell == "" || container == "" {
 		pod, err := client.CoreV1().Pods(namespace).Get(r.Context(), podName, metav1.GetOptions{})
 		if err != nil {
-			log.Printf("[exec] pod fetch failed for %s/%s (OS detection + container defaulting skipped): %v", namespace, podName, err)
+			log.Printf("[exec] pod fetch failed for %s/%s (OS detection + container defaulting skipped): %v", k8s.SanitizeForLog(namespace), k8s.SanitizeForLog(podName), err)
 		} else {
 			if overrideShell == "" {
 				podOS = detectPodOS(r.Context(), pod, nodeLabelsLookupFor(client))
@@ -324,7 +324,7 @@ func (s *Server) handlePodExec(w http.ResponseWriter, r *http.Request) {
 				execManager.mu.Lock()
 				session.Container = container
 				execManager.mu.Unlock()
-				log.Printf("[exec] session %s defaulted to container %q for %s/%s", sessionID, container, namespace, podName)
+				log.Printf("[exec] session %s defaulted to container %q for %s/%s", sessionID, container, k8s.SanitizeForLog(namespace), k8s.SanitizeForLog(podName))
 			}
 		}
 	}

--- a/internal/server/exec.go
+++ b/internal/server/exec.go
@@ -93,6 +93,31 @@ func defaultExecCommand(override, fallback, podOS string) []string {
 	return []string{"sh", "-c", defaultShellScript}
 }
 
+// defaultContainerAnnotation is the client-side convention kubectl, k9s, and
+// Lens use to mark the "main" container of a multi-container pod. Service
+// meshes (Istio, Linkerd, ASM) set it during injection to point past their
+// sidecar — without it, an unspecified container defaults to containers[0],
+// which on a mesh pod is the distroless proxy with no shell.
+const defaultContainerAnnotation = "kubectl.kubernetes.io/default-container"
+
+// defaultExecContainer picks the container to target when the request doesn't
+// name one. It honors defaultContainerAnnotation (matching kubectl exec
+// behavior), falling back to the first container. Returns "" only for a pod
+// with no containers.
+func defaultExecContainer(pod *corev1.Pod) string {
+	if name := pod.Annotations[defaultContainerAnnotation]; name != "" {
+		for _, c := range pod.Spec.Containers {
+			if c.Name == name {
+				return name
+			}
+		}
+	}
+	if len(pod.Spec.Containers) > 0 {
+		return pod.Spec.Containers[0].Name
+	}
+	return ""
+}
+
 // osNodeLabelsLookup is injected so detectPodOS is unit-testable without a
 // fake client.
 type osNodeLabelsLookup func(ctx context.Context, nodeName string) (map[string]string, error)
@@ -279,17 +304,28 @@ func (s *Server) handlePodExec(w http.ResponseWriter, r *http.Request) {
 	}
 	auth.AuditLog(r, namespace, podName)
 
-	// OS detection runs whenever ?shell= isn't explicit. --pod-shell-default
-	// must NOT short-circuit — it's POSIX-only, and a Windows pod still has
-	// to be routed to the Windows script ahead of the fallback. Pod-fetch
-	// failure is non-fatal: log and assume Linux.
+	// Fetch the pod when we need it for OS detection (?shell= not explicit) or
+	// to default an unspecified container. Defaulting to containers[0] without
+	// consulting kubectl.kubernetes.io/default-container lands mesh-injected
+	// pods in their distroless sidecar (no shell); honor the annotation like
+	// kubectl does. Pod-fetch failure is non-fatal: log, assume Linux, and let
+	// the apiserver apply its own containers[0] default.
 	var podOS string
-	if overrideShell == "" {
+	if overrideShell == "" || container == "" {
 		pod, err := client.CoreV1().Pods(namespace).Get(r.Context(), podName, metav1.GetOptions{})
 		if err != nil {
-			log.Printf("[exec] OS detection skipped for %s/%s (assuming Linux): %v", namespace, podName, err)
+			log.Printf("[exec] pod fetch failed for %s/%s (OS detection + container defaulting skipped): %v", namespace, podName, err)
 		} else {
-			podOS = detectPodOS(r.Context(), pod, nodeLabelsLookupFor(client))
+			if overrideShell == "" {
+				podOS = detectPodOS(r.Context(), pod, nodeLabelsLookupFor(client))
+			}
+			if container == "" {
+				container = defaultExecContainer(pod)
+				execManager.mu.Lock()
+				session.Container = container
+				execManager.mu.Unlock()
+				log.Printf("[exec] session %s defaulted to container %q for %s/%s", sessionID, container, namespace, podName)
+			}
 		}
 	}
 	command := defaultExecCommand(overrideShell, DefaultPodShellCommand, podOS)

--- a/internal/server/exec_test.go
+++ b/internal/server/exec_test.go
@@ -85,6 +85,42 @@ func TestDefaultExecCommand(t *testing.T) {
 // TestWindowsDefaultShellScript is a tripwire — if you edit the script,
 // manually verify against both Nano Server (no PowerShell) and Server Core
 // (PowerShell present) before merging.
+// TestDefaultExecContainer pins the container-selection precedence: a valid
+// kubectl.kubernetes.io/default-container annotation wins, otherwise the first
+// container. This is what keeps mesh-injected pods (sidecar at containers[0])
+// from execing into a shell-less proxy.
+func TestDefaultExecContainer(t *testing.T) {
+	podWith := func(annotation string, containers ...string) *corev1.Pod {
+		pod := &corev1.Pod{}
+		if annotation != "" {
+			pod.Annotations = map[string]string{defaultContainerAnnotation: annotation}
+		}
+		for _, name := range containers {
+			pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{Name: name})
+		}
+		return pod
+	}
+
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want string
+	}{
+		{"annotation honored over first container", podWith("app", "istio-proxy", "app"), "app"},
+		{"no annotation falls back to first", podWith("", "istio-proxy", "app"), "istio-proxy"},
+		{"annotation naming missing container ignored", podWith("ghost", "istio-proxy", "app"), "istio-proxy"},
+		{"single container", podWith("", "app"), "app"},
+		{"no containers", podWith(""), ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := defaultExecContainer(tt.pod); got != tt.want {
+				t.Errorf("defaultExecContainer() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWindowsDefaultShellScript(t *testing.T) {
 	const expected = `where powershell >nul 2>&1 && powershell || cmd`
 	if windowsDefaultShellScript != expected {

--- a/packages/k8s-ui/src/components/dock/TerminalTab.tsx
+++ b/packages/k8s-ui/src/components/dock/TerminalTab.tsx
@@ -285,8 +285,10 @@ export function TerminalTab({
             <>
               <div className="text-amber-400 mb-2 text-sm">Shell not available</div>
               <div className="text-xs text-theme-text-tertiary mb-4 max-w-md">
-                This container doesn&apos;t have a shell (/bin/sh). This is common with distroless
-                or minimal container images. You can create a debug container to troubleshoot.
+                Container <span className="font-mono text-theme-text-secondary">{selectedContainer}</span> doesn&apos;t
+                have a shell (/bin/sh). This is common with distroless or minimal container images
+                {containers.length > 1 ? ' — try another container above, or' : '. You can'} create a
+                debug container to troubleshoot.
               </div>
               <div className="flex gap-2">
                 {createDebugContainerRef.current && (

--- a/packages/k8s-ui/src/components/resources/get-default-container-name.test.ts
+++ b/packages/k8s-ui/src/components/resources/get-default-container-name.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { getDefaultContainerName } from './resource-utils'
+
+const podWith = (annotation: string | undefined, ...containers: string[]) => ({
+  metadata: annotation
+    ? { annotations: { 'kubectl.kubernetes.io/default-container': annotation } }
+    : {},
+  spec: { containers: containers.map((name) => ({ name })) },
+})
+
+describe('getDefaultContainerName', () => {
+  it('honors the default-container annotation over the first container', () => {
+    expect(getDefaultContainerName(podWith('app', 'istio-proxy', 'app'))).toBe('app')
+  })
+
+  it('falls back to the first container when no annotation is present', () => {
+    expect(getDefaultContainerName(podWith(undefined, 'istio-proxy', 'app'))).toBe('istio-proxy')
+  })
+
+  it('ignores an annotation naming a container that does not exist', () => {
+    expect(getDefaultContainerName(podWith('ghost', 'istio-proxy', 'app'))).toBe('istio-proxy')
+  })
+
+  it('returns the only container for a single-container pod', () => {
+    expect(getDefaultContainerName(podWith(undefined, 'app'))).toBe('app')
+  })
+
+  it('returns undefined for a pod with no containers', () => {
+    expect(getDefaultContainerName(podWith(undefined))).toBeUndefined()
+  })
+})

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
@@ -2,7 +2,7 @@ import { useState, type ReactNode, type JSX } from 'react'
 import { Server, HardDrive, Terminal as TerminalIcon, FileText, Activity, CirclePlay, FolderOpen, List, Eye, EyeOff, Shield } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, CopyHandler, AlertBanner, ResourceLink } from '../../ui/drawer-components'
-import { formatResources, formatDuration, getPodProblems, getPodPhaseDisplay, healthColors, SEVERITY_DOT_COLOR } from '../resource-utils'
+import { formatResources, formatDuration, getPodProblems, getPodPhaseDisplay, healthColors, SEVERITY_DOT_COLOR, getDefaultContainerName } from '../resource-utils'
 import { getResourceStatusColor, SEVERITY_BADGE_BORDERED } from '../../../utils/badge-colors'
 import {
   rbacVerbBadgeClass,
@@ -286,7 +286,7 @@ export function PodRenderer({
   const [podFilesContainer, setPodFilesContainer] = useState<string | null>(null)
 
   const handleOpenTerminal = (containerName?: string) => {
-    const container = containerName || containers[0]?.name
+    const container = containerName || getDefaultContainerName(data)
     if (namespace && podName && container) {
       onOpenTerminal?.({
         namespace,

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -418,6 +418,23 @@ export interface ContainerSquareState {
   }
 }
 
+/**
+ * The container to default to for exec / logs on a multi-container pod. Honors
+ * the kubectl.kubernetes.io/default-container annotation (the convention
+ * kubectl, k9s, and Lens follow, and what service meshes like Istio set to
+ * point past their injected sidecar), falling back to the first container.
+ * Without this, mesh-injected pods default to their distroless sidecar — which
+ * has no shell — making the terminal appear broken.
+ */
+export function getDefaultContainerName(pod: any): string | undefined {
+  const containers = pod?.spec?.containers || []
+  const annotated = pod?.metadata?.annotations?.['kubectl.kubernetes.io/default-container']
+  if (annotated && containers.some((c: any) => c.name === annotated)) {
+    return annotated
+  }
+  return containers[0]?.name
+}
+
 export function getContainerSquareStates(pod: any): ContainerSquareState[] {
   const result: ContainerSquareState[] = []
   const initStatuses = pod.status?.initContainerStatuses || []

--- a/packages/k8s-ui/src/components/shared/ResourceActionsBar.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceActionsBar.tsx
@@ -24,6 +24,7 @@ import { ConfirmDialog } from '../ui/ConfirmDialog'
 import { DialogPortal } from '../ui/DialogPortal'
 import type { SelectedResource, WorkloadRevision } from '../../types'
 import { formatKindName } from '../ui/drawer-components'
+import { getDefaultContainerName } from '../resources/resource-utils'
 
 // ============================================================================
 // ACTIONS BAR - Interactive buttons that change based on resource kind
@@ -183,7 +184,7 @@ export function ResourceActionsBar({
       onOpenTerminal?.({
         namespace: resource.namespace,
         podName: resource.name,
-        containerName: containers[0],
+        containerName: getDefaultContainerName(data) || containers[0],
         containers,
       })
     }
@@ -195,7 +196,7 @@ export function ResourceActionsBar({
         namespace: resource.namespace,
         podName: resource.name,
         containers,
-        containerName,
+        containerName: containerName || getDefaultContainerName(data),
       })
     }
   }


### PR DESCRIPTION
Fixes #866.

## Problem

On mesh-injected pods (Istio / Anthos Service Mesh, Linkerd) the first container is a distroless sidecar (`istio-proxy`) with no `/bin/sh`. Radar's web terminal defaulted to `containers[0]`, hit the sidecar, the exec failed, and Radar reported it as *"this container doesn't have a shell (distroless)…"* — even though the **app** container next to it has a perfectly good shell. Nothing in the exec path read the `kubectl.kubernetes.io/default-container` annotation, so the apiserver fell through to `containers[0]`.

## Change

- **Honor `kubectl.kubernetes.io/default-container`** when defaulting the exec container, falling back to `containers[0]` — the same convention `kubectl`, k9s, and Lens follow.
  - **Server-side** (`internal/server/exec.go`, authoritative): when the `container` query param is empty, fetch the pod and pick the annotated container. Covers MCP / API / any caller, not just the SPA. Reuses the existing OS-detection pod fetch.
  - **Frontend** (`PodRenderer`, `ResourceActionsBar`): pod-level Terminal **and** Logs openers default via a shared `getDefaultContainerName()` helper, so the container picker pre-selects the right one.
- **Honest error message** (`TerminalTab`): the "Shell not available" panel now names the offending container and, on multi-container pods, suggests trying another container before reaching for a debug container.

I deliberately skipped the optional sidecar-name heuristic from the issue — Istio/Linkerd/ASM all set the annotation, so honoring it covers the real-world case without a hardcoded sidecar list that would rot.

## Tests

- 5 Go cases (`defaultExecContainer`) + 5 TS cases (`getDefaultContainerName`) pinning the precedence: annotation wins, invalid annotation ignored, single/empty pods.
- **End-to-end in kind** (reproduced without Istio: `pause` as `containers[0]`, `busybox` as `app`, annotation → `app`): no-param exec defaults to `app` and the shell works (log confirmed); `?container=sidecar` → `shell_not_found`; `?container=app` → works.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted defaulting and UX copy in the exec path; behavior matches kubectl and falls back to the previous first-container rule when the annotation is absent or invalid.
> 
> **Overview**
> Pod exec and the UI now default to the **app** container on mesh-injected pods instead of the first list entry (often a shell-less sidecar).
> 
> **Server (`exec.go`):** When `container` is omitted, the handler fetches the pod (also reusing that fetch when only OS detection was needed) and sets the target via `kubectl.kubernetes.io/default-container`, then `containers[0]`. The chosen name is stored on the exec session and logged with sanitized namespace/pod names.
> 
> **UI:** Shared `getDefaultContainerName()` drives pod-level **Terminal** and **Logs** defaults in `PodRenderer` and `ResourceActionsBar`. **`TerminalTab`** “Shell not available” copy names the failing container and, on multi-container pods, suggests switching containers before opening a debug container.
> 
> **Tests:** Go `TestDefaultExecContainer` and Vitest for `getDefaultContainerName` lock annotation precedence, invalid annotation fallback, and empty pods.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67564cbe7767e948f08aae38c93086daaeebcd58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->