### PR TITLE
Add endpointslices.discovery.k8s.io to rbac permissions

### DIFF
--- a/deploy/helm/radar/templates/clusterrole.yaml
+++ b/deploy/helm/radar/templates/clusterrole.yaml
@@ -25,6 +25,11 @@ rules:
       - resourcequotas
     verbs: ["get", "list", "watch"]
   - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
       - policy
     resources:
       - poddisruptionbudgets


### PR DESCRIPTION
## Description

Add missing permissions to get/list/watch `endpointslices.discovery.k8s.io`. Seems to have been missed in https://github.com/skyhook-io/radar/pull/850

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How has this been tested?

Adding to `additionalCrdGroups` locally

Describe the tests you ran to verify your changes.

- [x] Tested against a remote cluster

Error fixed: `radar 2026/06/05 14:53:52 [resource-counts] Failed to count EndpointSlice: failed to list resources: endpointslices.discovery.k8s.io is forbidden: User "system:serviceaccount:radar:radar" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope`

## Related issues

Fixes #848
