### PR TITLE
chore(deps): group npm minor/patch updates into one weekly Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,11 @@ updates:
     cooldown:
       default-days: 7
       semver-major-days: 14
+    groups:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Groups all npm minor and patch bumps into a single weekly `npm-minor-patch` Dependabot PR (this week's 5 individual npm PRs would have been 1). Major bumps remain individual PRs with the existing 14-day cooldown.

Mirrors the grouping already used for the gomod ecosystem (`k8s`, `otel`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes Dependabot configuration; no application runtime or dependency resolution behavior in the repo itself.
> 
> **Overview**
> Adds an **`npm-minor-patch`** Dependabot group so weekly npm **minor** and **patch** bumps land in **one** PR instead of many separate ones. **Major** npm updates are unchanged—they still open as individual PRs with the existing 14-day cooldown.
> 
> This matches the grouping pattern already used for **gomod** (`k8s`, `otel`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7b433ea1ca178f17ebb2ca3ba08d16ef145309b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->