### PR TITLE
Stream logs by default (#857)

### DIFF
--- a/packages/k8s-ui/src/components/logs/LogCore.tsx
+++ b/packages/k8s-ui/src/components/logs/LogCore.tsx
@@ -286,7 +286,7 @@ export function LogCore({
       }
       if (e.key === 's' && !e.ctrlKey && !e.metaKey && !e.altKey && onStartStream) {
         const target = e.target as HTMLElement | null
-        if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) return
+        if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT' || target.isContentEditable)) return
         e.preventDefault()
         if (isStreaming) onStopStream()
         else onStartStream()

--- a/packages/k8s-ui/src/components/logs/LogCore.tsx
+++ b/packages/k8s-ui/src/components/logs/LogCore.tsx
@@ -274,17 +274,27 @@ export function LogCore({
     })
   }, [])
 
-  // Keyboard shortcut: Ctrl+F to open search
+  // Keyboard shortcuts: Ctrl+F opens search; bare 's' toggles streaming
+  // (matches k9s). 's' is ignored while typing in a field so it doesn't
+  // hijack search input or other text entry.
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
         e.preventDefault()
         search.open()
+        return
+      }
+      if (e.key === 's' && !e.ctrlKey && !e.metaKey && !e.altKey && onStartStream) {
+        const target = e.target as HTMLElement | null
+        if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) return
+        e.preventDefault()
+        if (isStreaming) onStopStream()
+        else onStartStream()
       }
     }
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [search.open])
+  }, [search.open, onStartStream, onStopStream, isStreaming])
 
   const handleFollowOutput = useCallback((isAtBottom: boolean) => {
     if (isAtBottom) return 'smooth' as const
@@ -846,6 +856,7 @@ export function LogCore({
 
       {/* Keyboard shortcut hints */}
       <div className={`flex items-center gap-4 px-3 py-1 border-t ${palette.border} ${palette.toolbarBg} text-[10px] ${palette.textDisabled}`}>
+        {onStartStream && <Shortcut keys="S" label={isStreaming ? 'Stop stream' : 'Stream'} palette={palette} />}
         <Shortcut keys="Ctrl+F" label="Search" palette={palette} />
         <Shortcut keys="Enter" label="Next match" palette={palette} />
         <Shortcut keys="Shift+Enter" label="Prev match" palette={palette} />

--- a/packages/k8s-ui/src/components/logs/LogToolbarSelects.tsx
+++ b/packages/k8s-ui/src/components/logs/LogToolbarSelects.tsx
@@ -48,6 +48,8 @@ interface LogRangeSelectProps {
   tooltip?: string
   /** Dark/light palette selector. Defaults to `true` (dark viewer). */
   isDark?: boolean
+  /** When true, the control is greyed out and non-interactive. */
+  disabled?: boolean
 }
 
 export function LogRangeSelect({
@@ -56,14 +58,16 @@ export function LogRangeSelect({
   lineOptions = [100, 500, 1000, 5000],
   tooltip = 'How many logs to load — by line count or time range',
   isDark = true,
+  disabled = false,
 }: LogRangeSelectProps) {
   const palette = getLogPalette(isDark)
   return (
-    <Tooltip content={tooltip} position="bottom">
+    <Tooltip content={disabled ? 'Stop streaming to change the log range' : tooltip} position="bottom">
       <select
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className={`${selectClass(palette)} pr-5`}
+        disabled={disabled}
+        className={`${selectClass(palette)} pr-5 ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
       >
         <optgroup label="Lines">
           {lineOptions.map(n => (

--- a/packages/k8s-ui/src/components/logs/LogsViewer.tsx
+++ b/packages/k8s-ui/src/components/logs/LogsViewer.tsx
@@ -134,6 +134,10 @@ export function LogsViewer({
     if (autoStartedForRef.current === selectedContainer) return
     autoStartedForRef.current = selectedContainer
     handleStartStreaming()
+    // Reset the arm latch on teardown so a re-run re-streams — without this,
+    // React Strict Mode's mount→unmount→mount closes the stream but the latch
+    // stays set, leaving the viewer static.
+    return () => { autoStartedForRef.current = null }
   }, [willAutoStream, selectedContainer, handleStartStreaming])
 
   const downloadLogs = useCallback((format: DownloadFormat) => {

--- a/packages/k8s-ui/src/components/logs/LogsViewer.tsx
+++ b/packages/k8s-ui/src/components/logs/LogsViewer.tsx
@@ -169,19 +169,20 @@ export function LogsViewer({
     <>
       <ContainerSelect containers={containers} value={selectedContainer} onChange={setSelectedContainer} isDark={isDark} />
 
-      <Tooltip content="Show logs from the pod's previous instance (if it was restarted). Useful for troubleshooting crashed containers." position="bottom">
-        <label className={`flex items-center gap-1.5 text-xs ${palette.textSecondary}`}>
+      <Tooltip content={isStreaming ? 'Stop streaming to view the previous instance' : "Show logs from the pod's previous instance (if it was restarted). Useful for troubleshooting crashed containers."} position="bottom">
+        <label className={`flex items-center gap-1.5 text-xs ${palette.textSecondary} ${isStreaming ? 'opacity-50 cursor-not-allowed' : ''}`}>
           <input
             type="checkbox"
             checked={showPrevious}
             onChange={(e) => setShowPrevious(e.target.checked)}
+            disabled={isStreaming}
             className={`w-3 h-3 rounded ${palette.borderLight} ${palette.elevatedBg} text-blue-500 focus:ring-blue-500 focus:ring-offset-0`}
           />
           <span className={`border-b border-dotted ${isDark ? 'border-slate-500' : 'border-slate-400'}`}>Previous</span>
         </label>
       </Tooltip>
 
-      <LogRangeSelect value={logRange} onChange={setLogRange} isDark={isDark} />
+      <LogRangeSelect value={logRange} onChange={setLogRange} isDark={isDark} disabled={isStreaming} />
     </>
   )
 

--- a/packages/k8s-ui/src/components/logs/LogsViewer.tsx
+++ b/packages/k8s-ui/src/components/logs/LogsViewer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { parseLogLine, parseLogRange } from '../../utils/log-format'
 import { triggerDownload } from '../../utils/download'
 import { useLogBuffer } from './useLogBuffer'
@@ -30,6 +30,12 @@ export interface LogsViewerProps {
   overrideDownload?: (content: string, mime: string, filename: string) => void
   /** Force dark mode on the logs container (default: true) */
   forceDark?: boolean
+  /**
+   * Open the stream automatically on mount (and on container switch) instead of
+   * loading a static snapshot. The user can still Stop, and a manual Stop is not
+   * re-armed. Requires `createStream`. Default: false.
+   */
+  autoStream?: boolean
 }
 
 export function LogsViewer({
@@ -41,6 +47,7 @@ export function LogsViewer({
   createStream,
   overrideDownload,
   forceDark,
+  autoStream = false,
 }: LogsViewerProps) {
   const [selectedContainer, setSelectedContainer] = useState(initialContainer || containers[0] || '')
   const [isLoading, setIsLoading] = useState(false)
@@ -52,6 +59,13 @@ export function LogsViewer({
   const { tailLines, sinceSeconds } = parseLogRange(logRange)
   const { entries, append, set, clear } = useLogBuffer()
   const { isStreaming, startStreaming, stopStreaming } = useLogStream()
+
+  const willAutoStream = autoStream && !!createStream
+  // Tracks the container we've already auto-started for, so re-renders don't
+  // re-open the stream, and a container switch arms a fresh auto-start.
+  const autoStartedForRef = useRef<string | null>(null)
+  // Once the user explicitly Stops, don't auto-resume for this viewer's lifetime.
+  const userStoppedRef = useRef(false)
 
   const loadLogs = useCallback(async () => {
     if (!selectedContainer) return
@@ -72,11 +86,17 @@ export function LogsViewer({
     }
   }, [selectedContainer, tailLines, sinceSeconds, showPrevious, fetchLogs, set])
 
-  useEffect(() => { loadLogs() }, [loadLogs])
+  // When auto-streaming the stream supplies the initial tail, so the static
+  // snapshot fetch is skipped to avoid a redundant request and a flash of
+  // snapshot content before the stream takes over.
+  useEffect(() => { if (!willAutoStream) loadLogs() }, [loadLogs, willAutoStream])
   useEffect(() => { stopStreaming() }, [selectedContainer, stopStreaming])
 
   const handleStartStreaming = useCallback(() => {
     if (!createStream) return
+    // The stream replays the last N lines (TailLines + Follow); clear first so
+    // they don't duplicate whatever the snapshot already loaded.
+    clear()
     startStreaming(
       () => createStream({ container: selectedContainer, tailLines: 100, sinceSeconds }),
       {
@@ -87,7 +107,20 @@ export function LogsViewer({
         }),
       },
     )
-  }, [createStream, startStreaming, selectedContainer, sinceSeconds, append])
+  }, [createStream, startStreaming, selectedContainer, sinceSeconds, append, clear])
+
+  const handleStopStreaming = useCallback(() => {
+    userStoppedRef.current = true
+    stopStreaming()
+  }, [stopStreaming])
+
+  useEffect(() => {
+    if (!willAutoStream || !selectedContainer) return
+    if (userStoppedRef.current) return
+    if (autoStartedForRef.current === selectedContainer) return
+    autoStartedForRef.current = selectedContainer
+    handleStartStreaming()
+  }, [willAutoStream, selectedContainer, handleStartStreaming])
 
   const downloadLogs = useCallback((format: DownloadFormat) => {
     let content: string
@@ -138,14 +171,18 @@ export function LogsViewer({
     </>
   )
 
+  // While the auto-stream is opening (before the first 'connected'/log event),
+  // show the loading state rather than the empty-logs placeholder.
+  const isConnecting = willAutoStream && !isStreaming && entries.length === 0 && !userStoppedRef.current
+
   return (
     <LogCore
       entries={entries}
-      isLoading={isLoading}
+      isLoading={isLoading || isConnecting}
       errorMessage={fetchError}
       isStreaming={isStreaming}
       onStartStream={createStream ? handleStartStreaming : undefined}
-      onStopStream={stopStreaming}
+      onStopStream={handleStopStreaming}
       onRefresh={loadLogs}
       onDownload={downloadLogs}
       onClear={clear}

--- a/packages/k8s-ui/src/components/logs/LogsViewer.tsx
+++ b/packages/k8s-ui/src/components/logs/LogsViewer.tsx
@@ -58,7 +58,7 @@ export function LogsViewer({
 
   const { tailLines, sinceSeconds } = parseLogRange(logRange)
   const { entries, append, set, clear } = useLogBuffer()
-  const { isStreaming, startStreaming, stopStreaming } = useLogStream()
+  const { isStreaming, streamError, startStreaming, stopStreaming } = useLogStream()
 
   const willAutoStream = autoStream && !!createStream
   // Tracks the container we've already auto-started for, so re-renders don't
@@ -106,6 +106,7 @@ export function LogsViewer({
           container: data.container || selectedContainer,
         }),
       },
+      'Log stream connection failed',
     )
   }, [createStream, startStreaming, selectedContainer, sinceSeconds, append, clear])
 
@@ -172,14 +173,15 @@ export function LogsViewer({
   )
 
   // While the auto-stream is opening (before the first 'connected'/log event),
-  // show the loading state rather than the empty-logs placeholder.
-  const isConnecting = willAutoStream && !isStreaming && entries.length === 0 && !userStoppedRef.current
+  // show the loading state rather than the empty-logs placeholder. A stream
+  // error settles the connecting state so it can't spin forever.
+  const isConnecting = willAutoStream && !isStreaming && entries.length === 0 && !userStoppedRef.current && !streamError
 
   return (
     <LogCore
       entries={entries}
       isLoading={isLoading || isConnecting}
-      errorMessage={fetchError}
+      errorMessage={fetchError || (entries.length === 0 ? streamError : null)}
       isStreaming={isStreaming}
       onStartStream={createStream ? handleStartStreaming : undefined}
       onStopStream={handleStopStreaming}

--- a/packages/k8s-ui/src/components/logs/LogsViewer.tsx
+++ b/packages/k8s-ui/src/components/logs/LogsViewer.tsx
@@ -88,9 +88,21 @@ export function LogsViewer({
 
   // When auto-streaming the stream supplies the initial tail, so the static
   // snapshot fetch is skipped to avoid a redundant request and a flash of
-  // snapshot content before the stream takes over.
-  useEffect(() => { if (!willAutoStream) loadLogs() }, [loadLogs, willAutoStream])
+  // snapshot content before the stream takes over. If the user has Stopped we
+  // won't auto-start, so fall back to the snapshot — otherwise a container
+  // switch would keep showing the previous container's lines.
+  useEffect(() => {
+    if (!willAutoStream || userStoppedRef.current) loadLogs()
+  }, [loadLogs, willAutoStream])
   useEffect(() => { stopStreaming() }, [selectedContainer, stopStreaming])
+
+  // If auto-stream turns off while a stream is open (e.g. the pod went
+  // terminal), stop following so live appends don't race the snapshot.
+  const prevWillAutoStreamRef = useRef(willAutoStream)
+  useEffect(() => {
+    if (prevWillAutoStreamRef.current && !willAutoStream && isStreaming) stopStreaming()
+    prevWillAutoStreamRef.current = willAutoStream
+  }, [willAutoStream, isStreaming, stopStreaming])
 
   const handleStartStreaming = useCallback(() => {
     if (!createStream) return

--- a/packages/k8s-ui/src/components/logs/LogsViewer.tsx
+++ b/packages/k8s-ui/src/components/logs/LogsViewer.tsx
@@ -58,7 +58,7 @@ export function LogsViewer({
 
   const { tailLines, sinceSeconds } = parseLogRange(logRange)
   const { entries, append, set, clear } = useLogBuffer()
-  const { isStreaming, streamError, startStreaming, stopStreaming } = useLogStream()
+  const { isStreaming, streamError, connecting, startStreaming, stopStreaming } = useLogStream()
 
   const willAutoStream = autoStream && !!createStream
   // Tracks the container we've already auto-started for, so re-renders don't
@@ -95,7 +95,8 @@ export function LogsViewer({
   const handleStartStreaming = useCallback(() => {
     if (!createStream) return
     // The stream replays the last N lines (TailLines + Follow); clear first so
-    // they don't duplicate whatever the snapshot already loaded.
+    // they don't duplicate lines already in the buffer (the snapshot on the
+    // manual path, or an earlier stream on restart).
     clear()
     startStreaming(
       () => createStream({ container: selectedContainer, tailLines: 100, sinceSeconds }),
@@ -172,10 +173,9 @@ export function LogsViewer({
     </>
   )
 
-  // While the auto-stream is opening (before the first 'connected'/log event),
-  // show the loading state rather than the empty-logs placeholder. A stream
-  // error settles the connecting state so it can't spin forever.
-  const isConnecting = willAutoStream && !isStreaming && entries.length === 0 && !userStoppedRef.current && !streamError
+  // While the auto-stream is opening (before it first settles), show the
+  // loading state rather than the empty-logs placeholder.
+  const isConnecting = willAutoStream && connecting && entries.length === 0
 
   return (
     <LogCore

--- a/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
+++ b/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
@@ -67,7 +67,7 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
 
   const { tailLines, sinceSeconds } = parseLogRange(logRange)
   const { entries, append, set, clear } = useLogBuffer()
-  const { isStreaming, streamError, startStreaming, stopStreaming } = useLogStream()
+  const { isStreaming, streamError, connecting, startStreaming, stopStreaming } = useLogStream()
 
   const willAutoStream = autoStream && !!createStream
   // null sentinel so the initial selectedContainer ('' = all) still arms once.
@@ -125,7 +125,8 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
   const handleStartStreaming = useCallback(() => {
     if (!createStream) return
     // The stream replays the last N lines per pod (TailLines + Follow); clear
-    // first so they don't duplicate whatever the snapshot already loaded.
+    // first so they don't duplicate lines already in the buffer (the snapshot on
+    // the manual path, or an earlier stream on restart).
     clear()
     startStreaming(
       () => createStream({ container: selectedContainer || undefined, tailLines: 50, sinceSeconds }),
@@ -314,10 +315,9 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
     </>
   )
 
-  // While the auto-stream is opening (before the first 'connected'/log event),
-  // show the loading state rather than the empty-logs placeholder. A stream
-  // error settles the connecting state so it can't spin forever.
-  const isConnecting = willAutoStream && !isStreaming && entries.length === 0 && !userStoppedRef.current && !streamError
+  // While the auto-stream is opening (before it first settles), show the
+  // loading state rather than the empty-logs placeholder.
+  const isConnecting = willAutoStream && connecting && entries.length === 0
 
   return (
     <LogCore

--- a/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
+++ b/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
@@ -47,9 +47,15 @@ export interface WorkloadLogsViewerProps {
   overrideDownload?: (content: string, mime: string, filename: string) => void
   /** Force dark mode on the logs container (default: true) */
   forceDark?: boolean
+  /**
+   * Open the stream automatically on mount (and on container switch) instead of
+   * loading a static snapshot. The user can still Stop, and a manual Stop is not
+   * re-armed. Requires `createStream`. Default: false.
+   */
+  autoStream?: boolean
 }
 
-export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownload, forceDark }: WorkloadLogsViewerProps) {
+export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownload, forceDark, autoStream = false }: WorkloadLogsViewerProps) {
   const [selectedContainer, setSelectedContainer] = useState<string>('')
   const [pods, setPods] = useState<WorkloadPodInfo[]>([])
   const [selectedPods, setSelectedPods] = useState<Set<string>>(new Set())
@@ -62,6 +68,11 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
   const { tailLines, sinceSeconds } = parseLogRange(logRange)
   const { entries, append, set, clear } = useLogBuffer()
   const { isStreaming, startStreaming, stopStreaming } = useLogStream()
+
+  const willAutoStream = autoStream && !!createStream
+  // null sentinel so the initial selectedContainer ('' = all) still arms once.
+  const autoStartedForRef = useRef<string | null>(null)
+  const userStoppedRef = useRef(false)
 
   // Map pod.name → index. Color classes are resolved at render time from the
   // current palette (see LogCore / pod-filter dropdown below) so toggling
@@ -105,11 +116,17 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
     }
   }, [fetchAll, selectedContainer, tailLines, sinceSeconds, set])
 
-  useEffect(() => { loadLogs() }, [loadLogs])
+  // When auto-streaming the stream supplies the initial tail, so the static
+  // snapshot fetch is skipped to avoid a redundant request and a flash of
+  // snapshot content before the stream takes over.
+  useEffect(() => { if (!willAutoStream) loadLogs() }, [loadLogs, willAutoStream])
   useEffect(() => { stopStreaming() }, [selectedContainer, stopStreaming])
 
   const handleStartStreaming = useCallback(() => {
     if (!createStream) return
+    // The stream replays the last N lines per pod (TailLines + Follow); clear
+    // first so they don't duplicate whatever the snapshot already loaded.
+    clear()
     startStreaming(
       () => createStream({ container: selectedContainer || undefined, tailLines: 50, sinceSeconds }),
       {
@@ -158,7 +175,20 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
       },
       'Workload log stream error',
     )
-  }, [createStream, startStreaming, selectedContainer, sinceSeconds, append, podColorIndex, selectedPods.size])
+  }, [createStream, startStreaming, selectedContainer, sinceSeconds, append, podColorIndex, selectedPods.size, clear])
+
+  const handleStopStreaming = useCallback(() => {
+    userStoppedRef.current = true
+    stopStreaming()
+  }, [stopStreaming])
+
+  useEffect(() => {
+    if (!willAutoStream) return
+    if (userStoppedRef.current) return
+    if (autoStartedForRef.current === selectedContainer) return
+    autoStartedForRef.current = selectedContainer
+    handleStartStreaming()
+  }, [willAutoStream, selectedContainer, handleStartStreaming])
 
   const allContainers = useMemo(() => {
     const s = new Set<string>()
@@ -284,13 +314,17 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
     </>
   )
 
+  // While the auto-stream is opening (before the first 'connected'/log event),
+  // show the loading state rather than the empty-logs placeholder.
+  const isConnecting = willAutoStream && !isStreaming && entries.length === 0 && !userStoppedRef.current
+
   return (
     <LogCore
       entries={filteredEntries}
-      isLoading={isLoading}
+      isLoading={isLoading || isConnecting}
       isStreaming={isStreaming}
       onStartStream={createStream ? handleStartStreaming : undefined}
-      onStopStream={stopStreaming}
+      onStopStream={handleStopStreaming}
       onRefresh={loadLogs}
       onDownload={downloadLogs}
       onClear={clear}

--- a/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
+++ b/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
@@ -323,6 +323,7 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
         lineOptions={[50, 100, 500, 1000]}
         tooltip="How many logs to load per pod — by line count or time range"
         isDark={isDark}
+        disabled={isStreaming}
       />
     </>
   )

--- a/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
+++ b/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
@@ -201,6 +201,10 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
     if (autoStartedForRef.current === selectedContainer) return
     autoStartedForRef.current = selectedContainer
     handleStartStreaming()
+    // Reset the arm latch on teardown so a re-run re-streams — without this,
+    // React Strict Mode's mount→unmount→mount closes the stream but the latch
+    // stays set, leaving the viewer static.
+    return () => { autoStartedForRef.current = null }
   }, [willAutoStream, selectedContainer, handleStartStreaming])
 
   const allContainers = useMemo(() => {

--- a/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
+++ b/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
@@ -67,7 +67,7 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
 
   const { tailLines, sinceSeconds } = parseLogRange(logRange)
   const { entries, append, set, clear } = useLogBuffer()
-  const { isStreaming, startStreaming, stopStreaming } = useLogStream()
+  const { isStreaming, streamError, startStreaming, stopStreaming } = useLogStream()
 
   const willAutoStream = autoStream && !!createStream
   // null sentinel so the initial selectedContainer ('' = all) still arms once.
@@ -173,7 +173,7 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
           }
         },
       },
-      'Workload log stream error',
+      'Workload log stream connection failed',
     )
   }, [createStream, startStreaming, selectedContainer, sinceSeconds, append, podColorIndex, selectedPods.size, clear])
 
@@ -315,8 +315,9 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
   )
 
   // While the auto-stream is opening (before the first 'connected'/log event),
-  // show the loading state rather than the empty-logs placeholder.
-  const isConnecting = willAutoStream && !isStreaming && entries.length === 0 && !userStoppedRef.current
+  // show the loading state rather than the empty-logs placeholder. A stream
+  // error settles the connecting state so it can't spin forever.
+  const isConnecting = willAutoStream && !isStreaming && entries.length === 0 && !userStoppedRef.current && !streamError
 
   return (
     <LogCore
@@ -331,7 +332,7 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
       toolbarExtra={renderToolbarExtra}
       showPodName
       emptyMessage={pods.length === 0 ? 'No pods found' : 'No logs available'}
-      errorMessage={fetchError}
+      errorMessage={fetchError || (entries.length === 0 ? streamError : null)}
       forceDark={forceDark}
     />
   )

--- a/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
+++ b/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
@@ -118,9 +118,21 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
 
   // When auto-streaming the stream supplies the initial tail, so the static
   // snapshot fetch is skipped to avoid a redundant request and a flash of
-  // snapshot content before the stream takes over.
-  useEffect(() => { if (!willAutoStream) loadLogs() }, [loadLogs, willAutoStream])
+  // snapshot content before the stream takes over. If the user has Stopped we
+  // won't auto-start, so fall back to the snapshot — otherwise a container
+  // switch would keep showing the previous selection's lines.
+  useEffect(() => {
+    if (!willAutoStream || userStoppedRef.current) loadLogs()
+  }, [loadLogs, willAutoStream])
   useEffect(() => { stopStreaming() }, [selectedContainer, stopStreaming])
+
+  // If auto-stream turns off while a stream is open, stop following so live
+  // appends don't race the snapshot.
+  const prevWillAutoStreamRef = useRef(willAutoStream)
+  useEffect(() => {
+    if (prevWillAutoStreamRef.current && !willAutoStream && isStreaming) stopStreaming()
+    prevWillAutoStreamRef.current = willAutoStream
+  }, [willAutoStream, isStreaming, stopStreaming])
 
   const handleStartStreaming = useCallback(() => {
     if (!createStream) return

--- a/packages/k8s-ui/src/components/logs/useLogStream.ts
+++ b/packages/k8s-ui/src/components/logs/useLogStream.ts
@@ -89,10 +89,14 @@ export function useLogStream() {
     })
 
     es.addEventListener('error', (event) => {
-      handleSSEError(event, errorContext, () => { setIsStreaming(false); es.close() })
+      setIsStreaming(false)
       setConnecting(false)
-      // Don't report the close that normally follows a clean 'end' as a failure.
-      if (!endedRef.current) setStreamError(errorContext)
+      es.close()
+      // The browser fires 'error' on the normal close that follows a clean
+      // 'end'; that's not a failure, so don't log it or surface it.
+      if (endedRef.current) return
+      handleSSEError(event, errorContext, () => {})
+      setStreamError(errorContext)
     })
 
     eventSourceRef.current = es

--- a/packages/k8s-ui/src/components/logs/useLogStream.ts
+++ b/packages/k8s-ui/src/components/logs/useLogStream.ts
@@ -48,8 +48,13 @@ export function useLogStream() {
     setStreamError(null)
     setConnecting(true)
     const es = create()
+    // Ignore events from a superseded source: closing/replacing an EventSource
+    // (Stop, container switch, restart) can fire a late, async 'error' that
+    // would otherwise corrupt the new stream's state or show a false failure.
+    const isCurrent = () => eventSourceRef.current === es
 
     es.addEventListener('connected', (event) => {
+      if (!isCurrent()) return
       setIsStreaming(true)
       setConnecting(false)
       if (handlers.onConnected) {
@@ -60,6 +65,7 @@ export function useLogStream() {
     })
 
     es.addEventListener('log', (event) => {
+      if (!isCurrent()) return
       setConnecting(false)
       try { handlers.onLog(JSON.parse((event as MessageEvent).data)) } catch (e) {
         console.error('Failed to parse log event:', e)
@@ -67,6 +73,7 @@ export function useLogStream() {
     })
 
     es.addEventListener('pod_added', (event) => {
+      if (!isCurrent()) return
       if (handlers.onPodAdded) {
         try { handlers.onPodAdded(JSON.parse((event as MessageEvent).data)) } catch (e) {
           console.error('Failed to parse pod_added event:', e)
@@ -75,6 +82,7 @@ export function useLogStream() {
     })
 
     es.addEventListener('pod_removed', (event) => {
+      if (!isCurrent()) return
       if (handlers.onPodRemoved) {
         try { handlers.onPodRemoved(JSON.parse((event as MessageEvent).data)) } catch (e) {
           console.error('Failed to parse pod_removed event:', e)
@@ -83,12 +91,14 @@ export function useLogStream() {
     })
 
     es.addEventListener('end', () => {
+      if (!isCurrent()) return
       endedRef.current = true
       setIsStreaming(false)
       setConnecting(false)
     })
 
     es.addEventListener('error', (event) => {
+      if (!isCurrent()) { es.close(); return }
       setIsStreaming(false)
       setConnecting(false)
       es.close()

--- a/packages/k8s-ui/src/components/logs/useLogStream.ts
+++ b/packages/k8s-ui/src/components/logs/useLogStream.ts
@@ -18,6 +18,9 @@ export interface LogStreamHandlers {
  */
 export function useLogStream() {
   const [isStreaming, setIsStreaming] = useState(false)
+  // Set when the SSE connection errors so callers can stop showing a
+  // "connecting…" state forever if the stream never reaches `connected`.
+  const [streamError, setStreamError] = useState<string | null>(null)
   const eventSourceRef = useRef<EventSource | null>(null)
 
   const stopStreaming = useCallback(() => {
@@ -32,6 +35,7 @@ export function useLogStream() {
     errorContext = 'Log stream error',
   ) => {
     eventSourceRef.current?.close()
+    setStreamError(null)
     const es = create()
 
     es.addEventListener('connected', (event) => {
@@ -69,6 +73,7 @@ export function useLogStream() {
 
     es.addEventListener('error', (event) => {
       handleSSEError(event, errorContext, () => { setIsStreaming(false); es.close() })
+      setStreamError(errorContext)
     })
 
     eventSourceRef.current = es
@@ -77,5 +82,5 @@ export function useLogStream() {
   // Cleanup on unmount
   useEffect(() => () => { eventSourceRef.current?.close() }, [])
 
-  return { isStreaming, startStreaming, stopStreaming }
+  return { isStreaming, streamError, startStreaming, stopStreaming }
 }

--- a/packages/k8s-ui/src/components/logs/useLogStream.ts
+++ b/packages/k8s-ui/src/components/logs/useLogStream.ts
@@ -18,15 +18,24 @@ export interface LogStreamHandlers {
  */
 export function useLogStream() {
   const [isStreaming, setIsStreaming] = useState(false)
-  // Set when the SSE connection errors so callers can stop showing a
-  // "connecting…" state forever if the stream never reaches `connected`.
+  // Set when the connection fails (and not on a clean end — see endedRef).
   const [streamError, setStreamError] = useState<string | null>(null)
+  // True from a start attempt until the stream first settles (connected / end /
+  // error / stop). Lets callers show a connecting spinner that won't reappear
+  // after a clean end. Starts true so an auto-stream viewer paints the spinner
+  // immediately instead of flashing the empty state.
+  const [connecting, setConnecting] = useState(true)
   const eventSourceRef = useRef<EventSource | null>(null)
+  // EventSource fires a generic 'error' on the normal close that follows the
+  // server's 'end'; this distinguishes a clean end from a real failure.
+  const endedRef = useRef(false)
 
   const stopStreaming = useCallback(() => {
     eventSourceRef.current?.close()
     eventSourceRef.current = null
     setIsStreaming(false)
+    setConnecting(false)
+    setStreamError(null)
   }, [])
 
   const startStreaming = useCallback((
@@ -35,11 +44,14 @@ export function useLogStream() {
     errorContext = 'Log stream error',
   ) => {
     eventSourceRef.current?.close()
+    endedRef.current = false
     setStreamError(null)
+    setConnecting(true)
     const es = create()
 
     es.addEventListener('connected', (event) => {
       setIsStreaming(true)
+      setConnecting(false)
       if (handlers.onConnected) {
         try { handlers.onConnected(JSON.parse((event as MessageEvent).data)) } catch (e) {
           console.error('Failed to parse connected event:', e)
@@ -48,6 +60,7 @@ export function useLogStream() {
     })
 
     es.addEventListener('log', (event) => {
+      setConnecting(false)
       try { handlers.onLog(JSON.parse((event as MessageEvent).data)) } catch (e) {
         console.error('Failed to parse log event:', e)
       }
@@ -69,11 +82,17 @@ export function useLogStream() {
       }
     })
 
-    es.addEventListener('end', () => setIsStreaming(false))
+    es.addEventListener('end', () => {
+      endedRef.current = true
+      setIsStreaming(false)
+      setConnecting(false)
+    })
 
     es.addEventListener('error', (event) => {
       handleSSEError(event, errorContext, () => { setIsStreaming(false); es.close() })
-      setStreamError(errorContext)
+      setConnecting(false)
+      // Don't report the close that normally follows a clean 'end' as a failure.
+      if (!endedRef.current) setStreamError(errorContext)
     })
 
     eventSourceRef.current = es
@@ -82,5 +101,5 @@ export function useLogStream() {
   // Cleanup on unmount
   useEffect(() => () => { eventSourceRef.current?.close() }, [])
 
-  return { isStreaming, streamError, startStreaming, stopStreaming }
+  return { isStreaming, streamError, connecting, startStreaming, stopStreaming }
 }

--- a/web/src/components/logs/LogsViewer.tsx
+++ b/web/src/components/logs/LogsViewer.tsx
@@ -10,9 +10,11 @@ interface LogsViewerProps {
   podName: string
   containers: string[]
   initialContainer?: string
+  /** Start streaming on mount. Default true — callers pass false for terminal (completed/failed) pods. */
+  autoStream?: boolean
 }
 
-export function LogsViewer({ namespace, podName, containers, initialContainer }: LogsViewerProps) {
+export function LogsViewer({ namespace, podName, containers, initialContainer, autoStream = true }: LogsViewerProps) {
   const desktopDownload = useDesktopDownload()
   const { theme } = useTheme()
 
@@ -42,6 +44,7 @@ export function LogsViewer({ namespace, podName, containers, initialContainer }:
       createStream={makeStream}
       overrideDownload={desktopDownload}
       forceDark={theme === 'dark' ? true : undefined}
+      autoStream={autoStream}
     />
   )
 }

--- a/web/src/components/logs/WorkloadLogsViewer.tsx
+++ b/web/src/components/logs/WorkloadLogsViewer.tsx
@@ -9,9 +9,11 @@ interface WorkloadLogsViewerProps {
   kind: string
   namespace: string
   name: string
+  /** Start streaming on mount. Default true — workload logs are aggregated from live pods. */
+  autoStream?: boolean
 }
 
-export function WorkloadLogsViewer({ kind, namespace, name }: WorkloadLogsViewerProps) {
+export function WorkloadLogsViewer({ kind, namespace, name, autoStream = true }: WorkloadLogsViewerProps) {
   const desktopDownload = useDesktopDownload()
   const { theme } = useTheme()
 
@@ -38,6 +40,7 @@ export function WorkloadLogsViewer({ kind, namespace, name }: WorkloadLogsViewer
       createStream={makeStream}
       overrideDownload={desktopDownload}
       forceDark={theme === 'dark' ? true : undefined}
+      autoStream={autoStream}
     />
   )
 }

--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -705,9 +705,11 @@ function PodLogsTab({ namespace, name, resource, initialContainer, onConsumeInit
     return names
   }, [resource])
 
-  // A terminated pod has nothing to follow — only stream live ones.
+  // A terminated pod has nothing to follow — only stream live ones. Wait for
+  // the phase to be known so a completed pod isn't briefly streamed while the
+  // resource is still loading.
   const phase = resource?.status?.phase
-  const autoStream = phase !== 'Succeeded' && phase !== 'Failed'
+  const autoStream = !!phase && phase !== 'Succeeded' && phase !== 'Failed'
 
   useEffect(() => {
     if (initialContainer && containers.includes(initialContainer)) {

--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -705,6 +705,10 @@ function PodLogsTab({ namespace, name, resource, initialContainer, onConsumeInit
     return names
   }, [resource])
 
+  // A terminated pod has nothing to follow — only stream live ones.
+  const phase = resource?.status?.phase
+  const autoStream = phase !== 'Succeeded' && phase !== 'Failed'
+
   useEffect(() => {
     if (initialContainer && containers.includes(initialContainer)) {
       onConsumeInitialContainer?.()
@@ -718,6 +722,7 @@ function PodLogsTab({ namespace, name, resource, initialContainer, onConsumeInit
         podName={name}
         containers={containers}
         initialContainer={initialContainer || undefined}
+        autoStream={autoStream}
       />
     </div>
   )

--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -747,6 +747,13 @@ function MultiPodLogsTab({ pods, namespace, selectedPod, onSelectPod, initialCon
   const { data: logsData } = usePodLogs(podNamespace, selectedPod || '', { tailLines: 1 })
   const containers = logsData?.containers || []
 
+  // A terminated pod (common for Job/CronJob children) has nothing to follow —
+  // only stream live ones. Wait for the pod to load before deciding so we don't
+  // briefly auto-stream a completed pod while its phase is still unknown.
+  const { data: selectedPodResource } = useResource<any>('Pod', podNamespace, selectedPod || '')
+  const phase = selectedPodResource?.status?.phase
+  const autoStream = !!phase && phase !== 'Succeeded' && phase !== 'Failed'
+
   if (pods.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-full text-theme-text-tertiary">
@@ -784,6 +791,7 @@ function MultiPodLogsTab({ pods, namespace, selectedPod, onSelectPod, initialCon
             podName={selectedPod}
             containers={containers}
             initialContainer={initialContainer || undefined}
+            autoStream={autoStream}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary

Log viewers now **start streaming on mount** instead of requiring a click on the Stream button. As [#857](https://github.com/skyhook-io/radar/issues/857) notes, almost every comparable tool follows logs by default — k9s, Lens, ArgoCD, and Rancher all do. Today users keep forgetting to hit Stream and think their container is idle.

Terminated pods (`Succeeded`/`Failed`) deliberately do **not** auto-stream — there's nothing to follow — so they still load a static snapshot.

## What changed

- **New optional `autoStream` prop** on `LogsViewer` / `WorkloadLogsViewer` (default `false`, so `@skyhook-io/k8s-ui` consumers like Radar Hub are unaffected unless they opt in). Radar's web wrappers opt in:
  - Workload aggregate (Deploy/STS/DS) + dock pod logs → on
  - Single Pod → gated on phase (off for completed/failed); multi-pod (Job/CronJob) waits for the selected pod's phase before deciding
- **Respects the user.** Auto-start is keyed per-container and a manual **Stop** is sticky (won't re-arm). The redundant snapshot fetch is skipped while auto-streaming.
- **Fixes a pre-existing duplication bug.** The stream replays the last N lines (`TailLines` + `Follow`) and the buffer has no dedup, so starting a stream on top of the snapshot duplicated ~100 lines — for manual clicks too. The buffer is now cleared at stream start.
- **Snapshot-only controls** (Previous, log-range) are disabled while streaming — under the auto-stream default they otherwise appeared to do nothing. Stop to adjust them.
- **`s` toggles streaming** (k9s parity), ignored while typing in a field (input/textarea/select), documented in the shortcut hint bar.

Scroll-pause needed no work — Virtuoso already pauses follow when you scroll up, with a "Scroll to bottom" button to resume.

## Lifecycle hardening (review follow-ups)

`useLogStream` now exposes `connecting` + `streamError`:
- A connecting state bounded to the actual attempt — no infinite spinner if the SSE fails before connecting.
- The EventSource `error` that fires on the **normal close after `end`** is treated as a clean shutdown, not a failure (no false "connection failed" screen or console noise).
- Events from a superseded stream (after Stop / container switch / restart) are ignored, so a late async `error` can't corrupt the active stream or show a false failure.
- Switching container after a manual Stop reloads the snapshot instead of stranding the previous container's lines.
- When a followed pod goes terminal mid-stream, the open stream is stopped so live appends don't race the snapshot.

## Testing

- `make tsc` clean; 507/507 k8s-ui unit tests pass (on every commit).
- Visual-tested against a live cluster: running pod (dock) auto-streams; `s` toggles off/on; completed pod stays static with no duplicated lines; Deployment aggregate auto-streams; and a pod exiting mid-stream correctly shows "No logs available" rather than a false error.

Closes #857

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes log load/stream lifecycle and keyboard handling across pod and workload viewers; mistakes could cause missed streams, false errors, or wrong behavior for terminal pods.
> 
> **Overview**
> Log viewers **open SSE streaming on mount** by default in the Radar web app (opt-in via new **`autoStream`** on shared `LogsViewer` / `WorkloadLogsViewer`; library default stays `false`). Auto-start is per container/selection, **manual Stop is sticky**, and the initial snapshot fetch is skipped while auto-streaming to avoid flash and duplicate tails.
> 
> **`useLogStream`** now exposes **`connecting`** and **`streamError`**, treats post-`end` EventSource errors as clean shutdown, and ignores events from superseded connections. Starting a stream **clears the buffer** so replayed tail lines don’t duplicate snapshot content. **Previous** and **log range** are disabled while streaming; **`s`** toggles stream/stop (not in text fields), with a footer hint.
> 
> Workload/pod tabs pass **`autoStream`** only when phase is known and not `Succeeded`/`Failed`; if auto-stream turns off mid-session, open streams are stopped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2affa997c43f8b221d88cf4f53b45fccd37f4df4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->