### PR TITLE
Custom label/annotation columns in resource tables (#776)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Table-based resource browser with smart columns per resource kind.
 
 - Browse all resource types including CRDs
 - Search by name, filter by status or problems (CrashLoopBackOff, ImagePullBackOff, etc.)
+- Add custom columns from any label or annotation — sortable, filterable, and resizable
 - Click any resource for YAML manifest, related resources, logs, and events
 
 ### Image Filesystem Viewer

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect, useCallback, useRef, useContext } from 'react'
+import React, { useState, useMemo, useEffect, useCallback, useRef, useContext, useId } from 'react'
 import { TableVirtuoso, type TableVirtuosoHandle } from 'react-virtuoso'
 import { useRefreshAnimation } from '../../hooks/useRefreshAnimation'
 import { PaneLoader } from '../ui/PaneLoader'
@@ -1677,6 +1677,29 @@ function getDefaultVisibleColumns(columns: Column[]): Set<string> {
   return new Set(columns.filter(c => c.defaultVisible !== false).map(c => c.key))
 }
 
+// Host-injected leading columns minus any whose key collides with a built-in.
+// Rendering two columns under one key duplicates React keys and corrupts the
+// visibleColumns / columnWidths maps, so a colliding extra is dropped (dev-warn).
+// Shared by the allColumns memo and the settings-load effect so the collision
+// rule can't drift between them.
+function filterHostExtras(
+  extraLeadingColumns: ExtraColumn[] | undefined,
+  builtinKeys: Set<string>,
+  kindName: string,
+): ExtraColumn[] {
+  if (!extraLeadingColumns?.length) return []
+  return extraLeadingColumns.filter(c => {
+    if (builtinKeys.has(c.key)) {
+      if (import.meta.env?.DEV) {
+        // eslint-disable-next-line no-console
+        console.warn(`[ResourcesView] extraLeadingColumns key "${c.key}" collides with a built-in column for kind "${kindName}" — extra ignored`)
+      }
+      return false
+    }
+    return true
+  })
+}
+
 // localStorage helpers for column settings
 const COLUMN_SETTINGS_PREFIX = 'radar-columns-'
 
@@ -2031,6 +2054,9 @@ export function ResourcesView({
   const [showColumnPicker, setShowColumnPicker] = useState(false)
   const [customColumns, setCustomColumns] = useState<CustomColumnDef[]>([])
   const [customColumnDraft, setCustomColumnDraft] = useState<CustomColumnDef>({ source: 'label', path: '' })
+  // Per-instance so two ResourcesView tables on one page (e.g. fleet compare)
+  // don't share a datalist id and cross-suggest each other's keys.
+  const customColKeysListId = useId()
   const columnPickerRef = useRef<HTMLDivElement>(null)
   // Label/owner filtering for deep-linking from workload details
   const [labelSelector, setLabelSelector] = useState<string>(initialFilters.labelSelector)
@@ -2131,16 +2157,7 @@ export function ResourcesView({
     const kindColumns = getColumnsForKind(selectedKind.name, selectedKind.group)
     if (!extraLeadingColumns?.length && !builtCustomColumns.length) return kindColumns
     const builtinKeys = new Set(kindColumns.map(c => c.key))
-    const filteredExtras = (extraLeadingColumns ?? []).filter(c => {
-      if (builtinKeys.has(c.key)) {
-        if (import.meta.env?.DEV) {
-          // eslint-disable-next-line no-console
-          console.warn(`[ResourcesView] extraLeadingColumns key "${c.key}" collides with a built-in column for kind "${selectedKind.name}" — extra ignored`)
-        }
-        return false
-      }
-      return true
-    })
+    const filteredExtras = filterHostExtras(extraLeadingColumns, builtinKeys, selectedKind.name)
     return [...filteredExtras, ...kindColumns, ...builtCustomColumns]
   }, [selectedKind.name, selectedKind.group, extraLeadingColumns, builtCustomColumns])
 
@@ -2157,24 +2174,25 @@ export function ResourcesView({
   // (set false by the load effect, flipped true on its first skipped save).
   const isColumnSettingsLoaded = useRef(false)
   useEffect(() => {
-    // Re-arm the skip-initial-save guard per kind: this effect repopulates
-    // visible/widths/custom for the new kind via async setState, but the save
-    // effect (keyed to selectedKind too) would otherwise fire first in this
-    // same commit and persist the PREVIOUS kind's columns into the new kind's
-    // storage key. Skipping the first save after each load prevents that.
+    // Re-arm the skip-initial-save guard per kind. This effect repopulates
+    // visible/widths/custom for the new kind via async setState, so the save
+    // effect (also keyed to selectedKind) that runs in this same commit still
+    // sees the PREVIOUS kind's columns in state and would persist them under
+    // the new kind's storage key. Skipping the first save after each load
+    // prevents that cross-kind write.
     isColumnSettingsLoaded.current = false
     const saved = loadColumnSettings(selectedKind.name, selectedKind.group)
     // Reconstruct the effective column list locally rather than reading
     // `allColumns` — keying this effect to the kind (not allColumns) keeps
     // runtime custom-column add/remove from re-running it and clobbering the
     // in-session edit (and avoids a setCustomColumns → allColumns → re-run loop).
-    // sanitize guards the localStorage boundary: a malformed/legacy blob (non-
-    // array, blank path, bad source) must not crash the later .map or add dead columns.
+    // sanitize guards the localStorage boundary: a corrupted/hand-edited blob
+    // (non-array, blank path, bad source) must not crash the later .map or add dead columns.
     const savedCustom = sanitizeCustomColumnDefs(saved?.custom)
     setCustomColumns(savedCustom)
     const kindColumns = getColumnsForKind(selectedKind.name, selectedKind.group)
     const builtinKeys = new Set(kindColumns.map(c => c.key))
-    const extras = (extraLeadingColumns ?? []).filter(c => !builtinKeys.has(c.key))
+    const extras = filterHostExtras(extraLeadingColumns, builtinKeys, selectedKind.name)
     const effective = [...extras, ...kindColumns, ...savedCustom.map(buildCustomColumn)]
     // Host-injected extra columns (e.g. fleet Cluster) default to visible
     // even when the saved column-visibility blob predates them — a naive
@@ -4134,13 +4152,13 @@ export function ResourcesView({
                   >
                     <input
                       type="text"
-                      list="radar-custom-col-keys"
+                      list={customColKeysListId}
                       value={customColumnDraft.path}
                       onChange={e => setCustomColumnDraft(d => ({ ...d, path: e.target.value }))}
                       placeholder={`Add ${customColumnDraft.source} key…`}
                       className="flex-1 min-w-0 px-2 py-1 text-xs rounded bg-theme-base border border-theme-border text-theme-text-primary placeholder:text-theme-text-tertiary focus:outline-none focus:border-skyhook-500"
                     />
-                    <datalist id="radar-custom-col-keys">
+                    <datalist id={customColKeysListId}>
                       {customColumnKeySuggestions[customColumnDraft.source].map(k => (
                         <option key={k} value={k} />
                       ))}

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -224,6 +224,47 @@ export interface ExtraColumn extends Column {
   getFilterValue?: (resource: any) => string
 }
 
+// User-defined column sourcing a metadata.labels[path] or
+// metadata.annotations[path] value. Persisted per-kind in localStorage and
+// materialized into a self-contained ExtraColumn so it rides the existing
+// render/sort/filter override rails (extraColumnsByKey).
+type CustomColumnSource = 'label' | 'annotation'
+interface CustomColumnDef {
+  source: CustomColumnSource
+  path: string
+}
+
+function customColumnKey(d: CustomColumnDef): string {
+  return `${d.source}:${d.path}`
+}
+
+function readCustomColumnValue(resource: any, d: CustomColumnDef): string {
+  const bag = d.source === 'label' ? resource?.metadata?.labels : resource?.metadata?.annotations
+  const v = bag?.[d.path]
+  return typeof v === 'string' ? v : v == null ? '' : String(v)
+}
+
+function buildCustomColumn(d: CustomColumnDef): ExtraColumn {
+  return {
+    key: customColumnKey(d),
+    label: d.path,
+    width: 'w-40',
+    defaultVisible: true,
+    tooltip: d.source === 'label' ? `Label: ${d.path}` : `Annotation: ${d.path}`,
+    render: (resource: any) => {
+      const v = readCustomColumnValue(resource, d)
+      if (!v) return <span className="text-sm text-theme-text-secondary">-</span>
+      return (
+        <Tooltip content={v}>
+          <span className="text-sm text-theme-text-secondary truncate block">{v}</span>
+        </Tooltip>
+      )
+    },
+    getSortValue: (resource: any) => readCustomColumnValue(resource, d),
+    getFilterValue: (resource: any) => readCustomColumnValue(resource, d),
+  }
+}
+
 // Tailwind width class → pixel minimum mapping for CSS Grid column sizing
 const TAILWIND_WIDTH_TO_PX: Record<string, number> = {
   'w-12': 48, 'w-14': 56, 'w-16': 64, 'w-20': 80, 'w-24': 96,
@@ -1657,6 +1698,7 @@ const COLUMN_SETTINGS_PREFIX = 'radar-columns-'
 interface ColumnSettings {
   visible: string[]
   widths: Record<string, number>
+  custom?: CustomColumnDef[]
 }
 
 function loadColumnSettings(kind: string, group?: string): ColumnSettings | null {
@@ -2002,6 +2044,8 @@ export function ResourcesView({
   const [visibleColumns, setVisibleColumns] = useState<Set<string>>(new Set())
   const [columnWidths, setColumnWidths] = useState<Record<string, number>>({})
   const [showColumnPicker, setShowColumnPicker] = useState(false)
+  const [customColumns, setCustomColumns] = useState<CustomColumnDef[]>([])
+  const [customColumnDraft, setCustomColumnDraft] = useState<CustomColumnDef>({ source: 'label', path: '' })
   const columnPickerRef = useRef<HTMLDivElement>(null)
   // Label/owner filtering for deep-linking from workload details
   const [labelSelector, setLabelSelector] = useState<string>(initialFilters.labelSelector)
@@ -2086,6 +2130,12 @@ export function ResourcesView({
     return { pods, nodes }
   }, [topPodMetrics, topNodeMetrics])
 
+  // User-defined label/annotation columns materialized as self-contained
+  // ExtraColumns — appended after the built-ins and wired through the same
+  // render/sort/filter override rails (extraColumnsByKey).
+  const builtCustomColumns = useMemo(() => customColumns.map(buildCustomColumn), [customColumns])
+  const customColumnKeySet = useMemo(() => new Set(builtCustomColumns.map(c => c.key)), [builtCustomColumns])
+
   // Prepend extraLeadingColumns (host-injected leading columns) before
   // the kind-specific KNOWN_COLUMNS entries. When extras are undefined,
   // this collapses to single-cluster behavior. Built-in keys win on
@@ -2094,9 +2144,9 @@ export function ResourcesView({
   // duplicate React keys and corrupt visibleColumns / columnWidths state.
   const allColumns = useMemo(() => {
     const kindColumns = getColumnsForKind(selectedKind.name, selectedKind.group)
-    if (!extraLeadingColumns?.length) return kindColumns
+    if (!extraLeadingColumns?.length && !builtCustomColumns.length) return kindColumns
     const builtinKeys = new Set(kindColumns.map(c => c.key))
-    const filteredExtras = extraLeadingColumns.filter(c => {
+    const filteredExtras = (extraLeadingColumns ?? []).filter(c => {
       if (builtinKeys.has(c.key)) {
         if (import.meta.env?.DEV) {
           // eslint-disable-next-line no-console
@@ -2106,36 +2156,47 @@ export function ResourcesView({
       }
       return true
     })
-    return [...filteredExtras, ...kindColumns]
-  }, [selectedKind.name, selectedKind.group, extraLeadingColumns])
+    return [...filteredExtras, ...kindColumns, ...builtCustomColumns]
+  }, [selectedKind.name, selectedKind.group, extraLeadingColumns, builtCustomColumns])
 
   // Map of extra column keys for fast O(1) lookup on each render path
   // (cell render, sort, column-filter unique-values).
   const extraColumnsByKey = useMemo(() => {
     const m = new Map<string, ExtraColumn>()
     extraLeadingColumns?.forEach(c => m.set(c.key, c))
+    builtCustomColumns.forEach(c => m.set(c.key, c))
     return m
-  }, [extraLeadingColumns])
+  }, [extraLeadingColumns, builtCustomColumns])
 
   useEffect(() => {
     const saved = loadColumnSettings(selectedKind.name, selectedKind.group)
+    // Reconstruct the effective column list locally rather than reading
+    // `allColumns` — keying this effect to the kind (not allColumns) keeps
+    // runtime custom-column add/remove from re-running it and clobbering the
+    // in-session edit (and avoids a setCustomColumns → allColumns → re-run loop).
+    const savedCustom = saved?.custom ?? []
+    setCustomColumns(savedCustom)
+    const kindColumns = getColumnsForKind(selectedKind.name, selectedKind.group)
+    const builtinKeys = new Set(kindColumns.map(c => c.key))
+    const extras = (extraLeadingColumns ?? []).filter(c => !builtinKeys.has(c.key))
+    const effective = [...extras, ...kindColumns, ...savedCustom.map(buildCustomColumn)]
     // Host-injected extra columns (e.g. fleet Cluster) default to visible
     // even when the saved column-visibility blob predates them — a naive
     // Set(saved.visible) would silently hide host columns the user has
     // never been shown. Trade-off: a user can't permanently hide a host
     // extra column via the column picker — next mount re-adds it. Track
     // a sibling "hidden-extras" set if this becomes a real complaint.
-    const extraKeys = extraLeadingColumns?.map(c => c.key) ?? []
+    const extraKeys = extras.map(c => c.key)
     if (saved) {
       // If saved columns are just the defaults but this kind has specialized columns,
       // discard the stale save and use the specialized columns instead
       const defaultKeys = DEFAULT_COLUMNS.map(c => c.key)
-      const isStaleDefaults = allColumns !== DEFAULT_COLUMNS &&
+      const isStaleDefaults = kindColumns !== DEFAULT_COLUMNS &&
         saved.visible.length === defaultKeys.length &&
         saved.visible.every(v => defaultKeys.includes(v))
       if (isStaleDefaults) {
         clearColumnSettings(selectedKind.name, selectedKind.group)
-        setVisibleColumns(getDefaultVisibleColumns(allColumns))
+        setVisibleColumns(getDefaultVisibleColumns(effective))
         setColumnWidths({})
       } else {
         const merged = new Set(saved.visible)
@@ -2144,10 +2205,10 @@ export function ResourcesView({
         setColumnWidths(saved.widths || {})
       }
     } else {
-      setVisibleColumns(getDefaultVisibleColumns(allColumns))
+      setVisibleColumns(getDefaultVisibleColumns(effective))
       setColumnWidths({})
     }
-  }, [selectedKind.name, selectedKind.group, allColumns, extraLeadingColumns])
+  }, [selectedKind.name, selectedKind.group, extraLeadingColumns])
 
   // Save column settings when they change (skip initial load)
   const isColumnSettingsLoaded = useRef(false)
@@ -2160,8 +2221,9 @@ export function ResourcesView({
     saveColumnSettings(selectedKind.name, selectedKind.group, {
       visible: Array.from(visibleColumns),
       widths: columnWidths,
+      custom: customColumns,
     })
-  }, [visibleColumns, columnWidths, selectedKind.name, selectedKind.group])
+  }, [visibleColumns, columnWidths, customColumns, selectedKind.name, selectedKind.group])
 
   // Close column picker on outside click or Escape
   useEffect(() => {
@@ -2261,13 +2323,40 @@ export function ResourcesView({
     })
   }, [])
 
-  // Reset column settings to defaults
+  // Reset column settings to defaults (also drops user-added custom columns)
   const resetColumnSettings = useCallback(() => {
     clearColumnSettings(selectedKind.name, selectedKind.group)
-    setVisibleColumns(getDefaultVisibleColumns(allColumns))
+    setCustomColumns([])
+    const customKeys = new Set(builtCustomColumns.map(c => c.key))
+    setVisibleColumns(getDefaultVisibleColumns(allColumns.filter(c => !customKeys.has(c.key))))
     setColumnWidths({})
     isColumnSettingsLoaded.current = false
-  }, [selectedKind.name, selectedKind.group, allColumns])
+  }, [selectedKind.name, selectedKind.group, allColumns, builtCustomColumns])
+
+  // Add a user-defined label/annotation column (dedupe by key) and show it.
+  const addCustomColumn = useCallback((def: CustomColumnDef) => {
+    const path = def.path.trim()
+    if (!path) return
+    const key = customColumnKey({ ...def, path })
+    setCustomColumns(prev => prev.some(c => customColumnKey(c) === key) ? prev : [...prev, { ...def, path }])
+    setVisibleColumns(prev => {
+      if (prev.has(key)) return prev
+      const next = new Set(prev)
+      next.add(key)
+      return next
+    })
+  }, [])
+
+  // Remove a user-defined column entirely (not just hide it).
+  const removeCustomColumn = useCallback((key: string) => {
+    setCustomColumns(prev => prev.filter(c => customColumnKey(c) !== key))
+    setVisibleColumns(prev => {
+      if (!prev.has(key)) return prev
+      const next = new Set(prev)
+      next.delete(key)
+      return next
+    })
+  }, [])
 
   // Keyboard shortcut: / to focus search
   useRegisterShortcut({
@@ -2957,6 +3046,24 @@ export function ResourcesView({
 
   const selectedQuery = selectedKindQueryProp ?? resourceQueries[selectedQueryIndex]
   const resources = selectedQuery?.data
+
+  // Label/annotation keys present on the loaded rows — powers the
+  // add-custom-column autocomplete so users don't type keys blind. Sampled
+  // to bound cost on large lists; keys converge fast across rows of one kind.
+  const customColumnKeySuggestions = useMemo(() => {
+    const labels = new Set<string>()
+    const annotations = new Set<string>()
+    const rows = (resources as any[] | undefined) ?? []
+    for (let i = 0; i < rows.length && i < 500; i++) {
+      const meta = rows[i]?.metadata
+      if (meta?.labels) for (const k of Object.keys(meta.labels)) labels.add(k)
+      if (meta?.annotations) for (const k of Object.keys(meta.annotations)) annotations.add(k)
+    }
+    return {
+      label: Array.from(labels).sort(),
+      annotation: Array.from(annotations).sort(),
+    }
+  }, [resources])
   const isLoading = selectedQuery?.isLoading ?? true
   const selectedQueryError = selectedQuery?.error
   const isSelectedForbidden = isForbiddenError(selectedQueryError)
@@ -3964,26 +4071,91 @@ export function ResourcesView({
                     Reset
                   </button>
                 </div>
-                {allColumns.map(col => (
-                  <label
-                    key={col.key}
-                    className="flex items-center gap-2 px-3 py-1.5 hover:bg-theme-elevated"
+                {allColumns.map(col => {
+                  const isCustom = customColumnKeySet.has(col.key)
+                  return (
+                    <div
+                      key={col.key}
+                      className="group flex items-center gap-2 px-3 py-1.5 hover:bg-theme-elevated"
+                    >
+                      <label className="flex items-center gap-2 flex-1 min-w-0 cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={visibleColumns.has(col.key)}
+                          onChange={() => toggleColumnVisibility(col.key)}
+                          disabled={col.key === 'name'}
+                          className="rounded border-theme-border"
+                        />
+                        <span className={clsx(
+                          'text-sm truncate',
+                          col.key === 'name' ? 'text-theme-text-tertiary' : 'text-theme-text-primary'
+                        )} title={col.tooltip || col.label}>
+                          {col.label}
+                        </span>
+                      </label>
+                      {isCustom && (
+                        <button
+                          type="button"
+                          onClick={() => removeCustomColumn(col.key)}
+                          className="shrink-0 p-0.5 text-theme-text-tertiary hover:text-red-500 opacity-0 group-hover:opacity-100 focus:opacity-100"
+                          title="Remove column"
+                        >
+                          <X className="w-3.5 h-3.5" />
+                        </button>
+                      )}
+                    </div>
+                  )
+                })}
+                {/* Add a label/annotation column */}
+                <div className="border-t border-theme-border mt-1 pt-2 px-3 pb-1">
+                  <div className="flex items-center gap-1 mb-1.5">
+                    {(['label', 'annotation'] as CustomColumnSource[]).map(src => (
+                      <button
+                        key={src}
+                        type="button"
+                        onClick={() => setCustomColumnDraft(d => ({ ...d, source: src }))}
+                        className={clsx(
+                          'px-2 py-0.5 text-xs rounded capitalize',
+                          customColumnDraft.source === src
+                            ? 'bg-skyhook-500/20 text-skyhook-400'
+                            : 'text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-elevated'
+                        )}
+                      >
+                        {src}
+                      </button>
+                    ))}
+                  </div>
+                  <form
+                    className="flex items-center gap-1"
+                    onSubmit={e => {
+                      e.preventDefault()
+                      addCustomColumn(customColumnDraft)
+                      setCustomColumnDraft(d => ({ ...d, path: '' }))
+                    }}
                   >
                     <input
-                      type="checkbox"
-                      checked={visibleColumns.has(col.key)}
-                      onChange={() => toggleColumnVisibility(col.key)}
-                      disabled={col.key === 'name'}
-                      className="rounded border-theme-border"
+                      type="text"
+                      list="radar-custom-col-keys"
+                      value={customColumnDraft.path}
+                      onChange={e => setCustomColumnDraft(d => ({ ...d, path: e.target.value }))}
+                      placeholder={`Add ${customColumnDraft.source} key…`}
+                      className="flex-1 min-w-0 px-2 py-1 text-xs rounded bg-theme-base border border-theme-border text-theme-text-primary placeholder:text-theme-text-tertiary focus:outline-none focus:border-skyhook-500"
                     />
-                    <span className={clsx(
-                      'text-sm',
-                      col.key === 'name' ? 'text-theme-text-tertiary' : 'text-theme-text-primary'
-                    )}>
-                      {col.label}
-                    </span>
-                  </label>
-                ))}
+                    <datalist id="radar-custom-col-keys">
+                      {customColumnKeySuggestions[customColumnDraft.source].map(k => (
+                        <option key={k} value={k} />
+                      ))}
+                    </datalist>
+                    <button
+                      type="submit"
+                      disabled={!customColumnDraft.path.trim()}
+                      className="shrink-0 p-1 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded disabled:opacity-40 disabled:hover:bg-transparent"
+                      title="Add column"
+                    >
+                      <Plus className="w-4 h-4" />
+                    </button>
+                  </form>
+                </div>
               </div>
             )}
           </div>

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -2203,9 +2203,12 @@ export function ResourcesView({
     const extraKeys = extras.map(c => c.key)
     if (saved) {
       // If saved columns are just the defaults but this kind has specialized columns,
-      // discard the stale save and use the specialized columns instead
+      // discard the stale save and use the specialized columns instead. User-added
+      // custom columns mean the blob isn't a stale pure-defaults save — keep it, or
+      // the migration would clear them from storage (and un-hide hidden ones).
       const defaultKeys = DEFAULT_COLUMNS.map(c => c.key)
       const isStaleDefaults = kindColumns !== DEFAULT_COLUMNS &&
+        !savedCustom.length &&
         saved.visible.length === defaultKeys.length &&
         saved.visible.every(v => defaultKeys.includes(v))
       if (isStaleDefaults) {
@@ -2369,7 +2372,20 @@ export function ResourcesView({
       next.delete(key)
       return next
     })
-  }, [])
+    // Drop any filter/sort that targeted the removed column — otherwise the
+    // table keeps filtering (and syncing to the URL) on a key with no column
+    // and no UI to clear it, and sort silently references a gone column.
+    setColumnFilters(prev => {
+      if (!(key in prev)) return prev
+      const next = { ...prev }
+      delete next[key]
+      return next
+    })
+    if (sortColumn === key) {
+      setSortColumn(null)
+      setSortDirection(null)
+    }
+  }, [sortColumn])
 
   // Keyboard shortcut: / to focus search
   useRegisterShortcut({
@@ -3458,7 +3474,7 @@ export function ResourcesView({
     }
 
     return result
-  }, [resources, searchTerm, regexMode, searchRegex, columnFilters, problemFilters, showInactiveReplicaSets, labelSelector, ownerKind, ownerName, selectedKind.name, sortColumn, sortDirection, getSortValue, podMatchesProblemFilter])
+  }, [resources, searchTerm, regexMode, searchRegex, columnFilters, problemFilters, showInactiveReplicaSets, labelSelector, ownerKind, ownerName, selectedKind.name, sortColumn, sortDirection, getSortValue, extraColumnsByKey, podMatchesProblemFilter])
 
   // For nodes table: compute the majority minor version so outliers can be highlighted
   const majorityNodeMinorVersion = useMemo(() => {
@@ -4383,7 +4399,9 @@ export function ResourcesView({
                     </th>
                   )}
                   {columns.map((col, colIdx) => {
+                    // Built-in sortable keys, plus any extra/custom column that carries its own getSortValue.
                     const isSortable = ['name', 'namespace', 'age', 'status', 'ready', 'restarts', 'type', 'version', 'desired', 'available', 'upToDate', 'lastSeen', 'count', 'reason', 'object', 'cpu', 'memory', 'containers'].includes(col.key)
+                      || !!extraColumnsByKey.get(col.key)?.getSortValue
                     const isSorted = sortColumn === col.key
                     const isLastCol = colIdx === columns.length - 1
                     const filterCol = filterableColumnMap.get(col.key)

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -128,6 +128,7 @@ import {
 } from './resource-utils'
 import { SEVERITY_BADGE, EVENT_TYPE_COLORS } from '../../utils/badge-colors'
 import { pluralize } from '../../utils/pluralize'
+import { type CustomColumnDef, type CustomColumnSource, customColumnKey, readCustomColumnValue, sanitizeCustomColumnDefs } from '../../utils/custom-columns'
 import { Tooltip } from '../ui/Tooltip'
 // CRD-specific cell components (extracted)
 import { GitRepositoryCell, OCIRepositoryCell, HelmRepositoryCell, KustomizationCell, FluxHelmReleaseCell, FluxAlertCell } from './renderers/flux-cells'
@@ -224,26 +225,10 @@ export interface ExtraColumn extends Column {
   getFilterValue?: (resource: any) => string
 }
 
-// User-defined column sourcing a metadata.labels[path] or
-// metadata.annotations[path] value. Persisted per-kind in localStorage and
-// materialized into a self-contained ExtraColumn so it rides the existing
-// render/sort/filter override rails (extraColumnsByKey).
-type CustomColumnSource = 'label' | 'annotation'
-interface CustomColumnDef {
-  source: CustomColumnSource
-  path: string
-}
-
-function customColumnKey(d: CustomColumnDef): string {
-  return `${d.source}:${d.path}`
-}
-
-function readCustomColumnValue(resource: any, d: CustomColumnDef): string {
-  const bag = d.source === 'label' ? resource?.metadata?.labels : resource?.metadata?.annotations
-  const v = bag?.[d.path]
-  return typeof v === 'string' ? v : v == null ? '' : String(v)
-}
-
+// Materializes a custom-column def into a self-contained ExtraColumn so it
+// rides the existing render/sort/filter override rails (extraColumnsByKey).
+// The pure parts (key encoding, value read, load-boundary sanitizer) live in
+// utils/custom-columns so they're unit-tested; only the JSX render stays here.
 function buildCustomColumn(d: CustomColumnDef): ExtraColumn {
   return {
     key: customColumnKey(d),
@@ -2168,13 +2153,24 @@ export function ResourcesView({
     return m
   }, [extraLeadingColumns, builtCustomColumns])
 
+  // Guards the save effect from persisting on the initial load of each kind
+  // (set false by the load effect, flipped true on its first skipped save).
+  const isColumnSettingsLoaded = useRef(false)
   useEffect(() => {
+    // Re-arm the skip-initial-save guard per kind: this effect repopulates
+    // visible/widths/custom for the new kind via async setState, but the save
+    // effect (keyed to selectedKind too) would otherwise fire first in this
+    // same commit and persist the PREVIOUS kind's columns into the new kind's
+    // storage key. Skipping the first save after each load prevents that.
+    isColumnSettingsLoaded.current = false
     const saved = loadColumnSettings(selectedKind.name, selectedKind.group)
     // Reconstruct the effective column list locally rather than reading
     // `allColumns` — keying this effect to the kind (not allColumns) keeps
     // runtime custom-column add/remove from re-running it and clobbering the
     // in-session edit (and avoids a setCustomColumns → allColumns → re-run loop).
-    const savedCustom = saved?.custom ?? []
+    // sanitize guards the localStorage boundary: a malformed/legacy blob (non-
+    // array, blank path, bad source) must not crash the later .map or add dead columns.
+    const savedCustom = sanitizeCustomColumnDefs(saved?.custom)
     setCustomColumns(savedCustom)
     const kindColumns = getColumnsForKind(selectedKind.name, selectedKind.group)
     const builtinKeys = new Set(kindColumns.map(c => c.key))
@@ -2210,8 +2206,7 @@ export function ResourcesView({
     }
   }, [selectedKind.name, selectedKind.group, extraLeadingColumns])
 
-  // Save column settings when they change (skip initial load)
-  const isColumnSettingsLoaded = useRef(false)
+  // Save column settings when they change (skip the initial load of each kind)
   useEffect(() => {
     if (visibleColumns.size === 0) return // not loaded yet
     if (!isColumnSettingsLoaded.current) {

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -4054,8 +4054,8 @@ export function ResourcesView({
               <Columns3 className="w-4 h-4" />
             </button>
             {showColumnPicker && (
-              <div className="absolute right-0 top-full mt-1 z-50 bg-theme-surface border border-theme-border rounded-lg shadow-lg py-1 min-w-[200px] max-h-[400px] overflow-auto">
-                <div className="px-3 py-2 border-b border-theme-border flex items-center justify-between">
+              <div className="absolute right-0 top-full mt-1 z-50 bg-theme-surface border border-theme-border rounded-lg shadow-lg py-1 min-w-[200px] max-h-[400px] flex flex-col">
+                <div className="shrink-0 px-3 py-2 border-b border-theme-border flex items-center justify-between">
                   <span className="text-xs font-medium text-theme-text-secondary uppercase">Columns</span>
                   <button
                     onClick={resetColumnSettings}
@@ -4066,6 +4066,9 @@ export function ResourcesView({
                     Reset
                   </button>
                 </div>
+                {/* Column list scrolls; the add-column footer stays pinned so
+                    its input isn't pushed below the fold on kinds with many columns. */}
+                <div className="overflow-y-auto flex-1 min-h-0">
                 {allColumns.map(col => {
                   const isCustom = customColumnKeySet.has(col.key)
                   return (
@@ -4101,8 +4104,9 @@ export function ResourcesView({
                     </div>
                   )
                 })}
+                </div>
                 {/* Add a label/annotation column */}
-                <div className="border-t border-theme-border mt-1 pt-2 px-3 pb-1">
+                <div className="shrink-0 border-t border-theme-border pt-2 px-3 pb-1">
                   <div className="flex items-center gap-1 mb-1.5">
                     {(['label', 'annotation'] as CustomColumnSource[]).map(src => (
                       <button

--- a/packages/k8s-ui/src/components/resources/column-filter-serialization.test.ts
+++ b/packages/k8s-ui/src/components/resources/column-filter-serialization.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { parseColumnFilters, serializeColumnFilters } from './resource-utils'
+
+describe('column filter serialization round-trip', () => {
+  it('round-trips built-in keys', () => {
+    const filters = { status: ['Running'], namespace: ['kube-system', 'default'] }
+    expect(parseColumnFilters(serializeColumnFilters(filters))).toEqual(filters)
+  })
+
+  it('round-trips custom-column keys whose own colon collides with the delimiter', () => {
+    const filters = { 'label:tier': ['control-plane'], 'annotation:foo/bar': ['x'] }
+    const serialized = serializeColumnFilters(filters)
+    // The key colon must be encoded so the first literal ':' is the delimiter.
+    expect(serialized).toBe('label%3Atier:control-plane|annotation%3Afoo%2Fbar:x')
+    expect(parseColumnFilters(serialized)).toEqual(filters)
+  })
+
+  it('preserves commas inside values', () => {
+    const filters = { conditions: ['Ready,SchedulingDisabled'] }
+    expect(parseColumnFilters(serializeColumnFilters(filters))).toEqual(filters)
+  })
+
+  it('parses legacy unencoded built-in keys', () => {
+    expect(parseColumnFilters('status:Running')).toEqual({ status: ['Running'] })
+  })
+})

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -1648,8 +1648,12 @@ export function parseColumnFilters(filtersParam: string | null): Record<string, 
   for (const pair of filtersParam.split('|')) {
     const colonIdx = pair.indexOf(':')
     if (colonIdx > 0) {
-      const key = pair.slice(0, colonIdx).trim()
+      const rawKey = pair.slice(0, colonIdx).trim()
       const valStr = pair.slice(colonIdx + 1).trim()
+      // Keys are URI-encoded so a custom-column key's own colon (e.g.
+      // "label:tier") doesn't collide with the key:value delimiter.
+      let key: string
+      try { key = decodeURIComponent(rawKey) } catch { key = rawKey }
       if (key && valStr) {
         filters[key] = valStr.split(',').map(v => {
           try { return decodeURIComponent(v.trim()) } catch { return v.trim() }
@@ -1660,12 +1664,13 @@ export function parseColumnFilters(filtersParam: string | null): Record<string, 
   return filters
 }
 
-// Serialize column filters to URL param format
-// Values are URI-encoded so commas inside values (e.g. "Ready,SchedulingDisabled") survive the round-trip.
+// Serialize column filters to URL param format. Keys and values are both
+// URI-encoded so a colon inside a custom-column key (e.g. "label:tier") or a
+// comma inside a value (e.g. "Ready,SchedulingDisabled") survives the round-trip.
 export function serializeColumnFilters(filters: Record<string, string[]>): string {
   const result = Object.entries(filters)
     .filter(([, v]) => v.length > 0)
-    .map(([k, vals]) => `${k}:${vals.map(v => encodeURIComponent(v)).join(',')}`)
+    .map(([k, vals]) => `${encodeURIComponent(k)}:${vals.map(v => encodeURIComponent(v)).join(',')}`)
     .join('|')
   return result
 }

--- a/packages/k8s-ui/src/utils/custom-columns.test.ts
+++ b/packages/k8s-ui/src/utils/custom-columns.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { customColumnKey, readCustomColumnValue, sanitizeCustomColumnDefs } from './custom-columns'
+
+describe('customColumnKey', () => {
+  it('encodes source and path', () => {
+    expect(customColumnKey({ source: 'label', path: 'topology.kubernetes.io/zone' })).toBe('label:topology.kubernetes.io/zone')
+    expect(customColumnKey({ source: 'annotation', path: 'foo/bar' })).toBe('annotation:foo/bar')
+  })
+
+  it('produces equal keys for same source+path (dedupe contract)', () => {
+    const a = customColumnKey({ source: 'label', path: 'x' })
+    const b = customColumnKey({ source: 'label', path: 'x' })
+    expect(a).toBe(b)
+  })
+
+  it('distinguishes source for the same path', () => {
+    expect(customColumnKey({ source: 'label', path: 'x' }))
+      .not.toBe(customColumnKey({ source: 'annotation', path: 'x' }))
+  })
+})
+
+describe('readCustomColumnValue', () => {
+  const res = (meta: any) => ({ metadata: meta })
+
+  it('reads a label value', () => {
+    expect(readCustomColumnValue(res({ labels: { zone: 'us-east-1a' } }), { source: 'label', path: 'zone' })).toBe('us-east-1a')
+  })
+
+  it('reads an annotation value', () => {
+    expect(readCustomColumnValue(res({ annotations: { team: 'infra' } }), { source: 'annotation', path: 'team' })).toBe('infra')
+  })
+
+  it('does not cross labels and annotations', () => {
+    const r = res({ labels: { k: 'fromLabel' }, annotations: { k: 'fromAnnotation' } })
+    expect(readCustomColumnValue(r, { source: 'label', path: 'k' })).toBe('fromLabel')
+    expect(readCustomColumnValue(r, { source: 'annotation', path: 'k' })).toBe('fromAnnotation')
+  })
+
+  it('returns empty string for a missing key', () => {
+    expect(readCustomColumnValue(res({ labels: { a: '1' } }), { source: 'label', path: 'b' })).toBe('')
+  })
+
+  it('returns empty string when metadata/bag is absent', () => {
+    expect(readCustomColumnValue({}, { source: 'label', path: 'b' })).toBe('')
+    expect(readCustomColumnValue(res({}), { source: 'annotation', path: 'b' })).toBe('')
+    expect(readCustomColumnValue(undefined, { source: 'label', path: 'b' })).toBe('')
+  })
+
+  it('coerces non-string values, but maps null/undefined to empty (not the literal "null")', () => {
+    expect(readCustomColumnValue(res({ labels: { n: 5 as any } }), { source: 'label', path: 'n' })).toBe('5')
+    expect(readCustomColumnValue(res({ labels: { n: null as any } }), { source: 'label', path: 'n' })).toBe('')
+  })
+})
+
+describe('sanitizeCustomColumnDefs', () => {
+  it('returns [] for non-array input', () => {
+    expect(sanitizeCustomColumnDefs(undefined)).toEqual([])
+    expect(sanitizeCustomColumnDefs(null)).toEqual([])
+    expect(sanitizeCustomColumnDefs({ source: 'label', path: 'x' })).toEqual([])
+    expect(sanitizeCustomColumnDefs('label:x')).toEqual([])
+  })
+
+  it('keeps well-formed defs', () => {
+    const defs = [
+      { source: 'label', path: 'zone' },
+      { source: 'annotation', path: 'team' },
+    ]
+    expect(sanitizeCustomColumnDefs(defs)).toEqual(defs)
+  })
+
+  it('drops entries with invalid source, missing or blank path', () => {
+    const raw = [
+      { source: 'label', path: 'good' },
+      { source: 'lable', path: 'typo-source' },
+      { source: 'label', path: '' },
+      { source: 'label', path: '   ' },
+      { source: 'annotation' },
+      null,
+      'label:x',
+    ]
+    expect(sanitizeCustomColumnDefs(raw)).toEqual([{ source: 'label', path: 'good' }])
+  })
+})

--- a/packages/k8s-ui/src/utils/custom-columns.test.ts
+++ b/packages/k8s-ui/src/utils/custom-columns.test.ts
@@ -80,4 +80,32 @@ describe('sanitizeCustomColumnDefs', () => {
     ]
     expect(sanitizeCustomColumnDefs(raw)).toEqual([{ source: 'label', path: 'good' }])
   })
+
+  it('drops a non-string path without throwing (predicate short-circuits before trim)', () => {
+    const raw = [
+      { source: 'label', path: 42 },
+      { source: 'label', path: { nested: true } },
+      { source: 'annotation', path: 'ok' },
+    ]
+    expect(() => sanitizeCustomColumnDefs(raw)).not.toThrow()
+    expect(sanitizeCustomColumnDefs(raw)).toEqual([{ source: 'annotation', path: 'ok' }])
+  })
+
+  it('trims paths so the load path matches the add path', () => {
+    expect(sanitizeCustomColumnDefs([{ source: 'label', path: '  zone  ' }]))
+      .toEqual([{ source: 'label', path: 'zone' }])
+  })
+
+  it('dedupes by key, keeping the first occurrence', () => {
+    const raw = [
+      { source: 'label', path: 'zone' },
+      { source: 'label', path: 'zone' },
+      { source: 'label', path: ' zone ' },
+      { source: 'annotation', path: 'zone' },
+    ]
+    expect(sanitizeCustomColumnDefs(raw)).toEqual([
+      { source: 'label', path: 'zone' },
+      { source: 'annotation', path: 'zone' },
+    ])
+  })
 })

--- a/packages/k8s-ui/src/utils/custom-columns.ts
+++ b/packages/k8s-ui/src/utils/custom-columns.ts
@@ -25,16 +25,25 @@ export function readCustomColumnValue(resource: any, d: CustomColumnDef): string
 }
 
 // Drop anything that isn't a well-formed def — guards the localStorage load
-// boundary where a corrupted/legacy/hand-edited blob could otherwise be a
-// non-array (crashing a later .map) or carry empty/invalid entries (dead
-// columns). TypeScript's guarantees stop at JSON.parse, so this is the one
-// place the (source, non-empty path) invariant must be enforced at runtime.
+// boundary where a corrupted/hand-edited blob could otherwise be a non-array
+// (crashing a later .map) or carry empty/invalid entries (dead columns).
+// TypeScript's guarantees stop at JSON.parse, so this is the one place the
+// (source, non-empty path) invariant must be enforced at runtime. Paths are
+// trimmed and deduped by key so the load path produces the same defs the add
+// path would — a hand-edited blob can't yield a padded key or two columns
+// sharing one key.
 export function sanitizeCustomColumnDefs(raw: unknown): CustomColumnDef[] {
   if (!Array.isArray(raw)) return []
-  return raw.filter((c): c is CustomColumnDef =>
-    !!c &&
-    (c.source === 'label' || c.source === 'annotation') &&
-    typeof c.path === 'string' &&
-    c.path.trim() !== ''
-  )
+  const seen = new Set<string>()
+  const out: CustomColumnDef[] = []
+  for (const c of raw) {
+    if (!c || (c.source !== 'label' && c.source !== 'annotation') || typeof c.path !== 'string') continue
+    const def: CustomColumnDef = { source: c.source, path: c.path.trim() }
+    if (def.path === '') continue
+    const key = customColumnKey(def)
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(def)
+  }
+  return out
 }

--- a/packages/k8s-ui/src/utils/custom-columns.ts
+++ b/packages/k8s-ui/src/utils/custom-columns.ts
@@ -1,0 +1,40 @@
+// User-defined table columns sourcing a metadata.labels[path] or
+// metadata.annotations[path] value. Persisted per-kind in localStorage and
+// materialized (in ResourcesView) into a self-contained ExtraColumn so they
+// ride the existing render/sort/filter override rails.
+
+export type CustomColumnSource = 'label' | 'annotation'
+
+export interface CustomColumnDef {
+  source: CustomColumnSource
+  path: string
+}
+
+// Stable identity used as the React key, ExtraColumn.key, visibility-set
+// membership, and dedupe key. Built-in column keys never use a `:` prefix, so
+// `label:`/`annotation:` can't collide with them. Build-only — never parsed
+// back into source+path, so a colon inside `path` is harmless.
+export function customColumnKey(d: CustomColumnDef): string {
+  return `${d.source}:${d.path}`
+}
+
+export function readCustomColumnValue(resource: any, d: CustomColumnDef): string {
+  const bag = d.source === 'label' ? resource?.metadata?.labels : resource?.metadata?.annotations
+  const v = bag?.[d.path]
+  return typeof v === 'string' ? v : v == null ? '' : String(v)
+}
+
+// Drop anything that isn't a well-formed def — guards the localStorage load
+// boundary where a corrupted/legacy/hand-edited blob could otherwise be a
+// non-array (crashing a later .map) or carry empty/invalid entries (dead
+// columns). TypeScript's guarantees stop at JSON.parse, so this is the one
+// place the (source, non-empty path) invariant must be enforced at runtime.
+export function sanitizeCustomColumnDefs(raw: unknown): CustomColumnDef[] {
+  if (!Array.isArray(raw)) return []
+  return raw.filter((c): c is CustomColumnDef =>
+    !!c &&
+    (c.source === 'label' || c.source === 'annotation') &&
+    typeof c.path === 'string' &&
+    c.path.trim() !== ''
+  )
+}


### PR DESCRIPTION
## Summary

Closes #776. Adds k9s-style **custom columns** — users can surface any node/pod (or any kind's) `metadata.labels[key]` / `metadata.annotations[key]` as a real column in the resource table, configured from the existing column picker.

Custom columns are fully first-class: **sortable, filterable, resizable, removable**, and persisted per-kind in localStorage. Two users asked for this; the node-labels-as-columns case from the issue is the motivating example.

## How it works

The table already had a self-contained `ExtraColumn` abstraction (own `render` / `getSortValue` / `getFilterValue`) that host code uses to inject a multi-cluster "Cluster" column, flowing through `extraColumnsByKey` — which already overrides all three render paths. A custom column is just an internally-generated `ExtraColumn` appended to `allColumns` and merged into that map, so it reuses those rails with **no changes to `CellContent`'s switch, `getSortValue`, or `getCellFilterValue`**. Keys are prefixed (`label:` / `annotation:`) so they never collide with built-in keys.

The pure logic (key encoding, value read, and a load-boundary `sanitizeCustomColumnDefs` that trims, dedupes, and drops malformed entries) lives in `utils/custom-columns.ts` with **15 unit tests**; only the JSX `render` stays in the component.

In the column picker: each custom column gets a remove (×) button, and a **pinned footer** (so the input never scrolls below the fold) offers a Label/Annotation toggle plus a text input with **key autocomplete sampled from the loaded rows**. Long values truncate with a tooltip.

## State & persistence subtleties (worth a reviewer's eye)

- The settings-load effect is keyed to the kind, **not** `allColumns` — since `allColumns` now changes at runtime on add/remove, keeping it in deps would re-read localStorage mid-edit and clobber the change. The effect reconstructs the column list locally instead.
- The skip-initial-save guard is re-armed per kind so a kind switch can't persist the previous kind's columns under the new kind's storage key.
- Persisted defs are sanitized on load (untyped `JSON.parse` boundary), and the autocomplete `datalist` uses a per-instance `useId()` so two tables on one page (fleet compare) don't cross-suggest.

## Scope

localStorage-only, labels + annotations only, all resource kinds. Deferred: server-side / cross-device persistence, and arbitrary JSONPath/status-field columns (full k9s `views.yaml` power — skipped to preserve the no-config positioning).

## Verification

`make tsc` clean; **526 `@skyhook-io/k8s-ui` tests pass** (19 across the new column utils + filter-serialization round-trip). Visually verified end-to-end against the `kind` GitOps-demo cluster (1280/1920/2560 + dark mode): add a `kubernetes.io/arch` column on Nodes → `arm64`, persists across reload and Nodes→Pods→Nodes round-trips, remove + reset clear it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core ResourcesView state (columns, filters, URL sync, localStorage) across all kinds; logic is well-tested but regressions in column picker or kind-switch persistence are possible.
> 
> **Overview**
> Adds **k9s-style custom columns** to the Resources table: users can define columns from any `metadata.labels` or `metadata.annotations` key via the column picker, with sort, filter, resize, remove, and **per-kind localStorage** persistence.
> 
> Custom defs live in `utils/custom-columns.ts` (key encoding, value read, `sanitizeCustomColumnDefs` on load) and are turned into internal `ExtraColumn`s merged into `extraColumnsByKey`, reusing the existing render/sort/filter rails without extending `CellContent` switches. The picker gains a pinned add-column footer (label/annotation toggle, datalist autocomplete from sampled row keys, per-instance `useId`), remove buttons on custom columns, and refactored host-extra collision handling via `filterHostExtras`.
> 
> Column settings load/save is tightened so kind switches don’t cross-write storage, stale-default migration doesn’t wipe saved custom columns, and runtime add/remove doesn’t re-trigger load from `allColumns`. **URL column filters** now URI-encode keys so `label:…` keys don’t break the `key:value` serializer. README documents the feature; vitest covers custom columns and filter round-trips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a08f76dca529a38c0b69c67168fe03319a77f44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->