### PR TITLE
Basic support for the GPU/batch/inference ecosystem (37 kinds)

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,13 @@ Upgrade impact also gets list-only access to CSIStorageCapacities, FlowSchemas, 
 | **Dynamic Resource Allocation** | ResourceClaim, ResourceClaimTemplate, DeviceClass, ResourceSlice (resource.k8s.io, K8s 1.32+) |
 | **NVIDIA GPU Operator** | ClusterPolicy, NVIDIADriver |
 | **Calico** | NetworkPolicy, GlobalNetworkPolicy, StagedNetworkPolicy, StagedGlobalNetworkPolicy, StagedKubernetesNetworkPolicy, IPPool, HostEndpoint, Tier |
+| **Kueue** | ClusterQueue, LocalQueue, Workload, ResourceFlavor, AdmissionCheck (+ Cluster Autoscaler ProvisioningRequest) — basic |
+| **KubeRay** | RayCluster, RayJob, RayService, RayCronJob — basic |
+| **KServe** | InferenceService, ServingRuntime, ClusterServingRuntime, InferenceGraph, TrainedModel, LLMInferenceService — basic |
+| **Inference Gateway** | InferencePool (v1 + alpha groups), InferenceObjective — basic |
+| **Batch** | LeaderWorkerSet, JobSet, Volcano (Job/Queue/PodGroup/JobFlow/JobTemplate), Kubeflow (PyTorchJob/TFJob/MPIJob/TrainJob) — basic |
+| **KAI Scheduler** | Queue, PodGroup — basic |
+| **Model serving** | KAITO (Workspace, RAGEngine), NVIDIA NIM (NIMService/NIMCache/NIMPipeline), AMD GPU Operator (DeviceConfig) — basic |
 | **Cost (OpenCost)** | Namespace/workload/node cost breakdown via Prometheus (no CRDs) |
 | **CRDs** | Any Custom Resource Definition in your cluster (auto-discovered) |
 

--- a/deploy/helm/radar/templates/clusterrole.yaml
+++ b/deploy/helm/radar/templates/clusterrole.yaml
@@ -404,6 +404,70 @@ rules:
     resources: ["*"]
     verbs: ["get", "list", "watch"]
   {{- end }}
+  {{- if .Values.rbac.crdGroups.nimOperator }}
+  - apiGroups: ["apps.nvidia.com"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.amdGpu }}
+  - apiGroups: ["amd.com"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.kueue }}
+  # autoscaling.x-k8s.io carries ProvisioningRequests — created by Kueue's
+  # provisioning AdmissionCheck, so the two ship under one toggle.
+  - apiGroups: ["kueue.x-k8s.io", "autoscaling.x-k8s.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.kserve }}
+  - apiGroups: ["serving.kserve.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.kuberay }}
+  - apiGroups: ["ray.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.lws }}
+  - apiGroups: ["leaderworkerset.x-k8s.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.jobset }}
+  - apiGroups: ["jobset.x-k8s.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.inferenceGateway }}
+  # InferencePool graduated to inference.networking.k8s.io; llm-d now owns
+  # InferenceObjective while deployed alpha versions retain the old group.
+  - apiGroups: ["inference.networking.k8s.io", "inference.networking.x-k8s.io", "llm-d.ai"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.volcano }}
+  - apiGroups: ["batch.volcano.sh", "scheduling.volcano.sh", "flow.volcano.sh", "bus.volcano.sh"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.kaiScheduler }}
+  - apiGroups: ["scheduling.run.ai", "kai.scheduler"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.kaito }}
+  - apiGroups: ["kaito.sh"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.rbac.crdGroups.kubeflow }}
+  - apiGroups: ["kubeflow.org", "trainer.kubeflow.org"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
   {{- if .Values.rbac.crdGroups.nginx }}
   - apiGroups: ["nginx.org"]
     resources: ["*"]

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -148,9 +148,11 @@ rbac:
     clusterApi: true        # *.cluster.x-k8s.io (CAPI core + infrastructure / controlplane / bootstrap / addons)
     contour: true           # projectcontour.io
     crossplane: true        # crossplane.io, pkg.crossplane.io, apiextensions.crossplane.io, helm.crossplane.io, kubernetes.crossplane.io. For Upbound provider CRDs (s3.aws.upbound.io, compute.gcp.upbound.io, etc.) list them in additionalCrdGroups — K8s RBAC has no apiGroup wildcards.
+    amdGpu: true            # amd.com (AMD GPU Operator: DeviceConfig)
     descheduler: true       # descheduler.alpha.kubernetes.io
     dra: true               # resource.k8s.io (Dynamic Resource Allocation — ResourceClaims, DeviceClasses, ResourceSlices)
     envoyGateway: true      # gateway.envoyproxy.io
+    inferenceGateway: true  # inference.networking.k8s.io, inference.networking.x-k8s.io, llm-d.ai (Inference Gateway + llm-d routing APIs)
     externalDns: true       # externaldns.k8s.io
     externalSecrets: true   # external-secrets.io
     flux: true              # *.toolkit.fluxcd.io
@@ -158,16 +160,25 @@ rbac:
     gcpMonitoring: true     # monitoring.googleapis.com
     grafana: true           # monitoring.grafana.com, tempo/loki/grafana.integreatly.org
     istio: true             # networking.istio.io, security.istio.io
+    jobset: true            # jobset.x-k8s.io
+    kaiScheduler: true      # scheduling.run.ai, kai.scheduler (KAI Scheduler queues and pod groups)
+    kaito: true             # kaito.sh (Workspaces, RAGEngines)
     karpenter: true         # karpenter.sh, karpenter.k8s.aws, karpenter.azure.com, karpenter.k8s.gcp, eks.amazonaws.com (EKS Auto Mode NodeClasses)
     keda: true              # keda.sh
     knative: true           # serving.knative.dev, eventing.knative.dev, sources/messaging/flows/networking.internal.knative.dev
+    kserve: true            # serving.kserve.io (InferenceServices, ServingRuntimes, LLMInferenceServices)
+    kubeflow: true          # kubeflow.org, trainer.kubeflow.org (PyTorchJob/TFJob/MPIJob, TrainJob)
+    kuberay: true           # ray.io (RayClusters, RayJobs, RayServices)
     kubeshark: true         # kubeshark.io
     kubevirt: true          # kubevirt.io (VirtualMachines/VMIs) + cdi/clone/export/instancetype/migrations/pool/snapshot.kubevirt.io
+    kueue: true             # kueue.x-k8s.io + autoscaling.x-k8s.io (queues, workloads, ProvisioningRequests)
     kured: true             # kured.io
     kyverno: true           # kyverno.io, policies.kyverno.io (modern CEL policy family), wgpolicyk8s.io, reports.kyverno.io, openreports.io
+    lws: true               # leaderworkerset.x-k8s.io
     mariadb: true           # mariadb.mmontes.io
     networkPolicyApi: true  # policy.networking.k8s.io (Admin/Baseline/ClusterNetworkPolicy — SIG-network)
     nginx: true             # nginx.org
+    nimOperator: true       # apps.nvidia.com (NVIDIA NIM: NIMServices, NIMCaches, NIMPipelines)
     nvidia: true            # nvidia.com (GPU Operator: ClusterPolicy, NVIDIADriver)
     openshift: true         # observability.openshift.io
     opentelemetry: true     # opentelemetry.io
@@ -181,6 +192,7 @@ rbac:
     trivy: true             # aquasecurity.github.io
     velero: true            # velero.io
     verticalPodAutoscaler: true  # autoscaling.k8s.io (VPA — granted by default; no-op on clusters where VPA isn't installed)
+    volcano: true           # batch.volcano.sh, scheduling.volcano.sh, flow.volcano.sh, bus.volcano.sh
 
   # Additional CRD API groups for custom/unlisted CRDs
   # Example: ["mycompany.io", "custom.example.com"]

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1323,6 +1323,76 @@ Radar statically evaluates Calico selectors against workload pod templates and t
 
 ---
 
+## GPU & Batch Ecosystem (basic support)
+
+Basic resource support for the GPU scheduling, batch, and inference-serving ecosystem: **status badges, smart table columns, status filters, and sidebar grouping** for every kind below. Detail views use the standard spec/status renderer; topology participation and typed detail views land with the deeper per-tool integrations.
+
+### Kueue + Cluster Autoscaler
+
+| Resource | Group | Status source |
+|----------|-------|---------------|
+| ClusterQueue | `kueue.x-k8s.io` (v1beta2, v1beta1) | `Active` condition |
+| LocalQueue | `kueue.x-k8s.io` | `Active` condition |
+| Workload | `kueue.x-k8s.io` | Admitted / Evicted / Preempted / Finished conditions |
+| ResourceFlavor | `kueue.x-k8s.io` | — |
+| AdmissionCheck | `kueue.x-k8s.io` | `Active` condition |
+| ProvisioningRequest | `autoscaling.x-k8s.io` (v1, v1beta1) | Provisioned / Failed / CapacityRevoked / BookingExpired conditions |
+
+### KubeRay
+
+| Resource | Group | Status source |
+|----------|-------|---------------|
+| RayCluster | `ray.io/v1` | state + provisioning conditions |
+| RayJob | `ray.io/v1` | jobStatus + jobDeploymentStatus |
+| RayService | `ray.io/v1` | serviceStatus + upgrade/rollback conditions |
+| RayCronJob | `ray.io/v1` | suspend |
+
+### KServe
+
+| Resource | Group | Status source |
+|----------|-------|---------------|
+| InferenceService | `serving.kserve.io/v1beta1` | Ready condition + modelStatus.transitionStatus |
+| ServingRuntime / ClusterServingRuntime | `serving.kserve.io/v1alpha1` | spec.disabled |
+| InferenceGraph | `serving.kserve.io/v1alpha1` | Ready condition |
+| TrainedModel | `serving.kserve.io/v1alpha1` | Ready condition |
+| LLMInferenceService | `serving.kserve.io` (v1alpha2, v1alpha1) | Ready / aggregate conditions |
+
+### Gateway API Inference Extension
+
+| Resource | Group | Status source |
+|----------|-------|---------------|
+| InferencePool | `inference.networking.k8s.io/v1` and `inference.networking.x-k8s.io/v1alpha2` | per-parent Accepted + ResolvedRefs |
+| InferenceObjective | `llm-d.ai/v1alpha2` and `inference.networking.x-k8s.io/v1alpha2` | Accepted / Ready condition |
+
+### Batch: LeaderWorkerSet, JobSet, Volcano, Kubeflow Training
+
+| Resource | Group | Status source |
+|----------|-------|---------------|
+| LeaderWorkerSet | `leaderworkerset.x-k8s.io/v1` | Available / Progressing conditions |
+| JobSet | `jobset.x-k8s.io/v1alpha2` | Completed / Failed / Suspended conditions |
+| Job (Volcano) | `batch.volcano.sh/v1alpha1` | state.phase — disambiguated from batch/v1 Jobs by group |
+| Queue (Volcano) | `scheduling.volcano.sh/v1beta1` | state (Open/Closed) |
+| PodGroup (Volcano) | `scheduling.volcano.sh/v1beta1` | phase + Unschedulable condition |
+| JobFlow / JobTemplate | `flow.volcano.sh/v1alpha1` | state.phase / — |
+| Queue (KAI) | `scheduling.run.ai/v2` | Orphan / OverQuota conditions + allocation |
+| PodGroup (KAI) | `scheduling.run.ai/v2alpha2` | phase + scheduling conditions |
+| PyTorchJob / TFJob | `kubeflow.org/v1` | JobCondition pattern |
+| MPIJob | `kubeflow.org` (v1, v2beta1) | JobCondition pattern |
+| TrainJob | `trainer.kubeflow.org/v1alpha1` | Complete / Failed / Suspended conditions + active child jobs |
+
+Volcano Job, the Volcano/KAI Queues and PodGroups, and KAITO Workspaces share kind names with other resources — Radar disambiguates by API group in tables, filters, and status badges.
+
+### Model serving operators: KAITO, NVIDIA NIM, AMD
+
+| Resource | Group | Status source |
+|----------|-------|---------------|
+| Workspace (KAITO) | `kaito.sh` (v1beta1) | ResourceReady / InferenceReady / WorkspaceSucceeded conditions |
+| RAGEngine (KAITO) | `kaito.sh` (v1beta1, v1alpha1) | ResourceReady / ServiceReady conditions |
+| NIMService / NIMCache / NIMPipeline | `apps.nvidia.com/v1alpha1` | status.state |
+| DeviceConfig (AMD GPU Operator) | `amd.com/v1alpha1` | Ready condition + component DaemonSet rollout counts |
+
+---
+
 ## Any Other CRD
 
 Radar automatically discovers and displays **every** CRD installed in your cluster — no configuration or plugins required. Resources appear in the sidebar, can be filtered and searched, and show full YAML with syntax highlighting in the detail drawer. The integrations above add richer presentation, but every CRD is browsable out of the box.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1327,6 +1327,8 @@ Radar statically evaluates Calico selectors against workload pod templates and t
 
 Basic resource support for the GPU scheduling, batch, and inference-serving ecosystem: **status badges, smart table columns, status filters, and sidebar grouping** for every kind below. Detail views use the standard spec/status renderer; topology participation and typed detail views land with the deeper per-tool integrations.
 
+This is resource reconnaissance, not GPU accounting or end-to-end workload diagnosis. It does not inventory physical devices, distinguish virtual or fractional GPUs such as HAMi, report utilization, or explain the complete workload-to-queue-to-Pod scheduling path.
+
 ### Kueue + Cluster Autoscaler
 
 | Resource | Group | Status source |

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -34,7 +34,7 @@ import { ResourceBar } from '../ui/ResourceBar'
 import type { SelectedResource, APIResource } from '../../types'
 import { isForbiddenError } from '../../types/fetch-error'
 import type { NavigateToResource } from '../../utils/navigation'
-import { categorizeResources, CORE_RESOURCES, findAPIResourceForRoute } from '../../utils/api-resources'
+import { categorizeResources, CORE_RESOURCES, findAPIResourceForRoute, isCoreBatchJob } from '../../utils/api-resources'
 import { copyText } from '../../utils/clipboard'
 import {
   getPodStatus,
@@ -164,6 +164,18 @@ import { NodePoolCell, NodeClaimCell, EC2NodeClassCell } from './renderers/karpe
 import { ScaledObjectCell, ScaledJobCell, TriggerAuthenticationCell, ClusterTriggerAuthenticationCell } from './renderers/keda-cells'
 import { ResourceClaimCell, ResourceClaimTemplateCell, DeviceClassCell, ResourceSliceCell } from './renderers/dra-cells'
 import { NvidiaClusterPolicyCell, NvidiaDriverCell } from './renderers/nvidia-cells'
+import { ClusterQueueCell, LocalQueueCell, KueueWorkloadCell, ResourceFlavorCell, AdmissionCheckCell, ProvisioningRequestCell } from './renderers/kueue-cells'
+import { RayClusterCell, RayJobCell, RayServiceCell, RayCronJobCell } from './renderers/ray-cells'
+import { LeaderWorkerSetCell, JobSetCell } from './renderers/jobset-lws-cells'
+import { getJobSetReadyJobs, getJobSetRestarts } from './resource-utils-jobset-lws'
+import { InferenceServiceCell, ServingRuntimeCell, InferenceGraphCell, TrainedModelCell, LLMInferenceServiceCell } from './renderers/kserve-cells'
+import { InferencePoolCell, InferenceObjectiveCell } from './renderers/inference-gateway-cells'
+import { VolcanoJobCell, VolcanoQueueCell, VolcanoPodGroupCell, JobFlowCell, JobTemplateCell } from './renderers/volcano-cells'
+import { KaiQueueCell, KaiPodGroupCell } from './renderers/kai-cells'
+import { KaitoWorkspaceCell, RAGEngineCell } from './renderers/kaito-cells'
+import { NIMServiceCell, NIMCacheCell, NIMPipelineCell } from './renderers/nim-cells'
+import { AMDDeviceConfigCell } from './renderers/amd-gpu-cells'
+import { PyTorchJobCell, TFJobCell, MPIJobCell, TrainJobCell } from './renderers/kubeflow-training-cells'
 import { ServiceMonitorCell, PrometheusRuleCell, PodMonitorCell } from './renderers/prometheus-cells'
 import { PolicyReportCell, ClusterPolicyReportCell, KyvernoPolicyCell, ClusterPolicyCell,
   KyvernoUpdateRequestCell,
@@ -715,6 +727,314 @@ const KNOWN_COLUMNS: Record<string, Column[]> = {
     { key: 'status', label: 'Status', width: 'w-28' },
     { key: 'driverType', label: 'Type', width: 'w-28' },
     { key: 'version', label: 'Version', width: 'w-32' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  clusterqueues: [
+    { key: 'name', label: 'Name' },
+    { key: 'status', label: 'Status', width: 'w-24' },
+    { key: 'cohort', label: 'Cohort', width: 'w-32' },
+    { key: 'pendingWorkloads', label: 'Pending', width: 'w-24', tooltip: 'Pending workloads' },
+    { key: 'admittedWorkloads', label: 'Admitted', width: 'w-24', tooltip: 'Admitted workloads' },
+    { key: 'flavors', label: 'Flavors', width: 'w-40' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  localqueues: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-24' },
+    { key: 'clusterQueue', label: 'Cluster Queue', width: 'w-40' },
+    { key: 'pendingWorkloads', label: 'Pending', width: 'w-24' },
+    { key: 'admittedWorkloads', label: 'Admitted', width: 'w-24' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  workloads: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-28' },
+    { key: 'queueName', label: 'Queue', width: 'w-36' },
+    { key: 'admittedBy', label: 'Admitted By', width: 'w-36', tooltip: 'Admitting ClusterQueue' },
+    { key: 'priority', label: 'Priority', width: 'w-24' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  resourceflavors: [
+    { key: 'name', label: 'Name' },
+    { key: 'status', label: 'Status', width: 'w-24' },
+    { key: 'nodeLabels', label: 'Node Labels', width: 'w-28', tooltip: 'Node label selector count' },
+    { key: 'taints', label: 'Taints', width: 'w-24' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  admissionchecks: [
+    { key: 'name', label: 'Name' },
+    { key: 'status', label: 'Status', width: 'w-24' },
+    { key: 'controllerName', label: 'Controller', width: 'w-64' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  provisioningrequests: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-28' },
+    { key: 'provisioningClassName', label: 'Class', width: 'w-56' },
+    { key: 'podSets', label: 'Pod Sets', width: 'w-24' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  rayclusters: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-28' },
+    { key: 'rayVersion', label: 'Ray Version', width: 'w-28' },
+    { key: 'workers', label: 'Workers', width: 'w-24', tooltip: 'Available/desired worker replicas' },
+    { key: 'headService', label: 'Head Service', width: 'w-48' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  rayjobs: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-28' },
+    { key: 'jobStatus', label: 'Job Status', width: 'w-28' },
+    { key: 'deploymentStatus', label: 'Deployment', width: 'w-32' },
+    { key: 'cluster', label: 'Cluster', width: 'w-48' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  rayservices: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-28' },
+    { key: 'serviceStatus', label: 'Service Status', width: 'w-28' },
+    { key: 'clusters', label: 'Clusters', width: 'w-56', tooltip: 'Active and pending RayCluster names' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  raycronjobs: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-24' },
+    { key: 'schedule', label: 'Schedule', width: 'w-32' },
+    { key: 'suspend', label: 'Suspend', width: 'w-20' },
+    { key: 'lastSchedule', label: 'Last Schedule', width: 'w-28' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  leaderworkersets: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-28' },
+    { key: 'replicas', label: 'Groups', width: 'w-20', tooltip: 'Desired leader-worker groups' },
+    { key: 'size', label: 'Size', width: 'w-20', tooltip: 'Pods per group' },
+    { key: 'ready', label: 'Ready', width: 'w-20', tooltip: 'Ready groups / desired groups' },
+    { key: 'updated', label: 'Updated', width: 'w-20' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  jobsets: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-28' },
+    { key: 'replicatedJobs', label: 'Repl. Jobs', width: 'w-24', tooltip: 'Number of replicated job templates' },
+    { key: 'ready', label: 'Ready', width: 'w-20' },
+    { key: 'succeeded', label: 'Succeeded', width: 'w-24' },
+    { key: 'failed', label: 'Failed', width: 'w-20' },
+    { key: 'restarts', label: 'Restarts', width: 'w-24' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  inferenceservices: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-36', tooltip: 'Ready condition + model load state' },
+    { key: 'url', label: 'URL', width: 'w-64' },
+    { key: 'modelFormat', label: 'Format', width: 'w-28' },
+    { key: 'runtime', label: 'Runtime', width: 'w-40' },
+    { key: 'deploymentMode', label: 'Mode', width: 'w-28', tooltip: 'Serverless, RawDeployment, or ModelMesh' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  servingruntimes: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-24' },
+    { key: 'modelFormats', label: 'Model Formats', width: 'w-44', tooltip: 'Supported model formats' },
+    { key: 'image', label: 'Image', width: 'w-64' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  clusterservingruntimes: [
+    { key: 'name', label: 'Name' },
+    { key: 'status', label: 'Status', width: 'w-24' },
+    { key: 'modelFormats', label: 'Model Formats', width: 'w-44', tooltip: 'Supported model formats' },
+    { key: 'image', label: 'Image', width: 'w-64' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  inferencegraphs: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-24' },
+    { key: 'nodes', label: 'Nodes', width: 'w-20', tooltip: 'Router nodes in the graph' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  trainedmodels: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-24' },
+    { key: 'framework', label: 'Framework', width: 'w-28' },
+    { key: 'storageUri', label: 'Storage URI', width: 'w-56' },
+    { key: 'inferenceService', label: 'Inference Service', width: 'w-40', tooltip: 'Parent InferenceService' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  llminferenceservices: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-28' },
+    { key: 'model', label: 'Model', width: 'w-56', tooltip: 'Model name or URI' },
+    { key: 'replicas', label: 'Replicas', width: 'w-24' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  inferencepools: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-36', tooltip: 'Gateway acceptance and EPP resolution' },
+    { key: 'selector', label: 'Selector', width: 'w-48' },
+    { key: 'targetPorts', label: 'Target Ports', width: 'w-28' },
+    { key: 'extensionRef', label: 'Endpoint Picker', width: 'w-40', tooltip: 'EPP extension service' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  inferenceobjectives: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-24' },
+    { key: 'poolRef', label: 'Pool', width: 'w-40', tooltip: 'Target InferencePool' },
+    { key: 'priority', label: 'Priority', width: 'w-24' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  volcanojobs: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-28' },
+    { key: 'queue', label: 'Queue', width: 'w-32' },
+    { key: 'minAvailable', label: 'Min Available', width: 'w-28' },
+    { key: 'pods', label: 'Pods', width: 'w-44', tooltip: 'Running / succeeded / failed pod counts' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  volcanoqueues: [
+    { key: 'name', label: 'Name' },
+    { key: 'status', label: 'Status', width: 'w-24' },
+    { key: 'weight', label: 'Weight', width: 'w-20' },
+    { key: 'capability', label: 'Capability', width: 'w-48' },
+    { key: 'allocated', label: 'Allocated', width: 'w-48' },
+    { key: 'podGroups', label: 'PodGroups', width: 'w-44', tooltip: 'PodGroup counts by state' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  volcanopodgroups: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-32' },
+    { key: 'queue', label: 'Queue', width: 'w-32' },
+    { key: 'minMember', label: 'Min Member', width: 'w-28' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  jobflows: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-28' },
+    { key: 'flows', label: 'Flows', width: 'w-20' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  jobtemplates: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-24' },
+    { key: 'tasks', label: 'Tasks', width: 'w-20' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  kaiqueues: [
+    { key: 'name', label: 'Name' },
+    { key: 'status', label: 'Status', width: 'w-24' },
+    { key: 'parentQueue', label: 'Parent', width: 'w-32' },
+    { key: 'priority', label: 'Priority', width: 'w-20' },
+    { key: 'quota', label: 'Quota', width: 'w-52', tooltip: 'GPU fractions, CPU millicpus, memory MB; -1 = unlimited' },
+    { key: 'allocated', label: 'Allocated', width: 'w-48' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  kaipodgroups: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-32' },
+    { key: 'queue', label: 'Queue', width: 'w-32' },
+    { key: 'minMember', label: 'Min Member', width: 'w-28' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  kaitoworkspaces: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-28' },
+    { key: 'instanceType', label: 'Instance Type', width: 'w-40', tooltip: 'GPU node SKU provisioned for the workspace' },
+    { key: 'preset', label: 'Model', width: 'w-44', tooltip: 'Preset model (inference or tuning)' },
+    { key: 'nodes', label: 'Nodes', width: 'w-20', tooltip: 'Worker nodes ready / target' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  ragengines: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-28' },
+    { key: 'embedding', label: 'Embedding Model', width: 'w-56', tooltip: 'Local model ID/image or remote endpoint' },
+    { key: 'instanceType', label: 'Instance Type', width: 'w-40' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  nimservices: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-24' },
+    { key: 'model', label: 'Model / Image', width: 'w-64', tooltip: 'Served model name (falls back to NIM image)' },
+    { key: 'replicas', label: 'Replicas', width: 'w-28', tooltip: 'Available / desired (HPA range when autoscaling)' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  nimcaches: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-28' },
+    { key: 'source', label: 'Model Source', width: 'w-64', tooltip: 'NGC model puller image, or DataStore/HF model name' },
+    { key: 'storage', label: 'Storage', width: 'w-24', tooltip: 'Requested PVC size' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  nimpipelines: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-24' },
+    { key: 'services', label: 'Services', width: 'w-28', tooltip: 'NIM services in pipeline' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  deviceconfigs: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-24' },
+    { key: 'driver', label: 'Driver', width: 'w-40', tooltip: 'Out-of-tree driver install enabled (version)' },
+    { key: 'devicePluginImage', label: 'Device Plugin', width: 'w-64' },
+    { key: 'nodes', label: 'Nodes', width: 'w-20', tooltip: 'Device plugin DaemonSet available / desired' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  pytorchjobs: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-28' },
+    { key: 'replicas', label: 'Progress', width: 'w-48', tooltip: 'Active + succeeded / desired per replica type; failures shown separately' },
+    { key: 'elapsed', label: 'Elapsed', width: 'w-24', tooltip: 'Start to completion (or now)' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  tfjobs: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-28' },
+    { key: 'replicas', label: 'Progress', width: 'w-56', tooltip: 'Active + succeeded / desired per replica type; failures shown separately' },
+    { key: 'elapsed', label: 'Elapsed', width: 'w-24', tooltip: 'Start to completion (or now)' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  mpijobs: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-28' },
+    { key: 'replicas', label: 'Progress', width: 'w-48', tooltip: 'Active + succeeded / desired per replica type; failures shown separately' },
+    { key: 'elapsed', label: 'Elapsed', width: 'w-24', tooltip: 'Start to completion (or now)' },
+    { key: 'age', label: 'Age', width: 'w-24' },
+  ],
+  trainjobs: [
+    { key: 'name', label: 'Name' },
+    { key: 'namespace', label: 'Namespace', width: 'w-36' },
+    { key: 'status', label: 'Status', width: 'w-28' },
+    { key: 'runtime', label: 'Runtime', width: 'w-44', tooltip: 'Training runtime reference' },
+    { key: 'suspended', label: 'Suspended', width: 'w-24' },
     { key: 'age', label: 'Age', width: 'w-24' },
   ],
   scaledjobs: [
@@ -2127,6 +2447,14 @@ const GROUP_QUALIFIED_COLUMN_KEYS: Record<string, Record<string, string>> = {
   // Istio Gateway is not a Gateway API Gateway: it has servers and a workload
   // selector, and none of Class/Listeners/Routes/Addresses.
   gateways: { 'networking.istio.io': 'istiogateways' },
+  job: { batch: 'jobs', 'batch.volcano.sh': 'volcanojobs' },
+  jobs: { batch: 'jobs', 'batch.volcano.sh': 'volcanojobs' },
+  queue: { 'scheduling.volcano.sh': 'volcanoqueues', 'scheduling.run.ai': 'kaiqueues' },
+  queues: { 'scheduling.volcano.sh': 'volcanoqueues', 'scheduling.run.ai': 'kaiqueues' },
+  podgroup: { 'scheduling.volcano.sh': 'volcanopodgroups', 'scheduling.run.ai': 'kaipodgroups' },
+  podgroups: { 'scheduling.volcano.sh': 'volcanopodgroups', 'scheduling.run.ai': 'kaipodgroups' },
+  workspace: { 'kaito.sh': 'kaitoworkspaces' },
+  workspaces: { 'kaito.sh': 'kaitoworkspaces' },
   services: { 'serving.knative.dev': 'knativeservices' },
   configurations: { 'serving.knative.dev': 'knativeconfigurations' },
   revisions: { 'serving.knative.dev': 'knativerevisions' },
@@ -2195,6 +2523,7 @@ const GROUP_QUALIFIED_COLUMN_KEYS: Record<string, Record<string, string>> = {
 
 const GROUP_QUALIFIED_ONLY_COLUMN_KEYS = new Set([
   'networkpolicy', 'networkpolicies',
+  'job', 'jobs',
   // Other projects serve their own IPPool CRD, so only a Calico group earns the
   // Calico columns.
   'ippool', 'ippools',
@@ -2203,6 +2532,7 @@ const GROUP_QUALIFIED_ONLY_COLUMN_KEYS = new Set([
   'stagedglobalnetworkpolicy', 'stagedglobalnetworkpolicies',
   'stagedkubernetesnetworkpolicy', 'stagedkubernetesnetworkpolicies',
 ])
+
 const CALICO_ONLY_COLUMN_KEYS = new Set([
   'globalnetworkpolicy', 'globalnetworkpolicies',
   'stagednetworkpolicy', 'stagednetworkpolicies',
@@ -2213,7 +2543,7 @@ const CALICO_ONLY_COLUMN_KEYS = new Set([
 // Normalize a kind name to its plural API form used in KNOWN_COLUMNS keys.
 // Handles CRD singular names from URLs: 'ScaledObject' → 'scaledobjects', 'NodePool' → 'nodepools'
 // When group is provided, resolves collisions (e.g., 'services' + 'serving.knative.dev' → 'knativeservices')
-function normalizeKindToPlural(kind: string, group?: string): string {
+export function normalizeKindToPlural(kind: string, group?: string): string {
   const lower = kind.toLowerCase()
   // Check group-qualified mapping first for collision resolution
   if (group && GROUP_QUALIFIED_COLUMN_KEYS[lower]?.[group]) {
@@ -2457,6 +2787,43 @@ const CURATED_COLUMN_GROUPS: Record<string, readonly string[]> = {
   volumesnapshotlocations: ['velero.io'],
   clusterpolicyreports: ['wgpolicyk8s.io'],
   policyreports: ['wgpolicyk8s.io'],
+  deviceconfigs: ['amd.com'],
+  nimcaches: ['apps.nvidia.com'],
+  nimpipelines: ['apps.nvidia.com'],
+  nimservices: ['apps.nvidia.com'],
+  provisioningrequests: ['autoscaling.x-k8s.io'],
+  volcanojobs: ['batch.volcano.sh'],
+  jobflows: ['flow.volcano.sh'],
+  jobtemplates: ['flow.volcano.sh'],
+  inferencepools: ['inference.networking.k8s.io', 'inference.networking.x-k8s.io'],
+  inferenceobjectives: ['inference.networking.x-k8s.io', 'llm-d.ai'],
+  jobsets: ['jobset.x-k8s.io'],
+  kaitoworkspaces: ['kaito.sh'],
+  ragengines: ['kaito.sh'],
+  admissionchecks: ['kueue.x-k8s.io'],
+  clusterqueues: ['kueue.x-k8s.io'],
+  localqueues: ['kueue.x-k8s.io'],
+  resourceflavors: ['kueue.x-k8s.io'],
+  workloads: ['kueue.x-k8s.io'],
+  mpijobs: ['kubeflow.org'],
+  pytorchjobs: ['kubeflow.org'],
+  tfjobs: ['kubeflow.org'],
+  leaderworkersets: ['leaderworkerset.x-k8s.io'],
+  rayclusters: ['ray.io'],
+  raycronjobs: ['ray.io'],
+  rayjobs: ['ray.io'],
+  rayservices: ['ray.io'],
+  kaipodgroups: ['scheduling.run.ai'],
+  kaiqueues: ['scheduling.run.ai'],
+  volcanopodgroups: ['scheduling.volcano.sh'],
+  volcanoqueues: ['scheduling.volcano.sh'],
+  clusterservingruntimes: ['serving.kserve.io'],
+  inferencegraphs: ['serving.kserve.io'],
+  inferenceservices: ['serving.kserve.io'],
+  llminferenceservices: ['serving.kserve.io'],
+  servingruntimes: ['serving.kserve.io'],
+  trainedmodels: ['serving.kserve.io'],
+  trainjobs: ['trainer.kubeflow.org'],
 }
 
 function getColumnsForKind(kind: string, group?: string): Column[] {
@@ -2470,10 +2837,11 @@ function getColumnsForKind(kind: string, group?: string): Column[] {
   const key = normalizeKindToPlural(kind, group)
   const curated = KNOWN_COLUMNS[key]
   if (curated) {
+    const owners = CURATED_COLUMN_GROUPS[key]
+    if (group && owners) return owners.includes(group) ? curated : DEFAULT_COLUMNS
     // A core kind cannot be shadowed by a CRD, so it keeps its columns without
     // an ownership entry. Anything else has to be claimed for this exact group.
     if (!group || CORE_API_GROUPS.has(group)) return curated
-    if (CURATED_COLUMN_GROUPS[key]?.includes(group)) return curated
     if (isCuratedUnboundedGroup(key, group)) return curated
     return DEFAULT_COLUMNS
   }
@@ -2489,6 +2857,12 @@ function getColumnsForKind(kind: string, group?: string): Column[] {
  */
 export function hasCuratedColumns(kind: string, group?: string): boolean {
   return getColumnsForKind(kind, group) !== DEFAULT_COLUMNS
+}
+
+export function getCellFilterKind(kind: string, group?: string): string {
+  const normalized = normalizeKindToPlural(kind, group)
+  if (!group || hasCuratedColumns(kind, group) || normalized.startsWith('__generic_')) return normalized
+  return `__generic_${normalized}`
 }
 
 // Get the default visible columns for a kind
@@ -3698,11 +4072,14 @@ export function ResourcesView({
           if (containers.length > 0) {
             openLogs?.({ namespace: ns, podName: name, containers })
           }
-        } else if (['deployments', 'statefulsets', 'daemonsets', 'replicasets', 'jobs', 'workflows', 'cronjobs', 'cronworkflows', 'workflowtemplates', 'clusterworkflowtemplates', 'scaledjobs'].includes(kindLower)) {
+        } else if (['deployments', 'statefulsets', 'daemonsets', 'replicasets', 'workflows', 'cronjobs', 'cronworkflows', 'workflowtemplates', 'clusterworkflowtemplates', 'scaledjobs'].includes(kindLower) || isCoreBatchJob(kindLower, selectedKind.group)) {
           openWorkloadLogs?.({ namespace: ns, workloadKind: selectedKind.kind, workloadName: name })
         }
       },
-      enabled: highlightedIndex >= 0 && !compareMode && ['pods', 'deployments', 'statefulsets', 'daemonsets', 'replicasets', 'jobs', 'workflows', 'cronjobs', 'cronworkflows', 'workflowtemplates', 'clusterworkflowtemplates', 'scaledjobs'].includes(selectedKind.name.toLowerCase()),
+      enabled: highlightedIndex >= 0 && !compareMode && (
+        ['pods', 'deployments', 'statefulsets', 'daemonsets', 'replicasets', 'workflows', 'cronjobs', 'cronworkflows', 'workflowtemplates', 'clusterworkflowtemplates', 'scaledjobs'].includes(selectedKind.name.toLowerCase()) ||
+        isCoreBatchJob(selectedKind.name, selectedKind.group)
+      ),
     },
     {
       id: 'resources-sort-name',
@@ -4441,6 +4818,7 @@ export function ResourcesView({
         }
         return 0
       case 'ready':
+        if (kindLower === 'jobsets') return getJobSetReadyJobs(resource)
         // For DaemonSets, use numberReady/desiredNumberScheduled
         if (kindLower === 'daemonsets') {
           const desired = status.desiredNumberScheduled ?? 0
@@ -4461,6 +4839,7 @@ export function ResourcesView({
         // DaemonSet: updatedNumberScheduled, others: updatedReplicas
         return status.updatedNumberScheduled ?? status.updatedReplicas ?? 0
       case 'restarts':
+        if (kindLower === 'jobsets') return getJobSetRestarts(resource)
         return getPodRestarts(resource)
       case 'lastSeen': {
         const lastTs = resource.lastTimestamp || meta.creationTimestamp
@@ -4563,11 +4942,11 @@ export function ResourcesView({
     // when the parent supplied a custom getFilterValue.
     const activeColFilters = Object.entries(columnFilters).filter(([, vals]) => vals.length > 0)
     if (activeColFilters.length > 0) {
-      const kindLower = normalizeKindToPlural(selectedKind.name, selectedKind.group)
+      const cellFilterKind = getCellFilterKind(selectedKind.name, selectedKind.group)
       result = result.filter((r: any) =>
         activeColFilters.every(([col, vals]) => {
           const extra = extraColumnsByKey.get(col)
-          const cellVal = extra?.getFilterValue ? extra.getFilterValue(r) : getCellFilterValue(r, col, kindLower)
+          const cellVal = extra?.getFilterValue ? extra.getFilterValue(r) : getCellFilterValue(r, col, cellFilterKind)
           const match = vals.includes(cellVal)
           return columnFilterExcludes[col] ? !match : match
         })
@@ -4632,7 +5011,9 @@ export function ResourcesView({
       // Normalized, matching the filter call sites: a group-qualified kind
       // (istiogateways, cnpgclusters) otherwise arrives here as its bare plural
       // and misses its own sort readers. Hoisted out of the comparator.
-      const sortKind = normalizeKindToPlural(selectedKind.name, selectedKind.group)
+      // The ownership-aware wrapper also keeps a foreign CRD that reuses a
+      // curated plural on the generic reader used by its cells and filters.
+      const sortKind = getCellFilterKind(selectedKind.name, selectedKind.group)
       const keyOf = extra?.getSortValue ?? ((r: any) => getSortValue(r, sortColumn, sortKind))
       // Derived once per row, not once per comparison: a sort visits O(n log n)
       // pairs, and the status key now runs a per-kind status derivation.
@@ -4918,6 +5299,7 @@ export function ResourcesView({
     if (!resources || resources.length === 0) return null
 
     const kindLower = normalizeKindToPlural(selectedKind.name, selectedKind.group)
+    const cellFilterKind = getCellFilterKind(selectedKind.name, selectedKind.group)
     // Iterate over allColumns (built-ins + injected extras) so an
     // ExtraColumn with getFilterValue gets a column-filter dropdown like
     // any built-in does. The previous formulation iterated KNOWN_COLUMNS
@@ -4944,7 +5326,7 @@ export function ResourcesView({
       // Count distinct values for this column
       const valueCounts: Record<string, number> = {}
       for (const r of resources) {
-        const val = extra?.getFilterValue ? extra.getFilterValue(r) : getCellFilterValue(r, col.key, kindLower)
+        const val = extra?.getFilterValue ? extra.getFilterValue(r) : getCellFilterValue(r, col.key, cellFilterKind)
         if (val) {
           valueCounts[val] = (valueCounts[val] || 0) + 1
         }
@@ -6369,6 +6751,9 @@ function CellContent({ resource, kind, column, group, majorityNodeMinorVersion, 
 
   // Kind-specific columns (normalize CRD singular names like 'ScaledObject' → 'scaledobjects')
   const kindLower = normalizeKindToPlural(kind, group)
+  if (group && !hasCuratedColumns(kind, group)) {
+    return <GenericCell resource={resource} column={column} />
+  }
 
   // Kyverno cells are group-gated ahead of the switch so a non-matching CR
   // falls through to the switch's default (GenericCell) instead of being
@@ -6561,6 +6946,90 @@ function CellContent({ resource, kind, column, group, majorityNodeMinorVersion, 
       return <NvidiaClusterPolicyCell resource={resource} column={column} />
     case 'nvidiadrivers':
       return <NvidiaDriverCell resource={resource} column={column} />
+    // Kueue + Cluster Autoscaler
+    case 'clusterqueues':
+      return <ClusterQueueCell resource={resource} column={column} />
+    case 'localqueues':
+      return <LocalQueueCell resource={resource} column={column} />
+    case 'workloads':
+      return <KueueWorkloadCell resource={resource} column={column} />
+    case 'resourceflavors':
+      return <ResourceFlavorCell resource={resource} column={column} />
+    case 'admissionchecks':
+      return <AdmissionCheckCell resource={resource} column={column} />
+    case 'provisioningrequests':
+      return <ProvisioningRequestCell resource={resource} column={column} />
+    // KubeRay
+    case 'rayclusters':
+      return <RayClusterCell resource={resource} column={column} />
+    case 'rayjobs':
+      return <RayJobCell resource={resource} column={column} />
+    case 'rayservices':
+      return <RayServiceCell resource={resource} column={column} />
+    case 'raycronjobs':
+      return <RayCronJobCell resource={resource} column={column} />
+    // LeaderWorkerSet + JobSet
+    case 'leaderworkersets':
+      return <LeaderWorkerSetCell resource={resource} column={column} />
+    case 'jobsets':
+      return <JobSetCell resource={resource} column={column} />
+    // KServe
+    case 'inferenceservices':
+      return <InferenceServiceCell resource={resource} column={column} />
+    case 'servingruntimes':
+    case 'clusterservingruntimes':
+      return <ServingRuntimeCell resource={resource} column={column} />
+    case 'inferencegraphs':
+      return <InferenceGraphCell resource={resource} column={column} />
+    case 'trainedmodels':
+      return <TrainedModelCell resource={resource} column={column} />
+    case 'llminferenceservices':
+      return <LLMInferenceServiceCell resource={resource} column={column} />
+    // Gateway API Inference Extension
+    case 'inferencepools':
+      return <InferencePoolCell resource={resource} column={column} />
+    case 'inferenceobjectives':
+      return <InferenceObjectiveCell resource={resource} column={column} />
+    // Volcano (group-qualified keys disambiguate from batch Jobs and KAI)
+    case 'volcanojobs':
+      return <VolcanoJobCell resource={resource} column={column} />
+    case 'volcanoqueues':
+      return <VolcanoQueueCell resource={resource} column={column} />
+    case 'volcanopodgroups':
+      return <VolcanoPodGroupCell resource={resource} column={column} />
+    case 'jobflows':
+      return <JobFlowCell resource={resource} column={column} />
+    case 'jobtemplates':
+      return <JobTemplateCell resource={resource} column={column} />
+    // KAI Scheduler
+    case 'kaiqueues':
+      return <KaiQueueCell resource={resource} column={column} />
+    case 'kaipodgroups':
+      return <KaiPodGroupCell resource={resource} column={column} />
+    // KAITO
+    case 'kaitoworkspaces':
+      return <KaitoWorkspaceCell resource={resource} column={column} />
+    case 'ragengines':
+      return <RAGEngineCell resource={resource} column={column} />
+    // NVIDIA NIM Operator
+    case 'nimservices':
+      return <NIMServiceCell resource={resource} column={column} />
+    case 'nimcaches':
+      return <NIMCacheCell resource={resource} column={column} />
+    case 'nimpipelines':
+      return <NIMPipelineCell resource={resource} column={column} />
+    // AMD GPU Operator
+    case 'deviceconfigs':
+      return <AMDDeviceConfigCell resource={resource} column={column} />
+    // Kubeflow training
+    case 'pytorchjobs':
+      return <PyTorchJobCell resource={resource} column={column} />
+    case 'tfjobs':
+      return <TFJobCell resource={resource} column={column} />
+    case 'mpijobs':
+      return <MPIJobCell resource={resource} column={column} />
+    case 'trainjobs':
+      return <TrainJobCell resource={resource} column={column} />
     // ArgoCD GitOps resources
     case 'applications':
       return <ArgoApplicationCell resource={resource} column={column} />

--- a/packages/k8s-ui/src/components/resources/curated-column-ownership.test.ts
+++ b/packages/k8s-ui/src/components/resources/curated-column-ownership.test.ts
@@ -63,8 +63,8 @@ describe('curated column ownership', () => {
   // Brace-counting, not parsing: assert the extraction actually saw the whole
   // table, or a silently-missed key would let the guard above pass vacuously.
   it('extracted every curated key', () => {
-    expect(CURATED.length).toBe(199)
-    expect(OWNED.size).toBe(161)
+    expect(CURATED.length).toBe(236)
+    expect(OWNED.size).toBe(198)
     expect(CURATED).toContain('pods')
     expect(CURATED).toContain('crossplanemanagedresources')
     expect([...OWNED]).toContain('awsmanagedcontrolplanes')
@@ -121,7 +121,7 @@ describe('every declaration resolves', () => {
     .map(m => [m[1], m[2].split(',').map(g => g.trim().replace(/'/g, ''))] as const)
 
   it('covers the whole ownership table', () => {
-    expect(DECLARED.length).toBe(161)
+    expect(DECLARED.length).toBe(198)
   })
 
   it.each(DECLARED)('%s is curated under each group it claims', (key, groups) => {

--- a/packages/k8s-ui/src/components/resources/renderers/amd-gpu-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/amd-gpu-cells.tsx
@@ -1,0 +1,36 @@
+// AMD GPU Operator cell components for ResourcesView table
+
+import { clsx } from 'clsx'
+import {
+  getAMDDeviceConfigStatus,
+  getAMDDeviceConfigDriver,
+  getAMDDeviceConfigDevicePluginImage,
+  getAMDDeviceConfigNodeCount,
+} from '../resource-utils-amd-gpu'
+
+export function AMDDeviceConfigCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getAMDDeviceConfigStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'driver': {
+      const driver = getAMDDeviceConfigDriver(resource)
+      return <span className="text-sm text-theme-text-secondary">{driver}</span>
+    }
+    case 'devicePluginImage': {
+      const image = getAMDDeviceConfigDevicePluginImage(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{image}</span>
+    }
+    case 'nodes': {
+      const nodes = getAMDDeviceConfigNodeCount(resource)
+      return <span className="text-sm text-theme-text-secondary">{nodes}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}

--- a/packages/k8s-ui/src/components/resources/renderers/inference-gateway-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/inference-gateway-cells.tsx
@@ -1,0 +1,62 @@
+// Gateway API Inference Extension cell components for ResourcesView table
+
+import { clsx } from 'clsx'
+import {
+  getInferencePoolStatus,
+  getInferencePoolSelector,
+  getInferencePoolTargetPorts,
+  getInferencePoolExtensionRef,
+  getInferenceObjectiveStatus,
+  getInferenceObjectivePoolRef,
+  getInferenceObjectivePriority,
+} from '../resource-utils-inference-gateway'
+
+export function InferencePoolCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getInferencePoolStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'selector': {
+      const selector = getInferencePoolSelector(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{selector}</span>
+    }
+    case 'targetPorts': {
+      const ports = getInferencePoolTargetPorts(resource)
+      return <span className="text-sm text-theme-text-secondary">{ports}</span>
+    }
+    case 'extensionRef': {
+      const ref = getInferencePoolExtensionRef(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{ref}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}
+
+export function InferenceObjectiveCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getInferenceObjectiveStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'poolRef': {
+      const poolRef = getInferenceObjectivePoolRef(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{poolRef}</span>
+    }
+    case 'priority': {
+      const priority = getInferenceObjectivePriority(resource)
+      return <span className="text-sm text-theme-text-secondary">{priority}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}

--- a/packages/k8s-ui/src/components/resources/renderers/jobset-lws-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/jobset-lws-cells.tsx
@@ -1,0 +1,82 @@
+// LeaderWorkerSet and JobSet cell components for ResourcesView table
+
+import { clsx } from 'clsx'
+import {
+  getLeaderWorkerSetStatus,
+  getLeaderWorkerSetReplicas,
+  getLeaderWorkerSetSize,
+  getLeaderWorkerSetReady,
+  getLeaderWorkerSetUpdated,
+  getJobSetStatus,
+  getJobSetReplicatedJobs,
+  getJobSetReadyJobs,
+  getJobSetSucceededJobs,
+  getJobSetFailedJobs,
+  getJobSetRestarts,
+} from '../resource-utils-jobset-lws'
+
+export function LeaderWorkerSetCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getLeaderWorkerSetStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'replicas': {
+      const replicas = getLeaderWorkerSetReplicas(resource)
+      return <span className="text-sm text-theme-text-secondary">{replicas}</span>
+    }
+    case 'size': {
+      const size = getLeaderWorkerSetSize(resource)
+      return <span className="text-sm text-theme-text-secondary">{size}</span>
+    }
+    case 'ready': {
+      const ready = getLeaderWorkerSetReady(resource)
+      return <span className="text-sm text-theme-text-secondary">{ready}</span>
+    }
+    case 'updated': {
+      const updated = getLeaderWorkerSetUpdated(resource)
+      return <span className="text-sm text-theme-text-secondary">{updated}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}
+
+export function JobSetCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getJobSetStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'replicatedJobs': {
+      const count = getJobSetReplicatedJobs(resource)
+      return <span className="text-sm text-theme-text-secondary">{count}</span>
+    }
+    case 'ready': {
+      const ready = getJobSetReadyJobs(resource)
+      return <span className="text-sm text-theme-text-secondary">{ready}</span>
+    }
+    case 'succeeded': {
+      const succeeded = getJobSetSucceededJobs(resource)
+      return <span className="text-sm text-theme-text-secondary">{succeeded}</span>
+    }
+    case 'failed': {
+      const failed = getJobSetFailedJobs(resource)
+      return <span className={clsx('text-sm', failed > 0 ? 'text-theme-text-primary' : 'text-theme-text-secondary')}>{failed}</span>
+    }
+    case 'restarts': {
+      const restarts = getJobSetRestarts(resource)
+      return <span className="text-sm text-theme-text-secondary">{restarts}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}

--- a/packages/k8s-ui/src/components/resources/renderers/kai-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/kai-cells.tsx
@@ -1,0 +1,67 @@
+// KAI Scheduler cell components for ResourcesView table
+
+import { clsx } from 'clsx'
+import {
+  getKaiQueueStatus,
+  getKaiQueueParent,
+  getKaiQueuePriority,
+  getKaiQueueQuota,
+  getKaiQueueAllocated,
+  getKaiPodGroupStatus,
+  getKaiPodGroupQueue,
+  getKaiPodGroupMinMember,
+} from '../resource-utils-kai'
+
+export function KaiQueueCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getKaiQueueStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'parentQueue': {
+      const parent = getKaiQueueParent(resource)
+      return <span className="text-sm text-theme-text-secondary">{parent}</span>
+    }
+    case 'priority': {
+      const priority = getKaiQueuePriority(resource)
+      return <span className="text-sm text-theme-text-secondary">{priority}</span>
+    }
+    case 'quota': {
+      const quota = getKaiQueueQuota(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{quota}</span>
+    }
+    case 'allocated': {
+      const allocated = getKaiQueueAllocated(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{allocated}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}
+
+export function KaiPodGroupCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getKaiPodGroupStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'queue': {
+      const queue = getKaiPodGroupQueue(resource)
+      return <span className="text-sm text-theme-text-secondary">{queue}</span>
+    }
+    case 'minMember': {
+      const minMember = getKaiPodGroupMinMember(resource)
+      return <span className="text-sm text-theme-text-secondary">{minMember}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}

--- a/packages/k8s-ui/src/components/resources/renderers/kaito-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/kaito-cells.tsx
@@ -1,0 +1,62 @@
+// KAITO cell components for ResourcesView table
+
+import { clsx } from 'clsx'
+import {
+  getKaitoWorkspaceStatus,
+  getKaitoWorkspaceInstanceType,
+  getKaitoWorkspacePreset,
+  getKaitoWorkspaceNodeCount,
+  getRAGEngineStatus,
+  getRAGEngineEmbeddingModel,
+  getRAGEngineInstanceType,
+} from '../resource-utils-kaito'
+
+export function KaitoWorkspaceCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getKaitoWorkspaceStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'instanceType': {
+      const instanceType = getKaitoWorkspaceInstanceType(resource)
+      return <span className="text-sm text-theme-text-secondary">{instanceType}</span>
+    }
+    case 'preset': {
+      const preset = getKaitoWorkspacePreset(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{preset}</span>
+    }
+    case 'nodes': {
+      const nodes = getKaitoWorkspaceNodeCount(resource)
+      return <span className="text-sm text-theme-text-secondary">{nodes}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}
+
+export function RAGEngineCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getRAGEngineStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'embedding': {
+      const model = getRAGEngineEmbeddingModel(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{model}</span>
+    }
+    case 'instanceType': {
+      const instanceType = getRAGEngineInstanceType(resource)
+      return <span className="text-sm text-theme-text-secondary">{instanceType}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}

--- a/packages/k8s-ui/src/components/resources/renderers/kserve-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/kserve-cells.tsx
@@ -1,0 +1,145 @@
+// KServe cell components for ResourcesView table
+
+import { clsx } from 'clsx'
+import {
+  getInferenceServiceStatus,
+  getInferenceServiceUrl,
+  getInferenceServiceModelFormat,
+  getInferenceServiceRuntime,
+  getInferenceServiceDeploymentMode,
+  getServingRuntimeStatus,
+  getServingRuntimeModelFormats,
+  getServingRuntimeImage,
+  getInferenceGraphStatus,
+  getInferenceGraphNodeCount,
+  getTrainedModelStatus,
+  getTrainedModelFramework,
+  getTrainedModelStorageUri,
+  getTrainedModelInferenceService,
+  getLLMInferenceServiceStatus,
+  getLLMInferenceServiceModel,
+  getLLMInferenceServiceReplicas,
+} from '../resource-utils-kserve'
+
+export function InferenceServiceCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getInferenceServiceStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'url': {
+      const url = getInferenceServiceUrl(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{url}</span>
+    }
+    case 'modelFormat': {
+      const format = getInferenceServiceModelFormat(resource)
+      return <span className="text-sm text-theme-text-secondary">{format}</span>
+    }
+    case 'runtime': {
+      const runtime = getInferenceServiceRuntime(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{runtime}</span>
+    }
+    case 'deploymentMode': {
+      const mode = getInferenceServiceDeploymentMode(resource)
+      return <span className="text-sm text-theme-text-secondary">{mode}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}
+
+export function ServingRuntimeCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getServingRuntimeStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'modelFormats': {
+      const formats = getServingRuntimeModelFormats(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{formats}</span>
+    }
+    case 'image': {
+      const image = getServingRuntimeImage(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{image}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}
+
+export function InferenceGraphCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getInferenceGraphStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'nodes': {
+      const count = getInferenceGraphNodeCount(resource)
+      return <span className="text-sm text-theme-text-secondary">{count > 0 ? count : '-'}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}
+
+export function TrainedModelCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getTrainedModelStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'framework': {
+      const framework = getTrainedModelFramework(resource)
+      return <span className="text-sm text-theme-text-secondary">{framework}</span>
+    }
+    case 'storageUri': {
+      const uri = getTrainedModelStorageUri(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{uri}</span>
+    }
+    case 'inferenceService': {
+      const parent = getTrainedModelInferenceService(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{parent}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}
+
+export function LLMInferenceServiceCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getLLMInferenceServiceStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'model': {
+      const model = getLLMInferenceServiceModel(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{model}</span>
+    }
+    case 'replicas': {
+      const replicas = getLLMInferenceServiceReplicas(resource)
+      return <span className="text-sm text-theme-text-secondary">{replicas}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}

--- a/packages/k8s-ui/src/components/resources/renderers/kubeflow-training-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/kubeflow-training-cells.tsx
@@ -1,0 +1,72 @@
+// Kubeflow training cell components for ResourcesView table
+
+import { clsx } from 'clsx'
+import type { StatusBadge } from '../resource-utils'
+import {
+  getPyTorchJobStatus,
+  getTFJobStatus,
+  getMPIJobStatus,
+  getTrainingJobReplicas,
+  getTrainingJobElapsed,
+  getTrainJobStatus,
+  getTrainJobRuntime,
+  getTrainJobSuspended,
+} from '../resource-utils-kubeflow-training'
+
+function TrainingOperatorJobCell({ resource, column, getStatus }: { resource: any; column: string; getStatus: (resource: any) => StatusBadge }) {
+  switch (column) {
+    case 'status': {
+      const status = getStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'replicas': {
+      const replicas = getTrainingJobReplicas(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{replicas}</span>
+    }
+    case 'elapsed': {
+      const elapsed = getTrainingJobElapsed(resource)
+      return <span className="text-sm text-theme-text-secondary">{elapsed}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}
+
+export function PyTorchJobCell({ resource, column }: { resource: any; column: string }) {
+  return <TrainingOperatorJobCell resource={resource} column={column} getStatus={getPyTorchJobStatus} />
+}
+
+export function TFJobCell({ resource, column }: { resource: any; column: string }) {
+  return <TrainingOperatorJobCell resource={resource} column={column} getStatus={getTFJobStatus} />
+}
+
+export function MPIJobCell({ resource, column }: { resource: any; column: string }) {
+  return <TrainingOperatorJobCell resource={resource} column={column} getStatus={getMPIJobStatus} />
+}
+
+export function TrainJobCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getTrainJobStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'runtime': {
+      const runtime = getTrainJobRuntime(resource)
+      return <span className="text-sm text-theme-text-secondary">{runtime}</span>
+    }
+    case 'suspended': {
+      const suspended = getTrainJobSuspended(resource)
+      return <span className="text-sm text-theme-text-secondary">{suspended ? 'Yes' : '-'}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}

--- a/packages/k8s-ui/src/components/resources/renderers/kueue-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/kueue-cells.tsx
@@ -1,0 +1,176 @@
+// Kueue + Cluster Autoscaler ProvisioningRequest cell components for ResourcesView table
+
+import { clsx } from 'clsx'
+import {
+  getClusterQueueStatus,
+  getClusterQueueCohort,
+  getClusterQueuePendingWorkloads,
+  getClusterQueueAdmittedWorkloads,
+  getClusterQueueFlavors,
+  getLocalQueueStatus,
+  getLocalQueueClusterQueue,
+  getLocalQueuePendingWorkloads,
+  getLocalQueueAdmittedWorkloads,
+  getKueueWorkloadStatus,
+  getKueueWorkloadQueueName,
+  getKueueWorkloadAdmittedBy,
+  getKueueWorkloadPriority,
+  getResourceFlavorStatus,
+  getResourceFlavorNodeLabelCount,
+  getResourceFlavorTaintCount,
+  getAdmissionCheckStatus,
+  getAdmissionCheckControllerName,
+  getProvisioningRequestStatus,
+  getProvisioningRequestClassName,
+  getProvisioningRequestPodSetCount,
+} from '../resource-utils-kueue'
+
+export function ClusterQueueCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getClusterQueueStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'cohort': {
+      const cohort = getClusterQueueCohort(resource)
+      return <span className="text-sm text-theme-text-secondary">{cohort}</span>
+    }
+    case 'pendingWorkloads': {
+      const pending = getClusterQueuePendingWorkloads(resource)
+      return <span className="text-sm text-theme-text-secondary">{pending}</span>
+    }
+    case 'admittedWorkloads': {
+      const admitted = getClusterQueueAdmittedWorkloads(resource)
+      return <span className="text-sm text-theme-text-secondary">{admitted}</span>
+    }
+    case 'flavors': {
+      const flavors = getClusterQueueFlavors(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{flavors}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}
+
+export function LocalQueueCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getLocalQueueStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'clusterQueue': {
+      const clusterQueue = getLocalQueueClusterQueue(resource)
+      return <span className="text-sm text-theme-text-secondary">{clusterQueue}</span>
+    }
+    case 'pendingWorkloads': {
+      const pending = getLocalQueuePendingWorkloads(resource)
+      return <span className="text-sm text-theme-text-secondary">{pending}</span>
+    }
+    case 'admittedWorkloads': {
+      const admitted = getLocalQueueAdmittedWorkloads(resource)
+      return <span className="text-sm text-theme-text-secondary">{admitted}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}
+
+export function KueueWorkloadCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getKueueWorkloadStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'queueName': {
+      const queueName = getKueueWorkloadQueueName(resource)
+      return <span className="text-sm text-theme-text-secondary">{queueName}</span>
+    }
+    case 'admittedBy': {
+      const admittedBy = getKueueWorkloadAdmittedBy(resource)
+      return <span className="text-sm text-theme-text-secondary">{admittedBy}</span>
+    }
+    case 'priority': {
+      const priority = getKueueWorkloadPriority(resource)
+      return <span className="text-sm text-theme-text-secondary">{priority}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}
+
+export function ResourceFlavorCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getResourceFlavorStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'nodeLabels': {
+      const count = getResourceFlavorNodeLabelCount(resource)
+      return <span className="text-sm text-theme-text-secondary">{count > 0 ? count : '-'}</span>
+    }
+    case 'taints': {
+      const count = getResourceFlavorTaintCount(resource)
+      return <span className="text-sm text-theme-text-secondary">{count > 0 ? count : '-'}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}
+
+export function AdmissionCheckCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getAdmissionCheckStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'controllerName': {
+      const controllerName = getAdmissionCheckControllerName(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{controllerName}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}
+
+export function ProvisioningRequestCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getProvisioningRequestStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'provisioningClassName': {
+      const className = getProvisioningRequestClassName(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{className}</span>
+    }
+    case 'podSets': {
+      const count = getProvisioningRequestPodSetCount(resource)
+      return <span className="text-sm text-theme-text-secondary">{count > 0 ? count : '-'}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}

--- a/packages/k8s-ui/src/components/resources/renderers/nim-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/nim-cells.tsx
@@ -1,0 +1,81 @@
+// NVIDIA NIM Operator cell components for ResourcesView table
+
+import { clsx } from 'clsx'
+import {
+  getNIMServiceStatus,
+  getNIMServiceModel,
+  getNIMServiceReplicas,
+  getNIMCacheStatus,
+  getNIMCacheSourceType,
+  getNIMCacheModelSource,
+  getNIMCacheStorageSize,
+  getNIMPipelineStatus,
+  getNIMPipelineServiceCount,
+} from '../resource-utils-nim'
+
+export function NIMServiceCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getNIMServiceStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'model': {
+      const model = getNIMServiceModel(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{model}</span>
+    }
+    case 'replicas': {
+      const replicas = getNIMServiceReplicas(resource)
+      return <span className="text-sm text-theme-text-secondary">{replicas}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}
+
+export function NIMCacheCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getNIMCacheStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'source': {
+      const type = getNIMCacheSourceType(resource)
+      const model = getNIMCacheModelSource(resource)
+      const text = type !== '-' && model !== '-' ? `${type}: ${model}` : model
+      return <span className="text-sm text-theme-text-secondary truncate block">{text}</span>
+    }
+    case 'storage': {
+      const size = getNIMCacheStorageSize(resource)
+      return <span className="text-sm text-theme-text-secondary">{size}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}
+
+export function NIMPipelineCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getNIMPipelineStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'services': {
+      const count = getNIMPipelineServiceCount(resource)
+      return <span className="text-sm text-theme-text-secondary">{count}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}

--- a/packages/k8s-ui/src/components/resources/renderers/ray-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ray-cells.tsx
@@ -1,0 +1,124 @@
+// KubeRay cell components for ResourcesView table
+
+import { clsx } from 'clsx'
+import {
+  getRayClusterStatus,
+  getRayClusterVersion,
+  getRayClusterWorkers,
+  getRayClusterHeadService,
+  getRayJobStatus,
+  getRayJobJobStatus,
+  getRayJobDeploymentStatus,
+  getRayJobClusterName,
+  getRayServiceStatus,
+  getRayServiceServiceStatus,
+  getRayServiceClusters,
+  getRayCronJobStatus,
+  getRayCronJobSchedule,
+  getRayCronJobSuspend,
+  getRayCronJobLastSchedule,
+} from '../resource-utils-ray'
+
+export function RayClusterCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getRayClusterStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'rayVersion': {
+      const version = getRayClusterVersion(resource)
+      return <span className="text-sm text-theme-text-secondary">{version}</span>
+    }
+    case 'workers': {
+      const workers = getRayClusterWorkers(resource)
+      return <span className="text-sm text-theme-text-secondary">{workers}</span>
+    }
+    case 'headService': {
+      const svc = getRayClusterHeadService(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{svc}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}
+
+export function RayJobCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getRayJobStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'jobStatus': {
+      const jobStatus = getRayJobJobStatus(resource)
+      return <span className="text-sm text-theme-text-secondary">{jobStatus}</span>
+    }
+    case 'deploymentStatus': {
+      const deploymentStatus = getRayJobDeploymentStatus(resource)
+      return <span className="text-sm text-theme-text-secondary">{deploymentStatus}</span>
+    }
+    case 'cluster': {
+      const cluster = getRayJobClusterName(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{cluster}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}
+
+export function RayServiceCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getRayServiceStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'serviceStatus': {
+      const serviceStatus = getRayServiceServiceStatus(resource)
+      return <span className="text-sm text-theme-text-secondary">{serviceStatus}</span>
+    }
+    case 'clusters': {
+      const clusters = getRayServiceClusters(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{clusters}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}
+
+export function RayCronJobCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getRayCronJobStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'schedule': {
+      const schedule = getRayCronJobSchedule(resource)
+      return <span className="text-sm font-mono text-theme-text-secondary">{schedule}</span>
+    }
+    case 'suspend': {
+      const suspended = getRayCronJobSuspend(resource)
+      return <span className="text-sm text-theme-text-secondary">{suspended ? 'Yes' : 'No'}</span>
+    }
+    case 'lastSchedule': {
+      const lastSchedule = getRayCronJobLastSchedule(resource)
+      return <span className="text-sm text-theme-text-secondary">{lastSchedule}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}

--- a/packages/k8s-ui/src/components/resources/renderers/volcano-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/volcano-cells.tsx
@@ -1,0 +1,140 @@
+// Volcano cell components for ResourcesView table
+
+import { clsx } from 'clsx'
+import {
+  getVolcanoJobStatus,
+  getVolcanoJobQueue,
+  getVolcanoJobMinAvailable,
+  getVolcanoJobPodCounts,
+  getVolcanoQueueStatus,
+  getVolcanoQueueWeight,
+  getVolcanoQueueCapability,
+  getVolcanoQueueAllocated,
+  getVolcanoQueuePodGroupCounts,
+  getVolcanoPodGroupStatus,
+  getVolcanoPodGroupQueue,
+  getVolcanoPodGroupMinMember,
+  getJobFlowStatus,
+  getJobFlowFlowCount,
+  getJobTemplateStatus,
+  getJobTemplateTaskCount,
+} from '../resource-utils-volcano'
+
+export function VolcanoJobCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getVolcanoJobStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'queue': {
+      const queue = getVolcanoJobQueue(resource)
+      return <span className="text-sm text-theme-text-secondary">{queue}</span>
+    }
+    case 'minAvailable': {
+      const minAvailable = getVolcanoJobMinAvailable(resource)
+      return <span className="text-sm text-theme-text-secondary">{minAvailable}</span>
+    }
+    case 'pods': {
+      const counts = getVolcanoJobPodCounts(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{counts}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}
+
+export function VolcanoQueueCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getVolcanoQueueStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'weight': {
+      const weight = getVolcanoQueueWeight(resource)
+      return <span className="text-sm text-theme-text-secondary">{weight}</span>
+    }
+    case 'capability': {
+      const capability = getVolcanoQueueCapability(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{capability}</span>
+    }
+    case 'allocated': {
+      const allocated = getVolcanoQueueAllocated(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{allocated}</span>
+    }
+    case 'podGroups': {
+      const counts = getVolcanoQueuePodGroupCounts(resource)
+      return <span className="text-sm text-theme-text-secondary truncate block">{counts}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}
+
+export function VolcanoPodGroupCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getVolcanoPodGroupStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'queue': {
+      const queue = getVolcanoPodGroupQueue(resource)
+      return <span className="text-sm text-theme-text-secondary">{queue}</span>
+    }
+    case 'minMember': {
+      const minMember = getVolcanoPodGroupMinMember(resource)
+      return <span className="text-sm text-theme-text-secondary">{minMember}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}
+
+export function JobFlowCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getJobFlowStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'flows': {
+      const count = getJobFlowFlowCount(resource)
+      return <span className="text-sm text-theme-text-secondary">{count > 0 ? count : '-'}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}
+
+export function JobTemplateCell({ resource, column }: { resource: any; column: string }) {
+  switch (column) {
+    case 'status': {
+      const status = getJobTemplateStatus(resource)
+      return (
+        <span className={clsx('badge', status.color)}>
+          {status.text}
+        </span>
+      )
+    }
+    case 'tasks': {
+      const count = getJobTemplateTaskCount(resource)
+      return <span className="text-sm text-theme-text-secondary">{count > 0 ? count : '-'}</span>
+    }
+    default:
+      return <span className="text-sm text-theme-text-tertiary">-</span>
+  }
+}

--- a/packages/k8s-ui/src/components/resources/resource-utils-amd-gpu.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-amd-gpu.ts
@@ -1,0 +1,61 @@
+// AMD GPU Operator CRD utility functions
+
+import type { StatusBadge } from './resource-utils'
+import { healthColors } from './resource-utils'
+
+// ============================================================================
+// AMD DEVICECONFIG UTILITIES
+// ============================================================================
+
+export function getAMDDeviceConfigStatus(resource: any): StatusBadge {
+  const status = resource.status
+  if (!status) {
+    return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+  }
+
+  const ready = Array.isArray(status.conditions)
+    ? status.conditions.find((condition: any) => condition?.type === 'Ready')
+    : undefined
+  if (ready?.status === 'False') {
+    return { text: ready.reason || 'NotReady', color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+  if (ready?.status === 'True') {
+    return { text: 'Ready', color: healthColors.healthy, level: 'healthy' }
+  }
+
+  const components = [status.driver, status.devicePlugin, status.metricsExporter, status.configManager]
+    .filter((c: any) => c && (c.desiredNumber ?? 0) > 0)
+
+  if (components.length === 0) {
+    return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+  }
+
+  const allReady = components.every((c: any) => (c.availableNumber ?? 0) >= (c.desiredNumber ?? 0))
+  if (allReady) {
+    return { text: 'Ready', color: healthColors.healthy, level: 'healthy' }
+  }
+  return { text: 'Degraded', color: healthColors.degraded, level: 'degraded' }
+}
+
+export function getAMDDeviceConfigDriver(resource: any): string {
+  const driver = resource.spec?.driver
+  if (!driver) return '-'
+  if (driver.enable === true) {
+    return driver.version ? `Enabled (${driver.version})` : 'Enabled'
+  }
+  if (driver.enable === false) return 'Disabled'
+  return '-'
+}
+
+export function getAMDDeviceConfigDevicePluginImage(resource: any): string {
+  return resource.spec?.devicePlugin?.devicePluginImage || '-'
+}
+
+export function getAMDDeviceConfigNodeCount(resource: any): string {
+  const dp = resource.status?.devicePlugin || resource.status?.driver
+  if (!dp) return '-'
+  const available = dp.availableNumber ?? 0
+  const desired = dp.desiredNumber ?? 0
+  if (desired === 0) return '-'
+  return `${available}/${desired}`
+}

--- a/packages/k8s-ui/src/components/resources/resource-utils-gpu-ecosystem.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-gpu-ecosystem.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getClusterQueueCohort,
+  getKueueWorkloadPriority,
+  getKueueWorkloadStatus,
+} from './resource-utils-kueue'
+import { getRayClusterStatus, getRayJobStatus, getRayServiceStatus } from './resource-utils-ray'
+import {
+  getLLMInferenceServiceReplicas,
+  getServingRuntimeStatus,
+} from './resource-utils-kserve'
+import {
+  getInferenceObjectivePriority,
+  getInferenceObjectiveStatus,
+  getInferencePoolStatus,
+} from './resource-utils-inference-gateway'
+import { getJobSetStatus, getLeaderWorkerSetStatus } from './resource-utils-jobset-lws'
+import { getVolcanoJobStatus, getVolcanoPodGroupStatus } from './resource-utils-volcano'
+import { getKaiPodGroupStatus, getKaiQueuePriority, getKaiQueueQuota, getKaiQueueStatus } from './resource-utils-kai'
+import { getKaitoWorkspaceStatus, getRAGEngineStatus } from './resource-utils-kaito'
+import { getNIMCacheStatus, getNIMServiceReplicas } from './resource-utils-nim'
+import { getAMDDeviceConfigStatus } from './resource-utils-amd-gpu'
+import { getTrainingJobReplicas, getTrainJobStatus, trainingJobStatus } from './resource-utils-kubeflow-training'
+
+describe('GPU ecosystem API contracts', () => {
+  it('reads current Kueue v1beta2 fields and condition precedence', () => {
+    const workload = {
+      spec: { priorityClassRef: { name: 'critical' } },
+      status: { conditions: [
+        { type: 'Admitted', status: 'True' },
+        { type: 'Evicted', status: 'True' },
+      ] },
+    }
+    expect(getClusterQueueCohort({ spec: { cohortName: 'gpu' } })).toBe('gpu')
+    expect(getKueueWorkloadPriority(workload)).toBe('critical')
+    expect(getKueueWorkloadStatus(workload).text).toBe('Evicted')
+  })
+
+  it('lets KubeRay conditions outrank deprecated state fields', () => {
+    expect(getRayClusterStatus({
+      status: {
+        state: 'ready',
+        conditions: [{ type: 'HeadPodReady', status: 'False', reason: 'HeadUnavailable' }],
+      },
+    }).text).toBe('HeadUnavailable')
+    expect(getRayServiceStatus({
+      status: {
+        serviceStatus: 'Running',
+        conditions: [{ type: 'Ready', status: 'False', reason: 'ServeNotReady' }],
+      },
+    }).text).toBe('ServeNotReady')
+    expect(getRayServiceStatus({
+      spec: { suspend: true },
+      status: { conditions: [{ type: 'Suspending', status: 'True' }] },
+    }).text).toBe('Suspending')
+  })
+
+  it('requires both the KubeRay head and workers before reporting Ready', () => {
+    expect(getRayClusterStatus({
+      status: {
+        conditions: [{ type: 'HeadPodReady', status: 'True' }],
+        availableWorkerReplicas: 1,
+        desiredWorkerReplicas: 2,
+      },
+    }).text).toBe('Workers 1/2')
+    expect(getRayClusterStatus({
+      status: {
+        conditions: [{ type: 'HeadPodReady', status: 'True' }],
+        availableWorkerReplicas: 2,
+        desiredWorkerReplicas: 2,
+      },
+    }).text).toBe('Ready')
+  })
+
+  it('surfaces current KubeRay replica and RayJob deployment failures', () => {
+    expect(getRayClusterStatus({
+      status: {
+        conditions: [{ type: 'RayClusterReplicaFailure', status: 'True', reason: 'FailedCreateWorkerPod' }],
+      },
+    }).text).toBe('FailedCreateWorkerPod')
+    expect(getRayJobStatus({
+      status: { jobStatus: 'PENDING', jobDeploymentStatus: 'ValidationFailed' },
+    }).text).toBe('ValidationFailed')
+    expect(getRayJobStatus({
+      status: { jobStatus: 'RUNNING', jobDeploymentStatus: 'Failed' },
+    }).text).toBe('Failed')
+  })
+
+  it('does not claim KServe runtime health from enabled configuration alone', () => {
+    const enabled = getServingRuntimeStatus({ spec: {} })
+    expect(enabled.text).toBe('Enabled')
+    expect(enabled.level).toBe('neutral')
+  })
+
+  it('reads the inline replicas field in both served LLMInferenceService versions', () => {
+    expect(getLLMInferenceServiceReplicas({ spec: { replicas: 3 } })).toBe('3')
+  })
+
+  it('understands current llm-d and deployed InferenceObjective conditions', () => {
+    expect(getInferenceObjectiveStatus({
+      status: { conditions: [{ type: 'Ready', status: 'True' }] },
+    }).text).toBe('Accepted')
+    expect(getInferenceObjectiveStatus({
+      status: { conditions: [{ type: 'Accepted', status: 'False', reason: 'InvalidPool' }] },
+    }).text).toBe('InvalidPool')
+    expect(getInferenceObjectiveStatus({ status: { conditions: [] } }).text).toBe('Unknown')
+    expect(getInferenceObjectivePriority({ spec: {} })).toBe('0')
+  })
+
+  it('does not treat the alpha InferencePool sentinel parent as a Gateway', () => {
+    expect(getInferencePoolStatus({
+      status: { parent: [{ parentRef: { kind: 'Status', name: 'default' } }] },
+    }).text).toBe('Not referenced')
+  })
+
+  it('distinguishes pending JobSets from active work', () => {
+    expect(getJobSetStatus({ status: { replicatedJobsStatus: [{ active: 0, ready: 0 }] } }).text).toBe('Pending')
+    expect(getJobSetStatus({ status: { replicatedJobsStatus: [{ active: 1, ready: 0 }] } }).text).toBe('Running')
+  })
+
+  it('surfaces an unavailable LeaderWorkerSet before progress', () => {
+    expect(getLeaderWorkerSetStatus({
+      status: { conditions: [{ type: 'Available', status: 'False', reason: 'PodsNotReady' }] },
+    }).text).toBe('PodsNotReady')
+  })
+
+  it('classifies Volcano terminal and unschedulable states', () => {
+    expect(getVolcanoJobStatus({ status: { state: { phase: 'Failed' } } }).level).toBe('unhealthy')
+    expect(getVolcanoPodGroupStatus({
+      status: { conditions: [{ type: 'Unschedulable', status: 'True' }] },
+    }).text).toBe('Unschedulable')
+  })
+
+  it('reads KAI quota units and scheduling failures', () => {
+    expect(getKaiQueueQuota({
+      spec: { resources: { gpu: { quota: 2 }, cpu: { quota: 500 }, memory: { quota: -1 } } },
+    })).toBe('GPU: 2, CPU: 500m, Mem: unlimited')
+    expect(getKaiQueuePriority({ spec: {} })).toBe('100')
+    expect(getKaiQueueStatus({
+      status: { conditions: [{ type: 'Orphan', status: 'True', reason: 'ParentNotFound' }] },
+    }).text).toBe('ParentNotFound')
+    expect(getKaiPodGroupStatus({
+      status: { schedulingConditions: [{ type: 'UnschedulableOnNodePool', status: 'True' }] },
+    }).text).toBe('Unschedulable')
+  })
+
+  it('uses KAITO v1beta1 state and RAGEngine conditions', () => {
+    expect(getKaitoWorkspaceStatus({
+      status: { state: 'Failed', conditions: [{ type: 'ResourceReady', status: 'True' }] },
+    }).level).toBe('unhealthy')
+    expect(getKaitoWorkspaceStatus({ status: { state: 'Pending' } }).text).toBe('Pending')
+    expect(getRAGEngineStatus({
+      status: { conditions: [{ type: 'ServiceReady', status: 'False', reason: 'DeploymentUnavailable' }] },
+    }).text).toBe('DeploymentUnavailable')
+    expect(getRAGEngineStatus({
+      status: { conditions: [
+        { type: 'ResourceReady', status: 'True' },
+        { type: 'ServiceReady', status: 'True' },
+      ] },
+    }).text).toBe('Ready')
+  })
+
+  it('reads NIM state and scaling bounds', () => {
+    expect(getNIMCacheStatus({ status: { state: 'Failed' } }).level).toBe('unhealthy')
+    expect(getNIMServiceReplicas({
+      spec: { scale: { enabled: true, hpa: { minReplicas: 1, maxReplicas: 4 } } },
+      status: { availableReplicas: 2 },
+    })).toBe('2 (1-4)')
+  })
+
+  it('lets AMD DeviceConfig readiness conditions outrank rollout counts', () => {
+    expect(getAMDDeviceConfigStatus({
+      status: {
+        conditions: [{ type: 'Ready', status: 'False', reason: 'DriverInstallFailed' }],
+        driver: { desiredNumber: 2, availableNumber: 2 },
+        devicePlugin: { desiredNumber: 2, availableNumber: 2 },
+      },
+    }).text).toBe('DriverInstallFailed')
+  })
+
+  it('uses semantic precedence for Kubeflow conditions instead of array order', () => {
+    expect(trainingJobStatus({
+      status: { conditions: [
+        { type: 'Failed', status: 'True' },
+        { type: 'Running', status: 'True' },
+      ] },
+    }).text).toBe('Failed')
+    expect(getTrainJobStatus({
+      spec: { suspend: true },
+      status: { conditions: [] },
+    }).text).toBe('Suspended')
+    expect(getTrainJobStatus({
+      status: { conditions: [{ type: 'Suspended', status: 'False' }] },
+    }).text).toBe('Pending')
+    expect(getTrainJobStatus({
+      status: { jobsStatus: [{ name: 'trainer', active: 1 }] },
+    }).text).toBe('Running')
+    expect(getTrainJobStatus({
+      status: { conditions: [{ type: 'Failed', status: 'True' }] },
+    }).text).toBe('Failed')
+    expect(getTrainJobStatus({
+      status: {
+        conditions: [{ type: 'Complete', status: 'True' }],
+        jobsStatus: [{ name: 'trainer', active: 1 }],
+      },
+    }).text).toBe('Complete')
+    expect(getTrainingJobReplicas({
+      spec: { pytorchReplicaSpecs: { Worker: { replicas: 4 } } },
+      status: { replicaStatuses: { Worker: { active: 1, succeeded: 1, failed: 2 } } },
+    })).toBe('Worker 2/4 (2 failed)')
+  })
+})

--- a/packages/k8s-ui/src/components/resources/resource-utils-gpu-ecosystem.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-gpu-ecosystem.test.ts
@@ -6,6 +6,7 @@ import {
 } from './resource-utils-kueue'
 import { getRayClusterStatus, getRayJobStatus, getRayServiceStatus } from './resource-utils-ray'
 import {
+  getInferenceServiceStatus,
   getLLMInferenceServiceReplicas,
   getServingRuntimeStatus,
 } from './resource-utils-kserve'
@@ -90,6 +91,15 @@ describe('GPU ecosystem API contracts', () => {
     const enabled = getServingRuntimeStatus({ spec: {} })
     expect(enabled.text).toBe('Enabled')
     expect(enabled.level).toBe('neutral')
+  })
+
+  it('presents KServe transition failures as operator-readable status', () => {
+    expect(getInferenceServiceStatus({
+      status: { modelStatus: { transitionStatus: 'BlockedByFailedLoad' } },
+    }).text).toBe('Load failed')
+    expect(getInferenceServiceStatus({
+      status: { modelStatus: { transitionStatus: 'InvalidSpec' } },
+    }).text).toBe('Invalid spec')
   })
 
   it('reads the inline replicas field in both served LLMInferenceService versions', () => {

--- a/packages/k8s-ui/src/components/resources/resource-utils-inference-gateway.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-inference-gateway.ts
@@ -1,0 +1,119 @@
+// Gateway API Inference Extension CRD utility functions.
+// InferencePool exists in two shapes: v1 (inference.networking.k8s.io) and
+// v1alpha2 (inference.networking.x-k8s.io); accessors handle both.
+
+import type { StatusBadge } from './resource-utils'
+import { healthColors } from './resource-utils'
+
+// ============================================================================
+// INFERENCEPOOL UTILITIES
+// ============================================================================
+
+// v1 serializes status.parents, v1alpha2 serializes status.parent
+function getPoolParents(resource: any): any[] {
+  const status = resource.status
+  if (!status) return []
+  if (Array.isArray(status.parents)) return status.parents
+  if (Array.isArray(status.parent)) return status.parent
+  return []
+}
+
+// v1alpha2 reserves a synthetic parent entry to mean "no gateway references
+// this pool" — seen as parentRef {kind: Status, name: default} or as an
+// empty/missing parentRef. A ref without a name can't be a real Gateway.
+function isDefaultParent(parent: any): boolean {
+  const ref = parent?.parentRef
+  if (!ref?.name) return true
+  return ref.kind === 'Status' && ref.name === 'default'
+}
+
+export function getInferencePoolStatus(resource: any): StatusBadge {
+  const parents = getPoolParents(resource).filter((p: any) => !isDefaultParent(p))
+  if (parents.length === 0) {
+    return { text: 'Not referenced', color: healthColors.neutral, level: 'neutral' }
+  }
+
+  const conditions = parents.flatMap((p: any) => (Array.isArray(p?.conditions) ? p.conditions : []))
+  if (conditions.length === 0) {
+    return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+  }
+
+  const resolvedRefsFailed = conditions.find((c: any) => c?.type === 'ResolvedRefs' && c.status === 'False')
+  if (resolvedRefsFailed) {
+    return { text: resolvedRefsFailed.reason || 'RefsNotResolved', color: healthColors.alert, level: 'alert' }
+  }
+
+  const accepted = conditions.filter((c: any) => c?.type === 'Accepted')
+  const acceptedTrue = accepted.filter((c: any) => c.status === 'True')
+  if (accepted.length > 0 && acceptedTrue.length === accepted.length) {
+    return { text: 'Accepted', color: healthColors.healthy, level: 'healthy' }
+  }
+  if (acceptedTrue.length > 0) {
+    return { text: 'Partially accepted', color: healthColors.degraded, level: 'degraded' }
+  }
+  const notAccepted = accepted.find((c: any) => c.status === 'False')
+  if (notAccepted) {
+    return { text: notAccepted.reason || 'NotAccepted', color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+
+  return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+}
+
+export function getInferencePoolSelector(resource: any): string {
+  const selector = resource.spec?.selector
+  if (!selector || typeof selector !== 'object') return '-'
+  const labels = selector.matchLabels && typeof selector.matchLabels === 'object' ? selector.matchLabels : selector
+  const entries = Object.entries(labels).filter(([, v]) => typeof v === 'string' || typeof v === 'number')
+  if (entries.length === 0) return '-'
+  const parts = entries.map(([k, v]) => `${k}=${v}`)
+  if (parts.length > 2) return `${parts.slice(0, 2).join(', ')} +${parts.length - 2}`
+  return parts.join(', ')
+}
+
+export function getInferencePoolTargetPorts(resource: any): string {
+  const spec = resource.spec
+  if (!spec) return '-'
+  if (Array.isArray(spec.targetPorts)) {
+    const numbers = spec.targetPorts
+      .map((p: any) => p?.number)
+      .filter((n: any) => n !== undefined && n !== null)
+    return numbers.length > 0 ? numbers.join(', ') : '-'
+  }
+  if (spec.targetPortNumber !== undefined && spec.targetPortNumber !== null) {
+    return String(spec.targetPortNumber)
+  }
+  return '-'
+}
+
+export function getInferencePoolExtensionRef(resource: any): string {
+  const ref = resource.spec?.endpointPickerRef || resource.spec?.extensionRef
+  return ref?.name || '-'
+}
+
+// ============================================================================
+// INFERENCEOBJECTIVE UTILITIES
+// ============================================================================
+
+export function getInferenceObjectiveStatus(resource: any): StatusBadge {
+  const conditions = Array.isArray(resource.status?.conditions) ? resource.status.conditions : []
+  const accepted = conditions.find((c: any) => c?.type === 'Accepted')
+    || conditions.find((c: any) => c?.type === 'Ready')
+  if (accepted?.status === 'True') {
+    return { text: 'Accepted', color: healthColors.healthy, level: 'healthy' }
+  }
+  if (accepted?.status === 'False') {
+    return { text: accepted.reason || 'NotAccepted', color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+  return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+}
+
+export function getInferenceObjectivePoolRef(resource: any): string {
+  return resource.spec?.poolRef?.name || '-'
+}
+
+// API spec: consumers treat an unset priority as 0
+export function getInferenceObjectivePriority(resource: any): string {
+  const priority = resource.spec?.priority
+  if (priority === undefined || priority === null) return '0'
+  return String(priority)
+}

--- a/packages/k8s-ui/src/components/resources/resource-utils-jobset-lws.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-jobset-lws.ts
@@ -1,0 +1,117 @@
+// LeaderWorkerSet (leaderworkerset.x-k8s.io/v1) and JobSet (jobset.x-k8s.io/v1alpha2) utility functions
+
+import type { StatusBadge } from './resource-utils'
+import { healthColors } from './resource-utils'
+
+// ============================================================================
+// LEADERWORKERSET UTILITIES
+// ============================================================================
+
+export function getLeaderWorkerSetStatus(resource: any): StatusBadge {
+  const conditions = resource.status?.conditions || []
+
+  const availableCond = conditions.find((c: any) => c.type === 'Available')
+  if (availableCond?.status === 'True') {
+    return { text: 'Available', color: healthColors.healthy, level: 'healthy' }
+  }
+
+  const updateCond = conditions.find((c: any) => c.type === 'UpdateInProgress')
+  if (updateCond?.status === 'True') {
+    return { text: 'Updating', color: healthColors.degraded, level: 'degraded' }
+  }
+
+  const progressingCond = conditions.find((c: any) => c.type === 'Progressing')
+  if (progressingCond?.status === 'True') {
+    return { text: 'Progressing', color: healthColors.degraded, level: 'degraded' }
+  }
+
+  if (availableCond?.status === 'False') {
+    return { text: availableCond.reason || 'Unavailable', color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+
+  return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+}
+
+export function getLeaderWorkerSetReplicas(resource: any): string {
+  const replicas = resource.spec?.replicas
+  return replicas !== undefined && replicas !== null ? String(replicas) : '1'
+}
+
+export function getLeaderWorkerSetSize(resource: any): string {
+  const size = resource.spec?.leaderWorkerTemplate?.size
+  return size !== undefined && size !== null ? String(size) : '1'
+}
+
+export function getLeaderWorkerSetReady(resource: any): string {
+  const ready = resource.status?.readyReplicas ?? 0
+  const desired = resource.spec?.replicas ?? 1
+  return `${ready}/${desired}`
+}
+
+export function getLeaderWorkerSetUpdated(resource: any): string {
+  const updated = resource.status?.updatedReplicas
+  return updated !== undefined && updated !== null ? String(updated) : '0'
+}
+
+// ============================================================================
+// JOBSET UTILITIES
+// ============================================================================
+
+export function getJobSetStatus(resource: any): StatusBadge {
+  const conditions = resource.status?.conditions || []
+
+  const failedCond = conditions.find((c: any) => c.type === 'Failed')
+  if (failedCond?.status === 'True') {
+    return { text: failedCond.reason || 'Failed', color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+
+  const completedCond = conditions.find((c: any) => c.type === 'Completed')
+  if (completedCond?.status === 'True') {
+    return { text: 'Completed', color: healthColors.neutral, level: 'neutral' }
+  }
+
+  const suspendedCond = conditions.find((c: any) => c.type === 'Suspended')
+  if (suspendedCond?.status === 'True' || resource.spec?.suspend === true) {
+    return { text: 'Suspended', color: healthColors.neutral, level: 'neutral' }
+  }
+
+  // Running only when child jobs are actually live — a fresh JobSet carries a
+  // minimal status (no conditions, zeroed counts) before reconciliation.
+  const live = sumReplicatedJobsField(resource, 'active') + sumReplicatedJobsField(resource, 'ready')
+  if (live > 0) {
+    return { text: 'Running', color: healthColors.healthy, level: 'healthy' }
+  }
+  if (resource.status) {
+    return { text: 'Pending', color: healthColors.neutral, level: 'neutral' }
+  }
+
+  return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+}
+
+export function getJobSetReplicatedJobs(resource: any): string {
+  const jobs = resource.spec?.replicatedJobs
+  if (!Array.isArray(jobs) || jobs.length === 0) return '-'
+  return String(jobs.length)
+}
+
+function sumReplicatedJobsField(resource: any, field: string): number {
+  const statuses = resource.status?.replicatedJobsStatus
+  if (!Array.isArray(statuses)) return 0
+  return statuses.reduce((sum: number, s: any) => sum + (s?.[field] ?? 0), 0)
+}
+
+export function getJobSetReadyJobs(resource: any): number {
+  return sumReplicatedJobsField(resource, 'ready')
+}
+
+export function getJobSetSucceededJobs(resource: any): number {
+  return sumReplicatedJobsField(resource, 'succeeded')
+}
+
+export function getJobSetFailedJobs(resource: any): number {
+  return sumReplicatedJobsField(resource, 'failed')
+}
+
+export function getJobSetRestarts(resource: any): number {
+  return resource.status?.restarts ?? 0
+}

--- a/packages/k8s-ui/src/components/resources/resource-utils-kai.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-kai.ts
@@ -1,0 +1,105 @@
+// KAI Scheduler CRD utility functions
+
+import type { StatusBadge } from './resource-utils'
+import { healthColors } from './resource-utils'
+
+// ============================================================================
+// SHARED HELPERS
+// ============================================================================
+
+function summarizeResourceList(list: any): string {
+  if (!list || typeof list !== 'object') return '-'
+  const parts: string[] = []
+  if (list.cpu !== undefined) parts.push(`CPU: ${list.cpu}`)
+  if (list.memory !== undefined) parts.push(`Mem: ${list.memory}`)
+  if (list['nvidia.com/gpu'] !== undefined) parts.push(`GPU: ${list['nvidia.com/gpu']}`)
+  const rest = Object.keys(list).filter((k) => k !== 'cpu' && k !== 'memory' && k !== 'nvidia.com/gpu')
+  if (rest.length > 0) parts.push(`+${rest.length} more`)
+  return parts.length > 0 ? parts.join(', ') : '-'
+}
+
+// KAI quota units: GPU in fractions, CPU in millicpus, memory in megabytes; -1 means unlimited
+function formatKaiQuota(value: any, unit: string): string {
+  if (typeof value !== 'number') return '-'
+  if (value === -1) return 'unlimited'
+  return `${value}${unit}`
+}
+
+// ============================================================================
+// KAI QUEUE UTILITIES (scheduling.run.ai/v2, cluster-scoped)
+// ============================================================================
+
+export function getKaiQueueStatus(resource: any): StatusBadge {
+  const conditions = resource.status?.conditions || []
+  const orphan = conditions.find((condition: any) => condition?.type === 'Orphan' && condition?.status === 'True')
+  if (orphan) {
+    return { text: orphan.reason || 'Orphan', color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+  const overQuota = conditions.find((condition: any) => condition?.type === 'OverQuota' && condition?.status === 'True')
+  if (overQuota) {
+    return { text: overQuota.reason || 'Over quota', color: healthColors.degraded, level: 'degraded' }
+  }
+  return { text: 'Configured', color: healthColors.neutral, level: 'neutral' }
+}
+
+export function getKaiQueueParent(resource: any): string {
+  return resource.spec?.parentQueue || '-'
+}
+
+export function getKaiQueuePriority(resource: any): string {
+  const priority = resource.spec?.priority
+  return priority !== undefined && priority !== null ? String(priority) : '100'
+}
+
+export function getKaiQueueQuota(resource: any): string {
+  const resources = resource.spec?.resources
+  if (!resources) return '-'
+  const parts: string[] = []
+  if (typeof resources.gpu?.quota === 'number') parts.push(`GPU: ${formatKaiQuota(resources.gpu.quota, '')}`)
+  if (typeof resources.cpu?.quota === 'number') parts.push(`CPU: ${formatKaiQuota(resources.cpu.quota, 'm')}`)
+  if (typeof resources.memory?.quota === 'number') parts.push(`Mem: ${formatKaiQuota(resources.memory.quota, 'MB')}`)
+  return parts.length > 0 ? parts.join(', ') : '-'
+}
+
+export function getKaiQueueAllocated(resource: any): string {
+  return summarizeResourceList(resource.status?.allocated)
+}
+
+// ============================================================================
+// KAI PODGROUP UTILITIES (scheduling.run.ai/v2alpha2)
+// ============================================================================
+
+export function getKaiPodGroupStatus(resource: any): StatusBadge {
+  const phase = resource.status?.phase
+  if (phase === 'Running') {
+    return { text: 'Running', color: healthColors.healthy, level: 'healthy' }
+  }
+  const conditions = resource.status?.conditions || []
+  const schedulingConditions = resource.status?.schedulingConditions || []
+  const unschedulable =
+    conditions.some((c: any) => c.type === 'Unschedulable' && c.status === 'True') ||
+    schedulingConditions.some((c: any) => c.type === 'UnschedulableOnNodePool' && c.status === 'True')
+  if (unschedulable) {
+    return { text: 'Unschedulable', color: healthColors.alert, level: 'alert' }
+  }
+  if (phase === 'Pending' || phase === 'Inqueue' || phase === 'Completed' || phase === 'Succeeded') {
+    return { text: phase, color: healthColors.neutral, level: 'neutral' }
+  }
+  if (phase === 'Failed') {
+    return { text: 'Failed', color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+  // OSS KAI components never write status.phase (Run:ai platform does); fall back to pod counts
+  if (!phase && (resource.status?.running || 0) > 0) {
+    return { text: 'Running', color: healthColors.healthy, level: 'healthy' }
+  }
+  return { text: phase || 'Unknown', color: healthColors.unknown, level: 'unknown' }
+}
+
+export function getKaiPodGroupQueue(resource: any): string {
+  return resource.spec?.queue || '-'
+}
+
+export function getKaiPodGroupMinMember(resource: any): string {
+  const min = resource.spec?.minMember
+  return min !== undefined && min !== null ? String(min) : '-'
+}

--- a/packages/k8s-ui/src/components/resources/resource-utils-kaito.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-kaito.ts
@@ -1,0 +1,114 @@
+// KAITO CRD utility functions
+
+import type { StatusBadge } from './resource-utils'
+import { healthColors } from './resource-utils'
+
+// ============================================================================
+// KAITO WORKSPACE UTILITIES
+// ============================================================================
+
+// Workspace has top-level resource/inference/tuning fields, not under spec
+export function getKaitoWorkspaceStatus(resource: any): StatusBadge {
+  const state = resource.status?.state
+  if (state === 'Failed') {
+    return { text: 'Failed', color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+  if (state === 'NotReady') {
+    return { text: 'NotReady', color: healthColors.degraded, level: 'degraded' }
+  }
+  if (state === 'Ready' || state === 'Running') {
+    return { text: state, color: healthColors.healthy, level: 'healthy' }
+  }
+  if (state === 'Succeeded') {
+    return { text: 'Succeeded', color: healthColors.neutral, level: 'neutral' }
+  }
+  if (state === 'Pending') {
+    return { text: 'Pending', color: healthColors.neutral, level: 'neutral' }
+  }
+
+  const conditions = resource.status?.conditions || []
+  if (conditions.length === 0) {
+    return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+  }
+
+  const find = (type: string) => conditions.find((c: any) => c.type === type)
+  const succeeded = find('WorkspaceSucceeded')
+  const resourceReady = find('ResourceReady')
+  const inferenceReady = find('InferenceReady')
+  const jobStarted = find('JobStarted')
+
+  if (succeeded?.status === 'True') {
+    return { text: 'Succeeded', color: healthColors.neutral, level: 'neutral' }
+  }
+  if (resourceReady?.status === 'False') {
+    return { text: resourceReady.reason || 'ResourcesNotReady', color: healthColors.alert, level: 'alert' }
+  }
+  if (inferenceReady?.status === 'False') {
+    return { text: inferenceReady.reason || 'InferenceNotReady', color: healthColors.degraded, level: 'degraded' }
+  }
+  if (succeeded?.status === 'False') {
+    return { text: succeeded.reason || 'NotReady', color: healthColors.degraded, level: 'degraded' }
+  }
+  if (resourceReady?.status === 'True' || inferenceReady?.status === 'True' || jobStarted?.status === 'True') {
+    return { text: 'Progressing', color: healthColors.degraded, level: 'degraded' }
+  }
+
+  return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+}
+
+export function getKaitoWorkspaceInstanceType(resource: any): string {
+  return resource.resource?.instanceType || '-'
+}
+
+export function getKaitoWorkspacePreset(resource: any): string {
+  return resource.inference?.preset?.name || resource.tuning?.preset?.name || '-'
+}
+
+export function getKaitoWorkspaceNodeCount(resource: any): string {
+  const actual = (resource.status?.workerNodes || []).length
+  const desired = resource.status?.targetNodeCount ?? resource.resource?.count
+  if (desired !== undefined && desired !== null) return `${actual}/${desired}`
+  return `${actual}`
+}
+
+// ============================================================================
+// KAITO RAGENGINE UTILITIES
+// ============================================================================
+
+export function getRAGEngineStatus(resource: any): StatusBadge {
+  const conditions = resource.status?.conditions || []
+  if (conditions.length === 0) {
+    return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+  }
+
+  const find = (type: string) => conditions.find((c: any) => c.type === type)
+  const resourceReady = find('ResourceReady')
+  const serviceReady = find('ServiceReady')
+
+  if (resourceReady?.status === 'False') {
+    return { text: resourceReady.reason || 'ResourcesNotReady', color: healthColors.alert, level: 'alert' }
+  }
+  if (serviceReady?.status === 'False') {
+    return { text: serviceReady.reason || 'ServiceNotReady', color: healthColors.degraded, level: 'degraded' }
+  }
+  if (resourceReady?.status === 'True' && serviceReady?.status === 'True') {
+    return { text: 'Ready', color: healthColors.healthy, level: 'healthy' }
+  }
+  if (resourceReady?.status === 'True' || serviceReady?.status === 'True') {
+    return { text: 'Progressing', color: healthColors.degraded, level: 'degraded' }
+  }
+
+  return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+}
+
+export function getRAGEngineEmbeddingModel(resource: any): string {
+  const embedding = resource.spec?.embedding
+  if (!embedding) return '-'
+  if (embedding.local) return embedding.local.modelID || embedding.local.image || '-'
+  if (embedding.remote) return embedding.remote.url || 'remote'
+  return '-'
+}
+
+export function getRAGEngineInstanceType(resource: any): string {
+  return resource.spec?.compute?.instanceType || '-'
+}

--- a/packages/k8s-ui/src/components/resources/resource-utils-kserve.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-kserve.ts
@@ -1,0 +1,183 @@
+// KServe CRD utility functions
+
+import type { StatusBadge } from './resource-utils'
+import { healthColors } from './resource-utils'
+
+// ============================================================================
+// SHARED HELPERS
+// ============================================================================
+
+function findCondition(resource: any, type: string): any {
+  const conditions = resource.status?.conditions
+  if (!Array.isArray(conditions)) return undefined
+  return conditions.find((c: any) => c?.type === type)
+}
+
+function truncateMiddle(value: string, max = 44): string {
+  if (value.length <= max) return value
+  const keep = Math.floor((max - 1) / 2)
+  return `${value.slice(0, keep)}…${value.slice(-keep)}`
+}
+
+// ============================================================================
+// KSERVE INFERENCESERVICE UTILITIES
+// ============================================================================
+
+export function getInferenceServiceStatus(resource: any): StatusBadge {
+  const transition = resource.status?.modelStatus?.transitionStatus
+  if (transition === 'BlockedByFailedLoad' || transition === 'InvalidSpec') {
+    return { text: transition, color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+
+  const readyCond = findCondition(resource, 'Ready')
+  if (readyCond?.status === 'True') {
+    return { text: 'Ready', color: healthColors.healthy, level: 'healthy' }
+  }
+  if (readyCond) {
+    return { text: readyCond.reason || 'NotReady', color: healthColors.degraded, level: 'degraded' }
+  }
+
+  return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+}
+
+export function getInferenceServiceUrl(resource: any): string {
+  const url = resource.status?.url
+  return typeof url === 'string' && url ? url : '-'
+}
+
+export function getInferenceServiceModelFormat(resource: any): string {
+  return resource.spec?.predictor?.model?.modelFormat?.name || '-'
+}
+
+export function getInferenceServiceRuntime(resource: any): string {
+  return resource.spec?.predictor?.model?.runtime || '-'
+}
+
+export function getInferenceServiceDeploymentMode(resource: any): string {
+  const annotations = resource.metadata?.annotations || {}
+  return annotations['serving.kserve.io/deploymentMode'] || resource.status?.deploymentMode || '-'
+}
+
+// ============================================================================
+// KSERVE SERVINGRUNTIME / CLUSTERSERVINGRUNTIME UTILITIES
+// ============================================================================
+
+export function getServingRuntimeStatus(resource: any): StatusBadge {
+  if (resource.spec?.disabled === true) {
+    return { text: 'Disabled', color: healthColors.neutral, level: 'neutral' }
+  }
+  return { text: 'Enabled', color: healthColors.neutral, level: 'neutral' }
+}
+
+export function getServingRuntimeModelFormats(resource: any): string {
+  const formats = resource.spec?.supportedModelFormats
+  if (!Array.isArray(formats) || formats.length === 0) return '-'
+  const names = [...new Set(formats.map((f: any) => f?.name).filter(Boolean))] as string[]
+  if (names.length === 0) return '-'
+  if (names.length > 3) return `${names.slice(0, 3).join(', ')} +${names.length - 3}`
+  return names.join(', ')
+}
+
+export function getServingRuntimeImage(resource: any): string {
+  const containers = resource.spec?.containers
+  if (!Array.isArray(containers) || containers.length === 0) return '-'
+  return containers[0]?.image || '-'
+}
+
+// ============================================================================
+// KSERVE INFERENCEGRAPH UTILITIES
+// ============================================================================
+
+export function getInferenceGraphStatus(resource: any): StatusBadge {
+  const readyCond = findCondition(resource, 'Ready')
+  if (readyCond?.status === 'True') {
+    return { text: 'Ready', color: healthColors.healthy, level: 'healthy' }
+  }
+  if (readyCond?.status === 'False') {
+    return { text: readyCond.reason || 'NotReady', color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+  return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+}
+
+export function getInferenceGraphNodeCount(resource: any): number {
+  const nodes = resource.spec?.nodes
+  if (!nodes || typeof nodes !== 'object' || Array.isArray(nodes)) return 0
+  return Object.keys(nodes).length
+}
+
+// ============================================================================
+// KSERVE TRAINEDMODEL UTILITIES
+// ============================================================================
+
+export function getTrainedModelStatus(resource: any): StatusBadge {
+  const readyCond = findCondition(resource, 'Ready')
+  if (readyCond?.status === 'True') {
+    return { text: 'Ready', color: healthColors.healthy, level: 'healthy' }
+  }
+  if (readyCond?.status === 'False') {
+    return { text: readyCond.reason || 'NotReady', color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+  return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+}
+
+export function getTrainedModelFramework(resource: any): string {
+  return resource.spec?.model?.framework || '-'
+}
+
+export function getTrainedModelStorageUri(resource: any): string {
+  const uri = resource.spec?.model?.storageUri
+  if (typeof uri !== 'string' || !uri) return '-'
+  return truncateMiddle(uri)
+}
+
+export function getTrainedModelInferenceService(resource: any): string {
+  return resource.spec?.inferenceService || '-'
+}
+
+// ============================================================================
+// KSERVE LLMINFERENCESERVICE UTILITIES
+// ============================================================================
+
+export function getLLMInferenceServiceStatus(resource: any): StatusBadge {
+  const conditions = Array.isArray(resource.status?.conditions) ? resource.status.conditions : []
+
+  const readyCond = conditions.find((c: any) => c?.type === 'Ready')
+  if (readyCond?.status === 'True') {
+    return { text: 'Ready', color: healthColors.healthy, level: 'healthy' }
+  }
+  if (readyCond?.status === 'False') {
+    return { text: readyCond.reason || 'NotReady', color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+
+  if (conditions.length > 0) {
+    const failing = conditions.find((c: any) => c?.status === 'False')
+    if (failing) {
+      return { text: failing.reason || failing.type || 'NotReady', color: healthColors.degraded, level: 'degraded' }
+    }
+    if (conditions.every((c: any) => c?.status === 'True')) {
+      return { text: 'Ready', color: healthColors.healthy, level: 'healthy' }
+    }
+  }
+
+  return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+}
+
+export function getLLMInferenceServiceModel(resource: any): string {
+  const model = resource.spec?.model
+  if (!model || typeof model !== 'object') return '-'
+  if (model.name) return model.name
+  if (typeof model.uri === 'string' && model.uri) return truncateMiddle(model.uri)
+  return '-'
+}
+
+export function getLLMInferenceServiceModelUri(resource: any): string {
+  const uri = resource.spec?.model?.uri
+  if (typeof uri !== 'string' || !uri) return '-'
+  return truncateMiddle(uri)
+}
+
+export function getLLMInferenceServiceReplicas(resource: any): string {
+  const replicas = resource.spec?.replicas
+  if (replicas === undefined || replicas === null) return '-'
+  return String(replicas)
+}

--- a/packages/k8s-ui/src/components/resources/resource-utils-kserve.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-kserve.ts
@@ -25,8 +25,11 @@ function truncateMiddle(value: string, max = 44): string {
 
 export function getInferenceServiceStatus(resource: any): StatusBadge {
   const transition = resource.status?.modelStatus?.transitionStatus
-  if (transition === 'BlockedByFailedLoad' || transition === 'InvalidSpec') {
-    return { text: transition, color: healthColors.unhealthy, level: 'unhealthy' }
+  if (transition === 'BlockedByFailedLoad') {
+    return { text: 'Load failed', color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+  if (transition === 'InvalidSpec') {
+    return { text: 'Invalid spec', color: healthColors.unhealthy, level: 'unhealthy' }
   }
 
   const readyCond = findCondition(resource, 'Ready')

--- a/packages/k8s-ui/src/components/resources/resource-utils-kubeflow-training.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-kubeflow-training.ts
@@ -1,0 +1,121 @@
+// Kubeflow training CRD utility functions
+// Covers training-operator v1 (PyTorchJob/TFJob/MPIJob at kubeflow.org/v1),
+// mpi-operator (MPIJob at kubeflow.org/v2beta1), and Trainer v2 (TrainJob at trainer.kubeflow.org/v1alpha1)
+
+import type { StatusBadge } from './resource-utils'
+import { healthColors, formatDuration } from './resource-utils'
+
+// ============================================================================
+// SHARED HELPERS (kubeflow.org JobCondition pattern)
+// ============================================================================
+
+const REPLICA_SPEC_KEYS = ['pytorchReplicaSpecs', 'tfReplicaSpecs', 'mpiReplicaSpecs']
+
+function getReplicaSpecs(resource: any): Record<string, any> {
+  const spec = resource.spec || {}
+  for (const key of REPLICA_SPEC_KEYS) {
+    if (spec[key]) return spec[key]
+  }
+  return {}
+}
+
+export function trainingJobStatus(resource: any): StatusBadge {
+  const conditions = resource.status?.conditions || []
+  const isTrue = (type: string) => conditions.some((condition: any) => condition?.type === type && condition?.status === 'True')
+  if (isTrue('Failed')) {
+    return { text: 'Failed', color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+  if (isTrue('Succeeded')) {
+    return { text: 'Succeeded', color: healthColors.neutral, level: 'neutral' }
+  }
+  if (isTrue('Suspended')) {
+    return { text: 'Suspended', color: healthColors.degraded, level: 'degraded' }
+  }
+  if (isTrue('Restarting')) {
+    return { text: 'Restarting', color: healthColors.degraded, level: 'degraded' }
+  }
+  if (isTrue('Running')) {
+    return { text: 'Running', color: healthColors.healthy, level: 'healthy' }
+  }
+  return { text: 'Pending', color: healthColors.neutral, level: 'neutral' }
+}
+
+export function getTrainingJobReplicas(resource: any): string {
+  const specs = getReplicaSpecs(resource)
+  const statuses = resource.status?.replicaStatuses || {}
+  const types = Object.keys(specs)
+  for (const type of Object.keys(statuses)) {
+    if (!types.includes(type)) types.push(type)
+  }
+  if (types.length === 0) return '-'
+  return types
+    .map((type) => {
+      const status = statuses[type] || {}
+      const progress = (status.active ?? 0) + (status.succeeded ?? 0)
+      const failed = status.failed ?? 0
+      const desired = specs[type]?.replicas
+      // Unset spec replicas are defaulted in-controller (and the default
+      // differs per operator and replica type), so omit the denominator
+      // rather than guess
+      const count = desired == null ? `${type} ${progress}` : `${type} ${progress}/${desired}`
+      return failed > 0 ? `${count} (${failed} failed)` : count
+    })
+    .join(', ')
+}
+
+export function getTrainingJobElapsed(resource: any): string {
+  const startTime = resource.status?.startTime
+  if (!startTime) return '-'
+  const start = new Date(startTime)
+  const completionTime = resource.status?.completionTime
+  const end = completionTime ? new Date(completionTime) : new Date()
+  return formatDuration(end.getTime() - start.getTime())
+}
+
+// ============================================================================
+// PYTORCHJOB / TFJOB / MPIJOB STATUS
+// ============================================================================
+
+export function getPyTorchJobStatus(resource: any): StatusBadge {
+  return trainingJobStatus(resource)
+}
+
+export function getTFJobStatus(resource: any): StatusBadge {
+  return trainingJobStatus(resource)
+}
+
+export function getMPIJobStatus(resource: any): StatusBadge {
+  return trainingJobStatus(resource)
+}
+
+// ============================================================================
+// TRAINJOB (trainer.kubeflow.org/v1alpha1)
+// ============================================================================
+
+export function getTrainJobStatus(resource: any): StatusBadge {
+  const conditions = resource.status?.conditions || []
+  const isTrue = (type: string) => conditions.some((c: any) => c?.type === type && c?.status === 'True')
+
+  if (isTrue('Failed')) {
+    return { text: 'Failed', color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+  if (isTrue('Complete')) {
+    return { text: 'Complete', color: healthColors.neutral, level: 'neutral' }
+  }
+  if (isTrue('Suspended') || resource.spec?.suspend === true) {
+    return { text: 'Suspended', color: healthColors.degraded, level: 'degraded' }
+  }
+  const jobsStatus = Array.isArray(resource.status?.jobsStatus) ? resource.status.jobsStatus : []
+  if (jobsStatus.some((job: any) => Number(job?.active) > 0)) {
+    return { text: 'Running', color: healthColors.healthy, level: 'healthy' }
+  }
+  return { text: 'Pending', color: healthColors.neutral, level: 'neutral' }
+}
+
+export function getTrainJobRuntime(resource: any): string {
+  return resource.spec?.runtimeRef?.name || '-'
+}
+
+export function getTrainJobSuspended(resource: any): boolean {
+  return resource.spec?.suspend === true
+}

--- a/packages/k8s-ui/src/components/resources/resource-utils-kueue.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-kueue.ts
@@ -1,0 +1,198 @@
+// Kueue + Cluster Autoscaler ProvisioningRequest CRD utility functions
+
+import type { StatusBadge } from './resource-utils'
+import { healthColors } from './resource-utils'
+
+// ============================================================================
+// SHARED HELPERS
+// ============================================================================
+
+function findCondition(resource: any, type: string): any {
+  return (resource?.status?.conditions || []).find((c: any) => c?.type === type)
+}
+
+function activeConditionStatus(resource: any): StatusBadge {
+  const active = findCondition(resource, 'Active')
+  if (active?.status === 'True') {
+    return { text: 'Active', color: healthColors.healthy, level: 'healthy' }
+  }
+  if (active?.status === 'False') {
+    return { text: active.reason || 'Inactive', color: healthColors.alert, level: 'alert' }
+  }
+  return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+}
+
+function formatWorkloadCount(value: any): string {
+  return typeof value === 'number' ? String(value) : '-'
+}
+
+// ============================================================================
+// KUEUE CLUSTERQUEUE UTILITIES
+// ============================================================================
+
+export function getClusterQueueStatus(resource: any): StatusBadge {
+  return activeConditionStatus(resource)
+}
+
+export function getClusterQueueCohort(resource: any): string {
+  // v1beta2 renamed spec.cohort to spec.cohortName
+  return resource?.spec?.cohortName || resource?.spec?.cohort || '-'
+}
+
+export function getClusterQueuePendingWorkloads(resource: any): string {
+  return formatWorkloadCount(resource?.status?.pendingWorkloads)
+}
+
+export function getClusterQueueAdmittedWorkloads(resource: any): string {
+  return formatWorkloadCount(resource?.status?.admittedWorkloads)
+}
+
+export function getClusterQueueFlavors(resource: any): string {
+  const groups = resource?.spec?.resourceGroups || []
+  const flavors = [
+    ...new Set(groups.flatMap((g: any) => (g?.flavors || []).map((f: any) => f?.name).filter(Boolean))),
+  ] as string[]
+  if (flavors.length === 0) return '-'
+  if (flavors.length > 3) return `${flavors.slice(0, 3).join(', ')} +${flavors.length - 3}`
+  return flavors.join(', ')
+}
+
+// ============================================================================
+// KUEUE LOCALQUEUE UTILITIES
+// ============================================================================
+
+export function getLocalQueueStatus(resource: any): StatusBadge {
+  return activeConditionStatus(resource)
+}
+
+export function getLocalQueueClusterQueue(resource: any): string {
+  return resource?.spec?.clusterQueue || '-'
+}
+
+export function getLocalQueuePendingWorkloads(resource: any): string {
+  return formatWorkloadCount(resource?.status?.pendingWorkloads)
+}
+
+export function getLocalQueueAdmittedWorkloads(resource: any): string {
+  return formatWorkloadCount(resource?.status?.admittedWorkloads)
+}
+
+// ============================================================================
+// KUEUE WORKLOAD UTILITIES
+// ============================================================================
+
+export function getKueueWorkloadStatus(resource: any): StatusBadge {
+  const finished = findCondition(resource, 'Finished')
+  if (finished?.status === 'True') {
+    if (finished.reason === 'Failed') {
+      return { text: 'Failed', color: healthColors.unhealthy, level: 'unhealthy' }
+    }
+    return { text: 'Finished', color: healthColors.neutral, level: 'neutral' }
+  }
+
+  const evicted = findCondition(resource, 'Evicted')
+  if (evicted?.status === 'True') {
+    return { text: 'Evicted', color: healthColors.degraded, level: 'degraded' }
+  }
+
+  const preempted = findCondition(resource, 'Preempted')
+  if (preempted?.status === 'True') {
+    return { text: 'Preempted', color: healthColors.degraded, level: 'degraded' }
+  }
+
+  const admitted = findCondition(resource, 'Admitted')
+  if (admitted?.status === 'True') {
+    return { text: 'Admitted', color: healthColors.healthy, level: 'healthy' }
+  }
+
+  const quotaReserved = findCondition(resource, 'QuotaReserved')
+  if (quotaReserved?.status === 'True') {
+    return { text: 'QuotaReserved', color: healthColors.neutral, level: 'neutral' }
+  }
+
+  return { text: 'Pending', color: healthColors.neutral, level: 'neutral' }
+}
+
+export function getKueueWorkloadQueueName(resource: any): string {
+  return resource?.spec?.queueName || '-'
+}
+
+export function getKueueWorkloadAdmittedBy(resource: any): string {
+  return resource?.status?.admission?.clusterQueue || '-'
+}
+
+export function getKueueWorkloadPriority(resource: any): string {
+  const priority = resource?.spec?.priority
+  if (typeof priority === 'number') return String(priority)
+  // v1beta1 uses spec.priorityClassName, v1beta2 uses spec.priorityClassRef
+  return resource?.spec?.priorityClassRef?.name || resource?.spec?.priorityClassName || '-'
+}
+
+// ============================================================================
+// KUEUE RESOURCEFLAVOR UTILITIES
+// ============================================================================
+
+export function getResourceFlavorStatus(_resource: any): StatusBadge {
+  return { text: 'Configured', color: healthColors.neutral, level: 'neutral' }
+}
+
+export function getResourceFlavorNodeLabelCount(resource: any): number {
+  return Object.keys(resource?.spec?.nodeLabels || {}).length
+}
+
+export function getResourceFlavorTaintCount(resource: any): number {
+  return (resource?.spec?.nodeTaints || []).length
+}
+
+// ============================================================================
+// KUEUE ADMISSIONCHECK UTILITIES
+// ============================================================================
+
+export function getAdmissionCheckStatus(resource: any): StatusBadge {
+  return activeConditionStatus(resource)
+}
+
+export function getAdmissionCheckControllerName(resource: any): string {
+  return resource?.spec?.controllerName || '-'
+}
+
+// ============================================================================
+// CLUSTER AUTOSCALER PROVISIONINGREQUEST UTILITIES
+// ============================================================================
+
+export function getProvisioningRequestStatus(resource: any): StatusBadge {
+  const failed = findCondition(resource, 'Failed')
+  if (failed?.status === 'True') {
+    return { text: 'Failed', color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+
+  const capacityRevoked = findCondition(resource, 'CapacityRevoked')
+  if (capacityRevoked?.status === 'True') {
+    return { text: 'CapacityRevoked', color: healthColors.degraded, level: 'degraded' }
+  }
+
+  const bookingExpired = findCondition(resource, 'BookingExpired')
+  if (bookingExpired?.status === 'True') {
+    return { text: 'BookingExpired', color: healthColors.degraded, level: 'degraded' }
+  }
+
+  const provisioned = findCondition(resource, 'Provisioned')
+  if (provisioned?.status === 'True') {
+    return { text: 'Provisioned', color: healthColors.healthy, level: 'healthy' }
+  }
+
+  const accepted = findCondition(resource, 'Accepted')
+  if (accepted?.status === 'True') {
+    return { text: 'Accepted', color: healthColors.neutral, level: 'neutral' }
+  }
+
+  return { text: 'Pending', color: healthColors.neutral, level: 'neutral' }
+}
+
+export function getProvisioningRequestClassName(resource: any): string {
+  return resource?.spec?.provisioningClassName || '-'
+}
+
+export function getProvisioningRequestPodSetCount(resource: any): number {
+  return (resource?.spec?.podSets || []).length
+}

--- a/packages/k8s-ui/src/components/resources/resource-utils-nim.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-nim.ts
@@ -1,0 +1,109 @@
+// NVIDIA NIM Operator CRD utility functions
+
+import type { StatusBadge } from './resource-utils'
+import { healthColors } from './resource-utils'
+
+// ============================================================================
+// SHARED HELPERS
+// ============================================================================
+
+function stateToBadge(state: string | undefined): StatusBadge {
+  switch (state) {
+    case 'Ready':
+      return { text: 'Ready', color: healthColors.healthy, level: 'healthy' }
+    case 'Failed':
+      return { text: 'Failed', color: healthColors.unhealthy, level: 'unhealthy' }
+    case 'NotReady':
+    case 'Pending':
+    case 'InProgress':
+    case 'Started':
+    case 'PVC-Created':
+      return { text: state, color: healthColors.degraded, level: 'degraded' }
+    default:
+      return { text: state || 'Unknown', color: healthColors.unknown, level: 'unknown' }
+  }
+}
+
+// ============================================================================
+// NIMSERVICE UTILITIES
+// ============================================================================
+
+export function getNIMServiceStatus(resource: any): StatusBadge {
+  return stateToBadge(resource.status?.state)
+}
+
+export function getNIMServiceImage(resource: any): string {
+  const image = resource.spec?.image
+  if (!image?.repository) return '-'
+  return image.tag ? `${image.repository}:${image.tag}` : image.repository
+}
+
+export function getNIMServiceModel(resource: any): string {
+  const modelName = resource.status?.model?.name
+  if (modelName) return modelName
+  return getNIMServiceImage(resource)
+}
+
+export function getNIMServiceReplicas(resource: any): string {
+  const available = resource.status?.availableReplicas ?? 0
+  const scale = resource.spec?.scale
+  if (scale?.enabled) {
+    const min = scale.hpa?.minReplicas
+    const max = scale.hpa?.maxReplicas
+    if (min !== undefined && max !== undefined) return `${available} (${min}-${max})`
+    return `${available} (hpa)`
+  }
+  const desired = resource.spec?.replicas
+  if (desired !== undefined && desired !== null) return `${available}/${desired}`
+  return `${available}`
+}
+
+// ============================================================================
+// NIMCACHE UTILITIES
+// ============================================================================
+
+export function getNIMCacheStatus(resource: any): StatusBadge {
+  return stateToBadge(resource.status?.state)
+}
+
+export function getNIMCacheSourceType(resource: any): string {
+  const source = resource.spec?.source
+  if (!source) return '-'
+  if (source.ngc) return 'NGC'
+  if (source.dataStore) return 'DataStore'
+  if (source.hf) return 'HF'
+  return '-'
+}
+
+export function getNIMCacheModelSource(resource: any): string {
+  const source = resource.spec?.source
+  if (!source) return '-'
+  if (source.ngc) return source.ngc.modelPuller || source.ngc.modelEndpoint || '-'
+  const dshf = source.dataStore || source.hf
+  if (dshf) return dshf.modelName || dshf.datasetName || '-'
+  return '-'
+}
+
+export function getNIMCacheStorageSize(resource: any): string {
+  return resource.spec?.storage?.pvc?.size || '-'
+}
+
+export function getNIMCachePVCName(resource: any): string {
+  return resource.status?.pvc || resource.spec?.storage?.pvc?.name || '-'
+}
+
+// ============================================================================
+// NIMPIPELINE UTILITIES
+// ============================================================================
+
+export function getNIMPipelineStatus(resource: any): StatusBadge {
+  return stateToBadge(resource.status?.state)
+}
+
+export function getNIMPipelineServiceCount(resource: any): string {
+  const services = resource.spec?.services || []
+  if (services.length === 0) return '0'
+  const enabled = services.filter((s: any) => s?.enabled !== false).length
+  if (enabled < services.length) return `${enabled}/${services.length} enabled`
+  return `${services.length}`
+}

--- a/packages/k8s-ui/src/components/resources/resource-utils-ray.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-ray.ts
@@ -1,0 +1,214 @@
+// KubeRay CRD utility functions (ray.io/v1)
+
+import type { StatusBadge } from './resource-utils'
+import { healthColors, formatAge } from './resource-utils'
+
+// ============================================================================
+// RAYCLUSTER UTILITIES
+// ============================================================================
+
+export function getRayClusterStatus(resource: any): StatusBadge {
+  const state = resource.status?.state
+  const conditions = resource.status?.conditions || []
+
+  const suspendingCond = conditions.find((c: any) => c.type === 'RayClusterSuspending')
+  if (suspendingCond?.status === 'True') {
+    return { text: 'Suspending', color: healthColors.degraded, level: 'degraded' }
+  }
+
+  const suspendedCond = conditions.find((c: any) => c.type === 'RayClusterSuspended')
+  if (suspendedCond?.status === 'True') {
+    return { text: 'Suspended', color: healthColors.neutral, level: 'neutral' }
+  }
+
+  if (resource.spec?.suspend === true || state === 'suspended') {
+    return { text: 'Suspended', color: healthColors.neutral, level: 'neutral' }
+  }
+
+  const replicaFailureCond = conditions.find((c: any) => c.type === 'RayClusterReplicaFailure')
+  if (replicaFailureCond?.status === 'True') {
+    return { text: replicaFailureCond.reason || 'ReplicaFailure', color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+
+  if (state === 'failed') {
+    return { text: 'Failed', color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+
+  const headReadyCond = conditions.find((c: any) => c.type === 'HeadPodReady')
+  if (headReadyCond?.status === 'False') {
+    return { text: headReadyCond.reason || 'HeadNotReady', color: healthColors.degraded, level: 'degraded' }
+  }
+  if (headReadyCond?.status === 'True') {
+    const availableWorkers = resource.status?.availableWorkerReplicas ?? 0
+    const desiredWorkers = resource.status?.desiredWorkerReplicas ?? 0
+    if (availableWorkers >= desiredWorkers) {
+      return { text: 'Ready', color: healthColors.healthy, level: 'healthy' }
+    }
+    return { text: `Workers ${availableWorkers}/${desiredWorkers}`, color: healthColors.degraded, level: 'degraded' }
+  }
+
+  if (conditions.length === 0 && state === 'ready') {
+    return { text: 'Ready', color: healthColors.healthy, level: 'healthy' }
+  }
+
+  const provisionedCond = conditions.find((c: any) => c.type === 'RayClusterProvisioned')
+  if (provisionedCond?.status === 'True') {
+    return { text: 'Provisioned', color: healthColors.neutral, level: 'neutral' }
+  }
+
+  if (resource.status) {
+    return { text: 'Provisioning', color: healthColors.degraded, level: 'degraded' }
+  }
+
+  return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+}
+
+export function getRayClusterVersion(resource: any): string {
+  return resource.spec?.rayVersion || '-'
+}
+
+export function getRayClusterWorkers(resource: any): string {
+  const status = resource.status
+  if (!status) return '-'
+  const available = status.availableWorkerReplicas ?? 0
+  const desired = status.desiredWorkerReplicas ?? 0
+  return `${available}/${desired}`
+}
+
+export function getRayClusterHeadService(resource: any): string {
+  return resource.status?.head?.serviceName || '-'
+}
+
+// ============================================================================
+// RAYJOB UTILITIES
+// ============================================================================
+
+export function getRayJobStatus(resource: any): StatusBadge {
+  const jobStatus = resource.status?.jobStatus
+  const deploymentStatus = resource.status?.jobDeploymentStatus
+
+  if (deploymentStatus === 'Failed' || deploymentStatus === 'ValidationFailed') {
+    return { text: deploymentStatus, color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+
+  switch (jobStatus) {
+    case 'SUCCEEDED':
+      return { text: 'Succeeded', color: healthColors.neutral, level: 'neutral' }
+    case 'RUNNING':
+      return { text: 'Running', color: healthColors.healthy, level: 'healthy' }
+    case 'FAILED':
+      return { text: 'Failed', color: healthColors.unhealthy, level: 'unhealthy' }
+    case 'STOPPED':
+      return { text: 'Stopped', color: healthColors.neutral, level: 'neutral' }
+    case 'PENDING':
+      return { text: 'Pending', color: healthColors.neutral, level: 'neutral' }
+  }
+
+  switch (deploymentStatus) {
+    case 'Suspended':
+      return { text: 'Suspended', color: healthColors.neutral, level: 'neutral' }
+    case 'Complete':
+      return { text: 'Complete', color: healthColors.neutral, level: 'neutral' }
+    case 'Running':
+      return { text: 'Running', color: healthColors.healthy, level: 'healthy' }
+    case 'Initializing':
+    case 'Suspending':
+    case 'Retrying':
+    case 'Waiting':
+      return { text: deploymentStatus, color: healthColors.degraded, level: 'degraded' }
+  }
+
+  return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+}
+
+export function getRayJobJobStatus(resource: any): string {
+  return resource.status?.jobStatus || '-'
+}
+
+export function getRayJobDeploymentStatus(resource: any): string {
+  return resource.status?.jobDeploymentStatus || '-'
+}
+
+export function getRayJobClusterName(resource: any): string {
+  return resource.status?.rayClusterName || '-'
+}
+
+// ============================================================================
+// RAYSERVICE UTILITIES
+// ============================================================================
+
+export function getRayServiceStatus(resource: any): StatusBadge {
+  const conditions = resource.status?.conditions || []
+
+  const suspendingCond = conditions.find((c: any) => c.type === 'Suspending')
+  if (suspendingCond?.status === 'True') {
+    return { text: 'Suspending', color: healthColors.degraded, level: 'degraded' }
+  }
+
+  const suspendedCond = conditions.find((c: any) => c.type === 'Suspended')
+  if (suspendedCond?.status === 'True' || resource.spec?.suspend === true) {
+    return { text: 'Suspended', color: healthColors.neutral, level: 'neutral' }
+  }
+
+  const upgradeCond = conditions.find((c: any) => c.type === 'UpgradeInProgress')
+  if (upgradeCond?.status === 'True') {
+    return { text: 'Upgrading', color: healthColors.degraded, level: 'degraded' }
+  }
+
+  const rollbackCond = conditions.find((c: any) => c.type === 'RollbackInProgress')
+  if (rollbackCond?.status === 'True') {
+    return { text: 'RollingBack', color: healthColors.degraded, level: 'degraded' }
+  }
+
+  const readyCond = conditions.find((c: any) => c.type === 'Ready')
+  if (readyCond?.status === 'True') {
+    return { text: 'Ready', color: healthColors.healthy, level: 'healthy' }
+  }
+  if (readyCond?.status === 'False') {
+    return { text: readyCond.reason || 'NotReady', color: healthColors.degraded, level: 'degraded' }
+  }
+
+  if (resource.status?.serviceStatus === 'Running') {
+    return { text: 'Running', color: healthColors.healthy, level: 'healthy' }
+  }
+
+  return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }
+}
+
+export function getRayServiceServiceStatus(resource: any): string {
+  return resource.status?.serviceStatus || '-'
+}
+
+export function getRayServiceClusters(resource: any): string {
+  const active = resource.status?.activeServiceStatus?.rayClusterName
+  const pending = resource.status?.pendingServiceStatus?.rayClusterName
+  const parts: string[] = []
+  if (active) parts.push(active)
+  if (pending) parts.push(`pending: ${pending}`)
+  return parts.join(' ') || '-'
+}
+
+// ============================================================================
+// RAYCRONJOB UTILITIES
+// ============================================================================
+
+export function getRayCronJobStatus(resource: any): StatusBadge {
+  if (resource.spec?.suspend === true) {
+    return { text: 'Suspended', color: healthColors.neutral, level: 'neutral' }
+  }
+  return { text: 'Active', color: healthColors.neutral, level: 'neutral' }
+}
+
+export function getRayCronJobSchedule(resource: any): string {
+  return resource.spec?.schedule || '-'
+}
+
+export function getRayCronJobSuspend(resource: any): boolean {
+  return resource.spec?.suspend === true
+}
+
+export function getRayCronJobLastSchedule(resource: any): string {
+  const lastSchedule = resource.status?.lastScheduleTime
+  if (!lastSchedule) return '-'
+  return formatAge(lastSchedule)
+}

--- a/packages/k8s-ui/src/components/resources/resource-utils-volcano.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-volcano.ts
@@ -1,0 +1,176 @@
+// Volcano CRD utility functions
+
+import type { StatusBadge } from './resource-utils'
+import { healthColors } from './resource-utils'
+
+// ============================================================================
+// SHARED HELPERS
+// ============================================================================
+
+function summarizeResourceList(list: any): string {
+  if (!list || typeof list !== 'object') return '-'
+  const parts: string[] = []
+  if (list.cpu !== undefined) parts.push(`CPU: ${list.cpu}`)
+  if (list.memory !== undefined) parts.push(`Mem: ${list.memory}`)
+  if (list['nvidia.com/gpu'] !== undefined) parts.push(`GPU: ${list['nvidia.com/gpu']}`)
+  const rest = Object.keys(list).filter((k) => k !== 'cpu' && k !== 'memory' && k !== 'nvidia.com/gpu')
+  if (rest.length > 0) parts.push(`+${rest.length} more`)
+  return parts.length > 0 ? parts.join(', ') : '-'
+}
+
+function summarizeCounts(entries: Array<[string, number]>): string {
+  const parts = entries.filter(([, count]) => count > 0).map(([label, count]) => `${count} ${label}`)
+  return parts.length > 0 ? parts.join(', ') : '-'
+}
+
+// ============================================================================
+// VOLCANO JOB UTILITIES (batch.volcano.sh/v1alpha1)
+// ============================================================================
+
+export function getVolcanoJobStatus(resource: any): StatusBadge {
+  const phase = resource.status?.state?.phase
+  switch (phase) {
+    case 'Running':
+      return { text: 'Running', color: healthColors.healthy, level: 'healthy' }
+    case 'Pending':
+    case 'Completing':
+    case 'Completed':
+      return { text: phase, color: healthColors.neutral, level: 'neutral' }
+    case 'Failed':
+    case 'Aborted':
+    case 'Terminated':
+      return { text: phase, color: healthColors.unhealthy, level: 'unhealthy' }
+    case 'Aborting':
+    case 'Restarting':
+    case 'Terminating':
+      return { text: phase, color: healthColors.degraded, level: 'degraded' }
+    default:
+      return { text: phase || 'Unknown', color: healthColors.unknown, level: 'unknown' }
+  }
+}
+
+export function getVolcanoJobQueue(resource: any): string {
+  return resource.spec?.queue || 'default'
+}
+
+export function getVolcanoJobMinAvailable(resource: any): string {
+  const min = resource.spec?.minAvailable ?? resource.status?.minAvailable
+  return min !== undefined && min !== null ? String(min) : '-'
+}
+
+export function getVolcanoJobPodCounts(resource: any): string {
+  const status = resource.status || {}
+  return summarizeCounts([
+    ['running', status.running || 0],
+    ['succeeded', status.succeeded || 0],
+    ['failed', status.failed || 0],
+  ])
+}
+
+// ============================================================================
+// VOLCANO QUEUE UTILITIES (scheduling.volcano.sh/v1beta1, cluster-scoped)
+// ============================================================================
+
+export function getVolcanoQueueStatus(resource: any): StatusBadge {
+  const state = resource.status?.state
+  switch (state) {
+    case 'Open':
+      return { text: 'Open', color: healthColors.healthy, level: 'healthy' }
+    case 'Closed':
+      return { text: 'Closed', color: healthColors.neutral, level: 'neutral' }
+    case 'Closing':
+      return { text: 'Closing', color: healthColors.degraded, level: 'degraded' }
+    default:
+      return { text: state || 'Unknown', color: healthColors.unknown, level: 'unknown' }
+  }
+}
+
+export function getVolcanoQueueWeight(resource: any): string {
+  const weight = resource.spec?.weight
+  return weight !== undefined && weight !== null ? String(weight) : '1'
+}
+
+export function getVolcanoQueueCapability(resource: any): string {
+  return summarizeResourceList(resource.spec?.capability)
+}
+
+export function getVolcanoQueueAllocated(resource: any): string {
+  return summarizeResourceList(resource.status?.allocated)
+}
+
+export function getVolcanoQueuePodGroupCounts(resource: any): string {
+  const status = resource.status || {}
+  return summarizeCounts([
+    ['running', status.running || 0],
+    ['inqueue', status.inqueue || 0],
+    ['pending', status.pending || 0],
+    ['completed', status.completed || 0],
+    ['unknown', status.unknown || 0],
+  ])
+}
+
+// ============================================================================
+// VOLCANO PODGROUP UTILITIES (scheduling.volcano.sh/v1beta1)
+// ============================================================================
+
+export function getVolcanoPodGroupStatus(resource: any): StatusBadge {
+  const phase = resource.status?.phase
+  if (phase === 'Running') {
+    return { text: 'Running', color: healthColors.healthy, level: 'healthy' }
+  }
+  const conditions = resource.status?.conditions || []
+  const unschedulable = conditions.some((c: any) => c.type === 'Unschedulable' && c.status === 'True')
+  if (unschedulable) {
+    return { text: 'Unschedulable', color: healthColors.alert, level: 'alert' }
+  }
+  if (phase === 'Pending' || phase === 'Inqueue' || phase === 'Completed') {
+    return { text: phase, color: healthColors.neutral, level: 'neutral' }
+  }
+  return { text: phase || 'Unknown', color: healthColors.unknown, level: 'unknown' }
+}
+
+export function getVolcanoPodGroupQueue(resource: any): string {
+  return resource.spec?.queue || 'default'
+}
+
+export function getVolcanoPodGroupMinMember(resource: any): string {
+  const min = resource.spec?.minMember
+  return min !== undefined && min !== null ? String(min) : '-'
+}
+
+// ============================================================================
+// VOLCANO JOBFLOW UTILITIES (flow.volcano.sh/v1alpha1)
+// ============================================================================
+
+export function getJobFlowStatus(resource: any): StatusBadge {
+  const phase = resource.status?.state?.phase
+  switch (phase) {
+    case 'Running':
+      return { text: 'Running', color: healthColors.healthy, level: 'healthy' }
+    case 'Succeed':
+    case 'Pending':
+      return { text: phase, color: healthColors.neutral, level: 'neutral' }
+    case 'Failed':
+      return { text: 'Failed', color: healthColors.unhealthy, level: 'unhealthy' }
+    case 'Terminating':
+      return { text: 'Terminating', color: healthColors.degraded, level: 'degraded' }
+    default:
+      return { text: phase || 'Unknown', color: healthColors.unknown, level: 'unknown' }
+  }
+}
+
+export function getJobFlowFlowCount(resource: any): number {
+  return (resource.spec?.flows || []).length
+}
+
+// ============================================================================
+// VOLCANO JOBTEMPLATE UTILITIES (flow.volcano.sh/v1alpha1)
+// ============================================================================
+
+export function getJobTemplateStatus(_resource: any): StatusBadge {
+  return { text: 'Template', color: healthColors.neutral, level: 'neutral' }
+}
+
+export function getJobTemplateTaskCount(resource: any): number {
+  return (resource.spec?.tasks || []).length
+}

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -14,6 +14,17 @@ import { getArgoApplicationStatus, getArgoApplicationSetStatus, getArgoApplicati
 import { getPolicyReportStatus as _getPolicyReportStatus, getKyvernoPolicyStatus as _getKyvernoPolicyStatus } from './resource-utils-kyverno'
 import { getResourceClaimStatus as _getResourceClaimStatus, getResourceClaimDeviceClasses as _getResourceClaimDeviceClasses, getResourceClaimTemplateDeviceClasses as _getResourceClaimTemplateDeviceClasses, getResourceClaimAllocation as _getResourceClaimAllocation, getResourceClaimReservedFor as _getResourceClaimReservedFor } from './resource-utils-dra'
 import { getNvidiaClusterPolicyStatus as _getNvidiaClusterPolicyStatus, getNvidiaClusterPolicyEnabledComponents as _getNvidiaClusterPolicyEnabledComponents, getNvidiaDriverStatus as _getNvidiaDriverStatus } from './resource-utils-nvidia'
+import { getClusterQueueStatus as _getClusterQueueStatus, getLocalQueueStatus as _getLocalQueueStatus, getKueueWorkloadStatus as _getKueueWorkloadStatus, getResourceFlavorStatus as _getResourceFlavorStatus, getAdmissionCheckStatus as _getAdmissionCheckStatus, getProvisioningRequestStatus as _getProvisioningRequestStatus } from './resource-utils-kueue'
+import { getRayClusterStatus as _getRayClusterStatus, getRayJobStatus as _getRayJobStatus, getRayServiceStatus as _getRayServiceStatus, getRayCronJobStatus as _getRayCronJobStatus } from './resource-utils-ray'
+import { getLeaderWorkerSetStatus as _getLeaderWorkerSetStatus, getJobSetStatus as _getJobSetStatus } from './resource-utils-jobset-lws'
+import { getInferenceServiceStatus as _getInferenceServiceStatus, getServingRuntimeStatus as _getServingRuntimeStatus, getInferenceGraphStatus as _getInferenceGraphStatus, getTrainedModelStatus as _getTrainedModelStatus, getLLMInferenceServiceStatus as _getLLMInferenceServiceStatus } from './resource-utils-kserve'
+import { getInferencePoolStatus as _getInferencePoolStatus, getInferenceObjectiveStatus as _getInferenceObjectiveStatus } from './resource-utils-inference-gateway'
+import { getVolcanoJobStatus as _getVolcanoJobStatus, getVolcanoQueueStatus as _getVolcanoQueueStatus, getVolcanoPodGroupStatus as _getVolcanoPodGroupStatus, getJobFlowStatus as _getJobFlowStatus, getJobTemplateStatus as _getJobTemplateStatus } from './resource-utils-volcano'
+import { getKaiQueueStatus as _getKaiQueueStatus, getKaiPodGroupStatus as _getKaiPodGroupStatus } from './resource-utils-kai'
+import { getKaitoWorkspaceStatus as _getKaitoWorkspaceStatus, getRAGEngineStatus as _getRAGEngineStatus } from './resource-utils-kaito'
+import { getNIMServiceStatus as _getNIMServiceStatus, getNIMCacheStatus as _getNIMCacheStatus, getNIMPipelineStatus as _getNIMPipelineStatus } from './resource-utils-nim'
+import { getAMDDeviceConfigStatus as _getAMDDeviceConfigStatus } from './resource-utils-amd-gpu'
+import { getPyTorchJobStatus as _getPyTorchJobStatus, getTFJobStatus as _getTFJobStatus, getMPIJobStatus as _getMPIJobStatus, getTrainJobStatus as _getTrainJobStatus } from './resource-utils-kubeflow-training'
 import { getBackupStatus as _getBackupStatus, getRestoreStatus as _getRestoreStatus, getScheduleStatus as _getScheduleStatus, getBSLStatus as _getBSLStatus, getBackupRepositoryStatus as _getBackupRepositoryStatus } from './resource-utils-velero'
 import { getExternalSecretStatus as _getExternalSecretStatus, getClusterExternalSecretStatus as _getClusterExternalSecretStatus, getSecretStoreStatus as _getSecretStoreStatus, getClusterSecretStoreStatus as _getClusterSecretStoreStatus, getSecretStoreProviderType as _getSecretStoreProviderType } from './resource-utils-eso'
 import { getHPATableState, hpaStatusFromState } from './resource-utils-hpa'
@@ -2218,6 +2229,42 @@ export function getCellFilterValue(resource: any, column: string, kind: string):
       if (kindLower === 'nvidiaclusterpolicies') return _getNvidiaClusterPolicyStatus(resource).text
       if (kindLower === 'nvidiadrivers') return _getNvidiaDriverStatus(resource).text
       if (kindLower === 'resourceclaims') return _getResourceClaimStatus(resource).text
+      if (kindLower === 'clusterqueues') return _getClusterQueueStatus(resource).text
+      if (kindLower === 'localqueues') return _getLocalQueueStatus(resource).text
+      if (kindLower === 'workloads') return _getKueueWorkloadStatus(resource).text
+      if (kindLower === 'resourceflavors') return _getResourceFlavorStatus(resource).text
+      if (kindLower === 'admissionchecks') return _getAdmissionCheckStatus(resource).text
+      if (kindLower === 'provisioningrequests') return _getProvisioningRequestStatus(resource).text
+      if (kindLower === 'rayclusters') return _getRayClusterStatus(resource).text
+      if (kindLower === 'rayjobs') return _getRayJobStatus(resource).text
+      if (kindLower === 'rayservices') return _getRayServiceStatus(resource).text
+      if (kindLower === 'raycronjobs') return _getRayCronJobStatus(resource).text
+      if (kindLower === 'leaderworkersets') return _getLeaderWorkerSetStatus(resource).text
+      if (kindLower === 'jobsets') return _getJobSetStatus(resource).text
+      if (kindLower === 'inferenceservices') return _getInferenceServiceStatus(resource).text
+      if (kindLower === 'servingruntimes' || kindLower === 'clusterservingruntimes') return _getServingRuntimeStatus(resource).text
+      if (kindLower === 'inferencegraphs') return _getInferenceGraphStatus(resource).text
+      if (kindLower === 'trainedmodels') return _getTrainedModelStatus(resource).text
+      if (kindLower === 'llminferenceservices') return _getLLMInferenceServiceStatus(resource).text
+      if (kindLower === 'inferencepools') return _getInferencePoolStatus(resource).text
+      if (kindLower === 'inferenceobjectives') return _getInferenceObjectiveStatus(resource).text
+      if (kindLower === 'volcanojobs') return _getVolcanoJobStatus(resource).text
+      if (kindLower === 'volcanoqueues') return _getVolcanoQueueStatus(resource).text
+      if (kindLower === 'volcanopodgroups') return _getVolcanoPodGroupStatus(resource).text
+      if (kindLower === 'jobflows') return _getJobFlowStatus(resource).text
+      if (kindLower === 'jobtemplates') return _getJobTemplateStatus(resource).text
+      if (kindLower === 'kaiqueues') return _getKaiQueueStatus(resource).text
+      if (kindLower === 'kaipodgroups') return _getKaiPodGroupStatus(resource).text
+      if (kindLower === 'kaitoworkspaces') return _getKaitoWorkspaceStatus(resource).text
+      if (kindLower === 'ragengines') return _getRAGEngineStatus(resource).text
+      if (kindLower === 'nimservices') return _getNIMServiceStatus(resource).text
+      if (kindLower === 'nimcaches') return _getNIMCacheStatus(resource).text
+      if (kindLower === 'nimpipelines') return _getNIMPipelineStatus(resource).text
+      if (kindLower === 'deviceconfigs') return _getAMDDeviceConfigStatus(resource).text
+      if (kindLower === 'pytorchjobs') return _getPyTorchJobStatus(resource).text
+      if (kindLower === 'tfjobs') return _getTFJobStatus(resource).text
+      if (kindLower === 'mpijobs') return _getMPIJobStatus(resource).text
+      if (kindLower === 'trainjobs') return _getTrainJobStatus(resource).text
       // Positively gated, matching the cell dispatch: `backups` is reached here
       // only when the group is unknown to normalizeKindToPlural, and a third
       // vendor's Backup renders through the generic path — so the sort key has

--- a/packages/k8s-ui/src/components/resources/resources-column-filter.test.ts
+++ b/packages/k8s-ui/src/components/resources/resources-column-filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { isColumnFilterableByDistinctCount, SKIP_FILTER_COLUMNS } from './ResourcesView'
+import { getCellFilterKind, hasCuratedColumns, isColumnFilterableByDistinctCount, normalizeKindToPlural, SKIP_FILTER_COLUMNS } from './ResourcesView'
 
 describe('isColumnFilterableByDistinctCount', () => {
   // Caps were tuned after a customer-visible regression where the namespace
@@ -70,5 +70,31 @@ describe('isColumnFilterableByDistinctCount', () => {
       expect(SKIP_FILTER_COLUMNS.has('reason')).toBe(false)
       expect(isColumnFilterableByDistinctCount('reason', 8)).toBe(true)
     })
+  })
+})
+
+describe('GPU ecosystem column routing', () => {
+  it('uses specialized columns only for the owning API group', () => {
+    expect(hasCuratedColumns('workloads', 'kueue.x-k8s.io')).toBe(true)
+    expect(hasCuratedColumns('workloads', 'scheduling.k8s.io')).toBe(false)
+    expect(hasCuratedColumns('Workload', 'scheduling.k8s.io')).toBe(false)
+    expect(hasCuratedColumns('deviceconfigs', 'amd.com')).toBe(true)
+    expect(hasCuratedColumns('deviceconfigs', 'example.io')).toBe(false)
+    expect(getCellFilterKind('workloads', 'kueue.x-k8s.io')).toBe('workloads')
+    expect(getCellFilterKind('workloads', 'scheduling.k8s.io')).toBe('__generic_workloads')
+    expect(getCellFilterKind('deviceconfigs', 'example.io')).toBe('__generic_deviceconfigs')
+  })
+
+  it('keeps core, Volcano, and foreign Jobs on separate column paths', () => {
+    expect(normalizeKindToPlural('jobs', 'batch')).toBe('jobs')
+    expect(normalizeKindToPlural('jobs', 'batch.volcano.sh')).toBe('volcanojobs')
+    expect(normalizeKindToPlural('jobs', 'example.io')).toBe('__generic_jobs')
+    expect(normalizeKindToPlural('Job', 'example.io')).toBe('__generic_job')
+  })
+
+  it('recognizes both the current and deployed InferenceObjective groups', () => {
+    expect(hasCuratedColumns('inferenceobjectives', 'llm-d.ai')).toBe(true)
+    expect(hasCuratedColumns('inferenceobjectives', 'inference.networking.x-k8s.io')).toBe(true)
+    expect(hasCuratedColumns('inferenceobjectives', 'example.io')).toBe(false)
   })
 })

--- a/packages/k8s-ui/src/components/shared/EditableYamlView.tsx
+++ b/packages/k8s-ui/src/components/shared/EditableYamlView.tsx
@@ -20,6 +20,7 @@ import { Tooltip } from '../ui/Tooltip'
 import type { SelectedResource } from '../../types'
 import { resourceToYaml } from '../../utils/yaml'
 import { triggerDownload } from '../../utils/download'
+import { isCoreBatchJob } from '../../utils/api-resources'
 
 // ============================================================================
 // SUCCESS ANIMATION
@@ -45,6 +46,7 @@ export function SaveSuccessAnimation() {
 // Get edit warning for resource types with limited editability
 function getEditWarning(
   kind: string,
+  group?: string,
 ): { message: string; tip: string; learnMoreUrl?: string } | null {
   const k = kind.toLowerCase()
   if (k === 'pods' || k === 'pod') {
@@ -55,7 +57,7 @@ function getEditWarning(
         'https://kubernetes.io/docs/concepts/workloads/pods/#pod-update-and-replacement',
     }
   }
-  if (k === 'jobs' || k === 'job') {
+  if (isCoreBatchJob(k, group)) {
     return {
       message: 'Jobs cannot be modified after creation.',
       tip: 'Delete and recreate the Job to make changes.',
@@ -351,7 +353,7 @@ export function EditableYamlView({
   }, [])
 
   const yamlContent = yamlStringify(data, { lineWidth: 0, indent: 2 })
-  const editWarning = getEditWarning(resource.kind)
+  const editWarning = getEditWarning(resource.kind, resource.group)
   const formattedError = saveError ? formatSaveError(saveError) : null
   const isPending = (isSaving ?? false) || (isPreviewing ?? false)
 

--- a/packages/k8s-ui/src/components/shared/ResourceActionsBar.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceActionsBar.tsx
@@ -30,6 +30,7 @@ import { getDefaultContainerName } from '../resources/resource-utils'
 import { SetImageDialog, type ManagedImageSource } from './SetImageDialog'
 import type { WorkloadImageInventory, WorkloadImageUpdate } from '../../types/core'
 import { isArgoRolloutResource } from '../../utils/workload-rollout'
+import { isCoreBatchJob } from '../../utils/api-resources'
 
 // ============================================================================
 // ACTIONS BAR - Interactive buttons that change based on resource kind
@@ -166,13 +167,14 @@ export function ResourceActionsBar({
   onDrainNode, isDrainingNode,
 }: ResourceActionsBarProps) {
   const kind = resource.kind.toLowerCase()
+  const coreBatchJob = isCoreBatchJob(kind, resource.group)
   const supportsWorkloadActions = ['deployments', 'statefulsets', 'daemonsets'].includes(kind) ||
     (kind === 'rollouts' && isArgoRolloutResource(data))
   const canOpenWorkloadLogs = Boolean(
     canViewLogs &&
     !hideLogs &&
     openWorkloadLogs &&
-    ['deployments', 'statefulsets', 'daemonsets', 'jobs', 'workflows', 'cronjobs', 'cronworkflows', 'workflowtemplates', 'clusterworkflowtemplates', 'scaledjobs'].includes(kind)
+    (['deployments', 'statefulsets', 'daemonsets', 'workflows', 'cronjobs', 'cronworkflows', 'workflowtemplates', 'clusterworkflowtemplates', 'scaledjobs'].includes(kind) || coreBatchJob)
   )
 
   // Delete confirmation state
@@ -516,7 +518,7 @@ export function ResourceActionsBar({
       )}
 
       {/* Job logs */}
-      {kind === 'jobs' && onCopyCommand && (!canViewLogs || !openWorkloadLogs) && (
+      {coreBatchJob && onCopyCommand && (!canViewLogs || !openWorkloadLogs) && (
         <button
           onClick={(e) => onCopyCommand(
             `kubectl logs job/${resource.name} -n ${resource.namespace} -f`,

--- a/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.test.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.test.tsx
@@ -726,3 +726,122 @@ describe('Velero BackupRepository status', () => {
     expect(getResourceStatus('backuprepositories', foreign)?.text).not.toBe('Not ready')
   })
 })
+
+describe('GPU ecosystem kind collisions', () => {
+  it('routes Volcano Jobs away from the core JobRenderer to GenericRenderer', () => {
+    const html = renderKind('jobs', {
+      apiVersion: 'batch.volcano.sh/v1alpha1',
+      kind: 'Job',
+      metadata: { name: 'train', namespace: 'ml' },
+      spec: { queue: 'gpu-queue', minAvailable: 4 },
+      status: { state: { phase: 'Running' } },
+    }, 'ml')
+    expect(html).toContain('Min Available')
+    expect(html).toContain('gpu-queue')
+    expect(html).not.toContain('Completions')
+  })
+
+  it('routes status for queues by group (Volcano vs KAI)', () => {
+    const volcano = getResourceStatus('queues', {
+      apiVersion: 'scheduling.volcano.sh/v1beta1',
+      status: { state: 'Open' },
+    })
+    const kai = getResourceStatus('queues', {
+      apiVersion: 'scheduling.run.ai/v2',
+      spec: { priority: 100 },
+    })
+    expect(volcano?.text).toBe('Open')
+    expect(kai?.text).not.toBe('Open')
+  })
+
+  it('routes status for podgroups by group (Volcano vs KAI)', () => {
+    const volcano = getResourceStatus('podgroups', {
+      apiVersion: 'scheduling.volcano.sh/v1beta1',
+      status: { phase: 'Running' },
+    })
+    expect(volcano?.text).toBe('Running')
+  })
+
+  it('routes Kueue Workload status only for the kueue group', () => {
+    const admitted = getResourceStatus('workloads', {
+      apiVersion: 'kueue.x-k8s.io/v1beta2',
+      status: { conditions: [{ type: 'Admitted', status: 'True' }] },
+    })
+    expect(admitted?.text).toBe('Admitted')
+    const foreign = getResourceStatus('workloads', {
+      apiVersion: 'scheduling.k8s.io/v1alpha2',
+      status: { conditions: [{ type: 'Admitted', status: 'True' }] },
+    })
+    expect(foreign?.text).toBe('Admitted')
+    expect(foreign?.color).not.toBe(admitted?.color)
+  })
+
+  it('does not assign Volcano or core Job semantics to foreign collisions', () => {
+    const foreign = {
+      apiVersion: 'example.io/v1',
+      kind: 'Job',
+      metadata: { name: 'foreign', namespace: 'default' },
+      spec: { collisionProbe: COLLISION_PROBE },
+      status: { state: { phase: 'Running' } },
+    }
+    expect(getResourceStatus('jobs', foreign)).toBeNull()
+    const html = renderKind('jobs', foreign, 'default')
+    expect(html).toContain(COLLISION_PROBE)
+    expect(html).not.toContain('Completions')
+  })
+
+  it('keeps typed core Jobs on the core path when TypeMeta is absent', () => {
+    const core = {
+      kind: 'Job',
+      metadata: { name: 'core', namespace: 'default' },
+      spec: { completions: 1, parallelism: 1 },
+      status: { succeeded: 1, conditions: [{ type: 'Complete', status: 'True' }] },
+    }
+    expect(getResourceStatus('jobs', core)?.text).toBe('Complete')
+    const html = renderKind('jobs', core, 'default')
+    expect(html).toContain('Completions')
+  })
+
+  it('leaves foreign Queues and PodGroups on generic status handling', () => {
+    expect(getResourceStatus('queues', { apiVersion: 'example.io/v1', status: {} })).toBeNull()
+    expect(getResourceStatus('podgroups', { apiVersion: 'example.io/v1', status: {} })).toBeNull()
+  })
+
+  it('accepts the current llm-d InferenceObjective group', () => {
+    expect(getResourceStatus('inferenceobjectives', {
+      apiVersion: 'llm-d.ai/v1alpha2',
+      status: { conditions: [{ type: 'Ready', status: 'True' }] },
+    })?.text).toBe('Accepted')
+  })
+
+  it('routes KAITO Workspace status only for the kaito group', () => {
+    const ws = getResourceStatus('workspaces', {
+      apiVersion: 'kaito.sh/v1beta1',
+      status: { conditions: [{ type: 'ResourceReady', status: 'False' }] },
+    })
+    expect(ws).not.toBeNull()
+  })
+})
+
+describe('GPU ecosystem status edge cases', () => {
+  it('JobSet with minimal status is Pending, not Running', () => {
+    const fresh = getResourceStatus('jobsets', {
+      apiVersion: 'jobset.x-k8s.io/v1alpha2',
+      status: { replicatedJobsStatus: [{ name: 'w', active: 0, ready: 0 }] },
+    })
+    const live = getResourceStatus('jobsets', {
+      apiVersion: 'jobset.x-k8s.io/v1alpha2',
+      status: { replicatedJobsStatus: [{ name: 'w', active: 1, ready: 1 }] },
+    })
+    expect(fresh?.text).toBe('Pending')
+    expect(live?.text).toBe('Running')
+  })
+
+  it('InferencePool with only an empty-parentRef default entry reads Not referenced', () => {
+    const pool = getResourceStatus('inferencepools', {
+      apiVersion: 'inference.networking.x-k8s.io/v1alpha2',
+      status: { parent: [{ parentRef: {}, conditions: [{ type: 'Accepted', status: 'Unknown' }] }] },
+    })
+    expect(pool?.text).toBe('Not referenced')
+  })
+})

--- a/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceRendererDispatch.tsx
@@ -67,6 +67,17 @@ import {
 } from '../resources/resource-utils-kyverno-exceptions'
 import { getResourceClaimStatus, getResourceClaimTemplateStatus, getDeviceClassStatus, getResourceSliceStatus } from '../resources/resource-utils-dra'
 import { getNvidiaClusterPolicyStatus, getNvidiaDriverStatus } from '../resources/resource-utils-nvidia'
+import { getClusterQueueStatus, getLocalQueueStatus, getKueueWorkloadStatus, getResourceFlavorStatus, getAdmissionCheckStatus, getProvisioningRequestStatus } from '../resources/resource-utils-kueue'
+import { getRayClusterStatus, getRayJobStatus, getRayServiceStatus, getRayCronJobStatus } from '../resources/resource-utils-ray'
+import { getLeaderWorkerSetStatus, getJobSetStatus } from '../resources/resource-utils-jobset-lws'
+import { getInferenceServiceStatus, getServingRuntimeStatus, getInferenceGraphStatus, getTrainedModelStatus, getLLMInferenceServiceStatus } from '../resources/resource-utils-kserve'
+import { getInferencePoolStatus, getInferenceObjectiveStatus } from '../resources/resource-utils-inference-gateway'
+import { getVolcanoJobStatus, getVolcanoQueueStatus, getVolcanoPodGroupStatus, getJobFlowStatus, getJobTemplateStatus } from '../resources/resource-utils-volcano'
+import { getKaiQueueStatus, getKaiPodGroupStatus } from '../resources/resource-utils-kai'
+import { getKaitoWorkspaceStatus, getRAGEngineStatus } from '../resources/resource-utils-kaito'
+import { getNIMServiceStatus, getNIMCacheStatus, getNIMPipelineStatus } from '../resources/resource-utils-nim'
+import { getAMDDeviceConfigStatus } from '../resources/resource-utils-amd-gpu'
+import { getPyTorchJobStatus, getTFJobStatus, getMPIJobStatus, getTrainJobStatus } from '../resources/resource-utils-kubeflow-training'
 import { getBackupStatus, getRestoreStatus, getScheduleStatus, getBSLStatus, getBackupRepositoryStatus, isVeleroResource } from '../resources/resource-utils-velero'
 import {
   getVirtualServiceStatus,
@@ -678,6 +689,10 @@ export function ResourceRendererDispatch({
     isCalicoPolicyKind(kind) || kind === 'hostendpoints' || kind === 'ippools' || kind === 'tiers'
   ) && !isCoreNetworkPolicy && !((isCalicoPolicy || isCalicoHostEndpoint || isCalicoIPPool || isCalicoTier))
 
+  const nonCoreJobFallthrough = kind === 'jobs'
+    && !!data?.apiVersion
+    && !data.apiVersion.startsWith('batch/')
+
   const isKnownKind = KNOWN_KINDS.has(kind) || isCrossplaneMR || isCrossplaneClaim || isCrossplaneXR
 
   const PodComp = rendererOverrides?.PodRenderer ?? PodRenderer
@@ -742,7 +757,7 @@ export function ResourceRendererDispatch({
         {kind === 'ingresses' && !data?.apiVersion?.includes('networking.internal.knative.dev') && <IngressRenderer data={data} onNavigate={onNavigate} />}
         {kind === 'configmaps' && <ConfigMapRenderer data={data} />}
         {kind === 'secrets' && <SecretRenderer data={data} certificateInfo={certificateInfo} resourceData={data} onSaveSecretValue={onSaveSecretValue} isSaving={isSavingSecret} />}
-        {kind === 'jobs' && <JobRenderer data={data} />}
+        {kind === 'jobs' && !nonCoreJobFallthrough && <JobRenderer data={data} />}
         {kind === 'cronjobs' && <CronJobRenderer data={data} onNavigate={onNavigate} />}
         {kind === 'cronworkflows' && <CronWorkflowRenderer data={data} onNavigate={onNavigate} />}
         {(kind === 'hpas' || kind === 'horizontalpodautoscalers') && <HPAComp data={data} onNavigate={onNavigate} hpaDiagnosis={hpaDiagnosis} />}
@@ -941,7 +956,7 @@ export function ResourceRendererDispatch({
             for known-plural collisions where no apiVersion-gated renderer
             matched (e.g. a Knative Configuration sharing the `configurations`
             plural with Crossplane Configuration). */}
-        {(!isKnownKind || crossplaneCollisionFallthrough || kyvernoCollisionFallthrough || veleroCollisionFallthrough || groupGatedFallthrough || calicoCollisionFallthrough) && <GenericRenderer data={data} />}
+        {(!isKnownKind || crossplaneCollisionFallthrough || kyvernoCollisionFallthrough || veleroCollisionFallthrough || groupGatedFallthrough || calicoCollisionFallthrough || nonCoreJobFallthrough) && <GenericRenderer data={data} />}
 
         {/* Common sections - can be disabled when parent handles them separately */}
         {showCommonSections && (
@@ -1016,7 +1031,55 @@ export function getResourceStatus(kind: string, data: any): { text: string; colo
       SEVERITY_BADGE.error
     return { text, color }
   }
-  if (k === 'jobs') return getJobStatus(data)
+  if (k === 'jobs') {
+    if (data?.apiVersion?.startsWith('batch.volcano.sh/')) return getVolcanoJobStatus(data)
+    if (!data?.apiVersion || data.apiVersion.startsWith('batch/')) return getJobStatus(data)
+  }
+  if (k === 'queues') {
+    if (data?.apiVersion?.startsWith('scheduling.run.ai/')) return getKaiQueueStatus(data)
+    if (data?.apiVersion?.startsWith('scheduling.volcano.sh/')) return getVolcanoQueueStatus(data)
+  }
+  if (k === 'podgroups') {
+    if (data?.apiVersion?.startsWith('scheduling.run.ai/')) return getKaiPodGroupStatus(data)
+    if (data?.apiVersion?.startsWith('scheduling.volcano.sh/')) return getVolcanoPodGroupStatus(data)
+  }
+  if (k === 'workspaces' && data?.apiVersion?.startsWith('kaito.sh/')) return getKaitoWorkspaceStatus(data)
+  if (k === 'workloads' && data?.apiVersion?.startsWith('kueue.x-k8s.io/')) return getKueueWorkloadStatus(data)
+  if (k === 'clusterqueues' && data?.apiVersion?.startsWith('kueue.x-k8s.io/')) return getClusterQueueStatus(data)
+  if (k === 'localqueues' && data?.apiVersion?.startsWith('kueue.x-k8s.io/')) return getLocalQueueStatus(data)
+  if (k === 'resourceflavors' && data?.apiVersion?.startsWith('kueue.x-k8s.io/')) return getResourceFlavorStatus(data)
+  if (k === 'admissionchecks' && data?.apiVersion?.startsWith('kueue.x-k8s.io/')) return getAdmissionCheckStatus(data)
+  if (k === 'provisioningrequests' && data?.apiVersion?.startsWith('autoscaling.x-k8s.io/')) return getProvisioningRequestStatus(data)
+  if (k === 'rayclusters' && data?.apiVersion?.startsWith('ray.io/')) return getRayClusterStatus(data)
+  if (k === 'rayjobs' && data?.apiVersion?.startsWith('ray.io/')) return getRayJobStatus(data)
+  if (k === 'rayservices' && data?.apiVersion?.startsWith('ray.io/')) return getRayServiceStatus(data)
+  if (k === 'raycronjobs' && data?.apiVersion?.startsWith('ray.io/')) return getRayCronJobStatus(data)
+  if (k === 'leaderworkersets' && data?.apiVersion?.startsWith('leaderworkerset.x-k8s.io/')) return getLeaderWorkerSetStatus(data)
+  if (k === 'jobsets' && data?.apiVersion?.startsWith('jobset.x-k8s.io/')) return getJobSetStatus(data)
+  if (k === 'inferenceservices' && data?.apiVersion?.startsWith('serving.kserve.io/')) return getInferenceServiceStatus(data)
+  if ((k === 'servingruntimes' || k === 'clusterservingruntimes') && data?.apiVersion?.startsWith('serving.kserve.io/')) return getServingRuntimeStatus(data)
+  if (k === 'inferencegraphs' && data?.apiVersion?.startsWith('serving.kserve.io/')) return getInferenceGraphStatus(data)
+  if (k === 'trainedmodels' && data?.apiVersion?.startsWith('serving.kserve.io/')) return getTrainedModelStatus(data)
+  if (k === 'llminferenceservices' && data?.apiVersion?.startsWith('serving.kserve.io/')) return getLLMInferenceServiceStatus(data)
+  if (k === 'inferencepools' && (
+    data?.apiVersion?.startsWith('inference.networking.k8s.io/')
+    || data?.apiVersion?.startsWith('inference.networking.x-k8s.io/')
+  )) return getInferencePoolStatus(data)
+  if (k === 'inferenceobjectives' && (
+    data?.apiVersion?.startsWith('inference.networking.x-k8s.io/')
+    || data?.apiVersion?.startsWith('llm-d.ai/')
+  )) return getInferenceObjectiveStatus(data)
+  if (k === 'jobflows' && data?.apiVersion?.startsWith('flow.volcano.sh/')) return getJobFlowStatus(data)
+  if (k === 'jobtemplates' && data?.apiVersion?.startsWith('flow.volcano.sh/')) return getJobTemplateStatus(data)
+  if (k === 'ragengines' && data?.apiVersion?.startsWith('kaito.sh/')) return getRAGEngineStatus(data)
+  if (k === 'nimservices' && data?.apiVersion?.startsWith('apps.nvidia.com/')) return getNIMServiceStatus(data)
+  if (k === 'nimcaches' && data?.apiVersion?.startsWith('apps.nvidia.com/')) return getNIMCacheStatus(data)
+  if (k === 'nimpipelines' && data?.apiVersion?.startsWith('apps.nvidia.com/')) return getNIMPipelineStatus(data)
+  if (k === 'deviceconfigs' && data?.apiVersion?.startsWith('amd.com/')) return getAMDDeviceConfigStatus(data)
+  if (k === 'pytorchjobs' && data?.apiVersion?.startsWith('kubeflow.org/')) return getPyTorchJobStatus(data)
+  if (k === 'tfjobs' && data?.apiVersion?.startsWith('kubeflow.org/')) return getTFJobStatus(data)
+  if (k === 'mpijobs' && data?.apiVersion?.startsWith('kubeflow.org/')) return getMPIJobStatus(data)
+  if (k === 'trainjobs' && data?.apiVersion?.startsWith('trainer.kubeflow.org/')) return getTrainJobStatus(data)
   if (k === 'cronjobs') return getCronJobStatus(data)
   if (k === 'hpas' || k === 'horizontalpodautoscalers') return getHPAStatus(data)
   if (k === 'nodes') return getNodeStatus(data)

--- a/packages/k8s-ui/src/components/ui/drawer-components.tsx
+++ b/packages/k8s-ui/src/components/ui/drawer-components.tsx
@@ -733,6 +733,18 @@ export function formatKindName(kind: string): string {
     resourceclaims: 'ResourceClaim', resourceclaimtemplates: 'ResourceClaimTemplate',
     deviceclasses: 'DeviceClass', resourceslices: 'ResourceSlice',
     clusterpolicies: 'ClusterPolicy', nvidiadrivers: 'NVIDIADriver',
+    clusterqueues: 'ClusterQueue', localqueues: 'LocalQueue', resourceflavors: 'ResourceFlavor',
+    admissionchecks: 'AdmissionCheck', provisioningrequests: 'ProvisioningRequest',
+    rayclusters: 'RayCluster', rayjobs: 'RayJob', rayservices: 'RayService', raycronjobs: 'RayCronJob',
+    leaderworkersets: 'LeaderWorkerSet', jobsets: 'JobSet',
+    inferenceservices: 'InferenceService', servingruntimes: 'ServingRuntime',
+    clusterservingruntimes: 'ClusterServingRuntime', inferencegraphs: 'InferenceGraph',
+    trainedmodels: 'TrainedModel', llminferenceservices: 'LLMInferenceService',
+    inferencepools: 'InferencePool', inferenceobjectives: 'InferenceObjective',
+    jobflows: 'JobFlow', jobtemplates: 'JobTemplate', ragengines: 'RAGEngine',
+    nimservices: 'NIMService', nimcaches: 'NIMCache', nimpipelines: 'NIMPipeline',
+    deviceconfigs: 'DeviceConfig',
+    pytorchjobs: 'PyTorchJob', tfjobs: 'TFJob', mpijobs: 'MPIJob', trainjobs: 'TrainJob',
   }
   if (names[k]) return names[k]
 

--- a/packages/k8s-ui/src/components/workload/WorkloadView.tsx
+++ b/packages/k8s-ui/src/components/workload/WorkloadView.tsx
@@ -73,6 +73,7 @@ import {
 import { ServicePortCards, type ServicePortRenderProps } from '../resources/renderers/ServiceRenderer'
 import { rolloutMayAdvanceAutomatically, type WorkloadRolloutActivity } from '../../utils/workload-rollout'
 import { WorkloadRolloutNotice } from './WorkloadRolloutNotice'
+import { isCoreBatchJob } from '../../utils/api-resources'
 
 export type WorkloadTabType = 'overview' | 'topology' | 'timeline' | 'logs' | 'metrics' | 'reachability' | 'cost' | 'yaml'
 type TabType = WorkloadTabType
@@ -738,7 +739,10 @@ export function WorkloadView({
 
   const showMetricsTab = isMetricsAvailable ? isMetricsAvailable(kind, resource) : false
   const showCostTab = isCostAvailable ? isCostAvailable(kind, resource) : false
-  const logsTabVisible = Boolean(renderLogsTab) && (allPods.length > 0 || LOGS_TAB_WITHOUT_PODS_KINDS.has(kindToPlural(kind).toLowerCase()))
+  const normalizedKind = kindToPlural(kind).toLowerCase()
+  const logsWithoutPods = LOGS_TAB_WITHOUT_PODS_KINDS.has(normalizedKind) &&
+    (normalizedKind !== 'jobs' || isCoreBatchJob(kind, group))
+  const logsTabVisible = Boolean(renderLogsTab) && (allPods.length > 0 || logsWithoutPods)
   const metricsTabVisible = Boolean(showMetricsTab && renderMetricsTab)
   const costTabVisible = Boolean(showCostTab && renderCostTab)
   const podEvidenceLoading = resourceLoading || workloadPodsLoading || eventsLoading
@@ -1625,7 +1629,7 @@ function InfoTab({
     return <FetchResult loading={isLoading} error={error} className="h-full" />
   }
 
-  if (!isRuntimeWorkloadOverviewKind(selectedResource.kind)) {
+  if (!isRuntimeWorkloadOverviewKind(selectedResource.kind, selectedResource.group)) {
     return (
       <div className="h-full overflow-auto">
         {leadContent && (
@@ -1729,8 +1733,10 @@ const RUNTIME_WORKLOAD_OVERVIEW_KINDS = new Set(['deployments', 'statefulsets', 
 const ROLLOUT_STATUS_KINDS = new Set(['deployments', 'statefulsets', 'daemonsets', 'rollouts'])
 type RuntimeOverviewShape = 'replicated' | 'job' | 'cronjob'
 
-function isRuntimeWorkloadOverviewKind(kind: string) {
-  return RUNTIME_WORKLOAD_OVERVIEW_KINDS.has(kindToPlural(kind).toLowerCase())
+function isRuntimeWorkloadOverviewKind(kind: string, group?: string) {
+  const normalizedKind = kindToPlural(kind).toLowerCase()
+  return RUNTIME_WORKLOAD_OVERVIEW_KINDS.has(normalizedKind) &&
+    (normalizedKind !== 'jobs' || isCoreBatchJob(kind, group))
 }
 
 function isRolloutStatusKind(kind: string) {

--- a/packages/k8s-ui/src/utils/api-resources.test.ts
+++ b/packages/k8s-ui/src/utils/api-resources.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { categorizeResources, findAPIResourceForRoute, formatGroupName, shortenGroupName } from './api-resources'
+import { categorizeResources, findAPIResourceForRoute, formatGroupName, isCoreBatchJob, shortenGroupName } from './api-resources'
 
 describe('findAPIResourceForRoute', () => {
   const resources = [
@@ -45,6 +45,7 @@ describe('formatGroupName', () => {
     expect(formatGroupName('sql.cnrm.cloud.google.com')).toBe('Config Connector')
     expect(formatGroupName('crd.k8s.amazonaws.com')).toBe('AWS VPC CNI')
     expect(formatGroupName('acid.zalan.do')).toBe('Zalando Postgres')
+    expect(formatGroupName('llm-d.ai')).toBe('llm-d')
   })
 
   it('formats unmapped API groups without exposing raw domain strings', () => {
@@ -115,5 +116,13 @@ describe('categorizeResources', () => {
 
     expect(categories.find(c => c.name === 'Other Kubernetes APIs')).toBeUndefined()
     expect(categories.find(c => c.name === 'Kueue')?.resources.map(resource => resource.kind)).toEqual(['Workload'])
+  })
+})
+
+describe('isCoreBatchJob', () => {
+  it('distinguishes Kubernetes Jobs from same-kind custom resources', () => {
+    expect(isCoreBatchJob('Job', 'batch')).toBe(true)
+    expect(isCoreBatchJob('jobs')).toBe(true)
+    expect(isCoreBatchJob('Job', 'batch.volcano.sh')).toBe(false)
   })
 })

--- a/packages/k8s-ui/src/utils/api-resources.ts
+++ b/packages/k8s-ui/src/utils/api-resources.ts
@@ -65,6 +65,11 @@ export function findAPIResourceForRoute(
     ?? resources?.find(matchesRoute)
 }
 
+export function isCoreBatchJob(kind: string, group?: string): boolean {
+  const normalizedKind = kind.toLowerCase()
+  return (normalizedKind === 'job' || normalizedKind === 'jobs') && (!group || group === 'batch')
+}
+
 // Resources that should be hidden from the sidebar
 const HIDDEN_KINDS = ['PodMetrics', 'NodeMetrics']
 
@@ -216,7 +221,11 @@ export function formatGroupName(group: string): string {
     'jobset.x-k8s.io': 'JobSet',
     'inference.networking.k8s.io': 'Inference Gateway',
     'inference.networking.x-k8s.io': 'Inference Gateway',
+    'llm-d.ai': 'llm-d',
     'nvidia.com': 'NVIDIA GPU Operator',
+    'apps.nvidia.com': 'NVIDIA NIM',
+    'amd.com': 'AMD GPU Operator',
+    'trainer.kubeflow.org': 'Kubeflow',
     'scheduling.run.ai': 'KAI Scheduler',
     'kai.scheduler': 'KAI Scheduler',
     'kaito.sh': 'KAITO',

--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -24,6 +24,7 @@ import {
   isDiagnoseKind,
   isRolloutKind,
   canSetWorkloadImages,
+  isCoreBatchJob,
   type ManagedImageSource,
   type WorkloadImageTarget,
 } from '@skyhook-io/k8s-ui'
@@ -538,7 +539,8 @@ export function WorkloadView({
   )
 
   const batchKind = pluralToKind(apiKind)
-  const batchExecution = BATCH_EXECUTION_KINDS.has(batchKind)
+  const batchExecution = BATCH_EXECUTION_KINDS.has(batchKind) &&
+    (batchKind !== 'Job' || isCoreBatchJob(apiKind, rest.group))
   const batchRunsQuery = useWorkloadRuns(apiKind, namespace, name, expanded && batchExecution, {
     refetchActive: true,
     clusterScoped: batchKind === 'ClusterWorkflowTemplate',
@@ -1175,12 +1177,15 @@ export function WorkloadView({
         renderLogsTab={(props) => (
           <LogsTabContent
             {...props}
+            group={effectiveGroup}
             selectedRunKey={selectedRunKey}
             onSelectRun={handleSelectedRunChange}
           />
         )}
         renderExpandedOverview={({ kind: k, apiKind, namespace: ns, name: n, resource: res }) =>
-          BATCH_EXECUTION_KINDS.has(k) && res ? (
+          BATCH_EXECUTION_KINDS.has(k) &&
+          (k !== 'Job' || isCoreBatchJob(apiKind, effectiveGroup)) &&
+          res ? (
             <BatchExecutionFullscreen
               kind={k}
               apiKind={apiKind}
@@ -1545,6 +1550,7 @@ const SCHEDULED_LOG_KINDS = new Set([
 function LogsTabContent({
   kind,
   apiKind,
+  group,
   namespace,
   name,
   resource,
@@ -1558,6 +1564,7 @@ function LogsTabContent({
 }: {
   kind: string
   apiKind: string
+  group?: string
   namespace: string
   name: string
   resource: any
@@ -1584,7 +1591,7 @@ function LogsTabContent({
   }
 
   // Workload kinds with stable pod selectors use the aggregated workload logs viewer
-  if (WORKLOAD_LOG_KINDS.has(kind)) {
+  if (WORKLOAD_LOG_KINDS.has(kind) && (kind !== 'Job' || isCoreBatchJob(apiKind, group))) {
     return (
       <div className="h-full">
         <WorkloadLogsViewer


### PR DESCRIPTION
Radar can now recognize and assess the GPU scheduling, batch, distributed-training, and inference-serving resources operators commonly encounter. This breadth-first phase adds resource reconnaissance across the ecosystem while reserving GPU accounting, end-to-end workload diagnosis, topology, mutations, typed detail views, and vendor-specific diagnosis for deeper integrations.

## Coverage

Basic support covers **37 kinds across 12 integrations**:

| Integration | Kinds |
|---|---|
| Kueue + Cluster Autoscaler | ClusterQueue, LocalQueue, Workload, ResourceFlavor, AdmissionCheck, ProvisioningRequest |
| KubeRay | RayCluster, RayJob, RayService, RayCronJob |
| KServe | InferenceService, ServingRuntime, ClusterServingRuntime, InferenceGraph, TrainedModel, LLMInferenceService |
| Gateway API Inference Extension / llm-d | InferencePool (current + legacy group), InferenceObjective (current + legacy group) |
| Batch SIGs | LeaderWorkerSet, JobSet |
| Volcano | Job, Queue, PodGroup, JobFlow, JobTemplate |
| KAI Scheduler | Queue, PodGroup |
| KAITO | Workspace, RAGEngine |
| NVIDIA NIM | NIMService, NIMCache, NIMPipeline |
| AMD GPU Operator | DeviceConfig |
| Kubeflow Training | PyTorchJob, TFJob, MPIJob, TrainJob |

Each recognized kind receives purpose-built table columns, readable status badges and filters, and API-group-aware sidebar organization. Detail views intentionally use the standard spec/status renderer in this phase.

## Design and correctness

- Curated columns, cells, sorting, and filters share one API-group ownership decision, so colliding kinds such as Job, Queue, PodGroup, Workload, and Workspace do not inherit behavior from core Kubernetes or another vendor.
- Volcano Job remains distinct from `batch/v1` Job across rendering, logs actions, keyboard shortcuts, expanded batch views, and YAML edit guidance. Foreign Jobs with related Pods use per-Pod logs rather than the core Job workload endpoint.
- Kueue Workload remains distinct from the Kubernetes `scheduling.k8s.io/Workload`; the latter stays on generic printer columns and generic status semantics.
- Status adapters follow currently served API shapes, including Kueue conditions, KubeRay condition-first lifecycle, KServe LLMInferenceService versions, current and legacy InferencePool groups, llm-d InferenceObjective groups, KAI scheduling conditions, KAITO readiness, AMD rollout state, and Kubeflow semantic condition precedence.
- TrainJob reports Running only from active child-job evidence; terminal and suspended conditions take precedence. InferenceObjective reports Unknown when no Accepted or Ready evidence exists.
- Normal API discovery supplies these CRDs; no static warmup list or backend endpoint was added.

## Helm

The chart adds 12 default-on `rbac.crdGroups` toggles with matching read-only `get/list/watch` rules, including the released `llm-d.ai` group. Operators can disable each integration independently.

## Validation

- `make tsc`
- `make test`
- `make build`
- `npm test --workspace packages/k8s-ui` — 3,269 passed, 1 skipped
- focused GPU API-contract, ownership, collision, column, filter, and group-routing tests — 563 passed
- Helm chart rendering and real-cluster resource list/detail smoke coverage
- fresh end-to-end visual retest at HEAD `26c892f6` against `radar-test-nonprod`: real Kueue admission/completion, live Volcano scheduling, suspended KubeRay/JobSet/Kubeflow resources, status-rich fixtures for operator-less integrations, collision-separated core/Volcano Jobs, and zero console errors

All nine PR checks pass at HEAD `26c892f6`, including Backend, Frontend, k8s-ui, pkg, Helm, CodeQL, and Bugbot.

## Risk and limitations

- The UI surface is broad, so API-contract and API-group collision fixtures provide the primary regression defense.
- Helm installations gain read-only access to the new CRD API groups by default, with per-integration opt-outs.
- This phase does not inventory physical GPUs, distinguish virtual or fractional GPUs such as HAMi, report utilization, or explain the full workload-to-queue-to-Pod scheduling path.
- This phase does not claim topology, write actions, vendor-specific diagnosis, or typed detail renderers.
- #1524 remains separate: generic printer columns handle uncurated CRDs, while this PR supplies curated columns only for recognized API groups.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, collision-sensitive UI surface plus wider default Helm read RBAC on many CRD API groups; mitigated by ownership tests and API-contract fixtures, with no write/auth changes.
>
> **Overview**
> Adds **basic** reconnaissance for the GPU scheduling, batch, distributed training, and inference-serving stack: curated table columns, status badges/filters, and sidebar grouping for **37 kinds** across Kueue, KubeRay, KServe, Inference Gateway/llm-d, JobSet/LWS, Volcano, KAI, KAITO, NVIDIA NIM, AMD GPU Operator, and Kubeflow training.
>
> The Helm chart gains **12 default-on** `rbac.crdGroups` toggles with matching read-only `get/list/watch` rules (including Kueue + `autoscaling.x-k8s.io` and inference groups). README and `docs/integrations.md` document scope and limits (no GPU accounting or full scheduling-path diagnosis).
>
> `ResourcesView` wires new cell renderers and `resource-utils-*` status helpers, with **API-group ownership** so colliding kinds (`Job`, `Queue`, `PodGroup`, `Workload`, `Workspace`) do not pick up core Kubernetes or another vendor’s columns/filters. **`isCoreBatchJob`** keeps `batch/v1` Job on core logs/YAML/actions while Volcano Jobs use the Volcano path. **`getCellFilterKind`** and stricter curated-column gating avoid mis-routing foreign CRDs that reuse the same plural.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26c892f6b2e6a5fd5230a222cafa317519066e11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
