### PR TITLE
fix(auth): gate /api/connection + /debug/pprof behind authentication

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -132,9 +132,14 @@ func isExemptPath(path string) bool {
 		return false
 	}
 
+	// /api/connection is deliberately NOT exempt: POST /api/connection/retry
+	// is state-changing (kills all exec/port-forward sessions, reinitializes
+	// the informer cache) and GET /api/connection leaks kubeconfig context
+	// names. The terminal re-auth flow that relied on an unauthenticated
+	// retry curl only applies to local no-auth installs, where this
+	// middleware isn't mounted at all.
 	exemptPrefixes := []string{
 		"/api/health",
-		"/api/connection",
 		"/auth/",
 	}
 	for _, prefix := range exemptPrefixes {

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -135,9 +135,8 @@ func isExemptPath(path string) bool {
 	// /api/connection is deliberately NOT exempt: POST /api/connection/retry
 	// is state-changing (kills all exec/port-forward sessions, reinitializes
 	// the informer cache) and GET /api/connection leaks kubeconfig context
-	// names. The terminal re-auth flow that relied on an unauthenticated
-	// retry curl only applies to local no-auth installs, where this
-	// middleware isn't mounted at all.
+	// names. The terminal re-auth flow chains a retry curl only on no-auth
+	// installs, where this middleware isn't mounted at all.
 	exemptPrefixes := []string{
 		"/api/health",
 		"/auth/",
@@ -147,8 +146,13 @@ func isExemptPath(path string) bool {
 			return true
 		}
 	}
-	// Static assets don't require auth
-	if !strings.HasPrefix(path, "/api/") && !strings.HasPrefix(path, "/mcp") {
+	// Static assets don't require auth. /debug/* (pprof) is excluded: it's
+	// mounted on every non-cloud build, and the fallthrough would otherwise
+	// expose it unauthenticated whenever auth is enabled — /debug/pprof/heap
+	// leaks the entire in-memory K8s cache (every Secret, ConfigMap, Pod
+	// spec). /metrics stays open by this fallthrough: operational counters
+	// only, scraped by Prometheus.
+	if !strings.HasPrefix(path, "/api/") && !strings.HasPrefix(path, "/mcp") && !strings.HasPrefix(path, "/debug/") {
 		return true
 	}
 	return false

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -284,13 +284,18 @@ func TestIsExemptPath(t *testing.T) {
 	}{
 		{"/api/health", true},
 		{"/api/health/detailed", true},
-		{"/api/connection", false},
-		{"/api/connection/retry", false},
 		{"/auth/login", true},
 		{"/auth/callback", true},
+		// Static assets are exempt; /debug/* (pprof) is not — it leaks the
+		// in-memory K8s cache and must require auth whenever auth is on.
 		{"/", true},
 		{"/index.html", true},
 		{"/assets/main.js", true},
+		{"/debug/pprof/heap", false},
+		// API paths require auth. /api/connection is non-exempt in both
+		// modes (state-changing retry + kubeconfig context leak).
+		{"/api/connection", false},
+		{"/api/connection/retry", false},
 		{"/api/resources/pods", false},
 		{"/api/topology", false},
 		{"/api/auth/me", false},
@@ -308,10 +313,11 @@ func TestIsExemptPath(t *testing.T) {
 }
 
 // TestIsExemptPath_CloudMode verifies that cloud-mode narrows the exempt
-// set to /api/health + /auth/*. Under cloud-mode, static assets,
-// /api/connection, and /debug/pprof/* must all require auth — a regression
-// that silently re-added them would let an unauthenticated request through
-// the Cloud tunnel reach those paths.
+// set to /api/health + /auth/*. The cloud-mode-specific narrowing is that
+// static assets must also require auth — a regression that silently re-added
+// them would let an unauthenticated request through the Cloud tunnel reach
+// those paths. (/api/connection and /debug/pprof/* require auth in both
+// modes; see TestIsExemptPath.)
 func TestIsExemptPath_CloudMode(t *testing.T) {
 	t.Setenv("RADAR_CLOUD_MODE", "true")
 
@@ -322,10 +328,10 @@ func TestIsExemptPath_CloudMode(t *testing.T) {
 		{"/api/health", true},
 		{"/auth/login", true},
 		{"/auth/callback", true},
-		// Under non-cloud mode static assets would be exempt. Under
-		// cloud-mode they must require auth.
 		{"/api/connection", false},
 		{"/api/connection/retry", false},
+		// Under non-cloud mode static assets would be exempt. Under
+		// cloud-mode they must require auth.
 		{"/", false},
 		{"/index.html", false},
 		{"/assets/main.js", false},

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -42,7 +42,8 @@ func TestMiddleware_ExemptPaths(t *testing.T) {
 		want int
 	}{
 		{"/api/health", http.StatusNoContent},      // exempt
-		{"/api/connection", http.StatusNoContent},   // exempt
+		{"/api/connection", http.StatusUnauthorized},       // requires auth
+		{"/api/connection/retry", http.StatusUnauthorized}, // requires auth — state-changing
 		{"/auth/login", http.StatusNoContent},       // exempt
 		{"/auth/callback", http.StatusNoContent},    // exempt
 		{"/", http.StatusNoContent},                 // static asset — exempt
@@ -283,8 +284,8 @@ func TestIsExemptPath(t *testing.T) {
 	}{
 		{"/api/health", true},
 		{"/api/health/detailed", true},
-		{"/api/connection", true},
-		{"/api/connection/retry", true},
+		{"/api/connection", false},
+		{"/api/connection/retry", false},
 		{"/auth/login", true},
 		{"/auth/callback", true},
 		{"/", true},
@@ -321,8 +322,8 @@ func TestIsExemptPath_CloudMode(t *testing.T) {
 		{"/api/health", true},
 		{"/auth/login", true},
 		{"/auth/callback", true},
-		// Under non-cloud mode these would be exempt. Under cloud-mode
-		// they must require auth.
+		// Under non-cloud mode static assets would be exempt. Under
+		// cloud-mode they must require auth.
 		{"/api/connection", false},
 		{"/api/connection/retry", false},
 		{"/", false},

--- a/internal/server/server_auth_test.go
+++ b/internal/server/server_auth_test.go
@@ -346,7 +346,11 @@ func TestProxyAuth_UnauthenticatedBlocked(t *testing.T) {
 		"/api/events",
 		"/api/changes",
 		"/api/dashboard",
+		"/api/connection",
 		"/mcp",
+		// pprof is mounted on non-cloud builds; the auth middleware must
+		// still gate it (leaks the in-memory K8s cache otherwise).
+		"/debug/pprof/heap",
 	}
 
 	for _, path := range endpoints {
@@ -361,6 +365,19 @@ func TestProxyAuth_UnauthenticatedBlocked(t *testing.T) {
 			}
 		})
 	}
+
+	// POST /api/connection/retry is the reported state-changing endpoint —
+	// assert the mutating verb is gated, not just the GET surface.
+	t.Run("POST /api/connection/retry", func(t *testing.T) {
+		resp, err := http.Post(env.ts.URL+"/api/connection/retry", "application/json", nil)
+		if err != nil {
+			t.Fatalf("POST /api/connection/retry: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", resp.StatusCode)
+		}
+	})
 }
 
 func TestProxyAuth_ExemptPaths(t *testing.T) {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -35,7 +35,7 @@ import { pluralToKind } from '../utils/navigation'
 // and handles 401 responses globally. Merges caller-provided headers with
 // auth headers from the config module so library consumers (Radar Hub) can
 // inject Authorization bearer tokens without each call site knowing.
-function apiFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+export function apiFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
   const headers = new Headers(init?.headers)
   for (const [k, v] of Object.entries(getAuthHeaders())) {
     if (!headers.has(k)) headers.set(k, v)

--- a/web/src/components/ConnectionErrorView.tsx
+++ b/web/src/components/ConnectionErrorView.tsx
@@ -168,16 +168,18 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
   const openLocalTerminal = useOpenLocalTerminal()
   const { data: authMe } = useAuthMe()
 
-  // Auto-retry after successful auth. Only chained when Radar auth is
-  // disabled — with auth enabled the unauthenticated curl would 401 (and
-  // the local-terminal flow can't fix a remote server's credentials anyway).
+  // Auto-retry after successful auth. The terminal shell runs on the server
+  // host, so the auth command itself fixes the server's credentials in every
+  // mode — but the chained retry curl carries no session cookie, so it 401s
+  // once /api/connection is auth-gated. Only chain it when auth is *known*
+  // disabled (authMe still loading → don't chain a doomed call).
   const retryCmd = `curl -s -X POST http://${window.location.host}/api/connection/retry > /dev/null`
 
   const handleAuthInTerminal = () => {
     if (!authInfo?.authCommand) return
-    const cmd = authMe?.authEnabled
-      ? authInfo.authCommand.command
-      : `${authInfo.authCommand.command} && ${retryCmd}`
+    const cmd = authMe?.authEnabled === false
+      ? `${authInfo.authCommand.command} && ${retryCmd}`
+      : authInfo.authCommand.command
     openLocalTerminal({
       initialCommand: cmd,
       title: 'Auth',

--- a/web/src/components/ConnectionErrorView.tsx
+++ b/web/src/components/ConnectionErrorView.tsx
@@ -4,6 +4,7 @@ import type { ConnectionState } from '../context/ConnectionContext'
 import { ContextSwitcher } from './ContextSwitcher'
 import { parseContextName } from '../utils/context-name'
 import { useOpenLocalTerminal, ClusterName } from '@skyhook-io/k8s-ui'
+import { useAuthMe } from '../api/client'
 
 interface ConnectionErrorViewProps {
   connection: ConnectionState
@@ -165,14 +166,20 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
   const authInfo = isAuth ? getAuthHints(connection.context || '') : null
   const errorInfo = authInfo || errorHints[connection.errorType || 'unknown'] || errorHints.unknown
   const openLocalTerminal = useOpenLocalTerminal()
+  const { data: authMe } = useAuthMe()
 
-  // Build a command that auto-retries connection after successful auth
+  // Auto-retry after successful auth. Only chained when Radar auth is
+  // disabled — with auth enabled the unauthenticated curl would 401 (and
+  // the local-terminal flow can't fix a remote server's credentials anyway).
   const retryCmd = `curl -s -X POST http://${window.location.host}/api/connection/retry > /dev/null`
 
   const handleAuthInTerminal = () => {
     if (!authInfo?.authCommand) return
+    const cmd = authMe?.authEnabled
+      ? authInfo.authCommand.command
+      : `${authInfo.authCommand.command} && ${retryCmd}`
     openLocalTerminal({
-      initialCommand: `${authInfo.authCommand.command} && ${retryCmd}`,
+      initialCommand: cmd,
       title: 'Auth',
     })
   }

--- a/web/src/context/ConnectionContext.tsx
+++ b/web/src/context/ConnectionContext.tsx
@@ -1,7 +1,8 @@
 import { createContext, useContext, useState, useCallback, useEffect, useRef, ReactNode } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { ContextInfo } from '../types'
-import { getApiBase, getAuthHeaders, getCredentialsMode } from '../api/config'
+import { getApiBase } from '../api/config'
+import { apiFetch } from '../api/client'
 
 export type ConnectionStateType = 'connected' | 'disconnected' | 'connecting'
 
@@ -29,10 +30,11 @@ interface ConnectionContextValue {
 const ConnectionContext = createContext<ConnectionContextValue | null>(null)
 
 async function fetchConnectionStatus(): Promise<ConnectionStatusResponse> {
-  const response = await fetch(`${getApiBase()}/connection`, {
-    credentials: getCredentialsMode(),
-    headers: getAuthHeaders(),
-  })
+  // apiFetch handles a 401 globally (re-auth redirect). These endpoints are
+  // no longer auth-exempt, so a session that expires while the connection-
+  // error screen is parked open must route through that path rather than
+  // surfacing as a misleading "cannot connect to cluster" error.
+  const response = await apiFetch(`${getApiBase()}/connection`)
   if (!response.ok) {
     throw new Error('Failed to fetch connection status')
   }
@@ -40,10 +42,8 @@ async function fetchConnectionStatus(): Promise<ConnectionStatusResponse> {
 }
 
 async function retryConnection(): Promise<ConnectionState> {
-  const response = await fetch(`${getApiBase()}/connection/retry`, {
+  const response = await apiFetch(`${getApiBase()}/connection/retry`, {
     method: 'POST',
-    credentials: getCredentialsMode(),
-    headers: getAuthHeaders(),
   })
   if (!response.ok) {
     const error = await response.json().catch(() => ({ error: 'Unknown error' }))


### PR DESCRIPTION
## Summary

Closes an unauthenticated state-changing endpoint reported via responsible disclosure, plus a second instance of the same exemption bug found during review.

**Reported issue.** The `/api/connection` prefix was exempt from the auth middleware. On deployments with auth enabled (proxy/OIDC), `POST /api/connection/retry` was reachable unauthenticated — a state-changing endpoint that terminates all active exec and port-forward sessions and reinitializes the informer cache. `GET /api/connection` also leaked kubeconfig context names.

**Second instance (same class, more severe).** The static-asset fallthrough in `isExemptPath` also exempted `/debug/*`, which is mounted on every non-cloud build. On an auth-enabled OSS deployment that left `/debug/pprof/heap` reachable unauthenticated — a full dump of the in-memory K8s cache (every Secret, ConfigMap, Pod spec). Cloud-mode already excluded both; this brings OSS auth-enabled mode in line.

Default local installs are unaffected — the auth middleware isn't mounted when auth is disabled.

## Changes

- `internal/auth/middleware.go` — remove `/api/connection` from `exemptPrefixes`; exclude `/debug/` from the static-asset fallthrough. `/metrics` stays open by the same fallthrough (operational counters, scraped by Prometheus) — now documented as deliberate.
- `internal/auth/middleware_test.go` — exempt-path tables assert `/api/connection`, `/api/connection/retry`, and `/debug/pprof/heap` require auth.
- `internal/server/server_auth_test.go` — `TestProxyAuth_UnauthenticatedBlocked` now exercises the real router (where the vuln actually lived — middleware mounted before the route) for `/api/connection`, `POST /api/connection/retry`, and `/debug/pprof/heap`.
- `web/src/api/client.ts` + `web/src/context/ConnectionContext.tsx` — the connection status/retry fetches used raw `fetch` and bypassed the global 401 handler. Now that these endpoints can 401 (session expiry while parked on the connection-error screen), route them through `apiFetch` so a stale session triggers re-auth instead of a misleading "cannot connect to cluster" dead-end.
- `web/src/components/ConnectionErrorView.tsx` — fail closed on the terminal re-auth curl chain (append the cookieless retry curl only when auth is *known* disabled, not during the `authMe` loading window). Corrected the rationale comment: the local terminal runs on the **server host**, so the auth command fixes the server's credentials in every mode; only the cookieless retry curl 401s once `/api/connection` is gated.

## Why the exemption existed

It shipped with the original auth PR (#214) to support the pre-login connection-status poll and the terminal re-auth curl chain. Both flows only matter in no-auth mode, where the middleware isn't mounted at all — so the exemption was never load-bearing where it applied. The in-app poll and Retry button go through `apiFetch` with session credentials and keep working.

## Testing

- `go test ./internal/auth/ ./internal/server/` — pass
- `make tsc` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security fix for previously unauthenticated state-changing and data-leaking endpoints; frontend changes are narrow but affect session expiry and re-auth flows on connection errors.
> 
> **Overview**
> **Tightens auth exemptions** on auth-enabled deployments so sensitive API and debug routes no longer bypass the middleware.
> 
> `isExemptPath` no longer treats `/api/connection` as public, so unauthenticated callers cannot read kubeconfig context names or hit `POST /api/connection/retry` (session teardown + cache reinit). The static-asset fallthrough now excludes `/debug/*`, closing unauthenticated access to pprof (in-memory K8s cache dump) while leaving `/metrics` open for Prometheus.
> 
> Tests were updated to expect 401s on connection and pprof paths, including a full-router check for `POST /api/connection/retry`.
> 
> On the web side, connection status/retry calls go through exported `apiFetch` so a 401 triggers re-auth instead of a false cluster error. The connection error screen only chains a cookieless retry curl in the terminal when `authMe` confirms auth is disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 436387a3aa5df86028a4e810948c6f4ef6b690a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->