### PR TITLE
fix(chart): bump appVersion to 1.7.6 and add kubevirt RBAC

### DIFF
--- a/deploy/helm/radar/Chart.yaml
+++ b/deploy/helm/radar/Chart.yaml
@@ -3,7 +3,7 @@ name: radar
 description: Modern Kubernetes visibility - topology, traffic, Helm and GitOps management
 type: application
 version: 1.5.10
-appVersion: "1.5.7"
+appVersion: "1.7.6"
 icon: https://radarhq.io/radar/icon-512.png
 keywords:
   - kubernetes
@@ -38,7 +38,7 @@ annotations:
       url: https://radarhq.io/community/chat
   artifacthub.io/images: |
     - name: radar
-      image: ghcr.io/skyhook-io/radar:1.5.7
+      image: ghcr.io/skyhook-io/radar:1.7.6
   artifacthub.io/screenshots: |
     - title: Multi-cluster topology
       url: https://github.com/skyhook-io/radar/raw/main/docs/screenshots/topology-view.png

--- a/deploy/helm/radar/templates/clusterrole.yaml
+++ b/deploy/helm/radar/templates/clusterrole.yaml
@@ -319,6 +319,11 @@ rules:
     resources: ["*"]
     verbs: ["get", "list", "watch"]
   {{- end }}
+  {{- if .Values.rbac.crdGroups.kubevirt }}
+  - apiGroups: ["kubevirt.io", "cdi.kubevirt.io", "clone.kubevirt.io", "export.kubevirt.io", "instancetype.kubevirt.io", "migrations.kubevirt.io", "pool.kubevirt.io", "snapshot.kubevirt.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
   {{- if .Values.rbac.crdGroups.kured }}
   - apiGroups: ["kured.io"]
     resources: ["*"]

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -145,6 +145,7 @@ rbac:
     keda: true              # keda.sh
     knative: true           # serving.knative.dev, eventing.knative.dev, sources/messaging/flows/networking.internal.knative.dev
     kubeshark: true         # kubeshark.io
+    kubevirt: true          # kubevirt.io (VirtualMachines/VMIs) + cdi/clone/export/instancetype/migrations/pool/snapshot.kubevirt.io
     kured: true             # kured.io
     kyverno: true           # kyverno.io, wgpolicyk8s.io, reports.kyverno.io, openreports.io
     mariadb: true           # mariadb.mmontes.io


### PR DESCRIPTION
Two small chart fixes found while deploying the chart in-cluster.

## 1. Stale `appVersion` (1.5.7) breaks fresh installs

`deploy/helm/radar/Chart.yaml` pinned `appVersion` (and the artifacthub image annotation) to **1.5.7**, but the chart templates render flags that only exist in **1.7.x** binaries:

- `--auth-oidc-scopes` (added in #725)
- `--timeline-retention` / `--timeline-max-size` (added in #838)

So `helm install` with chart defaults pulls `ghcr.io/skyhook-io/radar:1.5.7`, and that binary rejects the unknown flags — it prints its usage and exits, so the pod never becomes ready. The failure is opaque (pod stuck `ContainerCreating`/`Terminating`, readiness `connection refused`; only `kubectl logs … | head` reveals `flag provided but not defined: -auth-oidc-scopes`).

Fix: bump `appVersion` and the artifacthub image annotation to **1.7.6** to match the templates. (Chart `version` intentionally left unbumped to avoid colliding with release automation — happy to bump if preferred.)

## 2. Add a `kubevirt` CRD group to the ClusterRole

On clusters running KubeVirt, Radar discovers `kubevirt.io` CRDs and tries to watch them, but the ClusterRole grants no access, producing a steady stream of:

```
kubevirts.kubevirt.io is forbidden: User "system:serviceaccount:radar:radar" cannot watch resource "kubevirts" ... at the cluster scope
```

Added a `crdGroups.kubevirt` toggle (defaulted `true`, consistent with the other CRD groups) granting read-only `get/list/watch` on `kubevirt.io` and its sub-APIs (`cdi`, `clone`, `export`, `instancetype`, `migrations`, `pool`, `snapshot`). Topology/resource-browser now surface KubeVirt VMs instead of logging forbidden-watch errors.

## Diff
- `Chart.yaml`: appVersion + image annotation 1.5.7 → 1.7.6
- `values.yaml`: add `rbac.crdGroups.kubevirt: true`
- `templates/clusterrole.yaml`: conditional kubevirt.io rule

Verified with `helm lint` + `helm template`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chart packaging and read-only CRD RBAC only; no application logic changes, though default image tag changes affect new installs.
> 
> **Overview**
> Aligns the Helm chart’s default container image with what the deployment template actually passes at startup, and adds read-only RBAC for KubeVirt CRDs.
> 
> **`appVersion`** (and the Artifact Hub image annotation) moves from **1.5.7** to **1.7.6** so default installs pull a binary that understands flags the chart already emits (e.g. `--auth-oidc-scopes`, `--timeline-retention` / `--timeline-max-size`). Chart **`version`** is unchanged.
> 
> Adds **`rbac.crdGroups.kubevirt`** (default **true**) and a matching **ClusterRole** rule granting **get/list/watch** on `kubevirt.io` and related sub-API groups, so KubeVirt resources can be watched without forbidden errors on clusters that run KubeVirt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f86e1ae9d09fe37fb21d9c05d319e267fa9d214. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->