### PR TITLE
k8s-ui: export shared Issues and Checks queue primitives

### DIFF
--- a/packages/k8s-ui/src/components/audit/index.ts
+++ b/packages/k8s-ui/src/components/audit/index.ts
@@ -1,3 +1,3 @@
 export { AuditCard, type AuditCardData } from './AuditCard'
 export { AuditAlerts, type AuditFinding } from './AuditAlerts'
-export { AuditFindingsTable, type AuditFindingsTableProps, type ResourceGroup, type CheckMeta } from './AuditFindingsTable'
+export { AuditFindingsTable, type AuditFindingsTableProps, type ResourceGroup, type CheckMeta, type CheckReference } from './AuditFindingsTable'

--- a/packages/k8s-ui/src/components/checks/ChecksView.tsx
+++ b/packages/k8s-ui/src/components/checks/ChecksView.tsx
@@ -255,11 +255,11 @@ export function ChecksView({ checks, catalog, anyData, resourceHref, onResourceC
           </div>
         </div>
 
-        <SeverityBar totals={totals} />
+        <CheckSeverityBar totals={totals} />
 
         <div className="flex flex-wrap items-center gap-1.5">
           {CHECK_SEVERITIES.map((s) => (
-            <SeverityChip key={s} severity={s} count={totals[s]} active={severityFilter.has(s)} onClick={() => toggle(setSeverityFilter, s)} />
+            <CheckSeverityChip key={s} severity={s} count={totals[s]} active={severityFilter.has(s)} onClick={() => toggle(setSeverityFilter, s)} />
           ))}
           <span className="mx-1.5 h-5 w-px bg-theme-border" />
           {CATEGORIES.map((c) => (
@@ -366,7 +366,7 @@ export function ChecksView({ checks, catalog, anyData, resourceHref, onResourceC
   )
 }
 
-function SeverityBar({ totals }: { totals: Record<CheckSeverity, number> }) {
+export function CheckSeverityBar({ totals }: { totals: Record<CheckSeverity, number> }) {
   const sum = CHECK_SEVERITIES.reduce((n, s) => n + totals[s], 0)
   return (
     <div className="flex h-1.5 overflow-hidden rounded-full bg-theme-elevated" role="img" aria-label="Severity distribution">
@@ -381,7 +381,7 @@ function SeverityBar({ totals }: { totals: Record<CheckSeverity, number> }) {
   )
 }
 
-function SeverityChip({ severity, count, active, onClick }: { severity: CheckSeverity; count: number; active: boolean; onClick: () => void }) {
+export function CheckSeverityChip({ severity, count, active, onClick }: { severity: CheckSeverity; count: number; active: boolean; onClick: () => void }) {
   return (
     <button
       type="button"
@@ -396,6 +396,242 @@ function SeverityChip({ severity, count, active, onClick }: { severity: CheckSev
       <span className={`font-semibold tabular-nums ${count > 0 ? SEVERITY_TEXT_CLASS[severity] : 'text-theme-text-tertiary'}`}>{count}</span>
       <span>{SEVERITY_LABEL[severity]}</span>
     </button>
+  )
+}
+
+export interface CheckReference {
+  label: string
+  url: string
+}
+
+export interface CheckRemediationBlockProps {
+  description?: string
+  remediation?: string
+  references?: CheckReference[]
+  layout?: 'columns' | 'stack'
+}
+
+export function CheckRemediationBlock({ description, remediation, references, layout = 'columns' }: CheckRemediationBlockProps) {
+  if (!description && !remediation && (!references || references.length === 0)) return null
+
+  if (layout === 'stack') {
+    return (
+      <div className="flex flex-col gap-2">
+        {description && <p className="text-[13px] leading-relaxed text-theme-text-secondary">{description}</p>}
+        {remediation && (
+          <div>
+            <div className="text-[11px] uppercase tracking-wider text-theme-text-tertiary">How to fix</div>
+            <p className="mt-0.5 text-[13px] leading-relaxed text-theme-text-secondary">{remediation}</p>
+          </div>
+        )}
+        {references && references.length > 0 && <CheckReferenceLinks references={references} />}
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <div className="flex flex-col gap-4 md:flex-row md:gap-8">
+        {remediation && (
+          <section className="md:flex-1">
+            <h4 className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-[var(--color-radar-accent)]">
+              <Wrench className="h-3.5 w-3.5" /> How to fix
+            </h4>
+            <p className="text-sm leading-relaxed text-theme-text-primary">{remediation}</p>
+          </section>
+        )}
+        {description && (
+          <section className="md:flex-1">
+            <h4 className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-theme-text-tertiary">What this checks</h4>
+            <p className="text-sm leading-relaxed text-theme-text-secondary">{description}</p>
+          </section>
+        )}
+      </div>
+      {references && references.length > 0 && <CheckReferenceLinks references={references} />}
+    </>
+  )
+}
+
+function CheckReferenceLinks({ references }: { references: CheckReference[] }) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5">
+      {references.map((r) => (
+        <a
+          key={r.url}
+          href={r.url}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center gap-1 text-xs font-medium text-[var(--color-radar-accent)] hover:underline"
+        >
+          {r.label}
+          <ExternalLink className="h-3 w-3" />
+        </a>
+      ))}
+    </div>
+  )
+}
+
+export interface CheckCardShellProps {
+  title: ReactNode
+  category: string
+  severity: CheckSeverity
+  open: boolean
+  onToggle: () => void
+  summary?: ReactNode
+  description?: ReactNode
+  renderActions?: () => ReactNode
+  children?: ReactNode
+  as?: 'li' | 'div'
+  className?: string
+  dimmed?: boolean
+}
+
+export function CheckCardShell({
+  title,
+  category,
+  severity,
+  open,
+  onToggle,
+  summary,
+  description,
+  renderActions,
+  children,
+  as = 'li',
+  className,
+  dimmed,
+}: CheckCardShellProps) {
+  const Container = as
+  return (
+    <Container
+      className={[
+        'overflow-hidden rounded-xl border border-theme-border bg-theme-surface shadow-theme-sm',
+        dimmed ? 'opacity-60' : '',
+        className ?? '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={open}
+        onClick={onToggle}
+        onKeyDown={(e) => {
+          if (e.target !== e.currentTarget) return
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            onToggle()
+          }
+        }}
+        className={`group flex cursor-pointer items-start gap-3 border-l-2 py-3 pl-3 pr-4 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-radar-accent)]/40 ${SEVERITY_RAIL_CLASS[severity]}`}
+      >
+        <ChevronRight className={`mt-0.5 h-4 w-4 shrink-0 text-theme-text-tertiary transition-transform duration-200 ${open ? 'rotate-90' : ''}`} />
+
+        <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="truncate text-sm font-semibold text-theme-text-primary">{title}</span>
+            <span className={`badge-sm shrink-0 text-[10px] ${categoryBadgeClass(category)}`}>{category}</span>
+          </div>
+          {description}
+          {summary}
+        </div>
+
+        <span className={`badge-sm mt-0.5 shrink-0 text-[10px] font-semibold ${SEVERITY_BADGE_CLASS[severity]}`}>
+          {SEVERITY_LABEL[severity]}
+        </span>
+        {renderActions?.()}
+      </div>
+
+      {open && (
+        <div className="grid transition-[grid-template-rows] duration-200 ease-out" style={{ gridTemplateRows: '1fr' }}>
+          <div className="overflow-hidden">
+            <div className="flex flex-col gap-4 border-t border-theme-border bg-theme-base/40 px-4 py-4 pl-11">{children}</div>
+          </div>
+        </div>
+      )}
+    </Container>
+  )
+}
+
+export interface CheckClusterBreakdownGroup {
+  id: string
+  label: ReactNode
+  environment?: string
+  count: ReactNode
+}
+
+export interface CheckClusterBreakdownShellProps<T extends CheckClusterBreakdownGroup> {
+  heading: ReactNode
+  groups: T[]
+  renderGroupBody: (group: T) => ReactNode
+  clusterCap?: number
+  autoExpandLimit?: number
+}
+
+export function CheckClusterBreakdownShell<T extends CheckClusterBreakdownGroup>({
+  heading,
+  groups,
+  renderGroupBody,
+  clusterCap = CLUSTER_CAP,
+  autoExpandLimit = AUTO_EXPAND_CLUSTERS,
+}: CheckClusterBreakdownShellProps<T>) {
+  const [openClusters, setOpenClusters] = useState<Set<string>>(
+    () => new Set(groups.length <= autoExpandLimit ? groups.map((g) => g.id) : []),
+  )
+  const [showAllClusters, setShowAllClusters] = useState(false)
+  const shown = showAllClusters ? groups : groups.slice(0, clusterCap)
+  const hiddenClusters = groups.length - shown.length
+
+  return (
+    <section className="flex flex-col gap-1.5">
+      <h4 className="text-[11px] font-semibold uppercase tracking-wide text-theme-text-tertiary">{heading}</h4>
+      <ul className="flex flex-col gap-1">
+        {shown.map((group) => {
+          const isOpen = openClusters.has(group.id)
+          return (
+            <li key={group.id} className="rounded-lg border border-theme-border/70 bg-theme-surface">
+              <button
+                type="button"
+                aria-expanded={isOpen}
+                onClick={() =>
+                  setOpenClusters((prev) => {
+                    const next = new Set(prev)
+                    if (next.has(group.id)) next.delete(group.id)
+                    else next.add(group.id)
+                    return next
+                  })
+                }
+                className="flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left transition-colors hover:bg-theme-hover/50"
+              >
+                <ChevronDown className={`h-3.5 w-3.5 shrink-0 text-theme-text-tertiary transition-transform duration-200 ${isOpen ? '' : '-rotate-90'}`} />
+                <span className="min-w-0 max-w-[260px] truncate text-sm font-medium text-theme-text-primary">{group.label}</span>
+                {group.environment && (
+                  <span className="shrink-0 rounded bg-theme-elevated px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-theme-text-secondary ring-1 ring-theme-border">
+                    {group.environment}
+                  </span>
+                )}
+                <span className="flex-1" />
+                <span className="shrink-0 text-xs tabular-nums text-theme-text-secondary">{group.count}</span>
+              </button>
+              <div className="grid transition-[grid-template-rows] duration-200 ease-out" style={{ gridTemplateRows: isOpen ? '1fr' : '0fr' }}>
+                <div className="overflow-hidden" inert={!isOpen || undefined}>
+                  <div className="px-2.5 pb-2 pl-7">{renderGroupBody(group)}</div>
+                </div>
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+      {hiddenClusters > 0 && (
+        <button
+          type="button"
+          onClick={() => setShowAllClusters(true)}
+          className="mt-0.5 inline-flex w-fit items-center gap-1 rounded px-2 py-1 text-xs font-medium text-[var(--color-radar-accent)] hover:underline"
+        >
+          View all {groups.length} clusters →
+        </button>
+      )}
+    </section>
   )
 }
 
@@ -428,102 +664,42 @@ function FleetCheckRow({
   if (onHideCategory) menuItems.push({ label: `Hide all ${fc.category} checks`, onClick: () => onHideCategory(fc.category) })
 
   return (
-    <li className="overflow-hidden rounded-xl border border-theme-border bg-theme-surface shadow-theme-sm">
-      <div
-        role="button"
-        tabIndex={0}
-        aria-expanded={open}
-        onClick={onToggle}
-        onKeyDown={(e) => {
-          if (e.target !== e.currentTarget) return
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault()
-            onToggle()
-          }
-        }}
-        className={`group flex cursor-pointer items-center gap-3 border-l-2 py-3 pl-3 pr-4 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-radar-accent)]/40 ${SEVERITY_RAIL_CLASS[fc.severity]}`}
-      >
-        <ChevronRight className={`h-4 w-4 shrink-0 text-theme-text-tertiary transition-transform duration-200 ${open ? 'rotate-90' : ''}`} />
-
-        <div className="flex min-w-0 flex-1 flex-col gap-1">
-          <div className="flex items-center gap-2">
-            <span className="truncate text-sm font-medium text-theme-text-primary">{fc.title}</span>
-            <span className={`badge-sm shrink-0 text-[10px] ${categoryBadgeClass(fc.category)}`}>{fc.category}</span>
-          </div>
-          <div className="flex min-w-0 items-center gap-1.5 text-xs text-theme-text-tertiary">
-            <span className="shrink-0 font-medium text-theme-text-secondary tabular-nums">
-              {fc.totalResources} {fc.totalResources === 1 ? 'resource' : 'resources'}
-            </span>
-            {clusterCount > 1 && (
-              <>
-                <span aria-hidden>·</span>
-                <span className="shrink-0 tabular-nums">{clusterCount} clusters</span>
-              </>
-            )}
-          </div>
+    <CheckCardShell
+      title={fc.title}
+      category={fc.category}
+      severity={fc.severity}
+      open={open}
+      onToggle={onToggle}
+      summary={
+        <div className="flex min-w-0 items-center gap-1.5 text-xs text-theme-text-tertiary">
+          <span className="shrink-0 font-medium text-theme-text-secondary tabular-nums">
+            {fc.totalResources} {fc.totalResources === 1 ? 'resource' : 'resources'}
+          </span>
+          {clusterCount > 1 && (
+            <>
+              <span aria-hidden>·</span>
+              <span className="shrink-0 tabular-nums">{clusterCount} clusters</span>
+            </>
+          )}
         </div>
+      }
+      renderActions={() => (menuItems.length > 0 ? <RowMenu items={menuItems} /> : null)}
+    >
+      <CheckRemediationBlock description={meta?.description} remediation={meta?.remediation} references={meta?.references} />
 
-        <span className={`badge-sm shrink-0 text-[10px] font-semibold ${SEVERITY_BADGE_CLASS[fc.severity]}`}>{SEVERITY_LABEL[fc.severity]}</span>
-        {menuItems.length > 0 && <RowMenu items={menuItems} />}
+      <div className="border-t border-theme-border/70 pt-3">
+        {single ? (
+          <ResourceList
+            label={`Affected resources (${fc.totalResources})`}
+            check={fc.clusters[0]}
+            resourceHref={resourceHref}
+            onResourceClick={onResourceClick}
+          />
+        ) : (
+          <ClusterBreakdown fc={fc} clusterLabel={clusterLabel} resourceHref={resourceHref} onResourceClick={onResourceClick} />
+        )}
       </div>
-
-      {/* Kept mounted (not `open &&`) so the grid-rows transition animates the
-          collapse too; inert when closed so SR + tab skip the clipped content. */}
-      <div className="grid transition-[grid-template-rows] duration-200 ease-out" style={{ gridTemplateRows: open ? '1fr' : '0fr' }}>
-        <div className="overflow-hidden" inert={!open || undefined}>
-          <div className="border-t border-theme-border bg-theme-base/40 px-4 py-4 pl-11">
-            <div className="flex flex-col gap-4">
-              <div className="flex flex-col gap-4 md:flex-row md:gap-8">
-                {meta?.remediation && (
-                  <section className="md:flex-1">
-                    <h4 className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-[var(--color-radar-accent)]">
-                      <Wrench className="h-3.5 w-3.5" /> How to fix
-                    </h4>
-                    <p className="text-sm leading-relaxed text-theme-text-primary">{meta.remediation}</p>
-                  </section>
-                )}
-                {meta?.description && (
-                  <section className="md:flex-1">
-                    <h4 className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-theme-text-tertiary">What this checks</h4>
-                    <p className="text-sm leading-relaxed text-theme-text-secondary">{meta.description}</p>
-                  </section>
-                )}
-              </div>
-
-              {meta?.references && meta.references.length > 0 && (
-                <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5">
-                  {meta.references.map((r) => (
-                    <a
-                      key={r.url}
-                      href={r.url}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="inline-flex items-center gap-1 text-xs font-medium text-[var(--color-radar-accent)] hover:underline"
-                    >
-                      {r.label}
-                      <ExternalLink className="h-3 w-3" />
-                    </a>
-                  ))}
-                </div>
-              )}
-
-              <div className="border-t border-theme-border/70 pt-3">
-                {single ? (
-                  <ResourceList
-                    label={`Affected resources (${fc.totalResources})`}
-                    check={fc.clusters[0]}
-                    resourceHref={resourceHref}
-                    onResourceClick={onResourceClick}
-                  />
-                ) : (
-                  <ClusterBreakdown fc={fc} clusterLabel={clusterLabel} resourceHref={resourceHref} onResourceClick={onResourceClick} />
-                )}
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </li>
+    </CheckCardShell>
   )
 }
 
@@ -542,73 +718,24 @@ function ClusterBreakdown({
   resourceHref?: (ref: CheckResourceRef) => string
   onResourceClick?: (ref: CheckResourceRef) => void
 }) {
-  const [openClusters, setOpenClusters] = useState<Set<string>>(
-    () => new Set(fc.clusters.length <= AUTO_EXPAND_CLUSTERS ? fc.clusters.map((c) => c.subject.cluster_id) : []),
-  )
-  const [showAllClusters, setShowAllClusters] = useState(false)
-  const shown = showAllClusters ? fc.clusters : fc.clusters.slice(0, CLUSTER_CAP)
-  const hiddenClusters = fc.clusters.length - shown.length
-
   return (
-    <section className="flex flex-col gap-1.5">
-      <h4 className="text-[11px] font-semibold uppercase tracking-wide text-theme-text-tertiary">
-        Affected resources <span className="tabular-nums">({fc.totalResources})</span> · {fc.clusters.length} clusters
-      </h4>
-      <ul className="flex flex-col gap-1">
-        {shown.map((c) => {
-          const id = c.subject.cluster_id
-          const isOpen = openClusters.has(id)
-          const env = c.environment
-          return (
-            <li key={id} className="rounded-lg border border-theme-border/70 bg-theme-surface">
-              <button
-                type="button"
-                aria-expanded={isOpen}
-                onClick={() =>
-                  setOpenClusters((prev) => {
-                    const next = new Set(prev)
-                    if (next.has(id)) next.delete(id)
-                    else next.add(id)
-                    return next
-                  })
-                }
-                className="flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left transition-colors hover:bg-theme-hover/50"
-              >
-                <ChevronDown className={`h-3.5 w-3.5 shrink-0 text-theme-text-tertiary transition-transform duration-200 ${isOpen ? '' : '-rotate-90'}`} />
-                <span className="min-w-0 max-w-[260px] truncate text-sm font-medium text-theme-text-primary">
-                  <ClusterName name={clusterLabel?.(c) || id} />
-                </span>
-                {env && (
-                  <span className="shrink-0 rounded bg-theme-elevated px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-theme-text-secondary ring-1 ring-theme-border">
-                    {env}
-                  </span>
-                )}
-                <span className="flex-1" />
-                <span className="shrink-0 text-xs tabular-nums text-theme-text-secondary">
-                  {c.affectedResources} {c.affectedResources === 1 ? 'resource' : 'resources'}
-                </span>
-              </button>
-              <div className="grid transition-[grid-template-rows] duration-200 ease-out" style={{ gridTemplateRows: isOpen ? '1fr' : '0fr' }}>
-                <div className="overflow-hidden" inert={!isOpen || undefined}>
-                  <div className="px-2.5 pb-2 pl-7">
-                    <ResourceList check={c} resourceHref={resourceHref} onResourceClick={onResourceClick} />
-                  </div>
-                </div>
-              </div>
-            </li>
-          )
-        })}
-      </ul>
-      {hiddenClusters > 0 && (
-        <button
-          type="button"
-          onClick={() => setShowAllClusters(true)}
-          className="mt-0.5 inline-flex w-fit items-center gap-1 rounded px-2 py-1 text-xs font-medium text-[var(--color-radar-accent)] hover:underline"
-        >
-          View all {fc.clusters.length} clusters →
-        </button>
+    <CheckClusterBreakdownShell
+      heading={
+        <>
+          Affected resources <span className="tabular-nums">({fc.totalResources})</span> · {fc.clusters.length} clusters
+        </>
+      }
+      groups={fc.clusters.map((c) => ({
+        id: c.subject.cluster_id,
+        label: <ClusterName name={clusterLabel?.(c) || c.subject.cluster_id} />,
+        environment: c.environment,
+        count: `${c.affectedResources} ${c.affectedResources === 1 ? 'resource' : 'resources'}`,
+        check: c,
+      }))}
+      renderGroupBody={(group) => (
+        <ResourceList check={group.check} resourceHref={resourceHref} onResourceClick={onResourceClick} />
       )}
-    </section>
+    />
   )
 }
 

--- a/packages/k8s-ui/src/components/checks/ChecksView.tsx
+++ b/packages/k8s-ui/src/components/checks/ChecksView.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import { ChevronDown, ChevronRight, ExternalLink, EyeOff, MoreHorizontal, Search, ShieldCheck, Wrench, X } from 'lucide-react'
 import { ClusterName, EmptyState, FilterPill } from '../ui'
-import type { CheckMeta } from '../audit'
+import type { CheckMeta, CheckReference } from '../audit'
 import { CHECK_SEVERITIES, CHECK_SEVERITY_RANK, type Check, type CheckSeverity, type EffectiveCheckFinding, type CheckResourceRef } from './types'
 import {
   SEVERITY_BADGE_CLASS,
@@ -399,10 +399,9 @@ export function CheckSeverityChip({ severity, count, active, onClick }: { severi
   )
 }
 
-export interface CheckReference {
-  label: string
-  url: string
-}
+// Re-export the audit CheckReference (single source of truth) — CheckMeta.references
+// is typed against this same shape, so the two must not drift apart.
+export type { CheckReference }
 
 export interface CheckRemediationBlockProps {
   description?: string
@@ -542,13 +541,14 @@ export function CheckCardShell({
         {renderActions?.()}
       </div>
 
-      {open && (
-        <div className="grid transition-[grid-template-rows] duration-200 ease-out" style={{ gridTemplateRows: '1fr' }}>
-          <div className="overflow-hidden">
-            <div className="flex flex-col gap-4 border-t border-theme-border bg-theme-base/40 px-4 py-4 pl-11">{children}</div>
-          </div>
+      {/* Kept mounted (not `open &&`) so the grid-rows transition animates the
+          collapse too, matching IssueRow; inert when closed so SR + tab skip
+          the clipped content. */}
+      <div className="grid transition-[grid-template-rows] duration-200 ease-out" style={{ gridTemplateRows: open ? '1fr' : '0fr' }}>
+        <div className="overflow-hidden" inert={!open || undefined}>
+          <div className="flex flex-col gap-4 border-t border-theme-border bg-theme-base/40 px-4 py-4 pl-11">{children}</div>
         </div>
-      )}
+      </div>
     </Container>
   )
 }

--- a/packages/k8s-ui/src/components/checks/index.ts
+++ b/packages/k8s-ui/src/components/checks/index.ts
@@ -1,3 +1,16 @@
-export { ChecksView, type ChecksViewProps } from './ChecksView'
+export {
+  CheckCardShell,
+  CheckClusterBreakdownShell,
+  CheckRemediationBlock,
+  CheckSeverityBar,
+  CheckSeverityChip,
+  ChecksView,
+  type CheckCardShellProps,
+  type CheckClusterBreakdownGroup,
+  type CheckClusterBreakdownShellProps,
+  type CheckReference,
+  type CheckRemediationBlockProps,
+  type ChecksViewProps,
+} from './ChecksView'
 export * from './types'
 export * from './severity'

--- a/packages/k8s-ui/src/components/issues/IssuesView.tsx
+++ b/packages/k8s-ui/src/components/issues/IssuesView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useState, type ComponentType, type ReactNode } from 'react';
 import { ChevronRight, CircleCheck, Clock, ExternalLink } from 'lucide-react';
 import { ClusterName, EmptyState } from '../ui';
 import { formatCompactAge, formatRelativeAgeTime } from '../../utils/format';
@@ -90,25 +90,48 @@ export function IssuesView({ issues, anyData, resourceHref, onResourceClick, clu
   );
 }
 
-function IssueRow({
-  issue,
-  clusterLabel,
-  open,
-  onToggle,
-  resourceHref,
-  onResourceClick,
-}: {
+export interface IssueRowSlotContext {
+  issue: Issue;
+  open: boolean;
+}
+
+export interface IssueRowProps {
   issue: Issue;
   clusterLabel?: (issue: Issue) => string | undefined;
   open: boolean;
   onToggle: () => void;
   resourceHref?: (ref: IssueResourceRef) => string;
   onResourceClick?: (ref: IssueResourceRef) => void;
-}) {
+  as?: 'li' | 'div';
+  className?: string;
+  dimmed?: boolean;
+  renderBadges?: (ctx: IssueRowSlotContext) => ReactNode;
+  renderMeta?: (ctx: IssueRowSlotContext) => ReactNode;
+  renderActions?: (ctx: IssueRowSlotContext) => ReactNode;
+  ResourceLinkIcon?: ComponentType<{ className?: string }>;
+}
+
+export function IssueRow({
+  issue,
+  clusterLabel,
+  open,
+  onToggle,
+  resourceHref,
+  onResourceClick,
+  as = 'li',
+  className,
+  dimmed,
+  renderBadges,
+  renderMeta,
+  renderActions,
+  ResourceLinkIcon = ExternalLink,
+}: IssueRowProps) {
   const cluster = clusterLabel?.(issue);
   const affected = affectedSummary(issue.affected);
   const { headline } = issueMessageParts(issue);
   const [renderDetails, setRenderDetails] = useState(open);
+  const Container = as;
+  const slotCtx = { issue, open };
 
   useEffect(() => {
     if (open) {
@@ -122,8 +145,12 @@ function IssueRow({
   }, [open, renderDetails]);
 
   return (
-    <li
-      className="overflow-hidden rounded-xl border border-theme-border bg-theme-surface shadow-theme-sm"
+    <Container
+      className={[
+        'overflow-hidden rounded-xl border border-theme-border bg-theme-surface shadow-theme-sm',
+        dimmed ? 'opacity-60' : '',
+        className ?? '',
+      ].filter(Boolean).join(' ')}
       style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 72px' }}
     >
       {/* The whole header is the single toggle target — chevron is just the
@@ -149,6 +176,7 @@ function IssueRow({
           <div className="flex min-w-0 items-baseline gap-2">
             <span className="shrink-0 text-sm font-medium text-theme-text-primary">{categoryLabel(issue.category)}</span>
             <span className={`badge-sm shrink-0 self-center text-[10px] ${groupBadgeClass(issue.category_group)}`}>{groupLabel(issue.category_group)}</span>
+            {renderBadges?.(slotCtx)}
             {/* The detector reason/message rides the title row so the most
                 useful triage signal is visible without expanding — it fills
                 the otherwise-empty band between the title and the severity
@@ -180,6 +208,7 @@ function IssueRow({
                 <span className="shrink-0 tabular-nums">{affected}</span>
               </>
             ) : null}
+            {renderMeta?.(slotCtx)}
           </div>
         </div>
 
@@ -203,6 +232,7 @@ function IssueRow({
         <span className={`badge-sm shrink-0 text-[10px] font-semibold ${ISSUE_SEVERITY_BADGE_CLASS[issue.severity]}`}>
           {ISSUE_SEVERITY_LABEL[issue.severity]}
         </span>
+        {renderActions?.(slotCtx)}
       </div>
 
       {renderDetails ? (
@@ -218,16 +248,16 @@ function IssueRow({
             <div className="border-t border-theme-border bg-theme-base/40 px-4 py-4 pl-11">
               <div className="flex flex-col gap-4">
                 <Diagnosis issue={issue} />
-                <DiagnosticContext issue={issue} resourceHref={resourceHref} onResourceClick={onResourceClick} />
+                <DiagnosticContext issue={issue} resourceHref={resourceHref} onResourceClick={onResourceClick} ResourceLinkIcon={ResourceLinkIcon} />
                 <div className="border-t border-theme-border/70 pt-3">
-                  <AffectedResources issue={issue} resourceHref={resourceHref} onResourceClick={onResourceClick} />
+                  <AffectedResources issue={issue} resourceHref={resourceHref} onResourceClick={onResourceClick} ResourceLinkIcon={ResourceLinkIcon} />
                 </div>
               </div>
             </div>
           </div>
         </div>
       ) : null}
-    </li>
+    </Container>
   );
 }
 
@@ -316,10 +346,12 @@ function DiagnosticContext({
   issue,
   resourceHref,
   onResourceClick,
+  ResourceLinkIcon,
 }: {
   issue: Issue;
   resourceHref?: (ref: IssueResourceRef) => string;
   onResourceClick?: (ref: IssueResourceRef) => void;
+  ResourceLinkIcon: ComponentType<{ className?: string }>;
 }) {
   const ctx = issue.diagnostic_context;
   const facts = ctx?.facts?.filter((fact) => fact.message || fact.refs?.length || fact.related_issues?.length) ?? [];
@@ -347,6 +379,7 @@ function DiagnosticContext({
                     refForLink={memberRef(issue, related.ref)}
                     resourceHref={resourceHref}
                     onResourceClick={onResourceClick}
+                    ResourceLinkIcon={ResourceLinkIcon}
                   />
                 ))}
               </ul>
@@ -359,6 +392,7 @@ function DiagnosticContext({
                     refForLink={memberRef(issue, ref)}
                     resourceHref={resourceHref}
                     onResourceClick={onResourceClick}
+                    ResourceLinkIcon={ResourceLinkIcon}
                   />
                 ))}
               </ul>
@@ -424,10 +458,12 @@ function AffectedResources({
   issue,
   resourceHref,
   onResourceClick,
+  ResourceLinkIcon,
 }: {
   issue: Issue;
   resourceHref?: (ref: IssueResourceRef) => string;
   onResourceClick?: (ref: IssueResourceRef) => void;
+  ResourceLinkIcon: ComponentType<{ className?: string }>;
 }) {
   const members = issue.members ?? [];
   // count is the backend fan-out size (members, subject excluded — see
@@ -439,7 +475,7 @@ function AffectedResources({
           first deep-link; members (the folded pods) follow. ResourceLine emits
           an <li>, so it needs a list parent of its own. */}
       <ul className="flex flex-col gap-px">
-        <ResourceLine label="Subject" refForLink={subjectRef(issue)} resourceHref={resourceHref} onResourceClick={onResourceClick} />
+        <ResourceLine label="Subject" refForLink={subjectRef(issue)} resourceHref={resourceHref} onResourceClick={onResourceClick} ResourceLinkIcon={ResourceLinkIcon} />
       </ul>
       {members.length > 0 && (
         <>
@@ -453,6 +489,7 @@ function AffectedResources({
                 refForLink={memberRef(issue, m)}
                 resourceHref={resourceHref}
                 onResourceClick={onResourceClick}
+                ResourceLinkIcon={ResourceLinkIcon}
               />
             ))}
           </ul>
@@ -472,11 +509,13 @@ function ResourceLine({
   refForLink,
   resourceHref,
   onResourceClick,
+  ResourceLinkIcon,
 }: {
   label?: string;
   refForLink: IssueResourceRef;
   resourceHref?: (ref: IssueResourceRef) => string;
   onResourceClick?: (ref: IssueResourceRef) => void;
+  ResourceLinkIcon: ComponentType<{ className?: string }>;
 }) {
   const r = refForLink;
   const linkable = !!(onResourceClick || resourceHref);
@@ -488,7 +527,7 @@ function ResourceLine({
         {r.namespace ? `${r.namespace} / ` : ''}
         {r.name}
       </span>
-      {linkable && <ExternalLink className="h-3 w-3 shrink-0 text-theme-text-tertiary opacity-0 transition-opacity group-hover/r:opacity-100" />}
+      {linkable && <ResourceLinkIcon className="h-3 w-3 shrink-0 text-theme-text-tertiary opacity-0 transition-opacity group-hover/r:opacity-100" />}
     </>
   );
   const cls = 'group/r flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-sm transition-colors hover:bg-theme-hover/60';

--- a/packages/k8s-ui/src/components/issues/index.ts
+++ b/packages/k8s-ui/src/components/issues/index.ts
@@ -2,8 +2,8 @@
 // module-internal and don't collide at the top-level barrel with the Checks
 // queue's identically-named helpers when both land. Issue-prefixed public
 // names are safe to surface.
-export { IssuesView } from './IssuesView';
-export type { IssuesViewProps } from './IssuesView';
+export { IssueRow, IssuesView } from './IssuesView';
+export type { IssueRowProps, IssueRowSlotContext, IssuesViewProps } from './IssuesView';
 export {
   ISSUE_SEVERITIES,
   ISSUE_SEVERITY_RANK,


### PR DESCRIPTION
Exports reusable Issues and Checks queue primitives from @skyhook-io/k8s-ui so Hub can reuse the OSS presentation instead of maintaining divergent copies.

IssueRow now accepts host slots for badges, metadata, actions, wrapper element, dimming, and resource-link icon overrides. Checks now exposes the severity bar/chip, card shell, remediation block, and cluster breakdown shell; the OSS ChecksView uses those same primitives internally so the exported API stays exercised by Radar itself.

This is the OSS side of skyhook-dev/radar-hub-web#104. After this lands, publish a new k8s-ui tag and bump Hub web to that package version before merging the Hub web reuse commit.

Verified:
- npm run tsc in packages/k8s-ui
- npm test in packages/k8s-ui
- Visual pass through Hub web against the mirrored local package

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-layer refactor and new public exports only; OSS views still use the same components internally, with no auth or data-path changes.
> 
> **Overview**
> Exports reusable **Issues** and **Checks** queue UI from `@skyhook-io/k8s-ui` so Hub can share Radar’s presentation instead of forked copies.
> 
> **Checks:** Renames and exports `CheckSeverityBar` / `CheckSeverityChip`, and adds shared **`CheckCardShell`**, **`CheckRemediationBlock`** (column or stack layout), and generic **`CheckClusterBreakdownShell`**. OSS `FleetCheckRow` is refactored to compose those primitives internally. **`CheckReference`** is re-exported from audit and surfaced on the checks barrel so reference typing stays aligned with `CheckMeta`.
> 
> **Issues:** **`IssueRow`** is exported with host slots (`renderBadges`, `renderMeta`, `renderActions`), optional wrapper (`as`, `className`, `dimmed`), and a pluggable **`ResourceLinkIcon`** for resource deep-links.
> 
> **Barrels:** `checks/index` and `issues/index` widen explicit exports; audit barrel adds `CheckReference`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f312cf000e2ca96bacd3bded9e331a706c7b77ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->