### PR TITLE
feat(k8s): configurable deadlines for context switch, first paint, namespace LIST and scope fanout

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ radar
 | `--disable-local-terminal` | `false` | Disable local terminal feature |
 | `--debug-image` | `busybox:latest` | Image for ephemeral debug containers and node debug pods. Point at a mirror for air-gapped / private-registry clusters. |
 | `--list-page-size` | `0` (off) | Paginate the initial LIST of high-cardinality kinds (Pods, ReplicaSets) at this size. Helps very large clusters that fail to sync; only used when WatchList streaming is unavailable. Try `2000`. |
+| `--context-switch-timeout` | `30s` | Maximum time a kubeconfig context switch may take. Widen on high-latency control planes — see [Tuning for slow clusters](#tuning-for-slow-or-high-latency-clusters). Env: `RADAR_CONTEXT_SWITCH_TIMEOUT`. |
+| `--first-paint-backstop` | `5m` | Hard upper bound on the initial critical-cache sync wait before Radar falls through to a partial-data render. Env: `RADAR_FIRST_PAINT_BACKSTOP`. |
+| `--namespace-list-timeout` | `5s` | Timeout for the cluster-wide namespace LIST used to decide if the user is RBAC-namespace-restricted. A timeout on a slow control plane is misreported in the UI as "Limited list — RBAC". Env: `RADAR_NAMESPACE_LIST_TIMEOUT`. |
+| `--max-scope-candidates` | `20` | Cap on the namespace-fallback probe fanout (used by accounts that can list namespaces cluster-wide but not list a specific kind cluster-wide). Raise above `20` for clusters with more than 20 namespaces. Env: `RADAR_MAX_SCOPE_CANDIDATES`. |
 | `--prometheus-url` | (auto-discover) | Manual Prometheus/VictoriaMetrics URL (skips auto-discovery) |
 | `--prometheus-header` | | HTTP header sent with every Prometheus request, format `Key=Value` (repeatable). Required for auth-protected backends. |
 | `--prometheus-header-from-env` | | HTTP header sent with every Prometheus request, sourced from an environment variable, format `Key=ENV_VAR` (repeatable). |
@@ -156,6 +160,45 @@ radar
 | `--version` | | Show version and exit |
 
 See [Configuration Guide](docs/configuration.md) for details on cluster connection precedence, multiple kubeconfig files, and context switching.
+
+### Tuning for slow or high-latency clusters
+
+The default deadlines (30 s context switch, 5 m first-paint backstop, 5 s
+namespace LIST, 20 scope candidates) are tuned for healthy clusters reached
+over fast, low-latency connections. They are too tight for clusters reached
+over SSH tunnels, geographically distant control planes, or accounts subject
+to API-server throttling, where they surface as one of three symptoms:
+
+- "Context switch timed out" toasts when the cache eventually does sync
+- "Limited list — RBAC doesn't allow listing all namespaces" even though the
+  account has cluster-wide list permission (the LIST timed out, not RBAC)
+- Kinds silently marked denied because the namespace they live in fell past
+  the 20-entry candidate cap
+
+Widen the four flags via CLI or via the matching environment variables
+(`RADAR_CONTEXT_SWITCH_TIMEOUT`, `RADAR_FIRST_PAINT_BACKSTOP`,
+`RADAR_NAMESPACE_LIST_TIMEOUT`, `RADAR_MAX_SCOPE_CANDIDATES`) — env vars
+keep secrets out of `ps` and let in-cluster deployments source the values
+from a ConfigMap:
+
+```bash
+# CLI
+kubectl radar \
+  --context-switch-timeout=120s \
+  --first-paint-backstop=10m \
+  --namespace-list-timeout=30s \
+  --max-scope-candidates=200
+
+# Environment (e.g. in a Deployment manifest)
+RADAR_CONTEXT_SWITCH_TIMEOUT=120s \
+RADAR_FIRST_PAINT_BACKSTOP=10m \
+RADAR_NAMESPACE_LIST_TIMEOUT=30s \
+RADAR_MAX_SCOPE_CANDIDATES=200 \
+  kubectl radar
+```
+
+Defaults are preserved when neither the flag nor the env var is set, so
+existing deployments are unaffected.
 
 ---
 

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -104,6 +104,15 @@ func main() {
 	cloudURL := flag.String("cloud-url", os.Getenv("RADAR_CLOUD_URL"), "Radar Cloud WebSocket URL (e.g. wss://api.radarhq.io/agent) — empty = local-only. Env: RADAR_CLOUD_URL")
 	cloudToken := flag.String("cloud-token", os.Getenv("RADAR_CLOUD_TOKEN"), "Cluster token from the Radar Cloud install wizard (rhc_<random>). Env: RADAR_CLOUD_TOKEN")
 	cloudClusterName := flag.String("cluster-name", os.Getenv("RADAR_CLOUD_CLUSTER_NAME"), "Human-readable cluster name for Radar Cloud (required with --cloud-url). Env: RADAR_CLOUD_CLUSTER_NAME")
+	// Tunable deadlines for slow / high-latency / SSH-tunneled clusters.
+	// Defaults preserve the original behavior. Each flag falls back to an
+	// environment variable so Kubernetes deployments can source values from
+	// a ConfigMap without exposing them in `ps`. Precedence: CLI flag wins
+	// when explicitly set; otherwise env var; otherwise the default.
+	contextSwitchTimeout := flag.Duration("context-switch-timeout", k8s.EnvDurationOr("RADAR_CONTEXT_SWITCH_TIMEOUT", 30*time.Second), "Maximum time a kubeconfig context switch may take (default: 30s). Widen to 120s or more for clusters reached over high-latency tunnels. Env: RADAR_CONTEXT_SWITCH_TIMEOUT")
+	firstPaintBackstop := flag.Duration("first-paint-backstop", k8s.EnvDurationOr("RADAR_FIRST_PAINT_BACKSTOP", 5*time.Minute), "Hard upper bound on the initial critical-cache sync wait before Radar falls through to partial-data render (default: 5m). Env: RADAR_FIRST_PAINT_BACKSTOP")
+	namespaceListTimeout := flag.Duration("namespace-list-timeout", k8s.EnvDurationOr("RADAR_NAMESPACE_LIST_TIMEOUT", 5*time.Second), "Timeout for the cluster-wide namespace LIST used to decide if the user is RBAC-namespace-restricted (default: 5s). Widen to 30s or more on slow control planes — a timeout here is misreported in the UI as 'Limited list — RBAC'. Env: RADAR_NAMESPACE_LIST_TIMEOUT")
+	maxScopeCandidates := flag.Int("max-scope-candidates", k8s.EnvIntOr("RADAR_MAX_SCOPE_CANDIDATES", 20), "Cap on the namespace-fallback probe fanout for users who can list namespaces cluster-wide but not list a specific kind cluster-wide (default: 20). Raise for clusters with more than 20 namespaces to avoid silently marking kinds as denied in dropped namespaces. Env: RADAR_MAX_SCOPE_CANDIDATES")
 	flag.Parse()
 
 	// Cloud-mode: Radar runs inside a customer cluster and fronts Radar
@@ -238,6 +247,18 @@ func main() {
 		defer rootCancel()
 		select {}
 	}
+
+	// Apply tunable k8s deadlines BEFORE any goroutine reads them. The
+	// setter is a no-op for zero values (preserves the default); each non-
+	// zero entry mutates the corresponding exported variable in the k8s
+	// package. Must run before InitializeK8s so the first connect attempt
+	// already observes the operator-chosen bounds.
+	k8s.ConfigureDeadlines(k8s.DeadlineOptions{
+		ContextSwitchTimeout: *contextSwitchTimeout,
+		FirstPaintBackstop:   *firstPaintBackstop,
+		NamespaceListTimeout: *namespaceListTimeout,
+		MaxScopeCandidates:   *maxScopeCandidates,
+	})
 
 	// Initialize K8s client (local only — parses kubeconfig, no network)
 	t := time.Now()

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -93,14 +93,9 @@ var minimalFirstPaintSet = map[string]bool{
 // gate and render with whatever is ready then.
 const firstPaintPatience = 8 * time.Second
 
-// firstPaintBackstop is the hard upper bound on the critical-sync wait.
-// If the minimal set still hasn't synced after this long, give up and
-// render with whatever's available — the user gets the same partial-data
-// experience they'd see today (zeros + "Still loading: …" hint) instead
-// of being trapped on the connecting screen indefinitely. Picked to be
-// much longer than a healthy cluster's sync time but short enough that
-// a permanently-throttled API server doesn't make Radar feel broken.
-const firstPaintBackstop = 5 * time.Minute
+// firstPaintBackstop now lives in deadlines.go as the exported package
+// variable FirstPaintBackstop so operators can widen the bound from the
+// command line without recompiling. The 5-minute default is preserved.
 
 // ResourceChange is a type alias for the canonical definition in pkg/k8score.
 type ResourceChange = k8score.ResourceChange
@@ -160,7 +155,7 @@ func InitResourceCache(ctx context.Context) error {
 			TimingLogger:        logTiming,
 			PatienceWindow:      firstPaintPatience,
 			MinimalSet:          minimalFirstPaintSet,
-			SyncTimeout:         firstPaintBackstop,
+			SyncTimeout:         FirstPaintBackstop,
 			SyncProgress:        emitSyncProgress,
 			DeferredSyncTimeout: 3 * time.Minute,
 			ListPageSize:        ListPageSize,

--- a/internal/k8s/capabilities.go
+++ b/internal/k8s/capabilities.go
@@ -800,14 +800,9 @@ func CheckResourcePermissions(ctx context.Context) *PermissionCheckResult {
 	return result
 }
 
-// maxScopeCandidates bounds the namespace-fallback probe fanout. It only
-// matters for a user who CAN list namespaces cluster-wide but CANNOT list
-// one of the probed kinds cluster-wide (e.g. a tenant operator with
-// namespace read but no cluster-wide secret read) — that path can return
-// hundreds of namespaces. Truly namespace-restricted users take the
-// non-authoritative branch in GetAccessibleNamespaces and never approach
-// this cap; their candidate list is at most 2 entries.
-const maxScopeCandidates = 20
+// MaxScopeCandidates was promoted to a package variable in deadlines.go
+// (default 20) so operators with clusters carrying more namespaces than the
+// original cap can widen the fanout via flag/env without recompiling.
 
 // buildScopeCandidates returns the namespace candidates for the fallback
 // probe when cluster-wide list is denied. Kubeconfig context (or
@@ -838,7 +833,7 @@ func buildScopeCandidates(ctx context.Context) []string {
 		// marked denied. Workaround: name the target with --namespace (or
 		// the kubeconfig context) so it sits ahead of the alphabetical
 		// accessible list and survives truncation.
-		log.Printf("RBAC: candidate namespaces truncated (cap=%d, %d dropped); kinds reachable only in dropped namespaces will be marked denied", maxScopeCandidates, dropped)
+		log.Printf("RBAC: candidate namespaces truncated (cap=%d, %d dropped); kinds reachable only in dropped namespaces will be marked denied", MaxScopeCandidates, dropped)
 	}
 	return out
 }
@@ -849,7 +844,7 @@ func buildScopeCandidates(ctx context.Context) []string {
 // already decided that list is not trustworthy as a probe target.
 func mergeScopeCandidates(ctxNs, flagNs string, accessible []string, authoritative bool) (out []string, dropped int) {
 	seen := map[string]bool{}
-	out = make([]string, 0, maxScopeCandidates)
+	out = make([]string, 0, MaxScopeCandidates)
 	atCap := false
 	add := func(ns string) {
 		if ns == "" || seen[ns] {
@@ -861,7 +856,7 @@ func mergeScopeCandidates(ctxNs, flagNs string, accessible []string, authoritati
 		}
 		seen[ns] = true
 		out = append(out, ns)
-		if len(out) >= maxScopeCandidates {
+		if len(out) >= MaxScopeCandidates {
 			atCap = true
 		}
 	}

--- a/internal/k8s/capabilities_probe_test.go
+++ b/internal/k8s/capabilities_probe_test.go
@@ -218,8 +218,8 @@ func TestMergeScopeCandidates_NonAuthoritativeIgnoresAccessible(t *testing.T) {
 func TestMergeScopeCandidates_CountsAllDrops(t *testing.T) {
 	// 25 accessible namespaces, no overlap with context/flag — pure cap test.
 	out, dropped := mergeScopeCandidates("", "", genNamespaces("ns", 25), true)
-	if len(out) != maxScopeCandidates {
-		t.Errorf("len(out) = %d, want %d", len(out), maxScopeCandidates)
+	if len(out) != MaxScopeCandidates {
+		t.Errorf("len(out) = %d, want %d", len(out), MaxScopeCandidates)
 	}
 	if dropped != 5 {
 		t.Errorf("dropped = %d, want 5 (25 accessible - 20 cap)", dropped)
@@ -231,8 +231,8 @@ func TestMergeScopeCandidates_CountsAllDrops(t *testing.T) {
 // missed truncation.
 func TestMergeScopeCandidates_CountsDropsWithContextAndFlag(t *testing.T) {
 	out, dropped := mergeScopeCandidates("dev", "prod", genNamespaces("ns", 25), true)
-	if len(out) != maxScopeCandidates {
-		t.Errorf("len(out) = %d, want %d", len(out), maxScopeCandidates)
+	if len(out) != MaxScopeCandidates {
+		t.Errorf("len(out) = %d, want %d", len(out), MaxScopeCandidates)
 	}
 	if out[0] != "dev" || out[1] != "prod" {
 		t.Errorf("out[0..1] = %v, want [dev prod]", out[:2])

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -707,7 +707,7 @@ func GetAccessibleNamespaces(ctx context.Context) ([]string, bool) {
 		return nil, false
 	}
 
-	listCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	listCtx, cancel := context.WithTimeout(ctx, NamespaceListTimeout)
 	defer cancel()
 
 	list, err := client.CoreV1().Namespaces().List(listCtx, metav1.ListOptions{})

--- a/internal/k8s/context_manager.go
+++ b/internal/k8s/context_manager.go
@@ -13,8 +13,9 @@ import (
 	"github.com/skyhook-io/radar/internal/errorlog"
 )
 
-// ContextSwitchTimeout is the maximum time allowed for a context switch operation
-const ContextSwitchTimeout = 30 * time.Second
+// ContextSwitchTimeout is now defined in deadlines.go as a package variable
+// so operators can override it via flag/env without recompiling. The default
+// value (30 * time.Second) is preserved for backwards compatibility.
 
 // ConnectionTestTimeout is the maximum time allowed for initial connection test
 // This is a short timeout for quick fail detection

--- a/internal/k8s/deadlines.go
+++ b/internal/k8s/deadlines.go
@@ -1,0 +1,127 @@
+package k8s
+
+import (
+	"log"
+	"os"
+	"strconv"
+	"time"
+)
+
+// Tunable deadlines and limits for the k8s layer.
+//
+// These were previously hardcoded constants. They were promoted to package-
+// level variables to allow operators running Radar against high-latency
+// API servers (SSH-tunneled clusters, geographically distant control planes,
+// throttled endpoints) to widen the bounds without recompiling.
+//
+// Defaults preserve the original behavior bit-for-bit. Override via flags
+// on cmd/explorer or via environment variables of the same name (see
+// ConfigureDeadlines and EnvDurationOr / EnvIntOr).
+//
+// Concurrency: ConfigureDeadlines must be called before the first goroutine
+// reads any of these (i.e. before InitializeK8s). No locking is provided —
+// the contract is "configure once at startup".
+var (
+	// ContextSwitchTimeout caps the time a kubeconfig context switch can take
+	// from the user clicking a context to the new client being live and the
+	// minimal informer set having synced. On healthy clusters it completes in
+	// a few seconds; on high-latency clusters reached over an SSH tunnel the
+	// minimal-set sync alone can exceed 30s.
+	ContextSwitchTimeout = 30 * time.Second
+
+	// FirstPaintBackstop is the hard upper bound on the critical-sync wait
+	// during initial cluster connect. Past this, Radar gives up waiting and
+	// renders with whatever caches are warm instead of pinning on the
+	// connecting screen indefinitely. Picked to be much longer than a
+	// healthy cluster's sync time but short enough that a permanently-
+	// throttled API server doesn't make Radar feel broken.
+	FirstPaintBackstop = 5 * time.Minute
+
+	// NamespaceListTimeout caps the cluster-wide LIST of namespaces used by
+	// GetAccessibleNamespaces to decide whether the user is namespace-
+	// restricted (RBAC fallback) or can enumerate everything. The original
+	// 5s was tight for high-latency control planes — when the LIST times out
+	// the UI shows "Limited list — RBAC doesn't allow listing all namespaces"
+	// even though the real cause was a transient timeout, not RBAC.
+	NamespaceListTimeout = 5 * time.Second
+
+	// MaxScopeCandidates bounds the namespace-fallback probe fanout (only
+	// reached by users who CAN list namespaces cluster-wide but CANNOT list
+	// a specific kind cluster-wide). The original cap of 20 silently dropped
+	// the tail on clusters with more than 20 namespaces; kinds reachable
+	// only in dropped namespaces were marked denied in the UI.
+	MaxScopeCandidates = 20
+)
+
+// DeadlineOptions carries the values supplied by the operator (via flags or
+// env vars) to ConfigureDeadlines. Zero values mean "leave the default".
+type DeadlineOptions struct {
+	ContextSwitchTimeout time.Duration
+	FirstPaintBackstop   time.Duration
+	NamespaceListTimeout time.Duration
+	MaxScopeCandidates   int
+}
+
+// ConfigureDeadlines applies any non-zero override in opts to the package
+// variables above. Must be called before InitializeK8s.
+//
+// Validation: durations must be > 0 (zero leaves the default untouched);
+// MaxScopeCandidates must be > 0 to be applied. Invalid values are logged
+// and ignored — Radar continues to start with defaults rather than aborting.
+func ConfigureDeadlines(opts DeadlineOptions) {
+	if opts.ContextSwitchTimeout < 0 {
+		log.Printf("[k8s] ignoring negative ContextSwitchTimeout %v, keeping default %v", opts.ContextSwitchTimeout, ContextSwitchTimeout)
+	} else if opts.ContextSwitchTimeout > 0 {
+		ContextSwitchTimeout = opts.ContextSwitchTimeout
+	}
+
+	if opts.FirstPaintBackstop < 0 {
+		log.Printf("[k8s] ignoring negative FirstPaintBackstop %v, keeping default %v", opts.FirstPaintBackstop, FirstPaintBackstop)
+	} else if opts.FirstPaintBackstop > 0 {
+		FirstPaintBackstop = opts.FirstPaintBackstop
+	}
+
+	if opts.NamespaceListTimeout < 0 {
+		log.Printf("[k8s] ignoring negative NamespaceListTimeout %v, keeping default %v", opts.NamespaceListTimeout, NamespaceListTimeout)
+	} else if opts.NamespaceListTimeout > 0 {
+		NamespaceListTimeout = opts.NamespaceListTimeout
+	}
+
+	if opts.MaxScopeCandidates < 0 {
+		log.Printf("[k8s] ignoring negative MaxScopeCandidates %d, keeping default %d", opts.MaxScopeCandidates, MaxScopeCandidates)
+	} else if opts.MaxScopeCandidates > 0 {
+		MaxScopeCandidates = opts.MaxScopeCandidates
+	}
+}
+
+// EnvDurationOr reads a Go duration from the named environment variable,
+// returning the fallback if the variable is unset or unparseable. Invalid
+// values are logged so a typo in a Deployment manifest doesn't silently
+// reduce to the default.
+func EnvDurationOr(envVar string, fallback time.Duration) time.Duration {
+	raw := os.Getenv(envVar)
+	if raw == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		log.Printf("[k8s] ignoring invalid %s=%q (%v), using default %v", envVar, raw, err, fallback)
+		return fallback
+	}
+	return d
+}
+
+// EnvIntOr reads a positive int from the named environment variable, with
+// the same fall-through-and-log semantics as EnvDurationOr.
+func EnvIntOr(envVar string, fallback int) int {
+	raw := os.Getenv(envVar)
+	if raw == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		log.Printf("[k8s] ignoring invalid %s=%q (%v), using default %d", envVar, raw, err, fallback)
+		return fallback
+	}
+	return n
+}

--- a/internal/k8s/deadlines_test.go
+++ b/internal/k8s/deadlines_test.go
@@ -1,0 +1,179 @@
+package k8s
+
+import (
+	"testing"
+	"time"
+)
+
+// withDeadlinesRestored snapshots the package-level deadlines, runs the test
+// body, and restores them. Tests in the same package that mutate the globals
+// must use this so test order doesn't leak state between cases.
+func withDeadlinesRestored(t *testing.T, body func()) {
+	t.Helper()
+	snap := DeadlineOptions{
+		ContextSwitchTimeout: ContextSwitchTimeout,
+		FirstPaintBackstop:   FirstPaintBackstop,
+		NamespaceListTimeout: NamespaceListTimeout,
+		MaxScopeCandidates:   MaxScopeCandidates,
+	}
+	t.Cleanup(func() {
+		ContextSwitchTimeout = snap.ContextSwitchTimeout
+		FirstPaintBackstop = snap.FirstPaintBackstop
+		NamespaceListTimeout = snap.NamespaceListTimeout
+		MaxScopeCandidates = snap.MaxScopeCandidates
+	})
+	body()
+}
+
+// Defaults must match the documented upstream-compatible values so that a
+// build without any flag/env override behaves bit-for-bit like before this
+// PR. If a default changes, the PR scope changed too — fail loudly.
+func TestDeadlineDefaults_PreserveUpstreamBehavior(t *testing.T) {
+	if ContextSwitchTimeout != 30*time.Second {
+		t.Errorf("ContextSwitchTimeout default = %v, want 30s", ContextSwitchTimeout)
+	}
+	if FirstPaintBackstop != 5*time.Minute {
+		t.Errorf("FirstPaintBackstop default = %v, want 5m", FirstPaintBackstop)
+	}
+	if NamespaceListTimeout != 5*time.Second {
+		t.Errorf("NamespaceListTimeout default = %v, want 5s", NamespaceListTimeout)
+	}
+	if MaxScopeCandidates != 20 {
+		t.Errorf("MaxScopeCandidates default = %d, want 20", MaxScopeCandidates)
+	}
+}
+
+func TestConfigureDeadlines_AppliesPositiveOverrides(t *testing.T) {
+	withDeadlinesRestored(t, func() {
+		ConfigureDeadlines(DeadlineOptions{
+			ContextSwitchTimeout: 120 * time.Second,
+			FirstPaintBackstop:   10 * time.Minute,
+			NamespaceListTimeout: 30 * time.Second,
+			MaxScopeCandidates:   200,
+		})
+		if ContextSwitchTimeout != 120*time.Second {
+			t.Errorf("ContextSwitchTimeout = %v, want 120s", ContextSwitchTimeout)
+		}
+		if FirstPaintBackstop != 10*time.Minute {
+			t.Errorf("FirstPaintBackstop = %v, want 10m", FirstPaintBackstop)
+		}
+		if NamespaceListTimeout != 30*time.Second {
+			t.Errorf("NamespaceListTimeout = %v, want 30s", NamespaceListTimeout)
+		}
+		if MaxScopeCandidates != 200 {
+			t.Errorf("MaxScopeCandidates = %d, want 200", MaxScopeCandidates)
+		}
+	})
+}
+
+// Zero in an opt field means "the caller didn't override it" — never reset
+// the live value to the type zero. Same semantics every other tunable in
+// the explorer uses.
+func TestConfigureDeadlines_ZeroLeavesDefault(t *testing.T) {
+	withDeadlinesRestored(t, func() {
+		ConfigureDeadlines(DeadlineOptions{})
+		if ContextSwitchTimeout != 30*time.Second {
+			t.Errorf("ContextSwitchTimeout mutated by zero opt: got %v", ContextSwitchTimeout)
+		}
+		if FirstPaintBackstop != 5*time.Minute {
+			t.Errorf("FirstPaintBackstop mutated by zero opt: got %v", FirstPaintBackstop)
+		}
+		if NamespaceListTimeout != 5*time.Second {
+			t.Errorf("NamespaceListTimeout mutated by zero opt: got %v", NamespaceListTimeout)
+		}
+		if MaxScopeCandidates != 20 {
+			t.Errorf("MaxScopeCandidates mutated by zero opt: got %d", MaxScopeCandidates)
+		}
+	})
+}
+
+// Negative values are bogus (a deployment-manifest typo, almost certainly)
+// and the safe behavior is to drop them and keep the default. The setter
+// logs the rejection so the typo is visible in startup logs.
+func TestConfigureDeadlines_NegativeRejected(t *testing.T) {
+	withDeadlinesRestored(t, func() {
+		ConfigureDeadlines(DeadlineOptions{
+			ContextSwitchTimeout: -1 * time.Second,
+			FirstPaintBackstop:   -1 * time.Minute,
+			NamespaceListTimeout: -1 * time.Second,
+			MaxScopeCandidates:   -1,
+		})
+		if ContextSwitchTimeout != 30*time.Second {
+			t.Errorf("negative ContextSwitchTimeout was applied: %v", ContextSwitchTimeout)
+		}
+		if FirstPaintBackstop != 5*time.Minute {
+			t.Errorf("negative FirstPaintBackstop was applied: %v", FirstPaintBackstop)
+		}
+		if NamespaceListTimeout != 5*time.Second {
+			t.Errorf("negative NamespaceListTimeout was applied: %v", NamespaceListTimeout)
+		}
+		if MaxScopeCandidates != 20 {
+			t.Errorf("negative MaxScopeCandidates was applied: %d", MaxScopeCandidates)
+		}
+	})
+}
+
+func TestEnvDurationOr_UnsetReturnsFallback(t *testing.T) {
+	t.Setenv("RADAR_TEST_EMPTY", "")
+	got := EnvDurationOr("RADAR_TEST_EMPTY", 7*time.Second)
+	if got != 7*time.Second {
+		t.Errorf("unset env should return fallback, got %v", got)
+	}
+}
+
+func TestEnvDurationOr_ParsesValid(t *testing.T) {
+	t.Setenv("RADAR_TEST_DUR", "45s")
+	got := EnvDurationOr("RADAR_TEST_DUR", 5*time.Second)
+	if got != 45*time.Second {
+		t.Errorf("valid env should be parsed, got %v", got)
+	}
+}
+
+func TestEnvDurationOr_InvalidFallsBack(t *testing.T) {
+	t.Setenv("RADAR_TEST_DUR_BAD", "not-a-duration")
+	got := EnvDurationOr("RADAR_TEST_DUR_BAD", 12*time.Second)
+	if got != 12*time.Second {
+		t.Errorf("invalid env should fall back to default, got %v", got)
+	}
+}
+
+func TestEnvIntOr_UnsetReturnsFallback(t *testing.T) {
+	t.Setenv("RADAR_TEST_EMPTY_INT", "")
+	got := EnvIntOr("RADAR_TEST_EMPTY_INT", 42)
+	if got != 42 {
+		t.Errorf("unset env should return fallback, got %d", got)
+	}
+}
+
+func TestEnvIntOr_ParsesValid(t *testing.T) {
+	t.Setenv("RADAR_TEST_INT", "200")
+	got := EnvIntOr("RADAR_TEST_INT", 20)
+	if got != 200 {
+		t.Errorf("valid env should be parsed, got %d", got)
+	}
+}
+
+func TestEnvIntOr_InvalidFallsBack(t *testing.T) {
+	t.Setenv("RADAR_TEST_INT_BAD", "twenty")
+	got := EnvIntOr("RADAR_TEST_INT_BAD", 20)
+	if got != 20 {
+		t.Errorf("invalid env should fall back to default, got %d", got)
+	}
+}
+
+// The precedence rule documented in the README is: flag (when explicitly set)
+// > env > default. We can't drive flag.Parse() from here, but we can verify
+// the building block: when main.go computes the flag's *default* via
+// EnvDurationOr(envVar, hardcodedDefault) and an env var is set, the env
+// value flows into the flag's default. The flag.Parse path then either
+// keeps that or overrides — both behaviors are stdlib flag, not our code.
+func TestEnvPrecedence_EnvOverridesHardcodedDefault(t *testing.T) {
+	t.Setenv("RADAR_PREC_DUR", "99s")
+	t.Setenv("RADAR_PREC_INT", "999")
+	if got := EnvDurationOr("RADAR_PREC_DUR", 1*time.Second); got != 99*time.Second {
+		t.Errorf("env should win over hardcoded default, got %v", got)
+	}
+	if got := EnvIntOr("RADAR_PREC_INT", 1); got != 999 {
+		t.Errorf("env should win over hardcoded default, got %d", got)
+	}
+}


### PR DESCRIPTION
## Description

Four hardcoded deadlines/limits in `internal/k8s` are promoted to runtime-
configurable values, exposed via flags on `cmd/explorer` and matching
`RADAR_*` environment variables. Defaults preserve current behavior
bit-for-bit; existing deployments are unaffected.

| Flag                        | Env var                         | Default | Previously |
| --------------------------- | ------------------------------- | ------- | ---------- |
| `--context-switch-timeout`  | `RADAR_CONTEXT_SWITCH_TIMEOUT`  | `30s`   | const 30s  |
| `--first-paint-backstop`    | `RADAR_FIRST_PAINT_BACKSTOP`    | `5m`    | const 5m   |
| `--namespace-list-timeout`  | `RADAR_NAMESPACE_LIST_TIMEOUT`  | `5s`    | literal 5s |
| `--max-scope-candidates`    | `RADAR_MAX_SCOPE_CANDIDATES`    | `20`    | const 20   |

The four values now live in a new `internal/k8s/deadlines.go` with a
`ConfigureDeadlines()` setter; `cmd/explorer` parses the flags + env
once and applies any overrides before `InitializeK8s`, so the first
connect attempt already observes the operator-chosen bounds. Precedence
is flag > env > default, matching the existing `RADAR_CLOUD_*` pattern.

## Motivation

Operators reaching API servers over high-latency paths (SSH tunnels,
geographically distant control planes, or accounts subject to API-server
throttling) see the original values surface as one of three confusing
symptoms — even on healthy clusters that *do* eventually respond:

- **"Context switch timed out"** toasts after the cache eventually syncs
- **"Limited list — RBAC doesn't allow listing all namespaces"** misreports
  when the cluster-wide LIST simply timed out instead of being denied
- **Kinds silently marked denied** when their namespace fell past the 20-
  entry scope candidate cap on clusters with more than 20 namespaces

This patch lets operators widen the bounds without recompiling. Defaults
are unchanged, so out-of-the-box behavior on small/fast clusters is
identical.

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

(Includes documentation updates as part of the feature.)

## How has this been tested?

- [x] Added unit tests (`internal/k8s/deadlines_test.go`, 11 cases)
  covering default-preservation, positive overrides, zero-leaves-default,
  negative-rejection, and env var parsing/precedence.
- [x] Existing `internal/k8s` tests continue to pass (including the
  `mergeScopeCandidates` cap regression tests that depend on the
  documented default of 20).
- [x] `go test ./...` — full repo suite green.
- [x] `go vet ./...` — no new warnings introduced by this PR.
- [x] Manual smoke against a remote cluster reached via SSH tunnel
  (cross-compiled `linux/amd64`, six contexts loaded, all four flags
  visible in the systemd unit's `ExecStart`, validated end-to-end:
  context switches succeed, namespace listing returns the full set,
  no "Limited list" misreports).

## Checklist

- [x] My code follows the project's coding standards (gofmt, conventional commits)
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary (rationale on each new var,
  doc block on `ConfigureDeadlines` / `EnvDurationOr` / `EnvIntOr`)
- [x] My changes generate no new warnings
- [x] Defaults preserve upstream behavior — no dependent changes required

## Files

```
internal/k8s/deadlines.go               +127 (new)
internal/k8s/deadlines_test.go          +179 (new)
cmd/explorer/main.go                    +21
README.md                               +43 (tunable flags table + "Tuning for slow or high-latency clusters" subsection)
internal/k8s/cache.go                   -10 / +3
internal/k8s/capabilities.go            -11 / +6
internal/k8s/capabilities_probe_test.go (rename refs only)
internal/k8s/client.go                  -1 / +1
internal/k8s/context_manager.go         -2 / +3
```

Total: 9 files, +388 / -27.

## Backwards compatibility

- No flag has a non-zero hardcoded value — every default is the original
  hardcoded value, preserved verbatim.
- `internal/k8s/MaxScopeCandidates` is a public rename of the previous
  internal `maxScopeCandidates` (same semantics). The single existing
  test file that referenced it (`capabilities_probe_test.go`) is updated
  in the same commit.
- No new dependencies.

## Related issues

None linked — change is operator-facing rather than fixing a tracked bug.
Happy to open a tracking issue first if maintainers prefer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Non-breaking operational knobs with bit-for-bit defaults; only affects connect, sync, and RBAC probe timing when operators override values.
> 
> **Overview**
> Operators can tune four Kubernetes-layer timeouts and limits at runtime instead of relying on hardcoded values.
> 
> **Context switch**, **first-paint backstop**, **namespace LIST**, and **max scope candidates** move into `internal/k8s/deadlines.go` as package variables, applied once at startup via `ConfigureDeadlines()` before `InitializeK8s`. `cmd/explorer` exposes matching CLI flags and `RADAR_*` env vars (same precedence pattern as existing cloud flags). Call sites in cache sync, `GetAccessibleNamespaces`, and RBAC namespace-fallback probing now read those variables.
> 
> Defaults match the previous constants (30s / 5m / 5s / 20), so unchanged deployments behave the same. README documents when to widen values for slow or tunneled clusters and adds example CLI/env configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5107f1b2a162f9ab3efae22086920615c4f94587. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->