### PR TITLE
Improve deterministic diagnostic signals

### DIFF
--- a/internal/issues/grouping.go
+++ b/internal/issues/grouping.go
@@ -278,18 +278,22 @@ func sortRefs(refs []Ref) {
 	})
 }
 
-// lessIssue is the canonical issue sort: severity desc, then ONSET (first_seen
-// desc) — deliberately NOT last_seen, which bumps to compose-time on every poll
-// and would reshuffle same-severity rows on each refetch. Then namespace, name,
-// and the stable id as a total tiebreak. This is byte-for-byte the order the
-// shared UI comparator (k8s-ui issues/types.ts:compareIssues) produces for a
-// single cluster — the UI's only extra key is `cluster`, which it sorts on for
-// fleet (multi-cluster) views and which is constant here. So /api/issues, MCP,
-// and the single-cluster UI return one identical queue. (id is the final
-// tiebreak — two rows can share subject+ns+name and differ only by cause.)
+// lessIssue is the canonical issue sort: severity desc, direct-blocker source
+// priority, then ONSET (first_seen desc) — deliberately NOT last_seen, which
+// bumps to compose-time on every poll and would reshuffle same-severity rows on
+// each refetch. Then namespace, name, and the stable id as a total tiebreak.
+// This is byte-for-byte the order the shared UI comparator (k8s-ui
+// issues/types.ts:compareIssues) produces for a single cluster — the UI's only
+// extra key is `cluster`, which it sorts on for fleet (multi-cluster) views and
+// which is constant here. So /api/issues, MCP, and the single-cluster UI return
+// one identical queue. (id is the final tiebreak — two rows can share
+// subject+ns+name and differ only by cause.)
 func lessIssue(a, b Issue) bool {
 	if a.Severity != b.Severity {
 		return SeverityRank(a.Severity) > SeverityRank(b.Severity)
+	}
+	if issueSourceRank(a.Source) != issueSourceRank(b.Source) {
+		return issueSourceRank(a.Source) > issueSourceRank(b.Source)
 	}
 	if !a.FirstSeen.Equal(b.FirstSeen) {
 		return a.FirstSeen.After(b.FirstSeen)
@@ -301,4 +305,18 @@ func lessIssue(a, b Issue) bool {
 		return a.Name < b.Name
 	}
 	return a.ID < b.ID
+}
+
+func issueSourceRank(s Source) int {
+	switch s {
+	case SourceScheduling:
+		return 4 // active bind/admission/post-bind blockers explain why work cannot run
+	case SourceMissingRef:
+		return 3 // direct references to absent objects are usually root-cause shaped
+	case SourceCondition:
+		return 2
+	case SourceProblem:
+		return 1
+	}
+	return 0
 }

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -1222,6 +1222,30 @@ func TestCompose_SeveritySortedDescending(t *testing.T) {
 	}
 }
 
+func TestCompose_DirectBlockersSortBeforeGenericProblems(t *testing.T) {
+	p := &fakeProvider{
+		problems: []k8s.Detection{
+			{Kind: "Pod", Namespace: "ns", Name: "crashy", Severity: "critical", Reason: "CrashLoopBackOff"},
+		},
+		missingRefs: []k8s.Detection{
+			{Kind: "Pod", Namespace: "ns", Name: "missing-config", Severity: "critical", Reason: "Missing ConfigMap"},
+		},
+		scheduling: []k8s.Detection{
+			{Kind: "ReplicaSet", Namespace: "ns", Name: "quota-blocked", Severity: "critical", Reason: "QuotaExceeded"},
+		},
+	}
+	out := Compose(p, Filters{})
+	if len(out) != 3 {
+		t.Fatalf("got %d issues: %+v", len(out), out)
+	}
+	if out[0].Source != SourceScheduling || out[0].Reason != "QuotaExceeded" {
+		t.Fatalf("active scheduling/admission blocker should sort first at same severity, got %+v", out[0])
+	}
+	if out[1].Source != SourceMissingRef {
+		t.Fatalf("missing ref should sort before generic problem at same severity, got %+v", out)
+	}
+}
+
 func TestCompose_SeverityFilter(t *testing.T) {
 	p := &fakeProvider{
 		problems: []k8s.Detection{

--- a/internal/k8s/detect_scheduling.go
+++ b/internal/k8s/detect_scheduling.go
@@ -903,7 +903,7 @@ func detectAdmissionConditionProblems(cache *ResourceCache, namespace string, se
 			if !deploymentNeedsPodCreation(d) {
 				continue
 			}
-			if hasSeenReplicaSetForDeployment(seen, d.Namespace, d.Name) {
+			if hasSeenReplicaSetForDeployment(cache, seen, d.Namespace, d.Name) {
 				continue
 			}
 			for _, c := range d.Status.Conditions {
@@ -956,10 +956,17 @@ func admissionProblemKey(kind, namespace, name string) string {
 	return kind + "/" + namespace + "/" + name
 }
 
-func hasSeenReplicaSetForDeployment(seen map[string]bool, namespace, deployment string) bool {
-	prefix := "ReplicaSet/" + namespace + "/" + deployment + "-"
-	for key := range seen {
-		if suffix, ok := strings.CutPrefix(key, prefix); ok && suffix != "" && !strings.Contains(suffix, "-") {
+func hasSeenReplicaSetForDeployment(cache *ResourceCache, seen map[string]bool, namespace, deployment string) bool {
+	if cache == nil || deployment == "" {
+		return false
+	}
+	l := cache.ReplicaSets()
+	if l == nil {
+		return false
+	}
+	items, _ := l.ReplicaSets(namespace).List(labels.Everything())
+	for _, rs := range items {
+		if seen[admissionProblemKey("ReplicaSet", rs.Namespace, rs.Name)] && replicaSetOwnedByDeployment(rs, deployment) {
 			return true
 		}
 	}
@@ -967,14 +974,27 @@ func hasSeenReplicaSetForDeployment(seen map[string]bool, namespace, deployment 
 }
 
 func hasSeenDeploymentForReplicaSet(seen map[string]bool, rs *appsv1.ReplicaSet) bool {
-	if rs == nil {
+	deployment, ok := replicaSetDeploymentOwnerName(rs)
+	if !ok {
 		return false
+	}
+	return seen[admissionProblemKey("Deployment", rs.Namespace, deployment)]
+}
+
+func replicaSetOwnedByDeployment(rs *appsv1.ReplicaSet, deployment string) bool {
+	name, ok := replicaSetDeploymentOwnerName(rs)
+	return ok && name == deployment
+}
+
+func replicaSetDeploymentOwnerName(rs *appsv1.ReplicaSet) (string, bool) {
+	if rs == nil {
+		return "", false
 	}
 	owner := controllerOwnerRef(rs.OwnerReferences)
 	if owner == nil || owner.Kind != "Deployment" || owner.Name == "" {
-		return false
+		return "", false
 	}
-	return seen[admissionProblemKey("Deployment", rs.Namespace, owner.Name)]
+	return owner.Name, true
 }
 
 // classifyAdmissionFailure maps a FailedCreate event message to a reason.

--- a/internal/k8s/detect_scheduling.go
+++ b/internal/k8s/detect_scheduling.go
@@ -787,11 +787,12 @@ func eventFirstTime(e *corev1.Event) time.Time {
 // A recovered workload has its replicas, so its lingering event is skipped.
 // Unknown kinds / unreadable listers default to true — never drop genuine coverage.
 func admissionTargetStillBlocked(cache *ResourceCache, obj corev1.ObjectReference) bool {
-	// "Blocked" means the controller still can't CREATE its pods — measured by
-	// created-count (Status.Replicas / CurrentNumberScheduled) below desired,
+	// "Blocked" means the controller still can't CREATE the pods it needs,
 	// NOT readiness. A workload whose pods were created but stay not-ready for
 	// another reason (e.g. unschedulable after a quota was raised) has its pods
-	// and is no longer admission-blocked.
+	// and is no longer admission-blocked. Deployments also need the updated
+	// replica count checked so rolling updates blocked on new-pod creation do
+	// not get masked by old replicas.
 	switch obj.Kind {
 	case "ReplicaSet":
 		if l := cache.ReplicaSets(); l != nil {
@@ -807,7 +808,7 @@ func admissionTargetStillBlocked(cache *ResourceCache, obj corev1.ObjectReferenc
 		if l := cache.Deployments(); l != nil {
 			d, err := l.Deployments(obj.Namespace).Get(obj.Name)
 			if err == nil {
-				return d.Status.Replicas < schedDesiredReplicas(d.Spec.Replicas)
+				return deploymentNeedsPodCreation(d)
 			}
 			if apierrors.IsNotFound(err) {
 				return false

--- a/internal/k8s/detect_scheduling.go
+++ b/internal/k8s/detect_scheduling.go
@@ -688,7 +688,7 @@ func DetectAdmissionProblems(cache *ResourceCache, namespace string) []Detection
 
 func detectAdmissionFailures(cache *ResourceCache, namespace string) []Detection {
 	if cache.Events() == nil {
-		return nil
+		return detectAdmissionConditionProblems(cache, namespace, map[string]bool{})
 	}
 	var events []*corev1.Event
 	if namespace != "" {
@@ -863,6 +863,9 @@ func schedDesiredReplicas(r *int32) int32 {
 func detectAdmissionConditionProblems(cache *ResourceCache, namespace string, seen map[string]bool) []Detection {
 	var out []Detection
 	now := time.Now()
+	if seen == nil {
+		seen = map[string]bool{}
+	}
 
 	if l := cache.ReplicaSets(); l != nil {
 		var items []*appsv1.ReplicaSet
@@ -873,7 +876,7 @@ func detectAdmissionConditionProblems(cache *ResourceCache, namespace string, se
 		}
 		for _, rs := range items {
 			key := admissionProblemKey("ReplicaSet", rs.Namespace, rs.Name)
-			if seen[key] || rs.Status.Replicas >= schedDesiredReplicas(rs.Spec.Replicas) {
+			if seen[key] || hasSeenDeploymentForReplicaSet(seen, rs) || rs.Status.Replicas >= schedDesiredReplicas(rs.Spec.Replicas) {
 				continue
 			}
 			for _, c := range rs.Status.Conditions {
@@ -883,6 +886,7 @@ func detectAdmissionConditionProblems(cache *ResourceCache, namespace string, se
 				if p, ok := admissionConditionProblem("ReplicaSet", rs.Namespace, rs.Name, c.Message, c.LastTransitionTime.Time, now); ok {
 					out = append(out, p)
 					seen[key] = true
+					break
 				}
 			}
 		}
@@ -960,6 +964,17 @@ func hasSeenReplicaSetForDeployment(seen map[string]bool, namespace, deployment 
 		}
 	}
 	return false
+}
+
+func hasSeenDeploymentForReplicaSet(seen map[string]bool, rs *appsv1.ReplicaSet) bool {
+	if rs == nil {
+		return false
+	}
+	owner := controllerOwnerRef(rs.OwnerReferences)
+	if owner == nil || owner.Kind != "Deployment" || owner.Name == "" {
+		return false
+	}
+	return seen[admissionProblemKey("Deployment", rs.Namespace, owner.Name)]
 }
 
 // classifyAdmissionFailure maps a FailedCreate event message to a reason.

--- a/internal/k8s/detect_scheduling.go
+++ b/internal/k8s/detect_scheduling.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -756,6 +757,11 @@ func detectAdmissionFailures(cache *ResourceCache, namespace string) []Detection
 			DurationSeconds: int64(ageDur.Seconds()),
 		})
 	}
+	seen := make(map[string]bool, len(problems))
+	for _, p := range problems {
+		seen[admissionProblemKey(p.Kind, p.Namespace, p.Name)] = true
+	}
+	problems = append(problems, detectAdmissionConditionProblems(cache, namespace, seen)...)
 	return problems
 }
 
@@ -851,6 +857,108 @@ func schedDesiredReplicas(r *int32) int32 {
 		return 1
 	}
 	return *r
+}
+
+func detectAdmissionConditionProblems(cache *ResourceCache, namespace string, seen map[string]bool) []Detection {
+	var out []Detection
+	now := time.Now()
+
+	if l := cache.ReplicaSets(); l != nil {
+		var items []*appsv1.ReplicaSet
+		if namespace != "" {
+			items, _ = l.ReplicaSets(namespace).List(labels.Everything())
+		} else {
+			items, _ = l.List(labels.Everything())
+		}
+		for _, rs := range items {
+			key := admissionProblemKey("ReplicaSet", rs.Namespace, rs.Name)
+			if seen[key] || rs.Status.Replicas >= schedDesiredReplicas(rs.Spec.Replicas) {
+				continue
+			}
+			for _, c := range rs.Status.Conditions {
+				if c.Type != appsv1.ReplicaSetReplicaFailure || c.Status != corev1.ConditionTrue {
+					continue
+				}
+				if p, ok := admissionConditionProblem("ReplicaSet", rs.Namespace, rs.Name, c.Message, c.LastTransitionTime.Time, now); ok {
+					out = append(out, p)
+					seen[key] = true
+				}
+			}
+		}
+	}
+
+	if l := cache.Deployments(); l != nil {
+		var items []*appsv1.Deployment
+		if namespace != "" {
+			items, _ = l.Deployments(namespace).List(labels.Everything())
+		} else {
+			items, _ = l.List(labels.Everything())
+		}
+		for _, d := range items {
+			if !deploymentNeedsPodCreation(d) {
+				continue
+			}
+			if hasSeenReplicaSetForDeployment(seen, d.Namespace, d.Name) {
+				continue
+			}
+			for _, c := range d.Status.Conditions {
+				if c.Type != appsv1.DeploymentReplicaFailure || c.Status != corev1.ConditionTrue {
+					continue
+				}
+				if p, ok := admissionConditionProblem("Deployment", d.Namespace, d.Name, c.Message, c.LastTransitionTime.Time, now); ok {
+					key := admissionProblemKey(p.Kind, p.Namespace, p.Name)
+					if !seen[key] {
+						out = append(out, p)
+						seen[key] = true
+					}
+				}
+			}
+		}
+	}
+
+	return out
+}
+
+func deploymentNeedsPodCreation(d *appsv1.Deployment) bool {
+	desired := schedDesiredReplicas(d.Spec.Replicas)
+	return desired > 0 && (d.Status.Replicas < desired || d.Status.UpdatedReplicas < desired)
+}
+
+func admissionConditionProblem(kind, namespace, name, message string, firstSeen, now time.Time) (Detection, bool) {
+	reason, ok := classifyAdmissionFailure(message)
+	if !ok {
+		return Detection{}, false
+	}
+	if firstSeen.IsZero() {
+		firstSeen = now
+	}
+	ageDur := now.Sub(firstSeen)
+	return Detection{
+		Kind:            kind,
+		Namespace:       namespace,
+		Name:            name,
+		Severity:        "critical",
+		Reason:          reason,
+		Message:         "pod creation blocked: " + strings.TrimSpace(message),
+		Age:             FormatAge(ageDur),
+		AgeSeconds:      int64(ageDur.Seconds()),
+		Duration:        FormatAge(ageDur),
+		DurationSeconds: int64(ageDur.Seconds()),
+	}, true
+}
+
+func admissionProblemKey(kind, namespace, name string) string {
+	return kind + "/" + namespace + "/" + name
+}
+
+func hasSeenReplicaSetForDeployment(seen map[string]bool, namespace, deployment string) bool {
+	prefix := "ReplicaSet/" + namespace + "/" + deployment + "-"
+	for key := range seen {
+		if suffix, ok := strings.CutPrefix(key, prefix); ok && suffix != "" && !strings.Contains(suffix, "-") {
+			return true
+		}
+	}
+	return false
 }
 
 // classifyAdmissionFailure maps a FailedCreate event message to a reason.

--- a/internal/k8s/detect_scheduling_integration_test.go
+++ b/internal/k8s/detect_scheduling_integration_test.go
@@ -327,9 +327,18 @@ func TestDetectAdmissionProblems_ConditionFallbackDoesNotDuplicateReplicaSetEven
 		},
 	}
 	rs := &appsv1.ReplicaSet{
-		ObjectMeta: metav1.ObjectMeta{Name: "search-abc123", Namespace: "prod"},
-		Spec:       appsv1.ReplicaSetSpec{Replicas: ptr32(3)},
-		Status:     appsv1.ReplicaSetStatus{Replicas: 1},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "search-abc123",
+			Namespace: "prod",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "search",
+				Controller: boolPtr(true),
+			}},
+		},
+		Spec:   appsv1.ReplicaSetSpec{Replicas: ptr32(3)},
+		Status: appsv1.ReplicaSetStatus{Replicas: 1},
 	}
 	evt := &corev1.Event{
 		ObjectMeta:     metav1.ObjectMeta{Name: "quota-event", Namespace: "prod"},
@@ -353,12 +362,64 @@ func TestDetectAdmissionProblems_ConditionFallbackDoesNotDuplicateReplicaSetEven
 	}
 }
 
+func TestDetectAdmissionProblems_UnrelatedReplicaSetDoesNotSuppressDeploymentCondition(t *testing.T) {
+	defer ResetTestState()
+	nowT := metav1.Now()
+	message := `pods "search-x" is forbidden: exceeded quota: memory-limit-quota, requested: limits.memory=1Gi, used: limits.memory=1Gi, limited: limits.memory=1Gi`
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "prod"},
+		Spec:       appsv1.DeploymentSpec{Replicas: ptr32(3)},
+		Status: appsv1.DeploymentStatus{
+			Replicas: 1,
+			Conditions: []appsv1.DeploymentCondition{{
+				Type:               appsv1.DeploymentReplicaFailure,
+				Status:             corev1.ConditionTrue,
+				Reason:             "FailedCreate",
+				Message:            message,
+				LastTransitionTime: nowT,
+			}},
+		},
+	}
+	unrelatedRS := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "app-backend", Namespace: "prod"},
+		Spec:       appsv1.ReplicaSetSpec{Replicas: ptr32(1)},
+		Status:     appsv1.ReplicaSetStatus{Replicas: 0},
+	}
+	evt := &corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{Name: "quota-event", Namespace: "prod"},
+		InvolvedObject: corev1.ObjectReference{Kind: "ReplicaSet", Namespace: "prod", Name: "app-backend"},
+		Reason:         "FailedCreate",
+		Type:           corev1.EventTypeWarning,
+		Message:        `Error creating: ` + message,
+		LastTimestamp:  nowT,
+	}
+	if err := InitTestResourceCache(fake.NewClientset(deploy, unrelatedRS, evt)); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	problems := DetectAdmissionProblems(GetResourceCache(), "prod")
+	if !findProblem(problems, "ReplicaSet", "prod", "app-backend", "QuotaExceeded") {
+		t.Fatalf("expected unrelated ReplicaSet event problem, got %+v", problems)
+	}
+	if !findProblem(problems, "Deployment", "prod", "app", "QuotaExceeded") {
+		t.Fatalf("unrelated ReplicaSet must not suppress Deployment condition fallback, got %+v", problems)
+	}
+}
+
 func TestDetectAdmissionProblems_ReplicaSetConditionFallbackDedupe(t *testing.T) {
 	defer ResetTestState()
 	nowT := metav1.Now()
 	rs := &appsv1.ReplicaSet{
-		ObjectMeta: metav1.ObjectMeta{Name: "search-abc123", Namespace: "prod"},
-		Spec:       appsv1.ReplicaSetSpec{Replicas: ptr32(3)},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "search-abc123",
+			Namespace: "prod",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "search",
+				Controller: boolPtr(true),
+			}},
+		},
+		Spec: appsv1.ReplicaSetSpec{Replicas: ptr32(3)},
 		Status: appsv1.ReplicaSetStatus{
 			Replicas: 1,
 			Conditions: []appsv1.ReplicaSetCondition{
@@ -413,8 +474,17 @@ func TestDetectAdmissionProblems_ConditionFallbackPrefersReplicaSet(t *testing.T
 		},
 	}
 	rs := &appsv1.ReplicaSet{
-		ObjectMeta: metav1.ObjectMeta{Name: "search-abc123", Namespace: "prod"},
-		Spec:       appsv1.ReplicaSetSpec{Replicas: ptr32(3)},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "search-abc123",
+			Namespace: "prod",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "search",
+				Controller: boolPtr(true),
+			}},
+		},
+		Spec: appsv1.ReplicaSetSpec{Replicas: ptr32(3)},
 		Status: appsv1.ReplicaSetStatus{
 			Replicas: 1,
 			Conditions: []appsv1.ReplicaSetCondition{{

--- a/internal/k8s/detect_scheduling_integration_test.go
+++ b/internal/k8s/detect_scheduling_integration_test.go
@@ -119,6 +119,149 @@ func TestDetectAdmissionProblems_FailedCreateCrossCheck(t *testing.T) {
 	}
 }
 
+func TestDetectAdmissionProblems_ReplicaFailureConditionFallback(t *testing.T) {
+	defer ResetTestState()
+	nowT := metav1.Now()
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "search", Namespace: "prod"},
+		Spec:       appsv1.DeploymentSpec{Replicas: ptr32(3)},
+		Status: appsv1.DeploymentStatus{
+			Replicas: 1,
+			Conditions: []appsv1.DeploymentCondition{{
+				Type:               appsv1.DeploymentReplicaFailure,
+				Status:             corev1.ConditionTrue,
+				Reason:             "FailedCreate",
+				Message:            `pods "search-x" is forbidden: exceeded quota: memory-limit-quota, requested: limits.memory=1Gi, used: limits.memory=1Gi, limited: limits.memory=1Gi`,
+				LastTransitionTime: nowT,
+			}},
+		},
+	}
+	if err := InitTestResourceCache(fake.NewClientset(deploy)); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	problems := DetectAdmissionProblems(GetResourceCache(), "prod")
+	if !findProblem(problems, "Deployment", "prod", "search", "QuotaExceeded") {
+		t.Fatalf("expected Deployment quota condition fallback, got %+v", problems)
+	}
+}
+
+func TestDetectAdmissionProblems_ReplicaFailureConditionFallbackForBlockedRollout(t *testing.T) {
+	defer ResetTestState()
+	nowT := metav1.Now()
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "search", Namespace: "prod"},
+		Spec:       appsv1.DeploymentSpec{Replicas: ptr32(3)},
+		Status: appsv1.DeploymentStatus{
+			Replicas:        3,
+			UpdatedReplicas: 1,
+			Conditions: []appsv1.DeploymentCondition{{
+				Type:               appsv1.DeploymentReplicaFailure,
+				Status:             corev1.ConditionTrue,
+				Reason:             "FailedCreate",
+				Message:            `pods "search-x" is forbidden: exceeded quota: memory-limit-quota, requested: limits.memory=1Gi, used: limits.memory=1Gi, limited: limits.memory=1Gi`,
+				LastTransitionTime: nowT,
+			}},
+		},
+	}
+	if err := InitTestResourceCache(fake.NewClientset(deploy)); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	problems := DetectAdmissionProblems(GetResourceCache(), "prod")
+	if !findProblem(problems, "Deployment", "prod", "search", "QuotaExceeded") {
+		t.Fatalf("expected Deployment quota condition fallback for blocked rollout, got %+v", problems)
+	}
+}
+
+func TestDetectAdmissionProblems_ConditionFallbackDoesNotDuplicateReplicaSetEvent(t *testing.T) {
+	defer ResetTestState()
+	nowT := metav1.Now()
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "search", Namespace: "prod"},
+		Spec:       appsv1.DeploymentSpec{Replicas: ptr32(3)},
+		Status: appsv1.DeploymentStatus{
+			Replicas: 1,
+			Conditions: []appsv1.DeploymentCondition{{
+				Type:               appsv1.DeploymentReplicaFailure,
+				Status:             corev1.ConditionTrue,
+				Reason:             "FailedCreate",
+				Message:            `pods "search-x" is forbidden: exceeded quota: memory-limit-quota, requested: limits.memory=1Gi, used: limits.memory=1Gi, limited: limits.memory=1Gi`,
+				LastTransitionTime: nowT,
+			}},
+		},
+	}
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "search-abc123", Namespace: "prod"},
+		Spec:       appsv1.ReplicaSetSpec{Replicas: ptr32(3)},
+		Status:     appsv1.ReplicaSetStatus{Replicas: 1},
+	}
+	evt := &corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{Name: "quota-event", Namespace: "prod"},
+		InvolvedObject: corev1.ObjectReference{Kind: "ReplicaSet", Namespace: "prod", Name: "search-abc123"},
+		Reason:         "FailedCreate",
+		Type:           corev1.EventTypeWarning,
+		Message:        `Error creating: pods "search-x" is forbidden: exceeded quota: memory-limit-quota, requested: limits.memory=1Gi, used: limits.memory=1Gi, limited: limits.memory=1Gi`,
+		LastTimestamp:  nowT,
+	}
+	if err := InitTestResourceCache(fake.NewClientset(deploy, rs, evt)); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	problems := DetectAdmissionProblems(GetResourceCache(), "prod")
+	if !findProblem(problems, "ReplicaSet", "prod", "search-abc123", "QuotaExceeded") {
+		t.Fatalf("expected ReplicaSet event problem, got %+v", problems)
+	}
+	for _, p := range problems {
+		if p.Kind == "Deployment" && p.Name == "search" {
+			t.Fatalf("Deployment condition duplicated ReplicaSet event: %+v", problems)
+		}
+	}
+}
+
+func TestDetectAdmissionProblems_ConditionFallbackPrefersReplicaSet(t *testing.T) {
+	defer ResetTestState()
+	nowT := metav1.Now()
+	message := `pods "search-x" is forbidden: exceeded quota: memory-limit-quota, requested: limits.memory=1Gi, used: limits.memory=1Gi, limited: limits.memory=1Gi`
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "search", Namespace: "prod"},
+		Spec:       appsv1.DeploymentSpec{Replicas: ptr32(3)},
+		Status: appsv1.DeploymentStatus{
+			Replicas: 1,
+			Conditions: []appsv1.DeploymentCondition{{
+				Type:               appsv1.DeploymentReplicaFailure,
+				Status:             corev1.ConditionTrue,
+				Reason:             "FailedCreate",
+				Message:            message,
+				LastTransitionTime: nowT,
+			}},
+		},
+	}
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "search-abc123", Namespace: "prod"},
+		Spec:       appsv1.ReplicaSetSpec{Replicas: ptr32(3)},
+		Status: appsv1.ReplicaSetStatus{
+			Replicas: 1,
+			Conditions: []appsv1.ReplicaSetCondition{{
+				Type:               appsv1.ReplicaSetReplicaFailure,
+				Status:             corev1.ConditionTrue,
+				Reason:             "FailedCreate",
+				Message:            message,
+				LastTransitionTime: nowT,
+			}},
+		},
+	}
+	if err := InitTestResourceCache(fake.NewClientset(deploy, rs)); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	problems := DetectAdmissionProblems(GetResourceCache(), "prod")
+	if !findProblem(problems, "ReplicaSet", "prod", "search-abc123", "QuotaExceeded") {
+		t.Fatalf("expected ReplicaSet condition problem, got %+v", problems)
+	}
+	for _, p := range problems {
+		if p.Kind == "Deployment" && p.Name == "search" {
+			t.Fatalf("Deployment condition duplicated ReplicaSet condition: %+v", problems)
+		}
+	}
+}
+
 // A SchedulingGated pod has PodScheduled=False but reason=SchedulingGated —
 // the scheduler hasn't tried yet because the pod carries scheduling gates.
 // That's an intentional not-yet-scheduled state, not a placement failure, so

--- a/internal/k8s/detect_scheduling_integration_test.go
+++ b/internal/k8s/detect_scheduling_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/skyhook-io/radar/pkg/k8score"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -13,6 +14,8 @@ import (
 )
 
 func ptr32(i int32) *int32 { return &i }
+
+func boolPtr(v bool) *bool { return &v }
 
 // Exercises the bind-time detector end-to-end: a Pending pod the scheduler
 // rejected on arch, with the node-fit resolver naming the offending label.
@@ -188,6 +191,43 @@ func TestDetectAdmissionProblems_ReplicaFailureConditionFallback(t *testing.T) {
 	}
 }
 
+func TestDetectAdmissionProblems_ReplicaFailureConditionFallbackWithoutEvents(t *testing.T) {
+	nowT := metav1.Now()
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "search", Namespace: "prod"},
+		Spec:       appsv1.DeploymentSpec{Replicas: ptr32(3)},
+		Status: appsv1.DeploymentStatus{
+			Replicas: 1,
+			Conditions: []appsv1.DeploymentCondition{{
+				Type:               appsv1.DeploymentReplicaFailure,
+				Status:             corev1.ConditionTrue,
+				Reason:             "FailedCreate",
+				Message:            `pods "search-x" is forbidden: exceeded quota: memory-limit-quota, requested: limits.memory=1Gi, used: limits.memory=1Gi, limited: limits.memory=1Gi`,
+				LastTransitionTime: nowT,
+			}},
+		},
+	}
+	core, err := k8score.NewResourceCache(k8score.CacheConfig{
+		Client: fake.NewClientset(deploy),
+		ResourceTypes: map[string]bool{
+			"deployments": true,
+		},
+		DeferredTypes: map[string]bool{},
+	})
+	if err != nil {
+		t.Fatalf("NewResourceCache: %v", err)
+	}
+	t.Cleanup(core.Stop)
+	cache := &ResourceCache{ResourceCache: core}
+	if cache.Events() != nil {
+		t.Fatal("test setup expected Events lister to be unavailable")
+	}
+	problems := DetectAdmissionProblems(cache, "prod")
+	if !findProblem(problems, "Deployment", "prod", "search", "QuotaExceeded") {
+		t.Fatalf("expected condition fallback without Events lister, got %+v", problems)
+	}
+}
+
 func TestDetectAdmissionProblems_ReplicaFailureConditionFallbackForBlockedRollout(t *testing.T) {
 	defer ResetTestState()
 	nowT := metav1.Now()
@@ -212,6 +252,60 @@ func TestDetectAdmissionProblems_ReplicaFailureConditionFallbackForBlockedRollou
 	problems := DetectAdmissionProblems(GetResourceCache(), "prod")
 	if !findProblem(problems, "Deployment", "prod", "search", "QuotaExceeded") {
 		t.Fatalf("expected Deployment quota condition fallback for blocked rollout, got %+v", problems)
+	}
+}
+
+func TestDetectAdmissionProblems_DeploymentEventSuppressesReplicaSetCondition(t *testing.T) {
+	defer ResetTestState()
+	nowT := metav1.Now()
+	message := `pods "search-x" is forbidden: exceeded quota: memory-limit-quota, requested: limits.memory=1Gi, used: limits.memory=1Gi, limited: limits.memory=1Gi`
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "search", Namespace: "prod"},
+		Spec:       appsv1.DeploymentSpec{Replicas: ptr32(3)},
+		Status:     appsv1.DeploymentStatus{Replicas: 1, UpdatedReplicas: 1},
+	}
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "search-abc123",
+			Namespace: "prod",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "search",
+				Controller: boolPtr(true),
+			}},
+		},
+		Spec: appsv1.ReplicaSetSpec{Replicas: ptr32(3)},
+		Status: appsv1.ReplicaSetStatus{
+			Replicas: 1,
+			Conditions: []appsv1.ReplicaSetCondition{{
+				Type:               appsv1.ReplicaSetReplicaFailure,
+				Status:             corev1.ConditionTrue,
+				Reason:             "FailedCreate",
+				Message:            message,
+				LastTransitionTime: nowT,
+			}},
+		},
+	}
+	evt := &corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{Name: "quota-event", Namespace: "prod"},
+		InvolvedObject: corev1.ObjectReference{Kind: "Deployment", Namespace: "prod", Name: "search"},
+		Reason:         "FailedCreate",
+		Type:           corev1.EventTypeWarning,
+		Message:        `Error creating: ` + message,
+		LastTimestamp:  nowT,
+	}
+	if err := InitTestResourceCache(fake.NewClientset(deploy, rs, evt)); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	problems := DetectAdmissionProblems(GetResourceCache(), "prod")
+	if !findProblem(problems, "Deployment", "prod", "search", "QuotaExceeded") {
+		t.Fatalf("expected Deployment event problem, got %+v", problems)
+	}
+	for _, p := range problems {
+		if p.Kind == "ReplicaSet" && p.Name == "search-abc123" {
+			t.Fatalf("ReplicaSet condition duplicated Deployment event problem: %+v", problems)
+		}
 	}
 }
 
@@ -256,6 +350,47 @@ func TestDetectAdmissionProblems_ConditionFallbackDoesNotDuplicateReplicaSetEven
 		if p.Kind == "Deployment" && p.Name == "search" {
 			t.Fatalf("Deployment condition duplicated ReplicaSet event: %+v", problems)
 		}
+	}
+}
+
+func TestDetectAdmissionProblems_ReplicaSetConditionFallbackDedupe(t *testing.T) {
+	defer ResetTestState()
+	nowT := metav1.Now()
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "search-abc123", Namespace: "prod"},
+		Spec:       appsv1.ReplicaSetSpec{Replicas: ptr32(3)},
+		Status: appsv1.ReplicaSetStatus{
+			Replicas: 1,
+			Conditions: []appsv1.ReplicaSetCondition{
+				{
+					Type:               appsv1.ReplicaSetReplicaFailure,
+					Status:             corev1.ConditionTrue,
+					Reason:             "FailedCreate",
+					Message:            `pods "search-x" is forbidden: exceeded quota: memory-limit-quota, requested: limits.memory=1Gi, used: limits.memory=1Gi, limited: limits.memory=1Gi`,
+					LastTransitionTime: nowT,
+				},
+				{
+					Type:               appsv1.ReplicaSetReplicaFailure,
+					Status:             corev1.ConditionTrue,
+					Reason:             "FailedCreate",
+					Message:            `pods "search-y" is forbidden: exceeded quota: memory-limit-quota, requested: limits.memory=1Gi, used: limits.memory=1Gi, limited: limits.memory=1Gi`,
+					LastTransitionTime: nowT,
+				},
+			},
+		},
+	}
+	if err := InitTestResourceCache(fake.NewClientset(rs)); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	problems := DetectAdmissionProblems(GetResourceCache(), "prod")
+	rows := 0
+	for _, p := range problems {
+		if p.Kind == "ReplicaSet" && p.Name == "search-abc123" {
+			rows++
+		}
+	}
+	if rows != 1 {
+		t.Fatalf("expected one ReplicaSet condition problem, got %d: %+v", rows, problems)
 	}
 }
 

--- a/internal/k8s/detect_scheduling_integration_test.go
+++ b/internal/k8s/detect_scheduling_integration_test.go
@@ -119,6 +119,49 @@ func TestDetectAdmissionProblems_FailedCreateCrossCheck(t *testing.T) {
 	}
 }
 
+func TestDetectAdmissionProblems_FailedCreateDeploymentBlockedRollout(t *testing.T) {
+	defer ResetTestState()
+	nowT := metav1.Now()
+	quotaMsg := `Error creating: pods "x" is forbidden: exceeded quota: mem-quota, used: requests.memory=2Gi, limited: requests.memory=2Gi`
+	deploy := func(name string, updatedReplicas int32) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "prod"},
+			Spec:       appsv1.DeploymentSpec{Replicas: ptr32(3)},
+			Status: appsv1.DeploymentStatus{
+				Replicas:        3, // old ReplicaSet still satisfies total replicas
+				UpdatedReplicas: updatedReplicas,
+			},
+		}
+	}
+	evt := func(name, deployName string) *corev1.Event {
+		return &corev1.Event{
+			ObjectMeta:     metav1.ObjectMeta{Name: name, Namespace: "prod"},
+			InvolvedObject: corev1.ObjectReference{Kind: "Deployment", Namespace: "prod", Name: deployName},
+			Reason:         "FailedCreate",
+			Type:           corev1.EventTypeWarning,
+			Message:        quotaMsg,
+			LastTimestamp:  nowT,
+		}
+	}
+	if err := InitTestResourceCache(fake.NewClientset(
+		deploy("rollout-blocked", 1),
+		deploy("rollout-complete", 3),
+		evt("e-rollout-blocked", "rollout-blocked"),
+		evt("e-rollout-complete", "rollout-complete"),
+	)); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	problems := DetectAdmissionProblems(GetResourceCache(), "prod")
+	if !findProblem(problems, "Deployment", "prod", "rollout-blocked", "QuotaExceeded") {
+		t.Fatalf("blocked rolling update should surface Deployment admission issue, got %+v", problems)
+	}
+	for _, p := range problems {
+		if p.Name == "rollout-complete" {
+			t.Fatalf("completed rollout with lingering event must not surface admission issue: %+v", p)
+		}
+	}
+}
+
 func TestDetectAdmissionProblems_ReplicaFailureConditionFallback(t *testing.T) {
 	defer ResetTestState()
 	nowT := metav1.Now()

--- a/internal/k8s/history.go
+++ b/internal/k8s/history.go
@@ -917,11 +917,15 @@ func sensitivePath(path string) bool {
 
 func sensitivePathSegment(segment string) bool {
 	segment = strings.ToLower(segment)
+	compact := strings.NewReplacer("-", "", "_", "", ".", "", "/", "").Replace(segment)
 	return strings.Contains(segment, "password") || strings.Contains(segment, "passwd") ||
 		strings.Contains(segment, "token") || strings.Contains(segment, "secret") ||
+		strings.Contains(segment, "credential") ||
 		strings.Contains(segment, "api_key") || strings.Contains(segment, "apikey") ||
 		strings.Contains(segment, "accesskey") || strings.Contains(segment, "privatekey") ||
-		strings.Contains(segment, "private_key")
+		strings.Contains(segment, "private_key") ||
+		strings.Contains(compact, "apikey") || strings.Contains(compact, "accesskey") ||
+		strings.Contains(compact, "privatekey") || strings.Contains(compact, "clientsecret")
 }
 
 func truncateConfigScalar(value string, max int) string {
@@ -2395,6 +2399,14 @@ func diffPodTemplateConfig(oldSpec, newSpec corev1.PodSpec) ([]FieldChange, []st
 			changes = append(changes, FieldChange{Path: fmt.Sprintf("spec.template.spec.containers[%s].envFrom", name), OldValue: oldEnvFrom, NewValue: newEnvFrom})
 			summary = append(summary, fmt.Sprintf("envFrom(%s) changed", name))
 		}
+		if oldC.ImagePullPolicy != newC.ImagePullPolicy {
+			changes = append(changes, FieldChange{
+				Path:     fmt.Sprintf("spec.template.spec.containers[%s].imagePullPolicy", name),
+				OldValue: string(oldC.ImagePullPolicy),
+				NewValue: string(newC.ImagePullPolicy),
+			})
+			summary = append(summary, fmt.Sprintf("imagePullPolicy(%s): %s→%s", name, oldC.ImagePullPolicy, newC.ImagePullPolicy))
+		}
 		for _, probeName := range []string{"readinessProbe", "livenessProbe", "startupProbe"} {
 			oldProbe := normalizedProbe(probeForName(oldC, probeName))
 			newProbe := normalizedProbe(probeForName(newC, probeName))
@@ -2404,11 +2416,11 @@ func diffPodTemplateConfig(oldSpec, newSpec corev1.PodSpec) ([]FieldChange, []st
 			}
 		}
 		if !equalStringSlices(oldC.Command, newC.Command) {
-			changes = append(changes, FieldChange{Path: fmt.Sprintf("spec.template.spec.containers[%s].command", name), OldValue: oldC.Command, NewValue: newC.Command})
+			changes = append(changes, FieldChange{Path: fmt.Sprintf("spec.template.spec.containers[%s].command", name), OldValue: commandArgDisplayValues(oldC.Command), NewValue: commandArgDisplayValues(newC.Command)})
 			summary = append(summary, fmt.Sprintf("command(%s) changed", name))
 		}
 		if !equalStringSlices(oldC.Args, newC.Args) {
-			changes = append(changes, FieldChange{Path: fmt.Sprintf("spec.template.spec.containers[%s].args", name), OldValue: oldC.Args, NewValue: newC.Args})
+			changes = append(changes, FieldChange{Path: fmt.Sprintf("spec.template.spec.containers[%s].args", name), OldValue: commandArgDisplayValues(oldC.Args), NewValue: commandArgDisplayValues(newC.Args)})
 			summary = append(summary, fmt.Sprintf("args(%s) changed", name))
 		}
 	}
@@ -2573,6 +2585,52 @@ func valueOrNil(v string, ok bool) any {
 }
 
 func envNameLooksSecret(name string) bool {
+	return sensitivePathSegment(name)
+}
+
+func commandArgDisplayValues(values []string) []string {
+	out := make([]string, len(values))
+	redactNext := false
+	for i, value := range values {
+		if redactNext {
+			out[i] = "[REDACTED]"
+			redactNext = false
+			continue
+		}
+		out[i], redactNext = commandArgDisplayValue(value)
+	}
+	return out
+}
+
+func commandArgDisplayValue(value string) (string, bool) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return value, false
+	}
+	if prefix, ok := splitInlineSecretArg(trimmed); ok {
+		return prefix + "[REDACTED]", false
+	}
+	if commandArgNameLooksSecret(trimmed) {
+		return trimmed, true
+	}
+	return truncateConfigScalar(aicontext.RedactSecrets(value), 200), false
+}
+
+func splitInlineSecretArg(value string) (string, bool) {
+	for _, sep := range []string{"=", ":"} {
+		if before, _, ok := strings.Cut(value, sep); ok && commandArgNameLooksSecret(before) {
+			return before + sep, true
+		}
+	}
+	return "", false
+}
+
+func commandArgNameLooksSecret(value string) bool {
+	name := strings.Trim(strings.TrimSpace(value), "\"'")
+	name = strings.TrimLeft(name, "-")
+	if name == "key" {
+		return true
+	}
 	return sensitivePathSegment(name)
 }
 

--- a/internal/k8s/history_diff_test.go
+++ b/internal/k8s/history_diff_test.go
@@ -39,6 +39,61 @@ func TestDiffPodTemplateConfig_ContainerAddRemove(t *testing.T) {
 	}
 }
 
+func TestDiffPodTemplateConfig_ImagePullPolicy(t *testing.T) {
+	oldSpec := corev1.PodSpec{Containers: []corev1.Container{{
+		Name: "app", Image: "app:v1", ImagePullPolicy: corev1.PullIfNotPresent,
+	}}}
+	newSpec := corev1.PodSpec{Containers: []corev1.Container{{
+		Name: "app", Image: "app:v1", ImagePullPolicy: corev1.PullAlways,
+	}}}
+
+	changes, summary := diffPodTemplateConfig(oldSpec, newSpec)
+	if !hasChangePath(changes, "spec.template.spec.containers[app].imagePullPolicy") {
+		t.Fatalf("expected imagePullPolicy change, got %+v", changes)
+	}
+	if joined := strings.Join(summary, "; "); !strings.Contains(joined, "imagePullPolicy(app)") {
+		t.Fatalf("expected imagePullPolicy summary, got %q", joined)
+	}
+}
+
+func TestDiffPodTemplateConfig_CommandArgsRedaction(t *testing.T) {
+	oldSpec := corev1.PodSpec{Containers: []corev1.Container{{
+		Name:    "app",
+		Image:   "app:v1",
+		Command: []string{"server", "--client-secret=old-command-secret"},
+		Args:    []string{"--api-key", "old-api-key", "--mode=prod", "password=old-password"},
+	}}}
+	newSpec := corev1.PodSpec{Containers: []corev1.Container{{
+		Name:    "app",
+		Image:   "app:v1",
+		Command: []string{"server", "--client-secret=new-command-secret"},
+		Args:    []string{"--api-key", "new-api-key", "--mode=prod", "password=new-password"},
+	}}}
+
+	changes, _ := diffPodTemplateConfig(oldSpec, newSpec)
+	for _, path := range []string{
+		"spec.template.spec.containers[app].command",
+		"spec.template.spec.containers[app].args",
+	} {
+		change, ok := findChangePath(changes, path)
+		if !ok {
+			t.Fatalf("expected %s change, got %+v", path, changes)
+		}
+		values := strings.Join([]string{
+			strings.Join(change.OldValue.([]string), " "),
+			strings.Join(change.NewValue.([]string), " "),
+		}, " ")
+		for _, leaked := range []string{"old-command-secret", "new-command-secret", "old-api-key", "new-api-key", "old-password", "new-password"} {
+			if strings.Contains(values, leaked) {
+				t.Fatalf("%s leaked secret value %q in %+v", path, leaked, change)
+			}
+		}
+		if !strings.Contains(values, "[REDACTED]") {
+			t.Fatalf("%s did not redact secret-looking values: %+v", path, change)
+		}
+	}
+}
+
 // Named probe ports must round-trip through the diff — IntVal renders them all
 // as 0, hiding edits and conflating distinct names.
 func TestNormalizedProbe_NamedPorts(t *testing.T) {
@@ -54,4 +109,18 @@ func TestNormalizedProbe_NamedPorts(t *testing.T) {
 	if reflect.DeepEqual(a, c) {
 		t.Errorf("named vs numeric port must differ: %v vs %v", a, c)
 	}
+}
+
+func hasChangePath(changes []FieldChange, path string) bool {
+	_, ok := findChangePath(changes, path)
+	return ok
+}
+
+func findChangePath(changes []FieldChange, path string) (FieldChange, bool) {
+	for _, change := range changes {
+		if change.Path == path {
+			return change, true
+		}
+	}
+	return FieldChange{}, false
 }

--- a/packages/k8s-ui/src/components/issues/issues.test.ts
+++ b/packages/k8s-ui/src/components/issues/issues.test.ts
@@ -28,6 +28,13 @@ describe('compareIssues', () => {
     expect([older, newer].sort(compareIssues).map((i) => i.id)).toEqual(['n', 'o'])
   })
 
+  it('orders direct startup blockers before generic problem rows at same severity', () => {
+    const generic = mk({ id: 'generic', source: 'problem', first_seen: '2026-05-01T00:00:00Z' })
+    const blocker = mk({ id: 'blocker', source: 'scheduling', first_seen: '2026-01-01T00:00:00Z' })
+    const missing = mk({ id: 'missing', source: 'missing_ref', first_seen: '2026-03-01T00:00:00Z' })
+    expect([generic, blocker, missing].sort(compareIssues).map((i) => i.id)).toEqual(['blocker', 'missing', 'generic'])
+  })
+
   it('does NOT reshuffle same-severity rows when only last_seen changes (anti-churn)', () => {
     // Two same-severity rows, same first_seen — order is the deterministic name tiebreak.
     const a = mk({ id: 'id-a', name: 'a', first_seen: '2026-01-01T00:00:00Z', last_seen: '2026-05-01T00:00:00Z' })

--- a/packages/k8s-ui/src/components/issues/types.ts
+++ b/packages/k8s-ui/src/components/issues/types.ts
@@ -24,6 +24,13 @@ export const ISSUE_SEVERITY_RANK: Record<IssueSeverity, number> = {
   warning: 1,
 };
 
+const ISSUE_SOURCE_RANK: Record<string, number> = {
+  scheduling: 4,
+  missing_ref: 3,
+  condition: 2,
+  problem: 1,
+};
+
 export function isIssueSeverity(s: string): s is IssueSeverity {
   return s === 'critical' || s === 'warning';
 }
@@ -209,15 +216,18 @@ export function memberRef(issue: Issue, member: IssueResourceRef): IssueResource
 
 /**
  * compareIssues is the queue's stable sort order (extracted from IssuesView so
- * it can be unit-tested). Severity first (critical before warning), then ONSET
- * — first_seen DESC, deliberately NOT last_seen: last_seen bumps to compose-time
- * on every poll, so sorting by it would reshuffle same-severity rows on each
- * refetch. The remaining keys (cluster → namespace → name → id) are a fully
- * deterministic tiebreak so the order never churns under auto-refresh.
+ * it can be unit-tested). Severity first (critical before warning), then
+ * direct-blocker source priority, then ONSET — first_seen DESC, deliberately
+ * NOT last_seen: last_seen bumps to compose-time on every poll, so sorting by
+ * it would reshuffle same-severity rows on each refetch. The remaining keys
+ * (cluster → namespace → name → id) are a fully deterministic tiebreak so the
+ * order never churns under auto-refresh.
  */
 export function compareIssues(a: Issue, b: Issue): number {
   const r = ISSUE_SEVERITY_RANK[b.severity] - ISSUE_SEVERITY_RANK[a.severity];
   if (r !== 0) return r;
+  const sr = (ISSUE_SOURCE_RANK[b.source] ?? 0) - (ISSUE_SOURCE_RANK[a.source] ?? 0);
+  if (sr !== 0) return sr;
   const fa = a.first_seen ?? '';
   const fb = b.first_seen ?? '';
   if (fa !== fb) return fb.localeCompare(fa);


### PR DESCRIPTION
## Summary

This PR improves the deterministic diagnostic signals Radar surfaces for broken Kubernetes workloads, focusing on cases where the system can make a clear, current, non-speculative claim.

It promotes active startup/admission blockers and missing references ahead of generic problem rows at the same severity. The Go issue ordering and the k8s-ui issue comparator now use the same source priority, so API/MCP consumers and the UI agree on which issue should be shown first.

It also expands admission blocker detection beyond raw `FailedCreate` events. Radar now falls back to `ReplicaFailure=True` conditions on Deployments and ReplicaSets when events are unavailable or incomplete, but only when the workload still needs pod creation and the message classifies as a deterministic admission failure such as quota, webhook, or PodSecurity rejection. This intentionally avoids surfacing "near quota" or other advisory signals that are not actively blocking pod startup.

For rolling updates, Deployments are treated as still blocked when `updatedReplicas` lags the desired replica count, even if old ReplicaSet pods keep total `replicas` at the target. Admission rows are de-duplicated using controller owner references so an owned ReplicaSet condition does not duplicate the Deployment issue, while unrelated ReplicaSets with similar names are not suppressed.

The PR also improves recent workload change summaries by adding pod-template diffs for `imagePullPolicy` and redacted container `command`/`args` changes. This builds on the existing env/envFrom/probe/container diff machinery and keeps the history output useful for real rollout regressions without dumping unrelated spec noise.

## Implementation Notes

- `internal/issues/grouping.go` ranks issue sources within the same severity: scheduling/admission blockers first, then missing refs, conditions, and generic problems.
- `packages/k8s-ui/src/components/issues/types.ts` mirrors the same ordering for client-side sorting.
- `internal/k8s/detect_scheduling.go` now keeps admission detection alive when the events cache is unavailable, adds condition-based fallback rows, handles blocked Deployment rollouts via updated replicas, and de-dupes Deployment/ReplicaSet rows by owner refs.
- `internal/k8s/history.go` adds `imagePullPolicy` diffs and redacts sensitive command/args values before storing them in `FieldChange`.

## Validation

- `go test ./internal/issues`
- `go test ./internal/k8s -run 'TestDetectAdmissionProblems|TestDiffPodTemplateConfig|TestNormalizedProbe|TestComputeDiff_DaemonSetProbeConfig_Detected|TestComputeDiff_StatefulSetEnvRemoval_Detected'`
- `go test ./internal/k8s -run 'TestDetectAdmissionProblems'`
- `go test ./internal/k8s`
- `npm test -- src/components/issues/issues.test.ts`
- `npx tsc --noEmit`
