### PR TITLE
Add MCP stdio catalog mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ radar
 | `--prometheus-header-from-env` | | HTTP header sent with every Prometheus request, sourced from an environment variable, format `Key=ENV_VAR` (repeatable). |
 | `--auth-mode` | `none` | Authentication mode: `none`, `proxy`, or `oidc` ([details](docs/authentication.md)) |
 | `--no-mcp` | `false` | Disable MCP server for AI tool integration |
+| `--mcp-catalog-stdio` | `false` | Start only the MCP catalog over stdio for registry introspection |
 | `--version` | | Show version and exit |
 
 See [Configuration Guide](docs/configuration.md) for details on cluster connection precedence, multiple kubeconfig files, and context switching.

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/skyhook-io/radar/internal/cloud"
 	"github.com/skyhook-io/radar/internal/config"
 	"github.com/skyhook-io/radar/internal/k8s"
+	mcppkg "github.com/skyhook-io/radar/internal/mcp"
 	"github.com/skyhook-io/radar/internal/server"
 	"golang.org/x/net/http/httpguts"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // Register all auth provider plugins (OIDC, GCP, Azure, etc.)
@@ -77,6 +78,7 @@ func main() {
 	flag.Var(promHeadersFromEnv, "prometheus-header-from-env", "HTTP header to send with Prometheus requests, sourced from an env var, e.g. 'Authorization=PROMETHEUS_TOKEN' (repeatable).")
 	// MCP server
 	noMCP := flag.Bool("no-mcp", !fileCfg.MCPEnabledOr(true), "Disable MCP (Model Context Protocol) server for AI tools")
+	mcpCatalogStdio := flag.Bool("mcp-catalog-stdio", false, "Start only the MCP catalog over stdio for registry/inspector introspection; skips Kubernetes initialization")
 	mcpCatalogOnly := flag.Bool("mcp-catalog-only", false, "Start only the MCP endpoint for registry/inspector catalog introspection; skips Kubernetes initialization")
 	// Auth flags
 	authMode := flag.String("auth-mode", "none", "Authentication mode: none, proxy, or oidc")
@@ -171,12 +173,15 @@ func main() {
 	if *mcpCatalogOnly && noMCPFlagSet && *noMCP {
 		log.Fatalf("--mcp-catalog-only cannot be combined with --no-mcp")
 	}
+	if *mcpCatalogStdio && noMCPFlagSet && *noMCP {
+		log.Fatalf("--mcp-catalog-stdio cannot be combined with --no-mcp")
+	}
 	resolvedPrometheusHeaders, err := app.ResolvePrometheusHeaders(promHeaders.value(), promHeadersFromEnv.value())
 	if err != nil {
 		log.Fatalf("Invalid Prometheus header configuration: %v", err)
 	}
 	mcpEnabled := !*noMCP
-	if *mcpCatalogOnly {
+	if *mcpCatalogOnly || *mcpCatalogStdio {
 		mcpEnabled = true
 	}
 
@@ -229,6 +234,16 @@ func main() {
 
 	// Set global flags
 	app.SetGlobals(cfg)
+
+	if *mcpCatalogStdio {
+		log.Printf("MCP catalog stdio mode enabled: skipping Kubernetes initialization")
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+		if err := mcppkg.RunStdio(ctx); err != nil && !errors.Is(err, context.Canceled) {
+			log.Fatalf("MCP stdio server failed: %v", err)
+		}
+		return
+	}
 
 	if *mcpCatalogOnly {
 		log.Printf("MCP catalog-only mode enabled: skipping Kubernetes initialization")

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -47,6 +47,15 @@ radar --mcp-catalog-only --no-browser
 
 This mode skips Kubernetes initialization and starts the `/mcp` endpoint for schema introspection. Cluster-backed tool calls still require a normal Radar process connected to Kubernetes.
 
+For registries that launch MCP servers over stdio, use:
+
+```bash
+radar --mcp-catalog-stdio
+```
+
+This exposes the same tool and resource catalog over stdio without starting the HTTP UI server.
+The stdio mode is intended only for catalog introspection; normal Radar sessions use the HTTP endpoint above.
+
 ## Setup Instructions
 
 Connect your AI tool to Radar's MCP server. Radar must be running first (`radar` or `kubectl radar`).

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,21 +1,20 @@
 package mcp
 
 import (
+	"context"
 	"log"
 	"net/http"
 	"os"
 	"strings"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/skyhook-io/radar/internal/version"
 )
 
-// NewHandler creates the MCP server, registers all tools and resources,
-// and returns an http.Handler to mount on chi.
-func NewHandler() http.Handler {
-	server := mcp.NewServer(
-		&mcp.Implementation{
+func newServer() *mcpsdk.Server {
+	server := mcpsdk.NewServer(
+		&mcpsdk.Implementation{
 			Name:    "radar",
 			Version: version.Current,
 		},
@@ -25,7 +24,17 @@ func NewHandler() http.Handler {
 	registerTools(server)
 	registerResources(server)
 
-	streamOpts := &mcp.StreamableHTTPOptions{Stateless: true}
+	return server
+}
+
+// RunStdio runs the MCP server over stdio.
+func RunStdio(ctx context.Context) error {
+	return newServer().Run(ctx, &mcpsdk.StdioTransport{})
+}
+
+// NewHandler creates the MCP HTTP handler to mount on chi.
+func NewHandler() http.Handler {
+	streamOpts := &mcpsdk.StreamableHTTPOptions{Stateless: true}
 	// The MCP SDK auto-enables DNS-rebinding protection (Host header must be
 	// loopback) when the server binds to a loopback address. That blocks
 	// Docker-isolated callers reaching us via host.docker.internal. Allow
@@ -35,8 +44,9 @@ func NewHandler() http.Handler {
 		log.Printf("[mcp] WARNING: DNS-rebinding Host check DISABLED via env (bench mode)")
 	}
 
-	handler := mcp.NewStreamableHTTPHandler(
-		func(r *http.Request) *mcp.Server { return server },
+	server := newServer()
+	handler := mcpsdk.NewStreamableHTTPHandler(
+		func(r *http.Request) *mcpsdk.Server { return server },
 		streamOpts,
 	)
 


### PR DESCRIPTION
## Summary

- Add a native `--mcp-catalog-stdio` mode for catalog-only MCP introspection
- Share MCP server construction between HTTP and stdio transports
- Document `radar --mcp-catalog-stdio` for registry catalog introspection

## Why

Glama's GitHub server build path launches a local MCP command behind `mcp-proxy`. Radar previously only exposed Streamable HTTP at `/mcp`, so Glama could not run catalog checks without proxying to an external endpoint. This gives Glama a local stdio command for catalog checks while leaving normal Radar sessions on the existing HTTP MCP endpoint.

`--mcp-catalog-stdio` is a standalone catalog introspection mode; it does not add a new cluster-connected stdio serving mode.

## Validation

- `go test ./cmd/explorer ./internal/mcp`
- `go run github.com/modelcontextprotocol/go-sdk/examples/client/listfeatures@v1.6.1 -- go run ./cmd/explorer --mcp-catalog-stdio`
- `go run github.com/modelcontextprotocol/go-sdk/examples/client/listfeatures@v1.6.1 -- go run ./cmd/explorer --mcp-catalog-stdio --mcp-catalog-only`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CLI path and refactor limited to MCP startup; no changes to cluster-connected MCP behavior or auth.
> 
> **Overview**
> Adds **`--mcp-catalog-stdio`**, a catalog-only startup path for MCP registries that spawn servers over stdio (e.g. Glama) instead of HTTP `/mcp`.
> 
> When the flag is set, Radar **skips Kubernetes and the HTTP UI** and runs the same tool/resource catalog via **`RunStdio`** on the MCP SDK stdio transport. MCP construction is **factored into `newServer()`** so HTTP (`NewHandler`) and stdio share registration logic. **`--mcp-catalog-stdio` cannot be used with `--no-mcp`** (same pattern as catalog-only HTTP); both catalog modes force MCP enabled.
> 
> **README** and **`docs/mcp.md`** document the flag and clarify that stdio is for introspection only—cluster-backed tools still need a normal Radar session on HTTP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d5848fc2e1bcca52d29d654a2186cedc0359b9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->