### PR TITLE
fix(resource-counts): use stable version for counts + skip non-listable kinds

### DIFF
--- a/internal/server/resource_counts.go
+++ b/internal/server/resource_counts.go
@@ -3,6 +3,7 @@ package server
 import (
 	"log"
 	"net/http"
+	"slices"
 	"sync"
 
 	"github.com/skyhook-io/radar/internal/k8s"
@@ -113,6 +114,12 @@ func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
 			var crds []crdInfo
 			for _, res := range resources {
 				if !res.IsCRD {
+					continue
+				}
+				// Informer-backed counts only work for listable+watchable kinds.
+				// Create-only review resources (LocalSubjectAccessReview, etc.)
+				// never sync an informer and would log a permanent count error.
+				if !slices.Contains(res.Verbs, "list") || !slices.Contains(res.Verbs, "watch") {
 					continue
 				}
 				key := res.Group + "/" + res.Kind

--- a/pkg/k8score/discovery.go
+++ b/pkg/k8score/discovery.go
@@ -376,17 +376,26 @@ func (d *ResourceDiscovery) GetGVRWithGroup(kindOrName string, group string) (sc
 	defer d.mu.RUnlock()
 
 	kindLower := strings.ToLower(kindOrName)
-	for _, res := range d.resources {
+	var best *APIResource
+	for i := range d.resources {
+		res := &d.resources[i]
 		if (strings.ToLower(res.Kind) == kindLower || strings.ToLower(res.Name) == kindLower) && res.Group == group {
-			return schema.GroupVersionResource{
-				Group:    res.Group,
-				Version:  res.Version,
-				Resource: res.Name,
-			}, true
+			// Multiple served versions can coexist (e.g. Gateway v1beta1 + v1).
+			// Informers are registered against the most stable version, so a
+			// first-match return would hand back a version no informer watches.
+			if best == nil || IsMoreStableVersion(res.Version, best.Version) {
+				best = res
+			}
 		}
 	}
-
-	return schema.GroupVersionResource{}, false
+	if best == nil {
+		return schema.GroupVersionResource{}, false
+	}
+	return schema.GroupVersionResource{
+		Group:    best.Group,
+		Version:  best.Version,
+		Resource: best.Name,
+	}, true
 }
 
 // GetResource returns the APIResource for a given kind or plural name.

--- a/pkg/k8score/discovery_test.go
+++ b/pkg/k8score/discovery_test.go
@@ -37,6 +37,43 @@ func TestAddAPIResourceRegistersGroupQualifiedCRD(t *testing.T) {
 	}
 }
 
+func TestGetGVRWithGroupPrefersMostStableVersion(t *testing.T) {
+	d := &ResourceDiscovery{
+		resourceMap: make(map[string]APIResource),
+		gvrMap:      make(map[string]schema.GroupVersionResource),
+	}
+
+	// Both versions served; deprecated v1beta1 discovered first. Informers are
+	// registered against the storage version (v1), so the count lookup must
+	// resolve to v1 — not the first-discovered v1beta1.
+	d.AddAPIResource(APIResource{
+		Group:      "gateway.networking.k8s.io",
+		Version:    "v1beta1",
+		Kind:       "Gateway",
+		Name:       "gateways",
+		Namespaced: true,
+		IsCRD:      true,
+		Verbs:      []string{"get", "list", "watch"},
+	})
+	d.AddAPIResource(APIResource{
+		Group:      "gateway.networking.k8s.io",
+		Version:    "v1",
+		Kind:       "Gateway",
+		Name:       "gateways",
+		Namespaced: true,
+		IsCRD:      true,
+		Verbs:      []string{"get", "list", "watch"},
+	})
+
+	gvr, ok := d.GetGVRWithGroup("Gateway", "gateway.networking.k8s.io")
+	if !ok {
+		t.Fatal("expected group-qualified Gateway lookup to resolve")
+	}
+	if gvr.Version != "v1" {
+		t.Fatalf("version = %q, want v1 (storage version, not first-discovered v1beta1)", gvr.Version)
+	}
+}
+
 func TestSupportsWatchGVRUsesExactGroupVersionResource(t *testing.T) {
 	d := &ResourceDiscovery{
 		resourceMap: make(map[string]APIResource),


### PR DESCRIPTION
Fixes #897.

`resource-counts` logged `informer not found or not synced for ...` every ~4s for the lifetime of the pod and silently omitted the affected kinds from the sidebar counts. Two independent root causes:

### 1. Version mismatch — `GetGVRWithGroup` returned first-match, not the stable version
Informers are registered against the **most stable** served version (`DiscoverAllCRDs` → `IsMoreStableVersion`). But the resource-counts CRD loop derived its count GVR via `GetGVRWithGroup`, which did a plain first-match linear scan over discovered resources. When a CRD served multiple versions (e.g. `gateway.networking.k8s.io` Gateway `v1beta1`+`v1`), it could hand back a version no informer watches → `Count()` finds nothing → permanent error, and the kind is dropped from counts.

Every other version selector already used `IsMoreStableVersion` (`GetGVR`/`gvrMap`, `GetAPIResources`, `DiscoverAllCRDs`) — the group-qualified lookup was the lone exception. This aligns it.

### 2. Non-listable kinds counted as CRDs
`authorization.k8s.io` / `authentication.k8s.io` aren't in `coreAPIGroups`, so create-only review resources (`LocalSubjectAccessReview`, `SubjectAccessReview`, `SelfSubjectRulesReview`, `TokenReview`, ...) were treated as CRDs and counted. They support only `create` — no informer can ever sync. The count loop now skips kinds lacking `list`+`watch`, mirroring the filter `DiscoverAllCRDs` already applies.

## Verification
Built old (`main`) vs new binaries and ran both against a cluster carrying the issue's exact CRDs with multiple served versions (Gateway/HTTPRoute, Kyverno PolicyException/Policy at v2beta1, `policies.kyverno.io/*` at v1beta1, `monitoring.googleapis.com/*` at v1alpha1, GKE ManagedCertificate at v1beta2):

| | `informer not found or not synced` errors |
|---|---|
| old | **40 distinct kinds**, every poll |
| new | **0** |

New binary also surfaces counts that were previously dropped (Gateway=1, HTTPRoute=7).

## Tests
- `TestGetGVRWithGroupPrefersMostStableVersion` — pins v1 selection when v1beta1 is discovered first (the issue's exact scenario).
- Existing discovery + resource tests pass; full `make test` + `make tsc` green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted discovery and counting fixes with a regression test; no auth or data-path changes beyond stopping erroneous count attempts.
> 
> **Overview**
> Fixes **resource-counts** polling so CRD sidebar counts use the same GVR versions as informers and stop hammering logs for kinds that can never be counted.
> 
> **`GetGVRWithGroup`** no longer returns the first matching group+kind; it picks the **most stable** served API version via `IsMoreStableVersion`, matching informer registration and other discovery paths. That removes version mismatches (e.g. Gateway `v1beta1` vs `v1`) that caused perpetual `informer not found or not synced` errors and missing counts.
> 
> The **resource-counts** CRD loop now **skips** kinds without both **`list`** and **`watch`**, so create-only auth/review APIs are not treated as informer-backed CRDs.
> 
> Adds **`TestGetGVRWithGroupPrefersMostStableVersion`** for multi-version Gateway lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4b46830d16daaaef2502cd5a78892627992b93e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->