### PR TITLE
fix(drawer): derive kind chip from data.kind, not URL plural (#879)

### DIFF
--- a/packages/k8s-ui/src/components/shared/ResourceActionsBar.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceActionsBar.tsx
@@ -23,7 +23,7 @@ import { ForceDeleteConfirmDialog, type CascadeDependent } from '../ui/ForceDele
 import { ConfirmDialog } from '../ui/ConfirmDialog'
 import { DialogPortal } from '../ui/DialogPortal'
 import type { SelectedResource, WorkloadRevision } from '../../types'
-import { formatKindName } from '../ui/drawer-components'
+import { displayKindName } from '../ui/drawer-components'
 import { getDefaultContainerName } from '../resources/resource-utils'
 
 // ============================================================================
@@ -517,20 +517,20 @@ export function ResourceActionsBar({
           <Tooltip
             content={
               onCompareTo && onCompareAcrossClusters
-                ? `Compare ${formatKindName(resource.kind).toLowerCase()}`
+                ? `Compare ${displayKindName(resource.kind, data?.kind).toLowerCase()}`
                 : onCompareAcrossClusters
                   ? `Compare across clusters`
-                  : `Compare to another ${formatKindName(resource.kind).toLowerCase()}`
+                  : `Compare to another ${displayKindName(resource.kind, data?.kind).toLowerCase()}`
             }
           >
             <button
               onClick={onCompareTo ?? onCompareAcrossClusters}
               aria-label={
                 onCompareTo && onCompareAcrossClusters
-                  ? `Compare ${formatKindName(resource.kind).toLowerCase()}`
+                  ? `Compare ${displayKindName(resource.kind, data?.kind).toLowerCase()}`
                   : onCompareAcrossClusters
                     ? `Compare across clusters`
-                    : `Compare to another ${formatKindName(resource.kind).toLowerCase()}`
+                    : `Compare to another ${displayKindName(resource.kind, data?.kind).toLowerCase()}`
               }
               className="p-1.5 text-theme-text-secondary border border-theme-border-light rounded-lg hover:text-theme-text-primary hover:bg-theme-elevated transition-colors flex items-center"
             >
@@ -577,7 +577,7 @@ export function ResourceActionsBar({
         onClose={() => setShowDeleteConfirm(false)}
         onConfirm={handleDeleteConfirm}
         resourceName={resource.name}
-        resourceKind={formatKindName(resource.kind)}
+        resourceKind={displayKindName(resource.kind, data?.kind)}
         namespaceName={resource.namespace}
         isLoading={isDeleting ?? false}
         cascadeDependents={cascadeDependents}

--- a/packages/k8s-ui/src/components/ui/ForceDeleteConfirmDialog.tsx
+++ b/packages/k8s-ui/src/components/ui/ForceDeleteConfirmDialog.tsx
@@ -1,7 +1,6 @@
 import { useState, useMemo } from 'react'
 import { ChevronDown, ChevronRight, Loader2 } from 'lucide-react'
 import { ConfirmDialog } from './ConfirmDialog'
-import { formatKindName } from './drawer-components'
 import { pluralize } from '../../utils/pluralize'
 
 export interface CascadeDependent {
@@ -115,7 +114,7 @@ function CascadeDependentsList({ dependents }: { dependents: CascadeDependent[] 
         <div className="px-3 pb-2.5 space-y-1.5">
           {grouped.map(([kind, names]) => (
             <div key={kind} className="text-xs">
-              <span className="font-medium text-theme-text-primary">{formatKindName(kind)}</span>
+              <span className="font-medium text-theme-text-primary">{kind}</span>
               <span className="text-theme-text-tertiary ml-1">({names.length})</span>
               <div className="ml-3 mt-0.5 text-theme-text-secondary font-mono break-all">
                 {names.slice(0, MAX_NAMES_PER_KIND).join(', ')}

--- a/packages/k8s-ui/src/components/ui/drawer-components.tsx
+++ b/packages/k8s-ui/src/components/ui/drawer-components.tsx
@@ -701,6 +701,14 @@ export function formatKindName(kind: string): string {
   return kind
 }
 
+// Resolve the display label for a kind chip. The fetched resource's `dataKind`
+// is the authoritative PascalCase kind and is correct for every CRD; prefer it.
+// Before data loads, fall back to deriving from the URL plural — which is only
+// reliable for the core kinds in formatKindName's map.
+export function displayKindName(urlPlural: string, dataKind?: string): string {
+  return dataKind || formatKindName(urlPlural)
+}
+
 // Type for copy handler
 export type CopyHandler = (text: string, key: string) => void
 

--- a/packages/k8s-ui/src/components/workload/WorkloadView.tsx
+++ b/packages/k8s-ui/src/components/workload/WorkloadView.tsx
@@ -51,7 +51,7 @@ import { EditableYamlView, SaveSuccessAnimation } from '../shared/EditableYamlVi
 import { ResourceRendererDispatch, getResourceStatus, type RendererOverrides } from '../shared/ResourceRendererDispatch'
 import { DetailShell, type DetailShellTab } from '../shared/DetailShell'
 import { HelmManagedByChip, ManagedByChip, type HelmOwnerRef } from '../shared/ManagedByChip'
-import { getKindColorOutline, formatKindName } from '../ui/drawer-components'
+import { getKindColorOutline, displayKindName } from '../ui/drawer-components'
 import { midTruncate } from '../../utils/format'
 
 export type WorkloadTabType = 'overview' | 'topology' | 'timeline' | 'logs' | 'metrics' | 'yaml'
@@ -555,7 +555,7 @@ export function WorkloadView({
           <div className="flex items-center justify-between px-4 pt-3 pb-2">
             <div className="flex items-center gap-2 flex-wrap">
               <span className={clsx('badge', getKindColorOutline(apiKind))}>
-                {formatKindName(apiKind)}
+                {displayKindName(apiKind, resource?.kind)}
               </span>
               {status && (
                 <span className={clsx('badge', status.color)}>
@@ -706,7 +706,7 @@ export function WorkloadView({
           </div>
           <div className="flex items-center gap-3 text-sm text-theme-text-secondary">
             <span className={clsx('badge', getKindColorOutline(apiKind))}>
-              {formatKindName(apiKind)}
+              {displayKindName(apiKind, resource?.kind)}
             </span>
             {status && (
               <span className={clsx('badge', status.color)}>
@@ -860,7 +860,7 @@ export function WorkloadView({
                       )}
                     >
                       <span className="truncate text-xs font-medium text-theme-text-primary">{midTruncate(o.name, 26)}</span>
-                      <span className="text-[10px] uppercase tracking-wide text-theme-text-tertiary">{formatKindName(o.kind)}</span>
+                      <span className="text-[10px] uppercase tracking-wide text-theme-text-tertiary">{o.kind}</span>
                     </button>
                   )
                 })}


### PR DESCRIPTION
Closes #879.

## Problem
The resource drawer header chip got its label from `formatKindName()` applied to the lowercase **URL plural**. That function only knows core kinds via a hardcoded map and naively singularizes everything else, so every unmapped CRD rendered mangled:

- `scaledobjects` → "Scaledobject"
- `gitrepositories` → "Gitrepositorie"
- `clusterpolicies` → "Clusterpolicy"

#878 patched the map for DRA/NVIDIA kinds, but the map approach means every new integration must remember to add entries, and the generic-fallback long tail is always wrong.

## Fix
The drawer always has the fetched resource, and `data.kind` carries the authoritative PascalCase kind (`ScaledObject`, `GitRepository`) for every CRD. New `displayKindName(urlPlural, dataKind?)` prefers `data.kind` and falls back to `formatKindName()` only for the brief render before data loads.

Threaded through:
- Both `WorkloadView` header chips (collapsed drawer + expanded view)
- `ResourceActionsBar` compare tooltips/aria-labels and the delete-dialog `resourceKind`
- The cascade-dependents list, which already receives backend-normalized PascalCase kinds — now rendered directly instead of re-mangled
- YAML object rail (topology nodes already carry PascalCase)

No abbreviation map. Chips read full PascalCase everywhere, consistent with Lens / Kubernetes Dashboard / Rancher / ArgoCD, where short forms like `hpa`/`pvc` are typing aliases (kubectl `SHORTNAMES`, k9s command aliases), not display labels.

`make tsc` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only label changes in the k8s UI; no API, auth, or mutation behavior changes.
> 
> **Overview**
> Fixes **mangled kind labels** for CRDs by preferring the fetched resource’s authoritative **`data.kind`** (PascalCase) instead of deriving labels from the URL plural via `formatKindName()`.
> 
> Adds **`displayKindName(urlPlural, dataKind?)`** in `drawer-components` and wires it through **drawer/expanded header chips**, **compare tooltips/aria-labels**, and the **delete confirmation** `resourceKind`. **Cascade dependent** and **YAML object rail** kind lines now show backend/PascalCase kinds directly, without re-singularizing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b6ef1051c0e3e5e51a257f707129e56a14a32b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->