### PR TITLE
Gate Radar config + audit settings to owners

### DIFF
--- a/internal/server/audit_handlers.go
+++ b/internal/server/audit_handlers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/skyhook-io/radar/internal/audit"
+	"github.com/skyhook-io/radar/internal/auth"
 	"github.com/skyhook-io/radar/internal/k8s"
 	"github.com/skyhook-io/radar/internal/settings"
 	bp "github.com/skyhook-io/radar/pkg/audit"
@@ -192,6 +193,9 @@ func (s *Server) handleGetAuditSettings(w http.ResponseWriter, r *http.Request) 
 // handlePutAuditSettings updates the audit configuration.
 // PUT /api/settings/audit
 func (s *Server) handlePutAuditSettings(w http.ResponseWriter, r *http.Request) {
+	if !s.requireCloudRole(w, r, auth.RoleOwner, "modify audit settings") {
+		return
+	}
 	var cfg settings.AuditConfig
 	if err := json.NewDecoder(r.Body).Decode(&cfg); err != nil {
 		s.writeError(w, http.StatusBadRequest, "Invalid JSON: "+err.Error())

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3280,6 +3280,40 @@ func (s *Server) writeError(w http.ResponseWriter, status int, message string) {
 	}
 }
 
+// writeErrorCode is writeError plus a stable machine-readable `error_code`
+// the SPA branches on (e.g. cloud_role_insufficient → "your role can't do
+// this" instead of a generic auth failure).
+func (s *Server) writeErrorCode(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(map[string]string{"error": message, "error_code": code}); err != nil {
+		log.Printf("Failed to encode error response: %v", err)
+	}
+}
+
+// requireCloudRole gates a mutating handler on the caller's Cloud role tier,
+// mirroring internal/helm's gate. Returns true if the request should proceed.
+//
+// Callers with no Cloud role (OSS, OIDC, or running outside Cloud's tunnel)
+// bypass the gate — radar OSS keeps using only K8s RBAC for authz, so the
+// single-user laptop case is never 403'd out of its own config. The gate is
+// strictly additive for Cloud-attributed callers: when their tier is below
+// `min`, returns 403 with error_code=cloud_role_insufficient.
+func (s *Server) requireCloudRole(w http.ResponseWriter, r *http.Request, min auth.CloudRole, opName string) bool {
+	role := auth.CloudRoleFromContext(r.Context())
+	if role.AtLeast(min) {
+		return true
+	}
+	username := "unknown"
+	if u := auth.UserFromContext(r.Context()); u != nil {
+		username = u.Username
+	}
+	log.Printf("[settings] Cloud role %q denied %s for user %q (need at least %q): %q", role, opName, username, min, r.URL.Path)
+	s.writeErrorCode(w, http.StatusForbidden, auth.ErrCodeCloudRoleInsufficient,
+		"Your Radar Cloud role ("+role.String()+") cannot "+opName+". Requires "+string(min)+" or higher.")
+	return false
+}
+
 // requireConnected returns false and writes a 503 error if not connected to cluster.
 // Use at the start of handlers that require an active cluster connection.
 func (s *Server) requireConnected(w http.ResponseWriter) bool {
@@ -3575,6 +3609,9 @@ func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 // PrometheusHeaders are preserved from the on-disk file: the GET response redacts them,
 // so a UI round-trip would otherwise silently wipe the user's auth headers.
 func (s *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
+	if !s.requireCloudRole(w, r, auth.RoleOwner, "modify Radar configuration") {
+		return
+	}
 	var updated config.Config
 	if err := json.NewDecoder(r.Body).Decode(&updated); err != nil {
 		s.writeError(w, http.StatusBadRequest, "invalid request body")

--- a/internal/server/settings_role_test.go
+++ b/internal/server/settings_role_test.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/skyhook-io/radar/internal/auth"
+)
+
+// userWithGroups builds an authenticated user carrying the given groups, used
+// to drive the Cloud-role gate (cloud:<tier> prefix).
+func userWithGroups(groups ...string) *auth.User {
+	return &auth.User{Username: "u@example.com", Groups: groups}
+}
+
+func putConfigStatus(t *testing.T, user *auth.User) (int, string) {
+	t.Helper()
+	// Redirect config persistence to a temp HOME so pass-through cases that
+	// reach config.Update() don't clobber the developer's real ~/.radar.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+	s := &Server{}
+	r := httptest.NewRequest("PUT", "/api/config", strings.NewReader(`{}`))
+	if user != nil {
+		r = r.WithContext(auth.ContextWithUser(r.Context(), user))
+	}
+	w := httptest.NewRecorder()
+	s.handlePutConfig(w, r)
+	return w.Code, w.Body.String()
+}
+
+func TestPutConfig_RoleGate(t *testing.T) {
+	// Non-owner Cloud roles are rejected with the stable error_code so the
+	// SPA can branch on it.
+	for _, tier := range []string{"cloud:viewer", "cloud:member"} {
+		code, body := putConfigStatus(t, userWithGroups(tier))
+		if code != http.StatusForbidden {
+			t.Errorf("%s: status = %d, want 403; body=%s", tier, code, body)
+		}
+		var resp map[string]string
+		if err := json.Unmarshal([]byte(body), &resp); err != nil {
+			t.Fatalf("%s: bad json: %v", tier, err)
+		}
+		if resp["error_code"] != auth.ErrCodeCloudRoleInsufficient {
+			t.Errorf("%s: error_code = %q, want %q", tier, resp["error_code"], auth.ErrCodeCloudRoleInsufficient)
+		}
+	}
+}
+
+func TestPutConfig_OwnerAndOSSBypassRoleGate(t *testing.T) {
+	// Owners and non-Cloud callers (no role group → OSS / OIDC / kubectl
+	// plugin) must get past the role gate. They may still fail later writing
+	// the config file, but they must NOT be 403'd by the gate — a single-user
+	// laptop owns its own config.
+	cases := []struct {
+		name string
+		user *auth.User
+	}{
+		{"owner", userWithGroups("cloud:owner")},
+		{"no-role-groups", userWithGroups("devs")},
+		{"no-user", nil},
+	}
+	for _, tc := range cases {
+		code, body := putConfigStatus(t, tc.user)
+		if code == http.StatusForbidden {
+			t.Errorf("%s: got 403 from role gate, want pass-through; body=%s", tc.name, body)
+		}
+	}
+}

--- a/web/src/components/audit/AuditSettingsDialog.tsx
+++ b/web/src/components/audit/AuditSettingsDialog.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from 'react'
-import { X, Plus, Trash2 } from 'lucide-react'
+import { X, Plus, Trash2, Lock } from 'lucide-react'
 import { clsx } from 'clsx'
-import { useAuditSettings, useUpdateAuditSettings, useAudit } from '../../api/client'
+import { useAuditSettings, useUpdateAuditSettings, useAudit, useCloudRole } from '../../api/client'
 import type { CheckMeta } from '@skyhook-io/k8s-ui'
 import { validateRFC1123Label, type ValidationResult } from '@skyhook-io/k8s-ui/utils/validators'
 
@@ -14,6 +14,11 @@ export function AuditSettingsDialog({ namespaces, onClose }: AuditSettingsDialog
   const { data: settings } = useAuditSettings()
   const { data: auditData } = useAudit(namespaces)
   const updateSettings = useUpdateAuditSettings()
+  // Audit policy is cluster-shared, so writes are owner-gated (enforced
+  // server-side too). Non-owners get a read-only view. Non-Cloud callers
+  // have no role and pass.
+  const { canAtLeast } = useCloudRole()
+  const canEdit = canAtLeast('owner')
   const [ignoredNs, setIgnoredNs] = useState<string[]>([])
   const [disabledChecks, setDisabledChecks] = useState<string[]>([])
   const [newNs, setNewNs] = useState('')
@@ -75,6 +80,15 @@ export function AuditSettingsDialog({ namespaces, onClose }: AuditSettingsDialog
         </div>
 
         <div className="px-5 py-4 overflow-y-auto flex-1">
+          {!canEdit && (
+            <div className="mb-4 rounded-lg border border-theme-border bg-theme-elevated/50 p-3 flex items-start gap-2.5">
+              <Lock className="w-3.5 h-3.5 mt-0.5 shrink-0 text-theme-text-tertiary" />
+              <p className="text-xs text-theme-text-tertiary">
+                Audit policy is shared across everyone using this Radar instance, so editing
+                is limited to owners. You can review the current settings here.
+              </p>
+            </div>
+          )}
           {/* Ignored Namespaces */}
           <div className="mb-6">
             <label className="text-xs font-medium text-theme-text-secondary uppercase tracking-wider">
@@ -90,7 +104,8 @@ export function AuditSettingsDialog({ namespaces, onClose }: AuditSettingsDialog
                   <span className="text-sm text-theme-text-primary">{ns}</span>
                   <button
                     onClick={() => setIgnoredNs(ignoredNs.filter(n => n !== ns))}
-                    className="p-1 rounded hover:bg-theme-hover text-theme-text-tertiary hover:text-red-400 transition-colors"
+                    disabled={!canEdit}
+                    className="p-1 rounded hover:bg-theme-hover text-theme-text-tertiary hover:text-red-400 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:text-theme-text-tertiary"
                   >
                     <Trash2 className="w-3.5 h-3.5" />
                   </button>
@@ -108,6 +123,7 @@ export function AuditSettingsDialog({ namespaces, onClose }: AuditSettingsDialog
                 onChange={e => setNewNs(e.target.value)}
                 onKeyDown={e => { if (e.key === 'Enter') addNamespace() }}
                 placeholder="Add namespace..."
+                disabled={!canEdit}
                 aria-invalid={newNsError ? true : undefined}
                 aria-describedby="new-ns-help"
                 className={clsx(
@@ -119,7 +135,7 @@ export function AuditSettingsDialog({ namespaces, onClose }: AuditSettingsDialog
               />
               <button
                 onClick={addNamespace}
-                disabled={!canAddNamespace}
+                disabled={!canEdit || !canAddNamespace}
                 className="px-3 py-1.5 text-sm btn-brand rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <Plus className="w-4 h-4" />
@@ -155,7 +171,8 @@ export function AuditSettingsDialog({ namespaces, onClose }: AuditSettingsDialog
                       type="checkbox"
                       checked={!disabled}
                       onChange={() => toggleCheck(check.id)}
-                      className="w-4 h-4 rounded border-theme-border text-skyhook-500 focus:ring-skyhook-500"
+                      disabled={!canEdit}
+                      className="w-4 h-4 rounded border-theme-border text-skyhook-500 focus:ring-skyhook-500 disabled:opacity-40 disabled:cursor-not-allowed"
                     />
                     <div className="flex-1 min-w-0">
                       <span className="text-sm text-theme-text-primary">{check.title}</span>
@@ -181,14 +198,16 @@ export function AuditSettingsDialog({ namespaces, onClose }: AuditSettingsDialog
             // text — otherwise the user clicks Save expecting their
             // entry to be included and it's silently dropped.
             disabled={
-              updateSettings.isPending || newNsError !== null || newNsDuplicate
+              !canEdit || updateSettings.isPending || newNsError !== null || newNsDuplicate
             }
             title={
-              newNsError
-                ? 'Fix or clear the pending namespace input before saving'
-                : newNsDuplicate
-                  ? 'Clear the duplicate pending input before saving'
-                  : undefined
+              !canEdit
+                ? 'Audit settings can only be changed by owners'
+                : newNsError
+                  ? 'Fix or clear the pending namespace input before saving'
+                  : newNsDuplicate
+                    ? 'Clear the duplicate pending input before saving'
+                    : undefined
             }
             className="px-4 py-1.5 text-sm btn-brand rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
           >

--- a/web/src/components/audit/AuditView.tsx
+++ b/web/src/components/audit/AuditView.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react'
-import { useAudit, useAuditSettings, useUpdateAuditSettings } from '../../api/client'
+import { useAudit, useAuditSettings, useUpdateAuditSettings, useCloudRole } from '../../api/client'
 import type { SelectedResource } from '../../types'
 import { ChecksView, PaneLoader, type CheckResourceRef } from '@skyhook-io/k8s-ui'
 import { ArrowLeft, ClipboardCheck, Settings } from 'lucide-react'
@@ -21,6 +21,11 @@ export function AuditView({ namespaces, onBack, onNavigateToResource }: AuditVie
   const { data, isLoading, error } = useAudit(namespaces)
   const { data: auditSettings } = useAuditSettings()
   const updateSettings = useUpdateAuditSettings()
+  // Audit policy is owner-gated (enforced server-side). Withhold the inline
+  // hide affordances from non-owners so they don't click into a 403 — the
+  // hide menus render only when these callbacks are passed.
+  const { canAtLeast } = useCloudRole()
+  const canEdit = canAtLeast('owner')
   const [showSettings, setShowSettings] = useState(false)
 
   const ignoredCount = auditSettings?.ignoredNamespaces?.length ?? 0
@@ -105,8 +110,8 @@ export function AuditView({ namespaces, onBack, onNavigateToResource }: AuditVie
         catalog={data.checks ?? {}}
         anyData
         onResourceClick={onResourceClick}
-        onHideCheck={hideCheck}
-        onHideCategory={hideCategory}
+        onHideCheck={canEdit ? hideCheck : undefined}
+        onHideCategory={canEdit ? hideCategory : undefined}
       />
 
       {showSettings && <AuditSettingsDialog namespaces={namespaces} onClose={() => setShowSettings(false)} />}

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -1,10 +1,11 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
-import { Settings, X, RotateCcw, Loader2, Copy, Check, Pin, Shield } from 'lucide-react'
+import { Settings, X, RotateCcw, Loader2, Copy, Check, Pin, Shield, Lock } from 'lucide-react'
 import { clsx } from 'clsx'
 import { useAnimatedUnmount } from '../../hooks/useAnimatedUnmount'
 import { TRANSITION_BACKDROP, TRANSITION_PANEL } from '../../utils/animation'
 import { apiUrl, getAuthHeaders, getCredentialsMode } from '../../api/config'
+import { useCloudRole } from '../../api/client'
 
 interface Config {
   kubeconfig?: string
@@ -34,6 +35,13 @@ interface SettingsDialogProps {
 export function SettingsDialog({ open, onClose, onShowMyPermissions }: SettingsDialogProps) {
   const dialogRef = useRef<HTMLDivElement>(null)
   const { shouldRender, isOpen } = useAnimatedUnmount(open, 200)
+  // Radar configuration (kubeconfig, port, integrations…) is host-level and
+  // affects every user of this instance, so it's gated to owners. Personal
+  // sections (My permissions) stay visible to everyone. Non-Cloud callers
+  // (OSS, OIDC, kubectl plugin) have no role and pass — single-user laptops
+  // are never locked out of their own config. Backend enforces this too.
+  const { canAtLeast } = useCloudRole()
+  const canEditConfig = canAtLeast('owner')
   const [configData, setConfigData] = useState<ConfigResponse | null>(null)
   const [editedConfig, setEditedConfig] = useState<Config>({})
   const [saving, setSaving] = useState(false)
@@ -169,33 +177,55 @@ export function SettingsDialog({ open, onClose, onShowMyPermissions }: SettingsD
             </div>
           )}
           {onShowMyPermissions && (
-            <div className="mb-4 rounded-md border border-theme-border bg-theme-elevated/50 p-3">
-              <div className="flex items-center justify-between gap-3">
-                <div className="min-w-0">
-                  <h3 className="text-sm font-medium text-theme-text-primary">My permissions</h3>
-                  <p className="mt-0.5 text-xs text-theme-text-tertiary">
-                    View what your current identity can do in this cluster.
-                  </p>
+            <div className="mb-5">
+              <SectionLabel>Personal</SectionLabel>
+              <div className="rounded-md border border-theme-border bg-theme-elevated/50 p-3">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <h3 className="text-sm font-medium text-theme-text-primary">My permissions</h3>
+                    <p className="mt-0.5 text-xs text-theme-text-tertiary">
+                      View what your current identity can do in this cluster.
+                    </p>
+                  </div>
+                  <button
+                    onClick={onShowMyPermissions}
+                    className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-hover rounded-md transition-colors"
+                  >
+                    <Shield className="w-3.5 h-3.5" />
+                    Open
+                  </button>
                 </div>
-                <button
-                  onClick={onShowMyPermissions}
-                  className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-hover rounded-md transition-colors"
-                >
-                  <Shield className="w-3.5 h-3.5" />
-                  Open
-                </button>
               </div>
             </div>
           )}
-          <StartupConfigTab
-            config={editedConfig}
-            effectiveConfig={configData?.effective}
-            isDesktop={isDesktop}
-            onChange={updateConfigField}
-          />
+
+          <SectionLabel>Radar configuration</SectionLabel>
+          {canEditConfig ? (
+            <StartupConfigTab
+              config={editedConfig}
+              effectiveConfig={configData?.effective}
+              isDesktop={isDesktop}
+              onChange={updateConfigField}
+            />
+          ) : (
+            <div className="rounded-md border border-theme-border bg-theme-elevated/50 p-4 flex items-start gap-3">
+              <Lock className="w-4 h-4 mt-0.5 shrink-0 text-theme-text-tertiary" />
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-theme-text-primary">Owner access required</p>
+                <p className="mt-0.5 text-xs text-theme-text-tertiary">
+                  These settings (kubeconfig, server port, timeline, integrations) affect
+                  every user of this Radar instance, so they're limited to owners. Ask an
+                  owner if you need a change here.
+                </p>
+              </div>
+            </div>
+          )}
         </div>
 
-        {/* Footer */}
+        {/* Footer — only the owner-gated config section is editable, so hide
+            the save controls entirely for non-owners (personal sections save
+            themselves). */}
+        {canEditConfig && (
         <div className="flex items-center justify-between gap-3 p-4 border-t border-theme-border shrink-0">
             <div className="flex items-center gap-2">
               <button
@@ -225,9 +255,20 @@ export function SettingsDialog({ open, onClose, onShowMyPermissions }: SettingsD
               Save
             </button>
           </div>
+        )}
       </div>
     </div>,
     document.body
+  )
+}
+
+// -- Section label ------------------------------------------------------------
+
+function SectionLabel({ children }: { children: ReactNode }) {
+  return (
+    <h3 className="text-xs font-medium text-theme-text-secondary uppercase tracking-wider mb-2">
+      {children}
+    </h3>
   )
 }
 


### PR DESCRIPTION
Closes #882.

## Problem

Every authenticated user could see the gear icon and mutate global Radar infrastructure settings — host-level config (kubeconfig, server port, timeline storage, Prometheus URL, MCP) and the cluster-shared audit policy. There was no role guard, so `viewer`/`member` users had the same write access as owners. This blocked onboarding non-admin users.

## Approach

The gear isn't one thing. It mixes **host-level Radar configuration** (affects every user of the instance, restart-scoped) with **personal** surfaces (My permissions). Rather than hide the whole icon, we split by ownership and gate only the shared surfaces on the Cloud `owner` role.

"admin" maps to the existing `owner` Cloud tier (`pkg/auth/cloud_role.go`) — not a new K8s-RBAC-derived role. This reuses the established product-side boundary already used to gate Helm operations, and keeps "can I attempt it" (Cloud role) separate from "can it succeed" (impersonated K8s RBAC).

## Changes

**Backend (source of truth)**
- New `Server.requireCloudRole` helper (mirrors `internal/helm`'s gate) + `writeErrorCode`.
- `PUT /api/config` and `PUT /api/settings/audit` now require `owner`; denials return `403` with `error_code=cloud_role_insufficient`.
- Non-Cloud callers (OSS, OIDC, kubectl plugin) carry no `cloud:<tier>` group → `AtLeast` passes them through unchanged. A single-user laptop is never 403'd out of its own config. This is the load-bearing behavior; there's a test pinning it.

**Frontend (UI affordance)**
- `SettingsDialog`: split into a **Personal** section (My permissions, always visible) and an **owner-gated Radar configuration** section. Non-owners see a locked explanation instead of the form, and the save/reset footer is hidden.
- `AuditSettingsDialog`: read-only for non-owners — locked banner, disabled inputs/checkboxes, disabled Save with explanatory tooltip.
- `AuditView`: the inline **Hide check / Hide category** row menus also write to the (now-gated) audit settings endpoint, so they're withheld from non-owners — the hide callbacks are passed only to owners, and `ChecksView` renders the menu only when callbacks are present. Without this a viewer's hide click would hit a silent 403.
- The gear icon stays visible so non-owners can still reach personal surfaces. (Deliberate deviation from the issue's "hide the icon" wording — hiding it would also hide My permissions. The server 403 is the real enforcement; the UI is affordance.)

## Verification

- Unit: `TestPutConfig_RoleGate` (`viewer`/`member` → `403` + stable `error_code`) and `TestPutConfig_OwnerAndOSSBypassRoleGate` (`owner`, no-role-group, no-user pass — OSS/laptop case stays open).
- Manual, both modes: **local** (no auth → everything editable, owner path) and **in-cluster** (`--auth-mode=proxy` with `X-Forwarded-Groups: cloud:viewer`). Confirmed backend 403 on both endpoints for a viewer, owner 200, and that the Settings + audit dialogs lock and the inline hide menus disappear.
- `make tsc`, frontend prod build, and `go test ./internal/server/` all green.