### PR TITLE
Tier 1 diagnostic signals: change-feed correctness, per-issue correlation, MCP ergonomics

### DIFF
--- a/internal/issues/compose.go
+++ b/internal/issues/compose.go
@@ -67,11 +67,11 @@ type ComposeStats struct {
 	TotalMatched int
 }
 
-// ListResponse is the canonical /api/issues + MCP `issues` response shape. HTTP
-// and MCP both build from NewListResponse so the contract can't drift between
-// them (and the hub mirrors one shape). Visibility and NarrowHint are set by the
-// caller — visibility is server-side RBAC data; NarrowHint is the MCP steering
-// string for a capped result.
+// ListResponse is the canonical base /api/issues + MCP `issues` response shape.
+// HTTP and MCP both build from NewListResponse so the shared fields can't drift
+// between them (and the hub mirrors one shape). Callers may add
+// surface-specific fields such as Visibility, MCP NarrowHint, or MCP per-issue
+// correlation markers.
 type ListResponse = issuesapi.Response
 
 // NewListResponse fills the shared fields from a Compose result. out==nil

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -458,11 +458,17 @@ func recordToTimelineStore(kind, namespace, name, uid, op string, oldObj, newObj
 	// the change feed can show what the recreate changed instead of a
 	// contentless delete+add pair. Guarded to young objects post-sync — the
 	// same conditions under which the add below is recorded at all.
+	//
+	// Status is stripped from BOTH sides before diffing: every recreate
+	// resets status, so cross-recreate status deltas (ready 1→0, condition
+	// flips) are tautological noise — and worse, a spec-identical recreate
+	// (namespace re-apply) would otherwise emit a status-only "recreated
+	// with changes" entry that reads as a config change.
 	recreated := false
 	if op == "add" && newObj != nil && initialSyncComplete {
 		if meta, ok := newObj.(metav1.Object); ok && time.Since(meta.GetCreationTimestamp().Time) <= 30*time.Second {
 			if stashed, ok := takeRecreateMatch(kind, namespace, name, uid); ok {
-				if localDiff := ComputeDiff(kind, stashed, newObj); localDiff != nil && len(localDiff.Fields) > 0 {
+				if localDiff := ComputeDiff(kind, stripStatusForRecreateDiff(stashed), stripStatusForRecreateDiff(newObj)); localDiff != nil && len(localDiff.Fields) > 0 {
 					diff = &timeline.DiffInfo{
 						Fields:  make([]timeline.FieldChange, len(localDiff.Fields)),
 						Summary: "recreated with changes: " + localDiff.Summary,

--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -235,6 +235,7 @@ func ResetResourceCache() {
 	}
 	cacheOnce = new(sync.Once)
 	initialSyncComplete = false
+	resetRecreateStash()
 }
 
 // recordK8sEventToTimeline records a K8s Event to the timeline store
@@ -392,6 +393,10 @@ func recordToTimelineStore(kind, namespace, name, uid, op string, oldObj, newObj
 		obj = oldObj
 	}
 
+	if op == "delete" {
+		stashDeletedForRecreate(kind, namespace, name, uid, obj)
+	}
+
 	owner := timeline.ExtractOwner(obj)
 	labels := timeline.ExtractLabels(obj)
 	healthState := timeline.DetermineHealthState(kind, obj)
@@ -448,6 +453,33 @@ func recordToTimelineStore(kind, namespace, name, uid, op string, oldObj, newObj
 		}
 	}
 
+	// Recreate-join: an add that replaces a just-deleted object of the same
+	// name but a different UID carries the diff against its predecessor, so
+	// the change feed can show what the recreate changed instead of a
+	// contentless delete+add pair. Guarded to young objects post-sync — the
+	// same conditions under which the add below is recorded at all.
+	recreated := false
+	if op == "add" && newObj != nil && initialSyncComplete {
+		if meta, ok := newObj.(metav1.Object); ok && time.Since(meta.GetCreationTimestamp().Time) <= 30*time.Second {
+			if stashed, ok := takeRecreateMatch(kind, namespace, name, uid); ok {
+				if localDiff := ComputeDiff(kind, stashed, newObj); localDiff != nil && len(localDiff.Fields) > 0 {
+					diff = &timeline.DiffInfo{
+						Fields:  make([]timeline.FieldChange, len(localDiff.Fields)),
+						Summary: "recreated with changes: " + localDiff.Summary,
+					}
+					for i, f := range localDiff.Fields {
+						diff.Fields[i] = timeline.FieldChange{
+							Path:     f.Path,
+							OldValue: f.OldValue,
+							NewValue: f.NewValue,
+						}
+					}
+					recreated = true
+				}
+			}
+		}
+	}
+
 	event := timeline.NewInformerEvent(
 		kind, apiVersion, namespace, name, uid,
 		timeline.OperationToEventType(op),
@@ -458,6 +490,9 @@ func recordToTimelineStore(kind, namespace, name, uid, op string, oldObj, newObj
 		createdAt,
 	)
 	event.ClusterContext = ActiveClusterContext()
+	if recreated {
+		event.Reason = timeline.ReasonRecreated
+	}
 
 	var events []timeline.TimelineEvent
 	if op == "add" && newObj != nil {

--- a/internal/k8s/history.go
+++ b/internal/k8s/history.go
@@ -621,7 +621,6 @@ func getLBAddresses(ingress []corev1.LoadBalancerIngress) []string {
 	return addrs
 }
 
-// diffConfigMap computes diff for ConfigMap resources
 // diffResourceQuota surfaces spec.hard changes ("quota tightened/loosened") —
 // the admission-relevant signal. status.used churns with normal pod lifecycle
 // and is deliberately excluded: used-only updates drop as empty diffs.

--- a/internal/k8s/history.go
+++ b/internal/k8s/history.go
@@ -61,6 +61,8 @@ var diffFunctions = map[string]kindDiffFunc{
 	"TCPRoute":                diffGatewayRoute,
 	"TLSRoute":                diffGatewayRoute,
 	"ReferenceGrant":          diffReferenceGrant,
+	"ResourceQuota":           diffResourceQuota,
+	"LimitRange":              diffLimitRange,
 }
 
 // ComputeDiff computes the diff between old and new objects based on kind.
@@ -620,6 +622,103 @@ func getLBAddresses(ingress []corev1.LoadBalancerIngress) []string {
 }
 
 // diffConfigMap computes diff for ConfigMap resources
+// diffResourceQuota surfaces spec.hard changes ("quota tightened/loosened") —
+// the admission-relevant signal. status.used churns with normal pod lifecycle
+// and is deliberately excluded: used-only updates drop as empty diffs.
+func diffResourceQuota(oldObj, newObj any) ([]FieldChange, []string) {
+	oldRQ, ok1 := oldObj.(*corev1.ResourceQuota)
+	newRQ, ok2 := newObj.(*corev1.ResourceQuota)
+	if !ok1 || !ok2 {
+		return nil, nil
+	}
+
+	var changes []FieldChange
+	var summary []string
+
+	keys := map[string]struct{}{}
+	for k := range oldRQ.Spec.Hard {
+		keys[string(k)] = struct{}{}
+	}
+	for k := range newRQ.Spec.Hard {
+		keys[string(k)] = struct{}{}
+	}
+	names := make([]string, 0, len(keys))
+	for k := range keys {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		oldQ, oldOK := oldRQ.Spec.Hard[corev1.ResourceName(name)]
+		newQ, newOK := newRQ.Spec.Hard[corev1.ResourceName(name)]
+		oldVal, newVal := "", ""
+		if oldOK {
+			oldVal = oldQ.String()
+		}
+		if newOK {
+			newVal = newQ.String()
+		}
+		if oldVal == newVal {
+			continue
+		}
+		changes = append(changes, FieldChange{
+			Path:     "spec.hard." + name,
+			OldValue: valueOrNil(oldVal, oldOK),
+			NewValue: valueOrNil(newVal, newOK),
+		})
+		summary = append(summary, fmt.Sprintf("quota %s: %s→%s", name, emptyAsNone(oldVal), emptyAsNone(newVal)))
+	}
+	return changes, summary
+}
+
+// diffLimitRange surfaces spec.limits changes as compact per-item renderings.
+func diffLimitRange(oldObj, newObj any) ([]FieldChange, []string) {
+	oldLR, ok1 := oldObj.(*corev1.LimitRange)
+	newLR, ok2 := newObj.(*corev1.LimitRange)
+	if !ok1 || !ok2 {
+		return nil, nil
+	}
+
+	oldItems := limitRangeItemRefs(oldLR.Spec.Limits)
+	newItems := limitRangeItemRefs(newLR.Spec.Limits)
+	if equalStringSlices(oldItems, newItems) {
+		return nil, nil
+	}
+	return []FieldChange{{
+		Path:     "spec.limits",
+		OldValue: oldItems,
+		NewValue: newItems,
+	}}, []string{"limit ranges changed"}
+}
+
+func limitRangeItemRefs(items []corev1.LimitRangeItem) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		parts := []string{string(item.Type)}
+		appendQuantities := func(label string, list corev1.ResourceList) {
+			if len(list) == 0 {
+				return
+			}
+			keys := make([]string, 0, len(list))
+			for k := range list {
+				keys = append(keys, string(k))
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				q := list[corev1.ResourceName(k)]
+				parts = append(parts, fmt.Sprintf("%s.%s=%s", label, k, q.String()))
+			}
+		}
+		appendQuantities("max", item.Max)
+		appendQuantities("min", item.Min)
+		appendQuantities("default", item.Default)
+		appendQuantities("defaultRequest", item.DefaultRequest)
+		out = append(out, strings.Join(parts, " "))
+	}
+	sort.Strings(out)
+	return out
+}
+
 func diffConfigMap(oldObj, newObj any) ([]FieldChange, []string) {
 	oldCM, ok1 := oldObj.(*corev1.ConfigMap)
 	newCM, ok2 := newObj.(*corev1.ConfigMap)
@@ -2423,8 +2522,139 @@ func diffPodTemplateConfig(oldSpec, newSpec corev1.PodSpec) ([]FieldChange, []st
 			changes = append(changes, FieldChange{Path: fmt.Sprintf("spec.template.spec.containers[%s].args", name), OldValue: commandArgDisplayValues(oldC.Args), NewValue: commandArgDisplayValues(newC.Args)})
 			summary = append(summary, fmt.Sprintf("args(%s) changed", name))
 		}
+		if oldMounts, newMounts := volumeMountRefs(oldC.VolumeMounts), volumeMountRefs(newC.VolumeMounts); !equalStringSlices(oldMounts, newMounts) {
+			changes = append(changes, FieldChange{Path: fmt.Sprintf("spec.template.spec.containers[%s].volumeMounts", name), OldValue: oldMounts, NewValue: newMounts})
+			summary = append(summary, fmt.Sprintf("volumeMounts(%s) changed", name))
+		}
+		if oldPorts, newPorts := containerPortRefs(oldC.Ports), containerPortRefs(newC.Ports); !equalStringSlices(oldPorts, newPorts) {
+			changes = append(changes, FieldChange{Path: fmt.Sprintf("spec.template.spec.containers[%s].ports", name), OldValue: oldPorts, NewValue: newPorts})
+			summary = append(summary, fmt.Sprintf("ports(%s) changed", name))
+		}
+		// Boolean-level only: securityContext values (capabilities, uids,
+		// seccomp profiles) are deep structures whose exact contents rarely
+		// matter to triage — that something changed does.
+		if !reflect.DeepEqual(oldC.SecurityContext, newC.SecurityContext) {
+			changes = append(changes, FieldChange{Path: fmt.Sprintf("spec.template.spec.containers[%s].securityContext", name), OldValue: "changed", NewValue: "changed"})
+			summary = append(summary, fmt.Sprintf("securityContext(%s) changed", name))
+		}
+	}
+
+	// Pod-level fields. Volume diffs carry source references only (never
+	// contents); tolerations are summarized to compact strings; affinity is a
+	// bare "changed" marker — its tree is too large to diff usefully.
+	if oldVols, newVols := volumeSourceRefs(oldSpec.Volumes), volumeSourceRefs(newSpec.Volumes); !equalStringSlices(oldVols, newVols) {
+		changes = append(changes, FieldChange{Path: "spec.template.spec.volumes", OldValue: oldVols, NewValue: newVols})
+		summary = append(summary, "volumes changed")
+	}
+	if oldSpec.ServiceAccountName != newSpec.ServiceAccountName {
+		changes = append(changes, FieldChange{Path: "spec.template.spec.serviceAccountName", OldValue: oldSpec.ServiceAccountName, NewValue: newSpec.ServiceAccountName})
+		summary = append(summary, fmt.Sprintf("serviceAccountName: %s→%s", emptyAsNone(oldSpec.ServiceAccountName), emptyAsNone(newSpec.ServiceAccountName)))
+	}
+	if !reflect.DeepEqual(oldSpec.NodeSelector, newSpec.NodeSelector) {
+		changes = append(changes, FieldChange{Path: "spec.template.spec.nodeSelector", OldValue: oldSpec.NodeSelector, NewValue: newSpec.NodeSelector})
+		summary = append(summary, "nodeSelector changed")
+	}
+	if oldTol, newTol := tolerationRefs(oldSpec.Tolerations), tolerationRefs(newSpec.Tolerations); !equalStringSlices(oldTol, newTol) {
+		changes = append(changes, FieldChange{Path: "spec.template.spec.tolerations", OldValue: oldTol, NewValue: newTol})
+		summary = append(summary, "tolerations changed")
+	}
+	if !reflect.DeepEqual(oldSpec.Affinity, newSpec.Affinity) {
+		changes = append(changes, FieldChange{Path: "spec.template.spec.affinity", OldValue: "changed", NewValue: "changed"})
+		summary = append(summary, "affinity changed")
+	}
+	if !reflect.DeepEqual(oldSpec.SecurityContext, newSpec.SecurityContext) {
+		changes = append(changes, FieldChange{Path: "spec.template.spec.securityContext", OldValue: "changed", NewValue: "changed"})
+		summary = append(summary, "pod securityContext changed")
 	}
 	return changes, summary
+}
+
+// volumeSourceRefs renders volumes as "name:sourceType/sourceName" references
+// — never volume contents.
+func volumeSourceRefs(vols []corev1.Volume) []string {
+	out := make([]string, 0, len(vols))
+	for _, v := range vols {
+		ref := "other"
+		switch {
+		case v.ConfigMap != nil:
+			ref = "configMap/" + v.ConfigMap.Name
+		case v.Secret != nil:
+			ref = "secret/" + v.Secret.SecretName
+		case v.PersistentVolumeClaim != nil:
+			ref = "pvc/" + v.PersistentVolumeClaim.ClaimName
+		case v.EmptyDir != nil:
+			ref = "emptyDir"
+		case v.HostPath != nil:
+			ref = "hostPath/" + v.HostPath.Path
+		case v.Projected != nil:
+			ref = "projected"
+		case v.DownwardAPI != nil:
+			ref = "downwardAPI"
+		case v.CSI != nil:
+			ref = "csi/" + v.CSI.Driver
+		}
+		out = append(out, v.Name+":"+ref)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func volumeMountRefs(mounts []corev1.VolumeMount) []string {
+	out := make([]string, 0, len(mounts))
+	for _, m := range mounts {
+		ref := m.Name + "→" + m.MountPath
+		if m.SubPath != "" {
+			ref += "/" + m.SubPath
+		}
+		if m.ReadOnly {
+			ref += "(ro)"
+		}
+		out = append(out, ref)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func containerPortRefs(ports []corev1.ContainerPort) []string {
+	out := make([]string, 0, len(ports))
+	for _, p := range ports {
+		proto := string(p.Protocol)
+		if proto == "" {
+			proto = "TCP"
+		}
+		ref := fmt.Sprintf("%d/%s", p.ContainerPort, proto)
+		if p.Name != "" {
+			ref += "(" + p.Name + ")"
+		}
+		out = append(out, ref)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func tolerationRefs(tols []corev1.Toleration) []string {
+	out := make([]string, 0, len(tols))
+	for _, t := range tols {
+		ref := t.Key
+		if t.Operator == corev1.TolerationOpExists {
+			ref += " exists"
+		} else if t.Value != "" {
+			ref += "=" + t.Value
+		}
+		if t.Effect != "" {
+			ref += ":" + string(t.Effect)
+		}
+		out = append(out, ref)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func emptyAsNone(s string) string {
+	if s == "" {
+		return "(default)"
+	}
+	return s
 }
 
 func containerConfigMap(spec corev1.PodSpec) map[string]corev1.Container {

--- a/internal/k8s/history_diff_test.go
+++ b/internal/k8s/history_diff_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -123,4 +124,170 @@ func findChangePath(changes []FieldChange, path string) (FieldChange, bool) {
 		}
 	}
 	return FieldChange{}, false
+}
+
+func TestDiffPodTemplateConfig_VolumesAndMounts(t *testing.T) {
+	oldSpec := corev1.PodSpec{
+		Volumes: []corev1.Volume{
+			{Name: "config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "app-config"}}}},
+		},
+		Containers: []corev1.Container{{
+			Name: "app", Image: "app:v1",
+			VolumeMounts: []corev1.VolumeMount{{Name: "config", MountPath: "/etc/config", ReadOnly: true}},
+		}},
+	}
+	newSpec := corev1.PodSpec{
+		Volumes: []corev1.Volume{
+			{Name: "config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "app-config-v2"}}}},
+			{Name: "cache", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		},
+		Containers: []corev1.Container{{
+			Name: "app", Image: "app:v1",
+			VolumeMounts: []corev1.VolumeMount{{Name: "config", MountPath: "/etc/config", ReadOnly: true}, {Name: "cache", MountPath: "/cache"}},
+		}},
+	}
+
+	changes, summary := diffPodTemplateConfig(oldSpec, newSpec)
+	if !hasChangePath(changes, "spec.template.spec.volumes") {
+		t.Fatalf("expected volumes change, got %+v", changes)
+	}
+	if !hasChangePath(changes, "spec.template.spec.containers[app].volumeMounts") {
+		t.Fatalf("expected volumeMounts change, got %+v", changes)
+	}
+	joined := strings.Join(summary, "; ")
+	if !strings.Contains(joined, "volumes changed") || !strings.Contains(joined, "volumeMounts(app)") {
+		t.Fatalf("summary missing volume changes: %q", joined)
+	}
+	// Volume diffs must carry source REFERENCES, not contents.
+	for _, c := range changes {
+		if c.Path == "spec.template.spec.volumes" {
+			refs, ok := c.NewValue.([]string)
+			if !ok {
+				t.Fatalf("volumes NewValue should be []string refs, got %T", c.NewValue)
+			}
+			if want := "config:configMap/app-config-v2"; !slicesContains(refs, want) {
+				t.Fatalf("volume refs = %v, want to include %q", refs, want)
+			}
+		}
+	}
+}
+
+func TestDiffPodTemplateConfig_PortsSAandScheduling(t *testing.T) {
+	oldSpec := corev1.PodSpec{
+		ServiceAccountName: "default",
+		NodeSelector:       map[string]string{"disk": "ssd"},
+		Containers: []corev1.Container{{
+			Name: "app", Image: "app:v1",
+			Ports: []corev1.ContainerPort{{ContainerPort: 8080, Name: "http"}},
+		}},
+	}
+	newSpec := corev1.PodSpec{
+		ServiceAccountName: "app-sa",
+		NodeSelector:       map[string]string{"disk": "ssd", "zone": "us-east1-b"},
+		Tolerations:        []corev1.Toleration{{Key: "dedicated", Value: "infra", Effect: corev1.TaintEffectNoSchedule}},
+		Containers: []corev1.Container{{
+			Name: "app", Image: "app:v1",
+			Ports: []corev1.ContainerPort{{ContainerPort: 9090, Name: "http"}},
+		}},
+	}
+
+	changes, summary := diffPodTemplateConfig(oldSpec, newSpec)
+	for _, path := range []string{
+		"spec.template.spec.containers[app].ports",
+		"spec.template.spec.serviceAccountName",
+		"spec.template.spec.nodeSelector",
+		"spec.template.spec.tolerations",
+	} {
+		if !hasChangePath(changes, path) {
+			t.Fatalf("expected change at %s, got %+v", path, changes)
+		}
+	}
+	joined := strings.Join(summary, "; ")
+	if !strings.Contains(joined, "serviceAccountName: default→app-sa") {
+		t.Fatalf("summary missing serviceAccountName transition: %q", joined)
+	}
+}
+
+func TestDiffPodTemplateConfig_SecurityContextAndAffinityBooleanLevel(t *testing.T) {
+	runAsNonRoot := true
+	oldSpec := corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: "app:v1"}}}
+	newSpec := corev1.PodSpec{
+		Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{}},
+		Containers: []corev1.Container{{
+			Name: "app", Image: "app:v1",
+			SecurityContext: &corev1.SecurityContext{RunAsNonRoot: &runAsNonRoot},
+		}},
+	}
+
+	changes, summary := diffPodTemplateConfig(oldSpec, newSpec)
+	joined := strings.Join(summary, "; ")
+	if !strings.Contains(joined, "securityContext(app) changed") {
+		t.Fatalf("summary missing securityContext marker: %q", joined)
+	}
+	if !strings.Contains(joined, "affinity changed") {
+		t.Fatalf("summary missing affinity marker: %q", joined)
+	}
+	// Boolean-level only: values must be the "changed" marker, not the structs.
+	for _, c := range changes {
+		if c.Path == "spec.template.spec.containers[app].securityContext" || c.Path == "spec.template.spec.affinity" {
+			if c.NewValue != "changed" {
+				t.Fatalf("%s NewValue = %v, want boolean-level \"changed\" marker", c.Path, c.NewValue)
+			}
+		}
+	}
+}
+
+func slicesContains(s []string, v string) bool {
+	for _, item := range s {
+		if item == v {
+			return true
+		}
+	}
+	return false
+}
+
+func TestDiffResourceQuota_HardChanges(t *testing.T) {
+	mk := func(mem string) *corev1.ResourceQuota {
+		return &corev1.ResourceQuota{
+			Spec: corev1.ResourceQuotaSpec{Hard: corev1.ResourceList{
+				"limits.memory": resource.MustParse(mem),
+				"pods":          resource.MustParse("20"),
+			}},
+		}
+	}
+	changes, summary := diffResourceQuota(mk("4Gi"), mk("1Gi"))
+	if len(changes) != 1 {
+		t.Fatalf("changes = %+v, want exactly the limits.memory change", changes)
+	}
+	if changes[0].Path != "spec.hard.limits.memory" {
+		t.Fatalf("path = %q", changes[0].Path)
+	}
+	if joined := strings.Join(summary, "; "); !strings.Contains(joined, "quota limits.memory: 4Gi→1Gi") {
+		t.Fatalf("summary = %q", joined)
+	}
+
+	// status.used churn must NOT produce a diff (would flood the timeline).
+	withUsed := mk("4Gi")
+	withUsed.Status.Used = corev1.ResourceList{"limits.memory": resource.MustParse("3Gi")}
+	if c, _ := diffResourceQuota(mk("4Gi"), withUsed); len(c) != 0 {
+		t.Fatalf("status.used-only update produced a diff: %+v", c)
+	}
+}
+
+func TestDiffLimitRange_ItemChanges(t *testing.T) {
+	mk := func(maxMem string) *corev1.LimitRange {
+		return &corev1.LimitRange{
+			Spec: corev1.LimitRangeSpec{Limits: []corev1.LimitRangeItem{{
+				Type: corev1.LimitTypeContainer,
+				Max:  corev1.ResourceList{"memory": resource.MustParse(maxMem)},
+			}}},
+		}
+	}
+	changes, _ := diffLimitRange(mk("1Gi"), mk("512Mi"))
+	if len(changes) != 1 || changes[0].Path != "spec.limits" {
+		t.Fatalf("changes = %+v", changes)
+	}
+	if c, _ := diffLimitRange(mk("1Gi"), mk("1Gi")); len(c) != 0 {
+		t.Fatalf("identical LimitRanges produced a diff: %+v", c)
+	}
 }

--- a/internal/k8s/recreate_stash.go
+++ b/internal/k8s/recreate_stash.go
@@ -1,8 +1,11 @@
 package k8s
 
 import (
+	"reflect"
 	"sync"
 	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // Delete+recreate under the same name (kubectl replace --force, delete &&
@@ -130,4 +133,28 @@ func resetRecreateStash() {
 	recreateStashMu.Lock()
 	defer recreateStashMu.Unlock()
 	recreateStash = map[string]recreateEntry{}
+}
+
+// stripStatusForRecreateDiff returns a copy of obj with .status zeroed so the
+// recreate diff covers desired state only. Shallow copy: the differs only
+// read, never mutate, so sharing spec internals is safe.
+func stripStatusForRecreateDiff(obj any) any {
+	if obj == nil {
+		return nil
+	}
+	if u, ok := obj.(*unstructured.Unstructured); ok {
+		c := u.DeepCopy()
+		delete(c.Object, "status")
+		return c
+	}
+	v := reflect.ValueOf(obj)
+	if v.Kind() != reflect.Ptr || v.IsNil() {
+		return obj
+	}
+	c := reflect.New(v.Elem().Type())
+	c.Elem().Set(v.Elem())
+	if f := c.Elem().FieldByName("Status"); f.IsValid() && f.CanSet() {
+		f.Set(reflect.Zero(f.Type()))
+	}
+	return c.Interface()
 }

--- a/internal/k8s/recreate_stash.go
+++ b/internal/k8s/recreate_stash.go
@@ -1,0 +1,133 @@
+package k8s
+
+import (
+	"sync"
+	"time"
+)
+
+// Delete+recreate under the same name (kubectl replace --force, delete &&
+// apply, Argo Replace=true, immutable-field edits) reaches the timeline as a
+// contentless delete + add pair: the old object is gone by the time the add
+// arrives, so there is nothing to diff against. The stash keeps the last-seen
+// object of recently deleted resources so the next add under the same name —
+// with a different UID — can be diffed against what it replaced.
+//
+// In-memory only: entries expire after recreateJoinTTL, the store is capped,
+// and a cluster-context switch clears it. The timeline itself still records
+// both raw events; the join only enriches the add.
+const (
+	recreateJoinTTL  = 15 * time.Minute
+	recreateStashCap = 2048
+)
+
+// recreateStashKinds mirrors the meaningful-changes feed kinds (config +
+// desired-state). Pods and other churn-heavy kinds are excluded: their
+// recreates use generated names, so a same-name join never fires and stashing
+// them would only burn memory. Secrets are deliberately excluded — a recreate
+// diff path for secret data needs its own redaction review first.
+var recreateStashKinds = map[string]bool{
+	"ConfigMap":               true,
+	"Deployment":              true,
+	"StatefulSet":             true,
+	"DaemonSet":               true,
+	"Service":                 true,
+	"Ingress":                 true,
+	"HorizontalPodAutoscaler": true,
+	"CronJob":                 true,
+	"ResourceQuota":           true,
+	"LimitRange":              true,
+	"Application":             true,
+	"Kustomization":           true,
+	"HelmRelease":             true,
+}
+
+type recreateEntry struct {
+	obj       any
+	uid       string
+	deletedAt time.Time
+}
+
+var (
+	recreateStashMu sync.Mutex
+	recreateStash   = map[string]recreateEntry{}
+)
+
+func recreateKey(kind, namespace, name string) string {
+	return kind + "/" + namespace + "/" + name
+}
+
+// stashDeletedForRecreate records a deleted object for a potential
+// recreate-join. No-op for kinds outside the allowlist.
+func stashDeletedForRecreate(kind, namespace, name, uid string, obj any) {
+	if obj == nil || !recreateStashKinds[kind] {
+		return
+	}
+	recreateStashMu.Lock()
+	defer recreateStashMu.Unlock()
+	if len(recreateStash) >= recreateStashCap {
+		evictRecreateStashLocked()
+	}
+	recreateStash[recreateKey(kind, namespace, name)] = recreateEntry{
+		obj:       obj,
+		uid:       uid,
+		deletedAt: time.Now(),
+	}
+}
+
+// takeRecreateMatch returns the stashed predecessor of kind/ns/name when the
+// new UID differs and the delete is within the join TTL. The entry is
+// consumed (or discarded, if stale or same-UID) either way.
+func takeRecreateMatch(kind, namespace, name, newUID string) (any, bool) {
+	if !recreateStashKinds[kind] {
+		return nil, false
+	}
+	recreateStashMu.Lock()
+	defer recreateStashMu.Unlock()
+	key := recreateKey(kind, namespace, name)
+	entry, ok := recreateStash[key]
+	if !ok {
+		return nil, false
+	}
+	delete(recreateStash, key)
+	if time.Since(entry.deletedAt) > recreateJoinTTL {
+		return nil, false
+	}
+	// Same UID means the informer replayed an object we already knew, not a
+	// recreate — nothing to join.
+	if newUID != "" && entry.uid == newUID {
+		return nil, false
+	}
+	return entry.obj, true
+}
+
+// evictRecreateStashLocked drops expired entries, then — if the stash is
+// still full — the oldest ones, until a quarter of the cap is free. Mass
+// namespace teardowns are the stress case; recreates that matter happen
+// seconds after the delete, so evicting the oldest first is safe.
+func evictRecreateStashLocked() {
+	now := time.Now()
+	for key, entry := range recreateStash {
+		if now.Sub(entry.deletedAt) > recreateJoinTTL {
+			delete(recreateStash, key)
+		}
+	}
+	target := recreateStashCap - recreateStashCap/4
+	for len(recreateStash) > target {
+		oldestKey := ""
+		var oldest time.Time
+		for key, entry := range recreateStash {
+			if oldestKey == "" || entry.deletedAt.Before(oldest) {
+				oldestKey, oldest = key, entry.deletedAt
+			}
+		}
+		delete(recreateStash, oldestKey)
+	}
+}
+
+// resetRecreateStash clears all entries. Called on cluster-context switch:
+// joining objects across clusters would fabricate diffs.
+func resetRecreateStash() {
+	recreateStashMu.Lock()
+	defer recreateStashMu.Unlock()
+	recreateStash = map[string]recreateEntry{}
+}

--- a/internal/k8s/recreate_stash.go
+++ b/internal/k8s/recreate_stash.go
@@ -23,11 +23,13 @@ const (
 	recreateStashCap = 2048
 )
 
-// recreateStashKinds mirrors the meaningful-changes feed kinds (config +
-// desired-state). Pods and other churn-heavy kinds are excluded: their
-// recreates use generated names, so a same-name join never fires and stashing
-// them would only burn memory. Secrets are deliberately excluded — a recreate
-// diff path for secret data needs its own redaction review first.
+// recreateStashKinds covers every kind the meaningful-changes feed tracks
+// (config + desired-state) plus CronJob, whose recreate diff enriches the
+// timeline even though the feed doesn't surface it. ReplicaSet-managed Pods
+// recreate under generated names, so a same-name join never fires for them;
+// StatefulSet Pods would join, but pod churn volume makes stashing every pod
+// too costly. Secrets are deliberately excluded — a recreate diff path for
+// secret data needs its own redaction review first.
 var recreateStashKinds = map[string]bool{
 	"ConfigMap":               true,
 	"Deployment":              true,
@@ -42,7 +44,14 @@ var recreateStashKinds = map[string]bool{
 	"Application":             true,
 	"Kustomization":           true,
 	"HelmRelease":             true,
+	"GitRepository":           true,
+	"OCIRepository":           true,
+	"HelmRepository":          true,
 }
+
+// RecreateJoinKind reports whether deletes of this kind are stashed for
+// recreate-join diffs.
+func RecreateJoinKind(kind string) bool { return recreateStashKinds[kind] }
 
 type recreateEntry struct {
 	obj       any

--- a/internal/k8s/recreate_stash_test.go
+++ b/internal/k8s/recreate_stash_test.go
@@ -1,0 +1,185 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/skyhook-io/radar/internal/timeline"
+)
+
+func testDeployment(uid, image string, created time.Time) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "web",
+			Namespace:         "shop",
+			UID:               types.UID(uid),
+			CreationTimestamp: metav1.NewTime(created),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "web", Image: image}},
+				},
+			},
+		},
+	}
+}
+
+// Delete + recreate under the same name must produce an add event that
+// carries the diff against the deleted predecessor, marked ReasonRecreated.
+func TestRecreateJoin_DeleteThenRecreateCarriesDiff(t *testing.T) {
+	prev := initialSyncComplete
+	initialSyncComplete = true
+	defer func() { initialSyncComplete = prev }()
+	resetRecreateStash()
+	defer resetRecreateStash()
+
+	timeline.ResetStore()
+	defer timeline.ResetStore()
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 100}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+
+	oldDep := testDeployment("uid-1", "nginx:1.0", time.Now().Add(-time.Hour))
+	recordToTimelineStore("Deployment", "shop", "web", "uid-1", "delete", nil, oldDep)
+
+	newDep := testDeployment("uid-2", "nginx:2.0", time.Now())
+	recordToTimelineStore("Deployment", "shop", "web", "uid-2", "add", nil, newDep)
+
+	events, err := timeline.GetStore().Query(context.Background(), timeline.QueryOptions{
+		Kinds: []string{"Deployment"}, Namespaces: []string{"shop"},
+	})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	var add, del *timeline.TimelineEvent
+	for i := range events {
+		switch events[i].EventType {
+		case timeline.EventTypeAdd:
+			add = &events[i]
+		case timeline.EventTypeDelete:
+			del = &events[i]
+		}
+	}
+	if del == nil {
+		t.Fatal("delete event missing — the timeline must keep the raw delete")
+	}
+	if add == nil {
+		t.Fatal("add event missing")
+	}
+	if add.Reason != timeline.ReasonRecreated {
+		t.Fatalf("add.Reason = %q, want %q", add.Reason, timeline.ReasonRecreated)
+	}
+	if add.Diff == nil || len(add.Diff.Fields) == 0 {
+		t.Fatalf("recreate add carries no diff: %+v", add)
+	}
+	if !strings.HasPrefix(add.Diff.Summary, "recreated with changes: ") {
+		t.Fatalf("summary = %q, want 'recreated with changes: …' prefix", add.Diff.Summary)
+	}
+	foundImage := false
+	for _, f := range add.Diff.Fields {
+		if strings.Contains(strings.ToLower(f.Path), "image") {
+			foundImage = true
+		}
+	}
+	if !foundImage {
+		t.Fatalf("diff lacks the image change: %+v", add.Diff.Fields)
+	}
+}
+
+// A re-add with the same UID is an informer replay, not a recreate.
+func TestRecreateJoin_SameUIDReAdd_NoJoin(t *testing.T) {
+	prev := initialSyncComplete
+	initialSyncComplete = true
+	defer func() { initialSyncComplete = prev }()
+	resetRecreateStash()
+	defer resetRecreateStash()
+
+	timeline.ResetStore()
+	defer timeline.ResetStore()
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 100}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+
+	dep := testDeployment("uid-1", "nginx:1.0", time.Now())
+	recordToTimelineStore("Deployment", "shop", "web", "uid-1", "delete", nil, dep)
+	recordToTimelineStore("Deployment", "shop", "web", "uid-1", "add", nil, dep)
+
+	events, err := timeline.GetStore().Query(context.Background(), timeline.QueryOptions{
+		Kinds: []string{"Deployment"}, EventTypes: []timeline.EventType{timeline.EventTypeAdd},
+	})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	for _, e := range events {
+		if e.Reason == timeline.ReasonRecreated {
+			t.Fatalf("same-UID re-add must not join: %+v", e)
+		}
+	}
+}
+
+func TestTakeRecreateMatch_TTLExpiry(t *testing.T) {
+	resetRecreateStash()
+	defer resetRecreateStash()
+
+	recreateStashMu.Lock()
+	recreateStash[recreateKey("Deployment", "shop", "web")] = recreateEntry{
+		obj: testDeployment("uid-1", "nginx:1.0", time.Now()), uid: "uid-1",
+		deletedAt: time.Now().Add(-recreateJoinTTL - time.Minute),
+	}
+	recreateStashMu.Unlock()
+
+	if _, ok := takeRecreateMatch("Deployment", "shop", "web", "uid-2"); ok {
+		t.Fatal("expired stash entry must not join")
+	}
+	recreateStashMu.Lock()
+	remaining := len(recreateStash)
+	recreateStashMu.Unlock()
+	if remaining != 0 {
+		t.Fatalf("expired entry should be consumed, %d left", remaining)
+	}
+}
+
+func TestRecreateStash_KindGateAndReset(t *testing.T) {
+	resetRecreateStash()
+	defer resetRecreateStash()
+
+	stashDeletedForRecreate("Pod", "shop", "p", "uid-1", &corev1.Pod{})
+	if _, ok := takeRecreateMatch("Pod", "shop", "p", "uid-2"); ok {
+		t.Fatal("Pod is outside the stash allowlist")
+	}
+
+	stashDeletedForRecreate("Deployment", "shop", "web", "uid-1", testDeployment("uid-1", "nginx:1.0", time.Now()))
+	resetRecreateStash()
+	if _, ok := takeRecreateMatch("Deployment", "shop", "web", "uid-2"); ok {
+		t.Fatal("reset must clear the stash")
+	}
+}
+
+func TestRecreateStash_CapEviction(t *testing.T) {
+	resetRecreateStash()
+	defer resetRecreateStash()
+
+	for i := 0; i < recreateStashCap+100; i++ {
+		stashDeletedForRecreate("ConfigMap", "shop", fmt.Sprintf("cm-%d", i), fmt.Sprintf("uid-%d", i), &corev1.ConfigMap{})
+	}
+	recreateStashMu.Lock()
+	size := len(recreateStash)
+	recreateStashMu.Unlock()
+	if size > recreateStashCap {
+		t.Fatalf("stash size %d exceeds cap %d", size, recreateStashCap)
+	}
+	// The newest entries must have survived eviction — recreates that matter
+	// happen seconds after the delete.
+	if _, ok := takeRecreateMatch("ConfigMap", "shop", fmt.Sprintf("cm-%d", recreateStashCap+99), "other-uid"); !ok {
+		t.Fatal("newest entry was evicted; eviction must drop oldest first")
+	}
+}

--- a/internal/k8s/recreate_stash_test.go
+++ b/internal/k8s/recreate_stash_test.go
@@ -183,3 +183,39 @@ func TestRecreateStash_CapEviction(t *testing.T) {
 		t.Fatal("newest entry was evicted; eviction must drop oldest first")
 	}
 }
+
+// A spec-identical recreate (namespace re-apply) must NOT join: status resets
+// across recreates are tautological, and a status-only "recreated with
+// changes" entry reads as a config change that never happened.
+func TestRecreateJoin_SpecIdenticalRecreate_NoJoin(t *testing.T) {
+	prev := initialSyncComplete
+	initialSyncComplete = true
+	defer func() { initialSyncComplete = prev }()
+	resetRecreateStash()
+	defer resetRecreateStash()
+
+	timeline.ResetStore()
+	defer timeline.ResetStore()
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 100}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+
+	oldDep := testDeployment("uid-1", "nginx:1.0", time.Now().Add(-time.Hour))
+	oldDep.Status = appsv1.DeploymentStatus{ReadyReplicas: 1, AvailableReplicas: 1}
+	recordToTimelineStore("Deployment", "shop", "web", "uid-1", "delete", nil, oldDep)
+
+	newDep := testDeployment("uid-2", "nginx:1.0", time.Now()) // same spec, fresh status
+	recordToTimelineStore("Deployment", "shop", "web", "uid-2", "add", nil, newDep)
+
+	events, err := timeline.GetStore().Query(context.Background(), timeline.QueryOptions{
+		Kinds: []string{"Deployment"}, EventTypes: []timeline.EventType{timeline.EventTypeAdd},
+	})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	for _, e := range events {
+		if e.Reason == timeline.ReasonRecreated {
+			t.Fatalf("spec-identical recreate must not join (status-only diff): %+v", e.Diff)
+		}
+	}
+}

--- a/internal/k8s/recreate_stash_test.go
+++ b/internal/k8s/recreate_stash_test.go
@@ -10,6 +10,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/skyhook-io/radar/internal/timeline"
@@ -217,5 +218,56 @@ func TestRecreateJoin_SpecIdenticalRecreate_NoJoin(t *testing.T) {
 		if e.Reason == timeline.ReasonRecreated {
 			t.Fatalf("spec-identical recreate must not join (status-only diff): %+v", e.Diff)
 		}
+	}
+}
+
+// The recreate diff must cover desired state only, for typed and unstructured
+// objects alike — GitOps CRDs (Application, Kustomization, HelmRelease) arrive
+// unstructured, and a status leak there reintroduces status-only "recreated
+// with changes" noise.
+func TestStripStatusForRecreateDiff(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "argoproj.io/v1alpha1",
+		"kind":       "Application",
+		"metadata":   map[string]any{"name": "web", "namespace": "argocd"},
+		"spec":       map[string]any{"project": "default"},
+		"status":     map[string]any{"sync": map[string]any{"status": "Synced"}},
+	}}
+	stripped, ok := stripStatusForRecreateDiff(u).(*unstructured.Unstructured)
+	if !ok {
+		t.Fatalf("unstructured input must come back unstructured, got %T", stripStatusForRecreateDiff(u))
+	}
+	if _, has := stripped.Object["status"]; has {
+		t.Fatal("status must be stripped from the unstructured copy")
+	}
+	if _, has := stripped.Object["spec"]; !has {
+		t.Fatal("spec must survive stripping")
+	}
+	if _, has := u.Object["status"]; !has {
+		t.Fatal("the original object must not be mutated")
+	}
+
+	dep := testDeployment("uid-1", "nginx:1.0", time.Now())
+	dep.Status = appsv1.DeploymentStatus{ReadyReplicas: 3}
+	strippedDep, ok := stripStatusForRecreateDiff(dep).(*appsv1.Deployment)
+	if !ok {
+		t.Fatalf("typed input must come back typed, got %T", stripStatusForRecreateDiff(dep))
+	}
+	if strippedDep.Status.ReadyReplicas != 0 {
+		t.Fatal("typed status must be zeroed in the copy")
+	}
+	if dep.Status.ReadyReplicas != 3 {
+		t.Fatal("the original typed object must not be mutated")
+	}
+	if strippedDep.Spec.Template.Spec.Containers[0].Image != "nginx:1.0" {
+		t.Fatal("typed spec must survive stripping")
+	}
+
+	if got := stripStatusForRecreateDiff(nil); got != nil {
+		t.Fatalf("nil input must return nil, got %v", got)
+	}
+	notPtr := "plain"
+	if got := stripStatusForRecreateDiff(notPtr); got != notPtr {
+		t.Fatalf("non-pointer input must pass through unchanged, got %v", got)
 	}
 }

--- a/internal/mcp/issue_correlation.go
+++ b/internal/mcp/issue_correlation.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"log"
 	"strings"
 	"time"
 
@@ -15,7 +16,7 @@ import (
 // Per-issue change correlation answers the first triage question — "did
 // anything change on THIS subject recently, or has it always been like
 // this?" — as deterministic per-issue facts. Radar makes no judgment call:
-// no demotion, no reordering, no causal claim. A chronic decoy issue
+// no demotion, no reordering, no causal claim. A chronic pre-existing issue
 // truthfully carries no_recent_changes; an incident workload carries the
 // correlated change refs; the consumer weighs them.
 const (
@@ -81,15 +82,22 @@ func attachIssueChangeCorrelation(ctx context.Context, resp *issues.ListResponse
 		}
 		checked++
 
-		changes, err := correlationChangesForIssue(ctx, iss, window)
+		changes, saturated, err := correlationChangesForIssue(ctx, iss, window)
 		if err != nil {
+			log.Printf("[mcp] issue change correlation failed for %s %s/%s: %v", iss.Kind, iss.Namespace, iss.Name, err)
 			continue // marker omitted = unknown, never a false "no changes"
 		}
-		// The marker's contract is spec/config evidence: status churn on a
+		// The marker's contract is non-status evidence: status churn on a
 		// failing workload is the SYMPTOM, not a change that could explain it
 		// — including it would make every failing issue read as "correlated".
 		changes = filterSpecConfigChanges(changes)
 		if len(changes) == 0 {
+			// A saturated candidate fetch may have missed older changes in
+			// the window (churn-heavy subjects overflow the newest-N query) —
+			// that's unknown, not "no changes".
+			if saturated {
+				continue
+			}
 			iss.NoRecentChanges = &issuesapi.NoRecentChangesMarker{
 				WindowSeconds: int(window.Seconds()),
 			}
@@ -105,14 +113,14 @@ func attachIssueChangeCorrelation(ctx context.Context, resp *issues.ListResponse
 func filterSpecConfigChanges(changes []issuesapi.RecentChange) []issuesapi.RecentChange {
 	out := changes[:0]
 	for _, c := range changes {
-		if c.ChangeCategory == "spec_config" || c.ChangeCategory == "lifecycle" {
+		if c.ChangeCategory == issuesapi.ChangeCategorySpecConfig || c.ChangeCategory == issuesapi.ChangeCategoryLifecycle {
 			out = append(out, c)
 		}
 	}
 	return out
 }
 
-func correlationChangesForIssue(ctx context.Context, iss *issuesapi.Issue, window time.Duration) ([]issuesapi.RecentChange, error) {
+func correlationChangesForIssue(ctx context.Context, iss *issuesapi.Issue, window time.Duration) ([]issuesapi.RecentChange, bool, error) {
 	if meaningfulchanges.WorkloadKind(iss.Kind) {
 		// Workload subjects also correlate against their directly referenced
 		// ConfigMaps; obj==nil degrades to workload-only changes.

--- a/internal/mcp/issue_correlation.go
+++ b/internal/mcp/issue_correlation.go
@@ -55,6 +55,10 @@ func attachIssueChangeCorrelation(ctx context.Context, resp *issues.ListResponse
 		if err != nil {
 			continue // marker omitted = unknown, never a false "no changes"
 		}
+		// The marker's contract is spec/config evidence: status churn on a
+		// failing workload is the SYMPTOM, not a change that could explain it
+		// — including it would make every failing issue read as "correlated".
+		changes = filterSpecConfigChanges(changes)
 		if len(changes) == 0 {
 			iss.NoRecentChanges = &issuesapi.NoRecentChangesMarker{
 				WindowSeconds: int(meaningfulchanges.DefaultSince.Seconds()),
@@ -66,6 +70,16 @@ func attachIssueChangeCorrelation(ctx context.Context, resp *issues.ListResponse
 		}
 		iss.CorrelatedChanges = changes
 	}
+}
+
+func filterSpecConfigChanges(changes []issuesapi.RecentChange) []issuesapi.RecentChange {
+	out := changes[:0]
+	for _, c := range changes {
+		if c.ChangeCategory == "spec_config" || c.ChangeCategory == "lifecycle" {
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 func correlationChangesForIssue(ctx context.Context, iss *issuesapi.Issue) ([]issuesapi.RecentChange, error) {

--- a/internal/mcp/issue_correlation.go
+++ b/internal/mcp/issue_correlation.go
@@ -1,0 +1,113 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+
+	"github.com/skyhook-io/radar/internal/issues"
+	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/internal/meaningfulchanges"
+	"github.com/skyhook-io/radar/pkg/issuesapi"
+)
+
+// Per-issue change correlation answers the first triage question — "did
+// anything change on THIS subject recently, or has it always been like
+// this?" — as deterministic per-issue facts. Radar makes no judgment call:
+// no demotion, no reordering, no causal claim. A chronic decoy issue
+// truthfully carries no_recent_changes; an incident workload carries the
+// correlated change refs; the consumer weighs them.
+const (
+	// correlationIssueCap bounds the per-issue lookups per response. When the
+	// cap skips criticals, Response.CorrelationTruncated says so explicitly —
+	// an unmarked issue under truncation means "not checked", never "no
+	// changes".
+	correlationIssueCap = 10
+	// correlationChangeCap bounds refs per issue: the top-ranked few changes
+	// are the evidence; the full feed stays one get_changes call away.
+	correlationChangeCap = 3
+	// correlationFieldLimit keeps per-ref field diffs compact.
+	correlationFieldLimit = 5
+)
+
+// attachIssueChangeCorrelation fills CorrelatedChanges / NoRecentChanges on
+// critical issues. Single-namespace responses only — cross-namespace listings
+// are inventory sweeps where per-issue timeline lookups would multiply cost
+// without a triage question on the table.
+func attachIssueChangeCorrelation(ctx context.Context, resp *issues.ListResponse) {
+	checked := 0
+	for i := range resp.Issues {
+		iss := &resp.Issues[i]
+		if iss.Severity != issuesapi.SeverityCritical {
+			continue
+		}
+		// Only kinds whose changes the feed records can truthfully claim "no
+		// changes" — for untracked kinds the marker is omitted (= unknown).
+		if !meaningfulchanges.TrackedKind(iss.Kind) {
+			continue
+		}
+		if checked >= correlationIssueCap {
+			resp.CorrelationTruncated = true
+			return
+		}
+		checked++
+
+		changes, err := correlationChangesForIssue(ctx, iss)
+		if err != nil {
+			continue // marker omitted = unknown, never a false "no changes"
+		}
+		if len(changes) == 0 {
+			iss.NoRecentChanges = &issuesapi.NoRecentChangesMarker{
+				WindowSeconds: int(meaningfulchanges.DefaultSince.Seconds()),
+			}
+			continue
+		}
+		if len(changes) > correlationChangeCap {
+			changes = changes[:correlationChangeCap]
+		}
+		iss.CorrelatedChanges = changes
+	}
+}
+
+func correlationChangesForIssue(ctx context.Context, iss *issuesapi.Issue) ([]issuesapi.RecentChange, error) {
+	if meaningfulchanges.WorkloadKind(iss.Kind) {
+		// Workload subjects also correlate against their directly referenced
+		// ConfigMaps; obj==nil degrades to workload-only changes.
+		obj := workloadObjectFromCache(iss.Kind, iss.Namespace, iss.Name)
+		return meaningfulchanges.RecentForWorkloadAndConfigMaps(
+			ctx, obj, iss.Kind, iss.Namespace, iss.Name,
+			meaningfulchanges.DefaultSince, correlationChangeCap, correlationFieldLimit,
+		)
+	}
+	return meaningfulchanges.RecentForResource(
+		ctx, iss.Kind, iss.Namespace, iss.Name,
+		meaningfulchanges.DefaultSince, correlationChangeCap, correlationFieldLimit,
+	)
+}
+
+func workloadObjectFromCache(kind, namespace, name string) any {
+	cache := k8s.GetResourceCache()
+	if cache == nil {
+		return nil
+	}
+	switch strings.ToLower(kind) {
+	case "deployment":
+		if l := cache.Deployments(); l != nil {
+			if o, err := l.Deployments(namespace).Get(name); err == nil {
+				return o
+			}
+		}
+	case "statefulset":
+		if l := cache.StatefulSets(); l != nil {
+			if o, err := l.StatefulSets(namespace).Get(name); err == nil {
+				return o
+			}
+		}
+	case "daemonset":
+		if l := cache.DaemonSets(); l != nil {
+			if o, err := l.DaemonSets(namespace).Get(name); err == nil {
+				return o
+			}
+		}
+	}
+	return nil
+}

--- a/internal/mcp/issue_correlation.go
+++ b/internal/mcp/issue_correlation.go
@@ -3,10 +3,12 @@ package mcp
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/skyhook-io/radar/internal/issues"
 	"github.com/skyhook-io/radar/internal/k8s"
 	"github.com/skyhook-io/radar/internal/meaningfulchanges"
+	"github.com/skyhook-io/radar/internal/timeline"
 	"github.com/skyhook-io/radar/pkg/issuesapi"
 )
 
@@ -29,11 +31,39 @@ const (
 	correlationFieldLimit = 5
 )
 
+// correlationMinObservation is the least watch time that justifies a "no
+// recent changes" claim. Below it (fresh start, recent restart) the marker is
+// omitted entirely — a 90-second-old store asserting anything about the past
+// hour would be fiction.
+const correlationMinObservation = 5 * time.Minute
+
+// correlationWindow returns the truthful claim window: the default lookback
+// clamped to how long this process's store has actually been observing.
+// Returns 0 when observation is too short to claim anything.
+func correlationWindow() time.Duration {
+	window := meaningfulchanges.DefaultSince
+	start := timeline.ObservationStart()
+	if start.IsZero() {
+		return 0
+	}
+	if observed := time.Since(start); observed < window {
+		window = observed
+	}
+	if window < correlationMinObservation {
+		return 0
+	}
+	return window
+}
+
 // attachIssueChangeCorrelation fills CorrelatedChanges / NoRecentChanges on
 // critical issues. Single-namespace responses only — cross-namespace listings
 // are inventory sweeps where per-issue timeline lookups would multiply cost
 // without a triage question on the table.
 func attachIssueChangeCorrelation(ctx context.Context, resp *issues.ListResponse) {
+	window := correlationWindow()
+	if window == 0 {
+		return // not enough observation to claim anything, in either direction
+	}
 	checked := 0
 	for i := range resp.Issues {
 		iss := &resp.Issues[i]
@@ -51,7 +81,7 @@ func attachIssueChangeCorrelation(ctx context.Context, resp *issues.ListResponse
 		}
 		checked++
 
-		changes, err := correlationChangesForIssue(ctx, iss)
+		changes, err := correlationChangesForIssue(ctx, iss, window)
 		if err != nil {
 			continue // marker omitted = unknown, never a false "no changes"
 		}
@@ -61,7 +91,7 @@ func attachIssueChangeCorrelation(ctx context.Context, resp *issues.ListResponse
 		changes = filterSpecConfigChanges(changes)
 		if len(changes) == 0 {
 			iss.NoRecentChanges = &issuesapi.NoRecentChangesMarker{
-				WindowSeconds: int(meaningfulchanges.DefaultSince.Seconds()),
+				WindowSeconds: int(window.Seconds()),
 			}
 			continue
 		}
@@ -82,19 +112,19 @@ func filterSpecConfigChanges(changes []issuesapi.RecentChange) []issuesapi.Recen
 	return out
 }
 
-func correlationChangesForIssue(ctx context.Context, iss *issuesapi.Issue) ([]issuesapi.RecentChange, error) {
+func correlationChangesForIssue(ctx context.Context, iss *issuesapi.Issue, window time.Duration) ([]issuesapi.RecentChange, error) {
 	if meaningfulchanges.WorkloadKind(iss.Kind) {
 		// Workload subjects also correlate against their directly referenced
 		// ConfigMaps; obj==nil degrades to workload-only changes.
 		obj := workloadObjectFromCache(iss.Kind, iss.Namespace, iss.Name)
 		return meaningfulchanges.RecentForWorkloadAndConfigMaps(
 			ctx, obj, iss.Kind, iss.Namespace, iss.Name,
-			meaningfulchanges.DefaultSince, correlationChangeCap, correlationFieldLimit,
+			window, correlationChangeCap, correlationFieldLimit,
 		)
 	}
 	return meaningfulchanges.RecentForResource(
 		ctx, iss.Kind, iss.Namespace, iss.Name,
-		meaningfulchanges.DefaultSince, correlationChangeCap, correlationFieldLimit,
+		window, correlationChangeCap, correlationFieldLimit,
 	)
 }
 

--- a/internal/mcp/issue_correlation_test.go
+++ b/internal/mcp/issue_correlation_test.go
@@ -19,7 +19,24 @@ func initCorrelationStore(t *testing.T) timeline.EventStore {
 	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 200}); err != nil {
 		t.Fatalf("InitStore: %v", err)
 	}
+	// Backdate observation past the full window: a fresh store has watched
+	// for ~0s and correlation correctly refuses to claim anything.
+	timeline.SetObservationStartForTest(time.Now().Add(-2 * time.Hour))
 	return timeline.GetStore()
+}
+
+// A store that has only just started observing must emit NO markers — in
+// either direction — rather than claim an hour-long window it never watched.
+func TestAttachIssueChangeCorrelation_SkipsOnShortObservation(t *testing.T) {
+	initCorrelationStore(t)
+	timeline.SetObservationStartForTest(time.Now().Add(-90 * time.Second))
+
+	resp := issues.ListResponse{Issues: []issuesapi.Issue{criticalIssue("Deployment", "web")}}
+	attachIssueChangeCorrelation(context.Background(), &resp)
+
+	if resp.Issues[0].NoRecentChanges != nil || len(resp.Issues[0].CorrelatedChanges) > 0 {
+		t.Fatalf("90s-old store must not claim anything: %+v", resp.Issues[0])
+	}
 }
 
 func criticalIssue(kind, name string) issuesapi.Issue {

--- a/internal/mcp/issue_correlation_test.go
+++ b/internal/mcp/issue_correlation_test.go
@@ -136,7 +136,9 @@ func TestCorrelationWindow_ClampsToObservation(t *testing.T) {
 				}
 				return
 			}
-			if got > tt.want || got < tt.want-5*time.Second {
+			// The clamped window is measured a beat after the start is set, so
+			// it can exceed want by the elapsed time between the two calls.
+			if got > tt.want+time.Second || got < tt.want-time.Second {
 				t.Fatalf("window = %v, want ~%v", got, tt.want)
 			}
 		})

--- a/internal/mcp/issue_correlation_test.go
+++ b/internal/mcp/issue_correlation_test.go
@@ -43,6 +43,17 @@ func TestAttachIssueChangeCorrelation_Markers(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("append: %v", err)
 	}
+	// Status churn on the chronic workload — the SYMPTOM, not a change; it
+	// must not count as correlation evidence.
+	if err := store.Append(context.Background(), timeline.TimelineEvent{
+		ID: "quiet-status", Timestamp: time.Now().Add(-2 * time.Minute),
+		Source: timeline.SourceInformer, ClusterContext: k8s.ActiveClusterContext(),
+		Kind: "Deployment", Namespace: "shop", Name: "quiet",
+		EventType: timeline.EventTypeUpdate,
+		Diff:      &timeline.DiffInfo{Fields: []timeline.FieldChange{{Path: "status.readyReplicas", OldValue: int32(1), NewValue: int32(0)}}, Summary: "ready: 1→0"},
+	}); err != nil {
+		t.Fatalf("append quiet status: %v", err)
+	}
 
 	resp := issues.ListResponse{Issues: []issuesapi.Issue{
 		criticalIssue("Deployment", "web"),
@@ -61,7 +72,7 @@ func TestAttachIssueChangeCorrelation_Markers(t *testing.T) {
 	}
 	quiet := resp.Issues[1]
 	if quiet.NoRecentChanges == nil || quiet.NoRecentChanges.WindowSeconds != 3600 {
-		t.Fatalf("quiet should carry no_recent_changes{3600}, got %+v", quiet.NoRecentChanges)
+		t.Fatalf("quiet should carry no_recent_changes{3600} despite status churn, got %+v (correlated=%+v)", quiet.NoRecentChanges, quiet.CorrelatedChanges)
 	}
 	if warn := resp.Issues[2]; warn.NoRecentChanges != nil || len(warn.CorrelatedChanges) != 0 {
 		t.Fatalf("warning issues must not be correlated: %+v", warn)

--- a/internal/mcp/issue_correlation_test.go
+++ b/internal/mcp/issue_correlation_test.go
@@ -6,8 +6,14 @@ import (
 	"testing"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
 	"github.com/skyhook-io/radar/internal/issues"
 	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/internal/meaningfulchanges"
 	"github.com/skyhook-io/radar/internal/timeline"
 	"github.com/skyhook-io/radar/pkg/issuesapi"
 )
@@ -99,6 +105,125 @@ func TestAttachIssueChangeCorrelation_Markers(t *testing.T) {
 	}
 	if resp.CorrelationTruncated {
 		t.Fatal("no truncation expected")
+	}
+}
+
+// The claim window clamps to actual observation time: a process restarted 30
+// minutes ago must not assert anything about the full default hour.
+func TestCorrelationWindow_ClampsToObservation(t *testing.T) {
+	initCorrelationStore(t)
+	cases := []struct {
+		name     string
+		observed time.Duration // 0 = zero observation start (no store)
+		want     time.Duration
+	}{
+		{"observed longer than default window", 2 * time.Hour, meaningfulchanges.DefaultSince},
+		{"clamped to observation time", 30 * time.Minute, 30 * time.Minute},
+		{"below minimum observation", 4 * time.Minute, 0},
+		{"zero observation start", 0, 0},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.observed == 0 {
+				timeline.SetObservationStartForTest(time.Time{})
+			} else {
+				timeline.SetObservationStartForTest(time.Now().Add(-tt.observed))
+			}
+			got := correlationWindow()
+			if tt.want == 0 {
+				if got != 0 {
+					t.Fatalf("window = %v, want 0", got)
+				}
+				return
+			}
+			if got > tt.want || got < tt.want-5*time.Second {
+				t.Fatalf("window = %v, want ~%v", got, tt.want)
+			}
+		})
+	}
+}
+
+// When the subject's candidate fetch saturates (churn-heavy subjects can
+// exceed the newest-N window in an hour), an empty filtered result is
+// UNKNOWN: emitting no_recent_changes would steer the agent away from a real
+// change the fetch never saw.
+func TestAttachIssueChangeCorrelation_OmitsMarkerOnSaturatedFetch(t *testing.T) {
+	store := initCorrelationStore(t)
+	now := time.Now()
+	for i := 0; i < 100; i++ {
+		if err := store.Append(context.Background(), timeline.TimelineEvent{
+			ID: fmt.Sprintf("churn-%d", i), Timestamp: now.Add(-time.Duration(i) * time.Second),
+			Source: timeline.SourceInformer, ClusterContext: k8s.ActiveClusterContext(),
+			Kind: "Deployment", Namespace: "shop", Name: "web",
+			EventType: timeline.EventTypeUpdate,
+			Diff:      &timeline.DiffInfo{Fields: []timeline.FieldChange{{Path: "status.readyReplicas", OldValue: int32(1), NewValue: int32(0)}}, Summary: "ready: 1→0"},
+		}); err != nil {
+			t.Fatalf("append churn %d: %v", i, err)
+		}
+	}
+
+	resp := issues.ListResponse{Issues: []issuesapi.Issue{criticalIssue("Deployment", "web")}}
+	attachIssueChangeCorrelation(context.Background(), &resp)
+
+	web := resp.Issues[0]
+	if web.NoRecentChanges != nil {
+		t.Fatalf("saturated fetch must omit the marker (unknown, not 'no changes'), got %+v", web.NoRecentChanges)
+	}
+	if len(web.CorrelatedChanges) != 0 {
+		t.Fatalf("status churn must not surface as correlated changes: %+v", web.CorrelatedChanges)
+	}
+}
+
+// A critical workload's correlation fans out to ConfigMaps its pod spec
+// references directly — the headline scenario: a config change crashes the
+// consumer, and the issue carries the ConfigMap change as evidence.
+func TestAttachIssueChangeCorrelation_WorkloadConfigMapFanout(t *testing.T) {
+	client := k8sfake.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "flagd", Namespace: "shop"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{{
+					Name: "config",
+					VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "flagd-config"},
+					}},
+				}},
+				Containers: []corev1.Container{{Name: "flagd", Image: "flagd:v1"}},
+			}},
+		},
+	})
+	if err := k8s.InitTestResourceCache(client); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	t.Cleanup(k8s.ResetTestState)
+	store := initCorrelationStore(t)
+
+	if err := store.Append(context.Background(), timeline.TimelineEvent{
+		ID: "cm-change", Timestamp: time.Now().Add(-5 * time.Minute),
+		Source: timeline.SourceInformer, ClusterContext: k8s.ActiveClusterContext(),
+		Kind: "ConfigMap", Namespace: "shop", Name: "flagd-config",
+		EventType: timeline.EventTypeUpdate,
+		Diff:      &timeline.DiffInfo{Fields: []timeline.FieldChange{{Path: "data.flags.adHighCpu.defaultVariant", OldValue: "off", NewValue: "on"}}, Summary: "flag changed"},
+	}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	resp := issues.ListResponse{Issues: []issuesapi.Issue{criticalIssue("Deployment", "flagd")}}
+	attachIssueChangeCorrelation(context.Background(), &resp)
+
+	flagd := resp.Issues[0]
+	if len(flagd.CorrelatedChanges) != 1 {
+		t.Fatalf("correlated_changes = %+v, want exactly the ConfigMap change", flagd.CorrelatedChanges)
+	}
+	c := flagd.CorrelatedChanges[0]
+	if c.Kind != "ConfigMap" || c.Name != "flagd-config" {
+		t.Fatalf("unexpected correlated change: %+v", c)
+	}
+	if len(c.ConsumedBy) != 1 || c.ConsumedBy[0] != "Deployment/flagd" {
+		t.Fatalf("consumed_by = %v, want [Deployment/flagd]", c.ConsumedBy)
+	}
+	if flagd.NoRecentChanges != nil {
+		t.Fatalf("issue with correlated changes must not also carry no_recent_changes: %+v", flagd.NoRecentChanges)
 	}
 }
 

--- a/internal/mcp/issue_correlation_test.go
+++ b/internal/mcp/issue_correlation_test.go
@@ -1,0 +1,106 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/skyhook-io/radar/internal/issues"
+	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/internal/timeline"
+	"github.com/skyhook-io/radar/pkg/issuesapi"
+)
+
+func initCorrelationStore(t *testing.T) timeline.EventStore {
+	t.Helper()
+	timeline.ResetStore()
+	t.Cleanup(timeline.ResetStore)
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 200}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+	return timeline.GetStore()
+}
+
+func criticalIssue(kind, name string) issuesapi.Issue {
+	return issuesapi.Issue{
+		Severity: issuesapi.SeverityCritical,
+		Kind:     kind, Namespace: "shop", Name: name,
+		Reason: "CrashLoopBackOff",
+	}
+}
+
+// The changed workload gets correlated_changes; the chronic one gets an
+// explicit no_recent_changes marker with the window.
+func TestAttachIssueChangeCorrelation_Markers(t *testing.T) {
+	store := initCorrelationStore(t)
+	if err := store.Append(context.Background(), timeline.TimelineEvent{
+		ID: "web-spec", Timestamp: time.Now().Add(-5 * time.Minute),
+		Source: timeline.SourceInformer, ClusterContext: k8s.ActiveClusterContext(),
+		Kind: "Deployment", Namespace: "shop", Name: "web",
+		EventType: timeline.EventTypeUpdate,
+		Diff:      &timeline.DiffInfo{Fields: []timeline.FieldChange{{Path: "spec.template.spec.containers[web].readinessProbe", OldValue: "/health", NewValue: "/healthz"}}, Summary: "readinessProbe(web) changed"},
+	}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	resp := issues.ListResponse{Issues: []issuesapi.Issue{
+		criticalIssue("Deployment", "web"),
+		criticalIssue("Deployment", "quiet"),
+		{Severity: issuesapi.SeverityWarning, Kind: "Deployment", Namespace: "shop", Name: "warn-only"},
+		criticalIssue("Pod", "standalone"), // untracked kind: no marker either way
+	}}
+	attachIssueChangeCorrelation(context.Background(), &resp)
+
+	web := resp.Issues[0]
+	if len(web.CorrelatedChanges) == 0 {
+		t.Fatalf("web should carry correlated_changes, got %+v", web)
+	}
+	if web.NoRecentChanges != nil {
+		t.Fatalf("web has both markers: %+v", web)
+	}
+	quiet := resp.Issues[1]
+	if quiet.NoRecentChanges == nil || quiet.NoRecentChanges.WindowSeconds != 3600 {
+		t.Fatalf("quiet should carry no_recent_changes{3600}, got %+v", quiet.NoRecentChanges)
+	}
+	if warn := resp.Issues[2]; warn.NoRecentChanges != nil || len(warn.CorrelatedChanges) != 0 {
+		t.Fatalf("warning issues must not be correlated: %+v", warn)
+	}
+	if pod := resp.Issues[3]; pod.NoRecentChanges != nil || len(pod.CorrelatedChanges) != 0 {
+		t.Fatalf("untracked kinds must not carry markers (cannot truthfully claim 'no changes'): %+v", pod)
+	}
+	if resp.CorrelationTruncated {
+		t.Fatal("no truncation expected")
+	}
+}
+
+// Past the cap, remaining criticals are skipped and the response says so.
+func TestAttachIssueChangeCorrelation_Truncation(t *testing.T) {
+	initCorrelationStore(t)
+
+	var list []issuesapi.Issue
+	for i := 0; i < correlationIssueCap+2; i++ {
+		list = append(list, criticalIssue("Deployment", fmt.Sprintf("dep-%d", i)))
+	}
+	resp := issues.ListResponse{Issues: list}
+	attachIssueChangeCorrelation(context.Background(), &resp)
+
+	if !resp.CorrelationTruncated {
+		t.Fatal("correlation_truncated must be set when criticals exceed the cap")
+	}
+	marked := 0
+	for _, iss := range resp.Issues {
+		if iss.NoRecentChanges != nil || len(iss.CorrelatedChanges) > 0 {
+			marked++
+		}
+	}
+	if marked != correlationIssueCap {
+		t.Fatalf("marked = %d, want exactly the cap (%d)", marked, correlationIssueCap)
+	}
+	// The issues past the cap carry NO marker — "not checked", never a false
+	// "no changes".
+	last := resp.Issues[len(resp.Issues)-1]
+	if last.NoRecentChanges != nil || len(last.CorrelatedChanges) > 0 {
+		t.Fatalf("issue past cap must be unmarked: %+v", last)
+	}
+}

--- a/internal/mcp/notfound.go
+++ b/internal/mcp/notfound.go
@@ -1,0 +1,210 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+)
+
+// Not-found errors are prompts: a wrong kind or namespace guess should cost
+// the agent one corrected call, not a search expedition. On not-found we do a
+// cheap cached-lister sweep for the same name under a different kind (same
+// namespace) and the same kind in another namespace, and say exactly how to
+// retry. Cross-namespace suggestions are RBAC-gated — we never reveal a
+// resource in a namespace the caller can't access. Secrets are excluded from
+// suggestions entirely.
+const maxNotFoundSuggestions = 3
+
+// notFoundError wraps a not-found error with retry suggestions when the
+// cache knows a likely match. Falls back to the bare error otherwise.
+func notFoundError(ctx context.Context, baseErr error, kind, namespace, name string) error {
+	if s := notFoundSuggestion(ctx, kind, namespace, name); s != "" {
+		return fmt.Errorf("resource not found: %w — %s", baseErr, s)
+	}
+	return fmt.Errorf("resource not found: %w", baseErr)
+}
+
+type notFoundProbe struct {
+	kind       string
+	existsIn   func(namespace, name string) bool
+	namespaces func(name string) []string
+}
+
+func notFoundProbes(cache *k8s.ResourceCache) []notFoundProbe {
+	var probes []notFoundProbe
+	everything := labels.Everything()
+	if l := cache.Deployments(); l != nil {
+		probes = append(probes, notFoundProbe{
+			kind: "Deployment",
+			existsIn: func(ns, name string) bool {
+				_, err := l.Deployments(ns).Get(name)
+				return err == nil
+			},
+			namespaces: func(name string) []string {
+				items, _ := l.List(everything)
+				var out []string
+				for _, item := range items {
+					if item.Name == name {
+						out = append(out, item.Namespace)
+					}
+				}
+				return out
+			},
+		})
+	}
+	if l := cache.StatefulSets(); l != nil {
+		probes = append(probes, notFoundProbe{
+			kind: "StatefulSet",
+			existsIn: func(ns, name string) bool {
+				_, err := l.StatefulSets(ns).Get(name)
+				return err == nil
+			},
+			namespaces: func(name string) []string {
+				items, _ := l.List(everything)
+				var out []string
+				for _, item := range items {
+					if item.Name == name {
+						out = append(out, item.Namespace)
+					}
+				}
+				return out
+			},
+		})
+	}
+	if l := cache.DaemonSets(); l != nil {
+		probes = append(probes, notFoundProbe{
+			kind: "DaemonSet",
+			existsIn: func(ns, name string) bool {
+				_, err := l.DaemonSets(ns).Get(name)
+				return err == nil
+			},
+			namespaces: func(name string) []string {
+				items, _ := l.List(everything)
+				var out []string
+				for _, item := range items {
+					if item.Name == name {
+						out = append(out, item.Namespace)
+					}
+				}
+				return out
+			},
+		})
+	}
+	if l := cache.Services(); l != nil {
+		probes = append(probes, notFoundProbe{
+			kind: "Service",
+			existsIn: func(ns, name string) bool {
+				_, err := l.Services(ns).Get(name)
+				return err == nil
+			},
+			namespaces: func(name string) []string {
+				items, _ := l.List(everything)
+				var out []string
+				for _, item := range items {
+					if item.Name == name {
+						out = append(out, item.Namespace)
+					}
+				}
+				return out
+			},
+		})
+	}
+	if l := cache.ConfigMaps(); l != nil {
+		probes = append(probes, notFoundProbe{
+			kind: "ConfigMap",
+			existsIn: func(ns, name string) bool {
+				_, err := l.ConfigMaps(ns).Get(name)
+				return err == nil
+			},
+			namespaces: func(name string) []string {
+				items, _ := l.List(everything)
+				var out []string
+				for _, item := range items {
+					if item.Name == name {
+						out = append(out, item.Namespace)
+					}
+				}
+				return out
+			},
+		})
+	}
+	if l := cache.CronJobs(); l != nil {
+		probes = append(probes, notFoundProbe{
+			kind: "CronJob",
+			existsIn: func(ns, name string) bool {
+				_, err := l.CronJobs(ns).Get(name)
+				return err == nil
+			},
+			namespaces: func(name string) []string {
+				items, _ := l.List(everything)
+				var out []string
+				for _, item := range items {
+					if item.Name == name {
+						out = append(out, item.Namespace)
+					}
+				}
+				return out
+			},
+		})
+	}
+	return probes
+}
+
+func kindMatchesProbe(requested, probeKind string) bool {
+	r := strings.ToLower(strings.TrimSpace(requested))
+	p := strings.ToLower(probeKind)
+	return r == p || r == p+"s" || strings.TrimSuffix(r, "es") == p
+}
+
+func notFoundSuggestion(ctx context.Context, kind, namespace, name string) string {
+	cache := k8s.GetResourceCache()
+	if cache == nil || name == "" {
+		return ""
+	}
+	probes := notFoundProbes(cache)
+	var parts []string
+
+	// Same name under a different kind in the same namespace — the classic
+	// "diagnose StatefulSet postgresql" when it's a Deployment.
+	if namespace != "" {
+		for _, p := range probes {
+			if kindMatchesProbe(kind, p.kind) {
+				continue
+			}
+			if p.existsIn(namespace, name) {
+				parts = append(parts, fmt.Sprintf("found %s %s/%s — retry with kind=%s", p.kind, namespace, name, strings.ToLower(p.kind)))
+				if len(parts) >= maxNotFoundSuggestions {
+					break
+				}
+			}
+		}
+	}
+
+	// Same kind in another namespace the caller can access.
+	if len(parts) < maxNotFoundSuggestions {
+		for _, p := range probes {
+			if !kindMatchesProbe(kind, p.kind) {
+				continue
+			}
+			for _, ns := range p.namespaces(name) {
+				if ns == namespace || !checkNamespaceAccess(ctx, ns) {
+					continue
+				}
+				parts = append(parts, fmt.Sprintf("found %s %s/%s — retry with namespace=%s", p.kind, ns, name, ns))
+				if len(parts) >= maxNotFoundSuggestions {
+					break
+				}
+			}
+			break
+		}
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, "; ") + "; or use search"
+}

--- a/internal/mcp/response_guards.go
+++ b/internal/mcp/response_guards.go
@@ -69,7 +69,12 @@ func truncateLargeConfigMapData(resourceData any) (any, string) {
 		}
 	}
 	if len(truncatedKeys) == 0 {
-		return resourceData, ""
+		// Over budget but every value sits under the floor (many tiny keys) —
+		// nothing to truncate, but the size still deserves a warning.
+		return resourceData, fmt.Sprintf(
+			"large ConfigMap (%d bytes total across %d keys): values left intact (each under %d bytes)",
+			total, valueCount, valueCap,
+		)
 	}
 	sort.Strings(truncatedKeys)
 	return resourceData, fmt.Sprintf(

--- a/internal/mcp/response_guards.go
+++ b/internal/mcp/response_guards.go
@@ -15,22 +15,28 @@ const (
 	configMapGuardValueBytes = 8 * 1024
 )
 
-// truncateLargeConfigMapData truncates oversized data values in a minified
-// ConfigMap payload (map[string]any with a "data" section). Returns the
-// (possibly modified) payload and a warning note ("" when nothing changed).
+// truncateLargeConfigMapData truncates oversized values in a minified
+// ConfigMap payload (map[string]any with "data" / "binaryData" sections),
+// mutating the payload in place. binaryData counts too — base64 blobs (cert
+// bundles, jars) are routinely the largest values. Returns the payload and a
+// warning note ("" when nothing changed).
 func truncateLargeConfigMapData(resourceData any) (any, string) {
 	m, ok := resourceData.(map[string]any)
 	if !ok {
 		return resourceData, ""
 	}
-	data, ok := m["data"].(map[string]any)
-	if !ok {
-		return resourceData, ""
+	var sections []map[string]any
+	for _, key := range []string{"data", "binaryData"} {
+		if section, ok := m[key].(map[string]any); ok {
+			sections = append(sections, section)
+		}
 	}
 	total := 0
-	for _, v := range data {
-		if s, ok := v.(string); ok {
-			total += len(s)
+	for _, section := range sections {
+		for _, v := range section {
+			if s, ok := v.(string); ok {
+				total += len(s)
+			}
 		}
 	}
 	if total <= configMapGuardTotalBytes {
@@ -38,13 +44,15 @@ func truncateLargeConfigMapData(resourceData any) (any, string) {
 	}
 
 	var truncatedKeys []string
-	for k, v := range data {
-		s, ok := v.(string)
-		if !ok || len(s) <= configMapGuardValueBytes {
-			continue
+	for _, section := range sections {
+		for k, v := range section {
+			s, ok := v.(string)
+			if !ok || len(s) <= configMapGuardValueBytes {
+				continue
+			}
+			section[k] = s[:configMapGuardValueBytes] + fmt.Sprintf("\n…[truncated by radar: value is %d bytes, showing first %d]", len(s), configMapGuardValueBytes)
+			truncatedKeys = append(truncatedKeys, k)
 		}
-		data[k] = s[:configMapGuardValueBytes] + fmt.Sprintf("\n…[truncated by radar: value is %d bytes, showing first %d]", len(s), configMapGuardValueBytes)
-		truncatedKeys = append(truncatedKeys, k)
 	}
 	if len(truncatedKeys) == 0 {
 		return resourceData, ""

--- a/internal/mcp/response_guards.go
+++ b/internal/mcp/response_guards.go
@@ -64,16 +64,23 @@ func truncateLargeConfigMapData(resourceData any) (any, string) {
 			if !ok || len(s) <= valueCap {
 				continue
 			}
-			section[k] = s[:valueCap] + fmt.Sprintf("\n…[truncated by radar: value is %d bytes, showing first %d]", len(s), valueCap)
+			replacement := s[:valueCap] + fmt.Sprintf("\n…[truncated by radar: value is %d bytes, showing first %d]", len(s), valueCap)
+			// Marker overhead can exceed the bytes saved for values only just
+			// over the cap — never grow a value in the name of truncating it.
+			if len(replacement) >= len(s) {
+				continue
+			}
+			section[k] = replacement
 			truncatedKeys = append(truncatedKeys, k)
 		}
 	}
 	if len(truncatedKeys) == 0 {
-		// Over budget but every value sits under the floor (many tiny keys) —
-		// nothing to truncate, but the size still deserves a warning.
+		// Over budget but no value is large enough that truncating it would
+		// shrink the payload (many small keys) — leave them intact, but the
+		// size still deserves a warning.
 		return resourceData, fmt.Sprintf(
-			"large ConfigMap (%d bytes total across %d keys): values left intact (each under %d bytes)",
-			total, valueCount, valueCap,
+			"large ConfigMap (%d bytes total across %d keys): values left intact — none large enough that truncation would reduce the payload",
+			total, valueCount,
 		)
 	}
 	sort.Strings(truncatedKeys)

--- a/internal/mcp/response_guards.go
+++ b/internal/mcp/response_guards.go
@@ -13,6 +13,10 @@ import (
 const (
 	configMapGuardTotalBytes = 16 * 1024
 	configMapGuardValueBytes = 8 * 1024
+	// configMapGuardValueFloor bounds how far the per-value cap tightens when
+	// many medium values blow the total budget — below this, values stop
+	// being readable at all.
+	configMapGuardValueFloor = 512
 )
 
 // truncateLargeConfigMapData truncates oversized values in a minified
@@ -31,11 +35,12 @@ func truncateLargeConfigMapData(resourceData any) (any, string) {
 			sections = append(sections, section)
 		}
 	}
-	total := 0
+	total, valueCount := 0, 0
 	for _, section := range sections {
 		for _, v := range section {
 			if s, ok := v.(string); ok {
 				total += len(s)
+				valueCount++
 			}
 		}
 	}
@@ -43,14 +48,23 @@ func truncateLargeConfigMapData(resourceData any) (any, string) {
 		return resourceData, ""
 	}
 
+	// A swarm of medium values can blow the total budget without any single
+	// value crossing the per-value cap — tighten the cap so the truncated
+	// total lands near the budget. The floor means a huge key count can still
+	// exceed the budget; accepted, the realistic bombs are few large values.
+	valueCap := configMapGuardValueBytes
+	if evenCap := configMapGuardTotalBytes / valueCount; evenCap < valueCap {
+		valueCap = max(evenCap, configMapGuardValueFloor)
+	}
+
 	var truncatedKeys []string
 	for _, section := range sections {
 		for k, v := range section {
 			s, ok := v.(string)
-			if !ok || len(s) <= configMapGuardValueBytes {
+			if !ok || len(s) <= valueCap {
 				continue
 			}
-			section[k] = s[:configMapGuardValueBytes] + fmt.Sprintf("\n…[truncated by radar: value is %d bytes, showing first %d]", len(s), configMapGuardValueBytes)
+			section[k] = s[:valueCap] + fmt.Sprintf("\n…[truncated by radar: value is %d bytes, showing first %d]", len(s), valueCap)
 			truncatedKeys = append(truncatedKeys, k)
 		}
 	}
@@ -59,7 +73,7 @@ func truncateLargeConfigMapData(resourceData any) (any, string) {
 	}
 	sort.Strings(truncatedKeys)
 	return resourceData, fmt.Sprintf(
-		"large ConfigMap (%d bytes total): values truncated to %dKB for keys %v",
-		total, configMapGuardValueBytes/1024, truncatedKeys,
+		"large ConfigMap (%d bytes total): values truncated to %d bytes for keys %v",
+		total, valueCap, truncatedKeys,
 	)
 }

--- a/internal/mcp/response_guards.go
+++ b/internal/mcp/response_guards.go
@@ -1,0 +1,57 @@
+package mcp
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Large ConfigMaps (init scripts, bundled JSON configs) can dominate a
+// get_resource response with tens of KB the agent rarely needs in full.
+// Values are truncated only when the total data size is genuinely large, and
+// always with an explicit warning — silent truncation would read as "that's
+// the whole value".
+const (
+	configMapGuardTotalBytes = 16 * 1024
+	configMapGuardValueBytes = 8 * 1024
+)
+
+// truncateLargeConfigMapData truncates oversized data values in a minified
+// ConfigMap payload (map[string]any with a "data" section). Returns the
+// (possibly modified) payload and a warning note ("" when nothing changed).
+func truncateLargeConfigMapData(resourceData any) (any, string) {
+	m, ok := resourceData.(map[string]any)
+	if !ok {
+		return resourceData, ""
+	}
+	data, ok := m["data"].(map[string]any)
+	if !ok {
+		return resourceData, ""
+	}
+	total := 0
+	for _, v := range data {
+		if s, ok := v.(string); ok {
+			total += len(s)
+		}
+	}
+	if total <= configMapGuardTotalBytes {
+		return resourceData, ""
+	}
+
+	var truncatedKeys []string
+	for k, v := range data {
+		s, ok := v.(string)
+		if !ok || len(s) <= configMapGuardValueBytes {
+			continue
+		}
+		data[k] = s[:configMapGuardValueBytes] + fmt.Sprintf("\n…[truncated by radar: value is %d bytes, showing first %d]", len(s), configMapGuardValueBytes)
+		truncatedKeys = append(truncatedKeys, k)
+	}
+	if len(truncatedKeys) == 0 {
+		return resourceData, ""
+	}
+	sort.Strings(truncatedKeys)
+	return resourceData, fmt.Sprintf(
+		"large ConfigMap (%d bytes total): values truncated to %dKB for keys %v",
+		total, configMapGuardValueBytes/1024, truncatedKeys,
+	)
+}

--- a/internal/mcp/response_guards_test.go
+++ b/internal/mcp/response_guards_test.go
@@ -1,0 +1,92 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+)
+
+func TestTruncateLargeConfigMapData(t *testing.T) {
+	small := map[string]any{"data": map[string]any{"k": "v"}}
+	if _, note := truncateLargeConfigMapData(small); note != "" {
+		t.Fatalf("small ConfigMap must pass untouched, got note %q", note)
+	}
+
+	big := strings.Repeat("x", 20*1024)
+	payload := map[string]any{"data": map[string]any{"init.sql": big, "small": "v"}}
+	out, note := truncateLargeConfigMapData(payload)
+	if note == "" {
+		t.Fatal("large ConfigMap must produce a truncation note")
+	}
+	data := out.(map[string]any)["data"].(map[string]any)
+	v := data["init.sql"].(string)
+	if len(v) >= len(big) {
+		t.Fatalf("value not truncated: %d bytes", len(v))
+	}
+	if !strings.Contains(v, "[truncated by radar:") {
+		t.Fatalf("truncated value lacks the explicit marker: %q", v[len(v)-100:])
+	}
+	if data["small"] != "v" {
+		t.Fatalf("small value must be untouched, got %v", data["small"])
+	}
+	if !strings.Contains(note, "init.sql") {
+		t.Fatalf("note must name truncated keys: %q", note)
+	}
+
+	// Non-map payloads pass through.
+	if _, note := truncateLargeConfigMapData("raw"); note != "" {
+		t.Fatal("non-map payload must pass through")
+	}
+}
+
+func TestKindMatchesProbe(t *testing.T) {
+	cases := []struct {
+		requested string
+		probe     string
+		want      bool
+	}{
+		{"deployment", "Deployment", true},
+		{"deployments", "Deployment", true},
+		{"Deployment", "Deployment", true},
+		{"statefulset", "Deployment", false},
+		{"services", "Service", true},
+	}
+	for _, tt := range cases {
+		if got := kindMatchesProbe(tt.requested, tt.probe); got != tt.want {
+			t.Errorf("kindMatchesProbe(%q,%q) = %v, want %v", tt.requested, tt.probe, got, tt.want)
+		}
+	}
+}
+
+// A wrong-kind guess must come back with the corrected retry call.
+func TestNotFoundSuggestion_WrongKind(t *testing.T) {
+	client := k8sfake.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "postgresql", Namespace: "shop"},
+	})
+	if err := k8s.InitTestResourceCache(client); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	t.Cleanup(k8s.ResetTestState)
+
+	s := notFoundSuggestion(context.Background(), "statefulset", "shop", "postgresql")
+	if !strings.Contains(s, "found Deployment shop/postgresql") || !strings.Contains(s, "kind=deployment") {
+		t.Fatalf("suggestion = %q, want Deployment kind correction", s)
+	}
+
+	// Same kind, wrong namespace → namespace correction.
+	s = notFoundSuggestion(context.Background(), "deployment", "prod", "postgresql")
+	if !strings.Contains(s, "namespace=shop") {
+		t.Fatalf("suggestion = %q, want namespace correction", s)
+	}
+
+	// Nothing similar → no suggestion.
+	if s := notFoundSuggestion(context.Background(), "deployment", "shop", "nonexistent"); s != "" {
+		t.Fatalf("expected empty suggestion, got %q", s)
+	}
+}

--- a/internal/mcp/response_guards_test.go
+++ b/internal/mcp/response_guards_test.go
@@ -95,6 +95,36 @@ func TestTruncateLargeConfigMapData_ManyTinyValuesWarnOnly(t *testing.T) {
 	}
 }
 
+// Values just above the truncation floor must never grow: keeping valueCap
+// bytes plus the ~60B marker can exceed a 540B original. The guard must leave
+// them intact and warn rather than enlarge the payload while claiming to cut.
+func TestTruncateLargeConfigMapData_NeverEnlarges(t *testing.T) {
+	data := map[string]any{}
+	for i := 0; i < 40; i++ {
+		data[fmt.Sprintf("near-floor-%d", i)] = strings.Repeat("x", 540) // > 512 cap, < cap+marker
+	}
+	in := map[string]any{"data": data}
+	before := 0
+	for _, v := range data {
+		before += len(v.(string))
+	}
+	out, note := truncateLargeConfigMapData(in)
+	if note == "" {
+		t.Fatal("over-budget payload must still warn")
+	}
+	after := 0
+	for k, v := range out.(map[string]any)["data"].(map[string]any) {
+		s := v.(string)
+		after += len(s)
+		if len(s) != 540 {
+			t.Fatalf("value %s changed to %d bytes — truncation enlarged or altered a near-floor value", k, len(s))
+		}
+	}
+	if after > before {
+		t.Fatalf("payload grew from %d to %d bytes", before, after)
+	}
+}
+
 // binaryData counts toward the size guard too — base64 blobs (cert bundles,
 // jars) are routinely the largest ConfigMap payloads.
 func TestTruncateLargeConfigMapData_BinaryData(t *testing.T) {

--- a/internal/mcp/response_guards_test.go
+++ b/internal/mcp/response_guards_test.go
@@ -73,6 +73,28 @@ func TestTruncateLargeConfigMapData_ManyMediumValues(t *testing.T) {
 	}
 }
 
+// When every value sits under the truncation floor but the total is still
+// over budget (many tiny keys), the guard can't shrink anything — it must
+// still warn rather than stay silent about a large payload.
+func TestTruncateLargeConfigMapData_ManyTinyValuesWarnOnly(t *testing.T) {
+	data := map[string]any{}
+	for i := 0; i < 40; i++ {
+		data[fmt.Sprintf("tiny-%d", i)] = strings.Repeat("x", 500)
+	}
+	out, note := truncateLargeConfigMapData(map[string]any{"data": data})
+	if note == "" {
+		t.Fatal("20KB of tiny values must still produce a size warning")
+	}
+	if strings.Contains(note, "truncated to") {
+		t.Fatalf("note claims truncation but nothing should shrink: %q", note)
+	}
+	for k, v := range out.(map[string]any)["data"].(map[string]any) {
+		if len(v.(string)) != 500 {
+			t.Fatalf("value %s modified: %d bytes", k, len(v.(string)))
+		}
+	}
+}
+
 // binaryData counts toward the size guard too — base64 blobs (cert bundles,
 // jars) are routinely the largest ConfigMap payloads.
 func TestTruncateLargeConfigMapData_BinaryData(t *testing.T) {

--- a/internal/mcp/response_guards_test.go
+++ b/internal/mcp/response_guards_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -42,6 +43,33 @@ func TestTruncateLargeConfigMapData(t *testing.T) {
 	// Non-map payloads pass through.
 	if _, note := truncateLargeConfigMapData("raw"); note != "" {
 		t.Fatal("non-map payload must pass through")
+	}
+}
+
+// Many medium values can blow the total budget without any single value
+// crossing the 8KB per-value cap — the guard must tighten the cap so the
+// payload still shrinks toward the budget instead of passing through whole.
+func TestTruncateLargeConfigMapData_ManyMediumValues(t *testing.T) {
+	data := map[string]any{}
+	for i := 0; i < 10; i++ {
+		data[fmt.Sprintf("part-%d", i)] = strings.Repeat("x", 3*1024)
+	}
+	out, note := truncateLargeConfigMapData(map[string]any{"data": data})
+	if note == "" {
+		t.Fatal("30KB of medium values must trigger the guard")
+	}
+	got := out.(map[string]any)["data"].(map[string]any)
+	totalAfter := 0
+	for k, v := range got {
+		s := v.(string)
+		totalAfter += len(s)
+		if !strings.Contains(s, "[truncated by radar:") {
+			t.Fatalf("value %s not truncated: %d bytes", k, len(s))
+		}
+	}
+	// 10 values capped near totalBudget/10 plus markers — far below the raw 30KB.
+	if totalAfter > configMapGuardTotalBytes+10*200 {
+		t.Fatalf("payload still %d bytes after truncation", totalAfter)
 	}
 }
 

--- a/internal/mcp/response_guards_test.go
+++ b/internal/mcp/response_guards_test.go
@@ -45,6 +45,34 @@ func TestTruncateLargeConfigMapData(t *testing.T) {
 	}
 }
 
+// binaryData counts toward the size guard too — base64 blobs (cert bundles,
+// jars) are routinely the largest ConfigMap payloads.
+func TestTruncateLargeConfigMapData_BinaryData(t *testing.T) {
+	blob := strings.Repeat("A", 20*1024)
+	payload := map[string]any{
+		"data":       map[string]any{"small": "v"},
+		"binaryData": map[string]any{"bundle.jks": blob},
+	}
+	out, note := truncateLargeConfigMapData(payload)
+	if note == "" {
+		t.Fatal("large binaryData must produce a truncation note")
+	}
+	bin := out.(map[string]any)["binaryData"].(map[string]any)
+	v := bin["bundle.jks"].(string)
+	if len(v) >= len(blob) {
+		t.Fatalf("binaryData value not truncated: %d bytes", len(v))
+	}
+	if !strings.Contains(v, "[truncated by radar:") {
+		t.Fatal("truncated binaryData value lacks the explicit marker")
+	}
+	if !strings.Contains(note, "bundle.jks") {
+		t.Fatalf("note must name the truncated key: %q", note)
+	}
+	if data := out.(map[string]any)["data"].(map[string]any); data["small"] != "v" {
+		t.Fatalf("small data value must be untouched, got %v", data["small"])
+	}
+}
+
 func TestKindMatchesProbe(t *testing.T) {
 	cases := []struct {
 		requested string
@@ -88,5 +116,30 @@ func TestNotFoundSuggestion_WrongKind(t *testing.T) {
 	// Nothing similar → no suggestion.
 	if s := notFoundSuggestion(context.Background(), "deployment", "shop", "nonexistent"); s != "" {
 		t.Fatalf("expected empty suggestion, got %q", s)
+	}
+}
+
+// Cross-namespace suggestions must never reveal a resource in a namespace the
+// caller can't read — a not-found error would otherwise become an existence
+// oracle across RBAC boundaries.
+func TestNotFoundSuggestion_CrossNamespaceRBACGated(t *testing.T) {
+	client := k8sfake.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "postgresql", Namespace: "secret-ns"},
+	})
+	if err := k8s.InitTestResourceCache(client); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	t.Cleanup(k8s.ResetTestState)
+
+	restricted := withTestUserPerms(t, "intruder", nil, []string{"shop"})
+	if s := notFoundSuggestion(restricted, "deployment", "shop", "postgresql"); s != "" {
+		t.Fatalf("suggestion leaked a resource in an inaccessible namespace: %q", s)
+	}
+
+	// The same lookup by a user who CAN read secret-ns gets the correction.
+	permitted := withTestUserPerms(t, "operator", nil, []string{"shop", "secret-ns"})
+	s := notFoundSuggestion(permitted, "deployment", "shop", "postgresql")
+	if !strings.Contains(s, "namespace=secret-ns") {
+		t.Fatalf("suggestion = %q, want namespace correction for permitted user", s)
 	}
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -310,8 +310,8 @@ func registerTools(server *mcp.Server) {
 			"not yet visible as runtime issues, or help distinguish creation-time " +
 			"baseline failures from the active incident. " +
 			"Single-namespace responses additionally correlate changes PER critical issue: " +
-			"`correlated_changes` lists recent spec/config changes on that issue's subject " +
-			"(and its referenced ConfigMaps); `no_recent_changes.windowSeconds` states the " +
+			"`correlated_changes` lists recent non-status changes on that issue's subject " +
+			"(and its referenced ConfigMaps); `no_recent_changes.window_seconds` states the " +
 			"subject had NO tracked changes in that window — strong evidence the issue is " +
 			"chronic rather than change-driven. An issue with neither marker was not " +
 			"checked (see `correlation_truncated`) — never read absence as 'no changes'. " +
@@ -937,7 +937,10 @@ func handleGetResource(ctx context.Context, req *mcp.CallToolRequest, input getR
 		// State-derived advisory warnings (deletionTimestamp, external manager,
 		// terminating namespace, workload health-condition history, PVC stuck
 		// Pending). Cheap — operates on the object we already fetched. Skipped
-		// for context=none so that mode stays a bare object for raw jq work.
+		// for context=none so that mode stays a bare object for raw jq work;
+		// the ConfigMap truncation note appended below is the one warning that
+		// survives context=none, because silent truncation would read as a
+		// complete value.
 		warnings = k8score.EnrichRuntimeObjectWarnings(rawObj)
 	}
 	if truncationNote != "" {
@@ -949,7 +952,7 @@ func handleGetResource(ctx context.Context, req *mcp.CallToolRequest, input getR
 	var recentChanges []issuesapi.RecentChange
 	var changesErr string
 	if includeChanges {
-		changes, err := meaningfulchanges.RecentForResource(ctx, kind, namespace, name, meaningfulchanges.DefaultSince, meaningfulchanges.ResourceLimit, meaningfulchanges.DefaultFieldLimit)
+		changes, _, err := meaningfulchanges.RecentForResource(ctx, kind, namespace, name, meaningfulchanges.DefaultSince, meaningfulchanges.ResourceLimit, meaningfulchanges.DefaultFieldLimit)
 		if err != nil {
 			changesErr = err.Error()
 		} else {
@@ -958,7 +961,8 @@ func handleGetResource(ctx context.Context, req *mcp.CallToolRequest, input getR
 	}
 
 	// Three shapes:
-	//   - bare resource: no includes, context=none
+	//   - bare resource: no includes, context=none, no warnings (a truncation
+	//     warning upgrades this to {resource, warnings})
 	//   - resource + resourceContext: no includes, default context
 	//   - resource + resourceContext + extras: includes set
 	if len(includes) == 0 && resourceCtx == nil && len(warnings) == 0 && !defaultConfigMapChanges {
@@ -1085,7 +1089,7 @@ func attachResourceExtras(ctx context.Context, cache *k8s.ResourceCache, result 
 		_, hasChanges := result["recentChanges"]
 		_, hasChangesErr := result["recentChangesError"]
 		if !hasChanges && !hasChangesErr {
-			if changes, err := meaningfulchanges.RecentForResource(ctx, kind, namespace, name, meaningfulchanges.DefaultSince, meaningfulchanges.ResourceLimit, meaningfulchanges.DefaultFieldLimit); err == nil {
+			if changes, _, err := meaningfulchanges.RecentForResource(ctx, kind, namespace, name, meaningfulchanges.DefaultSince, meaningfulchanges.ResourceLimit, meaningfulchanges.DefaultFieldLimit); err == nil {
 				result["recentChanges"] = changes
 			} else {
 				result["recentChangesError"] = err.Error()
@@ -2505,7 +2509,7 @@ func handleIssuesTool(ctx context.Context, _ *mcp.CallToolRequest, input issuesI
 		}
 	}
 	// Per-issue change correlation (single-namespace responses): each
-	// critical issue carries either its correlated spec/config changes or an
+	// critical issue carries either its correlated non-status changes or an
 	// explicit no_recent_changes marker — deterministic per-subject evidence
 	// the global recent_changes list can't bind to individual issues.
 	if len(allowedNamespaces) == 1 {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2485,8 +2485,8 @@ func handleIssuesTool(ctx context.Context, _ *mcp.CallToolRequest, input issuesI
 		filters.Filter = f
 	}
 	out, stats := issues.ComposeWithStats(provider, filters)
-	// Shared response shape (issues.ListResponse) — identical to /api/issues so
-	// HTTP and MCP can't drift.
+	// Shared base response shape (issues.ListResponse), then MCP-specific
+	// enrichments below.
 	resp := issues.NewListResponse(out, stats)
 	resp.ClusterContext = provider.ClusterContextForIssues(allowedNamespaces, func(group, resource string) bool {
 		return canReadInNamespace(ctx, group, resource, "kube-system", "list")

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -113,11 +113,13 @@ func registerTools(server *mcp.Server) {
 			"scoped to a namespace. " +
 			"Returns Kubernetes resource nodes and edges (Services, workloads, Pods, " +
 			"Ingresses, ConfigMaps, Secrets, owners) so you can see service-to-workload " +
-			"traffic and ownership relationships instead of inspecting resources one by one. " +
+			"routing and ownership relationships instead of inspecting resources one by one. " +
 			"Use view=traffic for routing/connectivity questions and view=resources for " +
-			"ownership/deployment hierarchy. Always specify namespace unless you specifically " +
-			"need a cross-namespace graph. If you already know the suspicious root, use " +
-			"get_neighborhood for a smaller focused graph.",
+			"ownership/deployment hierarchy. NOTE: view=traffic is SPEC-DERIVED routing " +
+			"(Ingress→Service→Pod declarations) — it does not show observed traffic, " +
+			"request rates, or live connections. Always specify namespace unless you " +
+			"specifically need a cross-namespace graph. If you already know the suspicious " +
+			"root, use get_neighborhood for a smaller focused graph.",
 		Annotations: readOnly,
 	}, logToolCall("get_topology", handleGetTopology))
 
@@ -307,6 +309,14 @@ func registerTools(server *mcp.Server) {
 			"attached it. It lists recent spec/config changes that may explain failures " +
 			"not yet visible as runtime issues, or help distinguish creation-time " +
 			"baseline failures from the active incident. " +
+			"Single-namespace responses additionally correlate changes PER critical issue: " +
+			"`correlated_changes` lists recent spec/config changes on that issue's subject " +
+			"(and its referenced ConfigMaps); `no_recent_changes.windowSeconds` states the " +
+			"subject had NO tracked changes in that window — strong evidence the issue is " +
+			"chronic rather than change-driven. An issue with neither marker was not " +
+			"checked (see `correlation_truncated`) — never read absence as 'no changes'. " +
+			"ConfigMap change entries carry `consumed_by` (workloads that mount/reference " +
+			"them directly). " +
 			"For raw Kubernetes Warning events use get_events; for static best-practice / " +
 			"security-posture findings (runAsRoot, missing PDB, no probes, missing resource " +
 			"limits) use get_cluster_audit — a separate axis that must never be conflated (a " +
@@ -877,7 +887,7 @@ func handleGetResource(ctx context.Context, req *mcp.CallToolRequest, input getR
 	if group != "" && !k8s.TypedKindOwnsGroup(kind, group) {
 		u, dynErr := cache.GetDynamicWithGroup(ctx, kind, namespace, name, group)
 		if dynErr != nil {
-			return nil, nil, fmt.Errorf("resource not found: %w", dynErr)
+			return nil, nil, notFoundError(ctx, dynErr, kind, namespace, name)
 		}
 		resourceData = aicontext.MinifyUnstructured(u, aicontext.LevelDetail)
 		rawObj = u
@@ -886,12 +896,12 @@ func handleGetResource(ctx context.Context, req *mcp.CallToolRequest, input getR
 		if err == k8s.ErrUnknownKind {
 			u, dynErr := cache.GetDynamicWithGroup(ctx, kind, namespace, name, group)
 			if dynErr != nil {
-				return nil, nil, fmt.Errorf("resource not found: %w", dynErr)
+				return nil, nil, notFoundError(ctx, dynErr, kind, namespace, name)
 			}
 			resourceData = aicontext.MinifyUnstructured(u, aicontext.LevelDetail)
 			rawObj = u
 		} else if err != nil {
-			return nil, nil, fmt.Errorf("resource not found: %w", err)
+			return nil, nil, notFoundError(ctx, err, kind, namespace, name)
 		} else {
 			k8s.SetTypeMeta(obj)
 			minified, minErr := aicontext.Minify(obj, aicontext.LevelDetail)
@@ -901,6 +911,14 @@ func handleGetResource(ctx context.Context, req *mcp.CallToolRequest, input getR
 			resourceData = minified
 			rawObj = obj
 		}
+	}
+
+	// Large ConfigMaps are token bombs that make agents anchor on volume
+	// instead of signal — truncate oversized data values with an explicit
+	// note. Applied regardless of context mode.
+	var truncationNote string
+	if meaningfulchanges.ConfigMapKind(kind) {
+		resourceData, truncationNote = truncateLargeConfigMapData(resourceData)
 	}
 
 	// Build the resourceContext section unless the caller opted out. Basic
@@ -921,6 +939,9 @@ func handleGetResource(ctx context.Context, req *mcp.CallToolRequest, input getR
 		// Pending). Cheap — operates on the object we already fetched. Skipped
 		// for context=none so that mode stays a bare object for raw jq work.
 		warnings = k8score.EnrichRuntimeObjectWarnings(rawObj)
+	}
+	if truncationNote != "" {
+		warnings = append(warnings, truncationNote)
 	}
 
 	defaultConfigMapChanges := meaningfulchanges.ConfigMapKind(kind)
@@ -1256,6 +1277,15 @@ func handleGetTopology(ctx context.Context, req *mcp.CallToolRequest, input topo
 		return toJSONResult(buildTopologySummary(topo))
 	}
 
+	// Steering for oversized graph responses — reuses the topology Warnings
+	// channel so the response shape stays stable.
+	const topologyGraphNodeHintThreshold = 300
+	if len(topo.Nodes) > topologyGraphNodeHintThreshold {
+		topo.Warnings = append(topo.Warnings, fmt.Sprintf(
+			"large graph (%d nodes) — scope with namespace=, use format=summary, or get_neighborhood around a suspect root",
+			len(topo.Nodes),
+		))
+	}
 	return toJSONResult(topo)
 }
 
@@ -2473,6 +2503,13 @@ func handleIssuesTool(ctx context.Context, _ *mcp.CallToolRequest, input issuesI
 				resp.RecentChangesReason = recentChangesReason
 			}
 		}
+	}
+	// Per-issue change correlation (single-namespace responses): each
+	// critical issue carries either its correlated spec/config changes or an
+	// explicit no_recent_changes marker — deterministic per-subject evidence
+	// the global recent_changes list can't bind to individual issues.
+	if len(allowedNamespaces) == 1 {
+		attachIssueChangeCorrelation(ctx, &resp)
 	}
 	// Steering hint when the issue list was capped (MCP-only).
 	if stats.TotalMatched > len(out) {

--- a/internal/mcp/tools_audit.go
+++ b/internal/mcp/tools_audit.go
@@ -24,6 +24,7 @@ type auditToolResult struct {
 	Findings   []auditFinding `json:"findings"`
 	TotalCount int            `json:"totalCount"`
 	Truncated  bool           `json:"truncated,omitempty"`
+	NarrowHint string         `json:"narrowHint,omitempty"`
 }
 
 type auditSummary struct {
@@ -145,9 +146,14 @@ func handleGetAudit(ctx context.Context, req *mcp.CallToolRequest, input auditIn
 
 	totalCount := len(filtered)
 	truncated := false
+	narrowHint := ""
 	if len(filtered) > limit {
 		filtered = filtered[:limit]
 		truncated = true
+		narrowHint = fmt.Sprintf(
+			"returned %d of %d findings — narrow with namespace=, category=, severity=, or raise limit",
+			limit, totalCount,
+		)
 	}
 
 	return toJSONResult(auditToolResult{
@@ -160,6 +166,7 @@ func handleGetAudit(ctx context.Context, req *mcp.CallToolRequest, input auditIn
 		Findings:   filtered,
 		TotalCount: totalCount,
 		Truncated:  truncated,
+		NarrowHint: narrowHint,
 	})
 }
 

--- a/internal/mcp/tools_diagnose.go
+++ b/internal/mcp/tools_diagnose.go
@@ -190,7 +190,7 @@ func handleDiagnose(ctx context.Context, _ *mcp.CallToolRequest, input diagnoseI
 
 	obj, err := k8s.FetchResource(cache, kindNorm, input.Namespace, input.Name)
 	if err != nil {
-		return nil, nil, fmt.Errorf("resource not found: %w", err)
+		return nil, nil, notFoundError(ctx, err, kindNorm, input.Namespace, input.Name)
 	}
 	k8s.SetTypeMeta(obj)
 	gvk := obj.GetObjectKind().GroupVersionKind()
@@ -373,7 +373,7 @@ func handleGitOpsDiagnose(ctx context.Context, input diagnoseInput, canonicalKin
 		if errors.Is(err, k8s.ErrUnknownDynamicKind) {
 			return nil, nil, fmt.Errorf("%s (%s) is not installed or not yet discovered in this cluster — is %s running?", canonicalKind, group, tool)
 		}
-		return nil, nil, fmt.Errorf("resource not found: %w", err)
+		return nil, nil, notFoundError(ctx, err, canonicalKind, input.Namespace, input.Name)
 	}
 	minified, err := aicontext.Minify(u, aicontext.LevelDetail)
 	if err != nil {

--- a/internal/mcp/tools_diagnose.go
+++ b/internal/mcp/tools_diagnose.go
@@ -296,7 +296,7 @@ func handleDiagnose(ctx context.Context, _ *mcp.CallToolRequest, input diagnoseI
 			})
 		}
 	}
-	if changes, err := meaningfulchanges.RecentForWorkloadAndConfigMaps(ctx, obj, kindNorm, input.Namespace, input.Name, meaningfulchanges.DefaultSince, meaningfulchanges.ResourceLimit, meaningfulchanges.DefaultFieldLimit); err == nil && len(changes) > 0 {
+	if changes, _, err := meaningfulchanges.RecentForWorkloadAndConfigMaps(ctx, obj, kindNorm, input.Namespace, input.Name, meaningfulchanges.DefaultSince, meaningfulchanges.ResourceLimit, meaningfulchanges.DefaultFieldLimit); err == nil && len(changes) > 0 {
 		resp.RecentChanges = changes
 	}
 	resp.DNSContext = dnsContextForDiagnose(ctx, cache, obj, pods, resp.LogsCurrent, resp.LogsPrevious, resp.Events)

--- a/internal/mcp/tools_neighborhood.go
+++ b/internal/mcp/tools_neighborhood.go
@@ -145,6 +145,9 @@ func handleGetNeighborhood(ctx context.Context, req *mcp.CallToolRequest, input 
 		return nil, nil, fmt.Errorf("resource kind is ambiguous for %s/%s/%s; provide group", input.Kind, input.Namespace, input.Name)
 	}
 	if len(sub.Nodes) == 0 {
+		if s := notFoundSuggestion(ctx, input.Kind, input.Namespace, input.Name); s != "" {
+			return nil, nil, fmt.Errorf("resource not found in topology: %s/%s/%s — %s", input.Kind, input.Namespace, input.Name, s)
+		}
 		return nil, nil, fmt.Errorf("resource not found in topology: %s/%s/%s", input.Kind, input.Namespace, input.Name)
 	}
 

--- a/internal/mcp/tools_rbac.go
+++ b/internal/mcp/tools_rbac.go
@@ -41,6 +41,7 @@ type subjectPermissionsResult struct {
 	Truncated  bool                `json:"truncated,omitempty"`
 	UsedByPods []string            `json:"usedByPods,omitempty"` // "ns/name" pairs
 	PodsTotal  int                 `json:"podsTotal,omitempty"`  // >0 when usedByPods was truncated
+	NarrowHint string              `json:"narrowHint,omitempty"`
 }
 
 type mcpSubject struct {
@@ -133,6 +134,9 @@ func handleGetSubjectPermissions(ctx context.Context, _ *mcp.CallToolRequest, in
 		Bindings:  make([]mcpBindingLite, 0, len(er.ViaBindings)),
 		FlatRules: er.Flat,
 		Truncated: er.Truncated,
+	}
+	if er.Truncated {
+		result.NarrowHint = "rule list truncated — the subject has more rules than shown; do not treat this list as the subject's complete permissions"
 	}
 
 	for _, br := range er.ViaBindings {

--- a/internal/meaningfulchanges/meaningfulchanges.go
+++ b/internal/meaningfulchanges/meaningfulchanges.go
@@ -683,6 +683,10 @@ func canonicalKind(kind string) string {
 		return "HelmRepository"
 	case "cronjob", "cronjobs":
 		return "CronJob"
+	case "resourcequota", "resourcequotas", "quota", "quotas":
+		return "ResourceQuota"
+	case "limitrange", "limitranges", "limits":
+		return "LimitRange"
 	case "job", "jobs":
 		return "Job"
 	case "replicaset", "replicasets", "rs":

--- a/internal/meaningfulchanges/meaningfulchanges.go
+++ b/internal/meaningfulchanges/meaningfulchanges.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/skyhook-io/radar/internal/k8s"
 	"github.com/skyhook-io/radar/internal/timeline"
@@ -20,13 +20,13 @@ const (
 	DefaultSince      = time.Hour
 	DefaultLimit      = 20
 	DefaultFieldLimit = 10
-	IssueChangesLimit      = 5
+	IssueChangesLimit = 5
 	ResourceLimit     = 3
 	maxCandidateLimit = 100
 )
 
 const (
-	ChangesReasonNoCriticalIssues                           = "no_critical_issues"
+	ChangesReasonNoCriticalIssues             = "no_critical_issues"
 	ChangesReasonAllCriticalStartedAtCreation = "all_critical_issues_started_at_resource_creation"
 )
 
@@ -268,6 +268,7 @@ func queryLifecycleCandidates(ctx context.Context, store timeline.EventStore, q 
 	opts := timeline.QueryOptions{
 		Namespaces:       q.Namespaces,
 		Kinds:            compactKinds(kinds),
+		Names:            compactNames(q.Name),
 		Since:            time.Now().Add(-q.Since),
 		Sources:          []timeline.EventSource{timeline.SourceInformer},
 		EventTypes:       []timeline.EventType{timeline.EventTypeAdd, timeline.EventTypeDelete},
@@ -283,6 +284,7 @@ func queryCandidates(ctx context.Context, store timeline.EventStore, q Query, ki
 	opts := timeline.QueryOptions{
 		Namespaces: q.Namespaces,
 		Kinds:      compactKinds(kinds),
+		Names:      compactNames(q.Name),
 		Since:      time.Now().Add(-q.Since),
 		Sources:    []timeline.EventSource{timeline.SourceInformer},
 		// Changes are root-cause evidence for the CURRENT cluster — the
@@ -531,6 +533,14 @@ func compactKinds(kinds []string) []string {
 		out = append(out, kind)
 	}
 	return out
+}
+
+func compactNames(name string) []string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil
+	}
+	return []string{name}
 }
 
 // coalesceRecreatePairs drops delete events whose resource was subsequently

--- a/internal/meaningfulchanges/meaningfulchanges.go
+++ b/internal/meaningfulchanges/meaningfulchanges.go
@@ -54,9 +54,20 @@ type Query struct {
 }
 
 func Recent(ctx context.Context, q Query) ([]issuesapi.RecentChange, bool, error) {
+	changes, outputCapped, fetchSaturated, err := recent(ctx, q)
+	return changes, outputCapped || fetchSaturated, err
+}
+
+// recent returns ranked changes plus two distinct truncation signals:
+// outputCapped (more qualifying changes existed than the requested limit) and
+// fetchSaturated (a candidate query hit its cap, so the window may contain
+// older events the fetch never saw). Negative claims ("no recent changes")
+// must key on fetchSaturated alone — output capping still observes the full
+// window and ranks spec/config changes above the churn that gets dropped.
+func recent(ctx context.Context, q Query) ([]issuesapi.RecentChange, bool, bool, error) {
 	store := timeline.GetStore()
 	if store == nil {
-		return nil, false, fmt.Errorf("timeline store not initialized")
+		return nil, false, false, fmt.Errorf("timeline store not initialized")
 	}
 	q = normalizeQuery(q)
 
@@ -64,7 +75,7 @@ func Recent(ctx context.Context, q Query) ([]issuesapi.RecentChange, bool, error
 		queryLimit := candidateLimit(q.Limit, q.Name != "")
 		events, err := queryCandidates(ctx, store, q, q.Kinds, queryLimit)
 		if err != nil {
-			return nil, false, err
+			return nil, false, false, err
 		}
 		// Lifecycle events (add/delete) are fetched separately so a burst of
 		// update churn can't push them out of the newest-N candidate window
@@ -72,34 +83,40 @@ func Recent(ctx context.Context, q Query) ([]issuesapi.RecentChange, bool, error
 		// churn, but it can only rank what the fetch returns.
 		lifecycleEvents, err := queryLifecycleCandidates(ctx, store, q, q.Kinds)
 		if err != nil {
-			return nil, false, err
+			return nil, false, false, err
 		}
 		changes, capped, err := rankedChanges(coalesceRecreatePairs(dedupeEvents(append(events, lifecycleEvents...))), q.Name, q.Limit, q.FieldLimit)
-		return changes, capped || len(events) >= queryLimit, err
+		saturated := len(events) >= queryLimit || len(lifecycleEvents) >= lifecycleCandidateLimit
+		return changes, capped, saturated, err
 	}
 
 	perQueryLimit := candidateLimit(q.Limit, false)
 	configEvents, err := queryCandidates(ctx, store, q, configKinds, perQueryLimit)
 	if err != nil {
-		return nil, false, err
+		return nil, false, false, err
 	}
 	specEvents, err := queryCandidates(ctx, store, q, specKinds, perQueryLimit)
 	if err != nil {
-		return nil, false, err
+		return nil, false, false, err
 	}
 	lifecycleKinds := append(append([]string{}, configKinds...), specKinds...)
 	lifecycleKinds = append(lifecycleKinds, lifecycleOnlyKinds...)
 	lifecycleEvents, err := queryLifecycleCandidates(ctx, store, q, lifecycleKinds)
 	if err != nil {
-		return nil, false, err
+		return nil, false, false, err
 	}
 	merged := coalesceRecreatePairs(dedupeEvents(append(append(configEvents, specEvents...), lifecycleEvents...)))
 	changes, capped, err := rankedChanges(merged, "", q.Limit, q.FieldLimit)
-	return changes, capped || len(configEvents) >= perQueryLimit || len(specEvents) >= perQueryLimit, err
+	saturated := len(configEvents) >= perQueryLimit || len(specEvents) >= perQueryLimit || len(lifecycleEvents) >= lifecycleCandidateLimit
+	return changes, capped, saturated, err
 }
 
-func RecentForResource(ctx context.Context, kind, namespace, name string, since time.Duration, limit, fieldLimit int) ([]issuesapi.RecentChange, error) {
-	changes, _, err := Recent(ctx, Query{
+// RecentForResource returns the subject's ranked changes plus a saturation
+// flag: true when a candidate fetch hit its cap and the window may contain
+// changes the query never saw. Callers asserting "no recent changes" must
+// treat saturation as unknown, never as evidence of absence.
+func RecentForResource(ctx context.Context, kind, namespace, name string, since time.Duration, limit, fieldLimit int) ([]issuesapi.RecentChange, bool, error) {
+	changes, _, saturated, err := recent(ctx, Query{
 		Namespaces: []string{namespace},
 		Kinds:      []string{canonicalKind(kind)},
 		Name:       name,
@@ -107,27 +124,30 @@ func RecentForResource(ctx context.Context, kind, namespace, name string, since 
 		Limit:      limit,
 		FieldLimit: fieldLimit,
 	})
-	return changes, err
+	return changes, saturated, err
 }
 
-func RecentForWorkloadAndConfigMaps(ctx context.Context, obj any, kind, namespace, name string, since time.Duration, limit, fieldLimit int) ([]issuesapi.RecentChange, error) {
+func RecentForWorkloadAndConfigMaps(ctx context.Context, obj any, kind, namespace, name string, since time.Duration, limit, fieldLimit int) ([]issuesapi.RecentChange, bool, error) {
 	var all []issuesapi.RecentChange
+	saturated := false
 	if isWorkloadKind(kind) {
-		changes, err := RecentForResource(ctx, kind, namespace, name, since, limit, fieldLimit)
+		changes, sat, err := RecentForResource(ctx, kind, namespace, name, since, limit, fieldLimit)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
+		saturated = saturated || sat
 		all = append(all, changes...)
 	}
 	for _, cm := range DirectConfigMapNames(obj) {
-		changes, err := RecentForResource(ctx, "ConfigMap", namespace, cm, since, limit, fieldLimit)
+		changes, sat, err := RecentForResource(ctx, "ConfigMap", namespace, cm, since, limit, fieldLimit)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
+		saturated = saturated || sat
 		all = append(all, changes...)
 	}
 	RankAndCap(&all, limit)
-	return all, nil
+	return all, saturated, nil
 }
 
 func ShouldAttachIssueChanges(issues []issuesapi.Issue) bool {
@@ -443,14 +463,14 @@ func fromEvent(e timeline.TimelineEvent, fieldLimit int) issuesapi.RecentChange 
 	return change
 }
 
-func classify(e timeline.TimelineEvent) (string, string) {
+func classify(e timeline.TimelineEvent) (issuesapi.ChangeCategory, string) {
 	if e.Source != timeline.SourceInformer {
 		return "", ""
 	}
 	if e.EventType == timeline.EventTypeAdd || e.EventType == timeline.EventTypeDelete {
 		if isLifecycleOnlyKind(e.Kind) {
 			if e.EventType == timeline.EventTypeDelete {
-				return "lifecycle", "secret deleted (name only)"
+				return issuesapi.ChangeCategoryLifecycle, "secret deleted (name only)"
 			}
 			return "", ""
 		}
@@ -458,9 +478,9 @@ func classify(e timeline.TimelineEvent) (string, string) {
 			// A recreate-join add carries the diff against the object it
 			// replaced — that's a desired-state change, not mere lifecycle.
 			if e.EventType == timeline.EventTypeAdd && e.Reason == timeline.ReasonRecreated && e.Diff != nil && len(e.Diff.Fields) > 0 {
-				return "spec_config", "recreated with desired-state or configuration changes"
+				return issuesapi.ChangeCategorySpecConfig, "recreated with desired-state or configuration changes"
 			}
-			return "lifecycle", "resource create/delete for config or desired state"
+			return issuesapi.ChangeCategoryLifecycle, "resource create/delete for config or desired state"
 		}
 		return "", ""
 	}
@@ -468,10 +488,10 @@ func classify(e timeline.TimelineEvent) (string, string) {
 		return "", ""
 	}
 	if hasSpecConfigField(e) {
-		return "spec_config", "desired-state or configuration field changed"
+		return issuesapi.ChangeCategorySpecConfig, "desired-state or configuration field changed"
 	}
 	if hasRuntimeStatusField(e) {
-		return "runtime_status", "status field changed"
+		return issuesapi.ChangeCategoryRuntimeStatus, "status field changed"
 	}
 	return "", ""
 }
@@ -500,11 +520,11 @@ func hasRuntimeStatusField(e timeline.TimelineEvent) bool {
 
 func score(c issuesapi.RecentChange) int {
 	switch c.ChangeCategory {
-	case "spec_config":
+	case issuesapi.ChangeCategorySpecConfig:
 		return 100
-	case "lifecycle":
+	case issuesapi.ChangeCategoryLifecycle:
 		return 70
-	case "runtime_status":
+	case issuesapi.ChangeCategoryRuntimeStatus:
 		return 40
 	default:
 		return 0

--- a/internal/meaningfulchanges/meaningfulchanges.go
+++ b/internal/meaningfulchanges/meaningfulchanges.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -395,6 +396,24 @@ func consumersOfConfigMap(cache *k8s.ResourceCache, namespace, name string) []st
 			}
 		}
 	}
+	if lister := cache.Jobs(); lister != nil {
+		if items, err := lister.Jobs(namespace).List(labels.Everything()); err == nil {
+			for _, j := range items {
+				if referencesConfigMap(j) {
+					out = append(out, "Job/"+j.Name)
+				}
+			}
+		}
+	}
+	if lister := cache.CronJobs(); lister != nil {
+		if items, err := lister.CronJobs(namespace).List(labels.Everything()); err == nil {
+			for _, cj := range items {
+				if referencesConfigMap(cj) {
+					out = append(out, "CronJob/"+cj.Name)
+				}
+			}
+		}
+	}
 	sort.Strings(out)
 	if len(out) > maxConsumersPerEntry {
 		out = out[:maxConsumersPerEntry]
@@ -734,6 +753,10 @@ func podSpecForObject(obj any) (corev1.PodSpec, bool) {
 		return o.Spec.Template.Spec, true
 	case *appsv1.DaemonSet:
 		return o.Spec.Template.Spec, true
+	case *batchv1.Job:
+		return o.Spec.Template.Spec, true
+	case *batchv1.CronJob:
+		return o.Spec.JobTemplate.Spec.Template.Spec, true
 	default:
 		return corev1.PodSpec{}, false
 	}

--- a/internal/meaningfulchanges/meaningfulchanges.go
+++ b/internal/meaningfulchanges/meaningfulchanges.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/skyhook-io/radar/internal/k8s"
@@ -35,7 +36,12 @@ var (
 		"Deployment", "StatefulSet", "DaemonSet", "Service", "Ingress",
 		"HorizontalPodAutoscaler", "Application", "Kustomization", "HelmRelease",
 		"GitRepository", "OCIRepository", "HelmRepository",
+		"ResourceQuota", "LimitRange",
 	}
+	// lifecycleOnlyKinds surface ONLY their delete events (name-only — never
+	// data). A deleted Secret breaks every consumer with zero K8s symptom on
+	// the Secret itself; its updates stay out of the feed entirely.
+	lifecycleOnlyKinds = []string{"Secret"}
 )
 
 type Query struct {
@@ -60,7 +66,15 @@ func Recent(ctx context.Context, q Query) ([]issuesapi.RecentChange, bool, error
 		if err != nil {
 			return nil, false, err
 		}
-		changes, capped, err := rankedChanges(events, q.Name, q.Limit, q.FieldLimit)
+		// Lifecycle events (add/delete) are fetched separately so a burst of
+		// update churn can't push them out of the newest-N candidate window
+		// before ranking ever sees them. Ranking scores deletes above status
+		// churn, but it can only rank what the fetch returns.
+		lifecycleEvents, err := queryLifecycleCandidates(ctx, store, q, q.Kinds)
+		if err != nil {
+			return nil, false, err
+		}
+		changes, capped, err := rankedChanges(coalesceRecreatePairs(dedupeEvents(append(events, lifecycleEvents...))), q.Name, q.Limit, q.FieldLimit)
 		return changes, capped || len(events) >= queryLimit, err
 	}
 
@@ -73,7 +87,14 @@ func Recent(ctx context.Context, q Query) ([]issuesapi.RecentChange, bool, error
 	if err != nil {
 		return nil, false, err
 	}
-	changes, capped, err := rankedChanges(dedupeEvents(append(configEvents, specEvents...)), "", q.Limit, q.FieldLimit)
+	lifecycleKinds := append(append([]string{}, configKinds...), specKinds...)
+	lifecycleKinds = append(lifecycleKinds, lifecycleOnlyKinds...)
+	lifecycleEvents, err := queryLifecycleCandidates(ctx, store, q, lifecycleKinds)
+	if err != nil {
+		return nil, false, err
+	}
+	merged := coalesceRecreatePairs(dedupeEvents(append(append(configEvents, specEvents...), lifecycleEvents...)))
+	changes, capped, err := rankedChanges(merged, "", q.Limit, q.FieldLimit)
 	return changes, capped || len(configEvents) >= perQueryLimit || len(specEvents) >= perQueryLimit, err
 }
 
@@ -236,6 +257,28 @@ func candidateLimit(finalLimit int, nameFiltered bool) int {
 	return limit
 }
 
+// lifecycleCandidateLimit bounds the dedicated add/delete query. Lifecycle
+// events are rare relative to updates, so a modest window covers the lookback
+// without re-importing the churn the separate query exists to escape.
+const lifecycleCandidateLimit = 50
+
+// queryLifecycleCandidates fetches add/delete events for the given kinds in a
+// query of their own, immune to crowding by update events.
+func queryLifecycleCandidates(ctx context.Context, store timeline.EventStore, q Query, kinds []string) ([]timeline.TimelineEvent, error) {
+	opts := timeline.QueryOptions{
+		Namespaces:       q.Namespaces,
+		Kinds:            compactKinds(kinds),
+		Since:            time.Now().Add(-q.Since),
+		Sources:          []timeline.EventSource{timeline.SourceInformer},
+		EventTypes:       []timeline.EventType{timeline.EventTypeAdd, timeline.EventTypeDelete},
+		ClusterContext:   k8s.ActiveClusterContext(),
+		Limit:            lifecycleCandidateLimit,
+		IncludeManaged:   false,
+		IncludeK8sEvents: false,
+	}
+	return store.Query(ctx, opts)
+}
+
 func queryCandidates(ctx context.Context, store timeline.EventStore, q Query, kinds []string, limit int) ([]timeline.TimelineEvent, error) {
 	opts := timeline.QueryOptions{
 		Namespaces: q.Namespaces,
@@ -267,7 +310,83 @@ func rankedChanges(events []timeline.TimelineEvent, name string, limit, fieldLim
 	}
 	capped := len(out) > limit
 	RankAndCap(&out, limit)
+	annotateConfigMapConsumers(out)
 	return out, capped, nil
+}
+
+// maxConsumersPerEntry bounds the consumed_by list on a ConfigMap entry.
+const maxConsumersPerEntry = 5
+
+// annotateConfigMapConsumers fills ConsumedBy on ConfigMap change entries by
+// scanning the cached workload listers for direct spec references (volumes,
+// envFrom, env valueFrom). Runs after ranking/capping, so at most one feed's
+// worth of entries triggers the scan. Direct references only: a workload that
+// reads this ConfigMap's data through an intermediary service is invisible
+// here, and ConsumedBy deliberately makes no claim about it.
+func annotateConfigMapConsumers(changes []issuesapi.RecentChange) {
+	cache := k8s.GetResourceCache()
+	if cache == nil {
+		return
+	}
+	for i := range changes {
+		if changes[i].Kind != "ConfigMap" || changes[i].Namespace == "" {
+			continue
+		}
+		changes[i].ConsumedBy = consumersOfConfigMap(cache, changes[i].Namespace, changes[i].Name)
+	}
+}
+
+func consumersOfConfigMap(cache *k8s.ResourceCache, namespace, name string) []string {
+	var out []string
+	referencesConfigMap := func(obj any) bool {
+		for _, cm := range DirectConfigMapNames(obj) {
+			if cm == name {
+				return true
+			}
+		}
+		return false
+	}
+	if lister := cache.Deployments(); lister != nil {
+		if items, err := lister.Deployments(namespace).List(labels.Everything()); err == nil {
+			for _, d := range items {
+				if referencesConfigMap(d) {
+					out = append(out, "Deployment/"+d.Name)
+				}
+			}
+		}
+	}
+	if lister := cache.StatefulSets(); lister != nil {
+		if items, err := lister.StatefulSets(namespace).List(labels.Everything()); err == nil {
+			for _, s := range items {
+				if referencesConfigMap(s) {
+					out = append(out, "StatefulSet/"+s.Name)
+				}
+			}
+		}
+	}
+	if lister := cache.DaemonSets(); lister != nil {
+		if items, err := lister.DaemonSets(namespace).List(labels.Everything()); err == nil {
+			for _, d := range items {
+				if referencesConfigMap(d) {
+					out = append(out, "DaemonSet/"+d.Name)
+				}
+			}
+		}
+	}
+	sort.Strings(out)
+	if len(out) > maxConsumersPerEntry {
+		out = out[:maxConsumersPerEntry]
+	}
+	return out
+}
+
+// TrackedKind reports whether the change feed tracks this kind's updates —
+// the gate for emitting per-issue "no recent changes" claims: asserting "no
+// changes" for a kind whose changes are never recorded would be a false
+// statement, not evidence.
+func TrackedKind(kind string) bool {
+	kind = canonicalKind(kind)
+	return isConfigKind(kind) || isSpecKind(kind)
 }
 
 func RankAndCap(changes *[]issuesapi.RecentChange, limit int) {
@@ -327,7 +446,18 @@ func classify(e timeline.TimelineEvent) (string, string) {
 		return "", ""
 	}
 	if e.EventType == timeline.EventTypeAdd || e.EventType == timeline.EventTypeDelete {
+		if isLifecycleOnlyKind(e.Kind) {
+			if e.EventType == timeline.EventTypeDelete {
+				return "lifecycle", "secret deleted (name only)"
+			}
+			return "", ""
+		}
 		if isConfigKind(e.Kind) || isSpecKind(e.Kind) {
+			// A recreate-join add carries the diff against the object it
+			// replaced — that's a desired-state change, not mere lifecycle.
+			if e.EventType == timeline.EventTypeAdd && e.Reason == timeline.ReasonRecreated && e.Diff != nil && len(e.Diff.Fields) > 0 {
+				return "spec_config", "recreated with desired-state or configuration changes"
+			}
 			return "lifecycle", "resource create/delete for config or desired state"
 		}
 		return "", ""
@@ -403,6 +533,39 @@ func compactKinds(kinds []string) []string {
 	return out
 }
 
+// coalesceRecreatePairs drops delete events whose resource was subsequently
+// recreated (a newer add event marked ReasonRecreated, which carries the diff
+// across the recreate). The synthesized add tells the whole story; keeping
+// the paired delete would present one change as two entries. True deletions —
+// no recreate add after them — always survive.
+func coalesceRecreatePairs(events []timeline.TimelineEvent) []timeline.TimelineEvent {
+	var recreates map[string]time.Time
+	for _, e := range events {
+		if e.EventType == timeline.EventTypeAdd && e.Reason == timeline.ReasonRecreated {
+			if recreates == nil {
+				recreates = map[string]time.Time{}
+			}
+			key := e.Kind + "/" + e.Namespace + "/" + e.Name
+			if ts, ok := recreates[key]; !ok || e.Timestamp.After(ts) {
+				recreates[key] = e.Timestamp
+			}
+		}
+	}
+	if recreates == nil {
+		return events
+	}
+	out := make([]timeline.TimelineEvent, 0, len(events))
+	for _, e := range events {
+		if e.EventType == timeline.EventTypeDelete {
+			if ts, ok := recreates[e.Kind+"/"+e.Namespace+"/"+e.Name]; ok && !e.Timestamp.After(ts) {
+				continue
+			}
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
 func dedupeEvents(events []timeline.TimelineEvent) []timeline.TimelineEvent {
 	seen := map[string]bool{}
 	out := make([]timeline.TimelineEvent, 0, len(events))
@@ -421,6 +584,15 @@ func dedupeEvents(events []timeline.TimelineEvent) []timeline.TimelineEvent {
 }
 
 func isConfigKind(kind string) bool { return kind == "ConfigMap" }
+
+func isLifecycleOnlyKind(kind string) bool {
+	for _, item := range lifecycleOnlyKinds {
+		if kind == item {
+			return true
+		}
+	}
+	return false
+}
 
 func isSpecKind(kind string) bool {
 	for _, item := range specKinds {

--- a/internal/meaningfulchanges/meaningfulchanges_test.go
+++ b/internal/meaningfulchanges/meaningfulchanges_test.go
@@ -3,6 +3,7 @@ package meaningfulchanges
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -359,6 +360,29 @@ func TestRecentCoalescesRecreatePairs(t *testing.T) {
 	}
 	if !recreate || !finalDelete || !trueDelete {
 		t.Fatalf("missing entries: recreate=%v finalDelete=%v trueDelete=%v in %+v", recreate, finalDelete, trueDelete, changes)
+	}
+}
+
+// The static canonicalKind fallback (cold start, partial discovery) must
+// cover every feed kind: a miss best-effort-capitalizes lowercase input
+// ("resourcequota" → "Resourcequota") which silently matches no timeline
+// events.
+func TestCanonicalKindCoversFeedKinds(t *testing.T) {
+	for _, kind := range append(append([]string{}, configKinds...), specKinds...) {
+		if got := canonicalKind(strings.ToLower(kind)); got != kind {
+			t.Errorf("canonicalKind(%q) = %q, want %q", strings.ToLower(kind), got, kind)
+		}
+	}
+	// kubectl shortnames and plurals for the kinds most recently added.
+	for in, want := range map[string]string{
+		"resourcequotas": "ResourceQuota",
+		"quota":          "ResourceQuota",
+		"limitranges":    "LimitRange",
+		"limits":         "LimitRange",
+	} {
+		if got := canonicalKind(in); got != want {
+			t.Errorf("canonicalKind(%q) = %q, want %q", in, got, want)
+		}
 	}
 }
 

--- a/internal/meaningfulchanges/meaningfulchanges_test.go
+++ b/internal/meaningfulchanges/meaningfulchanges_test.go
@@ -2,8 +2,14 @@ package meaningfulchanges
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/skyhook-io/radar/internal/k8s"
 	"github.com/skyhook-io/radar/internal/timeline"
@@ -111,6 +117,143 @@ func TestRecentRanksSpecConfigAboveStatusChurn(t *testing.T) {
 	}
 }
 
+// A Service delete followed by a burst of status-churn updates must still
+// surface: lifecycle events are fetched in a query of their own, so the
+// newest-N candidate window for updates cannot starve them out before
+// ranking. Repro shape: user-service delete + 81 Deployment updates
+// (missing_service, batch5).
+func TestRecentLifecycleEventSurvivesUpdateChurn(t *testing.T) {
+	timeline.ResetStore()
+	t.Cleanup(timeline.ResetStore)
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 1000}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+	store := timeline.GetStore()
+	now := time.Now()
+
+	if err := store.Append(context.Background(), timeline.TimelineEvent{
+		ID:             "svc-delete",
+		Timestamp:      now.Add(-10 * time.Minute),
+		Source:         timeline.SourceInformer,
+		ClusterContext: k8s.ActiveClusterContext(),
+		Kind:           "Service",
+		Namespace:      "shop",
+		Name:           "user-service",
+		EventType:      timeline.EventTypeDelete,
+	}); err != nil {
+		t.Fatalf("append delete: %v", err)
+	}
+	// 120 newer status-churn updates — more than the candidate window
+	// (candidateLimit(20) = 80), so the delete cannot survive a single
+	// newest-first fetch.
+	for i := 0; i < 120; i++ {
+		if err := store.Append(context.Background(), timeline.TimelineEvent{
+			ID:             fmt.Sprintf("churn-%d", i),
+			Timestamp:      now.Add(-time.Duration(120-i) * time.Second),
+			Source:         timeline.SourceInformer,
+			ClusterContext: k8s.ActiveClusterContext(),
+			Kind:           "Deployment",
+			Namespace:      "shop",
+			Name:           fmt.Sprintf("web-%d", i%10),
+			EventType:      timeline.EventTypeUpdate,
+			Diff:           &timeline.DiffInfo{Fields: []timeline.FieldChange{{Path: "status.readyReplicas", OldValue: int32(1), NewValue: int32(0)}}, Summary: "ready: 1→0"},
+		}); err != nil {
+			t.Fatalf("append churn %d: %v", i, err)
+		}
+	}
+
+	changes, _, err := Recent(context.Background(), Query{Namespaces: []string{"shop"}})
+	if err != nil {
+		t.Fatalf("Recent: %v", err)
+	}
+	found := false
+	for _, c := range changes {
+		if c.Kind == "Service" && c.Name == "user-service" && c.ChangeType == "delete" {
+			found = true
+			if c.ChangeCategory != "lifecycle" {
+				t.Fatalf("delete category = %q, want lifecycle", c.ChangeCategory)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("Service delete starved out of ranked changes; got %d changes, first: %+v", len(changes), changes[0])
+	}
+	// The delete (lifecycle, 70) must also outrank the churn (runtime_status, 40).
+	if changes[0].ChangeType != "delete" {
+		t.Fatalf("first change = %+v, want the Service delete ranked first", changes[0])
+	}
+}
+
+// A recreate (delete + ReasonRecreated add carrying the cross-recreate diff)
+// must surface as exactly ONE entry — the diff-bearing add, classified
+// spec_config — with the paired delete coalesced away. Entry count strictly
+// reduced is the acceptance criterion.
+func TestRecentCoalescesRecreatePairs(t *testing.T) {
+	timeline.ResetStore()
+	t.Cleanup(timeline.ResetStore)
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 100}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+	store := timeline.GetStore()
+	now := time.Now()
+
+	if err := store.Append(context.Background(), timeline.TimelineEvent{
+		ID: "dep-delete", Timestamp: now.Add(-10 * time.Second),
+		Source: timeline.SourceInformer, ClusterContext: k8s.ActiveClusterContext(),
+		Kind: "Deployment", Namespace: "shop", Name: "profile",
+		EventType: timeline.EventTypeDelete,
+	}); err != nil {
+		t.Fatalf("append delete: %v", err)
+	}
+	if err := store.Append(context.Background(), timeline.TimelineEvent{
+		ID: "dep-recreate", Timestamp: now.Add(-8 * time.Second),
+		Source: timeline.SourceInformer, ClusterContext: k8s.ActiveClusterContext(),
+		Kind: "Deployment", Namespace: "shop", Name: "profile",
+		EventType: timeline.EventTypeAdd, Reason: timeline.ReasonRecreated,
+		Diff: &timeline.DiffInfo{
+			Fields:  []timeline.FieldChange{{Path: "spec.template.spec.containers(profile).command", OldValue: "[profile]", NewValue: "[geo]"}},
+			Summary: "recreated with changes: command(profile) changed",
+		},
+	}); err != nil {
+		t.Fatalf("append recreate add: %v", err)
+	}
+	// A true delete with no recreate must survive coalescing.
+	if err := store.Append(context.Background(), timeline.TimelineEvent{
+		ID: "svc-true-delete", Timestamp: now.Add(-5 * time.Second),
+		Source: timeline.SourceInformer, ClusterContext: k8s.ActiveClusterContext(),
+		Kind: "Service", Namespace: "shop", Name: "user-service",
+		EventType: timeline.EventTypeDelete,
+	}); err != nil {
+		t.Fatalf("append true delete: %v", err)
+	}
+
+	changes, _, err := Recent(context.Background(), Query{Namespaces: []string{"shop"}})
+	if err != nil {
+		t.Fatalf("Recent: %v", err)
+	}
+	if len(changes) != 2 {
+		t.Fatalf("changes = %d entries %+v, want exactly 2 (recreate add + true delete)", len(changes), changes)
+	}
+	var recreate, trueDelete bool
+	for _, c := range changes {
+		if c.Name == "profile" {
+			if c.ChangeType != "add" {
+				t.Fatalf("profile entry = %+v, want the add (delete coalesced)", c)
+			}
+			if c.ChangeCategory != "spec_config" {
+				t.Fatalf("recreate add category = %q, want spec_config", c.ChangeCategory)
+			}
+			recreate = true
+		}
+		if c.Name == "user-service" && c.ChangeType == "delete" {
+			trueDelete = true
+		}
+	}
+	if !recreate || !trueDelete {
+		t.Fatalf("missing entries: recreate=%v trueDelete=%v in %+v", recreate, trueDelete, changes)
+	}
+}
+
 // The persistent timeline outlives context switches; Recent must never serve
 // another cluster's events as this cluster's changes.
 func TestRecentExcludesOtherClusterEvents(t *testing.T) {
@@ -135,5 +278,93 @@ func TestRecentExcludesOtherClusterEvents(t *testing.T) {
 	}
 	if len(changes) != 0 {
 		t.Fatalf("another cluster's events leaked into Recent: %+v", changes)
+	}
+}
+
+// Secret deletes surface (name-only); Secret adds and updates never do.
+func TestRecentSecretDeleteOnly(t *testing.T) {
+	timeline.ResetStore()
+	t.Cleanup(timeline.ResetStore)
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 100}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+	store := timeline.GetStore()
+	now := time.Now()
+
+	for _, e := range []timeline.TimelineEvent{
+		{ID: "sec-add", Timestamp: now.Add(-30 * time.Second), EventType: timeline.EventTypeAdd},
+		{ID: "sec-del", Timestamp: now.Add(-10 * time.Second), EventType: timeline.EventTypeDelete},
+	} {
+		e.Source = timeline.SourceInformer
+		e.ClusterContext = k8s.ActiveClusterContext()
+		e.Kind, e.Namespace, e.Name = "Secret", "shop", "db-credentials"
+		if err := store.Append(context.Background(), e); err != nil {
+			t.Fatalf("append %s: %v", e.ID, err)
+		}
+	}
+
+	changes, _, err := Recent(context.Background(), Query{Namespaces: []string{"shop"}})
+	if err != nil {
+		t.Fatalf("Recent: %v", err)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("changes = %+v, want exactly the Secret delete", changes)
+	}
+	c := changes[0]
+	if c.Kind != "Secret" || c.ChangeType != "delete" || c.ChangeCategory != "lifecycle" {
+		t.Fatalf("unexpected entry: %+v", c)
+	}
+	if len(c.Fields) != 0 {
+		t.Fatalf("secret delete must be name-only, got fields: %+v", c.Fields)
+	}
+}
+
+// ConfigMap change entries name the workloads that directly mount/reference
+// them — binding the config change to its consumer without a topology call.
+func TestRecentAnnotatesConfigMapConsumers(t *testing.T) {
+	client := fake.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "flagd", Namespace: "shop"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{{
+					Name: "config",
+					VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "flagd-config"},
+					}},
+				}},
+				Containers: []corev1.Container{{Name: "flagd", Image: "flagd:v1"}},
+			}},
+		},
+	})
+	if err := k8s.InitTestResourceCache(client); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	t.Cleanup(k8s.ResetTestState)
+
+	timeline.ResetStore()
+	t.Cleanup(timeline.ResetStore)
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 100}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+	if err := timeline.GetStore().Append(context.Background(), timeline.TimelineEvent{
+		ID: "cm-change", Timestamp: time.Now().Add(-time.Minute),
+		Source: timeline.SourceInformer, ClusterContext: k8s.ActiveClusterContext(),
+		Kind: "ConfigMap", Namespace: "shop", Name: "flagd-config",
+		EventType: timeline.EventTypeUpdate,
+		Diff:      &timeline.DiffInfo{Fields: []timeline.FieldChange{{Path: "data.flags.adHighCpu.defaultVariant", OldValue: "off", NewValue: "on"}}, Summary: "flag changed"},
+	}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	changes, _, err := Recent(context.Background(), Query{Namespaces: []string{"shop"}})
+	if err != nil {
+		t.Fatalf("Recent: %v", err)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("changes = %+v, want 1", changes)
+	}
+	got := changes[0].ConsumedBy
+	if len(got) != 1 || got[0] != "Deployment/flagd" {
+		t.Fatalf("consumed_by = %v, want [Deployment/flagd]", got)
 	}
 }

--- a/internal/meaningfulchanges/meaningfulchanges_test.go
+++ b/internal/meaningfulchanges/meaningfulchanges_test.go
@@ -184,6 +184,62 @@ func TestRecentLifecycleEventSurvivesUpdateChurn(t *testing.T) {
 	}
 }
 
+// Per-resource lookups must apply the resource name before store limits are
+// applied. Otherwise a busy namespace with many newer lifecycle events for the
+// same kind can hide this resource's delete and make per-issue correlation emit
+// a false no_recent_changes marker.
+func TestRecentForResourceLifecycleEventSurvivesLifecycleChurn(t *testing.T) {
+	timeline.ResetStore()
+	t.Cleanup(timeline.ResetStore)
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 1000}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+	store := timeline.GetStore()
+	now := time.Now()
+
+	if err := store.Append(context.Background(), timeline.TimelineEvent{
+		ID:             "target-delete",
+		Timestamp:      now.Add(-10 * time.Minute),
+		Source:         timeline.SourceInformer,
+		ClusterContext: k8s.ActiveClusterContext(),
+		Kind:           "Service",
+		Namespace:      "shop",
+		Name:           "user-service",
+		EventType:      timeline.EventTypeDelete,
+	}); err != nil {
+		t.Fatalf("append target delete: %v", err)
+	}
+
+	// More than both candidate caps for a named query (100) and lifecycle query
+	// (50). Without a store-level name filter, the target delete is not fetched
+	// and RecentForResource returns no changes.
+	for i := 0; i < 120; i++ {
+		if err := store.Append(context.Background(), timeline.TimelineEvent{
+			ID:             fmt.Sprintf("other-delete-%d", i),
+			Timestamp:      now.Add(-time.Duration(120-i) * time.Second),
+			Source:         timeline.SourceInformer,
+			ClusterContext: k8s.ActiveClusterContext(),
+			Kind:           "Service",
+			Namespace:      "shop",
+			Name:           fmt.Sprintf("other-service-%d", i),
+			EventType:      timeline.EventTypeDelete,
+		}); err != nil {
+			t.Fatalf("append lifecycle churn %d: %v", i, err)
+		}
+	}
+
+	changes, err := RecentForResource(context.Background(), "Service", "shop", "user-service", time.Hour, ResourceLimit, DefaultFieldLimit)
+	if err != nil {
+		t.Fatalf("RecentForResource: %v", err)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("changes = %+v, want exactly the target delete", changes)
+	}
+	if c := changes[0]; c.Kind != "Service" || c.Name != "user-service" || c.ChangeType != "delete" {
+		t.Fatalf("unexpected change: %+v", c)
+	}
+}
+
 // A recreate (delete + ReasonRecreated add carrying the cross-recreate diff)
 // must surface as exactly ONE entry — the diff-bearing add, classified
 // spec_config — with the paired delete coalesced away. Entry count strictly

--- a/internal/meaningfulchanges/meaningfulchanges_test.go
+++ b/internal/meaningfulchanges/meaningfulchanges_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -464,21 +465,37 @@ func TestRecentSecretDeleteOnly(t *testing.T) {
 
 // ConfigMap change entries name the workloads that directly mount/reference
 // them — binding the config change to its consumer without a topology call.
+// Jobs and CronJobs count: a migration/load-gen Job is often the only
+// consumer of a config-script ConfigMap.
 func TestRecentAnnotatesConfigMapConsumers(t *testing.T) {
-	client := fake.NewSimpleClientset(&appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{Name: "flagd", Namespace: "shop"},
-		Spec: appsv1.DeploymentSpec{
-			Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
-				Volumes: []corev1.Volume{{
-					Name: "config",
-					VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{Name: "flagd-config"},
+	client := fake.NewSimpleClientset(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "flagd", Namespace: "shop"},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{{
+						Name: "config",
+						VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "flagd-config"},
+						}},
+					}},
+					Containers: []corev1.Container{{Name: "flagd", Image: "flagd:v1"}},
+				}},
+			},
+		},
+		&batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "seed", Namespace: "shop"},
+			Spec: batchv1.JobSpec{
+				Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:    "seed",
+						Image:   "seed:v1",
+						EnvFrom: []corev1.EnvFromSource{{ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "flagd-config"}}}},
 					}},
 				}},
-				Containers: []corev1.Container{{Name: "flagd", Image: "flagd:v1"}},
-			}},
+			},
 		},
-	})
+	)
 	if err := k8s.InitTestResourceCache(client); err != nil {
 		t.Fatalf("InitTestResourceCache: %v", err)
 	}
@@ -507,7 +524,7 @@ func TestRecentAnnotatesConfigMapConsumers(t *testing.T) {
 		t.Fatalf("changes = %+v, want 1", changes)
 	}
 	got := changes[0].ConsumedBy
-	if len(got) != 1 || got[0] != "Deployment/flagd" {
-		t.Fatalf("consumed_by = %v, want [Deployment/flagd]", got)
+	if len(got) != 2 || got[0] != "Deployment/flagd" || got[1] != "Job/seed" {
+		t.Fatalf("consumed_by = %v, want [Deployment/flagd Job/seed]", got)
 	}
 }

--- a/internal/meaningfulchanges/meaningfulchanges_test.go
+++ b/internal/meaningfulchanges/meaningfulchanges_test.go
@@ -120,8 +120,7 @@ func TestRecentRanksSpecConfigAboveStatusChurn(t *testing.T) {
 // A Service delete followed by a burst of status-churn updates must still
 // surface: lifecycle events are fetched in a query of their own, so the
 // newest-N candidate window for updates cannot starve them out before
-// ranking. Repro shape: user-service delete + 81 Deployment updates
-// (missing_service, batch5).
+// ranking.
 func TestRecentLifecycleEventSurvivesUpdateChurn(t *testing.T) {
 	timeline.ResetStore()
 	t.Cleanup(timeline.ResetStore)
@@ -228,7 +227,7 @@ func TestRecentForResourceLifecycleEventSurvivesLifecycleChurn(t *testing.T) {
 		}
 	}
 
-	changes, err := RecentForResource(context.Background(), "Service", "shop", "user-service", time.Hour, ResourceLimit, DefaultFieldLimit)
+	changes, saturated, err := RecentForResource(context.Background(), "Service", "shop", "user-service", time.Hour, ResourceLimit, DefaultFieldLimit)
 	if err != nil {
 		t.Fatalf("RecentForResource: %v", err)
 	}
@@ -237,6 +236,49 @@ func TestRecentForResourceLifecycleEventSurvivesLifecycleChurn(t *testing.T) {
 	}
 	if c := changes[0]; c.Kind != "Service" || c.Name != "user-service" || c.ChangeType != "delete" {
 		t.Fatalf("unexpected change: %+v", c)
+	}
+	// The name filter applies at the store, so the churn never counts against
+	// this subject's candidate caps.
+	if saturated {
+		t.Fatal("other resources' churn must not saturate a named lookup")
+	}
+}
+
+// When the subject itself produces more events than the candidate cap, the
+// fetch may have missed older changes in the window — RecentForResource must
+// report saturation so callers never turn "saw nothing" into "nothing
+// happened".
+func TestRecentForResourceReportsSaturation(t *testing.T) {
+	timeline.ResetStore()
+	t.Cleanup(timeline.ResetStore)
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 1000}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+	store := timeline.GetStore()
+	now := time.Now()
+
+	for i := 0; i < maxCandidateLimit; i++ {
+		if err := store.Append(context.Background(), timeline.TimelineEvent{
+			ID:             fmt.Sprintf("self-churn-%d", i),
+			Timestamp:      now.Add(-time.Duration(i) * time.Second),
+			Source:         timeline.SourceInformer,
+			ClusterContext: k8s.ActiveClusterContext(),
+			Kind:           "Deployment",
+			Namespace:      "shop",
+			Name:           "web",
+			EventType:      timeline.EventTypeUpdate,
+			Diff:           &timeline.DiffInfo{Fields: []timeline.FieldChange{{Path: "status.readyReplicas", OldValue: int32(1), NewValue: int32(0)}}, Summary: "ready: 1→0"},
+		}); err != nil {
+			t.Fatalf("append churn %d: %v", i, err)
+		}
+	}
+
+	_, saturated, err := RecentForResource(context.Background(), "Deployment", "shop", "web", time.Hour, ResourceLimit, DefaultFieldLimit)
+	if err != nil {
+		t.Fatalf("RecentForResource: %v", err)
+	}
+	if !saturated {
+		t.Fatal("a candidate fetch at its cap must report saturation")
 	}
 }
 
@@ -282,31 +324,52 @@ func TestRecentCoalescesRecreatePairs(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("append true delete: %v", err)
 	}
+	// A final delete AFTER the recreate must also survive — only the delete
+	// paired with (i.e. preceding) the recreate add is folded away.
+	if err := store.Append(context.Background(), timeline.TimelineEvent{
+		ID: "dep-final-delete", Timestamp: now.Add(-3 * time.Second),
+		Source: timeline.SourceInformer, ClusterContext: k8s.ActiveClusterContext(),
+		Kind: "Deployment", Namespace: "shop", Name: "profile",
+		EventType: timeline.EventTypeDelete,
+	}); err != nil {
+		t.Fatalf("append final delete: %v", err)
+	}
 
 	changes, _, err := Recent(context.Background(), Query{Namespaces: []string{"shop"}})
 	if err != nil {
 		t.Fatalf("Recent: %v", err)
 	}
-	if len(changes) != 2 {
-		t.Fatalf("changes = %d entries %+v, want exactly 2 (recreate add + true delete)", len(changes), changes)
+	if len(changes) != 3 {
+		t.Fatalf("changes = %d entries %+v, want exactly 3 (recreate add + final delete + true delete)", len(changes), changes)
 	}
-	var recreate, trueDelete bool
+	var recreate, finalDelete, trueDelete bool
 	for _, c := range changes {
-		if c.Name == "profile" {
-			if c.ChangeType != "add" {
-				t.Fatalf("profile entry = %+v, want the add (delete coalesced)", c)
-			}
+		if c.Name == "profile" && c.ChangeType == "add" {
 			if c.ChangeCategory != "spec_config" {
 				t.Fatalf("recreate add category = %q, want spec_config", c.ChangeCategory)
 			}
 			recreate = true
 		}
+		if c.Name == "profile" && c.ChangeType == "delete" {
+			finalDelete = true
+		}
 		if c.Name == "user-service" && c.ChangeType == "delete" {
 			trueDelete = true
 		}
 	}
-	if !recreate || !trueDelete {
-		t.Fatalf("missing entries: recreate=%v trueDelete=%v in %+v", recreate, trueDelete, changes)
+	if !recreate || !finalDelete || !trueDelete {
+		t.Fatalf("missing entries: recreate=%v finalDelete=%v trueDelete=%v in %+v", recreate, finalDelete, trueDelete, changes)
+	}
+}
+
+// Every kind the change feed tracks must participate in recreate-join —
+// otherwise a delete+recreate of that kind surfaces as a contentless
+// delete+add pair instead of one diff-bearing change.
+func TestFeedKindsHaveRecreateJoin(t *testing.T) {
+	for _, kind := range append(append([]string{}, configKinds...), specKinds...) {
+		if !k8s.RecreateJoinKind(kind) {
+			t.Errorf("feed kind %s missing from the recreate stash", kind)
+		}
 	}
 }
 

--- a/internal/server/issues_handler.go
+++ b/internal/server/issues_handler.go
@@ -93,8 +93,8 @@ func (s *Server) handleIssues(w http.ResponseWriter, r *http.Request) {
 	}
 
 	out, stats := issues.ComposeWithStats(provider, filters)
-	// Shared response shape (issues.ListResponse) so /api/issues and the MCP
-	// issues tool can't drift; the hub mirrors one shape.
+	// Shared base response shape (issues.ListResponse); surfaces add their
+	// own enrichments after this point.
 	resp := issues.NewListResponse(out, stats)
 	resp.ClusterContext = provider.ClusterContextForIssues(namespaces, func(group, resource string) bool {
 		return s.canRead(r, group, resource, "kube-system", "list")

--- a/internal/timeline/manager.go
+++ b/internal/timeline/manager.go
@@ -161,8 +161,28 @@ func InitStore(cfg StoreConfig) error {
 			globalStore = NewMemoryStore(maxSize)
 			log.Printf("Initialized in-memory event store (max %d events)", maxSize)
 		}
+		observationStart = time.Now()
 	})
 	return initErr
+}
+
+// observationStart is when THIS process began recording events. Claims of
+// the form "no changes in the last N seconds" must clamp to it: after a
+// restart the store (in-memory always; SQLite during the downtime gap) has
+// not been watching for the full window, and asserting a longer one would be
+// a false statement.
+var observationStart time.Time
+
+// ObservationStart returns when this process's store began observing, or the
+// zero time when no store is initialized.
+func ObservationStart() time.Time {
+	return observationStart
+}
+
+// SetObservationStartForTest backdates the observation window so tests can
+// exercise claims that require a longer watch period.
+func SetObservationStartForTest(t time.Time) {
+	observationStart = t
 }
 
 // GetStore returns the global event store instance
@@ -182,6 +202,7 @@ func ResetStore() {
 		}
 		globalStore = nil
 	}
+	observationStart = time.Time{}
 	globalStoreOnce = sync.Once{}
 }
 

--- a/internal/timeline/manager.go
+++ b/internal/timeline/manager.go
@@ -55,6 +55,9 @@ const (
 	EventTypeNormal  = pkgtimeline.EventTypeNormal
 	EventTypeWarning = pkgtimeline.EventTypeWarning
 
+	// Reason constants
+	ReasonRecreated = pkgtimeline.ReasonRecreated
+
 	// HealthState constants
 	HealthHealthy   = pkgtimeline.HealthHealthy
 	HealthDegraded  = pkgtimeline.HealthDegraded

--- a/internal/timeline/manager.go
+++ b/internal/timeline/manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -161,28 +162,38 @@ func InitStore(cfg StoreConfig) error {
 			globalStore = NewMemoryStore(maxSize)
 			log.Printf("Initialized in-memory event store (max %d events)", maxSize)
 		}
-		observationStart = time.Now()
+		observationStartNanos.Store(time.Now().UnixNano())
 	})
 	return initErr
 }
 
-// observationStart is when THIS process began recording events. Claims of
-// the form "no changes in the last N seconds" must clamp to it: after a
-// restart the store (in-memory always; SQLite during the downtime gap) has
-// not been watching for the full window, and asserting a longer one would be
-// a false statement.
-var observationStart time.Time
+// observationStartNanos (unix nanos; 0 = no store) is when THIS process began
+// recording events. Claims of the form "no changes in the last N seconds"
+// must clamp to it: after a restart the store (in-memory always; SQLite
+// during the downtime gap) has not been watching for the full window, and
+// asserting a longer one would be a false statement. Atomic because it is
+// written on context switch (ResetStore) while concurrent MCP request
+// goroutines read it.
+var observationStartNanos atomic.Int64
 
 // ObservationStart returns when this process's store began observing, or the
 // zero time when no store is initialized.
 func ObservationStart() time.Time {
-	return observationStart
+	nanos := observationStartNanos.Load()
+	if nanos == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, nanos)
 }
 
 // SetObservationStartForTest backdates the observation window so tests can
 // exercise claims that require a longer watch period.
 func SetObservationStartForTest(t time.Time) {
-	observationStart = t
+	if t.IsZero() {
+		observationStartNanos.Store(0)
+		return
+	}
+	observationStartNanos.Store(t.UnixNano())
 }
 
 // GetStore returns the global event store instance
@@ -202,7 +213,7 @@ func ResetStore() {
 		}
 		globalStore = nil
 	}
-	observationStart = time.Time{}
+	observationStartNanos.Store(0)
 	globalStoreOnce = sync.Once{}
 }
 

--- a/internal/timeline/sqlite_store.go
+++ b/internal/timeline/sqlite_store.go
@@ -326,6 +326,18 @@ func (s *SQLiteStore) Query(ctx context.Context, opts QueryOptions) ([]TimelineE
 		query.WriteString(")")
 	}
 
+	if len(opts.EventTypes) > 0 {
+		query.WriteString(" AND event_type IN (")
+		for i, et := range opts.EventTypes {
+			if i > 0 {
+				query.WriteString(",")
+			}
+			query.WriteString("?")
+			args = append(args, string(et))
+		}
+		query.WriteString(")")
+	}
+
 	if opts.ClusterContext != "" {
 		query.WriteString(" AND cluster_context = ?")
 		args = append(args, opts.ClusterContext)

--- a/internal/timeline/sqlite_store.go
+++ b/internal/timeline/sqlite_store.go
@@ -304,6 +304,18 @@ func (s *SQLiteStore) Query(ctx context.Context, opts QueryOptions) ([]TimelineE
 		query.WriteString(")")
 	}
 
+	if len(opts.Names) > 0 {
+		query.WriteString(" AND name IN (")
+		for i, name := range opts.Names {
+			if i > 0 {
+				query.WriteString(",")
+			}
+			query.WriteString("?")
+			args = append(args, name)
+		}
+		query.WriteString(")")
+	}
+
 	if !opts.Since.IsZero() {
 		query.WriteString(" AND timestamp >= ?")
 		args = append(args, opts.Since.Format(time.RFC3339Nano))

--- a/internal/timeline/sqlite_store_test.go
+++ b/internal/timeline/sqlite_store_test.go
@@ -107,6 +107,34 @@ func TestSQLiteStore_AppendBatch(t *testing.T) {
 	}
 }
 
+func TestSQLiteStore_Query_Names(t *testing.T) {
+	store, cleanup := createTestSQLiteStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	events := []TimelineEvent{
+		{ID: "name-1", Timestamp: time.Now(), Kind: "Deployment", Namespace: "default", Name: "deploy-1", EventType: EventTypeAdd, Source: SourceInformer},
+		{ID: "name-2", Timestamp: time.Now(), Kind: "Deployment", Namespace: "default", Name: "deploy-2", EventType: EventTypeAdd, Source: SourceInformer},
+		{ID: "name-3", Timestamp: time.Now(), Kind: "Service", Namespace: "default", Name: "deploy-1", EventType: EventTypeAdd, Source: SourceInformer},
+	}
+	if err := store.AppendBatch(ctx, events); err != nil {
+		t.Fatalf("AppendBatch failed: %v", err)
+	}
+
+	result, err := store.Query(ctx, QueryOptions{Names: []string{"deploy-1"}, Limit: 10, IncludeManaged: true})
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("Expected 2 deploy-1 events, got %d", len(result))
+	}
+	for _, e := range result {
+		if e.Name != "deploy-1" {
+			t.Errorf("Expected name 'deploy-1', got %q", e.Name)
+		}
+	}
+}
+
 func TestSQLiteStore_Query_FilterPreset(t *testing.T) {
 	store, cleanup := createTestSQLiteStore(t)
 	defer cleanup()

--- a/internal/timeline/sqlite_store_test.go
+++ b/internal/timeline/sqlite_store_test.go
@@ -135,6 +135,42 @@ func TestSQLiteStore_Query_Names(t *testing.T) {
 	}
 }
 
+// The lifecycle candidate query (meaningfulchanges) depends on this filter:
+// a SQL-level regression here would silently re-import update churn or starve
+// deletes for sqlite-backed timelines.
+func TestSQLiteStore_Query_EventTypes(t *testing.T) {
+	store, cleanup := createTestSQLiteStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	events := []TimelineEvent{
+		{ID: "et-add", Timestamp: time.Now(), Kind: "Deployment", Namespace: "default", Name: "deploy-1", EventType: EventTypeAdd, Source: SourceInformer, Reason: ReasonRecreated},
+		{ID: "et-update", Timestamp: time.Now(), Kind: "Deployment", Namespace: "default", Name: "deploy-1", EventType: EventTypeUpdate, Source: SourceInformer},
+		{ID: "et-delete", Timestamp: time.Now(), Kind: "Deployment", Namespace: "default", Name: "deploy-2", EventType: EventTypeDelete, Source: SourceInformer},
+	}
+	if err := store.AppendBatch(ctx, events); err != nil {
+		t.Fatalf("AppendBatch failed: %v", err)
+	}
+
+	result, err := store.Query(ctx, QueryOptions{EventTypes: []EventType{EventTypeAdd, EventTypeDelete}, Limit: 10, IncludeManaged: true})
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("Expected 2 add/delete events, got %d", len(result))
+	}
+	for _, e := range result {
+		if e.EventType == EventTypeUpdate {
+			t.Errorf("update event %q leaked through the EventTypes filter", e.ID)
+		}
+		// Reason must survive the SQLite round-trip — recreate-join coalescing
+		// keys on it.
+		if e.ID == "et-add" && e.Reason != ReasonRecreated {
+			t.Errorf("Reason = %q, want %q after round-trip", e.Reason, ReasonRecreated)
+		}
+	}
+}
+
 func TestSQLiteStore_Query_FilterPreset(t *testing.T) {
 	store, cleanup := createTestSQLiteStore(t)
 	defer cleanup()

--- a/packages/k8s-ui/src/components/issues/types.ts
+++ b/packages/k8s-ui/src/components/issues/types.ts
@@ -108,6 +108,16 @@ export interface IssueRecentChange {
   change_category?: 'spec_config' | 'lifecycle' | 'runtime_status' | string;
   rank_reason?: string;
   fields?: IssueRecentChangeField[];
+  /** Workloads that mount/reference this ConfigMap directly ("Deployment/flagd").
+   *  Direct spec references only — runtime consumers via an intermediary
+   *  service are not captured. */
+  consumed_by?: string[];
+}
+
+/** "No tracked spec/config changes in the window" — the claim is scoped by
+ *  windowSeconds so a change just outside it can't be misread as absent. */
+export interface IssueNoRecentChanges {
+  windowSeconds: number;
 }
 
 /**
@@ -185,6 +195,15 @@ export interface Issue {
   issue_timing?: 'started_at_resource_creation' | 'started_after_resource_was_healthy';
   /** The evidence that determined issue_timing (for auditability). */
   issue_timing_basis?: 'condition' | 'owner_condition' | 'pod_creation' | 'deletion' | 'phase' | 'spec';
+
+  /** Recent spec/config changes on this issue's subject (and, for workload
+   *  subjects, its referenced ConfigMaps) — deterministic evidence, not a
+   *  causal claim. Single-namespace responses only. */
+  correlated_changes?: IssueRecentChange[];
+  /** Explicit "no tracked changes in the window" evidence. An issue with
+   *  NEITHER correlation field was not checked (see the response-level
+   *  correlation_truncated) — absence must not be read as "no changes". */
+  no_recent_changes?: IssueNoRecentChanges;
 }
 
 /** subjectRef builds a deep-linkable ref for an issue's subject — the row's

--- a/packages/k8s-ui/src/components/issues/types.ts
+++ b/packages/k8s-ui/src/components/issues/types.ts
@@ -114,10 +114,10 @@ export interface IssueRecentChange {
   consumed_by?: string[];
 }
 
-/** "No tracked spec/config changes in the window" — the claim is scoped by
- *  windowSeconds so a change just outside it can't be misread as absent. */
+/** "No tracked non-status changes in the window" — the claim is scoped by
+ *  window_seconds so a change just outside it can't be misread as absent. */
 export interface IssueNoRecentChanges {
-  windowSeconds: number;
+  window_seconds: number;
 }
 
 /**
@@ -196,13 +196,14 @@ export interface Issue {
   /** The evidence that determined issue_timing (for auditability). */
   issue_timing_basis?: 'condition' | 'owner_condition' | 'pod_creation' | 'deletion' | 'phase' | 'spec';
 
-  /** Recent spec/config changes on this issue's subject (and, for workload
-   *  subjects, its referenced ConfigMaps) — deterministic evidence, not a
-   *  causal claim. Single-namespace responses only. */
+  /** Recent non-status changes (spec/config and lifecycle) on this issue's
+   *  subject (and, for workload subjects, its referenced ConfigMaps) —
+   *  deterministic evidence, not a causal claim. Populated only on
+   *  single-namespace MCP issue responses; never set on /api/issues today. */
   correlated_changes?: IssueRecentChange[];
   /** Explicit "no tracked changes in the window" evidence. An issue with
-   *  NEITHER correlation field was not checked (see the response-level
-   *  correlation_truncated) — absence must not be read as "no changes". */
+   *  NEITHER correlation field was not checked — absence must not be read as
+   *  "no changes". MCP-only, like correlated_changes. */
   no_recent_changes?: IssueNoRecentChanges;
 }
 

--- a/pkg/issuesapi/types.go
+++ b/pkg/issuesapi/types.go
@@ -234,16 +234,27 @@ type ChangeField struct {
 	NewValue any    `json:"newValue,omitempty"`
 }
 
+// ChangeCategory classifies a RecentChange. The values drive both ranking and
+// the per-issue correlation filter — producers and consumers must share these
+// constants, not bare literals.
+type ChangeCategory string
+
+const (
+	ChangeCategorySpecConfig    ChangeCategory = "spec_config"
+	ChangeCategoryLifecycle     ChangeCategory = "lifecycle"
+	ChangeCategoryRuntimeStatus ChangeCategory = "runtime_status"
+)
+
 type RecentChange struct {
-	Kind           string        `json:"kind"`
-	Namespace      string        `json:"namespace,omitempty"`
-	Name           string        `json:"name"`
-	ChangeType     string        `json:"changeType"`
-	Summary        string        `json:"summary,omitempty"`
-	Timestamp      string        `json:"timestamp"`
-	ChangeCategory string        `json:"change_category,omitempty"`
-	RankReason     string        `json:"rank_reason,omitempty"`
-	Fields         []ChangeField `json:"fields,omitempty"`
+	Kind           string         `json:"kind"`
+	Namespace      string         `json:"namespace,omitempty"`
+	Name           string         `json:"name"`
+	ChangeType     string         `json:"changeType"`
+	Summary        string         `json:"summary,omitempty"`
+	Timestamp      string         `json:"timestamp"`
+	ChangeCategory ChangeCategory `json:"change_category,omitempty"`
+	RankReason     string         `json:"rank_reason,omitempty"`
+	Fields         []ChangeField  `json:"fields,omitempty"`
 	// ConsumedBy lists workloads that mount or reference this ConfigMap via
 	// their pod spec (volumes, envFrom, env valueFrom). Direct references
 	// only — runtime consumers reading through an intermediary service are
@@ -341,16 +352,17 @@ type Issue struct {
 	//   "phase"           — resource Phase field (e.g. PVC Pending)
 	//   "spec"            — structural spec invariant (no timestamp required)
 	IssueTimingBasis string `json:"issue_timing_basis,omitempty"`
-	// CorrelatedChanges lists recent spec/config changes on this issue's
-	// subject (and, for workload subjects, its directly referenced
-	// ConfigMaps) within the correlation lookback window. Deterministic
-	// evidence, not a causal claim — the consumer weighs whether the change
-	// explains the issue.
+	// CorrelatedChanges lists recent non-status changes (spec/config and
+	// lifecycle) on this issue's subject (and, for workload subjects, its
+	// directly referenced ConfigMaps) within the correlation lookback window.
+	// Deterministic evidence, not a causal claim — the consumer weighs
+	// whether the change explains the issue.
 	CorrelatedChanges []RecentChange `json:"correlated_changes,omitempty"`
-	// NoRecentChanges states the lookback window contained no spec/config
+	// NoRecentChanges states the lookback window contained no non-status
 	// changes for this issue's subject — evidence the issue is NOT
 	// change-driven within that window. Omitted when correlation was not
-	// attempted (cap reached, lookup failed); absence must never be read as
+	// attempted (cap reached, lookup failed) or when the candidate fetch
+	// saturated and may have missed changes; absence must never be read as
 	// "no changes".
 	NoRecentChanges *NoRecentChangesMarker `json:"no_recent_changes,omitempty"`
 }
@@ -359,7 +371,7 @@ type Issue struct {
 // scoped: a change 61 minutes ago truthfully reads as none under a 3600s
 // window.
 type NoRecentChangesMarker struct {
-	WindowSeconds int `json:"windowSeconds"`
+	WindowSeconds int `json:"window_seconds"`
 }
 
 type Response struct {

--- a/pkg/issuesapi/types.go
+++ b/pkg/issuesapi/types.go
@@ -244,6 +244,11 @@ type RecentChange struct {
 	ChangeCategory string        `json:"change_category,omitempty"`
 	RankReason     string        `json:"rank_reason,omitempty"`
 	Fields         []ChangeField `json:"fields,omitempty"`
+	// ConsumedBy lists workloads that mount or reference this ConfigMap via
+	// their pod spec (volumes, envFrom, env valueFrom). Direct references
+	// only — runtime consumers reading through an intermediary service are
+	// not captured.
+	ConsumedBy []string `json:"consumed_by,omitempty"`
 }
 
 type ClusterContext struct {
@@ -336,6 +341,25 @@ type Issue struct {
 	//   "phase"           — resource Phase field (e.g. PVC Pending)
 	//   "spec"            — structural spec invariant (no timestamp required)
 	IssueTimingBasis string `json:"issue_timing_basis,omitempty"`
+	// CorrelatedChanges lists recent spec/config changes on this issue's
+	// subject (and, for workload subjects, its directly referenced
+	// ConfigMaps) within the correlation lookback window. Deterministic
+	// evidence, not a causal claim — the consumer weighs whether the change
+	// explains the issue.
+	CorrelatedChanges []RecentChange `json:"correlated_changes,omitempty"`
+	// NoRecentChanges states the lookback window contained no spec/config
+	// changes for this issue's subject — evidence the issue is NOT
+	// change-driven within that window. Omitted when correlation was not
+	// attempted (cap reached, lookup failed); absence must never be read as
+	// "no changes".
+	NoRecentChanges *NoRecentChangesMarker `json:"no_recent_changes,omitempty"`
+}
+
+// NoRecentChangesMarker carries the window so the "no changes" claim is
+// scoped: a change 61 minutes ago truthfully reads as none under a 3600s
+// window.
+type NoRecentChangesMarker struct {
+	WindowSeconds int `json:"windowSeconds"`
 }
 
 type Response struct {
@@ -349,6 +373,10 @@ type Response struct {
 	ClusterContext      *ClusterContext `json:"cluster_context,omitempty"`
 	RecentChanges       []RecentChange  `json:"recent_changes,omitempty"`
 	RecentChangesReason string          `json:"recent_changes_reason,omitempty"`
+	// CorrelationTruncated is set when per-issue change correlation skipped
+	// some critical issues (cap reached). Under truncation, an issue without
+	// correlation markers means "not checked", not "no changes".
+	CorrelationTruncated bool `json:"correlation_truncated,omitempty"`
 }
 
 type BindingType string

--- a/pkg/timeline/memory_store.go
+++ b/pkg/timeline/memory_store.go
@@ -326,6 +326,13 @@ func (m *MemoryStore) matchesFilters(event *TimelineEvent, opts QueryOptions, cf
 		}
 	}
 
+	if len(opts.EventTypes) > 0 {
+		found := slices.Contains(opts.EventTypes, event.EventType)
+		if !found {
+			return false
+		}
+	}
+
 	// Handle IncludeManaged
 	// If opts.IncludeManaged is true, it overrides the preset's IncludeManaged setting
 	// This allows queries to explicitly request managed resources even with "default" preset

--- a/pkg/timeline/memory_store.go
+++ b/pkg/timeline/memory_store.go
@@ -119,18 +119,12 @@ func (m *MemoryStore) Query(ctx context.Context, opts QueryOptions) ([]TimelineE
 func (m *MemoryStore) QueryGrouped(ctx context.Context, opts QueryOptions) (*TimelineResponse, error) {
 	startTime := time.Now()
 
-	// First get all matching events
-	events, err := m.Query(ctx, QueryOptions{
-		Namespaces:       opts.Namespaces,
-		Kinds:            opts.Kinds,
-		Since:            opts.Since,
-		Until:            opts.Until,
-		Sources:          opts.Sources,
-		FilterPreset:     opts.FilterPreset,
-		Limit:            opts.Limit * 10, // Get more events for grouping
-		IncludeManaged:   opts.IncludeManaged,
-		IncludeK8sEvents: opts.IncludeK8sEvents,
-	})
+	// First get all matching events, with a higher limit for grouping. Copy the
+	// full option struct so new filters can't drift between Query and grouped
+	// queries.
+	queryOpts := opts
+	queryOpts.Limit = opts.Limit * 10
+	events, err := m.Query(ctx, queryOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -314,6 +308,13 @@ func (m *MemoryStore) matchesFilters(event *TimelineEvent, opts QueryOptions, cf
 
 	if len(opts.Kinds) > 0 {
 		found := slices.Contains(opts.Kinds, event.Kind)
+		if !found {
+			return false
+		}
+	}
+
+	if len(opts.Names) > 0 {
+		found := slices.Contains(opts.Names, event.Name)
 		if !found {
 			return false
 		}

--- a/pkg/timeline/memory_store_test.go
+++ b/pkg/timeline/memory_store_test.go
@@ -140,6 +140,34 @@ func TestMemoryStore_Query_Names(t *testing.T) {
 	}
 }
 
+func TestMemoryStore_Query_EventTypes(t *testing.T) {
+	store := NewMemoryStore(100)
+	ctx := context.Background()
+
+	events := []TimelineEvent{
+		{ID: "et-add", Timestamp: time.Now(), Kind: "Deployment", Namespace: "default", Name: "deploy-1", EventType: EventTypeAdd, Source: SourceInformer, Reason: ReasonRecreated},
+		{ID: "et-update", Timestamp: time.Now(), Kind: "Deployment", Namespace: "default", Name: "deploy-1", EventType: EventTypeUpdate, Source: SourceInformer},
+		{ID: "et-delete", Timestamp: time.Now(), Kind: "Deployment", Namespace: "default", Name: "deploy-2", EventType: EventTypeDelete, Source: SourceInformer},
+	}
+	_ = store.AppendBatch(ctx, events)
+
+	result, err := store.Query(ctx, QueryOptions{EventTypes: []EventType{EventTypeAdd, EventTypeDelete}, Limit: 10, IncludeManaged: true})
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("Expected 2 add/delete events, got %d", len(result))
+	}
+	for _, e := range result {
+		if e.EventType == EventTypeUpdate {
+			t.Errorf("update event %q leaked through the EventTypes filter", e.ID)
+		}
+		if e.ID == "et-add" && e.Reason != ReasonRecreated {
+			t.Errorf("Reason = %q, want %q", e.Reason, ReasonRecreated)
+		}
+	}
+}
+
 func TestMemoryStore_Query_Since(t *testing.T) {
 	store := NewMemoryStore(100)
 	ctx := context.Background()

--- a/pkg/timeline/memory_store_test.go
+++ b/pkg/timeline/memory_store_test.go
@@ -115,6 +115,31 @@ func TestMemoryStore_Query_Kinds(t *testing.T) {
 	}
 }
 
+func TestMemoryStore_Query_Names(t *testing.T) {
+	store := NewMemoryStore(100)
+	ctx := context.Background()
+
+	events := []TimelineEvent{
+		{ID: "name-1", Timestamp: time.Now(), Kind: "Deployment", Namespace: "default", Name: "deploy-1", EventType: EventTypeAdd, Source: SourceInformer},
+		{ID: "name-2", Timestamp: time.Now(), Kind: "Deployment", Namespace: "default", Name: "deploy-2", EventType: EventTypeAdd, Source: SourceInformer},
+		{ID: "name-3", Timestamp: time.Now(), Kind: "Service", Namespace: "default", Name: "deploy-1", EventType: EventTypeAdd, Source: SourceInformer},
+	}
+	_ = store.AppendBatch(ctx, events)
+
+	result, err := store.Query(ctx, QueryOptions{Names: []string{"deploy-1"}, Limit: 10, IncludeManaged: true})
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("Expected 2 deploy-1 events, got %d", len(result))
+	}
+	for _, e := range result {
+		if e.Name != "deploy-1" {
+			t.Errorf("Expected name 'deploy-1', got %q", e.Name)
+		}
+	}
+}
+
 func TestMemoryStore_Query_Since(t *testing.T) {
 	store := NewMemoryStore(100)
 	ctx := context.Background()

--- a/pkg/timeline/store.go
+++ b/pkg/timeline/store.go
@@ -54,6 +54,7 @@ type QueryOptions struct {
 	Since      time.Time     // Filter events after this time
 	Until      time.Time     // Filter events before this time
 	Sources    []EventSource // Filter by event source (empty = all)
+	EventTypes []EventType   // Filter by event type, e.g. add/delete (empty = all)
 	// ClusterContext scopes results to one cluster's events (empty = all).
 	// Anything answering "what happened on THIS cluster" must set it: the
 	// SQLite store outlives context switches, and rows written before the

--- a/pkg/timeline/store.go
+++ b/pkg/timeline/store.go
@@ -51,6 +51,7 @@ type QueryOptions struct {
 	// Filters
 	Namespaces []string      // Filter by namespaces (empty = all)
 	Kinds      []string      // Filter by resource kinds (empty = all)
+	Names      []string      // Filter by resource names (empty = all)
 	Since      time.Time     // Filter events after this time
 	Until      time.Time     // Filter events before this time
 	Sources    []EventSource // Filter by event source (empty = all)

--- a/pkg/timeline/types.go
+++ b/pkg/timeline/types.go
@@ -42,6 +42,12 @@ const (
 	EventTypeWarning EventType = "Warning"
 )
 
+// ReasonRecreated marks an add event that replaced a just-deleted resource of
+// the same kind/namespace/name (different UID). Such events carry a Diff
+// against the predecessor object — the delete+add pair was a recreate, and
+// the diff shows what changed across it.
+const ReasonRecreated = "recreated"
+
 // HealthState represents the health of a resource
 type HealthState string
 


### PR DESCRIPTION
## What

Three workstreams from the batch5 failure analysis (per-scenario attribution in the bench repo's RADAR_IMPROVEMENT_PLAN.md). Nothing here adds a new detector, heuristic, or judgment call — the changes make existing signals truthful, bound, and bindable to the issues they're about.

### Change-feed correctness
- **Candidate-starvation fix**: lifecycle (add/delete) events fetch in a dedicated timeline query (`EventTypes` filter added to the store layer), so update churn can no longer push them out of the newest-N candidate window before ranking sees them. Verified repro: a Service deletion buried under 81 pod-churn Deployment updates (missing_service, batch5).
- **Recreate-join**: delete+recreate under the same name (different UID, ≤15min apart) now emits one `recreated with changes: <diff>` entry carrying the cross-recreate spec diff; the paired delete is coalesced out of the feed (entry count strictly reduced — asserted in tests). In-memory TTL stash; reuses the existing per-kind differs so all redaction (env values, command/args secrets, ConfigMap sensitive paths) is inherited. Covers `kubectl replace --force`, Argo `Replace=true`, and immutable-field-edit recreates. Stash covers every feed-tracked kind including the Flux source kinds (pinned by a sync test).
- **Field coverage**: pod-template diffs add volumes/volumeMounts (source refs only), container ports, serviceAccountName, nodeSelector, tolerations (summarized), securityContext + affinity (boolean-level markers).
- **Kinds**: ResourceQuota/LimitRange join the feed with `spec.hard` diffs ("quota limits.memory: 4Gi→1Gi"); `status.used` churn deliberately excluded. Secret **deletes** surface name-only; Secret adds/updates never do.

### Per-issue change correlation (MCP issues, single-namespace)
Critical issues carry either `correlated_changes` (≤3 non-status refs — spec/config and lifecycle — for the subject and, for workloads, its directly referenced ConfigMaps) or `no_recent_changes: {window_seconds}` — deterministic per-subject evidence; no reordering, no demotion, no causal claims. Guard rails:
- status-churn rows are filtered out of correlation (the symptom is not a change)
- `window_seconds` clamps to actual observation time; under 5 minutes of observation no marker is emitted in either direction (a fresh store cannot truthfully claim anything about the past hour)
- when the subject's candidate fetch saturates (churn-heavy subjects can exceed the newest-N window), the marker is omitted — a saturated fetch is "unknown", never evidence of "no changes"
- capped at 10 criticals with explicit `correlation_truncated`; untracked kinds get no marker (absence = unknown, never "no changes"); lookup failures are logged and degrade to unmarked
- ConfigMap change entries carry `consumed_by` (direct mounting/referencing workloads, via lister scan)

### MCP ergonomics
- Not-found errors suggest the corrected call: `found Deployment ns/name — retry with kind=deployment; or use search` (cache lookup, cross-namespace suggestions RBAC-gated — now pinned by a test, Secrets excluded)
- Large-ConfigMap values truncate at 8KB (total >16KB) with an explicit marker + warning; `binaryData` counts too (base64 blobs are the largest real payloads)
- `narrowHint` on get_cluster_audit / get_subject_permissions truncation; large-graph steering warning on get_topology
- get_topology description now states `view=traffic` is spec-derived routing, not observed traffic

### Hardening (post-review pass)
- `ChangeCategory` is a typed constant set in `issuesapi`, shared by the feed producer and the correlation filter (a literal typo there would have silently mis-marked every issue)
- `observationStart` reads/writes are atomic (context-switch write vs concurrent MCP request reads)
- `no_recent_changes.windowSeconds` renamed to `window_seconds` to match sibling field convention (pre-release wire surface)

## Verification

Unit: full suite green on both modules; tests for starvation survival, recreate-join (TTL/UID/eviction/coalescing, delete-after-recreate, unstructured status-strip), field diffs, quota/limitrange differs, correlation markers/truncation/observation-clamp branches/saturation omission, workload→ConfigMap fan-out (end-to-end through the cache), consumed_by, cross-namespace suggestion RBAC gating, store-level `EventTypes` + `Reason` round-trip on both SQLite and memory stores, ConfigMap data+binaryData guard.

Live (old vs new binary side by side on a kind cluster + read-only GKE nonprod):
- recreate shows `recreated with changes: image nginx:1.25→1.27, command changed` as ONE entry vs baseline's contentless add+delete pair
- quota tightening visible (`4Gi→1Gi`) vs invisible on baseline
- failing workload with a config change carries the change refs; chronic crashloops on GKE nonprod correctly carry `no_recent_changes`
- post-restart daemon emits no markers until 5min of observation, then clamped `window_seconds: 314` (not 3600)
- 15min GKE nonprod observation: 9 feed entries, no flooding, no false recreate joins

Bench: radar-arm-only N=1 rerun on the affected SREGym subset to follow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches informer timeline recording, feed ranking, and MCP issue payloads where incorrect saturation or correlation markers could mislead triage; behavior is heavily tested but spans core observation paths.
> 
> **Overview**
> **Makes diagnostic signals truthful and bindable** — no new detectors; it fixes how changes are recorded, ranked, and attached to critical issues.
> 
> **Timeline / change feed:** Lifecycle add/delete events are queried separately so update churn cannot bury deletions. **Recreate-join** stashes recent deletes and enriches a young same-name add (new UID) with a status-stripped spec diff and `ReasonRecreated`, with paired deletes coalesced in the feed. Diffs expand for pod templates (volumes, mounts, ports, scheduling, security markers), **ResourceQuota** / **LimitRange**, Secret delete-only lifecycle, and store filters **`Names`** / **`EventTypes`**. **`RecentForResource`** exposes fetch **saturation**; ConfigMap entries get **`consumed_by`**.
> 
> **MCP issues (single-namespace):** Critical issues gain **`correlated_changes`** or **`no_recent_changes`** (window clamped to observation time, status churn excluded, cap + **`correlation_truncated`**). Ergonomics: not-found **retry hints** (RBAC-gated), large **ConfigMap** truncation, **`narrowHint`** on capped audit/RBAC tools, topology steering + clarified spec-derived traffic docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 344e2cf5f8db7f82b2ade9249afb0c63b777291d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->