### PR TITLE
Show pod problem details in issue banners

### DIFF
--- a/packages/k8s-ui/src/components/resources/get-pod-problems.test.ts
+++ b/packages/k8s-ui/src/components/resources/get-pod-problems.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { getPodProblems } from './resource-utils'
+
+describe('getPodProblems', () => {
+  it('includes the pod status message for evicted pods', () => {
+    const detail = 'Usage of EmptyDir volume "logs-nginx" exceeds the limit "2Gi".'
+
+    expect(
+      getPodProblems({
+        status: {
+          phase: 'Failed',
+          reason: 'Evicted',
+          message: detail,
+        },
+      }),
+    ).toContainEqual({ severity: 'high', message: 'Evicted', detail })
+  })
+
+  it('keeps exit-code labels stable while surfacing terminated messages', () => {
+    const detail = 'Container process exited after receiving SIGKILL.'
+
+    expect(
+      getPodProblems({
+        status: {
+          phase: 'Running',
+          containerStatuses: [
+            {
+              name: 'api',
+              restartCount: 0,
+              state: {
+                terminated: {
+                  exitCode: 137,
+                  reason: 'Error',
+                  message: detail,
+                },
+              },
+            },
+          ],
+        },
+      }),
+    ).toContainEqual({ severity: 'high', message: 'Exit Code 137', detail })
+  })
+
+  it('keeps waiting-state labels stable while surfacing kubelet messages', () => {
+    const detail = 'Back-off pulling image "registry.example.com/api:missing".'
+
+    expect(
+      getPodProblems({
+        status: {
+          phase: 'Pending',
+          containerStatuses: [
+            {
+              name: 'api',
+              restartCount: 0,
+              state: {
+                waiting: {
+                  reason: 'ImagePullBackOff',
+                  message: detail,
+                },
+              },
+            },
+          ],
+        },
+      }),
+    ).toContainEqual({ severity: 'critical', message: 'ImagePullBackOff', detail })
+  })
+})

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.test.tsx
@@ -51,3 +51,28 @@ describe('PodRenderer envFrom expansion', () => {
     expect(html).not.toContain('PUBLIC_URL<!-- -->=')
   })
 })
+
+describe('PodRenderer issues banner', () => {
+  it('renders pod status messages for evicted pods', () => {
+    const html = renderToString(
+      <PodRenderer
+        data={{
+          metadata: { name: 'nginx', namespace: 'default' },
+          spec: { containers: [{ name: 'nginx', image: 'nginx:latest' }] },
+          status: {
+            phase: 'Failed',
+            reason: 'Evicted',
+            message: 'Usage of EmptyDir volume "logs-nginx" exceeds the limit "2Gi".',
+          },
+        }}
+        onCopy={() => undefined}
+        copied={null}
+      />,
+    )
+
+    expect(html).toContain('Issues Detected')
+    expect(html).toContain('Evicted')
+    expect(html).toContain('Usage of EmptyDir volume')
+    expect(html).toContain('exceeds the limit')
+  })
+})

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.test.tsx
@@ -75,4 +75,35 @@ describe('PodRenderer issues banner', () => {
     expect(html).toContain('Usage of EmptyDir volume')
     expect(html).toContain('exceeds the limit')
   })
+
+  it('wraps long issue detail text inside the banner', () => {
+    const html = renderToString(
+      <PodRenderer
+        data={{
+          metadata: { name: 'api', namespace: 'default' },
+          spec: { containers: [{ name: 'api', image: 'registry.example.com/api:missing' }] },
+          status: {
+            phase: 'Pending',
+            containerStatuses: [
+              {
+                name: 'api',
+                restartCount: 0,
+                state: {
+                  waiting: {
+                    reason: 'ImagePullBackOff',
+                    message: `Back-off pulling image "${'a'.repeat(240)}"`,
+                  },
+                },
+              },
+            ],
+          },
+        }}
+        onCopy={() => undefined}
+        copied={null}
+      />,
+    )
+
+    expect(html).toContain('ImagePullBackOff')
+    expect(html).toContain('min-w-0 break-words')
+  })
 })

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
@@ -347,7 +347,7 @@ export function PodRenderer({
             {podProblems.map((p, i) => (
               <li key={i} className="flex items-start gap-1.5">
                 <span className={clsx('w-1.5 h-1.5 rounded-full shrink-0 mt-1', SEVERITY_DOT_COLOR[p.severity])} />
-                <span className="text-red-600 dark:text-red-400">
+                <span className="min-w-0 break-words text-red-600 dark:text-red-400">
                   {p.message}
                   {p.detail && <span className="text-theme-text-secondary">: {p.detail}</span>}
                 </span>

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -267,26 +267,28 @@ export function getPodProblems(pod: any): PodProblem[] {
   const initContainerStatuses = pod.status?.initContainerStatuses || []
   const conditions = pod.status?.conditions || []
   const phase = pod.status?.phase
+  const podStatusMessage = pod.status?.message || undefined
 
   // Failed or Unknown phase
   if (phase === 'Failed' && pod.status?.reason !== 'Evicted') {
-    problems.push({ severity: 'critical', message: 'Failed' })
+    problems.push({ severity: 'critical', message: 'Failed', detail: podStatusMessage })
   } else if (phase === 'Unknown') {
-    problems.push({ severity: 'high', message: 'Unknown' })
+    problems.push({ severity: 'high', message: 'Unknown', detail: podStatusMessage })
   }
 
   // Init container failures
   for (const cs of initContainerStatuses) {
     if (cs.state?.waiting?.reason && cs.state.waiting.reason !== 'PodInitializing') {
       const reason = cs.state.waiting.reason
+      const detail = cs.state.waiting.message || undefined
       if (['CrashLoopBackOff', 'ImagePullBackOff', 'ErrImagePull'].includes(reason)) {
-        problems.push({ severity: 'critical', message: `Init: ${reason}` })
+        problems.push({ severity: 'critical', message: `Init: ${reason}`, detail })
       } else {
-        problems.push({ severity: 'high', message: `Init: ${reason}` })
+        problems.push({ severity: 'high', message: `Init: ${reason}`, detail })
       }
     }
     if (cs.state?.terminated?.exitCode && cs.state.terminated.exitCode !== 0) {
-      problems.push({ severity: 'high', message: `Init: Exit Code ${cs.state.terminated.exitCode}` })
+      problems.push({ severity: 'high', message: `Init: Exit Code ${cs.state.terminated.exitCode}`, detail: cs.state.terminated.message || undefined })
     }
   }
 
@@ -294,30 +296,32 @@ export function getPodProblems(pod: any): PodProblem[] {
     // Check waiting state
     if (cs.state?.waiting?.reason) {
       const reason = cs.state.waiting.reason
+      const detail = cs.state.waiting.message || undefined
       if (['CrashLoopBackOff', 'ImagePullBackOff', 'ErrImagePull'].includes(reason)) {
-        problems.push({ severity: 'critical', message: reason })
+        problems.push({ severity: 'critical', message: reason, detail })
       } else if (reason === 'CreateContainerConfigError') {
-        problems.push({ severity: 'critical', message: 'Config Error' })
+        problems.push({ severity: 'critical', message: 'Config Error', detail })
       } else if (reason === 'ContainerCannotRun') {
-        problems.push({ severity: 'critical', message: 'Cannot Run' })
+        problems.push({ severity: 'critical', message: 'Cannot Run', detail })
       } else if (reason !== 'ContainerCreating' && reason !== 'PodInitializing') {
-        problems.push({ severity: 'high', message: reason })
+        problems.push({ severity: 'high', message: reason, detail })
       }
     }
     // Check terminated state
     if (cs.state?.terminated?.reason === 'OOMKilled') {
-      problems.push({ severity: 'critical', message: 'OOMKilled' })
+      problems.push({ severity: 'critical', message: 'OOMKilled', detail: cs.state.terminated.message || undefined })
     } else if (cs.state?.terminated?.exitCode && cs.state.terminated.exitCode !== 0) {
-      problems.push({ severity: 'high', message: `Exit Code ${cs.state.terminated.exitCode}` })
+      problems.push({ severity: 'high', message: `Exit Code ${cs.state.terminated.exitCode}`, detail: cs.state.terminated.message || undefined })
     }
     // High restart count
     if (cs.restartCount > 5) {
       problems.push({ severity: 'medium', message: `${cs.restartCount} restarts` })
     }
     // Volume mount issues from last state
-    const lastMsg = cs.lastState?.terminated?.message?.toLowerCase() || ''
+    const lastMsgRaw = cs.lastState?.terminated?.message || ''
+    const lastMsg = lastMsgRaw.toLowerCase()
     if (lastMsg.includes('failed to mount') || lastMsg.includes('failedattachvolume')) {
-      problems.push({ severity: 'high', message: 'Volume Mount Failed' })
+      problems.push({ severity: 'high', message: 'Volume Mount Failed', detail: lastMsgRaw || undefined })
     }
   }
 
@@ -332,23 +336,23 @@ export function getPodProblems(pod: any): PodProblem[] {
     if (cond.type === 'ContainersReady' && cond.status === 'False') {
       const msg = (cond.message || '').toLowerCase()
       if (msg.includes('readiness')) {
-        problems.push({ severity: 'medium', message: 'Readiness Probe Failing' })
+        problems.push({ severity: 'medium', message: 'Readiness Probe Failing', detail: cond.message || undefined })
       } else if (msg.includes('liveness')) {
-        problems.push({ severity: 'high', message: 'Liveness Probe Failing' })
+        problems.push({ severity: 'high', message: 'Liveness Probe Failing', detail: cond.message || undefined })
       }
     }
     // IP allocation failures (subnet exhaustion)
     if (cond.type === 'PodReadyToStartContainers' && cond.status === 'False') {
       const msg = (cond.message || '').toLowerCase()
       if (msg.includes('failed to assign an ip') || msg.includes('pod sandbox')) {
-        problems.push({ severity: 'critical', message: 'IP Allocation Failed' })
+        problems.push({ severity: 'critical', message: 'IP Allocation Failed', detail: cond.message || undefined })
       }
     }
   }
 
   // Evicted pods
   if (phase === 'Failed' && pod.status?.reason === 'Evicted') {
-    problems.push({ severity: 'high', message: 'Evicted' })
+    problems.push({ severity: 'high', message: 'Evicted', detail: podStatusMessage })
   }
 
   // Stuck terminating (zombie pod)


### PR DESCRIPTION
Pod issue banners now include the underlying kubelet/status detail text in addition to Radar’s stable problem labels. This makes failures like evictions, image pull errors, config errors, non-zero exits, probe failures, and IP allocation failures actionable without requiring users to dig into raw YAML.

The normalized labels remain stable, while the new detail field carries the verbose Kubernetes message when present. Added focused coverage for getPodProblems and the PodRenderer issue banner.

Validation:
- npm test -w @skyhook-io/k8s-ui -- src/components/resources/get-pod-problems.test.ts src/components/resources/renderers/PodRenderer.test.tsx
- npm run tsc -w @skyhook-io/k8s-ui
- Visual-tested Pod issue banners against live ImagePullBackOff and CreateContainerConfigError pods at 1920x1080 and 1280x800.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only enrichment of pod diagnostics in k8s-ui with stable labels preserved; no auth or API behavior changes.
> 
> **Overview**
> Pod **Issues Detected** banners now show Kubernetes/kubelet **detail text** after each stable problem label (e.g. `Evicted`, `ImagePullBackOff`, `Exit Code 137`), so operators see eviction limits, image pull errors, and similar messages without opening raw YAML.
> 
> `getPodProblems` is updated to fill the existing optional `detail` field from `pod.status.message`, container waiting/terminated messages, condition text, and volume-mount failure messages while **keeping short `message` strings unchanged** for filters and problem categories. The banner row uses **`min-w-0 break-words`** so long details wrap instead of overflowing.
> 
> Adds **Vitest** coverage for `getPodProblems` detail mapping and for `PodRenderer` banner output (eviction text and wrapping classes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f176ad6a23490eccaab20e05f75d5f47edcb24db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->