### PR TITLE
Remove redundant diff type stubs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1030,13 +1030,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/diff": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
-      "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -4131,7 +4124,6 @@
         "shiki": "^4.0.0"
       },
       "devDependencies": {
-        "@types/diff": "^7.0.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@xterm/addon-fit": "^0.11.0",
@@ -4208,7 +4200,6 @@
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.3.0",
         "@tanstack/react-query": "^5.100.14",
-        "@types/diff": "^8.0.0",
         "@types/node": "^25.7.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -4228,7 +4219,7 @@
         "vite": "^8.0.12"
       },
       "peerDependencies": {
-        "@skyhook-io/k8s-ui": ">=1.5.0",
+        "@skyhook-io/k8s-ui": ">=1.7.3",
         "@tanstack/react-query": ">=5",
         "@xyflow/react": ">=12.0.0",
         "clsx": ">=2",
@@ -4238,15 +4229,6 @@
         "react-dom": ">=19",
         "react-router-dom": ">=7",
         "tailwind-merge": ">=2"
-      }
-    },
-    "web/node_modules/@types/diff": {
-      "version": "8.0.0",
-      "deprecated": "This is a stub types definition. diff provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "diff": "*"
       }
     }
   }

--- a/packages/k8s-ui/package.json
+++ b/packages/k8s-ui/package.json
@@ -85,7 +85,6 @@
     "yaml": ">=2.0.0"
   },
   "devDependencies": {
-    "@types/diff": "^7.0.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@xterm/addon-fit": "^0.11.0",

--- a/web/package.json
+++ b/web/package.json
@@ -56,7 +56,6 @@
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.3.0",
     "@tanstack/react-query": "^5.100.14",
-    "@types/diff": "^8.0.0",
     "@types/node": "^25.7.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",


### PR DESCRIPTION
Removes the redundant `@types/diff` devDependencies from the web app and shared k8s-ui package. The runtime `diff` dependency stays in place; `diff@9` ships its own TypeScript definitions, so the stub packages are no longer needed.

This also refreshes the package lock metadata that npm regenerates, including the existing `@skyhook-io/k8s-ui` peer version in the web workspace. That keeps `npm install` from reintroducing local lockfile churn and unblocks Nix packaging without sed workarounds.

Closes #905.

Verification:
- `npm ci --ignore-scripts`
- `npx tsc -p packages/k8s-ui/tsconfig.json`
- `npx tsc -p web/tsconfig.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only type stub removal with no application logic changes; types still come from the existing `diff` dependency.
> 
> **Overview**
> Drops **`@types/diff`** from **`packages/k8s-ui`** and **`web`** devDependencies because **`diff@9`** already ships TypeScript types; the runtime **`diff`** dependency is unchanged.
> 
> **`package-lock.json`** is updated to match (including removal of the deprecated stub **`web/node_modules/@types/diff`** entry) and to record the **`@skyhook-io/k8s-ui`** peer floor as **`>=1.7.3`** in the web workspace so installs stay stable for Nix packaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51eac6d997cc6d7da72b0612d9ee3622df3f930b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->