### PR TITLE
Fix workload log stream reconnect loop

### DIFF
--- a/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
+++ b/packages/k8s-ui/src/components/logs/WorkloadLogsViewer.tsx
@@ -82,6 +82,11 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
     pods.forEach((pod, i) => m.set(pod.name, i))
     return m
   }, [pods])
+  const podColorIndexRef = useRef<Map<string, number>>(new Map())
+
+  useEffect(() => {
+    podColorIndexRef.current = podColorIndex
+  }, [podColorIndex])
 
   const podsInitialized = useRef(false)
 
@@ -94,6 +99,7 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
       const resultPods = result.pods ?? []
       const resultLogs = result.logs ?? []
 
+      podColorIndexRef.current = new Map(resultPods.map((pod, i) => [pod.name, i]))
       setPods(resultPods)
 
       if (!podsInitialized.current && resultPods.length > 0) {
@@ -148,10 +154,12 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
       {
         onConnected: (data: any) => {
           if (data?.pods) {
-            setPods(data.pods)
-            if (selectedPods.size === 0) {
-              setSelectedPods(new Set((data.pods as WorkloadPodInfo[]).map((p: WorkloadPodInfo) => p.name)))
-            }
+            const nextPods = data.pods as WorkloadPodInfo[]
+            podColorIndexRef.current = new Map(nextPods.map((pod, i) => [pod.name, i]))
+            setPods(nextPods)
+            setSelectedPods(prev => (
+              prev.size === 0 ? new Set(nextPods.map((p: WorkloadPodInfo) => p.name)) : prev
+            ))
           }
         },
         onLog: (data: any) => {
@@ -161,7 +169,7 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
               content: data.content || '',
               container: data.container || '',
               pod: data.pod || '',
-              podColorIndex: podColorIndex.get(data.pod || ''),
+              podColorIndex: podColorIndexRef.current.get(data.pod || ''),
             })
           }
         },
@@ -171,7 +179,8 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
             setPods(prev => {
               const existing = new Set(prev.map(p => p.name))
               const toAdd = newPods.filter(p => !existing.has(p.name))
-              return toAdd.length > 0 ? [...prev, ...toAdd] : prev
+              if (toAdd.length === 0) return prev
+              return [...prev, ...toAdd]
             })
             setSelectedPods(prev => {
               const next = new Set(prev)
@@ -191,7 +200,7 @@ export function WorkloadLogsViewer({ name, fetchAll, createStream, overrideDownl
       },
       'Workload log stream connection failed',
     )
-  }, [createStream, startStreaming, selectedContainer, sinceSeconds, append, podColorIndex, selectedPods.size, clear])
+  }, [createStream, startStreaming, selectedContainer, sinceSeconds, append, clear])
 
   const handleStopStreaming = useCallback(() => {
     userStoppedRef.current = true


### PR DESCRIPTION
## Summary

Fix workload log streaming auto-start so the stream callback is not recreated when the connected payload refreshes pod metadata. The pod color index now stays current through a ref, and selected pods are initialized with a functional update.

This prevents the multi-pod log view from repeatedly tearing down and reopening the workload log SSE stream on workloads with multiple pods. Fixes #906.

## Validation

- `npm --workspace @skyhook-io/k8s-ui run tsc`
- `npm --workspace @skyhook-io/k8s-ui test`
- `npm --workspace @skyhook-io/radar-app run tsc`
- `git diff --check`
- `make build`
- Visual test: DaemonSet `gke-metrics-agent` showed `10/10 pods` with one active workload log stream, and StatefulSet `redis-replicas` showed `3/3 pods` with one active workload log stream.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized React hook dependency and ref wiring in the workload logs viewer; no auth, API contract, or backend changes.
> 
> **Overview**
> Fixes a **reconnect loop** in multi-pod workload log auto-streaming where the SSE connection was torn down and reopened whenever the stream’s connected payload refreshed pod metadata.
> 
> `handleStartStreaming` no longer depends on `podColorIndex` or `selectedPods.size`, so updating pods from `onConnected` does not recreate the callback and re-trigger the auto-start effect. Pod label colors still stay correct via a **`podColorIndexRef`** updated on fetch, connect, and each log line. **Selected pods** are initialized on connect with a functional `setSelectedPods` so existing selections are preserved when the user already picked pods.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b43cff91a8b84f2544027ad3efb73eb04b86682. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->