### PR TITLE
Add browser selection for UI launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ radar
 | `--namespace` | (all) | Initial namespace filter (supports multi-select in the UI; also used as RBAC fallback for namespace-scoped users) |
 | `--port` | `9280` | Server port |
 | `--no-browser` | `false` | Don't auto-open browser |
+| `--browser` | | Browser to use when opening the UI, e.g. `firefox`, `google-chrome`, or `Google Chrome` on macOS |
 | `--timeline-storage` | `memory` | Timeline storage backend: `memory` or `sqlite` |
 | `--timeline-db` | `~/.radar/timeline.db` | Path to SQLite database (when using sqlite storage) |
 | `--timeline-max-size` | `1Gi` | Maximum SQLite DB + WAL size before pruning oldest events (e.g. `800Mi`, `8Gi`; `0` disables) |

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -51,6 +51,7 @@ func main() {
 	namespace := flag.String("namespace", fileCfg.Namespace, "Initial namespace filter (empty = all namespaces)")
 	port := flag.Int("port", fileCfg.PortOr(9280), "Server port")
 	noBrowser := flag.Bool("no-browser", fileCfg.NoBrowser, "Don't auto-open browser")
+	browser := flag.String("browser", fileCfg.Browser, "Browser to use when opening the UI (default: OS default browser; macOS app names supported)")
 	devMode := flag.Bool("dev", false, "Development mode (serve frontend from filesystem)")
 	showVersion := flag.Bool("version", false, "Show version and exit")
 	historyLimit := flag.Int("history-limit", fileCfg.HistoryLimitOr(10000), "Maximum number of events to retain in timeline")
@@ -191,6 +192,7 @@ func main() {
 		Namespace:                *namespace,
 		Port:                     *port,
 		NoBrowser:                *noBrowser,
+		Browser:                  *browser,
 		DevMode:                  *devMode,
 		HistoryLimit:             *historyLimit,
 		DebugEvents:              *debugEvents,
@@ -281,7 +283,7 @@ func main() {
 		if cfg.Namespace != "" {
 			url += fmt.Sprintf("?namespace=%s", cfg.Namespace)
 		}
-		go app.OpenBrowser(url)
+		go app.OpenBrowser(url, cfg.Browser)
 	}
 
 	// Now initialize cluster connection and caches (browser will see progress via SSE)

--- a/deploy/krew/radar.yaml
+++ b/deploy/krew/radar.yaml
@@ -23,10 +23,12 @@ spec:
     Usage:
       kubectl radar              # Opens browser UI on http://localhost:9280
       kubectl radar --namespace default  # Filter to specific namespace
+      kubectl radar --browser firefox    # Open with a specific browser
+      kubectl radar --browser "Google Chrome" # macOS app name
       kubectl radar --no-browser # Start server without opening browser
   caveats: |
     This plugin opens a web UI in your browser by default.
-    Use --no-browser to start the server without opening a browser.
+    Use --browser to choose a browser or --no-browser to start the server without opening one.
   platforms:
   - bin: kubectl-radar
     uri: https://github.com/skyhook-io/radar/releases/download/v0.6.5/radar_0.6.5_darwin_arm64.tar.gz

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,7 @@ Persistent defaults for CLI flags. CLI flags always override these values. Manag
   "namespace": "",
   "port": 9280,
   "noBrowser": false,
+  "browser": "",
   "timelineStorage": "memory",
   "timelineDbPath": "~/.radar/timeline.db",
   "timelineMaxSize": "0",
@@ -37,6 +38,7 @@ All fields are optional — omitted fields use built-in defaults.
 | `namespace` | Initial namespace filter |
 | `port` | Server port (default 9280) |
 | `noBrowser` | Don't auto-open browser |
+| `browser` | Browser for automatic launch (same as `--browser`; on macOS, app names like `Google Chrome` are supported) |
 | `timelineStorage` | `memory` or `sqlite` |
 | `timelineDbPath` | Path to SQLite database |
 | `timelineMaxSize` | Max SQLite DB + WAL size before pruning oldest events (`0` disables) |

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -31,6 +31,7 @@ type AppConfig struct {
 	Namespace                string
 	Port                     int
 	NoBrowser                bool
+	Browser                  string
 	DevMode                  bool
 	HistoryLimit             int
 	DebugEvents              bool
@@ -167,6 +168,7 @@ func CreateServer(cfg AppConfig) *server.Server {
 		Namespace:                cfg.Namespace,
 		Port:                     cfg.Port,
 		NoBrowser:                cfg.NoBrowser,
+		Browser:                  cfg.Browser,
 		TimelineStorage:          cfg.TimelineStorage,
 		TimelineDBPath:           cfg.TimelineDBPath,
 		TimelineMaxSize:          fmt.Sprintf("%d", cfg.TimelineMaxSizeBytes),

--- a/internal/app/browser.go
+++ b/internal/app/browser.go
@@ -4,26 +4,47 @@ import (
 	"log"
 	"os/exec"
 	"runtime"
+	"strings"
 )
 
 // OpenBrowser opens the given URL in the user's default browser.
-func OpenBrowser(url string) {
-	var cmd *exec.Cmd
-
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = exec.Command("open", url)
-	case "linux":
-		cmd = exec.Command("xdg-open", url)
-	case "windows":
-		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
-	default:
+func OpenBrowser(url, preferredBrowser string) {
+	cmd := browserCommand(url, preferredBrowser, runtime.GOOS)
+	if cmd == nil {
 		log.Printf("Cannot open browser on %s, please open manually: %s", runtime.GOOS, url)
 		return
 	}
-
+	if browser := strings.TrimSpace(preferredBrowser); browser != "" {
+		log.Printf("Opening browser %q: %s", browser, url)
+	} else {
+		log.Printf("Opening browser: %s", url)
+	}
 	if err := cmd.Start(); err != nil {
 		log.Printf("Failed to open browser: %v", err)
 		log.Printf("Please open manually: %s", url)
 	}
+}
+
+func browserCommand(url, preferredBrowser, goos string) *exec.Cmd {
+	if browser := strings.TrimSpace(preferredBrowser); browser != "" {
+		if goos == "darwin" && shouldOpenMacApp(browser) {
+			return exec.Command("open", "-a", browser, url)
+		}
+		return exec.Command(browser, url)
+	}
+	switch goos {
+	case "darwin":
+		return exec.Command("open", url)
+	case "linux":
+		return exec.Command("xdg-open", url)
+	case "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		return nil
+	}
+}
+
+func shouldOpenMacApp(browser string) bool {
+	lower := strings.ToLower(browser)
+	return strings.HasSuffix(lower, ".app") || !strings.Contains(browser, "/")
 }

--- a/internal/app/browser_test.go
+++ b/internal/app/browser_test.go
@@ -1,0 +1,58 @@
+package app
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestBrowserCommandUsesPreferredBrowser(t *testing.T) {
+	cmd := browserCommand("http://localhost:9280", "firefox", "linux")
+	assertCommandArgs(t, cmd.Args, []string{"firefox", "http://localhost:9280"})
+}
+
+func TestBrowserCommandUsesMacAppLauncherForAppNames(t *testing.T) {
+	cmd := browserCommand("http://localhost:9280", "Google Chrome", "darwin")
+	assertCommandArgs(t, cmd.Args, []string{"open", "-a", "Google Chrome", "http://localhost:9280"})
+}
+
+func TestBrowserCommandUsesMacAppLauncherForAppBundles(t *testing.T) {
+	cmd := browserCommand("http://localhost:9280", "/Applications/Firefox.app", "darwin")
+	assertCommandArgs(t, cmd.Args, []string{"open", "-a", "/Applications/Firefox.app", "http://localhost:9280"})
+}
+
+func TestBrowserCommandUsesMacExecutablePathDirectly(t *testing.T) {
+	cmd := browserCommand("http://localhost:9280", "/Applications/Firefox.app/Contents/MacOS/firefox", "darwin")
+	assertCommandArgs(t, cmd.Args, []string{"/Applications/Firefox.app/Contents/MacOS/firefox", "http://localhost:9280"})
+}
+
+func TestBrowserCommandUsesOSDefaults(t *testing.T) {
+	tests := []struct {
+		name string
+		goos string
+		args []string
+	}{
+		{name: "darwin", goos: "darwin", args: []string{"open", "http://localhost:9280"}},
+		{name: "linux", goos: "linux", args: []string{"xdg-open", "http://localhost:9280"}},
+		{name: "windows", goos: "windows", args: []string{"rundll32", "url.dll,FileProtocolHandler", "http://localhost:9280"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := browserCommand("http://localhost:9280", "", tt.goos)
+			assertCommandArgs(t, cmd.Args, tt.args)
+		})
+	}
+}
+
+func TestBrowserCommandReturnsNilForUnsupportedOS(t *testing.T) {
+	if cmd := browserCommand("http://localhost:9280", "", "plan9"); cmd != nil {
+		t.Fatalf("cmd = %v, want nil", cmd)
+	}
+}
+
+func assertCommandArgs(t *testing.T, got, want []string) {
+	t.Helper()
+	if !slices.Equal(got, want) {
+		t.Fatalf("Args = %v, want %v", got, want)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Namespace         string   `json:"namespace,omitempty"`
 	Port              int      `json:"port,omitempty"`
 	NoBrowser         bool     `json:"noBrowser,omitempty"`
+	Browser           string   `json:"browser,omitempty"`
 	TimelineStorage   string   `json:"timelineStorage,omitempty"`
 	TimelineDBPath    string   `json:"timelineDbPath,omitempty"`
 	TimelineRetention string   `json:"timelineRetention,omitempty"` // Go duration (e.g. "168h" for 7d); "0" disables age cleanup

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -34,6 +34,7 @@ func TestSaveAndLoad(t *testing.T) {
 		Namespace:       "prod",
 		Port:            9999,
 		NoBrowser:       true,
+		Browser:         "firefox",
 		TimelineStorage: "sqlite",
 		HistoryLimit:    5000,
 		PrometheusURL:   "http://prom:9090",
@@ -72,6 +73,9 @@ func TestSaveAndLoad(t *testing.T) {
 	}
 	if got.NoBrowser != want.NoBrowser {
 		t.Errorf("NoBrowser = %v, want %v", got.NoBrowser, want.NoBrowser)
+	}
+	if got.Browser != want.Browser {
+		t.Errorf("Browser = %q, want %q", got.Browser, want.Browser)
 	}
 	if got.TimelineStorage != want.TimelineStorage {
 		t.Errorf("TimelineStorage = %q, want %q", got.TimelineStorage, want.TimelineStorage)

--- a/internal/server/server_smoke_test.go
+++ b/internal/server/server_smoke_test.go
@@ -1040,7 +1040,7 @@ func TestSmokeGetConfig(t *testing.T) {
 func TestSmokePutConfig(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	resp := put(t, "/api/config", `{"kubeconfig":"/tmp/test-kube","port":9999,"namespace":"staging"}`)
+	resp := put(t, "/api/config", `{"kubeconfig":"/tmp/test-kube","port":9999,"namespace":"staging","browser":"Safari"}`)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
@@ -1055,6 +1055,9 @@ func TestSmokePutConfig(t *testing.T) {
 	if saved["port"] != float64(9999) {
 		t.Errorf("port = %v, want 9999", saved["port"])
 	}
+	if saved["browser"] != "Safari" {
+		t.Errorf("browser = %v, want Safari", saved["browser"])
+	}
 
 	// Verify persisted via GET
 	var got map[string]any
@@ -1062,6 +1065,9 @@ func TestSmokePutConfig(t *testing.T) {
 	file, _ := got["file"].(map[string]any)
 	if file["kubeconfig"] != "/tmp/test-kube" {
 		t.Errorf("persisted kubeconfig = %v", file["kubeconfig"])
+	}
+	if file["browser"] != "Safari" {
+		t.Errorf("persisted browser = %v", file["browser"])
 	}
 }
 

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -6,6 +6,8 @@ import { useAnimatedUnmount } from '../../hooks/useAnimatedUnmount'
 import { TRANSITION_BACKDROP, TRANSITION_PANEL } from '../../utils/animation'
 import { apiUrl, getAuthHeaders, getCredentialsMode } from '../../api/config'
 import { useCloudRole } from '../../api/client'
+import { useCapabilitiesContext } from '../../contexts/CapabilitiesContext'
+import type { DeploymentMode } from '../../types'
 
 interface Config {
   kubeconfig?: string
@@ -13,6 +15,7 @@ interface Config {
   namespace?: string
   port?: number
   noBrowser?: boolean
+  browser?: string
   timelineStorage?: 'memory' | 'sqlite'
   timelineDbPath?: string
   historyLimit?: number
@@ -41,6 +44,7 @@ export function SettingsDialog({ open, onClose, onShowMyPermissions }: SettingsD
   // (OSS, OIDC, kubectl plugin) have no role and pass — single-user laptops
   // are never locked out of their own config. Backend enforces this too.
   const { canAtLeast } = useCloudRole()
+  const capabilities = useCapabilitiesContext()
   const canEditConfig = canAtLeast('owner')
   const [configData, setConfigData] = useState<ConfigResponse | null>(null)
   const [editedConfig, setEditedConfig] = useState<Config>({})
@@ -130,6 +134,7 @@ export function SettingsDialog({ open, onClose, onShowMyPermissions }: SettingsD
   if (!shouldRender) return null
 
   const isDesktop = configData?.isDesktop ?? false
+  const deploymentMode = capabilities.deployment?.mode ?? 'local'
 
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center">
@@ -205,6 +210,7 @@ export function SettingsDialog({ open, onClose, onShowMyPermissions }: SettingsD
               config={editedConfig}
               effectiveConfig={configData?.effective}
               isDesktop={isDesktop}
+              deploymentMode={deploymentMode}
               onChange={updateConfigField}
             />
           ) : (
@@ -278,13 +284,16 @@ function StartupConfigTab({
   config,
   effectiveConfig,
   isDesktop,
+  deploymentMode,
   onChange,
 }: {
   config: Config
   effectiveConfig?: Config
   isDesktop: boolean
+  deploymentMode: DeploymentMode
   onChange: <K extends keyof Config>(field: K, value: Config[K]) => void
 }) {
+  const showBrowserLaunchControls = !isDesktop && deploymentMode === 'local'
   return (
     <div className="space-y-4">
       <p className="text-xs text-theme-text-tertiary">
@@ -332,12 +341,23 @@ function StartupConfigTab({
         onChange={(v) => onChange('port', v)}
       />
 
-      {!isDesktop && (
-        <ConfigToggle
-          label="Open browser on start"
-          value={!(config.noBrowser ?? false)}
-          onChange={(v) => onChange('noBrowser', !v ? true : undefined)}
-        />
+      {showBrowserLaunchControls && (
+        <>
+          <ConfigToggle
+            label="Open browser on start"
+            value={!(config.noBrowser ?? false)}
+            onChange={(v) => onChange('noBrowser', !v ? true : undefined)}
+          />
+
+          <ConfigField
+            label="Browser"
+            help="Browser for automatic launch; macOS app names are supported"
+            value={config.browser ?? ''}
+            effectiveValue={effectiveConfig?.browser}
+            placeholder="System default"
+            onChange={(v) => onChange('browser', v || undefined)}
+          />
+        </>
       )}
 
       <div className="border-t border-theme-border pt-4 mt-4">


### PR DESCRIPTION
Prompted by https://github.com/skyhook-io/radar/discussions/611.

Adds a configurable browser selector for Radar's automatic UI launch, covering local users whose desktop defaults or xdg-open setup do not open the desired browser.

The new --browser flag and persisted browser config field override the OS default launcher while preserving existing behavior when unset. On macOS, app names and .app bundles use open -a, so local testing can use --browser Safari or --browser "Google Chrome". The Settings dialog shows this control only for local non-desktop runs; in-cluster and Cloud installs do not show it because the server pod cannot open a user browser.

Updated README, configuration docs, and Krew copy. Validated with go test ./cmd/explorer ./internal/app ./internal/config, go test ./internal/server -run TestSmokePutConfig, and npx tsc --noEmit.