### PR TITLE
Track admission webhook configs in the change feed

### DIFF
--- a/internal/k8s/dynamic_cache.go
+++ b/internal/k8s/dynamic_cache.go
@@ -158,6 +158,13 @@ var supportedCRDFallbacks = []supportedCRDResource{
 	{Group: "notification.toolkit.fluxcd.io", Versions: []string{"v1beta3", "v1beta2"}, Resource: "alerts", Kind: "Alert", Namespaced: true},
 	{Group: "apiregistration.k8s.io", Versions: []string{"v1"}, Resource: "apiservices", Kind: "APIService", Namespaced: false},
 	{Group: "apiextensions.k8s.io", Versions: []string{"v1"}, Resource: "customresourcedefinitions", Kind: "CustomResourceDefinition", Namespaced: false},
+	// Admission webhook configs gate or silently rewrite admission for every
+	// matching resource — high blast radius, cluster-scoped, very low churn.
+	// Watched so a webhook appearing/changing shortly before failures surfaces
+	// in get_changes (a mutating webhook that rewrites a field leaves no event
+	// trail otherwise — see classifyAdmissionFailure, which only sees denials).
+	{Group: "admissionregistration.k8s.io", Versions: []string{"v1"}, Resource: "mutatingwebhookconfigurations", Kind: "MutatingWebhookConfiguration", Namespaced: false},
+	{Group: "admissionregistration.k8s.io", Versions: []string{"v1"}, Resource: "validatingwebhookconfigurations", Kind: "ValidatingWebhookConfiguration", Namespaced: false},
 	{Group: "gateway.networking.k8s.io", Versions: []string{"v1", "v1beta1"}, Resource: "gatewayclasses", Kind: "GatewayClass", Namespaced: false},
 	{Group: "gateway.networking.k8s.io", Versions: []string{"v1", "v1beta1"}, Resource: "gateways", Kind: "Gateway", Namespaced: true},
 	{Group: "gateway.networking.k8s.io", Versions: []string{"v1", "v1beta1"}, Resource: "httproutes", Kind: "HTTPRoute", Namespaced: true},

--- a/internal/k8s/history.go
+++ b/internal/k8s/history.go
@@ -1,6 +1,8 @@
 package k8s
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -36,33 +38,35 @@ type kindDiffFunc func(oldObj, newObj any) ([]FieldChange, []string)
 // status field a user would care about, because for kinds in this map,
 // recordToTimelineStore drops update events when the diff is empty.
 var diffFunctions = map[string]kindDiffFunc{
-	"Deployment":              diffDeployment,
-	"Pod":                     diffPod,
-	"Service":                 diffService,
-	"ConfigMap":               diffConfigMap,
-	"Ingress":                 diffIngress,
-	"ReplicaSet":              diffReplicaSet,
-	"DaemonSet":               diffDaemonSet,
-	"StatefulSet":             diffStatefulSet,
-	"HorizontalPodAutoscaler": diffHPA,
-	"Job":                     diffJob,
-	"Node":                    diffNode,
-	"PersistentVolumeClaim":   diffPVC,
-	"Application":             diffApplication,
-	"Kustomization":           diffKustomization,
-	"HelmRelease":             diffFluxHelmRelease,
-	"GitRepository":           func(o, n any) ([]FieldChange, []string) { return diffFluxSource(o, n, "GitRepository") },
-	"OCIRepository":           func(o, n any) ([]FieldChange, []string) { return diffFluxSource(o, n, "OCIRepository") },
-	"HelmRepository":          func(o, n any) ([]FieldChange, []string) { return diffFluxSource(o, n, "HelmRepository") },
-	"Gateway":                 diffGateway,
-	"GatewayClass":            diffGatewayClass,
-	"HTTPRoute":               diffGatewayRoute,
-	"GRPCRoute":               diffGatewayRoute,
-	"TCPRoute":                diffGatewayRoute,
-	"TLSRoute":                diffGatewayRoute,
-	"ReferenceGrant":          diffReferenceGrant,
-	"ResourceQuota":           diffResourceQuota,
-	"LimitRange":              diffLimitRange,
+	"Deployment":                     diffDeployment,
+	"Pod":                            diffPod,
+	"Service":                        diffService,
+	"ConfigMap":                      diffConfigMap,
+	"Ingress":                        diffIngress,
+	"ReplicaSet":                     diffReplicaSet,
+	"DaemonSet":                      diffDaemonSet,
+	"StatefulSet":                    diffStatefulSet,
+	"HorizontalPodAutoscaler":        diffHPA,
+	"Job":                            diffJob,
+	"Node":                           diffNode,
+	"PersistentVolumeClaim":          diffPVC,
+	"Application":                    diffApplication,
+	"Kustomization":                  diffKustomization,
+	"HelmRelease":                    diffFluxHelmRelease,
+	"GitRepository":                  func(o, n any) ([]FieldChange, []string) { return diffFluxSource(o, n, "GitRepository") },
+	"OCIRepository":                  func(o, n any) ([]FieldChange, []string) { return diffFluxSource(o, n, "OCIRepository") },
+	"HelmRepository":                 func(o, n any) ([]FieldChange, []string) { return diffFluxSource(o, n, "HelmRepository") },
+	"Gateway":                        diffGateway,
+	"GatewayClass":                   diffGatewayClass,
+	"HTTPRoute":                      diffGatewayRoute,
+	"GRPCRoute":                      diffGatewayRoute,
+	"TCPRoute":                       diffGatewayRoute,
+	"TLSRoute":                       diffGatewayRoute,
+	"ReferenceGrant":                 diffReferenceGrant,
+	"ResourceQuota":                  diffResourceQuota,
+	"LimitRange":                     diffLimitRange,
+	"MutatingWebhookConfiguration":   diffAdmissionWebhookConfiguration,
+	"ValidatingWebhookConfiguration": diffAdmissionWebhookConfiguration,
 }
 
 // ComputeDiff computes the diff between old and new objects based on kind.
@@ -716,6 +720,196 @@ func limitRangeItemRefs(items []corev1.LimitRangeItem) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// diffAdmissionWebhookConfiguration surfaces changes to Mutating/Validating
+// webhook configurations — high-blast-radius cluster objects that gate or
+// silently rewrite admission for every matching resource. Per-webhook it
+// tracks failurePolicy, the backend (service ref or url), the CA bundle
+// presence/size, the operation/resource rules, and sideEffects. The caBundle
+// bytes are NEVER emitted — only its length, so a cert rotation shows as a
+// size change without leaking the cert. Keyed by webhook name so a webhook
+// added / removed / changed are distinct entries.
+func diffAdmissionWebhookConfiguration(oldObj, newObj any) ([]FieldChange, []string) {
+	oldU, newU, ok := unstructuredPair(oldObj, newObj)
+	if !ok {
+		warnUnstructuredAssertFailed("AdmissionWebhookConfiguration", oldObj)
+		return nil, nil
+	}
+
+	oldHooks := indexWebhooksByName(oldU)
+	newHooks := indexWebhooksByName(newU)
+
+	names := map[string]struct{}{}
+	for n := range oldHooks {
+		names[n] = struct{}{}
+	}
+	for n := range newHooks {
+		names[n] = struct{}{}
+	}
+	sorted := make([]string, 0, len(names))
+	for n := range names {
+		sorted = append(sorted, n)
+	}
+	sort.Strings(sorted)
+
+	var changes []FieldChange
+	var summary []string
+	for _, name := range sorted {
+		oldS, oldOK := oldHooks[name]
+		newS, newOK := newHooks[name]
+		if oldOK && newOK && oldS == newS {
+			continue
+		}
+		changes = append(changes, FieldChange{
+			Path:     "webhooks[" + name + "]",
+			OldValue: valueOrNil(oldS, oldOK),
+			NewValue: valueOrNil(newS, newOK),
+		})
+		switch {
+		case !oldOK:
+			summary = append(summary, "webhook "+name+" added")
+		case !newOK:
+			summary = append(summary, "webhook "+name+" removed")
+		default:
+			summary = append(summary, "webhook "+name+" changed")
+		}
+	}
+	return changes, summary
+}
+
+// indexWebhooksByName maps each webhook's name to a compact, comparable summary
+// of the fields that matter for diagnosis. Unnamed entries are skipped.
+func indexWebhooksByName(u *unstructured.Unstructured) map[string]string {
+	out := map[string]string{}
+	hooks, _, _ := unstructured.NestedSlice(u.Object, "webhooks")
+	for _, h := range hooks {
+		hm, ok := h.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _, _ := unstructured.NestedString(hm, "name")
+		if name == "" {
+			continue
+		}
+		out[name] = webhookSummary(hm)
+	}
+	return out
+}
+
+func webhookSummary(hm map[string]any) string {
+	var parts []string
+	if fp, ok, _ := unstructured.NestedString(hm, "failurePolicy"); ok {
+		parts = append(parts, "failurePolicy="+fp)
+	}
+	// Backend: a Service ref or a raw URL — both decide where admission calls go.
+	if svcName, ok, _ := unstructured.NestedString(hm, "clientConfig", "service", "name"); ok {
+		svcNS, _, _ := unstructured.NestedString(hm, "clientConfig", "service", "namespace")
+		backend := "service=" + svcNS + "/" + svcName
+		if port, ok, _ := unstructured.NestedInt64(hm, "clientConfig", "service", "port"); ok && port != 0 {
+			backend += fmt.Sprintf(":%d", port)
+		}
+		if path, ok, _ := unstructured.NestedString(hm, "clientConfig", "service", "path"); ok && path != "" {
+			backend += path
+		}
+		parts = append(parts, backend)
+	} else if url, ok, _ := unstructured.NestedString(hm, "clientConfig", "url"); ok {
+		parts = append(parts, "url="+url)
+	}
+	// CA bundle: a short non-reversible digest, NEVER the bytes. The digest (not
+	// length) catches a same-length cert rotation — the expired_tls/tls_mismatch
+	// fault class. The bundle is a public CA cert, so the digest leaks nothing.
+	if ca, ok, _ := unstructured.NestedString(hm, "clientConfig", "caBundle"); ok && ca != "" {
+		sum := sha256.Sum256([]byte(ca))
+		parts = append(parts, "caBundle=sha256:"+hex.EncodeToString(sum[:])[:12])
+	} else {
+		parts = append(parts, "caBundle=none")
+	}
+	if se, ok, _ := unstructured.NestedString(hm, "sideEffects"); ok {
+		parts = append(parts, "sideEffects="+se)
+	}
+	// matchPolicy/timeoutSeconds/reinvocationPolicy each change how/when the
+	// webhook fires; the drop-empty contract means an omitted field that changes
+	// alone would vanish from the feed, so summarize them.
+	if mp, ok, _ := unstructured.NestedString(hm, "matchPolicy"); ok {
+		parts = append(parts, "matchPolicy="+mp)
+	}
+	if to, ok, _ := unstructured.NestedInt64(hm, "timeoutSeconds"); ok {
+		parts = append(parts, fmt.Sprintf("timeoutSeconds=%d", to))
+	}
+	if rp, ok, _ := unstructured.NestedString(hm, "reinvocationPolicy"); ok {
+		parts = append(parts, "reinvocationPolicy="+rp)
+	}
+	// Selectors are the webhook's blast radius — a re-scoping change (e.g. now
+	// matching the prod namespace) must register. Without these, a selector-only
+	// update would diff empty and recordToTimelineStore would silently drop it.
+	if ns := webhookSelectorSummary(hm, "namespaceSelector"); ns != "" {
+		parts = append(parts, "namespaceSelector={"+ns+"}")
+	}
+	if objSel := webhookSelectorSummary(hm, "objectSelector"); objSel != "" {
+		parts = append(parts, "objectSelector={"+objSel+"}")
+	}
+	parts = append(parts, "rules="+webhookRulesSummary(hm))
+	return strings.Join(parts, " ")
+}
+
+// webhookSelectorSummary renders a namespaceSelector/objectSelector compactly as
+// sorted matchLabels + matchExpressions. Empty (match-everything) selector → "".
+func webhookSelectorSummary(hm map[string]any, field string) string {
+	matchLabels, _, _ := unstructured.NestedStringMap(hm, field, "matchLabels")
+	exprs, _, _ := unstructured.NestedSlice(hm, field, "matchExpressions")
+	if len(matchLabels) == 0 && len(exprs) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(matchLabels))
+	for k := range matchLabels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys)+len(exprs))
+	for _, k := range keys {
+		parts = append(parts, k+"="+matchLabels[k])
+	}
+	exprStrs := make([]string, 0, len(exprs))
+	for _, e := range exprs {
+		em, ok := e.(map[string]any)
+		if !ok {
+			continue
+		}
+		key, _, _ := unstructured.NestedString(em, "key")
+		op, _, _ := unstructured.NestedString(em, "operator")
+		vals, _, _ := unstructured.NestedStringSlice(em, "values")
+		exprStrs = append(exprStrs, key+" "+op+" ["+strings.Join(vals, ",")+"]")
+	}
+	sort.Strings(exprStrs)
+	parts = append(parts, exprStrs...)
+	return strings.Join(parts, ",")
+}
+
+func webhookRulesSummary(hm map[string]any) string {
+	rules, _, _ := unstructured.NestedSlice(hm, "rules")
+	var out []string
+	for _, r := range rules {
+		rm, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		ops, _, _ := unstructured.NestedStringSlice(rm, "operations")
+		groups, _, _ := unstructured.NestedStringSlice(rm, "apiGroups")
+		versions, _, _ := unstructured.NestedStringSlice(rm, "apiVersions")
+		res, _, _ := unstructured.NestedStringSlice(rm, "resources")
+		// apiGroups/apiVersions/scope are part of the rule's match set — two
+		// rules differing only in apiGroup target different resources, so the
+		// full tuple must round-trip (resources alone would conflate them).
+		entry := strings.Join(ops, "/") + ":" +
+			strings.Join(groups, ",") + "/" + strings.Join(versions, ",") + "/" + strings.Join(res, ",")
+		if scope, ok, _ := unstructured.NestedString(rm, "scope"); ok && scope != "" {
+			entry += "[" + scope + "]"
+		}
+		out = append(out, entry)
+	}
+	sort.Strings(out)
+	return strings.Join(out, ";")
 }
 
 func diffConfigMap(oldObj, newObj any) ([]FieldChange, []string) {

--- a/internal/k8s/history_diff_test.go
+++ b/internal/k8s/history_diff_test.go
@@ -1,12 +1,14 @@
 package k8s
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -289,5 +291,105 @@ func TestDiffLimitRange_ItemChanges(t *testing.T) {
 	}
 	if c, _ := diffLimitRange(mk("1Gi"), mk("1Gi")); len(c) != 0 {
 		t.Fatalf("identical LimitRanges produced a diff: %+v", c)
+	}
+}
+
+func TestDiffAdmissionWebhookConfiguration(t *testing.T) {
+	// caBundle bytes are a long base64 blob; the differ must show its LENGTH,
+	// never the bytes, and a rotation must register as a change.
+	const caV1 = "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVowMTIzNDU2Nzg5"         // 48 chars
+	const caV2 = "WllYV1ZVVFNSUVBPTk1MS0pJSEdGRURDQkE5ODc2NTQzMjEwemFiY2Q=" // 56 chars
+
+	mk := func(failurePolicy, ca string) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "admissionregistration.k8s.io/v1",
+			"kind":       "ValidatingWebhookConfiguration",
+			"metadata":   map[string]any{"name": "pod-policy"},
+			"webhooks": []any{map[string]any{
+				"name":          "pod-policy.validation.k8s.io",
+				"failurePolicy": failurePolicy,
+				"sideEffects":   "None",
+				"clientConfig": map[string]any{
+					"caBundle": ca,
+					"service": map[string]any{
+						"namespace": "policy-system", "name": "pod-policy-webhook", "path": "/validate",
+					},
+				},
+				"rules": []any{map[string]any{
+					"operations": []any{"CREATE", "UPDATE"},
+					"resources":  []any{"pods"},
+				}},
+			}},
+		}}
+	}
+
+	// A caBundle rotation (the tls_mismatch fault class) registers as a change.
+	changes, summary := diffAdmissionWebhookConfiguration(mk("Fail", caV1), mk("Fail", caV2))
+	if len(changes) != 1 || changes[0].Path != "webhooks[pod-policy.validation.k8s.io]" {
+		t.Fatalf("caBundle rotation: changes = %+v", changes)
+	}
+	if !strings.Contains(strings.Join(summary, "; "), "changed") {
+		t.Fatalf("caBundle rotation: summary = %q", summary)
+	}
+	// SECURITY: the cert bytes must never appear — only a digest.
+	rendered := fmt.Sprintf("%v", changes)
+	if strings.Contains(rendered, caV1) || strings.Contains(rendered, caV2) {
+		t.Fatalf("caBundle bytes leaked into the diff: %s", rendered)
+	}
+	if !strings.Contains(rendered, "caBundle=sha256:") {
+		t.Fatalf("caBundle digest missing from diff: %s", rendered)
+	}
+
+	// A same-LENGTH rotation (different CA, identical base64 length) must still
+	// register — a length-only signal would miss it.
+	caSameLenA := strings.Repeat("A", 64)
+	caSameLenB := strings.Repeat("B", 64)
+	if c, _ := diffAdmissionWebhookConfiguration(mk("Fail", caSameLenA), mk("Fail", caSameLenB)); len(c) != 1 {
+		t.Fatalf("same-length caBundle rotation must register a change, got %+v", c)
+	}
+
+	// failurePolicy Ignore→Fail (turns a soft webhook into a hard gate).
+	if c, s := diffAdmissionWebhookConfiguration(mk("Ignore", caV1), mk("Fail", caV1)); len(c) != 1 || !strings.Contains(strings.Join(s, ";"), "changed") {
+		t.Fatalf("failurePolicy flip: changes=%+v summary=%v", c, s)
+	}
+
+	// Identical configs produce no diff (no timeline spam on no-op resyncs).
+	if c, _ := diffAdmissionWebhookConfiguration(mk("Fail", caV1), mk("Fail", caV1)); len(c) != 0 {
+		t.Fatalf("identical webhook configs produced a diff: %+v", c)
+	}
+
+	// A webhook appearing is its own add entry.
+	empty := &unstructured.Unstructured{Object: map[string]any{"webhooks": []any{}}}
+	c, s := diffAdmissionWebhookConfiguration(empty, mk("Fail", caV1))
+	if len(c) != 1 || !strings.Contains(strings.Join(s, ";"), "added") {
+		t.Fatalf("webhook add: changes=%+v summary=%v", c, s)
+	}
+}
+
+// A namespaceSelector re-scoping (match-everything → match prod) re-targets the
+// webhook's blast radius and MUST register — otherwise the selector-only update
+// diffs empty and recordToTimelineStore drops it silently.
+func TestDiffAdmissionWebhookConfiguration_SelectorRescope(t *testing.T) {
+	mk := func(withSelector bool) *unstructured.Unstructured {
+		hook := map[string]any{
+			"name":         "pod-policy.validation.k8s.io",
+			"clientConfig": map[string]any{"caBundle": "QUJD"},
+		}
+		if withSelector {
+			hook["namespaceSelector"] = map[string]any{
+				"matchLabels": map[string]any{"env": "prod"},
+			}
+		}
+		return &unstructured.Unstructured{Object: map[string]any{"webhooks": []any{hook}}}
+	}
+	changes, summary := diffAdmissionWebhookConfiguration(mk(false), mk(true))
+	if len(changes) != 1 {
+		t.Fatalf("selector rescope must register a change, got %+v", changes)
+	}
+	if rendered := fmt.Sprintf("%v", changes); !strings.Contains(rendered, "env=prod") {
+		t.Fatalf("new selector missing from diff: %s", rendered)
+	}
+	if !strings.Contains(strings.Join(summary, ";"), "changed") {
+		t.Fatalf("selector rescope summary = %v", summary)
 	}
 }

--- a/internal/k8s/recreate_stash.go
+++ b/internal/k8s/recreate_stash.go
@@ -47,6 +47,10 @@ var recreateStashKinds = map[string]bool{
 	"GitRepository":           true,
 	"OCIRepository":           true,
 	"HelmRepository":          true,
+	// Operators frequently delete+recreate webhook configs (cert rotation,
+	// re-registration); the join reconstructs the cross-recreate spec diff.
+	"MutatingWebhookConfiguration":   true,
+	"ValidatingWebhookConfiguration": true,
 }
 
 // RecreateJoinKind reports whether deletes of this kind are stashed for

--- a/internal/mcp/changes_rbac_test.go
+++ b/internal/mcp/changes_rbac_test.go
@@ -1,0 +1,51 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/skyhook-io/radar/pkg/issuesapi"
+)
+
+// The change feed must not become a side channel around the per-kind
+// cluster-scoped SAR that gates every other read: a cluster-wide user without
+// RBAC for admission webhook configs must not see them via get_changes, while
+// namespaced changes and full-access (no per-user RBAC) are unaffected.
+func TestFilterChangesByClusterScopedRBAC(t *testing.T) {
+	changes := []issuesapi.RecentChange{
+		{Kind: "MutatingWebhookConfiguration", Name: "pod-policy"}, // cluster-scoped
+		{Kind: "Deployment", Namespace: "shop", Name: "web"},       // namespaced
+	}
+	has := func(got []issuesapi.RecentChange, kind string) bool {
+		for _, c := range got {
+			if c.Kind == kind {
+				return true
+			}
+		}
+		return false
+	}
+
+	// No per-user RBAC on context (radar-SA / benchmark): nothing is filtered.
+	if got := filterChangesByClusterScopedRBAC(context.Background(), append([]issuesapi.RecentChange(nil), changes...)); len(got) != 2 {
+		t.Fatalf("no-user context must keep all changes, got %+v", got)
+	}
+
+	// Cluster-wide user WITHOUT webhook RBAC: the webhook change is dropped (the
+	// seeded SAR cache has no grant → canReadClusterScopedKind fails closed),
+	// the namespaced change is kept (gated by namespace, not this check).
+	denied := withClusterAdmin(t, "no-webhook-rbac")
+	got := filterChangesByClusterScopedRBAC(denied, append([]issuesapi.RecentChange(nil), changes...))
+	if has(got, "MutatingWebhookConfiguration") {
+		t.Fatalf("cluster-scoped webhook change leaked to a user without RBAC: %+v", got)
+	}
+	if !has(got, "Deployment") {
+		t.Fatalf("namespaced change must survive the cluster-scoped filter: %+v", got)
+	}
+
+	// Same user, now granted webhook read: the webhook change is returned.
+	granted := withClusterAdmin(t, "has-webhook-rbac")
+	grantClusterRead(t, "has-webhook-rbac", "admissionregistration.k8s.io/mutatingwebhookconfigurations")
+	if got := filterChangesByClusterScopedRBAC(granted, append([]issuesapi.RecentChange(nil), changes...)); !has(got, "MutatingWebhookConfiguration") {
+		t.Fatalf("granted user must see the webhook change, got %+v", got)
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1168,6 +1168,24 @@ func isPodKind(kind string) bool {
 	return kind == "pod" || kind == "pods"
 }
 
+// filterChangesByClusterScopedRBAC drops change entries for cluster-scoped
+// kinds the user lacks RBAC to read. The change feed namespace-filters but did
+// not honor per-kind cluster-scoped RBAC — fine while every tracked kind was
+// namespaced, but now that cluster-scoped kinds (admission webhook configs) are
+// in the feed it would be a side channel around the SAR that gates every other
+// read. No-op when no per-user RBAC is on context: canReadClusterScopedKind
+// returns true (the radar-SA / benchmark case), and it short-circuits true for
+// namespaced kinds, so only cluster-scoped denials are dropped.
+func filterChangesByClusterScopedRBAC(ctx context.Context, changes []issuesapi.RecentChange) []issuesapi.RecentChange {
+	filtered := changes[:0]
+	for _, c := range changes {
+		if canReadClusterScopedKind(ctx, c.Kind, "", "list") {
+			filtered = append(filtered, c)
+		}
+	}
+	return filtered
+}
+
 func handleGetChanges(ctx context.Context, req *mcp.CallToolRequest, input getChangesInput) (*mcp.CallToolResult, any, error) {
 	since := 1 * time.Hour
 	if input.Since != "" {
@@ -1216,6 +1234,7 @@ func handleGetChanges(ctx context.Context, req *mcp.CallToolRequest, input getCh
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to query timeline: %w", err)
 	}
+	changes = filterChangesByClusterScopedRBAC(ctx, changes)
 
 	// Always wrap so capped + uncapped agree on wire shape
 	// ({changes: [...], narrowHint?: "..."}).

--- a/internal/meaningfulchanges/meaningfulchanges.go
+++ b/internal/meaningfulchanges/meaningfulchanges.go
@@ -38,6 +38,10 @@ var (
 		"HorizontalPodAutoscaler", "Application", "Kustomization", "HelmRelease",
 		"GitRepository", "OCIRepository", "HelmRepository",
 		"ResourceQuota", "LimitRange",
+		// Cluster-scoped (namespace==""), so they surface in a cluster-wide
+		// get_changes, not in a single-namespace query — correct, since one
+		// webhook config gates admission across all namespaces.
+		"MutatingWebhookConfiguration", "ValidatingWebhookConfiguration",
 	}
 	// lifecycleOnlyKinds surface ONLY their delete events (name-only — never
 	// data). A deleted Secret breaks every consumer with zero K8s symptom on
@@ -516,7 +520,10 @@ func classify(e timeline.TimelineEvent) (issuesapi.ChangeCategory, string) {
 }
 
 func hasSpecConfigField(e timeline.TimelineEvent) bool {
-	if isConfigKind(e.Kind) {
+	// ConfigMap data and admission webhook configs hold their configuration at
+	// the top level (data / webhooks[]), not under spec. — the path-prefix
+	// heuristic below would drop their (curated, status-free) diffs entirely.
+	if isConfigKind(e.Kind) || isWebhookConfigKind(e.Kind) {
 		return true
 	}
 	for _, f := range e.Diff.Fields {
@@ -634,6 +641,13 @@ func dedupeEvents(events []timeline.TimelineEvent) []timeline.TimelineEvent {
 
 func isConfigKind(kind string) bool { return kind == "ConfigMap" }
 
+// isWebhookConfigKind reports admission webhook configuration kinds. Their
+// config lives at top-level webhooks[] with no status subresource, so every
+// tracked diff is a configuration change.
+func isWebhookConfigKind(kind string) bool {
+	return kind == "MutatingWebhookConfiguration" || kind == "ValidatingWebhookConfiguration"
+}
+
 func isLifecycleOnlyKind(kind string) bool {
 	for _, item := range lifecycleOnlyKinds {
 		if kind == item {
@@ -722,6 +736,10 @@ func canonicalKind(kind string) string {
 		return "NetworkPolicy"
 	case "poddisruptionbudget", "poddisruptionbudgets", "pdb":
 		return "PodDisruptionBudget"
+	case "mutatingwebhookconfiguration", "mutatingwebhookconfigurations":
+		return "MutatingWebhookConfiguration"
+	case "validatingwebhookconfiguration", "validatingwebhookconfigurations":
+		return "ValidatingWebhookConfiguration"
 	case "httproute", "httproutes":
 		return "HTTPRoute"
 	case "grpcroute", "grpcroutes":

--- a/internal/meaningfulchanges/meaningfulchanges_test.go
+++ b/internal/meaningfulchanges/meaningfulchanges_test.go
@@ -119,6 +119,46 @@ func TestRecentRanksSpecConfigAboveStatusChurn(t *testing.T) {
 	}
 }
 
+// A webhook config UPDATE must reach the feed classified as spec_config. The
+// differ emits top-level webhooks[...] paths (webhook configs have no spec.),
+// so without isWebhookConfigKind in hasSpecConfigField, classify would return
+// "" and rankedChanges would drop the change — silently no-op'ing the feature
+// for its main case. Cluster-scoped (namespace==""), so query cluster-wide.
+func TestRecentSurfacesWebhookConfigUpdate(t *testing.T) {
+	timeline.ResetStore()
+	t.Cleanup(timeline.ResetStore)
+	if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 10}); err != nil {
+		t.Fatalf("InitStore: %v", err)
+	}
+	store := timeline.GetStore()
+	if err := store.Append(context.Background(), timeline.TimelineEvent{
+		ID:             "wh-update",
+		Timestamp:      time.Now(),
+		Source:         timeline.SourceInformer,
+		ClusterContext: k8s.ActiveClusterContext(),
+		Kind:           "MutatingWebhookConfiguration",
+		Name:           "pod-policy",
+		EventType:      timeline.EventTypeUpdate,
+		Diff: &timeline.DiffInfo{
+			Fields:  []timeline.FieldChange{{Path: "webhooks[pod-policy.k8s.io]", OldValue: "failurePolicy=Ignore", NewValue: "failurePolicy=Fail"}},
+			Summary: "webhook pod-policy.k8s.io changed",
+		},
+	}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	changes, _, err := Recent(context.Background(), Query{Limit: 5})
+	if err != nil {
+		t.Fatalf("Recent: %v", err)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("changes = %d, want the webhook update: %+v", len(changes), changes)
+	}
+	if changes[0].Kind != "MutatingWebhookConfiguration" || changes[0].ChangeCategory != issuesapi.ChangeCategorySpecConfig {
+		t.Fatalf("webhook update misclassified: %+v", changes[0])
+	}
+}
+
 // A Service delete followed by a burst of status-churn updates must still
 // surface: lifecycle events are fetched in a query of their own, so the
 // newest-N candidate window for updates cannot starve them out before

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2409,8 +2409,27 @@ func (s *Server) handleChanges(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	events = s.filterChangesByClusterScopedRBAC(r, events)
 
 	s.writeJSON(w, events)
+}
+
+// filterChangesByClusterScopedRBAC drops timeline events for cluster-scoped
+// kinds the user lacks RBAC to read. Namespace-restricted users never reach
+// cluster-scoped events (namespace IN(...) excludes namespace==""), but a
+// cluster-wide user with no per-kind RBAC for, say, admission webhook configs
+// (now tracked) would otherwise see them here — a side channel around the SAR
+// that gates every other read. canRead memoizes per request, so the per-event
+// check is cheap and only fires for cluster-scoped kinds.
+func (s *Server) filterChangesByClusterScopedRBAC(r *http.Request, events []timeline.TimelineEvent) []timeline.TimelineEvent {
+	filtered := events[:0]
+	for _, e := range events {
+		if clusterScoped, group, resource := k8s.ClassifyKindScope(e.Kind, ""); clusterScoped && !s.canRead(r, group, resource, "", "list") {
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+	return filtered
 }
 
 // handleChangeChildren returns child resource changes for a given parent workload


### PR DESCRIPTION
## Summary

`MutatingWebhookConfiguration` / `ValidatingWebhookConfiguration` gate or silently rewrite admission for every matching resource, but radar never watched them. A mutating webhook that rewrites a field leaves no event trail (`classifyAdmissionFailure` only catches *denials*), so the change was invisible in `get_changes` — a real blind spot surfaced by SREGym batch6 transcript analysis.

This watches both kinds via the dynamic cache, adds them to the meaningful-changes `specKinds` and the recreate-join stash, and gives them a dedicated differ.

## What the differ surfaces

Per webhook, every field that decides whether/where it fires: `failurePolicy`, backend (service `ns/name:port/path` or `url`), rules (`operations` + `apiGroups/apiVersions/resources/scope`), `namespaceSelector`, `objectSelector`, `matchPolicy`, `timeoutSeconds`, `sideEffects`, `reinvocationPolicy`. The `caBundle` is reduced to a short `sha256` digest — never the bytes — which still catches a same-length cert rotation (the expired-TLS / TLS-mismatch fault class) without leaking the cert.

Coverage is deliberately comprehensive because kinds in `diffFunctions` drop empty-diff updates: any unsummarized field that changed alone would silently vanish from the feed.

## RBAC

These are the first cluster-scoped kinds in the change feed, which previously only namespace-filtered. Both change surfaces (MCP `get_changes`, server `/api/changes`) now gate cluster-scoped entries behind the same per-kind `SubjectAccessReview` that gates every other read, so the feed can't become a side channel. No-op for the radar-SA / full-access case; namespace-restricted users were already safe (the `namespace IN (...)` filter excludes cluster-scoped events).

Cluster-scoped, so webhook changes surface in a cluster-wide `get_changes`, not single-namespace queries (one webhook config spans all namespaces). Surfacing them in namespace-scoped feeds, mapped by `namespaceSelector`/rules, is deferred as a follow-up.

## Tests

New differ tests (caBundle rotation incl. same-length, selector re-scope, add, no-op) with an explicit assertion that cert bytes never leak; a change-feed RBAC regression test (cluster-wide user without webhook RBAC doesn't see webhook changes; granted user does). `go build`, `go vet`, and the `internal/k8s`, `internal/meaningfulchanges`, `internal/mcp`, `internal/server` suites pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster-wide admission configuration visibility and RBAC on the change feed; behavior is gated and tested, but mis-filtering could hide or leak high-blast-radius webhook changes.
> 
> **Overview**
> **Admission webhook configurations** (`MutatingWebhookConfiguration` / `ValidatingWebhookConfiguration`) are now watched in the dynamic cache and included in meaningful changes, recreate-join stash, and audited timeline diffs—so cert rotations, policy flips, and selector rescopes show up in `get_changes` even when mutating webhooks leave no denial events.
> 
> A new **`diffAdmissionWebhookConfiguration`** summarizes per-webhook changes (failure policy, backend, rules, selectors, etc.) and represents **`caBundle` as a short SHA-256 digest**, never raw cert bytes.
> 
> Because these are the **first cluster-scoped kinds** in the change feed, **MCP `get_changes` and the server changes API** now drop cluster-scoped entries when the user lacks per-kind list RBAC (same SAR model as other reads). Webhook updates are classified as **`spec_config`** via `isWebhookConfigKind` so top-level `webhooks[...]` diffs are not dropped by the `spec.` path heuristic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bcbbd1cf44fbf2cb58e2e0677ab8f1e3701d993. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->