### PR TITLE
Detect eventless post-bind startup stalls

### DIFF
--- a/internal/issues/category.go
+++ b/internal/issues/category.go
@@ -41,7 +41,7 @@ func Classify(in classifyInput) issuesapi.Category {
 			return issuesapi.CategoryAdmissionWebhookBlocking
 		case "RBACForbidden":
 			return issuesapi.CategoryRBACForbidden
-		case "IPExhaustion", "SandboxCreationFailed":
+		case "IPExhaustion", "SandboxCreationFailed", "PostBindStartupStall":
 			// scheduled but stuck creating the sandbox — a startup-stage stall
 			return issuesapi.CategoryContainerWaiting
 		case "VolumeMultiAttach", "VolumeAttach", "VolumeMount":

--- a/internal/issues/category_test.go
+++ b/internal/issues/category_test.go
@@ -21,6 +21,7 @@ func TestClassify(t *testing.T) {
 		{"rbac forbidden", classifyInput{Source: SourceScheduling, Kind: "Deployment", Reason: "RBACForbidden"}, issuesapi.CategoryRBACForbidden},
 		{"ip exhaustion is startup stall", classifyInput{Source: SourceScheduling, Kind: "Pod", Reason: "IPExhaustion"}, issuesapi.CategoryContainerWaiting},
 		{"sandbox failed is startup stall", classifyInput{Source: SourceScheduling, Kind: "Pod", Reason: "SandboxCreationFailed"}, issuesapi.CategoryContainerWaiting},
+		{"eventless post-bind startup stall", classifyInput{Source: SourceScheduling, Kind: "Pod", Reason: "PostBindStartupStall"}, issuesapi.CategoryContainerWaiting},
 		{"volume multiattach", classifyInput{Source: SourceScheduling, Kind: "Pod", Reason: "VolumeMultiAttach"}, issuesapi.CategoryVolumeMountFailed},
 		{"volume mount", classifyInput{Source: SourceScheduling, Kind: "Pod", Reason: "VolumeMount"}, issuesapi.CategoryVolumeMountFailed},
 		{"terminating pod", classifyInput{Source: SourceProblem, Kind: "Pod", Reason: "Terminating stuck"}, issuesapi.CategoryTerminationStuck},

--- a/internal/issues/provider.go
+++ b/internal/issues/provider.go
@@ -94,17 +94,20 @@ func (p *CacheProvider) DetectScheduling(namespaces []string) []k8s.Detection {
 	detect := func(ns string) []k8s.Detection {
 		out := k8s.DetectSchedulingProblems(p.cache, ns)
 		out = append(out, k8s.DetectAdmissionProblems(p.cache, ns)...)
-		out = append(out, k8s.DetectPostBindProblems(p.cache, ns)...)
 		return out
 	}
 	if len(namespaces) == 0 {
-		return detect("")
+		out := detect("")
+		out = append(out, k8s.DetectPostBindProblems(p.cache, "")...)
+		return out
 	}
 	perNs := make([][]k8s.Detection, 0, len(namespaces))
 	for _, ns := range namespaces {
 		perNs = append(perNs, detect(ns))
 	}
-	return flattenNamespacedProblems(perNs)
+	out := flattenNamespacedProblems(perNs)
+	out = append(out, k8s.DetectPostBindProblemsForNamespaces(p.cache, namespaces)...)
+	return out
 }
 
 func (p *CacheProvider) DetectCAPIProblems(namespaces []string) []k8s.Detection {

--- a/internal/k8s/detect_scheduling.go
+++ b/internal/k8s/detect_scheduling.go
@@ -485,8 +485,12 @@ func DetectSchedulingProblems(cache *ResourceCache, namespace string) []Detectio
 }
 
 func podScheduledCondition(pod *corev1.Pod) *corev1.PodCondition {
+	return podCondition(pod, corev1.PodScheduled)
+}
+
+func podCondition(pod *corev1.Pod, condType corev1.PodConditionType) *corev1.PodCondition {
 	for i := range pod.Status.Conditions {
-		if pod.Status.Conditions[i].Type == corev1.PodScheduled {
+		if pod.Status.Conditions[i].Type == condType {
 			return &pod.Status.Conditions[i]
 		}
 	}
@@ -1026,16 +1030,21 @@ func classifyAdmissionFailure(msg string) (string, bool) {
 // The pod was scheduled (a node accepted it) but the kubelet can't bring it
 // up — stuck in ContainerCreating because the CNI can't hand out an IP or the
 // CSI can't attach/mount a volume. radar otherwise treats ContainerCreating
-// as benign, so these silently sit as "Pending". The failure detail lives in
-// kubelet events (FailedCreatePodSandBox / FailedMount / FailedAttachVolume),
-// so this detector is event-driven, cross-checked against still-stuck pods so
-// a pod that recovered after a retry isn't falsely flagged.
+// as benign, so these silently sit as "Pending". The best failure detail lives
+// in kubelet events (FailedCreatePodSandBox / FailedMount / FailedAttachVolume),
+// but events expire; when no recent event remains, a narrow fallback catches
+// the CNI/sandbox shape: scheduled, old, ContainerCreating, and no Pod IP.
 
-const postBindFailureWindow = 10 * time.Minute
+const (
+	postBindFailureWindow     = 10 * time.Minute
+	postBindCriticalAfter     = 30 * time.Minute
+	podReadyToStartContainers = corev1.PodConditionType("PodReadyToStartContainers")
+)
 
 var postBindSeverity = map[string]string{
 	"IPExhaustion":          "critical",
 	"SandboxCreationFailed": "high",
+	"PostBindStartupStall":  "high",
 	"VolumeMultiAttach":     "critical",
 	"VolumeAttach":          "high",
 	"VolumeMount":           "high",
@@ -1044,7 +1053,25 @@ var postBindSeverity = map[string]string{
 // DetectPostBindProblems flags pods stuck in ContainerCreating due to CNI/IP
 // or volume failures. namespace="" scans all namespaces.
 func DetectPostBindProblems(cache *ResourceCache, namespace string) []Detection {
-	if cache == nil || cache.Events() == nil {
+	now := time.Now()
+	return detectPostBindProblems(cache, namespace, postBindStartupStallCounts(cache, []string{namespace}, now), now)
+}
+
+func DetectPostBindProblemsForNamespaces(cache *ResourceCache, namespaces []string) []Detection {
+	if len(namespaces) == 0 {
+		return DetectPostBindProblems(cache, "")
+	}
+	now := time.Now()
+	nodeStallCounts := postBindStartupStallCounts(cache, namespaces, now)
+	var out []Detection
+	for _, ns := range namespaces {
+		out = append(out, detectPostBindProblems(cache, ns, nodeStallCounts, now)...)
+	}
+	return out
+}
+
+func detectPostBindProblems(cache *ResourceCache, namespace string, nodeStallCounts map[string]int, now time.Time) []Detection {
+	if cache == nil {
 		return nil
 	}
 	stuck := stuckScheduledPods(cache, namespace)
@@ -1053,13 +1080,14 @@ func DetectPostBindProblems(cache *ResourceCache, namespace string) []Detection 
 	}
 
 	var events []*corev1.Event
-	if namespace != "" {
-		events, _ = cache.Events().Events(namespace).List(labels.Everything())
-	} else {
-		events, _ = cache.Events().List(labels.Everything())
+	if eventLister := cache.Events(); eventLister != nil {
+		if namespace != "" {
+			events, _ = eventLister.Events(namespace).List(labels.Everything())
+		} else {
+			events, _ = eventLister.List(labels.Everything())
+		}
 	}
 
-	now := time.Now()
 	// One row per stuck pod, showing the CURRENT blocker. The kubelet
 	// re-emits a post-bind event per retry and the active cause can change
 	// (NetworkNotReady → FailedMount). Informer List order is arbitrary, so
@@ -1070,6 +1098,7 @@ func DetectPostBindProblems(cache *ResourceCache, namespace string) []Detection 
 		reason string
 	}
 	latest := map[string]pbCandidate{}
+	expiredLatest := map[string]pbCandidate{}
 	var order []string
 	for _, e := range events {
 		if e.InvolvedObject.Kind != "Pod" {
@@ -1079,11 +1108,14 @@ func DetectPostBindProblems(cache *ResourceCache, namespace string) []Detection 
 		if !ok {
 			continue
 		}
-		if t := eventLastTime(e); !t.IsZero() && now.Sub(t) > postBindFailureWindow {
-			continue
-		}
 		key := e.InvolvedObject.Namespace + "/" + e.InvolvedObject.Name
 		if _, isStuck := stuck[key]; !isStuck {
+			continue
+		}
+		if t := eventLastTime(e); !t.IsZero() && now.Sub(t) > postBindFailureWindow {
+			if cur, exists := expiredLatest[key]; !exists || t.After(eventLastTime(cur.ev)) {
+				expiredLatest[key] = pbCandidate{ev: e, reason: reason}
+			}
 			continue
 		}
 		if cur, exists := latest[key]; exists {
@@ -1100,11 +1132,8 @@ func DetectPostBindProblems(cache *ResourceCache, namespace string) []Detection 
 	for _, key := range order {
 		c := latest[key]
 		pod := stuck[key]
-		severity := postBindSeverity[c.reason]
-		if severity == "" {
-			severity = "high"
-		}
 		ageDur := now.Sub(pod.CreationTimestamp.Time)
+		severity := postBindProblemSeverity(c.reason, ageDur)
 		ownerGroup, ownerKind, ownerName := podOwnerKindName(cache, pod)
 		problems = append(problems, Detection{
 			Kind:            "Pod",
@@ -1112,7 +1141,42 @@ func DetectPostBindProblems(cache *ResourceCache, namespace string) []Detection 
 			Name:            pod.Name,
 			Severity:        severity,
 			Reason:          c.reason,
-			Message:         "stuck creating: " + strings.TrimSpace(c.ev.Message),
+			Message:         postBindEventMessage(pod, c.reason, c.ev.Message, nodeStallCounts),
+			Age:             FormatAge(ageDur),
+			AgeSeconds:      int64(ageDur.Seconds()),
+			Duration:        FormatAge(ageDur),
+			DurationSeconds: int64(ageDur.Seconds()),
+			OwnerGroup:      ownerGroup,
+			OwnerKind:       ownerKind,
+			OwnerName:       ownerName,
+		})
+	}
+
+	var fallbackKeys []string
+	for key, pod := range stuck {
+		if _, hasRecentEvent := latest[key]; hasRecentEvent {
+			continue
+		}
+		if c, hasExpiredEvent := expiredLatest[key]; hasExpiredEvent && isVolumePostBindReason(c.reason) {
+			continue
+		}
+		if !isPostBindStartupStallPod(pod, now) {
+			continue
+		}
+		fallbackKeys = append(fallbackKeys, key)
+	}
+	sort.Strings(fallbackKeys)
+	for _, key := range fallbackKeys {
+		pod := stuck[key]
+		ageDur := now.Sub(pod.CreationTimestamp.Time)
+		ownerGroup, ownerKind, ownerName := podOwnerKindName(cache, pod)
+		problems = append(problems, Detection{
+			Kind:            "Pod",
+			Namespace:       pod.Namespace,
+			Name:            pod.Name,
+			Severity:        postBindProblemSeverity("PostBindStartupStall", ageDur),
+			Reason:          "PostBindStartupStall",
+			Message:         postBindFallbackMessage(pod, ageDur, nodeStallCounts),
 			Age:             FormatAge(ageDur),
 			AgeSeconds:      int64(ageDur.Seconds()),
 			Duration:        FormatAge(ageDur),
@@ -1142,6 +1206,175 @@ func stuckScheduledPods(cache *ResourceCache, namespace string) map[string]*core
 		}
 	}
 	return out
+}
+
+func postBindProblemSeverity(reason string, age time.Duration) string {
+	if (reason == "SandboxCreationFailed" || reason == "PostBindStartupStall") && age >= postBindCriticalAfter {
+		return "critical"
+	}
+	severity := postBindSeverity[reason]
+	if severity == "" {
+		return "high"
+	}
+	return severity
+}
+
+func isPostBindStartupStallPod(pod *corev1.Pod, now time.Time) bool {
+	if pod == nil || pod.Status.Phase != corev1.PodPending || pod.Spec.NodeName == "" {
+		return false
+	}
+	if cond := podScheduledCondition(pod); cond != nil && cond.Status == corev1.ConditionFalse {
+		return false
+	}
+	if pod.CreationTimestamp.IsZero() || now.Sub(pod.CreationTimestamp.Time) <= postBindFailureWindow {
+		return false
+	}
+	if podHasStatusIP(pod) {
+		return false
+	}
+	for i := range pod.Status.ContainerStatuses {
+		if w := pod.Status.ContainerStatuses[i].State.Waiting; w != nil && w.Reason == "ContainerCreating" {
+			return true
+		}
+	}
+	return false
+}
+
+func podHasStatusIP(pod *corev1.Pod) bool {
+	if pod.Status.PodIP != "" {
+		return true
+	}
+	for _, ip := range pod.Status.PodIPs {
+		if ip.IP != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func postBindStartupStallCounts(cache *ResourceCache, namespaces []string, now time.Time) map[string]int {
+	counts := map[string]int{}
+	if len(namespaces) == 0 {
+		namespaces = []string{""}
+	}
+	suppressed := expiredVolumePostBindPodKeys(cache, namespaces, now)
+	seen := map[string]bool{}
+	for _, namespace := range namespaces {
+		for _, pods := range listPodsByNamespace(cache, namespace) {
+			for _, pod := range pods {
+				key := pod.Namespace + "/" + pod.Name
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				if suppressed[key] {
+					continue
+				}
+				if !isPostBindStartupStallPod(pod, now) {
+					continue
+				}
+				counts[pod.Spec.NodeName]++
+			}
+		}
+	}
+	return counts
+}
+
+func expiredVolumePostBindPodKeys(cache *ResourceCache, namespaces []string, now time.Time) map[string]bool {
+	out := map[string]bool{}
+	if cache == nil {
+		return out
+	}
+	eventLister := cache.Events()
+	if eventLister == nil {
+		return out
+	}
+	if len(namespaces) == 0 {
+		namespaces = []string{""}
+	}
+	latestTime := map[string]time.Time{}
+	latestReason := map[string]string{}
+	for _, namespace := range namespaces {
+		var events []*corev1.Event
+		if namespace != "" {
+			events, _ = eventLister.Events(namespace).List(labels.Everything())
+		} else {
+			events, _ = eventLister.List(labels.Everything())
+		}
+		for _, e := range events {
+			if e.InvolvedObject.Kind != "Pod" {
+				continue
+			}
+			reason, ok := classifyPostBindFailure(e.Reason, e.Message)
+			if !ok {
+				continue
+			}
+			t := eventLastTime(e)
+			if t.IsZero() || now.Sub(t) <= postBindFailureWindow {
+				continue
+			}
+			key := e.InvolvedObject.Namespace + "/" + e.InvolvedObject.Name
+			if cur, exists := latestTime[key]; !exists || t.After(cur) {
+				latestTime[key] = t
+				latestReason[key] = reason
+			}
+		}
+	}
+	for key, reason := range latestReason {
+		if isVolumePostBindReason(reason) {
+			out[key] = true
+		}
+	}
+	return out
+}
+
+func postBindEventMessage(pod *corev1.Pod, reason, eventMessage string, nodeStallCounts map[string]int) string {
+	msg := "stuck creating"
+	if pod.Spec.NodeName != "" {
+		msg += " on node " + pod.Spec.NodeName
+	}
+	if eventMessage = strings.TrimSpace(eventMessage); eventMessage != "" {
+		msg += ": " + eventMessage
+	}
+	return appendPostBindNodeCorrelation(msg, pod, reason, nodeStallCounts)
+}
+
+func postBindFallbackMessage(pod *corev1.Pod, age time.Duration, nodeStallCounts map[string]int) string {
+	parts := []string{fmt.Sprintf("container is ContainerCreating with no Pod IP after %s", FormatAge(age))}
+	if cond := podCondition(pod, podReadyToStartContainers); cond != nil && cond.Status == corev1.ConditionFalse {
+		parts = append(parts, "PodReadyToStartContainers=False")
+	}
+	msg := fmt.Sprintf("stuck before container start on node %s: %s; no matching recent kubelet event found; check kubelet, container runtime, and CNI on that node",
+		pod.Spec.NodeName, strings.Join(parts, "; "))
+	return appendPostBindNodeCorrelation(msg, pod, "PostBindStartupStall", nodeStallCounts)
+}
+
+func appendPostBindNodeCorrelation(msg string, pod *corev1.Pod, reason string, nodeStallCounts map[string]int) string {
+	if !isNetworkPostBindReason(reason) || pod.Spec.NodeName == "" {
+		return msg
+	}
+	if count := nodeStallCounts[pod.Spec.NodeName]; count > 1 {
+		return fmt.Sprintf("%s; same node has %d visible pods stuck before container start", msg, count)
+	}
+	return msg
+}
+
+func isNetworkPostBindReason(reason string) bool {
+	switch reason {
+	case "IPExhaustion", "SandboxCreationFailed", "PostBindStartupStall":
+		return true
+	default:
+		return false
+	}
+}
+
+func isVolumePostBindReason(reason string) bool {
+	switch reason {
+	case "VolumeMultiAttach", "VolumeAttach", "VolumeMount":
+		return true
+	default:
+		return false
+	}
 }
 
 // classifyPostBindFailure maps a kubelet event (reason + message) to a

--- a/internal/k8s/detect_scheduling_integration_test.go
+++ b/internal/k8s/detect_scheduling_integration_test.go
@@ -589,6 +589,125 @@ func TestDetectPostBindProblems_LatestEventWins(t *testing.T) {
 	}
 }
 
+func TestDetectPostBindProblems_EventlessCNIStartupStall(t *testing.T) {
+	defer ResetTestState()
+	old := time.Now().Add(-45 * time.Minute)
+	stuck := postBindContainerCreatingPod("prod", "valkey", "worker-2", old)
+	sameNode := postBindContainerCreatingPod("kube-system", "calico-token-refresh", "worker-2", old)
+	slowImagePull := postBindContainerCreatingPod("prod", "image-pull", "worker-2", old)
+	slowImagePull.Status.PodIP = "10.1.2.3"
+	fresh := postBindContainerCreatingPod("prod", "fresh", "worker-2", time.Now().Add(-5*time.Minute))
+	unscheduled := postBindContainerCreatingPod("prod", "unscheduled", "worker-2", old)
+	unscheduled.Status.Conditions = append(unscheduled.Status.Conditions, corev1.PodCondition{
+		Type:   corev1.PodScheduled,
+		Status: corev1.ConditionFalse,
+		Reason: corev1.PodReasonUnschedulable,
+	})
+	initializing := postBindContainerCreatingPod("prod", "initializing", "worker-2", old)
+	initializing.Status.ContainerStatuses[0].State.Waiting.Reason = "PodInitializing"
+
+	if err := InitTestResourceCache(fake.NewClientset(stuck, sameNode, slowImagePull, fresh, unscheduled, initializing)); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	scoped := DetectPostBindProblems(GetResourceCache(), "prod")
+	if len(scoped) != 1 || strings.Contains(scoped[0].Message, "same node has 2 visible pods") {
+		t.Fatalf("single-namespace detector should not count kube-system pods, got %+v", scoped)
+	}
+	problems := DetectPostBindProblemsForNamespaces(GetResourceCache(), []string{"prod", "kube-system"})
+
+	var got *Detection
+	for i := range problems {
+		p := &problems[i]
+		switch p.Name {
+		case "valkey":
+			got = p
+		case "image-pull", "fresh", "unscheduled", "initializing":
+			t.Fatalf("pod %s should not be reported as eventless CNI startup stall: %+v", p.Name, problems)
+		}
+	}
+	if got == nil {
+		t.Fatalf("expected PostBindStartupStall for valkey, got %+v", problems)
+	}
+	if got.Reason != "PostBindStartupStall" || got.Severity != "critical" {
+		t.Fatalf("got reason/severity %s/%s, want PostBindStartupStall/critical: %+v", got.Reason, got.Severity, got)
+	}
+	for _, want := range []string{"worker-2", "no matching recent kubelet event", "same node has 2 visible pods"} {
+		if !strings.Contains(got.Message, want) {
+			t.Errorf("message %q missing %q", got.Message, want)
+		}
+	}
+}
+
+func TestDetectPostBindProblems_ExpiredVolumeEventSuppressesFallback(t *testing.T) {
+	defer ResetTestState()
+	old := time.Now().Add(-45 * time.Minute)
+	networkPod := postBindContainerCreatingPod("prod", "network", "worker-1", old)
+	volumePod := postBindContainerCreatingPod("prod", "web", "worker-1", old)
+	event := &corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{Name: "mount", Namespace: "prod"},
+		InvolvedObject: corev1.ObjectReference{Kind: "Pod", Namespace: "prod", Name: "web"},
+		Reason:         "FailedMount",
+		Type:           corev1.EventTypeWarning,
+		Message:        "Unable to attach or mount volumes: timed out waiting for the condition",
+		LastTimestamp:  metav1.NewTime(time.Now().Add(-30 * time.Minute)),
+	}
+	if err := InitTestResourceCache(fake.NewClientset(networkPod, volumePod, event)); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	problems := DetectPostBindProblems(GetResourceCache(), "prod")
+
+	for _, p := range problems {
+		if p.Name == "web" {
+			t.Fatalf("expired storage event must not be relabeled as an eventless CNI/runtime stall: %+v", problems)
+		}
+		if p.Name == "network" && strings.Contains(p.Message, "same node has 2 visible pods") {
+			t.Fatalf("expired storage event must not inflate same-node CNI/runtime correlation: %+v", problems)
+		}
+	}
+}
+
+func TestDetectPostBindProblems_RecentSandboxEventSuppressesFallback(t *testing.T) {
+	defer ResetTestState()
+	pod := postBindContainerCreatingPod("prod", "web", "worker-1", time.Now().Add(-45*time.Minute))
+	event := &corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{Name: "sandbox", Namespace: "prod"},
+		InvolvedObject: corev1.ObjectReference{Kind: "Pod", Namespace: "prod", Name: "web"},
+		Reason:         "FailedCreatePodSandBox",
+		Type:           corev1.EventTypeWarning,
+		Message:        "failed to create pod sandbox: network is not ready",
+		LastTimestamp:  metav1.Now(),
+	}
+	if err := InitTestResourceCache(fake.NewClientset(pod, event)); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	problems := DetectPostBindProblems(GetResourceCache(), "prod")
+
+	if len(problems) != 1 {
+		t.Fatalf("expected one event-backed post-bind row, got %+v", problems)
+	}
+	if problems[0].Reason != "SandboxCreationFailed" || problems[0].Severity != "critical" {
+		t.Fatalf("got reason/severity %s/%s, want SandboxCreationFailed/critical: %+v", problems[0].Reason, problems[0].Severity, problems[0])
+	}
+}
+
+func postBindContainerCreatingPod(namespace, name, node string, created time.Time) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, CreationTimestamp: metav1.NewTime(created)},
+		Spec:       corev1.PodSpec{NodeName: node, Containers: []corev1.Container{{Name: "main", Image: "example/app:latest"}}},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			Conditions: []corev1.PodCondition{{
+				Type:   podReadyToStartContainers,
+				Status: corev1.ConditionFalse,
+			}},
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:  "main",
+				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"}},
+			}},
+		},
+	}
+}
+
 // Exercises the cross-check for Job + DaemonSet, whose created-count signals
 // differ from the replica kinds: a Job that created no pod and a partially
 // scheduled DaemonSet are still blocked; a terminally-failed Job (Failed>0) and

--- a/internal/k8s/top_metrics.go
+++ b/internal/k8s/top_metrics.go
@@ -481,6 +481,20 @@ func topOwnerForPodResolved(cache *ResourceCache, pod *corev1.Pod) *TopOwnerInfo
 			}
 		}
 	}
+	if ref.Kind == "Job" && cache != nil {
+		if jl := cache.Jobs(); jl != nil {
+			if job, err := jl.Jobs(pod.Namespace).Get(ref.Name); err == nil && job != nil {
+				if owner := controllerOwnerRef(job.OwnerReferences); owner != nil {
+					return &TopOwnerInfo{
+						Group: schema.FromAPIVersionAndKind(owner.APIVersion, owner.Kind).Group,
+						Kind:  owner.Kind,
+						Name:  owner.Name,
+					}
+				}
+				return &TopOwnerInfo{Group: "batch", Kind: "Job", Name: ref.Name}
+			}
+		}
+	}
 	return topOwnerForPod(pod)
 }
 

--- a/internal/k8s/top_metrics_test.go
+++ b/internal/k8s/top_metrics_test.go
@@ -3,8 +3,10 @@ package k8s
 import (
 	"testing"
 
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestNormalizeTopMetricsOptions(t *testing.T) {
@@ -91,5 +93,68 @@ func TestTopOwnerForPodIgnoresNonControllerOwnerRefs(t *testing.T) {
 	}
 	if owner := topOwnerForPodResolved(nil, pod); owner != nil {
 		t.Fatalf("topOwnerForPodResolved = %+v, want nil for non-controller ownerRef", owner)
+	}
+}
+
+func TestTopOwnerForPodResolvedCollapsesJobToCronJob(t *testing.T) {
+	defer ResetTestState()
+	controller := true
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "calico-token-refresh-123",
+			Namespace: "kube-system",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "batch/v1",
+				Kind:       "CronJob",
+				Name:       "calico-token-refresh",
+				Controller: &controller,
+			}},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "calico-token-refresh-123-abc",
+			Namespace: "kube-system",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "batch/v1",
+				Kind:       "Job",
+				Name:       "calico-token-refresh-123",
+				Controller: &controller,
+			}},
+		},
+	}
+	if err := InitTestResourceCache(fake.NewClientset(job)); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+
+	owner := topOwnerForPodResolved(GetResourceCache(), pod)
+	if owner == nil || owner.Group != "batch" || owner.Kind != "CronJob" || owner.Name != "calico-token-refresh" {
+		t.Fatalf("owner = %+v, want batch/CronJob/calico-token-refresh", owner)
+	}
+}
+
+func TestTopOwnerForPodResolvedKeepsStandaloneJob(t *testing.T) {
+	defer ResetTestState()
+	controller := true
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "manual", Namespace: "prod"}}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "manual-abc",
+			Namespace: "prod",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "batch/v1",
+				Kind:       "Job",
+				Name:       "manual",
+				Controller: &controller,
+			}},
+		},
+	}
+	if err := InitTestResourceCache(fake.NewClientset(job)); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+
+	owner := topOwnerForPodResolved(GetResourceCache(), pod)
+	if owner == nil || owner.Group != "batch" || owner.Kind != "Job" || owner.Name != "manual" {
+		t.Fatalf("owner = %+v, want batch/Job/manual", owner)
 	}
 }

--- a/packages/k8s-ui/src/components/resources/get-pod-problems.test.ts
+++ b/packages/k8s-ui/src/components/resources/get-pod-problems.test.ts
@@ -64,4 +64,64 @@ describe('getPodProblems', () => {
       }),
     ).toContainEqual({ severity: 'critical', message: 'ImagePullBackOff', detail })
   })
+
+  it('infers sandbox startup stalls only for scheduled pods and follows backend severity gates', () => {
+    expect(
+      getPodProblems({
+        metadata: { creationTimestamp: new Date(Date.now() - 20 * 60 * 1000).toISOString() },
+        spec: { nodeName: 'worker-1' },
+        status: {
+          phase: 'Pending',
+          containerStatuses: [
+            {
+              name: 'api',
+              restartCount: 0,
+              state: { waiting: { reason: 'ContainerCreating' } },
+            },
+          ],
+        },
+      }),
+    ).toContainEqual({ severity: 'high', message: 'Sandbox Startup Stalled' })
+
+    expect(
+      getPodProblems({
+        metadata: { creationTimestamp: new Date(Date.now() - 45 * 60 * 1000).toISOString() },
+        spec: { nodeName: 'worker-1' },
+        status: {
+          phase: 'Pending',
+          containerStatuses: [
+            {
+              name: 'api',
+              restartCount: 0,
+              state: { waiting: { reason: 'ContainerCreating' } },
+            },
+          ],
+        },
+      }),
+    ).toContainEqual({ severity: 'critical', message: 'Sandbox Startup Stalled' })
+
+    expect(
+      getPodProblems({
+        metadata: { creationTimestamp: new Date(Date.now() - 45 * 60 * 1000).toISOString() },
+        spec: { nodeName: 'worker-1' },
+        status: {
+          phase: 'Pending',
+          conditions: [
+            {
+              type: 'PodScheduled',
+              status: 'False',
+              reason: 'Unschedulable',
+            },
+          ],
+          containerStatuses: [
+            {
+              name: 'api',
+              restartCount: 0,
+              state: { waiting: { reason: 'ContainerCreating' } },
+            },
+          ],
+        },
+      }),
+    ).not.toContainEqual(expect.objectContaining({ message: 'Sandbox Startup Stalled' }))
+  })
 })

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -268,6 +268,17 @@ export function getPodProblems(pod: any): PodProblem[] {
   const conditions = pod.status?.conditions || []
   const phase = pod.status?.phase
   const podStatusMessage = pod.status?.message || undefined
+  const hasPodIP = Boolean(pod.status?.podIP || pod.status?.podIPs?.some((ip: any) => ip?.ip))
+  const hasScheduledNode = Boolean(pod.spec?.nodeName)
+  const hasUnschedulableCondition = conditions.some((cond: any) => cond.type === 'PodScheduled' && cond.status === 'False')
+  const hasContainerCreating = containerStatuses.some((cs: any) => cs.state?.waiting?.reason === 'ContainerCreating')
+  const createdAtMs = pod.metadata?.creationTimestamp ? new Date(pod.metadata.creationTimestamp).getTime() : NaN
+  const podAgeMs = Number.isFinite(createdAtMs) ? Date.now() - createdAtMs : 0
+  const sandboxStartupStallAgeMs = 10 * 60 * 1000
+  const sandboxStartupStallCriticalAgeMs = 30 * 60 * 1000
+  const inferredSandboxStartupStall = phase === 'Pending' && hasScheduledNode && !hasUnschedulableCondition && hasContainerCreating && !hasPodIP && podAgeMs > sandboxStartupStallAgeMs
+  const inferredSandboxStartupStallSeverity: PodProblem['severity'] = podAgeMs >= sandboxStartupStallCriticalAgeMs ? 'critical' : 'high'
+  let hasSandboxStartupStallProblem = false
 
   // Failed or Unknown phase
   if (phase === 'Failed' && pod.status?.reason !== 'Evicted') {
@@ -344,10 +355,16 @@ export function getPodProblems(pod: any): PodProblem[] {
     // IP allocation failures (subnet exhaustion)
     if (cond.type === 'PodReadyToStartContainers' && cond.status === 'False') {
       const msg = (cond.message || '').toLowerCase()
-      if (msg.includes('failed to assign an ip') || msg.includes('pod sandbox')) {
+      if (msg.includes('failed to assign an ip')) {
         problems.push({ severity: 'critical', message: 'IP Allocation Failed', detail: cond.message || undefined })
+      } else if (msg.includes('pod sandbox')) {
+        problems.push({ severity: 'critical', message: 'Sandbox Startup Stalled', detail: cond.message || undefined })
+        hasSandboxStartupStallProblem = true
       }
     }
+  }
+  if (inferredSandboxStartupStall && !hasSandboxStartupStallProblem) {
+    problems.push({ severity: inferredSandboxStartupStallSeverity, message: 'Sandbox Startup Stalled' })
   }
 
   // Evicted pods


### PR DESCRIPTION
## Summary
This PR teaches Radar to surface a narrow class of post-bind startup failures that currently disappear once kubelet Warning events age out: pods that were already scheduled to a node, remain Pending in ContainerCreating, and still have no Pod IP after the existing post-bind failure window.

The motivating failure mode is node-level CNI/container-runtime startup trouble. In that state Kubernetes may have emitted useful kubelet events earlier, but if Radar only looks at recent events the pod can later look like an ordinary Pending pod even though it is already bound to a node and has not reached sandbox/container start. This PR adds an eventless fallback for that shape while keeping fresh kubelet events as the primary source of truth.

## Backend behavior
- Adds a `PostBindStartupStall` scheduling detection for pods that are Pending, bound to a node, older than the post-bind window, waiting in `ContainerCreating`, and missing both `podIP` and `podIPs`.
- Keeps recent kubelet events authoritative. If a recent sandbox, IP exhaustion, mount, or attach event exists, that classified event wins instead of the fallback.
- Escalates sandbox-style post-bind failures from high to critical only after 30 minutes. IP exhaustion remains critical immediately.
- Adds RBAC-scoped same-node correlation, so when multiple visible namespaces are queried the message can say that other visible pods on the same node are also stuck before container start.
- Routes namespace-filtered issue queries through the multi-namespace detector so correlation is scoped to what the caller can see, not the whole shared cache.
- Maps `PostBindStartupStall` into the existing container-waiting/startup-blocker issue category.

## Noise controls
The fallback is deliberately narrow. It does not fire for unscheduled pods, fresh pods, pods that already have a Pod IP, pods waiting only in init `PodInitializing`, or pods whose `PodScheduled` condition is false.

It also avoids relabeling storage problems as CNI/runtime problems. If the latest expired post-bind signal for the pod was a volume attach/mount failure, the fallback is suppressed. Those stale-volume-suppressed pods are also excluded from same-node correlation counts, so a reported CNI/runtime stall does not cite hidden storage-stalled pods as supporting evidence.

The remaining known risk is slow image/container startup before Pod IP assignment looking similar to runtime/CNI stall after the age gate. The guards above are meant to keep that from becoming broad spam, but this is still heuristic detection rather than a direct kubelet diagnosis.

## UI and grouping changes
- Pod detail now mirrors the backend inference for `Sandbox Startup Stalled`: scheduled node required, `PodScheduled=False` excluded, no Pod IP, `ContainerCreating`, and the same 10-minute/30-minute age split for high vs critical severity.
- Explicit `PodReadyToStartContainers=False` sandbox messages still surface directly; explicit IP assignment failures remain `IP Allocation Failed`.
- Top metrics now resolves Job-owned pods through their Job owner to CronJob when applicable, so CronJob pods group under the CronJob instead of stopping at the transient Job. Standalone Jobs still stay Jobs.

## Test coverage
- Backend scheduling tests cover eventless startup stalls, recent event precedence, stale volume-event suppression, same-node correlation scoping, critical escalation, and non-matches for fresh/unscheduled/IP-assigned/init-only pods.
- Issue classification has coverage for the new post-bind stall category.
- Top metrics tests cover Job to CronJob ownership collapse and standalone Job preservation.
- Shared UI tests cover pod problem inference for sandbox stalls, including scheduled-node, unschedulable-condition, and severity gates.

## Verification
- Focused backend scheduling tests
- Focused issues classification tests
- Focused shared UI pod-problem tests
- TypeScript check
- Full Go test suite