### PR TITLE
Catalog display metadata: check category + default severity, issue-category catalog

### DIFF
--- a/pkg/audit/registry.go
+++ b/pkg/audit/registry.go
@@ -44,256 +44,330 @@ var (
 )
 
 // CheckRegistry maps checkID → metadata for all built-in checks.
+//
+// Category MUST match the category the check emits at runtime (see pkg/audit/checks.go)
+// — the settings UI groups the catalog by it, so a mismatch would file a check
+// under a section its findings never appear in. TestRegistryCategoriesValid guards
+// the vocabulary; the cross-resource / lifecycle / deprecated-API checks all emit
+// as Reliability.
 var CheckRegistry = map[string]CheckMeta{
 	// ── Security ──────────────────────────────────────────────────────
 	"runAsRoot": {
 		ID:          "runAsRoot",
 		Title:       "Run as non-root",
+		Category:    CategorySecurity,
 		Description: "Containers running as root have full access to the host filesystem. If compromised, an attacker gains root-level access.",
 		Remediation: "Set securityContext.runAsNonRoot: true and runAsUser: 1000 (or higher) on the container or pod spec.",
 		Frameworks:  []string{FrameworkNSACISA, FrameworkCIS},
-		References:   []Reference{refSecurityContext, refPodSecurityStd, refNSACISA},
+		References:  []Reference{refSecurityContext, refPodSecurityStd, refNSACISA},
 	},
 	"privileged": {
 		ID:          "privileged",
 		Title:       "Privileged container",
+		Category:    CategorySecurity,
 		Description: "Privileged containers have all host capabilities, bypassing container isolation. An attacker in a privileged container can compromise the entire node.",
 		Remediation: "Set securityContext.privileged: false on the container.",
 		Frameworks:  []string{FrameworkNSACISA, FrameworkCIS},
-		References:   []Reference{refSecurityContext, refPodSecurityStd, refNSACISA},
+		References:  []Reference{refSecurityContext, refPodSecurityStd, refNSACISA},
 	},
 	"privilegeEscalation": {
 		ID:          "privilegeEscalation",
 		Title:       "Privilege escalation",
+		Category:    CategorySecurity,
 		Description: "Allows a process to gain more privileges than its parent. Attackers can exploit this to escalate from container to host.",
 		Remediation: "Set securityContext.allowPrivilegeEscalation: false on the container.",
 		Frameworks:  []string{FrameworkNSACISA, FrameworkCIS},
-		References:   []Reference{refSecurityContext, refPodSecurityStd},
+		References:  []Reference{refSecurityContext, refPodSecurityStd},
 	},
 	"readOnlyRootFs": {
 		ID:          "readOnlyRootFs",
 		Title:       "Read-only root filesystem",
+		Category:    CategorySecurity,
 		Description: "A writable root filesystem allows attackers to modify binaries, install tools, or tamper with the application.",
 		Remediation: "Set securityContext.readOnlyRootFilesystem: true. Use emptyDir volumes for writable paths.",
 		Frameworks:  []string{FrameworkNSACISA},
-		References:   []Reference{refSecurityContext, refNSACISA},
+		References:  []Reference{refSecurityContext, refNSACISA},
 	},
 	"dangerousCapabilities": {
 		ID:          "dangerousCapabilities",
 		Title:       "Dangerous capabilities",
+		Category:    CategorySecurity,
 		Description: "Capabilities like SYS_ADMIN, NET_ADMIN, and ALL grant near-root powers and can be used to escape the container.",
 		Remediation: "Remove dangerous capabilities from securityContext.capabilities.add. Drop all and add only what is needed.",
 		Frameworks:  []string{FrameworkNSACISA, FrameworkCIS},
-		References:   []Reference{refSecurityContext, refPodSecurityStd},
+		References:  []Reference{refSecurityContext, refPodSecurityStd},
 	},
 	"dockerSocketMount": {
 		ID:          "dockerSocketMount",
 		Title:       "Container runtime socket mounted",
+		Category:    CategorySecurity,
 		Description: "Mounting the Docker/containerd socket gives the container full control over the host's container runtime — equivalent to root access. This is a documented attack vector used in cryptojacking campaigns.",
 		Remediation: "Remove the hostPath volume mounting the container runtime socket. If CI/CD needs Docker access, use Docker-in-Docker (DinD) or Kaniko instead.",
 		Frameworks:  []string{FrameworkNSACISA, FrameworkCIS},
-		References:   []Reference{refHostPath, refNSACISA},
+		References:  []Reference{refHostPath, refNSACISA},
 	},
 	"sensitiveHostPath": {
 		ID:          "sensitiveHostPath",
 		Title:       "Sensitive host path mounted",
+		Category:    CategorySecurity,
 		Description: "Mounting sensitive host directories (/etc, /proc, /sys, /var/run) exposes host configuration, credentials, and runtime state to the container. Attackers can use this to escalate privileges or access other containers.",
 		Remediation: "Remove the hostPath volume or restrict it to a specific, non-sensitive directory. Use emptyDir or PVC for writable storage.",
 		Frameworks:  []string{FrameworkNSACISA, FrameworkCIS},
-		References:   []Reference{refHostPath, refPodSecurityStd},
+		References:  []Reference{refHostPath, refPodSecurityStd},
 	},
 	"secretInConfigMap": {
 		ID:          "secretInConfigMap",
 		Title:       "Potential secret in ConfigMap",
+		Category:    CategorySecurity,
 		Description: "ConfigMap keys with names suggesting sensitive data (passwords, tokens, keys) should use Kubernetes Secrets instead. ConfigMaps are not encrypted at rest and may appear in logs and kubectl output.",
 		Remediation: "Move sensitive data to a Secret resource. ConfigMaps should only contain non-sensitive configuration.",
 		Frameworks:  []string{FrameworkNSACISA},
-		References:   []Reference{refSecrets},
+		References:  []Reference{refSecrets},
 	},
 	"insecureCapabilities": {
 		ID:          "insecureCapabilities",
 		Title:       "Insecure capabilities",
+		Category:    CategorySecurity,
 		Description: "Capabilities like NET_RAW, SYS_PTRACE, and MKNOD can be exploited for packet spoofing, process injection, or device manipulation.",
 		Remediation: "Remove insecure capabilities from securityContext.capabilities.add. Use capabilities.drop: [ALL] and add back only what is strictly needed.",
 		Frameworks:  []string{FrameworkNSACISA, FrameworkCIS},
-		References:   []Reference{refSecurityContext, refPodSecurityStd},
+		References:  []Reference{refSecurityContext, refPodSecurityStd},
 	},
 	"hostNetwork": {
 		ID:          "hostNetwork",
 		Title:       "Host network",
+		Category:    CategorySecurity,
 		Description: "Sharing the host network namespace lets the container see all network traffic and access host network services.",
 		Remediation: "Remove hostNetwork: true unless the workload genuinely needs host network access.",
 		Frameworks:  []string{FrameworkNSACISA, FrameworkCIS},
-		References:   []Reference{refPodSecurityStd, refNSACISA},
+		References:  []Reference{refPodSecurityStd, refNSACISA},
 	},
 	"hostPID": {
 		ID:          "hostPID",
 		Title:       "Host PID namespace",
+		Category:    CategorySecurity,
 		Description: "Sharing the host PID namespace lets the container see and signal all host processes, enabling process injection attacks.",
 		Remediation: "Remove hostPID: true from the pod spec.",
 		Frameworks:  []string{FrameworkNSACISA, FrameworkCIS},
-		References:   []Reference{refPodSecurityStd, refNSACISA},
+		References:  []Reference{refPodSecurityStd, refNSACISA},
 	},
 	"hostIPC": {
 		ID:          "hostIPC",
 		Title:       "Host IPC namespace",
+		Category:    CategorySecurity,
 		Description: "Sharing the host IPC namespace allows access to shared memory and inter-process communication with host processes.",
 		Remediation: "Remove hostIPC: true from the pod spec.",
 		Frameworks:  []string{FrameworkNSACISA, FrameworkCIS},
-		References:   []Reference{refPodSecurityStd, refNSACISA},
+		References:  []Reference{refPodSecurityStd, refNSACISA},
 	},
 	"automountServiceAccountToken": {
 		ID:          "automountServiceAccountToken",
 		Title:       "Service account token auto-mount",
+		Category:    CategorySecurity,
 		Description: "Auto-mounted tokens can be used by attackers to authenticate to the Kubernetes API server and escalate privileges.",
 		Remediation: "Set automountServiceAccountToken: false on the pod spec. Only enable for pods that need API access.",
 		Frameworks:  []string{FrameworkNSACISA},
-		References:   []Reference{refSAToken, refNSACISA},
+		References:  []Reference{refSAToken, refNSACISA},
 	},
 
 	// ── Reliability ───────────────────────────────────────────────────
 	"readinessProbeMissing": {
 		ID:          "readinessProbeMissing",
 		Title:       "Missing readiness probe",
+		Category:    CategoryReliability,
 		Description: "Without a readiness probe, Kubernetes sends traffic to pods before they are ready, causing errors for users.",
 		Remediation: "Add a readinessProbe (HTTP GET, TCP, or exec) to each container.",
-		References:   []Reference{refProbes},
+		References:  []Reference{refProbes},
 	},
 	"livenessProbeMissing": {
 		ID:          "livenessProbeMissing",
 		Title:       "Missing liveness probe",
+		Category:    CategoryReliability,
 		Description: "Without a liveness probe, Kubernetes cannot detect and restart containers that are stuck or deadlocked.",
 		Remediation: "Add a livenessProbe (HTTP GET, TCP, or exec) to each container.",
-		References:   []Reference{refProbes},
+		References:  []Reference{refProbes},
 	},
 	"imageTagLatest": {
 		ID:          "imageTagLatest",
 		Title:       "Image tag latest or missing",
+		Category:    CategoryReliability,
 		Description: "Using 'latest' or no tag means deployments are not reproducible — you cannot tell which version is running, and rollbacks may not work.",
 		Remediation: "Pin images to a specific version tag (e.g., nginx:1.25.3).",
-		References:   []Reference{refImages},
+		References:  []Reference{refImages},
 	},
 	"pullPolicyNotAlways": {
 		ID:          "pullPolicyNotAlways",
 		Title:       "Pull policy not Always",
+		Category:    CategoryReliability,
 		Description: "With a mutable tag and non-Always pull policy, nodes may run stale cached images, causing inconsistency across replicas.",
 		Remediation: "Set imagePullPolicy: Always when using mutable tags, or pin to immutable digests.",
-		References:   []Reference{refImages},
+		References:  []Reference{refImages},
 	},
 	"singleReplica": {
 		ID:          "singleReplica",
 		Title:       "Single replica",
+		Category:    CategoryReliability,
 		Description: "A single-replica deployment has no redundancy — any pod disruption (node drain, OOM, crash) causes downtime.",
 		Remediation: "Set replicas: 2 or higher, or configure an HPA for autoscaling.",
-		References:   []Reference{refDeployments, refDisruptions},
+		References:  []Reference{refDeployments, refDisruptions},
 	},
 	"missingPDB": {
 		ID:          "missingPDB",
 		Title:       "Missing PodDisruptionBudget",
+		Category:    CategoryReliability,
 		Description: "Without a PDB, cluster operations (node drains, upgrades) can take down all replicas simultaneously.",
 		Remediation: "Create a PodDisruptionBudget with minAvailable or maxUnavailable matching your availability requirements.",
-		References:   []Reference{refDisruptions},
+		References:  []Reference{refDisruptions},
 	},
 	"missingTopologySpread": {
 		ID:          "missingTopologySpread",
 		Title:       "Missing topology spread constraints",
+		Category:    CategoryReliability,
 		Description: "Without topology spread constraints, all replicas can land on the same node or availability zone, giving an illusion of HA without real fault tolerance.",
 		Remediation: "Add topologySpreadConstraints to the pod template with topologyKey: kubernetes.io/hostname or topology.kubernetes.io/zone.",
-		References:   []Reference{refTopologySpread},
+		References:  []Reference{refTopologySpread},
 	},
 	"podHARisk": {
 		ID:          "podHARisk",
 		Title:       "All replicas on same node",
+		Category:    CategoryReliability,
 		Description: "All pod replicas are scheduled on the same node. If that node fails, all replicas go down simultaneously — no actual high availability.",
 		Remediation: "Add pod anti-affinity or topology spread constraints to distribute replicas across nodes.",
-		References:   []Reference{refAffinity, refTopologySpread},
+		References:  []Reference{refAffinity, refTopologySpread},
 	},
 
 	// ── Efficiency ────────────────────────────────────────────────────
 	"cpuRequestMissing": {
 		ID:          "cpuRequestMissing",
 		Title:       "Missing CPU request",
+		Category:    CategoryEfficiency,
 		Description: "Without CPU requests, the scheduler cannot make informed placement decisions, leading to overcommitted nodes and throttling.",
 		Remediation: "Set resources.requests.cpu (e.g., 100m) on each container.",
 		Frameworks:  []string{FrameworkCIS},
-		References:   []Reference{refResources},
+		References:  []Reference{refResources},
 	},
 	"memoryRequestMissing": {
 		ID:          "memoryRequestMissing",
 		Title:       "Missing memory request",
+		Category:    CategoryEfficiency,
 		Description: "Without memory requests, pods may be scheduled on nodes without enough memory, causing OOM kills.",
 		Remediation: "Set resources.requests.memory (e.g., 128Mi) on each container.",
 		Frameworks:  []string{FrameworkCIS},
-		References:   []Reference{refResources},
+		References:  []Reference{refResources},
 	},
 	"cpuLimitMissing": {
 		ID:          "cpuLimitMissing",
 		Title:       "Missing CPU limit",
+		Category:    CategoryEfficiency,
 		Description: "Without CPU limits, a single container can consume all CPU on a node, starving other workloads.",
 		Remediation: "Set resources.limits.cpu (e.g., 500m) on each container.",
 		Frameworks:  []string{FrameworkCIS},
-		References:   []Reference{refResources},
+		References:  []Reference{refResources},
 	},
 	"memoryLimitMissing": {
 		ID:          "memoryLimitMissing",
 		Title:       "Missing memory limit",
+		Category:    CategoryEfficiency,
 		Description: "Without memory limits, a container can consume unbounded memory, eventually triggering kernel OOM kills on the node.",
 		Remediation: "Set resources.limits.memory (e.g., 512Mi) on each container.",
 		Frameworks:  []string{FrameworkCIS},
-		References:   []Reference{refResources},
+		References:  []Reference{refResources},
 	},
 	"resourceUtilization": {
 		ID:          "resourceUtilization",
 		Title:       "Resource utilization mismatch",
+		Category:    CategoryEfficiency,
 		Description: "Pod resource usage is significantly different from its requests — either wasting resources (<10% used) or at risk of throttling/OOM (>90% used).",
 		Remediation: "Adjust resources.requests to match actual usage. Use metrics or VPA recommendations to right-size.",
-		References:   []Reference{refResources},
+		References:  []Reference{refResources},
 	},
 	"orphanConfigMapSecret": {
 		ID:          "orphanConfigMapSecret",
 		Title:       "Unused ConfigMap or Secret",
+		Category:    CategoryEfficiency,
 		Description: "This ConfigMap or Secret is not referenced by any pod (env vars, volumes, or imagePullSecrets). It may be orphaned and safe to remove.",
 		Remediation: "Verify this resource is no longer needed and delete it, or add a reference from a pod spec if it should be in use.",
-		References:   []Reference{refConfigMaps, refSecrets},
+		References:  []Reference{refConfigMaps, refSecrets},
 	},
 
+	// ── Cross-resource / lifecycle (emit under Reliability) ────────────
 	"deprecatedAPIVersion": {
 		ID:          "deprecatedAPIVersion",
 		Title:       "Deprecated API version",
+		Category:    CategoryReliability,
 		Description: "This cluster still serves a deprecated API version. Resources using this API will break after a Kubernetes upgrade that removes it.",
 		Remediation: "Migrate resources to the replacement API version before upgrading the cluster.",
-		References:   []Reference{refDeprecatedAPI},
+		References:  []Reference{refDeprecatedAPI},
 	},
-
-	// ── Cross-resource ────────────────────────────────────────────────
 	"serviceNoMatchingPods": {
 		ID:          "serviceNoMatchingPods",
 		Title:       "Service has no matching pods",
+		Category:    CategoryReliability,
 		Description: "The service selector does not match any running pods — traffic sent to this service will fail.",
 		Remediation: "Verify the service selector labels match the pod template labels on the target workload.",
-		References:   []Reference{refService},
+		References:  []Reference{refService},
 	},
 	"ingressNoMatchingService": {
 		ID:          "ingressNoMatchingService",
 		Title:       "Ingress references missing service",
+		Category:    CategoryReliability,
 		Description: "The ingress backend references a service that does not exist, so incoming traffic will get 503 errors.",
 		Remediation: "Check the ingress spec and correct the service name, or create the missing service.",
-		References:   []Reference{refIngress},
+		References:  []Reference{refIngress},
 	},
-
-	// ── Lifecycle ─────────────────────────────────────────────────────
 	"stuckTerminating": {
 		ID:          "stuckTerminating",
 		Title:       "Stuck terminating resource",
+		Category:    CategoryReliability,
 		Description: "This resource has metadata.deletionTimestamp set but is still alive past the cleanup window. Most controllers finish cleanup within seconds; minutes-long delays usually mean a finalizer's owning controller is unhealthy or unable to reach a dependent service. Common causes: the controller pod is CrashLoopBackOff, DNS resolution is broken, the finalizer logic depends on a webhook or external API that's unavailable.",
 		Remediation: "Check the controller responsible for each finalizer key (kubectl describe will show finalizers under metadata). For Argo CD, look at argocd-application-controller in the argocd namespace. For Flux, look at the matching controller (kustomize-controller, helm-controller, source-controller) in flux-system. Once the controller is healthy, deletion will resume automatically. If you must remove a stuck resource and accept the orphaned cleanup, manually clear the finalizers field — but only as a last resort.",
-		References:   []Reference{refFinalizers},
+		References:  []Reference{refFinalizers},
 	},
 	"crossplaneStuck": {
 		ID:          "crossplaneStuck",
 		Title:       "Stuck Crossplane resource",
+		Category:    CategoryReliability,
 		Description: "A Crossplane Managed Resource, Composite Resource, or Claim has been reporting Ready=False or Synced=False past the reconciliation window. Synced=False usually means a configuration error (bad ProviderConfig, malformed forProvider spec, missing IAM permissions, quota exceeded, schema mismatch). Ready=False usually means the provider accepted the spec but can't reach a desired state (target cloud API rejected, dependency missing, eventual-consistency lag past the threshold).",
 		Remediation: "Open the resource and read the latest condition's message — Crossplane providers almost always include the upstream cloud error verbatim. Common fixes: (1) check the linked Provider's Healthy condition; the package controller crashlooping starves every MR it manages. (2) verify the ProviderConfig credentials Secret still exists and is current (rotated keys, expired tokens). (3) check IAM/RBAC at the target cloud — Synced=False with auth errors needs a credentials fix, not a Crossplane fix. (4) look at quota/limit errors in the cloud provider console. (5) for paused resources (crossplane.io/paused annotation), this finding is intentionally suppressed — remove the annotation to resume reconciliation.",
-		References:   []Reference{refCrossplane},
+		References:  []Reference{refCrossplane},
 	},
+}
+
+// The two Checks-ladder levels a detector reaches with no override —
+// pkg/checks.MapSeverity emits only these (critical/low need an org override).
+var (
+	sevHigh   = string(checks.SeverityHigh)
+	sevMedium = string(checks.SeverityMedium)
+)
+
+// nonMediumDefault lists checks whose detector default maps above Medium (raw
+// severity "danger" → High). Everything else defaults to Medium. A few checks
+// pick the level per finding (sensitiveHostPath splits sensitive vs ordinary
+// paths; stuck*/crossplane ramp by age) — we surface their common/base case,
+// which is Medium. Mirror pkg/audit/checks.go emission when adding or re-ranking
+// a check (TestRegistryDefaultSeverity guards the values).
+var nonMediumDefault = map[string]string{
+	"privileged":            sevHigh,
+	"privilegeEscalation":   sevHigh,
+	"dangerousCapabilities": sevHigh,
+	"dockerSocketMount":     sevHigh,
+	"hostPID":               sevHigh,
+	"hostIPC":               sevHigh,
+	"imageTagLatest":        sevHigh,
+	"deprecatedAPIVersion":  sevHigh,
+}
+
+// Stamp DefaultSeverity onto the catalog so the Hub's Checks settings can show
+// the level a check resolves to (vs. just "Default") without each consumer
+// re-deriving it from raw findings.
+func init() {
+	for id := range CheckRegistry {
+		sev := sevMedium
+		if s, ok := nonMediumDefault[id]; ok {
+			sev = s
+		}
+		m := CheckRegistry[id]
+		m.DefaultSeverity = sev
+		CheckRegistry[id] = m
+	}
 }

--- a/pkg/audit/registry.go
+++ b/pkg/audit/registry.go
@@ -340,13 +340,11 @@ var (
 	sevMedium = string(checks.SeverityMedium)
 )
 
-// nonMediumDefault lists checks whose detector default maps above Medium (raw
-// severity "danger" → High). Everything else defaults to Medium. A few checks
-// pick the level per finding (sensitiveHostPath splits sensitive vs ordinary
-// paths; stuck*/crossplane ramp by age) — we surface their common/base case,
-// which is Medium. Mirror pkg/audit/checks.go emission when adding or re-ranking
-// a check (TestRegistryDefaultSeverity guards the values).
+// nonMediumDefault lists the checks shown as High; everything else defaults to
+// Medium. Mirror pkg/audit/checks.go emission when adding or re-ranking a check
+// (TestRegistryDefaultSeverity guards the values).
 var nonMediumDefault = map[string]string{
+	// Always emit danger → High.
 	"privileged":            sevHigh,
 	"privilegeEscalation":   sevHigh,
 	"dangerousCapabilities": sevHigh,
@@ -355,6 +353,15 @@ var nonMediumDefault = map[string]string{
 	"hostIPC":               sevHigh,
 	"imageTagLatest":        sevHigh,
 	"deprecatedAPIVersion":  sevHigh,
+	// Context-dependent — emit warning OR danger (sensitiveHostPath: a full
+	// host-root mount is danger, sensitive prefixes warning; stuck*/crossplane
+	// ramp warning→danger past ~30min). Surfaced as High (their worst case) so
+	// the settings catalog doesn't UNDER-call them — under-calling severity is
+	// the dangerous error on a posture surface. The queue still shows each
+	// finding's exact severity.
+	"sensitiveHostPath": sevHigh,
+	"stuckTerminating":  sevHigh,
+	"crossplaneStuck":   sevHigh,
 }
 
 // Stamp DefaultSeverity onto the catalog so the Hub's Checks settings can show

--- a/pkg/audit/registry_test.go
+++ b/pkg/audit/registry_test.go
@@ -1,0 +1,36 @@
+package audit
+
+import "testing"
+
+// Every catalog entry must declare a category in the same vocabulary findings
+// emit under — the Hub's Checks settings groups the catalog by it, so an empty
+// or mistyped category would file a check under a section its findings never
+// appear in (or drop it from the list entirely).
+func TestRegistryCategoriesValid(t *testing.T) {
+	valid := map[string]bool{
+		CategorySecurity:    true,
+		CategoryReliability: true,
+		CategoryEfficiency:  true,
+	}
+	for id, meta := range CheckRegistry {
+		if !valid[meta.Category] {
+			t.Errorf("check %q has category %q, want one of Security/Reliability/Efficiency", id, meta.Category)
+		}
+	}
+}
+
+// DefaultSeverity drives what the Hub's Checks settings shows for a non-overridden
+// check, so every catalog entry must carry a real ladder level.
+func TestRegistryDefaultSeverity(t *testing.T) {
+	for id, meta := range CheckRegistry {
+		if meta.DefaultSeverity != sevHigh && meta.DefaultSeverity != sevMedium {
+			t.Errorf("check %q has DefaultSeverity %q, want %q or %q", id, meta.DefaultSeverity, sevHigh, sevMedium)
+		}
+	}
+	// Every nonMediumDefault key must name a real check, or it's silently dead.
+	for id := range nonMediumDefault {
+		if _, ok := CheckRegistry[id]; !ok {
+			t.Errorf("nonMediumDefault names %q which is not in CheckRegistry", id)
+		}
+	}
+}

--- a/pkg/checks/checks.go
+++ b/pkg/checks/checks.go
@@ -80,12 +80,18 @@ const SourceRadarBuiltin = "radar_builtin"
 // CheckMeta is a check's static definition (catalog entry). pkg/audit aliases
 // this type so the audit engine's registry and this package share one shape.
 type CheckMeta struct {
-	ID          string      `json:"id"`
-	Title       string      `json:"title"`
-	Description string      `json:"description"`
-	Remediation string      `json:"remediation"`
-	Frameworks  []string    `json:"frameworks,omitempty"`
-	References  []Reference `json:"references,omitempty"`
+	ID       string `json:"id"`
+	Title    string `json:"title"`
+	Category string `json:"category,omitempty"` // Security|Reliability|Efficiency — the bucket findings emit under
+	// DefaultSeverity is the Checks-ladder level (MapSeverity of the detector's
+	// raw severity) a finding carries with no org override — its common/base
+	// case for checks that ramp or split by context. May be empty for catalogs
+	// from a Radar predating the field; consumers fall back to "Default".
+	DefaultSeverity string      `json:"defaultSeverity,omitempty"`
+	Description     string      `json:"description"`
+	Remediation     string      `json:"remediation"`
+	Frameworks      []string    `json:"frameworks,omitempty"`
+	References      []Reference `json:"references,omitempty"`
 }
 
 // Reference is an authoritative link for a check (Kubernetes docs, CIS,

--- a/pkg/issuesapi/catalog.go
+++ b/pkg/issuesapi/catalog.go
@@ -62,7 +62,7 @@ var catalogOrder = []Category{
 	CategoryMissingConfigRef, CategoryPDBBlocksEvictions, CategorySecretSyncFailed,
 	// Networking
 	CategoryServiceNoEndpoints, CategoryIngressBackendMissing, CategoryLoadBalancerPending,
-	CategoryGatewayNotReady, CategoryGatewayRouteInvalid, CategoryDNSFailure, CategoryNetworkPolicyBlock,
+	CategoryGatewayNotReady, CategoryGatewayRouteInvalid, CategoryDNSFailure,
 	// Storage
 	CategoryPVCPending, CategoryPVCLost, CategoryPVFailed, CategoryPVCResizeFailed,
 	CategoryVolumeMountFailed, CategoryVolumeAccessModeConflict,
@@ -78,6 +78,16 @@ var catalogOrder = []Category{
 	CategoryWebhookBackendDown, CategoryControlPlaneNotReady, CategoryMachineNotReady,
 }
 
+// categoriesWithoutDetector are enum categories Radar doesn't emit yet — the
+// detection layer (internal/issues/category.go) has no path that produces them.
+// They're deliberately excluded from the catalog: a settings registry must not
+// imply Radar detects something it can't (you can't hide what never fires).
+// When a detector lands, move the category into catalogOrder + categoryDescription
+// and drop it from here. TestCatalogComplete enforces both directions.
+var categoriesWithoutDetector = map[Category]bool{
+	CategoryNetworkPolicyBlock: true,
+}
+
 var categoryDescription = map[Category]string{
 	// Scheduling
 	CategoryUnschedulable:            "Pods can't be placed on any node — none satisfies their CPU/memory requests, node selector, affinity, taints, or topology constraints.",
@@ -85,16 +95,16 @@ var categoryDescription = map[Category]string{
 	CategoryAdmissionWebhookBlocking: "An admission webhook is rejecting the resource — a validating or mutating webhook denied or errored on the request.",
 	// Startup
 	CategoryImagePullFailed:     "A container image can't be pulled — wrong name/tag, a private registry without credentials, or the registry is unreachable (ImagePullBackOff).",
-	CategoryContainerWaiting:    "A container is stuck Waiting and never reached Running — blocked on config, secrets, volumes, or its image.",
+	CategoryContainerWaiting:    "A container is stuck Waiting and never reached Running — blocked on config, secrets, volumes, its image, or a pod sandbox / IP from the CNI.",
 	CategoryInitContainerFailed: "An init container is failing or looping, so the main containers never start.",
 	// Runtime
 	CategoryCrashLoop:         "A container keeps crashing and restarting (CrashLoopBackOff) — it exits non-zero shortly after starting.",
-	CategoryOOMKilled:         "A container was killed for exceeding its memory limit (OOMKilled) — raise the limit or fix the leak.",
+	CategoryOOMKilled:         "A container was OOMKilled — it hit its own memory limit, or the node ran out of memory. Check usage vs limits and node memory pressure before raising limits.",
 	CategoryLivenessProbeFail: "The liveness probe keeps failing, so the kubelet repeatedly restarts the container.",
 	CategoryReadinessFailed:   "The readiness probe is failing, so the pod is kept out of Service endpoints and receives no traffic.",
 	CategoryWorkloadDegraded:  "A workload has fewer ready replicas than desired — some pods are unavailable.",
 	CategoryHighRestart:       "A container has restarted many times — unstable even if it's currently running.",
-	CategoryJobFailed:         "A Job exhausted its retries (backoffLimit) without completing successfully.",
+	CategoryJobFailed:         "A Job failed — it exhausted its retries (backoffLimit) or hit its deadline — or has been running too long with no completions.",
 	CategoryCronJobFailed:     "A CronJob's recent runs are failing, or its schedule isn't producing successful jobs.",
 	// Configuration
 	CategoryMissingConfigRef:   "A pod references a ConfigMap, Secret, or volume that doesn't exist, so it can't start.",
@@ -106,8 +116,7 @@ var categoryDescription = map[Category]string{
 	CategoryLoadBalancerPending:   "A LoadBalancer Service is stuck Pending — the cloud controller hasn't provisioned an external IP.",
 	CategoryGatewayNotReady:       "A Gateway (Gateway API) isn't accepted or programmed — its listeners aren't serving.",
 	CategoryGatewayRouteInvalid:   "An HTTPRoute (or other route) was rejected or not accepted by its parent Gateway.",
-	CategoryDNSFailure:            "In-cluster DNS resolution is failing — CoreDNS or a workload's lookups aren't resolving.",
-	CategoryNetworkPolicyBlock:    "A NetworkPolicy is blocking traffic the workload needs — suspected denied connectivity.",
+	CategoryDNSFailure:            "CoreDNS's Corefile has a rule (an NXDOMAIN template or a rewrite) that can override Kubernetes service DNS — a misconfiguration that risks breaking in-cluster name resolution.",
 	// Storage
 	CategoryPVCPending:               "A PersistentVolumeClaim is stuck Pending — no matching volume and provisioning hasn't completed.",
 	CategoryPVCLost:                  "A PersistentVolumeClaim's bound volume was lost — the underlying PersistentVolume is gone.",
@@ -119,7 +128,7 @@ var categoryDescription = map[Category]string{
 	CategoryRolloutStalled:     "A Deployment or StatefulSet rollout is stuck — the new revision isn't progressing (progressDeadlineExceeded).",
 	CategoryHPALimitedOrFailed: "A HorizontalPodAutoscaler can't scale — missing metrics, pinned at max replicas, or scaling errors.",
 	// Security
-	CategoryRBACForbidden:        "A workload's ServiceAccount is being denied by RBAC — it lacks a permission it's trying to use.",
+	CategoryRBACForbidden:        "A workload can't create its pods — its controller's ServiceAccount is denied pod creation by RBAC.",
 	CategoryCertificateNotReady:  "A cert-manager Certificate isn't issued — issuance is failing or still pending.",
 	CategoryPodSecurityViolation: "Pod Security admission is rejecting pods — they violate the namespace's enforced Pod Security Standard.",
 	// Control plane
@@ -135,7 +144,7 @@ var categoryDescription = map[Category]string{
 	CategoryGitOpsOperationFailed: "A GitOps sync ran but failed — a resource apply, install, or upgrade errored.",
 	CategoryGitOpsOutOfSync:       "Live state has drifted from Git — the GitOps app is OutOfSync.",
 	CategoryGitOpsHealthDegraded:  "A GitOps app's managed resources are unhealthy or missing.",
-	CategoryWebhookBackendDown:    "An admission webhook's backend service is down — the webhook can't be reached, blocking matching requests.",
+	CategoryWebhookBackendDown:    "An admission webhook points at a backend Service that doesn't exist — matching requests are blocked (failurePolicy=Fail) or silently bypassed (Ignore).",
 	CategoryControlPlaneNotReady:  "A managed control plane (Cluster API) isn't ready — the cluster's control plane is unhealthy or still provisioning.",
 	CategoryMachineNotReady:       "A Cluster API Machine isn't ready — the underlying instance failed to join or is unhealthy.",
 }

--- a/pkg/issuesapi/catalog.go
+++ b/pkg/issuesapi/catalog.go
@@ -1,0 +1,159 @@
+package issuesapi
+
+// Static, human-facing catalog of issue categories for the Hub's Issues
+// settings — so an org can hide categories proactively, not just the ones
+// currently firing in the fleet. Descriptions live here (the category enum
+// carries none); titles are intentionally NOT included — consumers label
+// categories via their own map (k8s-ui categoryLabel) so the settings page and
+// the live queue stay labelled identically.
+
+// CatalogCategory is one issue category's static, displayable definition.
+type CatalogCategory struct {
+	Category    Category `json:"category"`
+	Description string   `json:"description"`
+}
+
+// CatalogGroup is a display group with its member categories, in display order.
+type CatalogGroup struct {
+	Group      CategoryGroup     `json:"group"`
+	Title      string            `json:"title"`
+	Categories []CatalogCategory `json:"categories"`
+}
+
+// groupOrder is the display order of category groups — the lifecycle arc a
+// workload moves through (schedule → start → run → wire up → …) then platform.
+var groupOrder = []CategoryGroup{
+	GroupScheduling, GroupStartup, GroupRuntime, GroupConfiguration,
+	GroupNetworking, GroupStorage, GroupScaling, GroupSecurity, GroupControlPlane,
+}
+
+var groupTitle = map[CategoryGroup]string{
+	GroupScheduling:    "Scheduling",
+	GroupStartup:       "Startup",
+	GroupRuntime:       "Runtime",
+	GroupConfiguration: "Configuration",
+	GroupNetworking:    "Networking",
+	GroupStorage:       "Storage",
+	GroupScaling:       "Scaling",
+	GroupSecurity:      "Security",
+	GroupControlPlane:  "Control plane",
+}
+
+// GroupTitle returns the display label for a category group.
+func GroupTitle(g CategoryGroup) string {
+	if t, ok := groupTitle[g]; ok {
+		return t
+	}
+	return string(g)
+}
+
+// catalogOrder is every real category (excluding "unknown") in display order
+// within its group. TestCatalogComplete keeps it in lockstep with the category
+// enum + group map.
+var catalogOrder = []Category{
+	// Scheduling
+	CategoryUnschedulable, CategoryQuotaExceeded, CategoryAdmissionWebhookBlocking,
+	// Startup
+	CategoryImagePullFailed, CategoryContainerWaiting, CategoryInitContainerFailed,
+	// Runtime
+	CategoryCrashLoop, CategoryOOMKilled, CategoryLivenessProbeFail, CategoryReadinessFailed,
+	CategoryWorkloadDegraded, CategoryHighRestart, CategoryJobFailed, CategoryCronJobFailed,
+	// Configuration
+	CategoryMissingConfigRef, CategoryPDBBlocksEvictions, CategorySecretSyncFailed,
+	// Networking
+	CategoryServiceNoEndpoints, CategoryIngressBackendMissing, CategoryLoadBalancerPending,
+	CategoryGatewayNotReady, CategoryGatewayRouteInvalid, CategoryDNSFailure, CategoryNetworkPolicyBlock,
+	// Storage
+	CategoryPVCPending, CategoryPVCLost, CategoryPVFailed, CategoryPVCResizeFailed,
+	CategoryVolumeMountFailed, CategoryVolumeAccessModeConflict,
+	// Scaling
+	CategoryRolloutStalled, CategoryHPALimitedOrFailed,
+	// Security
+	CategoryRBACForbidden, CategoryCertificateNotReady, CategoryPodSecurityViolation,
+	// Control plane
+	CategoryTerminationStuck, CategoryNodeNotReady, CategoryAPIServiceUnavailable,
+	CategoryNodeProvisioningFail, CategoryCrossplaneReconcile, CategoryOperatorConditionFail,
+	CategoryGitOpsSyncFailed, CategoryGitOpsRenderFailed, CategoryGitOpsSpecInvalid,
+	CategoryGitOpsOperationFailed, CategoryGitOpsOutOfSync, CategoryGitOpsHealthDegraded,
+	CategoryWebhookBackendDown, CategoryControlPlaneNotReady, CategoryMachineNotReady,
+}
+
+var categoryDescription = map[Category]string{
+	// Scheduling
+	CategoryUnschedulable:            "Pods can't be placed on any node — none satisfies their CPU/memory requests, node selector, affinity, taints, or topology constraints.",
+	CategoryQuotaExceeded:            "A ResourceQuota or LimitRange rejected the workload — the namespace is out of its CPU, memory, or object budget.",
+	CategoryAdmissionWebhookBlocking: "An admission webhook is rejecting the resource — a validating or mutating webhook denied or errored on the request.",
+	// Startup
+	CategoryImagePullFailed:     "A container image can't be pulled — wrong name/tag, a private registry without credentials, or the registry is unreachable (ImagePullBackOff).",
+	CategoryContainerWaiting:    "A container is stuck Waiting and never reached Running — blocked on config, secrets, volumes, or its image.",
+	CategoryInitContainerFailed: "An init container is failing or looping, so the main containers never start.",
+	// Runtime
+	CategoryCrashLoop:         "A container keeps crashing and restarting (CrashLoopBackOff) — it exits non-zero shortly after starting.",
+	CategoryOOMKilled:         "A container was killed for exceeding its memory limit (OOMKilled) — raise the limit or fix the leak.",
+	CategoryLivenessProbeFail: "The liveness probe keeps failing, so the kubelet repeatedly restarts the container.",
+	CategoryReadinessFailed:   "The readiness probe is failing, so the pod is kept out of Service endpoints and receives no traffic.",
+	CategoryWorkloadDegraded:  "A workload has fewer ready replicas than desired — some pods are unavailable.",
+	CategoryHighRestart:       "A container has restarted many times — unstable even if it's currently running.",
+	CategoryJobFailed:         "A Job exhausted its retries (backoffLimit) without completing successfully.",
+	CategoryCronJobFailed:     "A CronJob's recent runs are failing, or its schedule isn't producing successful jobs.",
+	// Configuration
+	CategoryMissingConfigRef:   "A pod references a ConfigMap, Secret, or volume that doesn't exist, so it can't start.",
+	CategoryPDBBlocksEvictions: "A PodDisruptionBudget is blocking evictions — node drains and upgrades can't make progress.",
+	CategorySecretSyncFailed:   "An external secret sync (e.g. External Secrets Operator) failed to materialize a Secret.",
+	// Networking
+	CategoryServiceNoEndpoints:    "A Service has no ready endpoints — its selector matches no ready pods, so traffic to it fails.",
+	CategoryIngressBackendMissing: "An Ingress points at a Service that doesn't exist — incoming requests get 503s.",
+	CategoryLoadBalancerPending:   "A LoadBalancer Service is stuck Pending — the cloud controller hasn't provisioned an external IP.",
+	CategoryGatewayNotReady:       "A Gateway (Gateway API) isn't accepted or programmed — its listeners aren't serving.",
+	CategoryGatewayRouteInvalid:   "An HTTPRoute (or other route) was rejected or not accepted by its parent Gateway.",
+	CategoryDNSFailure:            "In-cluster DNS resolution is failing — CoreDNS or a workload's lookups aren't resolving.",
+	CategoryNetworkPolicyBlock:    "A NetworkPolicy is blocking traffic the workload needs — suspected denied connectivity.",
+	// Storage
+	CategoryPVCPending:               "A PersistentVolumeClaim is stuck Pending — no matching volume and provisioning hasn't completed.",
+	CategoryPVCLost:                  "A PersistentVolumeClaim's bound volume was lost — the underlying PersistentVolume is gone.",
+	CategoryPVFailed:                 "A PersistentVolume is in Failed state — its reclaim or backing storage failed.",
+	CategoryPVCResizeFailed:          "A volume expansion didn't complete — the requested resize failed or is stuck.",
+	CategoryVolumeMountFailed:        "A pod can't mount a volume — attach/mount failed (wrong node, missing CSI driver, or permissions).",
+	CategoryVolumeAccessModeConflict: "A volume's access mode conflicts with how it's mounted (e.g. an RWO volume claimed by pods on different nodes).",
+	// Scaling
+	CategoryRolloutStalled:     "A Deployment or StatefulSet rollout is stuck — the new revision isn't progressing (progressDeadlineExceeded).",
+	CategoryHPALimitedOrFailed: "A HorizontalPodAutoscaler can't scale — missing metrics, pinned at max replicas, or scaling errors.",
+	// Security
+	CategoryRBACForbidden:        "A workload's ServiceAccount is being denied by RBAC — it lacks a permission it's trying to use.",
+	CategoryCertificateNotReady:  "A cert-manager Certificate isn't issued — issuance is failing or still pending.",
+	CategoryPodSecurityViolation: "Pod Security admission is rejecting pods — they violate the namespace's enforced Pod Security Standard.",
+	// Control plane
+	CategoryTerminationStuck:      "A resource is stuck Terminating past the cleanup window — a finalizer's owning controller is unhealthy.",
+	CategoryNodeNotReady:          "A node is NotReady — its kubelet isn't reporting healthy, putting the pods on it at risk.",
+	CategoryAPIServiceUnavailable: "An aggregated APIService is unavailable — its backing extension API server isn't responding.",
+	CategoryNodeProvisioningFail:  "Node provisioning failed — the autoscaler or Karpenter couldn't bring up a node.",
+	CategoryCrossplaneReconcile:   "A Crossplane managed or composite resource can't reconcile — its Ready or Synced condition is False.",
+	CategoryOperatorConditionFail: "An operator-managed resource is reporting a failed status condition.",
+	CategoryGitOpsSyncFailed:      "A GitOps app failed to sync (catch-all) — Argo CD or Flux couldn't reconcile it to the desired state.",
+	CategoryGitOpsRenderFailed:    "GitOps couldn't render manifests from Git — a kustomize/helm build or source fetch failed.",
+	CategoryGitOpsSpecInvalid:     "A GitOps app's spec is invalid — a bad destination, source, or project reference.",
+	CategoryGitOpsOperationFailed: "A GitOps sync ran but failed — a resource apply, install, or upgrade errored.",
+	CategoryGitOpsOutOfSync:       "Live state has drifted from Git — the GitOps app is OutOfSync.",
+	CategoryGitOpsHealthDegraded:  "A GitOps app's managed resources are unhealthy or missing.",
+	CategoryWebhookBackendDown:    "An admission webhook's backend service is down — the webhook can't be reached, blocking matching requests.",
+	CategoryControlPlaneNotReady:  "A managed control plane (Cluster API) isn't ready — the cluster's control plane is unhealthy or still provisioning.",
+	CategoryMachineNotReady:       "A Cluster API Machine isn't ready — the underlying instance failed to join or is unhealthy.",
+}
+
+// Catalog returns every issue category grouped and ordered for display, each
+// with its one-line description. Static (compiled in) — no cluster data needed.
+func Catalog() []CatalogGroup {
+	out := make([]CatalogGroup, 0, len(groupOrder))
+	for _, g := range groupOrder {
+		var cats []CatalogCategory
+		for _, c := range catalogOrder {
+			if GroupOf(c) == g {
+				cats = append(cats, CatalogCategory{Category: c, Description: categoryDescription[c]})
+			}
+		}
+		if len(cats) > 0 {
+			out = append(out, CatalogGroup{Group: g, Title: GroupTitle(g), Categories: cats})
+		}
+	}
+	return out
+}

--- a/pkg/issuesapi/catalog_test.go
+++ b/pkg/issuesapi/catalog_test.go
@@ -21,8 +21,22 @@ func TestCatalogComplete(t *testing.T) {
 		}
 	}
 	for c := range categoryGroup {
+		if categoriesWithoutDetector[c] {
+			// Excluded on purpose (no detector) — must NOT be in the catalog.
+			if _, ok := inOrder[c]; ok {
+				t.Errorf("category %q is marked no-detector but appears in catalogOrder", c)
+			}
+			continue
+		}
 		if _, ok := inOrder[c]; !ok {
 			t.Errorf("category %q is in the group map but missing from catalogOrder/catalog", c)
+		}
+	}
+	// Every no-detector exclusion must name a real enum category (else it's a
+	// stale typo silently excluding nothing).
+	for c := range categoriesWithoutDetector {
+		if _, ok := categoryGroup[c]; !ok {
+			t.Errorf("categoriesWithoutDetector lists %q which is not a real category", c)
 		}
 	}
 }

--- a/pkg/issuesapi/catalog_test.go
+++ b/pkg/issuesapi/catalog_test.go
@@ -1,0 +1,55 @@
+package issuesapi
+
+import "testing"
+
+// The catalog must stay in lockstep with the category enum: every real category
+// (everything in the group map) needs an order slot + a description, and nothing
+// extra. Otherwise the Hub's Issues settings would silently drop a category or
+// render a blank description.
+func TestCatalogComplete(t *testing.T) {
+	inOrder := map[Category]int{}
+	for _, c := range catalogOrder {
+		inOrder[c]++
+		if inOrder[c] > 1 {
+			t.Errorf("category %q appears more than once in catalogOrder", c)
+		}
+		if categoryDescription[c] == "" {
+			t.Errorf("category %q has no description", c)
+		}
+		if _, ok := categoryGroup[c]; !ok {
+			t.Errorf("category %q is in catalogOrder but not the group map", c)
+		}
+	}
+	for c := range categoryGroup {
+		if _, ok := inOrder[c]; !ok {
+			t.Errorf("category %q is in the group map but missing from catalogOrder/catalog", c)
+		}
+	}
+}
+
+// Catalog() groups by GroupOf, preserves group order, and surfaces every
+// category exactly once.
+func TestCatalogStructure(t *testing.T) {
+	cat := Catalog()
+	if len(cat) == 0 {
+		t.Fatal("Catalog() returned no groups")
+	}
+	seen := 0
+	for _, g := range cat {
+		if g.Title == "" {
+			t.Errorf("group %q has no title", g.Group)
+		}
+		for _, c := range g.Categories {
+			seen++
+			if GroupOf(c.Category) != g.Group {
+				t.Errorf("category %q filed under group %q but GroupOf says %q", c.Category, g.Group, GroupOf(c.Category))
+			}
+			if c.Description == "" {
+				t.Errorf("category %q has empty description in Catalog()", c.Category)
+			}
+		}
+	}
+	if seen != len(catalogOrder) {
+		t.Errorf("Catalog() surfaced %d categories, want %d", seen, len(catalogOrder))
+	}
+}


### PR DESCRIPTION
Additive, backward-compatible metadata on the check + issue catalogs that **Radar Hub's settings registries** consume. No behavior change in OSS Radar — these are new fields/functions; nothing existing reads them differently.

## What's added
- **`checks.CheckMeta.Category`** — `Security`/`Reliability`/`Efficiency`, the bucket a check's findings emit under. Populated for all 32 checks in `pkg/audit/registry.go`.
- **`checks.CheckMeta.DefaultSeverity`** — the Checks-ladder level a finding carries with no override (`MapSeverity`: danger→High, warning→Medium). Stamped via `init()` from a small map. Context-varying checks (sensitiveHostPath split by path; stuck*/crossplane age-ramp) surface their **worst case (High)** so a posture-settings catalog doesn't under-call them; the queue still shows each finding's exact severity.
- **`issuesapi.Catalog()`** — every issue category grouped by its 9 symptom groups, each with a one-line description, so a consumer can list *all* categories (not just ones currently firing in a fleet). Descriptions live here because the category enum carried none.

## Why
Radar Hub is rebuilding Settings → Checks and Settings → Issues as browsable registries (every check/category with a description + toggle), grouped by category. That needs each check's category + default severity, and the full issue-category catalog with descriptions — none of which existed as queryable metadata.

## Tests
`TestRegistryCategoriesValid`, `TestRegistryDefaultSeverity`, `TestCatalogComplete`, `TestCatalogStructure` keep the metadata in lockstep with the enums (a new check/category without a category/description/order entry fails CI).

Consumed by radar-hub + radar-hub-web (Settings registries). Ships in the next `radar/pkg` tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive JSON fields and a new static catalog API; no changes to audit execution, finding emission, or existing consumers.
> 
> **Overview**
> Adds **queryable catalog metadata** for Radar Hub’s Settings → Checks and Settings → Issues registries, without changing OSS Radar detection or rollup behavior.
> 
> **Checks:** `CheckMeta` gains optional `category` and `defaultSeverity`. All built-in checks in `pkg/audit/registry.go` now declare **Security / Reliability / Efficiency** to match runtime finding buckets. An `init()` stamps **default severity** (High vs Medium) from a small map aligned with `MapSeverity`, so the Hub can show the ladder level without re-deriving it from raw findings.
> 
> **Issues:** New `issuesapi.Catalog()` returns every detectable issue category grouped into nine symptom groups, each with a one-line description. Categories without detectors (e.g. network policy) are excluded so settings don’t imply coverage Radar doesn’t have.
> 
> **Tests:** `TestRegistryCategoriesValid`, `TestRegistryDefaultSeverity`, `TestCatalogComplete`, and `TestCatalogStructure` keep registry and catalog in sync with enums and descriptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa859c4ff112c7a1b0f1ad7c03cb8cd5d9271671. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
