### PR TITLE
Improve pod failure root cause issues

### DIFF
--- a/internal/issues/grouping.go
+++ b/internal/issues/grouping.go
@@ -125,11 +125,10 @@ func foldGroup(members []Issue) Issue {
 		LastSeen:             rep.LastSeen,
 	}
 	// A parsed diagnosis (cause/action/remediation) describes ONE resource's
-	// failure. Carry it onto the grouped row only when every member that has
-	// one agrees: a single-member group (a GitOps Application is its own
-	// subject) always carries it, but a workload rollup whose members fail for
-	// different reasons (OOMKilled vs ImagePullBackOff) must not present one
-	// member's cause as the whole group's.
+	// failure. Carry it onto the grouped row only when it is true for the
+	// entire group: a single-member group carries its own diagnosis, but a
+	// workload rollup omits diagnosis unless every folded member has the same
+	// tuple.
 	if dg, ok := agreedDiagnosis(members); ok {
 		g.Cause = dg.Cause
 		g.Action = dg.Action
@@ -195,21 +194,21 @@ func foldGroup(members []Issue) Issue {
 }
 
 // agreedDiagnosis returns the parsed diagnosis shared by a group's members, or
-// ok=false when members carry conflicting diagnoses. Members with no parsed
-// diagnosis (the common case for workload problems today) are ignored — they
-// don't count as disagreement. The full (cause, action, remediation) tuple
-// must match across every member that has one, so a mixed-cause rollup omits
-// the diagnosis rather than misattributing one member's fix to the group.
+// ok=false when members carry conflicting or incomplete diagnoses. The full
+// (cause, action, remediation) tuple must match across every member in a
+// multi-resource group, so a mixed rollup omits diagnosis rather than
+// misattributing one member's fix to the group.
 func agreedDiagnosis(members []Issue) (Issue, bool) {
 	var picked Issue
-	have := false
+	if len(members) == 0 {
+		return Issue{}, false
+	}
 	for _, m := range members {
-		if m.Cause == "" && m.Action == "" && m.RemediationKind == "" && m.RemediationTarget == "" &&
-			m.OperationRetryCount == 0 && !m.Stuck {
-			continue
+		if !hasDiagnosis(m) {
+			return Issue{}, false
 		}
-		if !have {
-			picked, have = m, true
+		if !hasDiagnosis(picked) {
+			picked = m
 			continue
 		}
 		if m.Cause != picked.Cause || m.Action != picked.Action ||
@@ -218,7 +217,12 @@ func agreedDiagnosis(members []Issue) (Issue, bool) {
 			return Issue{}, false
 		}
 	}
-	return picked, have
+	return picked, true
+}
+
+func hasDiagnosis(i Issue) bool {
+	return i.Cause != "" || i.Action != "" || i.RemediationKind != "" || i.RemediationTarget != "" ||
+		i.OperationRetryCount != 0 || i.Stuck
 }
 
 // betterRepresentative reports whether cand should replace cur as a group's

--- a/internal/issues/grouping_test.go
+++ b/internal/issues/grouping_test.go
@@ -85,12 +85,9 @@ func TestGroupIssues_CarriesAgreedDiagnosis(t *testing.T) {
 	}
 }
 
-// TestGroupIssues_CarriesLoneDiagnosis pins the "no opinion ≠ disagreement"
-// rule: when one member of a group has a parsed diagnosis and another has none,
-// the lone diagnosis still carries (a blank member is not treated as a
-// conflict). A naive "omit whenever any member lacks a diagnosis" would strip
-// the cause off every mixed workload+GitOps rollup.
-func TestGroupIssues_CarriesLoneDiagnosis(t *testing.T) {
+// TestGroupIssues_OmitsLoneDiagnosis pins that a workload rollup only carries
+// diagnosis when the diagnosis applies to every folded member.
+func TestGroupIssues_OmitsLoneDiagnosis(t *testing.T) {
 	dep := Ref{Group: "apps", Kind: "Deployment", Namespace: "ns", Name: "web"}
 	t0 := time.Unix(1000, 0)
 	a := flatPod("web-a", "CrashLoopBackOff", SeverityCritical, dep, t0, t0)
@@ -100,8 +97,8 @@ func TestGroupIssues_CarriesLoneDiagnosis(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("want 1 grouped row, got %d", len(got))
 	}
-	if got[0].Cause != a.Cause {
-		t.Errorf("lone diagnosis should carry; got cause %q, want %q", got[0].Cause, a.Cause)
+	if got[0].Cause != "" {
+		t.Errorf("lone member diagnosis must not carry to grouped row, got cause %q", got[0].Cause)
 	}
 }
 

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -178,6 +178,66 @@ func TestCompose_GroupedKindFilterMatchesSubject(t *testing.T) {
 	}
 }
 
+func TestCompose_GroupedDiagnosisRequiresEveryMemberToAgree(t *testing.T) {
+	p := &fakeProvider{
+		problems: []k8s.Detection{
+			{
+				Kind: "Pod", Namespace: "ns", Name: "web-a", Severity: "critical", Reason: "CrashLoopBackOff",
+				OwnerKind: "Deployment", OwnerName: "web",
+				Cause: "command not found", Action: "fix the container command",
+			},
+			{Kind: "Pod", Namespace: "ns", Name: "web-b", Severity: "critical", Reason: "CrashLoopBackOff", OwnerKind: "Deployment", OwnerName: "web"},
+		},
+	}
+	out := Compose(p, Filters{Grouped: true})
+	if len(out) != 1 {
+		t.Fatalf("got %d issues, want 1: %+v", len(out), out)
+	}
+	if out[0].Cause != "" || out[0].Action != "" {
+		t.Fatalf("mixed parsed/unparsed rollup must omit diagnosis, got cause=%q action=%q", out[0].Cause, out[0].Action)
+	}
+}
+
+func TestCompose_GroupedDiagnosisKeepsIdenticalMemberDiagnosis(t *testing.T) {
+	p := &fakeProvider{
+		problems: []k8s.Detection{
+			{
+				Kind: "Pod", Namespace: "ns", Name: "web-a", Severity: "critical", Reason: "CrashLoopBackOff",
+				OwnerKind: "Deployment", OwnerName: "web",
+				Cause: "command not found", Action: "fix the container command",
+			},
+			{
+				Kind: "Pod", Namespace: "ns", Name: "web-b", Severity: "critical", Reason: "CrashLoopBackOff",
+				OwnerKind: "Deployment", OwnerName: "web",
+				Cause: "command not found", Action: "fix the container command",
+			},
+		},
+	}
+	out := Compose(p, Filters{Grouped: true})
+	if len(out) != 1 {
+		t.Fatalf("got %d issues, want 1: %+v", len(out), out)
+	}
+	if out[0].Cause != "command not found" || out[0].Action != "fix the container command" {
+		t.Fatalf("identical member diagnosis should be promoted, got cause=%q action=%q", out[0].Cause, out[0].Action)
+	}
+}
+
+func TestCompose_GroupedSingleIssueKeepsDiagnosis(t *testing.T) {
+	p := &fakeProvider{
+		problems: []k8s.Detection{{
+			Kind: "Pod", Namespace: "ns", Name: "standalone", Severity: "critical", Reason: "CrashLoopBackOff",
+			Cause: "command not found", Action: "fix the container command",
+		}},
+	}
+	out := Compose(p, Filters{Grouped: true})
+	if len(out) != 1 {
+		t.Fatalf("got %d issues, want 1: %+v", len(out), out)
+	}
+	if out[0].Cause == "" || out[0].Action == "" {
+		t.Fatalf("single-resource issue should keep diagnosis, got %+v", out[0])
+	}
+}
+
 func TestCompose_DropsInfoSeverityFromQueue(t *testing.T) {
 	// info-severity problems are inert/posture (deprecated-RBAC residue,
 	// singleton-StatefulSet headless-DNS trivia) — excluded from the live issue
@@ -342,7 +402,11 @@ func TestCompose_PVCPendingDedupesOverMissingStorageClass(t *testing.T) {
 	// One incident, one row: the missing-ref row names the cause and wins.
 	p := &fakeProvider{
 		problems: []k8s.Detection{
-			{Kind: "PersistentVolumeClaim", Namespace: "ns", Name: "stuck-pvc", Severity: "high", Reason: "Pending", IssueTiming: "started_at_resource_creation", IssueTimingBasis: "phase"},
+			{
+				Kind: "PersistentVolumeClaim", Namespace: "ns", Name: "stuck-pvc", Severity: "high", Reason: "Pending",
+				Cause: "Storage provisioner failed to create a volume.", Action: "Check the CSI controller logs.",
+				IssueTiming: "started_at_resource_creation", IssueTimingBasis: "phase",
+			},
 		},
 		missingRefs: []k8s.Detection{
 			{Kind: "PersistentVolumeClaim", Namespace: "ns", Name: "stuck-pvc", Severity: "critical", Reason: "Missing StorageClass", Fingerprint: "Missing StorageClass|abc", IssueTiming: "started_at_resource_creation", IssueTimingBasis: "phase"},
@@ -360,6 +424,9 @@ func TestCompose_PVCPendingDedupesOverMissingStorageClass(t *testing.T) {
 	}
 	if pvcRows[0].Reason != "Missing StorageClass" {
 		t.Errorf("the cause-naming missing-ref row must win, got reason %q", pvcRows[0].Reason)
+	}
+	if pvcRows[0].Source != SourceMissingRef {
+		t.Errorf("missing-ref row must win over enriched phase row, got source %q", pvcRows[0].Source)
 	}
 	if pvcRows[0].IssueTiming != "started_at_resource_creation" || pvcRows[0].IssueTimingBasis != "phase" {
 		t.Errorf("surviving row must keep at-creation/phase timing, got (%q, %q)", pvcRows[0].IssueTiming, pvcRows[0].IssueTimingBasis)

--- a/internal/k8s/detect.go
+++ b/internal/k8s/detect.go
@@ -88,12 +88,11 @@ type Detection struct {
 	// Basis values: "condition" | "owner_condition" | "pod_creation" | "deletion" | "phase" | "spec".
 	IssueTiming      string
 	IssueTimingBasis string
-	// Cause / Action / Remediation* carry parsed domain diagnosis (today only
-	// GitOps controller errors, via pkg/gitops/diagnose) so the issues stream
-	// surfaces the same plain-English cause + next-step the GitOps detail page
-	// shows. Empty for detectors without a parser. RemediationKind names a
-	// structured one-click fix (e.g. "create-namespace") and RemediationTarget
-	// the resource it acts on.
+	// Cause / Action / Remediation* carry parsed domain diagnosis so the issues
+	// stream can surface a plain-English cause + next step when a detector has
+	// enough evidence. Empty for detectors without a parser. RemediationKind
+	// names a structured one-click fix (e.g. "create-namespace") and
+	// RemediationTarget the resource it acts on.
 	Cause             string
 	Action            string
 	RemediationKind   string
@@ -345,6 +344,7 @@ func DetectProblems(cache *ResourceCache, namespace string) []Detection {
 
 	podsByNamespace := listPodsByNamespace(cache, namespace)
 	probeFailures := latestProbeFailures(cache, namespace, now)
+	pvcPendingFailures := latestPVCPendingFailures(cache, namespace)
 
 	// Pod problems: high-signal container waiting/terminated states, old
 	// Pending pods, and restart-heavy pods. These are useful direct pointers
@@ -391,6 +391,12 @@ func DetectProblems(cache *ResourceCache, namespace string) []Detection {
 				reason = init.reason
 				message = init.message
 				fingerprint = init.fingerprint
+			}
+			var cause, action string
+			if reason == crashLoopReason {
+				cause, action = podCrashLoopDiagnosis(pod, now)
+			} else if c, a := imagePullDiagnosis(reason, message); c != "" {
+				cause, action = c, a
 			}
 			// IssueTiming: classify whether this pod has been failing since the Deployment
 			// was first created (started_at_resource_creation) or broke after a period of
@@ -500,6 +506,8 @@ func DetectProblems(cache *ResourceCache, namespace string) []Detection {
 				OwnerName:            ownerName,
 				IssueTiming:          podIssueTiming.IssueTiming,
 				IssueTimingBasis:     podIssueTiming.Basis,
+				Cause:                cause,
+				Action:               action,
 			})
 		}
 	}
@@ -905,17 +913,26 @@ func DetectProblems(cache *ResourceCache, namespace string) []Detection {
 					continue
 				}
 				if ageDur > 5*time.Minute {
+					message := "PVC is unbound — no volume has been provisioned"
+					var cause, action string
+					if failure, ok := pvcPendingFailures[pvc.Namespace+"/"+pvc.Name]; ok {
+						message = failure.message
+						cause = failure.cause
+						action = failure.action
+					}
 					problems = append(problems, Detection{
 						Kind:            "PersistentVolumeClaim",
 						Namespace:       pvc.Namespace,
 						Name:            pvc.Name,
 						Severity:        "high",
 						Reason:          "Pending",
-						Message:         "PVC is unbound — no volume has been provisioned",
+						Message:         message,
 						Age:             FormatAge(ageDur),
 						AgeSeconds:      int64(ageDur.Seconds()),
 						Duration:        FormatAge(ageDur),
 						DurationSeconds: int64(ageDur.Seconds()),
+						Cause:           cause,
+						Action:          action,
 						// Phase=Pending since creation means the PVC has never been bound —
 						// present since creation (wrong StorageClass, missing or failing provisioner).
 						IssueTiming:      "started_at_resource_creation",
@@ -1060,6 +1077,13 @@ type probeFailure struct {
 	at      time.Time
 }
 
+type pvcPendingFailure struct {
+	message string
+	cause   string
+	action  string
+	at      time.Time
+}
+
 type podSpecificProblem struct {
 	reason      string
 	message     string
@@ -1167,6 +1191,145 @@ func initContainerSpecSummary(pod *corev1.Pod, name string) string {
 		return strings.Join(parts, ", ")
 	}
 	return ""
+}
+
+func imagePullDiagnosis(reason, message string) (cause, action string) {
+	if !isImagePullReason(reason) {
+		return "", ""
+	}
+	ref := imageRefFromMessage(message)
+	lower := strings.ToLower(message)
+
+	switch {
+	case reason == "InvalidImageName" || strings.Contains(lower, "invalid reference format"):
+		return imageCause("Image reference is invalid", ref),
+			"Fix the image reference in the pod spec; check registry, repository, tag, and digest syntax."
+	case containsAny(lower, "unauthorized", "forbidden", "denied", "authentication required", "pull access denied") ||
+		containsStatusCode(lower, "401") || containsStatusCode(lower, "403"):
+		return imageCause("Not authorized to pull image", ref),
+			"Check imagePullSecrets, the pod service account, and registry permissions for this namespace."
+	case containsAny(lower, "toomanyrequests", "too many requests", "rate limit"):
+		return imageCause("Registry rate-limited", ref),
+			"Use an authenticated pull secret, reduce pull frequency, or mirror/cache the image."
+	case containsAny(lower, "no such host", "i/o timeout", "timeout", "connection refused", "dial tcp"):
+		return imageCause("Registry unreachable", ref),
+			"Check node egress, DNS, proxy/firewall rules, and the registry endpoint."
+	case containsAny(lower, "not found", "manifest unknown", "no such image", "no such manifest"):
+		return imageCause("Image not found", ref),
+			"Verify the repository and tag, then update the image reference or publish the missing image."
+	default:
+		return "", ""
+	}
+}
+
+func isImagePullReason(reason string) bool {
+	switch reason {
+	case "ImagePullBackOff", "ErrImagePull", "InvalidImageName", "ImageInspectError":
+		return true
+	default:
+		return false
+	}
+}
+
+func imageRefFromMessage(message string) string {
+	const marker = `image "`
+	start := strings.Index(message, marker)
+	if start < 0 {
+		return ""
+	}
+	rest := message[start+len(marker):]
+	end := strings.Index(rest, `"`)
+	if end < 0 {
+		return ""
+	}
+	return rest[:end]
+}
+
+func imageCause(base, ref string) string {
+	if ref == "" {
+		return base
+	}
+	return base + ": " + ref
+}
+
+func containsAny(s string, needles ...string) bool {
+	for _, needle := range needles {
+		if strings.Contains(s, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsStatusCode(s, code string) bool {
+	for start := strings.Index(s, code); start >= 0; {
+		end := start + len(code)
+		beforeOK := start == 0 || !isASCIIAlnum(s[start-1])
+		afterOK := end == len(s) || !isASCIIAlnum(s[end])
+		if beforeOK && afterOK {
+			return true
+		}
+		next := strings.Index(s[end:], code)
+		if next < 0 {
+			return false
+		}
+		start = end + next
+	}
+	return false
+}
+
+func isASCIIAlnum(b byte) bool {
+	return (b >= '0' && b <= '9') || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+func latestPVCPendingFailures(cache *ResourceCache, namespace string) map[string]pvcPendingFailure {
+	out := map[string]pvcPendingFailure{}
+	if cache == nil || cache.Events() == nil {
+		return out
+	}
+	var events []*corev1.Event
+	if namespace != "" {
+		events, _ = cache.Events().Events(namespace).List(labels.Everything())
+	} else {
+		events, _ = cache.Events().List(labels.Everything())
+	}
+	for _, e := range events {
+		if e.Type != corev1.EventTypeWarning || e.InvolvedObject.Kind != "PersistentVolumeClaim" {
+			continue
+		}
+		failure, ok := pvcPendingFailureFromEvent(e)
+		if !ok {
+			continue
+		}
+		if failure.at.IsZero() {
+			continue
+		}
+		key := e.InvolvedObject.Namespace + "/" + e.InvolvedObject.Name
+		if cur, exists := out[key]; exists && !failure.at.After(cur.at) {
+			continue
+		}
+		out[key] = failure
+	}
+	return out
+}
+
+func pvcPendingFailureFromEvent(e *corev1.Event) (pvcPendingFailure, bool) {
+	message := strings.TrimSpace(e.Message)
+	if message == "" {
+		message = e.Reason
+	}
+	f := pvcPendingFailure{message: message, at: eventLastTime(e)}
+	switch e.Reason {
+	case "ProvisioningFailed":
+		f.cause = "Storage provisioner failed to create a volume."
+		f.action = "Check the StorageClass/provisioner and CSI controller events or logs; fix the provisioner error, quota, credentials, or backend volume settings."
+	case "FailedBinding":
+		f.cause = "PVC could not bind to a PersistentVolume."
+		f.action = "Check matching PersistentVolumes, StorageClass topology and volumeBindingMode, and any consuming pod scheduling constraints."
+	default:
+		return pvcPendingFailure{}, false
+	}
+	return f, true
 }
 
 func latestProbeFailures(cache *ResourceCache, namespace string, now time.Time) map[string]probeFailure {

--- a/internal/k8s/detect_test.go
+++ b/internal/k8s/detect_test.go
@@ -10,6 +10,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -790,10 +791,15 @@ func TestDetectProblems_OperationalSignals(t *testing.T) {
 			Status: corev1.PodStatus{
 				Phase: corev1.PodRunning,
 				ContainerStatuses: []corev1.ContainerStatus{{
-					Name: "app",
+					Name:         "app",
+					RestartCount: 3,
 					State: corev1.ContainerState{
 						Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
 					},
+					LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+						Reason: "Error", ExitCode: 127,
+						StartedAt: metav1.NewTime(now.Add(-3 * time.Second)), FinishedAt: metav1.NewTime(now.Add(-2 * time.Second)),
+					}},
 				}},
 			},
 		},
@@ -887,6 +893,9 @@ func TestDetectProblems_OperationalSignals(t *testing.T) {
 	}
 
 	assertProblem(t, problems, "Pod", "crashy", "CrashLoopBackOff", "critical")
+	if got, ok := lookupProblem(problems, "Pod", "crashy", "CrashLoopBackOff"); !ok || !strings.Contains(got.Cause, "code 127") || !strings.Contains(got.Action, "command/args") {
+		t.Fatalf("crashy diagnosis = %+v, want exit-code cause/action", got)
+	}
 	// "Selector matches no pods" is warning, not critical — could be a
 	// deliberately scaled-to-zero workload. The "0/N selected pods ready"
 	// case below stays critical (workload exists, routing is actually
@@ -896,6 +905,128 @@ func TestDetectProblems_OperationalSignals(t *testing.T) {
 	assertProblem(t, problems, "Service", "api", "Unresolved named targetPort: http", "high")
 	assertProblem(t, problems, "PersistentVolumeClaim", "data", "Lost", "critical")
 	assertProblem(t, problems, "Job", "migrate", "BackoffLimitExceeded", "critical")
+}
+
+func TestImagePullDiagnosis(t *testing.T) {
+	cases := []struct {
+		name      string
+		reason    string
+		message   string
+		wantCause string
+		wantAct   string
+	}{
+		{
+			name:      "not found",
+			reason:    "ImagePullBackOff",
+			message:   `Back-off pulling image "reg.io/team/api:v2": failed to resolve reference "reg.io/team/api:v2": not found`,
+			wantCause: "Image not found: reg.io/team/api:v2",
+			wantAct:   "repository and tag",
+		},
+		{
+			name:      "auth wins over not found",
+			reason:    "ErrImagePull",
+			message:   `failed to pull image "priv.io/app:v1": not found: authentication required`,
+			wantCause: "Not authorized to pull image: priv.io/app:v1",
+			wantAct:   "imagePullSecrets",
+		},
+		{
+			name:      "registry unreachable",
+			reason:    "ImagePullBackOff",
+			message:   `failed to pull image "reg.io/app:v1": dial tcp: lookup reg.io: no such host`,
+			wantCause: "Registry unreachable: reg.io/app:v1",
+			wantAct:   "DNS",
+		},
+		{
+			name:      "rate limited",
+			reason:    "ImagePullBackOff",
+			message:   `toomanyrequests: rate limit exceeded for image "reg.io/app:v1"`,
+			wantCause: "Registry rate-limited: reg.io/app:v1",
+			wantAct:   "authenticated",
+		},
+		{
+			name:      "invalid reference",
+			reason:    "InvalidImageName",
+			message:   `Failed to apply default image tag "bad image": invalid reference format`,
+			wantCause: "Image reference is invalid",
+			wantAct:   "syntax",
+		},
+		{
+			name:    "unknown shape",
+			reason:  "ImagePullBackOff",
+			message: `some novel kubelet error for image "reg.io/app:v1"`,
+		},
+		{
+			name:    "non image pull reason",
+			reason:  "CrashLoopBackOff",
+			message: `not found`,
+		},
+		{
+			name:    "status code not embedded in tag",
+			reason:  "ImagePullBackOff",
+			message: `failed to pull image "reg.io/app:v401": unexpected response`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cause, action := imagePullDiagnosis(tc.reason, tc.message)
+			if cause != tc.wantCause {
+				t.Fatalf("cause = %q, want %q", cause, tc.wantCause)
+			}
+			if tc.wantAct == "" {
+				if action != "" {
+					t.Fatalf("action = %q, want empty", action)
+				}
+				return
+			}
+			if !strings.Contains(action, tc.wantAct) {
+				t.Fatalf("action = %q, want substring %q", action, tc.wantAct)
+			}
+		})
+	}
+}
+
+func TestDetectProblems_ImagePullDiagnosis(t *testing.T) {
+	defer ResetTestState()
+
+	old := metav1.NewTime(time.Now().Add(-10 * time.Minute))
+	client := fake.NewClientset(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "private", Namespace: "prod", CreationTimestamp: old},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "app",
+				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+					Reason:  "ImagePullBackOff",
+					Message: `failed to pull image "priv.io/app:v1": denied: requested access to the resource is denied`,
+				}},
+			}},
+		},
+	})
+
+	if err := InitTestResourceCache(client); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	cache := GetResourceCache()
+	deadline := time.Now().Add(2 * time.Second)
+	var problems []Detection
+	for time.Now().Before(deadline) {
+		problems = DetectProblems(cache, "prod")
+		if hasProblem(problems, "Pod", "private", "ImagePullBackOff") {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	got, ok := lookupProblem(problems, "Pod", "private", "ImagePullBackOff")
+	if !ok {
+		t.Fatalf("missing image pull problem: %+v", problems)
+	}
+	if got.Cause != "Not authorized to pull image: priv.io/app:v1" || !strings.Contains(got.Action, "imagePullSecrets") {
+		t.Fatalf("image pull diagnosis = %+v, want auth cause/action", got)
+	}
+	if !strings.Contains(got.Message, "requested access") {
+		t.Fatalf("raw kubelet message should be preserved, got %q", got.Message)
+	}
 }
 
 func TestDetectProblems_ProbeFailures(t *testing.T) {
@@ -1298,6 +1429,112 @@ func TestDetectProblems_NetworkAndStorageState(t *testing.T) {
 		t.Fatalf("FileSystemResizePending is in-progress, not a resize failure: %+v", problems)
 	}
 	assertProblem(t, problems, "PersistentVolume", "pv-bad", "Failed", "critical")
+}
+
+func TestDetectProblems_PVCPendingWarningEventDiagnosis(t *testing.T) {
+	defer ResetTestState()
+
+	now := time.Now()
+	old := metav1.NewTime(now.Add(-10 * time.Minute))
+	recent := metav1.NewTime(now.Add(-1 * time.Minute))
+	client := fake.NewClientset(
+		&corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "slow", Namespace: "prod", CreationTimestamp: old},
+			Status:     corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
+		},
+		&corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "normal-only", Namespace: "prod", CreationTimestamp: old},
+			Status:     corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
+		},
+		&corev1.Event{
+			ObjectMeta:     metav1.ObjectMeta{Name: "slow.1", Namespace: "prod"},
+			InvolvedObject: corev1.ObjectReference{Kind: "PersistentVolumeClaim", Namespace: "prod", Name: "slow"},
+			Type:           corev1.EventTypeWarning,
+			Reason:         "ProvisioningFailed",
+			Message:        "failed to provision volume with StorageClass fast: rpc error: quota exceeded",
+			LastTimestamp:  recent,
+		},
+		&corev1.Event{
+			ObjectMeta:     metav1.ObjectMeta{Name: "normal-only.1", Namespace: "prod"},
+			InvolvedObject: corev1.ObjectReference{Kind: "PersistentVolumeClaim", Namespace: "prod", Name: "normal-only"},
+			Type:           corev1.EventTypeNormal,
+			Reason:         "ExternalProvisioning",
+			Message:        "waiting for a volume to be created by the external provisioner",
+			LastTimestamp:  recent,
+		},
+	)
+
+	if err := InitTestResourceCache(client); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	cache := GetResourceCache()
+	deadline := time.Now().Add(2 * time.Second)
+	var problems []Detection
+	for time.Now().Before(deadline) {
+		problems = DetectProblems(cache, "prod")
+		if hasProblem(problems, "PersistentVolumeClaim", "slow", "Pending") &&
+			hasProblem(problems, "PersistentVolumeClaim", "normal-only", "Pending") {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	slow, ok := lookupProblem(problems, "PersistentVolumeClaim", "slow", "Pending")
+	if !ok {
+		t.Fatalf("missing slow PVC problem: %+v", problems)
+	}
+	if slow.Cause != "Storage provisioner failed to create a volume." || !strings.Contains(slow.Action, "CSI controller") {
+		t.Fatalf("slow PVC diagnosis = %+v, want provisioner cause/action", slow)
+	}
+	if !strings.Contains(slow.Message, "quota exceeded") {
+		t.Fatalf("slow PVC message = %q, want raw event detail", slow.Message)
+	}
+
+	normal, ok := lookupProblem(problems, "PersistentVolumeClaim", "normal-only", "Pending")
+	if !ok {
+		t.Fatalf("missing normal-only PVC problem: %+v", problems)
+	}
+	if normal.Cause != "" || normal.Action != "" || normal.Message != "PVC is unbound — no volume has been provisioned" {
+		t.Fatalf("normal ExternalProvisioning event should not diagnose PVC, got %+v", normal)
+	}
+}
+
+func TestDetectProblems_PVCPendingWaitForFirstConsumerStillSuppressed(t *testing.T) {
+	defer ResetTestState()
+
+	now := time.Now()
+	old := metav1.NewTime(now.Add(-10 * time.Minute))
+	mode := storagev1.VolumeBindingWaitForFirstConsumer
+	scName := "late-bind"
+	storageClass := &storagev1.StorageClass{
+		ObjectMeta:        metav1.ObjectMeta{Name: "late-bind"},
+		VolumeBindingMode: &mode,
+	}
+	client := fake.NewClientset(
+		storageClass,
+		&corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "awaiting-consumer", Namespace: "prod", CreationTimestamp: old},
+			Spec:       corev1.PersistentVolumeClaimSpec{StorageClassName: &scName},
+			Status:     corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
+		},
+		&corev1.Event{
+			ObjectMeta:     metav1.ObjectMeta{Name: "awaiting-consumer.1", Namespace: "prod"},
+			InvolvedObject: corev1.ObjectReference{Kind: "PersistentVolumeClaim", Namespace: "prod", Name: "awaiting-consumer"},
+			Type:           corev1.EventTypeWarning,
+			Reason:         "FailedBinding",
+			Message:        "waiting for first consumer to be created before binding",
+			LastTimestamp:  metav1.NewTime(now.Add(-1 * time.Minute)),
+		},
+	)
+
+	if err := InitTestResourceCache(client); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	cache := GetResourceCache()
+	time.Sleep(50 * time.Millisecond)
+	if problems := DetectProblems(cache, "prod"); hasProblem(problems, "PersistentVolumeClaim", "awaiting-consumer", "Pending") {
+		t.Fatalf("WaitForFirstConsumer PVC should stay suppressed despite Warning event: %+v", problems)
+	}
 }
 
 func TestDetectProblems_TerminatingResources(t *testing.T) {

--- a/internal/k8s/health.go
+++ b/internal/k8s/health.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"fmt"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -30,6 +31,8 @@ const initContainerStalledReason = "InitContainerStalled"
 // highRestartThreshold is the cumulative per-container RestartCount above which
 // a still-unhealthy container is treated as actively thrashing.
 const highRestartThreshold = 3
+
+const shortCrashRunWindow = 10 * time.Second
 
 // isStableCrashLoop reports whether a container is in an ACTIVE crashloop: it
 // has restarted with a crash-class last termination (CrashLoopBackOff / generic
@@ -323,6 +326,119 @@ func PodRestartContext(pod *corev1.Pod) (restartCount int32, lastTerminatedReaso
 	walk(pod.Status.ContainerStatuses)
 	walk(pod.Status.InitContainerStatuses)
 	return restartCount, lastTerminatedReason
+}
+
+type crashLoopCandidate struct {
+	status     corev1.ContainerStatus
+	init       bool
+	index      int
+	stateRank  int
+	finishedAt time.Time
+}
+
+func podCrashLoopDiagnosis(pod *corev1.Pod, now time.Time) (cause, action string) {
+	candidate, ok := activeCrashLoopCandidate(pod, now)
+	if !ok {
+		return "", ""
+	}
+	term := candidate.status.LastTerminationState.Terminated
+	if term == nil || term.ExitCode == 0 || term.Reason == "OOMKilled" {
+		return "", ""
+	}
+
+	ref := fmt.Sprintf("container %q", candidate.status.Name)
+	if candidate.init {
+		ref = fmt.Sprintf("init container %q", candidate.status.Name)
+	}
+	run := shortRunContext(term)
+
+	switch term.ExitCode {
+	case 127:
+		return fmt.Sprintf("%s exited with code 127: command not found.%s", ref, run),
+			"Check the image entrypoint and pod command/args; verify the binary exists in the image."
+	case 126:
+		return fmt.Sprintf("%s exited with code 126: command found but not executable.%s", ref, run),
+			"Check executable permissions, the shebang/interpreter, and the pod command/args."
+	case 139:
+		return fmt.Sprintf("%s exited with code 139: segmentation fault.%s", ref, run),
+			"Inspect previous container logs and recent image/code changes; check native libraries or unsafe code for a segfault."
+	case 137:
+		return fmt.Sprintf("%s exited with code 137, but Kubernetes did not report OOMKilled.%s", ref, run),
+			"Check node pressure, process-level SIGKILLs, and memory limits; inspect previous container logs for shutdown context."
+	default:
+		return fmt.Sprintf("%s is crashlooping after exit code %d.%s", ref, term.ExitCode, run),
+			"Inspect previous container logs for this container and verify the pod command, args, config, and dependencies."
+	}
+}
+
+func activeCrashLoopCandidate(pod *corev1.Pod, now time.Time) (crashLoopCandidate, bool) {
+	var best crashLoopCandidate
+	have := false
+	consider := func(cs corev1.ContainerStatus, init bool, index int, readyTrusted bool) {
+		if !isStableCrashLoop(&cs, now, readyTrusted) {
+			return
+		}
+		c := crashLoopCandidate{
+			status:    cs,
+			init:      init,
+			index:     index,
+			stateRank: crashLoopStateRank(cs),
+		}
+		if t := cs.LastTerminationState.Terminated; t != nil {
+			c.finishedAt = t.FinishedAt.Time
+		}
+		if !have || betterCrashLoopCandidate(c, best) {
+			best, have = c, true
+		}
+	}
+	for i := range pod.Status.InitContainerStatuses {
+		consider(pod.Status.InitContainerStatuses[i], true, i, false)
+	}
+	for i := range pod.Status.ContainerStatuses {
+		cs := pod.Status.ContainerStatuses[i]
+		consider(cs, false, i, containerHasReadinessProbe(pod.Spec.Containers, cs.Name))
+	}
+	return best, have
+}
+
+func crashLoopStateRank(cs corev1.ContainerStatus) int {
+	if cs.State.Waiting != nil {
+		return 0
+	}
+	if cs.State.Terminated != nil {
+		return 1
+	}
+	if cs.State.Running != nil {
+		return 2
+	}
+	return 3
+}
+
+func betterCrashLoopCandidate(cand, cur crashLoopCandidate) bool {
+	if cand.stateRank != cur.stateRank {
+		return cand.stateRank < cur.stateRank
+	}
+	if !cand.finishedAt.Equal(cur.finishedAt) {
+		return cand.finishedAt.After(cur.finishedAt)
+	}
+	if cand.init != cur.init {
+		return cand.init
+	}
+	if cand.status.Name != cur.status.Name {
+		return cand.status.Name < cur.status.Name
+	}
+	return cand.index < cur.index
+}
+
+func shortRunContext(term *corev1.ContainerStateTerminated) string {
+	if term == nil || term.StartedAt.IsZero() || term.FinishedAt.IsZero() {
+		return ""
+	}
+	runDuration := term.FinishedAt.Time.Sub(term.StartedAt.Time)
+	if runDuration <= 0 || runDuration >= shortCrashRunWindow {
+		return ""
+	}
+	return fmt.Sprintf(" It ran for %s before exiting.", FormatAge(runDuration))
 }
 
 // PodProblemReason returns a short reason string for a problematic pod.

--- a/internal/k8s/health_test.go
+++ b/internal/k8s/health_test.go
@@ -1,10 +1,12 @@
 package k8s
 
 import (
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
 	"testing"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestClassifyPodHealth(t *testing.T) {
@@ -543,6 +545,84 @@ func TestClassifyNodeHealth(t *testing.T) {
 				t.Errorf("Pressures = %v, want %d pressures", got.Pressures, tt.wantPressures)
 			}
 		})
+	}
+}
+
+func TestPodCrashLoopDiagnosisUsesActiveCrashCandidate(t *testing.T) {
+	now := time.Now()
+	started := metav1.NewTime(now.Add(-3 * time.Second))
+	finished := metav1.NewTime(now.Add(-2 * time.Second))
+	newerFinished := metav1.NewTime(now.Add(-1 * time.Second))
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{Containers: []corev1.Container{
+			{Name: "app"},
+			{Name: "sidecar"},
+		}},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:         "sidecar",
+					RestartCount: 0,
+					LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+						Reason: "Error", ExitCode: 139, FinishedAt: newerFinished,
+					}},
+				},
+				{
+					Name:         "app",
+					RestartCount: 2,
+					State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-1 * time.Second))}},
+					LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+						Reason: "Error", ExitCode: 127, StartedAt: started, FinishedAt: finished,
+					}},
+				},
+			},
+		},
+	}
+
+	cause, action := podCrashLoopDiagnosis(pod, now)
+	if !strings.Contains(cause, `container "app"`) || !strings.Contains(cause, "code 127") || !strings.Contains(cause, "before exiting") {
+		t.Fatalf("cause = %q, want app exit-code diagnosis with short-run context", cause)
+	}
+	if strings.Contains(cause, "sidecar") || strings.Contains(cause, "139") {
+		t.Fatalf("cause used unrelated newer termination: %q", cause)
+	}
+	if !strings.Contains(action, "command/args") {
+		t.Fatalf("action = %q, want command/args guidance", action)
+	}
+}
+
+func TestPodCrashLoopDiagnosisOrdersMultipleCandidates(t *testing.T) {
+	now := time.Now()
+	older := metav1.NewTime(now.Add(-30 * time.Second))
+	newer := metav1.NewTime(now.Add(-20 * time.Second))
+	pod := &corev1.Pod{
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:         "running-newer",
+					RestartCount: 2,
+					State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-1 * time.Second))}},
+					LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+						Reason: "Error", ExitCode: 139, FinishedAt: newer,
+					}},
+				},
+				{
+					Name:         "waiting-older",
+					RestartCount: 2,
+					State:        corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
+					LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+						Reason: "Error", ExitCode: 126, FinishedAt: older,
+					}},
+				},
+			},
+		},
+	}
+
+	cause, _ := podCrashLoopDiagnosis(pod, now)
+	if !strings.Contains(cause, `container "waiting-older"`) || !strings.Contains(cause, "code 126") {
+		t.Fatalf("cause = %q, want current waiting crashloop to win over newer running tick", cause)
 	}
 }
 

--- a/packages/k8s-ui/src/components/issues/IssuesView.tsx
+++ b/packages/k8s-ui/src/components/issues/IssuesView.tsx
@@ -271,11 +271,9 @@ function Diagnosis({ issue }: { issue: Issue }) {
           .join(' · ')
       : null;
   const { headline, detail } = issueMessageParts(issue);
-  // When the issue carries a parsed plain-English cause (GitOps controller
-  // errors), lead with it — the raw controller message is long and buries the
-  // useful part, and the detector reason ("OperationFailed") just repeats the
-  // category chip. The raw message is kept below as de-emphasized detail.
-  const rawMessage = [headline, detail].filter(Boolean).join(' ');
+  // When the issue carries a parsed plain-English cause, lead with it. The raw
+  // detector message is kept below as de-emphasized detail.
+  const rawMessage = issue.cause ? issue.message ?? '' : [headline, detail].filter(Boolean).join(' ');
   return (
     <section className="flex flex-col gap-1">
       <h4 className="text-[11px] font-semibold uppercase tracking-wide text-theme-text-tertiary">What's wrong</h4>
@@ -310,7 +308,7 @@ function Diagnosis({ issue }: { issue: Issue }) {
           {issue.operation_retry_count ? ` · retried ${issue.operation_retry_count}×` : ''}
         </p>
       ) : null}
-      {/* Raw controller message, de-emphasized — shown below the parsed cause so
+      {/* Raw detector message, de-emphasized — shown below the parsed cause so
           the precise error (URLs, resource names) is available without leading. */}
       {issue.cause && rawMessage ? (
         <p className="break-words font-mono text-[11px] leading-relaxed text-theme-text-tertiary">{rawMessage}</p>

--- a/packages/k8s-ui/src/components/issues/types.ts
+++ b/packages/k8s-ui/src/components/issues/types.ts
@@ -153,8 +153,8 @@ export interface Issue {
 
   reason: string;
   message?: string;
-  /** Parsed domain diagnosis (today GitOps controller errors): plain-English
-   *  cause, suggested next step, and an optional structured one-click fix.
+  /** Parsed domain diagnosis: plain-English cause, suggested next step, and
+   *  an optional structured one-click fix.
    *  Server-emitted (omitempty); empty for issues without a parser. */
   cause?: string;
   action?: string;

--- a/pkg/issuesapi/types.go
+++ b/pkg/issuesapi/types.go
@@ -295,11 +295,11 @@ type Issue struct {
 	Name          string        `json:"name"`
 	Reason        string        `json:"reason"`
 	Message       string        `json:"message,omitempty"`
-	// Cause / Action / Remediation* carry parsed domain diagnosis (today GitOps
-	// controller errors). They give the Issues page + MCP the same plain-English
-	// cause + next-step the GitOps detail page shows. All optional — empty for
-	// issues without a parser. RemediationKind names a structured one-click fix
-	// (e.g. "create-namespace"); RemediationTarget is the resource it acts on.
+	// Cause / Action / Remediation* carry parsed domain diagnosis. They give the
+	// Issues page + MCP a plain-English cause + next step when a detector has
+	// enough evidence. All optional — empty for issues without a parser.
+	// RemediationKind names a structured one-click fix (e.g. "create-namespace");
+	// RemediationTarget is the resource it acts on.
 	Cause             string `json:"cause,omitempty"`
 	Action            string `json:"action,omitempty"`
 	RemediationKind   string `json:"remediation_kind,omitempty"`


### PR DESCRIPTION
Summary:
- add backend cause/action diagnosis for high-confidence crashloop exit codes and image-pull failures
- enrich PVC Pending issues from current Warning events while preserving MissingStorageClass dedupe and WFFC suppression
- tighten grouped diagnosis promotion so workload rollups only show shared diagnoses

Tests:
- go test ./internal/k8s ./internal/issues
- go test github.com/skyhook-io/radar/pkg/issuesapi
- make test
- npm test --workspace @skyhook-io/k8s-ui
- npm run tsc --workspace @skyhook-io/k8s-ui
- make tsc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Grouped diagnosis behavior changes for multi-pod rollups (fewer false group-level fixes), and new message heuristics could miss or mislabel unusual registry errors; coverage is broad in `internal/k8s` and `internal/issues`.
> 
> **Overview**
> **Pod and storage detectors now emit plain-English `cause` / `action` on detections**, not only GitOps paths. CrashLoopBackOff uses exit-code–based diagnosis from the active crash-loop container (`podCrashLoopDiagnosis` in `health.go`). Image pull failures classify kubelet messages (auth, not found, rate limit, DNS, invalid ref). Long-pending PVCs pick up **Warning** events (`ProvisioningFailed`, `FailedBinding`) for message and diagnosis while **WaitForFirstConsumer** suppression stays unchanged.
> 
> **Grouped workload rollups are stricter about diagnosis.** `agreedDiagnosis` requires every folded member to have a full diagnosis tuple that matches; a single pod with a cause and siblings without no longer promotes that cause to the Deployment row (tests flipped from “carries lone” to “omits lone”).
> 
> The **Issues UI** leads with parsed `cause` when present and shows the raw detector message below; API/type comments describe diagnosis generically. **PVC pending vs missing StorageClass** dedupe is pinned so the missing-ref row wins over an enriched phase row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7e06c1f26e494babd40da34dde5eeb1940a4911. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->