### PR TITLE
Stabilize pod root cause guidance

### DIFF
--- a/internal/k8s/detect.go
+++ b/internal/k8s/detect.go
@@ -1207,7 +1207,7 @@ func imagePullDiagnosis(reason, message string) (cause, action string) {
 	case containsAny(lower, "unauthorized", "forbidden", "denied", "authentication required", "pull access denied") ||
 		containsStatusCode(lower, "401") || containsStatusCode(lower, "403"):
 		return imageCause("Not authorized to pull image", ref),
-			"Check imagePullSecrets, the pod service account, and registry permissions for this namespace."
+			"Check imagePullSecrets, the pod service account, registry permissions for this namespace, and whether the repository/tag exists."
 	case containsAny(lower, "toomanyrequests", "too many requests", "rate limit"):
 		return imageCause("Registry rate-limited", ref),
 			"Use an authenticated pull secret, reduce pull frequency, or mirror/cache the image."

--- a/internal/k8s/detect_test.go
+++ b/internal/k8s/detect_test.go
@@ -913,42 +913,42 @@ func TestImagePullDiagnosis(t *testing.T) {
 		reason    string
 		message   string
 		wantCause string
-		wantAct   string
+		wantActs  []string
 	}{
 		{
 			name:      "not found",
 			reason:    "ImagePullBackOff",
 			message:   `Back-off pulling image "reg.io/team/api:v2": failed to resolve reference "reg.io/team/api:v2": not found`,
 			wantCause: "Image not found: reg.io/team/api:v2",
-			wantAct:   "repository and tag",
+			wantActs:  []string{"repository and tag"},
 		},
 		{
 			name:      "auth wins over not found",
 			reason:    "ErrImagePull",
 			message:   `failed to pull image "priv.io/app:v1": not found: authentication required`,
 			wantCause: "Not authorized to pull image: priv.io/app:v1",
-			wantAct:   "imagePullSecrets",
+			wantActs:  []string{"imagePullSecrets", "repository/tag"},
 		},
 		{
 			name:      "registry unreachable",
 			reason:    "ImagePullBackOff",
 			message:   `failed to pull image "reg.io/app:v1": dial tcp: lookup reg.io: no such host`,
 			wantCause: "Registry unreachable: reg.io/app:v1",
-			wantAct:   "DNS",
+			wantActs:  []string{"DNS"},
 		},
 		{
 			name:      "rate limited",
 			reason:    "ImagePullBackOff",
 			message:   `toomanyrequests: rate limit exceeded for image "reg.io/app:v1"`,
 			wantCause: "Registry rate-limited: reg.io/app:v1",
-			wantAct:   "authenticated",
+			wantActs:  []string{"authenticated"},
 		},
 		{
 			name:      "invalid reference",
 			reason:    "InvalidImageName",
 			message:   `Failed to apply default image tag "bad image": invalid reference format`,
 			wantCause: "Image reference is invalid",
-			wantAct:   "syntax",
+			wantActs:  []string{"syntax"},
 		},
 		{
 			name:    "unknown shape",
@@ -972,14 +972,16 @@ func TestImagePullDiagnosis(t *testing.T) {
 			if cause != tc.wantCause {
 				t.Fatalf("cause = %q, want %q", cause, tc.wantCause)
 			}
-			if tc.wantAct == "" {
+			if len(tc.wantActs) == 0 {
 				if action != "" {
 					t.Fatalf("action = %q, want empty", action)
 				}
 				return
 			}
-			if !strings.Contains(action, tc.wantAct) {
-				t.Fatalf("action = %q, want substring %q", action, tc.wantAct)
+			for _, wantAct := range tc.wantActs {
+				if !strings.Contains(action, wantAct) {
+					t.Fatalf("action = %q, want substring %q", action, wantAct)
+				}
 			}
 		})
 	}

--- a/internal/k8s/health.go
+++ b/internal/k8s/health.go
@@ -438,7 +438,7 @@ func shortRunContext(term *corev1.ContainerStateTerminated) string {
 	if runDuration <= 0 || runDuration >= shortCrashRunWindow {
 		return ""
 	}
-	return fmt.Sprintf(" It ran for %s before exiting.", FormatAge(runDuration))
+	return " It exited within seconds of starting."
 }
 
 // PodProblemReason returns a short reason string for a problematic pod.

--- a/internal/k8s/health_test.go
+++ b/internal/k8s/health_test.go
@@ -581,7 +581,7 @@ func TestPodCrashLoopDiagnosisUsesActiveCrashCandidate(t *testing.T) {
 	}
 
 	cause, action := podCrashLoopDiagnosis(pod, now)
-	if !strings.Contains(cause, `container "app"`) || !strings.Contains(cause, "code 127") || !strings.Contains(cause, "before exiting") {
+	if !strings.Contains(cause, `container "app"`) || !strings.Contains(cause, "code 127") || !strings.Contains(cause, "within seconds") {
 		t.Fatalf("cause = %q, want app exit-code diagnosis with short-run context", cause)
 	}
 	if strings.Contains(cause, "sidecar") || strings.Contains(cause, "139") {
@@ -589,6 +589,40 @@ func TestPodCrashLoopDiagnosisUsesActiveCrashCandidate(t *testing.T) {
 	}
 	if !strings.Contains(action, "command/args") {
 		t.Fatalf("action = %q, want command/args guidance", action)
+	}
+}
+
+func TestPodCrashLoopDiagnosisShortRunContextStableAcrossReplicas(t *testing.T) {
+	now := time.Now()
+	mkPod := func(name string, runFor time.Duration) *corev1.Pod {
+		finished := metav1.NewTime(now.Add(-1 * time.Second))
+		started := metav1.NewTime(finished.Time.Add(-runFor))
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name:         "app",
+					RestartCount: 2,
+					State:        corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
+					LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+						Reason: "Error", ExitCode: 139, StartedAt: started, FinishedAt: finished,
+					}},
+				}},
+			},
+		}
+	}
+
+	fastCause, fastAction := podCrashLoopDiagnosis(mkPod("web-a", 2*time.Second), now)
+	slowerCause, slowerAction := podCrashLoopDiagnosis(mkPod("web-b", 4*time.Second), now)
+	if fastCause == "" || fastCause != slowerCause {
+		t.Fatalf("short-run crash causes should be identical across replicas, got %q vs %q", fastCause, slowerCause)
+	}
+	if fastAction != slowerAction {
+		t.Fatalf("short-run crash actions should be identical across replicas, got %q vs %q", fastAction, slowerAction)
+	}
+	if strings.Contains(fastCause, "2s") || strings.Contains(slowerCause, "4s") {
+		t.Fatalf("short-run cause should not include per-replica duration: %q / %q", fastCause, slowerCause)
 	}
 }
 


### PR DESCRIPTION
Summary:
- make short-run crashloop cause text stable across replicas so grouped diagnosis promotion does not drop identical root causes
- broaden auth-denied image-pull guidance to also verify repository/tag existence

Triage:
- Fix: per-replica short runtime in crash cause could prevent group-level diagnosis promotion
- Fix: denied image-pull messages can also mean missing repo/tag, so action text should cover both
- Skip: status-code boundary and empty-message paths were verified safe

Tests:
- go test ./internal/k8s

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized changes to diagnostic strings in `internal/k8s` with matching unit tests; no auth, API, or data-path behavior changes.
> 
> **Overview**
> **Crash-loop diagnosis** no longer embeds per-replica run duration (e.g. "ran for 2s") in `shortRunContext`; it uses a fixed **"exited within seconds of starting"** line so replicas with slightly different short runtimes still share the same `Cause`/`Action` and **group-level diagnosis promotion** is not dropped when causes would otherwise differ.
> 
> **Image pull (auth/denied)** remediation text now also tells operators to verify **repository/tag exists**, since denied messages can mean missing image as well as credentials.
> 
> Tests cover multi-replica crash-loop stability and auth-over-not-found action substrings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53f3bb84cc329adeb13fbb4962ed5aff0aa25938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->