### PR TITLE
Add 'b' hotkey to toggle bulk-select mode in resource viewer

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -2723,6 +2723,19 @@ export function ResourcesView({
       handler: () => handleSort('status'),
     },
     {
+      id: 'resources-bulk-select',
+      keys: 'b',
+      description: 'Toggle bulk select',
+      category: 'Table',
+      scope: 'resources',
+      handler: () => {
+        if (bulkMode) { exitBulkMode(); return }
+        if (!canBulkSelect) return
+        exitCompareMode()
+        setBulkMode(true)
+      },
+    },
+    {
       id: 'resources-clear-highlight',
       keys: 'Escape',
       description: 'Clear highlight / blur search',


### PR DESCRIPTION
## Summary

The resource viewer's bulk-select mode (multi-select rows → bulk restart/scale/delete) could only be entered by clicking the toolbar `ListChecks` button. This adds a keyboard shortcut so power users can toggle it without leaving the keyboard, consistent with the existing vim-style navigation (`j`/`k`/`d`/`y`/`l`).

@Cenness

## What changed

Registers a new `resources`-scope shortcut: **`b`** toggles bulk-select mode.

- Mirrors the toolbar button's exact behavior: if bulk mode is on, exit; otherwise — only when the current kind actually supports bulk actions (`canBulkSelect`) — exit compare mode and enter bulk mode. On an unsupported kind it's a no-op, matching the button being hidden there.
- `Escape` already exits bulk mode via the existing handler, so the pair is symmetric.
- Auto-appears in the `?` help overlay under **Table** as "Toggle bulk select" — no extra wiring.

Key choice: `b` (mnemonic for **b**ulk) was the pick after inventorying every bound key — it's unused in both the `resources` and `global` scopes.

One implementation note for reviewers: the `canBulkSelect` gate lives inside the handler rather than in the shortcut's `enabled` field. `canBulkSelect` is declared later in the component body than the shortcut-registration array, so referencing it in `enabled` would hit a TDZ error at render. The handler closure only reads it on keypress (after render) and is refreshed every render by the hook, so it always sees the current value.

## Testing

- `make tsc` passes.
- Did not run visual-test — this is a keyboard interaction that triggers the already-existing bulk bar UI; there's no new visual surface to capture.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single shortcut registration reusing existing bulk/compare state with no API, auth, or data-path changes.
> 
> **Overview**
> Adds a **`b`** keyboard shortcut in the resource viewer’s **Table** scope so bulk-select mode can be toggled from the keyboard, matching the existing toolbar **ListChecks** behavior.
> 
> Pressing **`b`** exits bulk mode when it’s already on; otherwise it only enters bulk mode when the current kind supports bulk actions (`canBulkSelect`), exits compare mode first, and does nothing on unsupported kinds. The shortcut shows in the **`?`** help overlay as “Toggle bulk select”; **`Escape`** still exits bulk mode via the existing handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dde2c0b12c1559ebaa2c8703340c2e13b46bf56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->