### PR TITLE
Fix CRD resources showing 0 in namespace-scoped installs

### DIFF
--- a/pkg/k8score/cache_test.go
+++ b/pkg/k8score/cache_test.go
@@ -1209,6 +1209,59 @@ func TestDynamicResourceCache_ListEmptyNamespaceDoesNotUnion(t *testing.T) {
 	}
 }
 
+// Mirror of ListEmptyNamespaceDoesNotUnion for namespace-scoped mode: when Radar
+// connects with a namespace-restricted identity (NamespaceFallback set),
+// cluster-wide list is denied so a GVR's only informers are per-namespace. An
+// all-namespaces read — List(gvr, "") and Count(gvr, nil) — MUST union them, or
+// namespaced CRDs show 0 in the UI despite synced per-namespace informers. The
+// NamespaceFallback gate is what keeps the no-union contract intact for a
+// cluster-wide cache (the sibling test) while fixing the namespace-scoped case.
+func TestDynamicResourceCache_ListEmptyNamespaceUnionsWhenNamespaceScoped(t *testing.T) {
+	const nsA, nsB = "team-a", "team-b"
+	gvr := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"}
+	dyn := fakeDynamicForListAccess(t, map[schema.GroupVersionResource]string{
+		gvr: "WidgetList",
+	}, func(_ schema.GroupVersionResource, namespace string) bool {
+		return namespace == nsA || namespace == nsB // namespaced only, never cluster-wide
+	})
+	for _, ns := range []string{nsA, nsB} {
+		obj := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "example.com/v1",
+			"kind":       "Widget",
+			"metadata":   map[string]any{"name": "w-" + ns, "namespace": ns},
+		}}
+		if _, err := dyn.Resource(gvr).Namespace(ns).Create(context.Background(), obj, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("seed %s: %v", ns, err)
+		}
+	}
+
+	d, err := NewDynamicResourceCache(DynamicCacheConfig{DynamicClient: dyn, NamespaceFallback: nsA})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+	for _, ns := range []string{nsA, nsB} {
+		if _, err := d.ListBlocking(gvr, ns, 2*time.Second); err != nil {
+			t.Fatalf("ListBlocking(%q) failed: %v", ns, err)
+		}
+	}
+
+	got, err := d.List(gvr, "")
+	if err != nil {
+		t.Fatalf("List(gvr, \"\") failed: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("List(gvr, \"\") = %d objects, want 2 (union of per-namespace informers in namespace-scoped mode)", len(got))
+	}
+
+	n, err := d.Count(gvr, nil)
+	if err != nil {
+		t.Fatalf("Count(gvr, nil) failed: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("Count(gvr, nil) = %d, want 2", n)
+	}
+}
+
 // ListWatched is the internal "scan what's already cached" path: it unions
 // every watched scope so namespace-restricted callers (audit, PolicyReport
 // indexing) don't silently drop namespace-scoped contents the way List(gvr,

--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -608,13 +608,30 @@ func (d *DynamicResourceCache) readEntries(gvr schema.GroupVersionResource, ns s
 	if e, ok := d.informers[informerKey{gvr: gvr}]; ok {
 		return []*informerEntry{e}
 	}
-	if ns == "" {
+	if ns != "" {
+		if e, ok := d.informers[informerKey{gvr: gvr, ns: ns}]; ok {
+			return []*informerEntry{e}
+		}
 		return nil
 	}
-	if e, ok := d.informers[informerKey{gvr: gvr, ns: ns}]; ok {
-		return []*informerEntry{e}
+	// ns == "" ("all namespaces") with no cluster-wide informer. When Radar
+	// connects with a namespace-restricted identity (NamespaceFallback set),
+	// cluster-wide list was denied so the only informers for this GVR are
+	// per-namespace — union them, otherwise an all-namespaces read returns
+	// nothing even though the per-namespace informers are synced. A cluster-wide
+	// cache (NamespaceFallback == "") stays empty here, preserving the
+	// deterministic cluster-wide-only contract that keeps incidental
+	// per-namespace informers from leaking across users.
+	if d.config.NamespaceFallback == "" {
+		return nil
 	}
-	return nil
+	var out []*informerEntry
+	for k, e := range d.informers {
+		if k.gvr == gvr {
+			out = append(out, e)
+		}
+	}
+	return out
 }
 
 // indexerItems gathers raw store objects from the given entries, filtered to
@@ -704,7 +721,29 @@ func (d *DynamicResourceCache) Count(gvr schema.GroupVersionResource, namespaces
 	}
 
 	if len(namespaces) == 0 {
-		return 0, fmt.Errorf("informer not found or not synced for %v", gvr)
+		// No cluster-wide informer. In namespace-scoped mode (NamespaceFallback
+		// set) union the per-namespace informers so Count agrees with
+		// readEntries on an all-namespaces read; a cluster-wide cache keeps the
+		// strict cluster-wide-only contract and errors.
+		if d.config.NamespaceFallback == "" {
+			return 0, fmt.Errorf("informer not found or not synced for %v", gvr)
+		}
+		total := 0
+		found := false
+		for k, e := range d.informers {
+			if k.gvr != gvr {
+				continue
+			}
+			if !e.synced {
+				return 0, fmt.Errorf("informer not found or not synced for %v", gvr)
+			}
+			found = true
+			total += len(e.informer.GetIndexer().List())
+		}
+		if !found {
+			return 0, fmt.Errorf("informer not found or not synced for %v", gvr)
+		}
+		return total, nil
 	}
 
 	total := 0


### PR DESCRIPTION
## Summary

Since 1.7.1, CRD-based resources (ExternalSecret, SecretStore, Traefik IngressRoute/Middleware/TLSOption, …) showed **0** in the UI on namespace-scoped installs — even though Radar discovered, watched, and synced them, with no RBAC errors in the logs. Operators running Radar in-cluster with a namespace-scoped ServiceAccount lost visibility into every CRD kind. Typed resources (pods, deployments) were unaffected, which is the tell. This restores CRD visibility for those installs.

Closes #926.

## Root cause

#770 (shipped in 1.7.1) tightened the dynamic CRD cache's read contract: `List(gvr,"")` / `Count(gvr,nil)` are served by a **cluster-wide informer only** and never union the per-namespace informers. A namespace-scoped identity (can't `list` cluster-wide) has **no cluster-wide informer** — only per-namespace ones — so an all-namespaces read returned nothing. Typed listers tolerate a `nil` filter (they return the namespace-scoped informer's contents directly), which is why **only CRDs** went blank while pods kept working.

## What changed

The fix lives in the dynamic cache (`pkg/k8score/dynamic_cache.go`), gated on `config.NamespaceFallback` — which is set **only** when Radar connects with a namespace-restricted identity. When there is no cluster-wide informer for a GVR, `List(gvr,"")` and `Count(gvr,nil)` now **union the per-namespace informers** for that GVR. A cluster-wide cache (`NamespaceFallback == ""`) keeps the strict cluster-wide-only behavior, so #770's determinism guarantee — no implicit cross-user union in the shared cache — is preserved.

Resolving it per-GVR in the cache (rather than rewriting the `nil` namespace filter in `parseNamespacesForUser`) is what keeps **mixed-scope** installs correct: kinds the identity can read cluster-wide (e.g. pods) keep their cluster-wide informer and are served cluster-wide; only the namespace-scoped CRDs union. Typed reads never touch this cache, so they can't be narrowed.

Reviewer focus: the `NamespaceFallback` gate is load-bearing — it's the discriminator between "single restricted identity" (safe to union its own per-namespace informers) and "shared cluster-wide cache" (must not union incidental per-namespace informers across users). The existing `TestDynamicResourceCache_ListEmptyNamespaceDoesNotUnion` pins the cluster-wide side of that boundary and still passes unchanged.

## Testing

Reproduced and verified end-to-end against a real cluster (`radar-test-nonprod`) with a namespace-scoped ServiceAccount kubeconfig (namespaced `Widget` CRD + 3 instances):
- **Pure namespace-scoped** (the #926 case): before, `/api/resources/widgets` returned `informer not found` and resource-counts omitted the kind while pods worked; after, the CRD lists 3/3 via REST and MCP, counts show 3, pods unchanged.
- **Mixed scope** (cluster-wide pods + namespace-only CRD): pods return the full cluster-wide set (48), CRDs return their namespace contents (3) — confirming cluster-wide kinds are not narrowed.

- `make test` / `pkg/k8score` suite — green; added `TestDynamicResourceCache_ListEmptyNamespaceUnionsWhenNamespaceScoped` (mirror of the existing no-union test).
- Ran the full `test-rbac.sh` cluster-wide auth harness (cluster-admin SA + proxy impersonation) — all per-user RBAC filtering passes, confirming the cluster-wide path is untouched. One assertion (`dave's dashboard namespaces count`) fails **identically on clean `main`** — a pre-existing stale test, unrelated to this change.
- No UI changes; visual-test not applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Alters shared dynamic-cache list/count semantics for all-namespace reads, but only when `NamespaceFallback` is set; cluster-wide behavior is explicitly preserved and covered by the existing sibling test.
> 
> **Overview**
> **Namespace-scoped dynamic CRD reads** no longer go empty when there is no cluster-wide informer but per-namespace watches are synced. `readEntries` now handles a specific namespace first, then—for `ns == ""` only—unions all informers for that GVR when `NamespaceFallback` is non-empty; cluster-wide caches (`NamespaceFallback == ""`) still return nothing for that path, matching the existing no-implicit-union contract.
> 
> **`Count`** follows the same rule: with no cluster-wide informer and an empty namespace filter, it sums per-namespace indexers in namespace-scoped mode instead of erroring as “not synced.”
> 
> A unit test asserts `List(gvr, "")` and `Count(gvr, nil)` return the union of objects across two warmed namespaces when `NamespaceFallback` is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e663dcfd0e91c4a5bb76fa55287c5f9e9875ede8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->