### PR TITLE
Fix Helm RBAC listing for namespace-scoped users and ServiceAccounts

### DIFF
--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -279,6 +279,50 @@ func (c *Client) ListReleases(namespace string) ([]HelmRelease, error) {
 	return listReleasesWith(actionConfig, namespace, "", nil)
 }
 
+// ListReleasesAcrossNamespaces lists releases for an explicit set of namespaces
+// and merges the results. A nil slice means "cluster-wide" (a single
+// AllNamespaces list). Callers pass the identity's accessible namespaces instead
+// of nil when it can't list secrets cluster-wide, so namespace-restricted users
+// and ServiceAccounts read Helm without a cluster-scoped `list secrets` (403).
+// Per-namespace lists are disjoint, so the merge can't duplicate a release.
+//
+// The accessible-namespace set is discovered from pod/deployment access, which
+// doesn't imply secrets access (Helm storage is Secrets) — a namespace where the
+// caller is bound to e.g. `view` denies the read. Those forbidden namespaces are
+// skipped so one of them doesn't blank releases the caller CAN see. Only when
+// every namespace is forbidden is the 403 surfaced, so the UI still shows
+// "Access Restricted" rather than a misleading empty list.
+func (c *Client) ListReleasesAcrossNamespaces(namespaces []string, username string, groups []string) ([]HelmRelease, error) {
+	if namespaces == nil {
+		return c.ListReleasesAsUser("", username, groups)
+	}
+	var all []HelmRelease
+	var lastForbidden error
+	authorized := false
+	for _, ns := range namespaces {
+		rels, err := c.ListReleasesAsUser(ns, username, groups)
+		if err != nil {
+			if IsForbiddenError(err) {
+				lastForbidden = err
+				continue
+			}
+			return nil, err
+		}
+		authorized = true
+		all = append(all, rels...)
+	}
+	if !authorized && lastForbidden != nil {
+		return nil, lastForbidden
+	}
+	sort.Slice(all, func(i, j int) bool {
+		if all[i].Namespace != all[j].Namespace {
+			return all[i].Namespace < all[j].Namespace
+		}
+		return all[i].Name < all[j].Name
+	})
+	return all, nil
+}
+
 func listReleasesWith(actionConfig *action.Configuration, namespace, username string, groups []string) ([]HelmRelease, error) {
 	listAction := action.NewList(actionConfig)
 	listAction.All = true
@@ -1667,6 +1711,36 @@ func (c *Client) BatchCheckUpgrades(namespace string) (*BatchUpgradeInfo, error)
 // touch K8s).
 func (c *Client) BatchCheckUpgradesAsUser(namespace, username string, groups []string) (*BatchUpgradeInfo, error) {
 	return c.batchCheckUpgrades(namespace, username, groups)
+}
+
+// BatchCheckUpgradesAcrossNamespaces is BatchCheckUpgradesAsUser over an explicit
+// set of namespaces, merging the per-namespace maps. A nil slice means
+// "cluster-wide". Mirrors ListReleasesAcrossNamespaces so the Helm view's
+// upgrade checks degrade the same way for namespace-restricted identities. Keys
+// are "storageNamespace/name" and namespaces are queried once each, so the merge
+// can't collide.
+//
+// Upgrade info is best-effort enrichment layered on top of the release list, so
+// forbidden namespaces are skipped and an all-forbidden result returns an empty
+// map rather than an error — the release list itself is what surfaces the 403.
+func (c *Client) BatchCheckUpgradesAcrossNamespaces(namespaces []string, username string, groups []string) (*BatchUpgradeInfo, error) {
+	if namespaces == nil {
+		return c.BatchCheckUpgradesAsUser("", username, groups)
+	}
+	merged := &BatchUpgradeInfo{Releases: make(map[string]*UpgradeInfo)}
+	for _, ns := range namespaces {
+		info, err := c.BatchCheckUpgradesAsUser(ns, username, groups)
+		if err != nil {
+			if IsForbiddenError(err) {
+				continue
+			}
+			return nil, err
+		}
+		for k, v := range info.Releases {
+			merged.Releases[k] = v
+		}
+	}
+	return merged, nil
 }
 
 func (c *Client) batchCheckUpgrades(namespace, username string, groups []string) (*BatchUpgradeInfo, error) {

--- a/internal/helm/handlers.go
+++ b/internal/helm/handlers.go
@@ -33,11 +33,30 @@ func userCreds(r *http.Request) (string, []string) {
 }
 
 // Handlers provides HTTP handlers for Helm endpoints
-type Handlers struct{}
+type Handlers struct {
+	// resolveNamespaces maps a request to the namespaces a Helm list should
+	// query. It returns (nil, true) for cluster-wide access, (namespaces, true)
+	// to list those namespaces and merge, and (_, false) when the identity has
+	// no namespace access. Injected by the server so the helm package doesn't
+	// depend on its per-user RBAC plumbing. May be nil in tests that don't
+	// exercise the list endpoints.
+	resolveNamespaces func(r *http.Request) ([]string, bool)
+}
 
-// NewHandlers creates a new Handlers instance
-func NewHandlers() *Handlers {
-	return &Handlers{}
+// NewHandlers creates a new Handlers instance. resolveNamespaces lets the list
+// endpoints degrade gracefully for namespace-restricted identities (see
+// handleListReleases); pass nil only in tests that don't hit those routes.
+func NewHandlers(resolveNamespaces func(r *http.Request) ([]string, bool)) *Handlers {
+	return &Handlers{resolveNamespaces: resolveNamespaces}
+}
+
+// listNamespaces resolves which namespaces a Helm list should query. Falls back
+// to cluster-wide (nil, true) when no resolver is wired.
+func (h *Handlers) listNamespaces(r *http.Request) ([]string, bool) {
+	if h.resolveNamespaces == nil {
+		return nil, true
+	}
+	return h.resolveNamespaces(r)
 }
 
 // RegisterRoutes registers Helm routes on the given router
@@ -84,10 +103,18 @@ func (h *Handlers) handleListReleases(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	namespace := r.URL.Query().Get("namespace")
+	// Resolve which namespaces to list. An explicit ?namespace= is honored by
+	// the resolver (via the request query); when none is given, a
+	// namespace-restricted identity resolves to its accessible namespaces
+	// instead of a cluster-wide `list secrets` that would 403.
+	namespaces, ok := h.listNamespaces(r)
+	if !ok {
+		writeJSON(w, []HelmRelease{})
+		return
+	}
 
 	username, groups := userCreds(r)
-	releases, err := client.ListReleasesAsUser(namespace, username, groups)
+	releases, err := client.ListReleasesAcrossNamespaces(namespaces, username, groups)
 	if err != nil {
 		if IsForbiddenError(err) {
 			writeError(w, http.StatusForbidden, "insufficient permissions to list Helm releases")
@@ -262,10 +289,14 @@ func (h *Handlers) handleBatchUpgradeCheck(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	namespace := r.URL.Query().Get("namespace")
+	namespaces, ok := h.listNamespaces(r)
+	if !ok {
+		writeJSON(w, &BatchUpgradeInfo{Releases: map[string]*UpgradeInfo{}})
+		return
+	}
 
 	username, groups := userCreds(r)
-	info, err := client.BatchCheckUpgradesAsUser(namespace, username, groups)
+	info, err := client.BatchCheckUpgradesAcrossNamespaces(namespaces, username, groups)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/internal/helm/handlers_test.go
+++ b/internal/helm/handlers_test.go
@@ -98,7 +98,7 @@ func TestRequireCloudRole(t *testing.T) {
 // We don't need a real Helm client because the gate runs first; the
 // handler short-circuits before touching `helm.GetClient()`.
 func TestSensitiveHelmHandlers_GateOnViewer(t *testing.T) {
-	h := NewHandlers()
+	h := NewHandlers(nil)
 
 	// (name, method, handler) for every endpoint we believe is gated.
 	// Sensitive reads → member; writes → member.

--- a/internal/helm/namespaces.go
+++ b/internal/helm/namespaces.go
@@ -10,15 +10,13 @@ import (
 // ResolveNoAuthListNamespaces returns a namespace fanout set for Helm list-style
 // reads in no-auth mode. nil means keep the single cluster-wide Helm list.
 func ResolveNoAuthListNamespaces(ctx context.Context) []string {
-	accessible, authoritative := k8s.GetAccessibleNamespaces(ctx)
-	if !authoritative && len(accessible) > 0 {
-		return accessible
-	}
-	if authoritative && len(accessible) > 0 {
+	accessible, _ := k8s.GetAccessibleNamespaces(ctx)
+	if len(accessible) > 0 {
 		allowed, apiErr := k8score.CanI(ctx, k8s.GetClient(), "", "", "secrets", "list")
-		if !apiErr && !allowed {
-			return accessible
+		if !apiErr && allowed {
+			return nil
 		}
+		return accessible
 	}
 	return nil
 }

--- a/internal/helm/namespaces.go
+++ b/internal/helm/namespaces.go
@@ -1,0 +1,24 @@
+package helm
+
+import (
+	"context"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/pkg/k8score"
+)
+
+// ResolveNoAuthListNamespaces returns a namespace fanout set for Helm list-style
+// reads in no-auth mode. nil means keep the single cluster-wide Helm list.
+func ResolveNoAuthListNamespaces(ctx context.Context) []string {
+	accessible, authoritative := k8s.GetAccessibleNamespaces(ctx)
+	if !authoritative && len(accessible) > 0 {
+		return accessible
+	}
+	if authoritative && len(accessible) > 0 {
+		allowed, apiErr := k8score.CanI(ctx, k8s.GetClient(), "", "", "secrets", "list")
+		if !apiErr && !allowed {
+			return accessible
+		}
+	}
+	return nil
+}

--- a/internal/helm/namespaces_test.go
+++ b/internal/helm/namespaces_test.go
@@ -1,0 +1,154 @@
+package helm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+
+	authv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+)
+
+func TestResolveNoAuthListNamespaces_ChecksClusterSecretsWithFallbackNamespaces(t *testing.T) {
+	var capture selfSubjectAccessReviewCapture
+	client := newNoAuthNamespaceClient(t, nil, errors.New("namespace list denied"), true, nil, &capture)
+	withNoAuthNamespaceClient(t, client, "backend-fallback")
+
+	got := ResolveNoAuthListNamespaces(context.Background())
+	if got != nil {
+		t.Fatalf("namespaces = %v, want nil for cluster-wide Helm list", got)
+	}
+	capture.assertClusterSecretList(t)
+}
+
+func TestResolveNoAuthListNamespaces_FansOutFallbackWhenClusterSecretsDenied(t *testing.T) {
+	var capture selfSubjectAccessReviewCapture
+	client := newNoAuthNamespaceClient(t, nil, errors.New("namespace list denied"), false, nil, &capture)
+	withNoAuthNamespaceClient(t, client, "backend-fallback")
+
+	got := ResolveNoAuthListNamespaces(context.Background())
+	if !slices.Equal(got, []string{"backend-fallback"}) {
+		t.Fatalf("namespaces = %v, want backend fallback namespace", got)
+	}
+	capture.assertClusterSecretList(t)
+}
+
+func TestResolveNoAuthListNamespaces_FansOutWhenClusterSecretsCheckErrors(t *testing.T) {
+	var capture selfSubjectAccessReviewCapture
+	client := newNoAuthNamespaceClient(t, []string{"beta", "alpha"}, nil, false, errors.New("self subject access review unavailable"), &capture)
+	withNoAuthNamespaceClient(t, client, "")
+
+	got := ResolveNoAuthListNamespaces(context.Background())
+	if !slices.Equal(got, []string{"alpha", "beta"}) {
+		t.Fatalf("namespaces = %v, want discovered namespaces", got)
+	}
+	capture.assertClusterSecretList(t)
+}
+
+type selfSubjectAccessReviewCapture struct {
+	calls     int
+	namespace string
+	resource  string
+	verb      string
+}
+
+func (c *selfSubjectAccessReviewCapture) assertClusterSecretList(t *testing.T) {
+	t.Helper()
+	if c.calls != 1 {
+		t.Fatalf("self subject access review calls = %d, want 1", c.calls)
+	}
+	if c.namespace != "" || c.resource != "secrets" || c.verb != "list" {
+		t.Fatalf("self subject access review = namespace=%q resource=%q verb=%q, want cluster-wide list secrets", c.namespace, c.resource, c.verb)
+	}
+}
+
+func withNoAuthNamespaceClient(t *testing.T, client *kubernetes.Clientset, fallback string) {
+	t.Helper()
+	prevClient := k8s.SetTestClient(client)
+	t.Cleanup(func() { k8s.SetTestClient(prevClient) })
+	k8s.SetFallbackNamespace(fallback)
+	t.Cleanup(func() { k8s.SetFallbackNamespace("") })
+}
+
+func newNoAuthNamespaceClient(t *testing.T, namespaces []string, namespaceListErr error, ssarAllowed bool, ssarErr error, capture *selfSubjectAccessReviewCapture) *kubernetes.Clientset {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/namespaces":
+			if namespaceListErr != nil {
+				writeK8sStatus(t, w, http.StatusForbidden, "Forbidden", namespaceListErr.Error())
+				return
+			}
+			items := make([]corev1.Namespace, 0, len(namespaces))
+			for _, name := range namespaces {
+				items = append(items, corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}})
+			}
+			writeTestJSON(t, w, corev1.NamespaceList{
+				TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "NamespaceList"},
+				Items:    items,
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews":
+			var review authv1.SelfSubjectAccessReview
+			if err := json.NewDecoder(r.Body).Decode(&review); err != nil {
+				t.Fatalf("decode self subject access review: %v", err)
+			}
+			if attrs := review.Spec.ResourceAttributes; attrs != nil {
+				capture.namespace = attrs.Namespace
+				capture.resource = attrs.Resource
+				capture.verb = attrs.Verb
+			}
+			capture.calls++
+			if ssarErr != nil {
+				writeK8sStatus(t, w, http.StatusInternalServerError, "InternalError", ssarErr.Error())
+				return
+			}
+			writeTestJSON(t, w, authv1.SelfSubjectAccessReview{
+				TypeMeta: metav1.TypeMeta{APIVersion: "authorization.k8s.io/v1", Kind: "SelfSubjectAccessReview"},
+				Status:   authv1.SubjectAccessReviewStatus{Allowed: ssarAllowed},
+			})
+		default:
+			writeK8sStatus(t, w, http.StatusNotFound, "NotFound", "unexpected test request")
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := kubernetes.NewForConfig(&rest.Config{
+		Host: server.URL,
+		ContentConfig: rest.ContentConfig{
+			ContentType: "application/json",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create test client: %v", err)
+	}
+	return client
+}
+
+func writeK8sStatus(t *testing.T, w http.ResponseWriter, code int, reason, message string) {
+	t.Helper()
+	w.WriteHeader(code)
+	writeTestJSON(t, w, metav1.Status{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Status"},
+		Status:   metav1.StatusFailure,
+		Reason:   metav1.StatusReason(reason),
+		Message:  message,
+		Code:     int32(code),
+	})
+}
+
+func writeTestJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Fatalf("write JSON response: %v", err)
+	}
+}

--- a/internal/k8s/testing.go
+++ b/internal/k8s/testing.go
@@ -134,6 +134,16 @@ func SetTestContextName(name string) string {
 	return prev
 }
 
+// SetTestClient overrides the package-level client and returns the previous
+// value so tests in other packages can restore it.
+func SetTestClient(c *kubernetes.Clientset) *kubernetes.Clientset {
+	clientMu.Lock()
+	prev := k8sClient
+	k8sClient = c
+	clientMu.Unlock()
+	return prev
+}
+
 // ResetTestState tears down the resource cache and resets all package-level
 // state so the next test starts clean.
 //

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2268,41 +2268,41 @@ func buildDashboard(ctx context.Context, cache *k8s.ResourceCache, namespace str
 	} else {
 		username, groups := userFromContext(ctx)
 		namespaces := resolveHelmListNamespaces(ctx, namespace)
-		var releases []helm.HelmRelease
-		var err error
-		if namespaces == nil || len(namespaces) > 0 {
-			releases, err = helmClient.ListReleasesAcrossNamespaces(namespaces, username, groups)
-		}
-		if err != nil {
-			// Not fatal for the dashboard — a viewer with no helm access
-			// still sees everything else. Surface to LLM consumers via
-			// Unavailable so they don't confidently report "Total=0
-			// releases" when in fact the read failed.
-			log.Printf("[mcp] Dashboard helm list failed: %v", err)
-			d.HelmReleases.Unavailable = true
-			if helm.IsForbiddenError(err) {
-				d.HelmReleases.UnavailableReason = "RBAC denied: caller cannot list Helm release secrets in this scope."
-			} else {
-				d.HelmReleases.UnavailableReason = "Helm read failed: " + err.Error()
-			}
+		if namespaces != nil && len(namespaces) == 0 {
+			// No namespace access: leave the zero-value Helm summary.
 		} else {
-			d.HelmReleases.Total = len(releases)
+			releases, err := helmClient.ListReleasesAcrossNamespaces(namespaces, username, groups)
+			if err != nil {
+				// Not fatal for the dashboard — a viewer with no helm access
+				// still sees everything else. Surface to LLM consumers via
+				// Unavailable so they don't confidently report "Total=0
+				// releases" when in fact the read failed.
+				log.Printf("[mcp] Dashboard helm list failed: %v", err)
+				d.HelmReleases.Unavailable = true
+				if helm.IsForbiddenError(err) {
+					d.HelmReleases.UnavailableReason = "RBAC denied: caller cannot list Helm release secrets in this scope."
+				} else {
+					d.HelmReleases.UnavailableReason = "Helm read failed: " + err.Error()
+				}
+			} else {
+				d.HelmReleases.Total = len(releases)
 
-			// Sort: failed/pending-install first, then unhealthy/degraded
-			sort.SliceStable(releases, func(i, j int) bool {
-				return helm.StatusPriority(releases[i].Status, releases[i].ResourceHealth) < helm.StatusPriority(releases[j].Status, releases[j].ResourceHealth)
-			})
-
-			limit := min(len(releases), 5)
-			for _, r := range releases[:limit] {
-				d.HelmReleases.Releases = append(d.HelmReleases.Releases, mcpHelmRelease{
-					Name:           r.Name,
-					Namespace:      r.Namespace,
-					Chart:          r.Chart,
-					ChartVersion:   r.ChartVersion,
-					Status:         r.Status,
-					ResourceHealth: r.ResourceHealth,
+				// Sort: failed/pending-install first, then unhealthy/degraded
+				sort.SliceStable(releases, func(i, j int) bool {
+					return helm.StatusPriority(releases[i].Status, releases[i].ResourceHealth) < helm.StatusPriority(releases[j].Status, releases[j].ResourceHealth)
 				})
+
+				limit := min(len(releases), 5)
+				for _, r := range releases[:limit] {
+					d.HelmReleases.Releases = append(d.HelmReleases.Releases, mcpHelmRelease{
+						Name:           r.Name,
+						Namespace:      r.Namespace,
+						Chart:          r.Chart,
+						ChartVersion:   r.ChartVersion,
+						Status:         r.Status,
+						ResourceHealth: r.ResourceHealth,
+					})
+				}
 			}
 		}
 	}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2267,7 +2267,12 @@ func buildDashboard(ctx context.Context, cache *k8s.ResourceCache, namespace str
 		d.HelmReleases.UnavailableReason = "Helm client not initialized."
 	} else {
 		username, groups := userFromContext(ctx)
-		releases, err := helmClient.ListReleasesAsUser(namespace, username, groups)
+		namespaces := resolveHelmListNamespaces(ctx, namespace)
+		var releases []helm.HelmRelease
+		var err error
+		if namespaces == nil || len(namespaces) > 0 {
+			releases, err = helmClient.ListReleasesAcrossNamespaces(namespaces, username, groups)
+		}
 		if err != nil {
 			// Not fatal for the dashboard — a viewer with no helm access
 			// still sees everything else. Surface to LLM consumers via

--- a/internal/mcp/tools_helm.go
+++ b/internal/mcp/tools_helm.go
@@ -9,9 +9,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/skyhook-io/radar/internal/helm"
-	"github.com/skyhook-io/radar/internal/k8s"
 	pkgauth "github.com/skyhook-io/radar/pkg/auth"
-	"github.com/skyhook-io/radar/pkg/k8score"
 )
 
 // userFromContext extracts the auth user attached by the HTTP middleware,
@@ -70,21 +68,7 @@ func resolveHelmListNamespaces(ctx context.Context, namespace string) []string {
 	if pkgauth.UserFromContext(ctx) != nil {
 		return filterNamespacesForUser(ctx, nil)
 	}
-	return noAuthHelmListNamespaces(ctx)
-}
-
-func noAuthHelmListNamespaces(ctx context.Context) []string {
-	accessible, authoritative := k8s.GetAccessibleNamespaces(ctx)
-	if !authoritative && len(accessible) > 0 {
-		return accessible
-	}
-	if authoritative && len(accessible) > 0 {
-		allowed, apiErr := k8score.CanI(ctx, k8s.GetClient(), "", "", "secrets", "list")
-		if !apiErr && !allowed {
-			return accessible
-		}
-	}
-	return nil
+	return helm.ResolveNoAuthListNamespaces(ctx)
 }
 
 func handleGetHelmRelease(ctx context.Context, req *mcp.CallToolRequest, input getHelmReleaseInput) (*mcp.CallToolResult, any, error) {

--- a/internal/mcp/tools_helm.go
+++ b/internal/mcp/tools_helm.go
@@ -9,7 +9,9 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/skyhook-io/radar/internal/helm"
+	"github.com/skyhook-io/radar/internal/k8s"
 	pkgauth "github.com/skyhook-io/radar/pkg/auth"
+	"github.com/skyhook-io/radar/pkg/k8score"
 )
 
 // userFromContext extracts the auth user attached by the HTTP middleware,
@@ -46,7 +48,11 @@ func handleListHelmReleases(ctx context.Context, req *mcp.CallToolRequest, input
 	}
 
 	username, groups := userFromContext(ctx)
-	releases, err := helmClient.ListReleasesAsUser(input.Namespace, username, groups)
+	namespaces := resolveHelmListNamespaces(ctx, input.Namespace)
+	if namespaces != nil && len(namespaces) == 0 {
+		return toJSONResult([]helm.HelmRelease{})
+	}
+	releases, err := helmClient.ListReleasesAcrossNamespaces(namespaces, username, groups)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to list helm releases: %w", err)
 	}
@@ -55,6 +61,30 @@ func handleListHelmReleases(ctx context.Context, req *mcp.CallToolRequest, input
 	// health fields (ResourceHealth, HealthIssue, HealthSummary) which
 	// provide the AI with actionable status information.
 	return toJSONResult(releases)
+}
+
+func resolveHelmListNamespaces(ctx context.Context, namespace string) []string {
+	if namespace != "" {
+		return []string{namespace}
+	}
+	if pkgauth.UserFromContext(ctx) != nil {
+		return filterNamespacesForUser(ctx, nil)
+	}
+	return noAuthHelmListNamespaces(ctx)
+}
+
+func noAuthHelmListNamespaces(ctx context.Context) []string {
+	accessible, authoritative := k8s.GetAccessibleNamespaces(ctx)
+	if !authoritative && len(accessible) > 0 {
+		return accessible
+	}
+	if authoritative && len(accessible) > 0 {
+		allowed, apiErr := k8score.CanI(ctx, k8s.GetClient(), "", "", "secrets", "list")
+		if !apiErr && !allowed {
+			return accessible
+		}
+	}
+	return nil
 }
 
 func handleGetHelmRelease(ctx context.Context, req *mcp.CallToolRequest, input getHelmReleaseInput) (*mcp.CallToolResult, any, error) {

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -287,21 +287,6 @@ type DashboardHelmRelease struct {
 	ResourceHealth string `json:"resourceHealth,omitempty"`
 }
 
-// mergeHelmSummary appends src into dst. The first non-empty Error / ErrorCode
-// wins so the UI surfaces a real failure rather than swallowing it under a
-// later success. Restricted is OR-merged: restricted in any namespace ⇒ flag.
-func mergeHelmSummary(dst *DashboardHelmSummary, src DashboardHelmSummary) {
-	dst.Total += src.Total
-	dst.Releases = append(dst.Releases, src.Releases...)
-	if src.Restricted {
-		dst.Restricted = true
-	}
-	if dst.Error == "" {
-		dst.Error = src.Error
-		dst.ErrorCode = src.ErrorCode
-	}
-}
-
 func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	if !s.requireConnected(w) {
 		return
@@ -490,18 +475,7 @@ func (s *Server) handleDashboardHelm(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Iterate per allowed namespace and aggregate. Cluster-wide access
-	// (namespaces == nil) collapses to a single "" call; a namespace-restricted
-	// identity gets its accessible namespaces from resolveHelmNamespaces so the
-	// summary doesn't 403 into a "Restricted" card.
-	var summary DashboardHelmSummary
-	if namespaces == nil {
-		summary = s.getDashboardHelmSummary(r, "")
-	} else {
-		for _, ns := range namespaces {
-			mergeHelmSummary(&summary, s.getDashboardHelmSummary(r, ns))
-		}
-	}
+	summary := s.getDashboardHelmSummary(r, namespaces)
 	s.writeJSON(w, summary)
 }
 
@@ -1371,7 +1345,7 @@ func (s *Server) getDashboardTrafficSummary(ctx context.Context, namespaces []st
 	}
 }
 
-func (s *Server) getDashboardHelmSummary(r *http.Request, namespace string) DashboardHelmSummary {
+func (s *Server) getDashboardHelmSummary(r *http.Request, namespaces []string) DashboardHelmSummary {
 	helmClient := helm.GetClient()
 	if helmClient == nil {
 		return DashboardHelmSummary{
@@ -1387,7 +1361,7 @@ func (s *Server) getDashboardHelmSummary(r *http.Request, namespace string) Dash
 		username = user.Username
 		groups = user.Groups
 	}
-	releases, err := helmClient.ListReleasesAsUser(namespace, username, groups)
+	releases, err := helmClient.ListReleasesAcrossNamespaces(namespaces, username, groups)
 	if err != nil {
 		if helm.IsForbiddenError(err) {
 			return DashboardHelmSummary{Releases: []DashboardHelmRelease{}, Restricted: true}
@@ -1400,6 +1374,10 @@ func (s *Server) getDashboardHelmSummary(r *http.Request, namespace string) Dash
 		}
 	}
 
+	return dashboardHelmSummaryFromReleases(releases)
+}
+
+func dashboardHelmSummaryFromReleases(releases []helm.HelmRelease) DashboardHelmSummary {
 	result := DashboardHelmSummary{
 		Total: len(releases),
 	}
@@ -1415,14 +1393,14 @@ func (s *Server) getDashboardHelmSummary(r *http.Request, namespace string) Dash
 	limit := min(len(releases), 6)
 
 	result.Releases = make([]DashboardHelmRelease, 0, limit)
-	for _, r := range releases[:limit] {
+	for _, rel := range releases[:limit] {
 		result.Releases = append(result.Releases, DashboardHelmRelease{
-			Name:           r.Name,
-			Namespace:      r.Namespace,
-			Chart:          r.Chart,
-			ChartVersion:   r.ChartVersion,
-			Status:         r.Status,
-			ResourceHealth: r.ResourceHealth,
+			Name:           rel.Name,
+			Namespace:      rel.Namespace,
+			Chart:          rel.Chart,
+			ChartVersion:   rel.ChartVersion,
+			Status:         rel.Status,
+			ResourceHealth: rel.ResourceHealth,
 		})
 	}
 

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -484,14 +484,16 @@ func (s *Server) handleDashboardHelm(w http.ResponseWriter, r *http.Request) {
 	if !s.requireConnected(w) {
 		return
 	}
-	namespaces := s.parseNamespacesForUser(r)
-	if noNamespaceAccess(namespaces) {
+	namespaces, ok := s.resolveHelmNamespaces(r)
+	if !ok {
 		s.writeJSON(w, DashboardHelmSummary{})
 		return
 	}
 
-	// Iterate per allowed namespace and aggregate. Cluster-admin / no-auth
-	// (namespaces == nil) collapses to a single "" call (cluster-wide).
+	// Iterate per allowed namespace and aggregate. Cluster-wide access
+	// (namespaces == nil) collapses to a single "" call; a namespace-restricted
+	// identity gets its accessible namespaces from resolveHelmNamespaces so the
+	// summary doesn't 403 into a "Restricted" card.
 	var summary DashboardHelmSummary
 	if namespaces == nil {
 		summary = s.getDashboardHelmSummary(r, "")

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/skyhook-io/radar/internal/helm"
+)
+
+func TestDashboardHelmSummaryFromReleasesSortsAndLimits(t *testing.T) {
+	releases := []helm.HelmRelease{
+		{Name: "healthy-a", Namespace: "apps", Chart: "svc", ChartVersion: "1.0.0", Status: "deployed", ResourceHealth: "healthy"},
+		{Name: "degraded", Namespace: "apps", Chart: "svc", ChartVersion: "1.1.0", Status: "deployed", ResourceHealth: "degraded"},
+		{Name: "failed", Namespace: "ops", Chart: "svc", ChartVersion: "2.0.0", Status: "failed"},
+		{Name: "pending", Namespace: "ops", Chart: "svc", ChartVersion: "2.1.0", Status: "pending-upgrade"},
+		{Name: "unhealthy", Namespace: "apps", Chart: "svc", ChartVersion: "1.2.0", Status: "deployed", ResourceHealth: "unhealthy"},
+		{Name: "healthy-b", Namespace: "ops", Chart: "svc", ChartVersion: "3.0.0", Status: "deployed", ResourceHealth: "healthy"},
+		{Name: "healthy-c", Namespace: "ops", Chart: "svc", ChartVersion: "4.0.0", Status: "deployed", ResourceHealth: "healthy"},
+	}
+
+	got := dashboardHelmSummaryFromReleases(releases)
+	if got.Total != len(releases) {
+		t.Fatalf("Total = %d, want %d", got.Total, len(releases))
+	}
+	if got.Restricted {
+		t.Fatal("Restricted = true, want false for a readable merged release list")
+	}
+	if len(got.Releases) != 6 {
+		t.Fatalf("len(Releases) = %d, want 6", len(got.Releases))
+	}
+	wantNames := []string{"failed", "pending", "unhealthy", "degraded", "healthy-a", "healthy-b"}
+	for i, want := range wantNames {
+		if got.Releases[i].Name != want {
+			t.Fatalf("Releases[%d].Name = %q, want %q", i, got.Releases[i].Name, want)
+		}
+	}
+}
+
+func TestDashboardHelmSummaryFromReleasesEmptyReadableList(t *testing.T) {
+	got := dashboardHelmSummaryFromReleases(nil)
+	if got.Total != 0 {
+		t.Fatalf("Total = %d, want 0", got.Total)
+	}
+	if got.Restricted {
+		t.Fatal("Restricted = true, want false for an empty readable release list")
+	}
+	if len(got.Releases) != 0 {
+		t.Fatalf("len(Releases) = %d, want 0", len(got.Releases))
+	}
+}

--- a/internal/server/namespace_scope_test.go
+++ b/internal/server/namespace_scope_test.go
@@ -5,9 +5,12 @@ import (
 	"net/http/httptest"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/skyhook-io/radar/internal/k8s"
 	pkgauth "github.com/skyhook-io/radar/pkg/auth"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 // newTestServer constructs a Server with just the state needed by the
@@ -251,4 +254,53 @@ func TestIntersectPicksWithAllowed(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveHelmNamespaces_NoAuthUsesBackendFallback(t *testing.T) {
+	s := newTestServer(t)
+	restoreHelmNamespaceFallbackState(t)
+
+	got, ok := s.resolveHelmNamespaces(reqAs(""))
+	if !ok {
+		t.Fatal("resolveHelmNamespaces returned ok=false")
+	}
+	if !slices.Equal(got, []string{"backend-fallback"}) {
+		t.Fatalf("namespaces = %v, want backend fallback namespace", got)
+	}
+}
+
+func TestResolveHelmNamespaces_AuthenticatedClusterWideUserDoesNotUseBackendFallback(t *testing.T) {
+	s := newTestServer(t)
+	restoreHelmNamespaceFallbackState(t)
+
+	s.permCache = pkgauth.NewPermissionCache()
+	s.permCache.Set("alice", &pkgauth.UserPermissions{AllowedNamespaces: nil})
+
+	got, ok := s.resolveHelmNamespaces(reqAs("alice"))
+	if !ok {
+		t.Fatal("resolveHelmNamespaces returned ok=false")
+	}
+	if got != nil {
+		t.Fatalf("namespaces = %v, want nil so Helm lists as the impersonated user cluster-wide", got)
+	}
+}
+
+func restoreHelmNamespaceFallbackState(t *testing.T) {
+	t.Helper()
+
+	prevTimeout := k8s.NamespaceListTimeout
+	k8s.NamespaceListTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { k8s.NamespaceListTimeout = prevTimeout })
+
+	prevClient := k8s.SetTestClient(nil)
+	t.Cleanup(func() { k8s.SetTestClient(prevClient) })
+
+	dummyClient, err := kubernetes.NewForConfig(&rest.Config{Host: "http://127.0.0.1:1"})
+	if err != nil {
+		t.Fatalf("creating dummy client: %v", err)
+	}
+	k8s.SetTestClient(dummyClient)
+
+	k8s.SetFallbackNamespace("backend-fallback")
+	t.Cleanup(func() { k8s.SetFallbackNamespace("") })
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -44,6 +44,7 @@ import (
 	"github.com/skyhook-io/radar/internal/updater"
 	"github.com/skyhook-io/radar/internal/version"
 	"github.com/skyhook-io/radar/pkg/hpadiag"
+	"github.com/skyhook-io/radar/pkg/k8score"
 	"github.com/skyhook-io/radar/pkg/perfstats"
 	"github.com/skyhook-io/radar/pkg/rbac"
 	topology "github.com/skyhook-io/radar/pkg/topology"
@@ -833,8 +834,8 @@ func (s *Server) parseNamespacesForUser(r *http.Request) []string {
 // always namespaced (stored as Secrets/ConfigMaps in a namespace), so unlike
 // cluster-scoped kinds it is always safe to narrow an "all namespaces" request
 // to the identity's accessible namespaces — which is what lets a
-// namespace-restricted user or ServiceAccount read Helm without a cluster-wide
-// `list secrets` (the 403 in issue #925).
+// namespace-restricted ServiceAccount read Helm without a cluster-wide
+// `list secrets`.
 //
 // Returns:
 //   - (nil, true)        cluster-wide: a single AllNamespaces list
@@ -861,18 +862,49 @@ func (s *Server) resolveHelmNamespaces(r *http.Request) ([]string, bool) {
 	if noNamespaceAccess(namespaces) {
 		return nil, false
 	}
-	if namespaces == nil {
-		// "All namespaces". A namespace-restricted identity can't list
-		// cluster-wide; resolve to the namespaces it can actually see so the
-		// Helm list degrades gracefully instead of 403-ing.
-		// GetAccessibleNamespaces is authoritative only when cluster-wide `list
-		// namespaces` succeeds — keep nil in that case for a single cluster-wide
-		// list.
-		if accessible, authoritative := k8s.GetAccessibleNamespaces(r.Context()); !authoritative && len(accessible) > 0 {
-			return accessible, true
+	if namespaces == nil && auth.UserFromContext(r.Context()) == nil {
+		// "All namespaces" in no-auth mode. A namespace-restricted
+		// ServiceAccount can't list cluster-wide; resolve to the namespaces it
+		// can actually see so the Helm list degrades gracefully instead of
+		// 403-ing. Authenticated users are handled by parseNamespacesForUser
+		// above, and Helm lists impersonate them directly; narrowing them with
+		// the backend client's fallback namespaces would under-list users whose
+		// RBAC is wider than Radar's own ServiceAccount.
+		if fallback := noAuthHelmNamespaces(r.Context()); len(fallback) > 0 {
+			return fallback, true
 		}
 	}
 	return namespaces, true
+}
+
+func dedupeStrings(values []string) []string {
+	if len(values) < 2 {
+		return values
+	}
+	seen := make(map[string]struct{}, len(values))
+	out := values[:0]
+	for _, v := range values {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}
+
+func noAuthHelmNamespaces(ctx context.Context) []string {
+	accessible, authoritative := k8s.GetAccessibleNamespaces(ctx)
+	if !authoritative && len(accessible) > 0 {
+		return accessible
+	}
+	if authoritative && len(accessible) > 0 {
+		allowed, apiErr := k8score.CanI(ctx, k8s.GetClient(), "", "", "secrets", "list")
+		if !apiErr && !allowed {
+			return accessible
+		}
+	}
+	return nil
 }
 
 // noNamespaceAccess returns true when a namespace filter explicitly grants no access
@@ -1000,7 +1032,7 @@ func parseNamespaces(query url.Values) []string {
 				result = append(result, trimmed)
 			}
 		}
-		return result
+		return dedupeStrings(result)
 	}
 	// Fall back to "namespace" (singular) for backward compatibility
 	if ns := query.Get("namespace"); ns != "" {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -848,7 +848,12 @@ func (s *Server) resolveHelmNamespaces(r *http.Request) ([]string, bool) {
 	// namespace discovery and wrongly drop a namespace where the caller has
 	// secrets but no pod access. A denied namespace surfaces as a 403 from the
 	// per-namespace list rather than a silent empty result.
-	if explicit := parseNamespaces(r.URL.Query()); explicit != nil {
+	//
+	// Guard on len > 0, not != nil: parseNamespaces returns an empty non-nil
+	// slice for a degenerate query like ?namespaces=,, — treat that as "no
+	// explicit filter" and fall through, rather than short-circuiting to a
+	// zero-namespace (empty) result.
+	if explicit := parseNamespaces(r.URL.Query()); len(explicit) > 0 {
 		return explicit, true
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -44,7 +44,6 @@ import (
 	"github.com/skyhook-io/radar/internal/updater"
 	"github.com/skyhook-io/radar/internal/version"
 	"github.com/skyhook-io/radar/pkg/hpadiag"
-	"github.com/skyhook-io/radar/pkg/k8score"
 	"github.com/skyhook-io/radar/pkg/perfstats"
 	"github.com/skyhook-io/radar/pkg/rbac"
 	topology "github.com/skyhook-io/radar/pkg/topology"
@@ -870,7 +869,7 @@ func (s *Server) resolveHelmNamespaces(r *http.Request) ([]string, bool) {
 		// above, and Helm lists impersonate them directly; narrowing them with
 		// the backend client's fallback namespaces would under-list users whose
 		// RBAC is wider than Radar's own ServiceAccount.
-		if fallback := noAuthHelmNamespaces(r.Context()); len(fallback) > 0 {
+		if fallback := helm.ResolveNoAuthListNamespaces(r.Context()); len(fallback) > 0 {
 			return fallback, true
 		}
 	}
@@ -891,20 +890,6 @@ func dedupeStrings(values []string) []string {
 		out = append(out, v)
 	}
 	return out
-}
-
-func noAuthHelmNamespaces(ctx context.Context) []string {
-	accessible, authoritative := k8s.GetAccessibleNamespaces(ctx)
-	if !authoritative && len(accessible) > 0 {
-		return accessible
-	}
-	if authoritative && len(accessible) > 0 {
-		allowed, apiErr := k8score.CanI(ctx, k8s.GetClient(), "", "", "secrets", "list")
-		if !apiErr && !allowed {
-			return accessible
-		}
-	}
-	return nil
 }
 
 // noNamespaceAccess returns true when a namespace filter explicitly grants no access

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -379,7 +379,7 @@ func (s *Server) setupRoutes() {
 			r.Get("/workloads/{kind}/{namespace}/{name}/pods", s.handleWorkloadPods)
 
 			// Helm routes
-			helmHandlers := helm.NewHandlers()
+			helmHandlers := helm.NewHandlers(s.resolveHelmNamespaces)
 			helmHandlers.RegisterRoutes(r)
 
 			// Image inspection routes
@@ -826,6 +826,48 @@ func (s *Server) parseNamespacesForUser(r *http.Request) []string {
 		filtered = s.getUserNamespaces(r, nil)
 	}
 	return filtered
+}
+
+// resolveHelmNamespaces decides which namespaces a Helm list (releases, upgrade
+// checks, dashboard summary) should query for this request. Helm releases are
+// always namespaced (stored as Secrets/ConfigMaps in a namespace), so unlike
+// cluster-scoped kinds it is always safe to narrow an "all namespaces" request
+// to the identity's accessible namespaces — which is what lets a
+// namespace-restricted user or ServiceAccount read Helm without a cluster-wide
+// `list secrets` (the 403 in issue #925).
+//
+// Returns:
+//   - (nil, true)        cluster-wide: a single AllNamespaces list
+//   - (namespaces, true) list each and merge
+//   - (nil, false)       no namespace access — caller returns an empty result
+func (s *Server) resolveHelmNamespaces(r *http.Request) ([]string, bool) {
+	// An explicit ?namespace=/?namespaces= request is honored as-is. Helm reads
+	// run as the caller (user impersonation, or the SA when auth is off), so the
+	// apiserver authorizes the secrets read directly — routing this through
+	// parseNamespacesForUser would intersect it with the pod/deployment-based
+	// namespace discovery and wrongly drop a namespace where the caller has
+	// secrets but no pod access. A denied namespace surfaces as a 403 from the
+	// per-namespace list rather than a silent empty result.
+	if explicit := parseNamespaces(r.URL.Query()); explicit != nil {
+		return explicit, true
+	}
+
+	namespaces := s.parseNamespacesForUser(r)
+	if noNamespaceAccess(namespaces) {
+		return nil, false
+	}
+	if namespaces == nil {
+		// "All namespaces". A namespace-restricted identity can't list
+		// cluster-wide; resolve to the namespaces it can actually see so the
+		// Helm list degrades gracefully instead of 403-ing.
+		// GetAccessibleNamespaces is authoritative only when cluster-wide `list
+		// namespaces` succeeds — keep nil in that case for a single cluster-wide
+		// list.
+		if accessible, authoritative := k8s.GetAccessibleNamespaces(r.Context()); !authoritative && len(accessible) > 0 {
+			return accessible, true
+		}
+	}
+	return namespaces, true
 }
 
 // noNamespaceAccess returns true when a namespace filter explicitly grants no access

--- a/internal/server/server_auth_test.go
+++ b/internal/server/server_auth_test.go
@@ -128,6 +128,7 @@ func TestParseNamespaces(t *testing.T) {
 		{"plural takes precedence", "namespaces=dev&namespace=prod", []string{"dev"}, false},
 		{"trims whitespace", "namespaces= dev , staging ", []string{"dev", "staging"}, false},
 		{"filters empty segments", "namespaces=dev,,staging,", []string{"dev", "staging"}, false},
+		{"dedupes namespaces preserving order", "namespaces=dev,staging,dev,prod,staging", []string{"dev", "staging", "prod"}, false},
 	}
 
 	for _, tt := range tests {

--- a/pkg/k8score/cache_test.go
+++ b/pkg/k8score/cache_test.go
@@ -1253,7 +1253,19 @@ func TestDynamicResourceCache_ListEmptyNamespaceUnionsWhenNamespaceScoped(t *tes
 		t.Errorf("List(gvr, \"\") = %d objects, want 2 (union of per-namespace informers in namespace-scoped mode)", len(got))
 	}
 
-	n, err := d.Count(gvr, nil)
+	// Count gates on the cache's own per-informer `synced` flag, which a
+	// background goroutine sets shortly AFTER informer.HasSynced() (what
+	// ListBlocking waited on) — so poll briefly rather than racing that
+	// propagation.
+	var n int
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		n, err = d.Count(gvr, nil)
+		if err == nil || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	if err != nil {
 		t.Fatalf("Count(gvr, nil) failed: %v", err)
 	}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1382,8 +1382,6 @@ function AppInner() {
         <div className="flex items-center gap-3 shrink-0">
           <NamespaceSwitcher
             ref={namespaceSwitcherRef}
-            disabled={mainView === 'helm'}
-            disabledTooltip="Helm view always shows all namespaces"
           />
 
 
@@ -1746,10 +1744,9 @@ function AppInner() {
           />
         )}
 
-        {/* Helm view - always show all namespaces since releases span multiple ns */}
         {mainView === 'helm' && (
           <HelmView
-            namespace=""
+            namespaces={namespaces}
             selectedRelease={selectedHelmRelease}
             onReleaseClick={(ns, name, storageNamespace) => {
               setSelectedHelmRelease({ namespace: ns, name, storageNamespace })

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2311,11 +2311,15 @@ export function useDrainNode() {
 // Helm API hooks
 // ============================================================================
 
+function helmNamespaceParams(namespaces: string[] = []) {
+  return namespaces.length > 0 ? `?namespaces=${namespaces.join(',')}` : ''
+}
+
 // List all Helm releases
-export function useHelmReleases(namespace?: string) {
-  const params = namespace ? `?namespace=${namespace}` : ''
+export function useHelmReleases(namespaces: string[] = []) {
+  const params = helmNamespaceParams(namespaces)
   return useQuery<HelmRelease[]>({
-    queryKey: ['helm-releases', namespace],
+    queryKey: ['helm-releases', namespaces],
     queryFn: () => fetchJSON(`/helm/releases${params}`),
     staleTime: 30000, // 30 seconds
   })
@@ -2393,10 +2397,10 @@ export function useHelmUpgradeInfo(namespace: string, name: string, enabled = tr
 }
 
 // Batch check for upgrade availability (for list view)
-export function useHelmBatchUpgradeInfo(namespace?: string, enabled = true) {
-  const params = namespace ? `?namespace=${namespace}` : ''
+export function useHelmBatchUpgradeInfo(namespaces: string[] = [], enabled = true) {
+  const params = helmNamespaceParams(namespaces)
   return useQuery<BatchUpgradeInfo>({
-    queryKey: ['helm-batch-upgrade-info', namespace],
+    queryKey: ['helm-batch-upgrade-info', namespaces],
     queryFn: () => fetchJSON(`/helm/upgrade-check${params}`),
     enabled,
     staleTime: 30000, // 30 seconds - keep in sync with release list

--- a/web/src/components/helm/HelmView.tsx
+++ b/web/src/components/helm/HelmView.tsx
@@ -15,23 +15,23 @@ import { InstallWizard } from './InstallWizard'
 type ViewTab = 'releases' | 'charts'
 
 interface HelmViewProps {
-  namespace: string
+  namespaces: string[]
   selectedRelease?: SelectedHelmRelease | null
   onReleaseClick?: (namespace: string, name: string, storageNamespace?: string) => void
 }
 
-export function HelmView({ namespace, selectedRelease, onReleaseClick }: HelmViewProps) {
+export function HelmView({ namespaces, selectedRelease, onReleaseClick }: HelmViewProps) {
   const [activeTab, setActiveTab] = useState<ViewTab>('releases')
   const [searchTerm, setSearchTerm] = useState('')
   const [selectedChart, setSelectedChart] = useState<{ repo: string; chart: string; version: string; source: ChartSource } | null>(null)
 
-  const { data: releases, isLoading, error: releasesError, refetch: refetchReleases } = useHelmReleases(namespace || undefined)
+  const { data: releases, isLoading, error: releasesError, refetch: refetchReleases } = useHelmReleases(namespaces)
   const isForbidden = isForbiddenError(releasesError)
   const releasesErrorMessage = releasesError instanceof Error ? releasesError.message : 'Failed to load Helm releases'
 
   // Lazy load upgrade info after releases are loaded
   const { data: upgradeInfo, isLoading: upgradeLoading, error: upgradeError, refetch: refetchUpgradeInfo } = useHelmBatchUpgradeInfo(
-    namespace || undefined,
+    namespaces,
     Boolean(releases && releases.length > 0)
   )
   const upgradeErrorMessage = upgradeError instanceof Error ? upgradeError.message : 'Upgrade checks failed'


### PR DESCRIPTION
## Summary

Fixes Helm release listing for namespace-scoped users and ServiceAccounts that can read Helm release Secrets in specific namespaces but cannot cluster-wide `list secrets`. Radar now resolves an appropriate namespace set before list-style Helm reads, and the Helm view now honors the global namespace switcher, so visible releases still show up instead of the whole Helm surface falling into "Access Restricted".

Closes #925.

## What Changed

Helm list-style reads now share explicit namespace resolution instead of treating an omitted namespace as an unconditional cluster-wide Helm SDK list:

- `Server.resolveHelmNamespaces` is the REST policy point for Helm list, upgrade-check, and dashboard summary reads.
- Explicit `?namespace=` / `?namespaces=` filters pass through to Helm and are authorized by the apiserver.
- Authenticated users still use Radar's per-user namespace filtering when no explicit namespace is provided.
- No-auth ServiceAccount mode uses accessible namespace discovery, and when namespace listing is available it checks actual cluster-wide `list secrets` before deciding whether to keep a cluster-wide Helm list or fan out per namespace.

The Helm client now has shared merge paths for namespace fanout:

- `ListReleasesAcrossNamespaces`
- `BatchCheckUpgradesAcrossNamespaces`

Those helpers skip forbidden namespaces during multi-namespace fanout so one namespace without Helm Secret access does not hide releases from namespaces the caller can read. If every release-list namespace is forbidden, the 403 still surfaces. Upgrade checks remain best-effort enrichment over the release list.

Covered surfaces:

- `GET /api/helm/releases`
- `GET /api/helm/upgrade-check`
- `GET /api/dashboard/helm`
- MCP `list_helm_releases`
- MCP dashboard Helm summary
- The Helm view release list and batch upgrade checks

The dashboard Helm card now builds from the same merged release-list path as the Helm API, so a partially forbidden namespace set does not mark the whole card as `restricted` when visible releases were returned. Duplicate explicit namespace filters are deduped before fanout.

The Helm view no longer disables the namespace switcher. Empty selection still means all namespaces; selecting one or more namespaces sends `?namespaces=...` to the release-list and batch-upgrade endpoints.

## Testing

Verified locally:

- `go test ./internal/server -run 'TestResolveHelmNamespaces|TestParseNamespaces|TestIntersectPicksWithAllowed|TestFinalizePostContextSwitch'`
- `go test ./internal/server -run 'TestDashboardHelmSummary|TestSmokeDashboardHelm|TestResolveHelmNamespaces|TestParseNamespaces'`
- `go test ./internal/mcp`
- `go test ./internal/helm`
- `go test -run TestDynamicResourceCache_ListEmptyNamespaceUnionsWhenNamespaceScoped` from `pkg/k8score`
- `make tsc`
- `make test`
- `make build`

Visual-test: skipped. This reuses the existing namespace switcher control and only changes whether Helm honors its selected namespace set; `make tsc` and `make build` cover the frontend wiring.

Also verified against a real cluster with Helm releases and mixed per-namespace RBAC: one namespace allowed Helm Secret reads, another had pods-only/no-secrets access. The fixed behavior returns visible releases from the allowed namespace, skips the forbidden namespace in multi-namespace fanout, and still returns a clear 403 when the requested namespace itself has no Helm Secret access.

## Notes

This PR still does not enumerate every namespace for an authenticated user who has cluster-wide pod/namespace visibility but lacks cluster-wide `list secrets`; that shape needs either an explicit namespace or a follow-up bounded per-namespace `secrets/list` authorization pass. The no-auth ServiceAccount equivalent is handled by checking cluster-wide `list secrets` before deciding whether to fan out.

Also included: a test-only deflake for `TestDynamicResourceCache_ListEmptyNamespaceUnionsWhenNamespaceScoped`, which now polls `Count` until the cache's synced flag catches up after `ListBlocking`.
