### PR TITLE
Collapse SA Permissions section by default for namespace-scoped wildcards

### DIFF
--- a/packages/k8s-ui/src/utils/rbac-blast-radius.test.ts
+++ b/packages/k8s-ui/src/utils/rbac-blast-radius.test.ts
@@ -35,15 +35,24 @@ describe('detectBlastRadius', () => {
     expect(reasons[0].reason).toMatch(/cluster-admin/)
   })
 
-  it('flags verb wildcards spanning every apiGroup', () => {
-    // apiGroups:['*'] with a verb wildcard is god-mode regardless of binding
-    // scope — admin-shaped roles look exactly like this.
+  it('flags an admin-shaped grant via ClusterRoleBinding', () => {
+    // apiGroups/resources/verbs all `*` bound cluster-wide is god-mode.
     const b = binding({
-      rules: [{ verbs: ['*'], resources: ['pods'], apiGroups: ['*'] }],
+      binding: { kind: 'ClusterRoleBinding', namespace: '', name: 'admin-crb', roleRef: { kind: 'ClusterRole', namespace: '', name: 'admin' } },
+      rules: [{ verbs: ['*'], resources: ['*'], apiGroups: ['*'] }],
     })
     const reasons = detectBlastRadius(subject([b]))
     expect(reasons).toHaveLength(1)
     expect(reasons[0].reason).toMatch(/verb wildcard/)
+  })
+
+  it('does NOT flag the same admin-shaped grant via a namespace RoleBinding', () => {
+    // A RoleBinding is namespace-scoped by apiserver construction — even
+    // `*/*/*` is namespace-admin, not cluster takeover, so it stays collapsed.
+    const b = binding({
+      rules: [{ verbs: ['*'], resources: ['*'], apiGroups: ['*'] }],
+    })
+    expect(detectBlastRadius(subject([b]))).toHaveLength(0)
   })
 
   it('flags verb wildcards on a cluster-wide binding (incl. cluster-wide secrets)', () => {

--- a/packages/k8s-ui/src/utils/rbac-blast-radius.test.ts
+++ b/packages/k8s-ui/src/utils/rbac-blast-radius.test.ts
@@ -35,13 +35,48 @@ describe('detectBlastRadius', () => {
     expect(reasons[0].reason).toMatch(/cluster-admin/)
   })
 
-  it('flags verb wildcards', () => {
+  it('flags verb wildcards spanning every apiGroup', () => {
+    // apiGroups:['*'] with a verb wildcard is god-mode regardless of binding
+    // scope — admin-shaped roles look exactly like this.
     const b = binding({
-      rules: [{ verbs: ['*'], resources: ['pods'], apiGroups: [''] }],
+      rules: [{ verbs: ['*'], resources: ['pods'], apiGroups: ['*'] }],
     })
     const reasons = detectBlastRadius(subject([b]))
     expect(reasons).toHaveLength(1)
     expect(reasons[0].reason).toMatch(/verb wildcard/)
+  })
+
+  it('flags verb wildcards on a cluster-wide binding (incl. cluster-wide secrets)', () => {
+    // Cluster-wide `verbs:['*']` on secrets is read-every-secret takeover and
+    // MUST stay loud even though the resource is named, not `*`.
+    const b = binding({
+      binding: { kind: 'ClusterRoleBinding', namespace: '', name: 'cluster-b', roleRef: { kind: 'ClusterRole', namespace: '', name: 'r' } },
+      rules: [{ verbs: ['*'], resources: ['secrets'], apiGroups: [''] }],
+    })
+    const reasons = detectBlastRadius(subject([b]))
+    expect(reasons).toHaveLength(1)
+    expect(reasons[0].reason).toMatch(/verb wildcard/)
+  })
+
+  it("does NOT flag a verb wildcard scoped to one operator's own CRDs", () => {
+    // `verbs:['*']` confined to a specific apiGroup+resources in a single
+    // namespace (RoleBinding) is the routine operator-owns-its-CRDs grant —
+    // expanding the Permissions section on every such SA is the over-fire
+    // this exclusion fixes.
+    const b = binding({
+      rules: [{ verbs: ['*'], resources: ['widgets'], apiGroups: ['acme.example.com'] }],
+    })
+    expect(detectBlastRadius(subject([b]))).toHaveLength(0)
+  })
+
+  it('does NOT flag a namespace RoleBinding with resource-wildcard verb-wildcard over one group', () => {
+    // `verbs:['*']` over `resources:['*']` in one apiGroup, bound via a
+    // namespace RoleBinding, is namespace-scoped — broad within the namespace
+    // but not cluster takeover. Common operator shape; stays collapsed.
+    const b = binding({
+      rules: [{ verbs: ['*'], resources: ['*'], apiGroups: ['acme.example.com'] }],
+    })
+    expect(detectBlastRadius(subject([b]))).toHaveLength(0)
   })
 
   it('flags escalation verbs', () => {
@@ -89,8 +124,9 @@ describe('detectBlastRadius', () => {
 
   it('dedupes by binding identity when multiple risky rules match', () => {
     const b = binding({
+      binding: { kind: 'ClusterRoleBinding', namespace: '', name: 'cluster-b', roleRef: { kind: 'ClusterRole', namespace: '', name: 'r' } },
       rules: [
-        { verbs: ['*'], resources: ['pods'], apiGroups: [''] },
+        { verbs: ['*'], resources: ['secrets'], apiGroups: [''] },
         { verbs: ['escalate'], resources: ['roles'], apiGroups: ['rbac.authorization.k8s.io'] },
       ],
     })

--- a/packages/k8s-ui/src/utils/rbac-blast-radius.ts
+++ b/packages/k8s-ui/src/utils/rbac-blast-radius.ts
@@ -47,20 +47,19 @@ export interface BlastRadiusReason {
  *
  *   1. cluster-admin role-name match (covers the "bound my SA to cluster-admin
  *      for testing" pattern even when rules aren't loaded)
- *   2. verb wildcards (`*`) that are also broadly scoped — i.e. the rule spans
- *      every apiGroup, or the binding is cluster-wide (a ClusterRoleBinding)
+ *   2. verb wildcards (`*`) granted by a cluster-wide binding (ClusterRoleBinding)
  *   3. escalation verbs (`escalate` / `bind` / `impersonate`)
  *   4. cluster-wide `create pods` (lateral-movement vector)
  *
  * Resource-only wildcards (e.g. `view`'s fluxcd CRD coverage) deliberately
  * do NOT trigger — they fire on every authenticated SA and would train
- * operators to ignore the alarm. A verb wildcard confined to a single
- * namespace (a RoleBinding) is likewise excluded — even `verbs:['*']` over
- * `resources:['*']` in one apiGroup is namespace-scoped, not cluster takeover,
- * and operators routinely hold exactly that over their own CRDs. Only a
- * cluster-wide binding, or a wildcard spanning every apiGroup, counts as
- * genuine god-mode. The current set is the calibrated minimum for "the Pod's
- * identity is genuinely god-mode".
+ * operators to ignore the alarm. A verb wildcard granted by a RoleBinding is
+ * likewise excluded — a RoleBinding is namespace-scoped by apiserver
+ * construction, so even `verbs:['*']` over `resources:['*']` across every
+ * apiGroup (namespace-admin) is not cluster takeover, and operators routinely
+ * hold broad wildcards over their own CRDs. Only a cluster-wide binding counts
+ * as genuine god-mode. The current set is the calibrated minimum for "the
+ * Pod's identity is genuinely god-mode".
  *
  * Dedupes by binding identity so a binding with multiple risky rules
  * counts once; first matching reason wins.
@@ -79,9 +78,12 @@ export function detectBlastRadius(rbacData: RBACSubjectResponse): BlastRadiusRea
     for (const r of br.rules ?? []) {
       const verbs = r.verbs ?? []
       const resources = r.resources ?? []
-      const groups = r.apiGroups ?? []
-      const broadlyScoped = groups.includes('*') || br.binding.kind === 'ClusterRoleBinding'
-      if (verbs.includes('*') && broadlyScoped) {
+      // A verb wildcard is only cluster takeover when the binding is itself
+      // cluster-wide. A RoleBinding is namespace-scoped by apiserver
+      // construction no matter how broad its rule (apiGroups/resources `*`
+      // included), so namespace-admin SAs stay collapsed; only
+      // ClusterRoleBindings count.
+      if (verbs.includes('*') && br.binding.kind === 'ClusterRoleBinding') {
         reasons.push({ binding: br, reason: 'grants verb wildcard (*) — every action on the listed resources' })
         break
       }

--- a/packages/k8s-ui/src/utils/rbac-blast-radius.ts
+++ b/packages/k8s-ui/src/utils/rbac-blast-radius.ts
@@ -47,14 +47,20 @@ export interface BlastRadiusReason {
  *
  *   1. cluster-admin role-name match (covers the "bound my SA to cluster-admin
  *      for testing" pattern even when rules aren't loaded)
- *   2. verb wildcards (`*`)
+ *   2. verb wildcards (`*`) that are also broadly scoped — i.e. the rule spans
+ *      every apiGroup, or the binding is cluster-wide (a ClusterRoleBinding)
  *   3. escalation verbs (`escalate` / `bind` / `impersonate`)
  *   4. cluster-wide `create pods` (lateral-movement vector)
  *
  * Resource-only wildcards (e.g. `view`'s fluxcd CRD coverage) deliberately
  * do NOT trigger — they fire on every authenticated SA and would train
- * operators to ignore the alarm. The current set is the calibrated minimum
- * for "the Pod's identity is genuinely god-mode".
+ * operators to ignore the alarm. A verb wildcard confined to a single
+ * namespace (a RoleBinding) is likewise excluded — even `verbs:['*']` over
+ * `resources:['*']` in one apiGroup is namespace-scoped, not cluster takeover,
+ * and operators routinely hold exactly that over their own CRDs. Only a
+ * cluster-wide binding, or a wildcard spanning every apiGroup, counts as
+ * genuine god-mode. The current set is the calibrated minimum for "the Pod's
+ * identity is genuinely god-mode".
  *
  * Dedupes by binding identity so a binding with multiple risky rules
  * counts once; first matching reason wins.
@@ -73,7 +79,9 @@ export function detectBlastRadius(rbacData: RBACSubjectResponse): BlastRadiusRea
     for (const r of br.rules ?? []) {
       const verbs = r.verbs ?? []
       const resources = r.resources ?? []
-      if (verbs.includes('*')) {
+      const groups = r.apiGroups ?? []
+      const broadlyScoped = groups.includes('*') || br.binding.kind === 'ClusterRoleBinding'
+      if (verbs.includes('*') && broadlyScoped) {
         reasons.push({ binding: br, reason: 'grants verb wildcard (*) — every action on the listed resources' })
         break
       }


### PR DESCRIPTION
## Problem

The Pod / Workload **"Permissions via ServiceAccount"** section auto-expands when `detectBlastRadius()` finds genuine god-mode RBAC. But a bare verb wildcard (`verbs:['*']`) was treated as blast radius *regardless of scope* — so it fired on the single most common operator grant in any cluster: `verbs:['*']` over an operator's own CRDs in one namespace. Result: the Permissions section started **expanded** on nearly every operator Pod/Workload, training operators to ignore it.

## Change

Gate the verb-wildcard blast-radius trigger on **cluster-wide binding scope**:

```js
if (verbs.includes('*') && br.binding.kind === 'ClusterRoleBinding') { /* blast radius */ }
```

A `RoleBinding` is namespace-scoped by apiserver construction no matter how broad its rule is, so it can never be cluster takeover — only a `ClusterRoleBinding` counts.

| RBAC shape | Before | After |
|---|---|---|
| namespace RoleBinding `{acme.io, *, *}` (operator's own CRDs) | expanded | **collapsed** |
| namespace RoleBinding `{*, *, *}` (namespace-admin) | expanded | **collapsed** |
| ClusterRoleBinding `{'', secrets, *}` (cluster-wide all-secrets) | expanded | expanded |
| ClusterRoleBinding `{*, *, *}` (admin-shaped) | expanded | expanded |

This is purely a **default-expand** calibration — the section still renders (collapsed) and the most-permissive rules still surface in the preview when opened. The other three blast-radius triggers (cluster-admin role match, escalation verbs, cluster-wide create-pods) are unchanged.

## Tests

`rbac-blast-radius.test.ts`: added regression cases for namespace-scoped wildcards (collapse, incl. admin-shaped via RoleBinding), cluster-wide via ClusterRoleBinding (expand, incl. cluster-wide secrets), and operator-own-CRDs (collapse). 16 in-file, 622 k8s-ui suite, `tsc` clean.

## Review notes

Cross-reviewed twice with Codex.
- **Folded:** its finding that `resources:['*']` and then `apiGroups:['*']` were over-broad scope signals — the trigger now keys purely on binding scope (`ClusterRoleBinding`).
- **Out of scope (pre-existing, follow-up candidates), deliberately not taken here:** (a) cluster-wide `create` on `resources:['*']` isn't caught by the create-pods trigger; (b) there is no cluster-wide secret-*read* (`get/list/watch secrets`) detector. Both pre-date this PR and live in other triggers — broadening detection is a separate change from this over-fire calibration.