### PR TITLE
Fix debug containers in restricted PodSecurity namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ radar
 | `--disable-exec` | `false` | Disable terminal and debug shell |
 | `--disable-helm-write` | `false` | Disable Helm write operations |
 | `--disable-local-terminal` | `false` | Disable local terminal feature |
-| `--debug-image` | `busybox:latest` | Image for ephemeral debug containers and node debug pods. Point at a mirror for air-gapped / private-registry clusters. |
+| `--debug-image` | `busybox:latest` | Image for ephemeral debug containers and node debug pods. If built-in restricted PodSecurity rejects the default pod debug container, Radar retries with a restricted-compatible Linux security context using the target/pod non-root UID, or UID `65532` by default; point at a compatible mirror for air-gapped / private-registry clusters. |
 | `--list-page-size` | `0` (off) | Paginate the initial LIST of high-cardinality kinds (Pods, ReplicaSets) at this size. Helps very large clusters that fail to sync; only used when WatchList streaming is unavailable. Try `2000`. |
 | `--context-switch-timeout` | `30s` | Maximum time a kubeconfig context switch may take. Widen on high-latency control planes — see [Tuning for slow clusters](#tuning-for-slow-or-high-latency-clusters). Env: `RADAR_CONTEXT_SWITCH_TIMEOUT`. |
 | `--first-paint-backstop` | `5m` | Hard upper bound on the initial critical-cache sync wait before Radar falls through to a partial-data render. Env: `RADAR_FIRST_PAINT_BACKSTOP`. |

--- a/deploy/helm/radar/README.md
+++ b/deploy/helm/radar/README.md
@@ -86,7 +86,7 @@ touches its contents.
 | `image.tag` | Image tag | Chart appVersion |
 | `service.type` | Service type | `ClusterIP` |
 | `service.port` | Service port | `9280` |
-| `debug.image` | Image for ephemeral debug containers and node debug pods (point at a mirror for air-gapped / private-registry clusters) | `""` (busybox:latest) |
+| `debug.image` | Image for ephemeral debug containers and node debug pods. In built-in restricted PodSecurity namespaces, pod debug containers may retry as the target/pod non-root UID, or UID `65532` by default; point at a compatible mirror for air-gapped / private-registry clusters. | `""` (busybox:latest) |
 | `listPageSize` | Paginate the initial LIST of high-cardinality kinds (Pods, ReplicaSets) on very large clusters; `0` = off, try `2000`. Only used when the apiserver lacks WatchList streaming. | `0` |
 | `ingress.enabled` | Enable ingress | `false` |
 | `ingress.className` | Ingress class name | `""` |

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -21,7 +21,11 @@ fullnameOverride: ""
 # Debug feature (terminal "Debug" tab): the image used for ephemeral debug
 # containers attached to pods and for privileged node debug pods. Point this at
 # a reachable mirror in air-gapped / private-registry clusters where the default
-# busybox:latest cannot be pulled. Empty = busybox:latest.
+# busybox:latest cannot be pulled. If built-in restricted PodSecurity rejects
+# the default pod debug container, Radar retries with a restricted-compatible
+# Linux security context using the target/pod non-root UID, or UID 65532 by
+# default. Custom images used there must work as a non-root user.
+# Empty = busybox:latest.
 # Note: Radar does not attach imagePullSecrets to debug containers/pods —
 # ephemeral containers inherit the target pod's, and node debug pods rely on the
 # default namespace's ServiceAccount / node registry config — so the image must

--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -153,7 +153,7 @@ rbac:
   helm: false         # Enable Helm write operations (broad permissions)
 ```
 
-The terminal's **Debug** action launches a throwaway container (ephemeral container on a pod, or a privileged pod on a node) using `busybox:latest` by default. In air-gapped or private-registry clusters where that image can't be pulled, point it at a reachable mirror:
+The terminal's **Debug** action launches a throwaway container (ephemeral container on a pod, or a privileged pod on a node) using `busybox:latest` by default. If the built-in restricted Pod Security Standard rejects the default pod debug container, Radar retries with a restricted-compatible Linux security context using the target/pod non-root UID, or UID `65532` by default, so custom images used in restricted namespaces must work as a non-root user. In air-gapped or private-registry clusters where the default image can't be pulled, point it at a reachable mirror:
 
 ```yaml
 # values.yaml
@@ -296,7 +296,7 @@ See [Helm Chart README](../deploy/helm/radar/README.md) for all available values
 | `ingress.className` | Ingress class | `""` |
 | `service.port` | Service port | `9280` |
 | `mcp.enabled` | Enable MCP server for AI tools | `true` |
-| `debug.image` | Image for ephemeral debug containers and node debug pods (point at a mirror for air-gapped / private-registry clusters) | `""` (busybox:latest) |
+| `debug.image` | Image for ephemeral debug containers and node debug pods. In built-in restricted PodSecurity namespaces, pod debug containers may retry as the target/pod non-root UID, or UID `65532` by default; point at a compatible mirror for air-gapped / private-registry clusters. | `""` (busybox:latest) |
 | `listPageSize` | Paginate the initial LIST of high-cardinality kinds (Pods, ReplicaSets) on very large clusters that fail to sync; `0` = off, try `2000`. Only used when the apiserver lacks WatchList streaming. | `0` |
 | `timeline.storage` | Event storage (memory/sqlite) | `memory` |
 | `timeline.dbPath` | SQLite database path | `/data/timeline.db` |

--- a/pkg/k8score/ephemeral.go
+++ b/pkg/k8score/ephemeral.go
@@ -3,6 +3,7 @@ package k8score
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -12,6 +13,8 @@ import (
 
 // DefaultDebugImage is the default image for ephemeral debug containers.
 const DefaultDebugImage = "busybox:latest"
+
+const defaultDebugRunAsUser int64 = 65532
 
 // EphemeralContainerOptions configures debug container creation.
 type EphemeralContainerOptions struct {
@@ -39,7 +42,28 @@ func CreateEphemeralContainer(ctx context.Context, client kubernetes.Interface, 
 		return nil, fmt.Errorf("failed to get pod: %w", err)
 	}
 
-	ec := corev1.EphemeralContainer{
+	ec := newEphemeralContainer(opts, nil)
+	updateErr := updateEphemeralContainer(ctx, client, pod, ec)
+	if updateErr != nil && isRestrictedPodSecurityError(updateErr) {
+		pod, err = client.CoreV1().Pods(opts.Namespace).Get(ctx, opts.PodName, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get pod: %w", err)
+		}
+		securityContext := debugContainerSecurityContext(pod, opts.TargetContainer)
+		if securityContext != nil {
+			ec = newEphemeralContainer(opts, securityContext)
+			updateErr = updateEphemeralContainer(ctx, client, pod, ec)
+		}
+	}
+	if updateErr != nil {
+		return nil, fmt.Errorf("failed to create ephemeral container: %w", updateErr)
+	}
+
+	return &ec, nil
+}
+
+func newEphemeralContainer(opts EphemeralContainerOptions, securityContext *corev1.SecurityContext) corev1.EphemeralContainer {
+	return corev1.EphemeralContainer{
 		EphemeralContainerCommon: corev1.EphemeralContainerCommon{
 			Name:                     opts.ContainerName,
 			Image:                    opts.Image,
@@ -47,23 +71,86 @@ func CreateEphemeralContainer(ctx context.Context, client kubernetes.Interface, 
 			Stdin:                    true,
 			TTY:                      true,
 			TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+			SecurityContext:          securityContext,
 		},
 		TargetContainerName: opts.TargetContainer,
 	}
+}
 
-	pod.Spec.EphemeralContainers = append(pod.Spec.EphemeralContainers, ec)
-
-	_, err = client.CoreV1().Pods(opts.Namespace).UpdateEphemeralContainers(
+func updateEphemeralContainer(ctx context.Context, client kubernetes.Interface, pod *corev1.Pod, ec corev1.EphemeralContainer) error {
+	updated := pod.DeepCopy()
+	updated.Spec.EphemeralContainers = append(updated.Spec.EphemeralContainers, ec)
+	_, err := client.CoreV1().Pods(updated.Namespace).UpdateEphemeralContainers(
 		ctx,
-		opts.PodName,
-		pod,
+		updated.Name,
+		updated,
 		metav1.UpdateOptions{},
 	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create ephemeral container: %w", err)
+	return err
+}
+
+func isRestrictedPodSecurityError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "violates PodSecurity") && strings.Contains(msg, "restricted")
+}
+
+func debugContainerSecurityContext(pod *corev1.Pod, targetContainer string) *corev1.SecurityContext {
+	if pod != nil && pod.Spec.OS != nil && pod.Spec.OS.Name == corev1.Windows {
+		return nil
 	}
 
-	return &ec, nil
+	runAsUser := debugRunAsUser(pod, targetContainer)
+	runAsGroup := debugRunAsGroup(pod, targetContainer)
+	return &corev1.SecurityContext{
+		AllowPrivilegeEscalation: boolPtr(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+		RunAsNonRoot: boolPtr(true),
+		RunAsGroup:   runAsGroup,
+		RunAsUser:    runAsUser,
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+}
+
+func debugRunAsUser(pod *corev1.Pod, targetContainer string) *int64 {
+	if pod != nil {
+		for i := range pod.Spec.Containers {
+			c := &pod.Spec.Containers[i]
+			if c.Name == targetContainer && c.SecurityContext != nil && c.SecurityContext.RunAsUser != nil && *c.SecurityContext.RunAsUser != 0 {
+				runAsUser := *c.SecurityContext.RunAsUser
+				return &runAsUser
+			}
+		}
+		if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.RunAsUser != nil && *pod.Spec.SecurityContext.RunAsUser != 0 {
+			runAsUser := *pod.Spec.SecurityContext.RunAsUser
+			return &runAsUser
+		}
+	}
+	runAsUser := defaultDebugRunAsUser
+	return &runAsUser
+}
+
+func debugRunAsGroup(pod *corev1.Pod, targetContainer string) *int64 {
+	if pod != nil {
+		for i := range pod.Spec.Containers {
+			c := &pod.Spec.Containers[i]
+			if c.Name == targetContainer && c.SecurityContext != nil && c.SecurityContext.RunAsGroup != nil && *c.SecurityContext.RunAsGroup != 0 {
+				runAsGroup := *c.SecurityContext.RunAsGroup
+				return &runAsGroup
+			}
+		}
+		if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.RunAsGroup != nil && *pod.Spec.SecurityContext.RunAsGroup != 0 {
+			runAsGroup := *pod.Spec.SecurityContext.RunAsGroup
+			return &runAsGroup
+		}
+	}
+	return nil
 }
 
 // WaitForEphemeralContainer polls until an ephemeral container reaches Running state or timeout.

--- a/pkg/k8score/ephemeral_test.go
+++ b/pkg/k8score/ephemeral_test.go
@@ -1,0 +1,328 @@
+package k8score
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func TestCreateEphemeralContainerDefaultsToGeneralSecurityContext(t *testing.T) {
+	client := fake.NewSimpleClientset(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-a",
+			Name:      "app-0",
+		},
+	})
+
+	ec, err := CreateEphemeralContainer(context.Background(), client, EphemeralContainerOptions{
+		Namespace:       "team-a",
+		PodName:         "app-0",
+		TargetContainer: "app",
+		Image:           "busybox:latest",
+		ContainerName:   "debugger",
+	})
+	if err != nil {
+		t.Fatalf("CreateEphemeralContainer returned error: %v", err)
+	}
+	if ec.SecurityContext != nil {
+		t.Fatalf("returned security context = %#v, want nil", ec.SecurityContext)
+	}
+
+	updated := updatedPodFromEphemeralAction(t, client.Actions())
+	if len(updated.Spec.EphemeralContainers) != 1 {
+		t.Fatalf("updated pod has %d ephemeral containers, want 1", len(updated.Spec.EphemeralContainers))
+	}
+	got := updated.Spec.EphemeralContainers[0]
+	if got.Name != "debugger" || got.TargetContainerName != "app" {
+		t.Fatalf("updated ephemeral container = %#v", got)
+	}
+	if got.SecurityContext != nil {
+		t.Fatalf("submitted security context = %#v, want nil", got.SecurityContext)
+	}
+}
+
+func TestCreateEphemeralContainerRetriesWithRestrictedSecurityContextAfterPodSecurityRejection(t *testing.T) {
+	client := fake.NewSimpleClientset(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-a",
+			Name:      "app-0",
+		},
+	})
+	rejectFirstRestrictedPodSecurityUpdate(client)
+
+	ec, err := CreateEphemeralContainer(context.Background(), client, EphemeralContainerOptions{
+		Namespace:       "team-a",
+		PodName:         "app-0",
+		TargetContainer: "app",
+		Image:           "busybox:latest",
+		ContainerName:   "debugger",
+	})
+	if err != nil {
+		t.Fatalf("CreateEphemeralContainer returned error: %v", err)
+	}
+
+	want := &corev1.SecurityContext{
+		AllowPrivilegeEscalation: boolPtr(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+		RunAsNonRoot: boolPtr(true),
+		RunAsUser:    int64Ptr(defaultDebugRunAsUser),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+	if !reflect.DeepEqual(ec.SecurityContext, want) {
+		t.Fatalf("returned security context = %#v, want %#v", ec.SecurityContext, want)
+	}
+
+	updates := updatedPodsFromEphemeralActions(t, client.Actions())
+	if len(updates) != 2 {
+		t.Fatalf("got %d ephemeral container updates, want 2", len(updates))
+	}
+	if got := updates[0].Spec.EphemeralContainers[0].SecurityContext; got != nil {
+		t.Fatalf("first submitted security context = %#v, want nil", got)
+	}
+	if got := updates[1].Spec.EphemeralContainers[0].SecurityContext; !reflect.DeepEqual(got, want) {
+		t.Fatalf("retry submitted security context = %#v, want %#v", got, want)
+	}
+}
+
+func TestCreateEphemeralContainerDoesNotRetryNonRestrictedError(t *testing.T) {
+	client := fake.NewSimpleClientset(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-a",
+			Name:      "app-0",
+		},
+	})
+	client.PrependReactor("update", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "ephemeralcontainers" {
+			return false, nil, nil
+		}
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Resource: "pods"},
+			"app-0",
+			fmt.Errorf("ephemeral containers are disabled"),
+		)
+	})
+
+	_, err := CreateEphemeralContainer(context.Background(), client, EphemeralContainerOptions{
+		Namespace:       "team-a",
+		PodName:         "app-0",
+		TargetContainer: "app",
+		Image:           "busybox:latest",
+		ContainerName:   "debugger",
+	})
+	if err == nil {
+		t.Fatal("CreateEphemeralContainer returned nil error, want failure")
+	}
+
+	updates := updatedPodsFromEphemeralActions(t, client.Actions())
+	if len(updates) != 1 {
+		t.Fatalf("got %d ephemeral container updates, want 1", len(updates))
+	}
+}
+
+func TestCreateEphemeralContainerUsesTargetContainerUserAndGroupOnRestrictedRetry(t *testing.T) {
+	targetUser := int64(1001)
+	targetGroup := int64(1002)
+	podUser := int64(2002)
+	podGroup := int64(2003)
+	client := fake.NewSimpleClientset(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-a",
+			Name:      "app-0",
+		},
+		Spec: corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsGroup: &podGroup,
+				RunAsUser:  &podUser,
+			},
+			Containers: []corev1.Container{{
+				Name: "app",
+				SecurityContext: &corev1.SecurityContext{
+					RunAsGroup: &targetGroup,
+					RunAsUser:  &targetUser,
+				},
+			}},
+		},
+	})
+	rejectFirstRestrictedPodSecurityUpdate(client)
+
+	ec, err := CreateEphemeralContainer(context.Background(), client, EphemeralContainerOptions{
+		Namespace:       "team-a",
+		PodName:         "app-0",
+		TargetContainer: "app",
+		Image:           "busybox:latest",
+		ContainerName:   "debugger",
+	})
+	if err != nil {
+		t.Fatalf("CreateEphemeralContainer returned error: %v", err)
+	}
+	if ec.SecurityContext == nil || ec.SecurityContext.RunAsUser == nil || *ec.SecurityContext.RunAsUser != targetUser {
+		t.Fatalf("runAsUser = %#v, want %d", ec.SecurityContext, targetUser)
+	}
+	if ec.SecurityContext.RunAsGroup == nil || *ec.SecurityContext.RunAsGroup != targetGroup {
+		t.Fatalf("runAsGroup = %#v, want %d", ec.SecurityContext, targetGroup)
+	}
+}
+
+func TestCreateEphemeralContainerUsesPodUserAndGroupWhenTargetUnsetOnRestrictedRetry(t *testing.T) {
+	podUser := int64(2002)
+	podGroup := int64(2003)
+	client := fake.NewSimpleClientset(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-a",
+			Name:      "app-0",
+		},
+		Spec: corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsGroup: &podGroup,
+				RunAsUser:  &podUser,
+			},
+			Containers: []corev1.Container{{
+				Name: "app",
+			}},
+		},
+	})
+	rejectFirstRestrictedPodSecurityUpdate(client)
+
+	ec, err := CreateEphemeralContainer(context.Background(), client, EphemeralContainerOptions{
+		Namespace:       "team-a",
+		PodName:         "app-0",
+		TargetContainer: "app",
+		Image:           "busybox:latest",
+		ContainerName:   "debugger",
+	})
+	if err != nil {
+		t.Fatalf("CreateEphemeralContainer returned error: %v", err)
+	}
+	if ec.SecurityContext == nil || ec.SecurityContext.RunAsUser == nil || *ec.SecurityContext.RunAsUser != podUser {
+		t.Fatalf("runAsUser = %#v, want %d", ec.SecurityContext, podUser)
+	}
+	if ec.SecurityContext.RunAsGroup == nil || *ec.SecurityContext.RunAsGroup != podGroup {
+		t.Fatalf("runAsGroup = %#v, want %d", ec.SecurityContext, podGroup)
+	}
+}
+
+func TestCreateEphemeralContainerDoesNotRetryWindowsPodWhenRestrictedContextUnavailable(t *testing.T) {
+	client := fake.NewSimpleClientset(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-a",
+			Name:      "win-0",
+		},
+		Spec: corev1.PodSpec{
+			OS: &corev1.PodOS{Name: corev1.Windows},
+		},
+	})
+	rejectFirstRestrictedPodSecurityUpdate(client)
+
+	_, err := CreateEphemeralContainer(context.Background(), client, EphemeralContainerOptions{
+		Namespace:     "team-a",
+		PodName:       "win-0",
+		Image:         "mcr.microsoft.com/windows/nanoserver:ltsc2022",
+		ContainerName: "debugger",
+	})
+	if err == nil {
+		t.Fatal("CreateEphemeralContainer returned nil error, want failure")
+	}
+
+	updates := updatedPodsFromEphemeralActions(t, client.Actions())
+	if len(updates) != 1 {
+		t.Fatalf("got %d ephemeral container updates, want 1", len(updates))
+	}
+	if got := updates[0].Spec.EphemeralContainers[0].SecurityContext; got != nil {
+		t.Fatalf("submitted security context = %#v, want nil", got)
+	}
+}
+
+func TestCreateEphemeralContainerOmitsLinuxSecurityContextForWindowsPod(t *testing.T) {
+	client := fake.NewSimpleClientset(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-a",
+			Name:      "win-0",
+		},
+		Spec: corev1.PodSpec{
+			OS: &corev1.PodOS{Name: corev1.Windows},
+		},
+	})
+
+	ec, err := CreateEphemeralContainer(context.Background(), client, EphemeralContainerOptions{
+		Namespace:     "team-a",
+		PodName:       "win-0",
+		Image:         "mcr.microsoft.com/windows/nanoserver:ltsc2022",
+		ContainerName: "debugger",
+	})
+	if err != nil {
+		t.Fatalf("CreateEphemeralContainer returned error: %v", err)
+	}
+	if ec.SecurityContext != nil {
+		t.Fatalf("returned security context = %#v, want nil", ec.SecurityContext)
+	}
+
+	updated := updatedPodFromEphemeralAction(t, client.Actions())
+	if len(updated.Spec.EphemeralContainers) != 1 {
+		t.Fatalf("updated pod has %d ephemeral containers, want 1", len(updated.Spec.EphemeralContainers))
+	}
+	if got := updated.Spec.EphemeralContainers[0].SecurityContext; got != nil {
+		t.Fatalf("submitted security context = %#v, want nil", got)
+	}
+}
+
+func updatedPodFromEphemeralAction(t *testing.T, actions []clienttesting.Action) *corev1.Pod {
+	t.Helper()
+	pods := updatedPodsFromEphemeralActions(t, actions)
+	if len(pods) == 0 {
+		t.Fatalf("no pods/ephemeralcontainers update action found in %#v", actions)
+	}
+	return pods[0]
+}
+
+func updatedPodsFromEphemeralActions(t *testing.T, actions []clienttesting.Action) []*corev1.Pod {
+	t.Helper()
+	var pods []*corev1.Pod
+	for _, action := range actions {
+		if action.GetVerb() != "update" || action.GetResource().Resource != "pods" || action.GetSubresource() != "ephemeralcontainers" {
+			continue
+		}
+		update, ok := action.(clienttesting.UpdateAction)
+		if !ok {
+			t.Fatalf("ephemeralcontainers action has type %T, want UpdateAction", action)
+		}
+		pod, ok := update.GetObject().(*corev1.Pod)
+		if !ok {
+			t.Fatalf("ephemeralcontainers update object has type %T, want *corev1.Pod", update.GetObject())
+		}
+		pods = append(pods, pod)
+	}
+	return pods
+}
+
+func rejectFirstRestrictedPodSecurityUpdate(client *fake.Clientset) {
+	attempts := 0
+	client.PrependReactor("update", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "ephemeralcontainers" {
+			return false, nil, nil
+		}
+		attempts++
+		if attempts == 1 {
+			return true, nil, apierrors.NewForbidden(
+				schema.GroupResource{Resource: "pods"},
+				"app-0",
+				fmt.Errorf("violates PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false"),
+			)
+		}
+		return false, nil, nil
+	})
+}
+
+func int64Ptr(v int64) *int64 { return &v }


### PR DESCRIPTION
Fixes #943

## Summary
Radar pod debug sessions currently create ephemeral containers without a securityContext, which built-in restricted PodSecurity rejects before the terminal can open. This preserves the existing general-path behavior for clusters that allow it, then retries only restricted PodSecurity failures with a restricted-compatible Linux context.

## What changed
- Create ephemeral debug containers with no securityContext on the first attempt to preserve existing behavior.
- Detect built-in restricted PodSecurity admission failures and retry after refetching the pod.
- On retry, set allowPrivilegeEscalation=false, drop ALL capabilities, require runAsNonRoot, and use RuntimeDefault seccomp.
- Select a non-root runtime identity from the target container, then the pod security context, then UID 65532; inherit runAsGroup when defined.
- Skip the Linux retry for explicit Windows pods and avoid retrying unrelated errors.
- Document the retry behavior and custom image requirement for restricted namespaces.

## Testing
- go test ./k8score
- make test
- make build
- Live smoke on `radar-test-nonprod` EKS v1.34.8: created a temporary restricted PodSecurity namespace with a non-root BusyBox pod, invoked Radar `/api/pods/radar-psa-live-943/nonroot-sleep/debug`, got `status:"running"`, and verified the admitted ephemeral container had `allowPrivilegeEscalation=false`, `capabilities.drop=["ALL"]`, `runAsNonRoot=true`, `runAsUser=1001`, `runAsGroup=1001`, and `seccompProfile=RuntimeDefault`. Temporary namespace was deleted.
- visual-test: skipped (backend/docs-only change)
- product-review: skipped (no UI/product surface)