### PR TITLE
fix(images): log dropped response errors + test(timeutil): cover FormatAgeShort

### DIFF
--- a/internal/images/handlers.go
+++ b/internal/images/handlers.go
@@ -3,6 +3,7 @@ package images
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 
@@ -180,25 +181,33 @@ func (h *Handlers) handleGetFile(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(content)))
-	w.Write(content)
+	if _, err := w.Write(content); err != nil {
+		log.Printf("[images] Failed to write file content: %v", err)
+	}
 }
 
 func writeJSON(w http.ResponseWriter, data any) {
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(data)
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		log.Printf("[images] Failed to encode JSON response: %v", err)
+	}
 }
 
 func writeAuthError(w http.ResponseWriter, image string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusUnauthorized)
-	json.NewEncoder(w).Encode(map[string]string{
+	if err := json.NewEncoder(w).Encode(map[string]string{
 		"error":        "Authentication required for this image",
 		"registryType": string(DetectRegistryType(image)),
-	})
+	}); err != nil {
+		log.Printf("[images] Failed to encode auth error response: %v", err)
+	}
 }
 
 func writeError(w http.ResponseWriter, status int, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(map[string]string{"error": message})
+	if err := json.NewEncoder(w).Encode(map[string]string{"error": message}); err != nil {
+		log.Printf("[images] Failed to encode error response: %v", err)
+	}
 }

--- a/pkg/timeutil/format.go
+++ b/pkg/timeutil/format.go
@@ -13,7 +13,7 @@ import (
 // "3s", "12m", "4h", "21d". Negative inputs clamp to zero — duration
 // formatting is for display, not validation, so don't surface "-1s".
 //
-// keep in sync: web/src/components/gitops/GitOpsView.tsx::formatRelativeAge
+// keep in sync: packages/k8s-ui/src/utils/format.ts::formatCompactAge
 // (TypeScript). Adding a new tier (e.g. "weeks") here without mirroring
 // it in TS would let the audit finding and the fleet banner disagree on
 // the same age.

--- a/pkg/timeutil/format_test.go
+++ b/pkg/timeutil/format_test.go
@@ -39,7 +39,7 @@ func TestFormatAgeShort(t *testing.T) {
 
 // Each tier boundary must flip the unit exactly at its threshold — a
 // regression here silently desyncs the Go-rendered age from the TypeScript
-// mirror in GitOpsView.tsx::formatRelativeAge.
+// mirror in packages/k8s-ui/src/utils/format.ts::formatCompactAge.
 func TestFormatAgeShort_TierBoundaries(t *testing.T) {
 	boundaries := []struct {
 		below     time.Duration

--- a/pkg/timeutil/format_test.go
+++ b/pkg/timeutil/format_test.go
@@ -1,0 +1,63 @@
+package timeutil
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatAgeShort(t *testing.T) {
+	tests := []struct {
+		name string
+		d    time.Duration
+		want string
+	}{
+		{"zero", 0, "0s"},
+		{"sub-second rounds down to 0s", 999 * time.Millisecond, "0s"},
+		{"seconds", 3 * time.Second, "3s"},
+		{"just under a minute", 59 * time.Second, "59s"},
+		{"exactly one minute", time.Minute, "1m"},
+		{"minutes round down", 90 * time.Second, "1m"},
+		{"just under an hour", 59 * time.Minute, "59m"},
+		{"exactly one hour", time.Hour, "1h"},
+		{"hours round down", 90 * time.Minute, "1h"},
+		{"just under a day", 23 * time.Hour, "23h"},
+		{"exactly one day", 24 * time.Hour, "1d"},
+		{"multiple days round down", 49 * time.Hour, "2d"},
+		{"three weeks", 21 * 24 * time.Hour, "21d"},
+		{"negative clamps to zero", -5 * time.Second, "0s"},
+		{"large negative clamps to zero", -100 * time.Hour, "0s"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FormatAgeShort(tt.d); got != tt.want {
+				t.Errorf("FormatAgeShort(%v) = %q, want %q", tt.d, got, tt.want)
+			}
+		})
+	}
+}
+
+// Each tier boundary must flip the unit exactly at its threshold — a
+// regression here silently desyncs the Go-rendered age from the TypeScript
+// mirror in GitOpsView.tsx::formatRelativeAge.
+func TestFormatAgeShort_TierBoundaries(t *testing.T) {
+	boundaries := []struct {
+		below     time.Duration
+		belowWant string
+		at        time.Duration
+		atWant    string
+	}{
+		{time.Minute - time.Nanosecond, "59s", time.Minute, "1m"},
+		{time.Hour - time.Nanosecond, "59m", time.Hour, "1h"},
+		{24*time.Hour - time.Nanosecond, "23h", 24 * time.Hour, "1d"},
+	}
+
+	for _, b := range boundaries {
+		if got := FormatAgeShort(b.below); got != b.belowWant {
+			t.Errorf("FormatAgeShort(%v) = %q, want %q", b.below, got, b.belowWant)
+		}
+		if got := FormatAgeShort(b.at); got != b.atWant {
+			t.Errorf("FormatAgeShort(%v) = %q, want %q", b.at, got, b.atWant)
+		}
+	}
+}


### PR DESCRIPTION
## What

Two small, self-contained improvements to untested/error-swallowing spots:

- **fix(images):** `writeJSON`, `writeAuthError`, `writeError`, and the
  file-download `w.Write` in `internal/images/handlers.go` all discarded
  their error returns. A failed body encode or partial write now logs via
  `log.Printf`, matching the convention in `internal/server/server.go`.
- **test(timeutil):** adds coverage for `pkg/timeutil/FormatAgeShort` —
  table cases for every unit tier plus a boundary test pinning the unit
  flips (59s→1m, 59m→1h, 23h→1d) and the negative-duration clamp, so the
  Go output can't silently desync from the TS mirror in
  `GitOpsView.tsx::formatRelativeAge`.

## Testing

- `go test ./pkg/timeutil/`
- `go vet ./internal/images/`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and test-only changes; no change to success-path API behavior or auth logic.
> 
> **Overview**
> Image HTTP helpers now **log** when response bodies fail to write or encode instead of silently ignoring errors, aligned with `internal/server` logging for the same failure modes.
> 
> `FormatAgeShort` gains **table and tier-boundary tests** (including negative clamping) so Go compact-age output stays pinned to the TypeScript mirror; the cross-language sync comment now points at `packages/k8s-ui/src/utils/format.ts::formatCompactAge`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 883986d7c8685920bf214cc810357b7b4bd5a143. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->