### PR TITLE
Replace SPA terminology in Radar

### DIFF
--- a/internal/helm/handlers.go
+++ b/internal/helm/handlers.go
@@ -986,7 +986,7 @@ func writeError(w http.ResponseWriter, status int, message string) {
 }
 
 // writeErrorCode is writeError with a stable machine-readable error_code
-// in the response body so the SPA + MCP clients can branch on the error
+// in the response body so the frontend + MCP clients can branch on the error
 // type without parsing the human message. Used for role-gated 403s and
 // any other case where the consumer wants to react differently per code.
 func writeErrorCode(w http.ResponseWriter, status int, code, message string) {
@@ -1011,7 +1011,7 @@ func writeErrorCode(w http.ResponseWriter, status int, code, message string) {
 // strictly additive for Cloud-attributed callers.
 //
 // When the caller IS Cloud-attributed and their tier is below `min`,
-// returns 403 with error_code=cloud_role_insufficient so the SPA can
+// returns 403 with error_code=cloud_role_insufficient so the frontend can
 // render a friendly "your role doesn't allow this" message instead of
 // a generic auth failure.
 func requireCloudRole(w http.ResponseWriter, r *http.Request, min auth.CloudRole, opName string) bool {

--- a/internal/helm/install_preflight.go
+++ b/internal/helm/install_preflight.go
@@ -225,7 +225,7 @@ func classifyInstallError(err error) InstallErrorClass {
 }
 
 // writeInstallError maps a Helm install error onto an HTTP response with a
-// stable error_code the SPA can branch on.
+// stable error_code the frontend can branch on.
 func writeInstallError(w http.ResponseWriter, err error) {
 	cls := classifyInstallError(err)
 	if cls.Code != "" {

--- a/internal/helm/install_preflight_test.go
+++ b/internal/helm/install_preflight_test.go
@@ -208,7 +208,7 @@ func TestClassifyHelmRBACError_NotMatching(t *testing.T) {
 }
 
 // TestClassifyInstallError pins the (status, code, message) mapping for every
-// branch the SPA depends on. Streaming and non-streaming endpoints both go
+// branch the frontend depends on. Streaming and non-streaming endpoints both go
 // through this classifier, so a regression here breaks both UIs at once.
 func TestClassifyInstallError(t *testing.T) {
 	rbacErr := errors.New(`Unable to continue: clusterroles.rbac.authorization.k8s.io "x" is forbidden: ` +
@@ -245,7 +245,7 @@ func TestClassifyInstallError(t *testing.T) {
 
 // TestInstallStreamErrorEvent ensures the SSE envelope carries the same
 // friendly message and error_code as the JSON HTTP path. A typo in the
-// field name ("errorCode" vs "error_code") would silently break the SPA's
+// field name ("errorCode" vs "error_code") would silently break the frontend's
 // install-stream branching; this pins the wire format.
 func TestInstallStreamErrorEvent(t *testing.T) {
 	event := installStreamErrorEvent(&ReleasePendingError{Name: "x", Namespace: "y", Status: "pending-install", Revision: 1})

--- a/internal/issues/types.go
+++ b/internal/issues/types.go
@@ -51,7 +51,7 @@ const (
 )
 
 // Source records which underlying detection channel emitted this issue.
-// It is an OUTPUT label (for SPA copy that explains why a row appeared,
+// It is an OUTPUT label (for frontend copy that explains why a row appeared,
 // and as a CEL filter binding), not an input filter — issues composes all
 // four sources unconditionally; detection provenance is not a triage axis.
 type Source = issuesapi.Source

--- a/internal/k8s/builtin_group_test.go
+++ b/internal/k8s/builtin_group_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TestTypedKindOwnsGroup pins the typed-vs-dynamic routing contract used by the
-// resource GET/LIST handlers (REST + AI). The bug this guards: the SPA threads
+// resource GET/LIST handlers (REST + AI). The bug this guards: the frontend threads
 // the real apiGroup for built-in workloads (deployments?group=apps), and the
 // handlers' "explicit group ⇒ dynamic cache" dispatch sent those to the dynamic
 // cache — which has no informer for built-ins — yielding a 400 "unknown

--- a/internal/k8s/policy_reports_test.go
+++ b/internal/k8s/policy_reports_test.go
@@ -11,7 +11,7 @@ import (
 // TestGetKyvernoStatus_LifecycleTransitions pins the four states callers
 // can observe via the public GetKyvernoStatus accessor. The status backs
 // the meta.kyverno field on /api/issues + the MCP issues tool, so a regression
-// here flips the SPA/agent's behavior between "no findings yet" copy and
+// here flips the frontend/agent's behavior between "no findings yet" copy and
 // "no violations" copy — both bad.
 //
 // We drive the state via direct manipulation of the package-level atomics

--- a/internal/mcp/tools_helm.go
+++ b/internal/mcp/tools_helm.go
@@ -92,11 +92,11 @@ func handleGetHelmRelease(ctx context.Context, req *mcp.CallToolRequest, input g
 
 	includes := parseIncludes(input.Include)
 
-	// Mirror the SPA gate on sensitive Helm reads: viewers cannot pull
+	// Mirror the frontend gate on sensitive Helm reads: viewers cannot pull
 	// values/manifest/diff. Without this the user would still be blocked
 	// by K8s RBAC (view ClusterRole excludes secrets), but the error would
 	// be a confusing K8s "secrets is forbidden" rather than the structured
-	// cloud_role_insufficient code the SPA emits.
+	// cloud_role_insufficient code the frontend emits.
 	cloudRole := pkgauth.CloudRoleFromContext(ctx)
 	gatedSensitive := !cloudRole.AtLeast(pkgauth.RoleMember)
 

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -79,7 +79,7 @@ type Result struct {
 	Searched int   `json:"searched"` // approx. number of objects scanned
 	// TotalMatched is the count of hits BEFORE truncation by Limit.
 	// Equals Total when no truncation occurred. Surfaced so callers
-	// (the hub's fleet aggregator, agents, the SPA) can report honest
+	// (the hub's fleet aggregator, agents, the frontend) can report honest
 	// "X of N" counts when the limit clips the result set — without
 	// it the caller has no way to tell it's looking at a windowed view.
 	TotalMatched int `json:"total_matched"`

--- a/internal/server/ai_handlers.go
+++ b/internal/server/ai_handlers.go
@@ -1,14 +1,14 @@
 // /api/ai/* is the REST mirror of the MCP agent surface. Both target AI
-// consumers (Claude, scripted agents) rather than the SPA, and both
+// consumers (Claude, scripted agents) rather than the frontend, and both
 // intentionally evolve at agent-iteration speed.
 //
-// Unlike /api/* (consumed by the SPA via a generated TypeScript client),
+// Unlike /api/* (consumed by the frontend via a generated TypeScript client),
 // the /api/ai/* surface is NOT specified in openapi.yaml. The original
 // motivation for OpenAPI-first in radar was frontend/backend type safety —
 // one spec, regenerated as Go server stubs + TS client. That value
 // proposition does not apply here: the agent consumer doesn't read
 // OpenAPI specs (it reads MCP tool descriptions or in-prompt instructions),
-// and the SPA doesn't call these endpoints at all.
+// and the frontend doesn't call these endpoints at all.
 //
 // Wire shapes for the agent surface live in pkg/resourcecontext (typed
 // JSON DTOs) and pkg/topology. MCP tools document their wire via

--- a/internal/server/ai_handlers_rbac_test.go
+++ b/internal/server/ai_handlers_rbac_test.go
@@ -108,7 +108,7 @@ func TestProxyAuth_AIGetPod_NamespaceAllowed(t *testing.T) {
 //   - list-namespaces SAR for `kind=namespaces`
 //   - per-namespace and/or cluster-wide list-secrets SAR for `kind=secrets`
 //
-// Where the REST path returns 200 with `[]` for denies (legacy SPA
+// Where the REST path returns 200 with `[]` for denies (legacy frontend
 // shape that doesn't leak kind existence), the AI path returns the
 // explicit status so agents see the failure instead of confusing
 // "empty cluster" output.

--- a/internal/server/gitops_handlers.go
+++ b/internal/server/gitops_handlers.go
@@ -288,7 +288,7 @@ func managedScanKindsFromDiscovery() []managedScanKind {
 
 // handleGitOpsManagedResources discovers resources in THIS cluster that are
 // managed by the named Argo Application, returning them as a synthetic
-// ResourceTree the SPA can render with the existing GitOpsTreeGraph
+// ResourceTree the frontend can render with the existing GitOpsTreeGraph
 // component.
 //
 // The endpoint is the destination-side companion to /api/gitops/tree —
@@ -321,7 +321,7 @@ func (s *Server) handleGitOpsManagedResources(w http.ResponseWriter, r *http.Req
 	if noNamespaceAccess(allowedNamespaces) {
 		// Caller has no namespace access — return a tree with just the
 		// synthetic root + a warning. Mirrors handleGitOpsTree's behavior
-		// rather than 403'ing so the SPA can render an honest empty state.
+		// rather than 403'ing so the frontend can render an honest empty state.
 		empty := gitopstree.BuildManagedTree(app, nsFilter, nil)
 		empty.Warnings = []string{"You do not have access to any namespace; managed resources are filtered out."}
 		s.writeJSON(w, empty)
@@ -358,7 +358,7 @@ func (s *Server) handleGitOpsManagedResources(w http.ResponseWriter, r *http.Req
 	// indistinguishable from "this app legitimately manages 0
 	// resources." A single-kind failure (CRD not installed, narrow
 	// RBAC) is expected and the scan continues; if every kind fails,
-	// the warning surfaces in the response so the SPA can render an
+	// the warning surfaces in the response so the frontend can render an
 	// inline note.
 	var kindErrors []string
 	for _, mk := range scanKinds {

--- a/internal/server/packages.go
+++ b/internal/server/packages.go
@@ -88,18 +88,18 @@ type PackagesResponse struct {
 // SourceError carries a per-source failure. Field names + JSON tags
 // are part of the /api/packages public response shape — wire-stable.
 // Code values are likewise stable (see ErrCode* below); add new codes,
-// never rename. Renaming any of these fields silently breaks the SPA
+// never rename. Renaming any of these fields silently breaks the frontend
 // (radar-hub-web) and MCP fleet_list_packages clients.
 type SourceError struct {
 	Source     packages.SourceCode `json:"source"`
 	StatusCode int                 `json:"statusCode,omitempty"`
 	Error      string              `json:"error"`
 	// Code is a machine-readable category for this failure. Stable
-	// across phrasing changes in Error so consumers (the SPA's
+	// across phrasing changes in Error so consumers (the frontend's
 	// categorize fn, MCP clients) can branch without string-matching
 	// log messages. Populated for known failure shapes; empty for
 	// generic errors (consumer falls back to category="failed").
-	// Producer: errorCodeForHelm in this file. Consumer: the SPA's
+	// Producer: errorCodeForHelm in this file. Consumer: the frontend's
 	// categorizeSourceError in radar-hub-web.
 	Code string `json:"code,omitempty"`
 	// AffectedNamespaces, when set, lists the namespaces this error
@@ -110,8 +110,8 @@ type SourceError struct {
 	AffectedNamespaces []string `json:"affectedNamespaces,omitempty"`
 }
 
-// Error code constants. Stable wire values — the SPA categorize and
-// MCP clients branch on these. Add new codes here, never rename.
+// Error code constants. Stable wire values that the frontend and MCP clients
+// branch on. Add new codes here, never rename.
 const (
 	ErrCodeRBACDenied   = "rbac_denied"
 	ErrCodeUnreachable  = "unreachable"
@@ -121,7 +121,7 @@ const (
 )
 
 // errorCodeForHelm classifies a Helm error string + status into a
-// stable Code value. The SPA used to do this with regex on the user-
+// stable Code value. The frontend used to do this with regex on the user-
 // visible string; doing it backend-side means a phrasing change in
 // the SDK doesn't silently move errors into "failed" until someone
 // updates the regex too.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -505,7 +505,7 @@ func (s *Server) setupRoutes() {
 
 	// OAuth/OIDC discovery probes from MCP HTTP clients. Without these
 	// explicit 404s, two failure modes appear:
-	//   (a) the SPA fallback below answers root-level /.well-known/* with the
+	//   (a) the index.html fallback below answers root-level /.well-known/* with the
 	//       React index.html (HTTP 200, text/html);
 	//   (b) the /mcp Mount answers /mcp/.well-known/* with 405 because the
 	//       MCP handler only accepts POST.
@@ -529,7 +529,7 @@ func (s *Server) setupRoutes() {
 		r.Mount("/mcp", s.mcpHandler)
 	}
 
-	// OAuth discovery probes from MCP HTTP clients. Without this, the SPA
+	// OAuth discovery probes from MCP HTTP clients. Without this, the frontend
 	// catch-all answers /.well-known/oauth-* with HTML 200, which newer
 	// claude-code parses as a broken OAuth flow and aborts MCP registration.
 	// Radar's MCP server is unauthenticated when run locally; signal that
@@ -537,17 +537,17 @@ func (s *Server) setupRoutes() {
 	r.Get("/.well-known/oauth-protected-resource", http.NotFound)
 	r.Get("/.well-known/oauth-authorization-server", http.NotFound)
 
-	// Static files (frontend) - SPA fallback to index.html
+	// Static files (frontend) - index.html fallback for client-side routes.
 	if s.staticFS != nil {
-		r.Handle("/*", spaHandler(http.FS(s.staticFS)))
+		r.Handle("/*", frontendHandler(http.FS(s.staticFS)))
 	} else if s.devMode {
 		// In dev mode, serve from web/dist
-		r.Handle("/*", spaHandler(http.Dir("web/dist")))
+		r.Handle("/*", frontendHandler(http.Dir("web/dist")))
 	}
 }
 
-// spaHandler serves static files, falling back to index.html for SPA routing
-func spaHandler(fsys http.FileSystem) http.Handler {
+// frontendHandler serves static files, falling back to index.html for client-side routing
+func frontendHandler(fsys http.FileSystem) http.Handler {
 	fileServer := http.FileServer(fsys)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -556,7 +556,7 @@ func spaHandler(fsys http.FileSystem) http.Handler {
 		// Try to open the file
 		f, err := fsys.Open(path)
 		if err != nil {
-			// File doesn't exist - serve index.html for SPA routing
+			// File doesn't exist - serve index.html for client-side routing
 			r.URL.Path = "/"
 			fileServer.ServeHTTP(w, r)
 			return
@@ -1194,7 +1194,7 @@ func (s *Server) handleListResources(w http.ResponseWriter, r *http.Request) {
 	namespaces := s.parseNamespacesForUser(r)
 
 	// Shared RBAC gate. REST converts denies to 200 with `[]` (legacy shape
-	// the SPA tolerates and that doesn't leak kind existence); the AI path
+	// the frontend tolerates and that doesn't leak kind existence); the AI path
 	// returns the explicit status.
 	finalNamespaces, _, _, ok := s.preflightResourceList(r, kind, group, namespaces)
 	if !ok {
@@ -1721,7 +1721,7 @@ func (s *Server) handleGetResource(w http.ResponseWriter, r *http.Request) {
 
 	// A non-empty group routes to the dynamic/CRD cache so CRDs whose plural
 	// collides with a core kind (e.g. KNative serving.knative.dev/services vs
-	// core "services") reach the right resource. But the SPA also threads the
+	// core "services") reach the right resource. But the frontend also threads the
 	// real apiGroup for BUILT-IN workloads (e.g. apps/Deployment), and those
 	// live in the typed cache, not the dynamic one — so a built-in addressed by
 	// its own group must still take the typed path below. Without this guard,
@@ -3334,7 +3334,7 @@ func (s *Server) writeError(w http.ResponseWriter, status int, message string) {
 }
 
 // writeErrorCode is writeError plus a stable machine-readable `error_code`
-// the SPA branches on (e.g. cloud_role_insufficient → "your role can't do
+// the frontend branches on (e.g. cloud_role_insufficient → "your role can't do
 // this" instead of a generic auth failure).
 func (s *Server) writeErrorCode(w http.ResponseWriter, status int, code, message string) {
 	w.Header().Set("Content-Type", "application/json")
@@ -3397,7 +3397,7 @@ func (s *Server) handleAuthMe(w http.ResponseWriter, r *http.Request) {
 		"authEnabled": s.authConfig.Enabled(),
 		"authMode":    s.authConfig.Mode,
 	}
-	// Tells the SPA whether proxy-mode logout can tear down the upstream
+	// Tells the frontend whether proxy-mode logout can tear down the upstream
 	// session (vs only clearing Radar's cookie), so it can warn the user.
 	if s.authConfig.Mode == "proxy" {
 		resp["proxyLogoutConfigured"] = s.authConfig.ProxyLogoutURL != ""
@@ -3405,7 +3405,7 @@ func (s *Server) handleAuthMe(w http.ResponseWriter, r *http.Request) {
 	if user := auth.UserFromContext(r.Context()); user != nil {
 		resp["username"] = user.Username
 		resp["groups"] = user.Groups
-		// Pre-compute the Cloud role so the SPA doesn't have to
+		// Pre-compute the Cloud role so the frontend doesn't have to
 		// re-parse `cloud:<tier>` group prefixes. Empty string means
 		// "not running under Cloud" (OSS deploy or no role group).
 		if role := auth.CloudRoleFromGroups(user.Groups); role != auth.RoleNone {

--- a/internal/server/server_auth_test.go
+++ b/internal/server/server_auth_test.go
@@ -89,7 +89,7 @@ func TestHandleAuthMe_AuthEnabled_WithUser(t *testing.T) {
 	if len(groups) != 2 {
 		t.Errorf("groups = %v, want 2 groups", groups)
 	}
-	// Non-Cloud user — cloudRole must be absent so the SPA's
+	// Non-Cloud user — cloudRole must be absent so the frontend's
 	// useCloudRole hook treats them as "not under Cloud."
 	if _, has := body["cloudRole"]; has {
 		t.Errorf("cloudRole should not be present for non-Cloud user (groups=%v)", groups)

--- a/internal/server/server_smoke_test.go
+++ b/internal/server/server_smoke_test.go
@@ -1054,20 +1054,20 @@ func TestSmokeCloudMode_PprofNotMounted(t *testing.T) {
 				t.Fatalf("GET %s: %v", p, err)
 			}
 			defer resp.Body.Close()
-			// Under cloud-mode the route is not mounted. The SPA fallback
+			// Under cloud-mode the route is not mounted. The index.html fallback
 			// serves index.html (200) for unknown paths — what matters is
 			// that it's NOT serving the pprof handler's dump output. A
-			// 200 with the SPA HTML (not pprof data) is the pass
+			// 200 with the frontend HTML (not pprof data) is the pass
 			// condition here.
 			if resp.StatusCode == 200 {
-				// Sanity: the response should be HTML (SPA fallback), not
+				// Sanity: the response should be HTML (index.html fallback), not
 				// a pprof dump.
 				ct := resp.Header.Get("Content-Type")
 				if !bytes.HasPrefix([]byte(ct), []byte("text/html")) {
 					t.Errorf("%s returned 200 with Content-Type %q — pprof may still be mounted", p, ct)
 				}
 			}
-			// 404 is also acceptable (no SPA handler in some test configs).
+			// 404 is also acceptable (no frontend handler in some test configs).
 		})
 	}
 }

--- a/internal/server/settings_role_test.go
+++ b/internal/server/settings_role_test.go
@@ -34,7 +34,7 @@ func putConfigStatus(t *testing.T, user *auth.User) (int, string) {
 
 func TestPutConfig_RoleGate(t *testing.T) {
 	// Non-owner Cloud roles are rejected with the stable error_code so the
-	// SPA can branch on it.
+	// frontend can branch on it.
 	for _, tier := range []string{"cloud:viewer", "cloud:member"} {
 		code, body := putConfigStatus(t, userWithGroups(tier))
 		if code != http.StatusForbidden {

--- a/packages/k8s-ui/src/components/checks/ChecksView.tsx
+++ b/packages/k8s-ui/src/components/checks/ChecksView.tsx
@@ -820,9 +820,9 @@ function FindingLine({
         </button>
       ) : resourceHref ? (
         // Opens in a new tab to match the ExternalLink glyph in `body`. For the
-        // Hub fleet view this href crosses the Hub→Cluster SPA boundary (a full
+        // Hub fleet view this href crosses the Hub to Cluster route-tree boundary (a full
         // document nav); a new tab keeps the Checks queue intact and avoids the
-        // cross-tree browser-Back dead-end (SKY-931).
+        // cross-tree browser-Back dead-end.
         <a href={resourceHref(r)} target="_blank" rel="noreferrer" className={cls}>
           {body}
         </a>

--- a/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
@@ -102,7 +102,7 @@ export interface FleetClusterStamp {
   name: string
 }
 export type FleetDestinationMatch = 'in_cluster' | 'exact' | 'inferred' | 'unmatched'
-// FleetDestinationConfidence is a coarse signal the SPA uses to style
+// FleetDestinationConfidence is a coarse signal the frontend uses to style
 // the destination chip. `high` = URL-equality match (either direct or
 // via Argo cluster-secret), `medium` = name-equality match (more
 // fragile, more likely to be a false positive when two clusters share
@@ -116,7 +116,7 @@ export interface FleetDestinationStamp {
   // Confidence + reason are populated for non-unmatched rows. They power
   // the chip's visual treatment (a checkmark on high-confidence matches)
   // and its title= tooltip respectively. Both come from the hub —
-  // adding new values shouldn't break the SPA (unknown confidence
+  // adding new values shouldn't break the frontend (unknown confidence
   // falls back to no special styling).
   confidence?: FleetDestinationConfidence
   reason?: string
@@ -184,7 +184,7 @@ export interface GitOpsTableViewProps {
   onRefresh?: () => void
   // Row click — caller routes to its own detail page. When the host also
   // passes `rowHrefFor`, the callback receives the MouseEvent so it can
-  // `preventDefault()` for SPA-local nav (e.g. react-router) or skip the
+  // `preventDefault()` for same-tree nav (e.g. react-router) or skip the
   // preventDefault to let the anchor's default full-page navigation run
   // (required for cross-router-boundary links).
   onRowClick: (row: GitOpsRow, event?: ReactMouseEvent) => void

--- a/packages/k8s-ui/src/components/gitops/detail-helpers.test.ts
+++ b/packages/k8s-ui/src/components/gitops/detail-helpers.test.ts
@@ -80,7 +80,7 @@ describe('getGitOpsTool', () => {
     expect(getGitOpsTool('appprojects', 'argoproj.io')).toBe('argo')
   })
   // Argo kinds without an explicit group still route to 'argo'.
-  // Defends against a normalizer that drops `group` from the SPA payload.
+  // Defends against a normalizer that drops `group` from the frontend payload.
   test('Argo kinds without group still route to argo', () => {
     expect(getGitOpsTool('applications', undefined)).toBe('argo')
     expect(getGitOpsTool('applicationsets', '')).toBe('argo')

--- a/packages/k8s-ui/src/components/timeline/TimelineSwimlanes.tsx
+++ b/packages/k8s-ui/src/components/timeline/TimelineSwimlanes.tsx
@@ -54,7 +54,7 @@ export interface TimelineSwimlanesProps {
   // RBAC capability flag (was a radar/web context); host passes it. Default false.
   hasLimitedAccess?: boolean
   // GitOps lane labels deep-link to a controller path; the host decides how to
-  // navigate (radar router push, or cross-SPA href). When omitted, GitOps lanes
+  // navigate (radar router push, or cross-route-tree href). When omitted, GitOps lanes
   // fall back to onResourceClick (the resource drawer).
   onNavigatePath?: (path: string) => void
 }

--- a/pkg/auth/cloud_role.go
+++ b/pkg/auth/cloud_role.go
@@ -30,7 +30,7 @@ const cloudGroupPrefix = "cloud:"
 
 // ErrCodeCloudRoleInsufficient is the stable wire value emitted in 403
 // response bodies (`error_code` field) when a request is denied by a
-// Cloud role gate. SPA + MCP clients branch on this exact string —
+// Cloud role gate. frontend + MCP clients branch on this exact string —
 // never rename. Hoisted out of internal/helm/handlers.go so the
 // canonical value lives next to the role types it pertains to.
 const ErrCodeCloudRoleInsufficient = "cloud_role_insufficient"

--- a/pkg/packages/addons.go
+++ b/pkg/packages/addons.go
@@ -13,7 +13,7 @@ import "strings"
 //     so (1) can't catch them.
 //
 // The Applications and Add-ons surfaces share this classifier rather than each
-// carrying a private allowlist. The SPA's interim KNOWN_ADDON_CHARTS
+// carrying a private allowlist. The frontend's interim KNOWN_ADDON_CHARTS
 // (radar-hub-web packagesModel.ts) mirrors this list until the hub forwards the
 // classification on the wire; keep the two in sync until then.
 

--- a/pkg/packages/aggregate.go
+++ b/pkg/packages/aggregate.go
@@ -20,7 +20,7 @@ import (
 //   - Unknown CRD groups stay as their own rows (FromCRDGroup set).
 //
 // Determinism: rows are returned sorted by (chart, namespace,
-// release_name) so consumers (SPA tables, MCP tool output) get stable
+// release_name) so consumers (frontend tables, MCP tool output) get stable
 // ordering across calls.
 func Aggregate(s Sources) []PackageRow {
 	// CRD-only rows that don't resolve to a chart get a synthetic key

--- a/pkg/packages/types.go
+++ b/pkg/packages/types.go
@@ -12,7 +12,7 @@
 package packages
 
 // SourceCode is the single-character code identifying which signal
-// contributed to a PackageRow. Stable on-wire — agents, SPAs, Hub
+// contributed to a PackageRow. Stable on-wire — agents, frontends, Hub
 // fan-in, etc. depend on these exact strings. Defined as a named type
 // so call sites get compile-time checks against typos.
 type SourceCode string
@@ -225,7 +225,7 @@ type PackageRow struct {
 	Contributors []SourceContribution `json:"contributors,omitempty"`
 	// FromCRDGroup, when set, indicates this row originated from a CRD
 	// whose group wasn't in crdGroupToChart — Chart is the group string
-	// itself in that case. Lets the SPA render with appropriate framing
+	// itself in that case. Lets the frontend render with appropriate framing
 	// ("cert-manager.io CRDs detected") vs a real chart row.
 	FromCRDGroup string `json:"fromCRDGroup,omitempty"`
 	// Overlay is the resolved Tier-2 app identity for this package (the

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1130,7 +1130,7 @@ function AppInner() {
     // Fleet mode overrides visible kinds to show only CAPI resources + Node
     const effectiveKinds = topologyMode === 'fleet' ? FLEET_MODE_KINDS : visibleKinds
 
-    // Filter by namespace (frontend-side) and by visible kinds
+    // Filter by namespace (client-side) and by visible kinds
     const nsSet = namespaces.length > 0 ? new Set(namespaces) : null
     const filteredNodes = displayedTopology.nodes.filter(node =>
       effectiveKinds.has(node.kind) &&

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -817,7 +817,7 @@ export function useAuthMe() {
 }
 
 // Tier ordering for Cloud-role gates. Mirrors radar OSS pkg/auth
-// CloudRole.AtLeast — the SPA must agree with the backend on what
+// CloudRole.AtLeast — the frontend must agree with the backend on what
 // "member-or-higher" means; otherwise we'd hide a button the
 // backend would happily honor (or vice versa).
 const CLOUD_ROLE_RANK: Record<string, number> = { viewer: 1, member: 2, owner: 3 }

--- a/web/src/components/helm/ChartBrowser.tsx
+++ b/web/src/components/helm/ChartBrowser.tsx
@@ -27,7 +27,7 @@ export function ChartBrowser({ onChartSelect }: ChartBrowserProps) {
 
   // Repo refresh is gated only by `requireHelmWrite` on the backend
   // (handleUpdateRepository deliberately skips requireCloudRole — it
-  // mutates pod-local chart cache, not cluster state). So the SPA gate
+  // mutates pod-local chart cache, not cluster state). So the frontend gate
   // here must NOT include the Cloud role check, or Cloud viewers with
   // rbac.helm=true would be blocked from a refresh the backend allows.
   const canHelmWrite = useCanHelmWrite()

--- a/web/src/components/helm/RoleGatedPanel.tsx
+++ b/web/src/components/helm/RoleGatedPanel.tsx
@@ -22,7 +22,7 @@ interface RoleGatedPanelProps {
  *
  * Bypasses for non-Cloud users (OSS, OIDC, etc.) — `canAtLeast` returns
  * true when no Cloud role is present. The backend gate has the same
- * shape, so the SPA stays in lockstep.
+ * shape, so the frontend stays in lockstep.
  */
 export function RoleGatedPanel({ min, feature, children }: RoleGatedPanelProps) {
   const { role, canAtLeast } = useCloudRole()


### PR DESCRIPTION
Summary

Purges internal-facing SPA wording from Radar in favor of frontend, web app, and client-side routing language. This keeps the terminology aligned with how Radar is actually embedded and served without changing runtime behavior.

What changed

- Renamed the static fallback handler from spaHandler to frontendHandler and reworded route fallback comments around client-side routing.
- Replaced SPA phrasing across server, MCP, package aggregation, auth/search, Helm, GitOps, timeline, and renderer comments/tests.
- Left Vite appType: spa unchanged because that is a required Vite config literal, not product terminology.

Testing

- go test ./internal/server
- git diff --check
- rg terminology scan across the repo; only the Vite appType literal remains.

Notes

Visual testing skipped: this is terminology and identifier cleanup with no UI behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and identifier renames only; static serving and wire contracts are unchanged.
> 
> **Overview**
> Aligns internal naming and comments with **frontend**, **client-side routing**, and **route-tree** wording instead of **SPA**, without changing APIs or runtime behavior.
> 
> The only functional rename is **`spaHandler` → `frontendHandler`** in `internal/server/server.go`, still serving static assets with an **`index.html` fallback** for unknown paths. Comments across server, Helm, MCP, packages, auth, GitOps, and `packages/k8s-ui` / `web` now describe the **frontend** (and Hub vs cluster **route-tree** boundaries) as the consumer of stable `error_code` fields and legacy empty-list RBAC shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5e738790dc44d62500e87077f6bd9db96612924. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->