### PR TITLE
Export an injectable Omnibar from @skyhook-io/radar-app (hero · search-page handoff · content scrim) + chromeless drawer anchor

### DIFF
--- a/packages/k8s-ui/src/components/ui/SearchPillInput.tsx
+++ b/packages/k8s-ui/src/components/ui/SearchPillInput.tsx
@@ -113,6 +113,14 @@ export function SearchPillInput({
   const [sel, setSel] = useState(0)
   const [dismissed, setDismissed] = useState(false)
   const [anchor, setAnchor] = useState<{ left: number; bottom: number } | null>(null)
+  // Collapse a long pill list to a few + "+N more" so they don't flood the
+  // field (e.g. a broad namespace scope seeded as ns: pills). Expanding wraps
+  // them so every pill stays removable.
+  const [pillsExpanded, setPillsExpanded] = useState(false)
+  const MAX_VISIBLE_PILLS = 3
+  const collapsePills = !pillsExpanded && pills.length > MAX_VISIBLE_PILLS + 1
+  const shownPills = collapsePills ? pills.slice(0, MAX_VISIBLE_PILLS) : pills
+  const hiddenPillCount = pills.length - shownPills.length
 
   const mod = useMemo(() => activeModifier(text, aliases), [text, aliases])
 
@@ -184,12 +192,12 @@ export function SearchPillInput({
   }, [suggesting, filtered, sel, mod, text, pills, commitPill, onChange, onKeyDown])
 
   return (
-    <div ref={containerRef} className={clsx('flex items-center gap-1.5', className)} onClick={() => inputRef.current?.focus()}>
+    <div ref={containerRef} className={clsx('flex items-center gap-1.5', pillsExpanded && 'flex-wrap', className)} onClick={() => inputRef.current?.focus()}>
       {leftSlot}
-      {pills.map((p, i) => (
+      {shownPills.map((p, i) => (
         <span key={`${p.key}:${p.value}:${i}`} className="inline-flex items-center gap-1 shrink-0 rounded-md bg-theme-elevated border border-theme-border-light pl-1.5 pr-1 py-0.5 text-xs whitespace-nowrap">
           <span className="text-theme-text-tertiary">{p.key}:</span>
-          <span className="text-theme-text-primary font-medium">{p.value}</span>
+          <span className="max-w-[16ch] truncate font-medium text-theme-text-primary" title={p.value}>{p.value}</span>
           <button
             type="button"
             tabIndex={-1}
@@ -201,6 +209,27 @@ export function SearchPillInput({
           </button>
         </span>
       ))}
+      {collapsePills && hiddenPillCount > 0 && (
+        <button
+          type="button"
+          tabIndex={-1}
+          onMouseDown={(e) => { e.preventDefault(); setPillsExpanded(true) }}
+          className="shrink-0 rounded-md bg-theme-elevated border border-theme-border-light px-1.5 py-0.5 text-xs font-medium text-theme-text-secondary hover:text-theme-text-primary whitespace-nowrap"
+          title="Show all filters"
+        >
+          +{hiddenPillCount} more
+        </button>
+      )}
+      {pillsExpanded && pills.length > MAX_VISIBLE_PILLS + 1 && (
+        <button
+          type="button"
+          tabIndex={-1}
+          onMouseDown={(e) => { e.preventDefault(); setPillsExpanded(false) }}
+          className="shrink-0 rounded-md px-1.5 py-0.5 text-xs text-theme-text-tertiary hover:text-theme-text-primary whitespace-nowrap"
+        >
+          less
+        </button>
+      )}
       <input
         ref={inputRef}
         type="text"

--- a/packages/k8s-ui/src/components/ui/SearchPillInput.tsx
+++ b/packages/k8s-ui/src/components/ui/SearchPillInput.tsx
@@ -38,6 +38,8 @@ export interface SearchPillInputProps {
   rightSlot?: React.ReactNode
   /** Applied to the input container (host owns the box chrome: height, bg, border). */
   className?: string
+  /** Applied to the `<input>` itself (host owns text size: e.g. a hero variant). */
+  inputClassName?: string
   'aria-label'?: string
   /** Fires when the modifier autocomplete opens/closes, so the host can suppress
       its own results dropdown while a modifier is being completed. */
@@ -101,6 +103,7 @@ export function SearchPillInput({
   leftSlot,
   rightSlot,
   className,
+  inputClassName,
   onSuggestingChange,
   ...rest
 }: SearchPillInputProps) {
@@ -207,7 +210,10 @@ export function SearchPillInput({
         onFocus={onFocus}
         placeholder={pills.length ? '' : placeholder}
         aria-label={rest['aria-label']}
-        className="flex-1 min-w-[80px] bg-transparent text-sm text-theme-text-primary placeholder-theme-text-tertiary outline-none"
+        className={clsx(
+          'flex-1 min-w-[80px] bg-transparent text-theme-text-primary placeholder-theme-text-tertiary outline-none',
+          inputClassName ?? 'text-sm',
+        )}
       />
       {rightSlot}
       {suggesting && anchor && mod && createPortal(

--- a/packages/k8s-ui/src/components/ui/SearchPillInput.tsx
+++ b/packages/k8s-ui/src/components/ui/SearchPillInput.tsx
@@ -118,6 +118,12 @@ export function SearchPillInput({
   // them so every pill stays removable.
   const [pillsExpanded, setPillsExpanded] = useState(false)
   const MAX_VISIBLE_PILLS = 3
+  // Reset the expand toggle once there's nothing to collapse (pills cleared or
+  // trimmed) — otherwise a later seed of many pills would render expanded,
+  // re-flooding the field instead of collapsing.
+  useEffect(() => {
+    if (pills.length <= MAX_VISIBLE_PILLS + 1) setPillsExpanded(false)
+  }, [pills.length])
   const collapsePills = !pillsExpanded && pills.length > MAX_VISIBLE_PILLS + 1
   const shownPills = collapsePills ? pills.slice(0, MAX_VISIBLE_PILLS) : pills
   const hiddenPillCount = pills.length - shownPills.length

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1851,6 +1851,9 @@ function AppInner() {
         <ResourceDetailDrawer
           resource={drawerResource}
           initialTab={drawerInitialTab}
+          // No Radar header in chromeless embeds (Radar Hub) — anchor the drawer
+          // to the top of the content area instead of leaving a 49px gap.
+          headerHeight={chromeless ? 0 : undefined}
           isOpen={resourceDrawer.isOpen}
           expanded={drawerExpanded}
           onClose={() => { setSelectedResource(null); setDrawerInitialTab('detail'); setDrawerExpanded(false) }}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -56,7 +56,8 @@ import { SettingsDialog } from './components/settings/SettingsDialog'
 import { MyPermissionsDialog } from './components/settings/MyPermissionsDialog'
 import type { TopologyNode, GroupingMode, MainView, SelectedResource, SelectedHelmRelease, NodeKind, TopologyMode, Topology, K8sEvent } from './types'
 import { kindToPlural, openExternal, apiVersionToGroup, buildWorkloadPath, searchHitToSelectedResource } from './utils/navigation'
-import { Omnibar, type OmnibarHandle } from './components/ui/Omnibar'
+import { type OmnibarHandle } from './components/ui/Omnibar'
+import { RadarOmnibar } from './components/ui/RadarOmnibar'
 import type { ContextSwitcherHandle } from './components/ContextSwitcher'
 
 // All possible node kinds (core + GitOps)
@@ -1352,7 +1353,7 @@ function AppInner() {
             Fills the space the pill bar left; embedded keeps the pills + modal. */}
         {showNavRail && (
           <div className="hidden sm:flex flex-1 justify-center min-w-0 px-3">
-            <Omnibar
+            <RadarOmnibar
               ref={omnibarRef}
               onNavigateView={(view) => setMainView(view)}
               onNavigateKind={(kind, group) => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -542,7 +542,9 @@ function AppInner() {
       description: 'Show keyboard shortcuts',
       category: 'General' as const,
       scope: 'global' as const,
-      handler: () => setShowHelp(prev => !prev),
+      // Chromeless embeds (Radar Hub) own their own help surface — don't open a
+      // competing Radar overlay.
+      handler: () => { if (!chromeless) setShowHelp(prev => !prev) },
     },
     {
       id: 'command-palette',
@@ -551,8 +553,10 @@ function AppInner() {
       category: 'General' as const,
       scope: 'global' as const,
       allowInInputs: true,
-      // Standalone focuses the top-center omnibar; embedded opens the modal.
-      handler: () => { if (showNavRail) omnibarRef.current?.focus(); else setShowCommandPalette(true) },
+      // Standalone focuses the top-center omnibar; embedded opens the modal. In
+      // a chromeless embed the HOST owns ⌘K (its own omnibar), so do nothing —
+      // otherwise both the host omnibar and Radar's palette fire on one ⌘K.
+      handler: () => { if (showNavRail) omnibarRef.current?.focus(); else if (!chromeless) setShowCommandPalette(true) },
     },
     {
       id: 'diagnostics',

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -717,6 +717,11 @@ export interface SearchHit {
   name: string
   matched?: SearchMatchedField[]
   summaryContext?: SearchSummaryContext
+  /** Embedder (Radar Hub) only: the cluster this hit belongs to, for
+   *  cross-cluster fleet search. Standalone Radar (single-cluster) leaves these
+   *  unset — the omnibar keys + displays the cluster only when present. */
+  cluster?: string
+  clusterName?: string
 }
 
 export interface SearchResult {

--- a/web/src/components/resources/ResourceDetailDrawer.tsx
+++ b/web/src/components/resources/ResourceDetailDrawer.tsx
@@ -18,6 +18,9 @@ interface ResourceDetailDrawerProps {
   onExpand?: (resource: SelectedResource) => void
   /** Navigate to another resource within expanded WorkloadView */
   onNavigateToResource?: (resource: SelectedResource) => void
+  /** Top offset for the drawer (px). Defaults to Radar's 49px header height;
+   *  pass 0 in chromeless embeds where there's no Radar header above it. */
+  headerHeight?: number
 }
 
 export function ResourceDetailDrawer(props: ResourceDetailDrawerProps) {

--- a/web/src/components/ui/Omnibar.tsx
+++ b/web/src/components/ui/Omnibar.tsx
@@ -260,7 +260,12 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
     const rest = (launcher ? filtered : filtered.slice(0, 8)).map((x) => x.item)
     const byCat = new Map<string, CommandItem[]>()
     for (const c of rest) { const l = byCat.get(c.category) ?? []; l.push(c); byCat.set(c.category, l) }
-    return COMMAND_CATEGORY_ORDER.filter((cat) => byCat.has(cat)).map((cat) => ({ category: cat, items: byCat.get(cat)! }))
+    // `CommandItem.category` is an open string, so a host can use one we don't
+    // rank — render those AFTER the known order rather than silently dropping
+    // their commands.
+    const known = COMMAND_CATEGORY_ORDER.filter((cat) => byCat.has(cat))
+    const extra = [...byCat.keys()].filter((cat) => !COMMAND_CATEGORY_ORDER.includes(cat))
+    return [...known, ...extra].map((cat) => ({ category: cat, items: byCat.get(cat)! }))
   }, [scoredCommands, leadingIds, freeText, pills.length])
 
   const toCmdRow = (c: CommandItem): Row => ({ id: `cmd:${c.id}`, kind: 'command', command: c })

--- a/web/src/components/ui/Omnibar.tsx
+++ b/web/src/components/ui/Omnibar.tsx
@@ -176,7 +176,7 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
   // trap the dim overlay). `centerX` aligns the panel under the input; `top` is
   // the HEADER's bottom (not the input's) so the dim starts cleanly below the
   // whole top bar.
-  const [anchor, setAnchor] = useState<{ centerX: number; top: number } | null>(null)
+  const [anchor, setAnchor] = useState<{ centerX: number; top: number; width: number } | null>(null)
 
   useImperativeHandle(ref, () => ({ focus: () => { inputRef.current?.focus(); inputRef.current?.select() } }), [])
 
@@ -285,14 +285,21 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
   // Selection tracked by stable id (not array index) so Enter can never fire a
   // stale row when the set shifts. Auto-follows the TOP result until the user
   // arrow-keys; a new query re-enables auto-follow.
+  // When the host wires a search page (onViewAllResults), Enter on an
+  // un-touched query goes THERE with the query rather than firing the top hit —
+  // so we never pre-select a row (the user opts into a specific result by
+  // arrowing/hovering). Without a search page (OSS), keep auto-follow-top so
+  // Enter still opens the best match.
+  const submitToSearch = !!onViewAllResults
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const userMovedRef = useRef(false)
   useEffect(() => { userMovedRef.current = false }, [queryString])
   const rowsKey = rows.map((r) => r.id).join('|')
   useEffect(() => {
+    const dflt = submitToSearch ? null : (rows[0]?.id ?? null)
     setSelectedId((cur) => {
-      if (!userMovedRef.current) return rows[0]?.id ?? null
-      return cur && rows.some((r) => r.id === cur) ? cur : rows[0]?.id ?? null
+      if (!userMovedRef.current) return dflt
+      return cur && rows.some((r) => r.id === cur) ? cur : dflt
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rowsKey])
@@ -339,12 +346,21 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
     else if (e.key === 'Enter') {
       e.preventDefault()
       const row = rows[selectedIndex]
-      if (!row) return
-      if (row.kind === 'resource' && resourcesStale) return
-      execute(row)
+      if (row) {
+        if (row.kind === 'resource' && resourcesStale) return
+        execute(row)
+        return
+      }
+      // No row chosen: submit the query to the full search page (the default
+      // for a host that wired one). viewAllRow carries the count when results
+      // are in; fall back to the raw query while they're still loading.
+      if (submitToSearch && searchActive) {
+        if (viewAllRow) execute(viewAllRow)
+        else { onViewAllResults?.(queryString); setOpen(false); setText(''); setPills([]); inputRef.current?.blur() }
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rows, selectedIndex, execute, resourcesStale])
+  }, [rows, selectedIndex, execute, resourcesStale, submitToSearch, searchActive, viewAllRow, onViewAllResults, queryString])
 
   useEffect(() => {
     listRef.current?.querySelector('[data-selected="true"]')?.scrollIntoView({ block: 'nearest' })
@@ -369,7 +385,7 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
       if (!el) return
       const r = el.getBoundingClientRect()
       const header = el.closest('header')
-      setAnchor({ centerX: r.left + r.width / 2, top: header ? header.getBoundingClientRect().bottom : r.bottom })
+      setAnchor({ centerX: r.left + r.width / 2, top: header ? header.getBoundingClientRect().bottom : r.bottom, width: r.width })
     }
     update()
     window.addEventListener('resize', update)
@@ -419,14 +435,17 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
 
       {open && anchor && (dropdownOpen || suggesting) && createPortal(
         <>
-          {/* Click-catcher below the field. The slim top-bar launcher dims the
-              page behind it; the hero (a landing-page search box, not a modal)
-              stays transparent — Google-style — so it never dims the dashboard
-              or seams across the rail. Both close on outside click. */}
+          {/* Scrim below the field — separates the dropdown from the page.
+              Hero (landing search box): z-[15] sits BELOW the rail/top bar
+              (z-20/30) so it dims + blurs only the dashboard content behind the
+              panel — no seam across the chrome, the bug the earlier full-overlay
+              had. Top-bar launcher keeps its heavier dim. Both close on click. */}
           <div
             className={clsx(
-              'fixed left-0 right-0 bottom-0 z-[120]',
-              !hero && 'bg-black/25 dark:bg-black/55 backdrop-blur-[2px]',
+              'fixed left-0 right-0 bottom-0',
+              hero
+                ? 'z-[15] bg-black/15 dark:bg-black/50 backdrop-blur-[3px]'
+                : 'z-[120] bg-black/25 dark:bg-black/55 backdrop-blur-[2px]',
             )}
             style={{ top: anchor.top }}
             onClick={() => { setOpen(false); inputRef.current?.blur() }}
@@ -434,8 +453,8 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
           {dropdownOpen && (
           <div
             ref={panelRef}
-            style={{ position: 'fixed', top: anchor.top + 8, left: anchor.centerX, transform: 'translateX(-50%)', width: 640, maxWidth: 'calc(100vw - 2rem)' }}
-            className="z-[121] dialog shadow-theme-lg overflow-hidden"
+            style={{ position: 'fixed', top: anchor.top + 8, left: anchor.centerX, transform: 'translateX(-50%)', width: hero ? Math.round(anchor.width) : 640, maxWidth: 'calc(100vw - 2rem)' }}
+            className="z-[121] dialog shadow-theme-lg ring-1 ring-black/5 dark:ring-white/10 overflow-hidden"
           >
           <div ref={listRef} className="max-h-[60vh] overflow-y-auto py-1">
             {recentRows.length > 0 && (
@@ -510,7 +529,9 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
             )}
           </div>
           <div className="flex items-center gap-3 px-3 py-1.5 border-t border-theme-border text-[11px] text-theme-text-tertiary">
-            <span className="flex items-center gap-1"><CornerDownLeft className="w-3 h-3" /> open</span>
+            <span className="flex items-center gap-1">
+              <CornerDownLeft className="w-3 h-3" /> {submitToSearch && searchActive && selectedIndex < 0 ? 'search all' : 'open'}
+            </span>
             <span>↑↓ navigate</span>
             <span>⇞⇟ page</span>
             <span>esc close</span>

--- a/web/src/components/ui/Omnibar.tsx
+++ b/web/src/components/ui/Omnibar.tsx
@@ -15,6 +15,8 @@ export interface OmnibarRecent {
   group?: string
   namespace?: string
   name: string
+  cluster?: string
+  clusterName?: string
 }
 
 // Search results the host feeds in (it runs its own search hook keyed on the
@@ -204,17 +206,17 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
 
   const resourceRows = useMemo<Row[]>(() => {
     const hits = searchData?.hits ?? []
-    return hits.map((hit) => ({ id: `res:${hit.kind}:${hit.group || ''}:${hit.namespace || ''}:${hit.name}`, kind: 'resource' as const, hit }))
+    return hits.map((hit) => ({ id: `res:${hit.cluster || ''}:${hit.kind}:${hit.group || ''}:${hit.namespace || ''}:${hit.name}`, kind: 'resource' as const, hit }))
   }, [searchData])
 
   // Launcher recents: only in the truly-empty state (no text, no pills).
   const recentRows = useMemo<Row[]>(() => {
     if (!open || freeText || pills.length > 0 || !loadRecents) return []
     return loadRecents().map((r) => ({
-      id: `recent:${r.kind}:${r.group || ''}:${r.namespace || ''}:${r.name}`,
+      id: `recent:${r.cluster || ''}:${r.kind}:${r.group || ''}:${r.namespace || ''}:${r.name}`,
       kind: 'resource' as const,
       recent: true,
-      hit: { score: 0, kind: r.kind, group: r.group, namespace: r.namespace, name: r.name } as SearchHit,
+      hit: { score: 0, kind: r.kind, group: r.group, namespace: r.namespace, name: r.name, cluster: r.cluster, clusterName: r.clusterName } as SearchHit,
     }))
   }, [open, freeText, pills.length, loadRecents])
 
@@ -471,6 +473,7 @@ function ResourceRow({ hit, selected, stale, onSelect, onActivate }: { hit: Sear
       <span className="shrink-0 max-w-[45%] truncate text-xs text-theme-text-tertiary">
         {highlight(hit.kind, tokensForSite(hit.matched, 'kind'))}
         {hit.namespace ? <> · {highlight(hit.namespace, tokensForSite(hit.matched, 'namespace'))}</> : ''}
+        {hit.clusterName ? <> · <span className="text-theme-text-secondary">{hit.clusterName}</span></> : ''}
       </span>
       {contentOnly && <span className="shrink-0 text-[10px] text-theme-text-tertiary italic">in spec</span>}
       {issues > 0 && <span className="ml-auto shrink-0 text-[10px] font-medium text-amber-600 dark:text-amber-400">{issues} issue{issues === 1 ? '' : 's'}</span>}

--- a/web/src/components/ui/Omnibar.tsx
+++ b/web/src/components/ui/Omnibar.tsx
@@ -4,11 +4,26 @@ import { Search, CornerDownLeft, Loader2, AlertTriangle } from 'lucide-react'
 import { clsx } from 'clsx'
 import { SearchPillInput, type SearchModifier } from '@skyhook-io/k8s-ui'
 import { getResourceIcon } from '../../utils/resource-icons'
-import { useSearch, useNamespaceScope, useContexts, type SearchHit, type SearchMatchedField } from '../../api/client'
-import { useAPIResources } from '../../api/apiResources'
-import { loadRecentResources, recordRecentResource } from '../../hooks/useRecentResources'
-import { useCommandItems, bestScore, type CommandItem, type CommandItemCallbacks } from './command-items'
+import type { SearchHit, SearchMatchedField } from '../../api/client'
+import { bestScore, type CommandItem } from './command-items'
 import { SearchSyntaxHelp } from './SearchSyntaxHelp'
+
+// Minimal recent-resource shape the omnibar renders. Hosts own the storage +
+// per-cluster partitioning behind loadRecents/recordRecent.
+export interface OmnibarRecent {
+  kind: string
+  group?: string
+  namespace?: string
+  name: string
+}
+
+// Search results the host feeds in (it runs its own search hook keyed on the
+// debounced query the omnibar emits via onQueryChange).
+export interface OmnibarSearchResult {
+  hits: SearchHit[]
+  total?: number
+  total_matched?: number
+}
 
 // Health → dot color (summaryContext.health is the same vocabulary as the rest
 // of Radar). Kept local + tiny to avoid pulling the full status-tone system.
@@ -66,9 +81,30 @@ export interface OmnibarHandle {
   focus: () => void
 }
 
-interface OmnibarProps extends CommandItemCallbacks {
-  /** Open a resource hit (route-based — sets the URL + opens the drawer). */
+export interface OmnibarProps {
+  /** Open a resource hit (route-based — sets the URL + opens the drawer/page). */
   onOpenResource: (hit: SearchHit) => void
+  /** Command-palette items, already built by the host (Views/Actions/Clusters/…).
+   *  Scored + grouped internally; the host doesn't rank them. */
+  commandItems: CommandItem[]
+  /** The host runs its own search keyed on this debounced query; `open` lets it
+   *  gate the request. */
+  onQueryChange?: (query: string, open: boolean) => void
+  /** Live search results for the current query (host-provided). */
+  searchData?: OmnibarSearchResult
+  isFetching?: boolean
+  isError?: boolean
+  /** True while React Query serves a previous query's data — gates Enter/clicks. */
+  isPlaceholderData?: boolean
+  /** Bounded modifier value sets to autocomplete (e.g. { ns: [...], kind: [...] }). */
+  modifierOptions?: Record<string, string[]>
+  /** Namespaces to seed as removable `ns:` pills when the launcher opens empty
+   *  (reflects the current view scope). */
+  seedNamespaces?: string[]
+  /** Recently-viewed resources for the empty launcher (host owns storage). */
+  loadRecents?: () => OmnibarRecent[]
+  recordRecent?: (r: OmnibarRecent) => void
+  placeholder?: string
 }
 
 type Row =
@@ -83,12 +119,28 @@ function pillsToQuery(pills: SearchModifier[]): string {
   return pills.map((p) => `${p.key}:${p.value}`).join(' ')
 }
 
-// The standalone omnibar: a persistent top-center search box that IS the ⌘K
-// surface. Typing runs the live, GLOBAL resource search (/api/search) alongside
-// the command-palette items; modifiers (ns:, kind:, …) become removable pills.
-// Resources lead, commands follow. ⌘K focuses it.
+// The omnibar: a persistent search box that IS the ⌘K surface. Typing runs the
+// host's live resource search alongside its command-palette items; modifiers
+// (ns:, kind:, …) become removable pills. Resources lead, commands follow.
+//
+// Injectable: all data — search, commands, recents, modifier options — flows in
+// via props, so Radar standalone (cluster /api/search) and Radar Hub (fleet
+// search) share the same UX. ⌘K focus is wired by the host.
 export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
-  { onOpenResource, ...callbacks },
+  {
+    onOpenResource,
+    commandItems,
+    onQueryChange,
+    searchData,
+    isFetching = false,
+    isError = false,
+    isPlaceholderData = false,
+    modifierOptions,
+    seedNamespaces,
+    loadRecents,
+    recordRecent,
+    placeholder = 'Search resources & commands…',
+  },
   ref,
 ) {
   const [text, setText] = useState('')
@@ -102,52 +154,34 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
   // The dropdown is portaled to <body> (so the header's stacking context can't
   // trap the dim overlay). `centerX` aligns the panel under the input; `top` is
   // the HEADER's bottom (not the input's) so the dim starts cleanly below the
-  // whole top bar — the input is shorter than the bar, so anchoring to it would
-  // slice the dim through the taller right-side controls.
+  // whole top bar.
   const [anchor, setAnchor] = useState<{ centerX: number; top: number } | null>(null)
 
   useImperativeHandle(ref, () => ({ focus: () => { inputRef.current?.focus(); inputRef.current?.select() } }), [])
 
-  const { data: nsScope } = useNamespaceScope()
-  const { data: apiResources } = useAPIResources()
-  const { data: contexts } = useContexts()
-  // Recents are partitioned by the current cluster so a context switch never
-  // surfaces (or opens) the previous cluster's resources.
-  const contextKey = useMemo(() => contexts?.find((c) => c.isCurrent)?.name ?? '', [contexts])
-  // ns + kind are the bounded, knowable modifier value sets worth autocompleting.
-  const modifierOptions = useMemo(() => ({
-    ns: nsScope?.accessibleNamespaces ?? [],
-    kind: apiResources ? [...new Set(apiResources.filter((r) => r.verbs?.includes('list')).map((r) => r.kind))].sort() : [],
-  }), [nsScope, apiResources])
-
   // Reflect the current view scope as an editable `ns:` pill on open, so a
   // deliberately broad ⌘K search shows (and lets you remove) the namespace it's
-  // narrowed to instead of silently scoping. Seeded once per open, only from a
-  // truly empty launcher state.
-  const actives = nsScope?.actives
+  // narrowed to. Seeded once per open, only from a truly empty launcher state.
   const seededRef = useRef(false)
   useEffect(() => {
     if (!open) { seededRef.current = false; return }
-    if (seededRef.current || actives === undefined) return
+    if (seededRef.current || seedNamespaces === undefined) return
     seededRef.current = true
-    if (pills.length === 0 && text === '' && actives.length > 0) {
-      setPills(actives.map((ns) => ({ key: 'ns', value: ns })))
+    if (pills.length === 0 && text === '' && seedNamespaces.length > 0) {
+      setPills(seedNamespaces.map((ns) => ({ key: 'ns', value: ns })))
     }
-  }, [open, actives, pills.length, text])
+  }, [open, seedNamespaces, pills.length, text])
 
   const freeText = text.trim()
   const queryString = useMemo(() => [pillsToQuery(pills), freeText].filter(Boolean).join(' '), [pills, freeText])
   const searchActive = queryString.length >= 2
-  // Small debounce: /api/search is a local in-memory index, so this exists only
-  // to coalesce fast keystrokes (less list reshuffle), not to cut network cost —
-  // kept under the ~100-150ms "feels instant" threshold. keepPreviousData +
-  // AbortSignal (see useSearch) handle the smoothness; commands aren't debounced.
+  // Small debounce: coalesce fast keystrokes (less list reshuffle). The host's
+  // search hook handles smoothness (keepPreviousData + AbortSignal).
   const debounced = useDebounced(queryString, 120)
-  // globalNs: ⌘K searches the user's full RBAC ceiling; scope comes only from
-  // `ns:` pills, never the silent view filter.
-  const { data: searchData, isFetching, isPlaceholderData, isError } = useSearch(debounced, { enabled: open, globalNs: true })
 
-  const commandItems = useCommandItems(callbacks)
+  // Tell the host which (debounced) query to search, and whether the surface is
+  // open (so it can gate the request).
+  useEffect(() => { onQueryChange?.(debounced, open) }, [debounced, open, onQueryChange])
 
   // Commands score against the FREE text only — modifiers live in pills, so the
   // launcher never sees "ns:" polluting a "go to topology" match. Empty + no
@@ -161,8 +195,7 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
   }, [commandItems, freeText, pills.length])
 
   // Kinds whose NAME strongly matches (exact 150 / prefix 100) lead ABOVE the
-  // resource instances: "⌘K → deployment → Deployments list" is a navigation
-  // flow the instance hits otherwise bury.
+  // resource instances.
   const leadingKinds = useMemo<CommandItem[]>(
     () => (freeText.length < 2 ? [] : scoredCommands.filter((x) => x.item.category === 'Resource Kinds' && x.score >= STRONG_KIND).slice(0, 5).map((x) => x.item)),
     [scoredCommands, freeText],
@@ -174,17 +207,16 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
     return hits.map((hit) => ({ id: `res:${hit.kind}:${hit.group || ''}:${hit.namespace || ''}:${hit.name}`, kind: 'resource' as const, hit }))
   }, [searchData])
 
-  // Launcher recents: only in the truly-empty state (no text, no pills). Read
-  // fresh from localStorage each open.
+  // Launcher recents: only in the truly-empty state (no text, no pills).
   const recentRows = useMemo<Row[]>(() => {
-    if (!open || freeText || pills.length > 0) return []
-    return loadRecentResources(contextKey).map((r) => ({
+    if (!open || freeText || pills.length > 0 || !loadRecents) return []
+    return loadRecents().map((r) => ({
       id: `recent:${r.kind}:${r.group || ''}:${r.namespace || ''}:${r.name}`,
       kind: 'resource' as const,
       recent: true,
       hit: { score: 0, kind: r.kind, group: r.group, namespace: r.namespace, name: r.name } as SearchHit,
     }))
-  }, [open, freeText, pills.length, contextKey])
+  }, [open, freeText, pills.length, loadRecents])
 
   // Remaining matched commands (leading kinds removed so they don't repeat),
   // grouped by their real category in a fixed order.
@@ -197,12 +229,9 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
 
   const toCmdRow = (c: CommandItem): Row => ({ id: `cmd:${c.id}`, kind: 'command', command: c })
 
-  // Free-text tokens for highlighting command labels (commands are scored
-  // client-side, so there's no server `matched`).
   const queryTokens = useMemo(() => freeText.split(/\s+/).filter(Boolean), [freeText])
 
-  // Ordered, id-stable list (render order == keyboard model): recents (launcher
-  // only), then leading kinds, then resources (when searchActive), then commands.
+  // Ordered, id-stable list (render order == keyboard model).
   const rows = useMemo<Row[]>(() => {
     const cmds: Row[] = commandGroups.flatMap((g) => g.items.map(toCmdRow))
     if (!freeText && pills.length === 0) return [...recentRows, ...cmds]
@@ -230,8 +259,7 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
     setSelectedId(rows[Math.min(Math.max(selectedIndex + delta, 0), rows.length - 1)]?.id ?? null)
   }
   const selectRow = (id: string) => { userMovedRef.current = true; setSelectedId(id) }
-  // Page by a full screenful of visible rows (minus one for context overlap),
-  // measured from the scroll container — a fixed count feels short on tall lists.
+  // Page by a full screenful of visible rows (minus one for context overlap).
   const pageStep = () => {
     const list = listRef.current
     const rowH = (list?.querySelector('button') as HTMLElement | null)?.offsetHeight
@@ -244,49 +272,40 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
       row.command.action()
     } else {
       const h = row.hit
-      recordRecentResource({ kind: h.kind, group: h.group, namespace: h.namespace, name: h.name }, contextKey)
+      recordRecent?.({ kind: h.kind, group: h.group, namespace: h.namespace, name: h.name })
       onOpenResource(h)
     }
     setOpen(false)
     setText('')
     setPills([])
     inputRef.current?.blur()
-  }, [onOpenResource, contextKey])
+  }, [onOpenResource, recordRecent])
 
   // The resources shown don't (yet) belong to the current query: the debounce
-  // hasn't fired, the data is React Query placeholder from a prior query, or
-  // results for this query haven't landed. Swallow Enter so it can't open a
-  // stale hit or a command standing in for an imminent resource.
+  // hasn't fired, the data is React Query placeholder, or results haven't landed.
   const resourcesStale = searchActive && (debounced !== queryString || isPlaceholderData || (resourceRows.length === 0 && isFetching))
 
-  // Forwarded from SearchPillInput for keys it doesn't consume (it owns Space →
-  // pill, Backspace → pop pill, and suggestion nav).
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (e.key === 'Escape') { e.preventDefault(); setOpen(false); inputRef.current?.blur(); return }
     if (e.key === 'ArrowDown') { e.preventDefault(); moveSelection(1) }
     else if (e.key === 'ArrowUp') { e.preventDefault(); moveSelection(-1) }
     else if (e.key === 'PageDown') { e.preventDefault(); moveSelection(pageStep()) }
     else if (e.key === 'PageUp') { e.preventDefault(); moveSelection(-pageStep()) }
-    // Home/End deliberately left native so they move the text caret, not the list.
     else if (e.key === 'Enter') {
       e.preventDefault()
       const row = rows[selectedIndex]
       if (!row) return
-      // Block Enter only for a stale RESOURCE row (could open a hidden/stale
-      // hit); commands and ready resources fire immediately.
       if (row.kind === 'resource' && resourcesStale) return
       execute(row)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rows, selectedIndex, execute, resourcesStale])
 
-  // Keep the selected row in view.
   useEffect(() => {
     listRef.current?.querySelector('[data-selected="true"]')?.scrollIntoView({ block: 'nearest' })
   }, [selectedId])
 
-  // Close on outside click — the panel is portaled out of the container, so it
-  // must be excluded explicitly or clicking a row would count as "outside".
+  // Close on outside click — the panel is portaled out of the container.
   useEffect(() => {
     if (!open) return
     const onDown = (e: MouseEvent) => {
@@ -297,8 +316,7 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
     return () => document.removeEventListener('mousedown', onDown)
   }, [open])
 
-  // Track the input's position so the portaled panel stays anchored under it
-  // through scroll / resize / layout shifts.
+  // Track the input's position so the portaled panel stays anchored under it.
   useEffect(() => {
     if (!open) { setAnchor(null); return }
     const update = () => {
@@ -333,7 +351,7 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
         onFocus={() => setOpen(true)}
         onSuggestingChange={setSuggesting}
         modifierOptions={modifierOptions}
-        placeholder="Search resources & commands…"
+        placeholder={placeholder}
         aria-label="Search resources and commands"
         inputRef={inputRef}
         leftSlot={<Search className="w-3.5 h-3.5 shrink-0 text-theme-text-tertiary" />}
@@ -351,11 +369,6 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
 
       {open && anchor && (dropdownOpen || suggesting) && createPortal(
         <>
-          {/* Dim + blur the busy dashboard behind so results read as a focused
-              search surface (Spotlight/Linear pattern), not a weak float. Starts
-              at the header's bottom edge so the search box + top bar stay crisp.
-              Tied to `open`, NOT the results panel, so completing a modifier (the
-              panel briefly yields to the autocomplete) doesn't strobe the dim. */}
           <div
             className="fixed left-0 right-0 bottom-0 z-[120] bg-black/25 dark:bg-black/55 backdrop-blur-[2px]"
             style={{ top: anchor.top }}
@@ -368,7 +381,6 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
             className="z-[121] dialog shadow-theme-lg overflow-hidden"
           >
           <div ref={listRef} className="max-h-[60vh] overflow-y-auto py-1">
-            {/* Recently viewed — launcher state only. */}
             {recentRows.length > 0 && (
               <div>
                 <div className="px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-theme-text-tertiary">Recently viewed</div>
@@ -378,8 +390,6 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
               </div>
             )}
 
-            {/* Leading kinds — strong kind-name matches lead so ⌘K navigation
-                to a kind isn't buried under instance hits. */}
             {leadingKinds.length > 0 && (
               <div>
                 <div className="px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-theme-text-tertiary">Resource Kinds</div>
@@ -390,7 +400,6 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
               </div>
             )}
 
-            {/* Resources section */}
             {searchActive && (
               <>
                 <div className="flex items-center justify-between px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-theme-text-tertiary">
@@ -413,16 +422,12 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
                   </div>
                 ) : (
                   resourceRows.map((row) => row.kind === 'resource' && (
-                    // Mirror the Enter guard: ignore clicks on stale rows (prior
-                    // query's results during debounce/placeholder) so a click can't
-                    // open/record the wrong resource. Dim them so it reads as pending.
                     <ResourceRow key={row.id} hit={row.hit} stale={resourcesStale} selected={row.id === selectedId} onSelect={() => selectRow(row.id)} onActivate={() => { if (!resourcesStale) execute(row) }} />
                   ))
                 )}
               </>
             )}
 
-            {/* Command groups, each under its real category header. */}
             {commandGroups.map((group) => (
               <div key={group.category}>
                 <div className="px-3 py-1 mt-1 text-[10px] font-semibold uppercase tracking-wider text-theme-text-tertiary">{group.category}</div>
@@ -452,8 +457,6 @@ function ResourceRow({ hit, selected, stale, onSelect, onActivate }: { hit: Sear
   const Icon = getResourceIcon(hit.kind)
   const dot = healthDot(hit.summaryContext?.health)
   const issues = hit.summaryContext?.issueCount ?? 0
-  // Lead is a name match; flag content-only matches so a name search isn't
-  // silently padded with body hits.
   const contentOnly = !!hit.matched?.length && hit.matched.every((m) => m.site.startsWith('content:'))
   return (
     <button

--- a/web/src/components/ui/Omnibar.tsx
+++ b/web/src/components/ui/Omnibar.tsx
@@ -296,7 +296,11 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
   useEffect(() => { userMovedRef.current = false }, [queryString])
   const rowsKey = rows.map((r) => r.id).join('|')
   useEffect(() => {
-    const dflt = submitToSearch ? null : (rows[0]?.id ?? null)
+    // Only suppress the pre-selection while actively SEARCHING (so Enter goes to
+    // the search page, not a maybe-wrong top hit). In the empty launcher there's
+    // no search to defer to, so auto-select the first row — otherwise Enter is a
+    // no-op while the footer still reads "open".
+    const dflt = submitToSearch && searchActive ? null : (rows[0]?.id ?? null)
     setSelectedId((cur) => {
       if (!userMovedRef.current) return dflt
       return cur && rows.some((r) => r.id === cur) ? cur : dflt
@@ -324,7 +328,7 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
       onViewAllResults?.(row.query)
     } else {
       const h = row.hit
-      recordRecent?.({ kind: h.kind, group: h.group, namespace: h.namespace, name: h.name })
+      recordRecent?.({ kind: h.kind, group: h.group, namespace: h.namespace, name: h.name, cluster: h.cluster, clusterName: h.clusterName })
       onOpenResource(h)
     }
     setOpen(false)

--- a/web/src/components/ui/Omnibar.tsx
+++ b/web/src/components/ui/Omnibar.tsx
@@ -404,7 +404,7 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
   const hero = size === 'hero'
 
   return (
-    <div ref={containerRef} className={hero ? 'relative w-full max-w-3xl' : 'relative w-full max-w-xl'}>
+    <div ref={containerRef} className={clsx('relative w-full', hero ? 'max-w-3xl' : 'max-w-xl', open && hero && 'z-[16]')}>
       <SearchPillInput
         className={hero
           ? 'min-h-14 px-5 rounded-2xl bg-theme-surface border border-theme-border shadow-theme-sm transition-colors focus-within:border-[var(--color-brand-500)] focus-within:shadow-[0_0_0_4px_color-mix(in_srgb,var(--color-brand-500)_15%,transparent)]'
@@ -435,19 +435,20 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
 
       {open && anchor && (dropdownOpen || suggesting) && createPortal(
         <>
-          {/* Scrim below the field — separates the dropdown from the page.
-              Hero (landing search box): z-[15] sits BELOW the rail/top bar
-              (z-20/30) so it dims + blurs only the dashboard content behind the
-              panel — no seam across the chrome, the bug the earlier full-overlay
-              had. Top-bar launcher keeps its heavier dim. Both close on click. */}
+          {/* Scrim — separates the dropdown from the page. Hero (landing search
+              box): full-viewport at z-[15], which sits BELOW the rail/top bar
+              (z-20/30) so those stay clean, while the search box itself is
+              lifted to z-[16] above it. Net: everything in the content area is
+              shaded except the navbar and the box — no chrome seam. Top-bar
+              launcher keeps its heavier dim below the field. Click closes. */}
           <div
             className={clsx(
               'fixed left-0 right-0 bottom-0',
               hero
-                ? 'z-[15] bg-black/15 dark:bg-black/50 backdrop-blur-[3px]'
+                ? 'top-0 z-[15] bg-black/15 dark:bg-black/50 backdrop-blur-[3px]'
                 : 'z-[120] bg-black/25 dark:bg-black/55 backdrop-blur-[2px]',
             )}
-            style={{ top: anchor.top }}
+            style={hero ? undefined : { top: anchor.top }}
             onClick={() => { setOpen(false); inputRef.current?.blur() }}
           />
           {dropdownOpen && (

--- a/web/src/components/ui/Omnibar.tsx
+++ b/web/src/components/ui/Omnibar.tsx
@@ -404,7 +404,14 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
   const hero = size === 'hero'
 
   return (
-    <div ref={containerRef} className={clsx('relative w-full', hero ? 'max-w-3xl' : 'max-w-xl', open && hero && 'z-[16]')}>
+    <div
+      ref={containerRef}
+      className={clsx('relative w-full', hero ? 'max-w-3xl' : 'max-w-xl', open && hero && 'z-[16]')}
+      // Open on click even when the field is already focused — onFocus alone
+      // never fires again, so an autofocused hero (Home) wouldn't reveal the
+      // launcher on a click.
+      onMouseDown={() => setOpen(true)}
+    >
       <SearchPillInput
         className={hero
           ? 'min-h-14 px-5 rounded-2xl bg-theme-surface border border-theme-border shadow-theme-sm transition-colors focus-within:border-[var(--color-brand-500)] focus-within:shadow-[0_0_0_4px_color-mix(in_srgb,var(--color-brand-500)_15%,transparent)]'
@@ -435,20 +442,17 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
 
       {open && anchor && (dropdownOpen || suggesting) && createPortal(
         <>
-          {/* Scrim — separates the dropdown from the page. Hero (landing search
-              box): full-viewport at z-[15], which sits BELOW the rail/top bar
-              (z-20/30) so those stay clean, while the search box itself is
-              lifted to z-[16] above it. Net: everything in the content area is
-              shaded except the navbar and the box — no chrome seam. Top-bar
-              launcher keeps its heavier dim below the field. Click closes. */}
+          {/* Scrim — separates the dropdown from the page, consistently in both
+              modes. At z-[15] it sits BELOW the rail/top bar (z-20/30), so the
+              nav chrome stays lit while the content behind the panel dims+blurs:
+              a "spotlight on search", not a full-screen modal dim (which fits a
+              centered command palette, not an anchored omnibar). The hero covers
+              from the top (its box is in the content, lifted to z-[16]); the
+              top-bar launcher covers from below the field (its box is already in
+              the z-20 chrome). Click closes. */}
           <div
-            className={clsx(
-              'fixed left-0 right-0 bottom-0',
-              hero
-                ? 'top-0 z-[15] bg-black/15 dark:bg-black/50 backdrop-blur-[3px]'
-                : 'z-[120] bg-black/25 dark:bg-black/55 backdrop-blur-[2px]',
-            )}
-            style={hero ? undefined : { top: anchor.top }}
+            className="fixed left-0 right-0 bottom-0 z-[15] bg-black/15 dark:bg-black/50 backdrop-blur-[3px]"
+            style={{ top: hero ? 0 : anchor.top }}
             onClick={() => { setOpen(false); inputRef.current?.blur() }}
           />
           {dropdownOpen && (

--- a/web/src/components/ui/Omnibar.tsx
+++ b/web/src/components/ui/Omnibar.tsx
@@ -241,13 +241,17 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
   }, [open, freeText, pills.length, loadRecents])
 
   // Remaining matched commands (leading kinds removed so they don't repeat),
-  // grouped by their real category in a fixed order.
+  // grouped by their real category in a fixed order. The empty launcher IS the
+  // command menu, so show it in full; while searching, cap so resource hits stay
+  // prominent.
   const commandGroups = useMemo(() => {
-    const rest = scoredCommands.filter((x) => !leadingIds.has(x.item.id)).slice(0, 8).map((x) => x.item)
+    const launcher = !freeText && pills.length === 0
+    const filtered = scoredCommands.filter((x) => !leadingIds.has(x.item.id))
+    const rest = (launcher ? filtered : filtered.slice(0, 8)).map((x) => x.item)
     const byCat = new Map<string, CommandItem[]>()
     for (const c of rest) { const l = byCat.get(c.category) ?? []; l.push(c); byCat.set(c.category, l) }
     return COMMAND_CATEGORY_ORDER.filter((cat) => byCat.has(cat)).map((cat) => ({ category: cat, items: byCat.get(cat)! }))
-  }, [scoredCommands, leadingIds])
+  }, [scoredCommands, leadingIds, freeText, pills.length])
 
   const toCmdRow = (c: CommandItem): Row => ({ id: `cmd:${c.id}`, kind: 'command', command: c })
 
@@ -405,8 +409,15 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
 
       {open && anchor && (dropdownOpen || suggesting) && createPortal(
         <>
+          {/* Click-catcher below the field. The slim top-bar launcher dims the
+              page behind it; the hero (a landing-page search box, not a modal)
+              stays transparent — Google-style — so it never dims the dashboard
+              or seams across the rail. Both close on outside click. */}
           <div
-            className="fixed left-0 right-0 bottom-0 z-[120] bg-black/25 dark:bg-black/55 backdrop-blur-[2px]"
+            className={clsx(
+              'fixed left-0 right-0 bottom-0 z-[120]',
+              !hero && 'bg-black/25 dark:bg-black/55 backdrop-blur-[2px]',
+            )}
             style={{ top: anchor.top }}
             onClick={() => { setOpen(false); inputRef.current?.blur() }}
           />

--- a/web/src/components/ui/Omnibar.tsx
+++ b/web/src/components/ui/Omnibar.tsx
@@ -110,6 +110,11 @@ export interface OmnibarProps {
    *  searching, handing the full (uncapped) query off to the host's dedicated
    *  search surface. Omit to keep the omnibar a pure launcher. */
   onViewAllResults?: (query: string) => void
+  /** Empty-launcher content. `true` (default) lists Views + Actions — the
+   *  cmd-K menu. `false` shows only Actions so recents/search lead and views
+   *  surface on type (use when the views are already always-visible, e.g. a
+   *  persistent nav rail). */
+  launcherShowsViews?: boolean
   placeholder?: string
   /** `hero` renders a large, centered field for landing surfaces (Home);
    *  `default` is the slim top-bar field. */
@@ -152,6 +157,7 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
     loadRecents,
     recordRecent,
     onViewAllResults,
+    launcherShowsViews = true,
     placeholder = 'Search resources & commands…',
     size = 'default',
     autoFocus = false,
@@ -206,15 +212,19 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
   useEffect(() => { onQueryChange?.(debounced, open) }, [debounced, open, onQueryChange])
 
   // Commands score against the FREE text only — modifiers live in pills, so the
-  // launcher never sees "ns:" polluting a "go to topology" match. Empty + no
-  // pills → Views + Actions (launcher default); with pills but no text the user
-  // is browsing a scope, so suppress the command default.
+  // launcher never sees "ns:" polluting a "go to topology" match. With pills but
+  // no text the user is browsing a scope, so suppress the command default. Empty
+  // + no pills → the launcher default: Views + Actions, or (when the host opts
+  // into a lean launcher) Actions only, so recents/search lead and the views
+  // surface on type instead of walling the dropdown.
   const scoredCommands = useMemo(() => {
     if (!freeText) {
-      return pills.length ? [] : commandItems.filter((i) => i.category === 'Views' || i.category === 'Actions').map((item) => ({ item, score: 1 }))
+      if (pills.length) return []
+      const cats = launcherShowsViews ? ['Views', 'Actions'] : ['Actions']
+      return commandItems.filter((i) => cats.includes(i.category)).map((item) => ({ item, score: 1 }))
     }
     return commandItems.map((item) => ({ item, score: bestScore(item, freeText) })).filter((x) => x.score > 0).sort((a, b) => b.score - a.score)
-  }, [commandItems, freeText, pills.length])
+  }, [commandItems, freeText, pills.length, launcherShowsViews])
 
   // Kinds whose NAME strongly matches (exact 150 / prefix 100) lead ABOVE the
   // resource instances.

--- a/web/src/components/ui/Omnibar.tsx
+++ b/web/src/components/ui/Omnibar.tsx
@@ -107,6 +107,11 @@ export interface OmnibarProps {
   loadRecents?: () => OmnibarRecent[]
   recordRecent?: (r: OmnibarRecent) => void
   placeholder?: string
+  /** `hero` renders a large, centered field for landing surfaces (Home);
+   *  `default` is the slim top-bar field. */
+  size?: 'default' | 'hero'
+  /** Focus the field on mount (Home hero — the primary action on the page). */
+  autoFocus?: boolean
 }
 
 type Row =
@@ -142,6 +147,8 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
     loadRecents,
     recordRecent,
     placeholder = 'Search resources & commands…',
+    size = 'default',
+    autoFocus = false,
   },
   ref,
 ) {
@@ -160,6 +167,13 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
   const [anchor, setAnchor] = useState<{ centerX: number; top: number } | null>(null)
 
   useImperativeHandle(ref, () => ({ focus: () => { inputRef.current?.focus(); inputRef.current?.select() } }), [])
+
+  // Hero autofocus parks the cursor in the field on mount (Home's primary
+  // action) but must NOT pop the dropdown — landing on the page shouldn't dim
+  // it behind a command palette. Suppress exactly the programmatic focus; a
+  // later user focus opens normally.
+  const skipFocusOpen = useRef(false)
+  useEffect(() => { if (autoFocus) { skipFocusOpen.current = true; inputRef.current?.focus() } }, [autoFocus])
 
   // Reflect the current view scope as an editable `ns:` pill on open, so a
   // deliberately broad ⌘K search shows (and lets you remove) the namespace it's
@@ -342,25 +356,30 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
 
   const clearNsPills = () => { setPills((prev) => prev.filter((p) => p.key !== 'ns')); inputRef.current?.focus() }
 
+  const hero = size === 'hero'
+
   return (
-    <div ref={containerRef} className="relative w-full max-w-xl">
+    <div ref={containerRef} className={hero ? 'relative w-full max-w-3xl' : 'relative w-full max-w-xl'}>
       <SearchPillInput
-        className="min-h-8 px-2.5 rounded-md bg-theme-elevated border border-transparent focus-within:border-theme-border focus-within:bg-theme-surface transition-colors"
+        className={hero
+          ? 'min-h-14 px-5 rounded-2xl bg-theme-surface border border-theme-border shadow-theme-sm transition-colors focus-within:border-[var(--color-brand-500)] focus-within:shadow-[0_0_0_4px_color-mix(in_srgb,var(--color-brand-500)_15%,transparent)]'
+          : 'min-h-8 px-2.5 rounded-md bg-theme-elevated border border-transparent focus-within:border-theme-border focus-within:bg-theme-surface transition-colors'}
+        inputClassName={hero ? 'text-lg py-4' : undefined}
         text={text}
         pills={pills}
         onChange={({ text: t, pills: p }) => { setText(t); setPills(p); setOpen(true) }}
         onKeyDown={handleKeyDown}
-        onFocus={() => setOpen(true)}
+        onFocus={() => { if (skipFocusOpen.current) { skipFocusOpen.current = false; return } setOpen(true) }}
         onSuggestingChange={setSuggesting}
         modifierOptions={modifierOptions}
         placeholder={placeholder}
         aria-label="Search resources and commands"
         inputRef={inputRef}
-        leftSlot={<Search className="w-3.5 h-3.5 shrink-0 text-theme-text-tertiary" />}
+        leftSlot={<Search className={hero ? 'w-5 h-5 shrink-0 text-theme-text-tertiary' : 'w-3.5 h-3.5 shrink-0 text-theme-text-tertiary'} />}
         rightSlot={
           <div className="flex items-center gap-1.5 shrink-0">
             <SearchSyntaxHelp />
-            {!text && pills.length === 0 && (
+            {!hero && !text && pills.length === 0 && (
               <kbd className="text-[10px] text-theme-text-tertiary bg-theme-surface px-1 py-0.5 rounded border border-theme-border-light">
                 {mac ? '⌘' : 'Ctrl+'}K
               </kbd>

--- a/web/src/components/ui/Omnibar.tsx
+++ b/web/src/components/ui/Omnibar.tsx
@@ -106,6 +106,10 @@ export interface OmnibarProps {
   /** Recently-viewed resources for the empty launcher (host owns storage). */
   loadRecents?: () => OmnibarRecent[]
   recordRecent?: (r: OmnibarRecent) => void
+  /** When set, a "See all N results" row appears below the resource hits while
+   *  searching, handing the full (uncapped) query off to the host's dedicated
+   *  search surface. Omit to keep the omnibar a pure launcher. */
+  onViewAllResults?: (query: string) => void
   placeholder?: string
   /** `hero` renders a large, centered field for landing surfaces (Home);
    *  `default` is the slim top-bar field. */
@@ -117,6 +121,7 @@ export interface OmnibarProps {
 type Row =
   | { id: string; kind: 'resource'; hit: SearchHit; recent?: boolean }
   | { id: string; kind: 'command'; command: CommandItem }
+  | { id: string; kind: 'viewAll'; query: string; count: number }
 
 const COMMAND_CATEGORY_ORDER = ['Views', 'Resource Kinds', 'Namespaces', 'Clusters', 'Actions']
 const PAGE = 8
@@ -146,6 +151,7 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
     seedNamespaces,
     loadRecents,
     recordRecent,
+    onViewAllResults,
     placeholder = 'Search resources & commands…',
     size = 'default',
     autoFocus = false,
@@ -251,9 +257,16 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
   const rows = useMemo<Row[]>(() => {
     const cmds: Row[] = commandGroups.flatMap((g) => g.items.map(toCmdRow))
     if (!freeText && pills.length === 0) return [...recentRows, ...cmds]
-    return [...leadingKinds.map(toCmdRow), ...(searchActive ? resourceRows : []), ...cmds]
+    const out: Row[] = [...leadingKinds.map(toCmdRow), ...(searchActive ? resourceRows : []), ...cmds]
+    // "See all results" tails the list when the host wired a full-search surface
+    // and there's something to expand to.
+    if (onViewAllResults && searchActive && resourceRows.length > 0) {
+      out.push({ id: 'view-all', kind: 'viewAll', query: queryString, count: searchData?.total_matched ?? resourceRows.length })
+    }
+    return out
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [recentRows, leadingKinds, resourceRows, commandGroups, freeText, pills.length, searchActive])
+  }, [recentRows, leadingKinds, resourceRows, commandGroups, freeText, pills.length, searchActive, onViewAllResults, queryString, searchData])
+  const viewAllRow = rows.find((r): r is Extract<Row, { kind: 'viewAll' }> => r.kind === 'viewAll')
 
   // Selection tracked by stable id (not array index) so Enter can never fire a
   // stale row when the set shifts. Auto-follows the TOP result until the user
@@ -286,6 +299,8 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
   const execute = useCallback((row: Row) => {
     if (row.kind === 'command') {
       row.command.action()
+    } else if (row.kind === 'viewAll') {
+      onViewAllResults?.(row.query)
     } else {
       const h = row.hit
       recordRecent?.({ kind: h.kind, group: h.group, namespace: h.namespace, name: h.name })
@@ -295,7 +310,7 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
     setText('')
     setPills([])
     inputRef.current?.blur()
-  }, [onOpenResource, recordRecent])
+  }, [onOpenResource, recordRecent, onViewAllResults])
 
   // The resources shown don't (yet) belong to the current query: the debounce
   // hasn't fired, the data is React Query placeholder, or results haven't landed.
@@ -458,6 +473,20 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
                 })}
               </div>
             ))}
+
+            {viewAllRow && (
+              <button
+                type="button"
+                data-selected={viewAllRow.id === selectedId}
+                onMouseEnter={() => selectRow(viewAllRow.id)}
+                onMouseDown={(e) => { e.preventDefault(); execute(viewAllRow) }}
+                className={clsx('w-full flex items-center gap-2.5 px-3 py-1.5 mt-1 text-left border-t border-theme-border transition-colors', viewAllRow.id === selectedId ? 'selection' : 'hover:bg-theme-elevated/40')}
+              >
+                <Search className="w-4 h-4 shrink-0 text-theme-text-tertiary" />
+                <span className="text-sm text-[var(--color-brand)]">See all {viewAllRow.count} result{viewAllRow.count === 1 ? '' : 's'}</span>
+                <CornerDownLeft className="w-3 h-3 ml-auto shrink-0 text-theme-text-tertiary" />
+              </button>
+            )}
           </div>
           <div className="flex items-center gap-3 px-3 py-1.5 border-t border-theme-border text-[11px] text-theme-text-tertiary">
             <span className="flex items-center gap-1"><CornerDownLeft className="w-3 h-3" /> open</span>

--- a/web/src/components/ui/RadarOmnibar.tsx
+++ b/web/src/components/ui/RadarOmnibar.tsx
@@ -1,0 +1,52 @@
+import { forwardRef, useMemo, useState } from 'react'
+import { Omnibar, type OmnibarHandle } from './Omnibar'
+import { useSearch, useNamespaceScope, useContexts, type SearchHit } from '../../api/client'
+import { useAPIResources } from '../../api/apiResources'
+import { loadRecentResources, recordRecentResource } from '../../hooks/useRecentResources'
+import { useCommandItems, type CommandItemCallbacks } from './command-items'
+
+interface RadarOmnibarProps extends CommandItemCallbacks {
+  onOpenResource: (hit: SearchHit) => void
+}
+
+// Radar standalone's omnibar: wires the injectable Omnibar to Radar's own hooks
+// (cluster /api/search, kubeconfig contexts, API discovery, recents). Radar Hub
+// provides a parallel wrapper over fleet search.
+export const RadarOmnibar = forwardRef<OmnibarHandle, RadarOmnibarProps>(function RadarOmnibar(
+  { onOpenResource, ...callbacks },
+  ref,
+) {
+  // The omnibar debounces internally and emits the query to search here.
+  const [query, setQuery] = useState('')
+  const [open, setOpen] = useState(false)
+
+  const { data: searchData, isFetching, isPlaceholderData, isError } = useSearch(query, { enabled: open, globalNs: true })
+  const { data: nsScope } = useNamespaceScope()
+  const { data: apiResources } = useAPIResources()
+  const { data: contexts } = useContexts()
+  const contextKey = useMemo(() => contexts?.find((c) => c.isCurrent)?.name ?? '', [contexts])
+
+  const modifierOptions = useMemo(() => ({
+    ns: nsScope?.accessibleNamespaces ?? [],
+    kind: apiResources ? [...new Set(apiResources.filter((r) => r.verbs?.includes('list')).map((r) => r.kind))].sort() : [],
+  }), [nsScope, apiResources])
+
+  const commandItems = useCommandItems(callbacks)
+
+  return (
+    <Omnibar
+      ref={ref}
+      onOpenResource={onOpenResource}
+      commandItems={commandItems}
+      onQueryChange={(q, o) => { setQuery(q); setOpen(o) }}
+      searchData={searchData}
+      isFetching={isFetching}
+      isError={isError}
+      isPlaceholderData={isPlaceholderData}
+      modifierOptions={modifierOptions}
+      seedNamespaces={nsScope?.actives}
+      loadRecents={() => loadRecentResources(contextKey)}
+      recordRecent={(r) => recordRecentResource(r, contextKey)}
+    />
+  )
+})

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -31,3 +31,18 @@ export type { ClusterSwitcherProps, ClusterSwitcherItem } from '@skyhook-io/k8s-
 // cluster prefix (e.g. /c/:id).
 export { resourcePath, buildWorkloadPath } from './utils/navigation';
 export type { SelectedResource } from '@skyhook-io/k8s-ui/types/core';
+
+// Injectable omnibar — the standalone search/command surface, decoupled from
+// Radar's own data hooks so embedders (Radar Hub) can drive it with fleet
+// search + their own command items while sharing the exact UX (pills, modifier
+// autocomplete, kind-first ranking, match highlighting, keyboard nav, recents).
+export { Omnibar } from './components/ui/Omnibar';
+export type {
+  OmnibarProps,
+  OmnibarHandle,
+  OmnibarRecent,
+  OmnibarSearchResult,
+} from './components/ui/Omnibar';
+export { bestScore } from './components/ui/command-items';
+export type { CommandItem } from './components/ui/command-items';
+export type { SearchHit, SearchMatchedField } from './api/client';


### PR DESCRIPTION
## Summary

Radar Cloud (Radar Hub) needs **one unified search/command surface** — across the whole fleet and inside a single cluster — that shares the *exact* UX with standalone Radar. This PR makes Radar's `Omnibar` **injectable** and exports it from `@skyhook-io/radar-app`, adds the affordances an embedder's landing hero + launcher need (hero size, a search-page handoff, a lean launcher, a content-only scrim, no-auto-select), and fixes the resource-drawer anchoring in chromeless embeds. **Standalone Radar's omnibar behavior is unchanged** — it now consumes the same component through a thin wrapper.

## What changed

### Injectable Omnibar (the core)
- **`Omnibar.tsx`** is decoupled from Radar's data hooks — search results, command items, recents, and modifier options all flow in via props (`onOpenResource`, `commandItems`, `onQueryChange`, `searchData`, `loadRecents`/`recordRecent`, `modifierOptions`, `seedNamespaces`). The component owns only presentation + interaction.
- **`RadarOmnibar.tsx`** (new) is the standalone wrapper: it wires Radar's own hooks (`useSearch`, `useNamespaceScope`, `useContexts`, `useAPIResources`, `useCommandItems`, recents) into the injectable `Omnibar`. `App.tsx` renders `RadarOmnibar` — behavior-preserving refactor.
- **`index.ts`** exports `Omnibar` + `OmnibarHandle`, `OmnibarProps`, `CommandItem`, `bestScore`, `SearchHit`, `SearchMatchedField`.

### Embedder-facing affordances
- **Cross-cluster hit identity** — `SearchHit` gains optional `cluster` / `clusterName` (`api/client.ts`) so an embedder can keep rows unique across clusters and label which cluster a hit is in (omitted when scoped to one).
- **Hero size** — `size="hero"` + `autoFocus` render a large landing-surface field; `SearchPillInput` gains an `inputClassName` escape hatch (`@skyhook-io/k8s-ui`) so the input text scales.
- **Search-page handoff** — `onViewAllResults` adds a "See all N results" row and, **by default, no pre-selected row**: Enter on an untouched query goes to the host's full search page with the query instead of firing a maybe-wrong top hit. Arrow/hover to opt into a specific result (footer hint flips `search all` ↔ `open`). Hosts that don't wire a search page keep auto-follow-top.
- **Lean launcher** — `launcherShowsViews` (default `true`) lets a host whose views are already always-visible (a persistent nav rail) show only Actions (+ recents) in the empty launcher, surfacing views on type.
- **Content-only scrim** — the dropdown separates from the page with a `z-15` spotlight that dims + blurs the content while leaving nav chrome lit, consistently in both the hero and the slim launcher (an anchored omnibar reads better with a content spotlight than the full-screen dim a *centered* command palette uses). The hero box is lifted above the scrim; the launcher opens on click even when the field is already focused.

### Chromeless embed
- **Resource-drawer anchor** — in `chrome:'none'` embeds the detail drawer now anchors to the content top (`headerHeight={chromeless ? 0 : undefined}` in `App.tsx` + `ResourceDetailDrawer.tsx`) instead of leaving a gap under a Radar top bar that isn't there.

## Backwards-compat
Standalone Radar is behavior-preserving: `RadarOmnibar` feeds the same data the old inline omnibar did; `launcherShowsViews` defaults true; with no `onViewAllResults` the omnibar keeps auto-follow-top. All new exports + props are additive. Per the library-distribution rules, this is a **minor** bump for `radar-app` (additive surface) and `k8s-ui` (additive `inputClassName`).

## Testing
`make tsc` green. Verified the injectable `Omnibar` both as standalone Radar (`RadarOmnibar`) and embedded in Radar Hub — Home hero, fleet + cluster top bars, scoped vs fleet-wide search + cluster labels, no-auto-select → Enter-to-search vs arrow-to-open, the content scrim (chrome lit, content dimmed, no seam, dark mode), and the chromeless resource-drawer anchor — against a local hub and prod. Screenshots in radar-hub-web#114.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large refactor of a primary navigation surface (keyboard, Enter, selection, scrim) with additive API; standalone path is preserved via RadarOmnibar but embedder wiring mistakes could affect search UX.
> 
> **Overview**
> Makes Radar’s **Omnibar** a host-driven search/command surface: search, commands, recents, and modifier options arrive via props, and **`RadarOmnibar`** wires standalone Radar’s existing hooks so OSS behavior stays the same. **`@skyhook-io/radar-app`** now exports `Omnibar`, related types, and `CommandItem` / `bestScore` for Radar Hub–style fleet search.
> 
> **Embedder UX:** optional `cluster` / `clusterName` on `SearchHit`; hero sizing (`size`, `autoFocus`, `inputClassName` on `SearchPillInput`); `onViewAllResults` with Enter-to-full-search when nothing is selected; `launcherShowsViews` for nav-rail layouts; content-only scrim (nav stays visible); pill collapse for many `ns:` filters.
> 
> **Chromeless embeds:** resource drawer uses `headerHeight={0}`; ⌘K and `?` shortcuts no-op so the host omnibar/help don’t double-fire.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cacdad6a3a4ff3be710ac7c5ff547f3b5f46c47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->