### PR TITLE
fix(cron): correct step-hour pattern in cronToHuman

### DIFF
--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -1127,6 +1127,10 @@ export function cronToHuman(cron: string): string {
   if (minute === '0' && hour === '0' && dayOfMonth === '*' && month === '*' && dayOfWeek === '*') {
     return 'Daily at midnight'
   }
+  if (minute === '0' && hour.startsWith('*/') && dayOfMonth === '*' && month === '*' && dayOfWeek === '*') {
+    const interval = hour.slice(2)
+    return interval === '1' ? 'Every hour' : `Every ${interval} hours`
+  }
   if (minute === '0' && hour !== '*' && dayOfMonth === '*' && month === '*' && dayOfWeek === '*') {
     return `Daily at ${hour}:00`
   }


### PR DESCRIPTION
## Description

fix a bug where step-cron expression like 0 */6 * * * was getting displayed as "Daily at /6:00" instead of "Every 6 hours"

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

Describe the tests you ran to verify your changes.

- [ ] Tested locally with minikube/kind
- [x] Tested against a remote cluster
- [ ] Added/updated unit tests

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged

## Related issues
This issue has not yet been reported.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small display-only change in cron string formatting with no API or scheduling behavior impact.
> 
> **Overview**
> Fixes **CronJob schedule labels** for hour-step crons (e.g. `0 */6 * * *`) that were shown as **"Daily at /6:00"** instead of a readable interval.
> 
> `cronToHuman` in `resource-utils.ts` now recognizes `minute === '0'` with `hour` like `*/N` (and `* * *` for day/month/weekday) **before** the generic “daily at hour” rule, returning **"Every hour"** for `*/1` or **"Every N hours"** otherwise. This affects CronJob table readable schedules and the CronJob drawer “Human” field via `getCronJobSchedule` / `cronToHuman`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37335ae2913c0e53ec096bb7fd30d640b26dfb78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->