### PR TITLE
Timeline: hide-deletes toggle + GitOps empty-state polish

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2375,6 +2375,7 @@ func (s *Server) handleChanges(w http.ResponseWriter, r *http.Request) {
 	filterPreset := r.URL.Query().Get("filter")
 	includeK8sEvents := r.URL.Query().Get("include_k8s_events") != "false" // default true
 	includeManaged := r.URL.Query().Get("include_managed") == "true"       // default false
+	includeDeleted := r.URL.Query().Get("include_deleted") != "false"      // default true
 	sourcesParam := r.URL.Query().Get("sources")                           // comma-separated, e.g. "k8s_event"
 
 	// Parse since timestamp
@@ -2410,6 +2411,7 @@ func (s *Server) handleChanges(w http.ResponseWriter, r *http.Request) {
 		Since:            since,
 		Limit:            limit,
 		IncludeManaged:   includeManaged,
+		ExcludeDeleted:   !includeDeleted,
 		IncludeK8sEvents: includeK8sEvents,
 		FilterPreset:     filterPreset,
 		// The persistent store retains events from previously-connected

--- a/internal/timeline/sqlite_store.go
+++ b/internal/timeline/sqlite_store.go
@@ -350,6 +350,13 @@ func (s *SQLiteStore) Query(ctx context.Context, opts QueryOptions) ([]TimelineE
 		query.WriteString(")")
 	}
 
+	// Filter deletes in SQL (before ORDER/LIMIT) so hiding them can't under-fill
+	// the page when the newest rows happen to be deletes.
+	if opts.ExcludeDeleted {
+		query.WriteString(" AND event_type != ?")
+		args = append(args, string(EventTypeDelete))
+	}
+
 	if opts.ClusterContext != "" {
 		query.WriteString(" AND cluster_context = ?")
 		args = append(args, opts.ClusterContext)

--- a/internal/timeline/sqlite_store_test.go
+++ b/internal/timeline/sqlite_store_test.go
@@ -244,6 +244,89 @@ func TestSQLiteStore_Query_IncludeManaged(t *testing.T) {
 	}
 }
 
+func TestSQLiteStore_Query_DeletedFiltering(t *testing.T) {
+	store, cleanup := createTestSQLiteStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := time.Now()
+
+	events := []TimelineEvent{
+		{ID: "deploy-add", Timestamp: now, Kind: "Deployment", Namespace: "default", Name: "deploy-1", EventType: EventTypeAdd, Source: SourceInformer},
+		{ID: "deploy-delete", Timestamp: now.Add(time.Second), Kind: "Deployment", Namespace: "default", Name: "deploy-2", EventType: EventTypeDelete, Source: SourceInformer},
+		{
+			ID: "pod-delete", Timestamp: now.Add(2 * time.Second), Kind: "Pod", Namespace: "default", Name: "pod-1",
+			EventType: EventTypeDelete, Source: SourceInformer,
+			Owner: &OwnerInfo{Kind: "ReplicaSet", Name: "deploy-1-abc"},
+		},
+	}
+	_ = store.AppendBatch(ctx, events)
+
+	// Default: top-level deletes show, managed (Pod) deletes do not — they follow IncludeManaged.
+	result, err := store.Query(ctx, QueryOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("Expected Deployment add + Deployment delete, got %d: %+v", len(result), result)
+	}
+	if result[0].ID != "deploy-delete" || result[1].ID != "deploy-add" {
+		t.Fatalf("unexpected result order: %+v", result)
+	}
+
+	// ExcludeDeleted drops the top-level delete too.
+	result, err = store.Query(ctx, QueryOptions{Limit: 10, ExcludeDeleted: true})
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+	if len(result) != 1 || result[0].ID != "deploy-add" {
+		t.Fatalf("Expected only Deployment add with ExcludeDeleted, got %+v", result)
+	}
+
+	// IncludeManaged surfaces the managed Pod delete alongside the rest.
+	result, err = store.Query(ctx, QueryOptions{Limit: 10, IncludeManaged: true})
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+	if len(result) != 3 {
+		t.Fatalf("Expected all 3 events with IncludeManaged, got %d: %+v", len(result), result)
+	}
+}
+
+func TestSQLiteStore_Query_ExcludeDeleted_LimitSkew(t *testing.T) {
+	store, cleanup := createTestSQLiteStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := time.Now()
+
+	// Two older non-delete events, then three newer deletes. With ExcludeDeleted
+	// applied after a SQL LIMIT, the newest rows (all deletes) would consume the
+	// page and the result would come back empty; filtering in SQL must still
+	// surface the older non-delete events.
+	events := []TimelineEvent{
+		{ID: "svc-add", Timestamp: now, Kind: "Service", Namespace: "default", Name: "svc-1", EventType: EventTypeAdd, Source: SourceInformer},
+		{ID: "deploy-add", Timestamp: now.Add(time.Second), Kind: "Deployment", Namespace: "default", Name: "deploy-1", EventType: EventTypeAdd, Source: SourceInformer},
+		{ID: "del-1", Timestamp: now.Add(2 * time.Second), Kind: "Deployment", Namespace: "default", Name: "d-a", EventType: EventTypeDelete, Source: SourceInformer},
+		{ID: "del-2", Timestamp: now.Add(3 * time.Second), Kind: "Deployment", Namespace: "default", Name: "d-b", EventType: EventTypeDelete, Source: SourceInformer},
+		{ID: "del-3", Timestamp: now.Add(4 * time.Second), Kind: "Deployment", Namespace: "default", Name: "d-c", EventType: EventTypeDelete, Source: SourceInformer},
+	}
+	_ = store.AppendBatch(ctx, events)
+
+	result, err := store.Query(ctx, QueryOptions{Limit: 2, ExcludeDeleted: true})
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("Expected 2 non-delete events despite newer deletes, got %d: %+v", len(result), result)
+	}
+	for _, e := range result {
+		if e.EventType == EventTypeDelete {
+			t.Fatalf("ExcludeDeleted returned a delete event: %+v", e)
+		}
+	}
+}
+
 func TestSQLiteStore_GroupByOwner(t *testing.T) {
 	store, cleanup := createTestSQLiteStore(t)
 	defer cleanup()

--- a/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
@@ -217,8 +217,11 @@ export interface GitOpsTableViewProps {
   searchHotkey?: boolean
   // emptyStateTitle / emptyStateBody override the "No GitOps resources
   // detected" copy. Hub passes "No GitOps resources across the fleet".
-  emptyStateTitle?: string
-  emptyStateBody?: string
+  // ReactNode (not just string) so a host can split the body across lines
+  // (e.g. a `<br/>` between "what's wrong" and "what to do") or emphasize
+  // part of it. Strings still work unchanged.
+  emptyStateTitle?: ReactNode
+  emptyStateBody?: ReactNode
   /**
    * Which side the filter rail sits on. Default 'left' (OSS Radar, which
    * has no app sidebar). A host with its own left navigation rail (the
@@ -483,7 +486,7 @@ export function GitOpsTableView({
   // be hidden behind a "nothing here" screen.
   if (totalGitOps === 0 && allRowsInput.length === 0 && !loading && !hasGlobalNamespaceFilter) {
     return (
-      <div className="flex h-full min-h-0 flex-1 items-center justify-center bg-theme-base p-4">
+      <div className="flex h-full min-h-0 flex-1 items-start justify-center bg-theme-base px-4 pb-4 pt-[22vh]">
         <div className="rounded-lg border border-theme-border bg-theme-surface p-8 text-center">
           <GitBranch className="mx-auto h-8 w-8 text-theme-text-tertiary" />
           <h2 className="mt-3 text-base font-semibold text-theme-text-primary">

--- a/packages/k8s-ui/src/components/timeline/TimelineList.tsx
+++ b/packages/k8s-ui/src/components/timeline/TimelineList.tsx
@@ -45,7 +45,7 @@ export interface TimelineListProps {
   events: TimelineEvent[]
   isLoading: boolean
   onRefresh?: () => void
-  onQueryChange?: (params: { timeRange: TimeRange; kind?: string }) => void
+  onQueryChange?: (params: { timeRange: TimeRange; kind?: string; includeDeleted: boolean }) => void
   hasLimitedAccess?: boolean
   namespaces?: string[]
   onViewChange?: (view: 'list' | 'swimlane') => void
@@ -85,11 +85,12 @@ export function TimelineList({ events, isLoading, onRefresh, onQueryChange, hasL
   const [activityTypeFilter, setActivityTypeFilter] = useState<ActivityTypeFilter>(initialFilter ?? 'all')
   const [timeRange, setTimeRange] = useState<TimeRange>(initialTimeRange ?? '1h')
   const [kindFilter, setKindFilter] = useState<string>('')
+  const [showDeleted, setShowDeleted] = useState(true)
   const [expandedItem, setExpandedItem] = useState<string | null>(null)
 
   useEffect(() => {
-    onQueryChange?.({ timeRange, kind: kindFilter || undefined })
-  }, [timeRange, kindFilter, onQueryChange])
+    onQueryChange?.({ timeRange, kind: kindFilter || undefined, includeDeleted: showDeleted })
+  }, [timeRange, kindFilter, showDeleted, onQueryChange])
 
 
   const [handleRefresh, isRefreshAnimating] = useRefreshAnimation(onRefresh ?? (() => {}))
@@ -111,6 +112,7 @@ export function TimelineList({ events, isLoading, onRefresh, onQueryChange, hasL
         const isUnhealthyChange = isChangeEvent(item) && (item.healthState === 'unhealthy' || item.healthState === 'degraded')
         if (!isUnhealthyChange) return false
       }
+      if (!showDeleted && item.eventType === 'delete') return false
 
       // Filter by search term
       if (searchTerm) {
@@ -129,7 +131,7 @@ export function TimelineList({ events, isLoading, onRefresh, onQueryChange, hasL
 
       return true
     })
-  }, [events, activityTypeFilter, searchTerm])
+  }, [events, activityTypeFilter, searchTerm, showDeleted])
 
   // Aggregated event group type
   type AggregatedItem = {
@@ -245,12 +247,13 @@ export function TimelineList({ events, isLoading, onRefresh, onQueryChange, hasL
 
   // Count stats
   const stats = useMemo(() => {
-    if (!events) return { total: 0, changes: 0, warnings: 0, unhealthy: 0 }
+    if (!events) return { total: 0, changes: 0, warnings: 0, unhealthy: 0, deleted: 0 }
     return {
       total: events.length,
       changes: events.filter((e) => isChangeEvent(e)).length,
       warnings: events.filter((e) => e.eventType === 'Warning').length,
       unhealthy: events.filter((e) => isChangeEvent(e) && (e.healthState === 'unhealthy' || e.healthState === 'degraded')).length,
+      deleted: events.filter((e) => e.eventType === 'delete').length,
     }
   }, [events])
 
@@ -305,6 +308,24 @@ export function TimelineList({ events, isLoading, onRefresh, onQueryChange, hasL
             tooltip="All native Kubernetes events (Normal + Warning types)"
           />
         </div>
+
+        <button
+          type="button"
+          onClick={() => setShowDeleted((v) => !v)}
+          title="Show or hide resources that were deleted, including Pods that no longer exist"
+          className={clsx(
+            'px-3 py-1.5 text-sm rounded-md transition-colors flex items-center gap-2 bg-theme-elevated',
+            showDeleted ? 'text-theme-text-primary' : 'text-theme-text-secondary hover:text-theme-text-primary'
+          )}
+        >
+          <Trash2 className="w-3 h-3" />
+          Deleted
+          {stats.deleted > 0 && (
+            <span className="text-xs px-1.5 rounded bg-theme-hover/50">
+              {stats.deleted}
+            </span>
+          )}
+        </button>
 
         {/* Kind filter */}
         <select

--- a/packages/k8s-ui/src/components/timeline/TimelineList.tsx
+++ b/packages/k8s-ui/src/components/timeline/TimelineList.tsx
@@ -45,7 +45,7 @@ export interface TimelineListProps {
   events: TimelineEvent[]
   isLoading: boolean
   onRefresh?: () => void
-  onQueryChange?: (params: { timeRange: TimeRange; kind?: string; includeDeleted: boolean }) => void
+  onQueryChange?: (params: { timeRange: TimeRange; kind?: string }) => void
   hasLimitedAccess?: boolean
   namespaces?: string[]
   onViewChange?: (view: 'list' | 'swimlane') => void
@@ -53,6 +53,11 @@ export interface TimelineListProps {
   onResourceClick?: NavigateToResource
   initialFilter?: ActivityTypeFilter
   initialTimeRange?: TimeRange
+  // Controlled "show deleted" toggle. When omitted the component manages it
+  // internally; the host passes it to share one toggle across list + swimlane
+  // and to drive server-side delete filtering.
+  showDeleted?: boolean
+  onShowDeletedChange?: (showDeleted: boolean) => void
 }
 
 const TIME_RANGES: { value: TimeRange; label: string }[] = [
@@ -80,17 +85,19 @@ const RESOURCE_KINDS = [
   'StatefulSet',
 ]
 
-export function TimelineList({ events, isLoading, onRefresh, onQueryChange, hasLimitedAccess, namespaces, onViewChange, currentView = 'list', onResourceClick, initialFilter, initialTimeRange }: TimelineListProps) {
+export function TimelineList({ events, isLoading, onRefresh, onQueryChange, hasLimitedAccess, namespaces, onViewChange, currentView = 'list', onResourceClick, initialFilter, initialTimeRange, showDeleted: showDeletedProp, onShowDeletedChange }: TimelineListProps) {
   const [searchTerm, setSearchTerm] = useState('')
   const [activityTypeFilter, setActivityTypeFilter] = useState<ActivityTypeFilter>(initialFilter ?? 'all')
   const [timeRange, setTimeRange] = useState<TimeRange>(initialTimeRange ?? '1h')
   const [kindFilter, setKindFilter] = useState<string>('')
-  const [showDeleted, setShowDeleted] = useState(true)
+  const [showDeletedInternal, setShowDeletedInternal] = useState(true)
+  const showDeleted = showDeletedProp ?? showDeletedInternal
+  const setShowDeleted = onShowDeletedChange ?? setShowDeletedInternal
   const [expandedItem, setExpandedItem] = useState<string | null>(null)
 
   useEffect(() => {
-    onQueryChange?.({ timeRange, kind: kindFilter || undefined, includeDeleted: showDeleted })
-  }, [timeRange, kindFilter, showDeleted, onQueryChange])
+    onQueryChange?.({ timeRange, kind: kindFilter || undefined })
+  }, [timeRange, kindFilter, onQueryChange])
 
 
   const [handleRefresh, isRefreshAnimating] = useRefreshAnimation(onRefresh ?? (() => {}))
@@ -311,7 +318,7 @@ export function TimelineList({ events, isLoading, onRefresh, onQueryChange, hasL
 
         <button
           type="button"
-          onClick={() => setShowDeleted((v) => !v)}
+          onClick={() => setShowDeleted(!showDeleted)}
           title="Show or hide resources that were deleted, including Pods that no longer exist"
           className={clsx(
             'px-3 py-1.5 text-sm rounded-md transition-colors flex items-center gap-2 bg-theme-elevated',

--- a/packages/k8s-ui/src/components/timeline/TimelineSwimlanes.tsx
+++ b/packages/k8s-ui/src/components/timeline/TimelineSwimlanes.tsx
@@ -21,6 +21,7 @@ import {
   Timer,
   RotateCcw,
   Shield,
+  Trash2,
 } from 'lucide-react'
 import type { TimelineEvent, Topology } from '../../types'
 import type { NavigateToResource } from '../../utils/navigation'
@@ -203,6 +204,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
   const [expandedLanes, setExpandedLanes] = useState<Set<string>>(new Set())
   const [hasAutoZoomed, setHasAutoZoomed] = useState(false)
   const [groupByApp, setGroupByApp] = useState(true) // Group by app.kubernetes.io/name label
+  const [showDeleted, setShowDeleted] = useState(true)
 
   // Stable lane ordering - use ref to avoid render loop (lanes depends on order, order depends on lanes)
   const laneOrderRef = useRef<Map<string, number>>(new Map())
@@ -253,17 +255,18 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
 
   // Filter events by search term
   const filteredEvents = useMemo(() => {
-    if (!searchTerm) return events
+    const baseEvents = showDeleted ? events : events.filter(e => e.eventType !== 'delete')
+    if (!searchTerm) return baseEvents
 
     const term = searchTerm.toLowerCase()
-    return events.filter(e =>
+    return baseEvents.filter(e =>
       e.name.toLowerCase().includes(term) ||
       e.kind.toLowerCase().includes(term) ||
       e.namespace?.toLowerCase().includes(term) ||
       e.reason?.toLowerCase().includes(term) ||
       e.message?.toLowerCase().includes(term)
     )
-  }, [events, searchTerm])
+  }, [events, searchTerm, showDeleted])
 
   // Build hierarchical lanes using owner references + topology edges
   // Uses the shared utility from utils/resource-hierarchy.ts
@@ -512,6 +515,18 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
                   className="w-3.5 h-3.5 rounded border-theme-border-light bg-theme-elevated text-accent focus:ring-accent focus:ring-offset-0"
                 />
                 <span className="border-b border-dotted border-theme-text-tertiary">Group by app</span>
+              </label>
+            </Tooltip>
+            <Tooltip content="Show resources Radar observed being deleted, including Pods that no longer exist" position="bottom">
+              <label className="flex items-center gap-1.5 text-xs text-theme-text-secondary hover:text-theme-text-primary">
+                <input
+                  type="checkbox"
+                  checked={showDeleted}
+                  onChange={(e) => setShowDeleted(e.target.checked)}
+                  className="w-3.5 h-3.5 rounded border-theme-border-light bg-theme-elevated text-accent focus:ring-accent focus:ring-offset-0"
+                />
+                <Trash2 className="w-3.5 h-3.5" />
+                <span className="border-b border-dotted border-theme-text-tertiary">Deleted</span>
               </label>
             </Tooltip>
             {/* View toggle */}

--- a/packages/k8s-ui/src/components/timeline/TimelineSwimlanes.tsx
+++ b/packages/k8s-ui/src/components/timeline/TimelineSwimlanes.tsx
@@ -58,6 +58,11 @@ export interface TimelineSwimlanesProps {
   // navigate (radar router push, or cross-route-tree href). When omitted, GitOps lanes
   // fall back to onResourceClick (the resource drawer).
   onNavigatePath?: (path: string) => void
+  // Controlled "show deleted" toggle. When omitted the component manages it
+  // internally; the host passes it to share one toggle with the list view and
+  // to drive server-side delete filtering on the underlying fetch.
+  showDeleted?: boolean
+  onShowDeletedChange?: (showDeleted: boolean) => void
 }
 
 interface ResourceLane extends BaseResourceLane {
@@ -181,7 +186,7 @@ function calculateInterestingnessWithBreakdown(lane: ResourceLane): ScoreBreakdo
   return breakdown
 }
 
-export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode, onViewModeChange, topology, namespaces, hasLimitedAccess = false, onNavigatePath }: TimelineSwimlanesProps) {
+export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode, onViewModeChange, topology, namespaces, hasLimitedAccess = false, onNavigatePath, showDeleted: showDeletedProp, onShowDeletedChange }: TimelineSwimlanesProps) {
   // Timeline lane labels for GitOps CRs (Application/Kustomization/HelmRelease)
   // deep-link to GitOps detail rather than the resource drawer — the lane is
   // already telling the user "this controller had changes/events"; the GitOps
@@ -204,7 +209,9 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
   const [expandedLanes, setExpandedLanes] = useState<Set<string>>(new Set())
   const [hasAutoZoomed, setHasAutoZoomed] = useState(false)
   const [groupByApp, setGroupByApp] = useState(true) // Group by app.kubernetes.io/name label
-  const [showDeleted, setShowDeleted] = useState(true)
+  const [showDeletedInternal, setShowDeletedInternal] = useState(true)
+  const showDeleted = showDeletedProp ?? showDeletedInternal
+  const setShowDeleted = onShowDeletedChange ?? setShowDeletedInternal
 
   // Stable lane ordering - use ref to avoid render loop (lanes depends on order, order depends on lanes)
   const laneOrderRef = useRef<Map<string, number>>(new Map())

--- a/pkg/timeline/memory_store.go
+++ b/pkg/timeline/memory_store.go
@@ -334,6 +334,10 @@ func (m *MemoryStore) matchesFilters(event *TimelineEvent, opts QueryOptions, cf
 		}
 	}
 
+	if opts.ExcludeDeleted && event.EventType == EventTypeDelete {
+		return false
+	}
+
 	// Handle IncludeManaged
 	// If opts.IncludeManaged is true, it overrides the preset's IncludeManaged setting
 	// This allows queries to explicitly request managed resources even with "default" preset

--- a/pkg/timeline/memory_store_test.go
+++ b/pkg/timeline/memory_store_test.go
@@ -421,6 +421,53 @@ func TestMemoryStore_IncludeManaged(t *testing.T) {
 	}
 }
 
+func TestMemoryStore_DeletedFiltering(t *testing.T) {
+	store := NewMemoryStore(100)
+	ctx := context.Background()
+	now := time.Now()
+
+	events := []TimelineEvent{
+		{ID: "deploy-add", Timestamp: now, Kind: "Deployment", Namespace: "default", Name: "deploy-1", EventType: EventTypeAdd, Source: SourceInformer},
+		{ID: "deploy-delete", Timestamp: now.Add(time.Second), Kind: "Deployment", Namespace: "default", Name: "deploy-2", EventType: EventTypeDelete, Source: SourceInformer},
+		{
+			ID: "pod-delete", Timestamp: now.Add(2 * time.Second), Kind: "Pod", Namespace: "default", Name: "pod-1",
+			EventType: EventTypeDelete, Source: SourceInformer,
+			Owner: &OwnerInfo{Kind: "ReplicaSet", Name: "deploy-1-abc"},
+		},
+	}
+	_ = store.AppendBatch(ctx, events)
+
+	// Default: top-level deletes show, managed (Pod) deletes do not — they follow IncludeManaged.
+	result, err := store.Query(ctx, QueryOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("Expected Deployment add + Deployment delete, got %d: %+v", len(result), result)
+	}
+	if result[0].ID != "deploy-delete" || result[1].ID != "deploy-add" {
+		t.Fatalf("unexpected result order: %+v", result)
+	}
+
+	// ExcludeDeleted drops the top-level delete too.
+	result, err = store.Query(ctx, QueryOptions{Limit: 10, ExcludeDeleted: true})
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+	if len(result) != 1 || result[0].ID != "deploy-add" {
+		t.Fatalf("Expected only Deployment add with ExcludeDeleted, got %+v", result)
+	}
+
+	// IncludeManaged surfaces the managed Pod delete alongside the rest.
+	result, err = store.Query(ctx, QueryOptions{Limit: 10, IncludeManaged: true})
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+	if len(result) != 3 {
+		t.Fatalf("Expected all 3 events with IncludeManaged, got %d: %+v", len(result), result)
+	}
+}
+
 func TestMemoryStore_FilterPreset(t *testing.T) {
 	store := NewMemoryStore(100)
 	ctx := context.Background()

--- a/pkg/timeline/store.go
+++ b/pkg/timeline/store.go
@@ -75,6 +75,7 @@ type QueryOptions struct {
 
 	// Include/exclude options
 	IncludeManaged   bool // Include ReplicaSets, Pods, Events (default false)
+	ExcludeDeleted   bool // Exclude delete events
 	IncludeK8sEvents bool // Include K8s Event resources (default true)
 }
 
@@ -84,6 +85,7 @@ func DefaultQueryOptions() QueryOptions {
 		Limit:            200,
 		GroupBy:          GroupByNone,
 		IncludeManaged:   false,
+		ExcludeDeleted:   false,
 		IncludeK8sEvents: true,
 	}
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1036,6 +1036,7 @@ export interface UseChangesOptions {
   filter?: string // Filter preset name ('default', 'all', 'warnings-only', 'workloads')
   includeK8sEvents?: boolean
   includeManaged?: boolean
+  includeDeleted?: boolean
   limit?: number
   enabled?: boolean
 }
@@ -1060,7 +1061,7 @@ function getTimeRangeDate(range: TimeRange): Date | null {
 }
 
 export function useChanges(options: UseChangesOptions = {}) {
-  const { namespaces = [], kind, timeRange = '1h', filter = 'all', includeK8sEvents = true, includeManaged = false, limit = 200, enabled = true } = options
+  const { namespaces = [], kind, timeRange = '1h', filter = 'all', includeK8sEvents = true, includeManaged = false, includeDeleted = true, limit = 200, enabled = true } = options
 
   const params = new URLSearchParams()
   if (namespaces.length > 0) params.set('namespaces', namespaces.join(','))
@@ -1068,6 +1069,7 @@ export function useChanges(options: UseChangesOptions = {}) {
   if (filter) params.set('filter', filter)
   if (!includeK8sEvents) params.set('include_k8s_events', 'false')
   if (includeManaged) params.set('include_managed', 'true')
+  if (!includeDeleted) params.set('include_deleted', 'false')
   params.set('limit', String(limit))
 
   const sinceDate = getTimeRangeDate(timeRange)
@@ -1078,7 +1080,7 @@ export function useChanges(options: UseChangesOptions = {}) {
   const queryString = params.toString()
 
   return useQuery<TimelineEvent[]>({
-    queryKey: ['changes', namespaces, kind, timeRange, filter, includeK8sEvents, includeManaged, limit],
+    queryKey: ['changes', namespaces, kind, timeRange, filter, includeK8sEvents, includeManaged, includeDeleted, limit],
     queryFn: () => fetchJSON(`/changes${queryString ? `?${queryString}` : ''}`),
     staleTime: 5000, // Consider data stale after 5 seconds to ensure fresh data on navigation
     refetchInterval: 60000, // SSE handles real-time updates; this is a fallback

--- a/web/src/components/timeline/TimelineList.tsx
+++ b/web/src/components/timeline/TimelineList.tsx
@@ -15,16 +15,17 @@ interface TimelineListProps {
   onResourceClick?: NavigateToResource
   initialFilter?: ActivityTypeFilter
   initialTimeRange?: TimeRange
+  showDeleted: boolean
+  onShowDeletedChange: (showDeleted: boolean) => void
 }
 
-export function TimelineList({ namespaces, onViewChange, currentView, onResourceClick, initialFilter, initialTimeRange }: TimelineListProps) {
+export function TimelineList({ namespaces, onViewChange, currentView, onResourceClick, initialFilter, initialTimeRange, showDeleted, onShowDeletedChange }: TimelineListProps) {
   const hasLimitedAccess = useHasLimitedAccess()
-  const [queryParams, setQueryParams] = useState<{ timeRange: TimeRange; kind?: string; includeDeleted: boolean }>({
+  const [queryParams, setQueryParams] = useState<{ timeRange: TimeRange; kind?: string }>({
     timeRange: initialTimeRange ?? '1h',
-    includeDeleted: true,
   })
 
-  const handleQueryChange = useCallback((params: { timeRange: TimeRange; kind?: string; includeDeleted: boolean }) => {
+  const handleQueryChange = useCallback((params: { timeRange: TimeRange; kind?: string }) => {
     setQueryParams(params)
   }, [])
 
@@ -33,7 +34,7 @@ export function TimelineList({ namespaces, onViewChange, currentView, onResource
     kind: queryParams.kind,
     timeRange: queryParams.timeRange,
     includeK8sEvents: true,
-    includeDeleted: queryParams.includeDeleted,
+    includeDeleted: showDeleted,
     limit: 500,
   })
 
@@ -66,6 +67,8 @@ export function TimelineList({ namespaces, onViewChange, currentView, onResource
       onResourceClick={onResourceClick}
       initialFilter={initialFilter}
       initialTimeRange={initialTimeRange}
+      showDeleted={showDeleted}
+      onShowDeletedChange={onShowDeletedChange}
     />
   )
 }

--- a/web/src/components/timeline/TimelineList.tsx
+++ b/web/src/components/timeline/TimelineList.tsx
@@ -19,11 +19,12 @@ interface TimelineListProps {
 
 export function TimelineList({ namespaces, onViewChange, currentView, onResourceClick, initialFilter, initialTimeRange }: TimelineListProps) {
   const hasLimitedAccess = useHasLimitedAccess()
-  const [queryParams, setQueryParams] = useState<{ timeRange: TimeRange; kind?: string }>({
+  const [queryParams, setQueryParams] = useState<{ timeRange: TimeRange; kind?: string; includeDeleted: boolean }>({
     timeRange: initialTimeRange ?? '1h',
+    includeDeleted: true,
   })
 
-  const handleQueryChange = useCallback((params: { timeRange: TimeRange; kind?: string }) => {
+  const handleQueryChange = useCallback((params: { timeRange: TimeRange; kind?: string; includeDeleted: boolean }) => {
     setQueryParams(params)
   }, [])
 
@@ -32,6 +33,7 @@ export function TimelineList({ namespaces, onViewChange, currentView, onResource
     kind: queryParams.kind,
     timeRange: queryParams.timeRange,
     includeK8sEvents: true,
+    includeDeleted: queryParams.includeDeleted,
     limit: 500,
   })
 

--- a/web/src/components/timeline/TimelineView.tsx
+++ b/web/src/components/timeline/TimelineView.tsx
@@ -42,6 +42,10 @@ export function TimelineView({ namespaces, onResourceClick, initialViewMode, ini
   // Force list view on large clusters without namespace filter
   const effectiveInitialMode = requiresNamespaceFilter ? 'list' : (initialViewMode ?? 'swimlane')
   const [viewMode, setViewMode] = useState<TimelineViewMode>(effectiveInitialMode)
+  // Shared across list + swimlane so the toggle carries across the view switch,
+  // and so the swimlane fetch can exclude deletes server-side (before LIMIT)
+  // rather than only hiding them client-side after the 10k cap.
+  const [showDeleted, setShowDeleted] = useState(true)
 
   // Only fetch heavy swimlane data when actually showing swimlanes
   const showSwimlanes = viewMode === 'swimlane' && !requiresNamespaceFilter
@@ -53,6 +57,7 @@ export function TimelineView({ namespaces, onResourceClick, initialViewMode, ini
     timeRange: 'all',
     includeK8sEvents: true,
     includeManaged: true,
+    includeDeleted: showDeleted,
     limit: 10000,
     enabled: showSwimlanes,
   })
@@ -119,6 +124,8 @@ export function TimelineView({ namespaces, onResourceClick, initialViewMode, ini
         onViewModeChange={setViewMode}
         topology={stableTopology}
         namespaces={namespaces}
+        showDeleted={showDeleted}
+        onShowDeletedChange={setShowDeleted}
       />
     )
   }
@@ -131,6 +138,8 @@ export function TimelineView({ namespaces, onResourceClick, initialViewMode, ini
       onResourceClick={onResourceClick}
       initialFilter={initialFilter}
       initialTimeRange={initialTimeRange}
+      showDeleted={showDeleted}
+      onShowDeletedChange={setShowDeleted}
     />
   )
 }


### PR DESCRIPTION
## Summary

Two small, independent timeline/GitOps improvements that came out of the Radar Cloud / Hub fleet work.

1. **Timeline "Deleted" toggle** — operators can now hide delete-event noise in both the list and swimlane timeline views. Delete events are the *only* surviving record of a resource that no longer exists (a removed Deployment, a Pod that's already gone), so they remain visible by default; the toggle exists to de-noise a churny window on demand.
2. **GitOps empty-state polish** — small presentation change to `GitOpsTableView` so a host (Radar Hub's fleet view) can render a richer empty state.

## What changed

**Timeline deleted-events filtering**
- New `ExcludeDeleted` query option on the timeline store (`include_deleted=false` on `/api/changes`), default off (deletes shown).
- SQLite store applies the delete filter **in SQL, before `ORDER BY … LIMIT`**, so hiding deletes can't under-fill a page when the newest rows happen to be deletes — this keeps the SQLite and in-memory backends consistent (regression test added for the limit-skew case).
- Removed the unused `IncludeDeletedManaged` option: the list view queries with the `all` preset (`IncludeManaged: true`), so managed-resource deletes already surface there; the option was dead on the real UI path. Managed deletes continue to follow `IncludeManaged` as before.
- UI: a `Deleted` control in the list toolbar (with a live count) and the swimlane toolbar; threaded through `useChanges` (`includeDeleted`).

**GitOps empty-state**
- `emptyStateTitle` / `emptyStateBody` widened from `string` → `ReactNode` (a host can split the body across lines or emphasize part of it; plain strings still work — non-breaking).
- Empty-state card anchored higher in the viewport instead of dead-center, so it reads better on a tall page.

## Testing
- `make tsc` ✓ · `go test ./...` for `pkg/timeline` + `internal/timeline` + `internal/server` ✓ (incl. new `DeletedFiltering` and `ExcludeDeleted_LimitSkew` tests).
- Visual-tested against a local `kind` cluster on the real `filter=all` path: toggle ON → delete rows shown (incl. Pods/ReplicaSets); toggle OFF → zero deletes, other events intact.

## Notes
- The list timeline intentionally shows all managed activity (pod creates/updates/deletes) by default; the toggle is purely a way to hide deletes, so it defaults ON for consistency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-path timeline filtering and presentation tweaks with regression tests; no auth, data writes, or security-sensitive behavior.
> 
> **Overview**
> Adds a **Deleted** control on timeline list and swimlane views (shared state when switching views) so operators can hide delete-event noise; deletes stay **on** by default.
> 
> Hiding deletes is wired through **`/api/changes`** via `include_deleted=false`, a new **`ExcludeDeleted`** query option on timeline stores, and **`useChanges`** (`includeDeleted`). The SQLite backend applies the delete filter **before** `ORDER BY … LIMIT` so a page of recent deletes cannot leave the UI empty; memory store matches. Managed-resource deletes still follow **`IncludeManaged`** as before.
> 
> **GitOpsTableView** empty-state copy props widen from `string` to **`ReactNode`** for richer host messaging, and the empty card sits higher in the viewport instead of vertically centered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13762c415cf7a108189dd795b3d0ca4a720e21f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->