### PR TITLE
feat(terminal): explicit copy + platform-aware paste in exec terminal

### DIFF
--- a/packages/k8s-ui/src/components/dock/LocalTerminalTab.tsx
+++ b/packages/k8s-ui/src/components/dock/LocalTerminalTab.tsx
@@ -5,6 +5,9 @@ import { WebLinksAddon } from '@xterm/addon-web-links'
 import '@xterm/xterm/css/xterm.css'
 import { RefreshCw } from 'lucide-react'
 import { clsx } from 'clsx'
+import { setupTerminalClipboard, copyTerminalSelection } from './terminalClipboard'
+import { TerminalClipboardToolbar } from './TerminalClipboardToolbar'
+import { useMultilinePasteConfirm } from './useMultilinePasteConfirm'
 
 export interface LocalTerminalTabProps {
   isActive?: boolean
@@ -30,6 +33,12 @@ export function LocalTerminalTab({
   const [isConnected, setIsConnected] = useState(false)
   const [isConnecting, setIsConnecting] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [hasSelection, setHasSelection] = useState(false)
+  const { confirmPaste, pasteDialog } = useMultilinePasteConfirm()
+
+  const handleCopy = useCallback(() => {
+    if (xtermRef.current) copyTerminalSelection(xtermRef.current)
+  }, [])
 
   const connect = useCallback(() => {
     if (!terminalRef.current) return
@@ -82,6 +91,12 @@ export function LocalTerminalTab({
     xtermRef.current = xterm
     fitAddonRef.current = fitAddon
 
+    setHasSelection(false)
+    const disposeClipboard = setupTerminalClipboard(xterm, terminalRef.current, {
+      confirmPaste,
+      onSelectionChange: setHasSelection,
+    })
+
     const doFit = (ws?: WebSocket) => {
       const dims = fitAddon.proposeDimensions()
       if (dims) xterm.resize(dims.cols, dims.rows)
@@ -123,7 +138,10 @@ export function LocalTerminalTab({
       }, 100)
     })
     resizeObserver.observe(terminalRef.current)
-    cleanupRef.current = () => resizeObserver.disconnect()
+    cleanupRef.current = () => {
+      resizeObserver.disconnect()
+      disposeClipboard()
+    }
 
     createSessionRef.current()
       .then(({ wsUrl }) => {
@@ -229,6 +247,8 @@ export function LocalTerminalTab({
             Reconnect
           </button>
         )}
+
+        {!error && <TerminalClipboardToolbar hasSelection={hasSelection} onCopy={handleCopy} />}
       </div>
 
       {/* Terminal or error */}
@@ -247,6 +267,7 @@ export function LocalTerminalTab({
       ) : (
         <div key="terminal" ref={terminalRef} className="absolute top-8 left-0 right-0 bottom-0 bg-[#0f172a] [&_.xterm-viewport]:!bg-[#0f172a]" />
       )}
+      {pasteDialog}
     </div>
   )
 }

--- a/packages/k8s-ui/src/components/dock/TerminalClipboardToolbar.tsx
+++ b/packages/k8s-ui/src/components/dock/TerminalClipboardToolbar.tsx
@@ -1,0 +1,35 @@
+import { Copy } from 'lucide-react'
+import { isMac } from '../../utils/platform'
+
+/**
+ * Right-aligned clipboard affordances for a terminal mini-toolbar: an explicit
+ * Copy button (enabled only when there's a selection — we don't copy-on-select)
+ * and a muted paste hint that truncates on narrow docks. Shared by TerminalTab
+ * and LocalTerminalTab.
+ */
+export function TerminalClipboardToolbar({
+  hasSelection,
+  onCopy,
+}: {
+  hasSelection: boolean
+  onCopy: () => void
+}) {
+  // Copy is an explicit button (+ ⌘C on macOS), so the hint just covers paste.
+  const hint = isMac() ? '⌘V to paste' : 'Right-click or Ctrl+V to paste'
+  return (
+    <>
+      <button
+        onClick={onCopy}
+        disabled={!hasSelection}
+        title="Copy selection"
+        className="ml-auto flex items-center gap-1 px-2 py-0.5 text-xs text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-elevated rounded disabled:opacity-40 disabled:hover:bg-transparent disabled:cursor-default"
+      >
+        <Copy className="w-3 h-3" />
+        Copy
+      </button>
+      <span className="min-w-0 truncate text-[11px] text-theme-text-tertiary/70" title={hint}>
+        {hint}
+      </span>
+    </>
+  )
+}

--- a/packages/k8s-ui/src/components/dock/TerminalTab.tsx
+++ b/packages/k8s-ui/src/components/dock/TerminalTab.tsx
@@ -5,6 +5,9 @@ import { WebLinksAddon } from '@xterm/addon-web-links'
 import '@xterm/xterm/css/xterm.css'
 import { RefreshCw, ChevronDown, Bug } from 'lucide-react'
 import { clsx } from 'clsx'
+import { setupTerminalClipboard, copyTerminalSelection } from './terminalClipboard'
+import { TerminalClipboardToolbar } from './TerminalClipboardToolbar'
+import { useMultilinePasteConfirm } from './useMultilinePasteConfirm'
 
 export interface TerminalTabProps {
   namespace: string
@@ -46,6 +49,12 @@ export function TerminalTab({
   const [errorType, setErrorType] = useState<string | null>(null)
   const [isCreatingDebug, setIsCreatingDebug] = useState(false)
   const [selectedContainer, setSelectedContainer] = useState(containerName)
+  const [hasSelection, setHasSelection] = useState(false)
+  const { confirmPaste, pasteDialog } = useMultilinePasteConfirm()
+
+  const handleCopy = useCallback(() => {
+    if (xtermRef.current) copyTerminalSelection(xtermRef.current)
+  }, [])
 
   const connect = useCallback(() => {
     if (!terminalRef.current) return
@@ -99,6 +108,12 @@ export function TerminalTab({
     xtermRef.current = xterm
     fitAddonRef.current = fitAddon
 
+    setHasSelection(false)
+    const disposeClipboard = setupTerminalClipboard(xterm, terminalRef.current, {
+      confirmPaste,
+      onSelectionChange: setHasSelection,
+    })
+
     const doFit = (ws?: WebSocket) => {
       const dims = fitAddon.proposeDimensions()
       if (dims) xterm.resize(dims.cols, dims.rows)
@@ -140,7 +155,10 @@ export function TerminalTab({
       }, 100)
     })
     resizeObserver.observe(terminalRef.current)
-    cleanupRef.current = () => resizeObserver.disconnect()
+    cleanupRef.current = () => {
+      resizeObserver.disconnect()
+      disposeClipboard()
+    }
 
     createSessionRef.current(selectedContainer)
       .then(({ wsUrl }) => {
@@ -276,6 +294,8 @@ export function TerminalTab({
             Reconnect
           </button>
         )}
+
+        {!error && <TerminalClipboardToolbar hasSelection={hasSelection} onCopy={handleCopy} />}
       </div>
 
       {/* Terminal or error — key forces xterm canvas unmount/remount on toggle */}
@@ -330,6 +350,7 @@ export function TerminalTab({
       ) : (
         <div key="terminal" ref={terminalRef} className="absolute top-8 left-0 right-0 bottom-0 bg-[#0f172a] [&_.xterm-viewport]:!bg-[#0f172a]" />
       )}
+      {pasteDialog}
     </div>
   )
 }

--- a/packages/k8s-ui/src/components/dock/terminalClipboard.test.ts
+++ b/packages/k8s-ui/src/components/dock/terminalClipboard.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { setupTerminalClipboard, copyTerminalSelection } from './terminalClipboard'
+
+// Minimal fakes — the helper touches onSelectionChange/getSelection/hasSelection/
+// paste/modes/attachCustomKeyEventHandler on the terminal and add/removeEventListener
+// on the element.
+function makeXterm(opts: { selection?: string; bracketed?: boolean } = {}) {
+  let selCb: (() => void) | null = null
+  let keyHandler: ((e: KeyboardEvent) => boolean) | null = null
+  const selection = opts.selection ?? ''
+  return {
+    _fireSelection: () => selCb?.(),
+    _key: (e: Partial<KeyboardEvent>) => keyHandler?.(e as KeyboardEvent),
+    onSelectionChange: vi.fn((fn: () => void) => { selCb = fn; return { dispose: vi.fn() } }),
+    attachCustomKeyEventHandler: vi.fn((fn: (e: KeyboardEvent) => boolean) => { keyHandler = fn }),
+    getSelection: vi.fn(() => selection),
+    hasSelection: vi.fn(() => selection.length > 0),
+    paste: vi.fn(),
+    modes: { bracketedPasteMode: opts.bracketed ?? false },
+  }
+}
+
+function makeElement() {
+  const handlers: Record<string, EventListener> = {}
+  return {
+    handlers,
+    addEventListener: vi.fn((type: string, fn: EventListener) => { handlers[type] = fn }),
+    removeEventListener: vi.fn((type: string) => { delete handlers[type] }),
+  }
+}
+
+function makePasteEvent(text: string) {
+  return { clipboardData: { getData: () => text }, preventDefault: vi.fn(), stopImmediatePropagation: vi.fn() }
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0))
+
+function setPlatform(platform: string) {
+  Object.defineProperty(globalThis, 'navigator', {
+    value: {
+      platform,
+      clipboard: {
+        writeText: vi.fn(() => Promise.resolve()),
+        readText: vi.fn(() => Promise.resolve('line one\nline two')),
+      },
+    },
+    configurable: true,
+  })
+}
+
+const origNavigator = globalThis.navigator
+const allow = () => Promise.resolve(true)
+const deny = () => Promise.resolve(false)
+
+beforeEach(() => setPlatform('Linux x86_64'))
+afterEach(() => {
+  Object.defineProperty(globalThis, 'navigator', { value: origNavigator, configurable: true })
+  vi.restoreAllMocks()
+})
+
+describe('copyTerminalSelection', () => {
+  it('writes the selection to the clipboard', () => {
+    copyTerminalSelection(makeXterm({ selection: 'pod-123' }) as never)
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('pod-123')
+  })
+
+  it('is a no-op when nothing is selected', () => {
+    copyTerminalSelection(makeXterm({ selection: '' }) as never)
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled()
+  })
+})
+
+describe('setupTerminalClipboard — selection reporting (no copy-on-select)', () => {
+  it('reports selection presence but never copies on selection', () => {
+    const xterm = makeXterm({ selection: 'hello' })
+    const onSelectionChange = vi.fn()
+    setupTerminalClipboard(xterm as never, makeElement() as never, { onSelectionChange })
+    xterm._fireSelection()
+    expect(onSelectionChange).toHaveBeenCalledWith(true)
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled() // <- key: selecting does NOT copy
+  })
+})
+
+describe('setupTerminalClipboard — ⌘C copy on macOS', () => {
+  beforeEach(() => setPlatform('MacIntel'))
+
+  it('copies the selection on ⌘C and swallows the event', () => {
+    const xterm = makeXterm({ selection: 'cmd-c-text' })
+    setupTerminalClipboard(xterm as never, makeElement() as never)
+    const e = { type: 'keydown', metaKey: true, key: 'c', preventDefault: vi.fn() }
+    const result = xterm._key(e)
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('cmd-c-text')
+    expect(e.preventDefault).toHaveBeenCalled()
+    expect(result).toBe(false)
+  })
+
+  it('leaves Ctrl+C alone so it still sends SIGINT', () => {
+    const xterm = makeXterm({ selection: 'x' })
+    setupTerminalClipboard(xterm as never, makeElement() as never)
+    const result = xterm._key({ type: 'keydown', ctrlKey: true, key: 'c', preventDefault: vi.fn() })
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled()
+    expect(result).toBe(true)
+  })
+
+  it('does not treat ⌘⇧C as copy (leaves the chord for the browser)', () => {
+    const xterm = makeXterm({ selection: 'x' })
+    setupTerminalClipboard(xterm as never, makeElement() as never)
+    const result = xterm._key({ type: 'keydown', metaKey: true, shiftKey: true, key: 'C', preventDefault: vi.fn() })
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled()
+    expect(result).toBe(true)
+  })
+
+  it('does nothing on ⌘C with no selection', () => {
+    const xterm = makeXterm({ selection: '' })
+    setupTerminalClipboard(xterm as never, makeElement() as never)
+    const result = xterm._key({ type: 'keydown', metaKey: true, key: 'c', preventDefault: vi.fn() })
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled()
+    expect(result).toBe(true)
+  })
+})
+
+describe('setupTerminalClipboard — no copy keybinding off macOS', () => {
+  it('does not attach a key handler on Linux/Windows (Copy button only)', () => {
+    const xterm = makeXterm({ selection: 'x' })
+    setupTerminalClipboard(xterm as never, makeElement() as never)
+    expect(xterm.attachCustomKeyEventHandler).not.toHaveBeenCalled()
+  })
+})
+
+describe('setupTerminalClipboard — right-click paste (non-mac)', () => {
+  it('pastes via xterm.paste on right-click', async () => {
+    const xterm = makeXterm()
+    const el = makeElement()
+    setupTerminalClipboard(xterm as never, el as never, { confirmPaste: allow })
+    expect(el.addEventListener).toHaveBeenCalledWith('contextmenu', expect.any(Function))
+    await el.handlers.contextmenu({ preventDefault: vi.fn() } as never)
+    await flush()
+    expect(xterm.paste).toHaveBeenCalledWith('line one\nline two')
+  })
+
+  it('does not paste when the multi-line confirmation is declined', async () => {
+    const xterm = makeXterm()
+    const el = makeElement()
+    const confirmPaste = vi.fn(deny)
+    setupTerminalClipboard(xterm as never, el as never, { confirmPaste })
+    await el.handlers.contextmenu({ preventDefault: vi.fn() } as never)
+    await flush()
+    expect(confirmPaste).toHaveBeenCalled()
+    expect(xterm.paste).not.toHaveBeenCalled()
+  })
+})
+
+describe('setupTerminalClipboard — multi-line paste guard', () => {
+  it('blocks a declined multi-line paste when bracketed-paste is off', async () => {
+    const xterm = makeXterm({ bracketed: false })
+    const el = makeElement()
+    const confirmPaste = vi.fn(deny)
+    setupTerminalClipboard(xterm as never, el as never, { confirmPaste })
+    const ev = makePasteEvent('rm -rf /tmp/a\nrm -rf /tmp/b')
+    el.handlers.paste(ev as never)
+    expect(ev.preventDefault).toHaveBeenCalled()
+    expect(ev.stopImmediatePropagation).toHaveBeenCalled()
+    expect(confirmPaste).toHaveBeenCalledWith({ lineCount: 2, text: 'rm -rf /tmp/a\nrm -rf /tmp/b' })
+    await flush()
+    expect(xterm.paste).not.toHaveBeenCalled()
+  })
+
+  it('confirms then pastes a multi-line paste that is accepted', async () => {
+    const xterm = makeXterm({ bracketed: false })
+    const el = makeElement()
+    setupTerminalClipboard(xterm as never, el as never, { confirmPaste: allow })
+    const ev = makePasteEvent('one\ntwo\nthree')
+    el.handlers.paste(ev as never)
+    expect(ev.preventDefault).toHaveBeenCalled()
+    await flush()
+    expect(xterm.paste).toHaveBeenCalledWith('one\ntwo\nthree')
+  })
+
+  it('does not paste once the helper is disposed (reconnect/teardown mid-confirm)', async () => {
+    const xterm = makeXterm({ bracketed: false })
+    const el = makeElement()
+    const dispose = setupTerminalClipboard(xterm as never, el as never, { confirmPaste: allow })
+    el.handlers.paste(makePasteEvent('one\ntwo') as never)
+    dispose() // terminal torn down before the (already-resolved) confirm runs
+    await flush()
+    expect(xterm.paste).not.toHaveBeenCalled()
+  })
+
+  it('does not warn on a single-line paste', () => {
+    const el = makeElement()
+    const confirmPaste = vi.fn(allow)
+    setupTerminalClipboard(makeXterm({ bracketed: false }) as never, el as never, { confirmPaste })
+    const ev = makePasteEvent('just one line\n')
+    el.handlers.paste(ev as never)
+    expect(confirmPaste).not.toHaveBeenCalled()
+    expect(ev.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('does not warn when bracketed-paste mode is on, even for multi-line', () => {
+    const el = makeElement()
+    const confirmPaste = vi.fn(allow)
+    setupTerminalClipboard(makeXterm({ bracketed: true }) as never, el as never, { confirmPaste })
+    const ev = makePasteEvent('one\ntwo')
+    el.handlers.paste(ev as never)
+    expect(confirmPaste).not.toHaveBeenCalled()
+    expect(ev.preventDefault).not.toHaveBeenCalled()
+  })
+})
+
+describe('setupTerminalClipboard — teardown', () => {
+  it('disposer removes listeners and disposes the selection listener', () => {
+    const xterm = makeXterm()
+    const el = makeElement()
+    const dispose = setupTerminalClipboard(xterm as never, el as never, { confirmPaste: allow })
+    const selectionDisposable = xterm.onSelectionChange.mock.results[0].value
+    dispose()
+    expect(selectionDisposable.dispose).toHaveBeenCalled()
+    expect(el.removeEventListener).toHaveBeenCalledWith('paste', expect.any(Function), true)
+    expect(el.removeEventListener).toHaveBeenCalledWith('contextmenu', expect.any(Function))
+  })
+})

--- a/packages/k8s-ui/src/components/dock/terminalClipboard.ts
+++ b/packages/k8s-ui/src/components/dock/terminalClipboard.ts
@@ -1,0 +1,122 @@
+import type { Terminal as XTerm } from '@xterm/xterm'
+import { isMac } from '../../utils/platform'
+
+export interface PasteConfirmInfo {
+  lineCount: number
+  text: string
+}
+
+/** Asks the host to confirm a risky paste; resolves true to proceed. */
+export type PasteConfirmer = (info: PasteConfirmInfo) => Promise<boolean>
+
+export interface TerminalClipboardOptions {
+  confirmPaste?: PasteConfirmer
+  /** Notified when the selection changes; drives the toolbar Copy button's enabled state. */
+  onSelectionChange?: (hasSelection: boolean) => void
+}
+
+/** Copies the terminal's current selection to the clipboard. No-op if nothing is selected. */
+export function copyTerminalSelection(xterm: XTerm): void {
+  const selection = xterm.getSelection()
+  if (selection) navigator.clipboard.writeText(selection).catch(() => {})
+}
+
+function pasteLineCount(text: string): number {
+  return text.replace(/\r\n?/g, '\n').replace(/\n+$/, '').split('\n').length
+}
+
+/**
+ * A paste is risky when it spans multiple lines AND the shell hasn't enabled
+ * bracketed-paste mode — without that mode every newline runs as a command, so
+ * the paste auto-executes. Mirrors VS Code's default: warn only when the paste
+ * would actually run (modern bash/zsh enable bracketed paste; sh/ash/dash don't).
+ */
+function isRiskyMultilinePaste(xterm: XTerm, text: string): boolean {
+  if (xterm.modes.bracketedPasteMode) return false
+  return text.replace(/\r\n?/g, '\n').trim().includes('\n')
+}
+
+/**
+ * Wires terminal clipboard behavior onto an xterm instance.
+ *
+ * Copy is explicit — the host's toolbar Copy button (via copyTerminalSelection)
+ * and ⌘C on macOS (Ctrl+C stays SIGINT). We deliberately do NOT copy on
+ * selection: a browser terminal has a single system clipboard with no separate
+ * PRIMARY buffer, so copy-on-select would clobber the clipboard on every
+ * incidental drag. `onSelectionChange` just reports selection presence so the
+ * host can enable/disable its Copy button.
+ *
+ * Paste: right-click on Windows/Linux (PuTTY/VS Code convention); macOS keeps its
+ * native menu. A risky multi-line paste is confirmed first via `confirmPaste`;
+ * the capture listener covers every paste entry point (Cmd/Ctrl+V, the macOS
+ * native menu) and the right-click handler reuses the gate. readText() is blocked
+ * in the Wails desktop webview, so all ops fail safe. Returns a disposer.
+ */
+export function setupTerminalClipboard(
+  xterm: XTerm,
+  element: HTMLElement,
+  options: TerminalClipboardOptions = {},
+): () => void {
+  const { confirmPaste, onSelectionChange } = options
+  const mac = isMac()
+  // Async paste (confirm dialog / readText) can resolve after the terminal is
+  // torn down by a reconnect or container switch, which disposes this xterm and
+  // builds a new one. Pasting into the disposed instance silently misses the
+  // visible session, so we gate the deferred paste on this flag.
+  let disposed = false
+
+  const selectionListener = xterm.onSelectionChange(() => {
+    onSelectionChange?.(xterm.hasSelection())
+  })
+
+  // macOS: ⌘C copies the selection. Ctrl+C is left untouched so it still sends
+  // SIGINT. Other platforms have no conflict-free copy keystroke in a browser
+  // (Ctrl+C = SIGINT, Ctrl+Shift+C = devtools), so they rely on the Copy button.
+  if (mac) {
+    xterm.attachCustomKeyEventHandler((e) => {
+      if (
+        e.type === 'keydown' && e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey &&
+        (e.key === 'c' || e.key === 'C') && xterm.hasSelection()
+      ) {
+        e.preventDefault()
+        copyTerminalSelection(xterm)
+        return false
+      }
+      return true
+    })
+  }
+
+  const handlePaste = (e: ClipboardEvent) => {
+    const text = e.clipboardData?.getData('text') ?? ''
+    if (!text || !confirmPaste || !isRiskyMultilinePaste(xterm, text)) return
+    e.preventDefault()
+    e.stopImmediatePropagation()
+    confirmPaste({ lineCount: pasteLineCount(text), text }).then((ok) => {
+      if (ok && !disposed) xterm.paste(text)
+    }).catch(() => {})
+  }
+  element.addEventListener('paste', handlePaste, true)
+
+  let handleContextMenu: ((e: MouseEvent) => void) | undefined
+  if (!mac) {
+    handleContextMenu = (e: MouseEvent) => {
+      e.preventDefault()
+      navigator.clipboard.readText().then(async (text) => {
+        if (!text || disposed) return
+        if (confirmPaste && isRiskyMultilinePaste(xterm, text)) {
+          const ok = await confirmPaste({ lineCount: pasteLineCount(text), text })
+          if (!ok || disposed) return
+        }
+        xterm.paste(text)
+      }).catch(() => {})
+    }
+    element.addEventListener('contextmenu', handleContextMenu)
+  }
+
+  return () => {
+    disposed = true
+    selectionListener.dispose()
+    element.removeEventListener('paste', handlePaste, true)
+    if (handleContextMenu) element.removeEventListener('contextmenu', handleContextMenu)
+  }
+}

--- a/packages/k8s-ui/src/components/dock/useMultilinePasteConfirm.tsx
+++ b/packages/k8s-ui/src/components/dock/useMultilinePasteConfirm.tsx
@@ -1,0 +1,75 @@
+import { useCallback, useRef, useState } from 'react'
+import { ConfirmDialog } from '../ui/ConfirmDialog'
+import type { PasteConfirmInfo, PasteConfirmer } from './terminalClipboard'
+
+// Session-scoped "Don't ask again" — app-wide for the page session (shared across
+// terminal tabs), reset on reload. Deliberately not persisted: a multi-line paste
+// warning re-appearing once per session is cheap, and it avoids a safety net the
+// user silently disabled long ago and forgot.
+let warningSuppressedThisSession = false
+
+/**
+ * Owns the themed confirmation shown before a risky multi-line paste runs in a
+ * terminal. Returns a `confirmPaste` callback to hand to setupTerminalClipboard
+ * and a `pasteDialog` node the host must render. Once the user opts out via
+ * "Don't ask again", pastes proceed without prompting for the rest of the session.
+ */
+export function useMultilinePasteConfirm(): { confirmPaste: PasteConfirmer; pasteDialog: React.ReactNode } {
+  const [pending, setPending] = useState<PasteConfirmInfo | null>(null)
+  const [dontAskAgain, setDontAskAgain] = useState(false)
+  const resolverRef = useRef<((ok: boolean) => void) | null>(null)
+
+  const confirmPaste = useCallback<PasteConfirmer>(
+    (info) => {
+      if (warningSuppressedThisSession) return Promise.resolve(true)
+      // A paste arriving while a dialog is still open supersedes it: decline the
+      // pending one so its promise resolves (the superseded paste is dropped)
+      // rather than leaking, then show the new prompt.
+      resolverRef.current?.(false)
+      return new Promise<boolean>((resolve) => {
+        resolverRef.current = resolve
+        setDontAskAgain(false)
+        setPending(info)
+      })
+    },
+    [],
+  )
+
+  const settle = useCallback(
+    (ok: boolean) => {
+      // Only suppress when the user actually proceeds — cancelling shouldn't
+      // quietly disable the warning.
+      if (ok && dontAskAgain) warningSuppressedThisSession = true
+      resolverRef.current?.(ok)
+      resolverRef.current = null
+      setPending(null)
+    },
+    [dontAskAgain],
+  )
+
+  const pasteDialog = pending ? (
+    <ConfirmDialog
+      open
+      variant="warning"
+      title="Paste multiple lines?"
+      message={`This pastes ${pending.lineCount} lines into the shell — they run immediately.`}
+      details={pending.text}
+      confirmLabel="Paste"
+      cancelLabel="Cancel"
+      onConfirm={() => settle(true)}
+      onClose={() => settle(false)}
+    >
+      <label className="flex items-center gap-2 text-sm text-theme-text-secondary cursor-pointer">
+        <input
+          type="checkbox"
+          checked={dontAskAgain}
+          onChange={(e) => setDontAskAgain(e.target.checked)}
+          className="w-4 h-4 rounded border-theme-border bg-theme-base accent-amber-500"
+        />
+        <span>Don&apos;t ask again this session</span>
+      </label>
+    </ConfirmDialog>
+  ) : null
+
+  return { confirmPaste, pasteDialog }
+}

--- a/packages/k8s-ui/src/hooks/useKeyboardShortcuts.tsx
+++ b/packages/k8s-ui/src/hooks/useKeyboardShortcuts.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { isMac as isMacPlatform } from '../utils/platform'
 
 export type ShortcutScope = 'global' | 'topology' | 'resources' | 'timeline' | 'helm' | 'gitops' | 'traffic' | 'applications' | 'audit' | 'drawer'
 
@@ -78,7 +79,7 @@ interface KeyMatcher {
   altKey?: boolean
 }
 
-const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform)
+const isMac = isMacPlatform()
 
 function parseKeys(keys: string): KeyMatcher {
   // Multi-key sequence (space-separated, e.g. "g g")

--- a/packages/k8s-ui/src/utils/platform.ts
+++ b/packages/k8s-ui/src/utils/platform.ts
@@ -1,0 +1,4 @@
+/** True when running on a macOS / iOS platform (drives ⌘ vs Ctrl conventions). */
+export function isMac(): boolean {
+  return typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform)
+}


### PR DESCRIPTION
Closes #948.

## What

Clipboard support for the in-browser pod-exec terminal (and the local + node terminals, which share the component).

**Copy — explicit, not on-select.** Terminal text isn't reachable by the browser's native copy: xterm renders its selection in an internal overlay with `user-select: none`, so `⌘C`/`Ctrl+C` over a native selection returns nothing (verified live: a native range over `.xterm-rows` yields 0 chars). Copying therefore needs explicit wiring. We do **not** copy-on-select — a browser terminal has a single system clipboard with no separate Linux-style PRIMARY buffer, so select-to-copy would silently clobber the clipboard on every incidental drag (the classic "I copied a command, double-clicked a word in the output, lost my command" footgun). Instead:

- A **"Copy" button** in the terminal toolbar, enabled when there's a selection — the conflict-free, cross-platform path.
- **⌘C on macOS** copies the selection; **Ctrl+C stays SIGINT**.
- No copy keystroke off macOS: `Ctrl+C` is SIGINT and `Ctrl+Shift+C` is the browser's devtools shortcut, so there's no clean copy keybinding in a browser there — hence the visible button. This matches how gnome-terminal / Konsole / Windows Terminal expose copy.

**Paste.**
- `Cmd/Ctrl+V` works everywhere (xterm's native paste).
- **Right-click pastes on Windows/Linux** (PuTTY / VS Code convention); **macOS keeps its native context menu**. Platform-aware via `navigator.platform`.
- **Multi-line paste guard (VS Code model):** pasting 2+ lines into a shell that hasn't enabled bracketed-paste mode pops a themed `ConfirmDialog` previewing the lines before they run — because in `sh`/`ash`/`dash` (most pod images) a pasted newline executes immediately. Single-line pastes and bracketed-paste shells (modern bash/zsh) are never interrupted. One capture-phase listener covers `⌘V`/`Ctrl+V` and the macOS native-menu paste; the right-click handler reuses the gate. The dialog has a **"Don't ask again this session"** checkbox — a session-scoped opt-out (app-wide for the page session, reset on reload; deliberately not persisted).

**Discoverability.** A muted, platform-aware paste hint in the toolbar (`⌘V to paste` on macOS; `Right-click or Ctrl+V to paste` elsewhere), right-aligned and truncating on narrow docks. Copy discoverability is the visible Copy button itself.

## Why this shape

The original issue asked for PuTTY-style copy-on-select. On a single-clipboard web terminal that's the wrong default (silent clobber, violates least-surprise; VS Code / Windows Terminal / Terminal.app all default it off), and dropping it doesn't reopen the issue because explicit copy still closes "I can't copy from the terminal." `xterm.paste()` honors bracketed paste where the shell supports it; all clipboard ops `.catch(() => {})` and the desktop webview's blocked `readText()` degrades safely.

## Structure

Shared helpers in `packages/k8s-ui/src/components/dock/`:
- `terminalClipboard.ts` — `setupTerminalClipboard(xterm, el, opts)` (selection reporting, ⌘C, paste gate), `copyTerminalSelection()`, `clipboardHintText()`.
- `useMultilinePasteConfirm.tsx` — owns the themed confirm + "Don't ask again".

`TerminalTab` and `LocalTerminalTab` consume them; `NodeTerminalTab` reuses `TerminalTab`.

## Test

- `make tsc` clean; `vitest` 645 passing.
- `terminalClipboard.test.ts` (16 cases): explicit copy via the Copy-button path, selecting does NOT copy, ⌘C copies on macOS, Ctrl+C stays SIGINT, no keybinding off macOS, right-click paste, the multi-line guard (block/confirm/single-line/bracketed-on/disposed-teardown), and teardown.
- visual-test: confirmed the paste confirmation (themed, app-centered, line preview + "Don't ask again"), and the toolbar; verified live that native selection over the terminal yields 0 chars (basis for explicit copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only terminal clipboard wiring with explicit safety for multi-line paste; no server or auth changes. Main risk is accidental paste into shells without bracketed paste, which the confirm dialog mitigates.
> 
> **Overview**
> Adds **shared clipboard behavior** for in-browser xterm sessions in **`TerminalTab`** and **`LocalTerminalTab`** (pod exec, local, and node terminals that reuse **`TerminalTab`**).
> 
> **Copy** is explicit only: a toolbar **Copy** button (enabled when xterm has a selection), **⌘C on macOS** (Ctrl+C still sends SIGINT), and no copy-on-select so incidental selections do not overwrite the system clipboard. **`setupTerminalClipboard`** reports selection state and is torn down on reconnect.
> 
> **Paste** adds **right-click paste** on non-macOS, a **multi-line guard** when bracketed-paste mode is off (capture-phase paste handler + shared confirm flow), and a **`TerminalClipboardToolbar`** paste hint. **`useMultilinePasteConfirm`** shows a warning dialog with optional **“Don’t ask again this session”**; deferred pastes are blocked after dispose.
> 
> Extracts **`isMac()`** to **`utils/platform`** (also used by keyboard shortcuts). **`terminalClipboard.test.ts`** covers copy, macOS keys, paste gates, and teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 386a40e4cd29acdabfa9f258d8af38c875ae958c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


