### PR TITLE
Reduce repeated topology and resource-event fetch work

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2370,6 +2370,7 @@ func (s *Server) handleChanges(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	kind := r.URL.Query().Get("kind")
+	name := r.URL.Query().Get("name")
 	sinceStr := r.URL.Query().Get("since")
 	limitStr := r.URL.Query().Get("limit")
 	filterPreset := r.URL.Query().Get("filter")
@@ -2420,6 +2421,9 @@ func (s *Server) handleChanges(w http.ResponseWriter, r *http.Request) {
 	}
 	if kind != "" {
 		opts.Kinds = []string{kind}
+	}
+	if name != "" {
+		opts.Names = []string{name}
 	}
 	if sourcesParam != "" {
 		validSources := map[timeline.EventSource]bool{

--- a/internal/server/server_smoke_test.go
+++ b/internal/server/server_smoke_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
@@ -788,6 +790,46 @@ func TestSmokeChanges(t *testing.T) {
 func TestSmokeChangesWithFilters(t *testing.T) {
 	var body []any
 	assertOK(t, get(t, "/api/changes?namespace=default&kind=Deployment&limit=10"), &body)
+}
+
+func TestSmokeChangesNameFilter(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	clusterContext := k8s.ActiveClusterContext()
+	events := []timeline.TimelineEvent{
+		{
+			ID:             "smoke-name-filter-keep",
+			Timestamp:      now,
+			Source:         timeline.SourceInformer,
+			Kind:           "Deployment",
+			Namespace:      "default",
+			Name:           "smoke-name-filter-keep",
+			EventType:      timeline.EventTypeUpdate,
+			ClusterContext: clusterContext,
+		},
+		{
+			ID:             "smoke-name-filter-drop",
+			Timestamp:      now,
+			Source:         timeline.SourceInformer,
+			Kind:           "Deployment",
+			Namespace:      "default",
+			Name:           "smoke-name-filter-drop",
+			EventType:      timeline.EventTypeUpdate,
+			ClusterContext: clusterContext,
+		},
+	}
+	if err := timeline.RecordEvents(ctx, events); err != nil {
+		t.Fatalf("RecordEvents: %v", err)
+	}
+
+	var body []timeline.TimelineEvent
+	assertOK(t, get(t, "/api/changes?namespace=default&kind=Deployment&name=smoke-name-filter-keep&include_managed=true&filter=all&limit=10"), &body)
+	if len(body) != 1 {
+		t.Fatalf("expected exactly one name-filtered event, got %d: %+v", len(body), body)
+	}
+	if body[0].Name != "smoke-name-filter-keep" {
+		t.Fatalf("expected smoke-name-filter-keep, got %q", body[0].Name)
+	}
 }
 
 func TestSmokeChangeChildren(t *testing.T) {

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -326,6 +326,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 
 	var rolloutGVR schema.GroupVersionResource
 	hasRollouts := false
+	rolloutsByNamespace := make(map[string][]*unstructured.Unstructured)
 	if resourceDiscovery != nil {
 		rolloutGVR, hasRollouts = resourceDiscovery.GetGVR("Rollout")
 	}
@@ -340,6 +341,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 			if !opts.MatchesNamespaceFilter(ns) {
 				continue
 			}
+			rolloutsByNamespace[ns] = append(rolloutsByNamespace[ns], rollout)
 			name := rollout.GetName()
 
 			rolloutID := fmt.Sprintf("rollout/%s/%s", ns, name)
@@ -2848,13 +2850,8 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 			}
 		}
 		// Check Rollouts (if we have any)
-		if hasRollouts && dynamicCache != nil {
-			svcRollouts, rolloutErr := dynamicCache.List(rolloutGVR, svc.Namespace)
-			if rolloutErr != nil {
-				log.Printf("WARNING [topology] Failed to list Rollouts for service %s/%s: %v", svc.Namespace, svc.Name, rolloutErr)
-				warnings = append(warnings, fmt.Sprintf("Failed to list Rollouts: %v", rolloutErr))
-			}
-			for _, rollout := range svcRollouts {
+		if hasRollouts {
+			for _, rollout := range rolloutsByNamespace[svc.Namespace] {
 				spec, _, _ := unstructured.NestedMap(rollout.Object, "spec", "template", "metadata")
 				if spec != nil {
 					if podLabels, ok := spec["labels"].(map[string]any); ok {

--- a/pkg/topology/builder_test.go
+++ b/pkg/topology/builder_test.go
@@ -12,40 +12,44 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	k8score "github.com/skyhook-io/radar/pkg/k8score"
 )
 
 // mockProvider implements ResourceProvider with configurable slices.
 type mockProvider struct {
-	pods         []*corev1.Pod
-	deployments  []*appsv1.Deployment
-	services     []*corev1.Service
-	daemonSets   []*appsv1.DaemonSet
-	statefulSets []*appsv1.StatefulSet
-	replicaSets  []*appsv1.ReplicaSet
-	jobs         []*batchv1.Job
-	cronJobs     []*batchv1.CronJob
-	ingresses    []*networkingv1.Ingress
-	configMaps   []*corev1.ConfigMap
-	secrets      []*corev1.Secret
-	pvcs         []*corev1.PersistentVolumeClaim
-	pvs          []*corev1.PersistentVolume
-	hpas         []*autoscalingv2.HorizontalPodAutoscaler
-	pdbs             []*policyv1.PodDisruptionBudget
-	networkPolicies  []*networkingv1.NetworkPolicy
-	nodes            []*corev1.Node
+	pods            []*corev1.Pod
+	deployments     []*appsv1.Deployment
+	services        []*corev1.Service
+	daemonSets      []*appsv1.DaemonSet
+	statefulSets    []*appsv1.StatefulSet
+	replicaSets     []*appsv1.ReplicaSet
+	jobs            []*batchv1.Job
+	cronJobs        []*batchv1.CronJob
+	ingresses       []*networkingv1.Ingress
+	configMaps      []*corev1.ConfigMap
+	secrets         []*corev1.Secret
+	pvcs            []*corev1.PersistentVolumeClaim
+	pvs             []*corev1.PersistentVolume
+	hpas            []*autoscalingv2.HorizontalPodAutoscaler
+	pdbs            []*policyv1.PodDisruptionBudget
+	networkPolicies []*networkingv1.NetworkPolicy
+	nodes           []*corev1.Node
 }
 
-func (m *mockProvider) Pods() ([]*corev1.Pod, error)                   { return m.pods, nil }
-func (m *mockProvider) Services() ([]*corev1.Service, error)           { return m.services, nil }
-func (m *mockProvider) Deployments() ([]*appsv1.Deployment, error)     { return m.deployments, nil }
-func (m *mockProvider) DaemonSets() ([]*appsv1.DaemonSet, error)       { return m.daemonSets, nil }
-func (m *mockProvider) StatefulSets() ([]*appsv1.StatefulSet, error)   { return m.statefulSets, nil }
-func (m *mockProvider) ReplicaSets() ([]*appsv1.ReplicaSet, error)     { return m.replicaSets, nil }
-func (m *mockProvider) Jobs() ([]*batchv1.Job, error)                  { return m.jobs, nil }
-func (m *mockProvider) CronJobs() ([]*batchv1.CronJob, error)          { return m.cronJobs, nil }
-func (m *mockProvider) Ingresses() ([]*networkingv1.Ingress, error)    { return m.ingresses, nil }
-func (m *mockProvider) ConfigMaps() ([]*corev1.ConfigMap, error)       { return m.configMaps, nil }
-func (m *mockProvider) Secrets() ([]*corev1.Secret, error)             { return m.secrets, nil }
+func (m *mockProvider) Pods() ([]*corev1.Pod, error)                 { return m.pods, nil }
+func (m *mockProvider) Services() ([]*corev1.Service, error)         { return m.services, nil }
+func (m *mockProvider) Deployments() ([]*appsv1.Deployment, error)   { return m.deployments, nil }
+func (m *mockProvider) DaemonSets() ([]*appsv1.DaemonSet, error)     { return m.daemonSets, nil }
+func (m *mockProvider) StatefulSets() ([]*appsv1.StatefulSet, error) { return m.statefulSets, nil }
+func (m *mockProvider) ReplicaSets() ([]*appsv1.ReplicaSet, error)   { return m.replicaSets, nil }
+func (m *mockProvider) Jobs() ([]*batchv1.Job, error)                { return m.jobs, nil }
+func (m *mockProvider) CronJobs() ([]*batchv1.CronJob, error)        { return m.cronJobs, nil }
+func (m *mockProvider) Ingresses() ([]*networkingv1.Ingress, error)  { return m.ingresses, nil }
+func (m *mockProvider) ConfigMaps() ([]*corev1.ConfigMap, error)     { return m.configMaps, nil }
+func (m *mockProvider) Secrets() ([]*corev1.Secret, error)           { return m.secrets, nil }
 func (m *mockProvider) PersistentVolumeClaims() ([]*corev1.PersistentVolumeClaim, error) {
 	return m.pvcs, nil
 }
@@ -62,6 +66,57 @@ func (m *mockProvider) NetworkPolicies() ([]*networkingv1.NetworkPolicy, error) 
 func (m *mockProvider) Nodes() ([]*corev1.Node, error) { return m.nodes, nil }
 func (m *mockProvider) GetResourceStatus(kind, namespace, name string) *ResourceStatus {
 	return nil
+}
+
+type rolloutDynamicProvider struct {
+	gvr                 schema.GroupVersionResource
+	rollouts            []*unstructured.Unstructured
+	listCalls           int
+	listNamespacesCalls int
+}
+
+func (m *rolloutDynamicProvider) List(_ schema.GroupVersionResource, _ string) ([]*unstructured.Unstructured, error) {
+	m.listCalls++
+	return nil, nil
+}
+
+func (m *rolloutDynamicProvider) ListNamespaces(_ schema.GroupVersionResource, _ []string) ([]*unstructured.Unstructured, error) {
+	m.listNamespacesCalls++
+	return m.rollouts, nil
+}
+
+func (m *rolloutDynamicProvider) Get(_ schema.GroupVersionResource, _, _ string) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+
+func (m *rolloutDynamicProvider) GetWatchedResources() []schema.GroupVersionResource {
+	return nil
+}
+
+func (m *rolloutDynamicProvider) GetDiscoveryStatus() k8score.CRDDiscoveryStatus {
+	return k8score.CRDDiscoveryComplete
+}
+
+func (m *rolloutDynamicProvider) GetGVR(kindOrName string) (schema.GroupVersionResource, bool) {
+	if kindOrName == "Rollout" {
+		return m.gvr, true
+	}
+	return schema.GroupVersionResource{}, false
+}
+
+func (m *rolloutDynamicProvider) GetGVRWithGroup(kindOrName, _ string) (schema.GroupVersionResource, bool) {
+	return m.GetGVR(kindOrName)
+}
+
+func (m *rolloutDynamicProvider) GetKindForGVR(gvr schema.GroupVersionResource) string {
+	if gvr == m.gvr {
+		return "Rollout"
+	}
+	return ""
+}
+
+func (m *rolloutDynamicProvider) IsCRD(kind string) bool {
+	return kind == "Rollout"
 }
 
 // --- Generators ---
@@ -116,6 +171,70 @@ func smallProvider() *mockProvider {
 }
 
 // --- Tests ---
+
+func TestBuildResourcesTopology_ReusesListedRolloutsForServiceEdges(t *testing.T) {
+	rolloutGVR := schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "rollouts"}
+	rollout := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "argoproj.io/v1alpha1",
+		"kind":       "Rollout",
+		"metadata": map[string]any{
+			"name":      "web",
+			"namespace": "prod",
+		},
+		"spec": map[string]any{
+			"replicas": int64(1),
+			"template": map[string]any{
+				"metadata": map[string]any{
+					"labels": map[string]any{"app": "web"},
+				},
+			},
+		},
+	}}
+	dynamic := &rolloutDynamicProvider{
+		gvr:      rolloutGVR,
+		rollouts: []*unstructured.Unstructured{rollout},
+	}
+	provider := &mockProvider{
+		services: []*corev1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "prod"},
+				Spec:       corev1.ServiceSpec{Selector: map[string]string{"app": "web"}},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "web-canary", Namespace: "prod"},
+				Spec:       corev1.ServiceSpec{Selector: map[string]string{"app": "web"}},
+			},
+		},
+	}
+
+	topo, err := NewBuilder(provider).WithDynamic(dynamic).Build(DefaultBuildOptions())
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+	if dynamic.listNamespacesCalls != 1 {
+		t.Fatalf("expected one Rollout ListNamespaces call, got %d", dynamic.listNamespacesCalls)
+	}
+	if dynamic.listCalls != 0 {
+		t.Fatalf("expected Service matching to reuse listed Rollouts without List calls, got %d", dynamic.listCalls)
+	}
+
+	wantTargets := map[string]bool{
+		"service/prod/web":        false,
+		"service/prod/web-canary": false,
+	}
+	for _, edge := range topo.Edges {
+		if edge.Type == EdgeExposes && edge.Target == "rollout/prod/web" {
+			if _, ok := wantTargets[edge.Source]; ok {
+				wantTargets[edge.Source] = true
+			}
+		}
+	}
+	for serviceID, found := range wantTargets {
+		if !found {
+			t.Fatalf("expected %s to expose rollout/prod/web; edges=%+v", serviceID, topo.Edges)
+		}
+	}
+}
 
 func TestLargeClusterDetection(t *testing.T) {
 	tests := []struct {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1136,6 +1136,7 @@ export function useResourceEvents(kind: string, namespace: string, name: string)
     const p = new URLSearchParams()
     p.set('namespace', namespace)
     p.set('kind', singularKind)
+    p.set('name', name)
     p.set('include_managed', 'true')
     p.set('since', since)
     return p
@@ -1152,8 +1153,7 @@ export function useResourceEvents(kind: string, namespace: string, name: string)
       const params = baseParams()
       params.set('sources', 'k8s_event')
       params.set('limit', '500')
-      const events = await fetchJSON<TimelineEvent[]>(`/changes?${params.toString()}`)
-      return events.filter(e => e.name === name)
+      return fetchJSON<TimelineEvent[]>(`/changes?${params.toString()}`)
     },
     enabled,
     refetchInterval: 15000,
@@ -1167,8 +1167,7 @@ export function useResourceEvents(kind: string, namespace: string, name: string)
       const params = baseParams()
       params.set('sources', 'informer,historical')
       params.set('limit', '50')
-      const events = await fetchJSON<TimelineEvent[]>(`/changes?${params.toString()}`)
-      return events.filter(e => e.name === name)
+      return fetchJSON<TimelineEvent[]>(`/changes?${params.toString()}`)
     },
     enabled,
     refetchInterval: 15000,


### PR DESCRIPTION
## Summary
This trims two small but high-confidence large-cluster hot paths: topology no longer re-lists Argo Rollouts once per Service, and resource detail activity requests are scoped to the resource name server-side instead of fetching kind+namespace history and filtering in the browser. Because the timeline store now filters by name before applying endpoint limits, busy namespaces are less likely to starve a resource detail page of that resource’s own events.

## What changed
- Reuses the Rollouts already fetched during topology construction by indexing them by namespace before Service selector matching.
- Adds `name` support to `/api/changes` by threading it into the existing timeline `QueryOptions.Names` filter.
- Updates `useResourceEvents` to include `name` in both resource event queries and removes client-side filtering.
- Adds regression coverage for Rollout list reuse and `/api/changes?name=...`.

## Testing
- `go test ./topology`
- `go test ./internal/server -run TestSmokeChanges`
- `make tsc`
- `make test`
- `make build`
- visual-test: skipped (no rendered UI delta)

## Notes
`make build` completed successfully; Vite emitted existing chunk-size / ELK dynamic import warnings.