### PR TITLE
Declared-only app identity: provenance, explicit annotation, ApplicationSet fan-out, hub-spoke claims

### DIFF
--- a/docs/app-grouping.md
+++ b/docs/app-grouping.md
@@ -6,6 +6,31 @@ the code lives in the files named at the end.
 
 ---
 
+## 0. The complexity budget — read this before adding anything
+
+This system tends toward complexity (the inputs are a mess), so it has a **hard
+design constraint.** Honor it on every change:
+
+1. **The spine stays three sentences.** An app is a *release unit*; *identity* is
+   "same app elsewhere," distinct from composition; *declared origins fold across
+   clusters, names don't.* If a change makes one of these three harder to state,
+   it's probably wrong. Everything else is edge-case handling around this spine —
+   it must never *become* the model.
+2. **Prefer declaration over inference.** Before adding a heuristic, ask "can the
+   user just *say it*?" The `app.skyhook.io/app` annotation exists precisely so
+   that when inference gets hairy, we hand the user a one-word escape hatch instead
+   of getting cleverer. Reach for that first.
+3. **The explainability test.** Every heuristic must be stateable in **one plain
+   sentence a non-k8s-expert nods at** (it goes in a tooltip). If it can't be —
+   simplify it, or replace it with a declaration. A heuristic you can't explain is
+   a heuristic the operator can't trust.
+
+Heuristics are fine; opacity is not. The current **watch-item is env-token
+discovery** (§12) — the one piece that fails the one-sentence test today and the
+first thing to put on the chopping block if the model needs to lose weight.
+
+---
+
 ## 1. Why this is hard
 
 A "deployable application" is **not a Kubernetes object.** There is no `App` kind.
@@ -313,3 +338,12 @@ then folds the rest only on collision-free declared origins.*
 - **Umbrella Helm charts (§2).** A chart bundling many independently-versioned
   services is one release unit → one app. If that's too coarse, the refinement is
   to split by independently-versioned image — not today's behavior.
+- **⚠️ Complexity watch-item: env-token discovery.** To put a non-trio app on the
+  env ladder, the identity resolver *discovers* whether a token like `loadtest` is
+  an environment by structural inference — "it recurs across ≥3 repo-corroborated
+  name-stem groups spanning ≥2 namespaces." That buys zero-config custom-env
+  detection, but it's the **one heuristic that fails the §0 one-sentence test** —
+  no operator can predict it. It's the first candidate to simplify if the model
+  grows: fall back to the trio (dev/staging/prod) + explicit env labels
+  (`app.kubernetes.io/environment`) + GitOps overlay paths, and make custom envs a
+  label. Flagged, not yet cut (the zero-config value is real).

--- a/docs/app-grouping.md
+++ b/docs/app-grouping.md
@@ -1,0 +1,315 @@
+# Application grouping — the mental model
+
+A reader-first map of how Radar decides "these workloads are one app" and "these
+apps across clusters are the same logical app." This is the *model*, in English;
+the code lives in the files named at the end.
+
+---
+
+## 1. Why this is hard
+
+A "deployable application" is **not a Kubernetes object.** There is no `App` kind.
+What a human calls "the billing app" is scattered across Deployments, a Worker, a
+CronJob, a Service, maybe an Ingress — possibly across several namespaces, and
+(in a fleet) across several clusters. Grouping is the act of **reconstructing the
+human's notion of an app from the rubble of K8s objects.** Every bit of
+complexity below exists because we get only indirect, inconsistent hints.
+
+---
+
+## 2. Two questions, two levels — keep them separate
+
+Almost all confusion comes from conflating two genuinely different problems:
+
+| | Question | Example |
+|---|----------|---------|
+| **Composition** | Which workloads are **deployed/released as one unit** — that unit *is* the app, in one cluster | the workloads in one Helm release / one Argo Application / one Flux Kustomization |
+| **Identity** | Which app-instances are the **same logical app**, across envs/clusters | billing@dev + billing@staging + billing@prod = **billing**, in three environments |
+
+Composition is "what ships and versions together." Identity is "is this the same
+app as that one over there." Different layers solve them. When you're lost, first
+ask: *am I thinking about composition or identity?*
+
+### What an "app" is — the unit of independent release
+
+An app is **the thing that ships together and is versioned together** — *not* a
+logical umbrella over services that happen to be related. This is the single most
+important judgment in the whole system, and it is deliberate:
+
+> Radar finds an app by climbing each workload's ownership to the **GitOps/Helm
+> manager that deploys it** (an Argo Application, a Flux Kustomization/HelmRelease,
+> a Helm release) and **stops there.** It does **not** climb up to the shared git
+> repo, or to a parent app-of-apps, even though it could.
+
+That "stop" is the whole point. If `backend` and `frontend` are deployed as **two
+separate Argo Applications**, they are **two apps** — even when they live in the
+same repo — because each is released and versioned on its own. Climbing to the
+shared repo/parent would collapse every separately-released service into one giant
+"shop" blob, which has no operational value. We refuse to do that. (Workloads with
+**no manager** resolve instead to their **topmost ownerRef** — a Deployment, or an
+operator CR like a CNPG `Cluster`.)
+
+The weaker labels (`part-of`, `name`) are a fallback for loose/raw workloads, not
+an umbrella over independently-released ones. **One honest caveat to the absolute
+claim:** apps are assembled by union-find over *atoms* — each workload contributes
+its structural root **and** its single strongest overlay label (§4). In the normal
+case a GitOps-managed workload carries its manager's label, so that label *is* the
+high-tier atom and the boundary holds. But the union also runs on the overlay
+atom, so if two workloads with **distinct manager roots** happen to expose only a
+shared weak label (e.g. a manager that doesn't stamp its own label, leaving only
+`part-of`), that shared label can still union the two. Precedence makes a stronger
+signal win *as the key*, but the union-find can cross a structural boundary via a
+shared weak overlay. And note: a shared **satellite** (Service/Ingress/ConfigMap)
+never merges two apps — only the workload atoms do.
+
+**The honest edge case:** one Helm *umbrella* chart that bundles many services is
+a single release unit, so Radar calls it one app — even if you think of the
+services as standalone. Where "released together" and "feels standalone" diverge,
+Radar follows the *release unit.* (If that proves too coarse, the refinement is to
+split an umbrella by independently-versioned image — a future call, not today's
+behavior.)
+
+---
+
+## 3. The pipeline — three layers
+
+A workload flows left-to-right; each layer answers part of the question.
+
+```
+  workload ──▶ [1] structuralRoot + ──▶ [2] applications_identity ──▶ [3] hub + fleet fold
+                  pkg/subject            app-instances → logical        logical apps →
+              workload → release unit    app + env (identity,           one fleet row
+              (composition)              per cluster)                   (identity, x-cluster)
+```
+
+1. **Composition — `structuralRoot` (topology graph) + `pkg/subject` overlay (per
+   cluster).** Climbs each workload's ownership to its **release unit** (the GitOps/
+   Helm manager that deploys it) and stops there (§2). The `pkg/subject` overlay
+   then *consolidates* roots the graph can't connect — hub-spoke Argo (controller
+   in another cluster), native-Helm release annotations — by reading the workload's
+   labels via a **precedence cascade** (§4). Output: every workload tagged with an
+   **overlay key** (which release unit / app it belongs to) and a **tier** (how
+   strong that signal is).
+
+2. **`applications_identity.go` (per cluster, OSS) — identity, within a cluster.**
+   Takes the per-cluster app rows and decides which are **env-variants of one
+   logical app** (`billing-dev`, `billing-staging` → "billing" spanning dev +
+   staging). It attaches an **identity** to each row:
+   - `key` — the logical app name (the display name of the group)
+   - `env` — this instance's environment (dev | staging | prod | …)
+   - `source` — *how* we concluded it (the provenance tier; see §5)
+   - `portable` — *may this fold across clusters?* (see §6)
+
+3. **Hub + fleet fold (cross cluster) — identity, across clusters.** The hub gathers
+   every cluster's rows and merges them in **two stages** (see §6): first it merges
+   any rows sharing the same overlay key (`app.Key`) into one fleet row — a
+   *structural* join that can span clusters even for non-declared apps; then the
+   fleet fold (`foldAppGroups`, a shared k8s-ui util that Radar Cloud renders)
+   collapses the remaining differently-keyed rows that share a **portable**
+   identity. Non-portable, differently-keyed rows stay per-cluster.
+
+---
+
+## 4. The composition cascade (the 9 tiers)
+
+When the topology graph can't connect two roots, `pkg/subject` consolidates them
+from the workload's labels, walking signals in strict precedence — the **first**
+(lowest-numbered) that matches wins. The ranking is **"how strongly does this
+signal indicate the release unit"**: a GitOps/Helm manager *is* a release unit (it
+deploys a set of workloads together), so it outranks any membership label.
+
+| Tier | Signal | Kind |
+|------|--------|------|
+| 1 | Flux HelmRelease (`helm.toolkit.fluxcd.io/*`) | **Release unit** (declared GitOps) |
+| 2 | Flux Kustomization (`kustomize.toolkit.fluxcd.io/*`) | **Release unit** (declared GitOps) |
+| 3 | Argo tracking-id (`argocd.argoproj.io/tracking-id`) | **Release unit** (declared GitOps) |
+| 4 | Argo instance (`argocd.argoproj.io/instance`) | **Release unit** (declared GitOps) |
+| 5 | Helm release (`meta.helm.sh/release-name`) | **Release unit** (Helm) |
+| 6 | `app.kubernetes.io/instance` | Membership label |
+| 7 | `app.kubernetes.io/part-of` | Membership label |
+| 8 | `app.kubernetes.io/name` | **Name** |
+| 9 | bare `app` / name heuristic | **Name** — *disabled in Applications today* |
+
+Confidence: **tiers 1–4 are high** (GitOps controllers), **tiers 5–8 are medium**
+(`meta.helm.sh/release-name`, `instance`, `part-of`, `name`), the rest low. So a
+Helm-release (tier 5) is a release *unit* but only *medium* confidence, not high.
+**Tier 9 (bare `app`) is off by default** — the Applications path calls the
+resolver with `allowBareApp=false`, and the overlay is dropped entirely when bare
+`app` would be the winner. So in practice the active cascade is tiers 1–8.
+
+**Two consequences of the ranking:** a workload released by its own Argo App
+(tier 3) wins on tier over a shared `part-of` (tier 7), so `part-of` doesn't *name*
+its app (§2's rule, with the union-find caveat there). And the most important split
+for the *cross-cluster* layer is **declared GitOps origin (1–4) vs. a name (6–8)**
+(see §6).
+
+---
+
+## 5. The identity tiers (the provenance `source`)
+
+Layer 2 re-expresses the same declared-vs-name split as a `source` on the wire, so
+the cross-cluster layer can make a safe decision from a machine-readable field
+(not a human evidence string). Three families:
+
+- **Explicit** — `app.skyhook.io/app` annotation. The user *deliberately* declares
+  "this is app X." Authoritative; overrides everything. *The escape hatch (§8).*
+- **Declared origins** — `argo-path`, `argo-appset`, `flux-source`. A shared
+  *upstream*: a GitOps source path with an env overlay, an ApplicationSet that fans
+  one app across envs, a Flux Kustomization path.
+- **Names** — `label` (`app.kubernetes.io/name`), `name-stem` (inferred from the
+  workload name + a shared image repo), `namespace`.
+
+---
+
+## 6. Cross-cluster — there are TWO joins, not one
+
+This is the part most people (including an early draft of this doc) get wrong.
+Two rows from two clusters can end up as one fleet row via **two different
+mechanisms**, and only the second is "declared-only":
+
+**Join A — the hub merges by overlay key (`app.Key`), first.** The hub stores
+rows under `rows[app.Key]` — the per-cluster overlay key. If two clusters produce
+the **same overlay key**, they become **one fleet row with a cell per cluster**,
+*before identity or portability is even considered.* For a declared app (Argo)
+the key is cluster-specific (the Argo identity), so this rarely fires. But for a
+**raw app with no GitOps signal, the key is `<ns>/<kind>/<name>`** — so two
+clusters each running `default/Deployment/redis` **merge into one `redis` row.**
+This join is **structural, not declared-only** — it's a name+namespace match, and
+the frontend cannot un-merge what the hub already merged. *(See the open question
+at the end — this is arguably an over-merge that should be cluster-scoped for
+non-declared rows.)*
+
+**Join B — the fleet fold by portable identity, second.** For rows that did *not*
+key-merge (different `app.Key` per cluster — the normal case for declared apps
+named per-env, e.g. `billing-dev` vs `billing-prod`), `foldAppGroups` collapses
+those that share a **portable identity**. *This* is the declared-only join:
+
+- A **declared origin is collision-free** — same Argo path / ApplicationSet / Flux
+  source / explicit annotation ⇒ the same app ⇒ `portable = true` ⇒ fold.
+- A **name collides** (two teams' `redis`) ⇒ `portable = false` ⇒ **not** folded by
+  Join B; the row stays scoped to its cluster (`localScope`).
+
+So the precise rule is: **`portable = true` only for explicit + declared origins,
+and that governs Join B. Join A (the hub key-merge) is a separate, structural
+match that declared-only does not currently constrain.** Join B is why grouping
+looks "less aggressive" than naive name-matching for *differently-keyed* apps —
+that's the point; naive matching merged unrelated apps and reported their health
+as one. Join A is the gap where a name-based cross-cluster merge can still slip
+through.
+
+---
+
+## 7. Two subtleties that trip people up
+
+**`pathKey` — display the name, fold by name **and** path.** A co-located
+declared-path identity (`argo-path`/`flux-source`) *shows* its name stem as `key`
+— so that within one cluster a declared instance (`billing-staging`, from
+`apps/billing/overlays/staging`) folds with a raw-but-corroborated sibling
+(`billing` in dev, no path) — and carries the path stem in `pathKey`. The fleet
+fold (Join B) keys portable rows on **`key` + `pathKey`** (literally
+`portable:${key}:${pathKey}`): same name *and* same path → fold; same name but
+*different* path (`teamA/billing` vs `teamB/billing`) → stay apart. Name for
+display, name+path for the join.
+*(Caveat: this is the co-located shape. A **hub-spoke** Argo claim instead puts the
+path stem directly in `key` and leaves `pathKey` empty — so it's already
+collision-safe by construction, but its `key` looks different from a co-located
+row's display-name key. Two identical apps that are co-located in one cluster and
+hub-spoke in another therefore won't fold together — a known seam.)*
+
+**Add-ons are the one exception to "no name folds."** Platform inventory (coredns,
+kube-proxy, cert-manager…) — classified as add-ons, not *your* apps — may fold
+across clusters **by name when a shared helm chart or dominant image corroborates**
+it's the same software. The harm of a wrong add-on merge is low (it's inventory,
+not app health), so the bar is corroboration, not a declared origin. Your apps
+never get this latitude.
+
+---
+
+## 8. The user's escape hatch — "how do I force grouping?"
+
+When an app has only a name (no GitOps origin), it stays per-cluster — *and the
+operator needs to know why and how to fix it.* The answer:
+
+> Set **`app.skyhook.io/app: <name>`** on the app's workloads, the **same value in
+> every cluster**, and Radar folds them. (Or deploy via Argo/Flux with the
+> environment in the source path.)
+
+Because the user sets it deliberately, it's a true cross-cluster declaration
+(zero collision) — `source = explicit`, `portable = true`, highest precedence.
+The in-product tooltip on each row says exactly this when a row is per-cluster.
+
+---
+
+## 9. The hub-spoke twist (centralized Argo)
+
+In hub-spoke Argo the Application *object* lives on a **controller** cluster while
+its **workloads** run on a **member** cluster — so the member's own rows never see
+the Application, and only the fleet hub sees both. The hub reads each Application's
+declared identity + its `spec.destination`, resolves the destination to a member
+cluster, and **stamps** the declared identity onto that cluster's matching
+workload rows. After that, the normal portable fold (§6) takes over.
+
+---
+
+## 10. Worked examples
+
+**Composition (what is one app):**
+
+0. **`backend` and `frontend`, each its own Argo Application, same repo, both
+   labeled `part-of: shop`.** → Each climbs to its *own* Argo App and stops →
+   **two apps**, not one "shop." The shared `part-of` (tier 7) never overrides the
+   per-Application release boundary (tier 3). This is the anti-umbrella rule. ✓
+
+**Identity (same app across envs/clusters):**
+
+1. **`billing` deployed dev + prod via the same Argo path** `apps/billing/overlays/<env>`.
+   → Tier 3 (Argo) → `source=argo-path`, `key=billing`, `pathKey=apps/billing`,
+   `portable=true`. Both clusters' rows fold into one **billing · dev prod** row. ✓
+
+2. **Two teams' `redis`, no GitOps, in *different* namespaces** (`team-a/redis`,
+   `team-b/redis`), different clusters.
+   → different overlay keys → **no Join-A merge**; tier 8 (name) → `portable=false`
+   → **no Join-B fold**. They **stay per-cluster** — two `redis` rows. ✓
+   *But* if both were `default/redis` (same `ns/kind/name`), they'd share an
+   overlay key and **Join A would merge them at the hub** regardless of
+   declared-only (the §6 caveat). To fold reliably *if* they're really one app:
+   add `app.skyhook.io/app`.
+
+3. **`coredns` in `kube-system` on both clusters.**
+   → add-on, same name + same chart → folds across clusters as one add-on row,
+   *because* the chart corroborates it's the same software (§7). ✓
+
+---
+
+## 11. Where the code lives
+
+| Concern | File |
+|---------|------|
+| **Composition: the boundary** — `structuralRoot`, `rootOf`, `groupApplications`, `inputAtoms`, the union-find over atoms | `internal/server/applications.go` |
+| Composition: the overlay signal cascade (the 9 tiers, `ResolveOverlay`) | `pkg/subject/overlay.go` |
+| Identity within a cluster: env grouping + `source`/`portable`/`pathKey` | `internal/server/applications_identity.go` |
+| Hub: Join A (key-merge), forward identity, declared-only promotion, hub-spoke claim stamping, add-on fold | `radar-hub: internal/server/fleet_applications.go` → `ComputeFleetApplications` |
+| Cross-cluster Join B (fold by `key`+`pathKey` when `portable`) | `packages/k8s-ui/src/utils/applications.ts` → `foldAppGroups` |
+| The "why grouped / how to fold" tooltip | `packages/k8s-ui/src/components/applications/AppTooltips.tsx` |
+
+**One-line summary:** *compose workloads into apps by the strongest deploy/release
+signal (stopping at the manager, never the shared repo); across clusters, the hub
+first merges identical overlay keys (structural — watch for raw-name over-merge),
+then folds the rest only on collision-free declared origins.*
+
+---
+
+## 12. Known gaps / open questions
+
+- **Join A undercuts declared-only for raw apps (§6).** The hub merges rows by
+  overlay key *before* portability. Raw apps key on `<ns>/<kind>/<name>`, so two
+  clusters' `default/redis` merge into one fleet row even though "names shouldn't
+  fold." Declared-only governs Join B but not Join A. *Open: should the hub scope
+  non-declared overlay keys by cluster, so only declared identities cross?*
+- **Co-located vs hub-spoke key shape (§7).** A path-declared app keys on its
+  display name + `pathKey` when co-located, but on the path stem (no `pathKey`)
+  when stamped from a hub-spoke claim — so the same app in both topologies won't
+  fold. Rare, but a real seam.
+- **Umbrella Helm charts (§2).** A chart bundling many independently-versioned
+  services is one release unit → one app. If that's too coarse, the refinement is
+  to split by independently-versioned image — not today's behavior.

--- a/internal/server/applications.go
+++ b/internal/server/applications.go
@@ -45,7 +45,31 @@ import (
 
 // applicationsResponse is the GET /api/applications body.
 type applicationsResponse struct {
-	Applications []appRow `json:"applications"`
+	Applications []appRow    `json:"applications"`
+	ArgoClaims   []argoClaim `json:"argoClaims,omitempty"`
+}
+
+// argoClaim propagates a declared Argo Application identity to the cluster its
+// workloads actually run in. In hub-spoke Argo the Application CR lives in a
+// control cluster while its workloads run in a member cluster, so this cluster's
+// workload rows never see the Application — only the fleet hub, which knows every
+// cluster, can stamp the identity onto the destination's rows. Emitted only for
+// Applications with a DECLARED-portable identity (Argo source path / validated
+// ApplicationSet fan-out); name/label apps are never propagated cross-cluster.
+type argoClaim struct {
+	Identity      *appIdentity  `json:"identity"`
+	DestServer    string        `json:"destServer,omitempty"`
+	DestName      string        `json:"destName,omitempty"`
+	DestNamespace string        `json:"destNamespace,omitempty"`
+	Workloads     []workloadRef `json:"workloads,omitempty"` // managed workloads (status.resources)
+}
+
+// workloadRef identifies one managed workload for the hub to match against a
+// destination cluster's rows.
+type workloadRef struct {
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
 }
 
 const applicationsCacheTTL = 60 * time.Second
@@ -58,8 +82,9 @@ var (
 )
 
 type applicationsCacheEntry struct {
-	at   time.Time
-	rows []appRow
+	at     time.Time
+	rows   []appRow
+	claims []argoClaim
 }
 
 // appRow is one logical app in this cluster.
@@ -133,6 +158,9 @@ type appWorkload struct {
 	// identity the chart/author declared. The strongest identity signal we have:
 	// app-identity resolver input, not on the wire.
 	nameLabel string
+	// appAnnotation is app.skyhook.io/app — the user's explicit cross-cluster app
+	// declaration (authoritative, portable). Resolver input, not on the wire.
+	appAnnotation string
 }
 
 // handleListApplications serves GET /api/applications.
@@ -182,20 +210,23 @@ func ListApplications(ctx context.Context, namespaces []string) (*applicationsRe
 	entry, hit := applicationsCache[cacheKey]
 	applicationsCacheMu.Unlock()
 	if hit && time.Since(entry.at) < applicationsCacheTTL {
-		return &applicationsResponse{Applications: entry.rows}, nil
+		return &applicationsResponse{Applications: entry.rows, ArgoClaims: entry.claims}, nil
 	}
 
 	g := buildAppGraph(cache, namespaces)
 	wls := collectAppWorkloads(cache, namespaces, g)
 	rows := groupApplications(wls)
-	resolveAppIdentities(rows, argoSourcePaths(ctx, cache), namespaceEnvLabels(cache))
+	sourcePaths, appSetChildren := argoApplicationFacts(ctx, cache)
+	appSetByKey := appSetFanouts(appSetChildren)
+	resolveAppIdentities(rows, sourcePaths, appSetByKey, namespaceEnvLabels(cache))
+	claims := collectArgoClaims(ctx, cache, sourcePaths, appSetByKey, namespaces)
 	applicationsCacheMu.Lock()
 	if len(applicationsCache) >= applicationsCacheMaxEntries {
 		evictOldestApplicationsCacheEntry()
 	}
-	applicationsCache[cacheKey] = applicationsCacheEntry{at: time.Now(), rows: rows}
+	applicationsCache[cacheKey] = applicationsCacheEntry{at: time.Now(), rows: rows, claims: claims}
 	applicationsCacheMu.Unlock()
-	return &applicationsResponse{Applications: rows}, nil
+	return &applicationsResponse{Applications: rows, ArgoClaims: claims}, nil
 }
 
 func evictOldestApplicationsCacheEntry() {
@@ -417,6 +448,7 @@ func collectAppWorkloads(cache *k8s.ResourceCache, namespaces []string, g *appGr
 				Reason:        reason,
 				envLabel:      envLabelOf(lbls),
 				nameLabel:     lbls["app.kubernetes.io/name"],
+				appAnnotation: strings.TrimSpace(anns[appIdentityAnnotation]),
 			},
 			overlay:  subject.ResolveOverlay(&meta, false),
 			events:   eventsForWorkload(eventsByObj[ns], kind, name, pods),

--- a/internal/server/applications.go
+++ b/internal/server/applications.go
@@ -218,7 +218,7 @@ func ListApplications(ctx context.Context, namespaces []string) (*applicationsRe
 	rows := groupApplications(wls)
 	sourcePaths, appSetChildren, argoItems := argoApplicationFacts(ctx, cache)
 	appSetByKey := appSetFanouts(appSetChildren)
-	resolveAppIdentities(rows, sourcePaths, appSetByKey, namespaceEnvLabels(cache))
+	resolveAppIdentities(rows, sourcePaths, appSetByKey, namespaceEnvLabels(cache), fluxKustomizationFacts(ctx, cache))
 	claims := collectArgoClaims(argoItems, sourcePaths, appSetByKey, namespaces)
 	applicationsCacheMu.Lock()
 	if len(applicationsCache) >= applicationsCacheMaxEntries {

--- a/internal/server/applications.go
+++ b/internal/server/applications.go
@@ -216,10 +216,10 @@ func ListApplications(ctx context.Context, namespaces []string) (*applicationsRe
 	g := buildAppGraph(cache, namespaces)
 	wls := collectAppWorkloads(cache, namespaces, g)
 	rows := groupApplications(wls)
-	sourcePaths, appSetChildren := argoApplicationFacts(ctx, cache)
+	sourcePaths, appSetChildren, argoItems := argoApplicationFacts(ctx, cache)
 	appSetByKey := appSetFanouts(appSetChildren)
 	resolveAppIdentities(rows, sourcePaths, appSetByKey, namespaceEnvLabels(cache))
-	claims := collectArgoClaims(ctx, cache, sourcePaths, appSetByKey, namespaces)
+	claims := collectArgoClaims(argoItems, sourcePaths, appSetByKey, namespaces)
 	applicationsCacheMu.Lock()
 	if len(applicationsCache) >= applicationsCacheMaxEntries {
 		evictOldestApplicationsCacheEntry()

--- a/internal/server/applications.go
+++ b/internal/server/applications.go
@@ -129,6 +129,10 @@ type appWorkload struct {
 	// envLabel is the explicit environment label, when the workload carries
 	// one (see envLabelOf) — app-identity resolver input, not on the wire.
 	envLabel string
+	// nameLabel is app.kubernetes.io/name — the explicit, cluster-agnostic app
+	// identity the chart/author declared. The strongest identity signal we have:
+	// app-identity resolver input, not on the wire.
+	nameLabel string
 }
 
 // handleListApplications serves GET /api/applications.
@@ -412,6 +416,7 @@ func collectAppWorkloads(cache *k8s.ResourceCache, namespaces []string, g *appGr
 				Restarts:      restarts,
 				Reason:        reason,
 				envLabel:      envLabelOf(lbls),
+				nameLabel:     lbls["app.kubernetes.io/name"],
 			},
 			overlay:  subject.ResolveOverlay(&meta, false),
 			events:   eventsForWorkload(eventsByObj[ns], kind, name, pods),

--- a/internal/server/applications_identity.go
+++ b/internal/server/applications_identity.go
@@ -889,12 +889,18 @@ func collectArgoClaims(ctx context.Context, cache resourceLister, sourcePaths ma
 	if err != nil {
 		return nil
 	}
-	// Scope claims to the caller's allowed namespaces (when filtered): an
-	// Application is a namespaced resource, and its claim exposes its destination +
-	// managed workloads, so a namespace-scoped user must not receive claims for
-	// Applications outside their visibility. Empty filter = unscoped (all).
+	// Scope claims to the caller's visibility. namespaces is nil for full access
+	// (no-auth local / the fleet hub), a non-nil EMPTY slice for explicit no
+	// access (noNamespaceAccess), and a non-nil non-empty set when scoped. A claim
+	// exposes an Application's destination + managed workloads, so a no-access
+	// caller gets nothing, and a scoped caller gets a claim only when it can see at
+	// least one of the workloads the Application MANAGES — filtering by the
+	// workload namespaces, not the Application's (which often lives in argocd).
+	if noNamespaceAccess(namespaces) {
+		return nil
+	}
 	var allowed map[string]bool
-	if len(namespaces) > 0 {
+	if namespaces != nil {
 		allowed = make(map[string]bool, len(namespaces))
 		for _, ns := range namespaces {
 			allowed[ns] = true
@@ -902,9 +908,6 @@ func collectArgoClaims(ctx context.Context, cache resourceLister, sourcePaths ma
 	}
 	var claims []argoClaim
 	for _, item := range items {
-		if allowed != nil && !allowed[item.GetNamespace()] {
-			continue
-		}
 		name := item.GetName()
 		nsKey := name
 		if ns := item.GetNamespace(); ns != "" {
@@ -936,9 +939,23 @@ func collectArgoClaims(ctx context.Context, cache resourceLister, sourcePaths ma
 			claim.DestNamespace, _ = dest["namespace"].(string)
 		}
 		claim.Workloads = argoManagedWorkloads(item)
+		if allowed != nil && !managedWorkloadVisible(claim.Workloads, allowed) {
+			continue // scoped caller can't see any workload this Application manages
+		}
 		claims = append(claims, claim)
 	}
 	return claims
+}
+
+// managedWorkloadVisible reports whether the caller (allowed namespace set) can
+// see at least one of the workloads an Argo claim manages.
+func managedWorkloadVisible(workloads []workloadRef, allowed map[string]bool) bool {
+	for _, w := range workloads {
+		if allowed[w.Namespace] {
+			return true
+		}
+	}
+	return false
 }
 
 // argoManagedWorkloads extracts the workload resources an Argo Application

--- a/internal/server/applications_identity.go
+++ b/internal/server/applications_identity.go
@@ -914,16 +914,22 @@ func collectArgoClaims(ctx context.Context, cache resourceLister, sourcePaths ma
 			nsKey = ns + "/" + name
 		}
 
-		// Declared identity: ApplicationSet fan-out first (a set declares the
-		// sibling relationship), else an env-bearing source path.
+		// Declared identity: an env-bearing source path FIRST, else an
+		// ApplicationSet fan-out. This MUST match resolveAppIdentities' row-level
+		// precedence (argo-path outranks argo-appset) — otherwise a co-located row
+		// keyed by its path and the claim keyed by its set would disagree and fail
+		// to fold.
 		var id *appIdentity
-		if fan, ok := appSetByKey[nsKey]; ok {
-			id = &appIdentity{Key: fan.stem, Env: fan.env, Confidence: "high", Portable: true, Source: SourceArgoAppSet,
-				Evidence: fmt.Sprintf("ApplicationSet fan-out %q (env %s)", fan.stem, fan.env)}
-		} else if path, ok := sourcePaths[nsKey]; ok {
+		if path, ok := sourcePaths[nsKey]; ok {
 			if stem, env := pathStemEnv(path); stem != "" {
 				id = &appIdentity{Key: stem, Env: env, Confidence: "high", Portable: true, Source: SourceArgoPath,
 					Evidence: "Argo CD source path " + stem + " (env overlay " + env + ")"}
+			}
+		}
+		if id == nil {
+			if fan, ok := appSetByKey[nsKey]; ok {
+				id = &appIdentity{Key: fan.stem, Env: fan.env, Confidence: "high", Portable: true, Source: SourceArgoAppSet,
+					Evidence: fmt.Sprintf("ApplicationSet fan-out %q (env %s)", fan.stem, fan.env)}
 			}
 		}
 		if id == nil {

--- a/internal/server/applications_identity.go
+++ b/internal/server/applications_identity.go
@@ -66,6 +66,13 @@ type appIdentity struct {
 	// shared upstream and are collision-free across clusters; NAMES (label,
 	// name-stem, namespace) collide (two teams' "redis") and stay per-cluster.
 	Source string `json:"source,omitempty"`
+	// PathKey is the declared source-PATH stem (argo-path / flux-source only). The
+	// display Key is the NAME stem (so a declared-path instance folds with a
+	// raw-but-corroborated sibling WITHIN a cluster), but two different apps can
+	// share a name while declaring different paths — so the fleet fold disambiguates
+	// portable rows by PathKey, keeping same-name/different-path apps apart across
+	// clusters. Empty for non-path tiers (their own Key is already collision-safe).
+	PathKey string `json:"pathKey,omitempty"`
 }
 
 // App identity provenance tiers (appIdentity.Source). The declaredOrigin set is
@@ -571,12 +578,13 @@ func resolveAppIdentities(rows []appRow, argoSourcePaths map[string]string, appS
 			}
 		}
 		for _, c := range members {
-			conf, why, portable, source := "medium", "", false, SourceNameStem
+			conf, why, portable, source, pathKey := "medium", "", false, SourceNameStem, ""
 			switch {
 			case c.pathStem != "":
 				conf = "high"
 				portable = true
 				source = c.pathSource
+				pathKey = c.pathStem
 				origin := "Argo CD source path"
 				if c.pathSource == SourceFluxSource {
 					origin = "Flux source path"
@@ -592,7 +600,7 @@ func resolveAppIdentities(rows []appRow, argoSourcePaths map[string]string, appS
 			default:
 				continue
 			}
-			c.row.Identity = &appIdentity{Key: stem, Env: c.env, Confidence: conf, Evidence: why, Portable: portable, Source: source}
+			c.row.Identity = &appIdentity{Key: stem, Env: c.env, Confidence: conf, Evidence: why, Portable: portable, Source: source, PathKey: pathKey}
 		}
 	}
 

--- a/internal/server/applications_identity.go
+++ b/internal/server/applications_identity.go
@@ -240,12 +240,13 @@ type identityCandidate struct {
 // in-cluster Argo Application name → its source path.
 func resolveAppIdentities(rows []appRow, argoSourcePaths map[string]string, nsEnvLabels map[string]string) {
 	type rowInfo struct {
-		row      *appRow
-		readings []reading
-		repos    map[string]bool
-		pathStem string
-		pathEnv  string
-		labelEnv string // explicit env label (workload, else namespace)
+		row       *appRow
+		readings  []reading
+		repos     map[string]bool
+		pathStem  string
+		pathEnv   string
+		labelEnv  string // explicit env label (workload, else namespace)
+		nameLabel string // app.kubernetes.io/name, when the row's workloads agree
 	}
 	infos := make([]rowInfo, 0, len(rows))
 	clusterNamespaces := map[string]bool{}
@@ -263,6 +264,7 @@ func resolveAppIdentities(rows []appRow, argoSourcePaths map[string]string, nsEn
 		}
 		info := rowInfo{row: r, readings: readingsOf(r.Name, ns), repos: map[string]bool{}}
 		wlEnv, wlEnvAgree := "", true
+		wlName, wlNameAgree := "", true
 		for _, w := range r.Workloads {
 			if repo := imageRepo(w.Image); repo != "" {
 				info.repos[repo] = true
@@ -274,11 +276,21 @@ func resolveAppIdentities(rows []appRow, argoSourcePaths map[string]string, nsEn
 					wlEnvAgree = false // disagreeing labels — refuse the tier
 				}
 			}
+			if w.nameLabel != "" {
+				if wlName == "" {
+					wlName = w.nameLabel
+				} else if wlName != w.nameLabel {
+					wlNameAgree = false // disagreeing app names — not one app
+				}
+			}
 		}
 		if wlEnv != "" && wlEnvAgree {
 			info.labelEnv = wlEnv
 		} else if v := nsEnvLabels[ns]; v != "" {
 			info.labelEnv = v
+		}
+		if wlName != "" && wlNameAgree {
+			info.nameLabel = wlName
 		}
 		if r.Tier == 3 || r.Tier == 4 {
 			for _, key := range argoSourcePathKeys(r.Key) {
@@ -524,6 +536,51 @@ func resolveAppIdentities(rows []appRow, argoSourcePaths map[string]string, nsEn
 				continue
 			}
 			c.row.Identity = &appIdentity{Key: stem, Env: c.env, Confidence: conf, Evidence: why, Portable: portable}
+		}
+	}
+
+	// Label tier — app.kubernetes.io/name is an explicit, cluster-agnostic app
+	// identity the chart/author declared. Unlike a name stem it needs no
+	// affix-stripping and no in-cluster group to corroborate, so it stands alone
+	// (single-instance rows included) and gives a clean, cluster-agnostic key.
+	//
+	// It is NOT portable on its own, though: a bare label is a per-cluster
+	// identity, not a cross-cluster guarantee — a generic name ("api", "web") or
+	// a reused chart name would otherwise collapse unrelated apps across clusters.
+	// Cross-cluster folding is the fleet consumer's corroborated decision (it has
+	// the cluster names + cross-cluster repo/env signal the per-cluster resolver
+	// lacks). The label still upgrades the weaker name-stem / namespace tiers and
+	// does NOT override a declared Argo source-path identity.
+	for i := range infos {
+		info := &infos[i]
+		if info.nameLabel == "" {
+			continue
+		}
+		if cur := info.row.Identity; cur != nil && cur.Confidence == "high" {
+			continue
+		}
+		env := ""
+		switch {
+		case info.row.Identity != nil && info.row.Identity.Env != "":
+			env = info.row.Identity.Env
+		case info.labelEnv != "":
+			env = canonicalEnvToken(info.labelEnv)
+		case info.pathEnv != "":
+			env = canonicalEnvToken(info.pathEnv)
+		default:
+			for _, rd := range info.readings {
+				if _, isTrio := trioEnv(rd.token); isTrio || qualified[rd.token] {
+					env = canonicalEnvToken(rd.token)
+					break
+				}
+			}
+		}
+		info.row.Identity = &appIdentity{
+			Key:        info.nameLabel,
+			Env:        env,
+			Confidence: "high",
+			Evidence:   fmt.Sprintf("app.kubernetes.io/name=%q", info.nameLabel),
+			Portable:   false,
 		}
 	}
 }

--- a/internal/server/applications_identity.go
+++ b/internal/server/applications_identity.go
@@ -244,13 +244,14 @@ func pathStemEnv(path string) (stem, env string) {
 
 // identityCandidate is one row's chosen env-instance reading, post-qualification.
 type identityCandidate struct {
-	row      *appRow
-	stem     string
-	env      string // canonical display token
-	pathStem string // F1 declared stem ("" when none)
-	labelEnv string // explicit env label ("" when none)
-	repos    map[string]bool
-	prio     int
+	row        *appRow
+	stem       string
+	env        string // canonical display token
+	pathStem   string // F1 declared stem ("" when none)
+	pathSource string // SourceArgoPath | SourceFluxSource for the declared path stem
+	labelEnv   string // explicit env label ("" when none)
+	repos      map[string]bool
+	prio       int
 	// adopted: this member's env token never qualified on its own — it joins
 	// only because the stem-group's CORE proved itself (≥2 qualified envs),
 	// and it never counts toward that proof. Single-token namespaces only;
@@ -262,16 +263,17 @@ type identityCandidate struct {
 // Two phases: discover which tokens are envs from the cluster's structure,
 // then form app groups using only qualified tokens. argoSourcePaths maps an
 // in-cluster Argo Application name → its source path.
-func resolveAppIdentities(rows []appRow, argoSourcePaths map[string]string, appSetByKey map[string]appSetFanout, nsEnvLabels map[string]string) {
+func resolveAppIdentities(rows []appRow, argoSourcePaths map[string]string, appSetByKey map[string]appSetFanout, nsEnvLabels map[string]string, fluxPaths map[string]string) {
 	type rowInfo struct {
-		row       *appRow
-		readings  []reading
-		repos     map[string]bool
-		pathStem  string
-		pathEnv   string
-		labelEnv  string // explicit env label (workload, else namespace)
-		nameLabel string // app.kubernetes.io/name, when the row's workloads agree
-		appAnno   string // app.skyhook.io/app explicit declaration, when workloads agree
+		row        *appRow
+		readings   []reading
+		repos      map[string]bool
+		pathStem   string
+		pathEnv    string
+		pathSource string // SourceArgoPath | SourceFluxSource for the declared path stem
+		labelEnv   string // explicit env label (workload, else namespace)
+		nameLabel  string // app.kubernetes.io/name, when the row's workloads agree
+		appAnno    string // app.skyhook.io/app explicit declaration, when workloads agree
 	}
 	infos := make([]rowInfo, 0, len(rows))
 	clusterNamespaces := map[string]bool{}
@@ -336,7 +338,16 @@ func resolveAppIdentities(rows []appRow, argoSourcePaths map[string]string, appS
 			for _, key := range argoSourcePathKeys(r.Key) {
 				if p, ok := argoSourcePaths[key]; ok {
 					if ps, pe := pathStemEnv(p); ps != "" {
-						info.pathStem, info.pathEnv = ps, pe
+						info.pathStem, info.pathEnv, info.pathSource = ps, pe, SourceArgoPath
+					}
+					break
+				}
+			}
+		} else if r.Tier == 2 { // Flux Kustomization — its source path is a declared origin, like Argo's.
+			for _, key := range argoSourcePathKeys(r.Key) {
+				if p, ok := fluxPaths[key]; ok {
+					if ps, pe := pathStemEnv(p); ps != "" {
+						info.pathStem, info.pathEnv, info.pathSource = ps, pe, SourceFluxSource
 					}
 					break
 				}
@@ -503,7 +514,7 @@ func resolveAppIdentities(rows []appRow, argoSourcePaths map[string]string, appS
 			}
 			continue
 		}
-		c := &identityCandidate{row: info.row, repos: info.repos, pathStem: info.pathStem, labelEnv: info.labelEnv}
+		c := &identityCandidate{row: info.row, repos: info.repos, pathStem: info.pathStem, pathSource: info.pathSource, labelEnv: info.labelEnv}
 		if chosen != nil {
 			c.stem = chosen.stem
 			c.env = canonicalEnvToken(chosen.token)
@@ -565,8 +576,12 @@ func resolveAppIdentities(rows []appRow, argoSourcePaths map[string]string, appS
 			case c.pathStem != "":
 				conf = "high"
 				portable = true
-				source = SourceArgoPath
-				why = "Argo CD source path " + c.pathStem + " (env overlay " + c.env + ")"
+				source = c.pathSource
+				origin := "Argo CD source path"
+				if c.pathSource == SourceFluxSource {
+					origin = "Flux source path"
+				}
+				why = origin + " " + c.pathStem + " (env overlay " + c.env + ")"
 			case c.labelEnv != "":
 				why = fmt.Sprintf("environment label %q + name/repo evidence", c.labelEnv)
 			case c.prio >= 2:
@@ -769,6 +784,49 @@ func argoSourcePathKeys(rowKey string) []string {
 		return []string{name}
 	}
 	return []string{ns + "/" + name, name}
+}
+
+// fluxKustomizationFacts maps each Flux Kustomization to its env-bearing source
+// path — the flux-source identity feed, mirroring the Argo source-path map. A
+// Kustomization's spec.path is a declared origin just like an Argo Application's.
+// Namespaced key always emitted; bare-name fallback only when unambiguous.
+func fluxKustomizationFacts(ctx context.Context, cache resourceLister) map[string]string {
+	out := map[string]string{}
+	byName := map[string]string{}
+	ambiguous := map[string]bool{}
+	items, err := cache.ListDynamicWithGroup(ctx, "Kustomization", "", "kustomize.toolkit.fluxcd.io")
+	if err != nil {
+		return out
+	}
+	for _, item := range items {
+		spec, _ := item.Object["spec"].(map[string]any)
+		if spec == nil {
+			continue
+		}
+		p, _ := spec["path"].(string)
+		if p == "" {
+			continue
+		}
+		if stem, _ := pathStemEnv(p); stem == "" {
+			continue
+		}
+		name := item.GetName()
+		nsKey := name
+		if ns := item.GetNamespace(); ns != "" {
+			nsKey = ns + "/" + name
+		}
+		out[nsKey] = p
+		if prev, exists := byName[name]; exists && prev != p {
+			delete(byName, name)
+			ambiguous[name] = true
+		} else if !ambiguous[name] {
+			byName[name] = p
+		}
+	}
+	for name, path := range byName {
+		out[name] = path
+	}
+	return out
 }
 
 // nameSegments splits a resource name on - and _ into its tokens.

--- a/internal/server/applications_identity.go
+++ b/internal/server/applications_identity.go
@@ -812,14 +812,14 @@ func appSetOwnerName(item *unstructured.Unstructured) string {
 // source-path feed (appKey → env-bearing path) plus the ApplicationSet → children
 // grouping that drives the declared argo-appset fan-out tier. Missing CRD / no
 // Argo → empty maps (the name/label tiers still work).
-func argoApplicationFacts(ctx context.Context, cache resourceLister) (sourcePaths map[string]string, appSetChildren map[string][]argoChild) {
+func argoApplicationFacts(ctx context.Context, cache resourceLister) (sourcePaths map[string]string, appSetChildren map[string][]argoChild, items []*unstructured.Unstructured) {
 	sourcePaths = map[string]string{}
 	appSetChildren = map[string][]argoChild{}
 	byName := map[string]string{}
 	ambiguous := map[string]bool{}
 	items, err := cache.ListDynamicWithGroup(ctx, "Application", "", "argoproj.io")
 	if err != nil {
-		return sourcePaths, appSetChildren
+		return sourcePaths, appSetChildren, nil
 	}
 	for _, item := range items {
 		name := item.GetName()
@@ -868,7 +868,7 @@ func argoApplicationFacts(ctx context.Context, cache resourceLister) (sourcePath
 	for name, path := range byName {
 		sourcePaths[name] = path
 	}
-	return sourcePaths, appSetChildren
+	return sourcePaths, appSetChildren, items
 }
 
 // argoWorkloadKinds are the status.resources kinds the hub matches against a
@@ -884,11 +884,7 @@ var argoWorkloadKinds = map[string]bool{
 // so the hub can stamp that identity onto the destination cluster's workload rows
 // in a hub-spoke topology. Applications with no declared identity are skipped —
 // name/label identity never propagates across clusters.
-func collectArgoClaims(ctx context.Context, cache resourceLister, sourcePaths map[string]string, appSetByKey map[string]appSetFanout, namespaces []string) []argoClaim {
-	items, err := cache.ListDynamicWithGroup(ctx, "Application", "", "argoproj.io")
-	if err != nil {
-		return nil
-	}
+func collectArgoClaims(items []*unstructured.Unstructured, sourcePaths map[string]string, appSetByKey map[string]appSetFanout, namespaces []string) []argoClaim {
 	// Scope claims to the caller's visibility. namespaces is nil for full access
 	// (no-auth local / the fleet hub), a non-nil EMPTY slice for explicit no
 	// access (noNamespaceAccess), and a non-nil non-empty set when scoped. A claim

--- a/internal/server/applications_identity.go
+++ b/internal/server/applications_identity.go
@@ -60,7 +60,31 @@ type appIdentity struct {
 	// participate in cross-cluster grouping. Local name/repo evidence must be
 	// scoped by the fleet consumer.
 	Portable bool `json:"portable,omitempty"`
+	// Source is the machine-readable provenance tier, so the fleet consumer can
+	// decide cross-cluster promotion on the SOURCE, not on a human evidence
+	// string. Declared GitOps ORIGINS (argo-path, argo-appset, flux-source) name a
+	// shared upstream and are collision-free across clusters; NAMES (label,
+	// name-stem, namespace) collide (two teams' "redis") and stay per-cluster.
+	Source string `json:"source,omitempty"`
 }
+
+// App identity provenance tiers (appIdentity.Source). The declaredOrigin set is
+// the only one a fleet consumer may auto-promote to cross-cluster portable.
+const (
+	SourceExplicit   = "explicit"    // app.skyhook.io/app annotation — user-declared, authoritative
+	SourceArgoPath   = "argo-path"   // declared Argo Application source path (origin)
+	SourceArgoAppSet = "argo-appset" // declared ApplicationSet fan-out (origin)
+	SourceFluxSource = "flux-source" // declared Flux source ref (origin)
+	SourceLabel      = "label"       // app.kubernetes.io/name — a NAME, collision-prone
+	SourceNameStem   = "name-stem"   // inferred name-stem — a NAME
+	SourceNamespace  = "namespace"   // namespace stem — a NAME
+)
+
+// appIdentityAnnotation is the explicit, user-declared cross-cluster app key. Set
+// the SAME value on an app's workloads in every cluster and Radar folds them — the
+// canonical answer to "how do I force grouping?" for non-GitOps apps. Deliberate
+// (zero-collision), so it is authoritative over every inferred/declared tier.
+const appIdentityAnnotation = "app.skyhook.io/app"
 
 // The ONLY hardcoded env vocabulary: the universal trio, kept solely because
 // promotion DIRECTION (dev < staging < prod) cannot be derived from a
@@ -238,7 +262,7 @@ type identityCandidate struct {
 // Two phases: discover which tokens are envs from the cluster's structure,
 // then form app groups using only qualified tokens. argoSourcePaths maps an
 // in-cluster Argo Application name → its source path.
-func resolveAppIdentities(rows []appRow, argoSourcePaths map[string]string, nsEnvLabels map[string]string) {
+func resolveAppIdentities(rows []appRow, argoSourcePaths map[string]string, appSetByKey map[string]appSetFanout, nsEnvLabels map[string]string) {
 	type rowInfo struct {
 		row       *appRow
 		readings  []reading
@@ -247,6 +271,7 @@ func resolveAppIdentities(rows []appRow, argoSourcePaths map[string]string, nsEn
 		pathEnv   string
 		labelEnv  string // explicit env label (workload, else namespace)
 		nameLabel string // app.kubernetes.io/name, when the row's workloads agree
+		appAnno   string // app.skyhook.io/app explicit declaration, when workloads agree
 	}
 	infos := make([]rowInfo, 0, len(rows))
 	clusterNamespaces := map[string]bool{}
@@ -265,6 +290,7 @@ func resolveAppIdentities(rows []appRow, argoSourcePaths map[string]string, nsEn
 		info := rowInfo{row: r, readings: readingsOf(r.Name, ns), repos: map[string]bool{}}
 		wlEnv, wlEnvAgree := "", true
 		wlName, wlNameAgree := "", true
+		wlApp, wlAppAgree, wlAppCount := "", true, 0
 		for _, w := range r.Workloads {
 			if repo := imageRepo(w.Image); repo != "" {
 				info.repos[repo] = true
@@ -283,6 +309,14 @@ func resolveAppIdentities(rows []appRow, argoSourcePaths map[string]string, nsEn
 					wlNameAgree = false // disagreeing app names — not one app
 				}
 			}
+			if w.appAnnotation != "" {
+				wlAppCount++
+				if wlApp == "" {
+					wlApp = w.appAnnotation
+				} else if wlApp != w.appAnnotation {
+					wlAppAgree = false // disagreeing explicit keys — not one app
+				}
+			}
 		}
 		if wlEnv != "" && wlEnvAgree {
 			info.labelEnv = wlEnv
@@ -291,6 +325,12 @@ func resolveAppIdentities(rows []appRow, argoSourcePaths map[string]string, nsEn
 		}
 		if wlName != "" && wlNameAgree {
 			info.nameLabel = wlName
+		}
+		// Explicit identity is authoritative + portable, so demand EVERY workload
+		// in the row carry the same value — a partial annotation must not promote
+		// the whole app (including unannotated components) to a portable identity.
+		if wlApp != "" && wlAppAgree && wlAppCount == len(r.Workloads) {
+			info.appAnno = wlApp
 		}
 		if r.Tier == 3 || r.Tier == 4 {
 			for _, key := range argoSourcePathKeys(r.Key) {
@@ -520,23 +560,51 @@ func resolveAppIdentities(rows []appRow, argoSourcePaths map[string]string, nsEn
 			}
 		}
 		for _, c := range members {
-			conf, why, portable := "medium", "", false
+			conf, why, portable, source := "medium", "", false, SourceNameStem
 			switch {
 			case c.pathStem != "":
 				conf = "high"
 				portable = true
+				source = SourceArgoPath
 				why = "Argo CD source path " + c.pathStem + " (env overlay " + c.env + ")"
 			case c.labelEnv != "":
 				why = fmt.Sprintf("environment label %q + name/repo evidence", c.labelEnv)
 			case c.prio >= 2:
+				source = SourceNamespace
 				why = fmt.Sprintf("namespace stem %q + shared image repo %s", stem, shared)
 			case shared != "":
 				why = fmt.Sprintf("name stem %q + shared image repo %s", stem, shared)
 			default:
 				continue
 			}
-			c.row.Identity = &appIdentity{Key: stem, Env: c.env, Confidence: conf, Evidence: why, Portable: portable}
+			c.row.Identity = &appIdentity{Key: stem, Env: c.env, Confidence: conf, Evidence: why, Portable: portable, Source: source}
 		}
+	}
+
+	// Env for the standalone label/explicit tiers: an env already resolved by a
+	// stronger signal wins, else the explicit env label, else a declared overlay
+	// env, else the row's best structural reading (trio outranks discovered tokens,
+	// same precedence as phase 2's better()).
+	resolveStandaloneEnv := func(info *rowInfo) string {
+		switch {
+		case info.row.Identity != nil && info.row.Identity.Env != "":
+			return info.row.Identity.Env
+		case info.labelEnv != "":
+			return canonicalEnvToken(info.labelEnv)
+		case info.pathEnv != "":
+			return canonicalEnvToken(info.pathEnv)
+		}
+		for _, rd := range info.readings {
+			if _, isTrio := trioEnv(rd.token); isTrio {
+				return canonicalEnvToken(rd.token)
+			}
+		}
+		for _, rd := range info.readings {
+			if qualified[rd.token] {
+				return canonicalEnvToken(rd.token)
+			}
+		}
+		return ""
 	}
 
 	// Label tier — app.kubernetes.io/name is an explicit, cluster-agnostic app
@@ -559,39 +627,75 @@ func resolveAppIdentities(rows []appRow, argoSourcePaths map[string]string, nsEn
 		if cur := info.row.Identity; cur != nil && cur.Confidence == "high" {
 			continue
 		}
-		env := ""
-		switch {
-		case info.row.Identity != nil && info.row.Identity.Env != "":
-			env = info.row.Identity.Env
-		case info.labelEnv != "":
-			env = canonicalEnvToken(info.labelEnv)
-		case info.pathEnv != "":
-			env = canonicalEnvToken(info.pathEnv)
-		default:
-			// Prefer a trio token over a discovered one (the universal ladder
-			// outranks affix tokens — same precedence as phase 2's better()), so
-			// e.g. a `prod` namespace wins over a stray `staging` name affix.
-			for _, rd := range info.readings {
-				if _, isTrio := trioEnv(rd.token); isTrio {
-					env = canonicalEnvToken(rd.token)
-					break
-				}
-			}
-			if env == "" {
-				for _, rd := range info.readings {
-					if qualified[rd.token] {
-						env = canonicalEnvToken(rd.token)
-						break
-					}
-				}
-			}
-		}
 		info.row.Identity = &appIdentity{
 			Key:        info.nameLabel,
-			Env:        env,
+			Env:        resolveStandaloneEnv(info),
 			Confidence: "high",
 			Evidence:   fmt.Sprintf("app.kubernetes.io/name=%q", info.nameLabel),
 			Portable:   false,
+			Source:     SourceLabel,
+		}
+	}
+
+	// ApplicationSet fan-out tier — a single-app fan-out set DECLARES that its
+	// children are env-variants of one app, so its stem is a portable identity.
+	// The join is the set ownership (declared); appSetFanouts already confirmed the
+	// shape. Overrides the weaker name/label tiers but NOT a declared Argo source
+	// path (an app keeps one GitOps key across clusters) or the explicit tier.
+	if len(appSetByKey) > 0 {
+		for i := range infos {
+			info := &infos[i]
+			// Argo rows only (tier 3 tracking-id / 4 instance, as in the F1 path
+			// gate above). A raw or label-only workload that merely shares a name
+			// with an ApplicationSet child must NOT match the set via the bare-name
+			// key fallback — that would stamp a false portable identity onto an app
+			// the set doesn't manage.
+			if info.row.Tier != 3 && info.row.Tier != 4 {
+				continue
+			}
+			if cur := info.row.Identity; cur != nil && (cur.Source == SourceArgoPath || cur.Source == SourceExplicit) {
+				continue
+			}
+			var fan *appSetFanout
+			for _, key := range argoSourcePathKeys(info.row.Key) {
+				if f, ok := appSetByKey[key]; ok {
+					fan = &f
+					break
+				}
+			}
+			if fan == nil {
+				continue
+			}
+			env := fan.env
+			if env == "" {
+				env = resolveStandaloneEnv(info)
+			}
+			info.row.Identity = &appIdentity{
+				Key:        fan.stem,
+				Env:        env,
+				Confidence: "high",
+				Evidence:   fmt.Sprintf("ApplicationSet fan-out %q (env %s)", fan.stem, env),
+				Portable:   true,
+				Source:     SourceArgoAppSet,
+			}
+		}
+	}
+
+	// Explicit tier — app.skyhook.io/app is the user's deliberate cross-cluster
+	// declaration: authoritative (overrides every inferred/declared tier) and
+	// portable (the user opted in, so it is collision-free by construction).
+	for i := range infos {
+		info := &infos[i]
+		if info.appAnno == "" {
+			continue
+		}
+		info.row.Identity = &appIdentity{
+			Key:        info.appAnno,
+			Env:        resolveStandaloneEnv(info),
+			Confidence: "high",
+			Evidence:   fmt.Sprintf("%s=%q", appIdentityAnnotation, info.appAnno),
+			Portable:   true,
+			Source:     SourceExplicit,
 		}
 	}
 }
@@ -667,20 +771,66 @@ func argoSourcePathKeys(rowKey string) []string {
 	return []string{ns + "/" + name, name}
 }
 
-// argoSourcePaths maps each in-cluster Argo Application to a source path
-// carrying an env segment — the F1 evidence feed. Namespaced keys are always
-// emitted; bare-name fallback is emitted only when the name is unambiguous.
-// Multi-source apps pick the first env-bearing path. Missing CRD / no Argo →
-// empty map (F2 still works).
-func argoSourcePaths(ctx context.Context, cache resourceLister) map[string]string {
-	out := map[string]string{}
+// nameSegments splits a resource name on - and _ into its tokens.
+func nameSegments(s string) []string {
+	return strings.FieldsFunc(s, func(r rune) bool { return r == '-' || r == '_' })
+}
+
+// trivialStems recur across unrelated apps, so they must never anchor a grouping.
+var trivialStems = map[string]bool{
+	"api": true, "app": true, "web": true, "ui": true, "svc": true,
+	"service": true, "server": true, "worker": true, "frontend": true,
+	"backend": true, "gateway": true, "proxy": true,
+}
+
+func isTrivialStem(stem string) bool {
+	return len(stem) < 3 || trivialStems[strings.ToLower(stem)]
+}
+
+// argoChild is one ApplicationSet-generated Application — the appKey forms it
+// maps to (ns/name + bare name) plus the bare Application name used to test the
+// set's fan-out shape.
+type argoChild struct {
+	keys []string
+	name string
+}
+
+// appSetOwnerName returns the ApplicationSet that generated this Application:
+// the controller ownerReference (survives the cache transform), falling back to
+// the argocd.argoproj.io/application-set-name label when a GC/preserve policy
+// drops the ownerRef. "" when the Application is not set-generated.
+func appSetOwnerName(item *unstructured.Unstructured) string {
+	for _, ref := range item.GetOwnerReferences() {
+		if ref.Kind == "ApplicationSet" && ref.Name != "" {
+			return ref.Name
+		}
+	}
+	return item.GetLabels()["argocd.argoproj.io/application-set-name"]
+}
+
+// argoApplicationFacts lists in-cluster Argo Applications once and returns the F1
+// source-path feed (appKey → env-bearing path) plus the ApplicationSet → children
+// grouping that drives the declared argo-appset fan-out tier. Missing CRD / no
+// Argo → empty maps (the name/label tiers still work).
+func argoApplicationFacts(ctx context.Context, cache resourceLister) (sourcePaths map[string]string, appSetChildren map[string][]argoChild) {
+	sourcePaths = map[string]string{}
+	appSetChildren = map[string][]argoChild{}
 	byName := map[string]string{}
 	ambiguous := map[string]bool{}
 	items, err := cache.ListDynamicWithGroup(ctx, "Application", "", "argoproj.io")
 	if err != nil {
-		return out
+		return sourcePaths, appSetChildren
 	}
 	for _, item := range items {
+		name := item.GetName()
+		nsKey := name
+		if ns := item.GetNamespace(); ns != "" {
+			nsKey = ns + "/" + name
+		}
+		if set := appSetOwnerName(item); set != "" {
+			appSetChildren[set] = append(appSetChildren[set], argoChild{keys: []string{nsKey, name}, name: name})
+		}
+
 		spec, _ := item.Object["spec"].(map[string]any)
 		if spec == nil {
 			continue
@@ -702,12 +852,7 @@ func argoSourcePaths(ctx context.Context, cache resourceLister) map[string]strin
 		}
 		for _, p := range paths {
 			if stem, _ := pathStemEnv(p); stem != "" {
-				name := item.GetName()
-				nsKey := name
-				if ns := item.GetNamespace(); ns != "" {
-					nsKey = ns + "/" + name
-				}
-				out[nsKey] = p
+				sourcePaths[nsKey] = p
 				if prev, exists := byName[name]; exists && prev != p {
 					delete(byName, name)
 					ambiguous[name] = true
@@ -721,7 +866,188 @@ func argoSourcePaths(ctx context.Context, cache resourceLister) map[string]strin
 		}
 	}
 	for name, path := range byName {
-		out[name] = path
+		sourcePaths[name] = path
+	}
+	return sourcePaths, appSetChildren
+}
+
+// argoWorkloadKinds are the status.resources kinds the hub matches against a
+// destination cluster's app rows. Config/Service/RBAC resources are not workloads
+// and would mis-target rows, so only true workloads carry a claim.
+var argoWorkloadKinds = map[string]bool{
+	"Deployment": true, "StatefulSet": true, "DaemonSet": true,
+	"ReplicaSet": true, "CronJob": true, "Job": true, "Rollout": true,
+}
+
+// collectArgoClaims emits one claim per Argo Application that carries a declared
+// identity (an Argo source-path stem, or a validated ApplicationSet env fan-out),
+// so the hub can stamp that identity onto the destination cluster's workload rows
+// in a hub-spoke topology. Applications with no declared identity are skipped —
+// name/label identity never propagates across clusters.
+func collectArgoClaims(ctx context.Context, cache resourceLister, sourcePaths map[string]string, appSetByKey map[string]appSetFanout, namespaces []string) []argoClaim {
+	items, err := cache.ListDynamicWithGroup(ctx, "Application", "", "argoproj.io")
+	if err != nil {
+		return nil
+	}
+	// Scope claims to the caller's allowed namespaces (when filtered): an
+	// Application is a namespaced resource, and its claim exposes its destination +
+	// managed workloads, so a namespace-scoped user must not receive claims for
+	// Applications outside their visibility. Empty filter = unscoped (all).
+	var allowed map[string]bool
+	if len(namespaces) > 0 {
+		allowed = make(map[string]bool, len(namespaces))
+		for _, ns := range namespaces {
+			allowed[ns] = true
+		}
+	}
+	var claims []argoClaim
+	for _, item := range items {
+		if allowed != nil && !allowed[item.GetNamespace()] {
+			continue
+		}
+		name := item.GetName()
+		nsKey := name
+		if ns := item.GetNamespace(); ns != "" {
+			nsKey = ns + "/" + name
+		}
+
+		// Declared identity: ApplicationSet fan-out first (a set declares the
+		// sibling relationship), else an env-bearing source path.
+		var id *appIdentity
+		if fan, ok := appSetByKey[nsKey]; ok {
+			id = &appIdentity{Key: fan.stem, Env: fan.env, Confidence: "high", Portable: true, Source: SourceArgoAppSet,
+				Evidence: fmt.Sprintf("ApplicationSet fan-out %q (env %s)", fan.stem, fan.env)}
+		} else if path, ok := sourcePaths[nsKey]; ok {
+			if stem, env := pathStemEnv(path); stem != "" {
+				id = &appIdentity{Key: stem, Env: env, Confidence: "high", Portable: true, Source: SourceArgoPath,
+					Evidence: "Argo CD source path " + stem + " (env overlay " + env + ")"}
+			}
+		}
+		if id == nil {
+			continue
+		}
+
+		spec, _ := item.Object["spec"].(map[string]any)
+		dest, _ := spec["destination"].(map[string]any)
+		claim := argoClaim{Identity: id}
+		if dest != nil {
+			claim.DestServer, _ = dest["server"].(string)
+			claim.DestName, _ = dest["name"].(string)
+			claim.DestNamespace, _ = dest["namespace"].(string)
+		}
+		claim.Workloads = argoManagedWorkloads(item)
+		claims = append(claims, claim)
+	}
+	return claims
+}
+
+// argoManagedWorkloads extracts the workload resources an Argo Application
+// manages from status.resources (the hub matches these against destination rows).
+func argoManagedWorkloads(item *unstructured.Unstructured) []workloadRef {
+	resources, _, _ := unstructured.NestedSlice(item.Object, "status", "resources")
+	var out []workloadRef
+	for _, r := range resources {
+		m, _ := r.(map[string]any)
+		if m == nil {
+			continue
+		}
+		kind, _ := m["kind"].(string)
+		if !argoWorkloadKinds[kind] {
+			continue
+		}
+		ns, _ := m["namespace"].(string)
+		nm, _ := m["name"].(string)
+		if nm == "" {
+			continue
+		}
+		out = append(out, workloadRef{Kind: kind, Namespace: ns, Name: nm})
+	}
+	return out
+}
+
+// appSetFanout is one child's declared identity within a single-app fan-out set.
+type appSetFanout struct {
+	stem string
+	env  string // canonical trio env
+}
+
+// appSetFanouts decides, per ApplicationSet, whether the set is a SINGLE-APP
+// fan-out (one app across envs) — the only shape whose set name is a valid app
+// identity — and returns the declared stem+env for each child appKey. A set is a
+// fan-out only when its children are identical except for ONE token position
+// whose values are ALL trio envs (dev/staging/prod). A multi-app BUNDLE set
+// (children with differing app stems) or a cluster/region fan-out (differing
+// tokens that aren't trio envs — those get their env from the hub) yields
+// nothing: the set name would over-merge unrelated apps.
+//
+// This is bounded to one declared sibling set, so it is NOT a global name-stem
+// match — the join is the ApplicationSet ownership; the token check only confirms
+// the set's shape.
+func appSetFanouts(appSetChildren map[string][]argoChild) map[string]appSetFanout {
+	out := map[string]appSetFanout{}
+	for _, children := range appSetChildren {
+		if len(children) < 2 {
+			continue
+		}
+		segsByChild := make([][]string, len(children))
+		width := -1
+		uniform := true
+		for i, c := range children {
+			segsByChild[i] = nameSegments(c.name)
+			if width == -1 {
+				width = len(segsByChild[i])
+			} else if len(segsByChild[i]) != width {
+				uniform = false
+			}
+		}
+		if !uniform || width < 2 {
+			continue // children must share the SAME shape to be one app's env-fan-out
+		}
+		// Find the single token position that varies; every other must be constant.
+		varyPos := -1
+		ok := true
+		for pos := 0; pos < width && ok; pos++ {
+			differs := false
+			for i := 1; i < len(segsByChild); i++ {
+				if !strings.EqualFold(segsByChild[i][pos], segsByChild[0][pos]) {
+					differs = true
+					break
+				}
+			}
+			if differs {
+				if varyPos != -1 {
+					ok = false // more than one varying position — not a clean env-fan-out
+				}
+				varyPos = pos
+			}
+		}
+		if !ok || varyPos == -1 {
+			continue
+		}
+		// The varying tokens must ALL be trio envs (declared single-app fan-out);
+		// otherwise the set varies by app or by cluster, not by env.
+		allEnv := true
+		for i := range children {
+			if _, isTrio := trioEnv(segsByChild[i][varyPos]); !isTrio {
+				allEnv = false
+				break
+			}
+		}
+		if !allEnv {
+			continue
+		}
+		stemSegs := append([]string{}, segsByChild[0][:varyPos]...)
+		stemSegs = append(stemSegs, segsByChild[0][varyPos+1:]...)
+		stem := strings.Join(stemSegs, "-")
+		if isTrivialStem(stem) {
+			continue
+		}
+		for i, c := range children {
+			env, _ := trioEnv(segsByChild[i][varyPos])
+			for _, k := range c.keys {
+				out[k] = appSetFanout{stem: stem, env: env}
+			}
+		}
 	}
 	return out
 }

--- a/internal/server/applications_identity.go
+++ b/internal/server/applications_identity.go
@@ -568,10 +568,21 @@ func resolveAppIdentities(rows []appRow, argoSourcePaths map[string]string, nsEn
 		case info.pathEnv != "":
 			env = canonicalEnvToken(info.pathEnv)
 		default:
+			// Prefer a trio token over a discovered one (the universal ladder
+			// outranks affix tokens — same precedence as phase 2's better()), so
+			// e.g. a `prod` namespace wins over a stray `staging` name affix.
 			for _, rd := range info.readings {
-				if _, isTrio := trioEnv(rd.token); isTrio || qualified[rd.token] {
+				if _, isTrio := trioEnv(rd.token); isTrio {
 					env = canonicalEnvToken(rd.token)
 					break
+				}
+			}
+			if env == "" {
+				for _, rd := range info.readings {
+					if qualified[rd.token] {
+						env = canonicalEnvToken(rd.token)
+						break
+					}
 				}
 			}
 		}

--- a/internal/server/applications_identity_test.go
+++ b/internal/server/applications_identity_test.go
@@ -498,3 +498,83 @@ func TestIdentities_ArgoSourcePathUsesNamespacedKey(t *testing.T) {
 		t.Fatalf("namespaced Argo path identities = %+v / %+v, want portable billing", a, b)
 	}
 }
+
+// withName stamps app.kubernetes.io/name on every workload of a row.
+func withName(r appRow, nameLabel string) appRow {
+	for i := range r.Workloads {
+		r.Workloads[i].nameLabel = nameLabel
+	}
+	return r
+}
+
+// A single-instance row with an app.kubernetes.io/name label gets a clean,
+// high-confidence identity keyed on the label — no in-cluster group needed. It
+// is NOT portable on its own: cross-cluster folding is the hub's corroborated
+// call (a bare label like "api" must not collapse unrelated apps globally).
+func TestIdentities_LabelGivesCleanSingletonKey(t *testing.T) {
+	rows := []appRow{
+		withName(identRow("koala-backend-xyz", "prod", 0, "prod/app/koala-backend-xyz", "ghcr.io/k/koala-backend:1"), "koala-backend"),
+	}
+	resolveAppIdentities(rows, nil, nil)
+	id := rows[0].Identity
+	if id == nil || id.Key != "koala-backend" || id.Confidence != "high" {
+		t.Fatalf("label identity not set high-confidence: %+v", id)
+	}
+	if id.Portable {
+		t.Errorf("bare label must not be standalone-portable: %+v", id)
+	}
+	if id.Env != "prod" {
+		t.Errorf("env = %q, want prod", id.Env)
+	}
+}
+
+// The label upgrades a weaker name-stem identity to a clean, high-confidence
+// declared key (portability stays the hub's call).
+func TestIdentities_LabelUpgradesNameStem(t *testing.T) {
+	rows := []appRow{
+		withName(identRow("widget", "dev", 0, "dev/app/widget", "ghcr.io/k/widget:1"), "widget"),
+		withName(identRow("widget", "prod", 0, "prod/app/widget", "ghcr.io/k/widget:2"), "widget"),
+	}
+	resolveAppIdentities(rows, nil, nil)
+	for i := range rows {
+		id := rows[i].Identity
+		if id == nil || id.Key != "widget" || id.Confidence != "high" {
+			t.Fatalf("expected high-confidence label key, got %+v", id)
+		}
+	}
+}
+
+// A declared Argo source-path identity (equally high confidence, more specific
+// about the env overlay) is NOT overwritten by the name label.
+func TestIdentities_LabelDoesNotOverrideArgoPath(t *testing.T) {
+	rows := []appRow{
+		withName(identRow("billing-staging", "staging", 4, "/Application/billing-staging", "ghcr.io/k/billing:1"), "billing"),
+		identRow("billing-dev", "dev", 4, "/Application/billing-dev", "ghcr.io/k/billing:2"),
+	}
+	resolveAppIdentities(rows, map[string]string{
+		"billing-staging": "billing/deploy/overlays/staging",
+		"billing-dev":     "billing/deploy/overlays/dev",
+	}, nil)
+	// The declared Argo identity must survive — its evidence still cites the
+	// source path, not the name label (which would mean the label clobbered it).
+	id := identOf(t, rows, "billing-staging")
+	if id == nil || !strings.Contains(id.Evidence, "Argo CD source path") {
+		t.Fatalf("Argo path identity overridden by label: %+v", id)
+	}
+	if id.Env != "staging" {
+		t.Errorf("Argo overlay env lost: %+v", id)
+	}
+}
+
+// Workloads disagreeing on app.kubernetes.io/name are not one app — no label
+// identity (and a lone row forms no group either).
+func TestIdentities_DisagreeingNameLabelsIgnored(t *testing.T) {
+	r := identRow("multi", "prod", 0, "prod/app/multi", "ghcr.io/k/multi:1", "ghcr.io/k/multi:1")
+	r.Workloads[0].nameLabel = "alpha"
+	r.Workloads[1].nameLabel = "beta"
+	rows := []appRow{r}
+	resolveAppIdentities(rows, nil, nil)
+	if rows[0].Identity != nil {
+		t.Fatalf("disagreeing name labels should not yield identity: %+v", rows[0].Identity)
+	}
+}

--- a/internal/server/applications_identity_test.go
+++ b/internal/server/applications_identity_test.go
@@ -43,7 +43,7 @@ func TestIdentities_DeclaredPathPlusRawNamespaceEnv(t *testing.T) {
 		identRow("billing-staging", "staging", 3, "/Application/billing-staging", "repo.dev/koala/billing:b_2026-06-05_01"),
 		identRow("billing", "dev", 0, "", "repo.dev/koala/billing:b_2026-05-18_00"),
 	}
-	resolveAppIdentities(rows, map[string]string{"billing-staging": "billing/deploy/overlays/staging"}, nil, nil)
+	resolveAppIdentities(rows, map[string]string{"billing-staging": "billing/deploy/overlays/staging"}, nil, nil, nil)
 
 	st := identOf(t, rows, "billing-staging")
 	if st == nil || st.Key != "billing" || st.Env != "staging" || st.Confidence != "high" {
@@ -62,7 +62,7 @@ func TestIdentities_EnvPrefixTrackingPair(t *testing.T) {
 		identRow("dev-koala-backend-us-east1", "dev", 3, "/Application/dev-koala-backend-us-east1", "repo.dev/koala/koala-backend:m1"),
 		identRow("staging-koala-backend-us-east1", "staging", 3, "/Application/staging-koala-backend-us-east1", "repo.dev/koala/koala-backend:m2"),
 	}
-	resolveAppIdentities(rows, nil, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil, nil)
 
 	a := identOf(t, rows, "dev-koala-backend-us-east1")
 	b := identOf(t, rows, "staging-koala-backend-us-east1")
@@ -82,7 +82,7 @@ func TestIdentities_SameNameAcrossEnvNamespaces(t *testing.T) {
 		identRow("project-infra", "staging", 7, "staging/app/project-infra", "repo.dev/koala/project-infra:y"),
 		identRow("project-infra", "qa", 7, "qa/app/project-infra", "repo.dev/koala/project-infra:z"),
 	}
-	resolveAppIdentities(rows, nil, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil, nil)
 	envs := map[string]bool{}
 	for i := range rows {
 		f := rows[i].Identity
@@ -103,7 +103,7 @@ func TestIdentities_NoRepoOverlapRefuses(t *testing.T) {
 		identRow("api", "dev", 0, "", "repo.dev/teamA/api:1"),
 		identRow("api", "staging", 0, "", "repo.dev/teamB/other:1"),
 	}
-	resolveAppIdentities(rows, nil, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil, nil)
 	if rows[0].Identity != nil || rows[1].Identity != nil {
 		t.Fatalf("uncorroborated stem match grouped: %+v / %+v", rows[0].Identity, rows[1].Identity)
 	}
@@ -115,7 +115,7 @@ func TestIdentities_SingleEnvRefuses(t *testing.T) {
 		identRow("worker", "staging", 0, "staging/app/worker-a", "repo.dev/koala/worker:1"),
 		identRow("worker", "staging", 0, "staging/app/worker-b", "repo.dev/koala/worker:1"),
 	}
-	resolveAppIdentities(rows, nil, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil, nil)
 	if rows[0].Identity != nil {
 		t.Fatalf("single-env group formed: %+v", rows[0].Identity)
 	}
@@ -130,7 +130,7 @@ func TestIdentities_ConflictingDeclaredStemsRefuse(t *testing.T) {
 	resolveAppIdentities(rows, map[string]string{
 		"shop-staging": "teamA/shop/overlays/staging",
 		"shop-dev":     "teamB/legacy-shop/overlays/dev",
-	}, nil, nil)
+	}, nil, nil, nil)
 	if rows[0].Identity != nil || rows[1].Identity != nil {
 		t.Fatalf("conflicting declarations grouped: %+v / %+v", rows[0].Identity, rows[1].Identity)
 	}
@@ -143,7 +143,7 @@ func TestIdentities_GenericTokensNotNameEvidence(t *testing.T) {
 		identRow("load-test", "apps", 0, "", "repo.dev/koala/load:1"),
 		identRow("load", "dev", 0, "", "repo.dev/koala/load:1"),
 	}
-	resolveAppIdentities(rows, nil, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil, nil)
 	if rows[0].Identity != nil {
 		t.Fatalf("'-test' suffix treated as env: %+v", rows[0].Identity)
 	}
@@ -155,7 +155,7 @@ func TestIdentities_EnvSynonymsCanonicalize(t *testing.T) {
 		identRow("pay-production", "payments", 0, "", "repo.dev/koala/pay:1"),
 		identRow("pay-stage", "payments", 0, "", "repo.dev/koala/pay:2"),
 	}
-	resolveAppIdentities(rows, nil, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil, nil)
 	a, b := rows[0].Identity, rows[1].Identity
 	if a == nil || b == nil || a.Env != "prod" || b.Env != "staging" {
 		t.Fatalf("synonyms = %+v / %+v, want prod / staging", a, b)
@@ -172,7 +172,7 @@ func TestIdentities_ClassificationNotIdentity(t *testing.T) {
 		}
 	}
 	tagged := mk()
-	resolveAppIdentities(tagged, nil, nil, nil)
+	resolveAppIdentities(tagged, nil, nil, nil, nil)
 	for i := range tagged {
 		tagged[i].Identity = nil
 	}
@@ -196,7 +196,7 @@ func TestIdentities_CustomTokenDiscoveredByRecurrence(t *testing.T) {
 		identRow("cron", "dev", 0, "dev/app/cron", "repo.dev/koala/cron:1"),
 		identRow("cron-loadtest", "team3", 0, "", "repo.dev/koala/cron:2"),
 	}
-	resolveAppIdentities(rows, nil, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil, nil)
 	a := identOf(t, rows, "api-loadtest")
 	if a == nil || a.Key != "api" || a.Env != "loadtest" {
 		t.Fatalf("api-loadtest identity = %+v, want key=api env=loadtest (recurrence-discovered)", a)
@@ -210,7 +210,7 @@ func TestIdentities_AffixCorroboratedByNamespace(t *testing.T) {
 		identRow("api", "dev", 0, "dev/app/api", "repo.dev/koala/api:1"),
 		identRow("api-loadtest", "loadtest", 0, "", "repo.dev/koala/api:2"),
 	}
-	resolveAppIdentities(rows, nil, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil, nil)
 	a := identOf(t, rows, "api-loadtest")
 	if a == nil || a.Env != "loadtest" {
 		t.Fatalf("affix+namespace corroboration failed: %+v", a)
@@ -228,7 +228,7 @@ func TestIdentities_VariantSuffixesNotEnvs(t *testing.T) {
 		identRow("mempool-cos", "infra", 0, "", "repo.dev/koala/mp:1"),
 		identRow("mempool-ubuntu", "infra", 0, "", "repo.dev/koala/mp:2"),
 	}
-	resolveAppIdentities(rows, nil, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil, nil)
 	for i := range rows {
 		if rows[i].Identity != nil {
 			t.Fatalf("variant suffix grouped as env: %s → %+v", rows[i].Name, rows[i].Identity)
@@ -243,7 +243,7 @@ func TestIdentities_MultiSegmentNamespaceNotAToken(t *testing.T) {
 		identRow("frps-a", "skyhook-clients-frps", 0, "", "repo.dev/koala/frps:1"),
 		identRow("frps-a", "skyhook-clients-frps-staging", 0, "", "repo.dev/koala/frps:2"),
 	}
-	resolveAppIdentities(rows, nil, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil, nil)
 	for i := range rows {
 		f := rows[i].Identity
 		if f != nil && f.Env != "staging" {
@@ -259,7 +259,7 @@ func TestIdentities_OneOffTokenNotDiscovered(t *testing.T) {
 		identRow("api", "dev", 0, "dev/app/api", "repo.dev/koala/api:1"),
 		identRow("api-v2", "dev", 0, "", "repo.dev/koala/api:2"),
 	}
-	resolveAppIdentities(rows, nil, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil, nil)
 	if f := identOf(t, rows, "api-v2"); f != nil {
 		t.Fatalf("api-v2 grouped as env instance: %+v", f)
 	}
@@ -273,7 +273,7 @@ func TestIdentities_ExplicitEnvLabels(t *testing.T) {
 	b := identRow("payments", "team-b", 0, "team-b/app/payments", "repo.dev/koala/pay:2")
 	a.Workloads[0].envLabel = "blue"
 	rows := []appRow{a, b}
-	resolveAppIdentities(rows, nil, nil, map[string]string{"team-b": "green"})
+	resolveAppIdentities(rows, nil, nil, map[string]string{"team-b": "green"}, nil)
 	fa, fb := rows[0].Identity, rows[1].Identity
 	if fa == nil || fa.Env != "blue" || fa.Confidence != "medium" || fa.Portable || !strings.Contains(fa.Evidence, `environment label "blue"`) {
 		t.Fatalf("workload-labeled instance = %+v, want env=blue medium/local with label evidence", fa)
@@ -295,7 +295,7 @@ func TestIdentities_DisagreeingWorkloadLabelsIgnored(t *testing.T) {
 	a.Workloads[1].envLabel = "prod"
 	b := identRow("api", "staging", 0, "staging/app/api", "repo.dev/koala/api:2")
 	rows := []appRow{a, b}
-	resolveAppIdentities(rows, nil, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil, nil)
 	fa := rows[0].Identity
 	// Falls back to the namespace reading (dev) instead of either label.
 	if fa == nil || fa.Env != "dev" {
@@ -323,7 +323,7 @@ func TestIdentities_AdoptionJoinsProvenCore(t *testing.T) {
 		identRow("project-infra", "staging", 7, "staging/app/project-infra", "repo.dev/koala/pi:y"),
 		identRow("project-infra", "sandboxx", 7, "sandboxx/app/project-infra", "repo.dev/koala/pi:z"),
 	}
-	resolveAppIdentities(rows, nil, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil, nil)
 	f := identOf(t, rows, "project-infra")
 	got := rows[2].Identity
 	if f == nil || got == nil || got.Key != "project-infra" || got.Env != "sandboxx" {
@@ -338,7 +338,7 @@ func TestIdentities_AdoptionNeverBootstraps(t *testing.T) {
 		identRow("api", "dev", 0, "dev/app/api", "repo.dev/koala/api:1"),
 		identRow("api", "teamspace", 0, "teamspace/app/api", "repo.dev/koala/api:2"),
 	}
-	resolveAppIdentities(rows, nil, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil, nil)
 	if rows[0].Identity != nil || rows[1].Identity != nil {
 		t.Fatalf("adoption bootstrapped a identity: %+v / %+v", rows[0].Identity, rows[1].Identity)
 	}
@@ -353,7 +353,7 @@ func TestIdentities_AdopteeNeverVetoesCore(t *testing.T) {
 		identRow("billing", "staging", 0, "staging/app/billing", "repo.dev/koala/billing:2"),
 		identRow("billing", "team", 0, "team/app/billing", "repo.dev/other/thing:1"),
 	}
-	resolveAppIdentities(rows, nil, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil, nil)
 	dev, st, stranger := rows[0].Identity, rows[1].Identity, rows[2].Identity
 	if dev == nil || st == nil || dev.Key != "billing" {
 		t.Fatalf("coincidence row vetoed the proven core: %+v / %+v", dev, st)
@@ -369,7 +369,7 @@ func TestIdentities_SameStemStrangerDoesNotVetoRepoCore(t *testing.T) {
 		identRow("api", "staging", 0, "staging/app/api", "repo.dev/team/api:2"),
 		identRow("api", "qa", 0, "qa/app/api", "repo.dev/other/api:1"),
 	}
-	resolveAppIdentities(rows, nil, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil, nil)
 	dev, st, stranger := rows[0].Identity, rows[1].Identity, rows[2].Identity
 	if dev == nil || st == nil || dev.Key != "api" || st.Key != "api" {
 		t.Fatalf("different-repo stranger vetoed valid api identity: %+v / %+v", dev, st)
@@ -385,7 +385,7 @@ func TestIdentities_EmptyRepoCandidateDoesNotHideLaterRepoCore(t *testing.T) {
 		identRow("api", "staging", 0, "staging/app/api", "repo.dev/team/api:1"),
 		identRow("api", "prod", 0, "prod/app/api", "repo.dev/team/api:2"),
 	}
-	resolveAppIdentities(rows, nil, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil, nil)
 	if rows[0].Identity != nil {
 		t.Fatalf("empty-repo candidate joined identity: %+v", rows[0].Identity)
 	}
@@ -414,7 +414,10 @@ func TestPathStemEnv(t *testing.T) {
 type stubLister struct{ items []*unstructured.Unstructured }
 
 func (s *stubLister) ListDynamicWithGroup(_ context.Context, kind, _, group string) ([]*unstructured.Unstructured, error) {
-	if kind != "Application" || group != "argoproj.io" {
+	switch {
+	case kind == "Application" && group == "argoproj.io":
+	case kind == "Kustomization" && group == "kustomize.toolkit.fluxcd.io":
+	default:
 		return nil, fmt.Errorf("unexpected list %s/%s", group, kind)
 	}
 	return s.items, nil
@@ -492,7 +495,7 @@ func TestIdentities_ArgoSourcePathUsesNamespacedKey(t *testing.T) {
 	resolveAppIdentities(rows, map[string]string{
 		"argocd-a/billing-staging": "apps/billing/overlays/staging",
 		"argocd-b/billing-dev":     "apps/billing/overlays/dev",
-	}, nil, nil)
+	}, nil, nil, nil)
 	a, b := rows[0].Identity, rows[1].Identity
 	if a == nil || b == nil || a.Key != "billing" || b.Key != "billing" || !a.Portable || !b.Portable {
 		t.Fatalf("namespaced Argo path identities = %+v / %+v, want portable billing", a, b)
@@ -515,7 +518,7 @@ func TestIdentities_LabelGivesCleanSingletonKey(t *testing.T) {
 	rows := []appRow{
 		withName(identRow("koala-backend-xyz", "prod", 0, "prod/app/koala-backend-xyz", "ghcr.io/k/koala-backend:1"), "koala-backend"),
 	}
-	resolveAppIdentities(rows, nil, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil, nil)
 	id := rows[0].Identity
 	if id == nil || id.Key != "koala-backend" || id.Confidence != "high" {
 		t.Fatalf("label identity not set high-confidence: %+v", id)
@@ -535,7 +538,7 @@ func TestIdentities_LabelUpgradesNameStem(t *testing.T) {
 		withName(identRow("widget", "dev", 0, "dev/app/widget", "ghcr.io/k/widget:1"), "widget"),
 		withName(identRow("widget", "prod", 0, "prod/app/widget", "ghcr.io/k/widget:2"), "widget"),
 	}
-	resolveAppIdentities(rows, nil, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil, nil)
 	for i := range rows {
 		id := rows[i].Identity
 		if id == nil || id.Key != "widget" || id.Confidence != "high" {
@@ -554,7 +557,7 @@ func TestIdentities_LabelDoesNotOverrideArgoPath(t *testing.T) {
 	resolveAppIdentities(rows, map[string]string{
 		"billing-staging": "billing/deploy/overlays/staging",
 		"billing-dev":     "billing/deploy/overlays/dev",
-	}, nil, nil)
+	}, nil, nil, nil)
 	// The declared Argo identity must survive — its evidence still cites the
 	// source path, not the name label (which would mean the label clobbered it).
 	id := identOf(t, rows, "billing-staging")
@@ -573,7 +576,7 @@ func TestIdentities_DisagreeingNameLabelsIgnored(t *testing.T) {
 	r.Workloads[0].nameLabel = "alpha"
 	r.Workloads[1].nameLabel = "beta"
 	rows := []appRow{r}
-	resolveAppIdentities(rows, nil, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil, nil)
 	if rows[0].Identity != nil {
 		t.Fatalf("disagreeing name labels should not yield identity: %+v", rows[0].Identity)
 	}
@@ -585,7 +588,7 @@ func TestIdentities_ExplicitAnnotationIsAuthoritativePortable(t *testing.T) {
 	r := identRow("billing-staging", "staging", 3, "/Application/billing-staging", "repo.dev/koala/billing:b1")
 	r.Workloads[0].appAnnotation = "koala-billing"
 	rows := []appRow{r}
-	resolveAppIdentities(rows, map[string]string{"billing-staging": "billing/deploy/overlays/staging"}, nil, nil)
+	resolveAppIdentities(rows, map[string]string{"billing-staging": "billing/deploy/overlays/staging"}, nil, nil, nil)
 
 	id := identOf(t, rows, "billing-staging")
 	if id == nil || id.Key != "koala-billing" || id.Source != SourceExplicit || !id.Portable {
@@ -602,7 +605,7 @@ func TestIdentities_ExplicitAnnotationStandsAlone(t *testing.T) {
 	r := identRow("api", "dev", 0, "dev/app/api", "ghcr.io/acme/api:1")
 	r.Workloads[0].appAnnotation = "acme-api"
 	rows := []appRow{r}
-	resolveAppIdentities(rows, nil, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil, nil)
 	id := identOf(t, rows, "api")
 	if id == nil || id.Key != "acme-api" || id.Source != SourceExplicit || !id.Portable {
 		t.Fatalf("standalone explicit identity = %+v, want key=acme-api source=explicit portable", id)
@@ -617,7 +620,7 @@ func TestIdentities_SourceProvenanceStamped(t *testing.T) {
 		identRow("billing-staging", "staging", 3, "/Application/billing-staging", "r.dev/b:1"),
 		identRow("billing", "dev", 0, "", "r.dev/b:2"),
 	}
-	resolveAppIdentities(argo, map[string]string{"billing-staging": "billing/deploy/overlays/staging"}, nil, nil)
+	resolveAppIdentities(argo, map[string]string{"billing-staging": "billing/deploy/overlays/staging"}, nil, nil, nil)
 	if id := identOf(t, argo, "billing-staging"); id == nil || id.Source != SourceArgoPath || !id.Portable {
 		t.Fatalf("argo-path source = %+v, want argo-path portable", id)
 	}
@@ -627,7 +630,7 @@ func TestIdentities_SourceProvenanceStamped(t *testing.T) {
 	lbl := identRow("web", "prod", 0, "prod/app/web", "ghcr.io/x/web:1")
 	lbl.Workloads[0].nameLabel = "web"
 	lrows := []appRow{lbl}
-	resolveAppIdentities(lrows, nil, nil, nil)
+	resolveAppIdentities(lrows, nil, nil, nil, nil)
 	if id := identOf(t, lrows, "web"); id == nil || id.Source != SourceLabel || id.Portable {
 		t.Fatalf("label source = %+v, want label NOT portable", id)
 	}
@@ -690,7 +693,7 @@ func TestIdentities_AppSetFanoutIsPortable(t *testing.T) {
 	fan := appSetFanouts(map[string][]argoChild{
 		"billing": {{keys: []string{"argocd/billing-dev", "billing-dev"}, name: "billing-dev"}, {keys: []string{"argocd/billing-prod", "billing-prod"}, name: "billing-prod"}},
 	})
-	resolveAppIdentities(rows, nil, fan, nil)
+	resolveAppIdentities(rows, nil, fan, nil, nil)
 	for _, name := range []string{"billing-dev", "billing-prod"} {
 		id := identOf(t, rows, name)
 		if id == nil || id.Key != "billing" || id.Source != SourceArgoAppSet || !id.Portable {
@@ -750,7 +753,7 @@ func TestIdentities_AppSetFanoutSkipsNonArgoRows(t *testing.T) {
 	fan := appSetFanouts(map[string][]argoChild{
 		"billing": {{keys: []string{"argocd/billing-dev", "billing-dev"}, name: "billing-dev"}, {keys: []string{"argocd/billing-prod", "billing-prod"}, name: "billing-prod"}},
 	})
-	resolveAppIdentities(rows, nil, fan, nil)
+	resolveAppIdentities(rows, nil, fan, nil, nil)
 	if id := rows[0].Identity; id != nil && id.Source == SourceArgoAppSet {
 		t.Fatalf("non-Argo row falsely stamped argo-appset: %+v", id)
 	}
@@ -763,7 +766,7 @@ func TestIdentities_ExplicitAnnotationRequiresAllWorkloads(t *testing.T) {
 	r.Workloads[0].appAnnotation = "acme-svc"
 	// r.Workloads[1] has no annotation → not all agree.
 	rows := []appRow{r}
-	resolveAppIdentities(rows, nil, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil, nil)
 	if id := rows[0].Identity; id != nil && id.Source == SourceExplicit {
 		t.Fatalf("partial annotation should not yield explicit identity: %+v", id)
 	}
@@ -773,7 +776,7 @@ func TestIdentities_ExplicitAnnotationRequiresAllWorkloads(t *testing.T) {
 	r2.Workloads[0].appAnnotation = "acme-svc"
 	r2.Workloads[1].appAnnotation = "acme-svc"
 	rows2 := []appRow{r2}
-	resolveAppIdentities(rows2, nil, nil, nil)
+	resolveAppIdentities(rows2, nil, nil, nil, nil)
 	if id := rows2[0].Identity; id == nil || id.Source != SourceExplicit || id.Key != "acme-svc" {
 		t.Fatalf("fully-annotated row should be explicit: %+v", id)
 	}
@@ -863,5 +866,54 @@ func TestCollectArgoClaims_PrefersPathOverAppSet(t *testing.T) {
 	}
 	if found == nil || found.Source != SourceArgoPath || found.Key != "apps/billing" {
 		t.Fatalf("billing-prod claim = %+v, want argo-path key=apps/billing", found)
+	}
+}
+
+// Flux Kustomization source paths yield a portable flux-source identity, the
+// declared-origin parallel to argo-path. The row tier is 2 (TierFluxKustomize);
+// the row key encodes the Kustomization (<ns>/Kustomization/<name>).
+func TestIdentities_FluxSourcePathIsPortable(t *testing.T) {
+	rows := []appRow{
+		identRow("billing", "billing", 2, "flux-system/Kustomization/billing-staging", "repo.dev/billing:1"),
+		identRow("billing", "billing", 2, "flux-system/Kustomization/billing-prod", "repo.dev/billing:2"),
+	}
+	flux := map[string]string{
+		"flux-system/billing-staging": "apps/billing/overlays/staging",
+		"flux-system/billing-prod":    "apps/billing/overlays/prod",
+	}
+	resolveAppIdentities(rows, nil, nil, nil, flux)
+	for i := range rows {
+		id := rows[i].Identity
+		// Key is the name stem (the join key that unifies a declared-path instance
+		// with a raw-but-corroborated sibling); the path is the declared SIGNAL that
+		// makes it portable, cited in the evidence.
+		if id == nil || id.Key != "billing" || id.Source != SourceFluxSource || !id.Portable {
+			t.Fatalf("row %d flux identity = %+v, want key=billing source=flux-source portable", i, id)
+		}
+		if !strings.Contains(id.Evidence, "Flux source path") {
+			t.Errorf("flux evidence should cite Flux source path: %q", id.Evidence)
+		}
+	}
+}
+
+// fluxKustomizationFacts maps each Kustomization to its env-bearing path,
+// emitting the namespaced key always and the bare name when unambiguous.
+func TestFluxKustomizationFacts(t *testing.T) {
+	ks := func(ns, name, path string) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"namespace": ns, "name": name},
+			"spec":     map[string]any{"path": path},
+		}}
+	}
+	lister := &stubLister{items: []*unstructured.Unstructured{
+		ks("flux-system", "billing-prod", "apps/billing/overlays/prod"),
+		ks("flux-system", "infra", "clusters/base"), // no env segment → skipped
+	}}
+	got := fluxKustomizationFacts(context.Background(), lister)
+	if got["flux-system/billing-prod"] != "apps/billing/overlays/prod" || got["billing-prod"] != "apps/billing/overlays/prod" {
+		t.Fatalf("flux facts = %v, want billing-prod path under both keys", got)
+	}
+	if _, ok := got["flux-system/infra"]; ok {
+		t.Fatalf("env-less path should be skipped: %v", got)
 	}
 }

--- a/internal/server/applications_identity_test.go
+++ b/internal/server/applications_identity_test.go
@@ -455,7 +455,7 @@ func TestArgoSourcePaths(t *testing.T) {
 		argoApp("no-env-path", map[string]any{"source": map[string]any{"path": "charts/api"}}),
 		argoApp("malformed", map[string]any{"source": "not-a-map"}),
 	}}
-	got, _ := argoApplicationFacts(context.Background(), lister)
+	got, _, _ := argoApplicationFacts(context.Background(), lister)
 	want := map[string]string{
 		"billing-staging": "billing/deploy/overlays/staging",
 		"multi":           "apps/overlays/dev",
@@ -475,7 +475,7 @@ func TestArgoSourcePaths_AmbiguousSameNameRefuses(t *testing.T) {
 		argoAppInNamespace("team-a", "billing-staging", map[string]any{"source": map[string]any{"path": "team-a/billing/overlays/staging"}}),
 		argoAppInNamespace("team-b", "billing-staging", map[string]any{"source": map[string]any{"path": "team-b/billing/overlays/staging"}}),
 	}}
-	got, _ := argoApplicationFacts(context.Background(), lister)
+	got, _, _ := argoApplicationFacts(context.Background(), lister)
 	if got["billing-staging"] != "" {
 		t.Fatalf("bare ambiguous argoSourcePaths[billing-staging] = %q, want empty", got["billing-staging"])
 	}
@@ -723,8 +723,8 @@ func TestCollectArgoClaims(t *testing.T) {
 		// No declared identity (env-less path) → no claim.
 		argoAppFull("infra", map[string]any{"source": map[string]any{"path": "charts/infra"}}, nil),
 	}}
-	sourcePaths, appSetChildren := argoApplicationFacts(context.Background(), lister)
-	claims := collectArgoClaims(context.Background(), lister, sourcePaths, appSetFanouts(appSetChildren), nil)
+	sourcePaths, appSetChildren, argoItems := argoApplicationFacts(context.Background(), lister)
+	claims := collectArgoClaims(argoItems, sourcePaths, appSetFanouts(appSetChildren), nil)
 
 	if len(claims) != 1 {
 		t.Fatalf("claims = %d, want 1 (only the declared app): %+v", len(claims), claims)
@@ -798,21 +798,21 @@ func TestCollectArgoClaims_NamespaceScoped(t *testing.T) {
 		app("billing", "apps/billing/overlays/prod", "team-a", "billing-api"),
 		app("shipping", "apps/shipping/overlays/prod", "team-b", "shipping-api"),
 	}}
-	sp, asc := argoApplicationFacts(context.Background(), lister)
+	sp, asc, argoItems := argoApplicationFacts(context.Background(), lister)
 	asf := appSetFanouts(asc)
 
 	// Scoped to team-a → only billing (its workload is visible), even though both
 	// Applications live in argocd, which is NOT in the allowed set.
-	claims := collectArgoClaims(context.Background(), lister, sp, asf, []string{"team-a"})
+	claims := collectArgoClaims(argoItems, sp, asf, []string{"team-a"})
 	if len(claims) != 1 || claims[0].Identity.Key != "apps/billing" {
 		t.Fatalf("namespace-scoped claims = %+v, want only billing (team-a workload visible)", claims)
 	}
 	// Explicit no access (non-nil empty) → nothing.
-	if none := collectArgoClaims(context.Background(), lister, sp, asf, []string{}); len(none) != 0 {
+	if none := collectArgoClaims(argoItems, sp, asf, []string{}); len(none) != 0 {
 		t.Fatalf("no-access claims = %d, want 0", len(none))
 	}
 	// Full access (nil) → both.
-	if all := collectArgoClaims(context.Background(), lister, sp, asf, nil); len(all) != 2 {
+	if all := collectArgoClaims(argoItems, sp, asf, nil); len(all) != 2 {
 		t.Fatalf("unscoped claims = %d, want 2", len(all))
 	}
 }
@@ -844,8 +844,8 @@ func TestCollectArgoClaims_PrefersPathOverAppSet(t *testing.T) {
 		"spec": map[string]any{"source": map[string]any{"path": "apps/billing/overlays/dev"}},
 	}}
 	lister := &stubLister{items: []*unstructured.Unstructured{item, sib}}
-	sp, asc := argoApplicationFacts(context.Background(), lister)
-	claims := collectArgoClaims(context.Background(), lister, sp, appSetFanouts(asc), nil)
+	sp, asc, argoItems := argoApplicationFacts(context.Background(), lister)
+	claims := collectArgoClaims(argoItems, sp, appSetFanouts(asc), nil)
 	for _, c := range claims {
 		if c.Identity != nil && c.Identity.Key == "billing-api" {
 			continue

--- a/internal/server/applications_identity_test.go
+++ b/internal/server/applications_identity_test.go
@@ -43,7 +43,7 @@ func TestIdentities_DeclaredPathPlusRawNamespaceEnv(t *testing.T) {
 		identRow("billing-staging", "staging", 3, "/Application/billing-staging", "repo.dev/koala/billing:b_2026-06-05_01"),
 		identRow("billing", "dev", 0, "", "repo.dev/koala/billing:b_2026-05-18_00"),
 	}
-	resolveAppIdentities(rows, map[string]string{"billing-staging": "billing/deploy/overlays/staging"}, nil)
+	resolveAppIdentities(rows, map[string]string{"billing-staging": "billing/deploy/overlays/staging"}, nil, nil)
 
 	st := identOf(t, rows, "billing-staging")
 	if st == nil || st.Key != "billing" || st.Env != "staging" || st.Confidence != "high" {
@@ -62,7 +62,7 @@ func TestIdentities_EnvPrefixTrackingPair(t *testing.T) {
 		identRow("dev-koala-backend-us-east1", "dev", 3, "/Application/dev-koala-backend-us-east1", "repo.dev/koala/koala-backend:m1"),
 		identRow("staging-koala-backend-us-east1", "staging", 3, "/Application/staging-koala-backend-us-east1", "repo.dev/koala/koala-backend:m2"),
 	}
-	resolveAppIdentities(rows, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil)
 
 	a := identOf(t, rows, "dev-koala-backend-us-east1")
 	b := identOf(t, rows, "staging-koala-backend-us-east1")
@@ -82,7 +82,7 @@ func TestIdentities_SameNameAcrossEnvNamespaces(t *testing.T) {
 		identRow("project-infra", "staging", 7, "staging/app/project-infra", "repo.dev/koala/project-infra:y"),
 		identRow("project-infra", "qa", 7, "qa/app/project-infra", "repo.dev/koala/project-infra:z"),
 	}
-	resolveAppIdentities(rows, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil)
 	envs := map[string]bool{}
 	for i := range rows {
 		f := rows[i].Identity
@@ -103,7 +103,7 @@ func TestIdentities_NoRepoOverlapRefuses(t *testing.T) {
 		identRow("api", "dev", 0, "", "repo.dev/teamA/api:1"),
 		identRow("api", "staging", 0, "", "repo.dev/teamB/other:1"),
 	}
-	resolveAppIdentities(rows, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil)
 	if rows[0].Identity != nil || rows[1].Identity != nil {
 		t.Fatalf("uncorroborated stem match grouped: %+v / %+v", rows[0].Identity, rows[1].Identity)
 	}
@@ -115,7 +115,7 @@ func TestIdentities_SingleEnvRefuses(t *testing.T) {
 		identRow("worker", "staging", 0, "staging/app/worker-a", "repo.dev/koala/worker:1"),
 		identRow("worker", "staging", 0, "staging/app/worker-b", "repo.dev/koala/worker:1"),
 	}
-	resolveAppIdentities(rows, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil)
 	if rows[0].Identity != nil {
 		t.Fatalf("single-env group formed: %+v", rows[0].Identity)
 	}
@@ -130,7 +130,7 @@ func TestIdentities_ConflictingDeclaredStemsRefuse(t *testing.T) {
 	resolveAppIdentities(rows, map[string]string{
 		"shop-staging": "teamA/shop/overlays/staging",
 		"shop-dev":     "teamB/legacy-shop/overlays/dev",
-	}, nil)
+	}, nil, nil)
 	if rows[0].Identity != nil || rows[1].Identity != nil {
 		t.Fatalf("conflicting declarations grouped: %+v / %+v", rows[0].Identity, rows[1].Identity)
 	}
@@ -143,7 +143,7 @@ func TestIdentities_GenericTokensNotNameEvidence(t *testing.T) {
 		identRow("load-test", "apps", 0, "", "repo.dev/koala/load:1"),
 		identRow("load", "dev", 0, "", "repo.dev/koala/load:1"),
 	}
-	resolveAppIdentities(rows, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil)
 	if rows[0].Identity != nil {
 		t.Fatalf("'-test' suffix treated as env: %+v", rows[0].Identity)
 	}
@@ -155,7 +155,7 @@ func TestIdentities_EnvSynonymsCanonicalize(t *testing.T) {
 		identRow("pay-production", "payments", 0, "", "repo.dev/koala/pay:1"),
 		identRow("pay-stage", "payments", 0, "", "repo.dev/koala/pay:2"),
 	}
-	resolveAppIdentities(rows, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil)
 	a, b := rows[0].Identity, rows[1].Identity
 	if a == nil || b == nil || a.Env != "prod" || b.Env != "staging" {
 		t.Fatalf("synonyms = %+v / %+v, want prod / staging", a, b)
@@ -172,7 +172,7 @@ func TestIdentities_ClassificationNotIdentity(t *testing.T) {
 		}
 	}
 	tagged := mk()
-	resolveAppIdentities(tagged, nil, nil)
+	resolveAppIdentities(tagged, nil, nil, nil)
 	for i := range tagged {
 		tagged[i].Identity = nil
 	}
@@ -196,7 +196,7 @@ func TestIdentities_CustomTokenDiscoveredByRecurrence(t *testing.T) {
 		identRow("cron", "dev", 0, "dev/app/cron", "repo.dev/koala/cron:1"),
 		identRow("cron-loadtest", "team3", 0, "", "repo.dev/koala/cron:2"),
 	}
-	resolveAppIdentities(rows, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil)
 	a := identOf(t, rows, "api-loadtest")
 	if a == nil || a.Key != "api" || a.Env != "loadtest" {
 		t.Fatalf("api-loadtest identity = %+v, want key=api env=loadtest (recurrence-discovered)", a)
@@ -210,7 +210,7 @@ func TestIdentities_AffixCorroboratedByNamespace(t *testing.T) {
 		identRow("api", "dev", 0, "dev/app/api", "repo.dev/koala/api:1"),
 		identRow("api-loadtest", "loadtest", 0, "", "repo.dev/koala/api:2"),
 	}
-	resolveAppIdentities(rows, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil)
 	a := identOf(t, rows, "api-loadtest")
 	if a == nil || a.Env != "loadtest" {
 		t.Fatalf("affix+namespace corroboration failed: %+v", a)
@@ -228,7 +228,7 @@ func TestIdentities_VariantSuffixesNotEnvs(t *testing.T) {
 		identRow("mempool-cos", "infra", 0, "", "repo.dev/koala/mp:1"),
 		identRow("mempool-ubuntu", "infra", 0, "", "repo.dev/koala/mp:2"),
 	}
-	resolveAppIdentities(rows, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil)
 	for i := range rows {
 		if rows[i].Identity != nil {
 			t.Fatalf("variant suffix grouped as env: %s → %+v", rows[i].Name, rows[i].Identity)
@@ -243,7 +243,7 @@ func TestIdentities_MultiSegmentNamespaceNotAToken(t *testing.T) {
 		identRow("frps-a", "skyhook-clients-frps", 0, "", "repo.dev/koala/frps:1"),
 		identRow("frps-a", "skyhook-clients-frps-staging", 0, "", "repo.dev/koala/frps:2"),
 	}
-	resolveAppIdentities(rows, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil)
 	for i := range rows {
 		f := rows[i].Identity
 		if f != nil && f.Env != "staging" {
@@ -259,7 +259,7 @@ func TestIdentities_OneOffTokenNotDiscovered(t *testing.T) {
 		identRow("api", "dev", 0, "dev/app/api", "repo.dev/koala/api:1"),
 		identRow("api-v2", "dev", 0, "", "repo.dev/koala/api:2"),
 	}
-	resolveAppIdentities(rows, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil)
 	if f := identOf(t, rows, "api-v2"); f != nil {
 		t.Fatalf("api-v2 grouped as env instance: %+v", f)
 	}
@@ -273,7 +273,7 @@ func TestIdentities_ExplicitEnvLabels(t *testing.T) {
 	b := identRow("payments", "team-b", 0, "team-b/app/payments", "repo.dev/koala/pay:2")
 	a.Workloads[0].envLabel = "blue"
 	rows := []appRow{a, b}
-	resolveAppIdentities(rows, nil, map[string]string{"team-b": "green"})
+	resolveAppIdentities(rows, nil, nil, map[string]string{"team-b": "green"})
 	fa, fb := rows[0].Identity, rows[1].Identity
 	if fa == nil || fa.Env != "blue" || fa.Confidence != "medium" || fa.Portable || !strings.Contains(fa.Evidence, `environment label "blue"`) {
 		t.Fatalf("workload-labeled instance = %+v, want env=blue medium/local with label evidence", fa)
@@ -295,7 +295,7 @@ func TestIdentities_DisagreeingWorkloadLabelsIgnored(t *testing.T) {
 	a.Workloads[1].envLabel = "prod"
 	b := identRow("api", "staging", 0, "staging/app/api", "repo.dev/koala/api:2")
 	rows := []appRow{a, b}
-	resolveAppIdentities(rows, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil)
 	fa := rows[0].Identity
 	// Falls back to the namespace reading (dev) instead of either label.
 	if fa == nil || fa.Env != "dev" {
@@ -323,7 +323,7 @@ func TestIdentities_AdoptionJoinsProvenCore(t *testing.T) {
 		identRow("project-infra", "staging", 7, "staging/app/project-infra", "repo.dev/koala/pi:y"),
 		identRow("project-infra", "sandboxx", 7, "sandboxx/app/project-infra", "repo.dev/koala/pi:z"),
 	}
-	resolveAppIdentities(rows, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil)
 	f := identOf(t, rows, "project-infra")
 	got := rows[2].Identity
 	if f == nil || got == nil || got.Key != "project-infra" || got.Env != "sandboxx" {
@@ -338,7 +338,7 @@ func TestIdentities_AdoptionNeverBootstraps(t *testing.T) {
 		identRow("api", "dev", 0, "dev/app/api", "repo.dev/koala/api:1"),
 		identRow("api", "teamspace", 0, "teamspace/app/api", "repo.dev/koala/api:2"),
 	}
-	resolveAppIdentities(rows, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil)
 	if rows[0].Identity != nil || rows[1].Identity != nil {
 		t.Fatalf("adoption bootstrapped a identity: %+v / %+v", rows[0].Identity, rows[1].Identity)
 	}
@@ -353,7 +353,7 @@ func TestIdentities_AdopteeNeverVetoesCore(t *testing.T) {
 		identRow("billing", "staging", 0, "staging/app/billing", "repo.dev/koala/billing:2"),
 		identRow("billing", "team", 0, "team/app/billing", "repo.dev/other/thing:1"),
 	}
-	resolveAppIdentities(rows, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil)
 	dev, st, stranger := rows[0].Identity, rows[1].Identity, rows[2].Identity
 	if dev == nil || st == nil || dev.Key != "billing" {
 		t.Fatalf("coincidence row vetoed the proven core: %+v / %+v", dev, st)
@@ -369,7 +369,7 @@ func TestIdentities_SameStemStrangerDoesNotVetoRepoCore(t *testing.T) {
 		identRow("api", "staging", 0, "staging/app/api", "repo.dev/team/api:2"),
 		identRow("api", "qa", 0, "qa/app/api", "repo.dev/other/api:1"),
 	}
-	resolveAppIdentities(rows, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil)
 	dev, st, stranger := rows[0].Identity, rows[1].Identity, rows[2].Identity
 	if dev == nil || st == nil || dev.Key != "api" || st.Key != "api" {
 		t.Fatalf("different-repo stranger vetoed valid api identity: %+v / %+v", dev, st)
@@ -385,7 +385,7 @@ func TestIdentities_EmptyRepoCandidateDoesNotHideLaterRepoCore(t *testing.T) {
 		identRow("api", "staging", 0, "staging/app/api", "repo.dev/team/api:1"),
 		identRow("api", "prod", 0, "prod/app/api", "repo.dev/team/api:2"),
 	}
-	resolveAppIdentities(rows, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil)
 	if rows[0].Identity != nil {
 		t.Fatalf("empty-repo candidate joined identity: %+v", rows[0].Identity)
 	}
@@ -455,7 +455,7 @@ func TestArgoSourcePaths(t *testing.T) {
 		argoApp("no-env-path", map[string]any{"source": map[string]any{"path": "charts/api"}}),
 		argoApp("malformed", map[string]any{"source": "not-a-map"}),
 	}}
-	got := argoSourcePaths(context.Background(), lister)
+	got, _ := argoApplicationFacts(context.Background(), lister)
 	want := map[string]string{
 		"billing-staging": "billing/deploy/overlays/staging",
 		"multi":           "apps/overlays/dev",
@@ -475,7 +475,7 @@ func TestArgoSourcePaths_AmbiguousSameNameRefuses(t *testing.T) {
 		argoAppInNamespace("team-a", "billing-staging", map[string]any{"source": map[string]any{"path": "team-a/billing/overlays/staging"}}),
 		argoAppInNamespace("team-b", "billing-staging", map[string]any{"source": map[string]any{"path": "team-b/billing/overlays/staging"}}),
 	}}
-	got := argoSourcePaths(context.Background(), lister)
+	got, _ := argoApplicationFacts(context.Background(), lister)
 	if got["billing-staging"] != "" {
 		t.Fatalf("bare ambiguous argoSourcePaths[billing-staging] = %q, want empty", got["billing-staging"])
 	}
@@ -492,7 +492,7 @@ func TestIdentities_ArgoSourcePathUsesNamespacedKey(t *testing.T) {
 	resolveAppIdentities(rows, map[string]string{
 		"argocd-a/billing-staging": "apps/billing/overlays/staging",
 		"argocd-b/billing-dev":     "apps/billing/overlays/dev",
-	}, nil)
+	}, nil, nil)
 	a, b := rows[0].Identity, rows[1].Identity
 	if a == nil || b == nil || a.Key != "billing" || b.Key != "billing" || !a.Portable || !b.Portable {
 		t.Fatalf("namespaced Argo path identities = %+v / %+v, want portable billing", a, b)
@@ -515,7 +515,7 @@ func TestIdentities_LabelGivesCleanSingletonKey(t *testing.T) {
 	rows := []appRow{
 		withName(identRow("koala-backend-xyz", "prod", 0, "prod/app/koala-backend-xyz", "ghcr.io/k/koala-backend:1"), "koala-backend"),
 	}
-	resolveAppIdentities(rows, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil)
 	id := rows[0].Identity
 	if id == nil || id.Key != "koala-backend" || id.Confidence != "high" {
 		t.Fatalf("label identity not set high-confidence: %+v", id)
@@ -535,7 +535,7 @@ func TestIdentities_LabelUpgradesNameStem(t *testing.T) {
 		withName(identRow("widget", "dev", 0, "dev/app/widget", "ghcr.io/k/widget:1"), "widget"),
 		withName(identRow("widget", "prod", 0, "prod/app/widget", "ghcr.io/k/widget:2"), "widget"),
 	}
-	resolveAppIdentities(rows, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil)
 	for i := range rows {
 		id := rows[i].Identity
 		if id == nil || id.Key != "widget" || id.Confidence != "high" {
@@ -554,7 +554,7 @@ func TestIdentities_LabelDoesNotOverrideArgoPath(t *testing.T) {
 	resolveAppIdentities(rows, map[string]string{
 		"billing-staging": "billing/deploy/overlays/staging",
 		"billing-dev":     "billing/deploy/overlays/dev",
-	}, nil)
+	}, nil, nil)
 	// The declared Argo identity must survive — its evidence still cites the
 	// source path, not the name label (which would mean the label clobbered it).
 	id := identOf(t, rows, "billing-staging")
@@ -573,8 +573,233 @@ func TestIdentities_DisagreeingNameLabelsIgnored(t *testing.T) {
 	r.Workloads[0].nameLabel = "alpha"
 	r.Workloads[1].nameLabel = "beta"
 	rows := []appRow{r}
-	resolveAppIdentities(rows, nil, nil)
+	resolveAppIdentities(rows, nil, nil, nil)
 	if rows[0].Identity != nil {
 		t.Fatalf("disagreeing name labels should not yield identity: %+v", rows[0].Identity)
+	}
+}
+
+// The explicit app.skyhook.io/app annotation is authoritative + portable, and
+// overrides even a declared Argo source-path identity (the user opted in).
+func TestIdentities_ExplicitAnnotationIsAuthoritativePortable(t *testing.T) {
+	r := identRow("billing-staging", "staging", 3, "/Application/billing-staging", "repo.dev/koala/billing:b1")
+	r.Workloads[0].appAnnotation = "koala-billing"
+	rows := []appRow{r}
+	resolveAppIdentities(rows, map[string]string{"billing-staging": "billing/deploy/overlays/staging"}, nil, nil)
+
+	id := identOf(t, rows, "billing-staging")
+	if id == nil || id.Key != "koala-billing" || id.Source != SourceExplicit || !id.Portable {
+		t.Fatalf("explicit identity = %+v, want key=koala-billing source=explicit portable", id)
+	}
+	if id.Env != "staging" {
+		t.Errorf("explicit tier should keep the env a stronger signal resolved: %+v", id)
+	}
+}
+
+// A single unlabeled row with the explicit annotation still groups — it needs no
+// in-cluster corroboration (the declaration stands alone).
+func TestIdentities_ExplicitAnnotationStandsAlone(t *testing.T) {
+	r := identRow("api", "dev", 0, "dev/app/api", "ghcr.io/acme/api:1")
+	r.Workloads[0].appAnnotation = "acme-api"
+	rows := []appRow{r}
+	resolveAppIdentities(rows, nil, nil, nil)
+	id := identOf(t, rows, "api")
+	if id == nil || id.Key != "acme-api" || id.Source != SourceExplicit || !id.Portable {
+		t.Fatalf("standalone explicit identity = %+v, want key=acme-api source=explicit portable", id)
+	}
+}
+
+// Source provenance is stamped on every tier so the fleet consumer can gate
+// cross-cluster promotion on the source, not on the human evidence string.
+func TestIdentities_SourceProvenanceStamped(t *testing.T) {
+	// Argo source path → argo-path, portable.
+	argo := []appRow{
+		identRow("billing-staging", "staging", 3, "/Application/billing-staging", "r.dev/b:1"),
+		identRow("billing", "dev", 0, "", "r.dev/b:2"),
+	}
+	resolveAppIdentities(argo, map[string]string{"billing-staging": "billing/deploy/overlays/staging"}, nil, nil)
+	if id := identOf(t, argo, "billing-staging"); id == nil || id.Source != SourceArgoPath || !id.Portable {
+		t.Fatalf("argo-path source = %+v, want argo-path portable", id)
+	}
+
+	// Bare app.kubernetes.io/name → label, NOT portable (collision-prone, the
+	// fleet must corroborate before any cross-cluster fold).
+	lbl := identRow("web", "prod", 0, "prod/app/web", "ghcr.io/x/web:1")
+	lbl.Workloads[0].nameLabel = "web"
+	lrows := []appRow{lbl}
+	resolveAppIdentities(lrows, nil, nil, nil)
+	if id := identOf(t, lrows, "web"); id == nil || id.Source != SourceLabel || id.Portable {
+		t.Fatalf("label source = %+v, want label NOT portable", id)
+	}
+}
+
+// The ApplicationSet fan-out discriminator: only a SINGLE-APP env-fan-out (one
+// app, children differ solely by a trio env token) is a valid set identity. A
+// multi-app bundle, a per-env bundle, and a cluster/region fan-out all refuse.
+func TestAppSetFanouts_SingleAppVsBundle(t *testing.T) {
+	child := func(name string) argoChild { return argoChild{keys: []string{name}, name: name} }
+
+	// Single-app env fan-out → folds to one stem, per-child env.
+	fanout := appSetFanouts(map[string][]argoChild{
+		"billing": {child("billing-dev"), child("billing-staging"), child("billing-prod")},
+	})
+	for _, c := range []struct{ key, env string }{{"billing-dev", "dev"}, {"billing-staging", "staging"}, {"billing-prod", "prod"}} {
+		if f, ok := fanout[c.key]; !ok || f.stem != "billing" || f.env != c.env {
+			t.Fatalf("fan-out child %s = %+v, want stem=billing env=%s", c.key, f, c.env)
+		}
+	}
+
+	// Multi-app bundle (children are different apps) → no set identity.
+	if got := appSetFanouts(map[string][]argoChild{
+		"platform": {child("frontend"), child("backend"), child("database")},
+	}); len(got) != 0 {
+		t.Fatalf("multi-app bundle set must not yield identity: %+v", got)
+	}
+
+	// Per-env bundle (one env, many apps — differing token is the APP, not env)
+	// → no set identity.
+	if got := appSetFanouts(map[string][]argoChild{
+		"prod-apps": {child("billing-prod"), child("shipping-prod")},
+	}); len(got) != 0 {
+		t.Fatalf("per-env bundle set must not yield identity: %+v", got)
+	}
+
+	// Cluster fan-out (differing token is a cluster name, not a trio env) → no
+	// OSS identity; env/identity for that shape comes from the hub.
+	if got := appSetFanouts(map[string][]argoChild{
+		"billing": {child("billing-uswest"), child("billing-useast")},
+	}); len(got) != 0 {
+		t.Fatalf("cluster fan-out must not yield OSS identity: %+v", got)
+	}
+
+	// Trivial stem (children collapse to "api") → refused.
+	if got := appSetFanouts(map[string][]argoChild{
+		"api": {child("api-dev"), child("api-prod")},
+	}); len(got) != 0 {
+		t.Fatalf("trivial-stem fan-out must not yield identity: %+v", got)
+	}
+}
+
+// An ApplicationSet fan-out makes its children portable (Source=argo-appset),
+// overriding the weaker name-stem tier — so they fold across clusters.
+func TestIdentities_AppSetFanoutIsPortable(t *testing.T) {
+	rows := []appRow{
+		identRow("billing-dev", "argocd", 3, "argocd/Application/billing-dev", "repo.dev/billing:1"),
+		identRow("billing-prod", "argocd", 3, "argocd/Application/billing-prod", "repo.dev/billing:2"),
+	}
+	fan := appSetFanouts(map[string][]argoChild{
+		"billing": {{keys: []string{"argocd/billing-dev", "billing-dev"}, name: "billing-dev"}, {keys: []string{"argocd/billing-prod", "billing-prod"}, name: "billing-prod"}},
+	})
+	resolveAppIdentities(rows, nil, fan, nil)
+	for _, name := range []string{"billing-dev", "billing-prod"} {
+		id := identOf(t, rows, name)
+		if id == nil || id.Key != "billing" || id.Source != SourceArgoAppSet || !id.Portable {
+			t.Fatalf("%s appset identity = %+v, want key=billing source=argo-appset portable", name, id)
+		}
+	}
+}
+
+// collectArgoClaims emits a claim only for Applications with a DECLARED identity,
+// carrying the destination + managed workloads so the hub can stamp it onto the
+// member cluster's rows (hub-spoke). Path-less / undeclared Applications emit none.
+func TestCollectArgoClaims(t *testing.T) {
+	argoAppFull := func(name string, spec, status map[string]any) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": name},
+			"spec":     spec,
+			"status":   status,
+		}}
+	}
+	lister := &stubLister{items: []*unstructured.Unstructured{
+		argoAppFull("billing-prod",
+			map[string]any{
+				"source":      map[string]any{"path": "apps/billing/overlays/prod"},
+				"destination": map[string]any{"name": "prod-cluster", "namespace": "billing"},
+			},
+			map[string]any{"resources": []any{
+				map[string]any{"kind": "Deployment", "namespace": "billing", "name": "billing-api"},
+				map[string]any{"kind": "ConfigMap", "namespace": "billing", "name": "billing-cfg"}, // not a workload
+			}}),
+		// No declared identity (env-less path) → no claim.
+		argoAppFull("infra", map[string]any{"source": map[string]any{"path": "charts/infra"}}, nil),
+	}}
+	sourcePaths, appSetChildren := argoApplicationFacts(context.Background(), lister)
+	claims := collectArgoClaims(context.Background(), lister, sourcePaths, appSetFanouts(appSetChildren), nil)
+
+	if len(claims) != 1 {
+		t.Fatalf("claims = %d, want 1 (only the declared app): %+v", len(claims), claims)
+	}
+	c := claims[0]
+	if c.Identity == nil || c.Identity.Key != "apps/billing" || c.Identity.Source != SourceArgoPath || !c.Identity.Portable {
+		t.Fatalf("claim identity = %+v, want apps/billing argo-path portable", c.Identity)
+	}
+	if c.DestName != "prod-cluster" || c.DestNamespace != "billing" {
+		t.Fatalf("claim destination = %q/%q, want prod-cluster/billing", c.DestName, c.DestNamespace)
+	}
+	if len(c.Workloads) != 1 || c.Workloads[0].Kind != "Deployment" || c.Workloads[0].Name != "billing-api" {
+		t.Fatalf("claim workloads = %+v, want only the Deployment", c.Workloads)
+	}
+}
+
+// Fix: a raw/label workload that merely SHARES A NAME with an ApplicationSet
+// child (but isn't Argo-managed) must not be promoted to a portable argo-appset
+// identity via the bare-name key fallback.
+func TestIdentities_AppSetFanoutSkipsNonArgoRows(t *testing.T) {
+	// A plain Deployment named "billing-dev" (tier 0, not Argo-managed).
+	rows := []appRow{identRow("billing-dev", "prod", 0, "prod/app/billing-dev", "repo.dev/x:1")}
+	fan := appSetFanouts(map[string][]argoChild{
+		"billing": {{keys: []string{"argocd/billing-dev", "billing-dev"}, name: "billing-dev"}, {keys: []string{"argocd/billing-prod", "billing-prod"}, name: "billing-prod"}},
+	})
+	resolveAppIdentities(rows, nil, fan, nil)
+	if id := rows[0].Identity; id != nil && id.Source == SourceArgoAppSet {
+		t.Fatalf("non-Argo row falsely stamped argo-appset: %+v", id)
+	}
+}
+
+// Fix: the explicit annotation is authoritative+portable, so a row where only
+// SOME workloads carry it must NOT be promoted (partial annotation ≠ whole app).
+func TestIdentities_ExplicitAnnotationRequiresAllWorkloads(t *testing.T) {
+	r := identRow("svc", "dev", 0, "dev/app/svc", "ghcr.io/a:1", "ghcr.io/a:1")
+	r.Workloads[0].appAnnotation = "acme-svc"
+	// r.Workloads[1] has no annotation → not all agree.
+	rows := []appRow{r}
+	resolveAppIdentities(rows, nil, nil, nil)
+	if id := rows[0].Identity; id != nil && id.Source == SourceExplicit {
+		t.Fatalf("partial annotation should not yield explicit identity: %+v", id)
+	}
+
+	// All workloads annotated (same value) → explicit identity applies.
+	r2 := identRow("svc", "dev", 0, "dev/app/svc", "ghcr.io/a:1", "ghcr.io/a:1")
+	r2.Workloads[0].appAnnotation = "acme-svc"
+	r2.Workloads[1].appAnnotation = "acme-svc"
+	rows2 := []appRow{r2}
+	resolveAppIdentities(rows2, nil, nil, nil)
+	if id := rows2[0].Identity; id == nil || id.Source != SourceExplicit || id.Key != "acme-svc" {
+		t.Fatalf("fully-annotated row should be explicit: %+v", id)
+	}
+}
+
+// Fix: collectArgoClaims scopes to the caller's allowed namespaces — a
+// namespace-scoped request must not leak claims for Applications elsewhere.
+func TestCollectArgoClaims_NamespaceScoped(t *testing.T) {
+	app := func(ns, name, path string) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"namespace": ns, "name": name},
+			"spec":     map[string]any{"source": map[string]any{"path": path}},
+		}}
+	}
+	lister := &stubLister{items: []*unstructured.Unstructured{
+		app("team-a", "billing", "apps/billing/overlays/prod"),
+		app("team-b", "shipping", "apps/shipping/overlays/prod"),
+	}}
+	sp, asc := argoApplicationFacts(context.Background(), lister)
+	// Scoped to team-a only → no team-b claim.
+	claims := collectArgoClaims(context.Background(), lister, sp, appSetFanouts(asc), []string{"team-a"})
+	if len(claims) != 1 || claims[0].Identity.Key != "apps/billing" {
+		t.Fatalf("namespace-scoped claims = %+v, want only team-a's billing", claims)
+	}
+	// Unscoped (nil) → both.
+	if all := collectArgoClaims(context.Background(), lister, sp, appSetFanouts(asc), nil); len(all) != 2 {
+		t.Fatalf("unscoped claims = %d, want 2", len(all))
 	}
 }

--- a/internal/server/applications_identity_test.go
+++ b/internal/server/applications_identity_test.go
@@ -779,27 +779,40 @@ func TestIdentities_ExplicitAnnotationRequiresAllWorkloads(t *testing.T) {
 	}
 }
 
-// Fix: collectArgoClaims scopes to the caller's allowed namespaces — a
-// namespace-scoped request must not leak claims for Applications elsewhere.
+// Fix: collectArgoClaims scopes by the MANAGED WORKLOAD namespace (an
+// Application may live in argocd while its workloads run elsewhere), returns
+// nothing for explicit no-access (non-nil empty), and everything for full access
+// (nil). A scoped caller gets a claim only when it can see a managed workload.
 func TestCollectArgoClaims_NamespaceScoped(t *testing.T) {
-	app := func(ns, name, path string) *unstructured.Unstructured {
+	// Both Applications live in argocd; their workloads run in app namespaces.
+	app := func(name, path, wlNs, wlName string) *unstructured.Unstructured {
 		return &unstructured.Unstructured{Object: map[string]any{
-			"metadata": map[string]any{"namespace": ns, "name": name},
+			"metadata": map[string]any{"namespace": "argocd", "name": name},
 			"spec":     map[string]any{"source": map[string]any{"path": path}},
+			"status": map[string]any{"resources": []any{
+				map[string]any{"kind": "Deployment", "namespace": wlNs, "name": wlName},
+			}},
 		}}
 	}
 	lister := &stubLister{items: []*unstructured.Unstructured{
-		app("team-a", "billing", "apps/billing/overlays/prod"),
-		app("team-b", "shipping", "apps/shipping/overlays/prod"),
+		app("billing", "apps/billing/overlays/prod", "team-a", "billing-api"),
+		app("shipping", "apps/shipping/overlays/prod", "team-b", "shipping-api"),
 	}}
 	sp, asc := argoApplicationFacts(context.Background(), lister)
-	// Scoped to team-a only → no team-b claim.
-	claims := collectArgoClaims(context.Background(), lister, sp, appSetFanouts(asc), []string{"team-a"})
+	asf := appSetFanouts(asc)
+
+	// Scoped to team-a → only billing (its workload is visible), even though both
+	// Applications live in argocd, which is NOT in the allowed set.
+	claims := collectArgoClaims(context.Background(), lister, sp, asf, []string{"team-a"})
 	if len(claims) != 1 || claims[0].Identity.Key != "apps/billing" {
-		t.Fatalf("namespace-scoped claims = %+v, want only team-a's billing", claims)
+		t.Fatalf("namespace-scoped claims = %+v, want only billing (team-a workload visible)", claims)
 	}
-	// Unscoped (nil) → both.
-	if all := collectArgoClaims(context.Background(), lister, sp, appSetFanouts(asc), nil); len(all) != 2 {
+	// Explicit no access (non-nil empty) → nothing.
+	if none := collectArgoClaims(context.Background(), lister, sp, asf, []string{}); len(none) != 0 {
+		t.Fatalf("no-access claims = %d, want 0", len(none))
+	}
+	// Full access (nil) → both.
+	if all := collectArgoClaims(context.Background(), lister, sp, asf, nil); len(all) != 2 {
 		t.Fatalf("unscoped claims = %d, want 2", len(all))
 	}
 }

--- a/internal/server/applications_identity_test.go
+++ b/internal/server/applications_identity_test.go
@@ -887,7 +887,7 @@ func TestIdentities_FluxSourcePathIsPortable(t *testing.T) {
 		// Key is the name stem (the join key that unifies a declared-path instance
 		// with a raw-but-corroborated sibling); the path is the declared SIGNAL that
 		// makes it portable, cited in the evidence.
-		if id == nil || id.Key != "billing" || id.Source != SourceFluxSource || !id.Portable {
+		if id == nil || id.Key != "billing" || id.Source != SourceFluxSource || !id.Portable || id.PathKey != "apps/billing" {
 			t.Fatalf("row %d flux identity = %+v, want key=billing source=flux-source portable", i, id)
 		}
 		if !strings.Contains(id.Evidence, "Flux source path") {

--- a/internal/server/applications_identity_test.go
+++ b/internal/server/applications_identity_test.go
@@ -816,3 +816,52 @@ func TestCollectArgoClaims_NamespaceScoped(t *testing.T) {
 		t.Fatalf("unscoped claims = %d, want 2", len(all))
 	}
 }
+
+// A claim's declared identity must use the same precedence as the row resolver:
+// an env-bearing Argo source path outranks an ApplicationSet fan-out, so a
+// co-located row (keyed by path) and a hub-spoke claim agree.
+func TestCollectArgoClaims_PrefersPathOverAppSet(t *testing.T) {
+	// An Application that is BOTH appset-owned AND has an env-overlay source path.
+	item := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
+			"name":            "billing-prod",
+			"ownerReferences": []any{map[string]any{"kind": "ApplicationSet", "name": "billing"}},
+		},
+		"spec": map[string]any{
+			"source":      map[string]any{"path": "apps/billing/overlays/prod"},
+			"destination": map[string]any{"name": "prod", "namespace": "billing"},
+		},
+		"status": map[string]any{"resources": []any{
+			map[string]any{"kind": "Deployment", "namespace": "billing", "name": "billing-api"},
+		}},
+	}}
+	// A sibling so the appset is a recognized fan-out.
+	sib := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
+			"name":            "billing-dev",
+			"ownerReferences": []any{map[string]any{"kind": "ApplicationSet", "name": "billing"}},
+		},
+		"spec": map[string]any{"source": map[string]any{"path": "apps/billing/overlays/dev"}},
+	}}
+	lister := &stubLister{items: []*unstructured.Unstructured{item, sib}}
+	sp, asc := argoApplicationFacts(context.Background(), lister)
+	claims := collectArgoClaims(context.Background(), lister, sp, appSetFanouts(asc), nil)
+	for _, c := range claims {
+		if c.Identity != nil && c.Identity.Key == "billing-api" {
+			continue
+		}
+		if c.Identity != nil && c.Identity.Source == SourceArgoAppSet {
+			t.Fatalf("claim used appset over argo-path: %+v", c.Identity)
+		}
+	}
+	// The billing-prod claim specifically must be argo-path (apps/billing), not appset (billing).
+	var found *appIdentity
+	for _, c := range claims {
+		if len(c.Workloads) == 1 && c.Workloads[0].Name == "billing-api" {
+			found = c.Identity
+		}
+	}
+	if found == nil || found.Source != SourceArgoPath || found.Key != "apps/billing" {
+		t.Fatalf("billing-prod claim = %+v, want argo-path key=apps/billing", found)
+	}
+}

--- a/packages/k8s-ui/src/components/applications/AppTooltips.tsx
+++ b/packages/k8s-ui/src/components/applications/AppTooltips.tsx
@@ -1,4 +1,4 @@
-import { provenanceSource, HEALTH_META, appGroupingExplainer, APP_IDENTITY_ANNOTATION, type AppWorkload, type AppIdentity } from '../../utils/applications'
+import { provenanceSource, HEALTH_META, appSourceLabel, isDeclaredAppSource, APP_IDENTITY_ANNOTATION, type AppWorkload } from '../../utils/applications'
 import { midTruncate } from '../../utils/format'
 
 // Structured tooltip content for the application chips. Both render a short
@@ -105,26 +105,53 @@ export function CategoryTooltip({
   )
 }
 
-// AppIdentityTooltip — why these instances are grouped. One line per distinct
-// evidence in the ProvenanceTooltip idiom (signals as inline-code, long repo
-// refs mid-truncated), plus a small flag when the grouping is heuristic-only.
-// No member list — the env pills next to this chip already show the instances.
+// AppIdentityTooltip — why these instances are grouped, and (in the fleet view)
+// whether the grouping folds across clusters + how to make it. A clear
+// source-driven headline, the per-evidence detail lines, and — when `fleet` and
+// the identity isn't a declared cross-cluster origin — the canonical "how to
+// fold" answer, so the question and its answer share one surface.
+//
+// `source`/`portable` come from the row's identity; absent (an older host that
+// doesn't pass them) the headline degrades to the evidence lines. `fleet` gates
+// the cross-cluster "how to fold" line — single-cluster (OSS) has no clusters to
+// fold across, so it shows only the grouping evidence.
 export function AppIdentityTooltip({
   members,
+  source,
+  portable,
+  fleet,
 }: {
   identityKey?: string
   members: { name: string; env: string; confidence: string; evidence: string }[]
+  source?: string
+  portable?: boolean
+  fleet?: boolean
 }) {
   const evidences = Array.from(new Set(members.map((m) => m.evidence).filter(Boolean)))
   const heuristicOnly = members.every((m) => m.confidence !== 'high')
+  // The wire `portable` flag is authoritative; fall back to deriving it from the
+  // source when an older host doesn't pass it.
+  const folds = portable ?? isDeclaredAppSource(source)
   return (
-    <div className="max-w-xs space-y-1">
+    <div className="max-w-xs space-y-1.5">
+      {source && <div className="text-xs font-medium text-theme-text-primary">Grouped by {appSourceLabel(source)}.</div>}
       {evidences.map((e, i) => (
-        <div key={i} className="text-xs text-theme-text-primary">
+        <div key={i} className="text-xs text-theme-text-secondary">
           <EvidenceLine evidence={e} />
         </div>
       ))}
-      {heuristicOnly && (
+      {fleet && folds && (
+        <div className="text-[10px] uppercase tracking-wide text-theme-text-tertiary">folds across clusters</div>
+      )}
+      {fleet && source !== undefined && !folds && (
+        <div className="space-y-1 border-t border-theme-border pt-1.5">
+          <div className="text-[11px] leading-snug text-theme-text-secondary">
+            Shown per-cluster — a name can't prove two clusters run the same app. To fold it across clusters, set the same{' '}
+            <code className="inline-code">{APP_IDENTITY_ANNOTATION}</code> on its workloads in each cluster, or deploy it via Argo CD / Flux with the environment in the source path.
+          </div>
+        </div>
+      )}
+      {!fleet && heuristicOnly && !source && (
         <div className={`text-[10px] uppercase tracking-wide ${HEALTH_META.degraded.text}`}>heuristic · medium confidence</div>
       )}
     </div>
@@ -174,28 +201,6 @@ function quotedEvidenceValue(value: string, prefix: string, separator: string): 
   const sep = value.indexOf(separator, start)
   if (sep < 0) return null
   return { value: value.slice(start, sep), rest: value.slice(sep + separator.length) }
-}
-
-// GroupingHint — why an app folds across clusters (or doesn't) and how to make
-// it. Rendered from the per-cluster row's info affordance, so the canonical
-// answer to "why isn't this grouped?" lives exactly where the question arises.
-export function GroupingHint({ identity }: { identity?: AppIdentity }) {
-  const { folds, how, fix } = appGroupingExplainer(identity)
-  return (
-    <div className="max-w-xs space-y-1.5">
-      <div className="text-xs text-theme-text-primary">{how}</div>
-      {folds ? (
-        <div className="text-[11px] leading-snug text-theme-text-secondary">
-          Folds across clusters — its identity is a declared origin.
-        </div>
-      ) : (
-        <>
-          <div className="text-[11px] leading-snug text-theme-text-secondary">{fix}</div>
-          <code className="inline-code">{APP_IDENTITY_ANNOTATION}=&lt;your-app&gt;</code>
-        </>
-      )}
-    </div>
-  )
 }
 
 // EnvHint — how environments are determined + how to set one explicitly.

--- a/packages/k8s-ui/src/components/applications/AppTooltips.tsx
+++ b/packages/k8s-ui/src/components/applications/AppTooltips.tsx
@@ -1,4 +1,4 @@
-import { provenanceSource, HEALTH_META, type AppWorkload } from '../../utils/applications'
+import { provenanceSource, HEALTH_META, appGroupingExplainer, APP_IDENTITY_ANNOTATION, type AppWorkload, type AppIdentity } from '../../utils/applications'
 import { midTruncate } from '../../utils/format'
 
 // Structured tooltip content for the application chips. Both render a short
@@ -174,6 +174,28 @@ function quotedEvidenceValue(value: string, prefix: string, separator: string): 
   const sep = value.indexOf(separator, start)
   if (sep < 0) return null
   return { value: value.slice(start, sep), rest: value.slice(sep + separator.length) }
+}
+
+// GroupingHint — why an app folds across clusters (or doesn't) and how to make
+// it. Rendered from the per-cluster row's info affordance, so the canonical
+// answer to "why isn't this grouped?" lives exactly where the question arises.
+export function GroupingHint({ identity }: { identity?: AppIdentity }) {
+  const { folds, how, fix } = appGroupingExplainer(identity)
+  return (
+    <div className="max-w-xs space-y-1.5">
+      <div className="text-xs text-theme-text-primary">{how}</div>
+      {folds ? (
+        <div className="text-[11px] leading-snug text-theme-text-secondary">
+          Folds across clusters — its identity is a declared origin.
+        </div>
+      ) : (
+        <>
+          <div className="text-[11px] leading-snug text-theme-text-secondary">{fix}</div>
+          <code className="inline-code">{APP_IDENTITY_ANNOTATION}=&lt;your-app&gt;</code>
+        </>
+      )}
+    </div>
+  )
 }
 
 // EnvHint — how environments are determined + how to set one explicitly.

--- a/packages/k8s-ui/src/components/applications/ApplicationsView.tsx
+++ b/packages/k8s-ui/src/components/applications/ApplicationsView.tsx
@@ -418,7 +418,7 @@ export function ApplicationsView({ entries: allEntries, variant, onSelect, title
                           <ChevronRight className={clsx('h-3.5 w-3.5 shrink-0 text-theme-text-tertiary transition-transform', r.expanded && 'rotate-90')} aria-hidden />
                           <span className="truncate font-semibold text-theme-text-primary">{r.label}</span>
                           <Tooltip
-                            content={<AppIdentityTooltip identityKey={r.label} members={r.members.map((m) => ({ name: m.row.name, env: m.row.identity!.env, confidence: m.row.identity!.confidence, evidence: m.row.identity!.evidence }))} />}
+                            content={<AppIdentityTooltip identityKey={r.label} source={r.members[0]?.row.identity?.source} portable={r.members[0]?.row.identity?.portable} fleet={variant === 'fleet'} members={r.members.map((m) => ({ name: m.row.name, env: m.row.identity!.env, confidence: m.row.identity!.confidence, evidence: m.row.identity!.evidence }))} />}
                             delay={150}
                           >
                             <span className={`${CHIP} ${r.confidence === 'high' ? CHIP_TONE.emerald : CHIP_TONE.neutral}`}>

--- a/packages/k8s-ui/src/utils/applications.test.ts
+++ b/packages/k8s-ui/src/utils/applications.test.ts
@@ -223,3 +223,22 @@ describe('appGroupingExplainer', () => {
     }
   })
 })
+
+describe('foldAppGroups pathKey disambiguation', () => {
+  const fleetEntry = (key: string, env: string, pathKey: string): AppGroupFoldEntry => ({
+    row: { key, name: 'billing', identity: { key: 'billing', env, confidence: 'high', evidence: 'e', portable: true, source: 'argo-path', pathKey } },
+    health: 'healthy', versions: [], ready: 1, desired: 1, kinds: { Deployment: 1 }, classComposition: [{ cls: 'service', count: 1 }],
+  })
+  const opts = { localScope: (e: AppGroupFoldEntry) => e.row.key }
+
+  it('folds same-name portable rows that share a pathKey', () => {
+    const rows = foldAppGroups([fleetEntry('cl-a', 'dev', 'apps/billing'), fleetEntry('cl-b', 'prod', 'apps/billing')], new Set(), false, opts)
+    expect(rows.filter((r) => r.kind === 'group').length).toBe(1)
+  })
+
+  it('does NOT fold same-name portable rows with different pathKeys (two teams, two paths)', () => {
+    const rows = foldAppGroups([fleetEntry('cl-a', 'dev', 'teamA/billing'), fleetEntry('cl-b', 'prod', 'teamB/billing')], new Set(), false, opts)
+    expect(rows.filter((r) => r.kind === 'group').length).toBe(0)
+    expect(rows.filter((r) => r.kind === 'instance').length).toBe(2)
+  })
+})

--- a/packages/k8s-ui/src/utils/applications.test.ts
+++ b/packages/k8s-ui/src/utils/applications.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { compareVersions, appGroupLagMessage, matchWorkloadAcrossInstances, foldAppGroups, identityEnvInferred, type AppGroupFoldEntry } from './applications'
+import { compareVersions, appGroupingExplainer, APP_IDENTITY_ANNOTATION, appGroupLagMessage, matchWorkloadAcrossInstances, foldAppGroups, identityEnvInferred, type AppGroupFoldEntry } from './applications'
 
 describe('compareVersions', () => {
   it('orders semver', () => {
@@ -203,5 +203,23 @@ describe('foldAppGroups', () => {
       localScope: (e) => e.row.key,
     })
     expect(grouped.map((r) => r.kind)).toEqual(['group'])
+  })
+})
+
+describe('appGroupingExplainer', () => {
+  it('declared origins fold across clusters with no fix needed', () => {
+    for (const source of ['explicit', 'argo-path', 'argo-appset', 'flux-source']) {
+      const e = appGroupingExplainer({ key: 'k', env: 'prod', confidence: 'high', evidence: '', source })
+      expect(e.folds).toBe(true)
+      expect(e.fix).toBeUndefined()
+    }
+  })
+
+  it('NAME sources stay per-cluster and tell the user how to fold', () => {
+    for (const source of ['label', 'name-stem', 'namespace', undefined]) {
+      const e = appGroupingExplainer({ key: 'k', env: 'prod', confidence: 'high', evidence: '', source })
+      expect(e.folds).toBe(false)
+      expect(e.fix).toContain(APP_IDENTITY_ANNOTATION)
+    }
   })
 })

--- a/packages/k8s-ui/src/utils/applications.ts
+++ b/packages/k8s-ui/src/utils/applications.ts
@@ -81,6 +81,8 @@ export function appSourceLabel(source?: string): string {
       return 'its ApplicationSet (env fan-out)'
     case 'flux-source':
       return 'its Flux source'
+    case 'addon':
+      return 'a shared add-on name + chart/image'
     case 'label':
       return 'the app.kubernetes.io/name label'
     case 'name-stem':

--- a/packages/k8s-ui/src/utils/applications.ts
+++ b/packages/k8s-ui/src/utils/applications.ts
@@ -57,6 +57,10 @@ export interface AppIdentity {
    *  explicit | argo-path | argo-appset | flux-source (declared origins, portable)
    *  · label | name-stem | namespace (NAMEs, per-cluster). */
   source?: string
+  /** Declared source-path stem (argo-path / flux-source only). The display `key`
+   *  is the name stem; this disambiguates same-name/different-path apps in the
+   *  portable cross-cluster fold. */
+  pathKey?: string
 }
 
 /** The user-set annotation that forces cross-cluster grouping — the canonical
@@ -548,7 +552,10 @@ export function foldAppGroups<T extends AppGroupFoldEntry>(
     if (!id) return null
     const scope = options.localScope?.(e)
     if (!scope) return id.key
-    return id.portable ? `portable:${id.key}` : `local:${scope}:${id.key}`
+    // A declared-PATH identity displays its name stem as the key but carries the
+    // path stem in pathKey; two different apps can share a name while declaring
+    // different paths, so disambiguate the portable cross-cluster fold by pathKey.
+    return id.portable ? `portable:${id.key}${id.pathKey ? `:${id.pathKey}` : ''}` : `local:${scope}:${id.key}`
   }
   const byGroup = new Map<string, T[]>()
   for (const e of entries) {

--- a/packages/k8s-ui/src/utils/applications.ts
+++ b/packages/k8s-ui/src/utils/applications.ts
@@ -53,6 +53,57 @@ export interface AppIdentity {
   evidence: string
   /** True when the key is backed by declared upstream identity and can group across clusters. */
   portable?: boolean
+  /** Machine-readable provenance tier (radar applications_identity.go):
+   *  explicit | argo-path | argo-appset | flux-source (declared origins, portable)
+   *  · label | name-stem | namespace (NAMEs, per-cluster). */
+  source?: string
+}
+
+/** The user-set annotation that forces cross-cluster grouping — the canonical
+ *  answer to "how do I make this fold?" for non-GitOps apps. */
+export const APP_IDENTITY_ANNOTATION = 'app.skyhook.io/app'
+
+/** Whether a Source is a declared cross-cluster origin (mirrors the hub's
+ *  isDeclaredPortableSource). NAMEs collide across clusters and stay per-cluster. */
+export function isDeclaredAppSource(source?: string): boolean {
+  return source === 'explicit' || source === 'argo-path' || source === 'argo-appset' || source === 'flux-source'
+}
+
+/** A short label for how an app's identity was determined, by Source — the
+ *  plain-language "grouped by …" phrase shown in the identity tooltip. */
+export function appSourceLabel(source?: string): string {
+  switch (source) {
+    case 'explicit':
+      return `the ${APP_IDENTITY_ANNOTATION} annotation`
+    case 'argo-path':
+      return 'its Argo CD source path'
+    case 'argo-appset':
+      return 'its ApplicationSet (env fan-out)'
+    case 'flux-source':
+      return 'its Flux source'
+    case 'label':
+      return 'the app.kubernetes.io/name label'
+    case 'name-stem':
+      return 'a shared name + image'
+    case 'namespace':
+      return 'a shared namespace + image'
+    default:
+      return 'its workload grouping'
+  }
+}
+
+/** The explainer for "why isn't this grouped across clusters, and how do I fix
+ *  it?" — drives the per-cluster row hint. `folds` is true when the identity is a
+ *  declared origin (folds cross-cluster); otherwise `fix` says what to add. */
+export function appGroupingExplainer(identity?: AppIdentity): { folds: boolean; how: string; fix?: string } {
+  const folds = isDeclaredAppSource(identity?.source)
+  return {
+    folds,
+    how: `Grouped by ${appSourceLabel(identity?.source)}.`,
+    fix: folds
+      ? undefined
+      : `This app only has a per-cluster name, which can't prove two clusters run the same app. To fold it across clusters, set ${APP_IDENTITY_ANNOTATION} on its workloads in each cluster (same value), or deploy it via Argo CD / Flux with the environment in the source path.`,
+  }
 }
 
 export interface AppRow {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1960,8 +1960,9 @@ function AppInner() {
       />
       <MyPermissionsDialog open={showMyPermissions} onClose={() => setShowMyPermissions(false)} />
 
-      {/* Debug overlay - only in dev mode */}
-      {import.meta.env.DEV && <DebugOverlay />}
+      {/* Debug overlay — dev mode, standalone only. Embedded hosts (Radar Hub)
+          own their own dev tooling; ours would collide with theirs bottom-right. */}
+      {import.meta.env.DEV && showNavRail && <DebugOverlay />}
       </div>
     </div>
     </PortForwardProvider>


### PR DESCRIPTION
## Summary

Cross-cluster app folding now rests on **declared identity**, not name inference. A name like `redis` collides across clusters, so grouping two clusters' apps by name silently merges unrelated ones (and aggregates their health as one app). This PR adds machine-readable provenance so the fleet folds only declared origins, plus the declared signals that make folding practical for real fleets — an explicit opt-in, ApplicationSet fan-out, hub-spoke propagation — and an in-product explainer so operators understand *why* an app folds or stays per-cluster.

## What changed

**Provenance — `appIdentity.Source`.** Every identity tier carries a source: declared origins (`explicit`, `argo-path`, `argo-appset`, `flux-source`) are collision-free and portable; NAMEs (`label`, `name-stem`, `namespace`) stay per-cluster. The fleet promotes on the source, not on a human evidence string.

**Explicit opt-in — `app.skyhook.io/app`.** The authoritative, portable answer to "how do I group this across clusters?" for non-GitOps apps: set the same value on an app's workloads in every cluster and they fold. Authoritative over every inferred/declared tier; requires *all* workloads in the row to carry it.

**ApplicationSet fan-out — `argo-appset`.** A single-app env fan-out set yields a portable identity. Multi-app bundles, per-env bundles, cluster fan-outs, and trivial stems are refused. Argo rows only — a raw workload sharing a name with a set child is never stamped.

**Argo claims — `collectArgoClaims`.** For hub-spoke topologies, emits each Argo Application's declared identity (path-before-appset, matching the row resolver) + destination + managed workloads, scoped to the caller's visible workloads. Consumed by radar-hub.

**In-product explainer.** `AppIdentityTooltip` leads with a source-driven "Grouped by …" headline and, in the fleet view, states whether the app folds across clusters and — when it doesn't — the canonical fix (`app.skyhook.io/app` or a GitOps env-path). Shared component, so both OSS and Cloud get it. Dev-only `DebugOverlay` gated to standalone (collided with the host's tooling when embedded).

## Testing

`go test ./internal/server/` + k8s-ui vitest + tsc green. Tests pin: the explicit-tier authority + all-workloads requirement, the fan-out-vs-bundle discriminator, non-Argo name-collision rejection, claim namespace-scoping + path-before-appset precedence, and provenance stamping per tier.

## Notes

- Flux-source identity is a documented follow-up (enum + hub gate ready; emission symmetric to `argo-path`).
- The fleet `ApplicationsView` (radar-hub-web / #956 k8s-ui) needs one line — pass `source` + `fleet` into the tooltip — for the full hint; it degrades to the evidence-derived explainer otherwise.
- Pairs with radar-hub's declared-only fold + hub-spoke stamping + add-on fold.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how fleet apps are grouped and what the applications API exposes; mis-tuned identity or hub claim logic could mis-merge health or leak Argo destination metadata to scoped callers, though behavior is heavily tested.
> 
> **Overview**
> Cross-cluster app folding now keys off **machine-readable provenance** (`identity.source`, `portable`, `pathKey`) instead of inferring from evidence strings. Declared origins (`explicit`, `argo-path`, `argo-appset`, `flux-source`) are portable; name-based tiers (`label`, `name-stem`, `namespace`) stay per-cluster so unrelated `redis` instances do not merge fleet-wide.
> 
> **Backend:** `resolveAppIdentities` gains tiers for `app.skyhook.io/app` (all workloads must agree), `app.kubernetes.io/name`, validated ApplicationSet env fan-outs, and Flux Kustomization source paths. `GET /api/applications` also returns **`argoClaims`** (declared identity + destination + managed workloads) for hub-spoke stamping, with namespace scoping on managed workload visibility. Applications cache stores claims alongside rows.
> 
> **Fleet UI:** `foldAppGroups` disambiguates portable folds with **`key` + `pathKey`**. `AppIdentityTooltip` shows a "Grouped by …" headline and, in fleet mode, whether the row folds across clusters plus how to fix per-cluster rows (`app.skyhook.io/app` or GitOps env paths). New **`docs/app-grouping.md`** documents composition vs identity, Join A/B, and design constraints.
> 
> **Minor:** Dev `DebugOverlay` only when the standalone nav rail is shown (avoids collision when embedded).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 121e87a51bc75b3d125f0d7830683ec69e63cb81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->