### PR TITLE
Use /api/issues contract for Home active issues

### DIFF
--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -717,11 +717,18 @@ func (s *Server) getDashboardHealth(cache *k8s.ResourceCache, namespace string) 
 
 	// Sort: critical first, then high, then medium; within each group sort by age (most recent first)
 	// "warning" is below medium — degraded states that aren't immediate
-	// failures. Listed explicitly so the Go zero-value (0) doesn't accidentally
-	// sort warnings ahead of critical when an unknown severity is encountered.
-	severityOrder := map[string]int{"critical": 0, "high": 1, "medium": 2, "warning": 3}
+	// failures. Info is inert/posture and ranks last. Unknown severities also
+	// rank last instead of falling through to Go's zero value beside critical.
+	severityOrder := map[string]int{"critical": 0, "high": 1, "medium": 2, "warning": 3, "info": 4}
 	sort.SliceStable(problems, func(i, j int) bool {
-		si, sj := severityOrder[problems[i].Severity], severityOrder[problems[j].Severity]
+		si, ok := severityOrder[problems[i].Severity]
+		if !ok {
+			si = len(severityOrder)
+		}
+		sj, ok := severityOrder[problems[j].Severity]
+		if !ok {
+			sj = len(severityOrder)
+		}
 		if si != sj {
 			return si < sj
 		}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1608,21 +1608,7 @@ function AppInner() {
               console.debug('[filters] App.onNavigateToResourceKind: navigating to', targetURL)
               navigate({ pathname: `/resources/${kind}`, search: newParams.toString() })
             }}
-            onNavigateToResource={(resource) => {
-              // Switch to resources view and open the resource detail drawer
-              setSelectedResource(resource)
-              const newParams = new URLSearchParams(searchParams)
-              newParams.delete('kind') // kind is now in the path
-              newParams.delete('mode')
-              newParams.delete('group')
-              newParams.delete('resource')
-              if (resource.group) {
-                newParams.set('apiGroup', resource.group)
-              } else {
-                newParams.delete('apiGroup')
-              }
-              navigate({ pathname: `/resources/${resource.kind}`, search: newParams.toString() })
-            }}
+            onNavigateToResource={navigateFromIssue}
           />
         )}
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -122,7 +122,7 @@ export interface DashboardProblem {
   namespace: string
   name: string
   group?: string
-  severity: 'critical' | 'high' | 'medium'
+  severity: 'critical' | 'high' | 'medium' | 'warning' | 'info'
   reason: string
   message: string
   age: string
@@ -341,8 +341,9 @@ export function useAudit(namespaces: string[] = []) {
 
 // Live cluster Issues — the grouped triage queue (radar's /api/issues =
 // internal/issues.Compose+Classify+Group). Single-cluster here; the Hub fleet
-// view fans the same shape across clusters. keepPreviousData semantics via
-// placeholderData so the queue doesn't flash empty on the 30s refresh.
+// view fans the same shape across clusters. Do not carry old data across query
+// keys: issues are scope-sensitive, so namespace changes must not show the
+// previous scope's rows while the new scope fetches.
 // total = rows returned (after the cap); total_matched = rows that matched
 // before the cap. total_matched > total means the queue was truncated — surface
 // that honestly rather than presenting a capped list as if it were complete.
@@ -365,7 +366,6 @@ export function useIssues(namespaces: string[] = []) {
     queryFn: () => fetchJSON(`/issues${params}`),
     staleTime: 30000,
     refetchInterval: 30000,
-    placeholderData: (prev) => prev,
   })
 }
 

--- a/web/src/components/home/ClusterHealthCard.tsx
+++ b/web/src/components/home/ClusterHealthCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import type { DashboardResponse, DashboardMetrics, DashboardCRDCount, DashboardProblem } from '../../api/client'
+import type { DashboardResponse, DashboardMetrics, DashboardCRDCount } from '../../api/client'
 import { HealthRing } from './HealthRing'
 import {
   AlertTriangle, CheckCircle, XCircle,
@@ -23,12 +23,13 @@ interface ClusterHealthCardProps {
   metrics: DashboardMetrics | null
   metricsServerAvailable: boolean
   topCRDs?: DashboardCRDCount[] // Loaded lazily, may be undefined
-  problems: DashboardProblem[]
+  issueCount: number
+  hasCriticalIssues: boolean
   nodeVersionSkew: DashboardResponse['nodeVersionSkew']
   onNavigateToKind: (kind: string, group?: string) => void
   onNavigateToView: () => void
   onWarningEventsClick?: () => void
-  onUnhealthyClick?: () => void
+  onIssuesClick?: () => void
 }
 
 function getMetricsInstallHint(platform: string): string {
@@ -113,12 +114,13 @@ export function ClusterHealthCard({
   metrics,
   metricsServerAvailable,
   topCRDs: _topCRDs,
-  problems,
+  issueCount,
+  hasCriticalIssues,
   nodeVersionSkew,
   onNavigateToKind,
   onNavigateToView,
   onWarningEventsClick,
-  onUnhealthyClick,
+  onIssuesClick,
 }: ClusterHealthCardProps) {
   void _topCRDs // Reserved for future CRD display
 
@@ -450,14 +452,14 @@ export function ClusterHealthCard({
               <span><span className="font-mono">{health.warningEvents}</span> Warning Events</span>
             </button>
           )}
-          {problems.length > 0 && (
+          {issueCount > 0 && (
             <button
-              onClick={onUnhealthyClick}
-              title="View timeline of unhealthy/degraded workload events"
-              className="badge status-unhealthy w-fit gap-1.5 hover:opacity-80 transition-opacity"
+              onClick={onIssuesClick}
+              title="View grouped live operational issues"
+              className={clsx('badge w-fit gap-1.5 hover:opacity-80 transition-opacity', hasCriticalIssues ? 'status-unhealthy' : 'status-degraded')}
             >
               <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
-              <span>View unhealthy workload events</span>
+              <span>{pluralize(issueCount, 'Active Issue')}</span>
             </button>
           )}
         </div>

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -1,8 +1,6 @@
 import { useMemo, type ReactNode } from 'react'
-import { useDashboard, useDashboardCRDs, useDashboardHelm } from '../../api/client'
-import type { DashboardResponse } from '../../api/client'
+import { useDashboard, useDashboardCRDs, useDashboardHelm, useIssues, type IssuesResponse } from '../../api/client'
 import type { ExtendedMainView, Topology, SelectedResource } from '../../types'
-import { kindToPlural } from '../../utils/navigation'
 import { TopologyPreview } from './TopologyPreview'
 import { HelmSummary } from './HelmSummary'
 import { ActivitySummary } from './ActivitySummary'
@@ -11,9 +9,18 @@ import { CertificateHealthCard } from './CertificateHealthCard'
 import { NetworkPolicyCoverageCard } from './NetworkPolicyCoverageCard'
 import { CostCard } from './CostCard'
 import { GitOpsControllersCard } from './GitOpsControllersCard'
-import { AuditCard, PaneLoader, StatusDot, mapHealthToTone } from '@skyhook-io/k8s-ui'
+import {
+  AuditCard,
+  PaneLoader,
+  StatusDot,
+  categoryLabel,
+  groupLabel,
+  subjectRef,
+  type Issue,
+} from '@skyhook-io/k8s-ui'
+import { formatCompactAge } from '@skyhook-io/k8s-ui/utils/format'
 import { ClusterHealthCard } from './ClusterHealthCard'
-import { AlertTriangle, Loader2, Shield } from 'lucide-react'
+import { AlertTriangle, CheckCircle, Loader2, Shield } from 'lucide-react'
 import { clsx } from 'clsx'
 
 interface HomeViewProps {
@@ -26,6 +33,10 @@ interface HomeViewProps {
 
 export function HomeView({ namespaces, topology, onNavigateToView, onNavigateToResourceKind, onNavigateToResource }: HomeViewProps) {
   const { data, isLoading, error } = useDashboard(namespaces)
+  const { data: issuesData, isLoading: issuesLoading, isFetching: issuesFetching, error: issuesError } = useIssues(namespaces)
+  const issues = issuesData?.issues ?? []
+  const issueCount = issuesData?.total_matched ?? issuesData?.total ?? issues.length
+  const hasCriticalIssues = issues.some((issue) => issue.severity === 'critical')
 
   // SSE is cluster-wide on small/medium clusters; the picker only narrows the
   // dashboard summary, so re-apply the filter here or the legend disagrees.
@@ -73,8 +84,6 @@ export function HomeView({ namespaces, topology, onNavigateToView, onNavigateToR
     )
   }
 
-  const hasProblems = data.problems && data.problems.length > 0
-
   const stillLoading = data.deferredLoading || (data.partialData && data.partialData.length > 0)
 
   return (
@@ -98,19 +107,17 @@ export function HomeView({ namespaces, topology, onNavigateToView, onNavigateToR
           metrics={data.metrics}
           metricsServerAvailable={data.metricsServerAvailable}
           topCRDs={crdsData?.topCRDs}
-          problems={data.problems ?? []}
+          issueCount={issueCount}
+          hasCriticalIssues={hasCriticalIssues}
           nodeVersionSkew={data.nodeVersionSkew}
           onNavigateToKind={onNavigateToResourceKind}
           onNavigateToView={() => onNavigateToView('resources')}
           onWarningEventsClick={() => onNavigateToView('timeline', { view: 'list', filter: 'warnings', time: 'all' })}
-          onUnhealthyClick={() => onNavigateToView('timeline', { view: 'list', filter: 'unhealthy', time: 'all' })}
+          onIssuesClick={() => onNavigateToView('issues')}
         />
 
-        {/* Row 2: Main content columns — teasers left, problems right (if any) */}
-        <div className={clsx(
-          'grid gap-6',
-          hasProblems ? 'grid-cols-1 lg:grid-cols-[1fr_420px]' : 'grid-cols-1'
-        )}>
+        {/* Row 2: Main content columns - teasers left, issues right */}
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_420px]">
           {/* Left column: teaser cards */}
           <div className="flex flex-col gap-6 auto-rows-min">
             {/* Live band — Topology + Timeline always render, so a fixed 2-up never strands.
@@ -190,14 +197,18 @@ export function HomeView({ namespaces, topology, onNavigateToView, onNavigateToR
             )}
           </div>
 
-          {/* Right column: problems panel */}
-          {hasProblems && (
-            <ProblemsPanel
-              problems={data.problems}
-              onNavigateToIssues={() => onNavigateToView('issues')}
-              onResourceClick={onNavigateToResource}
-            />
-          )}
+          <ProblemsPanel
+            issues={issues}
+            issueCount={issueCount}
+            visibility={issuesData?.visibility}
+            hasData={!!issuesData}
+            isLoading={issuesLoading && !issuesData}
+            isRefreshing={issuesFetching && !!issuesData}
+            error={issuesError}
+            totalReturned={issues.length}
+            onNavigateToIssues={() => onNavigateToView('issues')}
+            onResourceClick={onNavigateToResource}
+          />
         </div>
       </div>
     </div>
@@ -216,19 +227,56 @@ function BandItem({ children }: { children: ReactNode }) {
 // ============================================================================
 
 interface ProblemsPanelProps {
-  problems: DashboardResponse['problems']
+  issues: Issue[]
+  issueCount: number
+  visibility?: IssuesResponse['visibility']
+  hasData: boolean
+  isLoading: boolean
+  isRefreshing: boolean
+  error: unknown
+  totalReturned: number
   onNavigateToIssues: () => void
   onResourceClick: (resource: SelectedResource) => void
 }
 
 
-function ProblemsPanel({ problems, onNavigateToIssues, onResourceClick }: ProblemsPanelProps) {
+function ProblemsPanel({
+  issues,
+  issueCount,
+  visibility,
+  hasData,
+  isLoading,
+  isRefreshing,
+  error,
+  totalReturned,
+  onNavigateToIssues,
+  onResourceClick,
+}: ProblemsPanelProps) {
+  const hasCriticalIssues = issues.some((issue) => issue.severity === 'critical')
+  const hasIssues = issueCount > 0
+  const hasHardError = !!error && !hasData
+  const hasLimitedVisibility = !!visibility?.impact
+  const isTruncated = issueCount > totalReturned
+  const titleClass = hasCriticalIssues
+    ? 'text-red-500'
+    : hasIssues || hasHardError || hasLimitedVisibility
+      ? 'text-amber-500'
+      : 'text-theme-text-secondary'
+  const countClass = hasHardError
+    ? 'status-unknown'
+    : hasCriticalIssues
+      ? 'status-unhealthy'
+      : hasIssues || hasLimitedVisibility
+        ? 'status-degraded'
+        : 'status-healthy'
+  const countLabel = isLoading ? '...' : hasHardError ? 'error' : String(issueCount)
+
   return (
     <div className="rounded-xl bg-theme-surface shadow-theme-sm flex flex-col lg:max-h-[calc(100vh-280px)] lg:sticky lg:top-0">
       <div className="flex items-center justify-between px-5 py-3 border-b border-theme-border/50 shrink-0">
         <div className="flex items-center gap-2">
-          <AlertTriangle className="w-4 h-4 text-red-500" />
-          <span className="text-xs font-semibold uppercase tracking-wider text-red-500">Active Issues</span>
+          <AlertTriangle className={clsx('w-4 h-4', titleClass)} />
+          <span className={clsx('text-xs font-semibold uppercase tracking-wider', titleClass)}>Active Issues</span>
         </div>
         <div className="flex items-center gap-2">
           <button
@@ -238,41 +286,141 @@ function ProblemsPanel({ problems, onNavigateToIssues, onResourceClick }: Proble
           >
             View all
           </button>
-          <span className="badge status-unhealthy rounded-full">{problems.length}</span>
+          {isRefreshing && !isLoading && (
+            <Loader2 className="h-3.5 w-3.5 animate-spin text-theme-text-tertiary" aria-label="Refreshing issues" />
+          )}
+          <span className={clsx('badge rounded-full', countClass)}>{countLabel}</span>
         </div>
       </div>
       <div className="overflow-y-auto flex-1 min-h-0">
-        <div className="divide-y divide-theme-border">
-          {problems.map((p, i) => (
-            <button
-              key={`${p.kind}-${p.namespace}-${p.name}-${i}`}
-              className="w-full flex items-center gap-2 px-3 py-1.5 hover:bg-theme-hover transition-colors text-left"
-              onClick={() => onResourceClick({
-                kind: kindToPlural(p.kind),
-                namespace: p.namespace,
-                name: p.name,
-                group: p.group,
-              })}
-            >
-              <StatusDot tone={mapHealthToTone(p.severity)} className="shrink-0" />
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-1.5">
-                  <span className="text-[10px] text-theme-text-tertiary bg-theme-elevated px-1 py-0.5 rounded">{p.kind}</span>
-                  <span className="text-xs text-theme-text-primary truncate font-medium">{p.name}</span>
-                  <span className="text-[10px] text-theme-text-tertiary ml-auto shrink-0">{p.duration || p.age}</span>
-                </div>
-                <div className="flex items-center gap-1.5 mt-0.5">
-                  <span className="text-[11px] text-theme-text-secondary truncate">{p.reason}</span>
-                  <span className="text-[10px] text-theme-text-tertiary shrink-0">{p.namespace}</span>
-                </div>
-                {p.message && (
-                  <div className="text-[10px] text-theme-text-tertiary truncate mt-0.5">{p.message}</div>
-                )}
+        {isLoading ? (
+          <ProblemsPanelState
+            icon={<Loader2 className="h-5 w-5 animate-spin text-theme-text-tertiary" />}
+            title="Loading issues"
+            body="Checking live cluster issues for the selected scope."
+          />
+        ) : hasHardError ? (
+          <ProblemsPanelState
+            icon={<AlertTriangle className="h-5 w-5 text-amber-500" />}
+            title="Issues unavailable"
+            body={formatIssueError(error)}
+          />
+        ) : (
+          <>
+            {!!error && (
+              <ProblemsPanelNotice tone="warning">
+                Issue refresh failed. Showing the last successful result.
+              </ProblemsPanelNotice>
+            )}
+            {visibility?.impact && (
+              <ProblemsPanelNotice tone="warning">
+                Limited visibility - {visibility.impact} Results may be incomplete.
+              </ProblemsPanelNotice>
+            )}
+            {isTruncated && (
+              <ProblemsPanelNotice tone="neutral">
+                Showing {totalReturned} of {issueCount} issues. Narrow by namespace to see the rest.
+              </ProblemsPanelNotice>
+            )}
+
+            {issues.length === 0 ? (
+              <ProblemsPanelState
+                icon={
+                  hasLimitedVisibility
+                    ? <AlertTriangle className="h-5 w-5 text-amber-500" />
+                    : <CheckCircle className="h-5 w-5 text-green-500" />
+                }
+                title={hasLimitedVisibility ? 'No visible active issues' : 'No active issues'}
+                body={
+                  hasLimitedVisibility
+                    ? 'Radar could not read every workload source in this scope.'
+                    : 'No critical or warning issues across the selected scope.'
+                }
+              />
+            ) : (
+              <div className="divide-y divide-theme-border">
+                {issues.map((issue) => {
+                  const ref = subjectRef(issue)
+                  const age = issue.first_seen
+                    ? issue.issue_timing === 'started_at_resource_creation'
+                      ? 'since deploy'
+                      : formatCompactAge(issue.first_seen)
+                    : ''
+
+                  return (
+                    <button
+                      key={issue.id}
+                      className="w-full flex items-center gap-2 px-3 py-1.5 hover:bg-theme-hover transition-colors text-left"
+                      onClick={() => onResourceClick({
+                        kind: ref.kind,
+                        namespace: ref.namespace ?? '',
+                        name: ref.name,
+                        group: ref.group ?? '',
+                      })}
+                    >
+                      <StatusDot tone={issue.severity === 'critical' ? 'unhealthy' : 'degraded'} className="shrink-0" />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-1.5">
+                          <span className="text-[10px] text-theme-text-tertiary bg-theme-elevated px-1 py-0.5 rounded">{issue.kind}</span>
+                          <span className="text-xs text-theme-text-primary truncate font-medium">{issue.name}</span>
+                          {age && <span className="text-[10px] text-theme-text-tertiary ml-auto shrink-0">{age}</span>}
+                        </div>
+                        <div className="flex items-center gap-1.5 mt-0.5">
+                          <span className="text-[11px] text-theme-text-secondary truncate">{categoryLabel(issue.category)}</span>
+                          <span className="text-[10px] text-theme-text-tertiary shrink-0">{groupLabel(issue.category_group)}</span>
+                          {issue.namespace && <span className="text-[10px] text-theme-text-tertiary shrink-0">{issue.namespace}</span>}
+                        </div>
+                        {(issue.reason || issue.message) && (
+                          <div className="text-[10px] text-theme-text-tertiary truncate mt-0.5">
+                            {issue.reason}
+                            {issue.reason && issue.message ? ' - ' : ''}
+                            {issue.message}
+                          </div>
+                        )}
+                      </div>
+                    </button>
+                  )
+                })}
               </div>
-            </button>
-          ))}
-        </div>
+            )}
+          </>
+        )}
       </div>
     </div>
   )
+}
+
+function ProblemsPanelState({ icon, title, body }: { icon: ReactNode; title: string; body: string }) {
+  return (
+    <div className="flex min-h-[220px] flex-col items-center justify-center gap-2 px-6 py-10 text-center">
+      <div className="flex h-9 w-9 items-center justify-center rounded-full bg-theme-elevated">
+        {icon}
+      </div>
+      <p className="text-sm font-medium text-theme-text-primary">{title}</p>
+      <p className="max-w-[280px] text-xs leading-5 text-theme-text-secondary">{body}</p>
+    </div>
+  )
+}
+
+function ProblemsPanelNotice({ tone, children }: { tone: 'warning' | 'neutral'; children: ReactNode }) {
+  return (
+    <div className="px-3 pt-3">
+      <div
+        className={clsx(
+          'rounded-lg border px-3 py-2 text-xs leading-5',
+          tone === 'warning'
+            ? 'border-amber-500/20 bg-amber-500/10 text-theme-text-secondary'
+            : 'border-theme-border bg-theme-elevated text-theme-text-secondary',
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function formatIssueError(error: unknown): string {
+  return error instanceof Error && error.message
+    ? error.message
+    : 'Failed to load active issues.'
 }


### PR DESCRIPTION
## Summary

Home now uses the same `/api/issues` contract as the Issues page for prominent Active Issues surfaces. This keeps informational/raw dashboard detections from being promoted on Home when the Issues page intentionally filters or groups them differently, while keeping the Home issue rail visible even when the issues query is loading, empty, or unavailable.

## What changed

- Wired Home to `useIssues()` for the Active Issues rail and cluster health issue badge.
- Kept the Home Active Issues panel permanently mounted instead of hiding it when there are no rows.
- Added explicit panel states for initial loading, hard errors, empty results, limited RBAC visibility, capped results, and refresh failures with stale data.
- Updated the Home issue rows to render the composed issue contract: category/group labels, subject references, critical vs warning tone, and deploy-time age wording.
- Changed the cluster health badge from a raw “unhealthy workload events” affordance to an Active Issues entry point that opens the Issues page.
- Hardened the legacy dashboard problem model and sort order so `warning`, `info`, and unknown severities cannot rank beside critical items.

## Testing

- `make tsc`
- `make test`
- `make build`
- Visual check against `kind-radar-bench` at 1920x1080 and 1280x800.
- Playwright route-intercept checks for Home issue panel loading, hard-error, empty limited-visibility, and restored live-data states; final restored state had no console warnings or errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Home operational triage now depends on a separate scope-sensitive issues API and changed React Query caching; wrong counts or stale rows on namespace change would mislead operators, though behavior is more correct than mixing dashboard detections.
> 
> **Overview**
> Home **Active Issues** now comes from **`useIssues()`** (`/api/issues`) instead of dashboard **`problems`**, so the rail and badge match the Issues page grouping and filtering.
> 
> The **cluster health badge** is an **Active Issues** entry (count + critical vs degraded styling) that opens **Issues**, not the timeline unhealthy-events view. The **right rail** stays mounted with loading, error, empty, RBAC visibility, truncation, and stale-refresh states; rows use the shared issue model (category, subject ref, age).
> 
> **`useIssues`** no longer keeps previous data across namespace query keys. **`navigateFromIssue`** handles Home issue clicks (GitOps vs resource list). Legacy dashboard problem sort adds **`info`** and sends unknown severities to the end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b45b60ff1553312ea84080684ecba2f3c2dbbd16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->