### PR TITLE
Fix offline Monaco loader setup

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,9 +1,14 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import './monaco-setup'
+import { configureBundledMonaco } from './monaco-setup'
 import { RadarApp } from './RadarApp'
 import { openExternal } from './utils/navigation'
 import './index.css'
+
+// Keep this as an explicit call: side-effect-only imports of the Monaco setup can
+// be dropped by production tree-shaking, which makes offline desktop builds fall
+// back to Monaco's CDN loader.
+configureBundledMonaco()
 
 // Intercept external link clicks in the Wails desktop app.
 // <a target="_blank"> is swallowed by WKWebView/WebView2 — route through openExternal()

--- a/web/src/monaco-setup.ts
+++ b/web/src/monaco-setup.ts
@@ -3,8 +3,8 @@
 // over the network, so the YAML editor never loads in airgapped / offline
 // deployments. Bundling makes the binary fully self-contained.
 //
-// Imported for side effects from main.tsx (Radar's binary entry) only — library
-// consumers (e.g. Radar Hub) keep the default CDN loader unless they opt in.
+// Called from main.tsx (Radar's binary entry) only — library consumers
+// (e.g. Radar Hub) keep the default CDN loader unless they opt in.
 //
 // Import the editor API + YAML grammar directly rather than the `monaco-editor`
 // barrel: the barrel pulls in the JSON/CSS/HTML/TypeScript language services,
@@ -15,12 +15,19 @@ import 'monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution'
 import { loader } from '@monaco-editor/react'
 import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
 
-// YAML has no dedicated Monaco language worker — the base editor worker covers
-// everything we use, so route every label to it.
-;(self as typeof self & { MonacoEnvironment?: { getWorker(): Worker } }).MonacoEnvironment = {
-  getWorker() {
-    return new EditorWorker()
-  },
-}
+let configured = false
 
-loader.config({ monaco })
+export function configureBundledMonaco() {
+  if (configured) return
+  configured = true
+
+  // YAML has no dedicated Monaco language worker — the base editor worker covers
+  // everything we use, so route every label to it.
+  ;(globalThis as typeof globalThis & { MonacoEnvironment?: { getWorker(): Worker } }).MonacoEnvironment = {
+    getWorker() {
+      return new EditorWorker()
+    },
+  }
+
+  loader.config({ monaco })
+}


### PR DESCRIPTION
## Summary
Fixes #959 by making Radar desktop explicitly configure the bundled Monaco editor loader before the app renders. This prevents airgapped desktop installs from falling back to Monaco’s default jsdelivr loader when WebView cache is empty.

## What changed
- Replaced the side-effect-only `./monaco-setup` import in the binary app entry with an explicit `configureBundledMonaco()` call.
- Made the Monaco setup idempotent so the app entry can call it directly without relying on module side effects.
- Added a source comment documenting why this must remain an explicit call: production tree-shaking can drop side-effect-only setup and leave the emitted worker asset unused.

## Testing
- `npm run build`
- `make tsc`
- `make test`
- `git diff --check`
- visual-test: skipped (no rendered UI/layout delta)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bootstrap-only change to Monaco loader wiring; no auth, data, or API surface changes.
> 
> **Overview**
> Ensures airgapped Radar desktop builds load Monaco from the bundled package instead of falling back to the default jsdelivr CDN when the WebView cache is empty.
> 
> The binary entry (`main.tsx`) now calls **`configureBundledMonaco()`** before render instead of relying on a side-effect-only `./monaco-setup` import, with a comment that production tree-shaking can drop unused side-effect modules and leave the worker unused. **`monaco-setup.ts`** exposes that setup as an **idempotent** exported function (same `MonacoEnvironment` + `loader.config` behavior, using `globalThis` for the worker hook).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 869ec37fe8381fee541b55e8f4ab947928181be2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->