### PR TITLE
Optimize resource counts for large CRD clusters

### DIFF
--- a/internal/server/resource_counts.go
+++ b/internal/server/resource_counts.go
@@ -1,19 +1,27 @@
 package server
 
 import (
+	"errors"
 	"log"
 	"net/http"
 	"slices"
-	"sync"
 
 	"github.com/skyhook-io/radar/internal/k8s"
 	"github.com/skyhook-io/radar/pkg/k8score"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type ResourceCountsResponse struct {
-	Counts    map[string]int `json:"counts"`
-	Forbidden []string       `json:"forbidden,omitempty"`
+	Counts      map[string]int `json:"counts"`
+	Forbidden   []string       `json:"forbidden,omitempty"`
+	Unavailable []string       `json:"unavailable,omitempty"`
 }
+
+const (
+	endpointSliceCountKey          = "discovery.k8s.io/EndpointSlice"
+	endpointSliceCountNamespaceCap = 50
+	endpointSliceCountConcurrency  = 8
+)
 
 func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
 	if !s.requireConnected(w) {
@@ -34,37 +42,28 @@ func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
 
 	counts := make(map[string]int)
 	var forbidden []string
+	var unavailable []string
 
 	countEndpointSlices := func() {
 		dynamicCache := k8s.GetDynamicResourceCache()
 		if dynamicCache == nil {
+			unavailable = append(unavailable, endpointSliceCountKey)
 			return
 		}
 		gvr, ok := k8s.BuiltinGVR("endpointslices", "discovery.k8s.io")
 		if !ok {
+			unavailable = append(unavailable, endpointSliceCountKey)
 			return
 		}
-		total := 0
-		if len(namespaces) == 0 {
-			items, err := dynamicCache.ListDirect(r.Context(), gvr, "")
-			if err != nil {
+		total, err := dynamicCache.CountDirectProbe(r.Context(), gvr, namespaces, endpointSliceCountNamespaceCap, endpointSliceCountConcurrency)
+		if err != nil {
+			unavailable = append(unavailable, endpointSliceCountKey)
+			if !errors.Is(err, k8score.ErrResourceCountUnavailable) {
 				log.Printf("[resource-counts] Failed to count EndpointSlice: %v", err)
-				return
 			}
-			total = len(items)
-		} else {
-			for _, ns := range namespaces {
-				items, err := dynamicCache.ListDirect(r.Context(), gvr, ns)
-				if err != nil {
-					log.Printf("[resource-counts] Failed to count EndpointSlice in namespace %s: %v", ns, err)
-					continue
-				}
-				total += len(items)
-			}
+			return
 		}
-		if total > 0 {
-			counts["discovery.k8s.io/EndpointSlice"] = total
-		}
+		counts[endpointSliceCountKey] = total
 	}
 
 	for _, kl := range k8score.AllKindListers() {
@@ -90,12 +89,10 @@ func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
 		if kl.Kind() == "Namespace" && len(namespaces) > 0 {
 			n = len(namespaces)
 		}
-		if n > 0 {
-			counts[kl.CountKey()] = n
-		}
+		counts[kl.CountKey()] = n
 	}
 
-	// 2. Dynamic resources (CRDs) — counted concurrently since each Count() hits a separate informer indexer
+	// 2. Dynamic resources (CRDs) — report counts only for already-watched informers.
 	discovery := k8s.GetResourceDiscovery()
 	dynamicCache := k8s.GetDynamicResourceCache()
 	if discovery != nil && dynamicCache != nil {
@@ -103,15 +100,18 @@ func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			log.Printf("[resource-counts] Failed to discover API resources for CRD counts: %v", err)
 		} else {
-			// Deduplicate CRDs by group+kind
+			// Deduplicate CRDs by group+kind, keeping the most stable served version.
 			type crdInfo struct {
 				kind       string
 				group      string
 				resource   string
+				version    string
 				namespaced bool
+				gvr        schema.GroupVersionResource
 			}
 			seen := make(map[string]bool)
-			var crds []crdInfo
+			crds := make(map[string]crdInfo)
+			var order []string
 			for _, res := range resources {
 				if !res.IsCRD {
 					continue
@@ -125,51 +125,54 @@ func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
 				key := res.Group + "/" + res.Kind
 				if !seen[key] {
 					seen[key] = true
-					crds = append(crds, crdInfo{kind: res.Kind, group: res.Group, resource: res.Name, namespaced: res.Namespaced})
+					order = append(order, key)
+					crds[key] = crdInfo{
+						kind:       res.Kind,
+						group:      res.Group,
+						resource:   res.Name,
+						version:    res.Version,
+						namespaced: res.Namespaced,
+						gvr:        schema.GroupVersionResource{Group: res.Group, Version: res.Version, Resource: res.Name},
+					}
+				} else if k8score.IsMoreStableVersion(res.Version, crds[key].version) {
+					crds[key] = crdInfo{
+						kind:       res.Kind,
+						group:      res.Group,
+						resource:   res.Name,
+						version:    res.Version,
+						namespaced: res.Namespaced,
+						gvr:        schema.GroupVersionResource{Group: res.Group, Version: res.Version, Resource: res.Name},
+					}
 				}
 			}
 
-			var mu sync.Mutex
-			var wg sync.WaitGroup
-			for _, crd := range crds {
-				wg.Add(1)
-				go func(c crdInfo) {
-					defer wg.Done()
-					gvr, ok := discovery.GetGVRWithGroup(c.kind, c.group)
-					if !ok {
-						return
-					}
-					ns := namespaces
-					if !c.namespaced {
-						// Cluster-scoped CRD: per-kind SAR gate before
-						// listing cluster-wide. Mirrors the dashboard's
-						// collectClusterScopedCRDCounts.
-						if !s.canRead(r, c.group, c.resource, "", "list") {
-							return
-						}
-						ns = nil
-					}
-					n, err := dynamicCache.Count(gvr, ns)
-					if err != nil {
-						log.Printf("[resource-counts] Failed to count CRD %s/%s: %v", c.group, c.kind, err)
-						return
-					}
-					if n == 0 {
-						return
-					}
-					countKey := c.group + "/" + c.kind
-					mu.Lock()
-					counts[countKey] = n
-					mu.Unlock()
-				}(crd)
+			watchedCounts := dynamicCache.CountWatched(namespaces)
+			clusterScopedWatchedCounts := watchedCounts
+			if len(namespaces) > 0 {
+				clusterScopedWatchedCounts = dynamicCache.CountWatched(nil)
 			}
-			wg.Wait()
+			for _, key := range order {
+				crd := crds[key]
+				countSource := watchedCounts
+				if !crd.namespaced {
+					if !s.canRead(r, crd.group, crd.resource, "", "list") {
+						continue
+					}
+					countSource = clusterScopedWatchedCounts
+				}
+				if n, ok := countSource[crd.gvr]; ok {
+					counts[key] = n
+					continue
+				}
+				unavailable = append(unavailable, key)
+			}
 		}
 	}
 	countEndpointSlices()
 
 	s.writeJSON(w, ResourceCountsResponse{
-		Counts:    counts,
-		Forbidden: forbidden,
+		Counts:      counts,
+		Forbidden:   forbidden,
+		Unavailable: unavailable,
 	})
 }

--- a/internal/server/resource_counts_test.go
+++ b/internal/server/resource_counts_test.go
@@ -1,0 +1,193 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/skyhook-io/radar/internal/auth"
+	"github.com/skyhook-io/radar/internal/k8s"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestResourceCountsCountsWatchedCRDsAndMarksUnwatchedUnavailable(t *testing.T) {
+	widgetGVR := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"}
+	gadgetGVR := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "gadgets"}
+	endpointSliceGVR := schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			widgetGVR:        "WidgetList",
+			gadgetGVR:        "GadgetList",
+			endpointSliceGVR: "EndpointSliceList",
+		},
+		&unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "example.com/v1",
+			"kind":       "Widget",
+			"metadata":   map[string]any{"name": "w1", "namespace": "default"},
+		}},
+	)
+	dyn.PrependReactor("list", "endpointslices", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &unstructured.UnstructuredList{}, nil
+	})
+
+	if err := k8s.InitTestDynamicResourceCache(dyn, []k8s.APIResource{
+		{Group: "example.com", Version: "v1", Kind: "Widget", Name: "widgets", Namespaced: true, IsCRD: true, Verbs: []string{"get", "list", "watch"}},
+		{Group: "example.com", Version: "v1", Kind: "Gadget", Name: "gadgets", Namespaced: true, IsCRD: true, Verbs: []string{"get", "list", "watch"}},
+	}); err != nil {
+		t.Fatalf("InitTestDynamicResourceCache: %v", err)
+	}
+	t.Cleanup(k8s.ResetTestDynamicState)
+	dynCache := k8s.GetDynamicResourceCache()
+	if dynCache == nil {
+		t.Fatal("dynamic cache not initialized")
+	}
+	if err := dynCache.EnsureWatching(widgetGVR); err != nil {
+		t.Fatalf("EnsureWatching(widget): %v", err)
+	}
+	if !dynCache.WaitForSync(widgetGVR, 2*time.Second) {
+		t.Fatal("widget informer did not sync")
+	}
+
+	rec := httptest.NewRecorder()
+	testServerSrv.handleResourceCounts(rec, httptest.NewRequest(http.MethodGet, "/api/resource-counts", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body: %s", rec.Code, rec.Body.String())
+	}
+	var body ResourceCountsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := body.Counts["example.com/Widget"]; got != 1 {
+		t.Fatalf("Widget count = %d, want 1", got)
+	}
+	if _, ok := body.Counts["example.com/Gadget"]; ok {
+		t.Fatalf("unwatched Gadget unexpectedly had a count: %v", body.Counts["example.com/Gadget"])
+	}
+	if !containsString(body.Unavailable, "example.com/Gadget") {
+		t.Fatalf("unavailable = %v, want example.com/Gadget", body.Unavailable)
+	}
+	if got := body.Counts[endpointSliceCountKey]; got != 0 {
+		t.Fatalf("EndpointSlice count = %d, want 0", got)
+	}
+}
+
+func TestResourceCountsOmitsClusterScopedCRDWhenCanReadDenies(t *testing.T) {
+	nodePoolGVR := schema.GroupVersionResource{Group: "karpenter.sh", Version: "v1", Resource: "nodepools"}
+	endpointSliceGVR := schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			nodePoolGVR:      "NodePoolList",
+			endpointSliceGVR: "EndpointSliceList",
+		},
+		&unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "karpenter.sh/v1",
+			"kind":       "NodePool",
+			"metadata":   map[string]any{"name": "default"},
+		}},
+	)
+	dyn.PrependReactor("list", "endpointslices", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &unstructured.UnstructuredList{}, nil
+	})
+	if err := k8s.InitTestDynamicResourceCache(dyn, []k8s.APIResource{
+		{Group: "karpenter.sh", Version: "v1", Kind: "NodePool", Name: "nodepools", Namespaced: false, IsCRD: true, Verbs: []string{"get", "list", "watch"}},
+	}); err != nil {
+		t.Fatalf("InitTestDynamicResourceCache: %v", err)
+	}
+	t.Cleanup(k8s.ResetTestDynamicState)
+	dynCache := k8s.GetDynamicResourceCache()
+	if err := dynCache.EnsureWatching(nodePoolGVR); err != nil {
+		t.Fatalf("EnsureWatching(nodepool): %v", err)
+	}
+	if !dynCache.WaitForSync(nodePoolGVR, 2*time.Second) {
+		t.Fatal("nodepool informer did not sync")
+	}
+
+	s := newAuthServer(auth.Config{Mode: "proxy"})
+	user := &auth.User{Username: "alice"}
+	perms := &auth.UserPermissions{AllowedNamespaces: nil}
+	perms.SetCanI("list", "karpenter.sh", "nodepools", "", false)
+	s.permCache.Set(user.Username, perms)
+	req := requestWithUser(http.MethodGet, "/api/resource-counts", user)
+
+	rec := httptest.NewRecorder()
+	s.handleResourceCounts(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body: %s", rec.Code, rec.Body.String())
+	}
+	var body ResourceCountsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if _, ok := body.Counts["karpenter.sh/NodePool"]; ok {
+		t.Fatalf("cluster-scoped NodePool leaked through counts: %v", body.Counts["karpenter.sh/NodePool"])
+	}
+	if containsString(body.Unavailable, "karpenter.sh/NodePool") {
+		t.Fatalf("denied NodePool should not be advertised as unavailable: %v", body.Unavailable)
+	}
+}
+
+func TestResourceCountsCountsClusterScopedCRDDespiteNamespaceFilter(t *testing.T) {
+	nodePoolGVR := schema.GroupVersionResource{Group: "karpenter.sh", Version: "v1", Resource: "nodepools"}
+	endpointSliceGVR := schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			nodePoolGVR:      "NodePoolList",
+			endpointSliceGVR: "EndpointSliceList",
+		},
+		&unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "karpenter.sh/v1",
+			"kind":       "NodePool",
+			"metadata":   map[string]any{"name": "default"},
+		}},
+	)
+	dyn.PrependReactor("list", "endpointslices", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &unstructured.UnstructuredList{}, nil
+	})
+	if err := k8s.InitTestDynamicResourceCache(dyn, []k8s.APIResource{
+		{Group: "karpenter.sh", Version: "v1", Kind: "NodePool", Name: "nodepools", Namespaced: false, IsCRD: true, Verbs: []string{"get", "list", "watch"}},
+	}); err != nil {
+		t.Fatalf("InitTestDynamicResourceCache: %v", err)
+	}
+	t.Cleanup(k8s.ResetTestDynamicState)
+	dynCache := k8s.GetDynamicResourceCache()
+	if err := dynCache.EnsureWatching(nodePoolGVR); err != nil {
+		t.Fatalf("EnsureWatching(nodepool): %v", err)
+	}
+	if !dynCache.WaitForSync(nodePoolGVR, 2*time.Second) {
+		t.Fatal("nodepool informer did not sync")
+	}
+
+	rec := httptest.NewRecorder()
+	testServerSrv.handleResourceCounts(rec, httptest.NewRequest(http.MethodGet, "/api/resource-counts?namespace=default", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body: %s", rec.Code, rec.Body.String())
+	}
+	var body ResourceCountsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := body.Counts["karpenter.sh/NodePool"]; got != 1 {
+		t.Fatalf("NodePool count = %d, want 1", got)
+	}
+	if containsString(body.Unavailable, "karpenter.sh/NodePool") {
+		t.Fatalf("counted NodePool should not be marked unavailable: %v", body.Unavailable)
+	}
+}
+
+func containsString(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}

--- a/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
@@ -72,11 +72,22 @@ export type GitOpsMode = 'applications' | 'sources' | 'projects' | 'alerts'
 // the Scope switcher stays hidden until a second category lands. A one-option
 // switcher is just noise (an always-selected pill that can't be changed).
 const AVAILABLE_MODES: GitOpsMode[] = ['applications']
+const GITOPS_COUNT_GROUP_PREFIXES = [
+  'argoproj.io/',
+  'source.toolkit.fluxcd.io/',
+  'kustomize.toolkit.fluxcd.io/',
+  'helm.toolkit.fluxcd.io/',
+  'notification.toolkit.fluxcd.io/',
+]
 export type GitOpsViewMode = 'table' | 'tiles'
 // 'urgency' is the curated DEFAULT order (what needs attention first) — not a
 // column, so no header shows it as active; clicking any header replaces it with
 // that column's own semantics.
 export type SortKey = 'urgency' | 'name' | 'health' | 'sync' | 'lastSync' | 'project'
+
+function isGitOpsCountKey(key: string): boolean {
+  return GITOPS_COUNT_GROUP_PREFIXES.some((prefix) => key.startsWith(prefix))
+}
 
 // Row-level actions surfaced from the table's three-dot menu. The set
 // mirrors what the detail page exposes today; callers wire the mutations
@@ -180,6 +191,7 @@ export interface GitOpsTableViewProps {
   // counts keyed "group/Kind" — e.g. "argoproj.io/Application" → 17. Drives
   // the Scope-section mode tabs and the empty-state check.
   counts: Record<string, number>
+  countsUnavailable?: string[]
   // Caller refresh — typically invalidates its useQuery + refetches.
   onRefresh?: () => void
   // Row click — caller routes to its own detail page. When the host also
@@ -262,6 +274,7 @@ export function GitOpsTableView({
   loading,
   error,
   counts,
+  countsUnavailable,
   onRefresh,
   onRowClick,
   rowHrefFor,
@@ -356,7 +369,14 @@ export function GitOpsTableView({
     projects: counts['argoproj.io/AppProject'] ?? 0,
     alerts: counts['notification.toolkit.fluxcd.io/Alert'] ?? 0,
   }
-  const totalGitOps = Object.values(counts).reduce((sum, n) => sum + n, 0)
+  const totalGitOps = Object.entries(counts).reduce(
+    (sum, [key, n]) => sum + (isGitOpsCountKey(key) ? n : 0),
+    0,
+  )
+  const hasUnavailableGitOpsCounts = useMemo(
+    () => (countsUnavailable ?? []).some(isGitOpsCountKey),
+    [countsUnavailable],
+  )
 
   const projects = useMemo(
     () => countValues(allRows.map((row) => row.project).filter(Boolean)),
@@ -484,7 +504,7 @@ export function GitOpsTableView({
   // Also require zero actual rows: the cold-cache retry can populate `rows`
   // before the separate counts map catches up, and a populated table must not
   // be hidden behind a "nothing here" screen.
-  if (totalGitOps === 0 && allRowsInput.length === 0 && !loading && !hasGlobalNamespaceFilter) {
+  if (totalGitOps === 0 && allRowsInput.length === 0 && !loading && !hasGlobalNamespaceFilter && !hasUnavailableGitOpsCounts) {
     return (
       <div className="flex h-full min-h-0 flex-1 items-start justify-center bg-theme-base px-4 pb-4 pt-[22vh]">
         <div className="rounded-lg border border-theme-border bg-theme-surface p-8 text-center">

--- a/packages/k8s-ui/src/components/resources/ResourcesSidebar.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesSidebar.tsx
@@ -34,7 +34,8 @@ export interface ResourcesSidebarProps {
   onSelectedKindChange: (kind: SelectedKindInfo) => void
   onKindChange?: () => void
   apiResources?: APIResource[]
-  resourceCounts?: Record<string, number>
+  resourceCounts?: Record<string, number | null>
+  resourceUnavailable?: string[]
   resourceForbidden?: string[]
   pinned?: PinnedItem[]
   togglePin?: (item: PinnedItem) => void
@@ -176,6 +177,7 @@ export function ResourcesSidebar({
   onKindChange,
   apiResources,
   resourceCounts,
+  resourceUnavailable,
   resourceForbidden,
   pinned = [],
   togglePin = () => {},
@@ -257,11 +259,11 @@ export function ResourcesSidebar({
     }))
   }, [categories])
 
-  // null for a key means "not loaded yet" (rendered as a placeholder
-  // dash in the badge). 0 means "the API replied and confirmed there
-  // are zero of this kind". Don't conflate them — otherwise the
-  // sidebar shows a confident "0" for every kind while the count
-  // payload is still in flight.
+  const unavailableKinds = useMemo(() => new Set(resourceUnavailable ?? []), [resourceUnavailable])
+
+  // null for a key means "count unknown/unavailable" (rendered as a
+  // placeholder dash in the badge). 0 means "the API replied and
+  // confirmed there are zero of this kind".
   const counts = useMemo(() => {
     const results: Record<string, number | null> = {}
     if (!resourceCounts) {
@@ -273,15 +275,16 @@ export function ResourcesSidebar({
     }
     for (const resource of resourcesToCount) {
       const key = resource.group ? `${resource.group}/${resource.kind}` : resource.kind
-      const v = resourceCounts[key]
-      // Treat missing keys in a present resourceCounts payload as
-      // "the API replied and didn't include this kind" → 0. Treat the
-      // entire payload being absent as "not loaded" → null (handled
-      // above).
-      results[key] = v ?? 0
+      if (unavailableKinds.has(key)) {
+        results[key] = null
+      } else if (key in resourceCounts) {
+        results[key] = resourceCounts[key] ?? null
+      } else {
+        results[key] = 0
+      }
     }
     return results
-  }, [resourcesToCount, resourceCounts])
+  }, [resourcesToCount, resourceCounts, unavailableKinds])
 
   // Track which resource kinds returned 403 Forbidden
   const forbiddenKinds = useMemo(() => {

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1816,6 +1816,7 @@ export interface ResourceQueryResult {
 export interface LargeListGuardState {
   kind: string
   count?: number
+  reason?: 'too-many' | 'count-unavailable'
   limit: number
   namespaces: string[]
 }
@@ -1839,6 +1840,7 @@ interface ResourcesViewProps {
   // Lightweight counts for sidebar badges (from /api/resource-counts)
   resourceCounts?: Record<string, number>
   resourceForbidden?: string[]
+  resourceUnavailable?: string[]
   // Single query for the currently selected kind's full data
   selectedKindQuery?: ResourceQueryResult
   largeListGuard?: LargeListGuardState | null
@@ -2056,6 +2058,7 @@ export function ResourcesView({
   resourceQueries: resourceQueriesProp,
   resourceCounts: resourceCountsProp,
   resourceForbidden: resourceForbiddenProp,
+  resourceUnavailable: resourceUnavailableProp,
   selectedKindQuery: selectedKindQueryProp,
   largeListGuard,
   topPodMetrics,
@@ -3252,22 +3255,29 @@ export function ResourcesView({
   const counts = useMemo(() => {
     if (useNewCountsMode) {
       // resourceCountsProp uses "group/Kind" keys for CRDs, "Kind" for core — same format as sidebar
-      const results: Record<string, number> = {}
+      const unavailableKinds = new Set(resourceUnavailableProp ?? [])
+      const results: Record<string, number | null> = {}
       for (const resource of resourcesToCount) {
         const key = resource.group ? `${resource.group}/${resource.kind}` : resource.kind
-        results[key] = resourceCountsProp![key] ?? 0
+        if (unavailableKinds.has(key)) {
+          results[key] = null
+        } else if (key in resourceCountsProp!) {
+          results[key] = resourceCountsProp![key]
+        } else {
+          results[key] = 0
+        }
       }
       return results
     }
     // Legacy: derive counts from full query data
-    const results: Record<string, number> = {}
+    const results: Record<string, number | null> = {}
     resourcesToCount.forEach((resource, index) => {
       const data = resourceQueries[index]?.data
       const key = resource.group ? `${resource.group}/${resource.kind}` : resource.kind
       results[key] = Array.isArray(data) ? data.length : 0
     })
     return results
-  }, [useNewCountsMode, resourcesToCount, resourceCountsProp, resourceQueries])
+  }, [useNewCountsMode, resourcesToCount, resourceCountsProp, resourceUnavailableProp, resourceQueries])
 
   // Track which resource kinds returned 403 Forbidden
   const forbiddenKinds = useMemo(() => {
@@ -4002,6 +4012,7 @@ export function ResourcesView({
           apiResources={apiResourcesProp}
           resourceCounts={counts}
           resourceForbidden={Array.from(forbiddenKinds)}
+          resourceUnavailable={resourceUnavailableProp}
           pinned={pinned}
           togglePin={togglePin}
           isPinned={isPinned}
@@ -4503,11 +4514,14 @@ export function ResourcesView({
             <div className="absolute inset-0 flex flex-col items-center justify-center text-theme-text-tertiary px-6 text-center">
               <AlertTriangle className="w-8 h-8 text-amber-400 mb-2" />
               <p className="text-theme-text-secondary font-medium">
-                Too many {largeListGuard.kind.toLowerCase()} to show
+                {largeListGuard.reason === 'count-unavailable'
+                  ? `${largeListGuard.kind} count unavailable`
+                  : `Too many ${largeListGuard.kind.toLowerCase()} to show`}
               </p>
               <p className="text-sm mt-1 max-w-xl">
-                {largeListGuard.count?.toLocaleString()} {largeListGuard.kind.toLowerCase()} are in the current scope.
-                Choose a namespace or smaller namespace set to load this view.
+                {largeListGuard.reason === 'count-unavailable'
+                  ? 'Radar could not verify this list is small enough to load. Choose a namespace or smaller namespace set to try again.'
+                  : `${largeListGuard.count?.toLocaleString()} ${largeListGuard.kind.toLowerCase()} are in the current scope. Choose a namespace or smaller namespace set to load this view.`}
               </p>
               <p className="text-xs mt-2 text-theme-text-disabled">
                 Radar limits full table loads to {largeListGuard.limit.toLocaleString()} resources to keep the UI responsive.

--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -20,6 +20,9 @@ import (
 )
 
 var ErrResourceNotFound = errors.New("resource not found")
+var ErrResourceCountUnavailable = errors.New("resource count unavailable")
+
+const directCountProbeLimit int64 = 2
 
 // informerKey identifies one informer. ns == "" means a cluster-wide watch;
 // a non-empty ns is a namespace-scoped watch. A GVR can have one cluster-wide
@@ -761,6 +764,83 @@ func (d *DynamicResourceCache) Count(gvr schema.GroupVersionResource, namespaces
 	return total, nil
 }
 
+// CountWatched returns cached object counts for every currently watched and
+// synced GVR. It never starts informers and never probes the apiserver.
+func (d *DynamicResourceCache) CountWatched(namespaces []string) map[schema.GroupVersionResource]int {
+	if d == nil {
+		return nil
+	}
+
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	type watchedSet struct {
+		clusterWide *informerEntry
+		byNamespace map[string]*informerEntry
+	}
+	byGVR := make(map[schema.GroupVersionResource]*watchedSet)
+	for k, e := range d.informers {
+		if !e.informer.HasSynced() {
+			continue
+		}
+		set := byGVR[k.gvr]
+		if set == nil {
+			set = &watchedSet{byNamespace: make(map[string]*informerEntry)}
+			byGVR[k.gvr] = set
+		}
+		if k.ns == "" {
+			set.clusterWide = e
+		} else {
+			set.byNamespace[k.ns] = e
+		}
+	}
+
+	counts := make(map[schema.GroupVersionResource]int)
+	for gvr, set := range byGVR {
+		if len(namespaces) == 0 {
+			if set.clusterWide != nil {
+				counts[gvr] = len(set.clusterWide.informer.GetIndexer().List())
+				continue
+			}
+			if d.config.NamespaceFallback == "" {
+				continue
+			}
+			total := 0
+			for _, e := range set.byNamespace {
+				total += len(e.informer.GetIndexer().List())
+			}
+			counts[gvr] = total
+			continue
+		}
+		if set.clusterWide != nil {
+			n, err := countByNamespaces(set.clusterWide, namespaces)
+			if err == nil {
+				counts[gvr] = n
+			}
+			continue
+		}
+		total := 0
+		complete := true
+		for _, ns := range namespaces {
+			e, ok := set.byNamespace[ns]
+			if !ok {
+				complete = false
+				break
+			}
+			n, err := countByNamespaces(e, []string{ns})
+			if err != nil {
+				complete = false
+				break
+			}
+			total += n
+		}
+		if complete {
+			counts[gvr] = total
+		}
+	}
+	return counts
+}
+
 func countByNamespaces(e *informerEntry, namespaces []string) (int, error) {
 	total := 0
 	for _, ns := range namespaces {
@@ -771,6 +851,97 @@ func countByNamespaces(e *informerEntry, namespaces []string) (int, error) {
 		total += len(items)
 	}
 	return total, nil
+}
+
+func (d *DynamicResourceCache) CountDirectProbe(ctx context.Context, gvr schema.GroupVersionResource, namespaces []string, maxNamespaces, concurrency int) (int, error) {
+	if d == nil {
+		return 0, fmt.Errorf("dynamic resource cache not initialized")
+	}
+	if d.config.DynamicClient == nil {
+		return 0, fmt.Errorf("dynamic client not initialized")
+	}
+	if len(namespaces) == 0 {
+		return d.countDirectProbeOne(ctx, gvr, "")
+	}
+	if maxNamespaces > 0 && len(namespaces) > maxNamespaces {
+		return 0, ErrResourceCountUnavailable
+	}
+	if concurrency < 1 {
+		concurrency = 1
+	}
+	if concurrency > len(namespaces) {
+		concurrency = len(namespaces)
+	}
+
+	type result struct {
+		count int
+		err   error
+	}
+	jobs := make(chan string)
+	results := make(chan result, len(namespaces))
+	var wg sync.WaitGroup
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for ns := range jobs {
+				n, err := d.countDirectProbeOne(ctx, gvr, ns)
+				results <- result{count: n, err: err}
+			}
+		}()
+	}
+
+	go func() {
+		defer close(jobs)
+		for _, ns := range namespaces {
+			select {
+			case <-ctx.Done():
+				return
+			case jobs <- ns:
+			}
+		}
+	}()
+	wg.Wait()
+	close(results)
+
+	total := 0
+	for r := range results {
+		if r.err != nil {
+			return 0, r.err
+		}
+		total += r.count
+	}
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	return total, nil
+}
+
+func (d *DynamicResourceCache) countDirectProbeOne(ctx context.Context, gvr schema.GroupVersionResource, namespace string) (int, error) {
+	var list *unstructured.UnstructuredList
+	var err error
+	opts := metav1.ListOptions{Limit: directCountProbeLimit}
+	if namespace != "" {
+		list, err = d.config.DynamicClient.Resource(gvr).Namespace(namespace).List(ctx, opts)
+	} else {
+		list, err = d.config.DynamicClient.Resource(gvr).List(ctx, opts)
+	}
+	if err != nil {
+		if isAuthProbeError(err) {
+			return 0, ErrResourceCountUnavailable
+		}
+		return 0, fmt.Errorf("failed to probe resource count: %w", err)
+	}
+	if list == nil {
+		return 0, ErrResourceCountUnavailable
+	}
+	if remaining := list.GetRemainingItemCount(); remaining != nil {
+		return len(list.Items) + int(*remaining), nil
+	}
+	if list.GetContinue() == "" {
+		return len(list.Items), nil
+	}
+	return 0, ErrResourceCountUnavailable
 }
 
 // List returns all resources of a given GVR, optionally filtered by namespace.

--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -407,8 +407,12 @@ func (d *DynamicResourceCache) ProbeCount(gvr schema.GroupVersionResource) int {
 	}
 
 	count := len(list.Items)
-	if list.GetRemainingItemCount() != nil {
-		count += int(*list.GetRemainingItemCount())
+	if remaining := list.GetRemainingItemCount(); remaining != nil {
+		count += int(*remaining)
+		return count
+	}
+	if list.GetContinue() != "" {
+		return -2
 	}
 	return count
 }

--- a/pkg/k8score/dynamic_cache.go
+++ b/pkg/k8score/dynamic_cache.go
@@ -706,9 +706,9 @@ func entriesSynced(entries []*informerEntry) bool {
 // Count reads only what is already watched and synced; it does not start informers.
 //
 // A cluster-wide informer serves any namespace filter. Without one, Count can
-// only answer for explicitly-named namespaces (each must have its own synced
-// informer); counting "all" (nil namespaces) is unsupported in that mode and
-// returns a not-synced error rather than an incidental per-namespace union.
+// answer for explicitly-named namespaces when each has its own synced informer.
+// In namespace-fallback mode, Count(nil) unions the namespace-scoped informers
+// so it agrees with all-namespace reads.
 func (d *DynamicResourceCache) Count(gvr schema.GroupVersionResource, namespaces []string) (int, error) {
 	if d == nil {
 		return 0, fmt.Errorf("dynamic resource cache not initialized")
@@ -718,7 +718,7 @@ func (d *DynamicResourceCache) Count(gvr schema.GroupVersionResource, namespaces
 	defer d.mu.RUnlock()
 
 	if e, ok := d.informers[informerKey{gvr: gvr}]; ok {
-		if !e.synced {
+		if !e.informer.HasSynced() {
 			return 0, fmt.Errorf("informer not found or not synced for %v", gvr)
 		}
 		if len(namespaces) == 0 {
@@ -741,7 +741,7 @@ func (d *DynamicResourceCache) Count(gvr schema.GroupVersionResource, namespaces
 			if k.gvr != gvr {
 				continue
 			}
-			if !e.synced {
+			if !e.informer.HasSynced() {
 				return 0, fmt.Errorf("informer not found or not synced for %v", gvr)
 			}
 			found = true
@@ -756,7 +756,7 @@ func (d *DynamicResourceCache) Count(gvr schema.GroupVersionResource, namespaces
 	total := 0
 	for _, ns := range namespaces {
 		e, ok := d.informers[informerKey{gvr: gvr, ns: ns}]
-		if !ok || !e.synced {
+		if !ok || !e.informer.HasSynced() {
 			return 0, fmt.Errorf("informer not found or not synced for %v in namespace %s", gvr, ns)
 		}
 		n, err := countByNamespaces(e, []string{ns})

--- a/pkg/k8score/dynamic_cache_count_test.go
+++ b/pkg/k8score/dynamic_cache_count_test.go
@@ -96,6 +96,56 @@ func TestDynamicResourceCache_CountDirectProbeUnavailableWithoutRemainingCount(t
 	}
 }
 
+func TestDynamicResourceCache_ProbeCountUsesRemainingCount(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "WidgetList"},
+	)
+	dyn.PrependReactor("list", "widgets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		remaining := int64(41)
+		list := &unstructured.UnstructuredList{
+			Items: []unstructured.Unstructured{{}},
+		}
+		list.SetRemainingItemCount(&remaining)
+		list.SetContinue("next")
+		return true, list, nil
+	})
+
+	d, err := NewDynamicResourceCache(DynamicCacheConfig{DynamicClient: dyn})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+
+	if got := d.ProbeCount(gvr); got != 42 {
+		t.Fatalf("ProbeCount = %d, want 42", got)
+	}
+}
+
+func TestDynamicResourceCache_ProbeCountDefersWithoutRemainingCount(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "WidgetList"},
+	)
+	dyn.PrependReactor("list", "widgets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		list := &unstructured.UnstructuredList{
+			Items: []unstructured.Unstructured{{}},
+		}
+		list.SetContinue("next")
+		return true, list, nil
+	})
+
+	d, err := NewDynamicResourceCache(DynamicCacheConfig{DynamicClient: dyn})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+
+	if got := d.ProbeCount(gvr); got != -2 {
+		t.Fatalf("ProbeCount = %d, want -2", got)
+	}
+}
+
 func TestDynamicResourceCache_CountDirectProbeSumsNamespacesAndCapsFanout(t *testing.T) {
 	gvr := schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"}
 	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(

--- a/pkg/k8score/dynamic_cache_count_test.go
+++ b/pkg/k8score/dynamic_cache_count_test.go
@@ -1,0 +1,194 @@
+package k8score
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestDynamicResourceCache_CountDirectProbeUsesRemainingCount(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "EndpointSliceList"},
+	)
+	dyn.PrependReactor("list", "endpointslices", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		remaining := int64(7)
+		list := &unstructured.UnstructuredList{
+			Items: []unstructured.Unstructured{{}, {}},
+		}
+		list.SetRemainingItemCount(&remaining)
+		return true, list, nil
+	})
+
+	d, err := NewDynamicResourceCache(DynamicCacheConfig{DynamicClient: dyn})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+
+	got, err := d.CountDirectProbe(context.Background(), gvr, nil, 50, 8)
+	if err != nil {
+		t.Fatalf("CountDirectProbe failed: %v", err)
+	}
+	if got != 9 {
+		t.Fatalf("CountDirectProbe = %d, want 9", got)
+	}
+}
+
+func TestDynamicResourceCache_CountDirectProbeExactWhenServerReturnsCompleteList(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "EndpointSliceList"},
+	)
+	dyn.PrependReactor("list", "endpointslices", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		list := &unstructured.UnstructuredList{
+			Items: []unstructured.Unstructured{{}},
+		}
+		return true, list, nil
+	})
+
+	d, err := NewDynamicResourceCache(DynamicCacheConfig{DynamicClient: dyn})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+
+	got, err := d.CountDirectProbe(context.Background(), gvr, nil, 50, 8)
+	if err != nil {
+		t.Fatalf("CountDirectProbe failed: %v", err)
+	}
+	if got != 1 {
+		t.Fatalf("CountDirectProbe = %d, want 1", got)
+	}
+}
+
+func TestDynamicResourceCache_CountDirectProbeUnavailableWithoutRemainingCount(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "EndpointSliceList"},
+	)
+	dyn.PrependReactor("list", "endpointslices", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		list := &unstructured.UnstructuredList{
+			Items: []unstructured.Unstructured{{}, {}},
+		}
+		list.SetContinue("next")
+		return true, list, nil
+	})
+
+	d, err := NewDynamicResourceCache(DynamicCacheConfig{DynamicClient: dyn})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+
+	_, err = d.CountDirectProbe(context.Background(), gvr, nil, 50, 8)
+	if !errors.Is(err, ErrResourceCountUnavailable) {
+		t.Fatalf("CountDirectProbe error = %v, want ErrResourceCountUnavailable", err)
+	}
+}
+
+func TestDynamicResourceCache_CountDirectProbeSumsNamespacesAndCapsFanout(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "EndpointSliceList"},
+	)
+	remainingByNamespace := map[string]int64{
+		"team-a": 3,
+		"team-b": 1,
+	}
+	var seenMu sync.Mutex
+	seen := map[string]bool{}
+	dyn.PrependReactor("list", "endpointslices", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		listAction := action.(k8stesting.ListAction)
+		ns := listAction.GetNamespace()
+		seenMu.Lock()
+		seen[ns] = true
+		seenMu.Unlock()
+		remaining := remainingByNamespace[ns]
+		list := &unstructured.UnstructuredList{
+			Items: []unstructured.Unstructured{{}, {}},
+		}
+		list.SetRemainingItemCount(&remaining)
+		return true, list, nil
+	})
+
+	d, err := NewDynamicResourceCache(DynamicCacheConfig{DynamicClient: dyn})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+
+	got, err := d.CountDirectProbe(context.Background(), gvr, []string{"team-a", "team-b"}, 2, 2)
+	if err != nil {
+		t.Fatalf("CountDirectProbe failed: %v", err)
+	}
+	if got != 8 {
+		t.Fatalf("CountDirectProbe = %d, want 8", got)
+	}
+	for _, ns := range []string{"team-a", "team-b"} {
+		if !seen[ns] {
+			t.Fatalf("namespace %q was not probed", ns)
+		}
+	}
+
+	_, err = d.CountDirectProbe(context.Background(), gvr, []string{"team-a", "team-b"}, 1, 2)
+	if !errors.Is(err, ErrResourceCountUnavailable) {
+		t.Fatalf("over-cap CountDirectProbe error = %v, want ErrResourceCountUnavailable", err)
+	}
+}
+
+func TestDynamicResourceCache_CountWatchedRespectsInformerScope(t *testing.T) {
+	const nsA, nsB = "team-a", "team-b"
+	gvr := schema.GroupVersionResource{Group: "example.com", Version: "v1", Resource: "widgets"}
+	dyn := fakeDynamicForListAccess(t, map[schema.GroupVersionResource]string{
+		gvr: "WidgetList",
+	}, func(_ schema.GroupVersionResource, namespace string) bool {
+		return namespace == nsA || namespace == nsB
+	})
+	for _, ns := range []string{nsA, nsB} {
+		obj := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "example.com/v1",
+			"kind":       "Widget",
+			"metadata":   map[string]any{"name": "w-" + ns, "namespace": ns},
+		}}
+		if _, err := dyn.Resource(gvr).Namespace(ns).Create(context.Background(), obj, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("seed %s: %v", ns, err)
+		}
+	}
+
+	d, err := NewDynamicResourceCache(DynamicCacheConfig{DynamicClient: dyn})
+	if err != nil {
+		t.Fatalf("NewDynamicResourceCache failed: %v", err)
+	}
+	for _, ns := range []string{nsA, nsB} {
+		if _, err := d.ListBlocking(gvr, ns, 2*time.Second); err != nil {
+			t.Fatalf("ListBlocking(%q) failed: %v", ns, err)
+		}
+	}
+
+	all := d.CountWatched(nil)
+	if _, ok := all[gvr]; ok {
+		t.Fatalf("CountWatched(nil)[gvr] returned a partial namespace-scoped count: %v", all[gvr])
+	}
+	filtered := d.CountWatched([]string{nsA})
+	if got := filtered[gvr]; got != 1 {
+		t.Fatalf("CountWatched([%s])[gvr] = %d, want 1", nsA, got)
+	}
+	multiNamespace := d.CountWatched([]string{nsA, nsB})
+	if got := multiNamespace[gvr]; got != 2 {
+		t.Fatalf("CountWatched([%s,%s])[gvr] = %d, want 2", nsA, nsB, got)
+	}
+	partial := d.CountWatched([]string{nsA, "team-c"})
+	if _, ok := partial[gvr]; ok {
+		t.Fatalf("CountWatched returned partial count for missing namespace informer: %v", partial[gvr])
+	}
+}

--- a/web/src/components/gitops/GitOpsView.tsx
+++ b/web/src/components/gitops/GitOpsView.tsx
@@ -83,6 +83,7 @@ const KIND_BY_NAME = new Map(GITOPS_KINDS.map((k) => [k.name, k]))
 interface ResourceCountsResponse {
   counts: Record<string, number>
   forbidden?: string[]
+  unavailable?: string[]
 }
 
 interface GitOpsViewProps {
@@ -136,9 +137,9 @@ function GitOpsTableView({ namespaces, onClearNamespaces }: { namespaces: string
     initNavigationMap([...(apiResources ?? []), ...GITOPS_KINDS])
   }, [apiResources])
 
-  // Counts come from radar's /api/resource-counts, kind-filtered to the
-  // GitOps set. The extracted GitOpsTableView reads them for the
-  // Scope-section mode tabs + the empty-state check.
+  // Counts come from radar's /api/resource-counts. The extracted
+  // GitOpsTableView reads only the GitOps keys for mode tabs + empty-state
+  // checks.
   const countsQuery = useQuery({
     queryKey: ['gitops-resource-counts', namespacesParam],
     queryFn: async () => {
@@ -271,6 +272,7 @@ function GitOpsTableView({ namespaces, onClearNamespaces }: { namespaces: string
         loading={apiResourcesLoading || countsQuery.isLoading || rowsQuery.isLoading || coldRetrying}
         error={(rowsQuery.error as Error | null) ?? null}
         counts={countsQuery.data?.counts ?? {}}
+        countsUnavailable={countsQuery.data?.unavailable}
         onRefresh={() => rowsQuery.refetch()}
         onRowClick={(row) => {
           const ns = row.namespace || '_'
@@ -958,5 +960,3 @@ function TopologyCounts({ tree }: { tree: GitOpsResourceTree }) {
     </div>
   )
 }
-
-

--- a/web/src/components/gitops/GitOpsView.tsx
+++ b/web/src/components/gitops/GitOpsView.tsx
@@ -137,6 +137,12 @@ function GitOpsTableView({ namespaces, onClearNamespaces }: { namespaces: string
     initNavigationMap([...(apiResources ?? []), ...GITOPS_KINDS])
   }, [apiResources])
 
+  const hasGitOpsRowResource = useMemo(() => (
+    hasAPIResource(apiResources, 'applications', 'argoproj.io') ||
+    hasAPIResource(apiResources, 'kustomizations', 'kustomize.toolkit.fluxcd.io') ||
+    hasAPIResource(apiResources, 'helmreleases', 'helm.toolkit.fluxcd.io')
+  ), [apiResources])
+
   // Counts come from radar's /api/resource-counts. The extracted
   // GitOpsTableView reads only the GitOps keys for mode tabs + empty-state
   // checks.
@@ -218,6 +224,7 @@ function GitOpsTableView({ namespaces, onClearNamespaces }: { namespaces: string
   const [coldRetrying, setColdRetrying] = useState(false)
   useEffect(() => { coldRetriesRef.current = 0; setColdRetrying(false) }, [apiResources, namespacesParam])
   useEffect(() => {
+    if (!hasGitOpsRowResource || rowsQuery.error) { setColdRetrying(false); return }
     if (apiResourcesLoading || rowsQuery.isFetching) return
     if ((rowsQuery.data?.length ?? 0) > 0) { setColdRetrying(false); return }
     if (coldRetriesRef.current >= 4) { setColdRetrying(false); return }
@@ -225,7 +232,7 @@ function GitOpsTableView({ namespaces, onClearNamespaces }: { namespaces: string
     const t = window.setTimeout(() => { coldRetriesRef.current += 1; refetchTable() }, 2000)
     return () => window.clearTimeout(t)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rowsQuery.data, rowsQuery.isFetching, apiResourcesLoading])
+  }, [rowsQuery.data, rowsQuery.isFetching, rowsQuery.error, apiResourcesLoading, hasGitOpsRowResource])
 
   const handleRowAction = (row: GitOpsRow, action: GitOpsRowAction) => {
     const { kindName: kind, namespace, name, id } = row

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -23,6 +23,7 @@ import { getSkeletonYaml } from '../../utils/skeleton-yaml'
 interface ResourceCountsResponse {
   counts: Record<string, number>
   forbidden?: string[]
+  unavailable?: string[]
 }
 
 interface ResourcesViewProps {
@@ -137,19 +138,22 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
 
   const selectedCountKey = selectedKind ? resourceCountKey(selectedKind) : ''
   const selectedCount = selectedCountKey ? countsData?.counts[selectedCountKey] : undefined
+  const selectedCountUnavailable = selectedCountKey ? countsData?.unavailable?.includes(selectedCountKey) ?? false : false
   const isSelectedKindGuarded = selectedCountKey !== '' && LARGE_RESOURCE_LIST_GUARD_KEYS.has(selectedCountKey)
   const waitingForGuardCount = isSelectedKindGuarded && !countsData && !countsIsError
-  const largeListBlocked = isSelectedKindGuarded && countsData != null && (selectedCount ?? 0) > LARGE_RESOURCE_LIST_LIMIT
+  const largeListBlocked = isSelectedKindGuarded && countsData != null && (selectedCountUnavailable || (selectedCount ?? 0) > LARGE_RESOURCE_LIST_LIMIT)
   const selectedKindQueryBlocked = waitingForGuardCount || largeListBlocked
   const podCount = countsData?.counts.Pod
-  const podCountAllowsBulkMetrics = countsData != null && (podCount ?? 0) <= LARGE_RESOURCE_LIST_LIMIT
+  const podCountUnavailable = countsData?.unavailable?.includes('Pod') ?? false
+  const podCountAllowsBulkMetrics = countsData != null && !podCountUnavailable && (podCount ?? 0) <= LARGE_RESOURCE_LIST_LIMIT
   const selectedKindName = selectedKind?.name.toLowerCase() ?? ''
   const topPodMetricsEnabled = selectedKindName === 'pods' && podCountAllowsBulkMetrics
   const topNodeMetricsEnabled = selectedKindName === 'nodes' && namespaces.length === 0 && podCountAllowsBulkMetrics
   const largeListGuard = selectedKind && largeListBlocked
     ? {
         kind: selectedKind.name,
-        count: selectedCount,
+        count: selectedCountUnavailable ? undefined : selectedCount,
+        reason: selectedCountUnavailable ? 'count-unavailable' as const : 'too-many' as const,
         limit: LARGE_RESOURCE_LIST_LIMIT,
         namespaces,
       }
@@ -280,6 +284,7 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
       // Lightweight counts for sidebar (replaces 233 parallel queries)
       resourceCounts={countsData?.counts}
       resourceForbidden={countsData?.forbidden}
+      resourceUnavailable={countsData?.unavailable}
       selectedKindQuery={selectedKindQueryResult}
       largeListGuard={largeListGuard}
       onSelectedKindChange={setSelectedKind}


### PR DESCRIPTION
## Summary

Large CRD-heavy clusters were paying too much for `/api/resource-counts`: the endpoint could fan out across discovered CRDs and fully list EndpointSlices just to produce sidebar badges and large-list guard decisions. This keeps the count path cheap on large clusters while preserving an honest consumer contract: exact typed counts stay exact, and counts that cannot be produced cheaply are reported as unavailable instead of being treated as zero.

## What changed

- Reworked `/api/resource-counts` so typed informers always return exact counts, including zeroes, without dropping absent kinds from the payload.
- Changed CRD counting to use only already watched and synced dynamic informers. Discovered-but-unwatched CRDs are now reported in `unavailable`, avoiding count-time informer startup or broad dynamic list fanout.
- Added bounded direct count probes for EndpointSlices using small paginated list requests. Very broad namespace-scoped probes fail as unavailable instead of fanning out indefinitely.
- Added dynamic-cache helpers and tests for watched counts, direct probe counts, namespace fanout caps, auth/list failures, and paginated probe behavior when `remainingItemCount` is absent.
- Updated Resource Viewer sidebar counts and the large-list guard to render unavailable counts as unknown rather than zero. Guarded high-cardinality kinds only fail closed when their cheap count is explicitly unavailable.
- Updated GitOps table count handling so empty-state logic considers only GitOps count keys, respects unavailable GitOps counts, and does not get stuck in the cold-cache retry spinner on clusters with no Argo/Flux row-producing CRDs.

## Testing

- `go test ./internal/server -run TestResourceCounts`
- `go test ./...` from `pkg/k8score`
- `npx tsc --noEmit` in `web/`
- `npx tsc --noEmit` in `packages/k8s-ui/`
- `make tsc`
- `make test`
- `make build`
- `go test ./...` in `skyhook-connector` with its pinned Radar dependency
- Temporary local-workspace connector check against current Radar `pkg`: k8score-consuming connector packages passed; full connector build is blocked by an existing `gitops.SyncArgoApp` signature mismatch unrelated to this resource-count change.

Visual/live checks:

- Built and ran the embedded app against `kind-radar-bench`.
- Verified `/api/resource-counts` returned concrete cheap counts for normal typed/dynamic built-in resources, including Pods and EndpointSlices.
- Verified `/resources/pods` and `/resources/endpointslices` rendered expected sidebar counts and rows without triggering the large-list guard on a normal-size cluster.
- Verified `/gitops` on a cluster with no Argo/Flux CRDs now reaches `No GitOps resources detected` instead of staying on `Loading GitOps applications...`.
- Browser console had no frontend errors or warnings in the final GitOps empty-state check.

## Notes

- CRDs that are discovered but not watched now surface as unavailable rather than zero. That is intentional: starting new informers from the count endpoint would reintroduce the large-cluster cost this change removes.
- EndpointSlice namespace-scoped counting is capped to bound fanout. Users with a very broad namespace scope may need to narrow the namespace set before loading the EndpointSlice table.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes counting semantics and API shape (`unavailable`); guarded list loads and sidebar badges now fail closed when counts cannot be verified cheaply, which may block or confuse users on very broad namespace scopes or unwatched CRDs.
> 
> **Overview**
> **`/api/resource-counts`** is reworked so large CRD-heavy clusters no longer fan out concurrent dynamic `Count()` calls or fully list EndpointSlices. Typed informer counts now **always include zero** in the payload. **CRD counts** come only from **already watched/synced** informers via `CountWatched`; discovered-but-unwatched kinds land in a new **`unavailable`** array instead of starting informers or implying zero. **EndpointSlices** use bounded **`CountDirectProbe`** (namespace cap + concurrency) instead of full lists.
> 
> **`pkg/k8score`** adds `CountWatched`, `CountDirectProbe`, `ErrResourceCountUnavailable`, and tighter probe behavior when pagination cannot yield an exact total.
> 
> **UI** (Resources sidebar, large-list guard, GitOps) treats **`unavailable`** as unknown (dash badges, fail-closed guard with dedicated copy), sums only GitOps-relevant count keys for empty state, and skips cold-cache retry when the cluster has no row-producing GitOps CRDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69f50200757dc9cc5b9a4671abac3cb5a72fb897. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->