### PR TITLE
fix(desktop): inject version into Windows build

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -178,6 +178,7 @@ jobs:
               token: dummy' > ~/.kube/config
 
       - name: Build Windows exe
+        shell: bash
         run: cd cmd/desktop && wails build -platform windows/amd64 -ldflags "-X main.version=${GITHUB_REF_NAME#v}"
 
       - name: Create archive


### PR DESCRIPTION
## Problem

On Windows, the desktop app's **Help → About Radar** shows a blank version, and **Help → Check for Updates…** silently does nothing (reported in #966 for `v1.7.9`, installed via Scoop).

## Root cause

In `.github/workflows/release-desktop.yml`, the `Build Windows exe` step had no `shell:`, so it ran in **PowerShell** (the `windows-latest` default) while using **bash** parameter-expansion syntax:

```
-ldflags "-X main.version=${GITHUB_REF_NAME#v}"
```

PowerShell parses `${GITHUB_REF_NAME#v}` as a reference to a variable literally named `GITHUB_REF_NAME#v` (nonexistent → empty), so the Windows binary compiled in `-X main.version=` (**empty string**). Every other step in this job that relies on bash expansion already sets `shell: bash`; only the build step was missed — which is why macOS/Linux builds carry the version and Windows doesn't.

An empty version independently breaks both menu items:
- **About** — `menu.go` builds `"Version: " + version` → `"Version: "`.
- **Check for Updates** — `version.Current` is `""`; `isNewerVersion(latest, "")` fails the semver parse, so `updateAvailable` stays `false` and the notification component renders nothing.

## Fix

Add `shell: bash` to the `Build Windows exe` step so the expansion resolves.

## Testing (no Windows machine required)

Verified all three links of the chain locally:

1. **Shell expansion** in a real PowerShell (Docker `mcr.microsoft.com/powershell`):
   - `bash` → `-X main.version=1.7.9` ✅
   - `pwsh` → `-X main.version=` ❌ (reproduces the bug)
2. **About dialog** — built the real `cmd/desktop` binary both ways, ran `--version` (same `version` var the menu uses):
   - before → `Version: ` (matches the screenshot)
   - after → `Version: 1.7.9`
3. **Update check** — real `internal/version` comparison:
   - `isNewerVersion("1.7.10", "1.7.9")` → `true, nil` ✅
   - `isNewerVersion("1.7.10", "")` → `false, invalid semantic version` ❌

## Note for release

The broken `v1.7.9` Scoop binary can't be repaired in place — the fix takes effect on the next tagged release, after which Windows users run `scoop update radar-desktop`.

Fixes #966

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI workflow line change; no application runtime logic, only correct shell for existing ldflags.
> 
> **Overview**
> Fixes **blank version on Windows** desktop releases (About dialog and update checks) by running the **Build Windows exe** step under **bash** instead of the default PowerShell on `windows-latest`.
> 
> PowerShell does not expand `${GITHUB_REF_NAME#v}`, so `-ldflags "-X main.version=..."` was embedding an **empty** `main.version` while macOS/Linux builds already used bash-style expansion elsewhere in the job. Aligning this step with the other bash steps restores the tagged version in the Windows `Radar.exe`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28de6414b1c9b36e0d07c86d2befd4f07aa787ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->