### PR TITLE
ci: dev-image workflow — publish :dev on green main builds

### DIFF
--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -45,26 +45,9 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
-      - name: Compute tags
-        id: tags
-        # Always publish the immutable :dev-<sha>. Only move the mutable :dev
-        # when this commit is still main's tip, so a slow CI run for an older
-        # commit finishing after a newer one can't roll :dev backwards.
-        run: |
-          SHA="$(git rev-parse --short HEAD)"
-          TAGS="${DOCKER_REPO}:dev-${SHA}"
-          git fetch --quiet origin main
-          if [ "$(git rev-parse HEAD)" = "$(git rev-parse FETCH_HEAD)" ]; then
-            TAGS="${TAGS}"$'\n'"${DOCKER_REPO}:dev"
-          else
-            echo "::notice::superseded by a newer commit on main - publishing :dev-${SHA} only, not moving :dev"
-          fi
-          {
-            echo "sha=${SHA}"
-            echo "tags<<EOF"
-            echo "${TAGS}"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+      - name: Compute sha
+        id: sha
+        run: echo "value=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-buildx-action@v4
 
@@ -82,7 +65,19 @@ jobs:
           platforms: linux/amd64
           push: true
           build-args: |
-            VERSION=dev-${{ steps.tags.outputs.sha }}
-          tags: ${{ steps.tags.outputs.tags }}
+            VERSION=dev-${{ steps.sha.outputs.value }}
+          tags: ${{ env.DOCKER_REPO }}:dev-${{ steps.sha.outputs.value }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Move :dev if this commit is still main's tip
+        # Re-checked AFTER the build (not before): a newer commit landing during
+        # the build must not be overwritten by this older run. Registry-side
+        # retag of the just-pushed immutable tag, so no rebuild.
+        run: |
+          git fetch --quiet origin main
+          if [ "$(git rev-parse HEAD)" = "$(git rev-parse FETCH_HEAD)" ]; then
+            docker buildx imagetools create -t "${DOCKER_REPO}:dev" "${DOCKER_REPO}:dev-${{ steps.sha.outputs.value }}"
+          else
+            echo "::notice::superseded by a newer commit on main - leaving :dev unchanged"
+          fi

--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -1,4 +1,4 @@
-# Edge Image
+# Dev Image
 #
 # Publishes a single-arch dev image on every GREEN main build so a downstream
 # staging deployment can track main ahead of releases. Deliberately separate
@@ -7,9 +7,9 @@
 # `full` target) rather than promoting GoReleaser binaries.
 #
 # Tags pushed:
-#   :edge            mutable, always the newest green main build (what staging tracks)
-#   :edge-<shortsha> immutable, per-commit handle for rollback / future promotion
-name: Edge Image
+#   :dev            mutable, always the newest green main build (what staging tracks)
+#   :dev-<shortsha> immutable, per-commit handle for rollback / future promotion
+name: Dev Image
 
 on:
   workflow_run:
@@ -24,13 +24,13 @@ permissions:
 env:
   DOCKER_REPO: ghcr.io/skyhook-io/radar
 
-# Serialize edge builds so two runs can't race on the mutable :edge tag.
+# Serialize dev builds so two runs can't race on the mutable :dev tag.
 concurrency:
-  group: edge-image
+  group: dev-image
   cancel-in-progress: false
 
 jobs:
-  edge:
+  dev:
     # Only publish for a green CI run that came from a push to this repo's own
     # main branch. The repo/branch/event guards stop a fork PR (whose CI run
     # could carry a head branch named "main") from triggering a privileged build.
@@ -47,17 +47,17 @@ jobs:
 
       - name: Compute tags
         id: tags
-        # Always publish the immutable :edge-<sha>. Only move the mutable :edge
+        # Always publish the immutable :dev-<sha>. Only move the mutable :dev
         # when this commit is still main's tip, so a slow CI run for an older
-        # commit finishing after a newer one can't roll :edge backwards.
+        # commit finishing after a newer one can't roll :dev backwards.
         run: |
           SHA="$(git rev-parse --short HEAD)"
-          TAGS="${DOCKER_REPO}:edge-${SHA}"
+          TAGS="${DOCKER_REPO}:dev-${SHA}"
           git fetch --quiet origin main
           if [ "$(git rev-parse HEAD)" = "$(git rev-parse FETCH_HEAD)" ]; then
-            TAGS="${TAGS}"$'\n'"${DOCKER_REPO}:edge"
+            TAGS="${TAGS}"$'\n'"${DOCKER_REPO}:dev"
           else
-            echo "::notice::superseded by a newer commit on main - publishing :edge-${SHA} only, not moving :edge"
+            echo "::notice::superseded by a newer commit on main - publishing :dev-${SHA} only, not moving :dev"
           fi
           {
             echo "sha=${SHA}"
@@ -74,7 +74,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push edge image
+      - name: Build and push dev image
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -82,7 +82,7 @@ jobs:
           platforms: linux/amd64
           push: true
           build-args: |
-            VERSION=edge-${{ steps.tags.outputs.sha }}
+            VERSION=dev-${{ steps.tags.outputs.sha }}
           tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/edge-image.yml
+++ b/.github/workflows/edge-image.yml
@@ -1,0 +1,68 @@
+# Edge Image
+#
+# Publishes a single-arch dev image on every GREEN main build so a downstream
+# staging deployment can track main ahead of releases. Deliberately separate
+# from release.yml: it never touches `:latest`, the published Helm chart, or the
+# Homebrew/Scoop/Krew channels, and builds amd64-only from source (Dockerfile
+# `full` target) rather than promoting GoReleaser binaries.
+#
+# Tags pushed:
+#   :edge            mutable, always the newest green main build (what staging tracks)
+#   :edge-<shortsha> immutable, per-commit handle for rollback / future promotion
+name: Edge Image
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  DOCKER_REPO: ghcr.io/skyhook-io/radar
+
+jobs:
+  edge:
+    # Only publish for a green CI run that came from a push to this repo's own
+    # main branch. The repo/branch/event guards stop a fork PR (whose CI run
+    # could carry a head branch named "main") from triggering a privileged build.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Compute short sha
+        id: sha
+        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push edge image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          target: full
+          platforms: linux/amd64
+          push: true
+          build-args: |
+            VERSION=edge-${{ steps.sha.outputs.sha }}
+          tags: |
+            ${{ env.DOCKER_REPO }}:edge
+            ${{ env.DOCKER_REPO }}:edge-${{ steps.sha.outputs.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/edge-image.yml
+++ b/.github/workflows/edge-image.yml
@@ -24,6 +24,11 @@ permissions:
 env:
   DOCKER_REPO: ghcr.io/skyhook-io/radar
 
+# Serialize edge builds so two runs can't race on the mutable :edge tag.
+concurrency:
+  group: edge-image
+  cancel-in-progress: false
+
 jobs:
   edge:
     # Only publish for a green CI run that came from a push to this repo's own
@@ -40,9 +45,26 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
-      - name: Compute short sha
-        id: sha
-        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Compute tags
+        id: tags
+        # Always publish the immutable :edge-<sha>. Only move the mutable :edge
+        # when this commit is still main's tip, so a slow CI run for an older
+        # commit finishing after a newer one can't roll :edge backwards.
+        run: |
+          SHA="$(git rev-parse --short HEAD)"
+          TAGS="${DOCKER_REPO}:edge-${SHA}"
+          git fetch --quiet origin main
+          if [ "$(git rev-parse HEAD)" = "$(git rev-parse FETCH_HEAD)" ]; then
+            TAGS="${TAGS}"$'\n'"${DOCKER_REPO}:edge"
+          else
+            echo "::notice::superseded by a newer commit on main - publishing :edge-${SHA} only, not moving :edge"
+          fi
+          {
+            echo "sha=${SHA}"
+            echo "tags<<EOF"
+            echo "${TAGS}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-buildx-action@v4
 
@@ -60,9 +82,7 @@ jobs:
           platforms: linux/amd64
           push: true
           build-args: |
-            VERSION=edge-${{ steps.sha.outputs.sha }}
-          tags: |
-            ${{ env.DOCKER_REPO }}:edge
-            ${{ env.DOCKER_REPO }}:edge-${{ steps.sha.outputs.sha }}
+            VERSION=edge-${{ steps.tags.outputs.sha }}
+          tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Adds `.github/workflows/dev-image.yml`: on every **green CI run for main**, build a single-arch amd64 image from source (Dockerfile `full` target) and push:

- `ghcr.io/skyhook-io/radar:dev` — mutable, newest green main build
- `ghcr.io/skyhook-io/radar:dev-<sha>` — immutable per-commit handle (rollback / future promotion)

Triggered via `workflow_run` after CI, gated to `event==push` && `head_branch==main` && same-repo so a fork PR can't trigger a privileged build. A concurrency group serializes runs, and `:dev` only moves when the built commit is still main's tip (the immutable `:dev-<sha>` is always published) — so an out-of-order CI completion for an older commit can't roll `:dev` backwards.

Deliberately separate from `release.yml`: never touches `:latest`, the published Helm chart, or the Homebrew/Scoop/Krew channels.

Purpose: let a downstream staging environment track the next deliverable from main ahead of releases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pushes container images to GHCR using `GITHUB_TOKEN` with package write access; mitigations include same-repo/push-only triggers and post-build tip check, but a misconfigured `if` could widen who can publish.
> 
> **Overview**
> Adds a new **Dev Image** GitHub Actions workflow so staging can track `main` without going through release channels.
> 
> After a **successful CI** run on a **same-repo push to `main`**, it builds and pushes `ghcr.io/skyhook-io/radar:dev-<shortsha>` from the Dockerfile **`full`** target (linux/amd64 only), with `VERSION=dev-<sha>`. It then **retags** that image to the mutable **`dev`** tag only if the built commit is still **`main`’s tip** after the build, avoiding out-of-order CI from rolling `:dev` backward. A **`dev-image`** concurrency group serializes runs.
> 
> This path is intentionally isolated from **`release.yml`**: no `:latest`, Helm chart, or package manager channels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 321c454e4c8078c3d99d9bfeeb23726b1c326f19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->