### PR TITLE
feat(k8s-ui): ApplicationDetail accepts activeInstanceKey

### DIFF
--- a/packages/k8s-ui/src/components/applications/ApplicationDetail.tsx
+++ b/packages/k8s-ui/src/components/applications/ApplicationDetail.tsx
@@ -93,6 +93,13 @@ export type ApplicationDetailProps = {
   /** Env tokens the cluster proved (the list derives the same set) — keeps a
    *  ungrouped app's Environment fact consistent between list and detail. */
   discoveredEnvs?: ReadonlySet<string>
+  /** Which instance in `identityInstances` is active, by its `appKey`. Defaults
+   *  to `app.key` — correct for the OSS case, where each instance IS a distinct
+   *  app row keyed the same way. A host that keys instances on something other
+   *  than the app key (e.g. the Cloud fleet keys per cluster, while `app.key`
+   *  must stay the logical app key for provenance) passes the active instance's
+   *  key here so the switcher marks it. */
+  activeInstanceKey?: string
 } & SelectionProps
 
 function ContextFact({ label, children }: { label: string; children: ReactNode }) {
@@ -132,7 +139,7 @@ function compareDefinedVersions(a: string | undefined, b: string | undefined): n
   return compareVersions(a, b) ?? 0
 }
 
-export function ApplicationDetail({ app, onBack, renderWorkload, topology, topologyLoading, onNavigateToResource, identityInstances, onSwitchInstance, discoveredEnvs, selectedWorkloadKey, onSelectWorkload }: ApplicationDetailProps) {
+export function ApplicationDetail({ app, onBack, renderWorkload, topology, topologyLoading, onNavigateToResource, identityInstances, onSwitchInstance, discoveredEnvs, activeInstanceKey, selectedWorkloadKey, onSelectWorkload }: ApplicationDetailProps) {
   // Stable order regardless of API ordering: rail rows and the per-workload
   // color assignment both follow this array, so an order flap between
   // refetches must not reshuffle rows or reassign a workload's hue.
@@ -286,7 +293,7 @@ export function ApplicationDetail({ app, onBack, renderWorkload, topology, topol
           // pills for a handful; a picker beyond that (scales to ~any count).
           <div className="flex min-w-0 items-center gap-1.5">
             <span className="text-[10px] uppercase tracking-wide text-theme-text-tertiary">Environment</span>
-            <EnvSwitcher identityKey={app.identity?.key ?? ''} instances={identityInstances} activeKey={app.key} onSwitch={onSwitchInstance} />
+            <EnvSwitcher identityKey={app.identity?.key ?? ''} instances={identityInstances} activeKey={activeInstanceKey ?? app.key} onSwitch={onSwitchInstance} />
           </div>
         ) : env ? (
           <ContextFact label="Environment">


### PR DESCRIPTION
## What

`ApplicationDetail` fed `app.key` to the instance switcher's `activeKey`, conflating two distinct keys:
- the **logical app key** — used by the provenance tooltip (`provenanceSource` → `appNameFromKey`), and
- the **per-instance key** — which instance in `identityInstances` is active.

In OSS Radar these coincide (each instance is a distinct app row keyed alike), so it worked. A host that keys instances on something else had no way to mark the active instance without corrupting provenance.

## Change

Add an optional `activeInstanceKey?: string` prop (defaults to `app.key`). The `EnvSwitcher` matches against it instead of `app.key`. **Non-breaking** — existing callers get identical behavior.

## Why

Radar Hub's Cloud fleet view reuses `ApplicationDetail` but projects one logical app across multiple clusters: an "instance" is a `(cluster × env)` cell, keyed per cluster, while `app.key` must stay the logical key so the provenance tooltip names the app (not a cluster id). It passes `activeInstanceKey={activeCluster}` so the multi-cluster switcher marks the active instance correctly.

Consumed by skyhook-dev/radar-hub-web (companion PR) — the hub pins `@skyhook-io/k8s-ui ^1.8.3`, so this needs a `k8s-ui-v1.8.3` tag/publish before that PR's CI goes green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single optional prop with a default; only affects which env/instance pill appears selected in the identity switcher.
> 
> **Overview**
> Adds optional **`activeInstanceKey`** on `ApplicationDetail` so the multi-instance **Environment** switcher (`EnvSwitcher`) can highlight the active row without reusing **`app.key`**.
> 
> **`EnvSwitcher`** now receives `activeKey={activeInstanceKey ?? app.key}` instead of always `app.key`. **`app.key`** stays the logical app key (e.g. provenance tooltip); hosts that key each instance differently—such as Radar Hub’s per-cluster fleet view—can pass the active instance’s key (e.g. active cluster) so the switcher marks the right pill. **Non-breaking:** omitting the prop keeps prior OSS behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96fa29ba0d90a2ce0c1802b0246e3acedd97e56d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->