### PR TITLE
Show Helm releases for cluster-wide readers without cluster-wide secrets

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -861,19 +861,58 @@ func (s *Server) resolveHelmNamespaces(r *http.Request) ([]string, bool) {
 	if noNamespaceAccess(namespaces) {
 		return nil, false
 	}
-	if namespaces == nil && auth.UserFromContext(r.Context()) == nil {
-		// "All namespaces" in no-auth mode. A namespace-restricted
-		// ServiceAccount can't list cluster-wide; resolve to the namespaces it
-		// can actually see so the Helm list degrades gracefully instead of
-		// 403-ing. Authenticated users are handled by parseNamespacesForUser
-		// above, and Helm lists impersonate them directly; narrowing them with
-		// the backend client's fallback namespaces would under-list users whose
-		// RBAC is wider than Radar's own ServiceAccount.
-		if fallback := helm.ResolveNoAuthListNamespaces(r.Context()); len(fallback) > 0 {
-			return fallback, true
+	if namespaces == nil {
+		if auth.UserFromContext(r.Context()) == nil {
+			// "All namespaces" in no-auth mode. A namespace-restricted
+			// ServiceAccount can't list cluster-wide; resolve to the namespaces
+			// it can actually see so the Helm list degrades gracefully instead
+			// of 403-ing. Authenticated users are handled below; Helm lists
+			// impersonate them directly, so narrowing them with the backend
+			// client's fallback namespaces would under-list users whose RBAC is
+			// wider than Radar's own ServiceAccount.
+			if fallback := helm.ResolveNoAuthListNamespaces(r.Context()); len(fallback) > 0 {
+				return fallback, true
+			}
+		} else if !s.canRead(r, "", "secrets", "", "list") {
+			// Authenticated user with cluster-wide pod access (parseNamespacesFor-
+			// User returned nil) but NOT cluster-wide `list secrets`. Helm storage
+			// is Secrets, so a single cluster-wide list would 403 wholesale and
+			// blank the view. Resolve to the namespaces where the user CAN list
+			// secrets — a per-namespace SAR memoized on the user's perms (2-min
+			// TTL), so repeat page loads don't re-probe. Falls through to the
+			// cluster-wide path (→ honest 403) when they can't read secrets
+			// anywhere.
+			if allowed := s.filterNamespacesByCanRead(r, "", "secrets", "list", s.allNamespaceNames()); len(allowed) > 0 {
+				return allowed, true
+			}
 		}
 	}
 	return namespaces, true
+}
+
+// allNamespaceNames returns every namespace name from the shared cache lister,
+// or nil when the namespace informer isn't available. Used as the candidate
+// pool for per-user secrets-SAR filtering — the SAR is the authorization gate,
+// so the (cluster-wide) pool only needs to be a superset of what the user can
+// read.
+func (s *Server) allNamespaceNames() []string {
+	cache := k8s.GetResourceCache()
+	if cache == nil {
+		return nil
+	}
+	lister := cache.Namespaces()
+	if lister == nil {
+		return nil
+	}
+	nsList, err := lister.List(labels.Everything())
+	if err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(nsList))
+	for _, ns := range nsList {
+		names = append(names, ns.Name)
+	}
+	return names
 }
 
 func dedupeStrings(values []string) []string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"reflect"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -1008,12 +1009,32 @@ func (s *Server) filterNamespacesByCanRead(r *http.Request, group, resource, ver
 	if len(namespaces) == 0 {
 		return namespaces
 	}
+	// Bounded-parallel: each canRead miss is a SAR round-trip, so a serial loop
+	// over a large candidate set (e.g. a cluster-wide reader's full namespace
+	// list in resolveHelmNamespaces) would block the request for N round-trips.
+	// canRead memoizes on the mutex-guarded UserPermissions.canI, mirroring the
+	// parallel SAR probing in internal/k8s/capabilities.go. Result is sorted so
+	// the output is deterministic regardless of goroutine completion order.
+	const maxConcurrent = 16
+	sem := make(chan struct{}, maxConcurrent)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
 	out := make([]string, 0, len(namespaces))
 	for _, ns := range namespaces {
-		if s.canRead(r, group, resource, ns, verb) {
-			out = append(out, ns)
-		}
+		wg.Add(1)
+		go func(ns string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			if s.canRead(r, group, resource, ns, verb) {
+				mu.Lock()
+				out = append(out, ns)
+				mu.Unlock()
+			}
+		}(ns)
 	}
+	wg.Wait()
+	sort.Strings(out)
 	return out
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #931 (the documented "Known limitation"). A user with **cluster-wide pod access but not cluster-wide `list secrets`** — e.g. someone bound to the built-in `view` ClusterRole, plus a narrower Role granting secrets in one namespace — still got a wholesale **403** ("Access Restricted") on the default Helm view, even though they can read Helm releases in their own namespace(s). This is the minimal, cache-friendly mitigation that lets them see the releases they can actually read.

## Root cause

For this identity, `parseNamespacesForUser` returns `nil` (cluster-wide pod access detected via the discovery sentinel), so `resolveHelmNamespaces` fell through to a single **cluster-wide** Helm list → `list secrets` at cluster scope → denied → the whole view 403s. Helm authorizes on Secrets, but the namespace resolution keys on pods.

## What changed

One gated branch in `resolveHelmNamespaces`: when the resolved set is `nil` for an **authenticated** user, check whether they can list secrets cluster-wide (`canRead`). If not, resolve to the namespaces where they *can* — `filterNamespacesByCanRead` over all namespace names — so the existing per-namespace Helm listing returns those releases instead of 403-ing wholesale. Falls through to the cluster-wide path (→ honest 403) when they can't read secrets anywhere.

Unaffected paths:
- **Cluster-admins** (can list secrets cluster-wide) → `canRead` short-circuits → fast single cluster-wide list. No fan-out.
- **No-auth / in-cluster SAs** → existing `ResolveNoAuthListNamespaces` path (the SAR branch is gated on an authenticated user).
- **#931 namespace-scoped users** → already resolved to their namespaces upstream; never reach this branch.

## Caching

No new cache needed — the per-namespace `secrets/list` SARs memoize on the user's `UserPermissions.canI` (`permCache`, 2-min TTL with eviction). First Helm load for this identity does N cheap SARs; repeat loads within the window reuse them, so only the readable namespaces get Helm-listed. The no-auth/in-cluster case stores nothing per-user.

**Cost:** on first load (or after the 2-min TTL) this identity fans out one secrets-SAR per namespace. SARs are lightweight authz checks (much cheaper than trial Helm-lists), gated to this rare identity only, run with **bounded concurrency (16)**, and cached after. The request context carries the server timeout into each SAR.

## Testing

Verified end-to-end against EKS (`radar-test-nonprod`) with `--auth-mode=proxy` and a user `gwen`: cluster-wide pods+namespaces ClusterRole (no secrets) + a Role granting secrets in one namespace that has a Helm release.

| `GET /api/helm/releases` as gwen | Before | After |
|---|---|---|
| default (no namespace) | **403** Access Restricted | **200**, `[cw-rel]` (the release she can read) |

- `make test` — green.
- No UI changes; visual-test not applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Helm namespace resolution and parallel per-namespace authorization checks; behavior is gated to a narrow RBAC edge case but touches security-sensitive list paths.
> 
> **Overview**
> Fixes **wholesale 403** on the default Helm view for authenticated users who have **cluster-wide pod visibility** but **cannot `list secrets` at cluster scope** (Helm stores releases in Secrets). When `resolveHelmNamespaces` would otherwise use a single cluster-wide list, it now **narrows to namespaces where per-namespace `list secrets` SAR succeeds**, using the cached namespace list as candidates; cluster-admins and no-auth paths are unchanged.
> 
> Adds **`allNamespaceNames()`** to supply that candidate pool from the namespace informer. **`filterNamespacesByCanRead`** now runs SAR checks with **bounded parallelism (16)** and **sorted** output so large clusters don’t block on serial round-trips and results stay deterministic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30ead87bca0f2d56cbb96521ca767f81d5c37d18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
