### PR TITLE
Settings dialog: polish + apply Prometheus URL without a restart

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -148,14 +148,11 @@ func RegisterCallbacks(cfg AppConfig, timelineStoreCfg timeline.StoreConfig) {
 		return traffic.ReinitializeWithConfig(k8s.GetClient(), k8s.GetConfig(), k8s.GetContextName())
 	})
 
+	// Reinitialize carries the current manual URL + headers forward (including any
+	// applied live via /integrations/prometheus). Re-applying the captured startup
+	// cfg here would revert a live change on context switch, so we don't.
 	k8s.RegisterPrometheusFuncs(prometheuspkg.Reset, func() error {
 		prometheuspkg.Reinitialize(k8s.GetClient(), k8s.GetConfig(), k8s.GetContextName())
-		if cfg.PrometheusURL != "" {
-			prometheuspkg.SetManualURL(cfg.PrometheusURL)
-		}
-		if len(cfg.PrometheusHeaders) > 0 {
-			prometheuspkg.SetHeaders(cfg.PrometheusHeaders)
-		}
 		return nil
 	})
 }

--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -77,12 +77,19 @@ func newMCPHTTPClient() *http.Client {
 }
 
 // SetManualURL sets the --prometheus-url override on the global client.
+// manualURL is read under the per-client c.mu (discover, Reinitialize), so the
+// write must take c.mu too — not clientMu — to avoid a lock-mismatch race once
+// this is callable at runtime. Mirrors SetHeaders.
 func SetManualURL(rawURL string) {
-	clientMu.Lock()
-	defer clientMu.Unlock()
-	if globalClient != nil {
-		globalClient.manualURL = strings.TrimRight(rawURL, "/")
+	clientMu.RLock()
+	c := globalClient
+	clientMu.RUnlock()
+	if c == nil {
+		return
 	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.manualURL = strings.TrimRight(rawURL, "/")
 }
 
 // SetHeaders sets HTTP headers attached to every Prometheus request on the

--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -78,35 +78,35 @@ func newMCPHTTPClient() *http.Client {
 
 // SetManualURL sets the --prometheus-url override on the global client.
 // manualURL is read under the per-client c.mu (discover, Reinitialize), so the
-// write must take c.mu too — not clientMu — to avoid a lock-mismatch race once
-// this is callable at runtime. Mirrors SetHeaders.
+// write takes c.mu too. clientMu is held (read) across the whole write so a
+// concurrent Reinitialize can't swap globalClient out from under us and leave the
+// new pointer with stale settings. Lock order clientMu→c.mu matches Reinitialize.
 func SetManualURL(rawURL string) {
 	clientMu.RLock()
-	c := globalClient
-	clientMu.RUnlock()
-	if c == nil {
+	defer clientMu.RUnlock()
+	if globalClient == nil {
 		return
 	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.manualURL = strings.TrimRight(rawURL, "/")
+	globalClient.mu.Lock()
+	defer globalClient.mu.Unlock()
+	globalClient.manualURL = strings.TrimRight(rawURL, "/")
 }
 
 // SetHeaders sets HTTP headers attached to every Prometheus request on the
-// global client. Pass nil or an empty map to clear.
+// global client. Pass nil or an empty map to clear. Holds clientMu (read) across
+// the write for the same reason as SetManualURL.
 func SetHeaders(h map[string]string) {
 	clientMu.RLock()
-	c := globalClient
-	clientMu.RUnlock()
-	if c == nil {
+	defer clientMu.RUnlock()
+	if globalClient == nil {
 		return
 	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.headers = copyHeaders(h)
+	globalClient.mu.Lock()
+	defer globalClient.mu.Unlock()
+	globalClient.headers = copyHeaders(h)
 	// Drop the cached prom.Client so the next request rebuilds its transport
 	// with the new headers.
-	c.prom = nil
+	globalClient.prom = nil
 }
 
 func copyHeaders(h map[string]string) map[string]string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3800,11 +3800,20 @@ func (s *Server) handleApplyPrometheusURL(w http.ResponseWriter, r *http.Request
 		s.writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
-	url := strings.TrimSpace(body.PrometheusURL)
+	rawURL := strings.TrimSpace(body.PrometheusURL)
+
+	// Reject anything startup would log.Fatalf on, so "Apply now" can't persist a
+	// config that bricks the next launch. Empty reverts to auto-discovery.
+	if rawURL != "" {
+		if u, err := url.Parse(rawURL); err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+			s.writeError(w, http.StatusBadRequest, "Prometheus URL must be a valid HTTP(S) URL (e.g., http://prometheus-server.monitoring:9090)")
+			return
+		}
+	}
 
 	// Persist first: a failed disk write must not leave the running client
 	// pointed somewhere the on-disk config disagrees with.
-	if _, err := config.Update(func(c *config.Config) { c.PrometheusURL = url }); err != nil {
+	if _, err := config.Update(func(c *config.Config) { c.PrometheusURL = rawURL }); err != nil {
 		log.Printf("[config] Failed to persist Prometheus URL: %v", err)
 		s.writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -3812,8 +3821,8 @@ func (s *Server) handleApplyPrometheusURL(w http.ResponseWriter, r *http.Request
 
 	// Apply to the running client. Reset() drops the cached connection so the
 	// probe below rediscovers against the new URL instead of the old endpoint.
-	prometheuspkg.SetManualURL(url)
-	traffic.SetMetricsURL(url)
+	prometheuspkg.SetManualURL(rawURL)
+	traffic.SetMetricsURL(rawURL)
 	prometheuspkg.Reset()
 
 	resp := struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -41,6 +41,7 @@ import (
 	prometheuspkg "github.com/skyhook-io/radar/internal/prometheus"
 	"github.com/skyhook-io/radar/internal/settings"
 	"github.com/skyhook-io/radar/internal/timeline"
+	"github.com/skyhook-io/radar/internal/traffic"
 	"github.com/skyhook-io/radar/internal/updater"
 	"github.com/skyhook-io/radar/internal/version"
 	"github.com/skyhook-io/radar/pkg/hpadiag"
@@ -488,6 +489,7 @@ func (s *Server) setupRoutes() {
 			// Config (persisted startup configuration)
 			r.Get("/config", s.handleGetConfig)
 			r.Put("/config", s.handlePutConfig)
+			r.Put("/integrations/prometheus", s.handleApplyPrometheusURL)
 
 			// Desktop routes
 			r.Post("/desktop/open-url", s.handleDesktopOpenURL)
@@ -3774,6 +3776,59 @@ func (s *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	result.PrometheusHeaders = nil
 	s.writeJSON(w, result)
+}
+
+// handleApplyPrometheusURL re-points the running Prometheus client at a new URL
+// immediately and persists it. The Prometheus URL is one of the few settings
+// that doesn't need a restart: the metrics path reads it from a mutable global
+// per query, so re-pointing it live is safe and saves operators a restart loop
+// when tuning discovery. Reset() drops the cached connection so the next probe
+// rediscovers against the new URL rather than reusing the old endpoint. The
+// response carries the live reachability result so the UI can confirm the URL
+// actually works. An empty URL reverts to auto-discovery.
+func (s *Server) handleApplyPrometheusURL(w http.ResponseWriter, r *http.Request) {
+	if !s.requireCloudRole(w, r, auth.RoleOwner, "modify Radar configuration") {
+		return
+	}
+	if !s.requireConnected(w) {
+		return
+	}
+	var body struct {
+		PrometheusURL string `json:"prometheusUrl"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		s.writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	url := strings.TrimSpace(body.PrometheusURL)
+
+	prometheuspkg.SetManualURL(url)
+	traffic.SetMetricsURL(url)
+	prometheuspkg.Reset()
+
+	if _, err := config.Update(func(c *config.Config) { c.PrometheusURL = url }); err != nil {
+		log.Printf("[config] Failed to persist Prometheus URL: %v", err)
+		s.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	resp := struct {
+		Connected bool   `json:"connected"`
+		Address   string `json:"address,omitempty"`
+		Error     string `json:"error,omitempty"`
+	}{}
+	if client := prometheuspkg.GetClient(); client != nil {
+		ctx, cancel := context.WithTimeout(r.Context(), 12*time.Second)
+		defer cancel()
+		addr, _, err := client.EnsureConnected(ctx)
+		if err != nil {
+			resp.Error = err.Error()
+		} else {
+			resp.Connected = true
+			resp.Address = addr
+		}
+	}
+	s.writeJSON(w, resp)
 }
 
 // Debug handlers for event pipeline diagnostics

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3800,9 +3800,9 @@ func (s *Server) handleApplyPrometheusURL(w http.ResponseWriter, r *http.Request
 	if !s.requireCloudRole(w, r, auth.RoleOwner, "modify Radar configuration") {
 		return
 	}
-	if !s.requireConnected(w) {
-		return
-	}
+	// No requireConnected: persisting + applying a manual URL needs no cluster
+	// (the probe hits the URL over HTTP), so operators can point at an external
+	// Prometheus even while the cluster is unreachable, like handlePutConfig.
 	var body struct {
 		PrometheusURL string `json:"prometheusUrl"`
 		// Headers is a pointer so we can tell "not editing headers" (nil — keep

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"reflect"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -3731,6 +3732,9 @@ type configResponse struct {
 	File      config.Config `json:"file"`
 	Effective config.Config `json:"effective"`
 	IsDesktop bool          `json:"isDesktop"`
+	// PrometheusHeaderKeys lists the configured Prometheus header names so the UI
+	// can show what's set without ever receiving the (secret) values.
+	PrometheusHeaderKeys []string `json:"prometheusHeaderKeys,omitempty"`
 }
 
 // handleGetConfig returns the on-disk config file alongside the effective startup config.
@@ -3738,10 +3742,16 @@ type configResponse struct {
 // diagnostics endpoint already masks them as a presence bool.
 func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 	file := config.Load()
+	headerKeys := make([]string, 0, len(file.PrometheusHeaders))
+	for k := range file.PrometheusHeaders {
+		headerKeys = append(headerKeys, k)
+	}
+	sort.Strings(headerKeys)
 	file.PrometheusHeaders = nil
 	resp := configResponse{
-		File:      file,
-		IsDesktop: version.IsDesktop(),
+		File:                 file,
+		IsDesktop:            version.IsDesktop(),
+		PrometheusHeaderKeys: headerKeys,
 	}
 	if s.effectiveConfig != nil {
 		effective := *s.effectiveConfig
@@ -3795,6 +3805,11 @@ func (s *Server) handleApplyPrometheusURL(w http.ResponseWriter, r *http.Request
 	}
 	var body struct {
 		PrometheusURL string `json:"prometheusUrl"`
+		// Headers is a pointer so we can tell "not editing headers" (nil — keep
+		// what's on disk) apart from "clear all headers" (present but empty). The
+		// UI only sends it when the user touched the header editor, since GET
+		// redacts the values and can't round-trip them.
+		Headers *map[string]string `json:"headers"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		s.writeError(w, http.StatusBadRequest, "invalid request body")
@@ -3811,9 +3826,24 @@ func (s *Server) handleApplyPrometheusURL(w http.ResponseWriter, r *http.Request
 		}
 	}
 
+	var headers map[string]string
+	if body.Headers != nil {
+		headers = make(map[string]string, len(*body.Headers))
+		for k, v := range *body.Headers {
+			if k = strings.TrimSpace(k); k != "" {
+				headers[k] = v
+			}
+		}
+	}
+
 	// Persist first: a failed disk write must not leave the running client
 	// pointed somewhere the on-disk config disagrees with.
-	if _, err := config.Update(func(c *config.Config) { c.PrometheusURL = rawURL }); err != nil {
+	if _, err := config.Update(func(c *config.Config) {
+		c.PrometheusURL = rawURL
+		if body.Headers != nil {
+			c.PrometheusHeaders = headers
+		}
+	}); err != nil {
 		log.Printf("[config] Failed to persist Prometheus URL: %v", err)
 		s.writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -3823,6 +3853,10 @@ func (s *Server) handleApplyPrometheusURL(w http.ResponseWriter, r *http.Request
 	// probe below rediscovers against the new URL instead of the old endpoint.
 	prometheuspkg.SetManualURL(rawURL)
 	traffic.SetMetricsURL(rawURL)
+	if body.Headers != nil {
+		prometheuspkg.SetHeaders(headers)
+		traffic.SetMetricsHeaders(headers)
+	}
 	prometheuspkg.Reset()
 
 	resp := struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3802,15 +3802,19 @@ func (s *Server) handleApplyPrometheusURL(w http.ResponseWriter, r *http.Request
 	}
 	url := strings.TrimSpace(body.PrometheusURL)
 
-	prometheuspkg.SetManualURL(url)
-	traffic.SetMetricsURL(url)
-	prometheuspkg.Reset()
-
+	// Persist first: a failed disk write must not leave the running client
+	// pointed somewhere the on-disk config disagrees with.
 	if _, err := config.Update(func(c *config.Config) { c.PrometheusURL = url }); err != nil {
 		log.Printf("[config] Failed to persist Prometheus URL: %v", err)
 		s.writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+
+	// Apply to the running client. Reset() drops the cached connection so the
+	// probe below rediscovers against the new URL instead of the old endpoint.
+	prometheuspkg.SetManualURL(url)
+	traffic.SetMetricsURL(url)
+	prometheuspkg.Reset()
 
 	resp := struct {
 		Connected bool   `json:"connected"`

--- a/internal/traffic/manager.go
+++ b/internal/traffic/manager.go
@@ -32,6 +32,12 @@ var (
 	initOnce sync.Once
 	initErr  error
 
+	// metricsConfigMu guards the configured-metrics globals below. Originally
+	// these were written only at startup (no concurrent readers), but the live
+	// "apply Prometheus URL" path now writes them at runtime while a concurrent
+	// context-switch rebuild reads them in initOnce.Do — so the access needs a
+	// lock, matching the mutex-guarded prometheus client.
+	metricsConfigMu sync.RWMutex
 	// configuredMetricsURL is the user-provided --prometheus-url flag value.
 	// Stored at package level so it persists across context-switch resets.
 	configuredMetricsURL string
@@ -42,12 +48,16 @@ var (
 
 // SetMetricsURL sets a manual Prometheus/VictoriaMetrics URL, bypassing auto-discovery.
 func SetMetricsURL(url string) {
+	metricsConfigMu.Lock()
+	defer metricsConfigMu.Unlock()
 	configuredMetricsURL = url
 }
 
 // SetMetricsHeaders sets HTTP headers attached to every Prometheus query.
 // Used for auth-protected backends (Bearer tokens, X-Scope-OrgID, etc.).
 func SetMetricsHeaders(h map[string]string) {
+	metricsConfigMu.Lock()
+	defer metricsConfigMu.Unlock()
 	if len(h) == 0 {
 		configuredMetricsHeaders = nil
 		return
@@ -55,6 +65,13 @@ func SetMetricsHeaders(h map[string]string) {
 	out := make(map[string]string, len(h))
 	maps.Copy(out, h)
 	configuredMetricsHeaders = out
+}
+
+// metricsConfig returns the configured URL + headers under the read lock.
+func metricsConfig() (string, map[string]string) {
+	metricsConfigMu.RLock()
+	defer metricsConfigMu.RUnlock()
+	return configuredMetricsURL, configuredMetricsHeaders
 }
 
 // Initialize sets up the traffic manager with the given K8s client
@@ -74,10 +91,11 @@ func InitializeWithConfig(client kubernetes.Interface, config *rest.Config, cont
 		// Register available sources
 		manager.sources["hubble"] = NewHubbleSource(client)
 		caretta := NewCarettaSource(client)
-		if configuredMetricsURL != "" {
-			caretta.metricsURL = configuredMetricsURL
+		metricsURL, metricsHeaders := metricsConfig()
+		if metricsURL != "" {
+			caretta.metricsURL = metricsURL
 		}
-		caretta.headers = configuredMetricsHeaders
+		caretta.headers = metricsHeaders
 		manager.sources["caretta"] = caretta
 		manager.sources["istio"] = NewIstioSource(client)
 
@@ -317,8 +335,8 @@ func (m *Manager) generateRecommendation(info *ClusterInfo, detected []SourceSta
 	for _, s := range detected {
 		if s.Name == "istio" && s.Status == "error" {
 			return &Recommendation{
-				Name:   "istio",
-				Reason: "Istio service mesh detected but Prometheus not reachable. Use --prometheus-url to point Radar to your Prometheus instance for Istio traffic visibility.",
+				Name:    "istio",
+				Reason:  "Istio service mesh detected but Prometheus not reachable. Use --prometheus-url to point Radar to your Prometheus instance for Istio traffic visibility.",
 				DocsURL: "https://istio.io/latest/docs/ops/integrations/prometheus/",
 			}
 		}

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -576,14 +576,20 @@ function PrometheusConfigField({
 
   const handleApply = async () => {
     setApply({ status: 'applying' })
-    const editedHeaders =
-      headerRows === null
-        ? undefined
-        : Object.fromEntries(
-            headerRows
-              .map((r) => [r.key.trim(), r.value] as const)
-              .filter(([k, v]) => k !== '' && v !== '')
-          )
+    // Decide what to do with headers. undefined = leave them untouched. Only send
+    // a replacement when the editor has real content, or {} when the user emptied
+    // every row (explicit clear) — blank in-progress rows must NOT wipe stored
+    // secrets just because the editor happens to be open for a URL-only change.
+    let editedHeaders: Record<string, string> | undefined
+    if (headerRows !== null) {
+      const entered = Object.fromEntries(
+        headerRows
+          .map((r) => [r.key.trim(), r.value] as const)
+          .filter(([k, v]) => k !== '' && v !== '')
+      )
+      if (Object.keys(entered).length > 0) editedHeaders = entered
+      else if (headerRows.length === 0) editedHeaders = {}
+    }
     try {
       const res = await fetch(apiUrl('/integrations/prometheus'), {
         method: 'PUT',
@@ -601,6 +607,8 @@ function PrometheusConfigField({
       }
       if (editedHeaders !== undefined) {
         setAppliedKeys(Object.keys(editedHeaders).sort())
+      }
+      if (headerRows !== null) {
         setHeaderRows(null)
       }
       if (data?.connected) {
@@ -726,8 +734,9 @@ function PrometheusConfigField({
               </button>
             </div>
             <p className="text-xs text-theme-text-tertiary">
-              Saved when you click Apply now. Replaces all stored headers — existing
-              values are hidden, so re-enter any you want to keep.
+              Saved when you click Apply now. Entered headers replace all stored
+              ones — values are hidden, so re-enter any you want to keep. Leave
+              blank to keep existing headers unchanged.
             </p>
           </div>
         )}

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -524,7 +524,8 @@ type ApplyState =
   | { status: 'idle' }
   | { status: 'applying' }
   | { status: 'connected'; address: string }
-  | { status: 'error'; error: string }
+  | { status: 'unreachable'; error: string } // persisted, but the probe failed
+  | { status: 'failed'; error: string }       // request itself failed — nothing saved
 
 function PrometheusConfigField({
   value,
@@ -546,16 +547,16 @@ function PrometheusConfigField({
       })
       const data = await res.json().catch(() => null)
       if (!res.ok) {
-        setApply({ status: 'error', error: data?.error || res.statusText })
+        setApply({ status: 'failed', error: data?.error || res.statusText })
         return
       }
       if (data?.connected) {
         setApply({ status: 'connected', address: data.address || value.trim() })
       } else {
-        setApply({ status: 'error', error: data?.error || 'not reachable' })
+        setApply({ status: 'unreachable', error: data?.error || 'not reachable' })
       }
     } catch (err) {
-      setApply({ status: 'error', error: String(err) })
+      setApply({ status: 'failed', error: String(err) })
     }
   }
 
@@ -595,9 +596,13 @@ function PrometheusConfigField({
           <Check className="w-3 h-3 shrink-0" />
           Connected to {apply.address} — applied, no restart needed
         </p>
-      ) : apply.status === 'error' ? (
+      ) : apply.status === 'unreachable' ? (
         <p className="mt-1 text-xs text-amber-600 dark:text-amber-400/80">
           Saved, but not reachable: {apply.error}
+        </p>
+      ) : apply.status === 'failed' ? (
+        <p className="mt-1 text-xs text-red-600 dark:text-red-400/80">
+          Couldn't apply: {apply.error}
         </p>
       ) : (
         <p className="mt-1 text-xs text-theme-text-tertiary">

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
-import { Settings, X, RotateCcw, RotateCw, Loader2, Copy, Check, Pin, Shield, Lock } from 'lucide-react'
+import { Settings, X, RotateCcw, RotateCw, Loader2, Copy, Check, Pin, Shield, Lock, Plug } from 'lucide-react'
 import { clsx } from 'clsx'
 import { useAnimatedUnmount } from '../../hooks/useAnimatedUnmount'
 import { TRANSITION_BACKDROP, TRANSITION_PANEL } from '../../utils/animation'
@@ -336,7 +336,7 @@ function StartupConfigTab({
 
       <ConfigField
         label="Default Namespace"
-        help="Initial namespace filter on startup"
+        help="Startup default only — change the active namespace live anytime from the header switcher"
         value={config.namespace ?? ''}
         effectiveValue={effectiveConfig?.namespace}
         placeholder="All namespaces"
@@ -419,12 +419,8 @@ function StartupConfigTab({
         <h4 className="text-xs font-medium text-theme-text-secondary uppercase tracking-wider mb-3">Integrations</h4>
 
         <div className="space-y-4">
-          <ConfigField
-            label="Prometheus URL"
-            help="Manual Prometheus/VictoriaMetrics URL (skips auto-discovery)"
+          <PrometheusConfigField
             value={config.prometheusUrl ?? ''}
-            effectiveValue={effectiveConfig?.prometheusUrl}
-            placeholder="http://prometheus-server.monitoring:9090"
             onChange={(v) => onChange('prometheusUrl', v || undefined)}
           />
         </div>
@@ -510,6 +506,103 @@ function MCPSection({
             </p>
           )}
         </div>
+      )}
+    </div>
+  )
+}
+
+// -- Prometheus (live-appliable) ----------------------------------------------
+
+// Unlike the rest of this dialog, the Prometheus URL can be re-pointed without
+// a restart — the metrics path reads it from a mutable global. "Apply now" hits
+// PUT /integrations/prometheus, which persists the URL AND re-points the running
+// client, then probes it so we can confirm reachability inline. The global Save
+// still persists this field too (taking effect next launch, like everything
+// else); Apply is the shortcut to "now". No EffectiveHint here — the per-field
+// restart-diff hint would contradict the whole point of applying live.
+type ApplyState =
+  | { status: 'idle' }
+  | { status: 'applying' }
+  | { status: 'connected'; address: string }
+  | { status: 'error'; error: string }
+
+function PrometheusConfigField({
+  value,
+  onChange,
+}: {
+  value: string
+  onChange: (value: string) => void
+}) {
+  const [apply, setApply] = useState<ApplyState>({ status: 'idle' })
+
+  const handleApply = async () => {
+    setApply({ status: 'applying' })
+    try {
+      const res = await fetch(apiUrl('/integrations/prometheus'), {
+        method: 'PUT',
+        credentials: getCredentialsMode(),
+        headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+        body: JSON.stringify({ prometheusUrl: value.trim() }),
+      })
+      const data = await res.json().catch(() => null)
+      if (!res.ok) {
+        setApply({ status: 'error', error: data?.error || res.statusText })
+        return
+      }
+      if (data?.connected) {
+        setApply({ status: 'connected', address: data.address || value.trim() })
+      } else {
+        setApply({ status: 'error', error: data?.error || 'not reachable' })
+      }
+    } catch (err) {
+      setApply({ status: 'error', error: String(err) })
+    }
+  }
+
+  return (
+    <div>
+      <label className="block text-sm font-medium text-theme-text-primary mb-1">
+        Prometheus URL
+      </label>
+      <p className="text-xs text-theme-text-tertiary mb-1">
+        Manual Prometheus/VictoriaMetrics URL (skips auto-discovery)
+      </p>
+      <div className="flex items-center gap-2">
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => {
+            onChange(e.target.value)
+            if (apply.status !== 'applying') setApply({ status: 'idle' })
+          }}
+          placeholder="http://prometheus-server.monitoring:9090"
+          className="flex-1 min-w-0 px-3 py-1.5 text-sm bg-theme-elevated border border-theme-border rounded-md text-theme-text-primary placeholder:text-theme-text-tertiary focus:outline-none focus:border-skyhook-500"
+        />
+        <button
+          onClick={handleApply}
+          disabled={apply.status === 'applying'}
+          className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated border border-theme-border rounded-md transition-colors disabled:opacity-50"
+          title="Apply this URL to the running server now — no restart"
+        >
+          {apply.status === 'applying'
+            ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            : <Plug className="w-3.5 h-3.5" />}
+          Apply now
+        </button>
+      </div>
+      {apply.status === 'connected' ? (
+        <p className="mt-1 flex items-center gap-1 text-xs text-green-600 dark:text-green-400/80">
+          <Check className="w-3 h-3 shrink-0" />
+          Connected to {apply.address} — applied, no restart needed
+        </p>
+      ) : apply.status === 'error' ? (
+        <p className="mt-1 text-xs text-amber-600 dark:text-amber-400/80">
+          Saved, but not reachable: {apply.error}
+        </p>
+      ) : (
+        <p className="mt-1 text-xs text-theme-text-tertiary">
+          Applies immediately — no restart needed.
+        </p>
       )}
     </div>
   )

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
-import { Settings, X, RotateCcw, Loader2, Copy, Check, Pin, Shield, Lock } from 'lucide-react'
+import { Settings, X, RotateCcw, RotateCw, Loader2, Copy, Check, Pin, Shield, Lock } from 'lucide-react'
 import { clsx } from 'clsx'
 import { useAnimatedUnmount } from '../../hooks/useAnimatedUnmount'
 import { TRANSITION_BACKDROP, TRANSITION_PANEL } from '../../utils/animation'
@@ -165,7 +165,13 @@ export function SettingsDialog({ open, onClose, onShowMyPermissions }: SettingsD
         <div className="flex items-center justify-between p-4 border-b border-theme-border shrink-0">
           <div className="flex items-center gap-2">
             <Settings className="w-5 h-5 text-theme-text-secondary" />
-            <h2 className="text-lg font-semibold text-theme-text-primary">Settings</h2>
+            <div className="flex items-baseline gap-2">
+              <h2 className="text-lg font-semibold text-theme-text-primary">Settings</h2>
+              <span className="text-[11px] text-theme-text-tertiary">
+                Radar{versionInfo?.currentVersion ? ` v${versionInfo.currentVersion}` : ''}
+                <span className="text-theme-text-disabled"> · by Skyhook</span>
+              </span>
+            </div>
           </div>
           <button
             onClick={onClose}
@@ -233,7 +239,7 @@ export function SettingsDialog({ open, onClose, onShowMyPermissions }: SettingsD
             the save controls entirely for non-owners (personal sections save
             themselves). */}
         {canEditConfig && (
-        <div className="flex items-center justify-between gap-3 p-4 border-t border-theme-border shrink-0">
+        <div className="flex items-center justify-between gap-3 px-4 py-2.5 border-t border-theme-border shrink-0">
             <div className="flex items-center gap-2">
               <button
                 onClick={resetConfig}
@@ -253,32 +259,22 @@ export function SettingsDialog({ open, onClose, onShowMyPermissions }: SettingsD
                 </span>
               )}
             </div>
-            <button
-              onClick={saveConfig}
-              disabled={saving || !configDirty}
-              className="flex items-center gap-1.5 px-4 py-1.5 text-sm font-medium btn-brand rounded-md"
-            >
-              {saving && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
-              Save
-            </button>
+            <div className="flex items-center gap-3">
+              <span className="hidden sm:flex items-center gap-1.5 text-[11px] text-theme-text-tertiary">
+                <RotateCw className="w-3 h-3" />
+                Applies on next launch
+              </span>
+              <button
+                onClick={saveConfig}
+                disabled={saving || !configDirty}
+                className="flex items-center gap-1.5 px-4 py-1.5 text-sm font-medium btn-brand rounded-md"
+              >
+                {saving && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
+                Save
+              </button>
+            </div>
           </div>
         )}
-
-        {/* About — muted version footer (canonical "Settings → About"). */}
-        <div className="flex items-center justify-between gap-2 px-4 py-2 border-t border-theme-border/60 text-[11px] text-theme-text-tertiary shrink-0">
-          <span>
-            Radar{versionInfo?.currentVersion ? ` v${versionInfo.currentVersion}` : ''}
-            <span className="text-theme-text-disabled"> · by Skyhook</span>
-          </span>
-          <a
-            href="https://github.com/skyhook-io/radar"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-accent-text hover:underline"
-          >
-            GitHub
-          </a>
-        </div>
       </div>
     </div>,
     document.body
@@ -378,6 +374,18 @@ function StartupConfigTab({
       )}
 
       <div className="border-t border-theme-border pt-4 mt-4">
+        <h4 className="text-xs font-medium text-theme-text-secondary uppercase tracking-wider mb-3">AI Tools</h4>
+
+        <MCPSection
+          mcpEnabled={config.mcp ?? true}
+          onToggle={(v) => onChange('mcp', v)}
+          isDesktop={isDesktop}
+          portPinned={config.port != null && config.port > 0}
+          onPinPort={(port) => onChange('port', port)}
+        />
+      </div>
+
+      <div className="border-t border-theme-border pt-4 mt-4">
         <h4 className="text-xs font-medium text-theme-text-secondary uppercase tracking-wider mb-3">Timeline</h4>
 
         <div className="space-y-4">
@@ -388,7 +396,7 @@ function StartupConfigTab({
             <select
               value={config.timelineStorage ?? 'memory'}
               onChange={(e) => onChange('timelineStorage', e.target.value === 'memory' ? undefined : e.target.value as 'sqlite')}
-              className="w-full px-3 py-1.5 text-sm bg-theme-elevated border border-theme-border rounded-md text-theme-text-primary focus:outline-none focus:border-blue-500"
+              className="w-full px-3 py-1.5 text-sm bg-theme-elevated border border-theme-border rounded-md text-theme-text-primary focus:outline-none focus:border-skyhook-500"
             >
               <option value="memory">Memory (default)</option>
               <option value="sqlite">SQLite (persistent)</option>
@@ -418,14 +426,6 @@ function StartupConfigTab({
             effectiveValue={effectiveConfig?.prometheusUrl}
             placeholder="http://prometheus-server.monitoring:9090"
             onChange={(v) => onChange('prometheusUrl', v || undefined)}
-          />
-
-          <MCPSection
-            mcpEnabled={config.mcp ?? true}
-            onToggle={(v) => onChange('mcp', v)}
-            isDesktop={isDesktop}
-            portPinned={config.port != null && config.port > 0}
-            onPinPort={(port) => onChange('port', port)}
           />
         </div>
       </div>
@@ -543,7 +543,7 @@ function ConfigField({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
-        className="w-full px-3 py-1.5 text-sm bg-theme-elevated border border-theme-border rounded-md text-theme-text-primary placeholder:text-theme-text-tertiary focus:outline-none focus:border-blue-500"
+        className="w-full px-3 py-1.5 text-sm bg-theme-elevated border border-theme-border rounded-md text-theme-text-primary placeholder:text-theme-text-tertiary focus:outline-none focus:border-skyhook-500"
       />
       <EffectiveHint current={value || undefined} effective={effectiveValue} />
     </div>
@@ -603,7 +603,7 @@ function ConfigArrayField({
           commit(e.target.value)
         }}
         placeholder={placeholder}
-        className="w-full px-3 py-1.5 text-sm bg-theme-elevated border border-theme-border rounded-md text-theme-text-primary placeholder:text-theme-text-tertiary focus:outline-none focus:border-blue-500"
+        className="w-full px-3 py-1.5 text-sm bg-theme-elevated border border-theme-border rounded-md text-theme-text-primary placeholder:text-theme-text-tertiary focus:outline-none focus:border-skyhook-500"
       />
       <EffectiveHint current={canonical(value) || undefined} effective={canonical(effectiveValue) || undefined} />
     </div>
@@ -636,7 +636,7 @@ function ConfigNumberField({
         value={value ?? ''}
         onChange={(e) => onChange(e.target.value ? parseInt(e.target.value, 10) || undefined : undefined)}
         placeholder={placeholder}
-        className="w-full px-3 py-1.5 text-sm bg-theme-elevated border border-theme-border rounded-md text-theme-text-primary placeholder:text-theme-text-tertiary focus:outline-none focus:border-blue-500"
+        className="w-full px-3 py-1.5 text-sm bg-theme-elevated border border-theme-border rounded-md text-theme-text-primary placeholder:text-theme-text-tertiary focus:outline-none focus:border-skyhook-500"
       />
       <EffectiveHint current={value} effective={effectiveValue} />
     </div>

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -558,13 +558,21 @@ function PrometheusConfigField({
   // the user opened the editor; on Apply we send it verbatim, replacing all
   // stored headers (values are write-only, so the server never sends them back).
   const [headerRows, setHeaderRows] = useState<HeaderRow[] | null>(null)
-  // Mirrors the server's configured header keys so the summary updates after a
-  // successful apply without refetching the whole config.
-  const [storedKeys, setStoredKeys] = useState<string[]>(configuredHeaderKeys)
+  // Show the server's configured header keys, but let a successful apply override
+  // optimistically (config isn't refetched). Derived from the prop — not a
+  // mount-time snapshot — so it stays correct as config loads asynchronously.
+  const [appliedKeys, setAppliedKeys] = useState<string[] | null>(null)
+  const storedKeys = appliedKeys ?? configuredHeaderKeys
 
   const clearStatus = () => {
     if (apply.status !== 'applying') setApply({ status: 'idle' })
   }
+
+  // Footer Reset (and any external edit) clears the URL field without a keystroke;
+  // drop a stale "Connected"/"Saved" status so it doesn't describe an emptied field.
+  useEffect(() => {
+    setApply((s) => (s.status === 'idle' || s.status === 'applying' ? s : { status: 'idle' }))
+  }, [value])
 
   const handleApply = async () => {
     setApply({ status: 'applying' })
@@ -592,7 +600,7 @@ function PrometheusConfigField({
         return
       }
       if (editedHeaders !== undefined) {
-        setStoredKeys(Object.keys(editedHeaders).sort())
+        setAppliedKeys(Object.keys(editedHeaders).sort())
         setHeaderRows(null)
       }
       if (data?.connected) {
@@ -617,10 +625,7 @@ function PrometheusConfigField({
         <input
           type="text"
           value={value}
-          onChange={(e) => {
-            onChange(e.target.value)
-            clearStatus()
-          }}
+          onChange={(e) => onChange(e.target.value)}
           placeholder="http://prometheus-server.monitoring:9090"
           className="flex-1 min-w-0 px-3 py-1.5 text-sm bg-theme-elevated border border-theme-border rounded-md text-theme-text-primary placeholder:text-theme-text-tertiary focus:outline-none focus:border-skyhook-500"
         />

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
-import { Settings, X, RotateCcw, RotateCw, Loader2, Copy, Check, Pin, Shield, Lock, Plug } from 'lucide-react'
+import { Settings, X, RotateCcw, RotateCw, Loader2, Copy, Check, Pin, Shield, Lock, Plug, Plus } from 'lucide-react'
 import { clsx } from 'clsx'
 import { useAnimatedUnmount } from '../../hooks/useAnimatedUnmount'
 import { TRANSITION_BACKDROP, TRANSITION_PANEL } from '../../utils/animation'
@@ -27,6 +27,7 @@ interface ConfigResponse {
   file: Config
   effective: Config
   isDesktop: boolean
+  prometheusHeaderKeys?: string[]
 }
 
 interface SettingsDialogProps {
@@ -218,6 +219,7 @@ export function SettingsDialog({ open, onClose, onShowMyPermissions }: SettingsD
               effectiveConfig={configData?.effective}
               isDesktop={isDesktop}
               deploymentMode={deploymentMode}
+              prometheusHeaderKeys={configData?.prometheusHeaderKeys ?? []}
               onChange={updateConfigField}
             />
           ) : (
@@ -298,12 +300,14 @@ function StartupConfigTab({
   effectiveConfig,
   isDesktop,
   deploymentMode,
+  prometheusHeaderKeys,
   onChange,
 }: {
   config: Config
   effectiveConfig?: Config
   isDesktop: boolean
   deploymentMode: DeploymentMode
+  prometheusHeaderKeys: string[]
   onChange: <K extends keyof Config>(field: K, value: Config[K]) => void
 }) {
   const showBrowserLaunchControls = !isDesktop && deploymentMode === 'local'
@@ -421,6 +425,7 @@ function StartupConfigTab({
         <div className="space-y-4">
           <PrometheusConfigField
             value={config.prometheusUrl ?? ''}
+            configuredHeaderKeys={prometheusHeaderKeys}
             onChange={(v) => onChange('prometheusUrl', v || undefined)}
           />
         </div>
@@ -527,28 +532,58 @@ type ApplyState =
   | { status: 'unreachable'; error: string } // persisted, but the probe failed
   | { status: 'failed'; error: string }       // request itself failed — nothing saved
 
+type HeaderRow = { key: string; value: string }
+
 function PrometheusConfigField({
   value,
   onChange,
+  configuredHeaderKeys,
 }: {
   value: string
   onChange: (value: string) => void
+  configuredHeaderKeys: string[]
 }) {
   const [apply, setApply] = useState<ApplyState>({ status: 'idle' })
+  // null = not editing headers (preserve what's stored). A non-null array means
+  // the user opened the editor; on Apply we send it verbatim, replacing all
+  // stored headers (values are write-only, so the server never sends them back).
+  const [headerRows, setHeaderRows] = useState<HeaderRow[] | null>(null)
+  // Mirrors the server's configured header keys so the summary updates after a
+  // successful apply without refetching the whole config.
+  const [storedKeys, setStoredKeys] = useState<string[]>(configuredHeaderKeys)
+
+  const clearStatus = () => {
+    if (apply.status !== 'applying') setApply({ status: 'idle' })
+  }
 
   const handleApply = async () => {
     setApply({ status: 'applying' })
+    const editedHeaders =
+      headerRows === null
+        ? undefined
+        : Object.fromEntries(
+            headerRows
+              .map((r) => [r.key.trim(), r.value] as const)
+              .filter(([k, v]) => k !== '' && v !== '')
+          )
     try {
       const res = await fetch(apiUrl('/integrations/prometheus'), {
         method: 'PUT',
         credentials: getCredentialsMode(),
         headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
-        body: JSON.stringify({ prometheusUrl: value.trim() }),
+        body: JSON.stringify({
+          prometheusUrl: value.trim(),
+          ...(editedHeaders !== undefined ? { headers: editedHeaders } : {}),
+        }),
       })
       const data = await res.json().catch(() => null)
       if (!res.ok) {
         setApply({ status: 'failed', error: data?.error || res.statusText })
         return
+      }
+      if (editedHeaders !== undefined) {
+        setStoredKeys(Object.keys(editedHeaders).sort())
+        setHeaderRows(null)
       }
       if (data?.connected) {
         setApply({ status: 'connected', address: data.address || value.trim() })
@@ -574,7 +609,7 @@ function PrometheusConfigField({
           value={value}
           onChange={(e) => {
             onChange(e.target.value)
-            if (apply.status !== 'applying') setApply({ status: 'idle' })
+            clearStatus()
           }}
           placeholder="http://prometheus-server.monitoring:9090"
           className="flex-1 min-w-0 px-3 py-1.5 text-sm bg-theme-elevated border border-theme-border rounded-md text-theme-text-primary placeholder:text-theme-text-tertiary focus:outline-none focus:border-skyhook-500"
@@ -609,6 +644,77 @@ function PrometheusConfigField({
           Applies immediately — no restart needed.
         </p>
       )}
+
+      {/* Auth headers — for token / multi-tenant backends (Bearer, X-Scope-OrgID). */}
+      <div className="mt-3">
+        {headerRows === null ? (
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-xs text-theme-text-tertiary">
+              {storedKeys.length > 0
+                ? <>Auth headers: <span className="text-theme-text-secondary">{storedKeys.join(', ')}</span> <span className="text-theme-text-disabled">(values hidden)</span></>
+                : 'No auth headers'}
+            </span>
+            <button
+              onClick={() => { setHeaderRows([{ key: '', value: '' }]); clearStatus() }}
+              className="shrink-0 text-xs font-medium text-accent-text hover:underline"
+            >
+              {storedKeys.length > 0 ? 'Edit headers' : 'Add auth headers'}
+            </button>
+          </div>
+        ) : (
+          <div className="rounded-md border border-theme-border bg-theme-elevated/40 p-2.5 space-y-2">
+            {headerRows.map((row, i) => (
+              <div key={i} className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={row.key}
+                  onChange={(e) => {
+                    setHeaderRows((rows) => rows!.map((r, j) => j === i ? { ...r, key: e.target.value } : r))
+                    clearStatus()
+                  }}
+                  placeholder="Header (e.g. Authorization)"
+                  className="flex-1 min-w-0 px-2.5 py-1.5 text-xs bg-theme-base border border-theme-border rounded-md text-theme-text-primary placeholder:text-theme-text-tertiary focus:outline-none focus:border-skyhook-500"
+                />
+                <input
+                  type="password"
+                  value={row.value}
+                  onChange={(e) => {
+                    setHeaderRows((rows) => rows!.map((r, j) => j === i ? { ...r, value: e.target.value } : r))
+                    clearStatus()
+                  }}
+                  placeholder="Value (e.g. Bearer …)"
+                  className="flex-1 min-w-0 px-2.5 py-1.5 text-xs bg-theme-base border border-theme-border rounded-md text-theme-text-primary placeholder:text-theme-text-tertiary focus:outline-none focus:border-skyhook-500"
+                />
+                <button
+                  onClick={() => setHeaderRows((rows) => rows!.filter((_, j) => j !== i))}
+                  className="shrink-0 p-1 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-hover rounded"
+                  title="Remove header"
+                >
+                  <X className="w-3.5 h-3.5" />
+                </button>
+              </div>
+            ))}
+            <div className="flex items-center justify-between gap-2">
+              <button
+                onClick={() => setHeaderRows((rows) => [...rows!, { key: '', value: '' }])}
+                className="flex items-center gap-1 text-xs font-medium text-accent-text hover:underline"
+              >
+                <Plus className="w-3 h-3" /> Add header
+              </button>
+              <button
+                onClick={() => { setHeaderRows(null); clearStatus() }}
+                className="text-xs text-theme-text-tertiary hover:text-theme-text-primary"
+              >
+                Cancel
+              </button>
+            </div>
+            <p className="text-xs text-theme-text-tertiary">
+              Applied with the URL above. Replaces all stored headers — values are
+              write-only, so re-enter any you want to keep.
+            </p>
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -7,6 +7,7 @@ import { TRANSITION_BACKDROP, TRANSITION_PANEL } from '../../utils/animation'
 import { apiUrl, getAuthHeaders, getCredentialsMode } from '../../api/config'
 import { useCloudRole, useVersionCheck } from '../../api/client'
 import { useCapabilitiesContext } from '../../contexts/CapabilitiesContext'
+import { Tooltip } from '../ui/Tooltip'
 import type { DeploymentMode } from '../../types'
 
 interface Config {
@@ -157,7 +158,7 @@ export function SettingsDialog({ open, onClose, onShowMyPermissions }: SettingsD
         className={clsx(
           'relative bg-theme-surface border border-theme-border shadow-theme-lg w-full outline-none flex flex-col',
           'max-sm:inset-0 max-sm:absolute max-sm:rounded-none max-sm:max-h-full max-sm:border-0',
-          'sm:rounded-xl sm:max-w-xl sm:mx-4 sm:max-h-[85vh]',
+          'sm:rounded-xl sm:max-w-2xl sm:mx-4 sm:max-h-[85vh]',
           TRANSITION_PANEL,
           isOpen ? 'opacity-100 scale-100' : 'opacity-0 scale-95'
         )}
@@ -243,15 +244,16 @@ export function SettingsDialog({ open, onClose, onShowMyPermissions }: SettingsD
         {canEditConfig && (
         <div className="flex items-center justify-between gap-3 px-4 py-2.5 border-t border-theme-border shrink-0">
             <div className="flex items-center gap-2">
-              <button
-                onClick={resetConfig}
-                disabled={saving}
-                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded-md transition-colors disabled:opacity-50"
-                title="Reset all configuration to defaults"
-              >
-                <RotateCcw className="w-3.5 h-3.5" />
-                Reset
-              </button>
+              <Tooltip content="Clear all fields — reverts to defaults when saved">
+                <button
+                  onClick={resetConfig}
+                  disabled={saving}
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded-md transition-colors disabled:opacity-50"
+                >
+                  <RotateCcw className="w-3.5 h-3.5" />
+                  Reset
+                </button>
+              </Tooltip>
               {saveMessage && (
                 <span className={clsx(
                   'text-xs',
@@ -293,6 +295,19 @@ function SectionLabel({ children }: { children: ReactNode }) {
   )
 }
 
+// A titled card grouping related config fields. Cards (vs thin dividers) give the
+// sections clear visual separation in the scroll.
+function ConfigSection({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="rounded-lg border border-theme-border bg-theme-elevated/30 p-4">
+      <h4 className="text-xs font-medium text-theme-text-secondary uppercase tracking-wider mb-3">
+        {title}
+      </h4>
+      <div className="space-y-4">{children}</div>
+    </section>
+  )
+}
+
 // -- Startup Configuration Tab ------------------------------------------------
 
 function StartupConfigTab({
@@ -312,74 +327,76 @@ function StartupConfigTab({
 }) {
   const showBrowserLaunchControls = !isDesktop && deploymentMode === 'local'
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       <p className="text-xs text-theme-text-tertiary">
-        Changes require a restart to take effect.
+        Most changes require a restart to take effect.
         {isDesktop
           ? ' Quit and relaunch Radar to apply.'
           : ' Stop and restart the radar command to apply.'}
       </p>
 
-      <ConfigField
-        label="Kubeconfig"
-        help="Path to kubeconfig file"
-        value={config.kubeconfig ?? ''}
-        effectiveValue={effectiveConfig?.kubeconfig}
-        placeholder="~/.kube/config"
-        onChange={(v) => onChange('kubeconfig', v || undefined)}
-      />
+      <ConfigSection title="Cluster">
+        <ConfigField
+          label="Kubeconfig"
+          help="Path to kubeconfig file"
+          value={config.kubeconfig ?? ''}
+          effectiveValue={effectiveConfig?.kubeconfig}
+          placeholder="~/.kube/config"
+          onChange={(v) => onChange('kubeconfig', v || undefined)}
+        />
 
-      <ConfigArrayField
-        label="Kubeconfig Directories"
-        help="Comma-separated directories containing kubeconfig files"
-        value={config.kubeconfigDirs}
-        effectiveValue={effectiveConfig?.kubeconfigDirs}
-        placeholder="/path/to/dir1, /path/to/dir2"
-        onChange={(v) => onChange('kubeconfigDirs', v)}
-      />
+        <ConfigArrayField
+          label="Kubeconfig Directories"
+          help="Comma-separated directories containing kubeconfig files"
+          value={config.kubeconfigDirs}
+          effectiveValue={effectiveConfig?.kubeconfigDirs}
+          placeholder="/path/to/dir1, /path/to/dir2"
+          onChange={(v) => onChange('kubeconfigDirs', v)}
+        />
 
-      <ConfigField
-        label="Default Namespace"
-        help="Startup default only — change the active namespace live anytime from the header switcher"
-        value={config.namespace ?? ''}
-        effectiveValue={effectiveConfig?.namespace}
-        placeholder="All namespaces"
-        onChange={(v) => onChange('namespace', v || undefined)}
-      />
+        <ConfigField
+          label="Default Namespace"
+          help="Startup default only — change the active namespace live anytime from the header switcher"
+          value={config.namespace ?? ''}
+          effectiveValue={effectiveConfig?.namespace}
+          placeholder="All namespaces"
+          onChange={(v) => onChange('namespace', v || undefined)}
+        />
+      </ConfigSection>
 
-      <ConfigNumberField
-        label="Port"
-        help={isDesktop
-          ? 'Fixed server port (leave empty for random). Set this to keep a stable MCP endpoint.'
-          : 'Server port'}
-        value={config.port}
-        effectiveValue={effectiveConfig?.port}
-        placeholder={isDesktop ? 'Random' : '9280'}
-        onChange={(v) => onChange('port', v)}
-      />
+      <ConfigSection title="Server">
+        <ConfigNumberField
+          label="Port"
+          help={isDesktop
+            ? 'Fixed server port (leave empty for random). Set this to keep a stable MCP endpoint.'
+            : 'Server port'}
+          value={config.port}
+          effectiveValue={effectiveConfig?.port}
+          placeholder={isDesktop ? 'Random' : '9280'}
+          onChange={(v) => onChange('port', v)}
+        />
 
-      {showBrowserLaunchControls && (
-        <>
-          <ConfigToggle
-            label="Open browser on start"
-            value={!(config.noBrowser ?? false)}
-            onChange={(v) => onChange('noBrowser', !v ? true : undefined)}
-          />
+        {showBrowserLaunchControls && (
+          <>
+            <ConfigToggle
+              label="Open browser on start"
+              value={!(config.noBrowser ?? false)}
+              onChange={(v) => onChange('noBrowser', !v ? true : undefined)}
+            />
 
-          <ConfigField
-            label="Browser"
-            help="Browser for automatic launch; macOS app names are supported"
-            value={config.browser ?? ''}
-            effectiveValue={effectiveConfig?.browser}
-            placeholder="System default"
-            onChange={(v) => onChange('browser', v || undefined)}
-          />
-        </>
-      )}
+            <ConfigField
+              label="Browser"
+              help="Browser for automatic launch; macOS app names are supported"
+              value={config.browser ?? ''}
+              effectiveValue={effectiveConfig?.browser}
+              placeholder="System default"
+              onChange={(v) => onChange('browser', v || undefined)}
+            />
+          </>
+        )}
+      </ConfigSection>
 
-      <div className="border-t border-theme-border pt-4 mt-4">
-        <h4 className="text-xs font-medium text-theme-text-secondary uppercase tracking-wider mb-3">AI Tools</h4>
-
+      <ConfigSection title="AI Tools">
         <MCPSection
           mcpEnabled={config.mcp ?? true}
           onToggle={(v) => onChange('mcp', v)}
@@ -387,49 +404,41 @@ function StartupConfigTab({
           portPinned={config.port != null && config.port > 0}
           onPinPort={(port) => onChange('port', port)}
         />
-      </div>
+      </ConfigSection>
 
-      <div className="border-t border-theme-border pt-4 mt-4">
-        <h4 className="text-xs font-medium text-theme-text-secondary uppercase tracking-wider mb-3">Timeline</h4>
-
-        <div className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-theme-text-primary mb-1">
-              Storage Backend
-            </label>
-            <select
-              value={config.timelineStorage ?? 'memory'}
-              onChange={(e) => onChange('timelineStorage', e.target.value === 'memory' ? undefined : e.target.value as 'sqlite')}
-              className="w-full px-3 py-1.5 text-sm bg-theme-elevated border border-theme-border rounded-md text-theme-text-primary focus:outline-none focus:border-skyhook-500"
-            >
-              <option value="memory">Memory (default)</option>
-              <option value="sqlite">SQLite (persistent)</option>
-            </select>
-            <EffectiveHint current={config.timelineStorage} effective={effectiveConfig?.timelineStorage} />
-          </div>
-
-          <ConfigNumberField
-            label="History Limit"
-            help="Maximum events to retain"
-            value={config.historyLimit}
-            effectiveValue={effectiveConfig?.historyLimit}
-            placeholder="10000"
-            onChange={(v) => onChange('historyLimit', v)}
-          />
+      <ConfigSection title="Timeline">
+        <div>
+          <label className="block text-sm font-medium text-theme-text-primary mb-1">
+            Storage Backend
+          </label>
+          <select
+            value={config.timelineStorage ?? 'memory'}
+            onChange={(e) => onChange('timelineStorage', e.target.value === 'memory' ? undefined : e.target.value as 'sqlite')}
+            className="w-full px-3 py-1.5 text-sm bg-theme-elevated border border-theme-border rounded-md text-theme-text-primary focus:outline-none focus:border-skyhook-500"
+          >
+            <option value="memory">Memory (default)</option>
+            <option value="sqlite">SQLite (persistent)</option>
+          </select>
+          <EffectiveHint current={config.timelineStorage} effective={effectiveConfig?.timelineStorage} />
         </div>
-      </div>
 
-      <div className="border-t border-theme-border pt-4 mt-4">
-        <h4 className="text-xs font-medium text-theme-text-secondary uppercase tracking-wider mb-3">Integrations</h4>
+        <ConfigNumberField
+          label="History Limit"
+          help="Maximum events to retain"
+          value={config.historyLimit}
+          effectiveValue={effectiveConfig?.historyLimit}
+          placeholder="10000"
+          onChange={(v) => onChange('historyLimit', v)}
+        />
+      </ConfigSection>
 
-        <div className="space-y-4">
-          <PrometheusConfigField
-            value={config.prometheusUrl ?? ''}
-            configuredHeaderKeys={prometheusHeaderKeys}
-            onChange={(v) => onChange('prometheusUrl', v || undefined)}
-          />
-        </div>
-      </div>
+      <ConfigSection title="Integrations">
+        <PrometheusConfigField
+          value={config.prometheusUrl ?? ''}
+          configuredHeaderKeys={prometheusHeaderKeys}
+          onChange={(v) => onChange('prometheusUrl', v || undefined)}
+        />
+      </ConfigSection>
     </div>
   )
 }
@@ -467,7 +476,7 @@ function MCPSection({
   return (
     <div className="space-y-3">
       <ConfigToggle
-        label="MCP Server (AI tools)"
+        label="MCP Server"
         value={mcpEnabled}
         onChange={onToggle}
       />
@@ -480,13 +489,14 @@ function MCPSection({
               <code className="flex-1 px-2.5 py-1.5 text-xs font-mono bg-theme-elevated border border-theme-border rounded-md text-theme-text-primary truncate">
                 {mcpUrl}
               </code>
-              <button
-                onClick={handleCopy}
-                className="shrink-0 p-1.5 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-elevated rounded-md transition-colors"
-                title="Copy MCP URL"
-              >
-                {copied ? <Check className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5" />}
-              </button>
+              <Tooltip content="Copy MCP URL" wrapperClassName="shrink-0">
+                <button
+                  onClick={handleCopy}
+                  className="p-1.5 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-elevated rounded-md transition-colors"
+                >
+                  {copied ? <Check className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5" />}
+                </button>
+              </Tooltip>
             </div>
           </div>
 
@@ -614,17 +624,18 @@ function PrometheusConfigField({
           placeholder="http://prometheus-server.monitoring:9090"
           className="flex-1 min-w-0 px-3 py-1.5 text-sm bg-theme-elevated border border-theme-border rounded-md text-theme-text-primary placeholder:text-theme-text-tertiary focus:outline-none focus:border-skyhook-500"
         />
-        <button
-          onClick={handleApply}
-          disabled={apply.status === 'applying'}
-          className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated border border-theme-border rounded-md transition-colors disabled:opacity-50"
-          title="Apply this URL to the running server now — no restart"
-        >
-          {apply.status === 'applying'
-            ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
-            : <Plug className="w-3.5 h-3.5" />}
-          Apply now
-        </button>
+        <Tooltip content="Apply this URL to the running server now — no restart" wrapperClassName="shrink-0">
+          <button
+            onClick={handleApply}
+            disabled={apply.status === 'applying'}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated border border-theme-border rounded-md transition-colors disabled:opacity-50"
+          >
+            {apply.status === 'applying'
+              ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              : <Plug className="w-3.5 h-3.5" />}
+            Apply now
+          </button>
+        </Tooltip>
       </div>
       {apply.status === 'connected' ? (
         <p className="mt-1 flex items-center gap-1 text-xs text-green-600 dark:text-green-400/80">
@@ -685,13 +696,14 @@ function PrometheusConfigField({
                   placeholder="Value (e.g. Bearer …)"
                   className="flex-1 min-w-0 px-2.5 py-1.5 text-xs bg-theme-base border border-theme-border rounded-md text-theme-text-primary placeholder:text-theme-text-tertiary focus:outline-none focus:border-skyhook-500"
                 />
-                <button
-                  onClick={() => setHeaderRows((rows) => rows!.filter((_, j) => j !== i))}
-                  className="shrink-0 p-1 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-hover rounded"
-                  title="Remove header"
-                >
-                  <X className="w-3.5 h-3.5" />
-                </button>
+                <Tooltip content="Remove header" wrapperClassName="shrink-0">
+                  <button
+                    onClick={() => setHeaderRows((rows) => rows!.filter((_, j) => j !== i))}
+                    className="p-1 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-hover rounded"
+                  >
+                    <X className="w-3.5 h-3.5" />
+                  </button>
+                </Tooltip>
               </div>
             ))}
             <div className="flex items-center justify-between gap-2">
@@ -709,8 +721,8 @@ function PrometheusConfigField({
               </button>
             </div>
             <p className="text-xs text-theme-text-tertiary">
-              Applied with the URL above. Replaces all stored headers — values are
-              write-only, so re-enter any you want to keep.
+              Saved when you click Apply now. Replaces all stored headers — existing
+              values are hidden, so re-enter any you want to keep.
             </p>
           </div>
         )}


### PR DESCRIPTION
## Summary

Cleans up the Settings dialog and removes a sharp edge: it's effectively a startup-config editor — almost every field is read once at launch and inert until restart — but the layout didn't say so, its most valuable control sat last, and the one field that *can* take effect immediately (the Prometheus URL) forced a needless restart loop. This makes the next-launch reality visible at the moment you save, surfaces the AI Tools config, and lets the Prometheus connection — URL **and** auth headers — apply live with inline reachability feedback.

## What changed

**Layout & comprehension**
- **Config grouped into bordered card sections** — Cluster / Server / AI Tools / Timeline / Integrations — for clear visual separation (replacing thin dividers), in a slightly wider dialog so fields and the header editor have room. Dialog tooltips route through the shared `Tooltip` for consistent styling.
- **Version moved into the header** (`Radar v… · by Skyhook`), baseline-aligned beside the title. The old bottom "About" bar (and its redundant GitHub link) is gone; the version is now visible to non-owners too.
- **Persistent "Applies on next launch" cue beside Save** — the dialog's dominant fact, previously small text that scrolled away, now sits at the decision point.
- **MCP promoted to its own "AI Tools" section near the top**, where the port it depends on is already configured (was buried last under Integrations).
- Input/select focus borders moved to the brand `skyhook-500` token; footer padding trimmed.

**Apply the Prometheus connection live (no restart)**
- Unlike the rest of config, the Prometheus URL + headers live in mutable globals the metrics path reads per query — so they can be re-pointed at runtime, which is exactly when operators touch them (empty metrics/cost maps otherwise mean restart-to-test).
- New **`PUT /api/integrations/prometheus`**: validates the URL (rejects anything startup would `log.Fatalf` on, so Apply can't brick the next launch), persists URL + headers, re-points the running client (`SetManualURL`/`SetHeaders` + `Reset()` to drop the cached connection), then probes and returns the live reachability result. Empty URL reverts to auto-discovery.
- **Auth headers** for token / multi-tenant backends (Bearer, `X-Scope-OrgID` — Mimir/Cortex/Thanos): an inline key/value editor with password-masked values. Values are write-only — `GET /config` returns only the configured header *names* (`prometheusHeaderKeys`), never the values — so the editor replaces all headers on apply rather than pretending to round-trip secrets.
- Field shows live status (`Connected to X` / `Saved, but not reachable` / `Couldn't apply`) and opts out of the next-launch framing since it genuinely applies immediately.

**Namespace clarifier**
- "Default Namespace" help now notes it's the startup default only and the active namespace is live-switchable from the header — so users don't restart needlessly. (No behavior change.)

### Reviewer notes
- Live-apply re-points the **shared** Prometheus client, so **Istio** mesh traffic (which uses it) and resource-utilization/cost go live immediately. **Cilium/Hubble** traffic uses Hubble Relay (gRPC), not Prometheus — unaffected. The legacy Caretta source caches its own endpoint and updates on restart; it's slated for deprecation.
- The other restart-only fields (kubeconfig, port, timeline, MCP toggle) stay next-launch by design — captured into closures/singletons/the immutable router at boot, and for a local binary a restart is cheap.
- Concurrency: the runtime writers are lock-correct — `SetManualURL` writes under `c.mu` (matching `SetHeaders`/discovery reads), and the `traffic` metrics-config globals are mutex-guarded against the context-switch rebuild. Verified with `go test -race`.
- SSRF: the endpoint is owner-gated; in no-auth mode the whole instance is already an unauthenticated console, so an owner-issued probe isn't the weak link (consistent with the existing config-set path). Accepted deliberately.

## Testing

- `make tsc`, `go build ./...`, `go test -race ./internal/server/ ./internal/prometheus/ ./internal/traffic/` — all clean.
- Visual-tested against a live cluster (light + dark): card sections, wider dialog, header version, footer cue, AI Tools section, namespace help, custom tooltips.
- Exercised the live apply end-to-end: applying URL + `X-Scope-OrgID` header persisted both and returned the probe result; `GET /config` exposed the header *key* with the value redacted; clearing reverted config to `{}`; an invalid URL returned 400 without persisting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Owner-gated endpoint mutates shared Prometheus/traffic globals and persists secrets; concurrency is mutex-guarded but the live HTTP probe to operator-supplied URLs is an intentional SSRF surface consistent with existing config paths.
> 
> **Overview**
> Adds **live Prometheus reconfiguration** so owners can persist and apply URL and auth headers without restarting, plus a clearer Settings layout.
> 
> **Backend:** New owner-gated `PUT /api/integrations/prometheus` validates HTTP(S) URLs, writes config first, updates the running Prometheus and traffic metrics globals, resets the cached client, and returns a probe result. `GET /api/config` exposes `prometheusHeaderKeys` only (values stay redacted). Context-switch Prometheus reinit no longer reapplies startup URL/headers, so live changes survive switches. `SetManualURL` / `SetHeaders` and traffic metrics config use mutexes for safe concurrent updates.
> 
> **UI:** Settings uses bordered sections (Cluster, Server, AI Tools, Timeline, Integrations), a wider dialog, version in the header, and an “Applies on next launch” hint beside Save. Prometheus gets **Apply now** with inline connected/unreachable feedback and an optional auth-header editor that replaces stored headers on apply without round-tripping secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10e0e35f5b3183162b56f4f1f53b8db4681a4f0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->