### PR TITLE
docs: correct stale cluster-scoped RBAC gating description

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -11,7 +11,7 @@ User → [Auth Layer] → Radar Backend → K8s API (as user, via impersonation)
 ```
 
 1. **Authentication** identifies the user (proxy headers or OIDC login)
-2. **Reads** are filtered by namespace — Radar discovers which namespaces the user can access via `SubjectAccessReview` and only returns resources from those namespaces. Cluster-scoped resources (Nodes, ClusterRoles when `rbac.viewRBAC` is on, StorageClasses, etc.) are served from the ServiceAccount-populated informer cache without per-user RBAC re-checks, so anyone reaching Radar's API sees them regardless of their own K8s permissions on those kinds.
+2. **Reads** are filtered by namespace — Radar discovers which namespaces the user can access via `SubjectAccessReview` and only returns resources from those namespaces. Cluster-scoped resources (Nodes, PersistentVolumes, StorageClasses, ClusterRoles when `rbac.viewRBAC` is on, cluster-scoped CRDs, etc.) have no namespace to filter on, so they are gated per-kind via `SubjectAccessReview`: a user sees them only if their own RBAC permits listing that kind. Cluster-wide pod visibility does **not** imply Node/PV visibility — each cluster-scoped read goes through its own check.
 3. **Writes** use K8s impersonation — Radar makes the K8s API call as the authenticated user, so K8s RBAC decides whether it's allowed
 4. **UI adapts** — capability checks run per-user, so buttons (exec, restart, scale, Helm) only appear if the user has permission
 
@@ -349,7 +349,7 @@ When auth is enabled:
 - A **username** appears in the Radar header with a logout option
 - The **namespace selector** only shows namespaces the user can access
 - **Topology, resources, events, dashboard** are filtered to accessible namespaces
-- **Cluster-scoped resources** (Nodes, PersistentVolumes, StorageClasses) are currently visible to all authenticated users regardless of namespace permissions — per-resource SAR checks for these are planned for a future release
+- **Cluster-scoped resources** (Nodes, PersistentVolumes, StorageClasses) are gated per-kind via `SubjectAccessReview` — a user sees them only if their own RBAC permits listing that kind, independent of namespace access
 - **Helm releases** are visible to all authenticated users (reads use the ServiceAccount, not impersonation, because the K8s `view` role doesn't include `list secrets` which Helm requires). Write operations (install, upgrade, rollback, uninstall) are impersonated and require the user to have appropriate RBAC.
 - **Write buttons** (restart, scale, exec, Helm install, etc.) only appear if the user has permission
 - Write operations return **403** from K8s if RBAC denies them (shown as an error toast)


### PR DESCRIPTION
Part of a 3-repo **RBAC docs/copy accuracy** pass (siblings in radar-docs + radar-hub-web).

`authentication.md` claimed cluster-scoped resources (Nodes, PVs, StorageClasses) are served without per-user RBAC re-checks — *visible to all authenticated users* — with per-resource SAR "planned for a future release."

That gating **already ships**: `preflightResourceList` (`internal/server/server.go:1185`) denies cluster-scoped `list` via `canRead` SAR before serving, and `handleListResources` calls it. Verified live (cloud:owner is denied `list nodes`). Corrected both spots to the SAR-gated reality.

Docs-only; no code or RBAC-posture change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no code or authorization behavior changes.
> 
> **Overview**
> Updates **`docs/authentication.md`** so it matches current behavior: cluster-scoped kinds (Nodes, PVs, StorageClasses, cluster CRDs, etc.) are **not** visible to every authenticated user from the shared cache.
> 
> In **How It Works**, the read path now states that these resources are **gated per-kind with `SubjectAccessReview`**, with no namespace to filter on, and that **namespace/pod access does not imply** Node or PV visibility.
> 
> In **What Users See**, the bullet replaces the old “visible to all / SAR planned” wording with the same **per-kind SAR** model—users only see cluster-scoped lists when their own RBAC allows listing that kind.
> 
> **Docs-only**; no runtime or RBAC posture change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f2d8e3dd120b793e87e8dc3075cfbe492064ae3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->