### PR TITLE
feat(rbac): surface denied core cluster-scoped kinds instead of '0 / No X found'

### DIFF
--- a/internal/server/resource_counts.go
+++ b/internal/server/resource_counts.go
@@ -77,7 +77,14 @@ func (s *Server) handleResourceCounts(w http.ResponseWriter, r *http.Request) {
 		// per-user via SAR before counting.
 		if k8s.IsClusterOnlyKind(kl.Kind()) {
 			group, resource, ok := k8s.ClusterOnlyKindGVR(kl.Kind())
-			if !ok || !s.canRead(r, group, resource, "", "list") {
+			if !ok {
+				continue
+			}
+			// A core cluster-scoped kind always exists, so an RBAC denial is
+			// surfaced as forbidden rather than silently omitted — otherwise the
+			// UI shows "0 / No X found", indistinguishable from an empty cluster.
+			if !s.canRead(r, group, resource, "", "list") {
+				forbidden = append(forbidden, kl.CountKey())
 				continue
 			}
 		}

--- a/internal/server/resource_counts_test.go
+++ b/internal/server/resource_counts_test.go
@@ -134,6 +134,34 @@ func TestResourceCountsOmitsClusterScopedCRDWhenCanReadDenies(t *testing.T) {
 	}
 }
 
+func TestResourceCountsSurfacesDeniedCoreClusterScopedKindAsForbidden(t *testing.T) {
+	// A core cluster-scoped kind (Node) always exists, so an RBAC denial must be
+	// surfaced as forbidden — not silently omitted, which would render as
+	// "0 / No Node found", indistinguishable from an empty cluster.
+	s := newAuthServer(auth.Config{Mode: "proxy"})
+	user := &auth.User{Username: "alice"}
+	perms := &auth.UserPermissions{AllowedNamespaces: nil}
+	perms.SetCanI("list", "", "nodes", "", false)
+	s.permCache.Set(user.Username, perms)
+	req := requestWithUser(http.MethodGet, "/api/resource-counts", user)
+
+	rec := httptest.NewRecorder()
+	s.handleResourceCounts(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body: %s", rec.Code, rec.Body.String())
+	}
+	var body ResourceCountsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if _, ok := body.Counts["Node"]; ok {
+		t.Fatalf("denied Node leaked a count: %v", body.Counts["Node"])
+	}
+	if !containsString(body.Forbidden, "Node") {
+		t.Fatalf("denied core cluster-scoped Node should be in forbidden, got: %v", body.Forbidden)
+	}
+}
+
 func TestResourceCountsCountsClusterScopedCRDDespiteNamespaceFilter(t *testing.T) {
 	nodePoolGVR := schema.GroupVersionResource{Group: "karpenter.sh", Version: "v1", Resource: "nodepools"}
 	endpointSliceGVR := schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"}


### PR DESCRIPTION
## What
When a user's RBAC denies listing a **core cluster-scoped** kind (Node, PV, StorageClass, Namespace…), `handleResourceCounts` silently `continue`d — omitting the kind from both `counts` and `forbidden`. Core kinds are static in the sidebar, so they rendered as **`0` / "No Node found"** — indistinguishable from an empty cluster (the exact symptom a Hub owner hit on a cluster where their tier lacks cluster-scoped read).

## Change
`internal/server/resource_counts.go`: on `canRead` denial for a core cluster-scoped kind, add it to the existing `forbidden` set instead of dropping it. The frontend already renders an **"Access Restricted"** state + sidebar shield from `forbidden` (`ResourcesView.tsx`), so this lights up with no frontend change. CRDs keep the silent-omit behavior (a denied CRD is ambiguous with not-installed).

## Test
`TestResourceCountsSurfacesDeniedCoreClusterScopedKindAsForbidden` — denies `list nodes`, asserts Node is in `forbidden` and absent from `counts`. Existing `TestResourceCountsOmitsClusterScopedCRDWhenCanReadDenies` (CRD path unchanged) still passes.

Part of the cluster-scoped RBAC visibility work; no RBAC-posture change — read-authorization behavior is unchanged, only how a denial is reported.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reporting-only change for denied core cluster-scoped counts; authorization checks are unchanged and CRD behavior is untouched.
> 
> **Overview**
> When RBAC denies **list** on a **core cluster-scoped** kind (Node, PV, etc.), `handleResourceCounts` now adds that kind to **`forbidden`** instead of omitting it from the response. That stops the sidebar from showing **0 / “No X found”**, which looked like an empty cluster rather than an access denial; the UI already treats **`forbidden`** as “Access Restricted.”
> 
> **Cluster-scoped CRDs** still skip silently on denial (unchanged), since a denied CRD is ambiguous with not installed. A new test denies `list nodes` and asserts **Node** is in **`forbidden`** and absent from **`counts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d19a5f01d9c8b5ebc63b22b9f1c9c4744494b10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->