### PR TITLE
refactor(web): replace native title attributes with themed Tooltip

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1307,14 +1307,15 @@ function AppInner() {
                 </span>
               )}
               {!connected && (
+                <Tooltip content="Reconnect">
                 <button
                   onClick={reconnect}
                   disabled={isReconnecting}
-                  className="p-1 text-theme-text-secondary hover:text-theme-text-primary disabled:opacity-50"
-                  title="Reconnect"
+                  className="p-1 text-theme-text-secondary hover:text-theme-text-primary disabled:opacity-50 disabled:pointer-events-none"
                 >
                   <RefreshCw className={`w-3 h-3 ${isReconnecting ? 'animate-spin' : ''}`} />
                 </button>
+                </Tooltip>
               )}
             </div>
             {/* Port forwards indicator — shown only when sessions exist */}
@@ -1433,13 +1434,14 @@ function AppInner() {
 
           {/* Local terminal */}
           {capabilities.localTerminal && (
+            <Tooltip content="Open local terminal">
             <button
               onClick={() => openLocalTerminal()}
               className="p-1.5 rounded-md bg-theme-elevated hover:bg-theme-hover text-theme-text-secondary hover:text-theme-text-primary transition-colors"
-              title="Open local terminal"
             >
               <SquareTerminal className="w-4 h-4" />
             </button>
+            </Tooltip>
           )}
 
           {/* Theme toggle — hidden in embedded mode. Host apps (e.g. Radar
@@ -1459,20 +1461,22 @@ function AppInner() {
               old floating bottom-right pair. Settings moved to the rail bottom. */}
           {showNavRail && (
             <>
+              <Tooltip content="Keyboard shortcuts (?)">
               <button
                 onClick={() => setShowHelp(true)}
                 className="p-1.5 rounded-md bg-theme-elevated hover:bg-theme-hover text-theme-text-secondary hover:text-theme-text-primary transition-colors"
-                title="Keyboard shortcuts (?)"
               >
                 <HelpCircle className="w-4 h-4" />
               </button>
+              </Tooltip>
+              <Tooltip content="Report a bug / Diagnostics">
               <button
                 onClick={() => setShowDiagnostics(true)}
                 className="p-1.5 rounded-md bg-theme-elevated hover:bg-theme-hover text-theme-text-secondary hover:text-theme-text-primary transition-colors"
-                title="Report a bug / Diagnostics"
               >
                 <Bug className="w-4 h-4" />
               </button>
+              </Tooltip>
             </>
           )}
 
@@ -2243,10 +2247,10 @@ function ThemeToggle() {
   const { theme, toggleTheme } = useTheme()
 
   return (
+    <Tooltip content={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}>
     <button
       onClick={toggleTheme}
       className="p-1.5 rounded-md bg-theme-elevated hover:bg-theme-hover text-theme-text-secondary hover:text-theme-text-primary transition-colors"
-      title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
     >
       {theme === 'dark' ? (
         <Sun className="w-4 h-4" />
@@ -2254,6 +2258,7 @@ function ThemeToggle() {
         <Moon className="w-4 h-4" />
       )}
     </button>
+    </Tooltip>
   )
 }
 

--- a/web/src/components/ConnectionErrorView.tsx
+++ b/web/src/components/ConnectionErrorView.tsx
@@ -5,6 +5,7 @@ import { ContextSwitcher } from './ContextSwitcher'
 import { parseContextName } from '../utils/context-name'
 import { useOpenLocalTerminal, ClusterName } from '@skyhook-io/k8s-ui'
 import { useAuthMe } from '../api/client'
+import { Tooltip } from './ui/Tooltip'
 
 interface ConnectionErrorViewProps {
   connection: ConnectionState
@@ -137,18 +138,19 @@ function CopyableCommand({ command, onRunInTerminal }: { command: string; onRunI
         {command}
       </code>
       {onRunInTerminal && (
+        <Tooltip content="Run in terminal">
         <button
           onClick={() => onRunInTerminal(command)}
           className="shrink-0 text-theme-text-tertiary hover:text-theme-text-secondary transition-colors"
-          title="Run in terminal"
         >
           <TerminalSquare className="w-3.5 h-3.5" />
         </button>
+        </Tooltip>
       )}
+      <Tooltip content="Copy to clipboard">
       <button
         onClick={handleCopy}
         className="shrink-0 text-theme-text-tertiary hover:text-theme-text-secondary transition-colors"
-        title="Copy to clipboard"
       >
         {copied ? (
           <Check className="w-3.5 h-3.5 text-green-400" />
@@ -156,6 +158,7 @@ function CopyableCommand({ command, onRunInTerminal }: { command: string; onRunI
           <Copy className="w-3.5 h-3.5" />
         )}
       </button>
+      </Tooltip>
     </div>
   )
 }

--- a/web/src/components/ConnectionErrorView.tsx
+++ b/web/src/components/ConnectionErrorView.tsx
@@ -138,7 +138,7 @@ function CopyableCommand({ command, onRunInTerminal }: { command: string; onRunI
         {command}
       </code>
       {onRunInTerminal && (
-        <Tooltip content="Run in terminal">
+        <Tooltip content="Run in terminal" wrapperClassName="shrink-0">
         <button
           onClick={() => onRunInTerminal(command)}
           className="shrink-0 text-theme-text-tertiary hover:text-theme-text-secondary transition-colors"
@@ -147,7 +147,7 @@ function CopyableCommand({ command, onRunInTerminal }: { command: string; onRunI
         </button>
         </Tooltip>
       )}
-      <Tooltip content="Copy to clipboard">
+      <Tooltip content="Copy to clipboard" wrapperClassName="shrink-0">
       <button
         onClick={handleCopy}
         className="shrink-0 text-theme-text-tertiary hover:text-theme-text-secondary transition-colors"

--- a/web/src/components/DebugOverlay.tsx
+++ b/web/src/components/DebugOverlay.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Bug, X, ChevronDown, ChevronUp } from 'lucide-react'
 import { useRuntimeStats } from '../api/client'
+import { Tooltip } from './ui/Tooltip'
 
 function formatUptime(seconds: number): string {
   if (seconds < 60) return `${seconds}s`
@@ -17,13 +18,14 @@ export function DebugOverlay() {
 
   if (!visible) {
     return (
+      <Tooltip content="Show debug stats">
       <button
         onClick={() => setVisible(true)}
         className="fixed bottom-3 right-3 z-50 p-2 bg-theme-surface/90 border border-theme-border rounded-lg text-theme-text-tertiary hover:text-theme-text-secondary transition-colors"
-        title="Show debug stats"
       >
         <Bug className="w-4 h-4" />
       </button>
+      </Tooltip>
     )
   }
 

--- a/web/src/components/DebugOverlay.tsx
+++ b/web/src/components/DebugOverlay.tsx
@@ -18,10 +18,10 @@ export function DebugOverlay() {
 
   if (!visible) {
     return (
-      <Tooltip content="Show debug stats">
+      <Tooltip content="Show debug stats" position="left" wrapperClassName="fixed bottom-3 right-3 z-50">
       <button
         onClick={() => setVisible(true)}
-        className="fixed bottom-3 right-3 z-50 p-2 bg-theme-surface/90 border border-theme-border rounded-lg text-theme-text-tertiary hover:text-theme-text-secondary transition-colors"
+        className="p-2 bg-theme-surface/90 border border-theme-border rounded-lg text-theme-text-tertiary hover:text-theme-text-secondary transition-colors"
       >
         <Bug className="w-4 h-4" />
       </button>

--- a/web/src/components/UserMenu.tsx
+++ b/web/src/components/UserMenu.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from 'react'
 import { User, LogOut } from 'lucide-react'
 import { clsx } from 'clsx'
 import { useAuthMe } from '../api/client'
+import { Tooltip } from './ui/Tooltip'
 import { useQueryClient } from '@tanstack/react-query'
 
 interface UserMenuProps {
@@ -67,9 +68,9 @@ export function UserMenu({ variant = 'topbar', pinned = true }: UserMenuProps = 
   return (
     <div ref={menuRef} className={clsx('relative', isRail && 'group/item', isRail && !pinned && 'w-10')}>
       {isRail ? (
+        <Tooltip content={authMe.username} position="right" wrapperClassName="!block w-full">
         <button
           onClick={() => setIsOpen(!isOpen)}
-          title={authMe.username}
           className={clsx(
             'relative flex h-9 w-full items-center rounded-md text-sm font-medium text-theme-text-secondary hover:bg-theme-hover hover:text-theme-text-primary transition-colors',
             !pinned && 'max-w-10 overflow-hidden',
@@ -78,14 +79,16 @@ export function UserMenu({ variant = 'topbar', pinned = true }: UserMenuProps = 
           <span className="flex w-10 shrink-0 items-center justify-center">{avatar}</span>
           <span className={clsx('pr-3 truncate', !pinned && 'opacity-0')}>{authMe.username.split('@')[0]}</span>
         </button>
+        </Tooltip>
       ) : (
+        <Tooltip content={authMe.username}>
         <button
           onClick={() => setIsOpen(!isOpen)}
           className="w-7 h-7 rounded-full bg-blue-500/15 text-blue-500 flex items-center justify-center text-xs font-medium hover:bg-blue-500/25 transition-colors"
-          title={authMe.username}
         >
           {initials || <User className="w-3.5 h-3.5" />}
         </button>
+        </Tooltip>
       )}
 
       {/* Slim-rail fly-out label (account row, collapsed) */}

--- a/web/src/components/audit/AuditSettingsDialog.tsx
+++ b/web/src/components/audit/AuditSettingsDialog.tsx
@@ -4,6 +4,7 @@ import { clsx } from 'clsx'
 import { useAuditSettings, useUpdateAuditSettings, useAudit, useCloudRole } from '../../api/client'
 import type { CheckMeta } from '@skyhook-io/k8s-ui'
 import { validateRFC1123Label, type ValidationResult } from '@skyhook-io/k8s-ui/utils/validators'
+import { Tooltip } from '../ui/Tooltip'
 
 interface AuditSettingsDialogProps {
   namespaces: string[]
@@ -192,6 +193,17 @@ export function AuditSettingsDialog({ namespaces, onClose }: AuditSettingsDialog
           >
             Cancel
           </button>
+          <Tooltip
+            content={
+              !canEdit
+                ? 'Audit settings can only be changed by owners'
+                : newNsError
+                  ? 'Fix or clear the pending namespace input before saving'
+                  : newNsDuplicate
+                    ? 'Clear the duplicate pending input before saving'
+                    : ''
+            }
+          >
           <button
             onClick={handleSave}
             // Block save while the namespace input has unfixed pending
@@ -200,19 +212,11 @@ export function AuditSettingsDialog({ namespaces, onClose }: AuditSettingsDialog
             disabled={
               !canEdit || updateSettings.isPending || newNsError !== null || newNsDuplicate
             }
-            title={
-              !canEdit
-                ? 'Audit settings can only be changed by owners'
-                : newNsError
-                  ? 'Fix or clear the pending namespace input before saving'
-                  : newNsDuplicate
-                    ? 'Clear the duplicate pending input before saving'
-                    : undefined
-            }
-            className="px-4 py-1.5 text-sm btn-brand rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
+            className="px-4 py-1.5 text-sm btn-brand rounded-lg disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
           >
             {updateSettings.isPending ? 'Saving...' : 'Save'}
           </button>
+          </Tooltip>
         </div>
       </div>
     </div>

--- a/web/src/components/audit/AuditView.tsx
+++ b/web/src/components/audit/AuditView.tsx
@@ -4,6 +4,7 @@ import type { SelectedResource } from '../../types'
 import { ChecksView, PaneLoader, PageHeader, type CheckResourceRef } from '@skyhook-io/k8s-ui'
 import { ShieldCheck, Settings } from 'lucide-react'
 import { AuditSettingsDialog } from './AuditSettingsDialog'
+import { Tooltip } from '../ui/Tooltip'
 
 interface AuditViewProps {
   namespaces: string[]
@@ -82,13 +83,14 @@ export function AuditView({ namespaces, onNavigateToResource }: AuditViewProps) 
             {ignoredCount > 0 && (
               <button onClick={() => setShowSettings(true)} className="text-xs text-theme-text-tertiary hover:text-theme-text-secondary transition-colors">{ignoredCount} {ignoredCount === 1 ? 'namespace' : 'namespaces'} hidden</button>
             )}
+            <Tooltip content="Checks settings">
             <button
               onClick={() => setShowSettings(true)}
               className="p-2 rounded-lg hover:bg-theme-hover text-theme-text-tertiary hover:text-theme-text-secondary transition-colors"
-              title="Checks settings"
             >
               <Settings className="w-4 h-4" />
             </button>
+            </Tooltip>
           </>
         }
       />

--- a/web/src/components/cost/CostView.tsx
+++ b/web/src/components/cost/CostView.tsx
@@ -4,6 +4,7 @@ import type { OpenCostNamespaceCost, OpenCostWorkloadCost, OpenCostNodeCost } fr
 import { ArrowLeft, ChevronDown, ChevronRight, DollarSign, HelpCircle, Loader2, Server, X } from 'lucide-react'
 import { PaneLoader } from '@skyhook-io/k8s-ui'
 import { CostTrendChart } from './CostTrendChart'
+import { Tooltip } from '../ui/Tooltip'
 
 interface CostViewProps {
   onBack: () => void
@@ -177,8 +178,12 @@ export function CostView({ onBack }: CostViewProps) {
           <div className="grid grid-cols-[minmax(180px,1fr)_90px_90px_80px_minmax(160px,1fr)_120px] gap-2 px-4 py-2 border-b border-theme-border text-[11px] font-medium text-theme-text-tertiary uppercase tracking-wider">
             <span>Namespace</span>
             <span className="text-right">Hourly</span>
-            <span className="text-right cursor-help" title="Projected from current hourly rate — not historical spend">Monthly*</span>
-            <span className="text-right cursor-help" title="% of reserved resources actually being used, weighted by cost">Efficiency</span>
+            <Tooltip content="Projected from current hourly rate — not historical spend" wrapperClassName="!block text-right">
+            <span className="cursor-help">Monthly*</span>
+            </Tooltip>
+            <Tooltip content="% of reserved resources actually being used, weighted by cost" wrapperClassName="!block text-right">
+            <span className="cursor-help">Efficiency</span>
+            </Tooltip>
             <span>CPU / Memory</span>
             <span className="text-right">Cost Split</span>
           </div>
@@ -368,7 +373,9 @@ function NodeCostTable({ nodes }: { nodes: OpenCostNodeCost[] }) {
         <span>Node</span>
         <span>Instance Type</span>
         <span className="text-right">Hourly</span>
-        <span className="text-right cursor-help" title="Projected from current hourly rate — not historical spend">Monthly*</span>
+        <Tooltip content="Projected from current hourly rate — not historical spend" wrapperClassName="!block text-right">
+        <span className="cursor-help">Monthly*</span>
+        </Tooltip>
         <span className="text-right">CPU / Memory</span>
       </div>
 
@@ -387,9 +394,11 @@ function NodeCostRow({ node }: { node: OpenCostNodeCost }) {
 
   return (
     <div className="grid grid-cols-[minmax(200px,1fr)_minmax(120px,1fr)_90px_100px_140px] gap-2 px-4 py-2.5">
-      <span className="text-sm text-theme-text-primary truncate font-medium" title={node.name}>
+      <Tooltip content={node.name} wrapperClassName="!block min-w-0">
+      <span className="text-sm text-theme-text-primary truncate font-medium block">
         {node.name}
       </span>
+      </Tooltip>
       <span className="text-xs text-theme-text-secondary truncate">
         {node.instanceType || '-'}
         {node.region && <span className="text-theme-text-quaternary ml-1.5">({node.region})</span>}

--- a/web/src/components/helm/ChartBrowser.tsx
+++ b/web/src/components/helm/ChartBrowser.tsx
@@ -316,15 +316,16 @@ export function ChartBrowser({ onChartSelect }: ChartBrowserProps) {
                 ) : (
                   <div className="text-sm mt-1 flex flex-col items-center gap-2">
                     <p>Your repositories may be out of date.</p>
+                    <Tooltip content={canHelmWrite ? 'Run helm repo update on every configured repository' : helmWriteReason}>
                     <button
                       onClick={handleUpdateAllRepos}
                       disabled={isBatchUpdating || !canHelmWrite}
-                      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs btn-brand rounded disabled:opacity-50"
-                      title={canHelmWrite ? 'Run helm repo update on every configured repository' : helmWriteReason}
+                      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs btn-brand rounded disabled:opacity-50 disabled:pointer-events-none"
                     >
                       <RefreshCw className={`w-3.5 h-3.5 ${isBatchUpdating ? 'animate-spin' : ''}`} />
                       {isBatchUpdating ? 'Updating…' : 'Update all repositories'}
                     </button>
+                    </Tooltip>
                     <button
                       onClick={() => setChartSource('artifacthub')}
                       className="text-xs text-blue-400 hover:underline"
@@ -436,14 +437,15 @@ function RepoDropdownItem({ repo, isSelected, onSelect, onUpdate, isUpdating, ca
           </span>
         )}
       </button>
+      <Tooltip content={canUpdate ? "Update repository" : (cantUpdateReason ?? "Helm write permissions required")}>
       <button
         onClick={(e) => { e.stopPropagation(); onUpdate() }}
         disabled={isUpdating || !canUpdate}
-        className="p-1 text-theme-text-tertiary hover:text-theme-text-primary opacity-0 group-hover:opacity-100 transition-opacity disabled:opacity-50"
-        title={canUpdate ? "Update repository" : (cantUpdateReason ?? "Helm write permissions required")}
+        className="p-1 text-theme-text-tertiary hover:text-theme-text-primary opacity-0 group-hover:opacity-100 transition-opacity disabled:opacity-50 disabled:pointer-events-none"
       >
         <RefreshCw className={clsx('w-3.5 h-3.5', isUpdating && 'animate-spin')} />
       </button>
+      </Tooltip>
     </div>
   )
 }

--- a/web/src/components/helm/HelmReleaseDrawer.tsx
+++ b/web/src/components/helm/HelmReleaseDrawer.tsx
@@ -10,6 +10,7 @@ import { clsx } from 'clsx'
 import { useHelmRelease, useHelmManifest, useHelmValues, useHelmManifestDiff, useHelmUpgradeInfo, useHelmUninstall, upgradeWithProgress, rollbackWithProgress } from '../../api/client'
 import { useQueryClient } from '@tanstack/react-query'
 import { ConfirmDialog } from '../ui/ConfirmDialog'
+import { Tooltip } from '../ui/Tooltip'
 import { Markdown } from '../ui/Markdown'
 import type { SelectedHelmRelease, HelmHook, ChartDependency } from '../../types'
 import type { NavigateToResource } from '../../utils/navigation'
@@ -334,63 +335,72 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
                 checking...
               </span>
             ) : upgradeError ? (
+              <Tooltip content={upgradeErrorMessage ?? ''}>
               <span
                 className="badge bg-theme-hover/50 text-theme-text-secondary"
-                title={upgradeErrorMessage}
               >
                 upgrade check failed
               </span>
+              </Tooltip>
             ) : upgradeInfo?.updateAvailable ? (
+              <Tooltip content={canHelmWrite ? `Click to upgrade: ${upgradeInfo.currentVersion} → ${upgradeInfo.latestVersion}${upgradeInfo.repositoryName ? ` (${upgradeInfo.repositoryName})` : ''}` : helmActReason}>
               <button
                 onClick={() => setShowUpgradeConfirm(true)}
                 disabled={!canHelmWrite}
                 className={clsx(
-                  'badge transition-colors', SEVERITY_BADGE.warning,
+                  'badge transition-colors disabled:pointer-events-none', SEVERITY_BADGE.warning,
                   canHelmWrite ? 'hover:bg-amber-500/30 cursor-pointer' : 'opacity-50 cursor-not-allowed'
                 )}
-                title={canHelmWrite ? `Click to upgrade: ${upgradeInfo.currentVersion} → ${upgradeInfo.latestVersion}${upgradeInfo.repositoryName ? ` (${upgradeInfo.repositoryName})` : ''}` : helmActReason}
               >
                 <ArrowUpCircle className="w-3 h-3" />
                 {upgradeInfo.latestVersion}
               </button>
+              </Tooltip>
             ) : upgradeInfo && !upgradeInfo.error ? (
-              <span className={clsx('badge', SEVERITY_BADGE.success)} title="Chart is up to date">
+              <Tooltip content="Chart is up to date">
+              <span className={clsx('badge', SEVERITY_BADGE.success)}>
                 latest
               </span>
+              </Tooltip>
             ) : upgradeInfo?.error ? (
+              <Tooltip content={upgradeInfo.error}>
               <span
                 className="badge bg-theme-hover/50 text-theme-text-secondary"
-                title={upgradeInfo.error}
               >
                 upstream unknown
               </span>
+              </Tooltip>
             ) : null}
           </div>
           <div className="flex items-center gap-1">
+            <Tooltip content="Refresh">
             <button
               onClick={refetch}
               disabled={isRefreshAnimating}
-              className="p-1.5 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded disabled:opacity-50"
-              title="Refresh"
+              className="p-1.5 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded disabled:opacity-50 disabled:pointer-events-none"
             >
               <RefreshCw className={clsx('w-4 h-4', isRefreshAnimating && 'animate-spin')} />
             </button>
+            </Tooltip>
+            <Tooltip content={canHelmWrite ? 'Uninstall release' : helmActReason}>
             <button
               onClick={() => setShowUninstallConfirm(true)}
               disabled={!canHelmWrite}
               className={clsx(
-                'p-1.5 rounded',
+                'p-1.5 rounded disabled:pointer-events-none',
                 canHelmWrite
                   ? 'text-theme-text-secondary hover:text-red-400 hover:bg-red-500/10'
                   : 'text-theme-text-disabled cursor-not-allowed'
               )}
-              title={canHelmWrite ? 'Uninstall release' : helmActReason}
             >
               <Trash2 className="w-4 h-4" />
             </button>
-            <button onClick={onClose} className="p-1.5 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded" title="Close (Esc)">
+            </Tooltip>
+            <Tooltip content="Close (Esc)">
+            <button onClick={onClose} className="p-1.5 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded">
               <X className="w-4 h-4" />
             </button>
+            </Tooltip>
           </div>
         </div>
 
@@ -399,16 +409,18 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
           <div className="flex items-center gap-2">
             <Package className="w-5 h-5 text-purple-400" />
             <h2 className="text-lg font-semibold text-theme-text-primary truncate">{release.name}</h2>
+            <Tooltip content="Copy name">
             <button
               onClick={() => copyToClipboard(release.name, 'name')}
               className="p-1 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded shrink-0"
-              title="Copy name"
             >
               {copied === 'name' ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
             </button>
+            </Tooltip>
           </div>
           <p className="text-sm text-theme-text-tertiary">{release.namespace}</p>
           {releaseDetail?.managedByFluxHelmRelease && (
+            <Tooltip content={`Installed by Flux helm-controller via HelmRelease ${releaseDetail.managedByFluxHelmRelease}. Changes here would be reverted at the next reconcile.`}>
             <button
               type="button"
               onClick={() => {
@@ -416,11 +428,11 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
                 navigate(`/gitops/detail/helmreleases/${encodeURIComponent(ns || '_')}/${encodeURIComponent(name)}`)
               }}
               className="mt-1 inline-flex items-center gap-1 rounded border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[11px] text-amber-700 dark:text-amber-400 hover:bg-amber-500/20 transition-colors"
-              title={`Installed by Flux helm-controller via HelmRelease ${releaseDetail.managedByFluxHelmRelease}. Changes here would be reverted at the next reconcile.`}
             >
               <GitBranch className="w-3 h-3" />
               Managed by Flux · {releaseDetail.managedByFluxHelmRelease}
             </button>
+            </Tooltip>
           )}
         </div>
 

--- a/web/src/components/helm/HelmReleaseDrawer.tsx
+++ b/web/src/components/helm/HelmReleaseDrawer.tsx
@@ -409,7 +409,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
           <div className="flex items-center gap-2">
             <Package className="w-5 h-5 text-purple-400" />
             <h2 className="text-lg font-semibold text-theme-text-primary truncate">{release.name}</h2>
-            <Tooltip content="Copy name">
+            <Tooltip content="Copy name" wrapperClassName="shrink-0">
             <button
               onClick={() => copyToClipboard(release.name, 'name')}
               className="p-1 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded shrink-0"
@@ -420,14 +420,14 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
           </div>
           <p className="text-sm text-theme-text-tertiary">{release.namespace}</p>
           {releaseDetail?.managedByFluxHelmRelease && (
-            <Tooltip content={`Installed by Flux helm-controller via HelmRelease ${releaseDetail.managedByFluxHelmRelease}. Changes here would be reverted at the next reconcile.`}>
+            <Tooltip content={`Installed by Flux helm-controller via HelmRelease ${releaseDetail.managedByFluxHelmRelease}. Changes here would be reverted at the next reconcile.`} wrapperClassName="mt-1">
             <button
               type="button"
               onClick={() => {
                 const [ns, name] = releaseDetail.managedByFluxHelmRelease!.split('/')
                 navigate(`/gitops/detail/helmreleases/${encodeURIComponent(ns || '_')}/${encodeURIComponent(name)}`)
               }}
-              className="mt-1 inline-flex items-center gap-1 rounded border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[11px] text-amber-700 dark:text-amber-400 hover:bg-amber-500/20 transition-colors"
+              className="inline-flex items-center gap-1 rounded border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[11px] text-amber-700 dark:text-amber-400 hover:bg-amber-500/20 transition-colors"
             >
               <GitBranch className="w-3 h-3" />
               Managed by Flux · {releaseDetail.managedByFluxHelmRelease}

--- a/web/src/components/helm/HelmView.tsx
+++ b/web/src/components/helm/HelmView.tsx
@@ -226,14 +226,15 @@ export function HelmView({ namespaces, selectedRelease, onReleaseClick }: HelmVi
                   className="w-full max-w-md pl-10 pr-4 py-2 bg-theme-elevated border border-theme-border-light rounded-lg text-sm text-theme-text-primary placeholder-theme-text-disabled focus:outline-none focus:ring-2 focus:ring-blue-500"
                 />
               </div>
+              <Tooltip content="Refresh">
               <button
                 onClick={handleRefresh}
                 disabled={isRefreshAnimating}
-                className="p-2 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded-lg disabled:opacity-50"
-                title="Refresh"
+                className="p-2 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded-lg disabled:opacity-50 disabled:pointer-events-none"
               >
                 <RefreshCw className={clsx('w-4 h-4', isRefreshAnimating && 'animate-spin')} />
               </button>
+              </Tooltip>
             </div>
 
             {/* Releases Table */}

--- a/web/src/components/helm/InstallWizard.tsx
+++ b/web/src/components/helm/InstallWizard.tsx
@@ -411,11 +411,11 @@ export function InstallWizard({ repo, chartName, version, source, repoUrl, defau
                   Cancel
                 </button>
                 {step === 'review' ? (
+                  <Tooltip content={!canHelmWrite ? helmActReason : ''}>
                   <button
                     onClick={handleInstall}
                     disabled={!canInstall || isInstalling || !canHelmWrite}
-                    className="flex items-center gap-2 px-4 py-2 text-sm font-medium btn-brand rounded-lg disabled:cursor-not-allowed"
-                    title={!canHelmWrite ? helmActReason : undefined}
+                    className="flex items-center gap-2 px-4 py-2 text-sm font-medium btn-brand rounded-lg disabled:cursor-not-allowed disabled:pointer-events-none"
                   >
                     {isInstalling ? (
                       <Loader2 className="w-4 h-4 animate-spin" />
@@ -424,6 +424,7 @@ export function InstallWizard({ repo, chartName, version, source, repoUrl, defau
                     )}
                     Install
                   </button>
+                  </Tooltip>
                 ) : (
                   <button
                     onClick={() => setStep(step === 'info' ? 'values' : 'review')}

--- a/web/src/components/helm/OwnedResources.tsx
+++ b/web/src/components/helm/OwnedResources.tsx
@@ -13,6 +13,7 @@ import { useAvailablePorts } from '../../api/client'
 import { apiUrl, getAuthHeaders, getCredentialsMode } from '../../api/config'
 import { useNamespacedCapabilities } from '../../contexts/CapabilitiesContext'
 import { pluralize } from '@skyhook-io/k8s-ui'
+import { Tooltip } from '../ui/Tooltip'
 
 interface OwnedResourcesProps {
   resources: HelmOwnedResource[]
@@ -103,13 +104,14 @@ export function OwnedResources({ resources, onNavigate }: OwnedResourcesProps) {
           ) : (
             <span className="flex items-center gap-2">
               Showing {filteredResources.length} of {resources.length} resources
+              <Tooltip content="Clear filter">
               <button
                 onClick={() => setHealthFilter('all')}
                 className="p-0.5 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
-                title="Clear filter"
               >
                 <X className="w-3.5 h-3.5" />
               </button>
+              </Tooltip>
             </span>
           )}
         </div>
@@ -255,39 +257,44 @@ function ResourceItem({ resource, onNavigate }: ResourceItemProps) {
 
         {/* Status badge */}
         {resource.status && (
+          <Tooltip content={resource.message || resource.status}>
           <span
             className={clsx('badge-sm', getResourceStatusColor(resource.status || ''))}
-            title={resource.message || resource.status}
           >
             {resource.status}
           </span>
+          </Tooltip>
         )}
 
         {/* Issue summary (e.g., "OOMKilled", "CrashLoopBackOff") */}
         {resource.issue && (
+          <Tooltip content={resource.summary || resource.issue}>
           <span
             className="text-xs text-red-400"
-            title={resource.summary || resource.issue}
           >
             {resource.issue}
           </span>
+          </Tooltip>
         )}
 
         {/* Error icon with message tooltip */}
         {isError && resource.message && !resource.issue && (
-          <span title={resource.message}>
+          <Tooltip content={resource.message}>
+          <span>
             <AlertCircle className="w-3.5 h-3.5 text-red-400" />
           </span>
+          </Tooltip>
         )}
 
         {canNavigate && (
+          <Tooltip content="View details">
           <button
             onClick={handleClick}
             className="p-1 text-theme-text-tertiary opacity-0 group-hover:opacity-100 hover:text-theme-text-primary hover:bg-theme-elevated rounded transition-all"
-            title="View details"
           >
             <ExternalLink className="w-3.5 h-3.5" />
           </button>
+          </Tooltip>
         )}
       </div>
     </div>
@@ -383,35 +390,37 @@ function PodQuickActions({ namespace, podName, isRunning }: PodQuickActionsProps
 
       {/* Terminal */}
       {isRunning && canExec && (
+        <Tooltip content="Open terminal">
         <button
           onClick={(e) => { e.stopPropagation(); handleOpenTerminal() }}
           disabled={isLoadingAction}
-          className="p-1 text-theme-text-tertiary hover:text-blue-400 hover:bg-blue-500/10 rounded transition-colors disabled:opacity-50"
-          title="Open terminal"
+          className="p-1 text-theme-text-tertiary hover:text-blue-400 hover:bg-blue-500/10 rounded transition-colors disabled:opacity-50 disabled:pointer-events-none"
         >
           <Terminal className="w-3.5 h-3.5" />
         </button>
+        </Tooltip>
       )}
 
       {/* Logs */}
       {canViewLogs && (
+        <Tooltip content="View logs">
         <button
           onClick={(e) => { e.stopPropagation(); handleOpenLogs() }}
           disabled={isLoadingAction}
-          className="p-1 text-theme-text-tertiary hover:text-blue-400 hover:bg-blue-500/10 rounded transition-colors disabled:opacity-50"
-          title="View logs"
+          className="p-1 text-theme-text-tertiary hover:text-blue-400 hover:bg-blue-500/10 rounded transition-colors disabled:opacity-50 disabled:pointer-events-none"
         >
           <FileText className="w-3.5 h-3.5" />
         </button>
+        </Tooltip>
       )}
 
       {/* Port Forward */}
       {canPortForward && !portsLoading && ports.length > 0 && (
+        <Tooltip content={`Port forward :${ports[0].port}`}>
         <button
           onClick={(e) => { e.stopPropagation(); handlePortForward(ports[0].port) }}
           disabled={startPortForward.isPending}
-          className="p-1 text-theme-text-tertiary hover:text-blue-400 hover:bg-blue-500/10 rounded transition-colors disabled:opacity-50"
-          title={`Port forward :${ports[0].port}`}
+          className="p-1 text-theme-text-tertiary hover:text-blue-400 hover:bg-blue-500/10 rounded transition-colors disabled:opacity-50 disabled:pointer-events-none"
         >
           {startPortForward.isPending ? (
             <Loader2 className="w-3.5 h-3.5 animate-spin" />
@@ -419,6 +428,7 @@ function PodQuickActions({ namespace, podName, isRunning }: PodQuickActionsProps
             <Plug className="w-3.5 h-3.5" />
           )}
         </button>
+        </Tooltip>
       )}
     </div>
   )
@@ -449,11 +459,11 @@ function ServiceQuickActions({ namespace, serviceName }: ServiceQuickActionsProp
 
   return (
     <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+      <Tooltip content={`Port forward :${ports[0].port}`}>
       <button
         onClick={(e) => { e.stopPropagation(); handlePortForward(ports[0].port) }}
         disabled={startPortForward.isPending}
-        className="p-1 text-theme-text-tertiary hover:text-blue-400 hover:bg-blue-500/10 rounded transition-colors disabled:opacity-50"
-        title={`Port forward :${ports[0].port}`}
+        className="p-1 text-theme-text-tertiary hover:text-blue-400 hover:bg-blue-500/10 rounded transition-colors disabled:opacity-50 disabled:pointer-events-none"
       >
         {startPortForward.isPending ? (
           <Loader2 className="w-3.5 h-3.5 animate-spin" />
@@ -461,6 +471,7 @@ function ServiceQuickActions({ namespace, serviceName }: ServiceQuickActionsProp
           <Plug className="w-3.5 h-3.5" />
         )}
       </button>
+      </Tooltip>
     </div>
   )
 }

--- a/web/src/components/helm/RevisionHistory.tsx
+++ b/web/src/components/helm/RevisionHistory.tsx
@@ -4,6 +4,7 @@ import { clsx } from 'clsx'
 import type { HelmRevision } from '../../types'
 import { getStatusColor, formatDate, formatAge } from './helm-utils'
 import { SEVERITY_BADGE } from '../../utils/badge-colors'
+import { Tooltip } from '../ui/Tooltip'
 
 interface RevisionHistoryProps {
   history: HelmRevision[]
@@ -108,7 +109,7 @@ export function RevisionHistory({ history, currentRevision, onViewRevision, onCo
                   </div>
 
                   <div className="flex items-center gap-4 mt-1 text-xs text-theme-text-tertiary">
-                    <span title={revision.updated}>{formatDate(revision.updated)}</span>
+                    <Tooltip content={revision.updated}><span>{formatDate(revision.updated)}</span></Tooltip>
                     <span>{formatAge(revision.updated)} ago</span>
                   </div>
 

--- a/web/src/components/helm/ValuesViewer.tsx
+++ b/web/src/components/helm/ValuesViewer.tsx
@@ -9,6 +9,7 @@ import { YamlEditor } from '../ui/YamlEditor'
 import { useHelmPreviewValues, useHelmApplyValues } from '../../api/client'
 import { useCanHelmAct } from '../../api/client'
 import { ValuesDiffPreview } from './ValuesDiffPreview'
+import { Tooltip } from '../ui/Tooltip'
 
 interface ValuesViewerProps {
   values?: HelmValues
@@ -227,11 +228,11 @@ export function ValuesViewer({
                 )}
                 Preview
               </button>
+              <Tooltip content={!canHelmWrite ? helmActReason : ''}>
               <button
                 onClick={handleApply}
                 disabled={!!yamlError || applyMutation.isPending || !canHelmWrite}
-                className="flex items-center gap-1 px-2.5 py-1 text-xs btn-brand rounded disabled:cursor-not-allowed"
-                title={!canHelmWrite ? helmActReason : undefined}
+                className="flex items-center gap-1 px-2.5 py-1 text-xs btn-brand rounded disabled:cursor-not-allowed disabled:pointer-events-none"
               >
                 {applyMutation.isPending ? (
                   <Loader2 className="w-3.5 h-3.5 animate-spin" />
@@ -240,6 +241,7 @@ export function ValuesViewer({
                 )}
                 Apply
               </button>
+              </Tooltip>
             </>
           )}
         </div>

--- a/web/src/components/home/ClusterHealthCard.tsx
+++ b/web/src/components/home/ClusterHealthCard.tsx
@@ -224,8 +224,8 @@ export function ClusterHealthCard({
               // the visible text falls back to the platform label. Render no
               // tooltip in that case; local mode keeps it so users can hover
               // to see the full kubeconfig context path.
-              <Tooltip content={isInCluster ? '' : cluster.name} wrapperClassName="!block min-w-0 mb-1.5">
-              <h2 className="text-xl font-semibold text-theme-text-primary truncate leading-tight">
+              <Tooltip content={isInCluster ? '' : cluster.name} wrapperClassName="!block min-w-0">
+              <h2 className="text-xl font-semibold text-theme-text-primary truncate leading-tight mb-1.5">
                 {headlineName}
               </h2>
               </Tooltip>

--- a/web/src/components/home/ClusterHealthCard.tsx
+++ b/web/src/components/home/ClusterHealthCard.tsx
@@ -444,7 +444,7 @@ export function ClusterHealthCard({
         {/* Left column: Warning indicators (aligned with cluster info) */}
         <div className="flex flex-col justify-center gap-1 w-1/4 shrink-0 pr-4 border-r border-theme-border/50">
           {health.warningEvents > 0 && (
-            <Tooltip content="Native Kubernetes Warning events (e.g., ImagePullBackOff, FailedScheduling)">
+            <Tooltip content="Native Kubernetes Warning events (e.g., ImagePullBackOff, FailedScheduling)" wrapperClassName="w-fit">
             <button
               onClick={onWarningEventsClick}
               className="badge status-degraded w-fit gap-1.5 hover:opacity-80 transition-opacity"
@@ -455,7 +455,7 @@ export function ClusterHealthCard({
             </Tooltip>
           )}
           {issueCount > 0 && (
-            <Tooltip content="View grouped live operational issues">
+            <Tooltip content="View grouped live operational issues" wrapperClassName="w-fit">
             <button
               onClick={onIssuesClick}
               className={clsx('badge w-fit gap-1.5 hover:opacity-80 transition-opacity', hasCriticalIssues ? 'status-unhealthy' : 'status-degraded')}

--- a/web/src/components/home/ClusterHealthCard.tsx
+++ b/web/src/components/home/ClusterHealthCard.tsx
@@ -219,24 +219,24 @@ export function ClusterHealthCard({
                 its top bar; rendering it again here is redundant and
                 makes the card feel like a label rather than content. */}
             {!isCloud && (
-              <h2
-                className="text-xl font-semibold text-theme-text-primary truncate mb-1.5 leading-tight"
-                // In-cluster mode's cluster.name is the literal "in-cluster"
-                // sentinel, which would leak via the browser hover tooltip
-                // even though the visible text falls back to the platform
-                // label. Drop the title attribute entirely in that case;
-                // local mode keeps it so users can hover to see the full
-                // kubeconfig context path.
-                title={isInCluster ? undefined : cluster.name}
-              >
+              // In-cluster mode's cluster.name is the literal "in-cluster"
+              // sentinel, which would leak via the hover tooltip even though
+              // the visible text falls back to the platform label. Render no
+              // tooltip in that case; local mode keeps it so users can hover
+              // to see the full kubeconfig context path.
+              <Tooltip content={isInCluster ? '' : cluster.name} wrapperClassName="!block min-w-0 mb-1.5">
+              <h2 className="text-xl font-semibold text-theme-text-primary truncate leading-tight">
                 {headlineName}
               </h2>
+              </Tooltip>
             )}
             <div className="flex flex-col gap-0.5 text-xs text-theme-text-tertiary">
               {(parsedContext.account || parsedContext.region) && (
-                <span className="truncate font-mono" title={[parsedContext.account, parsedContext.region].filter(Boolean).join(' · ')}>
+                <Tooltip content={[parsedContext.account, parsedContext.region].filter(Boolean).join(' · ')} wrapperClassName="min-w-0">
+                <span className="truncate font-mono">
                   {[parsedContext.account, parsedContext.region].filter(Boolean).join(' · ')}
                 </span>
+                </Tooltip>
               )}
               {cluster.version && (
                 <span>Kubernetes {cluster.version}</span>
@@ -247,12 +247,11 @@ export function ClusterHealthCard({
                   (in-cluster has no meaningful context name, cloud
                   shell already renders the canonical name). */}
               {cluster.name && cluster.name !== headlineName && deployment.mode === 'local' && (
-                <span
-                  className="font-mono text-[10px] text-theme-text-disabled break-all leading-snug pt-0.5"
-                  title={cluster.name}
-                >
+                <Tooltip content={cluster.name}>
+                <span className="font-mono text-[10px] text-theme-text-disabled break-all leading-snug pt-0.5">
                   {cluster.name}
                 </span>
+                </Tooltip>
               )}
             </div>
             {nodeVersionSkew && (
@@ -290,9 +289,11 @@ export function ClusterHealthCard({
                 <Radio className="w-3.5 h-3.5 text-purple-400 animate-pulse shrink-0" />
                 <div className="flex flex-col gap-0.5 min-w-0 flex-1 text-left">
                   <span className="text-xs font-medium text-purple-400">MCP Server Live</span>
-                  <span className="text-[10px] text-theme-text-tertiary truncate font-mono" title={mcpUrl}>
+                  <Tooltip content={mcpUrl} wrapperClassName="min-w-0">
+                  <span className="text-[10px] text-theme-text-tertiary truncate font-mono">
                     HTTP · {mcpUrl}
                   </span>
+                  </Tooltip>
                 </div>
                 <Info className="w-3.5 h-3.5 text-purple-400/60 shrink-0" />
               </button>
@@ -443,24 +444,26 @@ export function ClusterHealthCard({
         {/* Left column: Warning indicators (aligned with cluster info) */}
         <div className="flex flex-col justify-center gap-1 w-1/4 shrink-0 pr-4 border-r border-theme-border/50">
           {health.warningEvents > 0 && (
+            <Tooltip content="Native Kubernetes Warning events (e.g., ImagePullBackOff, FailedScheduling)">
             <button
               onClick={onWarningEventsClick}
-              title="Native Kubernetes Warning events (e.g., ImagePullBackOff, FailedScheduling)"
               className="badge status-degraded w-fit gap-1.5 hover:opacity-80 transition-opacity"
             >
               <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
               <span><span className="font-mono">{health.warningEvents}</span> Warning Events</span>
             </button>
+            </Tooltip>
           )}
           {issueCount > 0 && (
+            <Tooltip content="View grouped live operational issues">
             <button
               onClick={onIssuesClick}
-              title="View grouped live operational issues"
               className={clsx('badge w-fit gap-1.5 hover:opacity-80 transition-opacity', hasCriticalIssues ? 'status-unhealthy' : 'status-degraded')}
             >
               <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
               <span>{pluralize(issueCount, 'Active Issue')}</span>
             </button>
+            </Tooltip>
           )}
         </div>
 

--- a/web/src/components/home/HelmSummary.tsx
+++ b/web/src/components/home/HelmSummary.tsx
@@ -88,7 +88,7 @@ export function HelmSummary({ data, onNavigate }: HelmSummaryProps) {
             <span className="text-xs font-medium text-theme-text-secondary">
               {data.errorCode === 'unconfigured' ? 'Helm not configured' : 'Helm unavailable'}
             </span>
-            <Tooltip content={data.error} wrapperClassName="mt-1 min-w-0">
+            <Tooltip content={data.error} wrapperClassName="!block mt-1 min-w-0 text-center">
             <span className="text-[11px] text-center px-2 truncate max-w-full">
               {data.errorCode === 'unconfigured'
                 ? 'Set rbac.helm=true in the Radar Helm chart values.'

--- a/web/src/components/home/HelmSummary.tsx
+++ b/web/src/components/home/HelmSummary.tsx
@@ -88,11 +88,13 @@ export function HelmSummary({ data, onNavigate }: HelmSummaryProps) {
             <span className="text-xs font-medium text-theme-text-secondary">
               {data.errorCode === 'unconfigured' ? 'Helm not configured' : 'Helm unavailable'}
             </span>
-            <span className="text-[11px] mt-1 text-center px-2 truncate max-w-full" title={data.error}>
+            <Tooltip content={data.error} wrapperClassName="mt-1 min-w-0">
+            <span className="text-[11px] text-center px-2 truncate max-w-full">
               {data.errorCode === 'unconfigured'
                 ? 'Set rbac.helm=true in the Radar Helm chart values.'
                 : data.error}
             </span>
+            </Tooltip>
           </div>
         ) : !data.releases || data.releases.length === 0 ? (
           <div className="flex items-center justify-center h-full py-4 text-xs text-theme-text-tertiary">

--- a/web/src/components/home/MCPSetupDialog.tsx
+++ b/web/src/components/home/MCPSetupDialog.tsx
@@ -2,6 +2,7 @@ import { useRef, useEffect, useState, useCallback } from 'react'
 import { X, Copy, Check, Radio, Terminal, MessageSquare, Code2, ChevronRight, Pin } from 'lucide-react'
 import { apiUrl, getAuthHeaders, getCredentialsMode } from '../../api/config'
 import { MCP_TOOL_CATALOG } from './mcpToolCatalog'
+import { Tooltip } from '../ui/Tooltip'
 
 interface MCPSetupDialogProps {
   open: boolean
@@ -19,13 +20,14 @@ function CopyButton({ text }: { text: string }) {
   }
 
   return (
+    <Tooltip content="Copy to clipboard" position="left" wrapperClassName="absolute top-2 right-2">
     <button
       onClick={handleCopy}
-      className="absolute top-2 right-2 p-1.5 rounded-md bg-theme-elevated/50 hover:bg-theme-elevated text-theme-text-tertiary hover:text-theme-text-secondary transition-colors"
-      title="Copy to clipboard"
+      className="p-1.5 rounded-md bg-theme-elevated/50 hover:bg-theme-elevated text-theme-text-tertiary hover:text-theme-text-secondary transition-colors"
     >
       {copied ? <Check className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5" />}
     </button>
+    </Tooltip>
   )
 }
 
@@ -308,19 +310,23 @@ export function MCPSetupDialog({ open, onClose, mcpUrl }: MCPSetupDialogProps) {
                   <div className="flex items-center gap-2">
                     <code className="inline-code text-[11px]">{tool.name}</code>
                     {tool.write && (
-                      <span className="badge-sm bg-amber-500/10 text-amber-600 dark:text-amber-400" title="Write tool — annotated as destructive">
+                      <Tooltip content="Write tool — annotated as destructive">
+                      <span className="badge-sm bg-amber-500/10 text-amber-600 dark:text-amber-400">
                         write
                       </span>
+                      </Tooltip>
                     )}
                   </div>
                   <p className="text-[11px] text-theme-text-tertiary leading-relaxed">{tool.desc}</p>
                   {tool.params.length > 0 && (
                     <div className="flex flex-wrap gap-1.5 pt-0.5">
                       {tool.params.map((p) => (
-                        <span key={p.arg} className="inline-code text-[11px]" title={p.desc}>
+                        <Tooltip key={p.arg} content={p.desc}>
+                        <span className="inline-code text-[11px]">
                           <span>{p.arg}</span>
                           {p.required && <span className="text-red-400">*</span>}
                         </span>
+                        </Tooltip>
                       ))}
                     </div>
                   )}

--- a/web/src/components/nav/PrimaryNavRail.tsx
+++ b/web/src/components/nav/PrimaryNavRail.tsx
@@ -132,7 +132,7 @@ export function PrimaryNavRail({ activeView, onNavigate, pinned, onTogglePinned,
           forced slim (showPinToggle=false) — expanding there isn't available. */}
       {showPinToggle && (
       <div className="px-2 pb-2 pt-1 border-t border-theme-border/50">
-        <Tooltip content={pinned ? 'Collapse navigation' : 'Expand navigation'} position="right" wrapperClassName="!block w-full">
+        <Tooltip content={pinned ? 'Collapse navigation' : 'Expand navigation'} position="right" wrapperClassName="!block w-full shrink-0">
         <button
           type="button"
           onClick={onTogglePinned}
@@ -158,7 +158,7 @@ function BrandRow({ pinned, onNavigate }: { pinned: boolean; onNavigate: (view: 
   // Clickable brand = secondary home affordance (logo→home convention). The
   // Home nav item below still carries the active state; the brand just navigates.
   return (
-    <Tooltip content="Home" position="right" wrapperClassName="!block w-full">
+    <Tooltip content="Home" position="right" wrapperClassName="!block w-full shrink-0">
     <button
       type="button"
       onClick={() => onNavigate('home')}

--- a/web/src/components/nav/PrimaryNavRail.tsx
+++ b/web/src/components/nav/PrimaryNavRail.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react'
 import { Home, Network, List, Clock, AlertTriangle, Package, GitBranch, Boxes, Activity, DollarSign, ShieldCheck, Settings, PanelLeftClose, PanelLeftOpen } from 'lucide-react'
 import { clsx } from 'clsx'
 import type { MainView } from '../../types'
+import { Tooltip } from '../ui/Tooltip'
 
 // The views the rail can navigate to. Broader than k8s-ui's ExtendedMainView
 // (which omits 'applications') — it mirrors the navigable subset of App.tsx's
@@ -131,11 +132,11 @@ export function PrimaryNavRail({ activeView, onNavigate, pinned, onTogglePinned,
           forced slim (showPinToggle=false) — expanding there isn't available. */}
       {showPinToggle && (
       <div className="px-2 pb-2 pt-1 border-t border-theme-border/50">
+        <Tooltip content={pinned ? 'Collapse navigation' : 'Expand navigation'} position="right" wrapperClassName="!block w-full">
         <button
           type="button"
           onClick={onTogglePinned}
           aria-label={pinned ? 'Collapse navigation' : 'Expand navigation'}
-          title={pinned ? 'Collapse navigation' : 'Expand navigation'}
           className="group/pin relative flex h-9 w-full items-center rounded-md text-theme-text-tertiary hover:bg-theme-hover hover:text-theme-text-secondary transition-colors"
         >
           <span className="flex w-10 shrink-0 items-center justify-center">
@@ -146,6 +147,7 @@ export function PrimaryNavRail({ activeView, onNavigate, pinned, onTogglePinned,
               would contradict the "Expand navigation" label. */}
           <span className={clsx('text-[13px] font-medium', !pinned && 'hidden')}>Collapse</span>
         </button>
+        </Tooltip>
       </div>
       )}
     </aside>
@@ -156,11 +158,11 @@ function BrandRow({ pinned, onNavigate }: { pinned: boolean; onNavigate: (view: 
   // Clickable brand = secondary home affordance (logo→home convention). The
   // Home nav item below still carries the active state; the brand just navigates.
   return (
+    <Tooltip content="Home" position="right" wrapperClassName="!block w-full">
     <button
       type="button"
       onClick={() => onNavigate('home')}
       aria-label="Radar — go to home"
-      title="Home"
       // Height matches the top bar header (App.tsx — items-center + py-2 = 51px)
       // so the rail's brand divider and the header's bottom border form one line.
       className="flex h-[51px] w-full items-center border-b border-theme-border/50 shrink-0 transition-opacity hover:opacity-80"
@@ -181,6 +183,7 @@ function BrandRow({ pinned, onNavigate }: { pinned: boolean; onNavigate: (view: 
         <span className="text-[9px] mt-0.5 tracking-wide uppercase text-theme-text-tertiary">by Skyhook</span>
       </span>
     </button>
+    </Tooltip>
   )
 }
 

--- a/web/src/components/portforward/PortForwardButton.tsx
+++ b/web/src/components/portforward/PortForwardButton.tsx
@@ -4,6 +4,7 @@ import { clsx } from 'clsx'
 import { useAvailablePorts, useClusterInfo, AvailablePort } from '../../api/client'
 import { useStartPortForward } from './PortForwardManager'
 import { validatePort } from '@skyhook-io/k8s-ui/utils/validators'
+import { Tooltip } from '../ui/Tooltip'
 
 interface PortForwardButtonProps {
   type: 'pod' | 'service'
@@ -206,31 +207,32 @@ export function PortForwardButton({
     // If no ports available, show disabled button
     if (!isLoading && ports.length === 0) {
       return (
+        <Tooltip content="No ports available">
         <button
           disabled
           className={clsx(
-            'flex items-center gap-2 px-3 py-2 bg-theme-elevated text-theme-text-primary text-sm rounded-lg opacity-50 cursor-not-allowed',
+            'flex items-center gap-2 px-3 py-2 bg-theme-elevated text-theme-text-primary text-sm rounded-lg opacity-50 cursor-not-allowed disabled:pointer-events-none',
             className
           )}
-          title="No ports available"
         >
           <Plug className="w-4 h-4" />
           No Ports
         </button>
+        </Tooltip>
       )
     }
 
     // If only one port, forward directly on click (most common case)
     if (ports.length === 1) {
       return (
+        <Tooltip content={`Port forward to ${ports[0].port}`}>
         <button
           onClick={() => handlePortSelect(ports[0])}
           disabled={isPending}
           className={clsx(
-            'flex items-center gap-2 px-3 py-2 bg-theme-elevated text-theme-text-primary text-sm rounded-lg hover:bg-theme-hover transition-colors disabled:opacity-50',
+            'flex items-center gap-2 px-3 py-2 bg-theme-elevated text-theme-text-primary text-sm rounded-lg hover:bg-theme-hover transition-colors disabled:opacity-50 disabled:pointer-events-none',
             className
           )}
-          title={`Port forward to ${ports[0].port}`}
         >
           {isPending ? (
             <Loader2 className="w-4 h-4 animate-spin" />
@@ -239,6 +241,7 @@ export function PortForwardButton({
           )}
           Forward :{ports[0].port}
         </button>
+        </Tooltip>
       )
     }
 
@@ -269,6 +272,7 @@ export function PortForwardButton({
               <div className="px-3 py-2 border-b border-theme-border">
                 <div className="text-xs text-theme-text-disabled mb-2">Listen on</div>
                 <div className="flex gap-1">
+                  <Tooltip content="Only accessible from this machine" wrapperClassName="flex-1">
                   <button
                     onClick={(e) => { e.stopPropagation(); setListenAddress('127.0.0.1') }}
                     className={clsx(
@@ -277,11 +281,12 @@ export function PortForwardButton({
                         ? 'btn-brand-toggle'
                         : 'bg-theme-elevated text-theme-text-tertiary hover:text-theme-text-primary'
                     )}
-                    title="Only accessible from this machine"
                   >
                     <Monitor className="w-3 h-3" />
                     localhost
                   </button>
+                  </Tooltip>
+                  <Tooltip content="Accessible from other machines on the network" wrapperClassName="flex-1">
                   <button
                     onClick={(e) => { e.stopPropagation(); setListenAddress('0.0.0.0') }}
                     className={clsx(
@@ -290,11 +295,11 @@ export function PortForwardButton({
                         ? 'bg-amber-600 text-white'
                         : 'bg-theme-elevated text-theme-text-tertiary hover:text-theme-text-primary'
                     )}
-                    title="Accessible from other machines on the network"
                   >
                     <Globe className="w-3 h-3" />
                     all interfaces
                   </button>
+                  </Tooltip>
                 </div>
               </div>
             )}
@@ -375,11 +380,11 @@ export function PortForwardInlineButton({
 
   return (
     <>
+      <Tooltip content={`Port forward ${port}`}>
       <button
         onClick={handleClick}
         disabled={disabled || isPending}
-        className="inline-flex items-center gap-1 px-1.5 py-0.5 bg-theme-elevated hover:bg-accent-muted rounded text-xs transition-colors disabled:opacity-50 disabled:hover:bg-theme-elevated"
-        title={`Port forward ${port}`}
+        className="inline-flex items-center gap-1 px-1.5 py-0.5 bg-theme-elevated hover:bg-accent-muted rounded text-xs transition-colors disabled:opacity-50 disabled:hover:bg-theme-elevated disabled:pointer-events-none"
       >
         {port}/{protocol}
         {isPending ? (
@@ -388,6 +393,7 @@ export function PortForwardInlineButton({
           <Plug className="w-3 h-3" />
         )}
       </button>
+      </Tooltip>
       {dialogInfo && (
         <KubectlCommandDialog info={dialogInfo} onClose={() => setDialogInfo(null)} />
       )}

--- a/web/src/components/resource-drawer/ResourceDrawer.tsx
+++ b/web/src/components/resource-drawer/ResourceDrawer.tsx
@@ -4,6 +4,7 @@ import { clsx } from 'clsx'
 import { useState, useCallback } from 'react'
 import type { TopologyNode, NodeKind, HealthStatus } from '../../types'
 import { getKindBadgeBordered, healthToSeverity, SEVERITY_BADGE_BORDERED } from '../../utils/badge-colors'
+import { Tooltip } from '../ui/Tooltip'
 
 interface ResourceDrawerProps {
   node: TopologyNode
@@ -146,10 +147,10 @@ export const ResourceDrawer = memo(function ResourceDrawer({
               <h2 className="text-lg font-semibold text-theme-text-primary truncate">
                 {node.name}
               </h2>
+              <Tooltip content="Copy name">
               <button
                 onClick={copyName}
                 className="p-1 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
-                title="Copy name"
               >
                 {copied ? (
                   <Check className="w-4 h-4 text-green-400" />
@@ -157,6 +158,7 @@ export const ResourceDrawer = memo(function ResourceDrawer({
                   <Copy className="w-4 h-4" />
                 )}
               </button>
+              </Tooltip>
             </div>
           </div>
           <button

--- a/web/src/components/resource/PrometheusChartsGrid.tsx
+++ b/web/src/components/resource/PrometheusChartsGrid.tsx
@@ -26,6 +26,7 @@ import {
   type CategoryDef,
 } from './PrometheusCharts'
 import { RestartEventLane } from './RestartChart'
+import { Tooltip } from '../ui/Tooltip'
 
 // Used when MetricsTabContent is in expanded (full-screen) mode. Drawer mode
 // uses the single-chart tabbed `PrometheusCharts` instead — drawer width
@@ -288,7 +289,11 @@ function WorkloadHealthBadge({ kind, namespace, name }: { kind: string; namespac
   // silently render as fine while we have no signal to display.
   if (error && !data) {
     const msg = error instanceof Error ? error.message : String(error)
-    return <span className={`badge badge-sm ${SEVERITY_BADGE.neutral}`} title={`Health check failed: ${msg}`}>Health unknown</span>
+    return (
+      <Tooltip content={`Health check failed: ${msg}`}>
+      <span className={`badge badge-sm ${SEVERITY_BADGE.neutral}`}>Health unknown</span>
+      </Tooltip>
+    )
   }
   if (!data?.sampleAvailable || data.rows.length === 0) return null
 
@@ -320,7 +325,9 @@ function PanelError({ message }: { message: string }) {
   return (
     <div className={`flex flex-col items-center justify-center h-full min-h-[160px] ${SEVERITY_TEXT.warning} text-xs px-3 text-center`}>
       Query failed
-      <span className="text-theme-text-quaternary mt-0.5 line-clamp-2" title={message}>{message}</span>
+      <Tooltip content={message} wrapperClassName="!block w-full">
+      <span className="text-theme-text-quaternary mt-0.5 line-clamp-2">{message}</span>
+      </Tooltip>
     </div>
   )
 }

--- a/web/src/components/resource/RestartChart.tsx
+++ b/web/src/components/resource/RestartChart.tsx
@@ -62,13 +62,10 @@ export function RestartEventLane({ kind, namespace, name, range = '1h' }: {
             <Tooltip
               key={i}
               content={`${new Date(r.timestamp * 1000).toLocaleString()} · ${r.label}${r.value > 1 ? ` ×${r.value}` : ''}`}
-            >
-            <div
-              className="absolute top-0 h-full w-px bg-amber-500/80"
-              style={{ left }}
+              wrapperClassName="absolute top-0 h-full w-px bg-amber-500/80"
+              wrapperStyle={{ left }}
             >
               <div className="absolute -top-0.5 left-1/2 -translate-x-1/2 w-1.5 h-1.5 rounded-full bg-amber-500" />
-            </div>
             </Tooltip>
           )
         })}

--- a/web/src/components/resource/RestartChart.tsx
+++ b/web/src/components/resource/RestartChart.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from 'react'
 import { AlertCircle } from 'lucide-react'
 import { usePrometheusResourceMetrics, usePrometheusStatus, type PrometheusSeries, type PrometheusTimeRange } from '../../api/client'
+import { Tooltip } from '../ui/Tooltip'
 
 /**
  * RestartEventLane — vertical markers at each restart event, on a dedicated
@@ -58,14 +59,17 @@ export function RestartEventLane({ kind, namespace, name, range = '1h' }: {
         {restarts.map((r, i) => {
           const left = `${Math.max(0, Math.min(100, ((r.timestamp - windowStart) / span) * 100))}%`
           return (
-            <div
+            <Tooltip
               key={i}
+              content={`${new Date(r.timestamp * 1000).toLocaleString()} · ${r.label}${r.value > 1 ? ` ×${r.value}` : ''}`}
+            >
+            <div
               className="absolute top-0 h-full w-px bg-amber-500/80"
               style={{ left }}
-              title={`${new Date(r.timestamp * 1000).toLocaleString()} · ${r.label}${r.value > 1 ? ` ×${r.value}` : ''}`}
             >
               <div className="absolute -top-0.5 left-1/2 -translate-x-1/2 w-1.5 h-1.5 rounded-full bg-amber-500" />
             </div>
+            </Tooltip>
           )
         })}
       </div>

--- a/web/src/components/resource/RightsizingStrip.tsx
+++ b/web/src/components/resource/RightsizingStrip.tsx
@@ -1,6 +1,7 @@
 import { ArrowRight, Check, Info, AlertTriangle } from 'lucide-react'
 import { SEVERITY_TEXT, SEVERITY_BADGE, type Severity } from '@skyhook-io/k8s-ui/utils/badge-colors'
 import { usePrometheusRightsizing, usePrometheusStatus, type RightsizingTone, type RightsizingRow } from '../../api/client'
+import { Tooltip } from '../ui/Tooltip'
 
 const RIGHTSIZING_KINDS = new Set(['Deployment', 'StatefulSet', 'DaemonSet'])
 
@@ -38,7 +39,9 @@ export function RightsizingStrip({ kind, namespace, name }: {
         <header className="flex items-center justify-between mb-1">
           <h3 className="text-sm font-medium text-theme-text-primary">Right-sizing</h3>
         </header>
-        <p className="text-xs text-theme-text-tertiary" title={msg}>Right-sizing unavailable — Prometheus query failed.</p>
+        <Tooltip content={msg}>
+        <p className="text-xs text-theme-text-tertiary">Right-sizing unavailable — Prometheus query failed.</p>
+        </Tooltip>
       </section>
     )
   }

--- a/web/src/components/resources/ImageFilesystemModal.tsx
+++ b/web/src/components/resources/ImageFilesystemModal.tsx
@@ -7,6 +7,7 @@ import { useImageMetadata, ApiError } from '../../api/client'
 import type { FileNode, ImageFilesystem } from '../../types'
 import { formatBytes } from '../../utils/format'
 import { downloadBlob, filterTree } from './file-browser-utils'
+import { Tooltip } from '../ui/Tooltip'
 import { apiUrl, getAuthHeaders, getCredentialsMode } from '../../api/config'
 
 // Manual fetch function for filesystem (not a hook - gives us full control)
@@ -141,9 +142,11 @@ export function ImageFilesystemModal({
         <div className="flex items-center justify-between p-4 border-b border-theme-border shrink-0">
           <div className="flex-1 min-w-0">
             <h3 className="text-lg font-semibold text-theme-text-primary">Image Filesystem</h3>
-            <p className="text-sm text-theme-text-secondary truncate mt-0.5" title={image}>
+            <Tooltip content={image} wrapperClassName="!block w-full">
+            <p className="text-sm text-theme-text-secondary truncate mt-0.5">
               {image}
             </p>
+            </Tooltip>
             {(displayFilesystem?.platform || metadata?.platform) && (
               <p className="text-xs text-theme-text-tertiary mt-1">
                 Platform: {displayFilesystem?.platform || metadata?.platform}
@@ -245,9 +248,11 @@ export function ImageFilesystemModal({
               <span>{formatBytes(displayFilesystem.totalSize)}</span>
               {displayFilesystem.layers && <span>{displayFilesystem.layers.length} layers</span>}
               {displayFilesystem.digest && (
-                <span className="truncate" title={displayFilesystem.digest}>
+                <Tooltip content={displayFilesystem.digest} wrapperClassName="min-w-0">
+                <span className="truncate">
                   Digest: {displayFilesystem.digest.substring(0, 20)}...
                 </span>
+                </Tooltip>
               )}
             </>
           )}
@@ -362,10 +367,10 @@ function DownloadConfirmation({ metadata, onConfirm, onCancel }: DownloadConfirm
             <pre className="bg-theme-elevated rounded p-3 text-xs text-theme-text-primary overflow-x-auto font-mono">
               {authCommand}
             </pre>
+            <Tooltip content="Copy to clipboard" position="left">
             <button
               onClick={handleCopy}
               className="absolute top-2 right-2 p-1.5 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-base rounded transition-colors"
-              title="Copy to clipboard"
             >
               {copied ? (
                 <Check className="w-4 h-4 text-green-400" />
@@ -373,6 +378,7 @@ function DownloadConfirmation({ metadata, onConfirm, onCancel }: DownloadConfirm
                 <Copy className="w-4 h-4" />
               )}
             </button>
+            </Tooltip>
           </div>
         </div>
       )}
@@ -461,10 +467,10 @@ function AuthenticationHelp({ image, registryType, onRetry }: AuthenticationHelp
             <pre className="bg-theme-elevated rounded p-3 text-xs text-theme-text-primary overflow-x-auto font-mono">
               {authCommand}
             </pre>
+            <Tooltip content="Copy to clipboard" position="left">
             <button
               onClick={handleCopy}
               className="absolute top-2 right-2 p-1.5 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-base rounded transition-colors"
-              title="Copy to clipboard"
             >
               {copied ? (
                 <Check className="w-4 h-4 text-green-400" />
@@ -472,6 +478,7 @@ function AuthenticationHelp({ image, registryType, onRetry }: AuthenticationHelp
                 <Copy className="w-4 h-4" />
               )}
             </button>
+            </Tooltip>
           </div>
         </div>
       )}
@@ -709,11 +716,11 @@ function FileTreeNode({ node, depth, defaultExpanded = true, image, namespace, p
         )}
 
         {isFile && (
+          <Tooltip content="Download file">
           <button
             onClick={handleDownload}
             disabled={downloading}
-            className="p-1 text-theme-text-tertiary hover:text-blue-400 hover:bg-theme-elevated rounded ml-1 disabled:opacity-50"
-            title="Download file"
+            className="p-1 text-theme-text-tertiary hover:text-blue-400 hover:bg-theme-elevated rounded ml-1 disabled:opacity-50 disabled:pointer-events-none"
           >
             {downloading ? (
               <Loader2 className="w-3.5 h-3.5 animate-spin" />
@@ -721,6 +728,7 @@ function FileTreeNode({ node, depth, defaultExpanded = true, image, namespace, p
               <Download className="w-3.5 h-3.5" />
             )}
           </button>
+          </Tooltip>
         )}
       </div>
 

--- a/web/src/components/resources/ImageFilesystemModal.tsx
+++ b/web/src/components/resources/ImageFilesystemModal.tsx
@@ -367,10 +367,10 @@ function DownloadConfirmation({ metadata, onConfirm, onCancel }: DownloadConfirm
             <pre className="bg-theme-elevated rounded p-3 text-xs text-theme-text-primary overflow-x-auto font-mono">
               {authCommand}
             </pre>
-            <Tooltip content="Copy to clipboard" position="left">
+            <Tooltip content="Copy to clipboard" position="left" wrapperClassName="absolute top-2 right-2">
             <button
               onClick={handleCopy}
-              className="absolute top-2 right-2 p-1.5 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-base rounded transition-colors"
+              className="p-1.5 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-base rounded transition-colors"
             >
               {copied ? (
                 <Check className="w-4 h-4 text-green-400" />
@@ -467,10 +467,10 @@ function AuthenticationHelp({ image, registryType, onRetry }: AuthenticationHelp
             <pre className="bg-theme-elevated rounded p-3 text-xs text-theme-text-primary overflow-x-auto font-mono">
               {authCommand}
             </pre>
-            <Tooltip content="Copy to clipboard" position="left">
+            <Tooltip content="Copy to clipboard" position="left" wrapperClassName="absolute top-2 right-2">
             <button
               onClick={handleCopy}
-              className="absolute top-2 right-2 p-1.5 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-base rounded transition-colors"
+              className="p-1.5 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-base rounded transition-colors"
             >
               {copied ? (
                 <Check className="w-4 h-4 text-green-400" />
@@ -716,11 +716,11 @@ function FileTreeNode({ node, depth, defaultExpanded = true, image, namespace, p
         )}
 
         {isFile && (
-          <Tooltip content="Download file">
+          <Tooltip content="Download file" wrapperClassName="ml-1">
           <button
             onClick={handleDownload}
             disabled={downloading}
-            className="p-1 text-theme-text-tertiary hover:text-blue-400 hover:bg-theme-elevated rounded ml-1 disabled:opacity-50 disabled:pointer-events-none"
+            className="p-1 text-theme-text-tertiary hover:text-blue-400 hover:bg-theme-elevated rounded disabled:opacity-50 disabled:pointer-events-none"
           >
             {downloading ? (
               <Loader2 className="w-3.5 h-3.5 animate-spin" />

--- a/web/src/components/resources/PodFilesystemModal.tsx
+++ b/web/src/components/resources/PodFilesystemModal.tsx
@@ -7,6 +7,7 @@ import type { FileNode } from '../../types'
 import { formatBytes } from '../../utils/format'
 import { downloadBlob, filterTree } from './file-browser-utils'
 import { apiUrl, getAuthHeaders, getCredentialsMode } from '../../api/config'
+import { Tooltip } from '../ui/Tooltip'
 
 interface PodFilesystem {
   root: FileNode
@@ -384,11 +385,11 @@ function PodFileTreeNode({ node, namespace, podName, container, onNavigate }: Po
       )}
 
       {isDownloadable && (
+        <Tooltip content="Download file">
         <button
           onClick={handleDownload}
           disabled={downloading}
-          className="p-1 text-theme-text-tertiary hover:text-blue-400 hover:bg-theme-elevated rounded ml-1 disabled:opacity-50"
-          title="Download file"
+          className="p-1 text-theme-text-tertiary hover:text-blue-400 hover:bg-theme-elevated rounded ml-1 disabled:opacity-50 disabled:pointer-events-none"
         >
           {downloading ? (
             <Loader2 className="w-3.5 h-3.5 animate-spin" />
@@ -396,6 +397,7 @@ function PodFileTreeNode({ node, namespace, podName, container, onNavigate }: Po
             <Download className="w-3.5 h-3.5" />
           )}
         </button>
+        </Tooltip>
       )}
     </div>
   )

--- a/web/src/components/resources/PodFilesystemModal.tsx
+++ b/web/src/components/resources/PodFilesystemModal.tsx
@@ -385,11 +385,11 @@ function PodFileTreeNode({ node, namespace, podName, container, onNavigate }: Po
       )}
 
       {isDownloadable && (
-        <Tooltip content="Download file">
+        <Tooltip content="Download file" wrapperClassName="ml-1">
         <button
           onClick={handleDownload}
           disabled={downloading}
-          className="p-1 text-theme-text-tertiary hover:text-blue-400 hover:bg-theme-elevated rounded ml-1 disabled:opacity-50 disabled:pointer-events-none"
+          className="p-1 text-theme-text-tertiary hover:text-blue-400 hover:bg-theme-elevated rounded disabled:opacity-50 disabled:pointer-events-none"
         >
           {downloading ? (
             <Loader2 className="w-3.5 h-3.5 animate-spin" />

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -7,6 +7,7 @@ import { TRANSITION_BACKDROP, TRANSITION_PANEL } from '../../utils/animation'
 import { apiUrl, getAuthHeaders, getCredentialsMode } from '../../api/config'
 import { useCloudRole, useVersionCheck } from '../../api/client'
 import { useCapabilitiesContext } from '../../contexts/CapabilitiesContext'
+import { Tooltip } from '../ui/Tooltip'
 import type { DeploymentMode } from '../../types'
 
 interface Config {
@@ -235,15 +236,16 @@ export function SettingsDialog({ open, onClose, onShowMyPermissions }: SettingsD
         {canEditConfig && (
         <div className="flex items-center justify-between gap-3 p-4 border-t border-theme-border shrink-0">
             <div className="flex items-center gap-2">
+              <Tooltip content="Reset all configuration to defaults">
               <button
                 onClick={resetConfig}
                 disabled={saving}
-                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded-md transition-colors disabled:opacity-50"
-                title="Reset all configuration to defaults"
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded-md transition-colors disabled:opacity-50 disabled:pointer-events-none"
               >
                 <RotateCcw className="w-3.5 h-3.5" />
                 Reset
               </button>
+              </Tooltip>
               {saveMessage && (
                 <span className={clsx(
                   'text-xs',
@@ -479,13 +481,14 @@ function MCPSection({
               <code className="flex-1 px-2.5 py-1.5 text-xs font-mono bg-theme-elevated border border-theme-border rounded-md text-theme-text-primary truncate">
                 {mcpUrl}
               </code>
+              <Tooltip content="Copy MCP URL">
               <button
                 onClick={handleCopy}
                 className="shrink-0 p-1.5 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-elevated rounded-md transition-colors"
-                title="Copy MCP URL"
               >
                 {copied ? <Check className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5" />}
               </button>
+              </Tooltip>
             </div>
           </div>
 

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -481,7 +481,7 @@ function MCPSection({
               <code className="flex-1 px-2.5 py-1.5 text-xs font-mono bg-theme-elevated border border-theme-border rounded-md text-theme-text-primary truncate">
                 {mcpUrl}
               </code>
-              <Tooltip content="Copy MCP URL">
+              <Tooltip content="Copy MCP URL" wrapperClassName="shrink-0">
               <button
                 onClick={handleCopy}
                 className="shrink-0 p-1.5 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-elevated rounded-md transition-colors"

--- a/web/src/components/traffic/TrafficFilterSidebar.tsx
+++ b/web/src/components/traffic/TrafficFilterSidebar.tsx
@@ -1,5 +1,4 @@
-import { memo, useState, useRef } from 'react'
-import { createPortal } from 'react-dom'
+import { memo, useState } from 'react'
 import {
   ChevronDown,
   Eye,
@@ -16,43 +15,7 @@ import { clsx } from 'clsx'
 import { SEVERITY_BADGE } from '@skyhook-io/k8s-ui/utils/badge-colors'
 import type { AddonMode } from './TrafficView'
 import { getNamespaceColor } from '../../utils/traffic-colors'
-
-// Fast tooltip component using portal to escape overflow
-function Tooltip({ children, content }: { children: React.ReactNode; content: string }) {
-  const [show, setShow] = useState(false)
-  const [pos, setPos] = useState({ x: 0, y: 0 })
-  const ref = useRef<HTMLDivElement>(null)
-
-  const handleMouseEnter = () => {
-    if (ref.current) {
-      const rect = ref.current.getBoundingClientRect()
-      setPos({ x: rect.right + 8, y: rect.top + rect.height / 2 })
-    }
-    setShow(true)
-  }
-
-  return (
-    <div
-      ref={ref}
-      className="inline-flex"
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={() => setShow(false)}
-    >
-      {children}
-      {show && createPortal(
-        <div
-          className="fixed z-[9999] pointer-events-none"
-          style={{ left: pos.x, top: pos.y, transform: 'translateY(-50%)' }}
-        >
-          <div className="bg-gray-900 text-white text-[10px] px-2 py-1.5 rounded shadow-lg max-w-[180px] leading-tight whitespace-normal">
-            {content}
-          </div>
-        </div>,
-        document.body
-      )}
-    </div>
-  )
-}
+import { Tooltip } from '../ui/Tooltip'
 
 // Connection threshold options
 const CONNECTION_THRESHOLDS = [
@@ -152,7 +115,7 @@ function ToggleOption({
           {label}
         </span>
       </button>
-      <Tooltip content={description}>
+      <Tooltip content={description} position="right">
         <Info className="w-3 h-3 text-theme-text-tertiary hover:text-theme-text-secondary cursor-help" />
       </Tooltip>
       <button
@@ -225,29 +188,31 @@ export const TrafficFilterSidebar = memo(function TrafficFilterSidebar({
         <div className="px-3 py-2 border-b border-theme-border space-y-1.5">
           <div className="flex items-center gap-2">
             <Clock className="w-3.5 h-3.5 text-theme-text-tertiary" />
+            <Tooltip content="Show traffic from the selected time window" wrapperClassName="!block flex-1">
             <select
               value={timeRange}
               onChange={(e) => setTimeRange(e.target.value)}
-              title="Show traffic from the selected time window"
               className="flex-1 bg-theme-elevated text-theme-text-primary text-xs rounded px-2 py-1.5 border border-theme-border focus:outline-none focus:ring-1 focus:ring-blue-500"
             >
               {TIME_RANGES.map(({ value, label }) => (
                 <option key={value} value={value}>{label}</option>
               ))}
             </select>
+            </Tooltip>
           </div>
           <div className="flex items-center gap-2">
             <Filter className="w-3.5 h-3.5 text-theme-text-tertiary" />
+            <Tooltip content="Hide low-traffic flows to reduce noise" wrapperClassName="!block flex-1">
             <select
               value={minConnections}
               onChange={(e) => setMinConnections(Number(e.target.value))}
-              title="Hide low-traffic flows to reduce noise"
               className="flex-1 bg-theme-elevated text-theme-text-primary text-xs rounded px-2 py-1.5 border border-theme-border focus:outline-none focus:ring-1 focus:ring-blue-500"
             >
               {CONNECTION_THRESHOLDS.map(({ value, label }) => (
                 <option key={value} value={value}>{label}</option>
               ))}
             </select>
+            </Tooltip>
           </div>
         </div>
 
@@ -279,7 +244,7 @@ export const TrafficFilterSidebar = memo(function TrafficFilterSidebar({
             <div className="flex items-center gap-2 mb-1.5">
               <Puzzle className="w-3.5 h-3.5 text-theme-text-tertiary" />
               <span className="text-xs text-theme-text-primary">Cluster Addons</span>
-              <Tooltip content="Monitoring, logging, cert-manager, etc. Excludes ingress controllers and service mesh.">
+              <Tooltip content="Monitoring, logging, cert-manager, etc. Excludes ingress controllers and service mesh." position="right">
                 <Info className="w-3 h-3 text-theme-text-tertiary hover:text-theme-text-secondary cursor-help" />
               </Tooltip>
             </div>

--- a/web/src/components/traffic/TrafficFilterSidebar.tsx
+++ b/web/src/components/traffic/TrafficFilterSidebar.tsx
@@ -188,7 +188,7 @@ export const TrafficFilterSidebar = memo(function TrafficFilterSidebar({
         <div className="px-3 py-2 border-b border-theme-border space-y-1.5">
           <div className="flex items-center gap-2">
             <Clock className="w-3.5 h-3.5 text-theme-text-tertiary" />
-            <Tooltip content="Show traffic from the selected time window" wrapperClassName="!block flex-1">
+            <Tooltip content="Show traffic from the selected time window" wrapperClassName="!flex flex-1">
             <select
               value={timeRange}
               onChange={(e) => setTimeRange(e.target.value)}
@@ -202,7 +202,7 @@ export const TrafficFilterSidebar = memo(function TrafficFilterSidebar({
           </div>
           <div className="flex items-center gap-2">
             <Filter className="w-3.5 h-3.5 text-theme-text-tertiary" />
-            <Tooltip content="Hide low-traffic flows to reduce noise" wrapperClassName="!block flex-1">
+            <Tooltip content="Hide low-traffic flows to reduce noise" wrapperClassName="!flex flex-1">
             <select
               value={minConnections}
               onChange={(e) => setMinConnections(Number(e.target.value))}

--- a/web/src/components/traffic/TrafficFlowList.tsx
+++ b/web/src/components/traffic/TrafficFlowList.tsx
@@ -8,6 +8,7 @@ import { pluralize } from '@skyhook-io/k8s-ui'
 import { useFlowSearch } from './TrafficFlowListContext'
 import { useQuery } from '@tanstack/react-query'
 import { fetchJSON } from '../../api/client'
+import { Tooltip } from '../ui/Tooltip'
 
 // DNS response code names
 const DNS_RCODES: Record<number, string> = {
@@ -174,28 +175,36 @@ export function TrafficFlowList({ flows }: TrafficFlowListProps) {
                   <span className="text-theme-text-tertiary tabular-nums whitespace-nowrap">{time}</span>
 
                   {/* Source */}
-                  <span className="truncate text-theme-text-primary" title={flow.source.namespace ? `${flow.source.namespace}/${flow.source.name}` : flow.source.name}>
+                  <Tooltip content={flow.source.namespace ? `${flow.source.namespace}/${flow.source.name}` : flow.source.name} wrapperClassName="min-w-0">
+                  <span className="truncate text-theme-text-primary">
                     {flow.source.name}
                   </span>
+                  </Tooltip>
 
                   {/* Destination */}
-                  <span className="truncate text-theme-text-primary" title={flow.destination.namespace ? `${flow.destination.namespace}/${flow.destination.name}` : flow.destination.name}>
+                  <Tooltip content={flow.destination.namespace ? `${flow.destination.namespace}/${flow.destination.name}` : flow.destination.name} wrapperClassName="min-w-0">
+                  <span className="truncate text-theme-text-primary">
                     {flow.destination.name}
                   </span>
+                  </Tooltip>
 
                   {/* Request info */}
                   <div className="flex items-center gap-1.5 min-w-0">
                     {isHTTP && (
                       <>
                         <span className={clsx('shrink-0 badge badge-sm text-[10px]', SEVERITY_BADGE.info)}>{flow.httpMethod}</span>
-                        <span className="truncate text-theme-text-secondary" title={flow.httpPath}>{flow.httpPath}</span>
+                        <Tooltip content={flow.httpPath ?? ''} wrapperClassName="min-w-0">
+                        <span className="truncate text-theme-text-secondary">{flow.httpPath}</span>
+                        </Tooltip>
                         {flow.l7Type === 'REQUEST' && <span className={clsx('shrink-0 text-[9px]', SEVERITY_TEXT.warning)}>no response</span>}
                       </>
                     )}
                     {isDNS && (
                       <>
                         <span className={clsx('shrink-0 badge badge-sm text-[10px]', SEVERITY_BADGE.neutral)}>DNS</span>
-                        <span className="truncate text-theme-text-secondary" title={flow.dnsQuery}>{flow.dnsQuery}</span>
+                        <Tooltip content={flow.dnsQuery ?? ''} wrapperClassName="min-w-0">
+                        <span className="truncate text-theme-text-secondary">{flow.dnsQuery}</span>
+                        </Tooltip>
                       </>
                     )}
                     {!isHTTP && !isDNS && (

--- a/web/src/components/traffic/TrafficGraph.tsx
+++ b/web/src/components/traffic/TrafficGraph.tsx
@@ -22,6 +22,7 @@ import { X, ArrowRight, Globe, Server, Activity, Puzzle } from 'lucide-react'
 import { isClusterAddon, type AddonMode } from './TrafficView'
 import { SEVERITY_BADGE, SEVERITY_TEXT } from '@skyhook-io/k8s-ui/utils/badge-colors'
 import { getNamespaceColor } from '../../utils/traffic-colors'
+import { Tooltip } from '../ui/Tooltip'
 
 const elk = new ELK()
 
@@ -845,7 +846,9 @@ function DetailsPanel({
                     {edgeData.flow.topHTTPPaths.map((p, i) => (
                       <div key={i} className="flex items-center gap-1.5 text-[10px]">
                         <span className={clsx('shrink-0 px-1 py-0.5 rounded badge font-medium', SEVERITY_BADGE.info)}>{p.method}</span>
-                        <span className="text-theme-text-primary truncate flex-1" title={p.path}>{p.path || '/'}</span>
+                        <Tooltip content={p.path} wrapperClassName="min-w-0 flex-1">
+                        <span className="text-theme-text-primary truncate flex-1">{p.path || '/'}</span>
+                        </Tooltip>
                         <span className="shrink-0 text-theme-text-secondary">{p.count}</span>
                         {p.avgMs ? <span className="shrink-0 text-theme-text-tertiary">{formatLatency(p.avgMs)}</span> : null}
                         {p.errorPct ? <span className={clsx('shrink-0', p.errorPct > 10 ? SEVERITY_TEXT.error : SEVERITY_TEXT.warning)}>{p.errorPct.toFixed(0)}%err</span> : null}
@@ -862,7 +865,9 @@ function DetailsPanel({
                   <div className="space-y-1 max-h-40 overflow-y-auto">
                     {edgeData.flow.topDNSQueries.map((q, i) => (
                       <div key={i} className="flex items-center gap-1.5 text-[10px]">
-                        <span className="text-theme-text-primary truncate flex-1" title={q.query}>{q.query}</span>
+                        <Tooltip content={q.query} wrapperClassName="min-w-0 flex-1">
+                        <span className="text-theme-text-primary truncate flex-1">{q.query}</span>
+                        </Tooltip>
                         <span className="shrink-0 text-theme-text-secondary">{q.count}</span>
                         {q.nxCount ? <span className={clsx('shrink-0', SEVERITY_TEXT.warning)}>NX:{q.nxCount}</span> : null}
                         {q.avgTTL ? <span className="shrink-0 text-theme-text-tertiary">TTL:{q.avgTTL}s</span> : null}

--- a/web/src/components/traffic/TrafficView.tsx
+++ b/web/src/components/traffic/TrafficView.tsx
@@ -12,6 +12,7 @@ import { clsx } from 'clsx'
 import { useQueryClient } from '@tanstack/react-query'
 import { useDock } from '../dock'
 import { EmptyState, PaneLoader } from '@skyhook-io/k8s-ui'
+import { Tooltip } from '../ui/Tooltip'
 
 // Addon types for filtering
 export type AddonMode = 'show' | 'group' | 'hide'
@@ -1117,11 +1118,12 @@ export function TrafficView({ namespaces }: TrafficViewProps) {
                 {/* Top-right: stats + actions */}
                 <div className="absolute top-3 right-3 z-10 flex items-center gap-2">
                   {flowsData?.flows && flowsData.flows.length > 0 && (
+                    <Tooltip content="Open flow list in dock">
                     <button onClick={openFlowListDock}
-                      className="flex items-center gap-1 px-2 py-1 text-[10px] rounded-lg bg-theme-surface/90 backdrop-blur border border-theme-border text-theme-text-secondary hover:text-theme-text-primary transition-colors"
-                      title="Open flow list in dock">
+                      className="flex items-center gap-1 px-2 py-1 text-[10px] rounded-lg bg-theme-surface/90 backdrop-blur border border-theme-border text-theme-text-secondary hover:text-theme-text-primary transition-colors">
                       <List className="w-3 h-3" /> Flows
                     </button>
+                    </Tooltip>
                   )}
                   <div className="flex items-center gap-1.5 px-2 py-1 rounded-lg bg-theme-surface/90 backdrop-blur border border-theme-border text-[10px] text-theme-text-tertiary">
                     {flowStats.shown}/{flowStats.total}

--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -43,6 +43,7 @@ import { useCanUpdateSecrets, useCanNodeWrite, useNamespacedCapabilities } from 
 import { useOpenTerminal, useOpenLogs, useOpenWorkloadLogs, useOpenNodeTerminal } from '../dock'
 import { PortForwardButton } from '../portforward/PortForwardButton'
 import { useToast } from '../ui/Toast'
+import { Tooltip } from '../ui/Tooltip'
 import { PodRenderer } from '../resources/renderers/PodRenderer'
 import { NodeRenderer } from '../resources/renderers/NodeRenderer'
 import { ServiceRenderer } from '../resources/renderers/ServiceRenderer'
@@ -879,15 +880,18 @@ function FluxSourceConsumersInner({ sourceKind, namespace, name }: { sourceKind:
       </h3>
       <div className="flex flex-wrap gap-1.5">
         {consumers.map((c) => (
-          <button
+          <Tooltip
             key={`${c.kind}/${c.namespace}/${c.name}`}
+            content={`${c.kind} ${c.namespace}/${c.name}`}
+          >
+          <button
             onClick={() => navigate(`/gitops/detail/${c.plural}/${encodeURIComponent(c.namespace)}/${encodeURIComponent(c.name)}`)}
             className="inline-flex items-center gap-1.5 rounded border border-theme-border bg-theme-surface px-1.5 py-0.5 text-[11px] text-theme-text-secondary hover:border-skyhook-500/60 hover:text-skyhook-500 transition-colors"
-            title={`${c.kind} ${c.namespace}/${c.name}`}
           >
             <span className="text-theme-text-tertiary">{c.kind === 'HelmRelease' ? 'HR' : 'K'}</span>
             <span>{c.namespace}/{c.name}</span>
           </button>
+          </Tooltip>
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary

Hover hints across the web UI used the browser's native `title` attribute — an unstyled gray box in the system font with a ~1s delay that ignores our theme entirely (and looks especially broken in dark mode). This migrates all **80** of them across **30 components** to the shared `<Tooltip>`, so every hint matches the app's surface, motion, and timing — and corrects the positioning/layout regressions that come from wrapping arbitrary controls in a tooltip span.

## What changed

**80 native `title=` → `<Tooltip>`** across helm, traffic, resource, home, nav, cost, audit, settings, and top-level chrome. Component props named `title` (`<PageHeader>`, `<ConfirmDialog>`, `<CreateResourceDialog>`, `<Section>`, `<DualLineChart>`, …) and SVG `<title>` children are untouched.

**Disabled triggers.** Native `title` fires on disabled elements, but a themed tooltip's hover handlers live on its wrapper span — and a disabled button swallows pointer events. Every control that shows its hint *while disabled* (helm write-gated actions across HelmReleaseDrawer / ValuesViewer / InstallWizard / ChartBrowser, port-forward, audit + settings Save, Reconnect, file downloads) gets `disabled:pointer-events-none` so hover passes through to the wrapper.

**Positioned triggers (review focus).** `<Tooltip>` measures its popup position from the wrapper span's `getBoundingClientRect()`. For an `absolute`/`fixed` child the wrapper is a 0×0 in-flow box, so the tooltip rendered detached from the visible control. Fixed by moving positioning onto `wrapperClassName` / `wrapperStyle` (DebugOverlay's fixed button, ImageFilesystemModal copy buttons, RestartChart markers) — matching the one site that already did it right (MCPSetupDialog). Related subtlety worth knowing: empty `content` makes `<Tooltip>` render its child *unwrapped*, so layout-critical classes belong on the child, not the conditional wrapper (e.g. `mb-1.5` on the in-cluster headline).

**Layout-aware wrapping.** The `inline-flex` wrapper can disrupt sizing: truncating flex items pass `wrapperClassName="min-w-0"`; full-width selects use `!flex flex-1`; self-sized controls keep `shrink-0` / `w-fit` on the wrapper (so hover targets and squish-resistance survive). Redundant `title`s duplicating an `aria-label` were dropped.

**Local-tooltip cleanup.** `TrafficFilterSidebar` had its own hand-rolled `bg-gray-900` portal tooltip — exactly the kind of off-theme tooltip this change targets. Consolidated its usages onto the shared `<Tooltip>` and deleted the duplicate implementation (and the now-unused `createPortal` / `useRef`).

## Testing

- `npm run tsc` (in `web/`) — clean.
- Visually verified against a live GKE cluster (23 helm releases, caretta, opencost): themed tooltips render and track dark mode across the helm drawer, traffic sidebar, cost, home, checks, and resource drawer. The full-width-select fix and the `w-fit`-badge fix were confirmed by measuring wrapper vs. child widths (selects fill, badge wrappers match the badge).
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only swap with no handler or API changes; main review focus is disabled-button tooltip behavior and truncation/layout regressions.
> 
> **Overview**
> Replaces browser **`title`** hover hints across the web UI with the shared **`<Tooltip>`** from `@skyhook-io/k8s-ui`, so hints match theme, timing, and positioning instead of the default OS tooltip.
> 
> Coverage spans top bar chrome (`App.tsx`), connection errors, helm, traffic, cost, audit, nav rail, port-forward, resource drawers, and home cards. Component **`title` props** (e.g. `PageHeader`, `ConfirmDialog`) and SVG `<title>` elements are unchanged.
> 
> **Disabled controls:** Native `title` still fires on disabled buttons; themed tooltips need hover on the wrapper, so gated/disabled actions (helm write, reconnect, save, port-forward, downloads) add **`disabled:pointer-events-none`** so explanations still show on hover.
> 
> **Layout:** Tooltip wrappers use **`wrapperClassName`** (`min-w-0`, `!block`, `flex-1`, etc.) where `inline-flex` would break truncation or full-width controls; some margins moved from the child to the wrapper.
> 
> **Cleanup:** **`TrafficFilterSidebar`** drops its local gray portal tooltip and uses the shared component (removes duplicate `createPortal` / positioning logic).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9a3b85bc891f5908a3ebe7c387d9da8ca929a71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
