### PR TITLE
feat(nav): onHostNavigate for smooth same-document host hand-off

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -179,6 +179,32 @@ function AppInner() {
   const capabilities = useCapabilitiesContext()
   const openLocalTerminal = useOpenLocalTerminal()
   const navCustomization = useNavCustomization()
+  // Hand off to a host-owned URL. The host's `onHostNavigate` (Radar Cloud's
+  // cross-tree swap) navigates same-document so the chrome morphs instead of
+  // cold-booting; without it we fall back to a hard `window.location` nav.
+  const goHost = useCallback(
+    (url: string) => {
+      if (navCustomization.onHostNavigate) navCustomization.onHostNavigate(url)
+      else window.location.assign(url)
+    },
+    [navCustomization],
+  )
+  // Resolve every host-takeover URL ONCE (memoized on navCustomization) so the
+  // setMainView intercept, redirect effect, nav-pill filtering, inline-view
+  // gating, and the cert click handler all consume the SAME value — host
+  // callbacks aren't guaranteed idempotent (scope / flags / signed URLs can
+  // shift between calls). undefined = not taken over → Radar renders the view
+  // itself. `clusterChecksHref` is the deprecated pre-1.7 hook, folded into the
+  // 'checks' target for back-compat.
+  const takeover: Record<FleetTakeoverTarget, string | undefined> = useMemo(
+    () => ({
+      issues: navCustomization.fleetTakeoverHref?.('issues'),
+      gitops: navCustomization.fleetTakeoverHref?.('gitops'),
+      checks: navCustomization.fleetTakeoverHref?.('checks') ?? navCustomization.clusterChecksHref?.(),
+      certs: navCustomization.fleetTakeoverHref?.('certs'),
+    }),
+    [navCustomization],
+  )
   const { pinned: navRailPinned, togglePinned: toggleNavRailPinned } = useNavRailPinned()
   // Standalone Radar gets the left nav rail; embedded hosts (Radar Hub) own
   // the left chrome via their own fleet rail and keep Radar's top-bar pills.
@@ -258,6 +284,20 @@ function AppInner() {
 
   // Set mainView by navigating to the path
   const setMainView = useCallback((view: ExtendedMainView, params?: Record<string, string>) => {
+    // Host takeover: fleet-shaped views (issues/gitops/checks) are owned by the
+    // host's fleet pages. Hand straight to the host instead of navigating to
+    // our own /<view> first — that intermediate hop mounts the view machinery
+    // and flashes the "Opening…" splash before the redirect effect bounces out.
+    // Skipping it makes the hand-off a single smooth cross-tree swap. (Direct
+    // /<view> URL entry still funnels through the redirect effect below.)
+    if (view === 'issues' || view === 'gitops' || view === 'checks') {
+      const href = takeover[view]
+      if (href) {
+        goHost(href)
+        return
+      }
+    }
+
     const path = view === 'home' ? '/' : `/${view}`
 
     // Start fresh — keep only cross-view params (namespaces), discard all view-specific ones
@@ -275,32 +315,15 @@ function AppInner() {
     }
 
     navigate({ pathname: path, search: newParams.toString() })
-  }, [navigate, searchParams])
+  }, [navigate, searchParams, takeover, goHost])
 
   // Cloud (embedded) takes over the "fleet-shaped" per-cluster views with its
   // own fleet pages scoped to this cluster — owned by the host's left rail — so
-  // Radar drops the matching pills (see the nav below) and any route into one
-  // of these views redirects to the host. Entry points that still land on the
-  // view — Home cards, ⌘K, WorkloadView's "view all" findings, bookmarks/deep
-  // links — all funnel through here. The view name doubles as the takeover
-  // target ('issues' | 'gitops' | 'checks'; 'audit' normalizes to 'checks' via
-  // getViewFromPath). `replace` (not assign) keeps the transient /<view> URL
-  // out of history so Back doesn't bounce off the redirect. Standalone OSS (no
-  // fleetTakeoverHref) is unaffected and renders the in-app view as before.
-  // Resolve every takeover target's host URL ONCE per render so the redirect
-  // effect, nav-pill filtering, inline-view gating, and the cert click handler
-  // all close over the SAME value — host callbacks aren't guaranteed idempotent
-  // (scope / flags / signed URLs can shift between calls). undefined = not taken
-  // over → Radar renders the view itself. `clusterChecksHref` is the deprecated
-  // pre-1.7 hook, folded into the 'checks' target for back-compat.
-  const fleetTakeoverHref = navCustomization.fleetTakeoverHref
-  const clusterChecksHref = navCustomization.clusterChecksHref
-  const takeover: Record<FleetTakeoverTarget, string | undefined> = {
-    issues: fleetTakeoverHref?.('issues'),
-    gitops: fleetTakeoverHref?.('gitops'),
-    checks: fleetTakeoverHref?.('checks') ?? clusterChecksHref?.(),
-    certs: fleetTakeoverHref?.('certs'),
-  }
+  // Radar drops the matching pills (see the nav below). In-app nav hands off in
+  // setMainView (above); direct /<view> URL entry funnels through the redirect
+  // effect below. Both consume the memoized `takeover` resolved above. Standalone
+  // OSS (no fleetTakeoverHref) is unaffected and renders the in-app view.
+  //
   // Has the host claimed this view? View-shaped targets only ('certs' has no
   // Radar view — only its Home card consults `takeover`). Used to drop the nav
   // pill and gate the inline view render in favor of the "Opening…" splash.
@@ -1641,7 +1664,7 @@ function AppInner() {
             // belongs in history. Omitted → the card falls back to Radar's own
             // TLS-secrets resource list.
             onNavigateToCerts={
-              takeover.certs ? () => window.location.assign(takeover.certs!) : undefined
+              takeover.certs ? () => goHost(takeover.certs!) : undefined
             }
           />
         )}

--- a/web/src/components/compare/useCompareLauncher.tsx
+++ b/web/src/components/compare/useCompareLauncher.tsx
@@ -31,15 +31,18 @@ export function useCompareLauncher({ kind, namespace, name, group }: UseCompareL
   const [open, setOpen] = useState(false)
   const kindLower = kind.toLowerCase()
   const { candidates, isPending, error } = useCompareCandidates(kindLower, group, open)
-  const { crossClusterCompareHref } = useNavCustomization()
+  const { crossClusterCompareHref, onHostNavigate } = useNavCustomization()
 
   const onCompareTo = useCallback(() => setOpen(true), [])
 
   const onCompareAcrossClusters = useCallback(() => {
     if (!crossClusterCompareHref) return
     const href = crossClusterCompareHref({ kind: kindLower, namespace, name, group })
-    window.location.assign(href)
-  }, [crossClusterCompareHref, kindLower, namespace, name, group])
+    // Smooth same-document hand-off when the host supports it (Radar Cloud's
+    // cross-tree swap), else a hard nav — same contract as App.tsx's goHost.
+    if (onHostNavigate) onHostNavigate(href)
+    else window.location.assign(href)
+  }, [crossClusterCompareHref, onHostNavigate, kindLower, namespace, name, group])
 
   const handlePick = useCallback(
     (picked: CompareResourceRef) => {

--- a/web/src/context/NavCustomization.tsx
+++ b/web/src/context/NavCustomization.tsx
@@ -54,11 +54,14 @@ interface NavCustomizationBase {
    *                 `clusterChecksHref` folded in here)
    *   - 'certs'   → the Certificate Health card
    *
-   * View-shaped targets (issues / gitops / checks) are also honored for any
-   * entry into that view — ⌘K, bookmarks, deep links — via a redirect effect
-   * in App.tsx, using window.location.replace so the transient /<view> URL
-   * stays out of history. 'certs' has no Radar view, so only the card consults
-   * it (window.location.assign — a real forward navigation the user initiated).
+   * View-shaped targets (issues / gitops / checks) are honored for every entry:
+   * in-app nav (Home cards, ⌘K, "view all") hands straight to the host from
+   * `setMainView` via `onHostNavigate` (smooth same-document hand-off, no
+   * intermediate /<view> mount); a direct /<view> URL (bookmark/deep link)
+   * funnels through a redirect effect that uses `window.location.replace` so
+   * the transient URL stays out of history. 'certs' has no Radar view, so only
+   * the card consults it. `onHostNavigate` is optional — without it everything
+   * falls back to `window.location` (a hard reload).
    */
   fleetTakeoverHref?: (target: FleetTakeoverTarget) => string | undefined;
   /**
@@ -68,6 +71,17 @@ interface NavCustomizationBase {
    * change. Remove in a major release once all consumers have migrated.
    */
   clusterChecksHref?: () => string;
+  /**
+   * Optional smooth navigator for host-owned URLs. When the host takes a
+   * destination over (`fleetTakeoverHref`, `crossClusterCompareHref`), Radar
+   * would otherwise hand off via `window.location` — a full document reload
+   * that cold-boots the host (white flash, re-auth, chrome teardown). A host
+   * that can navigate SAME-DOCUMENT (e.g. Radar Cloud's cross-tree swap with a
+   * View Transition) passes this so the hand-off morphs instead of reloading.
+   * Omitted → Radar falls back to `window.location` (hard nav), so standalone
+   * OSS / other hosts are unaffected.
+   */
+  onHostNavigate?: (url: string) => void;
   /**
    * Chrome level for embedded hosts. Default ('full', or omitted) renders
    * Radar's top bar + the view-switcher. 'none' suppresses BOTH — the host


### PR DESCRIPTION
## What

Adds `NavCustomization.onHostNavigate(url)` so an embedded host can take over navigations **same-document** instead of a hard `window.location` reload.

## Why

When Radar Cloud's cluster home dashboard routes a fleet-shaped card (Issues / GitOps / Checks / Certs) or a cross-cluster Compare out to a host fleet page, Radar hands off via `window.location` — a **full document reload**. That cold-boots the host: white flash, re-auth probe, chrome teardown. The cluster→fleet transition reads as: `"Opening…"` splash → hard reload → host `"Radar"` cold-boot splash → page. Two splashes + a rail teardown for what should be one smooth swap.

The host *can* navigate same-document (Radar Cloud's cross-tree swap with a View Transition) — it just had no way to tell Radar to use it.

## How

- **`NavCustomization.onHostNavigate?: (url) => void`** — optional smooth navigator. Omitted → Radar falls back to `window.location` (standalone OSS / other hosts unaffected).
- **`App.tsx`**:
  - New `goHost(url)` helper: `onHostNavigate(url)` if present, else `window.location.assign(url)`.
  - `setMainView` now hands fleet-shaped views (issues/gitops/checks with a takeover href) **straight to the host and returns** — skipping the intermediate `/<view>` mount and the `"Opening…"` splash entirely. This covers Home cards, ⌘K, "view all", nav.
  - The cert card uses `goHost`. The direct-`/<view>`-URL redirect effect stays `window.location.replace` (rare bookmark fallback; avoids a Back-trap).
  - Takeover URLs are resolved **once** (memoized on `navCustomization`) and consumed by `setMainView`, the effect, nav-pill filtering, gating, and the cert handler — preserving the single-resolution invariant (host callbacks may be non-idempotent).
- **`useCompareLauncher`**: cross-cluster compare uses `onHostNavigate` when present.

## Compatibility

Purely additive. No host passing `onHostNavigate` → identical `window.location` behavior as today. → minor `radar-app` bump.

## Verification

`tsc` + `vite build` clean. Cross-reviewed (codex, adversarial) — caught + fixed a single-resolution-invariant violation in the first cut (the intercept now consumes the memoized `takeover`).

## Release

Publish a new `radar-app` tag; Radar Hub then passes `onHostNavigate: (url) => crossTreeNavigate(url)` and bumps its pin.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional API with unchanged fallback when `onHostNavigate` is omitted; navigation-only changes with no auth or data-path impact.
> 
> **Overview**
> Adds optional **`NavCustomization.onHostNavigate`** so embedded hosts can hand off to fleet-owned URLs **same-document** instead of always using `window.location` (full reload).
> 
> **`App.tsx`** introduces **`goHost`**: calls `onHostNavigate` when provided, else `window.location.assign`. Fleet takeover URLs are resolved **once** via `useMemo` on `navCustomization`. **`setMainView`** now intercepts issues/gitops/checks when the host claims them and calls **`goHost`** immediately—skipping the intermediate `/<view>` route and **"Opening…"** splash. Bookmark/deep-link entry still uses **`window.location.replace`** in the redirect effect. The Certificate Health card uses **`goHost`** instead of raw `assign`.
> 
> **`useCompareLauncher`** uses the same pattern for cross-cluster compare.
> 
> Docs in **`NavCustomization`** describe the in-app vs bookmark hand-off split. Hosts that omit the hook keep prior hard-nav behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85b8058fe23c8cf9302678a31d26e2e4ededf4dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->