### PR TITLE
chore(web): clean & enforce react-hooks/exhaustive-deps

### DIFF
--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -21,9 +21,9 @@ export default tseslint.config(
     rules: {
       // ✅ Cleaned — keep blocking.
       'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'error',
 
       // ⏳ Ratchet queue (real signal; promote to error as each is cleaned).
-      'react-hooks/exhaustive-deps': 'warn',
       'react-hooks/set-state-in-effect': 'warn',
       'react-hooks/refs': 'warn',
       'react-hooks/static-components': 'warn',

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -897,7 +897,7 @@ function AppInner() {
       name: node.name,
       group: apiVersionToGroup(node.data.apiVersion as string | undefined),
     })
-  }, [navigate])
+  }, [navigate, navigateToResource])
 
   // Serialize namespaces for stable dependency tracking
   const namespacesKey = namespaces.join(',')
@@ -1113,6 +1113,11 @@ function AppInner() {
       // Switching to specific namespaces - disable namespace grouping
       setGroupingMode('none')
     }
+    // Intentionally runs ONLY when the namespace selection changes. It reads the
+    // current groupingMode but must not re-run when grouping changes, or it would
+    // immediately revert a manual/fleet grouping choice. namespacesKey is the
+    // manual dependency standing in for the namespaces array.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [namespacesKey])
 
   // Clear resource selection when changing views or namespaces

--- a/web/src/components/applications/ApplicationsView.tsx
+++ b/web/src/components/applications/ApplicationsView.tsx
@@ -28,7 +28,7 @@ interface ApplicationsViewProps {
 
 export function ApplicationsView({ namespaces, onOpenResource }: ApplicationsViewProps) {
   const query = useApplications(namespaces)
-  const apps = query.data?.applications ?? []
+  const apps = useMemo(() => query.data?.applications ?? [], [query.data])
 
   // Which app is open lives in the URL (?app=<key>) so the detail view is
   // deep-linkable and the browser back button returns to the list. Opening or

--- a/web/src/components/compare/CompareViewRoute.tsx
+++ b/web/src/components/compare/CompareViewRoute.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import {
   ResourceCompareView,
@@ -23,13 +23,21 @@ export function CompareViewRoute() {
   // reserved for topology grouping mode and gets stripped by App.tsx's URL
   // sync on every non-topology view.
   const group = searchParams.get('apiGroup') ?? undefined
-  const aParsed = parseRef(searchParams.get('a'))
-  const bParsed = parseRef(searchParams.get('b'))
+  const aRaw = searchParams.get('a')
+  const bRaw = searchParams.get('b')
 
   const [pickerOpen, setPickerOpen] = useState<CompareSide | null>(null)
 
-  const a: CompareResourceRef | null = aParsed ? { kind, namespace: aParsed.namespace, name: aParsed.name, group } : null
-  const b: CompareResourceRef | null = bParsed ? { kind, namespace: bParsed.namespace, name: bParsed.name, group } : null
+  // Memoized so the refs keep a stable identity across renders — otherwise the
+  // useCallbacks below (which depend on a/b) would be rebuilt every render.
+  const a: CompareResourceRef | null = useMemo(() => {
+    const p = parseRef(aRaw)
+    return p ? { kind, namespace: p.namespace, name: p.name, group } : null
+  }, [aRaw, kind, group])
+  const b: CompareResourceRef | null = useMemo(() => {
+    const p = parseRef(bRaw)
+    return p ? { kind, namespace: p.namespace, name: p.name, group } : null
+  }, [bRaw, kind, group])
 
   const aQuery = useResource<unknown>(a?.kind ?? '', a?.namespace ?? '', a?.name ?? '', a?.group)
   const bQuery = useResource<unknown>(b?.kind ?? '', b?.namespace ?? '', b?.name ?? '', b?.group)

--- a/web/src/components/cost/CostTrendChart.tsx
+++ b/web/src/components/cost/CostTrendChart.tsx
@@ -164,7 +164,7 @@ function StackedAreaChart({ series }: { series: OpenCostTrendSeries[] }) {
     })
 
     return { timestamps, stacked, minTs, maxTs, yMax, seriesLookups, toX, toY, yTicks, xTicks, paths }
-  }, [series])
+  }, [series, plotHeight, plotWidth])
 
   // Hover data — depends on hoverX + chartData, must be a separate hook (called unconditionally)
   const hoverData = useMemo(() => {
@@ -193,7 +193,7 @@ function StackedAreaChart({ series }: { series: OpenCostTrendSeries[] }) {
     })
 
     return { ts: closestTs, x: toX(closestTs), total, points }
-  }, [hoverX, chartData, series])
+  }, [hoverX, chartData, series, plotWidth])
 
   const handleMouseMove = useCallback((e: React.MouseEvent<SVGRectElement>) => {
     const svg = svgRef.current

--- a/web/src/components/helm/InstallWizard.tsx
+++ b/web/src/components/helm/InstallWizard.tsx
@@ -191,7 +191,7 @@ export function InstallWizard({ repo, chartName, version, source, repoUrl, defau
     } finally {
       setIsInstalling(false)
     }
-  }, [releaseName, namespace, chartName, version, repo, valuesYaml, createNamespace, onSuccess, isLocal, artifactHubDetail, queryClient])
+  }, [releaseName, namespace, chartName, version, repo, repoUrl, valuesYaml, createNamespace, onSuccess, isLocal, artifactHubDetail, queryClient])
 
   // Validate release name + namespace before letting the user
   // advance. Without this, a name like "Invalid Name With Spaces!"

--- a/web/src/components/home/ActivitySummary.tsx
+++ b/web/src/components/home/ActivitySummary.tsx
@@ -82,6 +82,9 @@ export function ActivitySummary({ namespaces, topology, onNavigate }: ActivitySu
     limit: 1000,
   })
 
+  // Intentionally re-sample 'now' only when events refresh (not every render),
+  // so the timeline window stays stable between data updates.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const now = useMemo(() => Date.now(), [events])
   const spanMs = SPAN_MINUTES * 60 * 1000
   const startTime = now - spanMs

--- a/web/src/components/issues/IssuesPane.tsx
+++ b/web/src/components/issues/IssuesPane.tsx
@@ -33,7 +33,7 @@ export function IssuesPane({ namespaces, onNavigateToResource }: IssuesPaneProps
   const { data, isLoading, error } = useIssues(namespaces)
   const [severityFilter, setSeverityFilter] = useState<Set<IssueSeverity>>(new Set())
 
-  const allIssues = data?.issues ?? []
+  const allIssues = useMemo(() => data?.issues ?? [], [data])
   const totals = useMemo(() => {
     const t: Record<IssueSeverity, number> = { critical: 0, warning: 0 }
     for (const i of allIssues) t[i.severity] = (t[i.severity] ?? 0) + 1

--- a/web/src/components/traffic/TrafficGraph.tsx
+++ b/web/src/components/traffic/TrafficGraph.tsx
@@ -1505,6 +1505,9 @@ export function TrafficGraph({ flows, hotPathThreshold = 0, showNamespaceGroups 
         }, 50)
         return () => clearTimeout(timer)
       }
+      // layoutedNodes is outer-scope state read here to re-fit once nodes land;
+      // keeping it as a dep preserves that trigger.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [fitView, layoutedNodes])
 
     return null


### PR DESCRIPTION
Follow-up to #980 (the ESLint foundation, now merged) — the second step of the ratchet.

## Summary

Second step of the ESLint ratchet: fixes all 11 `react-hooks/exhaustive-deps` findings and promotes the rule from `warn` to `error`, so missing/incorrect effect deps now block CI.

These are the dependency-array warnings — genuine stale-closure and broken-memoization risks `tsc` can't see.

## What changed

**Real missing deps** (added where the value is stable):
- App topology-nav `useCallback` → `navigateToResource` (a stable `useCallback`).
- InstallWizard install `useCallback` → `repoUrl`.
- CostTrendChart `useMemo`s → `plotWidth` / `plotHeight`.

**Broken memoization** — derived arrays/objects rebuilt every render (new identity → downstream `useMemo`/`useCallback` recomputed every render). Wrapped in `useMemo`:
- ApplicationsView `apps`, IssuesPane `allIssues`, CompareViewRoute `a`/`b`.

**Intentional cases** — documented with `eslint-disable-next-line` (zero behavior change, not silenced blindly):
- The namespace-grouping auto-default `useEffect` intentionally runs only on namespace change: it reads the current `groupingMode` but must not re-run when grouping changes, or it would revert a manual/fleet grouping choice.
- ActivitySummary re-samples `now` only when events refresh (deliberate cache-bust).
- TrafficGraph's fit-view effect reads outer-scope layout state to re-fit once nodes land.

## Testing

- `npm run lint` → 0 errors, 166 warnings (exit 0); `exhaustive-deps` count is now 0.
- `npm run tsc` — clean.

Next ratchet step after this: `react-hooks/set-state-in-effect` (30) or the small correctness bundle.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint policy plus hook dependency hygiene with no auth or data-path changes; intentional disables are documented and preserve existing behavior.
> 
> **Overview**
> **ESLint ratchet:** `react-hooks/exhaustive-deps` moves from `warn` to **`error`**, so missing or wrong effect/callback deps fail CI.
> 
> **Dependency fixes:** Stable callbacks get real deps (`navigateToResource` on topology navigation, `repoUrl` on Helm install). Chart memos include `plotWidth` / `plotHeight` where layout drives paths and hover math.
> 
> **Memoization:** Derived lists/refs that were new every render are wrapped in `useMemo` — applications list, issues list, compare side `a`/`b` refs — so downstream hooks and callbacks stop invalidating every paint.
> 
> **Intentional exceptions** (commented `eslint-disable-next-line`, behavior unchanged): namespace auto-grouping runs only on namespace changes (not when the user toggles grouping); activity timeline’s `now` advances only when events refresh; traffic graph fit-view still keys off layout node arrival.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6d5139bfacf89cc22a13f224717ebba75019e41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->