### PR TITLE
feat(ui): 'Your access on this cluster' — restricted-resources surface (WS3-2c)

### DIFF
--- a/web/src/components/settings/MyPermissionsDialog.tsx
+++ b/web/src/components/settings/MyPermissionsDialog.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
-import { Shield, X, Loader2 } from 'lucide-react'
+import { Shield, X, Loader2, Lock, ExternalLink } from 'lucide-react'
 import { clsx } from 'clsx'
+import { useQuery } from '@tanstack/react-query'
 import {
   rbacVerbBadgeClass,
   rbacResourceBadgeClass,
@@ -11,7 +12,7 @@ import {
 } from '@skyhook-io/k8s-ui'
 import { useAnimatedUnmount } from '../../hooks/useAnimatedUnmount'
 import { TRANSITION_BACKDROP, TRANSITION_PANEL } from '../../utils/animation'
-import { useNamespaces, useAuthMe } from '../../api/client'
+import { useNamespaces, useAuthMe, fetchJSON } from '../../api/client'
 import { useRBACWhoami } from '../../api/rbac'
 
 interface MyPermissionsDialogProps {
@@ -71,7 +72,7 @@ export function MyPermissionsDialog({ open, onClose }: MyPermissionsDialogProps)
         <div className="flex items-center justify-between p-4 border-b border-theme-border shrink-0">
           <div className="flex items-center gap-2">
             <Shield className="w-5 h-5 text-theme-text-secondary" />
-            <h2 className="text-lg font-semibold text-theme-text-primary">My Permissions</h2>
+            <h2 className="text-lg font-semibold text-theme-text-primary">Your access on this cluster</h2>
           </div>
           <button
             onClick={onClose}
@@ -134,6 +135,8 @@ export function MyPermissionsDialog({ open, onClose }: MyPermissionsDialogProps)
           ) : whoami ? (
             <PermissionsTable whoami={whoami} />
           ) : null}
+
+          <RestrictedResources enabled={open} />
         </div>
       </div>
     </div>,
@@ -226,6 +229,62 @@ function ResourceRuleRow({ rule }: { rule: { verbs?: string[]; apiGroups?: strin
           ))}
         </>
       )}
+    </div>
+  )
+}
+
+// displayKind strips the API group from a resource-counts key ("group/Kind" →
+// "Kind"; core kinds have no prefix).
+function displayKind(countKey: string): string {
+  const i = countKey.indexOf('/')
+  return i === -1 ? countKey : countKey.slice(i + 1)
+}
+
+// RestrictedResources surfaces the kinds Radar isn't showing the user (the
+// resource-counts `forbidden` set) — the "what's hidden from me" half of access,
+// alongside the SelfSubjectRulesReview rules above. That set mixes RBAC denials
+// with not-installed/not-watched kinds, so the copy says "usually RBAC" rather
+// than asserting a cause, and links to the docs that carry the unblock RBAC.
+function RestrictedResources({ enabled }: { enabled: boolean }) {
+  const { data } = useQuery<{ forbidden?: string[] }>({
+    queryKey: ['resource-counts', 'your-access'],
+    queryFn: () => fetchJSON('/resource-counts'),
+    enabled,
+    staleTime: 10000,
+  })
+  const forbidden = data?.forbidden ?? []
+  if (forbidden.length === 0) return null
+
+  return (
+    <div>
+      <div className="text-xs font-medium text-theme-text-secondary uppercase tracking-wider mb-2 flex items-center gap-1.5">
+        <Lock className="w-3.5 h-3.5 text-amber-400" />
+        Restricted or unavailable ({forbidden.length})
+      </div>
+      <p className="text-xs text-theme-text-tertiary mb-2">
+        Resource types Radar isn't showing you — usually because your RBAC doesn't allow listing
+        them, sometimes because the type isn't installed or watched on this cluster. Either way,
+        not an empty cluster.
+      </p>
+      <div className="flex flex-wrap gap-1.5">
+        {forbidden.map((k) => (
+          <span
+            key={k}
+            className="inline-flex items-center px-2 py-0.5 text-xs rounded border border-theme-border bg-theme-elevated text-theme-text-secondary"
+          >
+            {displayKind(k)}
+          </span>
+        ))}
+      </div>
+      <a
+        href="https://radarhq.io/docs/cloud/rbac"
+        target="_blank"
+        rel="noreferrer"
+        className="inline-flex items-center gap-1 text-xs text-accent-text hover:underline mt-2"
+      >
+        How to get access
+        <ExternalLink className="w-3 h-3" />
+      </a>
     </div>
   )
 }


### PR DESCRIPTION
## What
Turns the *My Permissions* dialog into the consolidated **"Your access on this cluster"** anchor the denied-vs-empty work points to. It already showed what you *can* do (SelfSubjectRulesReview rules); this adds the missing half — **what's restricted**:

- A **Restricted resources** section listing the kinds your RBAC can't list (from the `/resource-counts` `forbidden` set that radar#974 populates), shown as chips.
- Honest framing — *"an access boundary, not an empty cluster"* — and never claims *why* the SAR failed.
- A **How to get access** link to the RBAC docs (radar-docs#24 carries the troubleshooting + the exact ClusterRole YAML).

## Composes with
- radar#974 (backend surfaces denied kinds as `forbidden`)
- radar#975 (`RestrictedState` per-kind empty state — this is the cluster-wide summary it complements)
- radar-docs#24 (the "I can't see Nodes" troubleshooting the link targets)

## Verification
`make tsc` ✓. **visual-test: not run** — the Restricted-resources state only renders when a kind is RBAC-denied (needs an auth-mode cluster + restricted identity, same prerequisite as #975). Recommend one combined visual pass on a restricted cluster covering #975 + this. Dialog otherwise follows existing patterns.

## Follow-up (noted, not done)
Wire the per-kind `RestrictedState` (#975) 'see your full access' to open this dialog — cross-cutting (k8s-ui → host callback), deferred.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only UI and an existing `/resource-counts` endpoint; no auth or mutation paths change.
> 
> **Overview**
> Renames the permissions dialog to **"Your access on this cluster"** and adds a **Restricted or unavailable** section below the existing SelfSubjectRulesReview table.
> 
> When the dialog is open, it fetches `/resource-counts` and renders the `forbidden` kinds as chips (via `displayKind` to strip API group prefixes). Copy explains these are types Radar is not showing—often RBAC, sometimes missing/unwatched CRDs—and links to RBAC docs for **How to get access**. The section is hidden when `forbidden` is empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ee965debfc7018b85d66f0bbb1d5a92faa5ab75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->