### PR TITLE
fix(sse): RBAC filtering on the topology + k8s_event streams

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3705,7 +3705,12 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	r.URL.RawQuery = q.Encode()
-	s.broadcaster.HandleSSE(w, r)
+	// Cluster-scoped topology kinds (Nodes, PV, StorageClass, NodePool, …) have
+	// no namespace to filter on, so strip the ones this user can't list — the
+	// same gate the REST /api/topology handler applies. Resolved here (the
+	// request is available) and threaded through so the broadcast loop never
+	// runs a SAR.
+	s.broadcaster.HandleSSE(w, r, s.deniedClusterScopedTopoKinds(r))
 }
 
 // Settings handlers

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3710,7 +3710,18 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	// same gate the REST /api/topology handler applies. Resolved here (the
 	// request is available) and threaded through so the broadcast loop never
 	// runs a SAR.
-	s.broadcaster.HandleSSE(w, r, s.deniedClusterScopedTopoKinds(r))
+	deny := s.deniedClusterScopedTopoKinds(r)
+	// Namespace objects are cluster-scoped too (a Namespace k8s_event carries
+	// namespace=""), but Namespace is deliberately not in the topology table.
+	// Deny its change frames when the user can't list namespaces, so a
+	// namespace-restricted user doesn't learn namespace names via SSE.
+	if !s.canRead(r, "", "namespaces", "", "list") {
+		if deny == nil {
+			deny = map[topology.NodeKind]bool{}
+		}
+		deny[topology.KindNamespace] = true
+	}
+	s.broadcaster.HandleSSE(w, r, deny)
 }
 
 // Settings handlers

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -58,6 +58,11 @@ type ClientInfo struct {
 	Namespaces       []string // Filter to specific namespaces (empty = all)
 	ViewMode         string   // "full" or "traffic"
 	ShowPolicyEffect bool     // Evaluate NetworkPolicies on edges
+	// DeniedKinds are cluster-scoped topology kinds (Nodes, PV, StorageClass,
+	// NodePool, …) this user can't list, stripped from every topology frame.
+	// Resolved once at subscribe time (the request is available there) so the
+	// broadcast loop never runs a SAR. nil/empty for users with full access.
+	DeniedKinds map[topology.NodeKind]bool
 }
 
 type clientRegistration struct {
@@ -65,6 +70,7 @@ type clientRegistration struct {
 	namespaces       []string
 	viewMode         string
 	showPolicyEffect bool
+	deniedKinds      map[topology.NodeKind]bool
 }
 
 // SSEEvent represents an event to send to clients
@@ -365,7 +371,7 @@ func (b *SSEBroadcaster) run() {
 				close(reg.ch) // Signal rejection by closing the channel
 				continue
 			}
-			b.clients[reg.ch] = ClientInfo{Namespaces: reg.namespaces, ViewMode: reg.viewMode, ShowPolicyEffect: reg.showPolicyEffect}
+			b.clients[reg.ch] = ClientInfo{Namespaces: reg.namespaces, ViewMode: reg.viewMode, ShowPolicyEffect: reg.showPolicyEffect, DeniedKinds: reg.deniedKinds}
 			b.mu.Unlock()
 			log.Printf("SSE client connected (namespaces=%v, view=%s), total clients: %d", reg.namespaces, reg.viewMode, len(b.clients))
 
@@ -600,20 +606,25 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() {
 	// Note: namespaces are pre-sorted at subscription time for consistent grouping
 	type clientKey struct {
 		namespacesKey    string // comma-separated sorted namespaces
+		deniedKindsKey   string // comma-separated sorted denied cluster-scoped kinds
 		viewMode         string
 		showPolicyEffect bool
 	}
 	type clientGroup struct {
 		namespaces       []string
 		showPolicyEffect bool
+		deniedKinds      map[topology.NodeKind]bool
 		channels         []chan SSEEvent
 	}
 	clientGroups := make(map[clientKey]*clientGroup)
 	for ch, info := range clients {
 		nsKey := strings.Join(info.Namespaces, ",") // namespaces already sorted at subscribe time
-		key := clientKey{namespacesKey: nsKey, viewMode: info.ViewMode, showPolicyEffect: info.ShowPolicyEffect}
+		// Users with identical namespace + cluster-scoped RBAC share one frame;
+		// a user denied cluster-scoped kinds gets a distinct, stripped frame
+		// rather than the unfiltered bytes of a more-privileged peer.
+		key := clientKey{namespacesKey: nsKey, deniedKindsKey: deniedKindsKey(info.DeniedKinds), viewMode: info.ViewMode, showPolicyEffect: info.ShowPolicyEffect}
 		if clientGroups[key] == nil {
-			clientGroups[key] = &clientGroup{namespaces: info.Namespaces, showPolicyEffect: info.ShowPolicyEffect}
+			clientGroups[key] = &clientGroup{namespaces: info.Namespaces, showPolicyEffect: info.ShowPolicyEffect, deniedKinds: info.DeniedKinds}
 		}
 		clientGroups[key].channels = append(clientGroups[key].channels, ch)
 	}
@@ -638,6 +649,7 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() {
 			log.Printf("Error building topology for broadcast: %v", err)
 			continue
 		}
+		topo.StripNodeKinds(group.deniedKinds)
 
 		if int64(topo.EstimatedNodes) > maxEstimated {
 			maxEstimated = int64(topo.EstimatedNodes)
@@ -664,6 +676,21 @@ func (b *SSEBroadcaster) broadcastTopologyUpdate() {
 	// when maxEstimated stayed 0 (eg. every build errored) — that just
 	// falls through to the bootstrap proxy in topologyDebounceFor.
 	b.lastBroadcastMaxEstimated.Store(maxEstimated)
+}
+
+// deniedKindsKey builds a stable grouping key from a denied-kinds set so that
+// clients with the same effective cluster-scoped RBAC share a pre-marshaled
+// frame. Empty (full access) collapses to "" — the common case.
+func deniedKindsKey(deny map[topology.NodeKind]bool) string {
+	if len(deny) == 0 {
+		return ""
+	}
+	kinds := make([]string, 0, len(deny))
+	for k := range deny {
+		kinds = append(kinds, string(k))
+	}
+	sort.Strings(kinds)
+	return strings.Join(kinds, ",")
 }
 
 // heartbeat sends periodic heartbeats to keep connections alive
@@ -697,7 +724,7 @@ func (b *SSEBroadcaster) Broadcast(event SSEEvent) {
 }
 
 // Subscribe adds a new SSE client. Returns nil if max clients reached.
-func (b *SSEBroadcaster) Subscribe(namespaces []string, viewMode string, showPolicyEffect ...bool) chan SSEEvent {
+func (b *SSEBroadcaster) Subscribe(namespaces []string, viewMode string, deniedKinds map[topology.NodeKind]bool, showPolicyEffect ...bool) chan SSEEvent {
 	// Check client count before creating the channel to fail fast
 	b.mu.RLock()
 	clientCount := len(b.clients)
@@ -719,7 +746,7 @@ func (b *SSEBroadcaster) Subscribe(namespaces []string, viewMode string, showPol
 
 	policyEffect := len(showPolicyEffect) > 0 && showPolicyEffect[0]
 	ch := make(chan SSEEvent, 10)
-	b.register <- clientRegistration{ch: ch, namespaces: sortedNs, viewMode: viewMode, showPolicyEffect: policyEffect}
+	b.register <- clientRegistration{ch: ch, namespaces: sortedNs, viewMode: viewMode, showPolicyEffect: policyEffect, deniedKinds: deniedKinds}
 	return ch
 }
 
@@ -805,7 +832,7 @@ func buildFullTopology() (*topology.Topology, error) {
 }
 
 // HandleSSE is the HTTP handler for the SSE endpoint
-func (b *SSEBroadcaster) HandleSSE(w http.ResponseWriter, r *http.Request) {
+func (b *SSEBroadcaster) HandleSSE(w http.ResponseWriter, r *http.Request, deniedKinds map[topology.NodeKind]bool) {
 	// Set SSE headers
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
@@ -828,7 +855,7 @@ func (b *SSEBroadcaster) HandleSSE(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Subscribe to events
-	eventCh := b.Subscribe(namespaces, viewMode, policyEffect)
+	eventCh := b.Subscribe(namespaces, viewMode, deniedKinds, policyEffect)
 	if eventCh == nil {
 		http.Error(w, "Too many SSE connections", http.StatusServiceUnavailable)
 		return
@@ -860,6 +887,7 @@ func (b *SSEBroadcaster) HandleSSE(w http.ResponseWriter, r *http.Request) {
 		}
 		opts.ShowPolicyEffect = policyEffect
 		if topo, err := builder.Build(opts); err == nil {
+			topo.StripNodeKinds(deniedKinds)
 			data, marshalErr := json.Marshal(topo)
 			if marshalErr != nil {
 				log.Printf("SSE: failed to marshal initial topology: %v", marshalErr)

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"maps"
 	"net/http"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -520,10 +521,10 @@ func (b *SSEBroadcaster) watchResourceChanges() {
 						"summary": change.Diff.Summary,
 					}
 				}
-				b.Broadcast(SSEEvent{
+				b.broadcastResourceChange(SSEEvent{
 					Event: "k8s_event",
 					Data:  eventData,
-				})
+				}, change.Namespace, change.Kind)
 			}
 
 			// Schedule debounced topology update. Re-evaluate debounce on
@@ -721,6 +722,49 @@ func (b *SSEBroadcaster) Broadcast(event SSEEvent) {
 	for ch := range b.clients {
 		safeSend(ch, event)
 	}
+}
+
+// broadcastResourceChange sends a per-resource change frame (k8s_event, which
+// can carry a spec/data diff) only to clients whose RBAC plausibly permits the
+// resource. Namespaced changes go only to clients whose RBAC-filtered namespace
+// set includes the namespace; cluster-scoped changes go only to clients not
+// denied that kind (the topology denied set resolved at subscribe time).
+//
+// This is a PARTIAL gate, not a complete authorization boundary, and is a big
+// reduction over the previous broadcast-to-all (which leaked every diff to every
+// client). Two gaps remain, both needing per-(group,resource) state this path
+// doesn't carry yet (ResourceChange has only Kind):
+//   - namespaced kinds the user can't read WITHIN an allowed namespace (e.g.
+//     Secrets/Roles for a list-pods-only viewer) still pass the namespace check;
+//   - cluster-scoped kinds outside the topology set (ClusterRole, webhooks,
+//     cluster-scoped CRDs) aren't in DeniedKinds, and kind-string matching misses
+//     CRD variants (EC2NodeClass vs synthesized NodeClass).
+// The complete fix carries the exact GVR on ResourceChange and authorizes each
+// client via the cached per-user canRead — tracked separately.
+func (b *SSEBroadcaster) broadcastResourceChange(event SSEEvent, namespace, kind string) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	for ch, info := range b.clients {
+		if clientCanSeeChange(info, namespace, kind) {
+			safeSend(ch, event)
+		}
+	}
+}
+
+// clientCanSeeChange reports whether a client's RBAC allows a change frame.
+func clientCanSeeChange(info ClientInfo, namespace, kind string) bool {
+	if namespace != "" {
+		// Namespaced change: deliver only if the client can see that namespace.
+		// nil Namespaces means all-namespace access (no RBAC restriction).
+		if info.Namespaces == nil {
+			return true
+		}
+		return slices.Contains(info.Namespaces, namespace)
+	}
+	// Cluster-scoped change (no namespace): deliver unless the kind is one this
+	// client was denied — the per-kind SAR result resolved at subscribe time.
+	return !info.DeniedKinds[topology.NodeKind(kind)]
 }
 
 // Subscribe adds a new SSE client. Returns nil if max clients reached.

--- a/internal/server/sse_rbac_test.go
+++ b/internal/server/sse_rbac_test.go
@@ -1,0 +1,35 @@
+package server
+
+import (
+	"testing"
+
+	topology "github.com/skyhook-io/radar/pkg/topology"
+)
+
+// deniedKindsKey is the grouping seam that keeps a user who is denied a
+// cluster-scoped topology kind from sharing a more-privileged peer's
+// pre-marshaled (un-stripped) frame. It must be empty for full access (the
+// common case, so those users still coalesce) and stable + sorted otherwise.
+func TestDeniedKindsKey(t *testing.T) {
+	if got := deniedKindsKey(nil); got != "" {
+		t.Fatalf("nil → %q, want empty (full-access users must coalesce)", got)
+	}
+	if got := deniedKindsKey(map[topology.NodeKind]bool{}); got != "" {
+		t.Fatalf("empty → %q, want empty", got)
+	}
+	if got := deniedKindsKey(map[topology.NodeKind]bool{"Node": true}); got != "Node" {
+		t.Fatalf("single → %q, want Node", got)
+	}
+
+	// Same set, different insertion order → identical key (map iteration order
+	// must not leak into grouping, or two equally-denied users would build
+	// duplicate frames).
+	a := deniedKindsKey(map[topology.NodeKind]bool{"StorageClass": true, "Node": true, "PersistentVolume": true})
+	b := deniedKindsKey(map[topology.NodeKind]bool{"Node": true, "PersistentVolume": true, "StorageClass": true})
+	if a != b {
+		t.Fatalf("unstable key across iteration order: %q vs %q", a, b)
+	}
+	if a != "Node,PersistentVolume,StorageClass" {
+		t.Fatalf("key = %q, want Node,PersistentVolume,StorageClass", a)
+	}
+}

--- a/internal/server/sse_rbac_test.go
+++ b/internal/server/sse_rbac_test.go
@@ -42,6 +42,10 @@ func TestClientCanSeeChange(t *testing.T) {
 	scopedAB := ClientInfo{Namespaces: []string{"a", "b"}}
 	noAccess := ClientInfo{Namespaces: []string{"__no_access__"}}
 	deniedNodes := ClientInfo{DeniedKinds: map[topology.NodeKind]bool{"Node": true}}
+	// A user who can't list namespaces has Namespace added to the deny set at
+	// subscribe (handleSSE), so Namespace change events (cluster-scoped, name="")
+	// are blocked.
+	deniedNamespaces := ClientInfo{Namespaces: []string{"a"}, DeniedKinds: map[topology.NodeKind]bool{"Namespace": true}}
 
 	cases := []struct {
 		name      string
@@ -57,6 +61,8 @@ func TestClientCanSeeChange(t *testing.T) {
 		{"cluster-scoped allowed when not denied", scopedAB, "", "Node", true},
 		{"cluster-scoped denied kind blocked", deniedNodes, "", "Node", false},
 		{"cluster-scoped non-denied kind allowed", deniedNodes, "", "StorageClass", true},
+		{"Namespace event blocked when can't list namespaces", deniedNamespaces, "", "Namespace", false},
+		{"Namespace event allowed when can list namespaces", scopedAB, "", "Namespace", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/server/sse_rbac_test.go
+++ b/internal/server/sse_rbac_test.go
@@ -33,3 +33,36 @@ func TestDeniedKindsKey(t *testing.T) {
 		t.Fatalf("key = %q, want Node,PersistentVolume,StorageClass", a)
 	}
 }
+
+// clientCanSeeChange gates k8s_event (diff-bearing) frames per client so a
+// restricted user doesn't receive change content for namespaces or cluster-scoped
+// kinds their RBAC forbids.
+func TestClientCanSeeChange(t *testing.T) {
+	allAccess := ClientInfo{Namespaces: nil}
+	scopedAB := ClientInfo{Namespaces: []string{"a", "b"}}
+	noAccess := ClientInfo{Namespaces: []string{"__no_access__"}}
+	deniedNodes := ClientInfo{DeniedKinds: map[topology.NodeKind]bool{"Node": true}}
+
+	cases := []struct {
+		name      string
+		info      ClientInfo
+		namespace string
+		kind      string
+		want      bool
+	}{
+		{"all-access sees namespaced change", allAccess, "a", "ConfigMap", true},
+		{"scoped sees allowed namespace", scopedAB, "a", "Deployment", true},
+		{"scoped does NOT see other namespace", scopedAB, "c", "Deployment", false},
+		{"no-access sees nothing namespaced", noAccess, "a", "ConfigMap", false},
+		{"cluster-scoped allowed when not denied", scopedAB, "", "Node", true},
+		{"cluster-scoped denied kind blocked", deniedNodes, "", "Node", false},
+		{"cluster-scoped non-denied kind allowed", deniedNodes, "", "StorageClass", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clientCanSeeChange(tc.info, tc.namespace, tc.kind); got != tc.want {
+				t.Fatalf("clientCanSeeChange(%v, %q, %q) = %v, want %v", tc.info, tc.namespace, tc.kind, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What
RBAC filtering on the SSE stream, matching what the REST endpoints already enforce.

- **Topology frames** — strip cluster-scoped graph nodes (Nodes, PVs, StorageClasses, NodePools…) a user can't `list`, like REST `/api/topology`. **Complete.**
- **`k8s_event` frames** — carry spec/data diffs; were broadcast to all clients. Now filtered per client (`clientCanSeeChange`): namespaced by the user's allowed namespaces, cluster-scoped by their denied-kinds set. Includes **Namespace** change events (denied when the user can't `list namespaces`).

## Scope (honest)
The `k8s_event` filter is a **large reduction, not a complete boundary** — `ResourceChange` carries only `Kind` (no GVR), so it doesn't yet enforce per-kind RBAC *within* an allowed namespace (e.g. Secrets for a list-pods-only viewer) or cluster-scoped kinds outside the topology set besides Namespace. Tracked in **#913** (per-GVR authz).

## Cross-review note
A context-switch SSE-invalidation attempt was **removed** from this PR after a 3-round Claude↔Codex review: it can't be made correct by ordering alone (the global cache is swapped before the callback, so a generation guard is required), and it's a **local multi-context-only** concern (never cloud) that **pre-existed** this PR. The full context-switch staleness (namespace filter + denied-kinds) is tracked as a follow-up with the #913 hardening, rather than shipping a racy half-fix.

## Tests

**Unit:** `TestDeniedKindsKey`, `TestClientCanSeeChange` (incl. Namespace cases). `go test ./internal/server` green.

**Live validation** — `kind` cluster, radar in `--auth-mode=proxy` (the real Cloud path: per-user `SubjectAccessReview` against the apiserver). Three impersonated identities, a change burst across namespaces + cluster-scoped objects, concurrent SSE captures:

- `admin` — cluster-admin
- `dev` — list/watch in one namespace only (no nodes, no namespaces)
- `dev+nodes` — same as `dev` **plus** cluster-wide `list nodes` (precision probe)

| Change fired on `/api/events/stream` | `admin` | `dev` | `dev+nodes` |
|---|:--:|:--:|:--:|
| ConfigMap delete in the granted namespace | ✅ | ✅ | ✅ |
| ConfigMap delete in another namespace | ✅ | ❌ | ❌ |
| **Node** update (cordon — cluster-scoped) | ✅ | ❌ | ✅ |
| **Namespace** delete (cluster-scoped) | ✅ | ❌ | ❌ |
| SA/ConfigMap cascade from the deleted namespace | ✅ | ❌ | ❌ |

Every cell matches intent. The decisive row is **Node**: `dev+nodes` receives Node events but **not** Namespace events — confirming the gate is genuinely **per-kind** (keyed on each cluster-scoped kind's actual `list` grant), not a blanket cluster-scoped block. Before this change, `dev` would have received all five rows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multi-tenant SSE authorization and shared broadcast grouping; mistakes could hide legitimate updates or still leak diffs via the documented partial k8s_event gaps.
> 
> **Overview**
> Closes two **information-disclosure gaps** on `/api/events/stream`: topology SSE previously showed cluster-scoped graph nodes users couldn’t `list`, and **`k8s_event`** frames (including spec/data diffs) went to every subscriber with no filtering.
> 
> **Topology:** On connect, `handleSSE` resolves denied cluster-scoped kinds once via `deniedClusterScopedTopoKinds` (same idea as REST `/api/topology`) and adds **`Namespace`** to the deny set when the user can’t `list` namespaces. That map is stored on each client, **`StripNodeKinds`** runs on the initial and debounced topology builds, and broadcast **grouping keys** include a stable `deniedKindsKey` so restricted users don’t share a more-privileged peer’s pre-marshaled frame.
> 
> **`k8s_event`:** Resource changes use **`broadcastResourceChange`** / **`clientCanSeeChange`**—namespaced events only to clients whose namespace filter includes the namespace; cluster-scoped events blocked when the kind is in **`DeniedKinds`**. Documented as a partial gate (per-kind RBAC inside an allowed namespace and non-topology cluster kinds remain for a follow-up).
> 
> Tests cover **`deniedKindsKey`** stability and **`clientCanSeeChange`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ff33fc60d87052e46f74c1a8aea0ec562643ec3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
