### PR TITLE
chore(web): clean & enforce small correctness lint rules

### DIFF
--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -22,8 +22,14 @@ export default tseslint.config(
       // ✅ Cleaned — keep blocking.
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'error',
+      '@typescript-eslint/no-unused-vars': 'error',
+      '@typescript-eslint/no-unused-expressions': 'error',
+      'no-useless-assignment': 'error',
 
       // ⏳ Ratchet queue (real signal; promote to error as each is cleaned).
+      // preserve-caught-error needs `new Error(msg, { cause })` — deferred until
+      // the tsconfig lib is bumped to ES2022 (its own PR).
+      'preserve-caught-error': 'warn',
       'react-hooks/set-state-in-effect': 'warn',
       'react-hooks/refs': 'warn',
       'react-hooks/static-components': 'warn',
@@ -31,10 +37,6 @@ export default tseslint.config(
       'react-hooks/preserve-manual-memoization': 'warn',
       'react-hooks/immutability': 'warn',
       '@typescript-eslint/no-explicit-any': 'warn',
-      '@typescript-eslint/no-unused-vars': 'warn',
-      '@typescript-eslint/no-unused-expressions': 'warn',
-      'no-useless-assignment': 'warn',
-      'preserve-caught-error': 'warn',
 
       // DX/HMR nicety only — not worth churning 138 existing files. Disabled.
       'react-refresh/only-export-components': 'off',

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1509,7 +1509,7 @@ export function useAutoPromConnect(): void {
     if (attemptedRef.current === context) return
     let cached: string | null = null
     try { cached = window.localStorage.getItem(promAutoConnectKey(context)) } catch {
-      cached = null
+      // keep the null fallback
     }
 
     attemptedRef.current = context

--- a/web/src/components/issues/IssuesPane.tsx
+++ b/web/src/components/issues/IssuesPane.tsx
@@ -44,7 +44,7 @@ export function IssuesPane({ namespaces, onNavigateToResource }: IssuesPaneProps
   const toggleSeverity = (s: IssueSeverity) =>
     setSeverityFilter((prev) => {
       const next = new Set(prev)
-      next.has(s) ? next.delete(s) : next.add(s)
+      if (next.has(s)) next.delete(s); else next.add(s)
       return next
     })
 

--- a/web/src/components/traffic/TrafficView.tsx
+++ b/web/src/components/traffic/TrafficView.tsx
@@ -620,13 +620,13 @@ export function TrafficView({ namespaces }: TrafficViewProps) {
 
   // Toggle L7 filter helpers
   const toggleL7Method = useCallback((method: string) => {
-    setL7Methods(prev => { const next = new Set(prev); next.has(method) ? next.delete(method) : next.add(method); return next })
+    setL7Methods(prev => { const next = new Set(prev); if (next.has(method)) next.delete(method); else next.add(method); return next })
   }, [])
   const toggleL7StatusRange = useCallback((range: string) => {
-    setL7StatusRanges(prev => { const next = new Set(prev); next.has(range) ? next.delete(range) : next.add(range); return next })
+    setL7StatusRanges(prev => { const next = new Set(prev); if (next.has(range)) next.delete(range); else next.add(range); return next })
   }, [])
   const toggleL7Verdict = useCallback((verdict: string) => {
-    setL7Verdicts(prev => { const next = new Set(prev); next.has(verdict) ? next.delete(verdict) : next.add(verdict); return next })
+    setL7Verdicts(prev => { const next = new Set(prev); if (next.has(verdict)) next.delete(verdict); else next.add(verdict); return next })
   }, [])
 
   // Toggle namespace visibility

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -130,7 +130,7 @@ document.execCommand = function (command: string, showUI?: boolean, value?: stri
         dt.setData('text/plain', text)
         const ev = new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true })
         if (!el.dispatchEvent(ev)) return
-      } catch (_e) { /* ClipboardEvent dispatch failed, fall back to insertText */ }
+      } catch { /* ClipboardEvent dispatch failed, fall back to insertText */ }
       _origExecCommand('insertText', false, text)
     }).catch((err) => { console.warn('[Radar] Paste failed:', err) })
     return true


### PR DESCRIPTION
Third step of the ESLint ratchet (after #980 foundation, #982 exhaustive-deps). Clears and promotes three low-risk correctness rules from `warn` to `error`.

## What changed

- **`no-unused-expressions`** (4) — ternary-as-statement toggles (`set.has(x) ? set.delete(x) : set.add(x)`) rewritten as `if (set.has(x)) set.delete(x); else set.add(x)` in IssuesPane and TrafficView's three L7 filter helpers. Same behavior, no longer an expression-statement.
- **`no-useless-assignment`** (1) — `client.ts` dropped a redundant `cached = null` inside a catch whose `let cached` already initializes to `null`.
- **`no-unused-vars`** (1) — `main.tsx` unused catch binding `catch (_e)` → optional catch binding `catch`.

## Deferred

`preserve-caught-error` (2) stays at `warn` — satisfying it cleanly needs `new Error(msg, { cause })`, which requires bumping the tsconfig `lib` from ES2020 to ES2022. That's a deliberate project-config decision, so it gets its own follow-up rather than riding along here.

## Testing

- `npm run lint` → 0 errors, 160 warnings (exit 0); the three enforced rules are at 0.
- `npm run tsc` — clean.

Remaining ratchet queue: `set-state-in-effect` (30), `refs` (24), `static-components`/`purity`/`memoization` (~18), `preserve-caught-error` (2, pending the ES2022 bump), `no-explicit-any` (85, staying warn).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint policy plus behavior-preserving refactors only; no auth, API, or data-path changes.
> 
> **Overview**
> Continues the **ESLint ratchet** by promoting **`@typescript-eslint/no-unused-vars`**, **`@typescript-eslint/no-unused-expressions`**, and **`no-useless-assignment`** from `warn` to **`error`** in `web/eslint.config.mjs`, so CI blocks regressions on those rules.
> 
> Matching **mechanical fixes**: severity toggles in **IssuesPane** and three L7 filter helpers in **TrafficView** replace ternary-as-statement Set toggles with explicit `if`/`else`; **Prometheus auto-connect** in `client.ts` drops a redundant `cached = null` in a `catch` (the outer `let` already defaults to `null`); **desktop paste** in `main.tsx` uses an optional `catch` binding instead of unused `_e`.
> 
> **`preserve-caught-error`** stays at `warn`, with a config comment that fixing it cleanly needs `Error` `cause` and a separate **tsconfig `lib` ES2022** bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0948e74737a85171a240d11f3a6c4689d2b8ebb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->