### PR TITLE
chore(web): lint cleanup — FitView hoist, RBAC type, ES2022 + error cause

### DIFF
--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -25,11 +25,11 @@ export default tseslint.config(
       '@typescript-eslint/no-unused-vars': 'error',
       '@typescript-eslint/no-unused-expressions': 'error',
       'no-useless-assignment': 'error',
+      // Caught errors must be rethrown with `{ cause }` so the chain survives.
+      // Unblocked now that tsconfig lib is ES2022 (Error.cause is typed).
+      'preserve-caught-error': 'error',
 
       // ⏳ Ratchet queue (real signal; promote to error as each is cleaned).
-      // preserve-caught-error needs `new Error(msg, { cause })` — deferred until
-      // the tsconfig lib is bumped to ES2022 (its own PR).
-      'preserve-caught-error': 'warn',
       'react-hooks/set-state-in-effect': 'warn',
       'react-hooks/refs': 'warn',
       'react-hooks/static-components': 'warn',

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3048,7 +3048,7 @@ export function useSwitchContext() {
       } catch (error) {
         clearTimeout(timeoutId)
         if (error instanceof Error && error.name === 'AbortError') {
-          throw new Error('Context switch timed out. The cluster may be unreachable.')
+          throw new Error('Context switch timed out. The cluster may be unreachable.', { cause: error })
         }
         throw error
       }
@@ -3151,7 +3151,7 @@ export function useSetActiveNamespace() {
           error: error instanceof Error ? error.message : String(error),
         })
         if (error instanceof Error && error.name === 'AbortError') {
-          throw new Error('Namespace switch timed out. The cluster may be unreachable.')
+          throw new Error('Namespace switch timed out. The cluster may be unreachable.', { cause: error })
         }
         throw error
       }

--- a/web/src/components/settings/MyPermissionsDialog.tsx
+++ b/web/src/components/settings/MyPermissionsDialog.tsx
@@ -8,6 +8,7 @@ import {
   rbacApiGroupBadgeClass,
   rbacResourceNameBadgeClass,
   rbacNonResourceUrlBadgeClass,
+  type RBACWhoamiResponse,
 } from '@skyhook-io/k8s-ui'
 import { useAnimatedUnmount } from '../../hooks/useAnimatedUnmount'
 import { TRANSITION_BACKDROP, TRANSITION_PANEL } from '../../utils/animation'
@@ -141,7 +142,7 @@ export function MyPermissionsDialog({ open, onClose }: MyPermissionsDialogProps)
   )
 }
 
-function PermissionsTable({ whoami }: { whoami: { resourceRules: any[]; nonResourceRules: any[] } }) {
+function PermissionsTable({ whoami }: { whoami: RBACWhoamiResponse }) {
   const resourceRules = whoami.resourceRules ?? []
   const nonResourceRules = whoami.nonResourceRules ?? []
 

--- a/web/src/components/traffic/TrafficGraph.tsx
+++ b/web/src/components/traffic/TrafficGraph.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useEffect, useState, useCallback, useRef } from 'react'
+import { useMemo, useEffect, useState, useCallback, useRef, type MutableRefObject } from 'react'
 import {
   ReactFlow,
   Background,
@@ -971,6 +971,33 @@ const nodeTypes = {
   addonGroup: AddonGroupNode,
 }
 
+// Fits the view once nodes have been laid out. Module-scope (not defined inside
+// TrafficGraph's render) so it keeps a stable identity — otherwise it remounts
+// every render and its effect churns. Must render inside <ReactFlow> for the
+// useReactFlow() context; the trigger state is passed in as props.
+function FitViewOnChange({
+  shouldFitViewRef,
+  layoutedNodes,
+}: {
+  shouldFitViewRef: MutableRefObject<boolean>
+  layoutedNodes: Node<TrafficNodeData>[]
+}) {
+  const { fitView } = useReactFlow()
+
+  useEffect(() => {
+    if (shouldFitViewRef.current && layoutedNodes.length > 0) {
+      // Small delay to ensure nodes are rendered
+      const timer = setTimeout(() => {
+        fitView({ padding: 0.2, duration: 200 })
+        shouldFitViewRef.current = false
+      }, 50)
+      return () => clearTimeout(timer)
+    }
+  }, [fitView, layoutedNodes, shouldFitViewRef])
+
+  return null
+}
+
 export function TrafficGraph({ flows, hotPathThreshold = 0, showNamespaceGroups = false, serviceCategories, addonMode = 'show', trafficSource = '', onSelectionChange }: TrafficGraphProps) {
   const isIstio = trafficSource === 'istio'
   const connLabel = isIstio ? 'req/s' : 'conn'
@@ -1492,27 +1519,6 @@ export function TrafficGraph({ flows, hotPathThreshold = 0, showNamespaceGroups 
     onSelectionChange?.(null)
   }, [onSelectionChange])
 
-  // FitView handler component - must be inside ReactFlow
-  const FitViewOnChange = () => {
-    const { fitView } = useReactFlow()
-
-    useEffect(() => {
-      if (shouldFitViewRef.current && layoutedNodes.length > 0) {
-        // Small delay to ensure nodes are rendered
-        const timer = setTimeout(() => {
-          fitView({ padding: 0.2, duration: 200 })
-          shouldFitViewRef.current = false
-        }, 50)
-        return () => clearTimeout(timer)
-      }
-      // layoutedNodes is outer-scope state read here to re-fit once nodes land;
-      // keeping it as a dep preserves that trigger.
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [fitView, layoutedNodes])
-
-    return null
-  }
-
   return (
     <div className="w-full h-full relative">
       <ReactFlow
@@ -1538,7 +1544,7 @@ export function TrafficGraph({ flows, hotPathThreshold = 0, showNamespaceGroups 
       >
         <Background />
         <Controls />
-        <FitViewOnChange />
+        <FitViewOnChange shouldFitViewRef={shouldFitViewRef} layoutedNodes={layoutedNodes} />
       </ReactFlow>
 
       {/* Legend */}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",


### PR DESCRIPTION
Opportunistic lint cleanup from the triaged warning deep-dive — the handful of findings that were genuinely worth shipping, grouped into one chore PR. No rule weakened; two cleared rules tightened.

## What changed

**1. Hoist `FitViewOnChange` to module scope** (`traffic/TrafficGraph.tsx`)
It was defined *inside* `TrafficGraph`'s render, so it was a new component identity every render → React remounted it every render → its `useReactFlow()` + fit-view effect churned, defeating the `layoutedNodes` dependency that's supposed to gate it. Hoisted to module scope; the closure values it needs (`shouldFitViewRef`, `layoutedNodes`) are now props. Exact behavior preserved (50ms fitView timer + `shouldFitViewRef` gating); the stale `exhaustive-deps` disable is gone because the deps are now honest. Clears the one `static-components` warning that mattered.

**2. Tighten the RBAC table prop type** (`settings/MyPermissionsDialog.tsx`)
`PermissionsTable` re-loosened an already-typed value to `{ resourceRules: any[]; nonResourceRules: any[] }`. The value comes from `useRBACWhoami`, which is `RBACWhoamiResponse` (exported from `@skyhook-io/k8s-ui`). Typed the prop properly — removes 2 explicit-`any` and adds field-typo safety.

**3. Bump tsconfig to ES2022 + attach error cause** (`tsconfig.json`, `api/client.ts`, `eslint.config.mjs`)
`target`/`lib` were `ES2020` — the original Vite scaffold default, never revisited. Nothing in the repo pins it there (no browserslist, no `engines` floor, no esbuild `build.target`), and `useDefineForClassFields: true` already assumes ES2022 class semantics, so the config was self-inconsistent. Bumped both to ES2022, which types `Error.cause`. That unblocked the two `AbortError` rethrows in `client.ts` that silently dropped their original error — they now carry `{ cause }`, so the failure chain survives for debugging. With the last two instances cleared, `preserve-caught-error` is promoted `warn → error` so future dropped-cause rethrows fail CI.

## Why ES2022 is safe here
`noEmit: true` — tsc never transpiles, Vite/esbuild owns the actual output target. The bump only widens the *type* surface (`Error.cause`, `Array.at`, `Object.hasOwn`, …). Every ES2022 API ships in all browsers since 2021, well below this app's React-19 floor.

## Testing
- `tsc --noEmit` — clean (exit 0)
- `eslint .` — 0 errors; warnings 138 → 136 (the 2 cleared `preserve-caught-error`)
- React Compiler healthcheck (separately, for context): 292/292 components compile — codebase is already compiler-ready; these are quality cleanups toward that, not blockers
- No visual-test: #1 is a behavior-preserving fit-view refactor, #2 is type-only, #3 is config + error-cause plumbing — no rendered-surface change