### PR TITLE
fix(loading): splash anchor consistency + standardize pane loaders

### DIFF
--- a/packages/k8s-ui/src/components/charts/PrometheusChartsView.tsx
+++ b/packages/k8s-ui/src/components/charts/PrometheusChartsView.tsx
@@ -1,6 +1,7 @@
 import { clsx } from 'clsx'
 import { BarChart3, Wifi, WifiOff, Loader2 } from 'lucide-react'
 import { AreaChart } from './AreaChart'
+import { PaneLoader } from '../ui/PaneLoader'
 import { MetricsSummary } from './MetricsSummary'
 import { SeriesLegend } from './SeriesLegend'
 import type { TimeSeries, ReferenceLine } from './types'
@@ -108,10 +109,7 @@ export function PrometheusChartsView({
   if (statusLoading) {
     if (!showEmptyState) return null
     return (
-      <div className="flex items-center justify-center py-12 text-theme-text-tertiary">
-        <Loader2 className="mr-2 h-5 w-5 animate-spin" />
-        Checking Prometheus availability...
-      </div>
+      <PaneLoader label="Checking Prometheus availability…" className="py-12" />
     )
   }
 
@@ -181,10 +179,7 @@ export function PrometheusChartsView({
       {/* Chart area */}
       <div className="min-h-[280px] flex-1 p-4">
         {metricsLoading ? (
-          <div className="flex min-h-[240px] items-center justify-center text-theme-text-tertiary">
-            <Loader2 className="mr-2 h-5 w-5 animate-spin" />
-            Loading metrics...
-          </div>
+          <PaneLoader label="Loading metrics…" className="min-h-[240px]" />
         ) : metricsError ? (
           <div className="flex h-full items-center justify-center text-sm text-red-400">
             Failed to load metrics: {(metricsError as Error).message}

--- a/packages/k8s-ui/src/components/gitops/GitOpsDetailLayout.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsDetailLayout.tsx
@@ -1,5 +1,6 @@
 import { useEffect, type ComponentType, type ReactNode } from 'react'
 import { ArrowDownUp, ChevronDown, ChevronRight, Clock3, GitBranch, GitCommit, Loader2, Pause, Play, RefreshCw, Settings, Trash2, XCircle, Zap } from 'lucide-react'
+import { PaneLoader } from '../ui/PaneLoader'
 
 import { HealthStatusBadge, SyncStatusBadge } from './GitOpsStatusBadge'
 import { GitOpsIssuesBand, GitOpsStatusStrip } from './insights'
@@ -487,9 +488,7 @@ export function GitOpsDetailLayout(props: GitOpsDetailLayoutProps) {
       )}
 
       {resourceLoading ? (
-        <div className="flex flex-1 items-center justify-center text-theme-text-secondary">
-          <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Loading GitOps resource…
-        </div>
+        <PaneLoader label="Loading GitOps resource…" className="flex-1" />
       ) : resourceError ? (
         <div className="p-4 text-sm text-red-500">Failed to load resource: {resourceError.message}</div>
       ) : (

--- a/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
@@ -12,7 +12,6 @@ import {
   HeartPulse,
   LayoutGrid,
   List,
-  Loader2,
   Pause,
   Play,
   RefreshCw,
@@ -33,6 +32,7 @@ import { FacetSection, FacetButton } from '../ui/Facet'
 import { SortableTh, TH_CLASS, type SortDir } from '../ui/SortableTh'
 import { DistributionBar } from '../ui/DistributionBar'
 import { RowActionMenu, type RowActionItem } from '../ui/RowActionMenu'
+import { PaneLoader } from '../ui/PaneLoader'
 import { useRefreshAnimation } from '../../hooks/useRefreshAnimation'
 import { getGitOpsResourceStatus } from './detail-helpers'
 import { isArgoSuspendedByRadar } from '../resources/resource-utils-argo'
@@ -754,9 +754,7 @@ export function GitOpsTableView({
               {modeLabel(mode)} view is queued behind the application list.
             </div>
           ) : loading && filteredRows.length === 0 ? (
-            <div className="flex h-full items-center justify-center text-sm text-theme-text-secondary">
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Loading GitOps applications...
-            </div>
+            <PaneLoader label="Loading GitOps applications…" className="h-full" />
           ) : error ? (
             <div className="p-4 text-sm text-red-500">Failed to load GitOps applications: {error.message}</div>
           ) : filteredRows.length === 0 ? (

--- a/packages/k8s-ui/src/components/gitops/insights/GitOpsInsightViews.tsx
+++ b/packages/k8s-ui/src/components/gitops/insights/GitOpsInsightViews.tsx
@@ -1,4 +1,5 @@
 import { AlertTriangle, ChevronDown, ChevronRight, CircleAlert, Clock3, GitBranch, GitCommit, Info, Loader2, Plus, Trash2 } from 'lucide-react'
+import { PaneLoader } from '../../ui/PaneLoader'
 import { clsx } from 'clsx'
 import { Fragment, useEffect, useRef, useState, type ReactNode } from 'react'
 import type { GitOpsChange, GitOpsHistoryItem, GitOpsInsight, GitOpsInsightRef, GitOpsIssue, GitOpsPlanItem, GitOpsRemediation, GitOpsResourceTree, GitOpsTreeNode } from '../../../types'
@@ -725,7 +726,7 @@ export function GitOpsChangesView({ insight, error, onOpenResource, focusKey, tr
     return <InsightErrorState error={error} />
   }
   if (!insight) {
-    return <CenteredText>Loading GitOps resources...</CenteredText>
+    return <PaneLoader label="Loading GitOps resources…" className="h-full" />
   }
   // Build plan metadata maps keyed by ref so each Change row can advertise
   // its sync step, hook phase, and wave assignment. The plan and changes
@@ -1274,7 +1275,7 @@ interface GitOpsActivityInsightViewProps {
 
 export function GitOpsActivityInsightView({ insight, error, onRollback }: GitOpsActivityInsightViewProps) {
   if (error && !insight) return <InsightErrorState error={error} />
-  if (!insight) return <CenteredText>Loading GitOps activity...</CenteredText>
+  if (!insight) return <PaneLoader label="Loading GitOps activity…" className="h-full" />
   const canRollback = !!insight.capabilities?.rollback && !!onRollback
   // Auto-sync makes rollback futile — the controller would re-sync to HEAD
   // immediately. Argo's own Web UI disables the button in this state. Detect
@@ -1427,10 +1428,6 @@ function SectionHeader({ icon: Icon, title, hint }: { icon: typeof GitBranch; ti
       )}
     </div>
   )
-}
-
-function CenteredText({ children }: { children: ReactNode }) {
-  return <div className="flex h-full items-center justify-center text-sm text-theme-text-secondary">{children}</div>
 }
 
 // Surfaced when the insights endpoint errors. Without this the subviews

--- a/packages/k8s-ui/src/components/gitops/tree/GitOpsTreeGraph.tsx
+++ b/packages/k8s-ui/src/components/gitops/tree/GitOpsTreeGraph.tsx
@@ -15,7 +15,8 @@ import {
   type NodeTypes,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
-import { AlertTriangle, ChevronRight, Loader2, Maximize, Search, X } from 'lucide-react'
+import { AlertTriangle, ChevronRight, Maximize, Search, X } from 'lucide-react'
+import { PaneLoader } from '../../ui/PaneLoader'
 import { clsx } from 'clsx'
 
 import type { GitOpsResourceTree, GitOpsTreeNode, GitOpsTreeRef, HealthStatus } from '../../../types'
@@ -127,12 +128,7 @@ function GitOpsTreeGraphInner({
   }, [onNodeClick])
 
   if (loading) {
-    return (
-      <div className="flex h-full items-center justify-center text-theme-text-secondary">
-        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-        Loading GitOps resource tree...
-      </div>
-    )
+    return <PaneLoader label="Loading GitOps resource tree…" className="h-full" />
   }
 
   if (error) {

--- a/packages/k8s-ui/src/components/logs/LogCore.tsx
+++ b/packages/k8s-ui/src/components/logs/LogCore.tsx
@@ -796,7 +796,7 @@ export function LogCore({
         <div className={`flex-1 flex items-center justify-center ${palette.textTertiary}`}>
           <div className="flex items-center gap-2">
             <RotateCcw className="w-4 h-4 animate-spin" />
-            <span>Loading logs...</span>
+            <span>Loading logs…</span>
           </div>
         </div>
       ) : errorMessage ? (

--- a/packages/k8s-ui/src/components/resources/renderers/ServiceRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ServiceRenderer.tsx
@@ -128,7 +128,7 @@ export function ServiceRenderer({ data, onCopy, copied, endpointSlices, endpoint
       {hasNoSelector && !isExternalName && (
         <Section title="EndpointSlices" icon={Radio}>
           {endpointSlicesLoading ? (
-            <div className="text-sm text-theme-text-tertiary">Loading EndpointSlices...</div>
+            <div className="text-sm text-theme-text-tertiary">Loading EndpointSlices…</div>
           ) : endpointSlices && endpointSlices.length > 0 ? (
             <div className="space-y-2">
               {endpointSlices.map((slice: any) => {

--- a/packages/k8s-ui/src/components/resources/renderers/WorkloadRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/WorkloadRenderer.tsx
@@ -422,7 +422,7 @@ export function WorkloadRenderer({ kind, data, onNavigate, onViewPods, onScale, 
 
 function ScalerDiagnosisRow({ entry }: { entry: ScalerDiagnosis }) {
   if (entry.loading) {
-    return <div className="text-xs text-theme-text-tertiary">Loading autoscaler diagnosis...</div>
+    return <div className="text-xs text-theme-text-tertiary">Loading autoscaler diagnosis…</div>
   }
   if (entry.error) {
     return <div className="text-xs text-theme-text-tertiary">Autoscaler diagnosis unavailable</div>

--- a/packages/k8s-ui/src/components/shared/ResourceActionsBar.tsx
+++ b/packages/k8s-ui/src/components/shared/ResourceActionsBar.tsx
@@ -907,7 +907,7 @@ export function RevisionHistoryDialog({ kind, namespace, name, open, onClose, re
         <div className={clsx("p-4 overflow-y-auto", diffRevision ? "max-h-48 shrink-0" : "max-h-80")}>
           {isLoading && (
             <div className="flex items-center justify-center py-8 text-theme-text-secondary text-sm">
-              Loading revisions...
+              Loading revisions…
             </div>
           )}
 

--- a/packages/k8s-ui/src/components/ui/CodeViewer.tsx
+++ b/packages/k8s-ui/src/components/ui/CodeViewer.tsx
@@ -391,7 +391,7 @@ export function CodeViewer({
         style={{ maxHeight }}
       >
         {highlighting ? (
-          <div className="p-4 text-theme-text-tertiary text-sm font-mono">Loading...</div>
+          <div className="p-4 text-theme-text-tertiary text-sm font-mono">Loading…</div>
         ) : (
           <div
             ref={contentRef}

--- a/packages/k8s-ui/src/components/ui/YamlEditor.tsx
+++ b/packages/k8s-ui/src/components/ui/YamlEditor.tsx
@@ -233,7 +233,7 @@ export function YamlEditor({
         }}
         loading={
           <div className="flex items-center justify-center h-full bg-theme-surface text-theme-text-secondary">
-            Loading editor...
+            Loading editor…
           </div>
         }
       />

--- a/packages/k8s-ui/src/components/ui/drawer-components.tsx
+++ b/packages/k8s-ui/src/components/ui/drawer-components.tsx
@@ -990,7 +990,7 @@ export function EventsSection({ events, updates = [], isLoading, eventsError, up
   if (isLoading) {
     return (
       <Section title="Recent Events" defaultExpanded>
-        <div className="text-sm text-theme-text-tertiary">Loading events...</div>
+        <div className="text-sm text-theme-text-tertiary">Loading events…</div>
       </Section>
     )
   }

--- a/packages/k8s-ui/src/components/workload/WorkloadView.tsx
+++ b/packages/k8s-ui/src/components/workload/WorkloadView.tsx
@@ -1126,7 +1126,7 @@ function EventsTab({
     return (
       <div className="flex items-center justify-center h-full text-theme-text-tertiary">
         <RefreshCw className="w-5 h-5 animate-spin mr-2" />
-        Loading events...
+        Loading events…
       </div>
     )
   }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -138,14 +138,19 @@ function AuthBarrier({ authMode }: { authMode: string }) {
             src={radarLoadingIcon}
             alt=""
             aria-hidden
-            className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-11 h-11"
+            // Integer offset (vw/2 − 22) — matches the Connecting/Opening splashes;
+            // avoids sub-pixel jitter from translate(-50%) on odd-width viewports.
+            className="absolute w-11 h-11"
+            style={{ left: 'calc(50% - 22px)', top: 'calc(50% - 22px)' }}
           />
-          <p
-            className="absolute left-1/2 -translate-x-1/2 whitespace-nowrap text-[17px] font-semibold tracking-tight text-theme-text-primary"
+          <div
+            className="absolute left-1/2 -translate-x-1/2 text-center"
             style={{ top: 'calc(50% + 34px)' }}
           >
-            Redirecting to login…
-          </p>
+            <p className="whitespace-nowrap text-[17px] font-semibold tracking-tight text-theme-text-primary">
+              Redirecting to login…
+            </p>
+          </div>
         </div>
       </div>
     )
@@ -1866,9 +1871,26 @@ function AppInner() {
             own fetches) while the cross-document nav lands. Covers checks /
             issues / gitops with one block since only one view is active. */}
         {viewTakeoverHref && (
-          <div className="flex-1 flex flex-col items-center justify-center gap-3 bg-theme-base">
-            <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
-            <p className="text-sm text-theme-text-secondary">Opening…</p>
+          <div className="flex-1 relative bg-theme-base">
+            {/* Viewport-anchored, 17px — identical to the "Connecting" splash so
+                the mark doesn't move or resize across the takeover hand-off. */}
+            <div className="fixed inset-0 pointer-events-none">
+              <img
+                src={radarLoadingIcon}
+                alt=""
+                aria-hidden
+                className="absolute w-11 h-11"
+                style={{ left: 'calc(50% - 22px)', top: 'calc(50% - 22px)' }}
+              />
+              <div
+                className="absolute left-1/2 -translate-x-1/2 text-center"
+                style={{ top: 'calc(50% + 34px)' }}
+              >
+                <p className="whitespace-nowrap text-[17px] font-semibold tracking-tight text-theme-text-primary">
+                  Opening…
+                </p>
+              </div>
+            </div>
           </div>
         )}
 

--- a/web/src/components/DebugOverlay.tsx
+++ b/web/src/components/DebugOverlay.tsx
@@ -88,7 +88,7 @@ export function DebugOverlay() {
             )}
           </>
         ) : (
-          <span className="text-theme-text-tertiary">Loading...</span>
+          <span className="text-theme-text-tertiary">Loading…</span>
         )}
       </div>
     </div>

--- a/web/src/components/cost/CostTrendChart.tsx
+++ b/web/src/components/cost/CostTrendChart.tsx
@@ -34,7 +34,7 @@ export function CostTrendChart() {
       <div className="rounded-lg border border-theme-border bg-theme-surface/50 p-4">
         <div className="flex items-center justify-center h-[200px] text-theme-text-tertiary">
           <Loader2 className="w-5 h-5 animate-spin mr-2" />
-          Loading cost trend...
+          Loading cost trend…
         </div>
       </div>
     )

--- a/web/src/components/cost/CostView.tsx
+++ b/web/src/components/cost/CostView.tsx
@@ -282,7 +282,7 @@ function WorkloadRows({ namespace }: { namespace: string }) {
     return (
       <div className="px-4 py-3 flex items-center gap-2 text-xs text-theme-text-tertiary bg-theme-elevated/30">
         <Loader2 className="w-3.5 h-3.5 animate-spin" />
-        Loading workloads...
+        Loading workloads…
       </div>
     )
   }

--- a/web/src/components/helm/ChartBrowser.tsx
+++ b/web/src/components/helm/ChartBrowser.tsx
@@ -190,7 +190,7 @@ export function ChartBrowser({ onChartSelect }: ChartBrowserProps) {
                 </button>
                 <div className="border-t border-theme-border my-1" />
                 {reposLoading ? (
-                  <div className="px-3 py-2 text-sm text-theme-text-tertiary">Loading...</div>
+                  <div className="px-3 py-2 text-sm text-theme-text-tertiary">Loading…</div>
                 ) : repositories?.length === 0 ? (
                   <div className="px-3 py-2 text-sm text-theme-text-tertiary">No repositories configured</div>
                 ) : (

--- a/web/src/components/home/ActivitySummary.tsx
+++ b/web/src/components/home/ActivitySummary.tsx
@@ -128,7 +128,7 @@ export function ActivitySummary({ namespaces, topology, onNavigate }: ActivitySu
       <div className="flex-1 min-h-0 overflow-hidden px-4 py-1.5">
         {isLoading ? (
           <div className="flex items-center justify-center h-full py-4 text-xs text-theme-text-tertiary">
-            Loading...
+            Loading…
           </div>
         ) : error ? (
           <div className="flex items-center justify-center h-full py-4 text-xs text-theme-text-tertiary">

--- a/web/src/components/resource/PrometheusChartsGrid.tsx
+++ b/web/src/components/resource/PrometheusChartsGrid.tsx
@@ -316,7 +316,7 @@ function PanelLoading() {
   return (
     <div className="flex items-center justify-center h-full min-h-[160px] text-theme-text-tertiary text-xs">
       <Loader2 className="w-4 h-4 animate-spin mr-2" />
-      Loading...
+      Loading…
     </div>
   )
 }

--- a/web/src/components/shared/LargeClusterNamespacePicker.tsx
+++ b/web/src/components/shared/LargeClusterNamespacePicker.tsx
@@ -39,7 +39,7 @@ export function LargeClusterNamespacePicker({ namespaces, onSelect }: {
       <div className="max-h-[240px] overflow-y-auto rounded-lg border border-theme-border bg-theme-base">
         {!namespaces ? (
           <div className="px-3 py-6 text-center text-sm text-theme-text-tertiary">
-            Loading namespaces...
+            Loading namespaces…
           </div>
         ) : filtered.length === 0 ? (
           <div className="px-3 py-6 text-center text-sm text-theme-text-tertiary">

--- a/web/src/components/ui/DiagnosticsOverlay.tsx
+++ b/web/src/components/ui/DiagnosticsOverlay.tsx
@@ -99,7 +99,7 @@ export function DiagnosticsOverlay({ onClose, isOpen = true }: DiagnosticsOverla
         {/* Content */}
         <div className="overflow-y-auto flex-1 px-5 py-4 space-y-4">
           {isLoading && (
-            <div className="text-sm text-theme-text-tertiary text-center py-8">Loading diagnostics...</div>
+            <div className="text-sm text-theme-text-tertiary text-center py-8">Loading diagnostics…</div>
           )}
           {error && (
             <div className="text-sm text-red-400 text-center py-8">Failed to load diagnostics: {(error as Error).message}</div>


### PR DESCRIPTION
## Summary

Tightens loading-surface consistency in two ways: two full-screen splashes that anchored differently from the rest, and a couple of pane-level loaders that used a bare `Loader2` spinner + text instead of the standard radar-sweep `PaneLoader`. Surfaced by a loading-consistency audit of Radar Cloud (the GitOps board's "Loading GitOps applications…" stood out as a non-radar spinner).

## radar-app (`web/src/App.tsx`)
- **"Opening…" takeover splash** was content-flow centered + 14px secondary, so the mark slid/resized vs the viewport-anchored "Connecting to cluster" splash. Re-anchored to the identical `fixed inset-0` + integer-offset + 17px label.
- **"Redirecting to login…"** used `translate(-50%,-50%)` (sub-pixel jitter on odd-width viewports); switched to the integer-offset anchor the other splashes use. Now all four full-screen splashes (Connecting / Switching / Opening / Redirecting) share one anchor + type size.

## k8s-ui
- **`GitOpsTableView`** ("Loading GitOps applications…") and **`PrometheusChartsView`** ("Checking Prometheus availability…" / "Loading metrics…") rendered `Loader2` + text. Switched to **`PaneLoader`** — the radar sweep, the single loading metaphor for pane-level loads.
- In-button / in-row `Loader2` / `RefreshCw` spinners (action menus, dialogs, refresh/sync buttons) are intentionally left as-is — a 44px sweep in a button is wrong.

## Explicitly NOT in scope
The **viewport→pane logo shift** on cluster entry (the "Connecting" viewport splash → the Resources `PaneLoader` centered in the content pane). Fixing that cleanly needs the landing view's *first-data* signal lifted to App (it crosses into k8s-ui's query state), and the obvious "hold the splash until `topology` arrives" heuristic doesn't actually cover the `?resource=` deep-link case (topology ≠ resource-list readiness). Deferred as its own deliberate change.

## Release
Touches both packages → needs a `radar-app` **and** a `k8s-ui` tag. Radar Cloud pins both and will bump after publish.

## Testing
`tsc` + `vite build` clean (web + k8s-ui via the workspace). Worth a `/visual-test` on a takeover view (Opening…), the GitOps board (sweep instead of spinner), and the workload metrics tab.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only loading UI and copy; no auth, data, or API behavior changes.
> 
> **Overview**
> Aligns **full-screen loading splashes** in `web/src/App.tsx` so **Opening…** and **Redirecting to login…** use the same viewport-anchored layout as **Connecting** (fixed overlay, `calc(50% - 22px)` icon placement, 17px label) instead of flex-centered or `translate(-50%)` positioning that caused logo jump or sub-pixel jitter.
> 
> In **k8s-ui**, pane-level waits that used inline **`Loader2` + text** now use shared **`PaneLoader`** (radar sweep) for GitOps list/detail/insights/tree, Prometheus charts, and related surfaces. In-button and row spinners are unchanged.
> 
> A broad pass replaces **`Loading...`** with typographic **`Loading…`** across k8s-ui and web for consistent copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1107229f131fc7db84472f448f26e37529055aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->