### PR TITLE
feat(portforward): retry button for failed forwards

### DIFF
--- a/web/src/components/portforward/PortForwardManager.tsx
+++ b/web/src/components/portforward/PortForwardManager.tsx
@@ -767,7 +767,7 @@ export function PortForwardPanel() {
                       <Tooltip content="Retry" delay={300} position="bottom" disabled={!isPanelOpen}>
                       <button
                         onClick={() => retryPortForward(session)}
-                        disabled={retryingIds.has(session.id)}
+                        disabled={retryingIds.has(session.id) || stoppingIds.has(session.id)}
                         className="p-1.5 text-theme-text-tertiary hover:text-green-400 hover:bg-theme-hover rounded disabled:opacity-50"
                       >
                         {retryingIds.has(session.id) ? (
@@ -784,7 +784,7 @@ export function PortForwardPanel() {
                         commitInteraction()
                         stopPortForward(session.id)
                       }}
-                      disabled={stoppingIds.has(session.id)}
+                      disabled={stoppingIds.has(session.id) || retryingIds.has(session.id)}
                       className="p-1.5 text-theme-text-tertiary hover:text-red-400 hover:bg-theme-hover rounded disabled:opacity-50"
                     >
                       <Trash2 className="w-3.5 h-3.5" />

--- a/web/src/components/portforward/PortForwardManager.tsx
+++ b/web/src/components/portforward/PortForwardManager.tsx
@@ -20,6 +20,7 @@ import {
   Globe,
   Monitor,
   PenLine,
+  RotateCw,
 } from 'lucide-react'
 import { clsx } from 'clsx'
 // CSS_EASE (the shared spring curve) is intentionally NOT used for this panel —
@@ -30,6 +31,7 @@ import { Tooltip } from '../ui/Tooltip'
 import { useToast } from '../ui/Toast'
 import { openExternal } from '../../utils/navigation'
 import { apiUrl } from '../../api/config'
+import { apiFetch } from '../../api/client'
 import { pluralize } from '@skyhook-io/k8s-ui'
 
 // --- Types -------------------------------------------------------------------
@@ -86,7 +88,7 @@ function usePortForwardQuery() {
   return useQuery<PortForwardSession[]>({
     queryKey: ['portforwards'],
     queryFn: async () => {
-      const res = await fetch(apiUrl('/portforwards'))
+      const res = await apiFetch(apiUrl('/portforwards'))
       if (!res.ok) throw new Error('Failed to fetch port forwards')
       return res.json()
     },
@@ -390,6 +392,9 @@ export function PortForwardPanel() {
   // without disabling all stop buttons (the old shared-mutation approach blocked
   // every row when any single stop was in-flight).
   const [stoppingIds, setStoppingIds] = useState<Set<string>>(() => new Set())
+  // Per-session retry tracking — same rationale as stoppingIds: multiple failed
+  // forwards can be retried independently without disabling every retry button.
+  const [retryingIds, setRetryingIds] = useState<Set<string>>(() => new Set())
   const queryClient = useQueryClient()
   const { showSuccess, showError } = useToast()
 
@@ -424,7 +429,7 @@ export function PortForwardPanel() {
   const stopPortForward = useCallback(async (id: string) => {
     setStoppingIds(prev => new Set(prev).add(id))
     try {
-      const res = await fetch(apiUrl(`/portforwards/${id}`), { method: 'DELETE' })
+      const res = await apiFetch(apiUrl(`/portforwards/${id}`), { method: 'DELETE' })
       if (!res.ok) {
         const body = await res.json().catch(() => ({}))
         throw new Error(body.error || `Failed to stop port forward (HTTP ${res.status})`)
@@ -444,6 +449,48 @@ export function PortForwardPanel() {
     }
   }, [queryClient, showError])
 
+  // Recreate a failed forward. The errored session is already dead — there's no live
+  // forward to lose — so we drop the stale row FIRST, then recreate. Delete-first keeps
+  // the panel at exactly one row in every outcome (success → one running row; failure →
+  // one errored row), avoiding the orphaned-duplicate the reverse order would leave when
+  // the backend keeps a failed-start session in its map. A 404 means it was already
+  // cleared (e.g. context switch) — benign, proceed. Service-resolved sessions re-route
+  // through the service path via buildRecreateBody, so a retry after the backing pod was
+  // replaced re-resolves to a currently-running pod.
+  const retryPortForward = useCallback(async (session: PortForwardSession) => {
+    commitInteraction()
+    setRetryingIds(prev => new Set(prev).add(session.id))
+    try {
+      const delRes = await apiFetch(apiUrl(`/portforwards/${session.id}`), { method: 'DELETE' })
+      if (!delRes.ok && delRes.status !== 404) {
+        const body = await delRes.json().catch(() => ({}))
+        throw new Error(body.error || `Failed to clear failed port forward (HTTP ${delRes.status})`)
+      }
+      const res = await apiFetch(apiUrl('/portforwards'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(buildRecreateBody(session, { localPort: session.localPort, listenAddress: session.listenAddress })),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.error || `Failed to retry port forward (HTTP ${res.status})`)
+      }
+      queryClient.invalidateQueries({ queryKey: ['portforwards'] })
+      showSuccess('Port forward restarted', `Now listening on localhost:${session.localPort}`)
+    } catch (err) {
+      queryClient.invalidateQueries({ queryKey: ['portforwards'] })
+      const msg = err instanceof Error ? err.message : 'Failed to retry port forward'
+      showError('Failed to retry port forward', msg)
+      console.error('Failed to retry port forward:', err)
+    } finally {
+      setRetryingIds(prev => {
+        const next = new Set(prev)
+        next.delete(session.id)
+        return next
+      })
+    }
+  }, [commitInteraction, queryClient, showSuccess, showError])
+
   const toggleListenAddress = async (session: PortForwardSession) => {
     commitInteraction()
     const newAddress = session.listenAddress === '0.0.0.0' ? '127.0.0.1' : '0.0.0.0'
@@ -454,13 +501,13 @@ export function PortForwardPanel() {
     // apart from "original gone and recreate failed = data loss."
     let deleted = false
     try {
-      const delRes = await fetch(apiUrl(`/portforwards/${session.id}`), { method: 'DELETE' })
+      const delRes = await apiFetch(apiUrl(`/portforwards/${session.id}`), { method: 'DELETE' })
       if (!delRes.ok) {
         const body = await delRes.json().catch(() => ({}))
         throw new Error(body.error || `Failed to stop existing port forward (HTTP ${delRes.status})`)
       }
       deleted = true
-      const res = await fetch(apiUrl('/portforwards'), {
+      const res = await apiFetch(apiUrl('/portforwards'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(buildRecreateBody(session, { localPort: session.localPort, listenAddress: newAddress })),
@@ -501,13 +548,13 @@ export function PortForwardPanel() {
     // apart from "original gone and recreate failed = data loss."
     let deleted = false
     try {
-      const delRes = await fetch(apiUrl(`/portforwards/${session.id}`), { method: 'DELETE' })
+      const delRes = await apiFetch(apiUrl(`/portforwards/${session.id}`), { method: 'DELETE' })
       if (!delRes.ok) {
         const body = await delRes.json().catch(() => ({}))
         throw new Error(body.error || `Failed to stop existing port forward (HTTP ${delRes.status})`)
       }
       deleted = true
-      const res = await fetch(apiUrl('/portforwards'), {
+      const res = await apiFetch(apiUrl('/portforwards'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(buildRecreateBody(session, { localPort: newPort, listenAddress: session.listenAddress })),
@@ -716,6 +763,21 @@ export function PortForwardPanel() {
                       </button>
                       </Tooltip>
                     )}
+                    {session.status === 'error' && (
+                      <Tooltip content="Retry" delay={300} position="bottom" disabled={!isPanelOpen}>
+                      <button
+                        onClick={() => retryPortForward(session)}
+                        disabled={retryingIds.has(session.id)}
+                        className="p-1.5 text-theme-text-tertiary hover:text-green-400 hover:bg-theme-hover rounded disabled:opacity-50"
+                      >
+                        {retryingIds.has(session.id) ? (
+                          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                        ) : (
+                          <RotateCw className="w-3.5 h-3.5" />
+                        )}
+                      </button>
+                      </Tooltip>
+                    )}
                     <Tooltip content={session.status === 'error' ? 'Dismiss' : 'Stop'} delay={300} position="bottom" disabled={!isPanelOpen}>
                     <button
                       onClick={() => {
@@ -882,7 +944,7 @@ export function useStartPortForward() {
       localPort?: number
       listenAddress?: string // "127.0.0.1" (default) or "0.0.0.0"
     }) => {
-      const res = await fetch(apiUrl('/portforwards'), {
+      const res = await apiFetch(apiUrl('/portforwards'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(req),


### PR DESCRIPTION
## Summary

When a port forward dies — pod restart, OOM, lost connection, or a failed start — the panel previously offered only a **dismiss** action. Recovering meant re-navigating to the resource and re-selecting the port. This adds a **Retry** button to failed rows that recreates the forward in place, turning a dead tunnel back into a working one with one click.

Closes #1002.

## What changed

**Retry control.** Errored rows in the floating port-forward panel now render a `↻` Retry button (left of dismiss). It recreates the forward through the existing service/pod recreate path (`buildRecreateBody`), so a **service-targeted** forward re-resolves to a currently-running pod — a retry after the backing pod was replaced just works. Pod-targeted forwards retry against the same pod and fail clearly if it's gone (inherent, correct). Per-row `retryingIds` tracking lets multiple failures retry independently with their own spinner.

**Delete-first ordering (the load-bearing decision).** Retry deletes the dead session *before* recreating, rather than recreate-then-delete. Because an errored session is already dead, there's no live forward to lose — and delete-first keeps the panel at **exactly one row in every outcome** (success → one running row; failure → one errored row). Recreate-first would orphan a duplicate errored row whenever the backend retains a failed-start session in its map. This also means cleanup happens up front, so a delete failure surfaces honestly instead of being swallowed behind a success toast.

**Auth plumbing.** Routed all of the panel's port-forward fetches through the auth-aware `apiFetch` wrapper (credentials + auth headers + global 401 handling). Previously every call used bare `fetch`, bypassing that plumbing — so embedded consumers like Radar Hub couldn't authenticate the port-forward panel. This fixes the whole feature, not just the new retry calls.

### Reviewer focus
- The delete-first vs recreate-first tradeoff (one comment in `retryPortForward` explains it).
- A backend restart endpoint was considered and rejected: the existing toggle-listen / change-port flows already do client-side recreate with identical semantics, and the only net-new concern (optimistic "running" before the forward is truly ready) is pre-existing across every forward start, not introduced here.

## Testing

- `make tsc` ✓ · `go test` (server + all `pkg/...`) ✓ · `make build` (frontend + embed + binary) ✓
- **Visual-test (manual, live cluster):** staged a real errored session against a throwaway `nginx` service by forcing a local-port bind collision, then verified in the running UI that the panel shows the **Failed** row with the Retry button and that clicking Retry re-resolves the service to a healthy pod and restores a running forward. Playwright MCP wasn't available this session, so capture was manual rather than scripted.

## Notes

- Errored rows are intentionally **left until the user resolves them** (retry-success auto-removes the row; dismiss is the manual path). No timed auto-expiry — silently dropping a dead row would hide a forward the user was depending on.
- Retrying onto a now-occupied local port fails (the port can't be edited on an errored row); recourse is dismiss + restart. Rare; deliberately not auto-reassigning the port, which would change a URL the user may have bookmarked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes reusing existing recreate/delete semantics; `apiFetch` aligns behavior with the rest of the app and should fix auth gaps rather than introduce new server contracts.
> 
> **Overview**
> Failed port-forward rows in the floating panel now get a **Retry** action that clears the dead session (DELETE, treating 404 as OK) and recreates it via the same `buildRecreateBody` path used for listen/port changes—so service-backed forwards can re-resolve to a healthy pod. Per-row `retryingIds` keeps spinners and button disables independent when several rows fail at once.
> 
> All port-forward API calls in this component move from bare `fetch` to **`apiFetch`**, so credentials, auth headers, and global 401 handling apply to the whole panel (including embedded consumers), not only the new retry flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad5e998506029708ed4bd50f70a6f4fedf01c230. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->