### PR TITLE
fix(topology): unify group-collapse predicate to stop ELK layout crash + dropped edges

### DIFF
--- a/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
+++ b/packages/k8s-ui/src/components/topology/TopologyGraph.tsx
@@ -30,7 +30,7 @@ import { K8sResourceNode } from './K8sResourceNode'
 import { GroupNode } from './GroupNode'
 import { NEUTRAL_OWNER, type WorkloadFocus } from '../../utils/workload-colors'
 import { ownershipOf } from '../../utils/topology-neighborhood'
-import { buildHierarchicalElkGraph, applyHierarchicalLayout, getGroupKey, type GroupDisplayLevel } from './layout'
+import { buildHierarchicalElkGraph, applyHierarchicalLayout, getGroupKey, isGroupEffectivelyCollapsed, type GroupDisplayLevel } from './layout'
 import type { Topology, TopologyNode, TopologyEdge, ViewMode, GroupingMode } from '../../types'
 import { pluralize } from '../../utils/pluralize'
 import { foldHash } from '../../utils/structure-hash'
@@ -94,7 +94,9 @@ function buildEdges(
   groupingMode: GroupingMode,
   isTrafficView: boolean,
   nodeToGroup?: Map<string, string>,
-  nodeCount?: number
+  nodeCount?: number,
+  groupLevels?: Map<string, GroupDisplayLevel>,
+  smartDefaultActive = false,
 ): Edge[] {
   const edges: Edge[] = []
   const seenEdgeIds = new Set<string>() // O(1) duplicate detection
@@ -117,15 +119,17 @@ function buildEdges(
     let source = edge.source
     let target = edge.target
 
-    // If source is in a collapsed group, point to the group instead
+    // If source is in a collapsed group, point to the group instead. Same
+    // predicate as ELK node placement (isGroupEffectivelyCollapsed) so a
+    // rendered edge never references a member hidden inside a chip.
     const sourceGroup = nodeGroupMap.get(source)
-    if (sourceGroup && collapsedGroups.has(sourceGroup)) {
+    if (sourceGroup && isGroupEffectivelyCollapsed(sourceGroup, collapsedGroups, groupLevels, smartDefaultActive)) {
       source = sourceGroup
     }
 
     // If target is in a collapsed group, point to the group instead
     const targetGroup = nodeGroupMap.get(target)
-    if (targetGroup && collapsedGroups.has(targetGroup)) {
+    if (targetGroup && isGroupEffectivelyCollapsed(targetGroup, collapsedGroups, groupLevels, smartDefaultActive)) {
       target = targetGroup
     }
 
@@ -607,13 +611,20 @@ export function TopologyGraph({
     // Increment version to invalidate any previous in-flight layout
     const thisLayoutVersion = ++layoutVersionRef.current
 
+    // The smart-default chip pass only ever materializes namespace groups, so its
+    // "no-entry group defaults to collapsed" semantics apply only in namespace
+    // mode. Outside it (small clusters, app grouping) a no-entry group stays
+    // expanded — see isGroupEffectivelyCollapsed.
+    const smartDefaultActive = hasAppliedSmartDefaultRef.current && groupingMode === 'namespace'
+
     // Build hierarchical ELK graph
     const { elkGraph, groupMap, nodeToGroup } = buildHierarchicalElkGraph(
       workingNodes,
       workingEdges,
       groupingMode,
       collapsedGroups,
-      groupLevels
+      groupLevels,
+      smartDefaultActive
     )
     groupMapRef.current = groupMap
 
@@ -711,7 +722,9 @@ export function TopologyGraph({
           groupingMode,
           isTrafficView,
           nodeToGroup,
-          nodesWithHandlers.length
+          nodesWithHandlers.length,
+          groupLevels,
+          smartDefaultActive
         )
         setEdges(builtEdges)
       }

--- a/packages/k8s-ui/src/components/topology/layout-elk-graph.test.ts
+++ b/packages/k8s-ui/src/components/topology/layout-elk-graph.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { buildHierarchicalElkGraph, type GroupDisplayLevel } from './layout'
+import { describe, it, expect, beforeAll } from 'vitest'
+import { buildHierarchicalElkGraph, applyHierarchicalLayout, setLayoutEngine, type GroupDisplayLevel } from './layout'
 import type { TopologyNode, TopologyEdge } from '../../types'
 
 // Collect every id ELK will see as a layoutable shape: top-level children plus
@@ -44,7 +44,9 @@ describe('buildHierarchicalElkGraph — collapse predicate consistency', () => {
     // collapsedGroups mirrors TopologyGraph: only explicit non-'topology' levels.
     const collapsedGroups = new Set<string>(['group-namespace-app1'])
 
-    const { elkGraph } = buildHierarchicalElkGraph(nodes, edges, 'namespace', collapsedGroups, groupLevels)
+    // smartDefaultActive=true: the large-cluster chip pass ran, so the
+    // late-arriving skyhook-gateway defaults to collapsed.
+    const { elkGraph } = buildHierarchicalElkGraph(nodes, edges, 'namespace', collapsedGroups, groupLevels, true)
 
     const valid = validEndpointIds(elkGraph)
     for (const edge of elkGraph.edges) {
@@ -56,6 +58,38 @@ describe('buildHierarchicalElkGraph — collapse predicate consistency', () => {
     const endpoints = elkGraph.edges.flatMap(e => [...e.sources, ...e.targets])
     expect(endpoints).not.toContain('deployment/skyhook-gateway/skyhook-frpc')
     expect(endpoints).toContain('group-namespace-skyhook-gateway')
+  })
+
+  // Without smart-default (small clusters, manual toggles), collapsing one group
+  // must NOT cascade-collapse untouched no-entry groups. app2 has no level entry;
+  // since smartDefaultActive is false it stays expanded and its member renders.
+  it('does not cascade-collapse no-entry groups when smart-default is inactive', () => {
+    const nodes: TopologyNode[] = [
+      deployment('app1', 'web'),
+      deployment('app2', 'api'),
+    ]
+    const edges: TopologyEdge[] = [
+      { id: 'e1', source: 'deployment/app1/web', target: 'deployment/app2/api', type: 'routes-to' },
+    ]
+    // User collapsed only app1; app2 untouched (no entry).
+    const groupLevels = new Map<string, GroupDisplayLevel>([['group-namespace-app1', 'chip']])
+    const collapsedGroups = new Set<string>(['group-namespace-app1'])
+
+    const { elkGraph } = buildHierarchicalElkGraph(nodes, edges, 'namespace', collapsedGroups, groupLevels, false)
+
+    // app2 stays expanded with its member as a child.
+    const app2 = elkGraph.children.find(c => c.id === 'group-namespace-app2')
+    expect(app2?.children?.some(c => c.id === 'deployment/app2/api')).toBe(true)
+
+    // Edge stays valid: app1 redirected to its chip, app2 member kept (it exists).
+    const valid = validEndpointIds(elkGraph)
+    for (const edge of elkGraph.edges) {
+      expect(valid.has(edge.sources[0])).toBe(true)
+      expect(valid.has(edge.targets[0])).toBe(true)
+    }
+    const endpoints = elkGraph.edges.flatMap(e => [...e.sources, ...e.targets])
+    expect(endpoints).toContain('group-namespace-app1')
+    expect(endpoints).toContain('deployment/app2/api')
   })
 
   it('keeps edges between expanded groups referencing plain member ids', () => {
@@ -95,5 +129,34 @@ describe('buildHierarchicalElkGraph — collapse predicate consistency', () => {
       expect(valid.has(edge.sources[0])).toBe(true)
       expect(valid.has(edge.targets[0])).toBe(true)
     }
+  })
+})
+
+// Render layer: the GroupNode's displayLevel must agree with ELK placement, or a
+// chip renders over its own laid-out children. group.isCollapsed (from the layout
+// engine) is the single source of truth.
+describe('applyHierarchicalLayout — rendered displayLevel matches placement', () => {
+  beforeAll(() => setLayoutEngine('main-thread'))
+
+  const noop = () => {}
+  const callbacks = { onSetLevel: noop, onCardClick: noop }
+
+  it('renders an untouched no-entry group as topology (not chip) on manual collapse', async () => {
+    const nodes: TopologyNode[] = [deployment('app1', 'web'), deployment('app2', 'api')]
+    const edges: TopologyEdge[] = [
+      { id: 'e1', source: 'deployment/app1/web', target: 'deployment/app2/api', type: 'routes-to' },
+    ]
+    // Small cluster, smart-default inactive: user collapsed only app1.
+    const groupLevels = new Map<string, GroupDisplayLevel>([['group-namespace-app1', 'chip']])
+    const collapsedGroups = new Set<string>(['group-namespace-app1'])
+
+    const { elkGraph, groupMap } = buildHierarchicalElkGraph(nodes, edges, 'namespace', collapsedGroups, groupLevels, false)
+    const { nodes: rendered } = await applyHierarchicalLayout(
+      elkGraph, nodes, edges, groupMap, 'namespace', collapsedGroups, callbacks, false, groupLevels,
+    )
+
+    const groupNode = (id: string) => rendered.find(n => n.id === id && n.type === 'group')
+    expect(groupNode('group-namespace-app1')?.data.displayLevel).toBe('chip')
+    expect(groupNode('group-namespace-app2')?.data.displayLevel).toBe('topology')
   })
 })

--- a/packages/k8s-ui/src/components/topology/layout-elk-graph.test.ts
+++ b/packages/k8s-ui/src/components/topology/layout-elk-graph.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import { buildHierarchicalElkGraph, type GroupDisplayLevel } from './layout'
+import type { TopologyNode, TopologyEdge } from '../../types'
+
+// Collect every id ELK will see as a layoutable shape: top-level children plus
+// the members of expanded groups. An edge endpoint outside this set is exactly
+// what makes ELK throw "Referenced shape does not exist".
+function validEndpointIds(elkGraph: { children: Array<{ id: string; children?: Array<{ id: string }> }> }): Set<string> {
+  const ids = new Set<string>()
+  for (const child of elkGraph.children) {
+    ids.add(child.id)
+    for (const c of child.children ?? []) ids.add(c.id)
+  }
+  return ids
+}
+
+function deployment(ns: string, name: string): TopologyNode {
+  return {
+    id: `deployment/${ns}/${name}`,
+    kind: 'Deployment',
+    name,
+    status: 'healthy',
+    data: { namespace: ns },
+  }
+}
+
+describe('buildHierarchicalElkGraph — collapse predicate consistency', () => {
+  // Reproduces the Resources→Traffic crash: smart-default chipped the namespaces
+  // present at the time (app1), then a view switch surfaced a namespace
+  // (skyhook-gateway) with no groupLevels entry. Node placement hid its members
+  // (treated as collapsed) but the old edge-redirect only fired for groups in
+  // collapsedGroups — leaving an edge pointed at a hidden plain node id.
+  it('redirects edges into a late-arriving (no-level) group so no edge dangles', () => {
+    const nodes: TopologyNode[] = [
+      deployment('app1', 'web'),
+      deployment('skyhook-gateway', 'skyhook-frpc'),
+    ]
+    const edges: TopologyEdge[] = [
+      { id: 'e1', source: 'deployment/app1/web', target: 'deployment/skyhook-gateway/skyhook-frpc', type: 'routes-to' },
+    ]
+
+    // Smart default chipped app1 only; skyhook-gateway appeared later → no entry.
+    const groupLevels = new Map<string, GroupDisplayLevel>([['group-namespace-app1', 'chip']])
+    // collapsedGroups mirrors TopologyGraph: only explicit non-'topology' levels.
+    const collapsedGroups = new Set<string>(['group-namespace-app1'])
+
+    const { elkGraph } = buildHierarchicalElkGraph(nodes, edges, 'namespace', collapsedGroups, groupLevels)
+
+    const valid = validEndpointIds(elkGraph)
+    for (const edge of elkGraph.edges) {
+      expect(valid.has(edge.sources[0]), `source ${edge.sources[0]} must exist`).toBe(true)
+      expect(valid.has(edge.targets[0]), `target ${edge.targets[0]} must exist`).toBe(true)
+    }
+
+    // The plain hidden member id must never survive as an endpoint.
+    const endpoints = elkGraph.edges.flatMap(e => [...e.sources, ...e.targets])
+    expect(endpoints).not.toContain('deployment/skyhook-gateway/skyhook-frpc')
+    expect(endpoints).toContain('group-namespace-skyhook-gateway')
+  })
+
+  it('keeps edges between expanded groups referencing plain member ids', () => {
+    const nodes: TopologyNode[] = [
+      deployment('app1', 'web'),
+      deployment('app2', 'api'),
+    ]
+    const edges: TopologyEdge[] = [
+      { id: 'e1', source: 'deployment/app1/web', target: 'deployment/app2/api', type: 'routes-to' },
+    ]
+    // Both groups explicitly expanded.
+    const groupLevels = new Map<string, GroupDisplayLevel>([
+      ['group-namespace-app1', 'topology'],
+      ['group-namespace-app2', 'topology'],
+    ])
+
+    const { elkGraph } = buildHierarchicalElkGraph(nodes, edges, 'namespace', new Set(), groupLevels)
+
+    const valid = validEndpointIds(elkGraph)
+    for (const edge of elkGraph.edges) {
+      expect(valid.has(edge.sources[0])).toBe(true)
+      expect(valid.has(edge.targets[0])).toBe(true)
+    }
+    const endpoints = elkGraph.edges.flatMap(e => [...e.sources, ...e.targets])
+    expect(endpoints).toContain('deployment/app1/web')
+    expect(endpoints).toContain('deployment/app2/api')
+  })
+
+  it('produces no dangling endpoints with no grouping', () => {
+    const nodes: TopologyNode[] = [deployment('app1', 'web'), deployment('app1', 'api')]
+    const edges: TopologyEdge[] = [
+      { id: 'e1', source: 'deployment/app1/web', target: 'deployment/app1/api', type: 'routes-to' },
+    ]
+    const { elkGraph } = buildHierarchicalElkGraph(nodes, edges, 'none', new Set(), new Map())
+    const valid = validEndpointIds(elkGraph)
+    for (const edge of elkGraph.edges) {
+      expect(valid.has(edge.sources[0])).toBe(true)
+      expect(valid.has(edge.targets[0])).toBe(true)
+    }
+  })
+})

--- a/packages/k8s-ui/src/components/topology/layout-elk-graph.test.ts
+++ b/packages/k8s-ui/src/components/topology/layout-elk-graph.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from 'vitest'
-import { buildHierarchicalElkGraph, applyHierarchicalLayout, setLayoutEngine, type GroupDisplayLevel } from './layout'
+import { buildHierarchicalElkGraph, applyHierarchicalLayout, buildInterGroupEdges, setLayoutEngine, type GroupDisplayLevel } from './layout'
 import type { TopologyNode, TopologyEdge } from '../../types'
 
 // Collect every id ELK will see as a layoutable shape: top-level children plus
@@ -129,6 +129,66 @@ describe('buildHierarchicalElkGraph — collapse predicate consistency', () => {
       expect(valid.has(edge.sources[0])).toBe(true)
       expect(valid.has(edge.targets[0])).toBe(true)
     }
+  })
+})
+
+// Phase-2 meta layout: edges that position groups relative to each other must
+// survive even when both endpoints are already meta nodes (two collapsed chips, or
+// a chip and an ungrouped node). The old branching dropped those, so connected
+// chips weren't pulled together.
+describe('buildInterGroupEdges — meta-graph connectivity', () => {
+  const edge = (id: string, source: string, target: string) => ({ id, sources: [source], targets: [target] })
+
+  it('keeps chip↔chip edges (both endpoints already meta nodes)', () => {
+    const metaIds = new Set(['group-namespace-app1', 'group-namespace-app2'])
+    // Neither endpoint is an expanded-group member, so nodeToGroup is empty.
+    const out = buildInterGroupEdges([edge('e1', 'group-namespace-app1', 'group-namespace-app2')], new Map(), metaIds)
+    expect(out).toHaveLength(1)
+    expect(out[0]).toMatchObject({ sources: ['group-namespace-app1'], targets: ['group-namespace-app2'] })
+  })
+
+  it('keeps chip↔ungrouped edges', () => {
+    const metaIds = new Set(['group-namespace-app1', 'orphan-node'])
+    const out = buildInterGroupEdges([edge('e1', 'group-namespace-app1', 'orphan-node')], new Map(), metaIds)
+    expect(out).toHaveLength(1)
+  })
+
+  it('normalizes expanded-group members to their group', () => {
+    const nodeToGroup = new Map([
+      ['deployment/app1/web', 'group-namespace-app1'],
+      ['deployment/app2/api', 'group-namespace-app2'],
+    ])
+    const metaIds = new Set(['group-namespace-app1', 'group-namespace-app2'])
+    const out = buildInterGroupEdges([edge('e1', 'deployment/app1/web', 'deployment/app2/api')], nodeToGroup, metaIds)
+    expect(out[0]).toMatchObject({ sources: ['group-namespace-app1'], targets: ['group-namespace-app2'] })
+  })
+
+  it('drops intra-group edges and endpoints absent from the meta graph', () => {
+    const nodeToGroup = new Map([
+      ['deployment/app1/web', 'group-namespace-app1'],
+      ['deployment/app1/api', 'group-namespace-app1'],
+    ])
+    const metaIds = new Set(['group-namespace-app1'])
+    // Same group on both ends → intra, skip. And an edge to a non-meta id → skip.
+    const out = buildInterGroupEdges([
+      edge('e1', 'deployment/app1/web', 'deployment/app1/api'),
+      edge('e2', 'group-namespace-app1', 'ghost-node'),
+    ], nodeToGroup, metaIds)
+    expect(out).toHaveLength(0)
+  })
+
+  it('dedupes edges collapsing to the same meta pair', () => {
+    const nodeToGroup = new Map([
+      ['deployment/app1/web', 'group-namespace-app1'],
+      ['deployment/app1/api', 'group-namespace-app1'],
+      ['deployment/app2/x', 'group-namespace-app2'],
+    ])
+    const metaIds = new Set(['group-namespace-app1', 'group-namespace-app2'])
+    const out = buildInterGroupEdges([
+      edge('e1', 'deployment/app1/web', 'deployment/app2/x'),
+      edge('e2', 'deployment/app1/api', 'deployment/app2/x'),
+    ], nodeToGroup, metaIds)
+    expect(out).toHaveLength(1)
   })
 })
 

--- a/packages/k8s-ui/src/components/topology/layout.ts
+++ b/packages/k8s-ui/src/components/topology/layout.ts
@@ -496,6 +496,23 @@ export function buildHierarchicalElkGraph(
     }
   }
 
+  // A group is "effectively collapsed" (rendered as a single chip/card with its
+  // members hidden) when it's explicitly in collapsedGroups, OR levels exist for
+  // the current grouping mode and this group lacks an explicit 'topology' level.
+  // The second clause covers groups that appeared after the smart-default chip
+  // pass — e.g. a namespace that only surfaces after switching Resources↔Traffic,
+  // which therefore has no groupLevels entry at all.
+  //
+  // Node placement and edge redirect MUST share this predicate: if a member is
+  // hidden inside a chip but an edge still references it by plain id, ELK fails
+  // to import the graph ("Referenced shape does not exist").
+  const groupPrefix = `group-${groupingMode}-`
+  const hasLevelsForCurrentMode = !!groupLevels && groupLevels.size > 0 &&
+    [...groupLevels.keys()].some(k => k.startsWith(groupPrefix))
+  const isGroupCollapsed = (groupId: string): boolean =>
+    collapsedGroups.has(groupId) ||
+    (hasLevelsForCurrentMode && groupLevels!.get(groupId) !== 'topology')
+
   const children: ElkNode[] = []
   const processedNodes = new Set<string>()
 
@@ -516,16 +533,7 @@ export function buildHierarchicalElkGraph(
     // Create group nodes with children
     for (const [groupKey, memberIds] of groupMap) {
       const groupId = `group-${groupingMode}-${groupKey}`
-      // When groupLevels has entries for the CURRENT grouping mode, any group without
-      // an explicit 'topology' level is collapsed. This prevents late-arriving namespaces
-      // from defaulting to expanded and overlapping with collapsed chips.
-      // Only apply when levels exist for the same grouping prefix — don't let namespace
-      // levels leak into app/label grouping contexts.
-      const groupPrefix = `group-${groupingMode}-`
-      const hasLevelsForCurrentMode = groupLevels && groupLevels.size > 0 &&
-        [...groupLevels.keys()].some(k => k.startsWith(groupPrefix))
-      const isCollapsed = collapsedGroups.has(groupId) ||
-        (hasLevelsForCurrentMode && groupLevels!.get(groupId) !== 'topology')
+      const isCollapsed = isGroupCollapsed(groupId)
 
       if (isCollapsed) {
         const displayLevel = groupLevels?.get(groupId) || 'chip'
@@ -623,6 +631,18 @@ export function buildHierarchicalElkGraph(
     }
   }
 
+  // Every ELK edge endpoint must reference a node present in the graph (a
+  // top-level child, or a member of an expanded group). A single dangling
+  // reference makes ELK reject the whole import, blanking the topology — so we
+  // drop the stray edge instead. With the unified isGroupCollapsed predicate
+  // this should never fire; it's insurance against future placement/redirect
+  // drift.
+  const validEndpointIds = new Set<string>()
+  for (const child of children) {
+    validEndpointIds.add(child.id)
+    if (child.children) for (const c of child.children) validEndpointIds.add(c.id)
+  }
+
   // Build edges, redirecting to groups when collapsed
   const elkEdges: ElkEdge[] = []
   const seenEdges = new Set<string>()
@@ -631,16 +651,20 @@ export function buildHierarchicalElkGraph(
     let source = edge.source
     let target = edge.target
 
-    // Redirect edges to collapsed groups
+    // Redirect edges to collapsed groups — same predicate as node placement so
+    // an edge never references a member hidden inside a chip.
     const sourceGroup = nodeToGroup.get(source)
-    if (sourceGroup && collapsedGroups.has(sourceGroup)) {
+    if (sourceGroup && isGroupCollapsed(sourceGroup)) {
       source = sourceGroup
     }
 
     const targetGroup = nodeToGroup.get(target)
-    if (targetGroup && collapsedGroups.has(targetGroup)) {
+    if (targetGroup && isGroupCollapsed(targetGroup)) {
       target = targetGroup
     }
+
+    // Drop edges whose endpoints aren't in the graph (see validEndpointIds)
+    if (!validEndpointIds.has(source) || !validEndpointIds.has(target)) continue
 
     // Skip self-loops
     if (source === target) continue

--- a/packages/k8s-ui/src/components/topology/layout.ts
+++ b/packages/k8s-ui/src/components/topology/layout.ts
@@ -459,13 +459,41 @@ function pickGroupName(nodes: TopologyNode[]): string {
   return sorted[0].name
 }
 
+/**
+ * Whether a group renders as a single collapsed chip/card (members hidden) vs an
+ * expanded container. This is the ONE predicate that node placement, ELK edge
+ * redirect, and ReactFlow edge building must all agree on — if they diverge, an
+ * edge can reference a member hidden inside a chip, which either crashes ELK
+ * ("Referenced shape does not exist") or silently drops the rendered edge.
+ *
+ * - Explicit chip/cardGrid levels are always collapsed (they're in collapsedGroups).
+ * - When the smart-default chip pass is active (large clusters), a group with no
+ *   level entry is a late arrival and defaults to collapsed — e.g. a namespace
+ *   that only surfaces after switching Resources↔Traffic. When it is NOT active
+ *   (small clusters, manual per-group toggles), a no-entry group stays expanded,
+ *   so collapsing one group never cascades to untouched groups.
+ */
+export function isGroupEffectivelyCollapsed(
+  groupId: string,
+  collapsedGroups: Set<string>,
+  groupLevels: Map<string, GroupDisplayLevel> | undefined,
+  smartDefaultActive: boolean,
+): boolean {
+  if (collapsedGroups.has(groupId)) return true
+  if (smartDefaultActive && groupLevels?.get(groupId) !== 'topology') return true
+  return false
+}
+
 // Build hierarchical ELK graph with groups containing children
 export function buildHierarchicalElkGraph(
   topologyNodes: TopologyNode[],
   edges: Array<{ id: string; source: string; target: string; type: string }>,
   groupingMode: GroupingMode,
   collapsedGroups: Set<string>,
-  groupLevels?: Map<string, GroupDisplayLevel>
+  groupLevels?: Map<string, GroupDisplayLevel>,
+  /** True when the large-cluster smart-default chip pass has materialized levels;
+   *  makes no-entry groups default to collapsed (see isGroupEffectivelyCollapsed). */
+  smartDefaultActive = false,
 ): { elkGraph: ElkGraph; groupMap: Map<string, string[]>; nodeToGroup: Map<string, string> } {
   const groupMap = new Map<string, string[]>()
   const nodeToGroup = new Map<string, string>()
@@ -496,22 +524,10 @@ export function buildHierarchicalElkGraph(
     }
   }
 
-  // A group is "effectively collapsed" (rendered as a single chip/card with its
-  // members hidden) when it's explicitly in collapsedGroups, OR levels exist for
-  // the current grouping mode and this group lacks an explicit 'topology' level.
-  // The second clause covers groups that appeared after the smart-default chip
-  // pass — e.g. a namespace that only surfaces after switching Resources↔Traffic,
-  // which therefore has no groupLevels entry at all.
-  //
-  // Node placement and edge redirect MUST share this predicate: if a member is
-  // hidden inside a chip but an edge still references it by plain id, ELK fails
-  // to import the graph ("Referenced shape does not exist").
-  const groupPrefix = `group-${groupingMode}-`
-  const hasLevelsForCurrentMode = !!groupLevels && groupLevels.size > 0 &&
-    [...groupLevels.keys()].some(k => k.startsWith(groupPrefix))
+  // Node placement and edge redirect MUST share this predicate — see
+  // isGroupEffectivelyCollapsed for why.
   const isGroupCollapsed = (groupId: string): boolean =>
-    collapsedGroups.has(groupId) ||
-    (hasLevelsForCurrentMode && groupLevels!.get(groupId) !== 'topology')
+    isGroupEffectivelyCollapsed(groupId, collapsedGroups, groupLevels, smartDefaultActive)
 
   const children: ElkNode[] = []
   const processedNodes = new Set<string>()
@@ -889,12 +905,13 @@ export async function applyHierarchicalLayout(
       positions.set(group.groupId, pos)
 
       const { worstStatus, unhealthyCount } = computeGroupHealth(memberIds, nodeMap)
-      // Default to 'chip' when groupLevels has entries for the current grouping mode,
-      // so late-arriving namespaces don't render as expanded topology and overlap with chips.
-      const hasLevelsForMode = groupLevels && groupLevels.size > 0 &&
-        [...groupLevels.keys()].some(k => k.startsWith(`group-${groupingMode}-`))
-      const defaultLevel: GroupDisplayLevel = hasLevelsForMode ? 'chip' : 'topology'
-      const displayLevel: GroupDisplayLevel = groupLevels?.get(group.groupId) || (group.isCollapsed ? 'chip' : defaultLevel)
+      // Display level derives from the SAME source of truth as ELK node placement:
+      // group.isCollapsed reflects buildHierarchicalElkGraph's isGroupEffectivelyCollapsed
+      // decision (an expanded group was laid out with its children). Recomputing a
+      // separate "default" here would let the rendered chip disagree with the laid-out
+      // children — e.g. a manual single collapse rendering untouched groups as chips
+      // while their children are still placed. An explicit level (e.g. cardGrid) wins.
+      const displayLevel: GroupDisplayLevel = groupLevels?.get(group.groupId) || (group.isCollapsed ? 'chip' : 'topology')
 
       // Compute kind breakdown for collapsed chips
       const kindCounts: Record<string, number> = {}

--- a/packages/k8s-ui/src/components/topology/layout.ts
+++ b/packages/k8s-ui/src/components/topology/layout.ts
@@ -245,19 +245,11 @@ async function runLayoutOnMainThread(
 
   // Phase 2: Build meta-graph and position groups based on inter-group edges
   // (nodeToGroup was built once above).
-  const interGroupEdges: ElkEdge[] = []
-  const seen = new Set<string>()
-  for (const edge of elkGraph.edges) {
-    const sg = nodeToGroup.get(edge.sources[0])
-    const tg = nodeToGroup.get(edge.targets[0])
-    if (sg && tg && sg !== tg) {
-      const key = `${sg}->${tg}`
-      if (!seen.has(key)) { seen.add(key); interGroupEdges.push({ id: `inter-${key}`, sources: [sg], targets: [tg] }) }
-    } else if ((!sg && tg) || (sg && !tg)) {
-      const s = sg || edge.sources[0], t = tg || edge.targets[0], key = `${s}->${t}`
-      if (!seen.has(key)) { seen.add(key); interGroupEdges.push({ id: `inter-${key}`, sources: [s], targets: [t] }) }
-    }
-  }
+  const metaIds = new Set<string>([
+    ...groupLayouts.map(g => g.groupId),
+    ...ungroupedNodes.map(n => n.id),
+  ])
+  const interGroupEdges = buildInterGroupEdges(elkGraph.edges, nodeToGroup, metaIds)
 
   const metaResult = await elk.layout({
     id: 'meta-root',
@@ -321,6 +313,36 @@ interface ElkGraph {
   layoutOptions: Record<string, string>
   children: ElkNode[]
   edges: ElkEdge[]
+}
+
+/**
+ * Build the meta-graph edges that position groups relative to each other (Phase 2).
+ * Each endpoint is normalized to its meta node: an expanded group's member maps to
+ * its group (via nodeToGroup); a collapsed-group chip id or an ungrouped node id is
+ * ALREADY a meta node and is used as-is. Edges between two already-meta nodes
+ * (chip↔chip, chip↔ungrouped) must still be included — dropping them loses the
+ * connectivity ELK uses to place connected groups near each other. Endpoints absent
+ * from metaIds are skipped (defensive — keeps the meta graph importable).
+ *
+ * Mirrored inline in layout.worker.ts, which is intentionally self-contained.
+ */
+export function buildInterGroupEdges(
+  edges: ElkEdge[],
+  nodeToGroup: Map<string, string>,
+  metaIds: Set<string>,
+): ElkEdge[] {
+  const out: ElkEdge[] = []
+  const seen = new Set<string>()
+  for (const edge of edges) {
+    const s = nodeToGroup.get(edge.sources[0]) ?? edge.sources[0]
+    const t = nodeToGroup.get(edge.targets[0]) ?? edge.targets[0]
+    if (s === t || !metaIds.has(s) || !metaIds.has(t)) continue
+    const key = `${s}->${t}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push({ id: `inter-${key}`, sources: [s], targets: [t] })
+  }
+  return out
 }
 
 // Get app label from a node (if it has one)

--- a/packages/k8s-ui/src/components/topology/layout.worker.ts
+++ b/packages/k8s-ui/src/components/topology/layout.worker.ts
@@ -198,44 +198,28 @@ self.onmessage = async (e: MessageEvent<LayoutRequest>) => {
     }
 
     // Phase 2: Build meta-graph and position groups (nodeToGroup built once above).
-    // Find inter-group edges
-    const interGroupEdges: ElkEdge[] = []
-    const seenInterGroupEdges = new Set<string>()
-
-    for (const edge of elkGraph.edges) {
-      const sourceGroup = nodeToGroup.get(edge.sources[0])
-      const targetGroup = nodeToGroup.get(edge.targets[0])
-
-      if (sourceGroup && targetGroup && sourceGroup !== targetGroup) {
-        const edgeKey = `${sourceGroup}->${targetGroup}`
-        if (!seenInterGroupEdges.has(edgeKey)) {
-          seenInterGroupEdges.add(edgeKey)
-          interGroupEdges.push({
-            id: `inter-${edgeKey}`,
-            sources: [sourceGroup],
-            targets: [targetGroup],
-          })
-        }
-      } else if ((!sourceGroup && targetGroup) || (sourceGroup && !targetGroup)) {
-        const source = sourceGroup || edge.sources[0]
-        const target = targetGroup || edge.targets[0]
-        const edgeKey = `${source}->${target}`
-        if (!seenInterGroupEdges.has(edgeKey)) {
-          seenInterGroupEdges.add(edgeKey)
-          interGroupEdges.push({
-            id: `inter-${edgeKey}`,
-            sources: [source],
-            targets: [target],
-          })
-        }
-      }
-    }
-
-    // Build and layout meta-graph
+    // Canonical version: buildInterGroupEdges in layout.ts — kept inline here because
+    // the worker is intentionally self-contained. Normalize each endpoint to its meta
+    // node (expanded member → its group; a chip id or ungrouped id is already a meta
+    // node) and keep edges between two already-meta nodes (chip↔chip, chip↔ungrouped),
+    // which the old branching dropped — losing the connectivity used to place groups.
     const metaChildren: ElkNode[] = [
       ...groupLayouts.map(g => ({ id: g.groupId, width: g.width, height: g.height })),
       ...ungroupedNodes.map(n => ({ id: n.id, width: n.width, height: n.height })),
     ]
+    const metaIds = new Set<string>(metaChildren.map(c => c.id))
+
+    const interGroupEdges: ElkEdge[] = []
+    const seenInterGroupEdges = new Set<string>()
+    for (const edge of elkGraph.edges) {
+      const source = nodeToGroup.get(edge.sources[0]) ?? edge.sources[0]
+      const target = nodeToGroup.get(edge.targets[0]) ?? edge.targets[0]
+      if (source === target || !metaIds.has(source) || !metaIds.has(target)) continue
+      const edgeKey = `${source}->${target}`
+      if (seenInterGroupEdges.has(edgeKey)) continue
+      seenInterGroupEdges.add(edgeKey)
+      interGroupEdges.push({ id: `inter-${edgeKey}`, sources: [source], targets: [target] })
+    }
 
     const metaGraph: ElkGraph = {
       id: 'meta-root',


### PR DESCRIPTION
## Summary

The topology graph could blank out with *"Layout Error — Referenced shape does not exist: …"* (notably when switching Resources↔Traffic on a large cluster), and in related states could silently drop cross-namespace edges, render a collapsed chip on top of its own expanded children, or cascade-collapse untouched groups. Root cause: **multiple code paths each decided independently whether a group was collapsed, and they disagreed.** This PR funnels all of them through one predicate so node placement, edge routing, group rendering, and group positioning always agree.

## Root cause

A namespace group is shown either expanded (members laid out inside it) or as a single collapsed chip. Four places decided "is this group collapsed?" and had drifted:

1. ELK **node placement** (`buildHierarchicalElkGraph`) — hid members when a group had no explicit `'topology'` level.
2. ELK **edge redirect** — only rerouted edges for groups explicitly in `collapsedGroups`.
3. ReactFlow **`buildEdges`** — same narrow check as (2).
4. **`applyHierarchicalLayout`** — recomputed a separate `displayLevel` default for the rendered group node.

When they disagreed, an edge could point at a member hidden inside a chip: ELK rejects the whole graph (the crash), ReactFlow silently drops the edge, or the chip renders over laid-out children. A namespace that appears after the smart-default chip pass (e.g. surfaced by a view switch, like `skyhook-gateway`) hit (1) vs (2)/(3) directly.

Separately, because the predicate keyed off "any level entry exists," collapsing **one** group on a small cluster cascade-collapsed every untouched group. And the Phase-2 meta layout dropped edges between two collapsed chips, so connected chips weren't positioned together.

## What changed

- **One predicate, `isGroupEffectivelyCollapsed`** (exported from `layout.ts`), consumed by node placement, ELK edge redirect, and ReactFlow `buildEdges`.
- **Smart-default-aware:** a group with no level entry defaults to collapsed *only* when the large-cluster smart-default chip pass is active (`smartDefaultActive = hasAppliedSmartDefault && groupingMode === 'namespace'`). On small clusters / manual toggles, an untouched group stays expanded — collapsing one group no longer cascades.
- **Rendered `displayLevel` derives from `group.isCollapsed`** (the layout engine's output of the same predicate) rather than recomputing it, so chip/expanded rendering can't disagree with what was laid out.
- **`buildInterGroupEdges`** normalizes each Phase-2 endpoint to its meta node and keeps edges between two already-meta nodes (chip↔chip, chip↔ungrouped), which were previously dropped — so ELK positions connected chips near each other. Mirrored inline in the layout worker.
- **Orphan-edge guard** in `buildHierarchicalElkGraph` drops any edge whose endpoint isn't a real shape — insurance so this class degrades to a missing edge, never a blanked graph.

Reviewer focus: `isGroupEffectivelyCollapsed` / `buildInterGroupEdges` and the call sites that consume them — they must stay on the one predicate.

## Testing

- `make tsc` — clean
- `npx vitest run` (k8s-ui) — 663 pass
- New `layout-elk-graph.test.ts` covers: late-arriving collapse redirect (no dangling endpoint), no-cascade on manual collapse, render-layer `displayLevel` via `applyHierarchicalLayout`, and meta-edge connectivity (chip↔chip / chip↔ungrouped / normalization / intra+ghost drop / dedupe). The crash and `displayLevel` regressions were verified to fail against pre-fix code.
- Visual-test: skipped — the live repro needs a >5-namespace cluster plus late-arriving-namespace timing a capture can't reliably reproduce; invariants are pinned by unit tests instead.