### PR TITLE
fix(drawer): close resource peek on navigation + mutually exclude with WorkloadView

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -410,6 +410,8 @@ function AppInner() {
   // selected drawer resource. This covers both in-view kind switches and
   // cross-kind navigations from expanded drawers (for example Node -> View Pods).
   const prevResourcesKindKeyRef = useRef<string | null>(null)
+  // Pathname a non-URL-backed peek drawer was opened on (see navigateToResource).
+  const peekOwnerPathRef = useRef<string | null>(null)
   const currentResourceKindSlug = normalizedResourcesKindSlug.toLowerCase()
   const currentResourceGroup = searchParams.get('apiGroup') ?? ''
   const selectedResourceKindSlug = selectedResource ? kindToPlural(selectedResource.kind).toLowerCase() : ''
@@ -421,9 +423,27 @@ function AppInner() {
   const resourcesKindRouteChanged = mainView === 'resources' &&
     prevResourcesKindKeyRef.current !== null &&
     prevResourcesKindKeyRef.current !== `${currentResourceGroup}/${currentResourceKindSlug}`
-  const routeSelectedResource = resourcesKindRouteChanged && selectedResourceRouteMismatch
-    ? null
-    : selectedResource
+
+  // A peek opened outside /resources (topology, GitOps, Applications) carries no
+  // URL backing, so the only signal that the page beneath it has navigated is
+  // that the pathname no longer matches where it was opened. Hiding it here, at
+  // render time, closes the orphan on Back without adding another clearing
+  // effect that would race the `suppressViewClearRef` lifecycle. The /resources
+  // case is URL-backed and handled above; an expanded drawer (drawerExpanded)
+  // legitimately lives at /workload and must stay open across that navigation.
+  const peekRouteOrphaned = !!selectedResource && !drawerExpanded && mainView !== 'resources' &&
+    peekOwnerPathRef.current !== null && peekOwnerPathRef.current !== location.pathname
+
+  // In Applications the inline WorkloadView (?workload) and the peek drawer are
+  // mutually exclusive — never two detail surfaces at once. ?workload is the
+  // single source of truth: while it's set the peek yields to the inline view.
+  // (Opening a child peek from Applications clears ?workload, see onOpenResource.)
+  const appsInlineWorkloadActive = mainView === 'applications' && searchParams.has('workload')
+
+  const routeSelectedResource =
+    (resourcesKindRouteChanged && selectedResourceRouteMismatch) || peekRouteOrphaned || appsInlineWorkloadActive
+      ? null
+      : selectedResource
 
   useEffect(() => {
     if (mainView !== 'resources') {
@@ -458,6 +478,12 @@ function AppInner() {
 
   // Navigate to a resource — uses View Transitions cross-fade when drawer is already open
   const navigateToResource = useCallback((res: SelectedResource, tab: 'detail' | 'yaml' = 'detail') => {
+    // Record the route this peek was opened on. Outside /resources the drawer is
+    // not URL-backed, so this ref is what lets the render-time gate below close
+    // the peek when the page under it changes (e.g. browser Back off a GitOps
+    // detail page). window.location is read (not the `location` closure) so the
+    // value is always current regardless of this callback's memoization.
+    peekOwnerPathRef.current = window.location.pathname
     const update = () => { setDrawerInitialTab(tab); setSelectedResource(res) }
     // Skip the cross-fade animation entirely on first open (no
     // `selectedResource`); otherwise route through
@@ -1834,7 +1860,10 @@ function AppInner() {
           <GitOpsView
             namespaces={namespaces}
             onOpenResource={(resource) => {
-              setSelectedResource(resource)
+              // Route through navigateToResource so the peek records the page it
+              // opened on — that's what lets Back off the GitOps detail page close
+              // the drawer instead of orphaning it on the list.
+              navigateToResource(resource)
             }}
             onClearNamespaces={clearAllNamespaces}
           />
@@ -1845,7 +1874,17 @@ function AppInner() {
           <ApplicationsView
             namespaces={namespaces}
             onOpenResource={(resource) => {
-              setSelectedResource(resource)
+              // The peek and the inline WorkloadView are mutually exclusive: drop
+              // the inline workload selection so the app graph (not a second
+              // detail panel) sits behind the peek. Search-only change keeps the
+              // pathname — and thus the peek's owner-path — intact.
+              const params = new URLSearchParams(window.location.search)
+              if (params.has('workload') || params.has('tab')) {
+                params.delete('workload')
+                params.delete('tab')
+                navigate({ pathname: window.location.pathname, search: params.toString() }, { replace: true })
+              }
+              navigateToResource(resource)
             }}
           />
         )}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -171,6 +171,15 @@ function AuthBarrier({ authMode }: { authMode: string }) {
   )
 }
 
+// Identity of the "page" a non-URL-backed peek drawer belongs to. Pathname alone
+// is not enough: Applications keeps the list and an app's detail on the same
+// `/applications` pathname and distinguishes them with `?app=`, so a Back from
+// detail to list would otherwise leave the peek orphaned. Only `app` is included
+// (not the whole query) so filter/tab/namespace churn doesn't close the peek.
+function peekOwnerKey(pathname: string, search: string): string {
+  return `${pathname} ${new URLSearchParams(search).get('app') ?? ''}`
+}
+
 function AppInner() {
   const navigate = useNavigate()
   const location = useLocation()
@@ -410,8 +419,9 @@ function AppInner() {
   // selected drawer resource. This covers both in-view kind switches and
   // cross-kind navigations from expanded drawers (for example Node -> View Pods).
   const prevResourcesKindKeyRef = useRef<string | null>(null)
-  // Pathname a non-URL-backed peek drawer was opened on (see navigateToResource).
-  const peekOwnerPathRef = useRef<string | null>(null)
+  // Owner-key (pathname + ?app) a non-URL-backed peek was opened on; see
+  // navigateToResource and peekOwnerKey.
+  const peekOwnerKeyRef = useRef<string | null>(null)
   const currentResourceKindSlug = normalizedResourcesKindSlug.toLowerCase()
   const currentResourceGroup = searchParams.get('apiGroup') ?? ''
   const selectedResourceKindSlug = selectedResource ? kindToPlural(selectedResource.kind).toLowerCase() : ''
@@ -426,13 +436,14 @@ function AppInner() {
 
   // A peek opened outside /resources (topology, GitOps, Applications) carries no
   // URL backing, so the only signal that the page beneath it has navigated is
-  // that the pathname no longer matches where it was opened. Hiding it here, at
-  // render time, closes the orphan on Back without adding another clearing
-  // effect that would race the `suppressViewClearRef` lifecycle. The /resources
-  // case is URL-backed and handled above; an expanded drawer (drawerExpanded)
-  // legitimately lives at /workload and must stay open across that navigation.
+  // that its owner-key (pathname + ?app) no longer matches where it was opened.
+  // Hiding it here, at render time, closes the orphan on Back without adding
+  // another clearing effect that would race the `suppressViewClearRef` lifecycle.
+  // The /resources case is URL-backed and handled above; an expanded drawer
+  // (drawerExpanded) legitimately lives at /workload and must stay open there.
   const peekRouteOrphaned = !!selectedResource && !drawerExpanded && mainView !== 'resources' &&
-    peekOwnerPathRef.current !== null && peekOwnerPathRef.current !== location.pathname
+    peekOwnerKeyRef.current !== null &&
+    peekOwnerKeyRef.current !== peekOwnerKey(location.pathname, location.search)
 
   // In Applications the inline WorkloadView (?workload) and the peek drawer are
   // mutually exclusive — never two detail surfaces at once. ?workload is the
@@ -478,12 +489,13 @@ function AppInner() {
 
   // Navigate to a resource — uses View Transitions cross-fade when drawer is already open
   const navigateToResource = useCallback((res: SelectedResource, tab: 'detail' | 'yaml' = 'detail') => {
-    // Record the route this peek was opened on. Outside /resources the drawer is
+    // Record the page this peek was opened on. Outside /resources the drawer is
     // not URL-backed, so this ref is what lets the render-time gate below close
     // the peek when the page under it changes (e.g. browser Back off a GitOps
-    // detail page). window.location is read (not the `location` closure) so the
-    // value is always current regardless of this callback's memoization.
-    peekOwnerPathRef.current = window.location.pathname
+    // detail page, or Applications detail → list via ?app). window.location is
+    // read (not the `location` closure) so the value is always current
+    // regardless of this callback's memoization.
+    peekOwnerKeyRef.current = peekOwnerKey(window.location.pathname, window.location.search)
     const update = () => { setDrawerInitialTab(tab); setSelectedResource(res) }
     // Skip the cross-fade animation entirely on first open (no
     // `selectedResource`); otherwise route through


### PR DESCRIPTION
## Summary

The resource-detail **peek drawer** had two ways to become confusing, both reported with screenshots:

1. **Orphan on Back** — open a peek from a GitOps *detail* page → browser Back lands on the GitOps *list* with the drawer still open, now stale.
2. **Two detail surfaces at once** — in Applications, clicking a child resource opened the peek drawer *on top of* the inline `WorkloadView`, so the same screen showed two near-identical workload panels (mutually stale).

Both are the same root cause. Outside `/resources` the peek is plain `selectedResource` React state with **no URL backing**, and the only thing that closed it was a `mainView` *transition*. GitOps detail and list share `mainView==='gitops'` (no transition on Back), and Applications renders its own inline `WorkloadView` independently — so both slipped past the existing clear.

## What changed

Two **render-time gates** on `routeSelectedResource` (the value the drawer renders from). Deliberately *not* a new clearing `useEffect` — the surrounding nav code has explicit guards against URL↔state oscillation (the React-#185 blank-page crashes), and another effect would race the single-consumer `suppressViewClearRef`. Deriving visibility at render sidesteps that entirely.

- **Close on navigation.** A peek opened outside `/resources` records the pathname it was opened on (`navigateToResource`). When the current pathname no longer matches it, the peek is hidden — so Back off a detail page closes it. An **expanded** drawer (`drawerExpanded`, living at `/workload`) is explicitly exempt, so expand→collapse is untouched.
- **Mutual exclusion in Applications.** `?workload` (the inline `WorkloadView`) is the single source of truth: while it's set the peek yields, and opening a child peek clears `?workload` so the app *graph* — not a second panel — sits behind the peek. Never two detail surfaces.

GitOps and Applications resource-opens now route through `navigateToResource` so the owner-path is recorded consistently (previously bare `setSelectedResource`).

This is the **pragmatic** scope agreed in planning: the peek model stays where it works (Topology / Resources / GitOps tree / Issues); only the genuinely confusing collisions are fixed. Full URL-canonicalisation of the drawer everywhere (one URL-driven detail slot) is a deeper URL-schema redesign and is intentionally **deferred**.

## Testing

`tsc --noEmit` clean. Visual-tested end-to-end with Playwright against a live cluster (nonprod-cluster-us-east1):

- ✅ GitOps detail → open peek → **Back** → lands on list, **no orphaned drawer**.
- ✅ Applications → inline workload → click child → inline view collapses to graph + child peek opens (**one surface**); and selecting a workload while a peek is open hides the peek (mutual exclusion **both directions**).
- ✅ Peek → **expand** to `/workload` renders a single full view; `/resources` URL-backed peek still opens.
- ✅ No console errors / no React-#185 crash across the run.

Cross-reviewed in planning (Codex) — the render-time-gate approach was chosen specifically over a pathname `useEffect` on its advice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches central navigation and drawer visibility in `App.tsx`, where URL/state sync already has fragile guards; behavior is localized to non-`/resources` peeks and Applications query params.
> 
> **Overview**
> Fixes two UX bugs where the non-URL-backed resource **peek drawer** stayed visible after the page underneath changed, or overlapped Applications’ inline workload detail.
> 
> **Peek closes on navigation (outside `/resources`).** Opening a peek now records an owner key (`pathname` + `?app` only). `routeSelectedResource` is forced to `null` at render when that key no longer matches—e.g. browser Back from GitOps detail to list—without a new pathname `useEffect`. Expanded drawers at `/workload` are exempt.
> 
> **Applications: one detail surface.** While `?workload` is set, the peek is hidden; opening a child resource clears `workload`/`tab` from the URL and opens the peek via `navigateToResource`. GitOps and Applications `onOpenResource` handlers use `navigateToResource` instead of bare `setSelectedResource` so the owner key is always recorded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12b2c53c8c3100a3aefdeb4bb1589c7de02498e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->