### PR TITLE
perf(server): gzip-compress HTTP responses (klauspost, env-tunable)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/go-containerregistry v0.21.7
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/hashicorp/yamux v0.1.2
+	github.com/klauspost/compress v1.18.6
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.69.0
@@ -101,7 +102,6 @@ require (
 	github.com/jchv/go-winloader v0.0.0-20210711035445-715c2860da7e // indirect
 	github.com/jmoiron/sqlx v1.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/labstack/echo/v4 v4.13.3 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect

--- a/internal/server/compress.go
+++ b/internal/server/compress.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/go-chi/chi/v5/middleware"
 	kgzip "github.com/klauspost/compress/gzip"
@@ -61,5 +62,40 @@ func compressMiddleware() func(http.Handler) http.Handler {
 		gw, _ := kgzip.NewWriterLevel(w, lvl)
 		return gw
 	})
-	return c.Handler
+	compress := c.Handler
+	return func(next http.Handler) http.Handler {
+		compressed := compress(next)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Skip the compressor for streaming + upgrade requests. chi acquires
+			// a pooled gzip encoder per request *before* the handler sets its
+			// Content-Type, releasing it only when the handler returns — so a
+			// long-lived SSE (EventSource sends Accept-Encoding: gzip) or pod-exec
+			// WebSocket would pin an unused encoder for the whole stream. These
+			// responses aren't compressible anyway; bypass before any encoder is
+			// taken from the pool.
+			if isStreamingRequest(r) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			compressed.ServeHTTP(w, r)
+		})
+	}
+}
+
+// isStreamingRequest reports requests that open a long-lived response (SSE) or
+// switch protocols (WebSocket exec/terminal) and must not pass through the
+// compressor's per-request encoder acquisition.
+func isStreamingRequest(r *http.Request) bool {
+	if strings.Contains(strings.ToLower(r.Header.Get("Accept")), "text/event-stream") {
+		return true
+	}
+	if r.Header.Get("Upgrade") != "" {
+		return true
+	}
+	for _, v := range strings.Split(strings.ToLower(r.Header.Get("Connection")), ",") {
+		if strings.TrimSpace(v) == "upgrade" {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/server/compress.go
+++ b/internal/server/compress.go
@@ -86,6 +86,13 @@ func compressMiddleware() func(http.Handler) http.Handler {
 // switch protocols (WebSocket exec/terminal) and must not pass through the
 // compressor's per-request encoder acquisition.
 func isStreamingRequest(r *http.Request) bool {
+	// Match by route, not just request headers: every SSE endpoint ends in
+	// "/stream" (events, pod/workload logs, traffic flows). This holds even if a
+	// future consumer reads the stream via fetch (Accept: */*) instead of
+	// EventSource, which the header check below would miss.
+	if strings.HasSuffix(r.URL.Path, "/stream") {
+		return true
+	}
 	if strings.Contains(strings.ToLower(r.Header.Get("Accept")), "text/event-stream") {
 		return true
 	}

--- a/internal/server/compress.go
+++ b/internal/server/compress.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/go-chi/chi/v5/middleware"
+	kgzip "github.com/klauspost/compress/gzip"
+)
+
+// defaultCompressLevel is the gzip level used when RADAR_COMPRESS_LEVEL is unset.
+//
+// Level 1 (BestSpeed) is deliberate: on large clusters Radar's informer +
+// topology processing already runs CPU-hot, and that's exactly where response
+// bodies are largest, so peak compression cost coincides with peak baseline
+// load. gzip-1 on k8s JSON still yields ~90%+ size reduction at the highest
+// throughput — the marginal bytes from higher levels aren't worth contending
+// with the watch loop. Operators on bandwidth-bound / CPU-rich deployments can
+// raise it (or disable with 0) via RADAR_COMPRESS_LEVEL.
+const defaultCompressLevel = 1
+
+// resolveCompressLevel parses RADAR_COMPRESS_LEVEL: empty → default, 0 →
+// disabled, 1-9 → gzip level, anything else → default (logged).
+func resolveCompressLevel(raw string) int {
+	if raw == "" {
+		return defaultCompressLevel
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 || n > 9 {
+		log.Printf("[compress] invalid RADAR_COMPRESS_LEVEL %q; using default %d", raw, defaultCompressLevel)
+		return defaultCompressLevel
+	}
+	return n
+}
+
+// compressMiddleware returns a gzip response-compression middleware, or nil when
+// compression is disabled (RADAR_COMPRESS_LEVEL=0).
+//
+// k8s JSON (topology, resource lists, RBAC, audit) compresses 5-10x and today
+// travels raw over the network — costly over the Radar Cloud tunnel's high-RTT
+// hop. Compressing at the source means the bytes are small across both the
+// tunnel and the browser hop, with the hub passing them through untouched and
+// the browser decompressing transparently.
+//
+// gzip is overridden to use klauspost/compress, which is faster AND compresses
+// slightly better than stdlib at the same level (it's already a transitive dep).
+// chi's default content-type allowlist includes application/json but excludes
+// text/event-stream, so SSE streams are never compressed (flush semantics
+// intact), and chi forwards Hijack/Flush so pod-exec WebSocket upgrades are
+// unaffected. Applied uniformly in local and cloud mode.
+func compressMiddleware() func(http.Handler) http.Handler {
+	level := resolveCompressLevel(os.Getenv("RADAR_COMPRESS_LEVEL"))
+	if level == 0 {
+		return nil
+	}
+	c := middleware.NewCompressor(level)
+	c.SetEncoder("gzip", func(w io.Writer, lvl int) io.Writer {
+		gw, _ := kgzip.NewWriterLevel(w, lvl)
+		return gw
+	})
+	return c.Handler
+}

--- a/internal/server/compress_test.go
+++ b/internal/server/compress_test.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestResolveCompressLevel(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want int
+	}{
+		{"", defaultCompressLevel},
+		{"0", 0},
+		{"1", 1},
+		{"9", 9},
+		{"5", 5},
+		{"10", defaultCompressLevel},   // out of range
+		{"-1", defaultCompressLevel},   // negative
+		{"fast", defaultCompressLevel}, // non-numeric
+	}
+	for _, tc := range cases {
+		if got := resolveCompressLevel(tc.raw); got != tc.want {
+			t.Errorf("resolveCompressLevel(%q) = %d, want %d", tc.raw, got, tc.want)
+		}
+	}
+}
+
+func TestCompressMiddleware(t *testing.T) {
+	t.Setenv("RADAR_COMPRESS_LEVEL", "1")
+	cm := compressMiddleware()
+	if cm == nil {
+		t.Fatal("expected middleware at level 1, got nil")
+	}
+
+	r := chi.NewRouter()
+	r.Use(cm)
+	big := strings.Repeat(`{"k":"vvvvvvvvvv"},`, 500)
+	r.Get("/json", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, "["+big+`{"k":"v"}]`)
+	})
+	r.Get("/sse", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: "+big+"\n\n")
+	})
+
+	// JSON path: compressed and round-trips.
+	t.Run("json is gzipped", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/json", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		if got := rec.Header().Get("Content-Encoding"); got != "gzip" {
+			t.Fatalf("Content-Encoding = %q, want gzip", got)
+		}
+		zr, err := gzip.NewReader(rec.Body)
+		if err != nil {
+			t.Fatalf("gzip.NewReader: %v", err)
+		}
+		out, err := io.ReadAll(zr)
+		if err != nil {
+			t.Fatalf("decompress: %v", err)
+		}
+		if !strings.HasPrefix(string(out), "[") {
+			t.Fatalf("decompressed body unexpected: %.20q", out)
+		}
+	})
+
+	// SSE path: never compressed (text/event-stream excluded), flush intact.
+	t.Run("sse is not gzipped", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/sse", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		if got := rec.Header().Get("Content-Encoding"); got != "" {
+			t.Fatalf("SSE Content-Encoding = %q, want empty", got)
+		}
+		if !strings.HasPrefix(rec.Body.String(), "data: ") {
+			t.Fatalf("SSE body should be plaintext, got %.20q", rec.Body.String())
+		}
+	})
+}
+
+func TestCompressMiddlewareDisabled(t *testing.T) {
+	t.Setenv("RADAR_COMPRESS_LEVEL", "0")
+	if cm := compressMiddleware(); cm != nil {
+		t.Fatal("expected nil middleware when RADAR_COMPRESS_LEVEL=0")
+	}
+}

--- a/internal/server/compress_test.go
+++ b/internal/server/compress_test.go
@@ -96,8 +96,11 @@ func TestCompressMiddlewareDisabled(t *testing.T) {
 }
 
 func TestIsStreamingRequest(t *testing.T) {
-	mk := func(h map[string]string) *http.Request {
-		r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	mk := func(path string, h map[string]string) *http.Request {
+		if path == "" {
+			path = "/x"
+		}
+		r := httptest.NewRequest(http.MethodGet, path, nil)
 		for k, v := range h {
 			r.Header.Set(k, v)
 		}
@@ -105,20 +108,22 @@ func TestIsStreamingRequest(t *testing.T) {
 	}
 	cases := []struct {
 		name string
+		path string
 		hdr  map[string]string
 		want bool
 	}{
-		{"plain json", map[string]string{"Accept": "application/json"}, false},
-		{"sse", map[string]string{"Accept": "text/event-stream"}, true},
-		{"mcp dual accept", map[string]string{"Accept": "application/json, text/event-stream"}, true},
-		{"websocket upgrade", map[string]string{"Upgrade": "websocket", "Connection": "Upgrade"}, true},
-		{"connection upgrade only", map[string]string{"Connection": "keep-alive, Upgrade"}, true},
-		{"no headers", map[string]string{}, false},
+		{"plain json", "/api/resources", map[string]string{"Accept": "application/json"}, false},
+		{"sse", "/api/events/stream", map[string]string{"Accept": "text/event-stream"}, true},
+		{"stream route with */* accept", "/api/pods/n/p/logs/stream", map[string]string{"Accept": "*/*"}, true}, // path-based
+		{"mcp dual accept", "/mcp", map[string]string{"Accept": "application/json, text/event-stream"}, true},
+		{"websocket upgrade", "/api/pods/n/p/exec", map[string]string{"Upgrade": "websocket", "Connection": "Upgrade"}, true},
+		{"connection upgrade only", "/api/local-terminal", map[string]string{"Connection": "keep-alive, Upgrade"}, true},
+		{"no headers plain route", "/api/resources", map[string]string{}, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := isStreamingRequest(mk(tc.hdr)); got != tc.want {
-				t.Errorf("isStreamingRequest(%v) = %v, want %v", tc.hdr, got, tc.want)
+			if got := isStreamingRequest(mk(tc.path, tc.hdr)); got != tc.want {
+				t.Errorf("isStreamingRequest(%s, %v) = %v, want %v", tc.path, tc.hdr, got, tc.want)
 			}
 		})
 	}

--- a/internal/server/compress_test.go
+++ b/internal/server/compress_test.go
@@ -94,3 +94,32 @@ func TestCompressMiddlewareDisabled(t *testing.T) {
 		t.Fatal("expected nil middleware when RADAR_COMPRESS_LEVEL=0")
 	}
 }
+
+func TestIsStreamingRequest(t *testing.T) {
+	mk := func(h map[string]string) *http.Request {
+		r := httptest.NewRequest(http.MethodGet, "/x", nil)
+		for k, v := range h {
+			r.Header.Set(k, v)
+		}
+		return r
+	}
+	cases := []struct {
+		name string
+		hdr  map[string]string
+		want bool
+	}{
+		{"plain json", map[string]string{"Accept": "application/json"}, false},
+		{"sse", map[string]string{"Accept": "text/event-stream"}, true},
+		{"mcp dual accept", map[string]string{"Accept": "application/json, text/event-stream"}, true},
+		{"websocket upgrade", map[string]string{"Upgrade": "websocket", "Connection": "Upgrade"}, true},
+		{"connection upgrade only", map[string]string{"Connection": "keep-alive, Upgrade"}, true},
+		{"no headers", map[string]string{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isStreamingRequest(mk(tc.hdr)); got != tc.want {
+				t.Errorf("isStreamingRequest(%v) = %v, want %v", tc.hdr, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -196,6 +196,12 @@ func (s *Server) setupRoutes() {
 	r.Use(middleware.Recoverer)
 	// Note: Timeout middleware is applied per-group below to exempt streaming endpoints
 
+	// gzip response compression (content-type aware: JSON yes, SSE/WS no).
+	// nil when RADAR_COMPRESS_LEVEL=0. See compress.go.
+	if cm := compressMiddleware(); cm != nil {
+		r.Use(cm)
+	}
+
 	// CORS for development
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   []string{"http://localhost:*", "http://127.0.0.1:*"},


### PR DESCRIPTION
**Fix #4 of the Radar Cloud perf series** (Radar side). Pairs with skyhook-dev/radar-hub#78.

## Why
k8s JSON (topology, resource lists, RBAC, audit) compresses 5-10x but travels **raw** today — slow over the Radar Cloud tunnel's high-RTT hop. Compressing at the source means small bytes across **both** the tunnel and the browser hop; the hub passes them through untouched and the browser decompresses transparently.

## What changed
- New `compress.go`: chi response-compression middleware wired globally in `server.go` (after Recoverer).
- gzip overridden to use **klauspost/compress** — faster *and* better ratio than stdlib at the same level, and already a transitive dep (now promoted to direct).
- **Content-type aware** (chi default allowlist): `application/json` compressed, `text/event-stream` **excluded** → SSE streams never compressed (flush intact); chi forwards `Hijack`/`Flush` so pod-exec WebSocket upgrades are unaffected. Binary file downloads (octet-stream) aren't in the allowlist. Same in local and cloud mode.

## Why level 1 (default)
On large clusters the informer/topology loop already runs CPU-hot, and that's exactly where response bodies are largest — peak gzip cost coincides with peak load. Benchmarked on a 2.4 MB pod list: klauspost L1 = **~14x reduction at the highest throughput**, strictly better than stdlib L1 on both axes; higher levels buy ~20% smaller for materially more CPU. Tunable via `RADAR_COMPRESS_LEVEL` (0=off, 1-9).

## Backward compatibility
Output is standard gzip; browsers always send `Accept-Encoding` and decompress transparently. The hub passes compressed bytes through — see the companion hub PR, which makes the hub's body-parsing intercepts gzip-aware and **must deploy first**.

## Testing
`go build` + `go vet` + `go test ./internal/server/` green, incl. new `compress_test.go` (level resolver; JSON gzipped + round-trips; SSE not compressed; disabled at level 0).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all API response paths and streaming bypass logic; misclassification could break SSE or exec, and hub must handle gzip before this deploys in Cloud.
> 
> **Overview**
> Adds **global gzip response compression** on the HTTP server (after logger/recoverer) so large Kubernetes JSON payloads shrink before they cross the Radar Cloud tunnel and the browser.
> 
> New `compress.go` wires chi’s compressor with **klauspost/compress** (promoted to a direct `go.mod` dependency), defaulting to **gzip level 1** via `RADAR_COMPRESS_LEVEL` (unset → 1, `0` → off, `1–9` → level). JSON responses are compressed per chi’s content-type allowlist; **SSE and WebSocket/exec paths are explicitly bypassed** so long-lived streams don’t pin pooled encoders and flush/upgrade semantics stay intact (`isStreamingRequest` matches `*/stream`, `text/event-stream`, and upgrade headers).
> 
> `compress_test.go` covers level parsing, JSON gzip round-trip, SSE passthrough, disable-at-zero, and streaming detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b8d3ac49d6d685d67087c30c2fba4f48fbb124c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->