### PR TITLE
fix(topology): disambiguate config-flow from observed Live Traffic

### DIFF
--- a/packages/k8s-ui/src/components/topology/TopologyControls.tsx
+++ b/packages/k8s-ui/src/components/topology/TopologyControls.tsx
@@ -1,5 +1,6 @@
 import { FolderTree, ShieldCheck } from 'lucide-react'
 import type { TopologyMode, GroupingMode } from '../../types/core'
+import { Tooltip } from '../ui/Tooltip'
 
 interface TopologyControlsProps {
   viewMode: TopologyMode
@@ -11,6 +12,12 @@ interface TopologyControlsProps {
   onShowPolicyEffectChange?: (show: boolean) => void
   /** Show the "Fleet" button (CAPI cluster management view) */
   showFleetMode?: boolean
+  /**
+   * Navigate to the observed-traffic view. When provided, the "Network Flow"
+   * tooltip offers a link to it — disambiguating the config-derived flow graph
+   * here from the live, observed Traffic view. Omitted by hosts without one.
+   */
+  onNavigateToTraffic?: () => void
 }
 
 export function TopologyControls({
@@ -22,6 +29,7 @@ export function TopologyControls({
   showPolicyEffect = false,
   onShowPolicyEffectChange,
   showFleetMode = false,
+  onNavigateToTraffic,
 }: TopologyControlsProps) {
   return (
     <div className="absolute top-4 right-4 z-10 flex items-center gap-2">
@@ -69,16 +77,40 @@ export function TopologyControls({
         >
           Resources
         </button>
-        <button
-          onClick={() => onViewModeChange('traffic')}
-          className={`px-2.5 py-1 text-xs rounded-md transition-colors ${
-            viewMode === 'traffic'
-              ? 'bg-skyhook-600 text-white'
-              : 'text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated'
-          }`}
+        <Tooltip
+          position="bottom"
+          content={
+            <div className="space-y-1.5 text-left">
+              <p className="text-theme-text-secondary">
+                How requests <em>should</em> route, derived from Ingress, Services and
+                routing CRDs (Traefik, Gateway API, Istio…) — not observed packets.
+              </p>
+              {onNavigateToTraffic && (
+                <p className="text-theme-text-tertiary">
+                  Looking for observed, measured traffic?{' '}
+                  <button
+                    type="button"
+                    onClick={onNavigateToTraffic}
+                    className="text-skyhook-400 hover:text-skyhook-300 underline underline-offset-2"
+                  >
+                    Open Live Traffic →
+                  </button>
+                </p>
+              )}
+            </div>
+          }
         >
-          Traffic
-        </button>
+          <button
+            onClick={() => onViewModeChange('traffic')}
+            className={`px-2.5 py-1 text-xs rounded-md transition-colors whitespace-nowrap ${
+              viewMode === 'traffic'
+                ? 'bg-skyhook-600 text-white'
+                : 'text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated'
+            }`}
+          >
+            Network Flow <span className="opacity-70">(config)</span>
+          </button>
+        </Tooltip>
         {showFleetMode && (
           <button
             onClick={() => onViewModeChange('fleet')}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1410,7 +1410,7 @@ function AppInner() {
             // the bar is full, and the view's primary home is Cloud's fleet
             // rail. The view still exists and is reachable via /applications
             // and the view-switching shortcuts. Same treatment as Cost below.
-            { view: 'traffic' as const, icon: Activity, label: 'Traffic' },
+            { view: 'traffic' as const, icon: Activity, label: 'Live Traffic' },
             // Cost is intentionally hidden from the pill bar for now — the view still
             // exists and is reachable via /cost, the Home dashboard card, and the
             // command palette (⌘K). Remove this comment to restore it.
@@ -1793,7 +1793,7 @@ function AppInner() {
                   <TopologySearch
                     nodes={filteredTopology?.nodes ?? []}
                     allNodes={topology?.nodes}
-                    viewModeLabel={topologyMode === 'fleet' ? 'Fleet' : topologyMode === 'traffic' ? 'Traffic' : 'Resources'}
+                    viewModeLabel={topologyMode === 'fleet' ? 'Fleet' : topologyMode === 'traffic' ? 'Network Flow' : 'Resources'}
                     onNodeSelect={handleNodeClick}
                     onZoomToNode={(id) => setTopologyFocus((prev) => ({ id, nonce: (prev?.nonce ?? 0) + 1 }))}
                     // Stack below the namespace breadcrumb (shown only for a single
@@ -1815,6 +1815,7 @@ function AppInner() {
                     showPolicyEffect={showPolicyEffect}
                     onShowPolicyEffectChange={setShowPolicyEffect}
                     showFleetMode={displayedTopology?.nodes?.some(n => FLEET_MODE_KINDS.has(n.kind as NodeKind)) ?? false}
+                    onNavigateToTraffic={() => setMainView('traffic')}
                   />
                 </div>
               </>

--- a/web/src/components/home/TrafficSummary.tsx
+++ b/web/src/components/home/TrafficSummary.tsx
@@ -100,7 +100,7 @@ export function TrafficSummary({ data, onNavigate }: TrafficSummaryProps) {
       <div className="flex items-center justify-between px-5 py-3 border-b border-theme-border/50">
         <div className="flex items-center gap-2">
           <Activity className="w-4 h-4 text-theme-text-tertiary" />
-          <span className="text-xs font-semibold uppercase tracking-wider text-theme-text-secondary">Traffic</span>
+          <span className="text-xs font-semibold uppercase tracking-wider text-theme-text-secondary">Live Traffic</span>
         </div>
         {hasFlows && (
           <span className="text-[11px] text-theme-text-tertiary">
@@ -145,7 +145,7 @@ export function TrafficSummary({ data, onNavigate }: TrafficSummaryProps) {
       </div>
 
       <div className="px-4 py-1.5 border-t border-theme-border/50 flex items-center justify-end gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-theme-text-secondary group-hover:text-theme-text-primary transition-colors">
-        Open Traffic
+        Open Live Traffic
         <ArrowRight className="w-3.5 h-3.5 transition-transform group-hover:translate-x-0.5" />
       </div>
       </div>

--- a/web/src/components/nav/PrimaryNavRail.tsx
+++ b/web/src/components/nav/PrimaryNavRail.tsx
@@ -45,7 +45,7 @@ const NAV_ITEMS: NavItemDef[] = [
   { view: 'topology', icon: Network, label: 'Topology' },
   { view: 'applications', icon: Boxes, label: 'Applications' },
   { view: 'timeline', icon: Clock, label: 'Timeline' },
-  { view: 'traffic', icon: Activity, label: 'Traffic' },
+  { view: 'traffic', icon: Activity, label: 'Live Traffic' },
   { view: 'helm', icon: Package, label: 'Helm' },
   { view: 'gitops', icon: GitBranch, label: 'GitOps' },
   { view: 'checks', icon: ShieldCheck, label: 'Checks' },

--- a/web/src/components/ui/ShortcutHelpOverlay.tsx
+++ b/web/src/components/ui/ShortcutHelpOverlay.tsx
@@ -29,7 +29,7 @@ const VIEW_LABELS: Record<string, string> = {
   timeline: 'Timeline',
   helm: 'Helm',
   gitops: 'GitOps',
-  traffic: 'Traffic',
+  traffic: 'Live Traffic',
 }
 
 type ShortcutEntry = { description: string; keys: string[] }

--- a/web/src/components/ui/command-items.ts
+++ b/web/src/components/ui/command-items.ts
@@ -91,7 +91,7 @@ const VIEW_ENTRIES: { view: MainView; label: string; icon: React.ComponentType<{
   { view: 'timeline', label: 'Timeline', icon: Clock, shortcut: 'g l' },
   { view: 'helm', label: 'Helm', icon: Package, shortcut: 'g m' },
   { view: 'gitops', label: 'GitOps', icon: GitBranch, shortcut: 'g o' },
-  { view: 'traffic', label: 'Traffic', icon: Activity, shortcut: 'g f' },
+  { view: 'traffic', label: 'Live Traffic', icon: Activity, shortcut: 'g f' },
   { view: 'checks', label: 'Checks', icon: ShieldCheck, shortcut: 'g u' },
   { view: 'cost', label: 'Cost', icon: DollarSign, shortcut: 'g c' },
 ]


### PR DESCRIPTION
## Summary

Radar surfaced two different things under the word **"Traffic"**, and operators conflated them. The **Topology** view has an in-graph toggle whose "Traffic" mode renders a *config-derived* routing graph (Internet → IngressRoute → Service → Pods, built from manifests). A *separate* top-level nav view — also called "Traffic" — shows the *observed* network flows (eBPF/Cilium/Hubble). A user went to Topology expecting live network traffic and got the declarative graph instead.

This PR removes the naming collision so the two views read as opposite ends of one axis: **declared vs. observed**.

## What changed

**Topology toggle → "Network Flow (config)"** (`TopologyControls.tsx`)
- The view-mode toggle now reads `Resources | Network Flow (config) | Fleet`.
- The relabeled button carries an interactive tooltip explaining it's derived from Ingress, Services, and routing CRDs (Traefik, Gateway API, Istio…) — *not observed packets* — with a cross-link **"Open Live Traffic →"**.
- The cross-link is gated behind a new optional `onNavigateToTraffic?` prop. `@skyhook-io/k8s-ui` is consumed by Radar Hub; hosts that don't pass it simply get the explanation text with no link, so the shared-package surface stays backward-compatible.

**Observed-flows view → "Live Traffic"** (everywhere it surfaces)
- Nav rail (`PrimaryNavRail.tsx`), pill nav (`App.tsx`), command palette `g f` (`command-items.ts`), keyboard-shortcut overlay (`ShortcutHelpOverlay.tsx`), and the Home dashboard summary card header + CTA (`TrafficSummary.tsx`).
- The route (`/traffic`) and the internal `'traffic'` view id are **unchanged** — this is label/copy only, no behavioral or URL change.

The name "Live Traffic" was chosen over the industry-standard "Service Map" (Hubble/Dynatrace) / "Network Map" (Datadog) deliberately: those nouns lose the live/observed signal and "Network Map" would re-collide with "Network **Flow** (config)". "Live" vs "(config)" is the exact distinction being drawn, and it matches Radar's plain-language nav voice.

## Context: Traefik support

This started as a "Traefik isn't supported properly" report. Investigation found the Traefik topology integration is actually thorough (all 10 CRD kinds, both view modes, edges, renderers, icons, filters) — the real issue was this Topology-vs-Traffic confusion, not a Traefik gap. No Traefik code changed.

## Testing

- `make tsc` — clean.
- Visual-tested against a live cluster: confirmed the toggle label renders in the segmented control, the tooltip displays the explanation + link, **"Open Live Traffic →" navigates to `/traffic`**, and "Live Traffic" fits cleanly in the nav rail and the Home dashboard card header.

## Follow-ups

None required. The shared-package change is additive (one optional prop).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Label and tooltip-only UX changes plus an optional prop on shared `TopologyControls`; no routing, auth, or data-path changes.
> 
> **Overview**
> **Topology** no longer calls its config-derived routing mode “Traffic.” The view toggle is **Network Flow (config)** with a tooltip that explains manifest-based routing (Ingress, Services, routing CRDs) versus observed packets. Hosts can pass optional `onNavigateToTraffic` so the tooltip includes **Open Live Traffic →**; Radar wires that to the top-level traffic view.
> 
> The **observed flows** experience is renamed to **Live Traffic** everywhere users see it (nav rail, pill bar, command palette `g f`, shortcut help, home dashboard card). Internal view id `traffic` and `/traffic` are unchanged—copy only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dc850eab474a4a7c32b4109c4d1e585479b1091. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->