### PR TITLE
feat(helm): track upgrades for your own OCI-published charts

### DIFF
--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -1278,6 +1278,106 @@ func (c *Client) applyOCIUpgrade(info *UpgradeInfo, chartName, currentVersion st
 	return true
 }
 
+// AvailableVersions is AvailableVersionsAsUser without impersonation.
+func (c *Client) AvailableVersions(namespace, name string) ([]string, error) {
+	return c.availableVersions(namespace, name, "", nil)
+}
+
+// AvailableVersionsAsUser returns the newest-first list of chart versions a
+// release could be upgraded (or downgraded) to, resolved from its source — the
+// matching classic repo's index or, failing that, a registered OCI source. Lets
+// the upgrade dialog offer a specific target version instead of only "latest".
+// Returns an empty list (not an error) when the source can't be determined; the
+// dialog then falls back to latest-only.
+func (c *Client) AvailableVersionsAsUser(namespace, name, username string, groups []string) ([]string, error) {
+	return c.availableVersions(namespace, name, username, groups)
+}
+
+func (c *Client) availableVersions(namespace, name, username string, groups []string) ([]string, error) {
+	var actionConfig *action.Configuration
+	var err error
+	if username != "" {
+		actionConfig, err = c.getActionConfigForUser(namespace, username, groups)
+	} else {
+		actionConfig, err = c.getActionConfig(namespace)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	rel, err := action.NewGet(actionConfig).Run(name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get release: %w", err)
+	}
+	chartName := rel.Chart.Metadata.Name
+
+	// Resolve the classic repo the same way the upgrade check does, then return
+	// that repo's full version list — never a union across repos, which could mix
+	// an unrelated same-named chart's versions.
+	var candidates []repoVersionInfo
+	versionsByRepo := map[string][]string{}
+	if f, err := repo.LoadFile(c.settings.RepositoryConfig); err == nil {
+		cacheDir := c.settings.RepositoryCache
+		for _, r := range f.Repositories {
+			idx, err := repo.LoadIndexFile(filepath.Join(cacheDir, fmt.Sprintf("%s-index.yaml", r.Name)))
+			if err != nil {
+				continue
+			}
+			entries, ok := idx.Entries[chartName]
+			if !ok {
+				continue
+			}
+			latest := ""
+			all := make([]string, 0, len(entries))
+			hasCurrent := false
+			for _, v := range entries {
+				all = append(all, v.Version)
+				if latest == "" || compareVersions(v.Version, latest) > 0 {
+					latest = v.Version
+				}
+				if v.Version == rel.Chart.Metadata.Version {
+					hasCurrent = true
+				}
+			}
+			if latest != "" {
+				candidates = append(candidates, repoVersionInfo{repoName: r.Name, repoURL: r.URL, latestVersion: latest, hasCurrentVersion: hasCurrent})
+				versionsByRepo[r.Name] = all
+			}
+		}
+	}
+
+	if len(candidates) > 0 {
+		sourceHosts := chartSourceHosts(rel.Chart.Metadata.Home, rel.Chart.Metadata.Sources)
+		if _, repoName := findBestUpgradeVersion(candidates, sourceHosts); repoName != "" {
+			return capVersions(sortVersionsDesc(versionsByRepo[repoName])), nil
+		}
+		// Ambiguous classic source — don't guess a version list.
+		return nil, nil
+	}
+
+	return capVersions(c.discoverOCIVersions(chartName)), nil
+}
+
+// maxAvailableVersions bounds the version list returned to the upgrade dialog.
+// Some charts publish hundreds of versions; the newest N covers realistic upgrade
+// targets without an unwieldy dropdown or a large payload. The list is already
+// sorted newest-first, so this keeps the most relevant versions.
+const maxAvailableVersions = 50
+
+func capVersions(versions []string) []string {
+	if len(versions) > maxAvailableVersions {
+		return versions[:maxAvailableVersions]
+	}
+	return versions
+}
+
+// sortVersionsDesc returns versions sorted newest-first by semver.
+func sortVersionsDesc(versions []string) []string {
+	out := slices.Clone(versions)
+	sort.SliceStable(out, func(i, j int) bool { return compareVersions(out[i], out[j]) > 0 })
+	return out
+}
+
 // repoVersionInfo holds version information from a single repository for upgrade comparison.
 type repoVersionInfo struct {
 	repoName          string

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -1237,6 +1237,8 @@ func (c *Client) checkForUpgrade(namespace, name, username string, groups []stri
 		if c.applyOCIUpgrade(info, chartName, currentVersion, nil, nil) {
 			return info, nil
 		}
+		// Genuine untracked source — registering a chart source could fix it.
+		info.Untracked = true
 		if noClassicRepos && len(ListOCISources()) == 0 {
 			info.Error = "no chart sources configured"
 		} else {
@@ -1945,6 +1947,7 @@ func (c *Client) batchCheckUpgrades(namespace, username string, groups []string)
 				info.Error = "failed to load one or more configured repository indexes"
 			} else if !ociFallback(info, chartName, currentVersion) {
 				// Genuine absence → OCI fallback for the user's own OCI charts.
+				info.Untracked = true
 				info.Error = "chart not found in configured repositories or registered OCI sources"
 			}
 			result.Releases[key] = info

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -1739,7 +1739,11 @@ func (c *Client) upgradeWith(actionConfig *action.Configuration, name, targetVer
 	upgradeAction := action.NewUpgrade(actionConfig)
 	upgradeAction.Namespace = rel.Namespace
 	upgradeAction.Timeout = 120 * time.Second
-	upgradeAction.ReuseValues = true // Keep existing values
+	// Reset to the new chart's defaults, then re-merge the user's previously-supplied
+	// values on top — preserves their overrides while picking up the new chart's new
+	// default keys. Plain ReuseValues keeps the old merged values and can render nil
+	// for keys a newer chart added (a cross-version upgrade footgun).
+	upgradeAction.ResetThenReuseValues = true
 
 	// Use ChartPathOptions to locate/download the chart
 	client := action.NewInstall(actionConfig)

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -1176,6 +1176,7 @@ func (c *Client) checkForUpgrade(namespace, name, username string, groups []stri
 	// OCI fallback with an empty classic-candidate set rather than returning early.
 	var candidates []repoVersionInfo
 	noClassicRepos := false
+	indexLoadFailed := false
 	repoFile := c.settings.RepositoryConfig
 	f, err := repo.LoadFile(repoFile)
 	switch {
@@ -1194,6 +1195,7 @@ func (c *Client) checkForUpgrade(namespace, name, username string, groups []stri
 			indexFile, err := repo.LoadIndexFile(indexPath)
 			if err != nil {
 				log.Printf("[helm] skipping repo %q: failed to load index %s: %v", r.Name, indexPath, err)
+				indexLoadFailed = true
 				continue
 			}
 
@@ -1221,10 +1223,17 @@ func (c *Client) checkForUpgrade(namespace, name, username string, groups []stri
 	}
 
 	if len(candidates) == 0 {
-		// No classic match → registered OCI sources are the fallback for the user's
-		// own OCI-published charts. Only here (genuine absence), never on classic
-		// ambiguity below — falling back on ambiguity could advertise an OCI source
-		// for a release that actually came from a classic repo.
+		// A failed classic index could be hiding the release's real (classic)
+		// source, so surface that before OCI — matching resolveUpgradeChartPath —
+		// rather than mislabel a classic-repo release as OCI-tracked.
+		if indexLoadFailed {
+			info.Error = "failed to load one or more configured repository indexes"
+			return info, nil
+		}
+		// Genuine absence → registered OCI sources are the fallback for the user's
+		// own OCI-published charts. Only here, never on classic ambiguity below —
+		// falling back on ambiguity could advertise an OCI source for a release
+		// that actually came from a classic repo.
 		if c.applyOCIUpgrade(info, chartName, currentVersion, nil, nil) {
 			return info, nil
 		}
@@ -1682,9 +1691,15 @@ type chartPathCandidate struct {
 }
 
 func (c *Client) resolveUpgradeChartPath(chartName, targetVersion, repositoryName string, sourceHosts []string) (chartPath, resolvedRepo string, err error) {
+	// A missing/unreadable repo config is not fatal: a pure-OCI user has no
+	// repositories.yaml, and discovery may have advertised an OCI upgrade. Proceed
+	// with an empty classic set so the OCI fallback below can still resolve.
 	repos, err := repo.LoadFile(c.settings.RepositoryConfig)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to load repo file: %w", err)
+		if !os.IsNotExist(err) {
+			log.Printf("[helm] failed to load repository config during upgrade (treating as no classic repos): %v", err)
+		}
+		repos = &repo.File{}
 	}
 
 	var candidates []chartPathCandidate
@@ -1861,11 +1876,13 @@ func (c *Client) batchCheckUpgrades(namespace, username string, groups []string)
 	chartAllVersions := make(map[string]map[string][]string)
 
 	cacheDir := c.settings.RepositoryCache
+	indexLoadFailed := false
 	for _, r := range f.Repositories {
 		indexPath := filepath.Join(cacheDir, fmt.Sprintf("%s-index.yaml", r.Name))
 		indexFile, err := repo.LoadIndexFile(indexPath)
 		if err != nil {
 			log.Printf("[helm] skipping repo %q: failed to load index %s: %v", r.Name, indexPath, err)
+			indexLoadFailed = true
 			continue
 		}
 
@@ -1922,8 +1939,12 @@ func (c *Client) batchCheckUpgrades(namespace, username string, groups []string)
 
 		baseCandidates, ok := chartRepoVersions[chartName]
 		if !ok {
-			// No classic match → OCI fallback (genuine absence only).
-			if !ociFallback(info, chartName, currentVersion) {
+			// A failed classic index could be hiding this release's real source —
+			// surface that before OCI rather than mislabel it as OCI-tracked.
+			if indexLoadFailed {
+				info.Error = "failed to load one or more configured repository indexes"
+			} else if !ociFallback(info, chartName, currentVersion) {
+				// Genuine absence → OCI fallback for the user's own OCI charts.
 				info.Error = "chart not found in configured repositories or registered OCI sources"
 			}
 			result.Releases[key] = info

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -26,6 +26,7 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/registry"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/releaseutil"
 	"helm.sh/helm/v3/pkg/repo"
@@ -1170,59 +1171,68 @@ func (c *Client) checkForUpgrade(namespace, name, username string, groups []stri
 		CurrentVersion: currentVersion,
 	}
 
-	// Load repository file
+	// Load repository file. A missing/empty/unreadable repo config is not fatal —
+	// the user may rely solely on registered OCI sources, so we fall through to the
+	// OCI fallback with an empty classic-candidate set rather than returning early.
+	var candidates []repoVersionInfo
+	noClassicRepos := false
 	repoFile := c.settings.RepositoryConfig
 	f, err := repo.LoadFile(repoFile)
-	if err != nil {
-		if os.IsNotExist(err) {
-			info.Error = "no helm repositories configured"
-			return info, nil
+	switch {
+	case err != nil:
+		if !os.IsNotExist(err) {
+			log.Printf("[helm] failed to load repository config %s (treating as no classic repos): %v", repoFile, err)
 		}
-		info.Error = fmt.Sprintf("failed to load repo file: %v", err)
-		return info, nil
-	}
-
-	if len(f.Repositories) == 0 {
-		info.Error = "no helm repositories configured"
-		return info, nil
-	}
-
-	// Search through all repo indexes, tracking which repos contain the current version
-	var candidates []repoVersionInfo
-	cacheDir := c.settings.RepositoryCache
-
-	for _, r := range f.Repositories {
-		indexPath := filepath.Join(cacheDir, fmt.Sprintf("%s-index.yaml", r.Name))
-		indexFile, err := repo.LoadIndexFile(indexPath)
-		if err != nil {
-			log.Printf("[helm] skipping repo %q: failed to load index %s: %v", r.Name, indexPath, err)
-			continue
-		}
-
-		if versions, ok := indexFile.Entries[chartName]; ok {
-			var latestInRepo string
-			hasCurrentVersion := false
-			for _, v := range versions {
-				if latestInRepo == "" || compareVersions(v.Version, latestInRepo) > 0 {
-					latestInRepo = v.Version
-				}
-				if v.Version == currentVersion {
-					hasCurrentVersion = true
-				}
+		noClassicRepos = true
+	case len(f.Repositories) == 0:
+		noClassicRepos = true
+	default:
+		// Search through all repo indexes, tracking which repos contain the current version
+		cacheDir := c.settings.RepositoryCache
+		for _, r := range f.Repositories {
+			indexPath := filepath.Join(cacheDir, fmt.Sprintf("%s-index.yaml", r.Name))
+			indexFile, err := repo.LoadIndexFile(indexPath)
+			if err != nil {
+				log.Printf("[helm] skipping repo %q: failed to load index %s: %v", r.Name, indexPath, err)
+				continue
 			}
-			if latestInRepo != "" {
-				candidates = append(candidates, repoVersionInfo{
-					repoName:          r.Name,
-					repoURL:           r.URL,
-					latestVersion:     latestInRepo,
-					hasCurrentVersion: hasCurrentVersion,
-				})
+
+			if versions, ok := indexFile.Entries[chartName]; ok {
+				var latestInRepo string
+				hasCurrentVersion := false
+				for _, v := range versions {
+					if latestInRepo == "" || compareVersions(v.Version, latestInRepo) > 0 {
+						latestInRepo = v.Version
+					}
+					if v.Version == currentVersion {
+						hasCurrentVersion = true
+					}
+				}
+				if latestInRepo != "" {
+					candidates = append(candidates, repoVersionInfo{
+						repoName:          r.Name,
+						repoURL:           r.URL,
+						latestVersion:     latestInRepo,
+						hasCurrentVersion: hasCurrentVersion,
+					})
+				}
 			}
 		}
 	}
 
 	if len(candidates) == 0 {
-		info.Error = "chart not found in configured repositories"
+		// No classic match → registered OCI sources are the fallback for the user's
+		// own OCI-published charts. Only here (genuine absence), never on classic
+		// ambiguity below — falling back on ambiguity could advertise an OCI source
+		// for a release that actually came from a classic repo.
+		if c.applyOCIUpgrade(info, chartName, currentVersion, nil, nil) {
+			return info, nil
+		}
+		if noClassicRepos && len(ListOCISources()) == 0 {
+			info.Error = "no chart sources configured"
+		} else {
+			info.Error = "chart not found in configured repositories or registered OCI sources"
+		}
 		return info, nil
 	}
 
@@ -1235,9 +1245,26 @@ func (c *Client) checkForUpgrade(namespace, name, username string, groups []stri
 
 	info.LatestVersion = latestVersion
 	info.RepositoryName = repoName
+	info.SourceType = "repository"
 	info.UpdateAvailable = compareVersions(latestVersion, currentVersion) > 0
 
 	return info, nil
+}
+
+// applyOCIUpgrade probes registered OCI sources for chartName and, if one
+// publishes it, fills info (LatestVersion/ChartRef/SourceType/UpdateAvailable)
+// and returns true. The classic-repo inference is always tried first; this is the
+// fallback for the user's own OCI-published charts that no repo index lists.
+func (c *Client) applyOCIUpgrade(info *UpgradeInfo, chartName, currentVersion string, lister ociTagLister, tagCache map[string][]string) bool {
+	match := c.discoverOCIUpgrade(chartName, lister, tagCache)
+	if match == nil {
+		return false
+	}
+	info.LatestVersion = match.LatestVersion
+	info.ChartRef = match.ChartURL
+	info.SourceType = "oci"
+	info.UpdateAvailable = compareVersions(match.LatestVersion, currentVersion) > 0
+	return true
 }
 
 // repoVersionInfo holds version information from a single repository for upgrade comparison.
@@ -1607,6 +1634,16 @@ func (c *Client) upgradeWith(actionConfig *action.Configuration, name, targetVer
 	client := action.NewInstall(actionConfig)
 	client.Version = targetVersion
 
+	// OCI pulls need a registry client on the action; Radar's action config
+	// doesn't carry one by default. Wire it from the user's helm registry login.
+	if registry.IsOCI(chartPath) {
+		rc, err := c.newRegistryClientConcrete()
+		if err != nil {
+			return fmt.Errorf("failed to build OCI registry client: %w", err)
+		}
+		client.SetRegistryClient(rc)
+	}
+
 	cp, err := client.ChartPathOptions.LocateChart(chartPath, c.settings)
 	if err != nil {
 		return fmt.Errorf("failed to locate chart: %w", err)
@@ -1617,6 +1654,13 @@ func (c *Client) upgradeWith(actionConfig *action.Configuration, name, targetVer
 	chart, err := loader.Load(cp)
 	if err != nil {
 		return fmt.Errorf("failed to load chart: %w", err)
+	}
+
+	// Refuse a silent chart-swap: the resolved source must publish the SAME chart
+	// the release runs, not merely a chart at the same version. Matters most for
+	// OCI prefix probing, where "<prefix>/<chartName>" is derived, not asserted.
+	if chart.Metadata != nil && chart.Metadata.Name != chartName {
+		return fmt.Errorf("resolved chart is %q but release %q runs chart %q — refusing to swap charts", chart.Metadata.Name, name, chartName)
 	}
 
 	sendProgress("upgrading", fmt.Sprintf("Applying %s %s...", chartName, targetVersion), "")
@@ -1695,10 +1739,22 @@ func (c *Client) resolveUpgradeChartPath(chartName, targetVersion, repositoryNam
 		}
 		return "", "", fmt.Errorf("chart %s version %s not found in repository %s", chartName, targetVersion, repositoryName)
 	}
+
+	// Surface classic-repo index failures before the OCI fallback: a stale/missing
+	// index is a "fix your repo" condition the user should see, not something to
+	// silently paper over by pulling the same version from an OCI source.
 	if len(indexErrors) > 0 {
 		return "", "", fmt.Errorf("chart %s version %s not found in configured repositories; failed to load indexes: %s", chartName, targetVersion, strings.Join(indexErrors, "; "))
 	}
-	return "", "", fmt.Errorf("chart %s version %s not found in configured repositories", chartName, targetVersion)
+
+	// No classic-repo match and indexes loaded cleanly. Fall back to registered OCI
+	// sources — the server re-derives the oci:// ref from a configured prefix (never
+	// a client-supplied ref), keeping the upgrade path configured-only.
+	if url, ok := c.resolveOCIUpgradeURL(chartName, targetVersion); ok {
+		return url, "oci", nil
+	}
+
+	return "", "", fmt.Errorf("chart %s version %s not found in configured repositories or registered OCI sources", chartName, targetVersion)
 }
 
 // BatchCheckUpgrades checks for upgrades for all releases at once (more efficient)
@@ -1786,23 +1842,16 @@ func (c *Client) batchCheckUpgrades(namespace, username string, groups []string)
 		}
 	}
 
+	// A missing/unreadable repo config is not fatal: a user may rely solely on
+	// registered OCI sources, so we proceed with an empty classic-repo set and let
+	// the per-release OCI fallback run rather than failing every release here.
 	repoFile := c.settings.RepositoryConfig
 	f, err := repo.LoadFile(repoFile)
 	if err != nil {
-		message := fmt.Sprintf("failed to load Helm repositories: %v", err)
-		if os.IsNotExist(err) {
-			message = "no helm repositories configured"
-		} else {
-			log.Printf("[helm] failed to load repository config %s: %v", repoFile, err)
+		if !os.IsNotExist(err) {
+			log.Printf("[helm] failed to load repository config %s (treating as no classic repos): %v", repoFile, err)
 		}
-		for _, rel := range releases {
-			key := releaseUpgradeKey(rel, storageNamespaces[releaseStorageKey(rel)])
-			result.Releases[key] = &UpgradeInfo{
-				CurrentVersion: rel.Chart.Metadata.Version,
-				Error:          message,
-			}
-		}
-		return result, nil
+		f = &repo.File{}
 	}
 
 	// Split into two maps: latest-per-repo drives ranking; per-repo full
@@ -1845,26 +1894,53 @@ func (c *Client) batchCheckUpgrades(namespace, username string, groups []string)
 		}
 	}
 
+	// One registry client + tag cache shared across all releases in this batch, so
+	// the same OCI ref isn't re-listed per release. Built lazily on first miss so
+	// batches with no registered OCI sources pay nothing.
+	var ociLister ociTagLister
+	ociReady := false
+	tagCache := map[string][]string{}
+	ociFallback := func(info *UpgradeInfo, chartName, currentVersion string) bool {
+		if len(ListOCISources()) == 0 {
+			return false
+		}
+		if !ociReady {
+			ociLister = c.newRegistryClient()
+			ociReady = true
+		}
+		if ociLister == nil {
+			return false
+		}
+		return c.applyOCIUpgrade(info, chartName, currentVersion, ociLister, tagCache)
+	}
+
 	for _, rel := range releases {
 		key := releaseUpgradeKey(rel, storageNamespaces[releaseStorageKey(rel)])
 		currentVersion := rel.Chart.Metadata.Version
+		chartName := rel.Chart.Metadata.Name
 		info := &UpgradeInfo{CurrentVersion: currentVersion}
 
-		baseCandidates, ok := chartRepoVersions[rel.Chart.Metadata.Name]
+		baseCandidates, ok := chartRepoVersions[chartName]
 		if !ok {
-			info.Error = "chart not found in configured repositories"
+			// No classic match → OCI fallback (genuine absence only).
+			if !ociFallback(info, chartName, currentVersion) {
+				info.Error = "chart not found in configured repositories or registered OCI sources"
+			}
 			result.Releases[key] = info
 			continue
 		}
 
-		candidates := markCurrentVersion(baseCandidates, chartAllVersions[rel.Chart.Metadata.Name], currentVersion)
+		candidates := markCurrentVersion(baseCandidates, chartAllVersions[chartName], currentVersion)
 		sourceHosts := chartSourceHosts(rel.Chart.Metadata.Home, rel.Chart.Metadata.Sources)
 		latestVersion, repoName := findBestUpgradeVersion(candidates, sourceHosts)
 		if latestVersion == "" {
+			// Classic candidates exist but are ambiguous — don't let OCI override
+			// a release that came from a classic repo.
 			info.Error = "could not identify upstream chart repository"
 		} else {
 			info.LatestVersion = latestVersion
 			info.RepositoryName = repoName
+			info.SourceType = "repository"
 			info.UpdateAvailable = compareVersions(latestVersion, currentVersion) > 0
 		}
 		result.Releases[key] = info

--- a/internal/helm/handlers.go
+++ b/internal/helm/handlers.go
@@ -84,6 +84,12 @@ func (h *Handlers) RegisterRoutes(r chi.Router) {
 		// Chart browser (local repositories)
 		r.Get("/repositories", h.handleListRepositories)
 		r.Post("/repositories/{name}/update", h.handleUpdateRepository)
+
+		// Registered OCI chart sources (the OCI analog of `helm repo add`) — let
+		// Radar track upgrades for the user's own OCI-published charts.
+		r.Get("/oci-sources", h.handleListOCISources)
+		r.Post("/oci-sources", h.handleAddOCISource)
+		r.Delete("/oci-sources", h.handleRemoveOCISource)
 		r.Get("/charts", h.handleSearchCharts)
 		r.Get("/charts/{repo}/{chart}", h.handleGetChartDetail)
 		r.Get("/charts/{repo}/{chart}/{version}", h.handleGetChartDetailVersion)
@@ -748,6 +754,54 @@ func (h *Handlers) handleUpdateRepository(w http.ResponseWriter, r *http.Request
 	}
 
 	writeJSON(w, map[string]string{"status": "success", "message": "Repository updated"})
+}
+
+// ociSourceRequest is the body for registering/unregistering an OCI chart source.
+type ociSourceRequest struct {
+	Source string `json:"source"`
+}
+
+// handleListOCISources returns the registered OCI chart-source prefixes.
+func (h *Handlers) handleListOCISources(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, ListOCISources())
+}
+
+// handleAddOCISource registers an OCI chart-source prefix. Gated by
+// requireHelmWrite (same as repo refresh): it mutates pod-local config and
+// underpins later upgrades, but is not a cluster mutation.
+func (h *Handlers) handleAddOCISource(w http.ResponseWriter, r *http.Request) {
+	if !requireHelmWrite(w, r) {
+		return
+	}
+	var req ociSourceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	sources, err := AddOCISource(req.Source)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, sources)
+}
+
+// handleRemoveOCISource unregisters an OCI chart-source prefix.
+func (h *Handlers) handleRemoveOCISource(w http.ResponseWriter, r *http.Request) {
+	if !requireHelmWrite(w, r) {
+		return
+	}
+	var req ociSourceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	sources, err := RemoveOCISource(req.Source)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, sources)
 }
 
 // handleSearchCharts searches for charts across all repositories

--- a/internal/helm/handlers.go
+++ b/internal/helm/handlers.go
@@ -71,6 +71,7 @@ func (h *Handlers) RegisterRoutes(r chi.Router) {
 		r.Get("/releases/{namespace}/{name}/values", h.handleGetValues)
 		r.Get("/releases/{namespace}/{name}/diff", h.handleGetDiff)
 		r.Get("/releases/{namespace}/{name}/upgrade-info", h.handleCheckUpgrade)
+		r.Get("/releases/{namespace}/{name}/versions", h.handleAvailableVersions)
 		r.Get("/upgrade-check", h.handleBatchUpgradeCheck)
 		// Actions (write operations)
 		r.Post("/releases/{namespace}/{name}/rollback", h.handleRollback)
@@ -285,6 +286,36 @@ func (h *Handlers) handleCheckUpgrade(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, info)
+}
+
+// handleAvailableVersions returns the newest-first list of chart versions this
+// release could be upgraded/downgraded to, so the upgrade dialog can offer a
+// specific target version. Returns [] when the source can't be resolved.
+func (h *Handlers) handleAvailableVersions(w http.ResponseWriter, r *http.Request) {
+	client := GetClient()
+	if client == nil {
+		writeError(w, http.StatusServiceUnavailable, "Helm client not initialized")
+		return
+	}
+
+	namespace := chi.URLParam(r, "namespace")
+	name := chi.URLParam(r, "name")
+
+	username, groups := userCreds(r)
+	versions, err := client.AvailableVersionsAsUser(namespace, name, username, groups)
+	if err != nil {
+		if IsForbiddenError(err) {
+			writeError(w, http.StatusForbidden, "insufficient permissions to read Helm release")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	if versions == nil {
+		versions = []string{}
+	}
+	writeJSON(w, versions)
 }
 
 // handleBatchUpgradeCheck checks all releases for upgrades at once

--- a/internal/helm/oci_sources.go
+++ b/internal/helm/oci_sources.go
@@ -206,10 +206,12 @@ func (c *Client) discoverOCIUpgrade(chartName string, lister ociTagLister, tagCa
 			tags, err = lister.Tags(ref)
 			if err != nil {
 				// Expected when this prefix doesn't publish this chart (404) —
-				// the chart may live under a different registered prefix.
+				// the chart may live under a different registered prefix. Do NOT
+				// cache the failure: a transient timeout/network error would
+				// otherwise mark every release sharing this ref as untracked for
+				// the whole batch. A genuine 404 is cheap to re-probe.
 				tags = nil
-			}
-			if tagCache != nil {
+			} else if tagCache != nil {
 				tagCache[ref] = tags
 			}
 		}

--- a/internal/helm/oci_sources.go
+++ b/internal/helm/oci_sources.go
@@ -226,6 +226,31 @@ func (c *Client) discoverOCIUpgrade(chartName string, lister ociTagLister, tagCa
 	return best
 }
 
+// discoverOCIVersions returns the full newest-first version list for chartName
+// from the registered prefix that publishes it (the one with the highest newest
+// tag, matching discoverOCIUpgrade's tiebreak). Empty if no prefix has the chart.
+func (c *Client) discoverOCIVersions(chartName string) []string {
+	prefixes := ListOCISources()
+	if len(prefixes) == 0 || chartName == "" {
+		return nil
+	}
+	lister := c.newRegistryClient()
+	if lister == nil {
+		return nil
+	}
+	var best []string
+	for _, prefix := range prefixes {
+		tags, err := lister.Tags(ociRef(prefix, chartName))
+		if err != nil || len(tags) == 0 {
+			continue
+		}
+		if best == nil || compareVersions(tags[0], best[0]) > 0 {
+			best = tags
+		}
+	}
+	return best
+}
+
 // resolveOCIUpgradeURL returns the oci:// chart URL for chartName at targetVersion
 // if some registered prefix publishes that exact version. Used by the upgrade path
 // so the server only ever pulls from a registered (configured) source — never a

--- a/internal/helm/oci_sources.go
+++ b/internal/helm/oci_sources.go
@@ -197,19 +197,37 @@ func (c *Client) discoverOCIUpgrade(chartName string, lister ociTagLister, tagCa
 		}
 	}
 
-	var best *ociUpgradeMatch
-	for _, prefix := range prefixes {
+	prefix, tags := c.selectBestOCIPrefix(chartName, lister, tagCache)
+	if prefix == "" {
+		return nil
+	}
+	return &ociUpgradeMatch{LatestVersion: tags[0], ChartURL: ociChartURL(prefix, chartName)}
+}
+
+// selectBestOCIPrefix probes the registered prefixes for chartName and returns the
+// one whose newest tag is highest, plus its tags (newest-first). This single tiebreak
+// is shared by discovery, the version list, AND upgrade resolution — so the version a
+// user picks is always pulled from the same registry the list came from. Picking the
+// "first prefix that happens to contain the tag" here instead would let an upgrade pull
+// a same-name/same-version chart from a different registry than the picker showed.
+// tagCache (may be nil) dedupes lookups within a batch; failed probes are not cached.
+func (c *Client) selectBestOCIPrefix(chartName string, lister ociTagLister, tagCache map[string][]string) (string, []string) {
+	if chartName == "" {
+		return "", nil
+	}
+	var bestPrefix string
+	var bestTags []string
+	for _, prefix := range ListOCISources() {
 		ref := ociRef(prefix, chartName)
 		tags, cached := tagCache[ref]
 		if !cached {
 			var err error
 			tags, err = lister.Tags(ref)
 			if err != nil {
-				// Expected when this prefix doesn't publish this chart (404) —
-				// the chart may live under a different registered prefix. Do NOT
-				// cache the failure: a transient timeout/network error would
-				// otherwise mark every release sharing this ref as untracked for
-				// the whole batch. A genuine 404 is cheap to re-probe.
+				// Expected when this prefix doesn't publish this chart (404) — the
+				// chart may live under a different registered prefix. Don't cache the
+				// failure: a transient timeout would otherwise mark every release
+				// sharing this ref as untracked for the whole batch.
 				tags = nil
 			} else if tagCache != nil {
 				tagCache[ref] = tags
@@ -218,60 +236,42 @@ func (c *Client) discoverOCIUpgrade(chartName string, lister ociTagLister, tagCa
 		if len(tags) == 0 {
 			continue
 		}
-		latest := tags[0]
-		if best == nil || compareVersions(latest, best.LatestVersion) > 0 {
-			best = &ociUpgradeMatch{LatestVersion: latest, ChartURL: ociChartURL(prefix, chartName)}
+		if bestTags == nil || compareVersions(tags[0], bestTags[0]) > 0 {
+			bestPrefix, bestTags = prefix, tags
 		}
 	}
-	return best
+	return bestPrefix, bestTags
 }
 
-// discoverOCIVersions returns the full newest-first version list for chartName
-// from the registered prefix that publishes it (the one with the highest newest
-// tag, matching discoverOCIUpgrade's tiebreak). Empty if no prefix has the chart.
+// discoverOCIVersions returns the full newest-first version list for chartName from
+// the best-matching registered prefix (see selectBestOCIPrefix). Empty if none.
 func (c *Client) discoverOCIVersions(chartName string) []string {
-	prefixes := ListOCISources()
-	if len(prefixes) == 0 || chartName == "" {
+	if len(ListOCISources()) == 0 {
 		return nil
 	}
 	lister := c.newRegistryClient()
 	if lister == nil {
 		return nil
 	}
-	var best []string
-	for _, prefix := range prefixes {
-		tags, err := lister.Tags(ociRef(prefix, chartName))
-		if err != nil || len(tags) == 0 {
-			continue
-		}
-		if best == nil || compareVersions(tags[0], best[0]) > 0 {
-			best = tags
-		}
-	}
-	return best
+	_, tags := c.selectBestOCIPrefix(chartName, lister, nil)
+	return tags
 }
 
-// resolveOCIUpgradeURL returns the oci:// chart URL for chartName at targetVersion
-// if some registered prefix publishes that exact version. Used by the upgrade path
-// so the server only ever pulls from a registered (configured) source — never a
-// client-supplied ref.
+// resolveOCIUpgradeURL returns the oci:// chart URL for chartName at targetVersion,
+// resolved from the SAME prefix discovery/the version picker used (selectBestOCIPrefix),
+// so the upgrade pulls from the registry the user's version list came from. The server
+// only ever pulls from a registered (configured) source — never a client-supplied ref.
 func (c *Client) resolveOCIUpgradeURL(chartName, targetVersion string) (string, bool) {
-	prefixes := ListOCISources()
-	if len(prefixes) == 0 {
+	if len(ListOCISources()) == 0 {
 		return "", false
 	}
 	lister := c.newRegistryClient()
 	if lister == nil {
 		return "", false
 	}
-	for _, prefix := range prefixes {
-		tags, err := lister.Tags(ociRef(prefix, chartName))
-		if err != nil {
-			continue
-		}
-		if slices.Contains(tags, targetVersion) {
-			return ociChartURL(prefix, chartName), true
-		}
+	prefix, tags := c.selectBestOCIPrefix(chartName, lister, nil)
+	if prefix != "" && slices.Contains(tags, targetVersion) {
+		return ociChartURL(prefix, chartName), true
 	}
 	return "", false
 }

--- a/internal/helm/oci_sources.go
+++ b/internal/helm/oci_sources.go
@@ -1,0 +1,250 @@
+package helm
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+
+	"helm.sh/helm/v3/pkg/registry"
+
+	"github.com/skyhook-io/radar/internal/settings"
+)
+
+// ociProbeTimeout bounds a single registry tag lookup via the registry client's
+// http.Client. helm's Tags() uses context.Background() with no deadline of its
+// own, so without this an unreachable registered registry would stall the
+// (synchronous) batch upgrade check that backs the Helm list view.
+const ociProbeTimeout = 5 * time.Second
+
+// OCI chart-source registration.
+//
+// Helm v3 never persists the ref a release was installed from, and unlike
+// classic HTTP repos (listed in repositories.yaml) there is no native "configured
+// source list" for OCI registries — `helm registry login` stores only auth. So a
+// release installed via `helm install oci://…` has no discoverable upstream and
+// shows "source not tracked".
+//
+// A registered OCI prefix is the OCI analog of `helm repo add`: the user declares
+// once where their charts live (e.g. "oci://ghcr.io/myorg/charts"), and Radar
+// probes "<prefix>/<chartName>" to discover newer versions. Because matching is by
+// chart name at query time, no per-release mapping is persisted — which also means
+// prefixes are global to the Radar instance, not cluster-scoped.
+//
+// Credentials are reused from the user's existing `helm registry login` store
+// (settings.RegistryConfig); Radar stores no registry secrets of its own.
+
+// normalizeOCIPrefix validates and canonicalizes a registered prefix. It must be
+// an oci:// reference with at least a host; the trailing slash is trimmed so
+// "<prefix>/<chart>" joins cleanly.
+func normalizeOCIPrefix(raw string) (string, error) {
+	p := strings.TrimSpace(raw)
+	if p == "" {
+		return "", fmt.Errorf("source is empty")
+	}
+	if !strings.HasPrefix(p, "oci://") {
+		return "", fmt.Errorf("source must be an oci:// reference, got %q", raw)
+	}
+	// Strip the scheme before trimming slashes — trimming "oci://" directly would
+	// eat the "//" and yield "oci:".
+	rest := strings.Trim(strings.TrimPrefix(p, "oci://"), "/")
+	if rest == "" {
+		return "", fmt.Errorf("source must include a registry host")
+	}
+	if err := rejectLinkLocalHost(rest); err != nil {
+		return "", err
+	}
+	return "oci://" + rest, nil
+}
+
+// rejectLinkLocalHost blocks the highest-value SSRF target — the cloud metadata
+// endpoint (169.254.169.254) and link-local range — when the host is a literal
+// IP. Loopback / private ranges are deliberately allowed so local dev registries
+// (localhost:5000) still work; broader private-range/DNS-resolution blocking is
+// hosted-mode hardening tracked separately. Does NOT defend against a DNS name
+// that resolves into these ranges.
+func rejectLinkLocalHost(ref string) error {
+	host := ref
+	if i := strings.IndexAny(host, "/"); i >= 0 {
+		host = host[:i]
+	}
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	if ip := net.ParseIP(host); ip != nil && (ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()) {
+		return fmt.Errorf("registry host %q is in the link-local range and not allowed", host)
+	}
+	return nil
+}
+
+// ListOCISources returns the registered OCI prefixes (normalized).
+func ListOCISources() []string {
+	s := settings.Load()
+	out := make([]string, 0, len(s.HelmOCISources))
+	out = append(out, s.HelmOCISources...)
+	return out
+}
+
+// AddOCISource registers a prefix. Idempotent: re-adding an existing prefix is a
+// no-op rather than a duplicate. Returns the full updated list.
+func AddOCISource(raw string) ([]string, error) {
+	prefix, err := normalizeOCIPrefix(raw)
+	if err != nil {
+		return nil, err
+	}
+	updated, err := settings.Update(func(s *settings.Settings) {
+		if slices.Contains(s.HelmOCISources, prefix) {
+			return
+		}
+		s.HelmOCISources = append(s.HelmOCISources, prefix)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return updated.HelmOCISources, nil
+}
+
+// RemoveOCISource unregisters a prefix. Returns the full updated list.
+func RemoveOCISource(raw string) ([]string, error) {
+	prefix, err := normalizeOCIPrefix(raw)
+	if err != nil {
+		return nil, err
+	}
+	updated, err := settings.Update(func(s *settings.Settings) {
+		kept := s.HelmOCISources[:0]
+		for _, existing := range s.HelmOCISources {
+			if existing != prefix {
+				kept = append(kept, existing)
+			}
+		}
+		s.HelmOCISources = kept
+	})
+	if err != nil {
+		return nil, err
+	}
+	return updated.HelmOCISources, nil
+}
+
+// ociRef joins a registered prefix and chart name into the bare reference helm's
+// registry client expects (no oci:// scheme): "ghcr.io/myorg/charts/mychart".
+func ociRef(prefix, chartName string) string {
+	return strings.TrimPrefix(prefix, "oci://") + "/" + chartName
+}
+
+// ociChartURL is ociRef with the scheme retained, for LocateChart / display.
+func ociChartURL(prefix, chartName string) string {
+	return strings.TrimRight(prefix, "/") + "/" + chartName
+}
+
+// ociUpgradeMatch is the result of probing the registered prefixes for a chart.
+type ociUpgradeMatch struct {
+	// LatestVersion is the newest semver tag found across registered prefixes.
+	LatestVersion string
+	// ChartURL is the oci:// chart reference the latest version lives at, used
+	// to drive the upgrade. Always derived from a registered prefix.
+	ChartURL string
+}
+
+// ociTagLister abstracts registry.Client.Tags so discovery can be unit-tested
+// without a live registry.
+type ociTagLister interface {
+	Tags(ref string) ([]string, error)
+}
+
+// newRegistryClientConcrete builds a helm OCI registry client that authenticates
+// from the user's existing `helm registry login` store (settings.RegistryConfig).
+// Radar stores no registry secrets of its own.
+func (c *Client) newRegistryClientConcrete() (*registry.Client, error) {
+	return registry.NewClient(
+		registry.ClientOptEnableCache(true),
+		registry.ClientOptCredentialsFile(c.settings.RegistryConfig),
+		// Bound every request (incl. dial) so an unreachable registered registry
+		// can't stall the synchronous upgrade check.
+		registry.ClientOptHTTPClient(&http.Client{Timeout: ociProbeTimeout}),
+	)
+}
+
+// newRegistryClient is newRegistryClientConcrete for the discovery path. Returns
+// nil (logged) on failure so discovery degrades to "not tracked" rather than
+// erroring the whole upgrade check.
+func (c *Client) newRegistryClient() ociTagLister {
+	rc, err := c.newRegistryClientConcrete()
+	if err != nil {
+		log.Printf("[helm] OCI discovery disabled: failed to build registry client: %v", err)
+		return nil
+	}
+	return rc
+}
+
+// discoverOCIUpgrade probes the registered OCI prefixes for chartName and returns
+// the newest version found, or nil if no registered prefix publishes the chart.
+// lister may be reused across many releases in a batch; pass nil to build one.
+//
+// Tags() already filters to valid semver and sorts newest-first, so tags[0] is the
+// latest. tagCache dedupes repeated lookups of the same ref within a batch.
+func (c *Client) discoverOCIUpgrade(chartName string, lister ociTagLister, tagCache map[string][]string) *ociUpgradeMatch {
+	prefixes := ListOCISources()
+	if len(prefixes) == 0 || chartName == "" {
+		return nil
+	}
+	if lister == nil {
+		lister = c.newRegistryClient()
+		if lister == nil {
+			return nil
+		}
+	}
+
+	var best *ociUpgradeMatch
+	for _, prefix := range prefixes {
+		ref := ociRef(prefix, chartName)
+		tags, cached := tagCache[ref]
+		if !cached {
+			var err error
+			tags, err = lister.Tags(ref)
+			if err != nil {
+				// Expected when this prefix doesn't publish this chart (404) —
+				// the chart may live under a different registered prefix.
+				tags = nil
+			}
+			if tagCache != nil {
+				tagCache[ref] = tags
+			}
+		}
+		if len(tags) == 0 {
+			continue
+		}
+		latest := tags[0]
+		if best == nil || compareVersions(latest, best.LatestVersion) > 0 {
+			best = &ociUpgradeMatch{LatestVersion: latest, ChartURL: ociChartURL(prefix, chartName)}
+		}
+	}
+	return best
+}
+
+// resolveOCIUpgradeURL returns the oci:// chart URL for chartName at targetVersion
+// if some registered prefix publishes that exact version. Used by the upgrade path
+// so the server only ever pulls from a registered (configured) source — never a
+// client-supplied ref.
+func (c *Client) resolveOCIUpgradeURL(chartName, targetVersion string) (string, bool) {
+	prefixes := ListOCISources()
+	if len(prefixes) == 0 {
+		return "", false
+	}
+	lister := c.newRegistryClient()
+	if lister == nil {
+		return "", false
+	}
+	for _, prefix := range prefixes {
+		tags, err := lister.Tags(ociRef(prefix, chartName))
+		if err != nil {
+			continue
+		}
+		if slices.Contains(tags, targetVersion) {
+			return ociChartURL(prefix, chartName), true
+		}
+	}
+	return "", false
+}

--- a/internal/helm/oci_sources_test.go
+++ b/internal/helm/oci_sources_test.go
@@ -1,0 +1,174 @@
+package helm
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestNormalizeOCIPrefix(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{name: "plain", in: "oci://ghcr.io/myorg/charts", want: "oci://ghcr.io/myorg/charts"},
+		{name: "trailing slash trimmed", in: "oci://ghcr.io/myorg/charts/", want: "oci://ghcr.io/myorg/charts"},
+		{name: "whitespace trimmed", in: "  oci://ghcr.io/myorg/charts  ", want: "oci://ghcr.io/myorg/charts"},
+		{name: "host only", in: "oci://ghcr.io", want: "oci://ghcr.io"},
+		{name: "missing scheme", in: "ghcr.io/myorg/charts", wantErr: true},
+		{name: "http scheme rejected", in: "https://charts.example.com", wantErr: true},
+		{name: "empty", in: "", wantErr: true},
+		{name: "scheme only", in: "oci://", wantErr: true},
+		{name: "metadata IP blocked", in: "oci://169.254.169.254/charts", wantErr: true},
+		{name: "link-local with port blocked", in: "oci://169.254.0.1:5000/charts", wantErr: true},
+		{name: "loopback allowed (local dev registry)", in: "oci://localhost:5000/charts", want: "oci://localhost:5000/charts"},
+		{name: "private IP allowed (local dev registry)", in: "oci://10.0.0.5:5000/charts", want: "oci://10.0.0.5:5000/charts"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeOCIPrefix(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got %q", tt.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("normalizeOCIPrefix(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOCIRefAndURL(t *testing.T) {
+	prefix := "oci://ghcr.io/myorg/charts"
+	if got, want := ociRef(prefix, "mychart"), "ghcr.io/myorg/charts/mychart"; got != want {
+		t.Errorf("ociRef = %q, want %q (registry client wants no scheme)", got, want)
+	}
+	if got, want := ociChartURL(prefix, "mychart"), "oci://ghcr.io/myorg/charts/mychart"; got != want {
+		t.Errorf("ociChartURL = %q, want %q (LocateChart wants the scheme)", got, want)
+	}
+}
+
+// fakeTagLister returns canned tags per ref and records calls.
+type fakeTagLister struct {
+	tags  map[string][]string
+	errs  map[string]error
+	calls []string
+}
+
+func (f *fakeTagLister) Tags(ref string) ([]string, error) {
+	f.calls = append(f.calls, ref)
+	if err, ok := f.errs[ref]; ok {
+		return nil, err
+	}
+	return f.tags[ref], nil
+}
+
+func TestDiscoverOCIUpgrade(t *testing.T) {
+	// Two registered prefixes; the chart lives under the second one only.
+	withOCISources(t, []string{"oci://ghcr.io/orgA/charts", "oci://ghcr.io/orgB/charts"})
+
+	lister := &fakeTagLister{
+		tags: map[string][]string{
+			// Tags() returns semver-sorted newest-first.
+			"ghcr.io/orgB/charts/mychart": {"1.4.0", "1.3.0", "1.2.0"},
+		},
+		errs: map[string]error{
+			"ghcr.io/orgA/charts/mychart": fmt.Errorf("not found"),
+		},
+	}
+
+	c := &Client{}
+	match := c.discoverOCIUpgrade("mychart", lister, map[string][]string{})
+	if match == nil {
+		t.Fatal("expected a match from orgB, got nil")
+	}
+	if match.LatestVersion != "1.4.0" {
+		t.Errorf("LatestVersion = %q, want 1.4.0", match.LatestVersion)
+	}
+	if match.ChartURL != "oci://ghcr.io/orgB/charts/mychart" {
+		t.Errorf("ChartURL = %q, want oci://ghcr.io/orgB/charts/mychart", match.ChartURL)
+	}
+}
+
+func TestDiscoverOCIUpgrade_PicksNewestAcrossPrefixes(t *testing.T) {
+	withOCISources(t, []string{"oci://reg1/c", "oci://reg2/c"})
+	lister := &fakeTagLister{
+		tags: map[string][]string{
+			"reg1/c/app": {"2.0.0"},
+			"reg2/c/app": {"2.1.0"},
+		},
+	}
+	c := &Client{}
+	match := c.discoverOCIUpgrade("app", lister, map[string][]string{})
+	if match == nil || match.LatestVersion != "2.1.0" {
+		t.Fatalf("expected newest 2.1.0 across prefixes, got %+v", match)
+	}
+}
+
+func TestDiscoverOCIUpgrade_NoSourcesOrNoMatch(t *testing.T) {
+	withOCISources(t, nil)
+	c := &Client{}
+	if m := c.discoverOCIUpgrade("app", &fakeTagLister{}, map[string][]string{}); m != nil {
+		t.Errorf("expected nil with no registered sources, got %+v", m)
+	}
+
+	withOCISources(t, []string{"oci://reg/c"})
+	lister := &fakeTagLister{tags: map[string][]string{}} // chart not published anywhere
+	if m := c.discoverOCIUpgrade("app", lister, map[string][]string{}); m != nil {
+		t.Errorf("expected nil when chart not found, got %+v", m)
+	}
+}
+
+func TestDiscoverOCIUpgrade_TagCacheDedupes(t *testing.T) {
+	withOCISources(t, []string{"oci://reg/c"})
+	lister := &fakeTagLister{tags: map[string][]string{"reg/c/app": {"1.0.0"}}}
+	cache := map[string][]string{}
+	c := &Client{}
+	c.discoverOCIUpgrade("app", lister, cache)
+	c.discoverOCIUpgrade("app", lister, cache)
+	if len(lister.calls) != 1 {
+		t.Errorf("expected Tags called once (cached), got %d calls", len(lister.calls))
+	}
+}
+
+func TestApplyOCIUpgrade_SetsFields(t *testing.T) {
+	withOCISources(t, []string{"oci://reg/c"})
+	lister := &fakeTagLister{tags: map[string][]string{"reg/c/app": {"1.5.0"}}}
+	c := &Client{}
+
+	info := &UpgradeInfo{CurrentVersion: "1.4.0"}
+	if !c.applyOCIUpgrade(info, "app", "1.4.0", lister, map[string][]string{}) {
+		t.Fatal("expected applyOCIUpgrade to return true")
+	}
+	if info.SourceType != "oci" || info.LatestVersion != "1.5.0" || !info.UpdateAvailable {
+		t.Errorf("unexpected info: %+v", info)
+	}
+	if info.ChartRef != "oci://reg/c/app" {
+		t.Errorf("ChartRef = %q, want oci://reg/c/app", info.ChartRef)
+	}
+
+	// Same version → no update available, but still tracked.
+	info2 := &UpgradeInfo{CurrentVersion: "1.5.0"}
+	c.applyOCIUpgrade(info2, "app", "1.5.0", lister, map[string][]string{})
+	if info2.UpdateAvailable {
+		t.Error("expected UpdateAvailable=false when current == latest")
+	}
+}
+
+// withOCISources points settings at a temp HOME and seeds the registered OCI
+// sources for the duration of the test.
+func withOCISources(t *testing.T, sources []string) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	for _, s := range sources {
+		if _, err := AddOCISource(s); err != nil {
+			t.Fatalf("seeding source %q: %v", s, err)
+		}
+	}
+}

--- a/internal/helm/oci_sources_test.go
+++ b/internal/helm/oci_sources_test.go
@@ -2,6 +2,7 @@ package helm
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 )
 
@@ -108,6 +109,34 @@ func TestDiscoverOCIUpgrade_PicksNewestAcrossPrefixes(t *testing.T) {
 	match := c.discoverOCIUpgrade("app", lister, map[string][]string{})
 	if match == nil || match.LatestVersion != "2.1.0" {
 		t.Fatalf("expected newest 2.1.0 across prefixes, got %+v", match)
+	}
+}
+
+// Regression: discovery and upgrade resolution must agree on which prefix wins.
+// reg1 (first in settings order) also publishes the target version, but reg2 has the
+// higher newest tag, so the version picker shows reg2's list — the upgrade must
+// resolve from reg2, not "first prefix that happens to contain the tag" (reg1).
+func TestSelectBestOCIPrefix_ConsistentAcrossDiscoveryAndUpgrade(t *testing.T) {
+	withOCISources(t, []string{"oci://reg1/c", "oci://reg2/c"})
+	lister := &fakeTagLister{
+		tags: map[string][]string{
+			"reg1/c/app": {"1.0.0"},          // older, first in order, also has 1.0.0
+			"reg2/c/app": {"2.0.0", "1.0.0"}, // newer newest tag → wins
+		},
+	}
+	c := &Client{}
+	prefix, tags := c.selectBestOCIPrefix("app", lister, map[string][]string{})
+	if prefix != "oci://reg2/c" {
+		t.Fatalf("best prefix = %q, want oci://reg2/c (highest newest tag, not first-in-order)", prefix)
+	}
+	if len(tags) != 2 || tags[0] != "2.0.0" {
+		t.Fatalf("tags = %v, want reg2's [2.0.0 1.0.0]", tags)
+	}
+	// The version picker would offer 1.0.0 (in reg2's list); the upgrade must resolve
+	// 1.0.0 from reg2 too — the same prefix — even though reg1 also has it.
+	matchPrefix, matchTags := c.selectBestOCIPrefix("app", lister, map[string][]string{})
+	if matchPrefix != "oci://reg2/c" || !slices.Contains(matchTags, "1.0.0") {
+		t.Fatalf("upgrade resolution diverged: prefix=%q tags=%v", matchPrefix, matchTags)
 	}
 }
 

--- a/internal/helm/oci_sources_test.go
+++ b/internal/helm/oci_sources_test.go
@@ -137,6 +137,42 @@ func TestDiscoverOCIUpgrade_TagCacheDedupes(t *testing.T) {
 	}
 }
 
+// transientTagLister fails the first failCount calls for a ref, then succeeds —
+// models a transient timeout/network error.
+type transientTagLister struct {
+	tags      []string
+	failCount int
+	calls     int
+}
+
+func (l *transientTagLister) Tags(string) ([]string, error) {
+	l.calls++
+	if l.calls <= l.failCount {
+		return nil, fmt.Errorf("transient timeout")
+	}
+	return l.tags, nil
+}
+
+func TestDiscoverOCIUpgrade_DoesNotCacheFailures(t *testing.T) {
+	withOCISources(t, []string{"oci://reg/c"})
+	lister := &transientTagLister{tags: []string{"1.0.0"}, failCount: 1}
+	cache := map[string][]string{}
+	c := &Client{}
+
+	// First probe fails transiently — must NOT be cached as "untracked".
+	if m := c.discoverOCIUpgrade("app", lister, cache); m != nil {
+		t.Fatalf("expected nil on transient failure, got %+v", m)
+	}
+	// Second probe retries (failure wasn't cached) and succeeds.
+	m := c.discoverOCIUpgrade("app", lister, cache)
+	if m == nil || m.LatestVersion != "1.0.0" {
+		t.Fatalf("expected retry to succeed with 1.0.0, got %+v (calls=%d)", m, lister.calls)
+	}
+	if lister.calls != 2 {
+		t.Errorf("expected 2 calls (retry after transient failure), got %d", lister.calls)
+	}
+}
+
 func TestApplyOCIUpgrade_SetsFields(t *testing.T) {
 	withOCISources(t, []string{"oci://reg/c"})
 	lister := &fakeTagLister{tags: map[string][]string{"reg/c/app": {"1.5.0"}}}

--- a/internal/helm/oci_sources_test.go
+++ b/internal/helm/oci_sources_test.go
@@ -197,6 +197,40 @@ func TestApplyOCIUpgrade_SetsFields(t *testing.T) {
 	}
 }
 
+func TestSortVersionsDesc(t *testing.T) {
+	in := []string{"1.2.0", "1.10.0", "1.2.3", "0.9.0", "2.0.0"}
+	got := sortVersionsDesc(in)
+	want := []string{"2.0.0", "1.10.0", "1.2.3", "1.2.0", "0.9.0"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v (semver order, not lexical)", got, want)
+		}
+	}
+	// Input must not be mutated.
+	if in[0] != "1.2.0" {
+		t.Errorf("sortVersionsDesc mutated its input: %v", in)
+	}
+}
+
+func TestCapVersions(t *testing.T) {
+	short := []string{"3.0.0", "2.0.0", "1.0.0"}
+	if got := capVersions(short); len(got) != 3 {
+		t.Errorf("short list should pass through, got %d", len(got))
+	}
+
+	many := make([]string, maxAvailableVersions+25)
+	for i := range many {
+		many[i] = "v"
+	}
+	got := capVersions(many)
+	if len(got) != maxAvailableVersions {
+		t.Errorf("capped list = %d, want %d", len(got), maxAvailableVersions)
+	}
+}
+
 // withOCISources points settings at a temp HOME and seeds the registered OCI
 // sources for the duration of the test.
 func withOCISources(t *testing.T, sources []string) {

--- a/internal/helm/types.go
+++ b/internal/helm/types.go
@@ -112,7 +112,14 @@ type UpgradeInfo struct {
 	LatestVersion   string `json:"latestVersion,omitempty"`
 	UpdateAvailable bool   `json:"updateAvailable"`
 	RepositoryName  string `json:"repositoryName,omitempty"`
-	Error           string `json:"error,omitempty"`
+	// SourceType is "repository" for classic HTTP-repo matches and "oci" when the
+	// upgrade was discovered via a registered OCI source. Drives how the frontend
+	// frames the upgrade and the "source not tracked" affordance.
+	SourceType string `json:"sourceType,omitempty"`
+	// ChartRef is the oci:// chart reference an OCI-sourced upgrade lives at
+	// (display only — the upgrade path re-derives it from registered sources).
+	ChartRef string `json:"chartRef,omitempty"`
+	Error    string `json:"error,omitempty"`
 }
 
 // BatchUpgradeInfo contains upgrade info for multiple releases

--- a/internal/helm/types.go
+++ b/internal/helm/types.go
@@ -120,6 +120,12 @@ type UpgradeInfo struct {
 	// (display only — the upgrade path re-derives it from registered sources).
 	ChartRef string `json:"chartRef,omitempty"`
 	Error    string `json:"error,omitempty"`
+	// Untracked marks the specific error state where Radar genuinely can't tell
+	// where the chart comes from — i.e. registering a chart source could fix it.
+	// It is deliberately NOT set for repo-side errors (stale/broken index, classic
+	// ambiguity) so the UI doesn't steer the user to register an OCI source when
+	// the real fix is refreshing or disambiguating repos.
+	Untracked bool `json:"untracked,omitempty"`
 }
 
 // BatchUpgradeInfo contains upgrade info for multiple releases

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -38,6 +38,14 @@ type Settings struct {
 	// Empty slice (or missing key) means no pick is active and reads default
 	// to the user's full RBAC ceiling (typically "All namespaces").
 	ActiveNamespaces map[string][]string `json:"activeNamespaces,omitempty"`
+	// HelmOCISources are registered OCI chart-source prefixes (e.g.
+	// "oci://ghcr.io/myorg/charts") — the OCI analog of `helm repo add`, which
+	// has no native equivalent for OCI registries. Helm doesn't persist the ref
+	// a release was installed from, so these let Radar discover upgrades for the
+	// user's own OCI-published charts by probing "<prefix>/<chartName>". Not
+	// cluster-scoped: a registry is where your charts live, independent of which
+	// cluster they're deployed to.
+	HelmOCISources []string `json:"helmOciSources,omitempty"`
 }
 
 // mu serializes Load-mutate-Save cycles to prevent concurrent PUTs from

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -649,6 +649,11 @@ export interface UpgradeInfo {
   latestVersion?: string
   updateAvailable: boolean
   repositoryName?: string
+  // 'repository' for classic HTTP-repo matches, 'oci' when discovered via a
+  // registered OCI chart source. Absent when the source couldn't be determined.
+  sourceType?: 'repository' | 'oci'
+  // oci:// chart reference an OCI-sourced upgrade lives at (display only).
+  chartRef?: string
   error?: string
 }
 

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -655,6 +655,10 @@ export interface UpgradeInfo {
   // oci:// chart reference an OCI-sourced upgrade lives at (display only).
   chartRef?: string
   error?: string
+  // True only when the error is a genuinely untracked source (registering a
+  // chart source could fix it) — NOT for repo-side errors like a stale index or
+  // classic ambiguity. Gates the "track source" affordance.
+  untracked?: boolean
 }
 
 // Batch upgrade info keyed by "storageNamespace/name".

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2396,6 +2396,19 @@ export function useHelmUpgradeInfo(namespace: string, name: string, enabled = tr
   })
 }
 
+// Available chart versions for a release (newest-first), for the upgrade dialog's
+// version picker. Empty when the source can't be resolved — the dialog then falls
+// back to the latest version from upgrade-info.
+export function useHelmReleaseVersions(namespace: string, name: string, enabled = true) {
+  return useQuery<string[]>({
+    queryKey: ['helm-release-versions', namespace, name],
+    queryFn: () => fetchJSON(`/helm/releases/${namespace}/${name}/versions`),
+    enabled: Boolean(namespace && name && enabled),
+    staleTime: 30000,
+    retry: false,
+  })
+}
+
 // Batch check for upgrade availability (for list view)
 export function useHelmBatchUpgradeInfo(namespaces: string[] = [], enabled = true) {
   const params = helmNamespaceParams(namespaces)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2668,6 +2668,54 @@ export function useUpdateRepositorySilent() {
   })
 }
 
+// Registered OCI chart sources (the OCI analog of `helm repo add`). Used to
+// track upgrades for the user's own OCI-published charts.
+export function useHelmOCISources() {
+  return useQuery<string[]>({
+    queryKey: ['helm-oci-sources'],
+    queryFn: () => fetchJSON('/helm/oci-sources'),
+  })
+}
+
+async function mutateOCISource(method: 'POST' | 'DELETE', source: string): Promise<string[]> {
+  const response = await apiFetch(`${getApiBase()}/helm/oci-sources`, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ source }),
+  })
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Unknown error' }))
+    throw new Error(error.error || `HTTP ${response.status}`)
+  }
+  return response.json()
+}
+
+// Invalidate the upgrade-info queries so a newly-registered source is probed
+// immediately and "source not tracked" re-resolves.
+function invalidateHelmAfterSourceChange(queryClient: ReturnType<typeof useQueryClient>) {
+  queryClient.invalidateQueries({ queryKey: ['helm-oci-sources'] })
+  queryClient.invalidateQueries({ queryKey: ['helm-upgrade-info'] })
+  queryClient.invalidateQueries({ queryKey: ['helm-batch-upgrade-info'] })
+}
+
+export function useAddOCISource() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (source: string) => mutateOCISource('POST', source),
+    meta: { errorMessage: 'Failed to add chart source', successMessage: 'Chart source added' },
+    onSuccess: () => invalidateHelmAfterSourceChange(queryClient),
+  })
+}
+
+export function useRemoveOCISource() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (source: string) => mutateOCISource('DELETE', source),
+    meta: { errorMessage: 'Failed to remove chart source', successMessage: 'Chart source removed' },
+    onSuccess: () => invalidateHelmAfterSourceChange(queryClient),
+  })
+}
+
 // Search charts across all repositories
 export function useSearchCharts(query: string, allVersions = false, enabled = true) {
   return useQuery<ChartSearchResult>({

--- a/web/src/components/helm/HelmReleaseDrawer.tsx
+++ b/web/src/components/helm/HelmReleaseDrawer.tsx
@@ -7,7 +7,7 @@ import { useRefreshAnimation } from '../../hooks/useRefreshAnimation'
 import { X, Copy, Check, RefreshCw, Package, Code, History, FileText, Settings, Link2, Anchor, GitFork, BookOpen, ArrowUpCircle, Trash2, GitBranch } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { clsx } from 'clsx'
-import { useHelmRelease, useHelmManifest, useHelmValues, useHelmManifestDiff, useHelmUpgradeInfo, useHelmUninstall, upgradeWithProgress, rollbackWithProgress } from '../../api/client'
+import { useHelmRelease, useHelmManifest, useHelmValues, useHelmManifestDiff, useHelmUpgradeInfo, useHelmReleaseVersions, useHelmUninstall, upgradeWithProgress, rollbackWithProgress } from '../../api/client'
 import { useQueryClient } from '@tanstack/react-query'
 import { ConfirmDialog } from '../ui/ConfirmDialog'
 import { Tooltip } from '../ui/Tooltip'
@@ -52,6 +52,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
   const [showUninstallConfirm, setShowUninstallConfirm] = useState(false)
   const [showUpgradeConfirm, setShowUpgradeConfirm] = useState(false)
   const [showTrackSource, setShowTrackSource] = useState(false)
+  const [selectedVersion, setSelectedVersion] = useState<string | null>(null)
   const resizeStartX = useRef(0)
   const resizeStartWidth = useRef(DEFAULT_WIDTH)
   const { allowed: canHelmWrite, reason: helmActReason } = useCanHelmAct()
@@ -100,6 +101,16 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
     release.name
   )
   const upgradeErrorMessage = upgradeError instanceof Error ? upgradeError.message : 'Upgrade check failed'
+
+  // Available versions for the upgrade dialog's picker — only fetched while the
+  // confirm dialog is open. Default the selection to latest when it opens.
+  const { data: availableVersions } = useHelmReleaseVersions(helmNamespace, release.name, showUpgradeConfirm)
+  const targetVersion = selectedVersion ?? upgradeInfo?.latestVersion ?? ''
+  const isDowngrade = Boolean(
+    targetVersion && upgradeInfo?.currentVersion &&
+    availableVersions && availableVersions.indexOf(targetVersion) > availableVersions.indexOf(upgradeInfo.currentVersion) &&
+    availableVersions.includes(upgradeInfo.currentVersion)
+  )
 
   // Mutations for actions
   const uninstallMutation = useHelmUninstall()
@@ -236,7 +247,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
   }
 
   const handleUpgradeConfirm = async () => {
-    if (!upgradeInfo?.latestVersion) return
+    if (!targetVersion) return
     setIsUpgrading(true)
     setUpgradeProgress([])
 
@@ -244,8 +255,8 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
       await upgradeWithProgress(
         helmNamespace,
         release.name,
-        upgradeInfo.latestVersion,
-        upgradeInfo.repositoryName,
+        targetVersion,
+        upgradeInfo?.repositoryName,
         (event) => {
           if (event.type === 'progress' && event.message) {
             setUpgradeProgress(prev => [...prev, {
@@ -258,7 +269,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
 
       setUpgradeProgress(prev => [...prev, {
         phase: 'complete',
-        message: `Successfully upgraded to ${upgradeInfo.latestVersion}`,
+        message: `Successfully upgraded to ${targetVersion}`,
       }])
 
       // Invalidate queries
@@ -270,6 +281,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
       setTimeout(() => {
         setShowUpgradeConfirm(false)
         setUpgradeProgress([])
+        setSelectedVersion(null)
         refetch()
         switchTab('resources')
       }, 1500)
@@ -610,6 +622,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
         onClose={() => {
           setShowUpgradeConfirm(false)
           setUpgradeProgress([])
+          setSelectedVersion(null)
           if (isUpgrading) {
             // Upgrade continues server-side — switch to resources tab to monitor
             setIsUpgrading(false)
@@ -618,16 +631,48 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
         }}
         onConfirm={handleUpgradeConfirm}
         title="Upgrade Release"
-        message={`Upgrade "${release.name}" to version ${upgradeInfo?.latestVersion}?`}
+        message={`Upgrade "${release.name}" to version ${targetVersion}?`}
         details={upgradeProgress.length === 0
-          ? `This will upgrade the chart from version ${upgradeInfo?.currentVersion} to ${upgradeInfo?.latestVersion}. Your existing values will be preserved. The upgrade will be applied to your cluster immediately.`
+          ? `The chart will move from version ${upgradeInfo?.currentVersion} to ${targetVersion}. Your existing values will be preserved. The change is applied to your cluster immediately.`
           : undefined
         }
-        confirmLabel="Upgrade"
+        confirmLabel={isDowngrade ? 'Downgrade' : 'Upgrade'}
         variant="warning"
         isLoading={isUpgrading}
         isClosable
       >
+        {upgradeProgress.length === 0 && availableVersions && availableVersions.length > 1 && (
+          <div className="mb-1">
+            <label htmlFor="upgrade-version" className="block text-sm font-medium text-theme-text-secondary mb-1.5">
+              Target version
+            </label>
+            <select
+              id="upgrade-version"
+              value={targetVersion}
+              onChange={(e) => setSelectedVersion(e.target.value)}
+              disabled={isUpgrading}
+              className="w-full px-3 py-2 bg-theme-elevated border border-theme-border-light rounded-lg text-sm text-theme-text-primary focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
+            >
+              {availableVersions.map((v) => (
+                <option key={v} value={v}>
+                  {v}
+                  {v === upgradeInfo?.latestVersion ? ' (latest)' : ''}
+                  {v === upgradeInfo?.currentVersion ? ' (current)' : ''}
+                </option>
+              ))}
+            </select>
+            {isDowngrade && (
+              <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+                This is a downgrade from {upgradeInfo?.currentVersion}.
+              </p>
+            )}
+            {availableVersions.length >= 50 && (
+              <p className="mt-1 text-xs text-theme-text-tertiary">
+                Showing the 50 newest versions. Type to filter.
+              </p>
+            )}
+          </div>
+        )}
         {upgradeProgress.length > 0 && <ProgressLog entries={upgradeProgress} />}
       </ConfirmDialog>
 

--- a/web/src/components/helm/HelmReleaseDrawer.tsx
+++ b/web/src/components/helm/HelmReleaseDrawer.tsx
@@ -23,6 +23,7 @@ import { ManifestViewer } from './ManifestViewer'
 import { ValuesViewer } from './ValuesViewer'
 import { OwnedResources } from './OwnedResources'
 import { ManifestDiffViewer } from './ManifestDiffViewer'
+import { TrackChartSourceDialog } from './TrackChartSourceDialog'
 
 interface HelmReleaseDrawerProps {
   release: SelectedHelmRelease
@@ -50,6 +51,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
   const [rollbackRevision, setRollbackRevision] = useState<number | null>(null)
   const [showUninstallConfirm, setShowUninstallConfirm] = useState(false)
   const [showUpgradeConfirm, setShowUpgradeConfirm] = useState(false)
+  const [showTrackSource, setShowTrackSource] = useState(false)
   const resizeStartX = useRef(0)
   const resizeStartWidth = useRef(DEFAULT_WIDTH)
   const { allowed: canHelmWrite, reason: helmActReason } = useCanHelmAct()
@@ -342,8 +344,18 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
                 upgrade check failed
               </span>
               </Tooltip>
+            ) : upgradeInfo?.updateAvailable && releaseDetail?.managedByFluxHelmRelease ? (
+              // Route-only for GitOps-managed releases: a direct `helm upgrade`
+              // would be reverted at the next reconcile, so surface the available
+              // version as info and point at GitOps rather than offer the upgrade.
+              <Tooltip content={`${upgradeInfo.latestVersion} available — managed by Flux, upgrade via the GitOps view (a direct upgrade would be reverted at the next reconcile).`}>
+              <span className={clsx('badge', SEVERITY_BADGE.warning, 'opacity-90')}>
+                <ArrowUpCircle className="w-3 h-3" />
+                {upgradeInfo.latestVersion}
+              </span>
+              </Tooltip>
             ) : upgradeInfo?.updateAvailable ? (
-              <Tooltip content={canHelmWrite ? `Click to upgrade: ${upgradeInfo.currentVersion} → ${upgradeInfo.latestVersion}${upgradeInfo.repositoryName ? ` (${upgradeInfo.repositoryName})` : ''}` : helmActReason}>
+              <Tooltip content={canHelmWrite ? `Click to upgrade: ${upgradeInfo.currentVersion} → ${upgradeInfo.latestVersion}${upgradeInfo.repositoryName ? ` (${upgradeInfo.repositoryName})` : upgradeInfo.sourceType === 'oci' ? ' (OCI)' : ''}` : helmActReason}>
               <button
                 onClick={() => setShowUpgradeConfirm(true)}
                 disabled={!canHelmWrite}
@@ -363,13 +375,31 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
               </span>
               </Tooltip>
             ) : upgradeInfo?.error ? (
-              <Tooltip content={upgradeInfo.error}>
-              <span
-                className="badge bg-theme-hover/50 text-theme-text-secondary"
-              >
-                upstream unknown
-              </span>
-              </Tooltip>
+              releaseDetail?.managedByFluxHelmRelease ? (
+                // Managed by Flux — the "Managed by Flux" badge routes to GitOps,
+                // where the chart source lives. Don't push a Helm source here.
+                <Tooltip content="Chart source is managed by Flux — track upgrades from the GitOps view.">
+                <span className="badge bg-theme-hover/50 text-theme-text-secondary">
+                  source via GitOps
+                </span>
+                </Tooltip>
+              ) : (
+                // Helm doesn't record the install source. Offer to register one so
+                // Radar can track upgrades for the user's own (e.g. OCI) charts.
+                <Tooltip content={canHelmWrite ? "Radar can't tell where this chart was installed from. Register your chart source to track upgrades." : upgradeInfo.error}>
+                <button
+                  onClick={() => canHelmWrite && setShowTrackSource(true)}
+                  disabled={!canHelmWrite}
+                  className={clsx(
+                    'badge transition-colors disabled:pointer-events-none bg-theme-hover/50 text-theme-text-secondary',
+                    canHelmWrite ? 'hover:bg-theme-hover cursor-pointer' : 'opacity-50 cursor-not-allowed'
+                  )}
+                >
+                  <Link2 className="w-3 h-3" />
+                  source not tracked
+                </button>
+                </Tooltip>
+              )
             ) : null}
           </div>
           <div className="flex items-center gap-1">
@@ -592,6 +622,12 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
       >
         {upgradeProgress.length > 0 && <ProgressLog entries={upgradeProgress} />}
       </ConfirmDialog>
+
+      <TrackChartSourceDialog
+        open={showTrackSource}
+        onClose={() => setShowTrackSource(false)}
+        chartName={releaseDetail?.chart}
+      />
     </div>
   )
 }

--- a/web/src/components/helm/HelmReleaseDrawer.tsx
+++ b/web/src/components/helm/HelmReleaseDrawer.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { flushSync } from 'react-dom'
-import { FetchResult, useDockReservedHeight } from '@skyhook-io/k8s-ui'
+import { FetchResult, useDockReservedHeight, compareVersions } from '@skyhook-io/k8s-ui'
 import { startViewTransitionSafe } from '@skyhook-io/k8s-ui/utils/view-transition'
 import { TRANSITION_DRAWER } from '../../utils/animation'
 import { useRefreshAnimation } from '../../hooks/useRefreshAnimation'
@@ -106,10 +106,11 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
   // confirm dialog is open. Default the selection to latest when it opens.
   const { data: availableVersions } = useHelmReleaseVersions(helmNamespace, release.name, showUpgradeConfirm)
   const targetVersion = selectedVersion ?? upgradeInfo?.latestVersion ?? ''
+  // Semver compare, not list-position: the installed version may be older than
+  // the newest-N versions the picker shows, so it isn't always in the list.
   const isDowngrade = Boolean(
     targetVersion && upgradeInfo?.currentVersion &&
-    availableVersions && availableVersions.indexOf(targetVersion) > availableVersions.indexOf(upgradeInfo.currentVersion) &&
-    availableVersions.includes(upgradeInfo.currentVersion)
+    compareVersions(targetVersion, upgradeInfo.currentVersion) === -1
   )
 
   // Mutations for actions

--- a/web/src/components/helm/HelmReleaseDrawer.tsx
+++ b/web/src/components/helm/HelmReleaseDrawer.tsx
@@ -383,7 +383,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
                   source via GitOps
                 </span>
                 </Tooltip>
-              ) : (
+              ) : upgradeInfo.untracked ? (
                 // Helm doesn't record the install source. Offer to register one so
                 // Radar can track upgrades for the user's own (e.g. OCI) charts.
                 <Tooltip content={canHelmWrite ? "Radar can't tell where this chart was installed from. Register your chart source to track upgrades." : upgradeInfo.error}>
@@ -398,6 +398,14 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
                   <Link2 className="w-3 h-3" />
                   source not tracked
                 </button>
+                </Tooltip>
+              ) : (
+                // Repo-side error (stale/broken index, classic ambiguity) — not an
+                // OCI tracking issue, so surface it without steering to registration.
+                <Tooltip content={upgradeInfo.error}>
+                <span className="badge bg-theme-hover/50 text-theme-text-secondary">
+                  upgrade source unresolved
+                </span>
                 </Tooltip>
               )
             ) : null}

--- a/web/src/components/helm/TrackChartSourceDialog.tsx
+++ b/web/src/components/helm/TrackChartSourceDialog.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react'
+import { DialogPortal } from '@skyhook-io/k8s-ui/components/ui/DialogPortal'
+import { X, Plus, Trash2, Link2 } from 'lucide-react'
+import { clsx } from 'clsx'
+import { useHelmOCISources, useAddOCISource, useRemoveOCISource } from '../../api/client'
+
+interface TrackChartSourceDialogProps {
+  open: boolean
+  onClose: () => void
+  /** Chart name of the release this was opened from, for the example prompt. */
+  chartName?: string
+}
+
+// TrackChartSourceDialog lets the user register an OCI chart-source prefix — the
+// OCI analog of `helm repo add`. Helm doesn't persist the ref a release was
+// installed from, so for charts published to an OCI registry (and not managed by
+// GitOps) Radar can only track upgrades once the user declares where they live.
+// Registering a registry/org prefix lets Radar probe "<prefix>/<chartName>".
+export function TrackChartSourceDialog({ open, onClose, chartName }: TrackChartSourceDialogProps) {
+  const [value, setValue] = useState('')
+  const { data: sources } = useHelmOCISources()
+  const addSource = useAddOCISource()
+  const removeSource = useRemoveOCISource()
+
+  const trimmed = value.trim()
+  const invalid = trimmed !== '' && !trimmed.startsWith('oci://')
+
+  const handleAdd = () => {
+    if (!trimmed || invalid) return
+    addSource.mutate(trimmed, { onSuccess: () => setValue('') })
+  }
+
+  return (
+    <DialogPortal open={open} onClose={onClose} className="max-w-lg w-full">
+      <div className="flex items-start gap-3 p-4 border-b border-theme-border">
+        <div className="flex items-center justify-center w-10 h-10 rounded-full shrink-0 bg-theme-hover">
+          <Link2 className="w-5 h-5 text-theme-text-secondary" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="text-lg font-semibold text-theme-text-primary">Track chart source</h3>
+          <p className="text-sm text-theme-text-secondary mt-1">
+            Helm doesn&apos;t record where a chart was installed from. Register your OCI
+            registry prefix and Radar will check it for newer versions of your charts.
+          </p>
+        </div>
+        <button
+          onClick={onClose}
+          className="p-1 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
+        >
+          <X className="w-5 h-5" />
+        </button>
+      </div>
+
+      <div className="p-4 space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-theme-text-secondary mb-2">
+            OCI registry prefix
+          </label>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleAdd()}
+              placeholder="oci://ghcr.io/myorg/charts"
+              aria-invalid={invalid ? true : undefined}
+              className={clsx(
+                'flex-1 px-3 py-2 bg-theme-elevated border rounded-lg text-sm text-theme-text-primary placeholder-theme-text-disabled focus:outline-none focus:ring-2',
+                invalid ? 'border-red-500/60 focus:ring-red-500' : 'border-theme-border-light focus:ring-accent',
+              )}
+            />
+            <button
+              onClick={handleAdd}
+              disabled={!trimmed || invalid || addSource.isPending}
+              className="btn-brand px-3 py-2 text-sm inline-flex items-center gap-1 disabled:opacity-50 disabled:pointer-events-none"
+            >
+              <Plus className="w-4 h-4" />
+              Add
+            </button>
+          </div>
+          <p className="mt-1 text-xs text-theme-text-tertiary">
+            {invalid
+              ? 'Must be an oci:// reference.'
+              : chartName
+                ? `Radar will look for "${chartName}" under this prefix (and any others below).`
+                : 'Radar probes <prefix>/<chartName> for each untracked release.'}
+          </p>
+        </div>
+
+        {sources && sources.length > 0 && (
+          <div>
+            <p className="text-xs font-medium text-theme-text-tertiary uppercase tracking-wide mb-2">
+              Registered sources
+            </p>
+            <ul className="space-y-1">
+              {sources.map((src) => (
+                <li
+                  key={src}
+                  className="flex items-center justify-between gap-2 px-3 py-2 bg-theme-elevated rounded-lg"
+                >
+                  <span className="text-sm text-theme-text-primary font-mono truncate">{src}</span>
+                  <button
+                    onClick={() => removeSource.mutate(src)}
+                    disabled={removeSource.isPending}
+                    className="p-1 text-theme-text-secondary hover:text-red-400 hover:bg-red-500/10 rounded disabled:opacity-50"
+                    aria-label={`Remove ${src}`}
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <p className="text-xs text-theme-text-tertiary">
+          Credentials are reused from your <span className="font-mono">helm registry login</span>.
+          Radar stores no registry secrets.
+        </p>
+      </div>
+    </DialogPortal>
+  )
+}

--- a/web/src/components/helm/TrackChartSourceDialog.tsx
+++ b/web/src/components/helm/TrackChartSourceDialog.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react'
 import { DialogPortal } from '@skyhook-io/k8s-ui/components/ui/DialogPortal'
-import { X, Plus, Trash2, Link2 } from 'lucide-react'
+import { X, Plus, Trash2, Link2, AlertTriangle } from 'lucide-react'
 import { clsx } from 'clsx'
-import { useHelmOCISources, useAddOCISource, useRemoveOCISource } from '../../api/client'
+import { useHelmOCISources, useAddOCISource, useRemoveOCISource, useClusterInfo } from '../../api/client'
 
 interface TrackChartSourceDialogProps {
   open: boolean
@@ -19,8 +19,14 @@ interface TrackChartSourceDialogProps {
 export function TrackChartSourceDialog({ open, onClose, chartName }: TrackChartSourceDialogProps) {
   const [value, setValue] = useState('')
   const { data: sources } = useHelmOCISources()
+  const { data: clusterInfo } = useClusterInfo()
   const addSource = useAddOCISource()
   const removeSource = useRemoveOCISource()
+
+  // In-cluster Radar has no `helm registry login` store (the pod's HELM_CONFIG_HOME
+  // points at an empty /tmp), so private registries can't authenticate — only
+  // public charts can be tracked. Be honest about it rather than silently failing.
+  const inCluster = clusterInfo?.inCluster ?? false
 
   const trimmed = value.trim()
   const invalid = trimmed !== '' && !trimmed.startsWith('oci://')
@@ -113,10 +119,22 @@ export function TrackChartSourceDialog({ open, onClose, chartName }: TrackChartS
           </div>
         )}
 
-        <p className="text-xs text-theme-text-tertiary">
-          Credentials are reused from your <span className="font-mono">helm registry login</span>.
-          Radar stores no registry secrets.
-        </p>
+        {inCluster ? (
+          <div className="flex items-start gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+            <AlertTriangle className="w-4 h-4 shrink-0 mt-px" />
+            <span>
+              Radar is running in-cluster, where it has no{' '}
+              <span className="font-mono">helm registry login</span> credentials — only{' '}
+              <strong>public</strong> charts can be tracked. Private-registry support for in-cluster
+              Radar isn&apos;t available yet.
+            </span>
+          </div>
+        ) : (
+          <p className="text-xs text-theme-text-tertiary">
+            Credentials are reused from your <span className="font-mono">helm registry login</span>.
+            Radar stores no registry secrets.
+          </p>
+        )}
       </div>
     </DialogPortal>
   )


### PR DESCRIPTION
## Problem

When a Helm release shows **"upstream unknown"**, Radar offers no way to upgrade it. This blocks the common modern case of upgrading your **own** charts: `helm install oci://ghcr.io/myorg/charts/mychart` from CI.

Two root causes:
1. **Helm doesn't persist install provenance** (still true in **v4** — verified) — a release knows only its chart name/version, not the repo/OCI ref it came from. Radar reverse-infers the source by scanning configured repos' cached `index.yaml`; "upstream unknown" = inference found nothing. Upstream tracking exists only as a *draft* proposal — [HIP-0018](https://helm.sh/community/hips/hip-0018/) (`repoURL` + tarball digest in release metadata), unshipped as of Helm 4 ([#4256](https://github.com/helm/helm/issues/4256), [#6464](https://github.com/helm/helm/issues/6464)). If/when it lands, Radar can read `repoURL` directly and surface it through the existing `sourceType` field — so this design is forward-compatible.
2. **OCI has no `helm repo add`** — classic repos live in `repositories.yaml`, but `helm registry login` stores only *auth*, so there's no "configured source list" for OCI to match against.

## What this does

Adds **registered OCI chart sources** — the OCI analog of `helm repo add`. You declare a registry/org prefix once (`oci://ghcr.io/myorg/charts`); Radar probes `<prefix>/<chartName>` for each untracked release, discovers newer versions via the Helm registry client, and lights up the **existing** update-available badge + upgrade flow. Matching is by chart name at query time, so **nothing per-release is persisted** and prefixes are global to the Radar instance (not cluster-scoped).

Also:
- Reframes the dead-end **"upstream unknown"** chip as a neutral, actionable **"source not tracked"** affordance that opens a *Track chart source* dialog.
- **GitOps-managed (Flux) releases** show "source via GitOps" / a non-clickable version and route to the GitOps view instead of offering a direct `helm upgrade` that would be reverted at the next reconcile.
- **Upgrades now use `--reset-then-reuse-values`** (was `--reuse-values`). Since the version picker lets users jump across chart versions, plain reuse-values is a footgun — it keeps the old merged values and renders nil for keys a newer chart added (verified: podinfo 6.3→6.14 fails on `.Values.hooks`). Reset-then-reuse resets to the new chart's defaults then re-merges the user's overrides on top — preserving customizations while picking up new keys. Applies to all Helm upgrades (classic + OCI).

## Security model — configured-only

- The server only ever probes **user-registered** prefixes. The upgrade path **re-derives** the `oci://` ref from a registered prefix — it never trusts a client-supplied ref.
- Credentials reuse the user's existing `helm registry login` store; **Radar stores no registry secrets**.
- Registry requests are bounded by an `http.Client` timeout (an unreachable registry can't stall the list view).
- Link-local / cloud-metadata literal IPs are rejected at registration.
- Pulled chart name is validated against the release's chart (no silent chart-swap).

OCI fallback runs **only on genuine classic-repo absence**, never on classic *ambiguity*, and surfaces classic index-load errors **before** falling back — so it can't mask or override a release that actually came from a classic repo.

## Test plan

- [x] `go build ./...`, `go vet`, full `go test ./...` green
- [x] New unit tests: prefix normalization (incl. link-local rejection, loopback/private allowed), discovery selection across prefixes, tag-cache dedupe, `applyOCIUpgrade` field-setting, newest-version selection
- [x] `make tsc` green
- [x] **On-cluster visual-test** (kind + real OCI registry, `podinfo` via `oci://ghcr.io/stefanprodan/charts`): full flow — source-not-tracked → register prefix → OCI discovery → version picker → **real applied upgrade/downgrade** pulled from the registry. Screenshots in the comment below.

## Open / deferred (see NOTES.md)

- ⚠️ **SSRF posture (needs a product call):** only link-local/metadata *literal* IPs are blocked; loopback/RFC1918 are allowed so local dev registries (`localhost:5000`) work, and a DNS name resolving into private ranges is **not** blocked. Full private-range + DNS-resolution blocking is hosted-mode hardening that would break local registries — deferred deliberately, flagged for review.
- Per-release source pin (for OCI charts that don't follow a consistent prefix); hosted-mode credential storage — both per the signed-off plan.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds server-initiated registry probes and OCI upgrade execution with partial SSRF guards; mistakes in classic-vs-OCI fallback logic could mislabel sources or pull from the wrong registry.
> 
> **Overview**
> Adds **registered OCI chart sources** (persisted in settings, exposed via list/add/remove APIs) so Radar can discover upgrades for charts installed from `oci://` when classic `repositories.yaml` has no match. Upgrade checks, batch list enrichment, and chart resolution now **fall through to OCI** only when classic repos are genuinely absent—not when indexes fail or classic sources are ambiguous—and surface **`untracked`**, **`sourceType`**, and **`chartRef`** on `UpgradeInfo` for the UI.
> 
> **Upgrade path:** OCI pulls use the user's `helm registry login` credentials with bounded HTTP timeouts; upgrades resolve `oci://` refs server-side from registered prefixes, validate chart name before apply, and share tag caching across batch checks.
> 
> **Version picker:** New `/versions` endpoint returns newest-first semver lists (capped at 50) from the matched classic repo or OCI prefix; the release drawer upgrade dialog lets users pick a target version and labels downgrades.
> 
> **UI:** Replaces the dead-end "upstream unknown" chip with **source not tracked** (opens `TrackChartSourceDialog`), distinguishes repo errors vs untracked sources, and routes Flux-managed releases away from direct `helm upgrade`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02d499b5e84453082a15b3033d8b856e21b234fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


