### PR TITLE
fix(health): stop classifying benign/lifecycle states as degraded/unhealthy

### DIFF
--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -394,7 +394,7 @@ func recordToTimelineStore(kind, namespace, name, uid, op string, oldObj, newObj
 
 	owner := timeline.ExtractOwner(obj)
 	labels := timeline.ExtractLabels(obj)
-	healthState := timeline.DetermineHealthState(kind, obj)
+	healthState := classifyTimelineHealth(kind, obj, time.Now())
 	apiVersion := extractAPIVersion(obj)
 
 	var createdAt *time.Time

--- a/internal/k8s/detect.go
+++ b/internal/k8s/detect.go
@@ -565,6 +565,12 @@ func DetectProblems(cache *ResourceCache, namespace string) []Detection {
 				if scaledToZeroBackingWorkload(cache, svc) {
 					reason = "Backing workload scaled to 0"
 					message = "selector matches a Deployment/StatefulSet that is intentionally scaled to 0 replicas"
+				} else if selectorMatchesSucceededPod(svc, podsByNamespace[svc.Namespace]) {
+					// The selector DOES match pods — they're just completed Job pods,
+					// which aren't routable endpoints. "matches no pods" would be a
+					// false lead for an operator who can see them with kubectl.
+					reason = "Selector matches only completed pods"
+					message = "selector matches finished Job pods, which are not routable endpoints"
 				}
 				problems = append(problems, Detection{
 					Kind:            "Service",
@@ -1678,11 +1684,37 @@ func podsMatchingService(svc *corev1.Service, pods []*corev1.Pod) []*corev1.Pod 
 	selector := labels.SelectorFromSet(labels.Set(svc.Spec.Selector))
 	out := make([]*corev1.Pod, 0, len(pods))
 	for _, pod := range pods {
+		// Succeeded pods are never endpoints — Kubernetes excludes them from
+		// EndpointSlices. A Service whose selector happens to overlap completed
+		// Job pods (common when a chart shares app labels) must not be counted as
+		// "0/N ready" because of those benign, finished pods. Failed pods are
+		// deliberately kept: a Service backed only by Failed pods is a real
+		// no-ready-endpoints outage, not a benign empty selector.
+		if pod.Status.Phase == corev1.PodSucceeded {
+			continue
+		}
 		if selector.Matches(labels.Set(pod.Labels)) {
 			out = append(out, pod)
 		}
 	}
 	return out
+}
+
+// selectorMatchesSucceededPod reports whether the Service's selector matches at
+// least one Succeeded pod. Used only on the zero-live-endpoints branch to tell a
+// genuinely-orphaned selector from one matching only completed Job pods, so the
+// message stays accurate.
+func selectorMatchesSucceededPod(svc *corev1.Service, pods []*corev1.Pod) bool {
+	if svc == nil || len(svc.Spec.Selector) == 0 {
+		return false
+	}
+	selector := labels.SelectorFromSet(labels.Set(svc.Spec.Selector))
+	for _, pod := range pods {
+		if pod.Status.Phase == corev1.PodSucceeded && selector.Matches(labels.Set(pod.Labels)) {
+			return true
+		}
+	}
+	return false
 }
 
 // scaledToZeroBackingWorkload reports whether the Service's selector matches a

--- a/internal/k8s/detect_gitops_test.go
+++ b/internal/k8s/detect_gitops_test.go
@@ -551,35 +551,6 @@ func TestDetectArgoAppProblems_EmptyOpMessagePrefersCondition(t *testing.T) {
 	}
 }
 
-func TestEstimateCronMinInterval(t *testing.T) {
-	day := 24 * time.Hour
-	cases := []struct {
-		schedule string
-		wantOK   bool
-		atLeast  time.Duration // returned interval must be >= this
-	}{
-		{"*/5 * * * *", true, time.Hour}, // every 5 min → intra-day floor
-		{"0 * * * *", true, time.Hour},   // hourly (minute 0, every hour) → intra-day floor
-		{"0 0 * * *", true, day},         // daily
-		{"0 0 * * 1", true, 7 * day},     // weekly
-		{"0 0 1 * *", true, 28 * day},    // monthly (specific dom)
-		{"0 0 1 */4 *", true, 28 * day},  // quarterly (constrained month) — the hubble FP
-		{"@daily", true, day},            //
-		{"@weekly", true, 7 * day},       //
-		{"not a schedule", false, 0},     //
-	}
-	for _, c := range cases {
-		got, ok := estimateCronMinInterval(c.schedule)
-		if ok != c.wantOK {
-			t.Errorf("%q: ok=%v want %v", c.schedule, ok, c.wantOK)
-			continue
-		}
-		if ok && got < c.atLeast {
-			t.Errorf("%q: interval=%s, want >= %s", c.schedule, got, c.atLeast)
-		}
-	}
-}
-
 func TestDetectCronJobProblems_CadenceAware(t *testing.T) {
 	now := time.Now()
 	mk := func(name, schedule string, lastRunAgo time.Duration) *batchv1.CronJob {

--- a/internal/k8s/detect_test.go
+++ b/internal/k8s/detect_test.go
@@ -910,6 +910,48 @@ func TestDetectProblems_OperationalSignals(t *testing.T) {
 	assertProblem(t, problems, "Job", "migrate", "BackoffLimitExceeded", "critical")
 }
 
+func TestPodsMatchingServiceExcludesSucceededPods(t *testing.T) {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker", Namespace: "prod"},
+		Spec:       corev1.ServiceSpec{Selector: map[string]string{"app": "worker"}},
+	}
+	mkPod := func(name string, phase corev1.PodPhase) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "prod", Labels: map[string]string{"app": "worker"}},
+			Status:     corev1.PodStatus{Phase: phase},
+		}
+	}
+
+	// Succeeded (completed Job) pods are excluded; Failed pods are kept so a
+	// Service backed only by failed pods still reads as a real outage.
+	matched := podsMatchingService(svc, []*corev1.Pod{
+		mkPod("done", corev1.PodSucceeded),
+		mkPod("crashed", corev1.PodFailed),
+		mkPod("serving", corev1.PodRunning),
+	})
+	gotNames := map[string]bool{}
+	for _, p := range matched {
+		gotNames[p.Name] = true
+	}
+	if len(matched) != 2 || !gotNames["serving"] || !gotNames["crashed"] {
+		t.Fatalf("expected serving+crashed to match (Succeeded excluded), got %d: %+v", len(matched), matched)
+	}
+
+	// A Service backed solely by a completed Job pod must select no endpoints.
+	if got := podsMatchingService(svc, []*corev1.Pod{mkPod("done", corev1.PodSucceeded)}); len(got) != 0 {
+		t.Fatalf("Service matching only a completed Job pod should select no endpoints, got %d", len(got))
+	}
+
+	// ...but the selector DID match a completed pod, so the zero-endpoint message
+	// can say so instead of the false "matches no pods".
+	if !selectorMatchesSucceededPod(svc, []*corev1.Pod{mkPod("done", corev1.PodSucceeded)}) {
+		t.Fatal("selectorMatchesSucceededPod should detect a matching completed pod")
+	}
+	if selectorMatchesSucceededPod(svc, []*corev1.Pod{mkPod("serving", corev1.PodRunning)}) {
+		t.Fatal("selectorMatchesSucceededPod should be false when matches are not Succeeded")
+	}
+}
+
 func TestImagePullDiagnosis(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/internal/k8s/detect_workload.go
+++ b/internal/k8s/detect_workload.go
@@ -2,12 +2,12 @@ package k8s
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
 
+	"github.com/skyhook-io/radar/pkg/cronsched"
 	"github.com/skyhook-io/radar/pkg/hpadiag"
 )
 
@@ -99,51 +99,6 @@ type CronJobProblem struct {
 	Reason    string
 }
 
-// estimateCronMinInterval returns a coarse lower bound on the time between runs
-// of a standard 5-field cron schedule (minute hour dom month dow), plus the
-// common @-macros. It is deliberately approximate — its only job is to keep
-// DetectCronJobProblems from flagging a rare-cadence job (weekly / monthly /
-// quarterly) as "stale" against a flat daily threshold. ok=false for schedules
-// it can't parse; the caller then falls back to the flat threshold.
-func estimateCronMinInterval(schedule string) (time.Duration, bool) {
-	const day = 24 * time.Hour
-	s := strings.TrimSpace(schedule)
-	switch s {
-	case "@yearly", "@annually":
-		return 365 * day, true
-	case "@monthly":
-		return 28 * day, true
-	case "@weekly":
-		return 7 * day, true
-	case "@daily", "@midnight":
-		return day, true
-	case "@hourly":
-		return time.Hour, true
-	}
-	fields := strings.Fields(s)
-	if len(fields) != 5 {
-		return 0, false
-	}
-	hour, dom, month, dow := fields[1], fields[2], fields[3], fields[4]
-	switch {
-	case month != "*":
-		// Constrained to certain months → at most monthly, often far less.
-		return 28 * day, true
-	case dom != "*":
-		// Specific day(s)-of-month → monthly cadence.
-		return 28 * day, true
-	case dow != "*":
-		// Specific day(s)-of-week → weekly is the conservative lower bound.
-		return 7 * day, true
-	case hour != "*" && !strings.HasPrefix(hour, "*/"):
-		// Specific hour(s) each day → daily.
-		return day, true
-	default:
-		// Intra-day cadence (every minute / */n minutes or hours).
-		return time.Hour, true
-	}
-}
-
 // DetectCronJobProblems finds non-suspended CronJobs that haven't run recently.
 func DetectCronJobProblems(cronjobs []*batchv1.CronJob) []CronJobProblem {
 	var problems []CronJobProblem
@@ -152,15 +107,7 @@ func DetectCronJobProblems(cronjobs []*batchv1.CronJob) []CronJobProblem {
 		if cj.Spec.Suspend != nil && *cj.Spec.Suspend {
 			continue
 		}
-		// Staleness is relative to the schedule's cadence, not a flat day: a
-		// quarterly job that ran on schedule 29 days ago is healthy, not stale.
-		// Floor at 24h so frequent jobs keep the original sensitivity.
-		threshold := 24 * time.Hour
-		if interval, ok := estimateCronMinInterval(cj.Spec.Schedule); ok {
-			if grace := interval + interval/2; grace > threshold {
-				threshold = grace
-			}
-		}
+		threshold := cronsched.StaleThreshold(cj.Spec.Schedule)
 		if cj.Status.LastScheduleTime != nil {
 			sinceLast := now.Sub(cj.Status.LastScheduleTime.Time)
 			if sinceLast > threshold {

--- a/internal/k8s/timeline_health.go
+++ b/internal/k8s/timeline_health.go
@@ -1,0 +1,99 @@
+package k8s
+
+import (
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/skyhook-io/radar/internal/timeline"
+)
+
+// classifyTimelineHealth maps a changed resource to the timeline HealthState
+// using the SAME canonical classifiers the Problems panel and dashboards use
+// (ClassifyPodHealth for Pods), instead of a separate copy. The timeline package
+// can't reach this logic across the module boundary, so the caller — here, in
+// internal/k8s alongside ClassifyPodHealth — owns the classification and the
+// timeline just stores the result. This is what keeps a normally-completing Job
+// pod (phase Succeeded, or Ready False mid-termination) from being recorded as
+// degraded/Unhealthy the way the old naive duplicate did.
+func classifyTimelineHealth(kind string, obj any, now time.Time) timeline.HealthState {
+	switch kind {
+	case "Pod":
+		if pod, ok := obj.(*corev1.Pod); ok {
+			// The scheduler tried and failed to place this pod — the scheduling
+			// detector flags it immediately (no age grace), so the timeline must
+			// too, instead of treating a young Pending pod as healthy.
+			if IsPodUnschedulable(pod) {
+				return timeline.HealthDegraded
+			}
+			// A pod wedged in termination is a problem the badge + terminating
+			// detector flag (10m threshold); the timeline must agree so it doesn't
+			// stay in the Unhealthy filter's blind spot. ClassifyPodHealth doesn't
+			// look at deletionTimestamp, so check it here.
+			if dt := pod.DeletionTimestamp; dt != nil && now.Sub(dt.Time) > 10*time.Minute {
+				return timeline.HealthDegraded
+			}
+			return podHealthToTimeline(ClassifyPodHealth(pod, now))
+		}
+	case "Deployment":
+		if dep, ok := obj.(*appsv1.Deployment); ok {
+			return workloadReplicaHealth(specReplicas(dep.Spec.Replicas), dep.Status.ReadyReplicas, dep.Status.AvailableReplicas, true)
+		}
+	case "ReplicaSet":
+		if rs, ok := obj.(*appsv1.ReplicaSet); ok {
+			return workloadReplicaHealth(specReplicas(rs.Spec.Replicas), rs.Status.ReadyReplicas, 0, false)
+		}
+	case "StatefulSet":
+		if sts, ok := obj.(*appsv1.StatefulSet); ok {
+			return workloadReplicaHealth(specReplicas(sts.Spec.Replicas), sts.Status.ReadyReplicas, 0, false)
+		}
+	case "DaemonSet":
+		if ds, ok := obj.(*appsv1.DaemonSet); ok {
+			// A DaemonSet whose selector matches no nodes has DesiredNumberScheduled
+			// 0 — benign (nothing to run), not unhealthy.
+			return workloadReplicaHealth(ds.Status.DesiredNumberScheduled, ds.Status.NumberReady, 0, false)
+		}
+	}
+	return timeline.HealthUnknown
+}
+
+// podHealthToTimeline maps ClassifyPodHealth's vocabulary (healthy/warning/error)
+// onto the timeline HealthState vocabulary (healthy/degraded/unhealthy).
+func podHealthToTimeline(h string) timeline.HealthState {
+	switch h {
+	case "healthy":
+		return timeline.HealthHealthy
+	case "warning":
+		return timeline.HealthDegraded
+	case "error":
+		return timeline.HealthUnhealthy
+	default:
+		return timeline.HealthUnknown
+	}
+}
+
+// workloadReplicaHealth grades a replica-based workload. desired 0 is an
+// intentional scale-to-zero (healthy, not unhealthy); full readiness is healthy;
+// some-but-not-all ready is degraded; none ready with replicas wanted is
+// unhealthy. requireAvailable additionally demands available==desired (Deployment
+// tracks availability; ReplicaSet/StatefulSet/DaemonSet don't expose it the same).
+func workloadReplicaHealth(desired, ready, available int32, requireAvailable bool) timeline.HealthState {
+	if desired == 0 {
+		return timeline.HealthHealthy
+	}
+	if ready == desired && (!requireAvailable || available == desired) {
+		return timeline.HealthHealthy
+	}
+	if ready > 0 {
+		return timeline.HealthDegraded
+	}
+	return timeline.HealthUnhealthy
+}
+
+func specReplicas(r *int32) int32 {
+	if r != nil {
+		return *r
+	}
+	return 1
+}

--- a/internal/k8s/timeline_health_test.go
+++ b/internal/k8s/timeline_health_test.go
@@ -1,0 +1,138 @@
+package k8s
+
+import (
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/skyhook-io/radar/internal/timeline"
+)
+
+func TestClassifyTimelineHealthPod(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name string
+		pod  *corev1.Pod
+		want timeline.HealthState
+	}{
+		{
+			name: "succeeded pod is healthy",
+			pod:  &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodSucceeded}},
+			want: timeline.HealthHealthy,
+		},
+		{
+			// The reported bug: a Job pod completing — phase still Running, container
+			// Terminated exit 0, Ready flipped False — must NOT read as degraded.
+			name: "completing pod (terminated exit 0, ready false) is healthy",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{{
+						Name:  "main",
+						Ready: false,
+						State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Completed", ExitCode: 0}},
+					}},
+				},
+			},
+			want: timeline.HealthHealthy,
+		},
+		{
+			name: "failed pod is unhealthy",
+			pod:  &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodFailed}},
+			want: timeline.HealthUnhealthy,
+		},
+		{
+			// Unschedulable is flagged immediately (no young-Pending grace) so the
+			// timeline doesn't miss what the scheduling detector already surfaces.
+			name: "unschedulable pending pod is degraded",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase:      corev1.PodPending,
+				Conditions: []corev1.PodCondition{{Type: corev1.PodScheduled, Status: corev1.ConditionFalse, Reason: corev1.PodReasonUnschedulable}},
+			}},
+			want: timeline.HealthDegraded,
+		},
+		{
+			name: "stuck-terminating pod is degraded",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &metav1.Time{Time: now.Add(-11 * time.Minute)}},
+				Status: corev1.PodStatus{
+					Phase:             corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{{Name: "main", Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}}},
+				},
+			},
+			want: timeline.HealthDegraded,
+		},
+		{
+			name: "running and ready is healthy",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase:             corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{{Name: "main", Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}}},
+			}},
+			want: timeline.HealthHealthy,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyTimelineHealth("Pod", tc.pod, now); got != tc.want {
+				t.Errorf("classifyTimelineHealth = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyTimelineHealthWorkloads(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name string
+		kind string
+		obj  any
+		want timeline.HealthState
+	}{
+		{
+			name: "deployment scaled to zero is healthy",
+			kind: "Deployment",
+			obj:  &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Replicas: ptr32(0)}},
+			want: timeline.HealthHealthy,
+		},
+		{
+			name: "daemonset matching no nodes (0/0) is healthy",
+			kind: "DaemonSet",
+			obj:  &appsv1.DaemonSet{Status: appsv1.DaemonSetStatus{DesiredNumberScheduled: 0, NumberReady: 0}},
+			want: timeline.HealthHealthy,
+		},
+		{
+			name: "deployment fully ready is healthy",
+			kind: "Deployment",
+			obj:  &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Replicas: ptr32(2)}, Status: appsv1.DeploymentStatus{ReadyReplicas: 2, AvailableReplicas: 2}},
+			want: timeline.HealthHealthy,
+		},
+		{
+			name: "deployment partially ready is degraded",
+			kind: "Deployment",
+			obj:  &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Replicas: ptr32(2)}, Status: appsv1.DeploymentStatus{ReadyReplicas: 1, AvailableReplicas: 1}},
+			want: timeline.HealthDegraded,
+		},
+		{
+			name: "deployment none ready is unhealthy",
+			kind: "Deployment",
+			obj:  &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Replicas: ptr32(2)}, Status: appsv1.DeploymentStatus{ReadyReplicas: 0}},
+			want: timeline.HealthUnhealthy,
+		},
+		{
+			name: "unknown kind is unknown",
+			kind: "ConfigMap",
+			obj:  &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "x"}},
+			want: timeline.HealthUnknown,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyTimelineHealth(tc.kind, tc.obj, now); got != tc.want {
+				t.Errorf("classifyTimelineHealth(%s) = %q, want %q", tc.kind, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/timeline/manager.go
+++ b/internal/timeline/manager.go
@@ -100,9 +100,6 @@ func NewHistoricalEvent(kind, apiVersion, namespace, name string, ts time.Time, 
 }
 func ExtractOwner(obj any) *OwnerInfo         { return pkgtimeline.ExtractOwner(obj) }
 func ExtractLabels(obj any) map[string]string { return pkgtimeline.ExtractLabels(obj) }
-func DetermineHealthState(kind string, obj any) HealthState {
-	return pkgtimeline.DetermineHealthState(kind, obj)
-}
 func OperationToEventType(op string) EventType  { return pkgtimeline.OperationToEventType(op) }
 func EventTypeToOperation(et EventType) string  { return pkgtimeline.EventTypeToOperation(et) }
 func HealthStateToString(hs HealthState) string { return pkgtimeline.HealthStateToString(hs) }

--- a/packages/k8s-ui/src/components/resources/get-pod-phase-display.test.ts
+++ b/packages/k8s-ui/src/components/resources/get-pod-phase-display.test.ts
@@ -1,5 +1,32 @@
 import { describe, it, expect } from 'vitest'
-import { getPodPhaseDisplay } from './resource-utils'
+import { getPodPhaseDisplay, getPodStatus } from './resource-utils'
+
+describe('getPodStatus', () => {
+  it('keeps a Succeeded pod neutral despite a sidecar that OOMed before completion', () => {
+    const succeededWithOomedSidecar = {
+      status: {
+        phase: 'Succeeded',
+        containerStatuses: [
+          { name: 'main', ready: false, state: { terminated: { reason: 'Completed', exitCode: 0 } } },
+          { name: 'sidecar', ready: false, state: { terminated: { reason: 'OOMKilled', exitCode: 137 } } },
+        ],
+      },
+    }
+    const r = getPodStatus(succeededWithOomedSidecar)
+    expect(r.text).toBe('Completed')
+    expect(r.level).toBe('neutral')
+  })
+
+  it('still flags a crash-looping (non-terminal) pod as unhealthy', () => {
+    const crashing = {
+      status: {
+        phase: 'Running',
+        containerStatuses: [{ name: 'app', ready: false, state: { waiting: { reason: 'CrashLoopBackOff' } } }],
+      },
+    }
+    expect(getPodStatus(crashing).level).toBe('unhealthy')
+  })
+})
 
 const podRunningHealthy = {
   status: {
@@ -192,10 +219,57 @@ describe('getPodPhaseDisplay', () => {
     expect(r.level).toBe('unhealthy')
   })
 
-  it('marks pods with deletionTimestamp as Terminating regardless of phase', () => {
+  it('marks a long-terminating pod as Terminating + degraded (stuck shutdown)', () => {
     const r = getPodPhaseDisplay(podTerminating)
     expect(r.text).toBe('Running — Terminating')
     expect(r.level).toBe('degraded')
+  })
+
+  it('keeps a recently-terminating pod neutral (graceful shutdown in progress)', () => {
+    const recent = {
+      metadata: { deletionTimestamp: new Date(Date.now() - 30 * 1000).toISOString() },
+      status: { phase: 'Running', containerStatuses: [{ name: 'app', ready: true, restartCount: 0 }] },
+    }
+    const r = getPodPhaseDisplay(recent)
+    expect(r.text).toBe('Running — Terminating')
+    expect(r.level).toBe('neutral')
+  })
+
+  it('treats a completing pod (container exited 0, not ready) as healthy', () => {
+    const completing = {
+      status: {
+        phase: 'Running',
+        containerStatuses: [
+          { name: 'app', ready: false, restartCount: 0, state: { terminated: { reason: 'Completed', exitCode: 0 } } },
+        ],
+      },
+    }
+    const r = getPodPhaseDisplay(completing)
+    expect(r.text).toBe('Running')
+    expect(r.level).toBe('healthy')
+  })
+
+  it('keeps a Failed pod unhealthy even while it is terminating', () => {
+    const failedTerminating = {
+      metadata: { deletionTimestamp: new Date().toISOString() },
+      status: { phase: 'Failed' },
+    }
+    const r = getPodPhaseDisplay(failedTerminating)
+    expect(r.text).toBe('Failed')
+    expect(r.level).toBe('unhealthy')
+  })
+
+  it('surfaces a fatal container failure even while the pod is terminating', () => {
+    const terminatingCrash = {
+      metadata: { deletionTimestamp: new Date().toISOString() },
+      status: {
+        phase: 'Running',
+        containerStatuses: [{ name: 'app', ready: false, state: { waiting: { reason: 'CrashLoopBackOff' } } }],
+      },
+    }
+    const r = getPodPhaseDisplay(terminatingCrash)
+    expect(r.text).toBe('Running — CrashLoopBackOff')
+    expect(r.level).toBe('unhealthy')
   })
 
   it('falls back to Unknown for missing/unknown phase', () => {
@@ -206,8 +280,46 @@ describe('getPodPhaseDisplay', () => {
 
   it('handles Succeeded/Pending/Failed phases', () => {
     expect(getPodPhaseDisplay({ status: { phase: 'Succeeded' } }).level).toBe('neutral')
-    expect(getPodPhaseDisplay({ status: { phase: 'Pending' } }).level).toBe('degraded')
+    // A freshly-created Pending pod is benign (neutral), not degraded.
+    expect(getPodPhaseDisplay({ status: { phase: 'Pending' } }).level).toBe('neutral')
     expect(getPodPhaseDisplay({ status: { phase: 'Failed' } }).level).toBe('unhealthy')
+  })
+
+  it('flags Unschedulable immediately, but gives plain young Pending a grace window', () => {
+    // The scheduler tried and failed — surface it now, no grace (matches backend).
+    const unsched = {
+      status: { phase: 'Pending', conditions: [{ type: 'PodScheduled', status: 'False', reason: 'Unschedulable' }] },
+    }
+    expect(getPodPhaseDisplay(unsched).text).toBe('Pending — Unschedulable')
+    expect(getPodPhaseDisplay(unsched).level).toBe('degraded')
+
+    // Plain Pending (not yet placed) is benign while young, degraded once stuck.
+    expect(getPodPhaseDisplay({ status: { phase: 'Pending' } }).level).toBe('neutral')
+    const stuckPending = {
+      metadata: { creationTimestamp: new Date(Date.now() - 10 * 60 * 1000).toISOString() },
+      status: { phase: 'Pending' },
+    }
+    expect(getPodPhaseDisplay(stuckPending).level).toBe('degraded')
+  })
+
+  it('flags a failing init container immediately, even on a young Pending pod', () => {
+    const initFail = {
+      metadata: { creationTimestamp: new Date().toISOString() },
+      status: {
+        phase: 'Pending',
+        initContainerStatuses: [{ name: 'init', ready: false, state: { waiting: { reason: 'ImagePullBackOff' } } }],
+      },
+    }
+    const r = getPodPhaseDisplay(initFail)
+    expect(r.text).toBe('Pending — ImagePullBackOff')
+    expect(r.level).toBe('unhealthy')
+  })
+
+  it('flags broadened fatal reasons like InvalidImageName', () => {
+    const bad = {
+      status: { phase: 'Pending', containerStatuses: [{ name: 'app', state: { waiting: { reason: 'InvalidImageName' } } }] },
+    }
+    expect(getPodPhaseDisplay(bad).level).toBe('unhealthy')
   })
 
   it('flags ErrImagePull as unhealthy', () => {

--- a/packages/k8s-ui/src/components/resources/renderers/CronJobRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/CronJobRenderer.tsx
@@ -15,17 +15,24 @@ export function CronJobRenderer({ data, onNavigate }: CronJobRendererProps) {
   const isSuspended = spec.suspend === true
   const hasNeverRun = !status.lastScheduleTime
 
-  // Calculate time since last success vs last schedule
-  const lastScheduleAge = status.lastScheduleTime ? new Date().getTime() - new Date(status.lastScheduleTime).getTime() : 0
-  const lastSuccessAge = status.lastSuccessfulTime ? new Date().getTime() - new Date(status.lastSuccessfulTime).getTime() : 0
-  const recentFailures = lastScheduleAge > 0 && lastSuccessAge > lastScheduleAge
+  // "Recent failures" means the latest scheduled run didn't reach success.
+  // Only meaningful once nothing is running — while a job is active the most
+  // recent run is simply still in flight, not failing. With concurrencyPolicy
+  // Allow an older failed run can overlap a new active one; CronJob status only
+  // carries aggregate timestamps, so we accept missing that rare case here (the
+  // failed Job still surfaces in the job list / topology) rather than reviving
+  // the false positive that fired on every normal in-flight run.
+  const activeJobs = status.active?.length || 0
+  const lastSchedule = status.lastScheduleTime ? new Date(status.lastScheduleTime).getTime() : 0
+  const lastSuccess = status.lastSuccessfulTime ? new Date(status.lastSuccessfulTime).getTime() : 0
+  const recentFailures = activeJobs === 0 && lastSchedule > 0 && lastSchedule > lastSuccess
 
   return (
     <>
-      {/* Suspended warning */}
+      {/* Suspended is an intentional operator state, not a fault — keep it informational. */}
       {isSuspended && (
         <AlertBanner
-          variant="warning"
+          variant="info"
           icon={Pause}
           title="CronJob Suspended"
           message="No new jobs will be scheduled until this CronJob is resumed."
@@ -42,7 +49,7 @@ export function CronJobRenderer({ data, onNavigate }: CronJobRendererProps) {
       )}
 
       {/* Recent failures warning */}
-      {recentFailures && (
+      {recentFailures && !isSuspended && (
         <AlertBanner
           variant="error"
           title="Recent Jobs Failing"

--- a/packages/k8s-ui/src/components/resources/renderers/JobRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/JobRenderer.tsx
@@ -35,11 +35,6 @@ function getJobProblems(data: any): string[] {
     }
   }
 
-  // Check for suspended
-  if (spec.suspend) {
-    problems.push('Job is suspended — pods will not be created')
-  }
-
   return problems
 }
 
@@ -62,12 +57,18 @@ export function JobRenderer({ data }: JobRendererProps) {
 
   // Check if job completed successfully
   const isComplete = conditions.some((c: any) => c.type === 'Complete' && c.status === 'True')
+  const isSuspended = spec.suspend === true
 
   return (
     <>
       {/* Problems alert */}
       {hasProblems && (
         <AlertBanner variant="error" title="Job Issues" items={problems} />
+      )}
+
+      {/* Suspended is an intentional state, not a fault — keep it informational. */}
+      {isSuspended && !hasProblems && (
+        <AlertBanner variant="info" title="Job Suspended" message="Pods will not be created until this Job is resumed." />
       )}
 
       {/* Success banner */}

--- a/packages/k8s-ui/src/components/resources/renderers/WorkflowRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/WorkflowRenderer.tsx
@@ -48,7 +48,7 @@ function getPhaseBadgeClass(phase: string): string {
     case 'Succeeded':
       return 'status-healthy'
     case 'Running':
-      return 'status-degraded'
+      return 'status-neutral'
     case 'Failed':
     case 'Error':
       return 'status-unhealthy'

--- a/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-cnpg.ts
@@ -283,7 +283,7 @@ export function getCNPGScheduledBackupStatus(resource: any): StatusBadge {
   const isSuspended = resource.spec?.suspend === true
 
   if (isSuspended) {
-    return { text: 'Suspended', color: healthColors.degraded, level: 'degraded' }
+    return { text: 'Suspended', color: healthColors.neutral, level: 'neutral' }
   }
 
   // If we have a last schedule time, it's active

--- a/packages/k8s-ui/src/components/resources/resource-utils-keda.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-keda.ts
@@ -50,7 +50,9 @@ export function getScaledObjectStatus(resource: any): StatusBadge {
     return { text: 'Active', color: healthColors.healthy, level: 'healthy' }
   }
   if (activeCond?.status === 'False') {
-    return { text: 'Idle', color: healthColors.degraded, level: 'degraded' }
+    // Idle is the normal resting state of a scaler with no triggers firing
+    // (like a CronJob waiting for its next run), not a fault.
+    return { text: 'Idle', color: healthColors.neutral, level: 'neutral' }
   }
 
   if (readyCond?.status === 'True') {
@@ -129,17 +131,21 @@ export function getScaledJobStatus(resource: any): StatusBadge {
   if (readyCond?.status === 'True') {
     return { text: 'Ready', color: healthColors.healthy, level: 'healthy' }
   }
+  // A non-operational scaler (Ready=False) is unhealthy and must take precedence
+  // over the Idle (Active=False) branch below — otherwise a broken-and-idle
+  // ScaledJob hides as benign "Idle". Mirrors getScaledObjectStatus.
+  if (readyCond?.status === 'False') {
+    return { text: readyCond.reason || 'NotReady', color: healthColors.unhealthy, level: 'unhealthy' }
+  }
 
   const activeCond = conditions.find((c: any) => c.type === 'Active')
   if (activeCond?.status === 'True') {
     return { text: 'Active', color: healthColors.healthy, level: 'healthy' }
   }
   if (activeCond?.status === 'False') {
-    return { text: 'Idle', color: healthColors.degraded, level: 'degraded' }
-  }
-
-  if (readyCond?.status === 'False') {
-    return { text: readyCond.reason || 'NotReady', color: healthColors.unhealthy, level: 'unhealthy' }
+    // Idle is the normal resting state of a scaler with no triggers firing
+    // (like a CronJob waiting for its next run), not a fault.
+    return { text: 'Idle', color: healthColors.neutral, level: 'neutral' }
   }
 
   return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -112,41 +112,122 @@ export function podMatchesProblemCategory(problems: PodProblem[], restarts: numb
   }
 }
 
+// A transient lifecycle state (plain Pending, Terminating, awaiting an address)
+// is not a fault while it's young — it becomes one only once it's stuck past
+// these windows, mirroring the backend health thresholds (ClassifyPodHealth:
+// pending 5m; detect.go: terminating 10m, LB/PVC pending 5m). Two things escalate
+// immediately, regardless of age, because they're definitive failures the backend
+// also flags at once: fatal *container* states (CrashLoopBackOff, ImagePull,
+// InvalidImageName, OOMKilled, …) and Unschedulable (the scheduler tried and
+// could not place the pod).
+const PENDING_STUCK_MINUTES = 5
+const TERMINATING_STUCK_MINUTES = 10
+
+// minutesSince returns minutes elapsed since an ISO timestamp, or 0 when it's
+// missing/invalid — so "unknown age" is treated as not-yet-stuck (benign).
+function minutesSince(timestamp?: string): number {
+  if (!timestamp) return 0
+  const t = new Date(timestamp).getTime()
+  if (Number.isNaN(t)) return 0
+  return (Date.now() - t) / 60000
+}
+
+function podUnschedulable(pod: any): boolean {
+  const conds = pod?.status?.conditions || []
+  return conds.some(
+    (c: any) => c.type === 'PodScheduled' && c.status === 'False' && c.reason === 'Unschedulable'
+  )
+}
+
+// A container that has terminated successfully (exit 0) is done, not "not ready".
+// A completing Job pod (Running phase, container Completed, Ready=false) must not
+// read as degraded just because ready<total — this mirrors ClassifyPodHealth, so
+// the badge agrees with the timeline/Problems verdict.
+function containerSettledOk(cs: any): boolean {
+  return cs?.ready === true || cs?.state?.terminated?.exitCode === 0
+}
+
+// Hard-failure waiting reasons that won't self-resolve — mirrors the backend's
+// isFatalWaitingReason. These escalate immediately regardless of pod age or a
+// Terminating overlay (a bad image / config error is a real failure now, not a
+// benign young-Pending pod).
+const FATAL_WAITING_REASONS = new Set([
+  'CrashLoopBackOff', 'ImagePullBackOff', 'ErrImagePull', 'InvalidImageName',
+  'ImageInspectError', 'CreateContainerConfigError', 'CreateContainerError', 'RunContainerError',
+])
+
+// firstFatalContainer returns the first init- or main-container in a hard-failure
+// state (or null). Init containers are walked first: when init is failing the pod
+// stays Pending and main ContainerStatuses haven't populated yet, so checking main
+// alone would miss it and fall through to a benign "Pending".
+function firstFatalContainer(pod: any): { name: string; reason: string } | null {
+  const init = pod?.status?.initContainerStatuses || []
+  const main = pod?.status?.containerStatuses || []
+  for (const cs of [...init, ...main]) {
+    const w = cs?.state?.waiting?.reason
+    if (w && FATAL_WAITING_REASONS.has(w)) return { name: cs?.name, reason: w }
+    if (cs?.state?.terminated?.reason === 'OOMKilled') return { name: cs?.name, reason: 'OOMKilled' }
+  }
+  return null
+}
+
 export function getPodStatus(pod: any): StatusBadge {
   const phase = pod.status?.phase || 'Unknown'
   const containerStatuses = pod.status?.containerStatuses || []
 
-  // Check for terminating
-  if (pod.metadata?.deletionTimestamp) {
-    return { text: 'Terminating', color: healthColors.degraded, level: 'degraded' }
+  // Fatal init/main container states win over the Pending grace AND a Terminating
+  // overlay — a crash-loop, bad image, or config error is a real failure now,
+  // whatever the pod's age or deletion state. Skip for Succeeded: a terminal
+  // success must not flip unhealthy on a sidecar that OOMed before the main
+  // container finished (matches getPodPhaseDisplay + ClassifyPodHealth).
+  if (phase !== 'Succeeded') {
+    const fatal = firstFatalContainer(pod)
+    if (fatal) {
+      return { text: fatal.reason, color: healthColors.unhealthy, level: 'unhealthy' }
+    }
   }
 
-  // Check container states for issues
-  for (const cs of containerStatuses) {
-    if (cs.state?.waiting?.reason) {
-      const reason = cs.state.waiting.reason
-      if (['CrashLoopBackOff', 'ImagePullBackOff', 'ErrImagePull', 'CreateContainerConfigError'].includes(reason)) {
-        return { text: reason, color: healthColors.unhealthy, level: 'unhealthy' }
-      }
+  // A terminal failure stays unhealthy even while the pod is being deleted — the
+  // Terminating overlay below must not mask a Failed pod (the Problems panel and
+  // dashboard report it as an error regardless).
+  if (phase === 'Failed') {
+    return { text: 'Failed', color: healthColors.unhealthy, level: 'unhealthy' }
+  }
+
+  // Terminating: neutral while gracefully shutting down, degraded once stuck
+  // (a wedged finalizer / preStop hook holding the pod open).
+  if (pod.metadata?.deletionTimestamp) {
+    if (minutesSince(pod.metadata.deletionTimestamp) >= TERMINATING_STUCK_MINUTES) {
+      return { text: 'Terminating', color: healthColors.degraded, level: 'degraded' }
     }
-    if (cs.state?.terminated?.reason === 'OOMKilled') {
-      return { text: 'OOMKilled', color: healthColors.unhealthy, level: 'unhealthy' }
-    }
+    return { text: 'Terminating', color: healthColors.neutral, level: 'neutral' }
   }
 
   switch (phase) {
-    case 'Running':
-      // Check if all containers are ready
+    case 'Running': {
+      // Degrade only on containers that are neither ready nor successfully done —
+      // a completed container (exit 0) on a Running pod is finishing, not a fault.
       const ready = containerStatuses.filter((c: any) => c.ready).length
       const total = containerStatuses.length
-      if (total > 0 && ready < total) {
+      const unsettled = containerStatuses.filter((c: any) => !containerSettledOk(c)).length
+      if (unsettled > 0) {
         return { text: `Running (${ready}/${total})`, color: healthColors.degraded, level: 'degraded' }
       }
       return { text: 'Running', color: healthColors.healthy, level: 'healthy' }
+    }
     case 'Succeeded':
       return { text: 'Completed', color: healthColors.neutral, level: 'neutral' }
     case 'Pending':
-      return { text: 'Pending', color: healthColors.degraded, level: 'degraded' }
+      // Unschedulable = the scheduler tried and failed to place this pod; the
+      // backend flags it immediately (severity ramps with duration), so the badge
+      // does too. Plain Pending (not yet placed) keeps the young-grace window.
+      if (podUnschedulable(pod)) {
+        return { text: 'Unschedulable', color: healthColors.degraded, level: 'degraded' }
+      }
+      if (minutesSince(pod.metadata?.creationTimestamp) >= PENDING_STUCK_MINUTES) {
+        return { text: 'Pending', color: healthColors.degraded, level: 'degraded' }
+      }
+      return { text: 'Pending', color: healthColors.neutral, level: 'neutral' }
     case 'Failed':
       return { text: 'Failed', color: healthColors.unhealthy, level: 'unhealthy' }
     default:
@@ -181,49 +262,51 @@ export function getPodPhaseDisplay(pod: any): PodPhaseDisplay {
     0
   )
 
-  if (pod?.metadata?.deletionTimestamp) {
-    return {
-      phase,
-      text: `${phase} — Terminating`,
-      level: 'degraded',
-      hint: 'Pod has a deletionTimestamp set; awaiting graceful termination.',
+  // Container-state failures take precedence over phase AND over a Terminating
+  // overlay: a CrashLoopBackOff pod can still report phase: Running, an init
+  // failure keeps the pod Pending, and a pod crashing while being deleted is
+  // still a failure worth surfacing. Skip for Succeeded — a Job pod whose sidecar
+  // was OOMKilled before the main container completed should not read unhealthy
+  // after terminal success.
+  if (phase !== 'Succeeded') {
+    const fatal = firstFatalContainer(pod)
+    if (fatal) {
+      return {
+        phase,
+        text: `${phase} — ${fatal.reason}`,
+        level: 'unhealthy',
+        hint: fatal.reason === 'OOMKilled'
+          ? `Container "${fatal.name}" was OOMKilled.`
+          : `Container "${fatal.name}" is stuck in ${fatal.reason}.`,
+      }
     }
   }
 
-  // Container-state failures take precedence over phase: a CrashLoopBackOff
-  // pod can still report phase: Running. Skip for Succeeded — a Job pod whose
-  // sidecar was OOMKilled before the main container completed should not be
-  // shown as unhealthy after the pod has reached terminal success.
-  if (phase !== 'Succeeded') {
-    for (const cs of containerStatuses) {
-      const waitingReason = cs?.state?.waiting?.reason
-      if (
-        waitingReason === 'CrashLoopBackOff' ||
-        waitingReason === 'ImagePullBackOff' ||
-        waitingReason === 'ErrImagePull' ||
-        waitingReason === 'CreateContainerConfigError'
-      ) {
-        return {
-          phase,
-          text: `${phase} — ${waitingReason}`,
-          level: 'unhealthy',
-          hint: `Container "${cs.name}" is stuck in ${waitingReason}.`,
-        }
-      }
-      if (cs?.state?.terminated?.reason === 'OOMKilled') {
-        return {
-          phase,
-          text: `${phase} — OOMKilled`,
-          level: 'unhealthy',
-          hint: `Container "${cs.name}" was OOMKilled.`,
-        }
-      }
+  // A terminal failure stays unhealthy even while the pod is being deleted — don't
+  // let the Terminating overlay mask a Failed pod.
+  if (phase === 'Failed') {
+    return { phase, text: 'Failed', level: 'unhealthy' }
+  }
+
+  // Terminating: neutral while gracefully shutting down, degraded once stuck.
+  if (pod?.metadata?.deletionTimestamp) {
+    const stuck = minutesSince(pod.metadata.deletionTimestamp) >= TERMINATING_STUCK_MINUTES
+    return {
+      phase,
+      text: `${phase} — Terminating`,
+      level: stuck ? 'degraded' : 'neutral',
+      hint: stuck
+        ? 'Pod has been terminating for a while — a finalizer or preStop hook may be wedged.'
+        : 'Pod has a deletionTimestamp set; awaiting graceful termination.',
     }
   }
 
   switch (phase) {
     case 'Running': {
-      const notReady = totalContainers > 0 && readyContainers < totalContainers
+      // A successfully-completed container (exit 0) is settled, not "not ready" —
+      // don't degrade a completing pod over it (matches getPodStatus / timeline).
+      const unsettled = containerStatuses.filter((c) => !containerSettledOk(c)).length
+      const notReady = totalContainers > 0 && unsettled > 0
       const cycling = restartTotal > RESTART_CYCLING_THRESHOLD
       if (notReady && cycling) {
         return {
@@ -254,7 +337,26 @@ export function getPodPhaseDisplay(pod: any): PodPhaseDisplay {
     case 'Succeeded':
       return { phase, text: 'Completed', level: 'neutral' }
     case 'Pending':
-      return { phase, text: 'Pending', level: 'degraded' }
+      // Unschedulable = the scheduler tried and failed; surface it immediately
+      // (the backend does, with severity ramping by duration). Plain Pending
+      // (not yet placed) keeps the young-grace window.
+      if (podUnschedulable(pod)) {
+        return {
+          phase,
+          text: `${phase} — Unschedulable`,
+          level: 'degraded',
+          hint: 'No node can accept this pod (insufficient resources, taints, affinity, or quota).',
+        }
+      }
+      if (minutesSince(pod?.metadata?.creationTimestamp) >= PENDING_STUCK_MINUTES) {
+        return {
+          phase,
+          text: 'Pending',
+          level: 'degraded',
+          hint: 'Pod has been Pending for several minutes — check scheduling and image pulls.',
+        }
+      }
+      return { phase, text: 'Pending', level: 'neutral' }
     case 'Failed':
       return { phase, text: 'Failed', level: 'unhealthy' }
     default:
@@ -778,7 +880,12 @@ export function getIngressStatus(ingress: any): StatusBadge {
   if (lbIngress.length > 0) {
     return { text: 'Active', color: healthColors.healthy, level: 'healthy' }
   }
-  return { text: 'Pending', color: healthColors.degraded, level: 'degraded' }
+  // Awaiting an external address is normal right after creation; only flag it
+  // once the ingress/LB controller has had time and still hasn't assigned one.
+  if (minutesSince(ingress.metadata?.creationTimestamp) >= PENDING_STUCK_MINUTES) {
+    return { text: 'Pending', color: healthColors.degraded, level: 'degraded' }
+  }
+  return { text: 'Pending', color: healthColors.neutral, level: 'neutral' }
 }
 
 export function getIngressHosts(ingress: any): string {
@@ -905,7 +1012,7 @@ export function getJobStatus(job: any): StatusBadge {
   }
 
   if (job.spec?.suspend) {
-    return { text: 'Suspended', color: healthColors.degraded, level: 'degraded' }
+    return { text: 'Suspended', color: healthColors.neutral, level: 'neutral' }
   }
 
   if (status.active > 0) {
@@ -936,7 +1043,7 @@ export function getJobDuration(job: any): string | null {
 
 export function getCronJobStatus(cj: any): StatusBadge {
   if (cj.spec?.suspend) {
-    return { text: 'Suspended', color: healthColors.degraded, level: 'degraded' }
+    return { text: 'Suspended', color: healthColors.neutral, level: 'neutral' }
   }
   const activeJobs = cj.status?.active?.length || 0
   if (activeJobs > 0) {
@@ -1010,6 +1117,9 @@ export function getNodeStatus(node: any): StatusBadge {
   const isUnschedulable = node.spec?.unschedulable === true
 
   if (isReady && isUnschedulable) {
+    // Cordon is intentional but consequential — it's lost scheduling capacity, and
+    // a forgotten cordon strands nodes — so it stays on the warning axis (matching
+    // the backend Cordoned issue), unlike no-op intentional states (suspended/idle).
     return { text: 'Ready,SchedulingDisabled', color: healthColors.degraded, level: 'degraded' }
   }
   if (isReady) {
@@ -1161,7 +1271,12 @@ export function getPVCStatus(pvc: any): StatusBadge {
     case 'Bound':
       return { text: 'Bound', color: healthColors.healthy, level: 'healthy' }
     case 'Pending':
-      return { text: 'Pending', color: healthColors.degraded, level: 'degraded' }
+      // Pending is benign here: a WaitForFirstConsumer claim stays Pending by
+      // design until a pod needs it (could be forever for a scaled-to-zero
+      // workload). We can't see the StorageClass binding mode from the PVC alone,
+      // so age can't distinguish that from genuinely-stuck — the Problems panel,
+      // which has that context, owns the stuck-PVC alarm.
+      return { text: 'Pending', color: healthColors.neutral, level: 'neutral' }
     case 'Lost':
       return { text: 'Lost', color: healthColors.unhealthy, level: 'unhealthy' }
     default:
@@ -1236,7 +1351,7 @@ export function getWorkflowStatus(workflow: any): StatusBadge {
     case 'Succeeded':
       return { text: 'Succeeded', color: healthColors.healthy, level: 'healthy' }
     case 'Running':
-      return { text: 'Running', color: healthColors.degraded, level: 'degraded' }
+      return { text: 'Running', color: healthColors.neutral, level: 'neutral' }
     case 'Failed':
       return { text: 'Failed', color: healthColors.unhealthy, level: 'unhealthy' }
     case 'Error':

--- a/pkg/ai/context/summary.go
+++ b/pkg/ai/context/summary.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/skyhook-io/radar/pkg/cronsched"
 	"github.com/skyhook-io/radar/pkg/hpadiag"
 	"github.com/skyhook-io/radar/pkg/resourcecontext"
 )
@@ -422,9 +423,12 @@ func summarizeCronJob(cj *batchv1.CronJob) *ResourceSummary {
 	if cj.Spec.Suspend != nil && *cj.Spec.Suspend {
 		s.Suspended = cj.Spec.Suspend
 	} else {
-		if cj.Status.LastScheduleTime != nil && time.Since(cj.Status.LastScheduleTime.Time) > 24*time.Hour {
+		// Staleness is relative to the schedule's cadence, not a flat day: a
+		// weekly job that ran on schedule 25h ago is healthy, not stale.
+		threshold := cronsched.StaleThreshold(cj.Spec.Schedule)
+		if cj.Status.LastScheduleTime != nil && time.Since(cj.Status.LastScheduleTime.Time) > threshold {
 			s.Issue = "no recent runs"
-		} else if cj.Status.LastScheduleTime == nil && time.Since(cj.CreationTimestamp.Time) > 24*time.Hour {
+		} else if cj.Status.LastScheduleTime == nil && time.Since(cj.CreationTimestamp.Time) > threshold {
 			s.Issue = "never scheduled"
 		}
 	}

--- a/pkg/cronsched/cronsched.go
+++ b/pkg/cronsched/cronsched.go
@@ -1,0 +1,153 @@
+// Package cronsched provides coarse cadence estimation for cron schedules so
+// staleness checks can grade "this CronJob hasn't run recently" against the
+// schedule's own interval instead of a flat daily threshold. A quarterly job
+// that ran on schedule 29 days ago is healthy, not stale.
+package cronsched
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const day = 24 * time.Hour
+
+// MinInterval estimates a representative interval between runs of a standard
+// 5-field cron schedule (minute hour dom month dow), plus the common @-macros.
+// It is deliberately approximate — its only job is to keep staleness checks from
+// flagging a rare-cadence job (weekly / monthly / quarterly / yearly) as stale
+// against a flat daily threshold. For month-constrained schedules it returns the
+// largest gap between firing months (so a once-a-year job reads as ~yearly, not
+// monthly). ok=false for schedules it can't parse; callers then fall back to the
+// flat threshold.
+func MinInterval(schedule string) (time.Duration, bool) {
+	s := strings.TrimSpace(schedule)
+	// '?' is the Quartz "no specific value" token some schedules use in the
+	// day-of-month / day-of-week field; treat it as '*' so a daily "0 0 ? * *"
+	// isn't misread as a monthly cadence (and given a 42-day stale window).
+	s = strings.ReplaceAll(s, "?", "*")
+	switch s {
+	case "@yearly", "@annually":
+		return 365 * day, true
+	case "@monthly":
+		return 28 * day, true
+	case "@weekly":
+		return 7 * day, true
+	case "@daily", "@midnight":
+		return day, true
+	case "@hourly":
+		return time.Hour, true
+	}
+	fields := strings.Fields(s)
+	if len(fields) != 5 {
+		return 0, false
+	}
+	hour, dom, month, dow := fields[1], fields[2], fields[3], fields[4]
+	switch {
+	case month != "*":
+		// Constrained months → cadence is the largest gap between firing months
+		// (yearly if a single month, quarterly for */4, etc.), not a flat month.
+		if gap, ok := maxMonthGapDays(month); ok {
+			return gap, true
+		}
+		return 28 * day, true
+	case dom != "*":
+		// Specific day(s)-of-month → monthly cadence.
+		return 28 * day, true
+	case dow != "*":
+		// Specific day(s)-of-week → weekly is the conservative lower bound.
+		return 7 * day, true
+	case hour != "*" && !strings.HasPrefix(hour, "*/"):
+		// Specific hour(s) each day → daily.
+		return day, true
+	default:
+		// Intra-day cadence (every minute / */n minutes or hours).
+		return time.Hour, true
+	}
+}
+
+// maxMonthGapDays returns the longest stretch (in days) the schedule can go
+// between firing months, given a constrained month field. A single month fires
+// once a year; */4 fires every four months; a list takes the widest gap between
+// consecutive entries (wrapping past December). Months are valued at 31 days so
+// the estimate stays an upper bound — staleness should never trip on a healthy
+// rare-cadence job. ok=false when the field can't be parsed.
+func maxMonthGapDays(field string) (time.Duration, bool) {
+	months, ok := cronFieldValues(field, 1, 12)
+	if !ok || len(months) == 0 {
+		return 0, false
+	}
+	if len(months) == 1 {
+		return 365 * day, true
+	}
+	maxGap := months[0] + 12 - months[len(months)-1] // wrap from last to first next year
+	for i := 1; i < len(months); i++ {
+		if g := months[i] - months[i-1]; g > maxGap {
+			maxGap = g
+		}
+	}
+	return time.Duration(maxGap) * 31 * day, true
+}
+
+// cronFieldValues expands a single cron field (lists, ranges, steps, and *) into
+// its sorted set of concrete values within [lo, hi]. ok=false on any token it
+// can't parse so the caller can fall back rather than trust a partial set.
+func cronFieldValues(field string, lo, hi int) ([]int, bool) {
+	set := make(map[int]bool)
+	for _, part := range strings.Split(field, ",") {
+		step := 1
+		if i := strings.Index(part, "/"); i >= 0 {
+			st, err := strconv.Atoi(part[i+1:])
+			if err != nil || st <= 0 {
+				return nil, false
+			}
+			step = st
+			part = part[:i]
+		}
+		start, end := lo, hi
+		switch {
+		case part == "*":
+			// start/end already span [lo, hi]
+		case strings.Contains(part, "-"):
+			bounds := strings.SplitN(part, "-", 2)
+			a, err1 := strconv.Atoi(bounds[0])
+			b, err2 := strconv.Atoi(bounds[1])
+			if err1 != nil || err2 != nil {
+				return nil, false
+			}
+			start, end = a, b
+		default:
+			v, err := strconv.Atoi(part)
+			if err != nil {
+				return nil, false
+			}
+			start, end = v, v
+		}
+		if start < lo || end > hi || start > end {
+			return nil, false
+		}
+		for v := start; v <= end; v += step {
+			set[v] = true
+		}
+	}
+	out := make([]int, 0, len(set))
+	for v := range set {
+		out = append(out, v)
+	}
+	sort.Ints(out)
+	return out, len(out) > 0
+}
+
+// StaleThreshold returns how long a CronJob may go without running before it is
+// considered stale. Cadence-relative (interval + 50% grace) but floored at 24h
+// so frequent jobs keep the original sensitivity.
+func StaleThreshold(schedule string) time.Duration {
+	threshold := day
+	if interval, ok := MinInterval(schedule); ok {
+		if grace := interval + interval/2; grace > threshold {
+			threshold = grace
+		}
+	}
+	return threshold
+}

--- a/pkg/cronsched/cronsched_test.go
+++ b/pkg/cronsched/cronsched_test.go
@@ -1,0 +1,59 @@
+package cronsched
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMinInterval(t *testing.T) {
+	day := 24 * time.Hour
+	cases := []struct {
+		schedule string
+		wantOK   bool
+		atLeast  time.Duration // returned interval must be >= this
+	}{
+		{"*/5 * * * *", true, time.Hour}, // every 5 min → intra-day floor
+		{"0 * * * *", true, time.Hour},   // hourly (minute 0, every hour) → intra-day floor
+		{"0 0 * * *", true, day},         // daily
+		{"0 0 * * 1", true, 7 * day},     // weekly
+		{"0 0 1 * *", true, 28 * day},    // monthly (specific dom)
+		{"0 0 1 */4 *", true, 100 * day}, // quarterly (every 4th month) — gap ~4 months
+		{"0 0 1 1 *", true, 365 * day},   // yearly via numeric month (Jan 1)
+		{"0 0 1 1,7 *", true, 180 * day}, // semi-annual (Jan + Jul) — 6-month gap
+		{"0 0 ? * *", true, day},          // daily via Quartz '?' for day-of-month
+		{"0 0 * * ?", true, day},          // daily via Quartz '?' for day-of-week
+		{"@daily", true, day},            //
+		{"@weekly", true, 7 * day},       //
+		{"@yearly", true, 365 * day},     //
+		{"not a schedule", false, 0},     //
+	}
+	for _, c := range cases {
+		got, ok := MinInterval(c.schedule)
+		if ok != c.wantOK {
+			t.Errorf("%q: ok=%v want %v", c.schedule, ok, c.wantOK)
+			continue
+		}
+		if ok && got < c.atLeast {
+			t.Errorf("%q: interval=%s, want >= %s", c.schedule, got, c.atLeast)
+		}
+	}
+}
+
+func TestStaleThreshold(t *testing.T) {
+	day := 24 * time.Hour
+	cases := []struct {
+		schedule string
+		want     time.Duration
+	}{
+		{"*/5 * * * *", day},               // intra-day → floored at 24h
+		{"0 * * * *", day},                 // hourly → floored at 24h
+		{"0 0 * * *", 36 * time.Hour},      // daily → 24h + 50% grace
+		{"0 0 * * 1", 7*day + 84*time.Hour}, // weekly → 7d + 50% grace
+		{"unparseable", day},               // fallback → flat 24h
+	}
+	for _, c := range cases {
+		if got := StaleThreshold(c.schedule); got != c.want {
+			t.Errorf("%q: threshold=%s, want %s", c.schedule, got, c.want)
+		}
+	}
+}

--- a/pkg/timeline/converter.go
+++ b/pkg/timeline/converter.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -170,82 +169,11 @@ func ExtractLabels(obj any) map[string]string {
 	return relevant
 }
 
-// DetermineHealthState determines health state from an object
-func DetermineHealthState(kind string, obj any) HealthState {
-	switch kind {
-	case "Pod":
-		if pod, ok := obj.(*corev1.Pod); ok {
-			switch pod.Status.Phase {
-			case corev1.PodRunning:
-				for _, cs := range pod.Status.ContainerStatuses {
-					if !cs.Ready {
-						return HealthDegraded
-					}
-				}
-				return HealthHealthy
-			case corev1.PodSucceeded:
-				return HealthHealthy
-			case corev1.PodFailed:
-				return HealthUnhealthy
-			case corev1.PodPending:
-				return HealthDegraded
-			}
-		}
-	case "Deployment":
-		if dep, ok := obj.(*appsv1.Deployment); ok {
-			desired := int32(1)
-			if dep.Spec.Replicas != nil {
-				desired = *dep.Spec.Replicas
-			}
-			if dep.Status.ReadyReplicas == desired && dep.Status.AvailableReplicas == desired {
-				return HealthHealthy
-			}
-			if dep.Status.ReadyReplicas > 0 {
-				return HealthDegraded
-			}
-			return HealthUnhealthy
-		}
-	case "ReplicaSet":
-		if rs, ok := obj.(*appsv1.ReplicaSet); ok {
-			desired := int32(1)
-			if rs.Spec.Replicas != nil {
-				desired = *rs.Spec.Replicas
-			}
-			if rs.Status.ReadyReplicas == desired {
-				return HealthHealthy
-			}
-			if rs.Status.ReadyReplicas > 0 {
-				return HealthDegraded
-			}
-			return HealthUnhealthy
-		}
-	case "DaemonSet":
-		if ds, ok := obj.(*appsv1.DaemonSet); ok {
-			if ds.Status.NumberReady == ds.Status.DesiredNumberScheduled && ds.Status.DesiredNumberScheduled > 0 {
-				return HealthHealthy
-			}
-			if ds.Status.NumberReady > 0 {
-				return HealthDegraded
-			}
-			return HealthUnhealthy
-		}
-	case "StatefulSet":
-		if sts, ok := obj.(*appsv1.StatefulSet); ok {
-			desired := int32(1)
-			if sts.Spec.Replicas != nil {
-				desired = *sts.Spec.Replicas
-			}
-			if sts.Status.ReadyReplicas == desired {
-				return HealthHealthy
-			}
-			if sts.Status.ReadyReplicas > 0 {
-				return HealthDegraded
-			}
-			return HealthUnhealthy
-		}
-	}
-	return HealthUnknown
-}
+// Resource health classification for timeline events lives with the canonical
+// classifiers in internal/k8s (classifyTimelineHealth → ClassifyPodHealth), not
+// here: the timeline package can't reach that logic across the module boundary,
+// so the caller computes health and the event just stores it. A duplicate copy
+// here previously drifted and misclassified completing Job pods as degraded.
 
 // OperationToEventType converts an operation string to EventType
 func OperationToEventType(op string) EventType {

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -7519,7 +7519,9 @@ func extractKedaScaledObjectStatus(so unstructured.Unstructured) HealthStatus {
 		case "True":
 			return StatusHealthy
 		case "False":
-			return StatusDegraded
+			// Idle (no triggers firing) is the normal resting state of a Ready
+			// scaler, not degradation — match the resource view's neutral tone.
+			return StatusHealthy
 		}
 	}
 
@@ -7566,7 +7568,9 @@ func extractKedaScaledJobStatus(sj unstructured.Unstructured) HealthStatus {
 		case "True":
 			return StatusHealthy
 		case "False":
-			return StatusDegraded
+			// Idle (no jobs currently scaled) is a Ready scaler's normal resting
+			// state, not degradation — match the resource view's neutral tone.
+			return StatusHealthy
 		}
 	}
 


### PR DESCRIPTION
## Summary

Radar was crying wolf on benign Kubernetes states. Intentional or transient resources — suspended CronJobs/Jobs, completed Jobs, idle KEDA scalers, in-flight Argo Workflows, normally-completing and just-created pods — were painted amber/red and counted as problems, which buried the real ones (the Timeline **Unhealthy** filter was dominated by normally-completed cron pods). This PR makes the health/issue signal trustworthy again so an operator can triage from it.

It establishes one principle across every status surface:

> **Lifecycle/intent → neutral; only genuine impairment → amber/red — gated by "would an operator want this row when they filter to Unhealthy?"**

Transient states (plain Pending, Terminating, awaiting a load-balancer address) read neutral while young and escalate only once stuck past the same thresholds the backend uses. Definitive failures escalate immediately, no grace: fatal container states (init or main) and `Unschedulable` (the scheduler tried and could not place the pod).

## What changed

**Root cause — a duplicated, drifted classifier.** The Timeline computed pod/workload health with its own naive copy (`pkg/timeline.DetermineHealthState`) that had diverged from the canonical `internal/k8s.ClassifyPodHealth` — flagging a completing pod (`Ready: True→False` mid-termination) as `degraded`. The copy is **removed**; a new `internal/k8s.classifyTimelineHealth` classifies through the canonical path (the caller owns classification, the timeline package just stores the verdict), so the Timeline, Problems panel, and resource badges agree by construction. The same helper grades scaled-to-zero workloads and DaemonSets matching no nodes (0/0) as healthy, and recognizes `Unschedulable` immediately like the scheduling detector does.

**Backend false positives**
- `pkg/cronsched` (new): cadence-aware CronJob staleness — a weekly/quarterly/yearly job on schedule is no longer "stale" against a flat daily threshold. Shared by the problem detector and the AI/MCP summary so they can't drift.
- Service endpoint readiness excludes `Succeeded` pods (a completed Job pod sharing a Service's labels no longer triggers a critical "0/N ready"), but keeps `Failed` pods so a real no-endpoints outage still surfaces.

**Frontend status tones** (`resource-utils*.ts`, renderers, topology)
- Suspended Job/CronJob/CNPG ScheduledBackup → neutral; a suspended Job moves from a red "Job Issues" banner to an info banner.
- Argo Workflow `Running` → neutral; KEDA `Idle` (ScaledObject/ScaledJob) → neutral — fixed in **both** the resource view and the topology graph so they agree.
- CronJob "Recent Jobs Failing" banner no longer fires during normal in-flight runs.
- Pod / PVC / Ingress status is age- and reason-aware: `Pending`, `Terminating`, and "awaiting an address" read neutral while young and degrade once stuck past the backend windows (pending 5m, terminating 10m). A completing pod (a container exited 0, pod not yet Ready) is treated as settled, not degraded.
- Fatal init/main container states (CrashLoopBackOff, ImagePullBackOff, InvalidImageName, OOMKilled, …) and `Unschedulable` escalate immediately, regardless of age — matching the backend, which never grants those a grace window.
- Cordoned node stays on the warning axis: it's intentional but *consequential* (lost capacity; a forgotten cordon is a real incident), aligning the badge with the backend Cordoned issue.

**Reviewer focus:** `internal/k8s/timeline_health.go` (the canonical mapping, the `Unschedulable` short-circuit, and workload grading) and the pod-status logic in `resource-utils.ts` — the ordering (fatal container state → Terminating overlay → phase) and the age/reason gates are the subtle parts.

## Testing

- Go: `go build ./...` (root + `pkg`), `go test ./internal/k8s/ ./internal/timeline/ ./pkg/...` — green, incl. new `classifyTimelineHealth` tests (completing pod → healthy; scaled-to-zero / DaemonSet 0/0 → healthy; unschedulable → degraded) and `cronsched` (quarterly/yearly cadence; Succeeded-vs-Failed service matching).
- Frontend: `tsc --noEmit` clean; `vitest` 669 passing, incl. age/reason-aware Pending/Terminating, completing-pod, failing-init-container, and immediate-Unschedulable cases.
- Visual-tested against a live cluster with staged fixtures: completed Job pods render neutral; an Unschedulable pod renders an amber "Unschedulable" badge consistent with the Timeline lane and the Issues panel; the Timeline no longer fills its Unhealthy filter with completed cron pods; suspended CronJob shows a neutral chip + info banner; a running Argo Workflow shows a neutral badge.

## Follow-ups

- Topology node health for **Pods / Jobs / PVCs** is still phase-only (its helpers receive only the phase, not the object), so the graph can still grade a young Pending pod or active Job as degraded and can miss container-level failures. Aligning it needs a small signature refactor to thread the object (and ideally a shared canonical classifier) — tracked as a separate change to keep this PR scoped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches health classification across timeline, problems detection, UI badges, and topology—wide behavioral change with an intentional breaking removal of a public pkg API, but heavily tested and mostly reduces false positives rather than changing critical auth/data paths.
> 
> **Overview**
> Radar was treating many **benign or transient** Kubernetes states (completed Job pods, suspended workloads, idle KEDA scalers, young Pending pods) as degraded/unhealthy, which polluted the Timeline **Unhealthy** filter and UI badges.
> 
> **Timeline / backend:** Removes the drift-prone `pkg/timeline.DetermineHealthState` duplicate and records informer events via new `internal/k8s.classifyTimelineHealth`, which delegates to `ClassifyPodHealth` and shared workload replica rules (including scale-to-zero and stuck terminating/unschedulable pods). **Service** endpoint matching **excludes `Succeeded` pods** and reports a clearer reason when only completed Job pods match. **CronJob staleness** moves into shared **`pkg/cronsched`** (cadence-aware thresholds, Quartz `?` support) for detectors and AI summaries.
> 
> **UI / topology:** Pod status/phase display gains **age and reason gates** (Pending/Terminating/Ingress pending grace; immediate escalation for fatal container states and Unschedulable; completing pods and `Succeeded` with sidecar noise stay neutral/healthy). Suspended Jobs/CronJobs, idle KEDA, running Workflows, and similar **intentional resting states** shift from warning to **neutral**; CronJob “recent failures” ignores in-flight runs; **ScaledJob** `Ready=False` wins over Idle.
> 
> **Breaking:** Exported `pkg/timeline.DetermineHealthState` is removed; external importers must classify health themselves or use Radar’s internal path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ee026360108d2566dd0b5f88cb3bc0a1005f625. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

- **Breaking (intentional):** removes the exported `pkg/timeline.DetermineHealthState` from the versioned `github.com/skyhook-io/radar/pkg` module (it was a coarse, drift-prone duplicate; Radar now classifies via `internal/k8s.classifyTimelineHealth`). External Go importers pinned to it would need to drop the call — warrants a major `pkg` tag / release note.
