### PR TITLE
perf(connection): stop re-fetching the whole cache on initial connect

### DIFF
--- a/web/src/context/ConnectionContext.tsx
+++ b/web/src/context/ConnectionContext.tsx
@@ -62,6 +62,22 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
   // Track if SSE has started delivering connection_state events
   // Once SSE is active, it becomes the authoritative source for connection state
   const sseActiveRef = useRef(false)
+  // Track whether we've reached 'connected' at least once. Distinguishes the
+  // initial connect (bootstrap queries already fetched while 'connecting') from
+  // a reconnect after a drop (cache may be stale across the gap).
+  const hasConnectedRef = useRef(false)
+  // Whether the QueryClient already held data when this provider mounted. A host
+  // can share one client across cluster-scoped RadarApp mounts (see RadarApp's
+  // `queryClient` prop); that client may carry another cluster's data under
+  // identical keys, so a warm-at-mount cache must be fully refreshed on first
+  // connect. A cold cache (standalone, or a per-cluster remount) takes the cheap
+  // error-only path. Snapshot synchronously before this provider's own query
+  // registers — ConnectionProvider is the outermost provider, so a fresh client
+  // is genuinely empty here.
+  const cacheWarmAtMountRef = useRef<boolean | null>(null)
+  if (cacheWarmAtMountRef.current === null) {
+    cacheWarmAtMountRef.current = queryClient.getQueryCache().getAll().length > 0
+  }
 
   // Fetch initial connection status
   // Poll while connecting to get progress updates (SSE not established yet)
@@ -143,9 +159,20 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
       return status
     })
 
-    // If we just connected, invalidate queries to fetch fresh data
     if (status.state === 'connected') {
-      queryClient.invalidateQueries()
+      const firstConnect = !hasConnectedRef.current
+      hasConnectedRef.current = true
+      // A reconnect after a drop (cache stale across the gap), or a first connect
+      // onto a client that already carried data at mount (shared across clusters),
+      // refreshes the whole cache. A clean first connect only needs to recover the
+      // bootstrap queries that 503'd while the cluster was still 'connecting'
+      // (status === 'error'); the rest already fetched fresh during 'connecting',
+      // so re-fetching the whole cache there would double-load every endpoint.
+      if (!firstConnect || cacheWarmAtMountRef.current) {
+        queryClient.invalidateQueries()
+      } else {
+        queryClient.invalidateQueries({ predicate: (q) => q.state.status === 'error' })
+      }
     }
   }, [queryClient])
 


### PR DESCRIPTION
## Summary

On every initial connect, `ConnectionContext.updateFromSSE()` runs a **filterless** `queryClient.invalidateQueries()` the instant SSE delivers `connection_state=connected` — invalidating the *entire* React Query cache. The top-level bootstrap queries (`auth/me`, `contexts`, `namespaces`, `api-resources`, `capabilities`, `version-check`, `cluster/namespace-scope`, `portforwards`, `connection`, `settings`) have already fetched during the preceding `connecting` phase, so any of them that have **settled by the connect instant** get re-fetched a second time on first paint. This change stops that redundant re-fetch.

## What changed (`web/src/context/ConnectionContext.tsx`)

The blanket invalidate is only load-bearing for the cluster-data endpoints (`handleNamespaces` / `handleAPIResources` / `handleGetNamespaceScope`) that return `503` (`requireConnected`) while the cluster is still `connecting`: their first fetch errors and must be retried once the cluster is ready. So the fix preserves that recovery and drops only the wasteful part.

Distinguish **first connect** from **reconnect**:

- **First connect:** invalidate only **errored** queries (`predicate: q => q.state.status === 'error'`). The 503'd cluster-data queries recover; everything that already fetched fresh during `connecting` is left untouched — no second fetch.
- **Reconnect after a drop** (pod restart / SSE re-established): keep the **full** invalidate — the cache may be stale across the gap. Behavior unchanged.

It also guards the public `RadarApp` `queryClient` prop: a host that shares one client across cluster-scoped mounts can carry another cluster's data under identical keys, so a **warm-at-mount** cache still does a full invalidate on first connect. (Radar Hub mounts `<RadarApp key={clusterId}>` with its own client, so it always has a cold per-cluster cache and was never exposed to this — the guard just makes the library API correct regardless of how a host wires the client.)

## Impact — honest scoping

This is a **correctness/cleanliness fix that removes redundant load**, not a dramatic speedup. The amount of waste is **timing-dependent**: the invalidate only re-fetches queries that have *already settled* when SSE connects — anything still in-flight is deduped by React Query. Across real captures the visible doubling ranged from ~10 endpoints (fast local connect, where most bootstrap queries had settled) down to a single endpoint (`/api/settings`) on a run where the cluster connected later and most queries were still mid-flight. So on a typical connect the saving is modest and variable; the value is removing an unconditional full-cache invalidation that served no purpose on first connect.

## Testing

- `npm run tsc` ✓
- Verified with a query-cache subscriber + a Playwright network capture against a live `kind` cluster: before, the bootstrap endpoints re-fetched after the `connection_state=connected` event; after, they fetch once and the post-connect invalidate cascade is gone. Re-confirmed the cold-cache fast path still single-fetches after the shared-client guard was added.
- No frontend test runner is configured in this repo; `tsc` is the static gate.
- visual-test: **skipped** — the change is network/timing behavior with no rendered-UI delta; verified via network capture instead.

## Out of scope (separately tracked)

- `dashboard` / `issues` / `dashboard/crds` / `dashboard/helm` fetch twice via a distinct **query-key** change (they mount with `["dashboard",[]]`, then re-key to `["dashboard",[namespaces]]` once `namespaces` resolves) — pre-existing and unrelated to this invalidate.
- `portforwards` 401-retry is a separate retry-handling item.

## Rollout

This is the OSS repo. Radar Hub embeds `@skyhook-io/radar-app`, so reaching Cloud needs a `radar-app` release + a hub dependency bump as a follow-up.
