### PR TITLE
feat(ui): semantic badge token system + ratchet guard (protocol/note/accent/structural)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -103,24 +103,39 @@ Standard Tailwind type scale. No custom sizes or tracking. Use Tailwind utilitie
 Hover/disabled states are built into the classes. For non-brand buttons, use shadcn/ui `<Button>` variants.
 
 ### Badges
-Use the `<Badge>` component from `@skyhook-io/k8s-ui` — never hand-write badge color strings.
+Use the `<Badge>` component from `@skyhook-io/k8s-ui` — **never hand-write badge
+color strings** (`bg-<color>-NN/NN text-<color>-NN …`). Those bypass the theme
+(they're dark-tuned and wash out in light mode) and, worse, *overload hues across
+intents* — a green `bg-green-500/20` "HTTPS" chip becomes indistinguishable from a
+green "success" chip, so retuning "success" silently recolors every HTTPS tag.
+
+**Pick the prop by what the badge MEANS, not by the color you want** (tokens are
+named by intent so a future retune moves exactly the right ones):
+
+| The badge represents… | Use | Example |
+|---|---|---|
+| a status / outcome | `severity=` (`success`/`warning`/`alert`/`error`/`info`/`neutral`) | `<Badge severity="error">Failed</Badge>` |
+| resource health | `severity=` via `mapHealthToTone` / `getHealthBadgeColor` | health tone |
+| a K8s/CRD **resource kind** | `kind=` | `<Badge kind="Middleware">Middleware</Badge>` |
+| a transport **protocol/scheme** | `protocol=` (http/https/tls/tcp/udp/grpc/h2) | `<Badge protocol="HTTPS">HTTPS</Badge>` |
+| a neutral **attention/FYI** marker (cross-namespace, wildcard, default, immutable) | `tone="note"` | `<Badge tone="note">cross-namespace</Badge>` |
+| **local** categorical distinction (rw/ro, spot/on-demand, control-plane/worker) — hue has no global meaning, just "tell siblings apart" | `tone="accent1"`/`"accent2"`/`"accent3"` | `<Badge tone="accent1">rw</Badge>` |
+| a **structural** data fragment (port, path, host, weight, name, count) | `tone="structural"` | `<Badge tone="structural" size="sm">:8080</Badge>` |
+| genuinely one-off (last resort) | `colorClass=` | `<Badge colorClass="…">Custom</Badge>` |
 
 ```tsx
-// Status badge
 <Badge severity="success">Running</Badge>
-<Badge severity="warning">Pending</Badge>
-<Badge severity="error">Failed</Badge>
-
-// Resource kind badge
-<Badge kind="Deployment">Deployment</Badge>
 <Badge kind="Pod">my-pod</Badge>
-
-// Custom color (rare — prefer severity/kind)
-<Badge colorClass="...">Custom</Badge>
-
-// Small variant
-<Badge severity="info" size="sm">Info</Badge>
+<Badge protocol="TCP">TCP</Badge>      {/* protocol ≠ severity: TCP is indigo, not orange/success */}
+<Badge tone="note">wildcard</Badge>
+<Badge tone="structural" size="sm">:443</Badge>
 ```
+
+If you reach for `colorClass`, first ask whether you're inventing an intent that
+should be a named token here instead — if two places want "the same accent",
+that's a token, not two literals. A ratchet test
+(`badge-no-handrolled.test.tsx`) fails CI if a renderer **adds** a hand-rolled
+chip; the existing baseline shrinks over time, never grows.
 
 For programmatic color lookup (e.g., dynamic table cells):
 - `getKindColorClass(kind)` — returns Tailwind classes for a K8s resource kind

--- a/packages/k8s-ui/src/components/resources/renderers/EndpointSliceRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/EndpointSliceRenderer.tsx
@@ -1,6 +1,7 @@
 import { Radio, Server, Waypoints } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property } from '../../ui/drawer-components'
+import { Badge } from '../../ui/Badge'
 import type { ResourceRef } from '../../../types'
 
 interface EndpointSliceRendererProps {
@@ -69,7 +70,7 @@ export function EndpointSliceRenderer({ data, onNavigate }: EndpointSliceRendere
                     )}
                   </div>
                   <div className="flex items-center gap-2 shrink-0">
-                    <span className="badge-sm bg-theme-elevated text-theme-text-secondary border border-theme-border">{port.protocol || 'TCP'}</span>
+                    <Badge size="sm" protocol={port.protocol || 'TCP'}>{port.protocol || 'TCP'}</Badge>
                     <span className="font-mono text-theme-text-secondary">{port.port ?? '-'}</span>
                   </div>
                 </div>
@@ -92,9 +93,9 @@ export function EndpointSliceRenderer({ data, onNavigate }: EndpointSliceRendere
                     <div className="min-w-0 space-y-1">
                       <div className="flex flex-wrap items-center gap-1.5">
                         {(endpoint.addresses || []).map((address: string) => (
-                          <span key={address} className="badge-sm bg-theme-elevated text-theme-text-primary border border-theme-border font-mono">
+                          <Badge key={address} size="sm" tone="structural" className="font-mono">
                             {address}
-                          </span>
+                          </Badge>
                         ))}
                       </div>
                       {targetLabel && (

--- a/packages/k8s-ui/src/components/resources/renderers/GRPCRouteRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/GRPCRouteRenderer.tsx
@@ -1,6 +1,6 @@
 import { Globe, ArrowRight, Network, Filter } from 'lucide-react'
-import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceRefBadge } from '../../ui/drawer-components'
+import { Badge } from '../../ui/Badge'
 import type { ResourceRef } from '../../../types'
 
 interface GRPCRouteRendererProps {
@@ -77,7 +77,7 @@ export function GRPCRouteRenderer({ data, onNavigate }: GRPCRouteRendererProps) 
               hostnames.length > 0 ? (
                 <div className="flex flex-wrap gap-1">
                   {hostnames.map((h: string) => (
-                    <span key={h} className="badge bg-theme-elevated text-theme-text-secondary">{h}</span>
+                    <Badge key={h} tone="structural">{h}</Badge>
                   ))}
                 </div>
               ) : (
@@ -150,7 +150,7 @@ export function GRPCRouteRenderer({ data, onNavigate }: GRPCRouteRendererProps) 
                       {match.method && (
                         <>
                           {match.method.type && match.method.type !== 'Exact' && (
-                            <span className="px-1.5 py-0.5 bg-amber-500/20 text-amber-400 rounded text-[10px]">{match.method.type}</span>
+                            <Badge tone="accent1" size="sm">{match.method.type}</Badge>
                           )}
                           {match.method.service && (
                             <span>
@@ -200,9 +200,9 @@ export function GRPCRouteRenderer({ data, onNavigate }: GRPCRouteRendererProps) 
                     <div className="text-xs text-theme-text-secondary flex flex-wrap items-center gap-1.5">
                       <Filter className="w-3 h-3 text-theme-text-tertiary" />
                       {filters.map((filter: any, filterIdx: number) => (
-                        <span key={filterIdx} className="px-1.5 py-0.5 bg-amber-500/20 text-amber-400 rounded">
+                        <Badge key={filterIdx} tone="accent1" size="sm">
                           {filter.type}
-                        </span>
+                        </Badge>
                       ))}
                     </div>
                   </div>
@@ -231,20 +231,14 @@ export function GRPCRouteRenderer({ data, onNavigate }: GRPCRouteRendererProps) 
                   </div>
                   <div className="flex flex-wrap gap-2">
                     {accepted && (
-                      <span className={clsx(
-                        'badge',
-                        accepted.status === 'True' ? 'bg-green-500/20 text-green-400' : 'bg-red-500/20 text-red-400'
-                      )}>
+                      <Badge severity={accepted.status === 'True' ? 'success' : 'error'}>
                         {accepted.status === 'True' ? 'Accepted' : 'Not Accepted'}
-                      </span>
+                      </Badge>
                     )}
                     {resolved && (
-                      <span className={clsx(
-                        'badge',
-                        resolved.status === 'True' ? 'bg-green-500/20 text-green-400' : 'bg-yellow-500/20 text-yellow-400'
-                      )}>
+                      <Badge severity={resolved.status === 'True' ? 'success' : 'warning'}>
                         {resolved.status === 'True' ? 'Refs Resolved' : 'Unresolved Refs'}
-                      </span>
+                      </Badge>
                     )}
                   </div>
                   {accepted?.message && accepted.status === 'False' && (

--- a/packages/k8s-ui/src/components/resources/renderers/GatewayClassRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/GatewayClassRenderer.tsx
@@ -1,7 +1,6 @@
 import { Cpu } from 'lucide-react'
-import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, AlertBanner } from '../../ui/drawer-components'
-import { BADGE_INACTIVE } from '../../../utils/badge-colors'
+import { Badge } from '../../ui/Badge'
 
 interface GatewayClassRendererProps {
   data: any
@@ -35,16 +34,9 @@ export function GatewayClassRenderer({ data }: GatewayClassRendererProps) {
           <Property
             label="Accepted"
             value={
-              <span className={clsx(
-                'badge',
-                isAccepted
-                  ? 'bg-green-500/20 text-green-400'
-                  : isNotAccepted
-                    ? 'bg-red-500/20 text-red-400'
-                    : BADGE_INACTIVE
-              )}>
+              <Badge severity={isAccepted ? 'success' : isNotAccepted ? 'error' : 'neutral'}>
                 {isAccepted ? 'True' : isNotAccepted ? 'False' : 'Unknown'}
-              </span>
+              </Badge>
             }
           />
         </PropertyList>

--- a/packages/k8s-ui/src/components/resources/renderers/GatewayRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/GatewayRenderer.tsx
@@ -2,14 +2,7 @@ import { Globe, Radio, Lock } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
 import { BADGE_INACTIVE } from '../../../utils/badge-colors'
-
-const protocolColors: Record<string, string> = {
-  HTTP: 'bg-blue-500/20 text-blue-400',
-  HTTPS: 'bg-green-500/20 text-green-400',
-  TLS: 'bg-green-500/20 text-green-400',
-  TCP: 'bg-orange-500/20 text-orange-400',
-  UDP: 'bg-purple-500/20 text-purple-400',
-}
+import { Badge } from '../../ui/Badge'
 
 interface GatewayRendererProps {
   data: any
@@ -68,31 +61,17 @@ export function GatewayRenderer({ data, onNavigate }: GatewayRendererProps) {
           <Property
             label="Accepted"
             value={
-              <span className={clsx(
-                'badge',
-                isAccepted
-                  ? 'bg-green-500/20 text-green-400'
-                  : isNotAccepted
-                    ? 'bg-red-500/20 text-red-400'
-                    : BADGE_INACTIVE
-              )}>
+              <Badge severity={isAccepted ? 'success' : isNotAccepted ? 'error' : 'neutral'}>
                 {isAccepted ? 'True' : isNotAccepted ? 'False' : 'Unknown'}
-              </span>
+              </Badge>
             }
           />
           <Property
             label="Programmed"
             value={
-              <span className={clsx(
-                'badge',
-                isProgrammed
-                  ? 'bg-green-500/20 text-green-400'
-                  : isNotProgrammed
-                    ? 'bg-red-500/20 text-red-400'
-                    : BADGE_INACTIVE
-              )}>
+              <Badge severity={isProgrammed ? 'success' : isNotProgrammed ? 'error' : 'neutral'}>
                 {isProgrammed ? 'True' : isNotProgrammed ? 'False' : 'Unknown'}
-              </span>
+              </Badge>
             }
           />
         </PropertyList>
@@ -133,23 +112,20 @@ export function GatewayRenderer({ data, onNavigate }: GatewayRendererProps) {
                   <div className="flex items-center gap-2">
                     {isHTTPS && <Lock className="w-3.5 h-3.5 text-green-400" />}
                     <span className="text-sm font-medium text-theme-text-primary">{listener.name}</span>
-                    <span className={clsx(
-                      'px-1.5 py-0.5 rounded text-[10px] font-medium',
-                      protocolColors[listener.protocol] || BADGE_INACTIVE
-                    )}>
+                    <Badge protocol={listener.protocol} size="sm">
                       {listener.protocol}:{listener.port}
-                    </span>
+                    </Badge>
                   </div>
                   <div className="flex items-center gap-1">
                     {isConflicted && (
-                      <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-500/20 text-red-400">
+                      <Badge severity="error" size="sm">
                         Conflicted
-                      </span>
+                      </Badge>
                     )}
                     {hasUnresolvedRefs && (
-                      <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-yellow-500/20 text-yellow-400">
+                      <Badge severity="warning" size="sm">
                         Unresolved Refs
-                      </span>
+                      </Badge>
                     )}
                     {listenerAccepted && (
                       <span className={clsx(

--- a/packages/k8s-ui/src/components/resources/renderers/HTTPRouteRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/HTTPRouteRenderer.tsx
@@ -1,6 +1,6 @@
 import { Globe, ArrowRight, Network, Filter } from 'lucide-react'
-import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceRefBadge } from '../../ui/drawer-components'
+import { Badge } from '../../ui/Badge'
 import type { ResourceRef } from '../../../types'
 
 interface HTTPRouteRendererProps {
@@ -77,7 +77,7 @@ export function HTTPRouteRenderer({ data, onNavigate }: HTTPRouteRendererProps) 
               hostnames.length > 0 ? (
                 <div className="flex flex-wrap gap-1">
                   {hostnames.map((h: string) => (
-                    <span key={h} className="badge bg-theme-elevated text-theme-text-secondary">{h}</span>
+                    <Badge key={h} tone="structural">{h}</Badge>
                   ))}
                 </div>
               ) : (
@@ -148,9 +148,9 @@ export function HTTPRouteRenderer({ data, onNavigate }: HTTPRouteRendererProps) 
                   {matches.map((match: any, matchIdx: number) => (
                     <div key={matchIdx} className="text-xs text-theme-text-secondary flex flex-wrap items-center gap-1.5">
                       {match.method && (
-                        <span className="px-1.5 py-0.5 bg-blue-500/20 text-blue-400 rounded font-medium">
+                        <Badge tone="structural" size="sm">
                           {match.method}
-                        </span>
+                        </Badge>
                       )}
                       {match.path && (
                         <span>
@@ -201,9 +201,9 @@ export function HTTPRouteRenderer({ data, onNavigate }: HTTPRouteRendererProps) 
                       <Filter className="w-3 h-3 text-theme-text-tertiary" />
                       {filters.map((filter: any, filterIdx: number) => (
                         <span key={filterIdx} className="inline-flex items-center gap-1">
-                          <span className="px-1.5 py-0.5 bg-amber-500/20 text-amber-400 rounded">
+                          <Badge tone="accent1" size="sm">
                             {filter.type}
-                          </span>
+                          </Badge>
                           {filter.type === 'RequestHeaderModifier' && filter.requestHeaderModifier && (
                             <span className="text-theme-text-tertiary">
                               {summarizeHeaderModifier(filter.requestHeaderModifier)}
@@ -263,20 +263,14 @@ export function HTTPRouteRenderer({ data, onNavigate }: HTTPRouteRendererProps) 
                   </div>
                   <div className="flex flex-wrap gap-2">
                     {accepted && (
-                      <span className={clsx(
-                        'badge',
-                        accepted.status === 'True' ? 'bg-green-500/20 text-green-400' : 'bg-red-500/20 text-red-400'
-                      )}>
+                      <Badge severity={accepted.status === 'True' ? 'success' : 'error'}>
                         {accepted.status === 'True' ? 'Accepted' : 'Not Accepted'}
-                      </span>
+                      </Badge>
                     )}
                     {resolved && (
-                      <span className={clsx(
-                        'badge',
-                        resolved.status === 'True' ? 'bg-green-500/20 text-green-400' : 'bg-yellow-500/20 text-yellow-400'
-                      )}>
+                      <Badge severity={resolved.status === 'True' ? 'success' : 'warning'}>
                         {resolved.status === 'True' ? 'Refs Resolved' : 'Unresolved Refs'}
-                      </span>
+                      </Badge>
                     )}
                   </div>
                   {accepted?.message && accepted.status === 'False' && (

--- a/packages/k8s-ui/src/components/resources/renderers/HelmRepositoryRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/HelmRepositoryRenderer.tsx
@@ -1,6 +1,6 @@
 import { Database, CheckCircle2, Shield } from 'lucide-react'
-import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, ProblemAlerts } from '../../ui/drawer-components'
+import { Badge } from '../../ui/Badge'
 import { formatAge } from '../resource-utils'
 import { formatBytes } from '../../../utils/format'
 import { GitOpsStatusBadge, SyncCountdown } from '../../gitops'
@@ -58,12 +58,9 @@ export function HelmRepositoryRenderer({ data }: HelmRepositoryRendererProps) {
           <Property
             label="Type"
             value={
-              <span className={clsx(
-                'badge',
-                isOCI ? 'bg-purple-500/20 text-purple-400' : 'bg-blue-500/20 text-blue-400'
-              )}>
+              <Badge tone={isOCI ? 'accent2' : 'accent1'}>
                 {isOCI ? 'OCI' : 'HTTP'}
-              </span>
+              </Badge>
             }
           />
           {spec.provider && <Property label="Provider" value={spec.provider} />}

--- a/packages/k8s-ui/src/components/resources/renderers/IstioAuthorizationPolicyRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/IstioAuthorizationPolicyRenderer.tsx
@@ -1,18 +1,17 @@
 import { Shield } from 'lucide-react'
-import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, AlertBanner, KeyValueBadgeList } from '../../ui/drawer-components'
+import { Badge, type BadgeSeverity } from '../../ui/Badge'
 import {
   getAuthorizationPolicyAction,
   getAuthorizationPolicyRules,
   getAuthorizationPolicySelector,
 } from '../resource-utils-istio'
-import { BADGE_INACTIVE } from '../../../utils/badge-colors'
 
-const actionColors: Record<string, string> = {
-  ALLOW: 'bg-green-500/20 text-green-400',
-  DENY: 'bg-red-500/20 text-red-400',
-  CUSTOM: 'bg-blue-500/20 text-blue-400',
-  AUDIT: 'bg-yellow-500/20 text-yellow-400',
+const actionSeverity: Record<string, BadgeSeverity> = {
+  ALLOW: 'success',
+  DENY: 'error',
+  CUSTOM: 'info',
+  AUDIT: 'warning',
 }
 
 interface IstioAuthorizationPolicyRendererProps {
@@ -51,12 +50,9 @@ export function IstioAuthorizationPolicyRenderer({ data }: IstioAuthorizationPol
       <Section title="Authorization Policy" icon={Shield} defaultExpanded>
         <PropertyList>
           <Property label="Action" value={
-            <span className={clsx(
-              'badge',
-              actionColors[action] || BADGE_INACTIVE
-            )}>
+            <Badge severity={actionSeverity[action] ?? 'neutral'}>
               {action}
-            </span>
+            </Badge>
           } />
           <Property label="Scope" value={hasSelector ? 'Workload-scoped' : 'Namespace-wide'} />
           <Property label="Rules" value={String(rules.length)} />
@@ -88,24 +84,24 @@ export function IstioAuthorizationPolicyRenderer({ data }: IstioAuthorizationPol
                     {rule.from.map((f: any, fi: number) => (
                       <div key={fi} className="flex flex-wrap gap-1 mb-1">
                         {f.source?.principals?.map((p: string, pi: number) => (
-                          <span key={`p-${pi}`} className="badge-sm bg-blue-500/10 text-blue-400">
+                          <Badge key={`p-${pi}`} tone="structural" size="sm">
                             principal: {p}
-                          </span>
+                          </Badge>
                         ))}
                         {f.source?.namespaces?.map((n: string, ni: number) => (
-                          <span key={`n-${ni}`} className="badge-sm bg-purple-500/10 text-purple-400">
+                          <Badge key={`n-${ni}`} tone="structural" size="sm">
                             namespace: {n}
-                          </span>
+                          </Badge>
                         ))}
                         {f.source?.ipBlocks?.map((ip: string, ipi: number) => (
-                          <span key={`ip-${ipi}`} className="badge-sm bg-orange-500/10 text-orange-400">
+                          <Badge key={`ip-${ipi}`} tone="structural" size="sm">
                             IP: {ip}
-                          </span>
+                          </Badge>
                         ))}
                         {f.source?.requestPrincipals?.map((rp: string, rpi: number) => (
-                          <span key={`rp-${rpi}`} className="badge-sm bg-cyan-500/10 text-cyan-400">
+                          <Badge key={`rp-${rpi}`} tone="structural" size="sm">
                             reqPrincipal: {rp}
-                          </span>
+                          </Badge>
                         ))}
                       </div>
                     ))}
@@ -119,24 +115,24 @@ export function IstioAuthorizationPolicyRenderer({ data }: IstioAuthorizationPol
                     {rule.to.map((t: any, ti: number) => (
                       <div key={ti} className="flex flex-wrap gap-1 mb-1">
                         {t.operation?.hosts?.map((h: string, hi: number) => (
-                          <span key={`h-${hi}`} className="badge-sm bg-blue-500/10 text-blue-400">
+                          <Badge key={`h-${hi}`} tone="structural" size="sm">
                             host: {h}
-                          </span>
+                          </Badge>
                         ))}
                         {t.operation?.ports?.map((p: string, pi: number) => (
-                          <span key={`p-${pi}`} className="badge-sm bg-orange-500/10 text-orange-400">
+                          <Badge key={`p-${pi}`} tone="structural" size="sm">
                             port: {p}
-                          </span>
+                          </Badge>
                         ))}
                         {t.operation?.methods?.map((m: string, mi: number) => (
-                          <span key={`m-${mi}`} className="badge-sm bg-green-500/10 text-green-400">
+                          <Badge key={`m-${mi}`} tone="structural" size="sm">
                             method: {m}
-                          </span>
+                          </Badge>
                         ))}
                         {t.operation?.paths?.map((p: string, pi: number) => (
-                          <span key={`path-${pi}`} className="badge-sm bg-purple-500/10 text-purple-400">
+                          <Badge key={`path-${pi}`} tone="structural" size="sm">
                             path: {p}
-                          </span>
+                          </Badge>
                         ))}
                       </div>
                     ))}

--- a/packages/k8s-ui/src/components/resources/renderers/IstioGatewayRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/IstioGatewayRenderer.tsx
@@ -80,13 +80,16 @@ export function IstioGatewayRenderer({ data }: IstioGatewayRendererProps) {
                         <div>
                           <span className="text-theme-text-tertiary">TLS Mode: </span>
                           <Badge
+                            // Every TLS server row already shows a teal HTTPS/TLS protocol pill, so
+                            // a teal mode badge would collide. PASSTHROUGH uses `note` (the mode where
+                            // the gateway does not terminate TLS — the one worth flagging) to stay clear.
                             tone={
                               server.tls.mode === 'SIMPLE'
                                 ? 'accent1'
                                 : server.tls.mode === 'MUTUAL' || server.tls.mode === 'ISTIO_MUTUAL'
                                   ? 'accent2'
                                   : server.tls.mode === 'PASSTHROUGH' || server.tls.mode === 'AUTO_PASSTHROUGH'
-                                    ? 'accent3'
+                                    ? 'note'
                                     : 'structural'
                             }
                             size="sm"

--- a/packages/k8s-ui/src/components/resources/renderers/IstioGatewayRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/IstioGatewayRenderer.tsx
@@ -1,23 +1,12 @@
 import { Globe, Lock } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, AlertBanner, KeyValueBadgeList } from '../../ui/drawer-components'
+import { Badge } from '../../ui/Badge'
 import {
   getIstioGatewayStatus,
   getIstioGatewayServers,
   getIstioGatewaySelector,
 } from '../resource-utils-istio'
-import { BADGE_INACTIVE } from '../../../utils/badge-colors'
-
-const protocolColors: Record<string, string> = {
-  HTTP: 'bg-blue-500/20 text-blue-400',
-  HTTPS: 'bg-green-500/20 text-green-400',
-  HTTP2: 'bg-blue-500/20 text-blue-400',
-  GRPC: 'bg-purple-500/20 text-purple-400',
-  TCP: 'bg-orange-500/20 text-orange-400',
-  TLS: 'bg-green-500/20 text-green-400',
-  MONGO: 'bg-emerald-500/20 text-emerald-400',
-  MYSQL: 'bg-cyan-500/20 text-cyan-400',
-}
 
 interface IstioGatewayRendererProps {
   data: any
@@ -72,12 +61,9 @@ export function IstioGatewayRenderer({ data }: IstioGatewayRendererProps) {
                       <span className="text-sm font-medium text-theme-text-primary">
                         {server.port.name || `Port ${server.port.number}`}
                       </span>
-                      <span className={clsx(
-                        'px-1.5 py-0.5 rounded text-[10px] font-medium',
-                        protocolColors[protocol] || BADGE_INACTIVE
-                      )}>
+                      <Badge protocol={protocol} size="sm">
                         {protocol}:{server.port.number}
-                      </span>
+                      </Badge>
                     </div>
                   </div>
 
@@ -93,16 +79,20 @@ export function IstioGatewayRenderer({ data }: IstioGatewayRendererProps) {
                       <>
                         <div>
                           <span className="text-theme-text-tertiary">TLS Mode: </span>
-                          <span className={clsx(
-                            'px-1.5 py-0.5 rounded text-[10px] font-medium',
-                            server.tls.mode === 'SIMPLE' || server.tls.mode === 'MUTUAL'
-                              ? 'bg-green-500/20 text-green-400'
-                              : server.tls.mode === 'PASSTHROUGH'
-                                ? 'bg-blue-500/20 text-blue-400'
-                                : BADGE_INACTIVE
-                          )}>
+                          <Badge
+                            tone={
+                              server.tls.mode === 'SIMPLE'
+                                ? 'accent1'
+                                : server.tls.mode === 'MUTUAL'
+                                  ? 'accent2'
+                                  : server.tls.mode === 'PASSTHROUGH'
+                                    ? 'accent3'
+                                    : undefined
+                            }
+                            size="sm"
+                          >
                             {server.tls.mode || 'SIMPLE'}
-                          </span>
+                          </Badge>
                         </div>
                         {server.tls.credentialName && (
                           <div>

--- a/packages/k8s-ui/src/components/resources/renderers/IstioGatewayRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/IstioGatewayRenderer.tsx
@@ -83,11 +83,11 @@ export function IstioGatewayRenderer({ data }: IstioGatewayRendererProps) {
                             tone={
                               server.tls.mode === 'SIMPLE'
                                 ? 'accent1'
-                                : server.tls.mode === 'MUTUAL'
+                                : server.tls.mode === 'MUTUAL' || server.tls.mode === 'ISTIO_MUTUAL'
                                   ? 'accent2'
-                                  : server.tls.mode === 'PASSTHROUGH'
+                                  : server.tls.mode === 'PASSTHROUGH' || server.tls.mode === 'AUTO_PASSTHROUGH'
                                     ? 'accent3'
-                                    : undefined
+                                    : 'structural'
                             }
                             size="sm"
                           >

--- a/packages/k8s-ui/src/components/resources/renderers/IstioVirtualServiceRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/IstioVirtualServiceRenderer.tsx
@@ -1,6 +1,7 @@
 import { Network, Route } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceLink } from '../../ui/drawer-components'
+import { Badge } from '../../ui/Badge'
 import {
   getVirtualServiceStatus,
   getVirtualServiceHostsList,
@@ -62,7 +63,7 @@ export function IstioVirtualServiceRenderer({ data, onNavigate }: IstioVirtualSe
                 {gateways.map((gw, i) => {
                   // Gateway reference can be "namespace/name" or just "name" or "mesh"
                   if (gw === 'mesh') {
-                    return <span key={i} className="badge-sm bg-theme-hover text-theme-text-secondary">mesh</span>
+                    return <Badge key={i} tone="structural" size="sm">mesh</Badge>
                   }
                   const parts = gw.split('/')
                   const gwNs = parts.length === 2 ? parts[0] : ns
@@ -95,19 +96,19 @@ export function IstioVirtualServiceRenderer({ data, onNavigate }: IstioVirtualSe
                     {route.name || `Route ${i + 1}`}
                   </span>
                   {route.timeout && (
-                    <span className="px-1.5 py-0.5 bg-theme-hover rounded text-[10px] text-theme-text-secondary">
+                    <Badge tone="structural" size="sm">
                       timeout: {route.timeout}
-                    </span>
+                    </Badge>
                   )}
                   {route.fault && (
-                    <span className="px-1.5 py-0.5 bg-yellow-500/20 text-yellow-400 rounded text-[10px] font-medium">
+                    <Badge severity="warning" size="sm">
                       fault injection
-                    </span>
+                    </Badge>
                   )}
                   {route.mirror && (
-                    <span className="px-1.5 py-0.5 bg-purple-500/20 text-purple-400 rounded text-[10px] font-medium">
+                    <Badge tone="note" size="sm">
                       mirroring
-                    </span>
+                    </Badge>
                   )}
                 </div>
 
@@ -119,19 +120,19 @@ export function IstioVirtualServiceRenderer({ data, onNavigate }: IstioVirtualSe
                       {route.match.map((m: any, mi: number) => (
                         <div key={mi} className="flex flex-wrap gap-1 text-xs">
                           {m.uri && (
-                            <span className="px-1.5 py-0.5 bg-blue-500/10 text-blue-400 rounded">
+                            <Badge tone="structural" size="sm">
                               URI {Object.keys(m.uri)[0]}: {Object.values(m.uri)[0] as string}
-                            </span>
+                            </Badge>
                           )}
                           {m.method && (
-                            <span className="px-1.5 py-0.5 bg-blue-500/10 text-blue-400 rounded">
+                            <Badge tone="structural" size="sm">
                               Method: {m.method.exact || Object.values(m.method)[0]}
-                            </span>
+                            </Badge>
                           )}
                           {m.headers && Object.entries(m.headers).map(([hk, hv]: [string, any]) => (
-                            <span key={hk} className="px-1.5 py-0.5 bg-blue-500/10 text-blue-400 rounded">
+                            <Badge key={hk} tone="structural" size="sm">
                               Header {hk}: {typeof hv === 'object' ? Object.values(hv)[0] as string : String(hv)}
-                            </span>
+                            </Badge>
                           ))}
                         </div>
                       ))}
@@ -174,9 +175,9 @@ export function IstioVirtualServiceRenderer({ data, onNavigate }: IstioVirtualSe
                               <span className="text-theme-text-tertiary">:{destPort}</span>
                             )}
                             {destSubset && (
-                              <span className="px-1.5 py-0.5 bg-theme-hover rounded text-theme-text-secondary">
+                              <Badge tone="structural" size="sm">
                                 subset: {destSubset}
-                              </span>
+                              </Badge>
                             )}
                           </div>
                         )
@@ -201,16 +202,16 @@ export function IstioVirtualServiceRenderer({ data, onNavigate }: IstioVirtualSe
                 {route.fault && (
                   <div className="flex flex-wrap gap-2 text-xs">
                     {route.fault.delay && (
-                      <span className="px-1.5 py-0.5 bg-yellow-500/10 text-yellow-400 rounded">
+                      <Badge severity="warning" size="sm">
                         Delay: {route.fault.delay.fixedDelay}
                         {route.fault.delay.percentage?.value && ` (${route.fault.delay.percentage.value}%)`}
-                      </span>
+                      </Badge>
                     )}
                     {route.fault.abort && (
-                      <span className="px-1.5 py-0.5 bg-red-500/10 text-red-400 rounded">
+                      <Badge severity="error" size="sm">
                         Abort: HTTP {route.fault.abort.httpStatus}
                         {route.fault.abort.percentage?.value && ` (${route.fault.abort.percentage.value}%)`}
-                      </span>
+                      </Badge>
                     )}
                   </div>
                 )}

--- a/packages/k8s-ui/src/components/resources/renderers/KnativeNetworkingRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KnativeNetworkingRenderer.tsx
@@ -1,6 +1,7 @@
 import { Network, ShieldCheck, Server, Globe } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, KnativeNotReadyBanner, ResourceLink } from '../../ui/drawer-components'
+import { Badge } from '../../ui/Badge'
 import { kindToPlural } from '../../../utils/navigation'
 import { getKnativeConditionStatus } from '../resource-utils-knative'
 
@@ -43,14 +44,14 @@ export function KnativeIngressRenderer({ data }: RendererProps) {
               <div key={i} className="card-inner-lg">
                 <div className="flex flex-wrap gap-1 mb-2">
                   {(rule.hosts || []).map((host: string, hi: number) => (
-                    <span key={hi} className="badge-sm bg-blue-500/10 text-blue-400">
+                    <Badge key={hi} size="sm" tone="structural">
                       {host}
-                    </span>
+                    </Badge>
                   ))}
                   {rule.visibility && (
-                    <span className="px-1.5 py-0.5 bg-theme-hover rounded text-[10px] text-theme-text-secondary">
+                    <Badge size="sm" tone="structural">
                       {rule.visibility}
-                    </span>
+                    </Badge>
                   )}
                 </div>
                 {rule.http?.paths && rule.http.paths.length > 0 && (
@@ -117,9 +118,9 @@ export function KnativeCertificateRenderer({ data }: RendererProps) {
         <Section title={`DNS Names (${dnsNames.length})`} defaultExpanded>
           <div className="flex flex-wrap gap-1">
             {dnsNames.map((name: string, i: number) => (
-              <span key={i} className="badge-sm bg-theme-elevated text-theme-text-secondary">
+              <Badge key={i} size="sm" tone="structural">
                 {name}
-              </span>
+              </Badge>
             ))}
           </div>
         </Section>
@@ -157,12 +158,9 @@ export function ServerlessServiceRenderer({ data, onNavigate }: RendererProps) {
             </span>
           } />
           <Property label="Mode" value={mode ? (
-            <span className={clsx(
-              'badge',
-              mode === 'Proxy' ? 'bg-yellow-500/20 text-yellow-400' : 'bg-green-500/20 text-green-400'
-            )}>
+            <Badge tone={mode === 'Proxy' ? 'accent1' : 'accent2'}>
               {mode}
-            </span>
+            </Badge>
           ) : undefined} />
           <Property label="Activators" value={numActivators != null ? String(numActivators) : undefined} />
           <Property label="Protocol" value={protocolType} />

--- a/packages/k8s-ui/src/components/resources/renderers/SimpleRouteRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/SimpleRouteRenderer.tsx
@@ -1,6 +1,6 @@
 import { Globe, ArrowRight, Network } from 'lucide-react'
-import { clsx } from 'clsx'
 import { Section, PropertyList, Property, ConditionsSection, AlertBanner, ResourceRefBadge } from '../../ui/drawer-components'
+import { Badge } from '../../ui/Badge'
 import type { ResourceRef } from '../../../types'
 
 interface SimpleRouteRendererProps {
@@ -81,7 +81,7 @@ export function SimpleRouteRenderer({ data, kind, onNavigate }: SimpleRouteRende
                 hostnames.length > 0 ? (
                   <div className="flex flex-wrap gap-1">
                     {hostnames.map((h: string) => (
-                      <span key={h} className="badge bg-theme-elevated text-theme-text-secondary">{h}</span>
+                      <Badge key={h} tone="structural">{h}</Badge>
                     ))}
                   </div>
                 ) : (
@@ -163,20 +163,14 @@ export function SimpleRouteRenderer({ data, kind, onNavigate }: SimpleRouteRende
                   </div>
                   <div className="flex flex-wrap gap-2">
                     {accepted && (
-                      <span className={clsx(
-                        'badge',
-                        accepted.status === 'True' ? 'bg-green-500/20 text-green-400' : 'bg-red-500/20 text-red-400'
-                      )}>
+                      <Badge severity={accepted.status === 'True' ? 'success' : 'error'}>
                         {accepted.status === 'True' ? 'Accepted' : 'Not Accepted'}
-                      </span>
+                      </Badge>
                     )}
                     {resolved && (
-                      <span className={clsx(
-                        'badge',
-                        resolved.status === 'True' ? 'bg-green-500/20 text-green-400' : 'bg-yellow-500/20 text-yellow-400'
-                      )}>
+                      <Badge severity={resolved.status === 'True' ? 'success' : 'warning'}>
                         {resolved.status === 'True' ? 'Refs Resolved' : 'Unresolved Refs'}
-                      </span>
+                      </Badge>
                     )}
                   </div>
                   {accepted?.message && accepted.status === 'False' && (

--- a/packages/k8s-ui/src/components/resources/renderers/TraefikIngressRouteRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/TraefikIngressRouteRenderer.tsx
@@ -1,5 +1,6 @@
 import { Globe, Route, Layers, Lock } from 'lucide-react'
 import { Section, PropertyList, Property, AlertBanner, ResourceLink } from '../../ui/drawer-components'
+import { Badge } from '../../ui/Badge'
 
 interface TraefikIngressRouteRendererProps {
   data: any
@@ -84,14 +85,14 @@ export function TraefikIngressRouteRenderer({ data, onNavigate }: TraefikIngress
                     {route.match || 'No match rule'}
                   </span>
                   {route.priority && (
-                    <span className="px-1.5 py-0.5 bg-theme-hover rounded text-[10px] text-theme-text-secondary shrink-0">
+                    <Badge tone="structural" size="sm" className="shrink-0">
                       priority: {route.priority}
-                    </span>
+                    </Badge>
                   )}
                   {route.kind && route.kind !== 'Rule' && (
-                    <span className="px-1.5 py-0.5 bg-theme-hover rounded text-[10px] text-theme-text-secondary shrink-0">
+                    <Badge tone="structural" size="sm" className="shrink-0">
                       {route.kind}
-                    </span>
+                    </Badge>
                   )}
                 </div>
 
@@ -110,9 +111,9 @@ export function TraefikIngressRouteRenderer({ data, onNavigate }: TraefikIngress
                         return (
                           <div key={si} className="flex items-center gap-2 text-xs">
                             {isTraefikSvc && (
-                              <span className="px-1.5 py-0.5 bg-cyan-500/10 text-cyan-400 rounded text-[10px]">
+                              <Badge kind="TraefikService" size="sm">
                                 TraefikService
-                              </span>
+                              </Badge>
                             )}
                             <ResourceLink
                               name={svc.name}
@@ -152,9 +153,9 @@ export function TraefikIngressRouteRenderer({ data, onNavigate }: TraefikIngress
                             kind="middlewares"
                             namespace={mwNs}
                             label={
-                              <span className="px-1.5 py-0.5 bg-purple-500/10 text-purple-400 rounded text-[10px] inline-block">
+                              <Badge tone="accent1" size="sm" className="inline-block">
                                 {mw.namespace && mw.namespace !== ns ? `${mw.namespace}/` : ''}{mw.name}
-                              </span>
+                              </Badge>
                             }
                             onNavigate={onNavigate}
                           />
@@ -242,9 +243,9 @@ export function TraefikIngressRouteRenderer({ data, onNavigate }: TraefikIngress
                     onNavigate={onNavigate}
                   />
                   {isCrossNs && (
-                    <span className="px-1.5 py-0.5 bg-yellow-500/10 text-yellow-400 rounded text-[10px]">
+                    <Badge tone="note" size="sm">
                       {mw.namespace}
-                    </span>
+                    </Badge>
                   )}
                 </div>
               )

--- a/packages/k8s-ui/src/components/resources/renderers/TraefikMiddlewareRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/TraefikMiddlewareRenderer.tsx
@@ -1,5 +1,6 @@
 import { SlidersHorizontal, Layers, ShieldCheck } from 'lucide-react'
 import { Section, PropertyList, Property, AlertBanner, ResourceLink } from '../../ui/drawer-components'
+import { Badge } from '../../ui/Badge'
 import { getMiddlewareType } from '../resource-utils-traefik'
 
 interface TraefikMiddlewareRendererProps {
@@ -119,7 +120,7 @@ export function TraefikMiddlewareRenderer({ data, onNavigate }: TraefikMiddlewar
                   onNavigate={onNavigate}
                 />
                 {m.namespace && m.namespace !== ns && (
-                  <span className="px-1.5 py-0.5 bg-yellow-500/10 text-yellow-400 rounded text-[10px]">{m.namespace}</span>
+                  <Badge tone="note" size="sm">{m.namespace}</Badge>
                 )}
               </div>
             ))}

--- a/packages/k8s-ui/src/components/resources/renderers/TraefikServiceRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/TraefikServiceRenderer.tsx
@@ -1,5 +1,6 @@
 import { Split, Copy } from 'lucide-react'
 import { Section, PropertyList, Property, AlertBanner, ResourceLink } from '../../ui/drawer-components'
+import { Badge } from '../../ui/Badge'
 import { getTraefikServiceType } from '../resource-utils-traefik'
 
 interface TraefikServiceRendererProps {
@@ -17,7 +18,7 @@ function ServiceRow({ svc, ns, weightPct, onNavigate }: {
   const port = svc.port ? `:${svc.port}` : ''
   return (
     <div className="flex items-center gap-2 text-xs">
-      {isTraefik && <span className="px-1.5 py-0.5 bg-cyan-500/10 text-cyan-400 rounded text-[10px]">TraefikService</span>}
+      {isTraefik && <Badge kind="TraefikService" size="sm">TraefikService</Badge>}
       <ResourceLink
         name={svc.name}
         kind={isTraefik ? 'traefikservices' : 'services'}

--- a/packages/k8s-ui/src/components/resources/renderers/TraefikTLSOptionRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/TraefikTLSOptionRenderer.tsx
@@ -1,5 +1,6 @@
 import { Lock } from 'lucide-react'
 import { Section, PropertyList, Property } from '../../ui/drawer-components'
+import { Badge } from '../../ui/Badge'
 
 interface TraefikTLSOptionRendererProps {
   data: any
@@ -30,7 +31,7 @@ export function TraefikTLSOptionRenderer({ data }: TraefikTLSOptionRendererProps
         <Section title={`Cipher Suites (${ciphers.length})`}>
           <div className="flex flex-wrap gap-1">
             {ciphers.map((c, i) => (
-              <span key={i} className="px-1.5 py-0.5 bg-theme-hover rounded text-[10px] text-theme-text-secondary font-mono">{c}</span>
+              <Badge key={i} tone="structural" size="sm" className="font-mono">{c}</Badge>
             ))}
           </div>
         </Section>
@@ -40,7 +41,7 @@ export function TraefikTLSOptionRenderer({ data }: TraefikTLSOptionRendererProps
         <Section title={`Curve Preferences (${curves.length})`}>
           <div className="flex flex-wrap gap-1">
             {curves.map((c, i) => (
-              <span key={i} className="px-1.5 py-0.5 bg-theme-hover rounded text-[10px] text-theme-text-secondary font-mono">{c}</span>
+              <Badge key={i} tone="structural" size="sm" className="font-mono">{c}</Badge>
             ))}
           </div>
         </Section>

--- a/packages/k8s-ui/src/components/resources/renderers/badge-no-handrolled.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/badge-no-handrolled.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+// Ratchet guard for the badge token system (see DESIGN.md "Badges").
+//
+// Hand-rolled chip color strings (`bg-<color>-N/NN text-<color>-N`) bypass the
+// theme and overload hues across intents. The migration to <Badge> is
+// incremental: this test pins the set of renderer files that STILL contain
+// hand-rolled chips. The set may SHRINK (clean a file → remove it here) but must
+// never GROW — a new renderer must use <Badge>/tokens, not literal colors.
+//
+// When this fails because you cleaned a file: delete it from BASELINE.
+// When it fails because you added a chip: use <Badge severity|kind|protocol|tone>
+// instead (DESIGN.md has the decision tree).
+
+const CHIP_RE =
+  /bg-(red|green|blue|yellow|orange|amber|purple|cyan|pink|indigo|emerald|teal|violet|rose|lime|sky)-[0-9]+\/[0-9]+ text-(red|green|blue|yellow|orange|amber|purple|cyan|pink|indigo|emerald|teal|violet|rose|lime|sky)-[0-9]+/
+
+// Renderer files that still contain hand-rolled chips, pending migration.
+// Ratchet: this list only shrinks. Do not add to it.
+const BASELINE = new Set<string>([
+  'AlertRenderer.tsx', 'ArgoApplicationRenderer.tsx', 'CertificateRenderer.tsx',
+  'CertificateRequestRenderer.tsx', 'ChallengeRenderer.tsx', 'CiliumNetworkPolicyRenderer.tsx',
+  'ClusterExternalSecretRenderer.tsx', 'ClusterIssuerRenderer.tsx', 'ClusterNetworkPolicyRenderer.tsx',
+  'cnpg-cells.tsx', 'CNPGClusterRenderer.tsx', 'EventRenderer.tsx', 'GatewayRenderer.tsx',
+  'GenericRenderer.tsx', 'IngressClassRenderer.tsx', 'IstioPeerAuthenticationRenderer.tsx',
+  'IstioServiceEntryRenderer.tsx', 'KarpenterNodeClaimRenderer.tsx', 'knative-cells.tsx',
+  'KnativeEventingRenderer.tsx', 'KnativeRevisionRenderer.tsx', 'kyverno-cells.tsx',
+  'KyvernoPolicyReportRenderer.tsx', 'NetworkPolicyRenderer.tsx', 'NodeRenderer.tsx',
+  'OrderRenderer.tsx', 'PodRenderer.tsx', 'RoleRenderer.tsx', 'RolloutRenderer.tsx',
+  'SealedSecretRenderer.tsx', 'SecretRenderer.tsx', 'SecretStoreRenderer.tsx',
+  'VeleroBackupRenderer.tsx', 'VeleroRestoreRenderer.tsx', 'VeleroScheduleRenderer.tsx',
+  'VPARenderer.tsx', 'VulnerabilityReportRenderer.tsx', 'WebhookConfigRenderer.tsx',
+])
+
+const dir = fileURLToPath(new URL('.', import.meta.url))
+
+function filesWithHandRolledChips(): string[] {
+  return readdirSync(dir)
+    .filter((f) => f.endsWith('.tsx') && !f.endsWith('.test.tsx'))
+    .filter((f) => CHIP_RE.test(readFileSync(`${dir}/${f}`, 'utf8')))
+    .sort()
+}
+
+describe('badge token system — no hand-rolled chip colors', () => {
+  const offenders = filesWithHandRolledChips()
+
+  it('does not introduce hand-rolled chips in new/migrated files (ratchet only shrinks)', () => {
+    const newOffenders = offenders.filter((f) => !BASELINE.has(f))
+    expect(
+      newOffenders,
+      `These renderers use hand-rolled chip colors. Use <Badge severity|kind|protocol|tone> ` +
+        `(see DESIGN.md "Badges"), not literal bg-/text- color strings:\n  ${newOffenders.join('\n  ')}`,
+    ).toEqual([])
+  })
+
+  it('baseline has no stale entries (remove files you have already cleaned)', () => {
+    const stale = [...BASELINE].filter((f) => !offenders.includes(f)).sort()
+    expect(
+      stale,
+      `These files are in BASELINE but no longer contain hand-rolled chips — ` +
+        `delete them from BASELINE in this test:\n  ${stale.join('\n  ')}`,
+    ).toEqual([])
+  })
+})

--- a/packages/k8s-ui/src/components/resources/renderers/contour-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/contour-cells.tsx
@@ -2,6 +2,7 @@
 
 import { Shield } from 'lucide-react'
 import { Tooltip } from '../../ui/Tooltip'
+import { Badge, type BadgeSeverity } from '../../ui/Badge'
 import {
   getHTTPProxyFQDN,
   getHTTPProxyRouteCount,
@@ -36,11 +37,11 @@ export function HTTPProxyCell({ resource, column }: { resource: any; column: str
     }
     case 'status': {
       const { label } = getHTTPProxyStatus(resource)
-      const color = label === 'Valid' ? 'text-green-500'
-        : label === 'Invalid' ? 'text-red-500'
-        : label === 'Orphaned' ? 'text-yellow-500'
-        : 'text-theme-text-secondary'
-      return <span className={`text-sm ${color}`}>{label}</span>
+      const severity: BadgeSeverity = label === 'Valid' ? 'success'
+        : label === 'Invalid' ? 'error'
+        : label === 'Orphaned' ? 'warning'
+        : 'neutral'
+      return <Badge severity={severity}>{label}</Badge>
     }
     default:
       return <span className="text-sm text-theme-text-tertiary">-</span>

--- a/packages/k8s-ui/src/components/resources/renderers/istio-cells.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/istio-cells.tsx
@@ -1,7 +1,7 @@
 // Istio cell components for ResourcesView table
 
 import { clsx } from 'clsx'
-import { BADGE_INACTIVE } from '../../../utils/badge-colors'
+import { Badge, type BadgeSeverity } from '../../ui/Badge'
 import {
   getVirtualServiceStatus,
   getVirtualServiceHosts,
@@ -26,17 +26,17 @@ import {
   getAuthorizationPolicyRuleCount,
 } from '../resource-utils-istio'
 
-const modeColors: Record<string, string> = {
-  STRICT: 'bg-green-500/20 text-green-400',
-  PERMISSIVE: 'bg-yellow-500/20 text-yellow-400',
-  DISABLE: 'bg-red-500/20 text-red-400',
+const modeSeverity: Record<string, BadgeSeverity> = {
+  STRICT: 'success',
+  PERMISSIVE: 'warning',
+  DISABLE: 'error',
 }
 
-const actionColors: Record<string, string> = {
-  ALLOW: 'bg-green-500/20 text-green-400',
-  DENY: 'bg-red-500/20 text-red-400',
-  CUSTOM: 'bg-blue-500/20 text-blue-400',
-  AUDIT: 'bg-yellow-500/20 text-yellow-400',
+const actionSeverity: Record<string, BadgeSeverity> = {
+  ALLOW: 'success',
+  DENY: 'error',
+  CUSTOM: 'info',
+  AUDIT: 'warning',
 }
 
 export function VirtualServiceCell({ resource, column }: { resource: any; column: string }) {
@@ -133,12 +133,9 @@ export function ServiceEntryCell({ resource, column }: { resource: any; column: 
     case 'location': {
       const location = getServiceEntryLocation(resource)
       return (
-        <span className={clsx(
-          'badge',
-          location === 'MESH_EXTERNAL' ? 'bg-orange-500/20 text-orange-400' : 'bg-blue-500/20 text-blue-400'
-        )}>
+        <Badge tone={location === 'MESH_EXTERNAL' ? 'accent2' : 'accent1'}>
           {location === 'MESH_EXTERNAL' ? 'External' : 'Internal'}
-        </span>
+        </Badge>
       )
     }
     case 'ports': {
@@ -163,12 +160,9 @@ export function PeerAuthenticationCell({ resource, column }: { resource: any; co
     case 'mode': {
       const mode = getPeerAuthenticationMode(resource)
       return (
-        <span className={clsx(
-          'badge',
-          modeColors[mode] || BADGE_INACTIVE
-        )}>
+        <Badge severity={modeSeverity[mode] ?? 'neutral'}>
           {mode}
-        </span>
+        </Badge>
       )
     }
     case 'selector': {
@@ -193,12 +187,9 @@ export function AuthorizationPolicyCell({ resource, column }: { resource: any; c
     case 'action': {
       const action = getAuthorizationPolicyAction(resource)
       return (
-        <span className={clsx(
-          'badge',
-          actionColors[action] || BADGE_INACTIVE
-        )}>
+        <Badge severity={actionSeverity[action] ?? 'neutral'}>
           {action}
-        </span>
+        </Badge>
       )
     }
     case 'rules': {

--- a/packages/k8s-ui/src/components/ui/Badge.tsx
+++ b/packages/k8s-ui/src/components/ui/Badge.tsx
@@ -9,11 +9,31 @@ import type { ReactNode } from 'react'
 export type BadgeSeverity = 'success' | 'warning' | 'alert' | 'error' | 'info' | 'neutral'
 export type BadgeSize = 'sm' | 'default'
 
+// Intent tokens beyond severity/kind. Named by PURPOSE, not hue: two tokens may
+// share a color value today yet stay separate names so a future retune moves
+// exactly the right ones. See DESIGN.md "Badge decision tree".
+//
+// - protocol: transport/scheme tags (HTTP/TCP/UDP/…). Its OWN family because it
+//   is a recurring, meaningful axis and must NOT collide with severity hues
+//   (e.g. a green "HTTPS" must not read as "success").
+// - note:     neutral attention/FYI markers (cross-namespace, wildcard, default,
+//   immutable). Distinct from severity-info — it flags "noteworthy", not a status.
+// - accent1/2/3: LOCAL categorical distinction (rw/ro, spot/on-demand,
+//   control-plane/worker) where the hue carries no cross-screen meaning — just
+//   "tell these sibling options apart". The only place sharing is intended.
+// - structural: ports/paths/hosts/weights/names — neutral data fragments, not a
+//   status. Its own name so it can diverge from severity-neutral later.
+export type BadgeTone = 'note' | 'accent1' | 'accent2' | 'accent3' | 'structural'
+
 interface BadgeProps {
   /** Severity-based coloring (status badges) */
   severity?: BadgeSeverity
   /** K8s resource kind coloring (kind badges) */
   kind?: string
+  /** Transport protocol/scheme tag (http/https/tls/tcp/udp/grpc/h2) */
+  protocol?: string
+  /** Categorical/accent intent tone (see BadgeTone) */
+  tone?: BadgeTone
   /** Explicit color class override (bypasses severity/kind lookup) */
   colorClass?: string
   /** Size variant */
@@ -135,10 +155,45 @@ const KIND: Record<string, string> = {
 
 const DEFAULT_KIND_COLOR = 'bg-fuchsia-50 text-fuchsia-700 border-fuchsia-200 dark:bg-fuchsia-950/40 dark:text-fuchsia-400 dark:border-fuchsia-800/40'
 
+// ---------------------------------------------------------------------------
+// PROTOCOL COLORS — transport/scheme tags. Deliberately avoid severity hues
+// (emerald/amber/orange/red/sky) so a protocol never reads as a status.
+// ---------------------------------------------------------------------------
+const PROTOCOL: Record<string, string> = {
+  http:  'bg-blue-100 text-blue-700 border-blue-300 dark:bg-blue-950/50 dark:text-blue-400 dark:border-blue-700/40',
+  h2:    'bg-blue-100 text-blue-700 border-blue-300 dark:bg-blue-950/50 dark:text-blue-400 dark:border-blue-700/40',
+  h2c:   'bg-blue-100 text-blue-700 border-blue-300 dark:bg-blue-950/50 dark:text-blue-400 dark:border-blue-700/40',
+  https: 'bg-teal-100 text-teal-800 border-teal-300 dark:bg-teal-950/50 dark:text-teal-400 dark:border-teal-700/40',
+  tls:   'bg-teal-100 text-teal-800 border-teal-300 dark:bg-teal-950/50 dark:text-teal-400 dark:border-teal-700/40',
+  tcp:   'bg-indigo-100 text-indigo-700 border-indigo-300 dark:bg-indigo-950/50 dark:text-indigo-400 dark:border-indigo-700/40',
+  udp:   'bg-violet-100 text-violet-700 border-violet-300 dark:bg-violet-950/50 dark:text-violet-400 dark:border-violet-700/40',
+  grpc:  'bg-fuchsia-100 text-fuchsia-700 border-fuchsia-300 dark:bg-fuchsia-950/50 dark:text-fuchsia-400 dark:border-fuchsia-700/40',
+}
+const DEFAULT_PROTOCOL_COLOR = 'bg-slate-100 text-slate-700 border-slate-300 dark:bg-slate-950/50 dark:text-slate-400 dark:border-slate-700/40'
+
+// ---------------------------------------------------------------------------
+// TONE COLORS — note / local-categorical accents / structural.
+// ---------------------------------------------------------------------------
+const TONE: Record<BadgeTone, string> = {
+  // attention/FYI — distinct from severity so it doesn't read as warning/info
+  note:       'bg-violet-100 text-violet-700 border-violet-300 dark:bg-violet-950/50 dark:text-violet-400 dark:border-violet-700/40',
+  // three visually-distinct accents for local "tell siblings apart" use
+  accent1:    'bg-blue-100 text-blue-700 border-blue-300 dark:bg-blue-950/50 dark:text-blue-400 dark:border-blue-700/40',
+  accent2:    'bg-fuchsia-100 text-fuchsia-700 border-fuchsia-300 dark:bg-fuchsia-950/50 dark:text-fuchsia-400 dark:border-fuchsia-700/40',
+  accent3:    'bg-teal-100 text-teal-800 border-teal-300 dark:bg-teal-950/50 dark:text-teal-400 dark:border-teal-700/40',
+  // neutral data fragment (ports/paths/hosts/names)
+  structural: 'bg-theme-elevated text-theme-text-secondary border-theme-border',
+}
+
 // Structure classes
 const SIZE_CLASSES: Record<BadgeSize, string> = {
   default: 'badge',
   sm: 'badge-sm',
+}
+
+/** Resolve a protocol/scheme label (case-insensitive) to its color class. */
+export function getProtocolColorClass(protocol: string): string {
+  return PROTOCOL[protocol.toLowerCase().trim()] ?? DEFAULT_PROTOCOL_COLOR
 }
 
 /** Resolve kind color with fuzzy matching for plural/lowercase forms */
@@ -185,8 +240,14 @@ export function getSeverityColorClass(severity: BadgeSeverity): string {
  * Badge component — the ONE source of truth for badge rendering.
  * Use severity for status badges, kind for resource type badges, or colorClass for custom.
  */
-export function Badge({ severity, kind, colorClass, size = 'default', className, onClick, title, children }: BadgeProps) {
-  const color = colorClass ?? (severity ? SEVERITY[severity] : kind ? getKindColorClass(kind) : '')
+export function Badge({ severity, kind, protocol, tone, colorClass, size = 'default', className, onClick, title, children }: BadgeProps) {
+  const color =
+    colorClass ??
+    (severity ? SEVERITY[severity]
+      : protocol ? getProtocolColorClass(protocol)
+      : tone ? TONE[tone]
+      : kind ? getKindColorClass(kind)
+      : '')
   const cls = clsx(SIZE_CLASSES[size], color, className)
 
   if (onClick) {
@@ -196,4 +257,4 @@ export function Badge({ severity, kind, colorClass, size = 'default', className,
 }
 
 // Re-export the raw color maps for backwards compat (used by badge-colors.ts consumers)
-export { SEVERITY as BADGE_SEVERITY_COLORS, KIND as BADGE_KIND_COLORS }
+export { SEVERITY as BADGE_SEVERITY_COLORS, KIND as BADGE_KIND_COLORS, PROTOCOL as BADGE_PROTOCOL_COLORS, TONE as BADGE_TONE_COLORS }

--- a/packages/k8s-ui/src/components/ui/Badge.tsx
+++ b/packages/k8s-ui/src/components/ui/Badge.tsx
@@ -161,6 +161,7 @@ const DEFAULT_KIND_COLOR = 'bg-fuchsia-50 text-fuchsia-700 border-fuchsia-200 da
 // ---------------------------------------------------------------------------
 const PROTOCOL: Record<string, string> = {
   http:  'bg-blue-100 text-blue-700 border-blue-300 dark:bg-blue-950/50 dark:text-blue-400 dark:border-blue-700/40',
+  http2: 'bg-blue-100 text-blue-700 border-blue-300 dark:bg-blue-950/50 dark:text-blue-400 dark:border-blue-700/40',
   h2:    'bg-blue-100 text-blue-700 border-blue-300 dark:bg-blue-950/50 dark:text-blue-400 dark:border-blue-700/40',
   h2c:   'bg-blue-100 text-blue-700 border-blue-300 dark:bg-blue-950/50 dark:text-blue-400 dark:border-blue-700/40',
   https: 'bg-teal-100 text-teal-800 border-teal-300 dark:bg-teal-950/50 dark:text-teal-400 dark:border-teal-700/40',
@@ -168,6 +169,7 @@ const PROTOCOL: Record<string, string> = {
   tcp:   'bg-indigo-100 text-indigo-700 border-indigo-300 dark:bg-indigo-950/50 dark:text-indigo-400 dark:border-indigo-700/40',
   udp:   'bg-violet-100 text-violet-700 border-violet-300 dark:bg-violet-950/50 dark:text-violet-400 dark:border-violet-700/40',
   grpc:  'bg-fuchsia-100 text-fuchsia-700 border-fuchsia-300 dark:bg-fuchsia-950/50 dark:text-fuchsia-400 dark:border-fuchsia-700/40',
+  'grpc-web': 'bg-fuchsia-100 text-fuchsia-700 border-fuchsia-300 dark:bg-fuchsia-950/50 dark:text-fuchsia-400 dark:border-fuchsia-700/40',
 }
 const DEFAULT_PROTOCOL_COLOR = 'bg-slate-100 text-slate-700 border-slate-300 dark:bg-slate-950/50 dark:text-slate-400 dark:border-slate-700/40'
 


### PR DESCRIPTION
## Summary

Hand-rolled Tailwind chip colors (`bg-<color>-N/NN text-<color>-N`) had spread to **51 renderers / ~200 sites**. Two problems: they're dark-tuned so they **wash out in light mode**, and they **overload hues across unrelated intents** — a green `bg-green-500/20` "HTTPS" chip is visually identical to a green "success" chip, so retuning "success" would silently recolor every HTTPS tag. This introduces a **semantic badge-token system** so colors are chosen by *meaning*, centrally, and a future tweak moves exactly the right things.

## What changed

### Token system (`Badge.tsx`)
New intent tokens, **named by purpose, not hue** (two tokens may share a value today yet stay separate so they can diverge later):
- **`protocol`** (http/https/tls/tcp/udp/grpc/h2) — its *own* family, deliberately off the severity hues, so a protocol never reads as a status. This kills the green-HTTPS-vs-success collision.
- **`note`** — neutral attention/FYI markers (cross-namespace, wildcard, default, immutable), distinct from `severity-info`.
- **`accent1/2/3`** — *local* categorical distinction (rw/ro, spot/on-demand, control-plane/worker, TLS mode) where the hue only separates siblings and carries no global meaning.
- **`structural`** — neutral data fragments (ports/paths/hosts/weights/names).

Resolve order: `colorClass → severity → protocol → tone → kind`. All values follow Badge's existing light/dark theme-aware pattern, so migrated chips render correctly in both modes (the dark-only hand-rolled chips did not).

### DESIGN.md
Adds a **badge decision tree** — which prop for which intent (status→`severity`, health→tone, kind→`kind`, protocol→`protocol`, attention→`note`, local-categorical→`accent-*`, structural→`structural`) — and restates the "never hand-write color strings" rule now that there's a token for every case (previously unfollowable for accents, which is why it broke down).

### Ratchet guard (`badge-no-handrolled.test.tsx`)
Pins the set of renderers that still hand-roll chips (baseline = 38 files). The set may **shrink, never grow** — new code must use `<Badge>`, and the baseline converges to zero as files are cleaned. Closes the "consistency drifts back the moment we look away" gap.

### Migration (this PR: 13 files / 77 sites)
The high-value subset: **all Traefik renderers** (the originating cleanup) + the **protocol-collision offenders** (Gateway API, Istio, Contour, route renderers) where HTTPS=green read as success. The remaining ~38 files are ratcheted for incremental batched cleanup. Color/token only — no behavior, text, or layout changes.

## Testing

- `make tsc` ✓
- `npx vitest run` (k8s-ui): **665 tests pass** (54 files), incl. the new ratchet (no new offenders; baseline exact).
- **visual-test** ✓ — Traefik renderers on a live kind cluster, **dark and light mode**: chips render with proper light-mode contrast (the wash-out fix), the cross-namespace marker is the violet `note` tone (was yellow), protocol/kind/accent tones read distinctly. Protocol≠severity is structurally guaranteed by the PROTOCOL map (teal/indigo, not green/orange) and the deletion of the per-renderer `protocolColors` maps.

## Notes / follow-ups
- **Codex cross-review was inconclusive** — it hung on the 1195-line diff and was terminated; relying on self-review + the 665-test suite + Bugbot on this PR.
- The remaining ~38 hand-rolling files are tracked by the ratchet baseline for incremental cleanup; this PR proves the system + fixes the real semantic bug rather than shipping one unreviewable 200-edit diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only badge styling and docs/tests; no auth, data, or API behavior changes. Residual hand-rolled chips in baselined files are unchanged until later PRs.
> 
> **Overview**
> Introduces **intent-based badge tokens** on `<Badge>` (`protocol`, `tone` for `note` / `accent1–3` / `structural`) with theme-aware color maps, so chips are chosen by meaning—not ad hoc Tailwind—and **HTTPS/TCP no longer share green “success” hues**.
> 
> **DESIGN.md** documents a decision tree for which prop to use and points to a CI **ratchet test** that blocks new hand-rolled `bg-*-N/NN text-*` chips in renderers.
> 
> **Migration in this PR:** ~13 renderer/cell files (Traefik, Gateway API routes, Istio, Contour, Knative, etc.) swap inline color spans and local `protocolColors` maps for `<Badge severity|protocol|tone|kind>`. ~38 files remain on a shrinking baseline until follow-up cleanups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3df3be62d2081462ac99253696f9bb82ebc3e327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->