### PR TITLE
docs(readme): note Helm upgrade tracking + OCI chart sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Unified timeline of Kubernetes events and resource changes.
 
 ### Helm
 
-Manage Helm releases deployed in your cluster.
+Manage Helm releases deployed in your cluster — inspect values and rendered manifests, diff revisions, upgrade, rollback, and uninstall. Radar tracks available chart upgrades (from your configured repos or your own OCI registries) and lets you pick a specific target version.
 
 <p align="center">
   <img src="docs/screenshots/helm-view.png" alt="Helm View" width="800">


### PR DESCRIPTION
Tiny README touch-up: the Helm feature blurb was a single line. Mentions the upgrade-tracking / version-picker / own-OCI-chart capabilities shipped in #1011. User-facing detail lives in radar-docs (skyhook-dev/radar-docs#25).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edit with no runtime or security impact.
> 
> **Overview**
> Expands the **Helm** section intro in `README.md` from a one-liner into a fuller capability summary aligned with recent Helm work (#1011).
> 
> The new copy calls out **values/manifest inspection**, **revision diffs**, and **upgrade / rollback / uninstall** from the UI, and adds that Radar **surfaces available chart upgrades** (Helm repos or **OCI registries**) and supports **choosing a target version**. The existing bullet list under the screenshot is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4b7819b2e2ca054d89be578144c32a5c20a881a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->