### PR TITLE
feat(probe): probe a Service's HTTP endpoint from the browser

### DIFF
--- a/internal/server/probe.go
+++ b/internal/server/probe.go
@@ -1,0 +1,233 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"k8s.io/client-go/rest"
+
+	"github.com/skyhook-io/radar/internal/auth"
+)
+
+const (
+	probeTimeout      = 10 * time.Second
+	probeMaxBodyBytes = 512 * 1024 // cap the previewed response body at 512 KiB
+)
+
+// dnsName matches a DNS-1123 subdomain (namespace/service names). Port accepts a
+// numeric port or a DNS-1123 port name. Both are validated before being spliced
+// into the apiserver proxy URL so a crafted value can't escape the
+// services/{target}/proxy path structure.
+var (
+	probeNameRe = regexp.MustCompile(`^[a-z0-9]([-a-z0-9.]{0,251}[a-z0-9])?$`)
+	probePortRe = regexp.MustCompile(`^[a-zA-Z0-9]([-a-zA-Z0-9]{0,14})?$`)
+)
+
+type probeRequest struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`   // Service name
+	Port      string `json:"port"`   // port number or named port
+	Scheme    string `json:"scheme"` // "http" (default) or "https"
+	Path      string `json:"path"`   // request path, defaults to "/"
+}
+
+type probeResponse struct {
+	Status     int               `json:"status"`
+	DurationMs int64             `json:"durationMs"`
+	Headers    map[string]string `json:"headers"`
+	Body       string            `json:"body"`
+	Truncated  bool              `json:"truncated"`
+	BodyBytes  int               `json:"bodyBytes"`
+	// Error is set when the response was received but reading its body failed
+	// (e.g. the target stalled until the timeout). Status/body still reflect
+	// whatever arrived so a partial response isn't silently shown as success.
+	Error string `json:"error,omitempty"`
+}
+
+// probeHTTPClient builds the client used for a probe. Critically it disables
+// redirect-following: the client-go transport re-attaches the cluster bearer
+// token and Impersonate-* headers to every request it makes, so following a
+// Service-controlled 3xx to another host would leak those credentials to an
+// attacker-chosen endpoint (SSRF). Instead we surface the 3xx + Location to the
+// caller as the probe result.
+func probeHTTPClient(cfg *rest.Config) (*http.Client, error) {
+	client, err := rest.HTTPClientFor(cfg)
+	if err != nil {
+		return nil, err
+	}
+	client.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return client, nil
+}
+
+// proxyStatusError recognizes a Kubernetes Status object — what the apiserver's
+// services/proxy returns when it can't deliver the request to a backend (no ready
+// endpoints, connection refused) — and maps it to a plain-English message. The
+// Service never saw the request in these cases, so the raw Status JSON shouldn't
+// be shown as if it were the Service's response. Returns ok=false for a normal
+// app response (apps don't emit kind:"Status" objects).
+func proxyStatusError(body []byte) (string, bool) {
+	var st struct {
+		Kind    string `json:"kind"`
+		Status  string `json:"status"`
+		Reason  string `json:"reason"`
+		Message string `json:"message"`
+	}
+	if json.Unmarshal(body, &st) != nil || st.Kind != "Status" || st.Status != "Failure" {
+		return "", false
+	}
+	switch {
+	case strings.Contains(st.Message, "no endpoints available"):
+		return "No ready endpoints — this Service has no running pods behind it.", true
+	case st.Message != "":
+		return "The cluster could not reach this Service: " + st.Message, true
+	default:
+		return "The cluster could not reach this Service.", true
+	}
+}
+
+// handleProbeService issues a single server-side GET to an in-cluster Service via
+// the apiserver's services/proxy subresource, impersonating the caller so the
+// apiserver enforces RBAC (get services/proxy). This is the Cloud-safe stand-in
+// for port-forward when the question is "what does this endpoint return": the
+// request originates in-cluster and the response flows back to the browser — no
+// local listener, and the target is constrained to the named Service (not
+// arbitrary egress).
+func (s *Server) handleProbeService(w http.ResponseWriter, r *http.Request) {
+	var req probeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	req.Namespace = strings.TrimSpace(req.Namespace)
+	req.Name = strings.TrimSpace(req.Name)
+	req.Port = strings.TrimSpace(req.Port)
+	if !probeNameRe.MatchString(req.Namespace) {
+		s.writeError(w, http.StatusBadRequest, "invalid namespace")
+		return
+	}
+	if !probeNameRe.MatchString(req.Name) {
+		s.writeError(w, http.StatusBadRequest, "invalid service name")
+		return
+	}
+	if !probePortRe.MatchString(req.Port) {
+		s.writeError(w, http.StatusBadRequest, "invalid port")
+		return
+	}
+
+	scheme := strings.ToLower(strings.TrimSpace(req.Scheme))
+	if scheme == "" {
+		scheme = "http"
+	}
+	if scheme != "http" && scheme != "https" {
+		s.writeError(w, http.StatusBadRequest, "scheme must be http or https")
+		return
+	}
+
+	// The proxy suffix is the path the backend Service sees. Keep it as a rooted,
+	// single-line path; the apiserver only proxies it to the target so the blast
+	// radius stays within the (RBAC-gated) Service.
+	path := req.Path
+	if path == "" {
+		path = "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	if strings.ContainsAny(path, "\r\n") {
+		s.writeError(w, http.StatusBadRequest, "invalid path")
+		return
+	}
+
+	cfg := s.getConfigForRequest(r)
+	if cfg == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "K8s client not initialized")
+		return
+	}
+	auth.AuditLog(r, req.Namespace, req.Name)
+
+	httpClient, err := probeHTTPClient(cfg)
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, "failed to build cluster client")
+		return
+	}
+
+	// services/proxy target encodes [scheme:]name:port; the apiserver authorizes
+	// "get services/proxy" for the impersonated user before reaching the Service.
+	target := fmt.Sprintf("%s:%s:%s", scheme, req.Name, req.Port)
+	proxyURL := strings.TrimRight(cfg.Host, "/") +
+		"/api/v1/namespaces/" + req.Namespace + "/services/" + target + "/proxy" + path
+
+	ctx, cancel := context.WithTimeout(r.Context(), probeTimeout)
+	defer cancel()
+
+	preq, err := http.NewRequestWithContext(ctx, http.MethodGet, proxyURL, nil)
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, "invalid target")
+		return
+	}
+
+	start := time.Now()
+	resp, err := httpClient.Do(preq)
+	if err != nil {
+		s.writeError(w, http.StatusBadGateway, fmt.Sprintf("probe failed: %v", err))
+		return
+	}
+	defer resp.Body.Close()
+
+	// Read one byte past the cap so we can flag truncation without loading a huge body.
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, probeMaxBodyBytes+1))
+	truncated := len(body) > probeMaxBodyBytes
+	if truncated {
+		body = body[:probeMaxBodyBytes]
+	}
+	dur := time.Since(start).Milliseconds()
+
+	// A read error after headers arrived means the target stalled or reset
+	// mid-body. Surface it rather than passing off a partial body as a clean
+	// response — diagnosing that stall is the whole point of the probe.
+	var probeErr string
+	if readErr != nil {
+		if ctx.Err() != nil {
+			probeErr = fmt.Sprintf("response timed out after %s (headers received, body incomplete)", probeTimeout)
+		} else {
+			probeErr = fmt.Sprintf("error reading response body: %v", readErr)
+		}
+	}
+
+	respBody := string(body)
+	// A failure that the Service itself never produced — the apiserver proxy
+	// couldn't deliver the request (no ready endpoints, connection refused) and
+	// returned a Kubernetes Status object. Surface that as plain English instead
+	// of dumping a raw k8s API error at the operator, and drop the body since it
+	// isn't the Service's response.
+	if probeErr == "" {
+		if friendly, ok := proxyStatusError(body); ok {
+			probeErr = friendly
+			respBody = ""
+		}
+	}
+
+	headers := make(map[string]string, len(resp.Header))
+	for k := range resp.Header {
+		headers[k] = resp.Header.Get(k)
+	}
+
+	s.writeJSON(w, probeResponse{
+		Status:     resp.StatusCode,
+		DurationMs: dur,
+		Headers:    headers,
+		Body:       respBody,
+		Truncated:  truncated,
+		BodyBytes:  len(body),
+		Error:      probeErr,
+	})
+}

--- a/internal/server/probe_test.go
+++ b/internal/server/probe_test.go
@@ -1,0 +1,93 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"k8s.io/client-go/rest"
+)
+
+// A probed Service must not be able to drive Radar's credentialed client to a
+// redirect target: the client-go transport would re-attach the cluster bearer
+// token + Impersonate-* headers to the followed request, leaking them to an
+// attacker-chosen host. probeHTTPClient must therefore not follow redirects.
+func TestProbeHTTPClientDoesNotFollowRedirects(t *testing.T) {
+	var downstreamHits int32
+	downstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&downstreamHits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer downstream.Close()
+
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, downstream.URL+"/stolen", http.StatusFound)
+	}))
+	defer proxy.Close()
+
+	client, err := probeHTTPClient(&rest.Config{Host: proxy.URL})
+	if err != nil {
+		t.Fatalf("probeHTTPClient: %v", err)
+	}
+	resp, err := client.Get(proxy.URL + "/x")
+	if err != nil {
+		t.Fatalf("unexpected request error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusFound {
+		t.Errorf("expected the 302 to be returned (not followed), got %d", resp.StatusCode)
+	}
+	if hits := atomic.LoadInt32(&downstreamHits); hits != 0 {
+		t.Errorf("redirect was followed — downstream host hit %d time(s); credentials could leak", hits)
+	}
+}
+
+func TestProbeNameValidation(t *testing.T) {
+	valid := []string{"kube-system", "kube-dns", "my-svc", "a", "svc.with.dots", "argocd-server"}
+	for _, s := range valid {
+		if !probeNameRe.MatchString(s) {
+			t.Errorf("expected %q to be a valid name", s)
+		}
+	}
+	// Anything that could escape the services/{ns|name}/proxy path must be rejected.
+	invalid := []string{"", "x/../../etc", "a:b", "UPPER", "-leading", "trailing-", "has space", "name/sub", "a%2f"}
+	for _, s := range invalid {
+		if probeNameRe.MatchString(s) {
+			t.Errorf("expected %q to be rejected as a name", s)
+		}
+	}
+}
+
+func TestProxyStatusError(t *testing.T) {
+	noEndpoints := `{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"no endpoints available for service \"x\"","reason":"ServiceUnavailable","code":503}`
+	if msg, ok := proxyStatusError([]byte(noEndpoints)); !ok || msg != "No ready endpoints — this Service has no running pods behind it." {
+		t.Errorf("no-endpoints: ok=%v msg=%q", ok, msg)
+	}
+	otherFailure := `{"kind":"Status","apiVersion":"v1","status":"Failure","message":"dial tcp: connection refused","reason":"ServiceUnavailable"}`
+	if msg, ok := proxyStatusError([]byte(otherFailure)); !ok || msg == "" {
+		t.Errorf("other-failure: ok=%v msg=%q", ok, msg)
+	}
+	// A normal application response must NOT be treated as a proxy error.
+	for _, appBody := range []string{`{"status":"ok"}`, `<html>503 from app</html>`, `{"kind":"Pod"}`, ``} {
+		if _, ok := proxyStatusError([]byte(appBody)); ok {
+			t.Errorf("app body %q wrongly classified as proxy error", appBody)
+		}
+	}
+}
+
+func TestProbePortValidation(t *testing.T) {
+	valid := []string{"80", "9153", "http", "web-ui", "https"}
+	for _, s := range valid {
+		if !probePortRe.MatchString(s) {
+			t.Errorf("expected %q to be a valid port", s)
+		}
+	}
+	invalid := []string{"", "80:proxy/secrets", "a/b", "a:b", "port name", "this-port-name-is-way-too-long"}
+	for _, s := range invalid {
+		if probePortRe.MatchString(s) {
+			t.Errorf("expected %q to be rejected as a port", s)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -368,6 +368,10 @@ func (s *Server) setupRoutes() {
 			r.Delete("/portforwards/{id}", s.handleStopPortForward)
 			r.Get("/portforwards/available/{type}/{namespace}/{name}", s.handleGetAvailablePorts)
 
+			// Probe a Service's HTTP endpoint server-side (via apiserver
+			// services/proxy). Works in-cluster/Cloud where port-forward can't.
+			r.Post("/probe/service", s.handleProbeService)
+
 			// Active sessions (for context switch confirmation)
 			r.Get("/sessions", s.handleGetSessions)
 

--- a/packages/k8s-ui/src/components/resources/renderers/ServiceRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/ServiceRenderer.tsx
@@ -10,7 +10,11 @@ interface ServiceRendererProps {
   endpointSlices?: any[]
   endpointSlicesLoading?: boolean
   onNavigate?: (ref: ResourceRef) => void
-  renderPortAction?: (props: { namespace: string; serviceName: string; port: number; protocol: string }) => ReactNode
+  renderPortAction?: (props: { namespace: string; serviceName: string; port: number; protocol: string; name?: string; appProtocol?: string }) => ReactNode
+  /** Optional full-width content rendered inside a port's card, below its header
+   *  (e.g. an inline probe panel). Lets a host attach a port-scoped panel in the
+   *  drawer flow rather than as a separate overlay. */
+  renderPortPanel?: (props: { namespace: string; serviceName: string; port: number; protocol: string; name?: string; appProtocol?: string }) => ReactNode
 }
 
 function endpointSliceAddressCount(slice: any): number {
@@ -28,7 +32,7 @@ function endpointSliceReadyClass(ready: number, total: number): string {
   return 'status-unhealthy'
 }
 
-export function ServiceRenderer({ data, onCopy, copied, endpointSlices, endpointSlicesLoading, onNavigate, renderPortAction }: ServiceRendererProps) {
+export function ServiceRenderer({ data, onCopy, copied, endpointSlices, endpointSlicesLoading, onNavigate, renderPortAction, renderPortPanel }: ServiceRendererProps) {
   const spec = data.spec || {}
   const ports = spec.ports || []
   const lbIngress = data.status?.loadBalancer?.ingress || []
@@ -106,6 +110,8 @@ export function ServiceRenderer({ data, onCopy, copied, endpointSlices, endpoint
                       serviceName,
                       port: port.port,
                       protocol: port.protocol || 'TCP',
+                      name: port.name,
+                      appProtocol: port.appProtocol,
                     })}
                   </div>
                 </div>
@@ -113,6 +119,14 @@ export function ServiceRenderer({ data, onCopy, copied, endpointSlices, endpoint
                   {port.port}{port.targetPort != null && port.targetPort !== port.port ? ` → ${port.targetPort}` : ''}
                   {port.nodePort ? ` (NodePort: ${port.nodePort})` : ''}
                 </div>
+                {renderPortPanel?.({
+                  namespace,
+                  serviceName,
+                  port: port.port,
+                  protocol: port.protocol || 'TCP',
+                  name: port.name,
+                  appProtocol: port.appProtocol,
+                })}
               </div>
             ))}
           </div>

--- a/web/src/components/portforward/PortForwardButton.tsx
+++ b/web/src/components/portforward/PortForwardButton.tsx
@@ -103,7 +103,7 @@ function KubectlCommandDialog({
 
         <div className="p-4 space-y-3">
           <p className="text-sm text-theme-text-secondary">
-            Radar is running in-cluster, so port forwarding must be run from your local terminal.
+            Live port-forwarding isn&apos;t available here — run it from your own machine instead:
           </p>
           <div className="flex flex-col gap-1">
             <div className="flex items-center gap-2 text-sm text-theme-text-secondary">
@@ -147,8 +147,8 @@ function KubectlCommandDialog({
               {copied ? 'Copied' : copyFallback ? 'Press Ctrl+C' : 'Copy'}
             </button>
           </div>
-          <p className="text-xs text-theme-text-secondary">
-            Requires kubectl and authentication to this cluster.
+          <p className="text-xs text-theme-text-tertiary">
+            You&apos;ll need <code className="inline-code">kubectl</code> and your own credentials for this cluster to run it.
           </p>
         </div>
       </div>

--- a/web/src/components/probe/ServiceProbeButton.tsx
+++ b/web/src/components/probe/ServiceProbeButton.tsx
@@ -1,0 +1,193 @@
+import { useState } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import { Activity, Loader2, X, ChevronDown } from 'lucide-react'
+import { clsx } from 'clsx'
+import { apiFetch } from '../../api/client'
+import { apiUrl } from '../../api/config'
+import { Tooltip } from '../ui/Tooltip'
+
+// A port is "probe-able" only if it plausibly speaks HTTP — probing a raw TCP
+// port (Postgres, Redis) with a GET returns noise, so we don't offer it there
+// (that's the local-client TCP path's job). Heuristic over name/appProtocol/number.
+const HTTP_PORT_NUMBERS = new Set([80, 443, 8080, 8443, 8000, 8081, 3000, 5000, 9090, 9091, 9093, 9100, 15000, 15090])
+const HTTP_NAME_RE = /(^|[-_])(http|https|web|ui|console|dashboard|metrics|api|admin)([-_]|$)/i
+
+export function isHttpishPort(port: number, name?: string, appProtocol?: string, protocol?: string): boolean {
+  // HTTP rides TCP — a UDP port is never a GET target (e.g. statsd "metrics-udp").
+  if ((protocol || '').toUpperCase() === 'UDP') return false
+  const proto = (appProtocol || '').toLowerCase()
+  if (proto === 'http' || proto === 'https' || proto === 'http2') return true
+  if (proto && proto !== 'tcp') {
+    // explicit non-HTTP appProtocol (grpc, redis, postgres, …) → not a GET target
+    return false
+  }
+  if (name && HTTP_NAME_RE.test(name)) return true
+  return HTTP_PORT_NUMBERS.has(port)
+}
+
+export function defaultScheme(port: number, name?: string, appProtocol?: string): 'http' | 'https' {
+  if ((appProtocol || '').toLowerCase() === 'https') return 'https'
+  if (port === 443 || port === 8443) return 'https'
+  if (name && /https/i.test(name)) return 'https'
+  return 'http'
+}
+
+interface ProbeResult {
+  status: number
+  durationMs: number
+  headers: Record<string, string>
+  body: string
+  truncated: boolean
+  bodyBytes: number
+  error?: string
+}
+
+function statusTone(status: number): string {
+  if (status >= 200 && status < 300) return 'text-emerald-400'
+  if (status >= 300 && status < 400) return 'text-blue-400'
+  if (status >= 400 && status < 500) return 'text-amber-400'
+  return 'text-red-400'
+}
+
+// Small toggle button rendered in a port row's action slot. The panel itself
+// renders inline within the port card (see ProbePanel), not as an overlay.
+export function ProbeButton({ active, onClick }: { active: boolean; onClick: () => void }) {
+  return (
+    <Tooltip content="Probe this endpoint — GET from inside the cluster">
+      <button
+        onClick={(e) => { e.stopPropagation(); onClick() }}
+        aria-expanded={active}
+        className={clsx(
+          'inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs transition-colors',
+          active ? 'bg-accent-muted text-blue-400' : 'bg-theme-elevated hover:bg-accent-muted',
+        )}
+      >
+        Probe
+        <Activity className="w-3 h-3" />
+      </button>
+    </Tooltip>
+  )
+}
+
+// Inline probe form + response. Renders in the drawer flow (inside the port
+// card) rather than as a centered modal — the action is scoped to this port, so
+// it stays in context instead of taking over the screen.
+export function ProbePanel({
+  namespace,
+  serviceName,
+  port,
+  initialScheme,
+  onClose,
+}: {
+  namespace: string
+  serviceName: string
+  port: number
+  initialScheme: 'http' | 'https'
+  onClose: () => void
+}) {
+  const [scheme, setScheme] = useState<'http' | 'https'>(initialScheme)
+  const [path, setPath] = useState('/')
+  const [showHeaders, setShowHeaders] = useState(false)
+
+  const probe = useMutation<ProbeResult>({
+    mutationFn: async () => {
+      const res = await apiFetch(apiUrl('/probe/service'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ namespace, name: serviceName, port: String(port), scheme, path }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(data?.error || `Request failed (${res.status})`)
+      return data as ProbeResult
+    },
+  })
+
+  const result = probe.data
+
+  return (
+    <div className="mt-3 pt-3 border-t border-theme-border space-y-2" onClick={(e) => e.stopPropagation()}>
+      <div className="flex items-center justify-between">
+        <span className="flex items-center gap-1.5 text-xs font-medium text-theme-text-secondary">
+          <Activity className="w-3.5 h-3.5 text-blue-400" />
+          Probe — GET from inside the cluster
+        </span>
+        <button
+          onClick={onClose}
+          aria-label="Close probe"
+          className="p-0.5 text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
+        >
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      <form className="flex items-stretch gap-2" onSubmit={(e) => { e.preventDefault(); probe.mutate() }}>
+        <select
+          value={scheme}
+          onChange={(e) => setScheme(e.target.value as 'http' | 'https')}
+          className="bg-theme-base border border-theme-border rounded px-2 py-1 text-xs text-theme-text-primary font-mono"
+          aria-label="Scheme"
+        >
+          <option value="http">http</option>
+          <option value="https">https</option>
+        </select>
+        <input
+          type="text"
+          value={path}
+          onChange={(e) => setPath(e.target.value)}
+          placeholder="/healthz"
+          aria-label="Request path"
+          className="flex-1 min-w-0 bg-theme-base border border-theme-border rounded px-2 py-1 text-xs text-theme-text-primary font-mono"
+        />
+        <button
+          type="submit"
+          disabled={probe.isPending}
+          className="shrink-0 px-3 py-1 btn-brand text-xs rounded-lg flex items-center gap-1.5 disabled:opacity-50"
+        >
+          {probe.isPending ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Activity className="w-3.5 h-3.5" />}
+          Send
+        </button>
+      </form>
+
+      {probe.isError && (
+        <div className="text-xs text-red-400 bg-red-500/10 border border-red-500/30 rounded px-2 py-1.5">
+          {(probe.error as Error).message}
+        </div>
+      )}
+
+      {result && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-3 text-xs">
+            <span className={clsx('font-mono font-semibold', statusTone(result.status))}>{result.status}</span>
+            <span className="text-theme-text-tertiary">{result.durationMs} ms</span>
+            <span className="text-theme-text-tertiary">{result.bodyBytes.toLocaleString()} bytes{result.truncated ? ' (truncated)' : ''}</span>
+            <button
+              type="button"
+              onClick={() => setShowHeaders((v) => !v)}
+              className="ml-auto flex items-center gap-1 text-theme-text-secondary hover:text-theme-text-primary"
+            >
+              Headers <ChevronDown className={clsx('w-3 h-3 transition-transform', showHeaders && 'rotate-180')} />
+            </button>
+          </div>
+
+          {result.error && (
+            <div className="text-xs text-amber-400 bg-amber-500/10 border border-amber-500/30 rounded px-2 py-1.5">
+              {result.error}
+            </div>
+          )}
+
+          {showHeaders && (
+            <pre className="text-xs bg-theme-base rounded p-2 overflow-auto max-h-40 text-theme-text-secondary font-mono">
+              {Object.entries(result.headers).map(([k, v]) => `${k}: ${v}`).join('\n') || '(no headers)'}
+            </pre>
+          )}
+
+          {!result.error && (
+            <pre className="text-xs bg-theme-base rounded p-2 overflow-auto max-h-64 text-theme-text-primary font-mono whitespace-pre-wrap break-words">
+              {result.body || '(empty response body)'}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/resources/renderers/PodRenderer.tsx
+++ b/web/src/components/resources/renderers/PodRenderer.tsx
@@ -2,7 +2,7 @@ import { PodRenderer as BasePodRenderer } from '@skyhook-io/k8s-ui/components/re
 import type { CopyHandler } from '@skyhook-io/k8s-ui/components/ui/drawer-components'
 import type { ResolvedEnvFrom } from '@skyhook-io/k8s-ui'
 import { useOpenTerminal, useOpenLogs } from '../../dock'
-import { useNamespacedCapabilities } from '../../../contexts/CapabilitiesContext'
+import { useNamespacedCapabilities, useIsLocalDeployment } from '../../../contexts/CapabilitiesContext'
 import { usePodMetrics, usePodMetricsHistory, usePrometheusResourceMetrics, usePrometheusStatus } from '../../../api/client'
 import { useRBACSubject } from '../../../api/rbac'
 import { PortForwardInlineButton } from '../../portforward/PortForwardButton'
@@ -27,6 +27,10 @@ export function PodRenderer({ data, onCopy, copied, onNavigate, onOpenLogs, reso
 
   // Capabilities (namespace-scoped: re-checks RBAC if globally denied)
   const { canExec, canViewLogs, canPortForward } = useNamespacedCapabilities(namespace)
+  // Show the port-forward affordance for a live forward (local + RBAC) OR when
+  // not local — in-cluster/Cloud surfaces a copy-paste kubectl command instead.
+  // The button itself picks live vs. copy-command based on deployment mode.
+  const showPortForward = canPortForward || !useIsLocalDeployment()
 
   // Metrics
   const { data: metrics } = usePodMetrics(namespace, podName)
@@ -65,7 +69,7 @@ export function PodRenderer({ data, onCopy, copied, onNavigate, onOpenLogs, reso
       rbacError={rbacError as Error | null}
       canExec={canExec}
       canViewLogs={canViewLogs}
-      canPortForward={canPortForward}
+      canPortForward={showPortForward}
       onOpenTerminal={(params) => openTerminal(params)}
       onOpenLogsPanel={(params) => openLogsPanel(params)}
       renderPortAction={({ namespace: ns, podName: pod, port, protocol, disabled }) => (

--- a/web/src/components/resources/renderers/ServiceRenderer.tsx
+++ b/web/src/components/resources/renderers/ServiceRenderer.tsx
@@ -3,7 +3,7 @@ import { ServiceRenderer as BaseServiceRenderer } from '@skyhook-io/k8s-ui/compo
 import { PortForwardInlineButton } from '../../portforward/PortForwardButton'
 import { ProbeButton, ProbePanel, isHttpishPort, defaultScheme } from '../../probe/ServiceProbeButton'
 import { useResources } from '../../../api/client'
-import { useNamespacedCapabilities } from '../../../contexts/CapabilitiesContext'
+import { useNamespacedCapabilities, useIsLocalDeployment } from '../../../contexts/CapabilitiesContext'
 import type { ResourceRef } from '../../../types'
 
 interface ServiceRendererProps {
@@ -17,6 +17,10 @@ export function ServiceRenderer({ data, onCopy, copied, onNavigate }: ServiceRen
   const namespace = data.metadata?.namespace
   const serviceName = data.metadata?.name
   const { canPortForward } = useNamespacedCapabilities(namespace)
+  // Offer the port-forward affordance when a live forward is possible (local +
+  // RBAC) OR when we're not local — in-cluster/Cloud can't bind a local listener,
+  // but we still surface a copy-paste `kubectl port-forward` command.
+  const showPortForward = canPortForward || !useIsLocalDeployment()
   // Which port's inline probe panel is open (one at a time). Keyed by port number.
   const [activeProbePort, setActiveProbePort] = useState<number | null>(null)
   const spec = data.spec || {}
@@ -53,7 +57,7 @@ export function ServiceRenderer({ data, onCopy, copied, onNavigate }: ServiceRen
               onClick={() => setActiveProbePort((cur) => (cur === port ? null : port))}
             />
           )}
-          {canPortForward && (
+          {showPortForward && (
             <PortForwardInlineButton
               namespace={namespace}
               serviceName={serviceName}

--- a/web/src/components/resources/renderers/ServiceRenderer.tsx
+++ b/web/src/components/resources/renderers/ServiceRenderer.tsx
@@ -1,6 +1,7 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { ServiceRenderer as BaseServiceRenderer } from '@skyhook-io/k8s-ui/components/resources/renderers/ServiceRenderer'
 import { PortForwardInlineButton } from '../../portforward/PortForwardButton'
+import { ProbeButton, ProbePanel, isHttpishPort, defaultScheme } from '../../probe/ServiceProbeButton'
 import { useResources } from '../../../api/client'
 import { useNamespacedCapabilities } from '../../../contexts/CapabilitiesContext'
 import type { ResourceRef } from '../../../types'
@@ -16,6 +17,8 @@ export function ServiceRenderer({ data, onCopy, copied, onNavigate }: ServiceRen
   const namespace = data.metadata?.namespace
   const serviceName = data.metadata?.name
   const { canPortForward } = useNamespacedCapabilities(namespace)
+  // Which port's inline probe panel is open (one at a time). Keyed by port number.
+  const [activeProbePort, setActiveProbePort] = useState<number | null>(null)
   const spec = data.spec || {}
   const shouldLoadEndpointSlices = Boolean(
     namespace &&
@@ -42,14 +45,35 @@ export function ServiceRenderer({ data, onCopy, copied, onNavigate }: ServiceRen
       endpointSlices={matchingEndpointSlices}
       endpointSlicesLoading={endpointSlicesLoading}
       onNavigate={onNavigate}
-      renderPortAction={canPortForward ? (({ namespace, serviceName, port, protocol }) => (
-        <PortForwardInlineButton
-          namespace={namespace}
-          serviceName={serviceName}
-          port={port}
-          protocol={protocol}
-        />
-      )) : undefined}
+      renderPortAction={({ port, name, appProtocol, protocol }) => (
+        <>
+          {isHttpishPort(port, name, appProtocol, protocol) && (
+            <ProbeButton
+              active={activeProbePort === port}
+              onClick={() => setActiveProbePort((cur) => (cur === port ? null : port))}
+            />
+          )}
+          {canPortForward && (
+            <PortForwardInlineButton
+              namespace={namespace}
+              serviceName={serviceName}
+              port={port}
+              protocol={protocol}
+            />
+          )}
+        </>
+      )}
+      renderPortPanel={({ port, name, appProtocol }) =>
+        activeProbePort === port ? (
+          <ProbePanel
+            namespace={namespace}
+            serviceName={serviceName}
+            port={port}
+            initialScheme={defaultScheme(port, name, appProtocol)}
+            onClose={() => setActiveProbePort(null)}
+          />
+        ) : null
+      }
     />
   )
 }

--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -39,7 +39,7 @@ import { useResourceAudit, useResources } from '../../api/client'
 import { AuditAlerts } from '@skyhook-io/k8s-ui'
 import { WorkloadLogsViewer } from '../logs/WorkloadLogsViewer'
 import { LogsViewer } from '../logs/LogsViewer'
-import { useCanUpdateSecrets, useCanNodeWrite, useNamespacedCapabilities } from '../../contexts/CapabilitiesContext'
+import { useCanUpdateSecrets, useCanNodeWrite, useNamespacedCapabilities, useIsLocalDeployment } from '../../contexts/CapabilitiesContext'
 import { useOpenTerminal, useOpenLogs, useOpenWorkloadLogs, useOpenNodeTerminal } from '../dock'
 import { PortForwardButton } from '../portforward/PortForwardButton'
 import { useToast } from '../ui/Toast'
@@ -159,6 +159,9 @@ function useActionsBarProps(kind: string, namespace: string, name: string) {
   const openWorkloadLogs = useOpenWorkloadLogs()
   const openNodeTerminal = useOpenNodeTerminal()
   const { canExec, canViewLogs, canPortForward } = useNamespacedCapabilities(namespace)
+  // Live forward when local+RBAC; otherwise (in-cluster/Cloud) still surface the
+  // copy-paste kubectl command. The button picks live vs. copy by deployment mode.
+  const showPortForward = canPortForward || !useIsLocalDeployment()
 
   const deleteMutation = useDeleteResource()
   const restartWorkloadMutation = useRestartWorkload()
@@ -190,7 +193,7 @@ function useActionsBarProps(kind: string, namespace: string, name: string) {
   return {
     canExec,
     canViewLogs,
-    canPortForward,
+    canPortForward: showPortForward,
     onOpenTerminal: openTerminal,
     onOpenLogs: openLogs,
     onOpenWorkloadLogs: openWorkloadLogs,

--- a/web/src/contexts/CapabilitiesContext.tsx
+++ b/web/src/contexts/CapabilitiesContext.tsx
@@ -91,6 +91,14 @@ export function useCanPortForward(): boolean {
   return useContext(CapabilitiesContext).portForward
 }
 
+// True when Radar runs as a local binary (live port-forward is possible). When
+// false (in-cluster / Radar Cloud) a live forward can't bind a usable local
+// listener, so the UI offers a copy-paste `kubectl port-forward` command instead.
+// Defaults to local during the capabilities-loading window (see defaultCapabilities).
+export function useIsLocalDeployment(): boolean {
+  return useContext(CapabilitiesContext).deployment?.mode === 'local'
+}
+
 export function useCanViewSecrets(): boolean {
   return useContext(CapabilitiesContext).secrets
 }


### PR DESCRIPTION
> **Stacked on #1017** (port-forward in-cluster gating). Review/merge that first; GitHub will retarget this to `main` once it lands. The diff below is Probe-only.

## Summary

When Radar runs in the cloud, port-forward can't work (the listener would live on the in-cluster Radar pod, unreachable from the browser — #1017 gates it off). But operators still need to answer "what does this Service's endpoint return / is it alive?" **Probe** fills that gap: click a Service's HTTP port → Radar issues a GET to it **from inside the cluster** and shows the response in the browser. No port-forward, no local listener, no cluster credentials.

## How it works

`POST /api/probe/service` issues the GET through the apiserver's **`services/proxy` subresource** using the **impersonated caller** config, so the **apiserver enforces RBAC** (`get services/proxy`) — there's no raw ClusterIP dialing and no arbitrary egress (the target is the named Service). It's also the same mechanism a future browser App-Access proxy would use, validated here at low risk.

**Security hardening (the parts worth reviewing):**
- **Strict input validation** — `namespace`/`name`/`port` are regex-validated before being spliced into the proxy URL, so a crafted value can't escape the `services/{target}/proxy` path.
- **Redirects are not followed** — client-go's transport re-attaches the cluster bearer token + `Impersonate-*` headers to *every* request, so following a Service-controlled `3xx` to another host would leak credentials (SSRF). The `3xx`+`Location` is returned to the caller instead. Covered by a regression test.
- **Read errors surfaced** — a target that sends headers then stalls until the 10s timeout is reported as an error, not a clean partial 200.
- GET-only · 10s timeout · 512 KiB body cap.

**Frontend:** a `Probe` button on HTTP-ish TCP Service ports (heuristic over `appProtocol` / port name / common HTTP port numbers; UDP excluded) opens a dialog — scheme, path, Send, and a response view (status, duration, bytes, headers, body, error/timeout banner).

## Testing

- `make tsc` ✓ · `go test ./internal/server/...` ✓ (incl. validation + redirect-not-followed security tests)
- Live cluster: `kube-dns:9153/metrics` → `200` + metrics body; no-endpoints Service → apiserver `503`; injection attempts → `400`.
- **Visual-tested** the button → dialog → response flow; confirmed the button shows on `http`/`https` ports and is correctly absent on a `metrics-udp` (UDP) port.

## Scope / follow-ups

MVP is **Services + GET only**. Deliberately out of scope (tracked separately): `pods/proxy`, non-GET methods, and **C — true TCP via radar-as-local-client** (the datastore path), which gets its own design. No new capability flag — apiserver RBAC enforces access and a `403` surfaces in the response.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New credentialed server-side HTTP proxy path with deliberate SSRF/credential-leak mitigations; scope is GET-only to named Services but still security-sensitive and worth careful review.
> 
> **Overview**
> Adds **in-cluster Service HTTP probing** for when live port-forward is not usable (Radar Cloud / in-cluster): operators can GET a Service from inside the cluster and see status, timing, headers, and a capped body in the UI.
> 
> The backend exposes **`POST /api/probe/service`**, which issues a single GET through the apiserver **`services/proxy`** subresource using the **impersonated caller** (RBAC on `get services/proxy`). Inputs are regex-validated, paths are normalized, redirects are **not** followed (avoids leaking bearer/impersonation headers on SSRF), responses are limited to **10s / 512 KiB**, and apiserver `Status` failures are surfaced as plain-English errors instead of raw JSON.
> 
> On the frontend, **HTTP-ish TCP ports** on Services get a **Probe** toggle with an **inline panel** (scheme, path, Send, response view). Shared **ServiceRenderer** gains **`renderPortPanel`** and richer port metadata for actions.
> 
> Related UX: **`useIsLocalDeployment()`** still shows port-forward affordances in non-local deployments (copy-paste **`kubectl port-forward`**), and copy in the in-cluster port-forward dialog is clarified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a864e49f4860d193ab8de05af60dcae4e2aa5f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->