### PR TITLE
refactor(health): extract canonical pod classifier into pkg/health (PR 1/5)

### DIFF
--- a/internal/k8s/detect_scheduling.go
+++ b/internal/k8s/detect_scheduling.go
@@ -497,17 +497,6 @@ func podCondition(pod *corev1.Pod, condType corev1.PodConditionType) *corev1.Pod
 	return nil
 }
 
-// IsPodUnschedulable reports whether the scheduler tried and failed to place
-// the pod (PodScheduled=False). Such pods are owned by SourceScheduling,
-// which explains WHY — the generic problem detector skips them to avoid a
-// duplicate bare "Pending" row.
-func IsPodUnschedulable(pod *corev1.Pod) bool {
-	c := podScheduledCondition(pod)
-	// Only reason=Unschedulable counts; reason=SchedulingGated is an
-	// intentional not-yet-scheduled state, not a placement failure.
-	return c != nil && c.Status == corev1.ConditionFalse && c.Reason == corev1.PodReasonUnschedulable
-}
-
 // schedulingSeverity ramps with how long the pod has been unschedulable: a
 // momentary miss right after creation is usually transient; one stuck for
 // many minutes is a real, operator-actionable failure.

--- a/internal/k8s/health.go
+++ b/internal/k8s/health.go
@@ -1,25 +1,25 @@
 package k8s
 
 import (
-	"fmt"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/skyhook-io/radar/pkg/health"
 )
 
-// crashLoopReason is the canonical reason a stable-crashloop pod emits,
-// independent of the kubelet's instantaneous container phase. Folding to one
-// reason here keeps issues/category.Classify returning `crashloop` across the
-// Waiting→Running→Waiting oscillation (and the issue_id stable, since category
-// is hashed into it).
+// Pod health classification now lives in the shared pkg/health package so every
+// consumer (topology, timeline, packages, servers) reduces to one classifier.
+// The functions below are thin shims that preserve the original signatures and
+// outputs, so existing internal callers (dashboards, MCP counters, detectors)
+// are untouched. Node health still lives here pending its own migration.
+
+// crashLoopReason is the canonical reason a stable-crashloop pod emits. Used by
+// the problem detector to recognize the normalized reason pkg/health emits.
 const crashLoopReason = "CrashLoopBackOff"
 
 // highRestartReason is the canonical reason for a container that is actively
-// thrashing — a high cumulative restart count while still unhealthy and
-// churning — but is NOT a classic CrashLoopBackOff (its restarts come from
-// e.g. failing readiness probes with clean exits, so isStableCrashLoop's
-// crash-class guard doesn't fire). Naming it keeps the row out of the
-// `unknown` catch-all (see PodProblemReason / category.Classify).
+// thrashing but is not a classic CrashLoopBackOff.
 const highRestartReason = "HighRestartCount"
 
 const readinessProbeFailedReason = "ReadinessProbeFailed"
@@ -32,554 +32,42 @@ const initContainerStalledReason = "InitContainerStalled"
 // a still-unhealthy container is treated as actively thrashing.
 const highRestartThreshold = 3
 
-const shortCrashRunWindow = 10 * time.Second
-
-// isStableCrashLoop reports whether a container is in an ACTIVE crashloop: it
-// has restarted with a crash-class last termination (CrashLoopBackOff / generic
-// Error / non-zero exit), AND it has not since recovered. It reads the stable
-// history fields (RestartCount + LastTerminationState) rather than the
-// instantaneous State the kubelet flips between polls — so a real loop's brief
-// "Running" blip doesn't downgrade the verdict — but it must NOT fire on a
-// container that crashed once and is now running healthily: RestartCount and
-// LastTerminationState persist for the life of the container, so without the
-// recovery guard below a pod that restarted once at startup would read as a
-// crashloop forever. Three recovery signals clear it: a container currently
-// Ready when that Ready is probe-gated (readyTrusted) has passed its readiness
-// probe and is serving NOW; a container Running continuously past the kubelet's
-// max CrashLoopBackOff backoff (5m) has outlived the loop; and a container whose
-// CURRENT state is a clean exit (Terminated, exit 0) has succeeded — the common
-// init-container-retries-then-completes case, whose failed prior attempt lingers
-// in LastTerminationState. OOMKilled is intentionally excluded — it has its own
-// category/severity path upstream.
-//
-// readyTrusted gates the Ready short-circuit because Ready is only a meaningful
-// recovery signal when a readiness probe backs it: without a probe Ready just
-// mirrors Running and flips true during a loop's brief between-crash window, so
-// for probe-less containers the 5m Running guard below stays the discriminator.
-func isStableCrashLoop(cs *corev1.ContainerStatus, now time.Time, readyTrusted bool) bool {
-	if cs.RestartCount == 0 {
-		return false
-	}
-	if readyTrusted && cs.Ready {
-		return false
-	}
-	if r := cs.State.Running; r != nil && !r.StartedAt.IsZero() && now.Sub(r.StartedAt.Time) > 5*time.Minute {
-		return false
-	}
-	if term := cs.State.Terminated; term != nil && term.ExitCode == 0 {
-		return false
-	}
-	t := cs.LastTerminationState.Terminated
-	if t == nil {
-		return false
-	}
-	switch t.Reason {
-	case "OOMKilled":
-		// Memory pressure is classified separately (CategoryOOMKilled); don't
-		// fold it into the generic crashloop bucket.
-		return false
-	case "CrashLoopBackOff", "Error":
-		return true
-	}
-	// A non-zero exit code with no special reason is still a crash — the app
-	// died and the kubelet is restarting it.
-	return t.ExitCode != 0
-}
-
-// podHasStableCrashLoop reports whether any main or init container is in a
-// stable crashloop (see isStableCrashLoop).
-func podHasStableCrashLoop(pod *corev1.Pod, now time.Time) bool {
-	for i := range pod.Status.ContainerStatuses {
-		cs := &pod.Status.ContainerStatuses[i]
-		if isStableCrashLoop(cs, now, containerHasReadinessProbe(pod.Spec.Containers, cs.Name)) {
-			return true
-		}
-	}
-	for i := range pod.Status.InitContainerStatuses {
-		// Init containers carry no readiness probe and their Ready field is not a
-		// serving signal — never trust Ready as recovery there; the Running-window
-		// and clean-exit guards still apply.
-		if isStableCrashLoop(&pod.Status.InitContainerStatuses[i], now, false) {
-			return true
-		}
-	}
-	return false
-}
-
-// containerHasReadinessProbe reports whether the named container declares a
-// readiness probe — the condition under which its ContainerStatus.Ready is a
-// trustworthy "serving now" signal rather than a mirror of Running.
-func containerHasReadinessProbe(containers []corev1.Container, name string) bool {
-	for i := range containers {
-		if containers[i].Name == name {
-			return containers[i].ReadinessProbe != nil
-		}
-	}
-	return false
-}
-
-// restartedRecently reports whether a container's most recent termination
-// finished within the given window — i.e. it is still actively churning, not a
-// container that crashed long ago and has since gone quiet (the laptop-sleep /
-// node-reboot artifact where RestartCount is high but every termination is days
-// old).
-func restartedRecently(cs *corev1.ContainerStatus, now time.Time, within time.Duration) bool {
-	if t := cs.LastTerminationState.Terminated; t != nil && !t.FinishedAt.IsZero() {
-		return now.Sub(t.FinishedAt.Time) <= within
-	}
-	return false
-}
-
-// isActivelyThrashing reports whether a container has a high cumulative restart
-// count AND is currently unhealthy AND is still churning. The Ready gate is what
-// clears the recovered-after-crash false positive — a pod that restarted many
-// times at startup but is now Ready and stable (its RestartCount never resets)
-// no longer trips this. The Waiting/recency gate clears the slept-then-woken
-// node whose restarts are days old. The 5m window matches isStableCrashLoop's
-// horizon so the two guards don't drift.
-func isActivelyThrashing(cs *corev1.ContainerStatus, now time.Time) bool {
-	if cs.RestartCount <= highRestartThreshold || cs.Ready {
-		return false
-	}
-	if cs.State.Waiting != nil {
-		return true
-	}
-	return restartedRecently(cs, now, 5*time.Minute)
-}
-
-// podActiveThrashContainer reports whether any main container is actively
-// thrashing (see isActivelyThrashing). Init containers are excluded — a failing
-// init container surfaces through podProblemReasonRaw's init walk with a
-// specific reason already.
-func podActiveThrashContainer(pod *corev1.Pod, now time.Time) bool {
-	for i := range pod.Status.ContainerStatuses {
-		if isActivelyThrashing(&pod.Status.ContainerStatuses[i], now) {
-			return true
-		}
-	}
-	return false
-}
-
-func containerHasTrustedReady(containers []corev1.Container, cs corev1.ContainerStatus) bool {
-	return cs.Ready && containerHasReadinessProbe(containers, cs.Name)
-}
-
-func containerRecentlyRecoveredFromOOM(containers []corev1.Container, cs corev1.ContainerStatus, now time.Time) bool {
-	if cs.LastTerminationState.Terminated == nil || cs.LastTerminationState.Terminated.Reason != "OOMKilled" {
-		return false
-	}
-	if containerHasTrustedReady(containers, cs) {
-		return false
-	}
-	if r := cs.State.Running; r != nil && !r.StartedAt.IsZero() {
-		return now.Sub(r.StartedAt.Time) <= 5*time.Minute
-	}
-	return cs.State.Waiting != nil || restartedRecently(&cs, now, 5*time.Minute)
-}
-
-func podHasActiveOOMKilled(pod *corev1.Pod, now time.Time) bool {
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.State.Terminated != nil && cs.State.Terminated.Reason == "OOMKilled" {
-			return true
-		}
-		if containerRecentlyRecoveredFromOOM(pod.Spec.Containers, cs, now) {
-			return true
-		}
-	}
-	for _, cs := range pod.Status.InitContainerStatuses {
-		if cs.State.Terminated != nil && cs.State.Terminated.Reason == "OOMKilled" {
-			return true
-		}
-		if cs.LastTerminationState.Terminated != nil && cs.LastTerminationState.Terminated.Reason == "OOMKilled" {
-			if cs.State.Terminated != nil && cs.State.Terminated.ExitCode == 0 {
-				continue
-			}
-			if r := cs.State.Running; r != nil && !r.StartedAt.IsZero() && now.Sub(r.StartedAt.Time) > 5*time.Minute {
-				continue
-			}
-			return true
-		}
-	}
-	return false
-}
-
-func podHasReadinessProbeFailure(pod *corev1.Pod, now time.Time) bool {
-	if pod.Status.Phase != corev1.PodRunning {
-		return false
-	}
-	if !podReadyFalseLongEnough(pod, now, 5*time.Minute) {
-		return false
-	}
-	for i := range pod.Status.ContainerStatuses {
-		cs := &pod.Status.ContainerStatuses[i]
-		if cs.Ready || cs.State.Running == nil {
-			continue
-		}
-		if containerHasReadinessProbe(pod.Spec.Containers, cs.Name) {
-			return true
-		}
-	}
-	return false
-}
-
-func podReadyFalseLongEnough(pod *corev1.Pod, now time.Time, minAge time.Duration) bool {
-	for i := range pod.Status.Conditions {
-		cond := &pod.Status.Conditions[i]
-		if cond.Type != corev1.PodReady && cond.Type != corev1.ContainersReady {
-			continue
-		}
-		if cond.Status != corev1.ConditionFalse {
-			continue
-		}
-		if !cond.LastTransitionTime.IsZero() {
-			return now.Sub(cond.LastTransitionTime.Time) >= minAge
-		}
-		if !pod.CreationTimestamp.IsZero() {
-			return now.Sub(pod.CreationTimestamp.Time) >= minAge
-		}
-		return true
-	}
-	return false
-}
-
 // ClassifyPodHealth determines if a pod is "healthy", "warning", or "error".
-// This is the canonical implementation used by both MCP and REST dashboards.
+// Legacy three-value projection of the canonical health.Pod verdict.
 func ClassifyPodHealth(pod *corev1.Pod, now time.Time) string {
-	if pod.Status.Phase == corev1.PodSucceeded {
-		return "healthy"
-	}
-	if pod.Status.Phase == corev1.PodFailed {
-		return "error"
-	}
-
-	// Stable crashloop: a container that has restarted with a recorded crash
-	// outcome is an error REGARDLESS of whether the kubelet currently reports
-	// it Waiting (backing off) or Running (just restarted, about to die
-	// again). Keying off the instantaneous phase here is what made severity
-	// flap critical↔warning poll-to-poll; the stable history fields don't
-	// oscillate, so neither does the verdict. Checked before the per-state
-	// scan below so a momentary "Running" can't downgrade it.
-	if podHasStableCrashLoop(pod, now) {
-		return "error"
-	}
-
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.State.Waiting != nil && isFatalWaitingReason(cs.State.Waiting.Reason) {
-			return "error"
-		}
-	}
-	if podHasActiveOOMKilled(pod, now) {
-		return "error"
-	}
-
-	// Init container errors
-	for _, cs := range pod.Status.InitContainerStatuses {
-		if cs.State.Waiting != nil && isFatalWaitingReason(cs.State.Waiting.Reason) {
-			return "error"
-		}
-	}
-
-	// Warning: pods pending for more than 5 minutes
-	if pod.Status.Phase == corev1.PodPending {
-		if now.Sub(pod.CreationTimestamp.Time) > 5*time.Minute {
-			return "warning"
-		}
-		return "healthy"
-	}
-
-	if podHasReadinessProbeFailure(pod, now) {
-		return "warning"
-	}
-
-	// Warning: a container actively thrashing — high cumulative restarts AND
-	// currently not ready AND still churning. A plain RestartCount>N check
-	// also fires on a pod that crashed at startup and has since been Ready
-	// for hours (RestartCount never resets), and on nodes whose restarts are
-	// stale laptop-sleep / reboot artifacts — both are healthy now. The
-	// thrash gate (not-ready + recent/Waiting) excludes those.
-	if podActiveThrashContainer(pod, now) {
-		return "warning"
-	}
-
-	return "healthy"
+	return health.Pod(pod, now).LegacyString()
 }
 
-// PodRestartContext extracts crash-debugging context from a pod's container
-// statuses: total restarts across main + init containers, and the kubelet-
-// recorded reason for the most recent container termination (OOMKilled,
-// Error, Completed, etc.). Used by Pod problem rows so agents can tell
-// chronic-vs-acute (high RestartCount = old) and pick the right next call
-// (OOMKilled → memory analysis; Error → fetch previous logs).
-func PodRestartContext(pod *corev1.Pod) (restartCount int32, lastTerminatedReason string) {
-	var newestFinish time.Time
-	walk := func(statuses []corev1.ContainerStatus) {
-		for _, cs := range statuses {
-			restartCount += cs.RestartCount
-			if t := cs.LastTerminationState.Terminated; t != nil && !t.FinishedAt.IsZero() {
-				if newestFinish.IsZero() || t.FinishedAt.After(newestFinish) {
-					newestFinish = t.FinishedAt.Time
-					lastTerminatedReason = t.Reason
-				}
-			}
-		}
-	}
-	walk(pod.Status.ContainerStatuses)
-	walk(pod.Status.InitContainerStatuses)
-	return restartCount, lastTerminatedReason
-}
-
-type crashLoopCandidate struct {
-	status     corev1.ContainerStatus
-	init       bool
-	index      int
-	stateRank  int
-	finishedAt time.Time
-}
-
-func podCrashLoopDiagnosis(pod *corev1.Pod, now time.Time) (cause, action string) {
-	candidate, ok := activeCrashLoopCandidate(pod, now)
-	if !ok {
-		return "", ""
-	}
-	term := candidate.status.LastTerminationState.Terminated
-	if term == nil || term.ExitCode == 0 || term.Reason == "OOMKilled" {
-		return "", ""
-	}
-
-	ref := fmt.Sprintf("container %q", candidate.status.Name)
-	if candidate.init {
-		ref = fmt.Sprintf("init container %q", candidate.status.Name)
-	}
-	run := shortRunContext(term)
-
-	switch term.ExitCode {
-	case 127:
-		return fmt.Sprintf("%s exited with code 127: command not found.%s", ref, run),
-			"Check the image entrypoint and pod command/args; verify the binary exists in the image."
-	case 126:
-		return fmt.Sprintf("%s exited with code 126: command found but not executable.%s", ref, run),
-			"Check executable permissions, the shebang/interpreter, and the pod command/args."
-	case 139:
-		return fmt.Sprintf("%s exited with code 139: segmentation fault.%s", ref, run),
-			"Inspect previous container logs and recent image/code changes; check native libraries or unsafe code for a segfault."
-	case 137:
-		return fmt.Sprintf("%s exited with code 137, but Kubernetes did not report OOMKilled.%s", ref, run),
-			"Check node pressure, process-level SIGKILLs, and memory limits; inspect previous container logs for shutdown context."
-	default:
-		return fmt.Sprintf("%s is crashlooping after exit code %d.%s", ref, term.ExitCode, run),
-			"Inspect previous container logs for this container and verify the pod command, args, config, and dependencies."
-	}
-}
-
-func activeCrashLoopCandidate(pod *corev1.Pod, now time.Time) (crashLoopCandidate, bool) {
-	var best crashLoopCandidate
-	have := false
-	consider := func(cs corev1.ContainerStatus, init bool, index int, readyTrusted bool) {
-		if !isStableCrashLoop(&cs, now, readyTrusted) {
-			return
-		}
-		c := crashLoopCandidate{
-			status:    cs,
-			init:      init,
-			index:     index,
-			stateRank: crashLoopStateRank(cs),
-		}
-		if t := cs.LastTerminationState.Terminated; t != nil {
-			c.finishedAt = t.FinishedAt.Time
-		}
-		if !have || betterCrashLoopCandidate(c, best) {
-			best, have = c, true
-		}
-	}
-	for i := range pod.Status.InitContainerStatuses {
-		consider(pod.Status.InitContainerStatuses[i], true, i, false)
-	}
-	for i := range pod.Status.ContainerStatuses {
-		cs := pod.Status.ContainerStatuses[i]
-		consider(cs, false, i, containerHasReadinessProbe(pod.Spec.Containers, cs.Name))
-	}
-	return best, have
-}
-
-func crashLoopStateRank(cs corev1.ContainerStatus) int {
-	if cs.State.Waiting != nil {
-		return 0
-	}
-	if cs.State.Terminated != nil {
-		return 1
-	}
-	if cs.State.Running != nil {
-		return 2
-	}
-	return 3
-}
-
-func betterCrashLoopCandidate(cand, cur crashLoopCandidate) bool {
-	if cand.stateRank != cur.stateRank {
-		return cand.stateRank < cur.stateRank
-	}
-	if !cand.finishedAt.Equal(cur.finishedAt) {
-		return cand.finishedAt.After(cur.finishedAt)
-	}
-	if cand.init != cur.init {
-		return cand.init
-	}
-	if cand.status.Name != cur.status.Name {
-		return cand.status.Name < cur.status.Name
-	}
-	return cand.index < cur.index
-}
-
-func shortRunContext(term *corev1.ContainerStateTerminated) string {
-	if term == nil || term.StartedAt.IsZero() || term.FinishedAt.IsZero() {
-		return ""
-	}
-	runDuration := term.FinishedAt.Time.Sub(term.StartedAt.Time)
-	if runDuration <= 0 || runDuration >= shortCrashRunWindow {
-		return ""
-	}
-	return " It exited within seconds of starting."
-}
-
-// PodProblemReason returns a short reason string for a problematic pod.
-// Walks init containers first because when init is failing the pod stays
-// Pending and main ContainerStatuses haven't been populated yet — without
-// the init check the reason would fall through to "Pending", masking
-// CrashLoopBackOff / ImagePullBackOff / etc. on the actual failing
-// init container.
+// PodProblemReason returns a short reason string for a problematic pod. The
+// classifier is clock-injected; problem rows are only computed for pods already
+// flagged as problems, so time.Now() here just reuses the same active tests.
 func PodProblemReason(pod *corev1.Pod) string {
-	reason := podProblemReasonRaw(pod)
-	// Stable-crashloop normalization: a
-	// crashlooping container oscillates Waiting("CrashLoopBackOff") → Running
-	// (just restarted) → Terminated → Waiting between polls. On the "Running"
-	// tick the raw walk returns a bare phase ("Running") — which
-	// issues/category.classifyProblem maps to `unknown`, flipping the
-	// category (and the category-hashed issue_id) mid-cycle. When the stable
-	// history fields say this is a crashloop, emit the canonical reason so the
-	// row's category stays `crashloop` across the whole oscillation. We only
-	// override when the raw reason isn't already a more-specific, stable
-	// signal (ImagePullBackOff, OOMKilled, an init failure, …) — those win.
-	// time.Now() is fine here: PodProblemReason is only called on pods already
-	// classified as problems (recovered pods are filtered upstream by
-	// ClassifyPodHealth), so the recovery guard inside podHasStableCrashLoop
-	// never fires on this path — it's just reusing the same active-crashloop test.
-	now := time.Now()
-	if podHasStableCrashLoop(pod, now) && isPhaseOrCrashReason(reason) {
-		return crashLoopReason
-	}
-	if podHasActiveOOMKilled(pod, now) && isPhaseOnlyReason(reason) {
-		return "OOMKilled"
-	}
-	// Actively-thrashing-but-not-a-classic-backoff: a container churning on
-	// failed readiness probes with clean (exit 0) terminations isn't a stable
-	// crashloop, so the raw walk returns a bare phase ("Running") that would
-	// classify as `unknown`. Name it HighRestartCount so the row lands in a
-	// runtime category instead of the catch-all. Only override a bare phase —
-	// a specific reason (ImagePullBackOff, an init failure, a real crash) wins.
-	if podActiveThrashContainer(pod, now) && isPhaseOnlyReason(reason) {
-		return highRestartReason
-	}
-	return reason
-}
-
-// podProblemReasonRaw is the original phase/state walk: init containers first
-// (they block the pod Pending before main ContainerStatuses populate), then
-// main containers, falling back to the bare phase string.
-// isFatalWaitingReason reports whether a container's Waiting reason is a hard
-// failure that won't self-resolve on its own — as opposed to the transient
-// PodInitializing/ContainerCreating states. InvalidImageName is permanent (a
-// malformed image reference never becomes valid); the *ContainerError family
-// means the container couldn't be created or started (bad command, missing
-// device, runtime rejection). These were silently healthy before, so a typo'd
-// image tag produced no issue row at all.
-func isFatalWaitingReason(reason string) bool {
-	switch reason {
-	case "CrashLoopBackOff", "ImagePullBackOff", "ErrImagePull", "InvalidImageName",
-		"ImageInspectError", "CreateContainerConfigError", "CreateContainerError",
-		"RunContainerError":
-		return true
-	}
-	return false
+	return health.PodProblemReason(pod, time.Now())
 }
 
 // PodProblemMessage returns the kubelet's waiting/terminated message for the
-// first container in a problem state (init containers first, mirroring
-// podProblemReasonRaw's walk). This is the actionable detail behind an
-// otherwise-bare reason — ImagePullBackOff's "Failed to pull image X: …not
-// found", CreateContainerConfigError's "couldn't find key Y in Secret Z" —
-// which is small, decisive, and otherwise only visible by opening the pod.
+// first container in a problem state.
 func PodProblemMessage(pod *corev1.Pod) string {
-	for _, cs := range pod.Status.InitContainerStatuses {
-		if cs.State.Waiting != nil && cs.State.Waiting.Message != "" {
-			return cs.State.Waiting.Message
-		}
-		if cs.State.Terminated != nil && cs.State.Terminated.Message != "" {
-			return cs.State.Terminated.Message
-		}
-	}
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.State.Waiting != nil && cs.State.Waiting.Message != "" {
-			return cs.State.Waiting.Message
-		}
-		if cs.State.Terminated != nil && cs.State.Terminated.Message != "" {
-			return cs.State.Terminated.Message
-		}
-	}
-	return ""
+	return health.PodProblemMessage(pod)
 }
 
-func podProblemReasonRaw(pod *corev1.Pod) string {
-	for _, cs := range pod.Status.InitContainerStatuses {
-		if cs.State.Waiting != nil && cs.State.Waiting.Reason != "" {
-			return cs.State.Waiting.Reason
-		}
-		if cs.State.Terminated != nil && cs.State.Terminated.Reason != "" {
-			return cs.State.Terminated.Reason
-		}
-	}
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.State.Waiting != nil && cs.State.Waiting.Reason != "" {
-			return cs.State.Waiting.Reason
-		}
-		if cs.State.Terminated != nil && cs.State.Terminated.Reason != "" {
-			return cs.State.Terminated.Reason
-		}
-	}
-	if podHasReadinessProbeFailure(pod, time.Now()) {
-		return readinessProbeFailedReason
-	}
-	return string(pod.Status.Phase)
+// PodRestartContext extracts total restarts + the most recent termination reason.
+func PodRestartContext(pod *corev1.Pod) (restartCount int32, lastTerminatedReason string) {
+	return health.PodRestartContext(pod)
 }
 
-// isPhaseOrCrashReason reports whether reason is one that a stable-crashloop
-// override may safely replace: a bare lifecycle phase / no-op waiting state
-// (the instantaneous values that flap), or an already-crash-class reason
-// (so the canonical string is used consistently). A distinct, more-specific
-// reason like ImagePullBackOff or OOMKilled is NOT in this set and is left
-// untouched.
-func isPhaseOrCrashReason(reason string) bool {
-	switch reason {
-	case "Running", "Pending", "Succeeded", "Failed", "Unknown", "",
-		"PodInitializing", "ContainerCreating",
-		"CrashLoopBackOff", "Error":
-		return true
-	}
-	return false
+// IsPodUnschedulable reports whether the scheduler tried and failed to place the
+// pod (PodScheduled=False, reason=Unschedulable).
+func IsPodUnschedulable(pod *corev1.Pod) bool {
+	return health.IsPodUnschedulable(pod)
 }
 
-// isPhaseOnlyReason is the narrower set the HighRestartCount override may
-// replace: bare lifecycle phases / no-op waiting states only. It deliberately
-// excludes the crash-class reasons (CrashLoopBackOff/Error) and terminal phases
-// (Succeeded/Failed) that isPhaseOrCrashReason allows, so a thrash override can
-// never clobber a real crash or terminal signal — the stable-crashloop check
-// above already owns those.
-func isPhaseOnlyReason(reason string) bool {
-	switch reason {
-	case "Running", "Pending", "Unknown", "",
-		"PodInitializing", "ContainerCreating":
-		return true
-	}
-	return false
+func podCrashLoopDiagnosis(pod *corev1.Pod, now time.Time) (cause, action string) {
+	return health.PodCrashLoopDiagnosis(pod, now)
+}
+
+func podHasReadinessProbeFailure(pod *corev1.Pod, now time.Time) bool {
+	return health.PodHasReadinessProbeFailure(pod, now)
 }
 
 // NodeHealth describes the health of a single node.

--- a/pkg/health/level.go
+++ b/pkg/health/level.go
@@ -1,0 +1,110 @@
+// Package health is the canonical, pure resource health-classification engine
+// for Radar. It lives in pkg/ (not internal/) so every consumer — topology,
+// timeline, packages, resourcecontext, the REST/MCP servers — can share ONE
+// classifier instead of the parallel copies that drifted historically.
+//
+// It is a pure leaf: it imports only the Kubernetes API types, the standard
+// library, and other pkg/ leaves. It must never import anything from internal/,
+// nor from the consumer packages (timeline/packages/topology) that depend on it —
+// the per-surface adapters (Level → timeline.HealthState etc.) live on the
+// consumer side so the dependency arrow only ever points inward.
+//
+// Health LEVEL (this package) is distinct from issue/finding SEVERITY
+// (critical/alert/warning/info — owned by the Problems, Audit, and GitOps
+// Insights subsystems). This package classifies "how is this resource doing";
+// it does not rank findings.
+package health
+
+// Level is the canonical resource-health vocabulary. Five tiers, ordered from
+// most-benign to most-severe by Rank below.
+//
+// There is deliberately no "alert" tier here: alert (orange) is an issue/finding
+// severity, not a resource-health level — no core resource produces an "alert"
+// health state, and the only frontend emitters of it are bespoke per-CRD
+// renderers (Crossplane, NVIDIA, …) that classify locally. Keeping it out of the
+// backend Level keeps the operator's color vocabulary to the smallest set that
+// maps to distinct actions.
+type Level string
+
+const (
+	// LevelHealthy: confirmed good.
+	LevelHealthy Level = "healthy"
+	// LevelNeutral: intentional / lifecycle state — scaled-to-zero, suspended,
+	// completed, idle. Not a problem; must NOT pull an Unhealthy filter or a
+	// rollup. Aggregates as most-benign (ties healthy in WorseOf).
+	LevelNeutral Level = "neutral"
+	// LevelDegraded: partial impairment — some-but-not-all ready, transient
+	// problem past its grace window.
+	LevelDegraded Level = "degraded"
+	// LevelUnhealthy: genuine failure — crashloop, OOM, fatal waiting, none ready.
+	LevelUnhealthy Level = "unhealthy"
+	// LevelUnknown: no signal / unobserved. Ranks just above healthy so a
+	// no-data row is not promoted to "healthy" by a rollup, but below any real
+	// impairment.
+	LevelUnknown Level = "unknown"
+)
+
+// Rank orders the levels for worst-of aggregation. neutral ties healthy at 0 —
+// an all-neutral set aggregates as benign, NOT as a problem — while unknown sits
+// just above healthy (a "we don't know" row should not be reported as healthy,
+// but is quieter than any genuine impairment).
+func Rank(l Level) int {
+	switch l {
+	case LevelHealthy, LevelNeutral:
+		return 0
+	case LevelUnknown:
+		return 1
+	case LevelDegraded:
+		return 2
+	case LevelUnhealthy:
+		return 3
+	}
+	// Unrecognized vocabulary maps to the unknown rank — quieter than any real
+	// impairment, but still not promoted to healthy.
+	return 1
+}
+
+// WorseOf returns the more-severe of two levels by Rank. An empty Level is "no
+// opinion" — the other side wins. When ranks tie, a is returned (so a healthy/
+// neutral tie keeps whichever the caller folded first; both display calmly).
+func WorseOf(a, b Level) Level {
+	if a == "" {
+		return b
+	}
+	if b == "" {
+		return a
+	}
+	if Rank(b) > Rank(a) {
+		return b
+	}
+	return a
+}
+
+// Verdict is the full result of classifying a resource: its Level, a short
+// machine Reason token (e.g. "CrashLoopBackOff", "Completed") when the Level is
+// not plainly healthy, and an optional human Message (the kubelet detail behind
+// the reason). Reason/Message let the Problems and timeline surfaces reuse the
+// classification without a second pass.
+type Verdict struct {
+	Level   Level
+	Reason  string
+	Message string
+}
+
+// LegacyString projects a Verdict onto the legacy three-value pod-health
+// vocabulary ("healthy" | "warning" | "error") that ClassifyPodHealth returned
+// before this package existed. Kept so the internal/k8s shim is a provable no-op
+// for callers (dashboards, MCP counters) that still switch on those strings.
+func (v Verdict) LegacyString() string {
+	switch v.Level {
+	case LevelDegraded:
+		return "warning"
+	case LevelUnhealthy:
+		return "error"
+	default:
+		// healthy, neutral (e.g. Succeeded), unknown all read as "healthy" in
+		// the legacy vocabulary — matching the pre-split ClassifyPodHealth, whose
+		// default and Succeeded branches both returned "healthy".
+		return "healthy"
+	}
+}

--- a/pkg/health/level_test.go
+++ b/pkg/health/level_test.go
@@ -1,0 +1,61 @@
+package health
+
+import "testing"
+
+func TestRankOrdering(t *testing.T) {
+	// neutral ties healthy at the bottom; unknown sits just above; then degraded,
+	// then unhealthy. This is the single ordering all consumer rank maps derive
+	// from — pinning it here is what keeps them from re-diverging.
+	if Rank(LevelHealthy) != 0 || Rank(LevelNeutral) != 0 {
+		t.Fatalf("healthy and neutral must both rank 0 (most-benign), got %d/%d", Rank(LevelHealthy), Rank(LevelNeutral))
+	}
+	if !(Rank(LevelHealthy) < Rank(LevelUnknown) &&
+		Rank(LevelUnknown) < Rank(LevelDegraded) &&
+		Rank(LevelDegraded) < Rank(LevelUnhealthy)) {
+		t.Fatalf("rank order broken: healthy=%d unknown=%d degraded=%d unhealthy=%d",
+			Rank(LevelHealthy), Rank(LevelUnknown), Rank(LevelDegraded), Rank(LevelUnhealthy))
+	}
+	// Unrecognized vocab maps to the unknown rank, not promoted to healthy.
+	if Rank(Level("bogus")) != Rank(LevelUnknown) {
+		t.Fatalf("unrecognized level should rank as unknown, got %d", Rank(Level("bogus")))
+	}
+}
+
+func TestWorseOf(t *testing.T) {
+	cases := []struct {
+		a, b, want Level
+	}{
+		{LevelHealthy, LevelUnhealthy, LevelUnhealthy},
+		{LevelDegraded, LevelHealthy, LevelDegraded},
+		{LevelNeutral, LevelHealthy, LevelNeutral}, // tie → first arg
+		{LevelHealthy, LevelNeutral, LevelHealthy}, // tie → first arg
+		{LevelUnknown, LevelHealthy, LevelUnknown}, // unknown beats healthy
+		{LevelNeutral, LevelDegraded, LevelDegraded},
+		{"", LevelDegraded, LevelDegraded}, // empty = no opinion
+		{LevelDegraded, "", LevelDegraded},
+		{LevelUnhealthy, LevelDegraded, LevelUnhealthy},
+	}
+	for _, c := range cases {
+		if got := WorseOf(c.a, c.b); got != c.want {
+			t.Errorf("WorseOf(%q,%q) = %q, want %q", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestLegacyString(t *testing.T) {
+	cases := []struct {
+		level Level
+		want  string
+	}{
+		{LevelHealthy, "healthy"},
+		{LevelNeutral, "healthy"},   // Succeeded etc. read healthy in legacy vocab
+		{LevelUnknown, "healthy"},   // legacy classifier never produced unknown
+		{LevelDegraded, "warning"},
+		{LevelUnhealthy, "error"},
+	}
+	for _, c := range cases {
+		if got := (Verdict{Level: c.level}).LegacyString(); got != c.want {
+			t.Errorf("Verdict{%q}.LegacyString() = %q, want %q", c.level, got, c.want)
+		}
+	}
+}

--- a/pkg/health/pod.go
+++ b/pkg/health/pod.go
@@ -1,0 +1,333 @@
+package health
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Pod classifies a pod's health into a canonical Verdict. This is the single
+// source of truth that ClassifyPodHealth (legacy string), the timeline, the
+// dashboards, and MCP all reduce to.
+//
+// Precedence (broken-state checks first, benign last — a benign branch must
+// never be ordered ahead of a failure check):
+//
+//	Succeeded            → neutral  (completed; lifecycle, not a problem)
+//	Failed               → unhealthy
+//	stable crashloop     → unhealthy
+//	fatal waiting reason → unhealthy
+//	active OOMKilled     → unhealthy
+//	Pending > 5m         → degraded ; Pending < 5m → healthy (startup grace)
+//	readiness probe fail → degraded
+//	active thrash        → degraded
+//	default              → healthy
+//
+// Unschedulable and stuck-termination are NOT folded in here: they are detected
+// by callers that own their own pre-emption (the scheduling detector, the
+// terminating detector) and folding them in would change health-counter outputs.
+// They move into this classifier in a later migration where those changes are
+// owned explicitly.
+func Pod(pod *corev1.Pod, now time.Time) Verdict {
+	level := classifyPodLevel(pod, now)
+	v := Verdict{Level: level}
+	switch level {
+	case LevelDegraded, LevelUnhealthy:
+		v.Reason = PodProblemReason(pod, now)
+		v.Message = PodProblemMessage(pod)
+	case LevelNeutral:
+		if pod.Status.Phase == corev1.PodSucceeded {
+			v.Reason = "Completed"
+		}
+	}
+	return v
+}
+
+func classifyPodLevel(pod *corev1.Pod, now time.Time) Level {
+	if pod.Status.Phase == corev1.PodSucceeded {
+		return LevelNeutral
+	}
+	if pod.Status.Phase == corev1.PodFailed {
+		return LevelUnhealthy
+	}
+
+	// Stable crashloop: a container that has restarted with a recorded crash
+	// outcome is a failure REGARDLESS of whether the kubelet currently reports it
+	// Waiting (backing off) or Running (just restarted, about to die again).
+	// Keying off the instantaneous phase here is what made severity flap
+	// poll-to-poll; the stable history fields don't oscillate, so neither does
+	// the verdict. Checked before the per-state scan below so a momentary
+	// "Running" can't downgrade it.
+	if podHasStableCrashLoop(pod, now) {
+		return LevelUnhealthy
+	}
+
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.State.Waiting != nil && isFatalWaitingReason(cs.State.Waiting.Reason) {
+			return LevelUnhealthy
+		}
+	}
+	if podHasActiveOOMKilled(pod, now) {
+		return LevelUnhealthy
+	}
+
+	// Init container errors.
+	for _, cs := range pod.Status.InitContainerStatuses {
+		if cs.State.Waiting != nil && isFatalWaitingReason(cs.State.Waiting.Reason) {
+			return LevelUnhealthy
+		}
+	}
+
+	// Pods pending past the startup grace window.
+	if pod.Status.Phase == corev1.PodPending {
+		if now.Sub(pod.CreationTimestamp.Time) > 5*time.Minute {
+			return LevelDegraded
+		}
+		return LevelHealthy
+	}
+
+	if podHasReadinessProbeFailure(pod, now) {
+		return LevelDegraded
+	}
+
+	// A container actively thrashing — high cumulative restarts AND currently
+	// not ready AND still churning. A plain RestartCount>N check also fires on a
+	// pod that crashed at startup and has since been Ready for hours
+	// (RestartCount never resets), and on nodes whose restarts are stale
+	// laptop-sleep / reboot artifacts — both are healthy now. The thrash gate
+	// (not-ready + recent/Waiting) excludes those.
+	if podActiveThrashContainer(pod, now) {
+		return LevelDegraded
+	}
+
+	return LevelHealthy
+}
+
+// PodProblemReason returns a short reason token for a problematic pod. Walks
+// init containers first because when init is failing the pod stays Pending and
+// main ContainerStatuses haven't been populated yet — without the init check the
+// reason would fall through to "Pending", masking CrashLoopBackOff /
+// ImagePullBackOff / etc. on the actual failing init container.
+//
+// now is injected (callers pass the same clock they classify with) so the reason
+// is reproducible and the crashloop/thrash overrides use a single consistent
+// time base.
+func PodProblemReason(pod *corev1.Pod, now time.Time) string {
+	reason := podProblemReasonRaw(pod, now)
+	// Stable-crashloop normalization: a crashlooping container oscillates
+	// Waiting("CrashLoopBackOff") → Running (just restarted) → Terminated →
+	// Waiting between polls. On the "Running" tick the raw walk returns a bare
+	// phase ("Running") — which category classification maps to `unknown`,
+	// flipping the category (and the category-hashed issue_id) mid-cycle. When
+	// the stable history fields say this is a crashloop, emit the canonical
+	// reason so the row's category stays stable across the whole oscillation. We
+	// only override when the raw reason isn't already a more-specific, stable
+	// signal (ImagePullBackOff, OOMKilled, an init failure, …) — those win.
+	if podHasStableCrashLoop(pod, now) && isPhaseOrCrashReason(reason) {
+		return reasonCrashLoop
+	}
+	if podHasActiveOOMKilled(pod, now) && isPhaseOnlyReason(reason) {
+		return "OOMKilled"
+	}
+	// Actively-thrashing-but-not-a-classic-backoff: a container churning on
+	// failed readiness probes with clean (exit 0) terminations isn't a stable
+	// crashloop, so the raw walk returns a bare phase ("Running") that would
+	// classify as `unknown`. Name it HighRestartCount so the row lands in a
+	// runtime category instead of the catch-all. Only override a bare phase — a
+	// specific reason (ImagePullBackOff, an init failure, a real crash) wins.
+	if podActiveThrashContainer(pod, now) && isPhaseOnlyReason(reason) {
+		return reasonHighRestart
+	}
+	return reason
+}
+
+// podProblemReasonRaw is the phase/state walk: init containers first (they block
+// the pod Pending before main ContainerStatuses populate), then main containers,
+// falling back to the bare phase string.
+func podProblemReasonRaw(pod *corev1.Pod, now time.Time) string {
+	for _, cs := range pod.Status.InitContainerStatuses {
+		if cs.State.Waiting != nil && cs.State.Waiting.Reason != "" {
+			return cs.State.Waiting.Reason
+		}
+		if cs.State.Terminated != nil && cs.State.Terminated.Reason != "" {
+			return cs.State.Terminated.Reason
+		}
+	}
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.State.Waiting != nil && cs.State.Waiting.Reason != "" {
+			return cs.State.Waiting.Reason
+		}
+		if cs.State.Terminated != nil && cs.State.Terminated.Reason != "" {
+			return cs.State.Terminated.Reason
+		}
+	}
+	if podHasReadinessProbeFailure(pod, now) {
+		return reasonReadinessProbeFail
+	}
+	return string(pod.Status.Phase)
+}
+
+// PodProblemMessage returns the kubelet's waiting/terminated message for the
+// first container in a problem state (init containers first, mirroring
+// podProblemReasonRaw's walk). This is the actionable detail behind an otherwise
+// bare reason — ImagePullBackOff's "Failed to pull image X: …not found",
+// CreateContainerConfigError's "couldn't find key Y in Secret Z".
+func PodProblemMessage(pod *corev1.Pod) string {
+	for _, cs := range pod.Status.InitContainerStatuses {
+		if cs.State.Waiting != nil && cs.State.Waiting.Message != "" {
+			return cs.State.Waiting.Message
+		}
+		if cs.State.Terminated != nil && cs.State.Terminated.Message != "" {
+			return cs.State.Terminated.Message
+		}
+	}
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.State.Waiting != nil && cs.State.Waiting.Message != "" {
+			return cs.State.Waiting.Message
+		}
+		if cs.State.Terminated != nil && cs.State.Terminated.Message != "" {
+			return cs.State.Terminated.Message
+		}
+	}
+	return ""
+}
+
+// PodRestartContext extracts crash-debugging context: total restarts across main
+// + init containers, and the kubelet-recorded reason for the most recent
+// container termination (OOMKilled, Error, Completed, …). Lets callers tell
+// chronic-vs-acute and pick the right next step (OOMKilled → memory analysis;
+// Error → previous logs).
+func PodRestartContext(pod *corev1.Pod) (restartCount int32, lastTerminatedReason string) {
+	var newestFinish time.Time
+	walk := func(statuses []corev1.ContainerStatus) {
+		for _, cs := range statuses {
+			restartCount += cs.RestartCount
+			if t := cs.LastTerminationState.Terminated; t != nil && !t.FinishedAt.IsZero() {
+				if newestFinish.IsZero() || t.FinishedAt.After(newestFinish) {
+					newestFinish = t.FinishedAt.Time
+					lastTerminatedReason = t.Reason
+				}
+			}
+		}
+	}
+	walk(pod.Status.ContainerStatuses)
+	walk(pod.Status.InitContainerStatuses)
+	return restartCount, lastTerminatedReason
+}
+
+type crashLoopCandidate struct {
+	status     corev1.ContainerStatus
+	init       bool
+	index      int
+	stateRank  int
+	finishedAt time.Time
+}
+
+// PodCrashLoopDiagnosis returns a human-readable cause + suggested action for a
+// pod's active crashloop candidate, or empty strings when there is no actionable
+// crash (no candidate, OOM — which has its own path — or a clean exit).
+func PodCrashLoopDiagnosis(pod *corev1.Pod, now time.Time) (cause, action string) {
+	candidate, ok := activeCrashLoopCandidate(pod, now)
+	if !ok {
+		return "", ""
+	}
+	term := candidate.status.LastTerminationState.Terminated
+	if term == nil || term.ExitCode == 0 || term.Reason == "OOMKilled" {
+		return "", ""
+	}
+
+	ref := fmt.Sprintf("container %q", candidate.status.Name)
+	if candidate.init {
+		ref = fmt.Sprintf("init container %q", candidate.status.Name)
+	}
+	run := shortRunContext(term)
+
+	switch term.ExitCode {
+	case 127:
+		return fmt.Sprintf("%s exited with code 127: command not found.%s", ref, run),
+			"Check the image entrypoint and pod command/args; verify the binary exists in the image."
+	case 126:
+		return fmt.Sprintf("%s exited with code 126: command found but not executable.%s", ref, run),
+			"Check executable permissions, the shebang/interpreter, and the pod command/args."
+	case 139:
+		return fmt.Sprintf("%s exited with code 139: segmentation fault.%s", ref, run),
+			"Inspect previous container logs and recent image/code changes; check native libraries or unsafe code for a segfault."
+	case 137:
+		return fmt.Sprintf("%s exited with code 137, but Kubernetes did not report OOMKilled.%s", ref, run),
+			"Check node pressure, process-level SIGKILLs, and memory limits; inspect previous container logs for shutdown context."
+	default:
+		return fmt.Sprintf("%s is crashlooping after exit code %d.%s", ref, term.ExitCode, run),
+			"Inspect previous container logs for this container and verify the pod command, args, config, and dependencies."
+	}
+}
+
+func activeCrashLoopCandidate(pod *corev1.Pod, now time.Time) (crashLoopCandidate, bool) {
+	var best crashLoopCandidate
+	have := false
+	consider := func(cs corev1.ContainerStatus, init bool, index int, readyTrusted bool) {
+		if !isStableCrashLoop(&cs, now, readyTrusted) {
+			return
+		}
+		c := crashLoopCandidate{
+			status:    cs,
+			init:      init,
+			index:     index,
+			stateRank: crashLoopStateRank(cs),
+		}
+		if t := cs.LastTerminationState.Terminated; t != nil {
+			c.finishedAt = t.FinishedAt.Time
+		}
+		if !have || betterCrashLoopCandidate(c, best) {
+			best, have = c, true
+		}
+	}
+	for i := range pod.Status.InitContainerStatuses {
+		consider(pod.Status.InitContainerStatuses[i], true, i, false)
+	}
+	for i := range pod.Status.ContainerStatuses {
+		cs := pod.Status.ContainerStatuses[i]
+		consider(cs, false, i, containerHasReadinessProbe(pod.Spec.Containers, cs.Name))
+	}
+	return best, have
+}
+
+func crashLoopStateRank(cs corev1.ContainerStatus) int {
+	if cs.State.Waiting != nil {
+		return 0
+	}
+	if cs.State.Terminated != nil {
+		return 1
+	}
+	if cs.State.Running != nil {
+		return 2
+	}
+	return 3
+}
+
+func betterCrashLoopCandidate(cand, cur crashLoopCandidate) bool {
+	if cand.stateRank != cur.stateRank {
+		return cand.stateRank < cur.stateRank
+	}
+	if !cand.finishedAt.Equal(cur.finishedAt) {
+		return cand.finishedAt.After(cur.finishedAt)
+	}
+	if cand.init != cur.init {
+		return cand.init
+	}
+	if cand.status.Name != cur.status.Name {
+		return cand.status.Name < cur.status.Name
+	}
+	return cand.index < cur.index
+}
+
+func shortRunContext(term *corev1.ContainerStateTerminated) string {
+	if term == nil || term.StartedAt.IsZero() || term.FinishedAt.IsZero() {
+		return ""
+	}
+	runDuration := term.FinishedAt.Time.Sub(term.StartedAt.Time)
+	if runDuration <= 0 || runDuration >= shortCrashRunWindow {
+		return ""
+	}
+	return " It exited within seconds of starting."
+}

--- a/pkg/health/pod_test.go
+++ b/pkg/health/pod_test.go
@@ -1,0 +1,302 @@
+package health
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestPodGoldenVectors is the canonical, clock-injected health contract for
+// pods. Every case fixes an explicit `now` and uses timestamps relative to it,
+// so the table is reproducible and portable (PR4 mirrors it in vitest to keep
+// the TS classifier from drifting). It asserts both the Level and, for problem
+// pods, the Reason token.
+func TestPodGoldenVectors(t *testing.T) {
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	old := metav1.NewTime(now.Add(-10 * time.Minute))
+	recent := metav1.NewTime(now.Add(-1 * time.Minute))
+
+	cases := []struct {
+		name       string
+		pod        *corev1.Pod
+		wantLevel  Level
+		wantReason string // "" = don't assert reason
+	}{
+		{
+			name: "healthy running pod",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase:             corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{{Ready: true, RestartCount: 0}},
+			}},
+			wantLevel: LevelHealthy,
+		},
+		{
+			name:       "succeeded pod is neutral (completed)",
+			pod:        &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodSucceeded}},
+			wantLevel:  LevelNeutral,
+			wantReason: "Completed",
+		},
+		{
+			name:      "failed pod is unhealthy",
+			pod:       &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodFailed}},
+			wantLevel: LevelUnhealthy,
+		},
+		{
+			name: "CrashLoopBackOff is unhealthy",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}},
+				},
+			}},
+			wantLevel:  LevelUnhealthy,
+			wantReason: "CrashLoopBackOff",
+		},
+		{
+			name: "OOMKilled is unhealthy",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "OOMKilled"}}},
+				},
+			}},
+			wantLevel:  LevelUnhealthy,
+			wantReason: "OOMKilled",
+		},
+		{
+			name: "recovered LastTerminationState OOMKilled is healthy",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Ready:                true,
+					LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "OOMKilled"}},
+				}},
+			}},
+			wantLevel: LevelHealthy,
+		},
+		{
+			name: "init container fatal waiting is unhealthy",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: old},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"}}},
+					},
+				},
+			},
+			wantLevel:  LevelUnhealthy,
+			wantReason: "ImagePullBackOff",
+		},
+		{
+			name: "pending over 5 minutes is degraded",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: old},
+				Status:     corev1.PodStatus{Phase: corev1.PodPending},
+			},
+			wantLevel:  LevelDegraded,
+			wantReason: "Pending",
+		},
+		{
+			name: "recently pending is healthy (startup grace)",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: recent},
+				Status:     corev1.PodStatus{Phase: corev1.PodPending},
+			},
+			wantLevel: LevelHealthy,
+		},
+		{
+			name: "readiness probe failed long enough is degraded",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: old},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app", ReadinessProbe: &corev1.Probe{}}}},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{{
+						Type: corev1.PodReady, Status: corev1.ConditionFalse, LastTransitionTime: old,
+					}},
+					ContainerStatuses: []corev1.ContainerStatus{{
+						Name: "app", Ready: false,
+						State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: old}},
+					}},
+				},
+			},
+			wantLevel:  LevelDegraded,
+			wantReason: "ReadinessProbeFailed",
+		},
+		{
+			name: "recent readiness probe failure is still starting (healthy)",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: recent},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app", ReadinessProbe: &corev1.Probe{}}}},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{{
+						Type: corev1.PodReady, Status: corev1.ConditionFalse, LastTransitionTime: recent,
+					}},
+					ContainerStatuses: []corev1.ContainerStatus{{
+						Name: "app", Ready: false,
+						State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: recent}},
+					}},
+				},
+			},
+			wantLevel: LevelHealthy,
+		},
+		{
+			name: "recovered: high restart count but now ready and stable is healthy",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Ready: true, RestartCount: 10,
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-2 * time.Hour))}},
+				}},
+			}},
+			wantLevel: LevelHealthy,
+		},
+		{
+			name: "actively thrashing is degraded",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Ready: false, RestartCount: 1659,
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-30 * time.Minute))}},
+					LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+						Reason: "Completed", ExitCode: 0, FinishedAt: metav1.NewTime(now.Add(-30 * time.Second)),
+					}},
+				}},
+			}},
+			wantLevel:  LevelDegraded,
+			wantReason: "HighRestartCount",
+		},
+		{
+			name: "stale restarts (days old) is healthy",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Ready: false, RestartCount: 200,
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-72 * time.Hour))}},
+					LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+						Reason: "Completed", ExitCode: 0, FinishedAt: metav1.NewTime(now.Add(-72 * time.Hour)),
+					}},
+				}},
+			}},
+			wantLevel: LevelHealthy,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Pod(c.pod, now)
+			if got.Level != c.wantLevel {
+				t.Errorf("Pod().Level = %q, want %q", got.Level, c.wantLevel)
+			}
+			if c.wantReason != "" && got.Reason != c.wantReason {
+				t.Errorf("Pod().Reason = %q, want %q", got.Reason, c.wantReason)
+			}
+		})
+	}
+}
+
+// TestPodStableCrashLoopAcrossPhases pins crashloop monotonicity: a crashlooping
+// container's instantaneous State flaps Waiting → Running → Waiting poll-to-poll,
+// but the Verdict (Level + Reason) must stay fixed because it reads the stable
+// history fields.
+func TestPodStableCrashLoopAcrossPhases(t *testing.T) {
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	crashHistory := corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Error", ExitCode: 1}}
+	mkPod := func(state corev1.ContainerState) *corev1.Pod {
+		return &corev1.Pod{Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				RestartCount: 7, State: state, LastTerminationState: crashHistory,
+			}},
+		}}
+	}
+	states := []corev1.ContainerState{
+		{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
+		{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now)}},
+		{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
+	}
+	for i, st := range states {
+		v := Pod(mkPod(st), now)
+		if v.Level != LevelUnhealthy || v.Reason != "CrashLoopBackOff" {
+			t.Errorf("phase %d: got {%q,%q}, want stable {unhealthy,CrashLoopBackOff}", i, v.Level, v.Reason)
+		}
+	}
+}
+
+// TestPodProblemReasonInitWalk pins that init-container reasons win over the bare
+// Pending phase (the init-blocking case) and that specific reasons aren't clobbered.
+func TestPodProblemReasonInitWalk(t *testing.T) {
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name string
+		pod  *corev1.Pod
+		want string
+	}{
+		{
+			name: "init waiting reason wins over phase",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				InitContainerStatuses: []corev1.ContainerStatus{
+					{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}},
+				},
+			}},
+			want: "CrashLoopBackOff",
+		},
+		{
+			name: "falls back to phase",
+			pod:  &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodPending}},
+			want: "Pending",
+		},
+		{
+			name: "active ImagePullBackOff keeps specific reason over crashloop",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					RestartCount:         2,
+					State:                corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"}},
+					LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Error", ExitCode: 1}},
+				}},
+			}},
+			want: "ImagePullBackOff",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := PodProblemReason(c.pod, now); got != c.want {
+				t.Errorf("PodProblemReason = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestPodCrashLoopDiagnosis(t *testing.T) {
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	started := metav1.NewTime(now.Add(-3 * time.Second))
+	finished := metav1.NewTime(now.Add(-2 * time.Second))
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:         "app",
+				RestartCount: 2,
+				State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-1 * time.Second))}},
+				LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+					Reason: "Error", ExitCode: 127, StartedAt: started, FinishedAt: finished,
+				}},
+			}},
+		},
+	}
+	cause, action := PodCrashLoopDiagnosis(pod, now)
+	if !strings.Contains(cause, `container "app"`) || !strings.Contains(cause, "code 127") || !strings.Contains(cause, "within seconds") {
+		t.Fatalf("cause = %q, want app exit-127 diagnosis with short-run context", cause)
+	}
+	if !strings.Contains(action, "command/args") {
+		t.Fatalf("action = %q, want command/args guidance", action)
+	}
+}

--- a/pkg/health/reasons.go
+++ b/pkg/health/reasons.go
@@ -1,0 +1,298 @@
+package health
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Canonical reason tokens this package emits. They are deliberately the
+// Kubernetes-canonical strings so downstream category classification stays
+// stable across the kubelet's instantaneous state oscillation.
+const (
+	reasonCrashLoop          = "CrashLoopBackOff"
+	reasonHighRestart        = "HighRestartCount"
+	reasonReadinessProbeFail = "ReadinessProbeFailed"
+)
+
+// highRestartThreshold is the cumulative per-container RestartCount above which
+// a still-unhealthy container is treated as actively thrashing.
+const highRestartThreshold = 3
+
+const shortCrashRunWindow = 10 * time.Second
+
+// isStableCrashLoop reports whether a container is in an ACTIVE crashloop: it
+// has restarted with a crash-class last termination (CrashLoopBackOff / generic
+// Error / non-zero exit), AND it has not since recovered. It reads the stable
+// history fields (RestartCount + LastTerminationState) rather than the
+// instantaneous State the kubelet flips between polls — so a real loop's brief
+// "Running" blip doesn't downgrade the verdict — but it must NOT fire on a
+// container that crashed once and is now running healthily: RestartCount and
+// LastTerminationState persist for the life of the container, so without the
+// recovery guard below a pod that restarted once at startup would read as a
+// crashloop forever. Three recovery signals clear it: a container currently
+// Ready when that Ready is probe-gated (readyTrusted) has passed its readiness
+// probe and is serving NOW; a container Running continuously past the kubelet's
+// max CrashLoopBackOff backoff (5m) has outlived the loop; and a container whose
+// CURRENT state is a clean exit (Terminated, exit 0) has succeeded — the common
+// init-container-retries-then-completes case, whose failed prior attempt lingers
+// in LastTerminationState. OOMKilled is intentionally excluded — it has its own
+// category/severity path upstream.
+//
+// readyTrusted gates the Ready short-circuit because Ready is only a meaningful
+// recovery signal when a readiness probe backs it: without a probe Ready just
+// mirrors Running and flips true during a loop's brief between-crash window, so
+// for probe-less containers the 5m Running guard below stays the discriminator.
+func isStableCrashLoop(cs *corev1.ContainerStatus, now time.Time, readyTrusted bool) bool {
+	if cs.RestartCount == 0 {
+		return false
+	}
+	if readyTrusted && cs.Ready {
+		return false
+	}
+	if r := cs.State.Running; r != nil && !r.StartedAt.IsZero() && now.Sub(r.StartedAt.Time) > 5*time.Minute {
+		return false
+	}
+	if term := cs.State.Terminated; term != nil && term.ExitCode == 0 {
+		return false
+	}
+	t := cs.LastTerminationState.Terminated
+	if t == nil {
+		return false
+	}
+	switch t.Reason {
+	case "OOMKilled":
+		// Memory pressure is classified separately (CategoryOOMKilled); don't
+		// fold it into the generic crashloop bucket.
+		return false
+	case "CrashLoopBackOff", "Error":
+		return true
+	}
+	// A non-zero exit code with no special reason is still a crash — the app
+	// died and the kubelet is restarting it.
+	return t.ExitCode != 0
+}
+
+// podHasStableCrashLoop reports whether any main or init container is in a
+// stable crashloop (see isStableCrashLoop).
+func podHasStableCrashLoop(pod *corev1.Pod, now time.Time) bool {
+	for i := range pod.Status.ContainerStatuses {
+		cs := &pod.Status.ContainerStatuses[i]
+		if isStableCrashLoop(cs, now, containerHasReadinessProbe(pod.Spec.Containers, cs.Name)) {
+			return true
+		}
+	}
+	for i := range pod.Status.InitContainerStatuses {
+		// Init containers carry no readiness probe and their Ready field is not a
+		// serving signal — never trust Ready as recovery there; the Running-window
+		// and clean-exit guards still apply.
+		if isStableCrashLoop(&pod.Status.InitContainerStatuses[i], now, false) {
+			return true
+		}
+	}
+	return false
+}
+
+// containerHasReadinessProbe reports whether the named container declares a
+// readiness probe — the condition under which its ContainerStatus.Ready is a
+// trustworthy "serving now" signal rather than a mirror of Running.
+func containerHasReadinessProbe(containers []corev1.Container, name string) bool {
+	for i := range containers {
+		if containers[i].Name == name {
+			return containers[i].ReadinessProbe != nil
+		}
+	}
+	return false
+}
+
+// restartedRecently reports whether a container's most recent termination
+// finished within the given window — i.e. it is still actively churning, not a
+// container that crashed long ago and has since gone quiet (the laptop-sleep /
+// node-reboot artifact where RestartCount is high but every termination is days
+// old).
+func restartedRecently(cs *corev1.ContainerStatus, now time.Time, within time.Duration) bool {
+	if t := cs.LastTerminationState.Terminated; t != nil && !t.FinishedAt.IsZero() {
+		return now.Sub(t.FinishedAt.Time) <= within
+	}
+	return false
+}
+
+// isActivelyThrashing reports whether a container has a high cumulative restart
+// count AND is currently unhealthy AND is still churning. The Ready gate is what
+// clears the recovered-after-crash false positive — a pod that restarted many
+// times at startup but is now Ready and stable (its RestartCount never resets)
+// no longer trips this. The Waiting/recency gate clears the slept-then-woken
+// node whose restarts are days old. The 5m window matches isStableCrashLoop's
+// horizon so the two guards don't drift.
+func isActivelyThrashing(cs *corev1.ContainerStatus, now time.Time) bool {
+	if cs.RestartCount <= highRestartThreshold || cs.Ready {
+		return false
+	}
+	if cs.State.Waiting != nil {
+		return true
+	}
+	return restartedRecently(cs, now, 5*time.Minute)
+}
+
+// podActiveThrashContainer reports whether any main container is actively
+// thrashing (see isActivelyThrashing). Init containers are excluded — a failing
+// init container surfaces through podProblemReasonRaw's init walk with a
+// specific reason already.
+func podActiveThrashContainer(pod *corev1.Pod, now time.Time) bool {
+	for i := range pod.Status.ContainerStatuses {
+		if isActivelyThrashing(&pod.Status.ContainerStatuses[i], now) {
+			return true
+		}
+	}
+	return false
+}
+
+func containerHasTrustedReady(containers []corev1.Container, cs corev1.ContainerStatus) bool {
+	return cs.Ready && containerHasReadinessProbe(containers, cs.Name)
+}
+
+func containerRecentlyRecoveredFromOOM(containers []corev1.Container, cs corev1.ContainerStatus, now time.Time) bool {
+	if cs.LastTerminationState.Terminated == nil || cs.LastTerminationState.Terminated.Reason != "OOMKilled" {
+		return false
+	}
+	if containerHasTrustedReady(containers, cs) {
+		return false
+	}
+	if r := cs.State.Running; r != nil && !r.StartedAt.IsZero() {
+		return now.Sub(r.StartedAt.Time) <= 5*time.Minute
+	}
+	return cs.State.Waiting != nil || restartedRecently(&cs, now, 5*time.Minute)
+}
+
+func podHasActiveOOMKilled(pod *corev1.Pod, now time.Time) bool {
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.State.Terminated != nil && cs.State.Terminated.Reason == "OOMKilled" {
+			return true
+		}
+		if containerRecentlyRecoveredFromOOM(pod.Spec.Containers, cs, now) {
+			return true
+		}
+	}
+	for _, cs := range pod.Status.InitContainerStatuses {
+		if cs.State.Terminated != nil && cs.State.Terminated.Reason == "OOMKilled" {
+			return true
+		}
+		if cs.LastTerminationState.Terminated != nil && cs.LastTerminationState.Terminated.Reason == "OOMKilled" {
+			if cs.State.Terminated != nil && cs.State.Terminated.ExitCode == 0 {
+				continue
+			}
+			if r := cs.State.Running; r != nil && !r.StartedAt.IsZero() && now.Sub(r.StartedAt.Time) > 5*time.Minute {
+				continue
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// PodHasReadinessProbeFailure reports whether a running pod has been
+// Ready=False past the grace window with a readiness-probed container still
+// failing — exported for the problem detector, which shares this predicate.
+func PodHasReadinessProbeFailure(pod *corev1.Pod, now time.Time) bool {
+	return podHasReadinessProbeFailure(pod, now)
+}
+
+func podHasReadinessProbeFailure(pod *corev1.Pod, now time.Time) bool {
+	if pod.Status.Phase != corev1.PodRunning {
+		return false
+	}
+	if !podReadyFalseLongEnough(pod, now, 5*time.Minute) {
+		return false
+	}
+	for i := range pod.Status.ContainerStatuses {
+		cs := &pod.Status.ContainerStatuses[i]
+		if cs.Ready || cs.State.Running == nil {
+			continue
+		}
+		if containerHasReadinessProbe(pod.Spec.Containers, cs.Name) {
+			return true
+		}
+	}
+	return false
+}
+
+func podReadyFalseLongEnough(pod *corev1.Pod, now time.Time, minAge time.Duration) bool {
+	for i := range pod.Status.Conditions {
+		cond := &pod.Status.Conditions[i]
+		if cond.Type != corev1.PodReady && cond.Type != corev1.ContainersReady {
+			continue
+		}
+		if cond.Status != corev1.ConditionFalse {
+			continue
+		}
+		if !cond.LastTransitionTime.IsZero() {
+			return now.Sub(cond.LastTransitionTime.Time) >= minAge
+		}
+		if !pod.CreationTimestamp.IsZero() {
+			return now.Sub(pod.CreationTimestamp.Time) >= minAge
+		}
+		return true
+	}
+	return false
+}
+
+// isFatalWaitingReason reports whether a container's Waiting reason is a hard
+// failure that won't self-resolve on its own — as opposed to the transient
+// PodInitializing/ContainerCreating states. InvalidImageName is permanent (a
+// malformed image reference never becomes valid); the *ContainerError family
+// means the container couldn't be created or started (bad command, missing
+// device, runtime rejection).
+func isFatalWaitingReason(reason string) bool {
+	switch reason {
+	case "CrashLoopBackOff", "ImagePullBackOff", "ErrImagePull", "InvalidImageName",
+		"ImageInspectError", "CreateContainerConfigError", "CreateContainerError",
+		"RunContainerError":
+		return true
+	}
+	return false
+}
+
+// isPhaseOrCrashReason reports whether reason is one that a stable-crashloop
+// override may safely replace: a bare lifecycle phase / no-op waiting state
+// (the instantaneous values that flap), or an already-crash-class reason
+// (so the canonical string is used consistently). A distinct, more-specific
+// reason like ImagePullBackOff or OOMKilled is NOT in this set and is left
+// untouched.
+func isPhaseOrCrashReason(reason string) bool {
+	switch reason {
+	case "Running", "Pending", "Succeeded", "Failed", "Unknown", "",
+		"PodInitializing", "ContainerCreating",
+		"CrashLoopBackOff", "Error":
+		return true
+	}
+	return false
+}
+
+// isPhaseOnlyReason is the narrower set the HighRestartCount override may
+// replace: bare lifecycle phases / no-op waiting states only. It deliberately
+// excludes the crash-class reasons (CrashLoopBackOff/Error) and terminal phases
+// (Succeeded/Failed) that isPhaseOrCrashReason allows, so a thrash override can
+// never clobber a real crash or terminal signal — the stable-crashloop check
+// above already owns those.
+func isPhaseOnlyReason(reason string) bool {
+	switch reason {
+	case "Running", "Pending", "Unknown", "",
+		"PodInitializing", "ContainerCreating":
+		return true
+	}
+	return false
+}
+
+// IsPodUnschedulable reports whether the scheduler tried and failed to place the
+// pod (PodScheduled=False with reason=Unschedulable). reason=SchedulingGated is
+// an intentional not-yet-scheduled state, not a placement failure, and is
+// excluded.
+func IsPodUnschedulable(pod *corev1.Pod) bool {
+	for i := range pod.Status.Conditions {
+		c := &pod.Status.Conditions[i]
+		if c.Type == corev1.PodScheduled {
+			return c.Status == corev1.ConditionFalse && c.Reason == corev1.PodReasonUnschedulable
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

First of a 5-PR program to collapse Radar's ~8 drifting resource-health classifiers into one canonical engine. Today pod/workload health is computed independently in `internal/k8s` (timeline, dashboard, MCP), `pkg/topology`, `pkg/packages`, `pkg/resourcecontext`, and the frontend — across **three** Go health vocabularies and **four** divergent rank maps that drift (and one, in `applications.ts`, ranks `unknown` *below* healthy, opposite to Go). This PR lays the foundation and migrates the pod classifier, **changing no observable behavior** — every existing caller is held byte-for-byte identical via shims.

The module boundary forces the design: `pkg/` is a separate published module that **cannot import `internal/`**, so the shared classifier must live in `pkg/`. New package **`pkg/health`** is a pure leaf (K8s API + stdlib only; imports nothing from its own consumers).

## What changed

- **`pkg/health`** (new):
  - `Level` — the canonical 5-tier vocabulary (`healthy | neutral | degraded | unhealthy | unknown`) with one `Rank` + `WorseOf`. `neutral` ties `healthy` as most-benign (lifecycle/intentional states never worsen a rollup); `unknown` ranks just above healthy. **No `alert` tier** — that's an issue *severity*, not a resource *level* (no core resource produces it).
  - `Pod(pod, now) Verdict{Level, Reason, Message}` — the canonical pod classifier, moved verbatim from `internal/k8s/health.go` (crashloop-oscillation stability, OOM, fatal-waiting, pending grace, thrash detection all preserved).
  - Reason derivation is now **clock-injected** (`now` passed in rather than calling `time.Now()` internally) so verdicts are reproducible.
- **`internal/k8s/health.go`**: 576 lines → thin shims over `pkg/health` (`ClassifyPodHealth` projects the Verdict back to the legacy `healthy|warning|error` strings via `Verdict.LegacyString`, so dashboard/MCP counters are unchanged). `ClassifyNodeHealth` stays here pending PR5.
- **`detect_scheduling.go`**: removed the now-duplicate `IsPodUnschedulable` (moved to `pkg/health`).

## What a reviewer should focus on

- `Verdict.LegacyString` is the no-op guarantee: `neutral`/`unknown` → `"healthy"`, `degraded` → `"warning"`, `unhealthy` → `"error"`, matching the pre-split classifier exactly.
- `Succeeded → neutral` (was `"healthy"`) is the one vocabulary refinement; it collapses back to `"healthy"` in every PR1 consumer, so it's observably identical here and becomes a real wire value in PR3.
- **Deliberately deferred:** folding Unschedulable / stuck-terminating into the canonical classifier (would shift MCP/dashboard health *counters*) and `neutral` as a wire value land in later PRs where those consumer-visible effects are owned + reviewed.

## Testing

- Both modules `go build ./...` clean; `go vet ./health/...` clean.
- `pkg/health` clock-injected **golden vectors** pass (the anti-drift contract; PR4 mirrors them in vitest for the TS classifier).
- Existing `internal/k8s` health/scheduling parity tests unchanged and passing.
- Shim consumers `internal/server` + `internal/mcp` tests pass.
- No frontend/UI change → no tsc/visual-test.

## Follow-ups (the program)

PR2 Workload + topology crashloop-green fix · PR3 `neutral` ripple + rank-map unification · PR4 backend-emits-health + frontend hybrid · PR5 Node + cert + stuck-terminating threshold unification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large move of pod health and problem-reason logic into a new shared package; behavior is intended to be identical via shims and tests, but mis-wiring would affect dashboards, MCP counters, and problem detection across the fleet.
> 
> **Overview**
> Introduces **`pkg/health`** as the shared pod health engine so topology, timeline, dashboards, and MCP can converge on one classifier instead of parallel copies.
> 
> The package adds a five-tier **`Level`** vocabulary with **`Rank`/`WorseOf`**, **`Pod(pod, now) Verdict`** (level + reason + message), and clock-injected reason helpers. Pod logic moved out of **`internal/k8s/health.go`** is largely unchanged; **`Succeeded`** is modeled as **`neutral`** internally but still projects to legacy **`"healthy"`** via **`Verdict.LegacyString()`**, so existing **`healthy|warning|error`** callers stay the same.
> 
> **`internal/k8s/health.go`** is now thin wrappers around **`pkg/health`**; **`IsPodUnschedulable`** is centralized there and the duplicate in **`detect_scheduling.go`** is removed. Golden-vector and level-ordering tests in **`pkg/health`** document the contract for later PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dec60c23e5955a87d3b3448d2bdf63a46299ded. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->