### PR TITLE
fix(workload): support cluster-scoped resources in /workload URLs

### DIFF
--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -90,13 +90,27 @@ export function WorkloadViewRoute({ onNavigateToResource }: WorkloadViewRoutePro
   // Parse /workload/:kind/:ns/:name from pathname. Segments are URL-encoded by
   // buildWorkloadPath; names can also contain literal slashes (e.g. some CRD names),
   // which survive encoding as %2F and reassemble correctly here.
+  //
+  // Cluster-scoped resources (Node, PersistentVolume, Namespace, …) have no
+  // namespace: buildWorkloadPath encodes the namespace segment as '_'. Decode
+  // that back to '' here, and tolerate a legacy empty segment ('//') and the
+  // collapsed three-segment form (/workload/:kind/:name) for older links.
   const parts = location.pathname.replace(/^\//, '').split('/')
   const decode = (s: string): string => {
     try { return decodeURIComponent(s) } catch { return s }
   }
   const kind = decode(parts[1] ?? '')
-  const namespace = decode(parts[2] ?? '')
-  const name = parts.slice(3).map(decode).join('/')
+  let namespace: string
+  let name: string
+  if (parts.length <= 3) {
+    // /workload/:kind/:name — cluster-scoped link with no namespace segment.
+    namespace = ''
+    name = decode(parts[2] ?? '')
+  } else {
+    const nsSegment = parts[2] ?? ''
+    namespace = nsSegment === '_' || nsSegment === '' ? '' : decode(nsSegment)
+    name = parts.slice(3).map(decode).join('/')
+  }
   const group = searchParams.get('apiGroup') || ''
 
   const handleBack = useCallback(() => {
@@ -112,7 +126,8 @@ export function WorkloadViewRoute({ onNavigateToResource }: WorkloadViewRoutePro
   }, [navigate])
 
   // Hooks must run unconditionally — the invalid-URL guard comes after them.
-  if (!kind || !namespace || !name) {
+  // Namespace is empty for cluster-scoped resources, so only kind + name are required.
+  if (!kind || !name) {
     return (
       <div className="flex items-center justify-center h-full text-theme-text-tertiary">
         Invalid workload URL

--- a/web/src/utils/navigation.ts
+++ b/web/src/utils/navigation.ts
@@ -20,12 +20,14 @@ export type { NavigateToResource } from '@skyhook-io/k8s-ui/utils/navigation'
 /**
  * Build a /workload/:kind/:namespace/:name URL, preserving the API group as a
  * query param so the WorkloadView can resolve CRDs with colliding kind names.
- * Namespaced workloads only — WorkloadView requires a namespace. For arbitrary
- * kinds (including cluster-scoped) use resourcePath.
+ * Cluster-scoped resources (Node, PersistentVolume, Namespace, …) have no
+ * namespace; they're encoded with a '_' sentinel segment so the path stays
+ * positional and WorkloadViewRoute can parse it back. '_' is safe — it's not a
+ * valid DNS-1123 namespace label, so it can never collide with a real one.
  */
 export function buildWorkloadPath(resource: SelectedResource): string {
   const kind = encodeURIComponent(resource.kind)
-  const namespace = encodeURIComponent(resource.namespace)
+  const namespace = encodeURIComponent(resource.namespace || '_')
   const name = encodeURIComponent(resource.name)
   const base = `/workload/${kind}/${namespace}/${name}`
   return resource.group ? `${base}?apiGroup=${encodeURIComponent(resource.group)}` : base


### PR DESCRIPTION
## Problem

Opening a cluster-scoped resource (Node, PersistentVolume, Namespace) in the full-page workload view threw **"Invalid workload URL"** — e.g. `/workload/nodes/ip-10-0-24-73.us-west-2.compute.internal`.

These kinds have no namespace, so `buildWorkloadPath` emitted an empty namespace segment (`/workload/nodes//<name>`), and `WorkloadViewRoute` required `kind`, `namespace`, **and** `name` to all be non-empty. The empty namespace tripped the guard. It hit on fresh navigation / reload of any cluster-scoped workload URL (expanding from the drawer happened to work because the drawer kept its own expanded state).

The data layer (`useResourceWithRelationships`) and `NodeRenderer` already handled an empty namespace via the `_` sentinel, so the full-page view was *meant* to work — only the URL layer was broken.

## Fix

- `buildWorkloadPath` encodes a missing namespace as a `_` sentinel — the convention the API client and ClusterRole routing already use. `_` is not a valid DNS-1123 namespace label, so it can never collide with a real namespace.
- `WorkloadViewRoute` parses `_` back to `''` and the route guard now requires only `kind + name`. Parsing also tolerates the legacy empty-segment (`//`) and collapsed three-segment (`/workload/:kind/:name`) forms, so existing/bookmarked links keep working.

Two files, +23/−6. No backend or data-layer changes.

## Verification

- `make tsc` clean.
- Build↔parse round-trip checked across namespaced, cluster-scoped, and all legacy URL forms.
- Visual test against a live EKS cluster: the previously-broken Node URL now renders the full Node page (status, Capacity, Resource Usage, Addresses, Conditions, related pods); no relevant console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side routing and URL parsing only; backward-compatible with legacy workload URLs and no API or auth changes.
> 
> **Overview**
> Fixes **Invalid workload URL** when opening cluster-scoped resources (Node, PV, Namespace, etc.) in the full-page workload view.
> 
> **URL building:** `buildWorkloadPath` now writes `_` in the namespace segment when `namespace` is empty, keeping a stable four-segment path and matching the existing `_` sentinel used elsewhere in the app.
> 
> **URL parsing:** `WorkloadViewRoute` maps `_` (and legacy empty segments) back to `''`, accepts the older three-segment `/workload/:kind/:name` shape, and only requires **kind + name** in the guard—namespace may be blank for cluster-scoped kinds.
> 
> Bookmarked links with `//` or three-segment paths should still work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87156b4184f0b76a50c4046a20fc8e43351de0b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->