### PR TITLE
feat(web): per-page browser tab titles

### DIFF
--- a/packages/k8s-ui/src/components/gitops/GitOpsDetailLayout.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsDetailLayout.tsx
@@ -184,11 +184,11 @@ export interface GitOpsDetailLayoutProps {
   isFleetContext?: boolean
   destinationCluster?: { id: string; name: string }
 
-  // Tab-title side effect — sets document.title to "<name> — Radar" while
+  // Tab-title side effect — sets document.title to "<name> · Radar" while
   // mounted, restores on unmount. Opt-in so hub-web fleet detail can pick
   // its own title format ("<name> — Fleet GitOps").
   manageDocumentTitle?: boolean
-  documentTitleSuffix?: string                // defaults to " — Radar"
+  documentTitleSuffix?: string                // defaults to " · Radar"
 
   // Children slot — for dialogs (SyncOptionsDialog, RollbackDialog, …)
   // that should portal to body. Caller owns dialog state. Children render
@@ -246,7 +246,7 @@ export function GitOpsDetailLayout(props: GitOpsDetailLayoutProps) {
   useEffect(() => {
     if (!manageDocumentTitle) return
     const previous = document.title
-    const suffix = documentTitleSuffix ?? ' — Radar'
+    const suffix = documentTitleSuffix ?? ' · Radar'
     document.title = `${identity.name}${suffix}`
     return () => { document.title = previous }
   }, [identity.name, manageDocumentTitle, documentTitleSuffix])

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { flushSync } from 'react-dom'
 import { useRefreshAnimation } from './hooks/useRefreshAnimation'
 import { startViewTransitionSafe } from '@skyhook-io/k8s-ui/utils/view-transition'
+import { englishPlural } from '@skyhook-io/k8s-ui/utils/pluralize'
 import { useQueryClient } from '@tanstack/react-query'
 import { useNavigate, useLocation, useSearchParams, useNavigationType, NavigationType } from 'react-router-dom'
 import { HomeView } from './components/home/HomeView'
@@ -57,7 +58,7 @@ import { LargeClusterNamespacePicker } from './components/shared/LargeClusterNam
 import { SettingsDialog } from './components/settings/SettingsDialog'
 import { MyPermissionsDialog } from './components/settings/MyPermissionsDialog'
 import type { TopologyNode, GroupingMode, MainView, SelectedResource, SelectedHelmRelease, NodeKind, TopologyMode, Topology, K8sEvent } from './types'
-import { kindToPlural, openExternal, apiVersionToGroup, buildWorkloadPath, searchHitToSelectedResource } from './utils/navigation'
+import { kindToPlural, pluralToKind, openExternal, apiVersionToGroup, buildWorkloadPath, searchHitToSelectedResource } from './utils/navigation'
 import { type OmnibarHandle } from './components/ui/Omnibar'
 import { RadarOmnibar } from './components/ui/RadarOmnibar'
 import type { ContextSwitcherHandle } from './components/ContextSwitcher'
@@ -124,11 +125,11 @@ function getViewFromPath(pathname: string): ExtendedMainView {
   return 'home'
 }
 
-// Browser tab label for every Radar view, derived from the URL *path* so it's
+// Browser tab label for every Radar view, derived from the route URL so it's
 // correct regardless of which component renders it. A detail drawer that opens
 // over a list (?resource=…) is deliberately NOT titled — it's the same page, so
 // it keeps the list's title.
-function radarPageTitle(pathname: string): string | null {
+function radarPageTitle(pathname: string, search = '', apiResources?: { name: string; kind: string; group?: string }[]): string | null {
   const decode = (s: string) => {
     try {
       return decodeURIComponent(s)
@@ -138,19 +139,32 @@ function radarPageTitle(pathname: string): string | null {
   }
   const capitalize = (text: string) =>
     text ? text.charAt(0).toUpperCase() + text.slice(1) : text
+  const pluralKindTitle = (kind: string, resourceName: string) =>
+    kind.toLowerCase() === resourceName.toLowerCase() ? kind : englishPlural(kind)
   const pathSegments = pathname.replace(/^\//, '').split('/').filter(Boolean)
   const view = getViewFromPath(pathname)
 
   // Full-page resource detail: /workload/<kind>/<ns>/<name> (name may contain '/').
   if (view === 'workload') return pathSegments.slice(3).map(decode).join('/') || null
-  // Resources is browsed per-kind: /resources/<kind> → "<Kind>" (e.g. Configmaps);
+  // Resources is browsed per-kind: /resources/<kind> → "<Kind>" (e.g. ConfigMap);
   // bare /resources (before it redirects to a default kind) → "Resources".
-  if (view === 'resources')
-    return pathSegments[1] ? capitalize(decode(pathSegments[1])) : 'Resources'
+  if (view === 'resources') {
+    const resourceName = decode(pathSegments[1] ?? '')
+    if (!resourceName) return 'Resources'
+    const match = apiResources?.find((r) => r.name === resourceName)
+    return pluralKindTitle(match?.kind ?? pluralToKind(resourceName), resourceName)
+  }
   // GitOps detail is /gitops/detail/<kind>/<ns>/<name> → the resource name;
   // anything else (the list) → "GitOps".
   if (view === 'gitops')
     return pathSegments[1] === 'detail' ? decode(pathSegments[4] ?? '') || 'GitOps' : 'GitOps'
+  if (view === 'applications') {
+    const appKey = new URLSearchParams(search).get('app')
+    if (!appKey) return 'Applications'
+    const decoded = decode(appKey)
+    const slash = decoded.lastIndexOf('/')
+    return slash >= 0 && slash < decoded.length - 1 ? decoded.slice(slash + 1) : decoded
+  }
 
   // The landing view reads "Overview" rather than "Home" in the tab.
   if (view === 'home') return 'Overview'
@@ -315,10 +329,17 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
   // Get mainView from URL path
   const mainView = getViewFromPath(location.pathname)
 
+  // Initialize the kind→plural discovery map app-wide (not just on ResourcesView
+  // mount) so the omnibar can open a CRD hit with an irregular plural from any
+  // view — kindToPlural would otherwise English-guess the route before a
+  // resources view has run initNavigationMap().
+  const { data: navApiResources } = useAPIResources()
+  useEffect(() => { if (navApiResources) initNavigationMap(navApiResources) }, [navApiResources])
+
   // One URL-derived tab title for every view (see radarPageTitle). Driving it
   // from the URL — not the mounted component. Off unless the host opts in
   // (standalone passes manageDocumentTitle), so embedders keep title ownership.
-  useDocumentTitle(manageDocumentTitle ? radarPageTitle(location.pathname) : null, documentTitleSuffix)
+  useDocumentTitle(manageDocumentTitle ? radarPageTitle(location.pathname, location.search, navApiResources) : null, documentTitleSuffix)
 
   // Workload slug after `/resources/` (defaults to `pods`). Bare `/resources` redirects to `/resources/pods`.
   const normalizedResourcesKindSlug = useMemo(() => {
@@ -610,12 +631,6 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
   const namespaceSwitcherRef = useRef<NamespaceSwitcherHandle>(null)
   const omnibarRef = useRef<OmnibarHandle>(null)
 
-  // Initialize the kind→plural discovery map app-wide (not just on ResourcesView
-  // mount) so the omnibar can open a CRD hit with an irregular plural from any
-  // view — kindToPlural would otherwise English-guess the route before a
-  // resources view has run n().
-  const { data: navApiResources } = useAPIResources()
-  useEffect(() => { if (navApiResources) initNavigationMap(navApiResources) }, [navApiResources])
   const contextSwitcherRef = useRef<ContextSwitcherHandle>(null)
 
   // View switching keyboard shortcuts

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -48,6 +48,7 @@ import { debugNamespaceLog, useNamespaces, useNamespaceScope, useSetActiveNamesp
 import { routePath, apiUrl, getAuthHeaders, getCredentialsMode } from './api/config'
 import { KeyboardShortcutProvider, useRegisterShortcut, useRegisterShortcuts } from './hooks/useKeyboardShortcuts'
 import { useAnimatedUnmount } from './hooks/useAnimatedUnmount'
+import { useDocumentTitle } from './hooks/useDocumentTitle'
 import radarLoadingIcon from '@skyhook-io/k8s-ui/assets/radar/radar-icon-loading.svg'
 import { RefreshCw, Network, List, Clock, Package, Sun, Moon, Activity, Home, Star, Search, Bug, SquareTerminal, ShieldCheck, GitBranch, HelpCircle } from 'lucide-react'
 import { useTheme } from './context/ThemeContext'
@@ -123,6 +124,41 @@ function getViewFromPath(pathname: string): ExtendedMainView {
   return 'home'
 }
 
+// Browser tab label for every Radar view, derived from the URL *path* so it's
+// correct regardless of which component renders it. A detail drawer that opens
+// over a list (?resource=…) is deliberately NOT titled — it's the same page, so
+// it keeps the list's title.
+function radarPageTitle(pathname: string): string | null {
+  const decode = (s: string) => {
+    try {
+      return decodeURIComponent(s)
+    } catch {
+      return s
+    }
+  }
+  const capitalize = (text: string) =>
+    text ? text.charAt(0).toUpperCase() + text.slice(1) : text
+  const pathSegments = pathname.replace(/^\//, '').split('/').filter(Boolean)
+  const view = getViewFromPath(pathname)
+
+  // Full-page resource detail: /workload/<kind>/<ns>/<name> (name may contain '/').
+  if (view === 'workload') return pathSegments.slice(3).map(decode).join('/') || null
+  // Resources is browsed per-kind: /resources/<kind> → "<Kind>" (e.g. Configmaps);
+  // bare /resources (before it redirects to a default kind) → "Resources".
+  if (view === 'resources')
+    return pathSegments[1] ? capitalize(decode(pathSegments[1])) : 'Resources'
+  // GitOps detail is /gitops/detail/<kind>/<ns>/<name> → the resource name;
+  // anything else (the list) → "GitOps".
+  if (view === 'gitops')
+    return pathSegments[1] === 'detail' ? decode(pathSegments[4] ?? '') || 'GitOps' : 'GitOps'
+
+  // The landing view reads "Overview" rather than "Home" in the tab.
+  if (view === 'home') return 'Overview'
+  // Every other view's label is its id capitalized — getViewFromPath has already
+  // normalized aliases (e.g. /audit → 'checks'), so no lookup table is needed.
+  return capitalize(view)
+}
+
 function AuthBarrier({ authMode }: { authMode: string }) {
   useEffect(() => {
     if (authMode === 'oidc') {
@@ -185,7 +221,7 @@ function peekOwnerKey(pathname: string, search: string): string {
   return `${pathname} ${new URLSearchParams(search).get('app') ?? ''}`
 }
 
-function AppInner() {
+function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manageDocumentTitle?: boolean; documentTitleSuffix?: string }) {
   const navigate = useNavigate()
   const location = useLocation()
   const navigationType = useNavigationType()
@@ -278,6 +314,11 @@ function AppInner() {
 
   // Get mainView from URL path
   const mainView = getViewFromPath(location.pathname)
+
+  // One URL-derived tab title for every view (see radarPageTitle). Driving it
+  // from the URL — not the mounted component. Off unless the host opts in
+  // (standalone passes manageDocumentTitle), so embedders keep title ownership.
+  useDocumentTitle(manageDocumentTitle ? radarPageTitle(location.pathname) : null, documentTitleSuffix)
 
   // Workload slug after `/resources/` (defaults to `pods`). Bare `/resources` redirects to `/resources/pods`.
   const normalizedResourcesKindSlug = useMemo(() => {
@@ -2154,14 +2195,14 @@ function FloatingButtons({ showHelp, showCommandPalette, showDiagnostics, onHelp
 }
 
 // Main App component wrapped with providers
-function App() {
+function App({ manageDocumentTitle = false, documentTitleSuffix }: { manageDocumentTitle?: boolean; documentTitleSuffix?: string }) {
   return (
     <ConnectionProvider>
       <CapabilitiesProvider>
         <ContextSwitchProvider>
           <DockProvider>
             <KeyboardShortcutProvider>
-              <AppInner />
+              <AppInner manageDocumentTitle={manageDocumentTitle} documentTitleSuffix={documentTitleSuffix} />
             </KeyboardShortcutProvider>
           </DockProvider>
         </ContextSwitchProvider>

--- a/web/src/RadarApp.tsx
+++ b/web/src/RadarApp.tsx
@@ -71,6 +71,21 @@ export interface RadarAppProps {
    */
   navSlots?: NavCustomization;
   /**
+   * Whether Radar may set the browser tab title (`document.title`) per view.
+   * Defaults to OFF: embedders keep title ownership without opting out. The
+   * standalone binary opts in (`web/src/main.tsx` renders
+   * `<RadarApp manageDocumentTitle />`), and any full-page embed that wants
+   * Radar's per-view titles can do the same.
+   */
+  manageDocumentTitle?: boolean;
+  /**
+   * Trailing string appended after the per-view label (only when
+   * `manageDocumentTitle` is on). It's the *full* suffix including any
+   * separator, so a host can rebrand (`' — My Cloud'`) or drop it (`''`).
+   * Defaults to `' · Radar'`.
+   */
+  documentTitleSuffix?: string;
+  /**
    * Initial route for `router: 'memory'` (ignored for 'browser'). Lets a host
    * deep-link a specific view (e.g. '/topology') without owning the URL bar —
    * used with `navSlots.chrome: 'none'` to render a single per-cluster view
@@ -116,6 +131,8 @@ export function RadarApp({
   router = 'browser',
   queryClient,
   navSlots,
+  manageDocumentTitle = false,
+  documentTitleSuffix,
   initialPath,
 }: RadarAppProps): React.ReactElement {
   // Apply runtime config during render so module-level singletons are set
@@ -136,7 +153,7 @@ export function RadarApp({
       <QueryClientProvider client={client}>
         <ToastProvider>
           <NavCustomizationProvider value={navSlots}>
-            <App />
+            <App manageDocumentTitle={manageDocumentTitle} documentTitleSuffix={documentTitleSuffix} />
           </NavCustomizationProvider>
         </ToastProvider>
       </QueryClientProvider>

--- a/web/src/components/gitops/GitOpsView.tsx
+++ b/web/src/components/gitops/GitOpsView.tsx
@@ -446,15 +446,6 @@ function GitOpsDetailView({ namespaces, onOpenResource }: GitOpsViewProps) {
   const isFlux = tool === 'flux'
   const isArgoApp = kind === 'applications'
 
-  // Set the browser tab title so users with multiple resource tabs open can
-  // tell which is which without focusing each tab. Restore on unmount so a
-  // stray "Radar — argocd/foo" doesn't outlive its page.
-  useEffect(() => {
-    const previous = document.title
-    document.title = `${name} — Radar`
-    return () => { document.title = previous }
-  }, [name])
-
   // Detail-page shortcuts. Skip when a modal is already open so a stray "s"
   // in an input field doesn't pop another sync dialog.
   const shortcutsEnabled = !syncDialogOpen && !rollbackTarget
@@ -645,7 +636,7 @@ function GitOpsDetailView({ namespaces, onOpenResource }: GitOpsViewProps) {
           search: params.toString(),
         })
       } : undefined}
-      manageDocumentTitle={false /* OSS handles it via the in-effect-above */}
+      manageDocumentTitle={false /* title handled centrally in App's radarPageTitle */}
       renderTabBarCounts={({ tab }) => (
         tab === 'topology' && tree ? <TopologyCounts tree={tree} /> : null
       )}

--- a/web/src/hooks/useDocumentTitle.ts
+++ b/web/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+
+// Restore-on-unmount matters for overlay/detail views: closing a resource drawer
+// that opened over a list returns the list's title rather than stranding the
+// resource's. document.title is global to the page, so embedders that don't own
+// the whole tab pass a falsy `label` to opt out and keep their own title
+// (AppInner only feeds a label when the host passed `manageDocumentTitle`).
+//
+// `suffix` is the full trailing string after the label, so a host can rebrand
+// (' — My Cloud') or drop it entirely ('').
+const DEFAULT_SUFFIX = ' · Radar';
+
+export function useDocumentTitle(
+  label: string | null | undefined,
+  suffix: string = DEFAULT_SUFFIX,
+): void {
+  useEffect(() => {
+    if (!label) return;
+    const previous = document.title;
+    document.title = `${label}${suffix}`;
+    return () => {
+      document.title = previous;
+    };
+  }, [label, suffix]);
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -155,10 +155,12 @@ window.addEventListener('mouseup', (e: MouseEvent) => {
 }, true)
 
 
-// Standalone Radar binary: same-origin API, router at root. Library consumers
-// (e.g. radar-hub-web) render <RadarApp apiBase="..." basename="..." /> instead.
+// Standalone Radar binary: same-origin API, router at root. It owns the whole
+// tab, so it opts into per-view document.title. Library consumers (e.g.
+// radar-hub-web) render <RadarApp apiBase="..." basename="..." /> WITHOUT this
+// flag, keeping their own tab title.
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <RadarApp />
+    <RadarApp manageDocumentTitle />
   </React.StrictMode>
 )


### PR DESCRIPTION
## Description

Radar's standalone app now sets meaningful browser tab titles from the active route, so multiple Radar tabs and history entries are distinguishable instead of all reading "Radar".

Titles are resolved centrally in `App` from the URL:

- Static views use the view label, such as `Topology · Radar`, `Cost · Radar`, and `Overview · Radar`.
- Resource list pages use the plural collection name, such as `Pods · Radar` and `ConfigMaps · Radar`.
- Full resource detail pages use the resource name, such as `guestbook-healthy · Radar`.
- GitOps detail pages use the GitOps resource name, while the GitOps list uses `GitOps · Radar`.
- Application detail query routes use the selected app label, while the Applications list uses `Applications · Radar`.
- Resource drawers opened over list pages keep the list title because they are still the same page context.

The new `useDocumentTitle` hook applies the title and restores the previous value on unmount. Standalone Radar opts in via `<RadarApp manageDocumentTitle />`; library embedders keep ownership of `document.title` by default and can opt in with `manageDocumentTitle` plus an optional `documentTitleSuffix`.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

- [X] Tested locally with minikube/kind
- [ ] Tested against a remote cluster
- [ ] Added/updated unit tests
- `make tsc`
- `make test`
- `make build` via the visual-test startup workflow
- Playwright visual test against `kind-radar-gitops-demo` covering resource lists, GitOps detail, and Applications detail
- GitHub CI checks are passing

## Checklist

- [X] My code follows the project's coding standards
- [X] I have performed a self-review of my code
- [X] I have added comments where necessary
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged

## Related issues

No linked issue.
