### PR TITLE
feat(audit): Traefik ref-integrity for chain middlewares + errors.service

### DIFF
--- a/internal/audit/runner.go
+++ b/internal/audit/runner.go
@@ -66,12 +66,13 @@ func RunFromCache(cache *k8s.ResourceCache, namespaces []string, opts *RunOption
 	// being fabricated as "missing". `authoritative` marks which target GVRs are
 	// served by a synced cluster-wide informer — only those let the check assert
 	// absence (see checkTraefikDanglingRefs).
-	input.IngressRoutes, input.Middlewares, input.TraefikServices, input.TraefikAuthoritativeKinds = listTraefikDynamic(namespaces)
+	input.IngressRoutes, input.Middlewares, input.TraefikServices, input.MiddlewareSubjects, input.TraefikAuthoritativeKinds = listTraefikDynamic(namespaces)
 	// Core Services for Traefik ref resolution. Only populate (→ only assert a
 	// missing-Service finding) when the Services informer is cluster-wide, so
 	// absence is authoritative for every namespace — same coverage gate the
 	// dynamic Traefik kinds use. Namespace-scoped fallback → leave nil → skip.
-	if len(input.IngressRoutes) > 0 && cache.IsKindClusterWide("services") {
+	// Middleware subjects (errors.service refs) need it too, not just routes.
+	if (len(input.IngressRoutes) > 0 || len(input.MiddlewareSubjects) > 0) && cache.IsKindClusterWide("services") {
 		input.AllServices = listNamespaced(cache.Services(), nil)
 	}
 
@@ -175,10 +176,10 @@ var traefikKindForResource = func() map[string]string {
 // per-GVR gate fixes the false-positive (partial coverage), the per-kind
 // granularity (Middleware vs MiddlewareTCP, each its own GVR), and the
 // one-stuck-informer-suppresses-all problems together — each GVR is independent.
-func listTraefikDynamic(namespaces []string) (routes, middlewares, traefikServices []*unstructured.Unstructured, authoritative map[string]bool) {
+func listTraefikDynamic(namespaces []string) (routes, middlewares, traefikServices, middlewareSubjects []*unstructured.Unstructured, authoritative map[string]bool) {
 	cache := k8s.GetDynamicResourceCache()
 	if cache == nil {
-		return nil, nil, nil, nil
+		return nil, nil, nil, nil, nil
 	}
 
 	for _, group := range traefikGroups {
@@ -230,12 +231,16 @@ func listTraefikDynamic(namespaces []string) (routes, middlewares, traefikServic
 				routes = append(routes, u)
 			case "Middleware", "MiddlewareTCP":
 				middlewares = append(middlewares, u) // cluster-wide (cross-ns resolution)
+				// Also a subject for the chain/errors checks when in an audited ns.
+				if len(namespaces) == 0 || nsSet[u.GetNamespace()] {
+					middlewareSubjects = append(middlewareSubjects, u)
+				}
 			case "TraefikService":
 				traefikServices = append(traefikServices, u)
 			}
 		}
 	}
-	return routes, middlewares, traefikServices, authoritative
+	return routes, middlewares, traefikServices, middlewareSubjects, authoritative
 }
 
 // isCrossplaneMR mirrors the frontend heuristic — a Managed Resource always

--- a/pkg/audit/registry.go
+++ b/pkg/audit/registry.go
@@ -332,6 +332,22 @@ var CheckRegistry = map[string]CheckMeta{
 		Remediation: "Correct the middleware name/namespace in the router's spec.routes[].middlewares, or create the missing Middleware. A same-name Middleware in a different API group (traefik.io vs traefik.containo.us) does not satisfy the reference.",
 		References:  []Reference{refTraefikCRD},
 	},
+	"traefikChainMissingMiddleware": {
+		ID:          "traefikChainMissingMiddleware",
+		Title:       "Traefik chain references missing middleware",
+		Category:    CategoryReliability,
+		Description: "A Traefik chain Middleware lists a Middleware in spec.chain.middlewares that does not exist in the resolved namespace. Traefik accepts the chain but skips the missing link, so part of the intended middleware pipeline silently does not run.",
+		Remediation: "Correct the middleware name/namespace in spec.chain.middlewares, or create the missing Middleware. A same-name Middleware in a different API group (traefik.io vs traefik.containo.us) does not satisfy the reference.",
+		References:  []Reference{refTraefikCRD},
+	},
+	"traefikErrorsMissingService": {
+		ID:          "traefikErrorsMissingService",
+		Title:       "Traefik errors middleware references missing service",
+		Category:    CategoryReliability,
+		Description: "A Traefik errors Middleware references a Service in spec.errors.service that does not exist. Traefik accepts the middleware, but when an error page is needed the backend isn't there, so users get the default error instead of the custom one.",
+		Remediation: "Correct the service name/namespace in spec.errors.service, or create the missing Service. Cross-namespace references also require allowCrossNamespace on the Traefik CRD provider.",
+		References:  []Reference{refTraefikCRD},
+	},
 	"stuckTerminating": {
 		ID:          "stuckTerminating",
 		Title:       "Stuck terminating resource",

--- a/pkg/audit/traefik.go
+++ b/pkg/audit/traefik.go
@@ -7,11 +7,13 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-// checkTraefikDanglingRefs flags Traefik routers that reference a Service,
-// TraefikService, or Middleware that doesn't exist. Traefik ships no validation
-// webhook or linter — a typo'd ref silently drops traffic until someone reads
-// the controller logs — so this is genuinely additive (cf. Kubevious' built-in
-// "missing Middleware reference" validator).
+// checkTraefikDanglingRefs flags Traefik resources that reference a Service,
+// TraefikService, or Middleware that doesn't exist: routers (spec.routes →
+// Service/Middleware), chain middlewares (spec.chain.middlewares → Middleware),
+// and errors middlewares (spec.errors.service → Service). Traefik ships no
+// validation webhook or linter — a typo'd ref silently drops traffic or skips a
+// middleware until someone reads the controller logs — so this is genuinely
+// additive (cf. Kubevious' built-in "missing Middleware reference" validator).
 //
 // Matching is conservative to avoid false positives:
 //   - Only genuinely-absent refs are flagged; an explicit cross-namespace ref
@@ -22,11 +24,11 @@ import (
 //   - Service / Middleware presence is only asserted when we actually have the
 //     corresponding inventory (nil set = "couldn't list", so skip — never flag).
 //
-// Scope is deliberately partial: route → Service and route → Middleware. Nested
-// TraefikService services, middleware chains, errors.service, and TLS-secret
-// refs can also dangle and are not yet covered.
+// Scope is still deliberately partial: nested TraefikService weighted/mirror
+// sub-services, ServersTransport refs, and TLS-secret refs can also dangle and
+// are not yet covered.
 func checkTraefikDanglingRefs(input *CheckInput) []Finding {
-	if len(input.IngressRoutes) == 0 {
+	if len(input.IngressRoutes) == 0 && len(input.MiddlewareSubjects) == 0 {
 		return nil
 	}
 
@@ -55,8 +57,8 @@ func checkTraefikDanglingRefs(input *CheckInput) []Finding {
 
 	var findings []Finding
 	seen := make(map[string]bool)
-	add := func(route *unstructured.Unstructured, checkID, msg string) {
-		key := string(route.GetUID()) + "\x00" + checkID + "\x00" + msg
+	add := func(subject *unstructured.Unstructured, checkID, msg string) {
+		key := string(subject.GetUID()) + "\x00" + checkID + "\x00" + msg
 		if seen[key] {
 			return
 		}
@@ -65,11 +67,57 @@ func checkTraefikDanglingRefs(input *CheckInput) []Finding {
 		// builtin table (CRDs resolve to ""), which is what the per-resource
 		// drill-down looks up. Setting it would hide these findings there.
 		findings = append(findings, Finding{
-			Kind:      route.GetKind(),
-			Namespace: route.GetNamespace(), Name: route.GetName(),
+			Kind:      subject.GetKind(),
+			Namespace: subject.GetNamespace(), Name: subject.GetName(),
 			CheckID: checkID, Category: CategoryReliability, Severity: SeverityWarning,
 			Message: msg,
 		})
+	}
+
+	// checkServiceRef resolves a Traefik Service reference (core Service or, when
+	// kind=="TraefikService", a TraefikService) against the authoritative
+	// inventory and reports it as missing via `add`. Shared by router
+	// spec.routes[].services and errors-middleware spec.errors.service — both use
+	// the same Service ref shape. `refDesc` labels the subject in the message.
+	checkServiceRef := func(subject *unstructured.Unstructured, group, defaultNs, refDesc, checkID string, s map[string]any) {
+		name, _ := s["name"].(string)
+		if name == "" {
+			return
+		}
+		ns, _ := s["namespace"].(string)
+		if ns == "" {
+			ns = defaultNs
+		}
+		if kind, _ := s["kind"].(string); kind == "TraefikService" {
+			if authoritative[group+"\x00TraefikService"] && !traefikServices[group+"\x00"+ns+"/"+name] {
+				add(subject, checkID,
+					fmt.Sprintf("%s references TraefikService %q which is not found in the cluster", refDesc, traefikRefLabel(ns, name, defaultNs)))
+			}
+		} else if servicesListed && !coreServices[ns+"/"+name] {
+			add(subject, checkID,
+				fmt.Sprintf("%s references Service %q which is not found in the cluster", refDesc, traefikRefLabel(ns, name, defaultNs)))
+		}
+	}
+
+	// checkMiddlewareRef resolves a Traefik MiddlewareRef (name + optional
+	// namespace) against the authoritative inventory for mwKind. Shared by router
+	// spec.routes[].middlewares and chain-middleware spec.chain.middlewares[].
+	checkMiddlewareRef := func(subject *unstructured.Unstructured, group, mwKind, defaultNs, refDesc, checkID string, m map[string]any) {
+		if !authoritative[group+"\x00"+mwKind] {
+			return // no synced cluster-wide inventory for this kind → can't assert absence
+		}
+		name, _ := m["name"].(string)
+		if name == "" {
+			return
+		}
+		ns, _ := m["namespace"].(string)
+		if ns == "" {
+			ns = defaultNs
+		}
+		if !middlewares[group+"\x00"+mwKind+"\x00"+ns+"/"+name] {
+			add(subject, checkID,
+				fmt.Sprintf("%s references %s %q which is not found in the cluster", refDesc, mwKind, traefikRefLabel(ns, name, defaultNs)))
+		}
 	}
 
 	for _, route := range input.IngressRoutes {
@@ -89,44 +137,36 @@ func checkTraefikDanglingRefs(input *CheckInput) []Finding {
 			if !ok {
 				continue
 			}
-
 			for _, s := range nestedMaps(rm, "services") {
-				name, _ := s["name"].(string)
-				if name == "" {
-					continue
-				}
-				ns, _ := s["namespace"].(string)
-				if ns == "" {
-					ns = routeNs
-				}
-				if kind, _ := s["kind"].(string); kind == "TraefikService" {
-					if authoritative[group+"\x00TraefikService"] && !traefikServices[group+"\x00"+ns+"/"+name] {
-						add(route, "traefikRouteMissingService",
-							fmt.Sprintf("%s references TraefikService %q which is not found in the cluster", routeKind, traefikRefLabel(ns, name, routeNs)))
-					}
-				} else if servicesListed && !coreServices[ns+"/"+name] {
-					add(route, "traefikRouteMissingService",
-						fmt.Sprintf("%s references Service %q which is not found in the cluster", routeKind, traefikRefLabel(ns, name, routeNs)))
-				}
-			}
-
-			if !authoritative[group+"\x00"+mwKind] {
-				continue // no synced cluster-wide inventory for this kind → can't assert absence
+				checkServiceRef(route, group, routeNs, routeKind, "traefikRouteMissingService", s)
 			}
 			for _, m := range nestedMaps(rm, "middlewares") {
-				name, _ := m["name"].(string)
-				if name == "" {
-					continue
-				}
-				ns, _ := m["namespace"].(string)
-				if ns == "" {
-					ns = routeNs
-				}
-				if !middlewares[group+"\x00"+mwKind+"\x00"+ns+"/"+name] {
-					add(route, "traefikRouteMissingMiddleware",
-						fmt.Sprintf("%s references %s %q which is not found in the cluster", routeKind, mwKind, traefikRefLabel(ns, name, routeNs)))
-				}
+				checkMiddlewareRef(route, group, mwKind, routeNs, routeKind, "traefikRouteMissingMiddleware", m)
 			}
+		}
+	}
+
+	// Middleware subjects (audited namespaces): a `chain` middleware referencing a
+	// missing Middleware, or an `errors` middleware referencing a missing Service.
+	// Same silent-failure class as routes — Traefik accepts the bad ref and the
+	// chain/error-page simply doesn't work. Only HTTP Middlewares carry chain/
+	// errors; a MiddlewareTCP has neither key, so its loops are no-ops.
+	for _, mw := range input.MiddlewareSubjects {
+		group := traefikGroupOf(mw)
+		mwKind := mw.GetKind()
+		mwNs := mw.GetNamespace()
+
+		chain, _, _ := unstructured.NestedSlice(mw.Object, "spec", "chain", "middlewares")
+		for _, c := range chain {
+			cm, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+			checkMiddlewareRef(mw, group, mwKind, mwNs, mwKind+" chain", "traefikChainMissingMiddleware", cm)
+		}
+
+		if svc, ok, _ := unstructured.NestedMap(mw.Object, "spec", "errors", "service"); ok {
+			checkServiceRef(mw, group, mwNs, mwKind+" errors", "traefikErrorsMissingService", svc)
 		}
 	}
 	return findings

--- a/pkg/audit/traefik_test.go
+++ b/pkg/audit/traefik_test.go
@@ -215,3 +215,108 @@ func TestCheckTraefikDanglingRefs(t *testing.T) {
 		}
 	})
 }
+
+func traefikChainMw(group, ns, name string, chainRefs []map[string]any) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": group + "/v1alpha1",
+		"kind":       "Middleware",
+		"metadata":   map[string]any{"name": name, "namespace": ns, "uid": group + "/chain/" + ns + "/" + name},
+		"spec":       map[string]any{"chain": map[string]any{"middlewares": toIfaceSlice(chainRefs)}},
+	}}
+}
+
+func traefikErrorsMw(group, ns, name string, svcRef map[string]any) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": group + "/v1alpha1",
+		"kind":       "Middleware",
+		"metadata":   map[string]any{"name": name, "namespace": ns, "uid": group + "/errors/" + ns + "/" + name},
+		"spec":       map[string]any{"errors": map[string]any{"service": svcRef}},
+	}}
+}
+
+func TestCheckTraefikMiddlewareSubjectRefs(t *testing.T) {
+	const g = "traefik.io"
+
+	t.Run("chain flags missing middleware, accepts present", func(t *testing.T) {
+		input := &CheckInput{
+			Middlewares:               []*unstructured.Unstructured{traefikObj(g, "Middleware", "app", "present")},
+			TraefikAuthoritativeKinds: authoritative(g + "\x00Middleware"),
+			MiddlewareSubjects: []*unstructured.Unstructured{
+				traefikChainMw(g, "app", "c", []map[string]any{{"name": "present"}, {"name": "missing"}}),
+			},
+		}
+		if n := findingIDs(checkTraefikDanglingRefs(input))["traefikChainMissingMiddleware"]; n != 1 {
+			t.Errorf("want 1 missing chain middleware, got %d", n)
+		}
+	})
+
+	t.Run("chain cross-namespace ref resolves against cluster-wide inventory", func(t *testing.T) {
+		input := &CheckInput{
+			Middlewares:               []*unstructured.Unstructured{traefikObj(g, "Middleware", "shared", "auth")},
+			TraefikAuthoritativeKinds: authoritative(g + "\x00Middleware"),
+			MiddlewareSubjects: []*unstructured.Unstructured{
+				traefikChainMw(g, "app", "c", []map[string]any{{"name": "auth", "namespace": "shared"}}),
+			},
+		}
+		if n := findingIDs(checkTraefikDanglingRefs(input))["traefikChainMissingMiddleware"]; n != 0 {
+			t.Errorf("cross-namespace ref to an existing middleware must not be flagged, got %d", n)
+		}
+	})
+
+	t.Run("chain not authoritative → skip (no false positive)", func(t *testing.T) {
+		input := &CheckInput{
+			TraefikAuthoritativeKinds: authoritative(), // nothing authoritative
+			MiddlewareSubjects: []*unstructured.Unstructured{
+				traefikChainMw(g, "app", "c", []map[string]any{{"name": "ghost"}}),
+			},
+		}
+		if n := findingIDs(checkTraefikDanglingRefs(input))["traefikChainMissingMiddleware"]; n != 0 {
+			t.Errorf("non-authoritative middleware kind must not be asserted, got %d", n)
+		}
+	})
+
+	t.Run("errors flags missing service, accepts present", func(t *testing.T) {
+		input := &CheckInput{
+			AllServices: []*corev1.Service{svc("app", "present")},
+			MiddlewareSubjects: []*unstructured.Unstructured{
+				traefikErrorsMw(g, "app", "e-missing", map[string]any{"name": "missing"}),
+				traefikErrorsMw(g, "app", "e-present", map[string]any{"name": "present"}),
+			},
+		}
+		if n := findingIDs(checkTraefikDanglingRefs(input))["traefikErrorsMissingService"]; n != 1 {
+			t.Errorf("want 1 missing errors service, got %d", n)
+		}
+	})
+
+	t.Run("errors.service kind=TraefikService resolves against TraefikService inventory", func(t *testing.T) {
+		input := &CheckInput{
+			AllServices:               []*corev1.Service{}, // listed, empty
+			TraefikServices:           []*unstructured.Unstructured{traefikObj(g, "TraefikService", "app", "weighted")},
+			TraefikAuthoritativeKinds: authoritative(g + "\x00TraefikService"),
+			MiddlewareSubjects: []*unstructured.Unstructured{
+				traefikErrorsMw(g, "app", "e", map[string]any{"name": "weighted", "kind": "TraefikService"}),
+			},
+		}
+		if n := findingIDs(checkTraefikDanglingRefs(input))["traefikErrorsMissingService"]; n != 0 {
+			t.Errorf("present TraefikService ref must not be flagged, got %d", n)
+		}
+	})
+
+	t.Run("middleware-only namespace (no routes) still runs the checks", func(t *testing.T) {
+		// Regression guard: the early-return must not bail when there are only
+		// middleware subjects and zero IngressRoutes.
+		input := &CheckInput{
+			AllServices: []*corev1.Service{},
+			MiddlewareSubjects: []*unstructured.Unstructured{
+				traefikErrorsMw(g, "app", "e", map[string]any{"name": "missing"}),
+			},
+		}
+		got := checkTraefikDanglingRefs(input)
+		if len(got) != 1 {
+			t.Fatalf("want 1 finding from a middleware-only namespace, got %d", len(got))
+		}
+		if got[0].Kind != "Middleware" || got[0].Group != "" {
+			t.Errorf("finding must be on the Middleware with empty Group, got kind=%q group=%q", got[0].Kind, got[0].Group)
+		}
+	})
+}

--- a/pkg/audit/types.go
+++ b/pkg/audit/types.go
@@ -50,6 +50,12 @@ type CheckInput struct {
 	IngressRoutes   []*unstructured.Unstructured // IngressRoute / IngressRouteTCP / IngressRouteUDP (scoped to audited namespaces)
 	Middlewares     []*unstructured.Unstructured // Middleware / MiddlewareTCP (cluster-wide, for cross-ns ref resolution)
 	TraefikServices []*unstructured.Unstructured // TraefikService (cluster-wide)
+	// MiddlewareSubjects are Middleware/MiddlewareTCP in the AUDITED namespaces —
+	// the subjects of the chain/errors ref-integrity checks. Distinct from
+	// Middlewares (cluster-wide targets): refs resolve against the whole cluster,
+	// but findings are only reported for middlewares we're auditing, so a
+	// middleware in a non-audited namespace never leaks into a scoped scan.
+	MiddlewareSubjects []*unstructured.Unstructured
 	// TraefikAuthoritativeKinds keys (group\x00Kind) the target kinds served by a
 	// synced cluster-wide informer. The dangling-ref check asserts "missing" only
 	// for kinds present here — otherwise the cache may know only a subset of


### PR DESCRIPTION
## Summary

Traefik ships no admission webhook or linter, so a typo'd reference is accepted silently and the route/middleware just doesn't do what you wrote — until someone reads the controller logs. Radar's Cluster Audit already catches the two most common cases (router → Service, router → Middleware). This extends that coverage to the next two low-hanging dangling-ref cases an operator actually hits:

- **`traefikChainMissingMiddleware`** — a `chain` Middleware whose `spec.chain.middlewares[]` lists a Middleware that doesn't exist. Traefik runs the chain but skips the missing link, so part of the intended pipeline silently doesn't apply.
- **`traefikErrorsMissingService`** — an `errors` Middleware whose `spec.errors.service` references a Service (or TraefikService) that doesn't exist, so users get the default error page instead of the custom one.

## What changed

- **`pkg/audit/traefik.go`** — the route-ref resolution was extracted into two shared closures (`checkServiceRef`, `checkMiddlewareRef`) so the new chain/errors subjects reuse the *exact* same matching: group-family isolation (a `traefik.io` ref isn't satisfied by a `traefik.containo.us` object), cluster-wide target inventory for legitimate cross-namespace refs, and the cluster-wide-synced **authoritative gate** so a namespace-scoped cache never fabricates a "missing" finding. Route behavior is unchanged.
- **Subject scoping** (`internal/audit/runner.go` + `CheckInput.MiddlewareSubjects`) — middlewares are gathered cluster-wide as *targets* (for cross-ns resolution) but only the ones in **audited namespaces** are treated as *subjects*. This mirrors how routes are already scoped and prevents a middleware in a non-audited namespace from leaking into a namespace-scoped scan.
- **Early-return guard** now also runs when a namespace has middlewares but no IngressRoutes (otherwise a middleware-only namespace would skip the new checks).
- **`pkg/audit/registry.go`** — catalog entries (title/category/description/remediation) for the two CheckIDs, mirroring the existing `traefikRouteMissing*` entries.

Still deliberately out of scope (not low-hanging): nested TraefikService weighted/mirror sub-services, ServersTransport refs, TLS-secret refs.

## Testing

- `pkg/audit` + `pkg/checks` + `internal/server` tests green; `go build ./...` + `go vet` clean.
- New table tests (`pkg/audit/traefik_test.go`): chain missing/present, chain cross-namespace resolves, chain non-authoritative → skip (no false positive), errors missing/present, `errors.service` with `kind: TraefikService`, and a regression guard that a **middleware-only namespace** (no routes) still runs the checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive audit checks with conservative absence gating; existing route behavior is preserved via shared helpers.
> 
> **Overview**
> Extends cluster audit **Traefik dangling-reference** coverage beyond IngressRoutes to **chain** and **errors** Middlewares, with two new reliability checks: `traefikChainMissingMiddleware` and `traefikErrorsMissingService`.
> 
> **`checkTraefikDanglingRefs`** now audits Middlewares in audited namespaces via new **`MiddlewareSubjects`** (cluster-wide `Middlewares` still resolve cross-namespace targets). Route logic is refactored through shared **`checkServiceRef`** / **`checkMiddlewareRef`** helpers so chain/errors use the same group-family matching and authoritative-cache gates as routes. The runner loads cluster-wide **Services** when there are middleware subjects (not only routes), and the check no longer no-ops on middleware-only namespaces.
> 
> Registry entries and table tests cover missing/present refs, cross-namespace resolution, non-authoritative skip, and TraefikService-backed `errors.service`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dce38405dd2ee0c169bbc0402900595d3569c734. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->