### PR TITLE
support for initContainers

### DIFF
--- a/deploy/helm/radar/Chart.yaml
+++ b/deploy/helm/radar/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: radar
 description: Modern Kubernetes visibility - topology, traffic, Helm and GitOps management
 type: application
-version: 1.5.10
+version: 1.6.0
 appVersion: "1.7.6"
 icon: https://radarhq.io/radar/icon-512.png
 keywords:

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -35,6 +35,10 @@ spec:
       serviceAccountName: {{ include "radar.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/deploy/helm/radar/values.schema.json
+++ b/deploy/helm/radar/values.schema.json
@@ -297,17 +297,7 @@
     "initContainers": {
       "type": "array",
       "description": "Init containers to run before the main container.",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "properties": {
-          "name": { "type": "string" },
-          "image": { "type": "string" },
-          "command": { "type": "array", "items": { "type": "string" } },
-          "args": { "type": "array", "items": { "type": "string" } }
-        },
-        "required": ["name", "image"]
-      }
+      "items": { "type": "object" }
     },
     "probes": {
       "type": "object",

--- a/deploy/helm/radar/values.schema.json
+++ b/deploy/helm/radar/values.schema.json
@@ -294,6 +294,21 @@
         "required": ["name"]
       }
     },
+    "initContainers": {
+      "type": "array",
+      "description": "Init containers to run before the main container.",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": { "type": "string" },
+          "image": { "type": "string" },
+          "command": { "type": "array", "items": { "type": "string" } },
+          "args": { "type": "array", "items": { "type": "string" } }
+        },
+        "required": ["name", "image"]
+      }
+    },
     "probes": {
       "type": "object",
       "additionalProperties": false,

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -417,6 +417,12 @@ env: []
 #  - name: DEBUG
 #    value: "true"
 
+# Init containers to run before the main container
+initContainers: []
+#  - name: init-myservice
+#    image: busybox:1.36
+#    command: ['sh', '-c', 'echo init']
+
 # Liveness and readiness probes
 probes:
   liveness:


### PR DESCRIPTION
## Description

Adding support for attaching `initContainers` to radar's pod. There's many good reasons:

- Sidecar: you can add an initContainer with `restarPolicy: Always` and use kube-rbac-proxy to restrict the service accounts that can talk to radar (ingress controller, prometheus ... or custom agents running in cluster) 
- Secrets: there are tools that pull secrets from a secret store and dump it into pod filesystem
- It's kind of standard to support it in any helm chart

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

Describe the tests you ran to verify your changes.

- [x] Tested helm rendering with and without the initContainers construct


## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [ ] I have added comments where necessary
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged

## Related issues

Fixes #(issue number)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Helm-only, opt-in templating with no Radar binary changes; default remains an empty list.
> 
> **Overview**
> The Radar Helm chart can now attach **init containers** to the Radar pod via a new `initContainers` values key (defaults to empty, so existing installs are unchanged).
> 
> When set, the deployment template renders a standard `initContainers` block before the main Radar container, with full YAML passthrough for secret-fetch sidecars, pre-start checks, and similar patterns. The key is documented in `values.yaml` and validated in `values.schema.json`.
> 
> Chart version is bumped **1.5.10 → 1.6.0** for the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73f0e6904f307b878ac6f923146137a600d5c7b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->