### PR TITLE
feat(audit): badge resources with high-signal Cluster Audit findings (topology + list)

### DIFF
--- a/internal/server/audit_handlers.go
+++ b/internal/server/audit_handlers.go
@@ -166,17 +166,22 @@ func (s *Server) handleAuditResource(w http.ResponseWriter, r *http.Request) {
 	}
 	index := bp.IndexByResource(results.Findings)
 
-	// Try exact kind first, then map API resource name (e.g. "deployments") to Go kind (e.g. "Deployment").
-	// This handler is the UI's per-resource audit drill-down — group isn't on
-	// the URL today (the UI doesn't list grouped CRDs here yet), so we look
-	// up with group="" which matches the built-ins the audit suite scans.
-	// When CRD audit lands (#35 follow-up), thread group through the URL.
-	findings := index[bp.ResourceKey("", kind, namespace, name)]
-	if findings == nil {
-		goKind := apiResourceToKind(kind)
-		if goKind != kind {
-			findings = index[bp.ResourceKey("", goKind, namespace, name)]
-		}
+	// Resolve to the Go kind (built-in plural "deployments" → "Deployment"), then
+	// look up with the audit's keying convention. Findings carry group backfilled
+	// from the builtin table (built-ins → their group e.g. "apps"; CRDs → ""), so
+	// a bare group="" lookup missed every built-in finding keyed under a real
+	// group (Deployment under "apps", Job under "batch", …) — the drawer showed
+	// nothing for them. Group still resolves to "" for CRDs, so those keep working.
+	goKind := kind
+	if mapped := apiResourceToKind(kind); mapped != kind {
+		goKind = mapped
+	}
+	group := bp.GroupForBuiltinKind(goKind)
+	findings := index[bp.ResourceKey(group, goKind, namespace, name)]
+	if findings == nil && group != "" {
+		// Defensive: resolve even if a finding for this kind was emitted with an
+		// empty group despite the builtin table classifying it under a real one.
+		findings = index[bp.ResourceKey("", goKind, namespace, name)]
 	}
 	if findings == nil {
 		findings = []bp.Finding{}

--- a/packages/k8s-ui/src/components/audit/AuditAlerts.tsx
+++ b/packages/k8s-ui/src/components/audit/AuditAlerts.tsx
@@ -5,6 +5,10 @@ import { SEVERITY_TEXT, BP_CATEGORY_BADGE, DEFAULT_BADGE_COLOR } from '../../uti
 
 export interface AuditFinding {
   kind: string
+  /** API group, backfilled by the backend from the builtin Kind→group table
+   *  (built-ins → e.g. "apps"/"batch"; CRDs → ""). Part of the resource key
+   *  used to join findings onto topology nodes / list rows. */
+  group?: string
   namespace: string
   name: string
   checkID: string

--- a/packages/k8s-ui/src/components/audit/AuditBadgeTooltip.test.tsx
+++ b/packages/k8s-ui/src/components/audit/AuditBadgeTooltip.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import { AuditBadgeTooltip } from './AuditBadgeTooltip'
+
+const msgs = [
+  { severity: 'warning', message: 'Service selector matches no pods' },
+  { severity: 'danger', message: 'Ingress references missing Service' },
+  { severity: 'warning', message: 'Uses a deprecated API version' },
+  { severity: 'warning', message: 'A fourth finding' },
+]
+
+describe('AuditBadgeTooltip', () => {
+  it('lists each finding message up to the cap', () => {
+    const html = renderToString(<AuditBadgeTooltip messages={msgs.slice(0, 2)} />)
+    expect(html).toContain('Service selector matches no pods')
+    expect(html).toContain('Ingress references missing Service')
+    expect(html).not.toContain('more')
+  })
+
+  it('caps the list and collapses the rest into "+N more"', () => {
+    const html = renderToString(<AuditBadgeTooltip messages={msgs} max={3} />)
+    expect(html).toContain('+1 more')
+    expect(html).not.toContain('A fourth finding')
+  })
+
+  it('shows the click hint by default and omits it when disabled', () => {
+    expect(renderToString(<AuditBadgeTooltip messages={msgs.slice(0, 1)} />)).toContain('Click to open')
+    expect(renderToString(<AuditBadgeTooltip messages={msgs.slice(0, 1)} clickHint={false} />)).not.toContain('Click to open')
+  })
+})

--- a/packages/k8s-ui/src/components/audit/AuditBadgeTooltip.tsx
+++ b/packages/k8s-ui/src/components/audit/AuditBadgeTooltip.tsx
@@ -1,0 +1,47 @@
+import { ShieldAlert, AlertTriangle } from 'lucide-react'
+import { clsx } from 'clsx'
+import { SEVERITY_TEXT } from '../../utils/badge-colors'
+
+export interface AuditBadgeMessage {
+  severity: string
+  message: string
+}
+
+interface AuditBadgeTooltipProps {
+  messages: AuditBadgeMessage[]
+  /** Max messages to list before collapsing the rest into "+N more". */
+  max?: number
+  /** Hint that clicking opens the resource — omitted when the badge isn't clickable. */
+  clickHint?: boolean
+}
+
+/**
+ * Inline tooltip body for an audit badge: lists the actual finding messages
+ * (danger-first) so the operator reads WHAT is wrong on hover, instead of a
+ * content-free "N findings". Shared by the resource-list and topology-node
+ * badges so the two can't drift.
+ */
+export function AuditBadgeTooltip({ messages, max = 3, clickHint = true }: AuditBadgeTooltipProps) {
+  const shown = messages.slice(0, max)
+  const overflow = messages.length - shown.length
+  return (
+    <div className="flex flex-col gap-1 text-left">
+      {shown.map((m, i) => {
+        const isDanger = m.severity === 'danger'
+        const Icon = isDanger ? ShieldAlert : AlertTriangle
+        return (
+          <div key={i} className="flex items-start gap-1.5">
+            <Icon className={clsx('w-3 h-3 shrink-0 mt-0.5', isDanger ? SEVERITY_TEXT.error : SEVERITY_TEXT.warning)} />
+            <span>{m.message}</span>
+          </div>
+        )
+      })}
+      {overflow > 0 && (
+        <div className="text-theme-text-tertiary">{`+${overflow} more`}</div>
+      )}
+      {clickHint && (
+        <div className="text-theme-text-tertiary mt-0.5">Click to open →</div>
+      )}
+    </div>
+  )
+}

--- a/packages/k8s-ui/src/components/audit/AuditFindingsTable.tsx
+++ b/packages/k8s-ui/src/components/audit/AuditFindingsTable.tsx
@@ -27,6 +27,10 @@ export interface CheckMeta {
   remediation: string
   frameworks?: string[]
   references?: CheckReference[]
+  /** Finding means the specific resource is broken (reference-integrity /
+   *  lifecycle), worth a per-resource topology/list badge — vs posture /
+   *  best-practice checks that fire near-universally. Set by the backend registry. */
+  badgeWorthy?: boolean
 }
 
 /** An authoritative link for a check (K8s docs, CIS, NSA/CISA, …). */

--- a/packages/k8s-ui/src/components/audit/index.ts
+++ b/packages/k8s-ui/src/components/audit/index.ts
@@ -1,3 +1,4 @@
 export { AuditCard, type AuditCardData } from './AuditCard'
 export { AuditAlerts, type AuditFinding } from './AuditAlerts'
+export { AuditBadgeTooltip, type AuditBadgeMessage } from './AuditBadgeTooltip'
 export { AuditFindingsTable, type AuditFindingsTableProps, type ResourceGroup, type CheckMeta, type CheckReference } from './AuditFindingsTable'

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -6040,6 +6040,7 @@ function ReplicaSetCell({ resource, column }: { resource: any; column: string })
 }
 
 function ServiceCell({ resource, column }: { resource: any; column: string }) {
+  const { auditBadges } = useContext(ResourcesViewDataContext)
   switch (column) {
     case 'type': {
       const status = getServiceStatus(resource)
@@ -6060,6 +6061,20 @@ function ServiceCell({ resource, column }: { resource: any; column: string }) {
       )
     }
     case 'endpoints': {
+      // getServiceEndpointsStatus can't see live pods, so it optimistically
+      // reports "Active" for any service with a selector. The audit's
+      // serviceNoMatchingPods check DOES resolve the selector against live pods —
+      // the only badge-worthy finding a Service can carry — so when it fired,
+      // trust it over the guess instead of showing a false-green "Active".
+      const meta = resource.metadata || {}
+      const flagged = auditBadges?.[`${meta.namespace || ''}/${meta.name}`]
+      if (flagged && flagged.danger + flagged.warning > 0) {
+        return (
+          <span className={clsx('badge', flagged.danger > 0 ? 'status-unhealthy' : 'status-degraded')}>
+            No endpoints
+          </span>
+        )
+      }
       const { status, color } = getServiceEndpointsStatus(resource)
       return (
         <span className={clsx('badge', color)}>

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -134,6 +134,7 @@ import { pluralize } from '../../utils/pluralize'
 import { getPodGpuCount, getNodeGpuCount } from '../../utils/extended-resources'
 import { type CustomColumnDef, type CustomColumnSource, customColumnKey, readCustomColumnValue, sanitizeCustomColumnDefs } from '../../utils/custom-columns'
 import { Tooltip } from '../ui/Tooltip'
+import { AuditBadgeTooltip, type AuditBadgeMessage } from '../audit/AuditBadgeTooltip'
 // CRD-specific cell components (extracted)
 import { GitRepositoryCell, OCIRepositoryCell, HelmRepositoryCell, KustomizationCell, FluxHelmReleaseCell, FluxAlertCell } from './renderers/flux-cells'
 import { ArgoApplicationCell, ArgoApplicationSetCell, ArgoAppProjectCell } from './renderers/argo-cells'
@@ -1802,7 +1803,7 @@ interface ResourcesViewData {
   certExpiryError?: boolean
   // Cluster Audit findings for the listed kind, keyed by "namespace/name" (the
   // list shows one kind at a time, so ns/name is unambiguous). Host-injected.
-  auditBadges?: Record<string, { danger: number; warning: number }>
+  auditBadges?: Record<string, { danger: number; warning: number; messages?: AuditBadgeMessage[] }>
   onOpenLogs?: (params: { namespace: string; podName: string; containers: string[]; containerName?: string }) => void
   onOpenWorkloadLogs?: (params: { namespace: string; workloadKind: string; workloadName: string }) => void
 }
@@ -1856,7 +1857,7 @@ interface ResourcesViewProps {
   certExpiry?: Record<string, { expired?: boolean; daysLeft: number }>
   certExpiryError?: boolean
   // Cluster Audit findings for the selected kind, keyed by "namespace/name".
-  auditBadges?: Record<string, { danger: number; warning: number }>
+  auditBadges?: Record<string, { danger: number; warning: number; messages?: AuditBadgeMessage[] }>
   // Pinned kinds
   pinned?: Array<{ name: string; kind: string; group: string }>
   togglePin?: (kind: { name: string; kind: string; group: string }) => void
@@ -5195,7 +5196,9 @@ function CellContent({ resource, kind, column, group, majorityNodeMinorVersion, 
         </Tooltip>
         <CopyNameButton name={meta.name} />
         {auditTotal > 0 && audit && (
-          <Tooltip content={`${auditTotal} audit ${auditTotal === 1 ? 'finding' : 'findings'}${audit.danger > 0 ? ` · ${audit.danger} danger` : ''} — open to review`}>
+          <Tooltip content={audit.messages && audit.messages.length > 0
+            ? <AuditBadgeTooltip messages={audit.messages} />
+            : `${auditTotal} audit ${auditTotal === 1 ? 'finding' : 'findings'}${audit.danger > 0 ? ` · ${audit.danger} danger` : ''}`}>
             <span className={clsx('shrink-0 inline-flex items-center gap-0.5 text-[10px] font-medium cursor-help', audit.danger > 0 ? SEVERITY_TEXT.error : SEVERITY_TEXT.warning)}>
               <AlertTriangle className="w-3 h-3" />
               {auditTotal}

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -129,7 +129,7 @@ import {
   podMatchesProblemCategory,
   SEVERITY_DOT_COLOR,
 } from './resource-utils'
-import { SEVERITY_BADGE, EVENT_TYPE_COLORS } from '../../utils/badge-colors'
+import { SEVERITY_BADGE, EVENT_TYPE_COLORS, SEVERITY_TEXT } from '../../utils/badge-colors'
 import { pluralize } from '../../utils/pluralize'
 import { getPodGpuCount, getNodeGpuCount } from '../../utils/extended-resources'
 import { type CustomColumnDef, type CustomColumnSource, customColumnKey, readCustomColumnValue, sanitizeCustomColumnDefs } from '../../utils/custom-columns'
@@ -1800,6 +1800,9 @@ interface ResourcesViewData {
   onNavigate?: (path: string, options?: { replace?: boolean }) => void
   certExpiry?: Record<string, { expired?: boolean; daysLeft: number }>
   certExpiryError?: boolean
+  // Cluster Audit findings for the listed kind, keyed by "namespace/name" (the
+  // list shows one kind at a time, so ns/name is unambiguous). Host-injected.
+  auditBadges?: Record<string, { danger: number; warning: number }>
   onOpenLogs?: (params: { namespace: string; podName: string; containers: string[]; containerName?: string }) => void
   onOpenWorkloadLogs?: (params: { namespace: string; workloadKind: string; workloadName: string }) => void
 }
@@ -1852,6 +1855,8 @@ interface ResourcesViewProps {
   topNodeMetrics?: TopNodeMetrics[]
   certExpiry?: Record<string, { expired?: boolean; daysLeft: number }>
   certExpiryError?: boolean
+  // Cluster Audit findings for the selected kind, keyed by "namespace/name".
+  auditBadges?: Record<string, { danger: number; warning: number }>
   // Pinned kinds
   pinned?: Array<{ name: string; kind: string; group: string }>
   togglePin?: (kind: { name: string; kind: string; group: string }) => void
@@ -2070,6 +2075,7 @@ export function ResourcesView({
   topNodeMetrics,
   certExpiry,
   certExpiryError,
+  auditBadges,
   pinned = [],
   togglePin = () => {},
   isPinned = () => false,
@@ -4014,9 +4020,10 @@ export function ResourcesView({
     onNavigate,
     certExpiry,
     certExpiryError,
+    auditBadges,
     onOpenLogs,
     onOpenWorkloadLogs,
-  }), [onNavigate, certExpiry, certExpiryError, onOpenLogs, onOpenWorkloadLogs])
+  }), [onNavigate, certExpiry, certExpiryError, auditBadges, onOpenLogs, onOpenWorkloadLogs])
 
   return (
     <ResourcesViewDataContext.Provider value={resourcesViewDataContextValue}>
@@ -5155,6 +5162,7 @@ interface CellContentProps {
 }
 
 function CellContent({ resource, kind, column, group, majorityNodeMinorVersion, extraColumn, nameHref }: CellContentProps) {
+  const { auditBadges } = useContext(ResourcesViewDataContext)
   // Parent-injected extra columns short-circuit the built-in switch.
   // Used by hosts that inject leading columns (e.g. a multi-cluster Cluster column).
   if (extraColumn) {
@@ -5167,6 +5175,8 @@ function CellContent({ resource, kind, column, group, majorityNodeMinorVersion, 
   if (column === 'name') {
     const isTerminating = !!meta.deletionTimestamp
     const nameClass = clsx('text-sm font-medium truncate block', isTerminating ? 'text-theme-text-tertiary line-through' : 'text-theme-text-primary')
+    const audit = auditBadges?.[`${meta.namespace || ''}/${meta.name}`]
+    const auditTotal = audit ? audit.danger + audit.warning : 0
     return (
       <div className="flex items-center gap-1.5 min-w-0">
         <Tooltip content={meta.name}>
@@ -5184,6 +5194,14 @@ function CellContent({ resource, kind, column, group, majorityNodeMinorVersion, 
           )}
         </Tooltip>
         <CopyNameButton name={meta.name} />
+        {auditTotal > 0 && audit && (
+          <Tooltip content={`${auditTotal} audit ${auditTotal === 1 ? 'finding' : 'findings'}${audit.danger > 0 ? ` · ${audit.danger} danger` : ''} — open to review`}>
+            <span className={clsx('shrink-0 inline-flex items-center gap-0.5 text-[10px] font-medium cursor-help', audit.danger > 0 ? SEVERITY_TEXT.error : SEVERITY_TEXT.warning)}>
+              <AlertTriangle className="w-3 h-3" />
+              {auditTotal}
+            </span>
+          </Tooltip>
+        )}
         {isTerminating && (
           <Tooltip content="Resource is being deleted (has deletionTimestamp set). May be stuck due to finalizers.">
             <span className="shrink-0 flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium bg-red-500/15 text-red-600 dark:text-red-400 rounded">

--- a/packages/k8s-ui/src/components/topology/K8sResourceNode.tsx
+++ b/packages/k8s-ui/src/components/topology/K8sResourceNode.tsx
@@ -3,11 +3,12 @@ import { Handle, Position } from '@xyflow/react'
 import {
   ChevronDown,
   ChevronUp,
+  TriangleAlert,
 } from 'lucide-react'
 import { clsx } from 'clsx'
 import type { NodeKind, HealthStatus, PodSummary } from '../../types'
 import { displayKind } from '../../types'
-import { healthToSeverity, SEVERITY_DOT } from '../../utils/badge-colors'
+import { healthToSeverity, SEVERITY_DOT, SEVERITY_TEXT } from '../../utils/badge-colors'
 import { workloadHue } from '../../utils/workload-colors'
 import { ownershipOf } from '../../utils/topology-neighborhood'
 import { midTruncate } from '../../utils/format'
@@ -376,6 +377,10 @@ export const K8sResourceNode = memo(function K8sResourceNode({
   id,
 }: K8sResourceNodeProps) {
   const { kind, name, status, nodeData, selected, dimmed, onExpand, onCollapse, isExpanded } = data
+  // Cluster Audit findings joined onto this node by the host (web/ enriches each
+  // node's data by auditKey). Topology surfaces DANGER only — warnings would turn
+  // a dense graph into a heatmap; they live in the list + the resource drawer.
+  const auditDanger = typeof nodeData.auditDanger === 'number' ? nodeData.auditDanger : 0
   // Workload tint (application graph): a node owned by exactly one workload
   // carries that workload's hue. Only on healthy/unknown cards — degraded/
   // unhealthy already own the card background for health, which must win.
@@ -505,6 +510,14 @@ export const K8sResourceNode = memo(function K8sResourceNode({
                 >
                   <ChevronUp className="w-3.5 h-3.5 text-theme-text-secondary" />
                 </button>
+              )}
+              {auditDanger > 0 && (
+                <Tooltip
+                  content={`${auditDanger} audit ${auditDanger === 1 ? 'finding' : 'findings'} — open to review`}
+                  position="right"
+                >
+                  <TriangleAlert className={clsx('w-3 h-3 cursor-help', SEVERITY_TEXT.error)} />
+                </Tooltip>
               )}
               {issueTooltip ? (
                 <Tooltip content={issueTooltip} position="right">

--- a/packages/k8s-ui/src/components/topology/K8sResourceNode.tsx
+++ b/packages/k8s-ui/src/components/topology/K8sResourceNode.tsx
@@ -13,6 +13,7 @@ import { workloadHue } from '../../utils/workload-colors'
 import { ownershipOf } from '../../utils/topology-neighborhood'
 import { midTruncate } from '../../utils/format'
 import { Tooltip } from '../ui/Tooltip'
+import { AuditBadgeTooltip, type AuditBadgeMessage } from '../audit/AuditBadgeTooltip'
 
 // Get actionable tooltip content for health issues
 function getIssueTooltip(issue: string | undefined): React.ReactNode {
@@ -385,6 +386,7 @@ export const K8sResourceNode = memo(function K8sResourceNode({
   const auditDanger = typeof nodeData.auditDanger === 'number' ? nodeData.auditDanger : 0
   const auditWarning = typeof nodeData.auditWarning === 'number' ? nodeData.auditWarning : 0
   const auditTotal = auditDanger + auditWarning
+  const auditMessages = Array.isArray(nodeData.auditMessages) ? (nodeData.auditMessages as AuditBadgeMessage[]) : []
   // Workload tint (application graph): a node owned by exactly one workload
   // carries that workload's hue. Only on healthy/unknown cards — degraded/
   // unhealthy already own the card background for health, which must win.
@@ -517,7 +519,9 @@ export const K8sResourceNode = memo(function K8sResourceNode({
               )}
               {auditTotal > 0 && (
                 <Tooltip
-                  content={`${auditTotal} audit ${auditTotal === 1 ? 'finding' : 'findings'}${auditDanger > 0 ? ` · ${auditDanger} danger` : ''} — open to review`}
+                  content={auditMessages.length > 0
+                    ? <AuditBadgeTooltip messages={auditMessages} clickHint={false} />
+                    : `${auditTotal} audit ${auditTotal === 1 ? 'finding' : 'findings'}${auditDanger > 0 ? ` · ${auditDanger} danger` : ''}`}
                   position="right"
                 >
                   <TriangleAlert className={clsx('w-3 h-3 cursor-help', auditDanger > 0 ? SEVERITY_TEXT.error : SEVERITY_TEXT.warning)} />

--- a/packages/k8s-ui/src/components/topology/K8sResourceNode.tsx
+++ b/packages/k8s-ui/src/components/topology/K8sResourceNode.tsx
@@ -378,9 +378,13 @@ export const K8sResourceNode = memo(function K8sResourceNode({
 }: K8sResourceNodeProps) {
   const { kind, name, status, nodeData, selected, dimmed, onExpand, onCollapse, isExpanded } = data
   // Cluster Audit findings joined onto this node by the host (web/ enriches each
-  // node's data by auditKey). Topology surfaces DANGER only — warnings would turn
-  // a dense graph into a heatmap; they live in the list + the resource drawer.
+  // node's data by auditKey). The host only counts "badge-worthy" findings —
+  // reference-integrity / lifecycle, "this resource is actually broken" — not the
+  // posture/best-practice nags that fire near-universally, so the indicator stays
+  // a signal. Colored by worst severity (danger red, else warning amber).
   const auditDanger = typeof nodeData.auditDanger === 'number' ? nodeData.auditDanger : 0
+  const auditWarning = typeof nodeData.auditWarning === 'number' ? nodeData.auditWarning : 0
+  const auditTotal = auditDanger + auditWarning
   // Workload tint (application graph): a node owned by exactly one workload
   // carries that workload's hue. Only on healthy/unknown cards — degraded/
   // unhealthy already own the card background for health, which must win.
@@ -511,12 +515,12 @@ export const K8sResourceNode = memo(function K8sResourceNode({
                   <ChevronUp className="w-3.5 h-3.5 text-theme-text-secondary" />
                 </button>
               )}
-              {auditDanger > 0 && (
+              {auditTotal > 0 && (
                 <Tooltip
-                  content={`${auditDanger} audit ${auditDanger === 1 ? 'finding' : 'findings'} — open to review`}
+                  content={`${auditTotal} audit ${auditTotal === 1 ? 'finding' : 'findings'}${auditDanger > 0 ? ` · ${auditDanger} danger` : ''} — open to review`}
                   position="right"
                 >
-                  <TriangleAlert className={clsx('w-3 h-3 cursor-help', SEVERITY_TEXT.error)} />
+                  <TriangleAlert className={clsx('w-3 h-3 cursor-help', auditDanger > 0 ? SEVERITY_TEXT.error : SEVERITY_TEXT.warning)} />
                 </Tooltip>
               )}
               {issueTooltip ? (

--- a/pkg/audit/helpers.go
+++ b/pkg/audit/helpers.go
@@ -13,6 +13,13 @@ func ResourceKey(group, kind, namespace, name string) string {
 	return resourceid.ResourceKey(group, kind, namespace, name)
 }
 
+// GroupForBuiltinKind re-exports the builtin Kind→group table from pkg/resourceid
+// so callers resolving a finding's key (which backfills group the same way) don't
+// need a second import.
+func GroupForBuiltinKind(kind string) string {
+	return resourceid.GroupForBuiltinKind(kind)
+}
+
 // IndexByResource builds a lookup map from ResourceKey → []Finding.
 func IndexByResource(findings []Finding) map[string][]Finding {
 	m := make(map[string][]Finding)

--- a/pkg/audit/registry.go
+++ b/pkg/audit/registry.go
@@ -294,6 +294,7 @@ var CheckRegistry = map[string]CheckMeta{
 	// ── Cross-resource / lifecycle (emit under Reliability) ────────────
 	"deprecatedAPIVersion": {
 		ID:          "deprecatedAPIVersion",
+		BadgeWorthy: true,
 		Title:       "Deprecated API version",
 		Category:    CategoryReliability,
 		Description: "This cluster still serves a deprecated API version. Resources using this API will break after a Kubernetes upgrade that removes it.",
@@ -302,6 +303,7 @@ var CheckRegistry = map[string]CheckMeta{
 	},
 	"serviceNoMatchingPods": {
 		ID:          "serviceNoMatchingPods",
+		BadgeWorthy: true,
 		Title:       "Service has no matching pods",
 		Category:    CategoryReliability,
 		Description: "The service selector does not match any running pods — traffic sent to this service will fail.",
@@ -310,6 +312,7 @@ var CheckRegistry = map[string]CheckMeta{
 	},
 	"ingressNoMatchingService": {
 		ID:          "ingressNoMatchingService",
+		BadgeWorthy: true,
 		Title:       "Ingress references missing service",
 		Category:    CategoryReliability,
 		Description: "The ingress backend references a service that does not exist, so incoming traffic will get 503 errors.",
@@ -318,6 +321,7 @@ var CheckRegistry = map[string]CheckMeta{
 	},
 	"traefikRouteMissingService": {
 		ID:          "traefikRouteMissingService",
+		BadgeWorthy: true,
 		Title:       "Traefik router references missing service",
 		Category:    CategoryReliability,
 		Description: "A Traefik IngressRoute references a Service or TraefikService that does not exist. Traefik ships no admission webhook, so the bad reference is accepted silently and requests to that route fail until someone reads the controller logs.",
@@ -326,6 +330,7 @@ var CheckRegistry = map[string]CheckMeta{
 	},
 	"traefikRouteMissingMiddleware": {
 		ID:          "traefikRouteMissingMiddleware",
+		BadgeWorthy: true,
 		Title:       "Traefik router references missing middleware",
 		Category:    CategoryReliability,
 		Description: "A Traefik IngressRoute references a Middleware that does not exist in the resolved namespace. Traefik accepts the route but skips the missing middleware, so auth, rate-limit, or header rules you expect to apply silently do not.",
@@ -334,6 +339,7 @@ var CheckRegistry = map[string]CheckMeta{
 	},
 	"traefikChainMissingMiddleware": {
 		ID:          "traefikChainMissingMiddleware",
+		BadgeWorthy: true,
 		Title:       "Traefik chain references missing middleware",
 		Category:    CategoryReliability,
 		Description: "A Traefik chain Middleware lists a Middleware in spec.chain.middlewares that does not exist in the resolved namespace. Traefik accepts the chain but skips the missing link, so part of the intended middleware pipeline silently does not run.",
@@ -342,6 +348,7 @@ var CheckRegistry = map[string]CheckMeta{
 	},
 	"traefikErrorsMissingService": {
 		ID:          "traefikErrorsMissingService",
+		BadgeWorthy: true,
 		Title:       "Traefik errors middleware references missing service",
 		Category:    CategoryReliability,
 		Description: "A Traefik errors Middleware references a Service in spec.errors.service that does not exist. Traefik accepts the middleware, but when an error page is needed the backend isn't there, so users get the default error instead of the custom one.",
@@ -350,6 +357,7 @@ var CheckRegistry = map[string]CheckMeta{
 	},
 	"stuckTerminating": {
 		ID:          "stuckTerminating",
+		BadgeWorthy: true,
 		Title:       "Stuck terminating resource",
 		Category:    CategoryReliability,
 		Description: "This resource has metadata.deletionTimestamp set but is still alive past the cleanup window. Most controllers finish cleanup within seconds; minutes-long delays usually mean a finalizer's owning controller is unhealthy or unable to reach a dependent service. Common causes: the controller pod is CrashLoopBackOff, DNS resolution is broken, the finalizer logic depends on a webhook or external API that's unavailable.",
@@ -358,6 +366,7 @@ var CheckRegistry = map[string]CheckMeta{
 	},
 	"crossplaneStuck": {
 		ID:          "crossplaneStuck",
+		BadgeWorthy: true,
 		Title:       "Stuck Crossplane resource",
 		Category:    CategoryReliability,
 		Description: "A Crossplane Managed Resource, Composite Resource, or Claim has been reporting Ready=False or Synced=False past the reconciliation window. Synced=False usually means a configuration error (bad ProviderConfig, malformed forProvider spec, missing IAM permissions, quota exceeded, schema mismatch). Ready=False usually means the provider accepted the spec but can't reach a desired state (target cloud API rejected, dependency missing, eventual-consistency lag past the threshold).",

--- a/pkg/audit/registry.go
+++ b/pkg/audit/registry.go
@@ -356,9 +356,12 @@ var CheckRegistry = map[string]CheckMeta{
 		References:  []Reference{refTraefikCRD},
 	},
 	"stuckTerminating": {
-		ID:          "stuckTerminating",
-		BadgeWorthy: true,
-		Title:       "Stuck terminating resource",
+		ID: "stuckTerminating",
+		// Not BadgeWorthy: stuck-terminating is already surfaced by the live health
+		// pipeline (pkg/health renders the node degraded) and the "Terminating" chip
+		// in the resource-list name cell — a badge here would be a third redundant
+		// signal. It stays in the Checks/Audit views with its deletion-age ramp.
+		Title: "Stuck terminating resource",
 		Category:    CategoryReliability,
 		Description: "This resource has metadata.deletionTimestamp set but is still alive past the cleanup window. Most controllers finish cleanup within seconds; minutes-long delays usually mean a finalizer's owning controller is unhealthy or unable to reach a dependent service. Common causes: the controller pod is CrashLoopBackOff, DNS resolution is broken, the finalizer logic depends on a webhook or external API that's unavailable.",
 		Remediation: "Check the controller responsible for each finalizer key (kubectl describe will show finalizers under metadata). For Argo CD, look at argocd-application-controller in the argocd namespace. For Flux, look at the matching controller (kustomize-controller, helm-controller, source-controller) in flux-system. Once the controller is healthy, deletion will resume automatically. If you must remove a stuck resource and accept the orphaned cleanup, manually clear the finalizers field — but only as a last resort.",

--- a/pkg/checks/checks.go
+++ b/pkg/checks/checks.go
@@ -92,6 +92,13 @@ type CheckMeta struct {
 	Remediation     string      `json:"remediation"`
 	Frameworks      []string    `json:"frameworks,omitempty"`
 	References      []Reference `json:"references,omitempty"`
+	// BadgeWorthy marks a check whose finding means the specific resource is
+	// actually broken (reference-integrity, lifecycle, will-break-on-upgrade) —
+	// worth a per-resource badge on the topology graph and resource list.
+	// Deliberately FALSE for security-posture and best-practice checks (runAsRoot,
+	// missing limits, single-replica…) that fire on nearly every resource and
+	// would turn the badges into noise; those stay in the Checks/Audit views.
+	BadgeWorthy bool `json:"badgeWorthy,omitempty"`
 }
 
 // Reference is an authoritative link for a check (Kubernetes docs, CIS,

--- a/pkg/topology/auditkey.go
+++ b/pkg/topology/auditkey.go
@@ -1,0 +1,41 @@
+package topology
+
+import "github.com/skyhook-io/radar/pkg/resourceid"
+
+// collisionKindToK8sKind maps the disambiguated NodeKind labels Radar uses for
+// CRDs whose Kind collides with a core (or another) kind back to the real
+// Kubernetes Kind. The audit suite keys findings by the real Kind, so without
+// this remap a node like KindIstioGateway ("IstioGateway") would never match a
+// finding on "Gateway". For every non-collision node the NodeKind already IS the
+// K8s Kind. None of these collision kinds are audited today; this keeps topology
+// badges correct if one ever gains a check — the single place that needs to know.
+var collisionKindToK8sKind = map[NodeKind]string{
+	KindIstioGateway:         "Gateway",
+	KindKnativeService:       "Service",
+	KindKnativeConfiguration: "Configuration",
+	KindKnativeRevision:      "Revision",
+	KindKnativeRoute:         "Route",
+	KindCAPICluster:          "Cluster",
+}
+
+// stampAuditKeys annotates every node with the resource-identity key the audit
+// suite emits findings under (audit.ResourceKey == pkg/resourceid.ResourceKey),
+// so the frontend can join Cluster Audit findings onto topology nodes with a
+// single string lookup instead of re-deriving identity from apiVersion/kind
+// (which is fragile across the collision pseudo-kinds above). Group follows the
+// audit convention exactly: built-ins → their group, everything else → "".
+func stampAuditKeys(nodes []Node) []Node {
+	for i := range nodes {
+		k8sKind := string(nodes[i].Kind)
+		if real, ok := collisionKindToK8sKind[nodes[i].Kind]; ok {
+			k8sKind = real
+		}
+		if nodes[i].Data == nil {
+			nodes[i].Data = map[string]any{}
+		}
+		ns, _ := nodes[i].Data["namespace"].(string)
+		nodes[i].Data["auditKey"] = resourceid.ResourceKey(
+			resourceid.GroupForBuiltinKind(k8sKind), k8sKind, ns, nodes[i].Name)
+	}
+	return nodes
+}

--- a/pkg/topology/auditkey_test.go
+++ b/pkg/topology/auditkey_test.go
@@ -1,0 +1,27 @@
+package topology
+
+import "testing"
+
+func TestStampAuditKeys(t *testing.T) {
+	nodes := []Node{
+		{Kind: KindDeployment, Name: "api", Data: map[string]any{"namespace": "prod"}},
+		{Kind: "IngressRoute", Name: "r", Data: map[string]any{"namespace": "web"}},     // CRD → group ""
+		{Kind: KindIstioGateway, Name: "gw", Data: map[string]any{"namespace": "mesh"}}, // collision → real kind "Gateway"
+		{Kind: KindNamespace, Name: "team-a", Data: nil},                                // nil Data + cluster-scoped (no ns)
+	}
+
+	out := stampAuditKeys(nodes)
+
+	want := map[string]string{
+		"api":    "apps|Deployment|prod|api",
+		"r":      "|IngressRoute|web|r",
+		"gw":     "|Gateway|mesh|gw", // remapped from KindIstioGateway, group still "" (audit convention)
+		"team-a": "|Namespace||team-a",
+	}
+	for _, n := range out {
+		got, _ := n.Data["auditKey"].(string)
+		if got != want[n.Name] {
+			t.Errorf("auditKey for %q = %q, want %q", n.Name, got, want[n.Name])
+		}
+	}
+}

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -5229,7 +5229,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	// Summary mode: stamp collapsed pod counts onto their workload nodes.
 	stampPodSummaries(nodes, podSummaries)
 
-	topo := &Topology{Nodes: nodes, Edges: edges, Warnings: warnings}
+	topo := &Topology{Nodes: stampAuditKeys(nodes), Edges: edges, Warnings: warnings}
 
 	// Add CRD discovery status
 	if b.dynamic != nil {
@@ -6762,7 +6762,7 @@ func (b *Builder) buildTrafficTopology(opts BuildOptions) (*Topology, error) {
 		}
 	}
 
-	topo := &Topology{Nodes: nodes, Edges: edges, Warnings: warnings}
+	topo := &Topology{Nodes: stampAuditKeys(nodes), Edges: edges, Warnings: warnings}
 
 	// Add CRD discovery status
 	if b.dynamic != nil {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1270,7 +1270,10 @@ function AppInner() {
   // data.auditDanger. Re-runs only when findings change, and copies nodes only
   // when there are findings to attach — no overhead on clusters with none.
   const audit = useAudit(namespaces)
-  const auditSeverityMap = useMemo(() => buildAuditSeverityMap(audit.data?.findings), [audit.data?.findings])
+  const auditSeverityMap = useMemo(
+    () => buildAuditSeverityMap(audit.data?.findings, audit.data?.checks),
+    [audit.data?.findings, audit.data?.checks],
+  )
   const topologyWithAudit = useMemo((): Topology | null => {
     if (!filteredTopology) return null
     if (auditSeverityMap.size === 0) return filteredTopology

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1282,7 +1282,7 @@ function AppInner() {
       nodes: filteredTopology.nodes.map(node => {
         const counts = auditSeverityMap.get(node.data.auditKey as string)
         if (!counts) return node
-        return { ...node, data: { ...node.data, auditDanger: counts.danger, auditWarning: counts.warning } }
+        return { ...node, data: { ...node.data, auditDanger: counts.danger, auditWarning: counts.warning, auditMessages: counts.messages } }
       }),
     }
   }, [filteredTopology, auditSeverityMap])

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -44,7 +44,8 @@ import { ShortcutHelpOverlay } from './components/ui/ShortcutHelpOverlay'
 import { CommandPalette } from './components/ui/CommandPalette'
 import { DiagnosticsOverlay } from './components/ui/DiagnosticsOverlay'
 import { useEventSource } from './hooks/useEventSource'
-import { debugNamespaceLog, useNamespaces, useNamespaceScope, useSetActiveNamespace, useSwitchContext, useAuthMe } from './api/client'
+import { debugNamespaceLog, useNamespaces, useNamespaceScope, useSetActiveNamespace, useSwitchContext, useAuthMe, useAudit } from './api/client'
+import { buildAuditSeverityMap } from './utils/auditBadges'
 import { routePath, apiUrl, getAuthHeaders, getCredentialsMode } from './api/config'
 import { KeyboardShortcutProvider, useRegisterShortcut, useRegisterShortcuts } from './hooks/useKeyboardShortcuts'
 import { useAnimatedUnmount } from './hooks/useAnimatedUnmount'
@@ -1263,6 +1264,26 @@ function AppInner() {
     }
   }, [displayedTopology, visibleKinds, namespaces, topologyMode])
 
+  // Cluster Audit findings, joined onto topology nodes by the audit key the
+  // backend stamps on each node (data.auditKey). The graph surfaces DANGER only
+  // (warnings would turn a dense graph into a heatmap); the node component reads
+  // data.auditDanger. Re-runs only when findings change, and copies nodes only
+  // when there are findings to attach — no overhead on clusters with none.
+  const audit = useAudit(namespaces)
+  const auditSeverityMap = useMemo(() => buildAuditSeverityMap(audit.data?.findings), [audit.data?.findings])
+  const topologyWithAudit = useMemo((): Topology | null => {
+    if (!filteredTopology) return null
+    if (auditSeverityMap.size === 0) return filteredTopology
+    return {
+      ...filteredTopology,
+      nodes: filteredTopology.nodes.map(node => {
+        const counts = auditSeverityMap.get(node.data.auditKey as string)
+        if (!counts) return node
+        return { ...node, data: { ...node.data, auditDanger: counts.danger, auditWarning: counts.warning } }
+      }),
+    }
+  }, [filteredTopology, auditSeverityMap])
+
   // The graph node id of the currently open resource, used to highlight it on
   // the canvas. Looked up from the topology (not reconstructed) because node
   // ids are `<lowercaseKind>/<ns>/<name>` with special prefixes for CRD
@@ -1773,7 +1794,7 @@ function AppInner() {
 
                 <div className="flex-1 relative">
                   <TopologyGraph
-                    topology={filteredTopology}
+                    topology={topologyWithAudit}
                     viewMode={topologyMode}
                     groupingMode={effectiveGroupingMode}
                     hideGroupHeader={hideGroupHeader}

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useCallback, useEffect } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { ApiError, debugNamespaceLog, fetchJSON, isForbiddenError, useCapabilities, useNamespaceCapabilities, useSecretCertExpiry, useTopPodMetrics, useTopNodeMetrics, useBulkDeleteResources, useBulkRestartWorkloads, useBulkScaleWorkloads, useAudit } from '../../api/client'
+import { isBadgeWorthy } from '../../utils/auditBadges'
 import { apiUrl, getAuthHeaders, getCredentialsMode, getBasename } from '../../api/config'
 import { useAPIResources } from '../../api/apiResources'
 import { initNavigationMap } from '@skyhook-io/k8s-ui'
@@ -140,7 +141,9 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
   // Cluster Audit findings for the selected kind, keyed by "namespace/name" for
   // the resource list. The list shows ONE kind at a time, so ns/name is enough;
   // we still match the finding's group (built-ins → real group, CRDs → "") so a
-  // kind shared across groups doesn't bleed findings across the two lists.
+  // kind shared across groups doesn't bleed findings across the two lists. Only
+  // "badge-worthy" findings count (reference-integrity / lifecycle) — posture
+  // and best-practice nags fire near-universally and would just be noise.
   const audit = useAudit(namespaces)
   const auditBadges = useMemo(() => {
     if (!selectedKind || !audit.data?.findings) return undefined
@@ -148,6 +151,7 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
     const map: Record<string, { danger: number; warning: number }> = {}
     for (const f of audit.data.findings) {
       if (f.kind !== selectedKind.kind || (f.group ?? '') !== wantGroup) continue
+      if (!isBadgeWorthy(f, audit.data.checks)) continue
       const k = `${f.namespace || ''}/${f.name}`
       const cur = map[k] ?? { danger: 0, warning: 0 }
       if (f.severity === 'danger') cur.danger++
@@ -155,7 +159,7 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
       map[k] = cur
     }
     return map
-  }, [audit.data?.findings, selectedKind, isSelectedCrd])
+  }, [audit.data?.findings, audit.data?.checks, selectedKind, isSelectedCrd])
 
   const selectedCountKey = selectedKind ? resourceCountKey(selectedKind) : ''
   const selectedCount = selectedCountKey ? countsData?.counts[selectedCountKey] : undefined

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -138,6 +138,17 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
     return match?.isCrd ?? (!!selectedKind.group) // default: has group = likely CRD
   }, [selectedKind, apiResources])
 
+  // The canonical Kind for the selected resource. selectedKind.kind is the plural
+  // URL segment for CRDs/grouped kinds (e.g. "ingressroutes", "ingresses") — only
+  // core no-group kinds resolve to the real Kind there — so resolve it via
+  // discovery to match audit findings, which key by the real Kind ("IngressRoute").
+  const selectedKindCanonical = useMemo(() => {
+    if (!selectedKind) return undefined
+    const match = apiResources?.find(r => r.name === selectedKind.name && r.group === selectedKind.group)
+      ?? CORE_RESOURCES.find(r => r.name === selectedKind.name && r.group === selectedKind.group)
+    return match?.kind ?? selectedKind.kind
+  }, [selectedKind, apiResources])
+
   // Cluster Audit findings for the selected kind, keyed by "namespace/name" for
   // the resource list. The list shows ONE kind at a time, so ns/name is enough;
   // we still match the finding's group (built-ins → real group, CRDs → "") so a
@@ -150,7 +161,7 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
     const wantGroup = isSelectedCrd ? '' : selectedKind.group
     const map: Record<string, { danger: number; warning: number }> = {}
     for (const f of audit.data.findings) {
-      if (f.kind !== selectedKind.kind || (f.group ?? '') !== wantGroup) continue
+      if (f.kind !== selectedKindCanonical || (f.group ?? '') !== wantGroup) continue
       if (!isBadgeWorthy(f, audit.data.checks)) continue
       const k = `${f.namespace || ''}/${f.name}`
       const cur = map[k] ?? { danger: 0, warning: 0 }
@@ -159,7 +170,7 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
       map[k] = cur
     }
     return map
-  }, [audit.data?.findings, audit.data?.checks, selectedKind, isSelectedCrd])
+  }, [audit.data?.findings, audit.data?.checks, selectedKind, selectedKindCanonical, isSelectedCrd])
 
   const selectedCountKey = selectedKind ? resourceCountKey(selectedKind) : ''
   const selectedCount = selectedCountKey ? countsData?.counts[selectedCountKey] : undefined

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useCallback, useEffect } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { ApiError, debugNamespaceLog, fetchJSON, isForbiddenError, useCapabilities, useNamespaceCapabilities, useSecretCertExpiry, useTopPodMetrics, useTopNodeMetrics, useBulkDeleteResources, useBulkRestartWorkloads, useBulkScaleWorkloads } from '../../api/client'
+import { ApiError, debugNamespaceLog, fetchJSON, isForbiddenError, useCapabilities, useNamespaceCapabilities, useSecretCertExpiry, useTopPodMetrics, useTopNodeMetrics, useBulkDeleteResources, useBulkRestartWorkloads, useBulkScaleWorkloads, useAudit } from '../../api/client'
 import { apiUrl, getAuthHeaders, getCredentialsMode, getBasename } from '../../api/config'
 import { useAPIResources } from '../../api/apiResources'
 import { initNavigationMap } from '@skyhook-io/k8s-ui'
@@ -136,6 +136,26 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
       ?? CORE_RESOURCES.find(r => r.name === selectedKind.name && r.group === selectedKind.group)
     return match?.isCrd ?? (!!selectedKind.group) // default: has group = likely CRD
   }, [selectedKind, apiResources])
+
+  // Cluster Audit findings for the selected kind, keyed by "namespace/name" for
+  // the resource list. The list shows ONE kind at a time, so ns/name is enough;
+  // we still match the finding's group (built-ins → real group, CRDs → "") so a
+  // kind shared across groups doesn't bleed findings across the two lists.
+  const audit = useAudit(namespaces)
+  const auditBadges = useMemo(() => {
+    if (!selectedKind || !audit.data?.findings) return undefined
+    const wantGroup = isSelectedCrd ? '' : selectedKind.group
+    const map: Record<string, { danger: number; warning: number }> = {}
+    for (const f of audit.data.findings) {
+      if (f.kind !== selectedKind.kind || (f.group ?? '') !== wantGroup) continue
+      const k = `${f.namespace || ''}/${f.name}`
+      const cur = map[k] ?? { danger: 0, warning: 0 }
+      if (f.severity === 'danger') cur.danger++
+      else if (f.severity === 'warning') cur.warning++
+      map[k] = cur
+    }
+    return map
+  }, [audit.data?.findings, selectedKind, isSelectedCrd])
 
   const selectedCountKey = selectedKind ? resourceCountKey(selectedKind) : ''
   const selectedCount = selectedCountKey ? countsData?.counts[selectedCountKey] : undefined
@@ -294,6 +314,7 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
       topNodeMetrics={topNodeMetrics}
       certExpiry={certExpiry}
       certExpiryError={certExpiryError}
+      auditBadges={auditBadges}
       // Pinned kinds
       pinned={pinned}
       togglePin={togglePin}

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { ApiError, debugNamespaceLog, fetchJSON, isForbiddenError, useCapabilities, useNamespaceCapabilities, useSecretCertExpiry, useTopPodMetrics, useTopNodeMetrics, useBulkDeleteResources, useBulkRestartWorkloads, useBulkScaleWorkloads, useAudit } from '../../api/client'
 import { isBadgeWorthy } from '../../utils/auditBadges'
+import type { AuditBadgeMessage } from '@skyhook-io/k8s-ui'
 import { apiUrl, getAuthHeaders, getCredentialsMode, getBasename } from '../../api/config'
 import { useAPIResources } from '../../api/apiResources'
 import { initNavigationMap } from '@skyhook-io/k8s-ui'
@@ -159,15 +160,19 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
   const auditBadges = useMemo(() => {
     if (!selectedKind || !audit.data?.findings) return undefined
     const wantGroup = isSelectedCrd ? '' : selectedKind.group
-    const map: Record<string, { danger: number; warning: number }> = {}
+    const map: Record<string, { danger: number; warning: number; messages: AuditBadgeMessage[] }> = {}
     for (const f of audit.data.findings) {
       if (f.kind !== selectedKindCanonical || (f.group ?? '') !== wantGroup) continue
       if (!isBadgeWorthy(f, audit.data.checks)) continue
       const k = `${f.namespace || ''}/${f.name}`
-      const cur = map[k] ?? { danger: 0, warning: 0 }
+      const cur = map[k] ?? { danger: 0, warning: 0, messages: [] }
       if (f.severity === 'danger') cur.danger++
       else if (f.severity === 'warning') cur.warning++
+      cur.messages.push({ severity: f.severity, message: f.message })
       map[k] = cur
+    }
+    for (const cur of Object.values(map)) {
+      cur.messages.sort((a, b) => (a.severity === 'danger' ? 0 : 1) - (b.severity === 'danger' ? 0 : 1))
     }
     return map
   }, [audit.data?.findings, audit.data?.checks, selectedKind, selectedKindCanonical, isSelectedCrd])

--- a/web/src/utils/auditBadges.ts
+++ b/web/src/utils/auditBadges.ts
@@ -1,0 +1,27 @@
+import { resourceKey, type AuditFinding } from '@skyhook-io/k8s-ui'
+
+export interface AuditSeverityCounts {
+  danger: number
+  warning: number
+}
+
+/**
+ * buildAuditSeverityMap keys audit findings by the same resource key the backend
+ * stamps onto topology nodes (`node.data.auditKey`) and the resource list
+ * computes per row: `group|Kind|namespace|name`, group following the audit
+ * convention (built-ins → their group, CRDs → ""). Lets the topology/list
+ * surfaces join Cluster Audit findings with a single string lookup.
+ */
+export function buildAuditSeverityMap(
+  findings: AuditFinding[] | undefined,
+): Map<string, AuditSeverityCounts> {
+  const map = new Map<string, AuditSeverityCounts>()
+  for (const f of findings ?? []) {
+    const key = resourceKey(f.group ?? '', f.kind, f.namespace ?? '', f.name)
+    const cur = map.get(key) ?? { danger: 0, warning: 0 }
+    if (f.severity === 'danger') cur.danger++
+    else if (f.severity === 'warning') cur.warning++
+    map.set(key, cur)
+  }
+  return map
+}

--- a/web/src/utils/auditBadges.ts
+++ b/web/src/utils/auditBadges.ts
@@ -1,4 +1,4 @@
-import { resourceKey, type AuditFinding } from '@skyhook-io/k8s-ui'
+import { resourceKey, type AuditFinding, type CheckMeta } from '@skyhook-io/k8s-ui'
 
 export interface AuditSeverityCounts {
   danger: number
@@ -6,17 +6,31 @@ export interface AuditSeverityCounts {
 }
 
 /**
- * buildAuditSeverityMap keys audit findings by the same resource key the backend
- * stamps onto topology nodes (`node.data.auditKey`) and the resource list
- * computes per row: `group|Kind|namespace|name`, group following the audit
- * convention (built-ins → their group, CRDs → ""). Lets the topology/list
- * surfaces join Cluster Audit findings with a single string lookup.
+ * isBadgeWorthy keeps per-resource badges high-signal: only findings whose check
+ * is flagged `badgeWorthy` in the registry (reference-integrity / lifecycle —
+ * "this resource is actually broken") count. Security-posture and best-practice
+ * checks fire on nearly every resource and would turn the badges into noise;
+ * they live in the Checks/Audit views. Unknown checks default to NOT badged.
+ */
+export function isBadgeWorthy(
+  finding: AuditFinding,
+  checks: Record<string, CheckMeta> | undefined,
+): boolean {
+  return !!checks?.[finding.checkID]?.badgeWorthy
+}
+
+/**
+ * buildAuditSeverityMap keys badge-worthy findings by the same resource key the
+ * backend stamps onto topology nodes (`node.data.auditKey`): `group|Kind|ns|name`,
+ * group following the audit convention (built-ins → their group, CRDs → "").
  */
 export function buildAuditSeverityMap(
   findings: AuditFinding[] | undefined,
+  checks: Record<string, CheckMeta> | undefined,
 ): Map<string, AuditSeverityCounts> {
   const map = new Map<string, AuditSeverityCounts>()
   for (const f of findings ?? []) {
+    if (!isBadgeWorthy(f, checks)) continue
     const key = resourceKey(f.group ?? '', f.kind, f.namespace ?? '', f.name)
     const cur = map.get(key) ?? { danger: 0, warning: 0 }
     if (f.severity === 'danger') cur.danger++

--- a/web/src/utils/auditBadges.ts
+++ b/web/src/utils/auditBadges.ts
@@ -1,8 +1,16 @@
 import { resourceKey, type AuditFinding, type CheckMeta } from '@skyhook-io/k8s-ui'
 
+export interface AuditBadgeMessage {
+  severity: string
+  message: string
+}
+
 export interface AuditSeverityCounts {
   danger: number
   warning: number
+  /** The finding messages behind the counts, danger-first, for inline tooltips.
+   *  Lets a badge say WHAT is wrong on hover instead of just a count. */
+  messages: AuditBadgeMessage[]
 }
 
 /**
@@ -32,10 +40,14 @@ export function buildAuditSeverityMap(
   for (const f of findings ?? []) {
     if (!isBadgeWorthy(f, checks)) continue
     const key = resourceKey(f.group ?? '', f.kind, f.namespace ?? '', f.name)
-    const cur = map.get(key) ?? { danger: 0, warning: 0 }
+    const cur = map.get(key) ?? { danger: 0, warning: 0, messages: [] }
     if (f.severity === 'danger') cur.danger++
     else if (f.severity === 'warning') cur.warning++
+    cur.messages.push({ severity: f.severity, message: f.message })
     map.set(key, cur)
+  }
+  for (const cur of map.values()) {
+    cur.messages.sort((a, b) => (a.severity === 'danger' ? 0 : 1) - (b.severity === 'danger' ? 0 : 1))
   }
   return map
 }


### PR DESCRIPTION
## Summary

A resource that's **actually broken** — a dangling Traefik/Ingress backend ref, a Service whose selector resolves to no pods, a deprecated API that breaks on upgrade — was invisible everywhere an operator looks: it showed only in its own drawer, while the topology graph and resource list rendered it healthy. This surfaces those findings as a per-resource badge on both surfaces, fixes a pre-existing bug that hid built-in findings from the drawer, and removes a column that was contradicting the badge.

Composes with the health consolidation (#1024): that owns *runtime* health (is it running); this owns *cross-resource ref-integrity + upgrade-risk* (does its config reference things that exist). Different axes, no overlap.

## Keeping it a signal, not noise

Audit also emits posture/best-practice findings (`runAsRoot`, missing limits, single-replica) that fire on nearly every resource — *any-finding* badged **112** resources on a real staging namespace. So badges are gated on a registry **`badgeWorthy`** flag, true only for the 8 checks that mean a specific resource is broken: the 4 Traefik dangling-ref checks, `ingressNoMatchingService`, `serviceNoMatchingPods`, `deprecatedAPIVersion`, `crossplaneStuck`. Same namespace: **112 → 15** badged resources. (`stuckTerminating` was intentionally excluded — #1024's health pipeline already renders it degraded, and the name cell shows a "Terminating" chip; a badge would be a third redundant signal.)

## What changed

**Backend**
- `badgeWorthy` flag on the check registry (`pkg/checks` `CheckMeta` + `pkg/audit/registry.go`), exposed via the audit catalog the frontend already receives — curation lives with the checks, no drifting frontend list.
- Topology builder stamps each node with `data.auditKey` (`group|Kind|ns|name`, audit convention; collision pseudo-kinds like `IstioGateway`→`Gateway` remapped) so the frontend joins findings by one string lookup.
- **Drawer fix**: the per-resource endpoint looked up `group=""`, so built-in findings keyed under a real group (`Deployment`→`apps`) never reached the drawer. Now resolves via `GroupForBuiltinKind`.

**Frontend**
- **Topology** (`K8sResourceNode`) + **resource list** (`ResourcesView`): a per-resource indicator (triangle / name-cell badge) for badge-worthy findings only, colored by worst severity (danger red / warning amber). Injected via the existing context; audit is one React-Query fetch, deduped. Hovering a badge lists the actual finding messages inline (shared `AuditBadgeTooltip`, danger-first, capped) — the operator reads *what* is wrong without opening the drawer.
- **Service Endpoints column**: previously guessed a green "Active" for any service with a selector (it can't see live pods), contradicting the `serviceNoMatchingPods` badge on the same row. Now consumes that audit check and shows "No endpoints" when the selector resolves to nothing — column and badge agree.

## Testing

- Rebased on #1024 (clean). `make tsc` ✓ · k8s-ui vitest **674** (incl. ratchet + `stampAuditKeys`) ✓ · Go `pkg/{checks,audit,topology,health}` + `internal/server` ✓
- **Live-verified** (real GKE cluster): curation cuts **112 → 15** badged resources; Deployments list shows **0** badges (posture noise gone); a broken Service badges + its Endpoints column reads "No endpoints" instead of green "Active"; drawer endpoint returns built-in findings (was 0 pre-fix). Light + dark.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches audit API lookup semantics and topology/list UX; changes are additive with defensive fallback lookup, but incorrect keying could still miss or mis-attach badges.
> 
> **Overview**
> High-signal **Cluster Audit** findings (broken refs, missing backends, deprecated APIs) now show on the **topology graph** and **resource list**, not only in the audit drawer.
> 
> A registry **`badgeWorthy`** flag limits badges to reference-integrity / lifecycle checks so posture noise (`runAsRoot`, missing limits, etc.) stays in Audit views. Topology nodes get **`data.auditKey`** from the builder; the web app joins findings via `buildAuditSeverityMap` and injects counts into `K8sResourceNode` and `ResourcesView` name cells. **Service** rows override the optimistic green **Endpoints** column when `serviceNoMatchingPods` fired.
> 
> **Drawer fix:** `handleAuditResource` now resolves built-in kinds with `GroupForBuiltinKind` instead of `group=""`, so findings keyed under `apps`, `batch`, etc. appear again.
> 
> `AuditFinding.group` and `CheckMeta.badgeWorthy` are exposed on the shared k8s-ui types for joins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40d9143cae7833d94fc21413139492000f989e79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->