### PR TITLE
fix(k8s-ui): make image asset imports bundler-agnostic

### DIFF
--- a/packages/k8s-ui/src/components/ui/ClusterName.tsx
+++ b/packages/k8s-ui/src/components/ui/ClusterName.tsx
@@ -3,10 +3,18 @@ import { MiddleEllipsis } from './MiddleEllipsis'
 import { Tooltip } from './Tooltip'
 import { parseContextName } from '../../utils/context-name'
 import type { ParsedContextName } from '../../utils/context-name'
-import awsLogo from './provider-logos/aws.png'
-import awsLogoDark from './provider-logos/aws-dark.png'
-import gcpLogo from './provider-logos/gcp.png'
-import azureLogo from './provider-logos/azure.svg'
+import { assetUrl } from '../../utils/asset-url'
+import awsLogoAsset from './provider-logos/aws.png'
+import awsLogoDarkAsset from './provider-logos/aws-dark.png'
+import gcpLogoAsset from './provider-logos/gcp.png'
+import azureLogoAsset from './provider-logos/azure.svg'
+
+// assetUrl normalizes the bundler-specific asset-import type (string under Vite,
+// StaticImageData under webpack/Next) to a URL string usable in `<img src>`.
+const awsLogo = assetUrl(awsLogoAsset)
+const awsLogoDark = assetUrl(awsLogoDarkAsset)
+const gcpLogo = assetUrl(gcpLogoAsset)
+const azureLogo = assetUrl(azureLogoAsset)
 
 // ClusterName renders a kubectl context string with the meaningful
 // cluster identity surfaced as primary text and provider/region pushed

--- a/packages/k8s-ui/src/components/ui/PaneLoader.tsx
+++ b/packages/k8s-ui/src/components/ui/PaneLoader.tsx
@@ -1,4 +1,9 @@
-import radarLoadingIcon from '../../assets/radar/radar-icon-loading.svg'
+import { assetUrl } from '../../utils/asset-url'
+import radarLoadingIconAsset from '../../assets/radar/radar-icon-loading.svg'
+
+// assetUrl normalizes the bundler-specific asset-import type (string under Vite,
+// StaticImageData under webpack/Next) to a URL string usable in `<img src>`.
+const radarLoadingIcon = assetUrl(radarLoadingIconAsset)
 
 // PaneLoader — center-of-pane loading state. Animated radar icon stacked
 // above a label so swapping the label across the loading chain doesn't

--- a/packages/k8s-ui/src/utils/asset-url.ts
+++ b/packages/k8s-ui/src/utils/asset-url.ts
@@ -1,0 +1,13 @@
+// k8s-ui ships TS source, so each consumer's bundler types asset imports
+// differently: Vite resolves `import x from './x.png'` to a URL string, while
+// webpack/Next resolves it to a StaticImageData object. Reading `.src` off the
+// object (vs Vite's bare string) yields the bundler's own emitted URL, which is
+// the one that's correct in both client and SSR output — unlike
+// `new URL(asset, import.meta.url)`, which can produce a `file://` URL under SSR.
+// The structural `{ src: string }` type matches Next's StaticImageData without
+// depending on the Next-only type, so this also type-checks under Vite.
+export type AssetImport = string | { src: string }
+
+export function assetUrl(asset: AssetImport): string {
+  return typeof asset === 'string' ? asset : asset.src
+}


### PR DESCRIPTION
## What
`ClusterName` and `PaneLoader` imported their logos via default asset imports (`import logo from './x.png'`). Those resolve to a **URL string under Vite** but a **`StaticImageData` object under webpack/Next**. For non-Vite consumers (koala-frontend consumes k8s-ui *source* via `transpilePackages`) that broke:
- `tsc` — `StaticImageData` not assignable to the `string` logo fields
- `next build` — same type error fails the production build
- runtime — `<img src={StaticImageData}>` renders broken

## Fix
Normalize through a small `assetUrl()` helper: pass through Vite's string, or read `.src` off the `StaticImageData` object. This uses each bundler's **native** asset pipeline, so the emitted URL is correct in both client and SSR output — unlike `new URL(asset, import.meta.url)`, which can emit a `file://` URL under SSR (Vite documents this; webpack `target:node` uses a file base).

The structural `{ src: string }` type matches Next's `StaticImageData` without depending on the Next-only type, so it also type-checks under radar's own Vite build.

## Validation
- radar's own consumption is Vite (string passthrough) — unchanged behavior.
- Validated end-to-end against koala-frontend (Next/webpack via `transpilePackages`): packed this branch, installed into koala-frontend → `tsc` 0 errors **and** `next build` compiled successfully.

## Context
Enables koala-frontend to upgrade `@skyhook-io/k8s-ui` past 1.2.x. Requires publishing a new `@skyhook-io/k8s-ui` (1.8.6) for consumers to pick up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to how two components resolve static asset URLs; Vite behavior is unchanged and risk is mainly in image rendering for Next/webpack consumers.
> 
> **Overview**
> Adds **`assetUrl()`** in `utils/asset-url.ts` so default image imports work whether the consumer’s bundler types them as a URL **string** (Vite) or a **`{ src }` object** (webpack/Next). **`ClusterName`** and **`PaneLoader`** route their logo/SVG imports through that helper before using them in `<img src>`.
> 
> Vite consumers still get string passthrough; Next/webpack consumers that transpile k8s-ui source get valid types and runtime URLs without relying on `import.meta.url` (which can misbehave under SSR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fad74cebc130406d86b0edc7e003c51c049fb425. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->