### PR TITLE
fix(loader): keep the loading logo stable across the cluster-entry chain (+ repair stray NUL)

### DIFF
--- a/packages/k8s-ui/src/components/ui/PaneLoader.tsx
+++ b/packages/k8s-ui/src/components/ui/PaneLoader.tsx
@@ -26,7 +26,11 @@ export function PaneLoader({
           label is absolutely positioned below the icon and so never shifts it. */}
       <span className="relative">
         <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
-        <span className="absolute left-1/2 top-full mt-3 -translate-x-1/2 whitespace-nowrap text-sm text-theme-text-tertiary">
+        {/* Label style matches the splash surfaces (17px semibold tracking-tight,
+            primary) so the whole loading family — boot splash, connect splash,
+            PaneLoader — reads as one continuous state, not a font change at the
+            hand-off. */}
+        <span className="absolute left-1/2 top-full mt-3 -translate-x-1/2 whitespace-nowrap text-[17px] font-semibold tracking-tight text-theme-text-primary">
           {label}
         </span>
       </span>

--- a/packages/k8s-ui/src/components/ui/PaneLoader.tsx
+++ b/packages/k8s-ui/src/components/ui/PaneLoader.tsx
@@ -17,8 +17,11 @@ export function PaneLoader({
   label?: string
   className?: string
 }) {
+  // No `relative` on the root: the label anchors to the inner `relative` span
+  // below, and callers may pass a positioning class (e.g. `absolute inset-0`,
+  // for topology panes) — a root `relative` would conflict with it.
   return (
-    <div className={`relative flex items-center justify-center ${className}`} aria-live="polite">
+    <div className={`flex items-center justify-center ${className}`} aria-live="polite">
       {/* The icon is the only in-flow child, so it centers in the pane. The
           label is absolutely positioned below the icon and so never shifts it. */}
       <span className="relative">

--- a/packages/k8s-ui/src/components/ui/PaneLoader.tsx
+++ b/packages/k8s-ui/src/components/ui/PaneLoader.tsx
@@ -1,8 +1,13 @@
 import radarLoadingIcon from '../../assets/radar/radar-icon-loading.svg'
 
-// PaneLoader — center-of-pane loading state. Animated radar icon stacked
-// above a label so swapping the label across the loading chain doesn't
-// shift the icon horizontally. Pin to the parent's fill via `className`
+// PaneLoader — center-of-pane loading state. The animated radar icon is
+// pinned to the pane's exact center; the label hangs at a fixed offset
+// BELOW it, absolutely positioned (not a flex sibling), so the label never
+// affects where the icon sits. The icon therefore holds a single position
+// while only the text under it appears/changes — and it lands at the same
+// point as the host/connect splash surfaces (which center the icon at 50%
+// with the label decoupled below), so a splash → PaneLoader hand-off no
+// longer makes the logo jump. Pin to the parent's fill via `className`
 // (`flex-1`, `h-full`, `h-32`, `absolute inset-0`, etc.). The SVG self-
 // animates (sweep arm + blips, `prefers-reduced-motion` honored).
 export function PaneLoader({
@@ -13,9 +18,15 @@ export function PaneLoader({
   className?: string
 }) {
   return (
-    <div className={`flex flex-col items-center justify-center gap-3 ${className}`}>
-      <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
-      <span className="text-sm text-theme-text-tertiary">{label}</span>
+    <div className={`relative flex items-center justify-center ${className}`} aria-live="polite">
+      {/* The icon is the only in-flow child, so it centers in the pane. The
+          label is absolutely positioned below the icon and so never shifts it. */}
+      <span className="relative">
+        <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
+        <span className="absolute left-1/2 top-full mt-3 -translate-x-1/2 whitespace-nowrap text-sm text-theme-text-tertiary">
+          {label}
+        </span>
+      </span>
     </div>
   )
 }

--- a/packages/k8s-ui/src/components/workload/WorkloadView.tsx
+++ b/packages/k8s-ui/src/components/workload/WorkloadView.tsx
@@ -636,7 +636,9 @@ export function WorkloadView({
         {/* Content — viewTransitionName scopes View Transitions API cross-fade to this element */}
         <div className="flex-1 overflow-y-auto" style={{ viewTransitionName: 'drawer-content' }}>
           {!resource ? (
-            <FetchResult loading={resourceLoading} error={resourceError} className="h-32" />
+            // Fill the drawer body so the loading logo centers in it, not in a
+            // 128px box pinned to the top (matches the splash/PaneLoader centering).
+            <FetchResult loading={resourceLoading} error={resourceError} className="h-full" />
           ) : showYaml ? (
             <EditableYamlView
               resource={selectedResource}
@@ -881,7 +883,7 @@ export function WorkloadView({
               {yamlObject && !yamlObject.primary && renderRelatedYaml ? (
                 renderRelatedYaml(yamlObject)
               ) : !resource ? (
-                <FetchResult loading={resourceLoading} error={resourceError} className="h-32" />
+                <FetchResult loading={resourceLoading} error={resourceError} className="h-full" />
               ) : (
                 <EditableYamlView
                   resource={selectedResource}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -724,6 +724,16 @@ function AppInner() {
   // Connection state (for graceful startup)
   const { connection, retry: retryConnection, isRetrying, updateFromSSE: updateConnectionFromSSE } = useConnection()
 
+  // The app's content surface is ready to show: auth resolved, not mid context-
+  // switch, and the cluster connection is live. The main content area gates on
+  // exactly this, and so do the overlay drawers — otherwise a deep-link/refresh
+  // with `?resource=`/`?release=` renders the drawer on top of the connecting/
+  // switching splash, pushing the centered loading logo off-center and showing an
+  // empty drawer over a not-yet-loaded view. Gating both on the SAME readiness so
+  // a drawer only ever sits over a real content surface.
+  const contentReady = !isSwitching && !authMePending &&
+    !(authMe?.authEnabled && !authMe?.username) && connection.state === 'connected'
+
   // Query client for cache invalidation
   const queryClient = useQueryClient()
 
@@ -1674,7 +1684,7 @@ function AppInner() {
       )}
 
       {/* Main content - only show when connected and authenticated */}
-      {!isSwitching && !authMePending && !(authMe?.authEnabled && !authMe?.username) && connection.state === 'connected' && <div className="flex-1 flex overflow-hidden">
+      {contentReady && <div className="flex-1 flex overflow-hidden">
         <ErrorBoundary>
         {/* Home dashboard */}
         {mainView === 'home' && (
@@ -1982,8 +1992,10 @@ function AppInner() {
         </ErrorBoundary>
       </div>}
 
-      {/* Resource detail drawer — stays mounted, expands to full-screen WorkloadView */}
-      {resourceDrawer.shouldRender && drawerResource && (
+      {/* Resource detail drawer — stays mounted, expands to full-screen WorkloadView.
+          Gated on contentReady so it never renders over the connecting/switching
+          splash (which would push the centered logo off-center). */}
+      {contentReady && resourceDrawer.shouldRender && drawerResource && (
         <ResourceDetailDrawer
           resource={drawerResource}
           initialTab={drawerInitialTab}
@@ -2007,8 +2019,8 @@ function AppInner() {
         />
       )}
 
-      {/* Helm release drawer */}
-      {helmDrawer.shouldRender && drawerHelmRelease && (
+      {/* Helm release drawer — same contentReady gate as the resource drawer. */}
+      {contentReady && helmDrawer.shouldRender && drawerHelmRelease && (
         <HelmReleaseDrawer
           release={drawerHelmRelease}
           isOpen={helmDrawer.isOpen}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -133,12 +133,12 @@ function AuthBarrier({ authMode }: { authMode: string }) {
   if (authMode === 'oidc') {
     return (
       <div className="flex-1 relative bg-theme-base">
-        <div className="fixed inset-0 pointer-events-none">
+        <div className="absolute inset-0 pointer-events-none">
           <img
             src={radarLoadingIcon}
             alt=""
             aria-hidden
-            // Integer offset (vw/2 − 22) — matches the Connecting/Opening splashes;
+            // Integer offset (50% − 22) — matches the Connecting/Opening splashes;
             // avoids sub-pixel jitter from translate(-50%) on odd-width viewports.
             className="absolute w-11 h-11"
             style={{ left: 'calc(50% - 22px)', top: 'calc(50% - 22px)' }}
@@ -182,7 +182,7 @@ function AuthBarrier({ authMode }: { authMode: string }) {
 // detail to list would otherwise leave the peek orphaned. Only `app` is included
 // (not the whole query) so filter/tab/namespace churn doesn't close the peek.
 function peekOwnerKey(pathname: string, search: string): string {
-  return `${pathname} ${new URLSearchParams(search).get('app') ?? ''}`
+  return `${pathname}\n${new URLSearchParams(search).get('app') ?? ''}`
 }
 
 function AppInner() {
@@ -1579,20 +1579,20 @@ function AppInner() {
       )}
 
       {/* Connecting view — shown during initial connection or retry.
-          Icon is viewport-anchored so its screen position matches the
+          Icon is pane-anchored so its screen position matches the
           host hub splash across cross-document transitions. */}
       {!isSwitching && !(authMe?.authEnabled && !authMe?.username) && connection.state === 'connecting' && (
         <div className="flex-1 relative bg-theme-base">
-          {/* Icon absolutely anchored to viewport-center. The label block
+          {/* Icon absolutely anchored to the pane center. The label block
               sits at a fixed offset below — independent of label height
               so multi-line messages (context + progress) don't shift the
               icon's screen position. */}
-          <div className="fixed inset-0 pointer-events-none">
+          <div className="absolute inset-0 pointer-events-none">
             <img
               src={radarLoadingIcon}
               alt=""
               aria-hidden
-              // Integer offset (vw/2 − 22) — avoids sub-pixel jitter from
+              // Integer offset (50% − 22) — avoids sub-pixel jitter from
               // `translate(-50%, -50%)` on odd-width viewports.
               className="absolute w-11 h-11"
               style={{ left: 'calc(50% - 22px)', top: 'calc(50% - 22px)' }}
@@ -1620,15 +1620,15 @@ function AppInner() {
         </div>
       )}
 
-      {/* Context switching overlay — icon viewport-anchored, label below. */}
+      {/* Context switching overlay — icon pane-anchored, label below. */}
       {isSwitching && (
         <div className="flex-1 relative bg-theme-base">
-          <div className="fixed inset-0 pointer-events-none">
+          <div className="absolute inset-0 pointer-events-none">
             <img
               src={radarLoadingIcon}
               alt=""
               aria-hidden
-              // Integer offset (vw/2 − 22) — avoids sub-pixel jitter from
+              // Integer offset (50% − 22) — avoids sub-pixel jitter from
               // `translate(-50%, -50%)` on odd-width viewports.
               className="absolute w-11 h-11"
               style={{ left: 'calc(50% - 22px)', top: 'calc(50% - 22px)' }}
@@ -1926,7 +1926,7 @@ function AppInner() {
           <div className="flex-1 relative bg-theme-base">
             {/* Viewport-anchored, 17px — identical to the "Connecting" splash so
                 the mark doesn't move or resize across the takeover hand-off. */}
-            <div className="fixed inset-0 pointer-events-none">
+            <div className="absolute inset-0 pointer-events-none">
               <img
                 src={radarLoadingIcon}
                 alt=""


### PR DESCRIPTION
## Summary

Entering a cluster, the radar loading logo **jumped** through the loading chain — it shifted position, changed size/weight, and got pushed off-center by an empty drawer. This makes the whole chain (boot splash → connect splash → content `PaneLoader`) present **one stable, centered logo**: the icon holds a single position and only the text under it changes.

## What changed (each was a distinct jump)

1. **Anchor to the content pane, not the viewport.** The transient splashes (connecting / switching / opening / auth-redirect) centered the icon in the *viewport* (`fixed inset-0`) while `PaneLoader` centers in the *content pane*, so the logo snapped ~120px right + down at the splash→content hand-off. The splashes now use `absolute inset-0` (their wrapper is already the content pane), auto-adapting to rail width.
2. **`PaneLoader` icon-centered.** It stack-centered icon+label, leaving the icon ~16px above the pane center vs the splash. It now pins the **icon** at the pane center with the label absolutely below — the icon never moves when the label changes; only the text does. (Root `relative` dropped so callers' `absolute inset-0` — topology panes — still fill correctly.)
3. **Label matches the splash style.** PaneLoader's label was `text-sm`/normal/tertiary while every other loading surface is 17px semibold tracking-tight primary — so the text visibly shrank/de-weighted at the hand-off and read as a font change. Unified to the splash style.
4. **Overlay drawers gated on content readiness.** A deep-link / refresh with `?resource=` / `?release=` rendered the drawer during the `connecting` splash → empty drawer over a loading view, pushing the centered logo off-center. Extracted a `contentReady` boolean (auth resolved, not mid context-switch, connection connected — the same gate the main content used) and applied it to the content area **and** both drawers, so a drawer only ever sits over a real content surface.

## Also: repaired a stray NUL byte (regression from #1007)

`peekOwnerKey` used a literal `\0` as its string separator (a tool slip) — functionally a valid delimiter (compiled, shipped in `radar-app@1.8.1`) but source corruption that makes grep/rg treat `App.tsx` as binary. Swapped for a visible `\n`.

## Testing

- `tsc` (web + k8s-ui) clean; web build clean.
- **Measured** (standalone + embedded hub): splash icon & PaneLoader icon land at the same pane-center (e.g. 1066/1070, 482 in the 240px-rail hub), icon unmoved across a long label change; old stack-centered sat 16px high. Bugbot's `absolute inset-0` regression measured fixed (600×44 → 600×400 filling the pane). PaneLoader label computes identical to the splash (17px/600/DM Sans).
- **Embedded hub end-to-end** (local stack, real cluster): RadarApp renders clean (0 errors), drawer opens normally when connected, deep-link no longer drops the drawer over the connecting splash.

## Scope notes (deliberately out)

- **Inner-sidebar anchoring** (Resources/Topology/etc. center their data-pane loader right of their inner sidebar): left as-is — inner sidebars are persistent chrome, the loader-in-data-pane is the standard pattern, and a blanket hoist fights it + risks partial-refresh cases.
- Slide-in (vs pop) for the deferred drawer: the drawer materializes with content on deep-link/refresh, which is appropriate for restored state; a slide-in would need a hook reorder, deferred.

Pairs with hub **radar-hub-web #152** (the hub-side `RadarSplash` anchor). Ships together via the `radar-app` / `k8s-ui` republish + hub pin bump.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and render-gating only; no auth, data, or API behavior changes beyond deferring drawers until the cluster is connected.
> 
> **Overview**
> **Keeps the radar loading logo in one place** through boot/connect splashes, in-pane loaders, and drawer fetches so cluster entry no longer looks like the icon jumps or the typography changes mid-chain.
> 
> **`PaneLoader`** now centers only the icon in the pane and places the label absolutely below it (label text changes no longer shift the icon). Label styling matches the splash surfaces (17px semibold primary). Root layout avoids conflicting with callers’ `absolute inset-0`.
> 
> **App splashes** (connecting, context switch, auth redirect, takeover) switch from viewport-anchored `fixed inset-0` to **pane-anchored** `absolute inset-0` so the icon aligns with `PaneLoader` and embedded hub rails.
> 
> **`contentReady`** gates main content and both resource/Helm drawers (auth resolved, not switching context, connection connected) so deep-links with `?resource=` / `?release=` no longer open an empty drawer over the connecting splash and push the logo off-center.
> 
> **`WorkloadView`** drawer/YAML loading uses `h-full` instead of `h-32` so fetch spinners center in the drawer body.
> 
> **`peekOwnerKey`** replaces a stray NUL separator with `\n` (source/grep hygiene).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cb4192d60bf4b112a6eb29653ae18792496f0dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->