### PR TITLE
feat(health): frontend neutral/sky tier + neutral on every wire + cross-lang golden gate

### DIFF
--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -696,12 +696,21 @@ func extractTimelineHistoricalEvents(kind, apiVersion, namespace, name string, o
 					job.Status.StartTime.Time, "started", "", timeline.HealthDegraded, owner, labels))
 			}
 			if job.Status.CompletionTime != nil && !job.Status.CompletionTime.IsZero() {
-				health := timeline.HealthHealthy
-				if job.Status.Failed > 0 {
-					health = timeline.HealthUnhealthy
-				}
+				// CompletionTime is set only on SUCCESS — a completed Job is
+				// neutral/idle (done by design), even if earlier attempts failed
+				// (Status.Failed > 0 counts retries, not a terminal failure).
 				events = append(events, timeline.NewHistoricalEvent(kind, apiVersion, namespace, name,
-					job.Status.CompletionTime.Time, "completed", "", health, owner, labels))
+					job.Status.CompletionTime.Time, "completed", "", timeline.HealthNeutral, owner, labels))
+			} else {
+				// Terminal failure (backoffLimit exceeded) has no CompletionTime —
+				// surface the JobFailed condition as unhealthy at its transition time.
+				for _, cond := range job.Status.Conditions {
+					if cond.Type == batchv1.JobFailed && cond.Status == corev1.ConditionTrue {
+						events = append(events, timeline.NewHistoricalEvent(kind, apiVersion, namespace, name,
+							cond.LastTransitionTime.Time, "failed", cond.Message, timeline.HealthUnhealthy, owner, labels))
+						break
+					}
+				}
 			}
 		}
 

--- a/internal/k8s/timeline_health.go
+++ b/internal/k8s/timeline_health.go
@@ -32,15 +32,15 @@ func classifyTimelineHealth(kind string, obj any, now time.Time) timeline.Health
 }
 
 // levelToTimeline projects a canonical health.Level onto the timeline's wire
-// HealthState vocabulary. The timeline wire stays four-valued in this change, so
-// neutral (intentional/lifecycle states — scaled-to-zero, completed) collapses to
-// healthy, preserving the pre-consolidation behavior where those were recorded
-// healthy. The dedicated neutral tier — and the frontend rendering for it — lands
-// in the follow-up that owns the wire + UI together.
+// HealthState vocabulary. neutral (intentional/lifecycle states — scaled-to-zero,
+// completed, suspended) maps to the dedicated HealthNeutral so the timeline draws
+// a sky span instead of a false-green healthy one.
 func levelToTimeline(l health.Level) timeline.HealthState {
 	switch l {
-	case health.LevelHealthy, health.LevelNeutral:
+	case health.LevelHealthy:
 		return timeline.HealthHealthy
+	case health.LevelNeutral:
+		return timeline.HealthNeutral
 	case health.LevelDegraded:
 		return timeline.HealthDegraded
 	case health.LevelUnhealthy:

--- a/internal/k8s/timeline_health_test.go
+++ b/internal/k8s/timeline_health_test.go
@@ -20,9 +20,9 @@ func TestClassifyTimelineHealthPod(t *testing.T) {
 		want timeline.HealthState
 	}{
 		{
-			name: "succeeded pod is healthy (completed; neutral collapses on the wire)",
+			name: "succeeded pod is neutral (completed — intentional, sky span)",
 			pod:  &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodSucceeded}},
-			want: timeline.HealthHealthy,
+			want: timeline.HealthNeutral,
 		},
 		{
 			// The reported bug: a Job pod completing — phase still Running, container
@@ -93,16 +93,16 @@ func TestClassifyTimelineHealthWorkloads(t *testing.T) {
 		want timeline.HealthState
 	}{
 		{
-			name: "deployment scaled to zero is healthy (neutral collapses on the wire)",
+			name: "deployment scaled to zero is neutral (intentional — sky span)",
 			kind: "Deployment",
 			obj:  &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Replicas: ptr32(0)}},
-			want: timeline.HealthHealthy,
+			want: timeline.HealthNeutral,
 		},
 		{
-			name: "daemonset matching no nodes (0/0) is healthy (neutral collapses on the wire)",
+			name: "daemonset matching no nodes (0/0) is neutral (intentional — sky span)",
 			kind: "DaemonSet",
 			obj:  &appsv1.DaemonSet{Status: appsv1.DaemonSetStatus{DesiredNumberScheduled: 0, NumberReady: 0}},
-			want: timeline.HealthHealthy,
+			want: timeline.HealthNeutral,
 		},
 		{
 			name: "deployment fully ready is healthy",

--- a/internal/server/applications.go
+++ b/internal/server/applications.go
@@ -1208,15 +1208,11 @@ func jobDesired(j *batchv1.Job) int {
 }
 
 // levelToPackagesHealth projects a canonical health.Level onto the package wire
-// vocabulary. The package/app wire stays four-valued in this change, so neutral
-// (intentional/lifecycle states) collapses to healthy — benign, and it keeps a
-// running-Job or scaled-to-zero workload from regressing to Unknown in the
-// Applications UI. The dedicated neutral tier lands with the frontend follow-up
-// that owns the wire + rendering together.
+// vocabulary. neutral (intentional/idle — suspended, scaled-to-zero) maps to the
+// dedicated HealthNeutral; it aggregates as most-benign, so an all-idle app rolls
+// up to "Idle" in the Applications UI while a mixed healthy+idle app still reads
+// Healthy (WorseHealth prefers healthy on the tie).
 func levelToPackagesHealth(l health.Level) packages.Health {
-	if l == health.LevelNeutral {
-		return packages.HealthHealthy
-	}
 	return packages.Health(l)
 }
 

--- a/internal/timeline/manager.go
+++ b/internal/timeline/manager.go
@@ -63,6 +63,7 @@ const (
 	HealthHealthy   = pkgtimeline.HealthHealthy
 	HealthDegraded  = pkgtimeline.HealthDegraded
 	HealthUnhealthy = pkgtimeline.HealthUnhealthy
+	HealthNeutral   = pkgtimeline.HealthNeutral
 	HealthUnknown   = pkgtimeline.HealthUnknown
 
 	// GroupingMode constants

--- a/packages/k8s-ui/src/components/applications/ApplicationsView.tsx
+++ b/packages/k8s-ui/src/components/applications/ApplicationsView.tsx
@@ -56,6 +56,7 @@ const HEALTH_TONE: Record<AppHealth, FacetTone> = {
   unhealthy: 'error',
   degraded: 'warning',
   healthy: 'success',
+  neutral: 'info', // Idle — sky, calm
   unknown: 'neutral',
 }
 
@@ -297,6 +298,7 @@ export function ApplicationsView({ entries: allEntries, variant, onSelect, title
               {healthTile('unhealthy', 'error')}
               {healthTile('degraded', 'warning')}
               {healthTile('healthy', 'success')}
+              {healthTile('neutral', 'info')}
               {healthTile('unknown', 'neutral')}
             </>
           }

--- a/packages/k8s-ui/src/components/gitops/GitOpsStatusBadge.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsStatusBadge.tsx
@@ -67,7 +67,10 @@ function getStatusIcon(status: GitOpsStatus) {
 }
 
 function getStatusColorClass(status: GitOpsStatus): string {
-  if (status.suspended) return SEVERITY_BADGE_BORDERED.warning
+  // Suspended sync (manual-sync mode) is an intentional operating mode many teams
+  // run by default — sky (info), not amber. Real drift surfaces separately as
+  // OutOfSync (still amber); the Pause icon + "Suspended" label signal it's manual.
+  if (status.suspended) return SEVERITY_BADGE_BORDERED.info
   if (status.sync === 'Synced' && status.health === 'Healthy') return SEVERITY_BADGE_BORDERED.success
   if (status.health === 'Degraded') return SEVERITY_BADGE_BORDERED.error
   if (status.sync === 'OutOfSync') return SEVERITY_BADGE_BORDERED.warning
@@ -127,8 +130,9 @@ function getHealthInfo(health: GitOpsHealthStatus) {
  */
 export function SyncStatusBadge({ sync, suspended }: { sync: SyncStatus; suspended?: boolean }) {
   if (suspended) {
+    // Manual-sync mode is intentional — sky (info), not amber. See getStatusColorClass.
     return (
-      <span className={clsx('badge', SEVERITY_BADGE_BORDERED.warning)}>
+      <span className={clsx('badge', SEVERITY_BADGE_BORDERED.info)}>
         <Pause className="w-3 h-3" />
         Suspended
       </span>

--- a/packages/k8s-ui/src/components/gitops/GitOpsStatusBadge.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsStatusBadge.tsx
@@ -112,7 +112,9 @@ function getHealthInfo(health: GitOpsHealthStatus) {
     case 'Degraded':
       return { icon: XCircle, color: SEVERITY_BADGE.error, label: 'Degraded' }
     case 'Suspended':
-      return { icon: Pause, color: SEVERITY_BADGE.warning, label: 'Suspended' }
+      // Intentional pause, not a degradation — sky (info), matching the resource
+      // table + app rollup. The Pause icon already signals it's deliberate.
+      return { icon: Pause, color: SEVERITY_BADGE.info, label: 'Suspended' }
     case 'Missing':
       return { icon: AlertCircle, color: SEVERITY_BADGE.warning, label: 'Missing' }
     default:

--- a/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
@@ -1704,7 +1704,9 @@ function compareRows(a: GitOpsRow, b: GitOpsRow, sortKey: SortKey) {
 // row sorting above a Synced-Progressing one. A sync-aware triage ordering is a
 // reasonable separate default, but not what "sort by Health" should mean.)
 const HEALTH_RANK: Record<string, number> = {
-  Degraded: 0, Missing: 0, Suspended: 1, Unknown: 2, Progressing: 3, Healthy: 4,
+  // Suspended is intentional/benign (neutral), so it sorts at the healthy end —
+  // not near Degraded/Missing — matching its sky tone across the other surfaces.
+  Degraded: 0, Missing: 0, Unknown: 2, Progressing: 3, Healthy: 4, Suspended: 4,
 }
 function healthRank(row: GitOpsRow): number {
   return HEALTH_RANK[row.health] ?? 2

--- a/packages/k8s-ui/src/components/resources/get-pod-problems.test.ts
+++ b/packages/k8s-ui/src/components/resources/get-pod-problems.test.ts
@@ -124,4 +124,22 @@ describe('getPodProblems', () => {
       }),
     ).not.toContainEqual(expect.objectContaining({ message: 'Sandbox Startup Stalled' }))
   })
+
+  it('does not flag a completing Job pod (Running, container exited 0, Ready=false) as Not Ready', () => {
+    expect(
+      getPodProblems({
+        status: {
+          phase: 'Running',
+          containerStatuses: [
+            {
+              name: 'job',
+              ready: false,
+              restartCount: 0,
+              state: { terminated: { reason: 'Completed', exitCode: 0 } },
+            },
+          ],
+        },
+      }),
+    ).not.toContainEqual(expect.objectContaining({ message: 'Not Ready' }))
+  })
 })

--- a/packages/k8s-ui/src/components/resources/health-golden.test.ts
+++ b/packages/k8s-ui/src/components/resources/health-golden.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import {
+  getPodStatus,
+  getWorkloadStatus,
+  getJobStatus,
+  getCronJobStatus,
+  getPVCStatus,
+  type HealthLevel,
+} from './resource-utils'
+
+// Cross-language health contract. This loads the SAME fixture as the Go test
+// (pkg/health/golden_crosslang_test.go) and asserts the TS table classifiers
+// produce the level pkg/health recorded. pkg/health is the source of truth; this
+// is the anti-drift gate that keeps the two implementations from diverging.
+//
+// If this fails after a backend health change, the TS classifier in
+// resource-utils.ts must be updated to match — not the other way round.
+
+interface GoldenVector {
+  name: string
+  kind: string
+  level: HealthLevel
+  object: any
+}
+
+const here = dirname(fileURLToPath(import.meta.url))
+// src/components/resources -> repo root is five levels up, then pkg/health/testdata.
+const fixturePath = resolve(here, '../../../../../pkg/health/testdata/golden_vectors.json')
+const vectors: GoldenVector[] = JSON.parse(readFileSync(fixturePath, 'utf8')).vectors
+
+// Map a fixture kind onto the TS classifier that backs its table badge.
+function classify(kind: string, object: any): HealthLevel {
+  switch (kind) {
+    case 'Pod':
+      return getPodStatus(object).level
+    case 'Deployment':
+      return getWorkloadStatus(object, 'deployments').level
+    case 'StatefulSet':
+      return getWorkloadStatus(object, 'statefulsets').level
+    case 'DaemonSet':
+      return getWorkloadStatus(object, 'daemonsets').level
+    case 'Job':
+      return getJobStatus(object).level
+    case 'CronJob':
+      return getCronJobStatus(object).level
+    case 'PersistentVolumeClaim':
+      return getPVCStatus(object).level
+    default:
+      throw new Error(`golden vector kind "${kind}" has no TS classifier mapping`)
+  }
+}
+
+describe('health golden vectors (cross-language contract with pkg/health)', () => {
+  it('loaded a non-empty fixture shared with the Go test', () => {
+    expect(vectors.length).toBeGreaterThan(0)
+  })
+
+  for (const v of vectors) {
+    it(`${v.kind}: ${v.name}`, () => {
+      expect(classify(v.kind, v.object)).toBe(v.level)
+    })
+  }
+})

--- a/packages/k8s-ui/src/components/resources/renderers/JobRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/JobRenderer.tsx
@@ -25,8 +25,12 @@ function getJobProblems(data: any): string[] {
     }
   }
 
-  // Check for pod failures without terminal condition yet
-  if (!failedCondition && status.failed > 0) {
+  // Check for pod failures without terminal condition yet. A Job that already
+  // completed successfully (Complete condition) keeps its earlier failed pod
+  // attempts in status.failed — those are retries, not a problem — so don't flag
+  // them, or the drawer would read red while the table badge is calm neutral.
+  const completeCondition = conditions.find((c: any) => c.type === 'Complete' && c.status === 'True')
+  if (!failedCondition && !completeCondition && status.failed > 0) {
     const remaining = (spec.backoffLimit ?? 6) - status.failed
     if (remaining > 0) {
       problems.push(`${status.failed} pod(s) failed — ${remaining} retries remaining`)

--- a/packages/k8s-ui/src/components/resources/renderers/KedaScaledObjectRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/KedaScaledObjectRenderer.tsx
@@ -62,9 +62,9 @@ export function KedaScaledObjectRenderer({ data, onNavigate }: KedaScaledObjectR
       )}
       {isPaused && (
         <AlertBanner
-          variant="warning"
+          variant="info"
           title="Scaling Paused"
-          message="Autoscaling is paused via annotation."
+          message="Autoscaling is paused via annotation. This is intentional — resume by removing the paused annotation."
         />
       )}
 

--- a/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.tsx
@@ -90,10 +90,13 @@ export function NodeRenderer({ data, relationships, onViewPods, metrics, metrics
         <AlertBanner variant="error" title="Issues Detected" items={problems} />
       )}
 
-      {/* Cordoned is intentional (cordon/drain) — calm sky advisory, not an error */}
+      {/* Cordoned is intentional but consequential — it removes scheduling
+          capacity and a forgotten cordon strands a node. So it's a warning (amber),
+          matching the node table badge + the Cordoned audit check — NOT the calm
+          sky of a no-op intentional state (suspended/idle), and not a red error. */}
       {isCordoned && (
         <AlertBanner
-          variant="info"
+          variant="warning"
           title="Cordoned (unschedulable)"
           message="New pods won't be scheduled here. Uncordon to resume scheduling."
         />

--- a/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.tsx
@@ -26,16 +26,12 @@ function formatStorage(value: string | undefined): string {
   return formatMemory(value)
 }
 
-// Extract problems from node status and spec
+// Extract genuine problems from node status. Cordoned (unschedulable) is
+// deliberately NOT included here — it's an intentional operator action
+// (cordon/drain), surfaced separately as a calm advisory, not a red error.
 function getNodeProblems(data: any): string[] {
   const problems: string[] = []
   const conditions = data.status?.conditions || []
-  const spec = data.spec || {}
-
-  // Check if unschedulable
-  if (spec.unschedulable) {
-    problems.push('Node is cordoned (unschedulable)')
-  }
 
   for (const cond of conditions) {
     // NotReady is a problem when status is not True
@@ -77,6 +73,7 @@ export function NodeRenderer({ data, relationships, onViewPods, metrics, metrics
   // Check for problems
   const problems = getNodeProblems(data)
   const hasProblems = problems.length > 0
+  const isCordoned = !!spec.unschedulable
 
   // Extract platform info from labels
   const instanceType = labels['node.kubernetes.io/instance-type']
@@ -88,9 +85,18 @@ export function NodeRenderer({ data, relationships, onViewPods, metrics, metrics
 
   return (
     <>
-      {/* Problems alert - shown at top when there are issues */}
+      {/* Problems alert - shown at top when there are genuine issues */}
       {hasProblems && (
         <AlertBanner variant="error" title="Issues Detected" items={problems} />
+      )}
+
+      {/* Cordoned is intentional (cordon/drain) — calm sky advisory, not an error */}
+      {isCordoned && (
+        <AlertBanner
+          variant="info"
+          title="Cordoned (unschedulable)"
+          message="New pods won't be scheduled here. Uncordon to resume scheduling."
+        />
       )}
 
       {/* Node Info */}

--- a/packages/k8s-ui/src/components/resources/renderers/PVCRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PVCRenderer.tsx
@@ -28,10 +28,10 @@ export function PVCRenderer({ data, onNavigate, extraSections }: PVCRendererProp
   const annotations = data.metadata?.annotations || {}
   const phase = status.phase
 
-  // Problem detection
+  // Lost is a genuine failure (bound volume disappeared). Pending is a normal
+  // lifecycle state (provisioning / WaitForFirstConsumer), surfaced calmly below.
   const isLost = phase === 'Lost'
   const isPending = phase === 'Pending'
-  const hasProblems = isLost || isPending
 
   // Provisioner info from annotations
   const provisioner = annotations['volume.kubernetes.io/storage-provisioner']
@@ -42,7 +42,7 @@ export function PVCRenderer({ data, onNavigate, extraSections }: PVCRendererProp
   return (
     <>
       {/* Problem alerts */}
-      {hasProblems && isLost && (
+      {isLost && (
         <AlertBanner
           variant="error"
           title="Issues Detected"
@@ -50,11 +50,11 @@ export function PVCRenderer({ data, onNavigate, extraSections }: PVCRendererProp
         />
       )}
 
-      {hasProblems && isPending && (
+      {isPending && (
         <AlertBanner
-          variant="warning"
-          title="Issues Detected"
-          message="PVC is waiting to be bound to a volume"
+          variant="info"
+          title="Pending — awaiting binding"
+          message="Not yet bound to a volume. This is normal while provisioning, and expected indefinitely for a WaitForFirstConsumer StorageClass until a Pod that mounts this claim is scheduled."
         />
       )}
 

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
@@ -803,8 +803,16 @@ export function PodRenderer({
         </Section>
       )}
 
-      {/* Conditions */}
-      <ConditionsSection conditions={data.status?.conditions} />
+      {/* Conditions. A completed pod's Ready/ContainersReady flip to False with
+          reason "PodCompleted" — that's expected for a finished pod, not a failure,
+          so tone it neutral (gray) instead of red. Gated on the PodCompleted reason
+          so a genuinely not-ready pod (any other reason) still reads red. */}
+      <ConditionsSection
+        conditions={data.status?.conditions}
+        getConditionTone={(cond) =>
+          cond?.status === 'False' && cond?.reason === 'PodCompleted' ? 'unknown' : undefined
+        }
+      />
 
       {/* Permissions (via ServiceAccount) — placed below the diagnostic-
        *  signal sections (status, containers, resource usage, conditions)

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
@@ -548,6 +548,10 @@ export function PodRenderer({
             const lastTermination = status?.lastState?.terminated
             const currentWaiting = status?.state?.waiting
             const currentTerminated = status?.state?.terminated
+            // A container that exited 0 (a completed Job pod) is a success, not a
+            // failure — tone its badges/text sky, not red, so the drawer agrees
+            // with the calm "Completed" table badge instead of screaming red.
+            const terminatedOk = currentTerminated?.exitCode === 0
 
             return (
               <div key={container.name} className="card-inner-lg">
@@ -586,14 +590,17 @@ export function PodRenderer({
                     )}
                     <span className={clsx(
                       'badge',
-                      isReady ? SEVERITY_BADGE_BORDERED.success : SEVERITY_BADGE_BORDERED.error
+                      isReady ? SEVERITY_BADGE_BORDERED.success :
+                      terminatedOk ? SEVERITY_BADGE_BORDERED.info :
+                      SEVERITY_BADGE_BORDERED.error
                     )}>
-                      {isReady ? 'Ready' : 'Not Ready'}
+                      {isReady ? 'Ready' : terminatedOk ? 'Completed' : 'Not Ready'}
                     </span>
                     <span className={clsx(
                       'badge',
                       stateKey === 'running' ? SEVERITY_BADGE_BORDERED.success :
                       stateKey === 'waiting' ? SEVERITY_BADGE_BORDERED.warning :
+                      terminatedOk ? SEVERITY_BADGE_BORDERED.info :
                       SEVERITY_BADGE_BORDERED.error
                     )}>
                       {stateKey}
@@ -621,9 +628,10 @@ export function PodRenderer({
                       )}
                     </div>
                   )}
-                  {/* Show current terminated reason */}
+                  {/* Show current terminated reason — sky for a clean exit-0
+                      completion, red only for a genuine failure. */}
                   {currentTerminated?.reason && (
-                    <div className="text-red-400 flex items-center gap-1">
+                    <div className={clsx('flex items-center gap-1', terminatedOk ? 'text-sky-500 dark:text-sky-400' : 'text-red-400')}>
                       <span className="font-medium">Terminated: {currentTerminated.reason}</span>
                       {currentTerminated.exitCode !== undefined && currentTerminated.exitCode !== 0 && (
                         <span className="text-theme-text-tertiary">(exit code {currentTerminated.exitCode})</span>

--- a/packages/k8s-ui/src/components/resources/resource-utils-argo.test.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-argo.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { getArgoApplicationStatus } from './resource-utils-argo'
+
+describe('getArgoApplicationStatus', () => {
+  // A Suspended Argo app is intentionally paused — neutral (sky), matching the
+  // backend rollup (mapArgoHealth) + the GitOps badge, so it doesn't read amber
+  // on the resource table while reading Idle in Applications.
+  it('maps health Suspended to neutral (sky), not degraded', () => {
+    const badge = getArgoApplicationStatus({ status: { health: { status: 'Suspended' }, sync: { status: 'Synced' } } })
+    expect(badge.level).toBe('neutral')
+    expect(badge.text).toBe('Suspended')
+  })
+
+  it('still maps a healthy synced app to healthy', () => {
+    const badge = getArgoApplicationStatus({ status: { health: { status: 'Healthy' }, sync: { status: 'Synced' } } })
+    expect(badge.level).toBe('healthy')
+  })
+
+  it('still maps a degraded app to unhealthy', () => {
+    const badge = getArgoApplicationStatus({ status: { health: { status: 'Degraded' }, sync: { status: 'Synced' } } })
+    expect(badge.level).toBe('unhealthy')
+  })
+})

--- a/packages/k8s-ui/src/components/resources/resource-utils-argo.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-argo.ts
@@ -22,7 +22,11 @@ export function getArgoApplicationStatus(app: any): StatusBadge {
   const annotations = app.metadata?.annotations
   const suspendedByRadar = annotations?.['radarhq.io/suspended-prune'] || annotations?.['skyhook.io/suspended-prune']
   if (health === 'Suspended' || (!hasAutomatedSync && suspendedByRadar)) {
-    return { text: 'Suspended', color: healthColors.degraded, level: 'degraded' }
+    // Suspended = an operator deliberately paused this app — intentional, not a
+    // degradation. Neutral (sky), matching the backend rollup (mapArgoHealth) so a
+    // suspended app reads the same Idle tone in Applications, the resource table,
+    // and GitOps instead of amber in some surfaces and sky in others.
+    return { text: 'Suspended', color: healthColors.neutral, level: 'neutral' }
   }
 
   // Operation in progress

--- a/packages/k8s-ui/src/components/resources/resource-utils-keda.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-keda.ts
@@ -29,7 +29,9 @@ export function getScaledObjectStatus(resource: any): StatusBadge {
     conditions.some((c: any) => c.type === 'Paused' && c.status === 'True')
 
   if (isPaused) {
-    return { text: 'Paused', color: healthColors.degraded, level: 'degraded' }
+    // Paused = operator deliberately froze autoscaling — intentional, sky/neutral
+    // (like Idle), not amber.
+    return { text: 'Paused', color: healthColors.neutral, level: 'neutral' }
   }
 
   // Check Fallback condition

--- a/packages/k8s-ui/src/components/resources/resource-utils-keda.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils-keda.ts
@@ -130,24 +130,26 @@ export function getScaledJobStatus(resource: any): StatusBadge {
   const conditions = resource.status?.conditions || []
 
   const readyCond = conditions.find((c: any) => c.type === 'Ready')
-  if (readyCond?.status === 'True') {
-    return { text: 'Ready', color: healthColors.healthy, level: 'healthy' }
-  }
   // A non-operational scaler (Ready=False) is unhealthy and must take precedence
-  // over the Idle (Active=False) branch below — otherwise a broken-and-idle
-  // ScaledJob hides as benign "Idle". Mirrors getScaledObjectStatus.
+  // over the Idle branch — otherwise a broken-and-idle ScaledJob hides as benign.
   if (readyCond?.status === 'False') {
     return { text: readyCond.reason || 'NotReady', color: healthColors.unhealthy, level: 'unhealthy' }
   }
 
+  // Check Active BEFORE falling back to Ready=True: an operational scaler with no
+  // jobs running (Active=False) is intentionally idle → sky, not the green of a
+  // busy one. (Ready=True first would make Idle unreachable.) Mirrors
+  // getScaledObjectStatus.
   const activeCond = conditions.find((c: any) => c.type === 'Active')
   if (activeCond?.status === 'True') {
     return { text: 'Active', color: healthColors.healthy, level: 'healthy' }
   }
   if (activeCond?.status === 'False') {
-    // Idle is the normal resting state of a scaler with no triggers firing
-    // (like a CronJob waiting for its next run), not a fault.
     return { text: 'Idle', color: healthColors.neutral, level: 'neutral' }
+  }
+
+  if (readyCond?.status === 'True') {
+    return { text: 'Ready', color: healthColors.healthy, level: 'healthy' }
   }
 
   return { text: 'Unknown', color: healthColors.unknown, level: 'unknown' }

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -475,11 +475,11 @@ export function getPodProblems(pod: any): PodProblem[] {
     problems.push({ severity: 'high', message: 'Evicted', detail: podStatusMessage })
   }
 
-  // Stuck terminating (zombie pod)
+  // Stuck terminating (zombie pod). Use the same threshold as the badge
+  // (TERMINATING_STUCK_MINUTES) so the drawer problem and the table badge flip
+  // together — firing at 60s while the badge stayed calm to 10m was a mismatch.
   if (pod.metadata?.deletionTimestamp) {
-    const deleteTime = new Date(pod.metadata.deletionTimestamp).getTime()
-    const ageSeconds = (Date.now() - deleteTime) / 1000
-    if (ageSeconds > 60) {
+    if (minutesSince(pod.metadata.deletionTimestamp) >= TERMINATING_STUCK_MINUTES) {
       problems.push({ severity: 'medium', message: 'Stuck Terminating' })
     }
   }

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -646,7 +646,9 @@ export function getWorkloadStatus(resource: any, kind: string): StatusBadge {
     const ready = status.numberReady || 0
     const updated = status.updatedNumberScheduled || 0
 
-    if (desired === 0) return { text: '0 nodes', color: healthColors.unknown, level: 'unknown' }
+    // 0 desired = the node selector matches no nodes — intentional/idle, not a
+    // fault and not "unknown" (matches pkg/health.Workload). Sky.
+    if (desired === 0) return { text: '0 nodes', color: healthColors.neutral, level: 'neutral' }
     if (ready === desired && updated === desired) {
       return { text: `${ready}/${desired}`, color: healthColors.healthy, level: 'healthy' }
     }
@@ -1008,7 +1010,9 @@ export function getJobStatus(job: any): StatusBadge {
 
   const completeCond = conditions.find((c: any) => c.type === 'Complete' && c.status === 'True')
   if (completeCond) {
-    return { text: 'Complete', color: healthColors.healthy, level: 'healthy' }
+    // A completed Job is done by design — neutral/idle (sky), not the green of a
+    // serving workload (matches pkg/health.Workload).
+    return { text: 'Complete', color: healthColors.neutral, level: 'neutral' }
   }
 
   if (job.spec?.suspend) {

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -484,11 +484,14 @@ export function getPodProblems(pod: any): PodProblem[] {
     }
   }
 
-  // Not ready (Running but containers not ready)
+  // Not ready (Running but containers not ready). Use the same containerSettledOk
+  // gate as getPodStatus so a completing Job pod (Running, container terminated
+  // exit 0, Ready=false) doesn't raise a drawer problem while the table badge
+  // stays calm — a settled/completed container is not "Not Ready".
   if (phase === 'Running') {
-    const readyContainers = containerStatuses.filter((c: any) => c.ready).length
+    const unsettled = containerStatuses.filter((c: any) => !containerSettledOk(c)).length
     const totalContainers = containerStatuses.length
-    if (totalContainers > 0 && readyContainers < totalContainers) {
+    if (totalContainers > 0 && unsettled > 0) {
       // Only add if we haven't already flagged a more specific issue
       const hasSpecificIssue = problems.some(p =>
         p.message.includes('Probe') || p.message.includes('CrashLoop') || p.message.includes('OOM')

--- a/packages/k8s-ui/src/components/timeline/TimelineSwimlanes.tsx
+++ b/packages/k8s-ui/src/components/timeline/TimelineSwimlanes.tsx
@@ -573,6 +573,7 @@ export function TimelineSwimlanes({ events, isLoading, onResourceClick, viewMode
           <HealthBarLegendItem color="bg-blue-500/60 dark:bg-blue-500/60" label="rolling" description="Expected degradation during deployment rollout" />
           <HealthBarLegendItem color="bg-amber-500/60 dark:bg-[#b8861e]" label="degraded" description="Unexpected partial availability" />
           <HealthBarLegendItem color="bg-red-500/60 dark:bg-red-500/60" label="unhealthy" description="Resource is failing or not ready" />
+          <HealthBarLegendItem color="bg-sky-500/60 dark:bg-sky-500/60" label="idle" description="Intentionally off/resting (completed, suspended, scaled to zero)" />
         </div>
       </div>
 

--- a/packages/k8s-ui/src/components/timeline/shared.tsx
+++ b/packages/k8s-ui/src/components/timeline/shared.tsx
@@ -138,6 +138,10 @@ export function HealthSpanLegend() {
         <span className="w-4 h-2 rounded-sm bg-red-500/60 dark:bg-red-500/60" />
         <span>Unhealthy</span>
       </span>
+      <span className="flex items-center gap-1">
+        <span className="w-4 h-2 rounded-sm bg-sky-500/60 dark:bg-sky-500/60" />
+        <span>Idle</span>
+      </span>
     </div>
   )
 }
@@ -387,7 +391,7 @@ export function TimeAxis({ startTime, endTime, tickCount = 8, labelColumnClass =
  * Health span bar showing a health state over a time range.
  */
 interface HealthSpanProps {
-  health: 'healthy' | 'degraded' | 'unhealthy' | string
+  health: 'healthy' | 'rolling' | 'degraded' | 'unhealthy' | 'neutral' | 'unknown' | string
   left: number // percentage
   width: number // percentage
   title?: string
@@ -408,6 +412,9 @@ export function HealthSpan({ health, left, width, title, createdBefore }: Health
         return 'bg-amber-500/60 dark:bg-[#b8861e]'
       case 'unhealthy':
         return 'bg-red-500/60 dark:bg-red-500/60'
+      case 'neutral':
+        // intentional/idle (suspended, scaled-to-0) — sky, calm
+        return 'bg-sky-500/60 dark:bg-sky-500/60'
       default:
         // Unknown or other states
         return 'bg-gray-400/40'
@@ -569,7 +576,11 @@ export function buildHealthSpans(
   const existsUntil = deleteEvent ? new Date(deleteEvent.timestamp).getTime() : now
 
   const spans: { start: number; end: number; health: string }[] = []
-  let currentHealth = 'unknown'
+  // `null` is the "no health observed yet" sentinel — kept distinct from the
+  // real 'unknown' health value (emitted for node-lost pods). Overloading
+  // 'unknown' as both swallowed genuine-unknown spans and then false-greened
+  // them via the empty-spans fallback below.
+  let currentHealth: string | null = null
   let spanStart = Math.max(existsFrom, startTime)
 
   for (const evt of sorted) {
@@ -586,7 +597,7 @@ export function buildHealthSpans(
       continue
     }
 
-    if (newHealth !== currentHealth && currentHealth !== 'unknown') {
+    if (newHealth !== currentHealth && currentHealth !== null) {
       spans.push({ start: spanStart, end: ts, health: currentHealth })
       spanStart = ts
     }
@@ -594,7 +605,7 @@ export function buildHealthSpans(
   }
 
   // Close final span (only up to when resource existed)
-  if (currentHealth !== 'unknown') {
+  if (currentHealth !== null) {
     spans.push({ start: spanStart, end: Math.min(existsUntil, now), health: currentHealth })
   }
 

--- a/packages/k8s-ui/src/components/topology/K8sResourceNode.tsx
+++ b/packages/k8s-ui/src/components/topology/K8sResourceNode.tsx
@@ -215,6 +215,12 @@ const STATUS_STYLES: Record<HealthStatus, React.CSSProperties> = {
     border: '2px solid rgb(239 68 68 / 0.7)',
     backgroundColor: 'rgb(248 113 113 / 0.15)',
   },
+  // neutral = intentional/idle (suspended, scaled-to-0) — sky outline, calm.
+  // Distinct from `unknown`/`healthy` which carry no outline.
+  neutral: {
+    border: '2px solid rgb(56 189 248 / 0.55)',
+    backgroundColor: 'rgb(56 189 248 / 0.1)',
+  },
   healthy: {},
   unknown: {},
 }

--- a/packages/k8s-ui/src/components/topology/layout.ts
+++ b/packages/k8s-ui/src/components/topology/layout.ts
@@ -807,8 +807,11 @@ function computeWorkloadCards(
     })
     const primary = sorted[0]
 
-    // Compute worst health
-    let worstPriority = 3
+    // Compute worst health. Seed with Infinity (not 3) so an all-neutral
+    // component can surface neutral — `neutral` is priority 4 (most benign), so a
+    // `< 3` seed would never accept it and the card would stay green. Matches
+    // computeGroupHealth.
+    let worstPriority = Infinity
     let worstStatus: HealthStatus = 'healthy'
     for (const node of comp) {
       const p = HEALTH_PRIORITY[node.status] ?? 2

--- a/packages/k8s-ui/src/components/topology/layout.ts
+++ b/packages/k8s-ui/src/components/topology/layout.ts
@@ -731,11 +731,14 @@ export function buildHierarchicalElkGraph(
   }
 }
 
-// Lower number = higher severity
-const HEALTH_PRIORITY: Record<HealthStatus, number> = { unhealthy: 0, degraded: 1, unknown: 2, healthy: 3 }
+// Lower number = higher severity. `neutral` (intentional/idle) is the
+// most-benign tier, so a group whose every member is idle rolls up to neutral,
+// while a mixed healthy+idle group still reads healthy (healthy out-ranks
+// neutral). An empty/unresolved group defaults to healthy.
+const HEALTH_PRIORITY: Record<HealthStatus, number> = { unhealthy: 0, degraded: 1, unknown: 2, healthy: 3, neutral: 4 }
 
 function computeGroupHealth(memberIds: string[], nodeMap: Map<string, TopologyNode>): { worstStatus: HealthStatus; unhealthyCount: number } {
-  let worstPriority = 3
+  let worstPriority = Infinity
   let worstStatus: HealthStatus = 'healthy'
   let unhealthyCount = 0
   for (const id of memberIds) {

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -193,7 +193,7 @@ export function displayKind(kind: string): string {
   return shortNames[kind] || kind
 }
 
-export type HealthStatus = 'healthy' | 'degraded' | 'unhealthy' | 'unknown'
+export type HealthStatus = 'healthy' | 'degraded' | 'unhealthy' | 'neutral' | 'unknown'
 
 export type EdgeType = 'routes-to' | 'exposes' | 'manages' | 'uses' | 'configures' | 'protects'
 
@@ -557,7 +557,7 @@ export interface HelmRelease {
   lastOperation?: HelmOperation
   operations?: HelmOperation[]
   // Health summary from owned resources
-  resourceHealth?: 'healthy' | 'degraded' | 'unhealthy' | 'unknown'
+  resourceHealth?: 'healthy' | 'degraded' | 'unhealthy' | 'neutral' | 'unknown'
   healthIssue?: string    // Primary issue if unhealthy (e.g., "OOMKilled")
   healthSummary?: string  // Brief summary like "2/3 pods ready"
   // When set, this release was installed by Flux's helm-controller — the
@@ -612,7 +612,7 @@ export interface HelmReleaseDetail {
   notes: string
   history: HelmRevision[]
   resources: HelmOwnedResource[]
-  resourceHealth?: 'healthy' | 'degraded' | 'unhealthy' | 'unknown'
+  resourceHealth?: 'healthy' | 'degraded' | 'unhealthy' | 'neutral' | 'unknown'
   healthIssue?: string
   healthSummary?: string
   hooks?: HelmHook[]

--- a/packages/k8s-ui/src/utils/applications.test.ts
+++ b/packages/k8s-ui/src/utils/applications.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { compareVersions, appGroupingExplainer, APP_IDENTITY_ANNOTATION, appGroupLagMessage, matchWorkloadAcrossInstances, foldAppGroups, identityEnvInferred, type AppGroupFoldEntry } from './applications'
+import { compareVersions, appGroupingExplainer, APP_IDENTITY_ANNOTATION, appGroupLagMessage, matchWorkloadAcrossInstances, foldAppGroups, identityEnvInferred, worstHealth, type AppGroupFoldEntry } from './applications'
 
 describe('compareVersions', () => {
   it('orders semver', () => {
@@ -203,6 +203,60 @@ describe('foldAppGroups', () => {
       localScope: (e) => e.row.key,
     })
     expect(grouped.map((r) => r.kind)).toEqual(['group'])
+  })
+})
+
+describe('worstHealth', () => {
+  // Mirrors pkg/health.WorseOf: unhealthy > degraded > unknown > healthy > neutral,
+  // with neutral as the most-benign identity. Regression for the rank-inversion
+  // fix — seeding the fold with `unknown` (now rank 2) made all-healthy/all-idle
+  // sets wrongly return `unknown`.
+  it('all-healthy stays healthy (not unknown)', () => {
+    expect(worstHealth(['healthy', 'healthy'])).toBe('healthy')
+  })
+  it('all-neutral stays neutral', () => {
+    expect(worstHealth(['neutral', 'neutral'])).toBe('neutral')
+  })
+  it('healthy + neutral resolves to healthy (healthy out-ranks idle)', () => {
+    expect(worstHealth(['healthy', 'neutral'])).toBe('healthy')
+    expect(worstHealth(['neutral', 'healthy'])).toBe('healthy')
+  })
+  it('unknown out-ranks healthy (a node-lost workload is worse than a running one)', () => {
+    expect(worstHealth(['unknown', 'healthy'])).toBe('unknown')
+  })
+  it('unhealthy dominates everything', () => {
+    expect(worstHealth(['unhealthy', 'degraded', 'unknown', 'healthy', 'neutral'])).toBe('unhealthy')
+  })
+  it('empty set is the most-benign identity', () => {
+    expect(worstHealth([])).toBe('neutral')
+  })
+})
+
+describe('foldAppGroups health rollup', () => {
+  const grp = (env: string, health: string): AppGroupFoldEntry => ({
+    row: { key: `k-${env}`, name: `billing-${env}`, identity: { key: 'billing', env, confidence: 'medium', evidence: 'e' } },
+    health: health as AppGroupFoldEntry['health'],
+    versions: [],
+    ready: 1,
+    desired: 1,
+    kinds: { Deployment: 1 },
+    classComposition: [{ cls: 'service', count: 1 }],
+  })
+  const rollup = (...hs: string[]) => {
+    const rows = foldAppGroups(hs.map((h, i) => grp(`env${i}`, h)), new Set(), false)
+    return (rows[0] as Extract<(typeof rows)[0], { kind: 'group' }>).health
+  }
+  it('all-healthy group rolls up healthy (regression: was unknown)', () => {
+    expect(rollup('healthy', 'healthy')).toBe('healthy')
+  })
+  it('all-idle group rolls up neutral (Idle), not green', () => {
+    expect(rollup('neutral', 'neutral')).toBe('neutral')
+  })
+  it('mixed healthy + idle reads healthy', () => {
+    expect(rollup('healthy', 'neutral')).toBe('healthy')
+  })
+  it('healthy + unknown reads unknown (node-lost dominates)', () => {
+    expect(rollup('healthy', 'unknown')).toBe('unknown')
   })
 })
 

--- a/packages/k8s-ui/src/utils/applications.ts
+++ b/packages/k8s-ui/src/utils/applications.ts
@@ -6,7 +6,7 @@
 // (internal/server/applications.go). Field names match the Go json tags.
 
 export type AppWorkloadClass = 'service' | 'worker' | 'job' | 'mixed' | 'unknown'
-export type AppHealth = 'healthy' | 'degraded' | 'unhealthy' | 'unknown'
+export type AppHealth = 'healthy' | 'degraded' | 'unhealthy' | 'neutral' | 'unknown'
 
 export interface AppWorkload {
   kind: string
@@ -640,7 +640,9 @@ export function foldAppGroups<T extends AppGroupFoldEntry>(
 /** Normalize a wire health string to the AppHealth union (the health twin of
  *  workloadClassOf — keeps `as AppHealth` casts out of components). */
 export function healthOf(value: string | undefined): AppHealth {
-  return value === 'unhealthy' || value === 'degraded' || value === 'healthy' ? value : 'unknown'
+  return value === 'unhealthy' || value === 'degraded' || value === 'healthy' || value === 'neutral'
+    ? value
+    : 'unknown'
 }
 
 // -----------------------------------------------------------------------------
@@ -648,8 +650,16 @@ export function healthOf(value: string | undefined): AppHealth {
 // pale-pastel pills (which have no theme token) for the colored tiers.
 // -----------------------------------------------------------------------------
 
-export const HEALTH_ORDER: AppHealth[] = ['unhealthy', 'degraded', 'healthy', 'unknown']
-export const HEALTH_RANK: Record<string, number> = { unhealthy: 3, degraded: 2, healthy: 1, unknown: 0 }
+// Worst-first display + aggregation order. Mirrors the backend's
+// `pkg/health` Rank ordering (unhealthy > degraded > unknown > healthy ≈ neutral)
+// so the app rollup agrees with every other surface. `unknown` ranks ABOVE
+// healthy (a node-lost workload is worse than a running one); `neutral`
+// (intentional/idle) is the most-benign tier, so an all-idle app rolls up to
+// "Idle" while a mixed healthy+idle app still reads Healthy (healthy out-ranks
+// neutral in the max). NOTE: the previous map inverted this — it ranked
+// `unknown: 0` below `healthy`, disagreeing with the backend rollup.
+export const HEALTH_ORDER: AppHealth[] = ['unhealthy', 'degraded', 'unknown', 'healthy', 'neutral']
+export const HEALTH_RANK: Record<string, number> = { unhealthy: 4, degraded: 3, unknown: 2, healthy: 1, neutral: 0 }
 
 export interface HealthMeta {
   label: string
@@ -670,6 +680,7 @@ export const CHIP_TONE = {
   amber: 'bg-amber-50 text-amber-700 ring-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:ring-amber-900',
   emerald: 'bg-emerald-50 text-emerald-700 ring-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:ring-emerald-900',
   blue: 'bg-blue-50 text-blue-700 ring-blue-200 dark:bg-blue-950/40 dark:text-blue-300 dark:ring-blue-900',
+  sky: 'bg-sky-50 text-sky-700 ring-sky-200 dark:bg-sky-950/40 dark:text-sky-300 dark:ring-sky-900',
   violet: 'bg-violet-50 text-violet-700 ring-violet-200 dark:bg-violet-950/40 dark:text-violet-300 dark:ring-violet-900',
   neutral: 'bg-theme-hover text-theme-text-secondary ring-theme-border',
   muted: 'bg-theme-hover text-theme-text-tertiary ring-theme-border',
@@ -679,6 +690,9 @@ export const HEALTH_META: Record<AppHealth, HealthMeta> = {
   unhealthy: { label: 'Down', bar: 'bg-rose-500', text: 'text-rose-600 dark:text-rose-400', pill: CHIP_TONE.rose },
   degraded: { label: 'Degraded', bar: 'bg-amber-500', text: 'text-amber-600 dark:text-amber-400', pill: CHIP_TONE.amber },
   healthy: { label: 'Healthy', bar: 'bg-emerald-500', text: 'text-emerald-600 dark:text-emerald-400', pill: CHIP_TONE.emerald },
+  // neutral = intentionally idle/off (every workload suspended or scaled to 0).
+  // Sky, calm — not "Healthy" (it isn't serving) and not a problem to act on.
+  neutral: { label: 'Idle', bar: 'bg-sky-500', text: 'text-sky-600 dark:text-sky-400', pill: CHIP_TONE.sky },
   unknown: { label: 'Unknown', bar: 'bg-slate-400', text: 'text-theme-text-tertiary', pill: CHIP_TONE.muted },
 }
 

--- a/packages/k8s-ui/src/utils/applications.ts
+++ b/packages/k8s-ui/src/utils/applications.ts
@@ -582,7 +582,9 @@ export function foldAppGroups<T extends AppGroupFoldEntry>(
     const compMap = new Map<AppWorkloadClass, number>()
     let ready = 0
     let desired = 0
-    let health: AppHealth = 'unknown'
+    // Seed with the most-benign tier (rank 0) so the max-fold below has a valid
+    // identity now that `unknown` ranks above healthy — see worstHealth.
+    let health: AppHealth = 'neutral'
     for (const m of members) {
       const v = newest(m)
       // A fleet member spans several per-cluster envs; the host supplies them so
@@ -740,9 +742,14 @@ export function workloadClassOf(value?: AppWorkloadClass): AppWorkloadClass {
   }
 }
 
-/** Worst health across a set of raw health strings. */
+/** Worst health across a set of raw health strings. Seeds with `neutral` — the
+ *  most-benign tier (rank 0) — so it acts as the max-fold identity: any real
+ *  value out-ranks it, an all-neutral set stays neutral, and healthy+neutral
+ *  resolves to healthy. (Seeding with `unknown` would be wrong now that `unknown`
+ *  ranks ABOVE healthy — an all-healthy set would never beat it and return
+ *  `unknown`. Mirrors pkg/health.WorseOf.) */
 export function worstHealth(hs: string[]): AppHealth {
-  let w: AppHealth = 'unknown'
+  let w: AppHealth = 'neutral'
   for (const h of hs) if ((HEALTH_RANK[h] ?? 0) > (HEALTH_RANK[w] ?? 0)) w = h as AppHealth
   return w
 }

--- a/packages/k8s-ui/src/utils/badge-colors.ts
+++ b/packages/k8s-ui/src/utils/badge-colors.ts
@@ -38,6 +38,10 @@ export const HEALTH_BADGE_COLORS: Record<string, string> = {
   degraded: BADGE_SEVERITY_COLORS.warning,
   alert: BADGE_SEVERITY_COLORS.alert,
   unhealthy: BADGE_SEVERITY_COLORS.error,
+  // neutral = intentional/idle (suspended, scaled-to-0, completed) — sky, calm
+  // and distinct from `unknown` (gray, "can't determine"). Reuses the `info`
+  // sky palette; see `.status-neutral` in theme/components.css.
+  neutral: BADGE_SEVERITY_COLORS.info,
   unknown: BADGE_SEVERITY_COLORS.neutral,
 }
 
@@ -225,6 +229,9 @@ export function healthToSeverity(health: string): Severity {
     case 'error':
     case 'failed':
       return 'error'
+    // health 'neutral' (intentional/idle) renders sky via the `info` palette —
+    // calm, and visually distinct from 'unknown' which falls through to gray.
+    case 'neutral':
     case 'info':
       return 'info'
     default:

--- a/pkg/health/golden_crosslang_test.go
+++ b/pkg/health/golden_crosslang_test.go
@@ -1,0 +1,100 @@
+package health
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// goldenVector is one (object, expected-level) pair in the shared cross-language
+// contract. The same testdata/golden_vectors.json is loaded by the frontend's
+// vitest (packages/k8s-ui/src/__tests__/health-golden.test.ts) so the TS table
+// classifiers can't drift from pkg/health, which is the source of truth.
+type goldenVector struct {
+	Name   string          `json:"name"`
+	Kind   string          `json:"kind"`
+	Level  string          `json:"level"`
+	Object json.RawMessage `json:"object"`
+}
+
+// TestGoldenVectorsCrossLang pins that pkg/health produces the level recorded in
+// the shared fixture for each object. The display/wire level is what the frontend
+// renders, so pods go through PodDisplayLevel (folds unschedulable/terminating)
+// and workloads through Workload. Keep this in lockstep with the vitest mirror.
+func TestGoldenVectorsCrossLang(t *testing.T) {
+	raw, err := os.ReadFile("testdata/golden_vectors.json")
+	if err != nil {
+		t.Fatalf("read golden vectors: %v", err)
+	}
+	var file struct {
+		Vectors []goldenVector `json:"vectors"`
+	}
+	if err := json.Unmarshal(raw, &file); err != nil {
+		t.Fatalf("parse golden vectors: %v", err)
+	}
+	if len(file.Vectors) == 0 {
+		t.Fatal("no golden vectors loaded")
+	}
+
+	// Fixed clock — every vector is time-independent (see the fixture comment), so
+	// the exact value is irrelevant, but pinning it keeps the run reproducible.
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+
+	for _, v := range file.Vectors {
+		t.Run(v.Name, func(t *testing.T) {
+			got := classifyGolden(t, v.Kind, v.Object, now)
+			if string(got) != v.Level {
+				t.Errorf("%s [%s]: got level %q, want %q", v.Name, v.Kind, got, v.Level)
+			}
+		})
+	}
+}
+
+func classifyGolden(t *testing.T, kind string, obj json.RawMessage, now time.Time) Level {
+	t.Helper()
+	switch kind {
+	case "Pod":
+		var pod corev1.Pod
+		mustUnmarshal(t, obj, &pod)
+		return PodDisplayLevel(&pod, now)
+	case "Deployment":
+		var d appsv1.Deployment
+		mustUnmarshal(t, obj, &d)
+		return Workload(&d, now).Level
+	case "StatefulSet":
+		var s appsv1.StatefulSet
+		mustUnmarshal(t, obj, &s)
+		return Workload(&s, now).Level
+	case "DaemonSet":
+		var ds appsv1.DaemonSet
+		mustUnmarshal(t, obj, &ds)
+		return Workload(&ds, now).Level
+	case "Job":
+		var j batchv1.Job
+		mustUnmarshal(t, obj, &j)
+		return Workload(&j, now).Level
+	case "CronJob":
+		var cj batchv1.CronJob
+		mustUnmarshal(t, obj, &cj)
+		return Workload(&cj, now).Level
+	case "PersistentVolumeClaim":
+		var pvc corev1.PersistentVolumeClaim
+		mustUnmarshal(t, obj, &pvc)
+		return Workload(&pvc, now).Level
+	default:
+		t.Fatalf("golden vector kind %q has no Go classifier mapping", kind)
+		return LevelUnknown
+	}
+}
+
+func mustUnmarshal(t *testing.T, raw json.RawMessage, into any) {
+	t.Helper()
+	if err := json.Unmarshal(raw, into); err != nil {
+		t.Fatalf("unmarshal object: %v", err)
+	}
+}

--- a/pkg/health/testdata/golden_vectors.json
+++ b/pkg/health/testdata/golden_vectors.json
@@ -1,0 +1,125 @@
+{
+  "_comment": "Cross-language health contract. The Go test (golden_crosslang_test.go) and the TS test (packages/k8s-ui/src/__tests__/health-golden.test.ts) BOTH load this file and assert their classifier produces `level` for `object`. It is the anti-drift gate: pkg/health is the source of truth; the TS table classifiers must agree. Only TIME-INDEPENDENT cases belong here — the TS classifier uses the real wall clock (no injected clock), so anything gated on age (young-pending grace, stuck-terminating, CronJob staleness) is intentionally excluded. `level` is the display/wire level (Pod via PodDisplayLevel; workloads via Workload).",
+  "vectors": [
+    {
+      "name": "pod running and ready is healthy",
+      "kind": "Pod",
+      "level": "healthy",
+      "object": { "status": { "phase": "Running", "containerStatuses": [{ "ready": true }] } }
+    },
+    {
+      "name": "pod succeeded is neutral (completed)",
+      "kind": "Pod",
+      "level": "neutral",
+      "object": { "status": { "phase": "Succeeded" } }
+    },
+    {
+      "name": "pod failed is unhealthy",
+      "kind": "Pod",
+      "level": "unhealthy",
+      "object": { "status": { "phase": "Failed" } }
+    },
+    {
+      "name": "pod crashloop is unhealthy",
+      "kind": "Pod",
+      "level": "unhealthy",
+      "object": { "status": { "phase": "Running", "containerStatuses": [{ "ready": false, "state": { "waiting": { "reason": "CrashLoopBackOff" } } }] } }
+    },
+    {
+      "name": "pod node-lost (phase Unknown) is unknown",
+      "kind": "Pod",
+      "level": "unknown",
+      "object": { "status": { "phase": "Unknown" } }
+    },
+    {
+      "name": "pod unschedulable is degraded",
+      "kind": "Pod",
+      "level": "degraded",
+      "object": { "status": { "phase": "Pending", "conditions": [{ "type": "PodScheduled", "status": "False", "reason": "Unschedulable" }] } }
+    },
+    {
+      "name": "deployment all replicas ready is healthy",
+      "kind": "Deployment",
+      "level": "healthy",
+      "object": { "spec": { "replicas": 3 }, "status": { "replicas": 3, "readyReplicas": 3, "availableReplicas": 3, "updatedReplicas": 3 } }
+    },
+    {
+      "name": "deployment partially ready is degraded",
+      "kind": "Deployment",
+      "level": "degraded",
+      "object": { "spec": { "replicas": 3 }, "status": { "replicas": 3, "readyReplicas": 1, "availableReplicas": 1, "updatedReplicas": 3 } }
+    },
+    {
+      "name": "deployment none ready is unhealthy",
+      "kind": "Deployment",
+      "level": "unhealthy",
+      "object": { "spec": { "replicas": 3 }, "status": { "replicas": 3, "readyReplicas": 0, "availableReplicas": 0, "updatedReplicas": 3 } }
+    },
+    {
+      "name": "deployment scaled to zero is neutral",
+      "kind": "Deployment",
+      "level": "neutral",
+      "object": { "spec": { "replicas": 0 }, "status": {} }
+    },
+    {
+      "name": "statefulset all replicas ready is healthy",
+      "kind": "StatefulSet",
+      "level": "healthy",
+      "object": { "spec": { "replicas": 2 }, "status": { "replicas": 2, "readyReplicas": 2, "availableReplicas": 2, "updatedReplicas": 2 } }
+    },
+    {
+      "name": "daemonset fully scheduled is healthy",
+      "kind": "DaemonSet",
+      "level": "healthy",
+      "object": { "status": { "desiredNumberScheduled": 3, "numberReady": 3, "updatedNumberScheduled": 3, "numberAvailable": 3 } }
+    },
+    {
+      "name": "daemonset matching no nodes (0/0) is neutral",
+      "kind": "DaemonSet",
+      "level": "neutral",
+      "object": { "status": { "desiredNumberScheduled": 0, "numberReady": 0 } }
+    },
+    {
+      "name": "job complete is neutral",
+      "kind": "Job",
+      "level": "neutral",
+      "object": { "status": { "conditions": [{ "type": "Complete", "status": "True" }] } }
+    },
+    {
+      "name": "job failed is unhealthy",
+      "kind": "Job",
+      "level": "unhealthy",
+      "object": { "status": { "conditions": [{ "type": "Failed", "status": "True" }] } }
+    },
+    {
+      "name": "job suspended is neutral",
+      "kind": "Job",
+      "level": "neutral",
+      "object": { "spec": { "suspend": true }, "status": {} }
+    },
+    {
+      "name": "cronjob suspended is neutral",
+      "kind": "CronJob",
+      "level": "neutral",
+      "object": { "spec": { "suspend": true, "schedule": "*/5 * * * *" }, "status": {} }
+    },
+    {
+      "name": "pvc bound is healthy",
+      "kind": "PersistentVolumeClaim",
+      "level": "healthy",
+      "object": { "status": { "phase": "Bound" } }
+    },
+    {
+      "name": "pvc pending is neutral",
+      "kind": "PersistentVolumeClaim",
+      "level": "neutral",
+      "object": { "status": { "phase": "Pending" } }
+    },
+    {
+      "name": "pvc lost is unhealthy",
+      "kind": "PersistentVolumeClaim",
+      "level": "unhealthy",
+      "object": { "status": { "phase": "Lost" } }
+    }
+  ]
+}

--- a/pkg/packages/gitops.go
+++ b/pkg/packages/gitops.go
@@ -101,7 +101,10 @@ func mapArgoHealth(s string) Health {
 	case "degraded":
 		return HealthUnhealthy
 	case "suspended":
-		return HealthDegraded
+		// Suspended = an operator deliberately paused sync (or a suspended
+		// CronJob/Rollout). Intentional, not a degradation — neutral (sky), so it
+		// doesn't light up amber on a surface meant for things that need action.
+		return HealthNeutral
 	case "missing":
 		// Argo "Missing" = "should exist but doesn't" — a real signal
 		// (controller hasn't been able to apply); not the same as

--- a/pkg/packages/gitops_test.go
+++ b/pkg/packages/gitops_test.go
@@ -81,7 +81,8 @@ func TestMapArgoHealth(t *testing.T) {
 		"healthy":     HealthHealthy,
 		"Progressing": HealthDegraded,
 		"Degraded":    HealthUnhealthy,
-		"Suspended":   HealthDegraded,
+		// Suspended = intentional pause, not a degradation — neutral (sky).
+		"Suspended": HealthNeutral,
 		// Missing means "should exist but doesn't" — surface as a
 		// real signal (degraded), not as the same bucket as Unknown.
 		"Missing": HealthDegraded,

--- a/pkg/packages/types.go
+++ b/pkg/packages/types.go
@@ -46,7 +46,11 @@ const (
 	HealthHealthy   Health = "healthy"
 	HealthDegraded  Health = "degraded"
 	HealthUnhealthy Health = "unhealthy"
-	HealthUnknown   Health = "unknown"
+	// HealthNeutral = intentional/idle (suspended app, every workload scaled to
+	// 0). Aggregates as most-benign (WorseHealth ties healthy, healthy-preferred),
+	// so an all-idle app rolls up to neutral while a mixed app stays healthy.
+	HealthNeutral Health = "neutral"
+	HealthUnknown Health = "unknown"
 )
 
 // Overlay is the optional Tier-2 "application" identity ABOVE a package — the

--- a/pkg/resourcecontext/summary.go
+++ b/pkg/resourcecontext/summary.go
@@ -124,11 +124,10 @@ func deriveHealth(obj runtime.Object) string {
 }
 
 // levelToString maps a canonical health.Level onto the string vocabulary the AI
-// summary emits. The summary wire stays at the established healthy/degraded/
-// unhealthy set in this change, so neutral (intentional/lifecycle states) and
-// unknown both derive to "" — the field is omitted rather than asserting a status
-// for an intentionally-off or unobservable resource. The dedicated neutral value
-// lands with the frontend follow-up.
+// summary / search emit. neutral (intentional/idle — suspended, scaled-to-zero,
+// completed) is emitted explicitly so the consumer can distinguish "off on
+// purpose" from healthy. unknown still derives to "" (the field is omitted rather
+// than asserting a status for an unobservable resource).
 func levelToString(l health.Level) string {
 	switch l {
 	case health.LevelHealthy:
@@ -137,6 +136,8 @@ func levelToString(l health.Level) string {
 		return "degraded"
 	case health.LevelUnhealthy:
 		return "unhealthy"
+	case health.LevelNeutral:
+		return "neutral"
 	}
 	return ""
 }

--- a/pkg/resourcecontext/summary_test.go
+++ b/pkg/resourcecontext/summary_test.go
@@ -132,9 +132,9 @@ func TestBuildSummary_DeploymentReplicasHealth(t *testing.T) {
 		{"all_ready", 3, 3, []byte(`{"health":"healthy"}`)},
 		{"none_ready", 0, 3, []byte(`{"health":"unhealthy"}`)},
 		{"partial", 1, 3, []byte(`{"health":"degraded"}`)},
-		// Scaled to zero is intentional — health omitted (neutral collapses to ""
-		// on the summary wire until the dedicated tier lands).
-		{"scaled_to_zero", 0, 0, nil},
+		// Scaled to zero is intentional/idle — emitted as the dedicated neutral
+		// value so the agent can distinguish "off on purpose" from healthy.
+		{"scaled_to_zero", 0, 0, []byte(`{"health":"neutral"}`)},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/pkg/timeline/types.go
+++ b/pkg/timeline/types.go
@@ -55,7 +55,11 @@ const (
 	HealthHealthy   HealthState = "healthy"
 	HealthDegraded  HealthState = "degraded"
 	HealthUnhealthy HealthState = "unhealthy"
-	HealthUnknown   HealthState = "unknown"
+	// HealthNeutral = intentional/idle (suspended, scaled-to-0, completed) —
+	// renders sky in the timeline, distinct from HealthUnknown (gray). Aggregates
+	// as most-benign via health.WorseOf (ties healthy, healthy-preferred).
+	HealthNeutral HealthState = "neutral"
+	HealthUnknown HealthState = "unknown"
 )
 
 // GroupingMode determines how events are grouped in the timeline

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -7523,25 +7523,25 @@ func extractKedaScaledJobStatus(sj unstructured.Unstructured) HealthStatus {
 		}
 	}
 
-	// Ready condition takes priority
-	if readyCond != nil {
-		switch readyCond["status"] {
-		case "True":
-			return StatusHealthy
-		case "False":
-			return StatusDegraded
-		}
+	// Ready=False = not operational; surface it before the idle check.
+	if readyCond != nil && readyCond["status"] == "False" {
+		return StatusDegraded
 	}
 
+	// Check Active before treating Ready=True as healthy: an operational scaler
+	// with no jobs running (Active=False) is intentionally idle → neutral (sky),
+	// not the green of a busy one. (Ready=True first would make Idle unreachable.)
 	if activeCond != nil {
 		switch activeCond["status"] {
 		case "True":
 			return StatusHealthy
 		case "False":
-			// Idle (no jobs currently scaled) is a Ready scaler's normal resting
-			// state, not degradation — match the resource view's neutral tone.
-			return StatusHealthy
+			return StatusNeutral
 		}
+	}
+
+	if readyCond != nil && readyCond["status"] == "True" {
+		return StatusHealthy
 	}
 
 	return StatusUnknown

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -7440,14 +7440,15 @@ func extractNodeStatus(node corev1.Node) HealthStatus {
 
 // extractKedaScaledObjectStatus reads conditions and annotations from a KEDA ScaledObject
 func extractKedaScaledObjectStatus(so unstructured.Unstructured) HealthStatus {
-	// Check for Paused annotation (two variants)
+	// Check for Paused annotation (two variants). Paused = an operator
+	// deliberately froze autoscaling — intentional, so neutral (sky), not amber.
 	annotations := so.GetAnnotations()
 	if annotations != nil {
 		if paused, ok := annotations["autoscaling.keda.sh/paused"]; ok && paused == "true" {
-			return StatusDegraded
+			return StatusNeutral
 		}
 		if _, ok := annotations["autoscaling.keda.sh/paused-replicas"]; ok {
-			return StatusDegraded
+			return StatusNeutral
 		}
 	}
 
@@ -7487,9 +7488,10 @@ func extractKedaScaledObjectStatus(so unstructured.Unstructured) HealthStatus {
 		case "True":
 			return StatusHealthy
 		case "False":
-			// Idle (no triggers firing) is the normal resting state of a Ready
-			// scaler, not degradation — match the resource view's neutral tone.
-			return StatusHealthy
+			// Idle (no triggers firing, scaled to zero) is the normal resting
+			// state of a Ready scaler — intentional/off, so neutral (sky), not the
+			// green of an actively-serving workload.
+			return StatusNeutral
 		}
 	}
 

--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -7429,10 +7429,16 @@ func extractKarpenterNodeClaimStatus(nc unstructured.Unstructured) HealthStatus 
 func extractNodeStatus(node corev1.Node) HealthStatus {
 	for _, cond := range node.Status.Conditions {
 		if cond.Type == corev1.NodeReady {
-			if cond.Status == corev1.ConditionTrue {
-				return StatusHealthy
+			if cond.Status != corev1.ConditionTrue {
+				return StatusUnhealthy
 			}
-			return StatusUnhealthy
+			// Ready but cordoned = lost scheduling capacity — degraded (amber),
+			// matching the node table badge + drawer + Cordoned audit, so the same
+			// node doesn't read green here while it's flagged elsewhere.
+			if node.Spec.Unschedulable {
+				return StatusDegraded
+			}
+			return StatusHealthy
 		}
 	}
 	return StatusUnknown

--- a/pkg/topology/health_adapter.go
+++ b/pkg/topology/health_adapter.go
@@ -9,10 +9,9 @@ import (
 )
 
 // healthLevelToStatus projects a canonical health.Level onto the topology
-// HealthStatus used for NODE COLORING. Until the topology vocabulary gains a
-// dedicated neutral tier, neutral (intentional / lifecycle states — completed,
-// scaled-to-zero, pending PVC) renders as unknown (gray): calm, and never
-// green-for-intentional.
+// HealthStatus used for NODE COLORING. neutral (intentional / lifecycle states —
+// completed, scaled-to-zero, suspended, pending PVC) renders as StatusNeutral
+// (sky): calm, and distinct from unknown (gray, "can't determine").
 func healthLevelToStatus(l health.Level) HealthStatus {
 	switch l {
 	case health.LevelHealthy:
@@ -21,7 +20,9 @@ func healthLevelToStatus(l health.Level) HealthStatus {
 		return StatusDegraded
 	case health.LevelUnhealthy:
 		return StatusUnhealthy
-	default: // neutral (interim) + unknown
+	case health.LevelNeutral:
+		return StatusNeutral
+	default: // unknown
 		return StatusUnknown
 	}
 }

--- a/pkg/topology/health_adapter_test.go
+++ b/pkg/topology/health_adapter_test.go
@@ -32,11 +32,11 @@ func TestGetPodStatusInspectsContainers(t *testing.T) {
 		t.Errorf("ready pod node color = %q, want healthy", got)
 	}
 
-	// Completed pod is neutral → renders gray (unknown) until topology gains a
-	// dedicated neutral tier.
+	// Completed pod is neutral → renders sky (StatusNeutral), distinct from the
+	// gray of an unknown/node-lost pod.
 	completed := &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodSucceeded}}
-	if got := getPodStatus(completed); got != StatusUnknown {
-		t.Errorf("completed pod node color = %q, want unknown (interim neutral)", got)
+	if got := getPodStatus(completed); got != StatusNeutral {
+		t.Errorf("completed pod node color = %q, want neutral", got)
 	}
 
 	// Unschedulable pod reads degraded (the topology surface folds the scheduling
@@ -121,8 +121,8 @@ func TestPodSummaryStatusBuckets(t *testing.T) {
 
 func TestGetPVCStatusPendingIsNeutral(t *testing.T) {
 	pending := &corev1.PersistentVolumeClaim{Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending}}
-	if got := getPVCStatus(pending); got != StatusUnknown {
-		t.Errorf("pending PVC = %q, want unknown (interim neutral; was degraded)", got)
+	if got := getPVCStatus(pending); got != StatusNeutral {
+		t.Errorf("pending PVC = %q, want neutral (was degraded)", got)
 	}
 	bound := &corev1.PersistentVolumeClaim{Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound}}
 	if got := getPVCStatus(bound); got != StatusHealthy {
@@ -140,7 +140,7 @@ func TestGetJobStatusViaCanonical(t *testing.T) {
 	complete := &batchv1.Job{Status: batchv1.JobStatus{
 		Conditions: []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}},
 	}}
-	if got := getJobStatus(complete); got != StatusUnknown {
-		t.Errorf("completed job = %q, want unknown (interim neutral)", got)
+	if got := getJobStatus(complete); got != StatusNeutral {
+		t.Errorf("completed job = %q, want neutral", got)
 	}
 }

--- a/pkg/topology/health_adapter_test.go
+++ b/pkg/topology/health_adapter_test.go
@@ -144,3 +144,22 @@ func TestGetJobStatusViaCanonical(t *testing.T) {
 		t.Errorf("completed job = %q, want neutral", got)
 	}
 }
+
+// TestExtractNodeStatusCordoned pins that a Ready-but-cordoned node reads degraded
+// in topology — matching the node table badge + drawer + Cordoned audit — instead
+// of green, which would contradict every other surface for the same node.
+func TestExtractNodeStatusCordoned(t *testing.T) {
+	ready := corev1.Node{Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}}}}
+	if got := extractNodeStatus(ready); got != StatusHealthy {
+		t.Errorf("ready node = %q, want healthy", got)
+	}
+	cordoned := ready
+	cordoned.Spec.Unschedulable = true
+	if got := extractNodeStatus(cordoned); got != StatusDegraded {
+		t.Errorf("ready+cordoned node = %q, want degraded", got)
+	}
+	notReady := corev1.Node{Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionFalse}}}}
+	if got := extractNodeStatus(notReady); got != StatusUnhealthy {
+		t.Errorf("not-ready node = %q, want unhealthy", got)
+	}
+}

--- a/pkg/topology/types.go
+++ b/pkg/topology/types.go
@@ -121,7 +121,10 @@ const (
 	StatusHealthy   HealthStatus = "healthy"
 	StatusDegraded  HealthStatus = "degraded"
 	StatusUnhealthy HealthStatus = "unhealthy"
-	StatusUnknown   HealthStatus = "unknown"
+	// StatusNeutral = intentional/idle (suspended, scaled-to-0, completed) —
+	// renders sky on the frontend, distinct from StatusUnknown (gray).
+	StatusNeutral HealthStatus = "neutral"
+	StatusUnknown HealthStatus = "unknown"
 )
 
 // EdgeType represents the type of connection between nodes


### PR DESCRIPTION
## Why

PR #1024 consolidated all backend health classification into one `pkg/health` engine but kept the `neutral` tier internal-only — collapsed on every wire — so the frontend couldn't show "intentionally idle/off." This finishes the job: `neutral` becomes a real end-to-end **sky** tier, the frontend's health vocabulary is reconciled with the backend's and pinned against drift, and intentional/idle states read calm and consistent on every surface instead of fake-green, false-amber, or contradicting themselves between table and drawer.

Operator vocabulary: **sky = intentional / off / resting · green = healthy / serving · amber = degraded / limping · red = down · gray = unknown.**

## What changed

**`neutral`/sky as a real tier, end-to-end.** Added to the topology `HealthStatus`, app-rollup `AppHealth`, and the Helm + timeline unions, with sky rendering wired through the badge colors, topology nodes (`StatusNeutral`), the Applications rollup (an "Idle" tier + facet), and timeline spans + legend. The backend stops collapsing `neutral` on every wire (topology, timeline `HealthNeutral`, packages `HealthNeutral`, resourcecontext `"neutral"`), so it reaches the UI.

**States that are neutral (sky) — consistently across table badge · topology · detail drawer · timeline · app rollup · GitOps:** a completed Job and its Pod, a suspended CronJob/Job, scaled-to-zero workloads, a pending (WaitForFirstConsumer) PVC, KEDA Idle/Paused, an Argo Application whose health is Suspended, and Argo manual-sync. The one deliberate exception is a **cordoned Node**, which is amber everywhere — intentional, but a present-tense loss of scheduling capacity, so it stays on the warning axis (not sky, and not the old red "Issues Detected").

**App-rollup rank fix.** The frontend ranked `unknown` *below* healthy — the opposite of `pkg/health.Rank`. Corrected to `unhealthy > degraded > unknown > healthy ≈ neutral`, so an all-idle app rolls up to a distinct **Idle** badge while a mixed healthy+idle app still reads Healthy.

**Timeline.** `buildHealthSpans` no longer synthesizes a false-green bar over a genuine node-lost/unknown span (distinct null sentinel vs. the overloaded `'unknown'`); historical Job events read neutral on completion and unhealthy only on a terminal failure.

**Detail surfaces agree with the calm table badge:** completed Job-pod containers (exit 0) render sky "Completed", not red; a completed pod's expected `Ready: False (PodCompleted)` condition is toned neutral, not red; a pending PVC shows a sky "awaiting binding" advisory (mentions WaitForFirstConsumer); a cordoned Node shows an amber advisory, not a red error; the stuck-terminating problem fires at 10m (matching the badge), not 60s.

**Cross-language golden-vector CI gate.** A shared fixture (`pkg/health/testdata/golden_vectors.json`) is loaded by both a Go test (`pkg/health`) and a vitest (`k8s-ui`); each asserts its classifier produces the recorded level for the same object. `pkg/health` is the source of truth — CI fails if the TS table classifiers drift from it.

## Non-goals

Per-resource health emission on the REST **list** path is intentionally excluded: the list handler returns shared informer-cache pointers, so attaching computed health would mutate the shared cache. The golden-vector gate makes the list's TS classifier provably identical to `pkg/health`, which delivers the anti-drift goal without it.

## Testing

`go test ./...` (pkg + root) · `npm test` (k8s-ui) · `make tsc` — all green, with golden-vector + classifier regression tests added. Visual-tested across GKE and EKS, dark + light mode, covering the sky states end-to-end: KEDA Idle, the Applications Idle rollup, completed Job/Pod, suspended CronJob, pending PVC + its de-alarmed drawer, cordoned Node, and the timeline idle spans + legend.
