### PR TITLE
fix(cron): humanize step-minute schedules ("*/5 * * * *" → "Every 5 minutes")

### DIFF
--- a/packages/k8s-ui/src/components/resources/cron-to-human.test.ts
+++ b/packages/k8s-ui/src/components/resources/cron-to-human.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { cronToHuman } from './resource-utils'
+
+describe('cronToHuman', () => {
+  it.each([
+    // The reported bug: step-minute with a wildcard hour was caught by the
+    // "Every hour at :MM" branch before the interval branch.
+    ['*/5 * * * *', 'Every 5 minutes'],
+    ['*/15 * * * *', 'Every 15 minutes'],
+    ['*/30 * * * *', 'Every 30 minutes'],
+    ['*/1 * * * *', 'Every minute'],
+    // Literal minute must still read as "Every hour at :MM" (not regressed).
+    ['30 * * * *', 'Every hour at :30'],
+    ['0 * * * *', 'Every hour at :00'],
+    ['5 * * * *', 'Every hour at :05'],
+    // Every minute.
+    ['* * * * *', 'Every minute'],
+    // Step-hour (the #952 fix) must still work.
+    ['0 */6 * * *', 'Every 6 hours'],
+    ['0 */1 * * *', 'Every hour'],
+    // Daily patterns.
+    ['0 0 * * *', 'Daily at midnight'],
+    ['0 9 * * *', 'Daily at 9:00'],
+    // Weekdays — only when hour:minute are literal.
+    ['0 9 * * 1-5', 'Weekdays at 9:00'],
+    ['0 9 * * MON-FRI', 'Weekdays at 9:00'],
+    ['30 14 * * 1-5', 'Weekdays at 14:30'],
+    // Constrained step-minute must NOT claim an unconstrained interval — these run
+    // only in a window, so we fall back to the raw cron rather than mislead.
+    ['*/5 9 * * *', '*/5 9 * * *'],
+    ['*/5 * * * 1-5', '*/5 * * * 1-5'],
+    ['*/5 9 * * 1-5', '*/5 9 * * 1-5'],
+    ['*/1 9 * * *', '*/1 9 * * *'],
+    // Falls back to the raw expression for shapes we don't humanize.
+    ['15 14 1 * *', '15 14 1 * *'],
+    ['*/5', '*/5'],
+    ['', '-'],
+  ])('humanizes %s -> %s', (cron, expected) => {
+    expect(cronToHuman(cron)).toBe(expected)
+  })
+})

--- a/packages/k8s-ui/src/components/resources/resource-utils.ts
+++ b/packages/k8s-ui/src/components/resources/resource-utils.ts
@@ -1244,17 +1244,30 @@ export function cronToHuman(cron: string): string {
   if (minute === '0' && hour !== '*' && dayOfMonth === '*' && month === '*' && dayOfWeek === '*') {
     return `Daily at ${hour}:00`
   }
-  if (minute !== '*' && hour === '*' && dayOfMonth === '*' && month === '*' && dayOfWeek === '*') {
+  // Exclude step-minute ("*/N") here so it falls through to the interval branch
+  // below — otherwise "*/5 * * * *" rendered as "Every hour at :*/5" instead of
+  // "Every 5 minutes". A literal minute like "30" still reads "Every hour at :30".
+  if (minute !== '*' && !minute.startsWith('*/') && hour === '*' && dayOfMonth === '*' && month === '*' && dayOfWeek === '*') {
     return `Every hour at :${minute.padStart(2, '0')}`
   }
   if (minute === '*' && hour === '*' && dayOfMonth === '*' && month === '*' && dayOfWeek === '*') {
     return 'Every minute'
   }
-  if (minute.startsWith('*/')) {
+  // Only claim a plain "Every N minutes" when nothing else constrains the window;
+  // otherwise "*/5 9 * * *" (only at 09:xx) or "*/5 * * * 1-5" (weekdays only)
+  // would read as an unconstrained interval. Constrained shapes fall through to
+  // the raw cron rather than assert something misleading.
+  if (minute.startsWith('*/') && hour === '*' && dayOfMonth === '*' && month === '*' && dayOfWeek === '*') {
     const interval = minute.slice(2)
-    return `Every ${interval} minutes`
+    return interval === '1' ? 'Every minute' : `Every ${interval} minutes`
   }
-  if (dayOfWeek === '1-5' || dayOfWeek === 'MON-FRI') {
+  // Weekday phrasing needs a literal hour:minute — a wildcard/step in either field
+  // (e.g. "*/5 * * * 1-5") would render "Weekdays at *:*/5", so let it fall to raw.
+  if (
+    (dayOfWeek === '1-5' || dayOfWeek === 'MON-FRI') &&
+    hour !== '*' && !hour.startsWith('*/') &&
+    minute !== '*' && !minute.startsWith('*/')
+  ) {
     return `Weekdays at ${hour}:${minute.padStart(2, '0')}`
   }
 


### PR DESCRIPTION
## Why

`cronToHuman` rendered `*/5 * * * *` as **"Every hour at :*/5"** instead of **"Every 5 minutes"** — visible on the CronJob row + detail "Human" field. PR #952 fixed the sibling *step-hour* case (`0 */6 * * *` → "Every 6 hours") but didn't cover step-*minute*.

## Root cause

The `"Every hour at :MM"` branch (`minute !== '*' && hour === '*'`) matched any non-`*` minute — including `*/5` — and fired *before* the `minute.startsWith('*/')` interval branch a few lines down, so step-minutes never reached it.

## What changed

- Guard the `:MM` branch with `!minute.startsWith('*/')` so step-minutes fall through to the interval branch. A literal minute (`30 * * * *`) still reads "Every hour at :30".
- `*/1 * * * *` now reads "Every minute" (mirrors #952's `interval === '1'` handling).
- **Tightened two over-broad branches** found while verifying with a cross-model pass: the step-minute interval branch and the weekday branch now require the *other* cron fields to be unconstrained. So `*/5 9 * * *` (only at 09:xx) and `*/5 * * * 1-5` (weekdays only) fall back to the **raw cron** instead of confidently claiming "Every 5 minutes" / "Weekdays at *:*/5". Honest beats wrong.

## Testing

- New `cron-to-human.test.ts` — 22-case table covering the bug, every preserved pattern (literal minute, step-hour, daily, weekday), and the constrained shapes that now fall back to raw. `npm test` ✓ · `make tsc` ✓.
- Cross-checked with codex twice: it confirmed no regressions and "did not find an introduced correctness issue."

Independent of the health/neutral-tier PR (#1032) — pure cron-text fix, branched off main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in `cronToHuman` with targeted guards and new unit tests; no scheduling or API behavior.
> 
> **Overview**
> Fixes **`cronToHuman`** so CronJob list/detail “Human” text is correct for common step-minute schedules and avoids misleading labels when the cron is only partially matched.
> 
> **`*/5 * * * *`** (and similar) now shows **“Every 5 minutes”** instead of **“Every hour at :*/5”**, by excluding `*/N` minutes from the “Every hour at :MM” branch so step-minutes reach the interval logic. **`*/1 * * * *`** maps to **“Every minute”**, matching existing step-hour handling.
> 
> Step-minute **“Every N minutes”** and **“Weekdays at …”** phrasing only apply when hour/day fields are unconstrained and minute/hour are literals; otherwise the UI shows the **raw cron** (e.g. `*/5 9 * * *`, `*/5 * * * 1-5`) instead of implying a 24/7 interval.
> 
> Adds **`cron-to-human.test.ts`** with a table-driven suite for the bug, preserved patterns, and constrained fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ab29a0cd8e0142a83f2dd8266e42d7d082658b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->