### PR TITLE
fix(curl): don't let a stale close timer clear a newly-opened panel

### DIFF
--- a/web/src/components/resources/renderers/ServiceRenderer.tsx
+++ b/web/src/components/resources/renderers/ServiceRenderer.tsx
@@ -30,7 +30,9 @@ export function ServiceRenderer({ data, onCopy, copied, onNavigate }: ServiceRen
   const [curl, setCurl] = useState<{ port: number; closing: boolean } | null>(null)
   const closeCurl = useCallback(() => {
     setCurl((p) => (p ? { ...p, closing: true } : null))
-    window.setTimeout(() => setCurl(null), 220)
+    // Only drop the panel if it's still the one closing. Opening another port
+    // (which sets closing:false) before this fires must not clear the new panel.
+    window.setTimeout(() => setCurl((p) => (p?.closing ? null : p)), 220)
   }, [])
   const spec = data.spec || {}
   const shouldLoadEndpointSlices = Boolean(


### PR DESCRIPTION
## Summary

Followup to #1017. Bugbot flagged this one minute before that PR merged, so it landed unfixed.

The inline Curl panel's `closeCurl` scheduled an **unconditional** `setCurl(null)` after the 220ms collapse animation. If you closed one port's Curl panel and opened another port's within that window, the stale timer fired and wiped the **freshly-opened** panel.

## Fix

Guard the timeout to only clear while the panel is still closing:

```js
window.setTimeout(() => setCurl((p) => (p?.closing ? null : p)), 220)
```

Opening another port sets `closing: false`, so a stale timer no longer clears it; re-closing schedules a fresh timer. One-line change in `ServiceRenderer.tsx`.

## Testing

`make tsc` ✓. Visual-test skipped: one-line state-guard with self-evident semantics, and the local e2e kind cluster is currently unstable (OOM). CI covers tsc/lint/build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line UI state guard in `ServiceRenderer`; no auth, data, or API behavior changes.
> 
> **Overview**
> **Fixes a race** in the Service inline Curl panel: `closeCurl` still marks the panel `closing` and waits 220ms for the collapse animation, but the follow-up state update no longer unconditionally clears `curl`.
> 
> The timeout now uses a functional `setCurl` that sets state to `null` **only if** `p?.closing` is still true. Opening another port’s Curl within that window sets `{ port, closing: false }`, so a stale timer no longer wipes the newly opened panel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f6f02d5f342717f765b2188107ceb49719da534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->