### PR TITLE
Fix desktop menu actions

### DIFF
--- a/cmd/desktop/menu.go
+++ b/cmd/desktop/menu.go
@@ -11,12 +11,8 @@ func createMenu(desktopApp *DesktopApp, version string) *menu.Menu {
 
 	// File menu
 	fileMenu := appMenu.AddSubmenu("File")
-	fileMenu.AddText("New Window", keys.CmdOrCtrl("n"), func(_ *menu.CallbackData) {
-		// Future: open a new window with a different context
-	})
-	fileMenu.AddSeparator()
 	fileMenu.AddText("Settings...", keys.CmdOrCtrl(","), func(_ *menu.CallbackData) {
-		runtime.EventsEmit(desktopApp.ctx, "open-settings")
+		runtime.WindowExecJS(desktopApp.ctx, `window.dispatchEvent(new Event('radar:open-settings'))`)
 	})
 	fileMenu.AddSeparator()
 	fileMenu.AddText("Quit", keys.CmdOrCtrl("q"), func(_ *menu.CallbackData) {
@@ -97,8 +93,7 @@ func createMenu(desktopApp *DesktopApp, version string) *menu.Menu {
 	// Help menu
 	helpMenu := appMenu.AddSubmenu("Help")
 	helpMenu.AddText("Check for Updates...", nil, func(_ *menu.CallbackData) {
-		// Emit an event that the frontend listens for to trigger a version check
-		runtime.EventsEmit(desktopApp.ctx, "check-for-updates")
+		runtime.WindowExecJS(desktopApp.ctx, `window.dispatchEvent(new Event('radar:check-for-updates'))`)
 	})
 	helpMenu.AddSeparator()
 	helpMenu.AddText("About Radar", nil, func(_ *menu.CallbackData) {

--- a/cmd/desktop/menu_test.go
+++ b/cmd/desktop/menu_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/wailsapp/wails/v2/pkg/menu"
+)
+
+func TestCreateMenuFileMenuExposesSupportedActions(t *testing.T) {
+	appMenu := createMenu(&DesktopApp{}, "test")
+	fileMenu := findSubmenu(t, appMenu, "File")
+
+	got := menuLabels(fileMenu)
+	want := []string{"Settings...", "Quit"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("File menu labels = %v, want %v", got, want)
+	}
+}
+
+func TestCreateMenuHelpMenuKeepsUpdateAction(t *testing.T) {
+	appMenu := createMenu(&DesktopApp{}, "test")
+	helpMenu := findSubmenu(t, appMenu, "Help")
+
+	if !containsLabel(helpMenu, "Check for Updates...") {
+		t.Fatalf("Help menu is missing Check for Updates action")
+	}
+}
+
+func TestCreateMenuNativeActionsHaveCallbacks(t *testing.T) {
+	appMenu := createMenu(&DesktopApp{}, "test")
+
+	cases := []struct {
+		menu string
+		item string
+	}{
+		{"File", "Settings..."},
+		{"File", "Quit"},
+		{"Help", "Check for Updates..."},
+	}
+	for _, tc := range cases {
+		t.Run(tc.menu+"/"+tc.item, func(t *testing.T) {
+			item := findMenuItem(t, findSubmenu(t, appMenu, tc.menu), tc.item)
+			if item.Click == nil {
+				t.Fatalf("%s -> %s has no callback", tc.menu, tc.item)
+			}
+		})
+	}
+}
+
+func findSubmenu(t *testing.T, root *menu.Menu, label string) *menu.Menu {
+	t.Helper()
+	for _, item := range root.Items {
+		if item.Label == label && item.SubMenu != nil {
+			return item.SubMenu
+		}
+	}
+	t.Fatalf("submenu %q not found", label)
+	return nil
+}
+
+func findMenuItem(t *testing.T, m *menu.Menu, label string) *menu.MenuItem {
+	t.Helper()
+	for _, item := range m.Items {
+		if item.Label == label {
+			return item
+		}
+	}
+	t.Fatalf("menu item %q not found", label)
+	return nil
+}
+
+func menuLabels(m *menu.Menu) []string {
+	var labels []string
+	for _, item := range m.Items {
+		if item.Type == menu.SeparatorType {
+			continue
+		}
+		labels = append(labels, item.Label)
+	}
+	return labels
+}
+
+func containsLabel(m *menu.Menu, label string) bool {
+	for _, item := range m.Items {
+		if item.Label == label {
+			return true
+		}
+	}
+	return false
+}

--- a/web/e2e/settings.spec.ts
+++ b/web/e2e/settings.spec.ts
@@ -2,13 +2,13 @@ import { test, expect } from '@playwright/test'
 
 test.describe('Settings dialog', () => {
 
-  test('gear icon opens settings dialog', async ({ page }) => {
+  test('settings nav action opens settings dialog', async ({ page }) => {
     await page.goto('/')
     // Wait for the app to load
     await page.waitForSelector('header', { timeout: 10000 })
 
-    // Click the settings gear icon
-    const settingsBtn = page.locator('button[title="Settings"]')
+    // Click the Settings action in the primary nav rail
+    const settingsBtn = page.getByRole('button', { name: 'Settings' })
     await expect(settingsBtn).toBeVisible()
     await settingsBtn.click()
 
@@ -20,11 +20,20 @@ test.describe('Settings dialog', () => {
     await expect(page.getByText('Kubeconfig', { exact: true })).toBeVisible()
   })
 
+  test('desktop menu event opens settings dialog', async ({ page }) => {
+    await page.goto('/')
+    await page.waitForSelector('header', { timeout: 10000 })
+
+    await page.evaluate(() => window.dispatchEvent(new Event('radar:open-settings')))
+
+    await expect(page.getByText('Kubeconfig', { exact: true })).toBeVisible()
+  })
+
   test('Configuration fields are visible', async ({ page }) => {
     await page.goto('/')
     await page.waitForSelector('header', { timeout: 10000 })
 
-    await page.locator('button[title="Settings"]').click()
+    await page.getByRole('button', { name: 'Settings' }).click()
 
     // Should show the Configuration content
     await expect(page.locator('text=Changes require a restart')).toBeVisible()
@@ -37,7 +46,7 @@ test.describe('Settings dialog', () => {
     await page.goto('/')
     await page.waitForSelector('header', { timeout: 10000 })
 
-    await page.locator('button[title="Settings"]').click()
+    await page.getByRole('button', { name: 'Settings' }).click()
     await expect(page.getByText('Kubeconfig', { exact: true })).toBeVisible()
 
     await page.keyboard.press('Escape')
@@ -49,7 +58,7 @@ test.describe('Settings dialog', () => {
     await page.goto('/')
     await page.waitForSelector('header', { timeout: 10000 })
 
-    await page.locator('button[title="Settings"]').click()
+    await page.getByRole('button', { name: 'Settings' }).click()
     await expect(page.getByText('Kubeconfig', { exact: true })).toBeVisible()
 
     // Click the backdrop (outside the dialog)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -388,15 +388,6 @@ function AppInner() {
   const [showSettings, setShowSettings] = useState(false)
   const [showMyPermissions, setShowMyPermissions] = useState(false)
 
-  // Listen for desktop "open-settings" event from native menu
-  useEffect(() => {
-    const wailsRuntime = (window as unknown as Record<string, unknown>).runtime as
-      | { EventsOn?: (event: string, callback: () => void) => () => void }
-      | undefined
-    if (!wailsRuntime?.EventsOn) return
-    return wailsRuntime.EventsOn('open-settings', () => setShowSettings(true))
-  }, [])
-
   // Listen for "open-settings" DOM event (used by MCPSetupDialog etc.)
   useEffect(() => {
     const handler = () => setShowSettings(true)

--- a/web/src/components/ui/UpdateNotification.tsx
+++ b/web/src/components/ui/UpdateNotification.tsx
@@ -27,21 +27,16 @@ export function UpdateNotification() {
 
   const isDesktop = versionInfo?.installMethod === 'desktop'
 
-  // Listen for "Check for Updates" menu item in desktop app (Wails runtime event).
-  // Un-dismisses the notification and invalidates the version check cache.
+  // Listen for "Check for Updates" menu item in desktop app.
   useEffect(() => {
-    const wailsRuntime = (window as unknown as Record<string, unknown>).runtime as
-      | { EventsOn?: (event: string, callback: () => void) => () => void }
-      | undefined
-    if (!wailsRuntime?.EventsOn) return
-
-    const cleanup = wailsRuntime.EventsOn('check-for-updates', () => {
+    const handler = () => {
       setDismissed(false)
       try { localStorage.removeItem(DISMISSED_KEY) } catch { /* ignore */ }
       queryClient.invalidateQueries({ queryKey: ['version-check'] })
-    })
+    }
 
-    return cleanup
+    window.addEventListener('radar:check-for-updates', handler)
+    return () => window.removeEventListener('radar:check-for-updates', handler)
   }, [queryClient])
 
   // Log version check errors for debugging


### PR DESCRIPTION
## Summary

Fixes the Debian/GNOME desktop menu behavior reported in #1026. The native desktop menu no longer advertises an unsupported New Window action, and the remaining relevant menu items invoke the running Radar UI through DOM events that work after the Wails webview redirects to localhost.

## What changed

- Removed File -> New Window from the Wails desktop menu because Radar does not support opening a second native window through the current desktop shell.
- Kept File -> Settings..., wired through WindowExecJS to dispatch radar:open-settings into the active webview document.
- Updated Help -> Check for Updates... to use the same DOM-event bridge instead of Wails runtime events, which are unavailable after the desktop app redirects the webview to localhost.
- Removed dead frontend Wails runtime event listeners.
- Added desktop menu model coverage for the supported File menu actions and callback wiring.
- Added settings e2e coverage for the radar:open-settings event path, and updated the settings e2e selector to the current accessible nav action.

## Testing

- make tsc
- make test
- make build
- go test ./cmd/desktop
- npx playwright test e2e/settings.spec.ts --project=chromium
- visual-test: skipped (native desktop menu behavior and settings dialog event wiring; no new rendered UI surface)