### PR TITLE
feat(issues): coalesce same-subject issue rows into their root cause

### DIFF
--- a/internal/issues/compose.go
+++ b/internal/issues/compose.go
@@ -148,6 +148,13 @@ func ComposeWithStats(p Provider, f Filters) ([]Issue, ComposeStats) {
 	// rows, so they run BEFORE grouping and BEFORE the public filters.
 	out = applyClusterScopedAccess(out, f)
 	out = dedupePodSchedulingOverProblem(out)
+	// Same-resource structural-root → symptom: fold a pod's runtime symptom into
+	// the dangling-ref that caused it, and an autoscaler's condition into its
+	// missing target. Runs before the workload-rollup pass so the single richest
+	// child (the missing-ref root) is what reaches rollup suppression.
+	out = dedupeContainerWaitingOverMissingRef(out)
+	out = dedupeImagePullOverMissingPullSecret(out)
+	out = dedupeHPAOverMissingTarget(out)
 	out = dedupeWorkloadDegradedOverChild(out)
 	out = dedupeConditionOverMissingRef(out)
 	out = dedupePVCPendingOverMissingRef(out)

--- a/internal/issues/dedupe.go
+++ b/internal/issues/dedupe.go
@@ -245,6 +245,115 @@ func dedupePVCPendingOverMissingRef(in []Issue) []Issue {
 	return out
 }
 
+// missingConfigCausesWaiting are the by-name dangling references whose failure
+// surfaces as a container stuck in Waiting (CreateContainerConfigError): the
+// referenced ConfigMap/Secret/ServiceAccount/imagePullSecret doesn't exist, so
+// the kubelet can't build the container config. "Missing PVC" is excluded — it
+// blocks scheduling (unschedulable), not container creation.
+var missingConfigCausesWaiting = map[string]bool{
+	"Missing ConfigMap":       true,
+	"Missing Secret":          true,
+	"Missing ServiceAccount":  true,
+	"Missing imagePullSecret": true,
+}
+
+// structuralRootOverSymptom drops a runtime SYMPTOM row for a resource when a
+// structural root row — a by-name dangling reference the detector resolved —
+// exists for the SAME resource. The structural row names the exact broken object
+// and the concrete fix and is the reason the symptom exists, so it is the richer
+// row and always wins. Keyed on the resource itself (not the owner subject):
+// both rows describe the same Pod/HPA, emitted by different detectors.
+//
+// The surviving root is promoted to the highest severity among the symptoms it
+// absorbs, so folding a symptom can never lower the displayed incident severity
+// (the same floor dedupeWorkloadDegradedOverChild enforces, here preserved by
+// promotion rather than a keep-the-parent gate, since here the root is the
+// survivor).
+func structuralRootOverSymptom(in []Issue, isRoot, isSymptom func(Issue) bool) []Issue {
+	rootExists := map[string]bool{}
+	for _, i := range in {
+		if isRoot(i) {
+			rootExists[issueResourceKey(i)] = true
+		}
+	}
+	if len(rootExists) == 0 {
+		return in
+	}
+	foldedSev := map[string]int{}
+	out := in[:0]
+	for _, i := range in {
+		if isSymptom(i) && rootExists[issueResourceKey(i)] {
+			k := issueResourceKey(i)
+			if r := SeverityRank(i.Severity); r > foldedSev[k] {
+				foldedSev[k] = r
+			}
+			continue
+		}
+		out = append(out, i)
+	}
+	for idx := range out {
+		i := &out[idx]
+		if !isRoot(*i) {
+			continue
+		}
+		if r, ok := foldedSev[issueResourceKey(*i)]; ok && r > SeverityRank(i.Severity) {
+			i.Severity = severityForRank(r)
+		}
+	}
+	return out
+}
+
+// dedupeContainerWaitingOverMissingRef drops the generic container_waiting pod
+// row when a missing ConfigMap/Secret/ServiceAccount/imagePullSecret was
+// structurally detected for the same pod: the dangling ref IS why the container
+// can't start, and the missing-ref row names the exact object + fix.
+func dedupeContainerWaitingOverMissingRef(in []Issue) []Issue {
+	return structuralRootOverSymptom(in,
+		func(i Issue) bool {
+			return i.Source == SourceMissingRef && i.Kind == "Pod" &&
+				i.Category == issuesapi.CategoryMissingConfigRef && missingConfigCausesWaiting[i.Reason]
+		},
+		func(i Issue) bool {
+			return i.Source == SourceProblem && i.Kind == "Pod" &&
+				i.Category == issuesapi.CategoryContainerWaiting
+		})
+}
+
+// dedupeImagePullOverMissingPullSecret drops the image_pull_failed pod row when
+// the missing imagePullSecret was structurally detected for the same pod. Gated
+// tightly to the pull-secret reason: an unrelated image_pull_failed (wrong tag,
+// rate-limit) on the same pod has a different root and must survive.
+func dedupeImagePullOverMissingPullSecret(in []Issue) []Issue {
+	return structuralRootOverSymptom(in,
+		func(i Issue) bool {
+			return i.Source == SourceMissingRef && i.Kind == "Pod" &&
+				i.Category == issuesapi.CategoryMissingConfigRef && i.Reason == "Missing imagePullSecret"
+		},
+		func(i Issue) bool {
+			return i.Source == SourceProblem && i.Kind == "Pod" &&
+				i.Category == issuesapi.CategoryImagePullFailed
+		})
+}
+
+// dedupeHPAOverMissingTarget drops the hpa_limited_or_failed row when the
+// autoscaler's scaleTargetRef points at a workload that doesn't exist. When the
+// target is missing, every HPA/KEDA condition (can't-scale, no-metrics) is
+// downstream of that one fact — there is no target to scale or read metrics for —
+// so the missing-ref row is the single root. (When the target EXISTS there is no
+// missing-ref row, so a genuine maxed/metrics problem is never touched.)
+func dedupeHPAOverMissingTarget(in []Issue) []Issue {
+	isAutoscaler := func(kind string) bool {
+		return kind == "HorizontalPodAutoscaler" || kind == "ScaledObject"
+	}
+	return structuralRootOverSymptom(in,
+		func(i Issue) bool {
+			return i.Source == SourceMissingRef && isAutoscaler(i.Kind) && i.Reason == "Missing scaleTargetRef"
+		},
+		func(i Issue) bool {
+			return i.Category == issuesapi.CategoryHPALimitedOrFailed && isAutoscaler(i.Kind)
+		})
+}
+
 func isMissingRefEchoCondition(i Issue) bool {
 	if i.Group != "gateway.networking.k8s.io" {
 		return false
@@ -259,6 +368,21 @@ func isMissingRefEchoCondition(i Issue) bool {
 
 func issueResourceCategoryKey(i Issue) string {
 	return resourceKey(i.Group, i.Kind, i.Namespace, i.Name) + "\x00" + string(i.Category)
+}
+
+// issueResourceKey is the canonical key for the issue's OWN resource (not its
+// owner subject) — used by same-resource cross-detector dedup where two
+// detectors describe the same Pod/HPA.
+func issueResourceKey(i Issue) string {
+	return resourceKey(i.Group, i.Kind, i.Namespace, i.Name)
+}
+
+// severityForRank inverts SeverityRank for the two issue-layer severities.
+func severityForRank(r int) Severity {
+	if r >= 3 {
+		return SeverityCritical
+	}
+	return SeverityWarning
 }
 
 // subjectKeyOf is the canonical string key for a subject Ref — the same

--- a/internal/issues/dedupe.go
+++ b/internal/issues/dedupe.go
@@ -48,30 +48,48 @@ func subjectRef(i Issue) Ref {
 
 // childCategories are the specific, root-cause symptoms that, when present for a
 // subject, make the parent workload-level rollup (workload_degraded /
-// rollout_stalled) redundant. A degraded Deployment with crashlooping pods is
-// ONE incident — the crashloop — not two; keeping both is the inverse of
-// "50 pods = 1 row".
+// rollout_stalled / job_failed) redundant. A degraded Deployment with
+// crashlooping pods is ONE incident — the crashloop — not two; keeping both is
+// the inverse of "50 pods = 1 row".
+//
+// The admission-rejection categories belong here because a workload that can't
+// create its pods reports ReplicaFailure → the rollup, while the scheduling
+// source names the actual rejection (no Pod exists yet). They are emitted on the
+// same owner subject via the same path as quota_exceeded, so they fold the same way.
 var childCategories = map[issuesapi.Category]bool{
-	issuesapi.CategoryCrashLoop:           true,
-	issuesapi.CategoryHighRestart:         true,
-	issuesapi.CategoryImagePullFailed:     true,
-	issuesapi.CategoryOOMKilled:           true,
-	issuesapi.CategoryContainerWaiting:    true,
-	issuesapi.CategoryInitContainerFailed: true,
-	issuesapi.CategoryLivenessProbeFail:   true,
-	issuesapi.CategoryReadinessFailed:     true,
-	issuesapi.CategoryUnschedulable:       true,
-	issuesapi.CategoryQuotaExceeded:       true,
-	issuesapi.CategoryMissingConfigRef:    true,
-	issuesapi.CategoryVolumeMountFailed:   true,
-	issuesapi.CategoryPVCPending:          true,
+	issuesapi.CategoryCrashLoop:                true,
+	issuesapi.CategoryHighRestart:              true,
+	issuesapi.CategoryImagePullFailed:          true,
+	issuesapi.CategoryOOMKilled:                true,
+	issuesapi.CategoryContainerWaiting:         true,
+	issuesapi.CategoryInitContainerFailed:      true,
+	issuesapi.CategoryLivenessProbeFail:        true,
+	issuesapi.CategoryReadinessFailed:          true,
+	issuesapi.CategoryUnschedulable:            true,
+	issuesapi.CategoryQuotaExceeded:            true,
+	issuesapi.CategoryAdmissionWebhookBlocking: true,
+	issuesapi.CategoryPodSecurityViolation:     true,
+	issuesapi.CategoryRBACForbidden:            true,
+	issuesapi.CategoryMissingConfigRef:         true,
+	issuesapi.CategoryVolumeMountFailed:        true,
+	issuesapi.CategoryPVCPending:               true,
 }
 
 // parentRollupCategories are the workload-level summaries that should be
 // suppressed when a more-specific child symptom exists for the same subject.
+//
+// job_failed is a rollup too: a failed Job's pods resolve their top owner to the
+// Job, so a BackoffLimitExceeded Job whose pods crashloop/OOM/can't-pull is one
+// incident — the pod cause is the root. A DeadlineExceeded job (the controller
+// killed a slow-but-not-crashing pod) has no qualifying child, so the severity
+// gate keeps its row. cronjob_failed is deliberately NOT here: "stale" /
+// "never-scheduled" means no Jobs were produced at all — an orthogonal failure
+// with no symptom children to fold into (a failed child Job surfaces as
+// job_failed on that Job, which already resolves to the CronJob subject).
 var parentRollupCategories = map[issuesapi.Category]bool{
 	issuesapi.CategoryWorkloadDegraded: true,
 	issuesapi.CategoryRolloutStalled:   true,
+	issuesapi.CategoryJobFailed:        true,
 }
 
 // dedupeWorkloadDegradedOverChild drops the parent workload rollup row

--- a/internal/issues/dedupe.go
+++ b/internal/issues/dedupe.go
@@ -264,11 +264,17 @@ var missingConfigCausesWaiting = map[string]bool{
 // row and always wins. Keyed on the resource itself (not the owner subject):
 // both rows describe the same Pod/HPA, emitted by different detectors.
 //
-// The surviving root is promoted to the highest severity among the symptoms it
-// absorbs, so folding a symptom can never lower the displayed incident severity
-// (the same floor dedupeWorkloadDegradedOverChild enforces, here preserved by
-// promotion rather than a keep-the-parent gate, since here the root is the
-// survivor).
+// Two evidence properties of the dropped symptom are donated to the surviving
+// root so the fold loses nothing the operator needs:
+//   - Severity: the root is promoted to the highest severity among the symptoms
+//     it absorbs, so folding can never lower the displayed incident severity (the
+//     floor dedupeWorkloadDegradedOverChild enforces, here via promotion since the
+//     root is the survivor). A by-name root is stamped from resource age and has
+//     no timing of its own.
+//   - Timing: the root inherits the symptom's issue_timing when it has none. The
+//     symptom (e.g. an HPA cannot-scale derived from the ScalingActive condition)
+//     can carry the only accurate "started after the resource was healthy" signal;
+//     disagreeing symptoms donate nothing, mirroring the rollup pass.
 func structuralRootOverSymptom(in []Issue, isRoot, isSymptom func(Issue) bool) []Issue {
 	rootExists := map[string]bool{}
 	for _, i := range in {
@@ -280,12 +286,23 @@ func structuralRootOverSymptom(in []Issue, isRoot, isSymptom func(Issue) bool) [
 		return in
 	}
 	foldedSev := map[string]int{}
+	foldedTiming := map[string]string{}
+	foldedBasis := map[string]string{}
+	timingConflict := map[string]bool{}
 	out := in[:0]
 	for _, i := range in {
 		if isSymptom(i) && rootExists[issueResourceKey(i)] {
 			k := issueResourceKey(i)
 			if r := SeverityRank(i.Severity); r > foldedSev[k] {
 				foldedSev[k] = r
+			}
+			if i.IssueTiming != "" && !timingConflict[k] {
+				if prev, ok := foldedTiming[k]; ok && prev != i.IssueTiming {
+					timingConflict[k] = true
+				} else if !ok {
+					foldedTiming[k] = i.IssueTiming
+					foldedBasis[k] = i.IssueTimingBasis
+				}
 			}
 			continue
 		}
@@ -296,8 +313,15 @@ func structuralRootOverSymptom(in []Issue, isRoot, isSymptom func(Issue) bool) [
 		if !isRoot(*i) {
 			continue
 		}
-		if r, ok := foldedSev[issueResourceKey(*i)]; ok && r > SeverityRank(i.Severity) {
+		k := issueResourceKey(*i)
+		if r, ok := foldedSev[k]; ok && r > SeverityRank(i.Severity) {
 			i.Severity = severityForRank(r)
+		}
+		if i.IssueTiming == "" && !timingConflict[k] {
+			if t := foldedTiming[k]; t != "" {
+				i.IssueTiming = t
+				i.IssueTimingBasis = foldedBasis[k]
+			}
 		}
 	}
 	return out
@@ -314,8 +338,12 @@ func dedupeContainerWaitingOverMissingRef(in []Issue) []Issue {
 				i.Category == issuesapi.CategoryMissingConfigRef && missingConfigCausesWaiting[i.Reason]
 		},
 		func(i Issue) bool {
+			// Only the config-stage waiting reason is caused by a missing
+			// CM/Secret/SA — a multi-container pod can carry a different waiting
+			// reason (RunContainerError, ContainerCreating) from an unrelated
+			// container, which must not be folded away.
 			return i.Source == SourceProblem && i.Kind == "Pod" &&
-				i.Category == issuesapi.CategoryContainerWaiting
+				i.Category == issuesapi.CategoryContainerWaiting && i.Reason == "CreateContainerConfigError"
 		})
 }
 

--- a/internal/issues/dedupe_test.go
+++ b/internal/issues/dedupe_test.go
@@ -42,6 +42,94 @@ func TestDedupePodSchedulingOverProblem(t *testing.T) {
 	})
 }
 
+func TestDedupeWorkloadDegradedOverChild_Phase0(t *testing.T) {
+	dep := Ref{Group: "apps", Kind: "Deployment", Namespace: "ns", Name: "web"}
+
+	hasCategory := func(out []Issue, c issuesapi.Category) bool {
+		for _, i := range out {
+			if i.Category == c {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("job_failed folds into crashlooping child pod", func(t *testing.T) {
+		job := Ref{Group: "batch", Kind: "Job", Namespace: "ns", Name: "import"}
+		jobFailed := Issue{Source: SourceProblem, Group: "batch", Kind: "Job", Namespace: "ns", Name: "import",
+			Category: issuesapi.CategoryJobFailed, Severity: SeverityCritical, Reason: "BackoffLimitExceeded"}
+		childCrash := Issue{Source: SourceProblem, Kind: "Pod", Namespace: "ns", Name: "import-xyz",
+			Owner: job, Category: issuesapi.CategoryCrashLoop, Severity: SeverityCritical}
+		out := dedupeWorkloadDegradedOverChild([]Issue{jobFailed, childCrash})
+		if hasCategory(out, issuesapi.CategoryJobFailed) {
+			t.Fatalf("job_failed rollup should fold into the crashloop child, got %+v", out)
+		}
+		if !hasCategory(out, issuesapi.CategoryCrashLoop) {
+			t.Fatalf("crashloop child should survive as the root cause, got %+v", out)
+		}
+	})
+
+	t.Run("job_failed survives DeadlineExceeded with no crash child", func(t *testing.T) {
+		jobFailed := Issue{Source: SourceProblem, Group: "batch", Kind: "Job", Namespace: "ns", Name: "slow",
+			Category: issuesapi.CategoryJobFailed, Severity: SeverityCritical, Reason: "DeadlineExceeded"}
+		out := dedupeWorkloadDegradedOverChild([]Issue{jobFailed})
+		if !hasCategory(out, issuesapi.CategoryJobFailed) {
+			t.Fatalf("DeadlineExceeded job_failed with no child must survive, got %+v", out)
+		}
+	})
+
+	t.Run("rollout_stalled folds into admission rejection on same owner", func(t *testing.T) {
+		rollout := Issue{Source: SourceProblem, Group: "apps", Kind: "Deployment", Namespace: "ns", Name: "web",
+			Category: issuesapi.CategoryRolloutStalled, Severity: SeverityCritical, Reason: "ReplicaFailure"}
+		admission := Issue{Source: SourceScheduling, Group: "apps", Kind: "ReplicaSet", Namespace: "ns", Name: "web-abc",
+			Owner: dep, Category: issuesapi.CategoryAdmissionWebhookBlocking, Severity: SeverityCritical}
+		out := dedupeWorkloadDegradedOverChild([]Issue{rollout, admission})
+		if hasCategory(out, issuesapi.CategoryRolloutStalled) {
+			t.Fatalf("rollout_stalled should fold into the admission rejection root, got %+v", out)
+		}
+		if !hasCategory(out, issuesapi.CategoryAdmissionWebhookBlocking) {
+			t.Fatalf("admission rejection should survive as the root cause, got %+v", out)
+		}
+	})
+
+	t.Run("rollout_stalled folds into rbac_forbidden on same owner", func(t *testing.T) {
+		rollout := Issue{Source: SourceProblem, Group: "apps", Kind: "Deployment", Namespace: "ns", Name: "web",
+			Category: issuesapi.CategoryRolloutStalled, Severity: SeverityCritical, Reason: "ReplicaFailure"}
+		rbac := Issue{Source: SourceScheduling, Group: "apps", Kind: "ReplicaSet", Namespace: "ns", Name: "web-abc",
+			Owner: dep, Category: issuesapi.CategoryRBACForbidden, Severity: SeverityCritical}
+		out := dedupeWorkloadDegradedOverChild([]Issue{rollout, rbac})
+		if hasCategory(out, issuesapi.CategoryRolloutStalled) {
+			t.Fatalf("rollout_stalled should fold into rbac_forbidden, got %+v", out)
+		}
+	})
+
+	t.Run("cronjob_failed is not a rollup and survives alongside an unrelated job_failed", func(t *testing.T) {
+		cron := Issue{Source: SourceProblem, Group: "batch", Kind: "CronJob", Namespace: "ns", Name: "nightly",
+			Category: issuesapi.CategoryCronJobFailed, Severity: SeverityWarning, Reason: "stale"}
+		// Unrelated job (different subject) with a crashloop child — must not affect the cronjob row.
+		otherJob := Ref{Group: "batch", Kind: "Job", Namespace: "ns", Name: "other"}
+		jobFailed := Issue{Source: SourceProblem, Group: "batch", Kind: "Job", Namespace: "ns", Name: "other",
+			Category: issuesapi.CategoryJobFailed, Severity: SeverityCritical}
+		child := Issue{Source: SourceProblem, Kind: "Pod", Namespace: "ns", Name: "other-xyz",
+			Owner: otherJob, Category: issuesapi.CategoryCrashLoop, Severity: SeverityCritical}
+		out := dedupeWorkloadDegradedOverChild([]Issue{cron, jobFailed, child})
+		if !hasCategory(out, issuesapi.CategoryCronJobFailed) {
+			t.Fatalf("cronjob_failed must never be folded as a rollup, got %+v", out)
+		}
+	})
+
+	t.Run("severity gate: critical rollup with only a warning child is kept", func(t *testing.T) {
+		degraded := Issue{Source: SourceProblem, Group: "apps", Kind: "Deployment", Namespace: "ns", Name: "web",
+			Category: issuesapi.CategoryWorkloadDegraded, Severity: SeverityCritical, Reason: "0/3 available"}
+		waiting := Issue{Source: SourceProblem, Kind: "Pod", Namespace: "ns", Name: "web-abc",
+			Owner: dep, Category: issuesapi.CategoryContainerWaiting, Severity: SeverityWarning}
+		out := dedupeWorkloadDegradedOverChild([]Issue{degraded, waiting})
+		if !hasCategory(out, issuesapi.CategoryWorkloadDegraded) {
+			t.Fatalf("critical rollup must not be downgraded to a warning child, got %+v", out)
+		}
+	})
+}
+
 func TestDedupeConditionOverMissingRef(t *testing.T) {
 	missing := Issue{
 		Source:    SourceMissingRef,

--- a/internal/issues/dedupe_test.go
+++ b/internal/issues/dedupe_test.go
@@ -130,6 +130,87 @@ func TestDedupeWorkloadDegradedOverChild_Phase0(t *testing.T) {
 	})
 }
 
+func TestStructuralRootOverSymptom_Phase1(t *testing.T) {
+	dep := Ref{Group: "apps", Kind: "Deployment", Namespace: "ns", Name: "web"}
+
+	has := func(out []Issue, src Source, c issuesapi.Category, name string) bool {
+		for _, i := range out {
+			if i.Source == src && i.Category == c && i.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+	sevOf := func(out []Issue, c issuesapi.Category, name string) Severity {
+		for _, i := range out {
+			if i.Category == c && i.Name == name {
+				return i.Severity
+			}
+		}
+		return ""
+	}
+
+	t.Run("missing Secret folds container_waiting on same pod", func(t *testing.T) {
+		missing := Issue{Source: SourceMissingRef, Kind: "Pod", Namespace: "ns", Name: "web-abc", Owner: dep,
+			Category: issuesapi.CategoryMissingConfigRef, Reason: "Missing Secret", Severity: SeverityCritical}
+		waiting := Issue{Source: SourceProblem, Kind: "Pod", Namespace: "ns", Name: "web-abc", Owner: dep,
+			Category: issuesapi.CategoryContainerWaiting, Reason: "CreateContainerConfigError", Severity: SeverityWarning}
+		out := dedupeContainerWaitingOverMissingRef([]Issue{missing, waiting})
+		if has(out, SourceProblem, issuesapi.CategoryContainerWaiting, "web-abc") {
+			t.Fatalf("container_waiting should fold into the missing-Secret root, got %+v", out)
+		}
+		if !has(out, SourceMissingRef, issuesapi.CategoryMissingConfigRef, "web-abc") {
+			t.Fatalf("missing-ref root should survive, got %+v", out)
+		}
+	})
+
+	t.Run("missing Secret does NOT fold an unrelated image_pull on same pod", func(t *testing.T) {
+		missing := Issue{Source: SourceMissingRef, Kind: "Pod", Namespace: "ns", Name: "web-abc",
+			Category: issuesapi.CategoryMissingConfigRef, Reason: "Missing Secret", Severity: SeverityCritical}
+		imgPull := Issue{Source: SourceProblem, Kind: "Pod", Namespace: "ns", Name: "web-abc",
+			Category: issuesapi.CategoryImagePullFailed, Reason: "ErrImagePull", Severity: SeverityWarning}
+		out := dedupeImagePullOverMissingPullSecret([]Issue{missing, imgPull})
+		if !has(out, SourceProblem, issuesapi.CategoryImagePullFailed, "web-abc") {
+			t.Fatalf("image_pull_failed must survive when the root is a Secret (not a pull secret), got %+v", out)
+		}
+	})
+
+	t.Run("missing imagePullSecret folds image_pull on same pod", func(t *testing.T) {
+		missing := Issue{Source: SourceMissingRef, Kind: "Pod", Namespace: "ns", Name: "web-abc",
+			Category: issuesapi.CategoryMissingConfigRef, Reason: "Missing imagePullSecret", Severity: SeverityCritical}
+		imgPull := Issue{Source: SourceProblem, Kind: "Pod", Namespace: "ns", Name: "web-abc",
+			Category: issuesapi.CategoryImagePullFailed, Reason: "ImagePullBackOff", Severity: SeverityWarning}
+		out := dedupeImagePullOverMissingPullSecret([]Issue{missing, imgPull})
+		if has(out, SourceProblem, issuesapi.CategoryImagePullFailed, "web-abc") {
+			t.Fatalf("image_pull_failed should fold into the missing-imagePullSecret root, got %+v", out)
+		}
+	})
+
+	t.Run("HPA missing target folds the hpa condition row and promotes severity", func(t *testing.T) {
+		missing := Issue{Source: SourceMissingRef, Kind: "HorizontalPodAutoscaler", Group: "autoscaling", Namespace: "ns", Name: "web-hpa",
+			Category: issuesapi.CategoryMissingConfigRef, Reason: "Missing scaleTargetRef", Severity: SeverityWarning}
+		cond := Issue{Source: SourceProblem, Kind: "HorizontalPodAutoscaler", Group: "autoscaling", Namespace: "ns", Name: "web-hpa",
+			Category: issuesapi.CategoryHPALimitedOrFailed, Severity: SeverityCritical}
+		out := dedupeHPAOverMissingTarget([]Issue{missing, cond})
+		if has(out, SourceProblem, issuesapi.CategoryHPALimitedOrFailed, "web-hpa") {
+			t.Fatalf("hpa condition should fold into the missing-target root, got %+v", out)
+		}
+		// Floor preserved: warning root absorbing a critical symptom is promoted.
+		if sevOf(out, issuesapi.CategoryMissingConfigRef, "web-hpa") != SeverityCritical {
+			t.Fatalf("surviving root must be promoted to critical so folding doesn't downgrade, got %s", sevOf(out, issuesapi.CategoryMissingConfigRef, "web-hpa"))
+		}
+	})
+
+	t.Run("no missing-ref root is a no-op", func(t *testing.T) {
+		waiting := Issue{Source: SourceProblem, Kind: "Pod", Namespace: "ns", Name: "lonely",
+			Category: issuesapi.CategoryContainerWaiting, Severity: SeverityWarning}
+		out := dedupeContainerWaitingOverMissingRef([]Issue{waiting})
+		if len(out) != 1 {
+			t.Fatalf("expected the lone container_waiting to survive, got %+v", out)
+		}
+	})
+}
+
 func TestDedupeConditionOverMissingRef(t *testing.T) {
 	missing := Issue{
 		Source:    SourceMissingRef,

--- a/internal/k8s/detect.go
+++ b/internal/k8s/detect.go
@@ -999,6 +999,12 @@ func DetectProblems(cache *ResourceCache, namespace string) []Detection {
 				continue
 			}
 			ageDur := now.Sub(job.CreationTimestamp.Time)
+			// Stamp the controller owner (a CronJob, when this Job is one of its
+			// runs) so a failed Job rolls up to the same subject its pods do — the
+			// pods resolve their top owner to the CronJob, so job_failed must too
+			// or the rollup-over-pod-cause fold misses the match. A standalone Job
+			// has no controller owner and stays its own subject.
+			jobOwnerGroup, jobOwnerKind, jobOwnerName := controllerTopOwner(job.OwnerReferences)
 			if cond := failedJobCondition(job); cond != nil {
 				durDur := ageDur
 				if !cond.LastTransitionTime.IsZero() {
@@ -1020,6 +1026,9 @@ func DetectProblems(cache *ResourceCache, namespace string) []Detection {
 					AgeSeconds:      int64(ageDur.Seconds()),
 					Duration:        FormatAge(durDur),
 					DurationSeconds: int64(durDur.Seconds()),
+					OwnerGroup:      jobOwnerGroup,
+					OwnerKind:       jobOwnerKind,
+					OwnerName:       jobOwnerName,
 				})
 				continue
 			}
@@ -1036,6 +1045,9 @@ func DetectProblems(cache *ResourceCache, namespace string) []Detection {
 						AgeSeconds:      int64(ageDur.Seconds()),
 						Duration:        FormatAge(ageDur),
 						DurationSeconds: int64(ageDur.Seconds()),
+						OwnerGroup:      jobOwnerGroup,
+						OwnerKind:       jobOwnerKind,
+						OwnerName:       jobOwnerName,
 					})
 				}
 			}

--- a/internal/k8s/detect_scheduling.go
+++ b/internal/k8s/detect_scheduling.go
@@ -828,6 +828,11 @@ func detectAdmissionFailures(cache *ResourceCache, namespace string) []Detection
 		c := latest[key]
 		obj := c.ev.InvolvedObject
 		ageDur := now.Sub(eventFirstTime(c.ev))
+		// FailedCreate fires on the controller that couldn't create the pod —
+		// usually the ReplicaSet. Stamp its owning Deployment so the admission row
+		// rolls up to the same subject as the workload_degraded/rollout_stalled
+		// rollup it explains; otherwise the rollup-over-cause fold misses the match.
+		ownerGroup, ownerKind, ownerName := workloadControllerOwner(cache, obj.Kind, obj.Namespace, obj.Name)
 		problems = append(problems, Detection{
 			Kind:            obj.Kind,
 			Namespace:       obj.Namespace,
@@ -839,6 +844,9 @@ func detectAdmissionFailures(cache *ResourceCache, namespace string) []Detection
 			AgeSeconds:      int64(ageDur.Seconds()),
 			Duration:        FormatAge(ageDur),
 			DurationSeconds: int64(ageDur.Seconds()),
+			OwnerGroup:      ownerGroup,
+			OwnerKind:       ownerKind,
+			OwnerName:       ownerName,
 		})
 	}
 	seen := make(map[string]bool, len(problems))
@@ -968,6 +976,9 @@ func detectAdmissionConditionProblems(cache *ResourceCache, namespace string, se
 					continue
 				}
 				if p, ok := admissionConditionProblem("ReplicaSet", rs.Namespace, rs.Name, c.Message, c.LastTransitionTime.Time, now); ok {
+					// Roll the ReplicaSet's admission failure up to its Deployment,
+					// the same subject as the rollout_stalled rollup it explains.
+					p.OwnerGroup, p.OwnerKind, p.OwnerName = controllerTopOwner(rs.OwnerReferences)
 					out = append(out, p)
 					seen[key] = true
 					break

--- a/internal/k8s/detect_test.go
+++ b/internal/k8s/detect_test.go
@@ -2159,3 +2159,71 @@ func TestDetectProblems_PodIssueTimingCreationProximity(t *testing.T) {
 		t.Errorf("stable-pod late failure = (%q, %q), want (started_after_resource_was_healthy, owner_condition); ok=%v", latebreak.IssueTiming, latebreak.IssueTimingBasis, ok)
 	}
 }
+
+// TestJobDetectionStampsControllerOwner verifies a CronJob-owned failed Job
+// carries its CronJob as the resolved owner, so job_failed rolls up to the same
+// subject its pods do (their top owner is the CronJob) and the coalescing pass
+// can match them.
+func TestJobDetectionStampsControllerOwner(t *testing.T) {
+	now := time.Now()
+	controller := true
+	client := fake.NewClientset(
+		&batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "nightly-run",
+				Namespace:         "prod",
+				CreationTimestamp: metav1.NewTime(now.Add(-10 * time.Minute)),
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "batch/v1", Kind: "CronJob", Name: "nightly", Controller: &controller,
+				}},
+			},
+			Status: batchv1.JobStatus{
+				Conditions: []batchv1.JobCondition{{
+					Type: batchv1.JobFailed, Status: corev1.ConditionTrue, Reason: "BackoffLimitExceeded",
+				}},
+			},
+		},
+		// Standalone Job (no controller owner) — must stay its own subject.
+		&batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "oneoff",
+				Namespace:         "prod",
+				CreationTimestamp: metav1.NewTime(now.Add(-10 * time.Minute)),
+			},
+			Status: batchv1.JobStatus{
+				Conditions: []batchv1.JobCondition{{
+					Type: batchv1.JobFailed, Status: corev1.ConditionTrue, Reason: "BackoffLimitExceeded",
+				}},
+			},
+		},
+	)
+	if err := InitTestResourceCache(client); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+	cache := GetResourceCache()
+
+	var owned, standalone Detection
+	var okOwned, okStandalone bool
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		problems := DetectProblems(cache, "prod")
+		owned, okOwned = lookupProblem(problems, "Job", "nightly-run", "BackoffLimitExceeded")
+		standalone, okStandalone = lookupProblem(problems, "Job", "oneoff", "BackoffLimitExceeded")
+		if okOwned && okStandalone {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !okOwned {
+		t.Fatal("CronJob-owned failed Job not detected")
+	}
+	if owned.OwnerKind != "CronJob" || owned.OwnerName != "nightly" {
+		t.Errorf("CronJob-owned Job owner = (%q, %q), want (CronJob, nightly)", owned.OwnerKind, owned.OwnerName)
+	}
+	if !okStandalone {
+		t.Fatal("standalone failed Job not detected")
+	}
+	if standalone.OwnerKind != "" {
+		t.Errorf("standalone Job should have no controller owner, got %q", standalone.OwnerKind)
+	}
+}

--- a/internal/k8s/top_metrics.go
+++ b/internal/k8s/top_metrics.go
@@ -509,6 +509,44 @@ func controllerOwnerRef(refs []metav1.OwnerReference) *metav1.OwnerReference {
 	return nil
 }
 
+// controllerTopOwner returns the (group, kind, name) of a resource's controller
+// owner, or empty strings when it has none (it is its own top owner). Used to
+// stamp the owning controller onto workload-level Detections — a failed Job's
+// CronJob, a ReplicaSet's Deployment — so their issues roll up to the same
+// subject their pods do.
+func controllerTopOwner(refs []metav1.OwnerReference) (group, kind, name string) {
+	if o := controllerOwnerRef(refs); o != nil {
+		return schema.FromAPIVersionAndKind(o.APIVersion, o.Kind).Group, o.Kind, o.Name
+	}
+	return "", "", ""
+}
+
+// workloadControllerOwner resolves a workload object's controller owner from the
+// cache by kind+namespace+name (ReplicaSet→Deployment, Job→CronJob). For callers
+// that only hold an object reference (e.g. an Event's InvolvedObject) rather than
+// the object itself. Returns empty strings when there is no controller owner or
+// the object can't be resolved.
+func workloadControllerOwner(cache *ResourceCache, kind, namespace, name string) (group, ownerKind, ownerName string) {
+	if cache == nil {
+		return "", "", ""
+	}
+	switch kind {
+	case "ReplicaSet":
+		if l := cache.ReplicaSets(); l != nil {
+			if rs, err := l.ReplicaSets(namespace).Get(name); err == nil && rs != nil {
+				return controllerTopOwner(rs.OwnerReferences)
+			}
+		}
+	case "Job":
+		if l := cache.Jobs(); l != nil {
+			if job, err := l.Jobs(namespace).Get(name); err == nil && job != nil {
+				return controllerTopOwner(job.OwnerReferences)
+			}
+		}
+	}
+	return "", "", ""
+}
+
 func topOwnerForPod(pod *corev1.Pod) *TopOwnerInfo {
 	for _, ref := range pod.OwnerReferences {
 		if ref.Controller != nil && *ref.Controller {


### PR DESCRIPTION
## Summary

Issue correlation, same-subject tier. When one underlying problem produces several issue rows for the **same workload or the same resource**, Radar now collapses them to the single root-cause row instead of showing the operator a symptom *and* its cause as separate incidents. This is the deterministic, destructive half of the coalescing work (cross-subject *links* are the separate non-destructive #1042). It only folds rows that describe **the same incident on the same subject** — never across unrelated resources.

All folding runs as evidence-level passes in `internal/issues` before grouping, and the **severity floor is absolute: a fold never lowers the displayed severity of an incident.**

## The coalescing rules (what actually folds)

### 1. Workload/Job rollup → the specific pod cause (same owner subject)

A parent rollup row is **suppressed** when a more-specific child symptom of **at least equal severity** exists for the same owner-collapsed subject. The child names the real root cause, so it wins.

**Parent rollups that fold away:** `workload_degraded` ("N/M available", on Deployment/StatefulSet/DaemonSet) · `rollout_stalled` (progress-deadline exceeded, or ReplicaFailure) · `job_failed` (e.g. BackoffLimitExceeded).

**Child causes any of the above fold into** (the full set): `crashloop` · `oom_killed` · `high_restart` · `image_pull_failed` · `init_container_failed` · `container_waiting` · `liveness_probe_failed` · `readiness_failed` · `unschedulable` · `quota_exceeded` · `admission_webhook_blocking` · `pod_security_violation` · `rbac_forbidden` · `missing_config_ref` · `volume_mount_failed` · `pvc_pending`.

Concretely, the scenarios this collapses to one row:
- A Deployment "0/3 available" whose pods are **crashlooping / OOMing / restart-thrashing** → one crashloop/oom/high-restart row.
- A Deployment degraded because pods **can't pull their image / are stuck on a bad init container / are unschedulable** → one image-pull / init / unschedulable row.
- A Deployment degraded because pods are stuck on a **missing ConfigMap/Secret, a failing readiness/liveness probe, an unmountable volume, or a pending PVC** → one row of that cause.
- A **rollout stalled because pod *creation* is rejected** — namespace quota / a validating-or-mutating webhook / Pod Security admission / RBAC forbidding the controller from creating pods (cases where **no Pod object ever exists**) → one quota / admission-webhook / pod-security / rbac row. (These admission rows are emitted on the ReplicaSet; this PR stamps the owning Deployment so they roll up to it — see Detector changes.)
- A **Job that hit its backoff limit** whose pods crashloop/OOM/can't-pull → one pod-cause row; works for standalone Jobs and for **CronJob-owned runs** (the Job carries its CronJob as owner so it rolls up there).

### 2. Dangling-reference root → the runtime symptom it causes (same resource)

A by-name reference Radar resolved as missing is the proven cause of a runtime symptom on the *same* object, and the missing-ref row names the exact broken object + the fix — so it wins and the symptom folds into it:
- A pod's `container_waiting` (**CreateContainerConfigError**) → folds into the **missing ConfigMap / Secret / ServiceAccount / imagePullSecret** it references.
- A pod's `image_pull_failed` → folds into a **missing imagePullSecret**.
- An HPA or KEDA ScaledObject's `hpa_limited_or_failed` → folds into a **missing `scaleTargetRef`** (the autoscaler points at a workload that doesn't exist; every "can't scale" condition is downstream of that one fact).

## Guards — so coalescing never misleads

- **Severity floor (load-bearing):** a parent rollup is **kept** when it is strictly more severe than every child, so folding can never downgrade a critical incident to a warning. (e.g. a critical "0/1 available" whose only child is a *warning* container-waiting stays — both show.)
- **Structural-root-wins promotion:** when a dangling-ref root absorbs a symptom, it is promoted to the **max folded severity** and inherits the symptom's `issue_timing`, so the surviving row is never weaker or less-dated than what it replaced (e.g. KEDA's warning missing-target root absorbing a critical condition becomes critical).
- **Owner resolution so folds actually match:** Job detections carry their controller (CronJob); admission detections — which fire on the ReplicaSet — carry the owning Deployment. Without this the fold would key on the wrong subject and silently not fire.

## Deliberately NOT coalesced
- **`cronjob_failed`** — "stale / never-scheduled" is a *not-producing-Jobs* failure with no symptom children to fold into (a failed run surfaces as `job_failed` on the child Job, which folds there).
- **Unrelated symptoms that merely share a pod** — the container-waiting fold is gated to the **config-error reason**, and the image-pull fold to the **pull-secret**, so a multi-container pod's unrelated `RunContainerError` or a wrong-tag image pull on a different container is **not** swept away by a missing ConfigMap on another container.
- **A critical child never gets hidden** under a less-severe parent (the floor above), and nothing folds across different owners/resources.

## Detector changes (`internal/k8s`)
The folds key on the owner-collapsed subject, but admission and Job detections didn't carry that owner — so the folds were silent no-ops. New `controllerTopOwner` / `workloadControllerOwner` helpers stamp the controller owner: Job → CronJob, and the admission detection's ReplicaSet → its Deployment (event path via cache lookup, condition path from ownerRefs). This also activates the pre-existing `quota_exceeded` fold.

## What a reviewer should focus on
- The owner-stamping changes the **grouping subject** of admission/quota issues (now the Deployment) and CronJob-owned Job issues (now the CronJob). Intended — it's what makes the folds fire.
- `structuralRootOverSymptom` keys on the **resource itself** (not the owner subject): both rows describe the same Pod/HPA from two different detectors.

## Testing
- `go build ./...`, `go test ./internal/issues ./internal/k8s` — green.
- Unit tests for every new fold (job/admission rollups, the three structural folds) + the severity-gate regression + a detector test pinning CronJob / standalone owner stamping.
- **Verified live against kind / AWS / GCP via `/api/issues`:** a crashlooping Deployment showed only `crashloop` (parent `workload_degraded` suppressed — fold confirmed); a PVC-blocked workload kept both `workload_degraded` (critical) and `unschedulable` (warning) — the severity gate correctly *not* downgrading; healthy clusters (AWS) produced no spurious folds.

## Relationship to other PRs
Builds on the per-resource Operational Issues surface from #1033 (now merged): that section consumes the same `Compose` pipeline, so it shows these folded rows automatically. Cross-subject causal *links* (node / PVC / service blast-radius, confidence tiers) are the separate, non-destructive #1042.
