### PR TITLE
feat(issues): non-destructive cross-subject causal links (node + PVC blast radius)

### DIFF
--- a/internal/issues/compose.go
+++ b/internal/issues/compose.go
@@ -153,7 +153,6 @@ func ComposeWithStats(p Provider, f Filters) ([]Issue, ComposeStats) {
 	// missing target. Runs before the workload-rollup pass so the single richest
 	// child (the missing-ref root) is what reaches rollup suppression.
 	out = dedupeContainerWaitingOverMissingRef(out)
-	out = dedupeImagePullOverMissingPullSecret(out)
 	out = dedupeHPAOverMissingTarget(out)
 	out = dedupeWorkloadDegradedOverChild(out)
 	out = dedupeConditionOverMissingRef(out)

--- a/internal/issues/dedupe.go
+++ b/internal/issues/dedupe.go
@@ -347,21 +347,12 @@ func dedupeContainerWaitingOverMissingRef(in []Issue) []Issue {
 		})
 }
 
-// dedupeImagePullOverMissingPullSecret drops the image_pull_failed pod row when
-// the missing imagePullSecret was structurally detected for the same pod. Gated
-// tightly to the pull-secret reason: an unrelated image_pull_failed (wrong tag,
-// rate-limit) on the same pod has a different root and must survive.
-func dedupeImagePullOverMissingPullSecret(in []Issue) []Issue {
-	return structuralRootOverSymptom(in,
-		func(i Issue) bool {
-			return i.Source == SourceMissingRef && i.Kind == "Pod" &&
-				i.Category == issuesapi.CategoryMissingConfigRef && i.Reason == "Missing imagePullSecret"
-		},
-		func(i Issue) bool {
-			return i.Source == SourceProblem && i.Kind == "Pod" &&
-				i.Category == issuesapi.CategoryImagePullFailed
-		})
-}
+// (No image_pull_failed → missing-imagePullSecret fold: a *missing* pull-secret
+// object surfaces as CreateContainerConfigError, already covered by the
+// container_waiting fold above. A pod showing ImagePullBackOff while a pull
+// secret is missing is more often an unrelated failure — wrong tag, not-found,
+// rate-limit — so folding every image_pull_failed under the missing secret would
+// hide real, independent pull errors. Left out deliberately.)
 
 // dedupeHPAOverMissingTarget drops the hpa_limited_or_failed row when the
 // autoscaler's scaleTargetRef points at a workload that doesn't exist. When the

--- a/internal/issues/dedupe_test.go
+++ b/internal/issues/dedupe_test.go
@@ -164,25 +164,30 @@ func TestStructuralRootOverSymptom_Phase1(t *testing.T) {
 		}
 	})
 
-	t.Run("missing Secret does NOT fold an unrelated image_pull on same pod", func(t *testing.T) {
-		missing := Issue{Source: SourceMissingRef, Kind: "Pod", Namespace: "ns", Name: "web-abc",
-			Category: issuesapi.CategoryMissingConfigRef, Reason: "Missing Secret", Severity: SeverityCritical}
-		imgPull := Issue{Source: SourceProblem, Kind: "Pod", Namespace: "ns", Name: "web-abc",
-			Category: issuesapi.CategoryImagePullFailed, Reason: "ErrImagePull", Severity: SeverityWarning}
-		out := dedupeImagePullOverMissingPullSecret([]Issue{missing, imgPull})
-		if !has(out, SourceProblem, issuesapi.CategoryImagePullFailed, "web-abc") {
-			t.Fatalf("image_pull_failed must survive when the root is a Secret (not a pull secret), got %+v", out)
-		}
-	})
-
-	t.Run("missing imagePullSecret folds image_pull on same pod", func(t *testing.T) {
+	t.Run("image_pull_failed is NOT folded under a missing imagePullSecret", func(t *testing.T) {
+		// We deliberately don't fold image_pull_failed: an ImagePullBackOff
+		// alongside a missing pull secret is usually an unrelated pull error
+		// (wrong tag / not-found / rate-limit) that must survive.
 		missing := Issue{Source: SourceMissingRef, Kind: "Pod", Namespace: "ns", Name: "web-abc",
 			Category: issuesapi.CategoryMissingConfigRef, Reason: "Missing imagePullSecret", Severity: SeverityCritical}
 		imgPull := Issue{Source: SourceProblem, Kind: "Pod", Namespace: "ns", Name: "web-abc",
 			Category: issuesapi.CategoryImagePullFailed, Reason: "ImagePullBackOff", Severity: SeverityWarning}
-		out := dedupeImagePullOverMissingPullSecret([]Issue{missing, imgPull})
-		if has(out, SourceProblem, issuesapi.CategoryImagePullFailed, "web-abc") {
-			t.Fatalf("image_pull_failed should fold into the missing-imagePullSecret root, got %+v", out)
+		out := dedupeContainerWaitingOverMissingRef([]Issue{missing, imgPull})
+		if !has(out, SourceProblem, issuesapi.CategoryImagePullFailed, "web-abc") {
+			t.Fatalf("image_pull_failed must survive — it is not folded by the missing-ref passes, got %+v", out)
+		}
+	})
+
+	t.Run("missing imagePullSecret folds the pod's CreateContainerConfigError", func(t *testing.T) {
+		// A *missing* pull-secret object manifests as CreateContainerConfigError;
+		// that container_waiting row folds into the missing-ref root.
+		missing := Issue{Source: SourceMissingRef, Kind: "Pod", Namespace: "ns", Name: "web-abc",
+			Category: issuesapi.CategoryMissingConfigRef, Reason: "Missing imagePullSecret", Severity: SeverityCritical}
+		waiting := Issue{Source: SourceProblem, Kind: "Pod", Namespace: "ns", Name: "web-abc",
+			Category: issuesapi.CategoryContainerWaiting, Reason: "CreateContainerConfigError", Severity: SeverityWarning}
+		out := dedupeContainerWaitingOverMissingRef([]Issue{missing, waiting})
+		if has(out, SourceProblem, issuesapi.CategoryContainerWaiting, "web-abc") {
+			t.Fatalf("container_waiting should fold into the missing-imagePullSecret root, got %+v", out)
 		}
 	})
 

--- a/internal/issues/diagnostic_context.go
+++ b/internal/issues/diagnostic_context.go
@@ -53,18 +53,30 @@ var pvcAttributableCategories = map[issuesapi.Category]bool{
 	issuesapi.CategoryVolumeMountFailed: true,
 }
 
-// nodeAttributableCategories are pod-issue categories a NotReady / resource-
-// pressured node can plausibly cause. Node-independent causes are deliberately
-// excluded — an image-pull failure (registry/auth), a missing config reference,
-// or an admission rejection has nothing to do with the node, so linking it under
-// a node incident would be a false causal claim even as a hint.
-var nodeAttributableCategories = map[issuesapi.Category]bool{
-	issuesapi.CategoryCrashLoop:         true,
-	issuesapi.CategoryOOMKilled:         true,
-	issuesapi.CategoryHighRestart:       true,
-	issuesapi.CategoryContainerWaiting:  true,
-	issuesapi.CategoryReadinessFailed:   true,
-	issuesapi.CategoryLivenessProbeFail: true,
+// nodeReasonAttributable maps a node problem reason to the pod-issue categories
+// that reason can plausibly CAUSE — keyed on the reason because the cases are not
+// equivalent. Resource pressure produces specific, live symptoms (memory → OOM /
+// OOM-restart loops; disk or PID exhaustion → containers that can't be created).
+//
+// A fully NotReady (dead-kubelet) node is DELIBERATELY ABSENT: once the kubelet
+// stops reporting, a pod's status is stale, so its crashloop / OOM rows are
+// pre-existing application problems that merely happen to sit on the node — not
+// node-caused. Linking them would tell the operator "the node may be the cause"
+// when it isn't. The genuine dead-node blast radius (terminating / evicted pods,
+// unschedulable replacements) isn't captured by these runtime categories and is
+// left to a future, reason-aware detector. App-dominant categories (crashloop,
+// probe failures, image pull, missing config) are excluded for the same reason.
+var nodeReasonAttributable = map[string]map[issuesapi.Category]bool{
+	"MemoryPressure": {
+		issuesapi.CategoryOOMKilled:   true,
+		issuesapi.CategoryHighRestart: true,
+	},
+	"DiskPressure": {
+		issuesapi.CategoryContainerWaiting: true,
+	},
+	"PIDPressure": {
+		issuesapi.CategoryContainerWaiting: true,
+	},
 }
 
 type changeContextProvider interface {
@@ -282,19 +294,24 @@ func linkBlastRadius(b *diagnosticContextBuilder, pods []Ref, attributable map[i
 	})
 }
 
-// addNodeBlastRadiusContext links a NotReady / pressured node to the
-// node-attributable issues of the pods running on it (spec.nodeName). The node is
-// the candidate root; the pod issues are its blast radius. Confidence is medium,
-// not high: spec.nodeName proves a pod is ON the node, not that the node caused
-// its problem. Correctness rests on the category filter (node-independent causes
-// like image pull / config refs are excluded) plus the honest medium label — NOT
-// on a timestamp guard, because pod-issue onset isn't reliably recorded (FirstSeen
-// tracks pod age, not failure onset), so any such guard would drop legitimate
-// long-running pods newly hit by the node while still admitting unrelated ones.
+// addNodeBlastRadiusContext links a resource-pressured node to the pod issues
+// that pressure plausibly caused (matched by spec.nodeName, gated by the
+// reason→category map). The node is the candidate root; the pod issues are its
+// blast radius. Confidence is medium, not high: spec.nodeName proves a pod is ON
+// the node, and the category is consistent with the pressure, but co-located is
+// not proof of cause — hence the "may be the cause / verify" framing. A node whose
+// reason has no attributable categories (a dead-kubelet NotReady node, or an
+// unrecognized reason) links nothing. No timestamp guard: pod-issue onset isn't
+// reliably recorded (FirstSeen tracks pod age, not failure onset), so a guard
+// would drop legitimate long-running pods while still admitting unrelated ones.
 func addNodeBlastRadiusContext(b *diagnosticContextBuilder, node Issue, np nodeBlastRadiusProvider, flatByResource map[string][]Issue, groupedByID map[string]Issue) {
-	linkBlastRadius(b, np.PodsOnNode(node.Name), nodeAttributableCategories, flatByResource, groupedByID,
+	attributable := nodeReasonAttributable[node.Reason]
+	if len(attributable) == 0 {
+		return
+	}
+	linkBlastRadius(b, np.PodsOnNode(node.Name), attributable, flatByResource, groupedByID,
 		factNodeBlastRadius, issuesapi.ConfidenceMedium,
-		"Pods on this node have active issues — the node may be the cause.", nil)
+		fmt.Sprintf("Pods on this node show problems consistent with its %s — the node may be the cause.", node.Reason), nil)
 }
 
 // addPVCBlastRadiusContext links a broken PVC (pending / lost / resize-failed) to

--- a/internal/issues/diagnostic_context.go
+++ b/internal/issues/diagnostic_context.go
@@ -4,17 +4,9 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/skyhook-io/radar/pkg/issuesapi"
 )
-
-// nodeEvictionGrace is the slack allowed when deciding whether a pod symptom
-// predates its node going NotReady. The node-lifecycle controller waits ~5m
-// (default tolerationSeconds) before evicting pods off a NotReady node, so a
-// symptom can legitimately appear up to that long after — or just before — the
-// node's recorded transition and still be node-caused.
-const nodeEvictionGrace = 5 * time.Minute
 
 const (
 	maxDiagnosticRefs       = 5
@@ -272,17 +264,13 @@ func linkBlastRadius(b *diagnosticContextBuilder, pods []Ref, attributable map[i
 			related = append(related, issueRef(grouped))
 			refs = append(refs, pod)
 			seenIDs[flatIssue.ID] = true
-			if len(related) >= maxDiagnosticIssueRefs {
-				break
-			}
-		}
-		if len(related) >= maxDiagnosticIssueRefs {
-			break
 		}
 	}
 	if len(related) == 0 {
 		return
 	}
+	// Rank by severity BEFORE capping, so the cap keeps the worst issues, not the
+	// first pods in iteration order.
 	sortIssueRefs(related)
 	sortRefs(refs)
 	b.add(issuesapi.DiagnosticRoleCandidate, issuesapi.DiagnosticFact{
@@ -298,36 +286,46 @@ func linkBlastRadius(b *diagnosticContextBuilder, pods []Ref, attributable map[i
 // node-attributable issues of the pods running on it (spec.nodeName). The node is
 // the candidate root; the pod issues are its blast radius. Confidence is medium,
 // not high: spec.nodeName proves a pod is ON the node, not that the node caused
-// its problem — so node-independent categories are excluded up front, and a pod
-// whose issue clearly predates the node going bad (a pre-existing app failure
-// that merely happens to sit here) is filtered out.
+// its problem. Correctness rests on the category filter (node-independent causes
+// like image pull / config refs are excluded) plus the honest medium label — NOT
+// on a timestamp guard, because pod-issue onset isn't reliably recorded (FirstSeen
+// tracks pod age, not failure onset), so any such guard would drop legitimate
+// long-running pods newly hit by the node while still admitting unrelated ones.
 func addNodeBlastRadiusContext(b *diagnosticContextBuilder, node Issue, np nodeBlastRadiusProvider, flatByResource map[string][]Issue, groupedByID map[string]Issue) {
 	linkBlastRadius(b, np.PodsOnNode(node.Name), nodeAttributableCategories, flatByResource, groupedByID,
 		factNodeBlastRadius, issuesapi.ConfidenceMedium,
-		"Pods on this node have active issues — the node may be the cause.",
-		func(symptom Issue) bool { return !symptomPredatesNode(symptom, node) })
+		"Pods on this node have active issues — the node may be the cause.", nil)
 }
 
 // addPVCBlastRadiusContext links a broken PVC (pending / lost / resize-failed) to
-// the storage-attributable issues of the pods that mount it. The edge is the
-// declared claimName, so confidence is high; an unrelated crashloop on a mounting
-// pod is excluded by the category filter.
+// the storage issues of the pods that mount it. The mount edge is the declared
+// claimName, so a volume_mount_failed is unambiguously this PVC's fault (high
+// confidence). An unschedulable / container-waiting pod that mounts the claim is
+// only linked when its own message confirms a volume cause — a pod can mount the
+// PVC yet be unschedulable for CPU or waiting on unrelated config, which must not
+// be attributed to the PVC.
 func addPVCBlastRadiusContext(b *diagnosticContextBuilder, pvc Issue, pp pvcBlastRadiusProvider, flatByResource map[string][]Issue, groupedByID map[string]Issue) {
 	linkBlastRadius(b, pp.PodsMountingPVC(pvc.Namespace, pvc.Name), pvcAttributableCategories, flatByResource, groupedByID,
 		factPVCBlastRadius, issuesapi.ConfidenceHigh,
-		"Pods mounting this PVC are blocked by it.", nil)
+		"Pods mounting this PVC are blocked by it.",
+		func(symptom Issue) bool {
+			if symptom.Category == issuesapi.CategoryVolumeMountFailed {
+				return true
+			}
+			return symptomMentionsVolume(symptom, pvc.Name)
+		})
 }
 
-// symptomPredatesNode reports whether a pod symptom clearly began before the node
-// went bad — a pre-existing, independent failure that merely shares the node, not
-// one the node caused. Only applied when both timestamps are reliable; the node's
-// eviction grace (~5m) is allowed as slack so a symptom appearing just before the
-// node's recorded transition isn't wrongly excluded.
-func symptomPredatesNode(symptom, node Issue) bool {
-	if symptom.FirstSeen.IsZero() || node.FirstSeen.IsZero() {
-		return false
+// symptomMentionsVolume reports whether a scheduling / waiting symptom's text
+// confirms a volume cause — it names the PVC, or carries the scheduler's
+// volume-binding language — so an unrelated CPU-unschedulable pod that merely
+// mounts the claim isn't attributed to it.
+func symptomMentionsVolume(symptom Issue, pvcName string) bool {
+	text := strings.ToLower(symptom.Message + " " + symptom.Reason)
+	if pvcName != "" && strings.Contains(text, strings.ToLower(pvcName)) {
+		return true
 	}
-	return symptom.FirstSeen.Before(node.FirstSeen.Add(-nodeEvictionGrace))
+	return strings.Contains(text, "persistentvolumeclaim") || strings.Contains(text, "unbound") || strings.Contains(text, "volume node affinity")
 }
 
 func isServiceBackendContextCandidate(issue Issue) bool {

--- a/internal/issues/diagnostic_context.go
+++ b/internal/issues/diagnostic_context.go
@@ -29,6 +29,7 @@ const (
 	factBlockedInit         = "blocked_init_container"
 	factRestartCause        = "restart_cause"
 	factNodeBlastRadius     = "node_blast_radius"
+	factPVCBlastRadius      = "pvc_blast_radius"
 )
 
 type serviceBackendIssueProvider interface {
@@ -37,6 +38,27 @@ type serviceBackendIssueProvider interface {
 
 type nodeBlastRadiusProvider interface {
 	PodsOnNode(nodeName string) []Ref
+}
+
+type pvcBlastRadiusProvider interface {
+	PodsMountingPVC(namespace, pvcName string) []Ref
+}
+
+// pvcRootCategories are PVC-level problems that block the pods mounting the claim.
+var pvcRootCategories = map[issuesapi.Category]bool{
+	issuesapi.CategoryPVCPending:      true,
+	issuesapi.CategoryPVCLost:         true,
+	issuesapi.CategoryPVCResizeFailed: true,
+}
+
+// pvcAttributableCategories are the pod-side manifestations of a broken PVC: the
+// pod can't schedule (volume binding), can't mount, or is stuck creating. An
+// unrelated crashloop on a pod that merely happens to mount the claim is not
+// PVC-caused and is excluded.
+var pvcAttributableCategories = map[issuesapi.Category]bool{
+	issuesapi.CategoryUnschedulable:     true,
+	issuesapi.CategoryContainerWaiting:  true,
+	issuesapi.CategoryVolumeMountFailed: true,
 }
 
 // nodeAttributableCategories are pod-issue categories a NotReady / resource-
@@ -83,6 +105,10 @@ func enrichDiagnosticContext(shaped, flat, grouped []Issue, p Provider) []Issue 
 	var nodeProvider nodeBlastRadiusProvider
 	if np, ok := p.(nodeBlastRadiusProvider); ok {
 		nodeProvider = np
+	}
+	var pvcProvider pvcBlastRadiusProvider
+	if pp, ok := p.(pvcBlastRadiusProvider); ok {
+		pvcProvider = pp
 	}
 	var changeProvider changeContextProvider
 	if cp, ok := p.(changeContextProvider); ok {
@@ -157,6 +183,10 @@ func enrichDiagnosticContext(shaped, flat, grouped []Issue, p Provider) []Issue 
 			addNodeBlastRadiusContext(&b, *i, nodeProvider, flatByResource, groupedByID)
 		}
 
+		if pvcProvider != nil && i.Kind == "PersistentVolumeClaim" && pvcRootCategories[i.Category] {
+			addPVCBlastRadiusContext(&b, *i, pvcProvider, flatByResource, groupedByID)
+		}
+
 		if ctx := b.build(); ctx != nil {
 			i.DiagnosticContext = ctx
 		}
@@ -215,16 +245,11 @@ func addServiceBackendContext(b *diagnosticContextBuilder, issue Issue, serviceP
 	})
 }
 
-// addNodeBlastRadiusContext links a NotReady / pressured node to the
-// node-attributable issues of the pods running on it (spec.nodeName). The node is
-// the candidate root; the pod issues are its blast radius. Confidence is medium,
-// not high: spec.nodeName proves a pod is ON the node, not that the node caused
-// its problem — so node-independent categories are excluded up front, and a pod
-// whose issue clearly predates the node going bad (a pre-existing app failure
-// that merely happens to sit here) is filtered out. This is a non-destructive
-// hint: every pod issue keeps its own row.
-func addNodeBlastRadiusContext(b *diagnosticContextBuilder, node Issue, np nodeBlastRadiusProvider, flatByResource map[string][]Issue, groupedByID map[string]Issue) {
-	pods := np.PodsOnNode(node.Name)
+// linkBlastRadius adds a candidate-role fact linking a root issue to the
+// category-attributable issues of a set of affected pods (each flat pod issue
+// mapped to its grouped form). Non-destructive — it only annotates the root.
+// `accept` is an optional per-symptom guard beyond the category filter.
+func linkBlastRadius(b *diagnosticContextBuilder, pods []Ref, attributable map[issuesapi.Category]bool, flatByResource map[string][]Issue, groupedByID map[string]Issue, factType string, conf issuesapi.Confidence, message string, accept func(Issue) bool) {
 	if len(pods) == 0 {
 		return
 	}
@@ -234,10 +259,10 @@ func addNodeBlastRadiusContext(b *diagnosticContextBuilder, node Issue, np nodeB
 	for _, pod := range pods {
 		key := resourceKey(pod.Group, pod.Kind, pod.Namespace, pod.Name)
 		for _, flatIssue := range flatByResource[key] {
-			if !nodeAttributableCategories[flatIssue.Category] || seenIDs[flatIssue.ID] {
+			if !attributable[flatIssue.Category] || seenIDs[flatIssue.ID] {
 				continue
 			}
-			if symptomPredatesNode(flatIssue, node) {
+			if accept != nil && !accept(flatIssue) {
 				continue
 			}
 			grouped, ok := groupedByID[flatIssue.ID]
@@ -261,12 +286,36 @@ func addNodeBlastRadiusContext(b *diagnosticContextBuilder, node Issue, np nodeB
 	sortIssueRefs(related)
 	sortRefs(refs)
 	b.add(issuesapi.DiagnosticRoleCandidate, issuesapi.DiagnosticFact{
-		Type:          factNodeBlastRadius,
-		Message:       "Pods on this node have active issues — the node may be the cause.",
-		Confidence:    issuesapi.ConfidenceMedium,
+		Type:          factType,
+		Message:       message,
+		Confidence:    conf,
 		Refs:          limitRefs(dedupeRefs(refs), maxDiagnosticRefs),
 		RelatedIssues: limitIssueRefs(related, maxDiagnosticIssueRefs),
 	})
+}
+
+// addNodeBlastRadiusContext links a NotReady / pressured node to the
+// node-attributable issues of the pods running on it (spec.nodeName). The node is
+// the candidate root; the pod issues are its blast radius. Confidence is medium,
+// not high: spec.nodeName proves a pod is ON the node, not that the node caused
+// its problem — so node-independent categories are excluded up front, and a pod
+// whose issue clearly predates the node going bad (a pre-existing app failure
+// that merely happens to sit here) is filtered out.
+func addNodeBlastRadiusContext(b *diagnosticContextBuilder, node Issue, np nodeBlastRadiusProvider, flatByResource map[string][]Issue, groupedByID map[string]Issue) {
+	linkBlastRadius(b, np.PodsOnNode(node.Name), nodeAttributableCategories, flatByResource, groupedByID,
+		factNodeBlastRadius, issuesapi.ConfidenceMedium,
+		"Pods on this node have active issues — the node may be the cause.",
+		func(symptom Issue) bool { return !symptomPredatesNode(symptom, node) })
+}
+
+// addPVCBlastRadiusContext links a broken PVC (pending / lost / resize-failed) to
+// the storage-attributable issues of the pods that mount it. The edge is the
+// declared claimName, so confidence is high; an unrelated crashloop on a mounting
+// pod is excluded by the category filter.
+func addPVCBlastRadiusContext(b *diagnosticContextBuilder, pvc Issue, pp pvcBlastRadiusProvider, flatByResource map[string][]Issue, groupedByID map[string]Issue) {
+	linkBlastRadius(b, pp.PodsMountingPVC(pvc.Namespace, pvc.Name), pvcAttributableCategories, flatByResource, groupedByID,
+		factPVCBlastRadius, issuesapi.ConfidenceHigh,
+		"Pods mounting this PVC are blocked by it.", nil)
 }
 
 // symptomPredatesNode reports whether a pod symptom clearly began before the node

--- a/internal/issues/diagnostic_context.go
+++ b/internal/issues/diagnostic_context.go
@@ -319,13 +319,34 @@ func linkBlastRadius(b *diagnosticContextBuilder, pods []Ref, attributable map[i
 // reliably recorded (FirstSeen tracks pod age, not failure onset), so a guard
 // would drop legitimate long-running pods while still admitting unrelated ones.
 func addNodeBlastRadiusContext(b *diagnosticContextBuilder, node Issue, np nodeBlastRadiusProvider, flatByResource map[string][]Issue, groupedByID map[string]Issue) {
-	attributable := nodeReasonAttributable[node.Reason]
+	// A node can hit several pressures at once (memory + disk + PID); those
+	// detections share the node_not_ready ID and group into one issue that keeps
+	// only one representative Reason. Union the attributable categories across ALL
+	// of the node's detected reasons so a multi-pressure node links every pressure's
+	// pods (OOM under memory, stuck-creation under disk/PID), not just the
+	// representative's. (The flat node rows for both pressures sit under the node's
+	// resource key whether we were handed the grouped issue or a flat one.)
+	attributable := map[issuesapi.Category]bool{}
+	for _, f := range flatByResource[issueResourceKey(node)] {
+		if f.Kind == "Node" && f.Category == issuesapi.CategoryNodeNotReady {
+			for c := range nodeReasonAttributable[f.Reason] {
+				attributable[c] = true
+			}
+		}
+	}
+	// Fallback to the issue's own reason if no flat node rows are indexed under
+	// this key (defensive — normally the detections are present).
+	if len(attributable) == 0 {
+		for c := range nodeReasonAttributable[node.Reason] {
+			attributable[c] = true
+		}
+	}
 	if len(attributable) == 0 {
 		return
 	}
 	linkBlastRadius(b, np.PodsOnNode(node.Name), attributable, flatByResource, groupedByID,
 		factNodeBlastRadius, issuesapi.ConfidenceMedium,
-		fmt.Sprintf("Pods on this node show problems consistent with its %s — the node may be the cause.", node.Reason), nil)
+		"Pods on this node show problems consistent with its resource pressure — the node may be the cause.", nil)
 }
 
 // addPVCBlastRadiusContext links a broken PVC (pending / lost / resize-failed) to

--- a/internal/issues/diagnostic_context.go
+++ b/internal/issues/diagnostic_context.go
@@ -257,9 +257,16 @@ func linkBlastRadius(b *diagnosticContextBuilder, pods []Ref, attributable map[i
 	if len(pods) == 0 {
 		return
 	}
+	// Keep each linked issue paired with the pod it came from, so ranking and
+	// capping act on the pair — otherwise the displayed pods (Refs) and the
+	// displayed issues (RelatedIssues) are sorted/capped independently and the
+	// two lists diverge past the cap.
+	type linked struct {
+		ref Ref
+		rel issuesapi.IssueRef
+	}
 	seenIDs := make(map[string]bool)
-	var related []issuesapi.IssueRef
-	var refs []Ref
+	var links []linked
 	for _, pod := range pods {
 		key := resourceKey(pod.Group, pod.Kind, pod.Namespace, pod.Name)
 		for _, flatIssue := range flatByResource[key] {
@@ -273,24 +280,31 @@ func linkBlastRadius(b *diagnosticContextBuilder, pods []Ref, attributable map[i
 			if !ok {
 				grouped = flatIssue
 			}
-			related = append(related, issueRef(grouped))
-			refs = append(refs, pod)
+			links = append(links, linked{ref: pod, rel: issueRef(grouped)})
 			seenIDs[flatIssue.ID] = true
 		}
 	}
-	if len(related) == 0 {
+	if len(links) == 0 {
 		return
 	}
-	// Rank by severity BEFORE capping, so the cap keeps the worst issues, not the
-	// first pods in iteration order.
-	sortIssueRefs(related)
-	sortRefs(refs)
+	// Rank by the linked issue's severity BEFORE capping, so the cap keeps the
+	// worst issues (and their pods), not whatever came first in iteration order.
+	sort.SliceStable(links, func(i, j int) bool { return lessIssueRef(links[i].rel, links[j].rel) })
+	if len(links) > maxDiagnosticIssueRefs {
+		links = links[:maxDiagnosticIssueRefs]
+	}
+	related := make([]issuesapi.IssueRef, 0, len(links))
+	refs := make([]Ref, 0, len(links))
+	for _, l := range links {
+		related = append(related, l.rel)
+		refs = append(refs, l.ref)
+	}
 	b.add(issuesapi.DiagnosticRoleCandidate, issuesapi.DiagnosticFact{
 		Type:          factType,
 		Message:       message,
 		Confidence:    conf,
 		Refs:          limitRefs(dedupeRefs(refs), maxDiagnosticRefs),
-		RelatedIssues: limitIssueRefs(related, maxDiagnosticIssueRefs),
+		RelatedIssues: related,
 	})
 }
 
@@ -339,7 +353,10 @@ func addPVCBlastRadiusContext(b *diagnosticContextBuilder, pvc Issue, pp pvcBlas
 // mounts the claim isn't attributed to it.
 func symptomMentionsVolume(symptom Issue, pvcName string) bool {
 	text := strings.ToLower(symptom.Message + " " + symptom.Reason)
-	if pvcName != "" && strings.Contains(text, strings.ToLower(pvcName)) {
+	// Match the PVC name only when QUOTED, the way Kubernetes prints it
+	// (persistentvolumeclaim "name" not found). A bare substring match would fire
+	// on any text that happens to contain a short claim name like "data".
+	if pvcName != "" && strings.Contains(text, `"`+strings.ToLower(pvcName)+`"`) {
 		return true
 	}
 	return strings.Contains(text, "persistentvolumeclaim") || strings.Contains(text, "unbound") || strings.Contains(text, "volume node affinity")
@@ -497,23 +514,27 @@ func dedupeRefs(refs []Ref) []Ref {
 	return out
 }
 
+// lessIssueRef orders issue refs worst-first: severity desc, then a stable total
+// order over the identity fields.
+func lessIssueRef(a, b issuesapi.IssueRef) bool {
+	if a.Severity != b.Severity {
+		return SeverityRank(a.Severity) > SeverityRank(b.Severity)
+	}
+	if a.Ref.Namespace != b.Ref.Namespace {
+		return a.Ref.Namespace < b.Ref.Namespace
+	}
+	if a.Ref.Name != b.Ref.Name {
+		return a.Ref.Name < b.Ref.Name
+	}
+	if a.Ref.Kind != b.Ref.Kind {
+		return a.Ref.Kind < b.Ref.Kind
+	}
+	if a.Ref.Group != b.Ref.Group {
+		return a.Ref.Group < b.Ref.Group
+	}
+	return a.Reason < b.Reason
+}
+
 func sortIssueRefs(refs []issuesapi.IssueRef) {
-	sort.SliceStable(refs, func(i, j int) bool {
-		if refs[i].Severity != refs[j].Severity {
-			return SeverityRank(refs[i].Severity) > SeverityRank(refs[j].Severity)
-		}
-		if refs[i].Ref.Namespace != refs[j].Ref.Namespace {
-			return refs[i].Ref.Namespace < refs[j].Ref.Namespace
-		}
-		if refs[i].Ref.Name != refs[j].Ref.Name {
-			return refs[i].Ref.Name < refs[j].Ref.Name
-		}
-		if refs[i].Ref.Kind != refs[j].Ref.Kind {
-			return refs[i].Ref.Kind < refs[j].Ref.Kind
-		}
-		if refs[i].Ref.Group != refs[j].Ref.Group {
-			return refs[i].Ref.Group < refs[j].Ref.Group
-		}
-		return refs[i].Reason < refs[j].Reason
-	})
+	sort.SliceStable(refs, func(i, j int) bool { return lessIssueRef(refs[i], refs[j]) })
 }

--- a/internal/issues/diagnostic_context.go
+++ b/internal/issues/diagnostic_context.go
@@ -4,9 +4,17 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/skyhook-io/radar/pkg/issuesapi"
 )
+
+// nodeEvictionGrace is the slack allowed when deciding whether a pod symptom
+// predates its node going NotReady. The node-lifecycle controller waits ~5m
+// (default tolerationSeconds) before evicting pods off a NotReady node, so a
+// symptom can legitimately appear up to that long after — or just before — the
+// node's recorded transition and still be node-caused.
+const nodeEvictionGrace = 5 * time.Minute
 
 const (
 	maxDiagnosticRefs       = 5
@@ -20,10 +28,29 @@ const (
 	factProbeTarget         = "probe_target_mismatch"
 	factBlockedInit         = "blocked_init_container"
 	factRestartCause        = "restart_cause"
+	factNodeBlastRadius     = "node_blast_radius"
 )
 
 type serviceBackendIssueProvider interface {
 	SelectedPodsForService(namespace, name string) []Ref
+}
+
+type nodeBlastRadiusProvider interface {
+	PodsOnNode(nodeName string) []Ref
+}
+
+// nodeAttributableCategories are pod-issue categories a NotReady / resource-
+// pressured node can plausibly cause. Node-independent causes are deliberately
+// excluded — an image-pull failure (registry/auth), a missing config reference,
+// or an admission rejection has nothing to do with the node, so linking it under
+// a node incident would be a false causal claim even as a hint.
+var nodeAttributableCategories = map[issuesapi.Category]bool{
+	issuesapi.CategoryCrashLoop:         true,
+	issuesapi.CategoryOOMKilled:         true,
+	issuesapi.CategoryHighRestart:       true,
+	issuesapi.CategoryContainerWaiting:  true,
+	issuesapi.CategoryReadinessFailed:   true,
+	issuesapi.CategoryLivenessProbeFail: true,
 }
 
 type changeContextProvider interface {
@@ -52,6 +79,10 @@ func enrichDiagnosticContext(shaped, flat, grouped []Issue, p Provider) []Issue 
 	var serviceProvider serviceBackendIssueProvider
 	if sp, ok := p.(serviceBackendIssueProvider); ok {
 		serviceProvider = sp
+	}
+	var nodeProvider nodeBlastRadiusProvider
+	if np, ok := p.(nodeBlastRadiusProvider); ok {
+		nodeProvider = np
 	}
 	var changeProvider changeContextProvider
 	if cp, ok := p.(changeContextProvider); ok {
@@ -122,6 +153,10 @@ func enrichDiagnosticContext(shaped, flat, grouped []Issue, p Provider) []Issue 
 			addServiceBackendContext(&b, *i, serviceProvider, flatByResource, groupedByID)
 		}
 
+		if nodeProvider != nil && i.Kind == "Node" && i.Category == issuesapi.CategoryNodeNotReady {
+			addNodeBlastRadiusContext(&b, *i, nodeProvider, flatByResource, groupedByID)
+		}
+
 		if ctx := b.build(); ctx != nil {
 			i.DiagnosticContext = ctx
 		}
@@ -174,9 +209,76 @@ func addServiceBackendContext(b *diagnosticContextBuilder, issue Issue, serviceP
 	b.add(issuesapi.DiagnosticRoleAffected, issuesapi.DiagnosticFact{
 		Type:          factSelectedBackend,
 		Message:       "Selected backend pod(s) already have active issues.",
+		Confidence:    issuesapi.ConfidenceHigh, // declared selector edge Service→Pod
 		Refs:          limitRefs(dedupeRefs(refs), maxDiagnosticRefs),
 		RelatedIssues: limitIssueRefs(related, maxDiagnosticIssueRefs),
 	})
+}
+
+// addNodeBlastRadiusContext links a NotReady / pressured node to the
+// node-attributable issues of the pods running on it (spec.nodeName). The node is
+// the candidate root; the pod issues are its blast radius. Confidence is medium,
+// not high: spec.nodeName proves a pod is ON the node, not that the node caused
+// its problem — so node-independent categories are excluded up front, and a pod
+// whose issue clearly predates the node going bad (a pre-existing app failure
+// that merely happens to sit here) is filtered out. This is a non-destructive
+// hint: every pod issue keeps its own row.
+func addNodeBlastRadiusContext(b *diagnosticContextBuilder, node Issue, np nodeBlastRadiusProvider, flatByResource map[string][]Issue, groupedByID map[string]Issue) {
+	pods := np.PodsOnNode(node.Name)
+	if len(pods) == 0 {
+		return
+	}
+	seenIDs := make(map[string]bool)
+	var related []issuesapi.IssueRef
+	var refs []Ref
+	for _, pod := range pods {
+		key := resourceKey(pod.Group, pod.Kind, pod.Namespace, pod.Name)
+		for _, flatIssue := range flatByResource[key] {
+			if !nodeAttributableCategories[flatIssue.Category] || seenIDs[flatIssue.ID] {
+				continue
+			}
+			if symptomPredatesNode(flatIssue, node) {
+				continue
+			}
+			grouped, ok := groupedByID[flatIssue.ID]
+			if !ok {
+				grouped = flatIssue
+			}
+			related = append(related, issueRef(grouped))
+			refs = append(refs, pod)
+			seenIDs[flatIssue.ID] = true
+			if len(related) >= maxDiagnosticIssueRefs {
+				break
+			}
+		}
+		if len(related) >= maxDiagnosticIssueRefs {
+			break
+		}
+	}
+	if len(related) == 0 {
+		return
+	}
+	sortIssueRefs(related)
+	sortRefs(refs)
+	b.add(issuesapi.DiagnosticRoleCandidate, issuesapi.DiagnosticFact{
+		Type:          factNodeBlastRadius,
+		Message:       "Pods on this node have active issues — the node may be the cause.",
+		Confidence:    issuesapi.ConfidenceMedium,
+		Refs:          limitRefs(dedupeRefs(refs), maxDiagnosticRefs),
+		RelatedIssues: limitIssueRefs(related, maxDiagnosticIssueRefs),
+	})
+}
+
+// symptomPredatesNode reports whether a pod symptom clearly began before the node
+// went bad — a pre-existing, independent failure that merely shares the node, not
+// one the node caused. Only applied when both timestamps are reliable; the node's
+// eviction grace (~5m) is allowed as slack so a symptom appearing just before the
+// node's recorded transition isn't wrongly excluded.
+func symptomPredatesNode(symptom, node Issue) bool {
+	if symptom.FirstSeen.IsZero() || node.FirstSeen.IsZero() {
+		return false
+	}
+	return symptom.FirstSeen.Before(node.FirstSeen.Add(-nodeEvictionGrace))
 }
 
 func isServiceBackendContextCandidate(issue Issue) bool {

--- a/internal/issues/grouping.go
+++ b/internal/issues/grouping.go
@@ -123,6 +123,14 @@ func foldGroup(members []Issue) Issue {
 		LastTerminatedReason: rep.LastTerminatedReason,
 		FirstSeen:            rep.FirstSeen,
 		LastSeen:             rep.LastSeen,
+		// Per-issue context carries from the representative, like Reason/Message.
+		// In the cluster-wide path grouping runs before enrichment, so these are
+		// nil here and enrichment attaches to the grouped row afterward. On the
+		// per-resource RelatedIssues path Compose enriches the flat rows first,
+		// so without this the regroup would drop the representative's causal
+		// links / change context.
+		DiagnosticContext: rep.DiagnosticContext,
+		ChangeContext:     rep.ChangeContext,
 	}
 	// A parsed diagnosis (cause/action/remediation) describes ONE resource's
 	// failure. Carry it onto the grouped row only when it is true for the

--- a/internal/issues/grouping_test.go
+++ b/internal/issues/grouping_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/pkg/issuesapi"
 )
 
 // flatPod builds a flat pod issue the way Compose would — classified +
@@ -310,5 +311,23 @@ func TestRelatedIssues_UncappedMembers(t *testing.T) {
 	}
 	if got := RelatedIssues(p, nil, "apps", "Deployment", "prod", "web"); len(got) != 1 {
 		t.Errorf("owning Deployment = %d related issues, want 1", len(got))
+	}
+}
+
+func TestGroupIssuesPreservesDiagnosticContext(t *testing.T) {
+	flat := []Issue{{
+		ID: "pvc-x", Kind: "PersistentVolumeClaim", Namespace: "ns", Name: "data",
+		Category: issuesapi.CategoryPVCPending, Severity: SeverityCritical,
+		DiagnosticContext: &issuesapi.DiagnosticContext{
+			Role:  issuesapi.DiagnosticRoleCandidate,
+			Facts: []issuesapi.DiagnosticFact{{Type: "pvc_blast_radius", Confidence: issuesapi.ConfidenceHigh}},
+		},
+	}}
+	grouped := GroupIssues(flat)
+	if len(grouped) != 1 || grouped[0].DiagnosticContext == nil || len(grouped[0].DiagnosticContext.Facts) != 1 {
+		t.Fatalf("GroupIssues must carry the representative's diagnostic_context through the regroup (the per-resource RelatedIssues path depends on it), got %+v", grouped[0].DiagnosticContext)
+	}
+	if grouped[0].DiagnosticContext.Facts[0].Confidence != issuesapi.ConfidenceHigh {
+		t.Fatalf("confidence lost in regroup")
 	}
 }

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -1542,16 +1542,21 @@ func TestDetectGenericCRDIssues_SkipsListWhenKindFiltered(t *testing.T) {
 }
 
 func TestNodeBlastRadiusContext(t *testing.T) {
-	node := Issue{Kind: "Node", Name: "node-1", Category: issuesapi.CategoryNodeNotReady, Severity: SeverityCritical, Reason: "NotReady"}
-	crash := Issue{ID: "crash-1", Kind: "Pod", Namespace: "prod", Name: "web-abc", Category: issuesapi.CategoryCrashLoop, Severity: SeverityCritical}
-	pull := Issue{ID: "pull-1", Kind: "Pod", Namespace: "prod", Name: "api-xyz", Category: issuesapi.CategoryImagePullFailed, Severity: SeverityWarning}
+	// A MemoryPressure node: OOM is the attributable symptom; a crashloop on the
+	// same node is app-dominant and must NOT be attributed to memory pressure, and
+	// an image-pull failure is node-independent.
+	node := Issue{Kind: "Node", Name: "node-1", Category: issuesapi.CategoryNodeNotReady, Severity: SeverityCritical, Reason: "MemoryPressure"}
+	oom := Issue{ID: "oom-1", Kind: "Pod", Namespace: "prod", Name: "web-abc", Category: issuesapi.CategoryOOMKilled, Severity: SeverityCritical}
+	crash := Issue{ID: "crash-1", Kind: "Pod", Namespace: "prod", Name: "api-xyz", Category: issuesapi.CategoryCrashLoop, Severity: SeverityCritical}
+	pull := Issue{ID: "pull-1", Kind: "Pod", Namespace: "prod", Name: "cache-9", Category: issuesapi.CategoryImagePullFailed, Severity: SeverityWarning}
 
 	p := &fakeProvider{podsOnNode: map[string][]Ref{"node-1": {
 		{Kind: "Pod", Namespace: "prod", Name: "web-abc"},
 		{Kind: "Pod", Namespace: "prod", Name: "api-xyz"},
+		{Kind: "Pod", Namespace: "prod", Name: "cache-9"},
 	}}}
 
-	out := enrichDiagnosticContext([]Issue{node}, []Issue{node, crash, pull}, nil, p)
+	out := enrichDiagnosticContext([]Issue{node}, []Issue{node, oom, crash, pull}, nil, p)
 	ctx := out[0].DiagnosticContext
 	if ctx == nil {
 		t.Fatal("node issue got no diagnostic context")
@@ -1571,15 +1576,27 @@ func TestNodeBlastRadiusContext(t *testing.T) {
 	if ctx.Role != issuesapi.DiagnosticRoleCandidate {
 		t.Errorf("role = %q, want candidate", ctx.Role)
 	}
-	// The node-attributable crashloop links; the node-independent image-pull
-	// failure must NOT be attributed to the node.
-	if len(fact.RelatedIssues) != 1 || fact.RelatedIssues[0].Category != issuesapi.CategoryCrashLoop || fact.RelatedIssues[0].Ref.Name != "web-abc" {
-		t.Fatalf("expected only the on-node crashloop linked (not the node-independent image pull), got %+v", fact.RelatedIssues)
+	// Only the OOM (attributable to MemoryPressure) links — not the app-dominant
+	// crashloop, not the node-independent image pull.
+	if len(fact.RelatedIssues) != 1 || fact.RelatedIssues[0].Category != issuesapi.CategoryOOMKilled || fact.RelatedIssues[0].Ref.Name != "web-abc" {
+		t.Fatalf("expected only the OOM linked under MemoryPressure, got %+v", fact.RelatedIssues)
+	}
+}
+
+func TestNodeBlastRadiusContext_NotReadyLinksNothing(t *testing.T) {
+	// A dead-kubelet NotReady node: pod statuses are stale, so crashloop/OOM rows
+	// are pre-existing app problems, not node-caused — nothing should link.
+	node := Issue{Kind: "Node", Name: "dead", Category: issuesapi.CategoryNodeNotReady, Severity: SeverityCritical, Reason: "NotReady"}
+	oom := Issue{ID: "oom-9", Kind: "Pod", Namespace: "prod", Name: "p1", Category: issuesapi.CategoryOOMKilled, Severity: SeverityCritical}
+	p := &fakeProvider{podsOnNode: map[string][]Ref{"dead": {{Kind: "Pod", Namespace: "prod", Name: "p1"}}}}
+	out := enrichDiagnosticContext([]Issue{node}, []Issue{node, oom}, nil, p)
+	if out[0].DiagnosticContext != nil {
+		t.Fatalf("a NotReady (dead-kubelet) node must not attribute pod issues, got %+v", out[0].DiagnosticContext)
 	}
 }
 
 func TestNodeBlastRadiusContext_NoPodsNoFact(t *testing.T) {
-	node := Issue{Kind: "Node", Name: "lonely", Category: issuesapi.CategoryNodeNotReady, Severity: SeverityCritical}
+	node := Issue{Kind: "Node", Name: "lonely", Category: issuesapi.CategoryNodeNotReady, Severity: SeverityCritical, Reason: "MemoryPressure"}
 	p := &fakeProvider{}
 	out := enrichDiagnosticContext([]Issue{node}, []Issue{node}, nil, p)
 	if out[0].DiagnosticContext != nil {

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -1542,19 +1542,16 @@ func TestDetectGenericCRDIssues_SkipsListWhenKindFiltered(t *testing.T) {
 }
 
 func TestNodeBlastRadiusContext(t *testing.T) {
-	now := time.Now()
-	node := Issue{Kind: "Node", Name: "node-1", Category: issuesapi.CategoryNodeNotReady, Severity: SeverityCritical, Reason: "NotReady", FirstSeen: now}
-	crash := Issue{ID: "crash-1", Kind: "Pod", Namespace: "prod", Name: "web-abc", Category: issuesapi.CategoryCrashLoop, Severity: SeverityCritical, FirstSeen: now}
-	pull := Issue{ID: "pull-1", Kind: "Pod", Namespace: "prod", Name: "api-xyz", Category: issuesapi.CategoryImagePullFailed, Severity: SeverityWarning, FirstSeen: now}
-	old := Issue{ID: "old-1", Kind: "Pod", Namespace: "prod", Name: "old-pod", Category: issuesapi.CategoryCrashLoop, Severity: SeverityCritical, FirstSeen: now.Add(-time.Hour)}
+	node := Issue{Kind: "Node", Name: "node-1", Category: issuesapi.CategoryNodeNotReady, Severity: SeverityCritical, Reason: "NotReady"}
+	crash := Issue{ID: "crash-1", Kind: "Pod", Namespace: "prod", Name: "web-abc", Category: issuesapi.CategoryCrashLoop, Severity: SeverityCritical}
+	pull := Issue{ID: "pull-1", Kind: "Pod", Namespace: "prod", Name: "api-xyz", Category: issuesapi.CategoryImagePullFailed, Severity: SeverityWarning}
 
 	p := &fakeProvider{podsOnNode: map[string][]Ref{"node-1": {
 		{Kind: "Pod", Namespace: "prod", Name: "web-abc"},
 		{Kind: "Pod", Namespace: "prod", Name: "api-xyz"},
-		{Kind: "Pod", Namespace: "prod", Name: "old-pod"},
 	}}}
 
-	out := enrichDiagnosticContext([]Issue{node}, []Issue{node, crash, pull, old}, nil, p)
+	out := enrichDiagnosticContext([]Issue{node}, []Issue{node, crash, pull}, nil, p)
 	ctx := out[0].DiagnosticContext
 	if ctx == nil {
 		t.Fatal("node issue got no diagnostic context")
@@ -1574,8 +1571,10 @@ func TestNodeBlastRadiusContext(t *testing.T) {
 	if ctx.Role != issuesapi.DiagnosticRoleCandidate {
 		t.Errorf("role = %q, want candidate", ctx.Role)
 	}
+	// The node-attributable crashloop links; the node-independent image-pull
+	// failure must NOT be attributed to the node.
 	if len(fact.RelatedIssues) != 1 || fact.RelatedIssues[0].Category != issuesapi.CategoryCrashLoop || fact.RelatedIssues[0].Ref.Name != "web-abc" {
-		t.Fatalf("expected only the on-node crashloop linked (not the node-independent image pull, not the pre-existing crashloop), got %+v", fact.RelatedIssues)
+		t.Fatalf("expected only the on-node crashloop linked (not the node-independent image pull), got %+v", fact.RelatedIssues)
 	}
 }
 
@@ -1590,14 +1589,22 @@ func TestNodeBlastRadiusContext_NoPodsNoFact(t *testing.T) {
 
 func TestPVCBlastRadiusContext(t *testing.T) {
 	pvc := Issue{Kind: "PersistentVolumeClaim", Namespace: "prod", Name: "data", Category: issuesapi.CategoryPVCPending, Severity: SeverityCritical, Reason: "Pending"}
-	blocked := Issue{ID: "unsched-1", Kind: "Pod", Namespace: "prod", Name: "db-0", Category: issuesapi.CategoryUnschedulable, Severity: SeverityCritical}
+	// Unschedulable WITH volume-binding evidence in the message → linked.
+	blocked := Issue{ID: "unsched-1", Kind: "Pod", Namespace: "prod", Name: "db-0", Category: issuesapi.CategoryUnschedulable, Severity: SeverityCritical,
+		Message: "0/3 nodes are available: pod has unbound immediate PersistentVolumeClaims"}
+	// Unrelated crashloop on the same pod → never PVC-attributable.
 	crashing := Issue{ID: "crash-2", Kind: "Pod", Namespace: "prod", Name: "db-0", Category: issuesapi.CategoryCrashLoop, Severity: SeverityCritical}
+	// A DIFFERENT pod that also mounts the PVC but is unschedulable for CPU →
+	// must NOT be attributed to the PVC (no volume evidence in its message).
+	cpuBlocked := Issue{ID: "unsched-2", Kind: "Pod", Namespace: "prod", Name: "db-1", Category: issuesapi.CategoryUnschedulable, Severity: SeverityCritical,
+		Message: "0/3 nodes are available: 3 Insufficient cpu"}
 
 	p := &fakeProvider{podsMountingPVC: map[string][]Ref{"prod/data": {
 		{Kind: "Pod", Namespace: "prod", Name: "db-0"},
+		{Kind: "Pod", Namespace: "prod", Name: "db-1"},
 	}}}
 
-	out := enrichDiagnosticContext([]Issue{pvc}, []Issue{pvc, blocked, crashing}, nil, p)
+	out := enrichDiagnosticContext([]Issue{pvc}, []Issue{pvc, blocked, crashing, cpuBlocked}, nil, p)
 	ctx := out[0].DiagnosticContext
 	if ctx == nil {
 		t.Fatal("PVC issue got no diagnostic context")
@@ -1614,9 +1621,9 @@ func TestPVCBlastRadiusContext(t *testing.T) {
 	if fact.Confidence != issuesapi.ConfidenceHigh {
 		t.Errorf("confidence = %q, want high (declared claimName edge)", fact.Confidence)
 	}
-	// Only the storage-attributable unschedulable links; the unrelated crashloop
-	// on the same pod must not be attributed to the PVC.
-	if len(fact.RelatedIssues) != 1 || fact.RelatedIssues[0].Category != issuesapi.CategoryUnschedulable {
-		t.Fatalf("expected only the unschedulable linked, got %+v", fact.RelatedIssues)
+	// Only the volume-evidenced unschedulable links; the unrelated crashloop and
+	// the CPU-unschedulable pod (no volume evidence) must not be attributed.
+	if len(fact.RelatedIssues) != 1 || fact.RelatedIssues[0].Ref.Name != "db-0" || fact.RelatedIssues[0].Category != issuesapi.CategoryUnschedulable {
+		t.Fatalf("expected only the volume-evidenced unschedulable (db-0) linked, got %+v", fact.RelatedIssues)
 	}
 }

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -21,17 +21,18 @@ import (
 // pre-stages what the corresponding method returns. Test cases assemble
 // one of these and pass it to Compose.
 type fakeProvider struct {
-	problems       []k8s.Detection
-	missingRefs    []k8s.Detection
-	scheduling     []k8s.Detection
-	capiProblems   []k8s.Detection
-	gitopsProblems []k8s.Detection
-	dynamic        map[schema.GroupVersionResource][]*unstructured.Unstructured
-	kinds          map[schema.GroupVersionResource]string
-	namespaced     map[schema.GroupVersionResource]bool
-	selectedPods   map[string][]Ref
-	podsOnNode     map[string][]Ref
-	change         map[string]*issuesapi.ChangeContext
+	problems        []k8s.Detection
+	missingRefs     []k8s.Detection
+	scheduling      []k8s.Detection
+	capiProblems    []k8s.Detection
+	gitopsProblems  []k8s.Detection
+	dynamic         map[schema.GroupVersionResource][]*unstructured.Unstructured
+	kinds           map[schema.GroupVersionResource]string
+	namespaced      map[schema.GroupVersionResource]bool
+	selectedPods    map[string][]Ref
+	podsOnNode      map[string][]Ref
+	podsMountingPVC map[string][]Ref
+	change          map[string]*issuesapi.ChangeContext
 }
 
 func (f *fakeProvider) DetectProblems(_ []string) []k8s.Detection       { return f.problems }
@@ -61,6 +62,9 @@ func (f *fakeProvider) NamespacedForGVR(gvr schema.GroupVersionResource) (bool, 
 }
 func (f *fakeProvider) SelectedPodsForService(namespace, name string) []Ref {
 	return f.selectedPods[namespace+"/"+name]
+}
+func (f *fakeProvider) PodsMountingPVC(namespace, pvcName string) []Ref {
+	return f.podsMountingPVC[namespace+"/"+pvcName]
 }
 func (f *fakeProvider) PodsOnNode(nodeName string) []Ref {
 	return f.podsOnNode[nodeName]
@@ -1581,5 +1585,38 @@ func TestNodeBlastRadiusContext_NoPodsNoFact(t *testing.T) {
 	out := enrichDiagnosticContext([]Issue{node}, []Issue{node}, nil, p)
 	if out[0].DiagnosticContext != nil {
 		t.Fatalf("a node with no on-node issues should get no context, got %+v", out[0].DiagnosticContext)
+	}
+}
+
+func TestPVCBlastRadiusContext(t *testing.T) {
+	pvc := Issue{Kind: "PersistentVolumeClaim", Namespace: "prod", Name: "data", Category: issuesapi.CategoryPVCPending, Severity: SeverityCritical, Reason: "Pending"}
+	blocked := Issue{ID: "unsched-1", Kind: "Pod", Namespace: "prod", Name: "db-0", Category: issuesapi.CategoryUnschedulable, Severity: SeverityCritical}
+	crashing := Issue{ID: "crash-2", Kind: "Pod", Namespace: "prod", Name: "db-0", Category: issuesapi.CategoryCrashLoop, Severity: SeverityCritical}
+
+	p := &fakeProvider{podsMountingPVC: map[string][]Ref{"prod/data": {
+		{Kind: "Pod", Namespace: "prod", Name: "db-0"},
+	}}}
+
+	out := enrichDiagnosticContext([]Issue{pvc}, []Issue{pvc, blocked, crashing}, nil, p)
+	ctx := out[0].DiagnosticContext
+	if ctx == nil {
+		t.Fatal("PVC issue got no diagnostic context")
+	}
+	var fact *issuesapi.DiagnosticFact
+	for i := range ctx.Facts {
+		if ctx.Facts[i].Type == factPVCBlastRadius {
+			fact = &ctx.Facts[i]
+		}
+	}
+	if fact == nil {
+		t.Fatalf("no pvc_blast_radius fact, got %+v", ctx.Facts)
+	}
+	if fact.Confidence != issuesapi.ConfidenceHigh {
+		t.Errorf("confidence = %q, want high (declared claimName edge)", fact.Confidence)
+	}
+	// Only the storage-attributable unschedulable links; the unrelated crashloop
+	// on the same pod must not be attributed to the PVC.
+	if len(fact.RelatedIssues) != 1 || fact.RelatedIssues[0].Category != issuesapi.CategoryUnschedulable {
+		t.Fatalf("expected only the unschedulable linked, got %+v", fact.RelatedIssues)
 	}
 }

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -30,6 +30,7 @@ type fakeProvider struct {
 	kinds          map[schema.GroupVersionResource]string
 	namespaced     map[schema.GroupVersionResource]bool
 	selectedPods   map[string][]Ref
+	podsOnNode     map[string][]Ref
 	change         map[string]*issuesapi.ChangeContext
 }
 
@@ -60,6 +61,9 @@ func (f *fakeProvider) NamespacedForGVR(gvr schema.GroupVersionResource) (bool, 
 }
 func (f *fakeProvider) SelectedPodsForService(namespace, name string) []Ref {
 	return f.selectedPods[namespace+"/"+name]
+}
+func (f *fakeProvider) PodsOnNode(nodeName string) []Ref {
+	return f.podsOnNode[nodeName]
 }
 
 func (f *fakeProvider) ChangeContextForIssue(i Issue) *issuesapi.ChangeContext {
@@ -1530,5 +1534,52 @@ func TestDetectGenericCRDIssues_SkipsListWhenKindFiltered(t *testing.T) {
 		if got := p.listCalls[gvr] > 0; got != want {
 			t.Errorf("no kind filter: GVR %s called=%v, want %v", gvr.Resource, got, want)
 		}
+	}
+}
+
+func TestNodeBlastRadiusContext(t *testing.T) {
+	now := time.Now()
+	node := Issue{Kind: "Node", Name: "node-1", Category: issuesapi.CategoryNodeNotReady, Severity: SeverityCritical, Reason: "NotReady", FirstSeen: now}
+	crash := Issue{ID: "crash-1", Kind: "Pod", Namespace: "prod", Name: "web-abc", Category: issuesapi.CategoryCrashLoop, Severity: SeverityCritical, FirstSeen: now}
+	pull := Issue{ID: "pull-1", Kind: "Pod", Namespace: "prod", Name: "api-xyz", Category: issuesapi.CategoryImagePullFailed, Severity: SeverityWarning, FirstSeen: now}
+	old := Issue{ID: "old-1", Kind: "Pod", Namespace: "prod", Name: "old-pod", Category: issuesapi.CategoryCrashLoop, Severity: SeverityCritical, FirstSeen: now.Add(-time.Hour)}
+
+	p := &fakeProvider{podsOnNode: map[string][]Ref{"node-1": {
+		{Kind: "Pod", Namespace: "prod", Name: "web-abc"},
+		{Kind: "Pod", Namespace: "prod", Name: "api-xyz"},
+		{Kind: "Pod", Namespace: "prod", Name: "old-pod"},
+	}}}
+
+	out := enrichDiagnosticContext([]Issue{node}, []Issue{node, crash, pull, old}, nil, p)
+	ctx := out[0].DiagnosticContext
+	if ctx == nil {
+		t.Fatal("node issue got no diagnostic context")
+	}
+	var fact *issuesapi.DiagnosticFact
+	for i := range ctx.Facts {
+		if ctx.Facts[i].Type == factNodeBlastRadius {
+			fact = &ctx.Facts[i]
+		}
+	}
+	if fact == nil {
+		t.Fatalf("no node_blast_radius fact, got %+v", ctx.Facts)
+	}
+	if fact.Confidence != issuesapi.ConfidenceMedium {
+		t.Errorf("confidence = %q, want medium", fact.Confidence)
+	}
+	if ctx.Role != issuesapi.DiagnosticRoleCandidate {
+		t.Errorf("role = %q, want candidate", ctx.Role)
+	}
+	if len(fact.RelatedIssues) != 1 || fact.RelatedIssues[0].Category != issuesapi.CategoryCrashLoop || fact.RelatedIssues[0].Ref.Name != "web-abc" {
+		t.Fatalf("expected only the on-node crashloop linked (not the node-independent image pull, not the pre-existing crashloop), got %+v", fact.RelatedIssues)
+	}
+}
+
+func TestNodeBlastRadiusContext_NoPodsNoFact(t *testing.T) {
+	node := Issue{Kind: "Node", Name: "lonely", Category: issuesapi.CategoryNodeNotReady, Severity: SeverityCritical}
+	p := &fakeProvider{}
+	out := enrichDiagnosticContext([]Issue{node}, []Issue{node}, nil, p)
+	if out[0].DiagnosticContext != nil {
+		t.Fatalf("a node with no on-node issues should get no context, got %+v", out[0].DiagnosticContext)
 	}
 }

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -1612,9 +1612,11 @@ func TestPVCBlastRadiusContext(t *testing.T) {
 	// Unrelated crashloop on the same pod → never PVC-attributable.
 	crashing := Issue{ID: "crash-2", Kind: "Pod", Namespace: "prod", Name: "db-0", Category: issuesapi.CategoryCrashLoop, Severity: SeverityCritical}
 	// A DIFFERENT pod that also mounts the PVC but is unschedulable for CPU →
-	// must NOT be attributed to the PVC (no volume evidence in its message).
+	// must NOT be attributed to the PVC. Its message even contains the bare claim
+	// name "data" (unquoted) to guard against a substring false-match — only the
+	// QUOTED name or volume-binding phrasing counts as evidence.
 	cpuBlocked := Issue{ID: "unsched-2", Kind: "Pod", Namespace: "prod", Name: "db-1", Category: issuesapi.CategoryUnschedulable, Severity: SeverityCritical,
-		Message: "0/3 nodes are available: 3 Insufficient cpu"}
+		Message: "0/3 nodes are available: 3 Insufficient cpu for the data tier"}
 
 	p := &fakeProvider{podsMountingPVC: map[string][]Ref{"prod/data": {
 		{Kind: "Pod", Namespace: "prod", Name: "db-0"},

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -1595,6 +1595,40 @@ func TestNodeBlastRadiusContext_NotReadyLinksNothing(t *testing.T) {
 	}
 }
 
+func TestNodeBlastRadiusContext_MultiPressure(t *testing.T) {
+	// A node with BOTH MemoryPressure and DiskPressure groups into one issue that
+	// keeps a single representative Reason — the link must still cover BOTH
+	// pressures' pod categories (OOM under memory, container_waiting under disk).
+	grouped := Issue{Kind: "Node", Name: "node-1", Category: issuesapi.CategoryNodeNotReady, Severity: SeverityCritical, Reason: "MemoryPressure"}
+	flatMem := Issue{Kind: "Node", Name: "node-1", Category: issuesapi.CategoryNodeNotReady, Severity: SeverityCritical, Reason: "MemoryPressure"}
+	flatDisk := Issue{Kind: "Node", Name: "node-1", Category: issuesapi.CategoryNodeNotReady, Severity: SeverityCritical, Reason: "DiskPressure"}
+	oom := Issue{ID: "oom-1", Kind: "Pod", Namespace: "prod", Name: "a", Category: issuesapi.CategoryOOMKilled, Severity: SeverityCritical}
+	waiting := Issue{ID: "wait-1", Kind: "Pod", Namespace: "prod", Name: "b", Category: issuesapi.CategoryContainerWaiting, Severity: SeverityWarning, Reason: "ContainerCreating"}
+
+	p := &fakeProvider{podsOnNode: map[string][]Ref{"node-1": {
+		{Kind: "Pod", Namespace: "prod", Name: "a"},
+		{Kind: "Pod", Namespace: "prod", Name: "b"},
+	}}}
+
+	out := enrichDiagnosticContext([]Issue{grouped}, []Issue{flatMem, flatDisk, oom, waiting}, nil, p)
+	var fact *issuesapi.DiagnosticFact
+	for i := range out[0].DiagnosticContext.Facts {
+		if out[0].DiagnosticContext.Facts[i].Type == factNodeBlastRadius {
+			fact = &out[0].DiagnosticContext.Facts[i]
+		}
+	}
+	if fact == nil {
+		t.Fatal("no node_blast_radius fact for the multi-pressure node")
+	}
+	gotCats := map[issuesapi.Category]bool{}
+	for _, r := range fact.RelatedIssues {
+		gotCats[r.Category] = true
+	}
+	if !gotCats[issuesapi.CategoryOOMKilled] || !gotCats[issuesapi.CategoryContainerWaiting] {
+		t.Fatalf("multi-pressure node must link BOTH memory (OOM) and disk (container_waiting) pods, got %+v", fact.RelatedIssues)
+	}
+}
+
 func TestNodeBlastRadiusContext_NoPodsNoFact(t *testing.T) {
 	node := Issue{Kind: "Node", Name: "lonely", Category: issuesapi.CategoryNodeNotReady, Severity: SeverityCritical, Reason: "MemoryPressure"}
 	p := &fakeProvider{}

--- a/internal/issues/provider.go
+++ b/internal/issues/provider.go
@@ -180,6 +180,31 @@ func (p *CacheProvider) PodsOnNode(nodeName string) []Ref {
 	return refs
 }
 
+// PodsMountingPVC returns the pods that mount the named PersistentVolumeClaim
+// (spec.volumes[].persistentVolumeClaim.claimName) — the declared edge from a
+// PVC to the workloads it blocks. As with PodsOnNode, the caller intersects
+// against the request-scoped issue set, so visibility is enforced there.
+func (p *CacheProvider) PodsMountingPVC(namespace, pvcName string) []Ref {
+	if p == nil || p.cache == nil || p.cache.Pods() == nil || namespace == "" || pvcName == "" {
+		return nil
+	}
+	pods, err := p.cache.Pods().Pods(namespace).List(labels.Everything())
+	if err != nil {
+		return nil
+	}
+	refs := make([]Ref, 0)
+	for _, pod := range pods {
+		for _, v := range pod.Spec.Volumes {
+			if v.PersistentVolumeClaim != nil && v.PersistentVolumeClaim.ClaimName == pvcName {
+				refs = append(refs, Ref{Kind: "Pod", Namespace: pod.Namespace, Name: pod.Name})
+				break
+			}
+		}
+	}
+	sortRefs(refs)
+	return refs
+}
+
 func (p *CacheProvider) ChangeContextForIssue(i Issue) *issuesapi.ChangeContext {
 	if p == nil || p.cache == nil {
 		return nil

--- a/internal/issues/provider.go
+++ b/internal/issues/provider.go
@@ -158,6 +158,28 @@ func (p *CacheProvider) SelectedPodsForService(namespace, name string) []Ref {
 	return refs
 }
 
+// PodsOnNode returns every pod scheduled onto the named node (spec.nodeName).
+// The caller intersects these against the request-scoped issue set, so a pod the
+// user can't see contributes no link — RBAC/namespace scoping is preserved by the
+// intersection, not by this lister.
+func (p *CacheProvider) PodsOnNode(nodeName string) []Ref {
+	if p == nil || p.cache == nil || p.cache.Pods() == nil || nodeName == "" {
+		return nil
+	}
+	pods, err := p.cache.Pods().List(labels.Everything())
+	if err != nil {
+		return nil
+	}
+	refs := make([]Ref, 0)
+	for _, pod := range pods {
+		if pod.Spec.NodeName == nodeName {
+			refs = append(refs, Ref{Kind: "Pod", Namespace: pod.Namespace, Name: pod.Name})
+		}
+	}
+	sortRefs(refs)
+	return refs
+}
+
 func (p *CacheProvider) ChangeContextForIssue(i Issue) *issuesapi.ChangeContext {
 	if p == nil || p.cache == nil {
 		return nil

--- a/internal/k8s/detect.go
+++ b/internal/k8s/detect.go
@@ -999,12 +999,13 @@ func DetectProblems(cache *ResourceCache, namespace string) []Detection {
 				continue
 			}
 			ageDur := now.Sub(job.CreationTimestamp.Time)
-			// Stamp the controller owner (a CronJob, when this Job is one of its
-			// runs) so a failed Job rolls up to the same subject its pods do — the
-			// pods resolve their top owner to the CronJob, so job_failed must too
-			// or the rollup-over-pod-cause fold misses the match. A standalone Job
-			// has no controller owner and stays its own subject.
-			jobOwnerGroup, jobOwnerKind, jobOwnerName := controllerTopOwner(job.OwnerReferences)
+			// A failed Job stays its OWN subject — deliberately NOT rolled up to a
+			// CronJob owner. The Job's pods resolve their top owner to the CronJob
+			// (skipping the Job), so stamping the CronJob here would move job_failed
+			// off the Job and fold it away, leaving a failing Job's own detail page
+			// with no Operational Issues. Keeping the Job as the subject preserves
+			// that drill-down; standalone Jobs already fold with their pods (whose
+			// top owner is the Job).
 			if cond := failedJobCondition(job); cond != nil {
 				durDur := ageDur
 				if !cond.LastTransitionTime.IsZero() {
@@ -1026,9 +1027,6 @@ func DetectProblems(cache *ResourceCache, namespace string) []Detection {
 					AgeSeconds:      int64(ageDur.Seconds()),
 					Duration:        FormatAge(durDur),
 					DurationSeconds: int64(durDur.Seconds()),
-					OwnerGroup:      jobOwnerGroup,
-					OwnerKind:       jobOwnerKind,
-					OwnerName:       jobOwnerName,
 				})
 				continue
 			}
@@ -1045,9 +1043,6 @@ func DetectProblems(cache *ResourceCache, namespace string) []Detection {
 						AgeSeconds:      int64(ageDur.Seconds()),
 						Duration:        FormatAge(ageDur),
 						DurationSeconds: int64(ageDur.Seconds()),
-						OwnerGroup:      jobOwnerGroup,
-						OwnerKind:       jobOwnerKind,
-						OwnerName:       jobOwnerName,
 					})
 				}
 			}

--- a/internal/k8s/detect_test.go
+++ b/internal/k8s/detect_test.go
@@ -2164,7 +2164,11 @@ func TestDetectProblems_PodIssueTimingCreationProximity(t *testing.T) {
 // carries its CronJob as the resolved owner, so job_failed rolls up to the same
 // subject its pods do (their top owner is the CronJob) and the coalescing pass
 // can match them.
-func TestJobDetectionStampsControllerOwner(t *testing.T) {
+// TestJobDetectionStaysOwnSubject pins that a failed Job is NOT rolled up to its
+// CronJob owner — it stays its own subject so a failing Job's detail page keeps
+// showing the issue (the pods skip the Job in the owner chain, so rolling
+// job_failed up to the CronJob would fold it away from the Job).
+func TestJobDetectionStaysOwnSubject(t *testing.T) {
 	now := time.Now()
 	controller := true
 	client := fake.NewClientset(
@@ -2183,33 +2187,18 @@ func TestJobDetectionStampsControllerOwner(t *testing.T) {
 				}},
 			},
 		},
-		// Standalone Job (no controller owner) — must stay its own subject.
-		&batchv1.Job{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:              "oneoff",
-				Namespace:         "prod",
-				CreationTimestamp: metav1.NewTime(now.Add(-10 * time.Minute)),
-			},
-			Status: batchv1.JobStatus{
-				Conditions: []batchv1.JobCondition{{
-					Type: batchv1.JobFailed, Status: corev1.ConditionTrue, Reason: "BackoffLimitExceeded",
-				}},
-			},
-		},
 	)
 	if err := InitTestResourceCache(client); err != nil {
 		t.Fatalf("InitTestResourceCache: %v", err)
 	}
 	cache := GetResourceCache()
 
-	var owned, standalone Detection
-	var okOwned, okStandalone bool
+	var owned Detection
+	var okOwned bool
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		problems := DetectProblems(cache, "prod")
-		owned, okOwned = lookupProblem(problems, "Job", "nightly-run", "BackoffLimitExceeded")
-		standalone, okStandalone = lookupProblem(problems, "Job", "oneoff", "BackoffLimitExceeded")
-		if okOwned && okStandalone {
+		owned, okOwned = lookupProblem(DetectProblems(cache, "prod"), "Job", "nightly-run", "BackoffLimitExceeded")
+		if okOwned {
 			break
 		}
 		time.Sleep(20 * time.Millisecond)
@@ -2217,13 +2206,7 @@ func TestJobDetectionStampsControllerOwner(t *testing.T) {
 	if !okOwned {
 		t.Fatal("CronJob-owned failed Job not detected")
 	}
-	if owned.OwnerKind != "CronJob" || owned.OwnerName != "nightly" {
-		t.Errorf("CronJob-owned Job owner = (%q, %q), want (CronJob, nightly)", owned.OwnerKind, owned.OwnerName)
-	}
-	if !okStandalone {
-		t.Fatal("standalone failed Job not detected")
-	}
-	if standalone.OwnerKind != "" {
-		t.Errorf("standalone Job should have no controller owner, got %q", standalone.OwnerKind)
+	if owned.OwnerKind != "" {
+		t.Errorf("a CronJob-owned failed Job must stay its own subject (no owner stamp), got owner kind %q", owned.OwnerKind)
 	}
 }

--- a/packages/k8s-ui/src/components/issues/IssuesView.tsx
+++ b/packages/k8s-ui/src/components/issues/IssuesView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState, type ComponentType, type ReactNode } from
 import { ChevronRight, CircleCheck, Clock, ExternalLink } from 'lucide-react';
 import { ClusterName, EmptyState } from '../ui';
 import { formatCompactAge, formatRelativeAgeTime } from '../../utils/format';
+import { diagnosticRoleLabel, diagnosticFactLabel, confidenceTitle } from './diagnostic';
 import {
   ISSUE_SEVERITY_BADGE_CLASS,
   ISSUE_SEVERITY_LABEL,
@@ -408,62 +409,6 @@ function DiagnosticContext({
       </ul>
     </section>
   );
-}
-
-function diagnosticRoleLabel(role: string): string {
-  switch (role) {
-    case 'candidate':
-      return 'Candidate signal';
-    case 'affected':
-      return 'Affected signal';
-    case 'rollup':
-      return 'Rollup';
-    default:
-      return 'Context';
-  }
-}
-
-function diagnosticFactLabel(type: string): string {
-  switch (type) {
-    case 'explicit_reference':
-      return 'Explicit reference';
-    case 'owner_rollup':
-      return 'Owner rollup';
-    case 'selected_backend_issue':
-      return 'Selected backend';
-    case 'service_config_mismatch':
-      return 'Service config';
-    case 'service_env_reference':
-      return 'Service env';
-    case 'probe_target_mismatch':
-      return 'Probe target';
-    case 'blocked_init_container':
-      return 'Init container';
-    case 'restart_cause':
-      return 'Restart cause';
-    case 'node_blast_radius':
-      return 'Affected workloads';
-    case 'pvc_blast_radius':
-      return 'Blocked pods';
-    default:
-      return type.replace(/_/g, ' ');
-  }
-}
-
-// Plain-language gloss for the confidence chip's tooltip — the operator should
-// know a medium link is "these are co-located, the node may be the cause", not a
-// proven fact.
-function confidenceTitle(confidence: string): string {
-  switch (confidence) {
-    case 'high':
-      return 'High confidence: a declared structural link (selector, owner, or claim reference).';
-    case 'medium':
-      return 'Medium confidence: these resources are related, but causation is inferred — verify before acting.';
-    case 'low':
-      return 'Low confidence: a heuristic match.';
-    default:
-      return '';
-  }
 }
 
 // Native-tooltip detail for the collapsed-row age chip: absolute first-seen + last-seen

--- a/packages/k8s-ui/src/components/issues/IssuesView.tsx
+++ b/packages/k8s-ui/src/components/issues/IssuesView.tsx
@@ -366,6 +366,14 @@ function DiagnosticContext({
           <li key={`${fact.type}-${idx}`} className="flex flex-col gap-1.5 rounded-md border border-theme-border/70 px-2.5 py-2">
             <div className="flex min-w-0 items-baseline gap-2">
               <span className="shrink-0 text-xs font-medium text-theme-text-secondary">{diagnosticFactLabel(fact.type)}</span>
+              {fact.confidence ? (
+                <span
+                  className="shrink-0 badge-sm text-[10px] text-theme-text-tertiary"
+                  title={confidenceTitle(fact.confidence)}
+                >
+                  {fact.confidence} confidence
+                </span>
+              ) : null}
               {fact.message ? <span className="min-w-0 break-words text-xs leading-relaxed text-theme-text-tertiary">{fact.message}</span> : null}
             </div>
             {fact.related_issues?.length ? (
@@ -433,8 +441,28 @@ function diagnosticFactLabel(type: string): string {
       return 'Init container';
     case 'restart_cause':
       return 'Restart cause';
+    case 'node_blast_radius':
+      return 'Affected workloads';
+    case 'pvc_blast_radius':
+      return 'Blocked pods';
     default:
       return type.replace(/_/g, ' ');
+  }
+}
+
+// Plain-language gloss for the confidence chip's tooltip — the operator should
+// know a medium link is "these are co-located, the node may be the cause", not a
+// proven fact.
+function confidenceTitle(confidence: string): string {
+  switch (confidence) {
+    case 'high':
+      return 'High confidence: a declared structural link (selector, owner, or claim reference).';
+    case 'medium':
+      return 'Medium confidence: these resources are related, but causation is inferred — verify before acting.';
+    case 'low':
+      return 'Low confidence: a heuristic match.';
+    default:
+      return '';
   }
 }
 

--- a/packages/k8s-ui/src/components/issues/ResourceIssuesSection.tsx
+++ b/packages/k8s-ui/src/components/issues/ResourceIssuesSection.tsx
@@ -1,7 +1,7 @@
-import { AlertTriangle } from 'lucide-react'
+import { AlertTriangle, ExternalLink } from 'lucide-react'
 import { Section } from '../ui/drawer-components'
 import { Badge } from '../ui/Badge'
-import type { Issue } from './types'
+import type { Issue, IssueResourceRef } from './types'
 import { categoryLabel } from './severity'
 import { diagnosticRoleLabel, diagnosticFactLabel, confidenceTitle } from './diagnostic'
 
@@ -21,7 +21,14 @@ import { diagnosticRoleLabel, diagnosticFactLabel, confidenceTitle } from './dia
  * so it's omitted to keep the card scannable. (`message` is the body fallback
  * only for categories that don't yet emit a `cause`.)
  */
-export function ResourceIssuesSection({ issues }: { issues: Issue[] | undefined }) {
+export function ResourceIssuesSection({
+  issues,
+  onResourceClick,
+}: {
+  issues: Issue[] | undefined
+  /** When provided, related resources in a causal link become clickable. */
+  onResourceClick?: (ref: IssueResourceRef) => void
+}) {
   if (!issues || issues.length === 0) return null
   return (
     <Section title={`Operational Issues (${issues.length})`} icon={AlertTriangle} defaultExpanded>
@@ -58,7 +65,7 @@ export function ResourceIssuesSection({ issues }: { issues: Issue[] | undefined 
                   <code className="rounded bg-theme-elevated px-1 font-mono">{issue.remediation_target}</code> — apply it from the GitOps detail page.
                 </p>
               ) : null}
-              <CausalContext issue={issue} />
+              <CausalContext issue={issue} onResourceClick={onResourceClick} />
             </div>
           )
         })}
@@ -74,7 +81,7 @@ export function ResourceIssuesSection({ issues }: { issues: Issue[] | undefined 
  * renders the fuller context with clickable resource navigation; here the related
  * resources are shown as plain identifiers to keep the resource panel scannable.
  */
-function CausalContext({ issue }: { issue: Issue }) {
+function CausalContext({ issue, onResourceClick }: { issue: Issue; onResourceClick?: (ref: IssueResourceRef) => void }) {
   const ctx = issue.diagnostic_context
   const links = ctx?.facts?.filter((f) => f.confidence || (f.related_issues && f.related_issues.length > 0)) ?? []
   if (!ctx || links.length === 0) return null
@@ -98,15 +105,33 @@ function CausalContext({ issue }: { issue: Issue }) {
             </div>
             {fact.related_issues && fact.related_issues.length > 0 ? (
               <ul className="mt-0.5 space-y-0.5 pl-3">
-                {fact.related_issues.map((rel, ri) => (
-                  <li key={ri} className="text-theme-text-tertiary">
-                    <span className="text-[10px] uppercase tracking-wide text-theme-text-tertiary">{rel.ref.kind}</span>{' '}
-                    <span className="font-mono">
-                      {rel.ref.namespace ? `${rel.ref.namespace} / ` : ''}
-                      {rel.ref.name}
-                    </span>
-                  </li>
-                ))}
+                {fact.related_issues.map((rel, ri) => {
+                  const label = (
+                    <>
+                      <span className="text-[10px] uppercase tracking-wide text-theme-text-tertiary">{rel.ref.kind}</span>{' '}
+                      <span className="font-mono">
+                        {rel.ref.namespace ? `${rel.ref.namespace} / ` : ''}
+                        {rel.ref.name}
+                      </span>
+                    </>
+                  )
+                  return (
+                    <li key={ri} className="text-theme-text-tertiary">
+                      {onResourceClick ? (
+                        <button
+                          type="button"
+                          onClick={() => onResourceClick(rel.ref)}
+                          className="group inline-flex items-center gap-1 text-left hover:text-theme-text-secondary"
+                        >
+                          {label}
+                          <ExternalLink className="h-3 w-3 opacity-0 group-hover:opacity-100" />
+                        </button>
+                      ) : (
+                        label
+                      )}
+                    </li>
+                  )
+                })}
               </ul>
             ) : null}
           </li>

--- a/packages/k8s-ui/src/components/issues/ResourceIssuesSection.tsx
+++ b/packages/k8s-ui/src/components/issues/ResourceIssuesSection.tsx
@@ -3,6 +3,7 @@ import { Section } from '../ui/drawer-components'
 import { Badge } from '../ui/Badge'
 import type { Issue } from './types'
 import { categoryLabel } from './severity'
+import { diagnosticRoleLabel, diagnosticFactLabel, confidenceTitle } from './diagnostic'
 
 /**
  * ResourceIssuesSection — the compact "Operational Issues" block for the resource
@@ -57,10 +58,60 @@ export function ResourceIssuesSection({ issues }: { issues: Issue[] | undefined 
                   <code className="rounded bg-theme-elevated px-1 font-mono">{issue.remediation_target}</code> — apply it from the GitOps detail page.
                 </p>
               ) : null}
+              <CausalContext issue={issue} />
             </div>
           )
         })}
       </div>
     </Section>
+  )
+}
+
+/**
+ * CausalContext — the compact, drawer-density rendering of an issue's
+ * cross-subject causal links (DiagnosticContext). Shows only the linking facts
+ * (those carrying a confidence tier or related issues) — the queue's IssuesView
+ * renders the fuller context with clickable resource navigation; here the related
+ * resources are shown as plain identifiers to keep the resource panel scannable.
+ */
+function CausalContext({ issue }: { issue: Issue }) {
+  const ctx = issue.diagnostic_context
+  const links = ctx?.facts?.filter((f) => f.confidence || (f.related_issues && f.related_issues.length > 0)) ?? []
+  if (!ctx || links.length === 0) return null
+  return (
+    <div className="mt-2 border-t border-theme-border/60 pt-2">
+      <div className="mb-1 flex items-center gap-2">
+        <span className="text-[10px] font-semibold uppercase tracking-wide text-theme-text-tertiary">Context</span>
+        {ctx.role ? <span className="badge-sm text-[10px] text-theme-text-secondary">{diagnosticRoleLabel(ctx.role)}</span> : null}
+      </div>
+      <ul className="space-y-1.5">
+        {links.map((fact, idx) => (
+          <li key={`${fact.type}-${idx}`} className="text-xs">
+            <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+              <span className="font-medium text-theme-text-secondary">{diagnosticFactLabel(fact.type)}</span>
+              {fact.confidence ? (
+                <span className="badge-sm text-[10px] text-theme-text-tertiary" title={confidenceTitle(fact.confidence)}>
+                  {fact.confidence} confidence
+                </span>
+              ) : null}
+              {fact.message ? <span className="text-theme-text-tertiary">{fact.message}</span> : null}
+            </div>
+            {fact.related_issues && fact.related_issues.length > 0 ? (
+              <ul className="mt-0.5 space-y-0.5 pl-3">
+                {fact.related_issues.map((rel, ri) => (
+                  <li key={ri} className="text-theme-text-tertiary">
+                    <span className="text-[10px] uppercase tracking-wide text-theme-text-tertiary">{rel.ref.kind}</span>{' '}
+                    <span className="font-mono">
+                      {rel.ref.namespace ? `${rel.ref.namespace} / ` : ''}
+                      {rel.ref.name}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </div>
   )
 }

--- a/packages/k8s-ui/src/components/issues/diagnostic.ts
+++ b/packages/k8s-ui/src/components/issues/diagnostic.ts
@@ -1,0 +1,60 @@
+// Shared labels for rendering an issue's DiagnosticContext (the causal-link
+// surface). Used by both the cluster Issues queue (IssuesView) and the
+// per-resource Operational Issues block (ResourceIssuesSection) so the two
+// can't drift on wording.
+
+export function diagnosticRoleLabel(role: string): string {
+  switch (role) {
+    case 'candidate':
+      return 'Candidate signal';
+    case 'affected':
+      return 'Affected signal';
+    case 'rollup':
+      return 'Rollup';
+    default:
+      return 'Context';
+  }
+}
+
+export function diagnosticFactLabel(type: string): string {
+  switch (type) {
+    case 'explicit_reference':
+      return 'Explicit reference';
+    case 'owner_rollup':
+      return 'Owner rollup';
+    case 'selected_backend_issue':
+      return 'Selected backend';
+    case 'service_config_mismatch':
+      return 'Service config';
+    case 'service_env_reference':
+      return 'Service env';
+    case 'probe_target_mismatch':
+      return 'Probe target';
+    case 'blocked_init_container':
+      return 'Init container';
+    case 'restart_cause':
+      return 'Restart cause';
+    case 'node_blast_radius':
+      return 'Affected workloads';
+    case 'pvc_blast_radius':
+      return 'Blocked pods';
+    default:
+      return type.replace(/_/g, ' ');
+  }
+}
+
+// Plain-language gloss for the confidence chip's tooltip — the operator should
+// know a medium link is "these are co-located, the node may be the cause", not a
+// proven fact.
+export function confidenceTitle(confidence: string): string {
+  switch (confidence) {
+    case 'high':
+      return 'High confidence: a declared structural link (selector, owner, or claim reference).';
+    case 'medium':
+      return 'Medium confidence: these resources are related, but causation is inferred — verify before acting.';
+    case 'low':
+      return 'Low confidence: a heuristic match.';
+    default:
+      return '';
+  }
+}

--- a/packages/k8s-ui/src/components/issues/diagnostic.ts
+++ b/packages/k8s-ui/src/components/issues/diagnostic.ts
@@ -3,37 +3,41 @@
 // per-resource Operational Issues block (ResourceIssuesSection) so the two
 // can't drift on wording.
 
+// Operator-facing — describes the issue's place in the causal picture in plain
+// language, not Radar's internal role taxonomy.
 export function diagnosticRoleLabel(role: string): string {
   switch (role) {
     case 'candidate':
-      return 'Candidate signal';
+      return 'Possible cause';
     case 'affected':
-      return 'Affected signal';
+      return 'Affected';
     case 'rollup':
-      return 'Rollup';
+      return 'Grouped';
     default:
       return 'Context';
   }
 }
 
+// Operator-facing fact labels — plain language over the implementation-shaped
+// internal type names.
 export function diagnosticFactLabel(type: string): string {
   switch (type) {
     case 'explicit_reference':
-      return 'Explicit reference';
+      return 'Missing reference';
     case 'owner_rollup':
-      return 'Owner rollup';
+      return 'Grouped from pods';
     case 'selected_backend_issue':
-      return 'Selected backend';
+      return 'Backend pods';
     case 'service_config_mismatch':
       return 'Service config';
     case 'service_env_reference':
-      return 'Service env';
+      return 'Referenced service';
     case 'probe_target_mismatch':
       return 'Probe target';
     case 'blocked_init_container':
       return 'Init container';
     case 'restart_cause':
-      return 'Restart cause';
+      return 'Restart evidence';
     case 'node_blast_radius':
       return 'Affected workloads';
     case 'pvc_blast_radius':

--- a/packages/k8s-ui/src/components/issues/index.ts
+++ b/packages/k8s-ui/src/components/issues/index.ts
@@ -12,7 +12,7 @@ export {
   subjectRef,
   memberRef,
 } from './types';
-export type { Issue, IssueSeverity, IssueAffected, IssueResourceRef, IssueDiagnosticContext, IssueDiagnosticFact, IssueDiagnosticIssueRef, IssueDiagnosticRole, IssueChangeContext, IssueRecentChange, IssueRecentChangeField } from './types';
+export type { Issue, IssueSeverity, IssueAffected, IssueResourceRef, IssueDiagnosticContext, IssueDiagnosticFact, IssueDiagnosticConfidence, IssueDiagnosticIssueRef, IssueDiagnosticRole, IssueChangeContext, IssueRecentChange, IssueRecentChangeField } from './types';
 export {
   ISSUE_SEVERITY_LABEL,
   ISSUE_SEVERITY_BADGE_CLASS,

--- a/packages/k8s-ui/src/components/issues/types.ts
+++ b/packages/k8s-ui/src/components/issues/types.ts
@@ -73,9 +73,13 @@ export interface IssueDiagnosticIssueRef {
   severity?: IssueSeverity;
 }
 
+export type IssueDiagnosticConfidence = 'high' | 'medium' | 'low';
+
 export interface IssueDiagnosticFact {
   type: string;
   message?: string;
+  /** How certain a cross-subject causal link is. Absent for non-causal facts. */
+  confidence?: IssueDiagnosticConfidence;
   refs?: IssueResourceRef[];
   related_issues?: IssueDiagnosticIssueRef[];
 }

--- a/pkg/issuesapi/types.go
+++ b/pkg/issuesapi/types.go
@@ -210,11 +210,29 @@ type DiagnosticContext struct {
 }
 
 type DiagnosticFact struct {
-	Type          string     `json:"type"`
-	Message       string     `json:"message,omitempty"`
+	Type    string `json:"type"`
+	Message string `json:"message,omitempty"`
+	// Confidence rates how certain a cross-subject causal link is, so the UI can
+	// present a high-certainty structural edge differently from a heuristic one.
+	// Empty for non-causal facts (rollup, restart evidence).
+	Confidence    Confidence `json:"confidence,omitempty"`
 	Refs          []Ref      `json:"refs,omitempty"`
 	RelatedIssues []IssueRef `json:"related_issues,omitempty"`
 }
+
+// Confidence tiers a causal link by how deterministic the edge is:
+//   - high: a declared structural edge (selector, ownerRef, claimName) — the link
+//     is a fact, not an inference.
+//   - medium: a direct field match whose causation needs a guard (pod.spec.nodeName
+//     locates a pod on a failing node, but co-located ≠ caused-by).
+//   - low: a heuristic/message-pattern match.
+type Confidence string
+
+const (
+	ConfidenceHigh   Confidence = "high"
+	ConfidenceMedium Confidence = "medium"
+	ConfidenceLow    Confidence = "low"
+)
 
 type IssueRef struct {
 	Ref      Ref      `json:"ref"`

--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -536,7 +536,22 @@ export function WorkloadView({
           <FluxSourceConsumersSection kind={k} namespace={ns} name={n} />
         </>
       )}
-      renderOverviewLead={() => <ResourceIssuesSection issues={liveIssues} />}
+      renderOverviewLead={() => (
+        <ResourceIssuesSection
+          issues={liveIssues}
+          onResourceClick={
+            rest.onNavigateToResource
+              ? (ref) =>
+                  rest.onNavigateToResource?.({
+                    kind: kindToPlural(ref.kind),
+                    namespace: ref.namespace ?? '',
+                    name: ref.name,
+                    group: ref.group ?? '',
+                  })
+              : undefined
+          }
+        />
+      )}
       hasOperationalIssues={!!liveIssues?.length}
       onOpenGitOpsResource={gitopsOwnerQuery.data ? handleOpenGitOpsResource : undefined}
       resolvedGitOpsOwner={gitopsOwner}


### PR DESCRIPTION
## Summary

Issue correlation, cross-subject tier. When two issues on **different resources** are causally related — a memory-pressured node and the pods OOMing on it, a broken PVC and the pods that mount it, a Service and its failing backend pods — Radar now **links** them so the operator sees the blast radius and can find the root, without losing either row. This is the deliberately **non-destructive** counterpart to the same-subject coalescing in #1041: it never drops a row, never changes severity or ranking — it annotates the root issue with the symptoms it explains.

It reuses the existing `DiagnosticContext` mechanism (already on `main`, already rendered by the Issues view), computed after grouping over the **RBAC/namespace-scoped** issue set — so a link can never reference a resource outside the caller's authorization. (A related ref *can* point at an issue hidden by a display filter — e.g. a `?severity=critical` view may link a warning pod — because enrichment runs before the severity/kind/CEL filters; that's intended context, not a leak.)

## The new logic

### 1. Confidence tiers (new field on the public `issuesapi.DiagnosticFact`)

A causal link now carries a `confidence` so the UI can present a certain structural edge differently from a heuristic one. It is **absent** on non-causal facts (rollups, restart evidence):
- **high** — a *declared structural edge* the link is a fact about: a Service selector, an owner reference, a PVC `claimName`.
- **medium** — a *direct-field* match whose causation is inferred: `pod.spec.nodeName` proves a pod is *on* a node, not that the node *caused* its problem.
- **low** — a heuristic / message-pattern match. (reserved; not emitted yet)

### 2. Node blast-radius link (new) — `confidence: medium`

A resource-**pressured** node links to the pod issues that pressure plausibly caused (matched by `pod.spec.nodeName`). The node is the candidate root; the pod issues are its blast radius.

- **Reason-gated** — the link conditions on the node's *reason*, because the cases aren't equivalent:
  - **MemoryPressure** → `oom_killed`, `high_restart` (memory exhaustion → OOM / OOM-restart loops).
  - **DiskPressure** → `container_waiting` (no space to create containers / pull images).
  - **PIDPressure** → `container_waiting` (can't fork to start containers).
  - **NotReady (dead kubelet)** → **links nothing.** Once the kubelet stops reporting, a pod's status is stale, so its crashloop/OOM rows are pre-existing *app* problems that merely sit on the node — not node-caused. Linking them would falsely point the operator at the node. (The genuine dead-node blast radius — terminating/evicted pods, unschedulable replacements — isn't captured by these runtime categories and is left to a future reason-aware detector.)
  - App-dominant categories (crashloop, probe failures, image pull, missing config) are excluded throughout for the same reason.
- **Confidence: medium**, not high — `spec.nodeName` proves a pod is *on* the node and the category is consistent with the pressure, but co-located is not proof of cause; the UI frames it "the node may be the cause — verify."
- **No timestamp guard.** Pod-issue onset isn't reliably recorded (`FirstSeen` tracks pod age, not failure onset), so a guard would *drop legitimate* long-running pods newly hit by the node while still admitting unrelated ones. Precision rests on the reason→category gate + the honest medium label + the non-destructive shape (every pod issue keeps its own row).

### 3. PVC blast-radius link (new) — `confidence: high`

A broken PVC (`pvc_pending` / `pvc_lost` / `pvc_resize_failed`) links to the storage issues of the pods that mount it (matched by `spec.volumes[].persistentVolumeClaim.claimName`).

- **`volume_mount_failed`** links unconditionally — the mount edge is declared, so it's unambiguously this PVC's fault.
- **`unschedulable` / `container_waiting`** link only when the symptom's **own message confirms a volume cause** — it names the PVC, or carries the scheduler's volume-binding language (`persistentvolumeclaim`, `unbound`, `volume node affinity`). A pod that mounts the claim but is unschedulable for **CPU**, or waiting on unrelated config, is **not** attributed to the PVC.

### 4. Service backend link — now tagged `confidence: high`

The pre-existing `selected_backend_issue` fact (a `service_no_endpoints` Service whose selected backend pods have active issues) is now tagged high (declared selector edge). No behavior change beyond the tag.

### 5. Shared `linkBlastRadius` helper

Both new links go through one helper that collects all matching symptom issues, **ranks by severity, then caps** — so the capped list keeps the *worst* issues, not the first ones in iteration order. (Pre-existing inline backend-link code keeps its prior shape.)

## Guards — correctness & why it can't mislead or leak

- **RBAC/namespace scoping (no leak):** the provider lookups (`PodsOnNode`, `PodsMountingPVC`) list cluster/namespace-wide, but a link only materializes by **intersecting** the returned pods against the already-auth-filtered `flatByResource` set (namespaces are RBAC-filtered upstream; cluster-scoped rows are gated before enrichment). A resource outside the caller's authorization contributes nothing. Note: enrichment runs *before* the response's display filters (severity/kind/CEL), so a related ref may reference an issue those filters hid from the returned list — useful context, not an authorization leak.
- **Non-destructive:** the symptom keeps its own top-level row; the link is an annotation on the root. Nothing is suppressed or down-ranked — that distinguishes this tier from #1041.
- **Over-coalescing guards:** the per-link category allow-lists + the PVC volume-evidence gate + the honest medium label on the node link are what keep these from making false causal claims.
- **Confidence is absent on non-causal facts** (owner_rollup, restart_cause, service_config_mismatch) — only genuine cross-subject links are tagged.

## Frontend (`@skyhook-io/k8s-ui`)
Links render in **both** the cluster Issues view and the per-resource Operational Issues block (resource detail / WorkloadView):
- **Issues view** renders `DiagnosticContext` facts (it already did, generically); this adds a **confidence chip** with a plain-language tooltip (so a medium node link reads as "related, causation inferred — verify", not a proven fact) and labels for the new fact types ("Affected workloads", "Blocked pods").
- **`ResourceIssuesSection`** (the resource drawer) now renders a compact "Context" block for the causal-link facts. Shared the fact/role/confidence labels into `diagnostic.ts` so the two surfaces can't drift.
- Backend: `foldGroup` now preserves the representative's `DiagnosticContext`/`ChangeContext` — without it the per-resource `RelatedIssues` path (which regroups after enrichment) silently dropped the link before it reached the resource endpoint.

## New backend surface
- `issuesapi.DiagnosticFact.Confidence` (+ `Confidence` type / constants) — additive, backwards-compatible; existing consumers ignore it.
- Provider methods `PodsOnNode(node)` and `PodsMountingPVC(ns, claim)`.

## What a reviewer should focus on
- **Request-scoping** is the security-critical claim — confirm a link can't surface an issue outside the caller's RBAC/namespace view (it's gated by the `flatByResource` intersection).
- **Over-coalescing** — the category allow-lists and the PVC volume-evidence gate are the precision guards; the node link is intentionally medium-confidence because co-located ≠ caused-by.

## Testing
- `go build ./...`, `go test ./internal/issues ./internal/k8s ./internal/server`, and the `pkg/issuesapi` module — green; `make tsc` green.
- Unit tests pin: node category exclusion, PVC volume-evidence gate (CPU-unschedulable not attributed; unrelated crashloop excluded), confidence tiers, empty cases.
- **Verified live via `/api/issues` (kind / AWS / GCP):** `pvc_blast_radius` confirmed end-to-end on kind (induced a pending PVC + consuming pod → high-confidence link to the volume-evidenced unschedulable pod); `selected_backend` confirmed high-confidence with correct related pods; confidence correctly absent on non-causal facts; healthy/no-trigger clusters produced zero spurious links.
- **Visual-tested (Playwright, kind):** captured the rendered confidence chip + Context section in both the Issues view (`pvc_blast_radius`, `selected_backend`) and the per-resource Operational Issues block (PVC detail).
- **Not yet live-verified:** `node_blast_radius` — all test clusters had healthy nodes, and single-node kind can't be made MemoryPressure/NotReady without killing it; covered by unit tests, so its **medium-confidence** rendering is the one chip not captured live.

## Also includes — post-merge fixes for #1041 (Cursor Bugbot)
#1041 merged before its Bugbot findings were addressed, so the fixes ride here (they touch the same-subject coalescing code now in `main`):
- **Failed Jobs stay visible** — a `job_failed` is no longer rolled up to its CronJob owner. The Job's pods skip the Job in the owner chain (they resolve to the CronJob), so stamping the CronJob moved `job_failed` off the Job and folded it away, leaving a failing Job's own detail page empty. Jobs now stay their own subject; standalone Jobs still fold with their pods.
- **Dropped the image-pull fold** — `dedupeImagePullOverMissingPullSecret` folded away *every* `image_pull_failed` on a pod with a missing imagePullSecret, hiding unrelated wrong-tag/not-found/rate-limit errors. A missing pull-secret object surfaces as `CreateContainerConfigError`, which the container_waiting fold already covers.

## Follow-ups
- More cross-subject links, same non-destructive pattern: cert-manager chain, GitOps managed-by rollup, admission-webhook fan-in (needs detector work), apiservice(metrics)→HPA; tighten `unschedulable→PVC` once the scheduler reason class is threaded onto detections.
- Live-verify `node_blast_radius` (needs a multi-node cluster + induced MemoryPressure/NotReady).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes issue correlation, deduplication, and Job subject identity—operators may see different rows/links than before, but links are annotate-only and intersect with scoped issue data rather than leaking RBAC.
> 
> **Overview**
> Adds **non-destructive cross-resource correlation**: pressured **Nodes** and broken **PVCs** get `DiagnosticContext` facts that point at related pod issues (scoped to the auth-filtered flat issue set), with new **`confidence`** on causal facts (`medium` for node co-location, `high` for PVC mount edges and service backends). Shared **`linkBlastRadius`** ranks linked issues by severity before capping so refs and related issues stay aligned.
> 
> **Provider** gains **`PodsOnNode`** and **`PodsMountingPVC`**; enrichment runs after grouping on the cluster path, with **`foldGroup`** now copying **`DiagnosticContext`** / **`ChangeContext`** so per-resource **RelatedIssues** regroup does not drop links.
> 
> **Coalescing follow-ups:** removes **`dedupeImagePullOverMissingPullSecret`** so unrelated **`image_pull_failed`** rows are not hidden; failed **Jobs** no longer inherit **CronJob** owner stamps so **`job_failed`** stays visible on the Job detail page.
> 
> **UI:** shared **`diagnostic.ts`** labels, confidence chips in **IssuesView**, compact causal **Context** in **ResourceIssuesSection** (click-through from **WorkloadView** when navigation is available).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e6acd8a96dd8743b2e71d488b12c32ca734ea5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->