### PR TITLE
perf(timeline): reuse the cache-computed diff instead of recomputing per update

### DIFF
--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -175,7 +175,7 @@ func InitResourceCache(ctx context.Context) error {
 				}
 
 				// Record to timeline store
-				recordToTimelineStore(change.Kind, change.Namespace, change.Name, change.UID, change.Operation, oldObj, obj)
+				recordToTimelineStore(change.Kind, change.Namespace, change.Name, change.UID, change.Operation, oldObj, obj, change.Diff, true)
 			},
 
 			OnEventChange: func(obj any, op string) {
@@ -368,8 +368,13 @@ func getGeneration(obj any) int64 {
 	return m.GetGeneration()
 }
 
-// recordToTimelineStore records an event to the timeline store
-func recordToTimelineStore(kind, namespace, name, uid, op string, oldObj, newObj any) {
+// recordToTimelineStore records a resource change to the timeline. When the
+// caller has already computed the update diff (the cache layer does, before
+// firing OnChange), it passes it via precomputedDiff + diffPrecomputed=true so
+// we don't recompute the identical diff on the hottest per-update path. Callers
+// without a precomputed diff (tests, non-cache paths) pass nil + false and the
+// diff is computed here as before.
+func recordToTimelineStore(kind, namespace, name, uid, op string, oldObj, newObj any, precomputedDiff *DiffInfo, diffPrecomputed bool) {
 	store := timeline.GetStore()
 	if store == nil {
 		return
@@ -413,7 +418,13 @@ func recordToTimelineStore(kind, namespace, name, uid, op string, oldObj, newObj
 
 	var diff *timeline.DiffInfo
 	if op == "update" && oldObj != nil && newObj != nil {
-		if localDiff := ComputeDiff(kind, oldObj, newObj); localDiff != nil {
+		// Reuse the cache layer's already-computed diff on the hot path; only
+		// recompute for callers (tests / non-cache) that didn't precompute it.
+		localDiff := precomputedDiff
+		if !diffPrecomputed {
+			localDiff = ComputeDiff(kind, oldObj, newObj)
+		}
+		if localDiff != nil {
 			diff = &timeline.DiffInfo{
 				Fields:  make([]timeline.FieldChange, len(localDiff.Fields)),
 				Summary: localDiff.Summary,

--- a/internal/k8s/dedup_diff_test.go
+++ b/internal/k8s/dedup_diff_test.go
@@ -1,0 +1,50 @@
+package k8s
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/skyhook-io/radar/internal/timeline"
+)
+
+// The cache layer computes the update diff once and hands it to
+// recordToTimelineStore (diffPrecomputed=true) instead of recomputing it. This
+// pins the invariant that the precomputed path produces a timeline entry
+// identical to the recompute path — i.e. reusing the diff changed nothing.
+func TestRecordToTimelineStore_PrecomputedDiffMatchesRecompute(t *testing.T) {
+	now := time.Now()
+	oldDep := testDeployment("uid-1", "nginx:1.0", now)
+	newDep := testDeployment("uid-1", "nginx:2.0", now)
+
+	pre := ComputeDiff("Deployment", oldDep, newDep)
+	if pre == nil {
+		t.Fatal("expected a non-nil diff for an image change")
+	}
+
+	record := func(precomputed *DiffInfo, diffPrecomputed bool) *timeline.DiffInfo {
+		t.Helper()
+		timeline.ResetStore()
+		if err := timeline.InitStore(timeline.StoreConfig{Type: timeline.StoreTypeMemory, MaxSize: 10}); err != nil {
+			t.Fatalf("InitStore: %v", err)
+		}
+		recordToTimelineStore("Deployment", "shop", "web", "uid-1", "update", oldDep, newDep, precomputed, diffPrecomputed)
+		events, err := timeline.GetStore().Query(context.Background(), timeline.QueryOptions{Kinds: []string{"Deployment"}})
+		if err != nil {
+			t.Fatalf("Query: %v", err)
+		}
+		if len(events) != 1 {
+			t.Fatalf("expected exactly 1 recorded event, got %d", len(events))
+		}
+		return events[0].Diff
+	}
+
+	got := record(pre, true)   // production path: reuse the cache-computed diff
+	want := record(nil, false) // fallback path: recompute in recordToTimelineStore
+	t.Cleanup(timeline.ResetStore)
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("precomputed-diff timeline output differs from recompute:\n got=%+v\nwant=%+v", got, want)
+	}
+}

--- a/internal/k8s/dynamic_cache.go
+++ b/internal/k8s/dynamic_cache.go
@@ -89,6 +89,8 @@ func InitDynamicResourceCache(changeCh chan k8score.ResourceChange) error {
 					change.Operation,
 					oldObj,
 					obj,
+					change.Diff,
+					true,
 				)
 			},
 			OnDrop: func(kind, ns, name, reason, op string) {

--- a/internal/k8s/noisy_filter_audit_test.go
+++ b/internal/k8s/noisy_filter_audit_test.go
@@ -173,7 +173,7 @@ func TestRecordToTimelineStore_SyncAddMarksResourceSeen(t *testing.T) {
 		},
 	}
 
-	recordToTimelineStore("Pod", "default", "p", "pod-uid", "add", nil, pod)
+	recordToTimelineStore("Pod", "default", "p", "pod-uid", "add", nil, pod, nil, false)
 
 	store := timeline.GetStore()
 	if store == nil {

--- a/internal/k8s/recreate_stash_test.go
+++ b/internal/k8s/recreate_stash_test.go
@@ -50,10 +50,10 @@ func TestRecreateJoin_DeleteThenRecreateCarriesDiff(t *testing.T) {
 	}
 
 	oldDep := testDeployment("uid-1", "nginx:1.0", time.Now().Add(-time.Hour))
-	recordToTimelineStore("Deployment", "shop", "web", "uid-1", "delete", nil, oldDep)
+	recordToTimelineStore("Deployment", "shop", "web", "uid-1", "delete", nil, oldDep, nil, false)
 
 	newDep := testDeployment("uid-2", "nginx:2.0", time.Now())
-	recordToTimelineStore("Deployment", "shop", "web", "uid-2", "add", nil, newDep)
+	recordToTimelineStore("Deployment", "shop", "web", "uid-2", "add", nil, newDep, nil, false)
 
 	events, err := timeline.GetStore().Query(context.Background(), timeline.QueryOptions{
 		Kinds: []string{"Deployment"}, Namespaces: []string{"shop"},
@@ -111,8 +111,8 @@ func TestRecreateJoin_SameUIDReAdd_NoJoin(t *testing.T) {
 	}
 
 	dep := testDeployment("uid-1", "nginx:1.0", time.Now())
-	recordToTimelineStore("Deployment", "shop", "web", "uid-1", "delete", nil, dep)
-	recordToTimelineStore("Deployment", "shop", "web", "uid-1", "add", nil, dep)
+	recordToTimelineStore("Deployment", "shop", "web", "uid-1", "delete", nil, dep, nil, false)
+	recordToTimelineStore("Deployment", "shop", "web", "uid-1", "add", nil, dep, nil, false)
 
 	events, err := timeline.GetStore().Query(context.Background(), timeline.QueryOptions{
 		Kinds: []string{"Deployment"}, EventTypes: []timeline.EventType{timeline.EventTypeAdd},
@@ -203,10 +203,10 @@ func TestRecreateJoin_SpecIdenticalRecreate_NoJoin(t *testing.T) {
 
 	oldDep := testDeployment("uid-1", "nginx:1.0", time.Now().Add(-time.Hour))
 	oldDep.Status = appsv1.DeploymentStatus{ReadyReplicas: 1, AvailableReplicas: 1}
-	recordToTimelineStore("Deployment", "shop", "web", "uid-1", "delete", nil, oldDep)
+	recordToTimelineStore("Deployment", "shop", "web", "uid-1", "delete", nil, oldDep, nil, false)
 
 	newDep := testDeployment("uid-2", "nginx:1.0", time.Now()) // same spec, fresh status
-	recordToTimelineStore("Deployment", "shop", "web", "uid-2", "add", nil, newDep)
+	recordToTimelineStore("Deployment", "shop", "web", "uid-2", "add", nil, newDep, nil, false)
 
 	events, err := timeline.GetStore().Query(context.Background(), timeline.QueryOptions{
 		Kinds: []string{"Deployment"}, EventTypes: []timeline.EventType{timeline.EventTypeAdd},


### PR DESCRIPTION
## Summary

Every resource update was computing its diff **twice**. The informer cache computes `change.Diff` (consumed by the SSE change feed) before firing `OnChange`, but the timeline path (`recordToTimelineStore`) discarded it and recomputed the identical `ComputeDiff`. On high-churn kinds — Pod/Deployment/ReplicaSet status updates, the busiest traffic on an active cluster — the diff is the heaviest per-event operation (for generic CRDs it's a DeepCopy of both objects + a recursive normalize + `reflect.DeepEqual` over the full trees), and it was paid twice for zero added information.

## What changed

`recordToTimelineStore` now accepts the already-computed diff and reuses it on the hot path:
- Both production callers (typed cache `OnChange` and dynamic/CRD cache `OnChange`) pass `change.Diff` — which the cache layer already computed via the same `ComputeDiff(kind, oldObj, newObj)` over the same objects.
- Callers without a precomputed diff (tests, any non-cache path) pass `diffPrecomputed=false` and compute as before — behavior unchanged.

The result is **identical on the normal path**: the reused diff is the same `ComputeDiff` over the same old/new objects (verified for both the typed and dynamic caches), and the downstream conversion to `timeline.DiffInfo`, the no-diff generation-bump fallback, and the recreate-join path are all untouched.

One deliberate edge: if a dynamic/CRD differ *panics*, the cache layer's `safeCallback` leaves `change.Diff` nil and the timeline now records the generation-bump fallback instead of recomputing. Previously the recompute would panic again and the whole record was dropped — so this degrades to **more** information, not less. (Differ panics are a bug-only path; this is a strict robustness improvement, not a regression.)

This is the first of a set of audited hot-path optimizations; scope is deliberately just this one change.

## Testing

- `go build ./...` ✓ · `go test ./internal/k8s/... ./internal/server/...` ✓ · `go test -race ./internal/k8s/...` (timeline/diff/recreate paths) ✓
- New focused regression test `TestRecordToTimelineStore_PrecomputedDiffMatchesRecompute` asserts the precomputed-diff timeline entry is identical to the recompute path.
- visual-test: n/a (backend-only, no UI change).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only refactor with a fallback path and a regression test asserting identical timeline output; no API or UI changes.
> 
> **Overview**
> **Avoids double `ComputeDiff` on informer updates** by threading the diff the cache already built for the change feed into timeline recording instead of computing it again inside `recordToTimelineStore`.
> 
> `recordToTimelineStore` now takes `precomputedDiff` and `diffPrecomputed`. Typed and dynamic `OnChange` handlers pass `change.Diff` with `diffPrecomputed=true`; tests and other callers pass `nil` and `false` so behavior matches the old recompute path. Recreate-join and generation-bump fallbacks are unchanged.
> 
> Adds `TestRecordToTimelineStore_PrecomputedDiffMatchesRecompute` so the reuse path must produce the same timeline `DiffInfo` as recomputing in the helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 894ca31eb1016febc9bda84d694aeb7d749e0a76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
