### PR TITLE
perf(sse): pre-marshal event frames once per broadcast

### DIFF
--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -724,8 +724,27 @@ func (b *SSEBroadcaster) heartbeat() {
 	}
 }
 
+// premarshalEventData serializes event.Data to json.RawMessage once, before
+// fan-out, so the per-client SSE writer emits the same bytes to every connected
+// client instead of reflection-marshaling the identical payload N times (once
+// per tab). Frames whose Data is already json.RawMessage (the topology path)
+// pass through untouched. A marshal error leaves Data as-is — the per-client
+// writer then surfaces it via its existing error path.
+func premarshalEventData(event SSEEvent) SSEEvent {
+	if _, ok := event.Data.(json.RawMessage); ok {
+		return event
+	}
+	data, err := json.Marshal(event.Data)
+	if err != nil {
+		return event
+	}
+	event.Data = json.RawMessage(data)
+	return event
+}
+
 // Broadcast sends an event to all connected clients
 func (b *SSEBroadcaster) Broadcast(event SSEEvent) {
+	event = premarshalEventData(event)
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
@@ -752,6 +771,7 @@ func (b *SSEBroadcaster) Broadcast(event SSEEvent) {
 // The complete fix carries the exact GVR on ResourceChange and authorizes each
 // client via the cached per-user canRead — tracked separately.
 func (b *SSEBroadcaster) broadcastResourceChange(event SSEEvent, namespace, kind string) {
+	event = premarshalEventData(event)
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
@@ -961,7 +981,18 @@ func (b *SSEBroadcaster) HandleSSE(w http.ResponseWriter, r *http.Request, denie
 			if !ok {
 				return
 			}
-			data, err := json.Marshal(event.Data)
+			// Frames are pre-marshaled to json.RawMessage once before fan-out
+			// (premarshalEventData), so for the common case write the shared
+			// bytes directly — re-marshaling here would re-serialize the same
+			// payload for every connected client. Fall back to marshaling for
+			// any frame that wasn't pre-marshaled.
+			var data []byte
+			var err error
+			if raw, ok := event.Data.(json.RawMessage); ok {
+				data = raw
+			} else {
+				data, err = json.Marshal(event.Data)
+			}
 			if err != nil {
 				// Log the error and notify client instead of silently dropping
 				log.Printf("SSE: failed to marshal event %q: %v", event.Event, err)

--- a/internal/server/sse_premarshal_test.go
+++ b/internal/server/sse_premarshal_test.go
@@ -1,0 +1,66 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// premarshalEventData must produce exactly the bytes the old per-client writer
+// produced via json.Marshal(event.Data) — the optimization moves the marshal
+// from once-per-client to once-per-broadcast, it must not change the wire bytes.
+func TestPremarshalEventData_MatchesPerClientMarshal(t *testing.T) {
+	// Include a value with HTML-significant chars (<,>,&) — json.Marshal escapes
+	// these, so this guards that the pre-marshal path keeps that escaping.
+	data := map[string]any{
+		"kind":      "Pod",
+		"namespace": "default",
+		"name":      "web<svc>&db",
+		"operation": "update",
+		"diff": map[string]any{
+			"summary": "image changed",
+			"fields":  []any{map[string]any{"path": "spec.image", "old": "a", "new": "b"}},
+		},
+	}
+	ev := SSEEvent{Event: "k8s_event", Data: data}
+
+	want, err := json.Marshal(data) // the bytes the old per-client path emitted
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	got := premarshalEventData(ev)
+	raw, ok := got.Data.(json.RawMessage)
+	if !ok {
+		t.Fatalf("expected Data to be json.RawMessage after premarshal, got %T", got.Data)
+	}
+	if string(raw) != string(want) {
+		t.Fatalf("premarshaled bytes differ from per-client marshal:\n got=%s\nwant=%s", raw, want)
+	}
+	if got.Event != ev.Event {
+		t.Fatalf("event type changed: got %q want %q", got.Event, ev.Event)
+	}
+
+	// And the writer's RawMessage fast-path must equal the old json.Marshal(raw):
+	// re-marshaling already-marshaled (compact, escaped) bytes is a no-op.
+	reMarshaled, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("re-marshal: %v", err)
+	}
+	if string(reMarshaled) != string(raw) {
+		t.Fatalf("writer fast-path not equivalent to json.Marshal(RawMessage):\n direct=%s\nmarshaled=%s", raw, reMarshaled)
+	}
+}
+
+// A frame whose Data is already json.RawMessage (the topology path) must pass
+// through untouched — no double-marshal.
+func TestPremarshalEventData_RawMessagePassthrough(t *testing.T) {
+	raw := json.RawMessage(`{"already":"serialized","n":1}`)
+	got := premarshalEventData(SSEEvent{Event: "topology", Data: raw})
+	gotRaw, ok := got.Data.(json.RawMessage)
+	if !ok {
+		t.Fatalf("expected json.RawMessage, got %T", got.Data)
+	}
+	if string(gotRaw) != string(raw) {
+		t.Fatalf("RawMessage should pass through unchanged: got %s want %s", gotRaw, raw)
+	}
+}


### PR DESCRIPTION
## Summary

Every SSE frame was JSON-serialized independently inside each connected client's writer goroutine. A session with N open tabs therefore re-serialized the *identical* payload N times on every resource change — pure duplicated CPU and allocation that scales with tab count on the hottest path in the app (per-resource-change and topology broadcasts).

This serializes each frame **once** at broadcast time and fans out the shared bytes to all clients.

## What changed

- `premarshalEventData(SSEEvent)` serializes `event.Data` to a `json.RawMessage` a single time, before fan-out. Frames whose `Data` is already a `json.RawMessage` (the topology broadcast, which always pre-marshaled) pass through untouched, so both broadcast paths are now unified under one helper. A marshal error leaves `Data` as-is and falls through to the writer's existing per-frame error path.
- `Broadcast` and `broadcastResourceChange` call it as their first line, before taking the fan-out `RLock`. Fan-out semantics are otherwise unchanged (`RLock` → iterate clients → `safeSend`).
- The per-client writer in `HandleSSE` now writes a pre-marshaled `json.RawMessage` directly and only falls back to `json.Marshal` for any frame that wasn't pre-marshaled.

## Output equivalence

Byte-for-byte identical wire output. The only `json.RawMessage` frames that reach a client are themselves `json.Marshal` output (compact + HTML-escaped) — the topology payload and the pre-marshaled event maps. Re-marshaling already-`json.Marshal`'d bytes is a no-op (`json.Marshal(json.RawMessage(b)) == b` when `b` is canonical), so writing them directly equals the old `json.Marshal(event.Data)`. A unit test pins this, including HTML-significant characters (`<`, `>`, `&`) to guard the escaping, plus the `RawMessage` passthrough.

## Testing

- `go build ./...`
- `go test ./internal/server/` (full suite + new `sse_premarshal_test.go`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Hot-path performance refactor only; fan-out and RBAC filtering are unchanged, and tests assert identical serialized output.
> 
> **Overview**
> SSE event payloads were JSON-encoded separately in each connected client’s writer, so **N tabs meant N identical marshals** on every `k8s_event`, heartbeat, and other broadcast.
> 
> This adds **`premarshalEventData`** so `Broadcast` and `broadcastResourceChange` marshal **`event.Data` once** to shared `json.RawMessage` before fan-out; topology frames that were already `json.RawMessage` pass through unchanged. **`HandleSSE`** writes those bytes directly instead of re-marshaling, with a fallback when pre-marshal didn’t run or failed.
> 
> **Wire output stays byte-for-byte the same**; new tests lock that in (including HTML escaping) and the `RawMessage` passthrough path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e6a08a5b83133bd6ff70ebb9bc38bbe1d4c2318. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->