### PR TITLE
perf(topology): invert ConfigMap/Secret/PVC→workload matching to a consumer index

### DIFF
--- a/pkg/topology/builder.go
+++ b/pkg/topology/builder.go
@@ -231,6 +231,29 @@ func (b *Builder) detectLargeClusterAndOptimize(opts *BuildOptions) (bool, []str
 	return true, hiddenKinds, estimatedNodes
 }
 
+// workloadRefKey identifies a referenced ConfigMap/Secret/PVC by namespace and
+// name — the key for inverting the workload→names ref maps into a consumer index.
+type workloadRefKey struct {
+	namespace string
+	name      string
+}
+
+// buildConsumerIndex inverts a workload→referenced-names map into a
+// (namespace,name)→workloadIDs index. Building it once lets each
+// ConfigMap/Secret/PVC node look up its referencing workloads directly instead
+// of scanning every workload per node (O(workloads+refs) total vs O(nodes×workloads)).
+func buildConsumerIndex(refs map[string]map[string]bool, workloadNamespaces map[string]string) map[workloadRefKey][]string {
+	idx := make(map[workloadRefKey][]string)
+	for workloadID, names := range refs {
+		ns := workloadNamespaces[workloadID]
+		for name := range names {
+			key := workloadRefKey{namespace: ns, name: name}
+			idx[key] = append(idx[key], workloadID)
+		}
+	}
+	return idx
+}
+
 // buildResourcesTopology creates a comprehensive resource view
 func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 	nodes := make([]Node, 0)
@@ -3109,6 +3132,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 			log.Printf("WARNING [topology] Failed to list ConfigMaps: %v", cmErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list ConfigMaps: %v", cmErr))
 		}
+		cmConsumers := buildConsumerIndex(workloadConfigMapRefs, workloadNamespaces)
 		for _, cm := range configmaps {
 			if !opts.MatchesNamespaceFilter(cm.Namespace) {
 				continue
@@ -3116,25 +3140,18 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 
 			// Only include ConfigMaps that are referenced by workloads in the same namespace
 			cmID := fmt.Sprintf("configmap/%s/%s", cm.Namespace, cm.Name)
-			isReferenced := false
+			consumers := cmConsumers[workloadRefKey{namespace: cm.Namespace, name: cm.Name}]
 
-			for workloadID, refs := range workloadConfigMapRefs {
-				// Only match if workload is in the same namespace as the ConfigMap
-				if workloadNamespaces[workloadID] != cm.Namespace {
-					continue
-				}
-				if refs[cm.Name] {
-					isReferenced = true
-					edges = append(edges, Edge{
-						ID:     fmt.Sprintf("%s-to-%s", cmID, workloadID),
-						Source: cmID,
-						Target: workloadID,
-						Type:   EdgeConfigures,
-					})
-				}
+			for _, workloadID := range consumers {
+				edges = append(edges, Edge{
+					ID:     fmt.Sprintf("%s-to-%s", cmID, workloadID),
+					Source: cmID,
+					Target: workloadID,
+					Type:   EdgeConfigures,
+				})
 			}
 
-			if isReferenced {
+			if len(consumers) > 0 {
 				nodes = append(nodes, Node{
 					ID:     cmID,
 					Kind:   KindConfigMap,
@@ -3157,6 +3174,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 			log.Printf("WARNING [topology] Failed to list Secrets: %v", secretsErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list Secrets: %v", secretsErr))
 		}
+		secretConsumers := buildConsumerIndex(workloadSecretRefs, workloadNamespaces)
 		for _, secret := range secrets {
 			if !opts.MatchesNamespaceFilter(secret.Namespace) {
 				continue
@@ -3164,25 +3182,18 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 
 			// Only include Secrets that are referenced by workloads in the same namespace
 			secretID := fmt.Sprintf("secret/%s/%s", secret.Namespace, secret.Name)
-			isReferenced := false
+			consumers := secretConsumers[workloadRefKey{namespace: secret.Namespace, name: secret.Name}]
 
-			for workloadID, refs := range workloadSecretRefs {
-				// Only match if workload is in the same namespace as the Secret
-				if workloadNamespaces[workloadID] != secret.Namespace {
-					continue
-				}
-				if refs[secret.Name] {
-					isReferenced = true
-					edges = append(edges, Edge{
-						ID:     fmt.Sprintf("%s-to-%s", secretID, workloadID),
-						Source: secretID,
-						Target: workloadID,
-						Type:   EdgeConfigures,
-					})
-				}
+			for _, workloadID := range consumers {
+				edges = append(edges, Edge{
+					ID:     fmt.Sprintf("%s-to-%s", secretID, workloadID),
+					Source: secretID,
+					Target: workloadID,
+					Type:   EdgeConfigures,
+				})
 			}
 
-			if isReferenced {
+			if len(consumers) > 0 {
 				nodes = append(nodes, Node{
 					ID:     secretID,
 					Kind:   KindSecret,
@@ -3206,6 +3217,7 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 			log.Printf("WARNING [topology] Failed to list PersistentVolumeClaims: %v", pvcErr)
 			warnings = append(warnings, fmt.Sprintf("Failed to list PersistentVolumeClaims: %v", pvcErr))
 		}
+		pvcConsumers := buildConsumerIndex(workloadPVCRefs, workloadNamespaces)
 		for _, pvc := range pvcs {
 			if !opts.MatchesNamespaceFilter(pvc.Namespace) {
 				continue
@@ -3213,25 +3225,18 @@ func (b *Builder) buildResourcesTopology(opts BuildOptions) (*Topology, error) {
 
 			// Only include PVCs that are referenced by workloads in the same namespace
 			pvcID := fmt.Sprintf("persistentvolumeclaim/%s/%s", pvc.Namespace, pvc.Name)
-			isReferenced := false
+			consumers := pvcConsumers[workloadRefKey{namespace: pvc.Namespace, name: pvc.Name}]
 
-			for workloadID, refs := range workloadPVCRefs {
-				// Only match if workload is in the same namespace as the PVC
-				if workloadNamespaces[workloadID] != pvc.Namespace {
-					continue
-				}
-				if refs[pvc.Name] {
-					isReferenced = true
-					edges = append(edges, Edge{
-						ID:     fmt.Sprintf("%s-to-%s", pvcID, workloadID),
-						Source: pvcID,
-						Target: workloadID,
-						Type:   EdgeUses,
-					})
-				}
+			for _, workloadID := range consumers {
+				edges = append(edges, Edge{
+					ID:     fmt.Sprintf("%s-to-%s", pvcID, workloadID),
+					Source: pvcID,
+					Target: workloadID,
+					Type:   EdgeUses,
+				})
 			}
 
-			if isReferenced {
+			if len(consumers) > 0 {
 				// Get storage info
 				var storageSize string
 				if pvc.Spec.Resources.Requests != nil {

--- a/pkg/topology/config_edges_test.go
+++ b/pkg/topology/config_edges_test.go
@@ -1,0 +1,128 @@
+package topology
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// deployWithRefs builds a Deployment that references a ConfigMap, Secret, and
+// PVC by name via pod-spec volumes (the shapes extractWorkloadReferences reads).
+func deployWithRefs(ns, name, cmName, secretName, pvcName string) *appsv1.Deployment {
+	vols := []corev1.Volume{}
+	if cmName != "" {
+		vols = append(vols, corev1.Volume{Name: "cm", VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: cmName}}}})
+	}
+	if secretName != "" {
+		vols = append(vols, corev1.Volume{Name: "sec", VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{SecretName: secretName}}})
+	}
+	if pvcName != "" {
+		vols = append(vols, corev1.Volume{Name: "data", VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName}}})
+	}
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{Volumes: vols}},
+		},
+	}
+}
+
+func cm(ns, name string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
+}
+func secret(ns, name string) *corev1.Secret {
+	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
+}
+func pvc(ns, name string) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
+}
+
+// The ConfigMap/Secret/PVC→workload matching is inverted into a consumer index.
+// This pins the invariants that inversion must preserve: referenced resources
+// get nodes + EdgeConfigures/EdgeUses edges to every referencing workload,
+// unreferenced ones are omitted, and matching is strictly namespace-scoped
+// (a same-named resource in another namespace must NOT cross-link).
+func TestConfigSecretPVCEdges_InvertedMatching(t *testing.T) {
+	provider := &mockProvider{
+		deployments: []*appsv1.Deployment{
+			deployWithRefs("app", "web", "shared-cm", "tls", "data"),
+			deployWithRefs("app", "worker", "shared-cm", "", ""), // also refs shared-cm
+			deployWithRefs("other", "web", "shared-cm", "", ""),  // same names, different ns
+		},
+		configMaps: []*corev1.ConfigMap{
+			cm("app", "shared-cm"), cm("app", "unused-cm"),
+			cm("other", "shared-cm"),
+		},
+		secrets: []*corev1.Secret{secret("app", "tls"), secret("app", "unused-secret")},
+		pvcs:    []*corev1.PersistentVolumeClaim{pvc("app", "data"), pvc("app", "unused-pvc")},
+	}
+
+	opts := DefaultBuildOptions()
+	opts.IncludeSecrets = true
+	topo, err := NewBuilder(provider).Build(opts)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	nodeIDs := map[string]bool{}
+	for _, n := range topo.Nodes {
+		nodeIDs[n.ID] = true
+	}
+	edgeSet := map[string]bool{}
+	for _, e := range topo.Edges {
+		edgeSet[e.Source+" -> "+e.Target] = true
+	}
+
+	mustNode := func(id string) {
+		t.Helper()
+		if !nodeIDs[id] {
+			t.Errorf("expected node %q to be present", id)
+		}
+	}
+	noNode := func(id string) {
+		t.Helper()
+		if nodeIDs[id] {
+			t.Errorf("expected node %q to be absent (unreferenced)", id)
+		}
+	}
+	mustEdge := func(src, dst string) {
+		t.Helper()
+		if !edgeSet[src+" -> "+dst] {
+			t.Errorf("expected edge %s -> %s", src, dst)
+		}
+	}
+	noEdge := func(src, dst string) {
+		t.Helper()
+		if edgeSet[src+" -> "+dst] {
+			t.Errorf("did not expect edge %s -> %s", src, dst)
+		}
+	}
+
+	// shared-cm in app is referenced by BOTH web and worker → node + 2 edges.
+	mustNode("configmap/app/shared-cm")
+	mustEdge("configmap/app/shared-cm", "deployment/app/web")
+	mustEdge("configmap/app/shared-cm", "deployment/app/worker")
+
+	// tls secret + data PVC referenced only by app/web.
+	mustNode("secret/app/tls")
+	mustEdge("secret/app/tls", "deployment/app/web")
+	mustNode("persistentvolumeclaim/app/data")
+	mustEdge("persistentvolumeclaim/app/data", "deployment/app/web")
+
+	// Unreferenced resources: no node (and no edge).
+	noNode("configmap/app/unused-cm")
+	noNode("secret/app/unused-secret")
+	noNode("persistentvolumeclaim/app/unused-pvc")
+
+	// Namespace scoping: other/shared-cm links only to other/web, never across
+	// namespaces despite the identical name.
+	mustNode("configmap/other/shared-cm")
+	mustEdge("configmap/other/shared-cm", "deployment/other/web")
+	noEdge("configmap/other/shared-cm", "deployment/app/web")
+	noEdge("configmap/app/shared-cm", "deployment/other/web")
+}


### PR DESCRIPTION
## Summary

The resource-topology builder decided ConfigMap/Secret/PVC node inclusion (and built their edges) by scanning **every** workload's reference set for **every** config resource — three O(nodes × workloads) nested loops that run on every topology rebuild, i.e. on every debounced SSE broadcast and every fresh build. On clusters with many workloads and many ConfigMaps/Secrets (Secrets especially — every namespace carries `kube-root-ca.crt`, SA tokens, TLS material) this is the quadratic hot spot of the graph build.

## What changed

`buildConsumerIndex` inverts a workload→referenced-names map into a `(namespace, name) → []workloadID` consumer index, built once per kind. Each ConfigMap/Secret/PVC node then looks up its referencing workloads directly instead of scanning all of them:

- **Before:** for each of N config nodes, iterate all M workloads → `O(N × M)`
- **After:** build the index in `O(M × refs)`, then `O(1)` lookup per node → `O(M + N)` total

Applied identically to all three matchers (ConfigMap → `EdgeConfigures`, Secret → `EdgeConfigures`, PVC → `EdgeUses`).

## Equivalence

Output is unchanged. The index key is `{namespace, name}` where `namespace` is the workload's own namespace, so matching stays strictly same-namespace — a same-named ConfigMap in another namespace is never cross-linked. Node inclusion (`len(consumers) > 0`) is exactly the old `isReferenced`, and edge `Source`/`Target`/`ID`/`Type` are produced identically. Edge slice order was already nondeterministic (Go map iteration) and remains so.

## Testing

- `go test ./topology/` (pkg module) — full suite + new `config_edges_test.go`
- `go build ./...` + `go test ./internal/server/ ./internal/k8s/` (root module, topology consumers)

`config_edges_test.go` pins the invariants the inversion must preserve: referenced resources get nodes + edges to **every** referencing workload (fan-out), unreferenced resources are omitted, and matching is strictly namespace-scoped (identical-name resource in another namespace does not cross-link).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor preserves the same inclusion rules and edge shapes; risk is limited to subtle indexing bugs, which the new test covers for namespace scoping and fan-out.
> 
> **Overview**
> Replaces **per-resource scans over every workload** when building ConfigMap, Secret, and PVC topology nodes with a one-time **`buildConsumerIndex`** that maps `(namespace, name)` → referencing workload IDs. Each resource node now does a direct lookup to decide inclusion and emit `EdgeConfigures` / `EdgeUses` edges, cutting the hot path from **O(config nodes × workloads)** to **O(workloads + config nodes)** on every topology rebuild.
> 
> **`config_edges_test.go`** locks in behavioral parity: fan-out edges to all referencers, omission of unreferenced resources, and strict same-namespace matching (no cross-namespace links for identical names).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc091c20e75de6a6c1875b7e5fa435c63f02489a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->