### PR TITLE
perf(topology): cache the relationships index for detail-drawer lookups

### DIFF
--- a/internal/server/cached_topology_index_test.go
+++ b/internal/server/cached_topology_index_test.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"testing"
+
+	topology "github.com/skyhook-io/radar/pkg/topology"
+)
+
+func topoWithEdge(src, dst string) *topology.Topology {
+	return &topology.Topology{
+		Nodes: []topology.Node{{ID: src}, {ID: dst}},
+		Edges: []topology.Edge{{ID: src + "->" + dst, Source: src, Target: dst, Type: topology.EdgeManages}},
+	}
+}
+
+// GetCachedTopologyWithIndex must return a consistent (topo, index) pair, memoize
+// the index across calls for the same topology, and rebuild it when the cached
+// topology is replaced. These are the invariants the drawer-relationship
+// optimization relies on.
+func TestGetCachedTopologyWithIndex(t *testing.T) {
+	b := NewSSEBroadcaster()
+
+	// No topology cached yet → (nil, nil). (No k8s cache in tests, so
+	// GetCachedTopology won't attempt a rebuild.)
+	if topo, idx := b.GetCachedTopologyWithIndex(); topo != nil || idx != nil {
+		t.Fatalf("expected (nil, nil) with no cached topology, got (%v, %v)", topo, idx)
+	}
+
+	topoA := topoWithEdge("deployment/ns/web", "replicaset/ns/web-1")
+	b.updateCachedTopology(topoA)
+
+	gotTopo, idxA := b.GetCachedTopologyWithIndex()
+	if gotTopo != topoA {
+		t.Fatalf("expected the cached topology pointer back")
+	}
+	if idxA == nil {
+		t.Fatal("expected a non-nil index for a cached topology")
+	}
+	// The index reflects topoA's edge.
+	if _, outgoing := idxA.EdgesFor("deployment/ns/web"); len(outgoing) != 1 {
+		t.Fatalf("expected 1 outgoing edge for the deployment node, got %d", len(outgoing))
+	}
+
+	// Repeat call memoizes — same index pointer, no rebuild.
+	_, idxA2 := b.GetCachedTopologyWithIndex()
+	if idxA2 != idxA {
+		t.Fatal("expected the memoized index pointer to be reused")
+	}
+
+	// Replacing the topology invalidates the index; the next call builds a fresh one.
+	topoB := topoWithEdge("statefulset/ns/db", "pod/ns/db-0")
+	b.updateCachedTopology(topoB)
+	gotTopoB, idxB := b.GetCachedTopologyWithIndex()
+	if gotTopoB != topoB {
+		t.Fatalf("expected the replaced topology pointer back")
+	}
+	if idxB == nil || idxB == idxA {
+		t.Fatal("expected a fresh index after the topology was replaced")
+	}
+	if _, outgoing := idxB.EdgesFor("statefulset/ns/db"); len(outgoing) != 1 {
+		t.Fatalf("expected 1 outgoing edge in the new index, got %d", len(outgoing))
+	}
+	// The new index does not carry the old topology's nodes.
+	if in, out := idxB.EdgesFor("deployment/ns/web"); len(in) != 0 || len(out) != 0 {
+		t.Fatal("stale edge surfaced from a replaced topology's index")
+	}
+
+	// Clearing the topology (context-switch semantics) returns (nil, nil).
+	b.updateCachedTopology(nil)
+	if topo, idx := b.GetCachedTopologyWithIndex(); topo != nil || idx != nil {
+		t.Fatalf("expected (nil, nil) after clearing topology, got (%v, %v)", topo, idx)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1935,10 +1935,10 @@ func (s *Server) handleGetResource(w http.ResponseWriter, r *http.Request) {
 		// resource so ManagedBy synthesis disambiguates by group (avoids
 		// kind/plural collisions like Knative Service vs core Service).
 		var relationships *topology.Relationships
-		if cachedTopo := s.broadcaster.GetCachedTopology(); cachedTopo != nil {
+		if cachedTopo, relIdx := s.broadcaster.GetCachedTopologyWithIndex(); cachedTopo != nil {
 			relationships = topology.GetRelationshipsWithObject(kind, namespace, name, resource, cachedTopo,
 				k8s.NewTopologyResourceProvider(k8s.GetResourceCache()),
-				k8s.NewTopologyDynamicProvider(k8s.GetDynamicResourceCache(), k8s.GetResourceDiscovery()), nil)
+				k8s.NewTopologyDynamicProvider(k8s.GetDynamicResourceCache(), k8s.GetResourceDiscovery()), relIdx)
 		}
 
 		s.writeJSON(w, topology.ResourceWithRelationships{
@@ -2150,10 +2150,10 @@ func (s *Server) handleGetResource(w http.ResponseWriter, r *http.Request) {
 	// resource so ManagedBy synthesis uses the authoritative object instead
 	// of a group-blind kind/name lookup.
 	var relationships *topology.Relationships
-	if cachedTopo := s.broadcaster.GetCachedTopology(); cachedTopo != nil {
+	if cachedTopo, relIdx := s.broadcaster.GetCachedTopologyWithIndex(); cachedTopo != nil {
 		relationships = topology.GetRelationshipsWithObject(kind, namespace, name, resource, cachedTopo,
 			k8s.NewTopologyResourceProvider(k8s.GetResourceCache()),
-			k8s.NewTopologyDynamicProvider(k8s.GetDynamicResourceCache(), k8s.GetResourceDiscovery()), nil)
+			k8s.NewTopologyDynamicProvider(k8s.GetDynamicResourceCache(), k8s.GetResourceDiscovery()), relIdx)
 	}
 
 	// Return resource with relationships

--- a/internal/server/sse.go
+++ b/internal/server/sse.go
@@ -47,6 +47,11 @@ type SSEBroadcaster struct {
 	cachedTopology      *topology.Topology
 	cachedTopologyMu    sync.RWMutex
 	cachedTopologyDirty bool // true when changes occurred but topology not yet rebuilt
+	// cachedTopologyIndex is the inverted edge index over cachedTopology, built
+	// lazily on first relationship lookup and reused across drawer opens until
+	// the topology is replaced. Nil whenever cachedTopology changes (set under
+	// cachedTopologyMu alongside it). Guarded by cachedTopologyMu.
+	cachedTopologyIndex *topology.RelationshipsIndex
 
 	// warmupDone is closed when deferred informers finish syncing. During warmup,
 	// topology broadcasts use longer debounce and skip the expensive full-topology
@@ -294,6 +299,7 @@ func (b *SSEBroadcaster) registerContextSwitchCallback() {
 		// Clear cached topology and dirty flag for the old context
 		b.cachedTopologyMu.Lock()
 		b.cachedTopology = nil
+		b.cachedTopologyIndex = nil
 		b.cachedTopologyDirty = false
 		b.cachedTopologyMu.Unlock()
 
@@ -870,6 +876,39 @@ func (b *SSEBroadcaster) GetCachedTopology() *topology.Topology {
 	return topo
 }
 
+// GetCachedTopologyWithIndex returns the cached topology together with its
+// inverted edge index, building (and memoizing) the index on first use after a
+// topology refresh. Relationship lookups that pass the index skip the O(edges)
+// scan that edgesForNode/walkTopmostOwner otherwise do per call, so reusing one
+// index across drawer opens turns repeated O(E) work into O(in-degree) per lookup.
+//
+// The returned (topo, index) pair is always consistent: the index is built from
+// the exact topo returned. When the topology is replaced between the two reads,
+// a fresh index is built for the returned topo without polluting the cache.
+func (b *SSEBroadcaster) GetCachedTopologyWithIndex() (*topology.Topology, *topology.RelationshipsIndex) {
+	topo := b.GetCachedTopology() // handles lazy rebuild when dirty
+	if topo == nil {
+		return nil, nil
+	}
+
+	b.cachedTopologyMu.RLock()
+	idx := b.cachedTopologyIndex
+	current := b.cachedTopology
+	b.cachedTopologyMu.RUnlock()
+	if idx != nil && current == topo {
+		return topo, idx
+	}
+
+	// Build outside the lock — IndexByResource is O(edges).
+	built := topology.IndexByResource(topo)
+	b.cachedTopologyMu.Lock()
+	if b.cachedTopology == topo {
+		b.cachedTopologyIndex = built
+	}
+	b.cachedTopologyMu.Unlock()
+	return topo, built
+}
+
 // rebuildCachedTopology rebuilds the full topology for relationship lookups.
 // Returns true if the rebuild succeeded, false otherwise.
 func (b *SSEBroadcaster) rebuildCachedTopology() bool {
@@ -891,6 +930,7 @@ func (b *SSEBroadcaster) updateCachedTopology(topo *topology.Topology) {
 	b.cachedTopologyMu.Lock()
 	defer b.cachedTopologyMu.Unlock()
 	b.cachedTopology = topo
+	b.cachedTopologyIndex = nil // rebuilt lazily on next relationship lookup
 	b.cachedTopologyDirty = false
 }
 


### PR DESCRIPTION
## Summary

Opening a resource detail drawer computes the resource's relationships (owner, children, pods, services, config refs, ManagedBy) from the cached topology graph. Both detail handlers passed a `nil` edge index to `GetRelationshipsWithObject`, which forces a full O(edges) linear scan of the topology — once in `edgesForNode` and again in the ManagedBy owner walk (`walkTopmostOwner`) — on **every** drawer open. On a large cluster the graph has thousands of edges, so each drawer open re-scanned all of them twice.

## What changed

The inverted edge index (`RelationshipsIndex`, already used by the summary/search/list paths) is now built **once per topology refresh** and cached on the broadcaster next to the topology it indexes:

- `GetCachedTopologyWithIndex()` returns a consistent `(topology, index)` pair — the index is always built from the exact topology returned. It's built lazily on the first relationship lookup after a refresh and memoized for subsequent drawer opens.
- The index is invalidated (set nil under the same mutex) at the only two points that replace the cached-topology pointer: `updateCachedTopology` (refresh) and the context-switch reset.
- The two detail handlers now pass the cached index instead of `nil`.

Net: the first drawer open after a topology refresh pays the O(E) index build; every subsequent open until the next refresh is O(in-degree). Building the index inline per call would also be O(E), so caching across opens is what produces the win.

## Equivalence

Drawer relationship output is unchanged — the index path returns the same edges as the linear scan (`edgesForNode` prefers the index when present and falls back to the identical scan otherwise; the ManagedBy walk likewise). Verified live: built the optimized binary and a `main` baseline, ran both against a kind cluster, and diffed the `/api/resources/{kind}/{ns}/{name}` relationships for **117 workloads/pods/services** — identical across the board (the only flicker was transient cache drift on a live Flux-reconciled deployment, which matched on re-fetch).

## Testing

- `go test ./internal/server/` — full suite + new `cached_topology_index_test.go` (memoization, invalidation on topology replace, consistency of the returned pair, empty after clear)
- `go build ./...`, `go test ./topology/` (pkg module)
- Live equivalence diff vs `main` across 117 resources (above)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only caching with explicit invalidation on topology refresh; relationship semantics are unchanged when the index matches the existing linear-scan path.
> 
> **Overview**
> **Resource detail drawers** were calling `GetRelationshipsWithObject` with a `nil` edge index, forcing a full **O(edges)** scan of the cached topology on every open (including ManagedBy owner walks). This change wires in the same **`RelationshipsIndex`** path already used for list/search.
> 
> `SSEBroadcaster` now exposes **`GetCachedTopologyWithIndex()`**, which returns a consistent `(topology, index)` pair: the index is built lazily after each topology refresh, **memoized** for subsequent drawer opens, and **cleared** whenever the cached topology is replaced (`updateCachedTopology`, context switch / namespace rescope). Both resource **GET** handlers pass that index into `GetRelationshipsWithObject` instead of `nil`.
> 
> **Net effect:** the first lookup after a refresh pays one **O(E)** index build; later opens until the next refresh are **O(in-degree)**. Relationship output is intended to be unchanged (index vs linear scan equivalence).
> 
> Adds **`cached_topology_index_test.go`** covering memoization, invalidation on topology replace/clear, and pair consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5de42c42cd8a2693f275a298c1f3bbc7ba493e5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->