### PR TITLE
feat(issues): apiservice→HPA causal link + folded-pod counts on blast-radius links

### DIFF
--- a/internal/issues/diagnostic_context.go
+++ b/internal/issues/diagnostic_context.go
@@ -22,6 +22,7 @@ const (
 	factRestartCause        = "restart_cause"
 	factNodeBlastRadius     = "node_blast_radius"
 	factPVCBlastRadius      = "pvc_blast_radius"
+	factAPIServiceHPA       = "apiservice_hpa"
 )
 
 type serviceBackendIssueProvider interface {
@@ -191,6 +192,10 @@ func enrichDiagnosticContext(shaped, flat, grouped []Issue, p Provider) []Issue 
 			addPVCBlastRadiusContext(&b, *i, pvcProvider, flatByResource, groupedByID)
 		}
 
+		if metricsAPIFamily(*i) != "" {
+			addAPIServiceHPAContext(&b, *i, flat, groupedByID)
+		}
+
 		if ctx := b.build(); ctx != nil {
 			i.DiagnosticContext = ctx
 		}
@@ -250,62 +255,200 @@ func addServiceBackendContext(b *diagnosticContextBuilder, issue Issue, serviceP
 }
 
 // linkBlastRadius adds a candidate-role fact linking a root issue to the
-// category-attributable issues of a set of affected pods (each flat pod issue
-// mapped to its grouped form). Non-destructive — it only annotates the root.
-// `accept` is an optional per-symptom guard beyond the category filter.
+// category-attributable issues of a set of affected pods. Multiple affected pods
+// routinely fold into ONE grouped issue (5 pods of a Deployment → one row); those
+// collapse to a single related entry carrying a Count of the distinct pods, rather
+// than repeating the same grouped issue per pod. Non-destructive — it only
+// annotates the root. `accept` is an optional per-symptom guard beyond the
+// category filter.
 func linkBlastRadius(b *diagnosticContextBuilder, pods []Ref, attributable map[issuesapi.Category]bool, flatByResource map[string][]Issue, groupedByID map[string]Issue, factType string, conf issuesapi.Confidence, message string, accept func(Issue) bool) {
 	if len(pods) == 0 {
 		return
 	}
-	// Keep each linked issue paired with the pod it came from, so ranking and
-	// capping act on the pair — otherwise the displayed pods (Refs) and the
-	// displayed issues (RelatedIssues) are sorted/capped independently and the
-	// two lists diverge past the cap.
-	type linked struct {
-		ref Ref
-		rel issuesapi.IssueRef
-	}
-	seenIDs := make(map[string]bool)
-	var links []linked
-	for _, pod := range pods {
-		key := resourceKey(pod.Group, pod.Kind, pod.Namespace, pod.Name)
-		for _, flatIssue := range flatByResource[key] {
-			if !attributable[flatIssue.Category] || seenIDs[flatIssue.ID] {
-				continue
+	related, refs, total := collectRelated(groupedByID, func(yield func(Ref, Issue)) {
+		for _, pod := range pods {
+			key := resourceKey(pod.Group, pod.Kind, pod.Namespace, pod.Name)
+			for _, flatIssue := range flatByResource[key] {
+				if !attributable[flatIssue.Category] {
+					continue
+				}
+				if accept != nil && !accept(flatIssue) {
+					continue
+				}
+				yield(pod, flatIssue)
 			}
-			if accept != nil && !accept(flatIssue) {
-				continue
-			}
-			grouped, ok := groupedByID[flatIssue.ID]
-			if !ok {
-				grouped = flatIssue
-			}
-			links = append(links, linked{ref: pod, rel: issueRef(grouped)})
-			seenIDs[flatIssue.ID] = true
 		}
-	}
-	if len(links) == 0 {
+	})
+	if len(related) == 0 {
 		return
-	}
-	// Rank by the linked issue's severity BEFORE capping, so the cap keeps the
-	// worst issues (and their pods), not whatever came first in iteration order.
-	sort.SliceStable(links, func(i, j int) bool { return lessIssueRef(links[i].rel, links[j].rel) })
-	if len(links) > maxDiagnosticIssueRefs {
-		links = links[:maxDiagnosticIssueRefs]
-	}
-	related := make([]issuesapi.IssueRef, 0, len(links))
-	refs := make([]Ref, 0, len(links))
-	for _, l := range links {
-		related = append(related, l.rel)
-		refs = append(refs, l.ref)
 	}
 	b.add(issuesapi.DiagnosticRoleCandidate, issuesapi.DiagnosticFact{
 		Type:          factType,
-		Message:       message,
+		Message:       withTruncationNote(message, len(related), total),
 		Confidence:    conf,
-		Refs:          limitRefs(dedupeRefs(refs), maxDiagnosticRefs),
+		Refs:          limitRefs(refs, maxDiagnosticRefs),
 		RelatedIssues: related,
 	})
+}
+
+// withTruncationNote appends an explicit "showing N of total" note when the
+// related-issue list was capped, so the annotation never silently understates a
+// blast radius (the full set still appears as its own rows in the queue).
+func withTruncationNote(message string, shown, total int) string {
+	if total <= shown {
+		return message
+	}
+	return fmt.Sprintf("%s Showing the %d most severe of %d affected.", message, shown, total)
+}
+
+// collectRelated folds a stream of (affected resource, flat symptom issue) pairs
+// into deduped related-issue refs. Pairs are grouped by the symptom's GROUPED
+// issue, and because folded members all share one issue ID, N pods of one
+// workload collapse to a single related row carrying Count = the distinct
+// affected resources (NOT deduping on the shared issue ID, which would drop pods
+// b..N and leave count=1). Groups are ranked worst-first, then capped; the
+// returned Refs are the affected resources backing the kept groups, so the
+// displayed Refs and RelatedIssues stay consistent past the cap. The emit closure
+// calls yield once per candidate pairing.
+func collectRelated(groupedByID map[string]Issue, emit func(yield func(affected Ref, symptom Issue))) ([]issuesapi.IssueRef, []Ref, int) {
+	type group struct {
+		rel  issuesapi.IssueRef
+		pods []Ref
+	}
+	byGroup := map[string]*group{}
+	var order []string
+	emit(func(affected Ref, symptom Issue) {
+		grouped, ok := groupedByID[symptom.ID]
+		if !ok {
+			grouped = symptom
+		}
+		g := byGroup[grouped.ID]
+		if g == nil {
+			g = &group{rel: issueRef(grouped)}
+			byGroup[grouped.ID] = g
+			order = append(order, grouped.ID)
+		}
+		g.pods = append(g.pods, affected)
+	})
+	if len(order) == 0 {
+		return nil, nil, 0
+	}
+	total := len(order)
+	groups := make([]*group, 0, len(order))
+	for _, id := range order {
+		groups = append(groups, byGroup[id])
+	}
+	// Rank by the linked issue's severity BEFORE capping, so the cap keeps the
+	// worst issues (and their resources), not iteration order.
+	sort.SliceStable(groups, func(i, j int) bool { return lessIssueRef(groups[i].rel, groups[j].rel) })
+	if len(groups) > maxDiagnosticIssueRefs {
+		groups = groups[:maxDiagnosticIssueRefs]
+	}
+	related := make([]issuesapi.IssueRef, 0, len(groups))
+	var refs []Ref
+	for _, g := range groups {
+		rel := g.rel
+		distinct := dedupeRefs(g.pods)
+		if len(distinct) > 1 {
+			rel.Count = len(distinct)
+		}
+		related = append(related, rel)
+		refs = append(refs, distinct...)
+	}
+	return related, dedupeRefs(refs), total
+}
+
+// addAPIServiceHPAContext links an unavailable metrics APIService to the HPAs that
+// can't scale because they can't read metrics. Unlike the node/PVC links there is
+// no declared edge from an HPA to the APIService — a down metrics-server starves
+// every metric-driven HPA cluster-wide — so this is a cluster-wide fan-in gated on
+// (a) the APIService being a metrics aggregation API and (b) the HPA's OWN failure
+// naming a metrics-fetch cause (a maxReplicas-capped HPA is excluded). Confidence
+// is medium: the categories and "can't fetch metrics" symptom line up, but we
+// can't prove a specific HPA consumed this exact API server.
+func addAPIServiceHPAContext(b *diagnosticContextBuilder, apisvc Issue, flat []Issue, groupedByID map[string]Issue) {
+	family := metricsAPIFamily(apisvc)
+	if family == "" {
+		return
+	}
+	related, _, total := collectRelated(groupedByID, func(yield func(Ref, Issue)) {
+		for _, f := range flat {
+			if hpaBlockedOnMetricFamily(f, family) {
+				yield(Ref{Group: f.Group, Kind: f.Kind, Namespace: f.Namespace, Name: f.Name}, f)
+			}
+		}
+	})
+	if len(related) == 0 {
+		return
+	}
+	b.add(issuesapi.DiagnosticRoleCandidate, issuesapi.DiagnosticFact{
+		Type:          factAPIServiceHPA,
+		Message:       withTruncationNote("Autoscalers that can't read "+family+" metrics may be blocked by this unavailable metrics API.", len(related), total),
+		Confidence:    issuesapi.ConfidenceMedium,
+		RelatedIssues: related,
+	})
+}
+
+// metricsAPIFamily classifies an apiservice_unavailable issue by which metrics
+// aggregation API it serves — the only APIServices whose outage starves HPAs.
+// The three families are distinct failure domains (resource = CPU/mem via
+// metrics.k8s.io; custom = pods/object metrics; external), so a down API in one
+// family must only link HPAs failing on THAT family — not every metric-blocked
+// HPA. Returns "" for non-metrics or non-APIService issues. APIService objects are
+// named "<version>.<group>", so the group lives in the object name (the issue's
+// own Group is apiregistration.k8s.io, the aggregator, not the aggregated API);
+// the more specific suffixes are checked first since they also end in
+// "metrics.k8s.io".
+func metricsAPIFamily(i Issue) string {
+	if i.Kind != "APIService" || i.Category != issuesapi.CategoryAPIServiceUnavailable {
+		return ""
+	}
+	// APIService objects are named "<version>.<group>"; exact-match the group so a
+	// spoofed/nested name like "v1.external.metrics.k8s.io.example.com" or
+	// "v1.foo.metrics.k8s.io" does NOT classify as a real metrics API.
+	_, group, ok := strings.Cut(strings.ToLower(i.Name), ".")
+	if !ok {
+		return ""
+	}
+	switch group {
+	case "metrics.k8s.io":
+		return "resource"
+	case "custom.metrics.k8s.io":
+		return "custom"
+	case "external.metrics.k8s.io":
+		return "external"
+	default:
+		return ""
+	}
+}
+
+// hpaBlockedOnMetricFamily reports whether an HPA's failure is a metrics-fetch
+// problem in the SAME family as the down APIService — keyed on the controller's
+// stable FailedGet*Metric condition reason. It deliberately excludes the
+// missing-resource-request case ("missing request for cpu"): that fails with the
+// same FailedGetResourceMetric reason but is a workload-config problem the metrics
+// API outage doesn't cause, so attributing it to the APIService would mislead.
+func hpaBlockedOnMetricFamily(i Issue, family string) bool {
+	if i.Kind != "HorizontalPodAutoscaler" || i.Category != issuesapi.CategoryHPALimitedOrFailed {
+		return false
+	}
+	text := strings.ToLower(i.Reason + " " + i.Message)
+	if strings.Contains(text, "missing request") {
+		return false // pod lacks resource requests — not an API-server outage
+	}
+	switch family {
+	case "resource":
+		// Match the exact controller condition-reason tokens (both served by
+		// metrics.k8s.io), not a bare "resourcemetric" substring that a custom/
+		// external metric NAMED "resourcemetric" could trip.
+		return strings.Contains(text, "failedgetresourcemetric") || strings.Contains(text, "failedgetcontainerresourcemetric")
+	case "custom":
+		return strings.Contains(text, "failedgetobjectmetric") || strings.Contains(text, "failedgetpodsmetric")
+	case "external":
+		return strings.Contains(text, "failedgetexternalmetric")
+	default:
+		return false
+	}
 }
 
 // addNodeBlastRadiusContext links a resource-pressured node to the pod issues

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -1680,3 +1680,152 @@ func TestPVCBlastRadiusContext(t *testing.T) {
 		t.Fatalf("expected only the volume-evidenced unschedulable (db-0) linked, got %+v", fact.RelatedIssues)
 	}
 }
+
+func TestBlastRadiusCountsFoldedPods(t *testing.T) {
+	// Five pods of one Deployment all mount the PVC and all fail to mount it.
+	// GroupIssues folds them under one issue ID, so they collapse to ONE related
+	// row — but it must carry Count = the distinct affected pods, not silently
+	// drop pods 2..5 and show no count (the pre-fix behavior).
+	pvc := Issue{Kind: "PersistentVolumeClaim", Namespace: "prod", Name: "data", Category: issuesapi.CategoryPVCPending, Severity: SeverityCritical, Reason: "Pending"}
+	const groupID = "dep/prod/web/volume_mount_failed"
+	var flat []Issue
+	var pods []Ref
+	for _, name := range []string{"web-a", "web-b", "web-c", "web-d", "web-e"} {
+		flat = append(flat, Issue{ID: groupID, Kind: "Pod", Namespace: "prod", Name: name, Category: issuesapi.CategoryVolumeMountFailed, Severity: SeverityCritical, Reason: "FailedMount"})
+		pods = append(pods, Ref{Kind: "Pod", Namespace: "prod", Name: name})
+	}
+	// The grouped representative the folded pods resolve to (subject = the owning Deployment).
+	grouped := Issue{ID: groupID, Kind: "Deployment", Namespace: "prod", Name: "web", Category: issuesapi.CategoryVolumeMountFailed, Severity: SeverityCritical, Reason: "FailedMount"}
+
+	p := &fakeProvider{podsMountingPVC: map[string][]Ref{"prod/data": pods}}
+	out := enrichDiagnosticContext([]Issue{pvc}, append([]Issue{pvc}, flat...), []Issue{grouped}, p)
+
+	var fact *issuesapi.DiagnosticFact
+	for i := range out[0].DiagnosticContext.Facts {
+		if out[0].DiagnosticContext.Facts[i].Type == factPVCBlastRadius {
+			fact = &out[0].DiagnosticContext.Facts[i]
+		}
+	}
+	if fact == nil {
+		t.Fatal("no pvc_blast_radius fact")
+	}
+	if len(fact.RelatedIssues) != 1 {
+		t.Fatalf("five folded pods must collapse to one related row, got %d", len(fact.RelatedIssues))
+	}
+	if fact.RelatedIssues[0].Ref.Kind != "Deployment" || fact.RelatedIssues[0].Ref.Name != "web" {
+		t.Errorf("related ref = %+v, want the grouped Deployment", fact.RelatedIssues[0].Ref)
+	}
+	if fact.RelatedIssues[0].Count != 5 {
+		t.Errorf("Count = %d, want 5 distinct affected pods", fact.RelatedIssues[0].Count)
+	}
+}
+
+func TestAPIServiceHPABlastRadius(t *testing.T) {
+	// A down metrics APIService links the HPAs that can't fetch metrics — but NOT
+	// an HPA merely capped at maxReplicas, and NOT a non-metrics aggregated API.
+	// Production shape: the HPA detector sets Reason to the problem class
+	// ("cannot-scale" / "maxed") and puts the controller condition reason
+	// (FailedGet*Metric: ...) in Message — the gate matches on Reason+Message.
+	apisvc := Issue{Kind: "APIService", Group: "apiregistration.k8s.io", Name: "v1beta1.metrics.k8s.io", Category: issuesapi.CategoryAPIServiceUnavailable, Severity: SeverityCritical, Reason: "FailedDiscoveryCheck"}
+	starved := Issue{ID: "hpa-1", Kind: "HorizontalPodAutoscaler", Namespace: "prod", Name: "web", Category: issuesapi.CategoryHPALimitedOrFailed, Severity: SeverityWarning,
+		Reason: "cannot-scale", Message: "FailedGetResourceMetric: unable to get metrics for resource cpu"}
+	capped := Issue{ID: "hpa-2", Kind: "HorizontalPodAutoscaler", Namespace: "prod", Name: "api", Category: issuesapi.CategoryHPALimitedOrFailed, Severity: SeverityWarning,
+		Reason: "maxed", Message: "3/3 replicas: HPA is capped at maxReplicas=3"}
+
+	p := &fakeProvider{}
+	out := enrichDiagnosticContext([]Issue{apisvc}, []Issue{apisvc, starved, capped}, nil, p)
+	ctx := out[0].DiagnosticContext
+	if ctx == nil {
+		t.Fatal("metrics APIService got no diagnostic context")
+	}
+	var fact *issuesapi.DiagnosticFact
+	for i := range ctx.Facts {
+		if ctx.Facts[i].Type == factAPIServiceHPA {
+			fact = &ctx.Facts[i]
+		}
+	}
+	if fact == nil {
+		t.Fatalf("no apiservice_hpa fact, got %+v", ctx.Facts)
+	}
+	if fact.Confidence != issuesapi.ConfidenceMedium {
+		t.Errorf("confidence = %q, want medium (no declared HPA→APIService edge)", fact.Confidence)
+	}
+	// Only the metrics-starved HPA links; the maxReplicas-capped one is not
+	// metrics-caused and must not be attributed to the APIService outage.
+	if len(fact.RelatedIssues) != 1 || fact.RelatedIssues[0].Ref.Name != "web" {
+		t.Fatalf("expected only the metrics-starved HPA (web) linked, got %+v", fact.RelatedIssues)
+	}
+}
+
+func TestAPIServiceHPA_NonMetricsAPILinksNothing(t *testing.T) {
+	// A non-metrics aggregated APIService outage doesn't starve HPAs — no link,
+	// even with a metrics-starved HPA present.
+	apisvc := Issue{Kind: "APIService", Group: "apiregistration.k8s.io", Name: "v1.packages.operators.coreos.com", Category: issuesapi.CategoryAPIServiceUnavailable, Severity: SeverityCritical, Reason: "FailedDiscoveryCheck"}
+	starved := Issue{ID: "hpa-1", Kind: "HorizontalPodAutoscaler", Namespace: "prod", Name: "web", Category: issuesapi.CategoryHPALimitedOrFailed, Severity: SeverityWarning,
+		Reason: "cannot-scale", Message: "FailedGetResourceMetric: unable to get metrics for resource cpu"}
+	p := &fakeProvider{}
+	out := enrichDiagnosticContext([]Issue{apisvc}, []Issue{apisvc, starved}, nil, p)
+	if out[0].DiagnosticContext != nil {
+		t.Fatalf("a non-metrics APIService must not link HPAs, got %+v", out[0].DiagnosticContext)
+	}
+}
+
+func TestAPIServiceHPA_MetricFamilyMustMatch(t *testing.T) {
+	// The resource-metrics API (metrics.k8s.io) is down, but the only failing HPA
+	// fails on an EXTERNAL metric — a different failure domain. Linking them would
+	// point the operator at the wrong API, so nothing must link.
+	apisvc := Issue{Kind: "APIService", Group: "apiregistration.k8s.io", Name: "v1beta1.metrics.k8s.io", Category: issuesapi.CategoryAPIServiceUnavailable, Severity: SeverityCritical, Reason: "FailedDiscoveryCheck"}
+	external := Issue{ID: "hpa-x", Kind: "HorizontalPodAutoscaler", Namespace: "prod", Name: "queue", Category: issuesapi.CategoryHPALimitedOrFailed, Severity: SeverityWarning,
+		Reason: "cannot-scale", Message: "FailedGetExternalMetric: unable to get external metric prod/queue_depth"}
+	p := &fakeProvider{}
+	out := enrichDiagnosticContext([]Issue{apisvc}, []Issue{apisvc, external}, nil, p)
+	if out[0].DiagnosticContext != nil {
+		t.Fatalf("resource-metrics outage must not link an external-metric HPA, got %+v", out[0].DiagnosticContext)
+	}
+}
+
+func TestAPIServiceHPA_MissingRequestNotAttributed(t *testing.T) {
+	// metrics.k8s.io is down, but this HPA's FailedGetResourceMetric is really the
+	// missing-resource-request config case — the outage doesn't cause it, so it
+	// must not be attributed to the APIService.
+	apisvc := Issue{Kind: "APIService", Group: "apiregistration.k8s.io", Name: "v1beta1.metrics.k8s.io", Category: issuesapi.CategoryAPIServiceUnavailable, Severity: SeverityCritical, Reason: "FailedDiscoveryCheck"}
+	noReq := Issue{ID: "hpa-r", Kind: "HorizontalPodAutoscaler", Namespace: "prod", Name: "web", Category: issuesapi.CategoryHPALimitedOrFailed, Severity: SeverityWarning,
+		Reason: "cannot-scale", Message: "FailedGetResourceMetric: failed to get cpu utilization: missing request for cpu"}
+	p := &fakeProvider{}
+	out := enrichDiagnosticContext([]Issue{apisvc}, []Issue{apisvc, noReq}, nil, p)
+	if out[0].DiagnosticContext != nil {
+		t.Fatalf("a missing-request HPA failure must not be attributed to the metrics API, got %+v", out[0].DiagnosticContext)
+	}
+}
+
+func TestAPIServiceHPA_ContainerResourceMetric(t *testing.T) {
+	// ContainerResource HPA metrics fail with FailedGetContainerResourceMetric and
+	// are also served by metrics.k8s.io — they must link under the resource family.
+	apisvc := Issue{Kind: "APIService", Group: "apiregistration.k8s.io", Name: "v1beta1.metrics.k8s.io", Category: issuesapi.CategoryAPIServiceUnavailable, Severity: SeverityCritical, Reason: "FailedDiscoveryCheck"}
+	hpa := Issue{ID: "hpa-c", Kind: "HorizontalPodAutoscaler", Namespace: "prod", Name: "web", Category: issuesapi.CategoryHPALimitedOrFailed, Severity: SeverityWarning,
+		Reason: "cannot-scale", Message: "FailedGetContainerResourceMetric: unable to get container metric for cpu"}
+	p := &fakeProvider{}
+	out := enrichDiagnosticContext([]Issue{apisvc}, []Issue{apisvc, hpa}, nil, p)
+	if out[0].DiagnosticContext == nil {
+		t.Fatal("a FailedGetContainerResourceMetric HPA must link to the down metrics.k8s.io API")
+	}
+}
+
+func TestMetricsAPIFamily_ExactGroupMatch(t *testing.T) {
+	// A spoofed / nested name must NOT classify as a metrics API — the group is
+	// exact-matched, not substring-matched.
+	cases := map[string]string{
+		"v1beta1.metrics.k8s.io":              "resource",
+		"v1beta1.custom.metrics.k8s.io":       "custom",
+		"v1beta1.external.metrics.k8s.io":     "external",
+		"v1.external.metrics.k8s.io.evil.com": "",
+		"v1.foo.metrics.k8s.io":               "",
+		"v1.apps":                             "",
+	}
+	for name, want := range cases {
+		got := metricsAPIFamily(Issue{Kind: "APIService", Name: name, Category: issuesapi.CategoryAPIServiceUnavailable})
+		if got != want {
+			t.Errorf("metricsAPIFamily(%q) = %q, want %q", name, got, want)
+		}
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -98,7 +98,8 @@ func registerTools(server *mcp.Server) {
 		Name: "get_resource",
 		Description: "Use AFTER narrowing to one resource. Returns the resource's " +
 			"Kubernetes-shaped spec/status/metadata plus resourceContext when available " +
-			"(relationships, refs, issue/audit/policy rollups). This is the drill-down " +
+			"(relationships, refs, issue/audit/policy rollups — issues carry " +
+			"diagnostic_context with cross-subject causal links + a confidence tier). This is the drill-down " +
 			"tool, not the best first call for broad incidents. Start with issues, " +
 			"get_dashboard, search, or list_resources to rank candidates; then call " +
 			"get_resource for the exact object. If you are looking for a string across " +
@@ -170,7 +171,8 @@ func registerTools(server *mcp.Server) {
 			"is broken — find the root cause / localize the failure'. For a single " +
 			"Pod/Deployment/StatefulSet/DaemonSet, bundles: the resource (Kubernetes-shaped detail) + diagnostic " +
 			"resourceContext (managedBy, exposes, selectedBy, uses, runsOn, " +
-			"issue/audit/policy rollups) + current AND previous container logs across the " +
+			"issue/audit/policy rollups — issues carry diagnostic_context with cross-subject " +
+			"causal links + a confidence tier to walk symptom→root) + current AND previous container logs across the " +
 			"workload's pods + recent Warning events filtered to this resource + a " +
 			"recentChanges section for the workload and directly referenced " +
 			"ConfigMaps (no Secret content) + a " +
@@ -318,9 +320,17 @@ func registerTools(server *mcp.Server) {
 			"Severity normalized to critical/warning. This is one curated stream — there is " +
 			"no source filter; each row carries a `source` label (problem|missing_ref|" +
 			"scheduling|condition) you can slice on via the CEL filter= if needed. Some " +
-			"rows include `diagnostic_context`: deterministic facts such as explicit " +
-			"missing refs, selected backend issues, or workload rollups; treat these as " +
-			"triage context, not proof of root cause. " +
+			"rows include `diagnostic_context`: deterministic facts AND cross-subject " +
+			"causal links — a failing root (Node under resource pressure, broken PVC, " +
+			"Service with no endpoints, unavailable metrics APIService) annotated with the " +
+			"downstream issues it may explain, in `facts[].related_issues` (each `count` " +
+			"is how many affected resources fold into that linked issue). Each causal link " +
+			"carries a `confidence`: `high` = a declared structural edge (selector, owner, " +
+			"claimName) — treat as fact; `medium` = inferred/co-located (e.g. pods ON a " +
+			"pressured node) — a lead to verify, NOT proof; `low` = heuristic. The fact's " +
+			"`role` (candidate = possible cause, affected, rollup, context) places the row " +
+			"in the causal picture. Use these links to walk from a symptom to its likely " +
+			"root, but confirm a medium link before acting on it. " +
 			"When `recent_changes` is present, consider it if the issue list does not " +
 			"explain the reported symptom; `recent_changes_reason` says why Radar " +
 			"attached it. It lists recent spec/config changes that may explain failures " +

--- a/packages/k8s-ui/src/components/issues/IssuesView.tsx
+++ b/packages/k8s-ui/src/components/issues/IssuesView.tsx
@@ -384,6 +384,7 @@ function DiagnosticContext({
                     key={`${related.ref.group ?? ''}/${related.ref.kind}/${related.ref.namespace ?? ''}/${related.ref.name}#${relIdx}`}
                     label="Related"
                     refForLink={memberRef(issue, related.ref)}
+                    count={related.count}
                     resourceHref={resourceHref}
                     onResourceClick={onResourceClick}
                     ResourceLinkIcon={ResourceLinkIcon}
@@ -478,12 +479,14 @@ function AffectedResources({
 function ResourceLine({
   label,
   refForLink,
+  count,
   resourceHref,
   onResourceClick,
   ResourceLinkIcon,
 }: {
   label?: string;
   refForLink: IssueResourceRef;
+  count?: number;
   resourceHref?: (ref: IssueResourceRef) => string;
   onResourceClick?: (ref: IssueResourceRef) => void;
   ResourceLinkIcon: ComponentType<{ className?: string }>;
@@ -498,6 +501,9 @@ function ResourceLine({
         {r.namespace ? `${r.namespace} / ` : ''}
         {r.name}
       </span>
+      {count && count > 1 ? (
+        <span className="shrink-0 text-[10px] text-theme-text-tertiary tabular-nums" title={`${count} affected resources grouped under this issue`}>{count} affected</span>
+      ) : null}
       {linkable && <ResourceLinkIcon className="h-3 w-3 shrink-0 text-theme-text-tertiary opacity-0 transition-opacity group-hover/r:opacity-100" />}
     </>
   );

--- a/packages/k8s-ui/src/components/issues/ResourceIssuesSection.tsx
+++ b/packages/k8s-ui/src/components/issues/ResourceIssuesSection.tsx
@@ -113,6 +113,9 @@ function CausalContext({ issue, onResourceClick }: { issue: Issue; onResourceCli
                         {rel.ref.namespace ? `${rel.ref.namespace} / ` : ''}
                         {rel.ref.name}
                       </span>
+                      {rel.count && rel.count > 1 ? (
+                        <span className="ml-1 tabular-nums" title={`${rel.count} affected resources grouped under this issue`}>· {rel.count} affected</span>
+                      ) : null}
                     </>
                   )
                   return (

--- a/packages/k8s-ui/src/components/issues/diagnostic.ts
+++ b/packages/k8s-ui/src/components/issues/diagnostic.ts
@@ -42,6 +42,8 @@ export function diagnosticFactLabel(type: string): string {
       return 'Affected workloads';
     case 'pvc_blast_radius':
       return 'Blocked pods';
+    case 'apiservice_hpa':
+      return 'Stalled autoscalers';
     default:
       return type.replace(/_/g, ' ');
   }

--- a/packages/k8s-ui/src/components/issues/types.ts
+++ b/packages/k8s-ui/src/components/issues/types.ts
@@ -71,6 +71,10 @@ export interface IssueDiagnosticIssueRef {
   reason?: string;
   category?: string;
   severity?: IssueSeverity;
+  /** How many affected resources fold into this linked issue from the root's
+   *  perspective (e.g. 5 of a PVC's mounting pods under one Deployment issue).
+   *  Absent when the link covers a single resource. */
+  count?: number;
 }
 
 export type IssueDiagnosticConfidence = 'high' | 'medium' | 'low';

--- a/pkg/issuesapi/types.go
+++ b/pkg/issuesapi/types.go
@@ -239,6 +239,12 @@ type IssueRef struct {
 	Reason   string   `json:"reason,omitempty"`
 	Category Category `json:"category,omitempty"`
 	Severity Severity `json:"severity,omitempty"`
+	// Count is how many affected resources fold into this referenced issue from
+	// the linking root's perspective — e.g. a PVC link points at one grouped
+	// Deployment issue that 5 of the PVC's mounting pods fall under, so Count=5.
+	// Omitted (0) when the link covers a single resource. It is the root-specific
+	// subset, NOT the grouped issue's total membership, which can be larger.
+	Count int `json:"count,omitempty"`
 }
 
 type ChangeContext struct {


### PR DESCRIPTION
## Summary

Three follow-ups to the issue-correlation layer (#1041 / #1042), all in the established **non-destructive** style — links annotate a root with the issues it may explain; nothing is suppressed, down-ranked, or re-severitied:

1. **New causal link: an unavailable metrics APIService → the HPAs it starves.** When `metrics-server` (or a custom/external metrics adapter) is down, every metric-driven HPA shows `ScalingActive=False` / "unable to fetch metrics" — but the operator sees a pile of broken HPAs with no obvious common cause. Radar now links the down APIService to those HPAs so the root is one click away.
2. **Blast-radius links now count the resources they cover.** Previously, when 5 pods of one Deployment all hit the same PVC/node problem, the link collapsed them to a single row showing one pod with no indication there were more. It now shows the grouped issue once with an "N affected" count of the distinct affected resources.
3. **MCP tool descriptions** now tell the model that `diagnostic_context` carries cross-subject causal links + a confidence tier, so the LLM reasons symptom→root instead of just receiving the fields.

## The new logic

### 1. metrics-APIService → HPA fan-in (`apiservice_hpa`, confidence: medium)

Unlike the node/PVC links there is **no declared edge** from an HPA to the APIService it consumes — a down metrics server starves every metric-driven HPA cluster-wide — so this is a cluster-wide fan-in, gated hard on both ends to stay precise:

- **Root gate — metric family, exact-matched.** The root must be an `apiservice_unavailable` issue whose group (parsed from the `<version>.<group>` APIService name) **exactly** equals one of the three metrics groups — `metrics.k8s.io` (resource), `custom.metrics.k8s.io`, `external.metrics.k8s.io`. Exact match, not substring, so a spoofed/nested name like `v1.external.metrics.k8s.io.example.com` does not classify. A non-metrics aggregated API links nothing.
- **Symptom gate — same family.** An HPA links **only** when its own controller condition reason is the metrics-fetch failure for the **same family**: `FailedGetResourceMetric` / `FailedGetContainerResourceMetric` ↔ resource, `FailedGetObjectMetric` / `FailedGetPodsMetric` ↔ custom, `FailedGetExternalMetric` ↔ external. A down `external.metrics.k8s.io` does **not** claim a CPU-metric HPA, and two down metrics APIs don't both claim the same HPA.
- **Excludes workload config, not outage.** An HPA failing `FailedGetResourceMetric` because its pods are **missing resource requests** ("missing request for cpu") is a workload-config problem the API outage doesn't cause — filtered out, not attributed.
- **Excludes the non-causes.** A maxReplicas-capped HPA, or one scaling normally, carries no `FailedGet*Metric` reason and never links.
- **Confidence: medium**, not high — the family and the "can't fetch metrics" symptom line up, but there's no structural edge proving this exact HPA consumed this exact API server; the UI frames it "verify."

### 2. Affected-resource counts on blast-radius links (`IssueRef.count`)

`GroupIssues` buckets flat rows by issue ID, so all pods folded under one workload share a single ID. The previous linker deduped on that ID and so dropped every pod after the first, showing one uncounted row. The linker now groups linked symptoms by their **grouped** issue, counts the **distinct affected resources** under each, emits one related row per group carrying that count, and keeps the displayed refs aligned with the retained (severity-capped) related issues.

- `IssueRef.count` is a new additive field on the public `issuesapi` contract (omitted when 1). It is the **root-specific** subset (how many of the PVC's mounting pods fall under that Deployment issue), *not* the grouped issue's total membership, which can be larger.
- **No silent caps.** When more affected groups exist than the display cap, the fact message says so ("Showing the N most severe of M affected") rather than implying the blast radius is only N. The full set is never hidden — every affected resource still has its own row in the queue.
- All three links (node / PVC / APIService→HPA) flow through one shared `collectRelated` helper, so they can't drift.

### 3. MCP descriptions
`issues` (primary), `diagnose`, and `get_resource` now state that `diagnostic_context.facts[].related_issues` carry cross-subject causal links, each with a `confidence` (high = declared structural edge, treat as fact; medium = inferred/co-located, a lead to verify; low = heuristic), a `role` (candidate = possible cause), and a per-link `count`. No tools added/removed — the setup-dialog catalog is unchanged.

## Frontend (`@skyhook-io/k8s-ui`)
- An "N affected" count (noun-free, matching the existing subject-count phrasing — never the ambiguous "×N") renders next to a related-issue line in **both** the cluster Issues view and the per-resource Operational Issues block, via the shared `ResourceLine`. Hidden when the link covers a single resource.
- New fact label "Stalled autoscalers" for the `apiservice_hpa` link.

## Guards — why it can't mislead or leak
- **RBAC/namespace scoping:** the APIService→HPA fan-in scans the already-auth-filtered flat issue set (`flat` is RBAC/namespace-filtered upstream; cluster-scoped rows gated before enrichment), so a link can't surface an HPA outside the caller's view — same intersection guarantee as the node/PVC links.
- **Over-coalescing:** exact-group root match + same-family symptom match + the missing-request exclusion + the honest medium label are the precision guards. Resource/custom/external never cross-link.
- **Non-destructive:** every HPA / pod keeps its own top-level row; the link is an annotation on the root.

## What a reviewer should focus on
- **Over-linking** — the family-match gate (exact root group ↔ HPA `FailedGet*Metric` reason) and the missing-request exclusion are the precision-critical guards; medium confidence is deliberate (no declared HPA→APIService edge).
- **Count correctness** — `collectRelated` counts distinct affected resources, not the shared grouped issue ID.

## Testing
- `go test ./internal/issues ./internal/k8s ./internal/mcp ./internal/server` and the `pkg/issuesapi` module — green; `make tsc` green.
- Unit tests pin: APIService→HPA positive link + medium confidence; non-metrics API links nothing; metric-family mismatch links nothing (resource outage vs external-metric HPA); missing-request HPA not attributed; `FailedGetContainerResourceMetric` links under the resource family; exact group-match (spoofed/nested names rejected); maxReplicas-capped HPA excluded; folded-pod count = distinct resources collapsing to one row.
- **Cross-reviewed with Codex over three rounds** — every finding (missing-request false positive, metric-family mismatch, ContainerResource under-link, exact-group hardening) is fixed and pinned by the tests above. **Product-reviewed** the operator-facing surfaces: the "×N → N affected" comprehension fix and the no-silent-cap message came out of that pass.
- **Not visual-tested:** the count chip is a single additive render mirroring the existing `ResourceLine` pattern; exercising the new link live needs induced cluster state (metrics-server down; a multi-pod-folding PVC) that isn't readily reproducible — the same constraint that left #1042's `node_blast_radius` unit-tested only.

## Follow-ups (deliberately out of scope here)
- **Reverse symptom→root link** (an HPA/pod row pointing back at its root) — that's the link-first→demotion incident-grouping redesign; its own effort.
- More cross-subject links, same pattern: cert-manager chain, GitOps managed-by rollup, admission-webhook fan-in (needs detector work), `unschedulable→PVC` once the scheduler reason class is threaded onto detections.
- Live-verify `apiservice_hpa` and `node_blast_radius` (need a cluster with a down metrics-server / multi-node induced pressure).
- Plain-language confidence wording — a cross-surface change to all #1042 chips, not a one-PR tweak.

<img width="1704" height="380" alt="apiservice-hpa-link" src="https://github.com/user-attachments/assets/7338039f-79b8-48df-b367-6eb0d0b85753" />
<img width="1712" height="537" alt="pvc-blast-radius-count" src="https://github.com/user-attachments/assets/961a27a1-ca96-495e-bf32-9ec04b5962f6" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes triage/correlation logic and the public issues API; mis-linking HPAs to APIServices or wrong blast-radius counts could mislead operators, though gates and tests target precision.
> 
> **Overview**
> Extends **issue diagnostic_context** with a new **medium-confidence** link from unavailable **metrics APIServices** (`metrics.k8s.io` / custom / external, exact group match) to **HPAs** whose failure text matches the same metric family (`FailedGet*Metric`), excluding maxReplicas caps and **missing CPU/memory requests**.
> 
> **Blast-radius** linking (node, PVC, and the new APIService path) now goes through shared **`collectRelated`**: multiple pods folding into one grouped issue produce a **single related row** with **`IssueRef.count`** = distinct affected resources, aligned refs after severity capping, and an explicit **“showing N of M affected”** message when truncated.
> 
> **`issuesapi.IssueRef`** gains optional **`count`**; the k8s-ui issues views show **“N affected”** on related lines and label **`apiservice_hpa`** as **Stalled autoscalers**. MCP **`issues`**, **`diagnose`**, and **`get_resource`** descriptions now explain **`diagnostic_context`** causal links, confidence, roles, and per-link counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b218d3fd290accf130d215782c61584f5f63bebe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->