### PR TITLE
fix(web): vertically center theme toggle in header controls

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1639,7 +1639,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
               to the host's cookie/backend) and the user would see the theme
               bounce on every navigation between host routes and /c/:id. */}
           {!navCustomization.embedded && (
-            <div className="hidden md:block">
+            <div className="hidden md:flex items-center">
               <ThemeToggle />
             </div>
           )}


### PR DESCRIPTION
## Summary

The theme-toggle icon in the top-right header sat ~3px higher than the other controls (GitHub star, help, report-a-bug), leaving the icon row visibly uneven. This aligns it with its siblings.

## What changed

The right-controls row is a `flex items-center` strip of 28px icon buttons. Most are direct flex children (or block-level flex elements), so they center cleanly. The theme toggle was wrapped in a `block` div around a Tooltip that renders an `inline-flex` span — an inline-level element inside a block generates a line box, and its line-height leading inflated the wrapper to 34.5px. That both stretched the whole row and top-aligned the 28px button instead of centering it.

The wrapper is now a flex box (`hidden md:flex items-center`), so it hugs the button with no line-box leading and centers like every other control.

## Testing

- `make restart-fe` (frontend build + embed + restart)
- Measured the rendered header in the browser: the right-controls row is now a uniform 28px tall and all icon buttons share the same vertical baseline (previously the toggle was 3px high). Confirmed visually.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change on a layout wrapper; no behavior, auth, or data impact.
> 
> **Overview**
> Fixes the standalone header so the **theme toggle** lines up with the other right-side icon controls (help, GitHub star, etc.).
> 
> The toggle wrapper changes from `hidden md:block` to **`hidden md:flex items-center`**, so the `Tooltip`/`inline-flex` child no longer sits in a block line box with extra leading that stretched the row and left the ~28px button ~3px high relative to its siblings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 867b00353176cc82cfc7120d4c3445e482d01c31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->