### PR TITLE
feat(workload): expand resource peek into a context-retaining fullscreen overlay with a smooth morph

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -2951,6 +2951,11 @@ export function ResourcesView({
       params.set('resource', resourceNs ? `${resourceNs}/${resourceName}` : resourceName)
     } else {
       params.delete('resource')
+      // `full` (over-list fullscreen) and `tab` are resource-scoped — when no
+      // resource is selected they're stale; drop them so they can't leak onto a
+      // later selection (e.g. after a kind switch or closing the drawer).
+      params.delete('full')
+      params.delete('tab')
     }
 
     const newPath = `${basePath}/${kindInfo.name}`

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1944,10 +1944,6 @@ interface ResourcesViewProps {
   isBulkRestarting?: boolean
   onBulkScale?: (items: BulkResourceItem[], replicas: number, options?: { onSuccess?: () => void }) => void
   isBulkScaling?: boolean
-  /** When false, this list's keyboard shortcuts are not registered — used when a
-   *  fullscreen detail overlay sits on top of the still-mounted list so its
-   *  row-nav / Escape / action keys don't fire on the hidden background. Default true. */
-  shortcutsActive?: boolean
 }
 
 // Default selected kind
@@ -2068,7 +2064,6 @@ function LastUpdatedLabel({ lastUpdated }: { lastUpdated: Date }) {
 
 export function ResourcesView({
   namespaces, selectedResource, onResourceClick, onResourceClickYaml, onKindChange,
-  shortcutsActive = true,
   apiResources: apiResourcesProp,
   resourceQueries: resourceQueriesProp,
   resourceCounts: resourceCountsProp,
@@ -2514,7 +2509,6 @@ export function ResourcesView({
     category: 'Search',
     scope: 'resources',
     handler: () => searchInputRef.current?.focus(),
-    enabled: shortcutsActive,
   })
 
   // Keyboard navigation: highlighted row state
@@ -2614,8 +2608,8 @@ export function ResourcesView({
     onResourceClick?.(isSelected ? null : stripped)
   }, [onRowSelect, onResourceClick, selectedKind.name, selectedKind.group])
 
-  // Register navigation shortcuts (suppressed while a fullscreen overlay covers the list)
-  useRegisterShortcuts(shortcutsActive ? [
+  // Register navigation shortcuts
+  useRegisterShortcuts([
     {
       id: 'resources-nav-down',
       keys: 'j',
@@ -2788,7 +2782,7 @@ export function ResourcesView({
         else searchInputRef.current?.blur()
       },
     },
-  ] : [])
+  ])
 
   // Refs for accessing filteredResources inside shortcuts (computed later in component)
   const filteredResourceCountRef = useRef(0)
@@ -2798,7 +2792,7 @@ export function ResourcesView({
   const flatKindListRef = useRef<SelectedKindInfo[]>([])
 
   // Sidebar kind navigation: [ = previous kind, ] = next kind
-  useRegisterShortcuts(shortcutsActive ? [
+  useRegisterShortcuts([
     {
       id: 'resources-prev-kind',
       keys: '[',
@@ -2831,7 +2825,7 @@ export function ResourcesView({
         onKindChange?.()
       },
     },
-  ] : [])
+  ])
 
   // Close dropdowns on outside click
   useEffect(() => {

--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1944,6 +1944,10 @@ interface ResourcesViewProps {
   isBulkRestarting?: boolean
   onBulkScale?: (items: BulkResourceItem[], replicas: number, options?: { onSuccess?: () => void }) => void
   isBulkScaling?: boolean
+  /** When false, this list's keyboard shortcuts are not registered — used when a
+   *  fullscreen detail overlay sits on top of the still-mounted list so its
+   *  row-nav / Escape / action keys don't fire on the hidden background. Default true. */
+  shortcutsActive?: boolean
 }
 
 // Default selected kind
@@ -2064,6 +2068,7 @@ function LastUpdatedLabel({ lastUpdated }: { lastUpdated: Date }) {
 
 export function ResourcesView({
   namespaces, selectedResource, onResourceClick, onResourceClickYaml, onKindChange,
+  shortcutsActive = true,
   apiResources: apiResourcesProp,
   resourceQueries: resourceQueriesProp,
   resourceCounts: resourceCountsProp,
@@ -2509,6 +2514,7 @@ export function ResourcesView({
     category: 'Search',
     scope: 'resources',
     handler: () => searchInputRef.current?.focus(),
+    enabled: shortcutsActive,
   })
 
   // Keyboard navigation: highlighted row state
@@ -2608,8 +2614,8 @@ export function ResourcesView({
     onResourceClick?.(isSelected ? null : stripped)
   }, [onRowSelect, onResourceClick, selectedKind.name, selectedKind.group])
 
-  // Register navigation shortcuts
-  useRegisterShortcuts([
+  // Register navigation shortcuts (suppressed while a fullscreen overlay covers the list)
+  useRegisterShortcuts(shortcutsActive ? [
     {
       id: 'resources-nav-down',
       keys: 'j',
@@ -2782,7 +2788,7 @@ export function ResourcesView({
         else searchInputRef.current?.blur()
       },
     },
-  ])
+  ] : [])
 
   // Refs for accessing filteredResources inside shortcuts (computed later in component)
   const filteredResourceCountRef = useRef(0)
@@ -2792,7 +2798,7 @@ export function ResourcesView({
   const flatKindListRef = useRef<SelectedKindInfo[]>([])
 
   // Sidebar kind navigation: [ = previous kind, ] = next kind
-  useRegisterShortcuts([
+  useRegisterShortcuts(shortcutsActive ? [
     {
       id: 'resources-prev-kind',
       keys: '[',
@@ -2825,7 +2831,7 @@ export function ResourcesView({
         onKindChange?.()
       },
     },
-  ])
+  ] : [])
 
   // Close dropdowns on outside click
   useEffect(() => {

--- a/packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx
+++ b/packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx
@@ -108,15 +108,27 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
     const parent = el?.offsetParent as HTMLElement | null
     const measured = parent ? parent.clientWidth - leftOffset : el?.clientWidth
     if (measured && measured > 0) setFullWidthPx(measured)
+    // Pre-mount: render both layers (incoming invisible, frame held at its start
+    // width) for a couple of frames so the heavy incoming WorkloadView pays its
+    // mount + first-paint cost BEFORE the motion starts — otherwise that work
+    // lands as dropped frames in the first third of the animation. Only after it
+    // has painted (double rAF) do we arm the width + crossfade.
     setCrossfadeArmed(false)
-    const raf = requestAnimationFrame(() => setCrossfadeArmed(true))
-    const timer = setTimeout(() => {
-      settledExpanded.current = !!expanded
-      setCrossfadeArmed(false)
-      forceSettle()
-    }, DURATION_NORMAL)
+    let raf2 = 0
+    let timer = 0
+    const raf1 = requestAnimationFrame(() => {
+      raf2 = requestAnimationFrame(() => {
+        setCrossfadeArmed(true)
+        timer = window.setTimeout(() => {
+          settledExpanded.current = !!expanded
+          setCrossfadeArmed(false)
+          forceSettle()
+        }, DURATION_NORMAL)
+      })
+    })
     return () => {
-      cancelAnimationFrame(raf)
+      cancelAnimationFrame(raf1)
+      cancelAnimationFrame(raf2)
       clearTimeout(timer)
     }
   }, [expanded, prefersReducedMotion, leftOffset])
@@ -174,6 +186,14 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
   // when the user prefers reduced motion.
   const animateWidth = !isResizing && !prefersReducedMotion
 
+  // During the pre-mount frames (transitioning but not yet armed) hold the frame
+  // at its START width so the width transition fires only once the incoming
+  // layer has painted; otherwise it snaps to the target.
+  const fullW = `calc(100% - ${leftOffset}px)`
+  const startWidth = settledExpanded.current ? fullW : drawerWidth
+  const targetWidth = expanded ? fullW : drawerWidth
+  const containerWidth = transitioning && !crossfadeArmed ? startWidth : targetWidth
+
   const renderLayer = (layerExpanded: boolean, active: boolean) =>
     children({
       resource,
@@ -208,7 +228,7 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
         expanded && '!border-l-0',
       )}
       style={{
-        width: expanded ? `calc(100% - ${leftOffset}px)` : drawerWidth,
+        width: containerWidth,
         top: headerHeight,
         height: `calc(100% - ${headerHeight}px - ${dockInset}px)`,
       }}
@@ -244,6 +264,7 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
               width: layerExpanded ? (fullWidthPx ?? `calc(100% - ${leftOffset}px)`) : drawerWidth,
               opacity: isIncoming ? (crossfadeArmed ? 1 : 0) : (crossfadeArmed ? 0 : 1),
               transition: `opacity ${DURATION_NORMAL}ms ${CSS_EASE}`,
+              willChange: 'opacity',
             }}
             aria-hidden={!isIncoming}
           >

--- a/packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx
+++ b/packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx
@@ -19,8 +19,13 @@ interface ResourceDetailDrawerProps {
   expanded?: boolean
   /** Called when user clicks collapse in expanded mode */
   onCollapse?: () => void
-  /** Called when user clicks expand button */
-  onExpand?: (resource: SelectedResource) => void
+  /** Called when user clicks expand button. `opts.yaml` is true when expanding
+   *  from the drawer's YAML view, so the host can open the full view on YAML. */
+  onExpand?: (resource: SelectedResource, opts?: { yaml?: boolean }) => void
+  /** Whether the expanded view can collapse back to a side drawer. False on
+   *  mobile (no room for a drawer) — the collapse-to-drawer control is hidden
+   *  there and the host's onCollapse should close instead. Default true. */
+  canCollapseToDrawer?: boolean
   /** Navigate to another resource within expanded WorkloadView */
   onNavigateToResource?: (resource: SelectedResource) => void
   /** Height of the host app's top navigation bar in px (default: 49) */
@@ -35,7 +40,7 @@ interface ResourceDetailDrawerProps {
     active: boolean
     initialTab?: 'detail' | 'yaml'
     onClose: () => void
-    onExpand?: () => void
+    onExpand?: (opts?: { yaml?: boolean }) => void
     onBack?: () => void
     onNavigateToResource?: (resource: SelectedResource) => void
     onCollapseToDrawer?: () => void
@@ -71,7 +76,7 @@ function usePrefersReducedMotion(): boolean {
   return reduced
 }
 
-export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab, isOpen = true, expanded, onCollapse, onExpand, onNavigateToResource, headerHeight: headerHeightProp, leftOffset = 0, children }: ResourceDetailDrawerProps) {
+export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab, isOpen = true, expanded, onCollapse, onExpand, canCollapseToDrawer = true, onNavigateToResource, headerHeight: headerHeightProp, leftOffset = 0, children }: ResourceDetailDrawerProps) {
   const [drawerWidth, setDrawerWidth] = useState(() => getDefaultWidth(resource.kind))
   const [isResizing, setIsResizing] = useState(false)
   const resizeStartX = useRef(0)
@@ -199,10 +204,12 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
       active,
       initialTab,
       onClose,
-      onExpand: onExpand ? () => onExpand(resource) : undefined,
+      onExpand: onExpand ? (opts) => onExpand(resource, opts) : undefined,
       onBack: onCollapse ? () => onCollapse() : undefined,
       onNavigateToResource: handleNavigate,
-      onCollapseToDrawer: onCollapse ? () => onCollapse() : undefined,
+      // Hidden on mobile (no drawer to collapse to) — the host routes the
+      // back/close control through onCollapse instead.
+      onCollapseToDrawer: (canCollapseToDrawer && onCollapse) ? () => onCollapse() : undefined,
     })
 
   // While transitioning render both layers (outgoing = settled state, incoming

--- a/packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx
+++ b/packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx
@@ -1,9 +1,7 @@
 import { useState, useCallback, useEffect, useLayoutEffect, useReducer, useRef, type ReactNode } from 'react'
 import {
-  TRANSITION_DRAWER_SLIDE,
-  TRANSITION_DRAWER_EXPAND,
-  CSS_EASE,
-  DURATION_NORMAL,
+  DURATION_DRAWER_MORPH,
+  EASE_DRAWER_MORPH,
 } from '../../utils/animation'
 import { clsx } from 'clsx'
 import type { SelectedResource } from '../../types'
@@ -123,7 +121,7 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
           settledExpanded.current = !!expanded
           setCrossfadeArmed(false)
           forceSettle()
-        }, DURATION_NORMAL)
+        }, DURATION_DRAWER_MORPH)
       })
     })
     return () => {
@@ -221,7 +219,6 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
         // Clip the wider layer only while morphing; keep overflow visible at idle
         // so drawer popovers/tooltips aren't clipped.
         transitioning && 'overflow-hidden',
-        animateWidth ? TRANSITION_DRAWER_EXPAND : TRANSITION_DRAWER_SLIDE,
         isOpen
           ? 'translate-x-0 opacity-100'
           : 'translate-x-full opacity-0',
@@ -231,6 +228,11 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
         width: containerWidth,
         top: headerHeight,
         height: `calc(100% - ${headerHeight}px - ${dockInset}px)`,
+        // Inline so the morph duration/easing is controlled precisely (and stays
+        // in lockstep with the crossfade + JS window). Width only animates when
+        // not resizing / reduced-motion.
+        transition: `translate ${DURATION_DRAWER_MORPH}ms ${EASE_DRAWER_MORPH}, opacity ${DURATION_DRAWER_MORPH}ms ${EASE_DRAWER_MORPH}${animateWidth ? `, width ${DURATION_DRAWER_MORPH}ms ${EASE_DRAWER_MORPH}` : ''}`,
+        willChange: 'transform, width',
       }}
     >
       {/* Resize handle — hidden when expanded or mid-transition or on mobile */}
@@ -263,7 +265,7 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
             style={{
               width: layerExpanded ? (fullWidthPx ?? `calc(100% - ${leftOffset}px)`) : drawerWidth,
               opacity: isIncoming ? (crossfadeArmed ? 1 : 0) : (crossfadeArmed ? 0 : 1),
-              transition: `opacity ${DURATION_NORMAL}ms ${CSS_EASE}`,
+              transition: `opacity ${DURATION_DRAWER_MORPH}ms ${EASE_DRAWER_MORPH}`,
               willChange: 'opacity',
             }}
             aria-hidden={!isIncoming}

--- a/packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx
+++ b/packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx
@@ -41,6 +41,11 @@ interface ResourceDetailDrawerProps {
     initialTab?: 'detail' | 'yaml'
     onClose: () => void
     onExpand?: (opts?: { yaml?: boolean }) => void
+    /** Signal (hover/press the expand control) that expand is likely — pre-mounts
+     *  the heavy fullscreen layer invisibly so the click starts the morph instantly. */
+    onExpandIntent?: () => void
+    /** Intent withdrawn (pointer left the expand control) — discard the pre-mount. */
+    onCancelExpandIntent?: () => void
     onBack?: () => void
     onNavigateToResource?: (resource: SelectedResource) => void
     onCollapseToDrawer?: () => void
@@ -98,6 +103,33 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
   const [, forceSettle] = useReducer((c: number) => c + 1, 0)
   const transitioning = settledExpanded.current !== !!expanded
 
+  // Pre-mount: hovering/pressing the expand control mounts the heavy fullscreen
+  // layer invisibly ahead of the click, so the click arms the morph immediately
+  // (its mount cost is already paid). `wasPrewarmedRef` lets the transition skip a
+  // frame of pre-mount waiting since the layer has already painted.
+  const [prewarmExpand, setPrewarmExpand] = useState(false)
+  const wasPrewarmedRef = useRef(false)
+
+  const measureFullWidth = useCallback(() => {
+    const el = containerRef.current
+    const parent = el?.offsetParent as HTMLElement | null
+    const measured = parent ? parent.clientWidth - leftOffset : el?.clientWidth
+    if (measured && measured > 0) setFullWidthPx(measured)
+  }, [leftOffset])
+
+  const handleExpandIntent = useCallback(() => {
+    if (expanded || transitioning) return
+    measureFullWidth()
+    wasPrewarmedRef.current = true
+    setPrewarmExpand(true)
+  }, [expanded, transitioning, measureFullWidth])
+
+  const handleCancelExpandIntent = useCallback(() => {
+    if (transitioning || expanded) return
+    wasPrewarmedRef.current = false
+    setPrewarmExpand(false)
+  }, [transitioning, expanded])
+
   useLayoutEffect(() => {
     if (settledExpanded.current === !!expanded) return
     if (prefersReducedMotion) {
@@ -107,34 +139,35 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
     }
     // Pin the full-screen layer to the measured expanded width so its content
     // lays out at its final width from the first frame (no live reflow).
-    const el = containerRef.current
-    const parent = el?.offsetParent as HTMLElement | null
-    const measured = parent ? parent.clientWidth - leftOffset : el?.clientWidth
-    if (measured && measured > 0) setFullWidthPx(measured)
-    // Pre-mount: render both layers (incoming invisible, frame held at its start
-    // width) for a couple of frames so the heavy incoming WorkloadView pays its
-    // mount + first-paint cost BEFORE the motion starts — otherwise that work
-    // lands as dropped frames in the first third of the animation. Only after it
-    // has painted (double rAF) do we arm the width + crossfade.
+    measureFullWidth()
+    // The prewarm layer (if any) becomes the real transition layer now.
+    const prewarmed = wasPrewarmedRef.current && !!expanded
+    setPrewarmExpand(false)
+    // If the incoming layer was prewarmed it's already mounted + painted, so arm
+    // after a single frame. Otherwise double-rAF so its mount+paint lands BEFORE
+    // the motion starts (else it drops frames in the first third of the animation).
     setCrossfadeArmed(false)
     let raf2 = 0
     let timer = 0
+    const arm = () => {
+      setCrossfadeArmed(true)
+      timer = window.setTimeout(() => {
+        settledExpanded.current = !!expanded
+        setCrossfadeArmed(false)
+        wasPrewarmedRef.current = false
+        forceSettle()
+      }, DURATION_DRAWER_MORPH)
+    }
     const raf1 = requestAnimationFrame(() => {
-      raf2 = requestAnimationFrame(() => {
-        setCrossfadeArmed(true)
-        timer = window.setTimeout(() => {
-          settledExpanded.current = !!expanded
-          setCrossfadeArmed(false)
-          forceSettle()
-        }, DURATION_DRAWER_MORPH)
-      })
+      if (prewarmed) arm()
+      else raf2 = requestAnimationFrame(arm)
     })
     return () => {
       cancelAnimationFrame(raf1)
       cancelAnimationFrame(raf2)
       clearTimeout(timer)
     }
-  }, [expanded, prefersReducedMotion, leftOffset])
+  }, [expanded, prefersReducedMotion, measureFullWidth])
 
   // Reset drawer width when resource kind changes
   useEffect(() => {
@@ -205,6 +238,8 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
       initialTab,
       onClose,
       onExpand: onExpand ? (opts) => onExpand(resource, opts) : undefined,
+      onExpandIntent: onExpand ? handleExpandIntent : undefined,
+      onCancelExpandIntent: onExpand ? handleCancelExpandIntent : undefined,
       onBack: onCollapse ? () => onCollapse() : undefined,
       onNavigateToResource: handleNavigate,
       // Hidden on mobile (no drawer to collapse to) — the host routes the
@@ -215,8 +250,11 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
   // While transitioning render both layers (outgoing = settled state, incoming
   // = target). Keying by expanded-ness keeps the incoming layer's React
   // identity stable into idle, so it survives (state intact) while only the
-  // outgoing layer unmounts when the window ends.
-  const layerExpandedValues = transitioning ? [true, false] : [!!expanded]
+  // outgoing layer unmounts when the window ends. While prewarming (collapsed,
+  // intent signalled) also mount the expanded layer invisibly — keyed 'expanded'
+  // so it's reused (not remounted) when the real expand starts.
+  const showPrewarmLayer = prewarmExpand && !transitioning && !expanded
+  const layerExpandedValues = transitioning ? [true, false] : showPrewarmLayer ? [false, true] : [!!expanded]
 
   return (
     <div
@@ -258,8 +296,23 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
 
       {layerExpandedValues.map((layerExpanded) => {
         if (!transitioning) {
-          // Idle: a single layer fills the container (width tracks the frame so
-          // manual resize works).
+          // Prewarm: the expanded layer mounted invisibly ahead of the click.
+          // Pinned at full width + inert + opacity 0 so its mount cost is paid now,
+          // off-screen, and it's reused (same key) when the morph actually starts.
+          if (showPrewarmLayer && layerExpanded) {
+            return (
+              <div
+                key="expanded"
+                aria-hidden
+                inert
+                className="absolute top-0 bottom-0 right-0 overflow-hidden pointer-events-none opacity-0"
+                style={{ width: fullWidthPx ?? `calc(100% - ${leftOffset}px)` }}
+              >
+                {renderLayer(true, false)}
+              </div>
+            )
+          }
+          // Idle (or the visible collapsed layer during prewarm): fills the container.
           return (
             <div key={layerExpanded ? 'expanded' : 'collapsed'} className="absolute inset-0">
               {renderLayer(layerExpanded, true)}

--- a/packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx
+++ b/packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx
@@ -1,5 +1,10 @@
-import { useState, useCallback, useEffect, useRef, type ReactNode } from 'react'
-import { TRANSITION_DRAWER } from '../../utils/animation'
+import { useState, useCallback, useEffect, useLayoutEffect, useReducer, useRef, type ReactNode } from 'react'
+import {
+  TRANSITION_DRAWER_SLIDE,
+  TRANSITION_DRAWER_EXPAND,
+  CSS_EASE,
+  DURATION_NORMAL,
+} from '../../utils/animation'
 import { clsx } from 'clsx'
 import type { SelectedResource } from '../../types'
 import { useDockReservedHeight } from '../dock/DockContext'
@@ -28,6 +33,8 @@ interface ResourceDetailDrawerProps {
   children: (props: {
     resource: SelectedResource
     expanded: boolean
+    /** false on the outgoing layer mid-transition — suspend shortcuts/interaction */
+    active: boolean
     initialTab?: 'detail' | 'yaml'
     onClose: () => void
     onExpand?: () => void
@@ -52,18 +59,67 @@ function getDefaultWidth(kind: string): number {
   return WIDE_KINDS.has(kind.toLowerCase()) ? WIDE_WIDTH : DEFAULT_WIDTH
 }
 
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(
+    () => typeof window !== 'undefined' && !!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches,
+  )
+  useEffect(() => {
+    const mq = window.matchMedia?.('(prefers-reduced-motion: reduce)')
+    if (!mq) return
+    const onChange = () => setReduced(mq.matches)
+    mq.addEventListener('change', onChange)
+    return () => mq.removeEventListener('change', onChange)
+  }, [])
+  return reduced
+}
+
 export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab, isOpen = true, expanded, onCollapse, onExpand, onNavigateToResource, headerHeight: headerHeightProp, leftOffset = 0, children }: ResourceDetailDrawerProps) {
   const [drawerWidth, setDrawerWidth] = useState(() => getDefaultWidth(resource.kind))
   const [isResizing, setIsResizing] = useState(false)
   const resizeStartX = useRef(0)
   const resizeStartWidth = useRef(getDefaultWidth(resource.kind))
+  const containerRef = useRef<HTMLDivElement>(null)
+  const prefersReducedMotion = usePrefersReducedMotion()
 
-  // Detect collapse direction: was expanded last render, now not.
-  // Width snaps instantly on collapse (0ms) so content and size match.
-  // Expand keeps the nice 300ms width animation via TRANSITION_DRAWER.
-  const wasExpanded = useRef(!!expanded)
-  const isCollapsing = wasExpanded.current && !expanded
-  wasExpanded.current = !!expanded
+  // Expand/collapse crossfade. During the window we mount BOTH the drawer and
+  // full-screen layouts, each pinned to its own width (so neither reflows or
+  // squashes), and crossfade opacity while the container width (the frame)
+  // animates between them.
+  //
+  // `settledExpanded` is the last finished state. While it differs from the
+  // incoming `expanded` prop we're mid-transition: render both layers, fade
+  // `crossfadeArmed` 0→1 once a start frame has painted, then settle.
+  const settledExpanded = useRef(!!expanded)
+  const [crossfadeArmed, setCrossfadeArmed] = useState(false)
+  const [fullWidthPx, setFullWidthPx] = useState<number | null>(null)
+  const [, forceSettle] = useReducer((c: number) => c + 1, 0)
+  const transitioning = settledExpanded.current !== !!expanded
+
+  useLayoutEffect(() => {
+    if (settledExpanded.current === !!expanded) return
+    if (prefersReducedMotion) {
+      settledExpanded.current = !!expanded
+      forceSettle()
+      return
+    }
+    // Pin the full-screen layer to the measured expanded width so its content
+    // lays out at its final width from the first frame (no live reflow).
+    const el = containerRef.current
+    const parent = el?.offsetParent as HTMLElement | null
+    const measured = parent ? parent.clientWidth - leftOffset : el?.clientWidth
+    if (measured && measured > 0) setFullWidthPx(measured)
+    setCrossfadeArmed(false)
+    const raf = requestAnimationFrame(() => setCrossfadeArmed(true))
+    const timer = setTimeout(() => {
+      settledExpanded.current = !!expanded
+      setCrossfadeArmed(false)
+      forceSettle()
+    }, DURATION_NORMAL)
+    return () => {
+      cancelAnimationFrame(raf)
+      clearTimeout(timer)
+    }
+  }, [expanded, prefersReducedMotion, leftOffset])
 
   // Reset drawer width when resource kind changes
   useEffect(() => {
@@ -72,14 +128,14 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
     resizeStartWidth.current = w
   }, [resource.kind])
 
-  // Resize handlers (disabled when expanded)
+  // Resize handlers (disabled when expanded or mid-transition)
   const handleResizeStart = useCallback((e: React.MouseEvent) => {
-    if (expanded) return
+    if (expanded || transitioning) return
     e.preventDefault()
     setIsResizing(true)
     resizeStartX.current = e.clientX
     resizeStartWidth.current = drawerWidth
-  }, [drawerWidth, expanded])
+  }, [drawerWidth, expanded, transitioning])
 
   useEffect(() => {
     if (!isResizing) return
@@ -114,11 +170,38 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
   const headerHeight = headerHeightProp ?? 49
   const dockInset = useDockReservedHeight()
 
+  // Width animates during expand/collapse, but snaps during manual resize and
+  // when the user prefers reduced motion.
+  const animateWidth = !isResizing && !prefersReducedMotion
+
+  const renderLayer = (layerExpanded: boolean, active: boolean) =>
+    children({
+      resource,
+      expanded: layerExpanded,
+      active,
+      initialTab,
+      onClose,
+      onExpand: onExpand ? () => onExpand(resource) : undefined,
+      onBack: onCollapse ? () => onCollapse() : undefined,
+      onNavigateToResource: handleNavigate,
+      onCollapseToDrawer: onCollapse ? () => onCollapse() : undefined,
+    })
+
+  // While transitioning render both layers (outgoing = settled state, incoming
+  // = target). Keying by expanded-ness keeps the incoming layer's React
+  // identity stable into idle, so it survives (state intact) while only the
+  // outgoing layer unmounts when the window ends.
+  const layerExpandedValues = transitioning ? [true, false] : [!!expanded]
+
   return (
     <div
+      ref={containerRef}
       className={clsx(
         'absolute right-0 bg-theme-surface border-l border-theme-border flex flex-col shadow-drawer z-40',
-        TRANSITION_DRAWER,
+        // Clip the wider layer only while morphing; keep overflow visible at idle
+        // so drawer popovers/tooltips aren't clipped.
+        transitioning && 'overflow-hidden',
+        animateWidth ? TRANSITION_DRAWER_EXPAND : TRANSITION_DRAWER_SLIDE,
         isOpen
           ? 'translate-x-0 opacity-100'
           : 'translate-x-full opacity-0',
@@ -128,13 +211,10 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
         width: expanded ? `calc(100% - ${leftOffset}px)` : drawerWidth,
         top: headerHeight,
         height: `calc(100% - ${headerHeight}px - ${dockInset}px)`,
-        // Collapse is instant — no animation, content and width snap together.
-        // Expand + slide-in/out animate via TRANSITION_DRAWER class.
-        ...(isCollapsing && { transition: 'none' }),
       }}
     >
-      {/* Resize handle — hidden when expanded or on mobile */}
-      {!expanded && (
+      {/* Resize handle — hidden when expanded or mid-transition or on mobile */}
+      {!expanded && !transitioning && (
         <div
           onMouseDown={handleResizeStart}
           className={clsx(
@@ -145,15 +225,31 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
         />
       )}
 
-      {children({
-        resource,
-        expanded: !!expanded,
-        initialTab,
-        onClose,
-        onExpand: onExpand ? () => onExpand(resource) : undefined,
-        onBack: onCollapse ? () => onCollapse() : undefined,
-        onNavigateToResource: handleNavigate,
-        onCollapseToDrawer: onCollapse ? () => onCollapse() : undefined,
+      {layerExpandedValues.map((layerExpanded) => {
+        if (!transitioning) {
+          // Idle: a single layer fills the container (width tracks the frame so
+          // manual resize works).
+          return (
+            <div key={layerExpanded ? 'expanded' : 'collapsed'} className="absolute inset-0">
+              {renderLayer(layerExpanded, true)}
+            </div>
+          )
+        }
+        const isIncoming = layerExpanded === !!expanded
+        return (
+          <div
+            key={layerExpanded ? 'expanded' : 'collapsed'}
+            className="absolute top-0 bottom-0 right-0 overflow-hidden pointer-events-none"
+            style={{
+              width: layerExpanded ? (fullWidthPx ?? `calc(100% - ${leftOffset}px)`) : drawerWidth,
+              opacity: isIncoming ? (crossfadeArmed ? 1 : 0) : (crossfadeArmed ? 0 : 1),
+              transition: `opacity ${DURATION_NORMAL}ms ${CSS_EASE}`,
+            }}
+            aria-hidden={!isIncoming}
+          >
+            {renderLayer(layerExpanded, isIncoming)}
+          </div>
+        )
       })}
     </div>
   )

--- a/packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx
+++ b/packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx
@@ -247,7 +247,9 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
             }}
             aria-hidden={!isIncoming}
           >
-            {renderLayer(layerExpanded, isIncoming)}
+            {/* Both layers inactive mid-crossfade — shortcuts shouldn't dispatch
+                during the animation; the settled layer owns them once idle. */}
+            {renderLayer(layerExpanded, false)}
           </div>
         )
       })}

--- a/packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx
+++ b/packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx
@@ -104,11 +104,9 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
   const transitioning = settledExpanded.current !== !!expanded
 
   // Pre-mount: hovering/pressing the expand control mounts the heavy fullscreen
-  // layer invisibly ahead of the click, so the click arms the morph immediately
-  // (its mount cost is already paid). `wasPrewarmedRef` lets the transition skip a
-  // frame of pre-mount waiting since the layer has already painted.
+  // layer invisibly ahead of the click, so the click reuses it (same key) and the
+  // morph's first frames aren't competing with the layer's mount cost.
   const [prewarmExpand, setPrewarmExpand] = useState(false)
-  const wasPrewarmedRef = useRef(false)
 
   const measureFullWidth = useCallback(() => {
     const el = containerRef.current
@@ -120,13 +118,11 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
   const handleExpandIntent = useCallback(() => {
     if (expanded || transitioning) return
     measureFullWidth()
-    wasPrewarmedRef.current = true
     setPrewarmExpand(true)
   }, [expanded, transitioning, measureFullWidth])
 
   const handleCancelExpandIntent = useCallback(() => {
     if (transitioning || expanded) return
-    wasPrewarmedRef.current = false
     setPrewarmExpand(false)
   }, [transitioning, expanded])
 
@@ -134,18 +130,18 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
     if (settledExpanded.current === !!expanded) return
     if (prefersReducedMotion) {
       settledExpanded.current = !!expanded
+      setPrewarmExpand(false)
       forceSettle()
       return
     }
     // Pin the full-screen layer to the measured expanded width so its content
     // lays out at its final width from the first frame (no live reflow).
     measureFullWidth()
-    // The prewarm layer (if any) becomes the real transition layer now.
-    const prewarmed = wasPrewarmedRef.current && !!expanded
+    // The prewarm layer (if any) becomes the real transition layer now (reused by key).
     setPrewarmExpand(false)
-    // If the incoming layer was prewarmed it's already mounted + painted, so arm
-    // after a single frame. Otherwise double-rAF so its mount+paint lands BEFORE
-    // the motion starts (else it drops frames in the first third of the animation).
+    // Double-rAF so the incoming layer's mount+paint lands BEFORE the motion starts
+    // (else it drops frames in the first third). Prewarm keeps the heavy mount off
+    // the click path; these two frames are then cheap (the layer's already there).
     setCrossfadeArmed(false)
     let raf2 = 0
     let timer = 0
@@ -154,13 +150,11 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
       timer = window.setTimeout(() => {
         settledExpanded.current = !!expanded
         setCrossfadeArmed(false)
-        wasPrewarmedRef.current = false
         forceSettle()
       }, DURATION_DRAWER_MORPH)
     }
     const raf1 = requestAnimationFrame(() => {
-      if (prewarmed) arm()
-      else raf2 = requestAnimationFrame(arm)
+      raf2 = requestAnimationFrame(arm)
     })
     return () => {
       cancelAnimationFrame(raf1)
@@ -175,6 +169,12 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
     setDrawerWidth(w)
     resizeStartWidth.current = w
   }, [resource.kind])
+
+  // Drop a pending prewarm if the drawer closes or the target resource changes —
+  // its hover intent is stale, and a reopened drawer shouldn't pre-mount unbidden.
+  useEffect(() => {
+    setPrewarmExpand(false)
+  }, [isOpen, resource.kind, resource.namespace, resource.name])
 
   // Resize handlers (disabled when expanded or mid-transition)
   const handleResizeStart = useCallback((e: React.MouseEvent) => {
@@ -253,7 +253,7 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
   // outgoing layer unmounts when the window ends. While prewarming (collapsed,
   // intent signalled) also mount the expanded layer invisibly — keyed 'expanded'
   // so it's reused (not remounted) when the real expand starts.
-  const showPrewarmLayer = prewarmExpand && !transitioning && !expanded
+  const showPrewarmLayer = prewarmExpand && isOpen && !transitioning && !expanded
   const layerExpandedValues = transitioning ? [true, false] : showPrewarmLayer ? [false, true] : [!!expanded]
 
   return (

--- a/packages/k8s-ui/src/components/workload/WorkloadView.tsx
+++ b/packages/k8s-ui/src/components/workload/WorkloadView.tsx
@@ -71,6 +71,9 @@ interface WorkloadViewProps {
   onCollapseToDrawer?: () => void
   /** false = collapsed drawer mode, true (default) = full expanded mode */
   expanded?: boolean
+  /** false on the outgoing layer during an expand/collapse crossfade — suspend
+   *  keyboard shortcuts so the invisible layer doesn't capture them (default true) */
+  active?: boolean
   /** Close the drawer (collapsed mode) */
   onClose?: () => void
   /** Expand from drawer to full view */
@@ -248,6 +251,7 @@ export function WorkloadView({
   onNavigateToResource,
   onCollapseToDrawer,
   expanded = true,
+  active = true,
   onClose,
   onExpand,
   initialTab,
@@ -526,7 +530,7 @@ export function WorkloadView({
       category: expanded ? 'Navigation' as const : 'Drawer' as const,
       scope: expanded ? 'global' as const : 'drawer' as const,
       handler: expanded ? onBack : () => onClose?.(),
-      enabled: true,
+      enabled: active,
     },
     {
       id: 'drawer-yaml',
@@ -535,7 +539,7 @@ export function WorkloadView({
       category: 'Drawer' as const,
       scope: 'drawer' as const,
       handler: () => switchView(true),
-      enabled: !expanded,
+      enabled: active && !expanded,
     },
     {
       id: 'drawer-detail',
@@ -544,9 +548,9 @@ export function WorkloadView({
       category: 'Drawer' as const,
       scope: 'drawer' as const,
       handler: () => switchView(false),
-      enabled: !expanded,
+      enabled: active && !expanded,
     },
-  ], [expanded, onBack, onClose, switchView]))
+  ], [active, expanded, onBack, onClose, switchView]))
 
   const status = getResourceStatus(apiKind, resource)
 

--- a/packages/k8s-ui/src/components/workload/WorkloadView.tsx
+++ b/packages/k8s-ui/src/components/workload/WorkloadView.tsx
@@ -76,8 +76,9 @@ interface WorkloadViewProps {
   active?: boolean
   /** Close the drawer (collapsed mode) */
   onClose?: () => void
-  /** Expand from drawer to full view */
-  onExpand?: () => void
+  /** Expand from drawer to full view. `opts.yaml` true when expanding from the
+   *  drawer's YAML view so the full view opens on the YAML tab (edits carry over). */
+  onExpand?: (opts?: { yaml?: boolean }) => void
   /** Initial view tab — 'yaml' opens YAML directly */
   initialTab?: 'detail' | 'yaml'
   /** API group for CRD resources */
@@ -590,7 +591,7 @@ export function WorkloadView({
             <div className="flex items-center gap-1">
               {onExpand && (
                 <button
-                  onClick={onExpand}
+                  onClick={() => onExpand({ yaml: showYaml })}
                   className="p-1.5 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
                   title="Open full view"
                 >

--- a/packages/k8s-ui/src/components/workload/WorkloadView.tsx
+++ b/packages/k8s-ui/src/components/workload/WorkloadView.tsx
@@ -79,6 +79,9 @@ interface WorkloadViewProps {
   /** Expand from drawer to full view. `opts.yaml` true when expanding from the
    *  drawer's YAML view so the full view opens on the YAML tab (edits carry over). */
   onExpand?: (opts?: { yaml?: boolean }) => void
+  /** Hover/press the expand control = likely expand → pre-mount the full view. */
+  onExpandIntent?: () => void
+  onCancelExpandIntent?: () => void
   /** Initial view tab — 'yaml' opens YAML directly */
   initialTab?: 'detail' | 'yaml'
   /** API group for CRD resources */
@@ -255,6 +258,8 @@ export function WorkloadView({
   active = true,
   onClose,
   onExpand,
+  onExpandIntent,
+  onCancelExpandIntent,
   initialTab,
   group,
   breadcrumb,
@@ -595,6 +600,11 @@ export function WorkloadView({
               {onExpand && (
                 <button
                   onClick={() => onExpand({ yaml: showYaml })}
+                  // Pre-mount the fullscreen view on hover/press so the click starts
+                  // the morph instantly (its heavy mount is already paid for).
+                  onPointerEnter={onExpandIntent}
+                  onPointerDown={onExpandIntent}
+                  onPointerLeave={onCancelExpandIntent}
                   className="p-1.5 text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded"
                   title="Open full view"
                 >

--- a/packages/k8s-ui/src/components/workload/WorkloadView.tsx
+++ b/packages/k8s-ui/src/components/workload/WorkloadView.tsx
@@ -529,7 +529,10 @@ export function WorkloadView({
       keys: 'Escape',
       description: expanded ? 'Go back' : 'Close drawer',
       category: expanded ? 'Navigation' as const : 'Drawer' as const,
-      scope: expanded ? 'global' as const : 'drawer' as const,
+      // 'drawer' (top priority) in both modes so when this is the fullscreen
+      // overlay its Escape unambiguously wins over any background view's Escape
+      // (incl. another 'global'-scope WorkloadView mounted underneath).
+      scope: 'drawer' as const,
       handler: expanded ? onBack : () => onClose?.(),
       enabled: active,
     },

--- a/packages/k8s-ui/src/hooks/index.ts
+++ b/packages/k8s-ui/src/hooks/index.ts
@@ -5,5 +5,6 @@ export {
   useRegisterShortcut,
   useRegisterShortcuts,
   useActiveShortcuts,
+  useSuppressBaseShortcuts,
 } from './useKeyboardShortcuts'
 export type { KeyboardShortcut, ShortcutCategory } from './useKeyboardShortcuts'

--- a/packages/k8s-ui/src/hooks/useKeyboardShortcuts.tsx
+++ b/packages/k8s-ui/src/hooks/useKeyboardShortcuts.tsx
@@ -46,6 +46,10 @@ interface RegisteredShortcut extends KeyboardShortcut {
 interface KeyboardShortcutContextType {
   registerShortcut: (shortcut: KeyboardShortcut) => () => void
   activeShortcuts: KeyboardShortcut[]
+  /** When true, view-level shortcuts (the per-page scopes) are suppressed — used
+   *  while a fullscreen detail overlay covers the page so the hidden view's keys
+   *  don't fire. `global` (⌘K, the overlay's Escape) and `drawer` still fire. */
+  setBaseShortcutsSuppressed: (suppressed: boolean) => void
 }
 
 const KeyboardShortcutContext = createContext<KeyboardShortcutContextType | null>(null)
@@ -142,6 +146,9 @@ export function KeyboardShortcutProvider({ children }: { children: ReactNode }) 
   const [version, setVersion] = useState(0)
   const sequenceKeyRef = useRef<string | null>(null)
   const sequenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Read in the keydown handler (a ref, so no re-subscribe needed on change).
+  const baseSuppressedRef = useRef(false)
+  const setBaseShortcutsSuppressed = useCallback((s: boolean) => { baseSuppressedRef.current = s }, [])
 
   const registerShortcut = useCallback((shortcut: KeyboardShortcut) => {
     const id = nextRegistrationId++
@@ -161,9 +168,13 @@ export function KeyboardShortcutProvider({ children }: { children: ReactNode }) 
       const suppression = getSuppressionLevel(e)
       const suppressed = suppression !== 'none'
 
-      // Get all enabled shortcuts, sorted by scope priority (highest first)
+      // Get all enabled shortcuts, sorted by scope priority (highest first).
+      // While a fullscreen overlay covers the page, drop the view-level scopes
+      // (the hidden page's keys) but keep `global` (⌘K, the overlay's Escape) and
+      // `drawer` so the overlay still works.
       const shortcuts = Array.from(shortcutsRef.current.values())
         .filter(s => s.enabled !== false)
+        .filter(s => !baseSuppressedRef.current || s.scope === 'global' || s.scope === 'drawer')
         .sort((a, b) => SCOPE_PRIORITY[b.scope] - SCOPE_PRIORITY[a.scope])
 
       // Check for multi-key sequence completion
@@ -258,10 +269,20 @@ export function KeyboardShortcutProvider({ children }: { children: ReactNode }) 
   , [version])
 
   return (
-    <KeyboardShortcutContext.Provider value={{ registerShortcut, activeShortcuts }}>
+    <KeyboardShortcutContext.Provider value={{ registerShortcut, activeShortcuts, setBaseShortcutsSuppressed }}>
       {children}
     </KeyboardShortcutContext.Provider>
   )
+}
+
+/** Suppress view-level shortcuts while `active` (a fullscreen detail overlay is up).
+ *  `global` and `drawer` scopes keep firing so ⌘K and the overlay's own keys work. */
+export function useSuppressBaseShortcuts(active: boolean) {
+  const ctx = useContext(KeyboardShortcutContext)
+  useEffect(() => {
+    ctx?.setBaseShortcutsSuppressed(active)
+    return () => ctx?.setBaseShortcutsSuppressed(false)
+  }, [ctx, active])
 }
 
 /** Register a keyboard shortcut. Automatically deregisters on unmount or when key config changes. */

--- a/packages/k8s-ui/src/utils/animation.ts
+++ b/packages/k8s-ui/src/utils/animation.ts
@@ -30,6 +30,17 @@ export const DURATION_TOAST_EXIT = 200
 export const TRANSITION_DRAWER =
   `transition-[translate,opacity,width] duration-300 ${TW_EASE} will-change-[transform,width]`
 
+/** Resource drawer when its width must NOT animate (manual resize, reduced motion).
+ *  Only the slide-in/out (translate + opacity) transitions. */
+export const TRANSITION_DRAWER_SLIDE =
+  `transition-[translate,opacity] duration-300 ${TW_EASE} will-change-transform`
+
+/** Resource drawer expand/collapse — slide + an animated width (frame morph).
+ *  Tailwind can't compose two `transition-[…]` utilities (both set
+ *  transition-property), so width lives in this single combined preset. */
+export const TRANSITION_DRAWER_EXPAND =
+  `transition-[translate,opacity,width] duration-300 ${TW_EASE} will-change-[transform,width]`
+
 
 /** Overlay backdrop fade */
 export const TRANSITION_BACKDROP =

--- a/packages/k8s-ui/src/utils/animation.ts
+++ b/packages/k8s-ui/src/utils/animation.ts
@@ -22,23 +22,21 @@ export const DURATION_DOCK = 150
 /** Toast exit animation */
 export const DURATION_TOAST_EXIT = 200
 
+/** Drawer ↔ fullscreen expand/collapse morph. Longer than DURATION_NORMAL so a
+ *  large width change advances in small per-frame steps (reads as fluid, not
+ *  abrupt). Drives the frame width, the content crossfade, and the JS window
+ *  together — keep them in lockstep. */
+export const DURATION_DRAWER_MORPH = 360
+/** Gentle ease for the morph — eased at both ends so the big size change doesn't
+ *  lurch at the start the way the front-loaded iOS curve does. */
+export const EASE_DRAWER_MORPH = 'cubic-bezier(0.4, 0, 0.2, 1)'
+
 // -- Tailwind class presets ---------------------------------------------------
 // Reusable class fragments — import and spread into clsx() calls.
 
 /** Drawer slide from right — use with translate-x-0/translate-x-full + opacity.
  *  Also handles expand/collapse (width) so a single transition covers both. */
 export const TRANSITION_DRAWER =
-  `transition-[translate,opacity,width] duration-300 ${TW_EASE} will-change-[transform,width]`
-
-/** Resource drawer when its width must NOT animate (manual resize, reduced motion).
- *  Only the slide-in/out (translate + opacity) transitions. */
-export const TRANSITION_DRAWER_SLIDE =
-  `transition-[translate,opacity] duration-300 ${TW_EASE} will-change-transform`
-
-/** Resource drawer expand/collapse — slide + an animated width (frame morph).
- *  Tailwind can't compose two `transition-[…]` utilities (both set
- *  transition-property), so width lives in this single combined preset. */
-export const TRANSITION_DRAWER_EXPAND =
   `transition-[translate,opacity,width] duration-300 ${TW_EASE} will-change-[transform,width]`
 
 

--- a/packages/k8s-ui/src/utils/animation.ts
+++ b/packages/k8s-ui/src/utils/animation.ts
@@ -26,10 +26,11 @@ export const DURATION_TOAST_EXIT = 200
  *  large width change advances in small per-frame steps (reads as fluid, not
  *  abrupt). Drives the frame width, the content crossfade, and the JS window
  *  together — keep them in lockstep. */
-export const DURATION_DRAWER_MORPH = 360
-/** Gentle ease for the morph — eased at both ends so the big size change doesn't
- *  lurch at the start the way the front-loaded iOS curve does. */
-export const EASE_DRAWER_MORPH = 'cubic-bezier(0.4, 0, 0.2, 1)'
+export const DURATION_DRAWER_MORPH = 260
+/** Decelerate curve — fast start, gentle settle. Reads as snappy/responsive (the
+ *  earlier ease-in-out's slow start felt sluggish). Safe now that the pinned-layer
+ *  crossfade fixed the reflow that originally needed the gentle start. */
+export const EASE_DRAWER_MORPH = 'cubic-bezier(0.2, 0.8, 0.2, 1)'
 
 // -- Tailwind class presets ---------------------------------------------------
 // Reusable class fragments — import and spread into clsx() calls.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -26,7 +26,7 @@ import { ApplicationsView } from './components/applications/ApplicationsView'
 import { HelmReleaseDrawer } from './components/helm/HelmReleaseDrawer'
 import { PortForwardProvider, PortForwardIndicator, PortForwardPanel } from './components/portforward/PortForwardManager'
 import { DockProvider, BottomDock, useDock, useDockReservedHeight, useOpenLocalTerminal } from './components/dock'
-import { DURATION_DOCK } from '@skyhook-io/k8s-ui/utils/animation'
+import { DURATION_DOCK, DURATION_NORMAL } from '@skyhook-io/k8s-ui/utils/animation'
 import { ContextSwitcher } from './components/ContextSwitcher'
 import { NamespaceSwitcher, type NamespaceSwitcherHandle } from './components/NamespaceSwitcher'
 import { useNavCustomization } from './context/NavCustomization'
@@ -463,6 +463,20 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
   // Drawer expanded state (drawer grows to full width and renders WorkloadView)
   const [drawerExpanded, setDrawerExpanded] = useState(false)
 
+  // True for the duration of an expand/collapse animation. Gates the standalone
+  // WorkloadViewRoute so it can't flash behind the shrinking drawer during the
+  // async navigate(-1) pop on collapse (drawerExpanded flips before the URL does).
+  const [drawerTransitioning, setDrawerTransitioning] = useState(false)
+  const drawerTransitionTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const beginDrawerTransition = useCallback(() => {
+    setDrawerTransitioning(true)
+    if (drawerTransitionTimer.current) clearTimeout(drawerTransitionTimer.current)
+    // Outlast the drawer's own crossfade window (which starts a frame later, in a
+    // layout effect) so the standalone route can't flash behind the last frames.
+    drawerTransitionTimer.current = setTimeout(() => setDrawerTransitioning(false), DURATION_NORMAL + 100)
+  }, [])
+  useEffect(() => () => { if (drawerTransitionTimer.current) clearTimeout(drawerTransitionTimer.current) }, [])
+
   // Suppress the mainView-change clear effect during controlled expand/collapse transitions.
   const suppressViewClearRef = useRef(false)
 
@@ -630,9 +644,10 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
   // Collapse from expanded WorkloadView back to drawer
   const handleCollapseFromExpanded = useCallback(() => {
     suppressViewClearRef.current = true
+    beginDrawerTransition()
     setDrawerExpanded(false)
     navigate(-1)
-  }, [navigate])
+  }, [navigate, beginDrawerTransition])
 
   // Theme toggle for keyboard shortcut
   const { toggleTheme } = useTheme()
@@ -2075,7 +2090,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
         )}
 
         {/* Workload full view (direct URL only — expand from drawer uses drawer's expanded state) */}
-        {mainView === 'workload' && !drawerExpanded && (
+        {mainView === 'workload' && !drawerExpanded && !drawerTransitioning && (
           <WorkloadViewRoute
             onNavigateToResource={(resource) => {
               navigate(buildWorkloadPath(resource))
@@ -2105,6 +2120,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
           onNavigate={(res) => navigateToResource(res)}
           onExpand={(res) => {
             suppressViewClearRef.current = true
+            beginDrawerTransition()
             setDrawerExpanded(true)
             navigate(buildWorkloadPath(res))
           }}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -661,6 +661,21 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
     setSearchParams(p, { replace: true })
   }, [searchParams, setSearchParams])
 
+  // Close the peek and drop any expand flags. Outside /resources the drawer isn't
+  // URL-backed, so a lingering ?full=1/tab would make the next peek reopen
+  // fullscreen instead of as a side drawer. (On /resources, ResourcesView's own
+  // updateURL also scrubs these — deleting them here too is idempotent.)
+  const closeDrawer = useCallback(() => {
+    setSelectedResource(null)
+    setDrawerInitialTab('detail')
+    if (searchParams.has('full') || searchParams.has('tab')) {
+      const p = new URLSearchParams(searchParams)
+      p.delete('full')
+      p.delete('tab')
+      setSearchParams(p, { replace: true })
+    }
+  }, [searchParams, setSearchParams])
+
   // Theme toggle for keyboard shortcut
   const { toggleTheme } = useTheme()
 
@@ -2130,7 +2145,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
           headerHeight={chromeless ? 0 : undefined}
           isOpen={resourceDrawer.isOpen}
           expanded={drawerExpandedProp}
-          onClose={() => { setSelectedResource(null); setDrawerInitialTab('detail') }}
+          onClose={closeDrawer}
           onNavigate={(res) => navigateToResource(res)}
           canCollapseToDrawer={!isMobile}
           onExpand={(_res, opts) => {
@@ -2146,7 +2161,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
           }}
           // On mobile there's no drawer to collapse back to, so the collapse/back
           // control closes the resource (returns to the list) instead.
-          onCollapse={isMobile ? (() => { setSelectedResource(null); setDrawerInitialTab('detail') }) : handleCollapseFromExpanded}
+          onCollapse={isMobile ? closeDrawer : handleCollapseFromExpanded}
           onNavigateToResource={(resource) => {
             // Drill into a related resource while expanded: stay in the over-list
             // overlay for the new resource (pushed, so Back walks resource→resource

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -48,7 +48,7 @@ import { useEventSource } from './hooks/useEventSource'
 import { debugNamespaceLog, useNamespaces, useNamespaceScope, useSetActiveNamespace, useSwitchContext, useAuthMe, useAudit } from './api/client'
 import { buildAuditSeverityMap } from './utils/auditBadges'
 import { routePath, apiUrl, getAuthHeaders, getCredentialsMode } from './api/config'
-import { KeyboardShortcutProvider, useRegisterShortcut, useRegisterShortcuts } from './hooks/useKeyboardShortcuts'
+import { KeyboardShortcutProvider, useRegisterShortcut, useRegisterShortcuts, useSuppressBaseShortcuts } from './hooks/useKeyboardShortcuts'
 import { useAnimatedUnmount } from './hooks/useAnimatedUnmount'
 import { useDocumentTitle } from './hooks/useDocumentTitle'
 import radarLoadingIcon from '@skyhook-io/k8s-ui/assets/radar/radar-icon-loading.svg'
@@ -464,14 +464,20 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
   // ?full=1 on the resources route with a selected resource. Single source of truth
   // so browser Back/Forward and refresh restore it with no parallel state to desync.
   // Standalone fullscreen for non-list surfaces stays on the /workload route.
-  const drawerExpanded = mainView === 'resources' && !!selectedResource && searchParams.get('full') === '1'
+  // Expanded = ?full=1 with a selected resource, on ANY view. The peek drawer (over
+  // the resources list, the topology graph, GitOps, Applications…) grows to
+  // fullscreen over whatever view is underneath, which stays mounted. URL-derived
+  // so Back/Forward/refresh behave (on non-list views the peek isn't URL-backed, so
+  // refresh drops the overlay gracefully — that's an accepted asymmetry).
+  const drawerExpanded = !!selectedResource && searchParams.get('full') === '1'
 
   // On mobile there's no room for the side drawer — a resource detail is always
   // shown full-screen. `expandedView` is the effective fullscreen state (URL flag
-  // OR forced on mobile); it drives the drawer, the background-suppression gate,
-  // and the inert backdrop. `drawerExpanded` stays the URL truth for routing.
+  // OR forced on mobile); it drives the drawer, the inert backdrop, and the
+  // view-level keyboard-shortcut suppression so the hidden page's keys don't fire.
   const isMobile = useMediaQuery('(max-width: 639px)')
   const expandedView = drawerExpanded || (isMobile && !!selectedResource)
+  useSuppressBaseShortcuts(expandedView)
 
   // On a history Pop (back/forward) the URL is authoritative. The URL-write
   // effect, running with not-yet-synced state, would otherwise write the stale
@@ -1965,9 +1971,6 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
             onResourceClickYaml={(res) => navigateToResource(res, 'yaml')}
             onKindChange={() => setSelectedResource(null)}
             onClearNamespaces={clearAllNamespaces}
-            // While a fullscreen overlay covers the list, suppress its row-nav /
-            // Escape / action shortcuts so they don't fire on the hidden background.
-            shortcutsActive={!expandedView}
           />
         )}
 
@@ -2125,22 +2128,16 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
           onClose={() => { setSelectedResource(null); setDrawerInitialTab('detail') }}
           onNavigate={(res) => navigateToResource(res)}
           canCollapseToDrawer={!isMobile}
-          onExpand={(res, opts) => {
-            // Over a resource list → grow into the over-list fullscreen overlay
-            // (?full=1, pushed so Back collapses) and keep the list mounted
-            // underneath. Over any other surface there's nothing to retain, so
-            // open the standalone fullscreen page. Carry the YAML tab when
+          onExpand={(_res, opts) => {
+            // Grow the peek into a fullscreen overlay (?full=1, pushed so Back
+            // collapses) over whatever view is underneath — list, topology graph,
+            // GitOps, Applications — which stays mounted. Carry the YAML tab when
             // expanding from the drawer's YAML view so the editor (and its
             // session-persisted draft) is right there, not behind the Overview tab.
-            if (mainView === 'resources') {
-              const p = new URLSearchParams(searchParams)
-              p.set('full', '1')
-              if (opts?.yaml) p.set('tab', 'yaml')
-              setSearchParams(p)
-            } else {
-              const base = buildWorkloadPath(res)
-              navigate(opts?.yaml ? `${base}${base.includes('?') ? '&' : '?'}tab=yaml` : base)
-            }
+            const p = new URLSearchParams(searchParams)
+            p.set('full', '1')
+            if (opts?.yaml) p.set('tab', 'yaml')
+            setSearchParams(p)
           }}
           // On mobile there's no drawer to collapse back to, so the collapse/back
           // control closes the resource (returns to the list) instead.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -26,7 +26,7 @@ import { ApplicationsView } from './components/applications/ApplicationsView'
 import { HelmReleaseDrawer } from './components/helm/HelmReleaseDrawer'
 import { PortForwardProvider, PortForwardIndicator, PortForwardPanel } from './components/portforward/PortForwardManager'
 import { DockProvider, BottomDock, useDock, useDockReservedHeight, useOpenLocalTerminal } from './components/dock'
-import { DURATION_DOCK, DURATION_NORMAL } from '@skyhook-io/k8s-ui/utils/animation'
+import { DURATION_DOCK } from '@skyhook-io/k8s-ui/utils/animation'
 import { ContextSwitcher } from './components/ContextSwitcher'
 import { NamespaceSwitcher, type NamespaceSwitcherHandle } from './components/NamespaceSwitcher'
 import { useNavCustomization } from './context/NavCustomization'
@@ -460,25 +460,11 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
   // Diagnostics overlay state
   const [showDiagnostics, setShowDiagnostics] = useState(false)
 
-  // Drawer expanded state (drawer grows to full width and renders WorkloadView)
-  const [drawerExpanded, setDrawerExpanded] = useState(false)
-
-  // True for the duration of an expand/collapse animation. Gates the standalone
-  // WorkloadViewRoute so it can't flash behind the shrinking drawer during the
-  // async navigate(-1) pop on collapse (drawerExpanded flips before the URL does).
-  const [drawerTransitioning, setDrawerTransitioning] = useState(false)
-  const drawerTransitionTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const beginDrawerTransition = useCallback(() => {
-    setDrawerTransitioning(true)
-    if (drawerTransitionTimer.current) clearTimeout(drawerTransitionTimer.current)
-    // Outlast the drawer's own crossfade window (which starts a frame later, in a
-    // layout effect) so the standalone route can't flash behind the last frames.
-    drawerTransitionTimer.current = setTimeout(() => setDrawerTransitioning(false), DURATION_NORMAL + 100)
-  }, [])
-  useEffect(() => () => { if (drawerTransitionTimer.current) clearTimeout(drawerTransitionTimer.current) }, [])
-
-  // Suppress the mainView-change clear effect during controlled expand/collapse transitions.
-  const suppressViewClearRef = useRef(false)
+  // Drawer "expanded" (grows to full width over the retained list) is URL-derived:
+  // ?full=1 on the resources route with a selected resource. Single source of truth
+  // so browser Back/Forward and refresh restore it with no parallel state to desync.
+  // Standalone fullscreen for non-list surfaces stays on the /workload route.
+  const drawerExpanded = mainView === 'resources' && !!selectedResource && searchParams.get('full') === '1'
 
   // On a history Pop (back/forward) the URL is authoritative. The URL-write
   // effect, running with not-yet-synced state, would otherwise write the stale
@@ -511,9 +497,9 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
   // URL backing, so the only signal that the page beneath it has navigated is
   // that its owner-key (pathname + ?app) no longer matches where it was opened.
   // Hiding it here, at render time, closes the orphan on Back without adding
-  // another clearing effect that would race the `suppressViewClearRef` lifecycle.
-  // The /resources case is URL-backed and handled above; an expanded drawer
-  // (drawerExpanded) legitimately lives at /workload and must stay open there.
+  // another clearing effect. The /resources case is URL-backed and handled above;
+  // an expanded drawer (drawerExpanded) only exists on /resources (?full=1), so it
+  // is excluded here and never treated as an orphan.
   const peekRouteOrphaned = !!selectedResource && !drawerExpanded && mainView !== 'resources' &&
     peekOwnerKeyRef.current !== null &&
     peekOwnerKeyRef.current !== peekOwnerKey(location.pathname, location.search)
@@ -540,7 +526,6 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
 
     if (prev !== null && prev !== key && selectedResourceRouteMismatch) {
       setSelectedResource(null)
-      setDrawerExpanded(false)
     }
   }, [mainView, currentResourceKindSlug, currentResourceGroup, selectedResourceRouteMismatch])
 
@@ -641,13 +626,18 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
     navigateToResourceList(resource)
   }, [navigate, navigateToHelmRelease, navigateToResourceList])
 
-  // Collapse from expanded WorkloadView back to drawer
+  // Collapse the over-list fullscreen back to the drawer = drop ?full=1 (and the
+  // resource-scoped ?tab) in place. The button means "collapse THIS to a drawer"
+  // regardless of how we got here (expand, deep link, or a drill trail), so it
+  // scrubs rather than walking history — `navigate(-1)` would leave the app on a
+  // deep link, or step back to the previous resource after a drill. Browser Back
+  // keeps its own natural history walk (it pops the ?full=1 entry → collapse).
   const handleCollapseFromExpanded = useCallback(() => {
-    suppressViewClearRef.current = true
-    beginDrawerTransition()
-    setDrawerExpanded(false)
-    navigate(-1)
-  }, [navigate, beginDrawerTransition])
+    const p = new URLSearchParams(searchParams)
+    p.delete('full')
+    p.delete('tab')
+    setSearchParams(p, { replace: true })
+  }, [searchParams, setSearchParams])
 
   // Theme toggle for keyboard shortcut
   const { toggleTheme } = useTheme()
@@ -933,8 +923,8 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
       slowInvalidationRef.current = { updatedKinds: new Set(), timer: null }
 
       // Close any open drawers/overlays — old cluster's resources don't exist on the new one
+      // (?full=1 is cleared by the URL reset below).
       setSelectedResource(null)
-      setDrawerExpanded(false)
       setSelectedHelmRelease(null)
 
       // Reset URL to current view with no resource-specific params.
@@ -1299,13 +1289,6 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
   // But preserve selectedResource when navigating TO resources view (e.g., from Helm deep link)
   const prevMainView = useRef(mainView)
   useEffect(() => {
-    // Skip clearing during controlled expand/collapse transitions
-    if (suppressViewClearRef.current) {
-      suppressViewClearRef.current = false
-      prevMainView.current = mainView
-      return
-    }
-
     const navigatingToResources = mainView === 'resources' && prevMainView.current !== 'resources'
     const navigatingToHelm = mainView === 'helm' && prevMainView.current !== 'helm'
     prevMainView.current = mainView
@@ -1316,6 +1299,8 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
     // asserts. (On a real view switch the URL no longer carries the param, so
     // the clear proceeds.) Without this, deep-linking straight to a Helm
     // release lands on the release list with no drawer.
+    // (drawerExpanded is URL-derived from ?full=1, so leaving /resources drops it
+    // automatically — no explicit reset needed.)
     const params = new URLSearchParams(window.location.search)
     if (!navigatingToResources && !params.has('resource')) {
       setSelectedResource(null)
@@ -1323,7 +1308,6 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
     if (!navigatingToHelm && !params.has('release')) {
       setSelectedHelmRelease(null)
     }
-    setDrawerExpanded(false)
   }, [mainView])
 
   // Clear resource selection when namespaces change — but keep a selection the
@@ -1333,7 +1317,6 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
     const params = new URLSearchParams(window.location.search)
     if (!params.has('resource')) setSelectedResource(null)
     if (!params.has('release')) setSelectedHelmRelease(null)
-    setDrawerExpanded(false)
   }, [namespacesKey])
 
   // Filter topology based on visible kinds (uses displayedTopology which respects pause)
@@ -2089,8 +2072,10 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
           />
         )}
 
-        {/* Workload full view (direct URL only — expand from drawer uses drawer's expanded state) */}
-        {mainView === 'workload' && !drawerExpanded && !drawerTransitioning && (
+        {/* Workload full view — the standalone fullscreen route for non-list
+            surfaces and deep links. Expand-from-drawer is the ?full=1 overlay on
+            /resources instead, so it never routes here. */}
+        {mainView === 'workload' && (
           <WorkloadViewRoute
             onNavigateToResource={(resource) => {
               navigate(buildWorkloadPath(resource))
@@ -2116,18 +2101,35 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
           headerHeight={chromeless ? 0 : undefined}
           isOpen={resourceDrawer.isOpen}
           expanded={drawerExpanded}
-          onClose={() => { setSelectedResource(null); setDrawerInitialTab('detail'); setDrawerExpanded(false) }}
+          onClose={() => { setSelectedResource(null); setDrawerInitialTab('detail') }}
           onNavigate={(res) => navigateToResource(res)}
           onExpand={(res) => {
-            suppressViewClearRef.current = true
-            beginDrawerTransition()
-            setDrawerExpanded(true)
-            navigate(buildWorkloadPath(res))
+            // Over a resource list → grow into the over-list fullscreen overlay
+            // (?full=1, pushed so Back collapses) and keep the list mounted
+            // underneath. Over any other surface there's nothing to retain, so
+            // open the standalone fullscreen page.
+            if (mainView === 'resources') {
+              const p = new URLSearchParams(searchParams)
+              p.set('full', '1')
+              setSearchParams(p)
+            } else {
+              navigate(buildWorkloadPath(res))
+            }
           }}
           onCollapse={handleCollapseFromExpanded}
           onNavigateToResource={(resource) => {
-            setSelectedResource(resource)
-            navigate(buildWorkloadPath(resource), { replace: true })
+            // Drill into a related resource while expanded: stay in the over-list
+            // overlay for the new resource (pushed, so Back walks resource→resource
+            // still expanded). The backdrop list follows to the new kind.
+            const pluralKind = kindToPlural(resource.kind)
+            setSelectedResource({ ...resource, kind: pluralKind })
+            const p = new URLSearchParams()
+            const ns = searchParams.get('namespaces')
+            if (ns) p.set('namespaces', ns)
+            p.set('resource', resource.namespace ? `${resource.namespace}/${resource.name}` : resource.name)
+            if (resource.group) p.set('apiGroup', resource.group)
+            p.set('full', '1')
+            navigate({ pathname: `/resources/${pluralKind}`, search: p.toString() })
           }}
         />
       )}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1947,6 +1947,10 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
             onResourceClickYaml={(res) => navigateToResource(res, 'yaml')}
             onKindChange={() => setSelectedResource(null)}
             onClearNamespaces={clearAllNamespaces}
+            // While the fullscreen overlay (?full=1) covers the list, suppress its
+            // row-nav / Escape / action shortcuts so they don't fire on the hidden
+            // background list underneath.
+            shortcutsActive={!drawerExpanded}
           />
         )}
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -460,24 +460,16 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
   // Diagnostics overlay state
   const [showDiagnostics, setShowDiagnostics] = useState(false)
 
-  // Drawer "expanded" (grows to full width over the retained list) is URL-derived:
-  // ?full=1 on the resources route with a selected resource. Single source of truth
-  // so browser Back/Forward and refresh restore it with no parallel state to desync.
-  // Standalone fullscreen for non-list surfaces stays on the /workload route.
-  // Expanded = ?full=1 with a selected resource, on ANY view. The peek drawer (over
-  // the resources list, the topology graph, GitOps, Applications…) grows to
-  // fullscreen over whatever view is underneath, which stays mounted. URL-derived
-  // so Back/Forward/refresh behave (on non-list views the peek isn't URL-backed, so
-  // refresh drops the overlay gracefully — that's an accepted asymmetry).
+  // The peek drawer "expanded" into a fullscreen overlay = ?full=1 with a selected
+  // resource, on ANY view (resources list, topology graph, GitOps, Applications…) —
+  // the underlying view stays mounted. URL-derived so Back/Forward/refresh behave
+  // (non-list peeks aren't URL-backed, so refresh drops the overlay gracefully).
+  // Used by the routing effects below; the render uses `expandedView` (gated on what
+  // actually renders) — see further down.
   const drawerExpanded = !!selectedResource && searchParams.get('full') === '1'
 
-  // On mobile there's no room for the side drawer — a resource detail is always
-  // shown full-screen. `expandedView` is the effective fullscreen state (URL flag
-  // OR forced on mobile); it drives the drawer, the inert backdrop, and the
-  // view-level keyboard-shortcut suppression so the hidden page's keys don't fire.
+  // On mobile there's no room for the side drawer — a resource detail is always full-screen.
   const isMobile = useMediaQuery('(max-width: 639px)')
-  const expandedView = drawerExpanded || (isMobile && !!selectedResource)
-  useSuppressBaseShortcuts(expandedView)
 
   // On a history Pop (back/forward) the URL is authoritative. The URL-write
   // effect, running with not-yet-synced state, would otherwise write the stale
@@ -553,6 +545,19 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
   const lastResourceRef = useRef(routeSelectedResource)
   if (routeSelectedResource) lastResourceRef.current = routeSelectedResource
   const drawerResource = routeSelectedResource || lastResourceRef.current
+
+  // Effective fullscreen state — keyed off the resource that's ACTUALLY rendering
+  // (routeSelectedResource), not the raw selection, so an orphaned/mismatched peek
+  // can't inert the shell with no visible drawer. ?full=1 on any view, or forced on
+  // mobile (no room for a side drawer). Drives the inert backdrop + shortcut suppression.
+  const expandedView = !!routeSelectedResource && (searchParams.get('full') === '1' || isMobile)
+  useSuppressBaseShortcuts(expandedView)
+  // Held value for the drawer's `expanded` prop so closing an expanded drawer slides
+  // it out at full size instead of running a collapse morph mid-dismiss. Tracks the
+  // live state while a resource is selected; frozen during the slide-out.
+  const lastExpandedRef = useRef(expandedView)
+  if (routeSelectedResource) lastExpandedRef.current = expandedView
+  const drawerExpandedProp = routeSelectedResource ? expandedView : lastExpandedRef.current
 
   const lastHelmReleaseRef = useRef(selectedHelmRelease)
   if (selectedHelmRelease) lastHelmReleaseRef.current = selectedHelmRelease
@@ -2124,7 +2129,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
           // to the top of the content area instead of leaving a 49px gap.
           headerHeight={chromeless ? 0 : undefined}
           isOpen={resourceDrawer.isOpen}
-          expanded={expandedView}
+          expanded={drawerExpandedProp}
           onClose={() => { setSelectedResource(null); setDrawerInitialTab('detail') }}
           onNavigate={(res) => navigateToResource(res)}
           canCollapseToDrawer={!isMobile}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2124,17 +2124,22 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
           expanded={expandedView}
           onClose={() => { setSelectedResource(null); setDrawerInitialTab('detail') }}
           onNavigate={(res) => navigateToResource(res)}
-          onExpand={(res) => {
+          canCollapseToDrawer={!isMobile}
+          onExpand={(res, opts) => {
             // Over a resource list → grow into the over-list fullscreen overlay
             // (?full=1, pushed so Back collapses) and keep the list mounted
             // underneath. Over any other surface there's nothing to retain, so
-            // open the standalone fullscreen page.
+            // open the standalone fullscreen page. Carry the YAML tab when
+            // expanding from the drawer's YAML view so the editor (and its
+            // session-persisted draft) is right there, not behind the Overview tab.
             if (mainView === 'resources') {
               const p = new URLSearchParams(searchParams)
               p.set('full', '1')
+              if (opts?.yaml) p.set('tab', 'yaml')
               setSearchParams(p)
             } else {
-              navigate(buildWorkloadPath(res))
+              const base = buildWorkloadPath(res)
+              navigate(opts?.yaml ? `${base}${base.includes('?') ? '&' : '?'}tab=yaml` : base)
             }
           }}
           // On mobile there's no drawer to collapse back to, so the collapse/back

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -466,6 +466,13 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
   // Standalone fullscreen for non-list surfaces stays on the /workload route.
   const drawerExpanded = mainView === 'resources' && !!selectedResource && searchParams.get('full') === '1'
 
+  // On mobile there's no room for the side drawer — a resource detail is always
+  // shown full-screen. `expandedView` is the effective fullscreen state (URL flag
+  // OR forced on mobile); it drives the drawer, the background-suppression gate,
+  // and the inert backdrop. `drawerExpanded` stays the URL truth for routing.
+  const isMobile = useMediaQuery('(max-width: 639px)')
+  const expandedView = drawerExpanded || (isMobile && !!selectedResource)
+
   // On a history Pop (back/forward) the URL is authoritative. The URL-write
   // effect, running with not-yet-synced state, would otherwise write the stale
   // state back and revert the Pop — and oscillate with the URL→state read
@@ -579,6 +586,10 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
     newParams.delete('kind')
     newParams.delete('mode')
     newParams.delete('group')
+    // Open as a normal drawer — never inherit a stale ?full=1/tab from an
+    // expanded view we're navigating away from (only expand/drill set those).
+    newParams.delete('full')
+    newParams.delete('tab')
     newParams.set('resource', resource.namespace ? `${resource.namespace}/${resource.name}` : resource.name)
     if (resource.group) {
       newParams.set('apiGroup', resource.group)
@@ -1579,6 +1590,8 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
                 params.delete('kind')
                 if (group) params.set('apiGroup', group); else params.delete('apiGroup')
                 params.delete('resource')
+                params.delete('full')
+                params.delete('tab')
                 navigate({ pathname: `/resources/${kind}`, search: params.toString() })
               }}
               onSwitchContext={(name) => switchContext.mutate({ name }, { onSettled: () => setNamespaces([]) })}
@@ -1789,7 +1802,10 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
       )}
 
       {/* Main content - only show when connected and authenticated */}
-      {contentReady && <div className="flex-1 flex overflow-hidden">
+      {/* inert while a fullscreen detail overlay covers the views — keeps the
+          retained background list out of the focus order + a11y tree (the visual
+          cover already blocks pointer events). */}
+      {contentReady && <div className="flex-1 flex overflow-hidden" inert={expandedView}>
         <ErrorBoundary>
         {/* Home dashboard */}
         {mainView === 'home' && (
@@ -1804,6 +1820,8 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
               newParams.delete('kind') // kind is now in the path
               newParams.delete('mode')
               newParams.delete('resource')
+              newParams.delete('full') // don't carry an expanded-overlay flag onto a fresh kind list
+              newParams.delete('tab')
               newParams.delete('group') // Clear topology grouping param to avoid leaking into resources view
               if (apiGroup) {
                 newParams.set('apiGroup', apiGroup)
@@ -1947,10 +1965,9 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
             onResourceClickYaml={(res) => navigateToResource(res, 'yaml')}
             onKindChange={() => setSelectedResource(null)}
             onClearNamespaces={clearAllNamespaces}
-            // While the fullscreen overlay (?full=1) covers the list, suppress its
-            // row-nav / Escape / action shortcuts so they don't fire on the hidden
-            // background list underneath.
-            shortcutsActive={!drawerExpanded}
+            // While a fullscreen overlay covers the list, suppress its row-nav /
+            // Escape / action shortcuts so they don't fire on the hidden background.
+            shortcutsActive={!expandedView}
           />
         )}
 
@@ -2104,7 +2121,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
           // to the top of the content area instead of leaving a 49px gap.
           headerHeight={chromeless ? 0 : undefined}
           isOpen={resourceDrawer.isOpen}
-          expanded={drawerExpanded}
+          expanded={expandedView}
           onClose={() => { setSelectedResource(null); setDrawerInitialTab('detail') }}
           onNavigate={(res) => navigateToResource(res)}
           onExpand={(res) => {
@@ -2120,7 +2137,9 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
               navigate(buildWorkloadPath(res))
             }
           }}
-          onCollapse={handleCollapseFromExpanded}
+          // On mobile there's no drawer to collapse back to, so the collapse/back
+          // control closes the resource (returns to the list) instead.
+          onCollapse={isMobile ? (() => { setSelectedResource(null); setDrawerInitialTab('detail') }) : handleCollapseFromExpanded}
           onNavigateToResource={(resource) => {
             // Drill into a related resource while expanded: stay in the over-list
             // overlay for the new resource (pushed, so Back walks resource→resource
@@ -2196,6 +2215,8 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
             if (group) params.set('apiGroup', group)
             else params.delete('apiGroup')
             params.delete('resource')
+            params.delete('full')
+            params.delete('tab')
             navigate({ pathname: `/resources/${kind}`, search: params.toString() })
             // Focus the table search after navigation — the user came from ⌘K
             // (keyboard flow) and expects to type a resource name immediately.

--- a/web/src/components/resources/ResourceDetailDrawer.tsx
+++ b/web/src/components/resources/ResourceDetailDrawer.tsx
@@ -28,7 +28,7 @@ interface ResourceDetailDrawerProps {
 export function ResourceDetailDrawer(props: ResourceDetailDrawerProps) {
   return (
     <BaseResourceDetailDrawer {...props}>
-      {({ resource, expanded, active, initialTab, onClose, onExpand, onBack, onNavigateToResource, onCollapseToDrawer }) => (
+      {({ resource, expanded, active, initialTab, onClose, onExpand, onExpandIntent, onCancelExpandIntent, onBack, onNavigateToResource, onCollapseToDrawer }) => (
         <WorkloadView
           kind={resource.kind}
           namespace={resource.namespace}
@@ -39,6 +39,8 @@ export function ResourceDetailDrawer(props: ResourceDetailDrawerProps) {
           initialTab={initialTab}
           onClose={onClose}
           onExpand={onExpand}
+          onExpandIntent={onExpandIntent}
+          onCancelExpandIntent={onCancelExpandIntent}
           onBack={onBack ?? (() => {})}
           onNavigateToResource={onNavigateToResource}
           onCollapseToDrawer={onCollapseToDrawer}

--- a/web/src/components/resources/ResourceDetailDrawer.tsx
+++ b/web/src/components/resources/ResourceDetailDrawer.tsx
@@ -14,8 +14,10 @@ interface ResourceDetailDrawerProps {
   expanded?: boolean
   /** Called when user clicks collapse in expanded mode */
   onCollapse?: () => void
-  /** Called when user clicks expand button */
-  onExpand?: (resource: SelectedResource) => void
+  /** Called when user clicks expand button (opts.yaml = expanding from YAML view) */
+  onExpand?: (resource: SelectedResource, opts?: { yaml?: boolean }) => void
+  /** Hide the collapse-to-drawer control (mobile: no drawer to collapse to). Default true. */
+  canCollapseToDrawer?: boolean
   /** Navigate to another resource within expanded WorkloadView */
   onNavigateToResource?: (resource: SelectedResource) => void
   /** Top offset for the drawer (px). Defaults to Radar's 49px header height;

--- a/web/src/components/resources/ResourceDetailDrawer.tsx
+++ b/web/src/components/resources/ResourceDetailDrawer.tsx
@@ -26,13 +26,14 @@ interface ResourceDetailDrawerProps {
 export function ResourceDetailDrawer(props: ResourceDetailDrawerProps) {
   return (
     <BaseResourceDetailDrawer {...props}>
-      {({ resource, expanded, initialTab, onClose, onExpand, onBack, onNavigateToResource, onCollapseToDrawer }) => (
+      {({ resource, expanded, active, initialTab, onClose, onExpand, onBack, onNavigateToResource, onCollapseToDrawer }) => (
         <WorkloadView
           kind={resource.kind}
           namespace={resource.namespace}
           name={resource.name}
           group={resource.group}
           expanded={expanded}
+          active={active}
           initialTab={initialTab}
           onClose={onClose}
           onExpand={onExpand}

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -36,8 +36,6 @@ interface ResourcesViewProps {
   onResourceClickYaml?: NavigateToResource
   onKindChange?: () => void
   onClearNamespaces?: () => void
-  /** When false, list keyboard shortcuts are suppressed (a fullscreen overlay covers the list). */
-  shortcutsActive?: boolean
 }
 
 type SelectedKindInfo = { name: string; kind: string; group: string } | null
@@ -61,7 +59,7 @@ function resourceCountKey(kind: NonNullable<SelectedKindInfo>): string {
   return kind.group ? `${kind.group}/${kind.kind}` : kind.kind
 }
 
-export function ResourcesView({ namespaces, selectedResource, onResourceClick, onResourceClickYaml, onKindChange, onClearNamespaces, shortcutsActive }: ResourcesViewProps) {
+export function ResourcesView({ namespaces, selectedResource, onResourceClick, onResourceClickYaml, onKindChange, onClearNamespaces }: ResourcesViewProps) {
   const location = useLocation()
   const navigate = useNavigate()
 
@@ -322,7 +320,6 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
       onResourceClickYaml={onResourceClickYaml}
       onKindChange={onKindChange}
       onClearNamespaces={onClearNamespaces}
-      shortcutsActive={shortcutsActive}
       // Injected data
       apiResources={apiResources}
       // Lightweight counts for sidebar (replaces 233 parallel queries)

--- a/web/src/components/resources/ResourcesView.tsx
+++ b/web/src/components/resources/ResourcesView.tsx
@@ -36,6 +36,8 @@ interface ResourcesViewProps {
   onResourceClickYaml?: NavigateToResource
   onKindChange?: () => void
   onClearNamespaces?: () => void
+  /** When false, list keyboard shortcuts are suppressed (a fullscreen overlay covers the list). */
+  shortcutsActive?: boolean
 }
 
 type SelectedKindInfo = { name: string; kind: string; group: string } | null
@@ -59,7 +61,7 @@ function resourceCountKey(kind: NonNullable<SelectedKindInfo>): string {
   return kind.group ? `${kind.group}/${kind.kind}` : kind.kind
 }
 
-export function ResourcesView({ namespaces, selectedResource, onResourceClick, onResourceClickYaml, onKindChange, onClearNamespaces }: ResourcesViewProps) {
+export function ResourcesView({ namespaces, selectedResource, onResourceClick, onResourceClickYaml, onKindChange, onClearNamespaces, shortcutsActive }: ResourcesViewProps) {
   const location = useLocation()
   const navigate = useNavigate()
 
@@ -320,6 +322,7 @@ export function ResourcesView({ namespaces, selectedResource, onResourceClick, o
       onResourceClickYaml={onResourceClickYaml}
       onKindChange={onKindChange}
       onClearNamespaces={onClearNamespaces}
+      shortcutsActive={shortcutsActive}
       // Injected data
       apiResources={apiResources}
       // Lightweight counts for sidebar (replaces 233 parallel queries)

--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -164,7 +164,7 @@ interface WorkloadViewProps {
   /** false on the outgoing layer during an expand/collapse crossfade (default true) */
   active?: boolean
   onClose?: () => void
-  onExpand?: () => void
+  onExpand?: (opts?: { yaml?: boolean }) => void
   initialTab?: 'detail' | 'yaml'
   group?: string
 }

--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -165,6 +165,8 @@ interface WorkloadViewProps {
   active?: boolean
   onClose?: () => void
   onExpand?: (opts?: { yaml?: boolean }) => void
+  onExpandIntent?: () => void
+  onCancelExpandIntent?: () => void
   initialTab?: 'detail' | 'yaml'
   group?: string
 }

--- a/web/src/components/workload/WorkloadView.tsx
+++ b/web/src/components/workload/WorkloadView.tsx
@@ -161,6 +161,8 @@ interface WorkloadViewProps {
   onNavigateToResource?: NavigateToResource
   onCollapseToDrawer?: () => void
   expanded?: boolean
+  /** false on the outgoing layer during an expand/collapse crossfade (default true) */
+  active?: boolean
   onClose?: () => void
   onExpand?: () => void
   initialTab?: 'detail' | 'yaml'

--- a/web/src/hooks/useKeyboardShortcuts.tsx
+++ b/web/src/hooks/useKeyboardShortcuts.tsx
@@ -3,5 +3,6 @@ export {
   useRegisterShortcut,
   useRegisterShortcuts,
   useActiveShortcuts,
+  useSuppressBaseShortcuts,
 } from '@skyhook-io/k8s-ui'
 export type { KeyboardShortcut, ShortcutCategory } from '@skyhook-io/k8s-ui'


### PR DESCRIPTION
## Summary

Expanding a resource detail peek used to **navigate away** to the standalone `/workload` route — whatever you were triaging (the resource list, a topology graph, GitOps tree) vanished, and the drawer→fullscreen transition **stuttered** (the fullscreen layout reflowed live inside a still-growing box while collapse hard-snapped).

Now expand **grows the peek into a fullscreen overlay on the same route**, keeping the view underneath mounted, with a smooth GPU-composited morph. You stay in context: browser Back collapses, Forward re-expands, refresh persists the expanded state. `/workload` remains the canonical standalone route for deep-links and non-list surfaces.

## What changed

**Context-retaining overlay (`App`).** Expand sets `?full=1` on the current route (plus `?tab=yaml` when expanding from the drawer's YAML view) instead of pushing `/workload`. The underlying view — resource list, topology graph, GitOps, Applications — stays mounted beneath the overlay. Collapse, back, and close scrub those params in place. Drilling into a related resource while expanded updates `/resources/{kind}?…&full=1`, so browser Back walks resource→resource still expanded. Closing a peek always drops `full`/`tab` so the next peek opens as a side drawer, never a stale fullscreen.

**Smooth morph (`ResourceDetailDrawer`).** A ~260ms frame-morph + content crossfade: both the drawer and fullscreen layouts mount during the transition, each **pinned to its own measured width** so neither reflows or squashes, and the container width animates while their opacity crossfades (transform/opacity only — no per-frame layout). Symmetric expand and collapse; `prefers-reduced-motion` snaps instantly.

**Pre-mount on hover.** Hovering or pressing the expand control pre-mounts the heavy fullscreen layer invisibly (`inert`, `opacity-0`, pinned to full width) so the click reuses it and the morph's first frames aren't competing with the mount cost. The pre-warm is dropped on pointer-leave, close, reduced-motion, and resource change.

**Keyboard + a11y.** `useSuppressBaseShortcuts` drops view-level shortcuts while the overlay covers them (`global` + `drawer`/Escape still resolve); `WorkloadView`'s new `active` prop gates the hidden layer's shortcuts during the morph so it can't capture Escape/`y`/`e`; the backdrop content is `inert` when expanded so it isn't Tab-reachable.

**Mobile.** No side drawer — resource detail is always fullscreen, with a single close affordance (no collapse-to-drawer control).

**URL hygiene (`ResourcesView` + navigators).** List navigators and kind switches drop stale `full`/`tab`, so an expand flag from one peek never leaks onto the next.

## Testing

- `make tsc` ✓ · `make test` (Go + k8s-ui vitest) ✓
- Live-tested on a `kind` cluster, **desktop + mobile (390px)**, on both `/resources` and a **topology** surface (where the peek isn't URL-backed — the harder case):
  - peek → expand → collapse / back / close; the underlying view stays mounted throughout; the fullscreen workload view renders correctly over the graph
  - browser Back collapses, Forward re-expands; refresh persists `?full=1`
  - a fresh peek after an expand→close cycle opens as a **drawer** (no stale-fullscreen carryover), verified on both desktop and the mobile close path
  - hover **pre-mounts** the fullscreen layer (inert, opacity-0, full width) and **cancels on leave**
  - mobile flips to always-fullscreen with a single close control

## Notes

- **Deep-link asymmetry (intentional):** a `?full=1` link reopens fullscreen-over-list; a `/workload` link opens the standalone fullscreen. Both land somewhere sensible.
- Embedded/library consumers that don't wire the expand flow keep the original drawer behavior — the new props are additive.
