### PR TITLE
Keep expanded resource drawer off the sidebar

### DIFF
--- a/packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx
+++ b/packages/k8s-ui/src/components/workload/ResourceDetailDrawer.tsx
@@ -117,8 +117,9 @@ export function ResourceDetailDrawer({ resource, onClose, onNavigate, initialTab
   return (
     <div
       className={clsx(
-        'absolute right-0 bg-theme-surface border-l border-theme-border flex flex-col shadow-drawer z-40',
+        'absolute right-0 bg-theme-surface border-l border-theme-border flex flex-col z-40',
         TRANSITION_DRAWER,
+        !expanded && 'shadow-drawer',
         isOpen
           ? 'translate-x-0 opacity-100'
           : 'translate-x-full opacity-0',


### PR DESCRIPTION
## Summary
Expanded resource detail views should read as a full content-page surface, not as a right-side drawer floating over the app shell. This keeps the normal drawer shadow for collapsed drawers while removing that elevation in expanded mode so the sidebar remains visually untouched.

## What changed
- Applies shadow-drawer only when ResourceDetailDrawer is in its normal collapsed/right-drawer mode.
- Leaves expanded mode flat, matching its page-level layout inside the content column after the nav rail.

## Testing
- make tsc
- make test
- visual-test: ran against kind-radar-gitops-demo; opened the Argo CD Redis pod drawer, expanded it, and verified the expanded view starts after the sidebar with no drawer shadow bleed.

## Notes
- The visual-test console showed expected demo-cluster metrics and Prometheus connection errors; unrelated to this layout change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional class on drawer styling with no behavior, data, or layout logic changes beyond visual elevation.
> 
> **Overview**
> **Expanded resource detail** no longer uses the right-drawer elevation shadow, so it reads as a flat content-page surface beside the nav rail instead of a panel floating over the shell.
> 
> **Collapsed drawer mode** still applies `shadow-drawer` unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3b5200951aa39049cc1128632700edd6a2e5cc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->