### PR TITLE
docs: Traefik renderers + audit checks, RBAC denied-state, response compression (1.8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ Considered for follow-ups, deliberately not in this pass — RBAC audit checks (
 
 Radar includes a built-in [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that lets AI assistants — Claude, Cursor, Copilot, and others — query your cluster through Radar.
 
-Instead of raw `kubectl` output (verbose YAML that burns through LLM context windows), your AI gets pre-processed, token-optimized data: topology graphs, health assessments, deduplicated events, and filtered logs. Read tools are strictly read-only; write tools (restart, scale, sync) are clearly annotated and non-destructive.
+Instead of raw `kubectl` output (verbose YAML that burns through LLM context windows), your AI gets pre-processed, token-optimized data: topology graphs, health assessments, deduplicated events, and filtered logs. Read tools are strictly read-only; write tools (restart, scale, sync, and the like) carry explicit destructive-action hints and run under your cluster's RBAC, so the apiserver enforces what each identity is allowed to do.
 
 Enabled by default. Disable with `--no-mcp`. See the **[MCP Guide](docs/mcp.md)** for setup instructions.
 

--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -189,7 +189,7 @@ rbac:
 
 ### Graceful RBAC Degradation
 
-You see what you have access to — Radar doesn't require cluster-admin. Whatever your ServiceAccount (or the impersonated user, when auth is enabled) can list, Radar shows. Resource types you can't list show an "Access Restricted" message; namespaces you can't access don't appear.
+You see what you have access to — Radar doesn't require cluster-admin. Whatever your ServiceAccount (or the impersonated user, when auth is enabled) can list, Radar shows. Resource types you can't list show an actionable denied-state instead of a misleading "0 / None found": for a core cluster-scoped kind (Node, PV, StorageClass, and the like) your identity can't read, Radar shows a copyable `ClusterRole` + `ClusterRoleBinding` request to hand to a cluster admin (reason `rbac_denied`), and distinguishes that from a kind Radar's own ServiceAccount can't read, where a user-level grant wouldn't help (reason `unavailable`, no snippet). The "Your access on this cluster" dialog lists the core cluster-scoped kinds being hidden alongside your effective rules. Namespaces you can't access don't appear.
 
 A namespace-scoped ServiceAccount (RoleBinding without a ClusterRole) is fully supported — Radar detects this at startup and works within the permitted namespace.
 
@@ -315,6 +315,8 @@ See [Helm Chart README](../deploy/helm/radar/README.md) for all available values
 | `rbac.viewRBAC` | Show RBAC objects in resource browser | `false` |
 | `rbac.traffic` | Read Hubble TLS certs | `true` |
 | `rbac.crdGroups.all` | Wildcard CRD read access | `false` |
+
+**Response compression:** Radar gzip-compresses HTTP responses by default (streaming endpoints like SSE are excluded). The level defaults to `1` (best speed), since on large clusters peak response size coincides with peak CPU. Set the `RADAR_COMPRESS_LEVEL` environment variable (via the chart's pod `env`) to `0` to disable, or `2`-`9` to trade CPU for smaller bodies on bandwidth-bound deployments.
 
 ## Troubleshooting
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -304,6 +304,29 @@ Radar has first-class renderers for **AWS (CAPA)**, **GCP (CAPG)**, and **Azure 
 
 **Resource Browser:** Smart columns show entry points, hosts (extracted from match expressions), route summaries, TLS status, and middleware counts. All 10 Traefik kinds have dedicated table columns — Middleware shows type, TraefikService shows type and targets, ServersTransport shows insecure/serverName, TLSOption shows min TLS version.
 
+**Middleware / MiddlewareTCP Detail View:** type-aware rendering — `chain` links its member middlewares, auth middlewares (basicAuth/digestAuth/forwardAuth) show **secret references only, never values**, `errors` shows its service and status mapping, and unknown/plugin types fall back to a key/value view with nested credential keys redacted.
+
+**TraefikService Detail View:** weighted backends with weight bars, mirroring (primary plus mirrors with percentages), and the load-balancing strategy.
+
+**TLSOption Detail View:** minimum/maximum TLS versions, cipher suites, and client-auth configuration.
+
+**ServersTransport / ServersTransportTCP Detail View:** SNI, an `insecureSkipVerify` warning banner, CA/client-cert secret references, and timeouts.
+
+**Secret safety:** inline credentials in a Traefik CRD spec are redacted in the AI/MCP context (`get_resource`) — credential keys and high-confidence secret patterns are masked — and the Middleware detail renderer shows secret *references* only, never values. Reference names (`secretName`, `basicAuth.secret`, `rootCAsSecrets`) are preserved so you can still diagnose a bad reference. The raw YAML view still shows the object as stored in the cluster.
+
+### Cluster Audit checks
+
+Traefik ships no admission webhook or linter, so a typo'd reference is accepted silently and the route or middleware just doesn't do what you wrote. Radar's Cluster Audit catches the common dangling-reference cases as **Reliability** checks:
+
+| Check | What it catches |
+|-------|-----------------|
+| `traefikRouteMissingService` | An IngressRoute referencing a Service or TraefikService that doesn't exist |
+| `traefikRouteMissingMiddleware` | An IngressRoute referencing a Middleware that doesn't exist |
+| `traefikChainMissingMiddleware` | A `chain` Middleware listing a member Middleware that doesn't exist |
+| `traefikErrorsMissingService` | An `errors` Middleware whose `errors.service` references a Service that doesn't exist |
+
+These checks are **inventory-authoritative**: a "missing X" finding is asserted only when that target kind is served by a cluster-wide synced informer, so a namespace-scoped (RBAC-limited) cache skips the check rather than fabricating a false positive. Matching is group-aware — a `traefik.io` reference is not satisfied by a `traefik.containo.us` object — and cross-namespace references resolve correctly.
+
 ### Supported CRDs
 
 | CRD | Group | Topology | Detail View | AI Summary |
@@ -311,13 +334,15 @@ Radar has first-class renderers for **AWS (CAPA)**, **GCP (CAPG)**, and **Azure 
 | IngressRoute | `traefik.io/v1alpha1` | Yes | Yes | — |
 | IngressRouteTCP | `traefik.io/v1alpha1` | Yes | Yes | — |
 | IngressRouteUDP | `traefik.io/v1alpha1` | Yes | Yes | — |
-| Middleware | `traefik.io/v1alpha1` | Yes | Generic | — |
-| MiddlewareTCP | `traefik.io/v1alpha1` | Yes | Generic | — |
-| TraefikService | `traefik.io/v1alpha1` | Yes | Generic | — |
-| ServersTransport | `traefik.io/v1alpha1` | Yes | Generic | — |
-| ServersTransportTCP | `traefik.io/v1alpha1` | Yes | Generic | — |
-| TLSOption | `traefik.io/v1alpha1` | Yes | Generic | — |
+| Middleware | `traefik.io/v1alpha1` | Yes | Yes | — |
+| MiddlewareTCP | `traefik.io/v1alpha1` | Yes | Yes | — |
+| TraefikService | `traefik.io/v1alpha1` | Yes | Yes | — |
+| ServersTransport | `traefik.io/v1alpha1` | Yes | Yes | — |
+| ServersTransportTCP | `traefik.io/v1alpha1` | Yes | Yes | — |
+| TLSOption | `traefik.io/v1alpha1` | Yes | Yes | — |
 | TLSStore | `traefik.io/v1alpha1` | Yes | Generic | — |
+
+The legacy `traefik.containo.us` API group (pre-v2.11) is warm-listed alongside `traefik.io` so older clusters don't pay first-list latency.
 
 ---
 


### PR DESCRIPTION
## Summary

Brings the OSS docs in line with what shipped in Radar 1.8 (and the 1.7.x releases before it) across three areas: the expanded Traefik integration, the new RBAC denied-state UX, and response compression. These pages are also the upstream source for several public docs pages (synced into `radar-docs`).

## What changed

**`docs/integrations.md` - Traefik**
- Dedicated detail renderers now documented for Middleware/MiddlewareTCP, TraefikService, TLSOption, and ServersTransport/TCP (previously "Generic" in the support table).
- New **Cluster Audit checks** subsection: the four reference-integrity checks (`traefikRouteMissingService`, `traefikRouteMissingMiddleware`, `traefikChainMissingMiddleware`, `traefikErrorsMissingService`), including the inventory-authoritative gating that avoids false positives under a namespace-scoped cache, and group-aware matching.
- Legacy `traefik.containo.us` group warm-listing, and secret-safety scope: inline credentials are redacted in the AI/MCP context and the Middleware renderer shows references only; the raw YAML view still shows the stored object.

**`docs/in-cluster.md`**
- Graceful RBAC Degradation now describes the actionable denied-state for core cluster-scoped kinds: `rbac_denied` (copyable ClusterRole/ClusterRoleBinding request) vs `unavailable` (Radar's own ServiceAccount can't read it, no snippet), plus the "Your access on this cluster" dialog.
- Response compression: `RADAR_COMPRESS_LEVEL` (default 1, 0 disables, streaming endpoints excluded).

**`README.md`**
- Corrected the MCP blurb: write tools carry explicit destructive-action hints and run under your cluster RBAC (the old copy called them "non-destructive").

## Testing

Docs-only change. Verified the synced public pages regenerate cleanly from these sources via the `radar-docs` sync script.

## Related

- Public docs PR (depends on this - the synced Traefik/in-cluster public pages reflect these edits): https://github.com/skyhook-dev/radar-docs/pull/27
- Changelog PR: https://github.com/skyhook-dev/marketing/pull/149

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation changes with no runtime or deployment impact.
> 
> **Overview**
> Documentation-only PR bringing **README**, **`docs/in-cluster.md`**, and **`docs/integrations.md`** in line with Radar 1.8 behavior (upstream for synced public docs).
> 
> **Traefik (`integrations.md`)** — Documents dedicated detail renderers for Middleware/MiddlewareTCP, TraefikService, TLSOption, and ServersTransport/TCP (support table moves from Generic to Yes). Adds **Cluster Audit** reliability checks for dangling Traefik references, including inventory-authoritative gating under RBAC-limited caches and group-aware matching. Covers legacy `traefik.containo.us` warm-listing and **secret safety** (redaction in MCP/`get_resource`; Middleware UI shows references only; raw YAML unchanged).
> 
> **In-cluster (`in-cluster.md`)** — **Graceful RBAC degradation** now describes actionable denied states (`rbac_denied` with copyable ClusterRole/ClusterRoleBinding vs `unavailable` when Radar’s SA can’t read the kind) and the “Your access on this cluster” dialog. Adds **`RADAR_COMPRESS_LEVEL`** for default gzip HTTP compression (SSE excluded).
> 
> **README** — Fixes the MCP blurb: write tools expose destructive-action hints and execute under the caller’s cluster RBAC (replacing incorrect “non-destructive” wording).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f53d392b0e87149e13b97eab9fb24fe4f9e77588. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
