### PR TITLE
fix(web): hang-indent wrapped markdown list items

### DIFF
--- a/web/src/components/ui/Markdown.tsx
+++ b/web/src/components/ui/Markdown.tsx
@@ -39,10 +39,10 @@ export function Markdown({ children, className }: MarkdownProps) {
           </a>
         ),
         ul: ({ children }) => (
-          <ul className="list-disc list-inside my-2 space-y-1 text-theme-text-secondary">{children}</ul>
+          <ul className="list-disc list-outside pl-4 my-2 space-y-1 text-theme-text-secondary">{children}</ul>
         ),
         ol: ({ children }) => (
-          <ol className="list-decimal list-inside my-2 space-y-1 text-theme-text-secondary">{children}</ol>
+          <ol className="list-decimal list-outside pl-4 my-2 space-y-1 text-theme-text-secondary">{children}</ol>
         ),
         li: ({ children }) => (
           <li className="leading-relaxed">{children}</li>


### PR DESCRIPTION
## Summary

Markdown list items whose text wraps to a second line read awkwardly: the continuation line collapsed flush-left under the bullet/number instead of hanging-indented under the first text character. This makes multi-line bullets in Helm chart READMEs (and any other rendered markdown) hard to scan and blurs the boundary between list items.

## What changed

`Markdown.tsx` renders `<ul>`/`<ol>` with `list-outside pl-4` instead of `list-inside`. The marker now sits in the left padding and wrapped lines hang-indent under the item text; nested lists gain an additional level of indent per `pl-4`. Pure styling change — no behavioral or API impact, and the marker stays clear of the container edge in the padded scroll panels these render in (Helm Install Wizard README, Helm release drawer).

## Testing

- `make tsc` — passes.
- Visually verified in the Helm Install Wizard → "Show Chart README" (ingress-nginx): wrapped top-level items and nested ordered lists now hang-indent correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only change to markdown list classes with no API or logic impact.
> 
> **Overview**
> **Markdown list styling** in `Markdown.tsx` now uses **hang-indent** for wrapped bullets and numbers: `<ul>` and `<ol>` switch from `list-inside` to **`list-outside pl-4`**, so markers sit in the left padding and continuation lines align under the first line of text instead of flush-left under the marker.
> 
> This is **presentation-only** for shared markdown rendering (e.g. Helm Install Wizard chart README and Helm release drawer notes). Nested lists pick up an extra indent per `pl-4`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3aa4e7ea68a054c0a8802c8b4c0c15c38ee6b79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->