### PR TITLE
feat(issues): symptom→root cause pointers + secret-producer link

### DIFF
--- a/internal/issues/diagnostic_context.go
+++ b/internal/issues/diagnostic_context.go
@@ -121,6 +121,7 @@ func enrichDiagnosticContext(shaped, flat, grouped []Issue, p Provider) []Issue 
 	}
 
 	out := append([]Issue(nil), shaped...)
+	var incidentEdges []incidentEdge
 	for idx := range out {
 		var b diagnosticContextBuilder
 		i := &out[idx]
@@ -185,15 +186,15 @@ func enrichDiagnosticContext(shaped, flat, grouped []Issue, p Provider) []Issue 
 		}
 
 		if nodeProvider != nil && i.Kind == "Node" && i.Category == issuesapi.CategoryNodeNotReady {
-			addNodeBlastRadiusContext(&b, *i, nodeProvider, flatByResource, groupedByID)
+			addNodeBlastRadiusContext(&b, *i, &incidentEdges, nodeProvider, flatByResource, groupedByID)
 		}
 
 		if pvcProvider != nil && i.Kind == "PersistentVolumeClaim" && pvcRootCategories[i.Category] {
-			addPVCBlastRadiusContext(&b, *i, pvcProvider, flatByResource, groupedByID)
+			addPVCBlastRadiusContext(&b, *i, &incidentEdges, pvcProvider, flatByResource, groupedByID)
 		}
 
 		if metricsAPIFamily(*i) != "" {
-			addAPIServiceHPAContext(&b, *i, flat, groupedByID)
+			addAPIServiceHPAContext(&b, *i, &incidentEdges, flat, groupedByID)
 		}
 
 		if ctx := b.build(); ctx != nil {
@@ -201,7 +202,109 @@ func enrichDiagnosticContext(shaped, flat, grouped []Issue, p Provider) []Issue 
 		}
 	}
 
+	assignIncidentParents(out, incidentEdges)
 	return out
+}
+
+// incidentEdge is a proposed reverse pointer from a downstream symptom (its
+// grouped-issue ID) to a candidate root issue.
+type incidentEdge struct {
+	symptomID string
+	parent    issuesapi.IncidentParent
+}
+
+// recordIncidentEdges proposes a reverse pointer from each linked downstream
+// symptom to this root, capturing the root's subject ref + the link's confidence.
+// Self-edges are skipped. Only called for causal-direction-correct links (node /
+// pvc / apiservice / secret-producer / provisioning); selected_backend never
+// records edges because its related issues are the cause, not the symptom.
+func recordIncidentEdges(edges *[]incidentEdge, root Issue, factType string, conf issuesapi.Confidence, symptomIDs []string) {
+	if edges == nil {
+		return
+	}
+	parent := issuesapi.IncidentParent{
+		ID:         root.ID,
+		Ref:        Ref{Group: root.Group, Kind: root.Kind, Namespace: root.Namespace, Name: root.Name},
+		Category:   root.Category,
+		Confidence: conf,
+		FactType:   factType,
+	}
+	for _, sid := range symptomIDs {
+		if sid == "" || sid == root.ID {
+			continue // self-edge guard
+		}
+		*edges = append(*edges, incidentEdge{symptomID: sid, parent: parent})
+	}
+}
+
+// assignIncidentParents writes the single best IncidentParent onto each symptom
+// issue in `out`, reversing the root→symptom causal links. The rule is
+// deliberately conservative — mis-parenting is the cardinal sin: a higher
+// confidence tier wins (a declared PVC edge beats a co-located node), but among
+// DISTINCT roots at the SAME tier the pointer is left UNSET. Severity is NOT
+// causal evidence, so we never use it to choose between equally-confident roots;
+// an honest "no single root" beats a guessed one. (Cycles can't form with the
+// current link set — node/pvc/apiservice/secret-producer/provisioning roots are
+// never themselves downstream symptoms — so only the self-edge guard is needed.)
+func assignIncidentParents(out []Issue, edges []incidentEdge) {
+	if len(edges) == 0 {
+		return
+	}
+	idx := make(map[string]int, len(out))
+	for i := range out {
+		idx[out[i].ID] = i
+	}
+	cands := make(map[string][]issuesapi.IncidentParent)
+	for _, e := range edges {
+		if _, ok := idx[e.symptomID]; !ok {
+			continue // symptom not in the shaped set (filtered out / not present)
+		}
+		cands[e.symptomID] = append(cands[e.symptomID], e.parent)
+	}
+	for sid, ps := range cands {
+		if best, ok := bestIncidentParent(ps); ok {
+			best := best
+			out[idx[sid]].IncidentParent = &best
+		}
+	}
+}
+
+// bestIncidentParent returns the unique best root by confidence tier. Distinct
+// roots tied at the top tier → no winner (ok=false → omit). The same root
+// proposed by multiple facts collapses to one.
+func bestIncidentParent(ps []issuesapi.IncidentParent) (issuesapi.IncidentParent, bool) {
+	topRank := -1
+	for _, p := range ps {
+		if r := confidenceRank(p.Confidence); r > topRank {
+			topRank = r
+		}
+	}
+	atTop := map[string]issuesapi.IncidentParent{}
+	for _, p := range ps {
+		if confidenceRank(p.Confidence) == topRank {
+			atTop[p.ID] = p
+		}
+	}
+	if len(atTop) != 1 {
+		return issuesapi.IncidentParent{}, false
+	}
+	for _, p := range atTop {
+		return p, true
+	}
+	return issuesapi.IncidentParent{}, false
+}
+
+func confidenceRank(c issuesapi.Confidence) int {
+	switch c {
+	case issuesapi.ConfidenceHigh:
+		return 3
+	case issuesapi.ConfidenceMedium:
+		return 2
+	case issuesapi.ConfidenceLow:
+		return 1
+	default:
+		return 0
+	}
 }
 
 func addServiceBackendContext(b *diagnosticContextBuilder, issue Issue, serviceProvider serviceBackendIssueProvider, flatByResource map[string][]Issue, groupedByID map[string]Issue) {
@@ -261,11 +364,11 @@ func addServiceBackendContext(b *diagnosticContextBuilder, issue Issue, serviceP
 // than repeating the same grouped issue per pod. Non-destructive — it only
 // annotates the root. `accept` is an optional per-symptom guard beyond the
 // category filter.
-func linkBlastRadius(b *diagnosticContextBuilder, pods []Ref, attributable map[issuesapi.Category]bool, flatByResource map[string][]Issue, groupedByID map[string]Issue, factType string, conf issuesapi.Confidence, message string, accept func(Issue) bool) {
+func linkBlastRadius(b *diagnosticContextBuilder, root Issue, edges *[]incidentEdge, pods []Ref, attributable map[issuesapi.Category]bool, flatByResource map[string][]Issue, groupedByID map[string]Issue, factType string, conf issuesapi.Confidence, message string, accept func(Issue) bool) {
 	if len(pods) == 0 {
 		return
 	}
-	related, refs, total := collectRelated(groupedByID, func(yield func(Ref, Issue)) {
+	related, refs, total, relatedIDs := collectRelated(groupedByID, func(yield func(Ref, Issue)) {
 		for _, pod := range pods {
 			key := resourceKey(pod.Group, pod.Kind, pod.Namespace, pod.Name)
 			for _, flatIssue := range flatByResource[key] {
@@ -282,6 +385,7 @@ func linkBlastRadius(b *diagnosticContextBuilder, pods []Ref, attributable map[i
 	if len(related) == 0 {
 		return
 	}
+	recordIncidentEdges(edges, root, factType, conf, relatedIDs)
 	b.add(issuesapi.DiagnosticRoleCandidate, issuesapi.DiagnosticFact{
 		Type:          factType,
 		Message:       withTruncationNote(message, len(related), total),
@@ -310,8 +414,9 @@ func withTruncationNote(message string, shown, total int) string {
 // returned Refs are the affected resources backing the kept groups, so the
 // displayed Refs and RelatedIssues stay consistent past the cap. The emit closure
 // calls yield once per candidate pairing.
-func collectRelated(groupedByID map[string]Issue, emit func(yield func(affected Ref, symptom Issue))) ([]issuesapi.IssueRef, []Ref, int) {
+func collectRelated(groupedByID map[string]Issue, emit func(yield func(affected Ref, symptom Issue))) ([]issuesapi.IssueRef, []Ref, int, []string) {
 	type group struct {
+		id   string
 		rel  issuesapi.IssueRef
 		pods []Ref
 	}
@@ -324,14 +429,14 @@ func collectRelated(groupedByID map[string]Issue, emit func(yield func(affected 
 		}
 		g := byGroup[grouped.ID]
 		if g == nil {
-			g = &group{rel: issueRef(grouped)}
+			g = &group{id: grouped.ID, rel: issueRef(grouped)}
 			byGroup[grouped.ID] = g
 			order = append(order, grouped.ID)
 		}
 		g.pods = append(g.pods, affected)
 	})
 	if len(order) == 0 {
-		return nil, nil, 0
+		return nil, nil, 0, nil
 	}
 	total := len(order)
 	groups := make([]*group, 0, len(order))
@@ -345,6 +450,7 @@ func collectRelated(groupedByID map[string]Issue, emit func(yield func(affected 
 		groups = groups[:maxDiagnosticIssueRefs]
 	}
 	related := make([]issuesapi.IssueRef, 0, len(groups))
+	relatedIDs := make([]string, 0, len(groups))
 	var refs []Ref
 	for _, g := range groups {
 		rel := g.rel
@@ -353,9 +459,10 @@ func collectRelated(groupedByID map[string]Issue, emit func(yield func(affected 
 			rel.Count = len(distinct)
 		}
 		related = append(related, rel)
+		relatedIDs = append(relatedIDs, g.id)
 		refs = append(refs, distinct...)
 	}
-	return related, dedupeRefs(refs), total
+	return related, dedupeRefs(refs), total, relatedIDs
 }
 
 // addAPIServiceHPAContext links an unavailable metrics APIService to the HPAs that
@@ -366,12 +473,12 @@ func collectRelated(groupedByID map[string]Issue, emit func(yield func(affected 
 // naming a metrics-fetch cause (a maxReplicas-capped HPA is excluded). Confidence
 // is medium: the categories and "can't fetch metrics" symptom line up, but we
 // can't prove a specific HPA consumed this exact API server.
-func addAPIServiceHPAContext(b *diagnosticContextBuilder, apisvc Issue, flat []Issue, groupedByID map[string]Issue) {
+func addAPIServiceHPAContext(b *diagnosticContextBuilder, apisvc Issue, edges *[]incidentEdge, flat []Issue, groupedByID map[string]Issue) {
 	family := metricsAPIFamily(apisvc)
 	if family == "" {
 		return
 	}
-	related, _, total := collectRelated(groupedByID, func(yield func(Ref, Issue)) {
+	related, _, total, relatedIDs := collectRelated(groupedByID, func(yield func(Ref, Issue)) {
 		for _, f := range flat {
 			if hpaBlockedOnMetricFamily(f, family) {
 				yield(Ref{Group: f.Group, Kind: f.Kind, Namespace: f.Namespace, Name: f.Name}, f)
@@ -381,6 +488,7 @@ func addAPIServiceHPAContext(b *diagnosticContextBuilder, apisvc Issue, flat []I
 	if len(related) == 0 {
 		return
 	}
+	recordIncidentEdges(edges, apisvc, factAPIServiceHPA, issuesapi.ConfidenceMedium, relatedIDs)
 	b.add(issuesapi.DiagnosticRoleCandidate, issuesapi.DiagnosticFact{
 		Type:          factAPIServiceHPA,
 		Message:       withTruncationNote("Autoscalers that can't read "+family+" metrics may be blocked by this unavailable metrics API.", len(related), total),
@@ -461,7 +569,7 @@ func hpaBlockedOnMetricFamily(i Issue, family string) bool {
 // unrecognized reason) links nothing. No timestamp guard: pod-issue onset isn't
 // reliably recorded (FirstSeen tracks pod age, not failure onset), so a guard
 // would drop legitimate long-running pods while still admitting unrelated ones.
-func addNodeBlastRadiusContext(b *diagnosticContextBuilder, node Issue, np nodeBlastRadiusProvider, flatByResource map[string][]Issue, groupedByID map[string]Issue) {
+func addNodeBlastRadiusContext(b *diagnosticContextBuilder, node Issue, edges *[]incidentEdge, np nodeBlastRadiusProvider, flatByResource map[string][]Issue, groupedByID map[string]Issue) {
 	// A node can hit several pressures at once (memory + disk + PID); those
 	// detections share the node_not_ready ID and group into one issue that keeps
 	// only one representative Reason. Union the attributable categories across ALL
@@ -487,7 +595,7 @@ func addNodeBlastRadiusContext(b *diagnosticContextBuilder, node Issue, np nodeB
 	if len(attributable) == 0 {
 		return
 	}
-	linkBlastRadius(b, np.PodsOnNode(node.Name), attributable, flatByResource, groupedByID,
+	linkBlastRadius(b, node, edges, np.PodsOnNode(node.Name), attributable, flatByResource, groupedByID,
 		factNodeBlastRadius, issuesapi.ConfidenceMedium,
 		"Pods on this node show problems consistent with its resource pressure — the node may be the cause.", nil)
 }
@@ -499,8 +607,8 @@ func addNodeBlastRadiusContext(b *diagnosticContextBuilder, node Issue, np nodeB
 // only linked when its own message confirms a volume cause — a pod can mount the
 // PVC yet be unschedulable for CPU or waiting on unrelated config, which must not
 // be attributed to the PVC.
-func addPVCBlastRadiusContext(b *diagnosticContextBuilder, pvc Issue, pp pvcBlastRadiusProvider, flatByResource map[string][]Issue, groupedByID map[string]Issue) {
-	linkBlastRadius(b, pp.PodsMountingPVC(pvc.Namespace, pvc.Name), pvcAttributableCategories, flatByResource, groupedByID,
+func addPVCBlastRadiusContext(b *diagnosticContextBuilder, pvc Issue, edges *[]incidentEdge, pp pvcBlastRadiusProvider, flatByResource map[string][]Issue, groupedByID map[string]Issue) {
+	linkBlastRadius(b, pvc, edges, pp.PodsMountingPVC(pvc.Namespace, pvc.Name), pvcAttributableCategories, flatByResource, groupedByID,
 		factPVCBlastRadius, issuesapi.ConfidenceHigh,
 		"Pods mounting this PVC are blocked by it.",
 		func(symptom Issue) bool {

--- a/internal/issues/diagnostic_context.go
+++ b/internal/issues/diagnostic_context.go
@@ -24,6 +24,7 @@ const (
 	factPVCBlastRadius      = "pvc_blast_radius"
 	factAPIServiceHPA       = "apiservice_hpa"
 	factProvisioning        = "node_provisioning"
+	factSecretNotReady      = "secret_not_ready"
 )
 
 type serviceBackendIssueProvider interface {
@@ -38,11 +39,37 @@ type pvcBlastRadiusProvider interface {
 	PodsMountingPVC(namespace, pvcName string) []Ref
 }
 
+type secretProducerProvider interface {
+	// PodsDependingOnSecretProducer resolves the producer CR to its target Secret
+	// and the pods referencing it, returning (secretName, pods).
+	PodsDependingOnSecretProducer(group, kind, namespace, name string) (string, []Ref)
+}
+
 // pvcRootCategories are PVC-level problems that block the pods mounting the claim.
 var pvcRootCategories = map[issuesapi.Category]bool{
 	issuesapi.CategoryPVCPending:      true,
 	issuesapi.CategoryPVCLost:         true,
 	issuesapi.CategoryPVCResizeFailed: true,
+}
+
+// secretProducerRootCategories are the not-ready states of a Secret-producing CR
+// (cert-manager Certificate, external-secrets ExternalSecret) — when the producer
+// is failing, the Secret it owns is missing/stale and the pods referencing it
+// can't start.
+var secretProducerRootCategories = map[issuesapi.Category]bool{
+	issuesapi.CategoryCertificateNotReady: true,
+	issuesapi.CategorySecretSyncFailed:    true,
+}
+
+// secretAttributableCategories are the pod-side manifestations of a missing/stale
+// Secret: the structural missing-ref, a stuck container create, an init failure,
+// or a failed secret-volume mount. Broad runtime symptoms (crashloop, image pull)
+// are excluded — referencing the Secret doesn't make them the Secret's fault.
+var secretAttributableCategories = map[issuesapi.Category]bool{
+	issuesapi.CategoryMissingConfigRef:    true,
+	issuesapi.CategoryContainerWaiting:    true,
+	issuesapi.CategoryInitContainerFailed: true,
+	issuesapi.CategoryVolumeMountFailed:   true,
 }
 
 // pvcAttributableCategories are the pod-side manifestations of a broken PVC: the
@@ -115,6 +142,10 @@ func enrichDiagnosticContext(shaped, flat, grouped []Issue, p Provider) []Issue 
 	var pvcProvider pvcBlastRadiusProvider
 	if pp, ok := p.(pvcBlastRadiusProvider); ok {
 		pvcProvider = pp
+	}
+	var secretProvider secretProducerProvider
+	if sp, ok := p.(secretProducerProvider); ok {
+		secretProvider = sp
 	}
 	var changeProvider changeContextProvider
 	if cp, ok := p.(changeContextProvider); ok {
@@ -200,6 +231,10 @@ func enrichDiagnosticContext(shaped, flat, grouped []Issue, p Provider) []Issue 
 
 		if i.Category == issuesapi.CategoryNodeProvisioningFail {
 			addProvisioningContext(&b, *i, &incidentEdges, flat, groupedByID)
+		}
+
+		if secretProvider != nil && secretProducerRootCategories[i.Category] {
+			addSecretProducerContext(&b, *i, &incidentEdges, secretProvider, flatByResource, groupedByID)
 		}
 
 		if ctx := b.build(); ctx != nil {
@@ -670,6 +705,40 @@ func addPVCBlastRadiusContext(b *diagnosticContextBuilder, pvc Issue, edges *[]i
 			}
 			return symptomMentionsVolume(symptom, pvc.Name)
 		})
+}
+
+// addSecretProducerContext links a not-ready Secret-producing CR (Certificate /
+// ExternalSecret) to the pods that reference the Secret it owns and are failing
+// for a config/secret reason. The producer→Secret→Pod chain is declared, so a
+// pod failing on that exact Secret is high-confidence the producer's fault — but
+// a pod can reference the Secret yet fail for an unrelated reason, so the symptom
+// must NAME the Secret (or be a declared secret-volume mount failure), mirroring
+// the PVC volume-evidence gate.
+func addSecretProducerContext(b *diagnosticContextBuilder, root Issue, edges *[]incidentEdge, sp secretProducerProvider, flatByResource map[string][]Issue, groupedByID map[string]Issue) {
+	secretName, pods := sp.PodsDependingOnSecretProducer(root.Group, root.Kind, root.Namespace, root.Name)
+	if secretName == "" || len(pods) == 0 {
+		return
+	}
+	linkBlastRadius(b, root, edges, pods, secretAttributableCategories, flatByResource, groupedByID,
+		factSecretNotReady, issuesapi.ConfidenceHigh,
+		"Pods referencing the Secret this resource manages are blocked by it.",
+		func(symptom Issue) bool {
+			if symptom.Category == issuesapi.CategoryVolumeMountFailed {
+				return true
+			}
+			return mentionsQuotedName(symptom, secretName)
+		})
+}
+
+// mentionsQuotedName reports whether a symptom's text names the resource the way
+// Kubernetes prints it — quoted (`Secret "foo" not found`). A bare substring
+// would fire on any text containing a short name; the quotes anchor it.
+func mentionsQuotedName(symptom Issue, name string) bool {
+	if name == "" {
+		return false
+	}
+	text := strings.ToLower(symptom.Message + " " + symptom.Reason)
+	return strings.Contains(text, `"`+strings.ToLower(name)+`"`)
 }
 
 // symptomMentionsVolume reports whether a scheduling / waiting symptom's text

--- a/internal/issues/diagnostic_context.go
+++ b/internal/issues/diagnostic_context.go
@@ -683,24 +683,26 @@ func addSecretProducerContext(b *diagnosticContextBuilder, root Issue, edges *[]
 	linkBlastRadius(b, root, edges, pods, secretAttributableCategories, flatByResource, groupedByID,
 		factSecretNotReady, issuesapi.ConfidenceHigh,
 		"Pods referencing the Secret this resource manages are blocked by it.",
-		// The symptom must NAME the Secret — a pod can reference the Secret via env/
-		// envFrom/imagePullSecrets yet have a volume_mount_failed on an unrelated
-		// PVC/CSI volume, so (unlike PVC's mount edge) volume_mount_failed is NOT
-		// accepted unconditionally here.
+		// The symptom must name the Secret IN A SECRET CONTEXT — `Secret "foo"` —
+		// not a bare `"foo"`, so a pod that references Secret foo but actually fails
+		// on a ConfigMap/PVC also named foo isn't attributed here. (A pod can
+		// reference the Secret via env/envFrom yet fail on an unrelated volume, so
+		// volume_mount_failed is not accepted unconditionally either.)
 		func(symptom Issue) bool {
-			return mentionsQuotedName(symptom, secretName)
+			return symptomNamesSecret(symptom, secretName)
 		})
 }
 
-// mentionsQuotedName reports whether a symptom's text names the resource the way
-// Kubernetes prints it — quoted (`Secret "foo" not found`). A bare substring
-// would fire on any text containing a short name; the quotes anchor it.
-func mentionsQuotedName(symptom Issue, name string) bool {
+// symptomNamesSecret reports whether a symptom's text names the Secret in a
+// secret context — `secret "foo"`, the way the missing-ref detector and kubelet
+// print it. Requiring the word "secret" before the quoted name (not a bare
+// `"foo"`) keeps a pod that references Secret foo but fails on a ConfigMap/PVC
+// also named foo from being attributed to the Secret producer.
+func symptomNamesSecret(symptom Issue, name string) bool {
 	if name == "" {
 		return false
 	}
-	text := strings.ToLower(symptom.Message + " " + symptom.Reason)
-	return strings.Contains(text, `"`+strings.ToLower(name)+`"`)
+	return strings.Contains(strings.ToLower(symptom.Message+" "+symptom.Reason), `secret "`+strings.ToLower(name)+`"`)
 }
 
 // symptomMentionsVolume reports whether a scheduling / waiting symptom's text

--- a/internal/issues/diagnostic_context.go
+++ b/internal/issues/diagnostic_context.go
@@ -237,7 +237,15 @@ func enrichDiagnosticContext(shaped, flat, grouped []Issue, p Provider) []Issue 
 		}
 	}
 
-	assignIncidentParents(out, incidentEdges)
+	// incident_parent is a property of the GROUPED issue model: the whole-row
+	// coverage gate needs the grouped fan-out (Count), and a grouped subject has a
+	// unique ID. Only assign on the cluster grouped path (grouped != nil). The
+	// ungrouped paths — ?view=flat (raw evidence) and the per-resource regroup —
+	// share issue IDs across members and have Count 0, so coverage can't be checked
+	// and the pointer would attach arbitrarily; they deliberately leave it unset.
+	if len(grouped) > 0 {
+		assignIncidentParents(out, incidentEdges)
+	}
 	return out
 }
 

--- a/internal/issues/diagnostic_context.go
+++ b/internal/issues/diagnostic_context.go
@@ -23,7 +23,6 @@ const (
 	factNodeBlastRadius     = "node_blast_radius"
 	factPVCBlastRadius      = "pvc_blast_radius"
 	factAPIServiceHPA       = "apiservice_hpa"
-	factProvisioning        = "node_provisioning"
 	factSecretNotReady      = "secret_not_ready"
 )
 
@@ -229,10 +228,6 @@ func enrichDiagnosticContext(shaped, flat, grouped []Issue, p Provider) []Issue 
 			addAPIServiceHPAContext(&b, *i, &incidentEdges, flat, groupedByID)
 		}
 
-		if i.Category == issuesapi.CategoryNodeProvisioningFail {
-			addProvisioningContext(&b, *i, &incidentEdges, flat, groupedByID)
-		}
-
 		if secretProvider != nil && secretProducerRootCategories[i.Category] {
 			addSecretProducerContext(&b, *i, &incidentEdges, secretProvider, flatByResource, groupedByID)
 		}
@@ -256,7 +251,7 @@ type incidentEdge struct {
 // recordIncidentEdges proposes a reverse pointer from each linked downstream
 // symptom to this root, capturing the root's subject ref + the link's confidence.
 // Self-edges are skipped. Only called for causal-direction-correct links (node /
-// pvc / apiservice / secret-producer / provisioning); selected_backend never
+// pvc / apiservice / secret-producer); selected_backend never
 // records edges because its related issues are the cause, not the symptom.
 func recordIncidentEdges(edges *[]incidentEdge, root Issue, factType string, conf issuesapi.Confidence, symptomIDs []string) {
 	if edges == nil {
@@ -284,7 +279,7 @@ func recordIncidentEdges(edges *[]incidentEdge, root Issue, factType string, con
 // DISTINCT roots at the SAME tier the pointer is left UNSET. Severity is NOT
 // causal evidence, so we never use it to choose between equally-confident roots;
 // an honest "no single root" beats a guessed one. (Cycles can't form with the
-// current link set — node/pvc/apiservice/secret-producer/provisioning roots are
+// current link set — node/pvc/apiservice/secret-producer roots are
 // never themselves downstream symptoms — so only the self-edge guard is needed.)
 func assignIncidentParents(out []Issue, edges []incidentEdge) {
 	if len(edges) == 0 {
@@ -450,15 +445,21 @@ func withTruncationNote(message string, shown, total int) string {
 // issue, and because folded members all share one issue ID, N pods of one
 // workload collapse to a single related row carrying Count = the distinct
 // affected resources (NOT deduping on the shared issue ID, which would drop pods
-// b..N and leave count=1). Groups are ranked worst-first, then capped; the
-// returned Refs are the affected resources backing the kept groups, so the
-// displayed Refs and RelatedIssues stay consistent past the cap. The emit closure
-// calls yield once per candidate pairing.
+// b..N and leave count=1). Groups are ranked worst-first; the DISPLAY (related +
+// refs) is capped to maxDiagnosticIssueRefs, but `edgeIDs` (for the reverse
+// incident_parent pointer) is returned UNCAPPED — capping it would both drop
+// pointers past the cap and let the cap hide same-tier ambiguity. edgeIDs holds
+// only WHOLLY-COVERED groups: a grouped symptom is attributed to this root only
+// when every one of its members is in the affected set (affected ≥ grouped
+// fan-out). A Deployment whose pods are only partly explained by this root — a
+// subset mounting the PVC, or split across two pressured nodes — is omitted, so
+// the pointer never over-claims a mixed-cause row.
 func collectRelated(groupedByID map[string]Issue, emit func(yield func(affected Ref, symptom Issue))) ([]issuesapi.IssueRef, []Ref, int, []string) {
 	type group struct {
-		id   string
-		rel  issuesapi.IssueRef
-		pods []Ref
+		id         string
+		rel        issuesapi.IssueRef
+		memberSpan int // grouped issue's fan-out (members excl. subject); 0 = single resource
+		pods       []Ref
 	}
 	byGroup := map[string]*group{}
 	var order []string
@@ -469,7 +470,7 @@ func collectRelated(groupedByID map[string]Issue, emit func(yield func(affected 
 		}
 		g := byGroup[grouped.ID]
 		if g == nil {
-			g = &group{id: grouped.ID, rel: issueRef(grouped)}
+			g = &group{id: grouped.ID, rel: issueRef(grouped), memberSpan: grouped.Count}
 			byGroup[grouped.ID] = g
 			order = append(order, grouped.ID)
 		}
@@ -486,11 +487,20 @@ func collectRelated(groupedByID map[string]Issue, emit func(yield func(affected 
 	// Rank by the linked issue's severity BEFORE capping, so the cap keeps the
 	// worst issues (and their resources), not iteration order.
 	sort.SliceStable(groups, func(i, j int) bool { return lessIssueRef(groups[i].rel, groups[j].rel) })
+
+	// edgeIDs: uncapped, wholly-covered groups only — the basis for incident_parent.
+	var edgeIDs []string
+	for _, g := range groups {
+		affected := len(dedupeRefs(g.pods))
+		if affected >= g.memberSpan { // memberSpan 0 (single resource) ⇒ covered
+			edgeIDs = append(edgeIDs, g.id)
+		}
+	}
+
 	if len(groups) > maxDiagnosticIssueRefs {
 		groups = groups[:maxDiagnosticIssueRefs]
 	}
 	related := make([]issuesapi.IssueRef, 0, len(groups))
-	relatedIDs := make([]string, 0, len(groups))
 	var refs []Ref
 	for _, g := range groups {
 		rel := g.rel
@@ -499,10 +509,9 @@ func collectRelated(groupedByID map[string]Issue, emit func(yield func(affected 
 			rel.Count = len(distinct)
 		}
 		related = append(related, rel)
-		relatedIDs = append(relatedIDs, g.id)
 		refs = append(refs, distinct...)
 	}
-	return related, dedupeRefs(refs), total, relatedIDs
+	return related, dedupeRefs(refs), total, edgeIDs
 }
 
 // addAPIServiceHPAContext links an unavailable metrics APIService to the HPAs that
@@ -535,54 +544,6 @@ func addAPIServiceHPAContext(b *diagnosticContextBuilder, apisvc Issue, edges *[
 		Confidence:    issuesapi.ConfidenceMedium,
 		RelatedIssues: related,
 	})
-}
-
-// addProvisioningContext links a failed node provisioner (Karpenter NodeClaim/
-// NodePool, CAPI Machine — anything classified node_provisioning_failed) to the
-// pods stuck Pending because capacity could not be added. Like the APIService→HPA
-// fan-in there is no declared edge (an unschedulable pod doesn't name the
-// provisioner), so it's a cluster-wide fan-in gated on the pod's OWN scheduler
-// message naming a scale-up/capacity failure — NOT taint/affinity/CPU-on-existing,
-// which the provisioner can't fix. Confidence medium: the scale-up signal ties the
-// pod to autoscaling, but co-incidence isn't proof this provisioner is the one.
-func addProvisioningContext(b *diagnosticContextBuilder, root Issue, edges *[]incidentEdge, flat []Issue, groupedByID map[string]Issue) {
-	related, _, total, relatedIDs := collectRelated(groupedByID, func(yield func(Ref, Issue)) {
-		for _, f := range flat {
-			if unschedulableOnCapacity(f) {
-				yield(Ref{Group: f.Group, Kind: f.Kind, Namespace: f.Namespace, Name: f.Name}, f)
-			}
-		}
-	})
-	if len(related) == 0 {
-		return
-	}
-	recordIncidentEdges(edges, root, factProvisioning, issuesapi.ConfidenceMedium, relatedIDs)
-	b.add(issuesapi.DiagnosticRoleCandidate, issuesapi.DiagnosticFact{
-		Type:          factProvisioning,
-		Message:       withTruncationNote("Pods stuck Pending for capacity may be blocked by this failed provisioner.", len(related), total),
-		Confidence:    issuesapi.ConfidenceMedium,
-		RelatedIssues: related,
-	})
-}
-
-// unschedulableOnCapacity reports whether an unschedulable issue's scheduler text
-// blames a scale-up / capacity-provisioning failure (cluster-autoscaler's "pod
-// didn't trigger scale-up", Karpenter's incompatible-nodepool / "did not tolerate",
-// max-size-reached), as opposed to a taint/affinity/insufficient-on-existing-node
-// placement problem the provisioner can't resolve.
-func unschedulableOnCapacity(i Issue) bool {
-	if i.Category != issuesapi.CategoryUnschedulable {
-		return false
-	}
-	text := strings.ToLower(i.Reason + " " + i.Message)
-	return strings.Contains(text, "didn't trigger scale-up") ||
-		strings.Contains(text, "didn't trigger scaleup") ||
-		strings.Contains(text, "scale up") ||
-		strings.Contains(text, "scale-up") ||
-		strings.Contains(text, "max node group size reached") ||
-		strings.Contains(text, "max-node-group-size-reached") ||
-		strings.Contains(text, "incompatible with nodepool") ||
-		strings.Contains(text, "no instance type satisfied")
 }
 
 // metricsAPIFamily classifies an apiservice_unavailable issue by which metrics
@@ -722,10 +683,11 @@ func addSecretProducerContext(b *diagnosticContextBuilder, root Issue, edges *[]
 	linkBlastRadius(b, root, edges, pods, secretAttributableCategories, flatByResource, groupedByID,
 		factSecretNotReady, issuesapi.ConfidenceHigh,
 		"Pods referencing the Secret this resource manages are blocked by it.",
+		// The symptom must NAME the Secret — a pod can reference the Secret via env/
+		// envFrom/imagePullSecrets yet have a volume_mount_failed on an unrelated
+		// PVC/CSI volume, so (unlike PVC's mount edge) volume_mount_failed is NOT
+		// accepted unconditionally here.
 		func(symptom Issue) bool {
-			if symptom.Category == issuesapi.CategoryVolumeMountFailed {
-				return true
-			}
 			return mentionsQuotedName(symptom, secretName)
 		})
 }

--- a/internal/issues/diagnostic_context.go
+++ b/internal/issues/diagnostic_context.go
@@ -702,7 +702,18 @@ func symptomNamesSecret(symptom Issue, name string) bool {
 	if name == "" {
 		return false
 	}
-	return strings.Contains(strings.ToLower(symptom.Message+" "+symptom.Reason), `secret "`+strings.ToLower(name)+`"`)
+	text := strings.ToLower(symptom.Message + " " + symptom.Reason)
+	n := strings.ToLower(name)
+	// Quoted forms — the missing-ref detector + common kubelet text:
+	// `references Secret "foo"`, `secret "foo" not found`, `secrets "foo" not found`.
+	if strings.Contains(text, `secret "`+n+`"`) || strings.Contains(text, `secrets "`+n+`"`) {
+		return true
+	}
+	// Namespaced path form — kubelet's missing-key text `... in Secret <ns>/foo`.
+	if ns := strings.ToLower(symptom.Namespace); ns != "" && strings.Contains(text, "secret "+ns+"/"+n) {
+		return true
+	}
+	return false
 }
 
 // symptomMentionsVolume reports whether a scheduling / waiting symptom's text

--- a/internal/issues/diagnostic_context.go
+++ b/internal/issues/diagnostic_context.go
@@ -23,6 +23,7 @@ const (
 	factNodeBlastRadius     = "node_blast_radius"
 	factPVCBlastRadius      = "pvc_blast_radius"
 	factAPIServiceHPA       = "apiservice_hpa"
+	factProvisioning        = "node_provisioning"
 )
 
 type serviceBackendIssueProvider interface {
@@ -195,6 +196,10 @@ func enrichDiagnosticContext(shaped, flat, grouped []Issue, p Provider) []Issue 
 
 		if metricsAPIFamily(*i) != "" {
 			addAPIServiceHPAContext(&b, *i, &incidentEdges, flat, groupedByID)
+		}
+
+		if i.Category == issuesapi.CategoryNodeProvisioningFail {
+			addProvisioningContext(&b, *i, &incidentEdges, flat, groupedByID)
 		}
 
 		if ctx := b.build(); ctx != nil {
@@ -495,6 +500,54 @@ func addAPIServiceHPAContext(b *diagnosticContextBuilder, apisvc Issue, edges *[
 		Confidence:    issuesapi.ConfidenceMedium,
 		RelatedIssues: related,
 	})
+}
+
+// addProvisioningContext links a failed node provisioner (Karpenter NodeClaim/
+// NodePool, CAPI Machine — anything classified node_provisioning_failed) to the
+// pods stuck Pending because capacity could not be added. Like the APIService→HPA
+// fan-in there is no declared edge (an unschedulable pod doesn't name the
+// provisioner), so it's a cluster-wide fan-in gated on the pod's OWN scheduler
+// message naming a scale-up/capacity failure — NOT taint/affinity/CPU-on-existing,
+// which the provisioner can't fix. Confidence medium: the scale-up signal ties the
+// pod to autoscaling, but co-incidence isn't proof this provisioner is the one.
+func addProvisioningContext(b *diagnosticContextBuilder, root Issue, edges *[]incidentEdge, flat []Issue, groupedByID map[string]Issue) {
+	related, _, total, relatedIDs := collectRelated(groupedByID, func(yield func(Ref, Issue)) {
+		for _, f := range flat {
+			if unschedulableOnCapacity(f) {
+				yield(Ref{Group: f.Group, Kind: f.Kind, Namespace: f.Namespace, Name: f.Name}, f)
+			}
+		}
+	})
+	if len(related) == 0 {
+		return
+	}
+	recordIncidentEdges(edges, root, factProvisioning, issuesapi.ConfidenceMedium, relatedIDs)
+	b.add(issuesapi.DiagnosticRoleCandidate, issuesapi.DiagnosticFact{
+		Type:          factProvisioning,
+		Message:       withTruncationNote("Pods stuck Pending for capacity may be blocked by this failed provisioner.", len(related), total),
+		Confidence:    issuesapi.ConfidenceMedium,
+		RelatedIssues: related,
+	})
+}
+
+// unschedulableOnCapacity reports whether an unschedulable issue's scheduler text
+// blames a scale-up / capacity-provisioning failure (cluster-autoscaler's "pod
+// didn't trigger scale-up", Karpenter's incompatible-nodepool / "did not tolerate",
+// max-size-reached), as opposed to a taint/affinity/insufficient-on-existing-node
+// placement problem the provisioner can't resolve.
+func unschedulableOnCapacity(i Issue) bool {
+	if i.Category != issuesapi.CategoryUnschedulable {
+		return false
+	}
+	text := strings.ToLower(i.Reason + " " + i.Message)
+	return strings.Contains(text, "didn't trigger scale-up") ||
+		strings.Contains(text, "didn't trigger scaleup") ||
+		strings.Contains(text, "scale up") ||
+		strings.Contains(text, "scale-up") ||
+		strings.Contains(text, "max node group size reached") ||
+		strings.Contains(text, "max-node-group-size-reached") ||
+		strings.Contains(text, "incompatible with nodepool") ||
+		strings.Contains(text, "no instance type satisfied")
 }
 
 // metricsAPIFamily classifies an apiservice_unavailable issue by which metrics

--- a/internal/issues/grouping.go
+++ b/internal/issues/grouping.go
@@ -187,30 +187,12 @@ func foldGroup(members []Issue) Issue {
 	g.IssueTiming = groupIssueTiming
 	g.IssueTimingBasis = groupBasis
 
-	// IncidentParent (symptom→root pointer): carry only if every member that has
-	// one agrees on the SAME parent — mirrors the IssueTiming agreement rule above.
-	// A grouped symptom whose members resolve to DIFFERENT roots (one Deployment's
-	// pods spread across two pressured nodes, or a pod mounting two broken PVCs)
-	// has no single honest root, so omit rather than credit the representative's.
-	// (The cluster-wide path assigns IncidentParent after grouping, so this only
-	// fires on the per-resource RelatedIssues regroup, where members were enriched
-	// while still flat.)
-	var groupParent *issuesapi.IncidentParent
-	parentDisagree := false
-	for _, m := range members {
-		if m.IncidentParent == nil {
-			continue
-		}
-		if groupParent == nil {
-			groupParent = m.IncidentParent
-		} else if groupParent.ID != m.IncidentParent.ID {
-			parentDisagree = true
-			break
-		}
-	}
-	if !parentDisagree {
-		g.IncidentParent = groupParent
-	}
+	// IncidentParent is deliberately NOT carried through foldGroup: members of one
+	// grouped symptom share an issue ID, so the per-resource regroup can't tell
+	// which members the root actually covers (the whole-row coverage check that the
+	// cluster-wide path does after grouping isn't reconstructable here). The reverse
+	// pointer therefore ships on the cluster Issues view + MCP only; the per-resource
+	// path leaves it unset rather than over-claim a mixed-cause row.
 
 	// Count is the affected-resource fan-out — the non-subject members under
 	// this subject (the subject is shown separately as the header, not under

--- a/internal/issues/grouping.go
+++ b/internal/issues/grouping.go
@@ -187,6 +187,31 @@ func foldGroup(members []Issue) Issue {
 	g.IssueTiming = groupIssueTiming
 	g.IssueTimingBasis = groupBasis
 
+	// IncidentParent (symptom→root pointer): carry only if every member that has
+	// one agrees on the SAME parent — mirrors the IssueTiming agreement rule above.
+	// A grouped symptom whose members resolve to DIFFERENT roots (one Deployment's
+	// pods spread across two pressured nodes, or a pod mounting two broken PVCs)
+	// has no single honest root, so omit rather than credit the representative's.
+	// (The cluster-wide path assigns IncidentParent after grouping, so this only
+	// fires on the per-resource RelatedIssues regroup, where members were enriched
+	// while still flat.)
+	var groupParent *issuesapi.IncidentParent
+	parentDisagree := false
+	for _, m := range members {
+		if m.IncidentParent == nil {
+			continue
+		}
+		if groupParent == nil {
+			groupParent = m.IncidentParent
+		} else if groupParent.ID != m.IncidentParent.ID {
+			parentDisagree = true
+			break
+		}
+	}
+	if !parentDisagree {
+		g.IncidentParent = groupParent
+	}
+
 	// Count is the affected-resource fan-out — the non-subject members under
 	// this subject (the subject is shown separately as the header, not under
 	// "Affected resources"). Matches the UI/TS contract; captured before the

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -1902,6 +1902,33 @@ func TestIncidentParent_PVCHighPointer(t *testing.T) {
 	}
 }
 
+func TestIncidentParent_CoverageGate(t *testing.T) {
+	// A grouped Deployment unschedulable issue (3 member pods) gets the pointer
+	// only when ALL 3 are explained by the PVC; if only 2 mount it, the row is
+	// mixed-cause and the pointer is omitted (whole-row coverage).
+	mk := func(podsMounting int) []Issue {
+		pvc := Issue{ID: "pvc-1", Kind: "PersistentVolumeClaim", Namespace: "prod", Name: "data", Category: issuesapi.CategoryPVCPending, Severity: SeverityCritical, Reason: "Pending"}
+		dep := Issue{ID: "g", Kind: "Deployment", Namespace: "prod", Name: "web", Category: issuesapi.CategoryUnschedulable, Severity: SeverityCritical, Count: 3}
+		flat := []Issue{pvc}
+		var mounting []Ref
+		for n, name := range []string{"web-a", "web-b", "web-c"} {
+			flat = append(flat, Issue{ID: "g", Kind: "Pod", Namespace: "prod", Name: name, Category: issuesapi.CategoryUnschedulable, Severity: SeverityCritical,
+				Message: "pod has unbound immediate PersistentVolumeClaims"})
+			if n < podsMounting {
+				mounting = append(mounting, Ref{Kind: "Pod", Namespace: "prod", Name: name})
+			}
+		}
+		p := &fakeProvider{podsMountingPVC: map[string][]Ref{"prod/data": mounting}}
+		return enrichDiagnosticContext([]Issue{pvc, dep}, flat, []Issue{dep}, p)
+	}
+	if got := findByID(mk(3), "g").IncidentParent; got == nil || got.ID != "pvc-1" {
+		t.Errorf("full coverage (3/3) should link, got %+v", got)
+	}
+	if got := findByID(mk(2), "g").IncidentParent; got != nil {
+		t.Errorf("partial coverage (2/3) must omit the pointer, got %+v", *got)
+	}
+}
+
 func TestIncidentParent_NodeMediumPointer(t *testing.T) {
 	node := Issue{ID: "node-1", Kind: "Node", Name: "n1", Category: issuesapi.CategoryNodeNotReady, Severity: SeverityCritical, Reason: "MemoryPressure"}
 	sym := Issue{ID: "oom-1", Kind: "Pod", Namespace: "prod", Name: "web-a", Category: issuesapi.CategoryOOMKilled, Severity: SeverityCritical}
@@ -1957,60 +1984,5 @@ func TestSecretProducerContext(t *testing.T) {
 	}
 	if got := findByID(out, "cw-1"); got.IncidentParent != nil {
 		t.Fatalf("unrelated container-waiting pod must not be attributed, got %+v", *got.IncidentParent)
-	}
-}
-
-func TestProvisioningContext(t *testing.T) {
-	// A failed provisioner links pods stuck for capacity ("didn't trigger
-	// scale-up"), but NOT a pod unschedulable for a taint the provisioner can't fix.
-	prov := Issue{ID: "np-1", Kind: "NodeClaim", Group: "karpenter.sh", Name: "default-abc", Category: issuesapi.CategoryNodeProvisioningFail, Severity: SeverityCritical, Reason: "Launch failed"}
-	capacity := Issue{ID: "u-1", Kind: "Pod", Namespace: "prod", Name: "web-a", Category: issuesapi.CategoryUnschedulable, Severity: SeverityWarning,
-		Message: "0/3 nodes are available; pod didn't trigger scale-up: max node group size reached"}
-	taint := Issue{ID: "u-2", Kind: "Pod", Namespace: "prod", Name: "web-b", Category: issuesapi.CategoryUnschedulable, Severity: SeverityWarning,
-		Message: "0/3 nodes are available: 3 node(s) had untolerated taint {dedicated: gpu}"}
-
-	out := enrichDiagnosticContext([]Issue{prov, capacity, taint}, []Issue{prov, capacity, taint}, nil, &fakeProvider{})
-	// Forward fact on the provisioner root.
-	root := findByID(out, "np-1")
-	if root.DiagnosticContext == nil {
-		t.Fatal("provisioner root got no diagnostic context")
-	}
-	var fact *issuesapi.DiagnosticFact
-	for i := range root.DiagnosticContext.Facts {
-		if root.DiagnosticContext.Facts[i].Type == factProvisioning {
-			fact = &root.DiagnosticContext.Facts[i]
-		}
-	}
-	if fact == nil || len(fact.RelatedIssues) != 1 || fact.RelatedIssues[0].Ref.Name != "web-a" {
-		t.Fatalf("expected only the scale-up pod linked, got %+v", fact)
-	}
-	// Reverse pointer on the capacity pod; none on the taint pod.
-	if got := findByID(out, "u-1"); got.IncidentParent == nil || got.IncidentParent.ID != "np-1" || got.IncidentParent.Confidence != issuesapi.ConfidenceMedium {
-		t.Fatalf("capacity pod should point to the provisioner (medium), got %+v", got.IncidentParent)
-	}
-	if got := findByID(out, "u-2"); got.IncidentParent != nil {
-		t.Fatalf("taint-unschedulable pod must not be attributed to the provisioner, got %+v", *got.IncidentParent)
-	}
-}
-
-func TestIncidentParent_FoldGroupAgreement(t *testing.T) {
-	// Two pod members of one grouped issue resolve to DIFFERENT node parents →
-	// the grouped row must omit IncidentParent (no honest single root).
-	nodeA := hi("node-A")
-	nodeB := hi("node-B")
-	mixed := GroupIssues([]Issue{
-		{ID: "g1", Kind: "Pod", Namespace: "p", Name: "a", Category: issuesapi.CategoryOOMKilled, Severity: SeverityCritical, IncidentParent: &nodeA},
-		{ID: "g1", Kind: "Pod", Namespace: "p", Name: "b", Category: issuesapi.CategoryOOMKilled, Severity: SeverityCritical, IncidentParent: &nodeB},
-	})
-	if len(mixed) != 1 || mixed[0].IncidentParent != nil {
-		t.Fatalf("disagreeing members must omit IncidentParent, got %+v", mixed[0].IncidentParent)
-	}
-	// Agreeing members → carried.
-	same := GroupIssues([]Issue{
-		{ID: "g2", Kind: "Pod", Namespace: "p", Name: "a", Category: issuesapi.CategoryOOMKilled, Severity: SeverityCritical, IncidentParent: &nodeA},
-		{ID: "g2", Kind: "Pod", Namespace: "p", Name: "b", Category: issuesapi.CategoryOOMKilled, Severity: SeverityCritical, IncidentParent: &nodeA},
-	})
-	if same[0].IncidentParent == nil || same[0].IncidentParent.ID != "node-A" {
-		t.Fatalf("agreeing members must carry IncidentParent, got %+v", same[0].IncidentParent)
 	}
 }

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -1829,3 +1829,110 @@ func TestMetricsAPIFamily_ExactGroupMatch(t *testing.T) {
 		}
 	}
 }
+
+func hi(id string) issuesapi.IncidentParent {
+	return issuesapi.IncidentParent{ID: id, Confidence: issuesapi.ConfidenceHigh}
+}
+func med(id string) issuesapi.IncidentParent {
+	return issuesapi.IncidentParent{ID: id, Confidence: issuesapi.ConfidenceMedium}
+}
+
+func TestBestIncidentParent(t *testing.T) {
+	cases := []struct {
+		name   string
+		ps     []issuesapi.IncidentParent
+		wantID string // "" = expect omit
+	}{
+		{"single high", []issuesapi.IncidentParent{hi("A")}, "A"},
+		{"high beats medium", []issuesapi.IncidentParent{med("B"), hi("A")}, "A"},
+		{"same root twice collapses", []issuesapi.IncidentParent{med("A"), med("A")}, "A"},
+		{"distinct same-tier omit (no severity tiebreak)", []issuesapi.IncidentParent{med("A"), med("B")}, ""},
+		{"distinct high tie omit", []issuesapi.IncidentParent{hi("A"), hi("B")}, ""},
+		{"empty omit", nil, ""},
+	}
+	for _, tc := range cases {
+		got, ok := bestIncidentParent(tc.ps)
+		if tc.wantID == "" {
+			if ok {
+				t.Errorf("%s: expected omit, got %q", tc.name, got.ID)
+			}
+			continue
+		}
+		if !ok || got.ID != tc.wantID {
+			t.Errorf("%s: got (%q, %v), want %q", tc.name, got.ID, ok, tc.wantID)
+		}
+	}
+}
+
+func findByID(out []Issue, id string) *Issue {
+	for i := range out {
+		if out[i].ID == id {
+			return &out[i]
+		}
+	}
+	return nil
+}
+
+func TestIncidentParent_PVCHighPointer(t *testing.T) {
+	pvc := Issue{ID: "pvc-1", Kind: "PersistentVolumeClaim", Namespace: "prod", Name: "data", Category: issuesapi.CategoryPVCPending, Severity: SeverityCritical, Reason: "Pending"}
+	sym := Issue{ID: "sym-1", Kind: "Pod", Namespace: "prod", Name: "db-0", Category: issuesapi.CategoryUnschedulable, Severity: SeverityCritical,
+		Message: "0/3 nodes are available: pod has unbound immediate PersistentVolumeClaims"}
+	p := &fakeProvider{podsMountingPVC: map[string][]Ref{"prod/data": {{Kind: "Pod", Namespace: "prod", Name: "db-0"}}}}
+	out := enrichDiagnosticContext([]Issue{pvc, sym}, []Issue{pvc, sym}, nil, p)
+	got := findByID(out, "sym-1")
+	if got.IncidentParent == nil {
+		t.Fatal("symptom pod got no IncidentParent")
+	}
+	if got.IncidentParent.ID != "pvc-1" || got.IncidentParent.Confidence != issuesapi.ConfidenceHigh || got.IncidentParent.FactType != factPVCBlastRadius {
+		t.Errorf("IncidentParent = %+v, want pvc-1/high/pvc_blast_radius", *got.IncidentParent)
+	}
+	// The root itself must NOT get a parent.
+	if findByID(out, "pvc-1").IncidentParent != nil {
+		t.Error("the PVC root must not get an IncidentParent")
+	}
+}
+
+func TestIncidentParent_NodeMediumPointer(t *testing.T) {
+	node := Issue{ID: "node-1", Kind: "Node", Name: "n1", Category: issuesapi.CategoryNodeNotReady, Severity: SeverityCritical, Reason: "MemoryPressure"}
+	sym := Issue{ID: "oom-1", Kind: "Pod", Namespace: "prod", Name: "web-a", Category: issuesapi.CategoryOOMKilled, Severity: SeverityCritical}
+	p := &fakeProvider{podsOnNode: map[string][]Ref{"n1": {{Kind: "Pod", Namespace: "prod", Name: "web-a"}}}}
+	out := enrichDiagnosticContext([]Issue{node, sym}, []Issue{node, sym}, nil, p)
+	got := findByID(out, "oom-1")
+	if got.IncidentParent == nil || got.IncidentParent.ID != "node-1" || got.IncidentParent.Confidence != issuesapi.ConfidenceMedium {
+		t.Fatalf("expected medium IncidentParent → node-1, got %+v", got.IncidentParent)
+	}
+}
+
+func TestIncidentParent_SelectedBackendNoPointer(t *testing.T) {
+	// A Service with no endpoints because its backend pods crashloop — the pods
+	// are the CAUSE, not a symptom of the Service, so NO reverse pointer.
+	svc := Issue{ID: "svc-1", Kind: "Service", Namespace: "prod", Name: "api", Category: issuesapi.CategoryServiceNoEndpoints, Severity: SeverityCritical, Reason: "0/2 selected pods ready"}
+	pod := Issue{ID: "crash-1", Kind: "Pod", Namespace: "prod", Name: "api-x", Category: issuesapi.CategoryCrashLoop, Severity: SeverityCritical}
+	p := &fakeProvider{selectedPods: map[string][]Ref{"prod/api": {{Kind: "Pod", Namespace: "prod", Name: "api-x"}}}}
+	out := enrichDiagnosticContext([]Issue{svc, pod}, []Issue{svc, pod}, nil, p)
+	if got := findByID(out, "crash-1"); got.IncidentParent != nil {
+		t.Fatalf("selected_backend must not create a reverse pointer (inverted direction), got %+v", *got.IncidentParent)
+	}
+}
+
+func TestIncidentParent_FoldGroupAgreement(t *testing.T) {
+	// Two pod members of one grouped issue resolve to DIFFERENT node parents →
+	// the grouped row must omit IncidentParent (no honest single root).
+	nodeA := hi("node-A")
+	nodeB := hi("node-B")
+	mixed := GroupIssues([]Issue{
+		{ID: "g1", Kind: "Pod", Namespace: "p", Name: "a", Category: issuesapi.CategoryOOMKilled, Severity: SeverityCritical, IncidentParent: &nodeA},
+		{ID: "g1", Kind: "Pod", Namespace: "p", Name: "b", Category: issuesapi.CategoryOOMKilled, Severity: SeverityCritical, IncidentParent: &nodeB},
+	})
+	if len(mixed) != 1 || mixed[0].IncidentParent != nil {
+		t.Fatalf("disagreeing members must omit IncidentParent, got %+v", mixed[0].IncidentParent)
+	}
+	// Agreeing members → carried.
+	same := GroupIssues([]Issue{
+		{ID: "g2", Kind: "Pod", Namespace: "p", Name: "a", Category: issuesapi.CategoryOOMKilled, Severity: SeverityCritical, IncidentParent: &nodeA},
+		{ID: "g2", Kind: "Pod", Namespace: "p", Name: "b", Category: issuesapi.CategoryOOMKilled, Severity: SeverityCritical, IncidentParent: &nodeA},
+	})
+	if same[0].IncidentParent == nil || same[0].IncidentParent.ID != "node-A" {
+		t.Fatalf("agreeing members must carry IncidentParent, got %+v", same[0].IncidentParent)
+	}
+}

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -32,7 +32,13 @@ type fakeProvider struct {
 	selectedPods    map[string][]Ref
 	podsOnNode      map[string][]Ref
 	podsMountingPVC map[string][]Ref
+	secretProducer  map[string]secretProducerResult
 	change          map[string]*issuesapi.ChangeContext
+}
+
+type secretProducerResult struct {
+	name string
+	pods []Ref
 }
 
 func (f *fakeProvider) DetectProblems(_ []string) []k8s.Detection       { return f.problems }
@@ -68,6 +74,10 @@ func (f *fakeProvider) PodsMountingPVC(namespace, pvcName string) []Ref {
 }
 func (f *fakeProvider) PodsOnNode(nodeName string) []Ref {
 	return f.podsOnNode[nodeName]
+}
+func (f *fakeProvider) PodsDependingOnSecretProducer(_, _, namespace, name string) (string, []Ref) {
+	r := f.secretProducer[namespace+"/"+name]
+	return r.name, r.pods
 }
 
 func (f *fakeProvider) ChangeContextForIssue(i Issue) *issuesapi.ChangeContext {
@@ -1912,6 +1922,41 @@ func TestIncidentParent_SelectedBackendNoPointer(t *testing.T) {
 	out := enrichDiagnosticContext([]Issue{svc, pod}, []Issue{svc, pod}, nil, p)
 	if got := findByID(out, "crash-1"); got.IncidentParent != nil {
 		t.Fatalf("selected_backend must not create a reverse pointer (inverted direction), got %+v", *got.IncidentParent)
+	}
+}
+
+func TestSecretProducerContext(t *testing.T) {
+	// A not-ready Certificate links the pod whose missing-ref names its Secret,
+	// but NOT a pod that references the Secret yet fails for an unrelated reason.
+	cert := Issue{ID: "cert-1", Kind: "Certificate", Group: "cert-manager.io", Namespace: "prod", Name: "web-tls", Category: issuesapi.CategoryCertificateNotReady, Severity: SeverityCritical, Reason: "Issuing"}
+	blocked := Issue{ID: "mr-1", Kind: "Pod", Namespace: "prod", Name: "web-a", Category: issuesapi.CategoryMissingConfigRef, Severity: SeverityCritical,
+		Message: `Secret "web-tls-secret" referenced in volume does not exist`}
+	unrelated := Issue{ID: "cw-1", Kind: "Pod", Namespace: "prod", Name: "web-b", Category: issuesapi.CategoryContainerWaiting, Severity: SeverityWarning,
+		Reason: "ContainerCreating", Message: "waiting on something else entirely"}
+
+	p := &fakeProvider{secretProducer: map[string]secretProducerResult{
+		"prod/web-tls": {name: "web-tls-secret", pods: []Ref{
+			{Kind: "Pod", Namespace: "prod", Name: "web-a"},
+			{Kind: "Pod", Namespace: "prod", Name: "web-b"},
+		}},
+	}}
+	out := enrichDiagnosticContext([]Issue{cert, blocked, unrelated}, []Issue{cert, blocked, unrelated}, nil, p)
+
+	root := findByID(out, "cert-1")
+	var fact *issuesapi.DiagnosticFact
+	for i := range root.DiagnosticContext.Facts {
+		if root.DiagnosticContext.Facts[i].Type == factSecretNotReady {
+			fact = &root.DiagnosticContext.Facts[i]
+		}
+	}
+	if fact == nil || len(fact.RelatedIssues) != 1 || fact.RelatedIssues[0].Ref.Name != "web-a" {
+		t.Fatalf("expected only the Secret-naming pod linked, got %+v", fact)
+	}
+	if got := findByID(out, "mr-1"); got.IncidentParent == nil || got.IncidentParent.ID != "cert-1" || got.IncidentParent.Confidence != issuesapi.ConfidenceHigh {
+		t.Fatalf("blocked pod should point to the Certificate (high), got %+v", got.IncidentParent)
+	}
+	if got := findByID(out, "cw-1"); got.IncidentParent != nil {
+		t.Fatalf("unrelated container-waiting pod must not be attributed, got %+v", *got.IncidentParent)
 	}
 }
 

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -1888,7 +1888,7 @@ func TestIncidentParent_PVCHighPointer(t *testing.T) {
 	sym := Issue{ID: "sym-1", Kind: "Pod", Namespace: "prod", Name: "db-0", Category: issuesapi.CategoryUnschedulable, Severity: SeverityCritical,
 		Message: "0/3 nodes are available: pod has unbound immediate PersistentVolumeClaims"}
 	p := &fakeProvider{podsMountingPVC: map[string][]Ref{"prod/data": {{Kind: "Pod", Namespace: "prod", Name: "db-0"}}}}
-	out := enrichDiagnosticContext([]Issue{pvc, sym}, []Issue{pvc, sym}, nil, p)
+	out := enrichDiagnosticContext([]Issue{pvc, sym}, []Issue{pvc, sym}, []Issue{pvc, sym}, p)
 	got := findByID(out, "sym-1")
 	if got.IncidentParent == nil {
 		t.Fatal("symptom pod got no IncidentParent")
@@ -1933,7 +1933,7 @@ func TestIncidentParent_NodeMediumPointer(t *testing.T) {
 	node := Issue{ID: "node-1", Kind: "Node", Name: "n1", Category: issuesapi.CategoryNodeNotReady, Severity: SeverityCritical, Reason: "MemoryPressure"}
 	sym := Issue{ID: "oom-1", Kind: "Pod", Namespace: "prod", Name: "web-a", Category: issuesapi.CategoryOOMKilled, Severity: SeverityCritical}
 	p := &fakeProvider{podsOnNode: map[string][]Ref{"n1": {{Kind: "Pod", Namespace: "prod", Name: "web-a"}}}}
-	out := enrichDiagnosticContext([]Issue{node, sym}, []Issue{node, sym}, nil, p)
+	out := enrichDiagnosticContext([]Issue{node, sym}, []Issue{node, sym}, []Issue{node, sym}, p)
 	got := findByID(out, "oom-1")
 	if got.IncidentParent == nil || got.IncidentParent.ID != "node-1" || got.IncidentParent.Confidence != issuesapi.ConfidenceMedium {
 		t.Fatalf("expected medium IncidentParent → node-1, got %+v", got.IncidentParent)
@@ -1973,7 +1973,7 @@ func TestSecretProducerContext(t *testing.T) {
 			{Kind: "Pod", Namespace: "prod", Name: "web-c"},
 		}},
 	}}
-	out := enrichDiagnosticContext([]Issue{cert, blocked, unrelated, sameName}, []Issue{cert, blocked, unrelated, sameName}, nil, p)
+	out := enrichDiagnosticContext([]Issue{cert, blocked, unrelated, sameName}, []Issue{cert, blocked, unrelated, sameName}, []Issue{cert, blocked, unrelated, sameName}, p)
 
 	root := findByID(out, "cert-1")
 	var fact *issuesapi.DiagnosticFact

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -1915,6 +1915,39 @@ func TestIncidentParent_SelectedBackendNoPointer(t *testing.T) {
 	}
 }
 
+func TestProvisioningContext(t *testing.T) {
+	// A failed provisioner links pods stuck for capacity ("didn't trigger
+	// scale-up"), but NOT a pod unschedulable for a taint the provisioner can't fix.
+	prov := Issue{ID: "np-1", Kind: "NodeClaim", Group: "karpenter.sh", Name: "default-abc", Category: issuesapi.CategoryNodeProvisioningFail, Severity: SeverityCritical, Reason: "Launch failed"}
+	capacity := Issue{ID: "u-1", Kind: "Pod", Namespace: "prod", Name: "web-a", Category: issuesapi.CategoryUnschedulable, Severity: SeverityWarning,
+		Message: "0/3 nodes are available; pod didn't trigger scale-up: max node group size reached"}
+	taint := Issue{ID: "u-2", Kind: "Pod", Namespace: "prod", Name: "web-b", Category: issuesapi.CategoryUnschedulable, Severity: SeverityWarning,
+		Message: "0/3 nodes are available: 3 node(s) had untolerated taint {dedicated: gpu}"}
+
+	out := enrichDiagnosticContext([]Issue{prov, capacity, taint}, []Issue{prov, capacity, taint}, nil, &fakeProvider{})
+	// Forward fact on the provisioner root.
+	root := findByID(out, "np-1")
+	if root.DiagnosticContext == nil {
+		t.Fatal("provisioner root got no diagnostic context")
+	}
+	var fact *issuesapi.DiagnosticFact
+	for i := range root.DiagnosticContext.Facts {
+		if root.DiagnosticContext.Facts[i].Type == factProvisioning {
+			fact = &root.DiagnosticContext.Facts[i]
+		}
+	}
+	if fact == nil || len(fact.RelatedIssues) != 1 || fact.RelatedIssues[0].Ref.Name != "web-a" {
+		t.Fatalf("expected only the scale-up pod linked, got %+v", fact)
+	}
+	// Reverse pointer on the capacity pod; none on the taint pod.
+	if got := findByID(out, "u-1"); got.IncidentParent == nil || got.IncidentParent.ID != "np-1" || got.IncidentParent.Confidence != issuesapi.ConfidenceMedium {
+		t.Fatalf("capacity pod should point to the provisioner (medium), got %+v", got.IncidentParent)
+	}
+	if got := findByID(out, "u-2"); got.IncidentParent != nil {
+		t.Fatalf("taint-unschedulable pod must not be attributed to the provisioner, got %+v", *got.IncidentParent)
+	}
+}
+
 func TestIncidentParent_FoldGroupAgreement(t *testing.T) {
 	// Two pod members of one grouped issue resolve to DIFFERENT node parents →
 	// the grouped row must omit IncidentParent (no honest single root).

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -1902,6 +1902,22 @@ func TestIncidentParent_PVCHighPointer(t *testing.T) {
 	}
 }
 
+func TestIncidentParent_FlatViewNoPointer(t *testing.T) {
+	// Ungrouped mode (?view=flat, per-resource regroup): grouped is nil, so the
+	// whole-row coverage gate can't be evaluated (members share an ID, Count 0).
+	// incident_parent must NOT be assigned — it's a grouped-model property.
+	pvc := Issue{ID: "pvc-1", Kind: "PersistentVolumeClaim", Namespace: "prod", Name: "data", Category: issuesapi.CategoryPVCPending, Severity: SeverityCritical, Reason: "Pending"}
+	pod1 := Issue{ID: "g", Kind: "Pod", Namespace: "prod", Name: "db-0", Category: issuesapi.CategoryUnschedulable, Severity: SeverityCritical, Message: "pod has unbound immediate PersistentVolumeClaims"}
+	pod2 := Issue{ID: "g", Kind: "Pod", Namespace: "prod", Name: "db-1", Category: issuesapi.CategoryUnschedulable, Severity: SeverityCritical, Message: "pod has unbound immediate PersistentVolumeClaims"}
+	p := &fakeProvider{podsMountingPVC: map[string][]Ref{"prod/data": {{Kind: "Pod", Namespace: "prod", Name: "db-0"}, {Kind: "Pod", Namespace: "prod", Name: "db-1"}}}}
+	out := enrichDiagnosticContext([]Issue{pvc, pod1, pod2}, []Issue{pvc, pod1, pod2}, nil, p) // grouped == nil → ungrouped path
+	for _, i := range out {
+		if i.IncidentParent != nil {
+			t.Fatalf("ungrouped mode must not assign incident_parent, got one on %s/%s", i.Kind, i.Name)
+		}
+	}
+}
+
 func TestIncidentParent_CoverageGate(t *testing.T) {
 	// A grouped Deployment unschedulable issue (3 member pods) gets the pointer
 	// only when ALL 3 are explained by the PVC; if only 2 mount it, the row is

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -1960,14 +1960,20 @@ func TestSecretProducerContext(t *testing.T) {
 		Message: `Secret "web-tls-secret" referenced in volume does not exist`}
 	unrelated := Issue{ID: "cw-1", Kind: "Pod", Namespace: "prod", Name: "web-b", Category: issuesapi.CategoryContainerWaiting, Severity: SeverityWarning,
 		Reason: "ContainerCreating", Message: "waiting on something else entirely"}
+	// References Secret web-tls-secret but actually fails on a ConfigMap of the SAME
+	// name — the quoted name appears, but not in a `secret "…"` context, so it must
+	// NOT be attributed to the Certificate.
+	sameName := Issue{ID: "cm-1", Kind: "Pod", Namespace: "prod", Name: "web-c", Category: issuesapi.CategoryMissingConfigRef, Severity: SeverityCritical,
+		Message: `envFrom references ConfigMap "web-tls-secret" which does not exist`}
 
 	p := &fakeProvider{secretProducer: map[string]secretProducerResult{
 		"prod/web-tls": {name: "web-tls-secret", pods: []Ref{
 			{Kind: "Pod", Namespace: "prod", Name: "web-a"},
 			{Kind: "Pod", Namespace: "prod", Name: "web-b"},
+			{Kind: "Pod", Namespace: "prod", Name: "web-c"},
 		}},
 	}}
-	out := enrichDiagnosticContext([]Issue{cert, blocked, unrelated}, []Issue{cert, blocked, unrelated}, nil, p)
+	out := enrichDiagnosticContext([]Issue{cert, blocked, unrelated, sameName}, []Issue{cert, blocked, unrelated, sameName}, nil, p)
 
 	root := findByID(out, "cert-1")
 	var fact *issuesapi.DiagnosticFact
@@ -1984,5 +1990,8 @@ func TestSecretProducerContext(t *testing.T) {
 	}
 	if got := findByID(out, "cw-1"); got.IncidentParent != nil {
 		t.Fatalf("unrelated container-waiting pod must not be attributed, got %+v", *got.IncidentParent)
+	}
+	if got := findByID(out, "cm-1"); got.IncidentParent != nil {
+		t.Fatalf("same-named ConfigMap failure must not be attributed to the Secret, got %+v", *got.IncidentParent)
 	}
 }

--- a/internal/issues/issues_test.go
+++ b/internal/issues/issues_test.go
@@ -1995,3 +1995,23 @@ func TestSecretProducerContext(t *testing.T) {
 		t.Fatalf("same-named ConfigMap failure must not be attributed to the Secret, got %+v", *got.IncidentParent)
 	}
 }
+
+func TestSymptomNamesSecret(t *testing.T) {
+	mk := func(msg, ns string) Issue { return Issue{Namespace: ns, Message: msg} }
+	cases := []struct {
+		msg, ns string
+		want    bool
+	}{
+		{`references Secret "foo" which does not exist`, "prod", true},
+		{`MountVolume.SetUp failed: secret "foo" not found`, "prod", true},
+		{`secrets "foo" not found`, "prod", true},                  // plural kubelet path
+		{`couldn't find key tls.crt in Secret prod/foo`, "prod", true}, // namespaced missing-key
+		{`references ConfigMap "foo" which does not exist`, "prod", false}, // same name, wrong kind
+		{`waiting on something else`, "prod", false},
+	}
+	for _, c := range cases {
+		if got := symptomNamesSecret(mk(c.msg, c.ns), "foo"); got != c.want {
+			t.Errorf("symptomNamesSecret(%q) = %v, want %v", c.msg, got, c.want)
+		}
+	}
+}

--- a/internal/issues/provider.go
+++ b/internal/issues/provider.go
@@ -205,6 +205,93 @@ func (p *CacheProvider) PodsMountingPVC(namespace, pvcName string) []Ref {
 	return refs
 }
 
+// PodsReferencingSecret returns the pods that reference the named Secret through
+// any declared spec edge — volume (secret or projected), envFrom, env valueFrom,
+// or imagePullSecrets — the same surfaces detect_missing_refs walks. The caller
+// intersects against the request-scoped issue set, so visibility is enforced there.
+func (p *CacheProvider) PodsReferencingSecret(namespace, secretName string) []Ref {
+	if p == nil || p.cache == nil || p.cache.Pods() == nil || namespace == "" || secretName == "" {
+		return nil
+	}
+	pods, err := p.cache.Pods().Pods(namespace).List(labels.Everything())
+	if err != nil {
+		return nil
+	}
+	var refs []Ref
+	for _, pod := range pods {
+		if podReferencesSecret(pod, secretName) {
+			refs = append(refs, Ref{Kind: "Pod", Namespace: pod.Namespace, Name: pod.Name})
+		}
+	}
+	sortRefs(refs)
+	return refs
+}
+
+func podReferencesSecret(pod *corev1.Pod, secretName string) bool {
+	for _, v := range pod.Spec.Volumes {
+		if v.Secret != nil && v.Secret.SecretName == secretName {
+			return true
+		}
+		if v.Projected != nil {
+			for _, src := range v.Projected.Sources {
+				if src.Secret != nil && src.Secret.Name == secretName {
+					return true
+				}
+			}
+		}
+	}
+	for _, ips := range pod.Spec.ImagePullSecrets {
+		if ips.Name == secretName {
+			return true
+		}
+	}
+	containers := append([]corev1.Container(nil), pod.Spec.InitContainers...)
+	containers = append(containers, pod.Spec.Containers...)
+	for _, c := range containers {
+		for _, ef := range c.EnvFrom {
+			if ef.SecretRef != nil && ef.SecretRef.Name == secretName {
+				return true
+			}
+		}
+		for _, e := range c.Env {
+			if e.ValueFrom != nil && e.ValueFrom.SecretKeyRef != nil && e.ValueFrom.SecretKeyRef.Name == secretName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// PodsDependingOnSecretProducer resolves a Secret-producing CR (cert-manager
+// Certificate via spec.secretName, external-secrets ExternalSecret via
+// spec.target.name defaulting to its own name) to the pods that reference the
+// Secret it owns. The producer→Secret edge is declared in the CR spec and the
+// Pod→Secret edge is declared in the pod spec, so the chain is structural. Returns
+// nil when the CR can't be fetched or names no target.
+func (p *CacheProvider) PodsDependingOnSecretProducer(group, kind, namespace, name string) (string, []Ref) {
+	if p == nil || p.cache == nil || namespace == "" || name == "" {
+		return "", nil
+	}
+	u, err := p.cache.GetDynamicWithGroup(context.Background(), kind, namespace, name, group)
+	if err != nil || u == nil {
+		return "", nil
+	}
+	secretName := ""
+	switch kind {
+	case "Certificate":
+		secretName, _, _ = unstructured.NestedString(u.Object, "spec", "secretName")
+	case "ExternalSecret":
+		secretName, _, _ = unstructured.NestedString(u.Object, "spec", "target", "name")
+		if secretName == "" {
+			secretName = name // ExternalSecret defaults the target Secret to its own name
+		}
+	}
+	if secretName == "" {
+		return "", nil
+	}
+	return secretName, p.PodsReferencingSecret(namespace, secretName)
+}
+
 func (p *CacheProvider) ChangeContextForIssue(i Issue) *issuesapi.ChangeContext {
 	if p == nil || p.cache == nil {
 		return nil

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -329,7 +329,12 @@ func registerTools(server *mcp.Server) {
 			"claimName) — treat as fact; `medium` = inferred/co-located (e.g. pods ON a " +
 			"pressured node) — a lead to verify, NOT proof; `low` = heuristic. The fact's " +
 			"`role` (candidate = possible cause, affected, rollup, context) places the row " +
-			"in the causal picture. Use these links to walk from a symptom to its likely " +
+			"in the causal picture. The REVERSE is also provided: a symptom row may carry " +
+			"`incident_parent` (the root issue that explains it — id + ref + confidence + " +
+			"fact_type), so you can walk symptom→root directly without scanning every root's " +
+			"facts. It is set only when a single root is unambiguous (high beats medium; " +
+			"distinct same-confidence roots leave it unset). Use these links to walk from a " +
+			"symptom to its likely " +
 			"root, but confirm a medium link before acting on it. " +
 			"When `recent_changes` is present, consider it if the issue list does not " +
 			"explain the reported symptom; `recent_changes_reason` says why Radar " +

--- a/packages/k8s-ui/src/components/issues/IssuesView.tsx
+++ b/packages/k8s-ui/src/components/issues/IssuesView.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState, type ComponentType, type ReactNode } from
 import { ChevronRight, CircleCheck, Clock, ExternalLink } from 'lucide-react';
 import { ClusterName, EmptyState } from '../ui';
 import { formatCompactAge, formatRelativeAgeTime } from '../../utils/format';
-import { diagnosticRoleLabel, diagnosticFactLabel, confidenceTitle } from './diagnostic';
+import { diagnosticRoleLabel, diagnosticFactLabel, confidenceTitle, incidentParentLabel } from './diagnostic';
 import {
   ISSUE_SEVERITY_BADGE_CLASS,
   ISSUE_SEVERITY_LABEL,
@@ -209,6 +209,17 @@ export function IssueRow({
                 <span className="shrink-0 tabular-nums">{affected}</span>
               </>
             ) : null}
+            {issue.incident_parent ? (
+              <>
+                <span aria-hidden>·</span>
+                {/* Non-interactive signal (the header is the toggle — a nested
+                    button would be invalid); the clickable link lives in the body. */}
+                <span className="min-w-0 truncate text-theme-text-tertiary" title={confidenceTitle(issue.incident_parent.confidence ?? '')}>
+                  ↳ {incidentParentLabel(issue.incident_parent.fact_type, issue.incident_parent.confidence)}{' '}
+                  <span className="font-medium text-theme-text-secondary">{issue.incident_parent.ref.kind} / {issue.incident_parent.ref.name}</span>
+                </span>
+              </>
+            ) : null}
             {renderMeta?.(slotCtx)}
           </div>
         </div>
@@ -249,6 +260,21 @@ export function IssueRow({
             <div className="border-t border-theme-border bg-theme-base/40 px-4 py-4 pl-11">
               <div className="flex flex-col gap-4">
                 <Diagnosis issue={issue} />
+                {issue.incident_parent ? (
+                  <section className="flex flex-col gap-1">
+                    <h4 className="text-[11px] font-semibold uppercase tracking-wide text-theme-text-tertiary">
+                      {incidentParentLabel(issue.incident_parent.fact_type, issue.incident_parent.confidence)}
+                      {issue.incident_parent.confidence ? (
+                        <span className="ml-2 badge-sm text-[10px] font-normal text-theme-text-tertiary" title={confidenceTitle(issue.incident_parent.confidence)}>
+                          {issue.incident_parent.confidence} confidence
+                        </span>
+                      ) : null}
+                    </h4>
+                    <ul className="flex flex-col gap-px">
+                      <ResourceLine refForLink={memberRef(issue, issue.incident_parent.ref)} resourceHref={resourceHref} onResourceClick={onResourceClick} ResourceLinkIcon={ResourceLinkIcon} />
+                    </ul>
+                  </section>
+                ) : null}
                 <DiagnosticContext issue={issue} resourceHref={resourceHref} onResourceClick={onResourceClick} ResourceLinkIcon={ResourceLinkIcon} />
                 <div className="border-t border-theme-border/70 pt-3">
                   <AffectedResources issue={issue} resourceHref={resourceHref} onResourceClick={onResourceClick} ResourceLinkIcon={ResourceLinkIcon} />

--- a/packages/k8s-ui/src/components/issues/ResourceIssuesSection.tsx
+++ b/packages/k8s-ui/src/components/issues/ResourceIssuesSection.tsx
@@ -3,7 +3,7 @@ import { Section } from '../ui/drawer-components'
 import { Badge } from '../ui/Badge'
 import type { Issue, IssueResourceRef } from './types'
 import { categoryLabel } from './severity'
-import { diagnosticRoleLabel, diagnosticFactLabel, confidenceTitle } from './diagnostic'
+import { diagnosticRoleLabel, diagnosticFactLabel, confidenceTitle, incidentParentLabel } from './diagnostic'
 
 /**
  * ResourceIssuesSection — the compact "Operational Issues" block for the resource
@@ -63,6 +63,24 @@ export function ResourceIssuesSection({
                 <p className="mt-1 text-xs text-theme-text-tertiary">
                   Suggested fix: create namespace{' '}
                   <code className="rounded bg-theme-elevated px-1 font-mono">{issue.remediation_target}</code> — apply it from the GitOps detail page.
+                </p>
+              ) : null}
+              {issue.incident_parent ? (
+                <p className="mt-1 text-xs text-theme-text-tertiary">
+                  {incidentParentLabel(issue.incident_parent.fact_type, issue.incident_parent.confidence)}:{' '}
+                  {onResourceClick ? (
+                    <button
+                      type="button"
+                      onClick={() => onResourceClick(issue.incident_parent!.ref)}
+                      className="group inline-flex items-center gap-1 text-left font-mono hover:text-theme-text-secondary"
+                      title={confidenceTitle(issue.incident_parent.confidence ?? '')}
+                    >
+                      {issue.incident_parent.ref.kind} / {issue.incident_parent.ref.name}
+                      <ExternalLink className="h-3 w-3 opacity-0 group-hover:opacity-100" />
+                    </button>
+                  ) : (
+                    <span className="font-mono">{issue.incident_parent.ref.kind} / {issue.incident_parent.ref.name}</span>
+                  )}
                 </p>
               ) : null}
               <CausalContext issue={issue} onResourceClick={onResourceClick} />

--- a/packages/k8s-ui/src/components/issues/ResourceIssuesSection.tsx
+++ b/packages/k8s-ui/src/components/issues/ResourceIssuesSection.tsx
@@ -3,7 +3,7 @@ import { Section } from '../ui/drawer-components'
 import { Badge } from '../ui/Badge'
 import type { Issue, IssueResourceRef } from './types'
 import { categoryLabel } from './severity'
-import { diagnosticRoleLabel, diagnosticFactLabel, confidenceTitle, incidentParentLabel } from './diagnostic'
+import { diagnosticRoleLabel, diagnosticFactLabel, confidenceTitle } from './diagnostic'
 
 /**
  * ResourceIssuesSection — the compact "Operational Issues" block for the resource
@@ -63,24 +63,6 @@ export function ResourceIssuesSection({
                 <p className="mt-1 text-xs text-theme-text-tertiary">
                   Suggested fix: create namespace{' '}
                   <code className="rounded bg-theme-elevated px-1 font-mono">{issue.remediation_target}</code> — apply it from the GitOps detail page.
-                </p>
-              ) : null}
-              {issue.incident_parent ? (
-                <p className="mt-1 text-xs text-theme-text-tertiary">
-                  {incidentParentLabel(issue.incident_parent.fact_type, issue.incident_parent.confidence)}:{' '}
-                  {onResourceClick ? (
-                    <button
-                      type="button"
-                      onClick={() => onResourceClick(issue.incident_parent!.ref)}
-                      className="group inline-flex items-center gap-1 text-left font-mono hover:text-theme-text-secondary"
-                      title={confidenceTitle(issue.incident_parent.confidence ?? '')}
-                    >
-                      {issue.incident_parent.ref.kind} / {issue.incident_parent.ref.name}
-                      <ExternalLink className="h-3 w-3 opacity-0 group-hover:opacity-100" />
-                    </button>
-                  ) : (
-                    <span className="font-mono">{issue.incident_parent.ref.kind} / {issue.incident_parent.ref.name}</span>
-                  )}
                 </p>
               ) : null}
               <CausalContext issue={issue} onResourceClick={onResourceClick} />

--- a/packages/k8s-ui/src/components/issues/diagnostic.ts
+++ b/packages/k8s-ui/src/components/issues/diagnostic.ts
@@ -44,8 +44,6 @@ export function diagnosticFactLabel(type: string): string {
       return 'Blocked pods';
     case 'apiservice_hpa':
       return 'Stalled autoscalers';
-    case 'node_provisioning':
-      return 'Pods awaiting capacity';
     case 'secret_not_ready':
       return 'Dependent pods';
     default:
@@ -63,7 +61,6 @@ export function incidentParentLabel(factType?: string, confidence?: string): str
     case 'secret_not_ready':
       return 'Caused by';
     case 'apiservice_hpa':
-    case 'node_provisioning':
       return 'Likely cause';
     case 'node_blast_radius':
       return 'Related';

--- a/packages/k8s-ui/src/components/issues/diagnostic.ts
+++ b/packages/k8s-ui/src/components/issues/diagnostic.ts
@@ -44,6 +44,8 @@ export function diagnosticFactLabel(type: string): string {
       return 'Blocked pods';
     case 'apiservice_hpa':
       return 'Stalled autoscalers';
+    case 'node_provisioning':
+      return 'Pods awaiting capacity';
     default:
       return type.replace(/_/g, ' ');
   }

--- a/packages/k8s-ui/src/components/issues/diagnostic.ts
+++ b/packages/k8s-ui/src/components/issues/diagnostic.ts
@@ -46,6 +46,8 @@ export function diagnosticFactLabel(type: string): string {
       return 'Stalled autoscalers';
     case 'node_provisioning':
       return 'Pods awaiting capacity';
+    case 'secret_not_ready':
+      return 'Dependent pods';
     default:
       return type.replace(/_/g, ' ');
   }

--- a/packages/k8s-ui/src/components/issues/diagnostic.ts
+++ b/packages/k8s-ui/src/components/issues/diagnostic.ts
@@ -49,6 +49,25 @@ export function diagnosticFactLabel(type: string): string {
   }
 }
 
+// Operator-facing lead-in for the symptom→root pointer chip. Honest per fact
+// type: a declared PVC/Secret edge is a cause; a co-located node is only
+// "related" (node pressure can be a shared victim, not the root), so it must not
+// claim "caused by".
+export function incidentParentLabel(factType?: string, confidence?: string): string {
+  switch (factType) {
+    case 'pvc_blast_radius':
+    case 'secret_not_ready':
+      return 'Caused by';
+    case 'apiservice_hpa':
+    case 'node_provisioning':
+      return 'Likely cause';
+    case 'node_blast_radius':
+      return 'Related';
+    default:
+      return confidence === 'high' ? 'Caused by' : 'Possible cause';
+  }
+}
+
 // Plain-language gloss for the confidence chip's tooltip — the operator should
 // know a medium link is "these are co-located, the node may be the cause", not a
 // proven fact.

--- a/packages/k8s-ui/src/components/issues/index.ts
+++ b/packages/k8s-ui/src/components/issues/index.ts
@@ -12,7 +12,7 @@ export {
   subjectRef,
   memberRef,
 } from './types';
-export type { Issue, IssueSeverity, IssueAffected, IssueResourceRef, IssueDiagnosticContext, IssueDiagnosticFact, IssueDiagnosticConfidence, IssueDiagnosticIssueRef, IssueDiagnosticRole, IssueChangeContext, IssueRecentChange, IssueRecentChangeField } from './types';
+export type { Issue, IssueSeverity, IssueAffected, IssueResourceRef, IssueDiagnosticContext, IssueDiagnosticFact, IssueDiagnosticConfidence, IssueDiagnosticIssueRef, IssueDiagnosticRole, IssueIncidentParent, IssueChangeContext, IssueRecentChange, IssueRecentChangeField } from './types';
 export {
   ISSUE_SEVERITY_LABEL,
   ISSUE_SEVERITY_BADGE_CLASS,

--- a/packages/k8s-ui/src/components/issues/types.ts
+++ b/packages/k8s-ui/src/components/issues/types.ts
@@ -79,6 +79,18 @@ export interface IssueDiagnosticIssueRef {
 
 export type IssueDiagnosticConfidence = 'high' | 'medium' | 'low';
 
+/** Reverse pointer from a symptom issue to the root issue that explains it
+ *  (the inverse of diagnostic_context's root→symptom facts). Set only when a
+ *  single root is unambiguous. `ref` is the parent subject for display + deep
+ *  navigation (thread the issue's cluster_id onto it via memberRef). */
+export interface IssueIncidentParent {
+  id: string;
+  ref: IssueResourceRef;
+  category?: string;
+  confidence?: IssueDiagnosticConfidence;
+  fact_type?: string;
+}
+
 export interface IssueDiagnosticFact {
   type: string;
   message?: string;
@@ -186,6 +198,7 @@ export interface Issue {
   members?: IssueResourceRef[];
   members_truncated?: boolean;
   diagnostic_context?: IssueDiagnosticContext;
+  incident_parent?: IssueIncidentParent;
   change_context?: IssueChangeContext;
 
   // Pod crash context carried from the representative member.

--- a/pkg/issuesapi/types.go
+++ b/pkg/issuesapi/types.go
@@ -234,6 +234,24 @@ const (
 	ConfidenceLow    Confidence = "low"
 )
 
+// IncidentParent links a SYMPTOM issue to the ROOT issue that explains it — the
+// reverse of DiagnosticContext's root→symptom facts. Set only for causal links
+// whose related issues are genuinely DOWNSTREAM of the root (a broken PVC, a
+// pressured node, an unavailable metrics API, a not-ready Secret producer, a
+// failed node provisioner); never for selected_backend (where the related pods
+// are the cause, not the symptom). Carries the link's Confidence so the UI can
+// hedge a medium pointer ("related / verify") vs. a high one ("caused by"); it
+// deliberately carries NO "hide this row" flag — demotion is presentation policy,
+// not part of this contract. Assigned only when unambiguous: a single best root
+// by confidence tier; distinct roots at the same tier leave it unset.
+type IncidentParent struct {
+	ID         string     `json:"id"`                  // parent grouped-issue ID (within-cluster)
+	Ref        Ref        `json:"ref"`                 // parent subject, for display + deep-link
+	Category   Category   `json:"category,omitempty"`
+	Confidence Confidence `json:"confidence,omitempty"`
+	FactType   string     `json:"fact_type,omitempty"` // node_blast_radius | pvc_blast_radius | apiservice_hpa | secret_not_ready | node_provisioning
+}
+
 type IssueRef struct {
 	Ref      Ref      `json:"ref"`
 	Reason   string   `json:"reason,omitempty"`
@@ -348,6 +366,7 @@ type Issue struct {
 	Members              []Ref              `json:"members,omitempty"`
 	MembersTruncated     bool               `json:"members_truncated,omitempty"`
 	DiagnosticContext    *DiagnosticContext `json:"diagnostic_context,omitempty"`
+	IncidentParent       *IncidentParent    `json:"incident_parent,omitempty"`
 	ChangeContext        *ChangeContext     `json:"change_context,omitempty"`
 	// IssueTiming is best-effort timing evidence for when this issue entered
 	// the failing state, derived from K8s-native signals (condition

--- a/pkg/issuesapi/types.go
+++ b/pkg/issuesapi/types.go
@@ -237,8 +237,8 @@ const (
 // IncidentParent links a SYMPTOM issue to the ROOT issue that explains it — the
 // reverse of DiagnosticContext's root→symptom facts. Set only for causal links
 // whose related issues are genuinely DOWNSTREAM of the root (a broken PVC, a
-// pressured node, an unavailable metrics API, a not-ready Secret producer, a
-// failed node provisioner); never for selected_backend (where the related pods
+// pressured node, an unavailable metrics API, a not-ready Secret producer);
+// never for selected_backend (where the related pods
 // are the cause, not the symptom). Carries the link's Confidence so the UI can
 // hedge a medium pointer ("related / verify") vs. a high one ("caused by"); it
 // deliberately carries NO "hide this row" flag — demotion is presentation policy,
@@ -249,7 +249,7 @@ type IncidentParent struct {
 	Ref        Ref        `json:"ref"`                 // parent subject, for display + deep-link
 	Category   Category   `json:"category,omitempty"`
 	Confidence Confidence `json:"confidence,omitempty"`
-	FactType   string     `json:"fact_type,omitempty"` // node_blast_radius | pvc_blast_radius | apiservice_hpa | secret_not_ready | node_provisioning
+	FactType   string     `json:"fact_type,omitempty"` // node_blast_radius | pvc_blast_radius | apiservice_hpa | secret_not_ready
 }
 
 type IssueRef struct {


### PR DESCRIPTION
## Summary

When an operator lands on a *symptom* in the Issues list ("this Deployment can't schedule", "this HPA stalled"), the next question is always **why**. Radar's causal links were root-anchored only — a failing root (broken PVC, pressured node, down metrics API) was annotated with the symptoms it explains, but the symptom row had no pointer *back* to its cause. This adds that reverse pointer, `incident_parent`, so symptom→root navigation works in one click. It's the highest-value, lowest-risk slice of "incident grouping" — **navigation, not row-hiding** (no demotion; nothing is suppressed or reordered).

It also adds one **new causal link family** so the pointer covers more than the three existing links.

> Framing: these are **root-cause pointers / cause hints**, not visual "incident grouping" (no row compression). True demotion is deliberately deferred (see below).

## What's covered

A symptom row gains `incident_parent` for the causal links whose related issues are genuinely **downstream** of the root:

| Root | → Symptom | Confidence | UI lead-in |
|------|-----------|------------|------------|
| **PVC** pending/lost/resize-failed | pods mounting it (volume-evidenced) | high | "Caused by" |
| **Node** under MemoryPressure/DiskPressure/PIDPressure | pods on it (reason-gated) | medium | "Related" |
| **metrics APIService** unavailable | HPAs starved of that metric family | medium | "Likely cause" |
| **Secret producer** — cert-manager `Certificate` (`spec.secretName`) / external-secrets `ExternalSecret` (`spec.target.name`) — **NEW** | pods referencing the Secret it owns and failing for a config/secret reason | high | "Caused by" |

`selected_backend` (Service with no endpoints) is **excluded** — there the related pods are the *cause*, not a downstream symptom, so reversing it would invert causality.

## How it stays precise (over-linking is the cardinal sin)

- **Causal-direction allow-list**, not confidence-gating: only the four downstream links above record a reverse edge.
- **Best-parent, no guessing**: when several roots name one symptom, a higher confidence tier wins (a declared PVC edge over a co-located node); **distinct roots at the same tier leave the pointer unset** — severity is never used to pick a cause.
- **Whole-row coverage**: a grouped symptom (e.g. a Deployment folding N pods) gets the pointer only when **every** member is explained by the root (`affected ≥ fan-out`). A Deployment whose pods are only partly PVC-blocked, or split across two pressured nodes, is omitted rather than over-claimed. This also subsumes the multi-root ambiguity case.
- **Inherited gates**: the pointer rides the existing forward-link precision (PVC volume-evidence, node reason-gate + dead-kubelet exclusion, HPA metric-family match + missing-request exclusion). The new Secret link requires the symptom to **name the Secret** (so a pod that references it via env but fails on an unrelated volume isn't attributed).
- **Self-edge / cycle guards** (structurally impossible with the current roots, but cheap).
- Edge computation is **uncapped** — independent of the 5-item display cap — so no pointer is dropped and the cap can't hide ambiguity.

## Surfaces

- **Cluster Issues view**: a non-interactive cause-signal in the collapsed row header ("↳ Caused by PersistentVolumeClaim / data") + a clickable **"CAUSED BY"** section (with confidence) in the expanded body. Honest per-link wording (declared edges say "Caused by"; co-located node says "Related"). Cluster-scoped deep-link via the existing `memberRef`.
- **MCP `issues`**: symptom rows carry `incident_parent` (id + ref + confidence + fact_type) so an agent can walk symptom→root directly. Description updated.

## New backend surface
- `issuesapi.IncidentParent` + `Issue.IncidentParent` (additive, omitempty). No `Demote` field — demotion is presentation policy, not part of this contract.
- Provider methods `PodsReferencingSecret` and `PodsDependingOnSecretProducer` (resolves the producer CR's target Secret via the dynamic cache).

## Testing
- `go test ./internal/issues ./internal/mcp ./internal/server` + the `pkg/issuesapi` module — green; `make tsc` green.
- Unit tests pin: PVC (high) / node (medium) reverse pointers; `selected_backend` excluded; best-parent rule (high>medium, distinct same-tier → omit) as a pure unit; **whole-row coverage gate (3/3 links, 2/3 omits)**; secret-producer links only the Secret-naming pod; the root never points at itself.
- **Live-verified on kind — 3 of 4 link families end-to-end:**
  - **PVC** (high): pending PVC + 3-replica Deployment → the `unschedulable` issue gained `incident_parent → PersistentVolumeClaim/data`, rendered as the header chip + "CAUSED BY · HIGH CONFIDENCE" body section (0 console errors).
  - **apiservice→HPA** (medium): metrics-server scaled to 0 → the HPA's `cannot-scale` issue gained `incident_parent → APIService/v1beta1.metrics.k8s.io`.
  - **secret-producer** (high): cert-manager `Certificate` referencing a missing issuer + a pod mounting its Secret → the Deployment's `missing_config_ref` and `volume_mount_failed` issues gained `incident_parent → Certificate/web-tls`; the tightened gate proved correct (the mount failure linked *because* its kubelet message names `secret "web-tls-secret"`, not unconditionally).
- Cross-reviewed with Codex over multiple rounds; every finding (edge/cap coupling, secret gate, whole-row coverage, an unsound provisioning gate, a same-name secret false-positive) is fixed and pinned by tests.
- **Unit-tested-only**: the **node** blast-radius pointer (needs a multi-node cluster + induced MemoryPressure/NotReady), the same honest gap as the forward link.

## Deferred (out of scope, on purpose)
- **Per-resource drawer back-pointer**: the per-resource regroup can't reconstruct whole-row coverage (members share an issue ID), so the pointer ships on the Issues view + MCP only for now.
- **node-provisioning → unschedulable link**: its scheduler-message gate is fundamentally imprecise (cluster-autoscaler's "didn't trigger scale-up" includes taint/affinity reasons); needs the scheduler reason-class threaded onto detections first.
- **Demotion / true incident grouping** (root promoted, symptoms nested/hidden): a separately-validated policy needing relation-specific suppressibility — this PR is the non-destructive navigation foundation it builds on.
- More cross-subject links (cert→Ingress-TLS, admission-webhook fan-in): additive, each will auto-gain a reverse pointer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes causal attribution and navigation for operators/agents; logic is heavily gated but wrong parent hints could misdirect triage.
> 
> **Overview**
> Symptom issue rows can now carry **`incident_parent`**, a reverse pointer to the root that explains them (id, ref, confidence, fact type), built from existing root→symptom causal links for PVC, node blast radius, metrics APIService→HPA, and a **new** cert-manager **Certificate** / external-secrets **ExternalSecret** → dependent pods link (`secret_not_ready`). Assignment runs only on the **cluster grouped** issues path: it picks a single parent when confidence is unambiguous (high beats medium; tied distinct roots omit the field), requires **whole-row coverage** for grouped symptoms, and records edges **uncapped** separately from the display cap on related issues.
> 
> **CacheProvider** gains **`PodsReferencingSecret`** and **`PodsDependingOnSecretProducer`** to resolve producer CRs to target Secrets and referencing pods. **`foldGroup`** deliberately does not propagate `incident_parent` on per-resource regroup.
> 
> The **Issues** UI shows a collapsed-row cause hint and an expanded **Caused by / Related** section; **MCP** `issues` tool docs describe `incident_parent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62708596097c2451952cb6a13d1bdf1f4f611a32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->