### PR TITLE
feat(issues): incident_parent on the per-resource path (drawer + MCP get_resource/diagnose)

### DIFF
--- a/internal/issues/diagnostic_context.go
+++ b/internal/issues/diagnostic_context.go
@@ -241,9 +241,10 @@ func enrichDiagnosticContext(shaped, flat, grouped []Issue, p Provider) []Issue 
 	// coverage gate needs the grouped fan-out (Count), and a grouped subject has a
 	// unique ID. Only assign when called in grouped mode (grouped != nil) — the
 	// cluster Issues path, and the per-resource RelatedIssues path which re-runs
-	// this enrichment over its grouped set. The ungrouped ?view=flat call passes
-	// grouped == nil (members share issue IDs, Count 0, so coverage can't be
-	// checked and the pointer would attach arbitrarily) and leaves it unset.
+	// this enrichment over its grouped set. Ungrouped calls (?view=flat, the flat
+	// pass inside RelatedIssues, the GitOps resolver's Compose) pass grouped ==
+	// nil — members share issue IDs and Count 0, so coverage can't be checked and
+	// the pointer would attach arbitrarily — and leave it unset.
 	if len(grouped) > 0 {
 		assignIncidentParents(out, incidentEdges)
 	}

--- a/internal/issues/diagnostic_context.go
+++ b/internal/issues/diagnostic_context.go
@@ -239,10 +239,11 @@ func enrichDiagnosticContext(shaped, flat, grouped []Issue, p Provider) []Issue 
 
 	// incident_parent is a property of the GROUPED issue model: the whole-row
 	// coverage gate needs the grouped fan-out (Count), and a grouped subject has a
-	// unique ID. Only assign on the cluster grouped path (grouped != nil). The
-	// ungrouped paths — ?view=flat (raw evidence) and the per-resource regroup —
-	// share issue IDs across members and have Count 0, so coverage can't be checked
-	// and the pointer would attach arbitrarily; they deliberately leave it unset.
+	// unique ID. Only assign when called in grouped mode (grouped != nil) — the
+	// cluster Issues path, and the per-resource RelatedIssues path which re-runs
+	// this enrichment over its grouped set. The ungrouped ?view=flat call passes
+	// grouped == nil (members share issue IDs, Count 0, so coverage can't be
+	// checked and the pointer would attach arbitrarily) and leaves it unset.
 	if len(grouped) > 0 {
 		assignIncidentParents(out, incidentEdges)
 	}

--- a/internal/issues/grouping.go
+++ b/internal/issues/grouping.go
@@ -19,6 +19,10 @@ func RelatedIssues(p Provider, namespaces []string, group, kind, namespace, name
 	// what makes member #11..#N in a large fan-out resolve correctly.
 	flat := Compose(p, Filters{Namespaces: namespaces, Limit: NoLimit})
 	grouped := GroupIssues(flat)
+	// Run the grouped-mode enrichment (mirrors the cluster path) so the grouped
+	// issues get coverage-gated incident_parent pointers — GroupIssues alone only
+	// carries the representative's DiagnosticContext, never the reverse pointer.
+	grouped = enrichDiagnosticContext(grouped, flat, grouped, p)
 	return RelatedIssuesFrom(flat, grouped, group, kind, namespace, name)
 }
 

--- a/internal/issues/grouping.go
+++ b/internal/issues/grouping.go
@@ -192,11 +192,10 @@ func foldGroup(members []Issue) Issue {
 	g.IssueTimingBasis = groupBasis
 
 	// IncidentParent is deliberately NOT carried through foldGroup: members of one
-	// grouped symptom share an issue ID, so the per-resource regroup can't tell
-	// which members the root actually covers (the whole-row coverage check that the
-	// cluster-wide path does after grouping isn't reconstructable here). The reverse
-	// pointer therefore ships on the cluster Issues view + MCP only; the per-resource
-	// path leaves it unset rather than over-claim a mixed-cause row.
+	// grouped symptom share an issue ID, so carrying a member's pointer can't honor
+	// the whole-row coverage check. Both paths instead assign it AFTER grouping, in
+	// enrichDiagnosticContext's grouped mode — the cluster path inline, the
+	// per-resource RelatedIssues path via a second enrichment over its grouped set.
 
 	// Count is the affected-resource fan-out — the non-subject members under
 	// this subject (the subject is shown separately as the header, not under

--- a/internal/issues/grouping.go
+++ b/internal/issues/grouping.go
@@ -31,6 +31,8 @@ func RelatedIssues(p Provider, namespaces []string, group, kind, namespace, name
 // related issues for MANY resources in one request (e.g. the GitOps insights
 // resolver enriching every degraded managed resource) can Compose once and
 // match repeatedly, instead of running a full cluster Compose per resource.
+// It only matches — grouped-mode enrichment is the caller's responsibility, so
+// a bare GroupIssues pair yields rows without incident_parent.
 func RelatedIssuesFrom(flat, grouped []Issue, group, kind, namespace, name string) []Issue {
 	// Normalize the query group so a caller passing a raw API group — e.g. the
 	// GitOps L4 bridge forwarding Argo's status.resources[].group, which is ""
@@ -193,9 +195,11 @@ func foldGroup(members []Issue) Issue {
 
 	// IncidentParent is deliberately NOT carried through foldGroup: members of one
 	// grouped symptom share an issue ID, so carrying a member's pointer can't honor
-	// the whole-row coverage check. Both paths instead assign it AFTER grouping, in
+	// the whole-row coverage check. It is assigned AFTER grouping instead, in
 	// enrichDiagnosticContext's grouped mode — the cluster path inline, the
 	// per-resource RelatedIssues path via a second enrichment over its grouped set.
+	// Precomposed RelatedIssuesFrom callers that skip that enrichment (the GitOps
+	// insights resolver) get rows without the pointer.
 
 	// Count is the affected-resource fan-out — the non-subject members under
 	// this subject (the subject is shown separately as the header, not under

--- a/internal/issues/grouping_test.go
+++ b/internal/issues/grouping_test.go
@@ -241,6 +241,30 @@ func TestRelatedIssues_SubjectAndMember(t *testing.T) {
 	}
 }
 
+// TestRelatedIssues_PopulatesIncidentParent pins that the per-resource path runs
+// the grouped-mode enrichment, so a symptom returned for the drawer / get_resource
+// / diagnose carries the symptom→root incident_parent (not just the forward links).
+func TestRelatedIssues_PopulatesIncidentParent(t *testing.T) {
+	p := &fakeProvider{
+		problems: []k8s.Detection{
+			{Kind: "PersistentVolumeClaim", Namespace: "prod", Name: "data", Reason: "Pending", Severity: "critical"},
+		},
+		scheduling: []k8s.Detection{
+			{Kind: "Pod", Namespace: "prod", Name: "db-0", Reason: "Unschedulable", Severity: "critical",
+				Message: "pod has unbound immediate PersistentVolumeClaims"},
+		},
+		podsMountingPVC: map[string][]Ref{"prod/data": {{Kind: "Pod", Namespace: "prod", Name: "db-0"}}},
+	}
+	got := RelatedIssues(p, nil, "", "Pod", "prod", "db-0")
+	if len(got) != 1 {
+		t.Fatalf("RelatedIssues(db-0) = %d, want 1", len(got))
+	}
+	ip := got[0].IncidentParent
+	if ip == nil || ip.Ref.Kind != "PersistentVolumeClaim" || ip.Ref.Name != "data" || ip.Confidence != issuesapi.ConfidenceHigh {
+		t.Fatalf("expected incident_parent → PVC/data (high), got %+v", ip)
+	}
+}
+
 // TestRelatedIssuesFrom_MatchesPrecomposed pins that the compose-once helper
 // returns the same matches as RelatedIssues when handed an already-composed
 // (flat, grouped) pair — the path the GitOps insights resolver uses to avoid a

--- a/internal/issues/grouping_test.go
+++ b/internal/issues/grouping_test.go
@@ -265,10 +265,46 @@ func TestRelatedIssues_PopulatesIncidentParent(t *testing.T) {
 	}
 }
 
+// TestRelatedIssues_IncidentParentCoverageGate pins that the per-resource path
+// honors the whole-row coverage gate: when a root explains only SOME members of
+// a grouped symptom (2 of 3 unschedulable pods mount the Pending PVC), the row
+// gets no incident_parent — attributing a mixed-cause row to one root would
+// over-claim. Guards the grouped argument at the RelatedIssues enrichment call:
+// passing flat rows there would satisfy the happy-path test but break this one.
+func TestRelatedIssues_IncidentParentCoverageGate(t *testing.T) {
+	sched := make([]k8s.Detection, 0, 3)
+	for _, pod := range []string{"db-0", "db-1", "db-2"} {
+		sched = append(sched, k8s.Detection{
+			Kind: "Pod", Namespace: "prod", Name: pod, Reason: "Unschedulable", Severity: "critical",
+			Message:    "pod has unbound immediate PersistentVolumeClaims",
+			OwnerGroup: "apps", OwnerKind: "StatefulSet", OwnerName: "db",
+		})
+	}
+	p := &fakeProvider{
+		problems: []k8s.Detection{
+			{Kind: "PersistentVolumeClaim", Namespace: "prod", Name: "data", Reason: "Pending", Severity: "critical"},
+		},
+		scheduling: sched,
+		podsMountingPVC: map[string][]Ref{"prod/data": {
+			{Kind: "Pod", Namespace: "prod", Name: "db-0"},
+			{Kind: "Pod", Namespace: "prod", Name: "db-1"},
+		}},
+	}
+	got := RelatedIssues(p, nil, "", "Pod", "prod", "db-0")
+	if len(got) != 1 {
+		t.Fatalf("RelatedIssues(db-0) = %d, want 1", len(got))
+	}
+	if got[0].IncidentParent != nil {
+		t.Fatalf("partially-covered row (2 of 3 members mount the PVC) must not carry incident_parent, got %+v", got[0].IncidentParent)
+	}
+}
+
 // TestRelatedIssuesFrom_MatchesPrecomposed pins that the compose-once helper
-// returns the same matches as RelatedIssues when handed an already-composed
+// returns the same MATCH SET as RelatedIssues when handed an already-composed
 // (flat, grouped) pair — the path the GitOps insights resolver uses to avoid a
-// full Compose per managed resource.
+// full Compose per managed resource. Row payload is a different contract: it
+// reflects whatever pair the caller passes (see
+// TestRelatedIssuesFrom_NoIncidentParentOnBarePair).
 func TestRelatedIssuesFrom_MatchesPrecomposed(t *testing.T) {
 	p := &fakeProvider{problems: []k8s.Detection{
 		{Kind: "Pod", Namespace: "prod", Name: "web-abc-1", Reason: "CrashLoopBackOff", Severity: "critical",
@@ -281,6 +317,33 @@ func TestRelatedIssuesFrom_MatchesPrecomposed(t *testing.T) {
 	}
 	if got := RelatedIssuesFrom(flat, grouped, "apps", "Deployment", "prod", "other"); len(got) != 0 {
 		t.Errorf("RelatedIssuesFrom(unrelated) = %d, want 0", len(got))
+	}
+}
+
+// TestRelatedIssuesFrom_NoIncidentParentOnBarePair pins the contract split
+// between the two entry points: RelatedIssues enriches its grouped set, so the
+// same scenario carries incident_parent there (TestRelatedIssues_PopulatesIncidentParent),
+// while a caller handing RelatedIssuesFrom a bare GroupIssues pair gets rows
+// without the pointer — grouped-mode enrichment is the caller's responsibility.
+func TestRelatedIssuesFrom_NoIncidentParentOnBarePair(t *testing.T) {
+	p := &fakeProvider{
+		problems: []k8s.Detection{
+			{Kind: "PersistentVolumeClaim", Namespace: "prod", Name: "data", Reason: "Pending", Severity: "critical"},
+		},
+		scheduling: []k8s.Detection{
+			{Kind: "Pod", Namespace: "prod", Name: "db-0", Reason: "Unschedulable", Severity: "critical",
+				Message: "pod has unbound immediate PersistentVolumeClaims"},
+		},
+		podsMountingPVC: map[string][]Ref{"prod/data": {{Kind: "Pod", Namespace: "prod", Name: "db-0"}}},
+	}
+	flat := Compose(p, Filters{Limit: NoLimit})
+	grouped := GroupIssues(flat)
+	got := RelatedIssuesFrom(flat, grouped, "", "Pod", "prod", "db-0")
+	if len(got) != 1 {
+		t.Fatalf("RelatedIssuesFrom(db-0) = %d, want 1", len(got))
+	}
+	if got[0].IncidentParent != nil {
+		t.Fatalf("bare GroupIssues pair must not carry incident_parent, got %+v", got[0].IncidentParent)
 	}
 }
 

--- a/packages/k8s-ui/src/components/issues/ResourceIssuesSection.tsx
+++ b/packages/k8s-ui/src/components/issues/ResourceIssuesSection.tsx
@@ -3,7 +3,7 @@ import { Section } from '../ui/drawer-components'
 import { Badge } from '../ui/Badge'
 import type { Issue, IssueResourceRef } from './types'
 import { categoryLabel } from './severity'
-import { diagnosticRoleLabel, diagnosticFactLabel, confidenceTitle } from './diagnostic'
+import { diagnosticRoleLabel, diagnosticFactLabel, confidenceTitle, incidentParentLabel } from './diagnostic'
 
 /**
  * ResourceIssuesSection — the compact "Operational Issues" block for the resource
@@ -63,6 +63,24 @@ export function ResourceIssuesSection({
                 <p className="mt-1 text-xs text-theme-text-tertiary">
                   Suggested fix: create namespace{' '}
                   <code className="rounded bg-theme-elevated px-1 font-mono">{issue.remediation_target}</code> — apply it from the GitOps detail page.
+                </p>
+              ) : null}
+              {issue.incident_parent ? (
+                <p className="mt-1 text-xs text-theme-text-tertiary">
+                  {incidentParentLabel(issue.incident_parent.fact_type, issue.incident_parent.confidence)}:{' '}
+                  {onResourceClick ? (
+                    <button
+                      type="button"
+                      onClick={() => onResourceClick(issue.incident_parent!.ref)}
+                      className="group inline-flex items-center gap-1 text-left font-mono hover:text-theme-text-secondary"
+                      title={confidenceTitle(issue.incident_parent.confidence ?? '')}
+                    >
+                      {issue.incident_parent.ref.kind} / {issue.incident_parent.ref.name}
+                      <ExternalLink className="h-3 w-3 opacity-0 group-hover:opacity-100" />
+                    </button>
+                  ) : (
+                    <span className="font-mono">{issue.incident_parent.ref.kind} / {issue.incident_parent.ref.name}</span>
+                  )}
                 </p>
               ) : null}
               <CausalContext issue={issue} onResourceClick={onResourceClick} />

--- a/packages/k8s-ui/src/components/issues/ResourceIssuesSection.tsx
+++ b/packages/k8s-ui/src/components/issues/ResourceIssuesSection.tsx
@@ -14,7 +14,7 @@ import { diagnosticRoleLabel, diagnosticFactLabel, confidenceTitle, incidentPare
  *
  * Header mirrors the queue: the plain `categoryLabel` is the operator-facing
  * headline and the raw `reason` rides alongside as a muted signal (so the K8s
- * jargon is available but not the lead). Body is intentionally just the plain
+ * jargon is available but not the lead). Body is primarily the plain
  * `cause` (which names the offending object) + the `Next step` — the diagnosis
  * and the fix. The raw `message`/evidence stays in the queue + MCP where the
  * locator detail is wanted; inline it mostly restated the cause or the category,
@@ -34,6 +34,7 @@ export function ResourceIssuesSection({
     <Section title={`Operational Issues (${issues.length})`} icon={AlertTriangle} defaultExpanded>
       <div className="space-y-3">
         {issues.map((issue) => {
+          const parent = issue.incident_parent
           return (
             <div key={issue.id} className="card-inner">
               <div className="mb-1 flex min-w-0 items-baseline gap-2">
@@ -65,21 +66,21 @@ export function ResourceIssuesSection({
                   <code className="rounded bg-theme-elevated px-1 font-mono">{issue.remediation_target}</code> — apply it from the GitOps detail page.
                 </p>
               ) : null}
-              {issue.incident_parent ? (
+              {parent ? (
                 <p className="mt-1 text-xs text-theme-text-tertiary">
-                  {incidentParentLabel(issue.incident_parent.fact_type, issue.incident_parent.confidence)}:{' '}
+                  {incidentParentLabel(parent.fact_type, parent.confidence)}:{' '}
                   {onResourceClick ? (
                     <button
                       type="button"
-                      onClick={() => onResourceClick(issue.incident_parent!.ref)}
+                      onClick={() => onResourceClick(parent.ref)}
                       className="group inline-flex items-center gap-1 text-left font-mono hover:text-theme-text-secondary"
-                      title={confidenceTitle(issue.incident_parent.confidence ?? '')}
+                      title={confidenceTitle(parent.confidence ?? '')}
                     >
-                      {issue.incident_parent.ref.kind} / {issue.incident_parent.ref.name}
+                      {parent.ref.kind} / {parent.ref.name}
                       <ExternalLink className="h-3 w-3 opacity-0 group-hover:opacity-100" />
                     </button>
                   ) : (
-                    <span className="font-mono">{issue.incident_parent.ref.kind} / {issue.incident_parent.ref.name}</span>
+                    <span className="font-mono">{parent.ref.kind} / {parent.ref.name}</span>
                   )}
                 </p>
               ) : null}


### PR DESCRIPTION
## Summary

Completes the symptom→root cause-pointer feature (#1056) by extending the `incident_parent` reverse pointer to the **per-resource surfaces** — the resource drawer's Operational Issues block, and the MCP `get_resource` / `diagnose` tools. #1056 shipped the pointer on the cluster Issues view + MCP `issues`; this closes the one remaining gap so every surface that shows an issue can show *why it exists*.

## What changed

The per-resource path (`RelatedIssues`, behind `/api/issues/resource/...`, `get_resource`, `diagnose`) composed issues in **flat/ungrouped** mode, where the whole-row coverage gate can't be evaluated — so `incident_parent` was deliberately left unset there (#1056 even removed the drawer back-pointer because nothing populated it).

Now `RelatedIssues` runs the **grouped-mode enrichment** (`enrichDiagnosticContext(grouped, flat, grouped, p)`) after grouping — exactly mirroring the cluster path — so the grouped issues get the same coverage-gated `incident_parent`. It's one extra enrichment pass (not a second `Compose`); the link computation reuses the already-composed flat + grouped sets.

- **Backend**: one-line addition in `RelatedIssues`.
- **Frontend**: re-adds the drawer back-pointer in `ResourceIssuesSection` ("Caused by: ‹kind/name›", honest per-fact-type wording, clickable) — now that the path populates it.
- **MCP** `get_resource` / `diagnose` carry `incident_parent` on their related issues automatically.

The coverage gate, best-parent rule, and direction allow-list are unchanged — the per-resource path now simply runs the same well-gated assignment.

**Scope note — slightly broader than the pointer alone**: the grouped-mode pass also recomputes `ChangeContext` on the grouped rows and collapses blast-radius `related_issues` to grouped refs with counts, so the drawer/MCP payloads now match what the cluster Issues view shows (previously they carried the flat representative's uncollapsed context). This is the intended parity, not an accident. The GitOps insights resolver's precomposed `RelatedIssuesFrom` path deliberately skips the enrichment — it projects issues down to `Reason/Message/Category/Severity`, so the pointer would be dropped anyway; the contract is documented on `RelatedIssuesFrom` and pinned by test.

## Testing
- `go test ./internal/issues ./internal/mcp ./internal/server` + `pkg/issuesapi` — green; `make tsc` green.
- New test `TestRelatedIssues_PopulatesIncidentParent`: a PVC + a covered unschedulable pod → `RelatedIssues` returns the pod issue with `incident_parent → PVC/data (high)`.
- New test `TestRelatedIssues_IncidentParentCoverageGate` (review follow-up): a root covering only 2 of 3 members of a grouped symptom must NOT attach the pointer — mutation-verified (passing the flat set as the grouped argument fails it).
- New test `TestRelatedIssuesFrom_NoIncidentParentOnBarePair` (review follow-up): pins that a bare `GroupIssues` pair yields rows without the pointer.
- **Live-verified on kind**: induced a pending PVC + a 2-replica Deployment mounting it → `/api/issues/resource/Deployment/...` returned the `unschedulable` issue with `incident_parent → PVC/data (high)`, and the resource drawer's Operational Issues rendered **"Caused by: PersistentVolumeClaim / data"** (clickable, 0 console errors).

## Not included
- **node blast-radius live-verify**: still unit-tested only. Inducing a node `MemoryPressure`/`DiskPressure`/`PIDPressure` condition requires actually exhausting the node's (host-shared) memory/disk on the single-node test cluster — too risky to do safely. The pointer + forward link are unit-tested; live verification waits for a disposable multi-node environment.
- **Demotion / true incident grouping**: still its own deferred effort.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes causal attribution on per-resource APIs and drawer UI; logic reuses existing coverage gates but wrong enrichment inputs could mis-parent grouped symptoms.
> 
> **Overview**
> Extends **coverage-gated `incident_parent`** (symptom → root) to per-resource issue surfaces by running grouped-mode `enrichDiagnosticContext` inside `RelatedIssues` after `GroupIssues`, matching the cluster Issues path. MCP `get_resource` / `diagnose` and `/api/issues/resource/...` pick this up without separate API changes.
> 
> **Contract:** `RelatedIssuesFrom` still only matches; callers that pass a bare `GroupIssues` pair (e.g. GitOps insights compose-once) do **not** get `incident_parent` unless they enrich themselves. Comments in `diagnostic_context.go`, `grouping.go`, and tests document that split.
> 
> **UI:** `ResourceIssuesSection` shows the back-pointer (`incidentParentLabel` + optional clickable `kind / name`) when the API populates `incident_parent`.
> 
> **Tests:** Happy path (PVC → unschedulable pod), whole-row coverage gate (partial fan-out → no pointer), and bare-pair vs enriched `RelatedIssues` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 197030a428e9d179805ebd8d370a0e93f4b223da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
