### PR TITLE
Improve audit detector precision

### DIFF
--- a/internal/k8s/detect.go
+++ b/internal/k8s/detect.go
@@ -1527,10 +1527,10 @@ func pdbBlocksEvictionsMessage(pdb *policyv1.PodDisruptionBudget) string {
 }
 
 // sharedRWOVolumeConflicts returns the names of PVCs the Deployment's pod
-// template MOUNTS whose access modes permit only single-node attach
-// (ReadWriteOnce / ReadWriteOncePod, no ReadWriteMany) — a hard conflict for a
-// multi-replica Deployment. Only PVCs present in cache with known access modes
-// are considered; an unverifiable PVC is skipped rather than guessed at.
+// template MOUNTS whose bound access modes permit only single-node attach
+// (ReadWriteOnce / ReadWriteOncePod, no ReadWriteMany). Pending PVCs are skipped
+// here because the binding/provisioning failure is the actionable blocker until a
+// real volume can attach.
 func sharedRWOVolumeConflicts(cache *ResourceCache, d *appsv1.Deployment) []string {
 	pvcl := cache.PersistentVolumeClaims()
 	if pvcl == nil {
@@ -1547,7 +1547,7 @@ func sharedRWOVolumeConflicts(cache *ResourceCache, d *appsv1.Deployment) []stri
 		if err != nil || pvc == nil {
 			continue
 		}
-		if pvcSingleNodeAccessOnly(pvc) {
+		if pvc.Status.Phase == corev1.ClaimBound && pvcSingleNodeAccessOnly(pvc) {
 			out = append(out, pvc.Name)
 		}
 	}

--- a/internal/k8s/detect_config.go
+++ b/internal/k8s/detect_config.go
@@ -98,6 +98,7 @@ func suspiciousCoreDNSReason(corefile string) (string, bool) {
 type envServiceRef struct {
 	namespace string
 	name      string
+	host      string
 	port      int32
 	display   string
 }
@@ -174,6 +175,15 @@ func findEnvServiceRefChecks(cache *ResourceCache, workloads []envServiceWorkloa
 	if cache == nil || cache.Services() == nil {
 		return nil
 	}
+	var nodeHosts map[string]bool
+	nodeHostsLoaded := false
+	isNodeHost := func(host string) bool {
+		if !nodeHostsLoaded {
+			nodeHosts = envServiceNodeHosts(cache)
+			nodeHostsLoaded = true
+		}
+		return nodeHosts[strings.ToLower(host)]
+	}
 	var out []EnvServiceRefCheck
 	for _, wl := range workloads {
 		containers := make([]corev1.Container, 0, len(wl.spec.InitContainers)+len(wl.spec.Containers))
@@ -198,6 +208,9 @@ func findEnvServiceRefChecks(cache *ResourceCache, workloads []envServiceWorkloa
 				}
 				ref, ok := parseEnvServiceRef(value, wl.namespace)
 				if !ok {
+					continue
+				}
+				if isNodeHost(ref.host) {
 					continue
 				}
 				age := ageSeconds(now, wl.created)
@@ -627,7 +640,7 @@ func parseEnvServiceRef(value, defaultNamespace string) (envServiceRef, bool) {
 	}
 
 	parts := strings.Split(host, ".")
-	ref := envServiceRef{namespace: defaultNamespace, port: int32(port64), display: fmt.Sprintf("%s:%d", host, port64)}
+	ref := envServiceRef{namespace: defaultNamespace, host: host, port: int32(port64), display: fmt.Sprintf("%s:%d", host, port64)}
 	switch {
 	case len(parts) == 1:
 		ref.name = parts[0]
@@ -644,6 +657,31 @@ func parseEnvServiceRef(value, defaultNamespace string) (envServiceRef, bool) {
 		return envServiceRef{}, false
 	}
 	return ref, true
+}
+
+func envServiceNodeHosts(cache *ResourceCache) map[string]bool {
+	out := map[string]bool{}
+	if cache == nil || cache.Nodes() == nil {
+		return out
+	}
+	nodes, err := cache.Nodes().List(labels.Everything())
+	if err != nil {
+		logConfigListError("Node", "", err)
+		return out
+	}
+	add := func(value string) {
+		value = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(value), "."))
+		if value != "" {
+			out[value] = true
+		}
+	}
+	for _, node := range nodes {
+		add(node.Name)
+		for _, addr := range node.Status.Addresses {
+			add(addr.Address)
+		}
+	}
+	return out
 }
 
 func splitHostPort(value string) (string, string, bool) {

--- a/internal/k8s/detect_missing_refs.go
+++ b/internal/k8s/detect_missing_refs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"log"
+	"sort"
 	"strings"
 	"time"
 
@@ -627,14 +628,23 @@ func DetectMissingWebhookRefs(cache *ResourceCache, dynamicCache *DynamicResourc
 		return items
 	}
 
-	emit := func(kind, group, name, source, svcNS, svcName string, age time.Duration) Detection {
-		return withFix(missingRefProblem(kind, group, "", name,
-			"Missing webhook backend Service",
-			fmt.Sprintf("%s references Service %q in namespace %q which does not exist",
-				source, svcName, svcNS),
+	emit := func(kind, group, name, sourceRefPhrase, svcNS, svcName, severity, policySummary string, age time.Duration) Detection {
+		reason := "Missing webhook backend Service"
+		cause := fmt.Sprintf("Webhook backend Service %q in namespace %q doesn't exist.", svcName, svcNS)
+		if severity == "warning" {
+			cause += " One or more referencing webhooks use failurePolicy=Ignore, so admission proceeds but the webhook's validation or mutation is bypassed."
+		} else {
+			cause += " At least one referencing webhook uses failurePolicy=Fail (the Kubernetes default), so matching admission requests are blocked."
+		}
+		det := withFix(missingRefProblemSev(kind, group, "", name, severity,
+			reason,
+			fmt.Sprintf("%s Service %q in namespace %q which does not exist (%s)",
+				sourceRefPhrase, svcName, svcNS, policySummary),
 			age),
-			fmt.Sprintf("Webhook backend Service %q in namespace %q doesn't exist, so admission requests can't reach it — rules are bypassed (failurePolicy=Ignore) or admission is blocked (failurePolicy=Fail).", svcName, svcNS),
+			cause,
 			fmt.Sprintf("Restore Service %q and its endpoints in namespace %q, or fix clientConfig.service to point at the correct healthy Service.", svcName, svcNS))
+		det.Fingerprint = missingRefFingerprint(reason, "clientConfig.service:"+svcNS+"/"+svcName)
+		return det
 	}
 
 	checkWebhookList := func(items []*unstructured.Unstructured, ownerKind, ownerGroup, webhookPath string) []Detection {
@@ -645,7 +655,7 @@ func DetectMissingWebhookRefs(cache *ResourceCache, dynamicCache *DynamicResourc
 				continue
 			}
 			age := now.Sub(item.GetCreationTimestamp().Time)
-			seen := map[string]bool{}
+			missingByService := map[string]*webhookMissingBackend{}
 			for _, w := range webhooks {
 				wm, ok := w.(map[string]any)
 				if !ok {
@@ -660,16 +670,24 @@ func DetectMissingWebhookRefs(cache *ResourceCache, dynamicCache *DynamicResourc
 				if svcName == "" || svcNS == "" {
 					continue
 				}
-				key := svcNS + "/" + svcName
-				if seen[key] {
-					continue
-				}
-				seen[key] = true
 				if _, err := svcLister.Services(svcNS).Get(svcName); err != nil {
 					whName, _ := wm["name"].(string)
-					source := fmt.Sprintf("webhook %q clientConfig.service", whName)
-					problems = append(problems, emit(ownerKind, ownerGroup, item.GetName(), source, svcNS, svcName, age))
+					policy := webhookFailurePolicy(wm)
+					key := svcNS + "/" + svcName
+					missing := missingByService[key]
+					if missing == nil {
+						missing = &webhookMissingBackend{
+							serviceNamespace: svcNS,
+							serviceName:      svcName,
+						}
+						missingByService[key] = missing
+					}
+					missing.addWebhook(whName, policy)
 				}
+			}
+			for _, key := range sortedWebhookMissingBackendKeys(missingByService) {
+				missing := missingByService[key]
+				problems = append(problems, emit(ownerKind, ownerGroup, item.GetName(), missing.sourceReferencePhrase(), missing.serviceNamespace, missing.serviceName, missing.severity, missing.policySummary(), age))
 			}
 		}
 		return problems
@@ -685,6 +703,76 @@ func DetectMissingWebhookRefs(cache *ResourceCache, dynamicCache *DynamicResourc
 		"MutatingWebhookConfiguration", "admissionregistration.k8s.io", "webhooks",
 	)...)
 	return out
+}
+
+type webhookMissingBackend struct {
+	serviceNamespace string
+	serviceName      string
+	severity         string
+	webhooks         []string
+	policies         map[string]bool
+}
+
+func (m *webhookMissingBackend) addWebhook(name string, policy string) {
+	if name == "" {
+		name = "<unnamed>"
+	}
+	m.webhooks = append(m.webhooks, name)
+	if m.policies == nil {
+		m.policies = map[string]bool{}
+	}
+	m.policies[policy] = true
+	severity := webhookFailurePolicySeverity(policy)
+	if m.severity == "" || severity == "critical" {
+		m.severity = severity
+	}
+}
+
+func (m *webhookMissingBackend) sourceReferencePhrase() string {
+	names := append([]string(nil), m.webhooks...)
+	sort.Strings(names)
+	quoted := make([]string, 0, len(names))
+	for _, name := range names {
+		quoted = append(quoted, fmt.Sprintf("%q", name))
+	}
+	if len(quoted) == 1 {
+		return fmt.Sprintf("webhook %s clientConfig.service references", quoted[0])
+	}
+	return fmt.Sprintf("webhooks %s clientConfig.service reference", strings.Join(quoted, ", "))
+}
+
+func (m *webhookMissingBackend) policySummary() string {
+	if m.policies["Fail"] {
+		if m.policies["Ignore"] {
+			return "failurePolicy=Fail/Ignore"
+		}
+		return "failurePolicy=Fail"
+	}
+	return "failurePolicy=Ignore"
+}
+
+func webhookFailurePolicy(wm map[string]any) string {
+	policy, _, _ := unstructured.NestedString(wm, "failurePolicy")
+	if strings.EqualFold(policy, "Ignore") {
+		return "Ignore"
+	}
+	return "Fail"
+}
+
+func webhookFailurePolicySeverity(policy string) string {
+	if policy == "Ignore" {
+		return "warning"
+	}
+	return "critical"
+}
+
+func sortedWebhookMissingBackendKeys(in map[string]*webhookMissingBackend) []string {
+	keys := make([]string, 0, len(in))
+	for key := range in {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // DetectMissingGatewayRefs scans Gateway API Routes for backend Service refs

--- a/internal/k8s/detect_missing_refs_test.go
+++ b/internal/k8s/detect_missing_refs_test.go
@@ -639,6 +639,59 @@ func TestDetectMissingWebhookRefs(t *testing.T) {
 	}
 }
 
+func TestDetectMissingWebhookRefsFailurePolicySeverity(t *testing.T) {
+	defer ResetTestState()
+	defer ResetTestDynamicState()
+
+	now := metav1.NewTime(time.Now().Add(-5 * time.Minute))
+	client := fake.NewClientset()
+	if err := InitTestResourceCache(client); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+
+	vwhGVR := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "validatingwebhookconfigurations"}
+	scheme := runtime.NewScheme()
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{vwhGVR: "ValidatingWebhookConfigurationList"},
+		webhookConfig("ValidatingWebhookConfiguration", "validate-policy", now, []any{
+			webhookWithServicePolicy("explicit-ignore", "hooks", "ignore-svc", "Ignore"),
+			webhookWithServicePolicy("explicit-fail", "hooks", "fail-svc", "Fail"),
+			webhookWithService("default-fail", "hooks", "default-svc"),
+			webhookWithServicePolicy("mixed-ignore", "hooks", "mixed-svc", "Ignore"),
+			webhookWithServicePolicy("mixed-fail", "hooks", "mixed-svc", "Fail"),
+			webhookWithURL("external"),
+		}),
+	)
+	if err := InitTestDynamicResourceCache(dynClient, []APIResource{
+		{Group: "admissionregistration.k8s.io", Version: "v1", Kind: "ValidatingWebhookConfiguration", Name: "validatingwebhookconfigurations", Verbs: []string{"list", "watch"}},
+	}); err != nil {
+		t.Fatalf("InitTestDynamicResourceCache: %v", err)
+	}
+	dynCache := GetDynamicResourceCache()
+	if err := dynCache.EnsureWatching(vwhGVR); err != nil {
+		t.Fatalf("EnsureWatching validating webhooks: %v", err)
+	}
+	if !dynCache.WaitForSync(vwhGVR, 2*time.Second) {
+		t.Fatal("validating webhook dynamic cache did not sync")
+	}
+
+	problems := DetectMissingWebhookRefs(GetResourceCache(), dynCache, GetResourceDiscovery(), "")
+	if len(problems) != 4 {
+		t.Fatalf("expected one row per missing backend Service, got %d: %+v", len(problems), problems)
+	}
+	assertWebhookBackendSeverity(t, problems, "ignore-svc", "warning", "failurePolicy=Ignore")
+	assertWebhookBackendSeverity(t, problems, "fail-svc", "critical", "failurePolicy=Fail")
+	assertWebhookBackendSeverity(t, problems, "default-svc", "critical", "failurePolicy=Fail")
+	assertWebhookBackendSeverity(t, problems, "mixed-svc", "critical", "failurePolicy=Fail/Ignore")
+	assertWebhookBackendMessage(t, problems, "mixed-svc", `webhooks "mixed-fail", "mixed-ignore" clientConfig.service reference Service`)
+	for _, p := range problems {
+		if hasSubstr(p.Message, "external") {
+			t.Errorf("URL-based webhook should not flag: %+v", p)
+		}
+	}
+}
+
 func TestDetectMissingGatewayRefs(t *testing.T) {
 	defer ResetTestState()
 	defer ResetTestDynamicState()
@@ -906,7 +959,11 @@ func gatewayReferenceGrant(name, namespace string, ts metav1.Time, fromGroup, fr
 }
 
 func webhookWithService(name, namespace, service string) map[string]any {
-	return map[string]any{
+	return webhookWithServicePolicy(name, namespace, service, "")
+}
+
+func webhookWithServicePolicy(name, namespace, service, failurePolicy string) map[string]any {
+	webhook := map[string]any{
 		"name": name,
 		"clientConfig": map[string]any{
 			"service": map[string]any{
@@ -915,6 +972,40 @@ func webhookWithService(name, namespace, service string) map[string]any {
 			},
 		},
 	}
+	if failurePolicy != "" {
+		webhook["failurePolicy"] = failurePolicy
+	}
+	return webhook
+}
+
+func assertWebhookBackendSeverity(t *testing.T, problems []Detection, service, severity, policyText string) {
+	t.Helper()
+	for _, p := range problems {
+		if !hasSubstr(p.Message, service) {
+			continue
+		}
+		if p.Severity != severity {
+			t.Fatalf("%s severity = %q, want %q: %+v", service, p.Severity, severity, p)
+		}
+		if !hasSubstr(p.Message, policyText) || !hasSubstr(p.Cause, "failurePolicy=") {
+			t.Fatalf("%s should name policy in message/cause, got message=%q cause=%q", service, p.Message, p.Cause)
+		}
+		return
+	}
+	t.Fatalf("missing webhook backend problem for Service %s: %+v", service, problems)
+}
+
+func assertWebhookBackendMessage(t *testing.T, problems []Detection, service, text string) {
+	t.Helper()
+	for _, p := range problems {
+		if hasSubstr(p.Message, service) {
+			if !hasSubstr(p.Message, text) {
+				t.Fatalf("%s message = %q, want substring %q", service, p.Message, text)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing webhook backend problem for Service %s: %+v", service, problems)
 }
 
 func webhookWithURL(name string) map[string]any {

--- a/internal/k8s/detect_scheduling.go
+++ b/internal/k8s/detect_scheduling.go
@@ -122,7 +122,7 @@ func parseSchedulerMessage(msg string) (totalNodes int, reasons []SchedulingReas
 	}
 
 	for clause := range strings.SplitSeq(clauseStr, ", ") {
-		clause = strings.TrimSpace(clause)
+		clause = normalizeSchedulerClause(clause)
 		if clause == "" {
 			continue
 		}
@@ -133,11 +133,19 @@ func parseSchedulerMessage(msg string) (totalNodes int, reasons []SchedulingReas
 	return totalNodes, reasons
 }
 
+func normalizeSchedulerClause(clause string) string {
+	return strings.TrimSpace(strings.TrimRight(strings.TrimSpace(clause), ",."))
+}
+
 // classifyClause maps one scheduler clause to a structured reason. The
 // substring checks are ordered so the more specific phrasings win (e.g.
 // "anti-affinity" before "affinity", "node affinity/selector" before the
 // bare "affinity" used by pod-affinity).
 func classifyClause(clause string) (SchedulingReason, bool) {
+	clause = normalizeSchedulerClause(clause)
+	if clause == "" {
+		return SchedulingReason{}, false
+	}
 	r := SchedulingReason{Raw: clause}
 	if m := reLeadingCount.FindStringSubmatch(clause); m != nil {
 		r.NodeCount, _ = strconv.Atoi(m[1])
@@ -183,6 +191,8 @@ func classifyClause(clause string) (SchedulingReason, bool) {
 	case strings.Contains(lower, "unbound") && strings.Contains(lower, "persistentvolumeclaim"),
 		strings.Contains(lower, "persistent volumes to bind"):
 		r.Class = SchedVolumeBinding
+	case isIgnoredSchedulerClause(clause):
+		return SchedulingReason{}, false
 	case strings.Contains(lower, "unschedulable"), strings.Contains(lower, "were not ready"):
 		r.Class = SchedNodeUnschedulable
 	default:
@@ -554,6 +564,12 @@ func renderUnschedulableMessage(pod *corev1.Pod, schedMsg string, total int, rea
 		parts = append(parts, summary)
 	}
 	if len(parts) == 0 {
+		if total > 0 {
+			return fmt.Sprintf("Pod is unschedulable (0/%d nodes available)", total)
+		}
+		if schedulerMessageOnlyIgnoredNoise(schedMsg) {
+			return "Pod is unschedulable"
+		}
 		if msg := strings.TrimSpace(schedMsg); msg != "" {
 			return msg
 		}
@@ -564,6 +580,42 @@ func renderUnschedulableMessage(pod *corev1.Pod, schedMsg string, total int, rea
 		msg = fmt.Sprintf("%s (0/%d nodes available)", msg, total)
 	}
 	return msg
+}
+
+func schedulerMessageOnlyIgnoredNoise(msg string) bool {
+	msg = strings.TrimSpace(msg)
+	if msg == "" {
+		return false
+	}
+	if before, _, ok := strings.Cut(msg, ". preemption:"); ok {
+		msg = before
+	} else if before, _, ok := strings.Cut(msg, " preemption:"); ok {
+		msg = before
+	}
+	if _, rest, ok := strings.Cut(msg, ":"); ok {
+		msg = rest
+	}
+	msg = strings.TrimRight(strings.TrimSpace(msg), ".")
+	if msg == "" {
+		return false
+	}
+
+	sawIgnored := false
+	for clause := range strings.SplitSeq(msg, ", ") {
+		clause = normalizeSchedulerClause(clause)
+		if clause == "" {
+			continue
+		}
+		if !isIgnoredSchedulerClause(clause) {
+			return false
+		}
+		sawIgnored = true
+	}
+	return sawIgnored
+}
+
+func isIgnoredSchedulerClause(clause string) bool {
+	return strings.Contains(strings.ToLower(normalizeSchedulerClause(clause)), "no new claims to deallocate")
 }
 
 // unschedulableAction turns the parsed scheduler reasons into a concrete next
@@ -694,7 +746,7 @@ func summarizeReasons(reasons []SchedulingReason, skipAffinity bool) string {
 			}
 		}
 	}
-	return strings.Join(parts, ", ")
+	return strings.Join(nonEmptySchedulerSummaryParts(parts), ", ")
 }
 
 func nodesPhrase(n int) string {
@@ -702,6 +754,17 @@ func nodesPhrase(n int) string {
 		return "node(s)"
 	}
 	return fmt.Sprintf("%d node(s)", n)
+}
+
+func nonEmptySchedulerSummaryParts(parts []string) []string {
+	out := parts[:0]
+	for _, part := range parts {
+		part = normalizeSchedulerClause(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
 }
 
 // extractPodPlacement pulls the pod's node-targeting constraints (nodeSelector

--- a/internal/k8s/detect_scheduling_test.go
+++ b/internal/k8s/detect_scheduling_test.go
@@ -103,6 +103,44 @@ func TestParseSchedulerMessage_WholeMessageVariants(t *testing.T) {
 	}
 }
 
+func TestDescribeUnschedulable_DropsDRADeallocateJargon(t *testing.T) {
+	pod := &corev1.Pod{}
+	msg := describeUnschedulable(pod,
+		"0/1 nodes are available: no new claims to deallocate,, 1 node(s) didn't have free ports for the requested pod ports.",
+		nil)
+	if strings.Contains(msg, ",,") {
+		t.Fatalf("message should not contain double comma: %q", msg)
+	}
+	if strings.Contains(msg, "no new claims to deallocate") {
+		t.Fatalf("message should drop DRA scheduler jargon: %q", msg)
+	}
+	if !strings.Contains(msg, "1 node(s) no free host ports") {
+		t.Fatalf("message should retain the actionable host-port conflict: %q", msg)
+	}
+
+	draOnly := describeUnschedulable(pod,
+		"0/1 nodes are available: no new claims to deallocate.",
+		nil)
+	if strings.Contains(draOnly, "no new claims to deallocate") {
+		t.Fatalf("DRA-only message should not fall back to raw scheduler jargon: %q", draOnly)
+	}
+	if draOnly != "Pod is unschedulable (0/1 nodes available)" {
+		t.Fatalf("DRA-only message = %q, want generic node-count summary", draOnly)
+	}
+
+	draOnlyWithoutNodeCount := describeUnschedulable(pod, "no new claims to deallocate", nil)
+	if draOnlyWithoutNodeCount != "Pod is unschedulable" {
+		t.Fatalf("DRA-only message without node count = %q, want generic summary", draOnlyWithoutNodeCount)
+	}
+
+	repeatedDRAOnly := describeUnschedulable(pod,
+		"scheduler plugin details: no new claims to deallocate, no new claims to deallocate.",
+		nil)
+	if repeatedDRAOnly != "Pod is unschedulable" {
+		t.Fatalf("repeated DRA-only message = %q, want generic summary", repeatedDRAOnly)
+	}
+}
+
 func TestParseSchedulerMessage_Empty(t *testing.T) {
 	if total, reasons := parseSchedulerMessage(""); total != 0 || reasons != nil {
 		t.Errorf("empty message should yield 0/nil, got %d/%+v", total, reasons)

--- a/internal/k8s/detect_test.go
+++ b/internal/k8s/detect_test.go
@@ -422,6 +422,51 @@ func TestDetectProblems_ConfigSignals(t *testing.T) {
 		}
 	})
 
+	t.Run("node address endpoint is not treated as missing service", func(t *testing.T) {
+		defer ResetTestState()
+
+		client := fake.NewClientset(
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "kind-node-1"},
+				Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{
+					{Type: corev1.NodeHostName, Address: "kind-node-1"},
+					{Type: corev1.NodeInternalDNS, Address: "radar-gitops-demo-control-plane"},
+				}},
+			},
+			&appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "kindnet", Namespace: "kube-system", CreationTimestamp: metav1.NewTime(time.Now().Add(-5 * time.Minute))},
+				Spec: appsv1.DaemonSetSpec{
+					Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{
+						Name: "kindnet",
+						Env: []corev1.EnvVar{{
+							Name:  "CONTROL_PLANE_ENDPOINT",
+							Value: "radar-gitops-demo-control-plane:6443",
+						}},
+					}}}},
+				},
+				Status: appsv1.DaemonSetStatus{
+					DesiredNumberScheduled: 1,
+					NumberUnavailable:      1,
+				},
+			},
+		)
+		if err := InitTestResourceCache(client); err != nil {
+			t.Fatalf("InitTestResourceCache: %v", err)
+		}
+
+		time.Sleep(200 * time.Millisecond)
+		for _, c := range FindEnvServiceRefChecks(GetResourceCache(), "kube-system") {
+			if c.Status == "missing_service" {
+				t.Fatalf("node address endpoint should not emit missing_service check: %+v", c)
+			}
+		}
+		for _, p := range DetectProblems(GetResourceCache(), "kube-system") {
+			if p.Reason == "Missing referenced Service" {
+				t.Fatalf("node address endpoint should not promote to Issue: %+v", p)
+			}
+		}
+	})
+
 	t.Run("cross namespace env service ref is not promoted to issue", func(t *testing.T) {
 		defer ResetTestState()
 
@@ -2037,20 +2082,25 @@ func TestDetectProblems_SharedRWOVolume(t *testing.T) {
 			},
 		}
 	}
-	mkPVC := func(name string, mode corev1.PersistentVolumeAccessMode) *corev1.PersistentVolumeClaim {
+	mkPVCPhase := func(name string, phase corev1.PersistentVolumeClaimPhase, mode corev1.PersistentVolumeAccessMode) *corev1.PersistentVolumeClaim {
 		return &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "prod"},
 			Spec:       corev1.PersistentVolumeClaimSpec{AccessModes: []corev1.PersistentVolumeAccessMode{mode}},
-			Status:     corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound, AccessModes: []corev1.PersistentVolumeAccessMode{mode}},
+			Status:     corev1.PersistentVolumeClaimStatus{Phase: phase, AccessModes: []corev1.PersistentVolumeAccessMode{mode}},
 		}
+	}
+	mkPVC := func(name string, mode corev1.PersistentVolumeAccessMode) *corev1.PersistentVolumeClaim {
+		return mkPVCPhase(name, corev1.ClaimBound, mode)
 	}
 
 	client := fake.NewClientset(
 		mkDeploy("conflict", &two, "rwo-pvc"), // 2 replicas + RWO → flagged
 		mkDeploy("single", &one, "rwo-pvc"),   // 1 replica + RWO → fine
 		mkDeploy("rwx", &three, "rwx-pvc"),    // 3 replicas + RWX → fine
+		mkDeploy("pending", &two, "pending-pvc"),
 		mkPVC("rwo-pvc", corev1.ReadWriteOnce),
 		mkPVC("rwx-pvc", corev1.ReadWriteMany),
+		mkPVCPhase("pending-pvc", corev1.ClaimPending, corev1.ReadWriteOnce),
 	)
 	if err := InitTestResourceCache(client); err != nil {
 		t.Fatalf("InitTestResourceCache: %v", err)
@@ -2073,6 +2123,9 @@ func TestDetectProblems_SharedRWOVolume(t *testing.T) {
 	}
 	if hasProblem(problems, "Deployment", "rwx", reason) {
 		t.Errorf("multi-replica RWX mount should not be flagged: %+v", problems)
+	}
+	if hasProblem(problems, "Deployment", "pending", reason) {
+		t.Errorf("Pending RWO PVC should surface as a binding issue, not a replica access conflict: %+v", problems)
 	}
 }
 


### PR DESCRIPTION
## Summary

Improves audit detector precision for noisy real-cluster findings so Radar separates broken dependencies from benign infrastructure endpoints and scheduler/status noise. Operators should see fewer false positives while genuinely risky missing admission webhook backends and workload blockers remain visible.

Linear: SKY-1091

## What changed

- Admission webhook backend checks now account for `failurePolicy`: absent/default/explicit `Fail` reports as critical, explicit `Ignore` reports as warning, and multiple webhooks that share the same missing backend Service collapse into one issue using the worst severity and stable ordering/fingerprints.
- Config/env Service reference detection now suppresses node-host endpoints, including node names, hostnames, and node addresses such as kind-style control-plane `host:6443` values, while still reporting normal Service-shaped values.
- Scheduler unschedulable diagnosis drops empty fragments and noisy DRA deallocate-only jargon, but still preserves useful clauses such as host-port conflicts and falls back to a generic scheduler message when DRA text is the only clue.
- ReadWriteOnce volume-conflict detection now requires a `Bound` PVC, so pending PVCs stay classified as storage provisioning problems instead of volume-conflict alerts.

## Testing

- `go test ./internal/k8s -run 'TestDetectMissingWebhookRefs|TestDetectProblems_ConfigSignals|TestFindEnvServiceRefChecks_SplitHostPort|TestDescribeUnschedulable_DropsDRADeallocateJargon|TestDetectProblems_SharedRWOVolume'`
- `go test ./internal/k8s`
- `make tsc`
- `make test`
- `make build`

Live/API checks:
- Local demo cluster: Radar connected, CRD discovery completed, and the detector-focused issue filter returned zero webhook-backend, node-host, DRA-jargon, or ReadWriteOnce false positives.
- Managed GKE cluster with a missing admission webhook backend using `failurePolicy=Fail`: `/api/issues?limit=500` surfaced the missing backend as `critical` and the cause copy said matching admission requests can be blocked.
- Managed GKE cluster with three `failurePolicy=Ignore` webhooks sharing the same missing backend Service: Radar collapsed them into one `warning` issue, preserved the webhook names in stable order, and the cause copy said admission proceeds while validation or mutation is bypassed.
- Managed GKE clusters with hostPort scheduling pressure: scheduler issue copy preserved the actionable `no free host ports` reason and did not include the DRA-only `no new claims to deallocate` scheduler plugin text.
- Managed GKE and EKS clusters without these specific failure modes: detector-focused checks found zero `kind-control-plane` node-host false positives, zero DRA-jargon strings, and zero ReadWriteOnce conflict strings on pending/unbound storage cases.

Visual-test: skipped, because this is backend detector and diagnosis-copy logic with no rendered UI component changes.

## Notes / risk

Blast radius is limited to audit issue generation for admission webhook backends, config/env Service reference detection, scheduler unschedulable copy, and RWO volume-conflict classification. The main residual risks are over-suppressing a genuinely missing Service whose host exactly matches a node name/address, or failing to suppress node endpoints when Nodes cannot be listed; both affect issue visibility only, not cluster mutation. Unit tests and live checks against local, GKE, and EKS clusters cover the intended scenarios.
