### PR TITLE
Improve missing-ref remediation copy

### DIFF
--- a/internal/k8s/detect_crd_refs.go
+++ b/internal/k8s/detect_crd_refs.go
@@ -57,7 +57,7 @@ func detectRolloutMissingServices(cache *ResourceCache, dynamicCache *DynamicRes
 				fmt.Sprintf("%s references Service %q which does not exist", ref.path, ref.name),
 				age),
 				fmt.Sprintf("Service %q doesn't exist, so the Rollout controller can't shift traffic during a rollout.", ref.name),
-				fmt.Sprintf("Create Service %q in namespace %q, or point the Rollout's service ref at an existing Service.", ref.name, ro.GetNamespace())))
+				fmt.Sprintf("Point the Rollout's %s at an existing Service in namespace %q, or create Service %q if the rollout should still use it.", ref.path, ro.GetNamespace(), ref.name)))
 		}
 	}
 	return out
@@ -120,7 +120,7 @@ func detectKEDAMissingScaleTargets(cache *ResourceCache, dynamicCache *DynamicRe
 			fmt.Sprintf("spec.scaleTargetRef references %s %q which does not exist", ref.kind, ref.name),
 			age),
 			fmt.Sprintf("%s %q doesn't exist, so KEDA has nothing to scale.", ref.kind, ref.name),
-			fmt.Sprintf("Create %s %q in namespace %q, or point spec.scaleTargetRef at an existing workload.", ref.kind, ref.name, so.GetNamespace())))
+			fmt.Sprintf("Point spec.scaleTargetRef at an existing workload in namespace %q, remove the ScaledObject if the target is obsolete, or create %s %q if it should still exist.", so.GetNamespace(), ref.kind, ref.name)))
 	}
 	return out
 }

--- a/internal/k8s/detect_missing_refs.go
+++ b/internal/k8s/detect_missing_refs.go
@@ -128,14 +128,14 @@ func cmRefDiag(where, name, ns string) (reason, message, cause, action string) {
 	return "Missing ConfigMap",
 		fmt.Sprintf("%s references ConfigMap %q which does not exist", where, name),
 		fmt.Sprintf("ConfigMap %q, referenced by the pod's %s, doesn't exist — so the pod can't start.", name, where),
-		fmt.Sprintf("Create ConfigMap %q in namespace %q, mark the reference optional, or remove it.", name, ns)
+		fmt.Sprintf("Update the pod template (or recreate this Pod) to point the %s reference at an existing ConfigMap in namespace %q, mark the reference optional, remove it if obsolete, or create ConfigMap %q if the workload still requires it.", where, ns, name)
 }
 
 func secretRefDiag(where, name, ns string) (reason, message, cause, action string) {
 	return "Missing Secret",
 		fmt.Sprintf("%s references Secret %q which does not exist", where, name),
 		fmt.Sprintf("Secret %q, referenced by the pod's %s, doesn't exist — so the pod can't start.", name, where),
-		fmt.Sprintf("Create Secret %q in namespace %q, mark the reference optional, or remove it.", name, ns)
+		fmt.Sprintf("Update the pod template (or recreate this Pod) to point the %s reference at an existing Secret in namespace %q, mark the reference optional, remove it if obsolete, or create Secret %q if the workload still requires it.", where, ns, name)
 }
 
 // isTerminalPod reports whether a pod has terminally finished — Succeeded, or
@@ -205,7 +205,7 @@ func detectPodMissingRefs(cache *ResourceCache, namespace string, now time.Time)
 					emit("Missing PVC",
 						fmt.Sprintf("volume references PersistentVolumeClaim %q which does not exist", name),
 						fmt.Sprintf("PersistentVolumeClaim %q doesn't exist, so the pod can't be scheduled.", name),
-						fmt.Sprintf("Create PVC %q in namespace %q, or fix the volume's claimName.", name, p.Namespace))
+						fmt.Sprintf("Update the pod template (or recreate this Pod) so the volume's claimName points at an existing PVC in namespace %q, remove the volume/mount if obsolete, or create PVC %q if the pod still needs a new claim.", p.Namespace, name))
 				}
 
 			case v.ConfigMap != nil:
@@ -318,7 +318,7 @@ func detectPodMissingRefs(cache *ResourceCache, namespace string, now time.Time)
 					emit("Missing ServiceAccount",
 						fmt.Sprintf("references ServiceAccount %q which does not exist", sa),
 						fmt.Sprintf("ServiceAccount %q doesn't exist, so the pod can't start (or restart) with its expected identity/token.", sa),
-						fmt.Sprintf("Create ServiceAccount %q in namespace %q, or remove spec.serviceAccountName.", sa, p.Namespace))
+						fmt.Sprintf("Update the pod template (or recreate this Pod) so spec.serviceAccountName points at an existing ServiceAccount in namespace %q, remove it to use the default ServiceAccount, or create ServiceAccount %q if the pod needs that identity.", p.Namespace, sa))
 				}
 			}
 		}
@@ -342,7 +342,7 @@ func detectPodMissingRefs(cache *ResourceCache, namespace string, now time.Time)
 				emit("Missing imagePullSecret",
 					fmt.Sprintf("imagePullSecrets references Secret %q which does not exist", name),
 					fmt.Sprintf("Pull Secret %q doesn't exist, so private-registry image pulls fail (ImagePullBackOff).", name),
-					fmt.Sprintf("Create pull Secret %q in namespace %q, or point imagePullSecrets / the ServiceAccount at an existing one.", name, p.Namespace))
+					fmt.Sprintf("Update the pod template, recreate this Pod, or update the ServiceAccount to point at an existing pull Secret in namespace %q; remove the reference if images are public or obsolete, or create pull Secret %q if private-registry credentials are required.", p.Namespace, name))
 			}
 		}
 	}
@@ -377,7 +377,7 @@ func detectHPAMissingTarget(cache *ResourceCache, namespace string, now time.Tim
 			fmt.Sprintf("scaleTargetRef references %s %q which does not exist", ref.Kind, ref.Name),
 			age),
 			fmt.Sprintf("%s %q doesn't exist, so the autoscaler can't scale anything.", ref.Kind, ref.Name),
-			fmt.Sprintf("Create %s %q in namespace %q, or point scaleTargetRef at an existing workload.", ref.Kind, ref.Name, h.Namespace)))
+			fmt.Sprintf("Point scaleTargetRef at an existing workload in namespace %q, remove the HPA if the target is obsolete, or create %s %q if it should still exist.", h.Namespace, ref.Kind, ref.Name)))
 	}
 	return out
 }
@@ -458,7 +458,7 @@ func detectIngressMissingBackend(cache *ResourceCache, namespace string, now tim
 					fmt.Sprintf("%s references Service %q which does not exist", sourcePath, b.Name),
 					age),
 					fmt.Sprintf("Service %q doesn't exist, so this route serves nothing.", b.Name),
-					fmt.Sprintf("Create Service %q in namespace %q, or point the rule at an existing Service.", b.Name, ing.Namespace)))
+					fmt.Sprintf("Point the backend at an existing Service in namespace %q, remove the stale backend, or create Service %q if it should still receive traffic.", ing.Namespace, b.Name)))
 				return
 			}
 			// Service exists — verify the port resolves.
@@ -486,7 +486,7 @@ func detectIngressMissingBackend(cache *ResourceCache, namespace string, now tim
 					fmt.Sprintf("%s targets Service %q port %q which the Service does not expose", sourcePath, b.Name, portDesc),
 					age),
 					fmt.Sprintf("Service %q does not expose port %q, so traffic to this route is dropped.", b.Name, portDesc),
-					fmt.Sprintf("Add port %q to Service %q's spec.ports in namespace %q, or reference a port it already exposes.", portDesc, b.Name, ing.Namespace)))
+					fmt.Sprintf("Point the backend at a port Service %q already exposes in namespace %q, or add port %q to the Service's spec.ports if it should expose it.", b.Name, ing.Namespace, portDesc)))
 			}
 		}
 
@@ -522,7 +522,7 @@ func detectIngressMissingBackend(cache *ResourceCache, namespace string, now tim
 					fmt.Sprintf("tls[].secretName references Secret %q which does not exist", tls.SecretName),
 					age),
 					fmt.Sprintf("TLS Secret %q doesn't exist, so the controller may serve its default/self-signed cert and HTTPS clients see warnings.", tls.SecretName),
-					fmt.Sprintf("Create TLS Secret %q (type kubernetes.io/tls) in namespace %q, or remove the tls entry.", tls.SecretName, ing.Namespace))
+					fmt.Sprintf("Point tls[].secretName at an existing kubernetes.io/tls Secret in namespace %q, remove the tls entry, or create TLS Secret %q if this host still needs TLS.", ing.Namespace, tls.SecretName))
 				p.Severity = "warning"
 				out = append(out, p)
 			}
@@ -578,7 +578,7 @@ func detectStatefulSetMissingService(cache *ResourceCache, namespace string, now
 			out = append(out, withFix(missingRefProblemSev("StatefulSet", "apps", sts.Namespace, sts.Name,
 				severity, "Missing headless Service", message, age),
 				cause,
-				fmt.Sprintf("Create headless Service %q in namespace %q (clusterIP: None) selecting the StatefulSet's pods, or fix spec.serviceName.", sts.Spec.ServiceName, sts.Namespace)))
+				fmt.Sprintf("Create headless Service %q (clusterIP: None) selecting the StatefulSet's pods in namespace %q, or recreate the StatefulSet with spec.serviceName pointing at an existing headless Service (serviceName is immutable).", sts.Spec.ServiceName, sts.Namespace)))
 		}
 	}
 	return out
@@ -796,7 +796,7 @@ func detectGatewayRouteMissingBackends(svcLister corev1listers.ServiceLister, ge
 					fmt.Sprintf("%s references Service %q in namespace %q which does not exist", source, name, svcNS),
 					age),
 					fmt.Sprintf("Service %q in namespace %q doesn't exist, so this route's backend receives no traffic.", name, svcNS),
-					fmt.Sprintf("Create Service %q in namespace %q, or point the backendRef at an existing Service.", name, svcNS)))
+					fmt.Sprintf("Point the backendRef at an existing Service in namespace %q, remove the stale backendRef, or create Service %q if this route should still send traffic there.", svcNS, name)))
 				continue
 			}
 			if port == "" {
@@ -814,7 +814,7 @@ func detectGatewayRouteMissingBackends(svcLister corev1listers.ServiceLister, ge
 					fmt.Sprintf("%s targets Service %q in namespace %q port %q which the Service does not expose", source, name, svcNS, port),
 					age),
 					fmt.Sprintf("Service %q does not expose port %q, so the route backend can't receive traffic.", name, port),
-					fmt.Sprintf("Add port %q to Service %q in namespace %q, or reference a port it exposes.", port, name, svcNS)))
+					fmt.Sprintf("Reference a port Service %q already exposes in namespace %q, or add port %q to the Service if it should expose it.", name, svcNS, port)))
 			}
 			if svcNS != route.GetNamespace() && getReferenceGrants != nil {
 				if grants, ok := getReferenceGrants(svcNS); ok && !gatewayReferenceGranted(grants, kind, route.GetNamespace(), name) {
@@ -948,7 +948,7 @@ func detectPVCMissingStorageClass(cache *ResourceCache, namespace string, now ti
 				fmt.Sprintf("references StorageClass %q which does not exist", scName),
 				age),
 				fmt.Sprintf("StorageClass %q doesn't exist, so the PVC stays Pending and no volume is provisioned.", scName),
-				fmt.Sprintf("Create StorageClass %q, set spec.storageClassName to an existing class, or use the cluster default.", scName))
+				fmt.Sprintf("Recreate the PVC with spec.storageClassName set to an existing StorageClass or unset to use the cluster default (storageClassName is immutable), remove the stale claim if obsolete, or create StorageClass %q if that class should exist.", scName))
 			// Same invariant as the phase detector: a Pending PVC has never
 			// been bound, so the missing class has been breaking it since
 			// creation. Stamp timing here because this row wins the dedupe
@@ -1020,7 +1020,7 @@ func detectRoleBindingMissingRole(cache *ResourceCache, namespace string, now ti
 				fmt.Sprintf("roleRef points at %s %q which does not exist", rb.RoleRef.Kind, rb.RoleRef.Name),
 				age),
 				fmt.Sprintf("%s %q doesn't exist, so this RoleBinding grants no permissions.", rb.RoleRef.Kind, rb.RoleRef.Name),
-				fmt.Sprintf("Create %s %q, or recreate the binding pointing roleRef at an existing role (roleRef is immutable).", rb.RoleRef.Kind, rb.RoleRef.Name)))
+				fmt.Sprintf("Recreate the binding pointing roleRef at an existing role (roleRef is immutable), or create %s %q if that role should exist.", rb.RoleRef.Kind, rb.RoleRef.Name)))
 		}
 	}
 
@@ -1040,7 +1040,7 @@ func detectRoleBindingMissingRole(cache *ResourceCache, namespace string, now ti
 				fmt.Sprintf("roleRef points at %s %q which does not exist", crb.RoleRef.Kind, crb.RoleRef.Name),
 				age),
 				fmt.Sprintf("%s %q doesn't exist, so this ClusterRoleBinding grants no permissions.", crb.RoleRef.Kind, crb.RoleRef.Name),
-				fmt.Sprintf("Create %s %q, or recreate the binding pointing roleRef at an existing role (roleRef is immutable).", crb.RoleRef.Kind, crb.RoleRef.Name)))
+				fmt.Sprintf("Recreate the binding pointing roleRef at an existing role (roleRef is immutable), or create %s %q if that role should exist.", crb.RoleRef.Kind, crb.RoleRef.Name)))
 		}
 	}
 	return out

--- a/internal/k8s/detect_missing_refs_test.go
+++ b/internal/k8s/detect_missing_refs_test.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -145,6 +146,12 @@ func TestDetectMissingRefs(t *testing.T) {
 			},
 		},
 	}
+	ingMissingDefault := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Name: "ing-default", Namespace: "prod", CreationTimestamp: now},
+		Spec: networkingv1.IngressSpec{
+			DefaultBackend: &networkingv1.IngressBackend{Service: &networkingv1.IngressServiceBackend{Name: "missing-default-svc", Port: networkingv1.ServiceBackendPort{Number: 80}}},
+		},
+	}
 
 	// StatefulSet with missing headless service.
 	stsMissingSvc := &appsv1.StatefulSet{
@@ -193,7 +200,7 @@ func TestDetectMissingRefs(t *testing.T) {
 		existingSC, existingRole, existingClusterRole, existingDep,
 		podMissing, podHealthy, podDefaultSA,
 		hpaMissingTarget, hpaExistingTarget, hpaUnknownKind,
-		ingMixed,
+		ingMixed, ingMissingDefault,
 		stsMissingSvc, stsExistingSvc,
 		pvcExplicitMissingSC, pvcExistingSC, pvcDefaultSC,
 		rbMissing, rbExisting, crbMissing, crbExisting,
@@ -229,6 +236,7 @@ func TestDetectMissingRefs(t *testing.T) {
 		{"StatefulSet", "prod", "sts-bad", "Missing headless Service"},
 		{"HorizontalPodAutoscaler", "prod", "hpa-bad", "Missing scaleTargetRef"},
 		{"Ingress", "prod", "ing", "Missing backend Service"},
+		{"Ingress", "prod", "ing-default", "Missing backend Service"},
 		{"Ingress", "prod", "ing", "Missing backend Service port"},
 		{"Ingress", "prod", "ing", "Missing TLS Secret"},
 		{"PersistentVolumeClaim", "prod", "pvc-bad-sc", "Missing StorageClass"},
@@ -318,6 +326,29 @@ func TestDetectMissingRefs(t *testing.T) {
 			t.Errorf("missing-ref %q (%s/%s) has empty Action", p.Reason, p.Kind, p.Name)
 		}
 	}
+
+	assertProblemActionOrder(t, problems, "Pod", "prod", "broken", "Missing PVC", "missing-pvc", "existing PVC", "create PVC")
+	assertProblemActionContains(t, problems, "Pod", "prod", "broken", "Missing PVC", "pod template")
+	assertProblemActionContains(t, problems, "Pod", "prod", "broken", "Missing PVC", "recreate this Pod")
+	assertProblemActionOrder(t, problems, "Pod", "prod", "broken", "Missing ServiceAccount", "missing-sa", "existing ServiceAccount", "create ServiceAccount")
+	assertProblemActionContains(t, problems, "Pod", "prod", "broken", "Missing ServiceAccount", "pod template")
+	assertProblemActionOrder(t, problems, "Pod", "prod", "broken", "Missing imagePullSecret", "missing-pull", "existing pull Secret", "create pull Secret")
+	assertProblemActionContains(t, problems, "Pod", "prod", "broken", "Missing imagePullSecret", "pod template")
+	assertProblemActionOrder(t, problems, "HorizontalPodAutoscaler", "prod", "hpa-bad", "Missing scaleTargetRef", "missing-dep", "existing workload", "create Deployment")
+	assertProblemActionOrder(t, problems, "Ingress", "prod", "ing", "Missing backend Service", "missing-svc", "existing Service", "create Service")
+	assertProblemActionOrder(t, problems, "Ingress", "prod", "ing", "Missing backend Service port", "grpc-not-there", "already exposes", "add port")
+	assertProblemActionOrder(t, problems, "Ingress", "prod", "ing-default", "Missing backend Service", "missing-default-svc", "existing Service", "create Service")
+	assertProblemActionNotContains(t, problems, "Ingress", "prod", "ing-default", "Missing backend Service", "rule")
+	assertProblemActionNotContains(t, problems, "Ingress", "prod", "ing-default", "Missing backend Service", "route")
+	assertProblemActionOrder(t, problems, "Ingress", "prod", "ing", "Missing TLS Secret", "missing-tls", "existing kubernetes.io/tls Secret", "create TLS Secret")
+	assertProblemActionStarts(t, problems, "StatefulSet", "prod", "sts-bad", "Missing headless Service", "Create headless Service")
+	assertProblemActionContains(t, problems, "StatefulSet", "prod", "sts-bad", "Missing headless Service", "immutable")
+	assertProblemActionOrder(t, problems, "PersistentVolumeClaim", "prod", "pvc-bad-sc", "Missing StorageClass", "does-not-exist", "existing StorageClass", "create StorageClass")
+	assertProblemActionContains(t, problems, "PersistentVolumeClaim", "prod", "pvc-bad-sc", "Missing StorageClass", "immutable")
+	assertProblemActionOrder(t, problems, "RoleBinding", "prod", "rb-bad", "Missing roleRef target", "missing-role", "existing role", "create Role")
+	assertProblemActionContains(t, problems, "RoleBinding", "prod", "rb-bad", "Missing roleRef target", "immutable")
+	assertProblemActionOrder(t, problems, "ClusterRoleBinding", "", "crb-bad", "Missing roleRef target", "missing-cr", "existing role", "create ClusterRole")
+	assertProblemActionContains(t, problems, "ClusterRoleBinding", "", "crb-bad", "Missing roleRef target", "immutable")
 }
 
 func TestScaleTargetLookupResultDistinguishesErrors(t *testing.T) {
@@ -683,6 +714,9 @@ func TestDetectMissingGatewayRefs(t *testing.T) {
 	if len(problems) != 4 {
 		t.Fatalf("expected exactly 4 Gateway missing-ref problems, got %+v", problems)
 	}
+	assertProblemActionOrder(t, problems, "HTTPRoute", "prod", "broken", "Missing Gateway backend Service", "missing", "existing Service", "create Service")
+	assertProblemActionOrder(t, problems, "HTTPRoute", "prod", "broken", "Missing Gateway backend Service port", "9090", "already exposes", "add port")
+	assertProblemActionStarts(t, problems, "HTTPRoute", "prod", "broken", "Missing Gateway ReferenceGrant", "Create a ReferenceGrant")
 
 	scoped := DetectMissingGatewayRefs(GetResourceCache(), dynCache, GetResourceDiscovery(), "prod")
 	if len(scoped) != 4 {
@@ -765,6 +799,10 @@ func TestDetectMissingCRDRefs(t *testing.T) {
 	if len(problems) != 4 {
 		t.Fatalf("expected exactly 4 curated CRD missing refs, got %+v", problems)
 	}
+	assertProblemActionOrder(t, problems, "Rollout", "prod", "checkout", "Missing Rollout Service", "missing-canary", "existing Service", "create Service")
+	assertProblemActionContains(t, problems, "Rollout", "prod", "checkout", "Missing Rollout Service", "spec.strategy.canary.canaryService")
+	assertProblemActionNotContains(t, problems, "Rollout", "prod", "checkout", "Missing Rollout Service", "traffic-routing")
+	assertProblemActionOrder(t, problems, "ScaledObject", "prod", "missing-target", "Missing scaleTargetRef", "ghost", "existing workload", "create Deployment")
 	for _, p := range problems {
 		if p.Severity != "warning" {
 			t.Errorf("curated CRD missing refs should be warning-level, got %+v", p)
@@ -912,6 +950,75 @@ func hasSubstr(s, sub string) bool {
 	return false
 }
 
+func assertProblemActionOrder(t *testing.T, ps []Detection, kind, ns, name, reason, actionSubstr, earlier, later string) {
+	t.Helper()
+	for _, p := range ps {
+		if p.Kind != kind || p.Namespace != ns || p.Name != name || p.Reason != reason {
+			continue
+		}
+		if actionSubstr != "" && !strings.Contains(p.Action, actionSubstr) {
+			continue
+		}
+		if strings.HasPrefix(p.Action, "Create ") {
+			t.Fatalf("action should not lead with create: %q", p.Action)
+		}
+		assertSubstringOrder(t, p.Action, earlier, later)
+		return
+	}
+	t.Fatalf("missing problem action for %s %s/%s reason %q action containing %q; got %+v", kind, ns, name, reason, actionSubstr, ps)
+}
+
+func assertProblemActionStarts(t *testing.T, ps []Detection, kind, ns, name, reason, prefix string) {
+	t.Helper()
+	for _, p := range ps {
+		if p.Kind == kind && p.Namespace == ns && p.Name == name && p.Reason == reason {
+			if !strings.HasPrefix(p.Action, prefix) {
+				t.Fatalf("action for %s %s/%s reason %q = %q, want prefix %q", kind, ns, name, reason, p.Action, prefix)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing problem action for %s %s/%s reason %q; got %+v", kind, ns, name, reason, ps)
+}
+
+func assertProblemActionContains(t *testing.T, ps []Detection, kind, ns, name, reason, substr string) {
+	t.Helper()
+	for _, p := range ps {
+		if p.Kind == kind && p.Namespace == ns && p.Name == name && p.Reason == reason {
+			if !strings.Contains(p.Action, substr) {
+				t.Fatalf("action for %s %s/%s reason %q = %q, want substring %q", kind, ns, name, reason, p.Action, substr)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing problem action for %s %s/%s reason %q; got %+v", kind, ns, name, reason, ps)
+}
+
+func assertProblemActionNotContains(t *testing.T, ps []Detection, kind, ns, name, reason, substr string) {
+	t.Helper()
+	for _, p := range ps {
+		if p.Kind == kind && p.Namespace == ns && p.Name == name && p.Reason == reason {
+			if strings.Contains(p.Action, substr) {
+				t.Fatalf("action for %s %s/%s reason %q = %q, should not contain %q", kind, ns, name, reason, p.Action, substr)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing problem action for %s %s/%s reason %q; got %+v", kind, ns, name, reason, ps)
+}
+
+func assertSubstringOrder(t *testing.T, text, earlier, later string) {
+	t.Helper()
+	first := strings.Index(text, earlier)
+	second := strings.Index(text, later)
+	if first < 0 || second < 0 {
+		t.Fatalf("action %q must contain %q and %q", text, earlier, later)
+	}
+	if first > second {
+		t.Fatalf("action should mention %q before %q: %q", earlier, later, text)
+	}
+}
+
 func TestRefDiagHelpers(t *testing.T) {
 	r, m, c, a := cmRefDiag("volume", "app-config", "prod")
 	if r != "Missing ConfigMap" {
@@ -926,6 +1033,10 @@ func TestRefDiagHelpers(t *testing.T) {
 	if !hasSubstr(a, "app-config") || !hasSubstr(a, "prod") {
 		t.Errorf("action should name target + namespace: %q", a)
 	}
+	if !hasSubstr(a, "pod template") || !hasSubstr(a, "recreate this Pod") {
+		t.Errorf("action should mention pod-template/recreate framing: %q", a)
+	}
+	assertSubstringOrder(t, a, "existing ConfigMap", "create ConfigMap")
 
 	r2, _, _, a2 := secretRefDiag("envFrom", "db-creds", "prod")
 	if r2 != "Missing Secret" {
@@ -934,4 +1045,8 @@ func TestRefDiagHelpers(t *testing.T) {
 	if !hasSubstr(a2, "db-creds") || !hasSubstr(a2, "prod") {
 		t.Errorf("secret action should name target + namespace: %q", a2)
 	}
+	if !hasSubstr(a2, "pod template") || !hasSubstr(a2, "recreate this Pod") {
+		t.Errorf("secret action should mention pod-template/recreate framing: %q", a2)
+	}
+	assertSubstringOrder(t, a2, "existing Secret", "create Secret")
 }


### PR DESCRIPTION
## Summary

Fixes SKY-1093 by making missing-reference remediation copy lead with safer operator intent: point the reference at an existing object, remove stale references where that is valid, recreate immutable resources where needed, with creation reserved for cases where the missing object should actually exist.

## What changed

- Reordered Action copy for ConfigMap, Secret, PVC, ServiceAccount, imagePullSecret, HPA, Ingress, Gateway backend, Rollout, KEDA, StorageClass, and RBAC roleRef missing-reference findings.
- Added immutable-resource guidance where the referenced field cannot be edited in place: pod-template refs tell operators to update the pod template or recreate a bare Pod, PVC `storageClassName` requires PVC recreation, StatefulSet `serviceName` requires StatefulSet recreation, and RBAC `roleRef` requires binding recreation.
- Made scenario-specific copy more precise for Ingress default backends, backend Service ports, Gateway backendRef ports, and Argo Rollout service fields, so remediation names the backend or field actually reported by the detector.
- Kept create-first wording for the two intentional exceptions:
  - StatefulSet headless Service, where creating the named Service is the non-destructive common fix.
  - Gateway ReferenceGrant, where creation is the actual remediation.
- Added tests that pin action ordering, immutable-field wording, backend-port ordering, and scenario-specific wording without changing detector semantics, severity, causes, messages, fingerprints, or remediation targets.

## Risk / blast radius

Low. This changes operator-facing remediation text only; detector conditions, issue severity, causes, messages, fingerprints, API schema, and UI layout are unchanged. The main risk is misleading copy, mitigated by scenario tests that pin the final action ordering for the affected missing-reference cases.

## Testing

- `go test ./internal/k8s -run 'TestDetectMissingRefs|TestDetectMissingGatewayRefs|TestDetectMissingCRDRefs|TestRefDiagHelpers'`
- `go test ./internal/k8s`
- `make tsc`
- `make test`
- `make build`

Visual-test skipped: backend audit copy only; no UI layout or interaction changed.