### PR TITLE
Improve GitOps and Helm diagnosis copy

### DIFF
--- a/internal/issues/grouping.go
+++ b/internal/issues/grouping.go
@@ -119,6 +119,7 @@ func foldGroup(members []Issue) Issue {
 		Name:                 subject.Name,
 		Reason:               rep.Reason,
 		Message:              rep.Message,
+		RawMessage:           rep.RawMessage,
 		RestartCount:         rep.RestartCount,
 		LastTerminatedReason: rep.LastTerminatedReason,
 		FirstSeen:            rep.FirstSeen,

--- a/internal/issues/helm.go
+++ b/internal/issues/helm.go
@@ -2,6 +2,7 @@ package issues
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/skyhook-io/radar/internal/helm"
@@ -69,6 +70,9 @@ func nativeHelmIssueReason(op helm.HelmOperation) (Severity, string, bool) {
 }
 
 func nativeHelmIssueMessage(rel helm.HelmRelease, op helm.HelmOperation) string {
+	if nativeHelmOperationTimedOutWaitingForReadiness(op.Message) {
+		return fmt.Sprintf("Helm release %q did not become ready before Helm timed out.", rel.Name)
+	}
 	if op.Message != "" {
 		return op.Message
 	}
@@ -81,10 +85,21 @@ func nativeHelmIssueMessage(rel helm.HelmRelease, op helm.HelmOperation) string 
 }
 
 func nativeHelmIssueCause(op helm.HelmOperation) string {
+	if nativeHelmOperationTimedOutWaitingForReadiness(op.Message) {
+		return "The release's workload did not become ready before Helm timed out."
+	}
 	if op.Kind == helmhistory.KindPending {
 		return "A Helm install, upgrade, or rollback has remained pending past the stuck-operation threshold."
 	}
 	return "The latest native Helm release revision is failed."
+}
+
+func nativeHelmOperationTimedOutWaitingForReadiness(msg string) bool {
+	lower := strings.ToLower(msg)
+	if !strings.Contains(lower, "context deadline exceeded") || !strings.Contains(lower, "status: inprogress") {
+		return false
+	}
+	return strings.Contains(lower, "not ready") || strings.Contains(lower, "available: 0/")
 }
 
 func nativeHelmIssueAction(op helm.HelmOperation) string {

--- a/internal/issues/helm.go
+++ b/internal/issues/helm.go
@@ -71,7 +71,7 @@ func nativeHelmIssueReason(op helm.HelmOperation) (Severity, string, bool) {
 }
 
 func nativeHelmIssueMessage(rel helm.HelmRelease, op helm.HelmOperation) string {
-	if nativeHelmOperationTimedOutWaitingForReadiness(op.Message) {
+	if helmhistory.IsReadinessTimeoutMessage(nativeHelmRawCandidate(op)) {
 		return fmt.Sprintf("Helm release %q did not become ready before Helm timed out.", rel.Name)
 	}
 	if op.Message != "" {
@@ -86,7 +86,7 @@ func nativeHelmIssueMessage(rel helm.HelmRelease, op helm.HelmOperation) string 
 }
 
 func nativeHelmIssueCause(op helm.HelmOperation) string {
-	if nativeHelmOperationTimedOutWaitingForReadiness(op.Message) {
+	if helmhistory.IsReadinessTimeoutMessage(nativeHelmRawCandidate(op)) {
 		return "The release's workload did not become ready before Helm timed out."
 	}
 	if op.Kind == helmhistory.KindPending {
@@ -96,18 +96,20 @@ func nativeHelmIssueCause(op helm.HelmOperation) string {
 }
 
 func nativeHelmIssueRawMessage(op helm.HelmOperation) string {
-	if nativeHelmOperationTimedOutWaitingForReadiness(op.Message) {
+	if op.RawMessage != "" {
+		return strings.TrimSpace(op.RawMessage)
+	}
+	if helmhistory.IsReadinessTimeoutMessage(op.Message) {
 		return strings.TrimSpace(op.Message)
 	}
 	return ""
 }
 
-func nativeHelmOperationTimedOutWaitingForReadiness(msg string) bool {
-	lower := strings.ToLower(msg)
-	if !strings.Contains(lower, "context deadline exceeded") || !strings.Contains(lower, "status: inprogress") {
-		return false
+func nativeHelmRawCandidate(op helm.HelmOperation) string {
+	if op.RawMessage != "" {
+		return op.RawMessage
 	}
-	return strings.Contains(lower, "not ready") || strings.Contains(lower, "available: 0/")
+	return op.Message
 }
 
 func nativeHelmIssueAction(op helm.HelmOperation) string {

--- a/internal/issues/helm.go
+++ b/internal/issues/helm.go
@@ -34,19 +34,20 @@ func NativeHelmReleaseIssues(releases []helm.HelmRelease, now time.Time) []Issue
 			storageNamespace = rel.Namespace
 		}
 		iss := Issue{
-			Severity:  severity,
-			Source:    SourceProblem,
-			Kind:      "HelmRelease",
-			Group:     NativeHelmGroup,
-			Namespace: storageNamespace,
-			Name:      rel.Name,
-			Reason:    reason,
-			Message:   nativeHelmIssueMessage(rel, *op),
-			Cause:     nativeHelmIssueCause(*op),
-			Action:    nativeHelmIssueAction(*op),
-			Stuck:     true,
-			FirstSeen: firstSeen,
-			LastSeen:  now,
+			Severity:   severity,
+			Source:     SourceProblem,
+			Kind:       "HelmRelease",
+			Group:      NativeHelmGroup,
+			Namespace:  storageNamespace,
+			Name:       rel.Name,
+			Reason:     reason,
+			Message:    nativeHelmIssueMessage(rel, *op),
+			RawMessage: nativeHelmIssueRawMessage(*op),
+			Cause:      nativeHelmIssueCause(*op),
+			Action:     nativeHelmIssueAction(*op),
+			Stuck:      true,
+			FirstSeen:  firstSeen,
+			LastSeen:   now,
 		}
 		classifyIssue(&iss)
 		enrichIdentity(&iss)
@@ -92,6 +93,13 @@ func nativeHelmIssueCause(op helm.HelmOperation) string {
 		return "A Helm install, upgrade, or rollback has remained pending past the stuck-operation threshold."
 	}
 	return "The latest native Helm release revision is failed."
+}
+
+func nativeHelmIssueRawMessage(op helm.HelmOperation) string {
+	if nativeHelmOperationTimedOutWaitingForReadiness(op.Message) {
+		return strings.TrimSpace(op.Message)
+	}
+	return ""
 }
 
 func nativeHelmOperationTimedOutWaitingForReadiness(msg string) bool {

--- a/internal/issues/helm_test.go
+++ b/internal/issues/helm_test.go
@@ -39,18 +39,6 @@ func TestNativeHelmReleaseIssues(t *testing.T) {
 			},
 		},
 		{
-			Name:      "stuck-install-timeout",
-			Namespace: "apps",
-			LastOperation: &helm.HelmOperation{
-				Kind:          helmhistory.KindPending,
-				Status:        helmhistory.StatusStuck,
-				Revision:      3,
-				PendingStatus: "pending-install",
-				Updated:       updated.Add(2 * time.Minute),
-				Message:       `Release "stuck-install-timeout" failed: demo is not ready. status: InProgress, message: Available: 0/1 context deadline exceeded`,
-			},
-		},
-		{
 			Name:      "recovered-rollback",
 			Namespace: "apps",
 			LastOperation: &helm.HelmOperation{
@@ -76,8 +64,8 @@ func TestNativeHelmReleaseIssues(t *testing.T) {
 	}
 
 	got := NativeHelmReleaseIssues(releases, now)
-	if len(got) != 3 {
-		t.Fatalf("len(NativeHelmReleaseIssues) = %d, want 3: %#v", len(got), got)
+	if len(got) != 2 {
+		t.Fatalf("len(NativeHelmReleaseIssues) = %d, want 2: %#v", len(got), got)
 	}
 
 	failed := got[0]
@@ -106,19 +94,5 @@ func TestNativeHelmReleaseIssues(t *testing.T) {
 	pending := got[1]
 	if pending.Name != "stuck-upgrade" || pending.Severity != SeverityWarning || pending.Reason != "HelmReleasePending" {
 		t.Fatalf("pending issue = %#v", pending)
-	}
-
-	pendingTimeout := got[2]
-	if pendingTimeout.Name != "stuck-install-timeout" || pendingTimeout.Severity != SeverityWarning || pendingTimeout.Reason != "HelmReleasePending" {
-		t.Fatalf("pending timeout issue = %#v", pendingTimeout)
-	}
-	if !strings.Contains(pendingTimeout.Message, "did not become ready before Helm timed out") {
-		t.Fatalf("pending timeout issue message = %q, want readiness timeout copy", pendingTimeout.Message)
-	}
-	if strings.Contains(strings.ToLower(pendingTimeout.Message), "failed") {
-		t.Fatalf("pending timeout issue message should not call a pending release failed: %q", pendingTimeout.Message)
-	}
-	if !strings.Contains(pendingTimeout.RawMessage, "status: InProgress") || !strings.Contains(pendingTimeout.RawMessage, "context deadline exceeded") {
-		t.Fatalf("pending timeout raw message = %q, want original Helm timeout text", pendingTimeout.RawMessage)
 	}
 }

--- a/internal/issues/helm_test.go
+++ b/internal/issues/helm_test.go
@@ -1,6 +1,7 @@
 package issues
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -23,7 +24,7 @@ func TestNativeHelmReleaseIssues(t *testing.T) {
 				Status:   helmhistory.StatusFailed,
 				Revision: 1,
 				Updated:  updated,
-				Message:  `Release "failed-install" failed: context deadline exceeded`,
+				Message:  `Release "failed-install" failed: demo is not ready. status: InProgress, message: Available: 0/1 context deadline exceeded`,
 			},
 		},
 		{
@@ -35,6 +36,18 @@ func TestNativeHelmReleaseIssues(t *testing.T) {
 				Revision:      2,
 				PendingStatus: "pending-upgrade",
 				Updated:       updated.Add(time.Minute),
+			},
+		},
+		{
+			Name:      "stuck-install-timeout",
+			Namespace: "apps",
+			LastOperation: &helm.HelmOperation{
+				Kind:          helmhistory.KindPending,
+				Status:        helmhistory.StatusStuck,
+				Revision:      3,
+				PendingStatus: "pending-install",
+				Updated:       updated.Add(2 * time.Minute),
+				Message:       `Release "stuck-install-timeout" failed: demo is not ready. status: InProgress, message: Available: 0/1 context deadline exceeded`,
 			},
 		},
 		{
@@ -63,8 +76,8 @@ func TestNativeHelmReleaseIssues(t *testing.T) {
 	}
 
 	got := NativeHelmReleaseIssues(releases, now)
-	if len(got) != 2 {
-		t.Fatalf("len(NativeHelmReleaseIssues) = %d, want 2: %#v", len(got), got)
+	if len(got) != 3 {
+		t.Fatalf("len(NativeHelmReleaseIssues) = %d, want 3: %#v", len(got), got)
 	}
 
 	failed := got[0]
@@ -77,9 +90,29 @@ func TestNativeHelmReleaseIssues(t *testing.T) {
 	if !failed.Stuck || failed.FirstSeen != updated || failed.LastSeen != now {
 		t.Fatalf("failed issue timing/stuck = stuck:%v first:%v last:%v", failed.Stuck, failed.FirstSeen, failed.LastSeen)
 	}
+	if !strings.Contains(failed.Message, "did not become ready before Helm timed out") {
+		t.Fatalf("failed issue message = %q, want readiness timeout copy", failed.Message)
+	}
+	if strings.Contains(failed.Message, "status: InProgress") || strings.Contains(failed.Message, "Available: 0/1") || strings.Contains(failed.Message, "context deadline exceeded") {
+		t.Fatalf("failed issue message leaked Helm condition-speak: %q", failed.Message)
+	}
+	if !strings.Contains(failed.Cause, "workload did not become ready before Helm timed out") {
+		t.Fatalf("failed issue cause = %q, want readiness timeout cause", failed.Cause)
+	}
 
 	pending := got[1]
 	if pending.Name != "stuck-upgrade" || pending.Severity != SeverityWarning || pending.Reason != "HelmReleasePending" {
 		t.Fatalf("pending issue = %#v", pending)
+	}
+
+	pendingTimeout := got[2]
+	if pendingTimeout.Name != "stuck-install-timeout" || pendingTimeout.Severity != SeverityWarning || pendingTimeout.Reason != "HelmReleasePending" {
+		t.Fatalf("pending timeout issue = %#v", pendingTimeout)
+	}
+	if !strings.Contains(pendingTimeout.Message, "did not become ready before Helm timed out") {
+		t.Fatalf("pending timeout issue message = %q, want readiness timeout copy", pendingTimeout.Message)
+	}
+	if strings.Contains(strings.ToLower(pendingTimeout.Message), "failed") {
+		t.Fatalf("pending timeout issue message should not call a pending release failed: %q", pendingTimeout.Message)
 	}
 }

--- a/internal/issues/helm_test.go
+++ b/internal/issues/helm_test.go
@@ -99,6 +99,9 @@ func TestNativeHelmReleaseIssues(t *testing.T) {
 	if !strings.Contains(failed.Cause, "workload did not become ready before Helm timed out") {
 		t.Fatalf("failed issue cause = %q, want readiness timeout cause", failed.Cause)
 	}
+	if !strings.Contains(failed.RawMessage, "status: InProgress") || !strings.Contains(failed.RawMessage, "context deadline exceeded") {
+		t.Fatalf("failed issue raw message = %q, want original Helm timeout text", failed.RawMessage)
+	}
 
 	pending := got[1]
 	if pending.Name != "stuck-upgrade" || pending.Severity != SeverityWarning || pending.Reason != "HelmReleasePending" {
@@ -114,5 +117,8 @@ func TestNativeHelmReleaseIssues(t *testing.T) {
 	}
 	if strings.Contains(strings.ToLower(pendingTimeout.Message), "failed") {
 		t.Fatalf("pending timeout issue message should not call a pending release failed: %q", pendingTimeout.Message)
+	}
+	if !strings.Contains(pendingTimeout.RawMessage, "status: InProgress") || !strings.Contains(pendingTimeout.RawMessage, "context deadline exceeded") {
+		t.Fatalf("pending timeout raw message = %q, want original Helm timeout text", pendingTimeout.RawMessage)
 	}
 }

--- a/internal/issues/normalize.go
+++ b/internal/issues/normalize.go
@@ -57,6 +57,7 @@ func fromProblem(p k8s.Detection, now time.Time, source Source) Issue {
 		Name:                 p.Name,
 		Reason:               p.Reason,
 		Message:              p.Message,
+		RawMessage:           p.RawMessage,
 		Cause:                p.Cause,
 		Action:               p.Action,
 		RemediationKind:      p.RemediationKind,

--- a/internal/k8s/detect.go
+++ b/internal/k8s/detect.go
@@ -49,6 +49,7 @@ type Detection struct {
 	Severity        string // "critical", "high", "medium", "warning", or "info"
 	Reason          string
 	Message         string
+	RawMessage      string
 	Age             string // human-readable
 	AgeSeconds      int64  // for sorting
 	Duration        string // how long the problem has persisted

--- a/internal/k8s/detect_gitops.go
+++ b/internal/k8s/detect_gitops.go
@@ -144,12 +144,12 @@ func detectArgoAppProblems(apps []*unstructured.Unstructured, now time.Time) []D
 					continue
 				}
 			}
-			msg := opMsg
+			msg := diagnose.CleanArgoControllerMessage(opMsg)
 			if strings.TrimSpace(msg) == "" {
 				msg = "Last sync operation failed"
 			}
 			d := gitopsProblem("Application", argoGroup, ns, name, "critical", "OperationFailed", msg, argoOperationIssueAge(app, now, age))
-			applyArgoOperationDiagnosis(&d, opMsg)
+			applyArgoOperationDiagnosis(&d, msg)
 			// When there's a structured remediation, that one-click fix IS the
 			// next step. Otherwise (RBAC / webhook / immutable field, or an
 			// unrecognized message) point the operator at the operation details
@@ -317,6 +317,7 @@ func argoErrorCondition(app *unstructured.Unstructured, now time.Time) (condType
 		switch ct {
 		case "ComparisonError", "InvalidSpecError", "SyncError":
 			msg, _ := cm["message"].(string)
+			msg = diagnose.CleanArgoControllerMessage(msg)
 			ts, _ := cm["lastTransitionTime"].(string)
 			since, hasSince := durationFromTimestamp(now, ts)
 			return ct, msg, since, hasSince, true

--- a/internal/k8s/detect_gitops.go
+++ b/internal/k8s/detect_gitops.go
@@ -132,8 +132,9 @@ func detectArgoAppProblems(apps []*unstructured.Unstructured, now time.Time) []D
 			// present, it holds the actionable guidance — prefer it over a
 			// generic "operation failed" row rather than masking it.
 			if strings.TrimSpace(opMsg) == "" {
-				if ct, cmsg, since, hasSince, ok := argoErrorCondition(app, now); ok {
+				if ct, cmsg, rawMsg, since, hasSince, ok := argoErrorCondition(app, now); ok {
 					d := gitopsProblem("Application", argoGroup, ns, name, "critical", ct, cmsg, fallbackDuration(since, hasSince, age))
+					d.RawMessage = rawMsg
 					if ct == "SyncError" {
 						applyArgoOperationDiagnosis(&d, cmsg)
 					}
@@ -144,11 +145,12 @@ func detectArgoAppProblems(apps []*unstructured.Unstructured, now time.Time) []D
 					continue
 				}
 			}
-			msg := diagnose.CleanArgoControllerMessage(opMsg)
+			msg, rawMsg := diagnose.CleanArgoControllerMessageWithRaw(opMsg)
 			if strings.TrimSpace(msg) == "" {
 				msg = "Last sync operation failed"
 			}
 			d := gitopsProblem("Application", argoGroup, ns, name, "critical", "OperationFailed", msg, argoOperationIssueAge(app, now, age))
+			d.RawMessage = rawMsg
 			applyArgoOperationDiagnosis(&d, msg)
 			// When there's a structured remediation, that one-click fix IS the
 			// next step. Otherwise (RBAC / webhook / immutable field, or an
@@ -178,8 +180,9 @@ func detectArgoAppProblems(apps []*unstructured.Unstructured, now time.Time) []D
 		// without a sync operation (so operationState above won't catch them) —
 		// genuine reconciliation failures, critical, with the same condition-
 		// specific guidance the detail page shows.
-		if ct, msg, since, hasSince, ok := argoErrorCondition(app, now); ok {
+		if ct, msg, rawMsg, since, hasSince, ok := argoErrorCondition(app, now); ok {
 			d := gitopsProblem("Application", argoGroup, ns, name, "critical", ct, msg, fallbackDuration(since, hasSince, age))
+			d.RawMessage = rawMsg
 			d.Action = diagnose.ActionForCondition(ct)
 			out = append(out, d)
 			continue
@@ -303,10 +306,10 @@ func argoIsAutomated(app *unstructured.Unstructured) bool {
 // an error (ComparisonError / InvalidSpecError / SyncError). Argo writes these
 // as {type, message} without a status field, so FindFalseCondition can't match
 // them.
-func argoErrorCondition(app *unstructured.Unstructured, now time.Time) (condType, message string, since time.Duration, hasSince bool, found bool) {
+func argoErrorCondition(app *unstructured.Unstructured, now time.Time) (condType, message, rawMessage string, since time.Duration, hasSince bool, found bool) {
 	conds, ok, _ := unstructured.NestedSlice(app.Object, "status", "conditions")
 	if !ok {
-		return "", "", 0, false, false
+		return "", "", "", 0, false, false
 	}
 	for _, c := range conds {
 		cm, ok := c.(map[string]any)
@@ -317,13 +320,13 @@ func argoErrorCondition(app *unstructured.Unstructured, now time.Time) (condType
 		switch ct {
 		case "ComparisonError", "InvalidSpecError", "SyncError":
 			msg, _ := cm["message"].(string)
-			msg = diagnose.CleanArgoControllerMessage(msg)
+			msg, rawMsg := diagnose.CleanArgoControllerMessageWithRaw(msg)
 			ts, _ := cm["lastTransitionTime"].(string)
 			since, hasSince := durationFromTimestamp(now, ts)
-			return ct, msg, since, hasSince, true
+			return ct, msg, rawMsg, since, hasSince, true
 		}
 	}
-	return "", "", 0, false, false
+	return "", "", "", 0, false, false
 }
 
 // detectFluxProblems flags Flux Kustomizations/HelmReleases whose Ready condition

--- a/internal/k8s/detect_gitops_test.go
+++ b/internal/k8s/detect_gitops_test.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -75,7 +76,7 @@ func TestDetectGitOpsProblems(t *testing.T) {
 	kustGVR := schema.GroupVersionResource{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Resource: "kustomizations"}
 
 	comparisonErr := []any{
-		map[string]any{"type": "ComparisonError", "message": "app path does not exist"},
+		map[string]any{"type": "ComparisonError", "message": "rpc error: code = Unknown desc = app path does not exist"},
 	}
 
 	objs := []runtime.Object{
@@ -160,6 +161,14 @@ func TestDetectGitOpsProblems(t *testing.T) {
 	// action (not leave it empty).
 	if c, ok := bySubject["comparison"]; ok && c.Action == "" {
 		t.Errorf("ComparisonError problem should carry an Action, got empty")
+	}
+	if c, ok := bySubject["comparison"]; ok {
+		if c.Message != "app path does not exist" {
+			t.Errorf("ComparisonError message = %q, want cleaned app path error", c.Message)
+		}
+		if strings.Contains(c.Message, "rpc error") || strings.Contains(c.Message, "Unknown desc") {
+			t.Errorf("ComparisonError message leaked gRPC envelope: %q", c.Message)
+		}
 	}
 
 	wantSkip := []string{"missing-manual", "suspended", "progressing", "syncing", "healthy", "reconciling", "stale-gen", "ready"}
@@ -281,7 +290,7 @@ func TestDetectArgoAppProblems_OperationFailedParsesCause(t *testing.T) {
 			"sync":   map[string]any{"status": "OutOfSync"},
 			"operationState": map[string]any{
 				"phase":   "Failed",
-				"message": `failed to create resource: namespaces "demo-broken-sync" not found`,
+				"message": `rpc error: code = Unknown desc = failed to create resource: namespaces "demo-broken-sync" not found`,
 			},
 			// Argo writes a SyncError condition that parallel-encodes the same
 			// failure; the operation branch must supersede it (one row, not two).
@@ -304,8 +313,11 @@ func TestDetectArgoAppProblems_OperationFailedParsesCause(t *testing.T) {
 	if d.RemediationKind != diagnose.RemediationCreateNamespace || d.RemediationTarget != "demo-broken-sync" {
 		t.Errorf("got remediation kind=%q target=%q, want %q/demo-broken-sync", d.RemediationKind, d.RemediationTarget, diagnose.RemediationCreateNamespace)
 	}
-	if d.Message == "" {
-		t.Error("expected the raw operation message preserved on Message")
+	if d.Message != `failed to create resource: namespaces "demo-broken-sync" not found` {
+		t.Errorf("operation message = %q, want cleaned failure text", d.Message)
+	}
+	if strings.Contains(d.Message, "rpc error") || strings.Contains(d.Message, "Unknown desc") {
+		t.Errorf("operation message leaked gRPC envelope: %q", d.Message)
 	}
 }
 
@@ -347,7 +359,7 @@ func TestDetectArgoAppProblems_ErrorConditionUsesTransitionTimestamp(t *testing.
 			"conditions": []any{
 				map[string]any{
 					"type":               "ComparisonError",
-					"message":            "app path does not exist",
+					"message":            "rpc error: code = Unknown desc = failed to generate manifests: rpc error: code = Unknown desc = app path does not exist",
 					"lastTransitionTime": now.Add(-3 * time.Minute).Format(time.RFC3339),
 				},
 			},
@@ -360,6 +372,9 @@ func TestDetectArgoAppProblems_ErrorConditionUsesTransitionTimestamp(t *testing.
 	}
 	if got[0].DurationSeconds != int64((3 * time.Minute).Seconds()) {
 		t.Fatalf("condition should age from lastTransitionTime, got duration=%ds", got[0].DurationSeconds)
+	}
+	if got[0].Message != "failed to generate manifests: app path does not exist" {
+		t.Fatalf("condition message = %q, want cleaned manifest-generation error", got[0].Message)
 	}
 }
 

--- a/internal/k8s/detect_gitops_test.go
+++ b/internal/k8s/detect_gitops_test.go
@@ -281,6 +281,7 @@ func TestDetectArgoAppProblems_EnabledFalseIsManual(t *testing.T) {
 // double-reported.
 func TestDetectArgoAppProblems_OperationFailedParsesCause(t *testing.T) {
 	now := time.Now()
+	rawMessage := `rpc error: code = Unknown desc = failed to create resource: namespaces "demo-broken-sync" not found`
 	app := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "argoproj.io/v1alpha1", "kind": "Application",
 		"metadata": map[string]any{"name": "broken-sync", "namespace": "argocd"},
@@ -290,7 +291,7 @@ func TestDetectArgoAppProblems_OperationFailedParsesCause(t *testing.T) {
 			"sync":   map[string]any{"status": "OutOfSync"},
 			"operationState": map[string]any{
 				"phase":   "Failed",
-				"message": `rpc error: code = Unknown desc = failed to create resource: namespaces "demo-broken-sync" not found`,
+				"message": rawMessage,
 			},
 			// Argo writes a SyncError condition that parallel-encodes the same
 			// failure; the operation branch must supersede it (one row, not two).
@@ -315,6 +316,9 @@ func TestDetectArgoAppProblems_OperationFailedParsesCause(t *testing.T) {
 	}
 	if d.Message != `failed to create resource: namespaces "demo-broken-sync" not found` {
 		t.Errorf("operation message = %q, want cleaned failure text", d.Message)
+	}
+	if d.RawMessage != rawMessage {
+		t.Errorf("operation raw message = %q, want %q", d.RawMessage, rawMessage)
 	}
 	if strings.Contains(d.Message, "rpc error") || strings.Contains(d.Message, "Unknown desc") {
 		t.Errorf("operation message leaked gRPC envelope: %q", d.Message)

--- a/internal/k8s/history.go
+++ b/internal/k8s/history.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	aicontext "github.com/skyhook-io/radar/pkg/ai/context"
+	"github.com/skyhook-io/radar/pkg/gitops/diagnose"
 	"github.com/skyhook-io/radar/pkg/k8score"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
@@ -2057,6 +2058,7 @@ func diffApplication(oldObj, newObj any) ([]FieldChange, []string) {
 			summary = append(summary, fmt.Sprintf("operation: %s", opPhase))
 		}
 		if opMessage != "" && opPhase == "Failed" {
+			opMessage = diagnose.CleanArgoControllerMessage(opMessage)
 			summary = append(summary, fmt.Sprintf("error: %s", truncateMessage(opMessage)))
 		}
 	}
@@ -2078,6 +2080,7 @@ func diffApplication(oldObj, newObj any) ([]FieldChange, []string) {
 				opMessage, _, _ := unstructured.NestedString(newOp, "message")
 				summary = append(summary, "sync failed")
 				if opMessage != "" {
+					opMessage = diagnose.CleanArgoControllerMessage(opMessage)
 					summary = append(summary, fmt.Sprintf("error: %s", truncateMessage(opMessage)))
 				}
 			case "Running":

--- a/internal/k8s/history_diff_test.go
+++ b/internal/k8s/history_diff_test.go
@@ -210,6 +210,51 @@ func TestDiffPodTemplateConfig_PortsSAandScheduling(t *testing.T) {
 	}
 }
 
+func TestDiffApplicationCleansFailedOperationMessage(t *testing.T) {
+	rawMessage := `rpc error: code = Unknown desc = app path does not exist`
+	tests := []struct {
+		name string
+		old  *unstructured.Unstructured
+		new  *unstructured.Unstructured
+	}{
+		{
+			name: "failed operation appeared",
+			old:  applicationWithOperation("", ""),
+			new:  applicationWithOperation("Failed", rawMessage),
+		},
+		{
+			name: "running operation failed",
+			old:  applicationWithOperation("Running", ""),
+			new:  applicationWithOperation("Failed", rawMessage),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, summary := diffApplication(tt.old, tt.new)
+			joined := strings.Join(summary, "; ")
+			if strings.Contains(joined, "rpc error") {
+				t.Fatalf("summary leaked controller envelope: %q", joined)
+			}
+			if !strings.Contains(joined, "error: app path does not exist") {
+				t.Fatalf("summary missing cleaned operation error: %q", joined)
+			}
+		})
+	}
+}
+
+func applicationWithOperation(phase, message string) *unstructured.Unstructured {
+	status := map[string]any{}
+	if phase != "" {
+		op := map[string]any{"phase": phase}
+		if message != "" {
+			op["message"] = message
+		}
+		status["operationState"] = op
+	}
+	return &unstructured.Unstructured{Object: map[string]any{"status": status}}
+}
+
 func TestDiffPodTemplateConfig_SecurityContextAndAffinityBooleanLevel(t *testing.T) {
 	runAsNonRoot := true
 	oldSpec := corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: "app:v1"}}}

--- a/packages/k8s-ui/src/components/gitops/insights/GitOpsInsightViews.tsx
+++ b/packages/k8s-ui/src/components/gitops/insights/GitOpsInsightViews.tsx
@@ -56,6 +56,7 @@ export function GitOpsStatusStrip({ insight, loading }: GitOpsStatusStripProps) 
   const operationFailure = (insight.issues ?? []).find(
     (i) => i.severity === 'critical' && i.scope === 'operation' && i.stuck,
   )
+  const operationTooltipMessage = summary.rawOperationMessage || summary.operationMessage
   return (
     <div className="border-b border-theme-border bg-theme-base px-4 py-2">
       <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5">
@@ -87,7 +88,7 @@ export function GitOpsStatusStrip({ insight, loading }: GitOpsStatusStripProps) 
             (parsed cause, retry count, raw message) so the strip stays a
             calm orientation row instead of duplicating the error three times. */}
         {operation && summary.operationMessage && isInFlightPhase(operation) && (
-          <Tooltip content={summary.operationMessage} delay={400} wrapperClassName="min-w-0 max-w-[60ch]">
+          <Tooltip content={operationTooltipMessage} delay={400} wrapperClassName="min-w-0 max-w-[60ch]">
             <span className="block truncate text-[11px] text-theme-text-secondary">
               {summary.operationMessage}
             </span>
@@ -424,6 +425,8 @@ function GitOpsFailureCard({
   const [showRaw, setShowRaw] = useState(false)
   const stuck = !!issue.stuck
   const ref = issue.refs?.[0]
+  const rawControllerMessage = issue.rawMessage || issue.message
+  const rawControllerLabel = issue.rawMessage ? 'raw controller error' : 'controller message'
   // Title prioritizes the parsed cause's first sentence. Without parsing we
   // get the bare phase ("Failed") which alone tells the user nothing — fall
   // back to the first sentence of the raw message in that case so something
@@ -486,12 +489,12 @@ function GitOpsFailureCard({
               className="inline-flex items-center gap-1 text-[11px] text-theme-text-tertiary transition-colors hover:text-theme-text-secondary"
             >
               {showRaw ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-              {showRaw ? 'Hide raw controller error' : 'Show raw controller error'}
+              {showRaw ? `Hide ${rawControllerLabel}` : `Show ${rawControllerLabel}`}
             </button>
           </div>
           {showRaw && (
             <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap break-all rounded border border-theme-border bg-theme-base px-3 py-2 font-mono text-[11px] text-theme-text-secondary">
-              {issue.message}
+              {rawControllerMessage}
             </pre>
           )}
         </div>
@@ -609,6 +612,7 @@ function GitOpsCompactIssueStack({ issues, onSelectIssue }: { issues: GitOpsIssu
             const t = severityTone(issue.severity)
             const ref = issue.refs?.[0]
             const actionable = !!(onSelectIssue && ref)
+            const rawMessage = issue.rawMessage && issue.rawMessage !== issue.message ? issue.rawMessage : ''
             return (
               <button
                 key={`${issue.reason}-${index}`}
@@ -628,6 +632,7 @@ function GitOpsCompactIssueStack({ issues, onSelectIssue }: { issues: GitOpsIssu
                   </div>
                   <p className="mt-0.5 text-theme-text-secondary">{issue.message}</p>
                   {issue.cause && <p className="mt-0.5 text-[11px] text-theme-text-tertiary">{issue.cause}</p>}
+                  {rawMessage && <p className="mt-0.5 break-words font-mono text-[11px] text-theme-text-tertiary">{rawMessage}</p>}
                   {issue.action && <p className="mt-0.5 text-[11px] text-theme-text-tertiary">{issue.action}</p>}
                 </div>
                 {actionable && ref && (
@@ -1112,7 +1117,7 @@ function ChangeRow({
               live health message — operators chasing a broken sync want
               the failure reason on the same row, not in a drawer. */}
           {change.syncError && (
-            <Tooltip content={change.syncError} delay={400} wrapperClassName="ml-[18px] mt-1 block max-w-full">
+            <Tooltip content={change.rawSyncError || change.syncError} delay={400} wrapperClassName="ml-[18px] mt-1 block max-w-full">
               <span className="line-clamp-3 text-xs text-red-600 dark:text-red-400">{change.syncError}</span>
             </Tooltip>
           )}
@@ -1386,7 +1391,9 @@ function HistoryRows({
                 </Tooltip>
               )}
               {item.message && (
-                <div className={clsx('mt-0.5 line-clamp-2 text-[11px]', sourceDisplay ? 'text-theme-text-tertiary' : 'text-theme-text-secondary')}>{item.message}</div>
+                <Tooltip content={item.rawMessage || item.message} delay={400} wrapperClassName="mt-0.5 block max-w-full">
+                  <div className={clsx('line-clamp-2 text-[11px]', sourceDisplay ? 'text-theme-text-tertiary' : 'text-theme-text-secondary')}>{item.message}</div>
+                </Tooltip>
               )}
             </div>
           </li>

--- a/packages/k8s-ui/src/components/issues/IssuesView.tsx
+++ b/packages/k8s-ui/src/components/issues/IssuesView.tsx
@@ -300,7 +300,11 @@ function Diagnosis({ issue }: { issue: Issue }) {
   const { headline, detail } = issueMessageParts(issue);
   // When the issue carries a parsed plain-English cause, lead with it. The raw
   // detector message is kept below as de-emphasized detail.
-  const rawMessage = issue.cause ? (issue.raw_message ?? issue.message ?? '') : [headline, detail].filter(Boolean).join(' ');
+  const visibleMessage = [headline, detail].filter(Boolean).join(' ');
+  const rawMessage = issue.raw_message ?? (issue.cause ? issue.message ?? '' : '');
+  const shouldShowRawMessage = issue.cause
+    ? Boolean(rawMessage)
+    : Boolean(issue.raw_message && issue.raw_message !== visibleMessage);
   return (
     <section className="flex flex-col gap-1">
       <h4 className="text-[11px] font-semibold uppercase tracking-wide text-theme-text-tertiary">What's wrong</h4>
@@ -335,9 +339,9 @@ function Diagnosis({ issue }: { issue: Issue }) {
           {issue.operation_retry_count ? ` · retried ${issue.operation_retry_count}×` : ''}
         </p>
       ) : null}
-      {/* Raw detector message, de-emphasized — shown below the parsed cause so
-          the precise error (URLs, resource names) is available without leading. */}
-      {issue.cause && rawMessage ? (
+      {/* Raw detector message, de-emphasized so precise controller/kubelet text
+          remains available without leading the diagnosis. */}
+      {shouldShowRawMessage ? (
         <p className="break-words font-mono text-[11px] leading-relaxed text-theme-text-tertiary">{rawMessage}</p>
       ) : null}
       {crash ? <p className="text-xs text-theme-text-tertiary tabular-nums">{crash}</p> : null}

--- a/packages/k8s-ui/src/components/issues/IssuesView.tsx
+++ b/packages/k8s-ui/src/components/issues/IssuesView.tsx
@@ -300,7 +300,7 @@ function Diagnosis({ issue }: { issue: Issue }) {
   const { headline, detail } = issueMessageParts(issue);
   // When the issue carries a parsed plain-English cause, lead with it. The raw
   // detector message is kept below as de-emphasized detail.
-  const rawMessage = issue.cause ? issue.message ?? '' : [headline, detail].filter(Boolean).join(' ');
+  const rawMessage = issue.cause ? (issue.raw_message ?? issue.message ?? '') : [headline, detail].filter(Boolean).join(' ');
   return (
     <section className="flex flex-col gap-1">
       <h4 className="text-[11px] font-semibold uppercase tracking-wide text-theme-text-tertiary">What's wrong</h4>

--- a/packages/k8s-ui/src/components/issues/issues.test.ts
+++ b/packages/k8s-ui/src/components/issues/issues.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest'
+import { createElement } from 'react'
+import { renderToString } from 'react-dom/server'
 import { compareIssues, subjectRef, memberRef, normalizeImagePullMessage, issueMessageParts, type Issue } from './types'
 import { categoryLabel, groupLabel, groupBadgeClass } from './severity'
+import { IssueRow } from './IssuesView'
 
 const base: Issue = {
   id: 'id-0',
@@ -103,5 +106,23 @@ describe('image-pull message normalization', () => {
     const parts = issueMessageParts(mk({ category: 'missing_config_ref', reason: 'Missing Secret', message: 'secret "project-infra" not found' }))
     expect(parts.headline).toBe('secret "project-infra" not found')
     expect(parts.detail).toBe('')
+  })
+})
+
+describe('IssueRow diagnosis raw messages', () => {
+  it('shows raw_message when cleaned issue copy has no parsed cause', () => {
+    const issue = mk({
+      category: 'gitops_operation_failed',
+      category_group: 'configuration',
+      severity: 'critical',
+      reason: 'OperationFailed',
+      message: 'app path does not exist',
+      raw_message: 'rpc error: code = Unknown desc = app path does not exist',
+    })
+
+    const html = renderToString(createElement(IssueRow, { issue, open: true, onToggle: () => undefined, as: 'div' }))
+
+    expect(html).toContain('app path does not exist')
+    expect(html).toContain('rpc error: code = Unknown desc = app path does not exist')
   })
 })

--- a/packages/k8s-ui/src/components/issues/types.ts
+++ b/packages/k8s-ui/src/components/issues/types.ts
@@ -174,6 +174,7 @@ export interface Issue {
 
   reason: string;
   message?: string;
+  raw_message?: string;
   /** Parsed domain diagnosis: plain-English cause, suggested next step, and
    *  an optional structured one-click fix.
    *  Server-emitted (omitempty); empty for issues without a parser. */

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -587,6 +587,7 @@ export interface HelmOperation {
   source: HelmOperationSource
   confidence: HelmOperationConfidence
   message: string
+  rawMessage?: string
   evidence?: string
   failureDescription?: string
   revision?: number

--- a/packages/k8s-ui/src/types/gitops-insights.ts
+++ b/packages/k8s-ui/src/types/gitops-insights.ts
@@ -45,6 +45,7 @@ export interface GitOpsInsightSummary {
   // Latest operation status message — surfaced inline in the status strip
   // when an operation is in flight or just failed.
   operationMessage?: string
+  rawOperationMessage?: string
   source?: string
   targetRevision?: string
   lastRevision?: string
@@ -79,6 +80,7 @@ export interface GitOpsIssue {
   scope: GitOpsScope
   reason: string
   message: string
+  rawMessage?: string
   refs?: GitOpsInsightRef[]
   action?: string
   // Plain-English root cause when the message matched a recognized error
@@ -112,6 +114,7 @@ export interface GitOpsChange {
   // Per-resource sync failure message (Argo's status.resources[].syncResult).
   // Distinct from `message` (live health). Empty when sync succeeded.
   syncError?: string
+  rawSyncError?: string
   // Sync hook phase: PreSync / PostSync / SyncFail / PostDelete. Empty
   // for non-hook resources.
   hookPhase?: string
@@ -175,6 +178,7 @@ export interface GitOpsHistoryItem {
   deployedAt?: string
   phase?: string
   message?: string
+  rawMessage?: string
   source?: string
   initiatedBy?: string
 }

--- a/pkg/gitops/diagnose/diagnose.go
+++ b/pkg/gitops/diagnose/diagnose.go
@@ -168,6 +168,15 @@ func CleanArgoControllerMessage(msg string) string {
 	return cleaned
 }
 
+func CleanArgoControllerMessageWithRaw(msg string) (cleaned, raw string) {
+	original := strings.TrimSpace(msg)
+	cleaned = CleanArgoControllerMessage(original)
+	if original != "" && cleaned != original {
+		raw = original
+	}
+	return cleaned, raw
+}
+
 var unrecognizedOpErrorLogged sync.Map
 
 func logUnrecognizedOpError(msg string) {

--- a/pkg/gitops/diagnose/diagnose.go
+++ b/pkg/gitops/diagnose/diagnose.go
@@ -68,6 +68,8 @@ var argoAffectedRefRE = regexp.MustCompile(`([A-Z][A-Za-z0-9]+)(?:\.[A-Za-z0-9.\
 // "(retried N times)" suffix Argo appends when its retry policy has fired.
 var argoRetryRE = regexp.MustCompile(`\(retried (\d+) times?\)`)
 
+var argoGRPCEnvelopeRE = regexp.MustCompile(`(?i)rpc error:\s*code\s*=\s*[^\s]+\s+desc\s*=\s*`)
+
 // `namespaces "<name>" not found` — fires when the Application targets a
 // namespace that doesn't exist and CreateNamespace=false. The most common
 // "why won't this sync" case for new environments. Captured separately so
@@ -149,6 +151,21 @@ func ParseArgoOperationError(msg string) ParsedFailure {
 		logUnrecognizedOpError(msg)
 	}
 	return out
+}
+
+// CleanArgoControllerMessage strips transport envelopes from Argo controller
+// messages while preserving the original text when no meaningful tail remains.
+func CleanArgoControllerMessage(msg string) string {
+	original := strings.TrimSpace(msg)
+	if original == "" {
+		return ""
+	}
+	cleaned := argoGRPCEnvelopeRE.ReplaceAllString(original, "")
+	cleaned = strings.TrimLeft(strings.TrimSpace(cleaned), " :")
+	if cleaned == "" {
+		return original
+	}
+	return cleaned
 }
 
 var unrecognizedOpErrorLogged sync.Map

--- a/pkg/gitops/diagnose/diagnose_test.go
+++ b/pkg/gitops/diagnose/diagnose_test.go
@@ -188,6 +188,52 @@ func TestParseArgoOperationError_HookFailures(t *testing.T) {
 	}
 }
 
+func TestCleanArgoControllerMessage(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "single grpc envelope",
+			in:   "rpc error: code = Unknown desc = app path does not exist",
+			want: "app path does not exist",
+		},
+		{
+			name: "nested grpc envelope keeps diagnostic context",
+			in:   "application spec is invalid: rpc error: code = Unknown desc = failed to generate manifests: rpc error: code = Unknown desc = app path does not exist",
+			want: "application spec is invalid: failed to generate manifests: app path does not exist",
+		},
+		{
+			name: "nested command failure keeps middle layer",
+			in:   "rpc error: code = Unknown desc = Manifest generation error (cached): helm template failed: rpc error: code = Unknown desc = exit status 1",
+			want: "Manifest generation error (cached): helm template failed: exit status 1",
+		},
+		{
+			name: "plain condition message unchanged",
+			in:   "app path does not exist",
+			want: "app path does not exist",
+		},
+		{
+			name: "empty grpc desc preserves original",
+			in:   "rpc error: code = Unknown desc = ",
+			want: "rpc error: code = Unknown desc =",
+		},
+		{
+			name: "empty",
+			in:   "   ",
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := CleanArgoControllerMessage(tc.in); got != tc.want {
+				t.Fatalf("CleanArgoControllerMessage = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestSeverityForConditionType(t *testing.T) {
 	cases := []struct {
 		typ            string

--- a/pkg/gitops/diagnose/diagnose_test.go
+++ b/pkg/gitops/diagnose/diagnose_test.go
@@ -234,6 +234,22 @@ func TestCleanArgoControllerMessage(t *testing.T) {
 	}
 }
 
+func TestCleanArgoControllerMessageWithRaw(t *testing.T) {
+	raw := "rpc error: code = Unknown desc = app path does not exist"
+	cleaned, rawOut := CleanArgoControllerMessageWithRaw(raw)
+	if cleaned != "app path does not exist" {
+		t.Fatalf("cleaned = %q, want app path error", cleaned)
+	}
+	if rawOut != raw {
+		t.Fatalf("raw = %q, want %q", rawOut, raw)
+	}
+
+	cleaned, rawOut = CleanArgoControllerMessageWithRaw("app path does not exist")
+	if cleaned != "app path does not exist" || rawOut != "" {
+		t.Fatalf("plain message cleaned/raw = %q/%q, want unchanged/empty raw", cleaned, rawOut)
+	}
+}
+
 func TestSeverityForConditionType(t *testing.T) {
 	cases := []struct {
 		typ            string

--- a/pkg/gitops/insights/insights.go
+++ b/pkg/gitops/insights/insights.go
@@ -75,7 +75,8 @@ type Ref struct {
 // frontend dispatches on Kind to render the right button + onClick handler.
 //
 // Invariants (per Kind):
-//   RemediationCreateNamespace: Target MUST be a non-empty namespace name.
+//
+//	RemediationCreateNamespace: Target MUST be a non-empty namespace name.
 //
 // Construct via NewCreateNamespaceRemediation rather than struct literal —
 // the constructor enforces the per-Kind invariants; literal construction
@@ -344,6 +345,7 @@ func buildSummary(root *unstructured.Unstructured, tool string) Summary {
 		s.Health, _, _ = unstructured.NestedString(root.Object, "status", "health", "status")
 		s.OperationPhase, _, _ = unstructured.NestedString(root.Object, "status", "operationState", "phase")
 		s.OperationMessage, _, _ = unstructured.NestedString(root.Object, "status", "operationState", "message")
+		s.OperationMessage = diagnose.CleanArgoControllerMessage(s.OperationMessage)
 		s.TargetRevision, _, _ = unstructured.NestedString(root.Object, "status", "sync", "revision")
 		s.LastRevision, _, _ = unstructured.NestedString(root.Object, "status", "operationState", "syncResult", "revision")
 		s.LastReconcile, _, _ = unstructured.NestedString(root.Object, "status", "reconciledAt")
@@ -431,6 +433,7 @@ func buildIssues(root *unstructured.Unstructured, resourceTree *gitopstree.Resou
 		if phase, _, _ := unstructured.NestedString(root.Object, "status", "operationState", "phase"); phase == "Failed" || phase == "Error" {
 			operationFailed = true
 			msg, _, _ := unstructured.NestedString(root.Object, "status", "operationState", "message")
+			msg = diagnose.CleanArgoControllerMessage(msg)
 			parsed := diagnose.ParseArgoOperationError(msg)
 			issue := Issue{
 				Severity:    SeverityCritical,
@@ -753,7 +756,7 @@ func argoResourceChanges(root *unstructured.Unstructured, resolver Resolver) []C
 		if sr, ok := m["syncResult"].(map[string]any); ok {
 			status := gitops.StringValue(sr["status"])
 			if status != "Synced" && status != "Pruned" {
-				syncError = gitops.StringValue(sr["message"])
+				syncError = diagnose.CleanArgoControllerMessage(gitops.StringValue(sr["message"]))
 			}
 			hookPhase = gitops.StringValue(sr["hookPhase"])
 		}
@@ -918,7 +921,7 @@ func buildHistory(root *unstructured.Unstructured, tool string) []HistoryItem {
 			}
 			out = append(out, HistoryItem{
 				Phase:       gitops.StringValue(op["phase"]),
-				Message:     gitops.StringValue(op["message"]),
+				Message:     diagnose.CleanArgoControllerMessage(gitops.StringValue(op["message"])),
 				DeployedAt:  deployedAt,
 				Revision:    nestedString(op, "syncResult", "revision"),
 				InitiatedBy: initiatedBy,
@@ -1492,7 +1495,6 @@ func detectPendingDeletion(root *unstructured.Unstructured, resolver Resolver) *
 	}
 }
 
-
 // detectStuckDriftLoop emits a critical issue when an Argo Application is
 // in the "applied successfully but still drifted" state — the case where
 // the user stares at the OutOfSync badge for hours wondering why nothing
@@ -1608,7 +1610,7 @@ func argoApplicationConditions(root *unstructured.Unstructured) []Issue {
 			continue
 		}
 		typ := gitops.StringValue(m["type"])
-		msg := gitops.StringValue(m["message"])
+		msg := diagnose.CleanArgoControllerMessage(gitops.StringValue(m["message"]))
 		if typ == "" && msg == "" {
 			continue
 		}

--- a/pkg/gitops/insights/insights.go
+++ b/pkg/gitops/insights/insights.go
@@ -34,19 +34,20 @@ type Insight struct {
 }
 
 type Summary struct {
-	Tool             string `json:"tool"`
-	Kind             string `json:"kind"`
-	Namespace        string `json:"namespace"`
-	Name             string `json:"name"`
-	Sync             string `json:"sync,omitempty"`
-	Health           string `json:"health,omitempty"`
-	OperationPhase   string `json:"operationPhase,omitempty"`
-	OperationMessage string `json:"operationMessage,omitempty"`
-	Source           string `json:"source,omitempty"`
-	TargetRevision   string `json:"targetRevision,omitempty"`
-	LastRevision     string `json:"lastRevision,omitempty"`
-	LastReconcile    string `json:"lastReconcile,omitempty"`
-	PartialReason    string `json:"partialReason,omitempty"`
+	Tool                string `json:"tool"`
+	Kind                string `json:"kind"`
+	Namespace           string `json:"namespace"`
+	Name                string `json:"name"`
+	Sync                string `json:"sync,omitempty"`
+	Health              string `json:"health,omitempty"`
+	OperationPhase      string `json:"operationPhase,omitempty"`
+	OperationMessage    string `json:"operationMessage,omitempty"`
+	RawOperationMessage string `json:"rawOperationMessage,omitempty"`
+	Source              string `json:"source,omitempty"`
+	TargetRevision      string `json:"targetRevision,omitempty"`
+	LastRevision        string `json:"lastRevision,omitempty"`
+	LastReconcile       string `json:"lastReconcile,omitempty"`
+	PartialReason       string `json:"partialReason,omitempty"`
 	// AutoSyncMode is the human-readable syncPolicy chip label, e.g.
 	// "Manual", "Auto", "Auto · prune", "Auto · self-heal",
 	// "Auto · prune · self-heal", "Suspended" (Flux), or "".
@@ -123,12 +124,13 @@ func (r *Remediation) Validate() error {
 }
 
 type Issue struct {
-	Severity Severity `json:"severity"`
-	Scope    Scope    `json:"scope"`
-	Reason   string   `json:"reason"`
-	Message  string   `json:"message"`
-	Refs     []Ref    `json:"refs,omitempty"`
-	Action   string   `json:"action,omitempty"`
+	Severity   Severity `json:"severity"`
+	Scope      Scope    `json:"scope"`
+	Reason     string   `json:"reason"`
+	Message    string   `json:"message"`
+	RawMessage string   `json:"rawMessage,omitempty"`
+	Refs       []Ref    `json:"refs,omitempty"`
+	Action     string   `json:"action,omitempty"`
 	// Remediation, when set, exposes a structured one-click fix for this
 	// Issue. Frontend renders a contextual button on the failure card.
 	// Nil when no automated remedy is appropriate; the Action string still
@@ -156,7 +158,8 @@ type Change struct {
 	// SyncError is Argo's status.resources[].syncResult message — the last
 	// sync's per-resource failure. Distinct from Message (live health) so
 	// the UI can show "degraded right now" vs "last sync errored".
-	SyncError string `json:"syncError,omitempty"`
+	SyncError    string `json:"syncError,omitempty"`
+	RawSyncError string `json:"rawSyncError,omitempty"`
 	// HookPhase identifies sync hook resources (PreSync / PostSync /
 	// SyncFail / PostDelete); empty for non-hook resources.
 	HookPhase  string `json:"hookPhase,omitempty"`
@@ -219,6 +222,7 @@ type HistoryItem struct {
 	DeployedAt  string `json:"deployedAt,omitempty"`
 	Phase       string `json:"phase,omitempty"`
 	Message     string `json:"message,omitempty"`
+	RawMessage  string `json:"rawMessage,omitempty"`
 	Source      string `json:"source,omitempty"`
 	InitiatedBy string `json:"initiatedBy,omitempty"`
 }
@@ -344,8 +348,8 @@ func buildSummary(root *unstructured.Unstructured, tool string) Summary {
 		s.Sync, _, _ = unstructured.NestedString(root.Object, "status", "sync", "status")
 		s.Health, _, _ = unstructured.NestedString(root.Object, "status", "health", "status")
 		s.OperationPhase, _, _ = unstructured.NestedString(root.Object, "status", "operationState", "phase")
-		s.OperationMessage, _, _ = unstructured.NestedString(root.Object, "status", "operationState", "message")
-		s.OperationMessage = diagnose.CleanArgoControllerMessage(s.OperationMessage)
+		opMessage, _, _ := unstructured.NestedString(root.Object, "status", "operationState", "message")
+		s.OperationMessage, s.RawOperationMessage = diagnose.CleanArgoControllerMessageWithRaw(opMessage)
 		s.TargetRevision, _, _ = unstructured.NestedString(root.Object, "status", "sync", "revision")
 		s.LastRevision, _, _ = unstructured.NestedString(root.Object, "status", "operationState", "syncResult", "revision")
 		s.LastReconcile, _, _ = unstructured.NestedString(root.Object, "status", "reconciledAt")
@@ -432,14 +436,15 @@ func buildIssues(root *unstructured.Unstructured, resourceTree *gitopstree.Resou
 	if tool == "argocd" {
 		if phase, _, _ := unstructured.NestedString(root.Object, "status", "operationState", "phase"); phase == "Failed" || phase == "Error" {
 			operationFailed = true
-			msg, _, _ := unstructured.NestedString(root.Object, "status", "operationState", "message")
-			msg = diagnose.CleanArgoControllerMessage(msg)
+			opMessage, _, _ := unstructured.NestedString(root.Object, "status", "operationState", "message")
+			msg, rawMsg := diagnose.CleanArgoControllerMessageWithRaw(opMessage)
 			parsed := diagnose.ParseArgoOperationError(msg)
 			issue := Issue{
 				Severity:    SeverityCritical,
 				Scope:       ScopeOperation,
 				Reason:      phase,
 				Message:     fallback(msg, "Last sync operation failed"),
+				RawMessage:  rawMsg,
 				Action:      "Open Activity for operation details.",
 				Cause:       parsed.Cause,
 				RetryCount:  parsed.RetryCount,
@@ -752,26 +757,28 @@ func argoResourceChanges(root *unstructured.Unstructured, resolver Resolver) []C
 		// Empty status counts as "unknown — show the message" because Argo
 		// can write a pre-apply failure message before stamping a status.
 		syncError := ""
+		rawSyncError := ""
 		hookPhase := ""
 		if sr, ok := m["syncResult"].(map[string]any); ok {
 			status := gitops.StringValue(sr["status"])
 			if status != "Synced" && status != "Pruned" {
-				syncError = diagnose.CleanArgoControllerMessage(gitops.StringValue(sr["message"]))
+				syncError, rawSyncError = diagnose.CleanArgoControllerMessageWithRaw(gitops.StringValue(sr["message"]))
 			}
 			hookPhase = gitops.StringValue(sr["hookPhase"])
 		}
 		change := Change{
-			Ref:         ref,
-			Category:    category,
-			Sync:        sync,
-			Health:      health,
-			Message:     nestedMessage(m["health"]),
-			SyncError:   syncError,
-			HookPhase:   hookPhase,
-			HasDesired:  false,
-			HasLive:     true,
-			Partial:     true,
-			PartialNote: "Argo reports resource status here; desired manifest content is not available in Radar yet.",
+			Ref:          ref,
+			Category:     category,
+			Sync:         sync,
+			Health:       health,
+			Message:      nestedMessage(m["health"]),
+			SyncError:    syncError,
+			RawSyncError: rawSyncError,
+			HookPhase:    hookPhase,
+			HasDesired:   false,
+			HasLive:      true,
+			Partial:      true,
+			PartialNote:  "Argo reports resource status here; desired manifest content is not available in Radar yet.",
 		}
 		// Enrich from live cluster state when a resolver is wired. The
 		// drift diff turns the bare "OutOfSync" badge into a concrete
@@ -919,9 +926,11 @@ func buildHistory(root *unstructured.Unstructured, tool string) []HistoryItem {
 			if deployedAt == "" {
 				deployedAt = gitops.StringValue(op["startedAt"])
 			}
+			msg, rawMsg := diagnose.CleanArgoControllerMessageWithRaw(gitops.StringValue(op["message"]))
 			out = append(out, HistoryItem{
 				Phase:       gitops.StringValue(op["phase"]),
-				Message:     diagnose.CleanArgoControllerMessage(gitops.StringValue(op["message"])),
+				Message:     msg,
+				RawMessage:  rawMsg,
 				DeployedAt:  deployedAt,
 				Revision:    nestedString(op, "syncResult", "revision"),
 				InitiatedBy: initiatedBy,
@@ -1610,7 +1619,7 @@ func argoApplicationConditions(root *unstructured.Unstructured) []Issue {
 			continue
 		}
 		typ := gitops.StringValue(m["type"])
-		msg := diagnose.CleanArgoControllerMessage(gitops.StringValue(m["message"]))
+		msg, rawMsg := diagnose.CleanArgoControllerMessageWithRaw(gitops.StringValue(m["message"]))
 		if typ == "" && msg == "" {
 			continue
 		}
@@ -1622,11 +1631,12 @@ func argoApplicationConditions(root *unstructured.Unstructured) []Issue {
 			severity = SeverityWarning
 		}
 		out = append(out, Issue{
-			Severity: severity,
-			Scope:    ScopeCondition,
-			Reason:   fallback(typ, "Condition"),
-			Message:  fallback(msg, typ),
-			Action:   diagnose.ActionForCondition(typ),
+			Severity:   severity,
+			Scope:      ScopeCondition,
+			Reason:     fallback(typ, "Condition"),
+			Message:    fallback(msg, typ),
+			RawMessage: rawMsg,
+			Action:     diagnose.ActionForCondition(typ),
 		})
 	}
 	return out

--- a/pkg/gitops/insights/insights_test.go
+++ b/pkg/gitops/insights/insights_test.go
@@ -44,10 +44,12 @@ func TestBuildIssuesArgoFailedOperationProducesCritical(t *testing.T) {
 }
 
 func TestBuildArgoCleansControllerMessages(t *testing.T) {
+	rawOperation := "rpc error: code = Unknown desc = app path does not exist"
+	rawResource := "rpc error: code = Unknown desc = resource hook failed"
 	root := argoApp(map[string]any{
 		"operationState": map[string]any{
 			"phase":     "Failed",
-			"message":   "rpc error: code = Unknown desc = app path does not exist",
+			"message":   rawOperation,
 			"startedAt": "2026-05-03T12:00:00Z",
 		},
 		"resources": []any{
@@ -59,7 +61,7 @@ func TestBuildArgoCleansControllerMessages(t *testing.T) {
 				"status":    "OutOfSync",
 				"syncResult": map[string]any{
 					"status":  "SyncFailed",
-					"message": "rpc error: code = Unknown desc = resource hook failed",
+					"message": rawResource,
 				},
 			},
 		},
@@ -68,6 +70,9 @@ func TestBuildArgoCleansControllerMessages(t *testing.T) {
 	got := Build(root, nil, nil)
 	if got.Summary.OperationMessage != "app path does not exist" {
 		t.Fatalf("summary operation message = %q, want cleaned app path error", got.Summary.OperationMessage)
+	}
+	if got.Summary.RawOperationMessage != rawOperation {
+		t.Fatalf("summary raw operation message = %q, want %q", got.Summary.RawOperationMessage, rawOperation)
 	}
 	var opIssue *Issue
 	for i := range got.Issues {
@@ -79,11 +84,20 @@ func TestBuildArgoCleansControllerMessages(t *testing.T) {
 	if opIssue == nil || opIssue.Message != "app path does not exist" {
 		t.Fatalf("operation issue did not carry cleaned message: %+v", got.Issues)
 	}
+	if opIssue.RawMessage != rawOperation {
+		t.Fatalf("operation issue raw message = %q, want %q", opIssue.RawMessage, rawOperation)
+	}
 	if len(got.History) != 1 || got.History[0].Message != "app path does not exist" {
 		t.Fatalf("history did not carry cleaned message: %+v", got.History)
 	}
+	if got.History[0].RawMessage != rawOperation {
+		t.Fatalf("history raw message = %q, want %q", got.History[0].RawMessage, rawOperation)
+	}
 	if len(got.Changes) != 1 || got.Changes[0].SyncError != "resource hook failed" {
 		t.Fatalf("resource change did not carry cleaned sync error: %+v", got.Changes)
+	}
+	if got.Changes[0].RawSyncError != rawResource {
+		t.Fatalf("resource change raw sync error = %q, want %q", got.Changes[0].RawSyncError, rawResource)
 	}
 	for _, msg := range []string{
 		got.Summary.OperationMessage,

--- a/pkg/gitops/insights/insights_test.go
+++ b/pkg/gitops/insights/insights_test.go
@@ -43,6 +43,60 @@ func TestBuildIssuesArgoFailedOperationProducesCritical(t *testing.T) {
 	}
 }
 
+func TestBuildArgoCleansControllerMessages(t *testing.T) {
+	root := argoApp(map[string]any{
+		"operationState": map[string]any{
+			"phase":     "Failed",
+			"message":   "rpc error: code = Unknown desc = app path does not exist",
+			"startedAt": "2026-05-03T12:00:00Z",
+		},
+		"resources": []any{
+			map[string]any{
+				"group":     "apps",
+				"kind":      "Deployment",
+				"namespace": "apps",
+				"name":      "api",
+				"status":    "OutOfSync",
+				"syncResult": map[string]any{
+					"status":  "SyncFailed",
+					"message": "rpc error: code = Unknown desc = resource hook failed",
+				},
+			},
+		},
+	})
+
+	got := Build(root, nil, nil)
+	if got.Summary.OperationMessage != "app path does not exist" {
+		t.Fatalf("summary operation message = %q, want cleaned app path error", got.Summary.OperationMessage)
+	}
+	var opIssue *Issue
+	for i := range got.Issues {
+		if got.Issues[i].Scope == ScopeOperation {
+			opIssue = &got.Issues[i]
+			break
+		}
+	}
+	if opIssue == nil || opIssue.Message != "app path does not exist" {
+		t.Fatalf("operation issue did not carry cleaned message: %+v", got.Issues)
+	}
+	if len(got.History) != 1 || got.History[0].Message != "app path does not exist" {
+		t.Fatalf("history did not carry cleaned message: %+v", got.History)
+	}
+	if len(got.Changes) != 1 || got.Changes[0].SyncError != "resource hook failed" {
+		t.Fatalf("resource change did not carry cleaned sync error: %+v", got.Changes)
+	}
+	for _, msg := range []string{
+		got.Summary.OperationMessage,
+		opIssue.Message,
+		got.History[0].Message,
+		got.Changes[0].SyncError,
+	} {
+		if strings.Contains(msg, "rpc error") || strings.Contains(msg, "Unknown desc") {
+			t.Fatalf("Argo controller message leaked gRPC envelope: %q", msg)
+		}
+	}
+}
+
 func TestBuildIssuesArgoRunningOperationProducesInfo(t *testing.T) {
 	root := argoApp(map[string]any{
 		"operationState": map[string]any{"phase": "Running"},
@@ -543,7 +597,7 @@ func TestDetectManualDriftWithoutAutoSync(t *testing.T) {
 func TestArgoApplicationConditions_MapsTypesToSeverity(t *testing.T) {
 	root := argoApp(map[string]any{
 		"conditions": []any{
-			map[string]any{"type": "ComparisonError", "message": "rpc error: revision not found"},
+			map[string]any{"type": "ComparisonError", "message": "rpc error: code = Unknown desc = revision not found"},
 			map[string]any{"type": "OrphanedResourceWarning", "message": "ConfigMap foo has no owner"},
 			map[string]any{"type": "SomeUnrelatedInfo", "message": "noise"},
 			map[string]any{"type": "", "message": ""}, // skipped
@@ -557,8 +611,18 @@ func TestArgoApplicationConditions_MapsTypesToSeverity(t *testing.T) {
 	for _, iss := range got {
 		bySev[iss.Reason] = iss.Severity
 	}
+	byMessage := map[string]string{}
+	for _, iss := range got {
+		byMessage[iss.Reason] = iss.Message
+	}
 	if bySev["ComparisonError"] != SeverityCritical {
 		t.Errorf("ComparisonError severity = %q, want critical", bySev["ComparisonError"])
+	}
+	if byMessage["ComparisonError"] != "revision not found" {
+		t.Errorf("ComparisonError message = %q, want cleaned revision error", byMessage["ComparisonError"])
+	}
+	if strings.Contains(byMessage["ComparisonError"], "rpc error") || strings.Contains(byMessage["ComparisonError"], "Unknown desc") {
+		t.Errorf("ComparisonError message leaked gRPC envelope: %q", byMessage["ComparisonError"])
 	}
 	if bySev["OrphanedResourceWarning"] != SeverityWarning {
 		t.Errorf("OrphanedResourceWarning severity = %q, want warning", bySev["OrphanedResourceWarning"])

--- a/pkg/helmhistory/helmhistory.go
+++ b/pkg/helmhistory/helmhistory.go
@@ -196,7 +196,7 @@ func failedOperation(releaseName string, rev Revision, source Source) Operation 
 	}
 	rawMessage := ""
 	if IsReadinessTimeoutMessage(message) {
-		rawMessage = strings.TrimSpace(message)
+		rawMessage = strings.TrimSpace(rev.Description)
 		message = readinessTimeoutMessage(releaseName)
 	}
 	evidence := "Helm history revision status is failed"

--- a/pkg/helmhistory/helmhistory.go
+++ b/pkg/helmhistory/helmhistory.go
@@ -58,6 +58,7 @@ type Operation struct {
 	Source             Source          `json:"source"`
 	Confidence         Confidence      `json:"confidence"`
 	Message            string          `json:"message"`
+	RawMessage         string          `json:"rawMessage,omitempty"`
 	Evidence           string          `json:"evidence,omitempty"`
 	FailureDescription string          `json:"failureDescription,omitempty"`
 	Revision           int             `json:"revision,omitempty"`
@@ -114,7 +115,7 @@ func Analyze(releaseName string, currentRevision int, revisions []Revision, opts
 					}
 				}
 			}
-			ops = append(ops, failedOperation(rev, SourceHistory))
+			ops = append(ops, failedOperation(releaseName, rev, SourceHistory))
 			continue
 		}
 		if isCompletedRevisionStatus(status) {
@@ -133,7 +134,7 @@ func Analyze(releaseName string, currentRevision int, revisions []Revision, opts
 	if hasCurrent {
 		switch status := normalizeStatus(current.Status); {
 		case status == "failed":
-			op := failedOperation(current, SourceStatus)
+			op := failedOperation(releaseName, current, SourceStatus)
 			live = &op
 		case isPending(status) && !current.Updated.IsZero() && now.Sub(current.Updated) >= pendingStuckAfter:
 			op := pendingOperation(current, now.Sub(current.Updated))
@@ -183,7 +184,7 @@ func rolledBackOperation(failed, rollback Revision, target int) Operation {
 	}
 }
 
-func failedOperation(rev Revision, source Source) Operation {
+func failedOperation(releaseName string, rev Revision, source Source) Operation {
 	kind := KindReleaseFailed
 	message := fmt.Sprintf("Release failed at rev %d.", rev.Revision)
 	if isUpgradeFailureDescription(rev.Description) {
@@ -192,6 +193,11 @@ func failedOperation(rev Revision, source Source) Operation {
 	}
 	if rev.Description != "" {
 		message = message + " " + rev.Description
+	}
+	rawMessage := ""
+	if IsReadinessTimeoutMessage(message) {
+		rawMessage = strings.TrimSpace(message)
+		message = readinessTimeoutMessage(releaseName)
 	}
 	evidence := "Helm history revision status is failed"
 	if source == SourceStatus {
@@ -203,10 +209,27 @@ func failedOperation(rev Revision, source Source) Operation {
 		Source:     source,
 		Confidence: ConfidenceHigh,
 		Message:    message,
+		RawMessage: rawMessage,
 		Evidence:   evidence,
 		Revision:   rev.Revision,
 		Updated:    rev.Updated,
 	}
+}
+
+func IsReadinessTimeoutMessage(msg string) bool {
+	lower := strings.ToLower(msg)
+	if !strings.Contains(lower, "context deadline exceeded") || !strings.Contains(lower, "status: inprogress") {
+		return false
+	}
+	return strings.Contains(lower, "not ready") || strings.Contains(lower, "available: 0/")
+}
+
+func readinessTimeoutMessage(releaseName string) string {
+	name := strings.TrimSpace(releaseName)
+	if name == "" {
+		return "Helm release did not become ready before Helm timed out."
+	}
+	return fmt.Sprintf("Helm release %q did not become ready before Helm timed out.", name)
 }
 
 func rollbackOperation(rev Revision, target int) Operation {

--- a/pkg/helmhistory/helmhistory_test.go
+++ b/pkg/helmhistory/helmhistory_test.go
@@ -1,6 +1,7 @@
 package helmhistory
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -23,6 +24,35 @@ func TestAnalyzeCurrentFailedUpgrade(t *testing.T) {
 	}
 	if len(got.Operations) != 0 {
 		t.Fatalf("Operations = %#v, want no duplicate of live failed revision", got.Operations)
+	}
+}
+
+func TestAnalyzeCurrentFailedReadinessTimeoutCleansMessage(t *testing.T) {
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	rawDescription := `Release "crossplane" failed: resource Deployment/crossplane-system/crossplane not ready. status: InProgress, message: Available: 0/1
+resource Deployment/crossplane-system/crossplane-rbac-manager not ready. status: InProgress, message: Available: 0/1
+context deadline exceeded`
+	got := Analyze("crossplane", 1, []Revision{
+		rev(1, "failed", rawDescription, now.Add(-5*time.Minute)),
+	}, Options{Now: now})
+
+	if got.LastOperation == nil {
+		t.Fatal("LastOperation = nil")
+	}
+	want := `Helm release "crossplane" did not become ready before Helm timed out.`
+	if got.LastOperation.Message != want {
+		t.Fatalf("message = %q, want %q", got.LastOperation.Message, want)
+	}
+	if got.LastOperation.RawMessage == "" {
+		t.Fatal("RawMessage is empty, want original Helm timeout")
+	}
+	for _, leaked := range []string{"status: InProgress", "Available: 0/1", "context deadline exceeded"} {
+		if strings.Contains(got.LastOperation.Message, leaked) {
+			t.Fatalf("message leaked raw Helm timeout text %q: %q", leaked, got.LastOperation.Message)
+		}
+		if !strings.Contains(got.LastOperation.RawMessage, leaked) {
+			t.Fatalf("RawMessage missing %q: %q", leaked, got.LastOperation.RawMessage)
+		}
 	}
 }
 

--- a/pkg/helmhistory/helmhistory_test.go
+++ b/pkg/helmhistory/helmhistory_test.go
@@ -46,12 +46,12 @@ context deadline exceeded`
 	if got.LastOperation.RawMessage == "" {
 		t.Fatal("RawMessage is empty, want original Helm timeout")
 	}
+	if got.LastOperation.RawMessage != rawDescription {
+		t.Fatalf("RawMessage = %q, want %q", got.LastOperation.RawMessage, rawDescription)
+	}
 	for _, leaked := range []string{"status: InProgress", "Available: 0/1", "context deadline exceeded"} {
 		if strings.Contains(got.LastOperation.Message, leaked) {
 			t.Fatalf("message leaked raw Helm timeout text %q: %q", leaked, got.LastOperation.Message)
-		}
-		if !strings.Contains(got.LastOperation.RawMessage, leaked) {
-			t.Fatalf("RawMessage missing %q: %q", leaked, got.LastOperation.RawMessage)
 		}
 	}
 }

--- a/pkg/issuesapi/types.go
+++ b/pkg/issuesapi/types.go
@@ -245,8 +245,8 @@ const (
 // not part of this contract. Assigned only when unambiguous: a single best root
 // by confidence tier; distinct roots at the same tier leave it unset.
 type IncidentParent struct {
-	ID         string     `json:"id"`                  // parent grouped-issue ID (within-cluster)
-	Ref        Ref        `json:"ref"`                 // parent subject, for display + deep-link
+	ID         string     `json:"id"`  // parent grouped-issue ID (within-cluster)
+	Ref        Ref        `json:"ref"` // parent subject, for display + deep-link
 	Category   Category   `json:"category,omitempty"`
 	Confidence Confidence `json:"confidence,omitempty"`
 	FactType   string     `json:"fact_type,omitempty"` // node_blast_radius | pvc_blast_radius | apiservice_hpa | secret_not_ready
@@ -340,6 +340,7 @@ type Issue struct {
 	Name          string        `json:"name"`
 	Reason        string        `json:"reason"`
 	Message       string        `json:"message,omitempty"`
+	RawMessage    string        `json:"raw_message,omitempty"`
 	// Cause / Action / Remediation* carry parsed domain diagnosis. They give the
 	// Issues page + MCP a plain-English cause + next step when a detector has
 	// enough evidence. All optional — empty for issues without a parser.

--- a/web/src/components/helm/HelmReleaseDrawer.tsx
+++ b/web/src/components/helm/HelmReleaseDrawer.tsx
@@ -788,6 +788,8 @@ function HelmOperationBanner({
   const title = operationTitle(operation)
   const statusLabel = operation.status.replace(/_/g, ' ')
   const showStatusBadge = !(operation.status === 'failed' && title.toLowerCase().includes('failed'))
+  const rawMessage = operation.rawMessage?.trim()
+  const hasRawMessage = !!rawMessage && rawMessage !== operation.message.trim()
 
   return (
     <div className="m-4 mb-0 card-inner-lg">
@@ -802,7 +804,17 @@ function HelmOperationBanner({
             <OperationRevisionChips operation={operation} />
           </div>
           <p className="mt-1 text-sm text-theme-text-secondary">{operation.message}</p>
-          {operation.failureDescription && (
+          {hasRawMessage && (
+            <details className="mt-2">
+              <summary className="cursor-pointer select-none text-xs font-medium text-theme-text-tertiary hover:text-theme-text-secondary">
+                Show raw Helm error
+              </summary>
+              <pre className="mt-2 max-h-32 overflow-auto whitespace-pre-wrap break-words rounded bg-theme-base/60 p-2 font-mono text-[11px] leading-relaxed text-theme-text-tertiary">
+                {rawMessage}
+              </pre>
+            </details>
+          )}
+          {operation.failureDescription && !hasRawMessage && (
             <Tooltip content={operation.failureDescription} wrapperClassName="mt-1 flex">
               <span className="line-clamp-2 text-xs text-theme-text-tertiary">
                 {operation.failureDescription}
@@ -1032,12 +1044,15 @@ interface OverviewTabProps {
     notes: string
     readme?: string
     dependencies?: ChartDependency[]
+    lastOperation?: HelmOperation
   }
   onCopy: (text: string, key: string) => void
   copied: string | null
 }
 
 function OverviewTab({ release, onCopy, copied }: OverviewTabProps) {
+  const showDescription = !!release.description && !isDuplicateOperationRawDescription(release.description, release.lastOperation)
+
   return (
     <div className="p-4 space-y-4">
       {/* Chart info */}
@@ -1068,7 +1083,7 @@ function OverviewTab({ release, onCopy, copied }: OverviewTabProps) {
       </div>
 
       {/* Description */}
-      {release.description && (
+      {showDescription && (
         <div className="bg-theme-elevated/30 rounded-lg p-4">
           <h3 className="text-sm font-medium text-theme-text-secondary mb-2">Description</h3>
           <p className="text-sm text-theme-text-secondary">{release.description}</p>
@@ -1150,6 +1165,16 @@ function OverviewTab({ release, onCopy, copied }: OverviewTabProps) {
       )}
     </div>
   )
+}
+
+function isDuplicateOperationRawDescription(description: string, operation?: HelmOperation): boolean {
+  const desc = normalizeComparableText(description)
+  const raw = normalizeComparableText(operation?.rawMessage || '')
+  return desc !== '' && raw.includes(desc)
+}
+
+function normalizeComparableText(value: string): string {
+  return value.trim().replace(/\s+/g, ' ')
 }
 
 // Hooks tab content


### PR DESCRIPTION
## Why

Fixes SKY-1094 by turning noisy Argo controller wrappers and native Helm readiness-timeout output into operator-facing diagnosis copy. Operators should see the actionable failure as the headline while still having access to the exact controller or Helm text when they need it for debugging.

## What changed

- Added shared Argo controller-message cleanup in `pkg/gitops/diagnose` and reused it across cluster-wide GitOps issue detection, GitOps detail insights, Application history summaries, and per-resource sync errors.
- Preserved raw controller text as secondary detail wherever the primary message is cleaned: `raw_message` on issues and optional `rawMessage`, `rawOperationMessage`, and `rawSyncError` fields in GitOps insights.
- Kept Argo reason, severity, category, affected-resource, retry, and remediation parsing on the cleaned message so envelopes do not block structured diagnosis.
- Added conservative native Helm readiness-timeout normalization for failed releases with the observed `status: InProgress`, `Available: 0/1`, and `context deadline exceeded` shape.
- Preserved exact Helm revision text as `rawMessage`, without Radar synthetic prefixes, so the Helm drawer can show a clean banner and an expandable raw error.
- Updated the Helm drawer to suppress a duplicate raw Description card only when it matches the raw last operation, while keeping normal chart descriptions visible.
- Updated GitOps/Issues raw-detail surfaces so raw text remains inspectable without being the headline.

## Risk / blast radius

Low to medium. This changes diagnosis/display copy and adds optional API fields; it does not change cluster operations, writes, or controller interactions. The main risks are over-cleaning a controller message or under-matching a future Helm timeout shape. The implementation is intentionally conservative: envelope-free messages pass through unchanged, malformed/empty Argo envelopes fall back to the original message, and unrecognized Helm timeout shapes remain raw rather than being guessed.

## Testing

- `go test ./internal/issues ./internal/helm`
- `cd pkg && go test ./helmhistory`
- `npm --workspace @skyhook-io/k8s-ui test -- --run src/components/issues/issues.test.ts`
- `make tsc`
- `make test`
- `make build`
- Live API test against `radar-test-nonprod`: `/api/helm/releases/crossplane-system/crossplane` returns clean `lastOperation.message` and exact raw Helm revision text in `lastOperation.rawMessage`.
- Visual-test against `radar-test-nonprod`: Helm release drawer shows the clean timeout banner, keeps raw Helm output hidden until `Show raw Helm error` is expanded, and has zero console errors on the checked navigation.

## Notes

The Helm timeout heuristic is narrow by design. If Helm or kstatus emits a different timeout shape later, Radar will keep showing the raw text until that shape is explicitly added and tested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and optional API fields only—no writes or controller behavior. Risk is mis-cleaning or missing a future Helm timeout shape; unchanged envelopes pass through and unrecognized timeouts stay raw.
> 
> **Overview**
> Operators see **cleaned headlines** for Argo sync failures and native Helm readiness timeouts instead of `rpc error: code = Unknown desc = …` or kstatus condition dumps. **Original controller/Helm text** is kept on new optional fields (`raw_message` on issues; `rawMessage` / `rawOperationMessage` / `rawSyncError` on GitOps insights and Helm operations) and surfaced in Issues, GitOps insight bands, and the Helm drawer behind expand/tooltips.
> 
> Shared **`CleanArgoControllerMessage` / `CleanArgoControllerMessageWithRaw`** in `pkg/gitops/diagnose` drive cluster GitOps detection, insights build, Application history diffs, and per-resource sync errors; parsing/remediation still runs on the cleaned string. **`helmhistory`** applies a narrow readiness-timeout rewrite for failed revisions and stores the revision description in `rawMessage`; native Helm issues and grouping propagate **`RawMessage`** through the issues pipeline.
> 
> UI updates prefer cleaned `message` for display and only show raw detail when it differs from the headline (including deduping duplicate Helm overview descriptions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f05a1d4daa2716c8cd1e433b4322f7889295151. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->