### PR TITLE
Improve connection error recovery

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -27,6 +27,8 @@ import (
 	versionpkg "github.com/skyhook-io/radar/internal/version"
 )
 
+var clusterConnectionProbe = k8s.TestClusterConnection
+
 // AppConfig holds all parsed configuration for the Radar application.
 type AppConfig struct {
 	Kubeconfig               string
@@ -464,11 +466,6 @@ func Shutdown(srv *server.Server) {
 // timeouts ARE retried because the first call triggers a token refresh
 // (e.g., AWS SSO), and the cached token is available on the next attempt.
 func CheckClusterAccess(ctx context.Context) error {
-	clientset := k8s.GetClient()
-	if clientset == nil {
-		return fmt.Errorf("kubernetes client not initialized")
-	}
-
 	execAuth := k8s.UsesExecAuth()
 
 	// Exec credential plugins (EKS aws, GKE gcloud) may need 7-10s on first
@@ -510,33 +507,20 @@ func CheckClusterAccess(ctx context.Context) error {
 			}
 		}
 
-		t := time.Now()
 		attemptCtx, cancel := context.WithTimeout(ctx, attemptTimeout)
-
-		// Run the API call in a goroutine so we can select on the parent
-		// context. This guarantees we return when the deadline hits even
-		// if the exec credential plugin blocks beyond the HTTP timeout.
-		resultCh := make(chan error, 1)
-		go func() {
-			_, err := clientset.Discovery().RESTClient().Get().AbsPath("/version").Do(attemptCtx).Raw()
-			resultCh <- err
-		}()
-
-		var err error
-		select {
-		case err = <-resultCh:
-		case <-ctx.Done():
-			cancel()
-			if lastErr != nil {
-				return fmt.Errorf("failed to connect to cluster: %w", lastErr)
-			}
-			return fmt.Errorf("failed to connect to cluster: %w", ctx.Err())
-		}
+		t := time.Now()
+		err := clusterConnectionProbe(attemptCtx)
 		cancel()
 
 		if err == nil {
 			k8s.LogTiming("   Cluster /version check (attempt %d): %v", attempt+1, time.Since(t))
 			return nil
+		}
+		if ctx.Err() != nil {
+			if lastErr != nil {
+				return fmt.Errorf("failed to connect to cluster: %w", lastErr)
+			}
+			return fmt.Errorf("failed to connect to cluster: %w", err)
 		}
 		log.Printf("Cluster connectivity check failed (attempt %d/2): %v (%v)", attempt+1, err, time.Since(t))
 		lastErr = err

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -348,13 +348,14 @@ func InitializeCluster() {
 		// Update status IMMEDIATELY so the UI shows the error page.
 		// Don't wait for subsystem drain — exec credential plugins serialize
 		// API calls, so draining 20+ RBAC checks can take 30+ seconds.
+		errorType := k8s.ClassifyError(err)
 		k8s.SetConnectionStatus(k8s.ConnectionStatus{
 			State:     k8s.StateDisconnected,
 			Context:   k8s.GetContextName(),
 			Error:     err.Error(),
-			ErrorType: k8s.ClassifyError(err),
+			ErrorType: errorType,
 		})
-		log.Printf("[ops] InitializeCluster FAILED: %v (errorType=%s, %v elapsed)", err, k8s.ClassifyError(err), time.Since(clusterStart))
+		log.Printf("[ops] InitializeCluster FAILED: %v (errorType=%s, %v elapsed)", err, errorType, time.Since(clusterStart))
 
 		// Drain subsystem goroutine in background to prevent goroutine leak.
 		// Cleanup is handled by the next context switch or retry.
@@ -461,10 +462,11 @@ func Shutdown(srv *server.Server) {
 // EKS) is still blocking.
 //
 // Retries once after a 2-second pause to handle transient timeouts.
-// Deterministic errors (auth, RBAC, network) skip the retry — retrying
-// expired credentials or unreachable hosts won't help. Exception: exec auth
-// timeouts ARE retried because the first call triggers a token refresh
-// (e.g., AWS SSO), and the cached token is available on the next attempt.
+// Deterministic errors (config, auth, RBAC, network, TLS) skip the retry —
+// retrying missing config, bad credentials, denied permissions, bad certs, or
+// unreachable hosts won't help. Timeout-shaped exec-auth failures are still
+// retryable because the first call may trigger a token refresh, with the cached
+// token ready by retry.
 func CheckClusterAccess(ctx context.Context) error {
 	execAuth := k8s.UsesExecAuth()
 
@@ -482,10 +484,7 @@ func CheckClusterAccess(ctx context.Context) error {
 			// Exception: exec auth timeouts are retryable — the first call
 			// triggers a token refresh, and the cached token is ready by retry.
 			errType := k8s.ClassifyError(lastErr)
-			if errType == "rbac" || errType == "network" {
-				break
-			}
-			if errType == "auth" && !execAuth {
+			if errType == "config" || errType == "auth" || errType == "rbac" || errType == "network" || errType == "tls" {
 				break
 			}
 			// Don't retry if the parent context is already done

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -146,6 +146,87 @@ func TestCheckClusterAccessPreservesProbeErrorShape(t *testing.T) {
 	}
 }
 
+func TestCheckClusterAccessDoesNotRetryConcreteExecAuthFailure(t *testing.T) {
+	prevExec := k8s.SetTestContextUsesExec(true)
+	t.Cleanup(func() {
+		k8s.SetTestContextUsesExec(prevExec)
+	})
+	previousProbe := clusterConnectionProbe
+	calls := 0
+	clusterConnectionProbe = func(context.Context) error {
+		calls++
+		return errors.New("getting credentials: exec: executable aws failed with exit code 255")
+	}
+	t.Cleanup(func() {
+		clusterConnectionProbe = previousProbe
+	})
+
+	err := CheckClusterAccess(context.Background())
+	if err == nil {
+		t.Fatal("CheckClusterAccess() = nil, want error")
+	}
+	if calls != 1 {
+		t.Fatalf("clusterConnectionProbe calls = %d, want one attempt for deterministic auth failure", calls)
+	}
+	if got := k8s.ClassifyError(err); got != "auth" {
+		t.Fatalf("ClassifyError(CheckClusterAccess error) = %q, want auth", got)
+	}
+}
+
+func TestCheckClusterAccessDoesNotRetryDeterministicFailures(t *testing.T) {
+	tests := []struct {
+		name string
+		err  string
+		want string
+	}{
+		{
+			name: "config",
+			err:  "no context configured",
+			want: "config",
+		},
+		{
+			name: "rbac",
+			err:  `deployments.apps is forbidden: User "alice" cannot list resource`,
+			want: "rbac",
+		},
+		{
+			name: "network",
+			err:  `cluster unreachable: Get "https://cluster.example/version": dial tcp 10.0.0.1:443: connect: connection refused`,
+			want: "network",
+		},
+		{
+			name: "tls",
+			err:  `cluster unreachable: Get "https://cluster.example/version": tls: failed to verify certificate: x509: certificate signed by unknown authority`,
+			want: "tls",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			previousProbe := clusterConnectionProbe
+			calls := 0
+			clusterConnectionProbe = func(context.Context) error {
+				calls++
+				return errors.New(tt.err)
+			}
+			t.Cleanup(func() {
+				clusterConnectionProbe = previousProbe
+			})
+
+			err := CheckClusterAccess(context.Background())
+			if err == nil {
+				t.Fatal("CheckClusterAccess() = nil, want error")
+			}
+			if calls != 1 {
+				t.Fatalf("clusterConnectionProbe calls = %d, want one attempt for deterministic %s failure", calls, tt.name)
+			}
+			if got := k8s.ClassifyError(err); got != tt.want {
+				t.Fatalf("ClassifyError(CheckClusterAccess error) = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestConfigureNamespaceScopePreferenceResolverAuthDoesNotUseLocalSettings(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	k8s.ResetTestState()

--- a/internal/app/bootstrap_test.go
+++ b/internal/app/bootstrap_test.go
@@ -1,6 +1,9 @@
 package app
 
 import (
+	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/skyhook-io/radar/internal/auth"
@@ -114,6 +117,32 @@ func TestConfigureNamespaceScopePreferenceResolverRescopeSurvivesReconnect(t *te
 	k8s.RestoreNamespaceScopePreference("ctx-a")
 	if got := k8s.GetNamespaceScopeTarget(); got != "bar" {
 		t.Fatalf("target after rescope+reconnect = %q, want bar", got)
+	}
+}
+
+func TestCheckClusterAccessPreservesProbeErrorShape(t *testing.T) {
+	previousProbe := clusterConnectionProbe
+	calls := 0
+	clusterConnectionProbe = func(context.Context) error {
+		calls++
+		return errors.New("cluster unreachable: context deadline exceeded")
+	}
+	t.Cleanup(func() {
+		clusterConnectionProbe = previousProbe
+	})
+
+	err := CheckClusterAccess(context.Background())
+	if err == nil {
+		t.Fatal("CheckClusterAccess() = nil, want error")
+	}
+	if calls != 2 {
+		t.Fatalf("clusterConnectionProbe calls = %d, want 2 attempts", calls)
+	}
+	if !strings.Contains(err.Error(), "failed to connect to cluster: cluster unreachable: context deadline exceeded") {
+		t.Fatalf("CheckClusterAccess() error = %q, want preserved cluster-unreachable wrapper", err.Error())
+	}
+	if got := k8s.ClassifyError(err); got != "timeout" {
+		t.Fatalf("ClassifyError(CheckClusterAccess error) = %q, want timeout", got)
 	}
 }
 

--- a/internal/k8s/connection_state.go
+++ b/internal/k8s/connection_state.go
@@ -218,7 +218,13 @@ func ClassifyError(err error) string {
 	if strings.Contains(errLower, "unauthorized") ||
 		strings.Contains(errLower, "authentication required") ||
 		strings.Contains(errLower, "token has expired") ||
-		strings.Contains(errLower, "credentials") ||
+		strings.Contains(errLower, "expired token") ||
+		strings.Contains(errLower, "sso session") ||
+		strings.Contains(errLower, "sso token") ||
+		strings.Contains(errLower, "ssoproviderinvalidtoken") ||
+		strings.Contains(errLower, "aws sso login") ||
+		strings.Contains(errLower, "credential") ||
+		strings.Contains(errLower, "auth plugin timeout") ||
 		strings.Contains(errLower, "exec plugin") ||
 		strings.Contains(errLower, "gke-gcloud-auth-plugin") ||
 		strings.Contains(errLower, "unable to connect to the server") && strings.Contains(errLower, "oauth2") {
@@ -235,14 +241,17 @@ func ClassifyError(err error) string {
 		return "network"
 	}
 
-	// Timeout errors — but when an exec credential plugin is configured,
-	// timeouts almost always mean expired credentials (the plugin hangs
-	// trying to refresh), not actual network timeouts.
-	// Exception: "cluster unreachable" means the connectivity test ran
-	// (exec plugin didn't block), so the cluster itself is down/offline.
+	// Timeout errors — but when an exec credential plugin is configured, an
+	// unwrapped deadline exceeded often means the plugin hung while refreshing
+	// expired credentials. Keep transport timeouts in the timeout bucket so an
+	// offline or stalled cluster still points at connectivity instead of
+	// credentials.
 	if strings.Contains(errLower, "i/o timeout") ||
 		strings.Contains(errLower, "context deadline exceeded") ||
 		strings.Contains(errLower, "timeout") {
+		if strings.Contains(errLower, "i/o timeout") {
+			return "timeout"
+		}
 		if UsesExecAuth() && !strings.Contains(errLower, "cluster unreachable") {
 			return "auth"
 		}

--- a/internal/k8s/connection_state.go
+++ b/internal/k8s/connection_state.go
@@ -2,10 +2,15 @@ package k8s
 
 import (
 	"context"
+	"crypto/x509"
 	"errors"
+	"net"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // ConnectionState represents the current connection status to the cluster
@@ -23,7 +28,7 @@ type ConnectionStatus struct {
 	Context     string          `json:"context"`
 	ClusterName string          `json:"clusterName,omitempty"`
 	Error       string          `json:"error,omitempty"`
-	ErrorType   string          `json:"errorType,omitempty"` // auth, rbac, network, timeout, unknown
+	ErrorType   string          `json:"errorType,omitempty"` // config, auth, rbac, network, timeout, tls, unknown
 	ProgressMsg string          `json:"progressMessage,omitempty"`
 }
 
@@ -153,15 +158,18 @@ func isHelmKubernetesOperationError(lower string) bool {
 }
 
 func isTransportConnectivityError(lower string) bool {
+	return isTransportNetworkMessage(lower) || isTransportTimeoutMessage(lower)
+}
+
+func isTransportNetworkMessage(lower string) bool {
 	transportMarkers := []string{
 		"connection refused",
 		"no such host",
 		"dial tcp",
-		"i/o timeout",
-		"context deadline exceeded",
+		"dial udp",
 		"no route to host",
 		"connection reset by peer",
-		"tls handshake timeout",
+		"network is unreachable",
 	}
 	for _, marker := range transportMarkers {
 		if strings.Contains(lower, marker) {
@@ -169,6 +177,87 @@ func isTransportConnectivityError(lower string) bool {
 		}
 	}
 	return false
+}
+
+func isTransportTimeoutMessage(lower string) bool {
+	timeoutMarkers := []string{
+		"i/o timeout",
+		"context deadline exceeded",
+		"tls handshake timeout",
+		"timed out",
+		"timeout",
+	}
+	for _, marker := range timeoutMarkers {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func isAuthErrorMessage(lower string) bool {
+	authMarkers := []string{
+		"unauthorized",
+		"authentication required",
+		"token has expired",
+		"expired token",
+		"sso session",
+		"sso token",
+		"ssoproviderinvalidtoken",
+		"aws sso login",
+		"getting credentials",
+		"provide credentials",
+		"credentials expired",
+		"credential plugin",
+		"exec credential",
+		"exec plugin",
+		"gke-gcloud-auth-plugin",
+	}
+	for _, marker := range authMarkers {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return strings.Contains(lower, "unable to connect to the server") && strings.Contains(lower, "oauth2")
+}
+
+func isRBACErrorMessage(lower string) bool {
+	return strings.Contains(lower, " is forbidden") ||
+		strings.Contains(lower, "forbidden:") ||
+		strings.Contains(lower, "cannot list resource") ||
+		strings.Contains(lower, "cannot get resource")
+}
+
+func isConfigErrorMessage(lower string) bool {
+	configMarkers := []string{
+		"no context configured",
+		"no current context",
+		"current-context is not set",
+		"context was not found for specified context",
+		"no configuration has been provided",
+		"failed to build kubeconfig",
+		"no valid kubeconfig files found",
+		"no usable context found",
+		"no contexts found",
+		"k8s config not initialized",
+		"kubernetes client is not initialized",
+		"kubernetes discovery client is not initialized",
+	}
+	for _, marker := range configMarkers {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func isTLSCertificateMessage(lower string) bool {
+	return strings.Contains(lower, "x509:") ||
+		strings.Contains(lower, "certificate signed by unknown authority") ||
+		strings.Contains(lower, "certificate is valid for") ||
+		strings.Contains(lower, "cannot validate certificate") ||
+		strings.Contains(lower, "certificate has expired") ||
+		strings.Contains(lower, "certificate is not yet valid")
 }
 
 // UpdateConnectionProgress updates the progress message while connecting
@@ -197,68 +286,98 @@ func OnConnectionChange(callback ConnectionChangeCallback) {
 	connectionCallbacks = append(connectionCallbacks, callback)
 }
 
-// ClassifyError analyzes an error and returns its type (auth, rbac, network, timeout, unknown).
-// Uses the kubeconfig AuthInfo to improve classification — timeouts when an
-// exec credential plugin is configured are classified as "auth" since the
-// plugin hangs when tokens expire.
+// ClassifyError analyzes a cluster connection error and returns its type.
 func ClassifyError(err error) string {
 	if err == nil {
 		return ""
 	}
 
+	if apierrors.IsForbidden(err) {
+		return "rbac"
+	}
+	if apierrors.IsUnauthorized(err) {
+		return "auth"
+	}
+	if apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) || errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return "timeout"
+	}
+
 	errStr := err.Error()
 	errLower := strings.ToLower(errStr)
 
-	// RBAC errors (403 Forbidden - authenticated but insufficient permissions)
-	if strings.Contains(errLower, "forbidden") {
+	// RBAC/auth markers may be carried inside generic transport wrappers such as
+	// url.Error when client-go exec credential plugins fail before a request is sent.
+	if isConfigErrorMessage(errLower) {
+		return "config"
+	}
+	if isRBACErrorMessage(errLower) {
 		return "rbac"
 	}
-
-	// Authentication errors (401 Unauthorized - bad credentials)
-	if strings.Contains(errLower, "unauthorized") ||
-		strings.Contains(errLower, "authentication required") ||
-		strings.Contains(errLower, "token has expired") ||
-		strings.Contains(errLower, "expired token") ||
-		strings.Contains(errLower, "sso session") ||
-		strings.Contains(errLower, "sso token") ||
-		strings.Contains(errLower, "ssoproviderinvalidtoken") ||
-		strings.Contains(errLower, "aws sso login") ||
-		strings.Contains(errLower, "credential") ||
-		strings.Contains(errLower, "auth plugin timeout") ||
-		strings.Contains(errLower, "exec plugin") ||
-		strings.Contains(errLower, "gke-gcloud-auth-plugin") ||
-		strings.Contains(errLower, "unable to connect to the server") && strings.Contains(errLower, "oauth2") {
+	if isAuthErrorMessage(errLower) {
 		return "auth"
 	}
 
-	// Network errors
-	if strings.Contains(errLower, "connection refused") ||
-		strings.Contains(errLower, "no such host") ||
-		strings.Contains(errLower, "dial tcp") ||
-		strings.Contains(errLower, "tls handshake timeout") ||
-		strings.Contains(errLower, "network is unreachable") ||
-		strings.Contains(errLower, "no route to host") {
+	if isTLSCertificateError(err) || isTLSCertificateMessage(errLower) {
+		return "tls"
+	}
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return "network"
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return "network"
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
 		return "network"
 	}
 
-	// Timeout errors — but when an exec credential plugin is configured, an
-	// unwrapped deadline exceeded often means the plugin hung while refreshing
-	// expired credentials. Keep transport timeouts in the timeout bucket so an
-	// offline or stalled cluster still points at connectivity instead of
-	// credentials.
-	if strings.Contains(errLower, "i/o timeout") ||
-		strings.Contains(errLower, "context deadline exceeded") ||
-		strings.Contains(errLower, "timeout") {
-		if strings.Contains(errLower, "i/o timeout") {
-			return "timeout"
-		}
-		if UsesExecAuth() && !strings.Contains(errLower, "cluster unreachable") {
-			return "auth"
-		}
+	// Network errors
+	if isTransportNetworkMessage(errLower) {
+		return "network"
+	}
+
+	// Bare deadlines lack enough evidence to distinguish a hung exec plugin from
+	// an unreachable API endpoint, so keep them in the timeout bucket.
+	if isTransportTimeoutMessage(errLower) {
 		return "timeout"
 	}
 
 	return "unknown"
+}
+
+func isTLSCertificateError(err error) bool {
+	var unknownAuthority x509.UnknownAuthorityError
+	if errors.As(err, &unknownAuthority) {
+		return true
+	}
+	var unknownAuthorityPtr *x509.UnknownAuthorityError
+	if errors.As(err, &unknownAuthorityPtr) {
+		return true
+	}
+	var hostnameErr x509.HostnameError
+	if errors.As(err, &hostnameErr) {
+		return true
+	}
+	var hostnameErrPtr *x509.HostnameError
+	if errors.As(err, &hostnameErrPtr) {
+		return true
+	}
+	var certInvalid x509.CertificateInvalidError
+	if errors.As(err, &certInvalid) {
+		return true
+	}
+	var certInvalidPtr *x509.CertificateInvalidError
+	if errors.As(err, &certInvalidPtr) {
+		return true
+	}
+	return false
 }
 
 // IsConnected returns true if currently connected to a cluster

--- a/internal/k8s/connection_state_test.go
+++ b/internal/k8s/connection_state_test.go
@@ -124,3 +124,106 @@ func TestMarkDisconnectedIfClusterUnreachableIgnoresNonClusterNetworkErrors(t *t
 		t.Fatalf("state = %q, want %q", got.State, StateConnected)
 	}
 }
+
+func withContextExecAuth(t *testing.T, enabled bool) {
+	t.Helper()
+	clientMu.Lock()
+	prev := contextUsesExec
+	contextUsesExec = enabled
+	clientMu.Unlock()
+	t.Cleanup(func() {
+		clientMu.Lock()
+		contextUsesExec = prev
+		clientMu.Unlock()
+	})
+}
+
+func TestClassifyError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      string
+		execAuth bool
+		want     string
+	}{
+		{
+			name: "rbac forbidden",
+			err:  `deployments.apps is forbidden: User "alice" cannot list resource`,
+			want: "rbac",
+		},
+		{
+			name: "aws sso expired",
+			err:  "SSOProviderInvalidToken: the SSO session has expired or is invalid; run aws sso login",
+			want: "auth",
+		},
+		{
+			name: "client-go exec credential failure is auth",
+			err:  `failed to connect to cluster: Get "https://example.eks.amazonaws.com/version": getting credentials: exec: executable aws failed with exit code 255`,
+			want: "auth",
+		},
+		{
+			name: "plain context deadline is timeout without exec auth",
+			err:  "failed to connect to cluster: context deadline exceeded",
+			want: "timeout",
+		},
+		{
+			name: "cluster unreachable context deadline is timeout without exec auth",
+			err:  "failed to connect to cluster: cluster unreachable: context deadline exceeded",
+			want: "timeout",
+		},
+		{
+			name:     "exec auth context deadline is auth",
+			err:      "failed to connect to cluster: context deadline exceeded",
+			execAuth: true,
+			want:     "auth",
+		},
+		{
+			name:     "exec auth plugin timeout is auth",
+			err:      "failed to connect to cluster: auth plugin timeout: context deadline exceeded",
+			execAuth: true,
+			want:     "auth",
+		},
+		{
+			name:     "exec auth cluster unreachable context deadline stays timeout",
+			err:      "failed to connect to cluster: cluster unreachable: context deadline exceeded",
+			execAuth: true,
+			want:     "timeout",
+		},
+		{
+			name:     "exec auth cluster unreachable io timeout stays timeout",
+			err:      "failed to connect to cluster: cluster unreachable: i/o timeout",
+			execAuth: true,
+			want:     "timeout",
+		},
+		{
+			name:     "exec auth read io timeout stays timeout",
+			err:      "read tcp 10.0.0.1:443: i/o timeout",
+			execAuth: true,
+			want:     "timeout",
+		},
+		{
+			name:     "exec auth connection refused is network",
+			err:      "failed to connect to cluster: dial tcp 127.0.0.1:6443: connect: connection refused",
+			execAuth: true,
+			want:     "network",
+		},
+		{
+			name: "unknown",
+			err:  "something novel happened",
+			want: "unknown",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withContextExecAuth(t, tt.execAuth)
+			if got := ClassifyError(errors.New(tt.err)); got != tt.want {
+				t.Fatalf("ClassifyError(%q) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyErrorNil(t *testing.T) {
+	if got := ClassifyError(nil); got != "" {
+		t.Fatalf("ClassifyError(nil) = %q, want empty", got)
+	}
+}

--- a/internal/k8s/connection_state_test.go
+++ b/internal/k8s/connection_state_test.go
@@ -2,8 +2,15 @@ package k8s
 
 import (
 	"context"
+	"crypto/x509"
 	"errors"
+	"fmt"
+	"net"
+	"net/url"
 	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestMarkDisconnectedIfClusterUnreachable(t *testing.T) {
@@ -109,6 +116,36 @@ func TestMarkDisconnectedIfClusterUnreachableHandlesRawHelmTransportError(t *tes
 	if got.Error != message {
 		t.Fatalf("error = %q, want original message", got.Error)
 	}
+	if got.ErrorType != "network" {
+		t.Fatalf("errorType = %q, want network", got.ErrorType)
+	}
+}
+
+func TestMarkDisconnectedIfClusterUnreachablePreservesTimeoutClassification(t *testing.T) {
+	ResetTestState()
+	SetConnectionStatus(ConnectionStatus{
+		State:       StateConnected,
+		Context:     "kind-demo",
+		ClusterName: "demo",
+	})
+	previousProbe := clusterLivenessProbe
+	clusterLivenessProbe = func(context.Context) error { return errors.New("still unreachable") }
+	t.Cleanup(func() {
+		clusterLivenessProbe = previousProbe
+	})
+
+	message := `failed to list helm releases: Get "https://127.0.0.1:64287/api/v1/secrets": context deadline exceeded`
+	if !MarkDisconnectedIfClusterUnreachable(message) {
+		t.Fatal("MarkDisconnectedIfClusterUnreachable returned false for raw Helm timeout error")
+	}
+
+	got := GetConnectionStatus()
+	if got.State != StateDisconnected {
+		t.Fatalf("state = %q, want %q", got.State, StateDisconnected)
+	}
+	if got.ErrorType != "timeout" {
+		t.Fatalf("errorType = %q, want timeout", got.ErrorType)
+	}
 }
 
 func TestMarkDisconnectedIfClusterUnreachableIgnoresNonClusterNetworkErrors(t *testing.T) {
@@ -127,14 +164,9 @@ func TestMarkDisconnectedIfClusterUnreachableIgnoresNonClusterNetworkErrors(t *t
 
 func withContextExecAuth(t *testing.T, enabled bool) {
 	t.Helper()
-	clientMu.Lock()
-	prev := contextUsesExec
-	contextUsesExec = enabled
-	clientMu.Unlock()
+	prev := SetTestContextUsesExec(enabled)
 	t.Cleanup(func() {
-		clientMu.Lock()
-		contextUsesExec = prev
-		clientMu.Unlock()
+		SetTestContextUsesExec(prev)
 	})
 }
 
@@ -171,16 +203,16 @@ func TestClassifyError(t *testing.T) {
 			want: "timeout",
 		},
 		{
-			name:     "exec auth context deadline is auth",
+			name:     "exec auth context deadline stays timeout",
 			err:      "failed to connect to cluster: context deadline exceeded",
 			execAuth: true,
-			want:     "auth",
+			want:     "timeout",
 		},
 		{
-			name:     "exec auth plugin timeout is auth",
+			name:     "exec auth plugin timeout wrapper stays timeout",
 			err:      "failed to connect to cluster: auth plugin timeout: context deadline exceeded",
 			execAuth: true,
-			want:     "auth",
+			want:     "timeout",
 		},
 		{
 			name:     "exec auth cluster unreachable context deadline stays timeout",
@@ -201,10 +233,42 @@ func TestClassifyError(t *testing.T) {
 			want:     "timeout",
 		},
 		{
+			name:     "exec auth tls handshake timeout stays timeout",
+			err:      "net/http: TLS handshake timeout",
+			execAuth: true,
+			want:     "timeout",
+		},
+		{
 			name:     "exec auth connection refused is network",
 			err:      "failed to connect to cluster: dial tcp 127.0.0.1:6443: connect: connection refused",
 			execAuth: true,
 			want:     "network",
+		},
+		{
+			name:     "exec auth connection reset is network",
+			err:      "failed to connect to cluster: read tcp 10.0.0.1:443: connection reset by peer",
+			execAuth: true,
+			want:     "network",
+		},
+		{
+			name: "credentials word outside auth phrase is unknown",
+			err:  "loaded kubeconfig credentials-cache metadata",
+			want: "unknown",
+		},
+		{
+			name: "missing kubeconfig is config",
+			err:  "failed to build kubeconfig from /Users/alice/.kube/config: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable",
+			want: "config",
+		},
+		{
+			name: "no context configured is config",
+			err:  "no context configured",
+			want: "config",
+		},
+		{
+			name: "missing current context is config",
+			err:  `context was not found for specified context: prod`,
+			want: "config",
 		},
 		{
 			name: "unknown",
@@ -217,6 +281,98 @@ func TestClassifyError(t *testing.T) {
 			withContextExecAuth(t, tt.execAuth)
 			if got := ClassifyError(errors.New(tt.err)); got != tt.want {
 				t.Fatalf("ClassifyError(%q) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyErrorTypedErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "typed unauthorized is auth",
+			err:  apierrors.NewUnauthorized("token expired"),
+			want: "auth",
+		},
+		{
+			name: "typed forbidden is rbac",
+			err:  apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "", errors.New("denied")),
+			want: "rbac",
+		},
+		{
+			name: "typed server timeout is timeout",
+			err:  apierrors.NewServerTimeout(schema.GroupResource{Resource: "pods"}, "list", 1),
+			want: "timeout",
+		},
+		{
+			name: "typed request timeout is timeout",
+			err:  apierrors.NewTimeoutError("server slow", 1),
+			want: "timeout",
+		},
+		{
+			name: "context deadline is timeout",
+			err:  context.DeadlineExceeded,
+			want: "timeout",
+		},
+		{
+			name: "dns error is network",
+			err:  &url.Error{Op: "Get", URL: "https://cluster.example", Err: &net.DNSError{Err: "no such host", Name: "cluster.example"}},
+			want: "network",
+		},
+		{
+			name: "url-wrapped exec credential failure is auth",
+			err: fmt.Errorf("failed to connect to cluster: %w", &url.Error{
+				Op:  "Get",
+				URL: "https://example.eks.amazonaws.com/version",
+				Err: errors.New("getting credentials: exec: executable aws failed with exit code 255"),
+			}),
+			want: "auth",
+		},
+		{
+			name: "url-wrapped aws sso expiry is auth",
+			err: fmt.Errorf("failed to connect to cluster: %w", &url.Error{
+				Op:  "Get",
+				URL: "https://example.eks.amazonaws.com/version",
+				Err: errors.New("SSOProviderInvalidToken: the SSO session has expired or is invalid; run aws sso login"),
+			}),
+			want: "auth",
+		},
+		{
+			name: "wrapped auth plugin deadline stays timeout",
+			err:  fmt.Errorf("auth plugin timeout: %w", context.DeadlineExceeded),
+			want: "timeout",
+		},
+		{
+			name: "tls unknown authority is tls",
+			err: &url.Error{
+				Op:  "Get",
+				URL: "https://cluster.example/version",
+				Err: x509.UnknownAuthorityError{Cert: &x509.Certificate{}},
+			},
+			want: "tls",
+		},
+		{
+			name: "pointer tls unknown authority is tls",
+			err: &url.Error{
+				Op:  "Get",
+				URL: "https://cluster.example/version",
+				Err: &x509.UnknownAuthorityError{Cert: &x509.Certificate{}},
+			},
+			want: "tls",
+		},
+		{
+			name: "stringified x509 cluster unreachable is tls",
+			err:  errors.New(`Kubernetes cluster unreachable: Get "https://cluster.example/version": tls: failed to verify certificate: x509: certificate signed by unknown authority`),
+			want: "tls",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ClassifyError(tt.err); got != tt.want {
+				t.Fatalf("ClassifyError(%v) = %q, want %q", tt.err, got, tt.want)
 			}
 		})
 	}

--- a/internal/k8s/context_manager.go
+++ b/internal/k8s/context_manager.go
@@ -18,9 +18,11 @@ import (
 // so operators can override it via flag/env without recompiling. The default
 // value (30 * time.Second) is preserved for backwards compatibility.
 
-// ConnectionTestTimeout is the maximum time allowed for initial connection test
-// This is a short timeout for quick fail detection
+// ConnectionTestTimeout is the maximum time allowed for non-exec-auth
+// connection tests. This is a short timeout for quick fail detection.
 const ConnectionTestTimeout = 5 * time.Second
+const execAuthConnectionProbeHTTPTimeout = 10 * time.Second
+const connectionProbeTimeoutHeadroom = time.Second
 
 // ContextSwitchCallback is called when the context is switched
 type ContextSwitchCallback func(newContext string)
@@ -245,7 +247,7 @@ func TestClusterConnection(ctx context.Context) error {
 	// Create a copy of the config with a short timeout
 	// rest.CopyConfig properly copies all fields including TLS settings
 	testConfig := rest.CopyConfig(config)
-	testConfig.Timeout = ConnectionTestTimeout
+	testConfig.Timeout = connectionProbeHTTPTimeout(ctx)
 
 	// Create a temporary client with the short-timeout config
 	testClient, err := kubernetes.NewForConfig(testConfig)
@@ -269,8 +271,34 @@ func TestClusterConnection(ctx context.Context) error {
 		}
 		return nil
 	case <-ctx.Done():
-		return fmt.Errorf("cluster unreachable: %w", ctx.Err())
+		if !UsesExecAuth() {
+			return fmt.Errorf("cluster unreachable: %w", ctx.Err())
+		}
+		return fmt.Errorf("auth plugin timeout: %w", ctx.Err())
 	}
+}
+
+func connectionTestOperationTimeout() time.Duration {
+	if UsesExecAuth() {
+		return execAuthConnectionProbeHTTPTimeout + connectionProbeTimeoutHeadroom
+	}
+	return ConnectionTestTimeout
+}
+
+func connectionProbeHTTPTimeout(ctx context.Context) time.Duration {
+	timeout := ConnectionTestTimeout
+	if deadline, ok := ctx.Deadline(); ok {
+		remaining := time.Until(deadline)
+		if remaining > connectionProbeTimeoutHeadroom {
+			timeout = remaining - connectionProbeTimeoutHeadroom
+		} else if remaining > 0 {
+			timeout = remaining
+		}
+	}
+	if timeout <= 0 {
+		return ConnectionTestTimeout
+	}
+	return timeout
 }
 
 // PerformContextSwitch orchestrates a full context switch:
@@ -347,7 +375,7 @@ func PerformContextSwitch(newContext string) error {
 	reportProgress("Testing cluster connectivity...")
 	t = time.Now()
 	log.Println("Testing cluster connectivity...")
-	connCtx, connCancel := NewOperationContext(ConnectionTestTimeout)
+	connCtx, connCancel := NewOperationContext(connectionTestOperationTimeout())
 	defer connCancel()
 	if err := TestClusterConnection(connCtx); err != nil {
 		elapsed := time.Since(switchStart).Truncate(time.Millisecond)
@@ -422,7 +450,7 @@ func PerformNamespaceRescope(namespace string) error {
 	myGen := currentOperationGen()
 	reportProgress("Testing cluster connectivity...")
 	t := time.Now()
-	connCtx, connCancel := NewOperationContext(ConnectionTestTimeout)
+	connCtx, connCancel := NewOperationContext(connectionTestOperationTimeout())
 	defer connCancel()
 	if err := TestClusterConnection(connCtx); err != nil {
 		elapsed := time.Since(rescopeStart).Truncate(time.Millisecond)

--- a/internal/k8s/context_manager_test.go
+++ b/internal/k8s/context_manager_test.go
@@ -1,0 +1,43 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestConnectionProbeHTTPTimeout(t *testing.T) {
+	if got := connectionProbeHTTPTimeout(context.Background()); got != ConnectionTestTimeout {
+		t.Fatalf("connectionProbeHTTPTimeout(no deadline) = %v, want %v", got, ConnectionTestTimeout)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), ConnectionTestTimeout)
+	defer cancel()
+	got := connectionProbeHTTPTimeout(ctx)
+	if got <= 0 || got >= ConnectionTestTimeout {
+		t.Fatalf("connectionProbeHTTPTimeout(standard deadline) = %v, want positive timeout shorter than %v", got, ConnectionTestTimeout)
+	}
+	if got < ConnectionTestTimeout-2*connectionProbeTimeoutHeadroom {
+		t.Fatalf("connectionProbeHTTPTimeout(standard deadline) = %v, want close to deadline with headroom", got)
+	}
+
+	shortCtx, shortCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer shortCancel()
+	got = connectionProbeHTTPTimeout(shortCtx)
+	if got <= 0 || got > connectionProbeTimeoutHeadroom {
+		t.Fatalf("connectionProbeHTTPTimeout(short deadline) = %v, want the remaining short deadline", got)
+	}
+}
+
+func TestConnectionTestOperationTimeoutUsesLongerExecAuthBudget(t *testing.T) {
+	withContextExecAuth(t, false)
+	if got := connectionTestOperationTimeout(); got != ConnectionTestTimeout {
+		t.Fatalf("connectionTestOperationTimeout(no exec auth) = %v, want %v", got, ConnectionTestTimeout)
+	}
+
+	withContextExecAuth(t, true)
+	want := execAuthConnectionProbeHTTPTimeout + connectionProbeTimeoutHeadroom
+	if got := connectionTestOperationTimeout(); got != want {
+		t.Fatalf("connectionTestOperationTimeout(exec auth) = %v, want %v", got, want)
+	}
+}

--- a/internal/k8s/testing.go
+++ b/internal/k8s/testing.go
@@ -134,6 +134,16 @@ func SetTestContextName(name string) string {
 	return prev
 }
 
+// SetTestContextUsesExec overrides whether the current context uses exec auth
+// and returns the previous value so callers can restore it on cleanup.
+func SetTestContextUsesExec(enabled bool) bool {
+	clientMu.Lock()
+	prev := contextUsesExec
+	contextUsesExec = enabled
+	clientMu.Unlock()
+	return prev
+}
+
 // SetTestClient overrides the package-level client and returns the previous
 // value so tests in other packages can restore it.
 func SetTestClient(c *kubernetes.Clientset) *kubernetes.Clientset {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3553,14 +3553,18 @@ func (s *Server) handleConnectionRetry(w http.ResponseWriter, r *http.Request) {
 			s.writeError(w, http.StatusBadRequest, err.Error())
 			return
 		}
-		// Set disconnected state with error
+		errorType := k8s.ClassifyError(err)
 		k8s.SetConnectionStatus(k8s.ConnectionStatus{
 			State:     k8s.StateDisconnected,
 			Context:   ctx,
 			Error:     err.Error(),
-			ErrorType: k8s.ClassifyError(err),
+			ErrorType: errorType,
 		})
-		s.writeError(w, http.StatusServiceUnavailable, err.Error())
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		if encodeErr := json.NewEncoder(w).Encode(map[string]string{"error": err.Error(), "errorType": errorType}); encodeErr != nil {
+			log.Printf("Failed to encode connection retry error response: %v", encodeErr)
+		}
 		return
 	}
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -53,7 +53,7 @@ import { useAnimatedUnmount } from './hooks/useAnimatedUnmount'
 import { useDocumentTitle } from './hooks/useDocumentTitle'
 import type { ClusterLoadState } from './types/clusterLoadState'
 import { useClusterLoadState } from './hooks/useClusterLoadState'
-import { Network, List, Clock, Package, Sun, Moon, Activity, Home, Star, Search, Bug, SquareTerminal, ShieldCheck, GitBranch, HelpCircle, Loader2 } from 'lucide-react'
+import { Network, List, Clock, Package, Sun, Moon, Activity, Home, Star, Search, Bug, SquareTerminal, ShieldCheck, GitBranch, HelpCircle, Loader2, RefreshCw } from 'lucide-react'
 import { useTheme } from './context/ThemeContext'
 import { Tooltip } from './components/ui/Tooltip'
 import { LargeClusterNamespacePicker } from './components/shared/LargeClusterNamespacePicker'
@@ -995,7 +995,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
   // forceNamespaceFilter is only set for large clusters that require server-side filtering.
   // Fleet mode uses 'resources' topology on the backend — filtering is client-side
   const sseMode = topologyMode === 'fleet' ? 'resources' : topologyMode
-  const { topology } = useEventSource(namespaces, sseMode as 'resources' | 'traffic', {
+  const { topology, connected: eventStreamConnected, connecting: eventStreamConnecting, reconnect: reconnectEventStream } = useEventSource(namespaces, sseMode as 'resources' | 'traffic', {
     onContextSwitchComplete: endSwitch,
     onContextSwitchProgress: updateProgress,
     onContextChanged: () => {
@@ -1032,8 +1032,6 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
     },
     onK8sEvent: handleK8sEvent,
   }, forceNamespaceFilter, showPolicyEffect)
-  const clusterConnected = connection.state === 'connected'
-
   // On large clusters (where the server requires namespace filtering), keep
   // SSE's server-side filter in lockstep with the user's namespace pick.
   // Without this, header switches and deep-link loads can leave SSE filtered
@@ -1078,6 +1076,28 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
   // Track CRD discovery status from topology (more direct than cluster-info)
   // When discovery completes, topology will auto-update via SSE with new CRD nodes
   const crdDiscoveryStatus = topology?.crdDiscoveryStatus
+  const clusterConnectionState = connection.state
+  const clusterConnected = clusterConnectionState === 'connected'
+  const liveUpdatesDisconnected = clusterConnected && !eventStreamConnected && !eventStreamConnecting
+  const headerConnectionLabel =
+    clusterConnectionState === 'disconnected' ? 'Disconnected' :
+    clusterConnectionState === 'connecting' ? 'Connecting' :
+    liveUpdatesDisconnected ? 'Live updates disconnected' :
+    clusterLoadState.loading ? `Connected — ${clusterLoadState.message}` :
+    crdDiscoveryStatus === 'discovering' ? 'Connected — discovering Custom Resources...' :
+    'Connected'
+  const headerConnectionDisplayLabel =
+    clusterConnectionState === 'disconnected' ? 'Disconnected' :
+    clusterConnectionState === 'connecting' ? 'Connecting' :
+    liveUpdatesDisconnected ? 'Live updates disconnected' :
+    showClusterWarmupLabel ? clusterLoadState.message :
+    crdDiscoveryStatus === 'discovering' ? 'Discovering Custom Resources…' :
+    ''
+  const showHeaderReconnect =
+    clusterConnectionState === 'disconnected' ||
+    liveUpdatesDisconnected
+  const headerReconnect = clusterConnectionState === 'disconnected' ? retryConnection : reconnectEventStream
+  const headerReconnectPending = clusterConnectionState === 'disconnected' ? isRetrying : false
 
   // Debug: log discovery status changes
   useEffect(() => {
@@ -1578,58 +1598,49 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
                 />
               </ScopePill>
             )}
-            {/* Connection status — a fixed-size dot (state in the tooltip; the
-                dot is the reconnect control when disconnected) plus, when the
-                header is wide enough (xl+), a label. The label is nowrap and
-                unbounded: it overflows the fixed left column into the empty gap
-                before the centered search box rather than shifting anything (the
-                dot + pill are shrink-0, so layout stays put — the search box
-                never moves). Where the gap is smaller than the label, its tail
-                tucks under the omnibar's solid background. Below xl it's the dot
-                alone. */}
+            {/* Connection status — a fixed-size dot (state in the tooltip), an
+                optional reconnect button, and when the header is wide enough
+                (xl+), a label. The label is nowrap and unbounded: it overflows
+                the fixed left column into the empty gap before the centered
+                search box rather than shifting anything (the dot + pill are
+                shrink-0, so layout stays put — the search box never moves).
+                Where the gap is smaller than the label, its tail tucks under
+                the omnibar's solid background. Below xl it's the dot alone
+                unless reconnect is available. */}
             <div className="ml-1 flex items-center gap-1.5 shrink-0">
               <Tooltip
-                content={
-                  !clusterConnected
-                    ? 'Cluster disconnected — click to reconnect'
-                    : clusterLoadState.loading
-                      ? `Connected — ${clusterLoadState.message}`
-                    : crdDiscoveryStatus === 'discovering'
-                      ? 'Connected — discovering Custom Resources...'
-                      : 'Connected'
-                }
+                content={headerConnectionLabel}
                 delay={100}
                 position="bottom"
               >
-                {clusterConnected ? (
-                  <span
-                    className={`block w-2.5 h-2.5 shrink-0 rounded-full ${
-                      crdDiscoveryStatus === 'discovering' || clusterLoadState.loading
+                <span
+                  className={`block w-2.5 h-2.5 shrink-0 rounded-full ${
+                    clusterConnectionState === 'disconnected' || liveUpdatesDisconnected
+                      ? 'bg-red-500'
+                      : clusterConnectionState === 'connecting' || crdDiscoveryStatus === 'discovering' || clusterLoadState.loading
                         ? 'bg-amber-400 animate-pulse'
                         : 'bg-green-500'
-                    }`}
-                  />
-                ) : (
-                  <button
-                    type="button"
-                    onClick={retryConnection}
-                    disabled={isRetrying}
-                    aria-label="Cluster disconnected — reconnect"
-                    className="block shrink-0 disabled:cursor-default"
-                  >
-                    <span className={`block w-2.5 h-2.5 rounded-full bg-red-500 ${isRetrying ? 'animate-pulse' : ''}`} />
-                  </button>
-                )}
+                  }`}
+                />
               </Tooltip>
-              {(showClusterWarmupLabel || (showNavRail && (!clusterConnected || crdDiscoveryStatus === 'discovering'))) && (
+              {showNavRail && headerConnectionDisplayLabel && (
                 <span className="hidden xl:flex items-center gap-1.5 whitespace-nowrap text-[11px] text-theme-text-tertiary">
                   {showClusterWarmupLabel && <Loader2 className="w-3 h-3 animate-spin" />}
-                  {!clusterConnected
-                    ? 'Disconnected'
-                    : showClusterWarmupLabel
-                      ? clusterLoadState.message
-                      : 'Discovering Custom Resources…'}
+                  {headerConnectionDisplayLabel}
                 </span>
+              )}
+              {showHeaderReconnect && (
+                <Tooltip content="Reconnect" delay={100} position="bottom">
+                  <button
+                    type="button"
+                    onClick={headerReconnect}
+                    disabled={headerReconnectPending}
+                    aria-label={clusterConnectionState === 'disconnected' ? 'Reconnect cluster' : 'Reconnect live updates'}
+                    className="p-1 text-theme-text-secondary hover:text-theme-text-primary disabled:opacity-50 disabled:pointer-events-none"
+                  >
+                    <RefreshCw className={`w-3 h-3 ${headerReconnectPending ? 'animate-spin' : ''}`} />
+                  </button>
+                </Tooltip>
               )}
             </div>
             {/* Port forwards indicator — shown only when sessions exist */}

--- a/web/src/components/ConnectionErrorView.tsx
+++ b/web/src/components/ConnectionErrorView.tsx
@@ -29,8 +29,8 @@ function getAuthHints(context: string): AuthHints {
     case 'GKE': {
       const result: AuthHints = {
         title: 'GKE Authentication Failed',
-        hints: ['Your Google Cloud credentials have expired.'],
-        authCommand: { label: 'Re-authenticate with Google Cloud:', command: 'gcloud auth login' },
+        hints: ['Radar could not get Google Cloud credentials for this context.'],
+        authCommand: { label: 'Refresh Google Cloud credentials:', command: 'gcloud auth login' },
       }
       if (parsed.region && parsed.account) {
         const isZone = /^[a-z]+-[a-z]+\d+-[a-z]$/.test(parsed.region)
@@ -45,8 +45,11 @@ function getAuthHints(context: string): AuthHints {
     case 'EKS': {
       const result: AuthHints = {
         title: 'EKS Authentication Failed',
-        hints: ['Your AWS credentials have expired.'],
-        authCommand: { label: 'Re-authenticate with AWS:', command: 'aws sso login' },
+        hints: [
+          'Radar could not get AWS credentials for this context.',
+          'For AWS SSO contexts, the SSO session may need login.',
+        ],
+        authCommand: { label: 'If this context uses AWS SSO, refresh credentials:', command: 'aws sso login' },
       }
       if (parsed.region) {
         result.fallbackCommand = {
@@ -59,15 +62,15 @@ function getAuthHints(context: string): AuthHints {
     case 'AKS':
       return {
         title: 'AKS Authentication Failed',
-        hints: ['Your Azure credentials have expired.'],
-        authCommand: { label: 'Re-authenticate with Azure:', command: 'az login' },
+        hints: ['Radar could not get Azure credentials for this context.'],
+        authCommand: { label: 'Refresh Azure credentials:', command: 'az login' },
         fallbackCommand: { label: 'If that doesn\'t work, refresh cluster credentials:', command: 'az aks get-credentials --name <cluster> --resource-group <rg>' },
       }
     default:
       return {
         title: 'Authentication Failed',
         hints: [
-          'Your credentials may have expired',
+          'Radar could not get Kubernetes credentials for this context',
           'Re-authenticate with your cloud provider and try again',
         ],
       }
@@ -281,6 +284,12 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
 
             {connection.errorType !== 'config' && <ContextSwitcher />}
           </div>
+
+          {isAuth && (
+            <p className="mt-4 text-xs text-theme-text-tertiary">
+              Radar will keep retrying after credentials are refreshed.
+            </p>
+          )}
         </div>
       </div>
     </div>

--- a/web/src/components/ConnectionErrorView.tsx
+++ b/web/src/components/ConnectionErrorView.tsx
@@ -240,6 +240,7 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
   const errorInfo = commandInfo || errorHints[connection.errorType || 'unknown'] || errorHints.unknown
   const openLocalTerminal = useOpenLocalTerminal()
   const { data: authMe } = useAuthMe()
+  const showRawErrorOpen = !connection.errorType || connection.errorType === 'unknown'
 
   // Auto-retry after successful auth. The terminal shell runs on the server
   // host, so the auth command itself fixes the server's credentials in every
@@ -320,15 +321,19 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
                 <CopyableCommand command={commandInfo.fallbackCommand.command} onRunInTerminal={handleRunInTerminal} />
               </div>
             )}
+            {connection.error && (
+              <details open={showRawErrorOpen} className="mt-4 pt-3 border-t border-theme-border/50">
+                <summary className="cursor-pointer select-none text-xs font-medium text-theme-text-tertiary hover:text-theme-text-secondary">
+                  Raw error
+                </summary>
+                <div className="mt-2 bg-theme-elevated border border-theme-border rounded-md p-3 overflow-auto max-h-32">
+                  <code className="text-xs text-theme-text-tertiary font-mono whitespace-pre-wrap break-words">
+                    {connection.error}
+                  </code>
+                </div>
+              </details>
+            )}
           </div>
-
-          {connection.error && (
-            <div className="w-full bg-theme-elevated border border-theme-border rounded-lg p-3 mb-6 overflow-auto max-h-32">
-              <code className="text-xs text-red-400 font-mono whitespace-pre-wrap break-words">
-                {connection.error}
-              </code>
-            </div>
-          )}
 
           <div className="flex items-center gap-5">
             <button
@@ -349,7 +354,7 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
               )}
             </button>
 
-            {connection.errorType !== 'config' && <ContextSwitcher />}
+            {connection.errorType !== 'config' && <ContextSwitcher triggerName="Switch context" />}
           </div>
 
           {isAuth && (

--- a/web/src/components/ConnectionErrorView.tsx
+++ b/web/src/components/ConnectionErrorView.tsx
@@ -1,5 +1,5 @@
-import { XCircle, RefreshCw, Loader2, Copy, Check, TerminalSquare } from 'lucide-react'
-import { useState } from 'react'
+import { ServerOff, RefreshCw, Loader2, Copy, Check, TerminalSquare, ChevronRight } from 'lucide-react'
+import { useEffect, useState } from 'react'
 import type { ConnectionState } from '../context/ConnectionContext'
 import { ContextSwitcher } from './ContextSwitcher'
 import { parseContextName } from '../utils/context-name'
@@ -183,6 +183,7 @@ const errorHints: Record<string, { title: string; hints: string[] }> = {
 
 function CopyableCommand({ command, onRunInTerminal }: { command: string; onRunInTerminal?: (command: string) => void }) {
   const [copied, setCopied] = useState(false)
+  const commandParts = command.split(/(\s+)/)
 
   const handleCopy = () => {
     navigator.clipboard.writeText(command).then(() => {
@@ -195,8 +196,10 @@ function CopyableCommand({ command, onRunInTerminal }: { command: string; onRunI
 
   return (
     <div className="mt-2 flex items-center gap-2 bg-theme-elevated border border-theme-border rounded-md px-3 py-2 group">
-      <code className="text-xs font-mono text-theme-text-primary flex-1 select-all break-all">
-        {command}
+      <code className="text-xs font-mono text-theme-text-primary flex-1 min-w-0 select-all whitespace-pre-wrap break-normal">
+        {commandParts.map((part, index) => (
+          /\s+/.test(part) ? part : <span key={index} className="inline-block whitespace-nowrap">{part}</span>
+        ))}
       </code>
       {onRunInTerminal && (
         <Tooltip content="Run in terminal" wrapperClassName="shrink-0">
@@ -240,7 +243,12 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
   const errorInfo = commandInfo || errorHints[connection.errorType || 'unknown'] || errorHints.unknown
   const openLocalTerminal = useOpenLocalTerminal()
   const { data: authMe } = useAuthMe()
-  const showRawErrorOpen = !connection.errorType || connection.errorType === 'unknown'
+  const rawErrorDefaultOpen = !connection.errorType || connection.errorType === 'unknown'
+  const [showRawError, setShowRawError] = useState(rawErrorDefaultOpen)
+
+  useEffect(() => {
+    setShowRawError(rawErrorDefaultOpen)
+  }, [connection.error, rawErrorDefaultOpen])
 
   // Auto-retry after successful auth. The terminal shell runs on the server
   // host, so the auth command itself fixes the server's credentials in every
@@ -265,32 +273,34 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
   }
 
   return (
-    <div className="flex-1 flex items-start justify-center pt-16 px-8">
-      <div className="max-w-lg w-full">
+    <div className="flex-1 flex items-start justify-center pt-12 px-8">
+      <div className="max-w-xl w-full">
         <div className="flex flex-col items-center text-center">
-          <div className="w-16 h-16 rounded-full bg-red-500/10 flex items-center justify-center mb-6">
-            <XCircle className="w-10 h-10 text-red-400" />
+          <div className="w-14 h-14 rounded-full bg-red-500/10 flex items-center justify-center mb-5">
+            <ServerOff className="w-8 h-8 text-red-400" />
           </div>
 
           <h2 className="text-xl font-semibold text-theme-text-primary mb-2">
             {connection.errorType === 'config' ? 'No Cluster Configuration' : 'Cannot Connect to Cluster'}
           </h2>
 
-          <p className="text-sm text-theme-text-secondary mb-1 inline-flex items-center gap-1.5">
-            Context: {connection.context ? (
-              <ClusterName name={connection.context} />
-            ) : (
-              <span className="inline-code">(none)</span>
-            )}
-          </p>
-
-          {connection.clusterName && (
-            <p className="text-sm text-theme-text-secondary mb-4">
-              Cluster: <span className="inline-code">{connection.clusterName}</span>
+          <div className="mb-6 space-y-1">
+            <p className="text-sm text-theme-text-secondary inline-flex items-center gap-1.5">
+              Context: {connection.context ? (
+                <ClusterName name={connection.context} />
+              ) : (
+                <span className="inline-code">(none)</span>
+              )}
             </p>
-          )}
 
-          <div className="w-full bg-theme-surface border border-theme-border rounded-lg p-4 mb-6 text-left">
+            {connection.clusterName && (
+              <p className="text-sm text-theme-text-secondary">
+                Cluster: <span className="inline-code">{connection.clusterName}</span>
+              </p>
+            )}
+          </div>
+
+          <div className="w-full bg-theme-surface border border-theme-border rounded-lg p-4 mb-5 text-left">
             <h3 className="text-sm font-medium text-theme-text-primary mb-2">
               {errorInfo.title}
             </h3>
@@ -306,13 +316,15 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
               <div className="mt-3">
                 <p className="text-xs text-theme-text-tertiary">{commandInfo.authCommand.label}</p>
                 <CopyableCommand command={commandInfo.authCommand.command} onRunInTerminal={handleRunInTerminal} />
-                <button
-                  onClick={handleAuthInTerminal}
-                  className="mt-3 w-full inline-flex items-center justify-center gap-2 px-3 py-2 text-xs font-medium btn-brand rounded-md"
-                >
-                  <TerminalSquare className="w-3.5 h-3.5" />
-                  {isAuth ? 'Authenticate in terminal' : 'Run in terminal'}
-                </button>
+                {isAuth && (
+                  <button
+                    onClick={handleAuthInTerminal}
+                    className="mt-3 w-full inline-flex items-center justify-center gap-2 px-3 py-2 text-xs font-medium btn-brand rounded-md"
+                  >
+                    <TerminalSquare className="w-3.5 h-3.5" />
+                    Authenticate in terminal
+                  </button>
+                )}
               </div>
             )}
             {commandInfo?.fallbackCommand && (
@@ -322,16 +334,27 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
               </div>
             )}
             {connection.error && (
-              <details open={showRawErrorOpen} className="mt-4 pt-3 border-t border-theme-border/50">
-                <summary className="cursor-pointer select-none text-xs font-medium text-theme-text-tertiary hover:text-theme-text-secondary">
+              <div className="mt-4 pt-3 border-t border-theme-border/50">
+                <button
+                  type="button"
+                  aria-expanded={showRawError}
+                  aria-controls="connection-raw-error"
+                  onClick={() => setShowRawError((open) => !open)}
+                  className="flex items-center gap-1 text-xs font-medium text-theme-text-tertiary hover:text-theme-text-secondary transition-colors"
+                >
+                  <ChevronRight className={`h-3.5 w-3.5 transition-transform duration-200 ${showRawError ? 'rotate-90' : ''}`} />
                   Raw error
-                </summary>
-                <div className="mt-2 bg-theme-elevated border border-theme-border rounded-md p-3 overflow-auto max-h-32">
-                  <code className="text-xs text-theme-text-tertiary font-mono whitespace-pre-wrap break-words">
-                    {connection.error}
-                  </code>
+                </button>
+                <div className={`issue-details-motion ${showRawError ? 'issue-details-motion-open' : ''}`}>
+                  <div className="overflow-hidden">
+                    <div id="connection-raw-error" className="mt-2 bg-theme-elevated border border-theme-border rounded-md p-3 overflow-auto max-h-32">
+                      <code className="text-xs text-theme-text-tertiary font-mono whitespace-pre-wrap break-words">
+                        {connection.error}
+                      </code>
+                    </div>
+                  </div>
                 </div>
-              </details>
+              </div>
             )}
           </div>
 

--- a/web/src/components/ConnectionErrorView.tsx
+++ b/web/src/components/ConnectionErrorView.tsx
@@ -77,6 +77,56 @@ function getAuthHints(context: string): AuthHints {
   }
 }
 
+function getTimeoutHints(context: string): AuthHints | null {
+  const parsed = parseContextName(context)
+  const baseHints = [
+    'The Kubernetes API did not respond before the deadline.',
+    'Check VPN, firewall rules, and whether the cluster endpoint is reachable.',
+  ]
+
+  switch (parsed.provider) {
+    case 'GKE': {
+      const result: AuthHints = {
+        title: 'Connection Timed Out',
+        hints: [...baseHints, 'If the endpoint is reachable, Google Cloud credentials may need refresh.'],
+        authCommand: { label: 'If network access looks healthy, refresh Google Cloud credentials:', command: 'gcloud auth login' },
+      }
+      if (parsed.region && parsed.account) {
+        const isZone = /^[a-z]+-[a-z]+\d+-[a-z]$/.test(parsed.region)
+        const flag = isZone ? '--zone' : '--region'
+        result.fallbackCommand = {
+          label: 'If that does not work, refresh cluster credentials:',
+          command: `gcloud container clusters get-credentials ${parsed.clusterName} ${flag} ${parsed.region} --project ${parsed.account}`,
+        }
+      }
+      return result
+    }
+    case 'EKS': {
+      const result: AuthHints = {
+        title: 'Connection Timed Out',
+        hints: [...baseHints, 'If the endpoint is reachable, AWS credentials or SSO may need refresh.'],
+        authCommand: { label: 'If this context uses AWS SSO and network access looks healthy, refresh credentials:', command: 'aws sso login' },
+      }
+      if (parsed.region) {
+        result.fallbackCommand = {
+          label: 'If that does not work, refresh cluster credentials:',
+          command: `aws eks update-kubeconfig --name ${parsed.clusterName} --region ${parsed.region}`,
+        }
+      }
+      return result
+    }
+    case 'AKS':
+      return {
+        title: 'Connection Timed Out',
+        hints: [...baseHints, 'If the endpoint is reachable, Azure credentials may need refresh.'],
+        authCommand: { label: 'If network access looks healthy, refresh Azure credentials:', command: 'az login' },
+        fallbackCommand: { label: 'If that does not work, refresh cluster credentials:', command: 'az aks get-credentials --name <cluster> --resource-group <rg>' },
+      }
+    default:
+      return null
+  }
+}
+
 const errorHints: Record<string, { title: string; hints: string[] }> = {
   config: {
     title: 'No Kubeconfig Found',
@@ -102,6 +152,14 @@ const errorHints: Record<string, { title: string; hints: string[] }> = {
       'Check if VPN connection is required',
       'Verify firewall rules allow access',
       'Confirm the cluster is running',
+    ],
+  },
+  tls: {
+    title: 'Certificate Error',
+    hints: [
+      'Radar reached the Kubernetes API, but could not verify its TLS certificate',
+      'Check the kubeconfig cluster server hostname and certificate-authority settings',
+      'If this cluster intentionally uses a private CA, refresh the kubeconfig for this context',
     ],
   },
   timeout: {
@@ -142,25 +200,29 @@ function CopyableCommand({ command, onRunInTerminal }: { command: string; onRunI
       </code>
       {onRunInTerminal && (
         <Tooltip content="Run in terminal" wrapperClassName="shrink-0">
-        <button
-          onClick={() => onRunInTerminal(command)}
-          className="shrink-0 text-theme-text-tertiary hover:text-theme-text-secondary transition-colors"
-        >
-          <TerminalSquare className="w-3.5 h-3.5" />
-        </button>
+          <button
+            type="button"
+            onClick={() => onRunInTerminal(command)}
+            aria-label="Run command in terminal"
+            className="shrink-0 text-theme-text-tertiary hover:text-theme-text-secondary transition-colors"
+          >
+            <TerminalSquare className="w-3.5 h-3.5" />
+          </button>
         </Tooltip>
       )}
       <Tooltip content="Copy to clipboard" wrapperClassName="shrink-0">
-      <button
-        onClick={handleCopy}
-        className="shrink-0 text-theme-text-tertiary hover:text-theme-text-secondary transition-colors"
-      >
-        {copied ? (
-          <Check className="w-3.5 h-3.5 text-green-400" />
-        ) : (
-          <Copy className="w-3.5 h-3.5" />
-        )}
-      </button>
+        <button
+          type="button"
+          onClick={handleCopy}
+          aria-label="Copy command to clipboard"
+          className="shrink-0 text-theme-text-tertiary hover:text-theme-text-secondary transition-colors"
+        >
+          {copied ? (
+            <Check className="w-3.5 h-3.5 text-green-400" />
+          ) : (
+            <Copy className="w-3.5 h-3.5" />
+          )}
+        </button>
       </Tooltip>
     </div>
   )
@@ -169,8 +231,13 @@ function CopyableCommand({ command, onRunInTerminal }: { command: string; onRunI
 export function ConnectionErrorView({ connection, onRetry, isRetrying }: ConnectionErrorViewProps) {
   // For auth errors, generate context-aware hints with a specific re-auth command
   const isAuth = connection.errorType === 'auth'
-  const authInfo = isAuth ? getAuthHints(connection.context || '') : null
-  const errorInfo = authInfo || errorHints[connection.errorType || 'unknown'] || errorHints.unknown
+  const isTimeout = connection.errorType === 'timeout'
+  const commandInfo = isAuth
+    ? getAuthHints(connection.context || '')
+    : isTimeout
+      ? getTimeoutHints(connection.context || '')
+      : null
+  const errorInfo = commandInfo || errorHints[connection.errorType || 'unknown'] || errorHints.unknown
   const openLocalTerminal = useOpenLocalTerminal()
   const { data: authMe } = useAuthMe()
 
@@ -182,10 +249,10 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
   const retryCmd = `curl -s -X POST http://${window.location.host}/api/connection/retry > /dev/null`
 
   const handleAuthInTerminal = () => {
-    if (!authInfo?.authCommand) return
+    if (!commandInfo?.authCommand) return
     const cmd = authMe?.authEnabled === false
-      ? `${authInfo.authCommand.command} && ${retryCmd}`
-      : authInfo.authCommand.command
+      ? `${commandInfo.authCommand.command} && ${retryCmd}`
+      : commandInfo.authCommand.command
     openLocalTerminal({
       initialCommand: cmd,
       title: 'Auth',
@@ -234,23 +301,23 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
                 </li>
               ))}
             </ul>
-            {authInfo?.authCommand && (
+            {commandInfo?.authCommand && (
               <div className="mt-3">
-                <p className="text-xs text-theme-text-tertiary">{authInfo.authCommand.label}</p>
-                <CopyableCommand command={authInfo.authCommand.command} onRunInTerminal={handleRunInTerminal} />
+                <p className="text-xs text-theme-text-tertiary">{commandInfo.authCommand.label}</p>
+                <CopyableCommand command={commandInfo.authCommand.command} onRunInTerminal={handleRunInTerminal} />
                 <button
                   onClick={handleAuthInTerminal}
                   className="mt-3 w-full inline-flex items-center justify-center gap-2 px-3 py-2 text-xs font-medium btn-brand rounded-md"
                 >
                   <TerminalSquare className="w-3.5 h-3.5" />
-                  Authenticate in terminal
+                  {isAuth ? 'Authenticate in terminal' : 'Run in terminal'}
                 </button>
               </div>
             )}
-            {authInfo?.fallbackCommand && (
+            {commandInfo?.fallbackCommand && (
               <div className="mt-4 pt-3 border-t border-theme-border/50">
-                <p className="text-xs text-theme-text-tertiary">{authInfo.fallbackCommand.label}</p>
-                <CopyableCommand command={authInfo.fallbackCommand.command} onRunInTerminal={handleRunInTerminal} />
+                <p className="text-xs text-theme-text-tertiary">{commandInfo.fallbackCommand.label}</p>
+                <CopyableCommand command={commandInfo.fallbackCommand.command} onRunInTerminal={handleRunInTerminal} />
               </div>
             )}
           </div>

--- a/web/src/components/ContextSwitcher.tsx
+++ b/web/src/components/ContextSwitcher.tsx
@@ -16,6 +16,7 @@ interface ContextSwitcherProps {
   className?: string
   variant?: 'chip' | 'segment'
   label?: string
+  triggerName?: string
 }
 
 export interface ContextSwitcherHandle {
@@ -26,7 +27,12 @@ interface ParsedContext extends ParsedContextName {
   context: ContextInfo
 }
 
-export const ContextSwitcher = forwardRef<ContextSwitcherHandle, ContextSwitcherProps>(({ className = '', variant, label }, ref) => {
+function shouldSuppressSwitchErrorToast(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : ''
+  return message.includes('cluster connection failed:')
+}
+
+export const ContextSwitcher = forwardRef<ContextSwitcherHandle, ContextSwitcherProps>(({ className = '', variant, label, triggerName }, ref) => {
   const [showConfirm, setShowConfirm] = useState(false)
   const [pendingSwitch, setPendingSwitch] = useState<ParsedContext | null>(null)
   const [sessionCounts, setSessionCounts] = useState<SessionCounts | null>(null)
@@ -117,8 +123,10 @@ export const ContextSwitcher = forwardRef<ContextSwitcherHandle, ContextSwitcher
       endSwitch()
       // Backend may not transition to StateDisconnected on client-side errors
       // (network, timeout) — without this toast the user gets no feedback.
-      const message = error instanceof Error ? error.message : 'Unknown error'
-      showError('Failed to switch context', message)
+      if (!shouldSuppressSwitchErrorToast(error)) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        showError('Failed to switch context', message)
+      }
     }
   }
 
@@ -185,8 +193,8 @@ export const ContextSwitcher = forwardRef<ContextSwitcherHandle, ContextSwitcher
   // Fall back to clusterInfo.context for the very-early window before
   // /api/contexts has resolved.
   const currentParsed = currentId ? parsedById.get(currentId) : undefined
-  const currentRaw = currentParsed?.raw || clusterInfo?.context || currentCtx?.name || 'Unknown'
-  const currentSourceLabel = hasMultipleSources ? currentCtx?.source || undefined : undefined
+  const currentRaw = triggerName || currentParsed?.raw || clusterInfo?.context || currentCtx?.name || 'Unknown'
+  const currentSourceLabel = triggerName ? undefined : hasMultipleSources ? currentCtx?.source || undefined : undefined
 
   return (
     <>

--- a/web/src/context/ConnectionContext.tsx
+++ b/web/src/context/ConnectionContext.tsx
@@ -27,7 +27,19 @@ interface ConnectionContextValue {
   updateFromSSE: (status: ConnectionState) => void
 }
 
+class ConnectionRetryError extends Error {
+  errorType?: string
+
+  constructor(message: string, errorType?: string) {
+    super(message)
+    this.name = 'ConnectionRetryError'
+    this.errorType = errorType
+  }
+}
+
 const ConnectionContext = createContext<ConnectionContextValue | null>(null)
+const AUTO_RETRY_INITIAL_DELAY_MS = 10000
+const AUTO_RETRY_MAX_DELAY_MS = 60000
 
 async function fetchConnectionStatus(): Promise<ConnectionStatusResponse> {
   // apiFetch handles a 401 globally (re-auth redirect). These endpoints are
@@ -46,8 +58,8 @@ async function retryConnection(): Promise<ConnectionState> {
     method: 'POST',
   })
   if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Unknown error' }))
-    throw new Error(error.error || `HTTP ${response.status}`)
+    const error = await response.json().catch(() => ({ error: 'Unknown error' })) as { error?: string; errorType?: string }
+    throw new ConnectionRetryError(error.error || `HTTP ${response.status}`, error.errorType)
   }
   return response.json()
 }
@@ -59,6 +71,7 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
     context: '',
   })
   const [contexts, setContexts] = useState<ContextInfo[]>([])
+  const [isAutoRetrying, setIsAutoRetrying] = useState(false)
   // Track if SSE has started delivering connection_state events
   // Once SSE is active, it becomes the authoritative source for connection state
   const sseActiveRef = useRef(false)
@@ -66,6 +79,9 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
   // initial connect (bootstrap queries already fetched while 'connecting') from
   // a reconnect after a drop (cache may be stale across the gap).
   const hasConnectedRef = useRef(false)
+  const autoRetryInFlightRef = useRef(false)
+  const autoRetryDelayRef = useRef(AUTO_RETRY_INITIAL_DELAY_MS)
+  const manualRetryPendingRef = useRef(false)
   // Whether the QueryClient already held data when this provider mounted. A host
   // can share one client across cluster-scoped RadarApp mounts (see RadarApp's
   // `queryClient` prop); that client may carry another cluster's data under
@@ -113,6 +129,7 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
   const retryMutation = useMutation({
     mutationFn: retryConnection,
     onMutate: () => {
+      manualRetryPendingRef.current = true
       // Reset SSE active flag - polling can provide state until SSE reconnects
       sseActiveRef.current = false
       // Set connecting state while retrying
@@ -120,7 +137,6 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
         ...prev,
         state: 'connecting',
         error: undefined,
-        errorType: undefined,
         progressMessage: 'Connecting to cluster...',
       }))
     },
@@ -131,16 +147,94 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
       queryClient.invalidateQueries()
     },
     onError: (error: Error) => {
-      setConnection(prev => ({
-        ...prev,
-        state: 'disconnected',
-        error: error.message,
-        progressMessage: undefined,
-      }))
+      const retryError = error as ConnectionRetryError
+      setConnection(prev => {
+        if (sseActiveRef.current && prev.state === 'connected') return prev
+        return {
+          ...prev,
+          state: 'disconnected',
+          error: error.message,
+          errorType: retryError.errorType || prev.errorType,
+          progressMessage: undefined,
+        }
+      })
+    },
+    onSettled: () => {
+      manualRetryPendingRef.current = false
     },
   })
+  useEffect(() => {
+    manualRetryPendingRef.current = retryMutation.isPending
+  }, [retryMutation.isPending])
+
+  useEffect(() => {
+    if (connection.state !== 'disconnected') {
+      autoRetryDelayRef.current = AUTO_RETRY_INITIAL_DELAY_MS
+      return
+    }
+    let stopped = false
+    let retryTimeout: number | undefined
+
+    const scheduleRetry = () => {
+      retryTimeout = window.setTimeout(() => {
+        if (stopped) return
+        if (manualRetryPendingRef.current || autoRetryInFlightRef.current) {
+          scheduleRetry()
+          return
+        }
+
+        autoRetryInFlightRef.current = true
+        setIsAutoRetrying(true)
+        let recovered = false
+        retryConnection()
+          .then((result) => {
+            if (stopped) return
+            recovered = true
+            autoRetryDelayRef.current = AUTO_RETRY_INITIAL_DELAY_MS
+            sseActiveRef.current = false
+            setConnection(result)
+            queryClient.removeQueries()
+            queryClient.invalidateQueries()
+          })
+          .catch((error: Error) => {
+            if (stopped) return
+            const retryError = error as ConnectionRetryError
+            setConnection(prev => {
+              if (sseActiveRef.current && prev.state === 'connected') return prev
+              return {
+                ...prev,
+                state: 'disconnected',
+                error: error.message || prev.error,
+                errorType: retryError.errorType || prev.errorType,
+                progressMessage: undefined,
+              }
+            })
+            autoRetryDelayRef.current = Math.min(autoRetryDelayRef.current * 2, AUTO_RETRY_MAX_DELAY_MS)
+            // Keep the visible disconnected state until a retry succeeds.
+          })
+          .finally(() => {
+            autoRetryInFlightRef.current = false
+            setIsAutoRetrying(false)
+            if (!stopped && !recovered) {
+              scheduleRetry()
+            }
+          })
+      }, autoRetryDelayRef.current)
+    }
+
+    scheduleRetry()
+
+    return () => {
+      stopped = true
+      if (retryTimeout !== undefined) {
+        window.clearTimeout(retryTimeout)
+      }
+    }
+  }, [connection.state, queryClient])
 
   const retry = useCallback(() => {
+    if (retryMutation.isPending || autoRetryInFlightRef.current) return
+    manualRetryPendingRef.current = true
     retryMutation.mutate()
   }, [retryMutation])
 
@@ -180,7 +274,7 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
     connection,
     contexts,
     retry,
-    isRetrying: retryMutation.isPending,
+    isRetrying: retryMutation.isPending || isAutoRetrying,
     updateFromSSE,
   }
 

--- a/web/src/context/ConnectionContext.tsx
+++ b/web/src/context/ConnectionContext.tsx
@@ -11,7 +11,7 @@ export interface ConnectionState {
   context: string
   clusterName?: string
   error?: string
-  errorType?: string // auth, network, timeout, unknown
+  errorType?: string // config, auth, rbac, network, timeout, tls, unknown
   progressMessage?: string
 }
 
@@ -40,6 +40,10 @@ class ConnectionRetryError extends Error {
 const ConnectionContext = createContext<ConnectionContextValue | null>(null)
 const AUTO_RETRY_INITIAL_DELAY_MS = 10000
 const AUTO_RETRY_MAX_DELAY_MS = 60000
+
+export function shouldAutoRetryConnection(errorType?: string): boolean {
+  return errorType !== 'config' && errorType !== 'rbac'
+}
 
 async function fetchConnectionStatus(): Promise<ConnectionStatusResponse> {
   // apiFetch handles a 401 globally (re-auth redirect). These endpoints are
@@ -168,7 +172,7 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
   }, [retryMutation.isPending])
 
   useEffect(() => {
-    if (connection.state !== 'disconnected') {
+    if (connection.state !== 'disconnected' || !shouldAutoRetryConnection(connection.errorType)) {
       autoRetryDelayRef.current = AUTO_RETRY_INITIAL_DELAY_MS
       return
     }
@@ -230,7 +234,7 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
         window.clearTimeout(retryTimeout)
       }
     }
-  }, [connection.state, queryClient])
+  }, [connection.errorType, connection.state, queryClient])
 
   const retry = useCallback(() => {
     if (retryMutation.isPending || autoRetryInFlightRef.current) return

--- a/web/src/hooks/useEventSource.ts
+++ b/web/src/hooks/useEventSource.ts
@@ -7,6 +7,7 @@ interface UseEventSourceReturn {
   topology: Topology | null
   events: K8sEvent[]
   connected: boolean
+  connecting: boolean
   reconnect: () => void
 }
 
@@ -43,6 +44,7 @@ export function useEventSource(
   const [topology, setTopology] = useState<Topology | null>(null)
   const [events, setEvents] = useState<K8sEvent[]>([])
   const [connected, setConnected] = useState(false)
+  const [connecting, setConnecting] = useState(true)
   const eventSourceRef = useRef<EventSource | null>(null)
   const reconnectTimeoutRef = useRef<number | null>(null)
   const waitingForTopologyAfterSwitch = useRef(false)
@@ -66,6 +68,7 @@ export function useEventSource(
   optionsRef.current = options
 
   const connect = useCallback(() => {
+    setConnecting(true)
     // Clean up existing connection
     if (eventSourceRef.current) {
       eventSourceRef.current.close()
@@ -99,6 +102,7 @@ export function useEventSource(
     es.onopen = () => {
       console.log('SSE connected')
       setConnected(true)
+      setConnecting(false)
       // Reset backoff on successful connection
       reconnectDelayRef.current = INITIAL_RECONNECT_DELAY_MS
     }
@@ -106,6 +110,7 @@ export function useEventSource(
     es.onerror = (error) => {
       console.error('SSE error:', error)
       setConnected(false)
+      setConnecting(false)
       es.close()
 
       // Reconnect with exponential backoff
@@ -257,6 +262,7 @@ export function useEventSource(
     topology,
     events,
     connected,
+    connecting,
     reconnect,
   }
 }


### PR DESCRIPTION
## Why

Connection failures from Kubernetes exec-credential providers can look like generic transport failures, especially around AWS SSO, GKE auth plugins, and slow token refreshes. Radar should give credential guidance only when the error has real credential evidence, keep API/network timeouts in connectivity guidance, preserve the raw error for debugging, and recover automatically when the cluster becomes reachable again.

## What changed

- Classifies connection failures into `config`, `auth`, `rbac`, `network`, `timeout`, `tls`, and `unknown`.
- Treats concrete credential failures as `auth`, including AWS SSO expired-token strings, client-go `getting credentials: exec ... failed` wrappers, and GKE auth-plugin strings.
- Keeps bare deadlines, API server timeouts, `i/o timeout`, and bounded exec-plugin hangs in the `timeout` bucket instead of over-claiming expired credentials.
- Adds `tls` handling for typed and stringified x509/certificate verification failures.
- Classifies missing/no-context kubeconfig failures as `config` so the UI does not auto-retry a setup problem.
- Skips startup retry for deterministic `config`/`auth`/`rbac`/`network`/`tls` failures, while still retrying timeout-shaped failures where a second attempt can help.
- Returns `errorType` from failed `/api/connection/retry` responses so the UI can update stale guidance after manual or automatic retries.
- Auto-retries disconnected sessions with backoff only for recoverable classes; it avoids overlapping manual/automatic retries and refreshes cached data after recovery.
- Separates full cluster disconnection from live-update/SSE disconnection so an SSE-only drop does not look like a Kubernetes API failure.
- Improves the disconnected view with provider-aware recovery commands, runnable/copyable command controls, an animated raw-error disclosure, and accessible labels for icon-only actions.

## Verification

- `go test ./internal/k8s ./internal/app -run 'TestClassifyError|TestMarkDisconnectedIfClusterUnreachable|TestCheckClusterAccess|TestConnectionProbeHTTPTimeout|TestConnectionTestOperationTimeout' -count=1`
- `make tsc`
- `make test`
- `make build`

Unit coverage pins:

- typed 401/403/timeout errors;
- concrete exec credential failures vs bare deadline/timeouts;
- AWS SSO/GKE-style auth strings;
- x509 typed and stringified TLS failures;
- config/no-context kubeconfig failures;
- Helm cluster-unreachable classification;
- startup retry vs no-retry behavior for `config`/`auth`/`rbac`/`network`/`tls`/`timeout`.

Live/manual scenarios verified during the PR:

- healthy exec-auth startup on GKE and EKS contexts;
- expired/failed exec-auth guidance path;
- synthetic no-exec endpoint-refused kubeconfig;
- synthetic nonzero exec plugin;
- synthetic hanging exec plugin;
- disconnected UI render and retry path.

Visual-test: skipped. The UI delta is the disconnected shell/error-state behavior, which depends on kubeconfig/auth failure states rather than a stable in-app fixture. The final UI assertions are covered by typecheck, unit-tested server classification, and manual disconnected-state sanity.

## Risk / blast radius

This touches connection classification, startup retry, manual retry, auto-retry, and the disconnected shell for all local Radar sessions. The main risk is sending users to the wrong fix. Mitigation is conservative classification order: typed Kubernetes errors win first; concrete config/RBAC/auth/TLS strings are matched before generic network/timeout fallbacks; broad timeout strings remain a last bucket after more specific evidence. Raw errors stay visible, so the curated message does not hide debugging detail.

Residual risk: a novel provider or client-go error string can still fall to `unknown` or `timeout`; that is intentionally safer than over-claiming auth. Operators can still use the raw error, and the classifier tests now make future additions explicit.

Refs SKY-1095.
