### PR TITLE
Polish issues and resource UI copy

### DIFF
--- a/packages/k8s-ui/src/components/issues/IssuesView.tsx
+++ b/packages/k8s-ui/src/components/issues/IssuesView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, type ComponentType, type ReactNode } from 'react';
 import { AlertOctagon, AlertTriangle, ArrowRight, ChevronRight, CircleCheck, Clock, ExternalLink, Layers, Terminal, Workflow } from 'lucide-react';
-import { CardBody, CardSection, ClusterName, EmptyState, KIND_CHIP_CLASS, NEUTRAL_CHIP_CLASS, TerminalBlock } from '../ui';
+import { CardBody, CardSection, ClusterName, EmptyState, KIND_CHIP_CLASS, TerminalBlock } from '../ui';
 import { formatCompactAge, formatRelativeAgeTime } from '../../utils/format';
 import { diagnosticRoleLabel, diagnosticFactLabel, confidenceTitle, incidentParentLabel } from './diagnostic';
 import {
@@ -11,6 +11,7 @@ import {
   ISSUE_SEVERITY_SOLID_CLASS,
   ISSUE_SEVERITY_TEXT_CLASS,
   categoryLabel,
+  groupBadgeClass,
   groupLabel,
 } from './severity';
 import {
@@ -205,7 +206,7 @@ export function IssueRow({
         <div className="flex min-w-0 flex-1 flex-col gap-1">
           <div className="flex min-w-0 items-baseline gap-2">
             <span className="shrink-0 text-sm font-medium text-theme-text-primary">{categoryLabel(issue.category)}</span>
-            <span className={`shrink-0 self-center ${NEUTRAL_CHIP_CLASS}`}>{groupLabel(issue.category_group)}</span>
+            <span className={`shrink-0 self-center ${groupBadgeClass(issue.category_group)}`}>{groupLabel(issue.category_group)}</span>
             {renderBadges?.(slotCtx)}
             {/* The detector reason rides the title row while COLLAPSED so the
                 key triage signal shows without expanding. When open, the full
@@ -257,14 +258,12 @@ export function IssueRow({
           </div>
         </div>
 
-        {/* Right cluster — severity pill THEN age, vertically centered as a
-            group and top-aligned with the title line. */}
+        {/* Right cluster — severity pill THEN age, vertically centered as a group. */}
         <div className="flex shrink-0 items-center gap-3">
           <span className={`badge-sm shrink-0 px-2.5 py-0.5 text-xs font-semibold ${open ? ISSUE_SEVERITY_SOLID_CLASS[severity] : ISSUE_SEVERITY_BADGE_CLASS[severity]}`}>
             {ISSUE_SEVERITY_LABEL[severity]}
           </span>
-          {/* Age chip: chronic-vs-acute signal. started_at_resource_creation →
-              "since deploy" (raw age misleads — present since creation). */}
+          {/* Age chip: keep recency visible; the deployment-start signal rides as a secondary tag. */}
           {issue.first_seen ? (
             <time
               dateTime={issue.first_seen}
@@ -272,9 +271,10 @@ export function IssueRow({
               className="flex shrink-0 items-center gap-1 text-xs tabular-nums text-theme-text-tertiary"
             >
               <Clock className="h-3 w-3" aria-hidden />
-              {issue.issue_timing === 'started_at_resource_creation'
-                ? 'since deploy'
-                : formatCompactAge(issue.first_seen)}
+              {formatCompactAge(issue.first_seen)}
+              {issue.issue_timing === 'started_at_resource_creation' ? (
+                <span className="badge-sm ml-1 text-[10px] text-theme-text-secondary">since deploy</span>
+              ) : null}
             </time>
           ) : null}
           {renderActions?.(slotCtx)}

--- a/packages/k8s-ui/src/components/issues/ResourceIssuesSection.test.tsx
+++ b/packages/k8s-ui/src/components/issues/ResourceIssuesSection.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import { ResourceIssuesSection } from './ResourceIssuesSection'
+import type { Issue } from './types'
+
+const issue: Issue = {
+  id: 'pvc-root',
+  severity: 'critical',
+  source: 'missing_ref',
+  category: 'pvc_pending',
+  category_group: 'storage',
+  grouping_scope: 'pvc',
+  kind: 'PersistentVolumeClaim',
+  namespace: 'demo',
+  name: 'data',
+  reason: 'StorageClassMissing',
+  cause: 'PVC demo/data references a StorageClass that does not exist.',
+  diagnostic_context: {
+    role: 'candidate',
+    facts: [
+      {
+        type: 'pvc_blast_radius',
+        confidence: 'high',
+        message: 'Blocks pods that mount this claim.',
+      },
+    ],
+  },
+}
+
+describe('ResourceIssuesSection', () => {
+  it('keeps drawer context facts but omits the role badge', () => {
+    const html = renderToString(<ResourceIssuesSection issues={[issue]} />)
+
+    expect(html).toContain('Context')
+    expect(html).toContain('Blocked pods')
+    expect(html).toContain('high<!-- --> confidence')
+    expect(html).not.toContain('Possible cause')
+  })
+})

--- a/packages/k8s-ui/src/components/issues/ResourceIssuesSection.tsx
+++ b/packages/k8s-ui/src/components/issues/ResourceIssuesSection.tsx
@@ -3,7 +3,7 @@ import { Section } from '../ui/drawer-components'
 import { Badge } from '../ui/Badge'
 import type { Issue, IssueResourceRef } from './types'
 import { categoryLabel } from './severity'
-import { diagnosticRoleLabel, diagnosticFactLabel, confidenceTitle, incidentParentLabel } from './diagnostic'
+import { diagnosticFactLabel, confidenceTitle, incidentParentLabel } from './diagnostic'
 
 /**
  * ResourceIssuesSection — the compact "Operational Issues" block for the resource
@@ -108,7 +108,6 @@ function CausalContext({ issue, onResourceClick }: { issue: Issue; onResourceCli
     <div className="mt-2 border-t border-theme-border/60 pt-2">
       <div className="mb-1 flex items-center gap-2">
         <span className="text-[10px] font-semibold uppercase tracking-wide text-theme-text-tertiary">Context</span>
-        {ctx.role ? <span className="badge-sm text-[10px] text-theme-text-secondary">{diagnosticRoleLabel(ctx.role)}</span> : null}
       </div>
       <ul className="space-y-1.5">
         {links.map((fact, idx) => (

--- a/packages/k8s-ui/src/components/issues/issues.test.ts
+++ b/packages/k8s-ui/src/components/issues/issues.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 import { createElement } from 'react'
 import { renderToString } from 'react-dom/server'
 import { compareIssues, subjectRef, memberRef, normalizeImagePullMessage, issueMessageParts, type Issue } from './types'
-import { categoryLabel, groupLabel } from './severity'
+import { categoryLabel, groupBadgeClass, groupLabel } from './severity'
 import { IssueRow } from './IssuesView'
 
 const base: Issue = {
@@ -17,6 +17,10 @@ const base: Issue = {
   reason: 'CrashLoopBackOff',
 }
 const mk = (o: Partial<Issue>): Issue => ({ ...base, ...o })
+
+afterEach(() => {
+  vi.useRealTimers()
+})
 
 describe('compareIssues', () => {
   it('orders critical before warning regardless of observed age', () => {
@@ -61,6 +65,46 @@ describe('category/group label fallbacks', () => {
   it('humanizes an unmapped group', () => {
     expect(groupLabel('runtime')).toBe('Runtime')
     expect(groupLabel('some_future_group')).toBe('Some future group')
+  })
+  it('keeps ordinary group chips neutral and emphasizes control-plane/unknown groups', () => {
+    expect(groupBadgeClass('runtime')).toContain('text-theme-text-secondary')
+    expect(groupBadgeClass('runtime')).not.toContain('ring-theme-border-light')
+    expect(groupBadgeClass('control_plane')).toContain('text-theme-text-primary')
+    expect(groupBadgeClass('control_plane')).toContain('ring-theme-border-light')
+    expect(groupBadgeClass('unknown')).toContain('ring-theme-border-light')
+    expect(groupBadgeClass('some_future_group')).toContain('text-theme-text-secondary')
+    expect(groupBadgeClass('some_future_group')).not.toContain('ring-theme-border-light')
+  })
+})
+
+describe('IssueRow', () => {
+  it('keeps relative age visible and adds since-deploy as a secondary tag', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-30T12:00:00Z'))
+
+    const html = renderToString(createElement(IssueRow, {
+      issue: mk({
+        id: 'baseline',
+        first_seen: '2026-06-28T12:00:00Z',
+        issue_timing: 'started_at_resource_creation',
+      }),
+      open: false,
+      onToggle: () => undefined,
+    }))
+
+    expect(html).toContain('2d')
+    expect(html).toContain('since deploy')
+  })
+
+  it('uses the category-group chip class in the queue row', () => {
+    const html = renderToString(createElement(IssueRow, {
+      issue: mk({ category_group: 'control_plane' }),
+      open: false,
+      onToggle: () => undefined,
+    }))
+
+    expect(html).toContain('Control plane')
+    expect(html).toContain(groupBadgeClass('control_plane'))
   })
 })
 

--- a/packages/k8s-ui/src/components/issues/severity.ts
+++ b/packages/k8s-ui/src/components/issues/severity.ts
@@ -1,5 +1,6 @@
 import type { IssueSeverity } from './types';
 import { BADGE_SEVERITY_COLORS as sev } from '../ui/Badge';
+import { NEUTRAL_CHIP_CLASS } from '../ui/CardSection';
 import {
   TONE_HEADER_BAND_CLASS,
   TONE_RAIL_CLASS,
@@ -38,6 +39,14 @@ export const ISSUE_SEVERITY_TEXT_CLASS = byTone(TONE_TEXT_CLASS);
 export const ISSUE_SEVERITY_RAIL_CLASS = byTone(TONE_RAIL_CLASS);
 export const ISSUE_SEVERITY_SOLID_CLASS = byTone(TONE_SOLID_CLASS);
 export const ISSUE_SEVERITY_HEADER_BAND_CLASS = byTone(TONE_HEADER_BAND_CLASS);
+
+const GROUP_CHIP_EMPHASIS_CLASS = 'inline-flex items-center rounded-md px-2 py-0.5 text-[11px] font-semibold leading-tight bg-theme-elevated text-theme-text-primary ring-1 ring-theme-border-light';
+
+const EMPHASIZED_GROUPS = new Set(['control_plane', 'unknown']);
+
+export function groupBadgeClass(group: string): string {
+  return EMPHASIZED_GROUPS.has(group) ? GROUP_CHIP_EMPHASIS_CLASS : NEUTRAL_CHIP_CLASS;
+}
 
 // Display labels. The server emits raw snake_case category/group enums (so a
 // new category needs no frontend deploy to APPEAR); the UI humanizes for

--- a/packages/k8s-ui/src/components/resources/ResourcesSidebar.test.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesSidebar.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import type { APIResource } from '../../types'
+import { rawCRDGroupTitle, resourceMatchesSidebarFilter, ResourcesSidebar } from './ResourcesSidebar'
+
+const sqlInstance: APIResource = {
+  group: 'sql.cnrm.cloud.google.com',
+  version: 'v1beta1',
+  kind: 'SQLInstance',
+  name: 'sqlinstances',
+  namespaced: true,
+  isCrd: true,
+  verbs: ['list'],
+}
+
+describe('ResourcesSidebar CRD group labels', () => {
+  it('keeps raw API groups available for filtering and hover recovery', () => {
+    expect(resourceMatchesSidebarFilter(sqlInstance, 'cnrm')).toBe(true)
+    expect(resourceMatchesSidebarFilter(sqlInstance, 'google')).toBe(true)
+    expect(rawCRDGroupTitle([sqlInstance])).toBe('API group: sql.cnrm.cloud.google.com')
+  })
+
+  it('renders the raw API group in the category title while keeping the friendly label visible', () => {
+    const html = renderToString(
+      <ResourcesSidebar
+        selectedKind={null}
+        onSelectedKindChange={() => {}}
+        apiResources={[sqlInstance]}
+        resourceCounts={{ 'sql.cnrm.cloud.google.com/SQLInstance': 1 }}
+      />
+    )
+
+    expect(html).toContain('Config Connector')
+    expect(html).toContain('title="API group: sql.cnrm.cloud.google.com"')
+  })
+})

--- a/packages/k8s-ui/src/components/resources/ResourcesSidebar.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesSidebar.tsx
@@ -92,6 +92,25 @@ const CORE_RESOURCE_TYPES = [
   { kind: 'hpas', label: 'HPAs' },
 ] as const
 
+export function resourceMatchesSidebarFilter(resource: Pick<APIResource, 'kind' | 'name' | 'group'>, term: string): boolean {
+  const normalized = term.trim().toLowerCase()
+  if (!normalized) return true
+  return resource.kind.toLowerCase().includes(normalized) ||
+    resource.name.toLowerCase().includes(normalized) ||
+    resource.group.toLowerCase().includes(normalized)
+}
+
+export function rawCRDGroupTitle(resources: Pick<APIResource, 'group' | 'isCrd'>[]): string | undefined {
+  const groups = Array.from(new Set(
+    resources
+      .filter(resource => resource.isCrd && resource.group)
+      .map(resource => resource.group)
+  )).sort()
+
+  if (groups.length === 0) return undefined
+  return groups.length === 1 ? `API group: ${groups[0]}` : `API groups: ${groups.join(', ')}`
+}
+
 // Resource type button in sidebar
 interface ResourceTypeButtonProps {
   resource: APIResource
@@ -347,12 +366,10 @@ export function ResourcesSidebar({
     return sortedCategories
       .map(category => {
         const categoryMatches = category.name.toLowerCase().includes(term)
+        const rawGroupMatches = category.resources.some((resource: APIResource) => resource.group.toLowerCase().includes(term))
         // If the group name matches, show all its resources
-        if (categoryMatches) return category
-        const matchingResources = category.visibleResources.filter((resource: any) =>
-          resource.kind.toLowerCase().includes(term) ||
-          resource.name.toLowerCase().includes(term)
-        )
+        if (categoryMatches || rawGroupMatches) return category
+        const matchingResources = category.visibleResources.filter((resource: APIResource) => resourceMatchesSidebarFilter(resource, term))
         if (matchingResources.length === 0) return null
         return {
           ...category,
@@ -550,6 +567,7 @@ export function ResourcesSidebar({
           // Dynamic categories from API
           filteredCategories.map((category) => {
             const isExpanded = effectiveExpandedCategories.has(category.name)
+            const rawGroupTitle = rawCRDGroupTitle(category.resources)
             return (
               <div key={category.name} className="mb-2">
                 <button
@@ -561,7 +579,7 @@ export function ResourcesSidebar({
                   ) : (
                     <ChevronRight className="w-3 h-3" />
                   )}
-                  <span className="flex-1 text-left">{category.name}</span>
+                  <span className="flex-1 text-left truncate" title={rawGroupTitle}>{category.name}</span>
                   {!isExpanded && (
                     <span className={clsx('text-xs py-0.5 rounded bg-theme-elevated text-theme-text-secondary font-normal normal-case text-center font-mono', category.total < 1000 ? 'w-8' : 'w-9')}>
                       {category.total}

--- a/packages/k8s-ui/src/components/resources/renderers/PVCRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PVCRenderer.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import { PVCRenderer } from './PVCRenderer'
+
+describe('PVCRenderer', () => {
+  it('does not reassure indefinitely pending PVCs as normal', () => {
+    const html = renderToString(
+      <PVCRenderer
+        data={{
+          metadata: { name: 'data', namespace: 'demo' },
+          spec: { storageClassName: 'standard' },
+          status: { phase: 'Pending' },
+        }}
+      />,
+    )
+
+    expect(html).toContain('Pending')
+    expect(html).toContain('not yet bound')
+    expect(html).toContain('check the StorageClass')
+    expect(html).not.toContain('This is normal')
+    expect(html).not.toContain('expected indefinitely')
+  })
+})

--- a/packages/k8s-ui/src/components/resources/renderers/PVCRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PVCRenderer.tsx
@@ -53,8 +53,8 @@ export function PVCRenderer({ data, onNavigate, extraSections }: PVCRendererProp
       {isPending && (
         <AlertBanner
           variant="info"
-          title="Pending — awaiting binding"
-          message="Not yet bound to a volume. This is normal while provisioning, and expected indefinitely for a WaitForFirstConsumer StorageClass until a Pod that mounts this claim is scheduled."
+          title="Pending — not yet bound"
+          message="A PVC stays Pending while its volume is provisioned, or for a WaitForFirstConsumer StorageClass until a Pod that mounts it is scheduled. If it stays Pending, check the StorageClass, its provisioner, and storage quota."
         />
       )}
 

--- a/packages/k8s-ui/src/utils/api-resources.test.ts
+++ b/packages/k8s-ui/src/utils/api-resources.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { categorizeResources, formatGroupName, shortenGroupName } from './api-resources'
+
+describe('formatGroupName', () => {
+  it('uses friendly names for common CRD groups seen in clusters', () => {
+    expect(formatGroupName('policies.kyverno.io')).toBe('Kyverno')
+    expect(formatGroupName('networking.gke.io')).toBe('GKE Networking')
+    expect(formatGroupName('apiregistration.k8s.io')).toBe('API Registration')
+    expect(formatGroupName('monitoring.googleapis.com')).toBe('Google Cloud Monitoring')
+    expect(formatGroupName('sql.cnrm.cloud.google.com')).toBe('Config Connector')
+    expect(formatGroupName('crd.k8s.amazonaws.com')).toBe('AWS VPC CNI')
+    expect(formatGroupName('acid.zalan.do')).toBe('Zalando Postgres')
+  })
+
+  it('formats unmapped API groups without exposing raw domain strings', () => {
+    expect(formatGroupName('widgets.example.io')).toBe('Example Widgets')
+    expect(formatGroupName('api.my-company.dev')).toBe('My Company API')
+    expect(formatGroupName('dns.gke.example.io')).toBe('Example DNS GKE')
+    expect(formatGroupName('widgets.example.io')).not.toMatch(/\./)
+  })
+
+  it('does not promote Kubernetes domain-family suffixes into visible labels', () => {
+    expect(formatGroupName('flowcontrol.apiserver.k8s.io')).toBe('Apiserver Flowcontrol')
+    expect(formatGroupName('addons.cluster.x-k8s.io')).toBe('Cluster API')
+    expect(formatGroupName('ipam.cluster.x-k8s.io')).toBe('Cluster API')
+    expect(formatGroupName('nfd.k8s-sigs.io')).toBe('NFD')
+  })
+
+  it('keeps unmapped CRD groups separate from core categories', () => {
+    expect(formatGroupName('networking.io')).toBe('Networking APIs')
+    expect(formatGroupName('storage.io')).toBe('Storage APIs')
+  })
+
+  it('keeps shortenGroupName as the legacy suffix-stripping helper', () => {
+    expect(shortenGroupName('networking.gke.io')).toBe('networking.gke')
+    expect(shortenGroupName('rbac.authorization.k8s.io')).toBe('rbac.authorization')
+    expect(shortenGroupName('widgets.example.dev')).toBe('widgets.example')
+  })
+})
+
+describe('categorizeResources', () => {
+  it('does not merge unmapped CRDs into matching core categories', () => {
+    const categories = categorizeResources([
+      { group: 'networking.io', version: 'v1', kind: 'WidgetRoute', name: 'widgetroutes', namespaced: true, isCrd: true, verbs: ['list'] },
+    ])
+
+    const networking = categories.find(c => c.name === 'Networking')
+    const networkingAPIs = categories.find(c => c.name === 'Networking APIs')
+
+    expect(networking?.resources.some(r => r.kind === 'Service')).toBe(true)
+    expect(networking?.resources.some(r => r.kind === 'WidgetRoute')).toBe(false)
+    expect(networkingAPIs?.resources.map(r => r.kind)).toEqual(['WidgetRoute'])
+  })
+})

--- a/packages/k8s-ui/src/utils/api-resources.ts
+++ b/packages/k8s-ui/src/utils/api-resources.ts
@@ -13,6 +13,7 @@ const CONFIG_KINDS = ['ConfigMap', 'Secret', 'HorizontalPodAutoscaler', 'PodDisr
 const STORAGE_KINDS = ['PersistentVolumeClaim', 'PersistentVolume', 'StorageClass', 'VolumeAttachment']
 const ACCESS_CONTROL_KINDS = ['ServiceAccount', 'Role', 'ClusterRole', 'RoleBinding', 'ClusterRoleBinding']
 const CLUSTER_KINDS = ['Node', 'Namespace', 'Event']
+const CORE_CATEGORY_NAMES = new Set(['Workloads', 'Networking', 'Configuration', 'Storage', 'Access Control', 'Cluster'])
 
 // Core resources that must always be present (fallback if API discovery misses them)
 export const CORE_RESOURCES: APIResource[] = [
@@ -112,6 +113,7 @@ export function categorizeResources(resources: APIResource[]): ResourceCategory[
 export function formatGroupName(group: string): string {
   const knownGroups: Record<string, string> = {
     'argoproj.io': 'Argo',
+    'apiregistration.k8s.io': 'API Registration',
     'cert-manager.io': 'Cert Manager',
     'acme.cert-manager.io': 'Cert Manager',
     'istio.io': 'Istio',
@@ -119,10 +121,12 @@ export function formatGroupName(group: string): string {
     'security.istio.io': 'Istio',
     'telemetry.istio.io': 'Istio',
     'monitoring.coreos.com': 'Prometheus',
+    'monitoring.googleapis.com': 'Google Cloud Monitoring',
     'velero.io': 'Velero',
     'external-secrets.io': 'External Secrets',
     'keda.sh': 'KEDA',
     'gateway.networking.k8s.io': 'Gateway API',
+    'gateway.envoyproxy.io': 'Envoy Gateway',
     'traefik.io': 'Traefik',
     'traefik.containo.us': 'Traefik',
     'crossplane.io': 'Crossplane',
@@ -166,7 +170,11 @@ export function formatGroupName(group: string): string {
     'infrastructure.cluster.x-k8s.io': 'Cluster API',
     'ceph.rook.io': 'Rook',
     'kyverno.io': 'Kyverno',
+    'policies.kyverno.io': 'Kyverno',
     'k8s.nginx.org': 'NGINX',
+    'networking.gke.io': 'GKE Networking',
+    'warden.gke.io': 'GKE Warden',
+    'cloud.google.com': 'Google Cloud',
     'sparkoperator.k8s.io': 'Spark',
     'kubeflow.org': 'Kubeflow',
     'snapshot.storage.k8s.io': 'Snapshots',
@@ -177,6 +185,12 @@ export function formatGroupName(group: string): string {
     'resource.k8s.io': 'Dynamic Resource Allocation',
     'kueue.x-k8s.io': 'Kueue',
     'autoscaling.x-k8s.io': 'Cluster Autoscaler',
+    'crd.k8s.amazonaws.com': 'AWS VPC CNI',
+    'vpcresources.k8s.aws': 'AWS VPC CNI',
+    'elbv2.k8s.aws': 'AWS Load Balancer',
+    'eks.amazonaws.com': 'EKS',
+    'networking.k8s.aws': 'AWS Networking',
+    'acid.zalan.do': 'Zalando Postgres',
     'serving.kserve.io': 'KServe',
     'ray.io': 'KubeRay',
     'leaderworkerset.x-k8s.io': 'LeaderWorkerSet',
@@ -197,13 +211,66 @@ export function formatGroupName(group: string): string {
   // their own per-service groups like s3.aws.upbound.io, compute.gcp.upbound.io).
   if (group.endsWith('.upbound.io')) return 'Crossplane'
   if (group.endsWith('.crossplane.io')) return 'Crossplane'
-  return group
+  if (group === 'cluster.x-k8s.io' || group.endsWith('.cluster.x-k8s.io')) return 'Cluster API'
+  if (group.endsWith('.cnrm.cloud.google.com')) return 'Config Connector'
+  if (group.endsWith('.openshift.io')) return 'OpenShift'
+  return formatUnmappedGroupName(group)
 }
 
 export function shortenGroupName(group: string): string {
   return group
     .replace(/\.(io|com|org|dev|sh)$/, '')
     .replace(/\.k8s$/, '')
+}
+
+const GROUP_SUFFIX_LABELS = new Set([
+  'io', 'com', 'org', 'dev', 'sh', 'net', 'do', 'ai', 'cloud', 'co', 'app',
+  'k8s', 'x-k8s', 'k8s-sigs', 'sigs',
+])
+const GROUP_ACRONYMS: Record<string, string> = {
+  api: 'API',
+  aws: 'AWS',
+  amazonaws: 'AWS',
+  cnrm: 'CNRM',
+  crd: 'CRD',
+  csi: 'CSI',
+  dns: 'DNS',
+  gcp: 'GCP',
+  gke: 'GKE',
+  gpu: 'GPU',
+  hpa: 'HPA',
+  ipam: 'IPAM',
+  k8s: 'K8s',
+  nfd: 'NFD',
+  tcp: 'TCP',
+  tls: 'TLS',
+  udp: 'UDP',
+}
+
+function formatUnmappedGroupName(group: string): string {
+  const labels = group
+    .split('.')
+    .map(label => label.trim().toLowerCase())
+    .filter(label => label && !GROUP_SUFFIX_LABELS.has(label))
+
+  if (labels.length === 0) return group
+  if (labels.length === 1) return avoidCoreCategoryCollision(formatGroupToken(labels[0]))
+
+  const owner = labels[labels.length - 1]
+  const descriptors = labels.slice(0, -1)
+  return avoidCoreCategoryCollision([owner, ...descriptors].map(formatGroupToken).join(' '))
+}
+
+function avoidCoreCategoryCollision(label: string): string {
+  return CORE_CATEGORY_NAMES.has(label) ? `${label} APIs` : label
+}
+
+function formatGroupToken(token: string): string {
+  return token
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map(part => GROUP_ACRONYMS[part] ?? part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
 }
 
 function sortResources(resources: APIResource[]): APIResource[] {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1721,6 +1721,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
           {!showNavRail && (
           <button
             onClick={() => setShowCommandPalette(true)}
+            aria-label="Open command palette"
             className="hidden lg:flex items-center gap-2 h-7 px-2.5 rounded-md bg-theme-elevated hover:bg-theme-hover text-theme-text-secondary hover:text-theme-text-primary transition-colors"
           >
             <Search className="w-3.5 h-3.5" />
@@ -1742,6 +1743,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
             <Tooltip content="Open local terminal">
             <button
               onClick={() => openLocalTerminal()}
+              aria-label="Open local terminal"
               className="p-1.5 rounded-md bg-theme-elevated hover:bg-theme-hover text-theme-text-secondary hover:text-theme-text-primary transition-colors"
             >
               <SquareTerminal className="w-4 h-4" />
@@ -1769,6 +1771,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
               <Tooltip content="Keyboard shortcuts (?)">
               <button
                 onClick={() => setShowHelp(true)}
+                aria-label="Show keyboard shortcuts"
                 className="p-1.5 rounded-md bg-theme-elevated hover:bg-theme-hover text-theme-text-secondary hover:text-theme-text-primary transition-colors"
               >
                 <HelpCircle className="w-4 h-4" />
@@ -1777,6 +1780,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
               <Tooltip content="Report a bug / Diagnostics">
               <button
                 onClick={() => setShowDiagnostics(true)}
+                aria-label="Open diagnostics"
                 className="p-1.5 rounded-md bg-theme-elevated hover:bg-theme-hover text-theme-text-secondary hover:text-theme-text-primary transition-colors"
               >
                 <Bug className="w-4 h-4" />
@@ -2406,12 +2410,12 @@ function FloatingButtons({ showHelp, showCommandPalette, showDiagnostics, onHelp
   return (
     <div className={`fixed ${bottom} right-4 z-40 flex items-center gap-1.5`}>
       <Tooltip content="Report bug / Diagnostics" position="top">
-        <button onClick={onBugReport} className={btnClass}>
+        <button onClick={onBugReport} aria-label="Open diagnostics" className={btnClass}>
           <Bug className="w-3.5 h-3.5" />
         </button>
       </Tooltip>
       <Tooltip content="Keyboard shortcuts (?)" position="top">
-        <button onClick={onHelp} className={btnClass}>
+        <button onClick={onHelp} aria-label="Show keyboard shortcuts" className={btnClass}>
           ?
         </button>
       </Tooltip>
@@ -2563,6 +2567,7 @@ function GitHubStarButton() {
         target="_blank"
         rel="noopener noreferrer"
         onClick={handleClick}
+        aria-label={starred ? 'Open Radar on GitHub' : 'Star Radar on GitHub'}
         className="flex items-center gap-1.5 h-7 px-2 rounded-md transition-colors bg-theme-elevated hover:bg-theme-hover text-theme-text-secondary hover:text-theme-text-primary"
       >
         <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
@@ -2618,6 +2623,7 @@ function ThemeToggle() {
     <Tooltip content={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}>
     <button
       onClick={toggleTheme}
+      aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
       className="p-1.5 rounded-md bg-theme-elevated hover:bg-theme-hover text-theme-text-secondary hover:text-theme-text-primary transition-colors"
     >
       {theme === 'dark' ? (

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -359,11 +359,8 @@ function ProblemsPanel({
               <div className="divide-y divide-theme-border">
                 {issues.map((issue) => {
                   const ref = subjectRef(issue)
-                  const age = issue.first_seen
-                    ? issue.issue_timing === 'started_at_resource_creation'
-                      ? 'since deploy'
-                      : formatCompactAge(issue.first_seen)
-                    : ''
+                  const age = issue.first_seen ? formatCompactAge(issue.first_seen) : ''
+                  const startedAtDeploy = issue.issue_timing === 'started_at_resource_creation'
 
                   return (
                     <button
@@ -381,7 +378,12 @@ function ProblemsPanel({
                         <div className="flex items-center gap-1.5">
                           <span className="text-[10px] text-theme-text-tertiary bg-theme-elevated px-1 py-0.5 rounded">{issue.kind}</span>
                           <span className="text-xs text-theme-text-primary truncate font-medium">{issue.name}</span>
-                          {age && <span className="text-[10px] text-theme-text-tertiary ml-auto shrink-0">{age}</span>}
+                          {(age || startedAtDeploy) && (
+                            <span className="ml-auto flex shrink-0 items-center gap-1">
+                              {age && <span className="text-[10px] text-theme-text-tertiary tabular-nums">{age}</span>}
+                              {startedAtDeploy && <span className="badge-sm text-[10px] text-theme-text-secondary">since deploy</span>}
+                            </span>
+                          )}
                         </div>
                         <div className="flex items-center gap-1.5 mt-0.5">
                           <span className="text-[11px] text-theme-text-secondary truncate">{categoryLabel(issue.category)}</span>


### PR DESCRIPTION
## Why

SKY-1092 is a frontend polish pass for audit/issue surfaces that were making valid signals harder to understand:

- the issue drawer repeated internal root-cause role labels that are useful in the queue but noisy once a user is already reading the drawer;
- ordinary issue grouping chips were visually competing with severity;
- deployment timing needed to preserve resource age while making the recent-deploy context obvious;
- pending PVC copy could sound like the resource was expected to remain pending;
- CRD sidebar labels exposed raw API group mechanics in places where an operator expects recognizable product/platform names;
- a few icon-only controls were missing accessible labels.

## What changed

- Removed the drawer-only root-cause role badge while preserving confidence and related diagnostic facts; the issue queue still keeps the role label for scanability.
- Kept issue severity as the loud signal and made ordinary group chips neutral; only explicit control-plane/unknown group buckets retain subtle emphasis.
- Added a secondary "since deploy" timing label so the original age remains visible.
- Reworded the PVC pending note around provisioning, StorageClass, quota, and wait-for-consumer behavior.
- Expanded CRD/sidebar group labeling for common real clusters:
  - Cluster API subgroups collapse to `Cluster API`
  - Config Connector groups collapse to `Config Connector`
  - AWS VPC CNI / ELB / EKS groups get recognizable labels
  - OpenShift, Zalando Postgres, Node Feature Discovery, and common domain suffixes format more cleanly
- Made raw CRD API groups recoverable without making them primary: sidebar categories have native hover titles and search matches raw groups such as `cnrm` / `google`.
- Added accessible labels to the header and floating controls touched by this pass.

## Design notes

This is frontend-only and does not change issue generation, severity, API response shape, or Kubernetes reads.

The main product tradeoff is that CRD group labels are now intentionally friendlier than the raw API group. To avoid hiding useful technical detail, the raw group remains searchable and available on hover. Unknown groups still fall back through the existing formatter instead of being guessed.

Blast radius is limited to Radar UI and the shared `@skyhook-io/k8s-ui` resource sidebar. The riskiest behavior is mislabeling a CRD family; unit tests pin the known mappings and fallback cases added here, and raw-group recovery gives users an escape hatch when the friendly label is imperfect.

## Testing

- `make tsc`
- `make test`
- `npm --workspace @skyhook-io/k8s-ui test -- src/utils/api-resources.test.ts src/components/issues/issues.test.ts src/components/resources/ResourcesSidebar.test.tsx src/components/issues/ResourceIssuesSection.test.tsx src/components/resources/renderers/PVCRenderer.test.tsx`
- `make build`

Visual-test status:

- Ran earlier manual/visual sanity passes for the drawer, PVC note, CRD sidebar, and accessibility polish on this PR branch.
- After the final review-loop changes, I did not run a fresh screenshot pass; the final deltas are label mapping, raw-group hover/search recovery, and neutral chip class behavior, all covered by focused tests. A final screenshot pass is low-value but safe if desired before merge.

Fixes SKY-1092.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only copy and styling with no backend or API changes; main caveat is friendlier CRD labels, mitigated by hover/search for raw groups and pinned unit tests.
> 
> **Overview**
> Frontend polish for **issues**, **resource sidebar**, and **header controls** so triage signals read clearer without changing APIs or issue generation.
> 
> **Issues:** Resource drawer **Context** keeps facts and confidence but drops the internal **role** badge (`Possible cause`, etc.); the queue still shows roles. **Group chips** use `groupBadgeClass`—neutral for most groups, subtle emphasis only for `control_plane` / `unknown`. **Deployment timing** shows compact **age** plus a secondary **since deploy** tag when `issue_timing` is `started_at_resource_creation` (issue queue, `HomeView`).
> 
> **Resources:** **PVC Pending** copy no longer implies indefinite pending is normal; it points operators at StorageClass, provisioner, and quota. **CRD sidebar** uses friendlier `formatGroupName` mappings and heuristics, avoids merging unmapped CRDs into core categories (e.g. `Networking APIs`), exposes **raw API group** on category hover and in **filter** search (`cnrm`, `google`, etc.).
> 
> **A11y:** `aria-label` on icon-only controls (command palette, terminal, help, diagnostics, theme, GitHub star, floating buttons).
> 
> Unit tests cover group badges, age/since-deploy, drawer context, sidebar hover/search, PVC copy, and group-name formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2b5ebc3672122c1c4ee6be0463d97743b1565e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->