### PR TITLE
Handle unavailable metrics API without drawer errors

### DIFF
--- a/internal/k8s/cache.go
+++ b/internal/k8s/cache.go
@@ -901,6 +901,8 @@ func (c *ResourceCache) getDynamicWithGroup(ctx context.Context, kind string, na
 		u, err = dynamicCache.GetDirect(ctx, gvr, namespace, name)
 	} else if gvr.Group == "apiextensions.k8s.io" && gvr.Resource == "customresourcedefinitions" {
 		u, err = dynamicCache.GetDirect(ctx, gvr, namespace, name)
+	} else if gvr.Group == "apiregistration.k8s.io" && gvr.Resource == "apiservices" {
+		u, err = dynamicCache.GetDirect(ctx, gvr, namespace, name)
 	} else if preserveLastApplied {
 		u, err = dynamicCache.GetDirectPreserveLastApplied(ctx, gvr, namespace, name)
 	} else {

--- a/internal/k8s/cache_dynamic_test.go
+++ b/internal/k8s/cache_dynamic_test.go
@@ -1,0 +1,49 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func TestGetDynamicWithGroupDirectFetchesAPIService(t *testing.T) {
+	defer ResetTestDynamicState()
+
+	gvr := schema.GroupVersionResource{Group: "apiregistration.k8s.io", Version: "v1", Resource: "apiservices"}
+	apiService := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apiregistration.k8s.io/v1",
+		"kind":       "APIService",
+		"metadata": map[string]any{
+			"name": "v1beta1.metrics.k8s.io",
+		},
+	}}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "APIServiceList"},
+		apiService,
+	)
+	if err := InitTestDynamicResourceCache(dyn, []APIResource{{
+		Group:      "apiregistration.k8s.io",
+		Version:    "v1",
+		Kind:       "APIService",
+		Name:       "apiservices",
+		Namespaced: false,
+	}}); err != nil {
+		t.Fatalf("InitTestDynamicResourceCache: %v", err)
+	}
+
+	got, err := (&ResourceCache{}).GetDynamicWithGroup(context.Background(), "APIService", "", "v1beta1.metrics.k8s.io", "apiregistration.k8s.io")
+	if err != nil {
+		t.Fatalf("GetDynamicWithGroup: %v", err)
+	}
+	if got.GetName() != "v1beta1.metrics.k8s.io" {
+		t.Fatalf("GetDynamicWithGroup name = %q", got.GetName())
+	}
+	if count := GetDynamicResourceCache().GetInformerCount(); count != 0 {
+		t.Fatalf("GetDynamicWithGroup(APIService) started %d dynamic informer(s), want direct GET", count)
+	}
+}

--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -53,6 +53,17 @@ var (
 	clientMu     sync.RWMutex
 )
 
+type suppressDiscoveryDiagnosticsKey struct{}
+
+func withSuppressedDiscoveryDiagnostics(ctx context.Context) context.Context {
+	return context.WithValue(ctx, suppressDiscoveryDiagnosticsKey{}, true)
+}
+
+func discoveryDiagnosticsSuppressed(ctx context.Context) bool {
+	suppressed, _ := ctx.Value(suppressDiscoveryDiagnosticsKey{}).(bool)
+	return suppressed
+}
+
 // Initialize creates the global Prometheus client.
 func Initialize(client kubernetes.Interface, config *rest.Config, contextName string) {
 	clientMu.Lock()
@@ -296,7 +307,7 @@ func (c *Client) probe(ctx context.Context, addr string) bool {
 	tr.Headers = headers
 	ok, reason := prom.NewClient(tr).Probe(ctx)
 	if !ok {
-		logProbeRejection(addr, reason)
+		logProbeRejection(addr, reason, !discoveryDiagnosticsSuppressed(ctx))
 	}
 	return ok
 }
@@ -306,14 +317,18 @@ func (c *Client) probe(ctx context.Context, addr string) bool {
 // misconfiguration); empty instances get warning level (cluster state);
 // other failures use stdlib log so they appear in the discovery audit
 // trail without flooding errorlog.
-func logProbeRejection(addr string, reason prom.ProbeReason) {
+func logProbeRejection(addr string, reason prom.ProbeReason, recordDiagnostics bool) {
 	switch reason {
 	case prom.ProbeReasonAuthError:
-		errorlog.Record("prometheus", "error",
-			"endpoint %s rejected credentials (HTTP 401/403, check --prometheus-header)", addr)
+		if recordDiagnostics {
+			errorlog.Record("prometheus", "error",
+				"endpoint %s rejected credentials (HTTP 401/403, check --prometheus-header)", addr)
+		}
 	case prom.ProbeReasonEmptyInstance:
-		errorlog.Record("prometheus", "warning",
-			"endpoint %s has no active scrape targets (empty instance), skipping", addr)
+		if recordDiagnostics {
+			errorlog.Record("prometheus", "warning",
+				"endpoint %s has no active scrape targets (empty instance), skipping", addr)
+		}
 	case prom.ProbeReasonNotPrometheus:
 		log.Printf("[prometheus] endpoint %s responded but not in Prometheus format, skipping", addr)
 	case prom.ProbeReasonPromError:

--- a/internal/prometheus/discovery.go
+++ b/internal/prometheus/discovery.go
@@ -38,7 +38,9 @@ func (c *Client) discover(ctx context.Context) (string, string, error) {
 			c.markConnected(addr, "")
 			return addr, "", nil
 		}
-		errorlog.Record("prometheus", "error", "manual Prometheus URL %s not reachable", addr)
+		if !discoveryDiagnosticsSuppressed(ctx) {
+			errorlog.Record("prometheus", "error", "manual Prometheus URL %s not reachable", addr)
+		}
 		return "", "", fmt.Errorf("manual Prometheus URL %s not reachable", addr)
 	}
 
@@ -67,7 +69,9 @@ func (c *Client) discover(ctx context.Context) (string, string, error) {
 		log.Printf("[prometheus] Discover error: %v", err)
 	}
 	if len(candidates) == 0 {
-		errorlog.Record("prometheus", "warning", "no Prometheus service found in cluster")
+		if !discoveryDiagnosticsSuppressed(ctx) {
+			errorlog.Record("prometheus", "warning", "no Prometheus service found in cluster")
+		}
 		return "", "", fmt.Errorf("no Prometheus service found in cluster")
 	}
 
@@ -99,7 +103,9 @@ func (c *Client) discover(ctx context.Context) (string, string, error) {
 		connInfo, pfErr := portforward.Start(ctx, cand.Namespace, cand.Name, cand.TargetPort, contextName)
 		if pfErr != nil {
 			lastErr = fmt.Errorf("port-forward to %s/%s failed: %w", cand.Namespace, cand.Name, pfErr)
-			errorlog.Record("prometheus", "error", "port-forward to %s/%s failed: %v", cand.Namespace, cand.Name, pfErr)
+			if !discoveryDiagnosticsSuppressed(ctx) {
+				errorlog.Record("prometheus", "error", "port-forward to %s/%s failed: %v", cand.Namespace, cand.Name, pfErr)
+			}
 			continue
 		}
 
@@ -111,7 +117,9 @@ func (c *Client) discover(ctx context.Context) (string, string, error) {
 
 		portforward.Stop()
 		lastErr = fmt.Errorf("Prometheus at %s/%s not responding after port-forward", cand.Namespace, cand.Name)
-		errorlog.Record("prometheus", "error", "Prometheus at %s/%s not responding after port-forward", cand.Namespace, cand.Name)
+		if !discoveryDiagnosticsSuppressed(ctx) {
+			errorlog.Record("prometheus", "error", "Prometheus at %s/%s not responding after port-forward", cand.Namespace, cand.Name)
+		}
 	}
 
 	c.mu.Lock()

--- a/internal/prometheus/handlers.go
+++ b/internal/prometheus/handlers.go
@@ -64,9 +64,20 @@ func handleConnect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, _, err := client.EnsureConnected(r.Context())
+	ctx := r.Context()
+	optional := r.URL.Query().Get("optional") == "true"
+	if optional {
+		ctx = withSuppressedDiscoveryDiagnostics(ctx)
+	}
+	_, _, err := client.EnsureConnected(ctx)
 	if err != nil {
 		log.Printf("[prometheus] Connection failed: %v", err)
+		if optional {
+			status := client.GetStatus()
+			status.Error = "Prometheus connection failed: " + err.Error()
+			writeJSON(w, http.StatusOK, status)
+			return
+		}
 		errorlog.Record("prometheus", "error", "connection failed: %v", err)
 		writeError(w, http.StatusBadGateway, "Prometheus connection failed: "+err.Error())
 		return

--- a/internal/prometheus/handlers_test.go
+++ b/internal/prometheus/handlers_test.go
@@ -1,11 +1,64 @@
 package prometheus
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/skyhook-io/radar/internal/errorlog"
+	"github.com/skyhook-io/radar/pkg/prom"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestHandleConnectOptionalReturnsUnavailableStatus(t *testing.T) {
+	errorlog.Reset()
+	t.Cleanup(errorlog.Reset)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not prometheus", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	clientMu.Lock()
+	previous := globalClient
+	globalClient = &Client{
+		manualURL:   srv.URL,
+		contextName: "test-context",
+		httpClient:  &http.Client{Timeout: 5 * time.Second},
+	}
+	clientMu.Unlock()
+	t.Cleanup(func() {
+		clientMu.Lock()
+		globalClient = previous
+		clientMu.Unlock()
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/prometheus/connect?optional=true", nil)
+	rec := httptest.NewRecorder()
+	handleConnect(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var status prom.Status
+	if err := json.NewDecoder(rec.Body).Decode(&status); err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	if status.Connected {
+		t.Fatal("Connected = true, want false")
+	}
+	if status.Error == "" {
+		t.Fatal("Error is empty, want connection failure detail")
+	}
+	for _, entry := range errorlog.GetEntries() {
+		if entry.Source == "prometheus" && entry.Level == "error" {
+			t.Fatalf("optional connect recorded error log entry: %+v", entry)
+		}
+	}
+}
 
 func TestAnyNodeUsesDocker(t *testing.T) {
 	tests := []struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2226,7 +2226,13 @@ func isMetricsAPIUnavailable(err error) bool {
 	if !strings.Contains(msg, "metrics") {
 		return false
 	}
-	return strings.Contains(msg, "not found") || strings.Contains(msg, "could not find the requested resource")
+	return strings.Contains(msg, "not found") ||
+		strings.Contains(msg, "could not find the requested resource") ||
+		strings.Contains(msg, "no matches for kind") ||
+		strings.Contains(msg, "no resource matches") ||
+		strings.Contains(msg, "no metrics known") ||
+		strings.Contains(msg, "not available") ||
+		strings.Contains(msg, "unable to fetch metrics")
 }
 
 // handlePodMetricsHistory returns historical metrics for a specific pod
@@ -2240,21 +2246,22 @@ func (s *Server) handlePodMetricsHistory(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	history := store.GetPodMetricsHistory(namespace, name)
+	history := podMetricsHistoryResponse(store.GetPodMetricsHistory(namespace, name), namespace, name, store.CollectionHealth())
+	s.writeJSON(w, history)
+}
+
+func podMetricsHistoryResponse(history *k8s.PodMetricsHistory, namespace, name string, health k8s.MetricsCollectionHealth) *k8s.PodMetricsHistory {
 	if history == nil {
-		// Return empty history — include collection error if metrics are failing
 		history = &k8s.PodMetricsHistory{
 			Namespace:  namespace,
 			Name:       name,
 			Containers: []k8s.ContainerMetricsHistory{},
 		}
-		health := store.CollectionHealth()
-		if health.PodMetrics.ConsecutiveErrors > 0 {
-			history.CollectionError = health.PodMetrics.LastError
-		}
 	}
-
-	s.writeJSON(w, history)
+	if health.PodMetrics.ConsecutiveErrors > 0 {
+		history.CollectionError = health.PodMetrics.LastError
+	}
+	return history
 }
 
 // handleNodeMetricsHistory returns historical metrics for a specific node
@@ -2271,19 +2278,21 @@ func (s *Server) handleNodeMetricsHistory(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	history := store.GetNodeMetricsHistory(name)
+	history := nodeMetricsHistoryResponse(store.GetNodeMetricsHistory(name), name, store.CollectionHealth())
+	s.writeJSON(w, history)
+}
+
+func nodeMetricsHistoryResponse(history *k8s.NodeMetricsHistory, name string, health k8s.MetricsCollectionHealth) *k8s.NodeMetricsHistory {
 	if history == nil {
 		history = &k8s.NodeMetricsHistory{
 			Name:       name,
 			DataPoints: []k8s.MetricsDataPoint{},
 		}
-		health := store.CollectionHealth()
-		if health.NodeMetrics.ConsecutiveErrors > 0 {
-			history.CollectionError = health.NodeMetrics.LastError
-		}
 	}
-
-	s.writeJSON(w, history)
+	if health.NodeMetrics.ConsecutiveErrors > 0 {
+		history.CollectionError = health.NodeMetrics.LastError
+	}
+	return history
 }
 
 // handleTopPods returns the latest metrics for all pods (bulk endpoint for table view)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2269,10 +2269,14 @@ func (c *metricsAPIServiceDiagnosisCache) get(contextName string, includeConditi
 	if c.entries == nil {
 		c.entries = make(map[bool]metricsAPIServiceDiagnosisEntry, 2)
 	}
+	now := time.Now()
+	if entry, ok := c.entries[includeConditionMessage]; ok && entry.contextName != contextName && now.Before(entry.expiresAt) {
+		return diagnosis
+	}
 	c.entries[includeConditionMessage] = metricsAPIServiceDiagnosisEntry{
 		contextName: contextName,
 		diagnosis:   diagnosis,
-		expiresAt:   time.Now().Add(c.ttl),
+		expiresAt:   now.Add(c.ttl),
 	}
 	return diagnosis
 }
@@ -2296,12 +2300,15 @@ func metricsUnavailableDiagnosis(ctx context.Context, includeAPIServiceCondition
 	contextName := k8s.GetContextName()
 	return metricsAPIServiceDiagnosisMemo.get(contextName, includeAPIServiceConditionMessage, func() (string, bool) {
 		apiService, err := cache.GetDynamicWithGroup(ctx, metricsAPIServiceKind, "", metricsAPIServiceName, metricsAPIServiceGroup)
-		return metricsAPIServiceLookupDiagnosis(apiService, err, includeAPIServiceConditionMessage), isMetricsAPIServiceLookupCacheable(err)
+		return metricsAPIServiceLookupDiagnosis(apiService, err, includeAPIServiceConditionMessage), isMetricsAPIServiceLookupCacheable(apiService, err)
 	})
 }
 
-func isMetricsAPIServiceLookupCacheable(err error) bool {
-	return !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded)
+func isMetricsAPIServiceLookupCacheable(apiService *unstructured.Unstructured, err error) bool {
+	if err == nil {
+		return apiService != nil
+	}
+	return apierrors.IsNotFound(err) || errors.Is(err, k8score.ErrResourceNotFound)
 }
 
 func metricsAPIServiceLookupDiagnosis(apiService *unstructured.Unstructured, err error, includeConditionMessage bool) string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2235,6 +2235,16 @@ func isMetricsAPIUnavailable(err error) bool {
 		strings.Contains(msg, "unable to fetch metrics")
 }
 
+func metricsHistoryCollectionError(source, errMsg string) string {
+	if errMsg == "" {
+		return ""
+	}
+	if isMetricsAPIUnavailable(fmt.Errorf("failed to get %s metrics: %s", strings.ToLower(source), errMsg)) {
+		return fmt.Sprintf("%s metrics not found (metrics-server may not be installed)", source)
+	}
+	return errMsg
+}
+
 // handlePodMetricsHistory returns historical metrics for a specific pod
 func (s *Server) handlePodMetricsHistory(w http.ResponseWriter, r *http.Request) {
 	namespace := chi.URLParam(r, "namespace")
@@ -2259,7 +2269,7 @@ func podMetricsHistoryResponse(history *k8s.PodMetricsHistory, namespace, name s
 		}
 	}
 	if health.PodMetrics.ConsecutiveErrors > 0 {
-		history.CollectionError = health.PodMetrics.LastError
+		history.CollectionError = metricsHistoryCollectionError("Pod", health.PodMetrics.LastError)
 	}
 	return history
 }
@@ -2290,7 +2300,7 @@ func nodeMetricsHistoryResponse(history *k8s.NodeMetricsHistory, name string, he
 		}
 	}
 	if health.NodeMetrics.ConsecutiveErrors > 0 {
-		history.CollectionError = health.NodeMetrics.LastError
+		history.CollectionError = metricsHistoryCollectionError("Node", health.NodeMetrics.LastError)
 	}
 	return history
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2183,7 +2183,7 @@ func (s *Server) handlePodMetrics(w http.ResponseWriter, r *http.Request) {
 
 	metrics, err := k8s.GetPodMetrics(r.Context(), namespace, name)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		if isMetricsAPIUnavailable(err) {
 			s.writeError(w, http.StatusNotFound, "Pod metrics not found (metrics-server may not be installed)")
 			return
 		}
@@ -2204,7 +2204,7 @@ func (s *Server) handleNodeMetrics(w http.ResponseWriter, r *http.Request) {
 
 	metrics, err := k8s.GetNodeMetrics(r.Context(), name)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		if isMetricsAPIUnavailable(err) {
 			s.writeError(w, http.StatusNotFound, "Node metrics not found (metrics-server may not be installed)")
 			return
 		}
@@ -2213,6 +2213,20 @@ func (s *Server) handleNodeMetrics(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.writeJSON(w, metrics)
+}
+
+func isMetricsAPIUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if apierrors.IsNotFound(err) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	if !strings.Contains(msg, "metrics") {
+		return false
+	}
+	return strings.Contains(msg, "not found") || strings.Contains(msg, "could not find the requested resource")
 }
 
 // handlePodMetricsHistory returns historical metrics for a specific pod

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -48,6 +49,7 @@ import (
 	"github.com/skyhook-io/radar/internal/updater"
 	"github.com/skyhook-io/radar/internal/version"
 	"github.com/skyhook-io/radar/pkg/hpadiag"
+	"github.com/skyhook-io/radar/pkg/k8score"
 	"github.com/skyhook-io/radar/pkg/perfstats"
 	"github.com/skyhook-io/radar/pkg/rbac"
 	topology "github.com/skyhook-io/radar/pkg/topology"
@@ -2244,14 +2246,75 @@ func isMetricsAPIUnavailable(err error) bool {
 		strings.Contains(msg, "currently unable to handle the request")
 }
 
-func metricsHistoryCollectionError(source, errMsg string) (string, string) {
+const (
+	metricsAPIServiceKind  = "APIService"
+	metricsAPIServiceGroup = "apiregistration.k8s.io"
+	metricsAPIServiceName  = "v1beta1.metrics.k8s.io"
+)
+
+func metricsHistoryCollectionError(ctx context.Context, source, errMsg string) (string, string, string) {
 	if errMsg == "" {
-		return "", ""
+		return "", "", ""
 	}
 	if isMetricsAPIUnavailable(fmt.Errorf("failed to get %s metrics: %s", strings.ToLower(source), errMsg)) {
-		return fmt.Sprintf("%s metrics not found (metrics-server may not be installed)", source), errMsg
+		return fmt.Sprintf("%s metrics not found (metrics-server may not be installed)", source), errMsg, metricsUnavailableDiagnosis(ctx)
 	}
-	return errMsg, ""
+	return errMsg, "", ""
+}
+
+func metricsUnavailableDiagnosis(ctx context.Context) string {
+	cache := k8s.GetResourceCache()
+	if cache == nil {
+		return ""
+	}
+
+	apiService, err := cache.GetDynamicWithGroup(ctx, metricsAPIServiceKind, "", metricsAPIServiceName, metricsAPIServiceGroup)
+	if err != nil {
+		if apierrors.IsNotFound(err) || errors.Is(err, k8score.ErrResourceNotFound) {
+			return "The v1beta1.metrics.k8s.io APIService is not registered. Install metrics-server or restore that APIService."
+		}
+		return ""
+	}
+	if apiService == nil {
+		return ""
+	}
+	return metricsAPIServiceDiagnosis(apiService)
+}
+
+func metricsAPIServiceDiagnosis(apiService *unstructured.Unstructured) string {
+	conditions, found, _ := unstructured.NestedSlice(apiService.Object, "status", "conditions")
+	if !found {
+		return "The v1beta1.metrics.k8s.io APIService exists but has no Available condition. Check metrics-server and API aggregation status."
+	}
+
+	for _, condition := range conditions {
+		conditionMap, ok := condition.(map[string]any)
+		if !ok {
+			continue
+		}
+		conditionType, _ := conditionMap["type"].(string)
+		if conditionType != "Available" {
+			continue
+		}
+
+		status, _ := conditionMap["status"].(string)
+		reason, _ := conditionMap["reason"].(string)
+		reasonSuffix := ""
+		if reason != "" {
+			reasonSuffix = " (" + reason + ")"
+		}
+
+		switch status {
+		case "True":
+			return "The v1beta1.metrics.k8s.io APIService is Available, but metrics reads still fail. Check metrics-server logs and API aggregation errors."
+		case "False", "Unknown":
+			return "The v1beta1.metrics.k8s.io APIService is not Available" + reasonSuffix + ". Check the metrics-server Service, endpoints, and API aggregation/TLS configuration."
+		default:
+			return "The v1beta1.metrics.k8s.io APIService has an unexpected Available status" + reasonSuffix + ". Check metrics-server and API aggregation status."
+		}
+	}
+
+	return "The v1beta1.metrics.k8s.io APIService exists but has no Available condition. Check metrics-server and API aggregation status."
 }
 
 // handlePodMetricsHistory returns historical metrics for a specific pod
@@ -2270,11 +2333,11 @@ func (s *Server) handlePodMetricsHistory(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	history := podMetricsHistoryResponse(store.GetPodMetricsHistory(namespace, name), namespace, name, store.CollectionHealth())
+	history := podMetricsHistoryResponse(r.Context(), store.GetPodMetricsHistory(namespace, name), namespace, name, store.CollectionHealth())
 	s.writeJSON(w, history)
 }
 
-func podMetricsHistoryResponse(history *k8s.PodMetricsHistory, namespace, name string, health k8s.MetricsCollectionHealth) *k8s.PodMetricsHistory {
+func podMetricsHistoryResponse(ctx context.Context, history *k8s.PodMetricsHistory, namespace, name string, health k8s.MetricsCollectionHealth) *k8s.PodMetricsHistory {
 	if history == nil {
 		history = &k8s.PodMetricsHistory{
 			Namespace:  namespace,
@@ -2283,7 +2346,7 @@ func podMetricsHistoryResponse(history *k8s.PodMetricsHistory, namespace, name s
 		}
 	}
 	if health.PodMetrics.ConsecutiveErrors > 0 {
-		history.CollectionError, history.RawCollectionError = metricsHistoryCollectionError("Pod", health.PodMetrics.LastError)
+		history.CollectionError, history.RawCollectionError, history.MetricsUnavailableDiagnosis = metricsHistoryCollectionError(ctx, "Pod", health.PodMetrics.LastError)
 	}
 	return history
 }
@@ -2302,11 +2365,11 @@ func (s *Server) handleNodeMetricsHistory(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	history := nodeMetricsHistoryResponse(store.GetNodeMetricsHistory(name), name, store.CollectionHealth())
+	history := nodeMetricsHistoryResponse(r.Context(), store.GetNodeMetricsHistory(name), name, store.CollectionHealth())
 	s.writeJSON(w, history)
 }
 
-func nodeMetricsHistoryResponse(history *k8s.NodeMetricsHistory, name string, health k8s.MetricsCollectionHealth) *k8s.NodeMetricsHistory {
+func nodeMetricsHistoryResponse(ctx context.Context, history *k8s.NodeMetricsHistory, name string, health k8s.MetricsCollectionHealth) *k8s.NodeMetricsHistory {
 	if history == nil {
 		history = &k8s.NodeMetricsHistory{
 			Name:       name,
@@ -2314,7 +2377,7 @@ func nodeMetricsHistoryResponse(history *k8s.NodeMetricsHistory, name string, he
 		}
 	}
 	if health.NodeMetrics.ConsecutiveErrors > 0 {
-		history.CollectionError, history.RawCollectionError = metricsHistoryCollectionError("Node", health.NodeMetrics.LastError)
+		history.CollectionError, history.RawCollectionError, history.MetricsUnavailableDiagnosis = metricsHistoryCollectionError(ctx, "Node", health.NodeMetrics.LastError)
 	}
 	return history
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2252,36 +2252,133 @@ const (
 	metricsAPIServiceName  = "v1beta1.metrics.k8s.io"
 )
 
-func metricsHistoryCollectionError(ctx context.Context, source, errMsg string) (string, string, string) {
+var metricsAPIServiceDiagnosisMemo = metricsAPIServiceDiagnosisCache{
+	ttl:    5 * time.Second,
+	logTTL: time.Minute,
+}
+
+type metricsAPIServiceDiagnosisCache struct {
+	mu      sync.Mutex
+	ttl     time.Duration
+	entries map[bool]metricsAPIServiceDiagnosisEntry
+
+	logMu        sync.Mutex
+	logTTL       time.Duration
+	loggedErrors map[string]time.Time
+}
+
+type metricsAPIServiceDiagnosisEntry struct {
+	contextName string
+	expiresAt   time.Time
+	diagnosis   string
+}
+
+func (c *metricsAPIServiceDiagnosisCache) get(contextName string, includeConditionMessage bool, build func() (string, bool)) string {
+	if c == nil || c.ttl <= 0 {
+		diagnosis, _ := build()
+		return diagnosis
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.entries == nil {
+		c.entries = make(map[bool]metricsAPIServiceDiagnosisEntry, 2)
+	}
+	if entry, ok := c.entries[includeConditionMessage]; ok && entry.contextName == contextName && time.Now().Before(entry.expiresAt) {
+		return entry.diagnosis
+	}
+
+	diagnosis, cacheable := build()
+	if !cacheable {
+		return diagnosis
+	}
+	c.entries[includeConditionMessage] = metricsAPIServiceDiagnosisEntry{
+		contextName: contextName,
+		diagnosis:   diagnosis,
+		expiresAt:   time.Now().Add(c.ttl),
+	}
+	return diagnosis
+}
+
+func (c *metricsAPIServiceDiagnosisCache) shouldLogLookupError(contextName string, err error) bool {
+	if c == nil || c.logTTL <= 0 || err == nil {
+		return true
+	}
+
+	c.logMu.Lock()
+	defer c.logMu.Unlock()
+	now := time.Now()
+	if c.loggedErrors == nil {
+		c.loggedErrors = make(map[string]time.Time)
+	}
+	for key, expiresAt := range c.loggedErrors {
+		if !now.Before(expiresAt) {
+			delete(c.loggedErrors, key)
+		}
+	}
+	key := metricsAPIServiceLookupLogKey(contextName, err)
+	if expiresAt, ok := c.loggedErrors[key]; ok && now.Before(expiresAt) {
+		return false
+	}
+	c.loggedErrors[key] = now.Add(c.logTTL)
+	return true
+}
+
+func metricsAPIServiceLookupLogKey(contextName string, err error) string {
+	if statusErr, ok := err.(apierrors.APIStatus); ok {
+		status := statusErr.Status()
+		return fmt.Sprintf("%s\x00apiStatus\x00%d\x00%s\x00%s", contextName, status.Code, status.Reason, status.Status)
+	}
+	return fmt.Sprintf("%s\x00%T", contextName, err)
+}
+
+func metricsHistoryCollectionError(ctx context.Context, source, errMsg string, includeAPIServiceConditionMessage bool) (string, string, string) {
 	if errMsg == "" {
 		return "", "", ""
 	}
 	if isMetricsAPIUnavailable(fmt.Errorf("failed to get %s metrics: %s", strings.ToLower(source), errMsg)) {
-		return fmt.Sprintf("%s metrics not found (metrics-server may not be installed)", source), errMsg, metricsUnavailableDiagnosis(ctx)
+		return fmt.Sprintf("%s metrics not found (metrics-server may not be installed)", source), errMsg, metricsUnavailableDiagnosis(ctx, includeAPIServiceConditionMessage)
 	}
 	return errMsg, "", ""
 }
 
-func metricsUnavailableDiagnosis(ctx context.Context) string {
+func metricsUnavailableDiagnosis(ctx context.Context, includeAPIServiceConditionMessage bool) string {
 	cache := k8s.GetResourceCache()
 	if cache == nil {
 		return ""
 	}
 
-	apiService, err := cache.GetDynamicWithGroup(ctx, metricsAPIServiceKind, "", metricsAPIServiceName, metricsAPIServiceGroup)
+	contextName := k8s.GetContextName()
+	return metricsAPIServiceDiagnosisMemo.get(contextName, includeAPIServiceConditionMessage, func() (string, bool) {
+		apiService, err := cache.GetDynamicWithGroup(ctx, metricsAPIServiceKind, "", metricsAPIServiceName, metricsAPIServiceGroup)
+		return metricsAPIServiceLookupDiagnosis(apiService, err, includeAPIServiceConditionMessage), isMetricsAPIServiceLookupCacheable(err)
+	})
+}
+
+func isMetricsAPIServiceLookupCacheable(err error) bool {
+	return !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded)
+}
+
+func metricsAPIServiceLookupDiagnosis(apiService *unstructured.Unstructured, err error, includeConditionMessage bool) string {
 	if err != nil {
 		if apierrors.IsNotFound(err) || errors.Is(err, k8score.ErrResourceNotFound) {
 			return "The v1beta1.metrics.k8s.io APIService is not registered. Install metrics-server or restore that APIService."
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return ""
+		}
+		if metricsAPIServiceDiagnosisMemo.shouldLogLookupError(k8s.GetContextName(), err) {
+			log.Printf("[metrics] Failed to inspect %s APIService for metrics unavailable diagnosis: %v", metricsAPIServiceName, err)
 		}
 		return ""
 	}
 	if apiService == nil {
 		return ""
 	}
-	return metricsAPIServiceDiagnosis(apiService)
+	return metricsAPIServiceDiagnosis(apiService, includeConditionMessage)
 }
 
-func metricsAPIServiceDiagnosis(apiService *unstructured.Unstructured) string {
+func metricsAPIServiceDiagnosis(apiService *unstructured.Unstructured, includeConditionMessage bool) string {
 	conditions, found, _ := unstructured.NestedSlice(apiService.Object, "status", "conditions")
 	if !found {
 		return "The v1beta1.metrics.k8s.io APIService exists but has no Available condition. Check metrics-server and API aggregation status."
@@ -2303,18 +2400,51 @@ func metricsAPIServiceDiagnosis(apiService *unstructured.Unstructured) string {
 		if reason != "" {
 			reasonSuffix = " (" + reason + ")"
 		}
+		messageSuffix := ""
+		if includeConditionMessage {
+			messageSuffix = metricsAPIServiceConditionMessageSuffix(conditionMap)
+		}
 
 		switch status {
 		case "True":
 			return "The v1beta1.metrics.k8s.io APIService is Available, but metrics reads still fail. Check metrics-server logs and API aggregation errors."
 		case "False", "Unknown":
-			return "The v1beta1.metrics.k8s.io APIService is not Available" + reasonSuffix + ". Check the metrics-server Service, endpoints, and API aggregation/TLS configuration."
+			return metricsAPIServiceDiagnosisSentence(
+				"The v1beta1.metrics.k8s.io APIService is not Available"+reasonSuffix+messageSuffix,
+				"Check the metrics-server Service, endpoints, and API aggregation/TLS configuration.",
+			)
 		default:
-			return "The v1beta1.metrics.k8s.io APIService has an unexpected Available status" + reasonSuffix + ". Check metrics-server and API aggregation status."
+			return metricsAPIServiceDiagnosisSentence(
+				"The v1beta1.metrics.k8s.io APIService has an unexpected Available status"+reasonSuffix+messageSuffix,
+				"Check metrics-server and API aggregation status.",
+			)
 		}
 	}
 
 	return "The v1beta1.metrics.k8s.io APIService exists but has no Available condition. Check metrics-server and API aggregation status."
+}
+
+func metricsAPIServiceConditionMessageSuffix(conditionMap map[string]any) string {
+	message, _ := conditionMap["message"].(string)
+	message = strings.Join(strings.Fields(message), " ")
+	message = strings.TrimRight(message, ":;,")
+	if message == "" {
+		return ""
+	}
+
+	const maxRunes = 180
+	runes := []rune(message)
+	if len(runes) > maxRunes {
+		message = string(runes[:maxRunes]) + "..."
+	}
+	return ": " + message
+}
+
+func metricsAPIServiceDiagnosisSentence(subject, action string) string {
+	if strings.HasSuffix(subject, ".") || strings.HasSuffix(subject, "?") || strings.HasSuffix(subject, "!") {
+		return subject + " " + action
+	}
+	return subject + ". " + action
 }
 
 // handlePodMetricsHistory returns historical metrics for a specific pod
@@ -2333,11 +2463,12 @@ func (s *Server) handlePodMetricsHistory(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	history := podMetricsHistoryResponse(r.Context(), store.GetPodMetricsHistory(namespace, name), namespace, name, store.CollectionHealth())
+	includeAPIServiceConditionMessage := s.canRead(r, metricsAPIServiceGroup, "apiservices", "", "get")
+	history := podMetricsHistoryResponse(r.Context(), store.GetPodMetricsHistory(namespace, name), namespace, name, store.CollectionHealth(), includeAPIServiceConditionMessage)
 	s.writeJSON(w, history)
 }
 
-func podMetricsHistoryResponse(ctx context.Context, history *k8s.PodMetricsHistory, namespace, name string, health k8s.MetricsCollectionHealth) *k8s.PodMetricsHistory {
+func podMetricsHistoryResponse(ctx context.Context, history *k8s.PodMetricsHistory, namespace, name string, health k8s.MetricsCollectionHealth, includeAPIServiceConditionMessage bool) *k8s.PodMetricsHistory {
 	if history == nil {
 		history = &k8s.PodMetricsHistory{
 			Namespace:  namespace,
@@ -2346,7 +2477,7 @@ func podMetricsHistoryResponse(ctx context.Context, history *k8s.PodMetricsHisto
 		}
 	}
 	if health.PodMetrics.ConsecutiveErrors > 0 {
-		history.CollectionError, history.RawCollectionError, history.MetricsUnavailableDiagnosis = metricsHistoryCollectionError(ctx, "Pod", health.PodMetrics.LastError)
+		history.CollectionError, history.RawCollectionError, history.MetricsUnavailableDiagnosis = metricsHistoryCollectionError(ctx, "Pod", health.PodMetrics.LastError, includeAPIServiceConditionMessage)
 	}
 	return history
 }
@@ -2365,11 +2496,12 @@ func (s *Server) handleNodeMetricsHistory(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	history := nodeMetricsHistoryResponse(r.Context(), store.GetNodeMetricsHistory(name), name, store.CollectionHealth())
+	includeAPIServiceConditionMessage := s.canRead(r, metricsAPIServiceGroup, "apiservices", "", "get")
+	history := nodeMetricsHistoryResponse(r.Context(), store.GetNodeMetricsHistory(name), name, store.CollectionHealth(), includeAPIServiceConditionMessage)
 	s.writeJSON(w, history)
 }
 
-func nodeMetricsHistoryResponse(ctx context.Context, history *k8s.NodeMetricsHistory, name string, health k8s.MetricsCollectionHealth) *k8s.NodeMetricsHistory {
+func nodeMetricsHistoryResponse(ctx context.Context, history *k8s.NodeMetricsHistory, name string, health k8s.MetricsCollectionHealth, includeAPIServiceConditionMessage bool) *k8s.NodeMetricsHistory {
 	if history == nil {
 		history = &k8s.NodeMetricsHistory{
 			Name:       name,
@@ -2377,7 +2509,7 @@ func nodeMetricsHistoryResponse(ctx context.Context, history *k8s.NodeMetricsHis
 		}
 	}
 	if health.NodeMetrics.ConsecutiveErrors > 0 {
-		history.CollectionError, history.RawCollectionError, history.MetricsUnavailableDiagnosis = metricsHistoryCollectionError(ctx, "Node", health.NodeMetrics.LastError)
+		history.CollectionError, history.RawCollectionError, history.MetricsUnavailableDiagnosis = metricsHistoryCollectionError(ctx, "Node", health.NodeMetrics.LastError, includeAPIServiceConditionMessage)
 	}
 	return history
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2251,17 +2251,23 @@ func (c *metricsAPIServiceDiagnosisCache) get(contextName string, includeConditi
 	}
 
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	if c.entries == nil {
 		c.entries = make(map[bool]metricsAPIServiceDiagnosisEntry, 2)
 	}
 	if entry, ok := c.entries[includeConditionMessage]; ok && entry.contextName == contextName && time.Now().Before(entry.expiresAt) {
+		c.mu.Unlock()
 		return entry.diagnosis
 	}
+	c.mu.Unlock()
 
 	diagnosis, cacheable := build()
 	if !cacheable {
 		return diagnosis
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.entries == nil {
+		c.entries = make(map[bool]metricsAPIServiceDiagnosisEntry, 2)
 	}
 	c.entries[includeConditionMessage] = metricsAPIServiceDiagnosisEntry{
 		contextName: contextName,
@@ -2271,14 +2277,14 @@ func (c *metricsAPIServiceDiagnosisCache) get(contextName string, includeConditi
 	return diagnosis
 }
 
-func metricsHistoryCollectionError(ctx context.Context, source, errMsg string, includeAPIServiceConditionMessage bool) (string, string, string) {
+func metricsHistoryCollectionError(ctx context.Context, source, errMsg string, includeAPIServiceConditionMessage bool) (string, string, string, bool) {
 	if errMsg == "" {
-		return "", "", ""
+		return "", "", "", false
 	}
 	if k8score.MetricsAPIUnavailable(fmt.Errorf("failed to get %s metrics: %s", strings.ToLower(source), errMsg)) {
-		return fmt.Sprintf("%s metrics not found (metrics-server may not be installed)", source), errMsg, metricsUnavailableDiagnosis(ctx, includeAPIServiceConditionMessage)
+		return fmt.Sprintf("%s metrics not found (metrics-server may not be installed)", source), errMsg, metricsUnavailableDiagnosis(ctx, includeAPIServiceConditionMessage), true
 	}
-	return errMsg, "", ""
+	return errMsg, "", "", false
 }
 
 func metricsUnavailableDiagnosis(ctx context.Context, includeAPIServiceConditionMessage bool) string {
@@ -2414,7 +2420,7 @@ func podMetricsHistoryResponse(ctx context.Context, history *k8s.PodMetricsHisto
 		}
 	}
 	if health.PodMetrics.ConsecutiveErrors > 0 {
-		history.CollectionError, history.RawCollectionError, history.MetricsUnavailableDiagnosis = metricsHistoryCollectionError(ctx, "Pod", health.PodMetrics.LastError, includeAPIServiceConditionMessage)
+		history.CollectionError, history.RawCollectionError, history.MetricsUnavailableDiagnosis, history.MetricsUnavailable = metricsHistoryCollectionError(ctx, "Pod", health.PodMetrics.LastError, includeAPIServiceConditionMessage)
 	}
 	return history
 }
@@ -2446,7 +2452,7 @@ func nodeMetricsHistoryResponse(ctx context.Context, history *k8s.NodeMetricsHis
 		}
 	}
 	if health.NodeMetrics.ConsecutiveErrors > 0 {
-		history.CollectionError, history.RawCollectionError, history.MetricsUnavailableDiagnosis = metricsHistoryCollectionError(ctx, "Node", health.NodeMetrics.LastError, includeAPIServiceConditionMessage)
+		history.CollectionError, history.RawCollectionError, history.MetricsUnavailableDiagnosis, history.MetricsUnavailable = metricsHistoryCollectionError(ctx, "Node", health.NodeMetrics.LastError, includeAPIServiceConditionMessage)
 	}
 	return history
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2181,6 +2181,11 @@ func (s *Server) handlePodMetrics(w http.ResponseWriter, r *http.Request) {
 	namespace := chi.URLParam(r, "namespace")
 	name := chi.URLParam(r, "name")
 
+	if noNamespaceAccess(s.getUserNamespaces(r, []string{namespace})) {
+		s.writeError(w, http.StatusForbidden, "no access to namespace "+namespace)
+		return
+	}
+
 	metrics, err := k8s.GetPodMetrics(r.Context(), namespace, name)
 	if err != nil {
 		if isMetricsAPIUnavailable(err) {
@@ -2226,29 +2231,38 @@ func isMetricsAPIUnavailable(err error) bool {
 	if !strings.Contains(msg, "metrics") {
 		return false
 	}
+	if apierrors.IsServiceUnavailable(err) {
+		return true
+	}
 	return strings.Contains(msg, "not found") ||
 		strings.Contains(msg, "could not find the requested resource") ||
 		strings.Contains(msg, "no matches for kind") ||
 		strings.Contains(msg, "no resource matches") ||
 		strings.Contains(msg, "no metrics known") ||
 		strings.Contains(msg, "not available") ||
-		strings.Contains(msg, "unable to fetch metrics")
+		strings.Contains(msg, "unable to fetch metrics") ||
+		strings.Contains(msg, "currently unable to handle the request")
 }
 
-func metricsHistoryCollectionError(source, errMsg string) string {
+func metricsHistoryCollectionError(source, errMsg string) (string, string) {
 	if errMsg == "" {
-		return ""
+		return "", ""
 	}
 	if isMetricsAPIUnavailable(fmt.Errorf("failed to get %s metrics: %s", strings.ToLower(source), errMsg)) {
-		return fmt.Sprintf("%s metrics not found (metrics-server may not be installed)", source)
+		return fmt.Sprintf("%s metrics not found (metrics-server may not be installed)", source), errMsg
 	}
-	return errMsg
+	return errMsg, ""
 }
 
 // handlePodMetricsHistory returns historical metrics for a specific pod
 func (s *Server) handlePodMetricsHistory(w http.ResponseWriter, r *http.Request) {
 	namespace := chi.URLParam(r, "namespace")
 	name := chi.URLParam(r, "name")
+
+	if noNamespaceAccess(s.getUserNamespaces(r, []string{namespace})) {
+		s.writeError(w, http.StatusForbidden, "no access to namespace "+namespace)
+		return
+	}
 
 	store := k8s.GetMetricsHistory()
 	if store == nil {
@@ -2269,7 +2283,7 @@ func podMetricsHistoryResponse(history *k8s.PodMetricsHistory, namespace, name s
 		}
 	}
 	if health.PodMetrics.ConsecutiveErrors > 0 {
-		history.CollectionError = metricsHistoryCollectionError("Pod", health.PodMetrics.LastError)
+		history.CollectionError, history.RawCollectionError = metricsHistoryCollectionError("Pod", health.PodMetrics.LastError)
 	}
 	return history
 }
@@ -2300,7 +2314,7 @@ func nodeMetricsHistoryResponse(history *k8s.NodeMetricsHistory, name string, he
 		}
 	}
 	if health.NodeMetrics.ConsecutiveErrors > 0 {
-		history.CollectionError = metricsHistoryCollectionError("Node", health.NodeMetrics.LastError)
+		history.CollectionError, history.RawCollectionError = metricsHistoryCollectionError("Node", health.NodeMetrics.LastError)
 	}
 	return history
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2190,7 +2190,7 @@ func (s *Server) handlePodMetrics(w http.ResponseWriter, r *http.Request) {
 
 	metrics, err := k8s.GetPodMetrics(r.Context(), namespace, name)
 	if err != nil {
-		if isMetricsAPIUnavailable(err) {
+		if k8score.MetricsAPIUnavailable(err) {
 			s.writeError(w, http.StatusNotFound, "Pod metrics not found (metrics-server may not be installed)")
 			return
 		}
@@ -2211,7 +2211,7 @@ func (s *Server) handleNodeMetrics(w http.ResponseWriter, r *http.Request) {
 
 	metrics, err := k8s.GetNodeMetrics(r.Context(), name)
 	if err != nil {
-		if isMetricsAPIUnavailable(err) {
+		if k8score.MetricsAPIUnavailable(err) {
 			s.writeError(w, http.StatusNotFound, "Node metrics not found (metrics-server may not be installed)")
 			return
 		}
@@ -2222,30 +2222,6 @@ func (s *Server) handleNodeMetrics(w http.ResponseWriter, r *http.Request) {
 	s.writeJSON(w, metrics)
 }
 
-func isMetricsAPIUnavailable(err error) bool {
-	if err == nil {
-		return false
-	}
-	if apierrors.IsNotFound(err) {
-		return true
-	}
-	msg := strings.ToLower(err.Error())
-	if !strings.Contains(msg, "metrics") {
-		return false
-	}
-	if apierrors.IsServiceUnavailable(err) {
-		return true
-	}
-	return strings.Contains(msg, "not found") ||
-		strings.Contains(msg, "could not find the requested resource") ||
-		strings.Contains(msg, "no matches for kind") ||
-		strings.Contains(msg, "no resource matches") ||
-		strings.Contains(msg, "no metrics known") ||
-		strings.Contains(msg, "not available") ||
-		strings.Contains(msg, "unable to fetch metrics") ||
-		strings.Contains(msg, "currently unable to handle the request")
-}
-
 const (
 	metricsAPIServiceKind  = "APIService"
 	metricsAPIServiceGroup = "apiregistration.k8s.io"
@@ -2253,18 +2229,13 @@ const (
 )
 
 var metricsAPIServiceDiagnosisMemo = metricsAPIServiceDiagnosisCache{
-	ttl:    5 * time.Second,
-	logTTL: time.Minute,
+	ttl: 5 * time.Second,
 }
 
 type metricsAPIServiceDiagnosisCache struct {
 	mu      sync.Mutex
 	ttl     time.Duration
 	entries map[bool]metricsAPIServiceDiagnosisEntry
-
-	logMu        sync.Mutex
-	logTTL       time.Duration
-	loggedErrors map[string]time.Time
 }
 
 type metricsAPIServiceDiagnosisEntry struct {
@@ -2300,43 +2271,11 @@ func (c *metricsAPIServiceDiagnosisCache) get(contextName string, includeConditi
 	return diagnosis
 }
 
-func (c *metricsAPIServiceDiagnosisCache) shouldLogLookupError(contextName string, err error) bool {
-	if c == nil || c.logTTL <= 0 || err == nil {
-		return true
-	}
-
-	c.logMu.Lock()
-	defer c.logMu.Unlock()
-	now := time.Now()
-	if c.loggedErrors == nil {
-		c.loggedErrors = make(map[string]time.Time)
-	}
-	for key, expiresAt := range c.loggedErrors {
-		if !now.Before(expiresAt) {
-			delete(c.loggedErrors, key)
-		}
-	}
-	key := metricsAPIServiceLookupLogKey(contextName, err)
-	if expiresAt, ok := c.loggedErrors[key]; ok && now.Before(expiresAt) {
-		return false
-	}
-	c.loggedErrors[key] = now.Add(c.logTTL)
-	return true
-}
-
-func metricsAPIServiceLookupLogKey(contextName string, err error) string {
-	if statusErr, ok := err.(apierrors.APIStatus); ok {
-		status := statusErr.Status()
-		return fmt.Sprintf("%s\x00apiStatus\x00%d\x00%s\x00%s", contextName, status.Code, status.Reason, status.Status)
-	}
-	return fmt.Sprintf("%s\x00%T", contextName, err)
-}
-
 func metricsHistoryCollectionError(ctx context.Context, source, errMsg string, includeAPIServiceConditionMessage bool) (string, string, string) {
 	if errMsg == "" {
 		return "", "", ""
 	}
-	if isMetricsAPIUnavailable(fmt.Errorf("failed to get %s metrics: %s", strings.ToLower(source), errMsg)) {
+	if k8score.MetricsAPIUnavailable(fmt.Errorf("failed to get %s metrics: %s", strings.ToLower(source), errMsg)) {
 		return fmt.Sprintf("%s metrics not found (metrics-server may not be installed)", source), errMsg, metricsUnavailableDiagnosis(ctx, includeAPIServiceConditionMessage)
 	}
 	return errMsg, "", ""
@@ -2367,9 +2306,7 @@ func metricsAPIServiceLookupDiagnosis(apiService *unstructured.Unstructured, err
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return ""
 		}
-		if metricsAPIServiceDiagnosisMemo.shouldLogLookupError(k8s.GetContextName(), err) {
-			log.Printf("[metrics] Failed to inspect %s APIService for metrics unavailable diagnosis: %v", metricsAPIServiceName, err)
-		}
+		log.Printf("[metrics] Failed to inspect %s APIService for metrics unavailable diagnosis: %v", metricsAPIServiceName, err)
 		return ""
 	}
 	if apiService == nil {

--- a/internal/server/server_auth_test.go
+++ b/internal/server/server_auth_test.go
@@ -305,6 +305,26 @@ func newAuthTestServer(t *testing.T) *authTestEnv {
 	return &authTestEnv{ts: ts, srv: srv}
 }
 
+func TestProxyAuth_PodMetricsNamespaceGated(t *testing.T) {
+	paths := []string{
+		"/api/metrics/pods/default/web-0",
+		"/api/metrics/pods/default/web-0/history",
+	}
+
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			env := newAuthTestServer(t)
+			env.srv.permCache.Set("carol", &auth.UserPermissions{AllowedNamespaces: []string{"other"}})
+
+			resp := env.authGet(t, path, "carol", "")
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusForbidden {
+				t.Fatalf("%s: status = %d, want %d", path, resp.StatusCode, http.StatusForbidden)
+			}
+		})
+	}
+}
+
 // authPost sends a POST with proxy auth headers and a JSON body.
 func (e *authTestEnv) authPost(t *testing.T, path, user, groups, body string) *http.Response {
 	t.Helper()

--- a/internal/server/server_smoke_test.go
+++ b/internal/server/server_smoke_test.go
@@ -1023,6 +1023,10 @@ func TestSmokeMetricsNilDynamicClient(t *testing.T) {
 }
 
 func TestIsMetricsAPIUnavailable(t *testing.T) {
+	// These cases cover typed Kubernetes API errors first, then message shapes
+	// emitted by apimachinery discovery/restmapper, kubectl top-style metrics
+	// failures, and API aggregation 503s. Keep broad phrases gated by a
+	// metrics-specific signal so unrelated NotFound/Unavailable errors stay visible.
 	tests := []struct {
 		name string
 		err  error

--- a/internal/server/server_smoke_test.go
+++ b/internal/server/server_smoke_test.go
@@ -1082,11 +1082,11 @@ func TestMetricsHistoryResponseCarriesCollectionErrorWithBufferedHistory(t *test
 	health := k8s.MetricsCollectionHealth{
 		PodMetrics: k8s.MetricsSourceHealth{
 			ConsecutiveErrors: 1,
-			LastError:         "the server could not find the requested resource (get pods.metrics.k8s.io)",
+			LastError:         "the server could not find the requested resource",
 		},
 		NodeMetrics: k8s.MetricsSourceHealth{
 			ConsecutiveErrors: 1,
-			LastError:         "the server could not find the requested resource (get nodes.metrics.k8s.io)",
+			LastError:         "the server could not find the requested resource",
 		},
 	}
 
@@ -1102,8 +1102,8 @@ func TestMetricsHistoryResponseCarriesCollectionErrorWithBufferedHistory(t *test
 			}},
 		}},
 	}, "default", "api", health)
-	if podHistory.CollectionError != health.PodMetrics.LastError {
-		t.Fatalf("pod collection error = %q, want %q", podHistory.CollectionError, health.PodMetrics.LastError)
+	if podHistory.CollectionError != "Pod metrics not found (metrics-server may not be installed)" {
+		t.Fatalf("pod collection error = %q", podHistory.CollectionError)
 	}
 
 	nodeHistory := nodeMetricsHistoryResponse(&k8s.NodeMetricsHistory{
@@ -1114,6 +1114,29 @@ func TestMetricsHistoryResponseCarriesCollectionErrorWithBufferedHistory(t *test
 			Memory:    268435456,
 		}},
 	}, "kind-worker", health)
+	if nodeHistory.CollectionError != "Node metrics not found (metrics-server may not be installed)" {
+		t.Fatalf("node collection error = %q", nodeHistory.CollectionError)
+	}
+}
+
+func TestMetricsHistoryResponseKeepsNonAbsenceCollectionErrors(t *testing.T) {
+	health := k8s.MetricsCollectionHealth{
+		PodMetrics: k8s.MetricsSourceHealth{
+			ConsecutiveErrors: 1,
+			LastError:         "forbidden: no access to pods.metrics.k8s.io",
+		},
+		NodeMetrics: k8s.MetricsSourceHealth{
+			ConsecutiveErrors: 1,
+			LastError:         "forbidden: no access to nodes.metrics.k8s.io",
+		},
+	}
+
+	podHistory := podMetricsHistoryResponse(nil, "default", "api", health)
+	if podHistory.CollectionError != health.PodMetrics.LastError {
+		t.Fatalf("pod collection error = %q, want %q", podHistory.CollectionError, health.PodMetrics.LastError)
+	}
+
+	nodeHistory := nodeMetricsHistoryResponse(nil, "kind-worker", health)
 	if nodeHistory.CollectionError != health.NodeMetrics.LastError {
 		t.Fatalf("node collection error = %q, want %q", nodeHistory.CollectionError, health.NodeMetrics.LastError)
 	}

--- a/internal/server/server_smoke_test.go
+++ b/internal/server/server_smoke_test.go
@@ -1033,6 +1033,31 @@ func TestIsMetricsAPIUnavailable(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "metrics no matches for kind",
+			err:  errors.New(`failed to get pod metrics: no matches for kind "PodMetrics" in version "metrics.k8s.io/v1beta1"`),
+			want: true,
+		},
+		{
+			name: "metrics no resource matches",
+			err:  errors.New(`failed to get pod metrics: no resource matches "pods.metrics.k8s.io"`),
+			want: true,
+		},
+		{
+			name: "metrics not available",
+			err:  errors.New(`failed to get pod metrics: pods.metrics.k8s.io not available`),
+			want: true,
+		},
+		{
+			name: "no metrics known",
+			err:  errors.New(`failed to get pod metrics: no metrics known for pod "api" in pods.metrics.k8s.io`),
+			want: true,
+		},
+		{
+			name: "unable to fetch metrics",
+			err:  errors.New(`failed to get pod metrics: unable to fetch metrics from pods.metrics.k8s.io`),
+			want: true,
+		},
+		{
 			name: "non-metrics missing resource stays visible",
 			err:  errors.New("the server could not find the requested resource"),
 			want: false,
@@ -1050,6 +1075,47 @@ func TestIsMetricsAPIUnavailable(t *testing.T) {
 				t.Fatalf("isMetricsAPIUnavailable() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestMetricsHistoryResponseCarriesCollectionErrorWithBufferedHistory(t *testing.T) {
+	health := k8s.MetricsCollectionHealth{
+		PodMetrics: k8s.MetricsSourceHealth{
+			ConsecutiveErrors: 1,
+			LastError:         "the server could not find the requested resource (get pods.metrics.k8s.io)",
+		},
+		NodeMetrics: k8s.MetricsSourceHealth{
+			ConsecutiveErrors: 1,
+			LastError:         "the server could not find the requested resource (get nodes.metrics.k8s.io)",
+		},
+	}
+
+	podHistory := podMetricsHistoryResponse(&k8s.PodMetricsHistory{
+		Namespace: "default",
+		Name:      "api",
+		Containers: []k8s.ContainerMetricsHistory{{
+			Name: "api",
+			DataPoints: []k8s.MetricsDataPoint{{
+				Timestamp: time.Now(),
+				CPU:       100000000,
+				Memory:    268435456,
+			}},
+		}},
+	}, "default", "api", health)
+	if podHistory.CollectionError != health.PodMetrics.LastError {
+		t.Fatalf("pod collection error = %q, want %q", podHistory.CollectionError, health.PodMetrics.LastError)
+	}
+
+	nodeHistory := nodeMetricsHistoryResponse(&k8s.NodeMetricsHistory{
+		Name: "kind-worker",
+		DataPoints: []k8s.MetricsDataPoint{{
+			Timestamp: time.Now(),
+			CPU:       100000000,
+			Memory:    268435456,
+		}},
+	}, "kind-worker", health)
+	if nodeHistory.CollectionError != health.NodeMetrics.LastError {
+		t.Fatalf("node collection error = %q, want %q", nodeHistory.CollectionError, health.NodeMetrics.LastError)
 	}
 }
 

--- a/internal/server/server_smoke_test.go
+++ b/internal/server/server_smoke_test.go
@@ -20,6 +20,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
@@ -1095,7 +1096,7 @@ func TestMetricsHistoryResponseCarriesCollectionErrorWithBufferedHistory(t *test
 		},
 	}
 
-	podHistory := podMetricsHistoryResponse(&k8s.PodMetricsHistory{
+	podHistory := podMetricsHistoryResponse(context.Background(), &k8s.PodMetricsHistory{
 		Namespace: "default",
 		Name:      "api",
 		Containers: []k8s.ContainerMetricsHistory{{
@@ -1114,7 +1115,7 @@ func TestMetricsHistoryResponseCarriesCollectionErrorWithBufferedHistory(t *test
 		t.Fatalf("pod raw collection error = %q, want %q", podHistory.RawCollectionError, health.PodMetrics.LastError)
 	}
 
-	nodeHistory := nodeMetricsHistoryResponse(&k8s.NodeMetricsHistory{
+	nodeHistory := nodeMetricsHistoryResponse(context.Background(), &k8s.NodeMetricsHistory{
 		Name: "kind-worker",
 		DataPoints: []k8s.MetricsDataPoint{{
 			Timestamp: time.Now(),
@@ -1142,20 +1143,74 @@ func TestMetricsHistoryResponseKeepsNonAbsenceCollectionErrors(t *testing.T) {
 		},
 	}
 
-	podHistory := podMetricsHistoryResponse(nil, "default", "api", health)
+	podHistory := podMetricsHistoryResponse(context.Background(), nil, "default", "api", health)
 	if podHistory.CollectionError != health.PodMetrics.LastError {
 		t.Fatalf("pod collection error = %q, want %q", podHistory.CollectionError, health.PodMetrics.LastError)
 	}
 	if podHistory.RawCollectionError != "" {
 		t.Fatalf("pod raw collection error = %q, want empty", podHistory.RawCollectionError)
 	}
+	if podHistory.MetricsUnavailableDiagnosis != "" {
+		t.Fatalf("pod metrics unavailable diagnosis = %q, want empty", podHistory.MetricsUnavailableDiagnosis)
+	}
 
-	nodeHistory := nodeMetricsHistoryResponse(nil, "kind-worker", health)
+	nodeHistory := nodeMetricsHistoryResponse(context.Background(), nil, "kind-worker", health)
 	if nodeHistory.CollectionError != health.NodeMetrics.LastError {
 		t.Fatalf("node collection error = %q, want %q", nodeHistory.CollectionError, health.NodeMetrics.LastError)
 	}
 	if nodeHistory.RawCollectionError != "" {
 		t.Fatalf("node raw collection error = %q, want empty", nodeHistory.RawCollectionError)
+	}
+	if nodeHistory.MetricsUnavailableDiagnosis != "" {
+		t.Fatalf("node metrics unavailable diagnosis = %q, want empty", nodeHistory.MetricsUnavailableDiagnosis)
+	}
+}
+
+func TestMetricsAPIServiceDiagnosis(t *testing.T) {
+	tests := []struct {
+		name      string
+		condition map[string]any
+		want      string
+	}{
+		{
+			name: "available true points away from installation",
+			condition: map[string]any{
+				"type":   "Available",
+				"status": "True",
+			},
+			want: "The v1beta1.metrics.k8s.io APIService is Available, but metrics reads still fail. Check metrics-server logs and API aggregation errors.",
+		},
+		{
+			name: "available false includes reason",
+			condition: map[string]any{
+				"type":   "Available",
+				"status": "False",
+				"reason": "FailedDiscoveryCheck",
+			},
+			want: "The v1beta1.metrics.k8s.io APIService is not Available (FailedDiscoveryCheck). Check the metrics-server Service, endpoints, and API aggregation/TLS configuration.",
+		},
+		{
+			name: "available unknown includes reason",
+			condition: map[string]any{
+				"type":   "Available",
+				"status": "Unknown",
+				"reason": "ServiceNotFound",
+			},
+			want: "The v1beta1.metrics.k8s.io APIService is not Available (ServiceNotFound). Check the metrics-server Service, endpoints, and API aggregation/TLS configuration.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			apiService := &unstructured.Unstructured{Object: map[string]any{
+				"status": map[string]any{
+					"conditions": []any{tt.condition},
+				},
+			}}
+			if got := metricsAPIServiceDiagnosis(apiService); got != tt.want {
+				t.Fatalf("metricsAPIServiceDiagnosis() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/server/server_smoke_test.go
+++ b/internal/server/server_smoke_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -1010,6 +1011,43 @@ func TestSmokeMetricsNilDynamicClient(t *testing.T) {
 			var body map[string]any
 			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 				t.Fatalf("expected valid JSON response (not a panic), got decode error: %v (status=%d)", err, resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestIsMetricsAPIUnavailable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "bare metrics API absence from apiserver",
+			err:  errors.New("failed to get node metrics: the server could not find the requested resource"),
+			want: true,
+		},
+		{
+			name: "metrics not found",
+			err:  errors.New(`failed to get pod metrics: pods.metrics.k8s.io "api" not found`),
+			want: true,
+		},
+		{
+			name: "non-metrics missing resource stays visible",
+			err:  errors.New("the server could not find the requested resource"),
+			want: false,
+		},
+		{
+			name: "metrics forbidden stays visible",
+			err:  errors.New("failed to get node metrics: forbidden"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMetricsAPIUnavailable(tt.err); got != tt.want {
+				t.Fatalf("isMetricsAPIUnavailable() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/server/server_smoke_test.go
+++ b/internal/server/server_smoke_test.go
@@ -1058,6 +1058,11 @@ func TestIsMetricsAPIUnavailable(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "metrics APIService unavailable",
+			err:  errors.New(`failed to get pod metrics: the server is currently unable to handle the request (get pods.metrics.k8s.io)`),
+			want: true,
+		},
+		{
 			name: "non-metrics missing resource stays visible",
 			err:  errors.New("the server could not find the requested resource"),
 			want: false,
@@ -1105,6 +1110,9 @@ func TestMetricsHistoryResponseCarriesCollectionErrorWithBufferedHistory(t *test
 	if podHistory.CollectionError != "Pod metrics not found (metrics-server may not be installed)" {
 		t.Fatalf("pod collection error = %q", podHistory.CollectionError)
 	}
+	if podHistory.RawCollectionError != health.PodMetrics.LastError {
+		t.Fatalf("pod raw collection error = %q, want %q", podHistory.RawCollectionError, health.PodMetrics.LastError)
+	}
 
 	nodeHistory := nodeMetricsHistoryResponse(&k8s.NodeMetricsHistory{
 		Name: "kind-worker",
@@ -1116,6 +1124,9 @@ func TestMetricsHistoryResponseCarriesCollectionErrorWithBufferedHistory(t *test
 	}, "kind-worker", health)
 	if nodeHistory.CollectionError != "Node metrics not found (metrics-server may not be installed)" {
 		t.Fatalf("node collection error = %q", nodeHistory.CollectionError)
+	}
+	if nodeHistory.RawCollectionError != health.NodeMetrics.LastError {
+		t.Fatalf("node raw collection error = %q, want %q", nodeHistory.RawCollectionError, health.NodeMetrics.LastError)
 	}
 }
 
@@ -1135,10 +1146,16 @@ func TestMetricsHistoryResponseKeepsNonAbsenceCollectionErrors(t *testing.T) {
 	if podHistory.CollectionError != health.PodMetrics.LastError {
 		t.Fatalf("pod collection error = %q, want %q", podHistory.CollectionError, health.PodMetrics.LastError)
 	}
+	if podHistory.RawCollectionError != "" {
+		t.Fatalf("pod raw collection error = %q, want empty", podHistory.RawCollectionError)
+	}
 
 	nodeHistory := nodeMetricsHistoryResponse(nil, "kind-worker", health)
 	if nodeHistory.CollectionError != health.NodeMetrics.LastError {
 		t.Fatalf("node collection error = %q, want %q", nodeHistory.CollectionError, health.NodeMetrics.LastError)
+	}
+	if nodeHistory.RawCollectionError != "" {
+		t.Fatalf("node raw collection error = %q, want empty", nodeHistory.RawCollectionError)
 	}
 }
 

--- a/internal/server/server_smoke_test.go
+++ b/internal/server/server_smoke_test.go
@@ -1124,6 +1124,9 @@ func TestMetricsHistoryResponseCarriesCollectionErrorWithBufferedHistory(t *test
 	if podHistory.RawCollectionError != health.PodMetrics.LastError {
 		t.Fatalf("pod raw collection error = %q, want %q", podHistory.RawCollectionError, health.PodMetrics.LastError)
 	}
+	if !podHistory.MetricsUnavailable {
+		t.Fatalf("pod metrics unavailable = false, want true")
+	}
 
 	nodeHistory := nodeMetricsHistoryResponse(context.Background(), &k8s.NodeMetricsHistory{
 		Name: "kind-worker",
@@ -1138,6 +1141,9 @@ func TestMetricsHistoryResponseCarriesCollectionErrorWithBufferedHistory(t *test
 	}
 	if nodeHistory.RawCollectionError != health.NodeMetrics.LastError {
 		t.Fatalf("node raw collection error = %q, want %q", nodeHistory.RawCollectionError, health.NodeMetrics.LastError)
+	}
+	if !nodeHistory.MetricsUnavailable {
+		t.Fatalf("node metrics unavailable = false, want true")
 	}
 }
 
@@ -1163,6 +1169,9 @@ func TestMetricsHistoryResponseKeepsNonAbsenceCollectionErrors(t *testing.T) {
 	if podHistory.MetricsUnavailableDiagnosis != "" {
 		t.Fatalf("pod metrics unavailable diagnosis = %q, want empty", podHistory.MetricsUnavailableDiagnosis)
 	}
+	if podHistory.MetricsUnavailable {
+		t.Fatalf("pod metrics unavailable = true, want false")
+	}
 
 	nodeHistory := nodeMetricsHistoryResponse(context.Background(), nil, "kind-worker", health, true)
 	if nodeHistory.CollectionError != health.NodeMetrics.LastError {
@@ -1173,6 +1182,9 @@ func TestMetricsHistoryResponseKeepsNonAbsenceCollectionErrors(t *testing.T) {
 	}
 	if nodeHistory.MetricsUnavailableDiagnosis != "" {
 		t.Fatalf("node metrics unavailable diagnosis = %q, want empty", nodeHistory.MetricsUnavailableDiagnosis)
+	}
+	if nodeHistory.MetricsUnavailable {
+		t.Fatalf("node metrics unavailable = true, want false")
 	}
 }
 

--- a/internal/server/server_smoke_test.go
+++ b/internal/server/server_smoke_test.go
@@ -19,11 +19,16 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/skyhook-io/radar/internal/k8s"
 	"github.com/skyhook-io/radar/internal/timeline"
@@ -1107,7 +1112,7 @@ func TestMetricsHistoryResponseCarriesCollectionErrorWithBufferedHistory(t *test
 				Memory:    268435456,
 			}},
 		}},
-	}, "default", "api", health)
+	}, "default", "api", health, true)
 	if podHistory.CollectionError != "Pod metrics not found (metrics-server may not be installed)" {
 		t.Fatalf("pod collection error = %q", podHistory.CollectionError)
 	}
@@ -1122,7 +1127,7 @@ func TestMetricsHistoryResponseCarriesCollectionErrorWithBufferedHistory(t *test
 			CPU:       100000000,
 			Memory:    268435456,
 		}},
-	}, "kind-worker", health)
+	}, "kind-worker", health, true)
 	if nodeHistory.CollectionError != "Node metrics not found (metrics-server may not be installed)" {
 		t.Fatalf("node collection error = %q", nodeHistory.CollectionError)
 	}
@@ -1143,7 +1148,7 @@ func TestMetricsHistoryResponseKeepsNonAbsenceCollectionErrors(t *testing.T) {
 		},
 	}
 
-	podHistory := podMetricsHistoryResponse(context.Background(), nil, "default", "api", health)
+	podHistory := podMetricsHistoryResponse(context.Background(), nil, "default", "api", health, true)
 	if podHistory.CollectionError != health.PodMetrics.LastError {
 		t.Fatalf("pod collection error = %q, want %q", podHistory.CollectionError, health.PodMetrics.LastError)
 	}
@@ -1154,7 +1159,7 @@ func TestMetricsHistoryResponseKeepsNonAbsenceCollectionErrors(t *testing.T) {
 		t.Fatalf("pod metrics unavailable diagnosis = %q, want empty", podHistory.MetricsUnavailableDiagnosis)
 	}
 
-	nodeHistory := nodeMetricsHistoryResponse(context.Background(), nil, "kind-worker", health)
+	nodeHistory := nodeMetricsHistoryResponse(context.Background(), nil, "kind-worker", health, true)
 	if nodeHistory.CollectionError != health.NodeMetrics.LastError {
 		t.Fatalf("node collection error = %q, want %q", nodeHistory.CollectionError, health.NodeMetrics.LastError)
 	}
@@ -1190,6 +1195,34 @@ func TestMetricsAPIServiceDiagnosis(t *testing.T) {
 			want: "The v1beta1.metrics.k8s.io APIService is not Available (FailedDiscoveryCheck). Check the metrics-server Service, endpoints, and API aggregation/TLS configuration.",
 		},
 		{
+			name: "available false includes compact condition message",
+			condition: map[string]any{
+				"type":    "Available",
+				"status":  "False",
+				"reason":  "FailedDiscoveryCheck",
+				"message": "failing or missing response from https://10.96.142.7:443/apis/metrics.k8s.io/v1beta1: Get \"https://10.96.142.7\": connect: connection refused",
+			},
+			want: "The v1beta1.metrics.k8s.io APIService is not Available (FailedDiscoveryCheck): failing or missing response from https://10.96.142.7:443/apis/metrics.k8s.io/v1beta1: Get \"https://10.96.142.7\": connect: connection refused. Check the metrics-server Service, endpoints, and API aggregation/TLS configuration.",
+		},
+		{
+			name: "available false preserves ellipsis in condition message",
+			condition: map[string]any{
+				"type":    "Available",
+				"status":  "False",
+				"message": "timed out waiting...",
+			},
+			want: "The v1beta1.metrics.k8s.io APIService is not Available: timed out waiting... Check the metrics-server Service, endpoints, and API aggregation/TLS configuration.",
+		},
+		{
+			name: "available false trims dangling condition punctuation",
+			condition: map[string]any{
+				"type":    "Available",
+				"status":  "False",
+				"message": "connection refused:",
+			},
+			want: "The v1beta1.metrics.k8s.io APIService is not Available: connection refused. Check the metrics-server Service, endpoints, and API aggregation/TLS configuration.",
+		},
+		{
 			name: "available unknown includes reason",
 			condition: map[string]any{
 				"type":   "Available",
@@ -1207,11 +1240,189 @@ func TestMetricsAPIServiceDiagnosis(t *testing.T) {
 					"conditions": []any{tt.condition},
 				},
 			}}
-			if got := metricsAPIServiceDiagnosis(apiService); got != tt.want {
+			if got := metricsAPIServiceDiagnosis(apiService, true); got != tt.want {
 				t.Fatalf("metricsAPIServiceDiagnosis() = %q, want %q", got, tt.want)
 			}
 		})
 	}
+}
+
+func TestMetricsAPIServiceDiagnosisCanHideConditionMessage(t *testing.T) {
+	apiService := &unstructured.Unstructured{Object: map[string]any{
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{
+					"type":    "Available",
+					"status":  "False",
+					"reason":  "FailedDiscoveryCheck",
+					"message": "failing or missing response from https://10.96.142.7:443/apis/metrics.k8s.io/v1beta1",
+				},
+			},
+		},
+	}}
+	want := "The v1beta1.metrics.k8s.io APIService is not Available (FailedDiscoveryCheck). Check the metrics-server Service, endpoints, and API aggregation/TLS configuration."
+	if got := metricsAPIServiceDiagnosis(apiService, false); got != want {
+		t.Fatalf("metricsAPIServiceDiagnosis() = %q, want %q", got, want)
+	}
+}
+
+func TestMetricsAPIServiceDiagnosisWithoutAvailableCondition(t *testing.T) {
+	apiService := &unstructured.Unstructured{Object: map[string]any{
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{"type": "ServiceHealthy", "status": "True"},
+			},
+		},
+	}}
+	want := "The v1beta1.metrics.k8s.io APIService exists but has no Available condition. Check metrics-server and API aggregation status."
+	if got := metricsAPIServiceDiagnosis(apiService, true); got != want {
+		t.Fatalf("metricsAPIServiceDiagnosis() = %q, want %q", got, want)
+	}
+}
+
+func TestMetricsAPIServiceLookupDiagnosisWhenMissing(t *testing.T) {
+	err := apierrors.NewNotFound(schema.GroupResource{Group: metricsAPIServiceGroup, Resource: "apiservices"}, metricsAPIServiceName)
+	want := "The v1beta1.metrics.k8s.io APIService is not registered. Install metrics-server or restore that APIService."
+	if got := metricsAPIServiceLookupDiagnosis(nil, err, true); got != want {
+		t.Fatalf("metricsAPIServiceLookupDiagnosis() = %q, want %q", got, want)
+	}
+}
+
+func TestMetricsUnavailableDiagnosisWhenAPIServiceMissing(t *testing.T) {
+	resetMetricsAPIServiceDiagnosisMemoForTest(t)
+	defer k8s.ResetTestDynamicState()
+
+	gvr := schema.GroupVersionResource{Group: metricsAPIServiceGroup, Version: "v1", Resource: "apiservices"}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "APIServiceList"},
+	)
+	if err := k8s.InitTestDynamicResourceCache(dyn, []k8s.APIResource{{
+		Group:      metricsAPIServiceGroup,
+		Version:    "v1",
+		Kind:       metricsAPIServiceKind,
+		Name:       "apiservices",
+		Namespaced: false,
+	}}); err != nil {
+		t.Fatalf("InitTestDynamicResourceCache: %v", err)
+	}
+
+	want := "The v1beta1.metrics.k8s.io APIService is not registered. Install metrics-server or restore that APIService."
+	if got := metricsUnavailableDiagnosis(context.Background(), true); got != want {
+		t.Fatalf("metricsUnavailableDiagnosis() = %q, want %q", got, want)
+	}
+}
+
+func TestMetricsUnavailableDiagnosisMemoizesAPIServiceLookup(t *testing.T) {
+	resetMetricsAPIServiceDiagnosisMemoForTest(t)
+	defer k8s.ResetTestDynamicState()
+
+	gvr := schema.GroupVersionResource{Group: metricsAPIServiceGroup, Version: "v1", Resource: "apiservices"}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "APIServiceList"},
+	)
+	gets := 0
+	dyn.Fake.PrependReactor("get", "apiservices", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		gets++
+		return false, nil, nil
+	})
+	if err := k8s.InitTestDynamicResourceCache(dyn, []k8s.APIResource{{
+		Group:      metricsAPIServiceGroup,
+		Version:    "v1",
+		Kind:       metricsAPIServiceKind,
+		Name:       "apiservices",
+		Namespaced: false,
+	}}); err != nil {
+		t.Fatalf("InitTestDynamicResourceCache: %v", err)
+	}
+
+	for range 2 {
+		if got := metricsUnavailableDiagnosis(context.Background(), true); got == "" {
+			t.Fatalf("metricsUnavailableDiagnosis() returned empty diagnosis")
+		}
+	}
+	if gets != 1 {
+		t.Fatalf("APIService GET count = %d, want 1", gets)
+	}
+}
+
+func TestMetricsUnavailableDiagnosisMemoizesByConditionDetailFlag(t *testing.T) {
+	resetMetricsAPIServiceDiagnosisMemoForTest(t)
+	defer k8s.ResetTestDynamicState()
+
+	gvr := schema.GroupVersionResource{Group: metricsAPIServiceGroup, Version: "v1", Resource: "apiservices"}
+	apiService := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apiregistration.k8s.io/v1",
+		"kind":       metricsAPIServiceKind,
+		"metadata": map[string]any{
+			"name": metricsAPIServiceName,
+		},
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{
+					"type":    "Available",
+					"status":  "False",
+					"reason":  "FailedDiscoveryCheck",
+					"message": "failing or missing response from https://10.96.142.7:443/apis/metrics.k8s.io/v1beta1",
+				},
+			},
+		},
+	}}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "APIServiceList"},
+		apiService,
+	)
+	gets := 0
+	dyn.Fake.PrependReactor("get", "apiservices", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		gets++
+		return false, nil, nil
+	})
+	if err := k8s.InitTestDynamicResourceCache(dyn, []k8s.APIResource{{
+		Group:      metricsAPIServiceGroup,
+		Version:    "v1",
+		Kind:       metricsAPIServiceKind,
+		Name:       "apiservices",
+		Namespaced: false,
+	}}); err != nil {
+		t.Fatalf("InitTestDynamicResourceCache: %v", err)
+	}
+
+	detailed := metricsUnavailableDiagnosis(context.Background(), true)
+	if !strings.Contains(detailed, "10.96.142.7") {
+		t.Fatalf("detailed diagnosis = %q, want condition message", detailed)
+	}
+	redacted := metricsUnavailableDiagnosis(context.Background(), false)
+	if strings.Contains(redacted, "10.96.142.7") {
+		t.Fatalf("redacted diagnosis leaked condition message: %q", redacted)
+	}
+
+	_ = metricsUnavailableDiagnosis(context.Background(), true)
+	_ = metricsUnavailableDiagnosis(context.Background(), false)
+	if gets != 2 {
+		t.Fatalf("APIService GET count = %d, want 2 for two memo detail slots", gets)
+	}
+}
+
+func resetMetricsAPIServiceDiagnosisMemoForTest(t *testing.T) {
+	t.Helper()
+	metricsAPIServiceDiagnosisMemo.mu.Lock()
+	metricsAPIServiceDiagnosisMemo.entries = nil
+	metricsAPIServiceDiagnosisMemo.mu.Unlock()
+
+	metricsAPIServiceDiagnosisMemo.logMu.Lock()
+	metricsAPIServiceDiagnosisMemo.loggedErrors = nil
+	metricsAPIServiceDiagnosisMemo.logMu.Unlock()
+	t.Cleanup(func() {
+		metricsAPIServiceDiagnosisMemo.mu.Lock()
+		metricsAPIServiceDiagnosisMemo.entries = nil
+		metricsAPIServiceDiagnosisMemo.mu.Unlock()
+
+		metricsAPIServiceDiagnosisMemo.logMu.Lock()
+		metricsAPIServiceDiagnosisMemo.loggedErrors = nil
+		metricsAPIServiceDiagnosisMemo.logMu.Unlock()
+	})
 }
 
 // --- Settings & Config endpoints ---

--- a/internal/server/server_smoke_test.go
+++ b/internal/server/server_smoke_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -1361,6 +1362,95 @@ func TestMetricsUnavailableDiagnosisMemoizesAPIServiceLookup(t *testing.T) {
 	}
 	if gets != 1 {
 		t.Fatalf("APIService GET count = %d, want 1", gets)
+	}
+}
+
+func TestMetricsUnavailableDiagnosisDoesNotMemoizeTransientAPIServiceLookupError(t *testing.T) {
+	resetMetricsAPIServiceDiagnosisMemoForTest(t)
+	defer k8s.ResetTestDynamicState()
+
+	gvr := schema.GroupVersionResource{Group: metricsAPIServiceGroup, Version: "v1", Resource: "apiservices"}
+	apiService := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apiregistration.k8s.io/v1",
+		"kind":       metricsAPIServiceKind,
+		"metadata": map[string]any{
+			"name": metricsAPIServiceName,
+		},
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{
+					"type":   "Available",
+					"status": "False",
+					"reason": "FailedDiscoveryCheck",
+				},
+			},
+		},
+	}}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "APIServiceList"},
+		apiService,
+	)
+	gets := 0
+	dyn.Fake.PrependReactor("get", "apiservices", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		gets++
+		if gets == 1 {
+			return true, nil, fmt.Errorf("temporary apiservice lookup failure")
+		}
+		return false, nil, nil
+	})
+	if err := k8s.InitTestDynamicResourceCache(dyn, []k8s.APIResource{{
+		Group:      metricsAPIServiceGroup,
+		Version:    "v1",
+		Kind:       metricsAPIServiceKind,
+		Name:       "apiservices",
+		Namespaced: false,
+	}}); err != nil {
+		t.Fatalf("InitTestDynamicResourceCache: %v", err)
+	}
+
+	if got := metricsUnavailableDiagnosis(context.Background(), true); got != "" {
+		t.Fatalf("first metricsUnavailableDiagnosis() = %q, want empty transient diagnosis", got)
+	}
+	if got := metricsUnavailableDiagnosis(context.Background(), true); got == "" {
+		t.Fatalf("second metricsUnavailableDiagnosis() returned empty diagnosis after transient error")
+	}
+	if gets != 2 {
+		t.Fatalf("APIService GET count = %d, want 2", gets)
+	}
+}
+
+func TestMetricsAPIServiceDiagnosisCacheDoesNotOverwriteDifferentContext(t *testing.T) {
+	cache := metricsAPIServiceDiagnosisCache{ttl: time.Minute}
+	startedA := make(chan struct{})
+	releaseA := make(chan struct{})
+	resultA := make(chan string, 1)
+
+	go func() {
+		resultA <- cache.get("ctx-a", true, func() (string, bool) {
+			close(startedA)
+			<-releaseA
+			return "ctx-a diagnosis", true
+		})
+	}()
+
+	<-startedA
+	if got := cache.get("ctx-b", true, func() (string, bool) {
+		return "ctx-b diagnosis", true
+	}); got != "ctx-b diagnosis" {
+		t.Fatalf("ctx-b diagnosis = %q, want ctx-b diagnosis", got)
+	}
+
+	close(releaseA)
+	if got := <-resultA; got != "ctx-a diagnosis" {
+		t.Fatalf("ctx-a diagnosis = %q, want ctx-a diagnosis", got)
+	}
+
+	if got := cache.get("ctx-b", true, func() (string, bool) {
+		t.Fatal("ctx-b cache entry was overwritten by ctx-a")
+		return "", false
+	}); got != "ctx-b diagnosis" {
+		t.Fatalf("cached ctx-b diagnosis = %q, want ctx-b diagnosis", got)
 	}
 }
 

--- a/internal/server/server_smoke_test.go
+++ b/internal/server/server_smoke_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/skyhook-io/radar/internal/k8s"
 	"github.com/skyhook-io/radar/internal/timeline"
+	"github.com/skyhook-io/radar/pkg/k8score"
 )
 
 var (
@@ -1022,7 +1023,7 @@ func TestSmokeMetricsNilDynamicClient(t *testing.T) {
 	}
 }
 
-func TestIsMetricsAPIUnavailable(t *testing.T) {
+func TestMetricsAPIUnavailable(t *testing.T) {
 	// These cases cover typed Kubernetes API errors first, then message shapes
 	// emitted by apimachinery discovery/restmapper, kubectl top-style metrics
 	// failures, and API aggregation 503s. Keep broad phrases gated by a
@@ -1086,8 +1087,8 @@ func TestIsMetricsAPIUnavailable(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isMetricsAPIUnavailable(tt.err); got != tt.want {
-				t.Fatalf("isMetricsAPIUnavailable() = %v, want %v", got, tt.want)
+			if got := k8score.MetricsAPIUnavailable(tt.err); got != tt.want {
+				t.Fatalf("MetricsAPIUnavailable() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -1414,18 +1415,10 @@ func resetMetricsAPIServiceDiagnosisMemoForTest(t *testing.T) {
 	metricsAPIServiceDiagnosisMemo.mu.Lock()
 	metricsAPIServiceDiagnosisMemo.entries = nil
 	metricsAPIServiceDiagnosisMemo.mu.Unlock()
-
-	metricsAPIServiceDiagnosisMemo.logMu.Lock()
-	metricsAPIServiceDiagnosisMemo.loggedErrors = nil
-	metricsAPIServiceDiagnosisMemo.logMu.Unlock()
 	t.Cleanup(func() {
 		metricsAPIServiceDiagnosisMemo.mu.Lock()
 		metricsAPIServiceDiagnosisMemo.entries = nil
 		metricsAPIServiceDiagnosisMemo.mu.Unlock()
-
-		metricsAPIServiceDiagnosisMemo.logMu.Lock()
-		metricsAPIServiceDiagnosisMemo.loggedErrors = nil
-		metricsAPIServiceDiagnosisMemo.logMu.Unlock()
 	})
 }
 

--- a/packages/k8s-ui/src/components/resources/renderers/MetricsUnavailableNotice.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/MetricsUnavailableNotice.tsx
@@ -9,8 +9,8 @@ interface MetricsUnavailableNoticeProps {
 export function MetricsUnavailableNotice({ rawError, diagnosis }: MetricsUnavailableNoticeProps) {
   return (
     <div className="card-inner-lg text-xs text-theme-text-tertiary">
-      <div className="flex items-baseline gap-1.5">
-        <span className="min-w-0">
+      <div className="flex items-center gap-1.5">
+        <span className="min-w-0 leading-5">
           Metrics unavailable. Radar cannot read metrics.k8s.io.
         </span>
         {rawError && (
@@ -33,7 +33,7 @@ export function MetricsUnavailableNotice({ rawError, diagnosis }: MetricsUnavail
           >
             <button
               type="button"
-              className="inline-flex shrink-0 cursor-help items-center gap-1 text-[11px] font-medium leading-none text-theme-text-tertiary hover:text-theme-text-secondary"
+              className="inline-flex shrink-0 cursor-help items-center gap-1 text-xs font-medium leading-5 text-theme-text-tertiary hover:text-theme-text-secondary"
               aria-label="Metrics error details"
             >
               <Info className="h-3.5 w-3.5" />

--- a/packages/k8s-ui/src/components/resources/renderers/MetricsUnavailableNotice.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/MetricsUnavailableNotice.tsx
@@ -10,23 +10,20 @@ export function MetricsUnavailableNotice({ rawError }: MetricsUnavailableNoticeP
     <div className="card-inner-lg text-xs text-theme-text-tertiary">
       <div className="flex items-start gap-1.5">
         <span className="min-w-0">
-          Metrics unavailable. Radar could not read metrics.k8s.io. Install or repair metrics-server and its APIService to show live CPU and memory usage.
+          Metrics unavailable. Radar cannot read metrics.k8s.io.
         </span>
         {rawError && (
           <Tooltip
             content={(
               <span className="space-y-1">
                 <span className="block">
-                  This state only means Radar could not read Kubernetes metrics.k8s.io. Check the v1beta1.metrics.k8s.io APIService and metrics-server health.
+                  Check metrics-server and the metrics.k8s.io APIService.
                 </span>
                 <span className="block">
-                  On EKS or self-managed clusters, metrics-server may need to be installed. On managed platforms where it is bundled, check that it was not disabled or unhealthy.
+                  Prometheus is separate.
                 </span>
                 <span className="block">
-                  Prometheus is a separate metrics source; its availability does not make metrics.k8s.io available.
-                </span>
-                <span className="block">
-                  Raw metrics error: <span className="font-mono break-all">{rawError}</span>
+                  Raw error: <span className="font-mono break-words">{rawError}</span>
                 </span>
               </span>
             )}

--- a/packages/k8s-ui/src/components/resources/renderers/MetricsUnavailableNotice.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/MetricsUnavailableNotice.tsx
@@ -1,0 +1,49 @@
+import { Info } from 'lucide-react'
+import { Tooltip } from '../../ui/Tooltip'
+
+interface MetricsUnavailableNoticeProps {
+  rawError?: string
+}
+
+export function MetricsUnavailableNotice({ rawError }: MetricsUnavailableNoticeProps) {
+  return (
+    <div className="card-inner-lg text-xs text-theme-text-tertiary">
+      <div className="flex items-start gap-1.5">
+        <span className="min-w-0">
+          Metrics unavailable. Radar could not read metrics.k8s.io. Install or repair metrics-server and its APIService to show live CPU and memory usage.
+        </span>
+        {rawError && (
+          <Tooltip
+            content={(
+              <span className="space-y-1">
+                <span className="block">
+                  This state only means Radar could not read Kubernetes metrics.k8s.io. Check the v1beta1.metrics.k8s.io APIService and metrics-server health.
+                </span>
+                <span className="block">
+                  On EKS or self-managed clusters, metrics-server may need to be installed. On managed platforms where it is bundled, check that it was not disabled or unhealthy.
+                </span>
+                <span className="block">
+                  Prometheus is a separate metrics source; its availability does not make metrics.k8s.io available.
+                </span>
+                <span className="block">
+                  Raw metrics error: <span className="font-mono break-all">{rawError}</span>
+                </span>
+              </span>
+            )}
+            delay={150}
+            position="left"
+          >
+            <button
+              type="button"
+              className="mt-0.5 inline-flex shrink-0 cursor-help items-center gap-1 text-[11px] font-medium text-theme-text-tertiary hover:text-theme-text-secondary"
+              aria-label="Metrics error details"
+            >
+              <Info className="h-3.5 w-3.5" />
+              <span>Details</span>
+            </button>
+          </Tooltip>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/packages/k8s-ui/src/components/resources/renderers/MetricsUnavailableNotice.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/MetricsUnavailableNotice.tsx
@@ -9,7 +9,7 @@ interface MetricsUnavailableNoticeProps {
 export function MetricsUnavailableNotice({ rawError, diagnosis }: MetricsUnavailableNoticeProps) {
   return (
     <div className="card-inner-lg text-xs text-theme-text-tertiary">
-      <div className="flex items-start gap-1.5">
+      <div className="flex items-baseline gap-1.5">
         <span className="min-w-0">
           Metrics unavailable. Radar cannot read metrics.k8s.io.
         </span>
@@ -33,7 +33,7 @@ export function MetricsUnavailableNotice({ rawError, diagnosis }: MetricsUnavail
           >
             <button
               type="button"
-              className="mt-0.5 inline-flex shrink-0 cursor-help items-center gap-1 text-[11px] font-medium text-theme-text-tertiary hover:text-theme-text-secondary"
+              className="inline-flex shrink-0 cursor-help items-center gap-1 text-[11px] font-medium leading-none text-theme-text-tertiary hover:text-theme-text-secondary"
               aria-label="Metrics error details"
             >
               <Info className="h-3.5 w-3.5" />

--- a/packages/k8s-ui/src/components/resources/renderers/MetricsUnavailableNotice.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/MetricsUnavailableNotice.tsx
@@ -3,9 +3,10 @@ import { Tooltip } from '../../ui/Tooltip'
 
 interface MetricsUnavailableNoticeProps {
   rawError?: string
+  diagnosis?: string
 }
 
-export function MetricsUnavailableNotice({ rawError }: MetricsUnavailableNoticeProps) {
+export function MetricsUnavailableNotice({ rawError, diagnosis }: MetricsUnavailableNoticeProps) {
   return (
     <div className="card-inner-lg text-xs text-theme-text-tertiary">
       <div className="flex items-start gap-1.5">
@@ -20,7 +21,7 @@ export function MetricsUnavailableNotice({ rawError }: MetricsUnavailableNoticeP
                   This panel uses Kubernetes metrics.k8s.io for live CPU and memory; Prometheus data does not fill it.
                 </span>
                 <span className="block">
-                  Check that metrics-server is installed and healthy, and that the v1beta1.metrics.k8s.io APIService is Available.
+                  {diagnosis || 'Check that metrics-server is installed and healthy, and that the v1beta1.metrics.k8s.io APIService is Available.'}
                 </span>
                 <span className="block">
                   Raw error: <span className="font-mono break-words">{rawError}</span>

--- a/packages/k8s-ui/src/components/resources/renderers/MetricsUnavailableNotice.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/MetricsUnavailableNotice.tsx
@@ -17,10 +17,10 @@ export function MetricsUnavailableNotice({ rawError }: MetricsUnavailableNoticeP
             content={(
               <span className="space-y-1">
                 <span className="block">
-                  Check metrics-server and the metrics.k8s.io APIService.
+                  This panel uses Kubernetes metrics.k8s.io for live CPU and memory; Prometheus data does not fill it.
                 </span>
                 <span className="block">
-                  Prometheus is separate.
+                  Check that metrics-server is installed and healthy, and that the v1beta1.metrics.k8s.io APIService is Available.
                 </span>
                 <span className="block">
                   Raw error: <span className="font-mono break-words">{rawError}</span>

--- a/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.test.tsx
@@ -26,12 +26,18 @@ describe('NodeRenderer metrics', () => {
       <NodeRenderer
         data={node}
         metricsUnavailable
+        metricsHistory={{
+          dataPoints: [],
+          metricsUnavailableReason: 'the server could not find the requested resource',
+        }}
       />,
     )
 
     expect(html).toContain('Resource Usage')
     expect(html).toContain('Metrics unavailable')
-    expect(html).toContain('Install metrics-server')
+    expect(html).toContain('Radar could not read metrics.k8s.io')
+    expect(html).toContain('Install or repair metrics-server and its APIService')
+    expect(html).toContain('Metrics error details')
     expect(html).not.toContain('Metrics collection error')
     expect(html).not.toContain('Collecting metrics data')
   })
@@ -76,5 +82,21 @@ describe('NodeRenderer metrics', () => {
 
     expect(html).toContain('Metrics collection error')
     expect(html).toContain('forbidden: no access to nodes')
+  })
+
+  it('warns about non-absence collection errors even when historical samples exist', () => {
+    const html = renderToString(
+      <NodeRenderer
+        data={node}
+        metricsHistory={{
+          collectionError: 'forbidden: no access to nodes',
+          dataPoints: [{ timestamp: '2026-06-30T00:00:00Z', cpu: 100000000, memory: 268435456 }],
+        }}
+      />,
+    )
+
+    expect(html).toContain('Metrics collection error')
+    expect(html).toContain('forbidden: no access to nodes')
+    expect(html).toContain('CPU')
   })
 })

--- a/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.test.tsx
@@ -35,9 +35,9 @@ describe('NodeRenderer metrics', () => {
 
     expect(html).toContain('Resource Usage')
     expect(html).toContain('Metrics unavailable')
-    expect(html).toContain('Radar could not read metrics.k8s.io')
-    expect(html).toContain('Install or repair metrics-server and its APIService')
+    expect(html).toContain('Radar cannot read metrics.k8s.io')
     expect(html).toContain('Metrics error details')
+    expect(html).not.toContain('Install or repair metrics-server and its APIService')
     expect(html).not.toContain('Metrics collection error')
     expect(html).not.toContain('Collecting metrics data')
   })

--- a/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.test.tsx
@@ -50,6 +50,22 @@ describe('NodeRenderer metrics', () => {
     expect(html).not.toContain('Last updated')
   })
 
+  it('does not let stale historical metrics hide an unavailable state', () => {
+    const html = renderToString(
+      <NodeRenderer
+        data={node}
+        metricsUnavailable
+        metricsHistory={{
+          dataPoints: [{ timestamp: '2026-06-30T00:00:00Z', cpu: 100000000, memory: 268435456 }],
+        }}
+      />,
+    )
+
+    expect(html).toContain('Metrics unavailable')
+    expect(html).not.toContain('100m')
+    expect(html).not.toContain('256 MiB')
+  })
+
   it('keeps non-absence collection errors visible', () => {
     const html = renderToString(
       <NodeRenderer

--- a/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.test.tsx
@@ -36,6 +36,20 @@ describe('NodeRenderer metrics', () => {
     expect(html).not.toContain('Collecting metrics data')
   })
 
+  it('does not let stale live metrics hide an unavailable state', () => {
+    const html = renderToString(
+      <NodeRenderer
+        data={node}
+        metricsUnavailable
+        metrics={{ usage: { cpu: '100m', memory: '256Mi' }, timestamp: '2026-06-30T00:00:00Z' }}
+      />,
+    )
+
+    expect(html).toContain('Metrics unavailable')
+    expect(html).not.toContain('100m')
+    expect(html).not.toContain('Last updated')
+  })
+
   it('keeps non-absence collection errors visible', () => {
     const html = renderToString(
       <NodeRenderer

--- a/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import { NodeRenderer } from './NodeRenderer'
+
+const node = {
+  metadata: { name: 'kind-worker', labels: {} },
+  spec: {},
+  status: {
+    nodeInfo: {
+      osImage: 'Container-Optimized OS',
+      architecture: 'amd64',
+      kernelVersion: '6.1.0',
+      containerRuntimeVersion: 'containerd://1.7',
+      kubeletVersion: 'v1.33.0',
+      kubeProxyVersion: 'v1.33.0',
+    },
+    capacity: { cpu: '4', memory: '8Gi', pods: '110' },
+    allocatable: { cpu: '4', memory: '7Gi', pods: '110' },
+    conditions: [],
+  },
+}
+
+describe('NodeRenderer metrics', () => {
+  it('renders a calm unavailable state when metrics-server is absent', () => {
+    const html = renderToString(
+      <NodeRenderer
+        data={node}
+        metricsUnavailable
+      />,
+    )
+
+    expect(html).toContain('Resource Usage')
+    expect(html).toContain('Metrics unavailable')
+    expect(html).toContain('Install metrics-server')
+    expect(html).not.toContain('Metrics collection error')
+    expect(html).not.toContain('Collecting metrics data')
+  })
+
+  it('keeps non-absence collection errors visible', () => {
+    const html = renderToString(
+      <NodeRenderer
+        data={node}
+        metricsHistory={{ dataPoints: [], collectionError: 'forbidden: no access to nodes' }}
+      />,
+    )
+
+    expect(html).toContain('Metrics collection error')
+    expect(html).toContain('forbidden: no access to nodes')
+  })
+})

--- a/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.test.tsx
@@ -56,7 +56,7 @@ describe('NodeRenderer metrics', () => {
     expect(html).not.toContain('Last updated')
   })
 
-  it('does not let stale historical metrics hide an unavailable state', () => {
+  it('keeps buffered historical charts visible under an unavailable notice', () => {
     const html = renderToString(
       <NodeRenderer
         data={node}
@@ -68,8 +68,9 @@ describe('NodeRenderer metrics', () => {
     )
 
     expect(html).toContain('Metrics unavailable')
-    expect(html).not.toContain('100m')
-    expect(html).not.toContain('256 MiB')
+    expect(html).toContain('CPU')
+    expect(html).toContain('Memory')
+    expect(html).not.toContain('Last updated')
   })
 
   it('keeps non-absence collection errors visible', () => {

--- a/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.tsx
@@ -76,7 +76,8 @@ export function NodeRenderer({ data, relationships, onViewPods, metrics, metrics
   const hasProblems = problems.length > 0
   const isCordoned = !!spec.unschedulable
   const hasMetricsHistory = !!metricsHistory?.dataPoints?.length
-  const showMetricsUnavailable = !!metricsUnavailable && !metrics?.usage && !hasMetricsHistory && !metricsHistory?.collectionError
+  const showMetricsUnavailable = !!metricsUnavailable && !hasMetricsHistory && !metricsHistory?.collectionError
+  const currentMetrics = metricsUnavailable ? undefined : metrics
 
   // Extract platform info from labels
   const instanceType = labels['node.kubernetes.io/instance-type']
@@ -125,13 +126,13 @@ export function NodeRenderer({ data, relationships, onViewPods, metrics, metrics
               label: 'CPU',
               capacity: capacity.cpu,
               allocatable: allocatable.cpu,
-              inUse: metrics?.usage?.cpu,
+              inUse: currentMetrics?.usage?.cpu,
             },
             {
               label: 'Memory',
               capacity: formatMemory(capacity.memory),
               allocatable: formatMemory(allocatable.memory),
-              inUse: metrics?.usage?.memory ? formatMemory(metrics.usage.memory) : undefined,
+              inUse: currentMetrics?.usage?.memory ? formatMemory(currentMetrics.usage.memory) : undefined,
             },
             {
               label: 'Pods',
@@ -185,7 +186,7 @@ export function NodeRenderer({ data, relationships, onViewPods, metrics, metrics
       </Section>
 
       {/* Resource Usage (from metrics-server) — hidden when Prometheus has CPU/memory data */}
-      {!hideMetricsServer && (metrics?.usage || hasMetricsHistory || metricsHistory?.collectionError || showMetricsUnavailable) && (
+      {!hideMetricsServer && (currentMetrics?.usage || hasMetricsHistory || metricsHistory?.collectionError || showMetricsUnavailable) && (
         <Section title="Resource Usage" icon={Activity} defaultExpanded>
           {showMetricsUnavailable && (
             <div className="card-inner-lg text-xs text-theme-text-tertiary">
@@ -232,7 +233,7 @@ export function NodeRenderer({ data, relationships, onViewPods, metrics, metrics
                 />
               </div>
             </div>
-          ) : metrics?.usage ? (
+          ) : showMetricsUnavailable ? null : currentMetrics?.usage ? (
             /* Fallback to simple display if no history yet */
             <div className="space-y-3">
               <div className="card-inner-lg">
@@ -240,7 +241,7 @@ export function NodeRenderer({ data, relationships, onViewPods, metrics, metrics
                   <span className="text-sm font-medium text-theme-text-primary">CPU</span>
                 </div>
                 <div className="flex items-baseline gap-2">
-                  <span className="text-lg font-medium text-blue-400">{metrics.usage.cpu}</span>
+                  <span className="text-lg font-medium text-blue-400">{currentMetrics.usage.cpu}</span>
                   <span className="text-sm text-theme-text-tertiary">
                     / {allocatable.cpu || capacity.cpu || '?'} allocatable
                   </span>
@@ -251,19 +252,19 @@ export function NodeRenderer({ data, relationships, onViewPods, metrics, metrics
                   <span className="text-sm font-medium text-theme-text-primary">Memory</span>
                 </div>
                 <div className="flex items-baseline gap-2">
-                  <span className="text-lg font-medium text-purple-400">{formatMemory(metrics.usage.memory)}</span>
+                  <span className="text-lg font-medium text-purple-400">{formatMemory(currentMetrics.usage.memory)}</span>
                   <span className="text-sm text-theme-text-tertiary">
                     / {formatMemory(allocatable.memory) || formatMemory(capacity.memory) || '?'} allocatable
                   </span>
                 </div>
               </div>
             </div>
-          ) : showMetricsUnavailable ? null : (
+          ) : (
             <div className="text-xs text-theme-text-tertiary">Collecting metrics data...</div>
           )}
-          {metrics?.timestamp && (
+          {!showMetricsUnavailable && currentMetrics?.timestamp && (
             <div className="mt-2 text-xs text-theme-text-tertiary">
-              Last updated: {new Date(metrics.timestamp).toLocaleTimeString()}
+              Last updated: {new Date(currentMetrics.timestamp).toLocaleTimeString()}
             </div>
           )}
         </Section>

--- a/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.tsx
@@ -75,8 +75,8 @@ export function NodeRenderer({ data, relationships, onViewPods, metrics, metrics
   const problems = getNodeProblems(data)
   const hasProblems = problems.length > 0
   const isCordoned = !!spec.unschedulable
-  const hasMetricsHistory = !!metricsHistory?.dataPoints?.length
-  const showMetricsUnavailable = !!metricsUnavailable && !hasMetricsHistory && !metricsHistory?.collectionError
+  const showMetricsUnavailable = !!metricsUnavailable && !metricsHistory?.collectionError
+  const hasMetricsHistory = !showMetricsUnavailable && !!metricsHistory?.dataPoints?.length
   const currentMetrics = metricsUnavailable ? undefined : metrics
 
   // Extract platform info from labels
@@ -199,7 +199,7 @@ export function NodeRenderer({ data, relationships, onViewPods, metrics, metrics
               <span className="break-all">{metricsHistory.collectionError}</span>
             </div>
           )}
-          {metricsHistory?.dataPoints && metricsHistory.dataPoints.length > 0 ? (
+          {!showMetricsUnavailable && metricsHistory?.dataPoints && metricsHistory.dataPoints.length > 0 ? (
             <div className="space-y-4">
               {/* CPU Usage with Chart */}
               <div className="card-inner-lg">

--- a/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.tsx
@@ -77,7 +77,7 @@ export function NodeRenderer({ data, relationships, onViewPods, metrics, metrics
   const hasProblems = problems.length > 0
   const isCordoned = !!spec.unschedulable
   const showMetricsUnavailable = !!metricsUnavailable && !metricsHistory?.collectionError
-  const hasMetricsHistory = !showMetricsUnavailable && !!metricsHistory?.dataPoints?.length
+  const hasMetricsHistory = !!metricsHistory?.dataPoints?.length
   const currentMetrics = metricsUnavailable ? undefined : metrics
 
   // Extract platform info from labels
@@ -198,7 +198,7 @@ export function NodeRenderer({ data, relationships, onViewPods, metrics, metrics
               <span className="break-all">{metricsHistory.collectionError}</span>
             </div>
           )}
-          {!showMetricsUnavailable && metricsHistory?.dataPoints && metricsHistory.dataPoints.length > 0 ? (
+          {hasMetricsHistory && metricsHistory?.dataPoints ? (
             <div className="space-y-4">
               {/* CPU Usage with Chart */}
               <div className="card-inner-lg">

--- a/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.tsx
@@ -5,13 +5,14 @@ import { MetricsChart } from '../../ui/MetricsChart'
 import { formatMemoryString } from '../../../utils/format'
 import { getExtendedCapacityRows } from '../../../utils/extended-resources'
 import type { MetricsDataPoint } from '../../../types/core'
+import { MetricsUnavailableNotice } from './MetricsUnavailableNotice'
 
 interface NodeRendererProps {
   data: any
   relationships?: { pods?: any[] }
   onViewPods?: () => void
   metrics?: { usage?: { cpu: string; memory: string }; timestamp?: string }
-  metricsHistory?: { dataPoints?: MetricsDataPoint[]; collectionError?: string }
+  metricsHistory?: { dataPoints?: MetricsDataPoint[]; collectionError?: string; metricsUnavailableReason?: string }
   metricsUnavailable?: boolean
   hideMetricsServer?: boolean
 }
@@ -189,11 +190,9 @@ export function NodeRenderer({ data, relationships, onViewPods, metrics, metrics
       {!hideMetricsServer && (currentMetrics?.usage || hasMetricsHistory || metricsHistory?.collectionError || showMetricsUnavailable) && (
         <Section title="Resource Usage" icon={Activity} defaultExpanded>
           {showMetricsUnavailable && (
-            <div className="card-inner-lg text-xs text-theme-text-tertiary">
-              Metrics unavailable. Install metrics-server to show live CPU and memory usage.
-            </div>
+            <MetricsUnavailableNotice rawError={metricsHistory?.metricsUnavailableReason} />
           )}
-          {metricsHistory?.collectionError && !hasMetricsHistory && (
+          {metricsHistory?.collectionError && (
             <div className="mb-3 rounded-lg border border-yellow-500/30 bg-yellow-500/5 px-3 py-2 text-xs text-yellow-400">
               <span className="font-medium">Metrics collection error:</span>{' '}
               <span className="break-all">{metricsHistory.collectionError}</span>

--- a/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.tsx
@@ -12,6 +12,7 @@ interface NodeRendererProps {
   onViewPods?: () => void
   metrics?: { usage?: { cpu: string; memory: string }; timestamp?: string }
   metricsHistory?: { dataPoints?: MetricsDataPoint[]; collectionError?: string }
+  metricsUnavailable?: boolean
   hideMetricsServer?: boolean
 }
 
@@ -59,7 +60,7 @@ function getNodeProblems(data: any): string[] {
   return problems
 }
 
-export function NodeRenderer({ data, relationships, onViewPods, metrics, metricsHistory, hideMetricsServer }: NodeRendererProps) {
+export function NodeRenderer({ data, relationships, onViewPods, metrics, metricsHistory, metricsUnavailable, hideMetricsServer }: NodeRendererProps) {
   const status = data.status || {}
   const spec = data.spec || {}
   const metadata = data.metadata || {}
@@ -74,6 +75,8 @@ export function NodeRenderer({ data, relationships, onViewPods, metrics, metrics
   const problems = getNodeProblems(data)
   const hasProblems = problems.length > 0
   const isCordoned = !!spec.unschedulable
+  const hasMetricsHistory = !!metricsHistory?.dataPoints?.length
+  const showMetricsUnavailable = !!metricsUnavailable && !metrics?.usage && !hasMetricsHistory && !metricsHistory?.collectionError
 
   // Extract platform info from labels
   const instanceType = labels['node.kubernetes.io/instance-type']
@@ -182,9 +185,14 @@ export function NodeRenderer({ data, relationships, onViewPods, metrics, metrics
       </Section>
 
       {/* Resource Usage (from metrics-server) — hidden when Prometheus has CPU/memory data */}
-      {!hideMetricsServer && (metrics?.usage || metricsHistory?.dataPoints?.length || metricsHistory?.collectionError) && (
+      {!hideMetricsServer && (metrics?.usage || hasMetricsHistory || metricsHistory?.collectionError || showMetricsUnavailable) && (
         <Section title="Resource Usage" icon={Activity} defaultExpanded>
-          {metricsHistory?.collectionError && !metricsHistory?.dataPoints?.length && (
+          {showMetricsUnavailable && (
+            <div className="card-inner-lg text-xs text-theme-text-tertiary">
+              Metrics unavailable. Install metrics-server to show live CPU and memory usage.
+            </div>
+          )}
+          {metricsHistory?.collectionError && !hasMetricsHistory && (
             <div className="mb-3 rounded-lg border border-yellow-500/30 bg-yellow-500/5 px-3 py-2 text-xs text-yellow-400">
               <span className="font-medium">Metrics collection error:</span>{' '}
               <span className="break-all">{metricsHistory.collectionError}</span>
@@ -250,7 +258,7 @@ export function NodeRenderer({ data, relationships, onViewPods, metrics, metrics
                 </div>
               </div>
             </div>
-          ) : (
+          ) : showMetricsUnavailable ? null : (
             <div className="text-xs text-theme-text-tertiary">Collecting metrics data...</div>
           )}
           {metrics?.timestamp && (

--- a/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/NodeRenderer.tsx
@@ -12,7 +12,7 @@ interface NodeRendererProps {
   relationships?: { pods?: any[] }
   onViewPods?: () => void
   metrics?: { usage?: { cpu: string; memory: string }; timestamp?: string }
-  metricsHistory?: { dataPoints?: MetricsDataPoint[]; collectionError?: string; metricsUnavailableReason?: string }
+  metricsHistory?: { dataPoints?: MetricsDataPoint[]; collectionError?: string; metricsUnavailableReason?: string; metricsUnavailableDiagnosis?: string }
   metricsUnavailable?: boolean
   hideMetricsServer?: boolean
 }
@@ -190,7 +190,7 @@ export function NodeRenderer({ data, relationships, onViewPods, metrics, metrics
       {!hideMetricsServer && (currentMetrics?.usage || hasMetricsHistory || metricsHistory?.collectionError || showMetricsUnavailable) && (
         <Section title="Resource Usage" icon={Activity} defaultExpanded>
           {showMetricsUnavailable && (
-            <MetricsUnavailableNotice rawError={metricsHistory?.metricsUnavailableReason} />
+            <MetricsUnavailableNotice rawError={metricsHistory?.metricsUnavailableReason} diagnosis={metricsHistory?.metricsUnavailableDiagnosis} />
           )}
           {metricsHistory?.collectionError && (
             <div className="mb-3 rounded-lg border border-yellow-500/30 bg-yellow-500/5 px-3 py-2 text-xs text-yellow-400">

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.test.tsx
@@ -151,7 +151,7 @@ describe('PodRenderer metrics', () => {
     expect(html).not.toContain('Last updated')
   })
 
-  it('does not let stale historical metrics hide an unavailable state', () => {
+  it('keeps buffered historical charts visible under an unavailable notice', () => {
     const html = renderToString(
       <PodRenderer
         data={pod}
@@ -168,8 +168,9 @@ describe('PodRenderer metrics', () => {
     )
 
     expect(html).toContain('Metrics unavailable')
-    expect(html).not.toContain('100m')
-    expect(html).not.toContain('256 MiB')
+    expect(html).toContain('CPU')
+    expect(html).toContain('Memory')
+    expect(html).not.toContain('Last updated')
   })
 
   it('keeps non-absence collection errors visible', () => {

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.test.tsx
@@ -107,3 +107,36 @@ describe('PodRenderer issues banner', () => {
     expect(html).toContain('min-w-0 break-words')
   })
 })
+
+describe('PodRenderer metrics', () => {
+  it('renders a calm unavailable state when metrics-server is absent', () => {
+    const html = renderToString(
+      <PodRenderer
+        data={pod}
+        onCopy={() => undefined}
+        copied={null}
+        metricsUnavailable
+      />,
+    )
+
+    expect(html).toContain('Resource Usage')
+    expect(html).toContain('Metrics unavailable')
+    expect(html).toContain('Install metrics-server')
+    expect(html).not.toContain('Metrics collection error')
+    expect(html).not.toContain('Collecting metrics data')
+  })
+
+  it('keeps non-absence collection errors visible', () => {
+    const html = renderToString(
+      <PodRenderer
+        data={pod}
+        onCopy={() => undefined}
+        copied={null}
+        metricsHistory={{ containers: [], collectionError: 'forbidden: no access to pods.metrics.k8s.io' }}
+      />,
+    )
+
+    expect(html).toContain('Metrics collection error')
+    expect(html).toContain('forbidden: no access to pods.metrics.k8s.io')
+  })
+})

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.test.tsx
@@ -125,9 +125,9 @@ describe('PodRenderer metrics', () => {
 
     expect(html).toContain('Resource Usage')
     expect(html).toContain('Metrics unavailable')
-    expect(html).toContain('Radar could not read metrics.k8s.io')
-    expect(html).toContain('Install or repair metrics-server and its APIService')
+    expect(html).toContain('Radar cannot read metrics.k8s.io')
     expect(html).toContain('Metrics error details')
+    expect(html).not.toContain('Install or repair metrics-server and its APIService')
     expect(html).not.toContain('Metrics collection error')
     expect(html).not.toContain('Collecting metrics data')
   })

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.test.tsx
@@ -145,6 +145,27 @@ describe('PodRenderer metrics', () => {
     expect(html).not.toContain('Last updated')
   })
 
+  it('does not let stale historical metrics hide an unavailable state', () => {
+    const html = renderToString(
+      <PodRenderer
+        data={pod}
+        onCopy={() => undefined}
+        copied={null}
+        metricsUnavailable
+        metricsHistory={{
+          containers: [{
+            name: 'api',
+            dataPoints: [{ timestamp: '2026-06-30T00:00:00Z', cpu: 100000000, memory: 268435456 }],
+          }],
+        }}
+      />,
+    )
+
+    expect(html).toContain('Metrics unavailable')
+    expect(html).not.toContain('100m')
+    expect(html).not.toContain('256 MiB')
+  })
+
   it('keeps non-absence collection errors visible', () => {
     const html = renderToString(
       <PodRenderer

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.test.tsx
@@ -126,6 +126,25 @@ describe('PodRenderer metrics', () => {
     expect(html).not.toContain('Collecting metrics data')
   })
 
+  it('does not let stale live metrics hide an unavailable state', () => {
+    const html = renderToString(
+      <PodRenderer
+        data={pod}
+        onCopy={() => undefined}
+        copied={null}
+        metricsUnavailable
+        metrics={{
+          containers: [{ name: 'api', usage: { cpu: '100m', memory: '256Mi' } }],
+          timestamp: '2026-06-30T00:00:00Z',
+        }}
+      />,
+    )
+
+    expect(html).toContain('Metrics unavailable')
+    expect(html).not.toContain('100m')
+    expect(html).not.toContain('Last updated')
+  })
+
   it('keeps non-absence collection errors visible', () => {
     const html = renderToString(
       <PodRenderer

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.test.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.test.tsx
@@ -116,12 +116,18 @@ describe('PodRenderer metrics', () => {
         onCopy={() => undefined}
         copied={null}
         metricsUnavailable
+        metricsHistory={{
+          containers: [],
+          metricsUnavailableReason: 'the server could not find the requested resource',
+        }}
       />,
     )
 
     expect(html).toContain('Resource Usage')
     expect(html).toContain('Metrics unavailable')
-    expect(html).toContain('Install metrics-server')
+    expect(html).toContain('Radar could not read metrics.k8s.io')
+    expect(html).toContain('Install or repair metrics-server and its APIService')
+    expect(html).toContain('Metrics error details')
     expect(html).not.toContain('Metrics collection error')
     expect(html).not.toContain('Collecting metrics data')
   })
@@ -178,5 +184,26 @@ describe('PodRenderer metrics', () => {
 
     expect(html).toContain('Metrics collection error')
     expect(html).toContain('forbidden: no access to pods.metrics.k8s.io')
+  })
+
+  it('warns about non-absence collection errors even when historical samples exist', () => {
+    const html = renderToString(
+      <PodRenderer
+        data={pod}
+        onCopy={() => undefined}
+        copied={null}
+        metricsHistory={{
+          collectionError: 'forbidden: no access to pods.metrics.k8s.io',
+          containers: [{
+            name: 'api',
+            dataPoints: [{ timestamp: '2026-06-30T00:00:00Z', cpu: 100000000, memory: 268435456 }],
+          }],
+        }}
+      />,
+    )
+
+    expect(html).toContain('Metrics collection error')
+    expect(html).toContain('forbidden: no access to pods.metrics.k8s.io')
+    expect(html).toContain('CPU')
   })
 })

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
@@ -74,7 +74,7 @@ interface PodRendererProps {
   renderPortAction?: (props: { namespace: string; podName: string; port: number; protocol: string; disabled?: boolean }) => ReactNode
   // Metrics data injection
   metrics?: { containers?: any[]; timestamp?: string }
-  metricsHistory?: { containers?: any[]; collectionError?: string; metricsUnavailableReason?: string }
+  metricsHistory?: { containers?: any[]; collectionError?: string; metricsUnavailableReason?: string; metricsUnavailableDiagnosis?: string }
   metricsUnavailable?: boolean
   hideMetricsServer?: boolean
   // Filesystem browser render props
@@ -727,7 +727,7 @@ export function PodRenderer({
       {!hideMetricsServer && !!(currentMetrics?.containers?.length || hasMetricsHistory || metricsHistory?.collectionError || showMetricsUnavailable) && (
         <Section title="Resource Usage" icon={Activity} defaultExpanded>
           {showMetricsUnavailable && (
-            <MetricsUnavailableNotice rawError={metricsHistory?.metricsUnavailableReason} />
+            <MetricsUnavailableNotice rawError={metricsHistory?.metricsUnavailableReason} diagnosis={metricsHistory?.metricsUnavailableDiagnosis} />
           )}
           {metricsHistory?.collectionError && (
             <div className="mb-3 rounded-lg border border-yellow-500/30 bg-yellow-500/5 px-3 py-2 text-xs text-yellow-400">

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
@@ -15,6 +15,7 @@ import { RBACErrorSection, isRBACUnavailable } from './RBACErrorSection'
 import type { ResolvedEnvFrom, RBACSubjectResponse, RBACPolicyRule } from '../../../types'
 import { Tooltip } from '../../ui/Tooltip'
 import { MetricsChart } from '../../ui/MetricsChart'
+import { MetricsUnavailableNotice } from './MetricsUnavailableNotice'
 
 function parseValidDate(dateStr: string): Date | null {
   const d = new Date(dateStr)
@@ -73,7 +74,7 @@ interface PodRendererProps {
   renderPortAction?: (props: { namespace: string; podName: string; port: number; protocol: string; disabled?: boolean }) => ReactNode
   // Metrics data injection
   metrics?: { containers?: any[]; timestamp?: string }
-  metricsHistory?: { containers?: any[]; collectionError?: string }
+  metricsHistory?: { containers?: any[]; collectionError?: string; metricsUnavailableReason?: string }
   metricsUnavailable?: boolean
   hideMetricsServer?: boolean
   // Filesystem browser render props
@@ -726,11 +727,9 @@ export function PodRenderer({
       {!hideMetricsServer && !!(currentMetrics?.containers?.length || hasMetricsHistory || metricsHistory?.collectionError || showMetricsUnavailable) && (
         <Section title="Resource Usage" icon={Activity} defaultExpanded>
           {showMetricsUnavailable && (
-            <div className="card-inner-lg text-xs text-theme-text-tertiary">
-              Metrics unavailable. Install metrics-server to show live CPU and memory usage.
-            </div>
+            <MetricsUnavailableNotice rawError={metricsHistory?.metricsUnavailableReason} />
           )}
-          {metricsHistory?.collectionError && !hasMetricsHistory && (
+          {metricsHistory?.collectionError && (
             <div className="mb-3 rounded-lg border border-yellow-500/30 bg-yellow-500/5 px-3 py-2 text-xs text-yellow-400">
               <span className="font-medium">Metrics collection error:</span>{' '}
               <span className="break-all">{metricsHistory.collectionError}</span>

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
@@ -284,7 +284,7 @@ export function PodRenderer({
   const podProblems = getPodProblems(data)
   const hasProblems = podProblems.length > 0 && !operationalIssuesShown
   const showMetricsUnavailable = !!metricsUnavailable && !metricsHistory?.collectionError
-  const hasMetricsHistory = !showMetricsUnavailable && !!metricsHistory?.containers?.length
+  const hasMetricsHistory = !!metricsHistory?.containers?.length
   const currentMetrics = metricsUnavailable ? undefined : metrics
 
   // Image filesystem modal state
@@ -735,7 +735,7 @@ export function PodRenderer({
               <span className="break-all">{metricsHistory.collectionError}</span>
             </div>
           )}
-          {!showMetricsUnavailable && (
+          {(hasMetricsHistory || !showMetricsUnavailable) && (
             <div className="space-y-4">
               {(metricsHistory?.containers || currentMetrics?.containers || []).map((historyContainer) => {
                 // Find current metrics for this container

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
@@ -282,8 +282,8 @@ export function PodRenderer({
   const operationalIssuesShown = useOperationalIssuesShown()
   const podProblems = getPodProblems(data)
   const hasProblems = podProblems.length > 0 && !operationalIssuesShown
-  const hasMetricsHistory = !!metricsHistory?.containers?.length
-  const showMetricsUnavailable = !!metricsUnavailable && !hasMetricsHistory && !metricsHistory?.collectionError
+  const showMetricsUnavailable = !!metricsUnavailable && !metricsHistory?.collectionError
+  const hasMetricsHistory = !showMetricsUnavailable && !!metricsHistory?.containers?.length
   const currentMetrics = metricsUnavailable ? undefined : metrics
 
   // Image filesystem modal state

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
@@ -74,6 +74,7 @@ interface PodRendererProps {
   // Metrics data injection
   metrics?: { containers?: any[]; timestamp?: string }
   metricsHistory?: { containers?: any[]; collectionError?: string }
+  metricsUnavailable?: boolean
   hideMetricsServer?: boolean
   // Filesystem browser render props
   renderImageBrowser?: (props: { image: string; namespace: string; podName: string; pullSecrets: string[]; onClose: () => void; onSwitchToPodFiles?: () => void }) => ReactNode
@@ -257,6 +258,7 @@ export function PodRenderer({
   renderPortAction,
   metrics,
   metricsHistory,
+  metricsUnavailable,
   hideMetricsServer,
   renderImageBrowser,
   renderPodBrowser,
@@ -280,6 +282,8 @@ export function PodRenderer({
   const operationalIssuesShown = useOperationalIssuesShown()
   const podProblems = getPodProblems(data)
   const hasProblems = podProblems.length > 0 && !operationalIssuesShown
+  const hasMetricsHistory = !!metricsHistory?.containers?.length
+  const showMetricsUnavailable = !!metricsUnavailable && !metrics?.containers?.length && !hasMetricsHistory && !metricsHistory?.collectionError
 
   // Image filesystem modal state
   const [selectedImage, setSelectedImage] = useState<string | null>(null)
@@ -718,86 +722,93 @@ export function PodRenderer({
       )}
 
       {/* Resource Usage (from metrics-server) — hidden when Prometheus has CPU/memory data */}
-      {!hideMetricsServer && !!(metrics?.containers?.length || metricsHistory?.containers?.length || metricsHistory?.collectionError) && (
+      {!hideMetricsServer && !!(metrics?.containers?.length || hasMetricsHistory || metricsHistory?.collectionError || showMetricsUnavailable) && (
         <Section title="Resource Usage" icon={Activity} defaultExpanded>
-          {metricsHistory?.collectionError && !metricsHistory?.containers?.length && (
+          {showMetricsUnavailable && (
+            <div className="card-inner-lg text-xs text-theme-text-tertiary">
+              Metrics unavailable. Install metrics-server to show live CPU and memory usage.
+            </div>
+          )}
+          {metricsHistory?.collectionError && !hasMetricsHistory && (
             <div className="mb-3 rounded-lg border border-yellow-500/30 bg-yellow-500/5 px-3 py-2 text-xs text-yellow-400">
               <span className="font-medium">Metrics collection error:</span>{' '}
               <span className="break-all">{metricsHistory.collectionError}</span>
             </div>
           )}
-          <div className="space-y-4">
-            {(metricsHistory?.containers || metrics?.containers || []).map((historyContainer) => {
-              // Find current metrics for this container
-              const currentMetrics = metrics?.containers?.find(c => c.name === historyContainer.name)
-              // Find the container spec to compare against limits
-              const containerSpec = containers.find((c: any) => c.name === historyContainer.name)
-              const limits = containerSpec?.resources?.limits
-              const requests = containerSpec?.resources?.requests
+          {!showMetricsUnavailable && (
+            <div className="space-y-4">
+              {(metricsHistory?.containers || metrics?.containers || []).map((historyContainer) => {
+                // Find current metrics for this container
+                const currentMetrics = metrics?.containers?.find(c => c.name === historyContainer.name)
+                // Find the container spec to compare against limits
+                const containerSpec = containers.find((c: any) => c.name === historyContainer.name)
+                const limits = containerSpec?.resources?.limits
+                const requests = containerSpec?.resources?.requests
 
-              // Get historical data points (from history or empty)
-              const dataPoints = 'dataPoints' in historyContainer ? historyContainer.dataPoints : []
+                // Get historical data points (from history or empty)
+                const dataPoints = 'dataPoints' in historyContainer ? historyContainer.dataPoints : []
 
-              return (
-                <div key={historyContainer.name} className="card-inner-lg">
-                  <div className="flex items-center justify-between mb-3">
-                    <span className="text-sm font-medium text-theme-text-primary">{historyContainer.name}</span>
+                return (
+                  <div key={historyContainer.name} className="card-inner-lg">
+                    <div className="flex items-center justify-between mb-3">
+                      <span className="text-sm font-medium text-theme-text-primary">{historyContainer.name}</span>
+                    </div>
+
+                    {dataPoints && dataPoints.length > 0 ? (
+                      <div className="grid grid-cols-2 gap-6">
+                        <div>
+                          <div className="text-xs text-theme-text-tertiary mb-2">CPU</div>
+                          <MetricsChart
+                            dataPoints={dataPoints}
+                            type="cpu"
+                            height={80}
+                            showAxis={true}
+                            limit={limits?.cpu}
+                            request={requests?.cpu}
+                          />
+                        </div>
+                        <div>
+                          <div className="text-xs text-theme-text-tertiary mb-2">Memory</div>
+                          <MetricsChart
+                            dataPoints={dataPoints}
+                            type="memory"
+                            height={80}
+                            showAxis={true}
+                            limit={limits?.memory}
+                            request={requests?.memory}
+                          />
+                        </div>
+                      </div>
+                    ) : currentMetrics ? (
+                      /* Fallback to simple display if no history yet */
+                      <div className="grid grid-cols-2 gap-4 text-xs">
+                        <div>
+                          <div className="text-theme-text-tertiary mb-1">CPU</div>
+                          <div className="flex items-baseline gap-1">
+                            <span className="text-sm font-medium text-blue-400">{currentMetrics.usage.cpu}</span>
+                            {limits?.cpu && (
+                              <span className="text-theme-text-tertiary">/ {limits.cpu} limit</span>
+                            )}
+                          </div>
+                        </div>
+                        <div>
+                          <div className="text-theme-text-tertiary mb-1">Memory</div>
+                          <div className="flex items-baseline gap-1">
+                            <span className="text-sm font-medium text-purple-400">{currentMetrics.usage.memory}</span>
+                            {limits?.memory && (
+                              <span className="text-theme-text-tertiary">/ {limits.memory} limit</span>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="text-xs text-theme-text-tertiary">Collecting metrics data...</div>
+                    )}
                   </div>
-
-                  {dataPoints && dataPoints.length > 0 ? (
-                    <div className="grid grid-cols-2 gap-6">
-                      <div>
-                        <div className="text-xs text-theme-text-tertiary mb-2">CPU</div>
-                        <MetricsChart
-                          dataPoints={dataPoints}
-                          type="cpu"
-                          height={80}
-                          showAxis={true}
-                          limit={limits?.cpu}
-                          request={requests?.cpu}
-                        />
-                      </div>
-                      <div>
-                        <div className="text-xs text-theme-text-tertiary mb-2">Memory</div>
-                        <MetricsChart
-                          dataPoints={dataPoints}
-                          type="memory"
-                          height={80}
-                          showAxis={true}
-                          limit={limits?.memory}
-                          request={requests?.memory}
-                        />
-                      </div>
-                    </div>
-                  ) : currentMetrics ? (
-                    /* Fallback to simple display if no history yet */
-                    <div className="grid grid-cols-2 gap-4 text-xs">
-                      <div>
-                        <div className="text-theme-text-tertiary mb-1">CPU</div>
-                        <div className="flex items-baseline gap-1">
-                          <span className="text-sm font-medium text-blue-400">{currentMetrics.usage.cpu}</span>
-                          {limits?.cpu && (
-                            <span className="text-theme-text-tertiary">/ {limits.cpu} limit</span>
-                          )}
-                        </div>
-                      </div>
-                      <div>
-                        <div className="text-theme-text-tertiary mb-1">Memory</div>
-                        <div className="flex items-baseline gap-1">
-                          <span className="text-sm font-medium text-purple-400">{currentMetrics.usage.memory}</span>
-                          {limits?.memory && (
-                            <span className="text-theme-text-tertiary">/ {limits.memory} limit</span>
-                          )}
-                        </div>
-                      </div>
-                    </div>
-                  ) : (
-                    <div className="text-xs text-theme-text-tertiary">Collecting metrics data...</div>
-                  )}
-                </div>
-              )
-            })}
-          </div>
+                )
+              })}
+            </div>
+          )}
           {metrics?.timestamp && (
             <div className="mt-2 text-xs text-theme-text-tertiary">
               Last updated: {new Date(metrics.timestamp).toLocaleTimeString()}

--- a/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
+++ b/packages/k8s-ui/src/components/resources/renderers/PodRenderer.tsx
@@ -283,7 +283,8 @@ export function PodRenderer({
   const podProblems = getPodProblems(data)
   const hasProblems = podProblems.length > 0 && !operationalIssuesShown
   const hasMetricsHistory = !!metricsHistory?.containers?.length
-  const showMetricsUnavailable = !!metricsUnavailable && !metrics?.containers?.length && !hasMetricsHistory && !metricsHistory?.collectionError
+  const showMetricsUnavailable = !!metricsUnavailable && !hasMetricsHistory && !metricsHistory?.collectionError
+  const currentMetrics = metricsUnavailable ? undefined : metrics
 
   // Image filesystem modal state
   const [selectedImage, setSelectedImage] = useState<string | null>(null)
@@ -722,7 +723,7 @@ export function PodRenderer({
       )}
 
       {/* Resource Usage (from metrics-server) — hidden when Prometheus has CPU/memory data */}
-      {!hideMetricsServer && !!(metrics?.containers?.length || hasMetricsHistory || metricsHistory?.collectionError || showMetricsUnavailable) && (
+      {!hideMetricsServer && !!(currentMetrics?.containers?.length || hasMetricsHistory || metricsHistory?.collectionError || showMetricsUnavailable) && (
         <Section title="Resource Usage" icon={Activity} defaultExpanded>
           {showMetricsUnavailable && (
             <div className="card-inner-lg text-xs text-theme-text-tertiary">
@@ -737,9 +738,9 @@ export function PodRenderer({
           )}
           {!showMetricsUnavailable && (
             <div className="space-y-4">
-              {(metricsHistory?.containers || metrics?.containers || []).map((historyContainer) => {
+              {(metricsHistory?.containers || currentMetrics?.containers || []).map((historyContainer) => {
                 // Find current metrics for this container
-                const currentMetrics = metrics?.containers?.find(c => c.name === historyContainer.name)
+                const currentContainerMetrics = currentMetrics?.containers?.find(c => c.name === historyContainer.name)
                 // Find the container spec to compare against limits
                 const containerSpec = containers.find((c: any) => c.name === historyContainer.name)
                 const limits = containerSpec?.resources?.limits
@@ -779,13 +780,13 @@ export function PodRenderer({
                           />
                         </div>
                       </div>
-                    ) : currentMetrics ? (
+                    ) : currentContainerMetrics ? (
                       /* Fallback to simple display if no history yet */
                       <div className="grid grid-cols-2 gap-4 text-xs">
                         <div>
                           <div className="text-theme-text-tertiary mb-1">CPU</div>
                           <div className="flex items-baseline gap-1">
-                            <span className="text-sm font-medium text-blue-400">{currentMetrics.usage.cpu}</span>
+                            <span className="text-sm font-medium text-blue-400">{currentContainerMetrics.usage.cpu}</span>
                             {limits?.cpu && (
                               <span className="text-theme-text-tertiary">/ {limits.cpu} limit</span>
                             )}
@@ -794,7 +795,7 @@ export function PodRenderer({
                         <div>
                           <div className="text-theme-text-tertiary mb-1">Memory</div>
                           <div className="flex items-baseline gap-1">
-                            <span className="text-sm font-medium text-purple-400">{currentMetrics.usage.memory}</span>
+                            <span className="text-sm font-medium text-purple-400">{currentContainerMetrics.usage.memory}</span>
                             {limits?.memory && (
                               <span className="text-theme-text-tertiary">/ {limits.memory} limit</span>
                             )}
@@ -809,9 +810,9 @@ export function PodRenderer({
               })}
             </div>
           )}
-          {metrics?.timestamp && (
+          {!showMetricsUnavailable && currentMetrics?.timestamp && (
             <div className="mt-2 text-xs text-theme-text-tertiary">
-              Last updated: {new Date(metrics.timestamp).toLocaleTimeString()}
+              Last updated: {new Date(currentMetrics.timestamp).toLocaleTimeString()}
             </div>
           )}
         </Section>

--- a/packages/k8s-ui/src/components/ui/Toast.tsx
+++ b/packages/k8s-ui/src/components/ui/Toast.tsx
@@ -215,7 +215,7 @@ function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: () => void }
             <button
               onClick={toast.onDetailClick}
               className={clsx(
-                'mt-1.5 block text-xs font-mono break-all text-left rounded px-1.5 py-1 -ml-1.5 transition-colors',
+                'mt-1.5 block text-xs font-mono break-words text-left rounded px-1.5 py-1 -ml-1.5 transition-colors',
                 isError
                   ? 'text-red-300 hover:bg-red-900/50'
                   : isSuccess
@@ -227,7 +227,7 @@ function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: () => void }
               {toast.detail}
             </button>
           ) : (
-            <p className={clsx('mt-1 text-xs break-all', isError ? 'text-red-300/80' : isSuccess ? 'text-emerald-300/80' : 'text-theme-text-secondary')}>
+            <p className={clsx('mt-1 text-xs break-words', isError ? 'text-red-300/80' : isSuccess ? 'text-emerald-300/80' : 'text-theme-text-secondary')}>
               {toast.detail}
             </p>
           )

--- a/pkg/k8score/metrics_history.go
+++ b/pkg/k8score/metrics_history.go
@@ -170,13 +170,13 @@ func (rb *ringBuffer) GetAll() []MetricsDataPoint {
 }
 
 func metricsCollectionErrorLevel(err error) string {
-	if metricsAPIUnavailable(err) {
+	if MetricsAPIUnavailable(err) {
 		return "warning"
 	}
 	return "error"
 }
 
-func metricsAPIUnavailable(err error) bool {
+func MetricsAPIUnavailable(err error) bool {
 	if err == nil {
 		return false
 	}

--- a/pkg/k8score/metrics_history.go
+++ b/pkg/k8score/metrics_history.go
@@ -41,6 +41,7 @@ type PodMetricsHistory struct {
 	CollectionError             string                    `json:"collectionError,omitempty"`
 	RawCollectionError          string                    `json:"rawCollectionError,omitempty"`
 	MetricsUnavailableDiagnosis string                    `json:"metricsUnavailableDiagnosis,omitempty"`
+	MetricsUnavailable          bool                      `json:"metricsUnavailable,omitempty"`
 }
 
 // NodeMetricsHistory holds historical metrics for a node.
@@ -50,6 +51,7 @@ type NodeMetricsHistory struct {
 	CollectionError             string             `json:"collectionError,omitempty"`
 	RawCollectionError          string             `json:"rawCollectionError,omitempty"`
 	MetricsUnavailableDiagnosis string             `json:"metricsUnavailableDiagnosis,omitempty"`
+	MetricsUnavailable          bool               `json:"metricsUnavailable,omitempty"`
 }
 
 // TopPodMetrics holds the latest metrics snapshot for a single pod.

--- a/pkg/k8score/metrics_history.go
+++ b/pkg/k8score/metrics_history.go
@@ -35,17 +35,19 @@ type ContainerMetricsHistory struct {
 
 // PodMetricsHistory holds historical metrics for a pod.
 type PodMetricsHistory struct {
-	Namespace       string                    `json:"namespace"`
-	Name            string                    `json:"name"`
-	Containers      []ContainerMetricsHistory `json:"containers"`
-	CollectionError string                    `json:"collectionError,omitempty"`
+	Namespace          string                    `json:"namespace"`
+	Name               string                    `json:"name"`
+	Containers         []ContainerMetricsHistory `json:"containers"`
+	CollectionError    string                    `json:"collectionError,omitempty"`
+	RawCollectionError string                    `json:"rawCollectionError,omitempty"`
 }
 
 // NodeMetricsHistory holds historical metrics for a node.
 type NodeMetricsHistory struct {
-	Name            string             `json:"name"`
-	DataPoints      []MetricsDataPoint `json:"dataPoints"`
-	CollectionError string             `json:"collectionError,omitempty"`
+	Name               string             `json:"name"`
+	DataPoints         []MetricsDataPoint `json:"dataPoints"`
+	CollectionError    string             `json:"collectionError,omitempty"`
+	RawCollectionError string             `json:"rawCollectionError,omitempty"`
 }
 
 // TopPodMetrics holds the latest metrics snapshot for a single pod.
@@ -183,13 +185,17 @@ func metricsAPIUnavailable(err error) bool {
 	if !strings.Contains(msg, "metrics") {
 		return false
 	}
+	if apierrors.IsServiceUnavailable(err) {
+		return true
+	}
 	return strings.Contains(msg, "not found") ||
 		strings.Contains(msg, "could not find the requested resource") ||
 		strings.Contains(msg, "no matches for kind") ||
 		strings.Contains(msg, "no resource matches") ||
 		strings.Contains(msg, "no metrics known") ||
 		strings.Contains(msg, "not available") ||
-		strings.Contains(msg, "unable to fetch metrics")
+		strings.Contains(msg, "unable to fetch metrics") ||
+		strings.Contains(msg, "currently unable to handle the request")
 }
 
 // NewMetricsHistoryStore creates a MetricsHistoryStore. Call Start() to begin polling.

--- a/pkg/k8score/metrics_history.go
+++ b/pkg/k8score/metrics_history.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 )
@@ -163,6 +165,33 @@ func (rb *ringBuffer) GetAll() []MetricsDataPoint {
 	return result
 }
 
+func metricsCollectionErrorLevel(err error) string {
+	if metricsAPIUnavailable(err) {
+		return "warning"
+	}
+	return "error"
+}
+
+func metricsAPIUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if apierrors.IsNotFound(err) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	if !strings.Contains(msg, "metrics") {
+		return false
+	}
+	return strings.Contains(msg, "not found") ||
+		strings.Contains(msg, "could not find the requested resource") ||
+		strings.Contains(msg, "no matches for kind") ||
+		strings.Contains(msg, "no resource matches") ||
+		strings.Contains(msg, "no metrics known") ||
+		strings.Contains(msg, "not available") ||
+		strings.Contains(msg, "unable to fetch metrics")
+}
+
 // NewMetricsHistoryStore creates a MetricsHistoryStore. Call Start() to begin polling.
 func NewMetricsHistoryStore(client dynamic.Interface) *MetricsHistoryStore {
 	return &MetricsHistoryStore{
@@ -249,7 +278,7 @@ func (s *MetricsHistoryStore) collectPodMetrics(ctx context.Context, now time.Ti
 		if shouldReport {
 			log.Printf("[metrics] Pod metrics collection failed (count=%d): %v", count, err)
 			if s.OnError != nil {
-				s.OnError("metrics", "error", "pod metrics collection failed (count=%d): %v", count, err)
+				s.OnError("metrics", metricsCollectionErrorLevel(err), "pod metrics collection failed (count=%d): %v", count, err)
 			}
 		}
 		return
@@ -356,7 +385,7 @@ func (s *MetricsHistoryStore) collectNodeMetrics(ctx context.Context, now time.T
 		if shouldReport {
 			log.Printf("[metrics] Node metrics collection failed (count=%d): %v", count, err)
 			if s.OnError != nil {
-				s.OnError("metrics", "error", "node metrics collection failed (count=%d): %v", count, err)
+				s.OnError("metrics", metricsCollectionErrorLevel(err), "node metrics collection failed (count=%d): %v", count, err)
 			}
 		}
 		return

--- a/pkg/k8score/metrics_history.go
+++ b/pkg/k8score/metrics_history.go
@@ -35,19 +35,21 @@ type ContainerMetricsHistory struct {
 
 // PodMetricsHistory holds historical metrics for a pod.
 type PodMetricsHistory struct {
-	Namespace          string                    `json:"namespace"`
-	Name               string                    `json:"name"`
-	Containers         []ContainerMetricsHistory `json:"containers"`
-	CollectionError    string                    `json:"collectionError,omitempty"`
-	RawCollectionError string                    `json:"rawCollectionError,omitempty"`
+	Namespace                   string                    `json:"namespace"`
+	Name                        string                    `json:"name"`
+	Containers                  []ContainerMetricsHistory `json:"containers"`
+	CollectionError             string                    `json:"collectionError,omitempty"`
+	RawCollectionError          string                    `json:"rawCollectionError,omitempty"`
+	MetricsUnavailableDiagnosis string                    `json:"metricsUnavailableDiagnosis,omitempty"`
 }
 
 // NodeMetricsHistory holds historical metrics for a node.
 type NodeMetricsHistory struct {
-	Name               string             `json:"name"`
-	DataPoints         []MetricsDataPoint `json:"dataPoints"`
-	CollectionError    string             `json:"collectionError,omitempty"`
-	RawCollectionError string             `json:"rawCollectionError,omitempty"`
+	Name                        string             `json:"name"`
+	DataPoints                  []MetricsDataPoint `json:"dataPoints"`
+	CollectionError             string             `json:"collectionError,omitempty"`
+	RawCollectionError          string             `json:"rawCollectionError,omitempty"`
+	MetricsUnavailableDiagnosis string             `json:"metricsUnavailableDiagnosis,omitempty"`
 }
 
 // TopPodMetrics holds the latest metrics snapshot for a single pod.

--- a/pkg/k8score/metrics_history_test.go
+++ b/pkg/k8score/metrics_history_test.go
@@ -1,6 +1,74 @@
 package k8score
 
-import "testing"
+import (
+	"errors"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestMetricsCollectionErrorLevel(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "api not found",
+			err:  apierrors.NewNotFound(schema.GroupResource{Group: "metrics.k8s.io", Resource: "pods"}, "api"),
+			want: "warning",
+		},
+		{
+			name: "metrics api resource absent",
+			err:  errors.New("the server could not find the requested resource (get pods.metrics.k8s.io)"),
+			want: "warning",
+		},
+		{
+			name: "metrics kind not matched",
+			err:  errors.New("no matches for kind PodMetrics in version metrics.k8s.io/v1beta1"),
+			want: "warning",
+		},
+		{
+			name: "metrics not available",
+			err:  errors.New("pods.metrics.k8s.io not available"),
+			want: "warning",
+		},
+		{
+			name: "no metrics known",
+			err:  errors.New("no metrics known for pod api in pods.metrics.k8s.io"),
+			want: "warning",
+		},
+		{
+			name: "unable to fetch metrics",
+			err:  errors.New("unable to fetch metrics from pods.metrics.k8s.io"),
+			want: "warning",
+		},
+		{
+			name: "non metrics missing resource",
+			err:  errors.New("the server could not find the requested resource"),
+			want: "error",
+		},
+		{
+			name: "forbidden metrics",
+			err:  errors.New("pods.metrics.k8s.io is forbidden"),
+			want: "error",
+		},
+		{
+			name: "nil",
+			err:  nil,
+			want: "error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := metricsCollectionErrorLevel(tt.err); got != tt.want {
+				t.Fatalf("metricsCollectionErrorLevel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestParseCPU(t *testing.T) {
 	tests := []struct {

--- a/pkg/k8score/metrics_history_test.go
+++ b/pkg/k8score/metrics_history_test.go
@@ -45,6 +45,11 @@ func TestMetricsCollectionErrorLevel(t *testing.T) {
 			want: "warning",
 		},
 		{
+			name: "metrics APIService unavailable",
+			err:  errors.New("the server is currently unable to handle the request (get pods.metrics.k8s.io)"),
+			want: "warning",
+		},
+		{
 			name: "non metrics missing resource",
 			err:  errors.New("the server could not find the requested resource"),
 			want: "error",

--- a/web/src/api/client.metrics.test.ts
+++ b/web/src/api/client.metrics.test.ts
@@ -2,24 +2,12 @@ import { describe, expect, it } from 'vitest'
 import {
   ApiError,
   isMetricsUnavailableError,
-  isMetricsUnavailableMessage,
   normalizeNodeMetricsHistory,
   normalizePodMetricsHistory,
   shouldFetchLiveMetrics,
 } from './client'
 
 describe('metrics unavailable classification', () => {
-  it('recognizes metrics-server absence messages', () => {
-    expect(isMetricsUnavailableMessage('Pod metrics not found (metrics-server may not be installed)')).toBe(true)
-    expect(isMetricsUnavailableMessage('the server could not find the requested resource (get pods.metrics.k8s.io)')).toBe(true)
-    expect(isMetricsUnavailableMessage('no matches for kind "PodMetrics" in version "metrics.k8s.io/v1beta1"')).toBe(true)
-    expect(isMetricsUnavailableMessage('no resource matches "pods.metrics.k8s.io"')).toBe(true)
-    expect(isMetricsUnavailableMessage('the server is currently unable to handle the request (get pods.metrics.k8s.io)')).toBe(true)
-    expect(isMetricsUnavailableMessage('the server could not find the requested resource')).toBe(false)
-    expect(isMetricsUnavailableMessage('no access to nodes')).toBe(false)
-    expect(isMetricsUnavailableMessage('metrics-server forbidden')).toBe(false)
-  })
-
   it('only treats metrics-shaped API failures as metrics unavailable', () => {
     expect(isMetricsUnavailableError(new ApiError('Node metrics not found (metrics-server may not be installed)', 404))).toBe(true)
     expect(isMetricsUnavailableError(new ApiError('the server could not find the requested resource (get nodes.metrics.k8s.io)', 500))).toBe(true)

--- a/web/src/api/client.metrics.test.ts
+++ b/web/src/api/client.metrics.test.ts
@@ -14,16 +14,20 @@ describe('metrics unavailable classification', () => {
     expect(isMetricsUnavailableMessage('the server could not find the requested resource (get pods.metrics.k8s.io)')).toBe(true)
     expect(isMetricsUnavailableMessage('no matches for kind "PodMetrics" in version "metrics.k8s.io/v1beta1"')).toBe(true)
     expect(isMetricsUnavailableMessage('no resource matches "pods.metrics.k8s.io"')).toBe(true)
+    expect(isMetricsUnavailableMessage('the server is currently unable to handle the request (get pods.metrics.k8s.io)')).toBe(true)
     expect(isMetricsUnavailableMessage('the server could not find the requested resource')).toBe(false)
     expect(isMetricsUnavailableMessage('no access to nodes')).toBe(false)
+    expect(isMetricsUnavailableMessage('metrics-server forbidden')).toBe(false)
   })
 
   it('only treats metrics-shaped API failures as metrics unavailable', () => {
     expect(isMetricsUnavailableError(new ApiError('Node metrics not found (metrics-server may not be installed)', 404))).toBe(true)
     expect(isMetricsUnavailableError(new ApiError('the server could not find the requested resource (get nodes.metrics.k8s.io)', 500))).toBe(true)
     expect(isMetricsUnavailableError(new ApiError('failed to get node metrics: the server could not find the requested resource', 500))).toBe(true)
+    expect(isMetricsUnavailableError(new ApiError('the server is currently unable to handle the request (get nodes.metrics.k8s.io)', 500))).toBe(true)
     expect(isMetricsUnavailableError(new ApiError('the server could not find the requested resource', 500))).toBe(false)
     expect(isMetricsUnavailableError(new ApiError('no access to nodes', 403))).toBe(false)
+    expect(isMetricsUnavailableError(new ApiError('metrics-server forbidden', 500))).toBe(false)
     expect(isMetricsUnavailableError(new ApiError('database unavailable', 500))).toBe(false)
   })
 
@@ -33,17 +37,23 @@ describe('metrics unavailable classification', () => {
       name: 'api',
       containers: [],
       collectionError: 'the server could not find the requested resource (get pods.metrics.k8s.io)',
+      rawCollectionError: 'the server could not find the requested resource',
     })
     expect(podHistory.collectionError).toBeUndefined()
+    expect(podHistory.rawCollectionError).toBeUndefined()
     expect(podHistory.metricsUnavailable).toBe(true)
+    expect(podHistory.metricsUnavailableReason).toBe('the server could not find the requested resource')
 
     const nodeHistory = normalizeNodeMetricsHistory({
       name: 'kind-worker',
       dataPoints: [],
       collectionError: 'Node metrics not found (metrics-server may not be installed)',
+      rawCollectionError: 'the server could not find the requested resource',
     })
     expect(nodeHistory.collectionError).toBeUndefined()
+    expect(nodeHistory.rawCollectionError).toBeUndefined()
     expect(nodeHistory.metricsUnavailable).toBe(true)
+    expect(nodeHistory.metricsUnavailableReason).toBe('the server could not find the requested resource')
   })
 
   it('keeps non-metrics collection errors visible', () => {

--- a/web/src/api/client.metrics.test.ts
+++ b/web/src/api/client.metrics.test.ts
@@ -5,13 +5,16 @@ import {
   isMetricsUnavailableMessage,
   normalizeNodeMetricsHistory,
   normalizePodMetricsHistory,
+  shouldFetchLiveMetrics,
 } from './client'
 
 describe('metrics unavailable classification', () => {
   it('recognizes metrics-server absence messages', () => {
     expect(isMetricsUnavailableMessage('Pod metrics not found (metrics-server may not be installed)')).toBe(true)
     expect(isMetricsUnavailableMessage('the server could not find the requested resource (get pods.metrics.k8s.io)')).toBe(true)
-    expect(isMetricsUnavailableMessage('the server could not find the requested resource')).toBe(true)
+    expect(isMetricsUnavailableMessage('no matches for kind "PodMetrics" in version "metrics.k8s.io/v1beta1"')).toBe(true)
+    expect(isMetricsUnavailableMessage('no resource matches "pods.metrics.k8s.io"')).toBe(true)
+    expect(isMetricsUnavailableMessage('the server could not find the requested resource')).toBe(false)
     expect(isMetricsUnavailableMessage('no access to nodes')).toBe(false)
   })
 
@@ -51,5 +54,21 @@ describe('metrics unavailable classification', () => {
     })
     expect(history.collectionError).toBe('forbidden: no access to nodes')
     expect(history.metricsUnavailable).toBeUndefined()
+  })
+
+  it('keeps generic not-found collection errors visible without a metrics API signal', () => {
+    const history = normalizeNodeMetricsHistory({
+      name: 'kind-worker',
+      dataPoints: [],
+      collectionError: 'the server could not find the requested resource',
+    })
+    expect(history.collectionError).toBe('the server could not find the requested resource')
+    expect(history.metricsUnavailable).toBeUndefined()
+  })
+
+  it('waits for history classification before live metrics fetches', () => {
+    expect(shouldFetchLiveMetrics(false, false)).toBe(false)
+    expect(shouldFetchLiveMetrics(true, false)).toBe(true)
+    expect(shouldFetchLiveMetrics(true, true)).toBe(false)
   })
 })

--- a/web/src/api/client.metrics.test.ts
+++ b/web/src/api/client.metrics.test.ts
@@ -31,11 +31,12 @@ describe('metrics unavailable classification', () => {
     expect(isMetricsUnavailableError(new ApiError('database unavailable', 500))).toBe(false)
   })
 
-  it('turns metrics API collection errors into an unavailable state', () => {
+  it('uses the server-owned unavailable flag for history responses', () => {
     const podHistory = normalizePodMetricsHistory({
       namespace: 'default',
       name: 'api',
       containers: [],
+      metricsUnavailable: true,
       collectionError: 'the server could not find the requested resource (get pods.metrics.k8s.io)',
       rawCollectionError: 'the server could not find the requested resource',
       metricsUnavailableDiagnosis: 'The v1beta1.metrics.k8s.io APIService is not registered. Install metrics-server or restore that APIService.',
@@ -49,6 +50,7 @@ describe('metrics unavailable classification', () => {
     const nodeHistory = normalizeNodeMetricsHistory({
       name: 'kind-worker',
       dataPoints: [],
+      metricsUnavailable: true,
       collectionError: 'Node metrics not found (metrics-server may not be installed)',
       rawCollectionError: 'the server could not find the requested resource',
       metricsUnavailableDiagnosis: 'The v1beta1.metrics.k8s.io APIService is not Available (FailedDiscoveryCheck). Check the metrics-server Service, endpoints, and API aggregation/TLS configuration.',
@@ -58,6 +60,19 @@ describe('metrics unavailable classification', () => {
     expect(nodeHistory.metricsUnavailable).toBe(true)
     expect(nodeHistory.metricsUnavailableReason).toBe('the server could not find the requested resource')
     expect(nodeHistory.metricsUnavailableDiagnosis).toBe('The v1beta1.metrics.k8s.io APIService is not Available (FailedDiscoveryCheck). Check the metrics-server Service, endpoints, and API aggregation/TLS configuration.')
+  })
+
+  it('does not infer history unavailability from collection-error copy', () => {
+    const history = normalizeNodeMetricsHistory({
+      name: 'kind-worker',
+      dataPoints: [],
+      collectionError: 'Node metrics not found (metrics-server may not be installed)',
+      rawCollectionError: 'the server could not find the requested resource',
+    })
+    expect(history.collectionError).toBe('Node metrics not found (metrics-server may not be installed)')
+    expect(history.rawCollectionError).toBe('the server could not find the requested resource')
+    expect(history.metricsUnavailable).toBeUndefined()
+    expect(history.metricsUnavailableReason).toBeUndefined()
   })
 
   it('keeps non-metrics collection errors visible', () => {

--- a/web/src/api/client.metrics.test.ts
+++ b/web/src/api/client.metrics.test.ts
@@ -38,22 +38,26 @@ describe('metrics unavailable classification', () => {
       containers: [],
       collectionError: 'the server could not find the requested resource (get pods.metrics.k8s.io)',
       rawCollectionError: 'the server could not find the requested resource',
+      metricsUnavailableDiagnosis: 'The v1beta1.metrics.k8s.io APIService is not registered. Install metrics-server or restore that APIService.',
     })
     expect(podHistory.collectionError).toBeUndefined()
     expect(podHistory.rawCollectionError).toBeUndefined()
     expect(podHistory.metricsUnavailable).toBe(true)
     expect(podHistory.metricsUnavailableReason).toBe('the server could not find the requested resource')
+    expect(podHistory.metricsUnavailableDiagnosis).toBe('The v1beta1.metrics.k8s.io APIService is not registered. Install metrics-server or restore that APIService.')
 
     const nodeHistory = normalizeNodeMetricsHistory({
       name: 'kind-worker',
       dataPoints: [],
       collectionError: 'Node metrics not found (metrics-server may not be installed)',
       rawCollectionError: 'the server could not find the requested resource',
+      metricsUnavailableDiagnosis: 'The v1beta1.metrics.k8s.io APIService is not Available (FailedDiscoveryCheck). Check the metrics-server Service, endpoints, and API aggregation/TLS configuration.',
     })
     expect(nodeHistory.collectionError).toBeUndefined()
     expect(nodeHistory.rawCollectionError).toBeUndefined()
     expect(nodeHistory.metricsUnavailable).toBe(true)
     expect(nodeHistory.metricsUnavailableReason).toBe('the server could not find the requested resource')
+    expect(nodeHistory.metricsUnavailableDiagnosis).toBe('The v1beta1.metrics.k8s.io APIService is not Available (FailedDiscoveryCheck). Check the metrics-server Service, endpoints, and API aggregation/TLS configuration.')
   })
 
   it('keeps non-metrics collection errors visible', () => {

--- a/web/src/api/client.metrics.test.ts
+++ b/web/src/api/client.metrics.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
   ApiError,
+  getVisibleLiveMetrics,
   isMetricsUnavailableError,
+  isLiveMetricsUnavailable,
   normalizeNodeMetricsHistory,
   normalizePodMetricsHistory,
   shouldFetchLiveMetrics,
@@ -87,5 +89,18 @@ describe('metrics unavailable classification', () => {
     expect(shouldFetchLiveMetrics(false, false)).toBe(false)
     expect(shouldFetchLiveMetrics(true, false)).toBe(true)
     expect(shouldFetchLiveMetrics(true, true)).toBe(false)
+  })
+
+  it('does not expose cached live metrics while the live query is disabled', () => {
+    const cachedMetrics = { usage: { cpu: '10m', memory: '20Mi' } }
+    expect(getVisibleLiveMetrics(false, false, cachedMetrics)).toBeUndefined()
+    expect(getVisibleLiveMetrics(true, true, cachedMetrics)).toBeUndefined()
+    expect(getVisibleLiveMetrics(true, false, cachedMetrics)).toBe(cachedMetrics)
+  })
+
+  it('treats null live metrics as unavailable only after live fetch is enabled', () => {
+    expect(isLiveMetricsUnavailable(false, null)).toBe(false)
+    expect(isLiveMetricsUnavailable(true, null)).toBe(true)
+    expect(isLiveMetricsUnavailable(true, undefined)).toBe(false)
   })
 })

--- a/web/src/api/client.metrics.test.ts
+++ b/web/src/api/client.metrics.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ApiError,
+  isMetricsUnavailableError,
+  isMetricsUnavailableMessage,
+  normalizeNodeMetricsHistory,
+  normalizePodMetricsHistory,
+} from './client'
+
+describe('metrics unavailable classification', () => {
+  it('recognizes metrics-server absence messages', () => {
+    expect(isMetricsUnavailableMessage('Pod metrics not found (metrics-server may not be installed)')).toBe(true)
+    expect(isMetricsUnavailableMessage('the server could not find the requested resource (get pods.metrics.k8s.io)')).toBe(true)
+    expect(isMetricsUnavailableMessage('the server could not find the requested resource')).toBe(true)
+    expect(isMetricsUnavailableMessage('no access to nodes')).toBe(false)
+  })
+
+  it('only treats metrics-shaped API failures as metrics unavailable', () => {
+    expect(isMetricsUnavailableError(new ApiError('Node metrics not found (metrics-server may not be installed)', 404))).toBe(true)
+    expect(isMetricsUnavailableError(new ApiError('the server could not find the requested resource (get nodes.metrics.k8s.io)', 500))).toBe(true)
+    expect(isMetricsUnavailableError(new ApiError('failed to get node metrics: the server could not find the requested resource', 500))).toBe(true)
+    expect(isMetricsUnavailableError(new ApiError('the server could not find the requested resource', 500))).toBe(false)
+    expect(isMetricsUnavailableError(new ApiError('no access to nodes', 403))).toBe(false)
+    expect(isMetricsUnavailableError(new ApiError('database unavailable', 500))).toBe(false)
+  })
+
+  it('turns metrics API collection errors into an unavailable state', () => {
+    const podHistory = normalizePodMetricsHistory({
+      namespace: 'default',
+      name: 'api',
+      containers: [],
+      collectionError: 'the server could not find the requested resource (get pods.metrics.k8s.io)',
+    })
+    expect(podHistory.collectionError).toBeUndefined()
+    expect(podHistory.metricsUnavailable).toBe(true)
+
+    const nodeHistory = normalizeNodeMetricsHistory({
+      name: 'kind-worker',
+      dataPoints: [],
+      collectionError: 'Node metrics not found (metrics-server may not be installed)',
+    })
+    expect(nodeHistory.collectionError).toBeUndefined()
+    expect(nodeHistory.metricsUnavailable).toBe(true)
+  })
+
+  it('keeps non-metrics collection errors visible', () => {
+    const history = normalizeNodeMetricsHistory({
+      name: 'kind-worker',
+      dataPoints: [],
+      collectionError: 'forbidden: no access to nodes',
+    })
+    expect(history.collectionError).toBe('forbidden: no access to nodes')
+    expect(history.metricsUnavailable).toBeUndefined()
+  })
+})

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1386,12 +1386,12 @@ function withoutCollectionError<T extends { collectionError?: string; rawCollect
 }
 
 export function normalizePodMetricsHistory(history: PodMetricsHistory): PodMetricsHistory {
-  if (!isMetricsUnavailableMessage(history.collectionError)) return history
+  if (history.metricsUnavailable !== true) return history
   return { ...withoutCollectionError(history), metricsUnavailable: true, metricsUnavailableReason: history.rawCollectionError || history.collectionError }
 }
 
 export function normalizeNodeMetricsHistory(history: NodeMetricsHistory): NodeMetricsHistory {
-  if (!isMetricsUnavailableMessage(history.collectionError)) return history
+  if (history.metricsUnavailable !== true) return history
   return { ...withoutCollectionError(history), metricsUnavailable: true, metricsUnavailableReason: history.rawCollectionError || history.collectionError }
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1363,6 +1363,7 @@ export interface PodMetricsHistory {
   containers: ContainerMetricsHistory[]
   collectionError?: string
   rawCollectionError?: string
+  metricsUnavailableDiagnosis?: string
   metricsUnavailable?: boolean
   metricsUnavailableReason?: string
 }
@@ -1372,6 +1373,7 @@ export interface NodeMetricsHistory {
   dataPoints: MetricsDataPoint[]
   collectionError?: string
   rawCollectionError?: string
+  metricsUnavailableDiagnosis?: string
   metricsUnavailable?: boolean
   metricsUnavailableReason?: string
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1382,6 +1382,15 @@ export function shouldFetchLiveMetrics(historySettled: boolean, metricsUnavailab
   return historySettled && !metricsUnavailable
 }
 
+export function isLiveMetricsUnavailable(liveMetricsEnabled: boolean, metrics: unknown): boolean {
+  return liveMetricsEnabled && metrics === null
+}
+
+export function getVisibleLiveMetrics<T>(liveMetricsEnabled: boolean, metricsUnavailable: boolean, metrics: T | null | undefined): T | undefined {
+  if (!liveMetricsEnabled || metricsUnavailable) return undefined
+  return metrics ?? undefined
+}
+
 // Fetch historical metrics for a pod (last ~1 hour)
 export function usePodMetricsHistory(namespace: string, podName: string) {
   return useQuery<PodMetricsHistory>({

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -106,13 +106,15 @@ function mentionsMetricsAPIGroup(message: string): boolean {
 
 function hasMetricsUnavailablePhrase(message: string): boolean {
   return (
+    message.includes('may not be installed') ||
     message.includes('not found') ||
     message.includes('could not find the requested resource') ||
     message.includes('no matches for kind') ||
     message.includes('no resource matches') ||
     message.includes('no metrics known') ||
     message.includes('not available') ||
-    message.includes('unable to fetch metrics')
+    message.includes('unable to fetch metrics') ||
+    message.includes('currently unable to handle the request')
   )
 }
 
@@ -120,9 +122,13 @@ export function isMetricsUnavailableMessage(message: unknown): boolean {
   if (typeof message !== 'string') return false
   const normalized = message.toLowerCase()
   if (!normalized) return false
-  if (normalized.includes('metrics-server')) return true
-  if (!mentionsMetricsAPIGroup(normalized)) return false
-  return hasMetricsUnavailablePhrase(normalized)
+  const hasMetricsSignal = (
+    mentionsMetricsAPIGroup(normalized) ||
+    normalized.includes('pod metrics') ||
+    normalized.includes('node metrics') ||
+    normalized.includes('metrics-server')
+  )
+  return hasMetricsSignal && hasMetricsUnavailablePhrase(normalized)
 }
 
 export function isMetricsUnavailableError(error: unknown): boolean {
@@ -137,7 +143,7 @@ export function isMetricsUnavailableError(error: unknown): boolean {
       normalized.includes('pod metrics') ||
       normalized.includes('node metrics')
     )
-    return hasMetricsSignal && (normalized.includes('metrics-server') || hasMetricsUnavailablePhrase(normalized))
+    return hasMetricsSignal && hasMetricsUnavailablePhrase(normalized)
   })
 }
 
@@ -1356,30 +1362,35 @@ export interface PodMetricsHistory {
   name: string
   containers: ContainerMetricsHistory[]
   collectionError?: string
+  rawCollectionError?: string
   metricsUnavailable?: boolean
+  metricsUnavailableReason?: string
 }
 
 export interface NodeMetricsHistory {
   name: string
   dataPoints: MetricsDataPoint[]
   collectionError?: string
+  rawCollectionError?: string
   metricsUnavailable?: boolean
+  metricsUnavailableReason?: string
 }
 
-function withoutCollectionError<T extends { collectionError?: string }>(history: T): T {
+function withoutCollectionError<T extends { collectionError?: string; rawCollectionError?: string }>(history: T): T {
   const next = { ...history }
   delete next.collectionError
+  delete next.rawCollectionError
   return next
 }
 
 export function normalizePodMetricsHistory(history: PodMetricsHistory): PodMetricsHistory {
   if (!isMetricsUnavailableMessage(history.collectionError)) return history
-  return { ...withoutCollectionError(history), metricsUnavailable: true }
+  return { ...withoutCollectionError(history), metricsUnavailable: true, metricsUnavailableReason: history.rawCollectionError || history.collectionError }
 }
 
 export function normalizeNodeMetricsHistory(history: NodeMetricsHistory): NodeMetricsHistory {
   if (!isMetricsUnavailableMessage(history.collectionError)) return history
-  return { ...withoutCollectionError(history), metricsUnavailable: true }
+  return { ...withoutCollectionError(history), metricsUnavailable: true, metricsUnavailableReason: history.rawCollectionError || history.collectionError }
 }
 
 export function shouldFetchLiveMetrics(historySettled: boolean, metricsUnavailable: boolean): boolean {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -93,6 +93,38 @@ export function isForbiddenError(error: unknown): boolean {
   return error instanceof ApiError && error.status === 403
 }
 
+export function isMetricsUnavailableMessage(message: unknown): boolean {
+  if (typeof message !== 'string') return false
+  const normalized = message.toLowerCase()
+  if (!normalized) return false
+  if (normalized.includes('metrics-server')) return true
+  if (normalized.includes('could not find the requested resource')) return true
+  if (!normalized.includes('metrics.k8s.io')) return false
+  return (
+    normalized.includes('not found') ||
+    normalized.includes('could not find the requested resource') ||
+    normalized.includes('no metrics known') ||
+    normalized.includes('not available') ||
+    normalized.includes('unable to fetch metrics')
+  )
+}
+
+export function isMetricsUnavailableError(error: unknown): boolean {
+  if (!(error instanceof ApiError)) return false
+  if (error.status !== 404 && error.status !== 500) return false
+  return [error.message, error.data?.error].some((message) => {
+    if (typeof message !== 'string') return false
+    const normalized = message.toLowerCase()
+    const hasMetricsSignal = (
+      normalized.includes('metrics-server') ||
+      normalized.includes('metrics.k8s.io') ||
+      normalized.includes('pod metrics') ||
+      normalized.includes('node metrics')
+    )
+    return hasMetricsSignal && isMetricsUnavailableMessage(message)
+  })
+}
+
 export async function fetchJSON<T>(path: string, signal?: AbortSignal): Promise<T> {
   const response = await apiFetch(`${getApiBase()}${path}`, signal ? { signal } : undefined)
   if (!response.ok) {
@@ -1243,25 +1275,54 @@ export interface NodeMetrics {
   }
 }
 
+async function fetchMetricsOrNull<T>(path: string): Promise<T | null> {
+  try {
+    return await fetchJSON<T>(path)
+  } catch (error) {
+    if (isMetricsUnavailableError(error)) return null
+    throw error
+  }
+}
+
+function retryMetricsQuery(failureCount: number, error: unknown): boolean {
+  return !isMetricsUnavailableError(error) && failureCount < 1
+}
+
+function metricsRefetchInterval(query: { state: { data: unknown } }): number | false {
+  return query.state.data === null ? false : 30000
+}
+
+function metricsStaleTime(query: { state: { data: unknown } }): number {
+  return query.state.data === null ? Infinity : 15000
+}
+
+function refetchMetricsOnMount(query: { state: { data: unknown } }): boolean {
+  return query.state.data !== null
+}
+
 // Fetch metrics for a specific pod
-export function usePodMetrics(namespace: string, podName: string) {
-  return useQuery<PodMetrics>({
+export function usePodMetrics(namespace: string, podName: string, options?: { enabled?: boolean }) {
+  return useQuery<PodMetrics | null>({
     queryKey: ['pod-metrics', namespace, podName],
-    queryFn: () => fetchJSON(`/metrics/pods/${namespace}/${podName}`),
-    enabled: Boolean(namespace && podName),
-    staleTime: 15000, // Metrics are fresh for 15 seconds
-    refetchInterval: 30000, // Refresh every 30 seconds
+    queryFn: () => fetchMetricsOrNull<PodMetrics>(`/metrics/pods/${namespace}/${podName}`),
+    enabled: Boolean(namespace && podName) && (options?.enabled ?? true),
+    staleTime: metricsStaleTime,
+    refetchInterval: metricsRefetchInterval,
+    refetchOnMount: refetchMetricsOnMount,
+    retry: retryMetricsQuery,
   })
 }
 
 // Fetch metrics for a specific node
-export function useNodeMetrics(nodeName: string) {
-  return useQuery<NodeMetrics>({
+export function useNodeMetrics(nodeName: string, options?: { enabled?: boolean }) {
+  return useQuery<NodeMetrics | null>({
     queryKey: ['node-metrics', nodeName],
-    queryFn: () => fetchJSON(`/metrics/nodes/${nodeName}`),
-    enabled: Boolean(nodeName),
-    staleTime: 15000,
-    refetchInterval: 30000,
+    queryFn: () => fetchMetricsOrNull<NodeMetrics>(`/metrics/nodes/${nodeName}`),
+    enabled: Boolean(nodeName) && (options?.enabled ?? true),
+    staleTime: metricsStaleTime,
+    refetchInterval: metricsRefetchInterval,
+    refetchOnMount: refetchMetricsOnMount,
+    retry: retryMetricsQuery,
   })
 }
 
@@ -1285,19 +1346,33 @@ export interface PodMetricsHistory {
   name: string
   containers: ContainerMetricsHistory[]
   collectionError?: string
+  metricsUnavailable?: boolean
 }
 
 export interface NodeMetricsHistory {
   name: string
   dataPoints: MetricsDataPoint[]
   collectionError?: string
+  metricsUnavailable?: boolean
+}
+
+export function normalizePodMetricsHistory(history: PodMetricsHistory): PodMetricsHistory {
+  if (!isMetricsUnavailableMessage(history.collectionError)) return history
+  const { collectionError: _collectionError, ...rest } = history
+  return { ...rest, metricsUnavailable: true }
+}
+
+export function normalizeNodeMetricsHistory(history: NodeMetricsHistory): NodeMetricsHistory {
+  if (!isMetricsUnavailableMessage(history.collectionError)) return history
+  const { collectionError: _collectionError, ...rest } = history
+  return { ...rest, metricsUnavailable: true }
 }
 
 // Fetch historical metrics for a pod (last ~1 hour)
 export function usePodMetricsHistory(namespace: string, podName: string) {
   return useQuery<PodMetricsHistory>({
     queryKey: ['pod-metrics-history', namespace, podName],
-    queryFn: () => fetchJSON(`/metrics/pods/${namespace}/${podName}/history`),
+    queryFn: async () => normalizePodMetricsHistory(await fetchJSON<PodMetricsHistory>(`/metrics/pods/${namespace}/${podName}/history`)),
     enabled: Boolean(namespace && podName),
     staleTime: 25000, // Slightly less than poll interval
     refetchInterval: 30000, // Match the backend poll interval
@@ -1308,7 +1383,7 @@ export function usePodMetricsHistory(namespace: string, podName: string) {
 export function useNodeMetricsHistory(nodeName: string) {
   return useQuery<NodeMetricsHistory>({
     queryKey: ['node-metrics-history', nodeName],
-    queryFn: () => fetchJSON(`/metrics/nodes/${nodeName}/history`),
+    queryFn: async () => normalizeNodeMetricsHistory(await fetchJSON<NodeMetricsHistory>(`/metrics/nodes/${nodeName}/history`)),
     enabled: Boolean(nodeName),
     staleTime: 25000,
     refetchInterval: 30000,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -118,19 +118,6 @@ function hasMetricsUnavailablePhrase(message: string): boolean {
   )
 }
 
-export function isMetricsUnavailableMessage(message: unknown): boolean {
-  if (typeof message !== 'string') return false
-  const normalized = message.toLowerCase()
-  if (!normalized) return false
-  const hasMetricsSignal = (
-    mentionsMetricsAPIGroup(normalized) ||
-    normalized.includes('pod metrics') ||
-    normalized.includes('node metrics') ||
-    normalized.includes('metrics-server')
-  )
-  return hasMetricsSignal && hasMetricsUnavailablePhrase(normalized)
-}
-
 export function isMetricsUnavailableError(error: unknown): boolean {
   if (!(error instanceof ApiError)) return false
   if (error.status !== 404 && error.status !== 500) return false
@@ -1310,17 +1297,13 @@ function retryMetricsQuery(failureCount: number, error: unknown): boolean {
   return !isMetricsUnavailableError(error) && failureCount < 1
 }
 
-function metricsStaleTime(query: { state: { data: unknown } }): number {
-  return query.state.data === null ? 0 : 15000
-}
-
 // Fetch metrics for a specific pod
 export function usePodMetrics(namespace: string, podName: string, options?: { enabled?: boolean }) {
   return useQuery<PodMetrics | null>({
     queryKey: ['pod-metrics', namespace, podName],
     queryFn: () => fetchMetricsOrNull<PodMetrics>(`/metrics/pods/${namespace}/${podName}`),
     enabled: Boolean(namespace && podName) && (options?.enabled ?? true),
-    staleTime: metricsStaleTime,
+    staleTime: 15000,
     refetchInterval: 30000,
     refetchOnMount: 'always',
     refetchOnReconnect: 'always',
@@ -1334,7 +1317,7 @@ export function useNodeMetrics(nodeName: string, options?: { enabled?: boolean }
     queryKey: ['node-metrics', nodeName],
     queryFn: () => fetchMetricsOrNull<NodeMetrics>(`/metrics/nodes/${nodeName}`),
     enabled: Boolean(nodeName) && (options?.enabled ?? true),
-    staleTime: metricsStaleTime,
+    staleTime: 15000,
     refetchInterval: 30000,
     refetchOnMount: 'always',
     refetchOnReconnect: 'always',

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -93,13 +93,24 @@ export function isForbiddenError(error: unknown): boolean {
   return error instanceof ApiError && error.status === 403
 }
 
+const METRICS_API_GROUP_TOKENS = ['metrics', 'k8s', 'io'] as const
+
+function mentionsMetricsAPIGroup(message: string): boolean {
+  const tokens = message.split(/[^a-z0-9]+/).filter(Boolean)
+  return tokens.some((token, index) => (
+    token === METRICS_API_GROUP_TOKENS[0] &&
+    tokens[index + 1] === METRICS_API_GROUP_TOKENS[1] &&
+    tokens[index + 2] === METRICS_API_GROUP_TOKENS[2]
+  ))
+}
+
 export function isMetricsUnavailableMessage(message: unknown): boolean {
   if (typeof message !== 'string') return false
   const normalized = message.toLowerCase()
   if (!normalized) return false
   if (normalized.includes('metrics-server')) return true
   if (normalized.includes('could not find the requested resource')) return true
-  if (!normalized.includes('metrics.k8s.io')) return false
+  if (!mentionsMetricsAPIGroup(normalized)) return false
   return (
     normalized.includes('not found') ||
     normalized.includes('could not find the requested resource') ||
@@ -117,7 +128,7 @@ export function isMetricsUnavailableError(error: unknown): boolean {
     const normalized = message.toLowerCase()
     const hasMetricsSignal = (
       normalized.includes('metrics-server') ||
-      normalized.includes('metrics.k8s.io') ||
+      mentionsMetricsAPIGroup(normalized) ||
       normalized.includes('pod metrics') ||
       normalized.includes('node metrics')
     )

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -104,20 +104,25 @@ function mentionsMetricsAPIGroup(message: string): boolean {
   ))
 }
 
+function hasMetricsUnavailablePhrase(message: string): boolean {
+  return (
+    message.includes('not found') ||
+    message.includes('could not find the requested resource') ||
+    message.includes('no matches for kind') ||
+    message.includes('no resource matches') ||
+    message.includes('no metrics known') ||
+    message.includes('not available') ||
+    message.includes('unable to fetch metrics')
+  )
+}
+
 export function isMetricsUnavailableMessage(message: unknown): boolean {
   if (typeof message !== 'string') return false
   const normalized = message.toLowerCase()
   if (!normalized) return false
   if (normalized.includes('metrics-server')) return true
-  if (normalized.includes('could not find the requested resource')) return true
   if (!mentionsMetricsAPIGroup(normalized)) return false
-  return (
-    normalized.includes('not found') ||
-    normalized.includes('could not find the requested resource') ||
-    normalized.includes('no metrics known') ||
-    normalized.includes('not available') ||
-    normalized.includes('unable to fetch metrics')
-  )
+  return hasMetricsUnavailablePhrase(normalized)
 }
 
 export function isMetricsUnavailableError(error: unknown): boolean {
@@ -132,7 +137,7 @@ export function isMetricsUnavailableError(error: unknown): boolean {
       normalized.includes('pod metrics') ||
       normalized.includes('node metrics')
     )
-    return hasMetricsSignal && isMetricsUnavailableMessage(message)
+    return hasMetricsSignal && (normalized.includes('metrics-server') || hasMetricsUnavailablePhrase(normalized))
   })
 }
 
@@ -1299,16 +1304,8 @@ function retryMetricsQuery(failureCount: number, error: unknown): boolean {
   return !isMetricsUnavailableError(error) && failureCount < 1
 }
 
-function metricsRefetchInterval(query: { state: { data: unknown } }): number | false {
-  return query.state.data === null ? false : 30000
-}
-
 function metricsStaleTime(query: { state: { data: unknown } }): number {
-  return query.state.data === null ? Infinity : 15000
-}
-
-function refetchMetricsOnMount(query: { state: { data: unknown } }): boolean {
-  return query.state.data !== null
+  return query.state.data === null ? 0 : 15000
 }
 
 // Fetch metrics for a specific pod
@@ -1318,8 +1315,9 @@ export function usePodMetrics(namespace: string, podName: string, options?: { en
     queryFn: () => fetchMetricsOrNull<PodMetrics>(`/metrics/pods/${namespace}/${podName}`),
     enabled: Boolean(namespace && podName) && (options?.enabled ?? true),
     staleTime: metricsStaleTime,
-    refetchInterval: metricsRefetchInterval,
-    refetchOnMount: refetchMetricsOnMount,
+    refetchInterval: 30000,
+    refetchOnMount: 'always',
+    refetchOnReconnect: 'always',
     retry: retryMetricsQuery,
   })
 }
@@ -1331,8 +1329,9 @@ export function useNodeMetrics(nodeName: string, options?: { enabled?: boolean }
     queryFn: () => fetchMetricsOrNull<NodeMetrics>(`/metrics/nodes/${nodeName}`),
     enabled: Boolean(nodeName) && (options?.enabled ?? true),
     staleTime: metricsStaleTime,
-    refetchInterval: metricsRefetchInterval,
-    refetchOnMount: refetchMetricsOnMount,
+    refetchInterval: 30000,
+    refetchOnMount: 'always',
+    refetchOnReconnect: 'always',
     retry: retryMetricsQuery,
   })
 }
@@ -1367,16 +1366,24 @@ export interface NodeMetricsHistory {
   metricsUnavailable?: boolean
 }
 
+function withoutCollectionError<T extends { collectionError?: string }>(history: T): T {
+  const next = { ...history }
+  delete next.collectionError
+  return next
+}
+
 export function normalizePodMetricsHistory(history: PodMetricsHistory): PodMetricsHistory {
   if (!isMetricsUnavailableMessage(history.collectionError)) return history
-  const { collectionError: _collectionError, ...rest } = history
-  return { ...rest, metricsUnavailable: true }
+  return { ...withoutCollectionError(history), metricsUnavailable: true }
 }
 
 export function normalizeNodeMetricsHistory(history: NodeMetricsHistory): NodeMetricsHistory {
   if (!isMetricsUnavailableMessage(history.collectionError)) return history
-  const { collectionError: _collectionError, ...rest } = history
-  return { ...rest, metricsUnavailable: true }
+  return { ...withoutCollectionError(history), metricsUnavailable: true }
+}
+
+export function shouldFetchLiveMetrics(historySettled: boolean, metricsUnavailable: boolean): boolean {
+  return historySettled && !metricsUnavailable
 }
 
 // Fetch historical metrics for a pod (last ~1 hour)
@@ -1631,9 +1638,12 @@ export function useAutoPromConnect(): void {
     const timeout = window.setTimeout(() => {
       // Direct apiFetch (not via the usePrometheusConnect mutation) so the
       // meta-driven toast handler stays silent — the user didn't click anything.
-      apiFetch(`${getApiBase()}/prometheus/connect`, { method: 'POST' })
-        .then(resp => {
+      apiFetch(`${getApiBase()}/prometheus/connect?optional=true`, { method: 'POST' })
+        .then(async resp => {
           if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+          const nextStatus = await resp.json() as PrometheusStatus
+          queryClient.setQueryData(['prometheus-status'], nextStatus)
+          if (!nextStatus.connected) throw new Error(nextStatus.error || 'Prometheus unavailable')
           queryClient.invalidateQueries({ queryKey: ['prometheus-status'] })
         })
         .catch(() => {

--- a/web/src/components/resources/renderers/NodeRenderer.tsx
+++ b/web/src/components/resources/renderers/NodeRenderer.tsx
@@ -13,8 +13,12 @@ export function NodeRenderer({ data, relationships }: NodeRendererProps) {
   const nodeName = data.metadata?.name
 
   // Fetch node metrics
-  const { data: metrics } = useNodeMetrics(nodeName)
-  const { data: metricsHistory } = useNodeMetricsHistory(nodeName)
+  const metricsHistoryQuery = useNodeMetricsHistory(nodeName)
+  const { data: metricsHistory } = metricsHistoryQuery
+  const historyMetricsUnavailable = metricsHistory?.metricsUnavailable === true
+  const liveMetricsEnabled = !historyMetricsUnavailable && (metricsHistoryQuery.isSuccess || metricsHistoryQuery.isError)
+  const { data: metrics } = useNodeMetrics(nodeName, { enabled: liveMetricsEnabled })
+  const metricsUnavailable = metrics === null || historyMetricsUnavailable
 
   // Determine whether to hide metrics-server section (Prometheus has data)
   const { data: prometheusStatus } = usePrometheusStatus()
@@ -36,8 +40,9 @@ export function NodeRenderer({ data, relationships }: NodeRendererProps) {
         params.set('filters', serializeColumnFilters({ node: [nodeName] }))
         navigate(`/resources/pods?${params.toString()}`)
       } : undefined}
-      metrics={metrics}
+      metrics={metrics ?? undefined}
       metricsHistory={metricsHistory}
+      metricsUnavailable={metricsUnavailable}
       hideMetricsServer={hideMetricsServer}
     />
   )

--- a/web/src/components/resources/renderers/NodeRenderer.tsx
+++ b/web/src/components/resources/renderers/NodeRenderer.tsx
@@ -1,6 +1,6 @@
 import { NodeRenderer as BaseNodeRenderer } from '@skyhook-io/k8s-ui/components/resources/renderers/NodeRenderer'
 import { useNavigate } from 'react-router-dom'
-import { shouldFetchLiveMetrics, useNodeMetrics, useNodeMetricsHistory, usePrometheusResourceMetrics, usePrometheusStatus } from '../../../api/client'
+import { getVisibleLiveMetrics, isLiveMetricsUnavailable, shouldFetchLiveMetrics, useNodeMetrics, useNodeMetricsHistory, usePrometheusResourceMetrics, usePrometheusStatus } from '../../../api/client'
 import { serializeColumnFilters } from '../resource-utils'
 
 interface NodeRendererProps {
@@ -18,8 +18,8 @@ export function NodeRenderer({ data, relationships }: NodeRendererProps) {
   const historyMetricsUnavailable = metricsHistory?.metricsUnavailable === true
   const liveMetricsEnabled = shouldFetchLiveMetrics(metricsHistoryQuery.isFetched || metricsHistoryQuery.isError, historyMetricsUnavailable)
   const { data: metrics } = useNodeMetrics(nodeName, { enabled: liveMetricsEnabled })
-  const metricsUnavailable = historyMetricsUnavailable
-  const visibleMetrics = historyMetricsUnavailable ? undefined : (metrics ?? undefined)
+  const metricsUnavailable = historyMetricsUnavailable || isLiveMetricsUnavailable(liveMetricsEnabled, metrics)
+  const visibleMetrics = getVisibleLiveMetrics(liveMetricsEnabled, metricsUnavailable, metrics)
 
   // Determine whether to hide metrics-server section (Prometheus has data)
   const { data: prometheusStatus } = usePrometheusStatus()

--- a/web/src/components/resources/renderers/NodeRenderer.tsx
+++ b/web/src/components/resources/renderers/NodeRenderer.tsx
@@ -1,6 +1,6 @@
 import { NodeRenderer as BaseNodeRenderer } from '@skyhook-io/k8s-ui/components/resources/renderers/NodeRenderer'
 import { useNavigate } from 'react-router-dom'
-import { useNodeMetrics, useNodeMetricsHistory, usePrometheusResourceMetrics, usePrometheusStatus } from '../../../api/client'
+import { shouldFetchLiveMetrics, useNodeMetrics, useNodeMetricsHistory, usePrometheusResourceMetrics, usePrometheusStatus } from '../../../api/client'
 import { serializeColumnFilters } from '../resource-utils'
 
 interface NodeRendererProps {
@@ -16,9 +16,9 @@ export function NodeRenderer({ data, relationships }: NodeRendererProps) {
   const metricsHistoryQuery = useNodeMetricsHistory(nodeName)
   const { data: metricsHistory } = metricsHistoryQuery
   const historyMetricsUnavailable = metricsHistory?.metricsUnavailable === true
-  const liveMetricsEnabled = !historyMetricsUnavailable && (metricsHistoryQuery.isSuccess || metricsHistoryQuery.isError)
+  const liveMetricsEnabled = shouldFetchLiveMetrics(metricsHistoryQuery.isFetched || metricsHistoryQuery.isError, historyMetricsUnavailable)
   const { data: metrics } = useNodeMetrics(nodeName, { enabled: liveMetricsEnabled })
-  const metricsUnavailable = metrics === null || historyMetricsUnavailable
+  const metricsUnavailable = historyMetricsUnavailable
   const visibleMetrics = historyMetricsUnavailable ? undefined : (metrics ?? undefined)
 
   // Determine whether to hide metrics-server section (Prometheus has data)

--- a/web/src/components/resources/renderers/NodeRenderer.tsx
+++ b/web/src/components/resources/renderers/NodeRenderer.tsx
@@ -19,6 +19,7 @@ export function NodeRenderer({ data, relationships }: NodeRendererProps) {
   const liveMetricsEnabled = !historyMetricsUnavailable && (metricsHistoryQuery.isSuccess || metricsHistoryQuery.isError)
   const { data: metrics } = useNodeMetrics(nodeName, { enabled: liveMetricsEnabled })
   const metricsUnavailable = metrics === null || historyMetricsUnavailable
+  const visibleMetrics = historyMetricsUnavailable ? undefined : (metrics ?? undefined)
 
   // Determine whether to hide metrics-server section (Prometheus has data)
   const { data: prometheusStatus } = usePrometheusStatus()
@@ -40,7 +41,7 @@ export function NodeRenderer({ data, relationships }: NodeRendererProps) {
         params.set('filters', serializeColumnFilters({ node: [nodeName] }))
         navigate(`/resources/pods?${params.toString()}`)
       } : undefined}
-      metrics={metrics ?? undefined}
+      metrics={visibleMetrics}
       metricsHistory={metricsHistory}
       metricsUnavailable={metricsUnavailable}
       hideMetricsServer={hideMetricsServer}

--- a/web/src/components/resources/renderers/PodRenderer.tsx
+++ b/web/src/components/resources/renderers/PodRenderer.tsx
@@ -34,8 +34,12 @@ export function PodRenderer({ data, onCopy, copied, onNavigate, onOpenLogs, reso
   const showPortForward = canPortForward || !isLocal
 
   // Metrics
-  const { data: metrics } = usePodMetrics(namespace, podName)
-  const { data: metricsHistory } = usePodMetricsHistory(namespace, podName)
+  const metricsHistoryQuery = usePodMetricsHistory(namespace, podName)
+  const { data: metricsHistory } = metricsHistoryQuery
+  const historyMetricsUnavailable = metricsHistory?.metricsUnavailable === true
+  const liveMetricsEnabled = !historyMetricsUnavailable && (metricsHistoryQuery.isSuccess || metricsHistoryQuery.isError)
+  const { data: metrics } = usePodMetrics(namespace, podName, { enabled: liveMetricsEnabled })
+  const metricsUnavailable = metrics === null || historyMetricsUnavailable
 
   // Hide metrics-server section when Prometheus has CPU data
   const { data: prometheusStatus } = usePrometheusStatus()
@@ -82,8 +86,9 @@ export function PodRenderer({ data, onCopy, copied, onNavigate, onOpenLogs, reso
           disabled={disabled}
         />
       )}
-      metrics={metrics}
+      metrics={metrics ?? undefined}
       metricsHistory={metricsHistory}
+      metricsUnavailable={metricsUnavailable}
       hideMetricsServer={hideMetricsServer}
       renderImageBrowser={({ image, namespace: ns, podName: pod, pullSecrets, onClose, onSwitchToPodFiles }) => (
         <ImageFilesystemModal

--- a/web/src/components/resources/renderers/PodRenderer.tsx
+++ b/web/src/components/resources/renderers/PodRenderer.tsx
@@ -3,7 +3,7 @@ import type { CopyHandler } from '@skyhook-io/k8s-ui/components/ui/drawer-compon
 import type { ResolvedEnvFrom } from '@skyhook-io/k8s-ui'
 import { useOpenTerminal, useOpenLogs } from '../../dock'
 import { useNamespacedCapabilities, useIsLocalDeployment } from '../../../contexts/CapabilitiesContext'
-import { usePodMetrics, usePodMetricsHistory, usePrometheusResourceMetrics, usePrometheusStatus } from '../../../api/client'
+import { shouldFetchLiveMetrics, usePodMetrics, usePodMetricsHistory, usePrometheusResourceMetrics, usePrometheusStatus } from '../../../api/client'
 import { useRBACSubject } from '../../../api/rbac'
 import { PortForwardInlineButton } from '../../portforward/PortForwardButton'
 import { ImageFilesystemModal } from '../ImageFilesystemModal'
@@ -37,9 +37,9 @@ export function PodRenderer({ data, onCopy, copied, onNavigate, onOpenLogs, reso
   const metricsHistoryQuery = usePodMetricsHistory(namespace, podName)
   const { data: metricsHistory } = metricsHistoryQuery
   const historyMetricsUnavailable = metricsHistory?.metricsUnavailable === true
-  const liveMetricsEnabled = !historyMetricsUnavailable && (metricsHistoryQuery.isSuccess || metricsHistoryQuery.isError)
+  const liveMetricsEnabled = shouldFetchLiveMetrics(metricsHistoryQuery.isFetched || metricsHistoryQuery.isError, historyMetricsUnavailable)
   const { data: metrics } = usePodMetrics(namespace, podName, { enabled: liveMetricsEnabled })
-  const metricsUnavailable = metrics === null || historyMetricsUnavailable
+  const metricsUnavailable = historyMetricsUnavailable
   const visibleMetrics = historyMetricsUnavailable ? undefined : (metrics ?? undefined)
 
   // Hide metrics-server section when Prometheus has CPU data

--- a/web/src/components/resources/renderers/PodRenderer.tsx
+++ b/web/src/components/resources/renderers/PodRenderer.tsx
@@ -3,7 +3,7 @@ import type { CopyHandler } from '@skyhook-io/k8s-ui/components/ui/drawer-compon
 import type { ResolvedEnvFrom } from '@skyhook-io/k8s-ui'
 import { useOpenTerminal, useOpenLogs } from '../../dock'
 import { useNamespacedCapabilities, useIsLocalDeployment } from '../../../contexts/CapabilitiesContext'
-import { shouldFetchLiveMetrics, usePodMetrics, usePodMetricsHistory, usePrometheusResourceMetrics, usePrometheusStatus } from '../../../api/client'
+import { getVisibleLiveMetrics, isLiveMetricsUnavailable, shouldFetchLiveMetrics, usePodMetrics, usePodMetricsHistory, usePrometheusResourceMetrics, usePrometheusStatus } from '../../../api/client'
 import { useRBACSubject } from '../../../api/rbac'
 import { PortForwardInlineButton } from '../../portforward/PortForwardButton'
 import { ImageFilesystemModal } from '../ImageFilesystemModal'
@@ -39,8 +39,8 @@ export function PodRenderer({ data, onCopy, copied, onNavigate, onOpenLogs, reso
   const historyMetricsUnavailable = metricsHistory?.metricsUnavailable === true
   const liveMetricsEnabled = shouldFetchLiveMetrics(metricsHistoryQuery.isFetched || metricsHistoryQuery.isError, historyMetricsUnavailable)
   const { data: metrics } = usePodMetrics(namespace, podName, { enabled: liveMetricsEnabled })
-  const metricsUnavailable = historyMetricsUnavailable
-  const visibleMetrics = historyMetricsUnavailable ? undefined : (metrics ?? undefined)
+  const metricsUnavailable = historyMetricsUnavailable || isLiveMetricsUnavailable(liveMetricsEnabled, metrics)
+  const visibleMetrics = getVisibleLiveMetrics(liveMetricsEnabled, metricsUnavailable, metrics)
 
   // Hide metrics-server section when Prometheus has CPU data
   const { data: prometheusStatus } = usePrometheusStatus()

--- a/web/src/components/resources/renderers/PodRenderer.tsx
+++ b/web/src/components/resources/renderers/PodRenderer.tsx
@@ -40,6 +40,7 @@ export function PodRenderer({ data, onCopy, copied, onNavigate, onOpenLogs, reso
   const liveMetricsEnabled = !historyMetricsUnavailable && (metricsHistoryQuery.isSuccess || metricsHistoryQuery.isError)
   const { data: metrics } = usePodMetrics(namespace, podName, { enabled: liveMetricsEnabled })
   const metricsUnavailable = metrics === null || historyMetricsUnavailable
+  const visibleMetrics = historyMetricsUnavailable ? undefined : (metrics ?? undefined)
 
   // Hide metrics-server section when Prometheus has CPU data
   const { data: prometheusStatus } = usePrometheusStatus()
@@ -86,7 +87,7 @@ export function PodRenderer({ data, onCopy, copied, onNavigate, onOpenLogs, reso
           disabled={disabled}
         />
       )}
-      metrics={metrics ?? undefined}
+      metrics={visibleMetrics}
       metricsHistory={metricsHistory}
       metricsUnavailable={metricsUnavailable}
       hideMetricsServer={hideMetricsServer}


### PR DESCRIPTION
SKY-1096

## Summary

When Kubernetes resource metrics are absent or broken, Node and Pod drawers now show a deliberate unavailable state instead of noisy drawer errors or stale CPU/memory charts. Radar still keeps real collection failures visible and exposes the raw Kubernetes error in the details affordance for operators who need to debug the underlying API response.

## What changed

- Classifies unavailable `metrics.k8s.io` consistently across live metrics handlers, metrics history, frontend normalization, and shared Node/Pod renderers.
- Shares the Go metrics-unavailable classifier between server handlers and metrics-history collection so the Go absence cases cannot drift.
- Makes metrics-history unavailability a server-owned boolean, so the frontend no longer re-classifies history responses from user-facing copy.
- Keeps broad message matching scoped to metrics-specific signals so unrelated NotFound, unavailable, and forbidden errors stay visible as real failures.
- Preserves raw metrics errors on history responses while replacing the primary UI copy with friendly unavailable-state copy.
- Adds APIService diagnosis for `v1beta1.metrics.k8s.io` when the metrics API is unavailable:
  - missing APIService points to installing metrics-server or restoring that APIService
  - `Available=False/Unknown` points to the backing Service, endpoints, API aggregation, and TLS configuration
  - `Available=True` with failed reads points to metrics-server logs and aggregation errors
- Reads the APIService through a direct one-shot GET instead of starting a long-lived dynamic informer.
- Caches APIService diagnosis for 5s per context and per detail mode.
- Includes compact APIService condition messages only when the caller can `get apiservices.apiregistration.k8s.io`; namespace-scoped users still get lower-detail diagnosis without cluster-scoped condition text.
- Adds a shared Node/Pod `MetricsUnavailableNotice` with compact inline copy and a `Details` tooltip for the source context, APIService diagnosis, and raw metrics error.
- Prevents stale live metrics from masking current metrics API absence while keeping buffered historical charts visible under the unavailable notice.
- Shows non-absence collection errors above historical charts so old samples are not silently presented as healthy.
- Keeps pod metrics endpoints namespace-gated under proxy auth.
- Keeps optional Prometheus auto-connect failure quiet without changing explicit/manual connect errors.

## Risk / blast radius

Medium, bounded to metrics availability handling: server metrics endpoints, metrics history response shape, frontend API normalization, shared Node/Pod renderers, and optional Prometheus auto-connect. The primary risks are hiding a real metrics failure, leaking cluster-scoped APIService details to namespace-scoped users, or showing stale usage as current.

The API change is backwards-compatible: `metricsUnavailable` and `metricsUnavailableDiagnosis` are optional on pod/node history responses. The APIService lookup only runs after the metrics-unavailable classifier fires; if the APIService cannot be inspected, Radar falls back to generic guidance. The lookup is cached, and the cache does not hold its mutex while doing the Kubernetes API read.

Residual risk: the Go server and collector paths now share one classifier, while the TypeScript client keeps a parallel classifier only for live fetch-time errors. Tests pin the shared cases, and the server test table documents the source categories for those phrases.

## Testing

- `go test ./internal/server -run 'TestMetricsAPIServiceDiagnosis|TestMetricsAPIServiceLookupDiagnosisWhenMissing|TestMetricsUnavailableDiagnosisWhenAPIServiceMissing|TestMetricsUnavailableDiagnosisMemoizesAPIServiceLookup|TestMetricsUnavailableDiagnosisMemoizesByConditionDetailFlag|TestMetricsHistoryResponse' -count=1`
- `go test ./internal/server -run 'TestMetricsHistoryResponse|TestMetricsAPIServiceDiagnosis|TestMetricsUnavailableDiagnosis|TestMetricsAPIUnavailable' -count=1`
- `go test ./internal/server -run TestMetricsAPIUnavailable -count=1`
- `go test ./internal/k8s -run TestGetDynamicWithGroupDirectFetchesAPIService -count=1`
- `(cd pkg && go test ./k8score -run TestMetricsCollectionErrorLevel -count=1)`
- `go test ./internal/server ./internal/k8s -count=1`
- `./node_modules/.bin/vitest run web/src/api/client.metrics.test.ts`
- `npm test --workspace @skyhook-io/k8s-ui -- src/components/resources/renderers/NodeRenderer.test.tsx src/components/resources/renderers/PodRenderer.test.tsx`
- `make tsc`
- `make test` (rerun outside sandbox after sandbox-localhost bind failures in `httptest`)
- `make build`
- Healthy metrics API smoke on `radar-test-management`:
  - `v1beta1.metrics.k8s.io` APIService was `Available=True`
  - raw Metrics API returned node and pod metrics
  - Radar node/pod live metrics endpoints returned `200` with usage
  - Radar node/pod history endpoints returned data without `collectionError`, `rawCollectionError`, or `metricsUnavailableDiagnosis`
- Absent metrics API smoke on a temporary local kind cluster without metrics-server:
  - `v1beta1.metrics.k8s.io` APIService returned Kubernetes `NotFound`
  - raw `/apis/metrics.k8s.io/v1beta1/nodes` returned `the server could not find the requested resource`
  - Radar node/pod live metrics endpoints returned friendly `404` errors
  - Radar node/pod history endpoints returned friendly `collectionError`, preserved `rawCollectionError`, and diagnosed the missing APIService
- Visual coverage:
  - 1920x1080 browser pass on a no-`metrics.k8s.io` cluster verified the compact unavailable state, `Details` tooltip, raw error access, and zero console errors
  - screenshots are not attached because the available capture used non-public cluster data

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches metrics endpoints, history response shape, RBAC on pod metrics, and APIService reads; main risks are misclassifying real failures, leaking cluster-scoped diagnosis, or showing stale usage as current—mitigated by server-owned flags, RBAC-gated messages, and hiding live metrics when unavailable.
> 
> **Overview**
> When **metrics.k8s.io** is missing or broken, Node and Pod drawers show a deliberate **metrics unavailable** state instead of drawer errors or misleading live usage, while **buffered history charts** can still render and real failures (forbidden, etc.) stay visible.
> 
> **Backend:** Shared `MetricsAPIUnavailable` classification drives live metrics 404s, history fields (`metricsUnavailable`, `rawCollectionError`, `metricsUnavailableDiagnosis`), and downgraded collection logging. History responses inspect **`v1beta1.metrics.k8s.io`** via a **direct APIService GET** (no informer), with **5s memoized** diagnosis; APIService condition text is included only when the caller can `get apiservices`. Pod metrics routes gain **namespace access checks** under proxy auth.
> 
> **Frontend:** History normalization trusts the server `metricsUnavailable` flag; live metrics wait until history settles and skip retries when unavailable. Shared **`MetricsUnavailableNotice`** hides stale live values but keeps historical charts; web wrappers gate `usePodMetrics` / `useNodeMetrics` accordingly.
> 
> **Prometheus:** `POST /prometheus/connect?optional=true` suppresses discovery **errorlog** noise and returns **200** with disconnected status on failure (used by background auto-connect).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d703038592bd240d087592accada9fc5ea059e0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->