### PR TITLE
fix(audit): add HPA cannot-scale diagnosis

### DIFF
--- a/internal/k8s/detect.go
+++ b/internal/k8s/detect.go
@@ -710,6 +710,8 @@ func DetectProblems(cache *ResourceCache, namespace string) []Detection {
 				Severity:  severity,
 				Reason:    hp.Problem,
 				Message:   hp.Reason,
+				Cause:     hp.Cause,
+				Action:    hp.Action,
 				// One HPA can be BOTH maxed and unable-to-scale at once — distinct
 				// problems with distinct fixes. Fingerprint on the problem kind so
 				// they don't collapse into one hpa_limited_or_failed row.

--- a/internal/k8s/detect_test.go
+++ b/internal/k8s/detect_test.go
@@ -152,6 +152,39 @@ func hasAllProblemTypes(problems []Detection) bool {
 	return seen["Deployment"] && seen["StatefulSet"] && seen["DaemonSet"] && seen["HorizontalPodAutoscaler"] && seen["Job"]
 }
 
+func TestDetectProblems_HPACannotScaleIncludesDiagnosis(t *testing.T) {
+	defer ResetTestState()
+
+	client := fake.NewClientset(&autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "prod"},
+		Spec:       autoscalingv2.HorizontalPodAutoscalerSpec{MaxReplicas: 10},
+		Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+			CurrentReplicas: 3,
+			DesiredReplicas: 3,
+			Conditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+				{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionFalse, Reason: "FailedGetResourceMetric", Message: "failed to get cpu utilization: missing request for cpu"},
+			},
+		},
+	})
+	if err := InitTestResourceCache(client); err != nil {
+		t.Fatalf("InitTestResourceCache: %v", err)
+	}
+
+	p := waitForProblem(t, "prod", "cannot-scale")
+	if p.Kind != "HorizontalPodAutoscaler" || p.Name != "web" {
+		t.Fatalf("problem subject = %s/%s/%s, want HPA/prod/web: %+v", p.Kind, p.Namespace, p.Name, p)
+	}
+	if !strings.Contains(p.Message, "FailedGetResourceMetric") {
+		t.Fatalf("raw controller evidence was not preserved in Message: %+v", p)
+	}
+	if !strings.Contains(p.Cause, "CPU resource requests") {
+		t.Fatalf("HPA cause = %q, want missing CPU requests diagnosis", p.Cause)
+	}
+	if !strings.Contains(p.Action, "Add CPU resource requests") {
+		t.Fatalf("HPA action = %q, want request-setting next step", p.Action)
+	}
+}
+
 func TestDetectProblems_ConfigSignals(t *testing.T) {
 	t.Run("coredns service nxdomain override", func(t *testing.T) {
 		defer ResetTestState()

--- a/internal/k8s/detect_workload.go
+++ b/internal/k8s/detect_workload.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
@@ -17,13 +18,15 @@ type HPAProblem struct {
 	Namespace string
 	Problem   string // "maxed" or "cannot-scale"
 	Reason    string
+	Cause     string
+	Action    string
 }
 
 // DetectHPAProblems finds HPAs that have hit their replica ceiling OR that
 // cannot scale because the autoscaler can't fetch metrics. The latter is
 // the silent-broken-HPA case: spec is valid, target exists, but
 // status.conditions[?type=ScalingActive].status=False means the controller
-// gave up — metrics-server unavailable, broken adapter, missing resource
+// gave up — metrics.k8s.io unavailable, broken adapter, missing resource
 // requests on target pods, etc. K8s autoscaler condition reasons are
 // stable across versions (FailedGetResourceMetric / FailedGetScale /
 // FailedGetExternalMetric / FailedGetObjectMetric).
@@ -45,11 +48,14 @@ func DetectHPAProblems(hpas []*autoscalingv2.HorizontalPodAutoscaler) []HPAProbl
 		}
 
 		if reason, ok := firstHPAReason(diagnosis, hpadiag.ReasonUnableToScale, hpadiag.ReasonMetricsUnavailable); ok {
+			cause, action := hpaCannotScaleDiagnosis(reason, hpa.Namespace)
 			problems = append(problems, HPAProblem{
 				Name:      hpa.Name,
 				Namespace: hpa.Namespace,
 				Problem:   "cannot-scale",
 				Reason:    reasonText(reason),
+				Cause:     cause,
+				Action:    action,
 			})
 		}
 	}
@@ -75,6 +81,76 @@ func reasonText(reason hpadiag.Reason) string {
 		return reason.Message
 	}
 	return string(reason.ID)
+}
+
+func hpaCannotScaleDiagnosis(reason hpadiag.Reason, namespace string) (string, string) {
+	text := strings.ToLower(reason.ConditionReason + " " + reason.Message)
+	switch {
+	case hasHPAConditionReason(reason, "FailedGetResourceMetric") || hasHPAConditionReason(reason, "FailedGetContainerResourceMetric"):
+		if metric, ok := missingHPARequestMetric(text); ok {
+			containerResource := hasHPAConditionReason(reason, "FailedGetContainerResourceMetric")
+			target := "the HPA target workload's containers"
+			if containerResource {
+				target = "the container measured by the HPA's ContainerResource metric"
+			}
+			if metric == "" {
+				return "Target pods do not declare the required resource requests, so the HPA cannot compute utilization.",
+					"Add the missing resource requests to " + target + ", then wait for the HPA to refresh."
+			}
+			return fmt.Sprintf("Target pods do not declare %s resource requests, so the HPA cannot compute utilization.", metric),
+				fmt.Sprintf("Add %s resource requests to %s, then wait for the HPA to refresh.", metric, target)
+		}
+		namespacePhrase := "the HPA namespace"
+		if namespace != "" {
+			namespacePhrase = "namespace " + namespace
+		}
+		return "The resource metrics API (metrics.k8s.io) is unavailable or not returning pod metrics.",
+			"Verify a resource-metrics provider, typically metrics-server, is installed and that pod metrics are available in " + namespacePhrase + "."
+	case hasHPAConditionReason(reason, "FailedGetPodsMetric") || hasHPAConditionReason(reason, "FailedGetObjectMetric"):
+		return "The custom metrics adapter could not return the HPA's custom metric.",
+			"Check the custom metrics adapter and verify the metric name, selector, and namespace match what the HPA requests."
+	case hasHPAConditionReason(reason, "FailedGetExternalMetric"):
+		return "The external metrics adapter could not return the HPA's external metric.",
+			"Check the external metrics adapter and verify the metric name, selector, and backing query are available to the HPA."
+	case hasHPAConditionReason(reason, "FailedGetScale") || hasHPAConditionReason(reason, "FailedUpdateScale") || hasHPAConditionReason(reason, "FailedRescale") || reason.ID == hpadiag.ReasonUnableToScale:
+		return "The HPA controller cannot read or update the target's scale subresource.",
+			"Verify the scaleTargetRef exists, exposes the scale subresource, and allows the HPA controller to update it."
+	default:
+		return "The HPA controller cannot read one or more scaling metrics.",
+			"Inspect the HPA conditions and the relevant metrics adapter logs to identify which metric is unavailable."
+	}
+}
+
+func hasHPAConditionReason(reason hpadiag.Reason, token string) bool {
+	// The HPA controller emits stable FailedGet* reason tokens, and hpadiag
+	// copies cond.Reason verbatim. Adapter messages vary, so keep classification
+	// anchored to the structured reason instead of substring-matching prose.
+	return strings.EqualFold(reason.ConditionReason, token)
+}
+
+func missingHPARequestMetric(text string) (string, bool) {
+	const marker = "missing request for "
+	idx := strings.Index(text, marker)
+	if idx < 0 {
+		return "", false
+	}
+	rest := strings.TrimSpace(text[idx+len(marker):])
+	if rest == "" {
+		return "", true
+	}
+	fields := strings.Fields(rest)
+	if len(fields) == 0 {
+		return "", true
+	}
+	metric := strings.Trim(fields[0], `.,;:()[]{}"'`)
+	switch strings.ToLower(metric) {
+	case "cpu":
+		return "CPU", true
+	case "memory":
+		return "memory", true
+	default:
+		return "", true
+	}
 }
 
 func maxedReasonText(diagnosis *hpadiag.Diagnosis, reason hpadiag.Reason) string {

--- a/internal/k8s/detect_workload_test.go
+++ b/internal/k8s/detect_workload_test.go
@@ -18,6 +18,9 @@ func TestDetectHPAProblems(t *testing.T) {
 		wantCount   int
 		wantProblem string
 		wantReason  string
+		wantCause   string
+		wantAction  string
+		wantNoDiag  bool
 	}{
 		{
 			name: "maxed HPA",
@@ -37,6 +40,7 @@ func TestDetectHPAProblems(t *testing.T) {
 			wantCount:   1,
 			wantProblem: "maxed",
 			wantReason:  "10/10 replicas (wants 10): TooManyReplicas: the desired replica count is more than the maximum replica count",
+			wantNoDiag:  true,
 		},
 		{
 			name: "at max without controller limit condition is not maxed",
@@ -83,7 +87,7 @@ func TestDetectHPAProblems(t *testing.T) {
 			wantCount: 0,
 		},
 		{
-			name: "metrics unavailable",
+			name: "resource metric missing request",
 			hpas: []*autoscalingv2.HorizontalPodAutoscaler{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
@@ -92,13 +96,175 @@ func TestDetectHPAProblems(t *testing.T) {
 						CurrentReplicas: 5,
 						DesiredReplicas: 5,
 						Conditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
-							{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionFalse, Reason: "FailedGetResourceMetric", Message: "missing cpu request"},
+							{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionFalse, Reason: "FailedGetResourceMetric", Message: "missing request for cpu"},
 						},
 					},
 				},
 			},
 			wantCount:   1,
 			wantProblem: "cannot-scale",
+			wantCause:   "Target pods do not declare CPU resource requests",
+			wantAction:  "Add CPU resource requests",
+		},
+		{
+			name: "resource metrics API unavailable",
+			hpas: []*autoscalingv2.HorizontalPodAutoscaler{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "prod"},
+					Spec:       autoscalingv2.HorizontalPodAutoscalerSpec{MaxReplicas: 10},
+					Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+						CurrentReplicas: 5,
+						DesiredReplicas: 5,
+						Conditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+							{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionFalse, Reason: "FailedGetResourceMetric", Message: "unable to get metrics for resource cpu: unable to fetch metrics from resource metrics API"},
+						},
+					},
+				},
+			},
+			wantCount:   1,
+			wantProblem: "cannot-scale",
+			wantCause:   "metrics.k8s.io",
+			wantAction:  "resource-metrics provider",
+		},
+		{
+			name: "resource metric missing unknown request",
+			hpas: []*autoscalingv2.HorizontalPodAutoscaler{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+					Spec:       autoscalingv2.HorizontalPodAutoscalerSpec{MaxReplicas: 10},
+					Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+						CurrentReplicas: 5,
+						DesiredReplicas: 5,
+						Conditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+							{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionFalse, Reason: "FailedGetResourceMetric", Message: "missing request for required resource"},
+						},
+					},
+				},
+			},
+			wantCount:   1,
+			wantProblem: "cannot-scale",
+			wantCause:   "required resource requests",
+			wantAction:  "Add the missing resource requests",
+		},
+		{
+			name: "container resource metric missing request",
+			hpas: []*autoscalingv2.HorizontalPodAutoscaler{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "prod"},
+					Spec:       autoscalingv2.HorizontalPodAutoscalerSpec{MaxReplicas: 10},
+					Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+						CurrentReplicas: 5,
+						DesiredReplicas: 5,
+						Conditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+							{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionFalse, Reason: "FailedGetContainerResourceMetric", Message: "container cpu-exporter is missing request for memory"},
+						},
+					},
+				},
+			},
+			wantCount:   1,
+			wantProblem: "cannot-scale",
+			wantCause:   "memory resource requests",
+			wantAction:  "Add memory resource requests",
+		},
+		{
+			name: "custom pods metric unavailable",
+			hpas: []*autoscalingv2.HorizontalPodAutoscaler{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "queue", Namespace: "prod"},
+					Spec:       autoscalingv2.HorizontalPodAutoscalerSpec{MaxReplicas: 10},
+					Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+						CurrentReplicas: 5,
+						DesiredReplicas: 5,
+						Conditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+							{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionFalse, Reason: "FailedGetPodsMetric", Message: "unable to get pods metric queue_depth"},
+						},
+					},
+				},
+			},
+			wantCount:   1,
+			wantProblem: "cannot-scale",
+			wantCause:   "custom metrics adapter",
+			wantAction:  "metric name, selector, and namespace",
+		},
+		{
+			name: "custom object metric unavailable",
+			hpas: []*autoscalingv2.HorizontalPodAutoscaler{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "queue", Namespace: "prod"},
+					Spec:       autoscalingv2.HorizontalPodAutoscalerSpec{MaxReplicas: 10},
+					Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+						CurrentReplicas: 5,
+						DesiredReplicas: 5,
+						Conditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+							{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionFalse, Reason: "FailedGetObjectMetric", Message: "unable to get object metric requests_per_second"},
+						},
+					},
+				},
+			},
+			wantCount:   1,
+			wantProblem: "cannot-scale",
+			wantCause:   "custom metrics adapter",
+			wantAction:  "metric name, selector, and namespace",
+		},
+		{
+			name: "external metric unavailable",
+			hpas: []*autoscalingv2.HorizontalPodAutoscaler{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "queue", Namespace: "prod"},
+					Spec:       autoscalingv2.HorizontalPodAutoscalerSpec{MaxReplicas: 10},
+					Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+						CurrentReplicas: 5,
+						DesiredReplicas: 5,
+						Conditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+							{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionFalse, Reason: "FailedGetExternalMetric", Message: "unable to get external metric prod/queue_depth"},
+						},
+					},
+				},
+			},
+			wantCount:   1,
+			wantProblem: "cannot-scale",
+			wantCause:   "external metrics adapter",
+			wantAction:  "backing query",
+		},
+		{
+			name: "scale target unavailable",
+			hpas: []*autoscalingv2.HorizontalPodAutoscaler{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "prod"},
+					Spec:       autoscalingv2.HorizontalPodAutoscalerSpec{MaxReplicas: 10},
+					Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+						CurrentReplicas: 3,
+						DesiredReplicas: 3,
+						Conditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+							{Type: autoscalingv2.AbleToScale, Status: corev1.ConditionFalse, Reason: "FailedGetScale", Message: "deployments/scale.apps \"api\" not found"},
+						},
+					},
+				},
+			},
+			wantCount:   1,
+			wantProblem: "cannot-scale",
+			wantCause:   "scale subresource",
+			wantAction:  "scaleTargetRef exists",
+		},
+		{
+			name: "unknown metric fetch failure uses generic fallback",
+			hpas: []*autoscalingv2.HorizontalPodAutoscaler{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "queue", Namespace: "prod"},
+					Spec:       autoscalingv2.HorizontalPodAutoscalerSpec{MaxReplicas: 10},
+					Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+						CurrentReplicas: 5,
+						DesiredReplicas: 5,
+						Conditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+							{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionFalse, Reason: "FailedComputeMetricsReplicas", Message: "unable to compute replicas from metric"},
+						},
+					},
+				},
+			},
+			wantCount:   1,
+			wantProblem: "cannot-scale",
+			wantCause:   "one or more scaling metrics",
+			wantAction:  "relevant metrics adapter logs",
 		},
 		{
 			name: "maxed and metrics unavailable emit two distinct issues",
@@ -204,6 +370,15 @@ func TestDetectHPAProblems(t *testing.T) {
 			}
 			if tt.wantReason != "" && len(problems) > 0 && !strings.Contains(problems[0].Reason, tt.wantReason) {
 				t.Errorf("reason = %q, want to contain %q", problems[0].Reason, tt.wantReason)
+			}
+			if tt.wantCause != "" && len(problems) > 0 && !strings.Contains(problems[0].Cause, tt.wantCause) {
+				t.Errorf("cause = %q, want to contain %q", problems[0].Cause, tt.wantCause)
+			}
+			if tt.wantAction != "" && len(problems) > 0 && !strings.Contains(problems[0].Action, tt.wantAction) {
+				t.Errorf("action = %q, want to contain %q", problems[0].Action, tt.wantAction)
+			}
+			if tt.wantNoDiag && len(problems) > 0 && (problems[0].Cause != "" || problems[0].Action != "") {
+				t.Errorf("diagnosis = cause %q action %q, want both empty", problems[0].Cause, problems[0].Action)
 			}
 		})
 	}


### PR DESCRIPTION
## Why

HPA `cannot-scale` audit issues were surfacing raw controller text without a plain-English cause or next step. Distinct failures such as missing pod resource requests, resource metrics API outages, and custom/external metrics adapter errors looked too similar during triage.

Linear: SKY-1098

## What changed

- Adds `Cause` and `Action` to HPA `cannot-scale` detections while preserving the raw Kubernetes condition reason/message as evidence.
- Classifies stable HPA condition reasons separately:
  - missing CPU/memory resource requests on target pods
  - resource metrics API (`metrics.k8s.io`) unavailable or not returning pod metrics
  - custom pods/object metrics adapter failures
  - external metrics adapter failures
  - scale target read/update failures
  - generic metric-computation fallback when the controller only reports a broad metric failure
- Anchors classification on the structured HPA condition reason instead of substring-matching adapter prose.
- Preserves severity, category, fingerprinting, and the existing APIService/HPA diagnostic-context linking.

## Testing

- `go test ./internal/k8s -run 'TestDetectHPAProblems|TestDetectProblems_HPACannotScaleIncludesDiagnosis'`
- `go test ./internal/issues -run 'TestAPIServiceHPA'`
- `cd pkg && go test ./hpadiag`
- `make tsc`
- `make test`
- `make build`
- visual-test: skipped (backend-only issue diagnosis copy; no UI/layout delta)

## Risk / blast radius

This affects backend audit diagnosis fields for HPA issues only. It does not change severity, grouping, auth, cluster writes, or the raw Kubernetes evidence shown to the user. The main risk is misleading `Cause`/`Action` copy for an unusual HPA/controller/adaptor message; that is mitigated by matching exact condition reasons and falling back to generic guidance when the specific failure shape is not pinned by tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backend-only diagnosis copy for HPA cannot-scale issues; severity and grouping unchanged, with risk limited to misleading guidance on rare controller messages mitigated by reason-based classification and tests.
> 
> **Overview**
> HPA **`cannot-scale`** audit findings now include plain-English **`Cause`** and **`Action`** fields in addition to the raw Kubernetes condition text in **`Message`**, so triage can distinguish missing pod requests, metrics API outages, custom/external adapter failures, and scale-target errors.
> 
> Detection maps stable HPA condition reasons (e.g. `FailedGetResourceMetric`, `FailedGetPodsMetric`, `FailedGetScale`) via new **`hpaCannotScaleDiagnosis`** logic—anchored on structured **`ConditionReason`**, not adapter message substring matching—with a generic fallback when the failure shape is unknown. **`maxed`** HPAs still omit diagnosis; severity, fingerprints, and raw evidence are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6096858a078652c68cdbe2a51a796982d8edfa8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->