### PR TITLE
Refine DaemonSet unavailable audit severity

### DIFF
--- a/internal/k8s/detect.go
+++ b/internal/k8s/detect.go
@@ -139,6 +139,7 @@ func DetectProblems(cache *ResourceCache, namespace string) []Detection {
 			}
 		}
 	}
+	podsByNamespace := listPodsByNamespace(cache, namespace)
 
 	// Deployment problems: unavailableReplicas > 0
 	if depLister := cache.Deployments(); depLister != nil {
@@ -342,12 +343,15 @@ func DetectProblems(cache *ResourceCache, namespace string) []Detection {
 			if ds.Status.DesiredNumberScheduled > ds.Status.CurrentNumberScheduled {
 				appendDSProblem(fmt.Sprintf("%d not scheduled", ds.Status.DesiredNumberScheduled-ds.Status.CurrentNumberScheduled), "critical", "daemonset:not-scheduled")
 			} else if ds.Status.NumberUnavailable > 0 {
-				appendDSProblem(fmt.Sprintf("%d unavailable", ds.Status.NumberUnavailable), "critical", "daemonset:unavailable")
+				severity := "critical"
+				if daemonSetUnavailableIsByDesignUnschedulable(cache, ds, podsByNamespace) {
+					severity = "high"
+				}
+				appendDSProblem(fmt.Sprintf("%d unavailable", ds.Status.NumberUnavailable), severity, "daemonset:unavailable")
 			}
 		}
 	}
 
-	podsByNamespace := listPodsByNamespace(cache, namespace)
 	probeFailures := latestProbeFailures(cache, namespace, now)
 	pvcPendingFailures := latestPVCPendingFailures(cache, namespace)
 
@@ -1675,6 +1679,89 @@ func pvcAwaitsFirstConsumer(cache *ResourceCache, pvc *corev1.PersistentVolumeCl
 		}
 	}
 	return sc != nil && sc.VolumeBindingMode != nil && *sc.VolumeBindingMode == storagev1.VolumeBindingWaitForFirstConsumer
+}
+
+func daemonSetUnavailableIsByDesignUnschedulable(cache *ResourceCache, ds *appsv1.DaemonSet, podsByNamespace map[string][]*corev1.Pod) bool {
+	byDesignTargets := map[string]bool{}
+	for _, pod := range podsByNamespace[ds.Namespace] {
+		_, ownerKind, ownerName := podOwnerKindName(cache, pod)
+		if ownerKind != "DaemonSet" || ownerName != ds.Name {
+			continue
+		}
+		if daemonSetPodIsAssignedButUnavailable(pod) {
+			return false
+		}
+		cond := podScheduledCondition(pod)
+		if cond == nil || cond.Status != corev1.ConditionFalse || cond.Reason != corev1.PodReasonUnschedulable {
+			continue
+		}
+		_, reasons := parseSchedulerMessage(cond.Message)
+		if len(reasons) == 0 || !allDaemonSetByDesignPlacementReasons(reasons) {
+			return false
+		}
+		targetNode := daemonSetPodTargetNode(pod)
+		if targetNode == "" {
+			continue
+		}
+		byDesignTargets[targetNode] = true
+	}
+	return int32(len(byDesignTargets)) >= ds.Status.NumberUnavailable
+}
+
+func daemonSetPodIsAssignedButUnavailable(pod *corev1.Pod) bool {
+	if pod == nil || pod.Spec.NodeName == "" {
+		return false
+	}
+	for _, cond := range pod.Status.Conditions {
+		if (cond.Type == corev1.PodReady || cond.Type == corev1.ContainersReady) && cond.Status == corev1.ConditionFalse {
+			return true
+		}
+	}
+	for _, status := range pod.Status.ContainerStatuses {
+		if !status.Ready || status.State.Waiting != nil || status.State.Terminated != nil {
+			return true
+		}
+	}
+	return pod.Status.Phase == corev1.PodFailed
+}
+
+func daemonSetPodTargetNode(pod *corev1.Pod) string {
+	if pod == nil {
+		return ""
+	}
+	if pod.Spec.NodeName != "" {
+		return pod.Spec.NodeName
+	}
+	if pod.Spec.Affinity == nil || pod.Spec.Affinity.NodeAffinity == nil {
+		return ""
+	}
+	required := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	if required == nil {
+		return ""
+	}
+	for _, term := range required.NodeSelectorTerms {
+		for _, field := range term.MatchFields {
+			if field.Key == "metadata.name" && field.Operator == corev1.NodeSelectorOpIn && len(field.Values) == 1 {
+				return field.Values[0]
+			}
+		}
+	}
+	return ""
+}
+
+func allDaemonSetByDesignPlacementReasons(reasons []SchedulingReason) bool {
+	for _, reason := range reasons {
+		switch reason.Class {
+		case SchedNodeAffinitySelector:
+			continue
+		case SchedUntoleratedTaint:
+			if reason.TaintKey != "" && !isNodeLifecycleTaint(reason.TaintKey) {
+				continue
+			}
+		}
+		return false
+	}
+	return len(reasons) > 0
 }
 
 func listPodsByNamespace(cache *ResourceCache, namespace string) map[string][]*corev1.Pod {

--- a/internal/k8s/detect_test.go
+++ b/internal/k8s/detect_test.go
@@ -1300,6 +1300,64 @@ func TestDetectProblems_DaemonSetSchedulingStatus(t *testing.T) {
 	defer ResetTestState()
 
 	old := metav1.NewTime(time.Now().Add(-10 * time.Minute))
+	controller := true
+	dsOwner := func(name string) []metav1.OwnerReference {
+		return []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "DaemonSet", Name: name, Controller: &controller}}
+	}
+	daemonSetTargetAffinity := func(nodeName string) *corev1.Affinity {
+		if nodeName == "" {
+			return nil
+		}
+		return &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+					MatchFields: []corev1.NodeSelectorRequirement{{
+						Key:      "metadata.name",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{nodeName},
+					}},
+				}},
+			},
+		}}
+	}
+	unschedulableDSPod := func(dsName, podName, targetNode, message string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: "prod", CreationTimestamp: old, OwnerReferences: dsOwner(dsName)},
+			Spec:       corev1.PodSpec{Affinity: daemonSetTargetAffinity(targetNode)},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				Conditions: []corev1.PodCondition{{
+					Type:    corev1.PodScheduled,
+					Status:  corev1.ConditionFalse,
+					Reason:  corev1.PodReasonUnschedulable,
+					Message: message,
+				}},
+			},
+		}
+	}
+	assignedUnreadyDSPod := func(dsName, podName, nodeName string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: "prod", CreationTimestamp: old, OwnerReferences: dsOwner(dsName)},
+			Spec: corev1.PodSpec{
+				NodeName:   nodeName,
+				Containers: []corev1.Container{{Name: "main", Image: "nginx"}},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.ContainersReady, Status: corev1.ConditionFalse},
+					{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+				},
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name:  "main",
+					Ready: false,
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+					},
+				}},
+			},
+		}
+	}
 	client := fake.NewClientset(
 		&appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{Name: "missing", Namespace: "prod", CreationTimestamp: old},
@@ -1318,6 +1376,81 @@ func TestDetectProblems_DaemonSetSchedulingStatus(t *testing.T) {
 				NumberUnavailable:      1,
 			},
 		},
+		&appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "design-taint", Namespace: "prod", CreationTimestamp: old},
+			Status: appsv1.DaemonSetStatus{
+				DesiredNumberScheduled: 4,
+				CurrentNumberScheduled: 4,
+				NumberUnavailable:      1,
+			},
+		},
+		&appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "design-affinity", Namespace: "prod", CreationTimestamp: old},
+			Status: appsv1.DaemonSetStatus{
+				DesiredNumberScheduled: 4,
+				CurrentNumberScheduled: 4,
+				NumberUnavailable:      1,
+			},
+		},
+		&appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "capacity", Namespace: "prod", CreationTimestamp: old},
+			Status: appsv1.DaemonSetStatus{
+				DesiredNumberScheduled: 4,
+				CurrentNumberScheduled: 4,
+				NumberUnavailable:      1,
+			},
+		},
+		&appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "host-port", Namespace: "prod", CreationTimestamp: old},
+			Status: appsv1.DaemonSetStatus{
+				DesiredNumberScheduled: 4,
+				CurrentNumberScheduled: 4,
+				NumberUnavailable:      1,
+			},
+		},
+		&appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "not-scheduled-design", Namespace: "prod", CreationTimestamp: old},
+			Status: appsv1.DaemonSetStatus{
+				DesiredNumberScheduled: 4,
+				CurrentNumberScheduled: 3,
+				NumberUnavailable:      1,
+			},
+		},
+		&appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "partial-duplicate", Namespace: "prod", CreationTimestamp: old},
+			Status: appsv1.DaemonSetStatus{
+				DesiredNumberScheduled: 4,
+				CurrentNumberScheduled: 4,
+				NumberUnavailable:      2,
+			},
+		},
+		&appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "extra-unknown-target", Namespace: "prod", CreationTimestamp: old},
+			Status: appsv1.DaemonSetStatus{
+				DesiredNumberScheduled: 4,
+				CurrentNumberScheduled: 4,
+				NumberUnavailable:      1,
+			},
+		},
+		&appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "mixed-unready", Namespace: "prod", CreationTimestamp: old},
+			Status: appsv1.DaemonSetStatus{
+				DesiredNumberScheduled: 4,
+				CurrentNumberScheduled: 4,
+				NumberUnavailable:      1,
+			},
+		},
+		unschedulableDSPod("design-taint", "design-taint-pod", "node-a", "0/4 nodes are available: 4 node(s) had untolerated taint {dedicated: infra}."),
+		unschedulableDSPod("design-affinity", "design-affinity-pod", "node-b", "0/4 nodes are available: 4 node(s) didn't match Pod's node affinity/selector."),
+		unschedulableDSPod("capacity", "capacity-pod", "node-c", "0/4 nodes are available: 4 Insufficient cpu."),
+		unschedulableDSPod("host-port", "host-port-pod", "node-d", "0/4 nodes are available: 4 node(s) didn't have free ports for the requested pod ports."),
+		unschedulableDSPod("not-scheduled-design", "not-scheduled-design-pod", "node-e", "0/4 nodes are available: 4 node(s) had untolerated taint {dedicated: infra}."),
+		unschedulableDSPod("partial-duplicate", "partial-duplicate-pod-a", "node-f", "0/4 nodes are available: 4 node(s) had untolerated taint {dedicated: infra}."),
+		unschedulableDSPod("partial-duplicate", "partial-duplicate-pod-b", "node-f", "0/4 nodes are available: 4 node(s) didn't match Pod's node affinity/selector."),
+		unschedulableDSPod("extra-unknown-target", "extra-unknown-target-known", "node-g", "0/4 nodes are available: 4 node(s) had untolerated taint {dedicated: infra}."),
+		unschedulableDSPod("extra-unknown-target", "extra-unknown-target-empty", "", "0/4 nodes are available: 4 node(s) didn't match Pod's node affinity/selector."),
+		unschedulableDSPod("mixed-unready", "mixed-unready-placement-pod", "node-h", "0/4 nodes are available: 4 node(s) had untolerated taint {dedicated: infra}."),
+		assignedUnreadyDSPod("mixed-unready", "mixed-unready-crashing-pod", "node-i"),
 	)
 
 	if err := InitTestResourceCache(client); err != nil {
@@ -1334,7 +1467,15 @@ func TestDetectProblems_DaemonSetSchedulingStatus(t *testing.T) {
 		problems = DetectProblems(cache, "prod")
 		if hasProblem(problems, "DaemonSet", "missing", "2 not scheduled") &&
 			hasProblem(problems, "DaemonSet", "wrong-node", "1 misscheduled") &&
-			hasProblem(problems, "DaemonSet", "wrong-node", "1 unavailable") {
+			hasProblem(problems, "DaemonSet", "wrong-node", "1 unavailable") &&
+			hasProblem(problems, "DaemonSet", "design-taint", "1 unavailable") &&
+			hasProblem(problems, "DaemonSet", "design-affinity", "1 unavailable") &&
+			hasProblem(problems, "DaemonSet", "capacity", "1 unavailable") &&
+			hasProblem(problems, "DaemonSet", "host-port", "1 unavailable") &&
+			hasProblem(problems, "DaemonSet", "not-scheduled-design", "1 not scheduled") &&
+			hasProblem(problems, "DaemonSet", "partial-duplicate", "2 unavailable") &&
+			hasProblem(problems, "DaemonSet", "extra-unknown-target", "1 unavailable") &&
+			hasProblem(problems, "DaemonSet", "mixed-unready", "1 unavailable") {
 			break
 		}
 		time.Sleep(20 * time.Millisecond)
@@ -1343,6 +1484,14 @@ func TestDetectProblems_DaemonSetSchedulingStatus(t *testing.T) {
 	assertProblem(t, problems, "DaemonSet", "missing", "2 not scheduled", "critical")
 	assertProblem(t, problems, "DaemonSet", "wrong-node", "1 misscheduled", "high")
 	assertProblem(t, problems, "DaemonSet", "wrong-node", "1 unavailable", "critical")
+	assertProblem(t, problems, "DaemonSet", "design-taint", "1 unavailable", "high")
+	assertProblem(t, problems, "DaemonSet", "design-affinity", "1 unavailable", "high")
+	assertProblem(t, problems, "DaemonSet", "capacity", "1 unavailable", "critical")
+	assertProblem(t, problems, "DaemonSet", "host-port", "1 unavailable", "critical")
+	assertProblem(t, problems, "DaemonSet", "not-scheduled-design", "1 not scheduled", "critical")
+	assertProblem(t, problems, "DaemonSet", "partial-duplicate", "2 unavailable", "critical")
+	assertProblem(t, problems, "DaemonSet", "extra-unknown-target", "1 unavailable", "high")
+	assertProblem(t, problems, "DaemonSet", "mixed-unready", "1 unavailable", "critical")
 }
 
 func TestDetectProblems_DeploymentReplicaFailure(t *testing.T) {

--- a/internal/k8s/detect_test.go
+++ b/internal/k8s/detect_test.go
@@ -1409,6 +1409,22 @@ func TestDetectProblems_DaemonSetSchedulingStatus(t *testing.T) {
 			},
 		},
 		&appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "lifecycle-taint", Namespace: "prod", CreationTimestamp: old},
+			Status: appsv1.DaemonSetStatus{
+				DesiredNumberScheduled: 4,
+				CurrentNumberScheduled: 4,
+				NumberUnavailable:      1,
+			},
+		},
+		&appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "unparsed", Namespace: "prod", CreationTimestamp: old},
+			Status: appsv1.DaemonSetStatus{
+				DesiredNumberScheduled: 4,
+				CurrentNumberScheduled: 4,
+				NumberUnavailable:      1,
+			},
+		},
+		&appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{Name: "not-scheduled-design", Namespace: "prod", CreationTimestamp: old},
 			Status: appsv1.DaemonSetStatus{
 				DesiredNumberScheduled: 4,
@@ -1444,6 +1460,8 @@ func TestDetectProblems_DaemonSetSchedulingStatus(t *testing.T) {
 		unschedulableDSPod("design-affinity", "design-affinity-pod", "node-b", "0/4 nodes are available: 4 node(s) didn't match Pod's node affinity/selector."),
 		unschedulableDSPod("capacity", "capacity-pod", "node-c", "0/4 nodes are available: 4 Insufficient cpu."),
 		unschedulableDSPod("host-port", "host-port-pod", "node-d", "0/4 nodes are available: 4 node(s) didn't have free ports for the requested pod ports."),
+		unschedulableDSPod("lifecycle-taint", "lifecycle-taint-pod", "node-l", "0/4 nodes are available: 4 node(s) had untolerated taint {node.kubernetes.io/not-ready: }."),
+		unschedulableDSPod("unparsed", "unparsed-pod", "node-u", "0/4 nodes are available: 4 future scheduler predicate we do not parse yet."),
 		unschedulableDSPod("not-scheduled-design", "not-scheduled-design-pod", "node-e", "0/4 nodes are available: 4 node(s) had untolerated taint {dedicated: infra}."),
 		unschedulableDSPod("partial-duplicate", "partial-duplicate-pod-a", "node-f", "0/4 nodes are available: 4 node(s) had untolerated taint {dedicated: infra}."),
 		unschedulableDSPod("partial-duplicate", "partial-duplicate-pod-b", "node-f", "0/4 nodes are available: 4 node(s) didn't match Pod's node affinity/selector."),
@@ -1472,6 +1490,8 @@ func TestDetectProblems_DaemonSetSchedulingStatus(t *testing.T) {
 			hasProblem(problems, "DaemonSet", "design-affinity", "1 unavailable") &&
 			hasProblem(problems, "DaemonSet", "capacity", "1 unavailable") &&
 			hasProblem(problems, "DaemonSet", "host-port", "1 unavailable") &&
+			hasProblem(problems, "DaemonSet", "lifecycle-taint", "1 unavailable") &&
+			hasProblem(problems, "DaemonSet", "unparsed", "1 unavailable") &&
 			hasProblem(problems, "DaemonSet", "not-scheduled-design", "1 not scheduled") &&
 			hasProblem(problems, "DaemonSet", "partial-duplicate", "2 unavailable") &&
 			hasProblem(problems, "DaemonSet", "extra-unknown-target", "1 unavailable") &&
@@ -1488,6 +1508,8 @@ func TestDetectProblems_DaemonSetSchedulingStatus(t *testing.T) {
 	assertProblem(t, problems, "DaemonSet", "design-affinity", "1 unavailable", "high")
 	assertProblem(t, problems, "DaemonSet", "capacity", "1 unavailable", "critical")
 	assertProblem(t, problems, "DaemonSet", "host-port", "1 unavailable", "critical")
+	assertProblem(t, problems, "DaemonSet", "lifecycle-taint", "1 unavailable", "critical")
+	assertProblem(t, problems, "DaemonSet", "unparsed", "1 unavailable", "critical")
 	assertProblem(t, problems, "DaemonSet", "not-scheduled-design", "1 not scheduled", "critical")
 	assertProblem(t, problems, "DaemonSet", "partial-duplicate", "2 unavailable", "critical")
 	assertProblem(t, problems, "DaemonSet", "extra-unknown-target", "1 unavailable", "high")


### PR DESCRIPTION
## Why

DaemonSet `NumberUnavailable` was becoming a critical audit issue even when desired/current scheduling was satisfied and the only visible pod-level symptom was intentional placement exclusion, such as dedicated-node taints or node affinity/selector rules. That made by-design DaemonSets look like cluster-breaking incidents.

## What changed

- Keeps `daemonset:not-scheduled` critical whenever desired pods are not scheduled.
- Keeps misscheduled DaemonSets high.
- Downgrades `daemonset:unavailable` from critical to high only when the DaemonSet has enough owned pending pods with `PodScheduled=False/Unschedulable` to account for the unavailable count.
- Counts only target-node evidence that can be tied to a specific node; an extra by-design pod with unknown target no longer vetoes a downgrade when other pods already account for the unavailable count.
- Treats only explicit placement-by-design scheduler reasons as downgradeable:
  - node affinity / node selector mismatch
  - untolerated non-lifecycle taints
- Keeps capacity, host-port, lifecycle-taint, assigned-but-unready pods, mixed, unparsed, insufficient target evidence, and partial-evidence cases critical.

## Testing

- `go test ./internal/k8s -run TestDetectProblems_DaemonSetSchedulingStatus`
- `go test ./internal/k8s`
- `make tsc`
- `make test`
- `make build`
- Live read-only smoke with the built branch binary: `./radar --port 9368 --no-browser --no-mcp --timeline-storage memory`
  - Connected and exercised `/api/cluster-info`, `/api/resources/daemonsets`, `/api/issues`, and `/api/dashboard` across 10 cloud contexts spanning EKS and GKE, Kubernetes v1.33-v1.35.
  - Two GKE contexts had live partially unavailable DaemonSets. Both stayed critical because scheduler evidence included host-port/capacity-style failure, not only by-design placement exclusion.
  - Several configured contexts failed before branch logic ran due to auth or control-plane timeout; raw `kubectl get --raw=/version` confirmed representative successful and timeout cases.
- Playwright smoke on a live GKE context:
  - Overview page loaded with 0 new console warnings/errors.
  - Issues page loaded with 0 new console warnings/errors.
  - Captures: `sky-1099-gke-nonprod-overview.png`, `sky-1099-gke-nonprod-issues.png`.

## Notes

Risk/blast radius is limited to DaemonSet audit severity ranking. The failure mode is under- or over-ranking an operational issue, not mutating resources or changing API contracts; strict owner matching, full unavailable-count coverage, known target-node evidence, unready-pod vetoing, and conservative reason allowlisting keep uncertain cases critical.

Product/severity call: the downgrade target is intentionally high rather than warning. The detector can prove the unavailable count is explained by placement policy, but that still may represent lost node-level coverage or drift. High reduces false critical incidents without hiding the issue.

Tradeoff: node affinity/selector and non-lifecycle taint scheduler failures are treated as placement-by-design only when they fully explain the unavailable count. If final review decides those should represent drift rather than intentional exclusion, the allowlist can stay stricter and those cases can remain critical.

Refs SKY-1099.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only severity ranking for DaemonSet unavailable detections; uncertain cases remain critical and no cluster resources or APIs are modified.
> 
> **Overview**
> **DaemonSet `daemonset:unavailable` audit severity** is no longer always **critical**. When desired/current scheduling is satisfied and owned pods explain `NumberUnavailable` as intentional placement exclusion, severity drops to **high**.
> 
> Detection inspects DaemonSet-owned pods: assigned-but-unready pods (e.g. crash loops) still force **critical**. For pending `PodScheduled=False` / `Unschedulable` pods, it parses scheduler messages and only treats **node affinity/selector mismatch** and **non-lifecycle untolerated taints** as downgradeable; capacity, host ports, lifecycle taints, unparsed reasons, and incomplete target-node evidence stay **critical**. `listPodsByNamespace` runs earlier so this logic can reuse the same pod index.
> 
> `TestDetectProblems_DaemonSetSchedulingStatus` is expanded with fixtures for each branch (design taint/affinity, capacity, mixed unready, partial evidence, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fb7c6498a0c723ef7df04f829808b844cd816d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
