### PR TITLE
Fix timeline grouping, kind filter, swimlane error, and diagnostics text

### DIFF
--- a/internal/timeline/metrics.go
+++ b/internal/timeline/metrics.go
@@ -3,6 +3,7 @@ package timeline
 import (
 	"context"
 	"maps"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -327,7 +328,7 @@ func GetDiagnosis(kind, namespace, name string) DiagnoseResponse {
 			switch reason {
 			case DropReasonNoisyFilter:
 				resp.Recommendations = append(resp.Recommendations,
-					"Resource was filtered "+string(rune(count))+" times by noisy_filter - check isNoisyResource() patterns in cache.go")
+					"Resource was filtered "+strconv.Itoa(count)+" times by noisy_filter - check isNoisyResource() patterns in cache.go")
 			case DropReasonChannelFull:
 				resp.Recommendations = append(resp.Recommendations,
 					"Resource events dropped due to channel full - the system may be under heavy load")

--- a/packages/k8s-ui/src/components/timeline/TimelineList.tsx
+++ b/packages/k8s-ui/src/components/timeline/TimelineList.tsx
@@ -99,6 +99,32 @@ export function TimelineList({ events, isLoading, onRefresh, onQueryChange, hasL
     onQueryChange?.({ timeRange, kind: kindFilter || undefined })
   }, [timeRange, kindFilter, onQueryChange])
 
+  // Kind filter options: seed with common kinds, then accumulate every kind seen
+  // in the data so CRDs the cluster actually emits become filterable. The set only
+  // grows — selecting a kind narrows the server query to it, so deriving options
+  // from the current events alone would collapse the dropdown to that one kind.
+  const [seenKinds, setSeenKinds] = useState<Set<string>>(() => new Set(RESOURCE_KINDS))
+  useEffect(() => {
+    if (!events?.length) return
+    setSeenKinds((prev) => {
+      let next: Set<string> | null = null
+      for (const e of events) {
+        if (e.kind && !prev.has(e.kind)) {
+          if (!next) next = new Set(prev)
+          next.add(e.kind)
+        }
+      }
+      return next ?? prev
+    })
+  }, [events])
+  // Common kinds keep their curated order (most-used first); kinds discovered in
+  // the data that aren't in the seed (CRDs) are appended alphabetically.
+  const kindOptions = useMemo(() => {
+    const seeded = new Set<string>(RESOURCE_KINDS)
+    const extra = [...seenKinds].filter((k) => !seeded.has(k)).sort()
+    return [...RESOURCE_KINDS, ...extra]
+  }, [seenKinds])
+
 
   const [handleRefresh, isRefreshAnimating] = useRefreshAnimation(onRefresh ?? (() => {}))
 
@@ -341,7 +367,7 @@ export function TimelineList({ events, isLoading, onRefresh, onQueryChange, hasL
           className="appearance-none bg-theme-elevated text-theme-text-primary text-sm rounded-lg px-3 py-2 border border-theme-border-light focus:outline-none focus:ring-2 focus:ring-blue-500"
         >
           <option value="">All Kinds</option>
-          {RESOURCE_KINDS.map((kind) => (
+          {kindOptions.map((kind) => (
             <option key={kind} value={kind}>
               {kind}
             </option>

--- a/packages/k8s-ui/src/utils/resource-hierarchy.test.ts
+++ b/packages/k8s-ui/src/utils/resource-hierarchy.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+
+import type { TimelineEvent, Topology } from '../types/core'
+
+import { buildResourceHierarchy } from './resource-hierarchy'
+
+function svcEvent(namespace: string, name: string): TimelineEvent {
+  return {
+    id: `${namespace}/${name}`,
+    timestamp: '2024-01-01T00:00:00.000Z',
+    source: 'informer',
+    kind: 'Service',
+    namespace,
+    name,
+    eventType: 'update',
+  }
+}
+
+function svcNode(namespace: string, name: string, app: string) {
+  return {
+    id: `service/${namespace}/${name}`,
+    data: { apiVersion: 'v1', labels: { 'app.kubernetes.io/name': app } },
+  }
+}
+
+function topo(nodes: ReturnType<typeof svcNode>[]): Topology {
+  return { nodes, edges: [] } as unknown as Topology
+}
+
+describe('buildResourceHierarchy app-label grouping', () => {
+  it('does not merge the same app label across namespaces', () => {
+    const events = [svcEvent('team-a', 'web'), svcEvent('team-b', 'web')]
+    const topology = topo([svcNode('team-a', 'web', 'web'), svcNode('team-b', 'web', 'web')])
+
+    const lanes = buildResourceHierarchy({ events, topology, groupByApp: true })
+
+    expect(lanes).toHaveLength(2)
+    expect(lanes.every((l) => (l.children ?? []).length === 0)).toBe(true)
+    expect(new Set(lanes.map((l) => l.namespace))).toEqual(new Set(['team-a', 'team-b']))
+  })
+
+  it('groups distinct resources sharing an app label within one namespace', () => {
+    const events = [svcEvent('team-a', 'web'), svcEvent('team-a', 'web-edge')]
+    const topology = topo([svcNode('team-a', 'web', 'web'), svcNode('team-a', 'web-edge', 'web')])
+
+    const lanes = buildResourceHierarchy({ events, topology, groupByApp: true })
+
+    expect(lanes).toHaveLength(1)
+    expect(lanes[0].children).toHaveLength(1)
+  })
+})

--- a/packages/k8s-ui/src/utils/resource-hierarchy.ts
+++ b/packages/k8s-ui/src/utils/resource-hierarchy.ts
@@ -465,17 +465,20 @@ export function buildResourceHierarchy(options: HierarchyOptions): ResourceLane[
       'HTTPProxy', // Contour
     ])
 
-    // Group lanes by app label
+    // Group lanes by app label, scoped to namespace: the same app label in two
+    // namespaces (e.g. the same workload deployed to dev and staging) is two
+    // distinct apps and must not collapse into one lane.
     const appGroups = new Map<string, string[]>()
     for (const [laneId, lane] of laneMap) {
       if (laneParent.has(laneId)) continue
       if (!appLabelEligibleKinds.has(lane.kind)) continue
       const appLabel = laneAppLabels.get(laneId)
       if (!appLabel) continue
-      if (!appGroups.has(appLabel)) {
-        appGroups.set(appLabel, [])
+      const groupKey = `${lane.namespace}/${appLabel}`
+      if (!appGroups.has(groupKey)) {
+        appGroups.set(groupKey, [])
       }
-      appGroups.get(appLabel)!.push(laneId)
+      appGroups.get(groupKey)!.push(laneId)
     }
 
     // For each app group with multiple members, pick the best parent

--- a/web/src/components/timeline/TimelineView.tsx
+++ b/web/src/components/timeline/TimelineView.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useRef } from 'react'
-import { Network } from 'lucide-react'
+import { Network, AlertTriangle, RefreshCw } from 'lucide-react'
 import { TimelineList } from './TimelineList'
 import { TimelineSwimlanes } from './TimelineSwimlanes'
 import { useChanges, useTopology } from '../../api/client'
@@ -52,7 +52,7 @@ export function TimelineView({ namespaces, onResourceClick, initialViewMode, ini
 
   // Fetch all activity - zoom controls what's visible in the UI
   // Only fetch heavy 10k dataset for swimlanes; list view fetches its own 500
-  const { data: activity, isLoading } = useChanges({
+  const { data: activity, isLoading, isError, refetch } = useChanges({
     namespaces,
     timeRange: 'all',
     includeK8sEvents: true,
@@ -110,6 +110,30 @@ export function TimelineView({ namespaces, onResourceClick, initialViewMode, ini
                 </div>
               </div>
             </div>
+          </div>
+        </div>
+      )
+    }
+
+    // A failed fetch must not render as the swimlane "No events yet" empty state —
+    // that reads as a quiet cluster rather than a load failure.
+    if (isError) {
+      return (
+        <div className="flex-1 flex flex-col">
+          <div className="flex items-center justify-between px-4 py-2 border-b border-theme-border">
+            <div />
+            <ViewModeToggle viewMode={viewMode} onViewModeChange={setViewMode} />
+          </div>
+          <div className="flex-1 flex flex-col items-center justify-center text-theme-text-tertiary gap-3">
+            <AlertTriangle className="w-10 h-10 text-amber-400/70" />
+            <p className="text-base">Failed to load timeline data</p>
+            <button
+              onClick={() => refetch()}
+              className="flex items-center gap-2 px-3 py-1.5 text-sm bg-theme-elevated border border-theme-border-light rounded-lg hover:bg-theme-hover transition-colors"
+            >
+              <RefreshCw className="w-3.5 h-3.5" />
+              Try again
+            </button>
           </div>
         </div>
       )


### PR DESCRIPTION
Four small, independent timeline fixes. Each is releasable on its own; bundled here because they are all small and touch the same feature.

## Changes

**Namespace-scope app-label grouping** (`resource-hierarchy.ts`)
The swimlane's "group by app" collapsed the same `app.kubernetes.io/name` value across different namespaces into one lane. For multi-environment clusters (e.g. dev/test/staging namespaces) this fused unrelated workloads and parented one environment's activity under another's. Grouping is now scoped to namespace, matching the server-side grouping. Structural owner/topology grouping is unchanged.

**Kind filter from the data** (`TimelineList.tsx`)
The kind filter was a fixed 13-kind list, so CRDs the cluster actually emits were not filterable. It now seeds the common kinds (kept in their curated order) and accumulates kinds seen in the data (appended alphabetically). The set only grows, so selecting a kind — which narrows the server query — does not collapse the dropdown.

**Swimlane fetch-error state** (`TimelineView.tsx`)
A failed timeline fetch rendered as the swimlane's "no events" empty state, indistinguishable from a quiet cluster. It now shows an explicit error with a retry, mirroring the list view.

**Diagnostics drop-count formatting** (`metrics.go`)
The noisy-filter drop count in the resource diagnostics recommendation was rendered as a control character instead of its digits.

## Verification
- `tsc` clean; `@skyhook-io/k8s-ui` suite green (739 tests, incl. a new `resource-hierarchy` spec covering the namespace-scoping); `go test ./internal/timeline` green.
- Grouping fix validated before/after on a local kind cluster with a synthetic fixture (one app label across two namespaces): merged into one lane before, two separate lanes after.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized timeline UX and diagnostics fixes with targeted hierarchy logic change covered by new tests; no auth, security, or data-path changes.
> 
> **Overview**
> This PR bundles four small timeline fixes: swimlane **group-by-app** behavior, list **kind** filtering, swimlane **load failures**, and backend **diagnostics** text.
> 
> **Swimlane app-label grouping** now keys groups by `namespace/appLabel` instead of app label alone, so the same `app.kubernetes.io/name` in dev and staging stays in separate lanes. Within a namespace, resources that share an app label still group as before. Tests cover cross-namespace separation and same-namespace grouping.
> 
> **Timeline list kind filter** no longer uses only a fixed kind list. It keeps the curated common kinds in order and **accumulates** kinds seen in fetched events (CRDs appended alphabetically), so narrowing the server query by kind does not shrink the dropdown to a single option.
> 
> **Swimlane view** treats a failed `useChanges` fetch as an explicit error with retry instead of the empty “no events” state.
> 
> **Resource diagnostics** in `GetDiagnosis` now formats noisy-filter drop counts with `strconv.Itoa` instead of `string(rune(count))`, which produced garbage characters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb714feedae94f1c8b329621ea23b6151f198ebf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->