### PR TITLE
Support serving Radar under a base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ output) for plain text. URLs, tokens, and suggested commands remain unstyled.
 | `--namespace-scope` | `false` | Pin namespaced informer caches to a **single** namespace for large clusters (scoping to multiple namespaces is not supported yet). Requires `--namespace`, a kubeconfig context namespace, or a saved local single-namespace pick. Local mode can rebuild the cache when switching namespaces; auth/cloud mode locks the shared cache to the startup namespace. |
 | `--port` | `9280` | Server port |
 | `--listen-address` | `127.0.0.1` | HTTP listen address. Use `127.0.0.1` or `localhost` for local-only access; use `0.0.0.0` explicitly for containers, VMs, WSL, or remote/shared access, together with authentication and network controls. |
-| `--base-path` | | Serve Radar under a URL prefix such as `/radar`. Use when an ingress forwards a subpath without stripping it. |
+| `--base-path` | | Serve Radar under a URL prefix such as `/radar`. Use when an ingress forwards a subpath without stripping it — everything, including `/api/health`, moves under the prefix. Not supported with `--cloud-url`. |
 | `--no-browser` | `false` | Don't auto-open browser |
 | `--browser` | | Browser to use when opening the UI, e.g. `firefox`, `google-chrome`, or `Google Chrome` on macOS |
 | `--timeline-storage` | `memory` | Timeline storage backend: `memory` or `sqlite` |

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ output) for plain text. URLs, tokens, and suggested commands remain unstyled.
 | `--namespace-scope` | `false` | Pin namespaced informer caches to a **single** namespace for large clusters (scoping to multiple namespaces is not supported yet). Requires `--namespace`, a kubeconfig context namespace, or a saved local single-namespace pick. Local mode can rebuild the cache when switching namespaces; auth/cloud mode locks the shared cache to the startup namespace. |
 | `--port` | `9280` | Server port |
 | `--listen-address` | `127.0.0.1` | HTTP listen address. Use `127.0.0.1` or `localhost` for local-only access; use `0.0.0.0` explicitly for containers, VMs, WSL, or remote/shared access, together with authentication and network controls. |
+| `--base-path` | | Serve Radar under a URL prefix such as `/radar`. Use when an ingress forwards a subpath without stripping it. |
 | `--no-browser` | `false` | Don't auto-open browser |
 | `--browser` | | Browser to use when opening the UI, e.g. `firefox`, `google-chrome`, or `Google Chrome` on macOS |
 | `--timeline-storage` | `memory` | Timeline storage backend: `memory` or `sqlite` |

--- a/cmd/desktop/main.go
+++ b/cmd/desktop/main.go
@@ -180,7 +180,7 @@ func main() {
 	<-ready
 
 	// Write port file so MCP clients can discover the running server
-	app.WriteMCPPortFile(srv.ActualPort())
+	app.WriteMCPPortFile(srv.ActualPort(), srv.BasePath())
 
 	// Initialize cluster in background (browser will see progress via SSE)
 	if k8sInitErr == nil {

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -208,6 +208,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("Invalid --base-path %q: %v", *basePath, err)
 	}
+	// Radar Hub forwards root-relative paths over the tunnel and the ordinary
+	// listener is health-only at the literal /api/health, so a prefixed router
+	// would 404 both. Fail loudly instead of coming up broken.
+	if normalizedBasePath != "" && *cloudURL != "" {
+		log.Fatalf("--base-path is not supported with --cloud-url: Radar Hub owns the URL path when Radar runs in Cloud mode")
+	}
 	timelineMaxSizeBytes, err := config.ParseByteSize(*timelineMaxSize)
 	if err != nil {
 		log.Fatalf("Invalid --timeline-max-size %q: %v", *timelineMaxSize, err)

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -214,7 +214,7 @@ func main() {
 	// signals are checked because the chart sets them together but they are
 	// independent inputs, and either one alone is enough to break the prefix.
 	if normalizedBasePath != "" && (*cloudURL != "" || cloud.Mode()) {
-		log.Fatalf("--base-path is not supported in Radar Cloud mode (--cloud-url / RADAR_CLOUD_MODE): the Hub owns the URL path")
+		log.Fatalf("--base-path is not supported in Radar Cloud mode (--cloud-url / RADAR_CLOUD_MODE): Radar Cloud owns the URL path")
 	}
 	timelineMaxSizeBytes, err := config.ParseByteSize(*timelineMaxSize)
 	if err != nil {

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -210,9 +210,11 @@ func main() {
 	}
 	// Radar Hub forwards root-relative paths over the tunnel and the ordinary
 	// listener is health-only at the literal /api/health, so a prefixed router
-	// would 404 both. Fail loudly instead of coming up broken.
-	if normalizedBasePath != "" && *cloudURL != "" {
-		log.Fatalf("--base-path is not supported with --cloud-url: Radar Hub owns the URL path when Radar runs in Cloud mode")
+	// would 404 both. Fail loudly instead of coming up broken. Both Cloud
+	// signals are checked because the chart sets them together but they are
+	// independent inputs, and either one alone is enough to break the prefix.
+	if normalizedBasePath != "" && (*cloudURL != "" || cloud.Mode()) {
+		log.Fatalf("--base-path is not supported in Radar Cloud mode (--cloud-url / RADAR_CLOUD_MODE): the Hub owns the URL path")
 	}
 	timelineMaxSizeBytes, err := config.ParseByteSize(*timelineMaxSize)
 	if err != nil {

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -70,6 +70,7 @@ func main() {
 	namespaces := flag.String("namespaces", fileCfg.NamespacesFlag(), "Initial namespace filters as a comma-separated list (e.g. ns1,ns2,ns3). Use this when you can list resources in specific namespaces but cannot list namespaces cluster-wide.")
 	port := flag.Int("port", fileCfg.PortOr(9280), "Server port")
 	listenAddress := flag.String("listen-address", server.DefaultListenAddress, "HTTP listen address: 127.0.0.1 or localhost for local-only access; 0.0.0.0 for remote/shared access")
+	basePath := flag.String("base-path", "", "URL path prefix to serve Radar under, e.g. /radar (empty = root). Use when an ingress forwards a subpath without stripping it.")
 	noBrowser := flag.Bool("no-browser", fileCfg.NoBrowser, "Don't auto-open browser")
 	browser := flag.String("browser", fileCfg.Browser, "Browser to use when opening the UI (default: OS default browser; macOS app names supported)")
 	devMode := flag.Bool("dev", false, "Development mode (serve frontend from filesystem)")
@@ -203,6 +204,10 @@ func main() {
 	if err != nil {
 		log.Fatalf("Invalid --listen-address %q: %v", *listenAddress, err)
 	}
+	normalizedBasePath, err := server.NormalizeBasePath(*basePath)
+	if err != nil {
+		log.Fatalf("Invalid --base-path %q: %v", *basePath, err)
+	}
 	timelineMaxSizeBytes, err := config.ParseByteSize(*timelineMaxSize)
 	if err != nil {
 		log.Fatalf("Invalid --timeline-max-size %q: %v", *timelineMaxSize, err)
@@ -257,6 +262,7 @@ func main() {
 		Port:                     *port,
 		ListenAddress:            normalizedListenAddress,
 		ShowRemoteAccessHint:     true,
+		BasePath:                 normalizedBasePath,
 		NoBrowser:                *noBrowser,
 		Browser:                  *browser,
 		DevMode:                  *devMode,
@@ -378,7 +384,10 @@ func main() {
 
 	// Open browser — server is confirmed ready to accept connections
 	if !cfg.NoBrowser {
-		targetURL := fmt.Sprintf("http://localhost:%d", cfg.Port)
+		targetURL := fmt.Sprintf("http://localhost:%d%s", cfg.Port, cfg.BasePath)
+		if cfg.BasePath != "" {
+			targetURL += "/"
+		}
 		if len(cfg.Namespaces) > 0 {
 			targetURL += "?namespaces=" + neturl.QueryEscape(strings.Join(cfg.Namespaces, ","))
 		} else if cfg.Namespace != "" {

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -488,7 +488,7 @@ func startServer(srv *server.Server, startupStart time.Time) (context.Context, c
 	k8s.LogTiming(" Server listening: %v (since start)", time.Since(startupStart))
 
 	// Write port file so MCP clients can discover the running server
-	app.WriteMCPPortFile(srv.ActualPort())
+	app.WriteMCPPortFile(srv.ActualPort(), srv.BasePath())
 
 	return rootCtx, rootCancel
 }

--- a/deploy/helm/radar/README.md
+++ b/deploy/helm/radar/README.md
@@ -158,6 +158,7 @@ lands in the Helm release state. Rotation requires a pod restart. See
 | `image.tag` | Image tag | Chart appVersion |
 | `service.type` | Service type | `ClusterIP` |
 | `service.port` | Service port | `9280` |
+| `basePath` | URL prefix Radar serves under, e.g. `/radar` for no-strip-prefix subpath ingress | `""` |
 | `debug.image` | Image for ephemeral debug containers and node debug pods. In built-in restricted PodSecurity namespaces, pod debug containers may retry as the target/pod non-root UID, or UID `65532` by default; point at a compatible mirror for air-gapped / private-registry clusters. | `""` (busybox:latest) |
 | `listPageSize` | Paginate the initial LIST of high-cardinality kinds (Pods, ReplicaSets) on very large clusters; `0` = off, try `2000`. Only used when the apiserver lacks WatchList streaming. | `0` |
 | `ingress.enabled` | Enable ingress | `false` |

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -15,10 +15,13 @@
 {{- if $basePath }}
 {{- range $key := list "redirectURL" "postLogoutRedirectURL" }}
 {{- $val := get $.Values.auth.oidc $key }}
-{{- /* Compare the URL's PATH, not the whole string: a substring test passes
-       spuriously whenever the hostname happens to start with the same word,
-       e.g. basePath /radar against https://radar.example.com/auth/callback. */}}
-{{- if and $val (not (hasPrefix $basePath (urlParse $val).path)) }}
+{{- /* Match on whole path segments of the URL's path. Comparing the whole URL
+       string lets the authority satisfy the prefix (basePath /radar against
+       https://radar.example.com/auth/callback), and a bare string prefix on the
+       path lets a different segment satisfy it (/radartools/auth/callback). Same
+       rule the server applies when routing: equal, or followed by a slash. */}}
+{{- $p := (urlParse $val).path }}
+{{- if and $val (not (or (eq $p $basePath) (hasPrefix (printf "%s/" $basePath) $p))) }}
 {{- fail (printf "auth.oidc.%s (%s) must be under basePath %q — Radar serves /auth/* below the prefix, so the IdP would send the browser to a path that is not routed to Radar" $key $val $basePath) }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -6,6 +6,9 @@
 {{- if $trimmedBasePath -}}
 {{- $basePath = printf "/%s" $trimmedBasePath -}}
 {{- end -}}
+{{- if and $basePath .Values.cloud.enabled }}
+{{- fail "basePath is not supported with cloud.enabled=true: Radar Hub owns the URL path in Cloud mode, and the binary refuses the combination at startup — unset one of them rather than installing a release that crash-loops" }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -9,6 +9,17 @@
 {{- if and $basePath .Values.cloud.enabled }}
 {{- fail "basePath is not supported with cloud.enabled=true: Radar Hub owns the URL path in Cloud mode, and the binary refuses the combination at startup — unset one of them rather than installing a release that crash-loops" }}
 {{- end }}
+{{- /* URLs registered at the IdP have to carry the prefix: Radar's OIDC routes
+       move under it, and an unprefixed URI is not routed here, so login fails
+       after the callback rather than at install time. */}}
+{{- if $basePath }}
+{{- range $key := list "redirectURL" "postLogoutRedirectURL" }}
+{{- $val := get $.Values.auth.oidc $key }}
+{{- if and $val (not (contains $basePath $val)) }}
+{{- fail (printf "auth.oidc.%s (%s) must include basePath %q — Radar serves /auth/* under the prefix, so the IdP would send the browser to a path that is not routed to Radar" $key $val $basePath) }}
+{{- end }}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -1,6 +1,11 @@
 {{- if and .Values.persistence.enabled (eq .Values.timeline.storage "sqlite") (gt (int .Values.replicaCount) 1) }}
 {{- fail "replicaCount must be 1 when persistence.enabled=true and timeline.storage=sqlite: a single PVC cannot be safely shared across pods (RWO volumes won't attach to a second pod, RWX volumes risk SQLite corruption)" }}
 {{- end }}
+{{- $basePath := "" -}}
+{{- $trimmedBasePath := trimAll "/" (default "" .Values.basePath) -}}
+{{- if $trimmedBasePath -}}
+{{- $basePath = printf "/%s" $trimmedBasePath -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -49,6 +54,9 @@ spec:
             - --port={{ .Values.service.port }}
             - --listen-address=0.0.0.0
             - --no-browser
+            {{- if $basePath }}
+            - {{ printf "--base-path=%s" $basePath | quote }}
+            {{- end }}
             - --timeline-storage={{ .Values.timeline.storage }}
             {{- if eq .Values.timeline.storage "sqlite" }}
             - --timeline-db={{ .Values.timeline.dbPath }}
@@ -241,7 +249,7 @@ spec:
           {{- if .Values.probes.liveness.enabled }}
           livenessProbe:
             httpGet:
-              path: /api/health
+              path: {{ printf "%s/api/health" $basePath | quote }}
               port: http
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
@@ -251,7 +259,7 @@ spec:
           {{- if .Values.probes.readiness.enabled }}
           readinessProbe:
             httpGet:
-              path: /api/health
+              path: {{ printf "%s/api/health" $basePath | quote }}
               port: http
             initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.readiness.periodSeconds }}

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -15,8 +15,11 @@
 {{- if $basePath }}
 {{- range $key := list "redirectURL" "postLogoutRedirectURL" }}
 {{- $val := get $.Values.auth.oidc $key }}
-{{- if and $val (not (contains $basePath $val)) }}
-{{- fail (printf "auth.oidc.%s (%s) must include basePath %q — Radar serves /auth/* under the prefix, so the IdP would send the browser to a path that is not routed to Radar" $key $val $basePath) }}
+{{- /* Compare the URL's PATH, not the whole string: a substring test passes
+       spuriously whenever the hostname happens to start with the same word,
+       e.g. basePath /radar against https://radar.example.com/auth/callback. */}}
+{{- if and $val (not (hasPrefix $basePath (urlParse $val).path)) }}
+{{- fail (printf "auth.oidc.%s (%s) must be under basePath %q — Radar serves /auth/* below the prefix, so the IdP would send the browser to a path that is not routed to Radar" $key $val $basePath) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -7,7 +7,7 @@
 {{- $basePath = printf "/%s" $trimmedBasePath -}}
 {{- end -}}
 {{- if and $basePath .Values.cloud.enabled }}
-{{- fail "basePath is not supported with cloud.enabled=true: Radar Hub owns the URL path in Cloud mode, and the binary refuses the combination at startup — unset one of them rather than installing a release that crash-loops" }}
+{{- fail "basePath is not supported with cloud.enabled=true: Radar Cloud owns the URL path, and the binary refuses the combination at startup — unset one of them" }}
 {{- end }}
 {{- /* URLs registered at the IdP have to carry the prefix: Radar's OIDC routes
        move under it, and an unprefixed URI is not routed here, so login fails

--- a/deploy/helm/radar/values.schema.json
+++ b/deploy/helm/radar/values.schema.json
@@ -118,8 +118,8 @@
     },
     "basePath": {
       "type": "string",
-      "pattern": "^$|^/?[A-Za-z0-9._~-]+(/[A-Za-z0-9._~-]+)*/?$",
-      "description": "Optional URL path prefix served by Radar itself, e.g. /radar. Use when ingress forwards the subpath without stripping it. Path segments accept letters, digits, '-', '_', '.' and '~' — matching the server's --base-path validation, so an invalid value fails at install time instead of crash-looping the pod."
+      "pattern": "^$|^/?[A-Za-z0-9._~-]*[A-Za-z0-9_~-][A-Za-z0-9._~-]*(/[A-Za-z0-9._~-]*[A-Za-z0-9_~-][A-Za-z0-9._~-]*)*/?$",
+      "description": "Optional URL path prefix served by Radar itself, e.g. /radar. Use when ingress forwards the subpath without stripping it. Path segments accept letters, digits, '-', '_', '.' and '~', and no segment may be '.' or '..' — matching the server's --base-path validation, so an invalid value fails at install time instead of crash-looping the pod."
     },
     "ingress": {
       "type": "object",

--- a/deploy/helm/radar/values.schema.json
+++ b/deploy/helm/radar/values.schema.json
@@ -118,8 +118,8 @@
     },
     "basePath": {
       "type": "string",
-      "pattern": "^$|^/?[^:?#{}*]+$",
-      "description": "Optional URL path prefix served by Radar itself, e.g. /radar. Use when ingress forwards the subpath without stripping it."
+      "pattern": "^$|^/?[A-Za-z0-9._~-]+(/[A-Za-z0-9._~-]+)*/?$",
+      "description": "Optional URL path prefix served by Radar itself, e.g. /radar. Use when ingress forwards the subpath without stripping it. Path segments accept letters, digits, '-', '_', '.' and '~' — matching the server's --base-path validation, so an invalid value fails at install time instead of crash-looping the pod."
     },
     "ingress": {
       "type": "object",

--- a/deploy/helm/radar/values.schema.json
+++ b/deploy/helm/radar/values.schema.json
@@ -116,6 +116,11 @@
         "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
       }
     },
+    "basePath": {
+      "type": "string",
+      "pattern": "^$|^/?[^:?#{}*]+$",
+      "description": "Optional URL path prefix served by Radar itself, e.g. /radar. Use when ingress forwards the subpath without stripping it."
+    },
     "ingress": {
       "type": "object",
       "additionalProperties": true,

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -198,6 +198,11 @@ service:
   type: ClusterIP
   port: 9280
 
+# URL path prefix that Radar itself serves under, e.g. /radar. Set this when
+# your ingress forwards a subpath through to the service without stripping it.
+# Leave empty for root serving or for ingresses that rewrite /radar -> /.
+basePath: ""
+
 ingress:
   enabled: false
   className: ""

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -201,6 +201,7 @@ service:
 # URL path prefix that Radar itself serves under, e.g. /radar. Set this when
 # your ingress forwards a subpath through to the service without stripping it.
 # Leave empty for root serving or for ingresses that rewrite /radar -> /.
+# Cannot be combined with cloud.enabled — Radar Cloud owns the URL path.
 basePath: ""
 
 ingress:

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -148,6 +148,8 @@ When an admin disables a user at the IdP level (e.g., disables an Okta account),
 
 To enable, set `--auth-oidc-backchannel-logout` (or `auth.oidc.backchannelLogout: true` in Helm), then register `https://radar.example.com/auth/backchannel-logout` as the Back-Channel Logout URI in your IdP.
 
+If Radar is served under a base path, the route sits at `{basePath}/auth/backchannel-logout` — register that. An unprefixed URI is not routed to Radar, and the IdP's POST is silently lost: disabling a user leaves their Radar session live until the cookie expires, which is the exact failure this feature exists to prevent.
+
 ```yaml
 auth:
   mode: oidc

--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -63,8 +63,8 @@ Path segments accept letters, digits, `-`, `_`, `.` and `~`. Radar serves the ap
 **only** under the prefix — requests to unprefixed paths get a 404, so update any
 external health checks or scrapers that hit `/api/health` or `/metrics` directly
 (the chart's own probes follow `basePath` automatically). `basePath` is not
-supported together with Radar Cloud (`--cloud-url`), where the Hub owns the URL
-path.
+supported together with Radar Cloud (`--cloud-url`), which owns the URL path
+itself.
 
 **Every URL you hand to an external system must include the prefix.** With OIDC
 that means the values you register with your identity provider:

--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -75,6 +75,8 @@ auth:
   oidc:
     redirectURL: https://tools.your-domain.com/radar/auth/callback           # not /auth/callback
     postLogoutRedirectURL: https://tools.your-domain.com/radar/              # not /
+    # With backchannelLogout, the URI registered at the IdP is likewise
+    # https://tools.your-domain.com/radar/auth/backchannel-logout
 ```
 
 Radar's callback route lives at `{basePath}/auth/callback`, so a redirect URL

--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -66,6 +66,27 @@ external health checks or scrapers that hit `/api/health` or `/metrics` directly
 supported together with Radar Cloud (`--cloud-url`), where the Hub owns the URL
 path.
 
+**Every URL you hand to an external system must include the prefix.** With OIDC
+that means the values you register with your identity provider:
+
+```yaml
+basePath: /radar
+auth:
+  oidc:
+    redirectURL: https://tools.your-domain.com/radar/auth/callback           # not /auth/callback
+    postLogoutRedirectURL: https://tools.your-domain.com/radar/              # not /
+```
+
+Radar's callback route lives at `{basePath}/auth/callback`, so a redirect URL
+without the prefix sends the IdP to a path the ingress doesn't route to Radar and
+login ends in a 404.
+
+**Two Radar instances behind subpaths on the same host share browser state.**
+Cookies are set at `Path=/` and `localStorage` is scoped per origin, not per path,
+so `/radar-a` and `/radar-b` on one hostname will share the session cookie and UI
+preferences (and the session cookie is also sent to unrelated apps on that
+hostname). Give each instance its own hostname if you need them isolated.
+
 ### With Basic Authentication
 
 1. **Create the auth secret:**

--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -83,11 +83,20 @@ Radar's callback route lives at `{basePath}/auth/callback`, so a redirect URL
 without the prefix sends the IdP to a path the ingress doesn't route to Radar and
 login ends in a 404.
 
-**Two Radar instances behind subpaths on the same host share browser state.**
-Cookies are set at `Path=/` and `localStorage` is scoped per origin, not per path,
-so `/radar-a` and `/radar-b` on one hostname will share the session cookie and UI
-preferences (and the session cookie is also sent to unrelated apps on that
-hostname). Give each instance its own hostname if you need them isolated.
+**Give each instance its own hostname.** Two Radars behind subpaths on one
+hostname (`/radar-a`, `/radar-b`) are the same browser origin, so they share
+browser state: the session cookie is set at `Path=/`, and `localStorage` — which
+holds the theme, log-viewer preferences and similar per-instance settings — is
+scoped per origin with no path-scoped equivalent in the platform at all. Logging
+into one can end the other's session, and preferences set in one show up in the
+other. A hostname each keeps them properly separate.
+
+Separately from that: a Radar per cluster gives you a view per cluster. Each
+watches only its own cluster and carries its own upgrades, ingress and auth
+config, with no cross-cluster search or combined issue list across them. If you
+want several clusters in one view, that is what
+[Radar Cloud](https://radarhq.io) is for, and its agent dials out so there is no
+per-cluster ingress to wire up.
 
 ### With Basic Authentication
 

--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -39,6 +39,26 @@ helm upgrade --install radar skyhook/radar \
   -n radar -f values.yaml
 ```
 
+### Subpath Ingress (No Strip-Prefix)
+
+If your ingress forwards `/radar/...` to the Radar service as `/radar/...`, set `basePath` to the same prefix:
+
+```yaml
+# values.yaml
+basePath: /radar
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: tools.your-domain.com
+      paths:
+        - path: /radar
+          pathType: Prefix
+```
+
+Then open `https://tools.your-domain.com/radar/`. Do not set `basePath` when your ingress already rewrites `/radar` to `/`.
+
 ### With Basic Authentication
 
 1. **Create the auth secret:**
@@ -300,6 +320,7 @@ See [Helm Chart README](../deploy/helm/radar/README.md) for all available values
 | `ingress.enabled` | Enable ingress | `false` |
 | `ingress.className` | Ingress class | `""` |
 | `service.port` | Service port | `9280` |
+| `basePath` | URL prefix Radar serves under, e.g. `/radar` for no-strip-prefix subpath ingress | `""` |
 | `mcp.enabled` | Enable MCP server for AI tools | `true` |
 | `debug.image` | Image for ephemeral debug containers and node debug pods. In built-in restricted PodSecurity namespaces, pod debug containers may retry as the target/pod non-root UID, or UID `65532` by default; point at a compatible mirror for air-gapped / private-registry clusters. | `""` (busybox:latest) |
 | `listPageSize` | Paginate the initial LIST of high-cardinality kinds (Pods, ReplicaSets) on very large clusters that fail to sync; `0` = off, try `2000`. Only used when the apiserver lacks WatchList streaming. | `0` |

--- a/docs/in-cluster.md
+++ b/docs/in-cluster.md
@@ -59,6 +59,13 @@ ingress:
 
 Then open `https://tools.your-domain.com/radar/`. Do not set `basePath` when your ingress already rewrites `/radar` to `/`.
 
+Path segments accept letters, digits, `-`, `_`, `.` and `~`. Radar serves the app
+**only** under the prefix — requests to unprefixed paths get a 404, so update any
+external health checks or scrapers that hit `/api/health` or `/metrics` directly
+(the chart's own probes follow `basePath` automatically). `basePath` is not
+supported together with Radar Cloud (`--cloud-url`), where the Hub owns the URL
+path.
+
 ### With Basic Authentication
 
 1. **Create the auth secret:**

--- a/internal/ai/diagnoser.go
+++ b/internal/ai/diagnoser.go
@@ -42,6 +42,9 @@ type Request struct {
 	Name      string
 	// MCPPort is the port Radar's own MCP server listens on (localhost).
 	MCPPort int
+	// MCPBasePath is Radar's --base-path prefix ("" at the root). The MCP mounts
+	// live under it, so the loopback URL handed to the agent must carry it too.
+	MCPBasePath string
 	// SessionID, when set, resumes a prior CLI session (multi-turn) so the agent
 	// keeps full context (prior tool results + reasoning) without re-investigating.
 	SessionID string
@@ -388,7 +391,7 @@ func (d *Diagnoser) DiagnoseStream(ctx context.Context, req Request, onEvent fun
 	if !req.Apply {
 		path = "/mcp-readonly"
 	}
-	mcpURL := fmt.Sprintf("http://localhost:%d%s", req.MCPPort, path)
+	mcpURL := fmt.Sprintf("http://localhost:%d%s%s", req.MCPPort, req.MCPBasePath, path)
 
 	// An apply turn runs in a FRESH session, not a resume: it acts only on the
 	// user-confirmed fix text + target, so untrusted cluster data ingested during

--- a/internal/ai/runs.go
+++ b/internal/ai/runs.go
@@ -29,9 +29,10 @@ import (
 // Lock order is always m.mu → r.mu, never the reverse; the run goroutine never
 // takes m.mu.
 type RunManager struct {
-	d        *Diagnoser
-	mcpPort  func() int    // resolved lazily — the listener port isn't known at construction
-	ctxLabel func() string // current kube-context label, for the run's baseline
+	d           *Diagnoser
+	mcpPort     func() int    // resolved lazily — the listener port isn't known at construction
+	mcpBasePath string        // --base-path prefix the MCP mounts sit under ("" at the root)
+	ctxLabel    func() string // current kube-context label, for the run's baseline
 
 	baseCtx    context.Context // parent of every run ctx; cancelled on Shutdown
 	baseCancel context.CancelFunc
@@ -177,7 +178,7 @@ func turnTimeout() time.Duration {
 // callbacks because the listener port and kube-context are only known at runtime.
 // store persists history across restarts (nil = memory-only); persisted runs are
 // hydrated into the manager here.
-func NewRunManager(d *Diagnoser, mcpPort func() int, ctxLabel func() string, store RunStore) *RunManager {
+func NewRunManager(d *Diagnoser, mcpPort func() int, mcpBasePath string, ctxLabel func() string, store RunStore) *RunManager {
 	ctx, cancel := context.WithCancel(context.Background())
 	// Best-effort: a failure here just means runs get no shared workdir (logged).
 	root, err := os.MkdirTemp("", "radar-ai-")
@@ -188,6 +189,7 @@ func NewRunManager(d *Diagnoser, mcpPort func() int, ctxLabel func() string, sto
 	m := &RunManager{
 		d:             d,
 		mcpPort:       mcpPort,
+		mcpBasePath:   mcpBasePath,
 		ctxLabel:      ctxLabel,
 		baseCtx:       ctx,
 		baseCancel:    cancel,
@@ -489,7 +491,7 @@ func (m *RunManager) launchTurn(r *Run, question string, apply bool, fix, sessio
 		defer cancel()
 		diag, err := m.d.DiagnoseStream(ctx, Request{
 			Kind: r.Kind, Namespace: r.Namespace, Name: r.Name,
-			MCPPort: m.mcpPort(), SessionID: session,
+			MCPPort: m.mcpPort(), MCPBasePath: m.mcpBasePath, SessionID: session,
 			Question: question, Apply: apply, Fix: fix,
 			Agent: r.Agent, Profile: r.Profile, Model: r.Model, Effort: r.Effort,
 			Health: r.Health, WorkDir: r.WorkDir,

--- a/internal/ai/runs_test.go
+++ b/internal/ai/runs_test.go
@@ -178,7 +178,7 @@ func TestRunMatchesTarget(t *testing.T) {
 // enough for persistence-path tests (nothing spawns an agent).
 func persistedManager(t *testing.T, store RunStore, ctx string) *RunManager {
 	t.Helper()
-	m := NewRunManager(nil, func() int { return 0 }, func() string { return ctx }, store)
+	m := NewRunManager(nil, func() int { return 0 }, "", func() string { return ctx }, store)
 	t.Cleanup(func() {
 		// Don't let Shutdown close the shared test store between phases.
 		m.baseCancel()
@@ -433,7 +433,7 @@ func TestPersistenceGracefulShutdown(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	m := NewRunManager(nil, func() int { return 0 }, func() string { return "ctx-a" }, st)
+	m := NewRunManager(nil, func() int { return 0 }, "", func() string { return "ctx-a" }, st)
 	r := &Run{ID: "run-1", Kind: "Pod", Name: "p", Context: "ctx-a", store: st,
 		status: "running", inFlight: true, hydrated: true,
 		CreatedAt: nowUTC(), updatedAt: nowUTC(), subs: map[int]chan RunEvent{}}
@@ -521,7 +521,7 @@ func TestContextSwitchIdempotentOnStale(t *testing.T) {
 // store whose existing contents couldn't be loaded (manager refuses it — new
 // runs must not mint colliding ids against unknown DB contents).
 func TestHistoryUnavailableSurfaces(t *testing.T) {
-	m := NewRunManager(nil, func() int { return 0 }, func() string { return "ctx" }, nil)
+	m := NewRunManager(nil, func() int { return 0 }, "", func() string { return "ctx" }, nil)
 	if m.HistoryDegraded() {
 		t.Error("memory-only by CONFIG must not read as degraded")
 	}
@@ -538,7 +538,7 @@ func TestHistoryUnavailableSurfaces(t *testing.T) {
 		Status: "done", CreatedAt: nowUTC(), UpdatedAt: nowUTC()})
 	st.(*sqliteRunStore).barrier()
 	st.Close() // LoadRuns will fail in loadPersisted
-	m2 := NewRunManager(nil, func() int { return 0 }, func() string { return "ctx" }, st)
+	m2 := NewRunManager(nil, func() int { return 0 }, "", func() string { return "ctx" }, st)
 	if !m2.HistoryDegraded() {
 		t.Error("load failure must surface as degraded")
 	}

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -39,6 +39,7 @@ type AppConfig struct {
 	Port                     int
 	ListenAddress            string
 	ShowRemoteAccessHint     bool
+	BasePath                 string
 	NoBrowser                bool
 	Browser                  string
 	DevMode                  bool
@@ -270,6 +271,7 @@ func CreateServer(cfg AppConfig) *server.Server {
 	serverCfg := server.Config{
 		Port:             cfg.Port,
 		ListenAddress:    cfg.ListenAddress,
+		BasePath:         cfg.BasePath,
 		StartupLog:       true,
 		RemoteAccessHint: cfg.ShowRemoteAccessHint,
 		DevMode:          cfg.DevMode,

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -455,8 +455,11 @@ var mcpPortFileDisabled bool
 func DisableMCPPortFile() { mcpPortFileDisabled = true }
 
 // WriteMCPPortFile writes the actual server port to ~/.radar/mcp-port so MCP
-// clients can discover the running instance without hardcoding a port.
-func WriteMCPPortFile(port int) {
+// clients can discover the running instance without hardcoding a port. A
+// non-empty basePath is written as a second line: the routes it identifies sit
+// under that prefix, so the port alone is not enough to reach them. The port
+// stays on the first line so a port-only reader keeps working.
+func WriteMCPPortFile(port int, basePath string) {
 	path := mcpPortFilePath()
 	if path == "" || mcpPortFileDisabled {
 		return
@@ -465,7 +468,11 @@ func WriteMCPPortFile(port int) {
 		log.Printf("[mcp] Failed to create directory for port file: %v", err)
 		return
 	}
-	if err := os.WriteFile(path, fmt.Appendf(nil, "%d\n", port), 0o644); err != nil {
+	contents := fmt.Appendf(nil, "%d\n", port)
+	if basePath != "" {
+		contents = fmt.Appendf(contents, "%s\n", basePath)
+	}
+	if err := os.WriteFile(path, contents, 0o644); err != nil {
 		log.Printf("[mcp] Failed to write port file: %v", err)
 		return
 	}

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -539,8 +539,10 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("[oidc] User %s authenticated (groups: %v)", username, groups)
 
-	// Redirect to app
-	http.Redirect(w, r, "/", http.StatusFound)
+	// Redirect to the app root under its base path. A bare "/" would leave the
+	// user outside Radar on a subpath deployment, where the ingress routes only
+	// the prefix to this service.
+	http.Redirect(w, r, h.cfg.BasePath+"/", http.StatusFound)
 }
 
 // sessionIssued reports whether a CreateSessionCookie result actually

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -34,6 +34,12 @@ type OIDCHandler struct {
 	httpClient         *http.Client          // custom TLS client for OIDC provider calls; nil = default
 	revoker            *MemoryRevoker        // session revocation store; nil = backchannel logout disabled
 
+	// basePath is the URL prefix Radar serves under ("" at the root). Where Radar
+	// is mounted is the server's concern, not part of the shared auth config, but
+	// the post-login redirect has to land inside the app: under a no-strip subpath
+	// ingress only {basePath}/* is routed here, so "/" would leave the app.
+	basePath string
+
 	// Discovery: backchannel logout support
 	backchannelLogoutSupported        bool
 	backchannelLogoutSessionSupported bool
@@ -63,9 +69,11 @@ var supportedOIDCSigningAlgorithms = map[string]bool{
 	oidc.EdDSA: true,
 }
 
-// NewOIDCHandler creates a new OIDC handler. Returns an error if the provider
-// cannot be discovered (network error, invalid issuer URL, etc.).
-func NewOIDCHandler(ctx context.Context, cfg Config) (*OIDCHandler, error) {
+// NewOIDCHandler creates a new OIDC handler. basePath is the URL prefix Radar is
+// served under ("" at the root), which the post-login redirect must target.
+// Returns an error if the provider cannot be discovered (network error, invalid
+// issuer URL, etc.).
+func NewOIDCHandler(ctx context.Context, cfg Config, basePath string) (*OIDCHandler, error) {
 	// Build a custom HTTP client for OIDC provider TLS when configured
 	var httpClient *http.Client
 	if cfg.OIDCCACert != "" {
@@ -122,6 +130,7 @@ func NewOIDCHandler(ctx context.Context, cfg Config) (*OIDCHandler, error) {
 
 	h := &OIDCHandler{
 		cfg:                               cfg,
+		basePath:                          basePath,
 		provider:                          provider,
 		oauth:                             oauthCfg,
 		verifier:                          verifier,
@@ -542,7 +551,7 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	// Redirect to the app root under its base path. A bare "/" would leave the
 	// user outside Radar on a subpath deployment, where the ingress routes only
 	// the prefix to this service.
-	http.Redirect(w, r, h.cfg.BasePath+"/", http.StatusFound)
+	http.Redirect(w, r, h.basePath+"/", http.StatusFound)
 }
 
 // sessionIssued reports whether a CreateSessionCookie result actually

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -635,7 +635,7 @@ func TestNewOIDCHandler_ExplicitEndpointsVerifyES256Token(t *testing.T) {
 		OIDCClientID:         "radar",
 		OIDCClientSecret:     "secret",
 		OIDCRedirectURL:      "http://localhost/callback",
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("expected explicit-endpoint init to succeed: %v", err)
 	}
@@ -717,6 +717,11 @@ func (f *fakeIDP) defaultClaims() string {
 
 func (f *fakeIDP) newHandler(t *testing.T, cfg Config) *OIDCHandler {
 	t.Helper()
+	return f.newHandlerUnderBasePath(t, cfg, "")
+}
+
+func (f *fakeIDP) newHandlerUnderBasePath(t *testing.T, cfg Config, basePath string) *OIDCHandler {
+	t.Helper()
 	cfg.Mode = "oidc"
 	cfg.OIDCIssuer = f.issuer
 	if cfg.OIDCClientID == "" {
@@ -732,7 +737,7 @@ func (f *fakeIDP) newHandler(t *testing.T, cfg Config) *OIDCHandler {
 		// clock tick between issue and parse would flake the callback asserts.
 		cfg.CookieTTL = time.Hour
 	}
-	h, err := NewOIDCHandler(context.Background(), cfg)
+	h, err := NewOIDCHandler(context.Background(), cfg, basePath)
 	if err != nil {
 		t.Fatalf("NewOIDCHandler: %v", err)
 	}
@@ -1031,32 +1036,22 @@ func TestBackchannelLogout_CacheControlAlwaysSet(t *testing.T) {
 // Note: testing invalid/valid JWT verification requires a real OIDC provider
 // with JWKS. The pre-verification tests above cover all paths before Verify().
 
-// The post-login redirect must land inside the app. Under a no-strip subpath
-// ingress only {basePath}/* is routed to Radar, so a bare "/" would drop the
-// user onto whatever else owns the origin root right after authenticating.
-// Reaching the redirect itself needs a token exchange, so this pins the value
-// the handler was built with.
-func TestNewOIDCHandlerRetainsBasePath(t *testing.T) {
-	srv := newTLSOIDCServer()
-	defer srv.Close()
-
+// A completed login must land inside the app. Under a no-strip subpath ingress
+// only {basePath}/* is routed to Radar, so redirecting to a bare "/" would drop
+// the user onto whatever else owns the origin root right after authenticating.
+func TestHandleCallback_RedirectsUnderBasePath(t *testing.T) {
 	for _, basePath := range []string{"", "/radar", "/tools/radar"} {
-		h, err := NewOIDCHandler(context.Background(), Config{
-			Mode:                   "oidc",
-			OIDCIssuer:             srv.URL,
-			OIDCClientID:           "test",
-			OIDCClientSecret:       "secret",
-			OIDCRedirectURL:        "http://localhost" + basePath + "/auth/callback",
-			OIDCInsecureSkipVerify: true,
-		}, basePath)
-		if err != nil {
-			t.Fatalf("basePath %q: NewOIDCHandler: %v", basePath, err)
-		}
-		if h.basePath != basePath {
-			t.Errorf("basePath %q: handler.basePath = %q", basePath, h.basePath)
-		}
-		if got := h.basePath + "/"; got != basePath+"/" {
-			t.Errorf("basePath %q: post-login target = %q, want %q", basePath, got, basePath+"/")
-		}
+		t.Run("basePath="+basePath, func(t *testing.T) {
+			idp := newFakeIDP(t, oidc.RS256)
+			h := idp.newHandlerUnderBasePath(t, Config{}, basePath)
+			w := runCallback(h)
+
+			if w.Code != http.StatusFound {
+				t.Fatalf("status = %d, want 302 (body: %s)", w.Code, w.Body.String())
+			}
+			if got, want := w.Header().Get("Location"), basePath+"/"; got != want {
+				t.Errorf("Location = %q, want %q", got, want)
+			}
+		})
 	}
 }

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -333,7 +333,7 @@ func TestNewOIDCHandler_FailsWithSelfSignedCert(t *testing.T) {
 		OIDCClientID:     "test",
 		OIDCClientSecret: "secret",
 		OIDCRedirectURL:  "http://localhost/callback",
-	})
+	}, "")
 	if err == nil {
 		t.Fatal("expected TLS error, got nil")
 	}
@@ -353,7 +353,7 @@ func TestNewOIDCHandler_InsecureSkipVerify(t *testing.T) {
 		OIDCClientSecret:       "secret",
 		OIDCRedirectURL:        "http://localhost/callback",
 		OIDCInsecureSkipVerify: true,
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("expected success with InsecureSkipVerify, got: %v", err)
 	}
@@ -388,7 +388,7 @@ func TestNewOIDCHandler_CACert(t *testing.T) {
 		OIDCClientSecret: "secret",
 		OIDCRedirectURL:  "http://localhost/callback",
 		OIDCCACert:       f.Name(),
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("expected success with CA cert, got: %v", err)
 	}
@@ -425,7 +425,7 @@ func TestNewOIDCHandler_CACertTakesPrecedence(t *testing.T) {
 		OIDCRedirectURL:        "http://localhost/callback",
 		OIDCCACert:             f.Name(),
 		OIDCInsecureSkipVerify: true,
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("expected success, got: %v", err)
 	}
@@ -467,7 +467,7 @@ func TestNewOIDCHandler_InternalIssuerUsesInternalEndpoints(t *testing.T) {
 		OIDCClientID:       "radar",
 		OIDCClientSecret:   "secret",
 		OIDCRedirectURL:    "http://localhost/callback",
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("expected success with internal issuer, got: %v", err)
 	}
@@ -535,7 +535,7 @@ func TestNewOIDCHandler_InternalIssuerWithOverridesKeepsDiscoveryMetadata(t *tes
 		OIDCClientID:         "radar",
 		OIDCClientSecret:     "secret",
 		OIDCRedirectURL:      "http://localhost/callback",
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("expected success with internal issuer and overrides, got: %v", err)
 	}
@@ -565,7 +565,7 @@ func TestNewOIDCHandler_ExplicitEndpointsDoNotRequireDiscovery(t *testing.T) {
 		OIDCClientID:         "radar",
 		OIDCClientSecret:     "secret",
 		OIDCRedirectURL:      "http://localhost/callback",
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("expected explicit endpoints to initialize without discovery: %v", err)
 	}
@@ -927,7 +927,7 @@ func TestNewOIDCHandler_InvalidCACertPath(t *testing.T) {
 		OIDCClientSecret: "secret",
 		OIDCRedirectURL:  "http://localhost/callback",
 		OIDCCACert:       "/nonexistent/ca.pem",
-	})
+	}, "")
 	if err == nil {
 		t.Fatal("expected error for invalid CA cert path")
 	}
@@ -952,7 +952,7 @@ func TestNewOIDCHandler_InvalidCACertContent(t *testing.T) {
 		OIDCClientSecret: "secret",
 		OIDCRedirectURL:  "http://localhost/callback",
 		OIDCCACert:       f.Name(),
-	})
+	}, "")
 	if err == nil {
 		t.Fatal("expected error for invalid CA cert content")
 	}
@@ -1030,3 +1030,33 @@ func TestBackchannelLogout_CacheControlAlwaysSet(t *testing.T) {
 
 // Note: testing invalid/valid JWT verification requires a real OIDC provider
 // with JWKS. The pre-verification tests above cover all paths before Verify().
+
+// The post-login redirect must land inside the app. Under a no-strip subpath
+// ingress only {basePath}/* is routed to Radar, so a bare "/" would drop the
+// user onto whatever else owns the origin root right after authenticating.
+// Reaching the redirect itself needs a token exchange, so this pins the value
+// the handler was built with.
+func TestNewOIDCHandlerRetainsBasePath(t *testing.T) {
+	srv := newTLSOIDCServer()
+	defer srv.Close()
+
+	for _, basePath := range []string{"", "/radar", "/tools/radar"} {
+		h, err := NewOIDCHandler(context.Background(), Config{
+			Mode:                   "oidc",
+			OIDCIssuer:             srv.URL,
+			OIDCClientID:           "test",
+			OIDCClientSecret:       "secret",
+			OIDCRedirectURL:        "http://localhost" + basePath + "/auth/callback",
+			OIDCInsecureSkipVerify: true,
+		}, basePath)
+		if err != nil {
+			t.Fatalf("basePath %q: NewOIDCHandler: %v", basePath, err)
+		}
+		if h.basePath != basePath {
+			t.Errorf("basePath %q: handler.basePath = %q", basePath, h.basePath)
+		}
+		if got := h.basePath + "/"; got != basePath+"/" {
+			t.Errorf("basePath %q: post-login target = %q, want %q", basePath, got, basePath+"/")
+		}
+	}
+}

--- a/internal/diagnosecli/diagnosecli.go
+++ b/internal/diagnosecli/diagnosecli.go
@@ -272,11 +272,18 @@ func resolveServer(explicit string) (string, error) {
 		return "", fmt.Errorf("no running Radar found (%s missing) — start radar first, or pass --server http://localhost:<port>",
 			filepath.Join(home, ".radar", "mcp-port"))
 	}
-	port, err := strconv.Atoi(strings.TrimSpace(string(b)))
+	// Line 1 is the port; an optional line 2 carries the server's --base-path,
+	// without which every request would 404 against a subpath deployment.
+	lines := strings.Split(strings.TrimSpace(string(b)), "\n")
+	port, err := strconv.Atoi(strings.TrimSpace(lines[0]))
 	if err != nil || port <= 0 {
 		return "", fmt.Errorf("~/.radar/mcp-port is unreadable — is radar running? (or pass --server)")
 	}
-	return fmt.Sprintf("http://localhost:%d", port), nil
+	basePath := ""
+	if len(lines) > 1 {
+		basePath = strings.TrimRight(strings.TrimSpace(lines[1]), "/")
+	}
+	return fmt.Sprintf("http://localhost:%d%s", port, basePath), nil
 }
 
 type agentsResponse struct {

--- a/internal/diagnosecli/diagnosecli_test.go
+++ b/internal/diagnosecli/diagnosecli_test.go
@@ -2,6 +2,7 @@ package diagnosecli
 
 import (
 	"context"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -188,5 +189,39 @@ func TestResolveServerReadsBasePathFromDiscoveryFile(t *testing.T) {
 				t.Errorf("resolveServer() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// probeListening receives the discovered base URL, which carries the server's
+// --base-path when it has one. A path suffix is not a dialable address, so
+// leaving it in makes a healthy prefixed instance look dead and sends the CLI
+// off to spawn a throwaway standalone server instead of attaching.
+func TestProbeListeningIgnoresBasePathSuffix(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	addr := ln.Addr().String()
+
+	for _, base := range []string{
+		"http://" + addr,
+		"http://" + addr + "/radar",
+		"http://" + addr + "/tools/radar",
+		addr + "/radar",
+	} {
+		if !probeListening(base) {
+			t.Errorf("probeListening(%q) = false, want true", base)
+		}
+	}
+
+	closed, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	deadAddr := closed.Addr().String()
+	closed.Close()
+	if probeListening("http://" + deadAddr + "/radar") {
+		t.Error("probeListening on a closed port = true, want false")
 	}
 }

--- a/internal/diagnosecli/diagnosecli_test.go
+++ b/internal/diagnosecli/diagnosecli_test.go
@@ -157,3 +157,36 @@ func TestStandaloneEffectiveAgentHonorsCLIOverride(t *testing.T) {
 		t.Fatalf("unsupported explicit pick should fall back to the override, got %q", got)
 	}
 }
+
+func TestResolveServerReadsBasePathFromDiscoveryFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+		want     string
+	}{
+		{name: "port only (older instance)", contents: "9280\n", want: "http://localhost:9280"},
+		{name: "port and base path", contents: "9280\n/radar\n", want: "http://localhost:9280/radar"},
+		{name: "nested base path", contents: "9280\n/tools/radar\n", want: "http://localhost:9280/tools/radar"},
+		{name: "trailing slash trimmed", contents: "9280\n/radar/\n", want: "http://localhost:9280/radar"},
+		{name: "no trailing newline", contents: "9280\n/radar", want: "http://localhost:9280/radar"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			if err := os.MkdirAll(filepath.Join(home, ".radar"), 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(home, ".radar", "mcp-port"), []byte(tc.contents), 0o644); err != nil {
+				t.Fatalf("write port file: %v", err)
+			}
+			got, err := resolveServer("")
+			if err != nil {
+				t.Fatalf("resolveServer: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("resolveServer() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/diagnosecli/standalone.go
+++ b/internal/diagnosecli/standalone.go
@@ -157,8 +157,12 @@ func (t *tailBuffer) String() string {
 // probeListening reports whether anything answers on the discovered base —
 // used to distinguish "stale port file" from "no Radar at all".
 func probeListening(base string) bool {
-	u := strings.TrimPrefix(strings.TrimPrefix(base, "http://"), "https://")
-	conn, err := net.DialTimeout("tcp", u, time.Second)
+	// Dial the authority only. The base carries the server's --base-path when it
+	// has one, and a path suffix is not a valid dial address — leaving it in makes
+	// a healthy prefixed instance look dead.
+	authority := strings.TrimPrefix(strings.TrimPrefix(base, "http://"), "https://")
+	authority, _, _ = strings.Cut(authority, "/")
+	conn, err := net.DialTimeout("tcp", authority, time.Second)
 	if err != nil {
 		return false
 	}

--- a/internal/server/base_path_test.go
+++ b/internal/server/base_path_test.go
@@ -183,10 +183,10 @@ func TestServerMountsRoutesUnderBasePath(t *testing.T) {
 }
 
 // A base path must not become an authentication bypass. chi's Mount leaves
-// r.URL.Path prefixed, and the auth middleware treats paths outside /api, /mcp
-// and /debug as public static content — so before the prefix was stripped at the
-// router edge, every prefixed endpoint (including the /debug/pprof heap dump of
-// the whole informer cache) served unauthenticated.
+// r.URL.Path prefixed and the auth middleware treats paths outside /api, /mcp
+// and /debug as public static content, so any prefix left in place by the time
+// the middleware runs makes every endpoint read as public — including the
+// /debug/pprof heap dump of the whole informer cache.
 func TestBasePathDoesNotBypassAuth(t *testing.T) {
 	protected := []string{"/api/config", "/api/resources/pods", "/debug/pprof/heap", "/api/auth/whoami"}
 

--- a/internal/server/base_path_test.go
+++ b/internal/server/base_path_test.go
@@ -34,6 +34,12 @@ func TestNormalizeBasePath(t *testing.T) {
 		{name: "space rejected", raw: "/rad ar", wantErr: true},
 		{name: "percent encoding rejected", raw: "/rad%2Far", wantErr: true},
 		{name: "unreserved characters allowed", raw: "/radar-v2_1.0~beta", want: "/radar-v2_1.0~beta"},
+		// Scheme-relative forms would turn the redirect Location into an
+		// off-origin URL, so they must never normalize successfully.
+		{name: "protocol-relative rejected", raw: "//evil.com", wantErr: true},
+		{name: "backslash second position rejected", raw: `/\evil.com`, wantErr: true},
+		{name: "double backslash rejected", raw: `\\evil.com`, wantErr: true},
+		{name: "encoded protocol-relative rejected", raw: "/%2f%2fevil.com", wantErr: true},
 	}
 
 	for _, tt := range tests {
@@ -179,6 +185,41 @@ func TestServerMountsRoutesUnderBasePath(t *testing.T) {
 	}
 	if got := bareResp.Header().Get("Location"); got != "/radar/?namespace=default" {
 		t.Fatalf("bare prefix Location = %q, want /radar/?namespace=default", got)
+	}
+}
+
+// Both base-path redirects echo the request's query string, so their Location
+// must stay same-origin no matter what the caller sends: a value that browsers
+// read as scheme-relative ("//host", "/\host") would be an open redirect.
+func TestBasePathRedirectsStaySameOrigin(t *testing.T) {
+	hostileQueries := []string{
+		"//evil.com", `/\evil.com`, "http://evil.com", "https:%2f%2fevil.com",
+		"a=b&c=//evil.com", "%0d%0aSet-Cookie:+evil=1", "?=//evil.com",
+	}
+
+	for _, basePath := range []string{"/radar", "/tools/radar"} {
+		srv := New(Config{DevMode: true, BasePath: basePath})
+		for _, q := range hostileQueries {
+			for _, target := range []string{"/?" + q, basePath + "?" + q} {
+				resp := httptest.NewRecorder()
+				srv.Handler().ServeHTTP(resp, httptest.NewRequest(http.MethodGet, target, nil))
+
+				loc := resp.Header().Get("Location")
+				if !strings.HasPrefix(loc, basePath+"/") {
+					t.Errorf("GET %s: Location = %q, want it to start with %q", target, loc, basePath+"/")
+					continue
+				}
+				// A Location the browser resolves against another origin always
+				// begins "//" or "/\" — the prefix check above already rules
+				// that out, but assert it directly so the intent is explicit.
+				if strings.HasPrefix(loc, "//") || strings.HasPrefix(loc, `/\`) {
+					t.Errorf("GET %s: Location = %q is scheme-relative (open redirect)", target, loc)
+				}
+				if strings.ContainsAny(loc, "\r\n") {
+					t.Errorf("GET %s: Location = %q contains CR/LF (header injection)", target, loc)
+				}
+			}
+		}
 	}
 }
 

--- a/internal/server/base_path_test.go
+++ b/internal/server/base_path_test.go
@@ -188,6 +188,59 @@ func TestServerMountsRoutesUnderBasePath(t *testing.T) {
 	}
 }
 
+// index.html asset URLs get re-rooted under the prefix, but only the ones that
+// address this origin: a protocol-relative URL prefixed into "/radar//cdn…"
+// becomes a local path that 404s, and it would break only under a base path.
+func TestPrefixAttrPathsLeavesOtherOriginsAlone(t *testing.T) {
+	in := `<link href="//cdn.example.com/a.css"><script src="https://cdn.example.com/b.js"></script>` +
+		`<link href="./assets/c.css"><script src="/assets/d.js"></script>`
+
+	underPrefix := prefixAttrPaths(in, "/radar")
+	for _, want := range []string{
+		`href="//cdn.example.com/a.css"`,     // other origin, untouched
+		`src="https://cdn.example.com/b.js"`, // scheme-qualified, untouched
+		`href="/radar/assets/c.css"`,         // Vite-relative, re-rooted
+		`src="/radar/assets/d.js"`,           // root-absolute, re-rooted
+	} {
+		if !strings.Contains(underPrefix, want) {
+			t.Errorf("under /radar: missing %s\ngot: %s", want, underPrefix)
+		}
+	}
+
+	// At the root the relative form still has to become absolute so deep client
+	// routes don't resolve assets against the current path.
+	atRoot := prefixAttrPaths(in, "")
+	for _, want := range []string{
+		`href="//cdn.example.com/a.css"`,
+		`href="/assets/c.css"`,
+		`src="/assets/d.js"`,
+	} {
+		if !strings.Contains(atRoot, want) {
+			t.Errorf("at root: missing %s\ngot: %s", want, atRoot)
+		}
+	}
+}
+
+// The OIDC handler sends the browser into the app after a successful login, so
+// it has to know the prefix: under a no-strip subpath ingress only {basePath}/*
+// reaches this service, and a bare "/" would land the user outside Radar. The
+// redirect itself needs a token exchange to exercise, so this covers the wiring
+// that would silently break it.
+func TestAuthConfigCarriesNormalizedBasePath(t *testing.T) {
+	for raw, want := range map[string]string{
+		"":             "",
+		"/":            "",
+		"/radar":       "/radar",
+		"radar/":       "/radar",
+		"/tools/radar": "/tools/radar",
+	} {
+		srv := New(Config{DevMode: true, BasePath: raw, AuthConfig: auth.Config{Mode: "proxy"}})
+		if got := srv.authConfig.BasePath; got != want {
+			t.Errorf("BasePath %q: authConfig.BasePath = %q, want %q", raw, got, want)
+		}
+	}
+}
+
 // Both base-path redirects echo the request's query string, so their Location
 // must stay same-origin no matter what the caller sends: a value that browsers
 // read as scheme-relative ("//host", "/\host") would be an open redirect.

--- a/internal/server/base_path_test.go
+++ b/internal/server/base_path_test.go
@@ -221,26 +221,6 @@ func TestPrefixAttrPathsLeavesOtherOriginsAlone(t *testing.T) {
 	}
 }
 
-// The OIDC handler sends the browser into the app after a successful login, so
-// it has to know the prefix: under a no-strip subpath ingress only {basePath}/*
-// reaches this service, and a bare "/" would land the user outside Radar. The
-// redirect itself needs a token exchange to exercise, so this covers the wiring
-// that would silently break it.
-func TestAuthConfigCarriesNormalizedBasePath(t *testing.T) {
-	for raw, want := range map[string]string{
-		"":             "",
-		"/":            "",
-		"/radar":       "/radar",
-		"radar/":       "/radar",
-		"/tools/radar": "/tools/radar",
-	} {
-		srv := New(Config{DevMode: true, BasePath: raw, AuthConfig: auth.Config{Mode: "proxy"}})
-		if got := srv.authConfig.BasePath; got != want {
-			t.Errorf("BasePath %q: authConfig.BasePath = %q, want %q", raw, got, want)
-		}
-	}
-}
-
 // Both base-path redirects echo the request's query string, so their Location
 // must stay same-origin no matter what the caller sends: a value that browsers
 // read as scheme-relative ("//host", "/\host") would be an open redirect.

--- a/internal/server/base_path_test.go
+++ b/internal/server/base_path_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"testing/fstest"
+
+	"github.com/skyhook-io/radar/pkg/auth"
 )
 
 func TestNormalizeBasePath(t *testing.T) {
@@ -26,6 +28,12 @@ func TestNormalizeBasePath(t *testing.T) {
 		{name: "url rejected", raw: "https://example.com/radar", wantErr: true},
 		{name: "route pattern rejected", raw: "/{tenant}/radar", wantErr: true},
 		{name: "dot segment rejected", raw: "/radar/../api", wantErr: true},
+		{name: "quote rejected", raw: `/rad"ar`, wantErr: true},
+		{name: "angle bracket rejected", raw: "/rad<script>ar", wantErr: true},
+		{name: "backslash rejected", raw: `/rad\ar`, wantErr: true},
+		{name: "space rejected", raw: "/rad ar", wantErr: true},
+		{name: "percent encoding rejected", raw: "/rad%2Far", wantErr: true},
+		{name: "unreserved characters allowed", raw: "/radar-v2_1.0~beta", want: "/radar-v2_1.0~beta"},
 	}
 
 	for _, tt := range tests {
@@ -124,8 +132,10 @@ func TestFrontendHandlerRewritesIndexFallbackButNotAssets(t *testing.T) {
 		t.Fatalf("client-route fallback did not rewrite asset src:\n%s", indexBody)
 	}
 
+	// Root-relative: basePathHandler strips the prefix before the frontend
+	// handler sees the request.
 	assetResp := httptest.NewRecorder()
-	handler.ServeHTTP(assetResp, httptest.NewRequest(http.MethodGet, "/radar/assets/index.js", nil))
+	handler.ServeHTTP(assetResp, httptest.NewRequest(http.MethodGet, "/assets/index.js", nil))
 	if assetResp.Code != http.StatusOK {
 		t.Fatalf("asset status = %d, want 200", assetResp.Code)
 	}
@@ -160,5 +170,49 @@ func TestServerMountsRoutesUnderBasePath(t *testing.T) {
 	srv.Handler().ServeHTTP(prefixedResp, httptest.NewRequest(http.MethodGet, "/radar/api/health", nil))
 	if prefixedResp.Code != http.StatusOK {
 		t.Fatalf("prefixed API status = %d, want 200", prefixedResp.Code)
+	}
+
+	bareResp := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(bareResp, httptest.NewRequest(http.MethodGet, "/radar?namespace=default", nil))
+	if bareResp.Code != http.StatusMovedPermanently {
+		t.Fatalf("bare prefix status = %d, want 301", bareResp.Code)
+	}
+	if got := bareResp.Header().Get("Location"); got != "/radar/?namespace=default" {
+		t.Fatalf("bare prefix Location = %q, want /radar/?namespace=default", got)
+	}
+}
+
+// A base path must not become an authentication bypass. chi's Mount leaves
+// r.URL.Path prefixed, and the auth middleware treats paths outside /api, /mcp
+// and /debug as public static content — so before the prefix was stripped at the
+// router edge, every prefixed endpoint (including the /debug/pprof heap dump of
+// the whole informer cache) served unauthenticated.
+func TestBasePathDoesNotBypassAuth(t *testing.T) {
+	protected := []string{"/api/config", "/api/resources/pods", "/debug/pprof/heap", "/api/auth/whoami"}
+
+	// Proxy mode only: the exemption logic under test lives in
+	// auth.Authenticate and is mode-independent, and OIDC mode would need a
+	// reachable issuer for discovery.
+	for _, basePath := range []string{"", "/radar", "/tools/radar"} {
+		srv := New(Config{
+			DevMode:    true,
+			BasePath:   basePath,
+			AuthConfig: auth.Config{Mode: "proxy"},
+		})
+		for _, path := range protected {
+			resp := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(resp, httptest.NewRequest(http.MethodGet, basePath+path, nil))
+			if resp.Code != http.StatusUnauthorized {
+				t.Errorf("basePath=%q GET %s: status = %d, want 401 (unauthenticated request must be rejected)",
+					basePath, basePath+path, resp.Code)
+			}
+		}
+
+		// /api/health stays public for kubelet probes, under the prefix too.
+		healthResp := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(healthResp, httptest.NewRequest(http.MethodGet, basePath+"/api/health", nil))
+		if healthResp.Code != http.StatusOK {
+			t.Errorf("basePath=%q: health status = %d, want 200", basePath, healthResp.Code)
+		}
 	}
 }

--- a/internal/server/base_path_test.go
+++ b/internal/server/base_path_test.go
@@ -1,0 +1,164 @@
+package server
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func TestNormalizeBasePath(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{name: "empty", raw: "", want: ""},
+		{name: "root", raw: "/", want: ""},
+		{name: "adds leading slash", raw: "radar", want: "/radar"},
+		{name: "trims trailing slash", raw: "/radar/", want: "/radar"},
+		{name: "nested path", raw: "/tools/radar/", want: "/tools/radar"},
+		{name: "query rejected", raw: "/radar?x=1", wantErr: true},
+		{name: "fragment rejected", raw: "/radar#top", wantErr: true},
+		{name: "url rejected", raw: "https://example.com/radar", wantErr: true},
+		{name: "route pattern rejected", raw: "/{tenant}/radar", wantErr: true},
+		{name: "dot segment rejected", raw: "/radar/../api", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeBasePath(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("NormalizeBasePath(%q) returned nil error", tt.raw)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NormalizeBasePath(%q) returned error: %v", tt.raw, err)
+			}
+			if got != tt.want {
+				t.Fatalf("NormalizeBasePath(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRewriteFrontendIndexInjectsBasePathRuntimeConfig(t *testing.T) {
+	input := []byte(`<!doctype html>
+<html>
+  <head>
+    <link rel="icon" href="/favicon.svg">
+    <script type="module" crossorigin src="/assets/index.js"></script>
+    <link rel="modulepreload" crossorigin href="./assets/vendor.js">
+  </head>
+  <body>
+    <img src="/images/radar/radar-icon.svg">
+  </body>
+</html>`)
+
+	got := string(rewriteFrontendIndex(input, "/radar"))
+	for _, want := range []string{
+		`window.__RADAR_RUNTIME_CONFIG__={"basePath":"/radar","apiBase":"/radar/api","assetBase":"/radar"};`,
+		`href="/radar/favicon.svg"`,
+		`src="/radar/assets/index.js"`,
+		`href="/radar/assets/vendor.js"`,
+		`src="/radar/images/radar/radar-icon.svg"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("rewritten index missing %q:\n%s", want, got)
+		}
+	}
+
+	runtimeIdx := strings.Index(got, `window.__RADAR_RUNTIME_CONFIG__`)
+	moduleIdx := strings.Index(got, `<script type="module"`)
+	if runtimeIdx == -1 || moduleIdx == -1 || runtimeIdx > moduleIdx {
+		t.Fatalf("runtime config must be emitted before module script:\n%s", got)
+	}
+}
+
+func TestRewriteFrontendIndexRootLeavesHTMLUnchanged(t *testing.T) {
+	input := []byte(`<html><head><script type="module" src="/assets/index.js"></script></head></html>`)
+	got := rewriteFrontendIndex(input, "")
+	if string(got) != string(input) {
+		t.Fatalf("root base path should not rewrite index:\ngot  %s\nwant %s", got, input)
+	}
+}
+
+func TestRewriteFrontendIndexRootMakesRelativeAssetsAbsolute(t *testing.T) {
+	input := []byte(`<html><head><script type="module" src="./assets/index.js"></script><link rel="stylesheet" href="./assets/index.css"></head></html>`)
+	got := string(rewriteFrontendIndex(input, ""))
+	for _, want := range []string{
+		`src="/assets/index.js"`,
+		`href="/assets/index.css"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("rewritten root index missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, `__RADAR_RUNTIME_CONFIG__`) {
+		t.Fatalf("root base path should not inject runtime config:\n%s", got)
+	}
+}
+
+func TestFrontendHandlerRewritesIndexFallbackButNotAssets(t *testing.T) {
+	fsys := http.FS(fstest.MapFS{
+		"index.html":      &fstest.MapFile{Data: []byte(`<!doctype html><html><head><script type="module" src="/assets/index.js"></script></head><body></body></html>`)},
+		"assets/index.js": &fstest.MapFile{Data: []byte(`console.log("ok")`)},
+	})
+	handler := frontendHandler(fsys, "/radar")
+
+	indexResp := httptest.NewRecorder()
+	handler.ServeHTTP(indexResp, httptest.NewRequest(http.MethodGet, "/topology", nil))
+	if indexResp.Code != http.StatusOK {
+		t.Fatalf("client-route fallback status = %d, want 200", indexResp.Code)
+	}
+	indexBody := indexResp.Body.String()
+	if !strings.Contains(indexBody, `window.__RADAR_RUNTIME_CONFIG__={"basePath":"/radar","apiBase":"/radar/api","assetBase":"/radar"};`) {
+		t.Fatalf("client-route fallback did not inject runtime config:\n%s", indexBody)
+	}
+	if !strings.Contains(indexBody, `src="/radar/assets/index.js"`) {
+		t.Fatalf("client-route fallback did not rewrite asset src:\n%s", indexBody)
+	}
+
+	assetResp := httptest.NewRecorder()
+	handler.ServeHTTP(assetResp, httptest.NewRequest(http.MethodGet, "/radar/assets/index.js", nil))
+	if assetResp.Code != http.StatusOK {
+		t.Fatalf("asset status = %d, want 200", assetResp.Code)
+	}
+	assetBody, err := io.ReadAll(assetResp.Result().Body)
+	if err != nil {
+		t.Fatalf("read asset response: %v", err)
+	}
+	if string(assetBody) != `console.log("ok")` {
+		t.Fatalf("asset body = %q", assetBody)
+	}
+}
+
+func TestServerMountsRoutesUnderBasePath(t *testing.T) {
+	srv := New(Config{DevMode: true, BasePath: "/radar"})
+
+	rootResp := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rootResp, httptest.NewRequest(http.MethodGet, "/?namespace=default", nil))
+	if rootResp.Code != http.StatusFound {
+		t.Fatalf("root status = %d, want 302", rootResp.Code)
+	}
+	if got := rootResp.Header().Get("Location"); got != "/radar/?namespace=default" {
+		t.Fatalf("root redirect Location = %q, want /radar/?namespace=default", got)
+	}
+
+	unprefixedResp := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(unprefixedResp, httptest.NewRequest(http.MethodGet, "/api/health", nil))
+	if unprefixedResp.Code != http.StatusNotFound {
+		t.Fatalf("unprefixed API status = %d, want 404", unprefixedResp.Code)
+	}
+
+	prefixedResp := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(prefixedResp, httptest.NewRequest(http.MethodGet, "/radar/api/health", nil))
+	if prefixedResp.Code != http.StatusOK {
+		t.Fatalf("prefixed API status = %d, want 200", prefixedResp.Code)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -103,6 +103,10 @@ type Server struct {
 	// rebuild, not this handler's persist step).
 	scopeMutationMu sync.Mutex
 
+	// rootHintOnce keeps the base-path misconfiguration hint to a single log
+	// line no matter how many requests reach the origin root.
+	rootHintOnce sync.Once
+
 	// nsPickMu serializes namespace-pick mutations: the POST handler's
 	// persist+set pair and the read-path stale-pick prune. Without it, a
 	// prune computed from a stale snapshot can land after a user's fresh
@@ -322,6 +326,7 @@ func (s *Server) setupRoutes() {
 		appRouter := chi.NewRouter()
 		s.setupAppRoutes(appRouter)
 		s.router.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			s.hintRootRequestUnderBasePath()
 			http.Redirect(w, r, s.basePath+"/"+querySuffix(r), http.StatusFound)
 		})
 		s.router.Mount(s.basePath, s.basePathHandler(appRouter))
@@ -350,6 +355,23 @@ func (s *Server) basePathHandler(app http.Handler) http.Handler {
 			return
 		}
 		stripped.ServeHTTP(w, r)
+	})
+}
+
+// hintRootRequestUnderBasePath explains, once, the misconfiguration that
+// otherwise presents only as an unexplained browser redirect loop: an ingress
+// that strips the prefix sitting in front of a Radar that also serves under it.
+// Radar sends the browser to {basePath}/, the ingress strips it again, and the
+// two bounce until the browser gives up with ERR_TOO_MANY_REDIRECTS.
+//
+// Phrased as a hint rather than an error because reaching / is legitimate — a
+// port-forward straight to the pod lands here, as does an ingress that routes
+// the origin root through as well.
+func (s *Server) hintRootRequestUnderBasePath() {
+	s.rootHintOnce.Do(func() {
+		log.Printf("[base-path] serving under %s; a request arrived for / and was redirected to %s/. "+
+			"If the browser reports too many redirects, the ingress in front of Radar is stripping the prefix: "+
+			"either stop stripping it, or unset --base-path / chart basePath.", s.basePath, s.basePath)
 	})
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -221,7 +221,7 @@ func New(cfg Config) *Server {
 					store = st
 				}
 			}
-			s.aiRuns = ai.NewRunManager(d, s.ActualPort, k8s.GetContextName, store)
+			s.aiRuns = ai.NewRunManager(d, s.ActualPort, s.basePath, k8s.GetContextName, store)
 			if historyBroken {
 				// Persistence was requested but isn't working — the UI must say
 				// history won't survive a restart, not just a log line.
@@ -319,23 +319,42 @@ func (s *Server) setupRoutes() {
 		appRouter := chi.NewRouter()
 		s.setupAppRoutes(appRouter)
 		s.router.Get("/", func(w http.ResponseWriter, r *http.Request) {
-			target := s.basePath + "/"
-			if r.URL.RawQuery != "" {
-				target += "?" + r.URL.RawQuery
-			}
-			http.Redirect(w, r, target, http.StatusFound)
+			http.Redirect(w, r, s.basePath+"/"+querySuffix(r), http.StatusFound)
 		})
-		s.router.Get(s.basePath, func(w http.ResponseWriter, r *http.Request) {
-			target := s.basePath + "/"
-			if r.URL.RawQuery != "" {
-				target += "?" + r.URL.RawQuery
-			}
-			http.Redirect(w, r, target, http.StatusMovedPermanently)
-		})
-		s.router.Mount(s.basePath, appRouter)
+		s.router.Mount(s.basePath, s.basePathHandler(appRouter))
 		return
 	}
 	s.setupAppRoutes(s.router)
+}
+
+// basePathHandler adapts the prefixed public URL space to the app router, which
+// is written as if it owned the origin's root.
+//
+// The prefix MUST be stripped from r.URL.Path before any app middleware runs:
+// chi's Mount only rewrites the routing context's RoutePath and leaves
+// r.URL.Path prefixed, but the auth middleware matches on r.URL.Path and treats
+// anything outside /api, /mcp and /debug as public static content. A prefixed
+// path therefore looked public and skipped authentication entirely — including
+// /debug/pprof, which dumps the whole informer cache. Stripping here keeps that
+// translation at the single edge instead of every absolute-path check inside.
+func (s *Server) basePathHandler(app http.Handler) http.Handler {
+	stripped := http.StripPrefix(s.basePath, app)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Canonicalize the bare prefix to a trailing slash so the app always
+		// sees a rooted path.
+		if r.URL.Path == s.basePath {
+			http.Redirect(w, r, s.basePath+"/"+querySuffix(r), http.StatusMovedPermanently)
+			return
+		}
+		stripped.ServeHTTP(w, r)
+	})
+}
+
+func querySuffix(r *http.Request) string {
+	if r.URL.RawQuery == "" {
+		return ""
+	}
+	return "?" + r.URL.RawQuery
 }
 
 func (s *Server) setupAppRoutes(r chi.Router) {
@@ -764,21 +783,30 @@ func NormalizeBasePath(raw string) (string, error) {
 	if p == "" || p == "/" {
 		return "", nil
 	}
-	if strings.ContainsAny(p, "?#") {
-		return "", fmt.Errorf("must be a path only, without query or fragment")
-	}
-	if strings.ContainsAny(p, "{}*") {
-		return "", fmt.Errorf("must not contain route pattern characters")
-	}
 	if strings.Contains(p, "://") || strings.HasPrefix(p, "//") {
 		return "", fmt.Errorf("must be a path, not a URL")
 	}
 	if !strings.HasPrefix(p, "/") {
 		p = "/" + p
 	}
+	// Allowlist rather than a blocklist: the value is interpolated into a chi
+	// route pattern and into href/src attributes of the served index.html, so
+	// anything outside unreserved RFC 3986 path characters is rejected up front
+	// instead of relying on each consumer to escape it. Also blocks %-encoding,
+	// which would make the configured prefix and the routed path disagree.
 	for _, segment := range strings.Split(p, "/") {
+		if segment == "" {
+			continue
+		}
 		if segment == "." || segment == ".." {
 			return "", fmt.Errorf("must not contain . or .. path segments")
+		}
+		for _, c := range segment {
+			isAllowed := c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' ||
+				c >= '0' && c <= '9' || c == '-' || c == '_' || c == '.' || c == '~'
+			if !isAllowed {
+				return "", fmt.Errorf("segment %q contains disallowed character %q — use only letters, digits, '-', '_', '.', '~'", segment, c)
+			}
 		}
 	}
 	clean := pathpkg.Clean(p)
@@ -793,21 +821,10 @@ func frontendHandler(fsys http.FileSystem, basePath string) http.Handler {
 	fileServer := http.FileServer(fsys)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Paths arrive root-relative even under a base path — basePathHandler
+		// strips the prefix at the router edge. basePath is still needed to
+		// rewrite the asset URLs inside index.html.
 		path := r.URL.Path
-		serveReq := r
-		if basePath != "" {
-			switch {
-			case path == basePath:
-				path = "/"
-			case strings.HasPrefix(path, basePath+"/"):
-				path = strings.TrimPrefix(path, basePath)
-			}
-			if path != r.URL.Path {
-				serveReq = r.Clone(r.Context())
-				serveReq.URL = cloneURL(r.URL)
-				serveReq.URL.Path = path
-			}
-		}
 
 		if path == "/" || path == "/index.html" {
 			serveFrontendIndex(w, r, fsys, basePath)
@@ -831,13 +848,8 @@ func frontendHandler(fsys http.FileSystem, basePath string) http.Handler {
 			return
 		}
 
-		fileServer.ServeHTTP(w, serveReq)
+		fileServer.ServeHTTP(w, r)
 	})
-}
-
-func cloneURL(u *url.URL) *url.URL {
-	cloned := *u
-	return &cloned
 }
 
 func serveFrontendIndex(w http.ResponseWriter, r *http.Request, fsys http.FileSystem, basePath string) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -984,6 +984,12 @@ func (s *Server) ActualPort() int {
 	return s.port
 }
 
+// BasePath returns the normalized URL prefix the server mounted under, or ""
+// when it serves from the root.
+func (s *Server) BasePath() string {
+	return s.basePath
+}
+
 // ActualAddr returns the address the server is listening on (e.g. "localhost:9280").
 func (s *Server) ActualAddr() string {
 	return fmt.Sprintf("localhost:%d", s.ActualPort())

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"embed"
 	"encoding/json"
@@ -13,6 +14,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"net/url"
+	pathpkg "path"
 	"reflect"
 	"runtime"
 	"slices"
@@ -68,6 +70,7 @@ type Server struct {
 	vitalsMetrics      vitalsMetricsMemo
 	port               int
 	listenAddress      string
+	basePath           string
 	startupLog         bool
 	remoteAccessHint   bool
 	devMode            bool
@@ -147,6 +150,7 @@ type Server struct {
 type Config struct {
 	Port               int
 	ListenAddress      string         // 127.0.0.1/localhost for local-only; 0.0.0.0 for shared access
+	BasePath           string         // Optional URL path prefix for self-hosted subpath deployments
 	StartupLog         bool           // Emit the operator-facing startup block after a successful bind
 	RemoteAccessHint   bool           // Explain the explicit shared-listener opt-in (native CLI only)
 	DevMode            bool           // Serve frontend from filesystem instead of embedded
@@ -163,12 +167,17 @@ type Config struct {
 // New creates a new server instance
 func New(cfg Config) *Server {
 	cfg.AuthConfig.Defaults()
+	basePath, err := NormalizeBasePath(cfg.BasePath)
+	if err != nil {
+		log.Fatalf("Invalid base path %q: %v", cfg.BasePath, err)
+	}
 
 	s := &Server{
 		router:                chi.NewRouter(),
 		broadcaster:           NewSSEBroadcaster(),
 		port:                  cfg.Port,
 		listenAddress:         cfg.ListenAddress,
+		basePath:              basePath,
 		startupLog:            cfg.StartupLog,
 		remoteAccessHint:      cfg.RemoteAccessHint,
 		devMode:               cfg.DevMode,
@@ -306,7 +315,30 @@ func New(cfg Config) *Server {
 }
 
 func (s *Server) setupRoutes() {
-	r := s.router
+	if s.basePath != "" {
+		appRouter := chi.NewRouter()
+		s.setupAppRoutes(appRouter)
+		s.router.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			target := s.basePath + "/"
+			if r.URL.RawQuery != "" {
+				target += "?" + r.URL.RawQuery
+			}
+			http.Redirect(w, r, target, http.StatusFound)
+		})
+		s.router.Get(s.basePath, func(w http.ResponseWriter, r *http.Request) {
+			target := s.basePath + "/"
+			if r.URL.RawQuery != "" {
+				target += "?" + r.URL.RawQuery
+			}
+			http.Redirect(w, r, target, http.StatusMovedPermanently)
+		})
+		s.router.Mount(s.basePath, appRouter)
+		return
+	}
+	s.setupAppRoutes(s.router)
+}
+
+func (s *Server) setupAppRoutes(r chi.Router) {
 
 	// Middleware (applied to all routes)
 	r.Use(middleware.Logger)
@@ -718,26 +750,75 @@ func (s *Server) setupRoutes() {
 
 	// Static files (frontend) - index.html fallback for client-side routes.
 	if s.staticFS != nil {
-		r.Handle("/*", frontendHandler(http.FS(s.staticFS)))
+		r.Handle("/*", frontendHandler(http.FS(s.staticFS), s.basePath))
 	} else if s.devMode {
 		// In dev mode, serve from web/dist
-		r.Handle("/*", frontendHandler(http.Dir("web/dist")))
+		r.Handle("/*", frontendHandler(http.Dir("web/dist"), s.basePath))
 	}
 }
 
+// NormalizeBasePath canonicalizes the optional URL prefix used when Radar is
+// served behind an ingress path like /radar. Empty and "/" mean root.
+func NormalizeBasePath(raw string) (string, error) {
+	p := strings.TrimSpace(raw)
+	if p == "" || p == "/" {
+		return "", nil
+	}
+	if strings.ContainsAny(p, "?#") {
+		return "", fmt.Errorf("must be a path only, without query or fragment")
+	}
+	if strings.ContainsAny(p, "{}*") {
+		return "", fmt.Errorf("must not contain route pattern characters")
+	}
+	if strings.Contains(p, "://") || strings.HasPrefix(p, "//") {
+		return "", fmt.Errorf("must be a path, not a URL")
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	for _, segment := range strings.Split(p, "/") {
+		if segment == "." || segment == ".." {
+			return "", fmt.Errorf("must not contain . or .. path segments")
+		}
+	}
+	clean := pathpkg.Clean(p)
+	if clean == "/" || clean == "." {
+		return "", nil
+	}
+	return clean, nil
+}
+
 // frontendHandler serves static files, falling back to index.html for client-side routing
-func frontendHandler(fsys http.FileSystem) http.Handler {
+func frontendHandler(fsys http.FileSystem, basePath string) http.Handler {
 	fileServer := http.FileServer(fsys)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
+		serveReq := r
+		if basePath != "" {
+			switch {
+			case path == basePath:
+				path = "/"
+			case strings.HasPrefix(path, basePath+"/"):
+				path = strings.TrimPrefix(path, basePath)
+			}
+			if path != r.URL.Path {
+				serveReq = r.Clone(r.Context())
+				serveReq.URL = cloneURL(r.URL)
+				serveReq.URL.Path = path
+			}
+		}
+
+		if path == "/" || path == "/index.html" {
+			serveFrontendIndex(w, r, fsys, basePath)
+			return
+		}
 
 		// Try to open the file
 		f, err := fsys.Open(path)
 		if err != nil {
 			// File doesn't exist - serve index.html for client-side routing
-			r.URL.Path = "/"
-			fileServer.ServeHTTP(w, r)
+			serveFrontendIndex(w, r, fsys, basePath)
 			return
 		}
 		defer f.Close()
@@ -746,11 +827,74 @@ func frontendHandler(fsys http.FileSystem) http.Handler {
 		stat, err := f.Stat()
 		if err != nil || (stat.IsDir() && path != "/") {
 			// For directories without index.html, serve root index.html
-			r.URL.Path = "/"
+			serveFrontendIndex(w, r, fsys, basePath)
+			return
 		}
 
-		fileServer.ServeHTTP(w, r)
+		fileServer.ServeHTTP(w, serveReq)
 	})
+}
+
+func cloneURL(u *url.URL) *url.URL {
+	cloned := *u
+	return &cloned
+}
+
+func serveFrontendIndex(w http.ResponseWriter, r *http.Request, fsys http.FileSystem, basePath string) {
+	f, err := fsys.Open("/index.html")
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	defer f.Close()
+
+	stat, err := f.Stat()
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	body, err := io.ReadAll(f)
+	if err != nil {
+		http.Error(w, "failed to read frontend index", http.StatusInternalServerError)
+		return
+	}
+	body = rewriteFrontendIndex(body, basePath)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	http.ServeContent(w, r, "index.html", stat.ModTime(), bytes.NewReader(body))
+}
+
+func rewriteFrontendIndex(body []byte, basePath string) []byte {
+	html := string(body)
+	if basePath != "" {
+		html = strings.ReplaceAll(html, `href="/`, `href="`+basePath+`/`)
+		html = strings.ReplaceAll(html, `src="/`, `src="`+basePath+`/`)
+	}
+	html = strings.ReplaceAll(html, `href="./`, `href="`+basePath+`/`)
+	html = strings.ReplaceAll(html, `src="./`, `src="`+basePath+`/`)
+	if basePath == "" {
+		return []byte(html)
+	}
+	cfg := struct {
+		BasePath  string `json:"basePath"`
+		ApiBase   string `json:"apiBase"`
+		AssetBase string `json:"assetBase"`
+	}{
+		BasePath:  basePath,
+		ApiBase:   basePath + "/api",
+		AssetBase: basePath,
+	}
+	cfgJSON, err := json.Marshal(cfg)
+	if err != nil {
+		return body
+	}
+
+	runtimeScript := `<script>window.__RADAR_RUNTIME_CONFIG__=` + string(cfgJSON) + `;</script>`
+	if strings.Contains(html, `<script type="module"`) {
+		html = strings.Replace(html, `<script type="module"`, runtimeScript+"\n    "+`<script type="module"`, 1)
+	} else {
+		html = strings.Replace(html, `</head>`, "    "+runtimeScript+"\n  </head>", 1)
+	}
+	return []byte(html)
 }
 
 // Start starts the server. If port is 0, an OS-assigned port is used.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -171,6 +171,9 @@ func New(cfg Config) *Server {
 	if err != nil {
 		log.Fatalf("Invalid base path %q: %v", cfg.BasePath, err)
 	}
+	// The OIDC handler redirects into the app after login, so it needs to know
+	// where the app lives. Set before NewOIDCHandler reads the config below.
+	cfg.AuthConfig.BasePath = basePath
 
 	s := &Server{
 		router:                chi.NewRouter(),
@@ -875,14 +878,45 @@ func serveFrontendIndex(w http.ResponseWriter, r *http.Request, fsys http.FileSy
 	http.ServeContent(w, r, "index.html", stat.ModTime(), bytes.NewReader(body))
 }
 
-func rewriteFrontendIndex(body []byte, basePath string) []byte {
-	html := string(body)
-	if basePath != "" {
-		html = strings.ReplaceAll(html, `href="/`, `href="`+basePath+`/`)
-		html = strings.ReplaceAll(html, `src="/`, `src="`+basePath+`/`)
+// prefixAttrPaths re-roots the href/src URLs of the served index.html under
+// basePath, turning both root-absolute ("/x") and Vite's relative ("./x") forms
+// into "{basePath}/x" — the latter matters at the root too, where basePath is
+// empty and "./x" must still become "/x" so deep client routes resolve assets.
+//
+// Protocol-relative URLs ("//cdn.example.com/x") are deliberately skipped: they
+// address another origin, and prefixing one would silently turn it into a local
+// path that 404s. Scheme-qualified URLs never match, since the character after
+// the quote isn't a slash.
+func prefixAttrPaths(html, basePath string) string {
+	for _, attr := range []string{`href="`, `src="`} {
+		var out strings.Builder
+		rest := html
+		for {
+			i := strings.Index(rest, attr)
+			if i < 0 {
+				out.WriteString(rest)
+				break
+			}
+			out.WriteString(rest[:i+len(attr)])
+			rest = rest[i+len(attr):]
+			switch {
+			case strings.HasPrefix(rest, "//"):
+				// another origin — leave untouched
+			case strings.HasPrefix(rest, "./"):
+				out.WriteString(basePath + "/")
+				rest = rest[len("./"):]
+			case strings.HasPrefix(rest, "/"):
+				out.WriteString(basePath + "/")
+				rest = rest[len("/"):]
+			}
+		}
+		html = out.String()
 	}
-	html = strings.ReplaceAll(html, `href="./`, `href="`+basePath+`/`)
-	html = strings.ReplaceAll(html, `src="./`, `src="`+basePath+`/`)
+	return html
+}
+
+func rewriteFrontendIndex(body []byte, basePath string) []byte {
+	html := prefixAttrPaths(string(body), basePath)
 	if basePath == "" {
 		return []byte(html)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -330,13 +330,13 @@ func (s *Server) setupRoutes() {
 // basePathHandler adapts the prefixed public URL space to the app router, which
 // is written as if it owned the origin's root.
 //
-// The prefix MUST be stripped from r.URL.Path before any app middleware runs:
+// The prefix MUST be stripped from r.URL.Path before any app middleware runs.
 // chi's Mount only rewrites the routing context's RoutePath and leaves
-// r.URL.Path prefixed, but the auth middleware matches on r.URL.Path and treats
-// anything outside /api, /mcp and /debug as public static content. A prefixed
-// path therefore looked public and skipped authentication entirely — including
-// /debug/pprof, which dumps the whole informer cache. Stripping here keeps that
-// translation at the single edge instead of every absolute-path check inside.
+// r.URL.Path prefixed, while the auth middleware matches on r.URL.Path and
+// treats anything outside /api, /mcp and /debug as public static content — so a
+// still-prefixed path reads as public and skips authentication entirely,
+// /debug/pprof (which dumps the whole informer cache) included. Translating once
+// here keeps that concern at the edge rather than in every path check inside.
 func (s *Server) basePathHandler(app http.Handler) http.Handler {
 	stripped := http.StripPrefix(s.basePath, app)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -175,10 +175,6 @@ func New(cfg Config) *Server {
 	if err != nil {
 		log.Fatalf("Invalid base path %q: %v", cfg.BasePath, err)
 	}
-	// The OIDC handler redirects into the app after login, so it needs to know
-	// where the app lives. Set before NewOIDCHandler reads the config below.
-	cfg.AuthConfig.BasePath = basePath
-
 	s := &Server{
 		router:                chi.NewRouter(),
 		broadcaster:           NewSSEBroadcaster(),
@@ -292,7 +288,7 @@ func New(cfg Config) *Server {
 			if s.authConfig.OIDCRedirectURL == "" {
 				log.Fatalf("[auth] --auth-oidc-redirect-url is required when auth-mode=oidc")
 			}
-			oidcHandler, err := auth.NewOIDCHandler(context.Background(), s.authConfig)
+			oidcHandler, err := auth.NewOIDCHandler(context.Background(), s.authConfig, basePath)
 			if err != nil {
 				log.Fatalf("[auth] OIDC initialization failed (issuer=%s): %v — cannot start with auth-mode=oidc", s.authConfig.OIDCIssuer, err)
 			}

--- a/internal/server/startup_log.go
+++ b/internal/server/startup_log.go
@@ -23,6 +23,7 @@ const (
 type startupLogSummary struct {
 	listenAddress        string
 	port                 int
+	basePath             string
 	authMode             string
 	proxyUserHeader      string
 	proxyGroupsHeader    string
@@ -44,6 +45,7 @@ func (s *Server) logStartupSummaryBlock() {
 	summary := startupLogSummary{
 		listenAddress:        s.listenAddress,
 		port:                 s.ActualPort(),
+		basePath:             s.basePath,
 		authMode:             s.authConfig.Mode,
 		proxyUserHeader:      s.authConfig.UserHeader,
 		proxyGroupsHeader:    s.authConfig.GroupsHeader,
@@ -60,6 +62,16 @@ func (s *Server) logStartupSummaryBlock() {
 	for _, line := range formatStartupLogSummary(summary, color) {
 		log.Print(line)
 	}
+}
+
+// startupURLPath renders the URL path suffix for the startup block: a
+// normalized base path gets a trailing slash so the printed URL lands on the
+// app directly instead of bouncing through the root redirect.
+func startupURLPath(basePath string) string {
+	if basePath == "" {
+		return ""
+	}
+	return basePath + "/"
 }
 
 func formatStartupLogSummary(summary startupLogSummary, color bool) []string {
@@ -83,7 +95,7 @@ func formatStartupLogSummary(summary startupLogSummary, color bool) []string {
 	loopback := cloud.IsLoopbackHostname(summary.listenAddress)
 	if loopback {
 		lines = append(lines,
-			row("URL", fmt.Sprintf("http://localhost:%d", summary.port)),
+			row("URL", fmt.Sprintf("http://localhost:%d%s", summary.port, startupURLPath(summary.basePath))),
 			row("Access", paint(startupANSICyan, "LOCAL ONLY")+" ("+summary.listenAddress+")"),
 		)
 	} else {

--- a/packages/k8s-ui/src/components/topology/layout.worker.ts
+++ b/packages/k8s-ui/src/components/topology/layout.worker.ts
@@ -7,10 +7,11 @@
  */
 import ELK from 'elkjs/lib/elk-api.js'
 import elkWorkerAlgorithm from 'elkjs/lib/elk-worker.min.js?url'
+import { assetUrl } from '../../utils/asset-url'
 
 // Create ELK with explicit worker URL (runs the algorithm in our worker context)
 const elk = new ELK({
-  workerUrl: elkWorkerAlgorithm,
+  workerUrl: assetUrl(elkWorkerAlgorithm),
 })
 
 // ELK options for laying out nodes within a single group

--- a/packages/k8s-ui/src/utils/asset-url.test.ts
+++ b/packages/k8s-ui/src/utils/asset-url.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { assetUrl } from './asset-url'
+
+type RuntimeGlobal = typeof globalThis & {
+  __RADAR_RUNTIME_CONFIG__?: { assetBase?: string }
+}
+
+function setAssetBase(assetBase: string) {
+  ;(globalThis as RuntimeGlobal).__RADAR_RUNTIME_CONFIG__ = { assetBase }
+}
+
+/**
+ * Simulates a Worker scope, where `window` is absent and `location` is the
+ * worker script's own URL. jsdom defines `window`, so it has to be removed.
+ */
+function asWorkerAt(pathname: string, run: () => void) {
+  const realWindow = globalThis.window
+  // @ts-expect-error — deliberately emulating a scope without `window`
+  delete globalThis.window
+  const realLocation = globalThis.location
+  Object.defineProperty(globalThis, 'location', {
+    value: { pathname },
+    configurable: true,
+    writable: true,
+  })
+  try {
+    run()
+  } finally {
+    Object.defineProperty(globalThis, 'location', {
+      value: realLocation,
+      configurable: true,
+      writable: true,
+    })
+    globalThis.window = realWindow
+  }
+}
+
+afterEach(() => {
+  delete (globalThis as RuntimeGlobal).__RADAR_RUNTIME_CONFIG__
+})
+
+describe('assetUrl at the root (no base path)', () => {
+  it('leaves absolute paths untouched', () => {
+    expect(assetUrl('/images/radar/radar-icon.svg')).toBe('/images/radar/radar-icon.svg')
+  })
+
+  it('makes Vite-relative asset paths absolute', () => {
+    expect(assetUrl('./assets/index-abc.js')).toBe('/assets/index-abc.js')
+    expect(assetUrl('assets/index-abc.js')).toBe('/assets/index-abc.js')
+  })
+
+  it('unwraps the webpack/Next StaticImageData shape', () => {
+    expect(assetUrl({ src: '/_next/static/x.png' })).toBe('/_next/static/x.png')
+  })
+
+  // An app route may contain an "/assets/" segment (e.g. a namespace named
+  // "assets"). That must not be mistaken for a base path.
+  it('ignores an /assets/ segment in the current app route', () => {
+    expect(assetUrl('/images/radar/radar-icon.svg')).toBe('/images/radar/radar-icon.svg')
+  })
+})
+
+describe('assetUrl under a base path', () => {
+  it('prefixes absolute and relative asset paths', () => {
+    setAssetBase('/radar')
+    expect(assetUrl('/images/radar/radar-icon.svg')).toBe('/radar/images/radar/radar-icon.svg')
+    expect(assetUrl('./assets/index-abc.js')).toBe('/radar/assets/index-abc.js')
+    expect(assetUrl('assets/index-abc.js')).toBe('/radar/assets/index-abc.js')
+  })
+
+  it('is idempotent for already-prefixed paths', () => {
+    setAssetBase('/radar')
+    expect(assetUrl('/radar/assets/index-abc.js')).toBe('/radar/assets/index-abc.js')
+  })
+
+  it('leaves protocol-relative URLs alone', () => {
+    setAssetBase('/radar')
+    expect(assetUrl('//cdn.example.com/x.png')).toBe('//cdn.example.com/x.png')
+  })
+
+  it('handles a nested base path', () => {
+    setAssetBase('/tools/radar')
+    expect(assetUrl('/favicon.svg')).toBe('/tools/radar/favicon.svg')
+  })
+})
+
+describe('assetUrl inside a Worker', () => {
+  it('recovers the base path from the worker script URL', () => {
+    asWorkerAt('/radar/assets/layout.worker-abc.js', () => {
+      expect(assetUrl('/images/x.svg')).toBe('/radar/images/x.svg')
+    })
+  })
+
+  it('resolves to the root when the worker is served from the root', () => {
+    asWorkerAt('/assets/layout.worker-abc.js', () => {
+      expect(assetUrl('/images/x.svg')).toBe('/images/x.svg')
+    })
+  })
+
+  // The base path may itself contain "/assets/" — split on the last one.
+  it('splits on the last /assets/ segment', () => {
+    asWorkerAt('/host/assets/radar/assets/layout.worker-abc.js', () => {
+      expect(assetUrl('/images/x.svg')).toBe('/host/assets/radar/images/x.svg')
+    })
+  })
+
+  it('prefers the injected config over the URL heuristic', () => {
+    setAssetBase('/radar')
+    asWorkerAt('/somewhere/assets/worker.js', () => {
+      expect(assetUrl('/images/x.svg')).toBe('/radar/images/x.svg')
+    })
+  })
+})

--- a/packages/k8s-ui/src/utils/asset-url.ts
+++ b/packages/k8s-ui/src/utils/asset-url.ts
@@ -30,8 +30,16 @@ function getRuntimeAssetBase(): string {
   const configured = runtime?.assetBase?.replace(/\/+$/, '')
   if (configured) return configured
 
+  // A Worker has its own global scope, so it never sees the runtime config the
+  // server injects into index.html — but its own script URL sits at
+  // `<base>/assets/<chunk>.js`, so the base can be recovered from it. Restricted
+  // to worker scopes on purpose: on the main thread `pathname` is an app route,
+  // which may legitimately contain an "/assets/" segment (a namespace or
+  // resource named "assets") and would yield a bogus prefix for every asset.
+  if (typeof window !== 'undefined') return ''
   const pathname = globalThis.location?.pathname ?? ''
-  const assetsIndex = pathname.indexOf('/assets/')
+  // lastIndexOf, not indexOf: the base path itself may contain "/assets/".
+  const assetsIndex = pathname.lastIndexOf('/assets/')
   if (assetsIndex > 0) return pathname.slice(0, assetsIndex)
   return ''
 }

--- a/packages/k8s-ui/src/utils/asset-url.ts
+++ b/packages/k8s-ui/src/utils/asset-url.ts
@@ -9,5 +9,29 @@
 export type AssetImport = string | { src: string }
 
 export function assetUrl(asset: AssetImport): string {
-  return typeof asset === 'string' ? asset : asset.src
+  const url = typeof asset === 'string' ? asset : asset.src
+  const assetBase = getRuntimeAssetBase()
+  if (!assetBase || url.startsWith('//') || url === assetBase || url.startsWith(`${assetBase}/`)) {
+    if (url.startsWith('./assets/')) return `/assets/${url.slice('./assets/'.length)}`
+    if (url.startsWith('assets/')) return `/${url}`
+    return url
+  }
+  if (url.startsWith('./')) return `${assetBase}/${url.slice(2)}`
+  if (!url.startsWith('/') && url.startsWith('assets/')) return `${assetBase}/${url}`
+  if (!url.startsWith('/')) return url
+  return `${assetBase}${url}`
+}
+
+function getRuntimeAssetBase(): string {
+  if (typeof globalThis === 'undefined') return ''
+  const runtime = (globalThis as typeof globalThis & {
+    __RADAR_RUNTIME_CONFIG__?: { assetBase?: string }
+  }).__RADAR_RUNTIME_CONFIG__
+  const configured = runtime?.assetBase?.replace(/\/+$/, '')
+  if (configured) return configured
+
+  const pathname = globalThis.location?.pathname ?? ''
+  const assetsIndex = pathname.indexOf('/assets/')
+  if (assetsIndex > 0) return pathname.slice(0, assetsIndex)
+  return ''
 }

--- a/packages/k8s-ui/src/utils/index.ts
+++ b/packages/k8s-ui/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './format'
 export * from './pluralize'
+export * from './asset-url'
 export * from './badge-colors'
 export * from './resource-icons'
 export * from './navigation'

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -17,11 +17,6 @@ type Config struct {
 	Secret    string        // HMAC signing key for session cookies
 	CookieTTL time.Duration // default 4h, sliding
 
-	// BasePath is the URL prefix Radar is served under ("" at the root). Post-login
-	// redirects must target it: under a no-strip subpath ingress only {BasePath}/*
-	// is routed to Radar, so sending the browser to "/" lands outside the app.
-	BasePath string
-
 	// Proxy mode
 	UserHeader     string // default "X-Forwarded-User"
 	GroupsHeader   string // default "X-Forwarded-Groups"

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -17,6 +17,11 @@ type Config struct {
 	Secret    string        // HMAC signing key for session cookies
 	CookieTTL time.Duration // default 4h, sliding
 
+	// BasePath is the URL prefix Radar is served under ("" at the root). Post-login
+	// redirects must target it: under a no-strip subpath ingress only {BasePath}/*
+	// is routed to Radar, so sending the browser to "/" lands outside the app.
+	BasePath string
+
 	// Proxy mode
 	UserHeader     string // default "X-Forwarded-User"
 	GroupsHeader   string // default "X-Forwarded-Groups"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,7 +9,7 @@ import { DebugOverlay } from './components/DebugOverlay'
 import { GlobalDiagnoseButton } from './components/diagnose/LocalDiagnoseAction'
 import { useDiagnoseLayout } from './components/diagnose/DiagnoseContext'
 import { DiagnoseSurface } from './components/diagnose/DiagnoseSurface'
-import { TopologyGraph, TopologySearch, TopologyBreadcrumb, TopologyFilterSidebar, TopologyControls, FreshnessControl, gitOpsRouteForKind, gitOpsRouteForResource, ScopePill, PaneLoader } from '@skyhook-io/k8s-ui'
+import { TopologyGraph, TopologySearch, TopologyBreadcrumb, TopologyFilterSidebar, TopologyControls, FreshnessControl, gitOpsRouteForKind, gitOpsRouteForResource, ScopePill, PaneLoader, assetUrl } from '@skyhook-io/k8s-ui'
 import { initNavigationMap } from '@skyhook-io/k8s-ui/utils/navigation'
 import { useAPIResources, findAPIResourceForRoute } from './api/apiResources'
 import { TimelineView } from './components/timeline/TimelineView'
@@ -67,6 +67,8 @@ import { kindToPlural, pluralToKind, openExternal, apiVersionToGroup, relatedRes
 import { type OmnibarHandle } from './components/ui/Omnibar'
 import { RadarOmnibar } from './components/ui/RadarOmnibar'
 import type { ContextSwitcherHandle } from './components/ContextSwitcher'
+
+const radarLogoUrl = assetUrl('/images/radar/radar-icon.svg')
 
 // All possible node kinds (core + GitOps)
 const ALL_NODE_KINDS: NodeKind[] = [
@@ -2566,7 +2568,7 @@ function Logo() {
     <div className="flex items-center gap-2.5">
       <div className="relative w-7 h-7 rounded-lg overflow-hidden flex-shrink-0 bg-emerald-500/10 border border-emerald-500/20">
         <img
-          src="/images/radar/radar-icon.svg"
+          src={radarLogoUrl}
           alt=""
           aria-hidden
           className="w-full h-full p-0.5"

--- a/web/src/api/config.test.ts
+++ b/web/src/api/config.test.ts
@@ -40,6 +40,25 @@ describe('stripBasename', () => {
     expect(stripBasename('/c/abcdef/resources')).toBe('/c/abcdef/resources')
   })
 
+  // Standalone Radar sets a basename too once --base-path is configured, so the
+  // session-expiry return path round-trips through this in a new shape. Store
+  // strips once (client.ts) and restore strips again defensively (App.tsx) before
+  // navigate() re-applies the basename — the net effect must be the original
+  // route, never a doubled one.
+  it('round-trips a return path under a base path without doubling', () => {
+    setBasename('/radar')
+    const stored = stripBasename('/radar/resources/pods') + '?namespaces=prod'
+    expect(stored).toBe('/resources/pods?namespaces=prod')
+    // Restore side strips a second time; already-relative values are untouched.
+    expect(stripBasename(stored)).toBe('/resources/pods?namespaces=prod')
+  })
+
+  it('leaves a nested base path return path relative', () => {
+    setBasename('/tools/radar')
+    expect(stripBasename('/tools/radar/topology')).toBe('/topology')
+    expect(stripBasename(stripBasename('/tools/radar/topology'))).toBe('/topology')
+  })
+
   it('inverts routePath', () => {
     setBasename('/c/abc')
     expect(stripBasename(routePath('/auth/login'))).toBe('/auth/login')

--- a/web/src/components/ConnectionErrorView.tsx
+++ b/web/src/components/ConnectionErrorView.tsx
@@ -7,6 +7,7 @@ import { useOpenLocalTerminal, ClusterName } from '@skyhook-io/k8s-ui'
 import { useAuthMe } from '../api/client'
 import { Tooltip } from './ui/Tooltip'
 import { allShellSafe } from '../utils/shell-safe'
+import { apiUrl } from '../api/config'
 
 interface ConnectionErrorViewProps {
   connection: ConnectionState
@@ -357,7 +358,7 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
   // mode — but the chained retry curl carries no session cookie, so it 401s
   // once /api/connection is auth-gated. Only chain it when auth is *known*
   // disabled (authMe still loading → don't chain a doomed call).
-  const retryCmd = `curl -s -X POST http://${window.location.host}/api/connection/retry > /dev/null`
+  const retryCmd = `curl -s -X POST http://${window.location.host}${apiUrl('/connection/retry')} > /dev/null`
 
   const handleAuthInTerminal = () => {
     if (!commandInfo?.authCommand) return

--- a/web/src/components/UserMenu.tsx
+++ b/web/src/components/UserMenu.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from 'react'
 import { User, LogOut } from 'lucide-react'
 import { clsx } from 'clsx'
 import { useAuthMe } from '../api/client'
+import { routePath } from '../api/config'
 import { Tooltip } from './ui/Tooltip'
 import { useQueryClient } from '@tanstack/react-query'
 
@@ -33,9 +34,9 @@ export function UserMenu({ variant = 'topbar', pinned = true }: UserMenuProps = 
   }, [isOpen])
 
   const handleLogout = useCallback(async () => {
-    let redirectTo = '/'
+    let redirectTo = routePath('/')
     try {
-      const res = await fetch('/auth/logout', { credentials: 'same-origin' })
+      const res = await fetch(routePath('/auth/logout'), { credentials: 'same-origin' })
       const data = await res.json()
       if (data.redirectTo) {
         redirectTo = data.redirectTo

--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -30,6 +30,7 @@ import { AgentSetupNotice } from "./AgentSetupNotice";
 import { ConsentCard } from "./parts";
 import { buildLaunchCommand, launchAgentLabel, openInTerminal } from "./launch";
 import { type RunSummary, type ExecutionProfile } from "../../api/diagnose";
+import { routePath } from "../../api/config";
 
 function capWord(s: string): string {
   return s ? s[0].toUpperCase() + s.slice(1) : s;
@@ -66,7 +67,7 @@ function InvestigationMenu({ run }: { run: RunSummary }) {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const label = launchAgentLabel(run);
-  const command = buildLaunchCommand(run, `${window.location.origin}/mcp`);
+  const command = buildLaunchCommand(run, `${window.location.origin}${routePath('/mcp')}`);
   // No resumable session yet (or stale run) → nothing to hand off.
   if (!command) return null;
 

--- a/web/src/components/home/ClusterHealthCard.tsx
+++ b/web/src/components/home/ClusterHealthCard.tsx
@@ -10,11 +10,16 @@ import { clsx } from 'clsx'
 import { formatCPUMillicores, formatMemoryMiB } from '../../utils/format'
 import { useCapabilitiesContext } from '../../contexts/CapabilitiesContext'
 import { MCPSetupDialog } from './MCPSetupDialog'
-import { pluralize, parseContextName } from '@skyhook-io/k8s-ui'
+import { assetUrl, pluralize, parseContextName } from '@skyhook-io/k8s-ui'
 import { Tooltip } from '../ui/Tooltip'
+import { routePath } from '../../api/config'
 import gkeIcon from '../../assets/platform-icons/google_kubernetes_engine.png'
 import eksIcon from '../../assets/platform-icons/aws_eks.png'
 import aksIcon from '../../assets/platform-icons/azure-aks.svg'
+
+const gkeIconUrl = assetUrl(gkeIcon)
+const eksIconUrl = assetUrl(eksIcon)
+const aksIconUrl = assetUrl(aksIcon)
 
 interface ClusterHealthCardProps {
   health: DashboardResponse['health']
@@ -74,13 +79,13 @@ function MetricsUnavailableHint({ platform, metricsServerAvailable }: { platform
 function getPlatformInfo(platform: string): { name: string; icon: string | null } {
   const platformLower = platform.toLowerCase()
   if (platformLower.includes('gke') || platformLower.includes('google')) {
-    return { name: 'Google Kubernetes Engine', icon: gkeIcon }
+    return { name: 'Google Kubernetes Engine', icon: gkeIconUrl }
   }
   if (platformLower.includes('eks') || platformLower.includes('amazon') || platformLower.includes('aws')) {
-    return { name: 'Amazon EKS', icon: eksIcon }
+    return { name: 'Amazon EKS', icon: eksIconUrl }
   }
   if (platformLower.includes('aks') || platformLower.includes('azure')) {
-    return { name: 'Azure Kubernetes Service', icon: aksIcon }
+    return { name: 'Azure Kubernetes Service', icon: aksIconUrl }
   }
   if (platformLower.includes('openshift')) {
     return { name: 'OpenShift', icon: null }
@@ -138,7 +143,7 @@ export function ClusterHealthCard({
   const mcpEnabled = caps.mcpEnabled
   const isCloud = deployment.mode === 'cloud'
   const isInCluster = deployment.mode === 'in-cluster' || deployment.mode === 'cloud'
-  const mcpUrl = `${window.location.origin}/mcp`
+  const mcpUrl = `${window.location.origin}${routePath('/mcp')}`
   // In Cloud, MCP is org-wide and PAT-authed (api.radarhq.io/mcp). The OSS
   // "this binary is your local MCP server" framing is wrong there — Cloud
   // surfaces MCP from the hub Home dashboard instead.

--- a/web/src/components/nav/PrimaryNavRail.tsx
+++ b/web/src/components/nav/PrimaryNavRail.tsx
@@ -20,6 +20,9 @@ import {
 import { clsx } from "clsx";
 import type { MainView } from "../../types";
 import { Tooltip } from "../ui/Tooltip";
+import { assetUrl } from "@skyhook-io/k8s-ui";
+
+const radarLogoUrl = assetUrl("/images/radar/radar-icon.svg");
 
 // The views the rail can navigate to. Broader than k8s-ui's ExtendedMainView
 // (which omits 'applications') — it mirrors the navigable subset of App.tsx's
@@ -233,7 +236,7 @@ function BrandRow({
         <span className="flex w-14 shrink-0 items-center justify-center">
           <span className="relative w-7 h-7 rounded-lg overflow-hidden bg-emerald-500/10 border border-emerald-500/20">
             <img
-              src="/images/radar/radar-icon.svg"
+              src={radarLogoUrl}
               alt=""
               aria-hidden
               className="w-full h-full p-0.5"

--- a/web/src/components/resources/ImageFilesystemModal.tsx
+++ b/web/src/components/resources/ImageFilesystemModal.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useMemo, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { X, Folder, File, Link2, ChevronRight, ChevronDown, AlertTriangle, Loader2, Search, Download, HardDrive, Shield, ShieldCheck, Terminal, Copy, Check, RefreshCw } from 'lucide-react'
 import radarLoadingIcon from '@skyhook-io/k8s-ui/assets/radar/radar-icon-loading.svg'
+import { assetUrl } from '@skyhook-io/k8s-ui'
 import { clsx } from 'clsx'
 import { useImageMetadata, ApiError } from '../../api/client'
 import type { FileNode, ImageFilesystem } from '../../types'
@@ -10,6 +11,8 @@ import { downloadBlob, filterTree } from './file-browser-utils'
 import { Tooltip } from '../ui/Tooltip'
 import { apiUrl, getAuthHeaders, getCredentialsMode } from '../../api/config'
 import { Input } from '@skyhook-io/k8s-ui'
+
+const radarLoadingIconUrl = assetUrl(radarLoadingIcon)
 
 // Manual fetch function for filesystem (not a hook - gives us full control)
 async function fetchImageFilesystem(
@@ -182,7 +185,7 @@ export function ImageFilesystemModal({
           {/* Loading state */}
           {isLoading && (
             <div className="flex flex-col items-center justify-center gap-3 h-64">
-              <img src={radarLoadingIcon} alt="" aria-hidden className="w-11 h-11" />
+              <img src={radarLoadingIconUrl} alt="" aria-hidden className="w-11 h-11" />
               <span className="text-sm text-theme-text-secondary">
                 {isLoadingMetadata ? 'Checking image…' : 'Downloading image layers…'}
               </span>

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -9,7 +9,7 @@ import {
 import { clsx } from 'clsx'
 import { useAnimatedUnmount } from '../../hooks/useAnimatedUnmount'
 import { TRANSITION_BACKDROP, TRANSITION_PANEL } from '../../utils/animation'
-import { apiUrl, getAuthHeaders, getCredentialsMode } from '../../api/config'
+import { apiUrl, getAuthHeaders, getCredentialsMode, routePath } from '../../api/config'
 import {
   useCloudRole, useVersionCheck, useClusterInfo, usePrometheusStatus, useArgoStatus,
 } from '../../api/client'
@@ -1119,7 +1119,7 @@ function MCPSection({
   const [copied, setCopied] = useState(false)
 
   const currentPort = Number(window.location.port) || 80
-  const mcpUrl = `http://localhost:${currentPort}/mcp`
+  const mcpUrl = `http://localhost:${currentPort}${routePath('/mcp')}`
 
   const handleCopy = () => {
     navigator.clipboard.writeText(mcpUrl)

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -20,9 +20,9 @@ import { AISettingsSection, type AIDraft } from '../diagnose/AISettings'
 import { MyPermissionsContent } from './MyPermissionsDialog'
 import { useDiagnose } from '../diagnose/DiagnoseContext'
 
-// The loopback URL an MCP client is told to connect to. Both the overview row
-// and the MCP section show it, and they must not drift — one of them missed the
-// base path and advertised a URL that 404s under a subpath deployment.
+// The loopback URL an MCP client is told to connect to. Shared by the overview
+// row and the MCP section: both must carry the base path, or the URL they
+// advertise 404s under a subpath deployment.
 function mcpLoopbackUrl(): string {
   const port = Number(window.location.port) || 80
   return `http://localhost:${port}${routePath('/mcp')}`

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -20,6 +20,14 @@ import { AISettingsSection, type AIDraft } from '../diagnose/AISettings'
 import { MyPermissionsContent } from './MyPermissionsDialog'
 import { useDiagnose } from '../diagnose/DiagnoseContext'
 
+// The loopback URL an MCP client is told to connect to. Both the overview row
+// and the MCP section show it, and they must not drift — one of them missed the
+// base path and advertised a URL that 404s under a subpath deployment.
+function mcpLoopbackUrl(): string {
+  const port = Number(window.location.port) || 80
+  return `http://localhost:${port}${routePath('/mcp')}`
+}
+
 interface Config {
   kubeconfig?: string
   kubeconfigDirs?: string[]
@@ -842,8 +850,7 @@ function OverviewPanel({ active, onNavigate }: { active: boolean; onNavigate: (s
   const agentLabel =
     diag.agents.find((a) => a.name === diag.selectedAgent)?.label ?? diag.agents[0]?.label
   const mcpOn = capabilities.mcpEnabled
-  const port = Number(window.location.port) || 80
-  const mcpUrl = `http://localhost:${port}/mcp`
+  const mcpUrl = mcpLoopbackUrl()
 
   const rows: OverviewRow[] = [
     {
@@ -1119,7 +1126,7 @@ function MCPSection({
   const [copied, setCopied] = useState(false)
 
   const currentPort = Number(window.location.port) || 80
-  const mcpUrl = `http://localhost:${currentPort}${routePath('/mcp')}`
+  const mcpUrl = mcpLoopbackUrl()
 
   const handleCopy = () => {
     navigator.clipboard.writeText(mcpUrl)

--- a/web/src/components/traffic/TrafficWizard.tsx
+++ b/web/src/components/traffic/TrafficWizard.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from 'react'
 import type { TrafficSourcesResponse, TrafficWizardState } from '../../types'
 import { CheckCircle2, XCircle, AlertTriangle, Copy, ExternalLink, ArrowRight, ArrowLeft, Package } from 'lucide-react'
-import { PaneLoader } from '@skyhook-io/k8s-ui'
+import { assetUrl, PaneLoader } from '@skyhook-io/k8s-ui'
 import radarLoadingIcon from '@skyhook-io/k8s-ui/assets/radar/radar-icon-loading.svg'
 import { InstallWizard } from '../helm/InstallWizard'
+
+const radarLoadingIconUrl = assetUrl(radarLoadingIcon)
 
 interface TrafficWizardProps {
   state: TrafficWizardState
@@ -100,7 +102,7 @@ export function TrafficWizard({
         <div className="flex items-center justify-center h-full w-full">
           <div className="max-w-md w-full p-6 space-y-6">
             <div className="flex flex-col items-center gap-3">
-              <img src={radarLoadingIcon} alt="" aria-hidden className="h-11 w-11" />
+              <img src={radarLoadingIconUrl} alt="" aria-hidden className="h-11 w-11" />
               <h2 className="text-lg font-medium text-theme-text-primary">Waiting for traffic source…</h2>
               <p className="text-sm text-theme-text-secondary">
                 Checking for availability

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -153,8 +153,14 @@ window.addEventListener('mouseup', (e: MouseEvent) => {
 // tab, so it opts into per-view document.title. Library consumers (e.g.
 // radar-hub-web) render <RadarApp apiBase="..." basename="..." /> WITHOUT this
 // flag, keeping their own tab title.
+const runtimeConfig = window.__RADAR_RUNTIME_CONFIG__
+
 ReactDOM.createRoot(document.getElementById('radar')!).render(
   <React.StrictMode>
-    <RadarApp manageDocumentTitle />
+    <RadarApp
+      apiBase={runtimeConfig?.apiBase}
+      basename={runtimeConfig?.basePath}
+      manageDocumentTitle
+    />
   </React.StrictMode>
 )

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface Window {
+  __RADAR_RUNTIME_CONFIG__?: {
+    basePath?: string
+    apiBase?: string
+    assetBase?: string
+  }
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -4,6 +4,7 @@ import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
 
 export default defineConfig({
+  base: './',
   plugins: [tailwindcss(), react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Radar can be served under a URL prefix, so it can share a hostname with other apps behind an ingress that forwards a subpath without rewriting it — `https://tools.example.com/radar/` rather than needing its own host or a strip-prefix rule. Operators set `--base-path` on the binary or `basePath` in the chart; everything the browser and external systems touch resolves under that prefix. Root deployments are unaffected.

Closes #657.

## What changed

**Serving.** The app router mounts under the normalized prefix, and the prefix is **stripped at that mount boundary** so everything inside — handlers and middleware alike — sees root-relative paths exactly as it does at the root. This is the load-bearing decision and the thing to review most closely: chi's `Mount` shifts only the routing context's `RoutePath` and leaves `r.URL.Path` prefixed, while the auth middleware matches on `r.URL.Path` and treats anything outside `/api`, `/mcp` and `/debug` as public static content. The prefix therefore has to be gone before any of that runs, and translating once at the edge keeps the concern out of every absolute-path check inside. `TestBasePathDoesNotBypassAuth` holds the line across `""`, `/radar` and `/tools/radar`.

**Frontend handoff.** `index.html` is rewritten as it is served: a runtime config (`basePath`, `apiBase`, `assetBase`) is injected ahead of the module script, and `href`/`src` URLs that address this origin are re-rooted under the prefix while other origins are left alone. The app consumes that through the existing `RadarApp` `apiBase` / `basename` props, so there is no new user setting and no change to the `@skyhook-io/radar-app` surface. `assetUrl` becomes base-aware for assets referenced from JavaScript chunks; the ELK layout worker recovers the base from its own script URL, since a worker never sees the injected config.

**Anything that hands out a URL carries the prefix** — the OIDC post-login redirect, logout, the MCP endpoint shown in Settings and the setup dialog, the AI hand-off command, and `radar diagnose`'s discovery of a local instance (the port file gained an optional second line for the base path and still reads older port-only files).

**Validation, as early as possible.** The flag normalizes the value and accepts only unreserved RFC 3986 path characters — which is also what rules out the scheme-relative forms (`//host`, `/\host`) that would otherwise turn Radar's own redirects off-origin. The chart's schema accepts exactly the same set, and the chart fails at template time when `basePath` is combined with Radar Cloud (the Hub owns the URL path there) or when an OIDC redirect / post-logout URL sits outside the prefix. Each of those is a mistake whose only other symptom is a crash-looping pod or a login that fails long after `helm install` reported success.

**One diagnosable failure mode.** Pointing a *stripping* ingress at a Radar that also serves under the prefix produces nothing but a browser redirect loop, so a request arriving at the origin root logs a one-time line naming both the cause and the two fixes. It stays silent when the configuration is right.

## Operational notes

Radar serves the app **only** under the prefix; unprefixed paths 404. External health checks or metrics scrapers pointed at `/api/health` or `/metrics` need updating when adopting a base path — the chart's own probes follow `basePath` automatically.

URLs registered with an identity provider must include the prefix (`{basePath}/auth/callback`, the post-logout URL, and the back-channel logout URI). The chart now rejects the first two at install time; the docs cover all three.

Two Radar instances under different prefixes on one hostname share cookies and `localStorage`, which are scoped per origin rather than per path. Give each its own hostname if they need to be independent.

## Testing

Unit and type checks: `go test ./...` for both modules, `make tsc`, the web and k8s-ui suites, `make build`, `helm lint`. Named coverage added for auth not being bypassed under any prefix, redirects never emitting a scheme-relative `Location` or smuggling CR/LF, same-origin-only asset rewriting, the `assetUrl` matrix (root, prefixed, worker scope), the OIDC handler's base path, and local-instance discovery including the older port-file format.

Verified against a real cluster — kind with ingress-nginx, chart installed with `basePath: /radar` and the ingress routing that subpath:

- kubelet liveness and readiness probes at `{basePath}/api/health` pass; pod Ready with no restarts and no `Unhealthy` events
- the UI, its assets, deep client routes and the API all serve through the ingress; a browser session across the views produced 59 requests, all 200, with no console errors
- unprefixed paths (`/`, `/api/health`, `/assets/…`) 404 at the ingress, confirming only the prefix reaches Radar
- WebSocket pod exec upgrades through the ingress (`101 Switching Protocols`)

Verified against a real identity provider — Dex behind a proxy that routes only the subpath, so the origin root is genuinely not Radar:

- a full authorization-code login (redirect, credential post, callback, token exchange, JWKS verification) completes and lands inside the app
- the session is established, authenticated requests succeed and unauthenticated ones are rejected
- no request anywhere in the flow addressed a path outside the prefix

Also exercised: `radar diagnose` attaching to a prefixed instance and its agent reaching the prefixed MCP mount; `--dev` filesystem serving under a prefix; traversal and encoding probes (`..`, `..%2f`, `//`, `%2f`, case variants) finding no way past auth; and a root-serving control run confirming unchanged behavior with no runtime config injected.

No screenshots: this changes URL and static-serving behavior, not layout or rendering. The in-cluster browser pass above stood in for a visual check.

## Follow-ups

Session cookies are still issued at `Path=/`; scoping them to the prefix is a self-contained change to issuance and clearing that wants its own review. Honoring `X-Forwarded-Prefix` would make the prefix zero-config for ingresses that send it, and would also remove the mismatch between `basePath` and the ingress path as a possible mistake. Both are tracked separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches HTTP routing, auth path matching, OIDC redirects, and static/index rewriting—areas where misconfiguration or prefix handling bugs could expose routes or break login; mitigated by explicit validation, Helm install-time checks, and auth-bypass tests.
> 
> **Overview**
> Adds **`--base-path`** (CLI) and Helm **`basePath`** so Radar can live behind ingress that forwards a subpath **without** stripping it (e.g. `https://host/radar/`). Root serving is unchanged when the value is empty.
> 
> **HTTP routing.** The app mounts under the normalized prefix; the prefix is **stripped once at the mount boundary** so handlers and auth middleware still see root-relative paths—avoiding a class of auth bypass where prefixed `/api` or `/debug` would otherwise look like “static” routes. Unprefixed paths 404 when a prefix is set; `/` redirects into the prefix (with a one-time log hint if a strip-prefix ingress causes redirect loops). **`NormalizeBasePath`** rejects unsafe paths (dots, encoding, scheme-relative forms).
> 
> **Frontend.** Served **`index.html`** injects `window.__RADAR_RUNTIME_CONFIG__` and rewrites same-origin asset URLs; standalone boot passes **`apiBase`** / **`basename`** into `RadarApp`. **`assetUrl`** and UI call sites use **`routePath`** / **`apiUrl`** for auth, MCP links, and static assets (including workers).
> 
> **Integrations.** OIDC post-login redirect targets **`{basePath}/`**. MCP discovery (`~/.radar/mcp-port` optional second line), browser open URL, startup log URL, probes, and AI/MCP loopback URLs include the prefix. **`--base-path`** is refused with Radar Cloud (`--cloud-url` / `RADAR_CLOUD_MODE`).
> 
> **Helm/docs.** Chart passes `--base-path`, adjusts probe paths, fails render on `basePath` + cloud or OIDC URLs outside the prefix; values schema matches server validation. Docs cover subpath ingress and IdP callback URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 408f46ae9d0fe591b20720eec1a7a4fea47141ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->