### PR TITLE
feat(nav): namespace filter → cluster scope zone + view-aware (SKY-1070)

### DIFF
--- a/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
+++ b/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
@@ -238,7 +238,7 @@ export const ClusterSwitcher = forwardRef<ClusterSwitcherHandle, ClusterSwitcher
             <ClusterName
               name={currentName}
               fallbackBadge={<Server className="w-3.5 h-3.5 text-theme-text-secondary" />}
-              className={variant === 'segment' ? 'flex-1 min-w-0' : TRIGGER_NAME_MAX_WIDTH}
+              className={variant === 'segment' ? 'min-w-0' : TRIGGER_NAME_MAX_WIDTH}
               noTooltip={isOpen}
             />
             {currentSourceLabel && (
@@ -258,7 +258,7 @@ export const ClusterSwitcher = forwardRef<ClusterSwitcherHandle, ClusterSwitcher
             )}
           </>
         )}
-        <ChevronDown className={`w-3 h-3 ml-auto shrink-0 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+        <ChevronDown className={`w-3 h-3 shrink-0 transition-transform ${variant === 'segment' ? '' : 'ml-auto'} ${isOpen ? 'rotate-180' : ''}`} />
       </button>
 
       {isOpen && (

--- a/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
+++ b/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
@@ -58,6 +58,15 @@ export interface ClusterSwitcherProps {
   errorSlot?: ReactNode
   className?: string
   align?: 'left' | 'right'
+  /**
+   * 'chip' (default) renders a self-contained bordered pill. 'segment' renders
+   * a borderless label+value cell for embedding in a shared bordered container
+   * (the unified cluster+namespace scope control) — no border/background/min-w
+   * of its own, with an optional muted {@link label} before the value.
+   */
+  variant?: 'chip' | 'segment'
+  /** Muted label shown before the value in the 'segment' variant (e.g. "Cluster"). */
+  label?: string
 }
 
 // Trigger width cap. With middle-truncation kicking in, this is a
@@ -83,6 +92,8 @@ export const ClusterSwitcher = forwardRef<ClusterSwitcherHandle, ClusterSwitcher
   errorSlot,
   className = '',
   align = 'left',
+  variant = 'chip',
+  label,
 }, ref) => {
   const [isOpen, setIsOpen] = useState(false)
   const [search, setSearch] = useState('')
@@ -195,14 +206,21 @@ export const ClusterSwitcher = forwardRef<ClusterSwitcherHandle, ClusterSwitcher
         type="button"
         onClick={() => setIsOpen(v => !v)}
         disabled={disabled || loading}
-        className={`
-          flex items-center gap-1.5 px-2.5 py-1.5 min-w-[140px]
-          bg-theme-elevated border border-theme-border rounded text-sm font-medium
-          text-theme-text-primary hover:bg-theme-hover hover:border-theme-border-light
-          transition-colors cursor-pointer
-          disabled:opacity-50 disabled:cursor-not-allowed
-        `}
+        className={
+          variant === 'segment'
+            ? `flex items-center gap-1.5 px-3 py-1.5 h-full min-w-[150px] max-w-[240px] text-sm font-medium
+               text-theme-text-primary hover:bg-theme-hover transition-colors cursor-pointer
+               disabled:opacity-50 disabled:cursor-not-allowed`
+            : `flex items-center gap-1.5 px-2.5 py-1.5 min-w-[140px]
+               bg-theme-elevated border border-theme-border rounded text-sm font-medium
+               text-theme-text-primary hover:bg-theme-hover hover:border-theme-border-light
+               transition-colors cursor-pointer
+               disabled:opacity-50 disabled:cursor-not-allowed`
+        }
       >
+        {label && (
+          <span className="shrink-0 font-normal text-theme-text-tertiary">{label}</span>
+        )}
         {loading ? (
           <>
             <Loader2 className="w-3.5 h-3.5 animate-spin" />
@@ -220,7 +238,7 @@ export const ClusterSwitcher = forwardRef<ClusterSwitcherHandle, ClusterSwitcher
             <ClusterName
               name={currentName}
               fallbackBadge={<Server className="w-3.5 h-3.5 text-theme-text-secondary" />}
-              className={TRIGGER_NAME_MAX_WIDTH}
+              className={variant === 'segment' ? 'flex-1 min-w-0' : TRIGGER_NAME_MAX_WIDTH}
               noTooltip={isOpen}
             />
             {currentSourceLabel && (
@@ -240,7 +258,7 @@ export const ClusterSwitcher = forwardRef<ClusterSwitcherHandle, ClusterSwitcher
             )}
           </>
         )}
-        <ChevronDown className={`w-3 h-3 ml-auto transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+        <ChevronDown className={`w-3 h-3 ml-auto shrink-0 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
       </button>
 
       {isOpen && (

--- a/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
+++ b/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
@@ -238,7 +238,7 @@ export const ClusterSwitcher = forwardRef<ClusterSwitcherHandle, ClusterSwitcher
             <ClusterName
               name={currentName}
               fallbackBadge={<Server className="w-3.5 h-3.5 text-theme-text-secondary" />}
-              className={variant === 'segment' ? 'min-w-0' : TRIGGER_NAME_MAX_WIDTH}
+              className={variant === 'segment' ? 'min-w-0 max-w-[168px]' : TRIGGER_NAME_MAX_WIDTH}
               noTooltip={isOpen}
             />
             {currentSourceLabel && (

--- a/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
+++ b/packages/k8s-ui/src/components/cluster-switcher/ClusterSwitcher.tsx
@@ -208,7 +208,7 @@ export const ClusterSwitcher = forwardRef<ClusterSwitcherHandle, ClusterSwitcher
         disabled={disabled || loading}
         className={
           variant === 'segment'
-            ? `flex items-center gap-1.5 px-3 py-1.5 h-full min-w-[150px] max-w-[240px] text-sm font-medium
+            ? `flex items-center gap-1.5 px-3 py-1.5 h-full min-w-[150px] max-w-[264px] text-[13px] font-medium
                text-theme-text-primary hover:bg-theme-hover transition-colors cursor-pointer
                disabled:opacity-50 disabled:cursor-not-allowed`
             : `flex items-center gap-1.5 px-2.5 py-1.5 min-w-[140px]
@@ -238,7 +238,7 @@ export const ClusterSwitcher = forwardRef<ClusterSwitcherHandle, ClusterSwitcher
             <ClusterName
               name={currentName}
               fallbackBadge={<Server className="w-3.5 h-3.5 text-theme-text-secondary" />}
-              className={variant === 'segment' ? 'min-w-0 max-w-[168px]' : TRIGGER_NAME_MAX_WIDTH}
+              className={variant === 'segment' ? 'min-w-0 max-w-[214px]' : TRIGGER_NAME_MAX_WIDTH}
               noTooltip={isOpen}
             />
             {currentSourceLabel && (

--- a/packages/k8s-ui/src/components/namespace-switcher/NamespacePicker.tsx
+++ b/packages/k8s-ui/src/components/namespace-switcher/NamespacePicker.tsx
@@ -246,7 +246,7 @@ export const NamespacePicker = forwardRef<NamespacePickerHandle, NamespacePicker
           ) : restrictedHint ? (
             <AlertTriangle className="w-3.5 h-3.5 shrink-0 text-theme-text-tertiary" />
           ) : null}
-          <span className={`font-medium truncate ${variant === 'segment' ? 'flex-1 min-w-0' : 'max-w-[180px]'}`}>
+          <span className={`font-medium truncate ${variant === 'segment' ? 'min-w-0' : 'max-w-[180px]'}`}>
             {pending ? 'Switching…' : triggerLabel}
           </span>
           <ChevronDown className="w-3 h-3 shrink-0 opacity-60" />

--- a/packages/k8s-ui/src/components/namespace-switcher/NamespacePicker.tsx
+++ b/packages/k8s-ui/src/components/namespace-switcher/NamespacePicker.tsx
@@ -44,6 +44,15 @@ export interface NamespacePickerProps {
   disabled?: boolean
   disabledTooltip?: string
   className?: string
+  /**
+   * 'chip' (default) renders a self-contained pill. 'segment' renders a
+   * borderless label+value cell for embedding in a shared bordered container
+   * (the unified cluster+namespace scope control), with an optional muted
+   * {@link label} before the value and a shorter value ("All" vs "All namespaces").
+   */
+  variant?: 'chip' | 'segment'
+  /** Muted label shown before the value in the 'segment' variant (e.g. "Namespace"). */
+  label?: string
 }
 
 /**
@@ -66,7 +75,7 @@ export interface NamespacePickerProps {
  * onApply. "Clear all" applies immediately and closes.
  */
 export const NamespacePicker = forwardRef<NamespacePickerHandle, NamespacePickerProps>(function NamespacePicker(
-  { scope, onApply, loading = false, pending = false, disabled = false, disabledTooltip, className = '' },
+  { scope, onApply, loading = false, pending = false, disabled = false, disabledTooltip, className = '', variant = 'chip', label },
   ref,
 ) {
   const [isOpen, setIsOpen] = useState(false)
@@ -181,8 +190,12 @@ export const NamespacePicker = forwardRef<NamespacePickerHandle, NamespacePicker
   }
 
   const activeCount = scopeActives.length
+  // In segment mode the "Namespace" label already carries the noun, so the
+  // cluster-wide value collapses "All namespaces" → "All".
   const triggerLabel =
-    activeCount === 0 ? 'All namespaces' : activeCount === 1 ? scopeActives[0] : `${activeCount} namespaces`
+    activeCount === 0
+      ? variant === 'segment' ? 'All' : 'All namespaces'
+      : activeCount === 1 ? scopeActives[0] : `${activeCount} namespaces`
   const isClusterWide = activeCount === 0
   const restrictedHint = scope.mode === 'restricted'
   const cacheScopeLocked = scope.cacheScoped && !scope.namespaceRescope
@@ -218,18 +231,25 @@ export const NamespacePicker = forwardRef<NamespacePickerHandle, NamespacePicker
           ref={triggerRef}
           onClick={() => !isDisabled && (isOpen ? closeAndApply() : setIsOpen(true))}
           disabled={isDisabled}
-          className={`flex items-center gap-1.5 px-2 py-1 rounded text-sm bg-theme-elevated hover:bg-theme-hover text-theme-text-primary disabled:opacity-60 transition-colors ${className}`}
+          className={
+            variant === 'segment'
+              ? `flex items-center gap-1.5 px-3 py-1.5 h-full min-w-[110px] max-w-[170px] text-sm text-theme-text-primary hover:bg-theme-hover disabled:opacity-60 transition-colors ${className}`
+              : `flex items-center gap-1.5 px-2 py-1 rounded text-sm bg-theme-elevated hover:bg-theme-hover text-theme-text-primary disabled:opacity-60 transition-colors ${className}`
+          }
           aria-label="Switch active namespaces"
         >
+          {label && (
+            <span className="shrink-0 font-normal text-theme-text-tertiary">{label}</span>
+          )}
           {isClusterWide ? (
-            <Globe className="w-3.5 h-3.5 text-theme-text-tertiary" />
+            <Globe className="w-3.5 h-3.5 shrink-0 text-theme-text-tertiary" />
           ) : restrictedHint ? (
-            <AlertTriangle className="w-3.5 h-3.5 text-theme-text-tertiary" />
+            <AlertTriangle className="w-3.5 h-3.5 shrink-0 text-theme-text-tertiary" />
           ) : null}
-          <span className="font-medium max-w-[180px] truncate">
+          <span className={`font-medium truncate ${variant === 'segment' ? 'flex-1 min-w-0' : 'max-w-[180px]'}`}>
             {pending ? 'Switching…' : triggerLabel}
           </span>
-          <ChevronDown className="w-3 h-3 opacity-60" />
+          <ChevronDown className="w-3 h-3 shrink-0 opacity-60" />
         </button>
       </Tooltip>
 

--- a/packages/k8s-ui/src/components/namespace-switcher/NamespacePicker.tsx
+++ b/packages/k8s-ui/src/components/namespace-switcher/NamespacePicker.tsx
@@ -95,6 +95,18 @@ export const NamespacePicker = forwardRef<NamespacePickerHandle, NamespacePicker
     setDraft(new Set(scopeActives))
   }, [activesKey, scopeActives])
 
+  // Fully disable when the host disables the control (e.g. view-awareness
+  // navigating to a cluster-scoped surface): the trigger is inert and open()
+  // is blocked, but an already-open dropdown would still commit via Done /
+  // outside-click / Clear all — so close it (discarding the uncommitted draft)
+  // rather than letting a dead view apply a namespace change.
+  useEffect(() => {
+    if (disabled && isOpen) {
+      setIsOpen(false)
+      setSearch('')
+    }
+  }, [disabled, isOpen])
+
   const items = useMemo(() => {
     if (!scope) return [] as string[]
     return [...(scope.accessibleNamespaces ?? [])].sort((a, b) => a.localeCompare(b))

--- a/packages/k8s-ui/src/components/namespace-switcher/NamespacePicker.tsx
+++ b/packages/k8s-ui/src/components/namespace-switcher/NamespacePicker.tsx
@@ -190,12 +190,8 @@ export const NamespacePicker = forwardRef<NamespacePickerHandle, NamespacePicker
   }
 
   const activeCount = scopeActives.length
-  // In segment mode the "Namespace" label already carries the noun, so the
-  // cluster-wide value collapses "All namespaces" → "All".
   const triggerLabel =
-    activeCount === 0
-      ? variant === 'segment' ? 'All' : 'All namespaces'
-      : activeCount === 1 ? scopeActives[0] : `${activeCount} namespaces`
+    activeCount === 0 ? 'All namespaces' : activeCount === 1 ? scopeActives[0] : `${activeCount} namespaces`
   const isClusterWide = activeCount === 0
   const restrictedHint = scope.mode === 'restricted'
   const cacheScopeLocked = scope.cacheScoped && !scope.namespaceRescope

--- a/packages/k8s-ui/src/components/namespace-switcher/NamespacePicker.tsx
+++ b/packages/k8s-ui/src/components/namespace-switcher/NamespacePicker.tsx
@@ -104,8 +104,11 @@ export const NamespacePicker = forwardRef<NamespacePickerHandle, NamespacePicker
     if (disabled && isOpen) {
       setIsOpen(false)
       setSearch('')
+      // Discard the uncommitted draft so a later re-open reflects the current
+      // server actives, not stale toggles from before the control was disabled.
+      setDraft(new Set(scopeActives))
     }
-  }, [disabled, isOpen])
+  }, [disabled, isOpen, scopeActives])
 
   const items = useMemo(() => {
     if (!scope) return [] as string[]

--- a/packages/k8s-ui/src/components/namespace-switcher/NamespacePicker.tsx
+++ b/packages/k8s-ui/src/components/namespace-switcher/NamespacePicker.tsx
@@ -1,0 +1,350 @@
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { ChevronDown, Globe, Search, AlertTriangle, X } from 'lucide-react'
+import { Tooltip } from '../ui/Tooltip'
+
+/**
+ * Backend-reported namespace scope. Mirrors Radar's `/cluster/namespace-scope`
+ * response shape; the host supplies it however it fetches it (OSS via its API
+ * hooks, Radar Hub via the per-cluster apiBase).
+ */
+export interface NamespaceScopeView {
+  /** Currently-selected namespaces. Empty = cluster-wide ("All namespaces"). */
+  actives: string[]
+  /** Namespaces the user may pick from. */
+  accessibleNamespaces: string[]
+  mode?: 'cluster-wide' | 'namespace' | 'restricted' | string
+  /** Single-namespace cache-scope control instead of a multi-select filter. */
+  cacheScoped?: boolean
+  /** Under cacheScoped, whether the user may re-point the watched namespace. */
+  namespaceRescope?: boolean
+  cacheScopeNamespace?: string
+  kubeconfigNamespace?: string
+  canClearNamespace?: boolean
+  /** false when accessibleNamespaces is a best-effort short list (no list perm). */
+  authoritative?: boolean
+}
+
+export interface NamespacePickerHandle {
+  open: () => void
+}
+
+export interface NamespacePickerProps {
+  /** null/undefined while loading — the picker renders nothing until it arrives. */
+  scope: NamespaceScopeView | null | undefined
+  /**
+   * Applied when the selection is committed (dropdown close / clear all).
+   * The picker only calls this when the selection actually changed and is
+   * valid (respects the cacheScoped single-namespace constraint).
+   */
+  onApply: (namespaces: string[]) => void
+  loading?: boolean
+  /** A switch/mutation is in flight — trigger shows "Switching…" and is inert. */
+  pending?: boolean
+  disabled?: boolean
+  disabledTooltip?: string
+  className?: string
+}
+
+/**
+ * NamespacePicker is the presentational namespace scope control shared by
+ * Radar OSS and Radar Hub (mirrors the ClusterSwitcher pattern — pure UI, data
+ * injected via props). It is normally a per-user multi-select view filter. When
+ * the scope reports cacheScoped=true, it becomes a single-namespace cache scope
+ * control.
+ *
+ * Three states reflect what the scope reports:
+ *   - cluster-wide: empty trigger label "All namespaces"; picker lets the user
+ *     narrow the view.
+ *   - namespace:    label shows the namespace count (or single name); picker
+ *     offers other accessible namespaces and a clear-all reset.
+ *   - restricted:   user can't list namespaces and isn't pinned; picker
+ *     surfaces only the kubeconfig context's namespace + any saved picks.
+ *
+ * Selection model: the dropdown keeps a draft Set<string>; toggling rows
+ * mutates the draft locally; closing the dropdown applies the draft in a single
+ * onApply. "Clear all" applies immediately and closes.
+ */
+export const NamespacePicker = forwardRef<NamespacePickerHandle, NamespacePickerProps>(function NamespacePicker(
+  { scope, onApply, loading = false, pending = false, disabled = false, disabledTooltip, className = '' },
+  ref,
+) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [search, setSearch] = useState('')
+  const [pos, setPos] = useState({ top: 0, left: 0, width: 0 })
+  const [draft, setDraft] = useState<Set<string>>(() => new Set())
+
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  const scopeActives = useMemo(() => scope?.actives ?? [], [scope?.actives])
+  const activesKey = useMemo(() => [...scopeActives].sort().join(','), [scopeActives])
+
+  // Sync the draft with the server's view whenever it changes (initial load,
+  // post-mutation refetch, eviction after RBAC drift).
+  useEffect(() => {
+    setDraft(new Set(scopeActives))
+  }, [activesKey, scopeActives])
+
+  const items = useMemo(() => {
+    if (!scope) return [] as string[]
+    return [...(scope.accessibleNamespaces ?? [])].sort((a, b) => a.localeCompare(b))
+  }, [scope])
+
+  const filteredItems = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return items
+    return items.filter(n => n.toLowerCase().includes(q))
+  }, [items, search])
+
+  const applySelection = useCallback((next: Set<string>) => {
+    if (!scope) return
+    const nextArr = Array.from(next).sort()
+    if (scope.cacheScoped && nextArr.length !== 1) return
+    if (nextArr.join(',') === activesKey) return
+    onApply(nextArr)
+  }, [activesKey, scope, onApply])
+
+  const closeAndApply = useCallback(() => {
+    setIsOpen(false)
+    setSearch('')
+    applySelection(draft)
+  }, [applySelection, draft])
+
+  useImperativeHandle(ref, () => ({
+    open: () => {
+      if (disabled || loading || pending) return
+      setIsOpen(true)
+    },
+  }), [disabled, loading, pending])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const trigger = triggerRef.current
+    if (!trigger) return
+    const r = trigger.getBoundingClientRect()
+    setPos({ top: r.bottom + 4, left: r.left, width: Math.max(r.width, 240) })
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!isOpen) return
+    function onClick(e: MouseEvent) {
+      if (
+        !dropdownRef.current?.contains(e.target as Node) &&
+        !triggerRef.current?.contains(e.target as Node)
+      ) {
+        closeAndApply()
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') closeAndApply()
+    }
+    document.addEventListener('mousedown', onClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [isOpen, closeAndApply])
+
+  if (!scope) return null
+
+  const toggle = (ns: string) => {
+    if (scope.cacheScoped) {
+      setDraft(new Set([ns]))
+      return
+    }
+    const next = new Set(draft)
+    if (next.has(ns)) next.delete(ns)
+    else next.add(ns)
+    setDraft(next)
+  }
+
+  const clearAll = () => {
+    if (scope.cacheScoped) return
+    setDraft(new Set())
+    setIsOpen(false)
+    setSearch('')
+    applySelection(new Set())
+  }
+
+  const selectAllVisible = () => {
+    const next = new Set(draft)
+    for (const ns of filteredItems) next.add(ns)
+    setDraft(next)
+  }
+
+  const clearVisible = () => {
+    const next = new Set(draft)
+    for (const ns of filteredItems) next.delete(ns)
+    setDraft(next)
+  }
+
+  const activeCount = scopeActives.length
+  const triggerLabel =
+    activeCount === 0 ? 'All namespaces' : activeCount === 1 ? scopeActives[0] : `${activeCount} namespaces`
+  const isClusterWide = activeCount === 0
+  const restrictedHint = scope.mode === 'restricted'
+  const cacheScopeLocked = scope.cacheScoped && !scope.namespaceRescope
+  const isDisabled = disabled || loading || pending || cacheScopeLocked
+  const canClearAll = scope.canClearNamespace || activeCount === 0
+  const tooltipContent = disabled && disabledTooltip
+    ? disabledTooltip
+    : scope.cacheScoped
+      ? scope.namespaceRescope
+        ? `Radar is watching only ${scope.cacheScopeNamespace || triggerLabel} to stay fast on large clusters. Pick another namespace to re-point it (takes a moment; closes open terminals).`
+        : `Radar is watching only ${scope.cacheScopeNamespace || triggerLabel} on this cluster.`
+      : restrictedHint
+      ? 'Limited namespace visibility — only namespaces granted by your RBAC are shown.'
+      : isClusterWide
+        ? 'Currently viewing all namespaces. Click to narrow the view.'
+        : activeCount === 1
+          ? `View is filtered to namespace ${scopeActives[0]}. Click to switch or reset.`
+          : `View is filtered to ${activeCount} namespaces. Click to adjust or reset.`
+
+  // Counts used to label the bulk-action buttons; computed against the visible
+  // (filtered) set so the labels match what the action will affect.
+  const visibleSelectedCount = filteredItems.reduce((n, ns) => n + (draft.has(ns) ? 1 : 0), 0)
+  const allVisibleSelected = filteredItems.length > 0 && visibleSelectedCount === filteredItems.length
+
+  return (
+    <>
+      <Tooltip
+        content={tooltipContent}
+        delay={300}
+        position="bottom"
+      >
+        <button
+          ref={triggerRef}
+          onClick={() => !isDisabled && (isOpen ? closeAndApply() : setIsOpen(true))}
+          disabled={isDisabled}
+          className={`flex items-center gap-1.5 px-2 py-1 rounded text-sm bg-theme-elevated hover:bg-theme-hover text-theme-text-primary disabled:opacity-60 transition-colors ${className}`}
+          aria-label="Switch active namespaces"
+        >
+          {isClusterWide ? (
+            <Globe className="w-3.5 h-3.5 text-theme-text-tertiary" />
+          ) : restrictedHint ? (
+            <AlertTriangle className="w-3.5 h-3.5 text-theme-text-tertiary" />
+          ) : null}
+          <span className="font-medium max-w-[180px] truncate">
+            {pending ? 'Switching…' : triggerLabel}
+          </span>
+          <ChevronDown className="w-3 h-3 opacity-60" />
+        </button>
+      </Tooltip>
+
+      {isOpen &&
+        createPortal(
+          <div
+            ref={dropdownRef}
+            style={{ position: 'fixed', top: pos.top, left: pos.left, minWidth: pos.width, zIndex: 100 }}
+            className="bg-theme-surface border border-theme-border rounded-md shadow-theme-lg overflow-hidden"
+          >
+            {items.length > 6 && (
+              <div className="flex items-center gap-2 px-2 py-1.5 border-b border-theme-border">
+                <Search className="w-3.5 h-3.5 text-theme-text-tertiary" />
+                <input
+                  autoFocus
+                  value={search}
+                  onChange={e => setSearch(e.target.value)}
+                  placeholder="Filter namespaces"
+                  className="flex-1 bg-transparent text-sm outline-none text-theme-text-primary placeholder:text-theme-text-tertiary"
+                />
+              </div>
+            )}
+
+            {scope.cacheScoped ? (
+              <div className="px-3 py-1.5 border-b border-theme-border text-[11px] leading-snug text-theme-text-secondary">
+                Radar is watching one namespace to stay fast on large clusters.
+                {scope.namespaceRescope
+                  ? ' Pick another to re-point it — takes a moment and closes open terminals.'
+                  : ' This instance is locked to its startup namespace.'}
+              </div>
+            ) : (
+              <div className="flex items-center justify-between px-2 py-1.5 border-b border-theme-border text-xs text-theme-text-secondary">
+                <button
+                  onClick={canClearAll ? clearAll : undefined}
+                  disabled={!canClearAll || activeCount === 0}
+                  className="flex items-center gap-1 px-1.5 py-0.5 rounded hover:bg-theme-hover disabled:opacity-50 disabled:hover:bg-transparent"
+                  aria-label="Clear namespace selection"
+                >
+                  <X className="w-3 h-3" />
+                  Clear all
+                </button>
+                <button
+                  onClick={allVisibleSelected ? clearVisible : selectAllVisible}
+                  disabled={filteredItems.length === 0}
+                  className="px-1.5 py-0.5 rounded hover:bg-theme-hover disabled:opacity-50 disabled:hover:bg-transparent"
+                >
+                  {allVisibleSelected
+                    ? `Clear ${filteredItems.length} visible`
+                    : search.trim()
+                      ? `Select ${filteredItems.length} visible`
+                      : 'Select all'}
+                </button>
+              </div>
+            )}
+
+            <ul className="max-h-80 overflow-y-auto py-1">
+              {filteredItems.length === 0 && (
+                <li className="px-3 py-2 text-xs text-theme-text-tertiary">
+                  {search ? 'No matches.' : 'No namespaces available.'}
+                </li>
+              )}
+
+              {filteredItems.map(ns => {
+                const isChecked = draft.has(ns)
+                const isContextDefault = ns === scope.kubeconfigNamespace && ns !== ''
+                return (
+                  <li key={ns}>
+                    <label
+                      className="w-full flex items-center justify-between px-3 py-1.5 text-sm hover:bg-theme-hover text-left text-theme-text-primary cursor-pointer"
+                    >
+                      <span className="flex items-center gap-2 min-w-0">
+                        <input
+                          type={scope.cacheScoped ? 'radio' : 'checkbox'}
+                          name={scope.cacheScoped ? 'namespace-cache-scope' : undefined}
+                          checked={isChecked}
+                          onChange={() => toggle(ns)}
+                          className="shrink-0 accent-current"
+                        />
+                        <span className="truncate">{ns}</span>
+                        {isContextDefault && (
+                          <span className="text-[10px] uppercase tracking-wide text-theme-text-tertiary shrink-0">
+                            kubeconfig
+                          </span>
+                        )}
+                      </span>
+                    </label>
+                  </li>
+                )
+              })}
+            </ul>
+
+            <div className="flex items-center justify-between px-3 py-1.5 border-t border-theme-border text-[11px] text-theme-text-tertiary">
+              <span>
+                {scope.cacheScoped
+                  ? (draft.size === 1 ? Array.from(draft)[0] : 'Select a namespace')
+                  : draft.size === 0 ? 'All namespaces' : `${draft.size} selected`}
+              </span>
+              <button
+                onClick={closeAndApply}
+                className="px-2 py-0.5 rounded bg-theme-elevated hover:bg-theme-hover text-theme-text-primary"
+              >
+                Done
+              </button>
+            </div>
+
+            {!scope.authoritative && (
+              <div className="px-3 py-2 border-t border-theme-border text-[11px] status-degraded">
+                Limited list — your RBAC doesn&rsquo;t allow listing all
+                namespaces. Other namespaces may be accessible but won&rsquo;t
+                appear here until you switch context.
+              </div>
+            )}
+          </div>,
+          document.body,
+        )}
+    </>
+  )
+})

--- a/packages/k8s-ui/src/components/namespace-switcher/NamespacePicker.tsx
+++ b/packages/k8s-ui/src/components/namespace-switcher/NamespacePicker.tsx
@@ -229,7 +229,7 @@ export const NamespacePicker = forwardRef<NamespacePickerHandle, NamespacePicker
           disabled={isDisabled}
           className={
             variant === 'segment'
-              ? `flex items-center gap-1.5 px-3 py-1.5 h-full min-w-[110px] max-w-[170px] text-sm text-theme-text-primary hover:bg-theme-hover disabled:opacity-60 transition-colors ${className}`
+              ? `flex items-center gap-1.5 px-3 py-1.5 h-full min-w-[110px] max-w-[200px] text-[13px] text-theme-text-primary hover:bg-theme-hover disabled:opacity-60 transition-colors ${className}`
               : `flex items-center gap-1.5 px-2 py-1 rounded text-sm bg-theme-elevated hover:bg-theme-hover text-theme-text-primary disabled:opacity-60 transition-colors ${className}`
           }
           aria-label="Switch active namespaces"

--- a/packages/k8s-ui/src/components/namespace-switcher/NamespacePicker.tsx
+++ b/packages/k8s-ui/src/components/namespace-switcher/NamespacePicker.tsx
@@ -244,7 +244,7 @@ export const NamespacePicker = forwardRef<NamespacePickerHandle, NamespacePicker
           disabled={isDisabled}
           className={
             variant === 'segment'
-              ? `flex items-center gap-1.5 px-3 py-1.5 h-full min-w-[110px] max-w-[200px] text-[13px] text-theme-text-primary hover:bg-theme-hover disabled:opacity-60 transition-colors ${className}`
+              ? `flex items-center justify-center gap-1.5 px-3 py-1.5 h-full min-w-[110px] max-w-[200px] text-[13px] text-theme-text-primary hover:bg-theme-hover disabled:opacity-60 transition-colors ${className}`
               : `flex items-center gap-1.5 px-2 py-1 rounded text-sm bg-theme-elevated hover:bg-theme-hover text-theme-text-primary disabled:opacity-60 transition-colors ${className}`
           }
           aria-label="Switch active namespaces"

--- a/packages/k8s-ui/src/components/namespace-switcher/index.ts
+++ b/packages/k8s-ui/src/components/namespace-switcher/index.ts
@@ -1,0 +1,6 @@
+export { NamespacePicker } from './NamespacePicker'
+export type {
+  NamespacePickerProps,
+  NamespacePickerHandle,
+  NamespaceScopeView,
+} from './NamespacePicker'

--- a/packages/k8s-ui/src/components/scope-pill/ScopePill.tsx
+++ b/packages/k8s-ui/src/components/scope-pill/ScopePill.tsx
@@ -18,12 +18,16 @@ export interface ScopePillProps {
  * view-awareness, and any layout pinning are the host's concern.
  *
  * Deliberately NO `overflow-hidden`: ClusterSwitcher's dropdown renders inline
- * (absolute, not portaled), so clipping this ancestor would hide it.
+ * (absolute, not portaled), so clipping this ancestor would hide it. Instead of
+ * clipping, the outer corners of the first/last segment's TRIGGER button are
+ * rounded (7px = the 8px pill radius minus its 1px border) so each segment's
+ * hover/active fill follows the pill's shape instead of poking square corners
+ * past it. `>button` targets only the trigger, never the dropdown's buttons.
  */
 export function ScopePill({ children, className = '' }: ScopePillProps) {
   return (
     <div
-      className={`flex items-stretch shrink-0 rounded-lg border border-theme-border bg-theme-surface divide-x divide-theme-border ${className}`}
+      className={`flex items-stretch shrink-0 rounded-lg border border-theme-border bg-theme-surface divide-x divide-theme-border [&>*:first-child>button]:rounded-l-[7px] [&>*:last-child>button]:rounded-r-[7px] ${className}`}
     >
       {children}
     </div>

--- a/packages/k8s-ui/src/components/scope-pill/ScopePill.tsx
+++ b/packages/k8s-ui/src/components/scope-pill/ScopePill.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from 'react'
+
+export interface ScopePillProps {
+  /**
+   * The scope segments — typically a cluster switcher followed by a namespace
+   * picker, each rendered in its `variant="segment"` form (borderless). They're
+   * separated by a divider and read as one "what am I looking at" unit.
+   */
+  children: ReactNode
+  className?: string
+}
+
+/**
+ * ScopePill is the shared bordered shell for the cluster + namespace "scope"
+ * control, used by both OSS Radar's header and Radar Hub's cluster top bar so
+ * the two stay visually identical. It is purely the container: the segments
+ * (ClusterSwitcher / NamespacePicker in segment variant) and their data,
+ * view-awareness, and any layout pinning are the host's concern.
+ *
+ * Deliberately NO `overflow-hidden`: ClusterSwitcher's dropdown renders inline
+ * (absolute, not portaled), so clipping this ancestor would hide it.
+ */
+export function ScopePill({ children, className = '' }: ScopePillProps) {
+  return (
+    <div
+      className={`flex items-stretch shrink-0 rounded-lg border border-theme-border bg-theme-surface divide-x divide-theme-border ${className}`}
+    >
+      {children}
+    </div>
+  )
+}

--- a/packages/k8s-ui/src/components/scope-pill/index.ts
+++ b/packages/k8s-ui/src/components/scope-pill/index.ts
@@ -1,0 +1,2 @@
+export { ScopePill } from './ScopePill'
+export type { ScopePillProps } from './ScopePill'

--- a/packages/k8s-ui/src/components/ui/Toast.tsx
+++ b/packages/k8s-ui/src/components/ui/Toast.tsx
@@ -227,7 +227,7 @@ function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: () => void }
               {toast.detail}
             </button>
           ) : (
-            <p className={clsx('mt-1 text-xs break-all', isError ? 'text-red-300/80' : isSuccess ? 'text-emerald-300/80' : 'text-theme-text-secondary')}>
+            <p className={clsx('mt-1 text-xs break-words', isError ? 'text-red-300/80' : isSuccess ? 'text-emerald-300/80' : 'text-theme-text-secondary')}>
               {toast.detail}
             </p>
           )

--- a/packages/k8s-ui/src/index.ts
+++ b/packages/k8s-ui/src/index.ts
@@ -53,6 +53,10 @@ export * from './components/issues'
 // Cluster switcher (shared trigger+dropdown for OSS Radar and Radar Hub)
 export * from './components/cluster-switcher'
 
+// Namespace picker (shared scope-filter trigger+dropdown for OSS Radar and
+// Radar Hub — pure presentation, data injected via props)
+export * from './components/namespace-switcher'
+
 // Applications (shared host-agnostic list + detail shell for the deployable-
 // software surface; OSS renders single-cluster, Cloud adds the fleet layer)
 export * from './components/applications'

--- a/packages/k8s-ui/src/index.ts
+++ b/packages/k8s-ui/src/index.ts
@@ -57,6 +57,10 @@ export * from './components/cluster-switcher'
 // Radar Hub — pure presentation, data injected via props)
 export * from './components/namespace-switcher'
 
+// Scope pill — the shared bordered shell that groups the cluster + namespace
+// segments into one unit (OSS header + Radar Hub cluster top bar)
+export * from './components/scope-pill'
+
 // Applications (shared host-agnostic list + detail shell for the deployable-
 // software surface; OSS renders single-cluster, Cloud adds the fleet layer)
 export * from './components/applications'

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -52,7 +52,7 @@ import { KeyboardShortcutProvider, useRegisterShortcut, useRegisterShortcuts, us
 import { useAnimatedUnmount } from './hooks/useAnimatedUnmount'
 import { useDocumentTitle } from './hooks/useDocumentTitle'
 import radarLoadingIcon from '@skyhook-io/k8s-ui/assets/radar/radar-icon-loading.svg'
-import { RefreshCw, Network, List, Clock, Package, Sun, Moon, Activity, Home, Star, Search, Bug, SquareTerminal, ShieldCheck, GitBranch, HelpCircle } from 'lucide-react'
+import { Network, List, Clock, Package, Sun, Moon, Activity, Home, Star, Search, Bug, SquareTerminal, ShieldCheck, GitBranch, HelpCircle } from 'lucide-react'
 import { useTheme } from './context/ThemeContext'
 import { Tooltip } from './components/ui/Tooltip'
 import { LargeClusterNamespacePicker } from './components/shared/LargeClusterNamespacePicker'
@@ -1536,38 +1536,54 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
       {!chromeless && (
       <header className="relative z-50 flex items-center justify-between px-4 py-2 bg-theme-base/90 backdrop-blur-sm border-b border-theme-border/50">
         {/* Left: Logo + Cluster info. In the standalone (nav-rail) layout this
-            is one of three equal flex-1 columns so the centered omnibar stays
-            pinned; overflowing chrome truncates rather than shoving the search
-            box. The embedded/pill layout keeps shrink-0 (its center bar is
-            absolutely positioned, so equal columns aren't needed). */}
-        <div className={`flex items-center gap-4 ${showNavRail ? 'flex-1 min-w-0' : 'shrink-0'}`}>
+            is a FIXED-WIDTH column so the omnibar after it is force-pinned: the
+            scope pill + status dot can change width (cluster/namespace value)
+            without ever shifting the search box. The pill's own name/value caps
+            keep it inside this width; the embedded/pill layout keeps auto width
+            (its center bar is absolutely positioned). */}
+        <div className={`flex items-center gap-4 shrink-0 ${showNavRail ? 'w-[440px]' : ''}`}>
           {/* Standalone rail owns the brand; only the embedded/pill layout
               shows it in the header (host may override via brandSlot). */}
           {navCustomization.brandSlot ?? (showNavRail ? null : <Logo />)}
 
-          <div className="flex items-center gap-2">
-            {navCustomization.contextSlot ?? <ContextSwitcher ref={contextSwitcherRef} />}
-            {/* Namespace scope — the trailing chip of the cluster/namespace
-                "scope zone". Lighter than the cluster switcher (a reversible
-                view filter, not a destructive context switch) and view-aware
-                (disabled on cluster-scoped surfaces). Kept immediately after
-                the cluster chip so the two scope controls read as one unit. */}
-            <NamespaceSwitcher
-              ref={namespaceSwitcherRef}
-              disabled={namespaceFilter.disabled}
-              disabledTooltip={namespaceFilter.tooltip}
-            />
-            {/* Connection status — placed AFTER the scope zone, not between the
-                cluster and namespace chips: its inline label is variable-width
-                (dot only when healthy, "Discovering…" / "Disconnected" + retry
-                otherwise), so sitting it between them would shove the namespace
-                chip sideways on every connection-state change. Trailing here,
-                its width changes never move the scope controls. */}
-            <div className="flex items-center gap-1.5 ml-1">
+          <div className="flex items-center gap-2 min-w-0">
+            {navCustomization.contextSlot ? (
+              // Embedded host supplies its own cluster switcher — keep the two
+              // controls separate (the host owns the cluster chip's styling).
+              <>
+                {navCustomization.contextSlot}
+                <NamespaceSwitcher
+                  ref={namespaceSwitcherRef}
+                  disabled={namespaceFilter.disabled}
+                  disabledTooltip={namespaceFilter.tooltip}
+                />
+              </>
+            ) : (
+              // Standalone: cluster + namespace as one labelled "scope" pill —
+              // two borderless segments split by a divider, reading as a single
+              // "what am I looking at" unit. No overflow-hidden on the container:
+              // the ClusterSwitcher dropdown renders inline (absolute), so an
+              // ancestor clip would hide it.
+              <div className="flex items-stretch rounded-lg border border-theme-border bg-theme-surface divide-x divide-theme-border min-w-0">
+                <ContextSwitcher ref={contextSwitcherRef} variant="segment" />
+                <NamespaceSwitcher
+                  ref={namespaceSwitcherRef}
+                  variant="segment"
+                  disabled={namespaceFilter.disabled}
+                  disabledTooltip={namespaceFilter.tooltip}
+                />
+              </div>
+            )}
+            {/* Connection status — a single FIXED-SIZE dot (state lives in the
+                tooltip), trailing the scope pill. Dot-only keeps the left group
+                a stable width, so the pinned search box never shifts on
+                connection-state changes; when disconnected the dot itself is the
+                reconnect control. */}
+            <div className="ml-1 shrink-0 flex items-center">
               <Tooltip
                 content={
                   !clusterConnected
-                    ? 'Cluster disconnected'
+                    ? 'Cluster disconnected — click to reconnect'
                     : crdDiscoveryStatus === 'discovering'
                       ? 'Connected — discovering Custom Resources...'
                       : 'Connected'
@@ -1575,38 +1591,24 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
                 delay={100}
                 position="bottom"
               >
-                <span
-                  className={`w-2 h-2 rounded-full ${
-                    !clusterConnected
-                      ? 'bg-red-500'
-                      : crdDiscoveryStatus === 'discovering'
-                        ? 'bg-amber-400 animate-pulse'
-                        : 'bg-green-500'
-                  }`}
-                />
+                {clusterConnected ? (
+                  <span
+                    className={`block w-2.5 h-2.5 rounded-full ${
+                      crdDiscoveryStatus === 'discovering' ? 'bg-amber-400 animate-pulse' : 'bg-green-500'
+                    }`}
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    onClick={retryConnection}
+                    disabled={isRetrying}
+                    aria-label="Cluster disconnected — reconnect"
+                    className="block disabled:cursor-default"
+                  >
+                    <span className={`block w-2.5 h-2.5 rounded-full bg-red-500 ${isRetrying ? 'animate-pulse' : ''}`} />
+                  </button>
+                )}
               </Tooltip>
-              {/* Inline label only for non-steady states where the user
-                  might need to act or wait. The healthy "Connected" case
-                  is the dot alone; the dot's tooltip discloses it. Keeping
-                  "Connected" text here would expand the left section and
-                  collide with the absolute-centered nav block at xl, which
-                  is the same breakpoint where nav labels appear. */}
-              {(!clusterConnected || crdDiscoveryStatus === 'discovering') && (
-                <span className="text-[11px] text-theme-text-tertiary hidden xl:inline">
-                  {!clusterConnected ? 'Disconnected' : 'Discovering Custom Resources...'}
-                </span>
-              )}
-              {!clusterConnected && (
-                <Tooltip content="Reconnect">
-                <button
-                  onClick={retryConnection}
-                  disabled={isRetrying}
-                  className="p-1 text-theme-text-secondary hover:text-theme-text-primary disabled:opacity-50 disabled:pointer-events-none"
-                >
-                  <RefreshCw className={`w-3 h-3 ${isRetrying ? 'animate-spin' : ''}`} />
-                </button>
-                </Tooltip>
-              )}
             </div>
             {/* Port forwards indicator — shown only when sessions exist */}
             <PortForwardIndicator />
@@ -1701,9 +1703,8 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
           </div>
         )}
 
-        {/* Right: Controls. Equal flex-1 column in the standalone layout (mirror
-            of the left group) so the omnibar column stays centered. */}
-        <div className={`flex items-center gap-3 ${showNavRail ? 'flex-1 min-w-0 justify-end' : 'shrink-0'}`}>
+        {/* Right: Controls */}
+        <div className="flex items-center gap-3 shrink-0">
           {/* Command palette trigger — embedded only; standalone has the
               top-center omnibar (which is the ⌘K surface). */}
           {!showNavRail && (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1541,7 +1541,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
             without ever shifting the search box. The pill's own name/value caps
             keep it inside this width; the embedded/pill layout keeps auto width
             (its center bar is absolutely positioned). */}
-        <div className={`flex items-center gap-4 shrink-0 ${showNavRail ? 'w-[440px]' : ''}`}>
+        <div className={`flex items-center gap-4 shrink-0 ${showNavRail ? 'w-[478px]' : ''}`}>
           {/* Standalone rail owns the brand; only the embedded/pill layout
               shows it in the header (host may override via brandSlot). */}
           {navCustomization.brandSlot ?? (showNavRail ? null : <Logo />)}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -127,6 +127,48 @@ function getViewFromPath(pathname: string): ExtendedMainView {
   return 'home'
 }
 
+// The namespace scope filter is meaningful only on namespaced surfaces. On
+// cluster-scoped views it does nothing, so we disable it with an explanation
+// rather than leaving a dead control that silently ignores the pick:
+//   - Cost is reported per-namespace across the whole cluster (the view IS the
+//     breakdown; a filter would only hide rows).
+//   - A GitOps detail tree spans namespaces — its controller lives in one
+//     namespace but manages workloads across many.
+//   - A cluster-scoped resource kind (Nodes, PVs, ClusterRoles…) has no
+//     namespace at all.
+// The pick itself is preserved so it re-applies when the user returns to a
+// namespaced view.
+function namespaceFilterDisabled(
+  view: ExtendedMainView,
+  pathname: string,
+  apiResources?: { name: string; kind: string; namespaced: boolean }[],
+): { disabled: boolean; tooltip?: string } {
+  if (view === 'cost') {
+    return {
+      disabled: true,
+      tooltip: 'Cost is reported per namespace across the whole cluster — the namespace filter doesn’t apply here.',
+    }
+  }
+  const segments = pathname.replace(/^\//, '').split('/')
+  if (view === 'gitops' && segments[1] === 'detail') {
+    return {
+      disabled: true,
+      tooltip: 'This resource manages workloads across namespaces — the namespace filter doesn’t apply to its tree.',
+    }
+  }
+  if (view === 'resources') {
+    const kindSlug = segments[1]
+    const match = kindSlug ? apiResources?.find(r => r.name === kindSlug) : undefined
+    if (match && !match.namespaced) {
+      return {
+        disabled: true,
+        tooltip: `${match.kind} is a cluster-scoped resource — namespaces don’t apply.`,
+      }
+    }
+  }
+  return { disabled: false }
+}
+
 // Browser tab label for every Radar view, derived from the route URL so it's
 // correct regardless of which component renders it. A detail drawer that opens
 // over a list (?resource=…) is deliberately NOT titled — it's the same page, so
@@ -337,6 +379,10 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
   // resources view has run initNavigationMap().
   const { data: navApiResources } = useAPIResources()
   useEffect(() => { if (navApiResources) initNavigationMap(navApiResources) }, [navApiResources])
+
+  // View-aware namespace scope: disabled on cluster-scoped surfaces so the
+  // chip isn't a dead control next to the cluster switcher.
+  const namespaceFilter = namespaceFilterDisabled(mainView, location.pathname, navApiResources)
 
   // One URL-derived tab title for every view (see radarPageTitle). Driving it
   // from the URL — not the mounted component. Off unless the host opts in
@@ -1543,6 +1589,15 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
                 </Tooltip>
               )}
             </div>
+            {/* Namespace scope — the trailing chip of the cluster/namespace
+                "scope zone". Lighter than the cluster switcher (a reversible
+                view filter, not a destructive context switch) and view-aware
+                (disabled on cluster-scoped surfaces). */}
+            <NamespaceSwitcher
+              ref={namespaceSwitcherRef}
+              disabled={namespaceFilter.disabled}
+              disabledTooltip={namespaceFilter.tooltip}
+            />
             {/* Port forwards indicator — shown only when sessions exist */}
             <PortForwardIndicator />
           </div>
@@ -1633,11 +1688,6 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
 
         {/* Right: Controls */}
         <div className="flex items-center gap-3 shrink-0">
-          <NamespaceSwitcher
-            ref={namespaceSwitcherRef}
-          />
-
-
           {/* Command palette trigger — embedded only; standalone has the
               top-center omnibar (which is the ⌘K surface). */}
           {!showNavRail && (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1546,7 +1546,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
               shows it in the header (host may override via brandSlot). */}
           {navCustomization.brandSlot ?? (showNavRail ? null : <Logo />)}
 
-          <div className="flex items-center gap-2 min-w-0">
+          <div className={`flex items-center gap-2 min-w-0 ${showNavRail ? 'flex-1' : ''}`}>
             {navCustomization.contextSlot ? (
               // Embedded host supplies its own cluster switcher — keep the two
               // controls separate (the host owns the cluster chip's styling).
@@ -1564,7 +1564,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
               // "what am I looking at" unit. No overflow-hidden on the container:
               // the ClusterSwitcher dropdown renders inline (absolute), so an
               // ancestor clip would hide it.
-              <div className="flex items-stretch rounded-lg border border-theme-border bg-theme-surface divide-x divide-theme-border min-w-0">
+              <div className="flex items-stretch shrink-0 rounded-lg border border-theme-border bg-theme-surface divide-x divide-theme-border">
                 <ContextSwitcher ref={contextSwitcherRef} variant="segment" />
                 <NamespaceSwitcher
                   ref={namespaceSwitcherRef}
@@ -1574,12 +1574,12 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
                 />
               </div>
             )}
-            {/* Connection status — a single FIXED-SIZE dot (state lives in the
-                tooltip), trailing the scope pill. Dot-only keeps the left group
-                a stable width, so the pinned search box never shifts on
-                connection-state changes; when disconnected the dot itself is the
-                reconnect control. */}
-            <div className="ml-1 shrink-0 flex items-center">
+            {/* Connection status — a fixed-size dot (state in the tooltip; the
+                dot is the reconnect control when disconnected) plus, when the
+                header is wide enough (xl+), a label that fills the fixed left
+                column's remaining slack and TRUNCATES, so it never overflows or
+                pushes the pinned search box. Below xl it's the dot alone. */}
+            <div className={`ml-1 flex items-center gap-1.5 ${showNavRail ? 'flex-1 min-w-0' : 'shrink-0'}`}>
               <Tooltip
                 content={
                   !clusterConnected
@@ -1593,7 +1593,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
               >
                 {clusterConnected ? (
                   <span
-                    className={`block w-2.5 h-2.5 rounded-full ${
+                    className={`block w-2.5 h-2.5 shrink-0 rounded-full ${
                       crdDiscoveryStatus === 'discovering' ? 'bg-amber-400 animate-pulse' : 'bg-green-500'
                     }`}
                   />
@@ -1603,12 +1603,17 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
                     onClick={retryConnection}
                     disabled={isRetrying}
                     aria-label="Cluster disconnected — reconnect"
-                    className="block disabled:cursor-default"
+                    className="block shrink-0 disabled:cursor-default"
                   >
                     <span className={`block w-2.5 h-2.5 rounded-full bg-red-500 ${isRetrying ? 'animate-pulse' : ''}`} />
                   </button>
                 )}
               </Tooltip>
+              {showNavRail && (!clusterConnected || crdDiscoveryStatus === 'discovering') && (
+                <span className="hidden xl:block flex-1 min-w-0 truncate text-[11px] text-theme-text-tertiary">
+                  {!clusterConnected ? 'Disconnected' : 'Discovering Custom Resources…'}
+                </span>
+              )}
             </div>
             {/* Port forwards indicator — shown only when sessions exist */}
             <PortForwardIndicator />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1543,7 +1543,22 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
 
           <div className="flex items-center gap-2">
             {navCustomization.contextSlot ?? <ContextSwitcher ref={contextSwitcherRef} />}
-            {/* Connection status - next to cluster name */}
+            {/* Namespace scope — the trailing chip of the cluster/namespace
+                "scope zone". Lighter than the cluster switcher (a reversible
+                view filter, not a destructive context switch) and view-aware
+                (disabled on cluster-scoped surfaces). Kept immediately after
+                the cluster chip so the two scope controls read as one unit. */}
+            <NamespaceSwitcher
+              ref={namespaceSwitcherRef}
+              disabled={namespaceFilter.disabled}
+              disabledTooltip={namespaceFilter.tooltip}
+            />
+            {/* Connection status — placed AFTER the scope zone, not between the
+                cluster and namespace chips: its inline label is variable-width
+                (dot only when healthy, "Discovering…" / "Disconnected" + retry
+                otherwise), so sitting it between them would shove the namespace
+                chip sideways on every connection-state change. Trailing here,
+                its width changes never move the scope controls. */}
             <div className="flex items-center gap-1.5 ml-1">
               <Tooltip
                 content={
@@ -1589,15 +1604,6 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
                 </Tooltip>
               )}
             </div>
-            {/* Namespace scope — the trailing chip of the cluster/namespace
-                "scope zone". Lighter than the cluster switcher (a reversible
-                view filter, not a destructive context switch) and view-aware
-                (disabled on cluster-scoped surfaces). */}
-            <NamespaceSwitcher
-              ref={namespaceSwitcherRef}
-              disabled={namespaceFilter.disabled}
-              disabledTooltip={namespaceFilter.tooltip}
-            />
             {/* Port forwards indicator — shown only when sessions exist */}
             <PortForwardIndicator />
           </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,7 +8,7 @@ import { HomeView } from './components/home/HomeView'
 import { DebugOverlay } from './components/DebugOverlay'
 import { TopologyGraph, TopologySearch, TopologyFilterSidebar, TopologyControls, gitOpsRouteForKind, gitOpsRouteForResource } from '@skyhook-io/k8s-ui'
 import { initNavigationMap } from '@skyhook-io/k8s-ui/utils/navigation'
-import { useAPIResources } from './api/apiResources'
+import { useAPIResources, CORE_RESOURCES } from './api/apiResources'
 import { TimelineView } from './components/timeline/TimelineView'
 import { ResourcesView } from './components/resources/ResourcesView'
 import { serializeColumnFilters } from './components/resources/resource-utils'
@@ -382,7 +382,10 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
 
   // View-aware namespace scope: disabled on cluster-scoped surfaces so the
   // chip isn't a dead control next to the cluster switcher.
-  const namespaceFilter = namespaceFilterDisabled(mainView, location.pathname, navApiResources)
+  // Fall back to the static core-resource list before discovery loads, so the
+  // chip disables immediately on a cluster-scoped core kind (Nodes, PVs, …)
+  // instead of flickering enabled until /api-resources resolves.
+  const namespaceFilter = namespaceFilterDisabled(mainView, location.pathname, navApiResources ?? CORE_RESOURCES)
 
   // One URL-derived tab title for every view (see radarPageTitle). Driving it
   // from the URL — not the mounted component. Off unless the host opts in

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1541,7 +1541,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
             without ever shifting the search box. The pill's own name/value caps
             keep it inside this width; the embedded/pill layout keeps auto width
             (its center bar is absolutely positioned). */}
-        <div className={`flex items-center gap-4 shrink-0 ${showNavRail ? 'w-[478px]' : ''}`}>
+        <div className={`flex items-center gap-4 shrink-0 ${showNavRail ? 'w-[492px]' : ''}`}>
           {/* Standalone rail owns the brand; only the embedded/pill layout
               shows it in the header (host may override via brandSlot). */}
           {navCustomization.brandSlot ?? (showNavRail ? null : <Logo />)}
@@ -1576,9 +1576,13 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
             )}
             {/* Connection status — a fixed-size dot (state in the tooltip; the
                 dot is the reconnect control when disconnected) plus, when the
-                header is wide enough (xl+), a label that fills the fixed left
-                column's remaining slack and TRUNCATES, so it never overflows or
-                pushes the pinned search box. Below xl it's the dot alone. */}
+                header is wide enough (xl+), a label. The label is nowrap and
+                unbounded: it overflows the fixed left column into the empty gap
+                before the centered search box rather than shifting anything (the
+                dot + pill are shrink-0, so layout stays put — the search box
+                never moves). Where the gap is smaller than the label, its tail
+                tucks under the omnibar's solid background. Below xl it's the dot
+                alone. */}
             <div className="ml-1 flex items-center gap-1.5 shrink-0">
               <Tooltip
                 content={

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1535,8 +1535,12 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
       {/* Header — suppressed in chromeless embed; the host owns the chrome. */}
       {!chromeless && (
       <header className="relative z-50 flex items-center justify-between px-4 py-2 bg-theme-base/90 backdrop-blur-sm border-b border-theme-border/50">
-        {/* Left: Logo + Cluster info */}
-        <div className="flex items-center gap-4 shrink-0">
+        {/* Left: Logo + Cluster info. In the standalone (nav-rail) layout this
+            is one of three equal flex-1 columns so the centered omnibar stays
+            pinned; overflowing chrome truncates rather than shoving the search
+            box. The embedded/pill layout keeps shrink-0 (its center bar is
+            absolutely positioned, so equal columns aren't needed). */}
+        <div className={`flex items-center gap-4 ${showNavRail ? 'flex-1 min-w-0 overflow-hidden' : 'shrink-0'}`}>
           {/* Standalone rail owns the brand; only the embedded/pill layout
               shows it in the header (host may override via brandSlot). */}
           {navCustomization.brandSlot ?? (showNavRail ? null : <Logo />)}
@@ -1668,7 +1672,12 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
         )}
 
         {/* Center: omnibar — standalone search + command surface (the ⌘K entry).
-            Fills the space the pill bar left; embedded keeps the pills + modal. */}
+            Its container is one of three EQUAL flex-1 columns (see the left/right
+            groups): equal side columns keep this middle column — and the search
+            box centered in it — pinned regardless of how wide the left-side
+            chrome gets (cluster name, namespace label, "Discovering…" /
+            "Disconnected" text). Overflowing side content truncates instead of
+            dragging the box. Same pattern as Radar Hub's ClusterTopBar. */}
         {showNavRail && (
           <div className="hidden sm:flex flex-1 justify-center min-w-0 px-3">
             <RadarOmnibar
@@ -1692,8 +1701,9 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
           </div>
         )}
 
-        {/* Right: Controls */}
-        <div className="flex items-center gap-3 shrink-0">
+        {/* Right: Controls. Equal flex-1 column in the standalone layout (mirror
+            of the left group) so the omnibar column stays centered. */}
+        <div className={`flex items-center gap-3 ${showNavRail ? 'flex-1 min-w-0 justify-end' : 'shrink-0'}`}>
           {/* Command palette trigger — embedded only; standalone has the
               top-center omnibar (which is the ⌘K surface). */}
           {!showNavRail && (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1579,7 +1579,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
                 header is wide enough (xl+), a label that fills the fixed left
                 column's remaining slack and TRUNCATES, so it never overflows or
                 pushes the pinned search box. Below xl it's the dot alone. */}
-            <div className={`ml-1 flex items-center gap-1.5 ${showNavRail ? 'flex-1 min-w-0' : 'shrink-0'}`}>
+            <div className="ml-1 flex items-center gap-1.5 shrink-0">
               <Tooltip
                 content={
                   !clusterConnected
@@ -1610,7 +1610,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
                 )}
               </Tooltip>
               {showNavRail && (!clusterConnected || crdDiscoveryStatus === 'discovering') && (
-                <span className="hidden xl:block flex-1 min-w-0 truncate text-[11px] text-theme-text-tertiary">
+                <span className="hidden xl:block whitespace-nowrap text-[11px] text-theme-text-tertiary">
                   {!clusterConnected ? 'Disconnected' : 'Discovering Custom Resources…'}
                 </span>
               )}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1540,7 +1540,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
             pinned; overflowing chrome truncates rather than shoving the search
             box. The embedded/pill layout keeps shrink-0 (its center bar is
             absolutely positioned, so equal columns aren't needed). */}
-        <div className={`flex items-center gap-4 ${showNavRail ? 'flex-1 min-w-0 overflow-hidden' : 'shrink-0'}`}>
+        <div className={`flex items-center gap-4 ${showNavRail ? 'flex-1 min-w-0' : 'shrink-0'}`}>
           {/* Standalone rail owns the brand; only the embedded/pill layout
               shows it in the header (host may override via brandSlot). */}
           {navCustomization.brandSlot ?? (showNavRail ? null : <Logo />)}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,7 +6,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useNavigate, useLocation, useSearchParams, useNavigationType, NavigationType } from 'react-router-dom'
 import { HomeView } from './components/home/HomeView'
 import { DebugOverlay } from './components/DebugOverlay'
-import { TopologyGraph, TopologySearch, TopologyFilterSidebar, TopologyControls, gitOpsRouteForKind, gitOpsRouteForResource } from '@skyhook-io/k8s-ui'
+import { TopologyGraph, TopologySearch, TopologyFilterSidebar, TopologyControls, gitOpsRouteForKind, gitOpsRouteForResource, ScopePill } from '@skyhook-io/k8s-ui'
 import { initNavigationMap } from '@skyhook-io/k8s-ui/utils/navigation'
 import { useAPIResources, CORE_RESOURCES } from './api/apiResources'
 import { TimelineView } from './components/timeline/TimelineView'
@@ -1562,12 +1562,11 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
                 />
               </>
             ) : (
-              // Standalone: cluster + namespace as one labelled "scope" pill —
-              // two borderless segments split by a divider, reading as a single
-              // "what am I looking at" unit. No overflow-hidden on the container:
-              // the ClusterSwitcher dropdown renders inline (absolute), so an
-              // ancestor clip would hide it.
-              <div className="flex items-stretch shrink-0 rounded-lg border border-theme-border bg-theme-surface divide-x divide-theme-border">
+              // Standalone: cluster + namespace as one "scope" pill — two
+              // borderless segments split by a divider, reading as a single
+              // "what am I looking at" unit. The shared ScopePill shell is the
+              // same one Radar Hub's cluster top bar uses, so the two match.
+              <ScopePill>
                 <ContextSwitcher ref={contextSwitcherRef} variant="segment" />
                 <NamespaceSwitcher
                   ref={namespaceSwitcherRef}
@@ -1575,7 +1574,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
                   disabled={namespaceFilter.disabled}
                   disabledTooltip={namespaceFilter.tooltip}
                 />
-              </div>
+              </ScopePill>
             )}
             {/* Connection status — a fixed-size dot (state in the tooltip; the
                 dot is the reconnect control when disconnected) plus, when the

--- a/web/src/components/ConnectionErrorView.tsx
+++ b/web/src/components/ConnectionErrorView.tsx
@@ -254,7 +254,7 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
 
           {connection.error && (
             <div className="w-full bg-theme-elevated border border-theme-border rounded-lg p-3 mb-6 overflow-auto max-h-32">
-              <code className="text-xs text-red-400 font-mono whitespace-pre-wrap break-all">
+              <code className="text-xs text-red-400 font-mono whitespace-pre-wrap break-words">
                 {connection.error}
               </code>
             </div>

--- a/web/src/components/ContextSwitcher.tsx
+++ b/web/src/components/ContextSwitcher.tsx
@@ -14,6 +14,8 @@ import { parseContextName, type ParsedContextName } from '../utils/context-name'
 
 interface ContextSwitcherProps {
   className?: string
+  variant?: 'chip' | 'segment'
+  label?: string
 }
 
 export interface ContextSwitcherHandle {
@@ -24,7 +26,7 @@ interface ParsedContext extends ParsedContextName {
   context: ContextInfo
 }
 
-export const ContextSwitcher = forwardRef<ContextSwitcherHandle, ContextSwitcherProps>(({ className = '' }, ref) => {
+export const ContextSwitcher = forwardRef<ContextSwitcherHandle, ContextSwitcherProps>(({ className = '', variant, label }, ref) => {
   const [showConfirm, setShowConfirm] = useState(false)
   const [pendingSwitch, setPendingSwitch] = useState<ParsedContext | null>(null)
   const [sessionCounts, setSessionCounts] = useState<SessionCounts | null>(null)
@@ -191,6 +193,8 @@ export const ContextSwitcher = forwardRef<ContextSwitcherHandle, ContextSwitcher
       <ClusterSwitcher
         ref={ref}
         className={className}
+        variant={variant}
+        label={label}
         currentId={currentId}
         currentName={currentRaw}
         currentSourceLabel={currentSourceLabel}

--- a/web/src/components/NamespaceSwitcher.tsx
+++ b/web/src/components/NamespaceSwitcher.tsx
@@ -8,6 +8,8 @@ interface NamespaceSwitcherProps {
   className?: string
   disabled?: boolean
   disabledTooltip?: string
+  variant?: 'chip' | 'segment'
+  label?: string
 }
 
 /**
@@ -16,7 +18,7 @@ interface NamespaceSwitcherProps {
  * hooks; Radar Hub supplies its own container over the per-cluster apiBase.
  */
 export const NamespaceSwitcher = forwardRef<NamespaceSwitcherHandle, NamespaceSwitcherProps>(function NamespaceSwitcher(
-  { className, disabled, disabledTooltip },
+  { className, disabled, disabledTooltip, variant, label },
   ref,
 ) {
   const { data: scope, isLoading } = useNamespaceScope()
@@ -32,6 +34,8 @@ export const NamespaceSwitcher = forwardRef<NamespaceSwitcherHandle, NamespaceSw
       disabled={disabled}
       disabledTooltip={disabledTooltip}
       className={className}
+      variant={variant}
+      label={label}
     />
   )
 })

--- a/web/src/components/NamespaceSwitcher.tsx
+++ b/web/src/components/NamespaceSwitcher.tsx
@@ -1,12 +1,8 @@
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
-import { createPortal } from 'react-dom'
-import { ChevronDown, Globe, Search, AlertTriangle, X } from 'lucide-react'
+import { forwardRef } from 'react'
+import { NamespacePicker, type NamespacePickerHandle } from '@skyhook-io/k8s-ui'
 import { useNamespaceScope, useSetActiveNamespace } from '../api/client'
-import { Tooltip } from './ui/Tooltip'
 
-export interface NamespaceSwitcherHandle {
-  open: () => void
-}
+export type NamespaceSwitcherHandle = NamespacePickerHandle
 
 interface NamespaceSwitcherProps {
   className?: string
@@ -15,306 +11,27 @@ interface NamespaceSwitcherProps {
 }
 
 /**
- * NamespaceSwitcher is normally a per-user multi-select view filter. When the
- * backend reports cacheScoped=true, it becomes a single-namespace cache scope
- * control; local sessions may rebuild the cache for a different namespace.
- *
- * Three states reflect what the backend reports:
- *   - cluster-wide: empty trigger label "All namespaces", picker lets the
- *     user narrow the view; otherwise informational.
- *   - namespace:    label shows the namespace count (or single name); picker
- *     offers other accessible namespaces and a clear-all reset.
- *   - restricted:   user can't list namespaces and isn't pinned; picker
- *     surfaces only the kubeconfig context's namespace + any saved picks.
- *
- * Selection model: the dropdown keeps a draft Set<string>; toggling rows
- * mutates the draft locally; closing the dropdown applies the draft in a
- * single mutation. "Clear all" applies immediately and closes; "Select all
- * visible" / "Clear visible" mutate the draft only and wait for close.
+ * OSS Radar's namespace scope control — a thin data container over the shared
+ * presentational NamespacePicker (@skyhook-io/k8s-ui). Wires Radar's own API
+ * hooks; Radar Hub supplies its own container over the per-cluster apiBase.
  */
 export const NamespaceSwitcher = forwardRef<NamespaceSwitcherHandle, NamespaceSwitcherProps>(function NamespaceSwitcher(
-  { className = '', disabled = false, disabledTooltip },
+  { className, disabled, disabledTooltip },
   ref,
 ) {
   const { data: scope, isLoading } = useNamespaceScope()
   const setActive = useSetActiveNamespace()
 
-  const [isOpen, setIsOpen] = useState(false)
-  const [search, setSearch] = useState('')
-  const [pos, setPos] = useState({ top: 0, left: 0, width: 0 })
-  const [draft, setDraft] = useState<Set<string>>(() => new Set())
-
-  const triggerRef = useRef<HTMLButtonElement>(null)
-  const dropdownRef = useRef<HTMLDivElement>(null)
-
-  const scopeActives = useMemo(() => scope?.actives ?? [], [scope?.actives])
-  const activesKey = useMemo(() => [...scopeActives].sort().join(','), [scopeActives])
-
-  // Sync the draft with the server's view whenever it changes (initial load,
-  // post-mutation refetch, eviction after RBAC drift).
-  useEffect(() => {
-    setDraft(new Set(scopeActives))
-  }, [activesKey, scopeActives])
-
-  const items = useMemo(() => {
-    if (!scope) return [] as string[]
-    return [...(scope.accessibleNamespaces ?? [])].sort((a, b) => a.localeCompare(b))
-  }, [scope])
-
-  const filteredItems = useMemo(() => {
-    const q = search.trim().toLowerCase()
-    if (!q) return items
-    return items.filter(n => n.toLowerCase().includes(q))
-  }, [items, search])
-
-  const applySelection = useCallback((next: Set<string>) => {
-    if (!scope) return
-    const nextArr = Array.from(next).sort()
-    if (scope.cacheScoped && nextArr.length !== 1) return
-    if (nextArr.join(',') === activesKey) return
-    setActive.mutate({ namespaces: nextArr })
-  }, [activesKey, scope, setActive])
-
-  const closeAndApply = useCallback(() => {
-    setIsOpen(false)
-    setSearch('')
-    applySelection(draft)
-  }, [applySelection, draft])
-
-  useImperativeHandle(ref, () => ({
-    open: () => {
-      if (disabled || isLoading || setActive.isPending) return
-      setIsOpen(true)
-    },
-  }), [disabled, isLoading, setActive.isPending])
-
-  useEffect(() => {
-    if (!isOpen) return
-    const trigger = triggerRef.current
-    if (!trigger) return
-    const r = trigger.getBoundingClientRect()
-    setPos({ top: r.bottom + 4, left: r.left, width: Math.max(r.width, 240) })
-  }, [isOpen])
-
-  useEffect(() => {
-    if (!isOpen) return
-    function onClick(e: MouseEvent) {
-      if (
-        !dropdownRef.current?.contains(e.target as Node) &&
-        !triggerRef.current?.contains(e.target as Node)
-      ) {
-        closeAndApply()
-      }
-    }
-    function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') closeAndApply()
-    }
-    document.addEventListener('mousedown', onClick)
-    document.addEventListener('keydown', onKey)
-    return () => {
-      document.removeEventListener('mousedown', onClick)
-      document.removeEventListener('keydown', onKey)
-    }
-  }, [isOpen, closeAndApply])
-
-  if (!scope) return null
-
-  const toggle = (ns: string) => {
-    if (scope.cacheScoped) {
-      setDraft(new Set([ns]))
-      return
-    }
-    const next = new Set(draft)
-    if (next.has(ns)) next.delete(ns)
-    else next.add(ns)
-    setDraft(next)
-  }
-
-  const clearAll = () => {
-    if (scope.cacheScoped) return
-    setDraft(new Set())
-    setIsOpen(false)
-    setSearch('')
-    applySelection(new Set())
-  }
-
-  const selectAllVisible = () => {
-    const next = new Set(draft)
-    for (const ns of filteredItems) next.add(ns)
-    setDraft(next)
-  }
-
-  const clearVisible = () => {
-    const next = new Set(draft)
-    for (const ns of filteredItems) next.delete(ns)
-    setDraft(next)
-  }
-
-  const activeCount = scopeActives.length
-  const triggerLabel =
-    activeCount === 0 ? 'All namespaces' : activeCount === 1 ? scopeActives[0] : `${activeCount} namespaces`
-  const isClusterWide = activeCount === 0
-  const restrictedHint = scope.mode === 'restricted'
-  const cacheScopeLocked = scope.cacheScoped && !scope.namespaceRescope
-  const isDisabled = disabled || isLoading || setActive.isPending || cacheScopeLocked
-  const canClearAll = scope.canClearNamespace || activeCount === 0
-  const tooltipContent = disabled && disabledTooltip
-    ? disabledTooltip
-    : scope.cacheScoped
-      ? scope.namespaceRescope
-        ? `Radar is watching only ${scope.cacheScopeNamespace || triggerLabel} to stay fast on large clusters. Pick another namespace to re-point it (takes a moment; closes open terminals).`
-        : `Radar is watching only ${scope.cacheScopeNamespace || triggerLabel} on this cluster.`
-      : restrictedHint
-      ? 'Limited namespace visibility — only namespaces granted by your RBAC are shown.'
-      : isClusterWide
-        ? 'Currently viewing all namespaces. Click to narrow the view.'
-        : activeCount === 1
-          ? `View is filtered to namespace ${scopeActives[0]}. Click to switch or reset.`
-          : `View is filtered to ${activeCount} namespaces. Click to adjust or reset.`
-
-  // Counts used to label the bulk-action buttons; computed against the visible
-  // (filtered) set so the labels match what the action will affect.
-  const visibleSelectedCount = filteredItems.reduce((n, ns) => n + (draft.has(ns) ? 1 : 0), 0)
-  const allVisibleSelected = filteredItems.length > 0 && visibleSelectedCount === filteredItems.length
-
   return (
-    <>
-      <Tooltip
-        content={tooltipContent}
-        delay={300}
-        position="bottom"
-      >
-        <button
-          ref={triggerRef}
-          onClick={() => !isDisabled && (isOpen ? closeAndApply() : setIsOpen(true))}
-          disabled={isDisabled}
-          className={`flex items-center gap-1.5 px-2 py-1 rounded text-sm bg-theme-elevated hover:bg-theme-hover text-theme-text-primary disabled:opacity-60 transition-colors ${className}`}
-          aria-label="Switch active namespaces"
-        >
-          {isClusterWide ? (
-            <Globe className="w-3.5 h-3.5 text-theme-text-tertiary" />
-          ) : restrictedHint ? (
-            <AlertTriangle className="w-3.5 h-3.5 text-theme-text-tertiary" />
-          ) : null}
-          <span className="font-medium max-w-[180px] truncate">
-            {setActive.isPending ? 'Switching…' : triggerLabel}
-          </span>
-          <ChevronDown className="w-3 h-3 opacity-60" />
-        </button>
-      </Tooltip>
-
-      {isOpen &&
-        createPortal(
-          <div
-            ref={dropdownRef}
-            style={{ position: 'fixed', top: pos.top, left: pos.left, minWidth: pos.width, zIndex: 100 }}
-            className="bg-theme-surface border border-theme-border rounded-md shadow-theme-lg overflow-hidden"
-          >
-            {items.length > 6 && (
-              <div className="flex items-center gap-2 px-2 py-1.5 border-b border-theme-border">
-                <Search className="w-3.5 h-3.5 text-theme-text-tertiary" />
-                <input
-                  autoFocus
-                  value={search}
-                  onChange={e => setSearch(e.target.value)}
-                  placeholder="Filter namespaces"
-                  className="flex-1 bg-transparent text-sm outline-none text-theme-text-primary placeholder:text-theme-text-tertiary"
-                />
-              </div>
-            )}
-
-            {scope.cacheScoped ? (
-              <div className="px-3 py-1.5 border-b border-theme-border text-[11px] leading-snug text-theme-text-secondary">
-                Radar is watching one namespace to stay fast on large clusters.
-                {scope.namespaceRescope
-                  ? ' Pick another to re-point it — takes a moment and closes open terminals.'
-                  : ' This instance is locked to its startup namespace.'}
-              </div>
-            ) : (
-              <div className="flex items-center justify-between px-2 py-1.5 border-b border-theme-border text-xs text-theme-text-secondary">
-                <button
-                  onClick={canClearAll ? clearAll : undefined}
-                  disabled={!canClearAll || activeCount === 0}
-                  className="flex items-center gap-1 px-1.5 py-0.5 rounded hover:bg-theme-hover disabled:opacity-50 disabled:hover:bg-transparent"
-                  aria-label="Clear namespace selection"
-                >
-                  <X className="w-3 h-3" />
-                  Clear all
-                </button>
-                <button
-                  onClick={allVisibleSelected ? clearVisible : selectAllVisible}
-                  disabled={filteredItems.length === 0}
-                  className="px-1.5 py-0.5 rounded hover:bg-theme-hover disabled:opacity-50 disabled:hover:bg-transparent"
-                >
-                  {allVisibleSelected
-                    ? `Clear ${filteredItems.length} visible`
-                    : search.trim()
-                      ? `Select ${filteredItems.length} visible`
-                      : 'Select all'}
-                </button>
-              </div>
-            )}
-
-            <ul className="max-h-80 overflow-y-auto py-1">
-              {filteredItems.length === 0 && (
-                <li className="px-3 py-2 text-xs text-theme-text-tertiary">
-                  {search ? 'No matches.' : 'No namespaces available.'}
-                </li>
-              )}
-
-              {filteredItems.map(ns => {
-                const isChecked = draft.has(ns)
-                const isContextDefault = ns === scope.kubeconfigNamespace && ns !== ''
-                return (
-                  <li key={ns}>
-                    <label
-                      className="w-full flex items-center justify-between px-3 py-1.5 text-sm hover:bg-theme-hover text-left text-theme-text-primary cursor-pointer"
-                    >
-                      <span className="flex items-center gap-2 min-w-0">
-                        <input
-                          type={scope.cacheScoped ? 'radio' : 'checkbox'}
-                          name={scope.cacheScoped ? 'namespace-cache-scope' : undefined}
-                          checked={isChecked}
-                          onChange={() => toggle(ns)}
-                          className="shrink-0 accent-current"
-                        />
-                        <span className="truncate">{ns}</span>
-                        {isContextDefault && (
-                          <span className="text-[10px] uppercase tracking-wide text-theme-text-tertiary shrink-0">
-                            kubeconfig
-                          </span>
-                        )}
-                      </span>
-                    </label>
-                  </li>
-                )
-              })}
-            </ul>
-
-            <div className="flex items-center justify-between px-3 py-1.5 border-t border-theme-border text-[11px] text-theme-text-tertiary">
-              <span>
-                {scope.cacheScoped
-                  ? (draft.size === 1 ? Array.from(draft)[0] : 'Select a namespace')
-                  : draft.size === 0 ? 'All namespaces' : `${draft.size} selected`}
-              </span>
-              <button
-                onClick={closeAndApply}
-                className="px-2 py-0.5 rounded bg-theme-elevated hover:bg-theme-hover text-theme-text-primary"
-              >
-                Done
-              </button>
-            </div>
-
-            {!scope.authoritative && (
-              <div className="px-3 py-2 border-t border-theme-border text-[11px] status-degraded">
-                Limited list — your RBAC doesn&rsquo;t allow listing all
-                namespaces. Other namespaces may be accessible but won&rsquo;t
-                appear here until you switch context.
-              </div>
-            )}
-          </div>,
-          document.body,
-        )}
-    </>
+    <NamespacePicker
+      ref={ref}
+      scope={scope}
+      loading={isLoading}
+      pending={setActive.isPending}
+      onApply={namespaces => setActive.mutate({ namespaces })}
+      disabled={disabled}
+      disabledTooltip={disabledTooltip}
+      className={className}
+    />
   )
 })

--- a/web/src/components/ui/Omnibar.tsx
+++ b/web/src/components/ui/Omnibar.tsx
@@ -414,7 +414,7 @@ export const Omnibar = forwardRef<OmnibarHandle, OmnibarProps>(function Omnibar(
   return (
     <div
       ref={containerRef}
-      className={clsx('relative w-full', hero ? 'max-w-3xl' : 'max-w-xl', open && hero && 'z-[16]')}
+      className={clsx('relative w-full', hero ? 'max-w-3xl' : 'max-w-lg', open && hero && 'z-[16]')}
       // Open on click even when the field is already focused — onFocus alone
       // never fires again, so an autofocused hero (Home) wouldn't reveal the
       // launcher on a click.

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -33,6 +33,11 @@ export type {
   NamespaceScopeView,
 } from '@skyhook-io/k8s-ui';
 
+// Shared bordered shell that groups the cluster + namespace segments into one
+// pill — so Radar Hub's cluster top bar matches OSS Radar's header exactly.
+export { ScopePill } from '@skyhook-io/k8s-ui';
+export type { ScopePillProps } from '@skyhook-io/k8s-ui';
+
 // Deep-link builders — so consumers (Radar Hub) construct deep links into a
 // cluster view without hand-rolling Radar's internal URL format, which drifts
 // silently when Radar re-routes. `resourcePath` opens the detail drawer for any

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -23,6 +23,16 @@ export { ShortcutHelpOverlay } from './components/ui/ShortcutHelpOverlay';
 export { ClusterSwitcher } from '@skyhook-io/k8s-ui';
 export type { ClusterSwitcherProps, ClusterSwitcherItem } from '@skyhook-io/k8s-ui';
 
+// Shared namespace-scope picker primitive — re-exported so embedders (Radar
+// Hub) can render a namespace filter visually identical to OSS Radar's, driving
+// their own per-cluster scope (Hub via ?namespaces= on the embedded RadarApp).
+export { NamespacePicker } from '@skyhook-io/k8s-ui';
+export type {
+  NamespacePickerProps,
+  NamespacePickerHandle,
+  NamespaceScopeView,
+} from '@skyhook-io/k8s-ui';
+
 // Deep-link builders — so consumers (Radar Hub) construct deep links into a
 // cluster view without hand-rolling Radar's internal URL format, which drifts
 // silently when Radar re-routes. `resourcePath` opens the detail drawer for any


### PR DESCRIPTION
## Summary
Part of **SKY-1070**. Two coordinated changes (OSS here; Radar Hub in a companion PR):

1. **Placement** — move the namespace switcher from the right utility group into a left **scope zone** next to the cluster switcher, as a lighter, trailing, **view-aware** chip. Cluster + namespace together answer "what am I looking at" (`kubectl --context X -n Y`), so they belong adjacent; the lighter weight signals a reversible view filter vs. a destructive context switch (no coequal `Cluster / Namespace` breadcrumb).
2. **View-awareness** — the chip is now **disabled with an explanation** on cluster-scoped surfaces where it was a dead control: the **Cost** view, **GitOps detail** trees, and **cluster-scoped resource kinds** (Nodes, PVs, ClusterRoles…). The active pick is preserved so it re-applies when you return to a namespaced view.
3. **Shared primitive** — extract the trigger+dropdown into a presentational `NamespacePicker` in `@skyhook-io/k8s-ui` (mirrors `ClusterSwitcher` — pure UI, data via props) and re-export it from `@skyhook-io/radar-app`. OSS's `NamespaceSwitcher` becomes a thin data container. This lets Radar Hub render an identical filter driving its own per-cluster scope.

## Why
The namespace filter is *persistent, cross-cutting scope* (it survives view navigation and is server-persisted per-user), unlike the per-view facets — so it deserves a single standard placement grouped with the other scope control (cluster), not buried among utility icons. And a single always-on chip is a dead control on ~half the views; making it view-aware is the honest encoding.

## Verification
- `make tsc` ✓ · `@skyhook-io/k8s-ui` tests **739 pass** ✓ · Go tests ✓ · frontend build ✓
- **Visual-test** (the flagged left-header width risk): no collision at **1280** or **1440** with the omnibar centered; picker opens/positions correctly from the new location; `[disabled]` confirmed on Cost.

## Follow-ups / notes
- **Release gate:** the companion Radar Hub PR needs `@skyhook-io/k8s-ui` + `@skyhook-io/radar-app` republished with the `NamespacePicker` export before it can build — standard cross-repo order (merge + publish here first).
- Deferred (own tickets): the GitOps **list** namespace filter still produces misleading empty lists; single-resource detail views (`workload`/`compare`) keep the chip enabled (inert, not misleading).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persistent namespace scope UX and header layout across views; behavior changes when users navigate to Cost/GitOps/cluster-scoped resources, and embedders depend on new k8s-ui exports.
> 
> **Overview**
> Moves the **namespace filter** from the header’s right utilities into a left **scope zone** beside the cluster switcher, grouped as one “what am I looking at” control.
> 
> Adds shared **`NamespacePicker`** and **`ScopePill`** in `@skyhook-io/k8s-ui` (plus **`segment`** variant on **`ClusterSwitcher`**). OSS **`NamespaceSwitcher`** becomes a thin wrapper over the picker; standalone Radar wraps cluster + namespace in **`ScopePill`**, while embedders can keep separate chips via **`contextSlot`**.
> 
> Introduces **view-aware disabling** for the namespace control on surfaces where filtering doesn’t apply (**Cost**, **GitOps detail**, cluster-scoped **Resources** kinds), with tooltips; the saved selection is kept for when users return to namespaced views.
> 
> **Header layout** tweaks for the nav-rail layout: fixed-width left column and equal flex columns so the centered omnibar doesn’t shift when cluster/namespace labels change; disconnected state uses a **clickable reconnect dot** instead of a separate refresh control.
> 
> Minor polish: toast/error text **`break-words`**, slightly narrower header omnibar (**`max-w-lg`**). Re-exports **`NamespacePicker`** / **`ScopePill`** from **`@skyhook-io/radar-app`** for Radar Hub parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02e77cc85870956aa22f8a3eed688ecec7a81e96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->