### PR TITLE
fix(toast): wrap detail text at word boundaries, not mid-word

### DIFF
--- a/packages/k8s-ui/src/components/ui/Toast.tsx
+++ b/packages/k8s-ui/src/components/ui/Toast.tsx
@@ -227,7 +227,7 @@ function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: () => void }
               {toast.detail}
             </button>
           ) : (
-            <p className={clsx('mt-1 text-xs break-all', isError ? 'text-red-300/80' : isSuccess ? 'text-emerald-300/80' : 'text-theme-text-secondary')}>
+            <p className={clsx('mt-1 text-xs break-words', isError ? 'text-red-300/80' : isSuccess ? 'text-emerald-300/80' : 'text-theme-text-secondary')}>
               {toast.detail}
             </p>
           )

--- a/web/src/components/ConnectionErrorView.tsx
+++ b/web/src/components/ConnectionErrorView.tsx
@@ -254,7 +254,7 @@ export function ConnectionErrorView({ connection, onRetry, isRetrying }: Connect
 
           {connection.error && (
             <div className="w-full bg-theme-elevated border border-theme-border rounded-lg p-3 mb-6 overflow-auto max-h-32">
-              <code className="text-xs text-red-400 font-mono whitespace-pre-wrap break-all">
+              <code className="text-xs text-red-400 font-mono whitespace-pre-wrap break-words">
                 {connection.error}
               </code>
             </div>


### PR DESCRIPTION
## Problem
Toast **detail** text wraps mid-word — e.g. a `Failed to switch context` error rendered `context deadline e` / `xceeded` on two lines.

## Cause
`packages/k8s-ui/src/components/ui/Toast.tsx` used `break-all` (`word-break: break-all`) on the detail `<p>`, which breaks between any two characters.

## Fix
Use `break-words` (`overflow-wrap: break-word`) so prose wraps at spaces and only breaks *inside* a word when a single token alone overflows the line. (The `<code>`/file-path affordances in the same component keep `break-all` — correct for long unbroken tokens.)

Drive-by fix, unrelated to the namespace-filter work (SKY-1070); kept on its own branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tailwind class-only presentation changes with no logic, API, or data handling impact.
> 
> **Overview**
> Fixes awkward line breaks in user-facing error and toast detail text by switching from **`break-all`** to **`break-words`** so wrapping prefers spaces and only splits inside a token when it would overflow.
> 
> **Toast** non-clickable **detail** paragraphs now use `break-words`; clickable file-path details and command blocks still use `break-all` for long unbroken strings. **Connection error** raw message display in `ConnectionErrorView` gets the same treatment; copyable auth commands stay on `break-all`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43e4a357318c8e9c2ba020164f4a862eef3934dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->