### PR TITLE
Diagnose: durable history, radar diagnose CLI, instant context

### DIFF
--- a/cmd/desktop/main.go
+++ b/cmd/desktop/main.go
@@ -117,6 +117,8 @@ func main() {
 		PrometheusHeadersFromEnv: fileCfg.PrometheusHeadersFromEnv,
 		Version:                  version,
 		MCPEnabled:               fileCfg.MCPEnabledOr(true),
+		AIHistory:                fileCfg.AIHistoryOr(true),
+		AIHistoryDBPath:          fileCfg.AIHistoryDBPath,
 	}
 
 	app.SetGlobals(cfg)

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -69,6 +69,8 @@ func main() {
 	timelineDBPath := flag.String("timeline-db", fileCfg.TimelineDBPath, "Path to timeline database file (default: ~/.radar/timeline.db)")
 	timelineRetention := flag.Duration("timeline-retention", fileCfg.TimelineRetentionOr(7*24*time.Hour), "How long to retain timeline events when --timeline-storage=sqlite (e.g. 168h, 720h). 0 disables age-based cleanup.")
 	timelineMaxSize := flag.String("timeline-max-size", fileCfg.TimelineMaxSizeOr("1Gi"), "Maximum SQLite timeline storage size before pruning oldest events (e.g. 800Mi, 8Gi). 0 disables size-based pruning.")
+	// AI history (Diagnose investigations)
+	aiHistory := flag.Bool("ai-history", fileCfg.AIHistoryOr(true), "Persist AI investigations (transcripts + verdicts) to ~/.radar/ai-runs.db so they survive restarts")
 	// Traffic/metrics options
 	prometheusURL := flag.String("prometheus-url", fileCfg.PrometheusURL, "Manual Prometheus/VictoriaMetrics URL (skips auto-discovery)")
 	// --prometheus-header Key=Value, repeatable. Defaults populated from
@@ -222,6 +224,8 @@ func main() {
 		PrometheusHeaders:        resolvedPrometheusHeaders,
 		PrometheusHeadersFromEnv: promHeadersFromEnv.value(),
 		MCPEnabled:               mcpEnabled,
+		AIHistory:                *aiHistory,
+		AIHistoryDBPath:          fileCfg.AIHistoryDBPath,
 		Version:                  version,
 		AuthConfig: auth.Config{
 			Mode:                      *authMode,

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/skyhook-io/radar/internal/auth"
 	"github.com/skyhook-io/radar/internal/cloud"
 	"github.com/skyhook-io/radar/internal/config"
+	"github.com/skyhook-io/radar/internal/diagnosecli"
 	"github.com/skyhook-io/radar/internal/k8s"
 	mcppkg "github.com/skyhook-io/radar/internal/mcp"
 	"github.com/skyhook-io/radar/internal/server"
@@ -32,6 +33,14 @@ var (
 )
 
 func main() {
+	// Subcommand dispatch (before flag parsing — subcommands own their flags).
+	// `radar diagnose <kind>/<name>` is a thin client for a RUNNING instance.
+	if len(os.Args) > 1 && os.Args[1] == "diagnose" {
+		os.Exit(diagnosecli.Run(os.Args[2:], func(url string) {
+			app.OpenBrowser(url, "")
+		}))
+	}
+
 	startupStart := time.Now()
 
 	// Propagate the build-time version to the cloud dialer so the agent

--- a/internal/ai/detect.go
+++ b/internal/ai/detect.go
@@ -37,6 +37,26 @@ func AgentLabel(name string) string {
 	return name
 }
 
+// EffectiveAgent resolves an agent pick exactly the way the server will at
+// Start (Diagnoser.AgentName + defName): the pick when it names a supported
+// agent, else the first supported one, else "". Pre-boot/remote clients must
+// derive consent surfaces from THIS — an empty pick can resolve to Cursor.
+func EffectiveAgent(pick string, agents []AgentInfo) string {
+	def := ""
+	for _, a := range agents {
+		if !a.Supported {
+			continue
+		}
+		if a.Name == pick {
+			return pick
+		}
+		if def == "" {
+			def = a.Name
+		}
+	}
+	return def
+}
+
 // ConsentSurfaceFor maps an agent to its consent-disclosure surface. Cursor's
 // trust model is materially different (its global MCP servers can't be
 // excluded), so it has its own; drift between enforcement sites would silently

--- a/internal/ai/detect.go
+++ b/internal/ai/detect.go
@@ -28,6 +28,26 @@ var agentLabels = map[string]string{
 	"claude": "Claude Code", "codex": "Codex", "gemini": "Gemini CLI", "cursor-agent": "Cursor Agent",
 }
 
+// AgentLabel is the display name for an agent CLI — the ONE table every
+// surface (API, CLI header, consent prompts) reads, so labels can't drift.
+func AgentLabel(name string) string {
+	if l, ok := agentLabels[name]; ok {
+		return l
+	}
+	return name
+}
+
+// ConsentSurfaceFor maps an agent to its consent-disclosure surface. Cursor's
+// trust model is materially different (its global MCP servers can't be
+// excluded), so it has its own; drift between enforcement sites would silently
+// mis-gate consent, so both the server and the CLI call this.
+func ConsentSurfaceFor(agent string) string {
+	if agent == "cursor-agent" {
+		return "cursor"
+	}
+	return "standard"
+}
+
 // supportedAgents are the CLIs we can drive today (have a stream-json parser).
 func isSupportedAgent(name string) bool {
 	for _, c := range agentCLICandidates {

--- a/internal/ai/detect_test.go
+++ b/internal/ai/detect_test.go
@@ -1,0 +1,28 @@
+package ai
+
+import "testing"
+
+func TestEffectiveAgentMatchesServerResolution(t *testing.T) {
+	agents := []AgentInfo{
+		{Name: "claude", Supported: false},
+		{Name: "cursor-agent", Supported: true},
+		{Name: "codex", Supported: true},
+	}
+	cases := []struct{ pick, want string }{
+		{"", "cursor-agent"},       // empty pick → first SUPPORTED, not first listed
+		{"codex", "codex"},         // supported pick honored
+		{"claude", "cursor-agent"}, // unsupported pick falls back like AgentName
+		{"nope", "cursor-agent"},   // unknown pick falls back
+	}
+	for _, c := range cases {
+		if got := EffectiveAgent(c.pick, agents); got != c.want {
+			t.Errorf("EffectiveAgent(%q) = %q, want %q", c.pick, got, c.want)
+		}
+	}
+	if got := EffectiveAgent("", nil); got != "" {
+		t.Errorf("no supported agents should resolve to \"\", got %q", got)
+	}
+	if ConsentSurfaceFor(EffectiveAgent("", agents)) != "cursor" {
+		t.Error("empty pick with Cursor as default must gate on the cursor surface")
+	}
+}

--- a/internal/ai/diagnoser.go
+++ b/internal/ai/diagnoser.go
@@ -510,7 +510,15 @@ func healthFrame(target string, health *ResourceHealthSignal) string {
 				fmt.Fprintf(&b, ": %s", health.TopFinding)
 			}
 		}
-		b.WriteString(". Treat audit findings as configuration risk, not proof of a live outage.")
+		b.WriteString(".")
+		for _, line := range health.AuditFindings {
+			fmt.Fprintf(&b, " [%s] %s", line.Severity, line.Reason)
+			if line.Message != "" {
+				fmt.Fprintf(&b, ": %s", line.Message)
+			}
+			b.WriteString(".")
+		}
+		b.WriteString(" Treat audit findings as configuration risk, not proof of a live outage.")
 	}
 	return b.String()
 }

--- a/internal/ai/diagnoser.go
+++ b/internal/ai/diagnoser.go
@@ -84,14 +84,26 @@ type Request struct {
 // ResourceHealthSignal is the compact server-side health frame captured when a
 // run starts. Issue fields describe live operational findings; audit fields are
 // static posture findings and should not be treated as proof of an outage.
+// Issues/AuditFindings carry the top actual rows (capped) — aggregates alone
+// read as vague in the UI and starve the prompt of detail Radar already has.
 type ResourceHealthSignal struct {
-	Health          string `json:"health,omitempty"`
-	IssueCount      int    `json:"issueCount,omitempty"`
-	HighestSeverity string `json:"highestSeverity,omitempty"`
-	TopReason       string `json:"topReason,omitempty"`
-	AuditCount      int    `json:"auditCount,omitempty"`
-	AuditSeverity   string `json:"auditSeverity,omitempty"`
-	TopFinding      string `json:"topFinding,omitempty"`
+	Health          string       `json:"health,omitempty"`
+	IssueCount      int          `json:"issueCount,omitempty"`
+	HighestSeverity string       `json:"highestSeverity,omitempty"`
+	TopReason       string       `json:"topReason,omitempty"`
+	Issues          []HealthLine `json:"issues,omitempty"`
+	AuditCount      int          `json:"auditCount,omitempty"`
+	AuditSeverity   string       `json:"auditSeverity,omitempty"`
+	TopFinding      string       `json:"topFinding,omitempty"`
+	AuditFindings   []HealthLine `json:"auditFindings,omitempty"`
+}
+
+// HealthLine is one concrete issue/finding row: what Radar's issue engine or
+// audit suite actually said, not just a count.
+type HealthLine struct {
+	Severity string `json:"severity,omitempty"`
+	Reason   string `json:"reason,omitempty"`  // issue Reason / audit CheckID
+	Message  string `json:"message,omitempty"` // human detail, capped
 }
 
 // Diagnosis is the engine's final result.
@@ -473,6 +485,13 @@ func healthFrame(target string, health *ResourceHealthSignal) string {
 			}
 		}
 		b.WriteString(".")
+		for _, line := range health.Issues {
+			fmt.Fprintf(&b, " [%s] %s", line.Severity, line.Reason)
+			if line.Message != "" {
+				fmt.Fprintf(&b, ": %s", line.Message)
+			}
+			b.WriteString(".")
+		}
 	case health.Health == "healthy":
 		fmt.Fprintf(&b, "Radar currently reports %s as healthy and flags 0 active issues.", target)
 	case health.Health != "":

--- a/internal/ai/runs.go
+++ b/internal/ai/runs.go
@@ -532,7 +532,14 @@ func (m *RunManager) OnContextSwitch() {
 		c := r.cancel
 		inFlight := r.inFlight
 		hydrated := r.hydrated
+		alreadyStale := r.status == "stale"
 		r.mu.Unlock()
+		// A second switch (A→B→C) must not re-terminalize an already-stale run:
+		// its log already ends in the closed sentinel, and appending after it
+		// would break the replay contract (durably, now that logs persist).
+		if alreadyStale {
+			continue
+		}
 		if !inFlight && !hydrated {
 			// Loaded, never-touched history: mark stale without paying to load
 			// its transcript (terminal markers get store-assigned seqs).
@@ -602,27 +609,53 @@ func (m *RunManager) sweepForeignLocked() {
 // (running) runs survive and are re-persisted so their rows aren't orphaned by
 // the wipe.
 func (m *RunManager) ClearHistory() error {
+	// Snapshot which runs survive (live) vs go (terminal) under the lock.
 	m.mu.Lock()
 	kept := make([]string, 0, len(m.order))
+	var dropped []string
 	for _, id := range m.order {
-		r := m.runs[id]
-		if r.snapshotStatus() == "running" {
+		if m.runs[id].snapshotStatus() == "running" {
 			kept = append(kept, id)
+		} else {
+			dropped = append(dropped, id)
+		}
+	}
+	m.mu.Unlock()
+
+	// Store FIRST, memory second: if the delete fails, the UI must keep showing
+	// the runs — dropping memory first would show "cleared" while a restart
+	// resurrects everything from the intact DB. One transaction deleting only
+	// the non-kept rows, so a crash mid-clear can't lose a live investigation.
+	if m.store != nil {
+		if err := m.store.Clear(kept); err != nil {
+			return err
+		}
+	}
+
+	m.mu.Lock()
+	for _, id := range dropped {
+		r, ok := m.runs[id]
+		if !ok {
 			continue
 		}
 		delete(m.runs, id)
+		// Detach the store before finalizing: the run's rows were just deleted,
+		// and finalize's persisted closed-sentinel would re-create them.
+		r.mu.Lock()
+		r.store = nil
+		r.mu.Unlock()
 		r.finalize()
 		r.removeWorkDir()
 	}
-	m.order = kept
-	m.mu.Unlock()
-
-	if m.store == nil {
-		return nil
+	order := make([]string, 0, len(m.order))
+	for _, id := range m.order {
+		if _, ok := m.runs[id]; ok {
+			order = append(order, id)
+		}
 	}
-	// One transaction, deleting only the non-kept rows — a crash mid-clear can
-	// never lose a live investigation the user was told would survive.
-	return m.store.Clear(kept)
+	m.order = order
+	m.mu.Unlock()
+	return nil
 }
 
 // evictLocked drops the oldest finished run when over the retention cap. Running

--- a/internal/ai/runs.go
+++ b/internal/ai/runs.go
@@ -2,12 +2,13 @@ package ai
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -49,10 +50,9 @@ type RunManager struct {
 	mu            sync.Mutex
 	runs          map[string]*Run
 	order         []string // insertion order, for eviction
-	nextID        int
-	maxRetained   int    // total runs kept in memory (running + finished)
-	maxConcurrent int    // concurrent IN-FLIGHT turns (= live agent processes)
-	sweptCtx      string // last kube-context the loaded-run staleness sweep ran for
+	maxRetained   int      // total runs kept in memory (running + finished)
+	maxConcurrent int      // concurrent IN-FLIGHT turns (= live agent processes)
+	sweptCtx      string   // last kube-context the loaded-run staleness sweep ran for
 	// historyUnavailable marks that persistence was requested but is broken
 	// (store failed to open, or its existing contents couldn't be loaded) — the
 	// UI must say history won't survive a restart instead of implying it will.
@@ -203,7 +203,9 @@ func NewRunManager(d *Diagnoser, mcpPort func() int, ctxLabel func() string, sto
 //   - Cursor sessions are workspace-scoped and the workspace was a process-
 //     lifetime temp dir → drop the sessionID so follow-ups report "no session"
 //     instead of spawning an agent guaranteed to fail;
-//   - nextID reseeds past every persisted id so new runs can't collide.
+//   - run ids are random (newRunID), so ids can't collide across processes
+//     sharing the history DB (an ephemeral `radar diagnose --standalone` next
+//     to a long-running instance) or across restarts.
 func (m *RunManager) loadPersisted() {
 	if m.store == nil {
 		return
@@ -224,9 +226,6 @@ func (m *RunManager) loadPersisted() {
 	for _, s := range sums {
 		if s.ID == "" {
 			continue
-		}
-		if n := runIDNum(s.ID); n > m.nextID {
-			m.nextID = n
 		}
 		if s.UpdatedAt.Before(cutoff) {
 			m.store.DeleteRun(s.ID) // age-based retention
@@ -267,13 +266,19 @@ func (m *RunManager) loadPersisted() {
 	m.evictLocked() // the retention cap may have shrunk since the DB was written
 }
 
-// runIDNum extracts N from "run-N" ids ( 0 for anything else).
-func runIDNum(id string) int {
-	n, err := strconv.Atoi(strings.TrimPrefix(id, "run-"))
-	if err != nil {
-		return 0
+// newRunID mints a process-independent id. Random (not a counter) because
+// several processes can share the history DB — an ephemeral standalone run
+// minting counter ids next to a long-running instance would collide and
+// INSERT OR REPLACE another investigation's transcript.
+func newRunID() string {
+	var b [5]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// Fallback keeps ids unique within this process; collision across
+		// processes needs the same nanosecond, which the entropy above exists
+		// to avoid anyway.
+		return fmt.Sprintf("run-%d", time.Now().UnixNano())
 	}
-	return n
+	return "run-" + hex.EncodeToString(b[:])
 }
 
 // runWorkDir is the per-run scratch dir under the manager's private root — stable
@@ -401,8 +406,7 @@ func (m *RunManager) Start(kind, namespace, name, agent string, isolated bool, m
 		m.mu.Unlock()
 		return RunSummary{}, ErrAtCapacity
 	}
-	m.nextID++
-	id := fmt.Sprintf("run-%d", m.nextID)
+	id := newRunID()
 	r := &Run{
 		ID: id, Kind: kind, Namespace: namespace,
 		Name: name, Context: cur, Agent: agent, WorkDir: m.runWorkDir(id), Isolated: isolated,
@@ -469,7 +473,16 @@ func (m *RunManager) launchTurn(r *Run, question string, apply bool, fix, sessio
 			Question: question, Apply: apply, Fix: fix,
 			Agent: r.Agent, Isolated: r.Isolated, Model: r.Model, Effort: r.Effort,
 			Health: r.Health, WorkDir: r.WorkDir,
-		}, func(ev StreamEvent) { r.append(ev) })
+		}, func(ev StreamEvent) {
+			// The agent can keep streaming briefly after Stop/context-switch
+			// cancel it (process-group kill has a WaitDelay). Those events must
+			// not land after the terminal marker — replay ordering is the
+			// contract every subscriber rebuilds from.
+			if st := r.snapshotStatus(); st == "stopped" || st == "stale" {
+				return
+			}
+			r.append(ev)
+		})
 
 		r.mu.Lock()
 		r.inFlight = false
@@ -780,11 +793,19 @@ func (r *Run) ensureHydrated() bool {
 		return false
 	}
 	r.mu.Lock()
-	if !r.hydrated {
-		r.events = events
-		r.hydrated = true
+	defer r.mu.Unlock()
+	if r.hydrated {
+		return true
 	}
-	r.mu.Unlock()
+	// If the run was finalized while we were loading (a context switch marked it
+	// stale and enqueued its terminal markers), the snapshot we hold predates
+	// them. Installing it would freeze a short prefix forever — stay
+	// un-hydrated so the next touch reloads through the writer barrier.
+	if r.subs == nil && (len(events) == 0 || events[len(events)-1].Event.Type != "closed") {
+		return false
+	}
+	r.events = events
+	r.hydrated = true
 	return true
 }
 
@@ -824,7 +845,10 @@ func (r *Run) markStale() {
 		r.store.AppendEvent(r.ID, closed, &sum)
 		return
 	}
-	r.store.AppendEvent(r.ID, RunEvent{Event: StreamEvent{Type: "error", Error: "Cluster context changed — this investigation was about a different cluster."}}, nil)
+	// The stale status rides BOTH events: if the second write is lost, the DB
+	// must never show a non-terminal status over a log that already carries the
+	// cluster-change marker.
+	r.store.AppendEvent(r.ID, RunEvent{Event: StreamEvent{Type: "error", Error: "Cluster context changed — this investigation was about a different cluster."}}, &sum)
 	r.store.AppendEvent(r.ID, RunEvent{Event: StreamEvent{Type: "closed"}}, &sum)
 }
 

--- a/internal/ai/runs.go
+++ b/internal/ai/runs.go
@@ -53,6 +53,10 @@ type RunManager struct {
 	maxRetained   int    // total runs kept in memory (running + finished)
 	maxConcurrent int    // concurrent IN-FLIGHT turns (= live agent processes)
 	sweptCtx      string // last kube-context the loaded-run staleness sweep ran for
+	// historyUnavailable marks that persistence was requested but is broken
+	// (store failed to open, or its existing contents couldn't be loaded) — the
+	// UI must say history won't survive a restart instead of implying it will.
+	historyUnavailable bool
 }
 
 // Run is one investigation: identity, status, the agent session to resume, and the
@@ -202,7 +206,13 @@ func (m *RunManager) loadPersisted() {
 	}
 	sums, err := m.store.LoadRuns()
 	if err != nil {
-		log.Printf("[ai] could not load run history: %v", err)
+		// Refusing the store entirely is the only safe response: with the
+		// existing contents unknown, new runs would mint colliding run-N ids and
+		// INSERT OR REPLACE would overwrite the stored transcripts.
+		log.Printf("[ai] could not load run history — running memory-only to protect it: %v", err)
+		m.store.Close()
+		m.store = nil
+		m.historyUnavailable = true
 		return
 	}
 	cutoff := nowUTC().Add(-defaultHistoryAge)
@@ -581,10 +591,23 @@ func (m *RunManager) List() []RunSummary {
 	return out
 }
 
-// HistoryDegraded reports that run persistence stopped working — history will
-// not survive a restart. Surfaced on the runs-list response so the UI can say so.
+// HistoryDegraded reports that run persistence isn't working — history will
+// not survive a restart. Surfaced on the runs-list response so the UI can say
+// so. True when the store broke mid-flight (write failures) OR never became
+// usable (open/load failure with persistence requested).
 func (m *RunManager) HistoryDegraded() bool {
-	return m.store != nil && m.store.Degraded()
+	m.mu.Lock()
+	unavailable := m.historyUnavailable
+	m.mu.Unlock()
+	return unavailable || (m.store != nil && m.store.Degraded())
+}
+
+// MarkHistoryUnavailable records that persistence was requested but couldn't be
+// set up (e.g. the DB failed to open) so the UI can surface it.
+func (m *RunManager) MarkHistoryUnavailable() {
+	m.mu.Lock()
+	m.historyUnavailable = true
+	m.mu.Unlock()
 }
 
 // sweepForeignLocked marks runs loaded from a PREVIOUS process against a

--- a/internal/ai/runs.go
+++ b/internal/ai/runs.go
@@ -853,6 +853,24 @@ func (r *Run) markStale() {
 	r.updatedAt = nowUTC()
 	sum := r.summaryLocked()
 	hydrated := r.hydrated
+	// Deliver the terminal pair to live subscribers BEFORE closing their
+	// channels (finalize's pattern) — an abrupt close forces an EventSource
+	// reconnect round-trip instead of a clean terminal replay. Sequence
+	// numbers: continue the in-memory log for hydrated runs; the unhydrated
+	// case has no subscribers to speak of (Subscribe hydrates first), so the
+	// in-flight delivery uses provisional seqs and the STORE keeps the
+	// authoritative ones.
+	staleEv := StreamEvent{Type: "error", Error: "Cluster context changed — this investigation was about a different cluster."}
+	closedEv := StreamEvent{Type: "closed"}
+	for i, ev := range []StreamEvent{staleEv, closedEv} {
+		re := RunEvent{Seq: len(r.events) + 1 + i, Event: ev}
+		for _, ch := range r.subs {
+			select {
+			case ch <- re:
+			default:
+			}
+		}
+	}
 	for id, ch := range r.subs {
 		delete(r.subs, id)
 		close(ch)
@@ -866,8 +884,8 @@ func (r *Run) markStale() {
 		// The in-memory log is authoritative — persist with explicit seqs so
 		// memory and store stay aligned.
 		r.mu.Lock()
-		stale := RunEvent{Seq: len(r.events) + 1, Event: StreamEvent{Type: "error", Error: "Cluster context changed — this investigation was about a different cluster."}}
-		closed := RunEvent{Seq: len(r.events) + 2, Event: StreamEvent{Type: "closed"}}
+		stale := RunEvent{Seq: len(r.events) + 1, Event: staleEv}
+		closed := RunEvent{Seq: len(r.events) + 2, Event: closedEv}
 		r.events = append(r.events, stale, closed)
 		r.mu.Unlock()
 		r.store.AppendEvent(r.ID, stale, nil)
@@ -877,8 +895,8 @@ func (r *Run) markStale() {
 	// The stale status rides BOTH events: if the second write is lost, the DB
 	// must never show a non-terminal status over a log that already carries the
 	// cluster-change marker.
-	r.store.AppendEvent(r.ID, RunEvent{Event: StreamEvent{Type: "error", Error: "Cluster context changed — this investigation was about a different cluster."}}, &sum)
-	r.store.AppendEvent(r.ID, RunEvent{Event: StreamEvent{Type: "closed"}}, &sum)
+	r.store.AppendEvent(r.ID, RunEvent{Event: staleEv}, &sum)
+	r.store.AppendEvent(r.ID, RunEvent{Event: closedEv}, &sum)
 }
 
 // matchesTarget reports whether r is the same investigation as a Start request —

--- a/internal/ai/runs.go
+++ b/internal/ai/runs.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -40,12 +41,17 @@ type RunManager struct {
 	// its own temp workspace per turn, losing cross-turn resume but staying correct).
 	workRoot string
 
+	// store persists runs + event logs across restarts (nil = memory-only,
+	// the historical behavior). Owned here: Shutdown closes it.
+	store RunStore
+
 	mu            sync.Mutex
 	runs          map[string]*Run
 	order         []string // insertion order, for eviction
 	nextID        int
-	maxRetained   int // total runs kept in memory (running + finished)
-	maxConcurrent int // concurrent IN-FLIGHT turns (= live agent processes)
+	maxRetained   int    // total runs kept in memory (running + finished)
+	maxConcurrent int    // concurrent IN-FLIGHT turns (= live agent processes)
+	sweptCtx      string // last kube-context the loaded-run staleness sweep ran for
 }
 
 // Run is one investigation: identity, status, the agent session to resume, and the
@@ -65,16 +71,24 @@ type Run struct {
 	Health    *ResourceHealthSignal
 	CreatedAt time.Time
 
+	// store mirrors RunManager.store (nil = memory-only) so the event hot path
+	// can persist without reaching back to the manager.
+	store RunStore
+
 	mu        sync.Mutex
 	status    string // running | done | error | stopped | stale
 	sessionID string
 	preview   string // last root cause, for the list
 	updatedAt time.Time
 	events    []RunEvent
-	inFlight  bool
-	subs      map[int]chan RunEvent
-	nextSub   int
-	cancel    context.CancelFunc
+	// hydrated marks that r.events holds the run's full log. Runs created live
+	// are born hydrated; runs loaded from the store hydrate lazily on first
+	// read/mutation (ensureHydrated) so startup doesn't pay for old transcripts.
+	hydrated bool
+	inFlight bool
+	subs     map[int]chan RunEvent
+	nextSub  int
+	cancel   context.CancelFunc
 }
 
 // RunEvent is a sequenced stream event. Seq drives SSE id: / Last-Event-ID replay.
@@ -118,8 +132,12 @@ var (
 )
 
 const (
-	defaultMaxConcurrent = 3  // running child processes
-	defaultMaxRetained   = 20 // total runs kept in memory
+	defaultMaxConcurrent = 3   // running child processes
+	defaultMaxRetained   = 100 // total runs kept (memory rows + store)
+
+	// defaultHistoryAge is how long finished runs are kept in the store; older
+	// ones are dropped at startup. Count-based eviction still applies first.
+	defaultHistoryAge = 30 * 24 * time.Hour
 
 	// defaultTurnTimeout bounds one agent turn's wall-clock time. Generous — a
 	// deep multi-tool investigation runs minutes, not tens of minutes — while
@@ -140,7 +158,9 @@ func turnTimeout() time.Duration {
 
 // NewRunManager builds a manager over a resolved Diagnoser. mcpPort/ctxLabel are
 // callbacks because the listener port and kube-context are only known at runtime.
-func NewRunManager(d *Diagnoser, mcpPort func() int, ctxLabel func() string) *RunManager {
+// store persists history across restarts (nil = memory-only); persisted runs are
+// hydrated into the manager here.
+func NewRunManager(d *Diagnoser, mcpPort func() int, ctxLabel func() string, store RunStore) *RunManager {
 	ctx, cancel := context.WithCancel(context.Background())
 	// Best-effort: a failure here just means runs get no shared workdir (logged).
 	root, err := os.MkdirTemp("", "radar-ai-")
@@ -148,17 +168,93 @@ func NewRunManager(d *Diagnoser, mcpPort func() int, ctxLabel func() string) *Ru
 		log.Printf("[ai] could not create AI scratch root: %v (Cursor resume will be degraded)", err)
 		root = ""
 	}
-	return &RunManager{
+	m := &RunManager{
 		d:             d,
 		mcpPort:       mcpPort,
 		ctxLabel:      ctxLabel,
 		baseCtx:       ctx,
 		baseCancel:    cancel,
 		workRoot:      root,
+		store:         store,
 		runs:          map[string]*Run{},
 		maxRetained:   defaultMaxRetained,
 		maxConcurrent: defaultMaxConcurrent,
 	}
+	m.loadPersisted()
+	return m
+}
+
+// loadPersisted hydrates run ROWS from the store (event logs stay lazy — see
+// ensureHydrated) and normalizes state that can't carry across a process:
+//   - a persisted "running" run was interrupted by the restart → error, with a
+//     terminal event appended so replay still ends in a terminal marker;
+//   - Cursor sessions are workspace-scoped and the workspace was a process-
+//     lifetime temp dir → drop the sessionID so follow-ups report "no session"
+//     instead of spawning an agent guaranteed to fail;
+//   - nextID reseeds past every persisted id so new runs can't collide.
+func (m *RunManager) loadPersisted() {
+	if m.store == nil {
+		return
+	}
+	sums, err := m.store.LoadRuns()
+	if err != nil {
+		log.Printf("[ai] could not load run history: %v", err)
+		return
+	}
+	cutoff := nowUTC().Add(-defaultHistoryAge)
+	for _, s := range sums {
+		if s.ID == "" {
+			continue
+		}
+		if n := runIDNum(s.ID); n > m.nextID {
+			m.nextID = n
+		}
+		if s.UpdatedAt.Before(cutoff) {
+			m.store.DeleteRun(s.ID) // age-based retention
+			continue
+		}
+		if s.Agent == "cursor-agent" {
+			s.SessionID = ""
+		}
+		r := &Run{
+			ID: s.ID, Kind: s.Kind, Namespace: s.Namespace, Name: s.Name,
+			Context: s.Context, Agent: s.Agent, Isolated: s.Isolated,
+			Model: s.Model, Effort: s.Effort, ManagedBy: s.ManagedBy,
+			Health: s.Health, CreatedAt: s.CreatedAt,
+			store:  m.store,
+			status: s.Status, sessionID: s.SessionID, preview: s.Preview,
+			updatedAt: s.UpdatedAt,
+			subs:      map[int]chan RunEvent{},
+		}
+		if s.Status == "running" {
+			// Interrupted by the restart. Terminal statuses are written in the
+			// same transaction as their terminal event, so a "running" row means
+			// the log has no terminal marker yet — append one (store-assigned
+			// seq; the in-memory log stays lazy).
+			r.status = "error"
+			r.updatedAt = nowUTC()
+			sum := r.summaryLocked()
+			m.store.AppendEvent(r.ID, RunEvent{Event: StreamEvent{
+				Type:  "error",
+				Error: "Radar restarted while this investigation was running. Re-run Diagnose to analyze the current cluster.",
+			}}, &sum)
+		}
+		if r.status == "stale" {
+			r.subs = nil // stale runs were finalized — streams replay then close
+		}
+		m.runs[r.ID] = r
+		m.order = append(m.order, r.ID)
+	}
+	m.evictLocked() // the retention cap may have shrunk since the DB was written
+}
+
+// runIDNum extracts N from "run-N" ids ( 0 for anything else).
+func runIDNum(id string) int {
+	n, err := strconv.Atoi(strings.TrimPrefix(id, "run-"))
+	if err != nil {
+		return 0
+	}
+	return n
 }
 
 // runWorkDir is the per-run scratch dir under the manager's private root — stable
@@ -172,9 +268,11 @@ func (m *RunManager) runWorkDir(id string) string {
 }
 
 // Shutdown cancels every run (killing agent child processes) — called on server
-// stop so local agents don't outlive radar.
+// stop so local agents don't outlive radar. In-flight runs are marked stopped
+// BEFORE their contexts are cancelled so the run goroutines' terminal-status
+// guard keeps them from persisting a spurious "context canceled" error; the
+// store then drains and closes, and anything appended after that is a no-op.
 func (m *RunManager) Shutdown() {
-	m.baseCancel()
 	m.mu.Lock()
 	runs := make([]*Run, 0, len(m.runs))
 	for _, r := range m.runs {
@@ -183,11 +281,22 @@ func (m *RunManager) Shutdown() {
 	m.mu.Unlock()
 	for _, r := range runs {
 		r.mu.Lock()
+		if r.inFlight {
+			r.status = "stopped"
+			r.updatedAt = nowUTC()
+			if r.store != nil {
+				r.store.SaveRun(r.summaryLocked())
+			}
+		}
 		c := r.cancel
 		r.mu.Unlock()
 		if c != nil {
 			c()
 		}
+	}
+	m.baseCancel()
+	if m.store != nil {
+		m.store.Close()
 	}
 	// Drop every run's scratch in one shot — the process is going away.
 	if m.workRoot != "" {
@@ -269,13 +378,18 @@ func (m *RunManager) Start(kind, namespace, name, agent string, isolated bool, m
 		ID: id, Kind: kind, Namespace: namespace,
 		Name: name, Context: cur, Agent: agent, WorkDir: m.runWorkDir(id), Isolated: isolated,
 		Model: model, Effort: effort, ManagedBy: managedBy, Health: health, CreatedAt: nowUTC(),
+		store:  m.store,
 		status: "running", inFlight: true, updatedAt: nowUTC(),
-		subs: map[int]chan RunEvent{},
+		hydrated: true, // born live — its full log is in memory by construction
+		subs:     map[int]chan RunEvent{},
 	}
 	m.runs[r.ID] = r
 	m.order = append(m.order, r.ID)
 	m.evictLocked()
 	m.mu.Unlock()
+	if m.store != nil {
+		m.store.SaveRun(r.Summary())
+	}
 
 	m.launchTurn(r, "", false, "", "")
 	return r.Summary(), nil
@@ -288,6 +402,9 @@ func (m *RunManager) AddTurn(id, question string, apply bool, fix string) error 
 	if r == nil {
 		return ErrRunNotFound
 	}
+	// A follow-up on a run loaded from history must extend the PERSISTED log —
+	// hydrate before beginTurn so the new turn's sequence numbers continue it.
+	r.ensureHydrated()
 	session, err := m.beginTurn(r, true)
 	if err != nil {
 		return err
@@ -364,6 +481,7 @@ func (m *RunManager) Stop(id string) error {
 	if r == nil {
 		return ErrRunNotFound
 	}
+	r.ensureHydrated() // an in-flight run is always hydrated; harmless otherwise
 	r.mu.Lock()
 	if !r.inFlight {
 		r.mu.Unlock()
@@ -392,6 +510,17 @@ func (m *RunManager) OnContextSwitch() {
 	for _, r := range runs {
 		r.mu.Lock()
 		c := r.cancel
+		inFlight := r.inFlight
+		hydrated := r.hydrated
+		r.mu.Unlock()
+		if !inFlight && !hydrated {
+			// Loaded, never-touched history: mark stale without paying to load
+			// its transcript (terminal markers get store-assigned seqs).
+			r.markStale()
+			r.removeWorkDir()
+			continue
+		}
+		r.mu.Lock()
 		r.status = "stale"
 		r.mu.Unlock()
 		if c != nil {
@@ -409,6 +538,7 @@ func (m *RunManager) Get(id string) *Run { return m.get(id) }
 func (m *RunManager) get(id string) *Run {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.sweepForeignLocked()
 	return m.runs[id]
 }
 
@@ -416,11 +546,78 @@ func (m *RunManager) get(id string) *Run {
 func (m *RunManager) List() []RunSummary {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.sweepForeignLocked()
 	out := make([]RunSummary, 0, len(m.order))
 	for i := len(m.order) - 1; i >= 0; i-- {
 		out = append(out, m.runs[m.order[i]].Summary())
 	}
 	return out
+}
+
+// HistoryDegraded reports that run persistence stopped working — history will
+// not survive a restart. Surfaced on the runs-list response so the UI can say so.
+func (m *RunManager) HistoryDegraded() bool {
+	return m.store != nil && m.store.Degraded()
+}
+
+// sweepForeignLocked marks runs loaded from a PREVIOUS process against a
+// different kube-context as stale — the same treatment OnContextSwitch gives
+// live runs when the context changes under them. Runs once per observed context
+// label; the label callback resolves only after the cluster connects, which is
+// why this can't happen at load time. Caller holds m.mu.
+func (m *RunManager) sweepForeignLocked() {
+	cur := m.ctx()
+	if cur == "" || cur == m.sweptCtx {
+		return
+	}
+	m.sweptCtx = cur
+	for _, r := range m.runs {
+		if r.Context != cur {
+			r.markStale()
+		}
+	}
+}
+
+// ClearHistory drops every terminal run from memory and the store. Live
+// (running) runs survive and are re-persisted so their rows aren't orphaned by
+// the wipe.
+func (m *RunManager) ClearHistory() error {
+	m.mu.Lock()
+	kept := make([]string, 0, len(m.order))
+	var keptRuns []*Run
+	for _, id := range m.order {
+		r := m.runs[id]
+		if r.snapshotStatus() == "running" {
+			kept = append(kept, id)
+			keptRuns = append(keptRuns, r)
+			continue
+		}
+		delete(m.runs, id)
+		r.finalize()
+		r.removeWorkDir()
+	}
+	m.order = kept
+	m.mu.Unlock()
+
+	if m.store == nil {
+		return nil
+	}
+	if err := m.store.Clear(); err != nil {
+		return err
+	}
+	// Re-persist the survivors: their summary rows and any events already in
+	// memory (live runs are always hydrated, so this is the complete log).
+	for _, r := range keptRuns {
+		r.mu.Lock()
+		sum := r.summaryLocked()
+		events := append([]RunEvent(nil), r.events...)
+		r.mu.Unlock()
+		m.store.SaveRun(sum)
+		for _, e := range events {
+			m.store.AppendEvent(r.ID, e, nil)
+		}
+	}
+	return nil
 }
 
 // evictLocked drops the oldest finished run when over the retention cap. Running
@@ -443,6 +640,9 @@ func (m *RunManager) evictLocked() {
 		m.order = append(m.order[:idx], m.order[idx+1:]...)
 		victim.finalize()
 		victim.removeWorkDir() // best-effort: drop the evicted run's scratch dir
+		if m.store != nil {
+			m.store.DeleteRun(id)
+		}
 	}
 }
 
@@ -458,6 +658,12 @@ func (r *Run) removeWorkDir() {
 func (r *Run) Summary() RunSummary {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	return r.summaryLocked()
+}
+
+// summaryLocked builds the snapshot; the caller holds r.mu (or has exclusive
+// access to a not-yet-shared run).
+func (r *Run) summaryLocked() RunSummary {
 	return RunSummary{
 		ID: r.ID, Kind: r.Kind, Namespace: r.Namespace, Name: r.Name,
 		Context: r.Context, Agent: r.Agent, Isolated: r.Isolated,
@@ -466,6 +672,74 @@ func (r *Run) Summary() RunSummary {
 		Status: r.status, SessionID: r.sessionID,
 		Preview: r.preview, CreatedAt: r.CreatedAt, UpdatedAt: r.updatedAt,
 	}
+}
+
+// ensureHydrated loads the run's event log from the store on first touch. Every
+// path that reads or extends the log (Subscribe, follow-up turns, Stop) calls it
+// first, so sequence numbers always continue from the persisted log. Idempotent
+// and safe under concurrency: a racing second load just re-installs the same
+// immutable prefix before either appends.
+func (r *Run) ensureHydrated() {
+	if r.store == nil {
+		return
+	}
+	r.mu.Lock()
+	if r.hydrated {
+		r.mu.Unlock()
+		return
+	}
+	r.mu.Unlock()
+	events, err := r.store.LoadEvents(r.ID) // outside r.mu — a DB read may wait on the writer
+	r.mu.Lock()
+	if !r.hydrated {
+		if err != nil {
+			log.Printf("[ai] could not load transcript for %s: %v", r.ID, err)
+		} else {
+			r.events = events
+		}
+		r.hydrated = true
+	}
+	r.mu.Unlock()
+}
+
+// markStale flips a non-running run to stale and finalizes its stream without
+// requiring hydration: the terminal error + closed markers are appended in the
+// STORE with store-assigned sequence numbers, and the in-memory log stays lazy —
+// the next Subscribe hydrates and replays them. Used for runs loaded from a
+// previous process whose kube-context no longer matches.
+func (r *Run) markStale() {
+	r.mu.Lock()
+	if r.status == "stale" || r.inFlight {
+		r.mu.Unlock()
+		return
+	}
+	r.status = "stale"
+	r.updatedAt = nowUTC()
+	sum := r.summaryLocked()
+	hydrated := r.hydrated
+	for id, ch := range r.subs {
+		delete(r.subs, id)
+		close(ch)
+	}
+	r.subs = nil
+	r.mu.Unlock()
+	if r.store == nil {
+		return
+	}
+	if hydrated {
+		// The in-memory log is authoritative — persist with explicit seqs so
+		// memory and store stay aligned.
+		r.mu.Lock()
+		stale := RunEvent{Seq: len(r.events) + 1, Event: StreamEvent{Type: "error", Error: "Cluster context changed — this investigation was about a different cluster."}}
+		closed := RunEvent{Seq: len(r.events) + 2, Event: StreamEvent{Type: "closed"}}
+		r.events = append(r.events, stale, closed)
+		r.mu.Unlock()
+		r.store.AppendEvent(r.ID, stale, nil)
+		r.store.AppendEvent(r.ID, closed, &sum)
+		return
+	}
+	r.store.AppendEvent(r.ID, RunEvent{Event: StreamEvent{Type: "error", Error: "Cluster context changed — this investigation was about a different cluster."}}, nil)
+	r.store.AppendEvent(r.ID, RunEvent{Event: StreamEvent{Type: "closed"}}, &sum)
 }
 
 // matchesTarget reports whether r is the same investigation as a Start request —
@@ -488,6 +762,7 @@ func (r *Run) snapshotStatus() string {
 // The channel is closed only when the run is finalized (stale/evicted) — NOT when
 // a turn completes, so the same subscription sees later turns.
 func (r *Run) Subscribe(afterSeq int) (backlog []RunEvent, ch <-chan RunEvent, cancel func()) {
+	r.ensureHydrated() // a run loaded from history replays its persisted transcript
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for _, e := range r.events {
@@ -515,11 +790,23 @@ func (r *Run) Subscribe(afterSeq int) (backlog []RunEvent, ch <-chan RunEvent, c
 
 // append records an event and fans it out non-blockingly. A subscriber whose buffer
 // is full is dropped (it reconnects with Last-Event-ID to replay).
+// Persistence rides along: the event is enqueued to the store under r.mu (enqueue
+// never blocks), and TERMINAL events ("done"/"error") carry the run's summary so
+// the status column and its terminal event commit in one transaction — crash
+// recovery can then trust that a "running" row has no terminal marker.
 func (r *Run) append(ev StreamEvent) {
 	r.mu.Lock()
 	re := RunEvent{Seq: len(r.events) + 1, Event: ev}
 	r.events = append(r.events, re)
 	r.updatedAt = nowUTC()
+	if r.store != nil {
+		var sum *RunSummary
+		if ev.Type == "done" || ev.Type == "error" {
+			s := r.summaryLocked()
+			sum = &s
+		}
+		r.store.AppendEvent(r.ID, re, sum)
+	}
 	for id, ch := range r.subs {
 		select {
 		case ch <- re:
@@ -545,6 +832,12 @@ func (r *Run) finalize() {
 	re := RunEvent{Seq: len(r.events) + 1, Event: StreamEvent{Type: "closed"}}
 	r.events = append(r.events, re)
 	r.updatedAt = nowUTC()
+	if r.store != nil && r.hydrated {
+		// Unhydrated finalize only happens on eviction, where the rows are
+		// deleted right after — persisting a wrong-seq sentinel would be noise.
+		sum := r.summaryLocked()
+		r.store.AppendEvent(r.ID, re, &sum)
+	}
 	for id, ch := range r.subs {
 		select {
 		case ch <- re:

--- a/internal/ai/runs.go
+++ b/internal/ai/runs.go
@@ -57,6 +57,10 @@ type RunManager struct {
 	// (store failed to open, or its existing contents couldn't be loaded) — the
 	// UI must say history won't survive a restart instead of implying it will.
 	historyUnavailable bool
+	// brokenDBPath is the unusable history DB's location. Kept so ClearHistory
+	// can still honor the user's intent by removing the files — otherwise a
+	// later healthy startup would resurrect investigations they "cleared".
+	brokenDBPath string
 }
 
 // Run is one investigation: identity, status, the agent session to resume, and the
@@ -210,6 +214,7 @@ func (m *RunManager) loadPersisted() {
 		// existing contents unknown, new runs would mint colliding run-N ids and
 		// INSERT OR REPLACE would overwrite the stored transcripts.
 		log.Printf("[ai] could not load run history — running memory-only to protect it: %v", err)
+		m.brokenDBPath = m.store.Path()
 		m.store.Close()
 		m.store = nil
 		m.historyUnavailable = true
@@ -603,10 +608,12 @@ func (m *RunManager) HistoryDegraded() bool {
 }
 
 // MarkHistoryUnavailable records that persistence was requested but couldn't be
-// set up (e.g. the DB failed to open) so the UI can surface it.
-func (m *RunManager) MarkHistoryUnavailable() {
+// set up (the DB at dbPath failed to open) so the UI can surface it — and so
+// ClearHistory can still remove the files.
+func (m *RunManager) MarkHistoryUnavailable(dbPath string) {
 	m.mu.Lock()
 	m.historyUnavailable = true
+	m.brokenDBPath = dbPath
 	m.mu.Unlock()
 }
 
@@ -652,6 +659,19 @@ func (m *RunManager) ClearHistory() error {
 	if m.store != nil {
 		if err := m.store.Clear(kept); err != nil {
 			return err
+		}
+	}
+	// A broken (detached) history DB still holds investigations on disk — a
+	// later healthy startup would resurrect what the user just "cleared".
+	// Removing the files IS the recovery for an unopenable/unloadable DB.
+	m.mu.Lock()
+	broken := m.brokenDBPath
+	m.mu.Unlock()
+	if broken != "" {
+		for _, f := range []string{broken, broken + "-wal", broken + "-shm"} {
+			if err := os.Remove(f); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("history DB is unusable and couldn't be removed: %w", err)
+			}
 		}
 	}
 

--- a/internal/ai/runs.go
+++ b/internal/ai/runs.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -79,6 +80,10 @@ type Run struct {
 	ManagedBy string // immutable — GitOps/Helm owner of the target ("" = none), for the Apply warning
 	Health    *ResourceHealthSignal
 	CreatedAt time.Time
+	// OwnerPID is the process that owns this run's lifecycle. Persisted so a
+	// second process sharing the history DB (standalone beside a long-running
+	// instance) can tell a LIVE foreign run from one orphaned by a crash.
+	OwnerPID int
 
 	// store mirrors RunManager.store (nil = memory-only) so the event hot path
 	// can persist without reaching back to the manager.
@@ -121,6 +126,7 @@ type RunSummary struct {
 	Health    *ResourceHealthSignal `json:"health,omitempty"`
 	Status    string                `json:"status"`
 	SessionID string                `json:"sessionId,omitempty"`
+	OwnerPID  int                   `json:"ownerPid,omitempty"`
 	Preview   string                `json:"preview,omitempty"`
 	CreatedAt time.Time             `json:"createdAt"`
 	UpdatedAt time.Time             `json:"updatedAt"`
@@ -234,11 +240,22 @@ func (m *RunManager) loadPersisted() {
 		if s.Agent == "cursor-agent" {
 			s.SessionID = ""
 		}
+		// A "running" row owned by another LIVE process is not interrupted — it
+		// belongs to a long-running instance (or another standalone) sharing
+		// this DB right now. Repairing it would falsely fail their active run;
+		// adopting it would show a run this process can't stream. Leave it to
+		// its owner; a later boot repairs it once the owner is gone.
+		// At construction this manager owns nothing yet, so any alive-owner
+		// running row is foreign — even a same-pid one (another manager in
+		// this process).
+		if s.Status == "running" && pidAlive(s.OwnerPID) {
+			continue
+		}
 		r := &Run{
 			ID: s.ID, Kind: s.Kind, Namespace: s.Namespace, Name: s.Name,
 			Context: s.Context, Agent: s.Agent, Isolated: s.Isolated,
 			Model: s.Model, Effort: s.Effort, ManagedBy: s.ManagedBy,
-			Health: s.Health, CreatedAt: s.CreatedAt,
+			Health: s.Health, CreatedAt: s.CreatedAt, OwnerPID: s.OwnerPID,
 			store:  m.store,
 			status: s.Status, sessionID: s.SessionID, preview: s.Preview,
 			updatedAt: s.UpdatedAt,
@@ -264,6 +281,17 @@ func (m *RunManager) loadPersisted() {
 		m.order = append(m.order, r.ID)
 	}
 	m.evictLocked() // the retention cap may have shrunk since the DB was written
+}
+
+// pidAlive reports whether a process exists (signal 0; EPERM still means
+// alive). PID reuse is theoretically possible but irrelevant at this scale —
+// a false "alive" only delays crash repair until the next boot.
+func pidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
 }
 
 // newRunID mints a process-independent id. Random (not a counter) because
@@ -411,8 +439,9 @@ func (m *RunManager) Start(kind, namespace, name, agent string, isolated bool, m
 		ID: id, Kind: kind, Namespace: namespace,
 		Name: name, Context: cur, Agent: agent, WorkDir: m.runWorkDir(id), Isolated: isolated,
 		Model: model, Effort: effort, ManagedBy: managedBy, Health: health, CreatedAt: nowUTC(),
-		store:  m.store,
-		status: "running", inFlight: true, updatedAt: nowUTC(),
+		OwnerPID: os.Getpid(),
+		store:    m.store,
+		status:   "running", inFlight: true, updatedAt: nowUTC(),
 		hydrated: true, // born live — its full log is in memory by construction
 		subs:     map[int]chan RunEvent{},
 	}
@@ -652,25 +681,39 @@ func (m *RunManager) sweepForeignLocked() {
 // (running) runs survive and are re-persisted so their rows aren't orphaned by
 // the wipe.
 func (m *RunManager) ClearHistory() error {
-	// Snapshot which runs survive (live) vs go (terminal) under the lock.
+	// Remove terminal runs from ADDRESSABILITY first, atomically: a follow-up
+	// racing the clear would otherwise revive a run whose rows are about to be
+	// deleted, leaving a live agent on an orphaned object. Once out of m.runs,
+	// AddTurn/Get can't find them (ErrRunNotFound), so the window is closed.
 	m.mu.Lock()
+	origOrder := append([]string(nil), m.order...)
 	kept := make([]string, 0, len(m.order))
-	var dropped []string
+	var dropped []*Run
+	var droppedIDs []string
 	for _, id := range m.order {
-		if m.runs[id].snapshotStatus() == "running" {
+		r := m.runs[id]
+		if r.snapshotStatus() == "running" {
 			kept = append(kept, id)
-		} else {
-			dropped = append(dropped, id)
+			continue
 		}
+		dropped = append(dropped, r)
+		droppedIDs = append(droppedIDs, id)
+		delete(m.runs, id)
 	}
+	m.order = kept
 	m.mu.Unlock()
 
-	// Store FIRST, memory second: if the delete fails, the UI must keep showing
-	// the runs — dropping memory first would show "cleared" while a restart
-	// resurrects everything from the intact DB. One transaction deleting only
-	// the non-kept rows, so a crash mid-clear can't lose a live investigation.
+	// One transaction deleting only the non-kept rows, so a crash mid-clear
+	// can't lose a live investigation. On FAILURE, restore the removed runs —
+	// the UI must keep showing what the DB still holds.
 	if m.store != nil {
 		if err := m.store.Clear(kept); err != nil {
+			m.mu.Lock()
+			for i, r := range dropped {
+				m.runs[droppedIDs[i]] = r
+			}
+			m.order = origOrder
+			m.mu.Unlock()
 			return err
 		}
 	}
@@ -688,13 +731,7 @@ func (m *RunManager) ClearHistory() error {
 		}
 	}
 
-	m.mu.Lock()
-	for _, id := range dropped {
-		r, ok := m.runs[id]
-		if !ok {
-			continue
-		}
-		delete(m.runs, id)
+	for _, r := range dropped {
 		// Detach the store before finalizing: the run's rows were just deleted,
 		// and finalize's persisted closed-sentinel would re-create them.
 		r.mu.Lock()
@@ -703,14 +740,6 @@ func (m *RunManager) ClearHistory() error {
 		r.finalize()
 		r.removeWorkDir()
 	}
-	order := make([]string, 0, len(m.order))
-	for _, id := range m.order {
-		if _, ok := m.runs[id]; ok {
-			order = append(order, id)
-		}
-	}
-	m.order = order
-	m.mu.Unlock()
 	return nil
 }
 
@@ -763,7 +792,7 @@ func (r *Run) summaryLocked() RunSummary {
 		Context: r.Context, Agent: r.Agent, Isolated: r.Isolated,
 		Model: r.Model, Effort: r.Effort, ManagedBy: r.ManagedBy,
 		Health: r.Health,
-		Status: r.status, SessionID: r.sessionID,
+		Status: r.status, SessionID: r.sessionID, OwnerPID: r.OwnerPID,
 		Preview: r.preview, CreatedAt: r.CreatedAt, UpdatedAt: r.updatedAt,
 	}
 }

--- a/internal/ai/runs.go
+++ b/internal/ai/runs.go
@@ -18,8 +18,9 @@ import (
 // so it keeps going when the browser closes the panel, navigates away, or refreshes.
 // Clients subscribe to a run's event stream (with replay) to watch live or catch up.
 //
-// In-memory only: runs are lost when the radar process restarts. The feature is
-// gated to no-auth standalone radar, so a single local user owns all runs.
+// Runs live in memory and (when a RunStore is configured) persist to SQLite so
+// history survives restarts. The feature is gated to no-auth standalone radar,
+// so a single local user owns all runs.
 //
 // Locking: the manager mutex (m.mu) guards the runs map/order. Each Run's mutable
 // state (status, session, events, subs, …) is guarded by r.mu. Immutable identity
@@ -129,6 +130,9 @@ var (
 	ErrNoSession = errors.New("investigation has no resumable session yet")
 	// ErrStale is returned when continuing a run whose cluster context changed.
 	ErrStale = errors.New("investigation ran against a different cluster")
+	// ErrHistoryUnavailable is returned when a run's persisted transcript can't
+	// be loaded — appending without it could overwrite stored history.
+	ErrHistoryUnavailable = errors.New("investigation history is unavailable right now — try again")
 )
 
 const (
@@ -281,15 +285,19 @@ func (m *RunManager) Shutdown() {
 	m.mu.Unlock()
 	for _, r := range runs {
 		r.mu.Lock()
-		if r.inFlight {
+		inFlight := r.inFlight
+		if inFlight {
 			r.status = "stopped"
 			r.updatedAt = nowUTC()
-			if r.store != nil {
-				r.store.SaveRun(r.summaryLocked())
-			}
 		}
 		c := r.cancel
 		r.mu.Unlock()
+		if inFlight {
+			// Terminal marker BEFORE cancelling: replay must never end mid-turn
+			// (the UI would spin forever), and the error-typed event carries the
+			// stopped summary in one store transaction.
+			r.append(StreamEvent{Type: "error", Error: "Investigation stopped — Radar was shutting down."})
+		}
 		if c != nil {
 			c()
 		}
@@ -339,6 +347,12 @@ func (m *RunManager) beginTurn(r *Run, requireSession bool) (string, error) {
 	r.inFlight = true
 	r.status = "running"
 	r.updatedAt = nowUTC()
+	// Persist the running transition NOW: if Radar dies mid-turn, restart
+	// recovery keys off the status column — a stale terminal status here would
+	// leave an unterminated turn in the replayed transcript with no repair.
+	if r.store != nil {
+		r.store.SaveRun(r.summaryLocked())
+	}
 	return r.sessionID, nil
 }
 
@@ -404,7 +418,11 @@ func (m *RunManager) AddTurn(id, question string, apply bool, fix string) error 
 	}
 	// A follow-up on a run loaded from history must extend the PERSISTED log —
 	// hydrate before beginTurn so the new turn's sequence numbers continue it.
-	r.ensureHydrated()
+	// Refusing on failure protects the stored transcript: appending against an
+	// unknown prefix would re-sequence from 1 and overwrite it.
+	if !r.ensureHydrated() {
+		return ErrHistoryUnavailable
+	}
 	session, err := m.beginTurn(r, true)
 	if err != nil {
 		return err
@@ -481,7 +499,9 @@ func (m *RunManager) Stop(id string) error {
 	if r == nil {
 		return ErrRunNotFound
 	}
-	r.ensureHydrated() // an in-flight run is always hydrated; harmless otherwise
+	// An in-flight run is always hydrated (born live); a loaded run can't be
+	// in-flight, so its early return below makes a failed hydration harmless.
+	r.ensureHydrated()
 	r.mu.Lock()
 	if !r.inFlight {
 		r.mu.Unlock()
@@ -584,12 +604,10 @@ func (m *RunManager) sweepForeignLocked() {
 func (m *RunManager) ClearHistory() error {
 	m.mu.Lock()
 	kept := make([]string, 0, len(m.order))
-	var keptRuns []*Run
 	for _, id := range m.order {
 		r := m.runs[id]
 		if r.snapshotStatus() == "running" {
 			kept = append(kept, id)
-			keptRuns = append(keptRuns, r)
 			continue
 		}
 		delete(m.runs, id)
@@ -602,22 +620,9 @@ func (m *RunManager) ClearHistory() error {
 	if m.store == nil {
 		return nil
 	}
-	if err := m.store.Clear(); err != nil {
-		return err
-	}
-	// Re-persist the survivors: their summary rows and any events already in
-	// memory (live runs are always hydrated, so this is the complete log).
-	for _, r := range keptRuns {
-		r.mu.Lock()
-		sum := r.summaryLocked()
-		events := append([]RunEvent(nil), r.events...)
-		r.mu.Unlock()
-		m.store.SaveRun(sum)
-		for _, e := range events {
-			m.store.AppendEvent(r.ID, e, nil)
-		}
-	}
-	return nil
+	// One transaction, deleting only the non-kept rows — a crash mid-clear can
+	// never lose a live investigation the user was told would survive.
+	return m.store.Clear(kept)
 }
 
 // evictLocked drops the oldest finished run when over the retention cap. Running
@@ -679,27 +684,32 @@ func (r *Run) summaryLocked() RunSummary {
 // first, so sequence numbers always continue from the persisted log. Idempotent
 // and safe under concurrency: a racing second load just re-installs the same
 // immutable prefix before either appends.
-func (r *Run) ensureHydrated() {
+//
+// On a load FAILURE the run stays un-hydrated (retryable) and callers must not
+// append: sequencing against an unknown prefix would restart at seq 1 and
+// overwrite the persisted transcript.
+func (r *Run) ensureHydrated() bool {
 	if r.store == nil {
-		return
+		return true
 	}
 	r.mu.Lock()
 	if r.hydrated {
 		r.mu.Unlock()
-		return
+		return true
 	}
 	r.mu.Unlock()
 	events, err := r.store.LoadEvents(r.ID) // outside r.mu — a DB read may wait on the writer
+	if err != nil {
+		log.Printf("[ai] could not load transcript for %s: %v", r.ID, err)
+		return false
+	}
 	r.mu.Lock()
 	if !r.hydrated {
-		if err != nil {
-			log.Printf("[ai] could not load transcript for %s: %v", r.ID, err)
-		} else {
-			r.events = events
-		}
+		r.events = events
 		r.hydrated = true
 	}
 	r.mu.Unlock()
+	return true
 }
 
 // markStale flips a non-running run to stale and finalizes its stream without
@@ -762,7 +772,14 @@ func (r *Run) snapshotStatus() string {
 // The channel is closed only when the run is finalized (stale/evicted) — NOT when
 // a turn completes, so the same subscription sees later turns.
 func (r *Run) Subscribe(afterSeq int) (backlog []RunEvent, ch <-chan RunEvent, cancel func()) {
-	r.ensureHydrated() // a run loaded from history replays its persisted transcript
+	// A run loaded from history replays its persisted transcript. On a load
+	// failure, return an immediately-closed stream WITHOUT registering — the
+	// client's EventSource reconnect retries hydration (it stayed un-hydrated).
+	if !r.ensureHydrated() {
+		c := make(chan RunEvent)
+		close(c)
+		return nil, c, func() {}
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for _, e := range r.events {

--- a/internal/ai/runs_test.go
+++ b/internal/ai/runs_test.go
@@ -627,7 +627,7 @@ func TestClearHistoryRestoresOnFailure(t *testing.T) {
 	st.Close() // Clear will fail
 
 	if err := m.ClearHistory(); err == nil {
-		t.Skip("closed store reported success — Clear noop contract changed")
+		t.Fatal("clear on a closed store must fail — memory was about to drop state the DB still holds")
 	}
 	if m.Get("run-1") == nil {
 		t.Fatal("failed clear must restore the run to the list")

--- a/internal/ai/runs_test.go
+++ b/internal/ai/runs_test.go
@@ -373,3 +373,104 @@ func TestClearHistoryKeepsRunning(t *testing.T) {
 		t.Fatalf("live run's transcript not re-persisted: %+v", events)
 	}
 }
+
+// TestPersistenceInterruptedFollowup pins crash recovery for a follow-up: the
+// running transition persists at beginTurn, so a crash mid-follow-up (after a
+// prior DONE verdict) still loads as error with a terminal restart marker —
+// never a done row hiding an unterminated turn.
+func TestPersistenceInterruptedFollowup(t *testing.T) {
+	st, _ := testStore(t)
+	m1 := persistedManager(t, st, "ctx-a")
+	r := &Run{ID: "run-1", Kind: "Pod", Name: "p", Context: "ctx-a", store: st,
+		status: "done", sessionID: "s", hydrated: true,
+		CreatedAt: nowUTC(), updatedAt: nowUTC(), subs: map[int]chan RunEvent{}}
+	st.SaveRun(r.Summary())
+	r.append(StreamEvent{Type: "turn"})
+	r.append(StreamEvent{Type: "done", Diag: &Diagnosis{Healthy: true}})
+	m1.mu.Lock()
+	m1.runs[r.ID] = r
+	m1.order = append(m1.order, r.ID)
+	m1.mu.Unlock()
+
+	// A follow-up begins (status flips to running + persists)… then Radar dies.
+	if _, err := m1.beginTurn(r, true); err != nil {
+		t.Fatal(err)
+	}
+	r.append(StreamEvent{Type: "turn", Question: "and?"})
+	st.(*sqliteRunStore).barrier()
+
+	m2 := persistedManager(t, st, "ctx-a")
+	runs := m2.List()
+	if len(runs) != 1 || runs[0].Status != "error" {
+		t.Fatalf("interrupted follow-up loaded as %+v, want error", runs)
+	}
+	backlog, _, cancel := m2.Get("run-1").Subscribe(0)
+	defer cancel()
+	last := backlog[len(backlog)-1].Event
+	if last.Type != "error" || !strings.Contains(last.Error, "restarted") {
+		t.Fatalf("replay must end terminal after interrupted follow-up, got %+v", last)
+	}
+}
+
+// TestPersistenceGracefulShutdown pins that Shutdown leaves an in-flight run's
+// persisted log ending in a terminal event (stopped status + marker in one tx),
+// so post-restart replay never leaves the UI spinning on an unterminated turn.
+func TestPersistenceGracefulShutdown(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "ai-runs.db")
+	st, err := OpenRunStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := NewRunManager(nil, func() int { return 0 }, func() string { return "ctx-a" }, st)
+	r := &Run{ID: "run-1", Kind: "Pod", Name: "p", Context: "ctx-a", store: st,
+		status: "running", inFlight: true, hydrated: true,
+		CreatedAt: nowUTC(), updatedAt: nowUTC(), subs: map[int]chan RunEvent{}}
+	st.SaveRun(r.Summary())
+	r.append(StreamEvent{Type: "turn"})
+	m.mu.Lock()
+	m.runs[r.ID] = r
+	m.order = append(m.order, r.ID)
+	m.mu.Unlock()
+
+	m.Shutdown() // marks stopped + appends terminal marker + drains and closes the store
+
+	st2, err := OpenRunStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st2.Close()
+	runs, _ := st2.LoadRuns()
+	if len(runs) != 1 || runs[0].Status != "stopped" {
+		t.Fatalf("after graceful shutdown: %+v, want stopped", runs)
+	}
+	events, _ := st2.LoadEvents("run-1")
+	last := events[len(events)-1].Event
+	if last.Type != "error" || !strings.Contains(last.Error, "shutting down") {
+		t.Fatalf("persisted log must end terminal after shutdown, got %+v", last)
+	}
+}
+
+// TestHydrationFailureRefusesAppends pins the transcript-protection rule: when
+// the persisted log can't be loaded, follow-ups are refused (never sequenced
+// against an unknown prefix) and the run stays retryable.
+func TestHydrationFailureRefusesAppends(t *testing.T) {
+	st, _ := testStore(t)
+	st.SaveRun(RunSummary{ID: "run-1", Kind: "Pod", Name: "p", Context: "ctx-a",
+		Agent: "claude", Status: "done", SessionID: "s", CreatedAt: nowUTC(), UpdatedAt: nowUTC()})
+	st.(*sqliteRunStore).barrier()
+	m := persistedManager(t, st, "ctx-a")
+	st.Close() // simulate the DB becoming unreadable before first hydration
+
+	if err := m.AddTurn("run-1", "and?", false, ""); !errors.Is(err, ErrHistoryUnavailable) {
+		t.Fatalf("AddTurn with unloadable transcript = %v, want ErrHistoryUnavailable", err)
+	}
+	// Subscribe degrades to an immediately-closed stream (client retries).
+	backlog, ch, cancel := m.Get("run-1").Subscribe(0)
+	defer cancel()
+	if len(backlog) != 0 {
+		t.Fatalf("backlog on failed hydration = %+v", backlog)
+	}
+	if _, ok := <-ch; ok {
+		t.Error("channel must be closed on failed hydration")
+	}
+}

--- a/internal/ai/runs_test.go
+++ b/internal/ai/runs_test.go
@@ -3,6 +3,7 @@ package ai
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -512,9 +513,12 @@ func TestHistoryUnavailableSurfaces(t *testing.T) {
 	if m.HistoryDegraded() {
 		t.Error("memory-only by CONFIG must not read as degraded")
 	}
-	m.MarkHistoryUnavailable()
+	m.MarkHistoryUnavailable("/nonexistent/ai-runs.db")
 	if !m.HistoryDegraded() {
 		t.Error("open failure must surface as degraded")
+	}
+	if err := m.ClearHistory(); err != nil {
+		t.Errorf("clearing an already-missing broken DB must succeed, got %v", err)
 	}
 
 	st, _ := testStore(t)
@@ -528,5 +532,13 @@ func TestHistoryUnavailableSurfaces(t *testing.T) {
 	}
 	if m2.store != nil {
 		t.Error("load failure must detach the store — writes against unknown contents overwrite history")
+	}
+	// Clear must honor the user's intent even for a detached DB: remove the
+	// files so a later healthy startup can't resurrect "cleared" history.
+	if err := m2.ClearHistory(); err != nil {
+		t.Fatalf("clear with detached store: %v", err)
+	}
+	if _, err := os.Stat(m2.brokenDBPath); !os.IsNotExist(err) {
+		t.Error("broken history DB file must be removed by clear")
 	}
 }

--- a/internal/ai/runs_test.go
+++ b/internal/ai/runs_test.go
@@ -474,3 +474,31 @@ func TestHydrationFailureRefusesAppends(t *testing.T) {
 		t.Error("channel must be closed on failed hydration")
 	}
 }
+
+// TestContextSwitchIdempotentOnStale pins that a SECOND context switch doesn't
+// re-terminalize an already-stale run — its log must keep ending in the closed
+// sentinel (now durable, so a violation would persist and break every replay).
+func TestContextSwitchIdempotentOnStale(t *testing.T) {
+	st, _ := testStore(t)
+	m := persistedManager(t, st, "ctx-b")
+	r := &Run{ID: "run-1", Kind: "Pod", Name: "p", Context: "ctx-a", store: st,
+		status: "done", hydrated: true, CreatedAt: nowUTC(), updatedAt: nowUTC(),
+		subs: map[int]chan RunEvent{}}
+	st.SaveRun(r.Summary())
+	r.append(StreamEvent{Type: "turn"})
+	m.mu.Lock()
+	m.runs[r.ID] = r
+	m.order = append(m.order, r.ID)
+	m.mu.Unlock()
+
+	m.OnContextSwitch() // ctx change #1: stale + error + closed
+	before, _ := st.LoadEvents("run-1")
+	m.OnContextSwitch() // ctx change #2: must be a no-op for this run
+	after, _ := st.LoadEvents("run-1")
+	if len(after) != len(before) {
+		t.Fatalf("second switch appended events: %d → %d", len(before), len(after))
+	}
+	if last := after[len(after)-1].Event; last.Type != "closed" {
+		t.Fatalf("log must end in closed, got %+v", last)
+	}
+}

--- a/internal/ai/runs_test.go
+++ b/internal/ai/runs_test.go
@@ -502,3 +502,31 @@ func TestContextSwitchIdempotentOnStale(t *testing.T) {
 		t.Fatalf("log must end in closed, got %+v", last)
 	}
 }
+
+// TestHistoryUnavailableSurfaces pins the degraded-visibility contract for the
+// two setup failure modes: a store that never opened (server marks it) and a
+// store whose existing contents couldn't be loaded (manager refuses it — new
+// runs must not mint colliding ids against unknown DB contents).
+func TestHistoryUnavailableSurfaces(t *testing.T) {
+	m := NewRunManager(nil, func() int { return 0 }, func() string { return "ctx" }, nil)
+	if m.HistoryDegraded() {
+		t.Error("memory-only by CONFIG must not read as degraded")
+	}
+	m.MarkHistoryUnavailable()
+	if !m.HistoryDegraded() {
+		t.Error("open failure must surface as degraded")
+	}
+
+	st, _ := testStore(t)
+	st.SaveRun(RunSummary{ID: "run-7", Kind: "Pod", Name: "p", Context: "ctx",
+		Status: "done", CreatedAt: nowUTC(), UpdatedAt: nowUTC()})
+	st.(*sqliteRunStore).barrier()
+	st.Close() // LoadRuns will fail in loadPersisted
+	m2 := NewRunManager(nil, func() int { return 0 }, func() string { return "ctx" }, st)
+	if !m2.HistoryDegraded() {
+		t.Error("load failure must surface as degraded")
+	}
+	if m2.store != nil {
+		t.Error("load failure must detach the store — writes against unknown contents overwrite history")
+	}
+}

--- a/internal/ai/runs_test.go
+++ b/internal/ai/runs_test.go
@@ -555,3 +555,81 @@ func TestNewRunIDUnique(t *testing.T) {
 		seen[id] = true
 	}
 }
+
+// TestLoadSkipsLiveForeignRunning pins the shared-DB ownership rule: a
+// "running" row owned by another LIVE process must be neither repaired (that
+// would falsely fail their active run) nor adopted; once the owner is dead,
+// the next load repairs it as interrupted.
+func TestLoadSkipsLiveForeignRunning(t *testing.T) {
+	st, _ := testStore(t)
+	// Owned by THIS process (alive) but not this manager — must be skipped.
+	st.SaveRun(RunSummary{ID: "run-alive", Kind: "Pod", Name: "p", Context: "ctx",
+		Status: "running", OwnerPID: os.Getpid(), CreatedAt: nowUTC(), UpdatedAt: nowUTC()})
+	// Owned by a dead pid — must be repaired to error.
+	st.SaveRun(RunSummary{ID: "run-dead", Kind: "Pod", Name: "p2", Context: "ctx",
+		Status: "running", OwnerPID: 1 << 30, CreatedAt: nowUTC(), UpdatedAt: nowUTC()})
+	st.(*sqliteRunStore).barrier()
+
+	m := persistedManager(t, st, "ctx")
+	if m.Get("run-alive") != nil {
+		t.Error("live foreign running row must not be adopted")
+	}
+	dead := m.Get("run-dead")
+	if dead == nil || dead.snapshotStatus() != "error" {
+		t.Fatalf("dead-owner running row must be repaired, got %v", dead)
+	}
+	st.(*sqliteRunStore).barrier()
+	runs, _ := st.LoadRuns()
+	for _, r := range runs {
+		if r.ID == "run-alive" && r.Status != "running" {
+			t.Errorf("live foreign row was mutated: %+v", r)
+		}
+	}
+}
+
+// TestClearHistoryClosesFollowupRace pins the clear-vs-follow-up race: once
+// ClearHistory commits to dropping a terminal run, a concurrent follow-up must
+// get ErrRunNotFound — never revive a run whose rows are being deleted.
+func TestClearHistoryClosesFollowupRace(t *testing.T) {
+	st, _ := testStore(t)
+	m := persistedManager(t, st, "ctx-a")
+	r := &Run{ID: "run-1", Kind: "Pod", Name: "p", Context: "ctx-a", store: st,
+		status: "done", sessionID: "s", hydrated: true,
+		CreatedAt: nowUTC(), updatedAt: nowUTC(), subs: map[int]chan RunEvent{}}
+	st.SaveRun(r.Summary())
+	m.mu.Lock()
+	m.runs[r.ID] = r
+	m.order = append(m.order, r.ID)
+	m.mu.Unlock()
+
+	if err := m.ClearHistory(); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.AddTurn("run-1", "revive?", false, ""); !errors.Is(err, ErrRunNotFound) {
+		t.Fatalf("follow-up after clear = %v, want ErrRunNotFound", err)
+	}
+}
+
+// TestClearHistoryRestoresOnFailure pins the failure path: a failed store
+// clear must put the runs back — the UI keeps showing what the DB still holds.
+func TestClearHistoryRestoresOnFailure(t *testing.T) {
+	st, _ := testStore(t)
+	m := persistedManager(t, st, "ctx-a")
+	r := &Run{ID: "run-1", Kind: "Pod", Name: "p", Context: "ctx-a", store: st,
+		status: "done", hydrated: true,
+		CreatedAt: nowUTC(), updatedAt: nowUTC(), subs: map[int]chan RunEvent{}}
+	st.SaveRun(r.Summary())
+	m.mu.Lock()
+	m.runs[r.ID] = r
+	m.order = append(m.order, r.ID)
+	m.mu.Unlock()
+	st.(*sqliteRunStore).barrier()
+	st.Close() // Clear will fail
+
+	if err := m.ClearHistory(); err == nil {
+		t.Skip("closed store reported success — Clear noop contract changed")
+	}
+	if m.Get("run-1") == nil {
+		t.Fatal("failed clear must restore the run to the list")
+	}
+}

--- a/internal/ai/runs_test.go
+++ b/internal/ai/runs_test.go
@@ -1,7 +1,10 @@
 package ai
 
 import (
+	"errors"
+	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -28,8 +31,8 @@ func TestRunWorkDirUnderPrivateRoot(t *testing.T) {
 // backlog after its last-seen seq, then live events, then a close on terminal.
 func TestRunSubscribeReplay(t *testing.T) {
 	r := &Run{subs: map[int]chan RunEvent{}}
-	r.append(StreamEvent{Type: "turn"})              // seq 1
-	r.append(StreamEvent{Type: "phase"})             // seq 2
+	r.append(StreamEvent{Type: "turn"})                 // seq 1
+	r.append(StreamEvent{Type: "phase"})                // seq 2
 	r.append(StreamEvent{Type: "thinking", Token: "x"}) // seq 3
 
 	backlog, ch, cancel := r.Subscribe(1) // everything after seq 1
@@ -167,5 +170,206 @@ func TestRunMatchesTarget(t *testing.T) {
 	}
 	if r.matchesTarget("Deployment", "ns", "app", "ctx", "codex", true, "o3", "low") {
 		t.Error("different effort must NOT match")
+	}
+}
+
+// persistedManager builds a manager over a store with no live diagnoser — good
+// enough for persistence-path tests (nothing spawns an agent).
+func persistedManager(t *testing.T, store RunStore, ctx string) *RunManager {
+	t.Helper()
+	m := NewRunManager(nil, func() int { return 0 }, func() string { return ctx }, store)
+	t.Cleanup(func() {
+		// Don't let Shutdown close the shared test store between phases.
+		m.baseCancel()
+	})
+	return m
+}
+
+// TestPersistenceRestartRoundtrip pins the core promise: a finished run's
+// summary, transcript, and sessionId survive a "restart" (a second manager over
+// the same store), replay parity included.
+func TestPersistenceRestartRoundtrip(t *testing.T) {
+	st, _ := testStore(t)
+
+	m1 := persistedManager(t, st, "ctx-a")
+	r := &Run{
+		ID: "run-1", Kind: "Pod", Namespace: "ns", Name: "p", Context: "ctx-a",
+		Agent: "claude", store: st, status: "running", hydrated: true,
+		CreatedAt: nowUTC(), updatedAt: nowUTC(), subs: map[int]chan RunEvent{},
+	}
+	m1.mu.Lock()
+	m1.runs[r.ID] = r
+	m1.order = append(m1.order, r.ID)
+	m1.nextID = 1
+	m1.mu.Unlock()
+	st.SaveRun(r.Summary())
+
+	r.append(StreamEvent{Type: "turn"})
+	r.append(StreamEvent{Type: "thinking", Token: "checking"})
+	r.mu.Lock()
+	r.status = "done"
+	r.sessionID = "sess-42"
+	r.preview = "bad image"
+	r.mu.Unlock()
+	r.append(StreamEvent{Type: "done", Diag: &Diagnosis{RootCause: "bad image"}})
+	st.(*sqliteRunStore).barrier()
+
+	// "Restart": fresh manager, same store.
+	m2 := persistedManager(t, st, "ctx-a")
+	runs := m2.List()
+	if len(runs) != 1 || runs[0].Status != "done" || runs[0].SessionID != "sess-42" || runs[0].Preview != "bad image" {
+		t.Fatalf("restart lost state: %+v", runs)
+	}
+	// ID generation must not collide with the persisted run.
+	if m2.nextID != 1 {
+		t.Errorf("nextID = %d, want 1 (seeded from run-1)", m2.nextID)
+	}
+	// Replay parity: Subscribe hydrates the transcript from the store.
+	r2 := m2.Get("run-1")
+	backlog, _, cancel := r2.Subscribe(0)
+	defer cancel()
+	if len(backlog) != 3 || backlog[2].Event.Type != "done" || backlog[2].Event.Diag == nil {
+		t.Fatalf("replay after restart = %+v", backlog)
+	}
+}
+
+// TestPersistenceInterruptedRun pins crash recovery: a run persisted as
+// "running" loads as error with a terminal event appended, so replay still ends
+// in a terminal marker and Start won't focus the dead run.
+func TestPersistenceInterruptedRun(t *testing.T) {
+	st, _ := testStore(t)
+	st.SaveRun(RunSummary{ID: "run-3", Kind: "Pod", Name: "p", Context: "ctx-a",
+		Agent: "claude", Status: "running", CreatedAt: nowUTC(), UpdatedAt: nowUTC()})
+	st.AppendEvent("run-3", RunEvent{Seq: 1, Event: StreamEvent{Type: "turn"}}, nil)
+	st.(*sqliteRunStore).barrier()
+
+	m := persistedManager(t, st, "ctx-a")
+	runs := m.List()
+	if len(runs) != 1 || runs[0].Status != "error" {
+		t.Fatalf("interrupted run = %+v, want status error", runs)
+	}
+	r := m.Get("run-3")
+	backlog, _, cancel := r.Subscribe(0)
+	defer cancel()
+	last := backlog[len(backlog)-1]
+	if last.Event.Type != "error" || !strings.Contains(last.Event.Error, "restarted") {
+		t.Fatalf("replay must end in the restart marker, got %+v", last)
+	}
+}
+
+// TestPersistenceCursorNotResumable pins the accepted Cursor degradation: its
+// resume is workspace-scoped and the workspace died with the old process, so a
+// loaded Cursor run must refuse follow-ups via ErrNoSession — never spawn an
+// agent guaranteed to fail.
+func TestPersistenceCursorNotResumable(t *testing.T) {
+	st, _ := testStore(t)
+	st.SaveRun(RunSummary{ID: "run-1", Kind: "Pod", Name: "p", Context: "ctx-a",
+		Agent: "cursor-agent", Status: "done", SessionID: "cursor-sess",
+		CreatedAt: nowUTC(), UpdatedAt: nowUTC()})
+	st.(*sqliteRunStore).barrier()
+
+	m := persistedManager(t, st, "ctx-a")
+	if err := m.AddTurn("run-1", "and?", false, ""); !errors.Is(err, ErrNoSession) {
+		t.Fatalf("cursor follow-up after restart = %v, want ErrNoSession", err)
+	}
+}
+
+// TestPersistenceForeignContextSweep pins that history from another kube-context
+// loads view-only: stale status, closed stream after replay, follow-ups refused.
+func TestPersistenceForeignContextSweep(t *testing.T) {
+	st, _ := testStore(t)
+	st.SaveRun(RunSummary{ID: "run-1", Kind: "Pod", Name: "p", Context: "ctx-OLD",
+		Agent: "claude", Status: "done", SessionID: "s", CreatedAt: nowUTC(), UpdatedAt: nowUTC()})
+	st.AppendEvent("run-1", RunEvent{Seq: 1, Event: StreamEvent{Type: "turn"}}, nil)
+	st.(*sqliteRunStore).barrier()
+
+	m := persistedManager(t, st, "ctx-NEW")
+	runs := m.List() // sweep runs here (context label resolved)
+	if len(runs) != 1 || runs[0].Status != "stale" {
+		t.Fatalf("foreign-context run = %+v, want stale", runs)
+	}
+	if err := m.AddTurn("run-1", "and?", false, ""); !errors.Is(err, ErrStale) {
+		t.Fatalf("foreign-context follow-up = %v, want ErrStale", err)
+	}
+	st.(*sqliteRunStore).barrier()
+	// The persisted log gained terminal markers (store-assigned seqs), so a
+	// fresh subscribe replays and then CLOSES instead of hanging.
+	r := m.Get("run-1")
+	backlog, ch, cancel := r.Subscribe(0)
+	defer cancel()
+	last := backlog[len(backlog)-1]
+	if last.Event.Type != "closed" {
+		t.Fatalf("stale replay must end in closed, got %+v", backlog)
+	}
+	if _, ok := <-ch; ok {
+		t.Error("stale run's live channel must be closed")
+	}
+}
+
+// TestPersistenceEvictionDeletesRows pins that count-based eviction removes the
+// run from the store too — history and memory can't drift apart.
+func TestPersistenceEvictionDeletesRows(t *testing.T) {
+	st, _ := testStore(t)
+	m := persistedManager(t, st, "ctx-a")
+	m.maxRetained = 2
+	for i := 1; i <= 3; i++ {
+		id := fmt.Sprintf("run-%d", i)
+		r := &Run{ID: id, Kind: "Pod", Name: "p", Context: "ctx-a", store: st,
+			status: "done", hydrated: true, CreatedAt: nowUTC(), updatedAt: nowUTC(),
+			subs: map[int]chan RunEvent{}}
+		st.SaveRun(r.Summary())
+		m.mu.Lock()
+		m.runs[id] = r
+		m.order = append(m.order, id)
+		m.evictLocked()
+		m.mu.Unlock()
+	}
+	st.(*sqliteRunStore).barrier()
+	runs, _ := st.LoadRuns()
+	if len(runs) != 2 {
+		t.Fatalf("store kept %d runs after eviction, want 2", len(runs))
+	}
+	for _, r := range runs {
+		if r.ID == "run-1" {
+			t.Error("evicted run-1 still in store")
+		}
+	}
+}
+
+// TestClearHistoryKeepsRunning pins that Clear wipes finished runs (memory +
+// store) but a live investigation survives, fully re-persisted.
+func TestClearHistoryKeepsRunning(t *testing.T) {
+	st, _ := testStore(t)
+	m := persistedManager(t, st, "ctx-a")
+	mk := func(id, status string) *Run {
+		r := &Run{ID: id, Kind: "Pod", Name: "p", Context: "ctx-a", store: st,
+			status: status, hydrated: true, CreatedAt: nowUTC(), updatedAt: nowUTC(),
+			subs: map[int]chan RunEvent{}}
+		st.SaveRun(r.Summary())
+		m.mu.Lock()
+		m.runs[id] = r
+		m.order = append(m.order, id)
+		m.mu.Unlock()
+		return r
+	}
+	mk("run-1", "done")
+	live := mk("run-2", "running")
+	live.append(StreamEvent{Type: "turn"})
+
+	if err := m.ClearHistory(); err != nil {
+		t.Fatal(err)
+	}
+	st.(*sqliteRunStore).barrier()
+	runs := m.List()
+	if len(runs) != 1 || runs[0].ID != "run-2" {
+		t.Fatalf("memory after clear = %+v", runs)
+	}
+	stored, _ := st.LoadRuns()
+	if len(stored) != 1 || stored[0].ID != "run-2" {
+		t.Fatalf("store after clear = %+v", stored)
+	}
+	events, _ := st.LoadEvents("run-2")
+	if len(events) != 1 || events[0].Event.Type != "turn" {
+		t.Fatalf("live run's transcript not re-persisted: %+v", events)
 	}
 }

--- a/internal/ai/runs_test.go
+++ b/internal/ai/runs_test.go
@@ -201,7 +201,6 @@ func TestPersistenceRestartRoundtrip(t *testing.T) {
 	m1.mu.Lock()
 	m1.runs[r.ID] = r
 	m1.order = append(m1.order, r.ID)
-	m1.nextID = 1
 	m1.mu.Unlock()
 	st.SaveRun(r.Summary())
 
@@ -220,10 +219,6 @@ func TestPersistenceRestartRoundtrip(t *testing.T) {
 	runs := m2.List()
 	if len(runs) != 1 || runs[0].Status != "done" || runs[0].SessionID != "sess-42" || runs[0].Preview != "bad image" {
 		t.Fatalf("restart lost state: %+v", runs)
-	}
-	// ID generation must not collide with the persisted run.
-	if m2.nextID != 1 {
-		t.Errorf("nextID = %d, want 1 (seeded from run-1)", m2.nextID)
 	}
 	// Replay parity: Subscribe hydrates the transcript from the store.
 	r2 := m2.Get("run-1")
@@ -540,5 +535,23 @@ func TestHistoryUnavailableSurfaces(t *testing.T) {
 	}
 	if _, err := os.Stat(m2.brokenDBPath); !os.IsNotExist(err) {
 		t.Error("broken history DB file must be removed by clear")
+	}
+}
+
+// TestNewRunIDUnique pins the cross-process safety property: ids are random,
+// not a counter — two processes sharing the history DB (standalone next to a
+// long-running instance) must never mint the same id and overwrite each
+// other's transcripts.
+func TestNewRunIDUnique(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 1000; i++ {
+		id := newRunID()
+		if !strings.HasPrefix(id, "run-") || len(id) < 10 {
+			t.Fatalf("unexpected id shape %q", id)
+		}
+		if seen[id] {
+			t.Fatalf("duplicate id %q", id)
+		}
+		seen[id] = true
 	}
 }

--- a/internal/ai/store.go
+++ b/internal/ai/store.go
@@ -35,8 +35,10 @@ type RunStore interface {
 	LoadEvents(runID string) ([]RunEvent, error)
 	// DeleteRun removes a run and its events.
 	DeleteRun(id string)
-	// Clear synchronously removes every persisted run and event.
-	Clear() error
+	// Clear synchronously removes persisted runs and events in ONE transaction,
+	// except the given run ids (live investigations that must survive a crash
+	// mid-clear).
+	Clear(keep []string) error
 	// Degraded reports that persistence has stopped working (disk error or a
 	// saturated write queue) — history will not survive a restart.
 	Degraded() bool
@@ -292,16 +294,39 @@ func (s *sqliteRunStore) DeleteRun(id string) {
 	})
 }
 
-func (s *sqliteRunStore) Clear() error {
+func (s *sqliteRunStore) Clear(keep []string) error {
 	var out error
 	s.enqueueWait(func(db *sql.DB) error {
-		if _, err := db.Exec(`DELETE FROM run_events`); err != nil {
+		tx, err := db.Begin()
+		if err != nil {
 			out = err
 			return err
 		}
-		_, err := db.Exec(`DELETE FROM runs`)
-		out = err
-		return err
+		defer func() { _ = tx.Rollback() }()
+		args := make([]any, len(keep))
+		ph := ""
+		for i, id := range keep {
+			if i > 0 {
+				ph += ","
+			}
+			ph += "?"
+			args[i] = id
+		}
+		evQ, runQ := `DELETE FROM run_events`, `DELETE FROM runs`
+		if len(keep) > 0 {
+			evQ += ` WHERE run_id NOT IN (` + ph + `)`
+			runQ += ` WHERE id NOT IN (` + ph + `)`
+		}
+		if _, err := tx.Exec(evQ, args...); err != nil {
+			out = err
+			return err
+		}
+		if _, err := tx.Exec(runQ, args...); err != nil {
+			out = err
+			return err
+		}
+		out = tx.Commit()
+		return out
 	})
 	return out
 }

--- a/internal/ai/store.go
+++ b/internal/ai/store.go
@@ -42,6 +42,9 @@ type RunStore interface {
 	// Degraded reports that persistence has stopped working (disk error or a
 	// saturated write queue) — history will not survive a restart.
 	Degraded() bool
+	// Path returns the DB file path (so a detached/broken store's files can
+	// still be removed when the user clears history).
+	Path() string
 	// Close drains pending writes and closes the DB.
 	Close()
 }
@@ -66,6 +69,7 @@ CREATE TABLE IF NOT EXISTS run_events (
 // goroutine. Writes are enqueued (non-blocking) and applied in order; reads use
 // the same connection and may briefly wait on the writer (busy_timeout).
 type sqliteRunStore struct {
+	path string
 	db   *sql.DB
 	ops  chan func(db *sql.DB) error
 	done chan struct{}
@@ -117,6 +121,7 @@ func OpenRunStore(dbPath string) (RunStore, error) {
 	}
 
 	s := &sqliteRunStore{
+		path: dbPath,
 		db:   db,
 		ops:  make(chan func(db *sql.DB) error, 4096),
 		done: make(chan struct{}),
@@ -332,6 +337,8 @@ func (s *sqliteRunStore) Clear(keep []string) error {
 }
 
 func (s *sqliteRunStore) Degraded() bool { return s.degraded.Load() }
+
+func (s *sqliteRunStore) Path() string { return s.path }
 
 // Close drains pending writes and closes the DB. Late writers (agent goroutines
 // finishing after shutdown began) become no-ops via the closed flag; the flag

--- a/internal/ai/store.go
+++ b/internal/ai/store.go
@@ -7,6 +7,7 @@ package ai
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -301,7 +302,7 @@ func (s *sqliteRunStore) DeleteRun(id string) {
 
 func (s *sqliteRunStore) Clear(keep []string) error {
 	var out error
-	s.enqueueWait(func(db *sql.DB) error {
+	ran := s.enqueueWait(func(db *sql.DB) error {
 		tx, err := db.Begin()
 		if err != nil {
 			out = err
@@ -333,6 +334,11 @@ func (s *sqliteRunStore) Clear(keep []string) error {
 		out = tx.Commit()
 		return out
 	})
+	if !ran {
+		// A closed store didn't run the delete at all — reporting success here
+		// would let callers drop state the DB still holds.
+		return errors.New("history store is closed")
+	}
 	return out
 }
 

--- a/internal/ai/store.go
+++ b/internal/ai/store.go
@@ -1,0 +1,326 @@
+// SQLite persistence for AI investigation runs — the durable backing behind
+// RunManager's in-memory state, so history, transcripts, and the agent-session
+// hand-off survive a Radar restart. Single local user (the feature is gated to
+// no-auth standalone radar), so one DB file with a single writer is plenty.
+package ai
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+
+	_ "modernc.org/sqlite"
+)
+
+// RunStore persists runs and their event logs. Write methods are asynchronous
+// and must never block the caller — RunManager enqueues them while holding a
+// run's mutex on the live event path.
+type RunStore interface {
+	// SaveRun upserts a run's summary row.
+	SaveRun(s RunSummary)
+	// AppendEvent appends one event row. e.Seq > 0 inserts that exact sequence;
+	// e.Seq == 0 lets the store assign MAX(seq)+1 (used for terminal markers on
+	// runs whose log was never hydrated into memory). When summary is non-nil it
+	// is upserted in the SAME transaction — terminal events ride with their
+	// status so crash recovery can trust the status column.
+	AppendEvent(runID string, e RunEvent, summary *RunSummary)
+	// LoadRuns returns every persisted summary, oldest first.
+	LoadRuns() ([]RunSummary, error)
+	// LoadEvents returns a run's events ordered by seq.
+	LoadEvents(runID string) ([]RunEvent, error)
+	// DeleteRun removes a run and its events.
+	DeleteRun(id string)
+	// Clear synchronously removes every persisted run and event.
+	Clear() error
+	// Degraded reports that persistence has stopped working (disk error or a
+	// saturated write queue) — history will not survive a restart.
+	Degraded() bool
+	// Close drains pending writes and closes the DB.
+	Close()
+}
+
+const storeSchema = `
+CREATE TABLE IF NOT EXISTS runs (
+	id           TEXT PRIMARY KEY,
+	created_at   INTEGER NOT NULL,
+	updated_at   INTEGER NOT NULL,
+	status       TEXT NOT NULL,
+	summary_json TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS run_events (
+	run_id     TEXT NOT NULL,
+	seq        INTEGER NOT NULL,
+	event_json TEXT NOT NULL,
+	PRIMARY KEY (run_id, seq)
+);
+`
+
+// sqliteRunStore implements RunStore over one SQLite file with a single writer
+// goroutine. Writes are enqueued (non-blocking) and applied in order; reads use
+// the same connection and may briefly wait on the writer (busy_timeout).
+type sqliteRunStore struct {
+	db   *sql.DB
+	ops  chan func(db *sql.DB) error
+	done chan struct{}
+	// closeMu makes enqueue-vs-Close safe: senders hold RLock while checking the
+	// closed flag AND sending, Close holds Lock while flipping it and closing the
+	// channel — so a send can never race the close and panic.
+	closeMu  sync.RWMutex
+	closed   bool
+	degraded atomic.Bool
+}
+
+// OpenRunStore opens (or creates) the run history DB. The file is created 0600
+// before SQLite touches it so the WAL/SHM siblings inherit private permissions —
+// transcripts contain cluster data.
+func OpenRunStore(dbPath string) (RunStore, error) {
+	dir := filepath.Dir(dbPath)
+	if dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return nil, fmt.Errorf("ai history dir: %w", err)
+		}
+	}
+	f, err := os.OpenFile(dbPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("ai history file: %w", err)
+	}
+	_ = f.Close()
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("ai history open: %w", err)
+	}
+	// One writer at a time (SQLite's model); reads share the connection.
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	for _, pragma := range []string{
+		"PRAGMA journal_mode=WAL",
+		"PRAGMA busy_timeout=10000",
+		"PRAGMA synchronous=NORMAL",
+		"PRAGMA user_version=1",
+	} {
+		if _, err := db.Exec(pragma); err != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("ai history pragma: %w", err)
+		}
+	}
+	if _, err := db.Exec(storeSchema); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("ai history schema: %w", err)
+	}
+
+	s := &sqliteRunStore{
+		db:   db,
+		ops:  make(chan func(db *sql.DB) error, 4096),
+		done: make(chan struct{}),
+	}
+	go s.writer()
+	return s, nil
+}
+
+func (s *sqliteRunStore) writer() {
+	defer close(s.done)
+	for op := range s.ops {
+		if op == nil {
+			continue
+		}
+		if err := op(s.db); err != nil && !s.degraded.Load() {
+			s.degraded.Store(true)
+			log.Printf("[ai] history write failed — investigations will NOT survive a restart: %v", err)
+		}
+	}
+}
+
+// enqueue hands an op to the writer without ever blocking the caller (it runs
+// under a run's mutex on the hot path). A full queue flips degraded and drops.
+func (s *sqliteRunStore) enqueue(op func(db *sql.DB) error) {
+	s.closeMu.RLock()
+	defer s.closeMu.RUnlock()
+	if s.closed {
+		return
+	}
+	select {
+	case s.ops <- op:
+	default:
+		if !s.degraded.Load() {
+			s.degraded.Store(true)
+			log.Printf("[ai] history write queue full — dropping writes; investigations will NOT survive a restart")
+		}
+	}
+}
+
+// enqueueWait hands an op to the writer and blocks until it ran (user-initiated
+// operations like Clear, where dropping would be wrong). Returns false if the
+// store is closed.
+func (s *sqliteRunStore) enqueueWait(op func(db *sql.DB) error) bool {
+	done := make(chan struct{})
+	s.closeMu.RLock()
+	if s.closed {
+		s.closeMu.RUnlock()
+		return false
+	}
+	s.ops <- func(db *sql.DB) error {
+		defer close(done)
+		return op(db)
+	}
+	s.closeMu.RUnlock()
+	<-done
+	return true
+}
+
+// barrier waits until every op enqueued before it has been applied.
+func (s *sqliteRunStore) barrier() {
+	s.enqueueWait(func(*sql.DB) error { return nil })
+}
+
+func upsertRun(db *sql.DB, s RunSummary) error {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec(`INSERT INTO runs (id, created_at, updated_at, status, summary_json)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET updated_at=excluded.updated_at,
+			status=excluded.status, summary_json=excluded.summary_json`,
+		s.ID, s.CreatedAt.UnixMilli(), s.UpdatedAt.UnixMilli(), s.Status, string(b))
+	return err
+}
+
+func (s *sqliteRunStore) SaveRun(sum RunSummary) {
+	s.enqueue(func(db *sql.DB) error { return upsertRun(db, sum) })
+}
+
+func (s *sqliteRunStore) AppendEvent(runID string, e RunEvent, summary *RunSummary) {
+	s.enqueue(func(db *sql.DB) error {
+		b, err := json.Marshal(e.Event)
+		if err != nil {
+			return err
+		}
+		tx, err := db.Begin()
+		if err != nil {
+			return err
+		}
+		defer func() { _ = tx.Rollback() }()
+		if e.Seq > 0 {
+			_, err = tx.Exec(`INSERT OR REPLACE INTO run_events (run_id, seq, event_json) VALUES (?, ?, ?)`,
+				runID, e.Seq, string(b))
+		} else {
+			// Store-assigned sequence: terminal markers appended to a run whose
+			// log was never loaded into memory this process.
+			_, err = tx.Exec(`INSERT INTO run_events (run_id, seq, event_json)
+				SELECT ?, COALESCE(MAX(seq), 0) + 1, ? FROM run_events WHERE run_id = ?`,
+				runID, string(b), runID)
+		}
+		if err != nil {
+			return err
+		}
+		if summary != nil {
+			b, err := json.Marshal(*summary)
+			if err != nil {
+				return err
+			}
+			if _, err := tx.Exec(`INSERT INTO runs (id, created_at, updated_at, status, summary_json)
+				VALUES (?, ?, ?, ?, ?)
+				ON CONFLICT(id) DO UPDATE SET updated_at=excluded.updated_at,
+					status=excluded.status, summary_json=excluded.summary_json`,
+				summary.ID, summary.CreatedAt.UnixMilli(), summary.UpdatedAt.UnixMilli(),
+				summary.Status, string(b)); err != nil {
+				return err
+			}
+		}
+		return tx.Commit()
+	})
+}
+
+func (s *sqliteRunStore) LoadRuns() ([]RunSummary, error) {
+	s.barrier() // read-your-writes: drain queued ops so loads see them
+	rows, err := s.db.Query(`SELECT summary_json FROM runs ORDER BY created_at ASC, id ASC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []RunSummary
+	for rows.Next() {
+		var raw string
+		if err := rows.Scan(&raw); err != nil {
+			return nil, err
+		}
+		var sum RunSummary
+		if err := json.Unmarshal([]byte(raw), &sum); err != nil {
+			continue // one corrupt row shouldn't lose the rest of history
+		}
+		out = append(out, sum)
+	}
+	return out, rows.Err()
+}
+
+func (s *sqliteRunStore) LoadEvents(runID string) ([]RunEvent, error) {
+	s.barrier() // read-your-writes: a hydration right after markStale/startup must see those markers
+	rows, err := s.db.Query(`SELECT seq, event_json FROM run_events WHERE run_id = ? ORDER BY seq ASC`, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []RunEvent
+	for rows.Next() {
+		var seq int
+		var raw string
+		if err := rows.Scan(&seq, &raw); err != nil {
+			return nil, err
+		}
+		var ev StreamEvent
+		if err := json.Unmarshal([]byte(raw), &ev); err != nil {
+			continue
+		}
+		out = append(out, RunEvent{Seq: seq, Event: ev})
+	}
+	return out, rows.Err()
+}
+
+func (s *sqliteRunStore) DeleteRun(id string) {
+	s.enqueue(func(db *sql.DB) error {
+		if _, err := db.Exec(`DELETE FROM run_events WHERE run_id = ?`, id); err != nil {
+			return err
+		}
+		_, err := db.Exec(`DELETE FROM runs WHERE id = ?`, id)
+		return err
+	})
+}
+
+func (s *sqliteRunStore) Clear() error {
+	var out error
+	s.enqueueWait(func(db *sql.DB) error {
+		if _, err := db.Exec(`DELETE FROM run_events`); err != nil {
+			out = err
+			return err
+		}
+		_, err := db.Exec(`DELETE FROM runs`)
+		out = err
+		return err
+	})
+	return out
+}
+
+func (s *sqliteRunStore) Degraded() bool { return s.degraded.Load() }
+
+// Close drains pending writes and closes the DB. Late writers (agent goroutines
+// finishing after shutdown began) become no-ops via the closed flag; the flag
+// flip and the channel close happen under the write lock, so no sender can race
+// them.
+func (s *sqliteRunStore) Close() {
+	s.closeMu.Lock()
+	if s.closed {
+		s.closeMu.Unlock()
+		return
+	}
+	s.closed = true
+	close(s.ops)
+	s.closeMu.Unlock()
+	<-s.done
+	_ = s.db.Close()
+}

--- a/internal/ai/store_test.go
+++ b/internal/ai/store_test.go
@@ -1,0 +1,115 @@
+package ai
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func testStore(t *testing.T) (RunStore, string) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "ai-runs.db")
+	st, err := OpenRunStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(st.Close)
+	return st, dbPath
+}
+
+func TestStoreRoundtrip(t *testing.T) {
+	st, _ := testStore(t)
+	sum := RunSummary{
+		ID: "run-1", Kind: "Pod", Namespace: "ns", Name: "p", Context: "ctx-a",
+		Agent: "claude", Status: "running", SessionID: "sess-1",
+		CreatedAt: time.Now().UTC().Truncate(time.Millisecond),
+		UpdatedAt: time.Now().UTC().Truncate(time.Millisecond),
+	}
+	st.SaveRun(sum)
+	st.AppendEvent("run-1", RunEvent{Seq: 1, Event: StreamEvent{Type: "turn"}}, nil)
+	st.AppendEvent("run-1", RunEvent{Seq: 2, Event: StreamEvent{Type: "thinking", Token: "hmm"}}, nil)
+	// Terminal event rides with its summary in one transaction.
+	sum.Status = "done"
+	st.AppendEvent("run-1", RunEvent{Seq: 3, Event: StreamEvent{Type: "done"}}, &sum)
+	st.(*sqliteRunStore).barrier()
+
+	runs, err := st.LoadRuns()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runs) != 1 || runs[0].ID != "run-1" || runs[0].Status != "done" || runs[0].SessionID != "sess-1" {
+		t.Fatalf("LoadRuns = %+v", runs)
+	}
+	events, err := st.LoadEvents("run-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 3 || events[0].Seq != 1 || events[2].Event.Type != "done" {
+		t.Fatalf("LoadEvents = %+v", events)
+	}
+	if events[1].Event.Token != "hmm" {
+		t.Errorf("event payload lost: %+v", events[1])
+	}
+}
+
+func TestStoreAutoSeq(t *testing.T) {
+	st, _ := testStore(t)
+	st.AppendEvent("run-9", RunEvent{Seq: 1, Event: StreamEvent{Type: "turn"}}, nil)
+	// Seq 0 = store-assigned MAX+1: terminal markers on never-hydrated runs.
+	st.AppendEvent("run-9", RunEvent{Event: StreamEvent{Type: "error", Error: "stale"}}, nil)
+	st.AppendEvent("run-9", RunEvent{Event: StreamEvent{Type: "closed"}}, nil)
+	st.(*sqliteRunStore).barrier()
+
+	events, err := st.LoadEvents("run-9")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 3 || events[1].Seq != 2 || events[2].Seq != 3 {
+		t.Fatalf("auto-seq mis-assigned: %+v", events)
+	}
+	if events[2].Event.Type != "closed" {
+		t.Errorf("order lost: %+v", events)
+	}
+}
+
+func TestStoreDeleteAndClear(t *testing.T) {
+	st, _ := testStore(t)
+	for _, id := range []string{"run-1", "run-2"} {
+		st.SaveRun(RunSummary{ID: id, Status: "done", CreatedAt: time.Now(), UpdatedAt: time.Now()})
+		st.AppendEvent(id, RunEvent{Seq: 1, Event: StreamEvent{Type: "turn"}}, nil)
+	}
+	st.DeleteRun("run-1")
+	st.(*sqliteRunStore).barrier()
+	runs, _ := st.LoadRuns()
+	if len(runs) != 1 || runs[0].ID != "run-2" {
+		t.Fatalf("DeleteRun left %+v", runs)
+	}
+	if err := st.Clear(); err != nil {
+		t.Fatal(err)
+	}
+	runs, _ = st.LoadRuns()
+	events, _ := st.LoadEvents("run-2")
+	if len(runs) != 0 || len(events) != 0 {
+		t.Fatalf("Clear left runs=%d events=%d", len(runs), len(events))
+	}
+}
+
+func TestStoreFilePermissions(t *testing.T) {
+	_, dbPath := testStore(t)
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("history DB is %v, want 0600 — transcripts hold cluster data", perm)
+	}
+}
+
+func TestStoreOpenFailureIsClean(t *testing.T) {
+	// A path whose parent can't be created must error (caller degrades to
+	// memory-only), not panic or half-open.
+	if _, err := OpenRunStore(filepath.Join(string([]byte{0}), "nope.db")); err == nil {
+		t.Fatal("expected open error for impossible path")
+	}
+}

--- a/internal/ai/store_test.go
+++ b/internal/ai/store_test.go
@@ -85,7 +85,7 @@ func TestStoreDeleteAndClear(t *testing.T) {
 	if len(runs) != 1 || runs[0].ID != "run-2" {
 		t.Fatalf("DeleteRun left %+v", runs)
 	}
-	if err := st.Clear(); err != nil {
+	if err := st.Clear(nil); err != nil {
 		t.Fatal(err)
 	}
 	runs, _ = st.LoadRuns()

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -57,6 +57,8 @@ type AppConfig struct {
 	PrometheusHeadersFromEnv map[string]string
 	Version                  string
 	MCPEnabled               bool
+	AIHistory                bool   // persist AI investigations across restarts
+	AIHistoryDBPath          string // "" = ~/.radar/ai-runs.db
 	AuthConfig               auth.Config
 }
 
@@ -263,6 +265,18 @@ func CreateServer(cfg AppConfig) *server.Server {
 			HasPrometheusHeaders: len(cfg.PrometheusHeaders) > 0,
 		},
 		AuthConfig: cfg.AuthConfig,
+	}
+
+	// AI-history DB path: resolved here (like the timeline DB) so the server
+	// only sees a ready-to-open path. Only meaningful where the AI engine can
+	// actually enable (no-auth + MCP mounted) — the server checks that gate.
+	if cfg.AIHistory {
+		dbPath := cfg.AIHistoryDBPath
+		if dbPath == "" {
+			homeDir, _ := os.UserHomeDir()
+			dbPath = filepath.Join(homeDir, ".radar", "ai-runs.db")
+		}
+		serverCfg.AIHistoryDB = dbPath
 	}
 
 	if cfg.MCPEnabled {

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -425,11 +425,19 @@ func InitializeCluster() {
 	}()
 }
 
+// mcpPortFileDisabled suppresses port-file writes AND removals — an ephemeral
+// instance (radar diagnose --standalone) must never clobber or delete the slot
+// a real long-running Radar owns.
+var mcpPortFileDisabled bool
+
+// DisableMCPPortFile makes Write/RemoveMCPPortFile no-ops for this process.
+func DisableMCPPortFile() { mcpPortFileDisabled = true }
+
 // WriteMCPPortFile writes the actual server port to ~/.radar/mcp-port so MCP
 // clients can discover the running instance without hardcoding a port.
 func WriteMCPPortFile(port int) {
 	path := mcpPortFilePath()
-	if path == "" {
+	if path == "" || mcpPortFileDisabled {
 		return
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -446,7 +454,7 @@ func WriteMCPPortFile(port int) {
 // RemoveMCPPortFile removes the port discovery file on shutdown.
 func RemoveMCPPortFile() {
 	path := mcpPortFilePath()
-	if path == "" {
+	if path == "" || mcpPortFileDisabled {
 		return
 	}
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,12 @@ type Config struct {
 	AIHistory *bool `json:"aiHistory,omitempty"`
 	// AIHistoryDBPath overrides the history DB location (default ~/.radar/ai-runs.db).
 	AIHistoryDBPath string `json:"aiHistoryDbPath,omitempty"`
+	// AIConsent records the acknowledged AI-diagnosis disclosure version per
+	// surface ("standard", "cursor"). Machine-scoped on purpose: consent gates a
+	// machine-scoped action (spawn this machine's agent CLI, persist transcripts
+	// to this machine's disk), so one acknowledgment covers the web panel and
+	// the `radar diagnose` CLI alike.
+	AIConsent map[string]string `json:"aiConsent,omitempty"`
 }
 
 // mu serializes Load-mutate-Save cycles to prevent concurrent writes

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,11 @@ type Config struct {
 	// pods. Empty falls back to busybox:latest; set it to a reachable mirror for
 	// air-gapped / private-registry clusters.
 	DebugImage string `json:"debugImage,omitempty"`
+	// AIHistory persists AI investigations (transcripts + verdicts) to a local
+	// SQLite file so they survive restarts. nil = default (true), false = off.
+	AIHistory *bool `json:"aiHistory,omitempty"`
+	// AIHistoryDBPath overrides the history DB location (default ~/.radar/ai-runs.db).
+	AIHistoryDBPath string `json:"aiHistoryDbPath,omitempty"`
 }
 
 // mu serializes Load-mutate-Save cycles to prevent concurrent writes
@@ -127,6 +132,14 @@ func (c Config) HistoryLimitOr(def int) int {
 func (c Config) MCPEnabledOr(def bool) bool {
 	if c.MCP != nil {
 		return *c.MCP
+	}
+	return def
+}
+
+// AIHistoryOr returns *c.AIHistory if non-nil, otherwise the provided default.
+func (c Config) AIHistoryOr(def bool) bool {
+	if c.AIHistory != nil {
+		return *c.AIHistory
 	}
 	return def
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,42 @@ type Config struct {
 	AIConsent map[string]string `json:"aiConsent,omitempty"`
 }
 
+// AI-diagnosis consent disclosure versions, per surface. THE single source of
+// truth for the server endpoint and the CLI's standalone path alike — bump when
+// the consent copy's claims change materially, and prior acknowledgments stop
+// counting everywhere at once. (standard v3: transcripts persist to local
+// history; cursor v2: same disclosure on Cursor's distinct trust model.)
+var aiConsentVersions = map[string]string{
+	"standard": "v3",
+	"cursor":   "v2",
+}
+
+// AIConsentVersion returns the current disclosure version for a surface
+// ("" for an unknown surface).
+func AIConsentVersion(surface string) string { return aiConsentVersions[surface] }
+
+// AIConsentGiven reports whether the CURRENT disclosure version for the surface
+// has been acknowledged on this machine.
+func AIConsentGiven(surface string) bool {
+	v := aiConsentVersions[surface]
+	return v != "" && Load().AIConsent[surface] == v
+}
+
+// RecordAIConsent acknowledges the current disclosure version for a surface.
+func RecordAIConsent(surface string) error {
+	v := aiConsentVersions[surface]
+	if v == "" {
+		return os.ErrInvalid
+	}
+	_, err := Update(func(c *Config) {
+		if c.AIConsent == nil {
+			c.AIConsent = map[string]string{}
+		}
+		c.AIConsent[surface] = v
+	})
+	return err
+}
+
 // mu serializes Load-mutate-Save cycles to prevent concurrent writes
 // from overwriting each other's changes.
 var mu sync.Mutex

--- a/internal/diagnosecli/diagnosecli.go
+++ b/internal/diagnosecli/diagnosecli.go
@@ -1,0 +1,420 @@
+// Package diagnosecli implements `radar diagnose` — a terminal client for the
+// AI-diagnosis engine of a RUNNING radar instance. It is deliberately a thin
+// client over the same REST+SSE contract the web panel uses: the run it starts
+// is the same durable server-side job, so it can be watched or continued from
+// the UI (and vice versa).
+package diagnosecli
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/term"
+)
+
+// kindAliases maps kubectl-style short/plural names to the canonical Kind.
+var kindAliases = map[string]string{
+	"po": "Pod", "pod": "Pod", "pods": "Pod",
+	"deploy": "Deployment", "deployment": "Deployment", "deployments": "Deployment",
+	"sts": "StatefulSet", "statefulset": "StatefulSet", "statefulsets": "StatefulSet",
+	"ds": "DaemonSet", "daemonset": "DaemonSet", "daemonsets": "DaemonSet",
+	"rs": "ReplicaSet", "replicaset": "ReplicaSet", "replicasets": "ReplicaSet",
+	"svc": "Service", "service": "Service", "services": "Service",
+	"ing": "Ingress", "ingress": "Ingress", "ingresses": "Ingress",
+	"no": "Node", "node": "Node", "nodes": "Node",
+	"job": "Job", "jobs": "Job",
+	"cj": "CronJob", "cronjob": "CronJob", "cronjobs": "CronJob",
+	"cm": "ConfigMap", "configmap": "ConfigMap", "configmaps": "ConfigMap",
+	"secret": "Secret", "secrets": "Secret",
+	"ns": "Namespace", "namespace": "Namespace", "namespaces": "Namespace",
+	"pvc": "PersistentVolumeClaim", "persistentvolumeclaim": "PersistentVolumeClaim",
+	"pv": "PersistentVolume", "persistentvolume": "PersistentVolume",
+	"hpa": "HorizontalPodAutoscaler", "horizontalpodautoscaler": "HorizontalPodAutoscaler",
+}
+
+// normalizeKind resolves kubectl-style aliases; anything unknown is passed
+// through title-cased — the server and the agent's own tools resolve kinds
+// loosely, so this only needs to be friendly, not exhaustive.
+func normalizeKind(k string) string {
+	if canonical, ok := kindAliases[strings.ToLower(k)]; ok {
+		return canonical
+	}
+	if k == "" {
+		return k
+	}
+	return strings.ToUpper(k[:1]) + k[1:]
+}
+
+type options struct {
+	namespace string
+	agent     string
+	server    string
+	jsonOut   bool
+	open      bool
+	yes       bool
+}
+
+func newFlagSet() (*flag.FlagSet, *options) {
+	fs := flag.NewFlagSet("diagnose", flag.ContinueOnError)
+	o := &options{}
+	fs.StringVar(&o.namespace, "n", "", "Namespace of the resource")
+	fs.StringVar(&o.namespace, "namespace", "", "Namespace of the resource")
+	fs.StringVar(&o.agent, "agent", "", "Agent backend to use (claude|codex|cursor-agent; default = server's pick)")
+	fs.StringVar(&o.server, "server", "", "Radar server URL (default: discover the running instance via ~/.radar/mcp-port)")
+	fs.BoolVar(&o.jsonOut, "json", false, "Print the final verdict as JSON on stdout (progress goes to stderr)")
+	fs.BoolVar(&o.open, "open", false, "Also open the investigation in the Radar UI")
+	fs.BoolVar(&o.yes, "yes", false, "Skip the first-run consent prompt")
+	return fs, o
+}
+
+// Run executes `radar diagnose <kind>/<name>` and returns the process exit code.
+func Run(args []string, openBrowser func(url string)) int {
+	fs, o := newFlagSet()
+	fs.Usage = func() {
+		fmt.Fprint(os.Stderr, `Usage: radar diagnose <kind>/<name> [-n namespace] [flags]
+
+Runs an AI investigation of a Kubernetes resource using your own local agent
+CLI (Claude Code, Codex, or Cursor) against the running Radar instance — no
+API key, no cloud. The investigation is a durable Radar job: watch it here,
+in the Radar UI, or continue it in your own agent afterwards.
+
+Examples:
+  radar diagnose pod/checkout-6f4d -n prod
+  radar diagnose deploy/api --json > verdict.json
+  radar diagnose node/ip-10-0-3-36 --open
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	// Interleaved parse: Go's flag package stops at the first positional, but
+	// kubectl users write `radar diagnose pod/web -n prod` — collect positionals
+	// and keep parsing the remainder so flags may appear on either side.
+	var positionals []string
+	rest := args
+	for {
+		if err := fs.Parse(rest); err != nil {
+			return 2
+		}
+		if fs.NArg() == 0 {
+			break
+		}
+		positionals = append(positionals, fs.Arg(0))
+		rest = fs.Args()[1:]
+	}
+	if len(positionals) != 1 && len(positionals) != 2 {
+		fs.Usage()
+		return 2
+	}
+	var kind, name string
+	if len(positionals) == 2 {
+		kind, name = positionals[0], positionals[1]
+	} else {
+		var ok bool
+		kind, name, ok = strings.Cut(positionals[0], "/")
+		if !ok {
+			fmt.Fprintf(os.Stderr, "target must be <kind>/<name> (e.g. pod/web), got %q\n", positionals[0])
+			return 2
+		}
+	}
+	kind = normalizeKind(kind)
+
+	out := newRenderer(o.jsonOut)
+
+	base, err := resolveServer(o.server)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	agents, err := fetchAgents(base)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "found Radar at %s but couldn't query it: %v\n", base, err)
+		return 1
+	}
+	if !agents.Enabled {
+		fmt.Fprintln(os.Stderr, "AI diagnosis is disabled on this Radar instance — install Claude Code, Codex, or Cursor and restart radar.")
+		return 1
+	}
+
+	if !o.yes && !consentGiven() {
+		if !promptConsent(agents.label(o.agent)) {
+			fmt.Fprintln(os.Stderr, "aborted")
+			return 1
+		}
+	}
+
+	run, err := startRun(base, kind, o.namespace, name, o.agent)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	out.header(run, base)
+	if o.open {
+		openBrowser(base + "/?ai-run=" + run.ID)
+	}
+
+	diag, ok := streamRun(base, run.ID, out)
+	if !ok {
+		return 1
+	}
+	if o.jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(map[string]any{
+			"run": run.ID, "kind": run.Kind, "namespace": run.Namespace, "name": run.Name,
+			"agent": run.Agent, "diagnosis": diag,
+		})
+	}
+	return 0
+}
+
+// --- server discovery -------------------------------------------------------
+
+func resolveServer(explicit string) (string, error) {
+	if explicit != "" {
+		return strings.TrimRight(explicit, "/"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home dir: %w", err)
+	}
+	b, err := os.ReadFile(filepath.Join(home, ".radar", "mcp-port"))
+	if err != nil {
+		return "", fmt.Errorf("no running Radar found (%s missing) — start radar first, or pass --server http://localhost:<port>",
+			filepath.Join(home, ".radar", "mcp-port"))
+	}
+	port, err := strconv.Atoi(strings.TrimSpace(string(b)))
+	if err != nil || port <= 0 {
+		return "", fmt.Errorf("~/.radar/mcp-port is unreadable — is radar running? (or pass --server)")
+	}
+	return fmt.Sprintf("http://localhost:%d", port), nil
+}
+
+type agentsResponse struct {
+	Enabled bool `json:"enabled"`
+	Agents  []struct {
+		Name      string `json:"name"`
+		Label     string `json:"label"`
+		Supported bool   `json:"supported"`
+	} `json:"agents"`
+}
+
+func (a agentsResponse) label(pick string) string {
+	for _, ag := range a.Agents {
+		if ag.Name == pick || (pick == "" && ag.Supported) {
+			return ag.Label
+		}
+	}
+	return "your agent CLI"
+}
+
+func fetchAgents(base string) (agentsResponse, error) {
+	var out agentsResponse
+	err := getJSON(base+"/api/agents", &out)
+	return out, err
+}
+
+// --- consent ----------------------------------------------------------------
+
+func consentMarkerPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".radar", "cli-ai-consent")
+}
+
+func consentGiven() bool {
+	p := consentMarkerPath()
+	if p == "" {
+		return false
+	}
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+// promptConsent mirrors the UI's one-time consent card. Interactive terminals
+// get a real y/N gate; non-interactive callers (CI) get the disclosure on
+// stderr and proceed — an explicit `radar diagnose` invocation in a script is
+// already an informed act, and a blocking prompt there would just break CI.
+func promptConsent(agentLabel string) bool {
+	notice := fmt.Sprintf(`This runs your own %s on your machine — no Radar cloud, no API key.
+Radar sends the resource's spec, recent events, and pod logs to it (and on to
+its model provider under your account). Through Radar the agent can only READ
+your cluster. Transcripts are kept in your local Radar history until cleared.
+`, agentLabel)
+	fmt.Fprint(os.Stderr, notice)
+	// A real ioctl-backed check — os.ModeCharDevice would misread /dev/null
+	// (and daemon-inherited stdin) as an interactive terminal.
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return true
+	}
+	fmt.Fprint(os.Stderr, "Proceed? [y/N] ")
+	line, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+	if s := strings.ToLower(strings.TrimSpace(line)); s != "y" && s != "yes" {
+		return false
+	}
+	if p := consentMarkerPath(); p != "" {
+		_ = os.MkdirAll(filepath.Dir(p), 0o700)
+		_ = os.WriteFile(p, []byte("1\n"), 0o600)
+	}
+	return true
+}
+
+// --- run start + stream ------------------------------------------------------
+
+type runSummary struct {
+	ID        string `json:"id"`
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	Agent     string `json:"agent"`
+	SessionID string `json:"sessionId"`
+}
+
+func startRun(base, kind, namespace, name, agent string) (runSummary, error) {
+	body, _ := json.Marshal(map[string]any{
+		"kind": kind, "namespace": namespace, "name": name, "agent": agent,
+	})
+	resp, err := http.Post(base+"/api/diagnose/runs", "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		return runSummary{}, fmt.Errorf("couldn't start the investigation: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return runSummary{}, fmt.Errorf("couldn't start the investigation: %s", apiError(resp))
+	}
+	var run runSummary
+	if err := json.NewDecoder(resp.Body).Decode(&run); err != nil {
+		return runSummary{}, fmt.Errorf("unexpected response: %w", err)
+	}
+	return run, nil
+}
+
+type streamEvent struct {
+	Type  string          `json:"type"`
+	Token string          `json:"token"`
+	Error string          `json:"error"`
+	Step  *stepInfo       `json:"step"`
+	Diag  json.RawMessage `json:"diagnosis"`
+}
+
+type stepInfo struct {
+	ID      string `json:"id"`
+	Tool    string `json:"tool"`
+	Status  string `json:"status"`
+	Ms      *int64 `json:"ms"`
+	Summary string `json:"summary"`
+}
+
+// diagnosis mirrors the verdict fields the terminal renders.
+type diagnosis struct {
+	Healthy           bool     `json:"healthy"`
+	Inconclusive      bool     `json:"inconclusive"`
+	RootCause         string   `json:"rootCause"`
+	Report            string   `json:"report"`
+	Remediation       []string `json:"remediation"`
+	RecommendedIndex  *int     `json:"recommendedIndex"`
+	RecommendedReason string   `json:"recommendedReason"`
+	Confidence        *float64 `json:"confidence"`
+	SessionID         string   `json:"sessionId"`
+}
+
+// streamRun consumes the run's SSE stream until the FIRST turn terminates.
+// Returns the raw diagnosis JSON (for --json) and whether the turn succeeded.
+func streamRun(base, id string, out *renderer) (json.RawMessage, bool) {
+	resp, err := http.Get(base + "/api/diagnose/runs/" + id + "/stream")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "stream failed: %v\n", err)
+		return nil, false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(os.Stderr, "stream failed: %s\n", apiError(resp))
+		return nil, false
+	}
+
+	sc := bufio.NewScanner(resp.Body)
+	sc.Buffer(make([]byte, 0, 64*1024), 4<<20)
+	steps := map[string]stepInfo{}
+	for sc.Scan() {
+		line := sc.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var ev streamEvent
+		if json.Unmarshal([]byte(line[len("data: "):]), &ev) != nil {
+			continue
+		}
+		switch ev.Type {
+		case "thinking":
+			out.thinking(ev.Token)
+		case "step":
+			if ev.Step == nil {
+				continue
+			}
+			// The done event omits tool/summary; merge with the running one.
+			cur := steps[ev.Step.ID]
+			if ev.Step.Tool != "" {
+				cur.Tool = ev.Step.Tool
+			}
+			if ev.Step.Summary != "" {
+				cur.Summary = ev.Step.Summary
+			}
+			cur.Ms = ev.Step.Ms
+			cur.Status = ev.Step.Status
+			steps[ev.Step.ID] = cur
+			if ev.Step.Status == "done" {
+				out.step(cur)
+			}
+		case "done":
+			var d diagnosis
+			_ = json.Unmarshal(ev.Diag, &d)
+			out.verdict(d)
+			return ev.Diag, true
+		case "error":
+			out.errorLine(ev.Error)
+			return nil, false
+		case "closed":
+			out.errorLine("The investigation is no longer available.")
+			return nil, false
+		}
+	}
+	fmt.Fprintln(os.Stderr, "stream ended unexpectedly — the run keeps going; watch it in the Radar UI")
+	return nil, false
+}
+
+// --- helpers ------------------------------------------------------------------
+
+func getJSON(url string, into any) error {
+	client := http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s", apiError(resp))
+	}
+	return json.NewDecoder(resp.Body).Decode(into)
+}
+
+func apiError(resp *http.Response) string {
+	b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	var e struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal(b, &e) == nil && e.Error != "" {
+		return e.Error
+	}
+	return resp.Status
+}

--- a/internal/diagnosecli/diagnosecli.go
+++ b/internal/diagnosecli/diagnosecli.go
@@ -137,7 +137,14 @@ Flags:
 	}
 	agents, err := fetchAgents(base)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "found Radar at %s but couldn't query it: %v\n", base, err)
+		// A 404 here means SOMETHING answered but has no /api/agents — almost
+		// always an older Radar (or a stale ~/.radar/mcp-port pointing at one
+		// when several instances ran). Say that, not just "404".
+		if strings.Contains(err.Error(), "404") {
+			fmt.Fprintf(os.Stderr, "the Radar at %s doesn't support AI diagnosis — it's likely an older version (or a stale ~/.radar/mcp-port from another instance). Upgrade/restart it, or pass --server for the right instance.\n", base)
+		} else {
+			fmt.Fprintf(os.Stderr, "found Radar at %s but couldn't query it: %v\n", base, err)
+		}
 		return 1
 	}
 	if !agents.Enabled {

--- a/internal/diagnosecli/diagnosecli.go
+++ b/internal/diagnosecli/diagnosecli.go
@@ -165,8 +165,10 @@ Flags:
 		// read/write the shared machine-scoped store (~/.radar/config.json)
 		// directly — the ephemeral server then sees it as already given.
 		surface := consentSurface(o.agent)
-		if !o.yes && !consentGivenLocal(surface) {
-			if !promptConsent(localAgentLabel(o.agent), surface, recordConsentLocal) {
+		if !consentGivenLocal(surface) {
+			if o.yes {
+				recordConsentLocal(surface)
+			} else if !promptConsent(localAgentLabel(o.agent), surface, recordConsentLocal) {
 				fmt.Fprintln(os.Stderr, "aborted")
 				return 1
 			}
@@ -198,8 +200,12 @@ Flags:
 	}
 
 	surface := consentSurface(o.agent)
-	if !o.yes && !agents.Consented[surface] {
-		if !promptConsent(agents.label(o.agent), surface, func(sf string) { recordConsentHTTP(base, sf) }) {
+	if !agents.Consented[surface] {
+		if o.yes {
+			// --yes acknowledges the disclosure; the server enforces consent at
+			// start, so it must be recorded, not just skipped.
+			recordConsentHTTP(base, surface)
+		} else if !promptConsent(agents.label(o.agent), surface, func(sf string) { recordConsentHTTP(base, sf) }) {
 			fmt.Fprintln(os.Stderr, "aborted")
 			return 1
 		}
@@ -342,6 +348,10 @@ them) — if any of those can make changes, Cursor could use them.
 	// A real ioctl-backed check — os.ModeCharDevice would misread /dev/null
 	// (and daemon-inherited stdin) as an interactive terminal.
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		// Non-interactive callers proceed after the disclosure (an explicit
+		// invocation in a script is an informed act) — and must RECORD it,
+		// because the server enforces consent at start.
+		record(surface)
 		return true
 	}
 	fmt.Fprint(os.Stderr, "Proceed? [y/N] ")

--- a/internal/diagnosecli/diagnosecli.go
+++ b/internal/diagnosecli/diagnosecli.go
@@ -7,6 +7,7 @@ package diagnosecli
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -19,6 +20,8 @@ import (
 	"time"
 
 	"golang.org/x/term"
+
+	"github.com/skyhook-io/radar/internal/ai"
 )
 
 // kindAliases maps kubectl-style short/plural names to the canonical Kind.
@@ -55,12 +58,14 @@ func normalizeKind(k string) string {
 }
 
 type options struct {
-	namespace string
-	agent     string
-	server    string
-	jsonOut   bool
-	open      bool
-	yes       bool
+	namespace  string
+	agent      string
+	server     string
+	kubeconfig string
+	standalone bool
+	jsonOut    bool
+	open       bool
+	yes        bool
 }
 
 func newFlagSet() (*flag.FlagSet, *options) {
@@ -73,6 +78,8 @@ func newFlagSet() (*flag.FlagSet, *options) {
 	fs.BoolVar(&o.jsonOut, "json", false, "Print the final verdict as JSON on stdout (progress goes to stderr)")
 	fs.BoolVar(&o.open, "open", false, "Also open the investigation in the Radar UI")
 	fs.BoolVar(&o.yes, "yes", false, "Skip the first-run consent prompt")
+	fs.BoolVar(&o.standalone, "standalone", false, "Run against a temporary in-process Radar instead of a running instance (slower: connects to the cluster first)")
+	fs.StringVar(&o.kubeconfig, "kubeconfig", "", "Kubeconfig for --standalone (default: ~/.kube/config)")
 	return fs, o
 }
 
@@ -130,18 +137,52 @@ Flags:
 
 	out := newRenderer(o.jsonOut)
 
-	base, err := resolveServer(o.server)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return 1
+	// Resolve the engine: an explicit --server, else the running instance from
+	// ~/.radar/mcp-port, else fall back to a temporary in-process Radar (what
+	// --standalone forces). Cold start pays a cluster connect up front — the
+	// running-instance path stays the fast default.
+	standalone := o.standalone
+	var base string
+	if !standalone {
+		var err error
+		base, err = resolveServer(o.server)
+		if err != nil || !probeListening(base) {
+			if o.server != "" {
+				// An explicit --server that isn't answering is an error, not a
+				// cue to boot something else.
+				fmt.Fprintf(os.Stderr, "nothing is listening at %s\n", o.server)
+				return 1
+			}
+			fmt.Fprintln(os.Stderr, "no running Radar found — starting a temporary one for this investigation (use --server to target a running instance)")
+			standalone = true
+		}
 	}
+
+	if standalone {
+		// Consent BEFORE the boot: nobody wants to answer a prompt after
+		// watching a cluster connect for 30 seconds.
+		if !o.yes && !consentGiven() {
+			if !promptConsent(localAgentLabel(o.agent)) {
+				fmt.Fprintln(os.Stderr, "aborted")
+				return 1
+			}
+		}
+		b, shutdown, err := bootEphemeral(o.kubeconfig, false)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		defer shutdown()
+		base = b
+	}
+
 	agents, err := fetchAgents(base)
 	if err != nil {
 		// A 404 here means SOMETHING answered but has no /api/agents — almost
 		// always an older Radar (or a stale ~/.radar/mcp-port pointing at one
 		// when several instances ran). Say that, not just "404".
 		if strings.Contains(err.Error(), "404") {
-			fmt.Fprintf(os.Stderr, "the Radar at %s doesn't support AI diagnosis — it's likely an older version (or a stale ~/.radar/mcp-port from another instance). Upgrade/restart it, or pass --server for the right instance.\n", base)
+			fmt.Fprintf(os.Stderr, "the Radar at %s doesn't support AI diagnosis — it's likely an older version (or a stale ~/.radar/mcp-port from another instance). Upgrade/restart it, pass --server for the right instance, or use --standalone.\n", base)
 		} else {
 			fmt.Fprintf(os.Stderr, "found Radar at %s but couldn't query it: %v\n", base, err)
 		}
@@ -182,6 +223,20 @@ Flags:
 		})
 	}
 	return 0
+}
+
+// localAgentLabel names the agent for the standalone consent prompt by probing
+// PATH directly — there's no server to ask yet.
+func localAgentLabel(pick string) string {
+	for _, info := range ai.DetectAgents(context.Background(), false) {
+		if !info.Supported {
+			continue
+		}
+		if pick == "" || info.Name == pick {
+			return info.Label
+		}
+	}
+	return "your agent CLI"
 }
 
 // --- server discovery -------------------------------------------------------

--- a/internal/diagnosecli/diagnosecli.go
+++ b/internal/diagnosecli/diagnosecli.go
@@ -279,6 +279,20 @@ type runSummary struct {
 	Name      string `json:"name"`
 	Agent     string `json:"agent"`
 	SessionID string `json:"sessionId"`
+	ManagedBy string `json:"managedBy"`
+	Health    *struct {
+		IssueCount int `json:"issueCount"`
+		AuditCount int `json:"auditCount"`
+		Issues     []struct {
+			Severity string `json:"severity"`
+			Reason   string `json:"reason"`
+			Message  string `json:"message"`
+		} `json:"issues"`
+		AuditFindings []struct {
+			Reason  string `json:"reason"`
+			Message string `json:"message"`
+		} `json:"auditFindings"`
+	} `json:"health"`
 }
 
 func startRun(base, kind, namespace, name, agent string) (runSummary, error) {
@@ -343,6 +357,8 @@ func streamRun(base, id string, out *renderer) (json.RawMessage, bool) {
 		return nil, false
 	}
 
+	out.startSpinner()
+	defer out.stopSpinner()
 	sc := bufio.NewScanner(resp.Body)
 	sc.Buffer(make([]byte, 0, 64*1024), 4<<20)
 	steps := map[string]stepInfo{}

--- a/internal/diagnosecli/diagnosecli.go
+++ b/internal/diagnosecli/diagnosecli.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/term"
 
 	"github.com/skyhook-io/radar/internal/ai"
+	"github.com/skyhook-io/radar/internal/config"
 )
 
 // kindAliases maps kubectl-style short/plural names to the canonical Kind.
@@ -160,9 +161,12 @@ Flags:
 
 	if standalone {
 		// Consent BEFORE the boot: nobody wants to answer a prompt after
-		// watching a cluster connect for 30 seconds.
-		if !o.yes && !consentGiven() {
-			if !promptConsent(localAgentLabel(o.agent)) {
+		// watching a cluster connect for 30 seconds. No server exists yet, so
+		// read/write the shared machine-scoped store (~/.radar/config.json)
+		// directly — the ephemeral server then sees it as already given.
+		surface := consentSurface(o.agent)
+		if !o.yes && !consentGivenLocal(surface) {
+			if !promptConsent(localAgentLabel(o.agent), surface, recordConsentLocal) {
 				fmt.Fprintln(os.Stderr, "aborted")
 				return 1
 			}
@@ -193,8 +197,9 @@ Flags:
 		return 1
 	}
 
-	if !o.yes && !consentGiven() {
-		if !promptConsent(agents.label(o.agent)) {
+	surface := consentSurface(o.agent)
+	if !o.yes && !agents.Consented[surface] {
+		if !promptConsent(agents.label(o.agent), surface, func(sf string) { recordConsentHTTP(base, sf) }) {
 			fmt.Fprintln(os.Stderr, "aborted")
 			return 1
 		}
@@ -262,8 +267,9 @@ func resolveServer(explicit string) (string, error) {
 }
 
 type agentsResponse struct {
-	Enabled bool `json:"enabled"`
-	Agents  []struct {
+	Enabled   bool            `json:"enabled"`
+	Consented map[string]bool `json:"consented"`
+	Agents    []struct {
 		Name      string `json:"name"`
 		Label     string `json:"label"`
 		Supported bool   `json:"supported"`
@@ -287,33 +293,58 @@ func fetchAgents(base string) (agentsResponse, error) {
 
 // --- consent ----------------------------------------------------------------
 
-func consentMarkerPath() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
+// consentSurface maps an agent pick to its disclosure surface — Cursor's trust
+// model is materially different (its global MCP servers can't be excluded), so
+// it has its own.
+func consentSurface(agent string) string {
+	if agent == "cursor-agent" {
+		return "cursor"
 	}
-	return filepath.Join(home, ".radar", "cli-ai-consent")
+	return "standard"
 }
 
-func consentGiven() bool {
-	p := consentMarkerPath()
-	if p == "" {
-		return false
+// Consent versions mirror the server's (internal/server/ai_diagnose.go) — the
+// standalone path reads/writes the shared store directly, pre-boot.
+var consentVersions = map[string]string{"standard": "v3", "cursor": "v2"}
+
+func consentGivenLocal(surface string) bool {
+	return config.Load().AIConsent[surface] == consentVersions[surface]
+}
+
+func recordConsentLocal(surface string) {
+	_, _ = config.Update(func(c *config.Config) {
+		if c.AIConsent == nil {
+			c.AIConsent = map[string]string{}
+		}
+		c.AIConsent[surface] = consentVersions[surface]
+	})
+}
+
+// recordConsentHTTP persists consent via the running instance (same store).
+func recordConsentHTTP(base, surface string) {
+	body, _ := json.Marshal(map[string]string{"surface": surface})
+	resp, err := http.Post(base+"/api/diagnose/consent", "application/json", strings.NewReader(string(body)))
+	if err == nil {
+		_ = resp.Body.Close()
 	}
-	_, err := os.Stat(p)
-	return err == nil
 }
 
 // promptConsent mirrors the UI's one-time consent card. Interactive terminals
 // get a real y/N gate; non-interactive callers (CI) get the disclosure on
 // stderr and proceed — an explicit `radar diagnose` invocation in a script is
 // already an informed act, and a blocking prompt there would just break CI.
-func promptConsent(agentLabel string) bool {
+// record persists the acknowledgment to the shared machine-scoped store.
+func promptConsent(agentLabel, surface string, record func(surface string)) bool {
 	notice := fmt.Sprintf(`This runs your own %s on your machine — no Radar cloud, no API key.
 Radar sends the resource's spec, recent events, and pod logs to it (and on to
 its model provider under your account). Through Radar the agent can only READ
 your cluster. Transcripts are kept in your local Radar history until cleared.
 `, agentLabel)
+	if surface == "cursor" {
+		notice += `Note: Cursor also loads your own global MCP servers (Radar can't exclude
+them) — if any of those can make changes, Cursor could use them.
+`
+	}
 	fmt.Fprint(os.Stderr, notice)
 	// A real ioctl-backed check — os.ModeCharDevice would misread /dev/null
 	// (and daemon-inherited stdin) as an interactive terminal.
@@ -325,10 +356,7 @@ your cluster. Transcripts are kept in your local Radar history until cleared.
 	if s := strings.ToLower(strings.TrimSpace(line)); s != "y" && s != "yes" {
 		return false
 	}
-	if p := consentMarkerPath(); p != "" {
-		_ = os.MkdirAll(filepath.Dir(p), 0o700)
-		_ = os.WriteFile(p, []byte("1\n"), 0o600)
-	}
+	record(surface)
 	return true
 }
 

--- a/internal/diagnosecli/diagnosecli.go
+++ b/internal/diagnosecli/diagnosecli.go
@@ -164,7 +164,7 @@ Flags:
 		// watching a cluster connect for 30 seconds. No server exists yet, so
 		// read/write the shared machine-scoped store (~/.radar/config.json)
 		// directly — the ephemeral server then sees it as already given.
-		surface := consentSurface(o.agent)
+		surface := ai.ConsentSurfaceFor(o.agent)
 		if !consentGivenLocal(surface) {
 			if o.yes {
 				recordConsentLocal(surface)
@@ -173,7 +173,7 @@ Flags:
 				return 1
 			}
 		}
-		b, shutdown, err := bootEphemeral(o.kubeconfig, false)
+		b, shutdown, err := bootEphemeral(o.kubeconfig)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return 1
@@ -199,7 +199,7 @@ Flags:
 		return 1
 	}
 
-	surface := consentSurface(o.agent)
+	surface := ai.ConsentSurfaceFor(o.agent)
 	if !agents.Consented[surface] {
 		if o.yes {
 			// --yes acknowledges the disclosure; the server enforces consent at
@@ -298,16 +298,6 @@ func fetchAgents(base string) (agentsResponse, error) {
 }
 
 // --- consent ----------------------------------------------------------------
-
-// consentSurface maps an agent pick to its disclosure surface — Cursor's trust
-// model is materially different (its global MCP servers can't be excluded), so
-// it has its own.
-func consentSurface(agent string) string {
-	if agent == "cursor-agent" {
-		return "cursor"
-	}
-	return "standard"
-}
 
 // The standalone path reads/writes the shared store directly, pre-boot —
 // versions live in internal/config (one source of truth with the server).

--- a/internal/diagnosecli/diagnosecli.go
+++ b/internal/diagnosecli/diagnosecli.go
@@ -389,7 +389,9 @@ func streamRun(base, id string, out *renderer) (json.RawMessage, bool) {
 			cur.Ms = ev.Step.Ms
 			cur.Status = ev.Step.Status
 			steps[ev.Step.ID] = cur
-			if ev.Step.Status == "done" {
+			if ev.Step.Status == "running" {
+				out.toolStarted(cur.Tool)
+			} else if ev.Step.Status == "done" {
 				out.step(cur)
 			}
 		case "done":

--- a/internal/diagnosecli/diagnosecli.go
+++ b/internal/diagnosecli/diagnosecli.go
@@ -164,11 +164,15 @@ Flags:
 		// watching a cluster connect for 30 seconds. No server exists yet, so
 		// read/write the shared machine-scoped store (~/.radar/config.json)
 		// directly — the ephemeral server then sees it as already given.
-		surface := ai.ConsentSurfaceFor(o.agent)
+		effective := ai.EffectiveAgent(o.agent, ai.DetectAgents(context.Background(), false))
+		surface := ai.ConsentSurfaceFor(effective)
 		if !consentGivenLocal(surface) {
 			if o.yes {
-				recordConsentLocal(surface)
-			} else if !promptConsent(localAgentLabel(o.agent), surface, recordConsentLocal) {
+				if err := recordConsentLocal(surface); err != nil {
+					fmt.Fprintf(os.Stderr, "couldn't record consent: %v\n", err)
+					return 1
+				}
+			} else if !promptConsent(consentLabel(effective), surface, recordConsentLocal) {
 				fmt.Fprintln(os.Stderr, "aborted")
 				return 1
 			}
@@ -199,13 +203,17 @@ Flags:
 		return 1
 	}
 
-	surface := ai.ConsentSurfaceFor(o.agent)
+	effective := ai.EffectiveAgent(o.agent, agents.Agents)
+	surface := ai.ConsentSurfaceFor(effective)
 	if !agents.Consented[surface] {
 		if o.yes {
 			// --yes acknowledges the disclosure; the server enforces consent at
 			// start, so it must be recorded, not just skipped.
-			recordConsentHTTP(base, surface)
-		} else if !promptConsent(agents.label(o.agent), surface, func(sf string) { recordConsentHTTP(base, sf) }) {
+			if err := recordConsentHTTP(base, surface); err != nil {
+				fmt.Fprintf(os.Stderr, "couldn't record consent: %v\n", err)
+				return 1
+			}
+		} else if !promptConsent(consentLabel(effective), surface, func(sf string) error { return recordConsentHTTP(base, sf) }) {
 			fmt.Fprintln(os.Stderr, "aborted")
 			return 1
 		}
@@ -236,20 +244,6 @@ Flags:
 	return 0
 }
 
-// localAgentLabel names the agent for the standalone consent prompt by probing
-// PATH directly — there's no server to ask yet.
-func localAgentLabel(pick string) string {
-	for _, info := range ai.DetectAgents(context.Background(), false) {
-		if !info.Supported {
-			continue
-		}
-		if pick == "" || info.Name == pick {
-			return info.Label
-		}
-	}
-	return "your agent CLI"
-}
-
 // --- server discovery -------------------------------------------------------
 
 func resolveServer(explicit string) (string, error) {
@@ -275,20 +269,7 @@ func resolveServer(explicit string) (string, error) {
 type agentsResponse struct {
 	Enabled   bool            `json:"enabled"`
 	Consented map[string]bool `json:"consented"`
-	Agents    []struct {
-		Name      string `json:"name"`
-		Label     string `json:"label"`
-		Supported bool   `json:"supported"`
-	} `json:"agents"`
-}
-
-func (a agentsResponse) label(pick string) string {
-	for _, ag := range a.Agents {
-		if ag.Name == pick || (pick == "" && ag.Supported) {
-			return ag.Label
-		}
-	}
-	return "your agent CLI"
+	Agents    []ai.AgentInfo  `json:"agents"`
 }
 
 func fetchAgents(base string) (agentsResponse, error) {
@@ -305,17 +286,33 @@ func consentGivenLocal(surface string) bool {
 	return config.AIConsentGiven(surface)
 }
 
-func recordConsentLocal(surface string) {
-	_ = config.RecordAIConsent(surface)
+func recordConsentLocal(surface string) error {
+	return config.RecordAIConsent(surface)
 }
 
 // recordConsentHTTP persists consent via the running instance (same store).
-func recordConsentHTTP(base, surface string) {
+// Failures must surface: the server enforces consent at start, so a swallowed
+// write here turns into a baffling 403 one request later.
+func recordConsentHTTP(base, surface string) error {
 	body, _ := json.Marshal(map[string]string{"surface": surface})
 	resp, err := http.Post(base+"/api/diagnose/consent", "application/json", strings.NewReader(string(body)))
-	if err == nil {
-		_ = resp.Body.Close()
+	if err != nil {
+		return err
 	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s", apiError(resp))
+	}
+	return nil
+}
+
+// consentLabel names the agent in the disclosure. effective is "" only when no
+// supported CLI is detected — the run fails later with its own clearer error.
+func consentLabel(effective string) string {
+	if effective == "" {
+		return "your agent CLI"
+	}
+	return ai.AgentLabel(effective)
 }
 
 // promptConsent mirrors the UI's one-time consent card. Interactive terminals
@@ -323,7 +320,7 @@ func recordConsentHTTP(base, surface string) {
 // stderr and proceed — an explicit `radar diagnose` invocation in a script is
 // already an informed act, and a blocking prompt there would just break CI.
 // record persists the acknowledgment to the shared machine-scoped store.
-func promptConsent(agentLabel, surface string, record func(surface string)) bool {
+func promptConsent(agentLabel, surface string, record func(surface string) error) bool {
 	notice := fmt.Sprintf(`This runs your own %s on your machine — no Radar cloud, no API key.
 Radar sends the resource's spec, recent events, and pod logs to it (and on to
 its model provider under your account). Through Radar the agent can only READ
@@ -341,15 +338,21 @@ them) — if any of those can make changes, Cursor could use them.
 		// Non-interactive callers proceed after the disclosure (an explicit
 		// invocation in a script is an informed act) — and must RECORD it,
 		// because the server enforces consent at start.
-		record(surface)
-		return true
+		return recordOrReport(record, surface)
 	}
 	fmt.Fprint(os.Stderr, "Proceed? [y/N] ")
 	line, _ := bufio.NewReader(os.Stdin).ReadString('\n')
 	if s := strings.ToLower(strings.TrimSpace(line)); s != "y" && s != "yes" {
 		return false
 	}
-	record(surface)
+	return recordOrReport(record, surface)
+}
+
+func recordOrReport(record func(string) error, surface string) bool {
+	if err := record(surface); err != nil {
+		fmt.Fprintf(os.Stderr, "couldn't record consent: %v\n", err)
+		return false
+	}
 	return true
 }
 

--- a/internal/diagnosecli/diagnosecli.go
+++ b/internal/diagnosecli/diagnosecli.go
@@ -303,21 +303,14 @@ func consentSurface(agent string) string {
 	return "standard"
 }
 
-// Consent versions mirror the server's (internal/server/ai_diagnose.go) — the
-// standalone path reads/writes the shared store directly, pre-boot.
-var consentVersions = map[string]string{"standard": "v3", "cursor": "v2"}
-
+// The standalone path reads/writes the shared store directly, pre-boot —
+// versions live in internal/config (one source of truth with the server).
 func consentGivenLocal(surface string) bool {
-	return config.Load().AIConsent[surface] == consentVersions[surface]
+	return config.AIConsentGiven(surface)
 }
 
 func recordConsentLocal(surface string) {
-	_, _ = config.Update(func(c *config.Config) {
-		if c.AIConsent == nil {
-			c.AIConsent = map[string]string{}
-		}
-		c.AIConsent[surface] = consentVersions[surface]
-	})
+	_ = config.RecordAIConsent(surface)
 }
 
 // recordConsentHTTP persists consent via the running instance (same store).

--- a/internal/diagnosecli/diagnosecli_test.go
+++ b/internal/diagnosecli/diagnosecli_test.go
@@ -1,0 +1,97 @@
+package diagnosecli
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeKind(t *testing.T) {
+	cases := map[string]string{
+		"pod": "Pod", "pods": "Pod", "po": "Pod",
+		"deploy": "Deployment", "deployments": "Deployment",
+		"sts": "StatefulSet", "svc": "Service", "ns": "Namespace",
+		"Pod": "Pod", "CronJob": "CronJob",
+		// Unknown kinds pass through title-cased (CRDs, etc.).
+		"kafkacluster": "Kafkacluster", "HelmRelease": "HelmRelease",
+	}
+	for in, want := range cases {
+		if got := normalizeKind(in); got != want {
+			t.Errorf("normalizeKind(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestRendererVerdictShapes(t *testing.T) {
+	// Smoke: every verdict shape renders without panicking and mentions its
+	// anchor word (plain-text path, no TTY).
+	r := &renderer{w: nil, color: false}
+	_ = r
+	conf := 0.9
+	rec := 1
+	shapes := []struct {
+		d    diagnosis
+		want string
+	}{
+		{diagnosis{Healthy: true, Report: "All good."}, "No problems found"},
+		{diagnosis{Inconclusive: true, Report: "RBAC blocked reads."}, "Couldn't determine"},
+		{diagnosis{RootCause: "bad `image` tag", Remediation: []string{"fix the **tag**"},
+			RecommendedIndex: &rec, RecommendedReason: "targeted", Confidence: &conf}, "Root cause"},
+		{diagnosis{Report: "narration only"}, "narration only"},
+	}
+	for _, c := range shapes {
+		out := captureVerdict(t, c.d)
+		if !strings.Contains(out, c.want) {
+			t.Errorf("verdict output missing %q:\n%s", c.want, out)
+		}
+	}
+}
+
+func captureVerdict(t *testing.T, d diagnosis) string {
+	t.Helper()
+	tmp, err := createTempFile(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := &renderer{w: tmp, color: false}
+	r.verdict(d)
+	if _, err := tmp.Seek(0, 0); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 8192)
+	n, _ := tmp.Read(buf)
+	return string(buf[:n])
+}
+
+func createTempFile(t *testing.T) (*os.File, error) {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "render")
+	if err == nil {
+		t.Cleanup(func() { _ = f.Close() })
+	}
+	return f, err
+}
+
+// TestInterleavedFlagParsing pins kubectl-style invocation: flags may follow
+// the positional target (`radar diagnose pod/web -n prod --json`).
+func TestInterleavedFlagParsing(t *testing.T) {
+	fs, o := newFlagSet()
+	var positionals []string
+	rest := []string{"pod/web", "-n", "prod", "--json"}
+	for {
+		if err := fs.Parse(rest); err != nil {
+			t.Fatal(err)
+		}
+		if fs.NArg() == 0 {
+			break
+		}
+		positionals = append(positionals, fs.Arg(0))
+		rest = fs.Args()[1:]
+	}
+	if len(positionals) != 1 || positionals[0] != "pod/web" {
+		t.Fatalf("positionals = %v", positionals)
+	}
+	if o.namespace != "prod" || !o.jsonOut {
+		t.Fatalf("flags not parsed: ns=%q json=%v", o.namespace, o.jsonOut)
+	}
+}

--- a/internal/diagnosecli/render.go
+++ b/internal/diagnosecli/render.go
@@ -1,14 +1,29 @@
 package diagnosecli
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"golang.org/x/term"
+)
+
+const (
+	cReset = "\x1b[0m"
+	cDim   = "\x1b[2m"
+	cBold  = "\x1b[1m"
+	cGreen = "\x1b[32m"
+	cRed   = "\x1b[31m"
+	cAmber = "\x1b[33m"
+	cCyan  = "\x1b[36m"
+
+	// clearLine returns the cursor to column 0 and erases the spinner line.
+	clearLine = "\r\x1b[K"
 )
 
 // renderer writes the live transcript + verdict to the terminal. In --json mode
@@ -24,6 +39,8 @@ type renderer struct {
 	inThinking  bool
 	spinnerOn   bool      // spinner line currently drawn (must be erased before real output)
 	lastEvent   time.Time // last real output, for the quiet-gap threshold
+	activeTool  string    // tool currently running (the spinner speaks its activity verb)
+	sawAnything bool      // false until the agent's first output ("starting investigation…")
 	stopSpin    chan struct{}
 	spinStopped bool
 }
@@ -43,8 +60,9 @@ func newRenderer(jsonMode bool) *renderer {
 
 var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 
-// startSpinner shows "⠙ thinking… 12s" after a second of silence — only on a
-// real terminal (it repaints its own line), and never mid-thinking-line.
+// startSpinner shows a live activity line ("⠙ reading logs… 12s") after a
+// second of silence — only on a real terminal (it repaints its own line), and
+// never mid-thinking-line.
 func (r *renderer) startSpinner() {
 	if !r.color {
 		return
@@ -62,8 +80,9 @@ func (r *renderer) startSpinner() {
 			r.mu.Lock()
 			quiet := time.Since(r.lastEvent)
 			if quiet > time.Second && !r.inThinking {
-				fmt.Fprintf(r.w, "[K%s%s %s thinking… %ds%s",
-					cDim, spinnerFrames[frame%len(spinnerFrames)], cAmber+"·"+cReset+cDim, int(quiet.Seconds()), cReset)
+				fmt.Fprintf(r.w, "%s%s%s %s %ds%s",
+					clearLine, cAmber+spinnerFrames[frame%len(spinnerFrames)]+cReset,
+					cDim, r.activityVerbLocked(), int(quiet.Seconds()), cReset)
 				r.spinnerOn = true
 				frame++
 			}
@@ -86,27 +105,49 @@ func (r *renderer) stopSpinner() {
 // clearSpinnerLocked erases the spinner line before real output. Caller holds r.mu.
 func (r *renderer) clearSpinnerLocked() {
 	if r.spinnerOn {
-		fmt.Fprint(r.w, "[K")
+		fmt.Fprint(r.w, clearLine)
 		r.spinnerOn = false
 	}
 	r.lastEvent = time.Now()
+	r.sawAnything = true
 }
 
-const (
-	cReset = "\x1b[0m"
-	cDim   = "\x1b[2m"
-	cBold  = "\x1b[1m"
-	cGreen = "\x1b[32m"
-	cRed   = "\x1b[31m"
-	cAmber = "\x1b[33m"
-	cCyan  = "\x1b[36m"
-)
-
-func (r *renderer) c(code, s string) string {
-	if !r.color {
-		return s
+// activityVerbLocked mirrors the web panel's live status vocabulary: the wait
+// names what the agent is actually doing, not a generic "thinking". Caller
+// holds r.mu.
+func (r *renderer) activityVerbLocked() string {
+	if t := strings.ToLower(r.activeTool); t != "" {
+		switch {
+		case strings.Contains(t, "log"):
+			return "reading logs…"
+		case strings.Contains(t, "event"):
+			return "checking recent events…"
+		case strings.Contains(t, "prometheus") || strings.Contains(t, "metric") || strings.Contains(t, "top"):
+			return "checking metrics…"
+		case strings.Contains(t, "topology") || strings.Contains(t, "neighborhood") || strings.Contains(t, "graph"):
+			return "tracing dependencies…"
+		case strings.Contains(t, "list") || strings.Contains(t, "search"):
+			return "scanning related resources…"
+		case strings.Contains(t, "diagnose"):
+			return "running diagnostics…"
+		case strings.Contains(t, "resource") || strings.Contains(t, "describe"):
+			return "inspecting the resource…"
+		}
+		return prettyTool(r.activeTool) + "…"
 	}
-	return code + s + cReset
+	if !r.sawAnything {
+		return "starting investigation…"
+	}
+	return "thinking…"
+}
+
+// toolStarted records the running tool so the spinner narrates it.
+func (r *renderer) toolStarted(tool string) {
+	r.mu.Lock()
+	if tool != "" {
+		r.activeTool = tool
+	}
+	r.mu.Unlock()
 }
 
 func (r *renderer) header(run runSummary, base string) {
@@ -115,8 +156,8 @@ func (r *renderer) header(run runSummary, base string) {
 		target += run.Namespace + "/"
 	}
 	target += run.Name
-	fmt.Fprintf(r.w, "%s %s\n", r.c(cBold, "◉ Investigating"), target)
-	fmt.Fprintf(r.w, "%s\n", r.c(cDim, fmt.Sprintf("run %s · via %s · watch: %s/?ai-run=%s", run.ID, agentDisplay(run.Agent), base, run.ID)))
+	fmt.Fprintf(r.w, "%s %s\n", r.c(cBold, "◉ Investigating"), r.c(cBold, r.c(cCyan, target)))
+	fmt.Fprintf(r.w, "%s\n", r.c(cDim, fmt.Sprintf("%s · via %s · watch: %s/?ai-run=%s", run.ID, agentDisplay(run.Agent), base, run.ID)))
 	// Radar's read at start — the concrete issue rows the server captured, shown
 	// before the agent produces anything (its boot is the longest silent gap).
 	if h := run.Health; h != nil {
@@ -152,6 +193,13 @@ func agentDisplay(name string) string {
 	return name
 }
 
+func (r *renderer) c(code, s string) string {
+	if !r.color {
+		return s
+	}
+	return code + s + cReset
+}
+
 // thinking streams the agent's interleaved reasoning, dimmed.
 func (r *renderer) thinking(token string) {
 	if token == "" {
@@ -176,24 +224,61 @@ func (r *renderer) breakThinkingLocked() {
 	}
 }
 
-// step prints one completed tool call: "  ✓ get resource {"name":"web"} · 233ms".
+// step prints one completed tool call: "  ✓ get resource kind=node name=… 44ms".
 func (r *renderer) step(s stepInfo) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.clearSpinnerLocked()
 	r.breakThinkingLocked()
+	if s.Tool == r.activeTool {
+		r.activeTool = ""
+	}
 	line := "  " + r.c(cGreen, "✓") + " " + prettyTool(s.Tool)
-	if s.Summary != "" {
-		line += " " + r.c(cDim, compact(s.Summary, 80))
+	if args := prettyArgs(s.Summary); args != "" {
+		line += " " + r.c(cDim, args)
 	}
 	if s.Ms != nil {
-		line += r.c(cDim, fmt.Sprintf(" · %dms", *s.Ms))
+		line += r.c(cDim, fmt.Sprintf("  %dms", *s.Ms))
 	}
 	fmt.Fprintln(r.w, line)
 }
 
 func prettyTool(tool string) string {
 	return strings.ReplaceAll(tool, "_", " ")
+}
+
+// prettyArgs renders a tool's JSON input as terse k=v pairs — raw braces and
+// quotes read as noise at a glance. Identity keys lead (kind, namespace, name),
+// the rest follow sorted; anything non-JSON falls back to a compacted string.
+func prettyArgs(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(raw), &m); err != nil || len(m) == 0 {
+		return compact(raw, 80)
+	}
+	lead := []string{"kind", "namespace", "name"}
+	parts := make([]string, 0, len(m))
+	seen := map[string]bool{}
+	for _, k := range lead {
+		if v, ok := m[k]; ok {
+			parts = append(parts, fmt.Sprintf("%s=%v", k, v))
+			seen[k] = true
+		}
+	}
+	rest := make([]string, 0, len(m))
+	for k := range m {
+		if !seen[k] {
+			rest = append(rest, k)
+		}
+	}
+	sort.Strings(rest)
+	for _, k := range rest {
+		parts = append(parts, fmt.Sprintf("%s=%v", k, m[k]))
+	}
+	return compact(strings.Join(parts, " "), 90)
 }
 
 func compact(s string, max int) string {
@@ -232,21 +317,29 @@ func (r *renderer) verdict(d diagnosis) {
 	case d.RootCause != "":
 		conf := ""
 		if d.Confidence != nil {
-			conf = r.c(cDim, " · confidence "+confidenceLabel(*d.Confidence))
+			label := confidenceLabel(*d.Confidence)
+			col := cGreen
+			switch label {
+			case "medium":
+				col = cAmber
+			case "low":
+				col = cRed
+			}
+			conf = r.c(cDim, " · confidence ") + r.c(col, label)
 		}
 		fmt.Fprintf(r.w, "%s%s\n", r.c(cAmber, r.c(cBold, "▲ Root cause")), conf)
 		fmt.Fprintln(r.w, r.md(d.RootCause))
 		if len(d.Remediation) > 0 {
 			fmt.Fprintf(r.w, "\n%s\n", r.c(cBold, "Remediation"))
 			for i, step := range d.Remediation {
-				marker := fmt.Sprintf("  %d.", i+1)
+				marker := fmt.Sprintf("  %s", r.c(cDim, fmt.Sprintf("%d.", i+1)))
 				if d.RecommendedIndex != nil && *d.RecommendedIndex == i+1 {
-					marker = r.c(cGreen, "  ★"+fmt.Sprintf("%d.", i+1))
+					marker = "  " + r.c(cGreen, fmt.Sprintf("★%d.", i+1))
 				}
 				fmt.Fprintf(r.w, "%s %s\n", marker, r.md(step))
 			}
 			if d.RecommendedIndex != nil && d.RecommendedReason != "" {
-				fmt.Fprintf(r.w, "  %s\n", r.c(cDim, "★ recommended: "+d.RecommendedReason))
+				fmt.Fprintf(r.w, "  %s\n", r.c(cDim, "★ recommended — "+d.RecommendedReason))
 			}
 		}
 	default:

--- a/internal/diagnosecli/render.go
+++ b/internal/diagnosecli/render.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"golang.org/x/term"
+
+	"github.com/skyhook-io/radar/internal/ai"
 )
 
 const (
@@ -157,7 +159,7 @@ func (r *renderer) header(run runSummary, base string) {
 	}
 	target += run.Name
 	fmt.Fprintf(r.w, "%s %s\n", r.c(cBold, "◉ Investigating"), r.c(cBold, r.c(cCyan, target)))
-	fmt.Fprintf(r.w, "%s\n", r.c(cDim, fmt.Sprintf("%s · via %s · watch: %s/?ai-run=%s", run.ID, agentDisplay(run.Agent), base, run.ID)))
+	fmt.Fprintf(r.w, "%s\n", r.c(cDim, fmt.Sprintf("%s · via %s · watch: %s/?ai-run=%s", run.ID, ai.AgentLabel(run.Agent), base, run.ID)))
 	// Radar's read at start — the concrete issue rows the server captured, shown
 	// before the agent produces anything (its boot is the longest silent gap).
 	if h := run.Health; h != nil {
@@ -168,12 +170,7 @@ func (r *renderer) header(run runSummary, base string) {
 			}
 			fmt.Fprintf(r.w, "%s %s — %s\n", sev, r.c(cBold, line.Reason), line.Message)
 		}
-		if len(h.Issues) == 0 && h.IssueCount > 0 {
-			// Runs persisted before per-row capture carry only the rollup.
-			fmt.Fprintf(r.w, "%s %s\n", r.c(cAmber, "●"),
-				r.c(cBold, fmt.Sprintf("%d active issue(s)", h.IssueCount)))
-		}
-		if extra := h.IssueCount - len(h.Issues); extra > 0 && len(h.Issues) > 0 {
+		if extra := h.IssueCount - len(h.Issues); extra > 0 {
 			fmt.Fprintf(r.w, "%s\n", r.c(cDim, fmt.Sprintf("  +%d more active issues", extra)))
 		}
 		for _, f := range h.AuditFindings {
@@ -184,18 +181,6 @@ func (r *renderer) header(run runSummary, base string) {
 		fmt.Fprintf(r.w, "%s\n", r.c(cDim, "  managed by "+run.ManagedBy))
 	}
 	fmt.Fprintln(r.w)
-}
-
-func agentDisplay(name string) string {
-	switch name {
-	case "claude":
-		return "Claude Code"
-	case "codex":
-		return "Codex"
-	case "cursor-agent":
-		return "Cursor"
-	}
-	return name
 }
 
 func (r *renderer) c(code, s string) string {

--- a/internal/diagnosecli/render.go
+++ b/internal/diagnosecli/render.go
@@ -5,16 +5,27 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
+	"time"
 
 	"golang.org/x/term"
 )
 
 // renderer writes the live transcript + verdict to the terminal. In --json mode
 // everything human goes to stderr so stdout stays a clean JSON document.
+// A single mutex serializes event writes with the spinner goroutine: the model
+// goes quiet for long stretches (its own thinking + slow tools), and without a
+// live indicator a silent terminal reads as a hang.
 type renderer struct {
-	w          *os.File
-	color      bool
-	inThinking bool
+	w     *os.File
+	color bool
+
+	mu          sync.Mutex
+	inThinking  bool
+	spinnerOn   bool      // spinner line currently drawn (must be erased before real output)
+	lastEvent   time.Time // last real output, for the quiet-gap threshold
+	stopSpin    chan struct{}
+	spinStopped bool
 }
 
 func newRenderer(jsonMode bool) *renderer {
@@ -22,7 +33,63 @@ func newRenderer(jsonMode bool) *renderer {
 	if jsonMode {
 		w = os.Stderr
 	}
-	return &renderer{w: w, color: term.IsTerminal(int(w.Fd())) && os.Getenv("NO_COLOR") == ""}
+	return &renderer{
+		w:         w,
+		color:     term.IsTerminal(int(w.Fd())) && os.Getenv("NO_COLOR") == "",
+		lastEvent: time.Now(),
+		stopSpin:  make(chan struct{}),
+	}
+}
+
+var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// startSpinner shows "⠙ thinking… 12s" after a second of silence — only on a
+// real terminal (it repaints its own line), and never mid-thinking-line.
+func (r *renderer) startSpinner() {
+	if !r.color {
+		return
+	}
+	go func() {
+		t := time.NewTicker(120 * time.Millisecond)
+		defer t.Stop()
+		frame := 0
+		for {
+			select {
+			case <-r.stopSpin:
+				return
+			case <-t.C:
+			}
+			r.mu.Lock()
+			quiet := time.Since(r.lastEvent)
+			if quiet > time.Second && !r.inThinking {
+				fmt.Fprintf(r.w, "[K%s%s %s thinking… %ds%s",
+					cDim, spinnerFrames[frame%len(spinnerFrames)], cAmber+"·"+cReset+cDim, int(quiet.Seconds()), cReset)
+				r.spinnerOn = true
+				frame++
+			}
+			r.mu.Unlock()
+		}
+	}()
+}
+
+func (r *renderer) stopSpinner() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.spinStopped {
+		return
+	}
+	r.spinStopped = true
+	close(r.stopSpin)
+	r.clearSpinnerLocked()
+}
+
+// clearSpinnerLocked erases the spinner line before real output. Caller holds r.mu.
+func (r *renderer) clearSpinnerLocked() {
+	if r.spinnerOn {
+		fmt.Fprint(r.w, "[K")
+		r.spinnerOn = false
+	}
+	r.lastEvent = time.Now()
 }
 
 const (
@@ -49,7 +116,28 @@ func (r *renderer) header(run runSummary, base string) {
 	}
 	target += run.Name
 	fmt.Fprintf(r.w, "%s %s\n", r.c(cBold, "◉ Investigating"), target)
-	fmt.Fprintf(r.w, "%s\n\n", r.c(cDim, fmt.Sprintf("run %s · via %s · watch: %s/?ai-run=%s", run.ID, agentDisplay(run.Agent), base, run.ID)))
+	fmt.Fprintf(r.w, "%s\n", r.c(cDim, fmt.Sprintf("run %s · via %s · watch: %s/?ai-run=%s", run.ID, agentDisplay(run.Agent), base, run.ID)))
+	// Radar's read at start — the concrete issue rows the server captured, shown
+	// before the agent produces anything (its boot is the longest silent gap).
+	if h := run.Health; h != nil {
+		for _, line := range h.Issues {
+			sev := r.c(cRed, "●")
+			if line.Severity != "critical" {
+				sev = r.c(cAmber, "●")
+			}
+			fmt.Fprintf(r.w, "%s %s — %s\n", sev, r.c(cBold, line.Reason), line.Message)
+		}
+		if extra := h.IssueCount - len(h.Issues); extra > 0 {
+			fmt.Fprintf(r.w, "%s\n", r.c(cDim, fmt.Sprintf("  +%d more active issues", extra)))
+		}
+		for _, f := range h.AuditFindings {
+			fmt.Fprintf(r.w, "%s\n", r.c(cDim, fmt.Sprintf("  audit: %s — %s", f.Reason, f.Message)))
+		}
+	}
+	if run.ManagedBy != "" {
+		fmt.Fprintf(r.w, "%s\n", r.c(cDim, "  managed by "+run.ManagedBy))
+	}
+	fmt.Fprintln(r.w)
 }
 
 func agentDisplay(name string) string {
@@ -69,6 +157,9 @@ func (r *renderer) thinking(token string) {
 	if token == "" {
 		return
 	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.clearSpinnerLocked()
 	if r.color {
 		fmt.Fprint(r.w, cDim+token+cReset)
 	} else {
@@ -77,7 +168,8 @@ func (r *renderer) thinking(token string) {
 	r.inThinking = !strings.HasSuffix(token, "\n")
 }
 
-func (r *renderer) breakThinking() {
+// breakThinkingLocked ends a partial reasoning line. Caller holds r.mu.
+func (r *renderer) breakThinkingLocked() {
 	if r.inThinking {
 		fmt.Fprintln(r.w)
 		r.inThinking = false
@@ -86,7 +178,10 @@ func (r *renderer) breakThinking() {
 
 // step prints one completed tool call: "  ✓ get resource {"name":"web"} · 233ms".
 func (r *renderer) step(s stepInfo) {
-	r.breakThinking()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.clearSpinnerLocked()
+	r.breakThinkingLocked()
 	line := "  " + r.c(cGreen, "✓") + " " + prettyTool(s.Tool)
 	if s.Summary != "" {
 		line += " " + r.c(cDim, compact(s.Summary, 80))
@@ -110,12 +205,18 @@ func compact(s string, max int) string {
 }
 
 func (r *renderer) errorLine(msg string) {
-	r.breakThinking()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.clearSpinnerLocked()
+	r.breakThinkingLocked()
 	fmt.Fprintf(r.w, "\n%s %s\n", r.c(cRed, "✗"), msg)
 }
 
 func (r *renderer) verdict(d diagnosis) {
-	r.breakThinking()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.clearSpinnerLocked()
+	r.breakThinkingLocked()
 	fmt.Fprintln(r.w)
 	switch {
 	case d.Healthy && d.RootCause == "":

--- a/internal/diagnosecli/render.go
+++ b/internal/diagnosecli/render.go
@@ -168,7 +168,12 @@ func (r *renderer) header(run runSummary, base string) {
 			}
 			fmt.Fprintf(r.w, "%s %s — %s\n", sev, r.c(cBold, line.Reason), line.Message)
 		}
-		if extra := h.IssueCount - len(h.Issues); extra > 0 {
+		if len(h.Issues) == 0 && h.IssueCount > 0 {
+			// Runs persisted before per-row capture carry only the rollup.
+			fmt.Fprintf(r.w, "%s %s\n", r.c(cAmber, "●"),
+				r.c(cBold, fmt.Sprintf("%d active issue(s)", h.IssueCount)))
+		}
+		if extra := h.IssueCount - len(h.Issues); extra > 0 && len(h.Issues) > 0 {
 			fmt.Fprintf(r.w, "%s\n", r.c(cDim, fmt.Sprintf("  +%d more active issues", extra)))
 		}
 		for _, f := range h.AuditFindings {

--- a/internal/diagnosecli/render.go
+++ b/internal/diagnosecli/render.go
@@ -1,0 +1,186 @@
+package diagnosecli
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+// renderer writes the live transcript + verdict to the terminal. In --json mode
+// everything human goes to stderr so stdout stays a clean JSON document.
+type renderer struct {
+	w          *os.File
+	color      bool
+	inThinking bool
+}
+
+func newRenderer(jsonMode bool) *renderer {
+	w := os.Stdout
+	if jsonMode {
+		w = os.Stderr
+	}
+	return &renderer{w: w, color: term.IsTerminal(int(w.Fd())) && os.Getenv("NO_COLOR") == ""}
+}
+
+const (
+	cReset = "\x1b[0m"
+	cDim   = "\x1b[2m"
+	cBold  = "\x1b[1m"
+	cGreen = "\x1b[32m"
+	cRed   = "\x1b[31m"
+	cAmber = "\x1b[33m"
+	cCyan  = "\x1b[36m"
+)
+
+func (r *renderer) c(code, s string) string {
+	if !r.color {
+		return s
+	}
+	return code + s + cReset
+}
+
+func (r *renderer) header(run runSummary, base string) {
+	target := run.Kind + " "
+	if run.Namespace != "" {
+		target += run.Namespace + "/"
+	}
+	target += run.Name
+	fmt.Fprintf(r.w, "%s %s\n", r.c(cBold, "◉ Investigating"), target)
+	fmt.Fprintf(r.w, "%s\n\n", r.c(cDim, fmt.Sprintf("run %s · via %s · watch: %s/?ai-run=%s", run.ID, agentDisplay(run.Agent), base, run.ID)))
+}
+
+func agentDisplay(name string) string {
+	switch name {
+	case "claude":
+		return "Claude Code"
+	case "codex":
+		return "Codex"
+	case "cursor-agent":
+		return "Cursor"
+	}
+	return name
+}
+
+// thinking streams the agent's interleaved reasoning, dimmed.
+func (r *renderer) thinking(token string) {
+	if token == "" {
+		return
+	}
+	if r.color {
+		fmt.Fprint(r.w, cDim+token+cReset)
+	} else {
+		fmt.Fprint(r.w, token)
+	}
+	r.inThinking = !strings.HasSuffix(token, "\n")
+}
+
+func (r *renderer) breakThinking() {
+	if r.inThinking {
+		fmt.Fprintln(r.w)
+		r.inThinking = false
+	}
+}
+
+// step prints one completed tool call: "  ✓ get resource {"name":"web"} · 233ms".
+func (r *renderer) step(s stepInfo) {
+	r.breakThinking()
+	line := "  " + r.c(cGreen, "✓") + " " + prettyTool(s.Tool)
+	if s.Summary != "" {
+		line += " " + r.c(cDim, compact(s.Summary, 80))
+	}
+	if s.Ms != nil {
+		line += r.c(cDim, fmt.Sprintf(" · %dms", *s.Ms))
+	}
+	fmt.Fprintln(r.w, line)
+}
+
+func prettyTool(tool string) string {
+	return strings.ReplaceAll(tool, "_", " ")
+}
+
+func compact(s string, max int) string {
+	s = strings.Join(strings.Fields(s), " ")
+	if len(s) > max {
+		return s[:max-1] + "…"
+	}
+	return s
+}
+
+func (r *renderer) errorLine(msg string) {
+	r.breakThinking()
+	fmt.Fprintf(r.w, "\n%s %s\n", r.c(cRed, "✗"), msg)
+}
+
+func (r *renderer) verdict(d diagnosis) {
+	r.breakThinking()
+	fmt.Fprintln(r.w)
+	switch {
+	case d.Healthy && d.RootCause == "":
+		fmt.Fprintf(r.w, "%s\n", r.c(cGreen, r.c(cBold, "✔ No problems found")))
+		if d.Report != "" {
+			fmt.Fprintln(r.w, r.md(d.Report))
+		}
+	case d.Inconclusive && d.RootCause == "":
+		fmt.Fprintf(r.w, "%s\n", r.c(cAmber, r.c(cBold, "? Couldn't determine")))
+		if d.Report != "" {
+			fmt.Fprintln(r.w, r.md(d.Report))
+		}
+	case d.RootCause != "":
+		conf := ""
+		if d.Confidence != nil {
+			conf = r.c(cDim, " · confidence "+confidenceLabel(*d.Confidence))
+		}
+		fmt.Fprintf(r.w, "%s%s\n", r.c(cAmber, r.c(cBold, "▲ Root cause")), conf)
+		fmt.Fprintln(r.w, r.md(d.RootCause))
+		if len(d.Remediation) > 0 {
+			fmt.Fprintf(r.w, "\n%s\n", r.c(cBold, "Remediation"))
+			for i, step := range d.Remediation {
+				marker := fmt.Sprintf("  %d.", i+1)
+				if d.RecommendedIndex != nil && *d.RecommendedIndex == i+1 {
+					marker = r.c(cGreen, "  ★"+fmt.Sprintf("%d.", i+1))
+				}
+				fmt.Fprintf(r.w, "%s %s\n", marker, r.md(step))
+			}
+			if d.RecommendedIndex != nil && d.RecommendedReason != "" {
+				fmt.Fprintf(r.w, "  %s\n", r.c(cDim, "★ recommended: "+d.RecommendedReason))
+			}
+		}
+	default:
+		// No structured verdict — show whatever the agent said.
+		if d.Report != "" {
+			fmt.Fprintln(r.w, r.md(d.Report))
+		} else {
+			fmt.Fprintln(r.w, "The investigation finished without a clear result.")
+		}
+	}
+	fmt.Fprintf(r.w, "\n%s\n", r.c(cDim, "AI-generated — review before applying. Continue in the Radar UI or your own agent."))
+}
+
+func confidenceLabel(c float64) string {
+	switch {
+	case c >= 0.8:
+		return "high"
+	case c >= 0.5:
+		return "medium"
+	}
+	return "low"
+}
+
+var (
+	mdBold   = regexp.MustCompile(`\*\*([^*]+)\*\*`)
+	mdInline = regexp.MustCompile("`([^`]+)`")
+)
+
+// md renders the verdict's GitHub-flavored markdown for a terminal: bold and
+// inline code get ANSI treatment, everything else passes through.
+func (r *renderer) md(s string) string {
+	if !r.color {
+		return s
+	}
+	s = mdBold.ReplaceAllString(s, cBold+"$1"+cReset)
+	s = mdInline.ReplaceAllString(s, cCyan+"$1"+cReset)
+	return s
+}

--- a/internal/diagnosecli/standalone.go
+++ b/internal/diagnosecli/standalone.go
@@ -1,6 +1,7 @@
 package diagnosecli
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"net"
@@ -12,6 +13,7 @@ import (
 
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"golang.org/x/term"
+	"k8s.io/klog/v2"
 
 	"github.com/skyhook-io/radar/internal/app"
 )
@@ -25,6 +27,16 @@ import (
 func bootEphemeral(kubeconfig string, quiet bool) (base string, shutdown func(), err error) {
 	tail := &tailBuffer{limit: 64 << 10}
 	log.SetOutput(tail) // for the whole process — request logs would drown the transcript
+	// client-go logs through klog, which writes DIRECTLY to stderr by default
+	// (bypassing stdlib log) — e.g. apiserver deprecation warnings fired by the
+	// agent's list calls would stomp the transcript mid-spinner. The server
+	// path tames this in main(); the subcommand exits before reaching it, so
+	// repeat it here, pointed at the tail buffer.
+	klog.InitFlags(nil)
+	_ = flag.Set("v", "0")
+	_ = flag.Set("logtostderr", "false")
+	_ = flag.Set("alsologtostderr", "false")
+	klog.SetOutput(tail)
 	// chi's request logger holds its OWN logger bound to os.Stdout at package
 	// init — redirect it too, or every API call the CLI makes prints a line
 	// into the transcript. Must happen before CreateServer builds the router.

--- a/internal/diagnosecli/standalone.go
+++ b/internal/diagnosecli/standalone.go
@@ -24,7 +24,7 @@ import (
 // transcript still shows up in the UI later. Radar's boot logging is captured
 // to a tail buffer and surfaced only on failure; the terminal shows a single
 // connecting spinner instead.
-func bootEphemeral(kubeconfig string, quiet bool) (base string, shutdown func(), err error) {
+func bootEphemeral(kubeconfig string) (base string, shutdown func(), err error) {
 	tail := &tailBuffer{limit: 64 << 10}
 	log.SetOutput(tail) // for the whole process — request logs would drown the transcript
 	// client-go logs through klog, which writes DIRECTLY to stderr by default
@@ -75,9 +75,7 @@ func bootEphemeral(kubeconfig string, quiet bool) (base string, shutdown func(),
 	base = fmt.Sprintf("http://localhost:%d", srv.ActualPort())
 
 	stopSpin := make(chan struct{})
-	if !quiet {
-		go bootSpinner(stopSpin)
-	}
+	go bootSpinner(stopSpin) // self-gates on TTY + NO_COLOR
 	app.InitializeCluster()
 
 	// Connected = the diagnose endpoints stop returning 503 (requireConnected).

--- a/internal/diagnosecli/standalone.go
+++ b/internal/diagnosecli/standalone.go
@@ -1,0 +1,156 @@
+package diagnosecli
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
+	"golang.org/x/term"
+
+	"github.com/skyhook-io/radar/internal/app"
+)
+
+// bootEphemeral starts a temporary in-process Radar for one investigation:
+// headless, random port, no ~/.radar/mcp-port claim (a real instance may own
+// it), timeline in memory — but the SHARED ai-runs history, so a cold run's
+// transcript still shows up in the UI later. Radar's boot logging is captured
+// to a tail buffer and surfaced only on failure; the terminal shows a single
+// connecting spinner instead.
+func bootEphemeral(kubeconfig string, quiet bool) (base string, shutdown func(), err error) {
+	tail := &tailBuffer{limit: 64 << 10}
+	log.SetOutput(tail) // for the whole process — request logs would drown the transcript
+	// chi's request logger holds its OWN logger bound to os.Stdout at package
+	// init — redirect it too, or every API call the CLI makes prints a line
+	// into the transcript. Must happen before CreateServer builds the router.
+	chimiddleware.DefaultLogger = chimiddleware.RequestLogger(&chimiddleware.DefaultLogFormatter{
+		Logger: log.New(tail, "", log.LstdFlags), NoColor: true,
+	})
+
+	app.DisableMCPPortFile()
+	cfg := app.AppConfig{
+		Kubeconfig:      kubeconfig,
+		Port:            0, // random free port
+		NoBrowser:       true,
+		HistoryLimit:    1000, // in-memory timeline floor; this instance lives minutes
+		MCPEnabled:      true,
+		AIHistory:       true,
+		TimelineStorage: "memory",
+	}
+	app.SetGlobals(cfg)
+	if err := app.InitializeK8s(cfg); err != nil {
+		return "", nil, fmt.Errorf("kubeconfig: %w", err)
+	}
+	app.RegisterCallbacks(cfg, app.BuildTimelineStoreConfig(cfg))
+	srv := app.CreateServer(cfg)
+
+	ready := make(chan struct{})
+	go func() {
+		if err := srv.StartWithReady(ready); err != nil && !strings.Contains(err.Error(), "closed") {
+			log.Printf("ephemeral server error: %v", err)
+		}
+	}()
+	select {
+	case <-ready:
+	case <-time.After(15 * time.Second):
+		return "", nil, fmt.Errorf("temporary Radar didn't start listening\n%s", tail.String())
+	}
+	base = fmt.Sprintf("http://localhost:%d", srv.ActualPort())
+
+	stopSpin := make(chan struct{})
+	if !quiet {
+		go bootSpinner(stopSpin)
+	}
+	app.InitializeCluster()
+
+	// Connected = the diagnose endpoints stop returning 503 (requireConnected).
+	deadline := time.Now().Add(2 * time.Minute)
+	for {
+		resp, err := http.Get(base + "/api/diagnose/runs")
+		if err == nil {
+			code := resp.StatusCode
+			resp.Body.Close()
+			if code == http.StatusOK {
+				break
+			}
+			if code == http.StatusNotImplemented {
+				close(stopSpin)
+				return "", nil, fmt.Errorf("no supported agent CLI found — install Claude Code, Codex, or Cursor")
+			}
+		}
+		if time.Now().After(deadline) {
+			close(stopSpin)
+			return "", nil, fmt.Errorf("couldn't connect to the cluster\n--- radar log tail ---\n%s", tail.String())
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	close(stopSpin)
+
+	return base, func() { app.Shutdown(srv) }, nil
+}
+
+// bootSpinner is the pre-run wait line ("starting a temporary Radar —
+// connecting to cluster… 12s") on stderr; the renderer's own spinner takes
+// over once the investigation streams.
+func bootSpinner(stop <-chan struct{}) {
+	if os.Getenv("NO_COLOR") != "" || !term.IsTerminal(int(os.Stderr.Fd())) {
+		return
+	}
+	start := time.Now()
+	t := time.NewTicker(120 * time.Millisecond)
+	defer t.Stop()
+	frame := 0
+	for {
+		select {
+		case <-stop:
+			fmt.Fprint(os.Stderr, clearLine)
+			return
+		case <-t.C:
+			fmt.Fprintf(os.Stderr, "%s%s%s starting a temporary Radar — connecting to cluster… %ds%s",
+				clearLine, cAmber+spinnerFrames[frame%len(spinnerFrames)]+cReset, cDim,
+				int(time.Since(start).Seconds()), cReset)
+			frame++
+		}
+	}
+}
+
+// tailBuffer keeps the last `limit` bytes written — enough boot log to debug a
+// failed cluster connect without ever holding the whole request log.
+type tailBuffer struct {
+	mu    sync.Mutex
+	buf   []byte
+	limit int
+}
+
+func (t *tailBuffer) Write(p []byte) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.buf = append(t.buf, p...)
+	if len(t.buf) > t.limit {
+		t.buf = t.buf[len(t.buf)-t.limit:]
+	}
+	return len(p), nil
+}
+
+func (t *tailBuffer) String() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return string(t.buf)
+}
+
+// probeListening reports whether anything answers on the discovered base —
+// used to distinguish "stale port file" from "no Radar at all".
+func probeListening(base string) bool {
+	u := strings.TrimPrefix(strings.TrimPrefix(base, "http://"), "https://")
+	conn, err := net.DialTimeout("tcp", u, time.Second)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}

--- a/internal/server/ai_diagnose.go
+++ b/internal/server/ai_diagnose.go
@@ -249,6 +249,18 @@ func (s *Server) handleDiagnoseStart(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	agent := s.aiRuns.AgentName(strings.TrimSpace(body.Agent))
+	// The server owns the consent store, so it enforces it: spawning an agent
+	// and shipping cluster data to a model provider must not depend on client
+	// code remembering to check. Surface derives from the RESOLVED agent (an
+	// unknown name falls back to the default, never across trust surfaces).
+	surface := "standard"
+	if agent == "cursor-agent" {
+		surface = "cursor"
+	}
+	if !config.AIConsentGiven(surface) {
+		s.writeError(w, http.StatusForbidden, "AI disclosure not acknowledged for this agent — approve the consent prompt first")
+		return
+	}
 	isolated := body.Isolated == nil || *body.Isolated
 	model := strings.TrimSpace(body.Model)
 	if len(model) > 100 {

--- a/internal/server/ai_diagnose.go
+++ b/internal/server/ai_diagnose.go
@@ -118,23 +118,14 @@ func managedByFromMeta(obj *unstructured.Unstructured) string {
 	return ""
 }
 
-// Consent disclosure versions. Bump when the consent card's claims change
-// materially (standard v3: transcripts persist to local history; cursor v2:
-// same disclosure on Cursor's distinct trust model) — recorded consent for an
-// older version doesn't carry over.
-const (
-	consentStandardVersion = "v3"
-	consentCursorVersion   = "v2"
-)
-
 // currentConsents reports whether the CURRENT disclosure version has been
-// acknowledged, per surface. Machine-scoped (~/.radar/config.json): one
+// acknowledged, per surface (versions live in internal/config — one source of
+// truth with the CLI). Machine-scoped (~/.radar/config.json): one
 // acknowledgment covers the web panel and the CLI.
 func currentConsents() map[string]bool {
-	c := config.Load().AIConsent
 	return map[string]bool{
-		"standard": c["standard"] == consentStandardVersion,
-		"cursor":   c["cursor"] == consentCursorVersion,
+		"standard": config.AIConsentGiven("standard"),
+		"cursor":   config.AIConsentGiven("cursor"),
 	}
 }
 
@@ -171,22 +162,11 @@ func (s *Server) handleDiagnoseConsent(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
-	version := ""
-	switch body.Surface {
-	case "standard":
-		version = consentStandardVersion
-	case "cursor":
-		version = consentCursorVersion
-	default:
+	if config.AIConsentVersion(body.Surface) == "" {
 		s.writeError(w, http.StatusBadRequest, "surface must be \"standard\" or \"cursor\"")
 		return
 	}
-	if _, err := config.Update(func(c *config.Config) {
-		if c.AIConsent == nil {
-			c.AIConsent = map[string]string{}
-		}
-		c.AIConsent[body.Surface] = version
-	}); err != nil {
+	if err := config.RecordAIConsent(body.Surface); err != nil {
 		s.writeError(w, http.StatusInternalServerError, "couldn't record consent: "+err.Error())
 		return
 	}

--- a/internal/server/ai_diagnose.go
+++ b/internal/server/ai_diagnose.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/skyhook-io/radar/internal/ai"
+	"github.com/skyhook-io/radar/internal/config"
 	"github.com/skyhook-io/radar/internal/k8s"
 	"github.com/skyhook-io/radar/pkg/resourcecontext"
 )
@@ -117,6 +118,26 @@ func managedByFromMeta(obj *unstructured.Unstructured) string {
 	return ""
 }
 
+// Consent disclosure versions. Bump when the consent card's claims change
+// materially (standard v3: transcripts persist to local history; cursor v2:
+// same disclosure on Cursor's distinct trust model) — recorded consent for an
+// older version doesn't carry over.
+const (
+	consentStandardVersion = "v3"
+	consentCursorVersion   = "v2"
+)
+
+// currentConsents reports whether the CURRENT disclosure version has been
+// acknowledged, per surface. Machine-scoped (~/.radar/config.json): one
+// acknowledgment covers the web panel and the CLI.
+func currentConsents() map[string]bool {
+	c := config.Load().AIConsent
+	return map[string]bool{
+		"standard": c["standard"] == consentStandardVersion,
+		"cursor":   c["cursor"] == consentCursorVersion,
+	}
+}
+
 // handleListAgents reports the local agent CLIs detected on PATH, for the OSS
 // "AI Agent" picker. Safe: only fixed known names are probed (see ai.DetectAgents).
 func (s *Server) handleListAgents(w http.ResponseWriter, r *http.Request) {
@@ -124,9 +145,52 @@ func (s *Server) handleListAgents(w http.ResponseWriter, r *http.Request) {
 	// (e.g. a settings/picker view) so the Diagnose button's check stays instant.
 	withVersions := r.URL.Query().Get("versions") == "1"
 	s.writeJSON(w, map[string]any{
-		"agents":  ai.DetectAgents(r.Context(), withVersions),
-		"enabled": s.aiRuns != nil,
+		"agents":    ai.DetectAgents(r.Context(), withVersions),
+		"enabled":   s.aiRuns != nil,
+		"consented": currentConsents(),
 	})
+}
+
+// handleDiagnoseConsent records the user's acknowledgment of the current
+// disclosure for a surface ("standard" = Claude/Codex, "cursor" = Cursor's
+// distinct trust model). Doesn't require a connected cluster — consent can be
+// given while Radar is still connecting.
+func (s *Server) handleDiagnoseConsent(w http.ResponseWriter, r *http.Request) {
+	if !localOriginOK(r) {
+		s.writeError(w, http.StatusForbidden, "cross-origin request rejected")
+		return
+	}
+	if s.aiRuns == nil {
+		s.writeError(w, http.StatusNotImplemented, "AI diagnosis is not available")
+		return
+	}
+	var body struct {
+		Surface string `json:"surface"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		s.writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	version := ""
+	switch body.Surface {
+	case "standard":
+		version = consentStandardVersion
+	case "cursor":
+		version = consentCursorVersion
+	default:
+		s.writeError(w, http.StatusBadRequest, "surface must be \"standard\" or \"cursor\"")
+		return
+	}
+	if _, err := config.Update(func(c *config.Config) {
+		if c.AIConsent == nil {
+			c.AIConsent = map[string]string{}
+		}
+		c.AIConsent[body.Surface] = version
+	}); err != nil {
+		s.writeError(w, http.StatusInternalServerError, "couldn't record consent: "+err.Error())
+		return
+	}
+	s.writeJSON(w, map[string]any{"ok": true, "consented": currentConsents()})
 }
 
 // aiReady gates every diagnose endpoint: the engine is built only in no-auth

--- a/internal/server/ai_diagnose.go
+++ b/internal/server/ai_diagnose.go
@@ -317,7 +317,11 @@ func (s *Server) handleDiagnoseHistoryClear(w http.ResponseWriter, r *http.Reque
 		s.writeError(w, http.StatusForbidden, "cross-origin request rejected")
 		return
 	}
-	if !s.aiReady(w) {
+	// Deliberately NOT aiReady: clearing local history is a disk operation —
+	// requiring a connected cluster (like starting a run does) would make the
+	// privacy control fail exactly when a user is cleaning up a broken setup.
+	if s.aiRuns == nil {
+		s.writeError(w, http.StatusNotImplemented, "AI diagnosis is not available")
 		return
 	}
 	if err := s.aiRuns.ClearHistory(); err != nil {

--- a/internal/server/ai_diagnose.go
+++ b/internal/server/ai_diagnose.go
@@ -203,12 +203,34 @@ func (s *Server) handleDiagnoseStart(w http.ResponseWriter, r *http.Request) {
 	s.writeJSON(w, run)
 }
 
-// handleDiagnoseList returns all in-memory runs (newest first).
+// handleDiagnoseList returns all retained runs (newest first). historyDegraded
+// warns that persistence stopped working, so the UI can say history won't
+// survive a restart instead of letting the user believe otherwise.
 func (s *Server) handleDiagnoseList(w http.ResponseWriter, r *http.Request) {
 	if !s.aiReady(w) {
 		return
 	}
-	s.writeJSON(w, map[string]any{"runs": s.aiRuns.List()})
+	s.writeJSON(w, map[string]any{
+		"runs":            s.aiRuns.List(),
+		"historyDegraded": s.aiRuns.HistoryDegraded(),
+	})
+}
+
+// handleDiagnoseHistoryClear wipes the persisted investigation history (and
+// drops finished runs from memory). Live runs survive. POST, same-origin only.
+func (s *Server) handleDiagnoseHistoryClear(w http.ResponseWriter, r *http.Request) {
+	if !localOriginOK(r) {
+		s.writeError(w, http.StatusForbidden, "cross-origin request rejected")
+		return
+	}
+	if !s.aiReady(w) {
+		return
+	}
+	if err := s.aiRuns.ClearHistory(); err != nil {
+		s.writeError(w, http.StatusInternalServerError, "couldn't clear history: "+err.Error())
+		return
+	}
+	s.writeJSON(w, map[string]any{"ok": true})
 }
 
 // handleDiagnoseTurn adds a follow-up or apply turn to a run. POST {question?,

--- a/internal/server/ai_diagnose.go
+++ b/internal/server/ai_diagnose.go
@@ -253,11 +253,7 @@ func (s *Server) handleDiagnoseStart(w http.ResponseWriter, r *http.Request) {
 	// and shipping cluster data to a model provider must not depend on client
 	// code remembering to check. Surface derives from the RESOLVED agent (an
 	// unknown name falls back to the default, never across trust surfaces).
-	surface := "standard"
-	if agent == "cursor-agent" {
-		surface = "cursor"
-	}
-	if !config.AIConsentGiven(surface) {
+	if !config.AIConsentGiven(ai.ConsentSurfaceFor(agent)) {
 		s.writeError(w, http.StatusForbidden, "AI disclosure not acknowledged for this agent — approve the consent prompt first")
 		return
 	}

--- a/internal/server/ai_diagnose.go
+++ b/internal/server/ai_diagnose.go
@@ -49,8 +49,8 @@ func (s *Server) detectDiagnoseHealth(ctx context.Context, kind, namespace, name
 	if canonicalKind == "" {
 		canonicalKind = kind
 	}
-	issueSum := computeIssueSummaryForResource(cache, gvk.Group, canonicalKind, namespace, name)
-	auditSum := computeAuditSummaryForResource(cache, gvk.Group, canonicalKind, namespace, name)
+	issueSum, issueRows := computeIssueSummaryAndRows(cache, gvk.Group, canonicalKind, namespace, name)
+	auditSum, auditRows := computeAuditSummaryAndRows(cache, gvk.Group, canonicalKind, namespace, name)
 
 	var issueCount int
 	signal := &ai.ResourceHealthSignal{}
@@ -59,6 +59,13 @@ func (s *Server) detectDiagnoseHealth(ctx context.Context, kind, namespace, name
 		signal.IssueCount = issueSum.Count
 		signal.HighestSeverity = issueSum.HighestSeverity
 		signal.TopReason = issueSum.TopReason
+		for _, row := range issueRows[:min(len(issueRows), maxHealthLines)] {
+			signal.Issues = append(signal.Issues, ai.HealthLine{
+				Severity: string(row.Severity),
+				Reason:   row.Reason,
+				Message:  capHealthMessage(row.Message),
+			})
+		}
 	}
 	if summary := resourcecontext.BuildSummary(obj, resourcecontext.SummaryOptions{IssueCount: issueCount}); summary != nil {
 		signal.Health = summary.Health
@@ -67,8 +74,31 @@ func (s *Server) detectDiagnoseHealth(ctx context.Context, kind, namespace, name
 		signal.AuditCount = auditSum.Count
 		signal.AuditSeverity = auditSum.HighestSeverity
 		signal.TopFinding = auditSum.TopFinding
+		for _, row := range auditRows[:min(len(auditRows), maxHealthAuditLines)] {
+			signal.AuditFindings = append(signal.AuditFindings, ai.HealthLine{
+				Severity: normalizeAuditSeverity(row.Severity),
+				Reason:   row.CheckID,
+				Message:  capHealthMessage(row.Message),
+			})
+		}
 	}
 	return signal
+}
+
+const (
+	// maxHealthLines / maxHealthAuditLines cap the rows carried on the health
+	// frame: enough to make the context card + prompt concrete, small enough to
+	// stay a frame rather than a report (the agent reads the full state itself).
+	maxHealthLines      = 3
+	maxHealthAuditLines = 2
+)
+
+func capHealthMessage(msg string) string {
+	const max = 220
+	if len(msg) <= max {
+		return msg
+	}
+	return msg[:max-1] + "…"
 }
 
 func managedByFromMeta(obj *unstructured.Unstructured) string {

--- a/internal/server/ai_diagnose_test.go
+++ b/internal/server/ai_diagnose_test.go
@@ -3,6 +3,8 @@ package server
 import (
 	"net/http"
 	"testing"
+
+	"github.com/skyhook-io/radar/internal/config"
 )
 
 // TestLocalOriginOK pins the cross-origin guard on the process-spawning POST
@@ -30,5 +32,34 @@ func TestLocalOriginOK(t *testing.T) {
 		if got := localOriginOK(r); got != c.want {
 			t.Errorf("localOriginOK(%q) = %v, want %v", c.origin, got, c.want)
 		}
+	}
+}
+
+// TestConsentMachineScoped pins the shared consent store: recording via the
+// endpoint's config path must be visible to currentConsents (what /api/agents
+// reports to the panel AND what the CLI reads) — one acknowledgment covers
+// both surfaces' checks, per disclosure surface.
+func TestConsentMachineScoped(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if c := currentConsents(); c["standard"] || c["cursor"] {
+		t.Fatalf("fresh HOME must have no consent, got %v", c)
+	}
+	if _, err := config.Update(func(c *config.Config) {
+		c.AIConsent = map[string]string{"standard": consentStandardVersion}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	c := currentConsents()
+	if !c["standard"] || c["cursor"] {
+		t.Fatalf("standard consent must not cover cursor's surface: %v", c)
+	}
+	// A stale (older-version) acknowledgment must not count.
+	if _, err := config.Update(func(c *config.Config) {
+		c.AIConsent["cursor"] = "v1"
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if currentConsents()["cursor"] {
+		t.Fatal("an older disclosure version must not satisfy consent")
 	}
 }

--- a/internal/server/ai_diagnose_test.go
+++ b/internal/server/ai_diagnose_test.go
@@ -44,9 +44,7 @@ func TestConsentMachineScoped(t *testing.T) {
 	if c := currentConsents(); c["standard"] || c["cursor"] {
 		t.Fatalf("fresh HOME must have no consent, got %v", c)
 	}
-	if _, err := config.Update(func(c *config.Config) {
-		c.AIConsent = map[string]string{"standard": consentStandardVersion}
-	}); err != nil {
+	if err := config.RecordAIConsent("standard"); err != nil {
 		t.Fatal(err)
 	}
 	c := currentConsents()

--- a/internal/server/ai_handlers.go
+++ b/internal/server/ai_handlers.go
@@ -501,12 +501,20 @@ func (s *Server) topologyForContext(namespace string) (*topology.Topology, topol
 //
 // Returns nil when no issues match — Build then omits the IssueSummary field.
 func computeIssueSummaryForResource(cache *k8s.ResourceCache, group, kind, namespace, name string) *resourcecontext.IssueSummary {
+	sum, _ := computeIssueSummaryAndRows(cache, group, kind, namespace, name)
+	return sum
+}
+
+// computeIssueSummaryAndRows additionally returns the matched rows sorted by
+// (severity desc, reason asc) — the diagnose health frame shows the actual
+// lines, not just the rollup.
+func computeIssueSummaryAndRows(cache *k8s.ResourceCache, group, kind, namespace, name string) (*resourcecontext.IssueSummary, []issues.Issue) {
 	if cache == nil {
-		return nil
+		return nil, nil
 	}
 	provider := issues.NewCacheProvider()
 	if provider == nil {
-		return nil
+		return nil, nil
 	}
 	var namespaces []string
 	if namespace != "" {
@@ -518,7 +526,7 @@ func computeIssueSummaryForResource(cache *k8s.ResourceCache, group, kind, names
 	// both (a Deployment matched no Kind=Pod evidence rows → empty summary).
 	matched := issues.RelatedIssues(provider, namespaces, group, kind, namespace, name)
 	if len(matched) == 0 {
-		return nil
+		return nil, nil
 	}
 	bySource := make(map[string]int, len(matched))
 	for _, row := range matched {
@@ -542,7 +550,7 @@ func computeIssueSummaryForResource(cache *k8s.ResourceCache, group, kind, names
 		HighestSeverity: string(topSeverity),
 		TopReason:       topReason,
 		BySource:        bySource,
-	}
+	}, matched
 }
 
 // computeAuditSummaryForResource looks up audit findings for the subject
@@ -558,8 +566,13 @@ func computeIssueSummaryForResource(cache *k8s.ResourceCache, group, kind, names
 // influence the choice — agents pinning regression tests on
 // resourceContext output rely on stable field values across runs.
 func computeAuditSummaryForResource(cache *k8s.ResourceCache, group, kind, namespace, name string) *resourcecontext.AuditSummary {
+	sum, _ := computeAuditSummaryAndRows(cache, group, kind, namespace, name)
+	return sum
+}
+
+func computeAuditSummaryAndRows(cache *k8s.ResourceCache, group, kind, namespace, name string) (*resourcecontext.AuditSummary, []bpaudit.Finding) {
 	if cache == nil || kind == "" {
-		return nil
+		return nil, nil
 	}
 	// Match computeIssueSummaryForResource's guard: passing []string{""} to
 	// RunFromCache would filter to literally namespace="" resources instead
@@ -572,12 +585,12 @@ func computeAuditSummaryForResource(cache *k8s.ResourceCache, group, kind, names
 	}
 	results := audit.RunFromCache(cache, namespaces, nil)
 	if results == nil || len(results.Findings) == 0 {
-		return nil
+		return nil, nil
 	}
 	idx := bpaudit.IndexByResource(results.Findings)
 	match := idx[bpaudit.ResourceKey(group, kind, namespace, name)]
 	if len(match) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	// Sort by (severity desc, CheckID asc) so TopFinding is deterministic
@@ -594,7 +607,7 @@ func computeAuditSummaryForResource(cache *k8s.ResourceCache, group, kind, names
 		Count:           len(match),
 		HighestSeverity: normalizeAuditSeverity(match[0].Severity),
 		TopFinding:      topFinding,
-	}
+	}, match
 }
 
 // normalizeAuditSeverity maps the audit suite's emission vocabulary

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -177,7 +177,7 @@ func New(cfg Config) *Server {
 			if historyBroken {
 				// Persistence was requested but isn't working — the UI must say
 				// history won't survive a restart, not just a log line.
-				s.aiRuns.MarkHistoryUnavailable()
+				s.aiRuns.MarkHistoryUnavailable(cfg.AIHistoryDB)
 			}
 			log.Printf("[ai] diagnose enabled (default agent: %s)", d.DefaultAgent())
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -164,14 +164,21 @@ func New(cfg Config) *Server {
 			// disabled feature never creates the DB. Open failure degrades to
 			// memory-only runs (the historical behavior), never blocks startup.
 			var store ai.RunStore
+			historyBroken := false
 			if cfg.AIHistoryDB != "" {
 				if st, err := ai.OpenRunStore(cfg.AIHistoryDB); err != nil {
 					log.Printf("[ai] run history disabled — could not open %s: %v", cfg.AIHistoryDB, err)
+					historyBroken = true
 				} else {
 					store = st
 				}
 			}
 			s.aiRuns = ai.NewRunManager(d, s.ActualPort, k8s.GetContextName, store)
+			if historyBroken {
+				// Persistence was requested but isn't working — the UI must say
+				// history won't survive a restart, not just a log line.
+				s.aiRuns.MarkHistoryUnavailable()
+			}
 			log.Printf("[ai] diagnose enabled (default agent: %s)", d.DefaultAgent())
 		}
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -353,6 +353,7 @@ func (s *Server) setupRoutes() {
 			r.Post("/diagnose/runs/{id}/turns", s.handleDiagnoseTurn)
 			r.Post("/diagnose/runs/{id}/stop", s.handleDiagnoseStop)
 			r.Post("/diagnose/history/clear", s.handleDiagnoseHistoryClear)
+			r.Post("/diagnose/consent", s.handleDiagnoseConsent)
 			r.Get("/diagnostics", s.handleDiagnostics)
 			r.Get("/auth/me", s.handleAuthMe)
 			r.Get("/version-check", s.handleVersionCheck)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -125,6 +125,7 @@ type Config struct {
 	DiagConfig         *DiagConfig    // Sanitized config for diagnostics endpoint
 	EffectiveConfig    *config.Config // Running startup config for GET /api/config
 	AuthConfig         auth.Config    // Authentication configuration
+	AIHistoryDB        string         // AI run-history SQLite path ("" = memory-only runs)
 }
 
 // New creates a new server instance
@@ -159,7 +160,18 @@ func New(cfg Config) *Server {
 	if !s.authConfig.Enabled() && s.mcpHandler != nil {
 		if d, err := ai.NewDetected(context.Background()); err == nil {
 			s.aiDiagnoser = d
-			s.aiRuns = ai.NewRunManager(d, s.ActualPort, k8s.GetContextName)
+			// History store opens only when the engine actually enables, so a
+			// disabled feature never creates the DB. Open failure degrades to
+			// memory-only runs (the historical behavior), never blocks startup.
+			var store ai.RunStore
+			if cfg.AIHistoryDB != "" {
+				if st, err := ai.OpenRunStore(cfg.AIHistoryDB); err != nil {
+					log.Printf("[ai] run history disabled — could not open %s: %v", cfg.AIHistoryDB, err)
+				} else {
+					store = st
+				}
+			}
+			s.aiRuns = ai.NewRunManager(d, s.ActualPort, k8s.GetContextName, store)
 			log.Printf("[ai] diagnose enabled (default agent: %s)", d.DefaultAgent())
 		}
 	}
@@ -333,6 +345,7 @@ func (s *Server) setupRoutes() {
 			r.Get("/diagnose/runs", s.handleDiagnoseList)
 			r.Post("/diagnose/runs/{id}/turns", s.handleDiagnoseTurn)
 			r.Post("/diagnose/runs/{id}/stop", s.handleDiagnoseStop)
+			r.Post("/diagnose/history/clear", s.handleDiagnoseHistoryClear)
 			r.Get("/diagnostics", s.handleDiagnostics)
 			r.Get("/auth/me", s.handleAuthMe)
 			r.Get("/version-check", s.handleVersionCheck)

--- a/web/src/api/diagnose.ts
+++ b/web/src/api/diagnose.ts
@@ -41,14 +41,22 @@ export interface Diagnosis {
   sessionId?: string;
 }
 
+export interface HealthLine {
+  severity?: string;
+  reason?: string; // issue Reason / audit CheckID
+  message?: string;
+}
+
 export interface ResourceHealthSignal {
   health?: string;
   issueCount?: number;
   highestSeverity?: string;
   topReason?: string;
+  issues?: HealthLine[];
   auditCount?: number;
   auditSeverity?: string;
   topFinding?: string;
+  auditFindings?: HealthLine[];
 }
 
 export interface DiagnoseStreamEvent {

--- a/web/src/api/diagnose.ts
+++ b/web/src/api/diagnose.ts
@@ -148,16 +148,33 @@ export async function createRun(
   return res.json();
 }
 
+export interface RunsResponse {
+  runs: RunSummary[];
+  // Persistence stopped working (disk error) — history will NOT survive a
+  // restart; the UI should say so instead of letting the user assume otherwise.
+  historyDegraded?: boolean;
+}
+
 // listRuns returns all server-side runs (newest first) — the source of truth for
 // the recent-investigations list.
-export async function listRuns(signal?: AbortSignal): Promise<RunSummary[]> {
+export async function listRuns(signal?: AbortSignal): Promise<RunsResponse> {
   const res = await fetch(RUNS(), {
     credentials: getCredentialsMode(),
     signal,
   });
   if (!res.ok) throw new DiagnoseError(res.status, await errorText(res));
   const d = await res.json();
-  return d.runs ?? [];
+  return { runs: d.runs ?? [], historyDegraded: !!d.historyDegraded };
+}
+
+// clearHistory wipes the persisted investigation history (finished runs); live
+// investigations survive.
+export async function clearHistory(): Promise<void> {
+  const res = await fetch(`${getApiBase()}/diagnose/history/clear`, {
+    method: "POST",
+    credentials: getCredentialsMode(),
+  });
+  if (!res.ok) throw new DiagnoseError(res.status, await errorText(res));
 }
 
 // addTurn appends a follow-up (question) or an apply turn (apply + confirmed fix).

--- a/web/src/api/diagnose.ts
+++ b/web/src/api/diagnose.ts
@@ -15,6 +15,9 @@ export interface AgentInfo {
 export interface AgentsResponse {
   agents: AgentInfo[];
   enabled: boolean;
+  // Machine-scoped consent per disclosure surface, recorded server-side
+  // (~/.radar) — one acknowledgment covers the web panel and the CLI.
+  consented?: { standard?: boolean; cursor?: boolean };
 }
 
 export interface DiagnoseStep {
@@ -173,6 +176,19 @@ export async function listRuns(signal?: AbortSignal): Promise<RunsResponse> {
   if (!res.ok) throw new DiagnoseError(res.status, await errorText(res));
   const d = await res.json();
   return { runs: d.runs ?? [], historyDegraded: !!d.historyDegraded };
+}
+
+// recordConsent acknowledges the current disclosure for a surface, server-side.
+export async function recordConsent(
+  surface: "standard" | "cursor",
+): Promise<void> {
+  const res = await fetch(`${getApiBase()}/diagnose/consent`, {
+    method: "POST",
+    credentials: getCredentialsMode(),
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ surface }),
+  });
+  if (!res.ok) throw new DiagnoseError(res.status, await errorText(res));
 }
 
 // clearHistory wipes the persisted investigation history (finished runs); live

--- a/web/src/components/diagnose/AISettings.tsx
+++ b/web/src/components/diagnose/AISettings.tsx
@@ -1,7 +1,9 @@
 // The "AI Diagnosis" section of the Settings dialog. Controlled by the dialog:
 // it edits a STAGED draft and is committed on Save (like the rest of Settings),
 // not on every keystroke. Renders nothing when no supported agent CLI is installed.
-import { type AgentInfo } from "../../api/diagnose";
+import { useState } from "react";
+import { Trash2 } from "lucide-react";
+import { clearHistory, type AgentInfo } from "../../api/diagnose";
 import { AgentControls } from "./parts";
 
 export interface AIDraft {
@@ -11,16 +13,85 @@ export interface AIDraft {
   effort: string;
 }
 
+// ClearHistoryRow is an immediate action (not part of the staged draft): a
+// two-step confirm button that wipes finished investigations from the local
+// history DB. Live investigations survive.
+function ClearHistoryRow({ onCleared }: { onCleared: () => void }) {
+  const [confirming, setConfirming] = useState(false);
+  const [state, setState] = useState<"idle" | "busy" | "done" | "error">(
+    "idle",
+  );
+  const run = () => {
+    setState("busy");
+    clearHistory()
+      .then(() => {
+        setState("done");
+        setConfirming(false);
+        onCleared();
+      })
+      .catch(() => setState("error"));
+  };
+  return (
+    <div className="mt-3 flex items-center justify-between gap-2 border-t border-theme-border/60 pt-3">
+      <p className="text-[11px] leading-snug text-theme-text-tertiary">
+        Investigation transcripts are kept on this machine (
+        <code className="font-mono">~/.radar</code>) so history survives
+        restarts.
+        {state === "done" && (
+          <span className="ml-1 font-medium text-theme-text-secondary">
+            History cleared.
+          </span>
+        )}
+        {state === "error" && (
+          <span className="ml-1 font-medium text-red-400">
+            Couldn&apos;t clear history.
+          </span>
+        )}
+      </p>
+      {confirming ? (
+        <div className="flex shrink-0 items-center gap-1.5">
+          <button
+            onClick={() => setConfirming(false)}
+            className="rounded-md border border-theme-border px-2 py-1 text-xs text-theme-text-secondary hover:bg-theme-hover"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={run}
+            disabled={state === "busy"}
+            className="rounded-md border border-red-500/40 bg-red-500/10 px-2 py-1 text-xs font-medium text-red-400 hover:bg-red-500/20 disabled:opacity-50"
+          >
+            Clear all history
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={() => {
+            setState("idle");
+            setConfirming(true);
+          }}
+          className="flex shrink-0 items-center gap-1 rounded-md border border-theme-border px-2 py-1 text-xs text-theme-text-secondary hover:bg-theme-hover hover:text-theme-text-primary"
+        >
+          <Trash2 className="h-3 w-3" />
+          Clear history…
+        </button>
+      )}
+    </div>
+  );
+}
+
 export function AISettingsSection({
   available,
   agents,
   draft,
   onChange,
+  onHistoryCleared,
 }: {
   available: boolean;
   agents: AgentInfo[];
   draft: AIDraft;
   onChange: (patch: Partial<AIDraft>) => void;
+  onHistoryCleared: () => void;
 }) {
   if (!available || agents.length === 0) return null;
   return (
@@ -44,6 +115,7 @@ export function AISettingsSection({
         effort={draft.effort}
         onSetEffort={(v) => onChange({ effort: v })}
       />
+      <ClearHistoryRow onCleared={onHistoryCleared} />
     </section>
   );
 }

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -397,14 +397,18 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
   const close = useCallback(() => setOpen(false), []);
   const approveConsent = useCallback(() => {
     const surface = consentSurfaceFor(selectedAgentRef.current);
-    // Optimistic: the user just consented — the run proceeds regardless. The
-    // server write makes it durable (and shared with the CLI); if it fails,
-    // the only cost is being asked again next session.
-    setConsented((prev) => ({ ...prev, [surface]: true }));
-    recordConsent(surface).catch(() => {});
     const t = pendingTarget;
     setPendingTarget(null);
-    if (t) startRunRef.current(t);
+    // The server ENFORCES consent at start, so the acknowledgment must land
+    // before the run request — awaiting also makes it durable for the CLI.
+    recordConsent(surface)
+      .then(() => {
+        setConsented((prev) => ({ ...prev, [surface]: true }));
+        if (t) startRunRef.current(t);
+      })
+      .catch(() => {
+        setStartError("Couldn't record your consent — try again.");
+      });
   }, [pendingTarget]);
   const cancelConsent = useCallback(() => {
     setPendingTarget(null);

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -395,19 +395,28 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
   }, []);
   const goHome = useCallback(() => setView("home"), []);
   const close = useCallback(() => setOpen(false), []);
+  const consentBusyRef = useRef(false);
   const approveConsent = useCallback(() => {
+    if (consentBusyRef.current) return;
+    consentBusyRef.current = true;
+    setStartError(null);
     const surface = consentSurfaceFor(selectedAgentRef.current);
     const t = pendingTarget;
-    setPendingTarget(null);
     // The server ENFORCES consent at start, so the acknowledgment must land
     // before the run request — awaiting also makes it durable for the CLI.
     recordConsent(surface)
       .then(() => {
         setConsented((prev) => ({ ...prev, [surface]: true }));
+        // Cleared only on success: a failed write keeps the consent card up
+        // (needsConsent = !!pendingTarget) so "try again" works in place.
+        setPendingTarget(null);
         if (t) startRunRef.current(t);
       })
       .catch(() => {
         setStartError("Couldn't record your consent — try again.");
+      })
+      .finally(() => {
+        consentBusyRef.current = false;
       });
   }, [pendingTarget]);
   const cancelConsent = useCallback(() => {

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -46,6 +46,7 @@ interface DiagnoseCtx {
   activeRunId: string | null;
   runs: RunSummary[];
   runsLoaded: boolean; // first runs fetch landed (gates missing-run states)
+  runsLoadFailed: boolean; // latest runs fetch failed (poll keeps retrying)
   historyDegraded: boolean; // persistence broke — history won't survive a restart
   needsConsent: boolean; // a start is pending the one-time consent
   startError: string | null;
@@ -184,6 +185,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
   const [activeRunId, setActiveRunId] = useState<string | null>(null);
   const [runs, setRuns] = useState<RunSummary[]>([]);
   const [runsLoaded, setRunsLoaded] = useState(false);
+  const [runsLoadFailed, setRunsLoadFailed] = useState(false);
   const [historyDegraded, setHistoryDegraded] = useState(false);
   const [pendingTarget, setPendingTarget] = useState<Target | null>(null);
   const [startError, setStartError] = useState<string | null>(null);
@@ -274,9 +276,15 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
       .then((r) => {
         setRuns(r.runs);
         setRunsLoaded(true);
+        setRunsLoadFailed(false);
         setHistoryDegraded(!!r.historyDegraded);
       })
-      .catch(() => {});
+      .catch(() => {
+        // Leave runsLoaded false (a missing-run verdict needs a real list) but
+        // record the failure so the panel can say "retrying" instead of
+        // pretending nothing happened. The 4s poll keeps retrying while open.
+        setRunsLoadFailed(true);
+      });
   }, [available]);
 
   // A content-stable signature of the resources with a live (running) investigation,
@@ -423,6 +431,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
     activeRunId,
     runs,
     runsLoaded,
+    runsLoadFailed,
     historyDegraded,
     // pendingTarget is set ONLY when the current agent's consent is missing, and
     // cleared on approve/cancel — so its presence is exactly "consent needed now".

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -353,6 +353,30 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
     setView("investigation");
     setOpen(true);
   }, []);
+
+  // Deep link: ?ai-run=<id> opens the panel focused on that investigation —
+  // the URL `radar diagnose --open` prints/opens. Consumed once (then stripped)
+  // so back/forward and copied URLs don't keep re-opening the panel.
+  useEffect(() => {
+    if (!available) return;
+    let id: string | null = null;
+    try {
+      const params = new URLSearchParams(window.location.search);
+      id = params.get("ai-run");
+      if (id) {
+        params.delete("ai-run");
+        const qs = params.toString();
+        window.history.replaceState(
+          null,
+          "",
+          window.location.pathname + (qs ? `?${qs}` : "") + window.location.hash,
+        );
+      }
+    } catch {
+      /* URL APIs unavailable — skip the deep link */
+    }
+    if (id) openRun(id);
+  }, [available, openRun]);
   const openHome = useCallback(() => {
     setView("home");
     setOpen(true);

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -291,7 +291,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
   // panel closed — and only re-render when the set actually changes, not every poll.
   const runningSig = runs
     .filter((r) => r.status === "running")
-    .map((r) => `${r.kind} ${r.namespace} ${r.name}`)
+    .map((r) => `${r.kind}\x00${r.namespace}\x00${r.name}`)
     .sort()
     .join("|");
   const runningKeys = useMemo(

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -101,11 +101,13 @@ const MIN_W = 400;
 const MAX_W = 1100;
 const PANEL_BOUNDS = { min: MIN_W, max: MAX_W }; // stable ref for the layout context
 const WIDTH_KEY = "radar-ai-panel-width";
-const CONSENT_KEY = "radar-ai-consent-v2"; // v2: agent picker + isolation choice
+// v3: transcripts now persist to local Radar history (~/.radar) — a material
+// change to the disclosure, so prior consent doesn't carry over.
+const CONSENT_KEY = "radar-ai-consent-v3";
 // Cursor's trust model is materially different (it can't be isolated — the user's
 // own global MCP servers also load), so it gets its OWN consent: a user who already
 // approved Claude/Codex must still see Cursor's distinct disclosure before it runs.
-const CURSOR_CONSENT_KEY = "radar-ai-consent-cursor";
+const CURSOR_CONSENT_KEY = "radar-ai-consent-cursor-v2"; // v2: local history disclosure
 function consentKeyFor(agent: string): string {
   return agent === "cursor-agent" ? CURSOR_CONSENT_KEY : CONSENT_KEY;
 }

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -19,6 +19,7 @@ import {
   fetchAgents,
   listRuns,
   createRun,
+  recordConsent,
   DiagnoseError,
 } from "../../api/diagnose";
 import { type RunSummary, type AgentInfo } from "../../api/diagnose";
@@ -103,15 +104,15 @@ const MIN_W = 400;
 const MAX_W = 1100;
 const PANEL_BOUNDS = { min: MIN_W, max: MAX_W }; // stable ref for the layout context
 const WIDTH_KEY = "radar-ai-panel-width";
-// v3: transcripts now persist to local Radar history (~/.radar) — a material
-// change to the disclosure, so prior consent doesn't carry over.
-const CONSENT_KEY = "radar-ai-consent-v3";
-// Cursor's trust model is materially different (it can't be isolated — the user's
-// own global MCP servers also load), so it gets its OWN consent: a user who already
-// approved Claude/Codex must still see Cursor's distinct disclosure before it runs.
-const CURSOR_CONSENT_KEY = "radar-ai-consent-cursor-v2"; // v2: local history disclosure
-function consentKeyFor(agent: string): string {
-  return agent === "cursor-agent" ? CURSOR_CONSENT_KEY : CONSENT_KEY;
+// Consent is machine-scoped and lives server-side (~/.radar): it gates a
+// machine-scoped action (spawn this machine's agent CLI, persist transcripts to
+// this machine's disk), so one acknowledgment covers this panel AND the
+// `radar diagnose` CLI. Cursor gets its own surface — its trust model is
+// materially different (the user's global MCP servers can't be excluded), so
+// approving Claude/Codex never bypasses Cursor's distinct disclosure.
+type ConsentSurface = "standard" | "cursor";
+function consentSurfaceFor(agent: string): ConsentSurface {
+  return agent === "cursor-agent" ? "cursor" : "standard";
 }
 const AGENT_KEY = "radar-ai-agent";
 const ISOLATED_KEY = "radar-ai-isolated";
@@ -141,15 +142,6 @@ export function openDiagnoseSettings() {
   window.dispatchEvent(new CustomEvent("radar:open-settings"));
 }
 
-// localStorage can throw (private mode); never let it crash the always-mounted provider.
-function readConsent(agent: string): boolean {
-  try {
-    return localStorage.getItem(consentKeyFor(agent)) === "1";
-  } catch {
-    return false;
-  }
-}
-
 function readStored(key: string): string | null {
   try {
     return localStorage.getItem(key);
@@ -168,6 +160,9 @@ function writeStored(key: string, value: string) {
 export function DiagnoseProvider({ children }: { children: ReactNode }) {
   const [available, setAvailable] = useState(false);
   const [agents, setAgents] = useState<AgentInfo[]>([]);
+  const [consented, setConsented] = useState<
+    Record<ConsentSurface, boolean>
+  >({ standard: false, cursor: false });
   const [selectedAgent, setSelectedAgentState] = useState<string>(
     () => readStored(AGENT_KEY) || "",
   );
@@ -210,6 +205,10 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
       .then((r) => {
         if (!live) return;
         setAvailable(r.enabled);
+        setConsented({
+          standard: !!r.consented?.standard,
+          cursor: !!r.consented?.cursor,
+        });
         const supported = r.agents.filter((a) => a.supported);
         setAgents(supported);
         // Keep the stored pick only if it's still installed; else default to the
@@ -317,6 +316,8 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
   // (consent is agent-specific, so they must read the CURRENT pick, not a closure).
   const selectedAgentRef = useRef(selectedAgent);
   selectedAgentRef.current = selectedAgent;
+  const consentedRef = useRef(consented);
+  consentedRef.current = consented;
 
   // Monotonic token so an earlier createRun that resolves late can't steal focus
   // from a later click on a different resource (only the latest start wins).
@@ -351,7 +352,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
   const openInvestigation = useCallback((t: Target) => {
     setStartError(null);
     setOpen(true);
-    if (!readConsent(selectedAgentRef.current)) {
+    if (!consentedRef.current[consentSurfaceFor(selectedAgentRef.current)]) {
       setPendingTarget(t);
       setView("investigation");
       return;
@@ -395,11 +396,12 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
   const goHome = useCallback(() => setView("home"), []);
   const close = useCallback(() => setOpen(false), []);
   const approveConsent = useCallback(() => {
-    try {
-      localStorage.setItem(consentKeyFor(selectedAgentRef.current), "1");
-    } catch {
-      /* storage disabled — consent holds for this session */
-    }
+    const surface = consentSurfaceFor(selectedAgentRef.current);
+    // Optimistic: the user just consented — the run proceeds regardless. The
+    // server write makes it durable (and shared with the CLI); if it fails,
+    // the only cost is being asked again next session.
+    setConsented((prev) => ({ ...prev, [surface]: true }));
+    recordConsent(surface).catch(() => {});
     const t = pendingTarget;
     setPendingTarget(null);
     if (t) startRunRef.current(t);

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -45,6 +45,7 @@ interface DiagnoseCtx {
   view: DiagnoseView;
   activeRunId: string | null;
   runs: RunSummary[];
+  runsLoaded: boolean; // first runs fetch landed (gates missing-run states)
   historyDegraded: boolean; // persistence broke — history won't survive a restart
   needsConsent: boolean; // a start is pending the one-time consent
   startError: string | null;
@@ -182,6 +183,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
   const [view, setView] = useState<DiagnoseView>("home");
   const [activeRunId, setActiveRunId] = useState<string | null>(null);
   const [runs, setRuns] = useState<RunSummary[]>([]);
+  const [runsLoaded, setRunsLoaded] = useState(false);
   const [historyDegraded, setHistoryDegraded] = useState(false);
   const [pendingTarget, setPendingTarget] = useState<Target | null>(null);
   const [startError, setStartError] = useState<string | null>(null);
@@ -271,6 +273,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
     listRuns()
       .then((r) => {
         setRuns(r.runs);
+        setRunsLoaded(true);
         setHistoryDegraded(!!r.historyDegraded);
       })
       .catch(() => {});
@@ -419,6 +422,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
     view,
     activeRunId,
     runs,
+    runsLoaded,
     historyDegraded,
     // pendingTarget is set ONLY when the current agent's consent is missing, and
     // cleared on approve/cancel — so its presence is exactly "consent needed now".

--- a/web/src/components/diagnose/DiagnoseContext.tsx
+++ b/web/src/components/diagnose/DiagnoseContext.tsx
@@ -45,6 +45,7 @@ interface DiagnoseCtx {
   view: DiagnoseView;
   activeRunId: string | null;
   runs: RunSummary[];
+  historyDegraded: boolean; // persistence broke — history won't survive a restart
   needsConsent: boolean; // a start is pending the one-time consent
   startError: string | null;
   openInvestigation: (t: Target) => void;
@@ -179,6 +180,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
   const [view, setView] = useState<DiagnoseView>("home");
   const [activeRunId, setActiveRunId] = useState<string | null>(null);
   const [runs, setRuns] = useState<RunSummary[]>([]);
+  const [historyDegraded, setHistoryDegraded] = useState(false);
   const [pendingTarget, setPendingTarget] = useState<Target | null>(null);
   const [startError, setStartError] = useState<string | null>(null);
   const [width, setWidth] = useState<number>(() => {
@@ -265,7 +267,10 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
   const refreshRuns = useCallback(() => {
     if (!available) return;
     listRuns()
-      .then(setRuns)
+      .then((r) => {
+        setRuns(r.runs);
+        setHistoryDegraded(!!r.historyDegraded);
+      })
       .catch(() => {});
   }, [available]);
 
@@ -388,6 +393,7 @@ export function DiagnoseProvider({ children }: { children: ReactNode }) {
     view,
     activeRunId,
     runs,
+    historyDegraded,
     // pendingTarget is set ONLY when the current agent's consent is missing, and
     // cleared on approve/cancel — so its presence is exactly "consent needed now".
     needsConsent: !!pendingTarget,

--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -216,6 +216,22 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
       agentLabel={activeAgentLabel}
       maximized={maximized}
     />
+  ) : d.activeRunId && d.runsLoaded ? (
+    // A focused id that isn't in the loaded list — a deep link (?ai-run=…) to a
+    // cleared/evicted/unknown run. Say so; the generic "select an
+    // investigation" placeholder would read as a broken link.
+    <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center">
+      <p className="text-sm text-theme-text-secondary">
+        This investigation is no longer available — history keeps the most
+        recent investigations, and this one has been cleared.
+      </p>
+      <button
+        onClick={d.goHome}
+        className="rounded-lg border border-theme-border px-3 py-1.5 text-sm text-theme-text-secondary hover:bg-theme-hover"
+      >
+        View investigations
+      </button>
+    </div>
   ) : d.startError ? (
     <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center">
       <p className="text-sm text-theme-text-secondary">{d.startError}</p>

--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -333,6 +333,7 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
               runs={d.runs}
               selectedId={d.activeRunId}
               onSelect={d.openRun}
+              historyDegraded={d.historyDegraded}
             />
           </aside>
         )}
@@ -345,6 +346,7 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
               agentLabel={d.agentLabel}
               runs={d.runs}
               onSelect={d.openRun}
+              historyDegraded={d.historyDegraded}
             />
           </div>
         ) : (

--- a/web/src/components/diagnose/DiagnoseSurface.tsx
+++ b/web/src/components/diagnose/DiagnoseSurface.tsx
@@ -216,6 +216,15 @@ export function DiagnoseSurface({ topInset = 0 }: { topInset?: number }) {
       agentLabel={activeAgentLabel}
       maximized={maximized}
     />
+  ) : d.activeRunId && !d.runsLoaded ? (
+    // Deep-linked to a run before the list has ever loaded: show the load
+    // state (the 4s poll retries while the panel is open) — never the generic
+    // placeholder, and never a premature "no longer available".
+    <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-theme-text-tertiary">
+      {d.runsLoadFailed
+        ? "Couldn't load investigations — retrying…"
+        : "Loading investigations…"}
+    </div>
   ) : d.activeRunId && d.runsLoaded ? (
     // A focused id that isn't in the loaded list — a deep link (?ai-run=…) to a
     // cleared/evicted/unknown run. Say so; the generic "select an

--- a/web/src/components/diagnose/Home.tsx
+++ b/web/src/components/diagnose/Home.tsx
@@ -48,7 +48,9 @@ function statusWord(
     case "stopped":
       return { text: "Stopped", cls: "text-theme-text-tertiary" };
     case "stale":
-      return { text: "Stale", cls: "text-amber-500" };
+      // Plain words, not the internal status name: "stale" means the run was
+      // about a cluster that's no longer connected.
+      return { text: "Different cluster", cls: "text-amber-500" };
     default:
       return null;
   }
@@ -140,11 +142,20 @@ export function RecentList({
               )}
             </span>
           </div>
-          {r.preview && (
+          {(r.status === "stale" && r.context) || r.preview ? (
             <div className="truncate pl-3.5 text-xs text-theme-text-tertiary">
+              {/* A foreign-cluster run names its cluster — in mixed multi-
+                  context history, identical-looking rows otherwise give no way
+                  to tell WHICH cluster an investigation was about. */}
+              {r.status === "stale" && r.context ? (
+                <span className="text-amber-600/80 dark:text-amber-500/80">
+                  {r.context}
+                </span>
+              ) : null}
+              {r.status === "stale" && r.context && r.preview ? " · " : ""}
               {r.preview}
             </div>
-          )}
+          ) : null}
         </button>
       ))}
     </div>

--- a/web/src/components/diagnose/Home.tsx
+++ b/web/src/components/diagnose/Home.tsx
@@ -59,16 +59,29 @@ export function RecentList({
   runs,
   onSelect,
   selectedId,
+  historyDegraded = false,
 }: {
   agentLabel: string;
   runs: RunSummary[];
   onSelect: (id: string) => void;
   selectedId?: string | null;
+  historyDegraded?: boolean;
 }) {
   const now = Date.now();
 
+  // Persistence broke (disk error) — without this the user reasonably assumes
+  // their history survives a restart, and it won't.
+  const degradedNote = historyDegraded ? (
+    <div className="mb-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-2.5 py-1.5 text-[11px] leading-snug text-theme-text-secondary">
+      History isn&apos;t being saved right now (disk error) — investigations
+      won&apos;t survive a restart.
+    </div>
+  ) : null;
+
   if (runs.length === 0) {
     return (
+      <div>
+      {degradedNote}
       <div className="flex flex-col items-center px-4 py-12 text-center">
         <Sparkles className="mb-3 h-7 w-7 text-accent" />
         <div className="text-sm font-medium text-theme-text-primary">
@@ -80,14 +93,16 @@ export function RecentList({
           action to investigate it with {agentLabel} —{" "}
           <span className="font-medium text-theme-text-secondary">Diagnose</span>{" "}
           a problem, or just ask about it. Investigations run in the background
-          and stay here until you restart Radar.
+          and are kept in your history here.
         </p>
+      </div>
       </div>
     );
   }
 
   return (
     <div className="space-y-2">
+      {degradedNote}
       <div className="text-[11px] font-medium uppercase tracking-wide text-theme-text-tertiary">
         Investigations
       </div>

--- a/web/src/components/diagnose/InvestigationView.tsx
+++ b/web/src/components/diagnose/InvestigationView.tsx
@@ -25,6 +25,7 @@ import {
   TurnView,
   ResultCard,
   ApplyDialog,
+  RunContextCard,
   appendThinking,
   upsertTool,
   type Turn,
@@ -490,6 +491,7 @@ export function InvestigationView({
                 </button>
               </div>
             )}
+            <RunContextCard run={run} />
             {turns.map((t, i) => {
               const isLast = i === turns.length - 1;
               const canApply = i === lastRemediationIdx && !stale;

--- a/web/src/components/diagnose/InvestigationView.tsx
+++ b/web/src/components/diagnose/InvestigationView.tsx
@@ -476,9 +476,9 @@ export function InvestigationView({
                 <div className="flex items-start gap-2">
                   <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
                   <span>
-                    This investigation is no longer available — investigations are
-                    kept in memory and clear when Radar restarts or after enough
-                    newer ones. Re-run Diagnose to analyze the current cluster.
+                    This investigation is no longer available — history keeps
+                    the most recent investigations, and this one has been
+                    cleared. Re-run Diagnose to analyze the current cluster.
                   </span>
                 </div>
                 <button

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -519,6 +519,23 @@ export function RunContextCard({ run }: { run: RunSummary }) {
         </div>,
       );
     }
+  } else if (issueCount > 0) {
+    // Runs persisted before per-row capture carry only the rollup — never
+    // let a known-unhealthy run read as "0 active issues".
+    lines.push(
+      <div key="agg" className="flex items-start gap-1.5">
+        <StatusDot
+          tone={h?.highestSeverity === "critical" ? "unhealthy" : "degraded"}
+          className="mt-1 shrink-0"
+        />
+        <span className="min-w-0">
+          <span className="font-medium text-theme-text-primary">
+            {issueCount} active issue{issueCount === 1 ? "" : "s"}
+          </span>
+          {h?.topReason ? <> — {h.topReason}</> : null}
+        </span>
+      </div>,
+    );
   } else if (h?.health === "healthy") {
     lines.push(
       <div key="healthy" className="flex items-center gap-1.5">

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -480,51 +480,81 @@ export function TurnView({
 // health frame the server captured at run start. It renders instantly (no agent
 // round-trip), so the agent's boot time reads as "context, then deepening"
 // instead of dead air — and it anchors the verdict against Radar's own signal.
+function healthLineTone(severity?: string): "unhealthy" | "degraded" | "alert" {
+  if (severity === "critical") return "unhealthy";
+  if (severity === "warning") return "degraded";
+  return "alert";
+}
+
 export function RunContextCard({ run }: { run: RunSummary }) {
   const h = run.health;
   const issueCount = h?.issueCount ?? 0;
+  const issues = h?.issues ?? [];
+  const findings = h?.auditFindings ?? [];
   const lines: ReactNode[] = [];
-  if (issueCount > 0) {
-    lines.push(
-      <span key="issues">
-        <StatusDot tone="unhealthy" className="mr-1.5 inline-block" />
-        {issueCount} active issue{issueCount === 1 ? "" : "s"}
-        {h?.topReason ? (
-          <>
-            {" — "}
-            <span className="text-theme-text-primary">{h.topReason}</span>
-          </>
-        ) : null}
-      </span>,
-    );
+  if (issues.length > 0) {
+    // The actual issue rows Radar's engine flagged — the reason bolded, the
+    // engine's own detail sentence after it. Concrete beats a count.
+    for (const [i, line] of issues.entries()) {
+      lines.push(
+        <div key={`issue-${i}`} className="flex items-start gap-1.5">
+          <StatusDot
+            tone={healthLineTone(line.severity)}
+            className="mt-1 shrink-0"
+          />
+          <span className="min-w-0">
+            <span className="font-medium text-theme-text-primary">
+              {line.reason}
+            </span>
+            {line.message ? <> — {line.message}</> : null}
+          </span>
+        </div>,
+      );
+    }
+    if (issueCount > issues.length) {
+      lines.push(
+        <div key="more" className="pl-3.5 text-theme-text-tertiary">
+          +{issueCount - issues.length} more active issue
+          {issueCount - issues.length === 1 ? "" : "s"}
+        </div>,
+      );
+    }
   } else if (h?.health === "healthy") {
     lines.push(
-      <span key="healthy">
-        <StatusDot tone="healthy" className="mr-1.5 inline-block" />
+      <div key="healthy" className="flex items-center gap-1.5">
+        <StatusDot tone="healthy" className="shrink-0" />
         Reported healthy — 0 active issues
-      </span>,
+      </div>,
     );
   } else if (h) {
     lines.push(
-      <span key="none">
-        <StatusDot tone="unknown" className="mr-1.5 inline-block" />
-        0 active issues{h.health ? ` — status ${h.health}` : ""}
-      </span>,
+      <div key="none" className="flex items-center gap-1.5">
+        <StatusDot tone="unknown" className="shrink-0" />0 active issues
+        {h.health ? ` — status ${h.health}` : ""}
+      </div>,
     );
   }
-  if ((h?.auditCount ?? 0) > 0) {
+  for (const [i, f] of findings.entries()) {
     lines.push(
-      <span key="audit" className="text-theme-text-tertiary">
-        {h!.auditCount} configuration finding{h!.auditCount === 1 ? "" : "s"} from
-        cluster audit{h?.topFinding ? ` — ${h.topFinding}` : ""}
-      </span>,
+      <div key={`audit-${i}`} className="pl-3.5 text-theme-text-tertiary">
+        Audit: <span className="font-medium">{f.reason}</span>
+        {f.message ? <> — {f.message}</> : null}
+      </div>,
+    );
+  }
+  if ((h?.auditCount ?? 0) > findings.length && findings.length > 0) {
+    lines.push(
+      <div key="audit-more" className="pl-3.5 text-theme-text-tertiary">
+        +{h!.auditCount! - findings.length} more audit finding
+        {h!.auditCount! - findings.length === 1 ? "" : "s"}
+      </div>,
     );
   }
   if (run.managedBy) {
     lines.push(
-      <span key="managed" className="text-theme-text-tertiary">
+      <div key="managed" className="pl-3.5 text-theme-text-tertiary">
         Managed by {run.managedBy}
-      </span>,
+      </div>,
     );
   }
   if (lines.length === 0) return null;
@@ -533,11 +563,7 @@ export function RunContextCard({ run }: { run: RunSummary }) {
       <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-theme-text-tertiary">
         Radar&apos;s read at start
       </div>
-      <div className="space-y-0.5 text-xs text-theme-text-secondary">
-        {lines.map((l, i) => (
-          <div key={i}>{l}</div>
-        ))}
-      </div>
+      <div className="space-y-1 text-xs text-theme-text-secondary">{lines}</div>
     </div>
   );
 }

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -26,7 +26,9 @@ import {
   type Diagnosis,
   type DiagnoseStep,
   type AgentInfo,
+  type RunSummary,
 } from "../../api/diagnose";
+import { StatusDot } from "@skyhook-io/k8s-ui";
 import { Markdown } from "../ui/Markdown";
 
 // Segmented two-or-more-way selector — shared shape for the agent picker and the
@@ -470,6 +472,72 @@ export function TurnView({
           <span>{turn.error}</span>
         </div>
       )}
+    </div>
+  );
+}
+
+// RunContextCard opens every investigation with what RADAR already knows — the
+// health frame the server captured at run start. It renders instantly (no agent
+// round-trip), so the agent's boot time reads as "context, then deepening"
+// instead of dead air — and it anchors the verdict against Radar's own signal.
+export function RunContextCard({ run }: { run: RunSummary }) {
+  const h = run.health;
+  const issueCount = h?.issueCount ?? 0;
+  const lines: ReactNode[] = [];
+  if (issueCount > 0) {
+    lines.push(
+      <span key="issues">
+        <StatusDot tone="unhealthy" className="mr-1.5 inline-block" />
+        {issueCount} active issue{issueCount === 1 ? "" : "s"}
+        {h?.topReason ? (
+          <>
+            {" — "}
+            <span className="text-theme-text-primary">{h.topReason}</span>
+          </>
+        ) : null}
+      </span>,
+    );
+  } else if (h?.health === "healthy") {
+    lines.push(
+      <span key="healthy">
+        <StatusDot tone="healthy" className="mr-1.5 inline-block" />
+        Reported healthy — 0 active issues
+      </span>,
+    );
+  } else if (h) {
+    lines.push(
+      <span key="none">
+        <StatusDot tone="unknown" className="mr-1.5 inline-block" />
+        0 active issues{h.health ? ` — status ${h.health}` : ""}
+      </span>,
+    );
+  }
+  if ((h?.auditCount ?? 0) > 0) {
+    lines.push(
+      <span key="audit" className="text-theme-text-tertiary">
+        {h!.auditCount} configuration finding{h!.auditCount === 1 ? "" : "s"} from
+        cluster audit{h?.topFinding ? ` — ${h.topFinding}` : ""}
+      </span>,
+    );
+  }
+  if (run.managedBy) {
+    lines.push(
+      <span key="managed" className="text-theme-text-tertiary">
+        Managed by {run.managedBy}
+      </span>,
+    );
+  }
+  if (lines.length === 0) return null;
+  return (
+    <div className="rounded-md border border-theme-border/60 bg-theme-base/40 px-2.5 py-2">
+      <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-theme-text-tertiary">
+        Radar&apos;s read at start
+      </div>
+      <div className="space-y-0.5 text-xs text-theme-text-secondary">
+        {lines.map((l, i) => (
+          <div key={i}>{l}</div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -519,23 +519,6 @@ export function RunContextCard({ run }: { run: RunSummary }) {
         </div>,
       );
     }
-  } else if (issueCount > 0) {
-    // Runs persisted before per-row capture carry only the rollup — never
-    // let a known-unhealthy run read as "0 active issues".
-    lines.push(
-      <div key="agg" className="flex items-start gap-1.5">
-        <StatusDot
-          tone={h?.highestSeverity === "critical" ? "unhealthy" : "degraded"}
-          className="mt-1 shrink-0"
-        />
-        <span className="min-w-0">
-          <span className="font-medium text-theme-text-primary">
-            {issueCount} active issue{issueCount === 1 ? "" : "s"}
-          </span>
-          {h?.topReason ? <> — {h.topReason}</> : null}
-        </span>
-      </div>,
-    );
   } else if (h?.health === "healthy") {
     lines.push(
       <div key="healthy" className="flex items-center gap-1.5">

--- a/web/src/components/diagnose/parts.tsx
+++ b/web/src/components/diagnose/parts.tsx
@@ -518,7 +518,8 @@ export function ConsentCard({
         </span>{" "}
         on your machine — no Radar cloud, no API key, no account. Radar sends
         this resource&apos;s spec, recent events, and pod logs to it (and on to
-        its model provider under your account, not to Radar).
+        its model provider under your account, not to Radar). Transcripts are
+        kept in your local Radar history on this machine until cleared.
         {isolated && !isCursor && (
           <>
             {" "}

--- a/web/src/components/settings/SettingsDialog.tsx
+++ b/web/src/components/settings/SettingsDialog.tsx
@@ -268,6 +268,7 @@ export function SettingsDialog({ open, onClose, onShowMyPermissions }: SettingsD
               setAiDraft((d) => ({ ...d, ...patch }))
               setSaveMessage(null)
             }}
+            onHistoryCleared={diag.refreshRuns}
           />
 
           <SectionLabel>Radar configuration</SectionLabel>


### PR DESCRIPTION
**Stacked on #947** (Diagnose with AI) — merge that first, then retarget/rebase this to main. Together they ship as one feature.

Three pieces:

## 1. Runs persist to SQLite (`~/.radar/ai-runs.db`)

Runs were RAM-only: a restart lost every transcript, verdict, and the `sessionId` behind "continue in your agent" — even though the agent CLIs' own sessions survive on disk. Default-on, dir 0700 / file 0600, `--ai-history` / `aiHistory` config to disable.

- Two tables (`runs` + `run_events (run_id, seq)`); async single-writer enqueued under the run mutex; **terminal events commit with their status in one transaction** so crash recovery trusts the status column; loads drain the queue (read-your-writes).
- **Multi-process safe**: run ids are random (never a counter — an ephemeral standalone run beside a long-running instance can't collide and overwrite another investigation), and runs carry their owner pid, so loading history never "repairs" a `running` row that another live process owns.
- Run rows hydrate eagerly (interrupted `running` rows — initial turn or follow-up — flip to error with a restart marker; Cursor sessions cleared: workspace-scoped resume can't survive the temp workdir). Event logs hydrate lazily; **a failed load never marks hydrated** (appending against an unknown prefix would overwrite history — follow-ups refuse, Subscribe returns a closed stream for EventSource retry), and an unloadable DB detaches entirely rather than risk overwriting it.
- Cross-context history loads view-only (lazy staleness sweep, store-assigned terminal markers; idempotent across repeated context switches). Graceful shutdown appends a terminal marker before cancelling agents. Retention 100 runs / 30 days; eviction deletes rows. Any persistence failure (open/load/write) degrades **loudly**: log + `historyDegraded` on the list response + a panel notice.
- **Consent is machine-scoped, shared, and server-enforced**: acknowledged disclosure versions live server-side (`~/.radar/config.json`, per surface — Cursor keeps its distinct one), so consenting in the panel covers the CLI and vice versa, and `POST /diagnose/runs` refuses (403) until the resolved agent's surface is acknowledged — spawning an agent never depends on client-side checks alone. Disclosure-version bumps (this PR adds local retention to the copy) force a one-time re-acknowledgment. Settings gains a confirmed **Clear history** (`POST /api/diagnose/history/clear` — one keep-aware transaction; live runs survive; also removes a broken DB's files, which doubles as the recovery for a corrupted history DB).

## 2. `radar diagnose <kind>/<name>` — the terminal front-end

A CLI client that starts the **same durable server-side run** the panel uses:

```
$ radar diagnose deploy/lws-controller-manager -n lws-system
◉ Investigating Deployment lws-system/lws-controller-manager
run-4 · via Claude Code · watch: http://localhost:9280/?ai-run=run-4
● Unschedulable — 2 node(s) insufficient cpu. (0/2 nodes available)
● Available: MinimumReplicasUnavailable — Deployment does not have minimum availability.
  audit: cpuLimitMissing — Container "manager" has no CPU limit

<dimmed reasoning stream + ✓ tool calls as k=v pairs with timings>
⠙ reading logs… 12s

▲ Root cause · confidence high
...
Remediation
  ★1. <recommended, ★ marked, with the agent's why>
```

- **Two modes**: against a running Radar (discovered via `~/.radar/mcp-port`, or `--server`) — the fast default — or **cold** (`--standalone`, and the automatic fallback when nothing is running): boots a temporary in-process Radar, headless on a random port, consent prompt *before* the cluster-connect wait, a single "connecting to cluster…" spinner during it, clean teardown after. The ephemeral instance never touches the port-file discovery slot but **shares the history DB**, so a cold run's transcript shows up in the UI later.
- **Live activity line** during quiet gaps speaks the panel's vocabulary — "reading logs…", "tracing dependencies…", "starting investigation…" — from the step-running events, with elapsed seconds.
- `--json` for CI (clean verdict JSON on stdout, progress on stderr) · `--open` to watch in the UI via the new `?ai-run=<id>` deep link (consumed once, stripped from the URL) · kubectl-style kind aliases (`po`, `deploy`, `sts`, …) · flags on either side of the target · one-time consent prompt on real TTYs (non-interactive callers get the disclosure and proceed) · actionable errors for no-Radar, an older Radar behind a stale port file, and no-agent-installed. All boot/request/klog logging is captured to a tail buffer surfaced only on failure.

## 3. "Radar's read at start" — instant context

The transcript (panel *and* CLI header) opens with the concrete issue rows the server captured at run start — severity-dotted engine sentences like *"Unschedulable — 2 node(s) insufficient cpu (0/2 nodes available)"*, top audit findings, and the managedBy owner — rendered instantly from data Radar already has. The agent's boot time reads as context-then-deepening instead of dead air, the verdict stays anchored against Radar's own signal, and the same rows frame the first-turn prompt so the agent starts from specifics.

## Testing

- `go test ./internal/ai ./internal/diagnosecli` (incl. `-race`): store roundtrip/auto-seq/0600 perms, restart replay parity, interrupted initial turn **and** follow-up, graceful-shutdown roundtrip, hydration-failure refusal, foreign-context sweep idempotence, Cursor non-resumable, eviction deletes rows, clear-keeps-running, degraded-visibility for open+load failures, kind aliases, interleaved flag parsing, all verdict shapes render.
- **Live end-to-end**: run → kill radar → restart → list + full transcript replay + follow-up sequence continuity + clear (stubbed agent, temp HOME); real-agent runs against an EKS cluster from both the UI and the CLI; cold-start `--standalone` against EKS (fallback note → connect spinner → clean transcript → exit 0, no port file written); `?ai-run` deep link and the context card screenshot-verified in the panel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches local persistence of cluster transcripts and agent spawn/consent paths; large RunManager/store surface area with race and multi-process edge cases, though heavily tested.
> 
> **Overview**
> Adds **durable AI investigation history** (default SQLite at `~/.radar/ai-runs.db`, `--ai-history` / config to disable): transcripts and verdicts survive restarts, with async persistence, crash/interrupt recovery, random run IDs and owner-PID rules for shared DBs, lazy hydration with refusal to append on load failure, context-change staleness, retention/eviction, `historyDegraded` surfacing, and **Clear history** in settings plus `POST /api/diagnose/history/clear`.
> 
> Introduces **`radar diagnose <kind>/<name>`** as a terminal client over the same REST+SSE runs (discovery via `~/.radar/mcp-port`, `--standalone` ephemeral server fallback, consent before boot, live spinner, `--json` / `--open` with `?ai-run=` deep link). Ephemeral runs skip the MCP port file but can share the history DB.
> 
> **Consent** moves to machine-scoped `~/.radar/config.json` per surface (`standard` / `cursor`), enforced on run start and exposed via `POST /api/diagnose/consent`; the web panel and CLI share one acknowledgment.
> 
> **Instant context**: health frames and prompts include capped issue/audit **rows** (not just counts); panel and CLI show “Radar’s read at start” before the agent streams.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 299634b4dbe56e0cbfeed835f926807c69fe3c1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


