### PR TITLE
GitOps board: shape-stable loading state

### DIFF
--- a/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
@@ -32,7 +32,6 @@ import { FacetSection, FacetButton } from '../ui/Facet'
 import { SortableTh, TH_CLASS, type SortDir } from '../ui/SortableTh'
 import { DistributionBar } from '../ui/DistributionBar'
 import { RowActionMenu, type RowActionItem } from '../ui/RowActionMenu'
-import { PaneLoader } from '../ui/PaneLoader'
 import { getGitOpsResourceStatus } from './detail-helpers'
 import { isArgoSuspendedByRadar } from '../resources/resource-utils-argo'
 import { toggleSet } from './GitOpsGraphFilterRail'
@@ -531,6 +530,12 @@ export function GitOpsTableView({
 
   const showCrossClusterTile = typeof crossClusterCount === 'number' && mode === 'applications'
 
+  // First fetch, nothing to show yet. Drives the shape-stable loading
+  // treatment: tiles pulse instead of reading "0" (a false zero), the table
+  // area renders skeleton rows, and the filter rail holds its loaded height
+  // with section stubs — so the settled layout doesn't reflow into place.
+  const initialLoading = Boolean(loading) && allRowsInput.length === 0
+
   // Header tiles unify with the facet rail: each STATUS tile toggles its own
   // dimension and composes with the other facets + search (clicking "Out of
   // sync" adds sync=OutOfSync without wiping an active health filter or your
@@ -615,6 +620,7 @@ export function GitOpsTableView({
                   value={tile.value}
                   tone={tile.tone}
                   active={tile.active}
+                  loading={initialLoading}
                   onClick={() => {
                     if (tile.active) tile.clear?.()
                     else tile.apply?.()
@@ -631,6 +637,7 @@ export function GitOpsTableView({
         }`}
       >
       <GitOpsFilterSidebar
+        loading={initialLoading}
         side={filtersSide}
         mode={mode}
         onModeChange={setMode}
@@ -754,8 +761,8 @@ export function GitOpsTableView({
             <div className="flex h-full items-center justify-center text-sm text-theme-text-secondary">
               {modeLabel(mode)} view is queued behind the application list.
             </div>
-          ) : loading && filteredRows.length === 0 ? (
-            <PaneLoader label="Loading GitOps applications…" className="h-full" />
+          ) : initialLoading ? (
+            <GitOpsTableSkeleton />
           ) : error ? (
             <div className="p-4 text-sm text-red-500">Failed to load GitOps applications: {error.message}</div>
           ) : filteredRows.length === 0 ? (
@@ -805,7 +812,62 @@ export function GitOpsTableView({
 // GitOpsTableView's visual language and not generally useful elsewhere.
 // =============================================================================
 
+// Shape-stable loading stand-ins. Both mirror the loaded anatomy so data
+// resolves in place: rows appear inside the table frame, facets inside the
+// rail — no half-height rail dangling next to a centered spinner, no layout
+// jump when the response lands.
+function GitOpsTableSkeleton() {
+  return (
+    <div aria-live="polite" aria-label="Loading GitOps applications…" className="divide-y divide-theme-border-light">
+      {Array.from({ length: 10 }, (_, i) => (
+        <div key={i} className="flex items-center gap-6 px-4 py-3" style={{ opacity: 1 - i * 0.09 }}>
+          <div className="min-w-0 flex-[2] space-y-2">
+            <div className="h-4 w-2/3 animate-pulse rounded bg-theme-hover" />
+            <div className="h-3 w-1/2 animate-pulse rounded bg-theme-hover" />
+          </div>
+          <div className="hidden h-4 flex-1 animate-pulse rounded bg-theme-hover md:block" />
+          <div className="h-5 w-20 animate-pulse rounded-full bg-theme-hover" />
+          <div className="h-5 w-20 animate-pulse rounded-full bg-theme-hover" />
+          <div className="hidden h-4 flex-[1.5] animate-pulse rounded bg-theme-hover lg:block" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function GitOpsSidebarSkeleton() {
+  // Section stubs sized like the loaded rail (Sync ~4 rows, Health ~5,
+  // Automation ~3, Projects/Namespaces a few each) so the rail keeps its
+  // height while counts are unknown — showing real facet buttons with "0"
+  // counts would be false zeros.
+  const sections: Array<[string, number]> = [
+    ['Sync', 4],
+    ['Health', 5],
+    ['Automation', 3],
+    ['Projects', 4],
+    ['Namespaces', 4],
+  ]
+  return (
+    <div aria-hidden>
+      {sections.map(([title, rows]) => (
+        <div key={title} className="border-b border-theme-border-light px-3 py-3">
+          <div className="mb-2 h-3 w-24 animate-pulse rounded bg-theme-hover" />
+          <div className="space-y-1.5">
+            {Array.from({ length: rows }, (_, i) => (
+              <div key={i} className="flex items-center justify-between px-1.5 py-1">
+                <div className="h-3.5 animate-pulse rounded bg-theme-hover" style={{ width: `${52 - i * 6}%` }} />
+                <div className="h-3.5 w-6 animate-pulse rounded bg-theme-hover" />
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
 function GitOpsFilterSidebar({
+  loading,
   side,
   mode,
   onModeChange,
@@ -853,6 +915,8 @@ function GitOpsFilterSidebar({
   namespaceFilters: Set<string>
   onToggleNamespace: (value: string) => void
   onClear: () => void
+  /** Initial fetch in flight — hold the rail's shape with section stubs. */
+  loading?: boolean
 }) {
   return (
     <aside
@@ -867,6 +931,10 @@ function GitOpsFilterSidebar({
         </button>
       </div>
       <div className="flex-1 overflow-y-auto">
+        {loading ? (
+          <GitOpsSidebarSkeleton />
+        ) : (
+          <>
         {AVAILABLE_MODES.length > 1 && (
         <GitOpsFilterSection icon={GitBranch} title="Scope">
           <div className="grid grid-cols-2 gap-1">
@@ -960,6 +1028,8 @@ function GitOpsFilterSidebar({
             />
           ))}
         </GitOpsFilterSection>
+          </>
+        )}
       </div>
     </aside>
   )

--- a/packages/k8s-ui/src/components/ui/SummaryTile.tsx
+++ b/packages/k8s-ui/src/components/ui/SummaryTile.tsx
@@ -12,12 +12,16 @@ export function SummaryTile({
   tone = 'neutral',
   onClick,
   active = false,
+  loading = false,
 }: {
   label: string
   value: number
   tone?: SummaryTone
   onClick?: () => void
   active?: boolean
+  /** First fetch in flight — render a pulse instead of the value. A tile
+   *  that reads "0" while loading is a false zero, not a count. */
+  loading?: boolean
 }) {
   const toneClass = {
     neutral: 'text-theme-text-primary',
@@ -33,7 +37,11 @@ export function SummaryTile({
     error: 'border-red-500',
     info: 'border-sky-500',
   }[tone]
-  const value$ = <div className={`text-sm font-semibold ${toneClass}`}>{value}</div>
+  const value$ = loading ? (
+    <div className="my-1 h-3.5 w-8 animate-pulse rounded bg-theme-hover" aria-hidden />
+  ) : (
+    <div className={`text-sm font-semibold ${toneClass}`}>{value}</div>
+  )
   const label$ = <div className="text-xs text-theme-text-tertiary">{label}</div>
   if (!onClick) {
     return (


### PR DESCRIPTION
## Summary

First load of the GitOps board rendered a centered spinner beside a half-height filter rail, and the summary tiles read **0 Total Applications** while the fetch was in flight — a false zero, not a count. The loading frame now mirrors the loaded anatomy, so the settled page resolves in place instead of reflowing around a spinner.

## What changed

- **Summary tiles**: `SummaryTile` gains an additive `loading` prop — a pulse bar replaces the value while the first fetch is in flight, keeping the real labels. No consumer-breaking changes (Applications board can adopt the same prop).
- **Table area**: the initial-load branch renders skeleton rows (two-line, fading down the list) behind the real search toolbar, replacing the `PaneLoader` spinner.
- **Filter rail**: while loading, the rail holds its loaded height with pulsing section stubs (Sync / Health / Automation / Projects / Namespaces) instead of collapsing to half-height — and instead of rendering real facet buttons with unknowable `0` counts.

`initialLoading` is scoped to `loading && rows.length === 0`, so refreshes with data on screen keep the current non-blocking behavior.

## Testing

- `make tsc` green.
- Verified in a standalone Playwright harness mounting `GitOpsTableView` with `loading` + empty rows: 110 skeleton elements render in the stable frame (tiles, rail stubs, table rows), no false-zero tile values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational loading UX only in GitOps list components; optional SummaryTile prop is backward compatible and does not change data fetching or mutations.
> 
> **Overview**
> Replaces the GitOps board’s **first-load** centered spinner and misleading **0** summary counts with skeleton UI that matches the settled page layout.
> 
> **`initialLoading`** (`loading` with no rows yet) drives the new behavior; refreshes while data is already on screen are unchanged. **`SummaryTile`** gains an optional **`loading`** prop that shows a pulse instead of the numeric value. The table area uses **`GitOpsTableSkeleton`** instead of **`PaneLoader`**, and the filter rail shows **`GitOpsSidebarSkeleton`** section stubs so height and structure stay stable until counts arrive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88dff746b347a77bab72304d0b0eeb7ad99f9d1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->