### PR TITLE
Applications board: shape-stable loading state

### DIFF
--- a/packages/k8s-ui/src/components/applications/ApplicationsList.tsx
+++ b/packages/k8s-ui/src/components/applications/ApplicationsList.tsx
@@ -13,9 +13,11 @@ export interface ApplicationsListProps {
   onSelect: (key: string) => void
   /** Leading element in the header actions (e.g. a freshness control). */
   headerActions?: ReactNode
+  /** First fetch in flight — chassis renders its shape-stable skeleton. */
+  loading?: boolean
 }
 
-export function ApplicationsList({ apps, onSelect, headerActions }: ApplicationsListProps) {
+export function ApplicationsList({ apps, onSelect, headerActions, loading }: ApplicationsListProps) {
   // Env tokens this CLUSTER proved (identity classifications on the wire) feed
   // the namespace heuristic, so sibling-less rows in discovered env namespaces
   // still label without any hardcoded vocabulary.
@@ -24,6 +26,7 @@ export function ApplicationsList({ apps, onSelect, headerActions }: Applications
 
   return (
     <ApplicationsView
+      loading={loading}
       variant="single"
       entries={entries}
       onSelect={onSelect}

--- a/packages/k8s-ui/src/components/applications/ApplicationsView.tsx
+++ b/packages/k8s-ui/src/components/applications/ApplicationsView.tsx
@@ -5,6 +5,7 @@ import { clsx } from 'clsx'
 import { StatusDot, mapHealthToTone } from '../ui/status-tone'
 import { Tooltip } from '../ui/Tooltip'
 import { EmptyState } from '../ui/EmptyState'
+import { BoardTableSkeleton, BoardRailSkeleton } from '../ui/BoardSkeleton'
 import { SearchBox } from '../ui/SearchBox'
 import { useFilterState, defineFilterSchema } from '../../filter-state'
 import { PageHeader } from '../ui/PageHeader'
@@ -100,6 +101,9 @@ export interface ApplicationsViewProps {
   emptySlot?: ReactNode
   /** Leading element in the header actions cluster (e.g. a freshness control). */
   headerActions?: ReactNode
+  /** First fetch in flight — render the shape-stable skeleton (pulsing tiles,
+   *  rail stubs, table rows) instead of collapsing the chassis. */
+  loading?: boolean
 }
 
 const APPS_FILTER_SCHEMA = defineFilterSchema({
@@ -112,7 +116,7 @@ const APPS_FILTER_SCHEMA = defineFilterSchema({
   system: { param: 'system', type: 'boolean' },
 })
 
-export function ApplicationsView({ entries: allEntries, variant, onSelect, title = 'Applications', description, emptySlot, headerActions }: ApplicationsViewProps) {
+export function ApplicationsView({ entries: allEntries, variant, onSelect, title = 'Applications', description, emptySlot, headerActions, loading }: ApplicationsViewProps) {
   // Facets + search + show-system live in the URL (shareable, bookmarkable) via
   // the shared filter-state contract. Sort stays local: it's a compound
   // {key, dir} view-preference, not a result-narrowing filter, so it isn't
@@ -274,9 +278,16 @@ export function ApplicationsView({ entries: allEntries, variant, onSelect, title
     .sort((a, b) => (envRank(b[0] === 'none' ? undefined : b[0]) ?? -1) - (envRank(a[0] === 'none' ? undefined : a[0]) ?? -1))
     .map(([env, count]) => ({ value: env, label: env === 'none' ? 'unlabeled' : env, count }))
 
+  // First fetch, nothing to show yet: drive the shape-stable skeleton. The
+  // loaded state hides zero-count health tiles, so without this the header
+  // (tiles + distribution bar), rail, and table would all pop in at once.
+  const initialLoading = Boolean(loading) && allEntries.length === 0
+
   // Clickable status tile wired to the health facet — tap to filter to that tier.
   const healthTile = (h: AppHealth, tone: SummaryTone) =>
-    counts.health[h] ? (
+    initialLoading && (h === 'healthy' || h === 'degraded' || h === 'unhealthy') ? (
+      <SummaryTile key={h} label={HEALTH_META[h].label} value={0} tone={tone} loading />
+    ) : counts.health[h] ? (
       <SummaryTile key={h} label={HEALTH_META[h].label} value={counts.health[h]} tone={tone} active={fHealth.has(h)} onClick={() => filters.toggle('health', h)} />
     ) : null
 
@@ -301,7 +312,7 @@ export function ApplicationsView({ entries: allEntries, variant, onSelect, title
           actions={
             <>
               {headerActions}
-              <SummaryTile label={total === 1 ? 'application' : 'applications'} value={total} />
+              <SummaryTile label={total === 1 ? 'application' : 'applications'} value={total} loading={initialLoading} />
               {healthTile('unhealthy', 'error')}
               {healthTile('degraded', 'warning')}
               {healthTile('healthy', 'success')}
@@ -310,11 +321,15 @@ export function ApplicationsView({ entries: allEntries, variant, onSelect, title
             </>
           }
         />
-        <DistributionBar
-          className="mt-3"
-          ariaLabel="Health distribution"
-          segments={HEALTH_ORDER.map((h) => ({ key: h, count: counts.health[h] ?? 0, fillClass: HEALTH_META[h].bar }))}
-        />
+        {initialLoading ? (
+          <div className="mt-3 h-1.5 w-full animate-pulse rounded-full bg-theme-hover" aria-hidden />
+        ) : (
+          <DistributionBar
+            className="mt-3"
+            ariaLabel="Health distribution"
+            segments={HEALTH_ORDER.map((h) => ({ key: h, count: counts.health[h] ?? 0, fillClass: HEALTH_META[h].bar }))}
+          />
+        )}
       </div>
 
       {/* Body: filter sidebar | content (toolbar + table). */}
@@ -330,6 +345,18 @@ export function ApplicationsView({ entries: allEntries, variant, onSelect, title
             )}
           </div>
           <div className="flex-1 overflow-y-auto">
+            {initialLoading ? (
+              <BoardRailSkeleton
+                sections={[
+                  ['Availability', 5],
+                  ['Class', 3],
+                  ['Type', 4],
+                  ['Environment', 3],
+                  ['Source', 3],
+                ]}
+              />
+            ) : (
+              <>
             <Facet icon={HeartPulse} title="Availability" options={HEALTH_ORDER.map((h) => ({ value: h, label: HEALTH_META[h].label, count: counts.health[h] ?? 0, tone: HEALTH_TONE[h] }))} selected={fHealth} onToggle={(v) => filters.toggle('health', v)} />
             <Facet icon={Layers} title="Class" options={CLASS_ORDER.map((c) => ({ value: c, label: CLASS_META[c].label, count: counts.workloadClass[c] ?? 0 }))} selected={fClass} onToggle={(v) => filters.toggle('class', v)} />
             <Facet icon={Shapes} title="Type" options={CATEGORY_ORDER.map((c) => ({ value: c, label: CATEGORY_META[c].label, count: counts.category[c] ?? 0, tooltip: CATEGORY_META[c].tooltip }))} selected={fType} onToggle={(v) => filters.toggle('type', v)} />
@@ -341,6 +368,8 @@ export function ApplicationsView({ entries: allEntries, variant, onSelect, title
                 <span>Show system namespaces</span>
                 <span className="ml-auto tabular-nums text-theme-text-tertiary">{systemCount}</span>
               </label>
+            )}
+              </>
             )}
           </div>
         </aside>
@@ -369,7 +398,9 @@ export function ApplicationsView({ entries: allEntries, variant, onSelect, title
           </div>
 
           <div className="min-w-0 flex-1 overflow-auto bg-theme-base">
-          {entries.length === 0 ? (
+          {initialLoading ? (
+            <BoardTableSkeleton />
+          ) : entries.length === 0 ? (
             emptySlot && allEntries.length === 0 ? (
               emptySlot
             ) : (

--- a/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
+++ b/packages/k8s-ui/src/components/gitops/GitOpsTableView.tsx
@@ -32,6 +32,7 @@ import { FacetSection, FacetButton } from '../ui/Facet'
 import { SortableTh, TH_CLASS, type SortDir } from '../ui/SortableTh'
 import { DistributionBar } from '../ui/DistributionBar'
 import { RowActionMenu, type RowActionItem } from '../ui/RowActionMenu'
+import { BoardTableSkeleton, BoardRailSkeleton } from '../ui/BoardSkeleton'
 import { getGitOpsResourceStatus } from './detail-helpers'
 import { isArgoSuspendedByRadar } from '../resources/resource-utils-argo'
 import { toggleSet } from './GitOpsGraphFilterRail'
@@ -766,7 +767,7 @@ export function GitOpsTableView({
               {modeLabel(mode)} view is queued behind the application list.
             </div>
           ) : initialLoading ? (
-            <GitOpsTableSkeleton />
+            <BoardTableSkeleton />
           ) : error ? (
             <div className="p-4 text-sm text-red-500">Failed to load GitOps applications: {error.message}</div>
           ) : filteredRows.length === 0 ? (
@@ -815,60 +816,6 @@ export function GitOpsTableView({
 // Subcomponents — kept private to the file; they're tightly coupled to
 // GitOpsTableView's visual language and not generally useful elsewhere.
 // =============================================================================
-
-// Shape-stable loading stand-ins. Both mirror the loaded anatomy so data
-// resolves in place: rows appear inside the table frame, facets inside the
-// rail — no half-height rail dangling next to a centered spinner, no layout
-// jump when the response lands.
-function GitOpsTableSkeleton() {
-  return (
-    <div aria-live="polite" aria-label="Loading GitOps applications…" className="divide-y divide-theme-border-light">
-      {Array.from({ length: 10 }, (_, i) => (
-        <div key={i} className="flex items-center gap-6 px-4 py-3" style={{ opacity: 1 - i * 0.09 }}>
-          <div className="min-w-0 flex-[2] space-y-2">
-            <div className="h-4 w-2/3 animate-pulse rounded bg-theme-hover" />
-            <div className="h-3 w-1/2 animate-pulse rounded bg-theme-hover" />
-          </div>
-          <div className="hidden h-4 flex-1 animate-pulse rounded bg-theme-hover md:block" />
-          <div className="h-5 w-20 animate-pulse rounded-full bg-theme-hover" />
-          <div className="h-5 w-20 animate-pulse rounded-full bg-theme-hover" />
-          <div className="hidden h-4 flex-[1.5] animate-pulse rounded bg-theme-hover lg:block" />
-        </div>
-      ))}
-    </div>
-  )
-}
-
-function GitOpsSidebarSkeleton() {
-  // Section stubs sized like the loaded rail (Sync ~4 rows, Health ~5,
-  // Automation ~3, Projects/Namespaces a few each) so the rail keeps its
-  // height while counts are unknown — showing real facet buttons with "0"
-  // counts would be false zeros.
-  const sections: Array<[string, number]> = [
-    ['Sync', 4],
-    ['Health', 5],
-    ['Automation', 3],
-    ['Projects', 4],
-    ['Namespaces', 4],
-  ]
-  return (
-    <div aria-hidden>
-      {sections.map(([title, rows]) => (
-        <div key={title} className="border-b border-theme-border-light px-3 py-3">
-          <div className="mb-2 h-3 w-24 animate-pulse rounded bg-theme-hover" />
-          <div className="space-y-1.5">
-            {Array.from({ length: rows }, (_, i) => (
-              <div key={i} className="flex items-center justify-between px-1.5 py-1">
-                <div className="h-3.5 animate-pulse rounded bg-theme-hover" style={{ width: `${52 - i * 6}%` }} />
-                <div className="h-3.5 w-6 animate-pulse rounded bg-theme-hover" />
-              </div>
-            ))}
-          </div>
-        </div>
-      ))}
-    </div>
-  )
-}
 
 function GitOpsFilterSidebar({
   loading,
@@ -936,7 +883,15 @@ function GitOpsFilterSidebar({
       </div>
       <div className="flex-1 overflow-y-auto">
         {loading ? (
-          <GitOpsSidebarSkeleton />
+          <BoardRailSkeleton
+            sections={[
+              ['Sync', 4],
+              ['Health', 5],
+              ['Automation', 3],
+              ['Projects', 4],
+              ['Namespaces', 4],
+            ]}
+          />
         ) : (
           <>
         {AVAILABLE_MODES.length > 1 && (

--- a/packages/k8s-ui/src/components/ui/BoardSkeleton.tsx
+++ b/packages/k8s-ui/src/components/ui/BoardSkeleton.tsx
@@ -1,0 +1,47 @@
+// Shape-stable loading stand-ins for the list-board chassis (GitOps,
+// Applications). Both mirror the loaded anatomy so data resolves in place:
+// rows appear inside the table frame, facets inside the rail — no half-height
+// rail dangling next to a centered spinner, no layout jump when the response
+// lands.
+
+export function BoardTableSkeleton({ rows = 10 }: { rows?: number }) {
+  return (
+    <div aria-live="polite" aria-label="Loading…" className="divide-y divide-theme-border-light">
+      {Array.from({ length: rows }, (_, i) => (
+        <div key={i} className="flex items-center gap-6 px-4 py-3" style={{ opacity: 1 - i * 0.09 }}>
+          <div className="min-w-0 flex-[2] space-y-2">
+            <div className="h-4 w-2/3 animate-pulse rounded bg-theme-hover" />
+            <div className="h-3 w-1/2 animate-pulse rounded bg-theme-hover" />
+          </div>
+          <div className="hidden h-4 flex-1 animate-pulse rounded bg-theme-hover md:block" />
+          <div className="h-5 w-20 animate-pulse rounded-full bg-theme-hover" />
+          <div className="h-5 w-20 animate-pulse rounded-full bg-theme-hover" />
+          <div className="hidden h-4 flex-[1.5] animate-pulse rounded bg-theme-hover lg:block" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// Section stubs sized like the loaded rail so it keeps its height while
+// counts are unknown — real facet buttons with "0" counts would be false
+// zeros. `sections` = [title, rowCount] pairs approximating the loaded rail.
+export function BoardRailSkeleton({ sections }: { sections: Array<[string, number]> }) {
+  return (
+    <div aria-hidden>
+      {sections.map(([title, rows]) => (
+        <div key={title} className="border-b border-theme-border-light px-3 py-3">
+          <div className="mb-2 h-3 w-24 animate-pulse rounded bg-theme-hover" />
+          <div className="space-y-1.5">
+            {Array.from({ length: rows }, (_, i) => (
+              <div key={i} className="flex items-center justify-between px-1.5 py-1">
+                <div className="h-3.5 animate-pulse rounded bg-theme-hover" style={{ width: `${52 - i * 6}%` }} />
+                <div className="h-3.5 w-6 animate-pulse rounded bg-theme-hover" />
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web/src/components/applications/ApplicationsView.tsx
+++ b/web/src/components/applications/ApplicationsView.tsx
@@ -83,7 +83,14 @@ export function ApplicationsView({ namespaces, onOpenResource }: ApplicationsVie
   // the page header from vanishing while loading / on error, the wrapper shows
   // the same header bar above those states. (Keep title + description in sync
   // with ApplicationsList's PageHeader.)
-  if (query.isLoading || query.error) {
+  if (query.isLoading) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <ApplicationsList apps={[]} onSelect={selectApp} headerActions={freshness} loading />
+      </div>
+    )
+  }
+  if (query.error) {
     return (
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <div className="shrink-0 border-b border-theme-border px-4 py-4">
@@ -93,11 +100,7 @@ export function ApplicationsView({ namespaces, onOpenResource }: ApplicationsVie
             description="Deployable software in this cluster — your services, workers, and jobs, grouped by app/release evidence."
           />
         </div>
-        {query.isLoading ? (
-          <CenteredEmpty icon={Boxes} headline="Loading applications…" />
-        ) : (
-          <CenteredEmpty tone="filtered" icon={Boxes} headline="Failed to load applications" body={(query.error as Error).message} />
-        )}
+        <CenteredEmpty tone="filtered" icon={Boxes} headline="Failed to load applications" body={(query.error as Error).message} />
       </div>
     )
   }


### PR DESCRIPTION
## Summary

Gives the Applications board the same shape-stable loading treatment the GitOps board has (#1085). First load previously rendered a bare page header + centered "Loading applications…", then the summary tiles, health distribution bar, filter rail, toolbar, and table all popped in at once — the loaded state hides zero-count health tiles, so nothing in the header held its shape during the fetch.

## What changed

- **`ApplicationsView` (k8s-ui)** gains a `loading` prop: while the first fetch is in flight it renders pulsing summary tiles (`applications` + the three primary health tiers), a placeholder distribution bar, filter-rail section stubs (Availability / Class / Type / Environment / Source), and skeleton table rows behind the real search toolbar. Scoped to `loading && entries.length === 0`, so refreshes with data on screen are untouched. `ApplicationsList` passes it through.
- **Web wrapper** mounts the chassis skeleton on `isLoading` instead of the bare-header + `CenteredEmpty` branch; the error branch is unchanged.
- **Shared `ui/BoardSkeleton`**: the skeleton pieces from the GitOps board move to `BoardTableSkeleton` + `BoardRailSkeleton` (parameterized by rail sections); `GitOpsTableView` consumes the shared module instead of its local copies. No visual change to GitOps.

## Testing

- `make tsc` green; `applications` vitest suite passes (8/8).
- Verified in a standalone harness mounting `ApplicationsList` with `loading` + empty rows: 106 skeleton elements render in the stable frame, header/rail/table hold their loaded shape.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only loading presentation with scoped `initialLoading` gating; GitOps behavior is a refactor to shared skeleton components.
> 
> **Overview**
> Adds **shape-stable first-load skeletons** to the Applications list so the header, filter rail, and table keep their layout instead of popping in after fetch.
> 
> **`ApplicationsView` / `ApplicationsList`** accept a `loading` prop. When `loading && entries.length === 0` (`initialLoading`), the view shows pulsing summary tiles (including primary health tiers that would otherwise be hidden at zero count), a placeholder distribution bar, `BoardRailSkeleton` facet stubs, and `BoardTableSkeleton` rows while the real search toolbar stays visible. Refreshes with data already on screen are unchanged.
> 
> **Web `ApplicationsView`** mounts `ApplicationsList` with `loading` on `query.isLoading` instead of a bare header plus centered “Loading applications…”; the error path is split out and unchanged.
> 
> **`ui/BoardSkeleton`** extracts shared `BoardTableSkeleton` and `BoardRailSkeleton` from GitOps; **`GitOpsTableView`** drops its local skeleton copies and uses the shared module (no intended visual change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10271272d11b57d4f9f9d8586e8b8cb75ac7e3d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->