### PR TITLE
ResourceBar: quiet color scheme + inline layout

### DIFF
--- a/packages/k8s-ui/src/components/ui/ResourceBar.tsx
+++ b/packages/k8s-ui/src/components/ui/ResourceBar.tsx
@@ -2,7 +2,7 @@ import { clsx } from 'clsx'
 import { type ReactNode } from 'react'
 import { Tooltip } from './Tooltip'
 
-type ColorScheme = 'utilization' | 'count'
+type ColorScheme = 'utilization' | 'count' | 'quiet'
 
 interface ResourceBarProps {
   /** Formatted usage string (e.g., "847m", "2.1Gi", "17") */
@@ -11,50 +11,93 @@ interface ResourceBarProps {
   total: string
   /** Usage percentage (0–100) */
   percent: number
-  /** Color scheme: "utilization" (green/yellow/red) or "count" (blue/yellow) */
+  /** Color scheme:
+   *  - "utilization": green/yellow/red — node/workload detail surfaces
+   *  - "count": blue/yellow
+   *  - "quiet": dashboard-calibrated — brand fill, amber only at genuine
+   *    scheduling-pressure levels (≥90%), never red. High utilization is a
+   *    bin-packing goal, not an incident; alarming it trains amber-blindness. */
   colorScheme?: ColorScheme
-  /** Optional marker line position (0–100), e.g., request as % of limit */
+  /** Optional marker line position (0–100), e.g., requests as % of allocatable.
+   *  Under "quiet" the marker itself turns amber at ≥95% — a cluster whose
+   *  requests are at capacity is full to the scheduler even when usage is low. */
   markerPercent?: number
   /** Optional tooltip content shown on hover */
   tooltip?: ReactNode
+  /** Layout: "stacked" (default — numbers row above the track) or "inline"
+   *  (one row: label · track · percent) for dense cards. Inline requires
+   *  `label` and omits the used/total numbers row — put them in `tooltip`. */
+  layout?: 'stacked' | 'inline'
+  /** Short leading label for the inline layout (e.g. "CPU", "MEM"). */
+  label?: string
 }
 
 function getBarColor(percent: number, scheme: ColorScheme): string {
   if (scheme === 'count') {
     return percent > 90 ? 'bg-yellow-500' : 'bg-blue-500'
   }
+  if (scheme === 'quiet') {
+    return percent >= 90 ? 'bg-amber-500' : 'bg-emerald-400'
+  }
   if (percent > 85) return 'bg-red-500'
   if (percent > 60) return 'bg-yellow-500'
   return 'bg-green-500'
 }
 
-export function ResourceBar({ used, total, percent, colorScheme = 'utilization', markerPercent, tooltip }: ResourceBarProps) {
-  const bar = (
-    <div className="flex flex-col gap-0.5 min-w-0">
-      <div className="flex items-baseline justify-between gap-1">
-        <span className="text-xs font-mono text-theme-text-secondary truncate">
-          {used} / {total}
-        </span>
-        <span className="text-[10px] font-mono text-theme-text-tertiary shrink-0">
+function getMarkerColor(markerPercent: number, scheme: ColorScheme): string {
+  if (scheme === 'quiet' && markerPercent >= 95) return 'bg-amber-500'
+  return 'bg-theme-text-primary/70'
+}
+
+export function ResourceBar({
+  used,
+  total,
+  percent,
+  colorScheme = 'utilization',
+  markerPercent,
+  tooltip,
+  layout = 'stacked',
+  label,
+}: ResourceBarProps) {
+  const track = (
+    <div className={clsx('relative', layout === 'inline' && 'min-w-0 flex-1')}>
+      <div className={clsx('rounded-full border border-theme-border bg-theme-elevated overflow-hidden', layout === 'inline' ? 'h-1' : 'h-1.5')}>
+        <div
+          className={clsx('h-full rounded-full transition-[width] duration-300 ease-out', getBarColor(percent, colorScheme))}
+          style={{ width: `${Math.min(percent, 100)}%` }}
+        />
+      </div>
+      {markerPercent != null && markerPercent > 0 && markerPercent <= 100 && (
+        <div
+          className={clsx('absolute -top-[1px] h-[calc(100%+2px)] w-[2px]', getMarkerColor(markerPercent, colorScheme))}
+          style={{ left: `${markerPercent}%` }}
+        />
+      )}
+    </div>
+  )
+
+  const bar =
+    layout === 'inline' ? (
+      <div className="flex items-center gap-1.5 min-w-0">
+        <span className="w-7 shrink-0 text-[10px] font-medium uppercase tracking-wide text-theme-text-tertiary">{label}</span>
+        {track}
+        <span className="w-8 shrink-0 text-right text-[10.5px] font-mono tabular-nums text-theme-text-secondary">
           {Math.round(percent)}%
         </span>
       </div>
-      <div className="relative">
-        <div className="h-1.5 rounded-full border border-theme-border bg-theme-elevated overflow-hidden">
-          <div
-            className={clsx('h-full rounded-full transition-[width] duration-300 ease-out', getBarColor(percent, colorScheme))}
-            style={{ width: `${Math.min(percent, 100)}%` }}
-          />
+    ) : (
+      <div className="flex flex-col gap-0.5 min-w-0">
+        <div className="flex items-baseline justify-between gap-1">
+          <span className="text-xs font-mono text-theme-text-secondary truncate">
+            {used} / {total}
+          </span>
+          <span className="text-[10px] font-mono text-theme-text-tertiary shrink-0">
+            {Math.round(percent)}%
+          </span>
         </div>
-        {markerPercent != null && markerPercent > 0 && markerPercent <= 100 && (
-          <div
-            className="absolute -top-[1px] h-[calc(100%+2px)] w-[2px] bg-theme-text-primary/70"
-            style={{ left: `${markerPercent}%` }}
-          />
-        )}
+        {track}
       </div>
-    </div>
-  )
+    )
 
   if (tooltip) {
     return (


### PR DESCRIPTION
## Summary

Two additive props on the shared `ResourceBar`, for dashboard surfaces that need capacity bars without alarm fatigue:

- **`colorScheme="quiet"`** — brand-emerald fill; amber only at genuine scheduling-pressure levels (≥90% usage), never red. The `markerPercent` tick (requests as % of allocatable) turns amber independently at ≥95% — a cluster whose requests are at capacity is full *to the scheduler* even at low usage. Rationale: high utilization is a bin-packing goal, not an incident; the default green/yellow/red at 60/85 is right for node/workload detail but manufactures false alarms on fleet dashboards.
- **`layout="inline"`** — one-row form (`label · track · percent`) for dense cards; the used/total numbers move into the tooltip.

Existing consumers are untouched (both props default to current behavior; stacked markup unchanged).

First consumer: Radar Hub's fleet home cluster cards (usage fill + requests tick per cluster).

## Testing

`make tsc` green. Rendering verified in the hub card work that consumes it (usage/marker combinations including >90% fill and >95% marker).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only additive props with backward-compatible defaults; no changes to data or auth paths.
> 
> **Overview**
> Extends the shared **`ResourceBar`** with optional **`colorScheme="quiet"`** and **`layout="inline"`**, while keeping defaults so existing stacked utilization/count bars behave the same.
> 
> **`quiet`** uses emerald fill and only turns amber at ≥90% usage (no red), so fleet-style dashboards can show high utilization without the old 60/85 alarm ladder. The requests **marker** line can turn amber on its own at ≥95% under **`quiet`**, highlighting scheduler pressure when requests are nearly at allocatable even if live usage is low.
> 
> **`inline`** renders a compact row (`label · track · percent`) with a thinner track; the used/total row is dropped from the bar itself and is meant to live in the **tooltip** instead. The bar track markup is factored into a shared **`track`** block used by both layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b32a2e7598af50723de2778a3d27e323762d4641. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->