### PR TITLE
Crossplane: don't classify v2 core groups (protection/ops) as Managed-Resource groups

### DIFF
--- a/packages/k8s-ui/src/components/resources/ResourcesView.tsx
+++ b/packages/k8s-ui/src/components/resources/ResourcesView.tsx
@@ -1709,8 +1709,16 @@ function isLikelyCrossplaneMRGroup(kind: string, group: string): boolean {
   if (k === 'providerconfig' || k === 'providerconfigs') return false
   if (group.endsWith('.upbound.io')) return true
   if (group === 'kubernetes.crossplane.io' || group === 'helm.crossplane.io') return true
-  // Reserved Crossplane core groups — never MRs.
-  if (group === 'crossplane.io' || group === 'pkg.crossplane.io' || group === 'apiextensions.crossplane.io') {
+  // Reserved Crossplane core groups — never MRs. protection.crossplane.io
+  // (Usage/ClusterUsage) and ops.crossplane.io (Operations) are Crossplane v2's
+  // new core groups: lifecycle/orchestration objects, not provider resources.
+  if (
+    group === 'crossplane.io' ||
+    group === 'pkg.crossplane.io' ||
+    group === 'apiextensions.crossplane.io' ||
+    group === 'protection.crossplane.io' ||
+    group === 'ops.crossplane.io'
+  ) {
     return false
   }
   // Any other *.crossplane.io subgroup is presumed to be a provider's MR group.


### PR DESCRIPTION
Crossplane v2 introduced two new core API groups: \`protection.crossplane.io\` (Usage/ClusterUsage — successors of the deprecated \`apiextensions.crossplane.io\` Usage) and \`ops.crossplane.io\` (Operations). \`isLikelyCrossplaneMRGroup\` presumes any non-reserved \`*.crossplane.io\` subgroup is a provider's Managed-Resource group, so objects in these groups got the generic MR column set. Add both to the reserved-core list.

Category labeling (\`api-resources.ts\`) already handles them via its \`.crossplane.io\` suffix fallback, and the MR *renderer* dispatch is spec-shape-detected (\`isManagedResource\`), so the column classifier was the only misclassification site.

Found while chasing an apiserver deprecation warning for the legacy Usage CRD — Radar itself has no references to the deprecated kind.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single heuristic change in resource column selection; no auth, data, or API behavior changes.
> 
> **Overview**
> Crossplane v2 adds **`protection.crossplane.io`** (Usage/ClusterUsage) and **`ops.crossplane.io`** (Operations). The resources table treated any other `*.crossplane.io` group as a provider Managed Resource group, so those kinds incorrectly used the generic MR columns (external name, provider config, etc.).
> 
> **`isLikelyCrossplaneMRGroup`** now treats both groups as reserved core APIs (same bucket as `crossplane.io`, `pkg.crossplane.io`, `apiextensions.crossplane.io`), so **`getColumnsForKind`** falls back to default columns instead of **`crossplanemanagedresources`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7176c398fcbc9d35ab44391503d1faaabb793450. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->