### PR TITLE
docs: drop the MCP beta tag from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ Inspect what any ServiceAccount can actually do — without three `kubectl descr
 
 Considered for follow-ups, deliberately not in this pass — RBAC audit checks (wildcard / cluster-admin / orphan-binding / unused-role detection, Kubescape-aligned), a verb × resource matrix view on the SA page (rakkess-style), a "Subject Explorer" top-level page for browsing Users / Groups without a detail page today, a graph topology view of Subject → Binding → Role → Rule (`rbac-tool viz` style), in-UI binding edits, and a "can-i" free-form query UI. Read-only visibility ships first; we'll come back once we see how operators use the reverse-lookup.
 
-### AI Integration (MCP) <sup>beta</sup>
+### AI Integration (MCP)
 
 Radar includes a built-in [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that lets AI assistants — Claude, Cursor, Copilot, and others — query your cluster through Radar.
 


### PR DESCRIPTION
MCP is GA per the discussion on skyhook-dev/marketing#155 (the site no longer shows any beta qualifier). This removes the last `beta` tag, in the README's MCP section header, so README and site carry the same maturity statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only header text change with no runtime or security impact.
> 
> **Overview**
> Aligns README maturity wording with MCP being **GA**: the **AI Integration (MCP)** section heading no longer includes the `<sup>beta</sup>` tag.
> 
> No behavior, flags, or MCP docs content changes—only that header label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 068a7662f40295b5d03e364e0f6bcd76e46ba4e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->