### PR TITLE
docs: README privacy wording and navigation pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ curl -fsSL https://get.radarhq.io | sh && kubectl radar
 - **Zero install on your cluster** — runs on your laptop, talks to the K8s API directly
 - **Single binary** — no dependencies, no agents, no CRDs
 - **Fast on big clusters** — relationship-index caching, progressive loading, and SSE delta streaming keep the UI responsive at thousands of pods
-- **Airgapped-ready** — your cluster data never leaves. The one outbound call is an anonymous version check on start (version + OS/arch); block egress to `releases.skyhook.io` and Radar runs fully offline
+- **Private by design** — your cluster data stays on your machine. No account, no agents, no cloud sync, no cluster telemetry
+- **Airgapped-friendly** — runs as a single binary against the Kubernetes API and works in locked-down environments with outbound egress blocked
 - **Real-time** — watches your cluster via informers, pushes updates to the browser via SSE
 - **Works everywhere** — GKE, EKS, AKS, minikube, kind, k3s, or any conformant cluster
 - **AI-ready** — built-in [MCP server](docs/mcp.md) lets AI assistants query your cluster through Radar
@@ -483,7 +484,7 @@ Radar auto-discovers any CRD in your cluster. Popular tools get [dedicated integ
 
 ## Security
 
-Radar reads your cluster through your own credentials and keeps all cluster data local — the only outbound call is the anonymous version check described above. Found a vulnerability? Please report it privately to **security@skyhook.io** — see [SECURITY.md](SECURITY.md) for the process and response timelines.
+Radar reads your cluster through your own credentials and keeps cluster data local. It does not upload manifests, logs, events, metrics, or resource data to Skyhook, and it does not require an account, agent, or cloud backend. Found a vulnerability? Please report it privately to **security@skyhook.io** — see [SECURITY.md](SECURITY.md) for the process and response timelines.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 🌐 **[radarhq.io](https://radarhq.io)** · [Docs](https://radarhq.io/docs) · [Releases](https://github.com/skyhook-io/radar/releases)
 
-Topology, events, Helm, GitOps, audit, and AI — one binary, run it your way.
+Topology, resources, Helm, GitOps, traffic, audit, and MCP context for AI agents — from your laptop or in-cluster.
 
 [![CI](https://github.com/skyhook-io/radar/actions/workflows/ci.yml/badge.svg)](https://github.com/skyhook-io/radar/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/skyhook-io/radar?logo=github)](https://github.com/skyhook-io/radar/releases/latest)
@@ -68,7 +68,7 @@ curl -fsSL https://get.radarhq.io | sh
 brew install skyhook-io/tap/radar
 ```
 
-Then run: `kubectl radar`. (The bare `radar` command works if you installed via Homebrew or Scoop, or added a symlink yourself.)
+Then run: `kubectl radar`. Quick install, PowerShell, Homebrew, and Scoop also set up the `radar` shorthand. Krew and direct downloads use `kubectl radar` unless you add your own `radar` symlink.
 
 <details>
 <summary><b>More install options</b> — Desktop App (macOS/Linux/Windows), Krew, Scoop, In-Cluster Helm</summary>
@@ -141,7 +141,7 @@ See the [In-Cluster Deployment Guide](docs/in-cluster.md) for ingress, authentic
 # Opens browser automatically
 kubectl radar
 
-# Homebrew and Scoop installs also get the bare command
+# Quick install, PowerShell, Homebrew, and Scoop also set up the bare command
 radar
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ curl -fsSL https://get.radarhq.io | sh && kubectl radar
 
 - **Zero install on your cluster** — runs on your laptop, talks to the K8s API directly
 - **Single binary** — no dependencies, no agents, no CRDs
-- **Fast on big clusters** — relationship-index caching, progressive loading, and SSE delta streaming keep the UI responsive at thousands of pods
+- **Fast on big clusters** — tested on tens of thousands of pods, with responsive views and live updates under real cluster churn
 - **Private by design** — your cluster data stays on your machine. No account, no agents, no cloud sync, no cluster telemetry
 - **Airgapped-friendly** — runs as a single binary against the Kubernetes API and works in locked-down environments with outbound egress blocked
 - **Real-time** — watches your cluster via informers, pushes updates to the browser via SSE
 - **Works everywhere** — GKE, EKS, AKS, minikube, kind, k3s, or any conformant cluster
-- **AI-ready** — built-in [MCP server](docs/mcp.md) lets AI assistants query your cluster through Radar
+- **AI-ready** — built-in [MCP server](docs/mcp.md) lets AI agents query your cluster through Radar
 - **In-cluster option** — deploy with Helm for shared team access with RBAC-scoped permissions
 
 > "Have Radar deployed at work. As far as Kubernetes dashboards go, this is one of the best." — u/TheRealNetroxen
@@ -389,13 +389,13 @@ Inspect what any ServiceAccount can actually do — without three `kubectl descr
 - **Role / ClusterRole detail**: who is bound to this role, with subject summaries inline
 - **RoleBinding detail**: inline preview of the rules the binding grants + warnings when subjects include wide groups (`system:authenticated`, `system:unauthenticated`, `system:masters`)
 - **"My Permissions" panel**: namespace-scoped live `SelfSubjectRulesReview` for the current user — for fast "why can't I do X" debugging
-- **MCP**: `get_subject_permissions` tool exposes the same data to AI assistants for "is this SA over-privileged?" / "blast radius if compromised?" queries
+- **MCP**: `get_subject_permissions` tool exposes the same data to AI agents for "is this SA over-privileged?" / "blast radius if compromised?" queries
 
 Read-only visibility ships first; the considered follow-ups (RBAC audit checks, verb × resource matrix, subject explorer, graph view, in-UI edits, "can-i" queries) are tracked in [#1090](https://github.com/skyhook-io/radar/issues/1090).
 
 ### AI Integration (MCP)
 
-Radar includes a built-in [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that lets AI assistants — Claude, Cursor, Copilot, and others — query your cluster through Radar.
+Radar includes a built-in [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that lets AI agents — Claude, Cursor, Copilot, and others — query your cluster through Radar.
 
 Instead of raw `kubectl` output (verbose YAML that burns through LLM context windows), your AI gets pre-processed, token-optimized data: topology graphs, health assessments, deduplicated events, and filtered logs. Read tools are strictly read-only; write tools (restart, scale, sync, and the like) carry explicit destructive-action hints and run under your cluster's RBAC, so the apiserver enforces what each identity is allowed to do.
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 <a href="https://www.producthunt.com/products/radar-7?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_campaign=badge-radar-42edb7b0-e388-4fa8-9ba5-4876c2c0d638" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1130618&theme=neutral&period=daily" alt="Radar - The missing open-source Kubernetes UI | Product Hunt" width="250" height="54" /></a>
 
-**Modern Kubernetes visibility.**
-<br>Local-first. No account. No cloud dependency. Blazing Fast.
+**The missing open-source Kubernetes UI.**
+<br>Single binary. No account required. Free forever.
 
 🌐 **[radarhq.io](https://radarhq.io)** · [Docs](https://radarhq.io/docs) · [Releases](https://github.com/skyhook-io/radar/releases)
 
-Topology, event timeline, and service traffic — plus resource browsing, Helm management, and GitOps support for FluxCD and ArgoCD.
+Topology, events, Helm, GitOps, audit, and AI — one binary, run it your way.
 
 [![CI](https://github.com/skyhook-io/radar/actions/workflows/ci.yml/badge.svg)](https://github.com/skyhook-io/radar/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/skyhook-io/radar?logo=github)](https://github.com/skyhook-io/radar/releases/latest)
@@ -16,7 +16,19 @@ Topology, event timeline, and service traffic — plus resource browsing, Helm m
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Go](https://img.shields.io/badge/Go-1.26+-00ADD8?logo=go&logoColor=white)](https://go.dev/)
 
-Visualize your cluster topology, browse resources, stream logs, exec into pods, inspect container image filesystems, manage Helm releases, monitor GitOps workflows (FluxCD & ArgoCD), and forward ports - all from a single binary with zero cluster-side installation.
+<details>
+<summary><b>Table of contents</b></summary>
+
+- [Why Radar?](#why-radar)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Views](#views) — Topology · Resources · Image Filesystem · Timeline · Helm · Compare · TLS · GitOps · Traffic · Cost · Audit · RBAC · MCP · Auth
+- [Supported Resources](#supported-resources)
+- [Keyboard Shortcuts](#keyboard-shortcuts)
+- [Security](#security)
+- [Development](#development) · [Contributing](#contributing)
+
+</details>
 
 <p align="center">
   <img src="docs/screenshot.png" alt="Radar Screenshot" width="800">
@@ -32,12 +44,14 @@ curl -fsSL https://get.radarhq.io | sh && kubectl radar
 
 - **Zero install on your cluster** — runs on your laptop, talks to the K8s API directly
 - **Single binary** — no dependencies, no agents, no CRDs
-- **Blazing fast** - smart caching, progressive loading, parallelization and other optimizations
-- **Airgapped-ready** — no external network calls, works in isolated environments
+- **Fast on big clusters** — relationship-index caching, progressive loading, and SSE delta streaming keep the UI responsive at thousands of pods
+- **Airgapped-ready** — your cluster data never leaves. The one outbound call is an anonymous version check on start (version + OS/arch); block egress to `releases.skyhook.io` and Radar runs fully offline
 - **Real-time** — watches your cluster via informers, pushes updates to the browser via SSE
 - **Works everywhere** — GKE, EKS, AKS, minikube, kind, k3s, or any conformant cluster
 - **AI-ready** — built-in [MCP server](docs/mcp.md) lets AI assistants query your cluster through Radar
 - **In-cluster option** — deploy with Helm for shared team access with RBAC-scoped permissions
+
+> "Have Radar deployed at work. As far as Kubernetes dashboards go, this is one of the best." — u/TheRealNetroxen
 
 ---
 
@@ -53,7 +67,7 @@ curl -fsSL https://get.radarhq.io | sh
 brew install skyhook-io/tap/radar
 ```
 
-Then run: `kubectl radar` (or simply `radar`)
+Then run: `kubectl radar`. (The bare `radar` command works if you installed via Homebrew or Scoop, or added a symlink yourself.)
 
 <details>
 <summary><b>More install options</b> — Desktop App (macOS/Linux/Windows), Krew, Scoop, In-Cluster Helm</summary>
@@ -87,12 +101,12 @@ Native desktop app — no terminal needed.
 brew install --cask skyhook-io/tap/radar-desktop
 ```
 
-**Debian/Ubuntu:**
+**Debian/Ubuntu** — download the `.deb` from [GitHub Releases](https://github.com/skyhook-io/radar/releases), then:
 ```bash
 sudo apt install ./radar-desktop_*.deb
 ```
 
-**Fedora/RHEL:**
+**Fedora/RHEL** — download the `.rpm` from [GitHub Releases](https://github.com/skyhook-io/radar/releases), then:
 ```bash
 sudo rpm -i radar-desktop_*.rpm
 ```
@@ -126,7 +140,7 @@ See the [In-Cluster Deployment Guide](docs/in-cluster.md) for ingress, authentic
 # Opens browser automatically
 kubectl radar
 
-# Or simply
+# Homebrew and Scoop installs also get the bare command
 radar
 ```
 
@@ -376,7 +390,7 @@ Inspect what any ServiceAccount can actually do — without three `kubectl descr
 - **"My Permissions" panel**: namespace-scoped live `SelfSubjectRulesReview` for the current user — for fast "why can't I do X" debugging
 - **MCP**: `get_subject_permissions` tool exposes the same data to AI assistants for "is this SA over-privileged?" / "blast radius if compromised?" queries
 
-Considered for follow-ups, deliberately not in this pass — RBAC audit checks (wildcard / cluster-admin / orphan-binding / unused-role detection, Kubescape-aligned), a verb × resource matrix view on the SA page (rakkess-style), a "Subject Explorer" top-level page for browsing Users / Groups without a detail page today, a graph topology view of Subject → Binding → Role → Rule (`rbac-tool viz` style), in-UI binding edits, and a "can-i" free-form query UI. Read-only visibility ships first; we'll come back once we see how operators use the reverse-lookup.
+Read-only visibility ships first; the considered follow-ups (RBAC audit checks, verb × resource matrix, subject explorer, graph view, in-UI edits, "can-i" queries) are tracked in [#1090](https://github.com/skyhook-io/radar/issues/1090).
 
 ### AI Integration (MCP)
 
@@ -467,6 +481,12 @@ Radar auto-discovers any CRD in your cluster. Popular tools get [dedicated integ
 
 ---
 
+## Security
+
+Radar reads your cluster through your own credentials and keeps all cluster data local — the only outbound call is the anonymous version check described above. Found a vulnerability? Please report it privately to **security@skyhook.io** — see [SECURITY.md](SECURITY.md) for the process and response timelines.
+
+---
+
 ## Development
 
 See the **[Development Guide](DEVELOPMENT.md)** for building from source, architecture details, API reference, and contributing.
@@ -489,6 +509,8 @@ make watch-backend
 ## Contributing
 
 Contributions are welcome! Please read our [Contributing Guide](CONTRIBUTING.md) for details on the development workflow, pull request process, and coding standards.
+
+Questions or ideas? [GitHub Discussions](https://github.com/skyhook-io/radar/discussions) is the place — or come say hi at [radarhq.io/community](https://radarhq.io/community).
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,7 +36,8 @@ When running Radar locally on your machine:
 
 - **Uses your kubeconfig**: Radar authenticates using your existing `~/.kube/config` credentials
 - **Your permissions apply**: All operations are subject to your Kubernetes RBAC permissions
-- **No external communication**: Radar only communicates with the Kubernetes API server specified in your kubeconfig
+- **No cluster telemetry**: Radar does not upload manifests, logs, events, metrics, or resource data to Skyhook
+- **No cloud dependency**: Local mode does not require an account, agent, or cloud backend
 - **No persistent storage**: By default, no data persists between sessions (optional SQLite timeline storage is local-only)
 
 ### In-Cluster Deployment

--- a/docs/gitops.md
+++ b/docs/gitops.md
@@ -127,12 +127,12 @@ The GitOps tab isn't the only place Argo/Flux ownership matters. Surfaces across
 
 ## MCP integration
 
-`manage_gitops` MCP tool exposes the same actions to AI assistants with per-action input validation:
+`manage_gitops` MCP tool exposes the same actions to AI agents with per-action input validation:
 
 - Argo: `sync`, `suspend`, `resume`
 - Flux: `reconcile`, `suspend`, `resume`
 
-`get_resource` Summary carries lifecycle signal (`terminating`, `finalizers`) so AI assistants can distinguish a zombie from a live resource and won't suggest `Sync` on something pending deletion.
+`get_resource` Summary carries lifecycle signal (`terminating`, `finalizers`) so AI agents can distinguish a zombie from a live resource and won't suggest `Sync` on something pending deletion.
 
 See [MCP server](mcp.md) for the full tool list and security model.
 
@@ -163,6 +163,6 @@ Radar shows GitOps connections only when the controller and managed resources li
 
 ## See also
 
-- [MCP server](mcp.md) — how AI assistants drive GitOps operations and read lifecycle signal
+- [MCP server](mcp.md) — how AI agents drive GitOps operations and read lifecycle signal
 - [Integrations & CRDs](integrations.md) — full CRD support matrix for Argo CD, Flux, and everything else
 - [Configuration](configuration.md) — cluster connection, multi-context kubeconfig handling

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,10 +1,10 @@
 # AI Integration (MCP)
 
-Radar includes a built-in [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that lets AI assistants query your Kubernetes cluster.
+Radar includes a built-in [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that lets AI agents query your Kubernetes cluster.
 
 ## Why MCP instead of raw kubectl?
 
-Giving an AI assistant raw `kubectl` access has problems:
+Giving an AI agent raw `kubectl` access has problems:
 
 - **Token waste** — `kubectl get pod -o yaml` returns verbose YAML full of managed fields, status conditions, and metadata noise that burns through LLM context windows
 - **No enrichment** — raw output lacks topology relationships, health assessments, or cross-resource correlation

--- a/pkg/ai/context/summary.go
+++ b/pkg/ai/context/summary.go
@@ -31,7 +31,7 @@ type ResourceSummary struct {
 	Issue     string `json:"issue,omitempty"`
 	Age       string `json:"age,omitempty"`
 	// Terminating signals that metadata.deletionTimestamp is set on the
-	// resource. AI assistants need this signal to avoid suggesting
+	// resource. AI agents need this signal to avoid suggesting
 	// mutating actions that will fail (e.g. "run kubectl rollout restart"
 	// on a Pod that's being torn down) and to correctly diagnose "why is
 	// this stuck" scenarios where the resource is a finalizer-blocked

--- a/pkg/ai/context/summary_test.go
+++ b/pkg/ai/context/summary_test.go
@@ -709,7 +709,7 @@ func TestSummary_CronJobIssue(t *testing.T) {
 }
 
 // TestSummary_TerminatingFields pins the lifecycle fields on the AI
-// summary output. AI assistants (and the MCP list_resources tool)
+// summary output. AI agents (and the MCP list_resources tool)
 // rely on these to spot zombie/finalizer-stuck resources at a glance
 // — without them, an LLM advising on "why is this not converging"
 // has no way to detect a Terminating resource short of fetching the

--- a/web/src/components/home/MCPSetupDialog.tsx
+++ b/web/src/components/home/MCPSetupDialog.tsx
@@ -204,7 +204,7 @@ export function MCPSetupDialog({ open, onClose, mcpUrl }: MCPSetupDialogProps) {
               <a href="https://modelcontextprotocol.io" target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:text-purple-300 underline underline-offset-2">
                 Model Context Protocol
               </a>{' '}
-              (MCP) server that lets AI assistants query your cluster through Radar.
+              (MCP) server that lets AI agents query your cluster through Radar.
               Unlike raw kubectl access, Radar gives your AI pre-processed, enriched data —
               topology graphs, health assessments, deduplicated events, filtered logs — so it
               can understand your cluster state quickly without burning through context on


### PR DESCRIPTION
Refreshes the README so the first screen and security story match Radar’s current product positioning: a local-first Kubernetes UI that runs as a single binary, requires no account or agents, and keeps cluster data local.

## What changed

- Standardizes the hero around “The missing open-source Kubernetes UI” and a shorter trust line: single binary, no account required, free forever.
- Adds a collapsible table of contents so the long README is easier to scan.
- Reworks the first-screen feature line around topology, resources, GitOps, traffic, audit, and MCP context for AI agents.
- Reworks the Why Radar section with concrete performance language, private-by-design / airgapped-friendly messaging, and a validated scale claim for tens of thousands of pods.
- Clarifies installation and usage details: `kubectl radar` is universal; quick install, PowerShell, Homebrew, and Scoop also set up `radar`; Krew and direct downloads use `kubectl radar` unless users add a symlink.
- Adds a README Security section and aligns `SECURITY.md` around the core trust promise: no cluster telemetry, no upload of manifests, logs, events, metrics, or resource data to Skyhook, and no account, agent, or cloud backend requirement.
- Uses “AI agents” consistently across README, MCP docs, GitOps docs, and the MCP setup dialog.
- Keeps roadmap detail out of the README by linking RBAC follow-ups to #1090; removes the MCP beta label and adds Discussions/community pointers.

## Testing

- `git diff --check origin/main...HEAD`
- Docs/copy-only change; no runtime tests or visual test run.