### PR TITLE
Treat MCP as production-ready in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ Inspect what any ServiceAccount can actually do — without three `kubectl descr
 
 Considered for follow-ups, deliberately not in this pass — RBAC audit checks (wildcard / cluster-admin / orphan-binding / unused-role detection, Kubescape-aligned), a verb × resource matrix view on the SA page (rakkess-style), a "Subject Explorer" top-level page for browsing Users / Groups without a detail page today, a graph topology view of Subject → Binding → Role → Rule (`rbac-tool viz` style), in-UI binding edits, and a "can-i" free-form query UI. Read-only visibility ships first; we'll come back once we see how operators use the reverse-lookup.
 
-### AI Integration (MCP) <sup>beta</sup>
+### AI Integration (MCP)
 
 Radar includes a built-in [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that lets AI assistants — Claude, Cursor, Copilot, and others — query your cluster through Radar.
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,7 +1,5 @@
 # AI Integration (MCP)
 
-> **Beta** — This feature is new and may evolve. Feedback welcome via [GitHub Issues](https://github.com/skyhook-io/radar/issues).
-
 Radar includes a built-in [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that lets AI assistants query your Kubernetes cluster.
 
 ## Why MCP instead of raw kubectl?


### PR DESCRIPTION
Summary
MCP is live production functionality in Radar, so the public docs should present it without beta framing. This keeps the existing setup and safety guidance intact while aligning the README and MCP guide with the product status.

What changed
- README AI Integration heading presents MCP without a beta qualifier.
- MCP guide opens directly with the MCP server description instead of a beta warning.

Testing
- Not run; docs-only change.
- Verified with grep that no MCP beta wording remains.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation wording only; no runtime, API, or security behavior changes.
> 
> **Overview**
> **Docs-only update** that aligns public messaging with MCP being production functionality.
> 
> The README **AI Integration (MCP)** section no longer carries a **beta** qualifier on the heading. The **MCP guide** (`docs/mcp.md`) drops the opening beta warning and starts directly with the MCP server description; setup, tool lists, and safety content are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d47b7883ab2ebf801b7b6efea2a944196139714c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->