### PR TITLE
GET /api/argo/destinations: cluster-secret registry as topology facts

### DIFF
--- a/internal/server/argo_destinations.go
+++ b/internal/server/argo_destinations.go
@@ -1,0 +1,176 @@
+package server
+
+import (
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/pkg/k8score"
+)
+
+// GET /api/argo/destinations — the Argo CD cluster-secret registry as plain
+// topology facts: destination name + API server URL, nothing else. Exists so
+// fleet consumers (Radar Cloud's destination mapping) never have to pull full
+// cluster Secrets — whose .data carries destination-cluster credentials —
+// through an aggregator to read two fields.
+//
+// RBAC stance (deliberate, product-approved): SA-backed inventory. The
+// response is derived from Secrets, but emits ONLY the destination name and
+// server URL — the same facts any Argo user sees in its UI — so it is not
+// gated on the caller's own secret-read RBAC. .data never crosses the wire.
+//
+// Argo's implicit in-cluster destination has no cluster Secret; consumers
+// resolve in-cluster separately (as the hub already does).
+
+const argoClusterSecretLabel = "argocd.argoproj.io/secret-type"
+
+const maxDestinationFieldLen = 512
+
+func validDestinationName(name string) bool {
+	if name == "" || len(name) > maxDestinationFieldLen {
+		return false
+	}
+	return !strings.ContainsAny(name, "\n\r")
+}
+
+// sanitizeDestinationServer parses a cluster-secret server value and
+// reconstructs it as scheme://host[:port] — nothing else survives. Query
+// strings, fragments, paths, and userinfo are all places credential
+// material can hide in Secret data, and this endpoint deliberately serves
+// callers who cannot read Secrets, so the only safe output is a rebuilt
+// URL, never reflected bytes.
+func sanitizeDestinationServer(server string) (string, bool) {
+	if server == "" || len(server) > maxDestinationFieldLen {
+		return "", false
+	}
+	u, err := url.Parse(server)
+	if err != nil {
+		return "", false
+	}
+	if (u.Scheme != "https" && u.Scheme != "http") || u.Host == "" || u.User != nil {
+		return "", false
+	}
+	return u.Scheme + "://" + u.Host, true
+}
+
+func secretsScopeDisabled() bool {
+	perm := k8s.GetCachedPermissionResult()
+	if perm == nil {
+		return false
+	}
+	scope, ok := perm.Scopes[k8score.Secrets]
+	return ok && !scope.Enabled
+}
+
+type ArgoDestination struct {
+	Name   string `json:"name"`
+	Server string `json:"server"`
+	// Backing cluster Secret identity — source attribution and the only
+	// complete disambiguator when two secrets claim the same destination name.
+	SecretNamespace string `json:"secretNamespace"`
+	SecretName      string `json:"secretName"`
+}
+
+type ArgoDestinationsCompleteness struct {
+	// Secrets informer is still syncing (deferred kind) — retry shortly.
+	Syncing bool `json:"syncing"`
+	// The SA cannot list Secrets at all — destinations unknowable.
+	Restricted bool `json:"restricted"`
+	// Secrets are permitted but the informer failed to sync (timeout/abort) —
+	// distinct from RBAC restriction; a retry may recover.
+	Unavailable bool `json:"unavailable"`
+	// Secrets are cached from a single namespace only (cluster-wide list was
+	// denied at startup); destinations outside it are invisible.
+	ScopedToNamespace string `json:"scopedToNamespace,omitempty"`
+	Complete          bool   `json:"complete"`
+}
+
+type ArgoDestinationsResponse struct {
+	Destinations []ArgoDestination            `json:"destinations"`
+	Completeness ArgoDestinationsCompleteness `json:"completeness"`
+}
+
+func (s *Server) handleArgoDestinations(w http.ResponseWriter, r *http.Request) {
+	if !s.requireConnected(w) {
+		return
+	}
+	cache := k8s.GetResourceCache()
+	if cache == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "cluster cache not ready")
+		return
+	}
+
+	resp := ArgoDestinationsResponse{Destinations: []ArgoDestination{}}
+
+	secretLister := cache.Secrets()
+	if secretLister == nil {
+		// Distinguish three nil-lister causes: still syncing (deferred kind),
+		// RBAC-disabled at startup probe, or permitted-but-sync-failed.
+		switch {
+		case cache.IsDeferredPending(k8score.Secrets):
+			resp.Completeness.Syncing = true
+		case secretsScopeDisabled():
+			resp.Completeness.Restricted = true
+		default:
+			resp.Completeness.Unavailable = true
+		}
+		s.writeJSON(w, resp)
+		return
+	}
+
+	// A non-nil lister can still be namespace-scoped: startup probes fall
+	// back to a single namespace when cluster-wide secret list is denied.
+	if perm := k8s.GetCachedPermissionResult(); perm != nil {
+		if scope, ok := perm.Scopes[k8score.Secrets]; ok && scope.Enabled && scope.Namespace != "" {
+			resp.Completeness.ScopedToNamespace = scope.Namespace
+		}
+	}
+
+	selector := labels.SelectorFromSet(labels.Set{argoClusterSecretLabel: "cluster"})
+	secrets, err := secretLister.List(selector)
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, "listing argo cluster secrets: "+err.Error())
+		return
+	}
+	for _, sec := range secrets {
+		name := string(sec.Data["name"])
+		server := string(sec.Data["server"])
+		// The label is mutable and the exported keys come from Secret data —
+		// validate before reflecting: server must be a bounded http(s) URL
+		// with a host, name a bounded single-line string. Anything else is a
+		// malformed or hostile row, skipped.
+		sanitized, ok := sanitizeDestinationServer(server)
+		if !validDestinationName(name) || !ok {
+			continue
+		}
+		resp.Destinations = append(resp.Destinations, ArgoDestination{
+			Name:            name,
+			Server:          sanitized,
+			SecretNamespace: sec.Namespace,
+			SecretName:      sec.Name,
+		})
+	}
+	sort.Slice(resp.Destinations, func(i, j int) bool {
+		a, b := resp.Destinations[i], resp.Destinations[j]
+		if a.Name != b.Name {
+			return a.Name < b.Name
+		}
+		if a.SecretNamespace != b.SecretNamespace {
+			return a.SecretNamespace < b.SecretNamespace
+		}
+		if a.SecretName != b.SecretName {
+			return a.SecretName < b.SecretName
+		}
+		return a.Server < b.Server
+	})
+
+	resp.Completeness.Complete = !resp.Completeness.Syncing &&
+		!resp.Completeness.Restricted && !resp.Completeness.Unavailable &&
+		resp.Completeness.ScopedToNamespace == ""
+
+	s.writeJSON(w, resp)
+}

--- a/internal/server/argo_destinations_test.go
+++ b/internal/server/argo_destinations_test.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestArgoDestinations_InventoryWithoutSecretData(t *testing.T) {
+	resp, err := http.Get(testServer.URL + "/api/argo/destinations")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+
+	// The backing Secret carries credentials in data.config — they must
+	// never appear anywhere in the response, under any key.
+	if strings.Contains(string(raw), "SUPER-SECRET-TOKEN") || strings.Contains(string(raw), "bearerToken") {
+		t.Fatalf("response leaks secret material: %s", raw)
+	}
+	if strings.Contains(string(raw), "NOT-A-URL-TOKEN") {
+		t.Fatalf("response reflects non-URL server bytes: %s", raw)
+	}
+	if strings.Contains(string(raw), "EMBEDDED-CRED-TOKEN") {
+		t.Fatalf("response reflects URL userinfo credentials: %s", raw)
+	}
+	if strings.Contains(string(raw), "QUERY-CRED-TOKEN") || strings.Contains(string(raw), "FRAG-CRED") {
+		t.Fatalf("response reflects query/fragment credentials: %s", raw)
+	}
+
+	var got ArgoDestinationsResponse
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got.Destinations) != 2 {
+		t.Fatalf("destinations = %+v, want the valid fixture + the sanitized query-token one", got.Destinations)
+	}
+	for _, d := range got.Destinations {
+		if d.Name == "querytoken-cluster" && d.Server != "https://apiserver2.example" {
+			t.Errorf("query-token server not reduced to scheme://host: %q", d.Server)
+		}
+	}
+	d := got.Destinations[0]
+	if d.Name != "prod-us-east1" || d.Server != "https://34.10.0.1" || d.SecretNamespace != "argocd" || d.SecretName != "cluster-prod" {
+		t.Errorf("destination = %+v", d)
+	}
+	if !got.Completeness.Complete {
+		t.Errorf("completeness = %+v, want complete (fixture cache is cluster-wide)", got.Completeness)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -450,6 +450,7 @@ func (s *Server) setupRoutes() {
 			r.Post("/flux/{kind}/{namespace}/{name}/resume", s.handleFluxResume)
 
 			// ArgoCD routes
+			r.Get("/argo/destinations", s.handleArgoDestinations)
 			r.Post("/argo/applications/{namespace}/{name}/sync", s.handleArgoSync)
 			r.Post("/argo/applications/{namespace}/{name}/refresh", s.handleArgoRefresh)
 			r.Post("/argo/applications/{namespace}/{name}/rollback", s.handleArgoRollback)

--- a/internal/server/server_smoke_test.go
+++ b/internal/server/server_smoke_test.go
@@ -238,6 +238,65 @@ func TestMain(m *testing.M) {
 			ObjectMeta: metav1.ObjectMeta{Name: "nginx-tls", Namespace: "default"},
 			Type:       corev1.SecretTypeOpaque,
 		},
+		// Argo cluster-secret fixtures for /api/argo/destinations: one valid,
+		// one malformed (no server) that the endpoint must skip.
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster-prod", Namespace: "argocd",
+				Labels: map[string]string{"argocd.argoproj.io/secret-type": "cluster"},
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"name":   []byte("prod-us-east1"),
+				"server": []byte("https://34.10.0.1"),
+				"config": []byte(`{"bearerToken":"SUPER-SECRET-TOKEN"}`),
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster-broken", Namespace: "argocd",
+				Labels: map[string]string{"argocd.argoproj.io/secret-type": "cluster"},
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{"name": []byte("half-configured")},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster-hostile", Namespace: "argocd",
+				Labels: map[string]string{"argocd.argoproj.io/secret-type": "cluster"},
+			},
+			Type: corev1.SecretTypeOpaque,
+			// server is not a URL — a mislabeled/hostile row whose bytes must
+			// not be reflected by /api/argo/destinations.
+			Data: map[string][]byte{
+				"name":   []byte("hostile"),
+				"server": []byte("Bearer NOT-A-URL-TOKEN xyz"),
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster-userinfo", Namespace: "argocd",
+				Labels: map[string]string{"argocd.argoproj.io/secret-type": "cluster"},
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"name":   []byte("userinfo-cluster"),
+				"server": []byte("https://EMBEDDED-CRED-TOKEN@apiserver.example"),
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster-querytoken", Namespace: "argocd",
+				Labels: map[string]string{"argocd.argoproj.io/secret-type": "cluster"},
+			},
+			Type: corev1.SecretTypeOpaque,
+			// Credentials hidden in the query string — the endpoint must
+			// reconstruct scheme://host, never reflect these bytes.
+			Data: map[string][]byte{
+				"name":   []byte("querytoken-cluster"),
+				"server": []byte("https://apiserver2.example/?token=QUERY-CRED-TOKEN#FRAG-CRED"),
+			},
+		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "system-token", Namespace: "kube-system"},
 			Type:       corev1.SecretTypeOpaque,


### PR DESCRIPTION
## Summary

New endpoint returning the Argo CD cluster-secret registry as plain topology facts — `[{name, server, secretNamespace}]`. Exists so fleet consumers (Radar Cloud's GitOps destination mapping) never haul full cluster Secrets — whose `.data` carries destination-cluster credentials — through an aggregator to read two fields.

## What changed

- `GET /api/argo/destinations` (`internal/server/argo_destinations.go`): label-selects `argocd.argoproj.io/secret-type=cluster` across all namespaces from the SA cache (Argo's namespace varies: argocd / argo-cd / openshift-gitops), parses `data.name` + `data.server`, skips malformed entries, sorts stably.
- **RBAC stance (deliberate, product-approved)**: SA-backed inventory — the emitted facts are what any Argo user sees in its UI, so the endpoint is not gated on the caller's own secret-read RBAC. `.data` never crosses the wire; the test seeds a credential-bearing fixture and asserts the material cannot appear anywhere in the response.
- **Typed completeness**: `{syncing, restricted, scopedToNamespace, complete}` — distinguishes a still-syncing (deferred) secrets informer from RBAC restriction, and surfaces the startup fallback where secrets are cached from a single namespace only (destinations elsewhere invisible).
- Argo's implicit in-cluster destination has no cluster Secret; consumers resolve it separately (the hub already does).

## Testing

`go test ./...` green. New test: valid + malformed labeled fixtures → exactly the valid destination, credential-leak assertion, completeness on the cluster-wide cache.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Derives responses from cluster Secrets with an intentional bypass of per-caller secret-read RBAC; mitigated by strict URL reconstruction, field validation, and leak tests, but any sanitization gap would be high impact.
> 
> **Overview**
> Adds **`GET /api/argo/destinations`** so fleet consumers (e.g. Radar Cloud destination mapping) can read Argo CD cluster registry facts without pulling full cluster Secrets through an aggregator.
> 
> The handler label-selects `argocd.argoproj.io/secret-type=cluster`, reads only `data.name` and `data.server`, and returns **`name`**, **`server`** (rebuilt as `scheme://host`, dropping userinfo/query/fragment/path), plus **`secretNamespace`** / **`secretName`** for attribution. Malformed or hostile rows are skipped. Responses include **`completeness`** (`syncing`, `restricted`, `unavailable`, `scopedToNamespace`, `complete`) so clients know when the secrets informer is deferred, RBAC-disabled, sync-failed, or namespace-scoped.
> 
> **RBAC stance:** inventory is **ServiceAccount-backed**—not gated on the caller’s secret-read permissions—because only UI-visible topology is emitted and `.data` credentials never appear on the wire.
> 
> Smoke fixtures and **`TestArgoDestinations_InventoryWithoutSecretData`** assert credential tokens and reflected server bytes cannot appear in JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7316c18fa0f62152fd55bd8887cc3ced2cb85ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->