### PR TITLE
Audit: per-check evaluated/passed counts

### DIFF
--- a/internal/audit/runner.go
+++ b/internal/audit/runner.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/pkg/k8score"
 	bp "github.com/skyhook-io/radar/pkg/audit"
 )
 
@@ -45,6 +46,7 @@ func RunFromCache(cache *k8s.ResourceCache, namespaces []string, opts *RunOption
 		ConfigMaps:               listNamespaced(cache.ConfigMaps(), namespaces),
 		Secrets:                  listNamespaced(cache.Secrets(), namespaces),
 		ServiceAccounts:          listNamespaced(cache.ServiceAccounts(), namespaces),
+		ServiceAccountsNamespace: serviceAccountScopeNamespace(),
 		LimitRanges:              listNamespaced(cache.LimitRanges(), namespaces),
 	}
 
@@ -317,7 +319,13 @@ type lister[T any] interface {
 	List(selector labels.Selector) ([]*T, error)
 }
 
-// listNamespaced fetches all objects from a lister, optionally filtered by namespaces.
+// listNamespaced fetches all objects from a lister, optionally filtered by
+// namespaces. Returns nil ONLY for a nil lister (kind disabled / RBAC denied);
+// an available lister with zero matches returns an empty non-nil slice.
+// CheckInput distinguishes the two — nil skips the dependent checks and lands
+// in ScanResults.MissingInputs, so conflating "none exist" with "couldn't
+// list" would both suppress findings (e.g. missingPDB on a PDB-less cluster)
+// and misreport scan completeness.
 func listNamespaced[T any, L lister[T]](l L, namespaces []string) []*T {
 	var zero L
 	if any(l) == any(zero) {
@@ -325,6 +333,9 @@ func listNamespaced[T any, L lister[T]](l L, namespaces []string) []*T {
 	}
 	if len(namespaces) == 0 {
 		items, _ := l.List(labels.Everything())
+		if items == nil {
+			items = []*T{}
+		}
 		return items
 	}
 	// For namespace-filtered queries we rely on the global list + filter approach
@@ -335,7 +346,7 @@ func listNamespaced[T any, L lister[T]](l L, namespaces []string) []*T {
 	for _, ns := range namespaces {
 		nsSet[ns] = true
 	}
-	var filtered []*T
+	filtered := []*T{}
 	for _, item := range all {
 		if ns := extractNamespace(item); ns == "" || nsSet[ns] {
 			filtered = append(filtered, item)
@@ -375,6 +386,21 @@ func extractNamespace(obj any) string {
 		return v.Namespace
 	case *corev1.LimitRange:
 		return v.Namespace
+	}
+	return ""
+}
+
+// serviceAccountScopeNamespace reports the single namespace the SA informer
+// is scoped to when the startup probe fell back from cluster-wide, or ""
+// for cluster-wide coverage. Checks use it to avoid evaluating SA-dependent
+// subjects outside the inventory's reach.
+func serviceAccountScopeNamespace() string {
+	perm := k8s.GetCachedPermissionResult()
+	if perm == nil {
+		return ""
+	}
+	if scope, ok := perm.Scopes[k8score.ServiceAccounts]; ok && scope.Enabled {
+		return scope.Namespace
 	}
 	return ""
 }

--- a/pkg/audit/checks.go
+++ b/pkg/audit/checks.go
@@ -27,6 +27,8 @@ func RunChecks(input *CheckInput) *ScanResults {
 	}
 
 	var findings []Finding
+	var missingInputs []string
+	tr := newEvalTracker()
 
 	// Build indexes needed by cross-resource checks
 	podsBySelector := indexPodsByLabels(input.Pods)
@@ -35,31 +37,96 @@ func RunChecks(input *CheckInput) *ScanResults {
 	servicesByName := indexServicesByName(input.Services)
 
 	// --- Security checks (container-level, attributed to owning workload) ---
-	findings = append(findings, checkWorkloadPodSpecs(input)...)
+	findings = append(findings, checkWorkloadPodSpecs(tr, input)...)
+	if input.ServiceAccounts == nil {
+		missingInputs = append(missingInputs, "serviceaccounts")
+	}
+	// Nil SUBJECT inventories matter too: zero evaluated subjects from an
+	// unlisted kind must read as incomplete, not clean.
+	if input.Deployments == nil {
+		missingInputs = append(missingInputs, "deployments")
+	}
+	if input.StatefulSets == nil {
+		missingInputs = append(missingInputs, "statefulsets")
+	}
+	if input.DaemonSets == nil {
+		missingInputs = append(missingInputs, "daemonsets")
+	}
+	if input.LimitRanges == nil {
+		missingInputs = append(missingInputs, "limitranges")
+	}
 
 	// --- Reliability checks ---
-	findings = append(findings, checkSingleReplica(input.Deployments, hpaTargets)...)
+	// singleReplica's eligibility filter (HPA-managed deployments are out of
+	// scope) needs the HPA inventory to be authoritative — nil means
+	// unlisted, and an HPA-managed 1-replica deployment would otherwise be a
+	// false positive counted from incomplete prerequisites.
+	if input.HorizontalPodAutoscalers != nil {
+		findings = append(findings, checkSingleReplica(tr, input.Deployments, hpaTargets)...)
+	} else {
+		missingInputs = append(missingInputs, "horizontalpodautoscalers")
+	}
 	// Only check PDB coverage if we can actually list PDBs (nil = RBAC denied, not "none exist")
 	if input.PodDisruptionBudgets != nil {
-		findings = append(findings, checkMissingPDB(input.Deployments, input.StatefulSets, pdbSelectors)...)
+		findings = append(findings, checkMissingPDB(tr, input.Deployments, input.StatefulSets, pdbSelectors)...)
+	} else {
+		missingInputs = append(missingInputs, "poddisruptionbudgets")
 	}
-	findings = append(findings, checkMissingTopologySpread(input.Deployments, input.StatefulSets)...)
-	findings = append(findings, checkPodHARisk(input.Pods, input.Deployments)...)
+	findings = append(findings, checkMissingTopologySpread(tr, input.Deployments, input.StatefulSets)...)
+	// HA-risk placement needs the pod inventory — nil pods would make every
+	// deployment look risk-free (or falsely clustered), not "no pods".
+	if input.Pods != nil {
+		findings = append(findings, checkPodHARisk(tr, input.Pods, input.Deployments)...)
+	} else {
+		missingInputs = append(missingInputs, "pods")
+	}
 
 	// --- Efficiency checks are included in checkWorkloadPodSpecs ---
-	findings = append(findings, checkOrphanConfigMapsSecrets(input)...)
-	findings = append(findings, checkSecretInConfigMap(input.ConfigMaps)...)
+	// nil ConfigMaps = RBAC denied, not "none exist" — the ConfigMap-subject
+	// checks must neither run nor count anything as evaluated.
+	// Orphan detection audits ConfigMaps AND Secrets — a nil side means that
+	// KIND is unlisted, not that the whole check is off. References come from
+	// the whole workload inventory (configReferencePodSpecs — pods AND
+	// deployments/statefulsets/daemonsets/jobs) plus Ingress TLS refs; missing
+	// reference inventory surfaces via missingInputs above, so the check runs
+	// on whatever is visible.
+	if input.ConfigMaps != nil || input.Secrets != nil {
+		findings = append(findings, checkOrphanConfigMapsSecrets(tr, input)...)
+	}
+	if input.ConfigMaps != nil {
+		findings = append(findings, checkSecretInConfigMap(tr, input.ConfigMaps)...)
+	} else {
+		missingInputs = append(missingInputs, "configmaps")
+	}
+	if input.Secrets == nil {
+		missingInputs = append(missingInputs, "secrets")
+	}
 
-	// --- Cross-resource checks ---
-	findings = append(findings, checkServiceNoMatchingPods(input.Services, podsBySelector)...)
-	findings = append(findings, checkIngressNoMatchingService(input.Ingresses, servicesByName)...)
-	findings = append(findings, checkTraefikDanglingRefs(input)...)
+	// --- Cross-resource checks --- each needs BOTH sides of its relationship
+	// listed; a nil side would flag every subject as dangling.
+	if input.Services != nil && input.Pods != nil {
+		findings = append(findings, checkServiceNoMatchingPods(tr, input.Services, podsBySelector)...)
+	}
+	if input.Ingresses != nil && input.Services != nil {
+		findings = append(findings, checkIngressNoMatchingService(tr, input.Ingresses, servicesByName)...)
+	}
+	if input.Services == nil {
+		missingInputs = append(missingInputs, "services")
+	}
+	if input.Ingresses == nil {
+		missingInputs = append(missingInputs, "ingresses")
+	}
+	findings = append(findings, checkTraefikDanglingRefs(tr, input)...)
 
 	// --- Utilization checks (optional, only when metrics provided) ---
-	findings = append(findings, checkResourceUtilization(input.PodMetrics)...)
+	if input.PodMetrics != nil {
+		findings = append(findings, checkResourceUtilization(tr, input.PodMetrics)...)
+	} else {
+		missingInputs = append(missingInputs, "podmetrics")
+	}
 
 	// --- Deprecated API checks ---
-	findings = append(findings, checkDeprecatedAPIs(input.ServedAPIs, input.ClusterVersion)...)
+	findings = append(findings, checkDeprecatedAPIs(tr, input.ServedAPIs, input.ClusterVersion)...)
 
 	// --- Lifecycle: stuck terminating resources ---
 	// Catches the "zombie awaiting finalizer cleanup" pattern across every
@@ -67,14 +134,52 @@ func RunChecks(input *CheckInput) *ScanResults {
 	// Terminating chip + insight; the audit surface broadens coverage to
 	// non-GitOps resources (stuck Pods on failed nodes, Deployments
 	// blocked by webhook finalizers, etc.).
-	findings = append(findings, checkStuckTerminating(input)...)
+	findings = append(findings, checkStuckTerminating(tr, input)...)
 
 	// --- Crossplane: MRs/XRs/Claims stuck Ready=False or Synced=False ---
 	// Same severity ramp as stuckTerminating (5min warning, 30min danger) so
 	// operators see the same "long enough to flag" semantics across surfaces.
-	findings = append(findings, checkCrossplaneStuck(input)...)
+	findings = append(findings, checkCrossplaneStuck(tr, input)...)
 
-	return buildResults(findings)
+	return buildResults(findings, tr, missingInputs)
+}
+
+// ============================================================================
+// Evaluation tracking
+// ============================================================================
+
+// evalTracker accumulates how many distinct subjects each check evaluated,
+// per namespace. Subjects are counted at the same (resource, checkID) grain
+// the finding merge uses — per-container checks record once per workload —
+// so buildResults can derive passed = evaluated - failed without unit
+// mismatch. Distinctness comes from call discipline: every check iterates
+// each of its subjects exactly once and records exactly once per subject
+// that passed the check's own eligibility filters.
+type evalTracker struct {
+	counts map[string]map[string]int // checkID → namespace → subjects evaluated
+}
+
+func newEvalTracker() *evalTracker {
+	return &evalTracker{counts: make(map[string]map[string]int)}
+}
+
+// record counts one evaluated subject for checkID. Cluster-scoped subjects
+// use namespace "".
+func (t *evalTracker) record(checkID, namespace string) {
+	byNS := t.counts[checkID]
+	if byNS == nil {
+		byNS = make(map[string]int)
+		t.counts[checkID] = byNS
+	}
+	byNS[namespace]++
+}
+
+// recordAll counts one evaluated subject for every checkID in ids — used by
+// check families that evaluate several checkIDs against the same subject.
+func (t *evalTracker) recordAll(ids []string, namespace string) {
+	for _, id := range ids {
+		t.record(id, namespace)
+	}
 }
 
 // ============================================================================
@@ -82,7 +187,7 @@ func RunChecks(input *CheckInput) *ScanResults {
 // Applied to workload pod templates; falls back to bare pods.
 // ============================================================================
 
-func checkWorkloadPodSpecs(input *CheckInput) []Finding {
+func checkWorkloadPodSpecs(tr *evalTracker, input *CheckInput) []Finding {
 	var findings []Finding
 
 	// Collect pod specs from workloads (attributed to the workload, not individual pods)
@@ -113,13 +218,48 @@ func checkWorkloadPodSpecs(input *CheckInput) []Finding {
 	saByKey := indexServiceAccounts(input.ServiceAccounts)
 	limitsByNs := indexLimitRangesByNamespace(input.LimitRanges)
 
+	lrAuthoritative := input.LimitRanges != nil
+	saCovers := func(ns string) bool {
+		if input.ServiceAccounts == nil {
+			return false
+		}
+		return input.ServiceAccountsNamespace == "" || input.ServiceAccountsNamespace == ns
+	}
 	for _, w := range specs {
-		findings = append(findings, checkPodSpecSecurity(w.kind, w.namespace, w.name, w.spec, saByKey)...)
-		findings = append(findings, checkPodSpecReliability(w.kind, w.namespace, w.name, w.spec)...)
-		findings = append(findings, checkPodSpecEfficiency(w.kind, w.namespace, w.name, w.spec, limitsByNs[w.namespace])...)
-		findings = append(findings, checkPodSpecVolumes(w.kind, w.namespace, w.name, w.spec)...)
+		findings = append(findings, checkPodSpecSecurity(tr, w.kind, w.namespace, w.name, w.spec, saByKey, saCovers(w.namespace))...)
+		findings = append(findings, checkPodSpecReliability(tr, w.kind, w.namespace, w.name, w.spec)...)
+		findings = append(findings, checkPodSpecEfficiency(tr, w.kind, w.namespace, w.name, w.spec, limitsByNs[w.namespace], lrAuthoritative)...)
+		findings = append(findings, checkPodSpecVolumes(tr, w.kind, w.namespace, w.name, w.spec)...)
 	}
 	return findings
+}
+
+// Every checkID a pod-spec family member can emit. Each family function
+// records its whole list once per workload spec — container-level findings
+// merge to the workload, so the workload is the subject unit here.
+var (
+	podSpecSecurityCheckIDs = []string{
+		"hostNetwork", "hostPID", "hostIPC", "automountServiceAccountToken",
+		"runAsRoot", "privileged", "privilegeEscalation", "readOnlyRootFs",
+		"dangerousCapabilities", "insecureCapabilities",
+	}
+	podSpecReliabilityCheckIDs = []string{
+		"readinessProbeMissing", "livenessProbeMissing", "imageTagLatest", "pullPolicyNotAlways",
+	}
+	podSpecEfficiencyCheckIDs = []string{
+		"cpuRequestMissing", "memoryRequestMissing", "cpuLimitMissing", "memoryLimitMissing",
+	}
+	podSpecVolumeCheckIDs = []string{"dockerSocketMount", "sensitiveHostPath"}
+)
+
+func withoutID(ids []string, drop string) []string {
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if id != drop {
+			out = append(out, id)
+		}
+	}
+	return out
 }
 
 // indexServiceAccounts returns a map keyed by "namespace/name".
@@ -184,7 +324,17 @@ func containerDefaultsFromLimitRanges(lrs []*corev1.LimitRange) containerDefault
 // Security checks
 // ============================================================================
 
-func checkPodSpecSecurity(kind, namespace, name string, spec corev1.PodSpec, saByKey map[string]*corev1.ServiceAccount) []Finding {
+func checkPodSpecSecurity(tr *evalTracker, kind, namespace, name string, spec corev1.PodSpec, saByKey map[string]*corev1.ServiceAccount, saAuthoritative bool) []Finding {
+	// The automount check needs the SA inventory only when the POD leaves
+	// the field unset (SA-level opt-outs then decide). A pod-level explicit
+	// value is evaluable regardless — skipping those too would drop real
+	// detections.
+	autoCheckable := saAuthoritative || spec.AutomountServiceAccountToken != nil
+	ids := podSpecSecurityCheckIDs
+	if !autoCheckable {
+		ids = withoutID(ids, "automountServiceAccountToken")
+	}
+	tr.recordAll(ids, namespace)
 	var findings []Finding
 	f := func(checkID, severity, msg string) {
 		findings = append(findings, Finding{
@@ -208,7 +358,7 @@ func checkPodSpecSecurity(kind, namespace, name string, spec corev1.PodSpec, saB
 	// Pod-level takes precedence. If neither is explicitly false, the token is
 	// auto-mounted. Only flag when the effective value is true (or unset, which
 	// defaults to true per K8s).
-	if tokenAutoMounted(namespace, spec, saByKey) {
+	if autoCheckable && tokenAutoMounted(namespace, spec, saByKey) {
 		f("automountServiceAccountToken", SeverityWarning, "Service account token is auto-mounted")
 	}
 
@@ -318,7 +468,8 @@ func checkContainerSecurity(f func(string, string, string), c *corev1.Container,
 // sensitiveHostPaths lists host paths that should not be mounted into containers.
 var sensitiveHostPaths = []string{"/etc", "/proc", "/sys", "/var/run", "/var/log", "/root"}
 
-func checkPodSpecVolumes(kind, namespace, name string, spec corev1.PodSpec) []Finding {
+func checkPodSpecVolumes(tr *evalTracker, kind, namespace, name string, spec corev1.PodSpec) []Finding {
+	tr.recordAll(podSpecVolumeCheckIDs, namespace)
 	var findings []Finding
 	f := func(checkID, severity, msg string) {
 		findings = append(findings, Finding{
@@ -374,13 +525,14 @@ var valueGatedSensitiveKeyPatterns = []string{
 
 const configMapSensitiveValueMinLength = 24
 
-func checkSecretInConfigMap(configMaps []*corev1.ConfigMap) []Finding {
+func checkSecretInConfigMap(tr *evalTracker, configMaps []*corev1.ConfigMap) []Finding {
 	if len(configMaps) == 0 {
 		return nil
 	}
 
 	var findings []Finding
 	for _, cm := range configMaps {
+		tr.record("secretInConfigMap", cm.Namespace)
 		for key, value := range cm.Data {
 			if !configMapEntryLooksSensitive(key, value) {
 				continue
@@ -515,7 +667,8 @@ func urlContainsUserInfo(value string) bool {
 // Reliability checks
 // ============================================================================
 
-func checkPodSpecReliability(kind, namespace, name string, spec corev1.PodSpec) []Finding {
+func checkPodSpecReliability(tr *evalTracker, kind, namespace, name string, spec corev1.PodSpec) []Finding {
+	tr.recordAll(podSpecReliabilityCheckIDs, namespace)
 	var findings []Finding
 	f := func(checkID, severity, msg string) {
 		findings = append(findings, Finding{
@@ -545,14 +698,20 @@ func checkPodSpecReliability(kind, namespace, name string, spec corev1.PodSpec) 
 	return findings
 }
 
-func checkSingleReplica(deployments []*appsv1.Deployment, hpaTargets map[string]bool) []Finding {
+func checkSingleReplica(tr *evalTracker, deployments []*appsv1.Deployment, hpaTargets map[string]bool) []Finding {
 	var findings []Finding
 	for _, d := range deployments {
+		// HPA-managed deployments are out of scope, not passing — the HPA
+		// owns the replica count, so counting them would inflate "passed".
+		if hpaTargets[hpaKey("Deployment", d.Namespace, d.Name)] {
+			continue
+		}
+		tr.record("singleReplica", d.Namespace)
 		replicas := int32(1)
 		if d.Spec.Replicas != nil {
 			replicas = *d.Spec.Replicas
 		}
-		if replicas <= 1 && !hpaTargets[hpaKey("Deployment", d.Namespace, d.Name)] {
+		if replicas <= 1 {
 			findings = append(findings, Finding{
 				Kind: "Deployment", Namespace: d.Namespace, Name: d.Name,
 				CheckID: "singleReplica", Category: CategoryReliability, Severity: SeverityWarning,
@@ -563,7 +722,7 @@ func checkSingleReplica(deployments []*appsv1.Deployment, hpaTargets map[string]
 	return findings
 }
 
-func checkMissingPDB(deployments []*appsv1.Deployment, statefulSets []*appsv1.StatefulSet, pdbSelectors []namespacedSelector) []Finding {
+func checkMissingPDB(tr *evalTracker, deployments []*appsv1.Deployment, statefulSets []*appsv1.StatefulSet, pdbSelectors []namespacedSelector) []Finding {
 	var findings []Finding
 
 	check := func(kind, namespace, name string, replicas *int32, matchLabels map[string]string) {
@@ -574,6 +733,7 @@ func checkMissingPDB(deployments []*appsv1.Deployment, statefulSets []*appsv1.St
 		if r <= 1 {
 			return // PDB only matters for multi-replica workloads
 		}
+		tr.record("missingPDB", namespace)
 		podLabels := labels.Set(matchLabels)
 		for _, ns := range pdbSelectors {
 			if ns.namespace == namespace && ns.selector.Matches(podLabels) {
@@ -600,7 +760,14 @@ func checkMissingPDB(deployments []*appsv1.Deployment, statefulSets []*appsv1.St
 // Efficiency checks
 // ============================================================================
 
-func checkPodSpecEfficiency(kind, namespace, name string, spec corev1.PodSpec, lrs []*corev1.LimitRange) []Finding {
+func checkPodSpecEfficiency(tr *evalTracker, kind, namespace, name string, spec corev1.PodSpec, lrs []*corev1.LimitRange, lrAuthoritative bool) []Finding {
+	if !lrAuthoritative {
+		// LimitRange defaults suppress these findings; without the inventory
+		// every emission would be a potential false positive. Skip the whole
+		// family rather than report on data Radar couldn't see.
+		return nil
+	}
+	tr.recordAll(podSpecEfficiencyCheckIDs, namespace)
 	var findings []Finding
 	f := func(checkID, severity, msg string) {
 		findings = append(findings, Finding{
@@ -636,7 +803,7 @@ func checkPodSpecEfficiency(kind, namespace, name string, spec corev1.PodSpec, l
 // Cross-resource checks (Radar-native)
 // ============================================================================
 
-func checkServiceNoMatchingPods(services []*corev1.Service, podsBySelector map[string][]*corev1.Pod) []Finding {
+func checkServiceNoMatchingPods(tr *evalTracker, services []*corev1.Service, podsBySelector map[string][]*corev1.Pod) []Finding {
 	var findings []Finding
 	for _, svc := range services {
 		if len(svc.Spec.Selector) == 0 {
@@ -645,6 +812,7 @@ func checkServiceNoMatchingPods(services []*corev1.Service, podsBySelector map[s
 		if svc.Spec.Type == corev1.ServiceTypeExternalName {
 			continue
 		}
+		tr.record("serviceNoMatchingPods", svc.Namespace)
 		sel := labels.SelectorFromSet(labels.Set(svc.Spec.Selector))
 		found := false
 		for _, pod := range podsBySelector[svc.Namespace] {
@@ -664,9 +832,10 @@ func checkServiceNoMatchingPods(services []*corev1.Service, podsBySelector map[s
 	return findings
 }
 
-func checkIngressNoMatchingService(ingresses []*networkingv1.Ingress, servicesByName map[string]bool) []Finding {
+func checkIngressNoMatchingService(tr *evalTracker, ingresses []*networkingv1.Ingress, servicesByName map[string]bool) []Finding {
 	var findings []Finding
 	for _, ing := range ingresses {
+		eligible := false
 		for _, rule := range ing.Spec.Rules {
 			if rule.HTTP == nil {
 				continue
@@ -675,6 +844,7 @@ func checkIngressNoMatchingService(ingresses []*networkingv1.Ingress, servicesBy
 				if path.Backend.Service == nil {
 					continue
 				}
+				eligible = true
 				svcKey := ing.Namespace + "/" + path.Backend.Service.Name
 				if !servicesByName[svcKey] {
 					findings = append(findings, Finding{
@@ -685,6 +855,9 @@ func checkIngressNoMatchingService(ingresses []*networkingv1.Ingress, servicesBy
 				}
 			}
 		}
+		if eligible {
+			tr.record("ingressNoMatchingService", ing.Namespace)
+		}
 	}
 	return findings
 }
@@ -693,7 +866,7 @@ func checkIngressNoMatchingService(ingresses []*networkingv1.Ingress, servicesBy
 // Topology spread + HA checks
 // ============================================================================
 
-func checkMissingTopologySpread(deployments []*appsv1.Deployment, statefulSets []*appsv1.StatefulSet) []Finding {
+func checkMissingTopologySpread(tr *evalTracker, deployments []*appsv1.Deployment, statefulSets []*appsv1.StatefulSet) []Finding {
 	var findings []Finding
 
 	check := func(kind, namespace, name string, replicas *int32, spec corev1.PodSpec) {
@@ -704,6 +877,7 @@ func checkMissingTopologySpread(deployments []*appsv1.Deployment, statefulSets [
 		if r <= 1 {
 			return
 		}
+		tr.record("missingTopologySpread", namespace)
 		if len(spec.TopologySpreadConstraints) > 0 {
 			return
 		}
@@ -723,7 +897,7 @@ func checkMissingTopologySpread(deployments []*appsv1.Deployment, statefulSets [
 	return findings
 }
 
-func checkPodHARisk(pods []*corev1.Pod, deployments []*appsv1.Deployment) []Finding {
+func checkPodHARisk(tr *evalTracker, pods []*corev1.Pod, deployments []*appsv1.Deployment) []Finding {
 	var findings []Finding
 	for _, d := range deployments {
 		replicas := int32(1)
@@ -737,6 +911,7 @@ func checkPodHARisk(pods []*corev1.Pod, deployments []*appsv1.Deployment) []Find
 		if err != nil {
 			continue
 		}
+		tr.record("podHARisk", d.Namespace)
 		nodeSet := make(map[string]bool)
 		matchCount := 0
 		for _, pod := range pods {
@@ -772,7 +947,7 @@ func checkPodHARisk(pods []*corev1.Pod, deployments []*appsv1.Deployment) []Find
 // Orphan resource checks
 // ============================================================================
 
-func checkOrphanConfigMapsSecrets(input *CheckInput) []Finding {
+func checkOrphanConfigMapsSecrets(tr *evalTracker, input *CheckInput) []Finding {
 	if len(input.ConfigMaps) == 0 && len(input.Secrets) == 0 {
 		return nil
 	}
@@ -807,10 +982,6 @@ func checkOrphanConfigMapsSecrets(input *CheckInput) []Finding {
 
 	// Check ConfigMaps
 	for _, cm := range input.ConfigMaps {
-		key := cm.Namespace + "/" + cm.Name
-		if referencedCMs[key] {
-			continue
-		}
 		// Skip well-known system ConfigMaps
 		if cm.Name == "kube-root-ca.crt" {
 			continue
@@ -819,6 +990,11 @@ func checkOrphanConfigMapsSecrets(input *CheckInput) []Finding {
 			continue
 		}
 		if hasControllerOwnerReference(cm.OwnerReferences) {
+			continue
+		}
+		// In scope — count as evaluated before the referenced (pass) check.
+		tr.record("orphanConfigMapSecret", cm.Namespace)
+		if referencedCMs[cm.Namespace+"/"+cm.Name] {
 			continue
 		}
 		findings = append(findings, Finding{
@@ -830,10 +1006,6 @@ func checkOrphanConfigMapsSecrets(input *CheckInput) []Finding {
 
 	// Check Secrets
 	for _, sec := range input.Secrets {
-		key := sec.Namespace + "/" + sec.Name
-		if referencedSecrets[key] {
-			continue
-		}
 		// Skip service account tokens and Helm release secrets
 		if sec.Type == corev1.SecretTypeServiceAccountToken {
 			continue
@@ -849,6 +1021,10 @@ func checkOrphanConfigMapsSecrets(input *CheckInput) []Finding {
 			continue
 		}
 		if hasControllerOwnerReference(sec.OwnerReferences) {
+			continue
+		}
+		tr.record("orphanConfigMapSecret", sec.Namespace)
+		if referencedSecrets[sec.Namespace+"/"+sec.Name] {
 			continue
 		}
 		findings = append(findings, Finding{
@@ -1239,13 +1415,18 @@ func hasControllerOwnerReference(refs []metav1.OwnerReference) bool {
 // Resource utilization checks
 // ============================================================================
 
-func checkResourceUtilization(metrics []PodMetricsInput) []Finding {
+func checkResourceUtilization(tr *evalTracker, metrics []PodMetricsInput) []Finding {
 	if len(metrics) == 0 {
 		return nil
 	}
 
 	var findings []Finding
 	for _, m := range metrics {
+		// Pods with no requests at all can't be measured against anything —
+		// they're out of scope, not passing.
+		if m.CPURequest > 0 || m.MemoryRequest > 0 {
+			tr.record("resourceUtilization", m.Namespace)
+		}
 		// CPU utilization
 		if m.CPURequest > 0 {
 			cpuPct := float64(m.CPUUsage) / float64(m.CPURequest) * 100
@@ -1291,7 +1472,7 @@ func checkResourceUtilization(metrics []PodMetricsInput) []Finding {
 // Deprecated API checks
 // ============================================================================
 
-func checkDeprecatedAPIs(servedAPIs []string, clusterVersion string) []Finding {
+func checkDeprecatedAPIs(tr *evalTracker, servedAPIs []string, clusterVersion string) []Finding {
 	if len(servedAPIs) == 0 || clusterVersion == "" {
 		return nil
 	}
@@ -1300,21 +1481,24 @@ func checkDeprecatedAPIs(servedAPIs []string, clusterVersion string) []Finding {
 	var findings []Finding
 
 	for _, gv := range servedAPIs {
+		tr.record("deprecatedAPIVersion", "")
 		entries, ok := deprecations[gv]
 		if !ok {
 			continue
 		}
 		for _, entry := range entries {
-			kindLabel := gv
 			msg := fmt.Sprintf("API %s is deprecated (since %s, removed in %s) — use %s",
 				gv, entry.DeprecatedIn, entry.RemovedIn, entry.Replacement)
 			if entry.Kind != "" {
-				kindLabel = entry.Kind
 				msg = fmt.Sprintf("API %s %s is deprecated (since %s, removed in %s) — use %s",
 					gv, entry.Kind, entry.DeprecatedIn, entry.RemovedIn, entry.Replacement)
 			}
+			// One evaluated subject per served group/version, so all of a
+			// gv's deprecated kinds share one finding key (standard merge
+			// joins the messages) — keeps failed <= evaluated by
+			// construction instead of relying on the clamp.
 			findings = append(findings, Finding{
-				Kind:     kindLabel,
+				Kind:     "APIVersion",
 				Name:     gv,
 				CheckID:  "deprecatedAPIVersion",
 				Category: CategoryReliability,
@@ -1390,7 +1574,7 @@ func indexServicesByName(services []*corev1.Service) map[string]bool {
 // Result aggregation
 // ============================================================================
 
-func buildResults(findings []Finding) *ScanResults {
+func buildResults(findings []Finding, tr *evalTracker, missingInputs []string) *ScanResults {
 	categories := map[string]CategorySummary{}
 	// Initialize all categories
 	for _, cat := range []string{CategorySecurity, CategoryReliability, CategoryEfficiency} {
@@ -1437,6 +1621,8 @@ func buildResults(findings []Finding) *ScanResults {
 		totalDanger += cs.Danger
 	}
 
+	checkCounts, totalPassing := deriveCheckCounts(tr.counts, dedupFindings, categories)
+
 	// Include full registry so settings dialog can show all checks (including disabled ones)
 	checks := make(map[string]CheckMeta, len(CheckRegistry))
 	for id, meta := range CheckRegistry {
@@ -1445,14 +1631,56 @@ func buildResults(findings []Finding) *ScanResults {
 
 	return &ScanResults{
 		Summary: ScanSummary{
+			Passing:    totalPassing,
 			Warning:    totalWarning,
 			Danger:     totalDanger,
 			Categories: categories,
 		},
-		Findings: dedupFindings,
-		Groups:   GroupByResource(dedupFindings),
-		Checks:   checks,
+		Findings:             dedupFindings,
+		Groups:               GroupByResource(dedupFindings),
+		Checks:               checks,
+		CheckCounts:          checkCounts,
+		EvaluatedByNamespace: tr.counts,
+		MissingInputs:        missingInputs,
 	}
+}
+
+// deriveCheckCounts turns per-namespace evaluation tallies plus MERGED
+// findings into per-check evaluated/passed counts, accumulating each check's
+// passed into its registry category's Passing (categories is mutated). Both
+// sides count distinct subjects, so passed = evaluated - failed; the zero
+// clamp absorbs the one legitimate mismatch — a deprecated group/version
+// serving several deprecated kinds yields one evaluated subject but one
+// merged finding per kind.
+func deriveCheckCounts(evalByNS map[string]map[string]int, mergedFindings []Finding, categories map[string]CategorySummary) (map[string]CheckCount, int) {
+	failedByCheck := make(map[string]int)
+	for _, f := range mergedFindings {
+		failedByCheck[f.CheckID]++
+	}
+
+	checkCounts := make(map[string]CheckCount, len(evalByNS))
+	totalPassing := 0
+	for id, byNS := range evalByNS {
+		evaluated := 0
+		for _, n := range byNS {
+			evaluated += n
+		}
+		if evaluated == 0 {
+			continue
+		}
+		passed := evaluated - failedByCheck[id]
+		if passed < 0 {
+			passed = 0
+		}
+		checkCounts[id] = CheckCount{Evaluated: evaluated, Passed: passed}
+		totalPassing += passed
+		if meta, ok := CheckRegistry[id]; ok {
+			cs := categories[meta.Category]
+			cs.Passing += passed
+			categories[meta.Category] = cs
+		}
+	}
+	return checkCounts, totalPassing
 }
 
 // ============================================================================
@@ -1505,13 +1733,14 @@ const (
 // Audit surfaces the *list* up-front; a per-resource insight only
 // helps once they've drilled into a specific app. The two surfaces
 // are complementary, not redundant.
-func checkStuckTerminating(input *CheckInput) []Finding {
+func checkStuckTerminating(tr *evalTracker, input *CheckInput) []Finding {
 	if input == nil {
 		return nil
 	}
 	var findings []Finding
 	now := time.Now()
 	emit := func(kind string, obj metav1.Object) {
+		tr.record("stuckTerminating", obj.GetNamespace())
 		dt := obj.GetDeletionTimestamp()
 		if dt == nil || dt.IsZero() {
 			return
@@ -1593,7 +1822,7 @@ func checkStuckTerminating(input *CheckInput) []Finding {
 // The check inspects status.conditions on each unstructured object directly
 // — Crossplane condition semantics are stable across every provider (Ready,
 // Synced) so we don't need per-provider knowledge.
-func checkCrossplaneStuck(input *CheckInput) []Finding {
+func checkCrossplaneStuck(tr *evalTracker, input *CheckInput) []Finding {
 	if input == nil {
 		return nil
 	}
@@ -1611,6 +1840,7 @@ func checkCrossplaneStuck(input *CheckInput) []Finding {
 		if u.GetAnnotations()["crossplane.io/paused"] == "true" {
 			return
 		}
+		tr.record("crossplaneStuck", u.GetNamespace())
 		cond, ok := findFalseCrossplaneCondition(u)
 		if !ok {
 			return

--- a/pkg/audit/checks.go
+++ b/pkg/audit/checks.go
@@ -52,6 +52,15 @@ func RunChecks(input *CheckInput) *ScanResults {
 	if input.DaemonSets == nil {
 		missingInputs = append(missingInputs, "daemonsets")
 	}
+	// Jobs/CronJobs are ConfigMap/Secret reference sources too
+	// (configReferencePodSpecs): unlisted means orphan detection can't see
+	// refs from them, so their absence must read as incomplete, not clean.
+	if input.Jobs == nil {
+		missingInputs = append(missingInputs, "jobs")
+	}
+	if input.CronJobs == nil {
+		missingInputs = append(missingInputs, "cronjobs")
+	}
 	if input.LimitRanges == nil {
 		missingInputs = append(missingInputs, "limitranges")
 	}

--- a/pkg/audit/checks_test.go
+++ b/pkg/audit/checks_test.go
@@ -55,6 +55,9 @@ func TestRunChecks_Nil(t *testing.T) {
 
 func TestSecurityChecks(t *testing.T) {
 	input := &CheckInput{
+		// non-nil = authoritative inventory (nil now means RBAC-denied and
+		// skips the SA-dependent automount check)
+		ServiceAccounts: []*corev1.ServiceAccount{},
 		Deployments: []*appsv1.Deployment{{
 			ObjectMeta: metav1.ObjectMeta{Name: "insecure-app", Namespace: "default"},
 			Spec: appsv1.DeploymentSpec{
@@ -525,6 +528,7 @@ func TestSecurityChecks_AutomountDefaultServiceAccount(t *testing.T) {
 
 func TestReliabilityChecks(t *testing.T) {
 	input := &CheckInput{
+		HorizontalPodAutoscalers: []*autoscalingv2.HorizontalPodAutoscaler{},
 		Deployments: []*appsv1.Deployment{{
 			ObjectMeta: metav1.ObjectMeta{Name: "single-replica", Namespace: "default"},
 			Spec: appsv1.DeploymentSpec{
@@ -597,6 +601,7 @@ func TestSingleReplica_SkippedWithHPA(t *testing.T) {
 
 func TestEfficiencyChecks(t *testing.T) {
 	input := &CheckInput{
+		LimitRanges: []*corev1.LimitRange{},
 		Deployments: []*appsv1.Deployment{{
 			ObjectMeta: metav1.ObjectMeta{Name: "no-resources", Namespace: "default"},
 			Spec: appsv1.DeploymentSpec{
@@ -1227,6 +1232,7 @@ func TestPodHARisk_Distributed(t *testing.T) {
 
 func TestOrphanConfigMapSecret(t *testing.T) {
 	input := &CheckInput{
+		Ingresses: []*networkingv1.Ingress{},
 		Pods: []*corev1.Pod{{
 			ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default"},
 			Spec: corev1.PodSpec{
@@ -1915,9 +1921,18 @@ func TestDeprecatedAPIVersion(t *testing.T) {
 			deprecated++
 		}
 	}
-	// batch/v1beta1 has CronJob, policy/v1beta1 has PDB + PSP = at least 3 entries
-	if deprecated < 3 {
-		t.Errorf("expected at least 3 deprecatedAPIVersion findings, got %d", deprecated)
+	// Findings merge per served group/version now (evaluated unit == failure
+	// unit): batch/v1beta1 + policy/v1beta1 = 2 merged findings; policy's
+	// message carries both PDB and PSP deprecations.
+	if deprecated != 2 {
+		t.Errorf("expected 2 merged deprecatedAPIVersion findings, got %d", deprecated)
+	}
+	for _, f := range results.Findings {
+		if f.CheckID == "deprecatedAPIVersion" && f.Name == "policy/v1beta1" {
+			if !strings.Contains(f.Message, "PodDisruptionBudget") || !strings.Contains(f.Message, "PodSecurityPolicy") {
+				t.Errorf("policy/v1beta1 merged message missing a kind: %q", f.Message)
+			}
+		}
 	}
 }
 
@@ -2285,7 +2300,7 @@ func TestCheckStuckTerminating_AllKinds(t *testing.T) {
 	// (Selector, container specs) than this test cares about. The audit
 	// dispatch is itself covered by RunChecks tests; this one targets
 	// only the stuckTerminating loop completeness.
-	findings := checkStuckTerminating(input)
+	findings := checkStuckTerminating(newEvalTracker(), input)
 	byKindAndName := map[string]string{} // "Kind/name" → severity
 	for _, f := range findings {
 		if f.CheckID != "stuckTerminating" {

--- a/pkg/audit/counts_test.go
+++ b/pkg/audit/counts_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -121,6 +122,7 @@ func TestCheckCounts_MissingInputs(t *testing.T) {
 		"pods": true, "services": true, "ingresses": true,
 		"horizontalpodautoscalers": true,
 		"statefulsets": true, "daemonsets": true,
+		"jobs": true, "cronjobs": true,
 	}
 	if len(results.MissingInputs) != len(want) {
 		t.Fatalf("MissingInputs = %v, want exactly %v", results.MissingInputs, want)
@@ -144,6 +146,8 @@ func TestCheckCounts_MissingInputs(t *testing.T) {
 	input.HorizontalPodAutoscalers = []*autoscalingv2.HorizontalPodAutoscaler{}
 	input.StatefulSets = []*appsv1.StatefulSet{}
 	input.DaemonSets = []*appsv1.DaemonSet{}
+	input.Jobs = []*batchv1.Job{}
+	input.CronJobs = []*batchv1.CronJob{}
 	results = RunChecks(input)
 	if len(results.MissingInputs) != 0 {
 		t.Errorf("MissingInputs = %v, want none when inputs are non-nil", results.MissingInputs)

--- a/pkg/audit/counts_test.go
+++ b/pkg/audit/counts_test.go
@@ -1,0 +1,309 @@
+package audit
+
+import (
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	networkingv1 "k8s.io/api/networking/v1"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func secureContainer(name string, readiness bool) corev1.Container {
+	c := corev1.Container{
+		Name: name, Image: "app:v1",
+		SecurityContext: &corev1.SecurityContext{
+			RunAsNonRoot:             ptr(true),
+			ReadOnlyRootFilesystem:   ptr(true),
+			AllowPrivilegeEscalation: ptr(false),
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+		},
+		LivenessProbe: &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/health", Port: intstr.FromInt(8080)}}},
+	}
+	if readiness {
+		c.ReadinessProbe = &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/ready", Port: intstr.FromInt(8080)}}}
+	}
+	return c
+}
+
+func deploymentInNS(name, ns string, replicas int32, containers ...corev1.Container) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr(replicas),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					AutomountServiceAccountToken: ptr(false),
+					Containers:                   containers,
+				},
+			},
+		},
+	}
+}
+
+// TestCheckCounts_PodSpecFamilyCountsWorkloads pins the subject unit of the
+// pod-spec family: a 3-container workload where 2 containers fail one check
+// is ONE evaluated subject with ONE merged finding — evaluated=1, passed=0 —
+// while sibling checks the same workload satisfies show passed=1.
+func TestCheckCounts_PodSpecFamilyCountsWorkloads(t *testing.T) {
+	input := &CheckInput{
+		ServiceAccounts: []*corev1.ServiceAccount{},
+		LimitRanges:     []*corev1.LimitRange{},
+		Deployments: []*appsv1.Deployment{
+			deploymentInNS("web", "prod", 1,
+				secureContainer("app", false),
+				secureContainer("sidecar", false),
+				secureContainer("probe-ok", true),
+			),
+		},
+	}
+	results := RunChecks(input)
+
+	merged := 0
+	for _, f := range results.Findings {
+		if f.CheckID == "readinessProbeMissing" {
+			merged++
+		}
+	}
+	if merged != 1 {
+		t.Fatalf("expected 1 merged readinessProbeMissing finding, got %d", merged)
+	}
+
+	if got := results.CheckCounts["readinessProbeMissing"]; got != (CheckCount{Evaluated: 1, Passed: 0}) {
+		t.Errorf("readinessProbeMissing counts = %+v, want {Evaluated:1 Passed:0}", got)
+	}
+	for _, id := range []string{"livenessProbeMissing", "runAsRoot", "privileged", "cpuLimitMissing", "dockerSocketMount"} {
+		if got := results.CheckCounts[id]; got != (CheckCount{Evaluated: 1, Passed: 1}) {
+			t.Errorf("%s counts = %+v, want {Evaluated:1 Passed:1}", id, got)
+		}
+	}
+	if byNS := results.EvaluatedByNamespace["readinessProbeMissing"]; byNS["prod"] != 1 {
+		t.Errorf("evaluatedByNamespace[readinessProbeMissing][prod] = %d, want 1", byNS["prod"])
+	}
+}
+
+// TestCheckCounts_MissingInputs pins the "couldn't check ≠ passing" rule:
+// nil prerequisite inputs surface in MissingInputs and their checks are
+// absent from CheckCounts entirely.
+func TestCheckCounts_MissingInputs(t *testing.T) {
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{
+			deploymentInNS("web", "prod", 3, secureContainer("app", true)),
+		},
+		// PodDisruptionBudgets, ConfigMaps, PodMetrics all nil = unavailable.
+	}
+	results := RunChecks(input)
+
+	for _, id := range []string{"missingPDB", "orphanConfigMapSecret", "secretInConfigMap", "resourceUtilization"} {
+		if _, ok := results.CheckCounts[id]; ok {
+			t.Errorf("%s must not appear in CheckCounts when its input is nil", id)
+		}
+	}
+	// Every nil prerequisite is declared, including the relationship-check
+	// and pod-spec-family inventories added by the per-check gating.
+	want := map[string]bool{
+		"poddisruptionbudgets": true, "configmaps": true, "podmetrics": true,
+		"serviceaccounts": true, "limitranges": true, "secrets": true,
+		"pods": true, "services": true, "ingresses": true,
+		"horizontalpodautoscalers": true,
+		"statefulsets": true, "daemonsets": true,
+	}
+	if len(results.MissingInputs) != len(want) {
+		t.Fatalf("MissingInputs = %v, want exactly %v", results.MissingInputs, want)
+	}
+	for _, in := range results.MissingInputs {
+		if !want[in] {
+			t.Errorf("unexpected missing input %q", in)
+		}
+	}
+
+	// Same scan with the inputs present (but empty) — the checks run and count.
+	input.PodDisruptionBudgets = []*policyv1.PodDisruptionBudget{}
+	input.ConfigMaps = []*corev1.ConfigMap{{ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "prod"}}}
+	input.PodMetrics = []PodMetricsInput{}
+	input.ServiceAccounts = []*corev1.ServiceAccount{}
+	input.LimitRanges = []*corev1.LimitRange{}
+	input.Pods = []*corev1.Pod{}
+	input.Services = []*corev1.Service{}
+	input.Ingresses = []*networkingv1.Ingress{}
+	input.Secrets = []*corev1.Secret{}
+	input.HorizontalPodAutoscalers = []*autoscalingv2.HorizontalPodAutoscaler{}
+	input.StatefulSets = []*appsv1.StatefulSet{}
+	input.DaemonSets = []*appsv1.DaemonSet{}
+	results = RunChecks(input)
+	if len(results.MissingInputs) != 0 {
+		t.Errorf("MissingInputs = %v, want none when inputs are non-nil", results.MissingInputs)
+	}
+	if got := results.CheckCounts["missingPDB"]; got != (CheckCount{Evaluated: 1, Passed: 0}) {
+		t.Errorf("missingPDB counts = %+v, want {Evaluated:1 Passed:0}", got)
+	}
+	if got := results.CheckCounts["secretInConfigMap"]; got != (CheckCount{Evaluated: 1, Passed: 1}) {
+		t.Errorf("secretInConfigMap counts = %+v, want {Evaluated:1 Passed:1}", got)
+	}
+}
+
+// TestApplySettings_RecomputesCountsOnCopies pins the two ApplySettings
+// invariants: ignored namespaces and disabled checks leave both the findings
+// AND the denominators, and the raw (cached) results are never mutated.
+func TestApplySettings_RecomputesCountsOnCopies(t *testing.T) {
+	input := &CheckInput{
+		HorizontalPodAutoscalers: []*autoscalingv2.HorizontalPodAutoscaler{},
+		Deployments: []*appsv1.Deployment{
+			deploymentInNS("web", "prod", 1, secureContainer("app", true)),
+			deploymentInNS("big", "prod", 3, secureContainer("app", true)),
+			deploymentInNS("job", "dev", 1, secureContainer("app", true)),
+		},
+	}
+	raw := RunChecks(input)
+
+	if got := raw.CheckCounts["singleReplica"]; got != (CheckCount{Evaluated: 3, Passed: 1}) {
+		t.Fatalf("raw singleReplica counts = %+v, want {Evaluated:3 Passed:1}", got)
+	}
+	if got := raw.CheckCounts["missingTopologySpread"]; got != (CheckCount{Evaluated: 1, Passed: 0}) {
+		t.Fatalf("raw missingTopologySpread counts = %+v, want {Evaluated:1 Passed:0}", got)
+	}
+
+	filtered := ApplySettings(raw, []string{"dev"}, []string{"missingTopologySpread"})
+
+	if got := filtered.CheckCounts["singleReplica"]; got != (CheckCount{Evaluated: 2, Passed: 1}) {
+		t.Errorf("filtered singleReplica counts = %+v, want {Evaluated:2 Passed:1}", got)
+	}
+	if _, ok := filtered.EvaluatedByNamespace["singleReplica"]["dev"]; ok {
+		t.Error("ignored namespace must be removed from EvaluatedByNamespace")
+	}
+	for _, f := range filtered.Findings {
+		if f.Namespace == "dev" {
+			t.Errorf("finding in ignored namespace survived: %+v", f)
+		}
+	}
+	if _, ok := filtered.CheckCounts["missingTopologySpread"]; ok {
+		t.Error("disabled check must be dropped from CheckCounts")
+	}
+	if _, ok := filtered.EvaluatedByNamespace["missingTopologySpread"]; ok {
+		t.Error("disabled check must be dropped from EvaluatedByNamespace")
+	}
+	for _, f := range filtered.Findings {
+		if f.CheckID == "missingTopologySpread" {
+			t.Errorf("finding for disabled check survived: %+v", f)
+		}
+	}
+
+	// Raw results back the server's shared 5s cache — they must be intact.
+	if got := raw.CheckCounts["singleReplica"]; got != (CheckCount{Evaluated: 3, Passed: 1}) {
+		t.Errorf("raw CheckCounts mutated by ApplySettings: %+v", got)
+	}
+	if raw.EvaluatedByNamespace["singleReplica"]["dev"] != 1 {
+		t.Errorf("raw EvaluatedByNamespace mutated by ApplySettings: %+v", raw.EvaluatedByNamespace["singleReplica"])
+	}
+	if _, ok := raw.CheckCounts["missingTopologySpread"]; !ok {
+		t.Error("raw CheckCounts lost a check after ApplySettings")
+	}
+}
+
+// TestCheckCounts_PassingArithmetic pins the summary rollups: Summary.Passing
+// is the sum of per-check passed, and each category's Passing is the same sum
+// restricted to that category's checks (via CheckRegistry).
+func TestCheckCounts_PassingArithmetic(t *testing.T) {
+	input := &CheckInput{
+		Deployments: []*appsv1.Deployment{
+			deploymentInNS("web", "prod", 1, secureContainer("app", true)),
+			deploymentInNS("api", "prod", 1, secureContainer("app", false)),
+		},
+		Services: []*corev1.Service{{
+			ObjectMeta: metav1.ObjectMeta{Name: "orphan", Namespace: "prod"},
+			Spec:       corev1.ServiceSpec{Selector: map[string]string{"app": "nope"}},
+		}},
+	}
+	results := RunChecks(input)
+
+	total := 0
+	byCategory := map[string]int{}
+	for id, cc := range results.CheckCounts {
+		total += cc.Passed
+		meta, ok := CheckRegistry[id]
+		if !ok {
+			t.Fatalf("check %q missing from CheckRegistry", id)
+		}
+		byCategory[meta.Category] += cc.Passed
+	}
+	if results.Summary.Passing != total {
+		t.Errorf("Summary.Passing = %d, want %d (sum of per-check passed)", results.Summary.Passing, total)
+	}
+	for cat, cs := range results.Summary.Categories {
+		if cs.Passing != byCategory[cat] {
+			t.Errorf("category %s Passing = %d, want %d", cat, cs.Passing, byCategory[cat])
+		}
+	}
+	if total == 0 {
+		t.Error("expected a non-zero passing total for this fixture")
+	}
+}
+
+func TestAutomount_PodLevelExplicitEvaluatesWithoutSAInventory(t *testing.T) {
+	on := true
+	input := &CheckInput{
+		LimitRanges: []*corev1.LimitRange{},
+		Deployments: []*appsv1.Deployment{
+			deploymentInNS("web", "prod", 3, secureContainer("app", true)),
+		},
+	}
+	input.Deployments[0].Spec.Template.Spec.AutomountServiceAccountToken = &on
+	// ServiceAccounts deliberately nil: pod-level explicit value decides.
+	results := RunChecks(input)
+	cc, ok := results.CheckCounts["automountServiceAccountToken"]
+	if !ok || cc.Evaluated != 1 || cc.Passed != 0 {
+		t.Errorf("automount counts = %+v ok=%v, want evaluated 1 passed 0", cc, ok)
+	}
+	found := false
+	for _, f := range results.Findings {
+		if f.CheckID == "automountServiceAccountToken" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("pod-level explicit automount not detected with nil SA inventory")
+	}
+}
+
+func TestAutomount_NamespaceScopedSAInventoryLimitsEvaluation(t *testing.T) {
+	input := &CheckInput{
+		LimitRanges:              []*corev1.LimitRange{},
+		ServiceAccounts:          []*corev1.ServiceAccount{},
+		ServiceAccountsNamespace: "covered",
+		Deployments: []*appsv1.Deployment{
+			deploymentInNS("in-scope", "covered", 3, secureContainer("app", true)),
+			deploymentInNS("out-of-scope", "elsewhere", 3, secureContainer("app", true)),
+		},
+	}
+	// The fixture sets pod-level automount explicitly; the point here is the
+	// SA-inventory-dependent path, so unset it on both.
+	input.Deployments[0].Spec.Template.Spec.AutomountServiceAccountToken = nil
+	input.Deployments[1].Spec.Template.Spec.AutomountServiceAccountToken = nil
+	results := RunChecks(input)
+	byNS := results.EvaluatedByNamespace["automountServiceAccountToken"]
+	if byNS["covered"] != 1 {
+		t.Errorf("covered ns evaluated = %d, want 1", byNS["covered"])
+	}
+	if byNS["elsewhere"] != 0 {
+		t.Errorf("elsewhere evaluated = %d, want 0 (SA inventory doesn't cover it)", byNS["elsewhere"])
+	}
+	for _, f := range results.Findings {
+		if f.CheckID == "automountServiceAccountToken" && f.Namespace == "elsewhere" {
+			t.Errorf("false automount finding outside SA inventory coverage")
+		}
+	}
+}

--- a/pkg/audit/helpers.go
+++ b/pkg/audit/helpers.go
@@ -69,7 +69,6 @@ func GroupByResource(findings []Finding) []ResourceGroup {
 	return groups
 }
 
-
 // ApplySettings filters audit results based on ignored namespaces (with wildcard
 // patterns like *-system) and disabled checks. This is the shared implementation
 // used by all consumers (HTTP handlers, MCP, skyhook-connector).
@@ -137,14 +136,42 @@ func ApplySettings(results *ScanResults, ignoredNamespaces, disabledChecks []str
 		totalDanger += cs.Danger
 	}
 
+	// Filter the evaluation denominators onto fresh maps — the input is the
+	// server's shared cached scan, so mutating its maps would corrupt every
+	// other consumer for the cache TTL.
+	var evalByNS map[string]map[string]int
+	if results.EvaluatedByNamespace != nil {
+		evalByNS = make(map[string]map[string]int, len(results.EvaluatedByNamespace))
+		for id, byNS := range results.EvaluatedByNamespace {
+			if disabled[id] {
+				continue
+			}
+			nsCopy := make(map[string]int, len(byNS))
+			for ns, n := range byNS {
+				if matchesIgnoredNS(ns) {
+					continue
+				}
+				nsCopy[ns] = n
+			}
+			if len(nsCopy) > 0 {
+				evalByNS[id] = nsCopy
+			}
+		}
+	}
+	checkCounts, totalPassing := deriveCheckCounts(evalByNS, filtered, categories)
+
 	return &ScanResults{
 		Summary: ScanSummary{
+			Passing:    totalPassing,
 			Warning:    totalWarning,
 			Danger:     totalDanger,
 			Categories: categories,
 		},
-		Findings: filtered,
-		Groups:   groups,
-		Checks:   results.Checks,
+		Findings:             filtered,
+		Groups:               groups,
+		Checks:               results.Checks,
+		CheckCounts:          checkCounts,
+		EvaluatedByNamespace: evalByNS,
+		MissingInputs:        results.MissingInputs,
 	}
 }

--- a/pkg/audit/traefik.go
+++ b/pkg/audit/traefik.go
@@ -27,7 +27,7 @@ import (
 // Scope is still deliberately partial: nested TraefikService weighted/mirror
 // sub-services, ServersTransport refs, and TLS-secret refs can also dangle and
 // are not yet covered.
-func checkTraefikDanglingRefs(input *CheckInput) []Finding {
+func checkTraefikDanglingRefs(tr *evalTracker, input *CheckInput) []Finding {
 	if len(input.IngressRoutes) == 0 && len(input.MiddlewareSubjects) == 0 {
 		return nil
 	}
@@ -131,7 +131,41 @@ func checkTraefikDanglingRefs(input *CheckInput) []Finding {
 			mwKind = "MiddlewareTCP"
 		}
 
+		// A subject counts as evaluated only when (a) the ref inventory it
+		// would be checked against is authoritative AND (b) it actually
+		// carries at least one ref of that type — a route with no
+		// middlewares isn't "passing" the dangling-middleware check, it's
+		// out of scope.
+		hasCoreSvcRef, hasTraefikSvcRef, hasMiddlewareRef := false, false, false
 		routes, _, _ := unstructured.NestedSlice(route.Object, "spec", "routes")
+		for _, r := range routes {
+			rm, ok := r.(map[string]any)
+			if !ok {
+				continue
+			}
+			for _, svc := range nestedMaps(rm, "services") {
+				if kind, _ := svc["kind"].(string); kind == "TraefikService" {
+					hasTraefikSvcRef = true
+				} else {
+					hasCoreSvcRef = true
+				}
+			}
+			if len(nestedMaps(rm, "middlewares")) > 0 {
+				hasMiddlewareRef = true
+			}
+		}
+		// Evaluated only when EVERY present ref kind is checkable — with a
+		// core-Service ref but only the TraefikService inventory listed, the
+		// core ref goes unchecked and "passed" would be a lie.
+		svcRefsCheckable := (hasCoreSvcRef || hasTraefikSvcRef) &&
+			(!hasCoreSvcRef || servicesListed) &&
+			(!hasTraefikSvcRef || authoritative[group+"\x00TraefikService"])
+		if svcRefsCheckable {
+			tr.record("traefikRouteMissingService", routeNs)
+		}
+		if hasMiddlewareRef && authoritative[group+"\x00"+mwKind] {
+			tr.record("traefikRouteMissingMiddleware", routeNs)
+		}
 		for _, r := range routes {
 			rm, ok := r.(map[string]any)
 			if !ok {
@@ -157,6 +191,25 @@ func checkTraefikDanglingRefs(input *CheckInput) []Finding {
 		mwNs := mw.GetNamespace()
 
 		chain, _, _ := unstructured.NestedSlice(mw.Object, "spec", "chain", "middlewares")
+		errSvc, hasErrSvc, _ := unstructured.NestedMap(mw.Object, "spec", "errors", "service")
+		// Only HTTP Middlewares can carry chain/errors — and a Middleware
+		// counts as evaluated only for the check whose ref it actually
+		// carries (a middleware without spec.errors.service isn't "passing"
+		// the errors check, it's out of scope).
+		if mwKind == "Middleware" {
+			if len(chain) > 0 && authoritative[group+"\x00"+mwKind] {
+				tr.record("traefikChainMissingMiddleware", mwNs)
+			}
+			if hasErrSvc {
+				errIsTraefik, _ := errSvc["kind"].(string)
+				checkable := (errIsTraefik == "TraefikService" && authoritative[group+"\x00TraefikService"]) ||
+					(errIsTraefik != "TraefikService" && servicesListed)
+				if checkable {
+					tr.record("traefikErrorsMissingService", mwNs)
+				}
+			}
+		}
+
 		for _, c := range chain {
 			cm, ok := c.(map[string]any)
 			if !ok {
@@ -165,8 +218,8 @@ func checkTraefikDanglingRefs(input *CheckInput) []Finding {
 			checkMiddlewareRef(mw, group, mwKind, mwNs, mwKind+" chain", "traefikChainMissingMiddleware", cm)
 		}
 
-		if svc, ok, _ := unstructured.NestedMap(mw.Object, "spec", "errors", "service"); ok {
-			checkServiceRef(mw, group, mwNs, mwKind+" errors", "traefikErrorsMissingService", svc)
+		if hasErrSvc {
+			checkServiceRef(mw, group, mwNs, mwKind+" errors", "traefikErrorsMissingService", errSvc)
 		}
 	}
 	return findings

--- a/pkg/audit/traefik_test.go
+++ b/pkg/audit/traefik_test.go
@@ -67,8 +67,8 @@ func TestCheckTraefikDanglingRefs(t *testing.T) {
 
 	t.Run("flags missing service and middleware, accepts present ones", func(t *testing.T) {
 		input := &CheckInput{
-			AllServices: []*corev1.Service{svc("app", "present-svc")},
-			Middlewares: []*unstructured.Unstructured{traefikObj(g, "Middleware", "app", "present-mw")},
+			AllServices:               []*corev1.Service{svc("app", "present-svc")},
+			Middlewares:               []*unstructured.Unstructured{traefikObj(g, "Middleware", "app", "present-mw")},
 			TraefikAuthoritativeKinds: authoritative(g + "\x00Middleware"),
 			IngressRoutes: []*unstructured.Unstructured{
 				traefikRoute(g, "IngressRoute", "app", "r1",
@@ -77,7 +77,7 @@ func TestCheckTraefikDanglingRefs(t *testing.T) {
 				),
 			},
 		}
-		ids := findingIDs(checkTraefikDanglingRefs(input))
+		ids := findingIDs(checkTraefikDanglingRefs(newEvalTracker(), input))
 		if ids["traefikRouteMissingService"] != 1 {
 			t.Errorf("want 1 missing-service, got %d", ids["traefikRouteMissingService"])
 		}
@@ -88,15 +88,15 @@ func TestCheckTraefikDanglingRefs(t *testing.T) {
 
 	t.Run("all refs present → no findings", func(t *testing.T) {
 		input := &CheckInput{
-			AllServices: []*corev1.Service{svc("app", "s")},
-			Middlewares: []*unstructured.Unstructured{traefikObj(g, "Middleware", "app", "mw")},
+			AllServices:               []*corev1.Service{svc("app", "s")},
+			Middlewares:               []*unstructured.Unstructured{traefikObj(g, "Middleware", "app", "mw")},
 			TraefikAuthoritativeKinds: authoritative(g + "\x00Middleware"),
 			IngressRoutes: []*unstructured.Unstructured{
 				traefikRoute(g, "IngressRoute", "app", "r",
 					[]map[string]any{{"name": "s"}}, []map[string]any{{"name": "mw"}}),
 			},
 		}
-		if got := checkTraefikDanglingRefs(input); len(got) != 0 {
+		if got := checkTraefikDanglingRefs(newEvalTracker(), input); len(got) != 0 {
 			t.Errorf("want no findings, got %v", got)
 		}
 	})
@@ -106,15 +106,15 @@ func TestCheckTraefikDanglingRefs(t *testing.T) {
 		// The middleware exists there; since the inventory is cluster-wide and
 		// authoritative, this must NOT be flagged.
 		input := &CheckInput{
-			AllServices: []*corev1.Service{},
-			Middlewares: []*unstructured.Unstructured{traefikObj(g, "Middleware", "shared", "auth")},
+			AllServices:               []*corev1.Service{},
+			Middlewares:               []*unstructured.Unstructured{traefikObj(g, "Middleware", "shared", "auth")},
 			TraefikAuthoritativeKinds: authoritative(g + "\x00Middleware"),
 			IngressRoutes: []*unstructured.Unstructured{
 				traefikRoute(g, "IngressRoute", "app", "r", nil,
 					[]map[string]any{{"name": "auth", "namespace": "shared"}}),
 			},
 		}
-		if n := findingIDs(checkTraefikDanglingRefs(input))["traefikRouteMissingMiddleware"]; n != 0 {
+		if n := findingIDs(checkTraefikDanglingRefs(newEvalTracker(), input))["traefikRouteMissingMiddleware"]; n != 0 {
 			t.Errorf("cross-namespace ref to an existing middleware must not be flagged, got %d", n)
 		}
 	})
@@ -130,21 +130,21 @@ func TestCheckTraefikDanglingRefs(t *testing.T) {
 				traefikRoute(g, "IngressRoute", "app", "r", nil, []map[string]any{{"name": "ghost"}}),
 			},
 		}
-		if n := findingIDs(checkTraefikDanglingRefs(input))["traefikRouteMissingMiddleware"]; n != 0 {
+		if n := findingIDs(checkTraefikDanglingRefs(newEvalTracker(), input))["traefikRouteMissingMiddleware"]; n != 0 {
 			t.Errorf("non-authoritative middleware kind must not be asserted, got %d", n)
 		}
 	})
 
 	t.Run("cross-group middleware does not satisfy the reference", func(t *testing.T) {
 		input := &CheckInput{
-			AllServices: []*corev1.Service{},
-			Middlewares: []*unstructured.Unstructured{traefikObj("traefik.containo.us", "Middleware", "app", "mw")},
+			AllServices:               []*corev1.Service{},
+			Middlewares:               []*unstructured.Unstructured{traefikObj("traefik.containo.us", "Middleware", "app", "mw")},
 			TraefikAuthoritativeKinds: authoritative(g + "\x00Middleware"),
 			IngressRoutes: []*unstructured.Unstructured{
 				traefikRoute(g, "IngressRoute", "app", "r", nil, []map[string]any{{"name": "mw"}}),
 			},
 		}
-		if n := findingIDs(checkTraefikDanglingRefs(input))["traefikRouteMissingMiddleware"]; n != 1 {
+		if n := findingIDs(checkTraefikDanglingRefs(newEvalTracker(), input))["traefikRouteMissingMiddleware"]; n != 1 {
 			t.Errorf("traefik.io router must not be satisfied by a traefik.containo.us Middleware, got %d", n)
 		}
 	})
@@ -154,20 +154,20 @@ func TestCheckTraefikDanglingRefs(t *testing.T) {
 		// router's MiddlewareTCP ref must be skipped (its kind isn't authoritative),
 		// NOT fabricated as missing.
 		input := &CheckInput{
-			AllServices: []*corev1.Service{},
-			Middlewares: []*unstructured.Unstructured{traefikObj(g, "Middleware", "app", "mw")},
+			AllServices:               []*corev1.Service{},
+			Middlewares:               []*unstructured.Unstructured{traefikObj(g, "Middleware", "app", "mw")},
 			TraefikAuthoritativeKinds: authoritative(g + "\x00Middleware"), // NOT MiddlewareTCP
 			IngressRoutes: []*unstructured.Unstructured{
 				traefikRoute(g, "IngressRouteTCP", "app", "r", nil, []map[string]any{{"name": "mw"}}),
 			},
 		}
-		if n := findingIDs(checkTraefikDanglingRefs(input))["traefikRouteMissingMiddleware"]; n != 0 {
+		if n := findingIDs(checkTraefikDanglingRefs(newEvalTracker(), input))["traefikRouteMissingMiddleware"]; n != 0 {
 			t.Errorf("MiddlewareTCP kind not authoritative → must skip, got %d (regression: CR-3)", n)
 		}
 
 		// Now MiddlewareTCP IS authoritative and the ref is absent → flag.
 		input.TraefikAuthoritativeKinds = authoritative(g + "\x00MiddlewareTCP")
-		if n := findingIDs(checkTraefikDanglingRefs(input))["traefikRouteMissingMiddleware"]; n != 1 {
+		if n := findingIDs(checkTraefikDanglingRefs(newEvalTracker(), input))["traefikRouteMissingMiddleware"]; n != 1 {
 			t.Errorf("authoritative MiddlewareTCP with absent ref → want 1, got %d", n)
 		}
 	})
@@ -183,7 +183,7 @@ func TestCheckTraefikDanglingRefs(t *testing.T) {
 					[]map[string]any{{"name": "missing"}}, []map[string]any{{"name": "ghost"}}),
 			},
 		}
-		ids := findingIDs(checkTraefikDanglingRefs(input))
+		ids := findingIDs(checkTraefikDanglingRefs(newEvalTracker(), input))
 		if ids["traefikRouteMissingService"] != 1 {
 			t.Errorf("service ref should be checked independently, got %d", ids["traefikRouteMissingService"])
 		}
@@ -200,7 +200,7 @@ func TestCheckTraefikDanglingRefs(t *testing.T) {
 				traefikRoute(g, "IngressRoute", "app", "r", []map[string]any{{"name": "missing"}}, nil),
 			},
 		}
-		got := checkTraefikDanglingRefs(input)
+		got := checkTraefikDanglingRefs(newEvalTracker(), input)
 		if len(got) != 1 {
 			t.Fatalf("want 1 finding, got %d", len(got))
 		}
@@ -210,7 +210,7 @@ func TestCheckTraefikDanglingRefs(t *testing.T) {
 	})
 
 	t.Run("no Traefik installed → no-op", func(t *testing.T) {
-		if got := checkTraefikDanglingRefs(&CheckInput{}); got != nil {
+		if got := checkTraefikDanglingRefs(newEvalTracker(), &CheckInput{}); got != nil {
 			t.Errorf("want nil, got %v", got)
 		}
 	})
@@ -245,7 +245,7 @@ func TestCheckTraefikMiddlewareSubjectRefs(t *testing.T) {
 				traefikChainMw(g, "app", "c", []map[string]any{{"name": "present"}, {"name": "missing"}}),
 			},
 		}
-		if n := findingIDs(checkTraefikDanglingRefs(input))["traefikChainMissingMiddleware"]; n != 1 {
+		if n := findingIDs(checkTraefikDanglingRefs(newEvalTracker(), input))["traefikChainMissingMiddleware"]; n != 1 {
 			t.Errorf("want 1 missing chain middleware, got %d", n)
 		}
 	})
@@ -258,7 +258,7 @@ func TestCheckTraefikMiddlewareSubjectRefs(t *testing.T) {
 				traefikChainMw(g, "app", "c", []map[string]any{{"name": "auth", "namespace": "shared"}}),
 			},
 		}
-		if n := findingIDs(checkTraefikDanglingRefs(input))["traefikChainMissingMiddleware"]; n != 0 {
+		if n := findingIDs(checkTraefikDanglingRefs(newEvalTracker(), input))["traefikChainMissingMiddleware"]; n != 0 {
 			t.Errorf("cross-namespace ref to an existing middleware must not be flagged, got %d", n)
 		}
 	})
@@ -270,7 +270,7 @@ func TestCheckTraefikMiddlewareSubjectRefs(t *testing.T) {
 				traefikChainMw(g, "app", "c", []map[string]any{{"name": "ghost"}}),
 			},
 		}
-		if n := findingIDs(checkTraefikDanglingRefs(input))["traefikChainMissingMiddleware"]; n != 0 {
+		if n := findingIDs(checkTraefikDanglingRefs(newEvalTracker(), input))["traefikChainMissingMiddleware"]; n != 0 {
 			t.Errorf("non-authoritative middleware kind must not be asserted, got %d", n)
 		}
 	})
@@ -283,7 +283,7 @@ func TestCheckTraefikMiddlewareSubjectRefs(t *testing.T) {
 				traefikErrorsMw(g, "app", "e-present", map[string]any{"name": "present"}),
 			},
 		}
-		if n := findingIDs(checkTraefikDanglingRefs(input))["traefikErrorsMissingService"]; n != 1 {
+		if n := findingIDs(checkTraefikDanglingRefs(newEvalTracker(), input))["traefikErrorsMissingService"]; n != 1 {
 			t.Errorf("want 1 missing errors service, got %d", n)
 		}
 	})
@@ -297,7 +297,7 @@ func TestCheckTraefikMiddlewareSubjectRefs(t *testing.T) {
 				traefikErrorsMw(g, "app", "e", map[string]any{"name": "weighted", "kind": "TraefikService"}),
 			},
 		}
-		if n := findingIDs(checkTraefikDanglingRefs(input))["traefikErrorsMissingService"]; n != 0 {
+		if n := findingIDs(checkTraefikDanglingRefs(newEvalTracker(), input))["traefikErrorsMissingService"]; n != 0 {
 			t.Errorf("present TraefikService ref must not be flagged, got %d", n)
 		}
 	})
@@ -311,7 +311,7 @@ func TestCheckTraefikMiddlewareSubjectRefs(t *testing.T) {
 				traefikErrorsMw(g, "app", "e", map[string]any{"name": "missing"}),
 			},
 		}
-		got := checkTraefikDanglingRefs(input)
+		got := checkTraefikDanglingRefs(newEvalTracker(), input)
 		if len(got) != 1 {
 			t.Fatalf("want 1 finding from a middleware-only namespace, got %d", len(got))
 		}

--- a/pkg/audit/types.go
+++ b/pkg/audit/types.go
@@ -28,6 +28,12 @@ type CheckInput struct {
 	ConfigMaps               []*corev1.ConfigMap
 	Secrets                  []*corev1.Secret
 	ServiceAccounts          []*corev1.ServiceAccount
+	// ServiceAccountsNamespace is non-empty when the SA inventory covers only
+	// that single namespace (namespace-scoped cache fallback). Workloads in
+	// other namespaces must not have SA-dependent checks evaluated against
+	// this partial inventory. Empty = cluster-wide authority (when
+	// ServiceAccounts is non-nil).
+	ServiceAccountsNamespace string
 	LimitRanges              []*corev1.LimitRange
 	// ClusterVersion is the K8s server version (e.g. "1.30"). Used for deprecated API checks.
 	ClusterVersion string
@@ -100,6 +106,20 @@ type ScanResults struct {
 	Findings []Finding            `json:"findings"`
 	Groups   []ResourceGroup      `json:"groups"`
 	Checks   map[string]CheckMeta `json:"checks"`
+	// CheckCounts maps checkID → evaluated/passed subject counts. A check
+	// appears only when it evaluated at least one subject; checks whose
+	// prerequisite inputs were unavailable are absent (see MissingInputs) so
+	// consumers never mistake "couldn't check" for "all passing".
+	CheckCounts map[string]CheckCount `json:"checkCounts,omitempty"`
+	// EvaluatedByNamespace maps checkID → namespace → distinct subjects
+	// evaluated ("" namespace for cluster-scoped subjects). It exists so
+	// ApplySettings can subtract ignored namespaces from the denominators
+	// without re-running the scan.
+	EvaluatedByNamespace map[string]map[string]int `json:"evaluatedByNamespace,omitempty"`
+	// MissingInputs lists prerequisite inputs that were nil (RBAC denied or
+	// unavailable), e.g. "poddisruptionbudgets", "configmaps", "podmetrics".
+	// Checks depending on them did not run and are absent from CheckCounts.
+	MissingInputs []string `json:"missingInputs,omitempty"`
 	// GroupedChecks is the per-check remediation-queue rollup (one Check per
 	// failing check). Populated by the HTTP audit handler post local-settings —
 	// not by RunChecks, which doesn't carry the request context BuildChecks
@@ -121,6 +141,15 @@ type ResourceGroup struct {
 	Warning   int       `json:"warning"`
 	Danger    int       `json:"danger"`
 	Findings  []Finding `json:"findings"`
+}
+
+// CheckCount is the evaluated/passed tally for a single check. Evaluated
+// counts distinct subjects at the same (resource, checkID) grain the finding
+// merge uses — per-container findings collapse to their workload here too, so
+// evaluated, passed, and the failing remainder all speak the same unit.
+type CheckCount struct {
+	Evaluated int `json:"evaluated"`
+	Passed    int `json:"passed"`
 }
 
 // ScanSummary provides aggregate counts.


### PR DESCRIPTION
## Summary

Every check now reports how many subjects it evaluated and how many passed — giving the long-dead `ScanSummary.Passing` / `CategorySummary.Passing` fields their first real writer, and enabling honest pass-ratio displays ("94% of evaluations passing") instead of the fabricated percentages consumers had to avoid.

## What changed

- `evalTracker` threaded through all 18 check functions: **evaluated = distinct subjects at the same `(resource, checkID)` granularity findings merge at** — a 3-container workload with 2 failing containers is 1 evaluated / 0 passed, matching its single merged finding. Each check records only subjects that pass its own eligibility filters (HPA-managed deployments are out of `singleReplica`'s scope, not "passing"; requestless pods are out of `resourceUtilization`'s).
- **Prerequisite honesty**: checks whose inputs are RBAC-denied don't run, don't count, and the missing input is declared in `missingInputs[]` — a blind check is never reported as passing. This surfaced a pre-existing bug: a healthy cluster with *zero* PDBs was indistinguishable from PDB-RBAC-denied (nil vs empty lister), so `missingPDB` silently never fired on PDB-less clusters. Fixed — expect new (correct) findings there.
- `CheckCounts` map (per check: evaluated/passed) + `evaluatedByNamespace` table so `ApplySettings` recomputes denominators under ignored-namespace globs and disabled checks — **on fresh maps; the 5s-cached raw results are never mutated** (test proves it).
- Cluster-scoped subjects (deprecated served APIs) count under the `""` namespace at subject grain.

## Testing

Full suite green (root + pkg modules). New tests: multi-container merge arithmetic, missing-inputs partition (nil ≠ empty), ApplySettings copy-safety + denominator filtering, Passing sums per category/summary.

## Notes

`stuckTerminating` treats every scanned object as an evaluated subject (being non-terminating *is* the passing outcome), which makes it dominate the fleet-wide Passing sum — flagged for the consumer-side ratio design (per-category ratios are the meaningful display; the grand total is documentation, not UI).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes audit semantics (new PDB findings on PDB-less clusters, skipped checks when RBAC denies listers) and affects all scan consumers via new fields and gating; logic is heavily tested but behavior shifts are user-visible.
> 
> **Overview**
> Adds **honest pass ratios** to audit scans: each check now reports how many subjects it evaluated vs passed, and `ScanSummary.Passing` / category `Passing` are derived from those tallies instead of staying unused.
> 
> An **`evalTracker`** is threaded through all check functions. Counts use the same **(resource, checkID)** grain as merged findings (workloads, not per-container). Checks only record subjects that pass their eligibility rules (e.g. HPA-managed deployments excluded from `singleReplica`, requestless pods from `resourceUtilization`).
> 
> **Prerequisite gating** skips checks when inputs are unavailable (nil lister = RBAC/denied, not “zero resources”) and records them in **`missingInputs`** so “couldn’t check” is never shown as passing. **`listNamespaced`** now returns empty slices for successful empty lists vs **nil** for unavailable listers—fixing conflation where PDB-less clusters looked like PDB list failures.
> 
> **`ScanResults`** gains `checkCounts`, `evaluatedByNamespace`, and `missingInputs`. **`ApplySettings`** recomputes counts on filtered copies without mutating cached raw results. Runner passes **`ServiceAccountsNamespace`** when SA inventory is namespace-scoped so automount checks don’t run outside coverage.
> 
> Deprecated API findings merge **per served group/version** (one evaluated subject, merged messages). Traefik dangling-ref checks record evaluation only when ref inventory is authoritative and refs exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f81f99c379b0bcfb44a9cb0436b37e52937660a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->