### PR TITLE
fix(issues): clarify issue timing labels

### DIFF
--- a/internal/issues/grouping.go
+++ b/internal/issues/grouping.go
@@ -277,7 +277,7 @@ func affectedOf(refs []Ref) Affected {
 		switch r.Kind {
 		case "Pod":
 			a.Pods++
-		case "Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Job", "CronJob":
+		case "Deployment", "Rollout", "StatefulSet", "DaemonSet", "ReplicaSet", "Job", "CronJob":
 			a.Workloads++
 		case "Service":
 			a.Services++

--- a/internal/issues/grouping_test.go
+++ b/internal/issues/grouping_test.go
@@ -63,6 +63,32 @@ func TestGroupIssues_FoldsMembersUnderOwner(t *testing.T) {
 	}
 }
 
+func TestGroupIssues_RolloutSubjectIsWorkload(t *testing.T) {
+	ro := Ref{Group: "argoproj.io", Kind: "Rollout", Namespace: "ns", Name: "web"}
+	i := Issue{
+		Source: SourceProblem, Group: "apps", Kind: "ReplicaSet", Namespace: "ns", Name: "web-abc123",
+		Reason: "ReplicaFailure", Severity: SeverityCritical, Owner: ro,
+		FirstSeen: time.Unix(1000, 0), LastSeen: time.Unix(1000, 0), Count: 1,
+	}
+	classifyIssue(&i)
+	enrichIdentity(&i)
+
+	got := GroupIssues([]Issue{i})
+	if len(got) != 1 {
+		t.Fatalf("want 1 grouped row, got %d", len(got))
+	}
+	g := got[0]
+	if g.GroupingScope != issuesapi.ScopeWorkload {
+		t.Fatalf("rollout scope = %q, want workload", g.GroupingScope)
+	}
+	if g.Group != "argoproj.io" || g.Kind != "Rollout" || g.Name != "web" {
+		t.Fatalf("subject = %s/%s/%s, want argoproj.io/Rollout/web", g.Group, g.Kind, g.Name)
+	}
+	if g.Count != 1 || g.Affected.Workloads != 1 {
+		t.Fatalf("count=%d affected.workloads=%d, want 1/1", g.Count, g.Affected.Workloads)
+	}
+}
+
 // TestGroupIssues_CarriesAgreedDiagnosis pins that a single-member group (e.g.
 // a GitOps Application, which is its own subject) carries the parsed
 // cause/remediation onto the grouped row — without this foldGroup would emit

--- a/packages/k8s-ui/src/components/issues/IssuesView.tsx
+++ b/packages/k8s-ui/src/components/issues/IssuesView.tsx
@@ -3,6 +3,7 @@ import { AlertOctagon, AlertTriangle, ArrowRight, ChevronRight, CircleCheck, Clo
 import { CardBody, CardSection, ClusterName, EmptyState, KIND_CHIP_CLASS, TerminalBlock } from '../ui';
 import { formatCompactAge, formatRelativeAgeTime } from '../../utils/format';
 import { diagnosticRoleLabel, diagnosticFactLabel, confidenceTitle, incidentParentLabel } from './diagnostic';
+import { issueTiming } from './issue-timing';
 import {
   ISSUE_SEVERITY_BADGE_CLASS,
   ISSUE_SEVERITY_HEADER_BAND_CLASS,
@@ -155,6 +156,7 @@ export function IssueRow({
   const severity = normalizeIssueSeverity(issue.severity);
   const SeverityIcon = ISSUE_SEVERITY_ICON[severity];
   const slotCtx = { issue, open };
+  const timing = issueTiming(issue);
 
   useEffect(() => {
     if (open) {
@@ -272,8 +274,8 @@ export function IssueRow({
             >
               <Clock className="h-3 w-3" aria-hidden />
               {formatCompactAge(issue.first_seen)}
-              {issue.issue_timing === 'started_at_resource_creation' ? (
-                <span className="badge-sm ml-1 text-[10px] text-theme-text-secondary">since deploy</span>
+              {timing ? (
+                <span className="badge-sm ml-1 text-[10px] text-theme-text-secondary" title={timing.tooltip}>{timing.chip}</span>
               ) : null}
             </time>
           ) : null}
@@ -343,6 +345,7 @@ function Diagnosis({ issue }: { issue: Issue }) {
   // present, else headline+detail) rather than a string that may never appear.
   const visibleMessage = [headline, detail].filter(Boolean).join(' ');
   const shownText = issue.cause ?? visibleMessage;
+  const timing = issueTiming(issue);
   const rawError = [
     ...new Set(
       [issue.raw_message ?? (issue.cause ? issue.message : undefined), detail].filter(
@@ -359,15 +362,13 @@ function Diagnosis({ issue }: { issue: Issue }) {
   else if (issue.operation_retry_count) meta.push('Retrying');
   if (issue.operation_retry_count) meta.push(`retried ${issue.operation_retry_count}×`);
   if (crash) meta.push(crash);
+  if (timing) {
+    meta.push(timing.meta);
+  } else if (issue.first_seen) {
+    meta.push(`started ${formatRelativeAgeTime(issue.first_seen)}`);
+  }
   if (issue.first_seen) {
-    meta.push(
-      issue.issue_timing === 'started_at_resource_creation'
-        ? 'present since deployment'
-        : issue.issue_timing === 'started_after_resource_was_healthy'
-          ? `started ${formatRelativeAgeTime(issue.first_seen)} · was previously healthy`
-          : `started ${formatRelativeAgeTime(issue.first_seen)}`,
-    );
-    if (issue.last_seen && issue.issue_timing !== 'started_at_resource_creation') meta.push(`last seen ${formatRelativeAgeTime(issue.last_seen)}`);
+    if (issue.last_seen && timing?.kind !== 'creation') meta.push(`last seen ${formatRelativeAgeTime(issue.last_seen)}`);
   }
   if (issue.change_context) meta.push(changeContextText(issue.change_context));
 
@@ -496,11 +497,8 @@ function DiagnosticContext({
 // freshness, the two facts the compact "2h" hides.
 function ageTitle(issue: Issue): string {
   const parts: string[] = [];
-  if (issue.issue_timing === 'started_at_resource_creation') {
-    parts.push('Present since deployment — treat as baseline');
-  } else if (issue.issue_timing === 'started_after_resource_was_healthy') {
-    parts.push('Resource was previously healthy');
-  }
+  const timing = issueTiming(issue);
+  if (timing) parts.push(timing.tooltip);
   if (issue.first_seen) parts.push(`First seen ${new Date(issue.first_seen).toLocaleString()}`);
   if (issue.last_seen) parts.push(`Last seen ${formatRelativeAgeTime(issue.last_seen)}`);
   return parts.join('\n');

--- a/packages/k8s-ui/src/components/issues/index.ts
+++ b/packages/k8s-ui/src/components/issues/index.ts
@@ -5,6 +5,8 @@
 export { IssueRow, IssuesView } from './IssuesView';
 export type { IssueRowProps, IssueRowSlotContext, IssuesViewProps } from './IssuesView';
 export { ResourceIssuesSection } from './ResourceIssuesSection';
+export { issueTiming } from './issue-timing';
+export type { IssueTimingDisplay, IssueTimingDisplayKind } from './issue-timing';
 export {
   ISSUE_SEVERITIES,
   ISSUE_SEVERITY_RANK,

--- a/packages/k8s-ui/src/components/issues/issue-timing.ts
+++ b/packages/k8s-ui/src/components/issues/issue-timing.ts
@@ -1,0 +1,53 @@
+import { formatRelativeAgeTime } from '../../utils/format';
+import { isDeploymentLikeWorkloadKind } from '../../types';
+import type { Issue } from './types';
+
+export type IssueTimingDisplayKind = 'creation' | 'regression';
+
+export interface IssueTimingDisplay {
+  kind: IssueTimingDisplayKind;
+  chip: string;
+  meta: string;
+  tooltip: string;
+}
+
+function isDeploymentLikeCreation(issue: Issue): boolean {
+  const group = issue.group ?? '';
+  if (issue.kind === 'Pod') {
+    return issue.issue_timing_basis === 'pod_creation'
+      || issue.issue_timing_basis === 'owner_condition';
+  }
+  return isDeploymentLikeWorkloadKind(issue.kind, group);
+}
+
+export function issueTiming(issue: Issue): IssueTimingDisplay | null {
+  switch (issue.issue_timing) {
+    case 'started_after_resource_was_healthy': {
+      const started = issue.first_seen ? `started ${formatRelativeAgeTime(issue.first_seen)} after being healthy` : 'started after being healthy';
+      return {
+        kind: 'regression',
+        chip: 'after healthy',
+        meta: started,
+        tooltip: 'Previously healthy before this failing signal.',
+      };
+    }
+    case 'started_at_resource_creation': {
+      if (isDeploymentLikeCreation(issue)) {
+        return {
+          kind: 'creation',
+          chip: 'since deploy',
+          meta: 'present since deployment or first reconciliation',
+          tooltip: 'Failing signal began during deployment or first reconciliation.',
+        };
+      }
+      return {
+        kind: 'creation',
+        chip: 'since creation',
+        meta: 'present since creation or first reconciliation',
+        tooltip: 'Failing signal began during resource creation or first reconciliation.',
+      };
+    }
+    default:
+      return null;
+  }
+}

--- a/packages/k8s-ui/src/components/issues/issues.test.ts
+++ b/packages/k8s-ui/src/components/issues/issues.test.ts
@@ -4,6 +4,7 @@ import { renderToString } from 'react-dom/server'
 import { compareIssues, subjectRef, memberRef, normalizeImagePullMessage, issueMessageParts, type Issue } from './types'
 import { categoryLabel, groupBadgeClass, groupLabel } from './severity'
 import { IssueRow } from './IssuesView'
+import { issueTiming } from './issue-timing'
 
 const base: Issue = {
   id: 'id-0',
@@ -78,7 +79,7 @@ describe('category/group label fallbacks', () => {
 })
 
 describe('IssueRow', () => {
-  it('keeps relative age visible and adds since-deploy as a secondary tag', () => {
+  it('keeps relative age visible and adds deployment timing as a secondary tag', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-06-30T12:00:00Z'))
 
@@ -96,6 +97,25 @@ describe('IssueRow', () => {
     expect(html).toContain('since deploy')
   })
 
+  it('promotes after-healthy timing in the collapsed row', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-30T12:00:00Z'))
+
+    const html = renderToString(createElement(IssueRow, {
+      issue: mk({
+        id: 'regression',
+        first_seen: '2026-06-30T10:00:00Z',
+        issue_timing: 'started_after_resource_was_healthy',
+        issue_timing_basis: 'condition',
+      }),
+      open: false,
+      onToggle: () => undefined,
+    }))
+
+    expect(html).toContain('2h')
+    expect(html).toContain('after healthy')
+  })
+
   it('uses the category-group chip class in the queue row', () => {
     const html = renderToString(createElement(IssueRow, {
       issue: mk({ category_group: 'control_plane' }),
@@ -105,6 +125,87 @@ describe('IssueRow', () => {
 
     expect(html).toContain('Control plane')
     expect(html).toContain(groupBadgeClass('control_plane'))
+  })
+})
+
+describe('issueTiming', () => {
+  it('keeps deployment wording for deployment-like creation failures', () => {
+    expect(issueTiming(mk({
+      kind: 'Deployment',
+      group: 'apps',
+      issue_timing: 'started_at_resource_creation',
+      issue_timing_basis: 'condition',
+    }))).toMatchObject({
+      kind: 'creation',
+      chip: 'since deploy',
+      meta: 'present since deployment or first reconciliation',
+    })
+
+    expect(issueTiming(mk({
+      kind: 'Rollout',
+      group: 'argoproj.io',
+      issue_timing: 'started_at_resource_creation',
+      issue_timing_basis: 'condition',
+    }))).toMatchObject({
+      kind: 'creation',
+      chip: 'since deploy',
+      meta: 'present since deployment or first reconciliation',
+    })
+  })
+
+  it('uses deployment wording for pod issues only when workload timing evidence is present', () => {
+    expect(issueTiming(mk({
+      kind: 'Pod',
+      issue_timing: 'started_at_resource_creation',
+      issue_timing_basis: 'pod_creation',
+    }))).toMatchObject({
+      kind: 'creation',
+      chip: 'since deploy',
+    })
+
+    expect(issueTiming(mk({
+      kind: 'Pod',
+      issue_timing: 'started_at_resource_creation',
+      issue_timing_basis: 'phase',
+    }))).toMatchObject({
+      kind: 'creation',
+      chip: 'since creation',
+    })
+  })
+
+  it('uses resource creation wording for non-deployment creation failures', () => {
+    expect(issueTiming(mk({
+      kind: 'PersistentVolumeClaim',
+      issue_timing: 'started_at_resource_creation',
+      issue_timing_basis: 'phase',
+    }))).toMatchObject({
+      kind: 'creation',
+      chip: 'since creation',
+      meta: 'present since creation or first reconciliation',
+    })
+  })
+
+  it('describes after-healthy timing without implying root cause or safety', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-30T12:00:00Z'))
+
+    const display = issueTiming(mk({
+      first_seen: '2026-06-30T10:00:00Z',
+      issue_timing: 'started_after_resource_was_healthy',
+      issue_timing_basis: 'condition',
+    }))
+
+    expect(display).toMatchObject({
+      kind: 'regression',
+      chip: 'after healthy',
+      meta: 'started 2h ago after being healthy',
+      tooltip: 'Previously healthy before this failing signal.',
+    })
+    expect(`${display?.chip} ${display?.meta} ${display?.tooltip}`).not.toMatch(/baseline|safe|ignore/i)
+  })
+
+  it('returns null when there is no confident timing signal', () => {
+    expect(issueTiming(mk({ issue_timing: undefined, issue_timing_basis: undefined }))).toBeNull()
   })
 })
 

--- a/packages/k8s-ui/src/components/timeline/shared.tsx
+++ b/packages/k8s-ui/src/components/timeline/shared.tsx
@@ -8,7 +8,7 @@
 import { clsx } from 'clsx'
 import { ZoomIn, ZoomOut } from 'lucide-react'
 import type { TimelineEvent } from '../../types/core'
-import { isChangeEvent, isHistoricalEvent } from '../../types/core'
+import { isChangeEvent, isDeploymentLikeWorkloadKind, isHistoricalEvent } from '../../types/core'
 import { isProblematicEvent } from '../../utils/resource-hierarchy'
 
 // ============================================================================
@@ -495,12 +495,11 @@ export interface HealthSpanResult {
  * Rollout signals include:
  * - Diff summary contains "updated:" (indicating replica count or image changes)
  * - Diff summary mentions image changes
- * - Event is for Deployment/StatefulSet/DaemonSet with degraded health
+ * - Event is for a deployment-like workload with degraded health
  */
 function isRolloutEvent(event: TimelineEvent): boolean {
-  // Only workload kinds can have rollouts
-  const rolloutKinds = new Set(['Deployment', 'StatefulSet', 'DaemonSet', 'Rollout', 'ReplicaSet'])
-  if (!rolloutKinds.has(event.kind)) return false
+  // Only deployment-like workload controllers can have rollout transitions.
+  if (!isDeploymentLikeWorkloadKind(event.kind)) return false
 
   // Check diff summary for rollout signals
   if (event.diff?.summary) {

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -339,6 +339,20 @@ export function isWorkloadKind(kind: string): boolean {
   ].includes(kind)
 }
 
+export function isDeploymentLikeWorkloadKind(kind: string, group = ''): boolean {
+  switch (kind) {
+    case 'Deployment':
+    case 'ReplicaSet':
+    case 'StatefulSet':
+    case 'DaemonSet':
+      return group === '' || group === 'apps'
+    case 'Rollout':
+      return group === '' || group === 'argoproj.io'
+    default:
+      return false
+  }
+}
+
 // Check if a resource kind is typically managed by another
 export function isManagedKind(kind: string): boolean {
   return ['ReplicaSet', 'Pod', 'Event'].includes(kind)

--- a/pkg/gitops/tree/graph.go
+++ b/pkg/gitops/tree/graph.go
@@ -128,7 +128,7 @@ func refFromTopologyNode(n topology.Node) ResourceRef {
 
 func infoFromTopology(n topology.Node) []InfoItem {
 	switch string(n.Kind) {
-	case "Deployment", "StatefulSet", "DaemonSet", "ReplicaSet":
+	case "Deployment", "Rollout", "StatefulSet", "DaemonSet", "ReplicaSet":
 		if summary, ok := n.Data["statusSummary"].(string); ok && summary != "" {
 			return []InfoItem{{Name: "Status", Value: summary}}
 		}
@@ -258,7 +258,7 @@ func kindPriority(kind string) int {
 		"CustomResourceDefinition": 5,
 		"ClusterRole":              6, "ClusterRoleBinding": 7, "Role": 8, "RoleBinding": 9,
 		"Service":    10,
-		"Deployment": 11, "StatefulSet": 11, "DaemonSet": 11,
+		"Deployment": 11, "Rollout": 11, "StatefulSet": 11, "DaemonSet": 11,
 		"ReplicaSet": 12, "Pod": 13,
 		"Ingress": 14, "Gateway": 14, "HTTPRoute": 15,
 	}

--- a/pkg/gitops/tree/graph_test.go
+++ b/pkg/gitops/tree/graph_test.go
@@ -3,6 +3,7 @@ package tree
 import (
 	"testing"
 
+	"github.com/skyhook-io/radar/pkg/topology"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -52,5 +53,22 @@ func TestClassifyGitOpsKind(t *testing.T) {
 				t.Fatalf("got (%q, %q), want (%q, %q)", tool, kind, tt.wantTool, tt.wantKind)
 			}
 		})
+	}
+}
+
+func TestRolloutTopologyInfoAndPriority(t *testing.T) {
+	info := infoFromTopology(topology.Node{
+		Kind: topology.KindRollout,
+		Data: map[string]any{
+			"readyReplicas": int64(2),
+			"totalReplicas": int64(3),
+		},
+	})
+	if len(info) != 1 || info[0].Name != "Ready" || info[0].Value != "2/3" {
+		t.Fatalf("rollout info = %#v, want Ready 2/3", info)
+	}
+
+	if got, want := kindPriority("Rollout"), kindPriority("Deployment"); got != want {
+		t.Fatalf("rollout priority = %d, want deployment priority %d", got, want)
 	}
 }

--- a/pkg/issuesapi/catalog.go
+++ b/pkg/issuesapi/catalog.go
@@ -125,7 +125,7 @@ var categoryDescription = map[Category]string{
 	CategoryVolumeMountFailed:        "A pod can't mount a volume — attach/mount failed (wrong node, missing CSI driver, or permissions).",
 	CategoryVolumeAccessModeConflict: "A volume's access mode conflicts with how it's mounted (e.g. an RWO volume claimed by pods on different nodes).",
 	// Scaling
-	CategoryRolloutStalled:     "A Deployment or StatefulSet rollout is stuck — the new revision isn't progressing (progressDeadlineExceeded).",
+	CategoryRolloutStalled:     "A workload rollout is stuck — the new revision isn't progressing (progressDeadlineExceeded).",
 	CategoryHPALimitedOrFailed: "A HorizontalPodAutoscaler can't scale — missing metrics, pinned at max replicas, or scaling errors.",
 	// Security
 	CategoryRBACForbidden:        "A workload can't create its pods — its controller's ServiceAccount is denied pod creation by RBAC.",

--- a/pkg/subject/subject.go
+++ b/pkg/subject/subject.go
@@ -92,7 +92,7 @@ func (s Subject) Key() string {
 // for unrecognized kinds. Exported so checks can reuse it.
 func ScopeForKind(kind string) Scope {
 	switch kind {
-	case "Pod", "Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Job", "CronJob":
+	case "Pod", "Deployment", "Rollout", "StatefulSet", "DaemonSet", "ReplicaSet", "Job", "CronJob":
 		return ScopeWorkload
 	case "Service":
 		return ScopeService

--- a/pkg/subject/subject_test.go
+++ b/pkg/subject/subject_test.go
@@ -135,7 +135,7 @@ func TestResolveSubject_UnknownOperatorDegradesToWorkload(t *testing.T) {
 
 func TestScopeForKind(t *testing.T) {
 	cases := map[string]Scope{
-		"Pod": ScopeWorkload, "Deployment": ScopeWorkload, "CronJob": ScopeWorkload,
+		"Pod": ScopeWorkload, "Deployment": ScopeWorkload, "Rollout": ScopeWorkload, "CronJob": ScopeWorkload,
 		"Service": ScopeService, "Ingress": ScopeIngress, "PersistentVolumeClaim": ScopePVC,
 		"Node": ScopeNode, "Frobnicator": ScopeUnknown,
 	}

--- a/pkg/timeline/filter_test.go
+++ b/pkg/timeline/filter_test.go
@@ -229,6 +229,14 @@ func TestDefaultFilterPreset(t *testing.T) {
 	if !allPreset.IncludeManaged {
 		t.Error("all preset should have IncludeManaged=true")
 	}
+
+	workloadPreset, ok := presets["workloads"]
+	if !ok {
+		t.Fatal("workloads preset should exist")
+	}
+	if !slices.Contains(workloadPreset.IncludeKinds, "Rollout") {
+		t.Error("workloads preset should include Rollout")
+	}
 }
 
 func TestCompileFilter_InvalidRegex(t *testing.T) {

--- a/pkg/timeline/types.go
+++ b/pkg/timeline/types.go
@@ -217,7 +217,7 @@ func DefaultFilterPresets() map[string]FilterPreset {
 		"workloads": {
 			Name: "workloads",
 			IncludeKinds: []string{
-				"Deployment", "DaemonSet", "StatefulSet", "ReplicaSet",
+				"Deployment", "Rollout", "DaemonSet", "StatefulSet", "ReplicaSet",
 				"Job", "CronJob", "Pod",
 			},
 			IncludeManaged: true,

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -10,6 +10,7 @@ import { CertificateHealthCard } from './CertificateHealthCard'
 import { NetworkPolicyCoverageCard } from './NetworkPolicyCoverageCard'
 import { CostCard } from './CostCard'
 import { GitOpsControllersCard } from './GitOpsControllersCard'
+import { Tooltip } from '../ui/Tooltip'
 import {
   AuditCard,
   FreshnessControl,
@@ -17,6 +18,7 @@ import {
   StatusDot,
   categoryLabel,
   groupLabel,
+  issueTiming,
   subjectRef,
   type Issue,
 } from '@skyhook-io/k8s-ui'
@@ -360,7 +362,7 @@ function ProblemsPanel({
                 {issues.map((issue) => {
                   const ref = subjectRef(issue)
                   const age = issue.first_seen ? formatCompactAge(issue.first_seen) : ''
-                  const startedAtDeploy = issue.issue_timing === 'started_at_resource_creation'
+                  const timing = issueTiming(issue)
 
                   return (
                     <button
@@ -378,10 +380,14 @@ function ProblemsPanel({
                         <div className="flex items-center gap-1.5">
                           <span className="text-[10px] text-theme-text-tertiary bg-theme-elevated px-1 py-0.5 rounded">{issue.kind}</span>
                           <span className="text-xs text-theme-text-primary truncate font-medium">{issue.name}</span>
-                          {(age || startedAtDeploy) && (
+                          {(age || timing) && (
                             <span className="ml-auto flex shrink-0 items-center gap-1">
                               {age && <span className="text-[10px] text-theme-text-tertiary tabular-nums">{age}</span>}
-                              {startedAtDeploy && <span className="badge-sm text-[10px] text-theme-text-secondary">since deploy</span>}
+                              {timing && (
+                                <Tooltip content={timing.tooltip} delay={100}>
+                                  <span className="badge-sm text-[10px] text-theme-text-secondary">{timing.chip}</span>
+                                </Tooltip>
+                              )}
                             </span>
                           )}
                         </div>


### PR DESCRIPTION
## Summary

SKY-1097. This clarifies Radar's existing issue timing signal so active failures are not framed as safe baseline noise, and aligns Argo Rollouts with Radar's deployment-like workload model. Creation-time failures now say whether they are present since deploy or since creation, and after-healthy failures get a visible `after healthy` chip.

## What changed

- Added a shared `issueTiming` helper in `@skyhook-io/k8s-ui` for issue timing display copy.
- Added a shared `isDeploymentLikeWorkloadKind` helper for group-aware deployment-like controller semantics: Deployment, ReplicaSet, StatefulSet, DaemonSet, and Argo Rollout.
- Updated the Issues queue, Home Problems panel, and timeline rollout-event detection to use shared timing/deployment-like semantics.
- Replaced `treat as baseline` and similar copy with neutral timing language:
  - deployment/rollout evidence: `since deploy`
  - non-deployment resource creation evidence: `since creation`
  - previously healthy evidence: `after healthy`
- Aligned Rollout issue metadata with workload semantics:
  - `Rollout` now reports workload `grouping_scope`
  - Rollout-owned generated workloads count under `affected.workloads`
  - `rollout_stalled` catalog copy no longer excludes Rollout
- Added Rollout to existing workload display/classification paths in the timeline workload preset and GitOps tree readiness/ordering.
- No detector, severity, sort, or filter behavior changes.

## Testing

- `make tsc`
- `cd web && node scripts/check-no-native-title.mjs`
- `cd packages/k8s-ui && npm test -- --run src/components/issues/issues.test.ts`
- `go test github.com/skyhook-io/radar/pkg/subject github.com/skyhook-io/radar/pkg/issuesapi github.com/skyhook-io/radar/pkg/timeline github.com/skyhook-io/radar/pkg/gitops/tree`
- `go test github.com/skyhook-io/radar/internal/issues`
- `make test`
- `make build`
- visual-test: skipped; this is a small data-conditional copy/classification change, and the exact rendered labels are pinned by unit tests rather than a live cluster state that is hard to manufacture reliably.

## Notes

Blast radius is issue timing presentation plus Rollout issue metadata visible through API/MCP/UI (`grouping_scope`, affected workload counts, and catalog text). The Rollout metadata change is intentionally additive/corrective; detector output and severity are unchanged. The main residual risk is wording nuance or a consumer relying on the previous `unknown` scope for Rollout rows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and additive Rollout metadata only; detectors, severity, and sort behavior are unchanged. Residual risk is consumers that assumed Rollout had non-workload scope or old timing wording.
> 
> **Overview**
> **Issue timing** is centralized in a new `issueTiming` helper (`@skyhook-io/k8s-ui`), replacing inline `issue_timing` branches in the Issues queue, Home Problems panel, and age tooltips. Copy drops “baseline / safe” framing: creation-time failures show **`since deploy`** vs **`since creation`** (using `issue_timing_basis` for Pods), regressions show an **`after healthy`** chip and neutral tooltips/meta.
> 
> **Argo Rollouts** are aligned with deployment-like workloads via `isDeploymentLikeWorkloadKind`: backend **`Rollout`** gets workload `grouping_scope`, counts in `affected.workloads`, and updated `rollout_stalled` catalog text; timeline rollout detection, workload presets, and GitOps tree readiness/priority include Rollout alongside Deployment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 778f25f23ae93a5f985e5189a222ff0b89990dfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->