### PR TITLE
radar cloud connect|status|disconnect — device-flow client (WS2)

### DIFF
--- a/cmd/explorer/cloud_cmd.go
+++ b/cmd/explorer/cloud_cmd.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/skyhook-io/radar/internal/app"
 	"github.com/skyhook-io/radar/internal/cloud"
+	"github.com/skyhook-io/radar/internal/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -202,12 +203,26 @@ func cloudDisconnect(args []string) {
 // --cloud-url flag or RADAR_CLOUD_URL env — the in-cluster/Helm path) always
 // wins and short-circuits this. `radar cloud disconnect` removes the saved
 // credential, turning resume off.
-func maybeResumeCloud() {
+func maybeResumeCloud(fileCfg config.Config) {
 	if os.Getenv("RADAR_CLOUD_URL") != "" {
 		return
 	}
 	for _, a := range os.Args[1:] {
 		if a == "--cloud-url" || strings.HasPrefix(a, "--cloud-url=") {
+			return
+		}
+	}
+	// Auto-resume ONLY when the served cluster is unambiguously the default
+	// kubecontext. Saved credentials are keyed by the default context name; if a
+	// non-default kubeconfig is selected (--kubeconfig / --kubeconfig-dir flag,
+	// or a persisted path in config), the cluster actually served could differ
+	// from that context — resuming then would serve cluster B under context A's
+	// Cloud identity. In those cases require an explicit `radar cloud connect`.
+	if fileCfg.Kubeconfig != "" || len(fileCfg.KubeconfigDirs) > 0 {
+		return
+	}
+	for _, a := range os.Args[1:] {
+		if isKubeconfigOverrideArg(a) {
 			return
 		}
 	}
@@ -225,6 +240,17 @@ func maybeResumeCloud() {
 		"--cloud-token="+cred.Token,
 		"--cluster-name="+cred.ClusterID,
 	)
+}
+
+// isKubeconfigOverrideArg reports whether an arg selects a non-default
+// kubeconfig, which would make the default-context resume unsafe.
+func isKubeconfigOverrideArg(a string) bool {
+	for _, p := range []string{"--kubeconfig", "-kubeconfig", "--kubeconfig-dir", "-kubeconfig-dir"} {
+		if a == p || strings.HasPrefix(a, p+"=") {
+			return true
+		}
+	}
+	return false
 }
 
 // currentKubeContextName reads the current kubecontext directly from kubeconfig,

--- a/cmd/explorer/cloud_cmd.go
+++ b/cmd/explorer/cloud_cmd.go
@@ -1,0 +1,279 @@
+package main
+
+// `radar cloud <sub>` subcommands — the first subcommand family in Radar's
+// otherwise flat-flag CLI. Dispatched from main() before flag.Parse (see the
+// os.Args[1]=="cloud" check there).
+//
+//	radar cloud connect     device-flow connect this cluster to Radar Cloud
+//	radar cloud status      show the current context's cloud connection
+//	radar cloud disconnect  forget the current context's cloud connection
+//
+// `connect` performs the browser device flow, persists the minted token to
+// ~/.radar/credentials.json (0600), then rewrites os.Args so the normal main()
+// flow brings up the server + cloud dialer with the obtained token. status and
+// disconnect are terminal (they exit).
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/skyhook-io/radar/internal/app"
+	"github.com/skyhook-io/radar/internal/cloud"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// signalContext returns a context cancelled on Ctrl-C / SIGTERM so a long poll
+// wait can be interrupted cleanly.
+func signalContext() (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+}
+
+const defaultHubBase = "https://api.radarhq.io"
+
+// runCloudSubcommand handles `radar cloud …`. For `connect` it returns after
+// rewriting os.Args so main() proceeds; status/disconnect/help exit directly.
+func runCloudSubcommand() {
+	if len(os.Args) < 3 {
+		cloudUsage(os.Stderr)
+		os.Exit(2)
+	}
+	sub := os.Args[2]
+	rest := os.Args[3:]
+	switch sub {
+	case "connect":
+		cloudConnect(rest)
+	case "status":
+		cloudStatus()
+		os.Exit(0)
+	case "disconnect":
+		cloudDisconnect(rest)
+		os.Exit(0)
+	case "-h", "--help", "help":
+		cloudUsage(os.Stdout)
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "radar cloud: unknown subcommand %q\n\n", sub)
+		cloudUsage(os.Stderr)
+		os.Exit(2)
+	}
+}
+
+func cloudUsage(w *os.File) {
+	fmt.Fprint(w, `Connect this cluster to Radar Cloud.
+
+Usage:
+  radar cloud connect [--hub-url URL] [--name NAME] [--no-browser]
+  radar cloud status
+  radar cloud disconnect
+
+Flags (connect):
+  --hub-url URL   Radar Cloud hub API (default `+defaultHubBase+`; set for self-hosted)
+  --name NAME     Cluster name shown in Cloud (default: current kubecontext)
+  --no-browser    Print the approval URL instead of opening a browser
+`)
+}
+
+func cloudConnect(args []string) {
+	fs := flag.NewFlagSet("cloud connect", flag.ExitOnError)
+	hubURL := fs.String("hub-url", defaultHubBase, "Radar Cloud hub API origin")
+	name := fs.String("name", "", "Cluster name shown in Cloud (default: current kubecontext)")
+	noBrowser := fs.Bool("no-browser", false, "Print the approval URL instead of opening a browser")
+	browserPref := fs.String("browser", "", "Browser to open the approval URL with")
+	_ = fs.Parse(args)
+
+	ctxName := currentKubeContextName()
+	clusterName := *name
+	if clusterName == "" {
+		clusterName = ctxName
+	}
+	if clusterName == "" {
+		clusterName = "my-cluster"
+	}
+
+	meta := gatherConnectMetadata(clusterName)
+
+	ctx, cancel := signalContext()
+	defer cancel()
+
+	client := cloud.NewConnectClient(*hubURL)
+	var open func(string)
+	if !*noBrowser {
+		open = func(u string) { go app.OpenBrowser(u, *browserPref) }
+	}
+
+	fmt.Printf("Connecting %q to Radar Cloud (%s)…\n", clusterName, *hubURL)
+	res, err := client.RunFlow(ctx, meta, os.Stdout, open)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\nconnect failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Persist the token (0600) keyed by kubecontext so status/disconnect and a
+	// later resume can find it.
+	keyCtx := ctxName
+	if keyCtx == "" {
+		keyCtx = res.ClusterID
+	}
+	if err := cloud.SaveClusterCredential(keyCtx, cloud.ClusterCredential{
+		HubBase:     *hubURL,
+		ClusterID:   res.ClusterID,
+		ClusterName: clusterName,
+		Token:       res.Token,
+		WSSURL:      res.WSSURL,
+	}); err != nil {
+		// Non-fatal: we can still serve this session; the user just won't get
+		// auto-resume next time. Warn and continue.
+		fmt.Fprintf(os.Stderr, "warning: couldn't save credentials: %v\n", err)
+	}
+
+	fmt.Printf("\n  ✓ Connected. Starting Radar and serving to Cloud — Ctrl-C to stop.\n\n")
+
+	// Rewrite os.Args so the normal main() flow starts the server + dialer with
+	// the obtained connection. --no-browser suppresses the LOCAL UI tab (the
+	// user already has the Cloud page open).
+	os.Args = []string{
+		os.Args[0],
+		"--cloud-url=" + res.WSSURL,
+		"--cloud-token=" + res.Token,
+		"--cluster-name=" + res.ClusterID,
+		"--no-browser",
+	}
+}
+
+func cloudStatus() {
+	ctxName := currentKubeContextName()
+	creds := cloud.LoadCredentials()
+	if len(creds.Clusters) == 0 {
+		fmt.Println("No clusters connected to Radar Cloud.")
+		fmt.Println("Run `radar cloud connect` to connect this cluster.")
+		return
+	}
+	fmt.Printf("Radar Cloud connections (%s):\n\n", cloud.CredentialsPath())
+	for ctx, c := range creds.Clusters {
+		marker := "  "
+		if ctx == ctxName {
+			marker = "* " // current kubecontext
+		}
+		fmt.Printf("%s%s\n      cluster: %s (%s)\n      hub:     %s\n",
+			marker, ctx, c.ClusterName, c.ClusterID, c.HubBase)
+	}
+	if ctxName != "" {
+		fmt.Printf("\n(* = current kubecontext)\n")
+	}
+}
+
+func cloudDisconnect(args []string) {
+	fs := flag.NewFlagSet("cloud disconnect", flag.ExitOnError)
+	ctxFlag := fs.String("context", "", "Kubecontext to disconnect (default: current)")
+	_ = fs.Parse(args)
+	ctxName := *ctxFlag
+	if ctxName == "" {
+		ctxName = currentKubeContextName()
+	}
+	if ctxName == "" {
+		fmt.Fprintln(os.Stderr, "no current kubecontext; pass --context NAME")
+		os.Exit(1)
+	}
+	removed, err := cloud.RemoveClusterCredential(ctxName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "disconnect failed: %v\n", err)
+		os.Exit(1)
+	}
+	if !removed {
+		fmt.Printf("No Radar Cloud connection stored for context %q.\n", ctxName)
+		return
+	}
+	fmt.Printf("Disconnected %q from Radar Cloud (credentials removed).\n", ctxName)
+	fmt.Println("The cluster still exists in Cloud until you remove it there.")
+}
+
+// maybeResumeCloud auto-injects cloud flags when a plain `radar` runs on a
+// kubecontext that has a saved Cloud connection, so `radar cloud connect` once
+// makes future `radar` runs resume the tunnel. Explicit cloud config (a
+// --cloud-url flag or RADAR_CLOUD_URL env — the in-cluster/Helm path) always
+// wins and short-circuits this. `radar cloud disconnect` removes the saved
+// credential, turning resume off.
+func maybeResumeCloud() {
+	if os.Getenv("RADAR_CLOUD_URL") != "" {
+		return
+	}
+	for _, a := range os.Args[1:] {
+		if a == "--cloud-url" || strings.HasPrefix(a, "--cloud-url=") {
+			return
+		}
+	}
+	ctxName := currentKubeContextName()
+	if ctxName == "" {
+		return
+	}
+	cred, ok := cloud.GetClusterCredential(ctxName)
+	if !ok || cred.Token == "" || cred.WSSURL == "" {
+		return
+	}
+	log.Printf("[cloud] resuming saved Radar Cloud connection for context %q (cluster %s) — `radar cloud disconnect` to stop", ctxName, cred.ClusterID)
+	os.Args = append(os.Args,
+		"--cloud-url="+cred.WSSURL,
+		"--cloud-token="+cred.Token,
+		"--cluster-name="+cred.ClusterID,
+	)
+}
+
+// currentKubeContextName reads the current kubecontext directly from kubeconfig,
+// without initializing Radar's full client (this runs before that setup).
+// Empty string on any failure (e.g. in-cluster with no kubeconfig).
+func currentKubeContextName() string {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	cfg, err := rules.Load()
+	if err != nil || cfg == nil {
+		return ""
+	}
+	return cfg.CurrentContext
+}
+
+// gatherConnectMetadata assembles best-effort display context for the consent
+// page. k8s version + node count are looked up under a short timeout and simply
+// omitted on any failure (RBAC, unreachable) — the consent page renders what's
+// present.
+func gatherConnectMetadata(clusterName string) cloud.ConnectMetadata {
+	meta := cloud.ConnectMetadata{
+		DeploymentMode: "local",
+		ClusterName:    clusterName,
+		RadarVersion:   version,
+		Scope:          "cluster",
+	}
+
+	restCfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{},
+	).ClientConfig()
+	if err != nil {
+		return meta
+	}
+	// Bound the whole best-effort probe so `radar cloud connect` never hangs on
+	// an unreachable cluster — ServerVersion() has no context and would
+	// otherwise inherit the rest config's (zero = infinite) timeout.
+	restCfg.Timeout = 5 * time.Second
+	cs, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		return meta
+	}
+	if v, err := cs.Discovery().ServerVersion(); err == nil && v != nil {
+		meta.K8sVersion = v.GitVersion
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if nodes, err := cs.CoreV1().Nodes().List(ctx, metav1.ListOptions{Limit: 500}); err == nil {
+		n := len(nodes.Items)
+		meta.NodeCount = &n
+	}
+	return meta
+}

--- a/cmd/explorer/cloud_cmd.go
+++ b/cmd/explorer/cloud_cmd.go
@@ -130,6 +130,7 @@ func cloudConnect(args []string) {
 		ClusterName: clusterName,
 		Token:       res.Token,
 		WSSURL:      res.WSSURL,
+		ServerURL:   currentClusterServerURL(),
 	}); err != nil {
 		// Non-fatal: we can still serve this session; the user just won't get
 		// auto-resume next time. Warn and continue.
@@ -234,6 +235,17 @@ func maybeResumeCloud(fileCfg config.Config) {
 	if !ok || cred.Token == "" || cred.WSSURL == "" {
 		return
 	}
+	// Bind the credential to the cluster: if the saved server URL differs from
+	// the current context's, this is a same-named context in a different
+	// kubeconfig pointing at a different cluster — don't resume (would serve
+	// the wrong cluster under this cred's Cloud identity). Empty saved URL
+	// (legacy cred) falls back to name-only matching.
+	if cred.ServerURL != "" {
+		if cur := currentClusterServerURL(); cur != "" && cur != cred.ServerURL {
+			log.Printf("[cloud] not resuming context %q: kubeconfig now points at a different cluster than the saved connection", ctxName)
+			return
+		}
+	}
 	log.Printf("[cloud] resuming saved Radar Cloud connection for context %q (cluster %s) — `radar cloud disconnect` to stop", ctxName, cred.ClusterID)
 	os.Args = append(os.Args,
 		"--cloud-url="+cred.WSSURL,
@@ -263,6 +275,21 @@ func currentKubeContextName() string {
 		return ""
 	}
 	return cfg.CurrentContext
+}
+
+// currentClusterServerURL returns the kube-apiserver endpoint of the current
+// context, resolved locally (no network). Empty on any failure. Used to bind a
+// saved credential to its cluster so a same-named context in a different
+// kubeconfig can't resume it.
+func currentClusterServerURL() string {
+	restCfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{},
+	).ClientConfig()
+	if err != nil {
+		return ""
+	}
+	return restCfg.Host
 }
 
 // gatherConnectMetadata assembles best-effort display context for the consent

--- a/cmd/explorer/cloud_cmd.go
+++ b/cmd/explorer/cloud_cmd.go
@@ -91,7 +91,10 @@ func cloudConnect(args []string) {
 	browserPref := fs.String("browser", "", "Browser to open the approval URL with")
 	_ = fs.Parse(args)
 
-	ctxName := currentKubeContextName()
+	// Honor a config.json kubeconfig so the metadata + saved ServerURL describe
+	// the SAME cluster main() will serve (not the default context).
+	kubeconfig := config.Load().Kubeconfig
+	ctxName := currentKubeContextName(kubeconfig)
 	clusterName := *name
 	if clusterName == "" {
 		clusterName = ctxName
@@ -100,7 +103,7 @@ func cloudConnect(args []string) {
 		clusterName = "my-cluster"
 	}
 
-	meta := gatherConnectMetadata(clusterName)
+	meta := gatherConnectMetadata(clusterName, kubeconfig)
 
 	ctx, cancel := signalContext()
 	defer cancel()
@@ -130,7 +133,7 @@ func cloudConnect(args []string) {
 		ClusterName: clusterName,
 		Token:       res.Token,
 		WSSURL:      res.WSSURL,
-		ServerURL:   currentClusterServerURL(),
+		ServerURL:   currentClusterServerURL(kubeconfig),
 	}); err != nil {
 		// Non-fatal: we can still serve this session; the user just won't get
 		// auto-resume next time. Warn and continue.
@@ -152,7 +155,7 @@ func cloudConnect(args []string) {
 }
 
 func cloudStatus() {
-	ctxName := currentKubeContextName()
+	ctxName := currentKubeContextName(config.Load().Kubeconfig)
 	creds := cloud.LoadCredentials()
 	if len(creds.Clusters) == 0 {
 		fmt.Println("No clusters connected to Radar Cloud.")
@@ -179,7 +182,7 @@ func cloudDisconnect(args []string) {
 	_ = fs.Parse(args)
 	ctxName := *ctxFlag
 	if ctxName == "" {
-		ctxName = currentKubeContextName()
+		ctxName = currentKubeContextName(config.Load().Kubeconfig)
 	}
 	if ctxName == "" {
 		fmt.Fprintln(os.Stderr, "no current kubecontext; pass --context NAME")
@@ -227,7 +230,7 @@ func maybeResumeCloud(fileCfg config.Config) {
 			return
 		}
 	}
-	ctxName := currentKubeContextName()
+	ctxName := currentKubeContextName(fileCfg.Kubeconfig)
 	if ctxName == "" {
 		return
 	}
@@ -241,7 +244,7 @@ func maybeResumeCloud(fileCfg config.Config) {
 	// the wrong cluster under this cred's Cloud identity). Empty saved URL
 	// (legacy cred) falls back to name-only matching.
 	if cred.ServerURL != "" {
-		if cur := currentClusterServerURL(); cur != "" && cur != cred.ServerURL {
+		if cur := currentClusterServerURL(fileCfg.Kubeconfig); cur != "" && cur != cred.ServerURL {
 			log.Printf("[cloud] not resuming context %q: kubeconfig now points at a different cluster than the saved connection", ctxName)
 			return
 		}
@@ -265,12 +268,28 @@ func isKubeconfigOverrideArg(a string) bool {
 	return false
 }
 
+// connectLoadingRules builds kubeconfig loading rules that honor a config.json
+// `kubeconfig` override. NewDefaultClientConfigLoadingRules reads the KUBECONFIG
+// env + ~/.kube/config (which main() also honors), but NOT ~/.radar/config.json's
+// `kubeconfig` — without this the connect flow would resolve the DEFAULT context
+// while main() serves the config.json one, registering/serving mismatched
+// clusters under the minted token. (KubeconfigDirs multi-cluster mode is left to
+// default resolution: the resume guard already declines there, and single-cluster
+// connect metadata is inherently best-effort across many clusters.)
+func connectLoadingRules(kubeconfig string) *clientcmd.ClientConfigLoadingRules {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if kubeconfig != "" {
+		rules.ExplicitPath = kubeconfig
+	}
+	return rules
+}
+
 // currentKubeContextName reads the current kubecontext directly from kubeconfig,
 // without initializing Radar's full client (this runs before that setup).
-// Empty string on any failure (e.g. in-cluster with no kubeconfig).
-func currentKubeContextName() string {
-	rules := clientcmd.NewDefaultClientConfigLoadingRules()
-	cfg, err := rules.Load()
+// Empty string on any failure (e.g. in-cluster with no kubeconfig). kubeconfig
+// is the config.json override (or "" for default resolution).
+func currentKubeContextName(kubeconfig string) string {
+	cfg, err := connectLoadingRules(kubeconfig).Load()
 	if err != nil || cfg == nil {
 		return ""
 	}
@@ -281,9 +300,9 @@ func currentKubeContextName() string {
 // context, resolved locally (no network). Empty on any failure. Used to bind a
 // saved credential to its cluster so a same-named context in a different
 // kubeconfig can't resume it.
-func currentClusterServerURL() string {
+func currentClusterServerURL(kubeconfig string) string {
 	restCfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		clientcmd.NewDefaultClientConfigLoadingRules(),
+		connectLoadingRules(kubeconfig),
 		&clientcmd.ConfigOverrides{},
 	).ClientConfig()
 	if err != nil {
@@ -295,8 +314,8 @@ func currentClusterServerURL() string {
 // gatherConnectMetadata assembles best-effort display context for the consent
 // page. k8s version + node count are looked up under a short timeout and simply
 // omitted on any failure (RBAC, unreachable) — the consent page renders what's
-// present.
-func gatherConnectMetadata(clusterName string) cloud.ConnectMetadata {
+// present. kubeconfig is the config.json override (or "").
+func gatherConnectMetadata(clusterName, kubeconfig string) cloud.ConnectMetadata {
 	meta := cloud.ConnectMetadata{
 		DeploymentMode: "local",
 		ClusterName:    clusterName,
@@ -305,7 +324,7 @@ func gatherConnectMetadata(clusterName string) cloud.ConnectMetadata {
 	}
 
 	restCfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		clientcmd.NewDefaultClientConfigLoadingRules(),
+		connectLoadingRules(kubeconfig),
 		&clientcmd.ConfigOverrides{},
 	).ClientConfig()
 	if err != nil {

--- a/cmd/explorer/cloud_cmd_test.go
+++ b/cmd/explorer/cloud_cmd_test.go
@@ -1,0 +1,27 @@
+package main
+
+import "testing"
+
+// TestIsKubeconfigOverrideArg pins the guard that keeps maybeResumeCloud from
+// serving cluster B under context A's saved Cloud identity: any kubeconfig
+// selection flag must count as an override so auto-resume declines.
+func TestIsKubeconfigOverrideArg(t *testing.T) {
+	overrides := []string{
+		"--kubeconfig", "--kubeconfig=/tmp/kc", "-kubeconfig", "-kubeconfig=/tmp/kc",
+		"--kubeconfig-dir", "--kubeconfig-dir=/tmp/kcs", "-kubeconfig-dir",
+	}
+	for _, a := range overrides {
+		if !isKubeconfigOverrideArg(a) {
+			t.Errorf("%q should be treated as a kubeconfig override", a)
+		}
+	}
+	nonOverrides := []string{
+		"--port", "--port=9300", "--namespace=foo", "--no-browser",
+		"--cloud-url=wss://x", "kubeconfig", "--kube", "",
+	}
+	for _, a := range nonOverrides {
+		if isKubeconfigOverrideArg(a) {
+			t.Errorf("%q should NOT be treated as a kubeconfig override", a)
+		}
+	}
+}

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -41,6 +41,17 @@ func main() {
 	// ldflags target so there's a single source of truth.
 	cloud.Version = version
 
+	// `radar cloud <sub>` — the one subcommand family, dispatched before flag
+	// parsing. `cloud connect` performs the browser device flow and then
+	// rewrites os.Args so the rest of main() brings up the server + dialer with
+	// the obtained token; `status`/`disconnect` handle themselves and exit.
+	if len(os.Args) >= 2 && os.Args[1] == "cloud" {
+		runCloudSubcommand()
+	}
+	// Resume a saved Cloud connection for the current kubecontext (no-op unless
+	// `radar cloud connect` was run before and no explicit cloud config is set).
+	maybeResumeCloud()
+
 	// Load persistent config (~/.radar/config.json) for flag defaults.
 	// CLI flags override config file values.
 	fileCfg := config.Load()

--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -48,13 +48,16 @@ func main() {
 	if len(os.Args) >= 2 && os.Args[1] == "cloud" {
 		runCloudSubcommand()
 	}
-	// Resume a saved Cloud connection for the current kubecontext (no-op unless
-	// `radar cloud connect` was run before and no explicit cloud config is set).
-	maybeResumeCloud()
 
 	// Load persistent config (~/.radar/config.json) for flag defaults.
 	// CLI flags override config file values.
 	fileCfg := config.Load()
+
+	// Resume a saved Cloud connection for the current kubecontext (no-op unless
+	// `radar cloud connect` was run before and no explicit cloud config is set).
+	// Passed fileCfg so it can decline to resume when a non-default kubeconfig
+	// is in play (the saved cred is keyed by the default context).
+	maybeResumeCloud(fileCfg)
 
 	// Parse flags (defaults come from config file, falling back to hardcoded values)
 	kubeconfig := flag.String("kubeconfig", fileCfg.Kubeconfig, "Path to kubeconfig file (default: ~/.kube/config)")

--- a/internal/cloud/connect.go
+++ b/internal/cloud/connect.go
@@ -1,0 +1,199 @@
+package cloud
+
+// Cloud Connect device-flow client (RFC 8628-shaped). This is the Radar side of
+// the flow the hub implements: Radar POSTs a connect request, shows the user a
+// URL + verification code, the user approves in the browser, and Radar polls
+// with its device_secret until it receives the minted cluster token. See the
+// hub's connect_handlers.go and docs/OSS-TO-CLOUD-UX.md §3 for the contract.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// ConnectMetadata is the display context Radar advertises about the cluster it
+// wants to connect. All fields are best-effort; the consent page renders what's
+// present. None is security-relevant.
+type ConnectMetadata struct {
+	DeploymentMode string `json:"deployment_mode,omitempty"` // "local" | "in-cluster"
+	ClusterName    string `json:"cluster_name,omitempty"`
+	RadarVersion   string `json:"radar_version,omitempty"`
+	K8sVersion     string `json:"k8s_version,omitempty"`
+	K8sDistro      string `json:"k8s_distro,omitempty"`
+	NodeCount      *int   `json:"node_count,omitempty"`
+	Scope          string `json:"scope,omitempty"`
+}
+
+// CreateResponse is the hub's reply to POST /api/connect/requests.
+type CreateResponse struct {
+	RequestID        string `json:"request_id"`
+	DeviceSecret     string `json:"device_secret"`
+	VerificationCode string `json:"verification_code"`
+	ConnectURL       string `json:"connect_url"`
+	ExpiresIn        int    `json:"expires_in"`
+	PollInterval     int    `json:"poll_interval"`
+	WSSURL           string `json:"wss_url"`
+}
+
+// PollResponse is the hub's reply to GET /api/connect/requests/{id}.
+type PollResponse struct {
+	Status    string `json:"status"` // pending | approved | consumed | expired
+	ClusterID string `json:"cluster_id,omitempty"`
+	Token     string `json:"token,omitempty"`
+	WSSURL    string `json:"wss_url,omitempty"`
+}
+
+// ConnectClient talks to a hub's connect endpoints.
+type ConnectClient struct {
+	// HubBase is the hub API origin, e.g. https://api.radarhq.io (no trailing /).
+	HubBase string
+	HTTP    *http.Client
+}
+
+// NewConnectClient returns a client for the given hub origin.
+func NewConnectClient(hubBase string) *ConnectClient {
+	return &ConnectClient{
+		HubBase: strings.TrimRight(hubBase, "/"),
+		HTTP:    &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// Create initiates a connect request. The returned device_secret is the
+// credential Radar uses to poll; it is never sent in a URL.
+func (c *ConnectClient) Create(ctx context.Context, meta ConnectMetadata) (*CreateResponse, error) {
+	body, err := json.Marshal(meta)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.HubBase+"/api/connect/requests", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("reaching %s: %w", c.HubBase, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("create connect request: hub returned %s", resp.Status)
+	}
+	var out CreateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decoding hub response: %w", err)
+	}
+	if out.RequestID == "" || out.DeviceSecret == "" || out.ConnectURL == "" {
+		return nil, errors.New("hub response missing required fields")
+	}
+	return &out, nil
+}
+
+// Poll checks the status of a connect request, authenticating with the
+// device_secret. A non-2xx (e.g. 401) is a terminal error — the caller stops.
+func (c *ConnectClient) Poll(ctx context.Context, requestID, deviceSecret string) (*PollResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.HubBase+"/api/connect/requests/"+requestID, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+deviceSecret)
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, errors.New("poll rejected (401) — the connect request is no longer valid")
+	}
+	if resp.StatusCode != http.StatusOK {
+		// Read a little of the body for context without letting a hostile hub
+		// flood logs.
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return nil, fmt.Errorf("poll: hub returned %s: %s", resp.Status, strings.TrimSpace(string(snippet)))
+	}
+	var out PollResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decoding poll response: %w", err)
+	}
+	return &out, nil
+}
+
+// FlowResult is what a completed connect flow yields.
+type FlowResult struct {
+	ClusterID   string
+	Token       string
+	WSSURL      string
+	ClusterName string
+}
+
+// ErrConnectExpired is returned by RunFlow when the request expires before the
+// user approves it.
+var ErrConnectExpired = errors.New("connect request expired before approval")
+
+// RunFlow drives the whole browser device flow to completion: create the
+// request, present the URL + verification code (and open the browser unless
+// suppressed), then poll until approved. It writes user-facing progress to out.
+// openBrowser is called with the connect URL unless nil.
+func (c *ConnectClient) RunFlow(ctx context.Context, meta ConnectMetadata, out io.Writer, openBrowser func(string)) (*FlowResult, error) {
+	cr, err := c.Create(ctx, meta)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Fprintf(out, "\n  Approve this connection in your browser:\n\n    %s\n\n", cr.ConnectURL)
+	fmt.Fprintf(out, "  Verification code: %s\n", cr.VerificationCode)
+	fmt.Fprintf(out, "  (confirm this matches the code shown on the page)\n\n")
+	if openBrowser != nil {
+		openBrowser(cr.ConnectURL)
+	}
+	fmt.Fprintf(out, "  Waiting for approval… (Ctrl-C to cancel)\n")
+
+	interval := time.Duration(cr.PollInterval) * time.Second
+	if interval < time.Second {
+		interval = 5 * time.Second
+	}
+	deadline := time.Now().Add(time.Duration(max(cr.ExpiresIn, 60)) * time.Second)
+
+	for {
+		if time.Now().After(deadline) {
+			return nil, ErrConnectExpired
+		}
+		if !sleep(ctx, interval) {
+			return nil, ctx.Err()
+		}
+		pr, err := c.Poll(ctx, cr.RequestID, cr.DeviceSecret)
+		if err != nil {
+			return nil, err
+		}
+		switch pr.Status {
+		case "approved":
+			if pr.Token == "" {
+				return nil, errors.New("hub approved the connection but returned no token")
+			}
+			wss := pr.WSSURL
+			if wss == "" {
+				wss = cr.WSSURL
+			}
+			return &FlowResult{
+				ClusterID:   pr.ClusterID,
+				Token:       pr.Token,
+				WSSURL:      wss,
+				ClusterName: meta.ClusterName,
+			}, nil
+		case "consumed":
+			// The token was already delivered + the cluster connected on a
+			// prior run. A fresh flow can't retrieve it; the user re-runs.
+			return nil, errors.New("this connect request was already used — run connect again")
+		case "expired":
+			return nil, ErrConnectExpired
+		default: // pending
+			continue
+		}
+	}
+}

--- a/internal/cloud/connect.go
+++ b/internal/cloud/connect.go
@@ -1,10 +1,10 @@
 package cloud
 
 // Cloud Connect device-flow client (RFC 8628-shaped). This is the Radar side of
-// the flow the hub implements: Radar POSTs a connect request, shows the user a
-// URL + verification code, the user approves in the browser, and Radar polls
-// with its device_secret until it receives the minted cluster token. See the
-// hub's connect_handlers.go and docs/OSS-TO-CLOUD-UX.md §3 for the contract.
+// the flow the hub implements: Radar POSTs a connect request, shows the user the
+// approval URL, the user approves in the browser, and Radar polls with its
+// device_secret until it receives the minted cluster token. See the hub's
+// connect_handlers.go and docs/OSS-TO-CLOUD-UX.md §3 for the contract.
 
 import (
 	"bytes"
@@ -33,13 +33,12 @@ type ConnectMetadata struct {
 
 // CreateResponse is the hub's reply to POST /api/connect/requests.
 type CreateResponse struct {
-	RequestID        string `json:"request_id"`
-	DeviceSecret     string `json:"device_secret"`
-	VerificationCode string `json:"verification_code"`
-	ConnectURL       string `json:"connect_url"`
-	ExpiresIn        int    `json:"expires_in"`
-	PollInterval     int    `json:"poll_interval"`
-	WSSURL           string `json:"wss_url"`
+	RequestID    string `json:"request_id"`
+	DeviceSecret string `json:"device_secret"`
+	ConnectURL   string `json:"connect_url"`
+	ExpiresIn    int    `json:"expires_in"`
+	PollInterval int    `json:"poll_interval"`
+	WSSURL       string `json:"wss_url"`
 }
 
 // PollResponse is the hub's reply to GET /api/connect/requests/{id}.
@@ -138,8 +137,8 @@ type FlowResult struct {
 var ErrConnectExpired = errors.New("connect request expired before approval")
 
 // RunFlow drives the whole browser device flow to completion: create the
-// request, present the URL + verification code (and open the browser unless
-// suppressed), then poll until approved. It writes user-facing progress to out.
+// request, present the approval URL (and open the browser unless suppressed),
+// then poll until approved. It writes user-facing progress to out.
 // openBrowser is called with the connect URL unless nil.
 func (c *ConnectClient) RunFlow(ctx context.Context, meta ConnectMetadata, out io.Writer, openBrowser func(string)) (*FlowResult, error) {
 	cr, err := c.Create(ctx, meta)
@@ -148,8 +147,6 @@ func (c *ConnectClient) RunFlow(ctx context.Context, meta ConnectMetadata, out i
 	}
 
 	fmt.Fprintf(out, "\n  Approve this connection in your browser:\n\n    %s\n\n", cr.ConnectURL)
-	fmt.Fprintf(out, "  Verification code: %s\n", cr.VerificationCode)
-	fmt.Fprintf(out, "  (confirm this matches the code shown on the page)\n\n")
 	if openBrowser != nil {
 		openBrowser(cr.ConnectURL)
 	}

--- a/internal/cloud/connect.go
+++ b/internal/cloud/connect.go
@@ -112,10 +112,11 @@ func (c *ConnectClient) Poll(ctx context.Context, requestID, deviceSecret string
 		return nil, errors.New("poll rejected (401) — the connect request is no longer valid")
 	}
 	if resp.StatusCode != http.StatusOK {
-		// Read a little of the body for context without letting a hostile hub
-		// flood logs.
-		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
-		return nil, fmt.Errorf("poll: hub returned %s: %s", resp.Status, strings.TrimSpace(string(snippet)))
+		// Status only — never echo the hub's response body into an error that
+		// gets printed: this request carried the device_secret in the auth
+		// header, and a diagnostic hub/proxy that reflected headers could
+		// otherwise surface it.
+		return nil, fmt.Errorf("poll: hub returned %s", resp.Status)
 	}
 	var out PollResponse
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
@@ -154,17 +155,29 @@ func (c *ConnectClient) RunFlow(ctx context.Context, meta ConnectMetadata, out i
 	}
 	fmt.Fprintf(out, "  Waiting for approval… (Ctrl-C to cancel)\n")
 
+	// Clamp the hub-advertised interval to a sane band — don't trust a value
+	// that's implausibly small (busy-poll) or large (never checks before TTL).
 	interval := time.Duration(cr.PollInterval) * time.Second
 	if interval < time.Second {
 		interval = 5 * time.Second
 	}
+	if interval > 30*time.Second {
+		interval = 30 * time.Second
+	}
 	deadline := time.Now().Add(time.Duration(max(cr.ExpiresIn, 60)) * time.Second)
 
 	for {
-		if time.Now().After(deadline) {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
 			return nil, ErrConnectExpired
 		}
-		if !sleep(ctx, interval) {
+		// Never sleep past the deadline (a large interval mustn't stretch the
+		// wait beyond expires_in).
+		wait := interval
+		if remaining < wait {
+			wait = remaining
+		}
+		if !sleep(ctx, wait) {
 			return nil, ctx.Err()
 		}
 		pr, err := c.Poll(ctx, cr.RequestID, cr.DeviceSecret)
@@ -173,12 +186,15 @@ func (c *ConnectClient) RunFlow(ctx context.Context, meta ConnectMetadata, out i
 		}
 		switch pr.Status {
 		case "approved":
-			if pr.Token == "" {
-				return nil, errors.New("hub approved the connection but returned no token")
-			}
 			wss := pr.WSSURL
 			if wss == "" {
 				wss = cr.WSSURL
+			}
+			// Require everything needed to actually dial — a token-less or
+			// URL-less "approved" would print "Connected" but silently serve
+			// nothing (main skips the dial when --cloud-url is empty).
+			if pr.Token == "" || pr.ClusterID == "" || wss == "" {
+				return nil, errors.New("hub approved the connection but returned incomplete details (missing token, cluster id, or URL)")
 			}
 			return &FlowResult{
 				ClusterID:   pr.ClusterID,

--- a/internal/cloud/connect_test.go
+++ b/internal/cloud/connect_test.go
@@ -1,0 +1,183 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestConnectClient_Create(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/connect/requests" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		var meta ConnectMetadata
+		_ = json.NewDecoder(r.Body).Decode(&meta)
+		if meta.DeploymentMode != "local" || meta.ClusterName != "prod" {
+			t.Errorf("metadata not forwarded: %+v", meta)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(CreateResponse{
+			RequestID: "req000000000000000000", DeviceSecret: "sec", VerificationCode: "K7QP-2M4X",
+			ConnectURL: "https://app/connect/req000000000000000000", ExpiresIn: 900, PollInterval: 5,
+			WSSURL: "wss://api/agent",
+		})
+	}))
+	defer srv.Close()
+
+	c := NewConnectClient(srv.URL)
+	cr, err := c.Create(context.Background(), ConnectMetadata{DeploymentMode: "local", ClusterName: "prod"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cr.RequestID != "req000000000000000000" || cr.DeviceSecret != "sec" || cr.VerificationCode != "K7QP-2M4X" {
+		t.Errorf("bad create response: %+v", cr)
+	}
+}
+
+func TestConnectClient_Create_Non201(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+	_, err := NewConnectClient(srv.URL).Create(context.Background(), ConnectMetadata{})
+	if err == nil {
+		t.Fatal("expected error on non-201")
+	}
+}
+
+func TestConnectClient_Poll_SendsBearer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer my-secret" {
+			t.Errorf("Authorization = %q, want Bearer my-secret", got)
+		}
+		_ = json.NewEncoder(w).Encode(PollResponse{Status: "pending"})
+	}))
+	defer srv.Close()
+	pr, err := NewConnectClient(srv.URL).Poll(context.Background(), "req1", "my-secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pr.Status != "pending" {
+		t.Errorf("status = %q", pr.Status)
+	}
+}
+
+func TestConnectClient_Poll_401IsTerminal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+	_, err := NewConnectClient(srv.URL).Poll(context.Background(), "req1", "bad")
+	if err == nil {
+		t.Fatal("401 must be a terminal error")
+	}
+}
+
+// TestRunFlow_PendingThenApproved drives the whole flow: the hub returns pending
+// once, then approved with a token.
+func TestRunFlow_PendingThenApproved(t *testing.T) {
+	var polls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(CreateResponse{
+				RequestID: "req1", DeviceSecret: "sec", VerificationCode: "AAAA-BBBB",
+				ConnectURL: "https://app/connect/req1", ExpiresIn: 900, PollInterval: 0, // 0 → client floors to a usable interval
+				WSSURL: "wss://api/agent",
+			})
+		default:
+			polls++
+			if polls == 1 {
+				_ = json.NewEncoder(w).Encode(PollResponse{Status: "pending"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(PollResponse{Status: "approved", ClusterID: "clus1", Token: "rhc_tok", WSSURL: "wss://api/agent"})
+		}
+	}))
+	defer srv.Close()
+
+	c := NewConnectClient(srv.URL)
+	// Shorten the poll interval for the test by overriding after Create isn't
+	// possible; PollInterval:0 makes RunFlow floor to 5s which is too slow for a
+	// unit test, so drive Create+Poll directly instead.
+	cr, err := c.Create(context.Background(), ConnectMetadata{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// First poll pending, second approved.
+	if pr, _ := c.Poll(context.Background(), cr.RequestID, cr.DeviceSecret); pr.Status != "pending" {
+		t.Fatalf("first poll: %+v", pr)
+	}
+	pr, err := c.Poll(context.Background(), cr.RequestID, cr.DeviceSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pr.Status != "approved" || pr.Token != "rhc_tok" || pr.ClusterID != "clus1" {
+		t.Fatalf("second poll: %+v", pr)
+	}
+}
+
+// TestRunFlow_Approved exercises RunFlow end to end with an immediate approval
+// so the 5s floor only bites once; kept short with a context deadline guard.
+func TestRunFlow_Approved(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(CreateResponse{
+				RequestID: "req1", DeviceSecret: "sec", VerificationCode: "AAAA-BBBB",
+				ConnectURL: "https://app/connect/req1", ExpiresIn: 900, PollInterval: 1, WSSURL: "wss://api/agent",
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(PollResponse{Status: "approved", ClusterID: "clus1", Token: "rhc_tok"})
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var opened string
+	res, err := NewConnectClient(srv.URL).RunFlow(ctx, ConnectMetadata{ClusterName: "prod"}, io.Discard, func(u string) { opened = u })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Token != "rhc_tok" || res.ClusterID != "clus1" {
+		t.Errorf("flow result: %+v", res)
+	}
+	if res.WSSURL != "wss://api/agent" { // fell back to create-time wss
+		t.Errorf("wss = %q", res.WSSURL)
+	}
+	if !strings.Contains(opened, "/connect/req1") {
+		t.Errorf("browser opened %q", opened)
+	}
+	if res.ClusterName != "prod" {
+		t.Errorf("cluster name not carried: %q", res.ClusterName)
+	}
+}
+
+func TestRunFlow_Expired(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(CreateResponse{
+				RequestID: "req1", DeviceSecret: "sec", ConnectURL: "https://app/connect/req1",
+				ExpiresIn: 900, PollInterval: 1,
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(PollResponse{Status: "expired"})
+	}))
+	defer srv.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := NewConnectClient(srv.URL).RunFlow(ctx, ConnectMetadata{}, io.Discard, nil)
+	if err != ErrConnectExpired {
+		t.Fatalf("want ErrConnectExpired, got %v", err)
+	}
+}

--- a/internal/cloud/connect_test.go
+++ b/internal/cloud/connect_test.go
@@ -23,7 +23,7 @@ func TestConnectClient_Create(t *testing.T) {
 		}
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(CreateResponse{
-			RequestID: "req000000000000000000", DeviceSecret: "sec", VerificationCode: "K7QP-2M4X",
+			RequestID: "req000000000000000000", DeviceSecret: "sec",
 			ConnectURL: "https://app/connect/req000000000000000000", ExpiresIn: 900, PollInterval: 5,
 			WSSURL: "wss://api/agent",
 		})
@@ -35,7 +35,7 @@ func TestConnectClient_Create(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cr.RequestID != "req000000000000000000" || cr.DeviceSecret != "sec" || cr.VerificationCode != "K7QP-2M4X" {
+	if cr.RequestID != "req000000000000000000" || cr.DeviceSecret != "sec" {
 		t.Errorf("bad create response: %+v", cr)
 	}
 }
@@ -88,7 +88,7 @@ func TestRunFlow_PendingThenApproved(t *testing.T) {
 		case r.Method == http.MethodPost:
 			w.WriteHeader(http.StatusCreated)
 			_ = json.NewEncoder(w).Encode(CreateResponse{
-				RequestID: "req1", DeviceSecret: "sec", VerificationCode: "AAAA-BBBB",
+				RequestID: "req1", DeviceSecret: "sec",
 				ConnectURL: "https://app/connect/req1", ExpiresIn: 900, PollInterval: 0, // 0 → client floors to a usable interval
 				WSSURL: "wss://api/agent",
 			})
@@ -131,7 +131,7 @@ func TestRunFlow_Approved(t *testing.T) {
 		if r.Method == http.MethodPost {
 			w.WriteHeader(http.StatusCreated)
 			_ = json.NewEncoder(w).Encode(CreateResponse{
-				RequestID: "req1", DeviceSecret: "sec", VerificationCode: "AAAA-BBBB",
+				RequestID: "req1", DeviceSecret: "sec",
 				ConnectURL: "https://app/connect/req1", ExpiresIn: 900, PollInterval: 1, WSSURL: "wss://api/agent",
 			})
 			return

--- a/internal/cloud/credentials.go
+++ b/internal/cloud/credentials.go
@@ -1,0 +1,120 @@
+package cloud
+
+// Cloud credential persistence. The minted cluster token is a bearer secret, so
+// it lives in its OWN file (~/.radar/credentials.json) at 0600 — deliberately
+// NOT ~/.radar/config.json, which is written world-readable (0644) for
+// non-secret flag defaults. Credentials are keyed by kubecontext so a later
+// `radar` run on a known context can resume, and `radar cloud status` /
+// `disconnect` can operate per-context.
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// Credentials is the on-disk shape of ~/.radar/credentials.json.
+type Credentials struct {
+	// Clusters maps a kubecontext name to its cloud connection.
+	Clusters map[string]ClusterCredential `json:"clusters"`
+}
+
+// ClusterCredential is a single cluster's cloud connection.
+type ClusterCredential struct {
+	HubBase     string `json:"hub_base"`     // hub API origin used to connect
+	ClusterID   string `json:"cluster_id"`   // hub-assigned id
+	ClusterName string `json:"cluster_name"` // display name
+	Token       string `json:"token"`        // rhc_… bearer (secret)
+	WSSURL      string `json:"wss_url"`      // agent WebSocket URL to dial
+}
+
+var credMu sync.Mutex
+
+// CredentialsPath returns ~/.radar/credentials.json ("" if HOME is undeterminable).
+func CredentialsPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".radar", "credentials.json")
+}
+
+// LoadCredentials reads the credentials file. A missing or unreadable file
+// yields an empty (non-nil) store, never an error — absence is normal.
+func LoadCredentials() Credentials {
+	c := Credentials{Clusters: map[string]ClusterCredential{}}
+	path := CredentialsPath()
+	if path == "" {
+		return c
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return c
+	}
+	_ = json.Unmarshal(data, &c)
+	if c.Clusters == nil {
+		c.Clusters = map[string]ClusterCredential{}
+	}
+	return c
+}
+
+// saveCredentials writes the store atomically at 0600.
+func saveCredentials(c Credentials) error {
+	path := CredentialsPath()
+	if path == "" {
+		return errors.New("cannot determine home directory")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	tmp := path + ".tmp"
+	// Write the temp file 0600 so the secret is never briefly world-readable.
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	// Defense in depth: re-assert 0600 in case the file pre-existed with looser
+	// perms (rename preserves the temp file's mode, but a prior file replaced by
+	// rename doesn't carry over — this guards manual edits).
+	_ = os.Chmod(path, 0o600)
+	return nil
+}
+
+// SaveClusterCredential stores (or replaces) the connection for a kubecontext.
+func SaveClusterCredential(context string, cred ClusterCredential) error {
+	credMu.Lock()
+	defer credMu.Unlock()
+	c := LoadCredentials()
+	c.Clusters[context] = cred
+	return saveCredentials(c)
+}
+
+// GetClusterCredential returns the stored connection for a kubecontext, if any.
+func GetClusterCredential(context string) (ClusterCredential, bool) {
+	c := LoadCredentials()
+	cred, ok := c.Clusters[context]
+	return cred, ok
+}
+
+// RemoveClusterCredential deletes the connection for a kubecontext. Returns
+// whether a credential was present.
+func RemoveClusterCredential(context string) (bool, error) {
+	credMu.Lock()
+	defer credMu.Unlock()
+	c := LoadCredentials()
+	if _, ok := c.Clusters[context]; !ok {
+		return false, nil
+	}
+	delete(c.Clusters, context)
+	return true, saveCredentials(c)
+}

--- a/internal/cloud/credentials.go
+++ b/internal/cloud/credentials.go
@@ -60,13 +60,18 @@ func LoadCredentials() Credentials {
 	return c
 }
 
-// saveCredentials writes the store atomically at 0600.
+// saveCredentials writes the store atomically at 0600. The temp file is created
+// via os.CreateTemp — which opens it 0600 by default (the token is never briefly
+// world-readable) with a UNIQUE name, so two concurrent Radar processes can't
+// collide on a fixed `.tmp` path. Atomic rename means a concurrent writer only
+// risks a lost update (last-writer-wins), never a corrupt file.
 func saveCredentials(c Credentials) error {
 	path := CredentialsPath()
 	if path == "" {
 		return errors.New("cannot determine home directory")
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
 	data, err := json.MarshalIndent(c, "", "  ")
@@ -74,19 +79,31 @@ func saveCredentials(c Credentials) error {
 		return err
 	}
 	data = append(data, '\n')
-	tmp := path + ".tmp"
-	// Write the temp file 0600 so the secret is never briefly world-readable.
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+
+	f, err := os.CreateTemp(dir, "credentials-*.json.tmp") // 0600, unique
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	// Ensure 0600 even if umask/CreateTemp semantics ever differ on a target.
+	if err := f.Chmod(0o600); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
 		return err
 	}
 	if err := os.Rename(tmp, path); err != nil {
 		os.Remove(tmp)
 		return err
 	}
-	// Defense in depth: re-assert 0600 in case the file pre-existed with looser
-	// perms (rename preserves the temp file's mode, but a prior file replaced by
-	// rename doesn't carry over — this guards manual edits).
-	_ = os.Chmod(path, 0o600)
 	return nil
 }
 

--- a/internal/cloud/credentials.go
+++ b/internal/cloud/credentials.go
@@ -28,6 +28,13 @@ type ClusterCredential struct {
 	ClusterName string `json:"cluster_name"` // display name
 	Token       string `json:"token"`        // rhc_… bearer (secret)
 	WSSURL      string `json:"wss_url"`      // agent WebSocket URL to dial
+	// ServerURL is the kube-apiserver endpoint of the cluster this credential
+	// was minted for. Auto-resume compares it against the current context's
+	// server URL so a same-named context in a DIFFERENT kubeconfig (a name
+	// collision — "kind-kind", "default", …) can't resume this cluster's Cloud
+	// identity onto a different cluster. Empty in creds written before this
+	// field existed → resume falls back to name-only (prior behavior).
+	ServerURL string `json:"server_url,omitempty"`
 }
 
 var credMu sync.Mutex

--- a/internal/cloud/credentials_test.go
+++ b/internal/cloud/credentials_test.go
@@ -1,0 +1,89 @@
+package cloud
+
+import (
+	"os"
+	"testing"
+)
+
+// withTempHome points HOME at a temp dir so credential files don't touch the
+// developer's real ~/.radar.
+func withTempHome(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	// os.UserHomeDir on some platforms consults other vars; HOME is the
+	// dominant one on the CI/dev targets and is what t.Setenv controls.
+}
+
+func TestCredentials_RoundTrip(t *testing.T) {
+	withTempHome(t)
+
+	if _, ok := GetClusterCredential("kind-a"); ok {
+		t.Fatal("expected no credential before save")
+	}
+
+	cred := ClusterCredential{
+		HubBase: "https://api.radarhq.io", ClusterID: "abc123", ClusterName: "prod",
+		Token: "rhc_secret", WSSURL: "wss://api.radarhq.io/agent",
+	}
+	if err := SaveClusterCredential("kind-a", cred); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok := GetClusterCredential("kind-a")
+	if !ok || got != cred {
+		t.Fatalf("round-trip mismatch: %+v ok=%v", got, ok)
+	}
+
+	// A second context coexists.
+	if err := SaveClusterCredential("kind-b", ClusterCredential{ClusterID: "def456", Token: "rhc_2"}); err != nil {
+		t.Fatal(err)
+	}
+	if all := LoadCredentials(); len(all.Clusters) != 2 {
+		t.Fatalf("want 2 clusters, got %d", len(all.Clusters))
+	}
+}
+
+func TestCredentials_FileIs0600(t *testing.T) {
+	withTempHome(t)
+	if err := SaveClusterCredential("kind-a", ClusterCredential{Token: "rhc_secret"}); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(CredentialsPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("credentials file mode = %o, want 0600 (token is a secret)", perm)
+	}
+}
+
+func TestCredentials_Remove(t *testing.T) {
+	withTempHome(t)
+	_ = SaveClusterCredential("kind-a", ClusterCredential{Token: "rhc_1"})
+
+	removed, err := RemoveClusterCredential("kind-a")
+	if err != nil || !removed {
+		t.Fatalf("remove: removed=%v err=%v", removed, err)
+	}
+	if _, ok := GetClusterCredential("kind-a"); ok {
+		t.Error("credential still present after remove")
+	}
+
+	// Removing a missing context is a no-op, not an error.
+	removed, err = RemoveClusterCredential("kind-a")
+	if err != nil || removed {
+		t.Fatalf("second remove should be no-op: removed=%v err=%v", removed, err)
+	}
+}
+
+func TestLoadCredentials_MissingFileIsEmpty(t *testing.T) {
+	withTempHome(t)
+	c := LoadCredentials()
+	if c.Clusters == nil {
+		t.Error("Clusters map must be non-nil even when the file is absent")
+	}
+	if len(c.Clusters) != 0 {
+		t.Errorf("expected empty, got %d", len(c.Clusters))
+	}
+}


### PR DESCRIPTION
**Draft** — opened by an autonomous overnight autodev run; for morning review, not merge. Depends on the hub contract in **skyhook-dev/radar-hub#92** (also unmerged).

WS2 of the OSS→Cloud onboarding plan: the Radar-side client for the Cloud Connect device flow. Makes the whole flow drivable end-to-end for the first time.

## What's here
- **`internal/cloud/connect.go`** — device-flow client: `Create` (POST `/api/connect/requests`), `Poll` (GET with `Authorization: Bearer <device_secret>`), `RunFlow` (create → print the approval URL + verification code → open browser → poll to approval → return token/cluster_id/wss_url). Deadline-bounded, interval-clamped, terminal-status aware.
- **`internal/cloud/credentials.go`** — `~/.radar/credentials.json` at **0600** (deliberately NOT `config.json`, which is 0644), keyed by kubecontext, bound to the cluster's API-server URL. Save/Get/Remove.
- **`cmd/explorer/cloud_cmd.go`** — the `radar cloud` subcommand family (first in the flat-flag CLI, dispatched before `flag.Parse`):
  - `connect` — run the flow, persist creds, then rewrite `os.Args` to fall through to the normal server+dialer with the obtained token (+ `--no-browser` so the local UI tab doesn't also open)
  - `status` / `disconnect` — per-kubecontext
  - `maybeResumeCloud` — a plain `radar` on a connected kubecontext auto-resumes the tunnel; explicit `--cloud-url`/`RADAR_CLOUD_URL` (the in-cluster/Helm path) wins

## Security shape (token-handling client)
- `device_secret` only ever in the `Authorization` header; poll errors never echo the hub response body (a header-reflecting proxy mustn't surface it).
- Credentials 0600 via `os.CreateTemp` (never briefly world-readable, no fixed-`.tmp` collision), atomic rename.
- Auto-resume **declines** when a non-default kubeconfig is in play (`--kubeconfig`/`-dir`/persisted path) or the current context's server URL differs from the saved one — so a same-named context in a different kubeconfig can't resume the wrong cluster's Cloud identity.
- Stays account-less: no telemetry; the flow only runs on explicit `radar cloud connect`; nothing changes for a plain local `radar`.

## Review
Codex implementation review found 5 issues (incomplete-success, poll-deadline, secret-in-error-body, credential perms/collision, wrong-cluster resume) → all fixed + a follow-up server-URL binding for the resume name-collision edge → re-confirmed. `go test ./...` + `go build ./...` green (the radar CI gate).

## ⚠️ Flag for review (security posture — deliberately not decided autonomously)
A laptop `radar cloud connect` serves **`auth-mode=none`** and — until hub-side preview-cluster visibility (**WS11**) lands — creates an **org-visible** cluster served with the laptop's kubeconfig identity. The client here is protocol plumbing; cluster visibility is a hub decision. Hub #92 isn't deployed, so no live impact. This is the security gap the preview-cluster model exists to close.

## Deferred (noted, not in this PR)
QR for headless boxes (needs a QR dep) · Home "Connect to Cloud" card + `deployment.mode` gating (radar web/) · CLI star-prompt nudge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches bearer token persistence and auto-injection of cloud flags; mitigations include 0600 credentials, server-URL binding, and kubeconfig override guards, but wrong-cluster or org-visible laptop clusters remain a product/policy concern noted in the PR.
> 
> **Overview**
> Adds **`radar cloud connect|status|disconnect`** as the first CLI subcommand family, dispatched in `main()` before `flag.Parse`. **`connect`** runs the hub device flow (create → browser approval → poll), stores the minted token in **`~/.radar/credentials.json` (0600)**, keyed by kubecontext and bound to the API server URL, then rewrites **`os.Args`** so the normal startup path dials Cloud with `--cloud-url` / `--cloud-token` / `--cluster-name`.
> 
> New **`internal/cloud/connect.go`** implements the HTTP client (`Create`, `Poll`, **`RunFlow`**) with clamped poll intervals, expiry deadlines, and safe error handling (no echoing poll response bodies). **`internal/cloud/credentials.go`** provides save/load/remove with atomic writes.
> 
> **`maybeResumeCloud`** injects saved cloud flags on a plain **`radar`** when no explicit `--cloud-url` / `RADAR_CLOUD_URL` is set, but **refuses** auto-resume for non-default kubeconfig selection or when the current context’s server URL no longer matches the saved credential—avoiding wrong-cluster identity. Connect metadata honors **`config.json`** kubeconfig overrides so connect and serve target the same cluster.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4bbc2cae12bf70a5ab24dcce6b4d8660af1122b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->