### PR TITLE
Fix embedded Radar loading status and scroll height

### DIFF
--- a/packages/k8s-ui/src/components/ui/PaneLoader.tsx
+++ b/packages/k8s-ui/src/components/ui/PaneLoader.tsx
@@ -38,9 +38,13 @@ export function PaneLoader({
             primary) so the whole loading family — boot splash, connect splash,
             PaneLoader — reads as one continuous state, not a font change at the
             hand-off. */}
-        <span className="absolute left-1/2 top-full mt-3 -translate-x-1/2 whitespace-nowrap text-[17px] font-semibold tracking-tight text-theme-text-primary">
-          {label}
-          {children}
+        <span className="absolute left-1/2 top-full mt-3 w-[min(24rem,calc(100vw-2rem))] -translate-x-1/2 text-center text-[17px] font-semibold tracking-tight text-theme-text-primary">
+          <span className="block whitespace-nowrap">{label}</span>
+          {children && (
+            <span className="block whitespace-normal">
+              {children}
+            </span>
+          )}
         </span>
       </span>
     </div>

--- a/packages/k8s-ui/src/components/ui/PaneLoader.tsx
+++ b/packages/k8s-ui/src/components/ui/PaneLoader.tsx
@@ -1,5 +1,6 @@
 import { assetUrl } from '../../utils/asset-url'
 import radarLoadingIconAsset from '../../assets/radar/radar-icon-loading.svg'
+import type { ReactNode } from 'react'
 
 // assetUrl normalizes the bundler-specific asset-import type (string under Vite,
 // StaticImageData under webpack/Next) to a URL string usable in `<img src>`.
@@ -18,9 +19,11 @@ const radarLoadingIcon = assetUrl(radarLoadingIconAsset)
 export function PaneLoader({
   label = 'Loading…',
   className = '',
+  children,
 }: {
   label?: string
   className?: string
+  children?: ReactNode
 }) {
   // No `relative` on the root: the label anchors to the inner `relative` span
   // below, and callers may pass a positioning class (e.g. `absolute inset-0`,
@@ -37,6 +40,7 @@ export function PaneLoader({
             hand-off. */}
         <span className="absolute left-1/2 top-full mt-3 -translate-x-1/2 whitespace-nowrap text-[17px] font-semibold tracking-tight text-theme-text-primary">
           {label}
+          {children}
         </span>
       </span>
     </div>

--- a/web/README.md
+++ b/web/README.md
@@ -38,6 +38,12 @@ export function ClusterPage({ clusterId }: { clusterId: string }) {
 
 See `RadarAppProps` + `NavCustomization` in the type declarations for the full surface.
 
+## Embedding notes
+
+When `navSlots.embedded` is true, Radar sizes itself to the host container (`height: 100%`) instead of owning the browser viewport. Mount it inside a container with a definite height so the host chrome owns the page scrollbar.
+
+Chromeless hosts (`navSlots.chrome = 'none'`) can pass `onClusterLoadStateChange` and render `state.message` in their own topbar while Radar finishes loading deferred cluster resources.
+
 ## Tailwind
 
 Radar uses Tailwind v4 classes throughout. Your app's Tailwind config must scan Radar's source:
@@ -64,4 +70,4 @@ Call these before mounting `<RadarApp>`.
 
 ## Backwards compatibility
 
-The `RadarApp` props (`apiBase`, `basename`, `router`, `navSlots`, `queryClient`) and the runtime-config setters are the stable surface. Adding to them is fine; removing or renaming is a breaking change.
+The `RadarApp` props (`apiBase`, `basename`, `router`, `navSlots`, `queryClient`, `manageDocumentTitle`, `documentTitleSuffix`, `initialPath`, `onClusterLoadStateChange`) and the runtime-config setters are the stable surface. Adding to them is fine; removing or renaming is a breaking change.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -915,7 +915,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
       if (clusterLoadObserverEnabled && clusterLoadPending) {
         return {
           loading: true,
-          message: 'Loading remaining resources…',
+          message: 'Loading dashboard…',
           pendingKinds: [],
         }
       }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,7 +6,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useNavigate, useLocation, useSearchParams, useNavigationType, NavigationType } from 'react-router-dom'
 import { HomeView } from './components/home/HomeView'
 import { DebugOverlay } from './components/DebugOverlay'
-import { TopologyGraph, TopologySearch, TopologyFilterSidebar, TopologyControls, FreshnessControl, gitOpsRouteForKind, gitOpsRouteForResource, ScopePill } from '@skyhook-io/k8s-ui'
+import { TopologyGraph, TopologySearch, TopologyFilterSidebar, TopologyControls, FreshnessControl, gitOpsRouteForKind, gitOpsRouteForResource, ScopePill, PaneLoader } from '@skyhook-io/k8s-ui'
 import { initNavigationMap } from '@skyhook-io/k8s-ui/utils/navigation'
 import { useAPIResources, CORE_RESOURCES } from './api/apiResources'
 import { TimelineView } from './components/timeline/TimelineView'
@@ -52,7 +52,6 @@ import { KeyboardShortcutProvider, useRegisterShortcut, useRegisterShortcuts, us
 import { useAnimatedUnmount } from './hooks/useAnimatedUnmount'
 import { useDocumentTitle } from './hooks/useDocumentTitle'
 import { dashboardClusterLoadState, idleClusterLoadState, type ClusterLoadState } from './types/clusterLoadState'
-import radarLoadingIcon from '@skyhook-io/k8s-ui/assets/radar/radar-icon-loading.svg'
 import { Network, List, Clock, Package, Sun, Moon, Activity, Home, Star, Search, Bug, SquareTerminal, ShieldCheck, GitBranch, HelpCircle, Loader2 } from 'lucide-react'
 import { useTheme } from './context/ThemeContext'
 import { Tooltip } from './components/ui/Tooltip'
@@ -227,19 +226,10 @@ function AuthBarrier({ authMode }: { authMode: string }) {
 
   if (authMode === 'oidc') {
     return (
-      <div className="flex flex-1 min-h-[calc(100vh-51px)] items-center justify-center bg-theme-base">
-        <div className="pointer-events-none flex flex-col items-center text-center">
-          <img
-            src={radarLoadingIcon}
-            alt=""
-            aria-hidden
-            className="w-11 h-11"
-          />
-          <p className="mt-3 whitespace-nowrap text-[17px] font-semibold tracking-tight text-theme-text-primary">
-            Redirecting to login…
-          </p>
-        </div>
-      </div>
+      <PaneLoader
+        label="Redirecting to login…"
+        className="flex-1 min-h-[calc(100vh-51px)] bg-theme-base"
+      />
     )
   }
 
@@ -1885,72 +1875,60 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
           Icon is pane-anchored so its screen position matches the
           host hub splash across cross-document transitions. */}
       {!isSwitching && !(authMe?.authEnabled && !authMe?.username) && connection.state === 'connecting' && (
-        <div className="flex flex-1 min-h-[calc(100vh-51px)] items-center justify-center bg-theme-base">
-          <div className="pointer-events-none flex flex-col items-center text-center">
-            <img
-              src={radarLoadingIcon}
-              alt=""
-              aria-hidden
-              className="w-11 h-11"
-            />
-            <p className="mt-3 whitespace-nowrap text-[17px] font-semibold tracking-tight text-theme-text-primary">
-              Connecting to cluster
-            </p>
-            {connection.context && (
-              <p className="mt-1 text-sm text-theme-text-secondary">{connection.context}</p>
-            )}
-            {connection.progressMessage && (
-              <p className="mt-3 text-xs text-theme-text-tertiary animate-pulse">
-                {connection.progressMessage}
-              </p>
-            )}
-          </div>
-        </div>
+        <PaneLoader
+          label="Connecting to cluster"
+          className="flex-1 min-h-[calc(100vh-51px)] bg-theme-base"
+        >
+          {connection.context && (
+            <span className="mt-1 block text-sm font-normal tracking-normal text-theme-text-secondary">
+              {connection.context}
+            </span>
+          )}
+          {connection.progressMessage && (
+            <span className="mt-3 block text-xs font-normal tracking-normal text-theme-text-tertiary animate-pulse">
+              {connection.progressMessage}
+            </span>
+          )}
+        </PaneLoader>
       )}
 
       {/* Context switching overlay */}
       {isSwitching && (
-        <div className="flex flex-1 min-h-[calc(100vh-51px)] items-center justify-center bg-theme-base">
-          <div className="pointer-events-none flex flex-col items-center text-center">
-            <img
-              src={radarLoadingIcon}
-              alt=""
-              aria-hidden
-              className="w-11 h-11"
-            />
-            <div className="mt-3 whitespace-nowrap text-[17px] font-semibold tracking-tight text-theme-text-primary">Switching context</div>
-              {targetContext && (
-                <div className="text-xs mt-2 text-theme-text-tertiary">
-                  {targetContext.provider ? (
-                    <span className="flex items-center justify-center gap-1.5">
-                      <span className="text-blue-400 font-medium">{targetContext.provider}</span>
-                      {targetContext.account && (
-                        <>
-                          <span className="text-theme-text-tertiary/50">•</span>
-                          <span>{targetContext.account}</span>
-                        </>
-                      )}
-                      {targetContext.region && (
-                        <>
-                          <span className="text-theme-text-tertiary/50">•</span>
-                          <span>{targetContext.region}</span>
-                        </>
-                      )}
+        <PaneLoader
+          label="Switching context"
+          className="flex-1 min-h-[calc(100vh-51px)] bg-theme-base"
+        >
+          {targetContext && (
+            <span className="mt-2 block text-xs font-normal tracking-normal text-theme-text-tertiary">
+              {targetContext.provider ? (
+                <span className="flex items-center justify-center gap-1.5">
+                  <span className="text-blue-400 font-medium">{targetContext.provider}</span>
+                  {targetContext.account && (
+                    <>
                       <span className="text-theme-text-tertiary/50">•</span>
-                      <span className="text-theme-text-secondary font-medium">{targetContext.clusterName}</span>
-                    </span>
-                  ) : (
-                    <span>{targetContext.raw}</span>
+                      <span>{targetContext.account}</span>
+                    </>
                   )}
-                </div>
+                  {targetContext.region && (
+                    <>
+                      <span className="text-theme-text-tertiary/50">•</span>
+                      <span>{targetContext.region}</span>
+                    </>
+                  )}
+                  <span className="text-theme-text-tertiary/50">•</span>
+                  <span className="text-theme-text-secondary font-medium">{targetContext.clusterName}</span>
+                </span>
+              ) : (
+                <span>{targetContext.raw}</span>
               )}
-              {progressMessage && (
-                <div className="text-xs mt-3 text-theme-text-tertiary animate-pulse">
-                  {progressMessage}
-                </div>
-              )}
-          </div>
-        </div>
+            </span>
+          )}
+          {progressMessage && (
+            <span className="mt-3 block text-xs font-normal tracking-normal text-theme-text-tertiary animate-pulse">
+              {progressMessage}
+            </span>
+          )}
+        </PaneLoader>
       )}
 
       {/* Main content - only show when connected and authenticated */}
@@ -2210,19 +2188,10 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
             own fetches) while the cross-document nav lands. Covers checks /
             issues / gitops with one block since only one view is active. */}
         {viewTakeoverHref && (
-          <div className="flex flex-1 min-h-[calc(100vh-51px)] items-center justify-center bg-theme-base">
-            <div className="pointer-events-none flex flex-col items-center text-center">
-              <img
-                src={radarLoadingIcon}
-                alt=""
-                aria-hidden
-                className="w-11 h-11"
-              />
-              <p className="mt-3 whitespace-nowrap text-[17px] font-semibold tracking-tight text-theme-text-primary">
-                Opening…
-              </p>
-            </div>
-          </div>
+          <PaneLoader
+            label="Opening…"
+            className="flex-1 min-h-[calc(100vh-51px)] bg-theme-base"
+          />
         )}
 
         {/* Best practices detail view (inline only when the host hasn't taken

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -910,6 +910,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
   const clusterLoadState = useMemo(
     () => {
       if (!needsClusterLoadState) return idleClusterLoadState
+      if (clusterLoadError) return idleClusterLoadState
       if (clusterLoadData) return dashboardClusterLoadState(clusterLoadData)
       if (clusterLoadObserverEnabled && clusterLoadPending) {
         return {
@@ -920,7 +921,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
       }
       return idleClusterLoadState
     },
-    [clusterLoadData, clusterLoadObserverEnabled, clusterLoadPending, needsClusterLoadState],
+    [clusterLoadData, clusterLoadError, clusterLoadObserverEnabled, clusterLoadPending, needsClusterLoadState],
   )
   const clusterLoadStateKnown =
     !needsClusterLoadState || Boolean(clusterLoadData) || (clusterLoadObserverEnabled && (clusterLoadPending || clusterLoadError))

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -885,13 +885,17 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
   const contentReady = !isSwitching && !authMePending &&
     !(authMe?.authEnabled && !authMe?.username) && connection.state === 'connected'
 
-  const { clusterLoadState, showHomeClusterLoadFallback } = useClusterLoadState({
+  const { clusterLoadState, showHomeClusterLoadFallback, clusterLoadInitial } = useClusterLoadState({
     namespaces,
     mainView,
     chromeless,
     contentReady,
     onClusterLoadStateChange,
   })
+  // Only label background/deferred warmup in the topbar — during the initial
+  // dashboard fetch the center splash already says "Loading dashboard…", so the
+  // dot alone carries the topbar. See useClusterLoadState's clusterLoadInitial.
+  const showClusterWarmupLabel = clusterLoadState.loading && !clusterLoadInitial
 
   // Query client for cache invalidation
   const queryClient = useQueryClient()
@@ -1617,12 +1621,12 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
                   </button>
                 )}
               </Tooltip>
-              {(clusterLoadState.loading || (showNavRail && (!clusterConnected || crdDiscoveryStatus === 'discovering'))) && (
+              {(showClusterWarmupLabel || (showNavRail && (!clusterConnected || crdDiscoveryStatus === 'discovering'))) && (
                 <span className="hidden xl:flex items-center gap-1.5 whitespace-nowrap text-[11px] text-theme-text-tertiary">
-                  {clusterLoadState.loading && <Loader2 className="w-3 h-3 animate-spin" />}
+                  {showClusterWarmupLabel && <Loader2 className="w-3 h-3 animate-spin" />}
                   {!clusterConnected
                     ? 'Disconnected'
-                    : clusterLoadState.loading
+                    : showClusterWarmupLabel
                       ? clusterLoadState.message
                       : 'Discovering Custom Resources…'}
                 </span>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -45,14 +45,15 @@ import { ShortcutHelpOverlay } from './components/ui/ShortcutHelpOverlay'
 import { CommandPalette } from './components/ui/CommandPalette'
 import { DiagnosticsOverlay } from './components/ui/DiagnosticsOverlay'
 import { useEventSource } from './hooks/useEventSource'
-import { debugNamespaceLog, useNamespaces, useNamespaceScope, useSetActiveNamespace, useSwitchContext, useAuthMe, useAudit } from './api/client'
+import { debugNamespaceLog, useNamespaces, useNamespaceScope, useSetActiveNamespace, useSwitchContext, useAuthMe, useAudit, useDashboard } from './api/client'
 import { buildAuditSeverityMap } from './utils/auditBadges'
 import { routePath, apiUrl, getAuthHeaders, getCredentialsMode } from './api/config'
 import { KeyboardShortcutProvider, useRegisterShortcut, useRegisterShortcuts, useSuppressBaseShortcuts } from './hooks/useKeyboardShortcuts'
 import { useAnimatedUnmount } from './hooks/useAnimatedUnmount'
 import { useDocumentTitle } from './hooks/useDocumentTitle'
+import { dashboardClusterLoadState, idleClusterLoadState, type ClusterLoadState } from './types/clusterLoadState'
 import radarLoadingIcon from '@skyhook-io/k8s-ui/assets/radar/radar-icon-loading.svg'
-import { Network, List, Clock, Package, Sun, Moon, Activity, Home, Star, Search, Bug, SquareTerminal, ShieldCheck, GitBranch, HelpCircle } from 'lucide-react'
+import { Network, List, Clock, Package, Sun, Moon, Activity, Home, Star, Search, Bug, SquareTerminal, ShieldCheck, GitBranch, HelpCircle, Loader2 } from 'lucide-react'
 import { useTheme } from './context/ThemeContext'
 import { Tooltip } from './components/ui/Tooltip'
 import { LargeClusterNamespacePicker } from './components/shared/LargeClusterNamespacePicker'
@@ -279,7 +280,13 @@ function peekOwnerKey(pathname: string, search: string): string {
   return `${pathname}\n${new URLSearchParams(search).get('app') ?? ''}`
 }
 
-function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manageDocumentTitle?: boolean; documentTitleSuffix?: string }) {
+interface AppProps {
+  manageDocumentTitle?: boolean
+  documentTitleSuffix?: string
+  onClusterLoadStateChange?: (state: ClusterLoadState) => void
+}
+
+function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterLoadStateChange }: AppProps) {
   const navigate = useNavigate()
   const location = useLocation()
   const navigationType = useNavigationType()
@@ -894,6 +901,65 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
   // a drawer only ever sits over a real content surface.
   const contentReady = !isSwitching && !authMePending &&
     !(authMe?.authEnabled && !authMe?.username) && connection.state === 'connected'
+
+  const showHomeClusterLoadFallback = chromeless && !onClusterLoadStateChange && mainView === 'home'
+  const needsClusterLoadState = contentReady && (!chromeless || Boolean(onClusterLoadStateChange) || showHomeClusterLoadFallback)
+  const clusterLoadNamespaceKey = namespaces.join('\0')
+  const [clusterLoadObserverActive, setClusterLoadObserverActive] = useState(false)
+  useEffect(() => {
+    if (!needsClusterLoadState) {
+      setClusterLoadObserverActive(false)
+      return
+    }
+    setClusterLoadObserverActive(true)
+  }, [needsClusterLoadState, clusterLoadNamespaceKey])
+  useEffect(() => {
+    if (needsClusterLoadState && mainView === 'home') {
+      setClusterLoadObserverActive(true)
+    }
+  }, [mainView, needsClusterLoadState])
+
+  const clusterLoadObserverEnabled = needsClusterLoadState && clusterLoadObserverActive
+  const {
+    data: clusterLoadData,
+    isPending: clusterLoadPending,
+    isError: clusterLoadError,
+  } = useDashboard(namespaces, { enabled: clusterLoadObserverEnabled })
+  const clusterLoadState = useMemo(
+    () => {
+      if (!needsClusterLoadState) return idleClusterLoadState
+      if (clusterLoadData) return dashboardClusterLoadState(clusterLoadData)
+      if (clusterLoadObserverEnabled && clusterLoadPending) {
+        return {
+          loading: true,
+          message: 'Loading remaining resources…',
+          pendingKinds: [],
+        }
+      }
+      return idleClusterLoadState
+    },
+    [clusterLoadData, clusterLoadObserverEnabled, clusterLoadPending, needsClusterLoadState],
+  )
+  const clusterLoadStateKnown =
+    !needsClusterLoadState || Boolean(clusterLoadData) || (clusterLoadObserverEnabled && (clusterLoadPending || clusterLoadError))
+  useEffect(() => {
+    if (
+      needsClusterLoadState &&
+      mainView !== 'home' &&
+      ((clusterLoadData && !clusterLoadState.loading) || clusterLoadError)
+    ) {
+      setClusterLoadObserverActive(false)
+    }
+  }, [clusterLoadData, clusterLoadError, clusterLoadState.loading, mainView, needsClusterLoadState])
+  useEffect(() => {
+    return () => {
+      onClusterLoadStateChange?.(idleClusterLoadState)
+    }
+  }, [onClusterLoadStateChange])
+  useEffect(() => {
+    if (!clusterLoadStateKnown) return
+    onClusterLoadStateChange?.(clusterLoadState)
+  }, [clusterLoadState, clusterLoadStateKnown, onClusterLoadStateChange])
 
   // Query client for cache invalidation
   const queryClient = useQueryClient()
@@ -1516,7 +1582,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
         content column (min-w-0, shrinkable) would fall below the old desktop
         floor at small windows. Embedded mode has no rail → plain 800. */}
     <div
-      className="relative flex h-screen bg-theme-base"
+      className={`relative flex bg-theme-base ${navCustomization.embedded ? 'h-full min-h-0' : 'h-screen'}`}
       style={{ minWidth: 800 + (showNavRail ? (navRailEffectivePinned ? 176 : 56) : 0) }}
     >
       {showNavRail && (
@@ -1590,6 +1656,8 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
                 content={
                   !clusterConnected
                     ? 'Cluster disconnected — click to reconnect'
+                    : clusterLoadState.loading
+                      ? `Connected — ${clusterLoadState.message}`
                     : crdDiscoveryStatus === 'discovering'
                       ? 'Connected — discovering Custom Resources...'
                       : 'Connected'
@@ -1615,9 +1683,14 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
                   </button>
                 )}
               </Tooltip>
-              {showNavRail && (!clusterConnected || crdDiscoveryStatus === 'discovering') && (
-                <span className="hidden xl:block whitespace-nowrap text-[11px] text-theme-text-tertiary">
-                  {!clusterConnected ? 'Disconnected' : 'Discovering Custom Resources…'}
+              {(clusterLoadState.loading || (showNavRail && (!clusterConnected || crdDiscoveryStatus === 'discovering'))) && (
+                <span className="hidden xl:flex items-center gap-1.5 whitespace-nowrap text-[11px] text-theme-text-tertiary">
+                  {clusterLoadState.loading && <Loader2 className="w-3 h-3 animate-spin" />}
+                  {!clusterConnected
+                    ? 'Disconnected'
+                    : clusterLoadState.loading
+                      ? clusterLoadState.message
+                      : 'Discovering Custom Resources…'}
                 </span>
               )}
             </div>
@@ -1922,6 +1995,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix }: { manage
           <HomeView
             namespaces={namespaces}
             topology={topology}
+            fallbackClusterLoadState={showHomeClusterLoadFallback ? clusterLoadState : undefined}
             onNavigateToView={setMainView}
             onNavigateToResourceKind={(kind, apiGroup, filters) => {
               // Navigate to resources view with kind in URL path
@@ -2424,14 +2498,18 @@ function FloatingButtons({ showHelp, showCommandPalette, showDiagnostics, onHelp
 }
 
 // Main App component wrapped with providers
-function App({ manageDocumentTitle = false, documentTitleSuffix }: { manageDocumentTitle?: boolean; documentTitleSuffix?: string }) {
+function App({ manageDocumentTitle = false, documentTitleSuffix, onClusterLoadStateChange }: AppProps) {
   return (
     <ConnectionProvider>
       <CapabilitiesProvider>
         <ContextSwitchProvider>
           <DockProvider>
             <KeyboardShortcutProvider>
-              <AppInner manageDocumentTitle={manageDocumentTitle} documentTitleSuffix={documentTitleSuffix} />
+              <AppInner
+                manageDocumentTitle={manageDocumentTitle}
+                documentTitleSuffix={documentTitleSuffix}
+                onClusterLoadStateChange={onClusterLoadStateChange}
+              />
             </KeyboardShortcutProvider>
           </DockProvider>
         </ContextSwitchProvider>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -228,7 +228,7 @@ function AuthBarrier({ authMode }: { authMode: string }) {
     return (
       <PaneLoader
         label="Redirecting to login…"
-        className="flex-1 min-h-[calc(100vh-51px)] bg-theme-base"
+        className="flex-1 min-h-0 bg-theme-base"
       />
     )
   }
@@ -1877,7 +1877,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
       {!isSwitching && !(authMe?.authEnabled && !authMe?.username) && connection.state === 'connecting' && (
         <PaneLoader
           label="Connecting to cluster"
-          className="flex-1 min-h-[calc(100vh-51px)] bg-theme-base"
+          className="flex-1 min-h-0 bg-theme-base"
         >
           {connection.context && (
             <span className="mt-1 block text-sm font-normal tracking-normal text-theme-text-secondary">
@@ -1896,7 +1896,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
       {isSwitching && (
         <PaneLoader
           label="Switching context"
-          className="flex-1 min-h-[calc(100vh-51px)] bg-theme-base"
+          className="flex-1 min-h-0 bg-theme-base"
         >
           {targetContext && (
             <span className="mt-2 block text-xs font-normal tracking-normal text-theme-text-tertiary">
@@ -2190,7 +2190,7 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
         {viewTakeoverHref && (
           <PaneLoader
             label="Opening…"
-            className="flex-1 min-h-[calc(100vh-51px)] bg-theme-base"
+            className="flex-1 min-h-0 bg-theme-base"
           />
         )}
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -892,10 +892,10 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
     contentReady,
     onClusterLoadStateChange,
   })
-  // Only label background/deferred warmup in the topbar — during the initial
-  // dashboard fetch the center splash already says "Loading dashboard…", so the
-  // dot alone carries the topbar. See useClusterLoadState's clusterLoadInitial.
-  const showClusterWarmupLabel = clusterLoadState.loading && !clusterLoadInitial
+  // Suppress the topbar warmup label during the initial dashboard fetch only on
+  // Home, where the center "Loading dashboard…" splash already covers it. Off
+  // Home there's no splash, so keep the label as the only text cue.
+  const showClusterWarmupLabel = clusterLoadState.loading && !(clusterLoadInitial && mainView === 'home')
 
   // Query client for cache invalidation
   const queryClient = useQueryClient()

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -45,13 +45,14 @@ import { ShortcutHelpOverlay } from './components/ui/ShortcutHelpOverlay'
 import { CommandPalette } from './components/ui/CommandPalette'
 import { DiagnosticsOverlay } from './components/ui/DiagnosticsOverlay'
 import { useEventSource } from './hooks/useEventSource'
-import { debugNamespaceLog, useNamespaces, useNamespaceScope, useSetActiveNamespace, useSwitchContext, useAuthMe, useAudit, useDashboard } from './api/client'
+import { debugNamespaceLog, useNamespaces, useNamespaceScope, useSetActiveNamespace, useSwitchContext, useAuthMe, useAudit } from './api/client'
 import { buildAuditSeverityMap } from './utils/auditBadges'
 import { routePath, apiUrl, getAuthHeaders, getCredentialsMode } from './api/config'
 import { KeyboardShortcutProvider, useRegisterShortcut, useRegisterShortcuts, useSuppressBaseShortcuts } from './hooks/useKeyboardShortcuts'
 import { useAnimatedUnmount } from './hooks/useAnimatedUnmount'
 import { useDocumentTitle } from './hooks/useDocumentTitle'
-import { dashboardClusterLoadState, idleClusterLoadState, type ClusterLoadState } from './types/clusterLoadState'
+import type { ClusterLoadState } from './types/clusterLoadState'
+import { useClusterLoadState } from './hooks/useClusterLoadState'
 import { Network, List, Clock, Package, Sun, Moon, Activity, Home, Star, Search, Bug, SquareTerminal, ShieldCheck, GitBranch, HelpCircle, Loader2 } from 'lucide-react'
 import { useTheme } from './context/ThemeContext'
 import { Tooltip } from './components/ui/Tooltip'
@@ -884,65 +885,13 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
   const contentReady = !isSwitching && !authMePending &&
     !(authMe?.authEnabled && !authMe?.username) && connection.state === 'connected'
 
-  const showHomeClusterLoadFallback = chromeless && !onClusterLoadStateChange && mainView === 'home'
-  const needsClusterLoadState = contentReady && (!chromeless || Boolean(onClusterLoadStateChange) || showHomeClusterLoadFallback)
-  const clusterLoadNamespaceKey = namespaces.join('\0')
-  const [clusterLoadObserverActive, setClusterLoadObserverActive] = useState(false)
-  useEffect(() => {
-    if (!needsClusterLoadState) {
-      setClusterLoadObserverActive(false)
-      return
-    }
-    setClusterLoadObserverActive(true)
-  }, [needsClusterLoadState, clusterLoadNamespaceKey])
-  useEffect(() => {
-    if (needsClusterLoadState && mainView === 'home') {
-      setClusterLoadObserverActive(true)
-    }
-  }, [mainView, needsClusterLoadState])
-
-  const clusterLoadObserverEnabled = needsClusterLoadState && clusterLoadObserverActive
-  const {
-    data: clusterLoadData,
-    isPending: clusterLoadPending,
-    isError: clusterLoadError,
-  } = useDashboard(namespaces, { enabled: clusterLoadObserverEnabled })
-  const clusterLoadState = useMemo(
-    () => {
-      if (!needsClusterLoadState) return idleClusterLoadState
-      if (clusterLoadError) return idleClusterLoadState
-      if (clusterLoadData) return dashboardClusterLoadState(clusterLoadData)
-      if (clusterLoadObserverEnabled && clusterLoadPending) {
-        return {
-          loading: true,
-          message: 'Loading dashboard…',
-          pendingKinds: [],
-        }
-      }
-      return idleClusterLoadState
-    },
-    [clusterLoadData, clusterLoadError, clusterLoadObserverEnabled, clusterLoadPending, needsClusterLoadState],
-  )
-  const clusterLoadStateKnown =
-    !needsClusterLoadState || Boolean(clusterLoadData) || (clusterLoadObserverEnabled && (clusterLoadPending || clusterLoadError))
-  useEffect(() => {
-    if (
-      needsClusterLoadState &&
-      mainView !== 'home' &&
-      ((clusterLoadData && !clusterLoadState.loading) || clusterLoadError)
-    ) {
-      setClusterLoadObserverActive(false)
-    }
-  }, [clusterLoadData, clusterLoadError, clusterLoadState.loading, mainView, needsClusterLoadState])
-  useEffect(() => {
-    return () => {
-      onClusterLoadStateChange?.(idleClusterLoadState)
-    }
-  }, [onClusterLoadStateChange])
-  useEffect(() => {
-    if (!clusterLoadStateKnown) return
-    onClusterLoadStateChange?.(clusterLoadState)
-  }, [clusterLoadState, clusterLoadStateKnown, onClusterLoadStateChange])
+  const { clusterLoadState, showHomeClusterLoadFallback } = useClusterLoadState({
+    namespaces,
+    mainView,
+    chromeless,
+    contentReady,
+    onClusterLoadStateChange,
+  })
 
   // Query client for cache invalidation
   const queryClient = useQueryClient()
@@ -1651,7 +1600,9 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
                 {clusterConnected ? (
                   <span
                     className={`block w-2.5 h-2.5 shrink-0 rounded-full ${
-                      crdDiscoveryStatus === 'discovering' ? 'bg-amber-400 animate-pulse' : 'bg-green-500'
+                      crdDiscoveryStatus === 'discovering' || clusterLoadState.loading
+                        ? 'bg-amber-400 animate-pulse'
+                        : 'bg-green-500'
                     }`}
                   />
                 ) : (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -227,25 +227,17 @@ function AuthBarrier({ authMode }: { authMode: string }) {
 
   if (authMode === 'oidc') {
     return (
-      <div className="flex-1 relative bg-theme-base">
-        <div className="absolute inset-0 pointer-events-none">
+      <div className="flex flex-1 min-h-[calc(100vh-51px)] items-center justify-center bg-theme-base">
+        <div className="pointer-events-none flex flex-col items-center text-center">
           <img
             src={radarLoadingIcon}
             alt=""
             aria-hidden
-            // Integer offset (50% − 22) — matches the Connecting/Opening splashes;
-            // avoids sub-pixel jitter from translate(-50%) on odd-width viewports.
-            className="absolute w-11 h-11"
-            style={{ left: 'calc(50% - 22px)', top: 'calc(50% - 22px)' }}
+            className="w-11 h-11"
           />
-          <div
-            className="absolute left-1/2 -translate-x-1/2 text-center"
-            style={{ top: 'calc(50% + 34px)' }}
-          >
-            <p className="whitespace-nowrap text-[17px] font-semibold tracking-tight text-theme-text-primary">
-              Redirecting to login…
-            </p>
-          </div>
+          <p className="mt-3 whitespace-nowrap text-[17px] font-semibold tracking-tight text-theme-text-primary">
+            Redirecting to login…
+          </p>
         </div>
       </div>
     )
@@ -1893,62 +1885,40 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
           Icon is pane-anchored so its screen position matches the
           host hub splash across cross-document transitions. */}
       {!isSwitching && !(authMe?.authEnabled && !authMe?.username) && connection.state === 'connecting' && (
-        <div className="flex-1 relative bg-theme-base">
-          {/* Icon absolutely anchored to the pane center. The label block
-              sits at a fixed offset below — independent of label height
-              so multi-line messages (context + progress) don't shift the
-              icon's screen position. */}
-          <div className="absolute inset-0 pointer-events-none">
+        <div className="flex flex-1 min-h-[calc(100vh-51px)] items-center justify-center bg-theme-base">
+          <div className="pointer-events-none flex flex-col items-center text-center">
             <img
               src={radarLoadingIcon}
               alt=""
               aria-hidden
-              // Integer offset (50% − 22) — avoids sub-pixel jitter from
-              // `translate(-50%, -50%)` on odd-width viewports.
-              className="absolute w-11 h-11"
-              style={{ left: 'calc(50% - 22px)', top: 'calc(50% - 22px)' }}
+              className="w-11 h-11"
             />
-            <div
-              className="absolute left-1/2 -translate-x-1/2 text-center"
-              style={{ top: 'calc(50% + 34px)' }}
-            >
-              {/* 17px semibold matches the other splash surfaces so font
-                  weight doesn't visibly swap during hub → cluster
-                  transitions. Subtitles below stay smaller/dimmer. */}
-              <p className="whitespace-nowrap text-[17px] font-semibold tracking-tight text-theme-text-primary">
-                Connecting to cluster
+            <p className="mt-3 whitespace-nowrap text-[17px] font-semibold tracking-tight text-theme-text-primary">
+              Connecting to cluster
+            </p>
+            {connection.context && (
+              <p className="mt-1 text-sm text-theme-text-secondary">{connection.context}</p>
+            )}
+            {connection.progressMessage && (
+              <p className="mt-3 text-xs text-theme-text-tertiary animate-pulse">
+                {connection.progressMessage}
               </p>
-              {connection.context && (
-                <p className="text-sm text-theme-text-secondary mt-1">{connection.context}</p>
-              )}
-              {connection.progressMessage && (
-                <p className="text-xs text-theme-text-tertiary animate-pulse mt-3">
-                  {connection.progressMessage}
-                </p>
-              )}
-            </div>
+            )}
           </div>
         </div>
       )}
 
-      {/* Context switching overlay — icon pane-anchored, label below. */}
+      {/* Context switching overlay */}
       {isSwitching && (
-        <div className="flex-1 relative bg-theme-base">
-          <div className="absolute inset-0 pointer-events-none">
+        <div className="flex flex-1 min-h-[calc(100vh-51px)] items-center justify-center bg-theme-base">
+          <div className="pointer-events-none flex flex-col items-center text-center">
             <img
               src={radarLoadingIcon}
               alt=""
               aria-hidden
-              // Integer offset (50% − 22) — avoids sub-pixel jitter from
-              // `translate(-50%, -50%)` on odd-width viewports.
-              className="absolute w-11 h-11"
-              style={{ left: 'calc(50% - 22px)', top: 'calc(50% - 22px)' }}
+              className="w-11 h-11"
             />
-            <div
-              className="absolute left-1/2 -translate-x-1/2 text-center"
-              style={{ top: 'calc(50% + 34px)' }}
-            >
-              <div className="whitespace-nowrap text-[17px] font-semibold tracking-tight text-theme-text-primary">Switching context</div>
+            <div className="mt-3 whitespace-nowrap text-[17px] font-semibold tracking-tight text-theme-text-primary">Switching context</div>
               {targetContext && (
                 <div className="text-xs mt-2 text-theme-text-tertiary">
                   {targetContext.provider ? (
@@ -1979,7 +1949,6 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
                   {progressMessage}
                 </div>
               )}
-            </div>
           </div>
         </div>
       )}
@@ -2241,25 +2210,17 @@ function AppInner({ manageDocumentTitle = false, documentTitleSuffix, onClusterL
             own fetches) while the cross-document nav lands. Covers checks /
             issues / gitops with one block since only one view is active. */}
         {viewTakeoverHref && (
-          <div className="flex-1 relative bg-theme-base">
-            {/* Viewport-anchored, 17px — identical to the "Connecting" splash so
-                the mark doesn't move or resize across the takeover hand-off. */}
-            <div className="absolute inset-0 pointer-events-none">
+          <div className="flex flex-1 min-h-[calc(100vh-51px)] items-center justify-center bg-theme-base">
+            <div className="pointer-events-none flex flex-col items-center text-center">
               <img
                 src={radarLoadingIcon}
                 alt=""
                 aria-hidden
-                className="absolute w-11 h-11"
-                style={{ left: 'calc(50% - 22px)', top: 'calc(50% - 22px)' }}
+                className="w-11 h-11"
               />
-              <div
-                className="absolute left-1/2 -translate-x-1/2 text-center"
-                style={{ top: 'calc(50% + 34px)' }}
-              >
-                <p className="whitespace-nowrap text-[17px] font-semibold tracking-tight text-theme-text-primary">
-                  Opening…
-                </p>
-              </div>
+              <p className="mt-3 whitespace-nowrap text-[17px] font-semibold tracking-tight text-theme-text-primary">
+                Opening…
+              </p>
             </div>
           </div>
         )}

--- a/web/src/RadarApp.tsx
+++ b/web/src/RadarApp.tsx
@@ -27,6 +27,7 @@ import { setApiBase, setBasename } from './api/config';
 import { NavCustomizationProvider } from './context/NavCustomization';
 import { FilterLocationBridge } from './filter/FilterLocationBridge';
 import type { NavCustomization } from './context/NavCustomization';
+import type { ClusterLoadState } from './types/clusterLoadState';
 
 // Declare the shape of mutation meta here — inlined rather than in a
 // separate side-effect-only module so consumers that tree-shake aggressively
@@ -93,6 +94,12 @@ export interface RadarAppProps {
    * chromeless under the host's own chrome (Radar Hub's per-cluster destinations).
    */
   initialPath?: string;
+  /**
+   * Reports cluster-data warmup after the main connection is usable. Embedders
+   * with their own chrome (Radar Hub) can render this in their topbar while
+   * Radar runs with `navSlots.chrome: 'none'`.
+   */
+  onClusterLoadStateChange?: (state: ClusterLoadState) => void;
 }
 
 // Default QueryClient with the same shape Radar's standalone binary uses.
@@ -135,6 +142,7 @@ export function RadarApp({
   manageDocumentTitle = false,
   documentTitleSuffix,
   initialPath,
+  onClusterLoadStateChange,
 }: RadarAppProps): React.ReactElement {
   // Apply runtime config during render so module-level singletons are set
   // before children construct URLs. getApiBase() / getAuthHeaders() /
@@ -155,7 +163,11 @@ export function RadarApp({
         <ToastProvider>
           <NavCustomizationProvider value={navSlots}>
             <FilterLocationBridge>
-              <App manageDocumentTitle={manageDocumentTitle} documentTitleSuffix={documentTitleSuffix} />
+              <App
+                manageDocumentTitle={manageDocumentTitle}
+                documentTitleSuffix={documentTitleSuffix}
+                onClusterLoadStateChange={onClusterLoadStateChange}
+              />
             </FilterLocationBridge>
           </NavCustomizationProvider>
         </ToastProvider>

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -371,11 +371,12 @@ export interface DashboardCRDsResponse {
   topCRDs: DashboardCRDCount[]
 }
 
-export function useDashboard(namespaces: string[] = []) {
+export function useDashboard(namespaces: string[] = [], options?: { enabled?: boolean }) {
   const params = namespaces.length > 0 ? `?namespaces=${namespaces.join(',')}` : ''
   return useQuery<DashboardResponse>({
     queryKey: ['dashboard', namespaces],
     queryFn: () => fetchJSON(`/dashboard${params}`),
+    enabled: options?.enabled ?? true,
     staleTime: 15000, // 15 seconds
     refetchInterval: DASHBOARD_REFRESH_INTERVAL_MS,
   })

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -1,6 +1,7 @@
 import { useMemo, type ReactNode } from 'react'
 import { useDashboard, useDashboardCRDs, useDashboardHelm, useIssues, type IssuesResponse } from '../../api/client'
 import { useConnection } from '../../context/ConnectionContext'
+import type { ClusterLoadState } from '../../types/clusterLoadState'
 import type { ExtendedMainView, Topology, SelectedResource } from '../../types'
 import { TopologyPreview } from './TopologyPreview'
 import { HelmSummary } from './HelmSummary'
@@ -33,6 +34,7 @@ interface HomeViewProps {
   onNavigateToView: (view: ExtendedMainView, params?: Record<string, string>) => void
   onNavigateToResourceKind: (kind: string, group?: string, filters?: Record<string, string[]>) => void
   onNavigateToResource: (resource: SelectedResource) => void
+  fallbackClusterLoadState?: ClusterLoadState
   /**
    * Optional override for the Certificate Health card's click. When an embedded
    * host (Radar Cloud) takes Certs over with its own fleet page, it passes this
@@ -42,7 +44,7 @@ interface HomeViewProps {
   onNavigateToCerts?: () => void
 }
 
-export function HomeView({ namespaces, topology, onNavigateToView, onNavigateToResourceKind, onNavigateToResource, onNavigateToCerts }: HomeViewProps) {
+export function HomeView({ namespaces, topology, fallbackClusterLoadState, onNavigateToView, onNavigateToResourceKind, onNavigateToResource, onNavigateToCerts }: HomeViewProps) {
   const { data, isLoading, error, dataUpdatedAt, refetch } = useDashboard(namespaces)
   const { connection } = useConnection()
   const { data: issuesData, isLoading: issuesLoading, isFetching: issuesFetching, error: issuesError } = useIssues(namespaces)
@@ -96,19 +98,13 @@ export function HomeView({ namespaces, topology, onNavigateToView, onNavigateToR
     )
   }
 
-  const stillLoading = data.deferredLoading || (data.partialData && data.partialData.length > 0)
-
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-[1600px] mx-auto px-6 py-6 space-y-6">
-        {stillLoading && (
-          <div className="flex items-center gap-2 text-xs text-theme-text-tertiary">
-            <Loader2 className="w-3 h-3 animate-spin" />
-            <span>
-              {data.partialData && data.partialData.length > 0
-                ? `Still loading: ${data.partialData.join(', ')}`
-                : 'Loading remaining resources…'}
-            </span>
+        {fallbackClusterLoadState?.loading && (
+          <div className="flex items-center gap-2 text-sm text-theme-text-tertiary">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span>{fallbackClusterLoadState.message}</span>
           </div>
         )}
         {/* Row 1: Cluster Health Card (combined health + resource counts) */}

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -71,7 +71,7 @@ export function HomeView({ namespaces, topology, fallbackClusterLoadState, onNav
   const { data: helmData } = useDashboardHelm(namespaces)
 
   if (isLoading) {
-    return <PaneLoader label="Loading dashboard…" className="flex-1 min-h-[calc(100vh-51px)]" />
+    return <PaneLoader label="Loading dashboard…" className="flex-1 min-h-0" />
   }
 
   if (error || !data) {

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -71,7 +71,7 @@ export function HomeView({ namespaces, topology, fallbackClusterLoadState, onNav
   const { data: helmData } = useDashboardHelm(namespaces)
 
   if (isLoading) {
-    return <PaneLoader label="Loading dashboard…" className="flex-1" />
+    return <PaneLoader label="Loading dashboard…" className="flex-1 min-h-[calc(100vh-51px)]" />
   }
 
   if (error || !data) {

--- a/web/src/hooks/useClusterLoadState.ts
+++ b/web/src/hooks/useClusterLoadState.ts
@@ -1,0 +1,67 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { useDashboard, type DashboardResponse } from '../api/client'
+import { dashboardClusterLoadState, idleClusterLoadState, type ClusterLoadState } from '../types/clusterLoadState'
+
+interface UseClusterLoadStateArgs {
+  namespaces: string[]
+  mainView: string
+  chromeless: boolean
+  contentReady: boolean
+  onClusterLoadStateChange?: (state: ClusterLoadState) => void
+}
+
+interface UseClusterLoadStateResult {
+  clusterLoadState: ClusterLoadState
+  showHomeClusterLoadFallback: boolean
+}
+
+// Tracks cluster-data warmup (deferred/partial dashboard load) once the main
+// connection is usable. Standalone / embedded-with-chrome render it in Radar's
+// topbar; chromeless hosts (Radar Hub) receive it via onClusterLoadStateChange;
+// a chromeless host without a callback gets a fallback row on Home.
+export function useClusterLoadState({
+  namespaces,
+  mainView,
+  chromeless,
+  contentReady,
+  onClusterLoadStateChange,
+}: UseClusterLoadStateArgs): UseClusterLoadStateResult {
+  const showHomeClusterLoadFallback = chromeless && !onClusterLoadStateChange && mainView === 'home'
+  const needsClusterLoadState =
+    contentReady && (!chromeless || Boolean(onClusterLoadStateChange) || mainView === 'home')
+
+  // Off Home, stop observing once warmup has settled so we don't keep refetching
+  // /dashboard on other views. `enabled: false` makes the observer inactive,
+  // which also drops it from the SSE-driven invalidateQueries(['dashboard'])
+  // refetches — a stopped refetchInterval alone would not. Home stays live via
+  // HomeView's own observer; returning Home or changing scope re-arms, since
+  // `enabled` is derived from the current cached (re)load state.
+  const queryClient = useQueryClient()
+  const cached = queryClient.getQueryState<DashboardResponse>(['dashboard', namespaces])
+  const warmupSettled =
+    cached?.status === 'error' || (cached?.data != null && !dashboardClusterLoadState(cached.data).loading)
+  const enabled = needsClusterLoadState && (mainView === 'home' || !warmupSettled)
+
+  const { data, isPending, isError } = useDashboard(namespaces, { enabled })
+
+  const clusterLoadState = useMemo<ClusterLoadState>(() => {
+    if (!needsClusterLoadState || isError) return idleClusterLoadState
+    if (data) return dashboardClusterLoadState(data)
+    if (isPending) return { loading: true, message: 'Loading dashboard…', pendingKinds: [] }
+    return idleClusterLoadState
+  }, [needsClusterLoadState, isError, data, isPending])
+
+  // Ref the host callback so an unmemoized prop doesn't churn emits, and so the
+  // unmount reset fires only on real unmount (not on every callback identity change).
+  const emitRef = useRef(onClusterLoadStateChange)
+  useEffect(() => {
+    emitRef.current = onClusterLoadStateChange
+  })
+  useEffect(() => {
+    emitRef.current?.(clusterLoadState)
+  }, [clusterLoadState])
+  useEffect(() => () => emitRef.current?.(idleClusterLoadState), [])
+
+  return { clusterLoadState, showHomeClusterLoadFallback }
+}

--- a/web/src/hooks/useClusterLoadState.ts
+++ b/web/src/hooks/useClusterLoadState.ts
@@ -14,6 +14,10 @@ interface UseClusterLoadStateArgs {
 interface UseClusterLoadStateResult {
   clusterLoadState: ClusterLoadState
   showHomeClusterLoadFallback: boolean
+  // The dashboard's first fetch is still in flight (no data yet). In this phase a
+  // center "Loading dashboard…" splash is shown, so the topbar label would be
+  // redundant — callers can suppress it and keep just the status dot.
+  clusterLoadInitial: boolean
 }
 
 // Tracks cluster-data warmup (deferred/partial dashboard load) once the main
@@ -63,5 +67,7 @@ export function useClusterLoadState({
   }, [clusterLoadState])
   useEffect(() => () => emitRef.current?.(idleClusterLoadState), [])
 
-  return { clusterLoadState, showHomeClusterLoadFallback }
+  const clusterLoadInitial = clusterLoadState.loading && !data
+
+  return { clusterLoadState, showHomeClusterLoadFallback, clusterLoadInitial }
 }

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -4,6 +4,7 @@
 // bundler that transpiles TSX and resolves workspace-style peer deps. The
 // same source is consumed by Radar's binary via main.tsx.
 export { RadarApp, type RadarAppProps } from './RadarApp';
+export type { ClusterLoadState } from './types/clusterLoadState';
 export {
   setApiBase,
   setBasename,

--- a/web/src/types/clusterLoadState.ts
+++ b/web/src/types/clusterLoadState.ts
@@ -1,0 +1,33 @@
+export interface ClusterLoadState {
+  loading: boolean
+  message: string | null
+  pendingKinds: string[]
+}
+
+export const idleClusterLoadState: ClusterLoadState = {
+  loading: false,
+  message: null,
+  pendingKinds: [],
+}
+
+export function dashboardClusterLoadState(data?: {
+  deferredLoading?: boolean
+  partialData?: string[]
+}): ClusterLoadState {
+  const pendingKinds = data?.partialData ?? []
+  if (pendingKinds.length > 0) {
+    return {
+      loading: true,
+      message: `Still loading: ${pendingKinds.join(', ')}`,
+      pendingKinds,
+    }
+  }
+  if (data?.deferredLoading) {
+    return {
+      loading: true,
+      message: 'Loading remaining resources…',
+      pendingKinds: [],
+    }
+  }
+  return idleClusterLoadState
+}


### PR DESCRIPTION
Summary:
Radar embedded/chromeless mode now lets the host own viewport sizing and cluster warmup chrome. This keeps Hub from showing a Home-page loading row under its own topbar and prevents embedded Radar from forcing a second page scrollbar.

What changed:
- Dashboard warmup status is normalized into a public `ClusterLoadState` and surfaced from `RadarApp` through `onClusterLoadStateChange`, so hosts with their own chrome can render the same state in their topbar.
- Radar topbar renders the cluster warmup indicator when Radar chrome is visible, while the Home dashboard no longer renders a separate global loading row.
- Embedded Radar root sizing is parent-owned with `h-full min-h-0`; standalone Radar continues to own the viewport with `h-screen`.
- Loader panes use parent-sized `flex-1 min-h-0` surfaces, so embedded hosts do not get viewport-derived overflow during connect, context switch, auth redirect, takeover, or initial dashboard load.
- `PaneLoader` centers the Radar icon independently from labels and allows subtitle content to wrap without moving the icon.
- `useDashboard` accepts an optional `enabled` flag, and the shell dashboard observer drops after non-Home views confirm warmup is complete.
- The package README documents the embedded height requirement and chromeless load-state callback.

Testing:
- `make tsc`
- `make test`
- Hub local prod-backed visual check: delayed `Loading cluster…` → `Connecting to cluster` → `Loading dashboard…` transition kept the Radar icon at the same measured center and reported no document/body extra scroll during the loading states.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and embed API additions only; no auth or data-path changes. New callback is optional and backward compatible.
> 
> **Overview**
> Improves **embedded and chromeless** Radar so hosts (e.g. Hub) own viewport scroll and loading chrome while keeping the radar icon stable across splash hand-offs.
> 
> **Cluster warmup for embedders:** Dashboard deferred/partial load is modeled as public `ClusterLoadState` and reported through new `RadarApp` prop `onClusterLoadStateChange` (also exported from the package). `useClusterLoadState` drives this; `useDashboard` gains optional `enabled` so the shell observer stops on non-Home views once warmup settles. When Radar chrome is visible, the topbar status dot/label shows the same warmup text (hidden on Home during the center “Loading dashboard…” splash). Home no longer renders its own global deferred-loading row; chromeless hosts without the callback get an optional fallback row on Home via `fallbackClusterLoadState`.
> 
> **Layout and loaders:** Embedded root uses `h-full min-h-0` instead of `h-screen`; connect/switch/auth/takeover/dashboard loaders use `PaneLoader` with `flex-1 min-h-0` instead of duplicated absolute-positioned SVG markup. **`PaneLoader`** adds optional `children` for subtitles, width-constrained centered labels, and wrapping text without shifting the icon.
> 
> **Docs:** README adds embedding height guidance and documents the chromeless load-state callback on the stable `RadarApp` API surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afa0f4c6fdf3e68ef15a5ba0fe24db47c711cd60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->