### PR TITLE
k8s-ui: Checks 'Medium' severity amber → yellow

### DIFF
--- a/packages/k8s-ui/src/components/checks/severity.ts
+++ b/packages/k8s-ui/src/components/checks/severity.ts
@@ -10,14 +10,15 @@ import {
 } from '../ui/severity-tone'
 
 // The visual language for the 4-tier Checks severity ladder. One hue per tier:
-// red=critical, orange=high, amber=medium, neutral=low — read the queue's left
-// rail top-to-bottom and severity is obvious without reading a word. The actual
-// color strings are shared with the Issue card via the tone module; here we only
-// map each tier onto its tone.
+// red=critical, orange=high, yellow=medium, neutral=low — read the queue's left
+// rail top-to-bottom and severity is obvious without reading a word. Medium is
+// yellow (not amber) so it sits a clear hue-step below high's orange rather than
+// blurring into it. The color strings are shared with the Issue card via the
+// tone module; here we only map each tier onto its tone.
 const CHECK_SEVERITY_TONE: Record<CheckSeverity, SeverityTone> = {
   critical: 'red',
   high: 'orange',
-  medium: 'amber',
+  medium: 'yellow',
   low: 'slate',
 }
 
@@ -35,14 +36,17 @@ export const SEVERITY_LABEL: Record<CheckSeverity, string> = {
   low: 'Low',
 }
 
-// Pill badge — the loud, explicit severity signal on rows + drawer header.
-// Uses the canonical Badge severity tones (BADGE_SEVERITY_COLORS) so the queue's
-// severity pills read identically to status badges everywhere else (rendered
-// with `badge-sm`).
+// Soft pill badge — the loud, explicit severity signal on rows + drawer header.
+// Critical/high/low reuse the canonical Badge tones; medium takes an explicit
+// yellow (matching its tone above) rather than the shared amber `warning` tone,
+// so it reads a clear step below high's orange without shifting the amber
+// `warning` badge used elsewhere (Issues, GitOps). yellow-800 on yellow-100
+// clears WCAG for the pill text.
 export const SEVERITY_BADGE_CLASS: Record<CheckSeverity, string> = {
   critical: sev.error,
   high: sev.alert,
-  medium: sev.warning,
+  medium:
+    'bg-yellow-100 text-yellow-800 border-yellow-300 dark:bg-yellow-950/50 dark:text-yellow-400 dark:border-yellow-700/40',
   low: sev.neutral,
 }
 

--- a/packages/k8s-ui/src/components/ui/severity-tone.ts
+++ b/packages/k8s-ui/src/components/ui/severity-tone.ts
@@ -7,13 +7,16 @@
 // Literal class strings (no template interpolation) so Tailwind's scanner sees
 // every utility.
 
-export type SeverityTone = 'red' | 'orange' | 'amber' | 'slate'
+export type SeverityTone = 'red' | 'orange' | 'amber' | 'yellow' | 'slate'
 
-// Text color — leading severity glyph + emphasis text.
+// Text color — leading severity glyph + emphasis text. Yellow takes the darker
+// -700 step in light mode: its low luminance is illegible at -600 on a light
+// surface, where red/orange/amber still clear.
 export const TONE_TEXT_CLASS: Record<SeverityTone, string> = {
   red: 'text-red-600 dark:text-red-400',
   orange: 'text-orange-600 dark:text-orange-400',
   amber: 'text-amber-600 dark:text-amber-400',
+  yellow: 'text-yellow-700 dark:text-yellow-400',
   slate: 'text-slate-500 dark:text-slate-400',
 }
 
@@ -22,6 +25,7 @@ export const TONE_FILL_CLASS: Record<SeverityTone, string> = {
   red: 'bg-red-500',
   orange: 'bg-orange-500',
   amber: 'bg-amber-500',
+  yellow: 'bg-yellow-500',
   slate: 'bg-slate-400',
 }
 
@@ -31,17 +35,19 @@ export const TONE_RAIL_CLASS: Record<SeverityTone, string> = {
   red: 'border-l-red-500 hover:bg-red-50/40 dark:hover:bg-red-950/20',
   orange: 'border-l-orange-500 hover:bg-orange-50/40 dark:hover:bg-orange-950/20',
   amber: 'border-l-amber-500 hover:bg-amber-50/30 dark:hover:bg-amber-950/15',
+  yellow: 'border-l-yellow-500 hover:bg-yellow-50/30 dark:hover:bg-yellow-950/15',
   slate: 'border-l-slate-300 dark:border-l-slate-600 hover:bg-theme-hover/40',
 }
 
 // Solid severity pill — the loud focus signal on an expanded card's header band
 // (collapsed cards keep the soft BADGE pill so a long queue stays calm).
-// The warm mid-tones (orange/amber) take dark text: white on orange-600/amber-500
-// sits at ~3.5:1/~2.1:1, below WCAG for the 12px pill text.
+// The warm mid-tones (orange/amber/yellow) take dark text: white on them sits
+// below WCAG for the 12px pill text.
 export const TONE_SOLID_CLASS: Record<SeverityTone, string> = {
   red: 'bg-red-600 text-white',
   orange: 'bg-orange-500 text-orange-950',
   amber: 'bg-amber-400 text-amber-950',
+  yellow: 'bg-yellow-400 text-yellow-950',
   slate: 'bg-slate-500 text-white dark:bg-slate-600',
 }
 
@@ -52,5 +58,6 @@ export const TONE_HEADER_BAND_CLASS: Record<SeverityTone, string> = {
   red: 'border-l-red-500 bg-red-50 dark:bg-red-950/40',
   orange: 'border-l-orange-500 bg-orange-50 dark:bg-orange-950/30',
   amber: 'border-l-amber-500 bg-amber-50 dark:bg-amber-950/30',
+  yellow: 'border-l-yellow-500 bg-yellow-50 dark:bg-yellow-950/30',
   slate: 'border-l-slate-300 dark:border-l-slate-600 bg-slate-50 dark:bg-slate-900/40',
 }


### PR DESCRIPTION
## Summary

On the Checks queue, Critical=red, High=orange, Medium=amber crammed three warm hues into a tight band — High and Medium read almost the same at a glance. This adds a `yellow` severity tone and maps Medium onto it, so the ladder is **red → orange → yellow → slate**: evenly spaced while keeping the "hotter = worse" convention (yellow = caution/medium).

## What changed

- `severity-tone.ts` gains a `yellow` tone across all five class maps (text, fill, rail, solid pill, header band).
- The Check ladder maps Medium → `yellow` (was `amber`).
- Medium's soft badge takes an explicit yellow rather than the shared `amber` `warning` badge tone — so the change is scoped to the Check ladder and doesn't shift the `warning` badge used by Issues / GitOps.

Contrast: yellow's low luminance means the emphasis-text tone uses `yellow-700` in light mode (not `-600` like the others); the soft badge `yellow-100/800` and solid pill `yellow-400/950` clear WCAG for pill text. Verified in-browser (light + dark): High=orange and Medium=yellow dots/badges are now clearly distinct.

## Delivery

This is a k8s-ui change; it reaches radar-hub-web via a k8s-ui publish + a dep bump there. Radar OSS's Checks view picks it up directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only Tailwind class and tone mapping changes in k8s-ui Checks severity styling; no logic, API, or auth impact.
> 
> **Overview**
> **Checks queue** Medium severity is re-colored from **amber** to **yellow** so **High (orange)** and **Medium** are easier to tell apart when scanning rails, dots, and badges.
> 
> A new **`yellow`** entry is added to the shared `severity-tone` maps (text, fill, rail, solid pill, header band), with light-mode text at **`yellow-700`** and badge/pill pairs chosen for contrast. **`checks/severity.ts`** maps Medium to **`yellow`** and gives Medium a **dedicated yellow soft badge** instead of the shared amber **`warning`** badge, so Issues/GitOps warning styling stays unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe17117bb70ee603e191a6d4fadb28c217e0c8c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->