### PR TITLE
audit: feed pod metrics so resourceUtilization actually evaluates

### DIFF
--- a/internal/audit/runner.go
+++ b/internal/audit/runner.go
@@ -15,8 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/skyhook-io/radar/internal/k8s"
-	"github.com/skyhook-io/radar/pkg/k8score"
 	bp "github.com/skyhook-io/radar/pkg/audit"
+	"github.com/skyhook-io/radar/pkg/k8score"
 )
 
 // RunOptions provides optional data sources for checks that need them.
@@ -31,6 +31,11 @@ func RunFromCache(cache *k8s.ResourceCache, namespaces []string, opts *RunOption
 	if cache == nil {
 		return &bp.ScanResults{Summary: bp.ScanSummary{Categories: map[string]bp.CategorySummary{}}}
 	}
+
+	// Capture the context generation before reading the cache. If a context
+	// switch lands while we're building the input, the metrics join below bails
+	// rather than pairing this cluster's pods with the next cluster's usage.
+	gen := k8s.CurrentOperationGen()
 
 	input := &bp.CheckInput{
 		Pods:                     listNamespaced(cache.Pods(), namespaces),
@@ -53,6 +58,17 @@ func RunFromCache(cache *k8s.ResourceCache, namespaces []string, opts *RunOption
 	if opts != nil {
 		input.ClusterVersion = opts.ClusterVersion
 		input.ServedAPIs = opts.ServedAPIs
+	}
+
+	// resourceUtilization needs live pod usage joined with each pod's requests.
+	// Usage comes from the metrics-history store (nil until metrics-server is
+	// polled); requests come from the pod specs already listed above. When no
+	// usage is available PodMetrics stays nil and the check honestly reports as
+	// a missing input rather than running on nothing.
+	if store := k8s.GetMetricsHistory(); store != nil && k8s.CurrentOperationGen() == gen {
+		if usage := store.GetAllPodMetricsLatest(); len(usage) > 0 {
+			input.PodMetrics = joinPodMetrics(usage, input.Pods)
+		}
 	}
 
 	// Crossplane Managed Resources / Composites / Claims live in the dynamic
@@ -312,6 +328,60 @@ func isCrossplaneComposite(u *unstructured.Unstructured) bool {
 		}
 	}
 	return false
+}
+
+// joinPodMetrics pairs live pod usage (metrics-history store, CPU in nanocores)
+// with each in-scope pod's summed container requests, normalized to the
+// millicores/bytes units resourceUtilization compares. Only pods that both
+// reported a usage sample and are in the audited scope are included — a pod with
+// no sample isn't evaluated. Returns nil when nothing is measurable so the check
+// stays in MissingInputs rather than reporting a false empty pass.
+func joinPodMetrics(usage []k8score.TopPodMetrics, pods []*corev1.Pod) []bp.PodMetricsInput {
+	type req struct{ cpuMilli, memBytes int64 }
+	reqByPod := make(map[string]req, len(pods))
+	for _, p := range pods {
+		var r req
+		add := func(c corev1.Container) {
+			if q, ok := c.Resources.Requests[corev1.ResourceCPU]; ok {
+				r.cpuMilli += q.MilliValue()
+			}
+			if q, ok := c.Resources.Requests[corev1.ResourceMemory]; ok {
+				r.memBytes += q.Value()
+			}
+		}
+		for _, c := range p.Spec.Containers {
+			add(c)
+		}
+		// Native sidecars (initContainers with RestartPolicy=Always) run for the
+		// whole pod lifetime, so their usage is in the pod-level metrics and
+		// their requests belong in the denominator.
+		for _, c := range p.Spec.InitContainers {
+			if c.RestartPolicy != nil && *c.RestartPolicy == corev1.ContainerRestartPolicyAlways {
+				add(c)
+			}
+		}
+		reqByPod[p.Namespace+"/"+p.Name] = r
+	}
+
+	out := make([]bp.PodMetricsInput, 0, len(usage))
+	for _, m := range usage {
+		r, inScope := reqByPod[m.Namespace+"/"+m.Name]
+		if !inScope {
+			continue
+		}
+		out = append(out, bp.PodMetricsInput{
+			Namespace:     m.Namespace,
+			Name:          m.Name,
+			CPUUsage:      m.CPU / 1_000_000, // nanocores → millicores
+			MemoryUsage:   m.Memory,
+			CPURequest:    r.cpuMilli,
+			MemoryRequest: r.memBytes,
+		})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // lister is a generic interface that all typed K8s listers satisfy.

--- a/internal/audit/runner_test.go
+++ b/internal/audit/runner_test.go
@@ -1,11 +1,17 @@
 package audit
 
 import (
+	"strconv"
 	"testing"
 
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+
+	bp "github.com/skyhook-io/radar/pkg/audit"
+	"github.com/skyhook-io/radar/pkg/k8score"
 )
 
 type testLister[T any] struct {
@@ -33,3 +39,101 @@ func TestListNamespacedFiltersBatchResources(t *testing.T) {
 		t.Fatalf("expected only target namespace CronJob, got %#v", cronJobs)
 	}
 }
+
+func TestJoinPodMetrics(t *testing.T) {
+	pod := func(ns, name string, cpuMilli, memMi int64) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{
+				Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse(fmtMilli(cpuMilli)),
+					corev1.ResourceMemory: resource.MustParse(fmtMi(memMi)),
+				}},
+			}}},
+		}
+	}
+	pods := []*corev1.Pod{
+		pod("prod", "web", 200, 256), // requests: 200m cpu, 256Mi mem
+		pod("prod", "no-req-but-in-scope", 0, 0),
+		pod("prod", "no-metrics", 100, 128), // in scope but no usage sample
+	}
+	// Usage: CPU in nanocores, Memory in bytes. web uses 20m (=20e6 nanocores);
+	// out-of-scope reports usage but isn't in the audited pod set.
+	usage := []k8score.TopPodMetrics{
+		{Namespace: "prod", Name: "web", CPU: 20_000_000, Memory: 64 * 1024 * 1024},
+		{Namespace: "prod", Name: "no-req-but-in-scope", CPU: 5_000_000, Memory: 8 * 1024 * 1024},
+		{Namespace: "other", Name: "out-of-scope", CPU: 999_000_000, Memory: 1 << 30},
+	}
+
+	got := joinPodMetrics(usage, pods)
+
+	byName := map[string]bp.PodMetricsInput{}
+	for _, m := range got {
+		byName[m.Name] = m
+	}
+	if _, ok := byName["out-of-scope"]; ok {
+		t.Error("out-of-scope pod (no matching in-scope pod) must be excluded")
+	}
+	if _, ok := byName["no-metrics"]; ok {
+		t.Error("in-scope pod with no usage sample must be excluded (not evaluated)")
+	}
+	web := byName["web"]
+	if web.CPUUsage != 20 { // 20e6 nanocores → 20 millicores
+		t.Errorf("web CPUUsage = %d, want 20 millicores", web.CPUUsage)
+	}
+	if web.CPURequest != 200 {
+		t.Errorf("web CPURequest = %d, want 200 millicores", web.CPURequest)
+	}
+	if web.MemoryUsage != 64*1024*1024 {
+		t.Errorf("web MemoryUsage = %d bytes", web.MemoryUsage)
+	}
+	if web.MemoryRequest != 256*1024*1024 {
+		t.Errorf("web MemoryRequest = %d bytes, want 256Mi", web.MemoryRequest)
+	}
+	// A pod with usage but zero requests is still surfaced (the check itself
+	// treats zero-request pods as out of scope, not this join).
+	if _, ok := byName["no-req-but-in-scope"]; !ok {
+		t.Error("in-scope pod with a usage sample should be surfaced even with zero requests")
+	}
+
+	if joinPodMetrics(nil, pods) != nil {
+		t.Error("no usage samples must return nil (stays in MissingInputs), not an empty slice")
+	}
+}
+
+func TestJoinPodMetricsCountsNativeSidecarRequests(t *testing.T) {
+	always := corev1.ContainerRestartPolicyAlways
+	req := func(cpuMilli, memMi int64) corev1.ResourceRequirements {
+		return corev1.ResourceRequirements{Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse(fmtMilli(cpuMilli)),
+			corev1.ResourceMemory: resource.MustParse(fmtMi(memMi)),
+		}}
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "prod", Name: "meshed"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Resources: req(100, 128)}}, // app: 100m / 128Mi
+			InitContainers: []corev1.Container{
+				{Resources: req(50, 64), RestartPolicy: &always}, // native sidecar: counts
+				{Resources: req(999, 999)},                       // plain init: excluded
+			},
+		},
+	}
+	usage := []k8score.TopPodMetrics{{Namespace: "prod", Name: "meshed", CPU: 30_000_000, Memory: 1}}
+
+	got := joinPodMetrics(usage, []*corev1.Pod{pod})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(got))
+	}
+	// app (100m/128Mi) + native sidecar (50m/64Mi); plain init container excluded.
+	if got[0].CPURequest != 150 {
+		t.Errorf("CPURequest = %d, want 150m (app + native sidecar, not plain init)", got[0].CPURequest)
+	}
+	if got[0].MemoryRequest != 192*1024*1024 {
+		t.Errorf("MemoryRequest = %d, want 192Mi (app + native sidecar)", got[0].MemoryRequest)
+	}
+}
+
+func fmtMilli(m int64) string { return itoa(m) + "m" }
+func fmtMi(mi int64) string   { return itoa(mi) + "Mi" }
+func itoa(n int64) string     { return strconv.FormatInt(n, 10) }

--- a/internal/k8s/context_manager.go
+++ b/internal/k8s/context_manager.go
@@ -123,6 +123,13 @@ func currentOperationGen() uint64 {
 	return operationGen
 }
 
+// CurrentOperationGen exposes currentOperationGen to other packages so a
+// multi-source read (e.g. the audit joining cache pods with the global metrics
+// store) can detect a context switch that landed mid-read and bail out.
+func CurrentOperationGen() uint64 {
+	return currentOperationGen()
+}
+
 // NewOperationContext returns a context derived from the current operation
 // context with the given timeout. Use this instead of context.Background()
 // for API calls that should be canceled on context switch.

--- a/internal/k8s/metrics_history.go
+++ b/internal/k8s/metrics_history.go
@@ -44,6 +44,10 @@ func InitMetricsHistory() {
 
 // GetMetricsHistory returns the metrics history store.
 func GetMetricsHistory() *MetricsHistoryStore {
+	// Read under the same lock Init/Reset write the pointer with — audit scans
+	// (HTTP/MCP) now call this concurrently with a context switch's Reset.
+	metricsHistoryMu.Lock()
+	defer metricsHistoryMu.Unlock()
 	return metricsHistoryStore
 }
 


### PR DESCRIPTION
## Summary

The `resourceUtilization` audit check — the one that flags over-/under-provisioned pods (usage far from requests) — has never run in the fleet audit. The runner built `CheckInput` from the resource cache but never populated `PodMetrics`, so the check silently no-op'd: its efficiency findings never appeared and its coverage denominator was always absent (it just showed up as a missing input). Radar already collects the data — this wires it in.

## What changed

`RunFromCache` now builds `PodMetrics` by joining two sources it already has access to:
- **Usage** from the metrics-history store (`GetAllPodMetricsLatest()`), the same continuously-polled store that backs the Top/metrics views.
- **Requests** summed per pod from the container specs already listed for the audit.

`joinPodMetrics` normalizes both to the millicores/bytes the check compares (store CPU is nanocores), and only includes pods that **both** reported a usage sample and are in the audited scope — a pod with no sample isn't evaluated.

Points worth a reviewer's eye:
- **Native sidecars count.** The request denominator includes `initContainers` with `RestartPolicy=Always` — their usage is part of pod-level metrics, so omitting their requests would inflate the ratio and produce false warnings.
- **Honest when metrics are absent.** If metrics-server hasn't reported (store nil or empty), `PodMetrics` stays nil and the check reports as a missing input rather than a false empty pass — no behavior change on clusters without metrics.
- **Concurrency-safe read.** `GetMetricsHistory()` now reads the store pointer under the same lock `Init`/`Reset` write it with, since audit scans (HTTP/MCP) call it concurrently with a context-switch reset.

## Testing

`go build ./...`, `go test ./internal/audit/ ./pkg/audit/` green. New unit tests cover the usage↔request join (unit conversion, in-scope filtering, nil-when-empty) and the native-sidecar denominator (native sidecar counted, plain init container excluded).

Live-verified across three environments:
- **GKE** (218 pods, metrics-server): `resourceUtilization` evaluates 71 pods (10 passing) → 61 findings; spot-checked a flagged pod's reported usage/requests against `kubectl top` + the pod spec to confirm the unit conversion is correct on real data. The fleet has 9 native-sidecar pods, exercising the init-container denominator path.
- **EKS** (63 pods, ARN context): evaluates 15 pods (4 passing) → 11 findings — confirms the path on a non-GKE provider.
- **kind, no metrics-server**: graceful degradation — `resourceUtilization` stays in `missingInputs`, produces zero findings, and does not panic (identical to prior behavior).

In both metrics-present clusters `podmetrics` is gone from `missingInputs` — the check runs instead of being reported as unavailable.