### PR TITLE
server: evict saved namespace picks whose namespace was deleted

### DIFF
--- a/internal/server/namespace_scope.go
+++ b/internal/server/namespace_scope.go
@@ -58,6 +58,28 @@ func nsPreferenceKey(username, contextName string) string {
 	return username + "\x00" + contextName
 }
 
+// getActiveNamespaceForUserInContext returns this user's picks together with
+// the context they were read under, as one atomic snapshot. Read paths that
+// later mutate the pick must commit against the returned ctxName — capturing
+// the context in a separate GetContextName() call risks a mismatch if the
+// context switches between the two reads.
+func (s *Server) getActiveNamespaceForUserInContext(r *http.Request) (string, []string) {
+	username := ""
+	if u := auth.UserFromContext(r.Context()); u != nil {
+		username = u.Username
+	}
+	ctxName := k8s.GetContextName()
+	if ctxName == "" {
+		return "", nil
+	}
+	v, ok := s.nsPreferences.Load(nsPreferenceKey(username, ctxName))
+	if !ok {
+		return ctxName, nil
+	}
+	picks, _ := v.([]string)
+	return ctxName, picks
+}
+
 // getActiveNamespaceForUser returns this user's namespace picks for the
 // current context. Empty/nil means "All namespaces."
 func (s *Server) getActiveNamespaceForUser(r *http.Request) []string {
@@ -147,7 +169,10 @@ func (s *Server) loadSavedNamespacePreference(r *http.Request) {
 		return
 	}
 	if picks := saved.ActiveNamespaces[ctxName]; len(picks) > 0 {
-		s.nsPreferences.Store(key, append([]string(nil), picks...))
+		// Seed only while the pick is still empty. The Load check above is
+		// racy on its own — a concurrent POST could install a pick between it
+		// and this store — so re-check under the lock and skip if one landed.
+		s.commitPickMutation(r, ctxName, nil, picks, false)
 	}
 }
 
@@ -160,6 +185,66 @@ func pruneToExistingNamespaces(picks, existing []string) []string {
 		return picks
 	}
 	return intersectPicksWithAllowed(picks, existing)
+}
+
+// commitPickMutation replaces the active pick with survivors, but only if the
+// stored pick is still exactly `expected` under the still-current context.
+//
+// Every read-path pick mutation (deleted-namespace prune, RBAC trim, empty-
+// fallback clear, first-request seed) computes its result from a snapshot read
+// earlier in the request. Between that read and the write, a concurrent POST
+// can install a fresh pick or a context switch can swap the cluster. Writing
+// unconditionally would revert the fresh pick or persist old-context survivors
+// under the new context's key — the lost-update class the namespace-pick lock
+// exists to close. On a snapshot mismatch the write is skipped: the caller
+// still uses its own snapshot for this one request, and the live pick
+// re-converges on its next read.
+//
+// persist rewrites the no-auth settings.json so the mutation survives a restart
+// (and isn't re-seeded stale from disk). Only the deleted-namespace prune sets
+// it — an RBAC trim, empty-fallback clear, or seed is a per-user in-memory view
+// filter that must not touch the shared single-user settings file.
+func (s *Server) commitPickMutation(r *http.Request, ctxName string, expected, survivors []string, persist bool) {
+	if ctxName == "" {
+		return
+	}
+	username := ""
+	if u := auth.UserFromContext(r.Context()); u != nil {
+		username = u.Username
+	}
+	key := nsPreferenceKey(username, ctxName)
+
+	s.nsPickMu.Lock()
+	defer s.nsPickMu.Unlock()
+
+	// Bind the whole mutation to the snapshot ctxName — never re-derive the
+	// key from the live context inside the critical section. A concurrent
+	// context switch flips k8s.GetContextName() without holding nsPickMu, so
+	// going through get/setActiveNamespaceForUser (which each re-read the live
+	// context) could compare against one context's pick and then store under
+	// another's. Skip if the context already moved on; otherwise read, compare,
+	// and write all under the same key.
+	if k8s.GetContextName() != ctxName {
+		return
+	}
+	var current []string
+	if v, ok := s.nsPreferences.Load(key); ok {
+		current, _ = v.([]string)
+	}
+	if !slices.Equal(current, expected) {
+		return
+	}
+	if len(survivors) == 0 {
+		s.nsPreferences.Delete(key)
+	} else {
+		// Defensive copy so callers can mutate their input after the store.
+		s.nsPreferences.Store(key, append([]string(nil), survivors...))
+	}
+	if persist && auth.UserFromContext(r.Context()) == nil && !k8s.ForceNamespaceScope {
+		if err := persistNamespacePick(ctxName, survivors); err != nil {
+			log.Printf("[namespace] failed to persist namespace pick for context %q: %v", ctxName, err)
+		}
+	}
 }
 
 // pruneDeletedNamespacePicks drops saved picks whose namespaces were deleted
@@ -176,28 +261,10 @@ func pruneToExistingNamespaces(picks, existing []string) []string {
 func (s *Server) pruneDeletedNamespacePicks(r *http.Request, picks []string) []string {
 	ctxName := k8s.GetContextName()
 	survivors := pruneToExistingNamespaces(picks, s.allNamespaceNames())
-	if len(survivors) == len(picks) || ctxName == "" {
+	if len(survivors) == len(picks) {
 		return survivors
 	}
-
-	// The prune validated a snapshot; mutate only if that snapshot is still
-	// the live state. A concurrent POST replacing the pick, or a context
-	// switch mid-request, makes the survivors stale — skip, and let the new
-	// pick be pruned on its own next read. Without the guard a slow read
-	// could land after a user's fresh pick and silently revert it, or
-	// persist old-context survivors under the new context's key.
-	s.nsPickMu.Lock()
-	defer s.nsPickMu.Unlock()
-	if k8s.GetContextName() != ctxName || !slices.Equal(s.getActiveNamespaceForUser(r), picks) {
-		return survivors
-	}
-
-	s.setActiveNamespaceForUser(r, survivors)
-	if auth.UserFromContext(r.Context()) == nil && !k8s.ForceNamespaceScope {
-		if err := persistNamespacePick(ctxName, survivors); err != nil {
-			log.Printf("[namespace] failed to persist pruned namespace pick for context %q: %v", ctxName, err)
-		}
-	}
+	s.commitPickMutation(r, ctxName, picks, survivors, true)
 	return survivors
 }
 
@@ -230,7 +297,10 @@ func (s *Server) handleGetNamespaceScope(w http.ResponseWriter, r *http.Request)
 	}
 
 	s.loadSavedNamespacePreference(r)
-	actives := s.pruneDeletedNamespacePicks(r, s.getActiveNamespaceForUser(r))
+	// Read the pick and its context as one snapshot so a later trim commits
+	// against the same context it was computed from, not a switched-in one.
+	pickCtx, activesRaw := s.getActiveNamespaceForUserInContext(r)
+	actives := s.pruneDeletedNamespacePicks(r, activesRaw)
 	kubeNs := k8s.GetContextNamespace()
 	cacheScopeNs := k8s.GetNamespaceScopeTarget()
 
@@ -258,12 +328,13 @@ func (s *Server) handleGetNamespaceScope(w http.ResponseWriter, r *http.Request)
 
 	// Drop picks that the user no longer has access to (RBAC changed mid-
 	// session). Partial revocation: keep the survivors, only clear the pick
-	// entirely when nothing survives. Persist the trimmed set so it doesn't
-	// re-trim on every read.
+	// entirely when nothing survives. Store the trimmed set so it doesn't
+	// re-trim on every read — through the guarded mutation so a stale trim
+	// can't revert a concurrent POST or cross a context switch.
 	if len(actives) > 0 {
 		survivors := intersectPicksWithAllowed(actives, namespaces)
 		if len(survivors) != len(actives) {
-			s.setActiveNamespaceForUser(r, survivors)
+			s.commitPickMutation(r, pickCtx, actives, survivors, false)
 			actives = survivors
 		}
 	}

--- a/internal/server/namespace_scope.go
+++ b/internal/server/namespace_scope.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/skyhook-io/radar/internal/auth"
@@ -149,6 +150,56 @@ func (s *Server) loadSavedNamespacePreference(r *http.Request) {
 	}
 }
 
+// pruneToExistingNamespaces returns picks minus namespaces absent from
+// existing. An empty existing list means the namespace informer can't answer
+// (namespace-scoped cache, restricted RBAC) — picks pass through unchanged,
+// since wrongly evicting a valid pick is worse than keeping a stale one.
+func pruneToExistingNamespaces(picks, existing []string) []string {
+	if len(existing) == 0 {
+		return picks
+	}
+	return intersectPicksWithAllowed(picks, existing)
+}
+
+// pruneDeletedNamespacePicks drops saved picks whose namespaces were deleted
+// from the cluster. Without this, a stale pick silently empties every read —
+// in no-auth mode nothing downstream re-validates it (getUserNamespaces is a
+// pass-through), so the UI looks like an empty cluster forever.
+//
+// Survivors are written back to the in-memory pick and, for the no-auth
+// single-user case, to settings.json — otherwise loadSavedNamespacePreference
+// re-seeds the stale pick from disk on the next request and the eviction is
+// undone. Skipped under --namespace-scope, where the saved pick doubles as
+// the cache-scope restore value and handleSetActiveNamespace owns its
+// lifecycle.
+func (s *Server) pruneDeletedNamespacePicks(r *http.Request, picks []string) []string {
+	ctxName := k8s.GetContextName()
+	survivors := pruneToExistingNamespaces(picks, s.allNamespaceNames())
+	if len(survivors) == len(picks) || ctxName == "" {
+		return survivors
+	}
+
+	// The prune validated a snapshot; mutate only if that snapshot is still
+	// the live state. A concurrent POST replacing the pick, or a context
+	// switch mid-request, makes the survivors stale — skip, and let the new
+	// pick be pruned on its own next read. Without the guard a slow read
+	// could land after a user's fresh pick and silently revert it, or
+	// persist old-context survivors under the new context's key.
+	s.nsPickMu.Lock()
+	defer s.nsPickMu.Unlock()
+	if k8s.GetContextName() != ctxName || !slices.Equal(s.getActiveNamespaceForUser(r), picks) {
+		return survivors
+	}
+
+	s.setActiveNamespaceForUser(r, survivors)
+	if auth.UserFromContext(r.Context()) == nil && !k8s.ForceNamespaceScope {
+		if err := persistNamespacePick(ctxName, survivors); err != nil {
+			log.Printf("[namespace] failed to persist pruned namespace pick for context %q: %v", ctxName, err)
+		}
+	}
+	return survivors
+}
+
 // intersectPicksWithAllowed returns the picks that survive RBAC filtering.
 // allowed=nil means cluster-admin / auth-disabled — all picks pass through.
 // Returns nil when the input picks are empty (no narrowing in effect).
@@ -178,7 +229,7 @@ func (s *Server) handleGetNamespaceScope(w http.ResponseWriter, r *http.Request)
 	}
 
 	s.loadSavedNamespacePreference(r)
-	actives := s.getActiveNamespaceForUser(r)
+	actives := s.pruneDeletedNamespacePicks(r, s.getActiveNamespaceForUser(r))
 	kubeNs := k8s.GetContextNamespace()
 	cacheScopeNs := k8s.GetNamespaceScopeTarget()
 
@@ -365,6 +416,12 @@ func (s *Server) handleSetActiveNamespace(w http.ResponseWriter, r *http.Request
 		s.scopeMutationMu.Lock()
 		defer s.scopeMutationMu.Unlock()
 	}
+	// Pairs this handler's persist+set with the read-path stale-pick prune:
+	// the prune re-checks the live pick under the same lock before mutating,
+	// so it can't revert a pick set here from a stale snapshot. Lock order is
+	// scopeMutationMu → nsPickMu; the prune takes only nsPickMu.
+	s.nsPickMu.Lock()
+	defer s.nsPickMu.Unlock()
 
 	// Persist the no-auth (single-user) pick across restarts before acting on it.
 	// Auth-enabled deploys skip persistence — it'd require user-keyed storage we

--- a/internal/server/namespace_scope.go
+++ b/internal/server/namespace_scope.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/skyhook-io/radar/internal/auth"
 	"github.com/skyhook-io/radar/internal/k8s"
@@ -420,8 +421,14 @@ func (s *Server) handleSetActiveNamespace(w http.ResponseWriter, r *http.Request
 	// the prune re-checks the live pick under the same lock before mutating,
 	// so it can't revert a pick set here from a stale snapshot. Lock order is
 	// scopeMutationMu → nsPickMu; the prune takes only nsPickMu.
+	//
+	// Released explicitly before the closing handleGetNamespaceScope render:
+	// that path runs the prune, which takes nsPickMu itself — holding it
+	// across the render would self-deadlock (the mutex is not reentrant).
+	// OnceFunc keeps every early error return covered by the defer.
 	s.nsPickMu.Lock()
-	defer s.nsPickMu.Unlock()
+	unlockNsPick := sync.OnceFunc(s.nsPickMu.Unlock)
+	defer unlockNsPick()
 
 	// Persist the no-auth (single-user) pick across restarts before acting on it.
 	// Auth-enabled deploys skip persistence — it'd require user-keyed storage we
@@ -480,6 +487,7 @@ func (s *Server) handleSetActiveNamespace(w http.ResponseWriter, r *http.Request
 	}
 
 	s.setActiveNamespaceForUser(r, cleaned)
+	unlockNsPick()
 
 	// Return the fresh scope state so the UI can update without a follow-up GET.
 	s.handleGetNamespaceScope(w, r)

--- a/internal/server/namespace_scope.go
+++ b/internal/server/namespace_scope.go
@@ -258,8 +258,11 @@ func (s *Server) commitPickMutation(r *http.Request, ctxName string, expected, s
 // undone. Skipped under --namespace-scope, where the saved pick doubles as
 // the cache-scope restore value and handleSetActiveNamespace owns its
 // lifecycle.
-func (s *Server) pruneDeletedNamespacePicks(r *http.Request, picks []string) []string {
-	ctxName := k8s.GetContextName()
+// ctxName is the context the picks were snapshotted under (from
+// getActiveNamespaceForUserInContext). The commit binds to it rather than
+// re-reading the live context, so a switch between the caller's snapshot and
+// this prune can't persist old-context survivors under the new context's key.
+func (s *Server) pruneDeletedNamespacePicks(r *http.Request, ctxName string, picks []string) []string {
 	survivors := pruneToExistingNamespaces(picks, s.allNamespaceNames())
 	// Compare contents, not just length: skip the write only when nothing
 	// actually changed. A length check would rely on the prune being a pure
@@ -303,7 +306,7 @@ func (s *Server) handleGetNamespaceScope(w http.ResponseWriter, r *http.Request)
 	// Read the pick and its context as one snapshot so a later trim commits
 	// against the same context it was computed from, not a switched-in one.
 	pickCtx, activesRaw := s.getActiveNamespaceForUserInContext(r)
-	actives := s.pruneDeletedNamespacePicks(r, activesRaw)
+	actives := s.pruneDeletedNamespacePicks(r, pickCtx, activesRaw)
 	kubeNs := k8s.GetContextNamespace()
 	cacheScopeNs := k8s.GetNamespaceScopeTarget()
 

--- a/internal/server/namespace_scope.go
+++ b/internal/server/namespace_scope.go
@@ -261,7 +261,10 @@ func (s *Server) commitPickMutation(r *http.Request, ctxName string, expected, s
 func (s *Server) pruneDeletedNamespacePicks(r *http.Request, picks []string) []string {
 	ctxName := k8s.GetContextName()
 	survivors := pruneToExistingNamespaces(picks, s.allNamespaceNames())
-	if len(survivors) == len(picks) {
+	// Compare contents, not just length: skip the write only when nothing
+	// actually changed. A length check would rely on the prune being a pure
+	// order-preserving filter; equality holds regardless of how it evolves.
+	if slices.Equal(survivors, picks) {
 		return survivors
 	}
 	s.commitPickMutation(r, ctxName, picks, survivors, true)

--- a/internal/server/namespace_scope_test.go
+++ b/internal/server/namespace_scope_test.go
@@ -473,7 +473,7 @@ func TestPruneDeletedNamespacePicks_SkipsWhenPickChangedMidFlight(t *testing.T) 
 	// A user POST lands while the read is pruning its snapshot.
 	s.setActiveNamespaceForUser(req, []string{"broken"})
 
-	survivors := s.pruneDeletedNamespacePicks(req, snapshot)
+	survivors := s.pruneDeletedNamespacePicks(req, "test-ctx", snapshot)
 	if !slices.Equal(survivors, []string{"default"}) {
 		t.Fatalf("survivors = %v, want [default] (this request still filters by its own snapshot)", survivors)
 	}
@@ -619,20 +619,27 @@ func TestPruneDeletedNamespacePicks_SkipsAcrossContextSwitch(t *testing.T) {
 	snapshot := []string{"default", "ghost"}
 	s.setActiveNamespaceForUser(req, snapshot)
 
-	// Simulate the interleaving: the prune's entry snapshot saw "test-ctx";
-	// wrap the call so the context flips before it runs (the guard re-reads
-	// the context under the lock, so a flip before the call exercises the
-	// same skip path as one mid-call).
+	// The pick was snapshotted under "test-ctx"; the context flips to
+	// "other-ctx" before the prune runs. Preseed other-ctx with the SAME value,
+	// so a prune that keyed off the live context would find its stored pick
+	// equal to the snapshot and wrongly trim it. Prune carries the snapshot
+	// ctx, so the commit guard (live context != snapshot ctx) skips the write.
 	prev := k8s.SetTestContextName("other-ctx")
-	survivorsUnderOther := s.pruneDeletedNamespacePicks(req, snapshot)
-	k8s.SetTestContextName(prev)
+	s.setActiveNamespaceForUser(req, snapshot) // other-ctx pick == snapshot
+	survivorsUnderOther := s.pruneDeletedNamespacePicks(req, "test-ctx", snapshot)
 	_ = survivorsUnderOther
 
-	// The original context's pick and settings are untouched.
+	// other-ctx's coincidentally-matching pick must NOT be trimmed to survivors.
 	if picks := s.getActiveNamespaceForUser(req); !slices.Equal(picks, snapshot) {
-		t.Errorf("old-context pick mutated across switch: %v, want %v", picks, snapshot)
+		t.Errorf("new-context pick trimmed by a stale-snapshot prune: %v, want %v", picks, snapshot)
 	}
 	if saved := settings.Load().ActiveNamespaces["other-ctx"]; len(saved) != 0 {
 		t.Errorf("survivors persisted under the new context's key: %v", saved)
+	}
+	k8s.SetTestContextName(prev)
+
+	// The original context's pick is also untouched.
+	if picks := s.getActiveNamespaceForUser(req); !slices.Equal(picks, snapshot) {
+		t.Errorf("old-context pick mutated across switch: %v, want %v", picks, snapshot)
 	}
 }

--- a/internal/server/namespace_scope_test.go
+++ b/internal/server/namespace_scope_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/skyhook-io/radar/internal/k8s"
+	"github.com/skyhook-io/radar/internal/settings"
 	pkgauth "github.com/skyhook-io/radar/pkg/auth"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -305,6 +306,113 @@ func restoreHelmNamespaceFallbackState(t *testing.T) {
 	t.Cleanup(func() { k8s.SetFallbackNamespace("") })
 }
 
+// The shared TestMain cache holds exactly two namespaces: "default" and
+// "broken". Anything else counts as deleted from the cluster.
+
+func TestParseNamespacesForUser_EvictsDeletedSavedPick(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	s := newTestServer(t)
+
+	// A pick saved in a previous session names a namespace that has since
+	// been deleted from the cluster.
+	if _, err := settings.Update(func(st *settings.Settings) {
+		st.ActiveNamespaces = map[string][]string{"test-ctx": {"ghost"}}
+	}); err != nil {
+		t.Fatalf("settings.Update: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/resources/pods", nil)
+	if got := s.parseNamespacesForUser(req); got != nil {
+		t.Fatalf("parseNamespacesForUser = %v, want nil (unfiltered) after stale-pick eviction", got)
+	}
+	if picks := s.getActiveNamespaceForUser(reqAs("")); len(picks) != 0 {
+		t.Errorf("stale pick survived in memory: %v", picks)
+	}
+	// The eviction must reach settings.json — otherwise loadSavedNamespace-
+	// Preference re-seeds the stale pick on the next request.
+	if saved := settings.Load().ActiveNamespaces["test-ctx"]; len(saved) != 0 {
+		t.Errorf("stale pick survived in settings: %v", saved)
+	}
+}
+
+func TestParseNamespacesForUser_TrimsPartiallyDeletedPick(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	s := newTestServer(t)
+
+	if _, err := settings.Update(func(st *settings.Settings) {
+		st.ActiveNamespaces = map[string][]string{"test-ctx": {"default", "ghost"}}
+	}); err != nil {
+		t.Fatalf("settings.Update: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/resources/pods", nil)
+	if got := s.parseNamespacesForUser(req); !slices.Equal(got, []string{"default"}) {
+		t.Fatalf("parseNamespacesForUser = %v, want [default]", got)
+	}
+	if picks := s.getActiveNamespaceForUser(reqAs("")); !slices.Equal(picks, []string{"default"}) {
+		t.Errorf("in-memory pick = %v, want [default]", picks)
+	}
+	if saved := settings.Load().ActiveNamespaces["test-ctx"]; !slices.Equal(saved, []string{"default"}) {
+		t.Errorf("saved pick = %v, want [default]", saved)
+	}
+}
+
+func TestParseNamespacesForUser_ValidSavedPickStillFilters(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	s := newTestServer(t)
+	s.setActiveNamespaceForUser(reqAs(""), []string{"default"})
+
+	req := httptest.NewRequest("GET", "/api/resources/pods", nil)
+	if got := s.parseNamespacesForUser(req); !slices.Equal(got, []string{"default"}) {
+		t.Fatalf("parseNamespacesForUser = %v, want [default]", got)
+	}
+	if picks := s.getActiveNamespaceForUser(reqAs("")); !slices.Equal(picks, []string{"default"}) {
+		t.Errorf("valid pick was disturbed: %v", picks)
+	}
+}
+
+func TestPruneToExistingNamespaces(t *testing.T) {
+	tests := []struct {
+		name     string
+		picks    []string
+		existing []string
+		want     []string
+	}{
+		{
+			name:     "nil existing (informer unavailable) leaves picks alone",
+			picks:    []string{"alpha", "beta"},
+			existing: nil,
+			want:     []string{"alpha", "beta"},
+		},
+		{
+			name:     "empty existing leaves picks alone",
+			picks:    []string{"alpha"},
+			existing: []string{},
+			want:     []string{"alpha"},
+		},
+		{
+			name:     "deleted namespace dropped, survivors kept",
+			picks:    []string{"alpha", "ghost"},
+			existing: []string{"alpha", "beta"},
+			want:     []string{"alpha"},
+		},
+		{
+			name:     "all deleted returns empty",
+			picks:    []string{"ghost", "phantom"},
+			existing: []string{"alpha"},
+			want:     []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pruneToExistingNamespaces(tt.picks, tt.existing)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("pruneToExistingNamespaces(%v, %v) = %v, want %v", tt.picks, tt.existing, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseNamespacesForUser_ForcedCacheScope(t *testing.T) {
 	s := newTestServer(t)
 	k8s.ForceNamespaceScope = true
@@ -331,5 +439,61 @@ func TestParseNamespacesForUser_ForcedCacheScope(t *testing.T) {
 				t.Fatalf("parseNamespacesForUser(%q) = %v, want %v", tt.url, got, tt.want)
 			}
 		})
+	}
+}
+
+// The prune validates a snapshot of the pick; if a concurrent POST replaces
+// the pick before the prune's write, the write must be skipped — otherwise a
+// slow read reverts the user's fresh pick to pruned survivors of the old one.
+func TestPruneDeletedNamespacePicks_SkipsWhenPickChangedMidFlight(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	s := newTestServer(t)
+	req := reqAs("")
+
+	// The stale snapshot a slow read is working from.
+	snapshot := []string{"default", "ghost"}
+	s.setActiveNamespaceForUser(req, snapshot)
+
+	// A user POST lands while the read is pruning its snapshot.
+	s.setActiveNamespaceForUser(req, []string{"broken"})
+
+	survivors := s.pruneDeletedNamespacePicks(req, snapshot)
+	if !slices.Equal(survivors, []string{"default"}) {
+		t.Fatalf("survivors = %v, want [default] (this request still filters by its own snapshot)", survivors)
+	}
+	// The fresh pick must be untouched — the prune's write was skipped.
+	if picks := s.getActiveNamespaceForUser(req); !slices.Equal(picks, []string{"broken"}) {
+		t.Errorf("fresh pick reverted by stale prune: %v, want [broken]", picks)
+	}
+	if saved := settings.Load().ActiveNamespaces["test-ctx"]; len(saved) != 0 {
+		t.Errorf("stale prune persisted survivors over the fresh pick: %v", saved)
+	}
+}
+
+// A context switch between snapshot and write must also skip the mutation —
+// old-context survivors must not persist under the new context's key.
+func TestPruneDeletedNamespacePicks_SkipsAcrossContextSwitch(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	s := newTestServer(t)
+	req := reqAs("")
+
+	snapshot := []string{"default", "ghost"}
+	s.setActiveNamespaceForUser(req, snapshot)
+
+	// Simulate the interleaving: the prune's entry snapshot saw "test-ctx";
+	// wrap the call so the context flips before it runs (the guard re-reads
+	// the context under the lock, so a flip before the call exercises the
+	// same skip path as one mid-call).
+	prev := k8s.SetTestContextName("other-ctx")
+	survivorsUnderOther := s.pruneDeletedNamespacePicks(req, snapshot)
+	k8s.SetTestContextName(prev)
+	_ = survivorsUnderOther
+
+	// The original context's pick and settings are untouched.
+	if picks := s.getActiveNamespaceForUser(req); !slices.Equal(picks, snapshot) {
+		t.Errorf("old-context pick mutated across switch: %v, want %v", picks, snapshot)
+	}
+	if saved := settings.Load().ActiveNamespaces["other-ctx"]; len(saved) != 0 {
+		t.Errorf("survivors persisted under the new context's key: %v", saved)
 	}
 }

--- a/internal/server/namespace_scope_test.go
+++ b/internal/server/namespace_scope_test.go
@@ -470,6 +470,129 @@ func TestPruneDeletedNamespacePicks_SkipsWhenPickChangedMidFlight(t *testing.T) 
 	}
 }
 
+// commitPickMutation is the single guarded writer every read-path pick
+// mutation goes through. A stale snapshot must never revert a concurrent POST.
+func TestCommitPickMutation_SkipsWhenPickChangedMidFlight(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	s := newTestServer(t)
+	req := reqAs("")
+
+	// The snapshot a slow read computed its survivors from.
+	snapshot := []string{"default", "ghost"}
+	s.setActiveNamespaceForUser(req, snapshot)
+
+	// A user POST replaces the pick before the read commits.
+	s.setActiveNamespaceForUser(req, []string{"broken"})
+
+	// The read tries to trim its stale snapshot down to survivors.
+	s.commitPickMutation(req, "test-ctx", snapshot, []string{"default"}, false)
+
+	if picks := s.getActiveNamespaceForUser(req); !slices.Equal(picks, []string{"broken"}) {
+		t.Errorf("fresh pick reverted by stale mutation: %v, want [broken]", picks)
+	}
+}
+
+// A commit whose snapshot still matches the live pick must go through — the
+// guard only skips on mismatch, it doesn't block the common case.
+func TestCommitPickMutation_AppliesWhenSnapshotStillLive(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	s := newTestServer(t)
+	req := reqAs("")
+
+	snapshot := []string{"default", "ghost"}
+	s.setActiveNamespaceForUser(req, snapshot)
+
+	s.commitPickMutation(req, "test-ctx", snapshot, []string{"default"}, false)
+
+	if picks := s.getActiveNamespaceForUser(req); !slices.Equal(picks, []string{"default"}) {
+		t.Errorf("in-memory pick = %v, want [default]", picks)
+	}
+	// persist=false: the in-memory trim must NOT touch settings.json.
+	if saved := settings.Load().ActiveNamespaces["test-ctx"]; len(saved) != 0 {
+		t.Errorf("view-filter trim leaked to settings: %v", saved)
+	}
+}
+
+// persist=false must not touch settings even when it clears the pick — the
+// empty-fallback clear and RBAC trim are in-memory view filters.
+func TestCommitPickMutation_ClearWithoutPersistKeepsSettings(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	s := newTestServer(t)
+	req := reqAs("")
+
+	if _, err := settings.Update(func(st *settings.Settings) {
+		st.ActiveNamespaces = map[string][]string{"test-ctx": {"default"}}
+	}); err != nil {
+		t.Fatalf("settings.Update: %v", err)
+	}
+	s.setActiveNamespaceForUser(req, []string{"default"})
+
+	s.commitPickMutation(req, "test-ctx", []string{"default"}, nil, false)
+
+	if picks := s.getActiveNamespaceForUser(req); len(picks) != 0 {
+		t.Errorf("pick not cleared in memory: %v", picks)
+	}
+	if saved := settings.Load().ActiveNamespaces["test-ctx"]; !slices.Equal(saved, []string{"default"}) {
+		t.Errorf("in-memory clear leaked to settings: %v, want [default] preserved", saved)
+	}
+}
+
+// A context switch between the caller's snapshot and the helper's write must
+// skip the whole mutation — the helper keys off the passed snapshot ctxName,
+// never the live context. Regression guard for a helper that re-derived the
+// key from k8s.GetContextName() at write time: it would compare against one
+// context's pick and store under another's.
+func TestCommitPickMutation_SkipsAcrossContextSwitch(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	s := newTestServer(t) // live context = test-ctx
+	req := reqAs("")
+
+	snapshot := []string{"default"}
+	s.setActiveNamespaceForUser(req, snapshot) // pick under test-ctx
+
+	// Switch context and preseed the SAME-valued pick under the new context.
+	// A helper that keyed off the live context would find expected==current
+	// here and wrongly clear it; the snapshot-pinned helper must not.
+	prev := k8s.SetTestContextName("other-ctx")
+	s.setActiveNamespaceForUser(req, []string{"default"}) // pick under other-ctx
+
+	// Caller snapshotted test-ctx; the switch to other-ctx already happened.
+	s.commitPickMutation(req, "test-ctx", snapshot, nil, false)
+
+	// other-ctx pick untouched — the context guard skipped the whole mutation.
+	if picks := s.getActiveNamespaceForUser(req); !slices.Equal(picks, []string{"default"}) {
+		t.Errorf("other-ctx pick mutated under the wrong key: %v, want [default]", picks)
+	}
+	k8s.SetTestContextName(prev)
+	// test-ctx pick also untouched.
+	if picks := s.getActiveNamespaceForUser(req); !slices.Equal(picks, snapshot) {
+		t.Errorf("test-ctx pick mutated after context switch: %v, want %v", picks, snapshot)
+	}
+}
+
+// The first-request seed reads settings then stores. If a POST installs a
+// fresh pick between the two, the seed must not overwrite it with the disk value.
+func TestLoadSavedNamespacePreference_SeedDoesNotClobberFreshPick(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	s := newTestServer(t)
+	req := reqAs("")
+
+	if _, err := settings.Update(func(st *settings.Settings) {
+		st.ActiveNamespaces = map[string][]string{"test-ctx": {"default"}}
+	}); err != nil {
+		t.Fatalf("settings.Update: %v", err)
+	}
+
+	// A POST already set a different pick in memory.
+	s.setActiveNamespaceForUser(req, []string{"broken"})
+
+	s.loadSavedNamespacePreference(req)
+
+	if picks := s.getActiveNamespaceForUser(req); !slices.Equal(picks, []string{"broken"}) {
+		t.Errorf("seed clobbered fresh pick with disk value: %v, want [broken]", picks)
+	}
+}
+
 // A context switch between snapshot and write must also skip the mutation —
 // old-context survivors must not persist under the new context's key.
 func TestPruneDeletedNamespacePicks_SkipsAcrossContextSwitch(t *testing.T) {

--- a/internal/server/namespace_scope_test.go
+++ b/internal/server/namespace_scope_test.go
@@ -402,6 +402,22 @@ func TestPruneToExistingNamespaces(t *testing.T) {
 			existing: []string{"alpha"},
 			want:     []string{},
 		},
+		{
+			// Duplicates are preserved when they still exist — the prune must
+			// not dedup, so a no-op prune leaves the pick byte-for-byte equal.
+			name:     "duplicates preserved when all exist",
+			picks:    []string{"alpha", "alpha"},
+			existing: []string{"alpha", "beta"},
+			want:     []string{"alpha", "alpha"},
+		},
+		{
+			// Duplicate survives, the deleted sibling is dropped — the survivor
+			// count differs from the input, so the eviction still commits.
+			name:     "duplicate kept, deleted sibling dropped",
+			picks:    []string{"alpha", "alpha", "ghost"},
+			existing: []string{"alpha", "beta"},
+			want:     []string{"alpha", "alpha"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -881,7 +881,7 @@ func (s *Server) parseNamespacesForUser(r *http.Request) []string {
 		// against the same context, not one switched in mid-request.
 		s.loadSavedNamespacePreference(r)
 		if ctx, picks := s.getActiveNamespaceForUserInContext(r); len(picks) > 0 {
-			picks = s.pruneDeletedNamespacePicks(r, picks)
+			picks = s.pruneDeletedNamespacePicks(r, ctx, picks)
 			if len(picks) > 0 {
 				namespaces = picks
 				pickFallback = true

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -90,6 +90,12 @@ type Server struct {
 	// rebuild, not this handler's persist step).
 	scopeMutationMu sync.Mutex
 
+	// nsPickMu serializes namespace-pick mutations: the POST handler's
+	// persist+set pair and the read-path stale-pick prune. Without it, a
+	// prune computed from a stale snapshot can land after a user's fresh
+	// pick and silently revert it.
+	nsPickMu sync.Mutex
+
 	// Short-TTL cache for topology builds. The Topology graph is a
 	// deterministic projection of the informer cache; rebuilding it walks
 	// every resource of every kind. A 5s TTL absorbs the typical bursts
@@ -866,11 +872,17 @@ func (s *Server) parseNamespacesForUser(r *http.Request) []string {
 		}
 	}
 	if namespaces == nil {
-		// No explicit filter — use the user's saved picks if any.
+		// No explicit filter — use the user's saved picks if any, pruned of
+		// namespaces that were deleted from the cluster since the pick was made.
+		// When every pick is stale, fall through with no filter so the user sees
+		// the full cluster instead of a silently-empty UI.
 		s.loadSavedNamespacePreference(r)
 		if picks := s.getActiveNamespaceForUser(r); len(picks) > 0 {
-			namespaces = picks
-			pickFallback = true
+			picks = s.pruneDeletedNamespacePicks(r, picks)
+			if len(picks) > 0 {
+				namespaces = picks
+				pickFallback = true
+			}
 		}
 	}
 	filtered := s.getUserNamespaces(r, namespaces)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -858,6 +858,7 @@ func mergeNamespaceCapability(global, namespaced, checkErrored bool) bool {
 func (s *Server) parseNamespacesForUser(r *http.Request) []string {
 	namespaces := parseNamespaces(r.URL.Query())
 	pickFallback := false
+	pickCtx := ""
 	if k8s.ForceNamespaceScope {
 		target := k8s.GetNamespaceScopeTarget()
 		if target == "" {
@@ -875,13 +876,16 @@ func (s *Server) parseNamespacesForUser(r *http.Request) []string {
 		// No explicit filter — use the user's saved picks if any, pruned of
 		// namespaces that were deleted from the cluster since the pick was made.
 		// When every pick is stale, fall through with no filter so the user sees
-		// the full cluster instead of a silently-empty UI.
+		// the full cluster instead of a silently-empty UI. Read the pick and its
+		// context as one snapshot so the empty-fallback clear below commits
+		// against the same context, not one switched in mid-request.
 		s.loadSavedNamespacePreference(r)
-		if picks := s.getActiveNamespaceForUser(r); len(picks) > 0 {
+		if ctx, picks := s.getActiveNamespaceForUserInContext(r); len(picks) > 0 {
 			picks = s.pruneDeletedNamespacePicks(r, picks)
 			if len(picks) > 0 {
 				namespaces = picks
 				pickFallback = true
+				pickCtx = ctx
 			}
 		}
 	}
@@ -891,8 +895,11 @@ func (s *Server) parseNamespacesForUser(r *http.Request) []string {
 	// stale pick entirely and recomputing as if no filter were set, so the
 	// user sees their full RBAC ceiling instead of a silently-empty UI.
 	// Symmetric with handleGetNamespaceScope's partial-revocation eviction.
+	// namespaces holds the pruned picks this fallback filtered on; clear only
+	// if it's still the live pick, so a stale read can't wipe a concurrent
+	// POST or clear across a context switch.
 	if pickFallback && noNamespaceAccess(filtered) {
-		s.setActiveNamespaceForUser(r, nil)
+		s.commitPickMutation(r, pickCtx, namespaces, nil, false)
 		filtered = s.getUserNamespaces(r, nil)
 	}
 	return filtered


### PR DESCRIPTION
## Problem

Radar persists the header namespace switcher's pick (no-auth local case) and applies it to every read. If the picked namespace is later **deleted from the cluster**, every endpoint silently returns empty — the UI looks like an empty cluster with no hint that a stale filter is the cause, and there is no recovery: the existing stale-pick recovery only triggers when RBAC filtering empties the pick, which never happens in no-auth mode (`getUserNamespaces` is a pass-through there). The pick re-seeds from settings on every request, so the state is permanent until the user manually finds and clears the namespace filter.

## Fix

- Saved picks are pruned against the live namespace list when applied: deleted namespaces drop out; when none survive, the pick is fully evicted and reads fall back to unfiltered.
- **Evict only on positive knowledge**: when the namespace informer can't answer (namespace-scoped cache, restricted RBAC), picks pass through untouched — wrongly dropping a valid pick is worse than keeping a stale one.
- Explicit `?namespaces=` query filters are unaffected; only the saved-pick fallback path prunes.
- The eviction **persists to settings** — in-memory-only eviction would be undone on the next request when the saved preference re-seeds from disk. Persistence is skipped under `--namespace-scope`, where the saved pick doubles as the cache-scope restore value.
- Pick mutations are serialized (`nsPickMu`), and the prune revalidates its snapshot under the lock before writing: a concurrent pick change or a kubeconfig context switch mid-request skips the write, so a slow read can't revert a fresh pick or persist old-context survivors under the new context's key.
- `handleGetNamespaceScope` reports through the same prune, so the scope endpoint and the read path can't disagree.

## Testing

- 6 new tests: full eviction, partial trim, valid-pick-unaffected, informer-unavailable pass-through, and two race-guard regressions (pick changed mid-flight, context switch mid-flight). Full `internal/server` suite green including `-race`.
- Live verification on a kind cluster: a settings file pinning a nonexistent namespace previously made `/api/namespaces` return `[]` forever; with the fix the first request returns all 8 namespaces and rewrites settings with the stale pick removed (other settings preserved). A valid pick still filters correctly after restart.

https://claude.ai/code/session_019aHPAeh1q88KxMGgyDpESc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared namespace-filter state on every read and POST with new locking; incorrect pruning or persistence could change multi-user/no-auth visibility, though guards and conservative informer behavior limit blast radius.
> 
> **Overview**
> Fixes a case where a **persisted namespace switcher pick** for a deleted namespace made every read look empty (especially in no-auth mode), with no self-healing because disk kept re-seeding the stale filter.
> 
> On the saved-pick fallback path, picks are now **pruned against live cluster namespaces** (`pruneToExistingNamespaces` / `pruneDeletedNamespacePicks`): partial trims drop gone names; full eviction clears the pick and reads fall back to unfiltered. Pruning is skipped when the informer cannot list namespaces (empty/nil existing), so valid picks are not dropped on uncertainty. **Deleted-namespace eviction persists to `settings.json`** for the no-auth single-user case; RBAC trims, empty-fallback clears, and disk seeding use `commitPickMutation` with `persist=false`.
> 
> **`commitPickMutation`** plus **`nsPickMu`** centralize read-path writes: compare-and-swap on the snapshotted pick and kube context, skip on concurrent POST or context switch, and avoid deadlocking `handleSetActiveNamespace` (release lock before the trailing GET). **`getActiveNamespaceForUserInContext`** pairs pick + context for one atomic snapshot. The same prune runs in **`handleGetNamespaceScope`** and **`parseNamespacesForUser`** so scope API and resource reads stay aligned.
> 
> Tests cover full/partial eviction, informer-unavailable pass-through, and race/context-switch guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a8dc6bae4a7cbcbce7f80af6989bc1d03db77d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->