### PR TITLE
audit: remove the resourceUtilization check

### DIFF
--- a/pkg/audit/checks.go
+++ b/pkg/audit/checks.go
@@ -127,13 +127,6 @@ func RunChecks(input *CheckInput) *ScanResults {
 	}
 	findings = append(findings, checkTraefikDanglingRefs(tr, input)...)
 
-	// --- Utilization checks (optional, only when metrics provided) ---
-	if input.PodMetrics != nil {
-		findings = append(findings, checkResourceUtilization(tr, input.PodMetrics)...)
-	} else {
-		missingInputs = append(missingInputs, "podmetrics")
-	}
-
 	// --- Deprecated API checks ---
 	findings = append(findings, checkDeprecatedAPIs(tr, input.ServedAPIs, input.ClusterVersion)...)
 
@@ -1418,63 +1411,6 @@ func hasControllerOwnerReference(refs []metav1.OwnerReference) bool {
 		}
 	}
 	return false
-}
-
-// ============================================================================
-// Resource utilization checks
-// ============================================================================
-
-func checkResourceUtilization(tr *evalTracker, metrics []PodMetricsInput) []Finding {
-	if len(metrics) == 0 {
-		return nil
-	}
-
-	var findings []Finding
-	for _, m := range metrics {
-		// Pods with no requests at all can't be measured against anything —
-		// they're out of scope, not passing.
-		if m.CPURequest > 0 || m.MemoryRequest > 0 {
-			tr.record("resourceUtilization", m.Namespace)
-		}
-		// CPU utilization
-		if m.CPURequest > 0 {
-			cpuPct := float64(m.CPUUsage) / float64(m.CPURequest) * 100
-			if cpuPct < 10 && m.CPUUsage > 0 {
-				findings = append(findings, Finding{
-					Kind: "Pod", Namespace: m.Namespace, Name: m.Name,
-					CheckID: "resourceUtilization", Category: CategoryEfficiency, Severity: SeverityWarning,
-					Message: fmt.Sprintf("CPU usage is %.0f%% of request (%dm used, %dm requested) — consider reducing request", cpuPct, m.CPUUsage, m.CPURequest),
-				})
-			} else if cpuPct > 90 {
-				findings = append(findings, Finding{
-					Kind: "Pod", Namespace: m.Namespace, Name: m.Name,
-					CheckID: "resourceUtilization", Category: CategoryEfficiency, Severity: SeverityWarning,
-					Message: fmt.Sprintf("CPU usage is %.0f%% of request (%dm used, %dm requested) — at risk of throttling", cpuPct, m.CPUUsage, m.CPURequest),
-				})
-			}
-		}
-
-		// Memory utilization
-		if m.MemoryRequest > 0 {
-			memPct := float64(m.MemoryUsage) / float64(m.MemoryRequest) * 100
-			memUsageMi := m.MemoryUsage / (1024 * 1024)
-			memReqMi := m.MemoryRequest / (1024 * 1024)
-			if memPct < 10 && m.MemoryUsage > 0 {
-				findings = append(findings, Finding{
-					Kind: "Pod", Namespace: m.Namespace, Name: m.Name,
-					CheckID: "resourceUtilization", Category: CategoryEfficiency, Severity: SeverityWarning,
-					Message: fmt.Sprintf("Memory usage is %.0f%% of request (%dMi used, %dMi requested) — consider reducing request", memPct, memUsageMi, memReqMi),
-				})
-			} else if memPct > 90 {
-				findings = append(findings, Finding{
-					Kind: "Pod", Namespace: m.Namespace, Name: m.Name,
-					CheckID: "resourceUtilization", Category: CategoryEfficiency, Severity: SeverityWarning,
-					Message: fmt.Sprintf("Memory usage is %.0f%% of request (%dMi used, %dMi requested) — at risk of OOM kill", memPct, memUsageMi, memReqMi),
-				})
-			}
-		}
-	}
-	return findings
 }
 
 // ============================================================================

--- a/pkg/audit/checks_test.go
+++ b/pkg/audit/checks_test.go
@@ -1949,48 +1949,6 @@ func TestDeprecatedAPIVersion_NoServedAPIs(t *testing.T) {
 	}
 }
 
-func TestResourceUtilization(t *testing.T) {
-	input := &CheckInput{
-		PodMetrics: []PodMetricsInput{
-			{Namespace: "default", Name: "waste-pod", CPUUsage: 5, CPURequest: 1000, MemoryUsage: 10 * 1024 * 1024, MemoryRequest: 512 * 1024 * 1024},     // 0.5% CPU, 2% memory — waste
-			{Namespace: "default", Name: "hot-pod", CPUUsage: 950, CPURequest: 1000, MemoryUsage: 480 * 1024 * 1024, MemoryRequest: 512 * 1024 * 1024},    // 95% CPU, 94% memory — risk
-			{Namespace: "default", Name: "normal-pod", CPUUsage: 500, CPURequest: 1000, MemoryUsage: 256 * 1024 * 1024, MemoryRequest: 512 * 1024 * 1024}, // 50% — fine
-			{Namespace: "default", Name: "no-request-pod", CPUUsage: 100, CPURequest: 0, MemoryUsage: 128 * 1024 * 1024, MemoryRequest: 0},                // no requests — skip
-		},
-	}
-
-	results := RunChecks(input)
-	pods := map[string]int{} // pod name → finding count
-	for _, f := range results.Findings {
-		if f.CheckID == "resourceUtilization" {
-			pods[f.Name]++
-		}
-	}
-
-	if pods["waste-pod"] < 1 {
-		t.Error("expected utilization finding for waste-pod (under-utilized)")
-	}
-	if pods["hot-pod"] < 1 {
-		t.Error("expected utilization finding for hot-pod (over-utilized)")
-	}
-	if pods["normal-pod"] > 0 {
-		t.Error("normal-pod at 50% utilization should not be flagged")
-	}
-	if pods["no-request-pod"] > 0 {
-		t.Error("pod with no requests should not be flagged")
-	}
-}
-
-func TestResourceUtilization_Empty(t *testing.T) {
-	input := &CheckInput{}
-	results := RunChecks(input)
-	for _, f := range results.Findings {
-		if f.CheckID == "resourceUtilization" {
-			t.Error("resourceUtilization should not fire when no metrics provided")
-		}
-	}
-}
-
 func TestDockerSocketMount(t *testing.T) {
 	input := &CheckInput{
 		Deployments: []*appsv1.Deployment{{

--- a/pkg/audit/counts_test.go
+++ b/pkg/audit/counts_test.go
@@ -105,11 +105,11 @@ func TestCheckCounts_MissingInputs(t *testing.T) {
 		Deployments: []*appsv1.Deployment{
 			deploymentInNS("web", "prod", 3, secureContainer("app", true)),
 		},
-		// PodDisruptionBudgets, ConfigMaps, PodMetrics all nil = unavailable.
+		// PodDisruptionBudgets, ConfigMaps all nil = unavailable.
 	}
 	results := RunChecks(input)
 
-	for _, id := range []string{"missingPDB", "orphanConfigMapSecret", "secretInConfigMap", "resourceUtilization"} {
+	for _, id := range []string{"missingPDB", "orphanConfigMapSecret", "secretInConfigMap"} {
 		if _, ok := results.CheckCounts[id]; ok {
 			t.Errorf("%s must not appear in CheckCounts when its input is nil", id)
 		}
@@ -117,11 +117,11 @@ func TestCheckCounts_MissingInputs(t *testing.T) {
 	// Every nil prerequisite is declared, including the relationship-check
 	// and pod-spec-family inventories added by the per-check gating.
 	want := map[string]bool{
-		"poddisruptionbudgets": true, "configmaps": true, "podmetrics": true,
+		"poddisruptionbudgets": true, "configmaps": true,
 		"serviceaccounts": true, "limitranges": true, "secrets": true,
 		"pods": true, "services": true, "ingresses": true,
 		"horizontalpodautoscalers": true,
-		"statefulsets": true, "daemonsets": true,
+		"statefulsets":             true, "daemonsets": true,
 		"jobs": true, "cronjobs": true,
 	}
 	if len(results.MissingInputs) != len(want) {
@@ -136,7 +136,6 @@ func TestCheckCounts_MissingInputs(t *testing.T) {
 	// Same scan with the inputs present (but empty) — the checks run and count.
 	input.PodDisruptionBudgets = []*policyv1.PodDisruptionBudget{}
 	input.ConfigMaps = []*corev1.ConfigMap{{ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "prod"}}}
-	input.PodMetrics = []PodMetricsInput{}
 	input.ServiceAccounts = []*corev1.ServiceAccount{}
 	input.LimitRanges = []*corev1.LimitRange{}
 	input.Pods = []*corev1.Pod{}

--- a/pkg/audit/registry.go
+++ b/pkg/audit/registry.go
@@ -274,14 +274,6 @@ var CheckRegistry = map[string]CheckMeta{
 		Frameworks:  []string{FrameworkCIS},
 		References:  []Reference{refResources},
 	},
-	"resourceUtilization": {
-		ID:          "resourceUtilization",
-		Title:       "Resource utilization mismatch",
-		Category:    CategoryEfficiency,
-		Description: "Pod resource usage is significantly different from its requests — either wasting resources (<10% used) or at risk of throttling/OOM (>90% used).",
-		Remediation: "Adjust resources.requests to match actual usage. Use metrics or VPA recommendations to right-size.",
-		References:  []Reference{refResources},
-	},
 	"orphanConfigMapSecret": {
 		ID:          "orphanConfigMapSecret",
 		Title:       "Unused ConfigMap or Secret",

--- a/pkg/audit/types.go
+++ b/pkg/audit/types.go
@@ -40,9 +40,6 @@ type CheckInput struct {
 	// ServedAPIs lists API group/versions the cluster still serves (e.g. ["apps/v1", "batch/v1beta1"]).
 	// Used to detect deprecated APIs. Callers populate from discovery client.
 	ServedAPIs []string
-	// PodMetrics provides live CPU/memory usage for utilization checks.
-	// Optional — check is skipped when nil/empty. Callers populate from metrics-server or equivalent.
-	PodMetrics []PodMetricsInput
 	// ConfigObjectRefs lists ConfigMaps and Secrets referenced by non-core
 	// resources that the typed Kubernetes structs above do not cover.
 	ConfigObjectRefs []ConfigObjectRef
@@ -85,16 +82,6 @@ type ConfigObjectRef struct {
 	Name      string
 }
 
-// PodMetricsInput provides metrics data for resource utilization checks.
-type PodMetricsInput struct {
-	Namespace     string
-	Name          string
-	CPUUsage      int64 // millicores
-	MemoryUsage   int64 // bytes
-	CPURequest    int64 // millicores
-	MemoryRequest int64 // bytes
-}
-
 // ScanResults is the output of RunChecks.
 //
 // Checks is the catalog (checkID -> definition) — kept under the "checks" JSON
@@ -117,7 +104,7 @@ type ScanResults struct {
 	// without re-running the scan.
 	EvaluatedByNamespace map[string]map[string]int `json:"evaluatedByNamespace,omitempty"`
 	// MissingInputs lists prerequisite inputs that were nil (RBAC denied or
-	// unavailable), e.g. "poddisruptionbudgets", "configmaps", "podmetrics".
+	// unavailable), e.g. "poddisruptionbudgets", "configmaps".
 	// Checks depending on them did not run and are absent from CheckCounts.
 	MissingInputs []string `json:"missingInputs,omitempty"`
 	// GroupedChecks is the per-check remediation-queue rollup (one Check per


### PR DESCRIPTION
## Summary

Removes the `resourceUtilization` audit check. Utilization / right-sizing is already covered — and far better — by two existing Radar surfaces, so this check was redundant noise, and it never actually ran (its metrics input was never fed, so it sat permanently in `missingInputs` as a dormant "couldn't run" check that invites re-wiring). Removing it is the honest end state: **the audit doesn't own utilization; the Cost view and Right-sizing do.**

## Why it doesn't belong in the audit

| | **CostView** (per-cluster) | **RightsizingStrip** (per-workload) | ~~audit `resourceUtilization`~~ |
|---|---|---|---|
| Data | reserved-vs-used | Prometheus **P95 over a window** | single instantaneous sample |
| "x% of request is fine" | tiers: 50%+ good, <25% investigate | 2–3× headroom doesn't nag | flagged every pod <10% |
| Risk signal | — | vs the **limit** (throttle / OOM) | vs the **request** (wrong) |
| Absolute floor | framed as **$/hr idle** | recommendation, not nag | none — flagged tiny pods |
| Output | dollars of idle capacity | current → recommended request | "consider reducing request" per pod |

The check scored risk as a ratio to the *request* rather than proximity to the *limit*, had no absolute-value floor, and emitted everything at flat `warning` severity — so on a real fleet it flagged the large majority of pods (~86% on a 218-pod cluster) with low-value "reduce request" findings, burying the rare genuine ones (OOM/throttle risk) in the noise. Fleet-level utilization visibility, if wanted later, belongs as a Cost/right-sizing rollup, not per-pod audit findings.

## What changed

Drops, all within `pkg/audit`: the `checkResourceUtilization` function + its `RunChecks` gating, the `resourceUtilization` catalog entry, the `CheckInput.PodMetrics` input field, the `PodMetricsInput` type, and the two now-dead tests. `podmetrics` is no longer a possible `missingInputs` value.

## Testing

`go build ./...` + `go test ./...` (pkg + `internal/audit` + `internal/server`) green. (The `PodMetricsInput` in `pkg/ai/context` is an unrelated type for AI-context formatting and is untouched.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion-only in `pkg/audit` with no auth or data-path changes; utilization is handled elsewhere in the product.
> 
> **Overview**
> Removes the **`resourceUtilization`** efficiency check from cluster audit: **`RunChecks`** no longer gates on pod metrics, **`checkResourceUtilization`** and its **&lt;10% / &gt;90%** request-ratio warnings are gone, and the **`resourceUtilization`** entry drops from **`CheckRegistry`**.
> 
> Also removes the unused metrics contract—**`CheckInput.PodMetrics`**, **`PodMetricsInput`**, and **`podmetrics`** as a possible **`MissingInputs`** value—so scans no longer advertise a check that callers never fed. Tests for utilization and **`TestCheckCounts_MissingInputs`** are updated accordingly; other efficiency checks (missing requests/limits) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0ded9fa14c9618609733b426b636ff7e7b13485. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->