### PR TITLE
add support for mounting extraVolumes

### DIFF
--- a/deploy/helm/radar/Chart.yaml
+++ b/deploy/helm/radar/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: radar
 description: Modern Kubernetes visibility - topology, traffic, Helm and GitOps management
 type: application
-version: 1.6.0
+version: 1.7.0
 appVersion: "1.7.6"
 icon: https://radarhq.io/radar/icon-512.png
 keywords:

--- a/deploy/helm/radar/templates/deployment.yaml
+++ b/deploy/helm/radar/templates/deployment.yaml
@@ -225,6 +225,9 @@ spec:
             - name: data
               mountPath: /data
             {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
@@ -234,6 +237,9 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "radar.fullname" . }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/deploy/helm/radar/values.schema.json
+++ b/deploy/helm/radar/values.schema.json
@@ -299,6 +299,16 @@
       "description": "Init containers to run before the main container.",
       "items": { "type": "object" }
     },
+    "extraVolumes": {
+      "type": "array",
+      "description": "Additional volumes to add to the pod.",
+      "items": { "type": "object" }
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "description": "Additional volume mounts for the main container.",
+      "items": { "type": "object" }
+    },
     "probes": {
       "type": "object",
       "additionalProperties": false,

--- a/deploy/helm/radar/values.yaml
+++ b/deploy/helm/radar/values.yaml
@@ -423,6 +423,18 @@ initContainers: []
 #    image: busybox:1.36
 #    command: ['sh', '-c', 'echo init']
 
+# Additional volumes to add to the pod
+extraVolumes: []
+#  - name: my-config
+#    configMap:
+#      name: my-configmap
+
+# Additional volume mounts for the main container
+extraVolumeMounts: []
+#  - name: my-config
+#    mountPath: /etc/my-config
+#    readOnly: true
+
 # Liveness and readiness probes
 probes:
   liveness:


### PR DESCRIPTION
## Description

This enables adding volumes to radar. One use-case is that you might want to add secret files or sidecars needing config, like kube-rbac-proxy

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How has this been tested?

Describe the tests you ran to verify your changes.

I tested rendering with this:

```yaml
initContainers:
  - name: init-permissions
    image: busybox:1.36
    command: ['sh', '-c', 'echo "Init complete"']
    volumeMounts:
    - name: app-config
      mountPath: /etc/radar/custom
      readOnly: true

extraVolumes:
  - name: app-config
    configMap:
      name: radar-custom-config

# This will mount in the main container
extraVolumeMounts:
  - name: app-config
    mountPath: /etc/radar/custom
    readOnly: true
```
 

Then ran:

```bash
helm template test deploy/helm/radar/ -f deploy/helm/radar/test-values.yaml -s templates/deployment.yaml
```

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [ ] I have added comments where necessary
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged

## Related issues

Fixes #(issue number)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change with empty defaults; misconfigured mounts could affect pod scheduling or app file paths but does not alter application code or auth.
> 
> **Overview**
> Adds **optional Helm values** `extraVolumes` and `extraVolumeMounts` so deployers can attach ConfigMaps, Secrets, or other pod volumes and mount them into the main Radar container (e.g. custom config or files for sidecars like kube-rbac-proxy).
> 
> The deployment template **merges** these arrays after the built-in `tmp`, `home`, and optional SQLite `data` mounts. Defaults stay empty; `values.schema.json` documents the new keys. Chart **version** is bumped **1.6.0 → 1.7.0** (unchanged `appVersion`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f93a75f80e983bf41c4fee0d74f79372b931bb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->