### PR TITLE
Fix Ctrl+R desktop reload colliding with terminal reverse-search

### DIFF
--- a/cmd/desktop/menu.go
+++ b/cmd/desktop/menu.go
@@ -1,10 +1,26 @@
 package main
 
 import (
+	goruntime "runtime"
+
 	"github.com/wailsapp/wails/v2/pkg/menu"
 	"github.com/wailsapp/wails/v2/pkg/menu/keys"
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
+
+// reloadAccelerator picks the Reload shortcut per platform. Off macOS,
+// CmdOrCtrl+R resolves to Ctrl+R — the terminal's reverse-i-search binding — and
+// a native menu accelerator fires regardless of webview focus, so it would
+// hijack Ctrl+R inside a pod/local shell. Ctrl+Shift+R keeps a reload hotkey
+// without shadowing a key terminals actually send (plain function keys like F5
+// are consumed by TUIs and cmd.exe history). macOS keeps Cmd+R, which doesn't
+// collide (terminals use Ctrl, not Cmd).
+func reloadAccelerator(goos string) *keys.Accelerator {
+	if goos == "darwin" {
+		return keys.CmdOrCtrl("r")
+	}
+	return keys.Combo("r", keys.ControlKey, keys.ShiftKey)
+}
 
 func createMenu(desktopApp *DesktopApp, version string) *menu.Menu {
 	appMenu := menu.NewMenu()
@@ -70,7 +86,7 @@ func createMenu(desktopApp *DesktopApp, version string) *menu.Menu {
 		runtime.WindowExecJS(desktopApp.ctx, "window.history.forward()")
 	})
 	viewMenu.AddSeparator()
-	viewMenu.AddText("Reload", keys.CmdOrCtrl("r"), func(_ *menu.CallbackData) {
+	viewMenu.AddText("Reload", reloadAccelerator(goruntime.GOOS), func(_ *menu.CallbackData) {
 		runtime.WindowReloadApp(desktopApp.ctx)
 	})
 	viewMenu.AddSeparator()

--- a/cmd/desktop/menu_test.go
+++ b/cmd/desktop/menu_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"reflect"
+	goruntime "runtime"
 	"testing"
 
 	"github.com/wailsapp/wails/v2/pkg/menu"
+	"github.com/wailsapp/wails/v2/pkg/menu/keys"
 )
 
 func TestCreateMenuFileMenuExposesSupportedActions(t *testing.T) {
@@ -45,6 +47,43 @@ func TestCreateMenuNativeActionsHaveCallbacks(t *testing.T) {
 				t.Fatalf("%s -> %s has no callback", tc.menu, tc.item)
 			}
 		})
+	}
+}
+
+func TestReloadAcceleratorAvoidsCtrlROffMac(t *testing.T) {
+	cases := []struct {
+		goos string
+		want *keys.Accelerator
+	}{
+		{"darwin", keys.CmdOrCtrl("r")},
+		{"windows", keys.Combo("r", keys.ControlKey, keys.ShiftKey)},
+		{"linux", keys.Combo("r", keys.ControlKey, keys.ShiftKey)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.goos, func(t *testing.T) {
+			got := reloadAccelerator(tc.goos)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("reloadAccelerator(%q) = %+v, want %+v", tc.goos, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCreateMenuReloadIsWiredToPlatformAccelerator asserts the Reload item uses
+// the platform-picked accelerator. On Linux CI (goruntime.GOOS == "linux") this
+// executes the non-mac branch for real, proving Ctrl+R is not bound to Reload.
+func TestCreateMenuReloadIsWiredToPlatformAccelerator(t *testing.T) {
+	appMenu := createMenu(&DesktopApp{}, "test")
+	reload := findMenuItem(t, findSubmenu(t, appMenu, "View"), "Reload")
+
+	if reload.Click == nil {
+		t.Fatal("Reload item has no callback")
+	}
+	if !reflect.DeepEqual(reload.Accelerator, reloadAccelerator(goruntime.GOOS)) {
+		t.Fatalf("Reload accelerator = %+v, want %+v", reload.Accelerator, reloadAccelerator(goruntime.GOOS))
+	}
+	if goruntime.GOOS != "darwin" && reflect.DeepEqual(reload.Accelerator, keys.CmdOrCtrl("r")) {
+		t.Fatalf("Reload is bound to Ctrl+R on %s — collides with terminal reverse-i-search", goruntime.GOOS)
 	}
 }
 


### PR DESCRIPTION
## Problem

Fixes #1092. In the desktop build, pressing **Ctrl+R** inside a terminal (pod exec, local shell, or node terminal) reloads the whole app back to home instead of triggering the shell's reverse-i-search.

## Root cause

Ctrl+R was a **Wails native menu accelerator**, not a JS/web hotkey — `cmd/desktop/menu.go` bound the "Reload" View-menu item to `keys.CmdOrCtrl("r")`. That resolves to:

- **macOS** → `Cmd+R` (no collision — terminals use Ctrl, not Cmd)
- **Windows/Linux** → `Ctrl+R` (collides with terminal reverse-i-search)

Native menu accelerators fire regardless of webview focus, so no frontend/xterm `preventDefault` could intercept it. The keystroke still reached xterm (reverse-search flashed) *and* the menu fired `WindowReloadApp()`. This is why the report is Windows/Linux-specific.

## Fix

Pick the Reload accelerator per platform:

- **macOS**: keep `Cmd+R` (unchanged, never collided)
- **Windows/Linux**: use **Ctrl+Shift+R**

Any *unmodified* native accelerator is stolen from a focused terminal regardless of key (that's the root cause), so F5 wasn't actually collision-free — it's used by TUIs (htop, Midnight Commander) and cmd.exe history. `Ctrl+Shift+R` keeps a reload hotkey while dodging keys terminals actually send: terminals don't bind `Ctrl+Shift+<letter>`, and it's distinct from reverse-i-search's `Ctrl+R`.

Purely a menu-level change; fixes all three terminal surfaces at once with no frontend changes.

## Tests

- `TestReloadAcceleratorAvoidsCtrlROffMac` — pins the accelerator choice for darwin/windows/linux.
- `TestCreateMenuReloadIsWiredToPlatformAccelerator` — asserts the real `createMenu` wires the platform accelerator into the Reload item and that it is **not** plain Ctrl+R off-mac. Because `cmd/desktop` tests run on `ubuntu-latest` in CI, this executes the non-mac branch for real on every PR.

## Verification boundary

Selection + real wiring are enforced by CI (including on Linux). The native end-to-end behavior — the accelerator firing reload and Ctrl+R reaching xterm — depends on OS menu-accelerator dispatch and can't be faithfully simulated headlessly. **Needs a manual smoke test on a Windows/Linux desktop build** (open a pod terminal → Ctrl+R shows reverse-search + no reload; Ctrl+Shift+R reloads).