### PR TITLE
Fix OCI Helm upgrade source discovery

### DIFF
--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -1832,34 +1832,16 @@ func (c *Client) checkForUpgrade(namespace, name, username string, groups []stri
 	}
 
 	if len(candidates) == 0 {
-		// A failed classic index could be hiding the release's real (classic)
-		// source, so surface that before OCI — matching resolveUpgradeChartPath —
-		// rather than mislabel a classic-repo release as OCI-tracked.
-		if indexLoadFailed {
-			info.Error = "failed to load one or more configured repository indexes"
-			return info, nil
-		}
-		// Genuine absence → registered OCI sources are the fallback for the user's
-		// own OCI-published charts. Only here, never on classic ambiguity below —
-		// falling back on ambiguity could advertise an OCI source for a release
-		// that actually came from a classic repo.
-		if c.applyOCIUpgrade(info, chartName, currentVersion, nil, nil) {
-			return info, nil
-		}
-		// Genuine untracked source — registering a chart source could fix it.
-		info.Untracked = true
-		if noClassicRepos && len(ListOCISources()) == 0 {
-			info.Error = "no chart sources configured"
-		} else {
-			info.Error = "chart not found in configured repositories or registered OCI sources"
-		}
+		applyNoClassicCandidateUpgrade(info, noClassicRepos, indexLoadFailed, len(ListOCISources()) > 0, func() bool {
+			return c.applyOCIUpgrade(info, chartName, currentVersion, nil, nil)
+		})
 		return info, nil
 	}
 
 	sourceHosts := chartSourceHosts(rel.Chart.Metadata.Home, rel.Chart.Metadata.Sources)
 	latestVersion, repoName := findBestUpgradeVersion(candidates, sourceHosts)
 	if latestVersion == "" {
-		info.Error = "could not identify upstream chart repository"
+		markUpgradeSourceIssue(info, UpgradeSourceIssueAmbiguousRepository, "could not identify upstream chart repository")
 		return info, nil
 	}
 
@@ -1869,6 +1851,27 @@ func (c *Client) checkForUpgrade(namespace, name, username string, groups []stri
 	info.UpdateAvailable = compareVersions(latestVersion, currentVersion) > 0
 
 	return info, nil
+}
+
+func markUpgradeSourceIssue(info *UpgradeInfo, issue UpgradeSourceIssue, message string) {
+	info.Error = message
+	info.SourceIssue = issue
+	info.Untracked = issue == UpgradeSourceIssueUntracked
+}
+
+func applyNoClassicCandidateUpgrade(info *UpgradeInfo, noClassicRepos, indexLoadFailed, hasRegisteredOCISources bool, ociFallback func() bool) {
+	if ociFallback != nil && ociFallback() {
+		return
+	}
+	if indexLoadFailed {
+		markUpgradeSourceIssue(info, UpgradeSourceIssueRepoIndexError, "failed to load one or more configured repository indexes")
+		return
+	}
+	if noClassicRepos && !hasRegisteredOCISources {
+		markUpgradeSourceIssue(info, UpgradeSourceIssueUntracked, "no chart sources configured")
+		return
+	}
+	markUpgradeSourceIssue(info, UpgradeSourceIssueUntracked, "chart not found in configured repositories or registered OCI sources")
 }
 
 // applyOCIUpgrade probes registered OCI sources for chartName and, if one
@@ -2406,6 +2409,10 @@ type chartPathCandidate struct {
 }
 
 func (c *Client) resolveUpgradeChartPath(chartName, targetVersion, repositoryName string, sourceHosts []string) (chartPath, resolvedRepo string, err error) {
+	return c.resolveUpgradeChartPathWithOCIResolver(chartName, targetVersion, repositoryName, sourceHosts, c.resolveOCIUpgradeURL)
+}
+
+func (c *Client) resolveUpgradeChartPathWithOCIResolver(chartName, targetVersion, repositoryName string, sourceHosts []string, resolveOCIUpgradeURL func(string, string) (string, bool)) (chartPath, resolvedRepo string, err error) {
 	// A missing/unreadable repo config is not fatal: a pure-OCI user has no
 	// repositories.yaml, and discovery may have advertised an OCI upgrade. Proceed
 	// with an empty classic set so the OCI fallback below can still resolve.
@@ -2470,18 +2477,16 @@ func (c *Client) resolveUpgradeChartPath(chartName, targetVersion, repositoryNam
 		return "", "", fmt.Errorf("chart %s version %s not found in repository %s", chartName, targetVersion, repositoryName)
 	}
 
-	// Surface classic-repo index failures before the OCI fallback: a stale/missing
-	// index is a "fix your repo" condition the user should see, not something to
-	// silently paper over by pulling the same version from an OCI source.
-	if len(indexErrors) > 0 {
-		return "", "", fmt.Errorf("chart %s version %s not found in configured repositories; failed to load indexes: %s", chartName, targetVersion, strings.Join(indexErrors, "; "))
+	// No classic-repo match. Fall back to registered OCI sources before reporting
+	// unrelated index failures; the server re-derives the oci:// ref from a
+	// configured prefix (never a client-supplied ref), keeping the upgrade path
+	// configured-only.
+	if url, ok := resolveOCIUpgradeURL(chartName, targetVersion); ok {
+		return url, "oci", nil
 	}
 
-	// No classic-repo match and indexes loaded cleanly. Fall back to registered OCI
-	// sources — the server re-derives the oci:// ref from a configured prefix (never
-	// a client-supplied ref), keeping the upgrade path configured-only.
-	if url, ok := c.resolveOCIUpgradeURL(chartName, targetVersion); ok {
-		return url, "oci", nil
+	if len(indexErrors) > 0 {
+		return "", "", fmt.Errorf("chart %s version %s not found in configured repositories or registered OCI sources; failed to load indexes: %s", chartName, targetVersion, strings.Join(indexErrors, "; "))
 	}
 
 	return "", "", fmt.Errorf("chart %s version %s not found in configured repositories or registered OCI sources", chartName, targetVersion)
@@ -2577,11 +2582,15 @@ func (c *Client) batchCheckUpgrades(namespace, username string, groups []string)
 	// the per-release OCI fallback run rather than failing every release here.
 	repoFile := c.settings.RepositoryConfig
 	f, err := repo.LoadFile(repoFile)
+	noClassicRepos := false
 	if err != nil {
 		if !os.IsNotExist(err) {
 			log.Printf("[helm] failed to load repository config %s (treating as no classic repos): %v", repoFile, err)
 		}
 		f = &repo.File{}
+	}
+	if len(f.Repositories) == 0 {
+		noClassicRepos = true
 	}
 
 	// Split into two maps: latest-per-repo drives ranking; per-repo full
@@ -2654,15 +2663,9 @@ func (c *Client) batchCheckUpgrades(namespace, username string, groups []string)
 
 		baseCandidates, ok := chartRepoVersions[chartName]
 		if !ok {
-			// A failed classic index could be hiding this release's real source —
-			// surface that before OCI rather than mislabel it as OCI-tracked.
-			if indexLoadFailed {
-				info.Error = "failed to load one or more configured repository indexes"
-			} else if !ociFallback(info, chartName, currentVersion) {
-				// Genuine absence → OCI fallback for the user's own OCI charts.
-				info.Untracked = true
-				info.Error = "chart not found in configured repositories or registered OCI sources"
-			}
+			applyNoClassicCandidateUpgrade(info, noClassicRepos, indexLoadFailed, len(ListOCISources()) > 0, func() bool {
+				return ociFallback(info, chartName, currentVersion)
+			})
 			result.Releases[key] = info
 			continue
 		}
@@ -2673,7 +2676,7 @@ func (c *Client) batchCheckUpgrades(namespace, username string, groups []string)
 		if latestVersion == "" {
 			// Classic candidates exist but are ambiguous — don't let OCI override
 			// a release that came from a classic repo.
-			info.Error = "could not identify upstream chart repository"
+			markUpgradeSourceIssue(info, UpgradeSourceIssueAmbiguousRepository, "could not identify upstream chart repository")
 		} else {
 			info.LatestVersion = latestVersion
 			info.RepositoryName = repoName

--- a/internal/helm/client_test.go
+++ b/internal/helm/client_test.go
@@ -155,6 +155,93 @@ func TestFindBestUpgradeVersion(t *testing.T) {
 	}
 }
 
+func TestApplyNoClassicCandidateUpgrade_SourceIssueMapping(t *testing.T) {
+	tests := []struct {
+		name                    string
+		noClassicRepos          bool
+		indexLoadFailed         bool
+		hasRegisteredOCISources bool
+		ociFallback             bool
+		wantIssue               UpgradeSourceIssue
+		wantUntracked           bool
+		wantSourceType          string
+		wantErrorContains       string
+	}{
+		{
+			name:                    "registered OCI source wins before repo index error",
+			indexLoadFailed:         true,
+			hasRegisteredOCISources: true,
+			ociFallback:             true,
+			wantSourceType:          "oci",
+		},
+		{
+			name:                    "repo index error when OCI does not resolve",
+			indexLoadFailed:         true,
+			hasRegisteredOCISources: true,
+			wantIssue:               UpgradeSourceIssueRepoIndexError,
+			wantErrorContains:       "failed to load one or more configured repository indexes",
+		},
+		{
+			name:              "no configured chart sources",
+			noClassicRepos:    true,
+			wantIssue:         UpgradeSourceIssueUntracked,
+			wantUntracked:     true,
+			wantErrorContains: "no chart sources configured",
+		},
+		{
+			name:                    "chart absent from configured sources",
+			hasRegisteredOCISources: true,
+			wantIssue:               UpgradeSourceIssueUntracked,
+			wantUntracked:           true,
+			wantErrorContains:       "chart not found in configured repositories or registered OCI sources",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := &UpgradeInfo{}
+			applyNoClassicCandidateUpgrade(info, tt.noClassicRepos, tt.indexLoadFailed, tt.hasRegisteredOCISources, func() bool {
+				if !tt.ociFallback {
+					return false
+				}
+				info.SourceType = "oci"
+				info.ChartRef = "oci://reg/charts/app"
+				info.LatestVersion = "1.2.0"
+				return true
+			})
+
+			if info.SourceIssue != tt.wantIssue {
+				t.Fatalf("SourceIssue = %q, want %q (info=%+v)", info.SourceIssue, tt.wantIssue, info)
+			}
+			if info.Untracked != tt.wantUntracked {
+				t.Fatalf("Untracked = %v, want %v (info=%+v)", info.Untracked, tt.wantUntracked, info)
+			}
+			if info.SourceType != tt.wantSourceType {
+				t.Fatalf("SourceType = %q, want %q (info=%+v)", info.SourceType, tt.wantSourceType, info)
+			}
+			if tt.wantErrorContains != "" && !strings.Contains(info.Error, tt.wantErrorContains) {
+				t.Fatalf("Error = %q, want to contain %q", info.Error, tt.wantErrorContains)
+			}
+			if tt.wantErrorContains == "" && info.Error != "" {
+				t.Fatalf("Error = %q, want empty", info.Error)
+			}
+		})
+	}
+}
+
+func TestMarkUpgradeSourceIssue_AmbiguousRepositoryIsNotUntracked(t *testing.T) {
+	info := &UpgradeInfo{}
+
+	markUpgradeSourceIssue(info, UpgradeSourceIssueAmbiguousRepository, "could not identify upstream chart repository")
+
+	if info.SourceIssue != UpgradeSourceIssueAmbiguousRepository {
+		t.Fatalf("SourceIssue = %q, want %q", info.SourceIssue, UpgradeSourceIssueAmbiguousRepository)
+	}
+	if info.Untracked {
+		t.Fatal("ambiguous classic repository should not be marked untracked")
+	}
+}
+
 func TestChartSourceHosts(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -1392,6 +1479,48 @@ func TestResolveUpgradeChartPath_RepositoryHintDoesNotFallback(t *testing.T) {
 	}
 }
 
+func TestResolveUpgradeChartPath_ReportsIndexErrorAfterOCIFallbackFails(t *testing.T) {
+	withOCISources(t, nil)
+	client := testHelmClientWithRepoConfigOnly(t)
+
+	_, _, err := client.resolveUpgradeChartPath("postgres", "0.19.6", "", nil)
+	if err == nil {
+		t.Fatal("expected index error after OCI fallback miss")
+	}
+	if !strings.Contains(err.Error(), "not found in configured repositories or registered OCI sources") {
+		t.Fatalf("error = %q", err)
+	}
+	if !strings.Contains(err.Error(), "failed to load indexes") {
+		t.Fatalf("error = %q", err)
+	}
+}
+
+func TestResolveUpgradeChartPath_UsesOCIBeforeUnrelatedIndexError(t *testing.T) {
+	client := testHelmClientWithRepoConfigOnly(t)
+
+	chartPath, repoName, err := client.resolveUpgradeChartPathWithOCIResolver(
+		"postgres",
+		"0.19.6",
+		"",
+		nil,
+		func(chartName, targetVersion string) (string, bool) {
+			if chartName != "postgres" || targetVersion != "0.19.6" {
+				return "", false
+			}
+			return "oci://registry-1.docker.io/cloudpirates/postgres", true
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repoName != "oci" {
+		t.Fatalf("repoName = %q, want oci", repoName)
+	}
+	if chartPath != "oci://registry-1.docker.io/cloudpirates/postgres" {
+		t.Fatalf("chartPath = %q, want OCI chart path", chartPath)
+	}
+}
+
 func testHelmClientWithRepos(t *testing.T) *Client {
 	return testHelmClientWithRepoVersions(t, map[string][]string{
 		"bitnami": {"9.5.11"},
@@ -1440,6 +1569,29 @@ entries:
 	}
 	for name, versions := range versionsByRepo {
 		writeIndex(name, versions)
+	}
+
+	return &Client{settings: &cli.EnvSettings{
+		RepositoryConfig: repoFile,
+		RepositoryCache:  cacheDir,
+	}}
+}
+
+func testHelmClientWithRepoConfigOnly(t *testing.T) *Client {
+	t.Helper()
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+	if err := os.Mkdir(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	repoFile := filepath.Join(dir, "repositories.yaml")
+	if err := os.WriteFile(repoFile, []byte(`apiVersion: v1
+generated: "2026-05-05T00:00:00Z"
+repositories:
+- name: broken
+  url: https://charts.example.invalid
+`), 0o644); err != nil {
+		t.Fatal(err)
 	}
 
 	return &Client{settings: &cli.EnvSettings{

--- a/internal/helm/oci_sources.go
+++ b/internal/helm/oci_sources.go
@@ -269,6 +269,13 @@ func (c *Client) resolveOCIUpgradeURL(chartName, targetVersion string) (string, 
 	if lister == nil {
 		return "", false
 	}
+	return c.resolveOCIUpgradeURLWithLister(chartName, targetVersion, lister)
+}
+
+func (c *Client) resolveOCIUpgradeURLWithLister(chartName, targetVersion string, lister ociTagLister) (string, bool) {
+	if lister == nil || len(ListOCISources()) == 0 {
+		return "", false
+	}
 	prefix, tags := c.selectBestOCIPrefix(chartName, lister, nil)
 	if prefix != "" && slices.Contains(tags, targetVersion) {
 		return ociChartURL(prefix, chartName), true

--- a/internal/helm/oci_sources_test.go
+++ b/internal/helm/oci_sources_test.go
@@ -226,6 +226,24 @@ func TestApplyOCIUpgrade_SetsFields(t *testing.T) {
 	}
 }
 
+func TestResolveOCIUpgradeURLWithLister_UsesRegisteredPrefix(t *testing.T) {
+	withOCISources(t, []string{"oci://reg/c"})
+	lister := &fakeTagLister{tags: map[string][]string{"reg/c/app": {"1.4.0", "1.5.0"}}}
+	c := &Client{}
+
+	url, ok := c.resolveOCIUpgradeURLWithLister("app", "1.5.0", lister)
+	if !ok {
+		t.Fatal("expected OCI URL resolution")
+	}
+	if url != "oci://reg/c/app" {
+		t.Fatalf("url = %q, want oci://reg/c/app", url)
+	}
+
+	if _, ok := c.resolveOCIUpgradeURLWithLister("app", "2.0.0", lister); ok {
+		t.Fatal("unexpected resolution for a version not published by the registered source")
+	}
+}
+
 func TestSortVersionsDesc(t *testing.T) {
 	in := []string{"1.2.0", "1.10.0", "1.2.3", "0.9.0", "2.0.0"}
 	got := sortVersionsDesc(in)

--- a/internal/helm/types.go
+++ b/internal/helm/types.go
@@ -259,6 +259,16 @@ type ResourceDiff struct {
 	ParseErrorCount int              `json:"parseErrorCount,omitempty"`
 }
 
+// UpgradeSourceIssue identifies why Radar could not resolve the upstream chart
+// source for upgrade checks.
+type UpgradeSourceIssue string
+
+const (
+	UpgradeSourceIssueUntracked           UpgradeSourceIssue = "untracked"
+	UpgradeSourceIssueRepoIndexError      UpgradeSourceIssue = "repo_index_error"
+	UpgradeSourceIssueAmbiguousRepository UpgradeSourceIssue = "ambiguous_repository"
+)
+
 // UpgradeInfo contains information about available upgrades
 type UpgradeInfo struct {
 	CurrentVersion  string `json:"currentVersion"`
@@ -271,13 +281,12 @@ type UpgradeInfo struct {
 	SourceType string `json:"sourceType,omitempty"`
 	// ChartRef is the oci:// chart reference an OCI-sourced upgrade lives at
 	// (display only — the upgrade path re-derives it from registered sources).
-	ChartRef string `json:"chartRef,omitempty"`
-	Error    string `json:"error,omitempty"`
+	ChartRef    string             `json:"chartRef,omitempty"`
+	Error       string             `json:"error,omitempty"`
+	SourceIssue UpgradeSourceIssue `json:"sourceIssue,omitempty"`
 	// Untracked marks the specific error state where Radar genuinely can't tell
 	// where the chart comes from — i.e. registering a chart source could fix it.
-	// It is deliberately NOT set for repo-side errors (stale/broken index, classic
-	// ambiguity) so the UI doesn't steer the user to register an OCI source when
-	// the real fix is refreshing or disambiguating repos.
+	// Kept for compatibility; SourceIssue is the richer reason code.
 	Untracked bool `json:"untracked,omitempty"`
 }
 

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -836,9 +836,11 @@ export interface UpgradeInfo {
   // oci:// chart reference an OCI-sourced upgrade lives at (display only).
   chartRef?: string
   error?: string
+  // Machine-readable source-resolution failure, used to make the Helm drawer
+  // explain whether tracking an OCI source can help.
+  sourceIssue?: 'untracked' | 'repo_index_error' | 'ambiguous_repository'
   // True only when the error is a genuinely untracked source (registering a
-  // chart source could fix it) — NOT for repo-side errors like a stale index or
-  // classic ambiguity. Gates the "track source" affordance.
+  // chart source could fix it). Kept for compatibility; prefer sourceIssue.
   untracked?: boolean
 }
 

--- a/web/src/components/helm/HelmReleaseDrawer.test.ts
+++ b/web/src/components/helm/HelmReleaseDrawer.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { isUpgradeSourceIssueActionable } from './HelmReleaseDrawer'
+
+describe('isUpgradeSourceIssueActionable', () => {
+  it('keeps classic repository ambiguity informational', () => {
+    expect(isUpgradeSourceIssueActionable('ambiguous_repository')).toBe(false)
+  })
+
+  it('lets OCI registration help untracked and repo-index states', () => {
+    expect(isUpgradeSourceIssueActionable('untracked')).toBe(true)
+    expect(isUpgradeSourceIssueActionable('repo_index_error')).toBe(true)
+  })
+
+  it('does not treat a missing reason code as actionable', () => {
+    expect(isUpgradeSourceIssueActionable(undefined)).toBe(false)
+  })
+})

--- a/web/src/components/helm/HelmReleaseDrawer.tsx
+++ b/web/src/components/helm/HelmReleaseDrawer.tsx
@@ -12,7 +12,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { ConfirmDialog } from '../ui/ConfirmDialog'
 import { Tooltip } from '../ui/Tooltip'
 import { Markdown } from '../ui/Markdown'
-import type { SelectedHelmRelease, HelmHook, ChartDependency, HelmOperation, HelmOperationInsight, HelmOwnedResource, HookDiagnostic, HookLogEvidence } from '../../types'
+import type { SelectedHelmRelease, HelmHook, ChartDependency, HelmOperation, HelmOperationInsight, HelmOwnedResource, HookDiagnostic, HookLogEvidence, UpgradeInfo } from '../../types'
 import { apiVersionToGroup, kindToPlural, type NavigateToResource } from '../../utils/navigation'
 import { formatDate } from './helm-utils'
 import { getHelmStatusColor, getKindBadgeColor, getResourceStatusColor, SEVERITY_BADGE, SEVERITY_TEXT } from '../../utils/badge-colors'
@@ -33,6 +33,42 @@ interface HelmReleaseDrawerProps {
 }
 
 type TabId = 'overview' | 'history' | 'manifest' | 'values' | 'resources' | 'hooks'
+
+type UpgradeSourceIssue = NonNullable<UpgradeInfo['sourceIssue']>
+type ActionableUpgradeSourceIssue = Exclude<UpgradeSourceIssue, 'ambiguous_repository'>
+
+function getUpgradeSourceIssue(upgradeInfo: UpgradeInfo): UpgradeSourceIssue | undefined {
+  return upgradeInfo.sourceIssue
+}
+
+function getUpgradeSourceIssueLabel(issue: UpgradeSourceIssue) {
+  switch (issue) {
+    case 'repo_index_error':
+      return 'upgrade source blocked'
+    case 'ambiguous_repository':
+      return 'upgrade source ambiguous'
+    case 'untracked':
+      return 'upgrade source not tracked'
+  }
+}
+
+function getUpgradeSourceIssueTooltip(issue: UpgradeSourceIssue, error: string | undefined, canHelmWrite: boolean, disabledReason: string | undefined) {
+  if (!canHelmWrite) {
+    return disabledReason ?? error ?? 'Helm actions are disabled.'
+  }
+  switch (issue) {
+    case 'repo_index_error':
+      return 'A configured Helm repo index failed. Fix or refresh that repo, or register an OCI prefix if this chart came from OCI.'
+    case 'ambiguous_repository':
+      return 'Multiple configured Helm repos match this chart. Fix the repo list or source metadata so Radar can identify one source.'
+    case 'untracked':
+      return "Radar can't tell where this chart was installed from. Register an OCI chart source to track upgrades."
+  }
+}
+
+export function isUpgradeSourceIssueActionable(issue: UpgradeInfo['sourceIssue']): issue is ActionableUpgradeSourceIssue {
+  return Boolean(issue && issue !== 'ambiguous_repository')
+}
 
 const MIN_WIDTH = 500
 const MAX_WIDTH_PERCENT = 0.8
@@ -92,6 +128,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
     release.name
   )
   const upgradeErrorMessage = upgradeError instanceof Error ? upgradeError.message : 'Upgrade check failed'
+  const upgradeSourceIssue = upgradeInfo ? getUpgradeSourceIssue(upgradeInfo) : undefined
 
   // Available versions for the upgrade dialog's picker — only fetched while the
   // confirm dialog is open. Default the selection to latest when it opens.
@@ -401,10 +438,15 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
                   source via GitOps
                 </span>
                 </Tooltip>
-              ) : upgradeInfo.untracked ? (
-                // Helm doesn't record the install source. Offer to register one so
-                // Radar can track upgrades for the user's own (e.g. OCI) charts.
-                <Tooltip content={canHelmWrite ? "Radar can't tell where this chart was installed from. Register your chart source to track upgrades." : upgradeInfo.error}>
+              ) : upgradeSourceIssue && !isUpgradeSourceIssueActionable(upgradeSourceIssue) ? (
+                <Tooltip content={getUpgradeSourceIssueTooltip(upgradeSourceIssue, upgradeInfo.error, canHelmWrite, helmActReason)}>
+                <span className="badge bg-theme-hover/50 text-theme-text-secondary">
+                  <Link2 className="w-3 h-3" />
+                  {getUpgradeSourceIssueLabel(upgradeSourceIssue)}
+                </span>
+                </Tooltip>
+              ) : isUpgradeSourceIssueActionable(upgradeSourceIssue) ? (
+                <Tooltip content={getUpgradeSourceIssueTooltip(upgradeSourceIssue, upgradeInfo.error, canHelmWrite, helmActReason)}>
                 <button
                   onClick={() => canHelmWrite && setShowTrackSource(true)}
                   disabled={!canHelmWrite}
@@ -414,12 +456,10 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
                   )}
                 >
                   <Link2 className="w-3 h-3" />
-                  upgrade source not tracked
+                  {getUpgradeSourceIssueLabel(upgradeSourceIssue)}
                 </button>
                 </Tooltip>
               ) : (
-                // Repo-side error (stale/broken index, classic ambiguity) — not an
-                // OCI tracking issue, so surface it without steering to registration.
                 <Tooltip content={upgradeInfo.error}>
                 <span className="badge bg-theme-hover/50 text-theme-text-secondary">
                   upgrade source unresolved
@@ -685,6 +725,8 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
         open={showTrackSource}
         onClose={() => setShowTrackSource(false)}
         chartName={releaseDetail?.chart}
+        sourceIssue={upgradeSourceIssue}
+        sourceError={upgradeInfo?.error}
       />
     </div>
   )

--- a/web/src/components/helm/TrackChartSourceDialog.tsx
+++ b/web/src/components/helm/TrackChartSourceDialog.tsx
@@ -3,12 +3,39 @@ import { DialogPortal } from '@skyhook-io/k8s-ui/components/ui/DialogPortal'
 import { X, Plus, Trash2, Link2, AlertTriangle } from 'lucide-react'
 import { clsx } from 'clsx'
 import { useHelmOCISources, useAddOCISource, useRemoveOCISource, useClusterInfo } from '../../api/client'
+import type { UpgradeInfo } from '../../types'
 
 interface TrackChartSourceDialogProps {
   open: boolean
   onClose: () => void
   /** Chart name of the release this was opened from, for the example prompt. */
   chartName?: string
+  sourceIssue?: UpgradeInfo['sourceIssue']
+  sourceError?: string
+}
+
+function getSourceIssueCopy(sourceIssue: UpgradeInfo['sourceIssue'], sourceError?: string) {
+  switch (sourceIssue) {
+    case 'repo_index_error':
+      return {
+        title: 'A Helm repo index failed',
+        body: 'Fix, refresh, or remove the broken Helm repo index. If this release came from OCI, add its registry prefix and Radar will check OCI before reporting that repo error.',
+      }
+    case 'ambiguous_repository':
+      return {
+        title: 'Multiple Helm repos match',
+        body: 'Radar will not guess between classic repos. Adding an OCI prefix will not enable direct upgrades while those repos remain ambiguous.',
+      }
+    case 'untracked':
+      return {
+        title: 'Source not tracked',
+        body: 'Helm does not record the install source. Add the OCI prefix that contains this chart.',
+      }
+    default:
+      return sourceError
+        ? { title: 'Source unresolved', body: sourceError }
+        : undefined
+  }
 }
 
 // TrackChartSourceDialog lets the user register an OCI chart-source prefix — the
@@ -16,7 +43,7 @@ interface TrackChartSourceDialogProps {
 // installed from, so for charts published to an OCI registry (and not managed by
 // GitOps) Radar can only track upgrades once the user declares where they live.
 // Registering a registry/org prefix lets Radar probe "<prefix>/<chartName>".
-export function TrackChartSourceDialog({ open, onClose, chartName }: TrackChartSourceDialogProps) {
+export function TrackChartSourceDialog({ open, onClose, chartName, sourceIssue, sourceError }: TrackChartSourceDialogProps) {
   const [value, setValue] = useState('')
   const { data: sources } = useHelmOCISources()
   const { data: clusterInfo } = useClusterInfo()
@@ -30,6 +57,11 @@ export function TrackChartSourceDialog({ open, onClose, chartName }: TrackChartS
 
   const trimmed = value.trim()
   const invalid = trimmed !== '' && !trimmed.startsWith('oci://')
+  const normalizedInput = trimmed.replace(/\/+$/, '')
+  const normalizedChartName = chartName?.trim().replace(/^\/+|\/+$/g, '') ?? ''
+  const probedRef = normalizedInput && normalizedChartName ? `${normalizedInput}/${normalizedChartName}` : ''
+  const looksLikeFullChartRef = Boolean(normalizedInput && normalizedChartName && normalizedInput.endsWith(`/${normalizedChartName}`))
+  const sourceIssueCopy = getSourceIssueCopy(sourceIssue, sourceError)
 
   const handleAdd = () => {
     if (!trimmed || invalid) return
@@ -58,6 +90,16 @@ export function TrackChartSourceDialog({ open, onClose, chartName }: TrackChartS
       </div>
 
       <div className="p-4 space-y-4">
+        {sourceIssueCopy && (
+          <div className="flex items-start gap-2 rounded-lg border border-theme-border bg-theme-elevated px-3 py-2 text-sm">
+            <AlertTriangle className="w-4 h-4 shrink-0 mt-0.5 text-theme-text-secondary" />
+            <div>
+              <p className="font-medium text-theme-text-primary">{sourceIssueCopy.title}</p>
+              <p className="text-theme-text-secondary">{sourceIssueCopy.body}</p>
+            </div>
+          </div>
+        )}
+
         <div>
           <label className="block text-sm font-medium text-theme-text-secondary mb-2">
             OCI registry prefix
@@ -87,8 +129,10 @@ export function TrackChartSourceDialog({ open, onClose, chartName }: TrackChartS
           <p className="mt-1 text-xs text-theme-text-tertiary">
             {invalid
               ? 'Must be an oci:// reference.'
+              : looksLikeFullChartRef
+                ? `This looks like a full chart ref. Radar would probe "${probedRef}"; remove the final "/${normalizedChartName}" if "${normalizedChartName}" is the chart name.`
               : chartName
-                ? `Radar will look for "${chartName}" under this prefix (and any others below).`
+                ? `Radar will probe "${probedRef || `<prefix>/${normalizedChartName}`}".`
                 : 'Radar probes <prefix>/<chartName> for each untracked release.'}
           </p>
         </div>


### PR DESCRIPTION
## Summary
- resolve registered OCI Helm sources before surfacing unrelated classic repo index failures
- add sourceIssue reason codes so the Helm drawer distinguishes untracked, blocked repo index, and ambiguous classic repo states
- tune the chart-source dialog copy and full-chart-ref warning

Fixes #1112

## Verification
- reproduced on radar-test-nonprod with an OCI-installed cloudpirates/postgres release plus a broken classic repo index
- verified the fixed build on the same cluster: after registering oci://registry-1.docker.io/cloudpirates, upgrade-info resolved sourceType=oci and chartRef=oci://registry-1.docker.io/cloudpirates/postgres
- go test ./internal/helm
- npx vitest run web/src/components/helm/HelmReleaseDrawer.test.ts
- make tsc
- make test
- make build
- visual-test screenshots for blocked source chip, dialog warning, and latest state after registration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ordering and error semantics on the Helm upgrade discovery path and adds a new API field consumed by the UI; behavior is covered by new tests but affects how users interpret upgrade failures.
> 
> **Overview**
> Helm **upgrade discovery and resolution** now try **registered OCI sources before** surfacing unrelated classic repo index failures, so OCI-installed charts can resolve even when a configured HTTP repo index is broken.
> 
> The API adds **`sourceIssue`** on `UpgradeInfo` (`untracked`, `repo_index_error`, `ambiguous_repository`) via shared helpers (`applyNoClassicCandidateUpgrade`, `markUpgradeSourceIssue`), used by single and batch upgrade checks. **`resolveUpgradeChartPath`** follows the same ordering (OCI fallback, then index errors). Ambiguous classic-repo matches set **`ambiguous_repository`** without marking the release untracked.
> 
> The **Helm drawer** uses `sourceIssue` for chip labels, tooltips, and when **“track OCI source”** is actionable (`repo_index_error` / `untracked` yes; **`ambiguous_repository`** informational only). **Track chart source** dialog copy and a **full chart ref** input warning were updated; shared types gained `sourceIssue`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b96b363e7a3da09cfb4b2c05ff7d0d7723ef0611. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->