### PR TITLE
Edit Helm values during release upgrades

### DIFF
--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -26,6 +26,7 @@ import (
 	"github.com/skyhook-io/radar/pkg/helmhistory"
 
 	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/registry"
@@ -2315,6 +2316,32 @@ func (c *Client) UpgradeAsUser(namespace, name, targetVersion, repositoryName st
 	return c.upgradeWith(actionConfig, name, targetVersion, repositoryName, noop)
 }
 
+// UpgradeWithValuesProgress upgrades a release to a target version applying the
+// supplied user values (WYSIWYG), reporting progress via a channel.
+func (c *Client) UpgradeWithValuesProgress(namespace, name, targetVersion, repositoryName string, newValues map[string]any, progressCh chan<- InstallProgress) error {
+	sendProgress := progressSender(progressCh)
+	sendProgress("preparing", fmt.Sprintf("Getting current release %s...", name), "")
+
+	actionConfig, err := c.getActionConfig(namespace)
+	if err != nil {
+		return err
+	}
+	return c.upgradeWithValues(actionConfig, name, targetVersion, repositoryName, newValues, sendProgress)
+}
+
+// UpgradeWithValuesProgressAsUser upgrades a release to a target version applying
+// the supplied user values with K8s impersonation and progress reporting.
+func (c *Client) UpgradeWithValuesProgressAsUser(namespace, name, targetVersion, repositoryName string, newValues map[string]any, username string, groups []string, progressCh chan<- InstallProgress) error {
+	sendProgress := progressSender(progressCh)
+	sendProgress("preparing", fmt.Sprintf("Getting current release %s...", name), "")
+
+	actionConfig, err := c.getActionConfigForUser(namespace, username, groups)
+	if err != nil {
+		return err
+	}
+	return c.upgradeWithValues(actionConfig, name, targetVersion, repositoryName, newValues, sendProgress)
+}
+
 func progressSender(progressCh chan<- InstallProgress) func(phase, message, detail string) {
 	return func(phase, message, detail string) {
 		if progressCh == nil {
@@ -2335,15 +2362,10 @@ func (c *Client) upgradeWith(actionConfig *action.Configuration, name, targetVer
 		return fmt.Errorf("failed to get current release: %w", err)
 	}
 
-	chartName := rel.Chart.Metadata.Name
-	sendProgress("resolving", fmt.Sprintf("Finding %s version %s in repositories...", chartName, targetVersion), "")
-
-	chartPath, resolvedRepo, err := c.resolveUpgradeChartPath(chartName, targetVersion, repositoryName, chartSourceHosts(rel.Chart.Metadata.Home, rel.Chart.Metadata.Sources))
+	targetChart, err := c.chartForUpgradeTarget(actionConfig, rel, targetVersion, repositoryName, sendProgress)
 	if err != nil {
 		return err
 	}
-
-	sendProgress("downloading", fmt.Sprintf("Downloading %s-%s from %s...", chartName, targetVersion, resolvedRepo), chartPath)
 
 	// Create upgrade action — don't use Wait=true because Radar already
 	// shows real-time resource status via SSE. Waiting blocks the dialog
@@ -2357,49 +2379,105 @@ func (c *Client) upgradeWith(actionConfig *action.Configuration, name, targetVer
 	// for keys a newer chart added (a cross-version upgrade footgun).
 	upgradeAction.ResetThenReuseValues = true
 
-	// Use ChartPathOptions to locate/download the chart
-	client := action.NewInstall(actionConfig)
-	client.Version = targetVersion
-
-	// OCI pulls need a registry client on the action; Radar's action config
-	// doesn't carry one by default. Wire it from the user's helm registry login.
-	if registry.IsOCI(chartPath) {
-		rc, err := c.newRegistryClientConcrete()
-		if err != nil {
-			return fmt.Errorf("failed to build OCI registry client: %w", err)
-		}
-		client.SetRegistryClient(rc)
-	}
-
-	cp, err := client.ChartPathOptions.LocateChart(chartPath, c.settings)
-	if err != nil {
-		return fmt.Errorf("failed to locate chart: %w", err)
-	}
-
-	sendProgress("loading", "Loading chart...", cp)
-
-	chart, err := loader.Load(cp)
-	if err != nil {
-		return fmt.Errorf("failed to load chart: %w", err)
-	}
-
-	// Refuse a silent chart-swap: the resolved source must publish the SAME chart
-	// the release runs, not merely a chart at the same version. Matters most for
-	// OCI prefix probing, where "<prefix>/<chartName>" is derived, not asserted.
-	if chart.Metadata != nil && chart.Metadata.Name != chartName {
-		return fmt.Errorf("resolved chart is %q but release %q runs chart %q — refusing to swap charts", chart.Metadata.Name, name, chartName)
-	}
-
-	sendProgress("upgrading", fmt.Sprintf("Applying %s %s...", chartName, targetVersion), "")
+	sendProgress("upgrading", fmt.Sprintf("Applying %s %s...", rel.Chart.Metadata.Name, targetVersion), "")
 
 	// Run the upgrade
-	_, err = upgradeAction.Run(name, chart, rel.Config)
+	_, err = upgradeAction.Run(name, targetChart, rel.Config)
 	if err != nil {
 		return fmt.Errorf("upgrade failed: %w", err)
 	}
 
 	sendProgress("complete", fmt.Sprintf("Successfully upgraded %s to %s", name, targetVersion), "")
 	return nil
+}
+
+// upgradeWithValues upgrades a release to a target chart version applying exactly
+// the supplied user values (WYSIWYG — ResetValues, no merge with prior overrides).
+// The plain upgradeWith path keeps ResetThenReuseValues for the blind carry-over case.
+func (c *Client) upgradeWithValues(actionConfig *action.Configuration, name, targetVersion, repositoryName string, newValues map[string]any, sendProgress func(phase, message, detail string)) error {
+	getAction := action.NewGet(actionConfig)
+	rel, err := getAction.Run(name)
+	if err != nil {
+		return fmt.Errorf("failed to get current release: %w", err)
+	}
+
+	targetChart, err := c.chartForUpgradeTarget(actionConfig, rel, targetVersion, repositoryName, sendProgress)
+	if err != nil {
+		return err
+	}
+
+	upgradeAction := action.NewUpgrade(actionConfig)
+	upgradeAction.Namespace = rel.Namespace
+	upgradeAction.Timeout = 120 * time.Second
+	upgradeAction.ResetValues = true // WYSIWYG: apply only the edited values
+
+	sendProgress("upgrading", fmt.Sprintf("Applying %s %s...", rel.Chart.Metadata.Name, targetVersion), "")
+
+	_, err = upgradeAction.Run(name, targetChart, newValues)
+	if err != nil {
+		return fmt.Errorf("upgrade failed: %w", err)
+	}
+
+	sendProgress("complete", fmt.Sprintf("Successfully upgraded %s to %s", name, targetVersion), "")
+	return nil
+}
+
+func (c *Client) chartForUpgradeTarget(actionConfig *action.Configuration, rel *release.Release, targetVersion, repositoryName string, sendProgress func(phase, message, detail string)) (*chart.Chart, error) {
+	if targetVersion == "" || targetVersion == rel.Chart.Metadata.Version {
+		return rel.Chart, nil
+	}
+	return c.loadTargetChart(actionConfig, rel, targetVersion, repositoryName, sendProgress)
+}
+
+// loadTargetChart resolves, downloads and loads the chart for a target upgrade
+// version, refusing a silent chart-swap (the resolved source must publish the
+// same chart the release runs). Shared by the upgrade and preview paths so they
+// resolve the target version identically.
+func (c *Client) loadTargetChart(actionConfig *action.Configuration, rel *release.Release, targetVersion, repositoryName string, sendProgress func(phase, message, detail string)) (*chart.Chart, error) {
+	chartName := rel.Chart.Metadata.Name
+	sendProgress("resolving", fmt.Sprintf("Finding %s version %s in repositories...", chartName, targetVersion), "")
+
+	chartPath, resolvedRepo, err := c.resolveUpgradeChartPath(chartName, targetVersion, repositoryName, chartSourceHosts(rel.Chart.Metadata.Home, rel.Chart.Metadata.Sources))
+	if err != nil {
+		return nil, err
+	}
+
+	sendProgress("downloading", fmt.Sprintf("Downloading %s-%s from %s...", chartName, targetVersion, resolvedRepo), chartPath)
+
+	// Use ChartPathOptions to locate/download the chart
+	locate := action.NewInstall(actionConfig)
+	locate.Version = targetVersion
+
+	// OCI pulls need a registry client on the action; Radar's action config
+	// doesn't carry one by default. Wire it from the user's helm registry login.
+	if registry.IsOCI(chartPath) {
+		rc, err := c.newRegistryClientConcrete()
+		if err != nil {
+			return nil, fmt.Errorf("failed to build OCI registry client: %w", err)
+		}
+		locate.SetRegistryClient(rc)
+	}
+
+	cp, err := locate.ChartPathOptions.LocateChart(chartPath, c.settings)
+	if err != nil {
+		return nil, fmt.Errorf("failed to locate chart: %w", err)
+	}
+
+	sendProgress("loading", "Loading chart...", cp)
+
+	targetChart, err := loader.Load(cp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load chart: %w", err)
+	}
+
+	// Refuse a silent chart-swap: the resolved source must publish the SAME chart
+	// the release runs, not merely a chart at the same version. Matters most for
+	// OCI prefix probing, where "<prefix>/<chartName>" is derived, not asserted.
+	if targetChart.Metadata != nil && targetChart.Metadata.Name != chartName {
+		return nil, fmt.Errorf("resolved chart is %q but release %q runs chart %q — refusing to swap charts", targetChart.Metadata.Name, rel.Name, chartName)
+	}
+
+	return targetChart, nil
 }
 
 type chartPathCandidate struct {
@@ -2689,13 +2767,26 @@ func (c *Client) batchCheckUpgrades(namespace, username string, groups []string)
 	return result, nil
 }
 
-// PreviewValuesChange previews the effect of new values on a release via dry-run
-func (c *Client) PreviewValuesChange(namespace, name string, newValues map[string]any) (*ValuesPreviewResponse, error) {
+// PreviewValuesChange previews the effect of new values on a release via dry-run.
+// When targetVersion is non-empty and differs from the running chart version, the
+// dry-run renders against that target chart instead of the current chart.
+func (c *Client) PreviewValuesChange(namespace, name string, newValues map[string]any, targetVersion, repositoryName string) (*ValuesPreviewResponse, error) {
 	actionConfig, err := c.getActionConfig(namespace)
 	if err != nil {
 		return nil, err
 	}
+	return c.previewValuesChangeWith(actionConfig, name, newValues, targetVersion, repositoryName)
+}
 
+func (c *Client) PreviewValuesChangeAsUser(namespace, name string, newValues map[string]any, targetVersion, repositoryName string, username string, groups []string) (*ValuesPreviewResponse, error) {
+	actionConfig, err := c.getActionConfigForUser(namespace, username, groups)
+	if err != nil {
+		return nil, err
+	}
+	return c.previewValuesChangeWith(actionConfig, name, newValues, targetVersion, repositoryName)
+}
+
+func (c *Client) previewValuesChangeWith(actionConfig *action.Configuration, name string, newValues map[string]any, targetVersion, repositoryName string) (*ValuesPreviewResponse, error) {
 	// Get the current release
 	getAction := action.NewGet(actionConfig)
 	rel, err := getAction.Run(name)
@@ -2713,6 +2804,12 @@ func (c *Client) PreviewValuesChange(namespace, name string, newValues map[strin
 	// Get current manifest
 	currentManifest := rel.Manifest
 
+	noop := func(phase, message, detail string) {}
+	previewChart, err := c.chartForUpgradeTarget(actionConfig, rel, targetVersion, repositoryName, noop)
+	if err != nil {
+		return nil, err
+	}
+
 	// Perform a dry-run upgrade with the new values
 	upgradeAction := action.NewUpgrade(actionConfig)
 	upgradeAction.Namespace = rel.Namespace
@@ -2721,7 +2818,7 @@ func (c *Client) PreviewValuesChange(namespace, name string, newValues map[strin
 	upgradeAction.ResetValues = true // Use only the provided values, don't merge
 
 	// Run the dry-run upgrade
-	newRel, err := upgradeAction.Run(name, rel.Chart, newValues)
+	newRel, err := upgradeAction.Run(name, previewChart, newValues)
 	if err != nil {
 		return nil, fmt.Errorf("failed to preview values change: %w", err)
 	}

--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -2523,7 +2523,7 @@ func (c *Client) resolveUpgradeChartPathWithOCIResolver(chartName, targetVersion
 					continue
 				}
 				path := entry.URLs[0]
-				if !strings.HasPrefix(path, "http://") && !strings.HasPrefix(path, "https://") {
+				if !isAbsoluteChartURL(path) {
 					path = strings.TrimSuffix(r.URL, "/") + "/" + path
 				}
 				candidates = append(candidates, chartPathCandidate{repoName: r.Name, repoURL: r.URL, chartPath: path})
@@ -2568,6 +2568,10 @@ func (c *Client) resolveUpgradeChartPathWithOCIResolver(chartName, targetVersion
 	}
 
 	return "", "", fmt.Errorf("chart %s version %s not found in configured repositories or registered OCI sources", chartName, targetVersion)
+}
+
+func isAbsoluteChartURL(path string) bool {
+	return strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") || registry.IsOCI(path)
 }
 
 // BatchCheckUpgrades checks for upgrades for all releases at once (more efficient)

--- a/internal/helm/client_test.go
+++ b/internal/helm/client_test.go
@@ -637,6 +637,22 @@ func TestGetValuesWithAllValuesKeepsComputedWhenUserValuesReadFails(t *testing.T
 	}
 }
 
+func TestChartForUpgradeTargetReusesReleaseChartForSameVersion(t *testing.T) {
+	client := testHelmClientWithRepoConfigOnly(t)
+	rel := helmTestRelease("argo-cd", "demo", 1, release.StatusDeployed, "deployed")
+	rel.Chart.Metadata.Version = "9.5.11"
+
+	got, err := client.chartForUpgradeTarget(nil, rel, "9.5.11", "missing-repo", func(phase, message, detail string) {
+		t.Fatalf("same-version chart selection should not resolve/download chart, got progress %q %q %q", phase, message, detail)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != rel.Chart {
+		t.Fatal("chartForUpgradeTarget returned a different chart, want current release chart")
+	}
+}
+
 func TestDiffResourceRefs(t *testing.T) {
 	left := []ResourceRef{
 		{APIVersion: "apps/v1", Kind: "Deployment", Namespace: "demo", Name: "cart"},

--- a/internal/helm/client_test.go
+++ b/internal/helm/client_test.go
@@ -1453,6 +1453,49 @@ func TestResolveUpgradeChartPath_UsesRepositoryHint(t *testing.T) {
 	}
 }
 
+func TestResolveUpgradeChartPath_RepositoryIndexOCIURLIsAbsolute(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+	if err := os.Mkdir(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	repoFile := filepath.Join(dir, "repositories.yaml")
+	if err := os.WriteFile(repoFile, []byte(`apiVersion: v1
+generated: "2026-05-05T00:00:00Z"
+repositories:
+- name: bitnami
+  url: https://charts.bitnami.com/bitnami
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "bitnami-index.yaml"), []byte(`apiVersion: v1
+entries:
+  nginx:
+  - name: nginx
+    version: 25.0.5
+    urls:
+    - oci://registry-1.docker.io/bitnamicharts/nginx
+generated: "2026-05-05T00:00:00Z"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	client := &Client{settings: &cli.EnvSettings{
+		RepositoryConfig: repoFile,
+		RepositoryCache:  cacheDir,
+	}}
+
+	chartPath, repoName, err := client.resolveUpgradeChartPath("nginx", "25.0.5", "bitnami", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repoName != "bitnami" {
+		t.Fatalf("repo = %q, want bitnami", repoName)
+	}
+	if chartPath != "oci://registry-1.docker.io/bitnamicharts/nginx" {
+		t.Fatalf("chart path = %q, want OCI URL unchanged", chartPath)
+	}
+}
+
 func TestResolveUpgradeChartPath_AmbiguousWithoutHintOrAffinity(t *testing.T) {
 	client := testHelmClientWithRepos(t)
 

--- a/internal/helm/handlers.go
+++ b/internal/helm/handlers.go
@@ -2,6 +2,7 @@ package helm
 
 import (
 	"encoding/json"
+	"io"
 	"log"
 	"net/http"
 	"strconv"
@@ -30,6 +31,20 @@ func userCreds(r *http.Request) (string, []string) {
 		return user.Username, user.Groups
 	}
 	return "", nil
+}
+
+func decodeOptionalApplyValuesRequest(body io.Reader) (map[string]any, error) {
+	if body == nil {
+		return nil, nil
+	}
+	var req ApplyValuesRequest
+	if err := json.NewDecoder(body).Decode(&req); err != nil {
+		if err == io.EOF {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return req.Values, nil
 }
 
 // Handlers provides HTTP handlers for Helm endpoints
@@ -717,6 +732,12 @@ func (h *Handlers) handleUpgradeStream(w http.ResponseWriter, r *http.Request) {
 	}
 	repositoryName := r.URL.Query().Get("repository")
 
+	editedValues, err := decodeOptionalApplyValuesRequest(r.Body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+
 	// Set up SSE headers
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
@@ -732,9 +753,21 @@ func (h *Handlers) handleUpgradeStream(w http.ResponseWriter, r *http.Request) {
 	progressCh := make(chan InstallProgress, 10)
 	defer close(progressCh)
 
+	auth.AuditLog(r, namespace, name)
 	resultCh := make(chan error, 1)
 	go func() {
-		if user := auth.UserFromContext(r.Context()); user != nil {
+		user := auth.UserFromContext(r.Context())
+		// Use != nil, not len > 0: an explicit empty map ({}) means
+		// "clear all my overrides" and must NOT fall back to carry-over.
+		if editedValues != nil {
+			if user != nil {
+				resultCh <- client.UpgradeWithValuesProgressAsUser(namespace, name, version, repositoryName, editedValues, user.Username, user.Groups, progressCh)
+				return
+			}
+			resultCh <- client.UpgradeWithValuesProgress(namespace, name, version, repositoryName, editedValues, progressCh)
+			return
+		}
+		if user != nil {
 			resultCh <- client.UpgradeWithProgressAsUser(namespace, name, version, repositoryName, user.Username, user.Groups, progressCh)
 			return
 		}
@@ -806,7 +839,8 @@ func (h *Handlers) handlePreviewValues(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	preview, err := client.PreviewValuesChange(namespace, name, req.Values)
+	username, groups := userCreds(r)
+	preview, err := client.PreviewValuesChangeAsUser(namespace, name, req.Values, req.Version, req.Repository, username, groups)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/internal/helm/handlers_test.go
+++ b/internal/helm/handlers_test.go
@@ -3,8 +3,11 @@ package helm
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/skyhook-io/radar/internal/auth"
@@ -78,6 +81,48 @@ func TestRequireCloudRole(t *testing.T) {
 				if resp["error"] == "" {
 					t.Error("error message is empty")
 				}
+			}
+		})
+	}
+}
+
+func TestDecodeOptionalApplyValuesRequest(t *testing.T) {
+	cases := []struct {
+		name    string
+		body    string
+		hasBody bool
+		want    map[string]any
+		wantErr bool
+	}{
+		{name: "nil body"},
+		{name: "empty body", hasBody: true},
+		{name: "explicit empty values stays non nil", body: `{"values":{}}`, hasBody: true, want: map[string]any{}},
+		{name: "populated values", body: `{"values":{"replicaCount":2}}`, hasBody: true, want: map[string]any{"replicaCount": float64(2)}},
+		{name: "invalid json", body: `{"values":`, hasBody: true, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var body io.Reader
+			if tc.hasBody {
+				body = strings.NewReader(tc.body)
+			}
+
+			got, err := decodeOptionalApplyValuesRequest(body)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("decodeOptionalApplyValuesRequest returned error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("values = %#v, want %#v", got, tc.want)
+			}
+			if tc.want != nil && got == nil {
+				t.Fatal("values = nil, want explicit non-nil map")
 			}
 		})
 	}

--- a/internal/helm/types.go
+++ b/internal/helm/types.go
@@ -297,9 +297,13 @@ type BatchUpgradeInfo struct {
 	Releases map[string]*UpgradeInfo `json:"releases"`
 }
 
-// ApplyValuesRequest is the request body for applying new values to a release
+// ApplyValuesRequest is the request body for previewing/applying new values to a
+// release. Version/Repository are optional: when set, the preview renders against
+// that target chart version; when empty, the release's current chart is used.
 type ApplyValuesRequest struct {
-	Values map[string]any `json:"values"`
+	Values     map[string]any `json:"values"`
+	Version    string         `json:"version,omitempty"`
+	Repository string         `json:"repository,omitempty"`
 }
 
 // ValuesPreviewResponse contains the preview of a values change

--- a/packages/k8s-ui/src/components/ui/ConfirmDialog.tsx
+++ b/packages/k8s-ui/src/components/ui/ConfirmDialog.tsx
@@ -18,6 +18,7 @@ interface ConfirmDialogProps {
   isLoading?: boolean
   isClosable?: boolean // Allow closing even when isLoading (e.g., for long-running ops the user can dismiss)
   confirmDisabled?: boolean // Block the confirm action while custom content is invalid (e.g., bad YAML)
+  className?: string
   children?: ReactNode // Optional custom content (e.g., checkboxes)
 }
 
@@ -34,6 +35,7 @@ export function ConfirmDialog({
   isLoading = false,
   isClosable = false,
   confirmDisabled = false,
+  className,
   children,
 }: ConfirmDialogProps) {
   const canClose = !isLoading || isClosable
@@ -41,7 +43,7 @@ export function ConfirmDialog({
   const severity = isDanger ? 'error' : 'warning'
 
   return (
-    <DialogPortal open={open} onClose={onClose} closable={canClose} className="max-w-md w-full">
+    <DialogPortal open={open} onClose={onClose} closable={canClose} className={clsx('w-full', className ?? 'max-w-md')}>
       {/* Header */}
       <div className="flex items-start gap-3 p-4 border-b border-theme-border">
         <div

--- a/packages/k8s-ui/src/components/ui/ConfirmDialog.tsx
+++ b/packages/k8s-ui/src/components/ui/ConfirmDialog.tsx
@@ -17,6 +17,7 @@ interface ConfirmDialogProps {
   variant?: 'danger' | 'warning'
   isLoading?: boolean
   isClosable?: boolean // Allow closing even when isLoading (e.g., for long-running ops the user can dismiss)
+  confirmDisabled?: boolean // Block the confirm action while custom content is invalid (e.g., bad YAML)
   children?: ReactNode // Optional custom content (e.g., checkboxes)
 }
 
@@ -32,6 +33,7 @@ export function ConfirmDialog({
   variant = 'danger',
   isLoading = false,
   isClosable = false,
+  confirmDisabled = false,
   children,
 }: ConfirmDialogProps) {
   const canClose = !isLoading || isClosable
@@ -109,9 +111,9 @@ export function ConfirmDialog({
         </button>
         <button
           onClick={onConfirm}
-          disabled={isLoading}
+          disabled={isLoading || confirmDisabled}
           className={clsx(
-            'px-4 py-2 text-sm font-medium rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2',
+            'px-4 py-2 text-sm font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2',
             isDanger
               ? 'bg-red-600 hover:bg-red-700 text-theme-text-primary'
               : 'bg-amber-600 hover:bg-amber-700 text-theme-text-primary'

--- a/packages/k8s-ui/src/components/ui/DialogPortal.tsx
+++ b/packages/k8s-ui/src/components/ui/DialogPortal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type ReactNode } from 'react'
+import { useEffect, useRef, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import { clsx } from 'clsx'
 import { useAnimatedUnmount } from '../../hooks/useAnimatedUnmount'
@@ -29,19 +29,40 @@ export function DialogPortal({ open, onClose, children, className, closable = tr
   const dialogRef = useRef<HTMLDivElement>(null)
   const { shouldRender, isOpen } = useAnimatedUnmount(open, 200)
 
-  // Capture-phase ESC handler — stops event before it reaches document listeners (e.g. drawer shortcuts)
+  // Bubble phase lets nested editors and menus consume Escape before the dialog closes.
+  const handleDialogKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== 'Escape') return
+
+    e.stopPropagation()
+    e.preventDefault()
+
+    if (closable) {
+      onClose()
+    }
+  }
+
   useEffect(() => {
     if (!open) return
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && closable) {
-        e.stopPropagation()
-        e.preventDefault()
+
+    const handleDocumentKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      const modalDialogs = Array.from(document.querySelectorAll<HTMLElement>('[role="dialog"][aria-modal="true"]'))
+      const topDialog = modalDialogs[modalDialogs.length - 1]
+      if (topDialog !== dialogRef.current) return
+
+      if (dialogRef.current?.contains(e.target as Node)) return
+
+      e.stopPropagation()
+      e.preventDefault()
+
+      if (closable) {
         onClose()
       }
     }
-    document.addEventListener('keydown', handleKeyDown, true)
-    return () => document.removeEventListener('keydown', handleKeyDown, true)
-  }, [open, onClose, closable])
+
+    document.addEventListener('keydown', handleDocumentKeyDown, true)
+    return () => document.removeEventListener('keydown', handleDocumentKeyDown, true)
+  }, [open, closable, onClose])
 
   // Move focus into the dialog for accessibility and tab navigation
   useEffect(() => {
@@ -67,6 +88,7 @@ export function DialogPortal({ open, onClose, children, className, closable = tr
         role="dialog"
         aria-modal="true"
         tabIndex={-1}
+        onKeyDown={handleDialogKeyDown}
         className={clsx(
           'relative bg-theme-surface border border-theme-border rounded-lg shadow-2xl mx-4 outline-none',
           TRANSITION_PANEL,

--- a/packages/k8s-ui/src/components/ui/YamlEditor.tsx
+++ b/packages/k8s-ui/src/components/ui/YamlEditor.tsx
@@ -93,20 +93,6 @@ export function YamlEditor({
   const decorationsRef = useRef<string[]>([])
   const monacoRef = useRef<Monaco | null>(null)
 
-  useEffect(() => {
-    const editor = editorRef.current
-    const model = editor?.getModel()
-    if (!editor || !model || model.getValue() === value) return
-
-    const selection = editor.getSelection()
-    const scrollTop = editor.getScrollTop()
-    const scrollLeft = editor.getScrollLeft()
-    model.setValue(value)
-    if (selection) editor.setSelection(selection)
-    editor.setScrollTop(scrollTop)
-    editor.setScrollLeft(scrollLeft)
-  }, [value])
-
   // Apply decorations for editable fields
   const applyDecorations = useCallback(() => {
     const editor = editorRef.current
@@ -237,7 +223,7 @@ export function YamlEditor({
     <div className="rounded-lg overflow-hidden border border-theme-border" style={{ height }}>
       <Editor
         defaultLanguage="yaml"
-        defaultValue={value}
+        value={value}
         onChange={handleChange}
         onMount={handleEditorMount}
         theme="vs-dark"

--- a/packages/k8s-ui/src/components/ui/YamlEditor.tsx
+++ b/packages/k8s-ui/src/components/ui/YamlEditor.tsx
@@ -93,6 +93,20 @@ export function YamlEditor({
   const decorationsRef = useRef<string[]>([])
   const monacoRef = useRef<Monaco | null>(null)
 
+  useEffect(() => {
+    const editor = editorRef.current
+    const model = editor?.getModel()
+    if (!editor || !model || model.getValue() === value) return
+
+    const selection = editor.getSelection()
+    const scrollTop = editor.getScrollTop()
+    const scrollLeft = editor.getScrollLeft()
+    model.setValue(value)
+    if (selection) editor.setSelection(selection)
+    editor.setScrollTop(scrollTop)
+    editor.setScrollLeft(scrollLeft)
+  }, [value])
+
   // Apply decorations for editable fields
   const applyDecorations = useCallback(() => {
     const editor = editorRef.current
@@ -223,7 +237,7 @@ export function YamlEditor({
     <div className="rounded-lg overflow-hidden border border-theme-border" style={{ height }}>
       <Editor
         defaultLanguage="yaml"
-        value={value}
+        defaultValue={value}
         onChange={handleChange}
         onMount={handleEditorMount}
         theme="vs-dark"

--- a/packages/k8s-ui/src/types/core.ts
+++ b/packages/k8s-ui/src/types/core.ts
@@ -853,6 +853,8 @@ export interface BatchUpgradeInfo {
 // Request body for applying new values to a release
 export interface ApplyValuesRequest {
   values: Record<string, unknown>
+  version?: string
+  repository?: string
 }
 
 // Response for previewing values changes

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2770,19 +2770,24 @@ function streamHelmProgress(
   })
 }
 
-// Upgrade a release with progress streaming via SSE
+// When `values` is provided, the upgrade applies exactly those edited values
+// instead of carrying the release's prior values over blindly.
 export function upgradeWithProgress(
   namespace: string,
   name: string,
   version: string,
   repositoryName: string | undefined,
-  onProgress: (event: InstallProgressEvent) => void
+  onProgress: (event: InstallProgressEvent) => void,
+  values?: Record<string, unknown>
 ): Promise<void> {
   const params = new URLSearchParams({ version })
   if (repositoryName) params.set('repository', repositoryName)
+  const options: RequestInit = values
+    ? { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ values }) }
+    : { method: 'POST' }
   return streamHelmProgress(
     `${getApiBase()}/helm/releases/${namespace}/${name}/upgrade-stream?${params.toString()}`,
-    { method: 'POST' },
+    options,
     onProgress,
     'Upgrade failed',
   ).then(() => {})
@@ -2803,14 +2808,15 @@ export function rollbackWithProgress(
   ).then(() => {})
 }
 
-// Preview values change (dry-run upgrade)
+// When `version` is supplied, preview renders against that target chart version
+// instead of the release's current chart.
 export function useHelmPreviewValues() {
-  return useMutation<ValuesPreviewResponse, Error, { namespace: string; name: string; values: Record<string, unknown> }>({
-    mutationFn: async ({ namespace, name, values }) => {
+  return useMutation<ValuesPreviewResponse, Error, { namespace: string; name: string; values: Record<string, unknown>; version?: string; repository?: string }>({
+    mutationFn: async ({ namespace, name, values, version, repository }) => {
       const response = await apiFetch(`${getApiBase()}/helm/releases/${namespace}/${name}/values/preview`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ values }),
+        body: JSON.stringify({ values, version, repository }),
       })
       if (!response.ok) {
         const error = await response.json().catch(() => ({ error: 'Unknown error' }))

--- a/web/src/components/helm/HelmReleaseDrawer.tsx
+++ b/web/src/components/helm/HelmReleaseDrawer.tsx
@@ -4,7 +4,7 @@ import { FetchResult, useDockReservedHeight, compareVersions } from '@skyhook-io
 import { startViewTransitionSafe } from '@skyhook-io/k8s-ui/utils/view-transition'
 import { TRANSITION_DRAWER } from '../../utils/animation'
 import { useRefreshAnimation } from '../../hooks/useRefreshAnimation'
-import { X, Copy, Check, RefreshCw, Package, Code, History, Settings, Link2, Anchor, GitFork, BookOpen, ArrowUpCircle, Trash2, GitBranch, AlertTriangle, RotateCcw, Clock, GitCompare, ExternalLink, ChevronRight, ChevronDown, SlidersHorizontal, Eye, Loader2 } from 'lucide-react'
+import { X, Copy, Check, RefreshCw, Package, Code, History, Settings, Link2, Anchor, GitFork, BookOpen, ArrowUpCircle, Trash2, GitBranch, AlertTriangle, RotateCcw, Clock, GitCompare, ExternalLink, ChevronRight, SlidersHorizontal, Eye, Loader2 } from 'lucide-react'
 import yaml from 'yaml'
 import { useNavigate } from 'react-router-dom'
 import { clsx } from 'clsx'
@@ -100,6 +100,8 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
   const [showTrackSource, setShowTrackSource] = useState(false)
   const [selectedVersion, setSelectedVersion] = useState<string | null>(null)
   const [adjustValues, setAdjustValues] = useState(false)
+  const [renderAdjustValues, setRenderAdjustValues] = useState(false)
+  const [upgradeEditorReady, setUpgradeEditorReady] = useState(false)
   const [editedUpgradeYaml, setEditedUpgradeYaml] = useState('')
   const [upgradeValuesSeeded, setUpgradeValuesSeeded] = useState(false)
   const [upgradePreview, setUpgradePreview] = useState<ValuesPreviewResponse | null>(null)
@@ -337,6 +339,8 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
     setUpgradeProgress([])
     setSelectedVersion(null)
     setAdjustValues(false)
+    setRenderAdjustValues(false)
+    setUpgradeEditorReady(false)
     setEditedUpgradeYaml('')
     setUpgradeValuesSeeded(false)
     setUpgradePreview(null)
@@ -351,12 +355,39 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
     setUpgradeValuesSeeded(true)
   }, [adjustValues, upgradeValues, upgradeValuesSeeded])
 
-  const handleToggleAdjustValues = () => {
-    if (!adjustValues) {
-      setEditedUpgradeYaml('')
-      setUpgradeValuesSeeded(false)
+  useEffect(() => {
+    if (!adjustValues || upgradeValuesLoading || upgradeValuesError || !upgradeValuesSeeded) {
+      setUpgradeEditorReady(false)
+      return
     }
-    setAdjustValues(prev => !prev)
+
+    if (typeof window === 'undefined') {
+      setUpgradeEditorReady(true)
+      return
+    }
+
+    let frame2 = 0
+    const frame1 = window.requestAnimationFrame(() => {
+      frame2 = window.requestAnimationFrame(() => setUpgradeEditorReady(true))
+    })
+    return () => {
+      window.cancelAnimationFrame(frame1)
+      if (frame2) window.cancelAnimationFrame(frame2)
+    }
+  }, [adjustValues, upgradeValuesLoading, upgradeValuesError, upgradeValuesSeeded])
+
+  const handleToggleAdjustValues = () => {
+    if (adjustValues) {
+      setAdjustValues(false)
+      return
+    }
+
+    setRenderAdjustValues(true)
+    setUpgradeEditorReady(false)
+    setEditedUpgradeYaml('')
+    setUpgradeValuesSeeded(false)
+    upgradePreviewMutation.reset()
+    setAdjustValues(true)
   }
 
   // Validity is derived from the SAME parser used at submit — not the editor's
@@ -813,6 +844,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
         isLoading={isUpgrading}
         confirmDisabled={isPreviewingUpgrade || (adjustValues && (upgradeValuesLoading || !!upgradeValuesError || !upgradeValuesSeeded || !!upgradeYamlError))}
         isClosable
+        className="max-w-2xl"
       >
         {upgradeProgress.length === 0 && availableVersions && availableVersions.length > 1 && (
           <div className="mb-1">
@@ -851,66 +883,97 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
         )}
         {upgradeProgress.length === 0 && canHelmWrite && canViewSensitive && (
           <div className="mt-3 border-t border-theme-border pt-3">
-            <button
-              type="button"
-              onClick={handleToggleAdjustValues}
-              disabled={isUpgrading || isPreviewingUpgrade}
-              className="flex items-center gap-1.5 text-sm font-medium text-theme-text-secondary hover:text-theme-text-primary disabled:opacity-50"
+            <Tooltip content="Edit the user-supplied Helm values that Radar will pass to this upgrade.">
+              <button
+                type="button"
+                onClick={handleToggleAdjustValues}
+                disabled={isUpgrading || isPreviewingUpgrade}
+                aria-expanded={adjustValues}
+                aria-controls="helm-upgrade-values-panel"
+                className="flex items-center gap-1.5 text-sm font-medium text-theme-text-secondary hover:text-theme-text-primary disabled:opacity-50"
+              >
+                <ChevronRight className={clsx('w-4 h-4 transition-transform duration-200', adjustValues && 'rotate-90')} />
+                <SlidersHorizontal className="w-3.5 h-3.5" />
+                Adjust your values (optional)
+              </button>
+            </Tooltip>
+            <div
+              id="helm-upgrade-values-panel"
+              className={`issue-details-motion ${adjustValues ? 'issue-details-motion-open' : ''}`}
+              onTransitionEnd={(event) => {
+                if (event.target !== event.currentTarget) return
+                if (event.propertyName !== 'grid-template-rows') return
+                if (!adjustValues) {
+                  setRenderAdjustValues(false)
+                  setUpgradeEditorReady(false)
+                }
+              }}
             >
-              {adjustValues ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
-              <SlidersHorizontal className="w-3.5 h-3.5" />
-              Adjust your values (optional)
-            </button>
-            {upgradeValuesError && (
-              <div className="mt-2 px-3 py-2 text-xs text-red-400 bg-red-500/10 border border-red-500/30 rounded">
-                Couldn’t load current values: {upgradeValuesError instanceof Error ? upgradeValuesError.message : 'Unknown error'}
+              <div className="overflow-hidden">
+                {renderAdjustValues && (
+                  <div className="mt-2">
+                    <p className="mb-2 text-xs text-theme-text-tertiary">
+                      These are your current settings — edit them to carry into {targetVersion}. What you see here is exactly what gets applied.
+                    </p>
+                    {upgradeValuesError && (
+                      <div className="mt-2 px-3 py-2 text-xs text-red-400 bg-red-500/10 border border-red-500/30 rounded">
+                        Couldn’t load current values: {upgradeValuesError instanceof Error ? upgradeValuesError.message : 'Unknown error'}
+                      </div>
+                    )}
+                    {upgradeValuesLoading && (
+                      <div className="flex items-center gap-2 h-[240px] px-3 text-sm text-theme-text-secondary bg-theme-elevated border border-theme-border rounded">
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                        Loading current values...
+                      </div>
+                    )}
+                    {!upgradeValuesLoading && !upgradeValuesError && (
+                      upgradeEditorReady ? (
+                        <YamlEditor
+                          value={editedUpgradeYaml}
+                          onChange={(value) => {
+                            editedUpgradeYamlRef.current = value
+                            setEditedUpgradeYaml(value)
+                          }}
+                          readOnly={isPreviewingUpgrade || isUpgrading}
+                          height="240px"
+                        />
+                      ) : (
+                        <div className="flex items-center gap-2 h-[240px] px-3 text-sm text-theme-text-secondary bg-theme-elevated border border-theme-border rounded">
+                          <Loader2 className="w-4 h-4 animate-spin" />
+                          Preparing editor...
+                        </div>
+                      )
+                    )}
+                    {upgradeYamlError && (
+                      <div className="mt-2 px-3 py-2 text-xs text-red-400 bg-red-500/10 border border-red-500/30 rounded">
+                        {upgradeYamlError}
+                      </div>
+                    )}
+                    {upgradePreviewMutation.error && (
+                      <div className="mt-2 px-3 py-2 text-xs text-red-400 bg-red-500/10 border border-red-500/30 rounded">
+                        Couldn’t preview against {targetVersion}: {upgradePreviewMutation.error.message}. You can still upgrade.
+                      </div>
+                    )}
+                    <div className="mt-2 flex justify-end">
+                      <Tooltip
+                        content="Render this release with the selected chart version and edited values, then show the manifest diff. Nothing is applied until you confirm from the preview."
+                        wrapperClassName="shrink-0"
+                      >
+                        <button
+                          type="button"
+                          onClick={handleUpgradePreview}
+                          disabled={upgradeValuesLoading || !!upgradeValuesError || !upgradeValuesSeeded || !!upgradeYamlError || isPreviewingUpgrade || isUpgrading}
+                          className="flex items-center gap-1 px-2.5 py-1 text-xs text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded border border-theme-border disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                          {upgradePreviewMutation.isPending ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Eye className="w-3.5 h-3.5" />}
+                          Preview what changes
+                        </button>
+                      </Tooltip>
+                    </div>
+                  </div>
+                )}
               </div>
-            )}
-            {adjustValues && (
-              <div className="mt-2">
-                <p className="mb-2 text-xs text-theme-text-tertiary">
-                  These are your current settings — edit them to carry into {targetVersion}. What you see here is exactly what gets applied.
-                </p>
-                {upgradeValuesLoading && (
-                  <div className="flex items-center gap-2 h-24 px-3 text-sm text-theme-text-secondary bg-theme-elevated border border-theme-border rounded">
-                    <Loader2 className="w-4 h-4 animate-spin" />
-                    Loading current values...
-                  </div>
-                )}
-                {!upgradeValuesLoading && !upgradeValuesError && (
-                  <YamlEditor
-                    value={editedUpgradeYaml}
-                    onChange={(value) => {
-                      editedUpgradeYamlRef.current = value
-                      setEditedUpgradeYaml(value)
-                    }}
-                    readOnly={isPreviewingUpgrade || isUpgrading}
-                    height="240px"
-                  />
-                )}
-                {upgradeYamlError && (
-                  <div className="mt-2 px-3 py-2 text-xs text-red-400 bg-red-500/10 border border-red-500/30 rounded">
-                    {upgradeYamlError}
-                  </div>
-                )}
-                {upgradePreviewMutation.error && (
-                  <div className="mt-2 px-3 py-2 text-xs text-red-400 bg-red-500/10 border border-red-500/30 rounded">
-                    Couldn’t preview against {targetVersion}: {upgradePreviewMutation.error.message}. You can still upgrade.
-                  </div>
-                )}
-                <div className="mt-2 flex justify-end">
-                  <button
-                    type="button"
-                    onClick={handleUpgradePreview}
-                    disabled={upgradeValuesLoading || !!upgradeValuesError || !upgradeValuesSeeded || !!upgradeYamlError || isPreviewingUpgrade || isUpgrading}
-                    className="flex items-center gap-1 px-2.5 py-1 text-xs text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded border border-theme-border disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    {upgradePreviewMutation.isPending ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Eye className="w-3.5 h-3.5" />}
-                    Preview what changes
-                  </button>
-                </div>
-              </div>
-            )}
+            </div>
           </div>
         )}
         {upgradeProgress.length > 0 && <ProgressLog entries={upgradeProgress} />}

--- a/web/src/components/helm/HelmReleaseDrawer.tsx
+++ b/web/src/components/helm/HelmReleaseDrawer.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { flushSync } from 'react-dom'
 import { FetchResult, useDockReservedHeight, compareVersions } from '@skyhook-io/k8s-ui'
 import { startViewTransitionSafe } from '@skyhook-io/k8s-ui/utils/view-transition'
@@ -9,7 +9,6 @@ import yaml from 'yaml'
 import { useNavigate } from 'react-router-dom'
 import { clsx } from 'clsx'
 import { useHelmRelease, useHelmManifest, useHelmValues, useHelmUpgradeInfo, useHelmReleaseVersions, useHelmUninstall, upgradeWithProgress, rollbackWithProgress, useHelmPreviewValues } from '../../api/client'
-import { YamlEditor } from '../ui/YamlEditor'
 import { ValuesDiffPreview } from './ValuesDiffPreview'
 import { useQueryClient } from '@tanstack/react-query'
 import { ConfirmDialog } from '../ui/ConfirmDialog'
@@ -45,6 +44,11 @@ interface UpgradePreviewRequest {
   repositoryName?: string
 }
 
+interface ParsedUpgradeValues {
+  values: Record<string, unknown> | null
+  error: string | null
+}
+
 type UpgradeSourceIssue = NonNullable<UpgradeInfo['sourceIssue']>
 type ActionableUpgradeSourceIssue = Exclude<UpgradeSourceIssue, 'ambiguous_repository'>
 
@@ -77,6 +81,19 @@ function getUpgradeSourceIssueTooltip(issue: UpgradeSourceIssue, error: string |
   }
 }
 
+function parseUpgradeValuesYaml(raw: string): ParsedUpgradeValues {
+  try {
+    const parsed = yaml.parse(raw)
+    if (parsed === null || parsed === undefined) return { values: {}, error: null }
+    if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return { values: null, error: 'Values must be a YAML mapping (key: value), not a list or single value' }
+    }
+    return { values: parsed as Record<string, unknown>, error: null }
+  } catch (err) {
+    return { values: null, error: err instanceof Error ? err.message : 'Invalid YAML' }
+  }
+}
+
 export function isUpgradeSourceIssueActionable(issue: UpgradeInfo['sourceIssue']): issue is ActionableUpgradeSourceIssue {
   return Boolean(issue && issue !== 'ambiguous_repository')
 }
@@ -101,8 +118,8 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
   const [selectedVersion, setSelectedVersion] = useState<string | null>(null)
   const [adjustValues, setAdjustValues] = useState(false)
   const [renderAdjustValues, setRenderAdjustValues] = useState(false)
-  const [upgradeEditorReady, setUpgradeEditorReady] = useState(false)
   const [editedUpgradeYaml, setEditedUpgradeYaml] = useState('')
+  const [upgradeYamlError, setUpgradeYamlError] = useState<string | null>(null)
   const [upgradeValuesSeeded, setUpgradeValuesSeeded] = useState(false)
   const [upgradePreview, setUpgradePreview] = useState<ValuesPreviewResponse | null>(null)
   const [upgradePreviewRequest, setUpgradePreviewRequest] = useState<UpgradePreviewRequest | null>(null)
@@ -163,8 +180,13 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
 
   // Available versions for the upgrade dialog's picker — only fetched while the
   // confirm dialog is open. Default the selection to latest when it opens.
-  const { data: availableVersions } = useHelmReleaseVersions(helmNamespace, release.name, showUpgradeConfirm)
+  const {
+    data: availableVersions,
+    isLoading: availableVersionsLoading,
+    error: availableVersionsError,
+  } = useHelmReleaseVersions(helmNamespace, release.name, showUpgradeConfirm)
   const targetVersion = selectedVersion ?? upgradeInfo?.latestVersion ?? ''
+  const selectableVersions = availableVersions && availableVersions.length > 1 ? availableVersions : null
   // Semver compare, not list-position: the installed version may be older than
   // the newest-N versions the picker shows, so it isn't always in the list.
   const isDowngrade = Boolean(
@@ -185,10 +207,6 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
   useEffect(() => {
     targetVersionRef.current = targetVersion
   }, [targetVersion])
-
-  useEffect(() => {
-    editedUpgradeYamlRef.current = editedUpgradeYaml
-  }, [editedUpgradeYaml])
 
   // ESC key handler
   useEffect(() => {
@@ -340,8 +358,9 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
     setSelectedVersion(null)
     setAdjustValues(false)
     setRenderAdjustValues(false)
-    setUpgradeEditorReady(false)
     setEditedUpgradeYaml('')
+    editedUpgradeYamlRef.current = ''
+    setUpgradeYamlError(null)
     setUpgradeValuesSeeded(false)
     setUpgradePreview(null)
     setUpgradePreviewRequest(null)
@@ -351,30 +370,12 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
 
   useEffect(() => {
     if (!adjustValues || !upgradeValues || upgradeValuesSeeded) return
-    setEditedUpgradeYaml(userSuppliedToYaml(upgradeValues.userSupplied))
+    const nextYaml = userSuppliedToYaml(upgradeValues.userSupplied)
+    editedUpgradeYamlRef.current = nextYaml
+    setEditedUpgradeYaml(nextYaml)
+    setUpgradeYamlError(null)
     setUpgradeValuesSeeded(true)
   }, [adjustValues, upgradeValues, upgradeValuesSeeded])
-
-  useEffect(() => {
-    if (!adjustValues || upgradeValuesLoading || upgradeValuesError || !upgradeValuesSeeded) {
-      setUpgradeEditorReady(false)
-      return
-    }
-
-    if (typeof window === 'undefined') {
-      setUpgradeEditorReady(true)
-      return
-    }
-
-    let frame2 = 0
-    const frame1 = window.requestAnimationFrame(() => {
-      frame2 = window.requestAnimationFrame(() => setUpgradeEditorReady(true))
-    })
-    return () => {
-      window.cancelAnimationFrame(frame1)
-      if (frame2) window.cancelAnimationFrame(frame2)
-    }
-  }, [adjustValues, upgradeValuesLoading, upgradeValuesError, upgradeValuesSeeded])
 
   const handleToggleAdjustValues = () => {
     if (adjustValues) {
@@ -383,39 +384,29 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
     }
 
     setRenderAdjustValues(true)
-    setUpgradeEditorReady(false)
     setEditedUpgradeYaml('')
+    editedUpgradeYamlRef.current = ''
+    setUpgradeYamlError(null)
     setUpgradeValuesSeeded(false)
     upgradePreviewMutation.reset()
     setAdjustValues(true)
   }
 
-  // Validity is derived from the SAME parser used at submit — not the editor's
-  // (more lenient) inline diagnostics — so an invalid doc always blocks the button
-  // rather than silently no-op'ing on click. Empty editor means "no overrides" ({}).
-  const { parsedUpgradeValues, upgradeYamlError } = useMemo<{
-    parsedUpgradeValues: Record<string, unknown> | null
-    upgradeYamlError: string | null
-  }>(() => {
-    if (!adjustValues) return { parsedUpgradeValues: {}, upgradeYamlError: null }
-    try {
-      const parsed = yaml.parse(editedUpgradeYaml)
-      if (parsed === null || parsed === undefined) return { parsedUpgradeValues: {}, upgradeYamlError: null }
-      if (typeof parsed !== 'object' || Array.isArray(parsed)) {
-        return { parsedUpgradeValues: null, upgradeYamlError: 'Values must be a YAML mapping (key: value), not a list or single value' }
-      }
-      return { parsedUpgradeValues: parsed as Record<string, unknown>, upgradeYamlError: null }
-    } catch (err) {
-      return { parsedUpgradeValues: null, upgradeYamlError: err instanceof Error ? err.message : 'Invalid YAML' }
-    }
-  }, [adjustValues, editedUpgradeYaml])
+  const getEditedUpgradeValues = () => {
+    if (!adjustValues) return {}
+    const parsed = parseUpgradeValuesYaml(editedUpgradeYamlRef.current)
+    setUpgradeYamlError(parsed.error)
+    return parsed.values
+  }
 
   const handleUpgradePreview = async () => {
-    if (!targetVersion || upgradeValuesLoading || upgradeValuesError || !upgradeValuesSeeded || upgradeYamlError || !parsedUpgradeValues) return
-    const previewYaml = editedUpgradeYaml
+    if (!targetVersion || upgradeValuesLoading || upgradeValuesError || !upgradeValuesSeeded) return
+    const editedValues = getEditedUpgradeValues()
+    if (!editedValues) return
+    const previewYaml = editedUpgradeYamlRef.current
     const previewRequest: UpgradePreviewRequest = {
       targetVersion,
-      values: parsedUpgradeValues,
+      values: editedValues,
       repositoryName: upgradeInfo?.repositoryName,
     }
     try {
@@ -440,8 +431,9 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
 
     let editedValues = editedValuesOverride
     if (editedValues === undefined && adjustValues) {
-      if (upgradeValuesLoading || upgradeValuesError || !upgradeValuesSeeded || upgradeYamlError || !parsedUpgradeValues) return
-      editedValues = parsedUpgradeValues
+      if (upgradeValuesLoading || upgradeValuesError || !upgradeValuesSeeded) return
+      editedValues = getEditedUpgradeValues() ?? undefined
+      if (!editedValues) return
     }
 
     setShowUpgradePreview(false)
@@ -846,37 +838,64 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
         isClosable
         className="max-w-2xl"
       >
-        {upgradeProgress.length === 0 && availableVersions && availableVersions.length > 1 && (
+        {upgradeProgress.length === 0 && (
           <div className="mb-1">
-            <label htmlFor="upgrade-version" className="block text-sm font-medium text-theme-text-secondary mb-1.5">
+            <label
+              id="upgrade-version-label"
+              htmlFor={selectableVersions ? 'upgrade-version' : undefined}
+              className="block text-sm font-medium text-theme-text-secondary mb-1.5"
+            >
               Target version
             </label>
-            <select
-              id="upgrade-version"
-              value={targetVersion}
-              onChange={(e) => {
-                targetVersionRef.current = e.target.value
-                setSelectedVersion(e.target.value)
-              }}
-              disabled={isUpgrading || isPreviewingUpgrade}
-              className="w-full px-3 py-2 bg-theme-elevated border border-theme-border-light rounded-lg text-sm text-theme-text-primary focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
-            >
-              {availableVersions.map((v) => (
-                <option key={v} value={v}>
-                  {v}
-                  {v === upgradeInfo?.latestVersion ? ' (latest)' : ''}
-                  {v === upgradeInfo?.currentVersion ? ' (current)' : ''}
-                </option>
-              ))}
-            </select>
+            {availableVersionsLoading ? (
+              <div
+                aria-labelledby="upgrade-version-label"
+                aria-live="polite"
+                className="flex h-10 items-center gap-2 rounded-lg border border-theme-border-light bg-theme-elevated px-3 text-sm text-theme-text-secondary"
+              >
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Loading available versions...
+              </div>
+            ) : selectableVersions ? (
+              <select
+                id="upgrade-version"
+                value={targetVersion}
+                onChange={(e) => {
+                  targetVersionRef.current = e.target.value
+                  setSelectedVersion(e.target.value)
+                }}
+                disabled={isUpgrading || isPreviewingUpgrade}
+                className="w-full px-3 py-2 bg-theme-elevated border border-theme-border-light rounded-lg text-sm text-theme-text-primary focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
+              >
+                {selectableVersions.map((v) => (
+                  <option key={v} value={v}>
+                    {v}
+                    {v === upgradeInfo?.latestVersion ? ' (latest)' : ''}
+                    {v === upgradeInfo?.currentVersion ? ' (current)' : ''}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <div
+                aria-labelledby="upgrade-version-label"
+                className="flex h-10 items-center rounded-lg border border-theme-border-light bg-theme-elevated px-3 text-sm text-theme-text-primary"
+              >
+                {targetVersion}
+              </div>
+            )}
             {isDowngrade && (
               <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
                 This is a downgrade from {upgradeInfo?.currentVersion}.
               </p>
             )}
-            {availableVersions.length >= 50 && (
+            {availableVersionsError && (
               <p className="mt-1 text-xs text-theme-text-tertiary">
-                Showing the 50 newest versions. Type to filter.
+                Version list unavailable; using the detected target version.
+              </p>
+            )}
+            {availableVersions && availableVersions.length >= 50 && (
+              <p className="mt-1 text-xs text-theme-text-tertiary">
+                Showing the 50 newest versions.
               </p>
             )}
           </div>
@@ -905,7 +924,6 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
                 if (event.propertyName !== 'grid-template-rows') return
                 if (!adjustValues) {
                   setRenderAdjustValues(false)
-                  setUpgradeEditorReady(false)
                 }
               }}
             >
@@ -920,29 +938,28 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
                         Couldn’t load current values: {upgradeValuesError instanceof Error ? upgradeValuesError.message : 'Unknown error'}
                       </div>
                     )}
-                    {upgradeValuesLoading && (
-                      <div className="flex items-center gap-2 h-[240px] px-3 text-sm text-theme-text-secondary bg-theme-elevated border border-theme-border rounded">
+                    {(upgradeValuesLoading || !upgradeValuesSeeded) && (
+                      <div className="flex min-h-[180px] items-center gap-2 rounded border border-theme-border bg-theme-elevated px-3 text-sm text-theme-text-secondary">
                         <Loader2 className="w-4 h-4 animate-spin" />
                         Loading current values...
                       </div>
                     )}
-                    {!upgradeValuesLoading && !upgradeValuesError && (
-                      upgradeEditorReady ? (
-                        <YamlEditor
-                          value={editedUpgradeYaml}
-                          onChange={(value) => {
-                            editedUpgradeYamlRef.current = value
-                            setEditedUpgradeYaml(value)
-                          }}
-                          readOnly={isPreviewingUpgrade || isUpgrading}
-                          height="240px"
-                        />
-                      ) : (
-                        <div className="flex items-center gap-2 h-[240px] px-3 text-sm text-theme-text-secondary bg-theme-elevated border border-theme-border rounded">
-                          <Loader2 className="w-4 h-4 animate-spin" />
-                          Preparing editor...
-                        </div>
-                      )
+                    {!upgradeValuesLoading && !upgradeValuesError && upgradeValuesSeeded && (
+                      <textarea
+                        defaultValue={editedUpgradeYaml}
+                        onChange={(event) => {
+                          editedUpgradeYamlRef.current = event.target.value
+                          if (upgradeYamlError) setUpgradeYamlError(null)
+                        }}
+                        onBlur={() => setUpgradeYamlError(parseUpgradeValuesYaml(editedUpgradeYamlRef.current).error)}
+                        aria-label="Edited Helm values YAML"
+                        readOnly={isPreviewingUpgrade || isUpgrading}
+                        spellCheck={false}
+                        autoCorrect="off"
+                        autoCapitalize="off"
+                        rows={9}
+                        className="max-h-[360px] min-h-[180px] w-full resize-y rounded-lg border border-theme-border bg-theme-elevated px-3 py-2 font-mono text-xs leading-5 text-theme-text-primary placeholder:text-theme-text-tertiary focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30 read-only:opacity-70"
+                      />
                     )}
                     {upgradeYamlError && (
                       <div className="mt-2 px-3 py-2 text-xs text-red-400 bg-red-500/10 border border-red-500/30 rounded">

--- a/web/src/components/helm/HelmReleaseDrawer.tsx
+++ b/web/src/components/helm/HelmReleaseDrawer.tsx
@@ -1,18 +1,21 @@
-import { useState, useCallback, useEffect, useRef } from 'react'
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
 import { flushSync } from 'react-dom'
 import { FetchResult, useDockReservedHeight, compareVersions } from '@skyhook-io/k8s-ui'
 import { startViewTransitionSafe } from '@skyhook-io/k8s-ui/utils/view-transition'
 import { TRANSITION_DRAWER } from '../../utils/animation'
 import { useRefreshAnimation } from '../../hooks/useRefreshAnimation'
-import { X, Copy, Check, RefreshCw, Package, Code, History, Settings, Link2, Anchor, GitFork, BookOpen, ArrowUpCircle, Trash2, GitBranch, AlertTriangle, RotateCcw, Clock, GitCompare, ExternalLink } from 'lucide-react'
+import { X, Copy, Check, RefreshCw, Package, Code, History, Settings, Link2, Anchor, GitFork, BookOpen, ArrowUpCircle, Trash2, GitBranch, AlertTriangle, RotateCcw, Clock, GitCompare, ExternalLink, ChevronRight, ChevronDown, SlidersHorizontal, Eye, Loader2 } from 'lucide-react'
+import yaml from 'yaml'
 import { useNavigate } from 'react-router-dom'
 import { clsx } from 'clsx'
-import { useHelmRelease, useHelmManifest, useHelmValues, useHelmUpgradeInfo, useHelmReleaseVersions, useHelmUninstall, upgradeWithProgress, rollbackWithProgress } from '../../api/client'
+import { useHelmRelease, useHelmManifest, useHelmValues, useHelmUpgradeInfo, useHelmReleaseVersions, useHelmUninstall, upgradeWithProgress, rollbackWithProgress, useHelmPreviewValues } from '../../api/client'
+import { YamlEditor } from '../ui/YamlEditor'
+import { ValuesDiffPreview } from './ValuesDiffPreview'
 import { useQueryClient } from '@tanstack/react-query'
 import { ConfirmDialog } from '../ui/ConfirmDialog'
 import { Tooltip } from '../ui/Tooltip'
 import { Markdown } from '../ui/Markdown'
-import type { SelectedHelmRelease, HelmHook, ChartDependency, HelmOperation, HelmOperationInsight, HelmOwnedResource, HookDiagnostic, HookLogEvidence, UpgradeInfo } from '../../types'
+import type { SelectedHelmRelease, HelmHook, ChartDependency, HelmOperation, HelmOperationInsight, HelmOwnedResource, HookDiagnostic, HookLogEvidence, UpgradeInfo, ValuesPreviewResponse } from '../../types'
 import { apiVersionToGroup, kindToPlural, type NavigateToResource } from '../../utils/navigation'
 import { formatDate } from './helm-utils'
 import { getHelmStatusColor, getKindBadgeColor, getResourceStatusColor, SEVERITY_BADGE, SEVERITY_TEXT } from '../../utils/badge-colors'
@@ -35,6 +38,12 @@ interface HelmReleaseDrawerProps {
 }
 
 type TabId = 'overview' | 'history' | 'manifest' | 'values' | 'resources' | 'hooks'
+
+interface UpgradePreviewRequest {
+  targetVersion: string
+  values: Record<string, unknown>
+  repositoryName?: string
+}
 
 type UpgradeSourceIssue = NonNullable<UpgradeInfo['sourceIssue']>
 type ActionableUpgradeSourceIssue = Exclude<UpgradeSourceIssue, 'ambiguous_repository'>
@@ -90,8 +99,16 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
   const [showUpgradeConfirm, setShowUpgradeConfirm] = useState(false)
   const [showTrackSource, setShowTrackSource] = useState(false)
   const [selectedVersion, setSelectedVersion] = useState<string | null>(null)
+  const [adjustValues, setAdjustValues] = useState(false)
+  const [editedUpgradeYaml, setEditedUpgradeYaml] = useState('')
+  const [upgradeValuesSeeded, setUpgradeValuesSeeded] = useState(false)
+  const [upgradePreview, setUpgradePreview] = useState<ValuesPreviewResponse | null>(null)
+  const [upgradePreviewRequest, setUpgradePreviewRequest] = useState<UpgradePreviewRequest | null>(null)
+  const [showUpgradePreview, setShowUpgradePreview] = useState(false)
   const resizeStartX = useRef(0)
   const resizeStartWidth = useRef(DEFAULT_WIDTH)
+  const targetVersionRef = useRef('')
+  const editedUpgradeYamlRef = useRef('')
   const { allowed: canHelmWrite, reason: helmActReason } = useCanHelmAct()
   // Cloud viewers can't view release manifests / values / diffs
   // (backend gate at requireCloudRole('member')). Skip the queries
@@ -123,6 +140,16 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
     canViewSensitive,
     selectedRevision,
   )
+  const {
+    data: upgradeValues,
+    isLoading: upgradeValuesLoading,
+    error: upgradeValuesError,
+  } = useHelmValues(
+    helmNamespace,
+    release.name,
+    false,
+    canViewSensitive && showUpgradeConfirm && adjustValues,
+  )
 
   // Lazy check for upgrade availability
   const { data: upgradeInfo, isLoading: upgradeLoading, error: upgradeError } = useHelmUpgradeInfo(
@@ -145,11 +172,21 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
 
   // Mutations for actions
   const uninstallMutation = useHelmUninstall()
+  const upgradePreviewMutation = useHelmPreviewValues()
+  const isPreviewingUpgrade = upgradePreviewMutation.isPending
   const queryClient = useQueryClient()
   const [upgradeProgress, setUpgradeProgress] = useState<{ phase: string; message: string }[]>([])
   const [isUpgrading, setIsUpgrading] = useState(false)
   const [rollbackProgress, setRollbackProgress] = useState<{ phase: string; message: string }[]>([])
   const [isRollingBack, setIsRollingBack] = useState(false)
+
+  useEffect(() => {
+    targetVersionRef.current = targetVersion
+  }, [targetVersion])
+
+  useEffect(() => {
+    editedUpgradeYamlRef.current = editedUpgradeYaml
+  }, [editedUpgradeYaml])
 
   // ESC key handler
   useEffect(() => {
@@ -296,8 +333,87 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
     )
   }
 
-  const handleUpgradeConfirm = async () => {
-    if (!targetVersion) return
+  const resetUpgradeDialog = () => {
+    setUpgradeProgress([])
+    setSelectedVersion(null)
+    setAdjustValues(false)
+    setEditedUpgradeYaml('')
+    setUpgradeValuesSeeded(false)
+    setUpgradePreview(null)
+    setUpgradePreviewRequest(null)
+    setShowUpgradePreview(false)
+    upgradePreviewMutation.reset()
+  }
+
+  useEffect(() => {
+    if (!adjustValues || !upgradeValues || upgradeValuesSeeded) return
+    setEditedUpgradeYaml(userSuppliedToYaml(upgradeValues.userSupplied))
+    setUpgradeValuesSeeded(true)
+  }, [adjustValues, upgradeValues, upgradeValuesSeeded])
+
+  const handleToggleAdjustValues = () => {
+    if (!adjustValues) {
+      setEditedUpgradeYaml('')
+      setUpgradeValuesSeeded(false)
+    }
+    setAdjustValues(prev => !prev)
+  }
+
+  // Validity is derived from the SAME parser used at submit — not the editor's
+  // (more lenient) inline diagnostics — so an invalid doc always blocks the button
+  // rather than silently no-op'ing on click. Empty editor means "no overrides" ({}).
+  const { parsedUpgradeValues, upgradeYamlError } = useMemo<{
+    parsedUpgradeValues: Record<string, unknown> | null
+    upgradeYamlError: string | null
+  }>(() => {
+    if (!adjustValues) return { parsedUpgradeValues: {}, upgradeYamlError: null }
+    try {
+      const parsed = yaml.parse(editedUpgradeYaml)
+      if (parsed === null || parsed === undefined) return { parsedUpgradeValues: {}, upgradeYamlError: null }
+      if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return { parsedUpgradeValues: null, upgradeYamlError: 'Values must be a YAML mapping (key: value), not a list or single value' }
+      }
+      return { parsedUpgradeValues: parsed as Record<string, unknown>, upgradeYamlError: null }
+    } catch (err) {
+      return { parsedUpgradeValues: null, upgradeYamlError: err instanceof Error ? err.message : 'Invalid YAML' }
+    }
+  }, [adjustValues, editedUpgradeYaml])
+
+  const handleUpgradePreview = async () => {
+    if (!targetVersion || upgradeValuesLoading || upgradeValuesError || !upgradeValuesSeeded || upgradeYamlError || !parsedUpgradeValues) return
+    const previewYaml = editedUpgradeYaml
+    const previewRequest: UpgradePreviewRequest = {
+      targetVersion,
+      values: parsedUpgradeValues,
+      repositoryName: upgradeInfo?.repositoryName,
+    }
+    try {
+      const result = await upgradePreviewMutation.mutateAsync({
+        namespace: helmNamespace,
+        name: release.name,
+        values: previewRequest.values,
+        version: previewRequest.targetVersion,
+        repository: previewRequest.repositoryName,
+      })
+      if (targetVersionRef.current !== previewRequest.targetVersion || editedUpgradeYamlRef.current !== previewYaml) return
+      setUpgradePreview(result)
+      setUpgradePreviewRequest(previewRequest)
+      setShowUpgradePreview(true)
+    } catch {
+      return
+    }
+  }
+
+  const runUpgrade = async (versionToApply: string, editedValuesOverride: Record<string, unknown> | undefined, repositoryName: string | undefined) => {
+    if (!versionToApply) return
+
+    let editedValues = editedValuesOverride
+    if (editedValues === undefined && adjustValues) {
+      if (upgradeValuesLoading || upgradeValuesError || !upgradeValuesSeeded || upgradeYamlError || !parsedUpgradeValues) return
+      editedValues = parsedUpgradeValues
+    }
+
+    setShowUpgradePreview(false)
     setIsUpgrading(true)
     setUpgradeProgress([])
 
@@ -305,8 +421,8 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
       await upgradeWithProgress(
         helmNamespace,
         release.name,
-        targetVersion,
-        upgradeInfo?.repositoryName,
+        versionToApply,
+        repositoryName,
         (event) => {
           if (event.type === 'progress' && event.message) {
             setUpgradeProgress(prev => [...prev, {
@@ -314,24 +430,25 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
               message: event.message || '',
             }])
           }
-        }
+        },
+        editedValues
       )
 
       setUpgradeProgress(prev => [...prev, {
         phase: 'complete',
-        message: `Successfully upgraded to ${targetVersion}`,
+        message: `Successfully upgraded to ${versionToApply}`,
       }])
 
       // Invalidate queries
       queryClient.invalidateQueries({ queryKey: ['helm-releases'] })
       queryClient.invalidateQueries({ queryKey: ['helm-release', helmNamespace, release.name] })
       queryClient.invalidateQueries({ queryKey: ['helm-upgrade-info', helmNamespace, release.name] })
+      queryClient.invalidateQueries({ queryKey: ['helm-values', helmNamespace, release.name] })
       queryClient.invalidateQueries({ queryKey: ['helm-batch-upgrade-info'] })
 
       setTimeout(() => {
         setShowUpgradeConfirm(false)
-        setUpgradeProgress([])
-        setSelectedVersion(null)
+        resetUpgradeDialog()
         refetch()
         switchTab('resources')
       }, 1500)
@@ -343,6 +460,15 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
     } finally {
       setIsUpgrading(false)
     }
+  }
+
+  const handleUpgradeConfirm = () => {
+    void runUpgrade(targetVersion, undefined, upgradeInfo?.repositoryName)
+  }
+
+  const handleApplyUpgradePreview = () => {
+    if (!upgradePreviewRequest) return
+    void runUpgrade(upgradePreviewRequest.targetVersion, upgradePreviewRequest.values, upgradePreviewRequest.repositoryName)
   }
 
   const headerHeight = 49
@@ -668,8 +794,7 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
         open={showUpgradeConfirm}
         onClose={() => {
           setShowUpgradeConfirm(false)
-          setUpgradeProgress([])
-          setSelectedVersion(null)
+          resetUpgradeDialog()
           if (isUpgrading) {
             // Upgrade continues server-side — switch to resources tab to monitor
             setIsUpgrading(false)
@@ -680,12 +805,13 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
         title="Upgrade Release"
         message={`Upgrade "${release.name}" to version ${targetVersion}?`}
         details={upgradeProgress.length === 0
-          ? `The chart will move from version ${upgradeInfo?.currentVersion} to ${targetVersion}. Your existing values will be preserved. The change is applied to your cluster immediately.`
+          ? `The chart will move from version ${upgradeInfo?.currentVersion} to ${targetVersion}. ${adjustValues ? 'Your edited values will be applied.' : 'Your existing values will be preserved.'} The change is applied to your cluster immediately.`
           : undefined
         }
         confirmLabel={isDowngrade ? 'Downgrade' : 'Upgrade'}
         variant="warning"
         isLoading={isUpgrading}
+        confirmDisabled={isPreviewingUpgrade || (adjustValues && (upgradeValuesLoading || !!upgradeValuesError || !upgradeValuesSeeded || !!upgradeYamlError))}
         isClosable
       >
         {upgradeProgress.length === 0 && availableVersions && availableVersions.length > 1 && (
@@ -696,8 +822,11 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
             <select
               id="upgrade-version"
               value={targetVersion}
-              onChange={(e) => setSelectedVersion(e.target.value)}
-              disabled={isUpgrading}
+              onChange={(e) => {
+                targetVersionRef.current = e.target.value
+                setSelectedVersion(e.target.value)
+              }}
+              disabled={isUpgrading || isPreviewingUpgrade}
               className="w-full px-3 py-2 bg-theme-elevated border border-theme-border-light rounded-lg text-sm text-theme-text-primary focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
             >
               {availableVersions.map((v) => (
@@ -720,8 +849,83 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
             )}
           </div>
         )}
+        {upgradeProgress.length === 0 && canHelmWrite && canViewSensitive && (
+          <div className="mt-3 border-t border-theme-border pt-3">
+            <button
+              type="button"
+              onClick={handleToggleAdjustValues}
+              disabled={isUpgrading || isPreviewingUpgrade}
+              className="flex items-center gap-1.5 text-sm font-medium text-theme-text-secondary hover:text-theme-text-primary disabled:opacity-50"
+            >
+              {adjustValues ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+              <SlidersHorizontal className="w-3.5 h-3.5" />
+              Adjust your values (optional)
+            </button>
+            {upgradeValuesError && (
+              <div className="mt-2 px-3 py-2 text-xs text-red-400 bg-red-500/10 border border-red-500/30 rounded">
+                Couldn’t load current values: {upgradeValuesError instanceof Error ? upgradeValuesError.message : 'Unknown error'}
+              </div>
+            )}
+            {adjustValues && (
+              <div className="mt-2">
+                <p className="mb-2 text-xs text-theme-text-tertiary">
+                  These are your current settings — edit them to carry into {targetVersion}. What you see here is exactly what gets applied.
+                </p>
+                {upgradeValuesLoading && (
+                  <div className="flex items-center gap-2 h-24 px-3 text-sm text-theme-text-secondary bg-theme-elevated border border-theme-border rounded">
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Loading current values...
+                  </div>
+                )}
+                {!upgradeValuesLoading && !upgradeValuesError && (
+                  <YamlEditor
+                    value={editedUpgradeYaml}
+                    onChange={(value) => {
+                      editedUpgradeYamlRef.current = value
+                      setEditedUpgradeYaml(value)
+                    }}
+                    readOnly={isPreviewingUpgrade || isUpgrading}
+                    height="240px"
+                  />
+                )}
+                {upgradeYamlError && (
+                  <div className="mt-2 px-3 py-2 text-xs text-red-400 bg-red-500/10 border border-red-500/30 rounded">
+                    {upgradeYamlError}
+                  </div>
+                )}
+                {upgradePreviewMutation.error && (
+                  <div className="mt-2 px-3 py-2 text-xs text-red-400 bg-red-500/10 border border-red-500/30 rounded">
+                    Couldn’t preview against {targetVersion}: {upgradePreviewMutation.error.message}. You can still upgrade.
+                  </div>
+                )}
+                <div className="mt-2 flex justify-end">
+                  <button
+                    type="button"
+                    onClick={handleUpgradePreview}
+                    disabled={upgradeValuesLoading || !!upgradeValuesError || !upgradeValuesSeeded || !!upgradeYamlError || isPreviewingUpgrade || isUpgrading}
+                    className="flex items-center gap-1 px-2.5 py-1 text-xs text-theme-text-secondary hover:text-theme-text-primary hover:bg-theme-elevated rounded border border-theme-border disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {upgradePreviewMutation.isPending ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Eye className="w-3.5 h-3.5" />}
+                    Preview what changes
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
         {upgradeProgress.length > 0 && <ProgressLog entries={upgradeProgress} />}
       </ConfirmDialog>
+
+      {showUpgradePreview && upgradePreview && upgradePreviewRequest && (
+        <ValuesDiffPreview
+          previewData={upgradePreview}
+          onClose={() => setShowUpgradePreview(false)}
+          onApply={handleApplyUpgradePreview}
+          isApplying={isUpgrading}
+          title={`Preview upgrade to ${upgradePreviewRequest.targetVersion}`}
+          applyLabel={upgradeInfo?.currentVersion && compareVersions(upgradePreviewRequest.targetVersion, upgradeInfo.currentVersion) === -1 ? 'Downgrade' : 'Upgrade'}
+        />
+      )}
 
       <TrackChartSourceDialog
         open={showTrackSource}
@@ -732,6 +936,11 @@ export function HelmReleaseDrawer({ release, onClose, onNavigateToResource, isOp
       />
     </div>
   )
+}
+
+function userSuppliedToYaml(userSupplied: Record<string, unknown> | undefined): string {
+  if (!userSupplied || Object.keys(userSupplied).length === 0) return ''
+  return yaml.stringify(userSupplied, { lineWidth: 0 })
 }
 
 // Shared progress log for streaming Helm operations

--- a/web/src/components/helm/ValuesDiffPreview.tsx
+++ b/web/src/components/helm/ValuesDiffPreview.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
 import { X, Play, Loader2, FileText, AlertTriangle } from 'lucide-react'
 import { clsx } from 'clsx'
 import type { ValuesPreviewResponse } from '../../types'
@@ -8,6 +9,8 @@ interface ValuesDiffPreviewProps {
   onClose: () => void
   onApply: () => void
   isApplying: boolean
+  title?: string
+  applyLabel?: string
 }
 
 export function ValuesDiffPreview({
@@ -15,6 +18,8 @@ export function ValuesDiffPreview({
   onClose,
   onApply,
   isApplying,
+  title = 'Preview Changes',
+  applyLabel = 'Apply Changes',
 }: ValuesDiffPreviewProps) {
   const dialogRef = useRef<HTMLDivElement>(null)
 
@@ -40,7 +45,10 @@ export function ValuesDiffPreview({
   const hasChanges = previewData.manifestDiff.trim().length > 0 &&
     previewData.manifestDiff.split('\n').some(line => line.startsWith('+') || line.startsWith('-'))
 
-  return (
+  // Portal to body so the modal escapes any CSS-transformed ancestor (the release
+  // drawer, the upgrade ConfirmDialog) and layers on top rather than being trapped
+  // in a lower stacking context.
+  return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       {/* Backdrop */}
       <div
@@ -51,6 +59,8 @@ export function ValuesDiffPreview({
       {/* Dialog */}
       <div
         ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
         tabIndex={-1}
         className="relative dialog max-w-4xl w-full mx-4 max-h-[85vh] flex flex-col outline-none"
       >
@@ -58,7 +68,7 @@ export function ValuesDiffPreview({
         <div className="flex items-center justify-between px-4 py-3 border-b border-theme-border shrink-0">
           <div className="flex items-center gap-2">
             <FileText className="w-5 h-5 text-blue-400" />
-            <h3 className="text-lg font-semibold text-theme-text-primary">Preview Changes</h3>
+            <h3 className="text-lg font-semibold text-theme-text-primary">{title}</h3>
           </div>
           <button
             onClick={onClose}
@@ -120,12 +130,13 @@ export function ValuesDiffPreview({
               ) : (
                 <Play className="w-4 h-4" />
               )}
-              Apply Changes
+              {applyLabel}
             </button>
           </div>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   )
 }
 


### PR DESCRIPTION
## Summary

Adds an optional values-editing step to the Helm release upgrade flow, so operators can adjust release overrides while choosing a target chart version. Routine collapsed upgrades still preserve existing values without editor interaction; the expanded editor path applies exactly the YAML shown to the operator and can preview the rendered manifest diff before applying.

Closes #1113.

## What Changed

### Upgrade dialog
- Adds an optional Adjust your values section to the upgrade confirmation dialog, seeded lazily from the current release user-supplied values after the operator opts in.
- Validates edited YAML with the same parser used at submit time, and blocks preview or upgrade while values are invalid, not a mapping, or still loading.
- Keeps the target version picker, edited values, preview response, and apply action tied to the same version/values/repository target. Stale in-flight previews are ignored, and editable controls are frozen while preview rendering runs.
- Reuses the existing manifest diff preview surface and portals it to document.body so it layers correctly over drawers and dialogs.
- Updates dialog Escape handling so nested editors can consume Escape first, while the topmost modal still owns background Escape handling.
- Keeps Flux-managed releases on the existing GitOps-only path, so direct Helm upgrades remain unavailable for those releases.

### Helm backend and API
- Adds optional edited values support to the streaming upgrade endpoint.
- Uses Helm ResetValues when values are supplied, making the edited document the source of truth, including an empty mapping to clear overrides.
- Keeps no-body upgrades on ResetThenReuseValues so routine upgrades carry previous overrides while picking up new chart defaults.
- Extends values preview/apply request types with optional target version and repository fields.
- Shares target chart resolution between preview and apply, including reuse of the in-memory release chart for same-version values edits.
- Runs preview rendering under the requesting user identity, matching the apply authorization path.

### Tests
- Adds backend coverage for optional upgrade values request decoding, including nil body, empty body, explicit empty map, populated values, and invalid JSON.
- Adds chart-selection coverage that same-version upgrade targets reuse the release chart rather than resolving or downloading it.

## Testing

- go test ./internal/helm
- npm run lint
- npx tsc --noEmit
- make tsc
- make test
- make build
- git diff --check
- visual-test: skipped. This is an authenticated Helm upgrade workflow that needs a configured release and chart source to exercise end-to-end; covered here with focused backend tests, full lint/typecheck/test/build, and review of the frontend state paths.

## Notes

The edited-values path changes live Helm release values only when the operator expands the editor and submits values. The routine collapsed path preserves previous upgrade behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live Helm upgrade behavior when operators submit edited values (including clearing overrides) and touches chart resolution for cross-version preview/apply; routine no-body upgrades preserve prior carry-over semantics.
> 
> **Overview**
> Adds an optional **adjust values** step to the Helm release upgrade flow so operators can edit overrides for a chosen target chart version, preview the rendered manifest diff, then apply exactly what they edited.
> 
> **Backend:** The streaming upgrade endpoint accepts an optional JSON body with `values`. When present (including an explicit empty `{}` to clear overrides), upgrades use **ResetValues** and the WYSIWYG path; body-less upgrades still use **ResetThenReuseValues**. Preview/apply types gain optional `version` and `repository`; preview runs under the requesting user and shares **chartForUpgradeTarget** / **loadTargetChart** with apply so target resolution matches. OCI URLs in repo indexes are treated as absolute via **isAbsoluteChartURL**.
> 
> **UI:** The upgrade confirm dialog can expand a YAML editor seeded from user-supplied values, validate before preview/confirm, call preview against the selected version, and stream upgrade with edited values. **ConfirmDialog** supports `confirmDisabled` and wider layout; **DialogPortal** Escape handling defers to nested editors and topmost modal. **ValuesDiffPreview** portals to `document.body` with customizable title/apply label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66592cd0cd6cc0a9cfffbffddee8b8e46d97d776. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->